### PR TITLE
fix: Update the Arbitrum subgraph endpoint for Kwenta volume tracking

### DIFF
--- a/aggregator-derivatives/kwenta/index.ts
+++ b/aggregator-derivatives/kwenta/index.ts
@@ -29,7 +29,7 @@ const PROVIDER_CONFIG = {
   },
   [CHAIN.ARBITRUM]: {
     startTimestamp: 1696032000,
-    endpoint: "https://subgraph.satsuma-prod.com/7ed49092fef1/equilibria/perennial-v2-arbitrum-new/api",
+    endpoint: "https://subgraph.perennial.finance/arbitrum",
     query: gql`
       query aggregateStats($startTimestamp: BigInt!, $endTimestamp: BigInt!) {
         marketAccumulations(


### PR DESCRIPTION
The previous endpoint has been deprecated, causing the query to break. This PR resolves the issue by updating to the new endpoint.