### PR TITLE
bnx freestyle

### DIFF
--- a/dexs/bmx-freestyle/index.ts
+++ b/dexs/bmx-freestyle/index.ts
@@ -1,0 +1,115 @@
+import BigNumber from "bignumber.js";
+import { FetchOptions, FetchResultVolume, SimpleAdapter } from "../../adapters/types";
+import request, { gql } from "graphql-request";
+import { CHAIN } from "../../helpers/chains";
+
+
+const freestyleEndpoints: { [key: string]: string } = {
+  [CHAIN.BASE]:
+    "https://api.studio.thegraph.com/query/62454/analytics_base_8_2/version/latest",
+};
+
+interface IGraphResponseFreestyle {
+  dailyHistories: Array<{
+    tiemstamp: string;
+    platformFee: string;
+    accountSource: string;
+    tradeVolume: string;
+  }>;
+  totalHistories: Array<{
+    tiemstamp: string;
+    platformFee: string;
+    accountSource: string;
+    tradeVolume: BigNumber;
+  }>;
+}
+
+interface IGraphResponse {
+  volumeStats: Array<{
+    burn: string;
+    liquidation: string;
+    margin: string;
+    mint: string;
+    swap: string;
+  }>;
+}
+
+const ONE_DAY_IN_SECONDS = 60 * 60 * 24;
+
+const toString = (x: BigNumber) => {
+  if (x.isEqualTo(0)) return undefined;
+  return x.toString();
+};
+
+const freestyleQuery = gql`
+  query stats($from: String!, $to: String!) {
+    dailyHistories(
+      where: {
+        timestamp_gte: $from
+        timestamp_lte: $to
+        accountSource: "0x6D63921D8203044f6AbaD8F346d3AEa9A2719dDD"
+      }
+    ) {
+      timestamp
+      platformFee
+      accountSource
+      tradeVolume
+    }
+    totalHistories(
+      where: { accountSource: "0x6D63921D8203044f6AbaD8F346d3AEa9A2719dDD" }
+    ) {
+      timestamp
+      platformFee
+      accountSource
+      tradeVolume
+    }
+  }
+`;
+
+const fetchFreestyleVolume = async (timestamp: number, _t: any, options: FetchOptions): Promise<FetchResultVolume> => {
+    const startTime = options.startOfDay;
+    const endTime = startTime + ONE_DAY_IN_SECONDS;
+    const response: IGraphResponseFreestyle = await request(
+      freestyleEndpoints[options.chain],
+      freestyleQuery,
+      {
+        from: String(startTime),
+        to: String(endTime),
+      }
+    );
+
+    let dailyVolume = new BigNumber(0);
+    let totalVolume = new BigNumber(0);
+
+    response.dailyHistories.forEach((data) => {
+      dailyVolume = dailyVolume.plus(new BigNumber(data.tradeVolume));
+    });
+    response.totalHistories.forEach((data) => {
+      totalVolume = totalVolume.plus(new BigNumber(data.tradeVolume));
+    });
+
+    dailyVolume = dailyVolume.dividedBy(new BigNumber(1e18));
+    totalVolume = totalVolume.dividedBy(new BigNumber(1e18));
+
+    const _dailyVolume = toString(dailyVolume);
+    const _totalVolume = toString(totalVolume);
+
+
+    return {
+      timestamp: timestamp,
+      dailyVolume: _dailyVolume ?? "0",
+      totalVolume: _totalVolume ?? "0",
+    };
+  };
+
+const adapter: SimpleAdapter = {
+  version: 1,
+  adapter: {
+    [CHAIN.BASE]: {
+      fetch: fetchFreestyleVolume,
+      start: 0
+    }
+  }
+}
+
+export default adapter;

--- a/dexs/bmx/index.ts
+++ b/dexs/bmx/index.ts
@@ -1,18 +1,12 @@
 import request, { gql } from "graphql-request";
 import {
   BreakdownAdapter,
-  Fetch,
-  FetchResultVolume,
+  Fetch
 } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 import { getUniqStartOfTodayTimestamp } from "../../helpers/getUniSubgraphVolume";
 import BigNumber from "bignumber.js";
 
