### PR TITLE
Add Kinetix Perps (Derivatives) V2 Dimensions

### DIFF
--- a/dexs/kinetix-derivatives-v2/index.ts
+++ b/dexs/kinetix-derivatives-v2/index.ts
@@ -1,0 +1,70 @@
+import { SimpleAdapter, FetchResultVolume } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import { getTimestampAtStartOfDayUTC } from "../../utils/date";
+import { Chain } from "@defillama/sdk/build/general";
+import request, { gql } from "graphql-request";
+
+const kinetixPerpsV2Subgraph =
+  "https://kava-graph-node.metavault.trade/subgraphs/name/kinetixfi/perpv2";
+
+interface IReferralRecord {
+  volume: string; // Assuming volume is a string that represents a number
+  timestamp: number;
+}
+
+interface IVolumeStat {
+  cumulativeVolumeUsd: string;
+  volumeUsd: string;
+  id: string;
+}
+
+const fetch = () => {
+  return async (timestamp: number): Promise<FetchResultVolume> => {
+    const todaysTimestamp = getTimestampAtStartOfDayUTC(timestamp);
+
+    const graphQuery = gql`
+      query MyQuery {
+        volumeStats(where: {timestamp: ${todaysTimestamp}, period: "daily"}) {
+          cumulativeVolumeUsd
+          id
+          volumeUsd
+        }
+      }
+    `;
+
+    const response = await request(kinetixPerpsV2Subgraph, graphQuery);
+    const volumeStats: IVolumeStat[] = response.volumeStats;
+
+    let dailyVolumeUSD = BigInt(0);
+
+    volumeStats.forEach((vol) => {
+      dailyVolumeUSD += BigInt(vol.volumeUsd);
+    });
+
+    const finalDailyVolume = parseInt(dailyVolumeUSD.toString()) / 1e18;
+
+    return {
+      dailyVolume: finalDailyVolume.toString(),
+      timestamp: todaysTimestamp,
+    };
+  };
+};
+
+const methodology = {
+  dailyVolume:
+    "Total cumulativeVolumeUsd for specified chain for the given day",
+};
+
+const adapter: SimpleAdapter = {
+  adapter: {
+    [CHAIN.KAVA]: {
+      fetch: fetch(),
+      start: async () => 1706832000,
+      meta: {
+        methodology,
+      },
+    },
+  },
+};
+
+export default adapter;

--- a/fees/kinetix-derivatives-v2/index.ts
+++ b/fees/kinetix-derivatives-v2/index.ts
@@ -1,0 +1,60 @@
+import { Chain } from "@defillama/sdk/build/general";
+import { gql, request } from "graphql-request";
+import type { ChainEndpoints } from "../../adapters/types";
+import { Adapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+
+import { getTimestampAtStartOfDayUTC } from "../../utils/date";
+
+const endpoints = {
+  [CHAIN.KAVA]:
+    "https://kava-graph-node.metavault.trade/subgraphs/name/kinetixfi/perpv2",
+};
+
+const graphs = (graphUrls: ChainEndpoints) => {
+  return (chain: Chain) => {
+    return async (timestamp: number) => {
+      const todaysTimestamp = getTimestampAtStartOfDayUTC(timestamp);
+      const period = "daily";
+
+      const graphQuery = gql`{
+        feeStats(where: {timestamp: ${todaysTimestamp}, period: "${period}"}) {
+          id
+          timestamp
+          period
+          cumulativeFee
+          cumulativeFeeUsd
+          feeUsd
+        }
+      }`;
+
+      const graphRes = await request(graphUrls[chain], graphQuery);
+
+      const dailyFee = parseInt(graphRes.feeStats[0].feeUsd);
+
+      const finalDailyFee = dailyFee / 1e18;
+      const totalFees = parseInt(graphRes.feeStats[0].cumulativeFeeUsd) / 1e18;
+
+      return {
+        timestamp,
+        dailyFees: finalDailyFee.toString(),
+        totalFees: totalFees.toString(),
+        //dailyRevenue: (finalDailyFee * 0.3).toString(),
+      };
+    };
+  };
+};
+
+const adapter: Adapter = {
+  adapter: {
+    [CHAIN.KAVA]: {
+      fetch: graphs(endpoints)(CHAIN.KAVA),
+      start: async () => 1706832000,
+      meta: {
+        methodology: "All treasury, pool and keeper fees are collected",
+      },
+    },
+  },
+};
+
+export default adapter;


### PR DESCRIPTION
Kinetix Perps (Derivatives) V2 Dimensions (Dexs and Fees dimensions)


🦙 Running KINETIX-DERIVATIVES-V2 adapter 🦙
_______________________________________
Dexs for 5/2/2024
_______________________________________

KAVA 👇
Backfill start time: 2/2/2024
Daily volume: 3.51 M
Timestamp: 1707091200


🦙 Running KINETIX-DERIVATIVES-V2 adapter 🦙
_______________________________________
Fees for 5/2/2024
_______________________________________

KAVA 👇
Backfill start time: 2/2/2024
Methodology: All treasury, pool and keeper fees are collected
Timestamp: 1707177598
Daily fees: 3.67 k
Total fees: 7.81 k



