### PR TITLE
Correct Solidly V3 revenue from 100% to 20%

### DIFF
--- a/fees/solidly-v3.ts
+++ b/fees/solidly-v3.ts
@@ -42,7 +42,7 @@ const fetch = (chain: Chain) => {
       timestamp,
       dailyFees: dailyFee.toString(),
       dailyUserFees: dailyFee.toString(),
-      dailyRevenue: dailyFee.toString(),
+      dailyRevenue: dailyFee.times(0.2).toString(),
       dailyHoldersRevenue: dailyFee.times(0.2).toString(),
     };
   };


### PR DESCRIPTION
sorry, small oversight, revenue should be 20%, not 100%