### PR TITLE
add butterxyz

### DIFF
--- a/dexs/butterxyz/index.ts
+++ b/dexs/butterxyz/index.ts
@@ -1,0 +1,39 @@
+import { SimpleAdapter } from '../../adapters/types';
+import { CHAIN } from '../../helpers/chains';
+import { getGraphDimensions } from '../../helpers/getUniSubgraph';
+
+const dimensions = getGraphDimensions({
+  graphUrls: {
+    [CHAIN.MANTLE]: 'https://graph.butter.xyz/subgraphs/name/butterxyz/v3-subgraph',
+  },
+  totalVolume: {
+    factory: 'factories',
+    field: 'totalVolumeUSD',
+  },
+  dailyVolume: {
+    factory: 'butterDayData',
+    field: 'volumeUSD',
+  },
+  dailyFees: {
+    factory: 'butterDayData',
+    field: 'feesUSD',
+  },
+  feesPercent: {
+    type: 'fees',
+    ProtocolRevenue: 0,
+    HoldersRevenue: 0,
+    Fees: 0,
+    UserFees: 100,
+    SupplySideRevenue: 100,
+    Revenue: 0,
+  },
+});
+
+export default {
+  adapter: {
+    [CHAIN.MANTLE]: {
+      fetch: dimensions(CHAIN.MANTLE),
+      start: async () => 1702339200,
+    }
+  }
+} as SimpleAdapter;


### PR DESCRIPTION
Add butter.xyz to dexs.

Related PR for TVL: https://github.com/DefiLlama/DefiLlama-Adapters/pull/8391

`yarn test dexs butterxyz` outputs

```
🦙 Running BUTTERXYZ adapter 🦙
_______________________________________
Dexs for 13/12/2023
_______________________________________

MANTLE 👇
Backfill start time: 12/12/2023
NO METHODOLOGY SPECIFIED
Timestamp: 1702511998
Block: 26757212
Total volume: 935443.521523389
Daily volume: 934445.1947378222935103256110608372
Daily fees: 302.5708465040239084020706899408265
Total fees: 746.196627696544
Daily protocol revenue: 0
Total protocol revenue: 0
Daily holders revenue: 0
Total holders revenue: 0
Daily user fees: 302.5708465040239084020706899408265
Total user fees: 746.196627696544
Daily supply side revenue: 302.5708465040239084020706899408265
Total supply side revenue: 746.196627696544
Daily revenue: 0
Total revenue: 0
```