### PR TITLE
fix: correct volume and revenue calculation for overtime markets

### DIFF
--- a/options/thales/abis.ts
+++ b/options/thales/abis.ts
@@ -3,6 +3,7 @@ export const OVERTIME_EVENT_ABI = {
     boughtFromAmm: "event BoughtFromAmm(address buyer, address market, uint8 position, uint amount, uint sUSDPaid, address susd, address asset)",
     speedMarketCreated: "event MarketCreated(address market, address user, bytes32 asset, uint256 strikeTime, int64 strikePrice, uint8 direction, uint256 buyinAmount)",
     chainedMarketCreated: "event MarketCreated(address market, address user, bytes32 asset, uint64 timeFrame, uint64 strikeTime, int64 strikePrice, uint8[] directions, uint256 buyinAmount, uint256 payoutMultiplier, uint256 safeBoxImpact)",
-    safeboxFeePaid: "event SafeBoxFeePaid(uint safeBoxFee, uint safeBoxAmount, address collateral)"
+    safeboxFeePaid: "event SafeBoxFeePaid(uint safeBoxFee, uint safeBoxAmount, address collateral)",
+    safeboxSharePaid: "event SafeBoxSharePaid(uint safeBoxShare, uint safeBoxAmount)"
   };
   

--- a/options/thales/config.ts
+++ b/options/thales/config.ts
@@ -1,84 +1,6 @@
 import ADDRESSES from '../../helpers/coreAssets.json'
 import { CHAIN } from "../../helpers/chains";
 
