### PR TITLE
Add astrolescent volume

### DIFF
--- a/dexs/astrolescent/index.ts
+++ b/dexs/astrolescent/index.ts
@@ -1,6 +1,7 @@
 import { FetchResultFees, FetchResultVolume, SimpleAdapter } from "../../adapters/types"
 import { CHAIN } from "../../helpers/chains"
 import fetchURL from "../../utils/fetchURL"
+import customBackfill from "../../helpers/customBackfill";
 
 interface AstrolescentStats {
   volumeUSD:	number;
@@ -20,6 +21,7 @@ const adapters: SimpleAdapter = {
     [CHAIN.RADIXDLT]: {
       fetch: fetchVolume,
       start: 1698624000,
+      customBackfill: customBackfill(CHAIN.RADIXDLT, () => fetchVolume),
       runAtCurrTime: false
     }
   }

--- a/dexs/astrolescent/index.ts
+++ b/dexs/astrolescent/index.ts
@@ -1,0 +1,27 @@
+import { FetchResultFees, FetchResultVolume, SimpleAdapter } from "../../adapters/types"
+import { CHAIN } from "../../helpers/chains"
+import fetchURL from "../../utils/fetchURL"
+
+interface AstrolescentStats {
+  volumeUSD:	number;
+}
+const fetchVolume = async (timestamp: number): Promise<FetchResultVolume> => {
+  const response: AstrolescentStats = (await fetchURL(`https://api.astrolescent.com/stats/history?timestamp=${timestamp}`));
+  const dailyVolume = Number(response?.volumeUSD);
+
+  return {
+    dailyVolume,
+    timestamp
+  }
+}
+
+const adapters: SimpleAdapter = {
+  adapter: {
+    [CHAIN.RADIXDLT]: {
+      fetch: fetchVolume,
+      start: 1698624000,
+      runAtCurrTime: false
+    }
+  }
+}
+export default adapters;


### PR DESCRIPTION
Astrolescent is an **dex aggregator** on the Radix network and listed on DefiLlama as https://defillama.com/protocol/astrolescent

This PR adds our trade volume. In an earlier conversation with the team we were advised to add our adapter in the dexs folder and not in the aggregators folder. If that has changed, I'd happily move the adapter to the other folder.

I tested backdating the trade volume.

Thanks!