### PR TITLE
Add Beefy fees revenue

### DIFF
--- a/fees/beefy/index.ts
+++ b/fees/beefy/index.ts
@@ -1,0 +1,128 @@
+import { Adapter, Fetch, FetchResultFees } from '../../adapters/types';
+import { CHAIN } from '../../helpers/chains';
+import { queryDune } from '../../helpers/dune';
+
+const totalFee = 9.5;
+const strategistFee = 0.5;
+const callFee = 0.01;
+const revenueFee = totalFee - strategistFee - callFee;
+const holderShare = 36;
+const protocolShare = 64;
+
+function getDay(timestamp: number): string {
+  const date = new Date(timestamp * 1000);
+  return date.toISOString().split('T')[0];
+}
+
+interface IRevenue {
+  day: string;
+  arbitrum: number;
+  base: number;
+  polygon: number;
+  avalanche: number;
+  fantom: number;
+  optimism: number;
+  BNB: number;
+  ethereum: number;
+}
+
+const fetch = (chain: Exclude<keyof IRevenue, 'day'>): Fetch => {
+  return async (timestamp, _, {startOfDay}): Promise<FetchResultFees> => {
+    const endTimestamp = startOfDay + 86400;
+    const allRevenue: IRevenue[] = (await queryDune('3594948', {endTimestamp}));
+    const day = getDay(timestamp);
+    const entry = allRevenue.find(r => r.day === day);
+
+    if (!entry) {
+      throw new Error(`No fees found for ${day}`);
+    }
+
+    const dailyRevenue = entry[chain] || 0;
+    const dailyFees = dailyRevenue * (totalFee / revenueFee);
+    return {
+      dailyFees,
+      dailyRevenue,
+      dailyProtocolRevenue: `${dailyRevenue * (protocolShare/100)}`,
+      dailyHoldersRevenue: `${dailyRevenue * (holderShare/100)}`,
+      timestamp,
+    };
+  };
+};
+
+const methodology = {
+  Fees: `${totalFee}% of each harvest is charged as a performance fee`,
+  Revenue: `All fees except for ${strategistFee}% to strategist and variable harvest() call fee are revenue`,
+  HoldersRevenue: `${holderShare}% of revenue is distributed to holders who stake`,
+  ProtocolRevenue: `${protocolShare}% of revenue is distributed to the treasury`,
+};
+
+const adapter: Adapter = {
+  adapter: {
+    [CHAIN.ARBITRUM]: {
+      fetch: fetch('arbitrum'),
+      start: 1693958400, // 2023-09-06
+      runAtCurrTime: false,
+      meta: {
+        methodology
+      }
+    },
+   [CHAIN.BASE]: {
+      fetch: fetch('base'),
+      start: 1692921600, // 2023-08-25
+      runAtCurrTime: false,
+      meta: {
+        methodology
+      }
+    },
+    [CHAIN.POLYGON]: {
+      fetch: fetch('polygon'),
+      start: 1693958400, // 2023-09-06
+      runAtCurrTime: false,
+      meta: {
+        methodology
+      }
+    },
+    [CHAIN.AVAX]: {
+      fetch: fetch('avalanche'),
+      start: 1693958400, // 2023-09-06
+      runAtCurrTime: false,
+      meta: {
+        methodology
+      }
+    },
+    [CHAIN.FANTOM]: {
+      fetch: fetch('fantom'),
+      start: 1692921600, // 2023-08-25
+      runAtCurrTime: false,
+      meta: {
+        methodology
+      }
+    },
+    [CHAIN.OPTIMISM]: {
+      fetch: fetch('optimism'),
+      start: 1692921600, // 2023-08-25
+      runAtCurrTime: false,
+      meta: {
+        methodology
+      }
+    },
+    [CHAIN.BSC]: {
+      fetch: fetch('BNB'),
+      start: 1692921600, // 2023-08-25
+      runAtCurrTime: false,
+      meta: {
+        methodology
+      }
+    },
+    [CHAIN.ETHEREUM]: {
+      fetch: fetch('ethereum'),
+      start: 1698105600, // 2023-10-24
+      runAtCurrTime: false,
+      meta: {
+        methodology
+      }
+    },
+  },
+  isExpensiveAdapter: true,
+};
+export default adapter;


### PR DESCRIPTION
Dune query: https://dune.com/queries/3594948

Note: `queryDune` stores the executions by query id, so this adapter will break if more than one day is queried in the same process.

