### PR TITLE
fix sanctum validator lsts dune query

### DIFF
--- a/fees/sanctum-validator-lsts/index.ts
+++ b/fees/sanctum-validator-lsts/index.ts
@@ -7,6 +7,10 @@ Total revenue is withdrawal fees (0.1%) + epoch fees (variable but no less than 
 Before the fee switch mid-March 2025, Sanctum stake pools were charging 0.1% deposit fees
 See https://x.com/sanctumso/status/1898234985372328274 for more details
 
+Here are the different materialized query you can find in the query below:
+- dune.sanctumso.result_sanctum_validator_stake_accounts (https://dune.com/queries/5061762): list of stake accounts from sanctum stake pools
+- dune.sanctumso.result_sanctum_lsts_manager_fee_accounts (https://dune.com/queries/4787643): list of manager fee accounts that stake pools fees get sent to from stake pools with an ATH stake of more than 1k SOL
+
 */
 
 import { FetchOptions, SimpleAdapter } from "../../adapters/types";
@@ -21,8 +25,8 @@ const fetch: any = async (options: FetchOptions) => {
       SELECT 
           COALESCE(sum(rew.lamports/1e9), 0) as daily_fees
       FROM solana.rewards rew
-      JOIN dune.sanctumso.result_sanctum_stake_pools_validator_stake_accounts vsa
-          ON vsa.stake_account = rew.recipient AND rew.block_date = vsa.epoch_block_date
+      JOIN dune.sanctumso.result_sanctum_validator_stake_accounts vsa
+          ON vsa.stake_account = rew.recipient
       WHERE rew.block_time >= from_unixtime(${options.startTimestamp})
         AND rew.block_time <= from_unixtime(${options.endTimestamp})
         AND rew.reward_type = 'Staking'


### PR DESCRIPTION
the logic used previously doesn't work because the materialized query would update the data to be used for the JOIN (the epoch start block_date) after your script had run
instead i created a new materialized query to be used without disruption
this is why the fee number for April 28th, 2025 (1745787600 ) is missing, i'm not sure if you can fix it

```csv
timestamp,dailyFees
1745787600,3743.5376392859894
```

sorry for flip-flopping but it should be good now, appreciate your patience