### PR TITLE
Stride Adapter - Dymensions

### DIFF
--- a/fees/stride.ts
+++ b/fees/stride.ts
@@ -61,6 +61,12 @@ const adapter: Adapter = {
       start: 0,
       meta,
     },
+    dymension: {
+      fetch: fetch("dymension"),
+      runAtCurrTime: true,
+      start: 0,
+      meta,
+    },
     juno: {
       fetch: fetch("juno"),
       runAtCurrTime: true,


### PR DESCRIPTION
This pull request adds `Dymensions`' daily fees and revenues to Stride's adapter.

Feel free to ask if you have any more questions!

Here's the output of the test: 
```bash
$ npm test fees stride

> adapters@1.0.0 test
> ts-node --transpile-only cli/testAdapter.ts fees stride

🦙 Running STRIDE adapter 🦙
_______________________________________
Fees for 30/5/2024
_______________________________________

COSMOS 👇
Backfill start time not defined
Timestamp: 1717113599 (2024-05-30T23:59:59.000Z)
Daily fees: 10.65 k
└─ Methodology: Fees are staking rewards earned by tokens staked with Stride. They are measured across Stride's LSD tokens' yields and converted to USD terms.
Daily revenue: 1.18 k
└─ Methodology: Stride collects 10% of liquid staked assets's staking rewards. These fees are measured across Stride's LSD tokens' yields and converted to USD terms.


CELESTIA 👇
Backfill start time not defined
Timestamp: 1717113599 (2024-05-30T23:59:59.000Z)
Daily fees: 8.06 k
└─ Methodology: Fees are staking rewards earned by tokens staked with Stride. They are measured across Stride's LSD tokens' yields and converted to USD terms.
Daily revenue: 896
└─ Methodology: Stride collects 10% of liquid staked assets's staking rewards. These fees are measured across Stride's LSD tokens' yields and converted to USD terms.


OSMOSIS 👇
Backfill start time not defined
Timestamp: 1717113599 (2024-05-30T23:59:59.000Z)
Daily fees: 6.05 k
└─ Methodology: Fees are staking rewards earned by tokens staked with Stride. They are measured across Stride's LSD tokens' yields and converted to USD terms.
Daily revenue: 673
└─ Methodology: Stride collects 10% of liquid staked assets's staking rewards. These fees are measured across Stride's LSD tokens' yields and converted to USD terms.


DYDX 👇
Backfill start time not defined
Timestamp: 1717113599 (2024-05-30T23:59:59.000Z)
Daily fees: 10.38 k
└─ Methodology: Fees are staking rewards earned by tokens staked with Stride. They are measured across Stride's LSD tokens' yields and converted to USD terms.
Daily revenue: 1.15 k
└─ Methodology: Stride collects 10% of liquid staked assets's staking rewards. These fees are measured across Stride's LSD tokens' yields and converted to USD terms.


DYMENSION 👇
Backfill start time not defined
Timestamp: 1717113599 (2024-05-30T23:59:59.000Z)
Daily fees: 161
└─ Methodology: Fees are staking rewards earned by tokens staked with Stride. They are measured across Stride's LSD tokens' yields and converted to USD terms.
Daily revenue: 18
└─ Methodology: Stride collects 10% of liquid staked assets's staking rewards. These fees are measured across Stride's LSD tokens' yields and converted to USD terms.


JUNO 👇
Backfill start time not defined
Timestamp: 1717113599 (2024-05-30T23:59:59.000Z)
Daily fees: 282
└─ Methodology: Fees are staking rewards earned by tokens staked with Stride. They are measured across Stride's LSD tokens' yields and converted to USD terms.
Daily revenue: 31
└─ Methodology: Stride collects 10% of liquid staked assets's staking rewards. These fees are measured across Stride's LSD tokens' yields and converted to USD terms.


STARGAZE 👇
Backfill start time not defined
Timestamp: 1717113599 (2024-05-30T23:59:59.000Z)
Daily fees: 263
└─ Methodology: Fees are staking rewards earned by tokens staked with Stride. They are measured across Stride's LSD tokens' yields and converted to USD terms.
Daily revenue: 29
└─ Methodology: Stride collects 10% of liquid staked assets's staking rewards. These fees are measured across Stride's LSD tokens' yields and converted to USD terms.


TERRA 👇
Backfill start time not defined
Timestamp: 1717113599 (2024-05-30T23:59:59.000Z)
Daily fees: 53
└─ Methodology: Fees are staking rewards earned by tokens staked with Stride. They are measured across Stride's LSD tokens' yields and converted to USD terms.
Daily revenue: 6
└─ Methodology: Stride collects 10% of liquid staked assets's staking rewards. These fees are measured across Stride's LSD tokens' yields and converted to USD terms.


EVMOS 👇
Backfill start time not defined
Timestamp: 1717113599 (2024-05-30T23:59:59.000Z)
Daily fees: 292
└─ Methodology: Fees are staking rewards earned by tokens staked with Stride. They are measured across Stride's LSD tokens' yields and converted to USD terms.
Daily revenue: 32
└─ Methodology: Stride collects 10% of liquid staked assets's staking rewards. These fees are measured across Stride's LSD tokens' yields and converted to USD terms.


INJECTIVE 👇
Backfill start time not defined
Timestamp: 1717113599 (2024-05-30T23:59:59.000Z)
Daily fees: 316
└─ Methodology: Fees are staking rewards earned by tokens staked with Stride. They are measured across Stride's LSD tokens' yields and converted to USD terms.
Daily revenue: 35
└─ Methodology: Stride collects 10% of liquid staked assets's staking rewards. These fees are measured across Stride's LSD tokens' yields and converted to USD terms.


UMEE 👇
Backfill start time not defined
Timestamp: 1717113599 (2024-05-30T23:59:59.000Z)
Daily fees: 30
└─ Methodology: Fees are staking rewards earned by tokens staked with Stride. They are measured across Stride's LSD tokens' yields and converted to USD terms.
Daily revenue: 3
└─ Methodology: Stride collects 10% of liquid staked assets's staking rewards. These fees are measured across Stride's LSD tokens' yields and converted to USD terms.


COMDEX 👇
Backfill start time not defined
Timestamp: 1717113599 (2024-05-30T23:59:59.000Z)
Daily fees: 14
└─ Methodology: Fees are staking rewards earned by tokens staked with Stride. They are measured across Stride's LSD tokens' yields and converted to USD terms.
Daily revenue: 2
└─ Methodology: Stride collects 10% of liquid staked assets's staking rewards. These fees are measured across Stride's LSD tokens' yields and converted to USD terms.
```