### PR TITLE
update Demex Exchange's historical volume endpoint

### DIFF
--- a/dexs/demex/index.ts
+++ b/dexs/demex/index.ts
@@ -1,38 +1,54 @@
-import fetchURL from "../../utils/fetchURL"
-import { SimpleAdapter } from "../../adapters/types";
-import { CHAIN } from "../../helpers/chains";
-import { getUniqStartOfTodayTimestamp } from "../../helpers/getUniSubgraphVolume";
+// import fetchURL from "../../utils/fetchURL"
+// import { SimpleAdapter } from "../../adapters/types";
+// import { CHAIN } from "../../helpers/chains";
+// import { getUniqStartOfTodayTimestamp } from "../../helpers/getUniSubgraphVolume";
 
-const START_TIME = 1659312000;
-const historicalVolumeEndpoint = (until: number) => `https://api-insights.carbon.network/pool/volume?from=${START_TIME}&interval=day&until=${until}`
+// const START_TIME = 1659312000;
+// const historicalVolumeEndpoint = (until: number) => `https://api-insights.carbon.network/pool/volume?from=${START_TIME}&interval=day&until=${until}`
 
-interface IVolumeall {
-  volumeValue: string;
-  totalVolumeValue: string;
-  date: string;
-}
+// interface IVolumeall {
+//   volumeValue: string;
+//   totalVolumeValue: string;
+//   date: string;
+// }
 
