### PR TITLE
Fix wrong chain for Mosaic

### DIFF
--- a/aggregators/mosaic/index.ts
+++ b/aggregators/mosaic/index.ts
@@ -20,7 +20,7 @@ const fetch = async (_: any): Promise<FetchResult> => {
 const adapter: any = {
   timetravel: false,
   adapter: {
-    [CHAIN.MOVEMENT]: {
+    [CHAIN.MOVE]: {
       fetch: fetch,
       runAtCurrTime: true,
       start: "2025-03-10",

--- a/helpers/chains.ts
+++ b/helpers/chains.ts
@@ -91,7 +91,6 @@ export enum CHAIN {
   XDC = "xdc",
   STARKNET = "starknet",
   MOONBEAM = "moonbeam",
-  MOVEMENT = "movement",
   WAVES = "waves",
   CARBON = "carbon",
   THUNDERCORE = "thundercore",


### PR DESCRIPTION
- Fix wrong chain for Mosaic:
  - Use `CHAIN.MOVE` instead of `CHAIN.MOVEMENT`
  - Remove `CHAIN.MOVEMENT`