-const ONE_DAY_IN_SECONDS = 60 * 60 * 24;
-const toString = (x: BigNumber) => {
-  if (x.isEqualTo(0)) return undefined;
-  return x.toString();
-};
 
 const startTimestamps: { [chain: string]: number } = {
   [CHAIN.BASE]: 1694304000,
@@ -50,30 +44,6 @@ const historicalOI = gql`
       id
       longOpenInterest
       shortOpenInterest
-    }
-  }
-`;
-const freestyleQuery = gql`
-  query stats($from: String!, $to: String!) {
-    dailyHistories(
-      where: {
-        timestamp_gte: $from
-        timestamp_lte: $to
-        accountSource: "0x6D63921D8203044f6AbaD8F346d3AEa9A2719dDD"
-      }
-    ) {
-      timestamp
-      platformFee
-      accountSource
-      tradeVolume
-    }
-    totalHistories(
-      where: { accountSource: "0x6D63921D8203044f6AbaD8F346d3AEa9A2719dDD" }
-    ) {
-      timestamp
-      platformFee
-      accountSource
-      tradeVolume
     }
   }
 `;
@@ -184,45 +154,6 @@ const getFetch =
     };
   };
 
-const fetchFreestyleVolume =
-  (query: string) =>
-  (chain: string): Fetch =>
-  async (timestamp: number): Promise<FetchResultVolume> => {
-    const response: IGraphResponseFreestyle = await request(
-      freestyleEndpoints[chain],
-      query,
-      {
-        from: String(timestamp - ONE_DAY_IN_SECONDS),
-        to: String(timestamp),
-      }
-    );
-
-    let dailyVolume = new BigNumber(0);
-    let totalVolume = new BigNumber(0);
-
-    response.dailyHistories.forEach((data) => {
-      dailyVolume = dailyVolume.plus(new BigNumber(data.tradeVolume));
-    });
-    response.totalHistories.forEach((data) => {
-      totalVolume = totalVolume.plus(new BigNumber(data.tradeVolume));
-    });
-
-    dailyVolume = dailyVolume.dividedBy(new BigNumber(1e18));
-    totalVolume = totalVolume.dividedBy(new BigNumber(1e18));
-
-    const _dailyVolume = toString(dailyVolume);
-    const _totalVolume = toString(totalVolume);
-
-    const dayTimestamp = getUniqStartOfTodayTimestamp(
-      new Date(timestamp * 1000)
-    );
-
-    return {
-      timestamp: dayTimestamp,
-      dailyVolume: _dailyVolume ?? "0",
-      totalVolume: _totalVolume ?? "0",
-    };
-  };
 
 const adapter: BreakdownAdapter = {
   breakdown: {
@@ -244,12 +175,6 @@ const adapter: BreakdownAdapter = {
         },
       };
     }, {}),
-    "derivatives-freestyle": {
-      [CHAIN.BASE]: {
-        fetch: fetchFreestyleVolume(freestyleQuery)(CHAIN.BASE),
-        start: 1714681913,
-      },
-    },
   },
 };
 


