### PR TITLE
Update index.ts

### DIFF
--- a/dexs/maia-v3/index.ts
+++ b/dexs/maia-v3/index.ts
@@ -26,7 +26,7 @@ const v3Graphs = getGraphDimensions({
   },
   feesPercent: {
     type: "fees",
-    ProtocolRevenue: 10, // 10% of fees are going to LPs
+    ProtocolRevenue: 10, // 10% of fees are going to protocol
     HoldersRevenue: 0,
     UserFees: 100, // User fees are 100% of collected fees
     SupplySideRevenue: 90, // 90% of fees are going to LPs


### PR DESCRIPTION
Smol typo on Unimaia V3 adapter comments #1332

Fee switch is on for Unimaia V3. 
currently states 10% -> LPers & 90% -> LPers

should b
10% -> protocol
90% -> LPers

