### PR TITLE
Add fees adapter for StakeDAO

### DIFF
--- a/fees/stakedao/index.ts
+++ b/fees/stakedao/index.ts
@@ -31,11 +31,13 @@ const fetch = async (options: FetchOptions) => {
     options, 
     targets: [LIQUIDITY_FEES_RECIPIENT] 
   });
-
+  const dailyRevenue = dailyProtocolRevenue.clone();
+  dailyRevenue.addBalances(dailyHoldersRevenue);
   return {
     dailyFees,
     dailyProtocolRevenue,
     dailyHoldersRevenue,
+    dailyRevenue, // Protocol Revenue + Holder Revenue
     dailyUserFees
   };
 };

--- a/fees/stakedao/index.ts
+++ b/fees/stakedao/index.ts
@@ -1,0 +1,53 @@
+import { Adapter, FetchOptions } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import { addTokensReceived } from '../../helpers/token';
+
+// Fee recipient addresses
+const TREASURY_FEES_RECIPIENT = '0x9EBBb3d59d53D6aD3FA5464f36c2E84aBb7cf5c1';
+const VESDT_FEE_RECIPIENT = '0x1fE537BD59A221854a53a5B7a81585B572787fce';
+const LIQUIDITY_FEES_RECIPIENT = '0x576D7AD8eAE92D9A972104Aac56c15255dDBE080';
+
+const fetch = async (options: FetchOptions) => {
+  // All fees collected from all sources
+  const dailyFees = await addTokensReceived({ 
+    options, 
+    targets: [TREASURY_FEES_RECIPIENT, VESDT_FEE_RECIPIENT, LIQUIDITY_FEES_RECIPIENT] 
+  });
+
+  // Treasury revenue (Protocol Revenue)
+  const dailyProtocolRevenue = await addTokensReceived({ 
+    options, 
+    targets: [TREASURY_FEES_RECIPIENT] 
+  });
+
+  // Revenue for veSDT holders
+  const dailyHoldersRevenue = await addTokensReceived({ 
+    options, 
+    targets: [VESDT_FEE_RECIPIENT] 
+  });
+  
+  // Fees paid by users (liquidity fees)
+  const dailyUserFees = await addTokensReceived({ 
+    options, 
+    targets: [LIQUIDITY_FEES_RECIPIENT] 
+  });
+
+  return {
+    dailyFees,
+    dailyProtocolRevenue,
+    dailyHoldersRevenue,
+    dailyUserFees
+  };
+};
+
+const adapter: Adapter = {
+  version: 2,
+  adapter: {
+    [CHAIN.ETHEREUM]: {
+      fetch,
+      start: '2021-01-01',
+    }
+  }
+};
+
+export default adapter;


### PR DESCRIPTION
## Description
This PR adds a fees adapter for StakeDAO that tracks revenue streams across three key addresses:

- Treasury fees: 0x9EBBb3d59d53D6aD3FA5464f36c2E84aBb7cf5c1
- veSDT holder rewards: 0x1fE537BD59A221854a53a5B7a81585B572787fce
- User fees: 0x576D7AD8eAE92D9A972104Aac56c15255dDBE080

## Implementation Details
- Categorizes fees according to Dimension's standard metrics
- Tracks inflows to each address using the `addTokensReceived` helper
- Ethereum mainnet only
- Start date: January 1, 2021

## Testing
The adapter has been tested using the standard test suite:
`npm test fees stakedao`

## Metrics Tracked
- dailyFees: Total fees across all addresses
- dailyProtocolRevenue: Treasury revenue
- dailyHoldersRevenue: Revenue for veSDT holders
- dailyUserFees: Fees paid by users 