### PR TITLE
Ether fi additions revenue and track token buybacks

### DIFF
--- a/fees/ether-fi/index.ts
+++ b/fees/ether-fi/index.ts
@@ -4,6 +4,7 @@ import { Adapter, FetchOptions } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 import { ethers } from "ethers";
 import ADDRESSES from '../../helpers/coreAssets.json';
+import { queryDuneSql } from '../../helpers/dune';
 
 const EETH = ADDRESSES.ethereum.EETH;
 const EIGEN = ADDRESSES.ethereum.EIGEN;
@@ -190,7 +191,165 @@ const getMiscStakingRevenue = async (options: FetchOptions) => {
   };
 }
 
-const fetch = async (options: FetchOptions) => {
+const getAdditionalRevenueStreams = async (options: FetchOptions) => {
+  const query = `
+    with 
+    
+    -- Restaking rewards from Eigenlayer via restaker contract
+    restaking_rewards as (
+        select 
+            'restaking_rewards' as revenue_source,
+            sum(((0.035 * token_balance_usd) * 0.038)/365) as revenue_usd
+        from 
+        dune.ether_fi.result_aum
+        where address in (0x1B7a4C3797236A1C37f8741c0Be35c2c72736fFf, 0x917cee801a67f933f2e6b33fc0cd1ed2d5909d88)
+        and lower(token_symbol) like '%steth%'
+        and day >= date(from_unixtime(${options.startTimestamp})) 
+        and day < date(from_unixtime(${options.endTimestamp}))
+        and token_balance_usd > 0
+    ),
+    
+    -- ether.fi cash spend events
+    spend_events as (
+        select 
+            bytearray_to_uint256(bytearray_substring(data,33,32))/1e6 as spend_usd
+        from 
+        scroll.logs 
+        where TIME_RANGE
+        and contract_address in (0x5423885B376eBb4e6104b8Ab1A908D350F6A162e, 0x380B2e96799405be6e3D965f4044099891881acB)
+        and topic0 = 0xe70f33131caa91c15ec116944772ba79bcc4cd6501cdfa178d66f903a796759a
+
+        union all 
+
+        select 
+            bytearray_to_uint256(bytearray_substring(data,33,32))/1e6 as spend_usd
+        from 
+        scroll.logs 
+        where TIME_RANGE
+        and contract_address = 0x380B2e96799405be6e3D965f4044099891881acB
+        and topic0 = 0xbe1dc90fb3facc4238834ef8da43ef4f286440a3546f49a89ebb82efb37f21cb
+
+        union all 
+
+        select 
+            bytearray_to_uint256(bytearray_substring(data, 321, 32)) / 1e6 as spend_usd
+        from 
+        scroll.logs 
+        where TIME_RANGE
+        and contract_address = 0x380B2e96799405be6e3D965f4044099891881acB
+        and topic0 = 0x244f4cc0665ad7ee4709aa59b30d3ea581cecde1b0430a3f23a5dc609d4890fc
+    ),
+    
+    -- ether.fi cash spends revenue (1.38% fee)
+    cash_spends_revenue as (
+        select 
+            'cash_spends' as revenue_source,
+            sum(0.0138 * spend_usd) as revenue_usd
+        from 
+        spend_events
+    ),
+    
+    -- ether.fi cash borrows revenue (optimized - direct calculation from queries)
+    cash_borrows_revenue as (
+        select 
+            'cash_borrows' as revenue_source,
+            sum(daily_revenue) as revenue_usd
+        from 
+        query_5535845
+        where day >= date(from_unixtime(${options.startTimestamp})) 
+        and day < date(from_unixtime(${options.endTimestamp}))
+    ),
+    
+    -- ether.fi cash cashback events
+    cashback_events as (
+        select 
+            bytearray_to_uint256(bytearray_substring(data,65,32))/1e6 as cashback_usd 
+        from 
+        scroll.logs 
+        where TIME_RANGE
+        and contract_address = 0x5423885B376eBb4e6104b8Ab1A908D350F6A162e
+        and topic0 = 0xc2f328aca2253ffbf4bdb01552106555dbedd5b21bc86578abbbb849d73613a6
+
+        union all 
+
+        select 
+            bytearray_to_uint256(bytearray_substring(data,97,32))/1e6 + bytearray_to_uint256(bytearray_substring(data,161,32))/1e6 as cashback_usd 
+        from 
+        scroll.logs 
+        where TIME_RANGE
+        and contract_address = 0x380B2e96799405be6e3D965f4044099891881acB
+        and topic0 = 0xeb47a17fe64c36c7ac73cc029dd561d73e8df11215ed25fbb8c30653bf6d3a72
+
+        union all 
+
+        select 
+            bytearray_to_uint256(bytearray_substring(data,97,32))/1e6 as cashback_usd 
+        from 
+        scroll.logs 
+        where TIME_RANGE
+        and contract_address = 0x380B2e96799405be6e3D965f4044099891881acB
+        and topic0 = 0x0b79a9660f2e7ba216d6c8c6aa4a73dff96833d3c0b14a067da90c3b1f3118dc
+
+        union all 
+
+        select 
+            bytearray_to_uint256(bytearray_substring(data,97,32))/1e6 as cashback_usd 
+        from 
+        scroll.logs 
+        where TIME_RANGE
+        and contract_address = 0x380B2e96799405be6e3D965f4044099891881acB
+        and topic0 = 0x89d3571a498b5d3d68599f5f00c3016f9604aafa7701c52c1b04109cd909a798
+    ),
+    
+    -- ether.fi cashbacks revenue
+    cash_cashbacks_revenue as (
+        select 
+            'cash_cashbacks' as revenue_source,
+            sum(cashback_usd) as revenue_usd
+        from 
+        cashback_events
+    )
+    
+    -- Combine all revenue sources
+    select revenue_source, revenue_usd from restaking_rewards
+    union all
+    select revenue_source, revenue_usd from cash_spends_revenue  
+    union all
+    select revenue_source, revenue_usd from cash_borrows_revenue
+    union all
+    select revenue_source, revenue_usd from cash_cashbacks_revenue`;
+
+  const result = await queryDuneSql(options, query);
+  const revenues = {
+    restakingRewards: 0,
+    cashSpends: 0,
+    cashBorrows: 0,
+    cashCashbacks: 0
+  };
+
+  if (result && result.length > 0) {
+    result.forEach(row => {
+      switch (row.revenue_source) {
+        case 'restaking_rewards':
+          revenues.restakingRewards = Number(row.revenue_usd || 0);
+          break;
+        case 'cash_spends':
+          revenues.cashSpends = Number(row.revenue_usd || 0);
+          break;
+        case 'cash_borrows':
+          revenues.cashBorrows = Number(row.revenue_usd || 0);
+          break;
+        case 'cash_cashbacks':
+          revenues.cashCashbacks = Number(row.revenue_usd || 0);
+          break;
+      }
+    });
+  }
+  console.log(revenues);
+  return revenues;
+}
+
+const fetch = async (_a:any, _b:any, options: FetchOptions) => {
   const dailyFees = options.createBalances();
   const dailyRev = options.createBalances();
 
@@ -240,6 +399,33 @@ const fetch = async (options: FetchOptions) => {
   dailyRev.add(EIGEN, eigenRevenue);
   dailyFees.add(EIGEN, eigenRevenue);
 
+  // Add missing revenue sources via optimized merged Dune query
+  const additionalRevenues = await getAdditionalRevenueStreams(options);
+  
+  // Restaking rewards from Eigenlayer via restaker contract (0x1B7a4C3797236A1C37f8741c0Be35c2c72736fFf)
+  if (additionalRevenues.restakingRewards > 0) {
+    dailyRev.addUSDValue(additionalRevenues.restakingRewards);
+    dailyFees.addUSDValue(additionalRevenues.restakingRewards);
+  }
+
+  // ether.fi cash spends revenue (1.38% fee)
+  if (additionalRevenues.cashSpends > 0) {
+    dailyRev.addUSDValue(additionalRevenues.cashSpends);
+    dailyFees.addUSDValue(additionalRevenues.cashSpends);
+  }
+
+  // ether.fi cash borrows revenue
+  if (additionalRevenues.cashBorrows > 0) {
+    dailyRev.addUSDValue(additionalRevenues.cashBorrows);
+    dailyFees.addUSDValue(additionalRevenues.cashBorrows);
+  }
+
+  // ether.fi cashbacks revenue
+  if (additionalRevenues.cashCashbacks > 0) {
+    dailyRev.addUSDValue(additionalRevenues.cashCashbacks);
+    dailyFees.addUSDValue(additionalRevenues.cashCashbacks);
+  }
+
   // liquid earnings
   for (const vault of Object.values(LIQUID_VAULTS)) {
     let accountStateAbi = ''
@@ -277,13 +463,13 @@ const fetch = async (options: FetchOptions) => {
 };
 
 const adapter: Adapter = {
-  version: 2,
+  version: 1,
   fetch,
   chains: [CHAIN.ETHEREUM],
   methodology: {
-    Fees: "Staking/restaking rewards and Liquid Vault fees.",
-    Revenue: "Staking/restaking rewards and Liquid Vault platform management fees.",
-    ProtocolRevenue: "Staking/restaking rewards and Liquid Vault platform management fees.",
+    Fees: "Staking/restaking rewards, Liquid Vault fees, ether.fi cash transaction fees (1.38%), cashbacks, and borrowing interest.",
+    Revenue: "Staking/restaking rewards including Eigenlayer restaking via restaker contract, Liquid Vault platform management fees, ether.fi cash revenue from spends/borrows/cashbacks.",
+    ProtocolRevenue: "Staking/restaking rewards including Eigenlayer restaking via restaker contract, Liquid Vault platform management fees, ether.fi cash revenue from spends/borrows/cashbacks.",
   },
   start: '2024-03-13'
 };


### PR DESCRIPTION
For 2025-08-25
```
{
  restakingRewards: 10464.680167876963,
  cashSpends: 6027.843036000004,
  cashBorrows: 475.86655617791007,
  cashCashbacks: 14482.526800000009,
  buybacks: 0
}
ETHEREUM 👇
Backfill start time: 13/3/2024
Daily fees: 1.66 M
Daily revenue: 898.52 k
Daily protocol revenue: 898.52 k
Daily holders revenue: 0
```