### PR TITLE
colony: fees/revenue from staking and dex & users

### DIFF
--- a/fees/colony/dex.ts
+++ b/fees/colony/dex.ts
@@ -1,0 +1,42 @@
+import { getGraphDimensions } from "../../helpers/getUniSubgraph"
+import { FetchOptions, FetchResultGeneric } from "../../adapters/types";
+
+export async function dexRevenue(
+  options: FetchOptions,
+  dexSubgraphEndpoint: string,
+  DexFactoryContract: string,
+): Promise<FetchResultGeneric> {
+
+  const endpoints = {
+    [options.chain]: dexSubgraphEndpoint,
+  };
+
+  const VOLUME_USD = "volumeUSD";
+  const FEES_USD = "feesUSD";
+
+  const v2Graph = getGraphDimensions({
+    graphUrls: endpoints,
+    totalVolume: {
+      factory: "factories",
+      field: VOLUME_USD,
+    },
+    dailyVolume: {
+      factory: "dayData",
+      field: VOLUME_USD,
+    },
+    totalFees: {
+      factory: "factories",
+      field: FEES_USD,
+    },
+    dailyFees: {
+      factory: "dayData",
+      field: FEES_USD,
+    },
+    feesPercent: {
+      type: "fees",
+      ProtocolRevenue: 100, // Fees going back to liquidity providers
+    }
+  });
+
+  return v2Graph(options.chain)(options)
+}

--- a/fees/colony/index.ts
+++ b/fees/colony/index.ts
@@ -1,0 +1,84 @@
+import { Balances } from "@defillama/sdk";
+import { Adapter, FetchOptions, FetchResultV2, FetchResponseValue } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+
+import { stakingRevenue } from "./staking";
+import { dexRevenue } from "./dex";
+
+const { request, gql } = require("graphql-request");
+
+const ColonyGovernanceToken = "0xec3492a2508DDf4FDc0cD76F31f340b30d1793e6";
+const DexFactoryContract = "0x814ebf333bdaf1d2d364c22a1e2400a812f1f850"
+const StakingV3Contract = "0x62685d3EAacE96D6145D35f3B7540d35f482DE5b"
+
+const stakingSubgraphEndpoint = 'https://graph.colonylab.io/subgraphs/name/colony/stakingV3-avalanche-production';
+const dexSubgraphEndpoint = 'https://graph.colonylab.io/subgraphs/name/colony-dex/exchange-avalanche-production';
+
+const methodology = {
+    HoldersRevenue: "Staking and Unstaking fees are collected by the protocol and distributed back to the stakers.",
+    ProtocolRevenue: "Colony DEX distribute swap fees back to liquidity providers."
+}
+
+const convertToNumber = async (value: FetchResponseValue): Promise<number> => {
+  if (typeof value === 'string') {
+    return Number(value);
+  }
+  if (typeof value === 'number') {
+    return value;
+  }
+  if (value instanceof Balances) {
+    return await value.getUSDValue();
+  }
+  return 0;
+};
+
+async function fetch(options: FetchOptions): Promise<FetchResultV2> {
+  const { createBalances, startTimestamp } = options;
+
+  let totalHoldersRevenue = createBalances();
+  let dailyHoldersRevenue = createBalances();
+
+  const stakingResult = await stakingRevenue(
+    options,
+    stakingSubgraphEndpoint,
+    ColonyGovernanceToken,
+    StakingV3Contract
+  );
+
+  const dexResult = await dexRevenue(
+    options,
+    dexSubgraphEndpoint,
+    DexFactoryContract
+  );
+
+  const mergedResult = {
+    timestamp: dexResult.timestamp,
+    block: dexResult.block,
+    totalVolume: dexResult.totalVolume,
+    dailyVolume: dexResult.dailyVolume,
+
+    totalFees: await convertToNumber(dexResult.totalFees) + stakingResult.totalFees,
+    dailyFees: await convertToNumber(dexResult.dailyFees) + stakingResult.dailyFees,
+
+    totalHoldersRevenue: stakingResult.totalHoldersRevenue,
+    dailyHoldersRevenue: stakingResult.dailyHoldersRevenue,
+    dailyProtocolRevenue: dexResult["dailyProtocolRevenue"],
+    totalProtocolRevenue: dexResult["totalProtocolRevenue"],
+  };
+  return mergedResult;
+}
+
+const adapter: Adapter = {
+  version: 2,
+  adapter: {
+    [CHAIN.AVAX]: {
+      fetch,
+      start: 1711370069,
+      meta: {
+          methodology
+      }
+    },
+  }
+}
+
+export default adapter;

