### PR TITLE
Ethena Double Counting of Inflows

### DIFF
--- a/fees/ethena.ts
+++ b/fees/ethena.ts
@@ -2,13 +2,15 @@ import { FetchOptions, SimpleAdapter } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
 import { queryIndexer } from "../helpers/indexer";
 
-const mint_event = 'event Mint( address indexed minter,address indexed benefactor,address indexed beneficiary,address collateral_asset,uint256 collateral_amount,uint256 usde_amount)';
+const mint_event =
+  "event Mint( address indexed minter,address indexed benefactor,address indexed beneficiary,address collateral_asset,uint256 collateral_amount,uint256 usde_amount)";
 const fetch = async (options: FetchOptions) => {
   const logs = await options.getLogs({
     eventAbi: mint_event,
-    target: '0x2cc440b721d2cafd6d64908d6d8c4acc57f8afc3',
+    target: "0x2cc440b721d2cafd6d64908d6d8c4acc57f8afc3",
   });
-  const in_flow = await queryIndexer(`
+  const in_flow = await queryIndexer(
+    `
   SELECT
     '0x' || encode(data, 'hex') AS data,
     '0x' || encode(contract_address, 'hex') AS token
@@ -17,11 +19,15 @@ const fetch = async (options: FetchOptions) => {
   WHERE
     block_number > 18637861
     AND topic_0 = '\\xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef'
+    AND topic_1 NOT IN ('\\x00000000000000000000000071e4f98e8f20c88112489de3dded4489802a3a87', '\\x0000000000000000000000002b5ab59163a6e93b4486f6055d33ca4a115dd4d5')
     AND topic_2 in ('\\x00000000000000000000000071e4f98e8f20c88112489de3dded4489802a3a87', '\\x0000000000000000000000002b5ab59163a6e93b4486f6055d33ca4a115dd4d5')
     AND block_time BETWEEN llama_replace_date_range;
-`, options);
+`,
+    options
+  );
 
-const out_flow = await queryIndexer(`
+  const out_flow = await queryIndexer(
+    `
   SELECT
     '0x' || encode(data, 'hex') AS data,
     '0x' || encode(contract_address, 'hex') AS token
@@ -32,7 +38,9 @@ const out_flow = await queryIndexer(`
     AND topic_0 = '\\xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef'
     AND topic_2 in ('\\x000000000000000000000000f2fa332bd83149c66b09b45670bce64746c6b439')
     AND block_time BETWEEN llama_replace_date_range;
-`, options);
+`,
+    options
+  );
   const dailyFeesInflow = options.createBalances();
   const supplyRewards = options.createBalances();
 
@@ -49,23 +57,23 @@ const out_flow = await queryIndexer(`
     dailyFeesMint.add(log.collateral_asset, log.collateral_amount);
   });
 
-  dailyFeesMint.resizeBy(0.001)
+  dailyFeesMint.resizeBy(0.001);
   dailyFeesMint.addBalances(dailyFeesInflow);
-  const revenue = dailyFeesMint.clone()
-  revenue.subtract(supplyRewards)
+  const revenue = dailyFeesMint.clone();
+  revenue.subtract(supplyRewards);
   return {
     dailyFees: dailyFeesMint,
     dailyRevenue: revenue,
-  }
-}
+  };
+};
 
 const adapters: SimpleAdapter = {
   version: 2,
   adapter: {
     [CHAIN.ETHEREUM]: {
       fetch: fetch,
-      start: 1700784000
-    }
-  }
-}
-export default adapters
+      start: 1700784000,
+    },
+  },
+};
+export default adapters;


### PR DESCRIPTION
# Fix Double Counting of Inflows

## Description

There seems to be an issue of double counting revenue in the calculation of inflows for Ethena's fees. The current formula for revenue is:

```
(stables_from_mint + basis_funding_from_copper) - stable_outflow_redeem
```

Inflows are identified from any transfer event leading to either:

- [Main Funding Rate Revenue Safe](https://etherscan.io/address/0x71e4f98e8f20c88112489de3dded4489802a3a87#tokentxns)
- [Secondary Funding Rate Revenue Safe](https://etherscan.io/address/0x2b5ab59163a6e93b4486f6055d33ca4a115dd4d5#tokentxns)

Inflows appear to be coming from Copper for funding rate reimbursement into the first or second addresses. Sometimes, the first address sends funds to the second address.

Outflows are tracked from:

- [Outflows Address](https://etherscan.io/address/0xf2fa332bd83149c66b09b45670bce64746c6b439#tokentxns)

## Problem

The current implementation may double count inflows when funds are transferred between the two revenue safes. This results in an inflated revenue calculation. 

### Example

- **In from Copper:** [Transaction](https://etherscan.io/tx/0xea5d9b35265f0d344d427c30a78bda59ef442d31f3a104537cc0a8a540fa3983)
- **Out to Second Safe and for Rewards:** [Transaction](https://etherscan.io/tx/0xcd2cb222664ff722e81f1966d43e92327bba9cf78ed5f7d2548185b6ad51f46b)

## Solution

Update the query to ensure `topic_1` is not either address in `topic_2`, preventing double counting when transferring between safes.

### Updated Query

```sql
const in_flow = await queryIndexer(`
  SELECT
    '0x' || encode(data, 'hex') AS data,
    '0x' || encode(contract_address, 'hex') AS token
  FROM
    ethereum.event_logs
  WHERE
    block_number > 18637861
    AND topic_0 = '\\xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef'
    AND topic_2 IN ('\\x00000000000000000000000071e4f98e8f20c88112489de3dded4489802a3a87', '\\x0000000000000000000000002b5ab59163a6e93b4486f6055d33ca4a115dd4d5')
    AND topic_1 NOT IN ('\\x00000000000000000000000071e4f98e8f20c88112489de3dded4489802a3a87', '\\x0000000000000000000000002b5ab59163a6e93b4486f6055d33ca4a115dd4d5')
    AND block_time BETWEEN llama_replace_date_range;
`, options);
```

This change will ensure that inflows are only counted when they are not internal transfers between the two safes.