### PR TITLE
Add Prophet.fun

### DIFF
--- a/dexs/prophet-fun/index.ts
+++ b/dexs/prophet-fun/index.ts
@@ -1,13 +1,11 @@
 
 import fetchURL from "../../utils/fetchURL"
-import { type SimpleAdapter } from "../../adapters/types";
+import { FetchOptions, type SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 
-const URL = "https://backend.prophet.fun/business-metrics/daily-volume"
-
-
-const fetch = async (timestamp: any) => {
-  const data = await fetchURL(URL + "?timestamp=" + timestamp.startOfDay);
+const fetch = async (_a: any, _b: any, options: FetchOptions) => {
+  const URL = "https://backend.prophet.fun/business-metrics/daily-volume"
+  const data = await fetchURL(URL + "?timestamp=" + options.startOfDay);
 
   return {
     dailyVolume: data.dailyVolume,
@@ -15,15 +13,10 @@ const fetch = async (timestamp: any) => {
 };
 
 const adapter: SimpleAdapter = {
-  version: 2,
-  methodology: 'Volume of all trades that go through the protocol',
-  adapter: {
-    [CHAIN.SOLANA]: {
-      fetch,
-      start: '2025-07-24'
-    },
-  }
+  version: 1,
+  chains: [CHAIN.SOLANA],
+  fetch,
+  start: '2025-07-24',
 };
 
 export default adapter;
-

--- a/dexs/prophet-fun/index.ts
+++ b/dexs/prophet-fun/index.ts
@@ -1,0 +1,29 @@
+
+import fetchURL from "../../utils/fetchURL"
+import { type SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+
+const URL = "https://backend.prophet.fun/business-metrics/daily-volume"
+
+
+const fetch = async (timestamp: any) => {
+  const data = await fetchURL(URL + "?timestamp=" + timestamp.startOfDay);
+
+  return {
+    dailyVolume: data.dailyVolume,
+  };
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  methodology: 'Volume of all trades that go through the protocol',
+  adapter: {
+    [CHAIN.SOLANA]: {
+      fetch,
+      start: '2025-07-24'
+    },
+  }
+};
+
+export default adapter;
+


### PR DESCRIPTION
Hey guys!

Name: Prophet.fun
Twitter: https://x.com/Prophet_fun
Website: https://prophet.fun/
Chain: Solana
Description: Prophet.fun is a fast, on-chain prediction platform built on Solana. Bet on crypto price swings, whale wallet moves, narrative shifts on Crypto Twitter, and degen roulette-style markets.
Category: DEX
<img width="400" height="400" alt="prophet-fun" src="https://github.com/user-attachments/assets/d75fd915-6819-404c-bab0-abb0f01a4ca4" />

Related to https://github.com/DefiLlama/DefiLlama-Adapters/pull/15679