### PR TITLE
Fix Mevx, using option to blacklists with Allium queries

### DIFF
--- a/fees/mevx.ts
+++ b/fees/mevx.ts
@@ -3,13 +3,17 @@ import { CHAIN } from "../helpers/chains";
 import { getSolanaReceived } from "../helpers/token";
 
 const fetch: any = async (options: FetchOptions) => {
-  const dailyFees = await getSolanaReceived({ options, targets: [
-    '5wkyL2FLEcyUUgc3UeGntHTAfWfzDrVuxMnaMm7792Gk',
-    '4Lpvp1q69SHentfYcMBUrkgvppeEx6ovHCSYjg4UYXiq',
-    'BS3CyJ9rRC4Tp8G7f86r6hGvuu3XdrVGNVpbNM9U5WRZ',
-  ] })
-  return { dailyFees, dailyRevenue: dailyFees, }
-}
+  const dailyFees = await getSolanaReceived({
+    blacklists: ['3kxSQybWEeQZsMuNWMRJH4TxrhwoDwfv41TNMLRzFP5A', 'BS3CyJ9rRC4Tp8G7f86r6hGvuu3XdrVGNVpbNM9U5WRZ', '4Lpvp1q69SHentfYcMBUrkgvppeEx6ovHCSYjg4UYXiq'],
+    options,
+    targets: [
+      "5wkyL2FLEcyUUgc3UeGntHTAfWfzDrVuxMnaMm7792Gk",
+      "4Lpvp1q69SHentfYcMBUrkgvppeEx6ovHCSYjg4UYXiq",
+      "BS3CyJ9rRC4Tp8G7f86r6hGvuu3XdrVGNVpbNM9U5WRZ",
+    ],
+  });
+  return { dailyFees, dailyRevenue: dailyFees };
+};
 
 const adapter: SimpleAdapter = {
   version: 2,
@@ -19,7 +23,7 @@ const adapter: SimpleAdapter = {
       start: 0,
     },
   },
-  isExpensiveAdapter: true
+  isExpensiveAdapter: true,
 };
 
 export default adapter;


### PR DESCRIPTION
Added an option to blacklist addresses in our Allium query to avoid counting large token amounts in our SolanaReceived if the team sends a significant amount to the addresses we are tracking