### PR TITLE
chore: request historical resync for Astros aggregator

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,4 @@
 Find the instructions to list, write, test and submit an adapter [here](https://docs.llama.fi/list-your-project/other-dashboards)
 
 Example: `yarn test fees bitcoin`
+ # 或者做任何最小修改，比如加个注释行

--- a/aggregators/navi/index.ts
+++ b/aggregators/navi/index.ts
@@ -4,6 +4,7 @@ import axios from "axios";
 
 const sentioApiKey = "s0T3OflD18sDuN6DeSy7XyVsPqHQTbD4z"; //Read Only
 
+// we need to resync the history data of this aggregator
 const fetchDailyVolume = async ({
   fromTimestamp,
   toTimestamp,
@@ -22,7 +23,7 @@ const fetchDailyVolume = async ({
         sql: `SELECT SUM(GREATEST(amount_in_usd, amount_out_usd)) AS usdValue
               FROM 'swapEvent'
               WHERE timestamp >= ${fromTimestamp} AND timestamp <= ${toTimestamp};`,
-      }
+      },
     }),
   }).then((response) => response.data);
 


### PR DESCRIPTION
We have fixed the issue in our Sentio pipeline for the Astros DEX aggregator. This PR is just to request a historical volume resync for completeness.

Endpoint remains the same:  
https://app.sentio.xyz/api/v1/analytics/navi/dex-aggregator/sql/execute