```
> yarn test fees beefy          
yarn run v1.22.19
$ yarn run update-submodules && ts-node --transpile-only cli/testAdapter.ts fees beefy
$ git submodule update --init --recursive --remote --merge
🦙 Running BEEFY adapter 🦙
_______________________________________
Fees for 4/4/2024
_______________________________________

waiting for query id 3594948 to complete...
waiting for query id 3594948 to complete...
waiting for query id 3594948 to complete...
ARBITRUM 👇
Backfill start time: 6/9/2023
Daily fees: 2.59 k
└─ Methodology: 9.5% of each harvest is charged as a performance fee
Daily revenue: 2.45 k
└─ Methodology: All fees except for 0.5% to strategist and variable harvest() call fee are revenue
Daily protocol revenue: 1.57 k
└─ Methodology: 64% of revenue is distributed to the treasury
Daily holders revenue: 881
└─ Methodology: 36% of revenue is distributed to holders who stake
Timestamp: 1712275199 (2024-04-04T23:59:59.000Z)


BASE 👇
Backfill start time: 25/8/2023
Daily fees: 15.23 k
└─ Methodology: 9.5% of each harvest is charged as a performance fee
Daily revenue: 14.42 k
└─ Methodology: All fees except for 0.5% to strategist and variable harvest() call fee are revenue
Daily protocol revenue: 9.23 k
└─ Methodology: 64% of revenue is distributed to the treasury
Daily holders revenue: 5.19 k
└─ Methodology: 36% of revenue is distributed to holders who stake
Timestamp: 1712275199 (2024-04-04T23:59:59.000Z)


POLYGON 👇
Backfill start time: 6/9/2023
Daily fees: 355
└─ Methodology: 9.5% of each harvest is charged as a performance fee
Daily revenue: 336
└─ Methodology: All fees except for 0.5% to strategist and variable harvest() call fee are revenue
Daily protocol revenue: 215
└─ Methodology: 64% of revenue is distributed to the treasury
Daily holders revenue: 121
└─ Methodology: 36% of revenue is distributed to holders who stake
Timestamp: 1712275199 (2024-04-04T23:59:59.000Z)


AVAX 👇
Backfill start time: 6/9/2023
Daily fees: 1.06 k
└─ Methodology: 9.5% of each harvest is charged as a performance fee
Daily revenue: 1.00 k
└─ Methodology: All fees except for 0.5% to strategist and variable harvest() call fee are revenue
Daily protocol revenue: 641
└─ Methodology: 64% of revenue is distributed to the treasury
Daily holders revenue: 360
└─ Methodology: 36% of revenue is distributed to holders who stake
Timestamp: 1712275199 (2024-04-04T23:59:59.000Z)


FANTOM 👇
Backfill start time: 25/8/2023
Daily fees: 1.59 k
└─ Methodology: 9.5% of each harvest is charged as a performance fee
Daily revenue: 1.51 k
└─ Methodology: All fees except for 0.5% to strategist and variable harvest() call fee are revenue
Daily protocol revenue: 966
└─ Methodology: 64% of revenue is distributed to the treasury
Daily holders revenue: 543
└─ Methodology: 36% of revenue is distributed to holders who stake
Timestamp: 1712275199 (2024-04-04T23:59:59.000Z)


OPTIMISM 👇
Backfill start time: 25/8/2023
Daily fees: 5.99 k
└─ Methodology: 9.5% of each harvest is charged as a performance fee
Daily revenue: 5.67 k
└─ Methodology: All fees except for 0.5% to strategist and variable harvest() call fee are revenue
Daily protocol revenue: 3.63 k
└─ Methodology: 64% of revenue is distributed to the treasury
Daily holders revenue: 2.04 k
└─ Methodology: 36% of revenue is distributed to holders who stake
Timestamp: 1712275199 (2024-04-04T23:59:59.000Z)


BSC 👇
Backfill start time: 25/8/2023
Daily fees: 0
└─ Methodology: 9.5% of each harvest is charged as a performance fee
Daily revenue: 0
└─ Methodology: All fees except for 0.5% to strategist and variable harvest() call fee are revenue
Daily protocol revenue: 0
└─ Methodology: 64% of revenue is distributed to the treasury
Daily holders revenue: 0
└─ Methodology: 36% of revenue is distributed to holders who stake
Timestamp: 1712275199 (2024-04-04T23:59:59.000Z)


ETHEREUM 👇
Backfill start time: 24/10/2023
Daily fees: 0
└─ Methodology: 9.5% of each harvest is charged as a performance fee
Daily revenue: 0
└─ Methodology: All fees except for 0.5% to strategist and variable harvest() call fee are revenue
Daily protocol revenue: 0
└─ Methodology: 64% of revenue is distributed to the treasury
Daily holders revenue: 0
└─ Methodology: 36% of revenue is distributed to holders who stake
Timestamp: 1712275199 (2024-04-04T23:59:59.000Z)
```