### PR TITLE
Remove fee data for VEAX and Concordex

### DIFF
--- a/dexs/concordex-io/index.ts
+++ b/dexs/concordex-io/index.ts
@@ -39,8 +39,6 @@ const adapter: SimpleAdapter = {
           timestamp: ts,
           dailyVolume: data.daily_volume,
           totalVolume: data.total_volume,
-          dailyFees: data.daily_fees,
-          totalFees: data.total_fees,
         }
       }
     }

--- a/dexs/veax/index.ts
+++ b/dexs/veax/index.ts
@@ -39,8 +39,6 @@ const adapter: SimpleAdapter = {
           timestamp: ts,
           dailyVolume: data.daily_volume,
           totalVolume: data.total_volume,
-          dailyFees: data.daily_fees,
-          totalFees: data.total_fees,
         }
       }
     }


### PR DESCRIPTION
Hi, our team wants to remove fee data because we are the only projects on chain who shows it