### PR TITLE
Get the contract id through api

### DIFF
--- a/dexs/edgeX/index.ts
+++ b/dexs/edgeX/index.ts
@@ -36,15 +36,12 @@ function parseContractIds(response: any): string[] {
 const fetch = async (timestamp: number): Promise<FetchResultVolume> => {
   const dayTimestamp = getUniqStartOfTodayTimestamp(new Date(timestamp * 1000)) * 1000
   const toTimestamp = dayTimestamp + 60 * 60 * 24 * 1000;
-  const contractIds: string[] = [
-    '10000001', '10000002',
-    '10000003', '10000004',
-    '10000005', '10000006',
-    '10000007', '10000008',
-    '10000009', '10000010'
-  ]
-  const klines = (await Promise.all(contractIds.map(async (contractId) => fetchURL(klineDailyEndpoint(contractId, dayTimestamp, toTimestamp)))))
-    .map((response: ApiResponse) => response.data.dataList);
+  const contractIds: string[] = parseContractIds(await fetchURL(metaDataEndpoint));
+  const klines = await Promise.all(contractIds.map(async (contractId) => {
+    const response: ApiResponse = await fetchURL(klineDailyEndpoint(contractId, dayTimestamp, toTimestamp));
+    return response.data.dataList;
+  }
+  ));
   const volumes = klines
     .flat()
     .map(kline => parseFloat(kline.value))


### PR DESCRIPTION
Get the contract id through api instead of hard coding the contract ids which does not include all contracts