### PR TITLE
add turbos volume

### DIFF
--- a/dexs/turbos/index.ts
+++ b/dexs/turbos/index.ts
@@ -2,6 +2,7 @@ import fetchURL from "../../utils/fetchURL"
 import { Chain } from "@defillama/sdk/build/general";
 import { SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
+import { getUniqStartOfTodayTimestamp } from "../../helpers/getUniSubgraphVolume";
 
 type IUrl = {
   [s: string]: string;
@@ -20,13 +21,14 @@ interface IVolume {
 
 const fetch = (chain: Chain) => {
   return async (timestamp: number) => {
+    const dayTimestamp = getUniqStartOfTodayTimestamp(new Date(timestamp * 1000))
     const volume: IVolume = (await fetchURL(url[chain]))?.data;
     return {
       totalVolume: `${volume?.totalVolume || undefined}`,
       dailyVolume: `${volume?.dailyVolume || undefined}`,
       weekVolume: `${volume?.weekVolume || undefined}`,
       monthVolume: `${volume?.monthVolume || undefined}`,
-      timestamp: Math.ceil(Date.now() / 1000),
+      timestamp: dayTimestamp,
     };
   };
 }

--- a/dexs/turbos/index.ts
+++ b/dexs/turbos/index.ts
@@ -8,7 +8,7 @@ type IUrl = {
 }
 
 const url: IUrl = {
-  [CHAIN.SUI]: "https://api.turbos.finance/info/vol"
+  [CHAIN.SUI]: "https://api.turbos.finance/dex/volume"
 }
 
 interface IVolume {

--- a/dexs/turbos/index.ts
+++ b/dexs/turbos/index.ts
@@ -1,0 +1,45 @@
+import fetchURL from "../../utils/fetchURL"
+import { Chain } from "@defillama/sdk/build/general";
+import { SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+
+type IUrl = {
+  [s: string]: string;
+}
+
+const url: IUrl = {
+  [CHAIN.SUI]: "https://api.turbos.finance/info/vol"
+}
+
+interface IVolume {
+  totalVolume: number,
+  dailyVolume: number,
+  weekVolume: number,
+  monthVolume: number,
+}
+
+const fetch = (chain: Chain) => {
+  return async (timestamp: number) => {
+    const volume: IVolume = (await fetchURL(url[chain]))?.data;
+    return {
+      totalVolume: `${volume?.totalVolume || undefined}`,
+      dailyVolume: `${volume?.dailyVolume || undefined}`,
+      weekVolume: `${volume?.weekVolume || undefined}`,
+      monthVolume: `${volume?.monthVolume || undefined}`,
+      timestamp: Math.ceil(Date.now() / 1000),
+    };
+  };
+}
+
+
+
+const adapter: SimpleAdapter = {
+  adapter: {
+    [CHAIN.SUI]: {
+      fetch: fetch(CHAIN.SUI),
+      start: async () => 1683158400,
+    }
+  },
+};
+
+export default adapter;


### PR DESCRIPTION
_______________________________________
Dexs for 15/10/2023
_______________________________________

SUI 👇
Backfill start time: 4/5/2023
NO METHODOLOGY SPECIFIED
Total volume: 48241135.03930907
Daily volume: 791019.1588018072
Week volume: 9645152.59951498
Month volume: 19777468.860982407
Timestamp: 1697328000