### PR TITLE
Add Grizzly Trade Derivatives V2 adapters.

### DIFF
--- a/dexs/grizzly-trade-derivatives-v2/index.ts
+++ b/dexs/grizzly-trade-derivatives-v2/index.ts
@@ -1,0 +1,69 @@
+import request, { gql } from "graphql-request";
+import { FetchResultVolume, SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import { getTimestampAtStartOfDayUTC } from "../../utils/date";
+
+const grizzlyPerpsV2Subgraph =
+  "https://api.studio.thegraph.com/query/55804/bnb-trade/version/latest";
+
+interface IReferralRecord {
+  volume: string; // Assuming volume is a string that represents a number
+  timestamp: number;
+}
+
+interface IVolumeStat {
+  cumulativeVolumeUsd: string;
+  volumeUsd: string;
+  id: string;
+}
+
+const fetch = () => {
+  return async (timestamp: number): Promise<FetchResultVolume> => {
+    const todaysTimestamp = getTimestampAtStartOfDayUTC(timestamp);
+
+    const graphQuery = gql`
+      query MyQuery {
+        volumeStats(where: {timestamp: ${todaysTimestamp}, period: "daily"}) {
+          cumulativeVolumeUsd
+          id
+          volumeUsd
+        }
+      }
+    `;
+
+    const response = await request(grizzlyPerpsV2Subgraph, graphQuery);
+    const volumeStats: IVolumeStat[] = response.volumeStats;
+
+    let dailyVolumeUSD = BigInt(0);
+
+    volumeStats.forEach((vol) => {
+      dailyVolumeUSD += BigInt(vol.volumeUsd);
+    });
+
+    const finalDailyVolume = parseInt(dailyVolumeUSD.toString()) / 1e18;
+
+    return {
+      dailyVolume: finalDailyVolume.toString(),
+      timestamp: todaysTimestamp,
+    };
+  };
+};
+
+const methodology = {
+  dailyVolume:
+    "Total cumulativeVolumeUsd for specified chain for the given day",
+};
+
+const adapter: SimpleAdapter = {
+  adapter: {
+    [CHAIN.BSC]: {
+      fetch: fetch(),
+      start: async () => 1706832000,
+      meta: {
+        methodology,
+      },
+    },
+  },
+};
+
+export default adapter;

--- a/fees/grizzly-trade-derivatives-v2.ts
+++ b/fees/grizzly-trade-derivatives-v2.ts
@@ -1,0 +1,60 @@
+import { Chain } from "@defillama/sdk/build/general";
+import { gql, request } from "graphql-request";
+import type { ChainEndpoints } from "../adapters/types";
+import { Adapter } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+
+import { getTimestampAtStartOfDayUTC } from "../utils/date";
+
+const endpoints = {
+  [CHAIN.BSC]:
+    "https://api.studio.thegraph.com/query/55804/bnb-trade/version/latest",
+};
+
+const graphs = (graphUrls: ChainEndpoints) => {
+  return (chain: Chain) => {
+    return async (timestamp: number) => {
+      const todaysTimestamp = getTimestampAtStartOfDayUTC(timestamp);
+      const period = "daily";
+
+      const graphQuery = gql`{
+        feeStats(where: {timestamp: ${todaysTimestamp}, period: "${period}"}) {
+          id
+          timestamp
+          period
+          cumulativeFee
+          cumulativeFeeUsd
+          feeUsd
+        }
+      }`;
+
+      const graphRes = await request(graphUrls[chain], graphQuery);
+
+      const dailyFee = parseInt(graphRes.feeStats[0].feeUsd);
+
+      const finalDailyFee = dailyFee / 1e18;
+      const totalFees = parseInt(graphRes.feeStats[0].cumulativeFeeUsd) / 1e18;
+
+      return {
+        timestamp,
+        dailyFees: finalDailyFee.toString(),
+        totalFees: totalFees.toString(),
+        //dailyRevenue: (finalDailyFee * 0.3).toString(),
+      };
+    };
+  };
+};
+
+const adapter: Adapter = {
+  adapter: {
+    [CHAIN.BSC]: {
+      fetch: graphs(endpoints)(CHAIN.BSC),
+      start: async () => 1706832000,
+      meta: {
+        methodology: "All treasury, pool and keeper fees are collected",
+      },
+    },
+  },
+};
+
+export default adapter;


### PR DESCRIPTION
🦙 Running GRIZZLY-TRADE-DERIVATIVES-V2 adapter 🦙
_______________________________________
Dexs for 21/4/2024
_______________________________________

BSC 👇
Backfill start time: 22/4/2024
Daily volume: 823
Timestamp: 1713657600 (2024-04-21T00:00:00.000Z)

🦙 Running GRIZZLY-TRADE-DERIVATIVES-V2 adapter 🦙
_______________________________________
Fees for 21/4/2024
_______________________________________

BSC 👇
Backfill start time: 22/4/2024
Methodology: All treasury, pool and keeper fees are collected
Timestamp: 1713743999 (2024-04-21T23:59:59.000Z)
Daily fees: 1
Total fees: 416