### PR TITLE
Add kinetix-v3 volume adapter. Change kinetix to kinetix-derivative adapter.

### DIFF
--- a/dexs/kinetix-derivative/index.ts
+++ b/dexs/kinetix-derivative/index.ts
@@ -4,7 +4,8 @@ import { CHAIN } from "../../helpers/chains";
 import { getUniqStartOfTodayTimestamp } from "../../helpers/getUniSubgraphVolume";
 
 const endpoints: { [key: string]: string } = {
-  [CHAIN.KAVA]: "https://kava-graph-node.metavault.trade/subgraphs/name/kinetixfi/kfi-subgraph",
+  [CHAIN.KAVA]:
+    "https://kava-graph-node.metavault.trade/subgraphs/name/kinetixfi/kfi-subgraph",
 };
 
 const historicalData = gql`

--- a/dexs/kinetix-v3/index.ts
+++ b/dexs/kinetix-v3/index.ts
@@ -1,0 +1,63 @@
+import { Chain } from "@defillama/sdk/build/general";
+import { CHAIN } from "../../helpers/chains";
+import { getGraphDimensions } from "../../helpers/getUniSubgraph";
+import { BreakdownAdapter } from "../../adapters/types";
+
+const endpointsV3 = {
+  [CHAIN.KAVA]:
+    "https://kava-graph-node.metavault.trade/subgraphs/name/kinetixfi/v3-subgraph",
+};
+
+const v3Graphs = getGraphDimensions({
+  graphUrls: endpointsV3,
+  totalVolume: {
+    factory: "factories",
+    field: "totalVolumeUSD",
+  },
+  dailyVolume: {
+    factory: "uniswapDayData",
+    field: "volumeUSD",
+  },
+  feesPercent: {
+    type: "fees",
+    ProtocolRevenue: 0,
+    HoldersRevenue: 0,
+    UserFees: 100, // User fees are 100% of collected fees
+    SupplySideRevenue: 100, // 100% of fees are going to LPs
+    Revenue: 0, // Set revenue to 0 as protocol fee is not set for all pools for now
+  },
+});
+
+const startTimeV3: { [key: string]: number } = {
+  [CHAIN.KAVA]: 1693267200,
+};
+
+const v3 = Object.keys(endpointsV3).reduce(
+  (acc, chain) => ({
+    ...acc,
+    [chain]: {
+      fetch: v3Graphs(chain as Chain),
+      start: async () => startTimeV3[chain],
+      meta: {
+        methodology: {
+          Fees: "Each pool charge between 0.01% to 1% fee",
+          UserFees: "Users pay between 0.01% to 1% fee",
+          Revenue: "0 to 1/4 of the fee goes to treasury",
+          HoldersRevenue: "None",
+          ProtocolRevenue: "Treasury receives a share of the fees",
+          SupplySideRevenue:
+            "Liquidity providers get most of the fees of all trades in their pools",
+        },
+      },
+    },
+  }),
+  {}
+);
+
+const adapter: BreakdownAdapter = {
+  breakdown: {
+    v3: v3,
+  },
+};
+
+export default adapter;


### PR DESCRIPTION
🦙 Running KINETIX-V3 adapter 🦙
_______________________________________
Dexs for 1/11/2023
_______________________________________

Version -> V3
---------
KAVA 👇
Backfill start time: 29/8/2023
Timestamp: 1698883199
Block: 7148453
Total volume: 4586043.672550229
Daily volume: 547615.5148818739767866812788706884
Daily fees: 118.6874611718792162576062907982687
└─ Methodology: Each pool charge between 0.01% to 1% fee
Total fees: 1131.9327176577897
└─ Methodology: Each pool charge between 0.01% to 1% fee
Daily protocol revenue: 0
└─ Methodology: Treasury receives a share of the fees
Total protocol revenue: 0
└─ Methodology: Treasury receives a share of the fees
Daily holders revenue: 0
└─ Methodology: None
Total holders revenue: 0
└─ Methodology: None
Daily user fees: 118.6874611718792162576062907982687
└─ Methodology: Users pay between 0.01% to 1% fee
Total user fees: 1131.9327176577897
└─ Methodology: Users pay between 0.01% to 1% fee
Daily supply side revenue: 118.6874611718792162576062907982687
└─ Methodology: Liquidity providers get most of the fees of all trades in their pools
Total supply side revenue: 1131.9327176577897
└─ Methodology: Liquidity providers get most of the fees of all trades in their pools
Daily revenue: 0
└─ Methodology: 0 to 1/4 of the fee goes to treasury
Total revenue: 0
└─ Methodology: 0 to 1/4 of the fee goes to treasury