### PR TITLE
Updated the new Thales/Overtime markets to calculate the volume

### DIFF
--- a/options/thales/abis.ts
+++ b/options/thales/abis.ts
@@ -1,0 +1,7 @@
+export const THALES_EVENT_ABI = {
+    ticketCreated: "event TicketCreated(address ticket, address recipient, uint buyInAmount, uint fees, uint payout, uint totalQuote, address collateral)",
+    boughtFromAmm: "event BoughtFromAmm(address buyer, address market, uint8 position, uint amount, uint sUSDPaid, address susd, address asset)",
+    speedMarketCreated: "event MarketCreated(address market, address user, bytes32 asset, uint256 strikeTime, int64 strikePrice, uint8 direction, uint256 buyinAmount)",
+    chainedMarketCreated: "event MarketCreated(address market, address user, bytes32 asset, uint64 timeFrame, uint64 strikeTime, int64 strikePrice, uint8[] directions, uint256 buyinAmount, uint256 payoutMultiplier, uint256 safeBoxImpact)"
+  };
+  

--- a/options/thales/config.ts
+++ b/options/thales/config.ts
@@ -1,0 +1,81 @@
+import ADDRESSES from '../../helpers/coreAssets.json'
+import { CHAIN } from "../../helpers/chains";
+
+export const THALES_CHAIN_CONFIG = {
+  optimism: { 
+    tokens: [
+      ADDRESSES.optimism.sUSD, 
+      ADDRESSES.optimism.USDC_CIRCLE, 
+      ADDRESSES.optimism.WETH_1
+    ], 
+    fromAddresses: [
+      '0x5ae7454827d83526261f3871c1029792644ef1b1', 
+      '0x278b5a44397c9d8e52743fedec263c4760dc1a1a',
+      '0x2d356b114cbca8deff2d8783eac2a5a5324fe1df',
+      '0xE16B8a01490835EC1e76bAbbB3Cadd8921b32001',
+      '0xFb4e4811C7A811E098A556bD79B64c20b479E431',
+      '0x170a5714112daeff20e798b6e92e25b86ea603c1',
+      '0x82b3634c0518507d5d817be6dab6233ebe4d68d9'
+    ], 
+    targets: [
+      '0xe853207c30f3c32eda9aeffddc67357d5332978c', 
+      '0xC392133eEa695603B51a5d5de73655d571c2CE51'
+    ],
+  },
+  arbitrum: {
+    tokens: [
+      ADDRESSES.arbitrum.USDC, 
+      ADDRESSES.arbitrum.USDC_CIRCLE, 
+      ADDRESSES.arbitrum.WETH
+    ],
+    fromAddresses: [
+      '0x2b89275efb9509c33d9ad92a4586bdf8c4d21505',
+      '0x5cf3b1882357bb66cf3cd2c85b81abbc85553962',
+      '0x02D0123a89Ae6ef27419d5EBb158d1ED4Cf24FA3',
+      '0xfb64E79A562F7250131cf528242CEB10fDC82395',
+      '0xae56177e405929c95e5d4b04c0c87e428cb6432b',
+      '0x2bb7d689780e7a34dd365359bd7333ab24903268'
+    ],
+    targets: [
+      '0xCd9c0E99396627C7746b4363B880939Ac2828d3E', 
+      '0x160Ca569999601bca06109D42d561D85D6Bb4b57'
+    ],
+  },
+  base: {
+    tokens: [
+      ADDRESSES.base.USDbC
+    ],
+    fromAddresses: [
+      '0xAFD339acf24813e8038bfdF19A8d87Eb94B4605d',
+      '0x5625c3233b52206a5f23c5fC1Ce16F6A7e3874dd',
+      '0xe41cD3A25CBdeDA0BC46D48C380393D953bD2034',
+      '0xB8109ac56EE572990e6d2C6b4648042bB1C33317',
+      '0x85b827d133FEDC36B844b20f4a198dA583B25BAA'
+    ],
+    targets: [
+      '0xe8e022405505a9F2b0B7452C844F1e64423849fC', 
+      '0x84aB38e42D8Da33b480762cCa543eEcA6135E040'
+    ],
+  }
+}
+
+export const THALES_CONTRACT_ADDRESSES = {
+    [CHAIN.OPTIMISM]: {
+      sportsAMMV2: "0xFb4e4811C7A811E098A556bD79B64c20b479E431",
+      thalesAMM: "0x9Ce94cdf8eCd57cec0835767528DC88628891dd9",
+      rangedAMM: "0xEd59dCA9c272FbC0ca4637F32ab32CBDB62E856B",
+      speedMarket: "0xE16B8a01490835EC1e76bAbbB3Cadd8921b32001",
+      chainedSpeedMarket: "0xFf8Cf5ABF583D0979C0B9c35d62dd1fD52cce7C7",
+    },
+    [CHAIN.ARBITRUM]: {
+      sportsAMMV2: "0xfb64E79A562F7250131cf528242CEB10fDC82395",
+      thalesAMM: "0x2b89275efB9509c33d9AD92A4586bdf8c4d21505",
+      rangedAMM: "0x5cf3b1882357BB66Cf3cd2c85b81AbBc85553962",
+      speedMarket: "0x02D0123a89Ae6ef27419d5EBb158d1ED4Cf24FA3",
+      chainedSpeedMarket: "0xe92B4c614b04c239d30c31A7ea1290AdDCb8217D",
+    },
+    [CHAIN.BASE]: {
+      speedMarket: "0x85b827d133FEDC36B844b20f4a198dA583B25BAA",
+      chainedSpeedMarket: "0x6848F001ddDb4442d352C495c7B4a231e3889b70"
+    },
+  };

