### PR TITLE
Remove 'fromAdddesses' filter for holders revenue

### DIFF
--- a/fees/peapods-finance/index.ts
+++ b/fees/peapods-finance/index.ts
@@ -8,7 +8,6 @@ const fetch = async (options: FetchOptions) => {
     options,
     target: "0x6499Add1cC6223Aeec0BD9e5355EfE10ceF519C5", //vlPEAS wallet
     token:  "0x02f92800f57bcd74066f5709f1daa1a4302df875", //PEAS token
-    fromAdddesses: ["0x88eaFE23769a4FC2bBF52E77767C3693e6acFbD5"], //revenue wallet
   });
 
   const protocolB = await addTokensReceived({


### PR DESCRIPTION
Since we are going to utilize limit and/or DCA orders to buy PEAS and sent to the holders revenue wallet (vlPEAS), the from-address will not always be the same address but can be contract or third party wallets. Any PEAS token entering the wallet will be used for holders revenue and can be counted.