### PR TITLE
dailyRevenue Correction

### DIFF
--- a/fees/stargate.ts
+++ b/fees/stargate.ts
@@ -49,7 +49,7 @@ const fetch = (chain: Chain) => {
     });
     const dailyVolume = bridgesVolumeInfo.reduce((acc, { volumeUsd }) => acc + Number(volumeUsd), 0);
     const dailyFees = dailyVolume * 0.0006;
-    const dailyRevenue = dailyVolume * 0.00015;
+    const dailyRevenue = dailyVolume * 0.0005;
     return {
       dailyFees: dailyFees.toString(),
       dailyRevenue: dailyRevenue.toString(),


### PR DESCRIPTION
Temporary update to dailyRevenue to more accurately capture Stargate's revenue. 

Stargate earns 5 bps on transfers when there are incentives on a pool and 4 bps when there no incentive (1 bp reverts to lps)