### PR TITLE
fix: bmx classic volume for december + add freestyle volume on mode

### DIFF
--- a/dexs/bmx-freestyle/index.ts
+++ b/dexs/bmx-freestyle/index.ts
@@ -9,7 +9,60 @@ import { CHAIN } from "../../helpers/chains";
 
 const freestyleEndpoints: { [key: string]: string } = {
   [CHAIN.BASE]:
-    "https://api-v2.morphex.trade/subgraph/3KhmYXgsM3CM1bbUCX8ejhcxQCtWwpUGhP7p9aDKZ94Z",
+    "https://api.goldsky.com/api/public/project_cm2x72f7p4cnq01x5fuy95ihm/subgraphs/bmx_analytics_base/0.8.2/gn",
+  [CHAIN.MODE]:
+    "https://api.goldsky.com/api/public/project_cm2x72f7p4cnq01x5fuy95ihm/subgraphs/bmx_analytics_mode/0.8.2/gn",
+};
+
+const freestyleQueries: { [key: string]: string } = {
+  [CHAIN.BASE]: gql`
+    query stats($from: String!, $to: String!) {
+      dailyHistories(
+        where: {
+          timestamp_gte: $from
+          timestamp_lte: $to
+          accountSource: "0x6D63921D8203044f6AbaD8F346d3AEa9A2719dDD"
+        }
+      ) {
+        timestamp
+        platformFee
+        accountSource
+        tradeVolume
+      }
+      totalHistories(
+        where: { accountSource: "0x6D63921D8203044f6AbaD8F346d3AEa9A2719dDD" }
+      ) {
+        timestamp
+        platformFee
+        accountSource
+        tradeVolume
+      }
+    }
+  `,
+  [CHAIN.MODE]: gql`
+    query stats($from: String!, $to: String!) {
+      dailyHistories(
+        where: {
+          timestamp_gte: $from
+          timestamp_lte: $to
+          accountSource: "0xC0ff4B56f62f20bA45f4229CC6BAaD986FA2a904"
+        }
+      ) {
+        timestamp
+        platformFee
+        accountSource
+        tradeVolume
+      }
+      totalHistories(
+        where: { accountSource: "0xC0ff4B56f62f20bA45f4229CC6BAaD986FA2a904" }
+      ) {
+        timestamp
+        platformFee
+        accountSource
+        tradeVolume
+      }
+    }
+  `,
 };
 
 interface IGraphResponseFreestyle {
@@ -27,47 +80,12 @@ interface IGraphResponseFreestyle {
   }>;
 }
 
-interface IGraphResponse {
-  volumeStats: Array<{
-    burn: string;
-    liquidation: string;
-    margin: string;
-    mint: string;
-    swap: string;
-  }>;
-}
-
 const ONE_DAY_IN_SECONDS = 60 * 60 * 24;
 
 const toString = (x: BigNumber) => {
   if (x.isEqualTo(0)) return undefined;
   return x.toString();
 };
-
-const freestyleQuery = gql`
-  query stats($from: String!, $to: String!) {
-    dailyHistories(
-      where: {
-        timestamp_gte: $from
-        timestamp_lte: $to
-        accountSource: "0x6D63921D8203044f6AbaD8F346d3AEa9A2719dDD"
-      }
-    ) {
-      timestamp
-      platformFee
-      accountSource
-      tradeVolume
-    }
-    totalHistories(
-      where: { accountSource: "0x6D63921D8203044f6AbaD8F346d3AEa9A2719dDD" }
-    ) {
-      timestamp
-      platformFee
-      accountSource
-      tradeVolume
-    }
-  }
-`;
 
 const fetchFreestyleVolume = async (
   timestamp: number,
@@ -78,7 +96,7 @@ const fetchFreestyleVolume = async (
   const endTime = startTime + ONE_DAY_IN_SECONDS;
   const response: IGraphResponseFreestyle = await request(
     freestyleEndpoints[options.chain],
-    freestyleQuery,
+    freestyleQueries[options.chain],
     {
       from: String(startTime),
       to: String(endTime),
@@ -113,7 +131,11 @@ const adapter: SimpleAdapter = {
   adapter: {
     [CHAIN.BASE]: {
       fetch: fetchFreestyleVolume,
-      start: '2024-05-01',
+      start: "2024-05-01",
+    },
+    [CHAIN.MODE]: {
+      fetch: fetchFreestyleVolume,
+      start: "2024-05-01",
     },
   },
 };

--- a/dexs/bmx/index.ts
+++ b/dexs/bmx/index.ts
@@ -10,9 +10,9 @@ const startTimestamps: { [chain: string]: number } = {
 };
 const endpoints: { [key: string]: string } = {
   [CHAIN.BASE]:
-    "https://api-v2.morphex.trade/subgraph/2vZHkWfx8g27Tri5LkTbhvCExCQcXJ3f28X2BwzFhjf6",
+    "https://api.goldsky.com/api/public/project_cm2x72f7p4cnq01x5fuy95ihm/subgraphs/bmx-base-stats/0.0.1/gn",
   [CHAIN.MODE]:
-    "https://api-v2.morphex.trade/subgraph/8tp7xrDSCuutJ5omjfQKHvkGJpLszqPVWg3pby9XMLEz",
+    "https://api.goldsky.com/api/public/project_cm2x72f7p4cnq01x5fuy95ihm/subgraphs/bmx-mode-stats/0.0.1/gn",
 };
 
 const historicalDataSwap = gql`

--- a/fees/bmx-freestyle.ts
+++ b/fees/bmx-freestyle.ts
@@ -4,7 +4,7 @@ import { FetchOptions, SimpleAdapter } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
 
 const endpoint =
-  "https://api-v2.morphex.trade/subgraph/3KhmYXgsM3CM1bbUCX8ejhcxQCtWwpUGhP7p9aDKZ94Z";
+  "https://api.goldsky.com/api/public/project_cm2x72f7p4cnq01x5fuy95ihm/subgraphs/bmx_analytics_base/0.8.2/gn";
 
 const query = gql`
   query stats($from: String!, $to: String!) {
@@ -106,7 +106,7 @@ const adapter: SimpleAdapter = {
   adapter: {
     [CHAIN.BASE]: {
       fetch: fetchVolume,
-      start: '2024-05-01',
+      start: "2024-05-01",
     },
   },
 };

--- a/fees/bmx.ts
+++ b/fees/bmx.ts
@@ -6,9 +6,9 @@ import { getTimestampAtStartOfDayUTC } from "../utils/date";
 
 const endpoints: { [key: string]: string } = {
   [CHAIN.BASE]:
-    "https://api-v2.morphex.trade/subgraph/2vZHkWfx8g27Tri5LkTbhvCExCQcXJ3f28X2BwzFhjf6",
+    "https://api.goldsky.com/api/public/project_cm2x72f7p4cnq01x5fuy95ihm/subgraphs/bmx-base-stats/0.0.1/gn",
   [CHAIN.MODE]:
-    "https://api-v2.morphex.trade/subgraph/8tp7xrDSCuutJ5omjfQKHvkGJpLszqPVWg3pby9XMLEz",
+    "https://api.goldsky.com/api/public/project_cm2x72f7p4cnq01x5fuy95ihm/subgraphs/bmx-mode-stats/0.0.1/gn",
 };
 
 const methodology = {


### PR DESCRIPTION
changes in dexs/bmx are for fixing classic volume not appearing for December 2024

changes in dexs/bmx-freestyle are for adding tracking for MODE, though for now our subgraph returns 0 as the total volume (we'll fix this in a few days, just pushing this altogether right now)