### PR TITLE
Hyperliquid: Use global stats endpoint to include all tokens in volume

### DIFF
--- a/dexs/hyperliquid/index.ts
+++ b/dexs/hyperliquid/index.ts
@@ -11,7 +11,7 @@ interface Response {
 }
 
 const fetch = async (timestamp: number) => {
-  const {totalVolume, dailyVolume}: Response = await axios.post(URL, {"type":"globalStats"});
+  const {totalVolume, dailyVolume}: Response = (await axios.post(URL, {"type":"globalStats"})).data;
   const dayTimestamp = getUniqStartOfTodayTimestamp(new Date(timestamp * 1000));
 
   return {

--- a/dexs/hyperliquid/index.ts
+++ b/dexs/hyperliquid/index.ts
@@ -11,7 +11,7 @@ interface Response {
 }
 
 const fetch = async (timestamp: number) => {
-  const {totalVolume, dailyVolume}: Response = (await axios.post(URL, {"type":"globalStats"})).data;
+  const {totalVolume, dailyVolume}: Response = (await axios.post(URL, {"type": "globalStats"})).data;
   const dayTimestamp = getUniqStartOfTodayTimestamp(new Date(timestamp * 1000));
 
   return {

--- a/dexs/hyperliquid/index.ts
+++ b/dexs/hyperliquid/index.ts
@@ -4,53 +4,19 @@ import { CHAIN } from "../../helpers/chains";
 import axios from "axios";
 
 const URL = "https://api.hyperliquid.xyz/info";
-const coins = {
-  'ARB': 'coingecko:arbitrum',
-  'DOGE': 'coingecko:dogecoin',
-  'OP': 'coingecko:optimism',
-  'DYDX': 'coingecko:dydx',
-  'SOL': 'coingecko:solana',
-  'LTC': 'coingecko:litecoin',
-  'AVAX': 'coingecko:avalanche-2',
-  'ETH': 'coingecko:ethereum',
-  'ATOM': 'coingecko:cosmos',
-  'BTC': 'coingecko:bitcoin',
-  'MATIC': 'coingecko:matic-network',
-  'APE': 'coingecko:apecoin',
-  'BNB': 'coingecko:binancecoin',
-}
 
-
-interface IAPIResponse {
-  volume: string;
-  timestamp: number;
-  id: string;
-  volumeUSD: number;
-  closePrice: string;
-};
-
-const getBody = (coin: string) => {
-  return {"type":"candleSnapshot", "req": {"coin": coin, "interval": "1d", "startTime": 1677283200000}}
+interface Response {
+  totalVolume?: number;
+  dailyVolume?: number;
 }
 
 const fetch = async (timestamp: number) => {
-  const dayTimestamp = getUniqStartOfTodayTimestamp(new Date(timestamp * 1000))
-  const historical = (await Promise.all(Object.keys(coins).map((coins: string) =>axios.post(URL, getBody(coins)))))
-    .map((a: any, index: number) => a.data.map((e: any) => { return { timestamp: e.t / 1000, volume: e.v, closePrice: e.c, id: Object.values(coins)[index]}})).flat()
+  const {totalVolume, dailyVolume}: Response = await axios.post(URL, {"type":"globalStats"});
+  const dayTimestamp = getUniqStartOfTodayTimestamp(new Date(timestamp * 1000));
 
-  const historicalUSD = historical.map((e: IAPIResponse) => {
-    return {
-      ...e,
-      volumeUSD: Number(e.volume) * Number(e.closePrice)
-    }
-  });
-  const dailyVolume = historicalUSD.filter((e: IAPIResponse) => e.timestamp === dayTimestamp)
-    .reduce((a: number, {volumeUSD}) => a+volumeUSD, 0);
-  const totalVolume = historicalUSD.filter((e: IAPIResponse) => e.timestamp <= dayTimestamp)
-    .reduce((a: number, {volumeUSD}) => a+volumeUSD, 0);
   return {
-    totalVolume: `${totalVolume}`,
-    dailyVolume: dailyVolume ? `${dailyVolume}` : undefined,
+    totalVolume: totalVolume?.toString(),
+    dailyVolume: dailyVolume?.toString(),
     timestamp: dayTimestamp,
   };
 };


### PR DESCRIPTION
```
$ yarn test dexs hyperliquid
yarn run v1.22.19
$ yarn run update-submodules && ts-node cli/testAdapter.ts dexs hyperliquid
$ git submodule update --init --recursive --remote --merge
🦙 Running HYPERLIQUID adapter 🦙
_______________________________________
Dexs for 26/7/2023
_______________________________________

ARBITRUM 👇
Backfill start time: 25/2/2023
NO METHODOLOGY SPECIFIED
Total volume: 2439076155.3031406
Daily volume: 46745783.31844899
Timestamp: 1690329600




✨  Done in 2.96s.
```