--- a/options/thales/eventArgs.ts
+++ b/options/thales/eventArgs.ts
@@ -1,0 +1,45 @@
+export interface ITicketCreatedEvent {
+    ticket: string;
+    recipient: string;
+    buyInAmount: bigint;
+    fees: bigint;
+    payout: bigint;
+    totalQuote: bigint;
+    collateral: string;
+  }
+  
+  export interface IBoughtFromAmmEvent {
+    buyer: string;
+    market: string;
+    position: number;
+    amount: bigint;
+    sUSDPaid: bigint;
+    susd: string;
+    asset: string;
+  }
+  
+  export interface IChainedMarketCreatedEvent {
+    market: string;
+    user: string;
+    asset: string;
+    timeFrame: bigint;
+    strikeTime: bigint;
+    strikePrice: bigint;
+    directions: number[];
+    buyinAmount: bigint;
+    payoutMultiplier: bigint;
+    safeBoxImpact: bigint;
+  }
+  
+  export interface ISpeedMarketCreatedEvent {
+    market: string;
+    user: string;
+    asset: string;
+    strikeTime: bigint;
+    pythPrice: bigint;
+    direction: number;
+    buyinAmount: bigint;
+    safeBoxImpact: bigint;
+    lpFeeWithSkew?: bigint;
+  }
+  

--- a/options/thales/index.ts
+++ b/options/thales/index.ts
@@ -1,76 +1,138 @@
-import ADDRESSES from '../../helpers/coreAssets.json'
+import { Adapter, FetchOptions, FetchResultV2 } from "../../adapters/types";
 import { addTokensReceived } from '../../helpers/token';
-import { Adapter, FetchOptions } from "../../adapters/types";
+import { THALES_CHAIN_CONFIG, THALES_CONTRACT_ADDRESSES } from './config';
+import { THALES_EVENT_ABI } from './abis';
+import { 
+  parseTicketCreatedEvent, 
+  parseBoughtFromAmmEvent, 
+  parseSpeedMarketCreatedEvent, 
+  parseChainedMarketCreatedEvent 
+} from './parsers';
 import { CHAIN } from "../../helpers/chains";
 
