### PR TITLE
add methodology string for how dailyVolume is calculated

### DIFF
--- a/dexs/infinityPools/index.ts
+++ b/dexs/infinityPools/index.ts
@@ -92,7 +92,10 @@ const adapters: SimpleAdapter = {
     [CHAIN.BASE]: {
       fetch: fetch as any,
       start: "2025-01-13",
-    },
-  },
+      meta:{
+        methodology: {dailyVolume: "This adapter calculates the daily volume of spot trading by processing the Spot Swap related events emitted by InfinityPools smart contracts"}
+      }
+    }
+  }
 };
 export default adapters;


### PR DESCRIPTION
- The adapter I have added is for Spot Swap Volume. On the DeFiLlama page, it is miscategorized as ` Perps Volume` . InfinityPools is a concentrated liquidity AMM where a liquidity range is allowed to be borrowed. Borrowing liquidity allows the borrowers to achieve all sorts of payoffs, including one similar to a perpetual. The adapter I have added has nothing to do with that. It simply calculates the daily volume of spot swap like any other concentrated liquidity AMM (think Uniswap V3). 

- Calculating `Perps Volume` is hard to do from events, and I will make a PR for that later. For now, a better label for what I have added would be `Spot Volume` Please correct it.


<img width="1451" alt="image" src="https://github.com/user-attachments/assets/07d63a06-3285-4d65-a090-d888824a8983" />
