### PR TITLE
feat: use standard exports helper function for Punchswap V2

### DIFF
--- a/dexs/kittypunch.ts
+++ b/dexs/kittypunch.ts
@@ -1,34 +1,5 @@
-
-// import request from "graphql-request";
-// import { SimpleAdapter } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
 import { uniV2Exports } from "../helpers/uniswap";
-// import { getUniqStartOfTodayTimestamp } from "../helpers/getUniSubgraphVolume";
-
-// const historical = "https://api.goldsky.com/api/public/project_cm33d1338c1jc010e715n1z6n/subgraphs/punch-swap-core-subgraph-flow-mainnet/2.3.0/gn";
-
-// const fetch: any = async (timestamp: number) => {
-//   const dayTimestamp = getUniqStartOfTodayTimestamp(new Date(timestamp * 1000))
-//   const query = `{
-//   uniswapDayDatas (where: { date: ${dayTimestamp}}){
-//     date
-//     dailyVolumeUSD
-
-//   }
-// }`
-//   const res = await request(historical, query);
-//   return {
-//     dailyVolume: res.uniswapDayDatas[0].dailyVolumeUSD,
-//   }
-// };
-
-// const adapter: SimpleAdapter = {
-//   adapter: {
-//     [CHAIN.FLOW]: {
-//       fetch,
-//     },
-//   },
-// };
 
 export default uniV2Exports({
 	[CHAIN.FLOW]: {

--- a/dexs/kittypunch.ts
+++ b/dexs/kittypunch.ts
@@ -1,34 +1,37 @@
 
-import request from "graphql-request";
-import { SimpleAdapter } from "../adapters/types";
+// import request from "graphql-request";
+// import { SimpleAdapter } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
-import { getUniqStartOfTodayTimestamp } from "../helpers/getUniSubgraphVolume";
+import { uniV2Exports } from "../helpers/uniswap";
+// import { getUniqStartOfTodayTimestamp } from "../helpers/getUniSubgraphVolume";
 
-const historical = "https://api.goldsky.com/api/public/project_cm33d1338c1jc010e715n1z6n/subgraphs/punch-swap-core-subgraph-flow-mainnet/2.3.0/gn";
+// const historical = "https://api.goldsky.com/api/public/project_cm33d1338c1jc010e715n1z6n/subgraphs/punch-swap-core-subgraph-flow-mainnet/2.3.0/gn";
 
+// const fetch: any = async (timestamp: number) => {
+//   const dayTimestamp = getUniqStartOfTodayTimestamp(new Date(timestamp * 1000))
+//   const query = `{
+//   uniswapDayDatas (where: { date: ${dayTimestamp}}){
+//     date
+//     dailyVolumeUSD
 
-const fetch: any = async (timestamp: number) => {
-  const dayTimestamp = getUniqStartOfTodayTimestamp(new Date(timestamp * 1000))
-  const query = `{
-  uniswapDayDatas (where: { date: ${dayTimestamp}}){
-    date
-    dailyVolumeUSD
-    
-  } 
-}`
-  const res = await request(historical, query);
-  return {
-    dailyVolume: res.uniswapDayDatas[0].dailyVolumeUSD,
-  }
-};
+//   }
+// }`
+//   const res = await request(historical, query);
+//   return {
+//     dailyVolume: res.uniswapDayDatas[0].dailyVolumeUSD,
+//   }
+// };
 
+// const adapter: SimpleAdapter = {
+//   adapter: {
+//     [CHAIN.FLOW]: {
+//       fetch,
+//     },
+//   },
+// };
 
-const adapter: SimpleAdapter = {
-  adapter: {
-    [CHAIN.FLOW]: {
-      fetch,
-    },
-  },
-};
-
-export default adapter;
+export default uniV2Exports({
+	[CHAIN.FLOW]: {
+		factory: "0x29372c22459a4e373851798bFd6808e71EA34A71",
+	},
+});

--- a/fees/kittypunch.ts
+++ b/fees/kittypunch.ts
@@ -1,0 +1,2 @@
+import adapter from '../dexs/kittypunch'
+export default adapter


### PR DESCRIPTION
Use standard `uniV2Exports` function to export Punchswap V2's volume and fee instead of customized subgraph