### PR TITLE
fix: permit failures of voters for rings

### DIFF
--- a/fees/rings/index.ts
+++ b/fees/rings/index.ts
@@ -15,7 +15,7 @@ const accountants = Object.values({
 const fetch: any = async ({ createBalances, getLogs, api }: FetchOptions) => {
   const dailyFees = createBalances();
   const ves = Object.values(VotingEscrows)
-  const voters = await api.multiCall({ abi: 'address:voter', calls: ves })
+  const voters = await api.multiCall({ abi: 'address:voter', calls: ves, permitFailure: true, excludeFailed: true })
   const baseAssets = await api.multiCall({ abi: 'address:baseAsset', calls: voters })
 
   // Budget event is yield generated from scUSD and scETH: comes from strategies in Ethereum veda vault


### PR DESCRIPTION
It failed previously for timestamps older than the deployment of veBTC for example

```yarn test fees rings 1738186658```