### PR TITLE
Add revenue to Steamm fees adapter

### DIFF
--- a/fees/steamm/index.ts
+++ b/fees/steamm/index.ts
@@ -19,6 +19,7 @@ const fetchSteammStats = async ({ startTimestamp, endTimestamp, createBalances }
 
   return {
     dailyFees,
+    dailyRevenue: dailyFees,
   };
 };
 


### PR DESCRIPTION
When the adapter was last updated, revenue was dropped.