### PR TITLE
CarbonDeFi: Add revenue = fees

### DIFF
--- a/dexs/carbondefi/utils.ts
+++ b/dexs/carbondefi/utils.ts
@@ -89,11 +89,11 @@ export const getDimensionsSum = async (
 
 export const getEmptyData = (options: FetchOptions) => {
   return {
-    dailyVolume: options.createBalances(),
-    dailyFees: options.createBalances(),
-    dailyRevenue: options.createBalances(),
-    totalVolume: options.createBalances(),
-    totalFees: options.createBalances(),
-    totalRevenue: options.createBalances(),
+    dailyVolume: 0,
+    dailyFees: 0,
+    dailyRevenue: 0,
+    totalVolume: 0,
+    totalFees: 0,
+    totalRevenue: 0,
   };
 };

--- a/dexs/carbondefi/utils.ts
+++ b/dexs/carbondefi/utils.ts
@@ -82,6 +82,8 @@ export const getDimensionsSum = async (
     totalVolume,
     dailyFees,
     totalFees,
+    dailyRevenue: dailyFees,
+    totalRevenue: totalFees,
   };
 };
 
@@ -89,7 +91,9 @@ export const getEmptyData = (options: FetchOptions) => {
   return {
     dailyVolume: options.createBalances(),
     dailyFees: options.createBalances(),
+    dailyRevenue: options.createBalances(),
     totalVolume: options.createBalances(),
     totalFees: options.createBalances(),
+    totalRevenue: options.createBalances(),
   };
 };


### PR DESCRIPTION
On Carbon DeFi (https://defillama.com/protocol/carbon-defi), 100% of the fees are used to buy back and burn the native token (BNT). It has been this way since Carbon DeFi was launched (i.e. from day 1).

According to the documentation, this means that fees are the same as revenue: https://docs.llama.fi/list-your-project/other-dashboards/dimensions