### PR TITLE
burrbear

### DIFF
--- a/protocols/burrbear.ts
+++ b/protocols/burrbear.ts
@@ -1,0 +1,44 @@
+import request from "graphql-request"
+import { FetchOptions, SimpleAdapter } from "../adapters/types"
+import { CHAIN } from "../helpers/chains"
+
+const url = 'https://api.goldsky.com/api/public/project_clq1h5ct0g4a201x18tfte5iv/subgraphs/bgt-subgraph/v1000000/gn'
+
+
+interface IProtocolData {
+    volumeUsd: number
+    feesUsd: number
+}
+const fetchVolume = async (options: FetchOptions) => {
+  const querry = `
+    {
+        poolDayDatas(where: {date_gte: ${options.startTimestamp}, date_lt: ${options.endTimestamp}}) {
+            date
+            volumeUsd
+            feesUsd
+        }
+    }`
+
+  const respose = (await request(url, querry)).poolDayDatas as IProtocolData[]
+
+  const dailyVolume = options.createBalances();
+  dailyVolume.addUSDValue(Number(respose.reduce((acc, item) => acc + Number(item.volumeUsd), 0)))
+  const dailyFees = dailyVolume.clone();
+  dailyFees.addUSDValue(Number(respose.reduce((acc, item) => acc + Number(item.feesUsd), 0)))
+  return {
+    dailyVolume: dailyVolume,
+    dailyFees: dailyFees,
+  }
+}
+
+const adapters: SimpleAdapter = {
+  version: 2,
+  adapter: {
+    [CHAIN.ABSTRACT]: {
+      fetch: fetchVolume,
+      runAtCurrTime: true
+    }
+  }
+}
+
+export default adapters


