### PR TITLE
kriya clmm volume

### DIFF
--- a/dexs/kriya-clmm/index.ts
+++ b/dexs/kriya-clmm/index.ts
@@ -9,7 +9,7 @@ type IUrl = {
 }
 
 const url: IUrl = {
-    [CHAIN.SUI]: `https://tkmw8dmcp8.execute-api.ap-southeast-1.amazonaws.com/prod/volume/clmm`
+    [CHAIN.SUI]: `https://tkmw8dmcp8.execute-api.ap-southeast-1.amazonaws.com/prod/volume/clmm/`
 }
 
 interface IVolume {

--- a/dexs/kriya-clmm/index.ts
+++ b/dexs/kriya-clmm/index.ts
@@ -1,6 +1,6 @@
 import fetchURL from "../../utils/fetchURL"
 import { Chain } from "@defillama/sdk/build/general";
-import { SimpleAdapter } from "../../adapters/types";
+import { FetchResultV2, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 import { getUniqStartOfTodayTimestamp } from "../../helpers/getUniSubgraphVolume";
 
@@ -20,10 +20,10 @@ interface IVolume {
 }
 
 const fetch = (chain: Chain) => {
-    return async (timestamp: number) => {
-        const dayTimestamp = getUniqStartOfTodayTimestamp(new Date(timestamp * 1000));
+    return async ({ endTimestamp }): Promise<FetchResultV2> => {
+        const dayTimestamp = getUniqStartOfTodayTimestamp(new Date(endTimestamp * 1000));
         // fetch for the passed timestamp.
-        const volumeUrl = url[chain] + String(timestamp);
+        const volumeUrl = url[chain] + String(endTimestamp);
         const volume: IVolume = (await fetchURL(volumeUrl));
         return {
             totalVolume: `${volume?.totalVolume || undefined}`,

--- a/dexs/kriya-clmm/index.ts
+++ b/dexs/kriya-clmm/index.ts
@@ -1,0 +1,45 @@
+import fetchURL from "../../utils/fetchURL"
+import { Chain } from "@defillama/sdk/build/general";
+import { SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import { getUniqStartOfTodayTimestamp } from "../../helpers/getUniSubgraphVolume";
+
+type IUrl = {
+    [s: string]: string;
+}
+
+const url: IUrl = {
+    [CHAIN.SUI]: `https://tkmw8dmcp8.execute-api.ap-southeast-1.amazonaws.com/prod/volume/clmm`
+}
+
+interface IVolume {
+    totalVolume: number,
+    dailyVolume: number,
+    weeklyVolume: number,
+    monthlyVolume: number,
+}
+
+const fetch = (chain: Chain) => {
+    return async (timestamp: number) => {
+        const dayTimestamp = getUniqStartOfTodayTimestamp(new Date(timestamp * 1000));
+        // fetch for the passed timestamp.
+        const volumeUrl = url[chain] + String(timestamp);
+        const volume: IVolume = (await fetchURL(volumeUrl));
+        return {
+            totalVolume: `${volume?.totalVolume || undefined}`,
+            dailyVolume: `${volume?.dailyVolume || undefined}`,
+            timestamp: dayTimestamp,
+        };
+    };
+}
+
+const adapter: SimpleAdapter = {
+    adapter: {
+        [CHAIN.SUI]: {
+            fetch: fetch(CHAIN.SUI),
+            start: 1683604174,
+        }
+    },
+};
+
+export default adapter;

--- a/dexs/kriya-clmm/index.ts
+++ b/dexs/kriya-clmm/index.ts
@@ -34,6 +34,7 @@ const fetch = (chain: Chain) => {
 }
 
 const adapter: SimpleAdapter = {
+    version: 2,
     adapter: {
         [CHAIN.SUI]: {
             fetch: fetch(CHAIN.SUI),


### PR DESCRIPTION
Hi team,

This is Kriya's Defillama space: https://defillama.com/protocol/kriya#information

We recently added a sub-category 'Kriya CLMM' (related PR: https://defillama.com/protocol/kriya#information)

I am raising this PR to add Kriya CLMM's Volume to Defilamma. The volume adapter for Kriya AMM will stay as it is and Kriya's volume = Kriya AMM volume + Kriya CLMM Volume

Folder wise mapping:-
kriya-dex -> Kriya AMM
kriya-clmm -> Kriya CLMM

Let me know if this PR works for the same

Thanks