### PR TITLE
Add LineHub V3 Volume Adapter

### DIFF
--- a/dexs/linehub-v3/index.ts
+++ b/dexs/linehub-v3/index.ts
@@ -1,0 +1,64 @@
+import { Chain } from "@defillama/sdk/build/general";
+import { CHAIN } from "../../helpers/chains";
+import { getGraphDimensions } from "../../helpers/getUniSubgraph";
+import { BreakdownAdapter } from "../../adapters/types";
+
+const endpointsV3 = {
+  [CHAIN.LINEA]:
+    "https://api.studio.thegraph.com/query/55804/linehub-v3/version/latest",
+};
+
+const v3Graphs = getGraphDimensions({
+  graphUrls: endpointsV3,
+  totalVolume: {
+    factory: "factories",
+    field: "totalVolumeUSD",
+  },
+  dailyVolume: {
+    factory: "uniswapDayData",
+    field: "volumeUSD",
+  },
+  feesPercent: {
+    type: "fees",
+    ProtocolRevenue: 0,
+    HoldersRevenue: 0,
+    UserFees: 100, // User fees are 100% of collected fees
+    SupplySideRevenue: 100, // 100% of fees are going to LPs
+    Revenue: 0, // Set revenue to 0 as protocol fee is not set for all pools for now
+  },
+});
+
+const startTimeV3: { [key: string]: number } = {
+  [CHAIN.LINEA]: 1713398400, // Thursday, April 18, 2024 12:00:00 AM
+};
+
+const v3 = Object.keys(endpointsV3).reduce(
+  (acc, chain) => ({
+    ...acc,
+    [chain]: {
+      fetch: v3Graphs(chain as Chain),
+      start: startTimeV3[chain],
+      meta: {
+        methodology: {
+          Fees: "Each pool charge between 0.01% to 1% fee",
+          UserFees: "Users pay between 0.01% to 1% fee",
+          Revenue: "0 to 1/4 of the fee goes to treasury",
+          HoldersRevenue: "None",
+          ProtocolRevenue: "Treasury receives a share of the fees",
+          SupplySideRevenue:
+            "Liquidity providers get most of the fees of all trades in their pools",
+        },
+      },
+    },
+  }),
+  {}
+);
+
+const adapter: BreakdownAdapter = {
+  version: 2,
+  breakdown: {
+    v3: v3,
+  },
+};
+
+export default adapter;


### PR DESCRIPTION
LineHub V3 volume adapter. 

🦙 Running LINEHUB-V3 adapter 🦙
_______________________________________
Dexs for 22/5/2024
_______________________________________

Version -> V3
---------
LINEA 👇
Backfill start time: 18/4/2024
Timestamp: 1716389625 (2024-05-22T14:53:45.000Z)
Block: 4.78 M
Total volume: 555.43 k
Daily volume: 10.76 k
Daily fees: 32