### PR TITLE
add dex for velocimeter v4 on iotaevm

### DIFF
--- a/dexs/velocimeter-v4/index.ts
+++ b/dexs/velocimeter-v4/index.ts
@@ -1,0 +1,6 @@
+import { CHAIN } from "../../helpers/chains";
+import { uniV2Exports } from "../../helpers/uniswap";
+
+export default uniV2Exports({
+  [CHAIN.IOTAEVM]: { factory: '0x10A288eF87586BE54ea690998cAC82F7Cc90BC50', },
+})

--- a/dexs/velocimeter-v4/index.ts
+++ b/dexs/velocimeter-v4/index.ts
@@ -2,5 +2,5 @@ import { CHAIN } from "../../helpers/chains";
 import { uniV2Exports } from "../../helpers/uniswap";
 
 export default uniV2Exports({
-  [CHAIN.IOTAEVM]: { factory: '0x10A288eF87586BE54ea690998cAC82F7Cc90BC50', },
+  [CHAIN.IOTAEVM]: { factory: '0x10A288eF87586BE54ea690998cAC82F7Cc90BC50', fees: 0.0025, voter: '0x6c9BB73106501c6E0241Fe8E141620868b3F0096' },
 })


### PR DESCRIPTION
Track dex volume for velocimeter v4 on iota evm.

https://explorer.evm.iota.org/address/0x10A288eF87586BE54ea690998cAC82F7Cc90BC50

cc @t0rbik