### PR TITLE
fix fluid revenue spikes

### DIFF
--- a/fees/fluid/revenue.ts
+++ b/fees/fluid/revenue.ts
@@ -64,9 +64,10 @@ const revenueResolver = async (api: ChainApi) => {
     calcRevenueSimulatedTime: async (totalAmounts: string, exchangePricesAndConfig: string, liquidityTokenBalance: string, timestamp: number) => {
       const blockTimestamp = await getTimestamp(await api.getBlock(), api.chain);
       if(blockTimestamp > timestamp) {
-        // calcRevenueSimulatedTime() method does not support the case where block.timestamp > input param timestamp
-        // difference here should be negligible, although advanced handling would be possible if needed via checking the actual time difference
-        // and processing further accordingly.
+        // calcRevenueSimulatedTime() method does not support the case where lastUpdateTimestamp (included in exchangePricesAndConfig) is > simulated block.timestamp ("timestamp"). 
+        // making the timestamp at least be block.timestamp guarantees that this can never be the case, as `exchangePricesAndConfig` is fetched at that block.timestamp.
+        // difference here should be very negligible (yield accrual for time difference), although advanced handling would be possible if needed via checking the actual time
+        // difference and processing further accordingly.
         timestamp = blockTimestamp;
       }
       return await api.call({ target: address, params: [totalAmounts, exchangePricesAndConfig, liquidityTokenBalance, timestamp], abi: abi.calcRevenueSimulatedTime, permitFailure: true });

--- a/fees/fluid/revenue.ts
+++ b/fees/fluid/revenue.ts
@@ -98,7 +98,6 @@ const getUncollectedLiquidities = async (api: ChainApi, timestamp: number, token
       const tokenBalance = liquidityTokenBalance[index];
   
       if (totalAmount === undefined || exchangePriceConfig === undefined || tokenBalance === undefined) return 0;
-
       const _uncollectedRevenue = await (await revenueResolver(api)).calcRevenueSimulatedTime(
         totalAmount,
         exchangePriceConfig,
@@ -205,6 +204,5 @@ export const getFluidDailyRevenue = async (options: FetchOptions) => {
     getLiquidityRevenues(options),
     getVaultsRevenues(options)
   ])
-
   return liquidityRevenues + vaultRevenues
 }

--- a/fees/fluid/revenue.ts
+++ b/fees/fluid/revenue.ts
@@ -64,8 +64,10 @@ const revenueResolver = async (api: ChainApi) => {
     calcRevenueSimulatedTime: async (totalAmounts: string, exchangePricesAndConfig: string, liquidityTokenBalance: string, timestamp: number) => {
       const blockTimestamp = await getTimestamp(await api.getBlock(), api.chain);
       if(blockTimestamp > timestamp) {
+        // calcRevenueSimulatedTime() method does not support the case where block.timestamp > input param timestamp
+        // difference here should be negligible, although advanced handling would be possible if needed via checking the actual time difference
+        // and processing further accordingly.
         timestamp = blockTimestamp;
-        console.log("adjusted timestamp to avoid error ON REVENUERESOLVER: blockTimestamp > timestamp");
       }
       return await api.call({ target: address, params: [totalAmounts, exchangePricesAndConfig, liquidityTokenBalance, timestamp], abi: abi.calcRevenueSimulatedTime, permitFailure: true });
     }
@@ -78,45 +80,31 @@ const getUncollectedLiquidities = async (api: ChainApi, timestamp: number, token
     (await liquidityResolver(api)).getExchangePricesAndConfig(tokens),
   ]);
 
-  console.log("getUncollectedLiquidities");
-  console.log("tokens", tokens);
-
   const liquidityTokenBalance: string[] = await api.multiCall({
     calls: tokens.filter((token) => token !== NATIVE_TOKEN).map((token) => ({ target: token, params: [LIQUIDITY] })),
     abi: "erc20:balanceOf",
   });
-  console.log(liquidityTokenBalance, "liquidityTokenBalance 1");
 
   if (tokens.includes(NATIVE_TOKEN)) {
     const { output: nativeBalance } = (await sdk.api.eth.getBalance({ target: LIQUIDITY, chain: api.chain, block: await api.getBlock() }))
     const eeIndex = tokens.indexOf(NATIVE_TOKEN);
     liquidityTokenBalance.splice(eeIndex, 0, nativeBalance);
   }
-  console.log(liquidityTokenBalance, "liquidityTokenBalance 2");
 
   return Promise.all(
     tokens.map(async (_, index) => {
       const totalAmount = totalAmounts[index];
       const exchangePriceConfig = exchangePricesAndConfig[index];
       const tokenBalance = liquidityTokenBalance[index];
-      console.log("\n-----------------");
-      console.log(index, "index");
-      console.log(totalAmount, "totalAmount");
-      console.log(exchangePriceConfig, "exchangePriceConfig");
-      console.log(tokenBalance, "tokenBalance");
   
       if (totalAmount === undefined || exchangePriceConfig === undefined || tokenBalance === undefined) return 0;
 
-      console.log("calling with", [totalAmount, exchangePriceConfig, tokenBalance, timestamp]);
-  
       const _uncollectedRevenue = await (await revenueResolver(api)).calcRevenueSimulatedTime(
         totalAmount,
         exchangePriceConfig,
         tokenBalance,
         timestamp
       );
-      console.log("\n-----------------");
-      console.log(_uncollectedRevenue, "_uncollectedRevenue");
   
       return _uncollectedRevenue ?? 0;
     })
@@ -127,16 +115,11 @@ const getLiquidityRevenues = async ({ api, fromApi, toApi, getLogs, createBalanc
   const dailyValues = createBalances();
   const tokens: string[] = (await (await liquidityResolver(api)).listedTokens()).map((t: string) => t.toLowerCase());
 
-  console.log("FROM-------------------")
-  const revenuesFrom = await getUncollectedLiquidities(fromApi, fromTimestamp, tokens);
-  const revenuesTo = await getUncollectedLiquidities(toApi, toTimestamp, tokens);
-  console.log("TO-------------------")
-
-  // // Fetch uncollected revenues for the "from" and "to" timestamps
-  // const [revenuesFrom, revenuesTo] = await Promise.all([
-  //   getUncollectedLiquidities(fromApi, fromTimestamp, tokens),
-  //   getUncollectedLiquidities(toApi, toTimestamp, tokens)
-  // ]);
+  // Fetch uncollected revenues for the "from" and "to" timestamps
+  const [revenuesFrom, revenuesTo] = await Promise.all([
+    getUncollectedLiquidities(fromApi, fromTimestamp, tokens),
+    getUncollectedLiquidities(toApi, toTimestamp, tokens)
+  ]);
 
   for (const [i, token] of tokens.entries()) {
     // Default to 0 if revenues are missing
@@ -146,19 +129,11 @@ const getLiquidityRevenues = async ({ api, fromApi, toApi, getLogs, createBalanc
       return sum + amount;
     }, 0);
 
-    console.log(collectedRevenue, "collectedRevenue");
-    console.log(revenuesTo[i], "revenuesTo[i]");
-    console.log(revenuesFrom[i], "revenuesFrom[i]");
     const revenueTo = (revenuesTo[i] !== undefined ? Number(revenuesTo[i]) : 0) + collectedRevenue;
     const revenueFrom = revenuesFrom[i] !== undefined ? Number(revenuesFrom[i]) : 0;
     const netRevenue = Math.max(0, revenueTo - revenueFrom);
 
-    const usdValueBefore = await dailyValues.getUSDValue();
-
     dailyValues.add(token, netRevenue)
-    const usdValueAfter = await dailyValues.getUSDValue();
-    console.log("added for token", token);
-    console.log((usdValueAfter - usdValueBefore).toString());
   }
   return dailyValues.getUSDValue();
 };
@@ -230,9 +205,6 @@ export const getFluidDailyRevenue = async (options: FetchOptions) => {
     getLiquidityRevenues(options),
     getVaultsRevenues(options)
   ])
-  
-  console.log("liquidityRevenues", liquidityRevenues, options.api.chain)
-  console.log("vaultRevenues", vaultRevenues, options.api.chain)
 
   return liquidityRevenues + vaultRevenues
 }


### PR DESCRIPTION
A timestamp was causing the bug, see comment in code

Before, random spikes because `reveneFrom` ends up 0 if call fails, e.g.:
![image](https://github.com/user-attachments/assets/a8bd09c0-1ede-45f9-80aa-f5fe87c1d0ab)

After:
![image](https://github.com/user-attachments/assets/facb24da-1b8d-4d9f-a386-95800855dbae)