### PR DESCRIPTION
- little cleanup
- feat: add eisen fee tracking on defillama
- fix: typo for event
- bugfix
- feat : added the Starbase project
- Revert "feat : added the Starbase project"
- feat : added the Starbase project
- rebrand
- fix : update the index.ts
- add: bsc & base chain
- dailyVolume and totalVolume scripts updated
- dailyFees and totalFees scripts updated
- valume script updated
- fix update script
- fixed the fee logic, as the value provided is comulative
- lifi fees
- lifi
- update: add sonic network
- update: grahps urls
- update: fees lnexchange-perp
- add fees
- fix fees
- Update volume and fees CVEX (#2345)
- add link fees
- fix :   replace wit new url
- fix get value
- feat: add metastable meth volume dimension adapter
- added totalRevenue, SupplySideRevenue and ProtocolSideRevenue
- fix names
- add superswap/
- track tribe.run fees
- add hfun fees
- merge metastable adapters
- refactor: remove unused URL constants in metastable musd adapter
- add InfintiyPools DEX volume (#2352)
- add cache thorchain
- add methodology string for how dailyVolume is calculated
- fix mapping missing price
- change graphurl for Jellyverse
- add nova-fi
- fix pair
- add liquity v2 fee adapter
- across
- enable reservoir-tools-amm
- enable reservoir-tools-clmm
- add zoodotfun
- track quill fees
- ambient: track plume
- dimension adapter for Amped Finance
- add new chain
- enhance getLiquityV2LogAdapter to include dailyHoldersRevenue in the return object
- refactor getLiquityV2LogAdapter to consolidate dailyFees calculation and remove dailyRevenue from return object
- fix query
- add Unit Zero chain to WOWMAX
- add jupiter
- fix: bmx classic volume for december + add freestyle on mode
- fix: BMX Classic and Freestyle Fees
- add spot fee wallet
- add rabby
- fix graph pancake
- add fees
- add ekubo eth
- fix prevent nagtive value
- fix missing token
- update the graph
- updated endpoint API on 4cast(memecast)
- added soneium of quicksap
- add raydium perps info
- fix set datetime
- fix graph
- update dependencies for @defillama/sdk and undici
- add raydium perps info more
- add looter
- rename
- add flaunch
- implement enso volume fetch
- modify enso aggregator, add ENSO_API_KEY to env
- fix missing
- feat(dexs): add ocelex V2 volume
- feat(fees): add ocelex V2
- remove logs
- fix graph url
- fix token price
- update correct starting timestamps
- feat: add Levvy Finance volume, fees, and revenue stats (#2375)
- feat: mark adapters as expensive
- add enso daily volumes
- remove zksync, avalanche until supported
- remove comments
- enso v2 adapter
- enso back to v1
- track bunni v2
- rename
- feat: add super sui vault to metastab le volume adapter
- update for fees inclusion for Amped Finance
- add fees/wavex
- add dex/wavex
- update fees/wavex
- update dex/wavex
- update fees/wavex methodology
- fix code format & update startTimestamps
- fix timestamp
- chore(ocelex): fix token namings
- fix(lynex): v1 dex wasn't showing any volume anymore
- Added VinuFinance volume (#2369)
- fix query
- feat: freeze lista (#2383)
- Update fx-protocol dailyFees (#2384)
- fix wrong fix data
- Add 1delta volume (#2378)
- enable jupiter-perpetual fees
- track penumbra dex
- update routers for kerberos and pocket universe
- rooster fee/volume
- fix error
- add kodiak-v3
- Add new factory addresses and core assets for berachain and other chains
- add new query
- Add Berachain adapter and RPC configuration
- Add Berachain Hub adapter export
- add new query
- add new query
- add beralis-v3
- update networks
- feat: add berachain on eisen
- Update Enso adapter to v2
- fix: gas token check
- add berachain
- Remove linea
- Revert package-lock.json
- revert package.json
- Update index.ts
- Update index.ts
- add polymarket fees
- rename
- Adding Berachain to Magpie Protocol
- Remove runAtCurrTime flag from various adapters and update version for Arbitrum adapter
- Improve underlying queries
- Add queryId const
- sailfish
- Revert "Update Enso adapter to v2"
- Update: D2Finance
- feat: add moby berachain integration
- enable artexswap
- enable mondrain
- add uni chain v2, v3
- Adding Linea and Ink to Magpie Protocol
- adding linea and ink to magpie protocol
- add Uniswap v4 adapter with support for multiple chains
- add Bitflow and Velar adapters with daily volume and fees fetching
- Revert "Revert "Update Enso adapter to v2""
- add legacy fees and volume
- update phantom
- separate shadow legacy and cl fees
- add asbtract support on Vertex
- fix spike and add bera chain kyper
- Add chains
- Add PulseX protocol adapter
- add uni chain zns
- isExpensiveAdapter: true
- impermax: add missing networks and replace hosted subgraphs
- Add Storyhunt v3 dex adapter
- Add PulseX adapters for V1, V2, and StableSwap
- Add KittyPunch adapter and remove Flow from blacklisted chains
- add four meme fees
- add revshare wallet
- add four-meme
- update four meme
- add fees stargate
- track sailor fi volume
- Sonic re-deployment for Amped Finance
- fix traderjoe
- fix error missing chain
- fix biswap
- update piperx volume
- add sonic chain
- Enso Volume - Berachain start date moved
- Add silverswap integration for fees / volume
- Fixed query
- Add olab
- add Kodiak V2 and V3 DEX and fee adapters for Berachain
- fix cow swap
- feat(defiapp): add defiapp volume data
- update daily volume
- add new DEX adapters and update fee fetching logic for multiple chains
- Added Abstract adapter
- add bloom trading bot
- fix: remove skipIndexer from getLogs call in balancer helper
- Fixed subgraph for dswapV3
- fix the graph
- Create index.js
- add is isExpensiveAdapter
- flashbot fees
- feat(syncswap): Add linea and scroll, add zksync-era univ3 pool
- Update index.ts bullaexchange
- Added revenue fix.
- gmx-v2 solana
- fix gmx-v2
- ferro bug fix
- Removed console log and reverted changes
- add citrex markets data fetching functionality
- add adapter for citrex markets with daily volume calculation
- remove unused import from citrex markets index file
- update citrex markets adapter start date and add methodology for daily volume calculation
- Add dailyVolume for olab
- chore: add options to send to when fetch retrying util function
- chore(defiapp): complete defiapp adapter for reporting volume
- chore(defiapp): comment update
- fix silverswap import
- - Update Solana fee tracking with blacklist signers - fix phantom fees by removing liquidations
- chore(defiapp): add methodology
- add magma-finance
- update to v2 and v3
- update nile subgraph & fee split
- update
- update
- fixed accordingly to the API endpoint changes
- chore: revert utils/fetchURL.ts to commit f94315c199fc827c375de557839d150e9e1cf572
- chore(defiapp): update fetch method to httpGet per feedback request
- add cache
- add entry/exit fees to dhedge
- use entry/exit fees events instead of filtering transfers
- feat(dexs/sushiswap): rp6
- add Amped Finance Base deployment
- Modify gmx sol total volume (#2446)
- feat: orderly adapter chain breakdown
- fix error
- Add base graph id
- add uniswap graph for uni chain
- fix version
- fix orderly-network
- Fix fees on base for solidly
- fix jup perp fees
- feat(syncswap): update scroll subgraph endpoint
- correct references to Base
- update zkSwapFinance stable fee
- add ultra fees
- fix fees distibution
- add jupiter-dca
- add sablier fees
- add missed fees
- add hedgey fees
- fix jupiter dca
- Added Xpress total values
- Enhance volume printing to support aggregation of multiple entries (#2460)
- berachain fees
- Add Caviarnine SimplePool adapter for daily volume and fees fetching
- include failed too
- add chain fees
- stabble: update stats API end point
- fix missing value
- fix v3 volume
- fix bsc fees
- fix info
- update info
- add flexperp dexs, fees adapter
- fix contract
- Add STEAMM fees (#2434)
- fix dateId
- fix version
- fix data
- add burrbear
