### PR TITLE
Add IPLR aggregator volume adapter (Jupiter / Solana)

### DIFF
--- a/aggregators/iplr.js
+++ b/aggregators/iplr.js
@@ -1,0 +1,26 @@
+// File: aggregators/iplr.js
+
+const { fetchURL } = require('../helper/utils')
+
+// Placeholder for Jupiter routed volume
+// To be replaced with real query logic from Jupiter logs or API
+const ROUTED_VOLUME = 8932.12; // Example: $8,932.12 of routed volume for the day
+
+async function fetchVolume(timestamp) {
+  return {
+    dailyVolume: ROUTED_VOLUME.toFixed(2),
+    timestamp
+  }
+}
+
+module.exports = {
+  timetravel: false,
+  adapter: {
+    solana: {
+      fetch: fetchVolume,
+      start: async () => 1713139200, // IPLR's approximate launch timestamp (adjust if needed)
+      runAtCurrTime: true,
+      methodology: `Volume is estimated based on IPLR/SOL routed trades through Jupiter Aggregator on Solana. Placeholder used until real integration is added. All trades are subject to a 10% tax (buy/sell).`
+    }
+  }
+}


### PR DESCRIPTION
This PR adds a placeholder aggregator volume adapter for IPLR routed through Jupiter on Solana.

Volume is simulated for now and will be updated once deeper integration or logging becomes available.

Network: Solana  
DEX: Jupiter  
Tax: 10% on swaps (buy/sell), noted in methodology
