### PR TITLE
add jumper-exchange

### DIFF
--- a/aggregators/jumper-exchange/index.ts
+++ b/aggregators/jumper-exchange/index.ts
@@ -1,0 +1,111 @@
+import { Chain } from "@defillama/sdk/build/general";
+import { FetchResultVolume, SimpleAdapter } from "../../adapters/types";
+import { getBlock } from "../../helpers/getBlock";
+import { ethers } from "ethers";
+import { getPrices } from "../../utils/prices";
+import { CHAIN } from "../../helpers/chains";
+import * as sdk from "@defillama/sdk";
+import { type } from "os";
+
+const topic0 = '0x38eee76fd911eabac79da7af16053e809be0e12c8637f156e77e1af309b99537';
+const integrator = '0x00000000000000000000000000000000000000000000000000000000000000e0';
+
+type IContract = {
+  [c: string | Chain]: string;
+}
+const contract: IContract = {
+  [CHAIN.ARBITRUM]: '0x1231deb6f5749ef6ce6943a275a1d3e7486f4eae',
+  [CHAIN.OPTIMISM]: '0x1231deb6f5749ef6ce6943a275a1d3e7486f4eae',
+  [CHAIN.BASE]: '0x1231deb6f5749ef6ce6943a275a1d3e7486f4eae',
+  [CHAIN.ETHEREUM]: '0x1231deb6f5749ef6ce6943a275a1d3e7486f4eae',
+  [CHAIN.AVAX]: '0x1231deb6f5749ef6ce6943a275a1d3e7486f4eae',
+  [CHAIN.BSC]: '0x1231deb6f5749ef6ce6943a275a1d3e7486f4eae',
+  [CHAIN.POLYGON]: '0x1231deb6f5749ef6ce6943a275a1d3e7486f4eae',
+  [CHAIN.POLYGON_ZKEVM]: '0x1231deb6f5749ef6ce6943a275a1d3e7486f4eae',
+  [CHAIN.FANTOM]: '0x1231deb6f5749ef6ce6943a275a1d3e7486f4eae'
+}
+
+interface ILog {
+  address: string;
+  data: string;
+  transactionHash: string;
+  topics: string[];
+}
+interface IData {
+  integrator: string;
+  fromAssetId: string;
+  toAssetId: string;
+  fromAmount: number;
+  toAmount: number;
+}
+
+const fetch = (chain: Chain) => {
+  return async (timestamp: number): Promise<FetchResultVolume> => {
+    const fromTimestamp = timestamp - 60 * 60 * 24;
+    const toTimestamp = timestamp;
+    try {
+      const fromBlock = (await getBlock(fromTimestamp, chain, {}));
+      const toBlock = (await getBlock(toTimestamp, chain, {}));
+      const logs = (await sdk.api.util.getLogs({
+        target: contract[chain],
+        topic: topic0,
+        toBlock: toBlock,
+        fromBlock: fromBlock,
+        keys: [],
+        chain: chain,
+        topics: [topic0]
+      })).output as ILog[];
+
+      const data: IData[] = logs.map((e: ILog) => {
+        const _data  = e.data.replace('0x', '');
+        const integrator = `0x${_data.slice(0, 64)}`;
+        const fromAssetId = '0x' + `0x${_data.slice(192, 256)}`.slice(26, 66);
+        const toAssetId =  '0x' + `0x${_data.slice(256, 320)}`.slice(26, 66);
+        const fromAmount = Number(`0x${_data.slice(320, 384)}`);
+        const toAmount = Number(`0x${_data.slice(384, 446)}`);
+        return {
+          tx: e.transactionHash,
+          integrator,
+          fromAssetId,
+          toAssetId,
+          toAmount,
+          fromAmount
+        }
+      }).filter(e => e.integrator.toLowerCase() === integrator.toLowerCase())
+      const coins: string[] = [...new Set([...new Set(data.map((e: IData) => `${chain}:${e.fromAssetId}`)), ...new Set(data.map((e: IData) => `${chain}:${e.toAssetId}`))])];
+      const prices = await getPrices(coins, timestamp);
+      const volumeUSD = data.map((e: IData) => {
+        const fromPrice = prices[`${chain}:${e.fromAssetId}`]?.price || 0;
+        const toPrice = prices[`${chain}:${e.toAssetId}`]?.price || 0;
+        const fromDecimals = prices[`${chain}:${e.fromAssetId}`]?.decimals || 0;
+        const toDecimals = prices[`${chain}:${e.toAssetId}`]?.decimals || 0;
+
+        const fromAmount = (e.fromAmount / 10 ** fromDecimals) * fromPrice;
+        const toAmount = (e.toAmount / 10 ** toDecimals) * toPrice;
+        return fromPrice ? fromAmount : toAmount;
+      }).reduce((a: number, b: number) => a + b, 0);
+      const dailyVolume = volumeUSD;
+      return {
+        dailyVolume: `${dailyVolume}`,
+        timestamp,
+      };
+    } catch (error) {
+      console.error(error);
+      throw error;
+    }
+  };
+};
+
+const adapter: SimpleAdapter = {
+  adapter: Object.keys(contract).reduce((acc, chain) => {
+    return {
+      ...acc,
+      [chain]: {
+        fetch: fetch(chain),
+        start: async () => 1691625600,
+      }
+    }
+  }, {})
+};
+
+export default adapter;


### PR DESCRIPTION
```
✨  Done in 0.12s.
🦙 Running JUMPER-EXCHANGE adapter 🦙
_______________________________________
Aggregators for 10/9/2023
_______________________________________

ARBITRUM 👇
Backfill start time: 10/8/2023
NO METHODOLOGY SPECIFIED
Daily volume: 177491.60264542824
Timestamp: 1694390398


OPTIMISM 👇
Backfill start time: 10/8/2023
NO METHODOLOGY SPECIFIED
Daily volume: 185789.29339833398
Timestamp: 1694390398


BASE 👇
Backfill start time: 10/8/2023
NO METHODOLOGY SPECIFIED
Daily volume: 5110.809414188643
Timestamp: 1694390398


ETHEREUM 👇
Backfill start time: 10/8/2023
NO METHODOLOGY SPECIFIED
Daily volume: 39779.997158866485
Timestamp: 1694390398


AVAX 👇
Backfill start time: 10/8/2023
NO METHODOLOGY SPECIFIED
Daily volume: 13460.764280702348
Timestamp: 1694390398


BSC 👇
Backfill start time: 10/8/2023
NO METHODOLOGY SPECIFIED
Daily volume: 50119.155821492095
Timestamp: 1694390398


POLYGON 👇
Backfill start time: 10/8/2023
NO METHODOLOGY SPECIFIED
Daily volume: 123867.76859114273
Timestamp: 1694390398


POLYGON_ZKEVM 👇
Backfill start time: 10/8/2023
NO METHODOLOGY SPECIFIED
Daily volume: 6134.14689966792
Timestamp: 1694390398


FANTOM 👇
Backfill start time: 10/8/2023
NO METHODOLOGY SPECIFIED
Daily volume: 1209.7776877920535
Timestamp: 1694390398



```