### PR TITLE
fix: Use CarbonDeFi API pricing for all chains

### DIFF
--- a/dexs/carbondefi/index.ts
+++ b/dexs/carbondefi/index.ts
@@ -1,10 +1,6 @@
 import { FetchOptions, IJSON, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
-import {
-  getEmptyData,
-  getDimensionsSum,
-  getDimensionsSumByToken,
-} from "./utils";
+import { getEmptyData, getDimensionsSum } from "./utils";
 
 const CARBON_METADATA: {
   methodology: IJSON<string>;
@@ -25,52 +21,28 @@ const CARBON_METADATA: {
 const chainInfo: { [key: string]: any } = {
   [CHAIN.ETHEREUM]: {
     endpoint: "https://api.carbondefi.xyz/v1/ethereum/analytics/volume",
-    controller: "0xC537e898CD774e2dCBa3B14Ea6f34C93d5eA45e1",
     startBlock: 17087375,
     startTimestamp: 1681986059,
-    getDimensionsByToken: false,
   },
   [CHAIN.SEI]: {
     endpoint: "https://api.carbondefi.xyz/v1/sei/analytics/volume",
-    controller: "0xe4816658ad10bF215053C533cceAe3f59e1f1087",
     startBlock: 79146720,
     startTimestamp: 1716825673,
-    getDimensionsByToken: true,
   },
   [CHAIN.CELO]: {
     endpoint: "https://api.carbondefi.xyz/v1/celo/analytics/volume",
-    controller: "0x6619871118D144c1c28eC3b23036FC1f0829ed3a",
     gasToken: "0x471EcE3750Da237f93B8E339c536989b8978a438",
     startBlock: 26828280,
     startTimestamp: 1721813184,
-    getDimensionsByToken: true,
   },
 };
 
 const getData = async (options: FetchOptions) => {
   const analyticsEndpoint = chainInfo[options.chain].endpoint;
-  const getDimensionsByToken = chainInfo[options.chain].getDimensionsByToken;
   const startTimestamp = options.fromTimestamp;
   const endTimestamp = options.toTimestamp;
-  const controller = chainInfo[options.chain].controller;
 
   try {
-    if (getDimensionsByToken) {
-      const pairs: string[] = (
-        await options.api.call({
-          target: controller,
-          abi: "function pairs() view returns (address[2][])",
-        })
-      ).flat();
-      const uniqueTokens: string[] = [...new Set(pairs)];
-      return getDimensionsSumByToken(
-        analyticsEndpoint,
-        uniqueTokens,
-        startTimestamp,
-        endTimestamp,
-        getEmptyData(options)
-      );
-    }
     return getDimensionsSum(analyticsEndpoint, startTimestamp, endTimestamp);
   } catch (e) {
     console.error(e);

--- a/dexs/carbondefi/types.ts
+++ b/dexs/carbondefi/types.ts
@@ -1,9 +1,5 @@
 interface CarbonAnalyticsItem {
   timestamp: string;
-  symbol?: string;
-  address?: string;
-  fees: number;
-  volume: number;
   feesUsd: number;
   volumeUsd: number;
 }

--- a/dexs/carbondefi/utils.ts
+++ b/dexs/carbondefi/utils.ts
@@ -28,13 +28,9 @@ const fetchWithPagination = async (endpoint: string, limit: number = 10000) => {
 export const fetchDataFromApi = async (
   endpoint: string,
   startTimestampS?: number,
-  endTimestampS?: number,
-  tokens?: string[]
+  endTimestampS?: number
 ): Promise<CarbonAnalyticsResponse> => {
   const url = new URL(endpoint);
-
-  // Filter by tokens
-  if (tokens?.length) url.searchParams.append("addresses", tokens.toString());
 
   // Filter by date
   if (startTimestampS && endTimestampS) {
@@ -84,63 +80,6 @@ export const getDimensionsSum = async (
     dailyVolume,
     totalVolume,
     dailyFees,
-    totalFees,
-  };
-};
-
-export const getDimensionsSumByToken = async (
-  endpoint: string,
-  tokens: string[],
-  startTimestamp: number,
-  endTimestamp: number,
-  emptyData: {
-    dailyVolume: Balances;
-    dailyFees: Balances;
-    totalVolume: Balances;
-    totalFees: Balances;
-  }
-) => {
-  const tokensEndpoint = endpoint + "/tokens";
-  const dailyData: CarbonAnalyticsResponse = await fetchDataFromApi(
-    tokensEndpoint,
-    startTimestamp,
-    endTimestamp,
-    tokens
-  );
-  const swapData: CarbonAnalyticsResponse = await fetchDataFromApi(
-    tokensEndpoint,
-    undefined,
-    undefined,
-    tokens
-  );
-
-  const { dailyVolume, dailyFees, totalFees, totalVolume } = emptyData;
-
-  swapData.forEach((swap) => {
-    if (!swap.address) return;
-    if (isNativeToken(swap.address)) {
-      totalVolume.addGasToken(swap.volume * 1e18);
-      totalFees.addGasToken(swap.fees * 1e18);
-    } else {
-      totalVolume.add(swap.address, swap.volume);
-      totalFees.add(swap.address, swap.fees);
-    }
-  });
-  dailyData.forEach((swap) => {
-    if (!swap.address) return;
-    if (isNativeToken(swap.address)) {
-      dailyVolume.addGasToken(swap.volume * 1e18);
-      dailyFees.addGasToken(swap.fees * 1e18);
-    } else {
-      dailyVolume.add(swap.address, swap.volume);
-      dailyFees.add(swap.address, swap.fees);
-    }
-  });
-
-  return {
-    dailyVolume,
-    dailyFees,
-    totalVolume,
     totalFees,
   };
 };


### PR DESCRIPTION
The API has had improvements to its pricing so there's no more need to return the token amounts. 

Before: 

```
ETHEREUM 👇
Backfill start time: 20/4/2023
Daily volume: 182
Total volume: 3.16 M
Daily fees: 0
Total fees: 6.34 k
End timestamp: 1740651711 (2025-02-27T10:21:51.000Z)


SEI 👇
Backfill start time: 27/5/2024
Daily volume: 18.75 k
Daily fees: 75
Total volume: 8.59 M
Total fees: 34.52 k
End timestamp: 1740651711 (2025-02-27T10:21:51.000Z)


CELO 👇
Backfill start time: 24/7/2024
Daily volume: 4.30 k
Daily fees: 9
Total volume: 7.03 M
Total fees: 14.08 k
End timestamp: 1740651711 (2025-02-27T10:21:51.000Z)


---- AGGREGATE 👇
Backfill start time not defined
End timestamp: 1740651711 (2025-02-27T10:21:51.000Z)
Daily volume: 23.22 k
Total volume: 18.78 M
Daily fees: 84
Total fees: 54.95 k
```

After:

```
ETHEREUM 👇
Backfill start time: 20/4/2023
Daily volume: 182
Total volume: 3.16 M
Daily fees: 0
Total fees: 6.34 k
End timestamp: 1740651502 (2025-02-27T10:18:22.000Z)


SEI 👇
Backfill start time: 27/5/2024
Daily volume: 60.07 k
Total volume: 26.69 M
Daily fees: 185
Total fees: 85.44 k
End timestamp: 1740651502 (2025-02-27T10:18:22.000Z)


CELO 👇
Backfill start time: 24/7/2024
Daily volume: 15.43 k
Total volume: 26.21 M
Daily fees: 31
Total fees: 52.52 k
End timestamp: 1740651502 (2025-02-27T10:18:22.000Z)


---- AGGREGATE 👇
Backfill start time not defined
End timestamp: 1740651502 (2025-02-27T10:18:22.000Z)
Daily volume: 75.68 k
Total volume: 56.06 M
Daily fees: 216
Total fees: 144.31 k
```

Can you please regenerate the CarbonDeFi volume and fee stats for Sei and Celo?