### PR TITLE
Add Stride stUMEE Fees

### DIFF
--- a/fees/stride.ts
+++ b/fees/stride.ts
@@ -75,6 +75,12 @@ const adapter: Adapter = {
        start: async () => 0,
        meta,
      }, 
+     umee: {
+       fetch: fetch("umee"),
+       runAtCurrTime: true,
+       start: async () => 0,
+       meta,
+     }, 
   },
 };
 


### PR DESCRIPTION
This adds stUMEE fees to Stride.

Testing locally everything passes, I get 

```
❯ yarn test fees stride
yarn run v1.22.19
$ yarn run update-submodules && ts-node cli/testAdapter.ts fees stride
$ git submodule update --init --recursive --remote --merge
🦙 Running STRIDE adapter 🦙
_______________________________________
Fees for 20/5/2023
_______________________________________

COSMOS 👇
Backfill start time not defined
Timestamp: 1684627198
Daily fees: 15409.423576682611
└─ Methodology: Fees are staking rewards earned by tokens staked with Stride. They are measured across Stride's LSD tokens' yields and converted to USD terms.
Daily revenue: 1540.9423576682611
└─ Methodology: Stride collects 10% of liquid staked assets's staking rewards. These fees are measured across Stride's LSD tokens' yields and converted to USD terms.


OSMOSIS 👇
Backfill start time not defined
Timestamp: 1684627198
Daily fees: 2321.3757508282292
└─ Methodology: Fees are staking rewards earned by tokens staked with Stride. They are measured across Stride's LSD tokens' yields and converted to USD terms.
Daily revenue: 232.13757508282293
└─ Methodology: Stride collects 10% of liquid staked assets's staking rewards. These fees are measured across Stride's LSD tokens' yields and converted to USD terms.


JUNO 👇
Backfill start time not defined
Timestamp: 1684627198
Daily fees: 145.92295924957276
└─ Methodology: Fees are staking rewards earned by tokens staked with Stride. They are measured across Stride's LSD tokens' yields and converted to USD terms.
Daily revenue: 14.592295924957277
└─ Methodology: Stride collects 10% of liquid staked assets's staking rewards. These fees are measured across Stride's LSD tokens' yields and converted to USD terms.


STARGAZE 👇
Backfill start time not defined
Timestamp: 1684627198
Daily fees: 242.77255358790993
└─ Methodology: Fees are staking rewards earned by tokens staked with Stride. They are measured across Stride's LSD tokens' yields and converted to USD terms.
Daily revenue: 24.277255358790995
└─ Methodology: Stride collects 10% of liquid staked assets's staking rewards. These fees are measured across Stride's LSD tokens' yields and converted to USD terms.


TERRA 👇
Backfill start time not defined
Timestamp: 1684627198
Daily fees: 409.71980624469194
└─ Methodology: Fees are staking rewards earned by tokens staked with Stride. They are measured across Stride's LSD tokens' yields and converted to USD terms.
Daily revenue: 40.9719806244692
└─ Methodology: Stride collects 10% of liquid staked assets's staking rewards. These fees are measured across Stride's LSD tokens' yields and converted to USD terms.


EVMOS 👇
Backfill start time not defined
Timestamp: 1684627198
Daily fees: 1528.852666621113
└─ Methodology: Fees are staking rewards earned by tokens staked with Stride. They are measured across Stride's LSD tokens' yields and converted to USD terms.
Daily revenue: 152.88526666211132
└─ Methodology: Stride collects 10% of liquid staked assets's staking rewards. These fees are measured across Stride's LSD tokens' yields and converted to USD terms.


INJECTIVE 👇
Backfill start time not defined
Timestamp: 1684627198
Daily fees: 431.51186124372714
└─ Methodology: Fees are staking rewards earned by tokens staked with Stride. They are measured across Stride's LSD tokens' yields and converted to USD terms.
Daily revenue: 43.151186124372714
└─ Methodology: Stride collects 10% of liquid staked assets's staking rewards. These fees are measured across Stride's LSD tokens' yields and converted to USD terms.


UMEE 👇
Backfill start time not defined
Timestamp: 1684627198
Daily fees: 5.397201878301443
└─ Methodology: Fees are staking rewards earned by tokens staked with Stride. They are measured across Stride's LSD tokens' yields and converted to USD terms.
Daily revenue: 0.5397201878301443
└─ Methodology: Stride collects 10% of liquid staked assets's staking rewards. These fees are measured across Stride's LSD tokens' yields and converted to USD terms.
```