### PR TITLE
Adding feature for Fees visibility for Bluefin Exchange

### DIFF
--- a/fees/bluefin.ts
+++ b/fees/bluefin.ts
@@ -1,0 +1,48 @@
+import fetchURL from "../utils/fetchURL"
+import { FetchResultFees, SimpleAdapter } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+
+const url_arb="https://dapi.api.arbitrum-prod.firefly.exchange/marketData/fees"
+const url_sui="https://dapi.api.sui-prod.bluefin.io/marketData/fees"
+
+const fetch_arb = async (timestamp: number): Promise<FetchResultFees> => {
+   const result= await fetchURL(url_arb);
+    const dailyFees=result.data.last24HoursFees;
+    const totalFees=result.data.totalFees;
+
+  return {
+    dailyFees: dailyFees ? `${dailyFees}` : undefined,
+    totalFees: totalFees ? `${totalFees}` : undefined,
+    timestamp: timestamp,
+  };
+};
+
+
+const fetch_sui = async (timestamp: number): Promise<FetchResultFees> => {
+    const result= await fetchURL(url_sui);
+    const dailyFees=result.data.last24HoursFees;
+    const totalFees=result.data.totalFees;
+
+  return {
+    dailyFees: dailyFees ? `${dailyFees}` : undefined,
+    totalFees: totalFees ? `${totalFees}` : undefined,
+    timestamp: timestamp,
+  };
+};
+
+const adapter: SimpleAdapter = {
+  adapter: {
+    [CHAIN.ARBITRUM]: {
+      fetch: fetch_arb,
+      start: async () => 1700265600,
+      runAtCurrTime: true,
+    },
+    [CHAIN.SUI]: {
+        fetch: fetch_sui,
+        start: async () => 1700265600,
+        runAtCurrTime: true,
+      },
+  },
+};
+
+export default adapter;


### PR DESCRIPTION
We have created an endpoint which gives total and daily fees for the last 24 hours and we intend to display it on Defilama.
