### PR TITLE
Add Quickswap Base network support for v2 and v4 (Algebra Integra)

### DIFF
--- a/dexs/quickswap-v4.ts
+++ b/dexs/quickswap-v4.ts
@@ -1,0 +1,15 @@
+import { CHAIN } from "../helpers/chains";
+import { uniV3Exports } from "../helpers/uniswap";
+
+const algebraV3PoolCreatedEvent = 'event Pool (address indexed token0, address indexed token1, address pool)'
+const algebraV3SwapEvent = 'event Swap(address indexed sender, address indexed recipient, int256 amount0, int256 amount1, uint160 price, uint128 liquidity, int24 tick, uint24 overrideFee, uint24 pluginFee)'
+
+export default uniV3Exports({
+  [CHAIN.BASE]: {
+    factory: "0xC5396866754799B9720125B104AE01d935Ab9C7b",
+    poolCreatedEvent: algebraV3PoolCreatedEvent,
+    swapEvent: algebraV3SwapEvent,
+    isAlgebraV3: true,
+    start: '2025-08-12',
+  },
+})

--- a/dexs/quickswap/index.ts
+++ b/dexs/quickswap/index.ts
@@ -16,6 +16,7 @@ const endpoints = {
   [CHAIN.POLYGON]: sdk.graph.modifyEndpoint(
     "FUWdkXWpi8JyhAnhKL5pZcVshpxuaUQG8JHMDqNCxjPd",
   ),
+  [CHAIN.BASE]: "https://gateway.thegraph.com/api/eae8430c94c2403f46fee0fdfa5f1fd4/subgraphs/id/HtaMv1w1dCbk6RzsEsMjdcgeWZWeNqwATNbCZtKhFY49",
 };
 
 const graphs = getChainVolume({
@@ -109,6 +110,10 @@ const adapter: BreakdownAdapter = {
       [CHAIN.POLYGON]: {
         fetch: graphs(CHAIN.POLYGON),
         start: '2020-10-08',
+      },
+      [CHAIN.BASE]: {
+        fetch: graphs(CHAIN.BASE),
+        start: '2025-08-12',
       },
     },
     v3: {


### PR DESCRIPTION
# Summary

Adds Base support for QuickSwap v2, v4 (Algebra Integral), start Date (Aug 12, 2025)