### PR TITLE
Corrected Velodrome fee percentage

### DIFF
--- a/fees/velodrome.ts
+++ b/fees/velodrome.ts
@@ -2,8 +2,8 @@ import { Adapter } from "../adapters/types";
 import volumeAdapter from "../dexs/velodrome";
 import { getDexChainFees } from "../helpers/getUniSubgraphFees";
 
-const TOTAL_FEES = 0.002;
-const PROTOCOL_FEES = 0.002;
+const TOTAL_FEES = 0.0002;
+const PROTOCOL_FEES = 0.0002;
 
 const feeAdapter = getDexChainFees({
   totalFees: TOTAL_FEES,


### PR DESCRIPTION
Current Velodrome fees are 0.02% per swap - corrected decimal which is currently calculating 0.2%