### PR TITLE
Add stTIA, stDYDX, and stCMDX fees to Stride

### DIFF
--- a/fees/stride.ts
+++ b/fees/stride.ts
@@ -43,8 +43,20 @@ const adapter: Adapter = {
       start: 0,
       meta,
     },
+    celestia: {
+      fetch: fetch("celestia"),
+      runAtCurrTime: true,
+      start: 0,
+      meta,
+    },
     osmosis: {
       fetch: fetch("osmosis"),
+      runAtCurrTime: true,
+      start: 0,
+      meta,
+    },
+    dydx: {
+      fetch: fetch("dydx"),
       runAtCurrTime: true,
       start: 0,
       meta,
@@ -81,6 +93,12 @@ const adapter: Adapter = {
     },
     umee: {
       fetch: fetch("umee"),
+      runAtCurrTime: true,
+      start: 0,
+      meta,
+    },
+    comdex: {
+      fetch: fetch("comdex"),
       runAtCurrTime: true,
       start: 0,
       meta,


### PR DESCRIPTION
Adds fees for 3 more of Stride's products. 

Please let me know if you have any questions! 

Output from tests looks good: 

```
❯ yarn test fees stride
yarn run v1.22.19
$ yarn run update-submodules && ts-node --transpile-only cli/testAdapter.ts fees stride
$ git submodule update --init --recursive --remote --merge
🦙 Running STRIDE adapter 🦙
_______________________________________
Fees for 6/3/2024
_______________________________________

COSMOS 👇
Backfill start time not defined
Timestamp: 1709769598 (2024-03-06T23:59:58.000Z)
Daily fees: 24.34 k
└─ Methodology: Fees are staking rewards earned by tokens staked with Stride. They are measured across Stride's LSD tokens' yields and converted to USD terms.
Daily revenue: 2.70 k
└─ Methodology: Stride collects 10% of liquid staked assets's staking rewards. These fees are measured across Stride's LSD tokens' yields and converted to USD terms.


CELESTIA 👇
Backfill start time not defined
Timestamp: 1709769598 (2024-03-06T23:59:58.000Z)
Daily fees: 21.43 k
└─ Methodology: Fees are staking rewards earned by tokens staked with Stride. They are measured across Stride's LSD tokens' yields and converted to USD terms.
Daily revenue: 2.38 k
└─ Methodology: Stride collects 10% of liquid staked assets's staking rewards. These fees are measured across Stride's LSD tokens' yields and converted to USD terms.


OSMOSIS 👇
Backfill start time not defined
Timestamp: 1709769598 (2024-03-06T23:59:58.000Z)
Daily fees: 13.12 k
└─ Methodology: Fees are staking rewards earned by tokens staked with Stride. They are measured across Stride's LSD tokens' yields and converted to USD terms.
Daily revenue: 1.46 k
└─ Methodology: Stride collects 10% of liquid staked assets's staking rewards. These fees are measured across Stride's LSD tokens' yields and converted to USD terms.


DYDX 👇
Backfill start time not defined
Timestamp: 1709769598 (2024-03-06T23:59:58.000Z)
Daily fees: 7.06 k
└─ Methodology: Fees are staking rewards earned by tokens staked with Stride. They are measured across Stride's LSD tokens' yields and converted to USD terms.
Daily revenue: 784
└─ Methodology: Stride collects 10% of liquid staked assets's staking rewards. These fees are measured across Stride's LSD tokens' yields and converted to USD terms.


JUNO 👇
Backfill start time not defined
Timestamp: 1709769598 (2024-03-06T23:59:58.000Z)
Daily fees: 640
└─ Methodology: Fees are staking rewards earned by tokens staked with Stride. They are measured across Stride's LSD tokens' yields and converted to USD terms.
Daily revenue: 71
└─ Methodology: Stride collects 10% of liquid staked assets's staking rewards. These fees are measured across Stride's LSD tokens' yields and converted to USD terms.


STARGAZE 👇
Backfill start time not defined
Timestamp: 1709769598 (2024-03-06T23:59:58.000Z)
Daily fees: 807
└─ Methodology: Fees are staking rewards earned by tokens staked with Stride. They are measured across Stride's LSD tokens' yields and converted to USD terms.
Daily revenue: 90
└─ Methodology: Stride collects 10% of liquid staked assets's staking rewards. These fees are measured across Stride's LSD tokens' yields and converted to USD terms.


TERRA 👇
Backfill start time not defined
Timestamp: 1709769598 (2024-03-06T23:59:58.000Z)
Daily fees: 82
└─ Methodology: Fees are staking rewards earned by tokens staked with Stride. They are measured across Stride's LSD tokens' yields and converted to USD terms.
Daily revenue: 9
└─ Methodology: Stride collects 10% of liquid staked assets's staking rewards. These fees are measured across Stride's LSD tokens' yields and converted to USD terms.


EVMOS 👇
Backfill start time not defined
Timestamp: 1709769598 (2024-03-06T23:59:58.000Z)
Daily fees: 448
└─ Methodology: Fees are staking rewards earned by tokens staked with Stride. They are measured across Stride's LSD tokens' yields and converted to USD terms.
Daily revenue: 50
└─ Methodology: Stride collects 10% of liquid staked assets's staking rewards. These fees are measured across Stride's LSD tokens' yields and converted to USD terms.


INJECTIVE 👇
Backfill start time not defined
Timestamp: 1709769598 (2024-03-06T23:59:58.000Z)
Daily fees: 349
└─ Methodology: Fees are staking rewards earned by tokens staked with Stride. They are measured across Stride's LSD tokens' yields and converted to USD terms.
Daily revenue: 39
└─ Methodology: Stride collects 10% of liquid staked assets's staking rewards. These fees are measured across Stride's LSD tokens' yields and converted to USD terms.


UMEE 👇
Backfill start time not defined
Timestamp: 1709769598 (2024-03-06T23:59:58.000Z)
Daily fees: 60
└─ Methodology: Fees are staking rewards earned by tokens staked with Stride. They are measured across Stride's LSD tokens' yields and converted to USD terms.
Daily revenue: 7
└─ Methodology: Stride collects 10% of liquid staked assets's staking rewards. These fees are measured across Stride's LSD tokens' yields and converted to USD terms.


COMDEX 👇
Backfill start time not defined
Timestamp: 1709769598 (2024-03-06T23:59:58.000Z)
Daily fees: 35
└─ Methodology: Fees are staking rewards earned by tokens staked with Stride. They are measured across Stride's LSD tokens' yields and converted to USD terms.
Daily revenue: 4
└─ Methodology: Stride collects 10% of liquid staked assets's staking rewards. These fees are measured across Stride's LSD tokens' yields and converted to USD terms.
```