### PR TITLE
hegic: improve naming of `timestamp` code

### DIFF
--- a/fees/hegic.ts
+++ b/fees/hegic.ts
@@ -3,14 +3,14 @@ import { ARBITRUM } from "../helpers/chains";
 
 import {
   fetchArbitrumAnalyticsData,
-  HEGIC_HERGE_START,
+  getEarliestAvailableTimestamp,
 } from "../options/hegic";
 
 const adapter: Adapter = {
   adapter: {
     [ARBITRUM]: {
       fetch: getHegicFees,
-      start: async () => HEGIC_HERGE_START,
+      start: getEarliestAvailableTimestamp,
       meta: {
         methodology: `
 The only thing anyone pays on Hegic is premiums. This goes into dailyFees.
@@ -27,7 +27,10 @@ Hegic Development fund also stakes ~170M Hegic tokens (16% of supply), so that c
   },
 };
 
-async function getHegicFees(timestamp: number): Promise<FetchResultFees> {
+async function getHegicFees(
+  /** Timestamp representing the end of the 24 hour period */
+  timestamp: number
+): Promise<FetchResultFees> {
   const optionsDashboardData = await fetchArbitrumAnalyticsData(timestamp);
 
   return {

--- a/options/hegic/index.ts
+++ b/options/hegic/index.ts
@@ -5,18 +5,27 @@ import { AnalyticsData, Position, StrategyType } from "./interfaces";
 
 export const analyticsEndpoint = "https://api.hegic.co/analytics";
 export const HEGIC_HERGE_START = dateStringToTimestamp("2022-10-24T11:21:45Z"); // taken from the first purchased option
+
 const secondsInADay = 24 * 60 * 60;
+
+/** Returns the earliest timestamp for which the data are available */
+export async function getEarliestAvailableTimestamp() {
+  return HEGIC_HERGE_START + secondsInADay;
+}
 
 const adapter: SimpleAdapter = {
   adapter: {
     arbitrum: {
       fetch: fetchArbitrumAnalyticsData,
-      start: async () => HEGIC_HERGE_START,
+      start: getEarliestAvailableTimestamp,
     },
   },
 };
 
-export async function fetchArbitrumAnalyticsData(timestamp: number) {
+export async function fetchArbitrumAnalyticsData(
+  /** Timestamp representing the end of the 24 hour period */
+  timestamp: number
+) {
   const analyticsData = await getAnalyticsData(analyticsEndpoint);
 
   const allPositions = [
@@ -45,9 +54,12 @@ async function getAnalyticsData(endpoint: string): Promise<AnalyticsData> {
   return (await fetchURL(endpoint))?.data;
 }
 
-function getPositionsForDaily(positions: Position[], fromTimestamp: number) {
-  const from = fromTimestamp - secondsInADay;
-  const to = fromTimestamp;
+function getPositionsForDaily(
+  positions: Position[],
+  endOfDayTimestamp: number
+) {
+  const from = endOfDayTimestamp - secondsInADay;
+  const to = endOfDayTimestamp;
   return positions.filter((position) => {
     const purchaseTimestamp = dateStringToTimestamp(position.purchaseDate);
     return purchaseTimestamp >= from && purchaseTimestamp < to;


### PR DESCRIPTION
- descriptive names of variables, and ts-doc comments to clarify what the timestamp  actually contains
- extract fn for `adapter.start()`