### PR TITLE
add avalon-finance-cedefi

### DIFF
--- a/fees/avalon-finance-cedefi/index.ts
+++ b/fees/avalon-finance-cedefi/index.ts
@@ -8,21 +8,20 @@ const abi = {
 		'function getPoolManagerConfig() view returns (tuple(uint256 DEFAULT_LTV, uint256 DEFAULT_LIQUIDATION_THRESHOLD, uint256 DEFAULT_POOL_INTEREST_RATE, uint256 DEFAULT_PROTOCOL_INTEREST_RATE, address USDT, address FBTC0, address FBTC1, address FBTCOracle, address AvalonUSDTVault, address AntaphaUSDTVault))',
 }
 
-const poolAddress = '0xF95308B15E45BFF3d0811B5732d17Eb2A555afB2'
+const poolAddress = '0x02feDCff97942fe28e8936Cdc3D7A480fdD248f0'
 
 export default {
 	adapter: {
 		[CHAIN.ETHEREUM]: {
 			fetch: (async ({ api, createBalances }) => {
-				const fees = createBalances()
-				const revenue = createBalances()
+				const dailyFees = createBalances()
+				const dailyRevenue = createBalances()
 
 				// Get the pool manager configuration
 				const poolManagerConfig = await api.call({
 					target: poolAddress,
 					abi: abi.getPoolManagerConfig,
 				})
-
 				const poolManagerReserveInformation = await api.call({
 					target: poolAddress,
 					abi: abi.getPoolManagerReserveInformation,
@@ -30,14 +29,15 @@ export default {
 
 				// Protocol Fee = PoolManagerReserveInformation.debt * PoolManagerConfig.DEFAULT_PROTOCOL_INTEREST_RATE
 				// DEFAULT_PROTOCOL_INTEREST_RATE decimals = 4
-				const amount = (poolManagerReserveInformation.debt * poolManagerConfig.DEFAULT_PROTOCOL_INTEREST_RATE) / 10000
+				const amount = poolManagerReserveInformation.debt * poolManagerConfig.DEFAULT_PROTOCOL_INTEREST_RATE / 1e4
 
-				fees.addToken('USDT', amount)
-				revenue.addToken('USDT', amount)
 
-				return { fees, revenue }
+				dailyFees.addUSDValue(amount)
+				dailyRevenue.addUSDValue(amount)
+
+				return { dailyFees, dailyRevenue }
 			}) as FetchV2,
-			start: 20398625,
+			start: 1722088222,
 		},
 	},
 	version: 2,

--- a/fees/avalon-finance-cedefi/index.ts
+++ b/fees/avalon-finance-cedefi/index.ts
@@ -1,0 +1,44 @@
+import { Adapter, FetchV2 } from '../../adapters/types'
+import { CHAIN } from '../../helpers/chains'
+
+const abi = {
+	getPoolManagerReserveInformation:
+		'function getPoolManagerReserveInformation() view returns (tuple(uint256 userAmount, uint256 collateral, uint256 debt, uint256 claimableUSDT, uint256 claimableBTC) poolManagerReserveInfor)',
+	getPoolManagerConfig:
+		'function getPoolManagerConfig() view returns (tuple(uint256 DEFAULT_LTV, uint256 DEFAULT_LIQUIDATION_THRESHOLD, uint256 DEFAULT_POOL_INTEREST_RATE, uint256 DEFAULT_PROTOCOL_INTEREST_RATE, address USDT, address FBTC0, address FBTC1, address FBTCOracle, address AvalonUSDTVault, address AntaphaUSDTVault))',
+}
+
+const poolAddress = '0xF95308B15E45BFF3d0811B5732d17Eb2A555afB2'
+
+export default {
+	adapter: {
+		[CHAIN.ETHEREUM]: {
+			fetch: (async ({ api, createBalances }) => {
+				const fees = createBalances()
+				const revenue = createBalances()
+
+				// Get the pool manager configuration
+				const poolManagerConfig = await api.call({
+					target: poolAddress,
+					abi: abi.getPoolManagerConfig,
+				})
+
+				const poolManagerReserveInformation = await api.call({
+					target: poolAddress,
+					abi: abi.getPoolManagerReserveInformation,
+				})
+
+				// Protocol Fee = PoolManagerReserveInformation.debt * PoolManagerConfig.DEFAULT_PROTOCOL_INTEREST_RATE
+				// DEFAULT_PROTOCOL_INTEREST_RATE decimals = 4
+				const amount = (poolManagerReserveInformation.debt * poolManagerConfig.DEFAULT_PROTOCOL_INTEREST_RATE) / 10000
+
+				fees.addToken('USDT', amount)
+				revenue.addToken('USDT', amount)
+
+				return { fees, revenue }
+			}) as FetchV2,
+			start: 20398625,
+		},
+	},
+	version: 2,
+} as Adapter

--- a/fees/avalon-finance-cedefi/types.ts
+++ b/fees/avalon-finance-cedefi/types.ts
@@ -1,0 +1,25 @@
+export type PoolManagerConfig = {
+  DEFAULT_LTV: bigint
+  DEFAULT_RECOVERY_LTV: bigint
+  DEFAULT_LIQUIDATION_THRESHOLD: bigint
+  DEFAULT_BUFFER: bigint
+  USDA: string
+  FBTC0: string
+  FBTC1: string
+  FBTCOracle: string
+  LiquidationBonusRate: bigint
+  BASE_INTEREST_RATE: bigint
+  PRIEMIUM_INTEREST_RATE: bigint
+}
+
+export type PoolManagerReserveInformation = {
+  userAmount: bigint
+  collateral: bigint
+  debt: bigint
+  claimableBTC: bigint
+}
+
+export type Reserve = {
+  decimals: number
+  symbol: string
+}


### PR DESCRIPTION
Trying to add Fee & Revenue for Avalon Labs CeDeFi. But it does not as expected. Looking for help. 

Fee & Revenue Mythology:  **Total Debt * Protocol Interest Rate.** 

OnChain Query
- CeDeFi Pool Address: `0xF95308B15E45BFF3d0811B5732d17Eb2A555afB2`
- Call `getPoolManagerReserveInformation` to get `debt` 
- Call `getPoolManagerConfig` to get `DEFAULT_POOL_INTEREST_RATE` 

----

Tried to build a fee and revenue adapter. But cannot pass the test. 

Error log:

```
[Error: Failed to call: function getPoolManagerConfig() view returns (tuple(uint256 DEFAULT_LTV, uint256 DEFAULT_LIQUIDATION_THRESHOLD, uint256 DEFAULT_POOL_INTEREST_RATE, uint256 DEFAULT_PROTOCOL_INTEREST_RATE, address USDT, address FBTC0, address FBTC1, address FBTCOracle, address AvalonUSDTVault, address AntaphaUSDTVault)) target: 0xF95308B15E45BFF3d0811B5732d17Eb2A555afB2 on chain: [ethereum] rpc: https://eth.llamarpc.com, https://rpc.ankr.com/eth, https://cloudflare-eth.com, https://ethereum-rpc.publicnode.com, https://1rpc.io/eth, https://rpc.mevblocker.io, https://rpc.flashbots.net, https://virginia.rpc.blxrbdn.com, https://uk.rpc.blxrbdn.com, https://singapore.rpc.blxrbdn.com, https://eth.rpc.blxrbdn.com, https://eth-mainnet.public.blastapi.io, https://api.securerpc.com/v1, https://eth-pokt.nodies.app, https://eth-mainnet-public.unifra.io, https://ethereum.blockpi.network/v1/rpc/public, https://rpc.payload.de, https://core.gashawk.io/rpc, https://eth.meowrpc.com, https://eth.drpc.org, https://mainnet.gateway.tenderly.co, https://gateway.tenderly.co/public/mainnet, https://eth.merkle.io, https://eth.nodeconnect.org, https://ethereum.rpc.subquery.network/public, https://rpc.graffiti.farm, https://rpc.public.curie.radiumblock.co/http/ethereum, https://eth-mainnet.4everland.org/v1/37fa9972c1b1cd5fab542c7bdd4cde2f, https://rpc.public.curie.radiumblock.co/ws/ethereum, https://rpc.flashbots.net/fast, https://rpc.mevblocker.io/fast, https://rpc.mevblocker.io/noreverts, https://rpc.mevblocker.io/fullprivacy  call reverted, reason: fragment.format is not a function   ] {
  _underlyingError: 'TypeError: fragment.format is not a function',
  _isCustomError: true,
  chain: 'ethereum'
}
```

