### PR TITLE
Add Odos V3 Frontend Fee

### DIFF
--- a/aggregators/odos/index.ts
+++ b/aggregators/odos/index.ts
@@ -32,26 +32,6 @@ const ODOS_V2_ROUTERS: TPool = {
   [CHAIN.UNICHAIN]: ['0x6409722F3a1C4486A3b1FE566cBDd5e9D946A1f3'],
 }
 
-function addReferralFees(entry: any) {
-  const isReferral = Number(entry.referralCode) == 1 && entry.referralFeeRecipient == ODOS_ROUTER_V3
-
-  if (entry.outputToken) {
-    // single-output case
-    const amount = Number(entry.amountOut)
-    const fee = isReferral ? Number(entry.referralFee) * amount / 1e18 : 0
-    dailyFees.add(entry.outputToken, fee)
-  }
-
-  if (entry.tokensOut && entry.amountsOut) {
-    // multi-output case
-    entry.tokensOut.forEach((token: string, idx: number) => {
-      const amount = Number(entry.amountsOut[idx])
-      const fee = isReferral ? Number(entry.referralFee) * amount / 1e18 : 0
-      dailyFees.add(token, fee)
-    })
-  }
-}
-
 async function fetch({ getLogs, createBalances, chain }: FetchOptions) {
   const routers = ODOS_V2_ROUTERS[chain];
 


### PR DESCRIPTION
Odos recently went live with a frontend fee using it's V3 router - the fee value is emitted in V3 events, and is collected as protocol revenue identically to slippage when the referral code is 1 and the fee recipient is the router address