### PR DESCRIPTION
- Add Umoja to Options & Fees dashboard.
- feat: add sushiswap aggregator adapter
- fluid: add arbitrum
- feat(fluid): simplify arbitrum config
- use sushi API for pricing
- fix rootstock
- move sushiswap aggregator adapter to dexs dir
- 7k aggregator volume statistic
- add adaptoer version
- get dailyvolume with version 2
- feat: add carbondefi volume and fees adapter
- refactor: Rename and clean-up getData
- add jup ape fees
- add uiswap v3 sei
- fix wrong result
- agg swap
- fix api key
- split dexalot by chaib
- fix: DefiLlama stats for panora
- intentx: Updated subgraph endpoint
- fix surfone
- fix fees
- disable op volume has spike
- update swapgpt
- Update Fees / order / new networks
- fix: Removed yarn lock
- fluid: add arbitrum
- feat(fluid): simplify arbitrum config
- add uniswap more chain
- fix chain
- add more
- add betmode
- glyph exchange v4 volumn&fees
- fix(fluid): add chain param to calls
- Update Vela Subgraph URI's
- Add base to fees adapter and update graph uris
- Update daily volume API end point for stabble
- bugfix: fetch function
- Change startTimestamp from startOfDay to fromTimestamp
- fix adapter
- fix adapyer
- Check tokens are native when adding dimension sums by token
- fix native token
- change token price
- feat: add scallop fee
- fix: Aero/Velo dexs events pagination
- fix timestamp
- Update Volume Tracking
- wrong hdr
- fix apollox
- disable run current
- disable run current
- Add SizeCredit fees
- fix openbook
- Update Perennial volumes to pull from new subgraph
- Listing D2Finance
- add dailyFees
- Dexfinance adapter
- Add SolTradingBot fee
- fix allow run houry
- feat: Include bribe data
- add eddy finance
- add eddy finance (#1688)
- add zeta chain to iziswap
- integrate AKKA in aggregators
- kana id updated
- fix version
- fix issue with querying the wrong value from the event
- fix fees and token price
- blasterswap v3 volume
- fix token price
- fix: optimize v2 daily volume request with sleep 2s interval
- DeDust volume export
- baseswap change v3 endpoint
- Update index.ts
- fix adapter
- fix version
- remove
- remove logs
- add zns dimensions
- change version and start timestamp
- use accurate timestamp for every chain and use try catch statement
- fix: optimize resend request when error code
- updated api key
- add YFX V4 vol on Base
- add YFX V4 fees on Base
- Update yfx-v4.ts
- add User router addresses of YFX V4
- kriya clmm volume
- feat:Add LiquidCollective dailyfees
- adapter version 2
- url fix
- v2 adapter fixes
- update endpoint
- feat: Add Juice-finance dailyFees based on depositFeeTaken on each vault
- fix timestamp
- fix vooi
- fix wrong chain assign
- fix woofi
- feat:Add Origin-Dollar fees & revenues
- allow run
- fix zns
- fix event
- fix raydium filter tvl before sum
- adding saturn swap volume adaptor to defillama
- Update Bladeswap graphql endpoint
- Update Stargate v1 (missed chains/addresses)
- wip
- fix address
- fix div
- feat: Adapter Silo-finance totalFees
- v1 uni
- Revert "v1 uni"
- add zklink
- Added kwenta to aggregator-derivatives
- Added USDC_V5 pool fee & revenue
- colony dimension adapter update
- add daily fees
- fix betmode
- colony staking revenue fix
- fix nuri v3
- add yakafinance dexs
- fix : add cetus
- remove not use
- add totalVolume for synfutures-v3
- feat:Adapter, Arrakis-v2 Fees
- rename cumulativeVolume
- feat:Adapter, Stargate-finance-v2 [ FEES ]
- fix timestamps
- Subgraph on dexswap
- rm yarn.lock
- add break
- feat: Adapter, Superstate [Fees]
- prettier
- small fix
- Add celo deployment to the carbondefi adapter
- add zklink
- fix
- add scroll
- fix set 0 fees
- fix the graph spiritswap
- fix meteora volume
- addedSpaceWhaleDEX
- subGraphVersion
- fix: add cetus-aggregator
- Add DeDust fees
- feat: apex-omni
- fix: ticker server
- Add MevX fee trackers
- feat: orderly fee adapter
- fix cetus
- fix naming
- Add C3 Exchange Volumes
- fix filter pool tvl more than 100k
- allow run current
- fix: update cetus
- rewrite ethena not to use indexer
- use v1
- fix for v1
- fix stuck
- add methodology
- allow runcurrent
- Update GMX V2 Volume and Swaps Tracking
- Delete dexs/gmx-v2/gmx-v2-trade directory
- Fix interface
- Update index.ts
- Fix dailyData pulling from volumeInfo
- Add methodology.
- Add in Base Fees for Radiant
- fix woofi
- fix symbol
- Update query
- fix linting
- fix breakdown key
- enable metaplex
- update fwx baseUrl
- fix cow protocol
- add dexalot chain
- get dexalot volumes by chain via api
- perf: event getLogs pagination
- fix baseUrl & map chain id
- Add edgeX volume
- fix metaplex
- revert dexalot from breakdown to simple adapter
- CSPT-454 Added Chainspot adapter
- feat: add mangrove on arbitrum
- fix query
- fix gmx
- update ktx subgraph endpoints
- feat: add RouteProcessor5 to sushiswap aggregator adapter
- fix cetus
- Update data endpoint
- swith to version 1
- enable polygon
- fix magpie
- limit offset
- add arbitrum
- add xlayer
- fix contract id
- Update WingRiders adapter
- add new fees
- fix shuff
- feat:Adapter, Factor
- remove logs
- add filter out pool is less than 1000 usd tvl
- fix ktx subgraph url
- chore: rename the address const
- fix
- fix rev
- Add demented-games to fees dashboard
- photon fees
- fix jupiter-perpetual
- remove not use
- add header
- Allez Labs: Adding Fee data for Kamino lending, this includes Interest, Liquidation and origination revenue as well as interest generated data
- fluid: add base
- add dexscreener fees
- Add Ston.fi fees and revenue calculations
- Update lifinity.ts
- feat: Implement seiyan-fun adapter
- Add referral fees
- fix ragage
- Add dailyFees
- add moonwell fees
- add sei to vertex
- add derivatives and volume sei vertex
- Add ReservesAdded event
- fix start time
- print message if a chain is skipped
- add astrolescent volume
- add custom backfill to Astrolescent
- patch
- custom block
- pendle active addresses
- switch too v1
- add pancake optiobs
- fix timestamp
- orai: add volume for oraidex v3
- change query
- feat:Adapter, Spiko Fees
- fix default value
- fix ston fees
- fix: Update subgraph links
- Add historical OI + Freestyle volume for BMX
- add sunpump
- add helio
- DackieSwap update endpoint subgraph
- add dextools
- add manifold
- clean
- add stablecoins + minor fix
- add thegraph
- dextools add native transfers
- fix sideshift
- fix skip unknow token
- block volume less than 0
- fix wrong set aadapter
- skip map work
- Update sideshift.ts
- soltradingbot
- fix
- fix negative rev
- add address
- chore: Update seiyanfun initial timestamp
- fix
- add 4Cast fees adaptor
- update: change endpoint url.
- edit start date
- fix filter by date id
- fix date
- impermax: add new chains fees
- pendle volumes
- v2 func
- fix get daily data
- Fixed reserve calculation
- fix version of api
- fix version
- update icpswap
- change directory
- upgrade sdk for tron
- fix sunpump
- fix not use param
- check metric against whitelist
- fix unidex
- feat: bellum exchange fees and revenue
- feat: Adapter Splash (fees)
- update fee
- fix fwx dexs
- Feat:Adapter, Ribbon, fees & volume
- small fix
- implement fwx-dex fees
- Add Jellyverse adapter for SEI chain
- fix nagative value
- 3xcalibur
- arbitrum ex
- fix wrong calling
- update houdini-swap fees
- Added seize tokens to daily fees
- add illuvium
- methodology
- add raybot
- fix createSolBalances
- implement fwx-dex dexs
- remove fwx-dex
- Add bitlayer network, rename vars
- feat: add cyberPerp adapter
- Update api url
- mul by 13e
- fix version
- fix delay dune query
- fix disable count swap for derivation
- Fix seize tokens
- feat: added Stride stBAND and stISLM fees
- fix chain
- Add velo fee canculation.
- fix: garden fee url
- Update index.ts
- Update index.ts
- feat:Adapter, OpenEden-t-bills Fees
- promise type
- fix allow error get block chain dymension
- update chain
- update: and chains Scroll, mantle and linea
- Add aquarius adapter
- incorrect v2 adapter
- fix
- fix split block ragg for get fees
- fix dodo fees
- fix version dodo
- fix breakdown
- bmx