-const fetch = async (timestamp: number) => {
-  const dayTimestamp = getUniqStartOfTodayTimestamp(new Date(timestamp * 1000))
-  const historicalVolume: IVolumeall[] = (await fetchURL(historicalVolumeEndpoint(dayTimestamp)))?.data.result.entries;
+// const fetch = async (timestamp: number) => {
+//   const dayTimestamp = getUniqStartOfTodayTimestamp(new Date(timestamp * 1000))
+//   const historicalVolume: IVolumeall[] = (await fetchURL(historicalVolumeEndpoint(dayTimestamp)))?.data.result.entries;
 
-  const volume = historicalVolume
-    .find(dayItem => (new Date(dayItem.date.split('T')[0]).getTime() / 1000) === dayTimestamp)
+//   const volume = historicalVolume
+//     .find(dayItem => (new Date(dayItem.date.split('T')[0]).getTime() / 1000) === dayTimestamp)
 
-  return {
-    totalVolume: `${volume?.totalVolumeValue}`,
-    dailyVolume: volume ? `${volume.volumeValue}` : undefined,
-    timestamp: dayTimestamp,
-  };
+//   return {
+//     totalVolume: `${volume?.totalVolumeValue}`,
+//     dailyVolume: volume ? `${volume.volumeValue}` : undefined,
+//     timestamp: dayTimestamp,
+//   };
+// };
+
+// const adapter: SimpleAdapter = {
+//   adapter: {
+//     [CHAIN.CARBON]: {
+//       fetch,
+//       start: async () => START_TIME,
+//     },
+//   },
+// };
+
+// export default adapter;
+
+const getUniqStartOfTodayTimestamp = (date = new Date()) => {
+  var date_utc = Date.UTC(
+    date.getUTCFullYear(),
+    date.getUTCMonth(),
+    date.getUTCDate(),
+    date.getUTCHours(),
+    date.getUTCMinutes(),
+    date.getUTCSeconds()
+  );
+  var startOfDay = new Date(date_utc);
+  var timestamp = startOfDay.getTime() / 1000;
+  return Math.floor(timestamp / 86400) * 86400;
 };
-
-const adapter: SimpleAdapter = {
-  adapter: {
-    [CHAIN.CARBON]: {
-      fetch,
-      start: async () => START_TIME,
-    },
-  },
-};
-
-export default adapter;
+const exactDateTimestamp = getUniqStartOfTodayTimestamp(new Date(1691107200 * 1000))
+console.log(exactDateTimestamp)

--- a/dexs/demex/index.ts
+++ b/dexs/demex/index.ts
@@ -1,59 +1,38 @@
-// import fetchURL from "../../utils/fetchURL"
-// import { SimpleAdapter } from "../../adapters/types";
-// import { CHAIN } from "../../helpers/chains";
-// import { getUniqStartOfTodayTimestamp } from "../../helpers/getUniSubgraphVolume";
+import fetchURL from "../../utils/fetchURL"
+import { SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import { getUniqStartOfTodayTimestamp } from "../../helpers/getUniSubgraphVolume";
 
-// const START_TIME = 1659312000;
-// const historicalVolumeEndpoint = (until: number) => `https://api-insights.carbon.network/pool/volume?from=${START_TIME}&interval=day&until=${until}`
+const START_TIME = 1659312000;
+const historicalVolumeEndpoint = (until: number) => `https://api-insights.carbon.network/market/volume?from=${START_TIME}&interval=day&until=${until}`
 
-// interface IVolumeall {
-//   volumeValue: string;
-//   totalVolumeValue: string;
-//   date: string;
-// }
+interface IVolumeall {
+  volumeValue: string;
+  totalVolumeValue: string;
+  date: string;
+}
 
-// const fetch = async (timestamp: number) => {
-//   const dayTimestamp = getUniqStartOfTodayTimestamp(new Date(timestamp * 1000))
-//   const historicalVolume: IVolumeall[] = (await fetchURL(historicalVolumeEndpoint(dayTimestamp)))?.data.result.entries;
+const fetch = async (timestamp: number) => {
+  const dayTimestamp = getUniqStartOfTodayTimestamp(new Date(timestamp * 1000))
+  const historicalVolume: IVolumeall[] = (await fetchURL(historicalVolumeEndpoint(dayTimestamp)))?.data.result.entries;
 
-//   const volume = historicalVolume
-//     .find(dayItem => (new Date(dayItem.date.split('T')[0]).getTime() / 1000) === dayTimestamp)
+  const volume = historicalVolume
+    .find(dayItem => (new Date(dayItem.date.split('T')[0]).getTime() / 1000) === dayTimestamp)
 
-//   return {
-//     totalVolume: `${volume?.totalVolumeValue}`,
-//     dailyVolume: volume ? `${volume.volumeValue}` : undefined,
-//     timestamp: dayTimestamp,
-//   };
-// };
-
-// const adapter: SimpleAdapter = {
-//   adapter: {
-//     [CHAIN.CARBON]: {
-//       fetch,
-//       start: async () => START_TIME,
-//     },
-//   },
-// };
-
-// export default adapter;
-
-const getUniqStartOfTodayTimestamp = (date = new Date()) => {
-  var date_utc = Date.UTC(
-    date.getUTCFullYear(),
-    date.getUTCMonth(),
-    date.getUTCDate(),
-    date.getUTCHours(),
-    date.getUTCMinutes(),
-    date.getUTCSeconds()
-  );
-  var startOfDay = new Date(date_utc);
-  var timestamp = startOfDay.getTime() / 1000;
-  return Math.floor(timestamp / 86400) * 86400;
+  return {
+    totalVolume: `${volume?.totalVolumeValue}`,
+    dailyVolume: volume ? `${volume.volumeValue}` : undefined,
+    timestamp: dayTimestamp,
+  };
 };
-const date = new Date(Date.UTC(2023, 4, 15, 3, 0, 0));
 
-// Get the Unix timestamp (in seconds) for the specified date
-const timestamp = Math.floor(date.getTime() / 1000);
+const adapter: SimpleAdapter = {
+  adapter: {
+    [CHAIN.CARBON]: {
+      fetch,
+      start: async () => START_TIME,
+    },
+  },
+};
 
-const exactDateTimestamp = getUniqStartOfTodayTimestamp(new Date(timestamp * 1000))
-console.log(exactDateTimestamp)
+export default adapter;

--- a/dexs/demex/index.ts
+++ b/dexs/demex/index.ts
@@ -50,5 +50,10 @@ const getUniqStartOfTodayTimestamp = (date = new Date()) => {
   var timestamp = startOfDay.getTime() / 1000;
   return Math.floor(timestamp / 86400) * 86400;
 };
-const exactDateTimestamp = getUniqStartOfTodayTimestamp(new Date(1691107200 * 1000))
+const date = new Date(Date.UTC(2023, 4, 15, 3, 0, 0));
+
+// Get the Unix timestamp (in seconds) for the specified date
+const timestamp = Math.floor(date.getTime() / 1000);
+
+const exactDateTimestamp = getUniqStartOfTodayTimestamp(new Date(timestamp * 1000))
 console.log(exactDateTimestamp)


### PR DESCRIPTION
Updated the 'historicalVolumeEndpoint' of Demex exchange. 
It was previously displaying the pool volume, but the correct volume to be displayed should be the market volume.