### PR TITLE
[feat] add fees dln adapter

### DIFF
--- a/fees/dln/index.ts
+++ b/fees/dln/index.ts
@@ -1,0 +1,85 @@
+import { Adapter, FetchResultFees } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import fetchURL from "../../utils/fetchURL";
+import { getTimestampAtStartOfDayUTC } from "../../utils/date";
+
+const fetch = (chainId: number) => {
+  return async (timestamp: number): Promise<FetchResultFees> => {
+    const todaysTimestamp = getTimestampAtStartOfDayUTC(timestamp);
+    const dateFrom = formatTimestampAsDate(todaysTimestamp);
+    const dateTo = dateFrom;
+    const url = `https://stats-api.dln.trade/api/Satistics/getDaily?dateFrom=${dateFrom}&dateTo=${dateTo}`;
+    const response = await fetchURL(url);
+    const dailyDatas = response.data.dailyData;
+    let fees = 0;
+    for (const dailyData of dailyDatas) {
+      if (dailyData.giveChainId.bigIntegerValue === chainId) {
+        fees += Number(dailyData.totalProtocolFeeUsd);
+      }
+    }
+
+    return {
+      dailyFees: String(fees),
+      dailyRevenue: String(fees),
+      timestamp,
+    } as FetchResultFees;
+  };
+};
+
+function pad(s: number) {
+  return s < 10 ? "0" + s : s;
+}
+
+function formatTimestampAsDate(timestamp: number) {
+  const date = new Date(timestamp * 1000);
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(
+    date.getDate()
+  )}`;
+}
+
+const adapter: Adapter = {
+  adapter: {
+    [CHAIN.ETHEREUM]: {
+      fetch: fetch(1),
+      start: async () => 1680278400,
+    },
+    [CHAIN.ARBITRUM]: {
+      fetch: fetch(42161),
+      start: async () => 1680278400,
+    },
+    [CHAIN.AVAX]: {
+      fetch: fetch(43114),
+      start: async () => 1680278400,
+    },
+    [CHAIN.BSC]: {
+      fetch: fetch(56),
+      start: async () => 1680278400,
+    },
+    [CHAIN.POLYGON]: {
+      fetch: fetch(137),
+      start: async () => 1680278400,
+    },
+    [CHAIN.SOLANA]: {
+      fetch: fetch(7565164),
+      start: async () => 1680278400,
+    },
+    [CHAIN.LINEA]: {
+      fetch: fetch(59144),
+      start: async () => 1680278400,
+    },
+    [CHAIN.BASE]: {
+      fetch: fetch(8453),
+      start: async () => 1680278400,
+    },
+    [CHAIN.OPTIMISM]: {
+      fetch: fetch(10),
+      start: async () => 1680278400,
+    },
+    [CHAIN.FANTOM]: {
+      fetch: fetch(250),
+      start: async () => 1680278400,
+    },
+  },
+};
+
+export default adapter;


### PR DESCRIPTION
the fees dln adapter exports:
```
✨  Done in 0.08s.
🦙 Running DLN adapter 🦙
_______________________________________
Fees for 20/11/2023
_______________________________________

ETHEREUM 👇
Backfill start time: 31/3/2023
NO METHODOLOGY SPECIFIED
Daily fees: 814.4309918973806
Daily revenue: 814.4309918973806
Timestamp: 1700524798


ARBITRUM 👇
Backfill start time: 31/3/2023
NO METHODOLOGY SPECIFIED
Daily fees: 380.4634202416002
Daily revenue: 380.4634202416002
Timestamp: 1700524798


AVAX 👇
Backfill start time: 31/3/2023
NO METHODOLOGY SPECIFIED
Daily fees: 53.354328
Daily revenue: 53.354328
Timestamp: 1700524798


BSC 👇
Backfill start time: 31/3/2023
NO METHODOLOGY SPECIFIED
Daily fees: 214.68950657087115
Daily revenue: 214.68950657087115
Timestamp: 1700524798


POLYGON 👇
Backfill start time: 31/3/2023
NO METHODOLOGY SPECIFIED
Daily fees: 52.89072207541137
Daily revenue: 52.89072207541137
Timestamp: 1700524798


SOLANA 👇
Backfill start time: 31/3/2023
NO METHODOLOGY SPECIFIED
Daily fees: 211.36703200000002
Daily revenue: 211.36703200000002
Timestamp: 1700524798


LINEA 👇
Backfill start time: 31/3/2023
NO METHODOLOGY SPECIFIED
Daily fees: 111.18279659111765
Daily revenue: 111.18279659111765
Timestamp: 1700524798


BASE 👇
Backfill start time: 31/3/2023
NO METHODOLOGY SPECIFIED
Daily fees: 189.07598012903247
Daily revenue: 189.07598012903247
Timestamp: 1700524798


OPTIMISM 👇
Backfill start time: 31/3/2023
NO METHODOLOGY SPECIFIED
Daily fees: 346.7659771670054
Daily revenue: 346.7659771670054
Timestamp: 1700524798


FANTOM 👇
Backfill start time: 31/3/2023
NO METHODOLOGY SPECIFIED
Daily fees: 0
Daily revenue: 0
Timestamp: 1700524798
```