--- a/fees/colony/staking.ts
+++ b/fees/colony/staking.ts
@@ -1,0 +1,76 @@
+import { Balances } from "@defillama/sdk";
+import { FetchOptions } from "../../adapters/types";
+
+const { request, gql } = require("graphql-request");
+
+export interface StakingRevenue {
+  totalFees: number;
+  dailyFees: number;
+  totalHoldersRevenue: number;
+  dailyHoldersRevenue: number;
+}
+
+interface ITotalStakeFees {
+  totalStakeFees: string;
+  totalUnstakeFees: string;
+}
+
+interface IDailyStakeFees {
+  stakeFees: string;
+  unstakeFees: string;
+}
+
+interface IGraphStakeResponse {
+  metrics: ITotalStakeFees[];
+  dailyMetrics: IDailyStakeFees[];
+}
+
+const queryStakingFeesMetrics = gql
+`query fees($date: Int!) {
+  metrics {
+    totalStakeFees
+    totalUnstakeFees
+  }
+  dailyMetrics(where: {date: $date}) {
+    unstakeFees
+    stakeFees
+  }
+}`;
+
+export async function stakingRevenue(
+  options: FetchOptions,
+  stakingSubgraphEndpoint: string,
+  ColonyGovernanceToken: string,
+  StakingV3Contract: string,
+): Promise<StakingRevenue> {
+  const { createBalances, startTimestamp } = options;
+
+  let totalHoldersRevenue = createBalances();
+  let dailyHoldersRevenue = createBalances();
+
+  const day = Math.floor(startTimestamp / 86400)
+  const date = day * 86400
+
+  try {
+    const res: IGraphStakeResponse = await request(stakingSubgraphEndpoint, queryStakingFeesMetrics, { date });
+
+    if (res.metrics && res.metrics.length) {
+      totalHoldersRevenue.add(ColonyGovernanceToken, res.metrics[0].totalStakeFees);
+      totalHoldersRevenue.add(ColonyGovernanceToken, res.metrics[0].totalUnstakeFees);
+    }
+
+    if (res.dailyMetrics && res.dailyMetrics.length) {
+      dailyHoldersRevenue.add(ColonyGovernanceToken, res.dailyMetrics[0].stakeFees);
+      dailyHoldersRevenue.add(ColonyGovernanceToken, res.dailyMetrics[0].unstakeFees);
+    }
+  } catch (e) {
+    console.error(e);
+  }
+
+  return {
+    totalFees: await totalHoldersRevenue.getUSDValue(),
+    dailyFees: await dailyHoldersRevenue.getUSDValue(),
+    totalHoldersRevenue: await totalHoldersRevenue.getUSDValue(),
+    dailyHoldersRevenue: await dailyHoldersRevenue.getUSDValue(),
+  }
+}

--- a/users/routers/routerAddresses.ts
+++ b/users/routers/routerAddresses.ts
@@ -2855,6 +2855,22 @@ export default ([
                 "0x858646372cc42e1a627fce94aa7a7033e7cf075a"
             ]
         }
+    },
+    {
+        "id":"1004",
+        "name":"Colony",
+        "addresses":{
+            "avax":[
+                "0xA2e7ab89A2C59818E1ecD925E718a9d63889A131", // Router
+                "0x2aC45f92EABaa8DCB2eA1807A659a1393C3947d0", // Masterchef
+                "0x3Db497a9783eBbEda6950d4f1911B3a27D79C071", // AntTiers
+                "0x62685d3EAacE96D6145D35f3B7540d35f482DE5b", // StakingV3
+                "0x62B38293896e040e36fE5345F9D30DbFd75C04B9", // EarlyStageManager
+                "0x17CE2A490CB260b48891aDE019a86f4B4a5520d4", // Comments
+                "0xac59c21ADfdDb1E56A959dD60a08c07AaED2F3Ba", // Upvotes
+                "0xd071AA359ed1b7776A12c8329f2C337aBED157D7", // Analysis
+            ]
+        }
     }
     
 ] as ProtocolAddresses[]).filter(isAddressesUsable)


### PR DESCRIPTION
This PR adds daily and total fee and revenue from both Colony staking and the Colony DEX (a Uniswap V2 fork). Specifically:
- **Staking data:** staking and unstaking fees are collected by the protocol and distributed back to the stakers, reflected as holders' revenue 
- **DEX data:** protocol revenue as Colony DEX distributes swap fees back to liquidity providers.
- Protocol addresses are applied to gather user-related information like active addresses, transactions, gas used (not sure it will work).

I had some trouble merging both sources but managed to do it. If you know a better method, please let me know.

Thank you