### PR TITLE
use dune for jupiter aggregator data.

### DIFF
--- a/aggregators/jupiter-aggregator/index.ts
+++ b/aggregators/jupiter-aggregator/index.ts
@@ -1,29 +1,31 @@
 import { CHAIN } from "../../helpers/chains";
-import { getUniqStartOfTodayTimestamp } from "../../helpers/getUniSubgraphVolume";
-import { fetchURLWithRetry } from "../../helpers/duneRequest";
+import { FetchOptions } from "../../adapters/types";
+import { queryDune } from "../../helpers/dune";
 
-const fetch = async (timestamp: number) => {
-  const unixTimestamp = getUniqStartOfTodayTimestamp();
-  const data = await fetchURLWithRetry(
-    `https://api.dune.com/api/v1/query/3099651/results`
-  );
-  const chainData = data.result.rows[0];
+const fetch = async (options: FetchOptions) => {
+  const start = options.startOfDay;
+  const data = await queryDune("4187430", {
+    start: start,
+    end: start + 24 * 60 * 60,
+  });
+  const chainData = data[0];
   if (!chainData) throw new Error(`Dune query failed: ${JSON.stringify(data)}`);
   return {
     dailyVolume: chainData.volume_24,
-    timestamp: unixTimestamp,
+    totalVolume: chainData.volume,
   };
 };
 
 const adapter: any = {
-  timetravel: false,
   adapter: {
     [CHAIN.SOLANA]: {
-      fetch: fetch,
+      fetch: (_t: any, _tt: any, options: FetchOptions) => fetch(options),
       runAtCurrTime: true,
-      start: 1729296000,
+      start: 1681599600,
       meta: {
         methodology: {
+          totalVolume:
+            "Volume is calculated by summing the token volume of all trades settled on the protocol since launch.",
           dailyVolume:
             "Volume is calculated by summing the token volume of all trades settled on the protocol that day.",
         },

--- a/aggregators/jupiter-aggregator/index.ts
+++ b/aggregators/jupiter-aggregator/index.ts
@@ -20,7 +20,6 @@ const adapter: any = {
   adapter: {
     [CHAIN.SOLANA]: {
       fetch: (_t: any, _tt: any, options: FetchOptions) => fetch(options),
-      runAtCurrTime: true,
       start: 1681599600,
       meta: {
         methodology: {


### PR DESCRIPTION
before that, it is using a custom endpoint by Jupiter that has been deprecated. now, it is using data directly from Dune by a third party, this way, it is more credible.