### PR TITLE
trade bots fees #2618 #2614 #2611

### DIFF
--- a/fees/finder-bot/index.ts
+++ b/fees/finder-bot/index.ts
@@ -1,0 +1,20 @@
+import { FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import { getSolanaReceived } from "../../helpers/token";
+
+const fetch: any = async (options: FetchOptions) => {
+  const dailyFees = await getSolanaReceived({ options, target: 'or8TBDJvuD86CUiFjFWX9oy34EmjoTtHEpPULP1JTta' })
+  return { dailyFees, dailyRevenue: dailyFees, }
+}
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  adapter: {
+    [CHAIN.SOLANA]: {
+      fetch: fetch,
+          },
+  },
+  isExpensiveAdapter: true
+};
+
+export default adapter;

--- a/fees/sol-trading-bot/index.ts
+++ b/fees/sol-trading-bot/index.ts
@@ -1,0 +1,20 @@
+import { FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import { getSolanaReceived } from "../../helpers/token";
+
+const fetch: any = async (options: FetchOptions) => {
+  const dailyFees = await getSolanaReceived({ options, targets: ['F34kcgMgCF7mYWkwLN3WN7KrFprr2NbwxuLvXx4fbztj', '96aFQc9qyqpjMfqdUeurZVYRrrwPJG2uPV6pceu4B1yb'] })
+  return { dailyFees, dailyRevenue: dailyFees, }
+}
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  adapter: {
+    [CHAIN.SOLANA]: {
+      fetch: fetch,
+          },
+  },
+  isExpensiveAdapter: true
+};
+
+export default adapter;

--- a/fees/suite/index.ts
+++ b/fees/suite/index.ts
@@ -1,0 +1,53 @@
+import {
+    Adapter,
+    FetchOptions,
+  } from "../../adapters/types";
+  import { CHAIN } from "../../helpers/chains";
+  import fetchURL from "../../utils/fetchURL";
+
+  const suiteBotFeesURL = 'https://crypton-be-bk6w.onrender.com/by-day';
+
+  interface DailyMetrics {
+    buy_volume_usd: number;
+    day: number;
+    fees_sui: number;
+    fees_usd: number;
+    number_of_new_users: number;
+    number_of_trades: number;
+    number_of_users: number;
+    sell_volume_usd: number;
+    volume_usd: number;
+}
+
+
+const fetchSuiteStats = async ({ endTimestamp }: FetchOptions) => {
+    // because the API doesn't support timestamp, we need to fetch all data and filter it
+    const url = `${suiteBotFeesURL}`
+    const stats: DailyMetrics[] = (await fetchURL(url).then((data) => data.data));
+    const closestDay = stats.reduce((prev, curr) => Math.abs(curr.day - endTimestamp) < Math.abs(prev.day - endTimestamp) ? curr : prev);
+    return {
+        dailyFees: closestDay.fees_usd,
+        dailyRevenue: closestDay.fees_usd,
+        dailyProtocolRevenue: closestDay.fees_usd / 2,
+        dailyHoldersRevenue: closestDay.fees_usd / 2,
+    };
+}
+
+const adapter: Adapter = {
+  version: 2,
+  adapter: {
+    [CHAIN.SUI]: {
+      fetch: fetchSuiteStats,
+      start: '2024-09-25',
+      meta: {
+        methodology:{
+            Fees: 'Total fees paid from bot trades',
+            ProtocolReveneue: '50% of the total fees goes to the treasury',
+            HolderRevenue: '50% of the total fees goes to the token holders (doesn\'t include other revenue sources)'
+        }
+      },
+    },
+  },
+};
+
+export default adapter;


### PR DESCRIPTION
Suite Trading Bot (#2618)
fetch https://crypton-be-bk6w.onrender.com/by-day (link from dune query)
revenue doesn't include other sources stated here https://docs.suite.tech/revenue-share

Finder Bot (#2614)
Tracked by checking sol transfer to the fee address (or8TBDJvuD86CUiFjFWX9oy34EmjoTtHEpPULP1JTta), taken from bot tx

Sol Trading Bot (#2611)
Address taken from https://github.com/duneanalytics/spellbook/blob/main/dbt_subprojects/solana/models/_sector/dex/bot_trades/solana/platforms/sol_trading_bot_solana_bot_trades.sql
It seems like the address is currently being used is only F34kcgMgCF7mYWkwLN3WN7KrFprr2NbwxuLvXx4fbztj & 96aFQc9qyqpjMfqdUeurZVYRrrwPJG2uPV6pceu4B1yb
