### PR TITLE
update metavault derivatives v2  chains

### DIFF
--- a/dexs/metavault-derivatives-v2/index.ts
+++ b/dexs/metavault-derivatives-v2/index.ts
@@ -1,8 +1,19 @@
-import { SimpleAdapter, FetchResultVolume } from "../../adapters/types";
+import {
+  SimpleAdapter,
+  FetchResultVolume,
+  ChainEndpoints,
+} from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 import { getTimestampAtStartOfDayUTC } from "../../utils/date";
 import { Chain } from "@defillama/sdk/build/general";
 import request, { gql } from "graphql-request";
+
+const endpoints: ChainEndpoints = {
+  [CHAIN.LINEA]:
+    "https://api.studio.thegraph.com/query/55804/linea-trade/version/latest",
+  [CHAIN.POLYGON]:
+    "https://api.thegraph.com/subgraphs/name/sdcrypt0/polygon-trade",
+};
 
 interface IReferralRecord {
   volume: string; // Assuming volume is a string that represents a number
@@ -15,7 +26,7 @@ interface IVolumeStat {
   id: string;
 }
 
-const fetch = () => {
+const fetch = (endpoint) => {
   return async (timestamp: number): Promise<FetchResultVolume> => {
     const todaysTimestamp = getTimestampAtStartOfDayUTC(timestamp);
 
@@ -29,8 +40,6 @@ const fetch = () => {
       }
     `;
 
-    const endpoint =
-      "https://linea-graph-node.metavault.trade/subgraphs/name/metavault/perpv1";
     const response = await request(endpoint, graphQuery);
     const volumeStats: IVolumeStat[] = response.volumeStats;
 
@@ -57,8 +66,15 @@ const methodology = {
 const adapter: SimpleAdapter = {
   adapter: {
     [CHAIN.LINEA]: {
-      fetch: fetch(),
-      start: 1701950449,
+      fetch: fetch(endpoints[CHAIN.LINEA]),
+      start: 1709251200,
+      meta: {
+        methodology,
+      },
+    },
+    [CHAIN.POLYGON]: {
+      fetch: fetch(endpoints[CHAIN.POLYGON]),
+      start: 1709251200,
       meta: {
         methodology,
       },

--- a/fees/metavault-derivatives-v2/index.ts
+++ b/fees/metavault-derivatives-v2/index.ts
@@ -6,18 +6,24 @@ import { CHAIN } from "../../helpers/chains";
 
 import { getTimestampAtStartOfDayUTC } from "../../utils/date";
 
-const endpoints = {
+const endpoints: ChainEndpoints = {
   [CHAIN.LINEA]:
-    "https://linea-graph-node.metavault.trade/subgraphs/name/metavault/perpv1",
+    "https://api.studio.thegraph.com/query/55804/linea-trade/version/latest",
+  [CHAIN.POLYGON]:
+    "https://api.thegraph.com/subgraphs/name/sdcrypt0/polygon-trade",
 };
+interface IFeeStat {
+  cumulativeFeeUsd: string;
+  feeUsd: string;
+  id: string;
+}
 
-const graphs = (graphUrls: ChainEndpoints) => {
-  return (chain: Chain) => {
-    return async (timestamp: number) => {
-      const todaysTimestamp = getTimestampAtStartOfDayUTC(timestamp);
-      const period = "daily";
+const fetch = (endpoint) => {
+  return async (timestamp: number) => {
+    const todaysTimestamp = getTimestampAtStartOfDayUTC(timestamp);
+    const period = "daily";
 
-      const graphQuery = gql`{
+    const graphQuery = gql`{
         feeStats(where: {timestamp: ${todaysTimestamp}, period: "${period}"}) {
           id
           timestamp
@@ -28,19 +34,24 @@ const graphs = (graphUrls: ChainEndpoints) => {
         }
       }`;
 
-      const graphRes = await request(graphUrls[chain], graphQuery);
+    const response = await request(endpoint, graphQuery);
+    const feeStats: IFeeStat[] = response.feeStats;
 
-      const dailyFee = parseInt(graphRes.feeStats[0].feeUsd);
+    let dailyFeeUSD = BigInt(0);
+    let totalFeeUSD = BigInt(0);
 
-      const finalDailyFee = dailyFee / 1e18;
-      const totalFees = parseInt(graphRes.feeStats[0].cumulativeFeeUsd) / 1e18;
+    feeStats.forEach((fee) => {
+      dailyFeeUSD += BigInt(fee.feeUsd);
+      totalFeeUSD += BigInt(fee.cumulativeFeeUsd);
+    });
 
-      return {
-        timestamp,
-        dailyFees: finalDailyFee.toString(),
-        totalFees: totalFees.toString(),
-        //dailyRevenue: (finalDailyFee * 0.3).toString(),
-      };
+    const finalDailyFee = parseInt(dailyFeeUSD.toString()) / 1e18;
+    const finalTotalFee = parseInt(totalFeeUSD.toString()) / 1e18;
+
+    return {
+      timestamp: todaysTimestamp,
+      dailyFees: finalDailyFee.toString(),
+      totalFees: finalTotalFee.toString(),
     };
   };
 };
@@ -48,8 +59,15 @@ const graphs = (graphUrls: ChainEndpoints) => {
 const adapter: Adapter = {
   adapter: {
     [CHAIN.LINEA]: {
-      fetch: graphs(endpoints)(CHAIN.LINEA),
-      start: 1701950449,
+      fetch: fetch(endpoints[CHAIN.LINEA]),
+      start: 1709251200,
+      meta: {
+        methodology: "All treasuryFee, poolFee and keeperFee are collected",
+      },
+    },
+    [CHAIN.POLYGON]: {
+      fetch: fetch(endpoints[CHAIN.POLYGON]),
+      start: 1709251200,
       meta: {
         methodology: "All treasuryFee, poolFee and keeperFee are collected",
       },


### PR DESCRIPTION
Metavault Derivatives V2 chains updated.

🦙 Running METAVAULT-DERIVATIVES-V2 adapter 🦙
_______________________________________
Fees for 12/3/2024
_______________________________________

LINEA 👇
Backfill start time: 1/3/2024
Methodology: All treasuryFee, poolFee and keeperFee are collected
Timestamp: 1710201600 (2024-03-12T00:00:00.000Z)
Daily fees: 10
Total fees: 10


POLYGON 👇
Backfill start time: 1/3/2024
Methodology: All treasuryFee, poolFee and keeperFee are collected
Timestamp: 1710201600 (2024-03-12T00:00:00.000Z)
Daily fees: 0
Total fees: 0