### PR TITLE
Update Perennial V2 volumes to pull from new subgraph

### DIFF
--- a/dexs/perennial-v2/index.ts
+++ b/dexs/perennial-v2/index.ts
@@ -6,28 +6,21 @@ import { getEnv } from '../../helpers/env'
 
 const apiKey = getEnv('PERENNIAL_V2_SUBGRAPH_API_KEY')
 const graphUrls: { [key: string]: string } = {
-  [CHAIN.ARBITRUM]: `https://subgraph.satsuma-prod.com/${apiKey}/equilibria/perennial-v2-arbitrum/api`,
+  [CHAIN.ARBITRUM]: `https://subgraph.satsuma-prod.com/${apiKey}/equilibria/perennial-v2-arbitrum-new/api`,
 }
 
 const volumeDataQuery = gql`
   query PNLVolume($period: BigInt!, $periodEnd: BigInt!) {
-    daily: bucketedVolumes(
-      where: {
-        bucket: daily
-        periodStartTimestamp_gte: $period
-        periodStartTimestamp_lt: $periodEnd
-      }
+    daily: protocolAccumulations(
+      where: { bucket: daily, timestamp_gte: $period, timestamp_lt: $periodEnd }
       first: 1000
-      orderBy: periodStartTimestamp
+      orderBy: timestamp
       orderDirection: desc
     ) {
-      market
       longNotional
       shortNotional
     }
-
-    total: bucketedVolumes(where: { bucket: all }, first: 1000) {
-      market
+    total: protocolAccumulations(where: { bucket: all }) {
       longNotional
       shortNotional
     }


### PR DESCRIPTION
Perennial has an improved [subgraph](https://github.com/equilibria-xyz/perennial-v2-subgraph-new) which will be maintained going forward. This PR switches the data to pull from the new subgraph

NOTE: Due to a bug in the previous subgraph, the cumulative volume was miscalculated, so it would be best to re-index data from the start using the new subgraph if possible