### PR TITLE
add mux-protocol aggregator

### DIFF
--- a/aggregator-derivatives/mux-protocol/index.ts
+++ b/aggregator-derivatives/mux-protocol/index.ts
@@ -1,0 +1,86 @@
+import fetchURL from "../../utils/fetchURL"
+import { Chain } from "@defillama/sdk/build/general";
+import { SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import customBackfill from "../../helpers/customBackfill";
+import { getUniqStartOfTodayTimestamp } from "../../helpers/getUniSubgraphVolume";
+
+const historicalVolumeEndpoint = "https://stats.mux.network/api/public/dashboard/13f401da-31b4-4d35-8529-bb62ca408de8/dashcard/389/card/306"
+
+interface IVolumeall {
+  volume: string;
+  time: string;
+  title: string;
+}
+
+type chains = {
+  [chain: string | Chain]: string;
+}
+
+const chainsMap: chains = {
+    [CHAIN.ARBITRUM]: "Arbitrum",
+    [CHAIN.AVAX]: "Avalanche",
+    [CHAIN.BSC]: "BNB Chain",
+    [CHAIN.FANTOM]: "Fantom"
+}
+
+const fetch = (chain: Chain) => {
+  return async (timestamp: number) => {
+    const dayTimestamp = getUniqStartOfTodayTimestamp(new Date(timestamp * 1000))
+    const callhistoricalVolume = (await fetchURL(historicalVolumeEndpoint))?.data.rows;
+
+    const historicalVolume: IVolumeall[] = callhistoricalVolume.map((e: string[] | number[]) => {
+      const [time, title, volume] = e;
+      return {
+        time,
+        volume,
+        title
+      } as IVolumeall;
+    });
+
+    const historical = historicalVolume.filter((e: IVolumeall)  => e.title === chainsMap[chain]);
+    const totalVolume = historical
+      .filter(volItem => getUniqStartOfTodayTimestamp(new Date(volItem.time)) <= dayTimestamp)
+      .reduce((acc, { volume }) => acc + Number(volume), 0)
+
+    const dailyVolume = historical
+      .find(dayItem => getUniqStartOfTodayTimestamp(new Date(dayItem.time)) === dayTimestamp)?.volume
+
+    return {
+      totalVolume: `${totalVolume}`,
+      dailyVolume: dailyVolume ? `${dailyVolume}` : undefined,
+      timestamp: dayTimestamp,
+    };
+  }
+};
+
+const getStartTimestamp = async (chain: Chain) => {
+  const callhistoricalVolume = (await fetchURL(historicalVolumeEndpoint))?.data.rows;
+  const historicalVolume: IVolumeall[] = callhistoricalVolume.map((e: string[] | number[]) => {
+    const [time, title, volume] = e;
+    return {
+      time,
+      volume,
+      title
+    } as IVolumeall;
+  });
+
+  const historicalCall = historicalVolume.filter((e: IVolumeall)  => e.title === chainsMap[chain]);
+  const historical = historicalCall.sort((a: IVolumeall,b: IVolumeall)=> new Date(a.time).getTime() - new Date(b.time).getTime());
+  return (new Date(historical[0].time).getTime()) / 1000
+}
+
+const adapter: SimpleAdapter = {
+  adapter: Object.keys(chainsMap).reduce((acc, chain: any) => {
+    return {
+      ...acc,
+      [chain]: {
+        fetch: fetch(chain as Chain),
+        start: async () => getStartTimestamp(chain),
+        customBackfill: customBackfill(chain as Chain, fetch),
+      }
+    }
+  }, {})
+};
+
+export default adapter;


### PR DESCRIPTION
add mux-protocol aggregator. test result:

```
🦙 Running MUX-PROTOCOL adapter 🦙
_______________________________________
Aggregator-derivatives for 19/2/2024
_______________________________________

ARBITRUM 👇
Backfill start time: 20/2/2024
NO METHODOLOGY SPECIFIED
Total volume: 32.08 B
Daily volume: 411.71 M
Timestamp: 1708300800 (2024-02-19T00:00:00.000Z)


AVAX 👇
Backfill start time: 20/2/2024
NO METHODOLOGY SPECIFIED
Total volume: 827.01 M
Daily volume: 80.69 k
Timestamp: 1708300800 (2024-02-19T00:00:00.000Z)


BSC 👇
Backfill start time: 20/2/2024
NO METHODOLOGY SPECIFIED
Total volume: 99.62 M
Daily volume: 12.00 k
Timestamp: 1708300800 (2024-02-19T00:00:00.000Z)


FANTOM 👇
Backfill start time: 20/2/2024
NO METHODOLOGY SPECIFIED
Total volume: 59.56 M
Daily volume: 0
Timestamp: 1708300800 (2024-02-19T00:00:00.000Z)

✨  Done in 14.46s.
```