### PR TITLE
Add contango fees #2621

### DIFF
--- a/fees/contango/index.ts
+++ b/fees/contango/index.ts
@@ -1,0 +1,95 @@
+import { FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import { queryDune } from "../../helpers/dune";
+
+let cachedData: any = null;
+let fetchPromise: Promise<any> | null = null;
+
+const fetchFees = async (options: FetchOptions) => {
+    const res = await queryDune("4865365", {
+      start: options.startTimestamp,
+      end: options.endTimestamp,
+    });
+
+    return {
+      data: res || []
+    };
+}
+
+const getFees = async (options: FetchOptions) => {
+    if (cachedData) {
+        return cachedData;
+    }
+    if (!fetchPromise) {
+        fetchPromise = fetchFees(options).then(data => {
+            cachedData = data;
+            fetchPromise = null;
+            return data;
+        }).catch(err => {
+            fetchPromise = null; // in case of error
+            throw err;
+        });
+    }
+    return fetchPromise;
+}
+
+const fetch = async (options: FetchOptions) => {
+    const dailyFees = await getFees(options);
+    const fee = options.createBalances();
+    const data = dailyFees.data.filter((d: any) => d.CHAIN === options.chain);
+    
+    if (data.length > 0) {
+        fee.addUSDValue(data[0].AMOUNT_USD);
+    }
+
+    return { dailyFees: fee };
+}
+
+const adapter: SimpleAdapter = {
+    version: 2,
+    adapter: {
+        [CHAIN.ETHEREUM]: {
+            fetch: fetch,
+            start: '2024-11-05'
+        },
+        [CHAIN.BASE]: {
+            fetch: fetch,
+            start: '2024-11-05'
+        },
+        [CHAIN.ARBITRUM]: {
+            fetch: fetch,
+            start: '2024-11-05'
+        },
+        [CHAIN.OPTIMISM]: {
+            fetch: fetch,
+            start: '2024-11-05'
+        },
+        [CHAIN.SCROLL]: {
+            fetch: fetch,
+            start: '2024-11-05'
+        },
+        [CHAIN.XDAI]: {
+            fetch: fetch,
+            start: '2024-11-05'
+        },
+        [CHAIN.AVAX]: {
+            fetch: fetch,
+            start: '2024-11-05'
+        },
+        [CHAIN.LINEA]: {
+            fetch: fetch,
+            start: '2024-11-05'
+        },
+        [CHAIN.POLYGON]: {
+            fetch: fetch,
+            start: '2024-11-05'
+        },
+        [CHAIN.BSC]: {
+            fetch: fetch,
+            start: '2024-11-05'
+        },
+    },
+    isExpensiveAdapter: true,
+}
+
+export default adapter;


### PR DESCRIPTION
Track contango fees, based on Contango dune dashboard
https://dune.com/contango_xyz/contango-v2
Modified the query a little bit https://dune.com/queries/4865365
```sh
yarn run v1.22.22
warning ..\..\package.json: No license field
$ ts-node --transpile-only cli/testAdapter.ts fees contango
🦙 Running CONTANGO adapter 🦙
---------------------------------------------------
Start Date:     Mon, 17 Mar 2025 00:25:40 GMT
End Date:       Tue, 18 Mar 2025 00:25:40 GMT
---------------------------------------------------

waiting for query id 4865365 to complete...
ETHEREUM 👇
Backfill start time: 5/11/2024
Daily fees: 1.50 k
End timestamp: 1742257539 (2025-03-18T00:25:39.000Z)


BASE 👇
Backfill start time: 5/11/2024
Daily fees: 698
End timestamp: 1742257539 (2025-03-18T00:25:39.000Z)


ARBITRUM 👇
Backfill start time: 5/11/2024
Daily fees: 23
End timestamp: 1742257539 (2025-03-18T00:25:39.000Z)


OPTIMISM 👇
Backfill start time: 5/11/2024
Daily fees: 221
End timestamp: 1742257539 (2025-03-18T00:25:39.000Z)


SCROLL 👇
Backfill start time: 5/11/2024
Daily fees: 0
End timestamp: 1742257539 (2025-03-18T00:25:39.000Z)


XDAI 👇
Backfill start time: 5/11/2024
Daily fees: 0
End timestamp: 1742257539 (2025-03-18T00:25:39.000Z)


AVAX 👇
Backfill start time: 5/11/2024
Daily fees: 0
End timestamp: 1742257539 (2025-03-18T00:25:39.000Z)


LINEA 👇
Backfill start time: 5/11/2024
Daily fees: 0
End timestamp: 1742257539 (2025-03-18T00:25:39.000Z)


POLYGON 👇
Backfill start time: 5/11/2024
Daily fees: 4
End timestamp: 1742257539 (2025-03-18T00:25:39.000Z)


BSC 👇
Backfill start time: 5/11/2024
Daily fees: 0
End timestamp: 1742257539 (2025-03-18T00:25:39.000Z)


---- AGGREGATE 👇
Backfill start time not defined
End timestamp: 1742257539 (2025-03-18T00:25:39.000Z)
Daily fees: 2.45 k
```
![image](https://github.com/user-attachments/assets/d303d9a0-9909-48af-a2a8-5603e0a7cb16)
