### PR TITLE
Fluid: fix get latest block before timestamp

### DIFF
--- a/fees/fluid/index.ts
+++ b/fees/fluid/index.ts
@@ -415,8 +415,7 @@ const getLiquidityRevenueFromTo = async (
 
     // add collected revenue in time frame to the to time point revenue.
     // to revenue = uncollected at that point + all collected revenue since from
-    const _revenueTo = BigNumber(revenueTo[index]);
-    _revenueTo.plus(collectedRevenue);
+    const _revenueTo = BigNumber(revenueTo[index]).plus(collectedRevenue);
 
     // get uncollected revenue in from -> to timespan
     dailyValues.add(


### PR DESCRIPTION
This PR is somewhat related to https://github.com/DefiLlama/dimension-adapters/pull/2086 

I added `-1` on `(await getBlock(api.chain, timestamp)).number - 1`  in that PR, but it looks like getBlock() is sometimes off by quite a bit. So I implemented a method to guarantee the block timestamp is the latest block **before** the target timestamp, because otherwise we get a revert when calling `calcRevenueSimulatedTime()`. 

Also fixes a bug for collectedRevenue case between from and to timestamp.

We had another spike in wrong revenue for Fluid. Which we need to backfill. I hope this PR helps to avoid all such cases in the future in the first place
![image](https://github.com/user-attachments/assets/9b2feb45-c200-4701-951c-f5b303291252)

![image](https://github.com/user-attachments/assets/29dab142-5443-4176-9c6e-3ee3e0bc1190)


