### PR TITLE
feat: orderly adapter chain breakdown

### DIFF
--- a/dexs/orderly-network/index.ts
+++ b/dexs/orderly-network/index.ts
@@ -1,48 +1,80 @@
 import type { BreakdownAdapter, FetchOptions } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 import { getUniqStartOfTodayTimestamp } from "../../helpers/getUniSubgraphVolume";
-import { httpGet } from "../../utils/fetchURL";
+import fetchURL from "../../utils/fetchURL";
 
-const dateToTs = (date: string) => new Date(date).getTime() / 1000
-const apiNear = "https://api.orderly.org/md/volume/daily_stats"
-const apiEVM = "https://api-evm.orderly.org/md/volume/daily_stats"
+const apiEVM = "https://api.orderly.org/md/volume/daily_stats";
+
+type VolumeBreakdown = {
+  chainId: string;
+  volume: number;
+};
+
+type DailyStats = {
+  volume: number;
+  date: string;
+  netFee: number;
+  dateString: string;
+  createdAt: string;
+  volumeBreakdown?: VolumeBreakdown[];
+};
+
+const chainIdToChainInfo: {
+  [key: string]: { chain: CHAIN; startDate: string };
+} = {
+  "42161": { chain: CHAIN.ARBITRUM, startDate: "2023-10-26" },
+  "10": { chain: CHAIN.OPTIMISM, startDate: "2023-11-30" },
+  "137": { chain: CHAIN.POLYGON, startDate: "2024-02-05" },
+  "8453": { chain: CHAIN.BASE, startDate: "2024-04-03" },
+  "5000": { chain: CHAIN.MANTLE, startDate: "2024-05-28" },
+  "1": { chain: CHAIN.ETHEREUM, startDate: "2024-06-13" },
+  "1329": { chain: CHAIN.SEI, startDate: "2024-10-18" },
+  "43114": { chain: CHAIN.AVAX, startDate: "2024-11-07" },
+  "900900900": { chain: CHAIN.SOLANA, startDate: "2024-11-29" },
+  "2818": { chain: CHAIN.MORPH, startDate: "2024-12-17" },
+  "146": { chain: CHAIN.SONIC, startDate: "2024-12-31" },
+};
+
+const fetchVolume = async (chainId: string, startOfDay: number) => {
+  const data: DailyStats[] = await fetchURL(apiEVM);
+  const cleanTimestamp = getUniqStartOfTodayTimestamp(
+    new Date(startOfDay * 1000)
+  );
+
+  // Find the stats for the requested date
+  const targetDate = new Date(startOfDay * 1000).toISOString().split("T")[0];
+  const dailyStats = data.find((day) => day.date.startsWith(targetDate));
+
+  if (!dailyStats)
+    return {
+      timestamp: cleanTimestamp,
+      dailyVolume: "0",
+    };
+
+  const volume = dailyStats.volumeBreakdown?.find(
+    (b) => b.chainId === chainId
+  )?.volume;
+
+  return {
+    timestamp: cleanTimestamp,
+    dailyVolume: volume?.toString() || "0",
+  };
+};
 
 const adapter: BreakdownAdapter = {
   breakdown: {
-    "orderly-network": {
-      [CHAIN.NEAR]: {
-        start: '2022-12-02',
-        fetch: async(__t: number, _: any, { startOfDay }: FetchOptions) => {
-          try {
-            const data = await httpGet(apiNear) // error
-            const cleanTimestamp = getUniqStartOfTodayTimestamp(new Date(startOfDay * 1000))
-            return {
-              timestamp: cleanTimestamp,
-              dailyVolume: data.find((t:any)=>dateToTs(t.date) === cleanTimestamp)?.volume
-            }
-          } catch (e) {
-            console.error(e);
-            return {
-              timestamp: startOfDay,
-              dailyVolume: 0
-            }
-          }
-        }
-      },
-    },
-    "orderly-network-derivatives": {
-      [CHAIN.ARBITRUM]: {
-        start: '2023-10-26',
-        fetch: async (__t: number, _: any, { startOfDay }: FetchOptions) =>{
-          const data = await httpGet(apiEVM)
-          const cleanTimestamp = getUniqStartOfTodayTimestamp(new Date(startOfDay * 1000))
-          return {
-            timestamp: cleanTimestamp,
-            dailyVolume: data.find((t:any)=>dateToTs(t.date) === cleanTimestamp)?.volume
-          }
-        }
-      }
-    }
-  }
-}
+    "orderly-network-derivatives": Object.entries(chainIdToChainInfo).reduce(
+      (acc, [chainId, { chain, startDate }]) => ({
+        ...acc,
+        [chain]: {
+          start: startDate,
+          fetch: async (__t: number, _: any, { startOfDay }: FetchOptions) =>
+            fetchVolume(chainId, startOfDay),
+        },
+      }),
+      {}
+    ),
+  },
+};
+
 export default adapter;


### PR DESCRIPTION
Hey,

this updated volume adapter for [Orderly Network](https://orderly.network/) will now track the volume per chain.
We also removed Near, because it's no longer used and in withdrawal-only mode.