### PR TITLE
[iziswap]Update adapter to get complete data

### DIFF
--- a/dexs/iziswap/index.ts
+++ b/dexs/iziswap/index.ts
@@ -6,7 +6,7 @@ import customBackfill from "../../helpers/customBackfill";
 import { getUniqStartOfTodayTimestamp } from "../../helpers/getUniSubgraphVolume";
 
 
-const historicalVolumeEndpoint = (chain_id: number) => `https://api.izumi.finance/api/v1/izi_swap/summary_record/?chain_id=${chain_id}&type=4&page_size=100000`
+const historicalVolumeEndpoint = (chain_id: number, page: number) => `https://api.izumi.finance/api/v1/izi_swap/summary_record/?chain_id=${chain_id}&type=4&page_size=100000&page=${page}`
 
 interface IVolumeall {
   volDay: number;
@@ -16,16 +16,40 @@ interface IVolumeall {
 type TChains = {
   [k: Chain | string]: number;
 };
+type TAdapter = {
+  [key:string]: any;
+};
 
 const chains: TChains =  {
   [CHAIN.BSC]: 56,
   [CHAIN.ERA]: 324,
+  [CHAIN.ARBITRUM]: 42161,
+  [CHAIN.METER]: 82,
+  [CHAIN.AURORA]: 1313161554,
+  [CHAIN.POLYGON]: 137,
+  [CHAIN.MANTLE]: 5000,
+  [CHAIN.ONTOLOGY_EVM]: 58,
+  [CHAIN.ULTRON]: 1231,
+  [CHAIN.LINEA]: 59144,
+  [CHAIN.SCROLL]: 534352,
+  [CHAIN.BASE]: 8453
 };
 
 const fetch = (chain: Chain) => {
   return async (timestamp: number) => {
-    const dayTimestamp = getUniqStartOfTodayTimestamp(new Date(timestamp * 1000))
-    const historical: IVolumeall[] = (await fetchURL(historicalVolumeEndpoint(chains[chain])))?.data.data;
+    const dayTimestamp = getUniqStartOfTodayTimestamp(new Date(timestamp * 1000));
+    let isSuccess = true;
+    let page = 1;
+    const historical: IVolumeall[] = [];
+    while (isSuccess) {
+      const response = (await fetchURL(historicalVolumeEndpoint(chains[chain], page)));
+      if (response.data.is_success){
+        Array.prototype.push.apply(historical, response.data.data);
+        page += 1;
+      } else {
+        isSuccess = false;
+      };
+    };
     const historicalVolume = historical.filter(e => e.chainId === chains[chain]);
     const totalVolume = historicalVolume
       .filter(volItem => (new Date(volItem.timestamp).getTime()) <= dayTimestamp)
@@ -42,20 +66,23 @@ const fetch = (chain: Chain) => {
   }
 };
 
+const adapters: TAdapter = {};
+for (const chain in chains) {
+  let startTime = 1689523200;
+  if (chain == CHAIN.BSC || chain == CHAIN.ERA){
+    startTime = 1680739200;
+  };
+  if (chains.hasOwnProperty(chain)) {
+    adapters[chain] = {
+      fetch: fetch(chain),
+      start: async () => startTime,
+      customBackfill: customBackfill(chain, fetch)
+    };
+  };
+};
 
 const adapter: SimpleAdapter = {
-  adapter: {
-    [CHAIN.BSC]: {
-      fetch: fetch(CHAIN.BSC),
-      start: async  () => 1680739200,
-      customBackfill: customBackfill(CHAIN.BSC as Chain, fetch)
-    },
-    [CHAIN.ERA]: {
-      fetch: fetch(CHAIN.ERA),
-      start: async  () => 1680739200,
-      customBackfill: customBackfill(CHAIN.ERA as Chain, fetch)
-    },
-  },
+  adapter: adapters
 };
 
 export default adapter;


### PR DESCRIPTION
Since our API limits the page size to 100, the adapter needs to make multiple calls to get the complete data. And more chains have been added to the adapter.