### PR TITLE
Add volume adapters for WAGMI launchpad

### DIFF
--- a/dexs/wagmi_ton/index.ts
+++ b/dexs/wagmi_ton/index.ts
@@ -1,0 +1,32 @@
+import fetchURL from "../../utils/fetchURL"
+import { CHAIN } from "../../helpers/chains";
+import { FetchOptions } from "../../adapters/types";
+import { getPrices } from "../../utils/prices";
+
+
+const endpoint = "https://tonfunstats-eqnd7.ondigitalocean.app/api/v1/getVolume"
+
+
+const fetch = async (options: FetchOptions) => {
+    const res = await fetchURL(`${endpoint}?from=${options.startTimestamp}&to=${options.endTimestamp}&service=wagmi`)
+    const TON = "coingecko:the-open-network"
+    const ton_price = await getPrices([TON], options.startTimestamp);
+
+    return {
+        dailyVolume: Number(BigInt(res.volume) / 1000000000n) * ton_price[TON].price,
+        timestamp: options.startTimestamp,
+    };
+};
+
+
+const adapter: any = {
+    version: 2,
+    adapter: {
+        [CHAIN.TON]: {
+            fetch,
+            start: '2024-10-24',
+        },
+    },
+};
+
+export default adapter;


### PR DESCRIPTION
The "wagmi_ton" adapter is linked to the WAGMI project, which can be found here:
https://github.com/DefiLlama/DefiLlama-Adapters/blob/main/projects/wagmi/index.js

We chose this name because "wagmi" was already taken, and this helps to avoid any naming conflicts.