### PR TITLE
Add Phoenix dex volume on Solana

### DIFF
--- a/dexs/phoenix/index.ts
+++ b/dexs/phoenix/index.ts
@@ -1,0 +1,30 @@
+import axios from 'axios';
+import { CHAIN } from '../../helpers/chains';
+
+const ONE_DAY_IN_SECONDS = 60 * 60 * 24
+
+const volumeEndpoint = "https://9senbezsz3.execute-api.us-east-1.amazonaws.com/Prod/get-global-volume";
+
+async function fetch(timestamp: number) {
+    const from = timestamp - ONE_DAY_IN_SECONDS;
+    const to = timestamp;
+    const response = await axios.get(volumeEndpoint, {
+        headers: { 'X-Api-Key': 'lty8FkZLKR87IA5g7uFEY6uH8MIk8mJT4OehR8hF' },
+        params: { start_timestamp: from, end_timestamp: to }
+    });
+
+    return {
+        dailyVolume: response.data.volume_in_quote_units,
+        timestamp: timestamp
+    }
+}
+
+export default {
+    adapter: {
+        [CHAIN.SOLANA]: {
+            fetch: fetch,
+            runAtCurrTime: true,
+            start: async () => 1677456000,
+        }
+    }
+}


### PR DESCRIPTION
Adds Phoenix dex volume (order book dex on Solana) 

Stats page: https://app.phoenix.trade/data
Blockworks article describing Phoenix: https://blockworks.co/news/solana-dex-phoenix-launch

`yarn test dexs phoenix` outputs
```
🦙 Running PHOENIX adapter 🦙
_______________________________________
Dexs for 17/12/2023
_______________________________________

SOLANA 👇
Backfill start time: 27/2/2023
NO METHODOLOGY SPECIFIED
Daily volume: 71.03 M
Timestamp: 1702857598




✨  Done in 1.60s.
```

I have an okay from the team for defi llama to use this endpoint. Screenshot that shows the endpoint is the same as on their stats page 

<img width="1726" alt="image" src="https://github.com/DefiLlama/dimension-adapters/assets/84360463/fd9fc892-5c05-4459-97a9-cc9016991c91">


