### PR TITLE
Add Base network to Kinetix V3 dexs adapter.

### DIFF
--- a/dexs/kinetix-v3/index.ts
+++ b/dexs/kinetix-v3/index.ts
@@ -6,6 +6,8 @@ import { BreakdownAdapter } from "../../adapters/types";
 const endpointsV3 = {
   [CHAIN.KAVA]:
     "https://kava-graph-node.metavault.trade/subgraphs/name/kinetixfi/v3-subgraph",
+  [CHAIN.BASE]:
+    "https://api.studio.thegraph.com/query/55804/kinetixfi-base-v3/version/latest",
 };
 
 const v3Graphs = getGraphDimensions({
@@ -30,6 +32,7 @@ const v3Graphs = getGraphDimensions({
 
 const startTimeV3: { [key: string]: number } = {
   [CHAIN.KAVA]: 1693267200,
+  [CHAIN.BASE]: 1715126400,
 };
 
 const v3 = Object.keys(endpointsV3).reduce(


### PR DESCRIPTION
BASE 👇
Backfill start time: 8/5/2024
Timestamp: 1716798162 (2024-05-27T08:22:42.000Z)
Block: 15.00 M
Total volume: 1.61 k
Daily volume: 137
Daily fees: 0