### PR TITLE
Add HOPR fees and revenue adapter

### DIFF
--- a/fees/hopr/index.ts
+++ b/fees/hopr/index.ts
@@ -1,0 +1,79 @@
+import { Adapter, FetchResultFees } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import * as sdk from "@defillama/sdk";
+import { getBlock } from "../../helpers/getBlock";
+
+const channels_address = '0x693Bac5ce61c720dDC68533991Ceb41199D8F8ae';
+const wxHOPR_address = '0xd4fdec44db9d44b8f2b6d529620f9c0c7066a2c1';
+const topic0 = '0x7165e2ebc7ce35cc98cb7666f9945b3617f3f36326b76d18937ba5fecf18739a'; //TicketRedeemed
+const topic1 = '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef'; //Sent 
+
+const methodology = {
+  Fees: "Protocol has no fees",
+  Revenue: "Sum of number of all tickets times ticket price in wxHOPR",
+}
+
+interface ITx {
+  data: string;
+  transactionHash: string;
+}
+
+const fetch = async (timestamp: number): Promise<FetchResultFees> => {
+  const fromTimestamp = timestamp - 60 * 60 * 24
+  const toTimestamp = timestamp
+  const fromBlock = (await getBlock(fromTimestamp, CHAIN.XDAI, {}));
+  const toBlock = (await getBlock(toTimestamp, CHAIN.XDAI, {}));
+
+  const ticketRedeemedLogs: ITx[] = (await sdk.api.util.getLogs({
+    target: channels_address,
+    topic: topic0,
+    fromBlock: fromBlock,
+    toBlock: toBlock,
+    topics: [topic0],
+    keys: [],
+    chain: CHAIN.XDAI
+  })).output as ITx[];
+
+  const erc20transferLog: ITx[] = (await sdk.api.util.getLogs({
+    target: wxHOPR_address,
+    topic: topic1,
+    fromBlock: fromBlock,
+    toBlock: toBlock,
+    topics: [topic1],
+    keys: [],
+    chain: CHAIN.XDAI
+  })).output as ITx[];
+
+  const dailyRevenueArray = ticketRedeemedLogs.map(ticket => {
+    const transactionHash = ticket.transactionHash;
+    const index = erc20transferLog.findIndex(transaction => transaction.transactionHash === transactionHash);
+    if(index !== -1) {
+      return erc20transferLog[index].data;
+    }
+  }).filter(elem => elem !== undefined) as string[];
+
+  const dailyRevenue = dailyRevenueArray.map((data: string) => {
+    const amount = Number(data) / 10 ** 6;
+    return amount;
+  }).reduce((a: number, b: number) => a+b,0);
+
+  return {
+    timestamp: timestamp,
+    dailyFees: `0`,
+    dailyRevenue: `${dailyRevenue}`
+  };
+}
+
+const adapter: Adapter = {
+  adapter: {
+    [CHAIN.XDAI]: {
+      fetch: fetch,
+      start: async () => 1693440000,
+      meta: {
+        methodology
+      }
+    },
+  }
+}
+
+export default adapter;

--- a/fees/hopr/index.ts
+++ b/fees/hopr/index.ts
@@ -3,7 +3,6 @@ import { CHAIN } from "../../helpers/chains";
 import * as sdk from "@defillama/sdk";
 import { getBlock } from "../../helpers/getBlock";
 import { getPrices } from "../../utils/prices";
-import BigNumber from "bignumber.js";
 
 const channels_address = '0x693Bac5ce61c720dDC68533991Ceb41199D8F8ae';
 const wxHOPR_address = '0xd4fdec44db9d44b8f2b6d529620f9c0c7066a2c1';
