### PR TITLE
Add volume adapter for Archly on Sonic

### DIFF
--- a/dexs/archly-finance-v2/index.ts
+++ b/dexs/archly-finance-v2/index.ts
@@ -25,6 +25,7 @@ export default uniV2Exports({
   [CHAIN.NEON]: { factory },
   [CHAIN.OPTIMISM]: { factory },
   [CHAIN.POLYGON]: { factory },
+  [CHAIN.SONIC]: { factory },
   [CHAIN.TELOS]: { factory },
   [CHAIN.ERA]: { factory: FACTORY_ADDRESS_ZKSYNC },
   [CHAIN.ZORA]: { factory },


### PR DESCRIPTION
Test failed locally for BSC and Neon. Adding test results sans BSC and Neon below:

yarn run v1.22.19
warning ../package.json: No license field
$ ts-node --transpile-only cli/testAdapter.ts dexs archly-finance-v2
🦙 Running ARCHLY-FINANCE-V2 adapter 🦙
---------------------------------------------------
Start Date:	Wed, 15 Jan 2025 15:17:01 GMT
End Date:	Thu, 16 Jan 2025 15:17:01 GMT
---------------------------------------------------

ARBITRUM_NOVA 👇
Backfill start time not defined
NO METHODOLOGY SPECIFIED
Daily volume: 0
Daily fees: 0
End timestamp: 1737040620 (2025-01-16T15:17:00.000Z)


ARBITRUM 👇
Backfill start time not defined
NO METHODOLOGY SPECIFIED
Daily volume: 14
Daily fees: 0
End timestamp: 1737040620 (2025-01-16T15:17:00.000Z)


AVAX 👇
Backfill start time not defined
NO METHODOLOGY SPECIFIED
Daily volume: 0
Daily fees: 0
End timestamp: 1737040620 (2025-01-16T15:17:00.000Z)


BASE 👇
Backfill start time not defined
NO METHODOLOGY SPECIFIED
Daily volume: 3
Daily fees: 0
End timestamp: 1737040620 (2025-01-16T15:17:00.000Z)


BLAST 👇
Backfill start time not defined
NO METHODOLOGY SPECIFIED
Daily volume: 0
Daily fees: 0
End timestamp: 1737040620 (2025-01-16T15:17:00.000Z)


CRONOS 👇
Backfill start time not defined
NO METHODOLOGY SPECIFIED
Daily volume: 0
Daily fees: 0
End timestamp: 1737040620 (2025-01-16T15:17:00.000Z)


ETHEREUM 👇
Backfill start time not defined
NO METHODOLOGY SPECIFIED
Daily volume: 0
Daily fees: 0
End timestamp: 1737040620 (2025-01-16T15:17:00.000Z)


FANTOM 👇
Backfill start time not defined
NO METHODOLOGY SPECIFIED
Daily volume: 0
Daily fees: 0
End timestamp: 1737040620 (2025-01-16T15:17:00.000Z)


FILECOIN 👇
Backfill start time not defined
NO METHODOLOGY SPECIFIED
Daily volume: 0
Daily fees: 0
End timestamp: 1737040620 (2025-01-16T15:17:00.000Z)


FRAXTAL 👇
Backfill start time not defined
NO METHODOLOGY SPECIFIED
Daily volume: 0
Daily fees: 0
End timestamp: 1737040620 (2025-01-16T15:17:00.000Z)


KAVA 👇
Backfill start time not defined
NO METHODOLOGY SPECIFIED
Daily volume: 6
Daily fees: 0
End timestamp: 1737040620 (2025-01-16T15:17:00.000Z)


MANTLE 👇
Backfill start time not defined
NO METHODOLOGY SPECIFIED
Daily volume: 0
Daily fees: 0
End timestamp: 1737040620 (2025-01-16T15:17:00.000Z)


METIS 👇
Backfill start time not defined
NO METHODOLOGY SPECIFIED
Daily volume: 0
Daily fees: 0
End timestamp: 1737040620 (2025-01-16T15:17:00.000Z)


MODE 👇
Backfill start time not defined
NO METHODOLOGY SPECIFIED
Daily volume: 0
Daily fees: 0
End timestamp: 1737040620 (2025-01-16T15:17:00.000Z)


OPTIMISM 👇
Backfill start time not defined
NO METHODOLOGY SPECIFIED
Daily volume: 10
Daily fees: 0
End timestamp: 1737040620 (2025-01-16T15:17:00.000Z)


POLYGON 👇
Backfill start time not defined
NO METHODOLOGY SPECIFIED
Daily volume: 1
Daily fees: 0
End timestamp: 1737040620 (2025-01-16T15:17:00.000Z)


SONIC 👇
Backfill start time not defined
NO METHODOLOGY SPECIFIED
Daily volume: 0
Daily fees: 0
End timestamp: 1737040620 (2025-01-16T15:17:00.000Z)


TELOS 👇
Backfill start time not defined
NO METHODOLOGY SPECIFIED
Daily volume: 14
Daily fees: 0
End timestamp: 1737040620 (2025-01-16T15:17:00.000Z)


ERA 👇
Backfill start time not defined
NO METHODOLOGY SPECIFIED
Daily volume: 0
Daily fees: 0
End timestamp: 1737040620 (2025-01-16T15:17:00.000Z)


ZORA 👇
Backfill start time not defined
NO METHODOLOGY SPECIFIED
Daily volume: 0
Daily fees: 0
End timestamp: 1737040620 (2025-01-16T15:17:00.000Z)




✨  Done in 67.14s.