### PR TITLE
using getChainVolumeWithGasToken for Fantom DEX volumes

### DIFF
--- a/dexs/knightswap-finance/index.ts
+++ b/dexs/knightswap-finance/index.ts
@@ -1,7 +1,7 @@
 import { SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 const {
-  getChainVolume,
+  getChainVolume,getChainVolumeWithGasToken
 } = require("../../helpers/getUniSubgraphVolume");
 const { getStartTimestamp } = require("../../helpers/getStartTimestamp");
 
@@ -22,7 +22,7 @@ const v1Graph = getChainVolume({
   },
 });
 
-const v2Graph = getChainVolume({
+const v2Graph = getChainVolumeWithGasToken({
   graphUrls: endpoints,
   totalVolume: {
     factory: "pancakeFactories",

--- a/dexs/morpheus-swap/index.ts
+++ b/dexs/morpheus-swap/index.ts
@@ -6,6 +6,7 @@ const adapters = univ2Adapter({
 }, {
   factoriesName: "pancakeFactories",
   dayData: "pancakeDayData",
+  gasToken: "coingecko:fantom"
 });
 
 adapters.adapter.fantom.start = async () => 1636106400;

--- a/dexs/protofi/index.ts
+++ b/dexs/protofi/index.ts
@@ -6,4 +6,5 @@ export default univ2Adapter({
 }, {
   factoriesName: "pancakeFactories",
   dayData: "pancakeDayData",
+  gasToken : "coingecko:fantom"
 });

--- a/dexs/soulswap/index.ts
+++ b/dexs/soulswap/index.ts
@@ -1,19 +1,19 @@
-import { getChainVolume } from "../../helpers/getUniSubgraphVolume";
+import { getChainVolumeWithGasToken } from "../../helpers/getUniSubgraphVolume";
 import { getStartTimestamp } from "../../helpers/getStartTimestamp";
-import { FANTOM } from "../../helpers/chains";
+import { /*AVAX,*/ FANTOM } from "../../helpers/chains";
 import { SimpleAdapter } from "../../adapters/types";
 import { Chain } from "@defillama/sdk/build/general";
 
 const endpoints = {
-// [AVAX]: "https://api.thegraph.com/subgraphs/name/soulswapfinance/avalanche-exchange
+  //[AVAX]: "https://api.thegraph.com/subgraphs/name/soulswapfinance/avalanche-exchange",
   [FANTOM]: "https://api.thegraph.com/subgraphs/name/soulswapfinance/fantom-exchange",
 };
 
 const VOLUME_FIELD = "volumeUSD";
 
-const graphs = getChainVolume({
+const graphs = getChainVolumeWithGasToken({
   graphUrls: {
-    // [AVAX]: endpoints[AVAX],
+    //[AVAX]: endpoints[AVAX],
     [FANTOM]: endpoints[FANTOM]
   },
   totalVolume: {
@@ -24,6 +24,7 @@ const graphs = getChainVolume({
     factory: "dayData",
     field: VOLUME_FIELD,
   },
+  priceToken: "coingecko:fantom"
 });
 
 const startTimeQuery = {

--- a/dexs/spartacus-exchange/index.ts
+++ b/dexs/spartacus-exchange/index.ts
@@ -4,7 +4,7 @@ import { univ2Adapter } from "../../helpers/getUniSubgraphVolume";
 const endpoints = {
   [CHAIN.FANTOM]: "https://api.thegraph.com/subgraphs/name/spartacus-finance/spadexinfo",
 };
-const adapter = univ2Adapter(endpoints, {});
+const adapter = univ2Adapter(endpoints, {"gasToken" : "coingecko:fantom"});
 adapter.adapter.fantom.start = async () => 1650883041;
 
 export default adapter

--- a/dexs/wingswap/index.ts
+++ b/dexs/wingswap/index.ts
@@ -8,6 +8,7 @@ const endpoints = {
 const adapter = univ2Adapter(endpoints, {
   factoriesName: "wingSwapFactories",
   dayData: "wingSwapDayData",
+  gasToken: "coingecko:fantom"
 });
 
 adapter.adapter.fantom.start = async () => 1637452800;

--- a/dexs/yoshi-exchange/index.ts
+++ b/dexs/yoshi-exchange/index.ts
@@ -11,5 +11,6 @@ export default univ2Adapter(endpoints, {
     factoriesName: "factories",
     dayData: "dayData",
     dailyVolume: "volumeUSD",
-    totalVolume: "volumeUSD"
+    totalVolume: "volumeUSD",
+    gasToken: "coingecko:fantom"
 });


### PR DESCRIPTION
Partial Fix for Multichain/Anyswap affected DEXes on fantom
- Issue: https://github.com/DefiLlama/dimension-adapters/issues/664
- Referenced Implementation: https://github.com/DefiLlama/dimension-adapters/commit/5f27d694d18c6153cca66fdc3b33244cff10adf1

Sanitized Volume Data for:
- [x] SoulSwap
- [x] Solidly
- [x] Yoshi Exchange
- [x] ProtoFi
- [x] KnightSwap
- [x] Morpheus Swap
- [x] WingSwap
- [x] Spartacus Exchange

DEX that still have old/wrong numbers:
- [ ] Elk
