### PR TITLE
yieldcapture on v3

### DIFF
--- a/dexs/balancer-v3/index.ts
+++ b/dexs/balancer-v3/index.ts
@@ -42,12 +42,14 @@ async function fetch({ createBalances, chain}: FetchOptions) {
       lifetimeSwapFees
       volume24h
       fees24h
+      yieldCapture24h
     }
   }
 }` 
   const { pools } = await request('https://api-v3.balancer.fi/graphql', query);
   pools.forEach((pool: any) => {
     dailyFees.addUSDValue(+pool.dynamicData.fees24h)
+    dailyFees.addUSDValue(+pool.dynamicData.yieldCapture24h)
     dailyVolume.addUSDValue(+pool.dynamicData.volume24h)
   })
   return { dailyFees, dailyVolume }

--- a/dexs/balancer-v3/index.ts
+++ b/dexs/balancer-v3/index.ts
@@ -24,8 +24,6 @@ async function fetch({ createBalances, chain}: FetchOptions) {
   const dailyFees = createBalances()
   const query = `query {
   pools: poolGetPools(
-    first: 1000
-    skip: 0
     orderBy: volume24h
     orderDirection: desc
     where: { chainIn: [${v3ChainMapping[chain]}] protocolVersionIn: [3]}

--- a/dexs/beets-v3/index.ts
+++ b/dexs/beets-v3/index.ts
@@ -23,8 +23,6 @@ async function fetch({ createBalances, chain}: FetchOptions) {
   const dailyFees = createBalances()
   const query = `query {
   pools: poolGetPools(
-    first: 1000
-    skip: 0
     orderBy: volume24h
     orderDirection: desc
     where: { chainIn: [${v3ChainMapping[chain]}] protocolVersionIn: [3]}

--- a/dexs/beets-v3/index.ts
+++ b/dexs/beets-v3/index.ts
@@ -41,12 +41,14 @@ async function fetch({ createBalances, chain}: FetchOptions) {
       lifetimeSwapFees
       volume24h
       fees24h
+      yieldCapture24h
     }
   }
 }` 
   const { pools } = await request('https://api-v3.balancer.fi/graphql', query);
   pools.forEach((pool: any) => {
     dailyFees.addUSDValue(+pool.dynamicData.fees24h)
+    dailyFees.addUSDValue(+pool.dynamicData.yieldCapture24h)
     dailyVolume.addUSDValue(+pool.dynamicData.volume24h)
   })
   return { dailyFees, dailyVolume }


### PR DESCRIPTION
Balancer v3 captures yield from yield bearing tokens and makes sure it stays inside the LP instead of be given to arbers. 

The same is true for v2 but the methodology of the dimension adapter for v2 uses subgraph and the subgraph does not have that data. We could, how ever, change that to use our API as well.