### PR TITLE
Fix for Solana historic data

### DIFF
--- a/fees/blazingbot.ts
+++ b/fees/blazingbot.ts
@@ -93,6 +93,7 @@ const adapter: SimpleAdapter = {
       start: '2024-11-23',
     },
   },
+  isExpensiveAdapter: true,
 };
 
 export default adapter;

--- a/fees/blazingbot.ts
+++ b/fees/blazingbot.ts
@@ -90,11 +90,9 @@ const adapter: SimpleAdapter = {
     },
     [CHAIN.SOLANA]: {
       fetch: fethcFeesSolana,
-      runAtCurrTime: true,
       start: '2024-11-23',
     },
   },
-  isExpensiveAdapter: true,
 };
 
 export default adapter;


### PR DESCRIPTION
when I first made this adapter we only got Solana data from the time the adapter was deployed, not since nov 23rd, and I think this was due to the usage of `runAtCurrTime` ? 