### PR TITLE
Fix CarbonDeFi all-time volume and fees

### DIFF
--- a/dexs/carbondefi/index.ts
+++ b/dexs/carbondefi/index.ts
@@ -41,9 +41,15 @@ const getData = async (options: FetchOptions) => {
   const analyticsEndpoint = chainInfo[options.chain].endpoint;
   const startTimestamp = options.fromTimestamp;
   const endTimestamp = options.toTimestamp;
+  const chainStartTimestamp = chainInfo[options.chain].startTimestamp;
 
   try {
-    return getDimensionsSum(analyticsEndpoint, startTimestamp, endTimestamp);
+    return getDimensionsSum(
+      analyticsEndpoint,
+      startTimestamp,
+      endTimestamp,
+      chainStartTimestamp
+    );
   } catch (e) {
     console.error(e);
     // Return empty values

--- a/dexs/carbondefi/utils.ts
+++ b/dexs/carbondefi/utils.ts
@@ -1,11 +1,6 @@
-import { Balances } from "@defillama/sdk";
 import { CarbonAnalyticsResponse } from "./types";
 import { FetchOptions } from "../../adapters/types";
 import fetchURL from "../../utils/fetchURL";
-
-const isNativeToken = (address: string) =>
-  address.toLowerCase() ===
-  "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE".toLowerCase();
 
 const fetchWithPagination = async (endpoint: string, limit: number = 10000) => {
   let offset = 0;
@@ -33,8 +28,10 @@ export const fetchDataFromApi = async (
   const url = new URL(endpoint);
 
   // Filter by date
-  if (startTimestampS && endTimestampS) {
+  if (startTimestampS) {
     url.searchParams.append("start", startTimestampS.toString());
+  }
+  if (endTimestampS) {
     url.searchParams.append("end", endTimestampS.toString());
   }
   return fetchWithPagination(url.href);
@@ -43,14 +40,18 @@ export const fetchDataFromApi = async (
 export const getDimensionsSum = async (
   endpoint: string,
   startTimestamp: number,
-  endTimestamp: number
+  endTimestamp: number,
+  chainStartTimestamp: number
 ) => {
   const dailyData: CarbonAnalyticsResponse = await fetchDataFromApi(
     endpoint,
     startTimestamp,
     endTimestamp
   );
-  const swapData: CarbonAnalyticsResponse = await fetchDataFromApi(endpoint);
+  const swapData: CarbonAnalyticsResponse = await fetchDataFromApi(
+    endpoint,
+    chainStartTimestamp
+  );
 
   const { dailyVolume, dailyFees } = dailyData.reduce(
     (prev, curr) => {


### PR DESCRIPTION
The Volume API endpoint provides 1-year data if no startTimestamp is specified. This wasn't a problem before but the protocol is now > 1 year old, so it's required to set this value to the chain start timestamp to get all historical data. 