### PR TITLE
Fix pumpswap volume/fees with new optimized dune query

### DIFF
--- a/dexs/pump-swap/index.ts
+++ b/dexs/pump-swap/index.ts
@@ -2,12 +2,14 @@ import { SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 import { queryDune } from "../../helpers/dune";
 
-const queryId = "4881760";
+const queryId = "4900425";
 
 interface IData {
-    amount: number;
-    token: string;
+    daily_volume_sol: number;
+    daily_protocol_fees_sol: number;
+    daily_lp_fees_sol: number;
 }
+
 const fetch = async ({ startTimestamp, endTimestamp, createBalances }) => {
   // https://x.com/pumpdotfun/status/1902762316774486276 source for platform and lp fees brakedown
   const data: IData[] = await queryDune(queryId, {
@@ -16,16 +18,20 @@ const fetch = async ({ startTimestamp, endTimestamp, createBalances }) => {
     })
 
     const dailyVolume = createBalances()
+    const dailySupplySideRevenue = createBalances()
+    const dailyProtocolRevenue = createBalances()
 
-    for (const { amount, token } of data) {
-      dailyVolume.add(token, amount)
-    }
+    dailyVolume.addGasToken(data[0].daily_volume_sol)
+    dailyProtocolRevenue.addGasToken(data[0].daily_protocol_fees_sol)
+    dailySupplySideRevenue.addGasToken(data[0].daily_lp_fees_sol)
 
-    const dailyFees = dailyVolume.clone(0.25 / 100)
-    const dailyUserFees = dailyFees
-    const dailyProtocolRevenue = dailyFees.clone(0.2)
-    const dailySupplySideRevenue = dailyFees.clone(0.8)
-    
+    const dailyFees = createBalances()
+    dailyFees.addBalances(dailyProtocolRevenue)
+    dailyFees.addBalances(dailySupplySideRevenue)
+    const dailyUserFees = dailyFees.clone(1)
+
+    // console.log(dailyVolume, dailyFees, dailyUserFees, dailyProtocolRevenue, dailySupplySideRevenue)
+
     return { 
       dailyVolume, 
       dailyFees,
@@ -39,7 +45,7 @@ const adapter: SimpleAdapter = {
     adapter: {
         [CHAIN.SOLANA]: {
             fetch,
-            start: '2023-04-01',
+            start: '2025-03-15',
             meta: {
                 methodology: {
                     Fees: "Each trade has a 0.25% fee - 0.20% goes to LPs and 0.05% goes to the protocol",


### PR DESCRIPTION
It's using onchain instruction calls for LP and Protocol fees and cover all inner executing account's instruction calls.
Optimized dune query based on the https://dune.com/adam_tehc/pumpswap dashboard.
