### PR TITLE
add bullbit-ai adapter

### DIFF
--- a/dexs/bullbit-ai/index.ts
+++ b/dexs/bullbit-ai/index.ts
@@ -1,0 +1,35 @@
+import { FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import { addGasTokensReceived } from '../../helpers/token';
+
+const feeReceiverMultisig = [
+  "0x87D30c1a5a79b060d7F6FBEa7791c381a2aFc7Ad"
+]
+
+const fromAddresses = [
+  "0x20be1319c5604d272fb828a9dccd38487e973cb8"
+]
+
+const fetch = async (options: FetchOptions) => {
+  let dailyVolume = options.createBalances()
+
+  await addGasTokensReceived({ multisigs: feeReceiverMultisig, balances: dailyVolume, options, fromAddresses })
+  dailyVolume = dailyVolume.resizeBy(100) // because of 1% fixed platform fee as per docs
+
+  return {
+    dailyVolume: dailyVolume
+  }
+}
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  adapter: {
+    [CHAIN.BSC]: {
+      fetch,
+      start: '2025-07-15'
+    },
+    
+  },
+}
+
+export default adapter

--- a/fees/bullbit-ai.ts
+++ b/fees/bullbit-ai.ts
@@ -1,0 +1,48 @@
+import { FetchOptions, SimpleAdapter } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+import { addGasTokensReceived, addTokensReceived } from "../helpers/token";
+
+const feeReceiverMultisig = [
+  "0x87D30c1a5a79b060d7F6FBEa7791c381a2aFc7Ad"
+]
+
+const fromAddresses = [
+  "0x20be1319c5604d272fb828a9dccd38487e973cb8"
+]
+
+const fetch: any = async (options: FetchOptions) => {
+  const dailyRevenue = await addTokensReceived({
+    options,
+    targets: feeReceiverMultisig,
+    fromAdddesses: fromAddresses,
+    skipIndexer: true
+  });
+
+  await addGasTokensReceived({
+    multisigs: feeReceiverMultisig,
+    balances: dailyRevenue,
+    options,
+    fromAddresses
+  });
+
+  const dailyFees = dailyRevenue.clone();
+
+  return { dailyFees, dailyRevenue };
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  adapter: {
+    [CHAIN.BSC]: { 
+      fetch,
+      meta: {
+        methodology: {
+          Fees: 'All fees paid by users for launching, trading tokens.',
+          Revenue: 'Fees collected by bullbit.ai protocol.',
+        }
+      },
+    },
+  },
+};
+
+export default adapter;


### PR DESCRIPTION
- Added a new adapter for bullbit.ai to the DEXs and Fees dashboards.
- The adapter calculates daily trading volume for DEXs and daily fees/revenue for Fees.
- Data is sourced directly from the BSC blockchain using feeReceiverMultisig and fromAddresses.