### PR TITLE
Add RFX fees and dexs adapter

### DIFF
--- a/dexs/rfx/index.ts
+++ b/dexs/rfx/index.ts
@@ -1,0 +1,101 @@
+import request, { gql } from "graphql-request";
+import { BreakdownAdapter, Fetch, FetchOptions } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import { getUniqStartOfTodayTimestamp } from "../../helpers/getUniSubgraphVolume";
+
+const endpoints: { [chain: string]: string } = {
+  [CHAIN.ZKSYNC]: "https://api.studio.thegraph.com/query/62681/rfxs-master/version/latest",
+};
+
+const historicalDataSwap = gql`
+  query get_volume($period: String!, $id: String!) {
+    volumeInfos(where: {period: $period, id: $id}) {
+      swapVolumeUsd
+    }
+  }
+`;
+
+const historicalDataDerivatives = gql`
+  query get_volume($period: String!, $id: String!) {
+    volumeInfos(where: {period: $period, id: $id}) {
+      marginVolumeUsd
+    }
+  }
+`;
+
+interface IGraphResponse {
+  volumeInfos: Array<{
+    swapVolumeUsd?: string;
+    marginVolumeUsd?: string;
+  }>;
+}
+
+const getFetch =
+  (query: string) =>
+  (chain: string): Fetch =>
+  async (_timestamp: number, _block: any, options: FetchOptions) => {
+    const dayTimestamp = getUniqStartOfTodayTimestamp(new Date(options.startOfDay * 1000));
+
+    const dailyData: IGraphResponse = await request(endpoints[chain], query, {
+      id: `1d:${dayTimestamp}`,  
+      period: "1d",
+    });
+
+    const totalData: IGraphResponse = await request(endpoints[chain], query, {
+      id: "total",
+      period: "total",
+    });
+
+    let dailyVolume = 0;
+    let totalVolume = 0;
+
+    if (dailyData.volumeInfos.length === 1) {
+      const volumeObj = dailyData.volumeInfos[0];
+      const sumOfFields = Object.values(volumeObj).reduce((sum, val) => sum + Number(val), 0);
+      dailyVolume = sumOfFields * 1e-30;
+    }
+
+    if (totalData.volumeInfos.length === 1) {
+      const volumeObj = totalData.volumeInfos[0];
+      const sumOfFields = Object.values(volumeObj).reduce((sum, val) => sum + Number(val), 0);
+      totalVolume = sumOfFields * 1e-30;
+    }
+
+    return {
+      timestamp: dayTimestamp,
+      dailyVolume: String(dailyVolume),
+      totalVolume: String(totalVolume),
+    };
+  };
+
+const startTimestamps: { [chain: string]: number } = {
+  [CHAIN.ZKSYNC]: 1733356800, 
+};
+
+const methodology = {
+  dailyVolume: "Sum of daily swap or margin volume for RFX subgraph.",
+  totalVolume: "Cumulative swap or margin volume since inception.",
+};
+
+const adapter: BreakdownAdapter = {
+  breakdown: {
+    "rfx-swap": {
+      [CHAIN.ZKSYNC]: {
+        fetch: getFetch(historicalDataSwap)(CHAIN.ZKSYNC),
+        start: startTimestamps[CHAIN.ZKSYNC],
+        meta: { methodology },
+      },
+    },
+    "rfx-trade": {
+      [CHAIN.ZKSYNC]: {
+        fetch: getFetch(historicalDataDerivatives)(CHAIN.ZKSYNC),
+        start: startTimestamps[CHAIN.ZKSYNC],
+        meta: { methodology },
+      },
+    },
+  },
+};
+
+export default adapter;
+
+

--- a/fees/rfx/index.ts
+++ b/fees/rfx/index.ts
@@ -1,0 +1,105 @@
+import request, { gql } from "graphql-request";
+import { Adapter, FetchResultFees, FetchOptions } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+
+const endpoints = {
+  [CHAIN.ZKSYNC]: "https://api.studio.thegraph.com/query/62681/rfxs-master/version/latest",
+};
+
+const timestampsQuery = gql`
+  {
+    revenueInfos(where: { period: "1d" }) {
+      id
+      timestamp
+    }
+  }
+`;
+
+const feeQuery = gql`
+  query get_fees($period: String!, $id: String!) {
+    revenueInfos(where: { period: $period, id: $id }) {
+      totalFeeUsd
+      cumulativeTotalFeeUsd
+    }
+  }
+`;
+
+interface ITimestampsResponse {
+  revenueInfos: Array<{
+    id: string;
+    timestamp: number;
+  }>;
+}
+
+interface IGraphFeesResponse {
+  revenueInfos: Array<{
+    totalFeeUsd: string;
+    cumulativeTotalFeeUsd: string;
+  }>;
+}
+
+const fetchFees = async (
+  rawTimestamp: number , 
+  _block: any,
+  _options: FetchOptions
+): Promise<FetchResultFees> => {
+  const timestamp = rawTimestamp ? Number(rawTimestamp) : undefined;
+
+  const timestampsData: ITimestampsResponse = await request(endpoints[CHAIN.ZKSYNC], timestampsQuery);
+  let availableTimestamps = timestampsData.revenueInfos.map((entry) => entry.timestamp);
+
+  if (availableTimestamps.length === 0) {
+    throw new Error("❌ No timestamps found in the subgraph.");
+  }
+
+  availableTimestamps.sort((a, b) => a - b);
+
+  let chosenTimestamp;
+
+  if (timestamp) {
+    chosenTimestamp = availableTimestamps.reduce((prev, curr) =>
+      Math.abs(curr - timestamp) < Math.abs(prev - timestamp) ? curr : prev
+    );
+  } else {
+    chosenTimestamp = availableTimestamps[availableTimestamps.length - 1];
+  }
+
+  console.log(`🔍 Using closest available timestamp: ${chosenTimestamp}`);
+
+  const dailyData: IGraphFeesResponse = await request(endpoints[CHAIN.ZKSYNC], feeQuery, {
+    id: chosenTimestamp.toString(),
+    period: "1d",
+  });
+
+  let dailyFees = 0;
+  let totalFees = 0;
+
+  if (dailyData.revenueInfos.length === 1) {
+    dailyFees = Number(dailyData.revenueInfos[0].totalFeeUsd) * 1e-30;
+    totalFees = Number(dailyData.revenueInfos[0].cumulativeTotalFeeUsd) * 1e-30;
+  }
+
+  return {
+    timestamp: chosenTimestamp,
+    dailyFees: String(dailyFees),
+    totalFees: String(totalFees),
+    dailyRevenue: String(dailyFees),
+    dailyProtocolRevenue: "0",
+    dailyHoldersRevenue: "0",
+    dailySupplySideRevenue: "0",
+  };
+};
+
+const adapter: Adapter = {
+  adapter: {
+    [CHAIN.ZKSYNC]: {
+      start: 1733356800,
+      fetch: fetchFees,
+    },
+  },
+  version: 2,
+};
+
+export default adapter;
+
+


### PR DESCRIPTION
## RFX Fees and DEX Adapter

[RFX](https://rfx.exchange/) is a perpetual DEX on **zkSync**.  
This PR implements both the **DEX** and **fees** adapters for RFX.

- **Fees Adapter:** Tracks daily fees and cumulative total fees.
- **DEX Adapter:** Tracks trading volume and liquidity.

### ✅ Data Verification:
- You can verify the data here: [RFX Stats](https://app.rfx.exchange/stats)
