### PR TITLE
add SyncSwap dex volume

### DIFF
--- a/dexs/syncswap/index.ts
+++ b/dexs/syncswap/index.ts
@@ -7,7 +7,7 @@ const endpoints = {
 
 const adapter = univ2Adapter(endpoints, {
   factoriesName: "syncSwapFactories",
-  dayData: "syncSwapSwitchDayData",
+  dayData: "dayData",
   dailyVolume: "dailyVolumeUSD",
   totalVolume: "totalVolumeUSD",
   dailyVolumeTimestampField: "date",


### PR DESCRIPTION
The test script was not working for me so I could not test to verify this adapters functionality, though it was copied directly from the mute.io adapter with only a changed subgraph link.