### PR TITLE
Fix Jup-Ape change query from allium to dune to fix the solanareceived bug

### DIFF
--- a/fees/jup-ape.ts
+++ b/fees/jup-ape.ts
@@ -1,9 +1,26 @@
 import { FetchOptions, SimpleAdapter } from "../adapters/types";
+// import { queryAllium } from "../helpers/allium";
+import { queryDuneSql } from "../helpers/dune";
 import { CHAIN } from "../helpers/chains";
-import { getSolanaReceived } from "../helpers/token";
+// import { getSolanaReceived } from "../helpers/token";
+
+const JUP_FEE_RECEIVER = '5YET3YapxD6to6rqPqTWB3R9pSbURy6yduuUtoZkzoPX';
 
 const fetchFeesSolana = async (_as:any, _b:any, options: FetchOptions) => {
-  const dailyFees = await getSolanaReceived({ options, target: '5YET3YapxD6to6rqPqTWB3R9pSbURy6yduuUtoZkzoPX' })
+  const query = `
+    SELECT
+      SUM(balance_change/1e9) AS total_fees
+    FROM solana.account_activity
+    WHERE address = '${JUP_FEE_RECEIVER}'
+      AND balance_change > 0
+      AND tx_success = true
+      AND TIME_RANGE
+  `;
+  const res = await queryDuneSql(options, query);
+  const dailyFees = options.createBalances();
+  dailyFees.addCGToken("solana", res[0].total_fees);
+
+  // const dailyFees = await getSolanaReceived({ options, target: '5YET3YapxD6to6rqPqTWB3R9pSbURy6yduuUtoZkzoPX' })
   return { dailyFees, dailyRevenue: dailyFees, }
 }
 


### PR DESCRIPTION
https://docs.allium.so/historical-verticals/token-transfers#id-4.-invisible-sol-transfers

allium getSolanaReceived won't work for jup-ape as in jup-ape scenario all the tx happens inside the jup-ape, so balance change is not reflected in asset transfer, check above link, so it will create invisible transfer, so that will inflate the fees.