### PR TITLE
[0x] Add missing chains: Berachain, Ink, Unichain

### DIFF
--- a/aggregators/zrx/index.ts
+++ b/aggregators/zrx/index.ts
@@ -22,6 +22,7 @@ const CHAINS: TChain = {
   [CHAIN.BERACHAIN]: 80094,
   [CHAIN.INK]: 57073,
   [CHAIN.UNICHAIN]: 130,
+  [CHAIN.WC]: 480,
 };
 
 const fetch = async (_a, _b, options: FetchOptions) => {

--- a/aggregators/zrx/index.ts
+++ b/aggregators/zrx/index.ts
@@ -19,6 +19,9 @@ const CHAINS: TChain = {
   [CHAIN.SCROLL]: 534352,
   [CHAIN.MANTLE]: 5000,
   [CHAIN.MODE]: 34443,
+  [CHAIN.BERACHAIN]: 80094,
+  [CHAIN.INK]: 57073,
+  [CHAIN.UNICHAIN]: 130,
 };
 
 const fetch = async (_a, _b, options: FetchOptions) => {


### PR DESCRIPTION
Hey there, there are a few chains missing that 0x supports, this PR addresses that. 

Sidenote: I don't see Worldchain being recognized at all, do you plan to add support for it too? We have it supported on 0x side, but since World doesn't seem to be recognized at all by DefiLllama (I didn't find it in `CHAINS`), I left it out for this PR. 

