### PR TITLE
feat: add chainflip dexs

### DIFF
--- a/dexs/chainflip/index.ts
+++ b/dexs/chainflip/index.ts
@@ -1,0 +1,32 @@
+import { SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import { httpGet } from "../../utils/fetchURL";
+
+const dimensionsEndpoint = "https://chainflip-broker.io/defillama/dexs"
+
+const fetch = async (timestamp: number) => {
+  const dimensionsData = await httpGet(`${dimensionsEndpoint}?timestamp=${timestamp}`, { headers: {"x-client-id": "defillama"}});
+
+  return {
+    timestamp: dimensionsData.timestamp,
+    dailyVolume: dimensionsData.dailyVolume, 
+    totalVolume: dimensionsData.totalVolume
+  };
+};
+
+const adapter: SimpleAdapter = {
+  adapter: {
+    [CHAIN.CHAINFLIP]: {
+      fetch,
+      start: 1700740800, // FLIP went live on 2023-11-23 12:00 UTC
+      runAtCurrTime: true,
+      meta: {
+        methodology: {
+          Volume: "Deposit value of a swap.",
+        }
+      }
+    },
+  },
+};
+
+export default adapter;

--- a/helpers/chains.ts
+++ b/helpers/chains.ts
@@ -161,7 +161,8 @@ export enum CHAIN {
   IOTAEVM = "iotaevm",
   ZKLINK = "zklink",
   DEXALOT = "dexalot",
-  IMMUTABLEX = "immutablex"
+  IMMUTABLEX = "immutablex",
+  CHAINFLIP = "chainflip"
 }
 
 // Don´t use


### PR DESCRIPTION
Start of dimensions adapters for [Chainflip](https://chainflip.io), this is similar to THORChain, bot a Dex and Chain.

I am starting with just the `dexs` adapter, adding `fees` in the next step.

Test output:

```
 user@dev-web3  [c] (base)  3.12.4  ~/chainflip/dimension-adapters   chainflip ●  yarn test dexs chainflip
yarn run v1.22.22
$ ts-node --transpile-only cli/testAdapter.ts dexs chainflip
🦙 Running CHAINFLIP adapter 🦙
---------------------------------------------------
Start Date:     Thu, 22 Aug 2024 00:00:00 GMT
End Date:       Fri, 23 Aug 2024 00:00:00 GMT
---------------------------------------------------

CHAINFLIP 👇
Backfill start time: 23/11/2023
End timestamp: 1724371199 (2024-08-22T23:59:59.000Z)
Daily volume: 1.88 M
└─ Methodology: Deposit value of a swap.
Total volume: 228.60 M
└─ Methodology: Deposit value of a swap.




Done in 4.54s.
```