@@ -14,7 +13,7 @@ const topic1 = '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3
 
 const methodology = {
   Fees: "Protocol has no supply-side fees, only user fees which are Sum of all ticket values redeemed in wxHOPR",
-  Revenue: "Sum of number of all tickets times ticket price in wxHOPR",
+  Revenue: "Sum of number of all tickets redeemed multiplied by ticket price in wxHOPR",
 }
 
 interface ITx {
@@ -67,7 +66,7 @@ const fetch = async (timestamp: number): Promise<FetchResultFees> => {
 
   return {
     timestamp: timestamp,
-    dailyFees: `0`,
+    dailyFees: `${dailyRevenueUSD}`,
     dailyUserFees: `${dailyRevenueUSD}`,
     dailyRevenue: `${dailyRevenueUSD}`
   };

--- a/fees/hopr/index.ts
+++ b/fees/hopr/index.ts
@@ -10,7 +10,7 @@ const wxHOPR_address = '0xd4fdec44db9d44b8f2b6d529620f9c0c7066a2c1';
 const xHOPR_address = '0xd057604a14982fe8d88c5fc25aac3267ea142a08';
 const chain = 'xdai';
 const topic0 = '0x7165e2ebc7ce35cc98cb7666f9945b3617f3f36326b76d18937ba5fecf18739a'; //TicketRedeemed
-const topic1 = '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef'; //Sent 
+const topic1 = '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef'; //Transfer 
 
 const methodology = {
   Fees: "Protocol has no supply-side fees, only user fees which are Sum of all ticket values redeemed in wxHOPR",

--- a/fees/hopr/index.ts
+++ b/fees/hopr/index.ts
@@ -22,11 +22,6 @@ interface ITx {
   transactionHash: string;
 }
 
-const toString = (x: BigNumber) => {
-  if (x.isEqualTo(0)) return undefined
-  return x.toString()
-}
-
 const fetch = async (timestamp: number): Promise<FetchResultFees> => {
   const fromTimestamp = timestamp - 60 * 60 * 24
   const toTimestamp = timestamp
@@ -73,6 +68,7 @@ const fetch = async (timestamp: number): Promise<FetchResultFees> => {
   return {
     timestamp: timestamp,
     dailyFees: `0`,
+    dailyUserFees: `0`,
     dailyRevenue: `${dailyRevenueUSD}`
   };
 }

--- a/fees/hopr/index.ts
+++ b/fees/hopr/index.ts
@@ -2,9 +2,13 @@ import { Adapter, FetchResultFees } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 import * as sdk from "@defillama/sdk";
 import { getBlock } from "../../helpers/getBlock";
+import { getPrices } from "../../utils/prices";
+import BigNumber from "bignumber.js";
 
 const channels_address = '0x693Bac5ce61c720dDC68533991Ceb41199D8F8ae';
 const wxHOPR_address = '0xd4fdec44db9d44b8f2b6d529620f9c0c7066a2c1';
+const xHOPR_address = '0xd057604a14982fe8d88c5fc25aac3267ea142a08';
+const chain = 'xdai';
 const topic0 = '0x7165e2ebc7ce35cc98cb7666f9945b3617f3f36326b76d18937ba5fecf18739a'; //TicketRedeemed
 const topic1 = '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef'; //Sent 
 
@@ -16,6 +20,11 @@ const methodology = {
 interface ITx {
   data: string;
   transactionHash: string;
+}
+
+const toString = (x: BigNumber) => {
+  if (x.isEqualTo(0)) return undefined
+  return x.toString()
 }
 
 const fetch = async (timestamp: number): Promise<FetchResultFees> => {
@@ -53,14 +62,18 @@ const fetch = async (timestamp: number): Promise<FetchResultFees> => {
   }).filter(elem => elem !== undefined) as string[];
 
   const dailyRevenue = dailyRevenueArray.map((data: string) => {
-    const amount = Number(data) / 10 ** 6;
+    const amount = Number(data) / 10 ** 18;
     return amount;
   }).reduce((a: number, b: number) => a+b,0);
+
+  const prices: any = (await getPrices([`${chain}:${xHOPR_address}`], toTimestamp));
+  const price = prices[`${chain}:${xHOPR_address}`]?.price || 0;
+  const dailyRevenueUSD = dailyRevenue * price;
 
   return {
     timestamp: timestamp,
     dailyFees: `0`,
-    dailyRevenue: `${dailyRevenue}`
+    dailyRevenue: `${dailyRevenueUSD}`
   };
 }
 

--- a/fees/hopr/index.ts
+++ b/fees/hopr/index.ts
@@ -13,7 +13,7 @@ const topic0 = '0x7165e2ebc7ce35cc98cb7666f9945b3617f3f36326b76d18937ba5fecf1873
 const topic1 = '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef'; //Sent 
 
 const methodology = {
-  Fees: "Protocol has no fees",
+  Fees: "Protocol has no supply-side fees, only user fees which are Sum of all ticket values redeemed in wxHOPR",
   Revenue: "Sum of number of all tickets times ticket price in wxHOPR",
 }
 
@@ -68,7 +68,7 @@ const fetch = async (timestamp: number): Promise<FetchResultFees> => {
   return {
     timestamp: timestamp,
     dailyFees: `0`,
-    dailyUserFees: `0`,
+    dailyUserFees: `${dailyRevenueUSD}`,
     dailyRevenue: `${dailyRevenueUSD}`
   };
 }


### PR DESCRIPTION
Add HOPR fees and revenue adapter

Methodology:
 -  Fees: Protocol has no supply-side fees, only user fees which are Sum of all ticket values redeemed in wxHOPR,
 -  Revenue: Sum of number of all tickets times ticket price in wxHOPR
 
 ```
Fees for 9/11/2023
_______________________________________

XDAI 👇
Timestamp: 1699574398
Daily fees: 0
Daily user fees: 11.671461664000123 USD
Daily revenue: 11.671461664000123 USD
```