### PR TITLE
Replace tigris fees and volume with dune query as stats api is down

### DIFF
--- a/fees/tigris/index.ts
+++ b/fees/tigris/index.ts
@@ -1,71 +1,86 @@
 import { Chain } from "@defillama/sdk/build/general";
-import { Adapter, FetchResultFees } from "../../adapters/types";
+import { Adapter, FetchResultFees, FetchOptions } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
-import { httpGet } from "../../utils/fetchURL";
+import { getTimestampAtStartOfDayUTC } from "../../utils/date";
+import { queryDuneSql } from "../../helpers/dune";
 
-const API_ENDPOINT = "https://flask.tigristrade.info";
-
-interface ApiResponse {
-  dailyFees: number;
-  dailyNotionalVolume: number;
-  dailyVolume: number;
-  day: number;
-  totalFees: number;
-  totalNotionalVolume: number;
-  totalVolume: number;
-  dailyRevenue: number;
-  dailyHoldersRevenue: number;
-  dailyProtocolRevenue: number;
-}
-
-const fetchFromAPI = async (chain: Chain, timestamp: number): Promise<ApiResponse[]> => {
-  let endpoint;
-  if (chain === CHAIN.POLYGON) {
-    endpoint = "/fetch-polygon-data";
-  } else if (chain === CHAIN.ARBITRUM) {
-    endpoint = "/fetch-arbitrum-data";
-  } else {
-    throw new Error(`Unsupported chain: ${chain}`);
-  }
-
-  const response = await httpGet(`${API_ENDPOINT}${endpoint}`, {
-    params: {
-      chain: chain,
-      timestamp: timestamp
-    }
-  });
-
-  return response;
-}
-
-function startOfDayTimestamp(timestamp: number): number {
-  const date = new Date(timestamp * 1000);
-  date.setUTCHours(0, 0, 0, 0);
-  return Math.floor(date.getTime() / 1000);
+interface DuneTradeData {
+  blockchain: string;
+  perpetuals_volume: string;
+  perpetuals_fees: string;
+  options_volume: string;
+  options_fees: string;
 }
 
 const fetch = (chain: Chain) => {
-  return async (timestamp: number): Promise<FetchResultFees> => {
-    const dataPoints = await fetchFromAPI(chain, timestamp);
-
-    const adjustedTimestamp = startOfDayTimestamp(timestamp);
-
-    const matchingData = dataPoints.find(e => e.day === adjustedTimestamp);
-
-    if (!matchingData)
-      throw new Error(`No matching data found for timestamp ${adjustedTimestamp}. Returning zero values.`);
+  return async (timestamp: number, _: any, options: FetchOptions): Promise<FetchResultFees> => {
+    const duneChainName = chain === CHAIN.ARBITRUM ? 'arbitrum' : 'polygon';
     
+    const duneData: DuneTradeData[] = await queryDuneSql(options, `
+      WITH all_trades AS (
+          SELECT
+              blockchain,
+              volume_usd,
+              fee_usd AS fees,
+              block_time,
+              'perpetuals' AS class
+          FROM
+              tigris.perpetual_trades
+          WHERE TIME_RANGE
+
+          UNION ALL
+
+          SELECT
+              blockchain,
+              volume_usd,
+              fees,
+              evt_block_time AS block_time,
+              'options' AS class
+          FROM
+              tigris.options_trades
+          WHERE evt_block_time >= from_unixtime(${options.startTimestamp})
+                AND evt_block_time <= from_unixtime(${options.endTimestamp})
+      ),
+      daily_summary AS (
+          SELECT
+              blockchain,
+              SUM(CASE WHEN class = 'perpetuals' THEN volume_usd ELSE 0 END) AS perpetuals_volume,
+              SUM(CASE WHEN class = 'perpetuals' THEN fees ELSE 0 END) AS perpetuals_fees,
+              SUM(CASE WHEN class = 'options' THEN volume_usd ELSE 0 END) AS options_volume,
+              SUM(CASE WHEN class = 'options' THEN fees ELSE 0 END) AS options_fees
+          FROM
+              all_trades
+          GROUP BY
+              blockchain
+      )
+      SELECT
+          blockchain,
+          perpetuals_volume,
+          perpetuals_fees,
+          options_volume,
+          options_fees
+      FROM
+          daily_summary
+      WHERE blockchain = '${duneChainName}';
+    `);
+
+    const chainData = duneData?.[0] ?? {
+      perpetuals_fees: '0',
+      options_fees: '0',
+      perpetuals_volume: '0',
+      options_volume: '0'
+    };
+    
+    const totalFees = Number(chainData.perpetuals_fees) + Number(chainData.options_fees);
+    const totalVolume = Number(chainData.perpetuals_volume) + Number(chainData.options_volume);
 
     return {
-      dailyFees: matchingData.dailyFees.toString(),
-      dailyRevenue: matchingData.dailyRevenue.toString(),
-      dailyProtocolRevenue: matchingData.dailyProtocolRevenue.toString(),
-      dailyHoldersRevenue: matchingData.dailyHoldersRevenue.toString(),
-      timestamp: matchingData.day,
-      totalFees: matchingData.totalFees.toString()
-    }
-  }
-}
+      timestamp: getTimestampAtStartOfDayUTC(timestamp),
+      dailyFees: totalFees.toString(),
+      dailyRevenue: totalFees.toString()
+    };
+  };
+};
 
 const adapter: Adapter = {
   version: 1,
@@ -79,6 +94,6 @@ const adapter: Adapter = {
       start: '2022-09-13',
     }
   }
-}
+};
 
 export default adapter;


### PR DESCRIPTION
from their discord: 
"trading was paused over the past few months due to architectural issues that led to traders being unfairly profitable while the treasury incurred losses. This created uncertainty within the team about the project's future, leading to internal conflicts and resulting in some members leaving. Moving forward, we have spent the past months reimagining the future of Tigris and redefining our goals."

so we can keep it disabled.