### PR TITLE
Fix CarbonDeFi adapter repeating daily volume

### DIFF
--- a/dexs/carbondefi/index.ts
+++ b/dexs/carbondefi/index.ts
@@ -41,7 +41,7 @@ const chainInfo: { [key: string]: any } = {
 const getData = async (options: FetchOptions) => {
   const analyticsEndpoint = chainInfo[options.chain].endpoint;
   const getDimensionsByToken = chainInfo[options.chain].getDimensionsByToken;
-  const startTimestamp = options.startOfDay;
+  const startTimestamp = options.fromTimestamp;
   const endTimestamp = options.toTimestamp;
 
   try {


### PR DESCRIPTION
CarbonDeFi adapter page is showing incorrect values for volume. Showing around $555 for daily volume in the past 4 days which does not match what is returned by the endpoint. 

Running the test locally now showed a daily volume of 2.31k.

Does changing startTimestamp from startOfDay to fromTimestamp fix this issue? Can you please clarify why we're seeing this?