### PR TITLE
Renzo protocol: Add daily revenue to fee adapter

### DIFF
--- a/fees/renzo/index.ts
+++ b/fees/renzo/index.ts
@@ -71,7 +71,7 @@ const adapter: SimpleAdapter = {
       fetch,
       meta: {
         methodology: {
-          Fees: "Fees collected from staking, restaking, vaults, and instant withdrawals",
+          Fees: "Fees collected from staking, restaking, vaults, and instant withdrawals.",
           Revenue: "Combined fees & earnings from staking, restaking, vaults, instant withdrawals, and Lido distributions."
         },
       },

--- a/fees/renzo/index.ts
+++ b/fees/renzo/index.ts
@@ -2,24 +2,32 @@ import { CHAIN } from "../../helpers/chains";
 import { FetchOptions, SimpleAdapter } from "../../adapters/types";
 import {
   getETHFeesWei,
+  getETHEarningsWei,
   getERC20FeesData,
+  getERC20EarningsData
 } from "./common";
 
 const fetch = async (_a: any, _b: any, options: FetchOptions) => {
   const { createBalances, startTimestamp, endTimestamp } = options;
 
-  const dailyFees = createBalances();
-
+  // Query data
   const ethFees = await getETHFeesWei(startTimestamp, endTimestamp);
-  
   const erc20Fees = await getERC20FeesData(startTimestamp, endTimestamp);
+  const ethEarnings = await getETHEarningsWei(startTimestamp, endTimestamp);
+  const erc20Earnings = await getERC20EarningsData(startTimestamp, endTimestamp);
 
+  // Init empty balances for fees & earnings
+  const dailyFees = createBalances();
+  const dailyEarnings = createBalances();
+
+  // Add ETH fees
   dailyFees.addGasToken(ethFees.stakingConsensusFeesWei);
   dailyFees.addGasToken(ethFees.stakingExecutionFeesWei);
   dailyFees.addGasToken(ethFees.rewardsDepositedFeesWei);
   dailyFees.addGasToken(ethFees.rewardsForwardedFeesWei);
   dailyFees.addGasToken(ethFees.instantWithdrawalFeesWei);
-  
+
+  // Add ERC20 fees
   for (const [tokenId, tokenFees] of erc20Fees.instantWithdrawalERC20Fees) {
     dailyFees.add(tokenId, tokenFees);
   }
@@ -30,10 +38,29 @@ const fetch = async (_a: any, _b: any, options: FetchOptions) => {
     dailyFees.add(tokenId, tokenFees);
   }
 
+  // Add ETH earnings
+  dailyEarnings.addGasToken(ethEarnings.stakingConsensusEarningsWei);
+  dailyEarnings.addGasToken(ethEarnings.stakingExecutionEarningsWei);
+  dailyEarnings.addGasToken(ethEarnings.rewardsDepositedEarningsWei);
+  dailyEarnings.addGasToken(ethEarnings.rewardsForwardedEarningsWei);
+  dailyEarnings.addGasToken(ethEarnings.lidoDistributionEarningsWei);
+
+  // Add ERC20 earnings
+  for (const [tokenId, tokenEarnings] of erc20Earnings.vaultDepositedERC20Earnings) {
+    dailyEarnings.add(tokenId, tokenEarnings);
+  }
+  for (const [tokenId, tokenEarnings] of erc20Earnings.vaultForwardedERC20Earnings) {
+    dailyEarnings.add(tokenId, tokenEarnings);
+  }
+
+  // Calculate revenue balances by combining fees & earnings
+  const dailyRevenue = createBalances();
+  dailyRevenue.addBalances(dailyFees.getBalances());
+  dailyRevenue.addBalances(dailyEarnings.getBalances());
+
   return {
     dailyFees,
-    dailyRevenue: dailyFees,
-    dailyProtocolRevenue: dailyFees
+    dailyRevenue
   };
 }
 
@@ -44,11 +71,11 @@ const adapter: SimpleAdapter = {
       fetch,
       meta: {
         methodology: {
-          Fees: "Fees collected from staking earnings, auto-forwarded restaking earnings, reward auction sales, instant withdrawals, and vault rewards",
-          Revenue: "Fees collected from staking earnings, auto-forwarded restaking earnings, reward auction sales, instant withdrawals, and vault rewards"
+          Fees: "Fees collected from staking, restaking, vaults, and instant withdrawals",
+          Revenue: "Combined fees & earnings from staking, restaking, vaults, instant withdrawals, and Lido distributions."
         },
       },
-      start: '2024-12-13' // December 13th, 2024
+      start: '2024-09-04' // September 4th, 2024 -- M4 EigenPod Upgrade
     }
   }
 }


### PR DESCRIPTION
Calculates Renzo protocol's daily revenue and includes it in the fee adapter.

Revenue is the calculated as the combined fees & earnings from staking, restaking, vaults, instant withdrawals, and Lido distributions.