### PR TITLE
dackieswap integrate volume chart

### DIFF
--- a/dexs/dackieswap/index.ts
+++ b/dexs/dackieswap/index.ts
@@ -1,0 +1,44 @@
+import { IJSON, SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+
+import { getGraphDimensions } from "../../helpers/getUniSubgraph";
+
+const v3Endpoint = {
+  [CHAIN.BASE]:
+    "https://api.studio.thegraph.com/query/50473/exchange-clmm/version/latest",
+};
+
+const VOLUME_USD = "volumeUSD";
+
+const v3Graph = getGraphDimensions({
+  graphUrls: v3Endpoint,
+  totalVolume: {
+    factory: "factories",
+  },
+  dailyVolume: {
+    factory: "pancakeDayData",
+    field: VOLUME_USD,
+  },
+  totalFees:{
+    factory: "factories",
+  },
+  dailyFees: {
+    factory: "pancakeDayData",
+    field: "feesUSD"
+  },
+});
+
+const v3StartTimes = {
+  [CHAIN.BASE]: 1691712000,
+} as IJSON<number>;
+
+const adapter: SimpleAdapter = {
+  adapter: {
+    [CHAIN.BASE]: {
+      fetch: v3Graph(CHAIN.BASE),
+      start: async () => v3StartTimes[CHAIN.BASE]
+    },
+  },
+};
+
+export default adapter;


### PR DESCRIPTION
DackieSwap integrate volume chart.

We already integrate TVL chart here
https://defillama.com/protocol/dackieswap

Now just want to add volume and fee chart, please help.