### PR TITLE
Add Bodega Market dailyHoldersRevenue

### DIFF
--- a/fees/bodega-market/index.ts
+++ b/fees/bodega-market/index.ts
@@ -4,18 +4,21 @@ import { CHAIN } from "../../helpers/chains";
 
 const fetch = async (options: FetchOptions): Promise<FetchResult> => {
   const {
-    data: { dailyFees, dailyRevenue },
+    data: { dailyFees, dailyRevenue, dailyHoldersRevenue },
   } = await axios.get(
     `https://tidelabs.io:2121/defillama/bodega-market/fees?from=${options.startTimestamp}&to=${options.endTimestamp}`
   );
   const dailyFeesUSD = options.createBalances();
   const dailyRevenueUSD = options.createBalances();
+  const dailyHoldersRevenueUSD = options.createBalances();
   dailyFeesUSD.addCGToken("cardano", Number(dailyFees));
   dailyRevenueUSD.addCGToken("cardano", Number(dailyRevenue));
+  dailyHoldersRevenueUSD.addCGToken("cardano", Number(dailyHoldersRevenue));
   return {
     timestamp: options.startOfDay,
     dailyFees: dailyFeesUSD,
     dailyRevenue: dailyRevenueUSD,
+    dailyHoldersRevenue: dailyHoldersRevenueUSD,
   };
 };
 
@@ -27,8 +30,8 @@ const adapter: Adapter = {
       start: "2024-06-4",
       meta: {
         methodology: {
-          Fees: "All betting fees collected, which are distributed to market creators and staking users.",
-          Revenue: "All betting fees distributed specifically to staking users.",
+          Fees: "All betting fees (4% of total protocol volume) go to Bodega token stakers.",
+          Revenue: "All fees are distributed to staking users.",
         },
       },
     },

--- a/fees/bodega-market/index.ts
+++ b/fees/bodega-market/index.ts
@@ -19,6 +19,9 @@ const fetch = async (options: FetchOptions): Promise<FetchResult> => {
     dailyFees: dailyFeesUSD,
     dailyRevenue: dailyRevenueUSD,
     dailyHoldersRevenue: dailyHoldersRevenueUSD,
+
+    // no protocol revenue
+    dailyProtocolRevenue: 0,
   };
 };
 
@@ -30,8 +33,10 @@ const adapter: Adapter = {
       start: "2024-06-4",
       meta: {
         methodology: {
-          Fees: "All betting fees (4% of total protocol volume) go to Bodega token stakers.",
-          Revenue: "All fees are distributed to staking users.",
+          Fees: "All betting fees (4% of total protocol volume) paid by users.",
+          Revenue: "All betting fees (4% of total protocol volume) paid by users.",
+          HoldersRevenue: "All revenue distributed to BODEGA holders.",
+          ProtocolRevenue: "No revenue for Bodega protocol.",
         },
       },
     },


### PR DESCRIPTION
This PR adds dailyHoldersRevenue for Bodega Market. Here is a X announcement so that you can verify 100% of fees go to token holders. https://x.com/BodegaCardano/status/1933108655903367626