### PR TITLE
correctly calculate steamm pool fees

### DIFF
--- a/fees/steamm/index.ts
+++ b/fees/steamm/index.ts
@@ -36,7 +36,7 @@ async function fetchPoolsStats(dayTimestamp: number): Promise<Array<PoolInfo>> {
     );
     const dailyFees = historicalItems.reduce(
       (accumulator: number, currentValue: any) =>
-        accumulator + currentValue.usdValue,
+        accumulator + new Number(currentValue.usdValue).valueOf(),
       0
     );
     poolInfos.push({

--- a/fees/steamm/index.ts
+++ b/fees/steamm/index.ts
@@ -25,14 +25,15 @@ async function fetchPoolsStats(dayTimestamp: number): Promise<Array<PoolInfo>> {
   const poolConfigs = await fetchURL(suilendPoolsURL())
   for (const poolConfig of poolConfigs) {
     const historicalItems = await fetchURL(suilendPoolHistoricalURL(poolConfig.pool.id, dayTimestamp, dayTimestamp + 24 * 60 * 60))
-    const dayItem = historicalItems.find(item => Number(item.start) === dayTimestamp)
-    if (dayItem) {
-      poolInfos.push({
-        id: poolConfig.pool.id,
-        feesUsdValue: Number(dayItem.usdValue),
-        protocolFeeRate: Number(poolConfig.pool.protocolFees.config.feeNumerator) / Number(poolConfig.pool.protocolFees.config.feeDenominator)
-      })
-    }
+    const dailyFees = historicalItems.reduce(
+      (accumulator: number, currentValue: any) => accumulator + currentValue.usdValue,
+      0,
+    );
+    poolInfos.push({
+      id: poolConfig.pool.id,
+      feesUsdValue: Number(dailyFees),
+      protocolFeeRate: Number(poolConfig.pool.protocolFees.config.feeNumerator) / Number(poolConfig.pool.protocolFees.config.feeDenominator)
+    });
   }
 
   return poolInfos;

--- a/fees/steamm/index.ts
+++ b/fees/steamm/index.ts
@@ -1,38 +1,50 @@
-import {
-  Adapter,
-  FetchOptions,
-} from "../../adapters/types";
+import { Adapter, FetchOptions } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 import fetchURL from "../../utils/fetchURL";
 
 const methodology = {
-  Fees: 'Total fees paid from swaps',
-  ProtocolReveneue: 'The portion of the total fees going to the STEAMM treasury'
-}
+  Fees: "Total fees paid from swaps",
+  ProtocolReveneue:
+    "The portion of the total fees going to the STEAMM treasury",
+};
 
-const suilendPoolsURL = () => `https://api.suilend.fi/steamm/pools/all`
-const suilendPoolHistoricalURL = (poolId: string, fromTimestamp: number, toTimestamp: number) => `https://api.suilend.fi/steamm/historical/fees?startTimestampS=${fromTimestamp}&endTimestampS=${toTimestamp}&intervalS=21600&poolId=${poolId}`
+const suilendPoolsURL = () => `https://api.suilend.fi/steamm/pools/all`;
+const suilendPoolHistoricalURL = (
+  poolId: string,
+  fromTimestamp: number,
+  toTimestamp: number
+) =>
+  `https://api.suilend.fi/steamm/historical/fees?startTimestampS=${fromTimestamp}&endTimestampS=${toTimestamp}&intervalS=21600&poolId=${poolId}`;
 
-interface PoolInfo {  
+interface PoolInfo {
   id: string;
   feesUsdValue: number;
   protocolFeeRate: number;
 }
 
 async function fetchPoolsStats(dayTimestamp: number): Promise<Array<PoolInfo>> {
-  const poolInfos: Array<PoolInfo> = []
+  const poolInfos: Array<PoolInfo> = [];
 
-  const poolConfigs = await fetchURL(suilendPoolsURL())
+  const poolConfigs = await fetchURL(suilendPoolsURL());
   for (const poolConfig of poolConfigs) {
-    const historicalItems = await fetchURL(suilendPoolHistoricalURL(poolConfig.pool.id, dayTimestamp, dayTimestamp + 24 * 60 * 60))
+    const historicalItems = await fetchURL(
+      suilendPoolHistoricalURL(
+        poolConfig.pool.id,
+        dayTimestamp,
+        dayTimestamp + 24 * 60 * 60
+      )
+    );
     const dailyFees = historicalItems.reduce(
-      (accumulator: number, currentValue: any) => accumulator + currentValue.usdValue,
-      0,
+      (accumulator: number, currentValue: any) =>
+        accumulator + currentValue.usdValue,
+      0
     );
     poolInfos.push({
       id: poolConfig.pool.id,
       feesUsdValue: Number(dailyFees),
-      protocolFeeRate: Number(poolConfig.pool.protocolFees.config.feeNumerator) / Number(poolConfig.pool.protocolFees.config.feeDenominator)
+      protocolFeeRate:
+        Number(poolConfig.pool.protocolFees.config.feeNumerator) /
+        Number(poolConfig.pool.protocolFees.config.feeDenominator),
     });
   }
 
@@ -40,13 +52,13 @@ async function fetchPoolsStats(dayTimestamp: number): Promise<Array<PoolInfo>> {
 }
 
 const fetchSteammStats = async ({ fromTimestamp }: FetchOptions) => {
-  const pools = await fetchPoolsStats(fromTimestamp)
+  const pools = await fetchPoolsStats(fromTimestamp);
 
-  let dailyFees = 0
-  let dailyProtocolRevenue = 0
+  let dailyFees = 0;
+  let dailyProtocolRevenue = 0;
   for (const pool of pools) {
-    dailyFees += pool.feesUsdValue
-    dailyProtocolRevenue += pool.feesUsdValue * pool.protocolFeeRate
+    dailyFees += pool.feesUsdValue;
+    dailyProtocolRevenue += pool.feesUsdValue * pool.protocolFeeRate;
   }
 
   return {
@@ -63,7 +75,7 @@ const adapter: Adapter = {
   adapter: {
     [CHAIN.SUI]: {
       fetch: fetchSteammStats,
-      start: '2025-02-16',
+      start: "2025-02-16",
       meta: {
         methodology,
       },


### PR DESCRIPTION
https://api.suilend.fi/steamm/historical/fees is meant to return a list of datapoints for the STEAMM frontend to use in a graph. The sum of all datapoints returned by this endpoint would produce the total amount of fees for that day.