### PR TITLE
Update Osmosis historical volume endpoint

### DIFF
--- a/dexs/osmosis/index.ts
+++ b/dexs/osmosis/index.ts
@@ -3,7 +3,7 @@ import { CHAIN } from "../../helpers/chains";
 import { getUniqStartOfTodayTimestamp } from "../../helpers/getUniSubgraphVolume";
 import fetchURL from "../../utils/fetchURL"
 
-const historicalVolumeEndpoint = "https://api-osmosis.imperator.co/volume/v2/historical/chart"
+const historicalVolumeEndpoint = "https://public-osmosis-api.numia.xyz/volume/historical/chart"
 
 interface IChartItem {
   time: string


### PR DESCRIPTION
The old data endpoint does not include volume from txs triggered by smart contracts, only direct swap msgs from EOAs.  This new endpoint includes smart contract initiated trade volume.