### PR TITLE
Update TopCut fee calculation

### DIFF
--- a/fees/topcut/index.ts
+++ b/fees/topcut/index.ts
@@ -3,29 +3,19 @@ import { FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { getETHReceived } from "../../helpers/token";
 
 const TOPCUT_VAULT = "0x3cfc3CBA1B4aAF969057F590D23efe46848F4270";
-const MARKETS = [
-  "0x9A5f16c1f2d6b8c9530144aD23Cfa9B3c4717eF1",
-  "0x8B64Cf63B08f7eB3ad163282bf61d382DfFF0586",
-  "0x10EF281AAc569Cb011BfcB4e1C6cA490011486a5",
-  "0xB8eC8622D8B7924337CA7B143683459fE5a13f79",
-  "0xE8B9a818D57E2413E05144311E2d4d190c3f711c",
-  "0xe6f44D70B36c45Fa3095E3E04E0480135630E089",
-];
 
 const fetch = async (options: FetchOptions) => {
-  // Track 9% of ETH inflows to the vault and all market contracts
-  const dailyFees = await getETHReceived({
-    options,
-    targets: MARKETS,
-  });
 
+  // 5% of ETH inflows to TopCut Markets go to the Vault (revenue)
+  // 9% of ETH inflows to TopCut Markets is the total fee burden to users
+  // 9% / 5% = 1.8 --> factor applied to ETH inflows to Vault to get Total Fees
   const dailyRevenue = await getETHReceived({
     options,
     target: TOPCUT_VAULT,
   });
 
   return {
-    dailyFees: dailyFees.resizeBy(9 / 100), // 9% of all ETH flows into all TopCutMarkets
+    dailyFees: dailyRevenue.resizeBy(9 / 5), // 9% total fees, 5% revenue -> Fees = 1.8 * revenue
     dailyRevenue: dailyRevenue,
     dailyProtocolRevenue: dailyRevenue,
   };
@@ -33,8 +23,8 @@ const fetch = async (options: FetchOptions) => {
 
 const meta = {
   methodology: {
-    Fees: "9% of all ETH flows into active TopCutMarkets",
-    Revenue: "All ETH flows into the TopCutVault",
+    Fees: "9% of all ETH flows into active TopCutMarkets, i.e. 1.8 times the protocol revenue.",
+    Revenue: "All ETH flows into the TopCutVault. Equals 5% of all ETH flow into TopCutMarkets.",
     ProtocolRevenue: "All ETH flows into the TopCutVault",
   },
 };


### PR DESCRIPTION
TopCut Markets take a total of 9% fees from users with 5% going to the Vault.

The list of active markets changes frequently, however, the Vault contract remains the same.

To ensure consistent fee tracking, we apply a constant to the Vault inflows to calculate the fees (9/5) instead of tracking and constantly updating each marekt.