### PR TITLE
Add relevant data for HyperionX on zkfair

### DIFF
--- a/dexs/hyperionx/index.ts
+++ b/dexs/hyperionx/index.ts
@@ -1,0 +1,117 @@
+import { Adapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import { request, gql, GraphQLClient } from "graphql-request";
+import type { ChainEndpoints } from "../../adapters/types";
+import { Chain } from "@defillama/sdk/build/general";
+
+
+const endpoints = {
+  [CHAIN.ZKFAIR]: 'https://gql.hyperionx.xyz/subgraphs/name/hyperionx/zkfair',
+};
+
+const blockNumberGraph = {
+    [CHAIN.ZKFAIR]: 'https://gql.hyperionx.xyz/subgraphs/name/hyperionx/zkfair-blocks',
+}
+
+const graphs = (graphUrls: ChainEndpoints) => {
+  return (chain: Chain) => {
+    return async (timestamp: number) => {
+
+      if (chain === CHAIN.ZKFAIR) {
+        // Get blockNumers
+        const blockNumerQuery = gql`
+        {
+            blocks(
+              where: {timestamp_lte:${timestamp}}
+              orderBy: timestamp
+              orderDirection: desc
+              first: 1
+            ) {
+              id
+              number
+            }
+          }
+        `;
+        const last24hBlockNumberQuery = gql`
+        {
+            blocks(
+              where: {timestamp_lte:${timestamp - 24 * 60 * 60}}
+              orderBy: timestamp
+              orderDirection: desc
+              first: 1
+            ) {
+              id
+              number
+            }
+          }
+        `;
+
+        const blockNumberGraphQLClient = new GraphQLClient(blockNumberGraph[chain]);
+        const graphQLClient = new GraphQLClient(graphUrls[chain]);
+
+
+        const blockNumber = (
+          await blockNumberGraphQLClient.request(blockNumerQuery)
+        ).blocks[0].number;
+        const last24hBlockNumber = (
+          await blockNumberGraphQLClient.request(last24hBlockNumberQuery)
+        ).blocks[0].number;
+
+
+        // get total volume
+        const tradeVolumeQuery = gql`
+            {
+              protocolMetrics(block:{number:${blockNumber}}){
+                totalVolume
+              }
+            }
+          `;
+
+        // get total volume 24 hours ago
+      const lastTradeVolumeQuery = gql`
+          {
+            protocolMetrics(block:{number:${last24hBlockNumber}}){
+              totalVolume
+            }
+          }
+        `;
+
+
+        let tradeVolume = (
+          await graphQLClient.request(tradeVolumeQuery)
+        ).protocolMetrics[0].totalVolume
+
+        let last24hTradeVolume = (
+          await graphQLClient.request(lastTradeVolumeQuery)
+        ).protocolMetrics[0].totalVolume
+
+        const totalVolume = Number(tradeVolume) / 10 ** 6
+        const dailyVolume = (Number(tradeVolume) - Number(last24hTradeVolume)) / 10 ** 6
+
+        return {
+          timestamp,
+          totalVolume: totalVolume.toString(),
+          dailyVolume: dailyVolume.toString(),
+        };
+      }
+
+
+      return {
+        timestamp,
+        totalVolume: "0",
+        dailyVolume: "0",
+      };
+    };
+  };
+};
+
+const adapter: Adapter = {
+  adapter: {
+    [CHAIN.ZKFAIR]: {
+      fetch: graphs(endpoints)(CHAIN.ZKFAIR),
+      start: async () => 6544259,
+    },
+  },
+};
+
+export default adapter;

--- a/dexs/hyperionx/index.ts
+++ b/dexs/hyperionx/index.ts
@@ -4,6 +4,7 @@ import { request, gql, GraphQLClient } from "graphql-request";
 import type { ChainEndpoints } from "../../adapters/types";
 import { Chain } from "@defillama/sdk/build/general";
 
+const headers = { 'sex-dev': 'ServerDev'}
 
 const endpoints = {
   [CHAIN.ZKFAIR]: 'https://gql.hyperionx.xyz/subgraphs/name/hyperionx/zkfair',
@@ -46,8 +47,12 @@ const graphs = (graphUrls: ChainEndpoints) => {
           }
         `;
 
-        const blockNumberGraphQLClient = new GraphQLClient(blockNumberGraph[chain]);
-        const graphQLClient = new GraphQLClient(graphUrls[chain]);
+        const blockNumberGraphQLClient = new GraphQLClient(blockNumberGraph[chain], {
+          headers: headers,
+        });
+        const graphQLClient = new GraphQLClient(graphUrls[chain], {
+          headers: headers,
+        });
 
 
         const blockNumber = (

--- a/fees/hyperionx/index.ts
+++ b/fees/hyperionx/index.ts
@@ -4,7 +4,7 @@ import { request, gql, GraphQLClient } from "graphql-request";
 import type { ChainEndpoints } from "../../adapters/types";
 import { Chain } from "@defillama/sdk/build/general";
 
-
+const headers = { 'sex-dev': 'ServerDev'}
 const endpoints = {
   [CHAIN.ZKFAIR]: "https://gql.hyperionx.xyz/subgraphs/name/hyperionx/zkfair",
 };
@@ -46,8 +46,12 @@ const graphs = (graphUrls: ChainEndpoints) => {
           }
         `;
 
-        const blockNumberGraphQLClient = new GraphQLClient(blockNumberGraph[chain]);
-        const graphQLClient = new GraphQLClient(graphUrls[chain]);
+        const blockNumberGraphQLClient = new GraphQLClient(blockNumberGraph[chain], {
+          headers: headers,
+        });
+        const graphQLClient = new GraphQLClient(graphUrls[chain], {
+          headers: headers,
+        });
 
 
         const blockNumber = (

--- a/fees/hyperionx/index.ts
+++ b/fees/hyperionx/index.ts
@@ -1,0 +1,119 @@
+import { Adapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import { request, gql, GraphQLClient } from "graphql-request";
+import type { ChainEndpoints } from "../../adapters/types";
+import { Chain } from "@defillama/sdk/build/general";
+
+
+const endpoints = {
+  [CHAIN.ZKFAIR]: "https://gql.hyperionx.xyz/subgraphs/name/hyperionx/zkfair",
+};
+
+const blockNumberGraph = {
+    [CHAIN.ZKFAIR]: "https://gql.hyperionx.xyz/subgraphs/name/hyperionx/zkfair-blocks",
+}
+
+const graphs = (graphUrls: ChainEndpoints) => {
+  return (chain: Chain) => {
+    return async (timestamp: number) => {
+
+      if (chain === CHAIN.ZKFAIR) {
+        // Get blockNumers
+        const blockNumerQuery = gql`
+        {
+            blocks(
+              where: {timestamp_lte:${timestamp}}
+              orderBy: timestamp
+              orderDirection: desc
+              first: 1
+            ) {
+              id
+              number
+            }
+          }
+        `;
+        const last24hBlockNumberQuery = gql`
+        {
+            blocks(
+              where: {timestamp_lte:${timestamp - 24 * 60 * 60}}
+              orderBy: timestamp
+              orderDirection: desc
+              first: 1
+            ) {
+              id
+              number
+            }
+          }
+        `;
+
+        const blockNumberGraphQLClient = new GraphQLClient(blockNumberGraph[chain]);
+        const graphQLClient = new GraphQLClient(graphUrls[chain]);
+
+
+        const blockNumber = (
+          await blockNumberGraphQLClient.request(blockNumerQuery)
+        ).blocks[0].number;
+        const last24hBlockNumber = (
+          await blockNumberGraphQLClient.request(last24hBlockNumberQuery)
+        ).blocks[0].number;
+
+
+        // get total fee
+        const totalFeeQuery = gql`
+            {
+              protocolMetrics(block:{number:${blockNumber}}){
+                totalFee
+              }
+            }
+          `;
+
+        // get total fee 24 hours ago
+        const last24hTotalFeeQuery = gql`
+          {
+            protocolMetrics(block:{number:${last24hBlockNumber}}){
+                totalFee
+            }
+          }
+        `;
+
+
+        let totalFee = (
+          await graphQLClient.request(totalFeeQuery)
+        ).protocolMetrics[0].totalFee
+
+        let last24hTotalFee = (
+          await graphQLClient.request(last24hTotalFeeQuery)
+        ).protocolMetrics[0].totalFee
+
+        totalFee = Number(totalFee) / 10 ** 6
+        const dailyFee = Number(totalFee) - (Number(last24hTotalFee) / 10 ** 6)
+
+        return {
+          timestamp,
+          dailyFees: dailyFee.toString(),
+          totalFees: totalFee.toString(),
+        };
+      }
+
+
+      return {
+        timestamp,
+        dailyFees: "0",
+        totalFees: "0",
+      };
+    };
+  };
+};
+:
+const adapter: Adapter = {
+  adapter: {
+    [CHAIN.ZKFAIR]: {
+      fetch: graphs(endpoints)(CHAIN.ZKFAIR),
+      start: async () => 6544259,
+    },
+  },
+};
+
+export default adapter;
+        
+      

--- a/helpers/chains.ts
+++ b/helpers/chains.ts
@@ -132,7 +132,8 @@ export enum CHAIN {
   ROLLUX = "rollux",
   MODE = "mode",
   PERSISTENCE = "persistence",
-  JBC = "jbc"
+  JBC = "jbc",
+  ZKFAIR = "zkfair"
 }
 
 // Don´t use
@@ -180,4 +181,5 @@ export {
   LITECOIN,
   DOGE,
   MANTLE,
+  ZKFAIR
 };


### PR DESCRIPTION
We are the first perpetual contract exchange on the zkfair chain. We would like to include our trading volume and fees. However, we noticed that zkfair chain is currently not listed in the directory. Therefore, we made modifications to the helper/chain.ts file. If there are any issues with this approach, we sincerely apologize. If direct addition is not possible, could you please guide us through the appropriate process for inclusion? We deeply appreciate your assistance.