### PR TITLE
logx options volume adapter

### DIFF
--- a/options/logx/index.ts
+++ b/options/logx/index.ts
@@ -1,0 +1,36 @@
+import fetchURL from "../../utils/fetchURL";
+import { FetchResult, SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+
+
+const URLEndpoint = "https://mainnetapiserver.logx.network/api/v1/stats/defillama/options?endTime=";
+const startTimestamp = 1733961600; // 12.12.2024
+
+interface IAPIResponse {
+  last24HourVolume: string;
+  totalVolume: string;
+}
+const fetch = async (timestamp: number): Promise<FetchResult> => {
+  const { last24HourVolume, totalVolume }: IAPIResponse = (
+    await fetchURL(`${URLEndpoint}${timestamp}`)
+  );
+
+  return {
+    totalPremiumVolume: totalVolume,
+    dailyPremiumVolume: last24HourVolume,
+    timestamp: timestamp,
+    dailyNotionalVolume: 0,
+    totalNotionalVolume: 0,
+  };
+};
+
+const adapter: SimpleAdapter = {
+  adapter: {
+    [CHAIN.LOGX]: {
+      fetch,
+      start: startTimestamp,
+    },
+  }
+};
+
+export default adapter;

--- a/options/logx/index.ts
+++ b/options/logx/index.ts
@@ -19,8 +19,8 @@ const fetch = async (timestamp: number): Promise<FetchResult> => {
     totalPremiumVolume: totalVolume,
     dailyPremiumVolume: last24HourVolume,
     timestamp: timestamp,
-    dailyNotionalVolume: 0,
-    totalNotionalVolume: 0,
+    dailyNotionalVolume: last24HourVolume,
+    totalNotionalVolume: totalVolume,
   };
 };
 


### PR DESCRIPTION
Options Volume adapter for LogX (live at [LogX Options](https://app.logx.network/options/BTC)).

We don't offer leverage on options hence returning notional value as "0".

Also, can we please show this next to "Perps Volume" in LogX V2 page? (https://defillama.com/protocol/logx-v2#information)
<img width="886" alt="image" src="https://github.com/user-attachments/assets/7a1754d5-0307-433e-a0bf-b1f85cb1fb52" />
