### PR TITLE
feature: modified token name for addCGToken

### DIFF
--- a/fees/pumpup.ts
+++ b/fees/pumpup.ts
@@ -3,6 +3,7 @@ import { FetchOptions, SimpleAdapter } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
 import { queryEvents } from "../helpers/sui";
 import axios from "axios";
+import BigNumber from "bignumber.js";
 
 const UNIHOUSE_CORE_PACKAGE_ID =
   "0x2f2226a22ebeb7a0e63ea39551829b238589d981d1c6dd454f01fcc513035593";
@@ -124,8 +125,13 @@ const fetchFees = async (options: FetchOptions) => {
     "0x2::sui::SUI",
     "0xdba34672e30cb065b1f93e3ab55318768fd6fef66c15942c9f7cb846e2f900e7::usdc::USDC",
     "0xfe3afec26c59e874f3c1d60b8203cb3852d2bb2aa415df9548b8d688e6683f93::alpha::ALPHA",
+    "0x76cb819b01abed502bee8a702b4c2d547532c12f25001c9dea795a5e631c26f1::fud::FUD",
+    "0xdeeb7a4662eec9f2f3def03fb937a663dddaa2e215b8078a284d026b7946c270::deep::DEEP",
   ];
-  for (const tokenType of tokenTypeList) {
+
+  const tokenCGName = ["sui", "usd-coin", "alpha-fi", "fud-the-pug", "deep"];
+
+  for (const [index, tokenType] of tokenTypeList.entries()) {
     const joinHouseEvents = await queryEvents({
       eventType: `${UNIHOUSE_CORE_PACKAGE_ID}::house::JoinHouseEvent<${tokenType}>`,
       options,
@@ -137,17 +143,17 @@ const fetchFees = async (options: FetchOptions) => {
     });
 
     const coinMetadata = await getCoinMetadata(tokenType);
+    const decimals = coinMetadata.decimals;
 
     joinHouseEvents.map((ev) => {
-      const symbol = coinMetadata.symbol.toLowerCase();
-      const decimals = coinMetadata.decimals;
-      dailyFees.addCGToken(symbol, ev.fee_taken / 10 ** decimals);
+      dailyFees.addCGToken(tokenCGName[index], ev.fee_taken / 10 ** decimals);
     });
 
     splitHouseEvents.map((ev) => {
-      const symbol = coinMetadata.symbol.toLowerCase();
-      const decimals = coinMetadata.decimals;
-      dailyFees.addCGToken(symbol, -ev.fee_reimbursed_amount / 10 ** decimals);
+      dailyFees.addCGToken(
+        tokenCGName[index],
+        -ev.fee_reimbursed_amount / 10 ** decimals
+      );
     });
   }
 


### PR DESCRIPTION
Hi, 

We are the DoubleUp team. We recently found that we were not correctly retrieving the prices of tokens other than SUI, so we want to update the code accordingly.

Furthermore, we have a question about the fees and revenues shown on the site.

<img width="1220" alt="image" src="https://github.com/user-attachments/assets/30f60f75-d771-4216-b229-cbe619635611" />

Let's take **Fees** as an example.

The "**Cumulative Fees**" shows that from June 2, 2024, until now, we have around 45K in fees.

However, when we collect fee data using the same method, we see a huge difference.

Below are the charts of cumulative SUI fees (counted in SUI) and USDC fees:

![image](https://github.com/user-attachments/assets/2f79074a-142a-40e4-a25b-230ee44a4fe7)

From September 11, 2024, until now, we have collected 161K SUI and 151K USDC in income fees.

This suggests that the actual fee amount is 10 times higher than what is shown on DeFiLlama.

After spending a few days reviewing the adapter code, we haven't found any clues about this discrepancy.

Could you help us resolve this issue?

Thanks in advance!
