### PR TITLE
feat: Kinetix volume and fee adapters

### DIFF
--- a/dexs/kinetix/index.ts
+++ b/dexs/kinetix/index.ts
@@ -1,0 +1,99 @@
+import request, { gql } from "graphql-request";
+import { Fetch, SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import { getUniqStartOfTodayTimestamp } from "../../helpers/getUniSubgraphVolume";
+
+const endpoints: { [key: string]: string } = {
+  [CHAIN.KAVA]:
+    "https://kava-graph-node.metavault.trade/subgraphs/name/kinetixfi/kfi-subgraph",
+};
+
+const historicalData = gql`
+  query get_volume($period: String!, $id: String!) {
+    volumeStats(where: { period: $period, id: $id }) {
+      swap
+    }
+  }
+`;
+
+interface IGraphResponse {
+  volumeStats: Array<{
+    burn: string;
+    liquidation: string;
+    margin: string;
+    mint: string;
+    swap: string;
+  }>;
+}
+
+const getFetch =
+  (chain: string): Fetch =>
+  async (timestamp: number) => {
+    const dayTimestamp = getUniqStartOfTodayTimestamp(
+      new Date(timestamp * 1000)
+    );
+    const dailyData: IGraphResponse = await request(
+      endpoints[chain],
+      historicalData,
+      {
+        id: String(dayTimestamp) + ":daily",
+        period: "daily",
+      }
+    );
+    const totalData: IGraphResponse = await request(
+      endpoints[chain],
+      historicalData,
+      {
+        id: "total",
+        period: "total",
+      }
+    );
+
+    return {
+      timestamp: dayTimestamp,
+      dailyVolume:
+        dailyData.volumeStats.length == 1
+          ? String(
+              Number(
+                Object.values(dailyData.volumeStats[0]).reduce((sum, element) =>
+                  String(Number(sum) + Number(element))
+                )
+              ) *
+                10 ** -30
+            )
+          : undefined,
+      totalVolume:
+        totalData.volumeStats.length == 1
+          ? String(
+              Number(
+                Object.values(totalData.volumeStats[0]).reduce((sum, element) =>
+                  String(Number(sum) + Number(element))
+                )
+              ) *
+                10 ** -30
+            )
+          : undefined,
+    };
+  };
+
+const getStartTimestamp = async (chain: string) => {
+  const startTimestamps: { [chain: string]: number } = {
+    [CHAIN.KAVA]: 1654041600,
+  };
+  return startTimestamps[chain];
+};
+
+const adapter: SimpleAdapter = {
+  adapter: Object.keys(endpoints).reduce((acc, chain) => {
+    return {
+      ...acc,
+      [chain]: {
+        fetch: getFetch(chain),
+        start: async () => getStartTimestamp(chain),
+        runAtCurrTime: true,
+      },
+    };
+  }, {}),
+};
+
+export default adapter;

--- a/fees/kinetix/index.ts
+++ b/fees/kinetix/index.ts
@@ -1,0 +1,59 @@
+import { Chain } from "@defillama/sdk/build/general";
+import { gql, request } from "graphql-request";
+import type { ChainEndpoints } from "../../adapters/types";
+import { Adapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import { getTimestampAtStartOfDayUTC } from "../../utils/date";
+
+const endpoints = {
+  [CHAIN.KAVA]:
+    "https://kava-graph-node.metavault.trade/subgraphs/name/kinetixfi/kfi-subgraph",
+};
+
+const graphs = (graphUrls: ChainEndpoints) => {
+  return (chain: Chain) => {
+    return async (timestamp: number) => {
+      const todaysTimestamp = getTimestampAtStartOfDayUTC(timestamp);
+      const searchTimestamp = todaysTimestamp + ":daily";
+
+      const graphQuery = gql`{
+        feeStat(id: "${searchTimestamp}") {
+          mint
+          burn
+          marginAndLiquidation
+          swap
+        }
+      }`;
+
+      const graphRes = await request(graphUrls[chain], graphQuery);
+
+      const dailyFee =
+        parseInt(graphRes.feeStat.mint) +
+        parseInt(graphRes.feeStat.burn) +
+        parseInt(graphRes.feeStat.marginAndLiquidation) +
+        parseInt(graphRes.feeStat.swap);
+      const finalDailyFee = dailyFee / 1e30;
+
+      return {
+        timestamp,
+        dailyFees: finalDailyFee.toString(),
+        dailyRevenue: (finalDailyFee * 0.3).toString(),
+      };
+    };
+  };
+};
+
+const adapter: Adapter = {
+  adapter: {
+    [CHAIN.KAVA]: {
+      fetch: graphs(endpoints)(CHAIN.KAVA),
+      start: async () => 5995754,
+      meta: {
+        methodology:
+          "All mint, burn, marginAndLiquidation and swap fees are collected and the daily fee amount is determined. Daily revenue is calculated as 30% of the total fee.",
+      },
+    },
+  },
+};
+
+export default adapter;


### PR DESCRIPTION
Fee adapter test results: 

🦙 Running KINETIX adapter 🦙
_______________________________________
Fees for 31/10/2023
_______________________________________

KAVA 👇
Backfill start time: 11/3/1970
Methodology: All mint, burn, marginAndLiquidation and swap fees are collected and the daily fee amount is determined. Daily revenue is calculated as 30% of the total fee.
Timestamp: 1698796798
Daily fees: 707.7126833950095
Daily revenue: 212.31380501850285


Dexs adapter test result:

🦙 Running KINETIX adapter 🦙
_______________________________________
Dexs for 31/10/2023
_______________________________________

KAVA 👇
Backfill start time: 1/6/2022
NO METHODOLOGY SPECIFIED
Timestamp: 1698710400
Daily volume: 116872.8985417094
Total volume: 3920789.8765547737
