### PR TITLE
Smardex: new chains added

### DIFF
--- a/dexs/SmarDex/index.ts
+++ b/dexs/SmarDex/index.ts
@@ -1,15 +1,44 @@
 import { SimpleAdapter } from "../../adapters/types";
-import { DEFAULT_DAILY_VOLUME_FIELD, DEFAULT_TOTAL_VOLUME_FIELD, getChainVolume } from "../../helpers/getUniSubgraphVolume";
+import {
+  DEFAULT_DAILY_VOLUME_FIELD,
+  DEFAULT_TOTAL_VOLUME_FIELD,
+  getGraphDimensions,
+} from "../../helpers/getUniSubgraph";
 import { CHAIN } from "../../helpers/chains";
 
-const VERSION = "v0.0.7";
+const SMARDEX_SUBGRAPH_API_KEY = process.env.SMARDEX_SUBGRAPH_API_KEY;
+const SMARDEX_SUBGRAPH_GATEWAY = "https://subgraph.smardex.io/defillama";
 
-const endpoints = {
-  [CHAIN.ETHEREUM]: `https://api.studio.thegraph.com/query/41381/smardex-volumes/${VERSION}`,
+if (!SMARDEX_SUBGRAPH_API_KEY) {
+  throw new Error("Missing SMARDEX_SUBGRAPH_API_KEY env variable");
+}
+
+const defaultHeaders = {
+  "x-api-key": SMARDEX_SUBGRAPH_API_KEY,
 };
 
-const graphs = getChainVolume({
-  graphUrls: endpoints,
+const graphUrls = {
+  [CHAIN.ARBITRUM]: `${SMARDEX_SUBGRAPH_GATEWAY}/arbitrum`,
+  [CHAIN.BSC]: `${SMARDEX_SUBGRAPH_GATEWAY}/bsc`,
+  [CHAIN.ETHEREUM]: `${SMARDEX_SUBGRAPH_GATEWAY}/ethereum`,
+  [CHAIN.POLYGON]: `${SMARDEX_SUBGRAPH_GATEWAY}/polygon`,
+};
+
+const graphRequestHeaders = {
+  [CHAIN.ARBITRUM]: defaultHeaders,
+  [CHAIN.BSC]: defaultHeaders,
+  [CHAIN.ETHEREUM]: defaultHeaders,
+  [CHAIN.POLYGON]: defaultHeaders,
+};
+
+/**
+ * @note We are using this method that allow us to use http headers
+ * The method `getGraphDimensions` try returns daily fees and total fees
+ * but we are currently not using them in our subgraphs, so they are undefined
+ */
+const graphs = getGraphDimensions({
+  graphUrls,
+  graphRequestHeaders,
   totalVolume: {
     factory: "smardexFactories",
     field: DEFAULT_TOTAL_VOLUME_FIELD,
@@ -17,7 +46,7 @@ const graphs = getChainVolume({
   dailyVolume: {
     factory: "factoryDayData",
     field: DEFAULT_DAILY_VOLUME_FIELD,
-    dateField: "date"
+    dateField: "date",
   },
 });
 
@@ -26,6 +55,18 @@ const adapter: SimpleAdapter = {
     [CHAIN.ETHEREUM]: {
       fetch: graphs(CHAIN.ETHEREUM),
       start: async () => 1678404995, // birthBlock timestamp
+    },
+    [CHAIN.BSC]: {
+      fetch: graphs(CHAIN.BSC),
+      start: async () => 1689581494,
+    },
+    [CHAIN.POLYGON]: {
+      fetch: graphs(CHAIN.POLYGON),
+      start: async () => 1689582144,
+    },
+    [CHAIN.ARBITRUM]: {
+      fetch: graphs(CHAIN.ARBITRUM),
+      start: async () => 1689582249,
     },
   },
 };

--- a/fees/SmarDex/index.ts
+++ b/fees/SmarDex/index.ts
@@ -3,38 +3,51 @@ import volumeAdapter from "../../dexs/SmarDex";
 import { CHAIN } from "../../helpers/chains";
 import type { Adapter } from "../../adapters/types";
 
-
-const LP_FEES = 0.0005;
-const POOL_FEES = 0.0002;
-const TOTAL_FEES = LP_FEES + POOL_FEES;
-
-const baseAdapter = getDexChainFees({
-  userFees: TOTAL_FEES,
-  totalFees: TOTAL_FEES,
-  supplySideRevenue: LP_FEES,
-  revenue: POOL_FEES,
-  holdersRevenue: POOL_FEES,
-  volumeAdapter,
-});
-
-const methodology = {
-  UserFees: "0.07% of each swap is collected from the user that swaps as trading fees.",
-  Fees: "0.07% of each swap is collected from the user that swaps as trading fees.",
-  Revenue: "0.02% of each swap is collected for the staking pool (SDEX holders that staked).",
-  ProtocolRevenue: `Protocol has no revenue.`,
-  SupplySideRevenue: "0.05% of each swap is collected for the liquidity providers.",
-  HoldersRevenue: "0.02% of each swap is collected for the staking pool (SDEX holders that staked)."
-};
+// Define fees for each chain
+const FEES = {
+  [CHAIN.ETHEREUM]: { LP_FEES: 0.0005, POOL_FEES: 0.0002 },
+  [CHAIN.BSC]: { LP_FEES: 0.0007, POOL_FEES: 0.0003 },
+  [CHAIN.POLYGON]: { LP_FEES: 0.0007, POOL_FEES: 0.0003 },
+  [CHAIN.ARBITRUM]: { LP_FEES: 0.0007, POOL_FEES: 0.0003 },
+} as { [chain: string]: { LP_FEES: number; POOL_FEES: number } };
 
 const adapter: Adapter = {
-  adapter: {
-    [CHAIN.ETHEREUM]: {
-      ...baseAdapter[CHAIN.ETHEREUM],
-      meta: {
-        methodology,
-      },
-    },
-  },
+  adapter: {},
 };
+
+for (let chain in FEES) {
+  const { LP_FEES, POOL_FEES } = FEES[chain];
+  const TOTAL_FEES = LP_FEES + POOL_FEES;
+
+  // Convert fees to percentages and round to two decimal places
+  const totalFeesPercent = (TOTAL_FEES * 100).toFixed(2);
+  const lpFeesPercent = (LP_FEES * 100).toFixed(2);
+  const poolFeesPercent = (POOL_FEES * 100).toFixed(2);
+
+  const baseAdapter = getDexChainFees({
+    userFees: TOTAL_FEES,
+    totalFees: TOTAL_FEES,
+    supplySideRevenue: LP_FEES,
+    revenue: POOL_FEES,
+    holdersRevenue: POOL_FEES,
+    volumeAdapter,
+  });
+
+  const methodology = {
+    UserFees: `${totalFeesPercent}% of each swap is collected from the user that swaps as trading fees.`,
+    Fees: `${totalFeesPercent}% of each swap is collected from the user that swaps as trading fees.`,
+    Revenue: `${poolFeesPercent}% of each swap is collected for the staking pool (SDEX holders that staked).`,
+    ProtocolRevenue: `Protocol has no revenue.`,
+    SupplySideRevenue: `${lpFeesPercent}% of each swap is collected for the liquidity providers.`,
+    HoldersRevenue: `${poolFeesPercent}% of each swap is collected for the staking pool (SDEX holders that staked).`,
+  };
+
+  adapter.adapter[chain] = {
+    ...baseAdapter[chain],
+    meta: {
+      methodology,
+    },
+  };
+}
 
 export default adapter;

--- a/fees/benqi-lending.ts
+++ b/fees/benqi-lending.ts
@@ -1,0 +1,211 @@
+import { Adapter, ChainBlocks, FetchResultFees } from "../adapters/types"
+import { CHAIN } from "../helpers/chains";
+import { getBlock } from "../helpers/getBlock";
+import * as sdk from "@defillama/sdk";
+import { ethers, BigNumber } from "ethers";
+import { getPrices } from "../utils/prices";
+
+
+interface IPrices {
+  [address: string]: {
+    decimals: number;
+    price: number;
+    symbol: string;
+    timestamp: number;
+  };
+}
+
+interface IContext {
+  currentTimestamp: number;
+  startTimestamp: number;
+  endTimestamp: number;
+  startBlock: number;
+  endBlock: number;
+  markets: string[];
+  underlyings: string[];
+  reserveFactors: string[];
+  prices: IPrices;
+}
+interface IAccrueInterestLog {
+  market: string;
+  cashPrior: BigNumber;
+  interestAccumulated: BigNumber;
+  borrowIndexNew: BigNumber;
+  totalBorrowsNew: BigNumber;
+}
+
+interface ITx {
+  address: string;
+  data: string;
+  topics: string[];
+  transactionHash: string;
+}
+
+const unitroller = "0x486Af39519B4Dc9a7fCcd318217352830E8AD9b4";
+const comptrollerABI = {
+  getAllMarkets: "function getAllMarkets() external view returns (address[])",
+};
+
+const topic0_accue_interest = '0x4dec04e750ca11537cabcd8a9eab06494de08da3735bc8871cd41250e190bc04';
+
+const tokenABI = {
+  underlying: "function underlying() external view returns (address)",
+  accrueInterest:"event AccrueInterest(uint256 cashPrior,uint256 interestAccumulated,uint256 borrowIndex,uint256 totalBorrows)",
+  reserveFactorMantissa: "function reserveFactorMantissa() external view returns (uint256)",
+};
+
+const contract_interface = new ethers.utils.Interface(Object.values(tokenABI));
+
+const fetch = async (timestamp: number): Promise<FetchResultFees> => {
+  const context = await getContext(timestamp, {});
+  const { dailyProtocolFees, dailyProtocolRevenue } = await getDailyProtocolFees(context);
+  const dailySupplySideRevenue = (dailyProtocolFees - dailyProtocolRevenue);
+  return {
+    timestamp,
+    dailyFees: dailyProtocolFees.toString(),
+    dailyRevenue: dailyProtocolRevenue.toString(),
+    dailyHoldersRevenue: dailyProtocolRevenue.toString(),
+    dailySupplySideRevenue: `${dailySupplySideRevenue}`
+  }
+}
+
+const getAllMarkets = async (
+  unitroller: string,
+  chain: CHAIN
+): Promise<string[]> => {
+  return (
+    await sdk.api.abi.call({
+      target: unitroller,
+      abi: comptrollerABI.getAllMarkets,
+      chain: chain,
+    })
+  ).output;
+};
+
+const getContext = async (timestamp: number, _: ChainBlocks): Promise<IContext> => {
+  const fromTimestamp = timestamp - 60 * 60 * 24
+  const toTimestamp = timestamp
+  const fromBlock = (await getBlock(fromTimestamp, CHAIN.AVAX, {}));
+  const toBlock = (await getBlock(toTimestamp, CHAIN.AVAX, {}));
+
+  const allMarketAddressess = await getAllMarkets(unitroller, CHAIN.AVAX);
+  const { underlyings, reserveFactors } = await getMarketDetails(allMarketAddressess,CHAIN.AVAX);
+
+  const prices = await getPrices(
+    [
+      ...underlyings.filter((e: string) => e).map((x: string) => `${CHAIN.AVAX}:${x.toLowerCase()}`),
+    ],
+    timestamp
+  );
+
+  return {
+    currentTimestamp: timestamp,
+    startTimestamp: fromTimestamp,
+    endTimestamp: toTimestamp,
+    startBlock: fromBlock,
+    endBlock: toBlock,
+    markets: allMarketAddressess,
+    underlyings,
+    reserveFactors,
+    prices,
+  };
+};
+
+const getMarketDetails = async (markets: string[], chain: CHAIN): Promise<{underlyings: string[], reserveFactors:string[]}> => {
+  const underlyings = await sdk.api.abi.multiCall({
+    calls: markets.map((market: string) => ({
+      target: market,
+    })),
+    abi: tokenABI.underlying,
+    chain: chain,
+    permitFailure: true,
+  });
+
+  const reserveFactors = await sdk.api.abi.multiCall({
+    calls: markets.map((market: string) => ({
+      target: market,
+    })),
+    abi: tokenABI.reserveFactorMantissa,
+    chain: chain,
+    permitFailure: true,
+  });
+  const _underlyings =  underlyings.output.map((x: any) => x.output);
+  _underlyings[0]  = '0xB31f66AA3C1e785363F0875A1B74E27b85FD66c7';
+  return {
+    underlyings: _underlyings,
+    reserveFactors: reserveFactors.output.map((x: any) => x.output),
+  };
+};
+
+
+const getDailyProtocolFees = async ({
+  markets,
+  underlyings,
+  reserveFactors,
+  prices,
+  startBlock,
+  endBlock,
+}: IContext) => {
+  let dailyProtocolFees = 0;
+  let dailyProtocolRevenue = 0;
+  const logs: ITx[] = (await Promise.all(
+    markets.map((address: string) => sdk.api.util.getLogs({
+      target: address,
+      topic: '',
+      toBlock: endBlock,
+      fromBlock: startBlock,
+      keys: [],
+      chain: CHAIN.AVAX,
+      topics: [topic0_accue_interest]
+  }))))
+    .map((e: any) => e)
+    .map(e => e.output).flat();
+
+  const raw_data: IAccrueInterestLog[] = logs.map((e: ITx) => {
+    const x =  contract_interface.parseLog(e);
+    return {
+      market: e.address,
+      cashPrior: x.args.cashPrior,
+      interestAccumulated: x.args.interestAccumulated,
+      borrowIndexNew: x.args.borrowIndex,
+      totalBorrowsNew: x.args.totalBorrows,
+    }
+  });
+
+  raw_data.forEach((log: IAccrueInterestLog) => {
+    const marketIndex = markets.findIndex((e: string) => e === log.market);
+    const underlying = underlyings[marketIndex].toLowerCase();
+    const price = prices[`${CHAIN.AVAX}:${underlying?.toLowerCase()}`];
+
+    const interestTokens = +ethers.utils.formatUnits(
+      log.interestAccumulated,
+      price?.decimals || 0
+    );
+    const reserveFactor = +ethers.utils.formatUnits(
+      reserveFactors[marketIndex],
+      18
+    );
+    const interestUSD = interestTokens * price?.price || 0;
+
+    dailyProtocolFees += interestUSD;
+    dailyProtocolRevenue += interestUSD * reserveFactor;
+  });
+
+  return {
+    dailyProtocolFees,
+    dailyProtocolRevenue,
+  };
+};
+
+
+const adapter: Adapter = {
+  adapter: {
+    [CHAIN.AVAX]: {
+      fetch: fetch,
+      start: async () => 1664582400,
+      runAtCurrTime: true,
+    },
+  },
+};
+
+export default adapter;


### PR DESCRIPTION
This pull request makes the Dimension smardex adapter compatible with all chains supported by Smardex.
I have upgraded the staking and farming addresses on `ethereum`.

**dexs/SmarDex/index.ts** changes
- New chains added: `arbitrum`, `polygon`, and `bsc`.
- Subgraph endpoints updated to smardex subgraph gateway
- The graphql queries are authenticated with `x-api-key` header

**fees/SmarDex/index.ts** changes
- New chains added: `arbitrum`, `polygon`, and `bsc`.
- There is `0.1%` fees on the new chains

:warning: The variable `SMARDEX_SUBGRAPH_API_KEY` (that we already provided to DefiLlama) is necessary.