### PR TITLE
feat(dopex): holder and supply side revenue

### DIFF
--- a/options/dopex/clamm.ts
+++ b/options/dopex/clamm.ts
@@ -33,7 +33,11 @@ async function getChainStats({ graphUrl, timestamp }: IGetChainStatsParams) {
         first: 1000
         orderDirection: asc
         orderBy: startTimestamp
-        where: { startTimestamp_gte: $fromTimestamp, startTimestamp_lte: $toTimestamp, volume_gt: 0 }
+        where: {
+          startTimestamp_gte: $fromTimestamp
+          startTimestamp_lte: $toTimestamp
+          volume_gt: 0
+        }
       ) {
         volume
         fees
@@ -58,14 +62,13 @@ async function getChainStats({ graphUrl, timestamp }: IGetChainStatsParams) {
       return {
         totalNotionalVolume:
           acc.totalNotionalVolume + Number(market.totalVolume),
-        totalPremiumVolume:
-          acc.totalPremiumVolume + Number(market.totalPremium),
+        totalFees: acc.totalFees + Number(market.totalPremium),
         totalRevenue: acc.totalRevenue + Number(market.totalFees),
       };
     },
     {
       totalNotionalVolume: 0,
-      totalPremiumVolume: 0,
+      totalFees: 0,
       totalRevenue: 0,
     }
   );
@@ -74,13 +77,13 @@ async function getChainStats({ graphUrl, timestamp }: IGetChainStatsParams) {
     (acc, market) => {
       return {
         dailyNotionalVolume: acc.dailyNotionalVolume + Number(market.volume),
-        dailyPremiumVolume: acc.dailyPremiumVolume + Number(market.premium),
+        dailyFees: acc.dailyFees + Number(market.premium),
         dailyRevenue: acc.dailyRevenue + Number(market.fees),
       };
     },
     {
       dailyNotionalVolume: 0,
-      dailyPremiumVolume: 0,
+      dailyFees: 0,
       dailyRevenue: 0,
     }
   );
@@ -88,9 +91,7 @@ async function getChainStats({ graphUrl, timestamp }: IGetChainStatsParams) {
   return {
     timestamp,
     ...cumulative,
-    totalFees: cumulative.totalRevenue,
     ...daily,
-    dailyFees: daily.dailyRevenue,
   };
 }
 

--- a/options/dopex/clamm.ts
+++ b/options/dopex/clamm.ts
@@ -62,13 +62,14 @@ async function getChainStats({ graphUrl, timestamp }: IGetChainStatsParams) {
       return {
         totalNotionalVolume:
           acc.totalNotionalVolume + Number(market.totalVolume),
-        totalFees: acc.totalFees + Number(market.totalPremium),
+        totalPremiumVolume:
+          acc.totalPremiumVolume + Number(market.totalPremium),
         totalRevenue: acc.totalRevenue + Number(market.totalFees),
       };
     },
     {
       totalNotionalVolume: 0,
-      totalFees: 0,
+      totalPremiumVolume: 0,
       totalRevenue: 0,
     }
   );
@@ -77,21 +78,19 @@ async function getChainStats({ graphUrl, timestamp }: IGetChainStatsParams) {
     (acc, market) => {
       return {
         dailyNotionalVolume: acc.dailyNotionalVolume + Number(market.volume),
-        dailyFees: acc.dailyFees + Number(market.premium),
+        dailyPremiumVolume: acc.dailyPremiumVolume + Number(market.premium),
         dailyRevenue: acc.dailyRevenue + Number(market.fees),
       };
     },
     {
       dailyNotionalVolume: 0,
-      dailyFees: 0,
+      dailyPremiumVolume: 0,
       dailyRevenue: 0,
     }
   );
 
   return {
     timestamp,
-    totalPremiumVolume: cumulative.totalFees,
-    dailyPremiumVolume: daily.dailyFees,
     ...cumulative,
     ...daily,
   };

--- a/options/dopex/clamm.ts
+++ b/options/dopex/clamm.ts
@@ -90,6 +90,8 @@ async function getChainStats({ graphUrl, timestamp }: IGetChainStatsParams) {
 
   return {
     timestamp,
+    totalPremiumVolume: cumulative.totalFees,
+    dailyPremiumVolume: daily.dailyFees,
     ...cumulative,
     ...daily,
   };

--- a/options/dopex/clamm.ts
+++ b/options/dopex/clamm.ts
@@ -93,6 +93,10 @@ async function getChainStats({ graphUrl, timestamp }: IGetChainStatsParams) {
     timestamp,
     ...cumulative,
     ...daily,
+    dailySupplySideRevenue: daily.dailyPremiumVolume,
+    totalSupplySideRevenue: cumulative.totalPremiumVolume,
+    dailyHoldersRevenue: daily.dailyRevenue,
+    totalDailyHoldersRevenue: cumulative.totalRevenue,
   };
 }
 


### PR DESCRIPTION
Current implementation shows same data for  daily revenue and daily fees this PR fixes that

current:
![image](https://github.com/DefiLlama/dimension-adapters/assets/90272722/504ef300-9dc4-43d1-8a3b-311c2c9a3516)

with fix:
![image](https://github.com/DefiLlama/dimension-adapters/assets/90272722/d498db26-f212-48ce-a098-798f6c5ea852)


