### PR TITLE
feat: Add tracking for historical OI + Freestyle volume for BMX

### DIFF
--- a/dexs/bmx/index.ts
+++ b/dexs/bmx/index.ts
@@ -1,13 +1,32 @@
 import request, { gql } from "graphql-request";
-import { BreakdownAdapter, Fetch } from "../../adapters/types";
+import {
+  BreakdownAdapter,
+  Fetch,
+  FetchResultVolume,
+} from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 import { getUniqStartOfTodayTimestamp } from "../../helpers/getUniSubgraphVolume";
+import BigNumber from "bignumber.js";
 
+const ONE_DAY_IN_SECONDS = 60 * 60 * 24;
+const toString = (x: BigNumber) => {
+  if (x.isEqualTo(0)) return undefined;
+  return x.toString();
+};
+
+const startTimestamps: { [chain: string]: number } = {
+  [CHAIN.BASE]: 1694304000,
+  [CHAIN.MODE]: 1720627435,
+};
 const endpoints: { [key: string]: string } = {
   [CHAIN.BASE]:
     "https://api.studio.thegraph.com/query/71696/bmx-base-stats/version/latest",
   [CHAIN.MODE]:
     "https://api.studio.thegraph.com/query/42444/bmx-mode-stats/version/latest",
+};
+const freestyleEndpoints: { [key: string]: string } = {
+  [CHAIN.BASE]:
+    "https://api.studio.thegraph.com/query/62454/analytics_base_8_2/version/latest",
 };
 
 const historicalDataSwap = gql`
@@ -17,12 +36,44 @@ const historicalDataSwap = gql`
     }
   }
 `;
-
 const historicalDataDerivatives = gql`
   query get_volume($period: String!, $id: String!) {
     volumeStats(where: { period: $period, id: $id }) {
       liquidation
       margin
+    }
+  }
+`;
+const historicalOI = gql`
+  query get_trade_stats($period: String!, $id: String!) {
+    tradingStats(where: { period: $period, id: $id }) {
+      id
+      longOpenInterest
+      shortOpenInterest
+    }
+  }
+`;
+const freestyleQuery = gql`
+  query stats($from: String!, $to: String!) {
+    dailyHistories(
+      where: {
+        timestamp_gte: $from
+        timestamp_lte: $to
+        accountSource: "0x6D63921D8203044f6AbaD8F346d3AEa9A2719dDD"
+      }
+    ) {
+      timestamp
+      platformFee
+      accountSource
+      tradeVolume
+    }
+    totalHistories(
+      where: { accountSource: "0x6D63921D8203044f6AbaD8F346d3AEa9A2719dDD" }
+    ) {
+      timestamp
+      platformFee
+      accountSource
+      tradeVolume
     }
   }
 `;
@@ -34,6 +85,27 @@ interface IGraphResponse {
     margin: string;
     mint: string;
     swap: string;
+  }>;
+}
+interface IGraphResponseOI {
+  tradingStats: Array<{
+    id: string;
+    longOpenInterest: string;
+    shortOpenInterest: string;
+  }>;
+}
+interface IGraphResponseFreestyle {
+  dailyHistories: Array<{
+    tiemstamp: string;
+    platformFee: string;
+    accountSource: string;
+    tradeVolume: string;
+  }>;
+  totalHistories: Array<{
+    tiemstamp: string;
+    platformFee: string;
+    accountSource: string;
+    tradeVolume: BigNumber;
   }>;
 }
 
@@ -52,9 +124,41 @@ const getFetch =
       id: "total",
       period: "total",
     });
+    let dailyOpenInterest = 0;
+    let dailyLongOpenInterest = 0;
+    let dailyShortOpenInterest = 0;
+
+    if (query === historicalDataDerivatives) {
+      const tradingStats: IGraphResponseOI = await request(
+        endpoints[chain],
+        historicalOI,
+        {
+          id: String(dayTimestamp) + ":daily",
+          period: "daily",
+        }
+      );
+      dailyOpenInterest =
+        Number(tradingStats.tradingStats[0].longOpenInterest) +
+        Number(tradingStats.tradingStats[0].shortOpenInterest);
+      dailyLongOpenInterest = Number(
+        tradingStats.tradingStats[0].longOpenInterest
+      );
+      dailyShortOpenInterest = Number(
+        tradingStats.tradingStats[0].shortOpenInterest
+      );
+    }
 
     return {
       timestamp: dayTimestamp,
+      dailyLongOpenInterest: dailyLongOpenInterest
+        ? String(dailyLongOpenInterest * 10 ** -30)
+        : undefined,
+      dailyShortOpenInterest: dailyShortOpenInterest
+        ? String(dailyShortOpenInterest * 10 ** -30)
+        : undefined,
+      dailyOpenInterest: dailyOpenInterest
+        ? String(dailyOpenInterest * 10 ** -30)
+        : undefined,
       dailyVolume:
         dailyData.volumeStats.length == 1
           ? String(
@@ -80,18 +184,70 @@ const getFetch =
     };
   };
 
+const fetchFreestyleVolume =
+  (query: string) =>
+  (chain: string): Fetch =>
+  async (timestamp: number): Promise<FetchResultVolume> => {
+    const response: IGraphResponseFreestyle = await request(
+      freestyleEndpoints[chain],
+      query,
+      {
+        from: String(timestamp - ONE_DAY_IN_SECONDS),
+        to: String(timestamp),
+      }
+    );
+
+    let dailyVolume = new BigNumber(0);
+    let totalVolume = new BigNumber(0);
+
+    response.dailyHistories.forEach((data) => {
+      dailyVolume = dailyVolume.plus(new BigNumber(data.tradeVolume));
+    });
+    response.totalHistories.forEach((data) => {
+      totalVolume = totalVolume.plus(new BigNumber(data.tradeVolume));
+    });
+
+    dailyVolume = dailyVolume.dividedBy(new BigNumber(1e18));
+    totalVolume = totalVolume.dividedBy(new BigNumber(1e18));
+
+    const _dailyVolume = toString(dailyVolume);
+    const _totalVolume = toString(totalVolume);
+
+    const dayTimestamp = getUniqStartOfTodayTimestamp(
+      new Date(timestamp * 1000)
+    );
+
+    return {
+      timestamp: dayTimestamp,
+      dailyVolume: _dailyVolume ?? "0",
+      totalVolume: _totalVolume ?? "0",
+    };
+  };
+
 const adapter: BreakdownAdapter = {
   breakdown: {
-    swap: {
+    swap: Object.keys(endpoints).reduce((acc, chain) => {
+      return {
+        ...acc,
+        [chain]: {
+          fetch: getFetch(historicalDataSwap)(chain),
+          start: startTimestamps[chain],
+        },
+      };
+    }, {}),
+    "derivatives-classic": Object.keys(endpoints).reduce((acc, chain) => {
+      return {
+        ...acc,
+        [chain]: {
+          fetch: getFetch(historicalDataDerivatives)(chain),
+          start: startTimestamps[chain],
+        },
+      };
+    }, {}),
+    "derivatives-freestyle": {
       [CHAIN.BASE]: {
-        fetch: getFetch(historicalDataSwap)(CHAIN.BASE),
-        start: 1694304000,
-      },
-    },
-    derivatives: {
-      [CHAIN.BASE]: {
-        fetch: getFetch(historicalDataDerivatives)(CHAIN.BASE),
-        start: 1694304000,
+        fetch: fetchFreestyleVolume(freestyleQuery)(CHAIN.BASE),
+        start: 1714681913,
       },
     },
   },

--- a/fees/bmx.ts
+++ b/fees/bmx.ts
@@ -1,6 +1,7 @@
 import { Adapter } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
 import { request, gql } from "graphql-request";
+import type { FetchV2 } from "../adapters/types"
 import { getTimestampAtStartOfDayUTC } from "../utils/date";
 
 const endpoints: { [key: string]: string } = {
@@ -20,8 +21,8 @@ const methodology = {
     "Revenue is 40% of all collected fees, which are distributed to BMX/wBLT LP stakers and BMX stakers",
 };
 
-const graphs = (chain: string) => async (timestamp: number) => {
-  const todaysTimestamp = getTimestampAtStartOfDayUTC(timestamp);
+const graphs: FetchV2 = async ({ chain, endTimestamp }) => {
+  const todaysTimestamp = getTimestampAtStartOfDayUTC(endTimestamp);
   const searchTimestamp = todaysTimestamp + ":daily";
 
   const graphQuery = gql`{
@@ -47,27 +48,27 @@ const graphs = (chain: string) => async (timestamp: number) => {
   const finalUserFee = userFee / 1e30;
 
   return {
-    timestamp,
+    endTimestamp,
     dailyFees: finalDailyFee.toString(),
     dailyUserFees: finalUserFee.toString(),
     dailyRevenue: (finalDailyFee * 0.4).toString(),
-    dailyHoldersRevenue: (finalDailyFee * 0.1).toString(),
+    dailyHoldersRevenue: (finalDailyFee * 0.4).toString(),
     dailySupplySideRevenue: (finalDailyFee * 0.6).toString(),
   };
 };
 
 const adapter: Adapter = {
-  version: 1,
+  version: 2,
   adapter: {
     [CHAIN.BASE]: {
-      fetch: graphs(CHAIN.BASE),
+      fetch: graphs,
       start: 1694304000,
       meta: {
         methodology,
       },
     },
     [CHAIN.MODE]: {
-      fetch: graphs(CHAIN.MODE),
+      fetch: graphs,
       start: 1720627435,
       meta: {
         methodology,


### PR DESCRIPTION
Fees:
  - Updated our adapter to use newer import
Dexs:
  - Added historical OI tracking for our Classic market (GMX v1 style)
  - Added derivatives volume tracking for our Freestyle product (intent-based trading)


Recently I committed changes to update our subgraph links to new ones that work, but on the DefiLlama website, the period from June 24 - August 16 just duplicates the fees and volume data on the graphs. I tested various timestamps from that period of time locally, and I got correct, non-duplicated values from the adapters. May you please look into this? Thanks!

![image](https://github.com/user-attachments/assets/ca2d30ac-e0ce-41a7-9c8f-a20dfd3ab248)