### PR TITLE
Add Evmos and Injective Fees to Stride

### DIFF
--- a/fees/stride.ts
+++ b/fees/stride.ts
@@ -63,7 +63,7 @@ const adapter: Adapter = {
       start: async () => 0,
       meta,
     },
-    /*  evmos: {
+      evmos: {
        fetch: fetch("evmos"),
        runAtCurrTime: true,
        start: async () => 0,
@@ -74,7 +74,7 @@ const adapter: Adapter = {
        runAtCurrTime: true,
        start: async () => 0,
        meta,
-     }, */
+     }, 
   },
 };
 


### PR DESCRIPTION
Stride's edge server was previously returning erroneous fees for two of its products, stEVMOS and stINJ. However, both of those queries have now been fixed (see [here](https://edge.stride.zone/api/injective/stats/fees) and [here](https://edge.stride.zone/api/evmos/stats/fees)).

This PR adds fetches fees for stEVMOS and stINJ again.