### PR TITLE
Add daily volume and fees for StormTrade

### DIFF
--- a/dexs/stormtrade/index.ts
+++ b/dexs/stormtrade/index.ts
@@ -1,0 +1,30 @@
+import { CHAIN } from '../../helpers/chains'
+import fetchURL from '../../utils/fetchURL'
+
+
+export default {
+    adapter: {
+        [CHAIN.TON]: {
+            runAtCurrTime: true,
+            start: async () => 1700000000,
+            meta: {
+                methodology: {
+                    DailyVolume: 'Leverage trading volume',
+                    DataSource: 'Data collected by the re:doubt team, available at https://beta.redoubt.online/tracker'
+                },
+            },
+            fetch: async () => {
+                const response = await fetchURL('https://api.redoubt.online/dapps/v1/export/defi/storm')
+
+                if (!response.data) {
+                    throw new Error('Error during re:doubt API call')
+                }
+
+                return {
+                    dailyVolume: { 'tether': response.data.volume },
+                    timestamp: response.data.timestamp
+                }
+            },
+        },
+    },
+}

--- a/dexs/stormtrade/index.ts
+++ b/dexs/stormtrade/index.ts
@@ -21,7 +21,7 @@ export default {
                 }
 
                 return {
-                    dailyVolume: { 'tether': response.data.volume },
+                    dailyVolume: response.data.volume.toString(),
                     timestamp: response.data.timestamp
                 }
             },

--- a/fees/stormtrade/index.ts
+++ b/fees/stormtrade/index.ts
@@ -21,7 +21,8 @@ export default {
                 }
 
                 return {
-                    dailyUserFees: { 'tether': response.data.fees },
+                    dailyUserFees: response.data.fees.toString(),
+                    dailyFees: response.data.fees.toString(),
                     timestamp: response.data.timestamp
                 }
             },

--- a/fees/stormtrade/index.ts
+++ b/fees/stormtrade/index.ts
@@ -1,0 +1,30 @@
+import { CHAIN } from '../../helpers/chains'
+import fetchURL from '../../utils/fetchURL'
+
+
+export default {
+    adapter: {
+        [CHAIN.TON]: {
+            runAtCurrTime: true,
+            start: async () => 1700000000,
+            meta: {
+                methodology: {
+                    Fees: 'Traders pay opening and closing fees',
+                    DataSource: 'Data collected by the re:doubt team, available at https://beta.redoubt.online/tracker'
+                },
+            },
+            fetch: async () => {
+                const response = await fetchURL('https://api.redoubt.online/dapps/v1/export/defi/storm')
+
+                if (!response.data) {
+                    throw new Error('Error during re:doubt API call')
+                }
+
+                return {
+                    dailyUserFees: { 'tether': response.data.fees },
+                    timestamp: response.data.timestamp
+                }
+            },
+        },
+    },
+}


### PR DESCRIPTION
Here is volume and fees data for the [StormTrade](https://defillama.com/protocol/storm-trade) project on TON blockchain. Data collected using [re:doubt](https://beta.redoubt.online/) analytical platform, references:
* [Smart-contracts specification](https://github.com/Tsunami-Exchange/storm-contracts-specs/tree/main)
* [Data parsers](https://github.com/re-doubt/ton-indexer/pull/28/files)
* [Live dashboard](https://tonalytica.redoubt.online/public/dashboards/yLrq2MRoaaPfhoaI9eJngVGcc9HBPiOcSBqSrE7H?org_slug=default) with the current metrics