### PR TITLE
update dexscreener fees

### DIFF
--- a/fees/dexscreener.ts
+++ b/fees/dexscreener.ts
@@ -19,7 +19,7 @@ const eth = async (options: FetchOptions) => {
 
 // TODO: check whether 5qR17nnyyBjoHPiGiAD4ZHFCSJixebJCYymArGgZiDnh was an older address where they received payments
 const sol = async (options: FetchOptions) => {
-    const dailyFees = await getSolanaReceived({ options, target: '23vEM5NAmK68uBHFM52nfNtZn7CgpHDSmAGWebsjg5ft' })
+    const dailyFees = await getSolanaReceived({ options, targets: ['23vEM5NAmK68uBHFM52nfNtZn7CgpHDSmAGWebsjg5ft', 'AJENSD55ZJBwipZnEf7UzW2pjxex1cV2jSKPz7aMwJo5'] })
     return { dailyFees, dailyRevenue: dailyFees, }
 }
 


### PR DESCRIPTION
gm llamas

added a [second address](https://solscan.io/account/AJENSD55ZJBwipZnEf7UzW2pjxex1cV2jSKPz7aMwJo5) to DEX Screener's fees

reasoning:
- Coinbase Commerce (hel.io), just like the already added address
- Receives values of $100, $250, $400, $900, $4000 (minus fees), which is what Boosts cost on DEX Screener
- Boosts were not included in current rev. tracking, only profile info payment

![image](https://github.com/user-attachments/assets/64ab82bd-73e3-494c-88f6-70478acb2542)
