### PR TITLE
flashtrade: update revenue and fees adpater for fee distribution

### DIFF
--- a/fees/flashtrade.ts
+++ b/fees/flashtrade.ts
@@ -3,9 +3,10 @@ import { CHAIN } from "../helpers/chains";
 import fetchURL from "../utils/fetchURL";
 
 interface Pool {
-    pool: string;
-    accured: string;
-    paid: string;
+    poolName: string;
+    date: string;
+    totalRevenue: string;
+    totalProtocolFee: string;
 }
 
 const methodology = {
@@ -13,24 +14,24 @@ const methodology = {
     ProtocolReveneue: '30% of all the fees accrued excluding Community pool.'
 }
 
-const urlDailyStats = "https://api.prod.flash.trade/market-stat/revenue-24hr";
+const urlDailyStats = "https://api.prod.flash.trade/protocol-fees/daily";
 
 const calculateProtocolRevenue = (stats: Pool[]) => {
     return stats
-        .filter(item => item.pool !== "Community.1")
-        .reduce((sum, item) => sum + 0.3 * parseFloat(item.accured), 0);
+        .filter(item => item.poolName !== "Community.1")
+        .reduce((sum, item) => sum + 0.3 * parseFloat(item.totalProtocolFee), 0);
 }
 
 const fetchFlashStats = async (_: number): Promise<FetchResultFees> => {
     const dailyStatsResponse = await fetchURL(urlDailyStats);
     const dailyStats: Pool[] = dailyStatsResponse;
-    const dailyAccrued = dailyStats.reduce((sum, item) => sum + parseFloat(item.accured), 0);
+    const dailyAccrued = (dailyStats.reduce((sum, item) => sum + parseFloat(item.totalProtocolFee), 0));
     const dailyProtocolRevenue = calculateProtocolRevenue(dailyStats);
 
     return {
-        dailyFees: dailyAccrued.toString(),
-        dailyRevenue: dailyProtocolRevenue.toString(),
-        dailyProtocolRevenue: dailyProtocolRevenue.toString(),
+        dailyFees: (dailyAccrued * 10**-6).toString(),
+        dailyRevenue: (dailyProtocolRevenue * 10**-6).toString(),
+        dailyProtocolRevenue: (dailyProtocolRevenue * 10**-6).toString(),
     };
 };
 


### PR DESCRIPTION
Flash Trade has introduced 50% revenue share for token stakes, leading to changes in calculations of revenue and protocol fees. This updated uses our latest API to calculate protocol fees and revenue adjusted for revenue share mechanism.