### PR TITLE
blast-remove

### DIFF
--- a/aggregators/hinkal/index.ts
+++ b/aggregators/hinkal/index.ts
@@ -98,20 +98,6 @@ const fetchOPTIMISM = async (options: FetchOptions) => {
   };
 };
 
-const fetchBLAST = async (options: FetchOptions) => {
-  const timestampStart = options.startTimestamp;
-  const timestampEnd = options.endTimestamp;
-  const urlVolume = `https://blast.server.hinkal.pro/totalVolume/${timestampStart}/${timestampEnd}/81457`;
-
-  const responseVolume = await httpGet(urlVolume);
-  const dataTotal = responseVolume;
-  const dailyVolume = dataTotal.internal_volume + dataTotal.external_volume;
-  return {
-    timestamp: options.startTimestamp,
-    dailyVolume,
-  };
-};
-
 const adapter: Adapter = {
   version: 2,
   adapter: {
@@ -125,7 +111,6 @@ const adapter: Adapter = {
     [CHAIN.BSC]: { fetch: fetchBNB, start: '2023-11-08' },
     [CHAIN.AVAX]: { fetch: fetchAVALANCHE, start: '2023-11-08' },
     [CHAIN.OPTIMISM]: { fetch: fetchOPTIMISM, start: '2023-11-07' },
-    [CHAIN.BLAST]: { fetch: fetchBLAST, start: '2024-05-23' },
   },
 };
 


### PR DESCRIPTION
hinkal doesn't provide access to blast network; therefore removing fetchBlast function which is causing currently errors; currently hinkal total volume is not updated since November 2024.