### PR TITLE
add active addresses for squadefi

### DIFF
--- a/users/routers/routerAddresses.ts
+++ b/users/routers/routerAddresses.ts
@@ -2819,5 +2819,14 @@ export default ([
             ]
         }
     },
+    {
+        "id":"3977",
+        "name": "SquaDeFi",
+        "addresses":{
+            "base":[
+                "0xfad362E479AA318F2De7b2c8a1993Df9BB2B3b1f", // KeyManager
+            ]
+        }
+    },
     
 ] as ProtocolAddresses[]).filter(isAddressesUsable)


### PR DESCRIPTION
As far as I understand, it is necessary to add my protocol to RouterAddresses file so that the “Active Addresses” button appears on the frontend. If everything is correct, please add it.