### PR TITLE
Fix Stride Terra chain issue

### DIFF
--- a/fees/stride.ts
+++ b/fees/stride.ts
@@ -9,10 +9,15 @@ interface DailyFeeResponse {
   };
 }
 
+const chainOverrides: { [key: string]: string } = {
+  "terra": "terra2",
+};
+
 const fetch = (chain: string) => {
   return async (timestamp: number): Promise<FetchResult> => {
+    const overriddenChain = chainOverrides[chain] || chain; // Override if exists, else use original
     const response = await axios.get<DailyFeeResponse>(
-      `https://edge.stride.zone/api/${chain}/stats/fees`
+      `https://edge.stride.zone/api/${overriddenChain}/stats/fees`
     );
 
     return {
@@ -22,6 +27,7 @@ const fetch = (chain: string) => {
     };
   };
 };
+
 
 const meta = {
   methodology: {


### PR DESCRIPTION
Stride's Fees aren't working because the chain "terra" was renamed to "terra2". This PR just overrides that so fees are flowing through properly. 

Output from test:

❯ yarn test fees stride
yarn run v1.22.19
$ yarn run update-submodules && ts-node cli/testAdapter.ts fees stride
$ git submodule update --init --recursive --remote --merge
🦙 Running STRIDE adapter 🦙
_______________________________________
Fees for 13/9/2023
_______________________________________

COSMOS 👇
Backfill start time not defined
Timestamp: 1694649598
Daily fees: 12171.948802514527
└─ Methodology: Fees are staking rewards earned by tokens staked with Stride. They are measured across Stride's LSD tokens' yields and converted to USD terms.
Daily revenue: 1217.1948802514528
└─ Methodology: Stride collects 10% of liquid staked assets's staking rewards. These fees are measured across Stride's LSD tokens' yields and converted to USD terms.


OSMOSIS 👇
Backfill start time not defined
Timestamp: 1694649598
Daily fees: 1010.6674607061306
└─ Methodology: Fees are staking rewards earned by tokens staked with Stride. They are measured across Stride's LSD tokens' yields and converted to USD terms.
Daily revenue: 101.06674607061306
└─ Methodology: Stride collects 10% of liquid staked assets's staking rewards. These fees are measured across Stride's LSD tokens' yields and converted to USD terms.


JUNO 👇
Backfill start time not defined
Timestamp: 1694649598
Daily fees: 398.95235776109575
└─ Methodology: Fees are staking rewards earned by tokens staked with Stride. They are measured across Stride's LSD tokens' yields and converted to USD terms.
Daily revenue: 39.89523577610958
└─ Methodology: Stride collects 10% of liquid staked assets's staking rewards. These fees are measured across Stride's LSD tokens' yields and converted to USD terms.


STARGAZE 👇
Backfill start time not defined
Timestamp: 1694649598
Daily fees: 113.58608133349313
└─ Methodology: Fees are staking rewards earned by tokens staked with Stride. They are measured across Stride's LSD tokens' yields and converted to USD terms.
Daily revenue: 11.358608133349314
└─ Methodology: Stride collects 10% of liquid staked assets's staking rewards. These fees are measured across Stride's LSD tokens' yields and converted to USD terms.


TERRA 👇
Backfill start time not defined
Timestamp: 1694649598
Daily fees: 82.10490640758056
└─ Methodology: Fees are staking rewards earned by tokens staked with Stride. They are measured across Stride's LSD tokens' yields and converted to USD terms.
Daily revenue: 8.210490640758056
└─ Methodology: Stride collects 10% of liquid staked assets's staking rewards. These fees are measured across Stride's LSD tokens' yields and converted to USD terms.


EVMOS 👇
Backfill start time not defined
Timestamp: 1694649598
Daily fees: 1365.8682422979925
└─ Methodology: Fees are staking rewards earned by tokens staked with Stride. They are measured across Stride's LSD tokens' yields and converted to USD terms.
Daily revenue: 136.58682422979925
└─ Methodology: Stride collects 10% of liquid staked assets's staking rewards. These fees are measured across Stride's LSD tokens' yields and converted to USD terms.


INJECTIVE 👇
Backfill start time not defined
Timestamp: 1694649598
Daily fees: 616.0308226017967
└─ Methodology: Fees are staking rewards earned by tokens staked with Stride. They are measured across Stride's LSD tokens' yields and converted to USD terms.
Daily revenue: 61.60308226017967
└─ Methodology: Stride collects 10% of liquid staked assets's staking rewards. These fees are measured across Stride's LSD tokens' yields and converted to USD terms.


UMEE 👇
Backfill start time not defined
Timestamp: 1694649598
Daily fees: 39.21103484151156
└─ Methodology: Fees are staking rewards earned by tokens staked with Stride. They are measured across Stride's LSD tokens' yields and converted to USD terms.
Daily revenue: 3.9211034841511565
└─ Methodology: Stride collects 10% of liquid staked assets's staking rewards. These fees are measured across Stride's LSD tokens' yields and converted to USD terms.




✨  Done in 2.30s.