### PR TITLE
Fix: Across Fee

### DIFF
--- a/fees/across.ts
+++ b/fees/across.ts
@@ -1,13 +1,37 @@
+/**
+ * Across Adapter
+ * 
+ * NOTE: This implementation uses Dune queries rather than event-based calculations.
+ * 
+ * Previous event-based methods had bugs because:
+ * 1. Events don't provide enough data points to accurately estimate fees
+ * 2. Simple inputAmount-outputAmount calculations are incorrect as token amounts 
+ *    have different decimal precision across chains
+ * 3. Cross-chain token swaps (e.g., ETH from Arbitrum to USDC on Base) 
+ *    complicates fee calculations
+ * 
+ * This Dune-based approach provides more accurate fee calculations by directly 
+ * querying processed cross-chain transfer data.
+ */
+
 import { Adapter, FetchOptions } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
-import { queryDune } from "../helpers/dune";
+import { queryDuneSql } from "../helpers/dune";
 
 interface IResponse {
   fees: number;
 }
 
 const fetch = async (options: FetchOptions) => {
-  const response: IResponse[] = (await queryDune("4965118", { start: options.startTimestamp, chain: options.chain, end: options.endTimestamp }));
+  const response: IResponse[] = (await queryDuneSql(options, `
+    SELECT
+        SUM(relay_fee_in_usd) as fees
+        , SUM(lp_fee_in_usd) as lp_fees
+    FROM dune.risk_labs.result_across_transfers_foundation
+    WHERE dst_chain = '${options.chain}'
+      AND relay_fee_in_usd is not null
+      AND TIME_RANGE
+   `));
 
   const dailyFees = response.reduce((acc, item) => acc + item.fees, 0)
 
@@ -35,6 +59,30 @@ const adapter: Adapter = {
     [CHAIN.POLYGON]: {
       fetch,
       start: "2023-04-30",
+    },
+    [CHAIN.BASE]: {
+      fetch,
+      start: "2023-08-22",
+    },
+    [CHAIN.ZKSYNC]: {
+      fetch,
+      start: "2023-08-10",
+    },
+    [CHAIN.LINEA]: {
+      fetch,
+      start: "2024-04-20",
+    },
+    [CHAIN.UNICHAIN]: {
+      fetch,
+      start: "2025-02-06",
+    },
+    [CHAIN.BLAST]: {
+      fetch,
+      start: "2024-07-10",
+    },
+    [CHAIN.SCROLL]: {
+      fetch,
+      start: "2024-07-31",
     },
   },
   isExpensiveAdapter: true,


### PR DESCRIPTION
Old Event based method had bugs, and it's not possible to estimate fees with events as not enough data points in events to estimate the fees. simple inputamount-outputamount is wrong, as the token amounts are based on their particular chain decimals. and some cases where different tokens like ETH from arbitrum to USDC in base.