### PR TITLE
synfuturesv2 volume: fix incorrect start time

### DIFF
--- a/dexs/synfutures-v2/index.ts
+++ b/dexs/synfutures-v2/index.ts
@@ -105,6 +105,13 @@ const fetchVolume = (chain: Chain) => {
     const coins = [...new Set(volumeRaw.map(e => `${chain}:${e.quoteAddr.toLowerCase()}`))];
     const prices = await getPrices(coins, fromTimestamp);
 
+    // check prices
+    coins.forEach(coin => {
+      if (!prices[coin]) {
+        throw new Error(`No price found for ${coin}`);
+      }
+    });
+
     const volume = volumeRaw.map((e: IVolume) => e.amount_quote * prices[`${chain}:${e.quoteAddr.toLowerCase()}`]?.price || 0);
     const dailyVolume = volume.reduce((acc: number, cur: number) => acc + cur, 0);
     return {


### PR DESCRIPTION
The existing code is presently computing yesterday's volume instead of today's. Now, the volume is correctly synchronized with our dune dashboard.

Below is the testing result:

🦙 Running SYNFUTURES-V2 adapter 🦙
_______________________________________
Dexs for 11/12/2023
_______________________________________

POLYGON 👇
Backfill start time: 8/9/2022
NO METHODOLOGY SPECIFIED
Daily volume: 26369263.733572043
Timestamp: 1702339198