### PR TITLE
update zkswap-v3 and zkswap-stable endpoint to new version

### DIFF
--- a/dexs/zkswap-stable/index.ts
+++ b/dexs/zkswap-stable/index.ts
@@ -3,7 +3,7 @@ import { CHAIN } from "../../helpers/chains";
 import { getGraphDimensions2 } from "../../helpers/getUniSubgraph";
 
 const endpoints = {
-  [CHAIN.ERA]: "https://api.studio.thegraph.com/query/49271/zf-exchange-stableswap-3/version/latest"
+  [CHAIN.ERA]: "https://api.studio.thegraph.com/query/49271/zf-exchange-stableswap-3/v0.1.1"
 }
 
 const graph = getGraphDimensions2({
@@ -13,8 +13,8 @@ const graph = getGraphDimensions2({
   },
   feesPercent: {
     type: "volume",
-    Fees: 0.0005,
-    Revenue: 0.0001667
+    Fees: 0.01,
+    Revenue: 0.0033
   }
 });
 
@@ -26,7 +26,7 @@ const adapters: SimpleAdapter = {
       start: '2024-11-06',
       meta: {
         methodology: {
-          UserFees: "User pays 0.0005% fees on each swap.",
+          UserFees: "User pays 0.01% fees on each swap.",
           ProtocolRevenue: "Approximately 33% of the fees go to the protocol.",
           SupplySideRevenue: "Approximately 67% of the fees are distributed to liquidity providers (ZFLP token holders)",
           Revenue: "Approximately 33% of the fees go to the protocol.",

--- a/dexs/zkswap-v3/index.ts
+++ b/dexs/zkswap-v3/index.ts
@@ -3,7 +3,8 @@ import { CHAIN } from "../../helpers/chains";
 import { getGraphDimensions2 } from "../../helpers/getUniSubgraph";
 
 const endpoints = {
-  [CHAIN.ERA]: "https://api.studio.thegraph.com/query/49271/zf-exchange-v3-version-2/version/latest"
+  // [CHAIN.ERA]: "https://gateway.thegraph.com/api/88ec88f205b57dce13befebc60ef5e0c/subgraphs/id/BeYacqRmNFgoNgPwqmD9CNzcH3Hqqy5WeQHhi3khQHPu"
+  [CHAIN.ERA]: "https://api.studio.thegraph.com/query/49271/zf-exchange-v3-version-2/v0.1.8"
 }
 
 const graph = getGraphDimensions2({


### PR DESCRIPTION
The previous endpoint had an issue, so we've updated to a new endpoint that accurately displays our V3 and Stableswap DEX’s volume.