### PR TITLE
Update missing fee tokens, addresses, chains

### DIFF
--- a/fees/nftearth.ts
+++ b/fees/nftearth.ts
@@ -7,6 +7,7 @@ import { getBlock } from "../helpers/getBlock";
 import { Chain } from "@defillama/sdk/build/general";
 
 const topic0 = '0x9d9af8e38d66c62e2c12f0225249fd9d721c54b83f48d9352c97c6cacdcb6f31';
+const topic1 = '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef';
 
 type TMarketPlaceAddress = {
   [l: string | Chain]: string;
@@ -14,6 +15,7 @@ type TMarketPlaceAddress = {
 const marketplace_address: TMarketPlaceAddress = {
   [CHAIN.OPTIMISM]: '0x0f9b80fc3c8b9123d0aef43df58ebdbc034a8901',
   [CHAIN.ARBITRUM]: '0x0f9b80fc3c8b9123d0aef43df58ebdbc034a8901',
+  [CHAIN.POLYGON]: '0x0f9b80fc3c8b9123d0aef43df58ebdbc034a8901'
 }
 
 interface ITx {
@@ -47,17 +49,25 @@ const fetch = (chain: Chain) => {
     })).output.map((e: any) => { return { data: e.data.replace('0x', ''), transactionHash: e.transactionHash } as ITx});
 
     const ethAddress = "ethereum:0x0000000000000000000000000000000000000000";
+    const ethOptimism ="optimism:0x4200000000000000000000000000000000000006";
     const l2dao = "optimism:0xd52f94df742a6f4b4c8b033369fe13a41782bf44";
-    const prices = await getPrices([ethAddress, l2dao], timestamp);
+    const op = "optimism:0x4200000000000000000000000000000000000042";
+    const nfteOptimism = "optimism:0xc96f4F893286137aC17e07Ae7F217fFca5db3AB6";
+    const nfteArbitrum = "arbitrum:0xb261104a83887ae92392fb5ce5899fcfe5481456";
+    const prices = await getPrices([ethAddress, l2dao, op, nfteOptimism, nfteArbitrum, ethOptimism], timestamp);
     const ethPrice = prices[ethAddress].price;
     const l2daoPrice = prices[l2dao].price;
+    const opPrice = prices[op].price;
+    const nfteOptimismPrice = prices[nfteOptimism].price
+    const nfteArbitrumPrice = prices[nfteArbitrum].price
+    const ethOptimismPrice = prices[ethOptimism].price
 
     const rawLogsData: ISaleData[] = logs.map((tx: ITx) => {
       const address = tx.data.slice(704, 768); // 11
       const contract_address = '0x' + address.slice(24, address.length);
       const thereIsNotCreatorFee = tx.data.length === 1280;
       const amount = Number('0x' + tx.data.slice(832, 896)) / 10 **  18; // 13
-      const _price = contract_address === '0x0000000000000000000000000000000000000000' ? ethPrice : l2daoPrice;
+      const _price = contract_address === '0x0000000000000000000000000000000000000000' ? ethOptimismPrice : opPrice;
       const creator_fee =  (Number('0x' + tx.data.slice(1152, 1216)) / 10 **  18) * _price; // 18
       const marketplace_fee =  (Number('0x' + tx.data.slice(1472, 1536)) / 10 **  18) * _price; // 23
 
@@ -92,6 +102,10 @@ const adapter: Adapter = {
       fetch: fetch(CHAIN.ARBITRUM),
       start: async ()  => 1676332800,
     },
+    [CHAIN.POLYGON]: {
+      fetch: fetch(CHAIN.POLYGON),
+      start: async ()  => 1675036800,
+  },
   }
 }
 


### PR DESCRIPTION
1. Fee Tokens: Added fee tokens $NFTE on both Optimism and Arbitrum, added fee token $OP on Optimism and fee token $WETH on Optimism.

2. Added Polygon network marketplace address.

3. Added missing topic that is not being counted for fee revenue from Bids/Accepted offers. Attached screencap of this in the block explorer logs... same for $WETH, $OP, $NFTE trades on the marketplace.

![image](https://user-images.githubusercontent.com/29180454/222323638-821965b0-dcfe-401e-ab58-01c734e7fc81.png)
