### PR TITLE
feat: add chainflip fees

### DIFF
--- a/fees/chainflip/index.ts
+++ b/fees/chainflip/index.ts
@@ -1,0 +1,57 @@
+import { SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import { httpGet } from "../../utils/fetchURL";
+
+const dimensionsEndpoint = "https://chainflip-broker.io/defillama/fees"
+
+const fetch = async (timestamp: number) => {
+  const dimensionsData = await httpGet(`${dimensionsEndpoint}?timestamp=${timestamp}`, { headers: {"x-client-id": "defillama"}});
+
+  return {
+    timestamp: timestamp,
+
+    // All fees and value collected from all sources, this also includes liquid staking rewards, generated yields and possible mint and burn fees paid by LP (but not transaction or gas fees).
+    dailyFees: dimensionsData.dailyFees, 
+
+    // Fees paid by protocol users excluding gas fees. This includes swap fees to open/close positions, borrow fees and all fees user has to pay.
+    dailyUserFees: dimensionsData.dailyUserFees, 
+
+    // (FLIP Burn) Revenue of the protocol governance, this includes treasury and gov token holders
+    dailyRevenue: dimensionsData.dailyRevenue,
+
+    // Value earned by liquidity providers
+    dailySupplySideRevenue: dimensionsData.dailySupplySideRevenue,
+
+    // Cumulative value of dailyFees
+    totalFees: dimensionsData.totalFees, 
+
+    // Cumulative value of dailyUserFees
+    totalUserFees: dimensionsData.totalUserFees,
+
+    // Cumulative value of dailyRevenue
+    totalRevenue: dimensionsData.totalRevenue, 
+
+    // Cumulative value of dailySupplySideRevenue
+    totalSupplySideRevenue: dimensionsData.totalSupplySideRevenue
+  };
+};
+
+const adapter: SimpleAdapter = {
+  adapter: {
+    [CHAIN.CHAINFLIP]: {
+      fetch,
+      start: 1717113600, // First decent swap was 2024-05-31 09:22:30.000000
+      runAtCurrTime: true,
+      meta: {
+        methodology: {
+          Fees: "Ingress, Broker, LP, Protocol and Egress fees.",
+          UserFees: "Broker, LP, Protocol fees.",
+          Revenue: "Protocol burns 0.10% of each swap.",
+          SupplySideRevenue: "LP pools have a 0.05% fee.",
+        }
+      }
+    },
+  },
+};
+
+export default adapter;

--- a/helpers/chains.ts
+++ b/helpers/chains.ts
@@ -161,7 +161,8 @@ export enum CHAIN {
   IOTAEVM = "iotaevm",
   ZKLINK = "zklink",
   DEXALOT = "dexalot",
-  IMMUTABLEX = "immutablex"
+  IMMUTABLEX = "immutablex",
+  CHAINFLIP = "chainflip"
 }
 
 // Don´t use


### PR DESCRIPTION
Start of dimensions adapters for [Chainflip](https://chainflip.io), this is similar to THORChain, both a DEX and Chain.

This is the fees adapter, please merge #1819 as well for `dexs`.

Output:

```
 user@dev-web3  [c] (base)  3.12.4  ~/chainflip/dimension-adapters   chainflip-fees ●  yarn test fees chainflip
yarn run v1.22.22
$ ts-node --transpile-only cli/testAdapter.ts fees chainflip
🦙 Running CHAINFLIP adapter 🦙
---------------------------------------------------
Start Date:     Thu, 22 Aug 2024 00:00:00 GMT
End Date:       Fri, 23 Aug 2024 00:00:00 GMT
---------------------------------------------------

CHAINFLIP 👇
Backfill start time: 31/5/2024
End timestamp: 1724371199 (2024-08-22T23:59:59.000Z)
Daily fees: 23.11 k
└─ Methodology: Ingress, Broker, LP, Protocol and Egress fees.
Daily user fees: 21.95 k
└─ Methodology: Broker, LP, Protocol fees.
Daily revenue: 1.88 k
└─ Methodology: Protocol burns 0.10% of each swap.
Daily supply side revenue: 19.67 k
└─ Methodology: LP pools have a 0.05% fee.
Total fees: 324.09 k
└─ Methodology: Ingress, Broker, LP, Protocol and Egress fees.
Total user fees: 300.32 k
└─ Methodology: Broker, LP, Protocol fees.
Total revenue: 108.62 k
└─ Methodology: Protocol burns 0.10% of each swap.
Total supply side revenue: 100.78 k
└─ Methodology: LP pools have a 0.05% fee.




Done in 6.78s.
```