### PR TITLE
Defx : Add defx adapter

### DIFF
--- a/dexs/defx/index.ts
+++ b/dexs/defx/index.ts
@@ -1,0 +1,38 @@
+import type { SimpleAdapter } from "../../adapters/types";
+import { getUniqStartOfTodayTimestamp } from "../../helpers/getUniSubgraphVolume";
+import { CHAIN } from "../../helpers/chains";
+import { httpGet } from "../../utils/fetchURL";
+
+const URL = "https://api.defx.com/v1/open/analytics/market/overview";
+
+interface Response {
+  data:{
+    totalVol?: string;
+    dayVol?: string;
+  }
+}
+
+const fetch = async (timestamp: number) => {
+  const response: Response = (await httpGet(URL));
+  const dayTimestamp = getUniqStartOfTodayTimestamp(new Date(timestamp * 1000));
+  
+  const returnObj = {
+    totalVolume: response?.data.totalVol?.toString(),
+    dailyVolume: response?.data.dayVol?.toString(),
+    timestamp: dayTimestamp,
+  };
+  
+  return returnObj;
+};
+
+const adapter: SimpleAdapter = {
+  adapter: {
+    "defx": {
+      fetch,
+      start: 1727780831,
+      runAtCurrTime: true
+    },
+  }
+};
+
+export default adapter;


### PR DESCRIPTION
```
(base) ➜  dimension-adapters git:(master) ✗ yarn test dexs defx                          
yarn run v1.22.19
$ ts-node --transpile-only cli/testAdapter.ts dexs defx
🦙 Running DEFX adapter 🦙
---------------------------------------------------
Start Date:     Mon, 21 Oct 2024 00:00:00 GMT
End Date:       Tue, 22 Oct 2024 00:00:00 GMT
---------------------------------------------------

DEFX 👇
Backfill start time: 1/10/2024
NO METHODOLOGY SPECIFIED
Total volume: 6.33 M
Daily volume: 27.13 k
End timestamp: 1729468800 (2024-10-21T00:00:00.000Z)




✨  Done in 5.08s.
```