### PR TITLE
Smardex: Register Base chain

### DIFF
--- a/dexs/SmarDex/index.ts
+++ b/dexs/SmarDex/index.ts
@@ -5,7 +5,6 @@ import {
   getGraphDimensions,
 } from "../../helpers/getUniSubgraph";
 import { CHAIN } from "../../helpers/chains";
-import { type } from "os";
 import { Chain } from "@defillama/sdk/build/general";
 
 const SMARDEX_SUBGRAPH_API_KEY = process.env.SMARDEX_SUBGRAPH_API_KEY;
@@ -22,6 +21,7 @@ const defaultHeaders = {
 
 const graphUrls = {
   [CHAIN.ARBITRUM]: `${SMARDEX_SUBGRAPH_GATEWAY}/arbitrum`,
+  [CHAIN.BASE]: `${SMARDEX_SUBGRAPH_GATEWAY}/base`,
   [CHAIN.BSC]: `${SMARDEX_SUBGRAPH_GATEWAY}/bsc`,
   [CHAIN.ETHEREUM]: `${SMARDEX_SUBGRAPH_GATEWAY}/ethereum`,
   [CHAIN.POLYGON]: `${SMARDEX_SUBGRAPH_GATEWAY}/polygon`,
@@ -32,6 +32,7 @@ type IMap = {
 }
 const graphRequestHeaders:IMap = {
   [CHAIN.ARBITRUM]: defaultHeaders,
+  [CHAIN.BASE]: defaultHeaders,
   [CHAIN.BSC]: defaultHeaders,
   [CHAIN.ETHEREUM]: defaultHeaders,
   [CHAIN.POLYGON]: defaultHeaders,
@@ -73,6 +74,10 @@ const adapter: SimpleAdapter = {
     [CHAIN.ARBITRUM]: {
       fetch: graphs(CHAIN.ARBITRUM),
       start: async () => 1689582249,
+    },
+    [CHAIN.BASE]: {
+      fetch: graphs(CHAIN.BASE),
+      start: async () => 1691491872,
     },
   },
 };

--- a/fees/SmarDex/index.ts
+++ b/fees/SmarDex/index.ts
@@ -19,6 +19,7 @@ const FEES = {
   [CHAIN.BSC]: { LP_FEES: 0.0007, POOL_FEES: 0.0003 },
   [CHAIN.POLYGON]: { LP_FEES: 0.0007, POOL_FEES: 0.0003 },
   [CHAIN.ARBITRUM]: { LP_FEES: 0.0007, POOL_FEES: 0.0003 },
+  [CHAIN.BASE]: { LP_FEES: 0.0007, POOL_FEES: 0.0003 },
 } as { [chain: string]: { LP_FEES: number; POOL_FEES: number } };
 
 // SDEX contract creation timestamps for each chain
@@ -27,6 +28,7 @@ const CHAIN_STARTS = {
   [CHAIN.BSC]: 1688978540,
   [CHAIN.POLYGON]: 1682085480,
   [CHAIN.ARBITRUM]: 1688976153,
+  [CHAIN.BASE]: 1691491872,
 } as { [chain: string]: number };
 
 // Methodology descriptions
@@ -72,7 +74,7 @@ export async function feesFromSubgraph(
   const timestamp = getTimestampAtStartOfDayUTC(time);
   const graphQuery = gql`
     {
-      feeDayDatas(first: 1, where: { dayId_lte: ${dayId} }) {
+      feeDayData(id: ${dayId}) {
         dailyFeesPoolUSD
         dailyFeesLpUSD
         totalFeesPoolUSD
@@ -83,8 +85,9 @@ export async function feesFromSubgraph(
 
   const url = `${SMARDEX_SUBGRAPH_GATEWAY}/${chain}`;
   const graphRes = await request(url, graphQuery, undefined, defaultHeaders);
-  const fees = graphRes["feeDayDatas"][0];
+  const fees = graphRes["feeDayData"];
 
+  // If the day is not available, fees are 0
   if (!fees) return { timestamp };
 
   const dailyFees = new BigNumber(fees.dailyFeesPoolUSD)


### PR DESCRIPTION
This pull request makes updates to the Smardex dimension-adapters with the recent Base chain support.

+ Fixed the GraphQL query that retrieves the fees.

Now, if a fees entity is not available for a given day, the adapter will return an empty fees response instead of the previous day's data.