-export const OVERTIME_CHAIN_CONFIG = {
-  optimism: { 
-    tokens: [
-      ADDRESSES.optimism.USDC_CIRCLE, 
-      ADDRESSES.optimism.USDC,
-      ADDRESSES.optimism.DAI,
-      ADDRESSES.optimism.USDT,
-      ADDRESSES.optimism.OP,
-      ADDRESSES.optimism.WETH,
-      ADDRESSES.optimism.WETH_1,
-      '0xedf38688b27036816a50185caa430d5479e1c63e' // OVERTIME TOKEN
-    ], 
-    fromAddresses: [
-      '0xFb4e4811C7A811E098A556bD79B64c20b479E431', // Sports AMM V2
-      '0x9Ce94cdf8eCd57cec0835767528DC88628891dd9', // Thales AMM
-      '0xEd59dCA9c272FbC0ca4637F32ab32CBDB62E856B', // Ranged AMM
-      '0xE16B8a01490835EC1e76bAbbB3Cadd8921b32001', // Speed Market
-      '0xFf8Cf5ABF583D0979C0B9c35d62dd1fD52cce7C7', // Chained Speed Market
-    ], 
-    targets: [
-      '0x7B280E647966a8FAc7eaB3157dAD8da3e37dDA35'
-    ],
-  },
-  arbitrum: {
-    tokens: [
-      ADDRESSES.arbitrum.USDC, 
-      ADDRESSES.arbitrum.USDC_CIRCLE, 
-      ADDRESSES.arbitrum.DAI,
-      ADDRESSES.arbitrum.USDT,
-      ADDRESSES.arbitrum.ARB,
-      ADDRESSES.arbitrum.WBTC,
-      ADDRESSES.arbitrum.WETH,
-      '0x5829d6fe7528bc8e92c4e81cc8f20a528820b51a' // OVERTIME TOKEN
-    ],
-    fromAddresses: [
-      '0xfb64E79A562F7250131cf528242CEB10fDC82395', // Sports AMM V2
-      '0x2b89275efb9509c33d9ad92a4586bdf8c4d21505', // Thales AMM
-      '0x5cf3b1882357bb66cf3cd2c85b81abbc85553962', // Ranged AMM
-      '0x02D0123a89Ae6ef27419d5EBb158d1ED4Cf24FA3', // Speed Market
-      '0xe92B4c614b04c239d30c31A7ea1290AdDCb8217D', // Chained Speed Market
-    ],
-    targets: [
-      '0x4952802B950e3f2F45eaF550f25546b188B3648A',
-    ],
-  },
-  base: {
-    tokens: [
-      ADDRESSES.base.USDC,
-      ADDRESSES.base.USDbC,
-      ADDRESSES.base.DAI,
-      ADDRESSES.base.USDT,
-      ADDRESSES.base.WETH,
-      ADDRESSES.ethereum.cbBTC, // cbBTC
-      '0x7750c092e284e2c7366f50c8306f43c7eb2e82a2' // OVERTIME TOKEN
-    ],
-    fromAddresses: [
-      '0x76923cDDE21928ddbeC4B8BFDC8143BB6d0841a8', // Sports AMM V2
-      '0x85b827d133FEDC36B844b20f4a198dA583B25BAA', // Speed Markets
-      '0x6848F001ddDb4442d352C495c7B4a231e3889b70'  // Chained Speed Markets
-    ],
-    targets: [
-      '0x7E5828c72225A1d046f5F7e60Ea7cd19116FAFe7', 
-    ],
-  },
-  polygon: {
-    tokens: [
-      ADDRESSES.polygon.USDC,
-    ],
-    fromAddresses: [
-      '0x4B1aED25f1877E1E9fBECBd77EeE95BB1679c361', // Speed Markets
-      '0x14D2d7f64D6F10f8eF06372c2e5E36850661a537', // Chained Speed Markets
-    ],
-    targets: [
-      '0xE931777640149fE67aE0771FF250aC93A5c38E85', 
-    ],
-  }
-}
-
 export const OVERTIME_CONTRACT_ADDRESSES = {
     [CHAIN.OPTIMISM]: {
       sportsAMMV2: "0xFb4e4811C7A811E098A556bD79B64c20b479E431",
@@ -104,3 +26,23 @@ export const OVERTIME_CONTRACT_ADDRESSES = {
       chainedSpeedMarket: "0x14D2d7f64D6F10f8eF06372c2e5E36850661a537"
     }
   };
+
+export const LP_CONTRACT_COLLATERAL_MAPPING: Record<string, Record<string, string>> = {
+  [CHAIN.OPTIMISM]: {
+    "0x7B280E647966a8FAc7eaB3157dAD8da3e37dDA35": ADDRESSES.optimism.USDC_CIRCLE,
+    "0x4f2822D4e60af7f9F70E7e45BC1941fe3461231e": ADDRESSES.optimism.WETH_1,
+    "0x59a7A8Ae9d58D69a69b6A24770EC771110647226": '0xedf38688b27036816a50185caa430d5479e1c63e' // OVERTIME TOKEN
+  },
+  [CHAIN.ARBITRUM]: {
+    "0x22d180f39a0eb66098cf839af5e3c6b009383b6a": ADDRESSES.arbitrum.USDC,
+    "0xcB4728a1789B87E05c813B68DBc5E6A98a4856bA": ADDRESSES.arbitrum.WETH,
+    "0xc5f5186b46c84bF63a9e166bfa2175D9bc391ce2": '0x5829d6fe7528bc8e92c4e81cc8f20a528820b51a', // OVERTIME TOKEN
+    "0xbD08D8F8c17C22fb0a12Fe490F38f40c59B60d2A": ADDRESSES.arbitrum.WBTC,
+  },
+  [CHAIN.BASE]: {
+    "0xf86e90412F52fDad8aD8D1aa2dA5B2C9a7e5f018": ADDRESSES.base.USDC,
+    "0xcc4ED8cD7101B512B134360ED3cCB759caB33f17": ADDRESSES.base.WETH,
+    "0xB4199DC163F3206643649E117A816ad0DECb6C3B": '0x7750c092e284e2c7366f50c8306f43c7eb2e82a2', // OVERTIME TOKEN
+    "0x8d4f838327DedFc735e202731358AcFc260c207a": ADDRESSES.base.cbBTC,
+  },
+};

--- a/options/thales/eventArgs.ts
+++ b/options/thales/eventArgs.ts
@@ -43,3 +43,14 @@ export interface ITicketCreatedEvent {
     lpFeeWithSkew?: bigint;
   }
   
+  export interface ISafeBoxFeePaidEvent {
+    safeBoxFee: bigint;
+    safeBoxAmount: bigint;
+    collateral: string;
+  }
+  
+  export interface ISafeBoxSharePaidEvent {
+    safeBoxShare: bigint;
+    safeBoxAmount: bigint;
+  }
+  


### PR DESCRIPTION
## Summary of Changes

  #### Fee Calculation System: Implemented Fee = Revenue + LP Performance Fee
  - Revenue from `SafeBoxFeePaid` events using `safeBoxAmount` field
  - LP Performance Fee from `SafeBoxSharePaid` events using `safeBoxAmount` field
  - Added LP contract-to-collateral mapping for proper token attribution

  #### Fixed Speed Market Volume Calculation
  - Issue: Incorrect decimal handling for `buyinAmount`
  - Fix: Proper `/1e18` decimal conversion for speed market volumes