### PR TITLE
Phantom EVM Fees

### DIFF
--- a/fees/phantom.ts
+++ b/fees/phantom.ts
@@ -1,9 +1,9 @@
 import { FetchOptions, SimpleAdapter } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
-import { getSolanaReceived } from "../helpers/token";
+import { getETHReceived, getSolanaReceived } from "../helpers/token";
 
-
-const fee_wallet_addresses = [
+// Solana fee wallet addresses
+const solana_fee_wallet_addresses = [
   '25mYnjJ2MXHZH6NvTTdA63JvjgRVcuiaj6MRiEQNs1Dq',
   '9yj3zvLS3fDMqi1F8zhkaWfq8TZpZWHe6cz1Sgt7djXf',
   '8psNvWTrdNTiVRNzAgsou9kETXNJm2SXZyaKuJraVRtf',
@@ -14,21 +14,46 @@ const fee_wallet_addresses = [
   'D1NJy3Qq3RKBG29EDRj28ozbGwnhmM5yBUp8PonSYUnm',
 ];
 
-const fetch: any = async (options: FetchOptions) => {
-    const dailyFees = await getSolanaReceived({ 
-      options, 
-      targets: fee_wallet_addresses, 
-      blacklist_signers: fee_wallet_addresses 
-    });
-    return { dailyFees, dailyRevenue: dailyFees }
-}
+// ETH fee wallet addresses
+const eth_fee_wallet_addresses = [
+  '0x1bcc58d165e5374d7b492b21c0a572fd61c0c2a0',
+  '0x7afa9d836d2fccf172b66622625e56404e465dbd'
+];
+
+// Solana fetch function
+const fetchSolana = async (options: FetchOptions) => {
+  const dailyFees = await getSolanaReceived({ 
+    options, 
+    targets: solana_fee_wallet_addresses, 
+    blacklist_signers: solana_fee_wallet_addresses 
+  });
+  return { dailyFees, dailyRevenue: dailyFees };
+};
+
+// ETH fetch function for each chain
+const fetchETH = async (options: FetchOptions) => {
+  const dailyFees = await getETHReceived({
+    options,
+    targets: eth_fee_wallet_addresses
+  });
+  return { dailyFees, dailyRevenue: dailyFees };
+};
 
 const adapter: SimpleAdapter = {
   version: 2,
   adapter: {
     [CHAIN.SOLANA]: {
-      fetch: fetch,
+      fetch: fetchSolana,
     },
+    [CHAIN.ETHEREUM]: {
+      fetch: fetchETH,
+    },
+    [CHAIN.BASE]: {
+      fetch: fetchETH,
+    },
+    [CHAIN.POLYGON]: {
+      fetch: fetchETH,
+    }
   },
   isExpensiveAdapter: true
 };


### PR DESCRIPTION
This pull request introduces support for tracking fees on Ethereum, Base, and Polygon chains in addition to Solana. It includes changes to separate fee wallet addresses and fetch functions by chain, enabling multi-chain support. The most important changes are summarized below:

### Multi-Chain Fee Tracking Enhancements:

* **Separation of Fee Wallet Addresses by Chain**: Introduced `solana_fee_wallet_addresses` and `eth_fee_wallet_addresses` to manage fee wallet addresses separately for Solana and Ethereum-based chains. (`fees/phantom.ts`, [[1]](diffhunk://#diff-38fa93735a9d4d56c9738f9ff0fff622b99ad7004f3b369aa41d9a0affad8645L3-R6) [[2]](diffhunk://#diff-38fa93735a9d4d56c9738f9ff0fff622b99ad7004f3b369aa41d9a0affad8645L17-R56)

* **Chain-Specific Fetch Functions**: Added `fetchSolana` and `fetchETH` functions to handle fee tracking for Solana and Ethereum-based chains respectively, ensuring modularity and clarity. (`fees/phantom.ts`, [fees/phantom.tsL17-R56](diffhunk://#diff-38fa93735a9d4d56c9738f9ff0fff622b99ad7004f3b369aa41d9a0affad8645L17-R56))

* **Support for Additional Chains**: Updated the adapter to include Ethereum, Base, and Polygon chains, each using the `fetchETH` function for fee tracking. (`fees/phantom.ts`, [fees/phantom.tsL17-R56](diffhunk://#diff-38fa93735a9d4d56c9738f9ff0fff622b99ad7004f3b369aa41d9a0affad8645L17-R56))