### PR TITLE
Add Citrex Markets adapter for dailyVolume 

### DIFF
--- a/dexs/citrex-markets/index.ts
+++ b/dexs/citrex-markets/index.ts
@@ -1,4 +1,3 @@
-import { version } from "os";
 import { getUniqStartOfTodayTimestamp } from "../../helpers/getUniSubgraphVolume";
 import { httpGet } from "../../utils/fetchURL";
 import { CHAIN } from "../../helpers/chains";

--- a/dexs/citrex-markets/index.ts
+++ b/dexs/citrex-markets/index.ts
@@ -45,7 +45,11 @@ const adapter = {
       [CHAIN.SEI]: {
         fetch,
         runAtCurrTime: true,
-        start: "2025-02-19",
+        start: "2025-02-18",
+        meta: {
+          methodology:
+            "The daily volume is calculated by querying the Citrex Markets API for the 24-hour volume of all USDC perpetual contracts.",
+        },
       },
     },
   },

--- a/dexs/citrex-markets/index.ts
+++ b/dexs/citrex-markets/index.ts
@@ -1,0 +1,46 @@
+import { getUniqStartOfTodayTimestamp } from "../../helpers/getUniSubgraphVolume";
+import { httpGet } from "../../utils/fetchURL";
+
+const URL = "https://api.citrex.markets/v1/ticker/24hr";
+
+interface ResponseItem {
+  fundingRateHourly: string;
+  fundingRateYearly: string;
+  high: string;
+  low: string;
+  markPrice: string;
+  nextFundingTime: string;
+  openInterest: string;
+  oraclePrice: string;
+  priceChange: string;
+  priceChangePercent: string;
+  productId: number;
+  productSymbol: string;
+  volume: string;
+}
+
+const fetch = async (timestamp: number) => {
+  const response: ResponseItem[] = await httpGet(URL);
+
+  //   console.log(response);
+
+  const dayTimestamp = getUniqStartOfTodayTimestamp(new Date(timestamp * 1000));
+
+  //   console.log(dayTimestamp);
+
+  // Divide by 10^18 to convert from min units to USDC as per the contract
+  const dailyVolume =
+    response.reduce((acc, item) => {
+      return acc + Number(item.volume);
+    }, 0) /
+    10 ** 18;
+
+  //   console.log(dailyVolume);
+
+  return {
+    dailyVolume: dailyVolume?.toString(),
+    timestamp: dayTimestamp,
+  };
+};
+
+fetch(1630000000);


### PR DESCRIPTION
Adding dailyVolume metric for [https://defillama.com/protocol/citrex-markets](https://defillama.com/protocol/citrex-markets)

🦙 Running CITREX-MARKETS adapter 🦙
---------------------------------------------------
Start Date:     Tue, 18 Feb 2025 00:00:00 GMT
End Date:       Wed, 19 Feb 2025 00:00:00 GMT
---------------------------------------------------

Version -> DERIVATIVES
---------
SEI 👇
Backfill start time: 18/2/2025
Methodology: The daily volume is calculated by querying the Citrex Markets API for the 24-hour volume of all perpetual contracts.
Daily volume: 136.74 k
End timestamp: 1739836800 (2025-02-18T00:00:00.000Z)
