### PR TITLE
Add Bluefin7K Aggregator dimesion-adaptor and deprecate 7K Aggregator

### DIFF
--- a/aggregators/7k-aggregator/index.ts
+++ b/aggregators/7k-aggregator/index.ts
@@ -1,19 +1,13 @@
-import fetchURL from '../../utils/fetchURL';
 import { FetchV2, SimpleAdapter } from '../../adapters/types';
 import { CHAIN } from '../../helpers/chains';
 
-// Bluefin7K Aggregator temporary use 7k.ag API to get volume data
-const URL = 'https://statistic.7k.ag';
-
-const fetch: FetchV2 = async ({ fromTimestamp, toTimestamp }) => {
-	const dailyVolume = await fetchURL(
-		`${URL}/volume-with-ts?from_timestamp=${fromTimestamp}&to_timestamp=${toTimestamp}`,
-	);
-	return { dailyVolume };
+const fetch: FetchV2 = async ({ }) => {
+	return { dailyVolume: 0 };
 };
 
 const adapter: SimpleAdapter = {
 	version: 2,
+	deadFrom: '2024-06-03',
 	adapter: {
 		[CHAIN.SUI]: {
 			fetch,

--- a/aggregators/bluefin7k-aggregator/index.ts
+++ b/aggregators/bluefin7k-aggregator/index.ts
@@ -1,0 +1,25 @@
+import fetchURL from '../../utils/fetchURL';
+import { FetchV2, SimpleAdapter } from '../../adapters/types';
+import { CHAIN } from '../../helpers/chains';
+
+// Bluefin7K Aggregator temporary use 7k.ag API to get volume data
+const URL = 'https://statistic.7k.ag';
+
+const fetch: FetchV2 = async ({ fromTimestamp, toTimestamp }) => {
+	const dailyVolume = await fetchURL(
+		`${URL}/volume-with-ts?from_timestamp=${fromTimestamp}&to_timestamp=${toTimestamp}`,
+	);
+	return { dailyVolume };
+};
+
+const adapter: SimpleAdapter = {
+	version: 2,
+	adapter: {
+		[CHAIN.SUI]: {
+			fetch,
+			start: '2025-06-03',
+		},
+	},
+};
+
+export default adapter;


### PR DESCRIPTION
# PR Description
7K Aggregator has partnered with Bluefin to launch a new aggregator: Bluefin7K Aggregator.

## Related Links:

Previous PR: https://github.com/DefiLlama/dimension-adapters/pull/3410

Commit reference: https://github.com/DefiLlama/defillama-server/commit/1f8c10a0984616eb55ae4884141da03542395295

Announcement: https://x.com/bluefinapp/status/1929596937181032908

# Background
Previously, the original 7K Aggregator was rebranded on DefiLlama to Bluefin7K. However, the 7K team has decided to:
- Preserve the historical volume data of the original 7K Aggregator, and
- Launch Bluefin7K Aggregator as a new, independent aggregator with its own history starting from the official launch date.

# Changes in This PR
1. Adds a new Bluefin7K Aggregator as an independent entry.
2. Updates the existing 7K Aggregator to stop recording further volume data.

The `start` for 7K Aggregator is explicitly set to 2025-06-03 to avoid history entries showing volume = 0, ensuring data consistency.