### PR TITLE
Fix too many requests error on thorchain adapter

### DIFF
--- a/fees/thorswap/index.ts
+++ b/fees/thorswap/index.ts
@@ -13,6 +13,8 @@ const chainMapping = {
   BCH: CHAIN.BITCOIN_CASH,
   DOGE: CHAIN.DOGECHAIN,
   GAIA: CHAIN.COSMOS,
+  BASE: CHAIN.BASE,
+  THOR: CHAIN.THORCHAIN
 }
 
 interface Pool {
@@ -68,9 +70,11 @@ export async function fetchCacheURL(url: string) {
   return requests[key]
 }
 
+const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms))
+
 const fetchFeesByChain = () => {
   const adapter = {}
-  const chains = ['BTC', 'ETH', 'LTC', 'DOGE', 'GAIA', 'AVAX', 'BSC', 'BCH']
+  const chains = ['BTC', 'ETH', 'LTC', 'DOGE', 'GAIA', 'AVAX', 'BSC', 'BCH', 'BASE', 'THOR']
   chains.forEach((chain: string) => {
     adapter[chainMapping[chain]] = {
       runAtCurrTime: true,
@@ -80,8 +84,11 @@ const fetchFeesByChain = () => {
         const reserveUrl = `https://midgard.ninerealms.com/v2/history/reserve?interval=day&from=${options.startTimestamp}&to=${options.endTimestamp}`
         const poolsUrl = `https://midgard.ninerealms.com/v2/pools?period=24h`
         const earnings = await fetchCacheURL(earningsUrl);
+        await sleep(3000)
         const revenue = await fetchCacheURL(reserveUrl);
+        await sleep(2000)
         const pools = await fetchCacheURL(poolsUrl);
+        await sleep(2000)
         const selectedEarningInterval = findInterval(startOfDay, earnings.intervals);
         const selectedRevenueInterval = findInterval(startOfDay, revenue.intervals);
 


### PR DESCRIPTION
The API used to retrieve the revenue generated by the THORChain protocol is returning 429 errors (too many requests), which prevents fees from being collected properly. As a result, THORChain appears at the bottom of the protocol revenue rankings.

To address this, a delay has been added between API calls, taking into account that the /history endpoint has a higher rate limit.

Currently, the adapter takes over a minute to run completely, as the number of supported chains has also increased with the protocol’s latest integrations.