### PR TITLE
Aweaver89/paradex volumes stats

### DIFF
--- a/dexs/paradex/index.ts
+++ b/dexs/paradex/index.ts
@@ -35,7 +35,7 @@ const adapter: SimpleAdapter = {
   adapter: {
     [CHAIN.ETHEREUM]: {
       fetch,
-      start: async () => 1614211200,
+      start: async () => 1693612800,
     },
   },
 };

--- a/dexs/paradex/index.ts
+++ b/dexs/paradex/index.ts
@@ -1,0 +1,43 @@
+import fetchURL from "../../utils/fetchURL"
+import { FetchResultVolume, SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+
+const historicalVolumeEndpoint = (market: string, start: number, end: number) => `https://api.prod.paradex.trade/v1/markets/summary?market=${market}&start=${start}&end=${end}`
+const marketsEndpoint = "https://api.prod.paradex.trade/v1/markets"
+
+interface IVolumeall {
+  volume_24h: string;
+  total_volume: string;
+  last_traded_price: string;
+  open_interest: string;
+}
+
+
+const fetch = async (timestamp: number): Promise<FetchResultVolume> => {
+  const end = timestamp
+  //need to calculate start time of timestamp - 24h
+  const start = end - (60 * 60 * 24)
+  const markets: string[] = ((await fetchURL(marketsEndpoint))?.data.results).map((m: any) => m.symbol);
+  const historical: IVolumeall[] = (await Promise.all(markets.map((market: string) => fetchURL(historicalVolumeEndpoint(market, start*1000, end*1000))))).map((e: any) => e.data.results.slice(-1)).flat()
+
+  const dailyVol = historical.reduce((a: number, b: IVolumeall) => a+Number(b.volume_24h), 0)
+
+  const totalVol = historical.reduce((a: number, b: IVolumeall) => a+Number(b.total_volume), 0)
+
+    return { 
+        timestamp, 
+        dailyVolume: dailyVol? `${dailyVol}`: undefined, 
+        totalVolume: totalVol? `${totalVol}`: undefined
+    };
+};
+
+const adapter: SimpleAdapter = {
+  adapter: {
+    [CHAIN.ETHEREUM]: {
+      fetch,
+      start: async () => 1614211200,
+    },
+  },
+};
+
+export default adapter; 

--- a/dexs/paradex/index.ts
+++ b/dexs/paradex/index.ts
@@ -8,8 +8,6 @@ const marketsEndpoint = "https://api.prod.paradex.trade/v1/markets"
 interface IVolumeall {
   volume_24h: string;
   total_volume: string;
-  last_traded_price: string;
-  open_interest: string;
 }
 
 
@@ -35,7 +33,7 @@ const adapter: SimpleAdapter = {
   adapter: {
     [CHAIN.ETHEREUM]: {
       fetch,
-      start: async () => 1693612800,
+      start: async () => 1693526400,
     },
   },
 };


### PR DESCRIPTION
### Add Paradex Derivative Volumes

**Added functions to extract 24h volume and total volume for our three instruments:**

- ETH-USD-PERP
- BTC-USD-PERP
- SOL-USD-PERP

**Overall goal**

Show Paradex at /derivatives/paradex and be listed on the boards there.