### PR TITLE
feat: add velo superchain bribes, volume/fees

### DIFF
--- a/dexs/velodrome-slipstream/index.ts
+++ b/dexs/velodrome-slipstream/index.ts
@@ -2,13 +2,34 @@ import { FetchOptions, FetchResultV2, SimpleAdapter } from "../../adapters/types
 import { CHAIN } from "../../helpers/chains";
 
 const sugarOld = '0x3e532BC1998584fe18e357B5187897ad0110ED3A'; // old Sugar version doesn't properly support pagination
-const sugar = '0xdE2aE25FB984dd60C77dcF6489Be9ee6438eC195';
 const abis: any = {
   "forSwaps": "function forSwaps(uint256 _limit, uint256 _offset) view returns ((address lp, int24 type, address token0, address token1, address factory, uint256 pool_fee)[])"
 }
 
+const superchainConfig = {
+  [CHAIN.OPTIMISM]: {
+    sugar: '0xdE2aE25FB984dd60C77dcF6489Be9ee6438eC195',
+  },
+  [CHAIN.MODE]: {
+    sugar: '0x8A5e97184E8850064805fAc2427ce7728689De5B',
+  },
+  [CHAIN.LISK]: {
+    sugar: '0x0F5B7D59690F99f34081E24557f022d06d580BB6',
+  },
+  [CHAIN.INK]: {
+    sugar: '0xD938B20f40505e33b7C131e6aDD6C6FF7380094A',
+  },
+  [CHAIN.SONEIUM]: {
+    sugar: '0xB1d0DFFe6260982164B53EdAcD3ccd58B081889d',
+  },
+  [CHAIN.FRAXTAL]: {
+    sugar: '0xB1d0DFFe6260982164B53EdAcD3ccd58B081889d',
+  }
+}
+
 interface IForSwap {
   lp: string;
+  type: number;
   token0: string;
   token1: string;
   pool_fee: string;
@@ -29,10 +50,10 @@ const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
   let currentOffset = 0;
   const allForSwaps: IForSwap[] = [];
   let unfinished = true;
-  let sugarContract = sugar;
+  let sugarContract = superchainConfig[options.chain]['sugar'];
 
   // before the new Sugar is deployed, we must use the old Sugar contract, and make one large Sugar call
-  if (options.startOfDay < 1715160600) {
+  if (options.chain === CHAIN.OPTIMISM && options.startOfDay < 1715160600) {
     chunkSize = 1800;
     sugarContract = sugarOld;
   }
@@ -42,12 +63,13 @@ const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
       target: sugarContract,
       params: [chunkSize, currentOffset],
       abi: abis.forSwaps,
-      chain: CHAIN.OPTIMISM,
+      chain: options.chain,
     }));
     
     const forSwaps: IForSwap[] = forSwapsUnfiltered.filter(t => Number(t.type) > 0).map((e: any) => {
       return {
         lp: e.lp,
+        type: e.type,
         token0: e.token0,
         token1: e.token1,
         pool_fee: e.pool_fee,
@@ -99,7 +121,27 @@ const adapters: SimpleAdapter = {
     [CHAIN.OPTIMISM]: {
       fetch: fetch as any,
       start: '2024-03-06',
-    }
+    },
+    [CHAIN.MODE]: {
+      fetch: fetch as any,
+      start: '2024-11-13',
+    },
+    [CHAIN.LISK]: {
+      fetch: fetch as any,
+      start: '2024-11-13',
+    },
+    [CHAIN.FRAXTAL]: {
+      fetch: fetch as any,
+      start: '2024-11-19',
+    },
+    // [CHAIN.INK]: {
+    //   fetch: fetch as any,
+    //   start: '2025-01-14',
+    // },
+    // [CHAIN.SONEIUM]: {
+    //   fetch: fetch as any,
+    //   start: '2025-01-14',
+    // },
   }
 }
 export default adapters;

--- a/dexs/velodrome-v2/index.ts
+++ b/dexs/velodrome-v2/index.ts
@@ -4,4 +4,9 @@ const swapEvent = 'event Swap(address indexed sender, address indexed to, uint25
 
 export default uniV2Exports({
   [CHAIN.OPTIMISM]: { factory: '0xF1046053aa5682b4F9a81b5481394DA16BE5FF5a',  swapEvent, },
+  [CHAIN.MODE]: { factory: '0x31832f2a97Fd20664D76Cc421207669b55CE4BC0',  swapEvent, },
+  [CHAIN.LISK]: { factory: '0x31832f2a97Fd20664D76Cc421207669b55CE4BC0',  swapEvent, },
+  [CHAIN.FRAXTAL]: { factory: '0x31832f2a97Fd20664D76Cc421207669b55CE4BC0',  swapEvent, },
+  //[CHAIN.INK]: { factory: '0x31832f2a97Fd20664D76Cc421207669b55CE4BC0',  swapEvent, },
+  //[CHAIN.SONEIUM]: { factory: '0x31832f2a97Fd20664D76Cc421207669b55CE4BC0',  swapEvent, },
 })

--- a/fees/velodrome-v2/index.ts
+++ b/fees/velodrome-v2/index.ts
@@ -96,7 +96,7 @@ const customLogic = async ({ dailyFees, fetchOptions, filteredPairs, }: any) => 
     })
   }
 
-  return { dailyBribesRevenue: dailyBribes } as any
+  return { dailyFees, dailyRevenue: dailyFees, dailyHoldersRevenue: dailyFees, dailyBribesRevenue: dailyBribes } as any
 }
 
 export default uniV2Exports({


### PR DESCRIPTION
Added bribes fetching from leaf Voter contract on the Superchain L2s for Velodrome. Added swaps fetching for the Superchain deployments on Mode + Lisk + Fraxtal. Left the Soneium and Ink deployments commented out for now because the backend doesn't seem to handle them yet