### PR TITLE
Added VELO and AERO LP revenue

### DIFF
--- a/adapters/types.ts
+++ b/adapters/types.ts
@@ -136,6 +136,8 @@ export type FetchResultFees = FetchResultBase & {
   totalUserFees?: FetchResponseValue;
   dailyBribesRevenue?: FetchResponseValue;
   dailyTokenTaxes?: FetchResponseValue;
+  dailyTreasuryFarmingRevenue?: FetchResponseValue;
+  totalTreasuryFarmingRevenue?: FetchResponseValue;
 };
 
 // INCENTIVES

--- a/fees/sonne-finance/helpers.ts
+++ b/fees/sonne-finance/helpers.ts
@@ -21,4 +21,27 @@ const getVeloGaugeDetails = async (
   };
 };
 
-export {  getVeloGaugeDetails };
+const getAeroGaugeDetails = async (
+  gauge: string,
+  token: string,
+  _account: string,
+  api: any
+) => {
+  // const lastEarn = await api.call({
+  //   target: gauge,
+  //   abi: "function lastEarn(address token, address account) external view returns (uint256)",
+  //   params: [token, account],
+  // });
+  const earned = await api.call({
+    target: gauge,
+    abi: "function earned(address _account) external view returns (uint256)",
+    params: [_account],
+  });
+
+  return {
+    // lastEarn: lastEarn,
+    earned: earned,
+  };
+};
+
+export {  getVeloGaugeDetails, getAeroGaugeDetails };

--- a/fees/sonne-finance/helpers.ts
+++ b/fees/sonne-finance/helpers.ts
@@ -1,22 +1,22 @@
 const getVeloGaugeDetails = async (
   gauge: string,
   token: string,
-  account: string,
+  _account: string,
   api: any
 ) => {
-  const lastEarn = await api.call({
-    target: gauge,
-    abi: "function lastEarn(address token, address account) external view returns (uint256)",
-    params: [token, account],
-  });
+  // const lastEarn = await api.call({
+  //   target: gauge,
+  //   abi: "function lastEarn(address token, address account) external view returns (uint256)",
+  //   params: [token, account],
+  // });
   const earned = await api.call({
     target: gauge,
-    abi: "function earned(address token, address account) external view returns (uint256)",
-    params: [token, account],
+    abi: "function earned(address _account) external view returns (uint256)",
+    params: [_account],
   });
 
   return {
-    lastEarn: lastEarn,
+    // lastEarn: lastEarn,
     earned: earned,
   };
 };

