### PR TITLE
zunami fee adapter

### DIFF
--- a/fees/zunami/index.ts
+++ b/fees/zunami/index.ts
@@ -1,0 +1,102 @@
+import {CHAIN} from "../../helpers/chains";
+import {Chain} from '@defillama/sdk/build/general';
+import {ChainBlocks, SimpleAdapter} from "../../adapters/types";
+import {getBlock} from "../../helpers/getBlock";
+import * as sdk from "@defillama/sdk";
+import fetchURL from "../../utils/fetchURL";
+
+const dataEndpoint = (fromTimestamp: number, toTimestamp: number): string => {
+    return "https://api.zunami.io/api/v2/zunami/yield?from=" + fromTimestamp + "&to=" + toTimestamp;
+};
+
+const ONE_DAY_IN_SECONDS = 60 * 60 * 24;
+const ZUNAMI_ADDRESS = "0x2ffCC661011beC72e1A9524E12060983E74D14ce";
+const APS_ADDRESS = "0xCaB49182aAdCd843b037bBF885AD56A3162698Bd";
+const FEE_DENOMINATOR = 1000;
+const START_TIMESTAMP = 1646956800;
+
+interface YieldData {
+    omnipoolYield: number;
+    apsYield: number;
+    rigidYield: number;
+    totalYield: number;
+}
+
+type TABI = {
+    [k: string]: object;
+}
+const ABIs: TABI = {
+    getManagementFee: {
+        "inputs": [],
+        "name": "managementFee",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    }
+};
+
+const getData = (chain: Chain) => {
+    return async (timestamp: number, _: ChainBlocks) => {
+        const from = timestamp - ONE_DAY_IN_SECONDS;
+        const to = timestamp;
+        const block = await getBlock(from, chain, {});
+        const omnipoolManagementFee = Number((
+            await sdk.api.abi.call({
+                target: ZUNAMI_ADDRESS,
+                chain: chain,
+                abi: ABIs.getManagementFee,
+                block: block
+            })
+        ).output) / FEE_DENOMINATOR
+        const apsManagementFee = Number((
+            await sdk.api.abi.call({
+                target: APS_ADDRESS,
+                chain: chain,
+                abi: ABIs.getManagementFee,
+                block: block
+            })
+        ).output) / FEE_DENOMINATOR
+
+        const dailyData: YieldData = (await fetchURL(dataEndpoint(from, to))).data;
+        const dailyRevenue = (dailyData.omnipoolYield * omnipoolManagementFee)
+            + (dailyData.apsYield * apsManagementFee) + dailyData.rigidYield;
+        const dailyHoldersRevenue = dailyData.omnipoolYield + dailyData.apsYield;
+
+        const totalData: YieldData = (await fetchURL(dataEndpoint(START_TIMESTAMP, to))).data
+        const totalRevenue = (totalData.omnipoolYield * omnipoolManagementFee)
+            + (totalData.apsYield * apsManagementFee) + totalData.rigidYield
+        const totalDailyHoldersRevenue = totalData.omnipoolYield + totalData.apsYield;
+
+        return {
+            dailyFees: `${dailyData.totalYield}`,
+            totalFees: `${totalData.totalYield}`,
+            dailyRevenue: `${dailyRevenue}`,
+            totalRevenue: `${totalRevenue}`,
+            dailyHoldersRevenue: `${dailyHoldersRevenue}`,
+            totalDailyHoldersRevenue: `${totalDailyHoldersRevenue}`,
+            timestamp
+        }
+    }
+}
+
+const methodology = {
+    Fees: "The protocol's revenue from Omnipools (performance fee) & Yield from Omnipools, Protocol's revenue from " +
+        "APS (performance fee) & Yield from APS, Yield from zStables collateral located in the pool.",
+    Revenue: "The protocol's revenue from Omnipools (performance fee), Protocol's revenue from APS (performance fee), " +
+        "Yield from zStables collateral located in the pool",
+    HoldersRevenue: "Yield from Omnipools, Yield from APS.",
+}
+
+const adapter: SimpleAdapter = {
+    adapter: {
+        [CHAIN.ETHEREUM]: {fetch: getData(CHAIN.ETHEREUM), start: async () => START_TIMESTAMP, meta: {methodology}},
+    }
+};
+
+export default adapter;


### PR DESCRIPTION
Test output:

```
ETHEREUM 👇
Backfill start time: 11/3/2022
Daily fees: 514.3686903904078
└─ Methodology: The protocol's revenue from Omnipools (performance fee) & Yield from Omnipools, Protocol's revenue from APS (performance fee) & Yield from APS, Yield from zStables collateral located in the pool.
Total fees: 314340.06860969454
└─ Methodology: The protocol's revenue from Omnipools (performance fee) & Yield from Omnipools, Protocol's revenue from APS (performance fee) & Yield from APS, Yield from zStables collateral located in the pool.
Daily revenue: 77.15530355856117
└─ Methodology: The protocol's revenue from Omnipools (performance fee), Protocol's revenue from APS (performance fee), Yield from zStables collateral located in the pool
Total revenue: 114738.71071737987
└─ Methodology: The protocol's revenue from Omnipools (performance fee), Protocol's revenue from APS (performance fee), Yield from zStables collateral located in the pool
Daily holders revenue: 514.3686903904078
└─ Methodology: Yield from Omnipools, Yield from APS.
Total daily holders revenue: 234825.1269321349
Timestamp: 1691107198
```
