### PR TITLE
Feat: update fees and add real

### DIFF
--- a/fees/impermax-finance/index.ts
+++ b/fees/impermax-finance/index.ts
@@ -1,0 +1,206 @@
+import { Adapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import { request } from "graphql-request";
+import { query } from "./query";
+import { getChainUnderlyingPrices } from "./prices";
+
+const methodology = {
+  Fees: "Fees is the interest rate paid by borrowers",
+  Revenue:
+    "Percentage of interest going to treasury, determined by each lending pools reserve factor.",
+};
+
+const config = {
+  ethereum: [
+    "https://api.studio.thegraph.com/query/46041/impermax-mainnet-v1/v0.0.1",
+  ],
+  polygon: [
+    "https://api.studio.thegraph.com/query/46041/impermax-x-uniswap-v2-polygon-v2/v0.0.1",
+    "https://api.studio.thegraph.com/query/46041/impermax-polygon-solv2/v0.0.1",
+    "https://api.studio.thegraph.com/query/46041/impermax-polygon-sol-stable/v0.0.1",
+  ],
+  arbitrum: [
+    "https://api.studio.thegraph.com/query/46041/impermax-arbitrum-v1/v0.0.1",
+    "https://api.studio.thegraph.com/query/46041/impermax-arbitrum-v2/v0.0.1",
+    "https://api.studio.thegraph.com/query/46041/impermax-arbitrum-solv2/v0.0.2",
+  ],
+  optimism: [
+    "https://api.studio.thegraph.com/query/46041/impermax-optimism-solv2/v0.0.1",
+  ],
+  fantom: [
+    "https://api.studio.thegraph.com/query/46041/impermax-fantom-solv2/v0.0.2",
+  ],
+  base: [
+    "https://api.studio.thegraph.com/query/46041/impermax-base-solv2/v0.0.2",
+    "https://api.studio.thegraph.com/query/46041/impermax-base-solv2-stable/v0.0.1",
+  ],
+  scroll: [
+    "https://api.studio.thegraph.com/query/46041/impermax-scroll-solv2/v0.0.2",
+    "https://api.studio.thegraph.com/query/46041/impermax-scroll-solv2-stable/0.0.9",
+  ],
+  real: [
+    "https://api.goldsky.com/api/public/project_cm2d5q4l4w31601vz4swb3vmi/subgraphs/impermax-finance/impermax-real-v2-stable/gn",
+    "https://api.goldsky.com/api/public/project_cm2rhb30ot9wu01to8c9h9e37/subgraphs/impermax-real-solv2/3.0/gn",
+  ],
+};
+
+const getChainBorrowables = async (chain: CHAIN) => {
+  const urls = config[chain];
+  let allBorrowables = [];
+
+  for (const url of urls) {
+    const queryResult = await request(url, query);
+    allBorrowables = allBorrowables.concat(queryResult.borrowables);
+  }
+
+  return allBorrowables;
+};
+
+interface IBorrowable {
+  id: string;
+  borrowRate: string;
+  reserveFactor: string;
+  totalBorrows: string;
+  totalBalance: string;
+  accrualTimestamp: string;
+  underlying: {
+    symbol: string;
+    id: string;
+  };
+}
+
+const MONTH_IN_SECONDS = 30 * 24 * 60 * 60;
+
+const calculate = (
+  borrowable: IBorrowable,
+  prices: object,
+  chain: CHAIN,
+  timestamp: number,
+): { dailyFees: number; dailyRevenue: number } => {
+  // Get this borrowable's stored data
+  const {
+    totalBorrows,
+    borrowRate,
+    reserveFactor,
+    underlying,
+    accrualTimestamp,
+  } = borrowable;
+
+  // Filter out dead borrowables and those we cannot get the underlying price
+  const underlyingPrice = prices[`${chain}:${underlying.id}`];
+  const hasAccruedRecently = timestamp - Number(accrualTimestamp) <= MONTH_IN_SECONDS;
+
+  if (!underlyingPrice || !hasAccruedRecently) { 
+    return { dailyFees: 0, dailyRevenue: 0 };
+  }
+
+  // The daily fees is the interest paid to lenders, while the daily revenue
+  // is the percentage that goes to the reserves according to the reserve factor.
+  const dailyBorrowAPR = Number(borrowRate) * 86400;
+  const dailyFees = Number(totalBorrows) * underlyingPrice * dailyBorrowAPR;
+  const dailyRevenue = dailyFees * Number(reserveFactor);
+
+  return { dailyFees, dailyRevenue };
+};
+
+const graphs = () => {
+  return (chain: CHAIN) => {
+    return async (timestamp: number) => {
+      // 1. Get all the chain borrowables
+      const borrowables: IBorrowable[] = await getChainBorrowables(chain);
+
+      // 2. Get the prices of all underlyings on this chain using llama + gecko
+      const underlyings = borrowables.map((i) => i.underlying.id);
+      const prices = await getChainUnderlyingPrices(chain, underlyings);
+
+      // Since each borrowable may have different reserve factor we have to
+      // loop through each one.
+      const { dailyFees, dailyRevenue } = borrowables
+        .map((b: IBorrowable) => calculate(b, prices, chain, timestamp))
+        .reduce(
+          (acc, val) => ({
+            dailyFees: acc.dailyFees + val.dailyFees,
+            dailyRevenue: acc.dailyRevenue + val.dailyRevenue,
+          }),
+          { dailyFees: 0, dailyRevenue: 0 },
+        );
+
+      return {
+        timestamp,
+        dailyFees: dailyFees.toString(),
+        dailyRevenue: dailyRevenue.toString(),
+      };
+    };
+  };
+};
+
+const adapter: Adapter = {
+  adapter: {
+    [CHAIN.ETHEREUM]: {
+      fetch: graphs()(CHAIN.ETHEREUM),
+      runAtCurrTime: true,
+      start: 1698019200,
+      meta: {
+        methodology,
+      },
+    },
+    [CHAIN.POLYGON]: {
+      fetch: graphs()(CHAIN.POLYGON),
+      runAtCurrTime: true,
+      start: 1698019200,
+      meta: {
+        methodology,
+      },
+    },
+    [CHAIN.ARBITRUM]: {
+      fetch: graphs()(CHAIN.ARBITRUM),
+      runAtCurrTime: true,
+      start: 1698019200,
+      meta: {
+        methodology,
+      },
+    },
+    [CHAIN.FANTOM]: {
+      fetch: graphs()(CHAIN.FANTOM),
+      runAtCurrTime: true,
+      start: 1698019200,
+      meta: {
+        methodology,
+      },
+    },
+    [CHAIN.BASE]: {
+      fetch: graphs()(CHAIN.BASE),
+      runAtCurrTime: true,
+      start: 1698019200,
+      meta: {
+        methodology,
+      },
+    },
+    [CHAIN.SCROLL]: {
+      fetch: graphs()(CHAIN.SCROLL),
+      runAtCurrTime: true,
+      start: 1698019200,
+      meta: {
+        methodology,
+      },
+    },
+    [CHAIN.OPTIMISM]: {
+      fetch: graphs()(CHAIN.OPTIMISM),
+      runAtCurrTime: true,
+      start: 1698019200,
+      meta: {
+        methodology,
+      },
+    },
+    [CHAIN.REAL]: {
+      fetch: graphs()(CHAIN.REAL),
+      runAtCurrTime: true,
+      start: 1698019200,
+      meta: {
+        methodology,
+      },
+    },
+  },
+};
+
+export default adapter;

--- a/fees/impermax-finance/old-adapter.ts
+++ b/fees/impermax-finance/old-adapter.ts
@@ -1,6 +1,8 @@
-import { Adapter } from "../adapters/types";
-import { CHAIN } from "../helpers/chains";
-import fetchURL from "../utils/fetchURL";
+// WARN: Old adapter with a fixed reserve rate
+
+import { Adapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import fetchURL from "../../utils/fetchURL";
 
 // NOTE: the yields server does not return all pools if liquidity is too low, which
 // may result in calculated fees and revenue being lower than what is real
@@ -48,71 +50,54 @@ const graphs = () => {
 
 const adapter: Adapter = {
   adapter: {
-    [CHAIN.ETHEREUM]: {
-      fetch: graphs()(CHAIN.ETHEREUM),
-      runAtCurrTime: true,
-      start: 1698019200,
-      meta: {
-        methodology
-      }
-    },
-    [CHAIN.POLYGON]: {
-      fetch: graphs()(CHAIN.POLYGON),
-      runAtCurrTime: true,
-      start: 1698019200,
-      meta: {
-        methodology
-      }
-    },
-    [CHAIN.ARBITRUM]: {
-      fetch: graphs()(CHAIN.ARBITRUM),
-      runAtCurrTime: true,
-      start: 1698019200,
-      meta: {
-        methodology
-      }
-    },
-    [CHAIN.AVAX]: {
-      fetch: graphs()(CHAIN.AVAX),
-      runAtCurrTime: true,
-      start: 1698019200,
-      meta: {
-        methodology
-      }
-    },
-    // disable beacause api is not include chain moonriver and canto yet
-    // [CHAIN.MOONRIVER]: {
-    //   fetch: graphs()(CHAIN.MOONRIVER),
-      // runAtCurrTime: true,
+    // [CHAIN.ETHEREUM]: {
+    //   fetch: graphs()(CHAIN.ETHEREUM),
+    //   runAtCurrTime: true,
     //   start: 1698019200,
     //   meta: {
     //     methodology
     //   }
     // },
-    // [CHAIN.CANTO]: {
-    //   fetch: graphs()(CHAIN.CANTO),
-      // runAtCurrTime: true,
+    // [CHAIN.POLYGON]: {
+    //   fetch: graphs()(CHAIN.POLYGON),
+    //   runAtCurrTime: true,
     //   start: 1698019200,
     //   meta: {
     //     methodology
     //   }
     // },
-    [CHAIN.ERA]: {
-      fetch: graphs()(CHAIN.ERA),
-      runAtCurrTime: true,
-      start: 1698019200,
-      meta: {
-        methodology
-      }
-    },
-    [CHAIN.FANTOM]: {
-      fetch: graphs()(CHAIN.FANTOM),
-      runAtCurrTime: true,
-      start: 1698019200,
-      meta: {
-        methodology
-      }
-    },
+    // [CHAIN.ARBITRUM]: {
+    //   fetch: graphs()(CHAIN.ARBITRUM),
+    //   runAtCurrTime: true,
+    //   start: 1698019200,
+    //   meta: {
+    //     methodology
+    //   }
+    // },
+    // [CHAIN.AVAX]: {
+    //   fetch: graphs()(CHAIN.AVAX),
+    //   runAtCurrTime: true,
+    //   start: 1698019200,
+    //   meta: {
+    //     methodology
+    //   }
+    // },
+    // [CHAIN.ERA]: {
+    //   fetch: graphs()(CHAIN.ERA),
+    //   runAtCurrTime: true,
+    //   start: 1698019200,
+    //   meta: {
+    //     methodology
+    //   }
+    // },
+    // [CHAIN.FANTOM]: {
+    //   fetch: graphs()(CHAIN.FANTOM),
+    //   runAtCurrTime: true,
+    //   start: 1698019200,
+    //   meta: {
+    //     methodology
+    //   }
+    // },
     [CHAIN.BASE]: {
       fetch: graphs()(CHAIN.BASE),
       runAtCurrTime: true,
@@ -121,16 +106,24 @@ const adapter: Adapter = {
         methodology
       }
     },
-    [CHAIN.SCROLL]: {
-      fetch: graphs()(CHAIN.SCROLL),
-      runAtCurrTime: true,
-      start: 1698019200,
-      meta: {
-        methodology
-      }
-    },
-    [CHAIN.OPTIMISM]: {
-      fetch: graphs()(CHAIN.OPTIMISM),
+    //[CHAIN.SCROLL]: {
+    //  fetch: graphs()(CHAIN.SCROLL),
+    //  runAtCurrTime: true,
+    //  start: 1698019200,
+    //  meta: {
+    //    methodology
+    //  }
+    //},
+    //[CHAIN.OPTIMISM]: {
+    //  fetch: graphs()(CHAIN.OPTIMISM),
+    //  runAtCurrTime: true,
+    //  start: 1698019200,
+    //  meta: {
+    //    methodology
+    //  }
+    //},
+    [CHAIN.REAL]: {
+      fetch: graphs()(CHAIN.REAL),
       runAtCurrTime: true,
       start: 1698019200,
       meta: {

--- a/fees/impermax-finance/prices.ts
+++ b/fees/impermax-finance/prices.ts
@@ -1,0 +1,104 @@
+const GECKOTERMINAL_IDS = { 
+  avalanche: 'avax',
+  ethereum: 'eth',
+  polygon: 'polygon_pos',
+  arbitrum: 'arbitrum',
+  fantom: 'ftm',
+  base: 'base',
+  scroll: 'scroll',
+  optimism: 'optimism',
+  real: 'real'
+}
+
+// Try llama, then geckoterminal, if all fail exclude
+export async function getChainUnderlyingPrices(chain: string, tokenAddresses: string[]) {
+  // Remove duplicate underlyings
+  const uniqueTokens = [...new Set(tokenAddresses)];
+
+  const { tokenPrices, missingTokens } = await getPriceFromDefiLlama(
+    chain,
+    uniqueTokens
+  );
+  if (tokenPrices && missingTokens.length == 0) return tokenPrices;
+
+  const tokenPricesV2 = { ...tokenPrices };
+
+  const coingeckoPrices = await getPriceFromGeckoTerminal(chain, missingTokens);
+  if (coingeckoPrices) {
+    for (const [key, price] of Object.entries(coingeckoPrices)) {
+      if (price) tokenPricesV2[key] = price;
+    }
+  }
+
+  return tokenPricesV2;
+}
+
+const getPriceFromDefiLlama = async (chain: string, tokenAddresses: string[]) => {
+  const MAX_LLAMA_COINS = 100;
+  const tokenPrices = {};
+  const missingTokens: string[] = [];
+
+  try {
+    for (let i = 0; i < tokenAddresses.length; i += MAX_LLAMA_COINS) {
+      const maxTokens = tokenAddresses.slice(i, i + MAX_LLAMA_COINS);
+      const chainTokens = maxTokens.map((address) => `${chain}:${address}`);
+
+      const { coins } = await fetch(
+        `https://coins.llama.fi/prices/current/${chainTokens.join(',')}`
+      ).then((i) => i.json());
+
+      maxTokens.forEach((token) => {
+        const key = `${chain}:${token}`;
+        const tokenPrice = coins[key]?.price;
+
+        // Push to missing and try get these from gecko
+        if (!tokenPrice) {
+          missingTokens.push(token);
+          return;
+        }
+
+        tokenPrices[key] = parseFloat(tokenPrice);
+      });
+    }
+
+    return { tokenPrices, missingTokens };
+  } catch (error) {
+    console.warn(`DefiLlama prices fail on ${chain}:`, error.message);
+    return { undefined, missingTokens: tokenAddresses };
+  }
+};
+
+async function getPriceFromGeckoTerminal(chain: string, tokenAddresses: string[]) {
+  console.log(`Getting ${tokenAddresses.length} tokens from gecko on ${chain}`);
+  const MAX_GECKO_COINS = 25;
+  const geckoChainId = GECKOTERMINAL_IDS[chain];
+  const tokenPrices = {};
+
+  try {
+    for (let i = 0; i < tokenAddresses.length; i += MAX_GECKO_COINS) {
+      const maxTokens = tokenAddresses.slice(i, i + MAX_GECKO_COINS);
+      const tokens = maxTokens.join(',');
+
+      const { data } = await fetch(
+        `https://api.geckoterminal.com/api/v2/simple/networks/${geckoChainId}/token_price/${tokens}`
+      ).then((i) => i.json());
+
+      maxTokens.forEach((token) => {
+        const key = `${chain}:${token}`;
+        const tokenPrice = data.attributes.token_prices[token];
+
+        if (!tokenPrice) {
+          console.warn(`No price found on Gecko for token: ${token}`);
+          return;
+        }
+
+        tokenPrices[key] = parseFloat(tokenPrice);
+      });
+    }
+    return tokenPrices;
+  } catch (error) {
+    console.error(`Gecko prices fail on ${chain}:`, error.message);
+    return undefined;
+  }
+}
+

--- a/fees/impermax-finance/query.ts
+++ b/fees/impermax-finance/query.ts
@@ -1,0 +1,45 @@
+import { gql } from "graphql-request";
+
+// GraphQL query
+export const query = gql`
+  {
+    borrowables {
+      id
+      totalBalance
+      totalBorrows
+      reserveFactor
+      borrowRate
+      accrualTimestamp
+      underlying {
+        id
+        name
+        symbol
+        decimals
+      }
+      lendingPool {
+        id
+        collateral {
+          liquidationFee
+          liquidationIncentive
+          safetyMargin
+        }
+        pair {
+          uniswapV2Factory
+          token0 {
+            id
+            name
+            symbol
+            decimals
+          }
+          token1 {
+            id
+            name
+            symbol
+            decimals
+          }
+        }
+      }
+    }
+  }
+`;
+

--- a/helpers/chains.ts
+++ b/helpers/chains.ts
@@ -176,6 +176,7 @@ export enum CHAIN {
   MINT = "mint",
   HELA = "hela",
   FUEL = "fuel",
+  REAL = "real"
 }
 
 // Don´t use


### PR DESCRIPTION
Wrote new logic for the `fees` adapter for `impermax-finance` as this way it is more accurate (previously we had a fix reserve factor for all pools of 10%, now we get it from the graphql endpoint).

Also note:

1. I added the `real` network to the `/helpers/`
2. I moved the fees adapter to its own directory `/fees/impermax-finance/index.ts`