### PR TITLE
Adding trade.grizzly.fi volume and fees page

### DIFF
--- a/dexs/grizzlyfi/index.ts
+++ b/dexs/grizzlyfi/index.ts
@@ -1,5 +1,5 @@
 import request, { gql } from "graphql-request";
-import { BreakdownAdapter, Fetch, SimpleAdapter } from "../../adapters/types";
+import { BreakdownAdapter, Fetch } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 import { getUniqStartOfTodayTimestamp } from "../../helpers/getUniSubgraphVolume";
 

--- a/dexs/grizzlyfi/index.ts
+++ b/dexs/grizzlyfi/index.ts
@@ -1,0 +1,110 @@
+import request, { gql } from "graphql-request";
+import { BreakdownAdapter, Fetch, SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import { getUniqStartOfTodayTimestamp } from "../../helpers/getUniSubgraphVolume";
+
+const endpoints: { [key: string]: string } = {
+    [CHAIN.BSC]: "https://api.thegraph.com/subgraphs/name/metavault-trade/grizzly-bnb-subgraph",
+}
+
+const historicalDataSwap = gql`
+  query get_volume($period: String!, $id: String!) {
+    volumeStats(where: {period: $period, id: $id}) {
+        swap
+      }
+  }
+`
+
+const historicalDataDerivatives = gql`
+  query get_volume($period: String!, $id: String!) {
+    volumeStats(where: {period: $period, id: $id}) {
+        liquidation
+        margin
+      }
+  }
+`
+
+const historicalDataGll = gql`
+  query get_volume($period: String!, $id: String!) {
+    volumeStats(where: {period: $period, id: $id}) {
+        mint
+        burn
+      }
+  }
+`
+
+interface IGraphResponse {
+    volumeStats: Array<{
+        burn: string,
+        liquidation: string,
+        margin: string,
+        mint: string,
+        swap: string,
+    }>
+}
+
+const getFetch = (query: string) => (chain: string): Fetch => async (timestamp: number) => {
+    const dayTimestamp = getUniqStartOfTodayTimestamp(new Date((timestamp * 1000)))
+    const dailyData: IGraphResponse = await request(endpoints[chain], query, {
+        id: String(dayTimestamp) + ':daily',
+        period: 'daily',
+    })
+    const totalData: IGraphResponse = await request(endpoints[chain], query, {
+        id: 'total',
+        period: 'total',
+    })
+
+    return {
+        timestamp: dayTimestamp,
+        dailyVolume:
+            dailyData.volumeStats.length == 1
+                ? String(Number(Object.values(dailyData.volumeStats[0]).reduce((sum, element) => String(Number(sum) + Number(element)))) * 10 ** -30)
+                : undefined,
+        totalVolume:
+            totalData.volumeStats.length == 1
+                ? String(Number(Object.values(totalData.volumeStats[0]).reduce((sum, element) => String(Number(sum) + Number(element)))) * 10 ** -30)
+                : undefined,
+
+    }
+}
+
+const getStartTimestamp = async (chain: string) => {
+    const startTimestamps: { [chain: string]: number } = {
+        [CHAIN.BSC]: 1689897600,
+    }
+    return startTimestamps[chain]
+}
+
+const adapter: BreakdownAdapter = {
+    breakdown: {
+        "swap": Object.keys(endpoints).reduce((acc, chain) => {
+            return {
+                ...acc,
+                [chain]: {
+                    fetch: getFetch(historicalDataSwap)(chain),
+                    start: async () => getStartTimestamp(chain)
+                }
+            }
+        }, {}),
+        "derivatives": Object.keys(endpoints).reduce((acc, chain) => {
+            return {
+                ...acc,
+                [chain]: {
+                    fetch: getFetch(historicalDataDerivatives)(chain),
+                    start: async () => getStartTimestamp(chain)
+                }
+            }
+        }, {}),
+        "gll": Object.keys(endpoints).reduce((acc, chain) => {
+            return {
+                ...acc,
+                [chain]: {
+                    fetch: getFetch(historicalDataGll)(chain),
+                    start: async () => getStartTimestamp(chain)
+                }
+            }
+        }, {})
+    }
+}
+
+export default adapter;

--- a/fees/grizzlyfi.ts
+++ b/fees/grizzlyfi.ts
@@ -1,0 +1,70 @@
+import { Adapter } from "../adapters/types";
+import { ARBITRUM, AVAX, BSC } from "../helpers/chains";
+import { request, gql } from "graphql-request";
+import type { ChainEndpoints } from "../adapters/types"
+import { Chain } from '@defillama/sdk/build/general';
+import { getTimestampAtStartOfDayUTC } from "../utils/date";
+
+const endpoints = {
+    [BSC]: "https://api.thegraph.com/subgraphs/name/metavault-trade/grizzly-bnb-subgraph"
+}
+
+const methodology = {
+    Fees: "Fees from open/close position (0.1%), swap (0.2% to 0.8%), mint and burn (based on tokens balance in the pool) and borrow fee ((assets borrowed)/(total assets in pool)*0.01%)",
+    UserFees: "Fees from open/close position (0.1%), swap (0.2% to 0.8%) and borrow fee ((assets borrowed)/(total assets in pool)*0.01%)",
+    HoldersRevenue: "10% goes to MVX stakers and 25% are buyback and burn of GHNY",
+    SupplySideRevenue: "50% of all collected fees goes to GLL holders",
+    Revenue: "15% Protocol revenue, 10% goes to MVX stakers and 25% are buyback and burn of GHNY",
+    ProtocolRevenue: "10% of all collected fees goes to Grizzly.fi treasury and 5% goes to marketing"
+}
+
+const graphs = (graphUrls: ChainEndpoints) => {
+    return (chain: Chain) => {
+        return async (timestamp: number) => {
+            const todaysTimestamp = getTimestampAtStartOfDayUTC(timestamp)
+            const searchTimestamp = todaysTimestamp + ":daily"
+
+            const graphQuery = gql
+                `{
+        feeStat(id: "${searchTimestamp}") {
+          mint
+          burn
+          marginAndLiquidation
+          swap
+        }
+      }`;
+
+            const graphRes = await request(graphUrls[chain], graphQuery);
+
+            const dailyFee = parseInt(graphRes.feeStat.mint) + parseInt(graphRes.feeStat.burn) + parseInt(graphRes.feeStat.marginAndLiquidation) + parseInt(graphRes.feeStat.swap)
+            const finalDailyFee = (dailyFee / 1e30);
+            const userFee = parseInt(graphRes.feeStat.marginAndLiquidation) + parseInt(graphRes.feeStat.swap)
+            const finalUserFee = (userFee / 1e30);
+
+            return {
+                timestamp,
+                dailyFees: finalDailyFee.toString(),
+                dailyUserFees: finalUserFee.toString(),
+                dailyRevenue: (finalDailyFee * 0.1 + finalDailyFee * 0.25 + finalDailyFee * 0.15).toString(),
+                dailyProtocolRevenue: (finalDailyFee * 0.15).toString(),
+                dailyHoldersRevenue: (finalDailyFee * 0.1 + finalDailyFee * 0.25).toString(),
+                dailySupplySideRevenue: (finalDailyFee * 0.5).toString()
+            };
+        };
+    };
+};
+
+
+const adapter: Adapter = {
+    adapter: {
+        [BSC]: {
+            fetch: graphs(endpoints)(BSC),
+            start: async () => 1689897600,
+            meta: {
+                methodology
+            }
+        },
+    }
+}
+
+export default adapter;


### PR DESCRIPTION
This PR adds the following grizzly perpetuals project: trade.grizzly.fi.

It adds the volumes generated from subgraph and the fees structures including methodology