### PR TITLE
Feat: Prefetch Function Support in Adapter

### DIFF
--- a/adapters/types.ts
+++ b/adapters/types.ts
@@ -39,6 +39,7 @@ export type FetchOptions = {
   getStartBlock: () => Promise<number>,
   getEndBlock: () => Promise<number>,
   dateString: string,
+  preFetchedResults?: any,
 }
 
 export type FetchGetLogsOptions = {
@@ -98,6 +99,7 @@ export type AdapterBase = {
   protocolType?: ProtocolType;
   version?: number;
   deadFrom?: string;
+  prefetch?: (timestamp: number, options: FetchOptions) => Promise<any>
 }
 
 export type SimpleAdapter = AdapterBase & {

--- a/cli/testAdapter.ts
+++ b/cli/testAdapter.ts
@@ -83,6 +83,7 @@ const passedFile = path.resolve(process.cwd(), `./${adapterType}/${process.argv[
     // Get adapter
     const volumes = await runAdapter(adapter, endTimestamp, chainBlocks, undefined, undefined, {
       adapterVersion,
+      prefetch: module.prefetch,
     })
     printVolumes(volumes, adapter)
     console.info("\n")
@@ -91,6 +92,7 @@ const passedFile = path.resolve(process.cwd(), `./${adapterType}/${process.argv[
     const allVolumes = await Promise.all(Object.entries(breakdownAdapter).map(([version, adapter]) =>
       runAdapter(adapter, endTimestamp, chainBlocks, undefined, undefined, {
         adapterVersion,
+        prefetch: adapter.prefetch,
         isTest: true,
       }).then(res => ({ version, res }))
     ))

--- a/fees/rainbow-wallet.ts
+++ b/fees/rainbow-wallet.ts
@@ -1,25 +1,72 @@
 import { Adapter, FetchOptions, FetchResultFees } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
+import { queryDuneSql } from "../helpers/dune";
 import { getTokenDiff } from "../helpers/token";
 
 const rainbowRouter = '0x00000000009726632680fb29d3f7a9734e3010e2'
 
+const RainBowRouter = {
+  [CHAIN.ETHEREUM]: rainbowRouter,
+  [CHAIN.OPTIMISM]: rainbowRouter,
+  [CHAIN.BSC]: rainbowRouter,
+  [CHAIN.UNICHAIN]: '0x2a0332E28913A06Fa924d40A3E2160f763010417',
+  [CHAIN.POLYGON]: rainbowRouter,
+  [CHAIN.BASE]: rainbowRouter,
+  [CHAIN.ARBITRUM]: rainbowRouter,
+  [CHAIN.AVAX]: rainbowRouter,
+  [CHAIN.INK]: rainbowRouter,
+  [CHAIN.BERACHAIN]: rainbowRouter,
+  [CHAIN.BLAST]: rainbowRouter,
+  [CHAIN.ZORA]: '0xA61550E9ddD2797E16489db09343162BE98d9483',
+  [CHAIN.APECHAIN]: rainbowRouter,
+  [CHAIN.GRAVITY]: rainbowRouter,
+}
+
+type IRequest = {
+  [key: string]: Promise<any>;
+}
+const requests: IRequest = {}
+
+const CHAIN_MAP = {
+  'bnb': CHAIN.BSC,
+  'avalanche_c': CHAIN.AVAX
+}
+
+// Prefetch function that will run once before any fetch calls
+const prefetch = async (timestamp: number, options: FetchOptions) => {
+  return await queryDuneSql(options, `
+    SELECT 
+        CASE 
+            WHEN blockchain = 'bnb' THEN 'bsc'
+            WHEN blockchain = 'avalanche_c' THEN 'avax'
+            ELSE blockchain
+        END as chain,
+        sum(amount_usd) as volume,
+        sum(amount_usd * 0.0085) as fees
+    FROM dex.trades
+    WHERE (
+        (tx_to = 0x00000000009726632680fb29d3f7a9734e3010e2 AND blockchain NOT IN ('unichain', 'zora'))
+        OR
+        (tx_to = 0x2a0332E28913A06Fa924d40A3E2160f763010417 AND blockchain = 'unichain')
+        OR
+        (tx_to = 0xA61550E9ddD2797E16489db09343162BE98d9483 AND blockchain = 'zora')
+    )
+    AND block_time >= from_unixtime(${options.startTimestamp})
+    AND block_time <= from_unixtime(${options.endTimestamp})
+    GROUP BY 1
+  `);
+};
+
 const fetch: any = async (timestamp: number, _: any, options: FetchOptions) => {
-  const { createBalances, getLogs, } = options
-  const dailyFees = createBalances()
-
-  const ethLogs = await getLogs({ target: rainbowRouter, eventAbi: 'event EthWithdrawn(address indexed target, uint256 amount)' })
-  const tokenLogs = await getLogs({ target: rainbowRouter, eventAbi: 'event TokenWithdrawn(address indexed token, address indexed target, uint256 amount)' })
-  let extraTokens = new Set<string>()
-
-  ethLogs.forEach((log: any) => dailyFees.addGasToken(log.amount))
-  tokenLogs.forEach((log: any) => {
-    extraTokens.add(log.token)
-    dailyFees.add(log.token, log.amount)
-  })
-
-  await getTokenDiff({ options, target: rainbowRouter, balances: dailyFees, extraTokens: [...extraTokens], })
-  dailyFees.removeNegativeBalances()
+  const results = options.preFetchedResults || [];
+  
+  let dailyFees = 0;
+  for (const result of results) {
+    if (result.chain === options.chain) {
+      dailyFees = result.fees;
+      break;
+    }
+  }
 
   return {
     timestamp,
@@ -37,16 +84,10 @@ const methodology = {
 const chainAdapter = { fetch, start: '2023-01-01', meta: { methodology } }
 
 const adapter: Adapter = {
-  adapter: {
-    [CHAIN.ETHEREUM]: chainAdapter,
-    [CHAIN.OPTIMISM]: chainAdapter,
-    [CHAIN.ARBITRUM]: chainAdapter,
-    [CHAIN.POLYGON]: chainAdapter,
-    [CHAIN.BASE]: chainAdapter,
-    [CHAIN.BSC]: chainAdapter,
-    [CHAIN.AVAX]: chainAdapter,
-  },
-
+  adapter: Object.fromEntries(Object.entries(RainBowRouter).map(
+    ([chain, router]) => [chain, chainAdapter]
+  )),
+  prefetch: prefetch,
 }
 
 export default adapter;


### PR DESCRIPTION
The prefetch function solves a key inefficiency in multi-chain DeFi adapters by fetching common data once instead of repeatedly for each chain. In the Rainbow Wallet example, it executes a single Dune SQL query that retrieves fee data for all chains, then stores this in preFetchedResults. Each chain's fetch function accesses this shared data through options.preFetchedResults, eliminating redundant database queries, reducing API load, and improving performance. This approach keeps the codebase cleaner by separating shared data fetching from chain-specific processing while maintaining backward compatibility.
This function would improve performance and use less resource/credits. mostly would be useful in dune/allium query/APIs where we can have multi-chain data in single request. 