--- a/fees/sonne-finance/index.ts
+++ b/fees/sonne-finance/index.ts
@@ -17,8 +17,8 @@ const veAeroHolder = "0x814ae3e7Bc6B20b4Da64b76A7E66BCa0993F22A8";
 
 const methodology = {
   Fees: "Fees are calculated from borrowers' interest payments, which are determined by the Annual Percentage Yield (APY) associated with the borrowed asset.",
-  Revenue: "Revenue is derived as a percentage of collected fees, determined by the reserve factor associated with each asset.",  
-  HoldersRevenue: "All revenue and VELO/AERO LP rewards are allocated entirely to $SONNE stakers.",
+  Revenue: "Revenue is derived as a percentage of collected fees, determined by the reserve factor associated with each asset. Revenue is allocated entirely to stakers.",  
+  TreasuryFarmingRevenue: "Protocol owned LP farming rewards (VELO/AERO) are allocated entirely to $SONNE stakers.",
 }
 
 const getDailyVeloRewards = async ({ api, fromTimestamp, toTimestamp, createBalances }: FetchOptions) => {
@@ -46,18 +46,16 @@ const getDailyAeroRewards = async ({ api, fromTimestamp, toTimestamp, createBala
 
 const fetchoptimism = async (timestamp: number, chainBlocks: ChainBlocks, options: FetchOptions): Promise<FetchResultFees> => {
   const { dailyFees, dailyRevenue } = await getFees(unitrollerOP, options, {});
-  const dailyHoldersRevenue = await getDailyVeloRewards(options);
-  dailyHoldersRevenue.addBalances(dailyRevenue);
+  const dailyTreasuryFarmingRevenue = await getDailyVeloRewards(options);
 
-  return { timestamp, dailyFees, dailyRevenue, dailyHoldersRevenue };
+  return { timestamp, dailyFees, dailyRevenue, dailyTreasuryFarmingRevenue };
 };
 
 const fetchbase = async (timestamp: number, chainBlocks: ChainBlocks, options: FetchOptions): Promise<FetchResultFees> => {
   const { dailyFees, dailyRevenue } = await getFees(unitrollerBASE, options, {});
-  const dailyHoldersRevenue = await getDailyAeroRewards(options);
-  dailyHoldersRevenue.addBalances(dailyRevenue);
+  const dailyTreasuryFarmingRevenue = await getDailyAeroRewards(options);
 
-  return { timestamp, dailyFees, dailyRevenue, dailyHoldersRevenue };
+  return { timestamp, dailyFees, dailyRevenue, dailyTreasuryFarmingRevenue };
 };
 
 const adapter: Adapter = {

--- a/fees/sonne-finance/index.ts
+++ b/fees/sonne-finance/index.ts
@@ -2,54 +2,78 @@ import { Adapter, ChainBlocks, FetchOptions, FetchResultFees } from "../../adapt
 import { CHAIN } from "../../helpers/chains";
 import {
   getVeloGaugeDetails,
+  getAeroGaugeDetails
 } from "./helpers";
 import { getFees } from "../../helpers/compoundV2";
 
 const unitrollerOP = "0x60CF091cD3f50420d50fD7f707414d0DF4751C58";
 const unitrollerBASE = "0x1DB2466d9F5e10D7090E7152B68d62703a2245F0";
 const veloGauge = "0x62D9e4e99482aF8D573d5ce1ed527C96783153ad";
+const aeroGauge = "0xCbfeaED3dd9310406c046FB496C7E77f7571a808";
 const veloToken = "0x9560e827aF36c94D2Ac33a39bCE1Fe78631088Db";
+const aeroToken = "0x940181a94A35A4569E4529A3CDfB74e38FD98631";
 const veVeloHolder = "0x784b82a27029c9e114b521abcc39d02b3d1deaf2";
+const veAeroHolder = "0x814ae3e7Bc6B20b4Da64b76A7E66BCa0993F22A8";
+
+const methodology = {
+  Fees: "Fees are calculated from borrowers' interest payments, which are determined by the Annual Percentage Yield (APY) associated with the borrowed asset.",
+  Revenue: "Revenue is derived as a percentage of collected fees, determined by the reserve factor associated with each asset.",  
+  HoldersRevenue: "All revenue and VELO/AERO LP rewards are allocated entirely to $SONNE stakers.",
+}
 
 const getDailyVeloRewards = async ({ api, fromTimestamp, toTimestamp, createBalances }: FetchOptions) => {
   const balances = createBalances();
-  const { earned } = await getVeloGaugeDetails(veloGauge, veloToken, veVeloHolder, api,);
+  const { earned} = await getVeloGaugeDetails(veloGauge, veloToken, veVeloHolder, api,);
 
   // const timespan = toTimestamp - fromTimestamp;
   // const earnedTimespan = toTimestamp - lastEarn;
   // const ratio = timespan / earnedTimespan;
-  balances.add(veloToken, earned);
+  balances.add(veloToken, earned/7); // TODO: Add more accurate dailyrewards based on timestamp
+  return balances
+};
+
+const getDailyAeroRewards = async ({ api, fromTimestamp, toTimestamp, createBalances }: FetchOptions) => {
+  const balances = createBalances();
+  const { earned} = await getAeroGaugeDetails(aeroGauge, aeroToken, veAeroHolder, api,);
+
+  // const timespan = toTimestamp - fromTimestamp;
+  // const earnedTimespan = toTimestamp - lastEarn;
+  // const ratio = timespan / earnedTimespan;
+  balances.add(aeroToken, earned/7); // TODO: Add more accurate dailyrewards based on timestamp
   return balances
 };
 
 
 const fetchoptimism = async (timestamp: number, chainBlocks: ChainBlocks, options: FetchOptions): Promise<FetchResultFees> => {
   const { dailyFees, dailyRevenue } = await getFees(unitrollerOP, options, {});
-  const dailyHoldersRevenue = await getDailyVeloRewards(options)
-  dailyHoldersRevenue.addBalances(dailyRevenue)
+  const dailyHoldersRevenue = await getDailyVeloRewards(options);
+  dailyHoldersRevenue.addBalances(dailyRevenue);
 
   return { timestamp, dailyFees, dailyRevenue, dailyHoldersRevenue };
 };
 
 const fetchbase = async (timestamp: number, chainBlocks: ChainBlocks, options: FetchOptions): Promise<FetchResultFees> => {
   const { dailyFees, dailyRevenue } = await getFees(unitrollerBASE, options, {});
-  // const dailyHoldersRevenue = await getDailyVeloRewards(options)
-  // dailyHoldersRevenue.addBalances(dailyRevenue)
+  const dailyHoldersRevenue = await getDailyAeroRewards(options);
+  dailyHoldersRevenue.addBalances(dailyRevenue);
 
-  return { timestamp, dailyFees, dailyRevenue, };
+  return { timestamp, dailyFees, dailyRevenue, dailyHoldersRevenue };
 };
 
 const adapter: Adapter = {
   adapter: {
     [CHAIN.OPTIMISM]: {
       fetch: fetchoptimism as any,
-      start: 1664582400,
+      start: 1664582400, // TODO: Sort out how to backfill data?graphs
+      meta: { methodology },
     },
     [CHAIN.BASE]: {
       fetch: fetchbase as any,
-      start: 1693449471,
+      start: 1693449471, // TODO: Sort out how to backfill data?graphs
+      meta: { methodology },
     },
   },
 };
+
 
 export default adapter;

--- a/fees/sonne-finance/index.ts
+++ b/fees/sonne-finance/index.ts
@@ -7,28 +7,28 @@ import { getFees } from "../../helpers/compoundV2";
 
 const unitrollerOP = "0x60CF091cD3f50420d50fD7f707414d0DF4751C58";
 const unitrollerBASE = "0x1DB2466d9F5e10D7090E7152B68d62703a2245F0";
-// const veloGauge = "0x62D9e4e99482aF8D573d5ce1ed527C96783153ad";
-// const veloToken = "0x9560e827aF36c94D2Ac33a39bCE1Fe78631088Db";
-// const veVeloHolder = "0x784b82a27029c9e114b521abcc39d02b3d1deaf2";
+const veloGauge = "0x62D9e4e99482aF8D573d5ce1ed527C96783153ad";
+const veloToken = "0x9560e827aF36c94D2Ac33a39bCE1Fe78631088Db";
+const veVeloHolder = "0x784b82a27029c9e114b521abcc39d02b3d1deaf2";
 
-// const getDailyVeloRewards = async ({ api, fromTimestamp, toTimestamp, createBalances }: FetchOptions) => {
-//   const balances = createBalances();
-//   const { lastEarn, earned } = await getVeloGaugeDetails(veloGauge, veloToken, veVeloHolder, api,);
+const getDailyVeloRewards = async ({ api, fromTimestamp, toTimestamp, createBalances }: FetchOptions) => {
+  const balances = createBalances();
+  const { earned } = await getVeloGaugeDetails(veloGauge, veloToken, veVeloHolder, api,);
 
-//   const timespan = toTimestamp - fromTimestamp;
-//   const earnedTimespan = toTimestamp - lastEarn;
-//   const ratio = timespan / earnedTimespan;
-//   balances.add(veloToken, earned * ratio);
-//   return balances
-// };
+  // const timespan = toTimestamp - fromTimestamp;
+  // const earnedTimespan = toTimestamp - lastEarn;
+  // const ratio = timespan / earnedTimespan;
+  balances.add(veloToken, earned);
+  return balances
+};
 
 
 const fetchoptimism = async (timestamp: number, chainBlocks: ChainBlocks, options: FetchOptions): Promise<FetchResultFees> => {
   const { dailyFees, dailyRevenue } = await getFees(unitrollerOP, options, {});
-  // const dailyHoldersRevenue = await getDailyVeloRewards(options)
-  // dailyHoldersRevenue.addBalances(dailyRevenue)
+  const dailyHoldersRevenue = await getDailyVeloRewards(options)
+  dailyHoldersRevenue.addBalances(dailyRevenue)
 
-  return { timestamp, dailyFees, dailyRevenue, };
+  return { timestamp, dailyFees, dailyRevenue, dailyHoldersRevenue };
 };
 
 const fetchbase = async (timestamp: number, chainBlocks: ChainBlocks, options: FetchOptions): Promise<FetchResultFees> => {


### PR DESCRIPTION
Revenue from Protocol owned LP positions in Velodrome and Aerodrome added to Optimism and Base respectively.

TO DO: Backfill past reward data on BASE
TO DO: Query Velodrome and Aerodrome for more accurate estimations on rewards.