### PR TITLE
Add Uniswap tracking for Lens chain

### DIFF
--- a/helpers/chains.ts
+++ b/helpers/chains.ts
@@ -238,6 +238,7 @@ export enum CHAIN {
   BITKUB = "bitkub",
   INITIA = "initia",
   COTI = "coti",
+  LENS = "lens",
 }
 
 // Don´t use

--- a/protocols/uniswap/index.ts
+++ b/protocols/uniswap/index.ts
@@ -331,6 +331,7 @@ const okuChains = [
   CHAIN.XDC,
   CHAIN.LIGHTLINK_PHOENIX,
   CHAIN.ARBITRUM,
+  CHAIN.LENS,
 ]
 
 


### PR DESCRIPTION
Note: I'm not quite sure that I properly handled everything needed to add Uniswap for Lens chain. I was getting this error when attempting to test it: `Error: Breakdown adapters are deprecated, migrate it to use simple adapter`.

In case helpful, this is the Uniswap contract deployed on Lens: `0xAA904d497e42608C014BE83a026E984aFc16129b`