### PR TITLE
Add Vesper and Metronome Synth Fees Adapters

### DIFF
--- a/fees/metronome-synth/index.ts
+++ b/fees/metronome-synth/index.ts
@@ -61,7 +61,8 @@ const fetch = (chain: string) => async (options: FetchOptions) => {
   });
 
   const dailyFees = fees.clone();
-  const dailyRevenue = fees.clone();
+  const dailyRevenue = options.createBalances();
+  dailyRevenue.addBalances(fees);                
   const dailyHoldersRevenue = options.createBalances();
 
   const vaults = VAULTS[chain] ?? [];

--- a/fees/metronome-synth/index.ts
+++ b/fees/metronome-synth/index.ts
@@ -1,0 +1,148 @@
+import { FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import { addTokensReceived } from "../../helpers/token";
+import { getPrices, getTokenPrice } from "../../utils/prices";
+
+const TREASURY = {
+  [CHAIN.ETHEREUM]: "0xd1de3f9cd4ae2f23da941a67ca4c739f8dd9af33",
+  [CHAIN.BASE]:     "0xe01df4ac1e1e57266900e62c37f12c986495a618",
+  [CHAIN.OPTIMISM]: "0xE01Df4ac1E1e57266900E62C37F12C986495A618",
+};
+
+const SYNTHS = {
+  [CHAIN.ETHEREUM]: [
+    "0x8b4F8aD3801B4015Dea6DA1D36f063Cbf4e231c7",
+    "0xab5eB14c09D416F0aC63661E57EDB7AEcDb9BEfA",
+    "0x64351fC9810aDAd17A690E4e1717Df5e7e085160",
+  ],
+  [CHAIN.BASE]: [
+    "0x7Ba6F01772924a82D9626c126347A28299E98c98",
+    "0x526728DBc96689597F85ae4cd716d4f7fCcBAE9d",
+  ],
+  [CHAIN.OPTIMISM]: [
+    "0x1610e3c85dd44Af31eD7f33a63642012Dca0C5A5",
+    "0x9dAbAE7274D28A45F0B65Bf8ED201A5731492ca0",
+    "0x33bCa143d9b41322479E8d26072a00a352404721",
+  ],
+};
+
+const VAULTS = {
+  [CHAIN.ETHEREUM]: [
+    {
+      vault: "0xCa7c607C590ad16007CCBbba9D26f4df656a36C2",
+      holder: "0x82ed3fc9d93112124b04b6c7b35394a5aba8af39",
+      underlying: "ethereum:0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+    },
+    {
+      vault: "0x4C73F025a1947ec770327B9956Fc61f535F72C22",
+      holder: "0x82ed3fc9d93112124b04b6c7b35394a5aba8af39",
+      underlying: "ethereum:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+    },
+  ],
+  [CHAIN.BASE]: [
+    {
+      vault: "0x913Ece180df83A2B81A4976F83cA88543a0C51b8",
+      holder: "0xdb9bd9eb1cdd9ae62a2e9569075a5154296cd632",
+      underlying: "base:0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+    },
+  ],
+};
+
+const MET_TOKEN = "0x2Ebd53d035150f328bd754D6DC66B99B0eDB89aa";
+const DISTRIBUTOR = "0x33f081a0f0240d0ed7e45c36848c01d7ad8038e9";
+const COINGECKO_ID = "metronome";
+const TRANSFER_EVENT = 'event Transfer(address indexed from, address indexed to, uint256 value)';
+
+const fetch = (chain: string) => async (options: FetchOptions) => {
+  const fees = await addTokensReceived({
+    options,
+    tokens: SYNTHS[chain],
+    targets: [TREASURY[chain]],
+  });
+
+  const dailyFees = fees.clone();
+  const dailyRevenue = fees.clone();
+  const dailyHoldersRevenue = options.createBalances();
+
+  const vaults = VAULTS[chain] ?? [];
+  for (const v of vaults) {
+    const [pps0, pps1, sharesRaw] = await Promise.all([
+      options.api.call({ abi: "uint256:pricePerShare", target: v.vault, block: options.startBlock }),
+      options.api.call({ abi: "uint256:pricePerShare", target: v.vault, block: options.endBlock }),
+      options.api.call({ abi: "erc20:balanceOf", target: v.vault, params: [v.holder], block: options.endBlock }),
+    ]);
+
+    const delta = BigInt(pps1.toString()) - BigInt(pps0.toString());
+    if (delta <= 0n) continue;
+
+    const shares = BigInt(sharesRaw.toString());
+    const gainRaw = (delta * shares) / 10n ** 18n;
+    if (gainRaw <= 0n) continue;
+
+    const price = await getTokenPrice(v.underlying, options.endTimestamp);
+    const usd = Number(gainRaw) * price;
+
+    if (usd > 0) dailyRevenue.addCGToken("usd-coin", usd);
+  }
+
+  if (chain === CHAIN.ETHEREUM && options.fromBlock && options.toBlock) {
+    const logs = await options.getLogs({
+      target: MET_TOKEN,
+      eventAbi: TRANSFER_EVENT,
+      fromBlock: options.fromBlock,
+      toBlock: options.toBlock,
+    });
+
+    for (const log of logs) {
+      if (log.to?.toLowerCase() === DISTRIBUTOR.toLowerCase()) {
+        const amount = Number(log.value) / 1e18;
+        dailyHoldersRevenue.addCGToken(COINGECKO_ID, amount);
+      }
+    }
+  }
+
+  return {
+    dailyFees,
+    dailyRevenue,
+    dailyHoldersRevenue,
+  };
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  adapter: {
+    [CHAIN.ETHEREUM]: {
+      fetch: fetch(CHAIN.ETHEREUM),
+      start: 1683840000,
+      meta: {
+        methodology: {
+          Fees: "Tracks synth asset inflows to treasury.",
+          Revenue: "Includes synth inflows and interest (converted to USD).",
+          Holders: "Tracks MET distributed to esMET lockers.",
+        },
+      },
+    },
+    [CHAIN.BASE]: {
+      fetch: fetch(CHAIN.BASE),
+      start: 1683840000,
+      meta: {
+        methodology: {
+          Fees: "Tracks synth asset inflows to treasury.",
+          Revenue: "Includes synth inflows and interest (converted to USD).",
+        },
+      },
+    },
+    [CHAIN.OPTIMISM]: {
+      fetch: fetch(CHAIN.OPTIMISM),
+      start: 1683840000,
+      meta: {
+        methodology: {
+          Fees: "Tracks synth asset inflows to treasury.",
+          Revenue: "Includes synth inflows and interest (converted to USD).",
+        },
+      },
+    },
+  },
+};
+
+export default adapter;

--- a/fees/metronome-synth/index.ts
+++ b/fees/metronome-synth/index.ts
@@ -53,8 +53,6 @@ const DISTRIBUTOR = "0x33f081a0f0240d0ed7e45c36848c01d7ad8038e9";
 const fetch = (chain: string) => async (options: FetchOptions) => {
   const dailyFees = await addTokensReceived({ options, tokens: SYNTHS[chain], targets: [TREASURY[chain]], });
 
-  const dailyRevenue = options.createBalances();
-  dailyRevenue.addBalances(dailyFees);
   const dailyHoldersRevenue = options.createBalances();
 
   const vaults = VAULTS[chain] ?? [];
@@ -72,7 +70,7 @@ const fetch = (chain: string) => async (options: FetchOptions) => {
     const gainRaw = (delta * shares) / 10n ** 18n;
     if (gainRaw <= 0n) continue;
 
-    dailyRevenue.add(v.underlying, gainRaw)
+    dailyFees.add(v.underlying, gainRaw)
   }
 
   if (chain === CHAIN.ETHEREUM) {
@@ -82,7 +80,7 @@ const fetch = (chain: string) => async (options: FetchOptions) => {
 
   return {
     dailyFees,
-    dailyRevenue,
+    dailyRevenue: dailyFees,
     dailyHoldersRevenue,
   };
 };

--- a/fees/vesper/index.ts
+++ b/fees/vesper/index.ts
@@ -1,0 +1,57 @@
+import { FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import { getBlock } from "../../helpers/getBlock";
+
+const VSP_TOKEN = "0x1b40183EFB4Dd766f11bda7a7c3ad8982e998421";
+const DISTRIBUTOR = "0xd31f42cf356e02689d1720b5ffaa6fc7229d255b";
+const COINGECKO_ID = "vesper-finance";
+const TRANSFER_EVENT = 'event Transfer(address indexed from, address indexed to, uint256 value)';
+
+const fetch = async (options: FetchOptions) => {
+  const dailyRevenue = options.createBalances();
+  const dailyFees = options.createBalances();
+  const dailyHoldersRevenue = options.createBalances();
+
+  const logs = await options.getLogs({
+    target: VSP_TOKEN,
+    eventAbi: TRANSFER_EVENT,
+    fromBlock: options.fromBlock,
+    toBlock: options.toBlock,
+  });
+
+  logs.forEach((log: any) => {
+    const to = log.to?.toLowerCase();
+    const amount = Number(log.value) / 1e18;
+
+    if (to === DISTRIBUTOR.toLowerCase()) {
+      dailyRevenue.addCGToken(COINGECKO_ID, amount);
+      dailyFees.addCGToken(COINGECKO_ID, amount);
+      dailyHoldersRevenue.addCGToken(COINGECKO_ID, amount);
+    }
+  });
+
+  return {
+    dailyRevenue,
+    dailyFees,
+    dailyHoldersRevenue,
+  };
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  adapter: {
+    [CHAIN.ETHEREUM]: {
+      fetch,
+      start: 1691558400, // Aug 9, 2023
+      meta: {
+        methodology: {
+          Fees: "Tracks VSP deposited into the distributor contract.",
+          Revenue: "Tracks VSP deposited into the distributor contract for esVSP lockers.",
+          Holders: "Assumes all VSP sent to distributor is for holders.",
+        },
+      },
+    },
+  },
+};
+
+export default adapter;

--- a/fees/vesper/index.ts
+++ b/fees/vesper/index.ts
@@ -1,39 +1,18 @@
 import { FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
-import { getBlock } from "../../helpers/getBlock";
+import { addTokensReceived } from "../../helpers/token";
 
 const VSP_TOKEN = "0x1b40183EFB4Dd766f11bda7a7c3ad8982e998421";
 const DISTRIBUTOR = "0xd31f42cf356e02689d1720b5ffaa6fc7229d255b";
-const COINGECKO_ID = "vesper-finance";
-const TRANSFER_EVENT = 'event Transfer(address indexed from, address indexed to, uint256 value)';
 
 const fetch = async (options: FetchOptions) => {
-  const dailyRevenue = options.createBalances();
-  const dailyFees = options.createBalances();
-  const dailyHoldersRevenue = options.createBalances();
 
-  const logs = await options.getLogs({
-    target: VSP_TOKEN,
-    eventAbi: TRANSFER_EVENT,
-    fromBlock: options.fromBlock,
-    toBlock: options.toBlock,
-  });
-
-  logs.forEach((log: any) => {
-    const to = log.to?.toLowerCase();
-    const amount = Number(log.value) / 1e18;
-
-    if (to === DISTRIBUTOR.toLowerCase()) {
-      dailyRevenue.addCGToken(COINGECKO_ID, amount);
-      dailyFees.addCGToken(COINGECKO_ID, amount);
-      dailyHoldersRevenue.addCGToken(COINGECKO_ID, amount);
-    }
-  });
+    const dailyFees = await addTokensReceived({ options, tokens: [VSP_TOKEN], targets: [DISTRIBUTOR], });
 
   return {
-    dailyRevenue,
+    dailyRevenue: dailyFees,
     dailyFees,
-    dailyHoldersRevenue,
+    dailyHoldersRevenue: dailyFees,
   };
 };
 


### PR DESCRIPTION
Adds fee adapters for:
- Vesper (tracks VSP transfers to distributor contract)
- Metronome Synth (tracks synth inflows to treasury, vault interest, and MET transfers to distributor contract)