### PR TITLE
add 4Cast fee adapter

### DIFF
--- a/fees/4cast/index.ts
+++ b/fees/4cast/index.ts
@@ -1,0 +1,41 @@
+import { Adapter, FetchOptions, FetchV2 } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import { postURL } from "../../utils/fetchURL";
+
+interface IData {
+  dailyFees: string;
+}
+
+const endpoint = "https://www.4cast.win/api/api/platformFees";
+
+function createSolBalances(options: FetchOptions, value: string) {
+  const balances = options.createBalances();
+
+  balances.addGasToken(Number(value));
+
+  return balances;
+}
+
+const fetch: FetchV2 = async (options) => {
+  const data: IData = await postURL(endpoint, {
+    startTimestamp: options.startTimestamp,
+    endTimestamp: options.endTimestamp,
+  });
+
+  return {
+    dailyFees: createSolBalances(options, data.dailyFees),
+  };
+};
+
+const adapter: Adapter = {
+  version: 2,
+  adapter: {
+    [CHAIN.SOLANA]: {
+      fetch,
+      runAtCurrTime: false,
+      start: 1721174400,
+    },
+  },
+};
+
+export default adapter;


### PR DESCRIPTION
4CAST (https://4cast.win/) is a fully on-chain, self-custody, and permissionless prediction market on Solana. We are adding a fees adapter in DeFi Llama so that users can get more insight into our protocol.

During development, we have encountered a problem. The fees adapter queries our API to get daily fees in SOL and then uses `options.createBalances()` with `addGasToken` to convert it into a `Balances` object. However, the test displays `Daily fees: 0` even though our API returns a valid value. Can someone take a look and tell how should we fix it?