### PR TITLE
Use .3% address instead of 1% for Thruster

### DIFF
--- a/protocols/thruster-v2.ts
+++ b/protocols/thruster-v2.ts
@@ -2,6 +2,6 @@ import { uniV2Exports } from "../helpers/uniswap";
 
 export default uniV2Exports({ 
   blast: {
-    factory: '0x37836821a2c03c171fB1a595767f4a16e2b93Fc4',
+    factory: '0xb4A7D971D0ADea1c73198C97d7ab3f9CE4aaFA13',
   }
 })


### PR DESCRIPTION
- Uses the 0.3% V2 Factory address instead of 1% address
- Did not see a similar function to merge exports within the `dimension-adapters` repo like https://github.com/DefiLlama/DefiLlama-Adapters/blob/main/projects/helper/utils.js#L120
- Ran test according to docs
![dimadap](https://github.com/DefiLlama/dimension-adapters/assets/153983957/c02d8c1f-70f5-4e18-a936-444466eef75a)
