### PR TITLE
Add Stride stBAND and stISLM fees

### DIFF
--- a/fees/stride.ts
+++ b/fees/stride.ts
@@ -10,13 +10,15 @@ interface DailyFeeResponse {
 }
 
 const chainOverrides: { [key: string]: string } = {
-  "terra": "terra2",
+  terra: "terra2",
 };
 
 const fetch = (chain: string) => {
   return async (timestamp: number): Promise<FetchResult> => {
     const overriddenChain = chainOverrides[chain] || chain; // Override if exists, else use original
-    const response: DailyFeeResponse = await httpGet(`https://edge.stride.zone/api/${overriddenChain}/stats/fees`);
+    const response: DailyFeeResponse = await httpGet(
+      `https://edge.stride.zone/api/${overriddenChain}/stats/fees`
+    );
 
     return {
       timestamp: timestamp,
@@ -25,7 +27,6 @@ const fetch = (chain: string) => {
     };
   };
 };
-
 
 const meta = {
   methodology: {
@@ -105,6 +106,18 @@ const adapter: Adapter = {
     },
     comdex: {
       fetch: fetch("comdex"),
+      runAtCurrTime: true,
+      start: 0,
+      meta,
+    },
+    haqq: {
+      fetch: fetch("haqq"),
+      runAtCurrTime: true,
+      start: 0,
+      meta,
+    },
+    band: {
+      fetch: fetch("band"),
       runAtCurrTime: true,
       start: 0,
       meta,

--- a/helpers/getBlock.ts
+++ b/helpers/getBlock.ts
@@ -48,7 +48,8 @@ const blacklistedChains: string[] = [
   "persistence",
   "sui",
   "neutron",
-  "terra2"
+  "terra2",
+  "dymension"
 ];
 
 async function getBlock(timestamp: number, chain: Chain, chainBlocks = {} as ChainBlocks) {


### PR DESCRIPTION
This PR adds stBAND and stISLM fees to Stride. 

Testing shows this error when running the test script, but our endpoint is functioning correctly. Do you have any idea why?
```
> adapters@1.0.0 test
> ts-node --transpile-only cli/testAdapter.ts fees stride

🦙 Running STRIDE adapter 🦙
---------------------------------------------------
Start Date:	Wed, 21 Aug 2024 00:00:00 GMT
End Date:	Thu, 22 Aug 2024 00:00:00 GMT
---------------------------------------------------

error fetching block [Error: Llama RPC error! methos: undefined
- host: https://dymension-evm-rpc.publicnode.com error: Cannot read properties of null (reading 'number')
- host: https://dymension.drpc.org error: Cannot read properties of null (reading 'number')] {
  _underlyingError: '[object Object]',
  _isCustomError: true
}
Error: Error getting block: dymension 1724198399 Request failed with status code 502
    at /Users/brian/Web/dimension-adapters/helpers/getBlock.ts:109:19
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async retry.retries (/Users/brian/Web/dimension-adapters/helpers/getBlock.ts:108:50)
    at async getBlock (/Users/brian/Web/dimension-adapters/helpers/getBlock.ts:108:25)
    at async getFromBlock (/Users/brian/Web/dimension-adapters/adapters/utils/runAdapter.ts:101:38)
    at async getOptionsObject (/Users/brian/Web/dimension-adapters/adapters/utils/runAdapter.ts:116:19)
    at async getChainResult (/Users/brian/Web/dimension-adapters/adapters/utils/runAdapter.ts:46:23)
    at async Promise.all (index 4)
    at async runAdapter (/Users/brian/Web/dimension-adapters/adapters/utils/runAdapter.ts:27:20)
    at async /Users/brian/Web/dimension-adapters/cli/testAdapter.ts:75:21 {
  chain: 'dymension'
}
```