### PR TITLE
Conveyor Statistics - Updated code and query to model the format of 1inch display

### DIFF
--- a/aggregators/conveyor/index.ts
+++ b/aggregators/conveyor/index.ts
@@ -45,7 +45,7 @@ const adapter: any = {
         ...acc,
         [(chainsMap as any)[chain] || chain]: {
           fetch: fetch(chain),
-          start: async () => 1701734400,
+          start: async () => 1692897682,
         },
       };
     }, {}),

--- a/aggregators/conveyor/index.ts
+++ b/aggregators/conveyor/index.ts
@@ -1,41 +1,51 @@
+import { FetchResult, SimpleAdapter } from "../../adapters/types";
 import { getUniqStartOfTodayTimestamp } from "../../helpers/getUniSubgraphVolume";
 import { fetchURLWithRetry } from "../../helpers/duneRequest";
 
-const chains: Record<string, string> = {
-  ethereum: "ethereum",
-  bnb: "bsc",
-  polygon: "polygon",
-  arbitrum: "arbitrum",
-  optimism: "optimism",
-  base: "base",
+const chainsMap: Record<string, string> = {
+  ETHEREUM: "ethereum",
+  ARBITRUM: "arbitrum",
+  POLYGON: "polygon",
+  BNB: "bsc",
+  OPTIMISM: "optimism",
+  BASE: "base",
 };
 
-const fetch = (chain: string) => async (timestamp: number) => {
-  const timestampDate = new Date(timestamp * 1000);
-  const unixTimestamp = getUniqStartOfTodayTimestamp(timestampDate);
-  const data = (
-    await fetchURLWithRetry("https://api.dune.com/api/v1/query/3319718/results")
-  ).data.result.rows;
-  const dayData = data.find(
-    ({ block_date, blockchain }: { block_date: number; blockchain: string }) =>
-      getUniqStartOfTodayTimestamp(new Date(block_date)) === unixTimestamp &&
-      blockchain === chain
-  );
+const fetch =
+  (chain: string) =>
+  async (_: number): Promise<FetchResult> => {
+    const unixTimestamp = getUniqStartOfTodayTimestamp();
 
-  return {
-    dailyVolume: dayData?.trade_amount ?? "0",
-    timestamp: unixTimestamp,
+    try {
+      const data = (
+        await fetchURLWithRetry(
+          `https://api.dune.com/api/v1/query/3325921/results`
+        )
+      ).data;
+      const chainData = data?.result?.rows?.find(
+        (row: any) => chainsMap[row.blockchain] === chain
+      );
+
+      return {
+        dailyVolume: chainData.volume_24h,
+        timestamp: unixTimestamp,
+      };
+    } catch (e) {
+      return {
+        dailyVolume: "0",
+        timestamp: unixTimestamp,
+      };
+    }
   };
-};
 
 const adapter: any = {
   adapter: {
-    ...Object.entries(chains).reduce((acc, [key, chain]) => {
+    ...Object.values(chainsMap).reduce((acc, chain) => {
       return {
         ...acc,
-        [chain]: {
-          fetch: fetch(key),
-          start: async () => new Date(2023, 6, 1).getTime() / 1000,
+        [(chainsMap as any)[chain] || chain]: {
+          fetch: fetch(chain),
+          start: async () => 1701734400,
         },
       };
     }, {}),


### PR DESCRIPTION
Dune Query: https://dune.com/queries/3325921

Current implementation does not break down chain volume and 7d, 30d individual volume.

I forked the 1inch query that supplies their data, rotated out their contracts for ours, and copied their index.ts file to conveyor folder and updated the dune URL. 

adapter passes when running 

`yarn test aggregators conveyor 1735344001`

🦙 Running CONVEYOR adapter 🦙
_______________________________________
Aggregators for 28/12/2024
_______________________________________

ETHEREUM 👇
Backfill start time: 24/8/2023
NO METHODOLOGY SPECIFIED
Daily volume: 10.44 k
Timestamp: 1704412800


ARBITRUM 👇
Backfill start time: 24/8/2023
NO METHODOLOGY SPECIFIED
Daily volume: 0
Timestamp: 1704412800


POLYGON 👇
Backfill start time: 24/8/2023
NO METHODOLOGY SPECIFIED
Daily volume: 2.8572312863382914
Timestamp: 1704412800


BSC 👇
Backfill start time: 24/8/2023
NO METHODOLOGY SPECIFIED
Daily volume: 1.13 k
Timestamp: 1704412800


OPTIMISM 👇
Backfill start time: 24/8/2023
NO METHODOLOGY SPECIFIED
Daily volume: 0
Timestamp: 1704412800


BASE 👇
Backfill start time: 24/8/2023
NO METHODOLOGY SPECIFIED
Daily volume: 0
Timestamp: 1704412800