### PR TITLE
Add LineHub Perps dexs and fees adapter.

### DIFF
--- a/dexs/linehub-perps/index.ts
+++ b/dexs/linehub-perps/index.ts
@@ -1,0 +1,68 @@
+import request, { gql } from "graphql-request";
+import { Adapter, ChainEndpoints, FetchV2 } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import { getTimestampAtStartOfDayUTC } from "../../utils/date";
+
+const endpoints = {
+  [CHAIN.LINEA]:
+    "https://api.studio.thegraph.com/query/55804/linehub-trade/version/latest",
+};
+
+interface IVolumeStat {
+  cumulativeVolumeUsd: string;
+  volumeUsd: string;
+  id: string;
+}
+
+const graphs = (graphUrls: ChainEndpoints) => {
+  const fetch: FetchV2 = async ({ chain, startTimestamp }) => {
+    const todaysTimestamp = getTimestampAtStartOfDayUTC(startTimestamp);
+
+    const graphQuery = gql`
+    query MyQuery {
+      volumeStats(where: {timestamp: ${todaysTimestamp}, period: "daily"}) {
+        cumulativeVolumeUsd
+        volumeUsd
+        id
+      }
+    }
+  `;
+
+    const graphRes = await request(graphUrls[chain], graphQuery);
+    const volumeStats: IVolumeStat[] = graphRes.volumeStats;
+
+    let dailyVolumeUSD = BigInt(0);
+
+    volumeStats.forEach((vol) => {
+      dailyVolumeUSD += BigInt(vol.volumeUsd);
+    });
+
+    const finalDailyVolume = parseInt(dailyVolumeUSD.toString()) / 1e18;
+
+    return {
+      dailyVolume: finalDailyVolume.toString(),
+      timestamp: todaysTimestamp,
+    };
+  };
+  return fetch;
+};
+
+const methodology = {
+  dailyVolume:
+    "Total cumulativeVolumeUsd for specified chain for the given day",
+};
+
+const adapter: Adapter = {
+  version: 2,
+  adapter: {
+    [CHAIN.LINEA]: {
+      fetch: graphs(endpoints),
+      start: 1719878400,
+      meta: {
+        methodology,
+      },
+    },
+  },
+};
+
+export default adapter;

--- a/fees/linehub-perps/index.ts
+++ b/fees/linehub-perps/index.ts
@@ -1,0 +1,73 @@
+import { gql, request } from "graphql-request";
+import type { ChainEndpoints, FetchV2 } from "../../adapters/types";
+import { Adapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+
+import { getTimestampAtStartOfDayUTC } from "../../utils/date";
+
+const endpoints = {
+  [CHAIN.LINEA]:
+    "https://api.studio.thegraph.com/query/55804/linehub-trade/version/latest",
+};
+
+interface IFeeStat {
+  cumulativeFeeUsd: string;
+  feeUsd: string;
+  id: string;
+}
+
+const graphs = (graphUrls: ChainEndpoints) => {
+  const fetch: FetchV2 = async ({ chain, startTimestamp }) => {
+    const todaysTimestamp = getTimestampAtStartOfDayUTC(startTimestamp);
+
+    const graphQuery = gql`
+    query MyQuery {
+      feeStats(where: {timestamp: ${todaysTimestamp}, period: daily}) {
+        cumulativeFeeUsd
+        feeUsd
+        id
+      }
+    }
+  `;
+
+    const graphRes = await request(graphUrls[chain], graphQuery);
+    const feeStats: IFeeStat[] = graphRes.feeStats;
+
+    let dailyFeeUSD = BigInt(0);
+    let totalFeeUSD = BigInt(0);
+
+    feeStats.forEach((fee) => {
+      dailyFeeUSD += BigInt(fee.feeUsd);
+      totalFeeUSD += BigInt(fee.cumulativeFeeUsd);
+    });
+
+    const finalDailyFee = parseInt(dailyFeeUSD.toString()) / 1e18;
+    const finalTotalFee = parseInt(totalFeeUSD.toString()) / 1e18;
+
+    return {
+      timestamp: todaysTimestamp,
+      dailyFees: finalDailyFee.toString(),
+      totalFees: finalTotalFee.toString(),
+    };
+  };
+  return fetch;
+};
+
+const methodology = {
+  dailyFees: "Total cumulativeFeeUsd for specified chain for the given day",
+};
+
+const adapter: Adapter = {
+  version: 2,
+  adapter: {
+    [CHAIN.LINEA]: {
+      fetch: graphs(endpoints),
+      start: 1719878400,
+      meta: {
+        methodology,
+      },
+    },
+  },
+};
+
+export default adapter;


### PR DESCRIPTION
Dexs adapter results: 

🦙 Running LINEHUB-PERPS adapter 🦙
---------------------------------------------------
Start Date:     Tue, 02 Jul 2024 07:13:18 GMT
End Date:       Wed, 03 Jul 2024 07:13:18 GMT
---------------------------------------------------

LINEA 👇
Backfill start time: 2/7/2024
Daily volume: 19.25 k
End timestamp: 1719990797 (2024-07-03T07:13:17.000Z)


Fees adapter result: 

🦙 Running LINEHUB-PERPS adapter 🦙
---------------------------------------------------
Start Date:     Tue, 02 Jul 2024 07:14:15 GMT
End Date:       Wed, 03 Jul 2024 07:14:15 GMT
---------------------------------------------------

LINEA 👇
Backfill start time: 2/7/2024
End timestamp: 1719990854 (2024-07-03T07:14:14.000Z)
Daily fees: 8
Total fees: 8
