### PR TITLE
Update convex.ts

### DIFF
--- a/fees/convex.ts
+++ b/fees/convex.ts
@@ -25,7 +25,7 @@ const abi = {
 const methodology = {
     UserFees: "No user fees",
     Fees: "Includes all treasury revenue, all revenue to CVX lockers and stakers and all revenue to liquid derivatives (cvxCRV, cvxFXS)",
-    HoldersRevenue: "All revenue going to CVX lockers and stakers, including bribes",
+    HoldersRevenue: "All revenue going to CVX lockers and stakers",
     Revenue: "Sum of protocol revenue and holders' revenue",
     ProtocolRevenue: "Share of revenue going to Convex treasury (includes caller incentives on Frax pools, POL yield and Votemarket bribes)",
     SupplySideRevenue: "All CRV, CVX and FXS rewards redistributed to liquidity providers staking on Convex.",


### PR DESCRIPTION
The description for "HoldersRevenue" was previously:

> All revenue going to CVX lockers and stakers, including bribes

This is what is displayed on the DefiLlama UI at https://defillama.com/holders-revenue

However it is misleading since by default, the UI does not include bribes (it needs to be toggled). 

I have therefore removed the mention of bribes from the description.

Or would it be possible to add a message informing users that they can toggle bribes? Something like "To include bribes, toggle the option in the top right dropdown"? The toggle is hard to find