### PR TITLE
feat: add carbondefi volume and fees adapter

### DIFF
--- a/dexs/carbondefi/index.ts
+++ b/dexs/carbondefi/index.ts
@@ -28,33 +28,32 @@ const chainInfo: { [key: string]: any } = {
     endpoint: "https://api.carbondefi.xyz/v1/analytics/volume",
     startBlock: 17087375,
     startTimestamp: 1681986059,
-    getVolumeByToken: false,
+    getDimensionsByToken: false,
   },
   [CHAIN.SEI]: {
     endpoint: "https://sei-api.carbondefi.xyz/v1/analytics/volume",
     startBlock: 79146720,
     startTimestamp: 1716825673,
-    getVolumeByToken: true,
+    getDimensionsByToken: true,
   },
 };
 
 const getData = async (options: FetchOptions) => {
   const analyticsEndpoint = chainInfo[options.chain].endpoint;
-  const getVolumeByToken = chainInfo[options.chain].getVolumeByToken;
+  const getDimensionsByToken = chainInfo[options.chain].getDimensionsByToken;
   const startTimestamp = options.startOfDay;
   const endTimestamp = options.toTimestamp;
 
   try {
     const swapData: CarbonAnalyticsResponse = await fetchURL(analyticsEndpoint);
 
-    if (getVolumeByToken) {
-      const volumeSumByToken = getDimensionsSumByToken(
+    if (getDimensionsByToken) {
+      return getDimensionsSumByToken(
         swapData,
         startTimestamp,
         endTimestamp,
         getEmptyData(options)
       );
-      return volumeSumByToken;
     }
     return getDimensionsSum(swapData, startTimestamp, endTimestamp);
   } catch (e) {

--- a/dexs/carbondefi/index.ts
+++ b/dexs/carbondefi/index.ts
@@ -1,0 +1,82 @@
+import { FetchOptions, IJSON, SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import fetchURL from "../../utils/fetchURL";
+import { CarbonAnalyticsResponse } from "./types";
+import {
+  getEmptyData,
+  getDimensionsSum,
+  getDimensionsSumByToken,
+} from "./utils";
+
+const CARBON_METADATA: {
+  methodology: IJSON<string>;
+  hallmarks: [number, string][];
+} = {
+  hallmarks: [
+    [1681986059, "CarbonDeFi Ethereum Launch"],
+    [1716825673, "CarbonDeFi Sei Launch"],
+  ],
+  methodology: {
+    Volume:
+      "Volume is calculated as the sum of the targetAmount tokens from TokensTraded events emitted by the CarbonController contract.",
+    Fees: "Fees are calculated as the sum of the tradingFeeAmount amount for the sourceToken if tradeByTarget is true or the targetToken if tradeByTarget is false, taken from TokensTraded events emitted by the CarbonController contract.",
+  },
+};
+
+const chainInfo: { [key: string]: any } = {
+  [CHAIN.ETHEREUM]: {
+    endpoint: "https://api.carbondefi.xyz/v1/analytics/volume",
+    startBlock: 17087375,
+    startTimestamp: 1681986059,
+    getVolumeByToken: false,
+  },
+  [CHAIN.SEI]: {
+    endpoint: "https://sei-api.carbondefi.xyz/v1/analytics/volume",
+    startBlock: 79146720,
+    startTimestamp: 1716825673,
+    getVolumeByToken: true,
+  },
+};
+
+const getData = async (options: FetchOptions) => {
+  const analyticsEndpoint = chainInfo[options.chain].endpoint;
+  const getVolumeByToken = chainInfo[options.chain].getVolumeByToken;
+  const startTimestamp = options.startOfDay;
+  const endTimestamp = options.toTimestamp;
+
+  try {
+    const swapData: CarbonAnalyticsResponse = await fetchURL(analyticsEndpoint);
+
+    if (getVolumeByToken) {
+      const volumeSumByToken = getDimensionsSumByToken(
+        swapData,
+        startTimestamp,
+        endTimestamp,
+        getEmptyData(options)
+      );
+      return volumeSumByToken;
+    }
+    return getDimensionsSum(swapData, startTimestamp, endTimestamp);
+  } catch (e) {
+    console.error(e);
+    // Return empty values
+    return getEmptyData(options);
+  }
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  adapter: {
+    [CHAIN.ETHEREUM]: {
+      fetch: getData,
+      start: chainInfo[CHAIN.ETHEREUM].startTimestamp,
+      meta: CARBON_METADATA,
+    },
+    [CHAIN.SEI]: {
+      fetch: getData,
+      start: chainInfo[CHAIN.SEI].startTimestamp,
+      meta: CARBON_METADATA,
+    },
+  },
+};
+export default adapter;

--- a/dexs/carbondefi/types.ts
+++ b/dexs/carbondefi/types.ts
@@ -1,0 +1,13 @@
+interface CarbonAnalyticsItem {
+  timestamp: string;
+  feesymbol: string;
+  feeaddress: string;
+  tradingfeeamount_real: number;
+  tradingfeeamount_usd: number;
+  targetsymbol: string;
+  targetaddress: string;
+  targetamount_real: number;
+  targetamount_usd: number;
+}
+
+export interface CarbonAnalyticsResponse extends Array<CarbonAnalyticsItem> {}

--- a/dexs/carbondefi/utils.ts
+++ b/dexs/carbondefi/utils.ts
@@ -1,0 +1,97 @@
+import { Balances } from "@defillama/sdk";
+import { CarbonAnalyticsResponse } from "./types";
+import { FetchOptions } from "../../adapters/types";
+
+const filterDataByDate = (
+  swapData: CarbonAnalyticsResponse,
+  startTimestampS: number,
+  endTimestampS: number
+) => {
+  const startTimestampMs = startTimestampS * 1000;
+  const endTimestampMs = endTimestampS * 1000;
+
+  return swapData.filter((swap) => {
+    const swapTsMs = Date.parse(swap.timestamp);
+    return swapTsMs >= startTimestampMs && swapTsMs <= endTimestampMs;
+  });
+};
+
+export const getDimensionsSum = (
+  swapData: CarbonAnalyticsResponse,
+  startTimestamp: number,
+  endTimestamp: number
+) => {
+  const dailyData = filterDataByDate(swapData, startTimestamp, endTimestamp);
+
+  const { dailyVolume, dailyFees } = dailyData.reduce(
+    (prev, curr) => {
+      return {
+        dailyVolume: prev.dailyVolume + curr.targetamount_usd,
+        dailyFees: prev.dailyFees + curr.tradingfeeamount_usd,
+      };
+    },
+    {
+      dailyVolume: 0,
+      dailyFees: 0,
+    }
+  );
+  const { totalVolume, totalFees } = swapData.reduce(
+    (prev, curr) => {
+      return {
+        totalVolume: prev.totalVolume + curr.targetamount_usd,
+        totalFees: prev.totalFees + curr.tradingfeeamount_usd,
+      };
+    },
+    {
+      totalVolume: 0,
+      totalFees: 0,
+    }
+  );
+  return {
+    dailyVolume,
+    totalVolume,
+    dailyFees,
+    totalFees,
+  };
+};
+
+export const getDimensionsSumByToken = (
+  swapData: CarbonAnalyticsResponse,
+  startTimestamp: number,
+  endTimestamp: number,
+  emptyData: {
+    dailyVolume: Balances;
+    dailyFees: Balances;
+    totalVolume: Balances;
+    totalFees: Balances;
+  }
+) => {
+  const dailyData = filterDataByDate(swapData, startTimestamp, endTimestamp);
+  const { dailyVolume, dailyFees, totalFees, totalVolume } = emptyData;
+
+  swapData.forEach((swap) => {
+    totalVolume.add(swap.targetaddress, swap.targetamount_real);
+    totalFees.add(swap.feeaddress, swap.tradingfeeamount_real);
+  });
+
+  dailyData.forEach((swap) => {
+    dailyVolume.add(swap.targetaddress, swap.targetamount_real);
+    dailyFees.add(swap.feeaddress, swap.tradingfeeamount_real);
+  });
+
+  return {
+    dailyVolume,
+    dailyFees,
+    totalVolume,
+    totalFees,
+  };
+};
+
+export const getEmptyData = (options: FetchOptions) => {
+  return {
+    dailyVolume: options.createBalances(),
+    dailyFees: options.createBalances(),
+    totalVolume: options.createBalances(),
+    totalFees: options.createBalances(),
+  };
+};


### PR DESCRIPTION
- Add adapter metadata (hallmarks and methodology) and getData function for Sei and Ethereum
- Add CarbonDeFi dimension sums for all tokens when usd prices are available by the endpoint
- Add CarbonDeFi dimensions sums per token when usd prices are not available