### PR TITLE
Add Metavault Derivatives V2 dimensions

### DIFF
--- a/dexs/metavault-derivatives-v2/index.ts
+++ b/dexs/metavault-derivatives-v2/index.ts
@@ -1,0 +1,67 @@
+import { SimpleAdapter, FetchResultVolume } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import { getTimestampAtStartOfDayUTC } from "../../utils/date";
+import { Chain } from "@defillama/sdk/build/general";
+import request, { gql } from "graphql-request";
+
+interface IReferralRecord {
+  volume: string; // Assuming volume is a string that represents a number
+  timestamp: number;
+}
+
+interface IVolumeStat {
+  cumulativeVolumeUsd: string;
+  id: string;
+}
+
+const fetch = () => {
+  return async (timestamp: number): Promise<FetchResultVolume> => {
+    const todaysTimestamp = getTimestampAtStartOfDayUTC(timestamp);
+
+    const graphQuery = gql`
+      query MyQuery {
+        volumeStats(where: {timestamp: ${todaysTimestamp}, period: "daily"}) {
+          cumulativeVolumeUsd
+          id
+        }
+      }
+    `;
+
+    const endpoint =
+      "https://linea-graph-node.metavault.trade/subgraphs/name/metavault/perpv1";
+    const response = await request(endpoint, graphQuery);
+    const volumeStats: IVolumeStat[] = response.volumeStats;
+
+    let dailyVolumeUSD = BigInt(0);
+
+    volumeStats.forEach((vol) => {
+      dailyVolumeUSD += BigInt(vol.cumulativeVolumeUsd);
+    });
+
+    const finalDailyVolume = parseInt(dailyVolumeUSD.toString()) / 1e18;
+
+    return {
+      dailyVolume: finalDailyVolume.toString(),
+      timestamp: todaysTimestamp,
+    };
+  };
+};
+
+const methodology = {
+  dailyVolume:
+    "Total cumulativeVolumeUsd for specified chain for the given day",
+};
+
+const adapter: SimpleAdapter = {
+  adapter: {
+    [CHAIN.LINEA]: {
+      fetch: fetch(),
+      start: async () => 1701950449,
+      meta: {
+        methodology,
+      },
+    },
+  },
+};
+
+export default adapter;

--- a/fees/metavault-derivatives-v2/index.ts
+++ b/fees/metavault-derivatives-v2/index.ts
@@ -1,0 +1,57 @@
+import { Chain } from "@defillama/sdk/build/general";
+import { gql, request } from "graphql-request";
+import type { ChainEndpoints } from "../../adapters/types";
+import { Adapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+
+import { getTimestampAtStartOfDayUTC } from "../../utils/date";
+
+const endpoints = {
+  [CHAIN.LINEA]:
+    "https://linea-graph-node.metavault.trade/subgraphs/name/metavault/perpv1",
+};
+
+const graphs = (graphUrls: ChainEndpoints) => {
+  return (chain: Chain) => {
+    return async (timestamp: number) => {
+      const todaysTimestamp = getTimestampAtStartOfDayUTC(timestamp);
+      const period = "daily";
+
+      const graphQuery = gql`{
+        feeStats(where: {timestamp: ${todaysTimestamp}, period: "${period}"}) {
+          id
+          timestamp
+          period
+          cumulativeFee
+          cumulativeFeeUsd
+        }
+      }`;
+
+      const graphRes = await request(graphUrls[chain], graphQuery);
+
+      const dailyFee = parseInt(graphRes.feeStats[0].cumulativeFeeUsd);
+
+      const finalDailyFee = dailyFee / 1e18;
+
+      return {
+        timestamp,
+        dailyFees: finalDailyFee.toString(),
+        //dailyRevenue: (finalDailyFee * 0.3).toString(),
+      };
+    };
+  };
+};
+
+const adapter: Adapter = {
+  adapter: {
+    [CHAIN.LINEA]: {
+      fetch: graphs(endpoints)(CHAIN.LINEA),
+      start: async () => 1701950449,
+      meta: {
+        methodology: "All treasuryFee, poolFee and keeperFee are collected",
+      },
+    },
+  },
+};
+
+export default adapter;


### PR DESCRIPTION
Metavault Derivatives V2 Dimensions (Dexs and Fees dimensions)

🦙 Running METAVAULT-DERIVATIVES-V2 adapter 🦙
_______________________________________
Dexs for 15/12/2023
_______________________________________

LINEA 👇
Backfill start time: 7/12/2023
Daily volume: 697343.1431058045
Timestamp: 1702598400

_______________________________________
Fees for 15/12/2023
_______________________________________

LINEA 👇
Backfill start time: 7/12/2023
Methodology: All treasuryFee, poolFee and keeperFee are collected
Timestamp: 1702684798
Daily fees: 463.91756850313965