-const config = {
-  optimism: { 
-    tokens: [ADDRESSES.optimism.sUSD, ADDRESSES.optimism.USDC_CIRCLE, ADDRESSES.optimism.WETH_1], 
-    fromAdddesses: [
-      '0x5ae7454827d83526261f3871c1029792644ef1b1', 
-      '0x278b5a44397c9d8e52743fedec263c4760dc1a1a',
-      '0x2d356b114cbca8deff2d8783eac2a5a5324fe1df',
-      '0xE16B8a01490835EC1e76bAbbB3Cadd8921b32001',
-      '0xFb4e4811C7A811E098A556bD79B64c20b479E431',
-      '0x170a5714112daeff20e798b6e92e25b86ea603c1',
-      '0x82b3634c0518507d5d817be6dab6233ebe4d68d9'
-    ], 
-    targets: [
-      '0xe853207c30f3c32eda9aeffddc67357d5332978c', 
-      '0xC392133eEa695603B51a5d5de73655d571c2CE51'
-    ],
-  },
-  arbitrum: {
-    tokens: [ADDRESSES.arbitrum.USDC, ADDRESSES.arbitrum.USDC_CIRCLE, ADDRESSES.arbitrum.WETH],
-    fromAdddesses: [
-      '0x2b89275efb9509c33d9ad92a4586bdf8c4d21505',
-      '0x5cf3b1882357bb66cf3cd2c85b81abbc85553962',
-      '0x02D0123a89Ae6ef27419d5EBb158d1ED4Cf24FA3',
-      '0xfb64E79A562F7250131cf528242CEB10fDC82395',
-      '0xae56177e405929c95e5d4b04c0c87e428cb6432b',
-      '0x2bb7d689780e7a34dd365359bd7333ab24903268'
-    ],
-    targets: [
-      '0xCd9c0E99396627C7746b4363B880939Ac2828d3E', 
-      '0x160Ca569999601bca06109D42d561D85D6Bb4b57'
-    ],
-  },
-  base: {
-    tokens: [ADDRESSES.base.USDbC],
-    fromAdddesses: [
-      '0xAFD339acf24813e8038bfdF19A8d87Eb94B4605d',
-      '0x5625c3233b52206a5f23c5fC1Ce16F6A7e3874dd',
-      '0xe41cD3A25CBdeDA0BC46D48C380393D953bD2034',
-      '0xB8109ac56EE572990e6d2C6b4648042bB1C33317',
-      '0x85b827d133FEDC36B844b20f4a198dA583B25BAA'
-    ],
-    targets: [
-      '0xe8e022405505a9F2b0B7452C844F1e64423849fC', 
-      '0x84aB38e42D8Da33b480762cCa543eEcA6135E040'
-    ],
+function getChainContractsToQuery(chain: string, dailyVolume: ReturnType<FetchOptions['createBalances']>) {
+  switch(chain) {
+    case CHAIN.OPTIMISM: {
+      const { sportsAMMV2, thalesAMM, rangedAMM, speedMarket, chainedSpeedMarket } 
+        = THALES_CONTRACT_ADDRESSES[CHAIN.OPTIMISM];
+      return [
+        {
+          address: sportsAMMV2,
+          eventAbi: THALES_EVENT_ABI.ticketCreated,
+          parser: (log: any) => parseTicketCreatedEvent(log, dailyVolume)
+        },
+        {
+          address: thalesAMM,
+          eventAbi: THALES_EVENT_ABI.boughtFromAmm,
+          parser: (log: any) => parseBoughtFromAmmEvent(log, dailyVolume)
+        },
+        {
+          address: rangedAMM,
+          eventAbi: THALES_EVENT_ABI.boughtFromAmm,
+          parser: (log: any) => parseBoughtFromAmmEvent(log, dailyVolume)
+        },
+        {
+          address: speedMarket,
+          eventAbi: THALES_EVENT_ABI.speedMarketCreated,
+          parser: (log: any) => parseSpeedMarketCreatedEvent(log, dailyVolume)
+        },
+        {
+          address: chainedSpeedMarket,
+          eventAbi: THALES_EVENT_ABI.chainedMarketCreated,
+          parser: (log: any) => parseChainedMarketCreatedEvent(log, dailyVolume)
+        }
+      ];
+    }
+    case CHAIN.ARBITRUM: {
+      const { sportsAMMV2, thalesAMM, rangedAMM, speedMarket, chainedSpeedMarket } 
+        = THALES_CONTRACT_ADDRESSES[CHAIN.ARBITRUM];
+      return [
+        {
+          address: sportsAMMV2,
+          eventAbi: THALES_EVENT_ABI.ticketCreated,
+          parser: (log: any) => parseTicketCreatedEvent(log, dailyVolume)
+        },
+        {
+          address: thalesAMM,
+          eventAbi: THALES_EVENT_ABI.boughtFromAmm,
+          parser: (log: any) => parseBoughtFromAmmEvent(log, dailyVolume)
+        },
+        {
+          address: rangedAMM,
+          eventAbi: THALES_EVENT_ABI.boughtFromAmm,
+          parser: (log: any) => parseBoughtFromAmmEvent(log, dailyVolume)
+        },
+        {
+          address: speedMarket,
+          eventAbi: THALES_EVENT_ABI.speedMarketCreated,
+          parser: (log: any) => parseSpeedMarketCreatedEvent(log, dailyVolume)
+        },
+        {
+          address: chainedSpeedMarket,
+          eventAbi: THALES_EVENT_ABI.chainedMarketCreated,
+          parser: (log: any) => parseChainedMarketCreatedEvent(log, dailyVolume)
+        }
+      ];
+    }
+    case CHAIN.BASE: {
+      const { speedMarket, chainedSpeedMarket } = THALES_CONTRACT_ADDRESSES[CHAIN.BASE];
+      return [
+        {
+          address: speedMarket,
+          eventAbi: THALES_EVENT_ABI.speedMarketCreated,
+          parser: (log: any) => parseSpeedMarketCreatedEvent(log, dailyVolume)
+        },
+        {
+          address: chainedSpeedMarket,
+          eventAbi: THALES_EVENT_ABI.chainedMarketCreated,
+          parser: (log: any) => parseChainedMarketCreatedEvent(log, dailyVolume)
+        }
+      ];
+    }
+    default:
+      throw new Error("No contracts found for this chain");
   }
 }
 
-const fetch = async (options: FetchOptions) => {
-    const dailyFees = await addTokensReceived({ ...config[options.chain], options})
-    return {
-      dailyFees,
-    };
+export async function fetch(options: FetchOptions): Promise<FetchResultV2> {
+  const dailyVolume = options.createBalances();
+  const contractConfigs = getChainContractsToQuery(options.chain, dailyVolume);
+  
+  await Promise.all(
+    contractConfigs.map(async (cfg) => {
+      const logs = await options.getLogs({
+        target: cfg.address,
+        eventAbi: cfg.eventAbi,
+        onlyArgs: true,
+      });
+      logs.forEach(log => cfg.parser(log));
+    })
+  );
+  
+  const dailyFees = await addTokensReceived({ ...THALES_CHAIN_CONFIG[options.chain], options});
+  
+  return {
+    dailyVolume,
+    dailyFees,
   };
-
+}
 
 const adapter: Adapter = {
   version: 2,
   adapter: {
     [CHAIN.ARBITRUM]: {
-      fetch, start: '2022-09-06',
+      fetch,
+      start: '2024-08-01',
     },
     [CHAIN.OPTIMISM]: {
-      fetch, start: '2022-01-10',
+      fetch,
+      start: '2024-08-01',
     },
     [CHAIN.BASE]: {
-      fetch, start: '2023-08-10',
+      fetch,
+      start: '2024-08-01',
     },
   },
 };
+
 export default adapter;

--- a/options/thales/parsers.ts
+++ b/options/thales/parsers.ts
@@ -1,0 +1,26 @@
+import { 
+    ITicketCreatedEvent, 
+    IBoughtFromAmmEvent, 
+    ISpeedMarketCreatedEvent, 
+    IChainedMarketCreatedEvent 
+  } from './eventArgs';
+  
+  export function parseTicketCreatedEvent(log: ITicketCreatedEvent, dailyBalance: any) {
+    const { payout, collateral } = log;
+    dailyBalance.addToken(collateral, payout);
+  }
+  
+  export function parseBoughtFromAmmEvent(log: IBoughtFromAmmEvent, dailyBalance: any) {
+    const { amount } = log;
+    dailyBalance.addUSDValue(Number(amount) / 1e18);
+  }
+  
+  export function parseSpeedMarketCreatedEvent(log: ISpeedMarketCreatedEvent, dailyBalance: any) {
+    const { buyinAmount } = log;
+    dailyBalance.addUSDValue(Number(buyinAmount) / 1e6); 
+  }
+  
+  export function parseChainedMarketCreatedEvent(log: IChainedMarketCreatedEvent, dailyBalance: any) {
+    const { buyinAmount, payoutMultiplier } = log;
+    dailyBalance.addUSDValue((Number(buyinAmount) / 1e6) * (Number(payoutMultiplier) / 1e18));
+  }


### PR DESCRIPTION
This PR implements volume tracking for the following markets across multiple chains:

#### Optimism / Arbitrum
1. SportsAMM
2. ThalesAMM
3. RangedAMM
4. SpeedMarket
5. ChainedSpreadMarket

#### Base
1. SpeedMarket
2. ChainedSpreadMarket