### PR TITLE
Add new sources of treasury revenue: POL yield and Votemarket bribes

### DIFF
--- a/fees/convex.ts
+++ b/fees/convex.ts
@@ -17,7 +17,7 @@ const methodology = {
     Fees: "Includes all treasury revenue, all revenue to CVX lockers and stakers and all revenue to liquid derivatives (cvxCRV, cvxFXS)",
     HoldersRevenue: "All revenue going to CVX lockers and stakers, including bribes",
     Revenue: "Sum of protocol revenue and holders' revenue",
-    ProtocolRevenue: "Share of revenue going to Convex treasury (includes caller incentives on Frax pools)",
+    ProtocolRevenue: "Share of revenue going to Convex treasury (includes caller incentives on Frax pools, POL yield and Votemarket bribes)",
     SupplySideRevenue: "All CRV, CVX and FXS rewards redistributed to liquidity providers staking on Convex.",
 }
 
@@ -43,6 +43,7 @@ const graph = (graphUrls: ChainEndpoints) => {
                         fxsRevenueToCallersAmount
                         crvRevenueToPlatformAmount
                         fxsRevenueToPlatformAmount
+                        otherRevenue
                         bribeRevenue
                     }
                 }`;
@@ -59,8 +60,8 @@ const graph = (graphUrls: ChainEndpoints) => {
             const dailyHoldersRevenue = snapshot.bribeRevenue.plus(snapshot.crvRevenueToCvxStakersAmount).plus(snapshot.fxsRevenueToCvxStakersAmount);
             // cvxCRV & cvxFXS liquid lockers revenue
             const liquidRevenue = snapshot.crvRevenueToCvxCrvStakersAmount.plus(snapshot.cvxRevenueToCvxCrvStakersAmount).plus(snapshot.threeCrvRevenueToCvxCrvStakersAmount).plus(snapshot.fxsRevenueToCvxFxsStakersAmount);
-            // Share of revenue redirected to treasury, includes call incentives monopolized by the protocol (FXS)
-            const dailyTreasuryRevenue = snapshot.crvRevenueToPlatformAmount.plus(snapshot.fxsRevenueToPlatformAmount).plus(snapshot.fxsRevenueToCallersAmount);
+            // Share of revenue redirected to treasury, includes call incentives monopolized by the protocol (FXS), POL revenue & vote market bribes
+            const dailyTreasuryRevenue = snapshot.crvRevenueToPlatformAmount.plus(snapshot.fxsRevenueToPlatformAmount).plus(snapshot.fxsRevenueToCallersAmount).plus(snapshot.otherRevenue);
 
             // Platform fee on CRV rewards + Rewards to liquid lockers + Rewards to CVX holders
             const dailyFees = dailyTreasuryRevenue.plus(liquidRevenue).plus(dailyHoldersRevenue);


### PR DESCRIPTION
Tracks recently added treasury revenue sources:
- Yield on protocol-owned liquidity in the cvxCRV & cvxFPIS pools (0x858847c21B075e45727fcB0B544BD843CD750361 & 0xa25B17D7deEE59f9e326e45cC3C0C1B158E74316 respectively)
- Bribe income from StakeDAO's votemarket (e.g. https://etherscan.io/tx/0x133d9d036bce71f1468de640e88393ba5c19692b96c8f7552a5868e16fb5aa41)
 