### PR TITLE
Add Morpho rewards to Spark Liquidity Layer revenue

### DIFF
--- a/fees/spark-liquidity-layer/index.ts
+++ b/fees/spark-liquidity-layer/index.ts
@@ -8,21 +8,26 @@ const getDay = (ts: number) => new Date(ts * 1000).toISOString().split('T')[0]
 async function fetch(options: FetchOptions): Promise<FetchResultFees> {
   const dailyRevenue = options.createBalances()
   const dailyFees = options.createBalances()
+  const dailySupplySideRevenue = options.createBalances()
 
   const date = getDay(options.startOfDay)
   const sql = getSqlFromFile('fees/spark-liquidity-layer/spark-liquidity-layer-revenue.sql', { dt: date })
 
   const response = await queryDuneSql(options, sql)
 
-  dailyRevenue.addUSDValue(response[0].revenue, METRIC.ASSETS_YIELDS, { skipChain: true })
-  dailyFees.addUSDValue(response[0].fees, METRIC.ASSETS_YIELDS, { skipChain: true })
+  const dssr = Number(response[0].fees) - Number(response[0].revenue)
 
-  return { dailyFees, dailyRevenue, dailyProtocolRevenue: dailyRevenue, }
+  dailyFees.addUSDValue(response[0].fees, METRIC.ASSETS_YIELDS)
+  dailyRevenue.addUSDValue(response[0].revenue, METRIC.ASSETS_YIELDS)
+  dailySupplySideRevenue.addUSDValue(dssr, METRIC.ASSETS_YIELDS)
+
+  return { dailyFees, dailyRevenue, dailySupplySideRevenue, dailyProtocolRevenue: dailyRevenue, }
 }
 
 const methodology = {
   Fees: 'Total interest earned on all loans.',
   Revenue: 'Fees collected minus the Sky Base Rate (vault stability fee) plus the monthly offchain rebate calculation for things like idle USDS.',
+  SupplySideRevenue: 'Fees collected distributed to supply-side depositors.',
   ProtocolRevenue: 'All revenue are collected by Spark protocol.',
 }
 
@@ -32,6 +37,9 @@ const breakdownMethodology = {
   },
   Revenue: {
     [METRIC.ASSETS_YIELDS]: 'Fees collected minus the Sky Base Rate (vault stability fee) plus the monthly offchain rebate calculation for things like idle USDS.',
+  },
+  SupplySideRevenue: {
+    [METRIC.ASSETS_YIELDS]: 'Fees collected distributed to supply-side depositors.',
   },
   ProtocolRevenue: {
     [METRIC.ASSETS_YIELDS]: 'All revenue are collected by Spark protocol.',

--- a/fees/spark-liquidity-layer/index.ts
+++ b/fees/spark-liquidity-layer/index.ts
@@ -41,6 +41,7 @@ const adapter: SimpleAdapter = {
   methodology,
   breakdownMethodology,
   fetch,
+  allowNegativeValue: true,
   start: '2025-07-01',
   chains: [CHAIN.ETHEREUM],
 }

--- a/fees/spark-liquidity-layer/index.ts
+++ b/fees/spark-liquidity-layer/index.ts
@@ -7,26 +7,28 @@ const getDay = (ts: number) => new Date(ts * 1000).toISOString().split('T')[0]
 
 async function fetch(options: FetchOptions): Promise<FetchResultFees> {
   const dailyRevenue = options.createBalances()
+  const dailyFees = options.createBalances()
 
   const date = getDay(options.startOfDay)
   const sql = getSqlFromFile('fees/spark-liquidity-layer/spark-liquidity-layer-revenue.sql', { dt: date })
 
   const response = await queryDuneSql(options, sql)
 
-  dailyRevenue.addUSDValue(response[0].revenue, METRIC.ASSETS_YIELDS,{ skipChain: true })
+  dailyRevenue.addUSDValue(response[0].revenue, METRIC.ASSETS_YIELDS, { skipChain: true })
+  dailyFees.addUSDValue(response[0].fees, METRIC.ASSETS_YIELDS, { skipChain: true })
 
-  return { dailyFees: dailyRevenue, dailyRevenue, dailyProtocolRevenue: dailyRevenue, }
+  return { dailyFees, dailyRevenue, dailyProtocolRevenue: dailyRevenue, }
 }
 
 const methodology = {
-  Fees: 'Fees collected minus the Sky Base Rate (vault stability fee) plus the monthly offchain rebate calculation for things like idle USDS.',
+  Fees: 'Total interest earned on all loans.',
   Revenue: 'Fees collected minus the Sky Base Rate (vault stability fee) plus the monthly offchain rebate calculation for things like idle USDS.',
   ProtocolRevenue: 'All revenue are collected by Spark protocol.',
 }
 
 const breakdownMethodology = {
   Fees: {
-    [METRIC.ASSETS_YIELDS]: 'Fees collected minus the Sky Base Rate (vault stability fee) plus the monthly offchain rebate calculation for things like idle USDS.',
+    [METRIC.ASSETS_YIELDS]: 'Total interest earned on all loans.',
   },
   Revenue: {
     [METRIC.ASSETS_YIELDS]: 'Fees collected minus the Sky Base Rate (vault stability fee) plus the monthly offchain rebate calculation for things like idle USDS.',

--- a/fees/spark-liquidity-layer/spark-liquidity-layer-revenue.sql
+++ b/fees/spark-liquidity-layer/spark-liquidity-layer-revenue.sql
@@ -23,8 +23,69 @@ with tokens (blockchain, token_address, token_symbol) as (
         ('ethereum', 0x8236a87084f8b84306f72007f36f2618a5634494, 'LBTC'),
         ('ethereum', 0x18084fba666a33d37592fa2633fd49a74dd93a88, 'tBTC'),
         ('ethereum', 0xcbb7c0000ab88b473b1f5afd9ef808440eed33bf, 'cbBTC'),
-        ('ethereum', 0x2260fac5e5542a773aa44fbcfedf7c193bc2c599, 'WBTC')
+        ('ethereum', 0x2260fac5e5542a773aa44fbcfedf7c193bc2c599, 'WBTC'),
+        ('base', 0xBAa5CC21fd487B8Fcc2F632f3F4E8D37262a0842, 'MORPHO')
 ),
+    morpho_daily_changes AS (
+        SELECT
+            DATE(evt_block_time) as dt,
+            contract_address,
+            SUM(
+                CASE
+                    WHEN "to" = 0x2917956eFF0B5eaF030abDB4EF4296DF775009cA
+                        THEN value / 1e18
+                    WHEN "from" = 0x2917956eFF0B5eaF030abDB4EF4296DF775009cA
+                        THEN -(value / 1e18)
+                    ELSE 0
+                END
+            ) as daily_net_change
+        FROM thirdweb_base.morphotokenoptimism_evt_transfer
+        WHERE
+            (
+                "from" = 0x2917956eFF0B5eaF030abDB4EF4296DF775009cA
+                OR "to" = 0x2917956eFF0B5eaF030abDB4EF4296DF775009cA
+            )
+        GROUP BY 1,2
+    ),
+    -- Get USDC token info for price lookup
+    usdc_token AS (
+        SELECT
+            blockchain,
+            token_address
+        FROM tokens
+        WHERE token_symbol = 'USDC'
+        LIMIT 1  -- In case there are multiple USDC entries
+    ),
+    morpho_rewards AS (
+        SELECT
+            b.dt,
+            'base' as blockchain,
+            'Morpho' as protocol_name,
+            'USDC' as token_symbol,
+            b.daily_net_change as MORPHO_rewards,
+            p.price_usd as MORPHO_price_usd,
+            b.daily_net_change * p.price_usd as MORPHO_rewards_usd,
+            -- Add USDC price for the same date
+            p_usdc.price_usd as USDC_price_usd,
+            b.daily_net_change * p.price_usd/p_usdc.price_usd as MORPHO_rewards_USDC,
+            SUM(b.daily_net_change) OVER (
+                ORDER BY b.dt ROWS UNBOUNDED PRECEDING
+            ) as cumulative_MORPHO_balance
+        FROM morpho_daily_changes b
+        JOIN tokens t
+            ON b.contract_address = t.token_address
+        LEFT JOIN dune.steakhouse.result_token_price p
+            ON t.blockchain = p.blockchain
+            AND t.token_address = p.token_address
+            AND b.dt = p.dt
+        -- Join USDC price for the same date
+        LEFT JOIN usdc_token ut ON 1=1  -- Cross join to get USDC token info
+        LEFT JOIN dune.steakhouse.result_token_price p_usdc
+            ON ut.blockchain = p_usdc.blockchain
+            AND ut.token_address = p_usdc.token_address
+            AND b.dt = p_usdc.dt
+        ORDER BY b.dt DESC
+    ),
      protocols_data as (
          select *
          from (
@@ -131,7 +192,7 @@ with tokens (blockchain, token_address, token_symbol) as (
                         case
                             when protocol_name = 'Sparklend' then (sl.interest_amount-sl.BR_cost) / 365
                             when protocol_name = 'Morpho'
-                                and token_symbol in ('DAI', 'USDC','USDS') then m.net_rev_interest / 365
+                                and token_symbol in ('DAI', 'USDC','USDS') then (m.interest_amount-m.BR_cost)/ 365+coalesce(mr.MORPHO_rewards_USDC,0)
                             when protocol_name = 'ethena' then e.daily_actual_revenue - e.daily_BR_cost
                             else (p.amount / 365) * p.reward_per + (p.amount / 365) * p.interest_per
                             end
@@ -140,6 +201,7 @@ with tokens (blockchain, token_address, token_symbol) as (
                   left join dune.sparkdotfi.result_spark_idle_dai_usds_in_sparklend_by_alm_proxy sl using (dt, protocol_name, token_symbol) -- Spark - Idle DAI & USDS in Sparklend by ALM Proxy
                   left join dune.sparkdotfi.result_spark_idle_dai_usdc_in_morpho_by_alm_proxy m using (dt, protocol_name, token_symbol) -- Spark - Idle DAI & USDC in Morpho by ALM Proxy
                   left join dune.sparkdotfi.result_spark_ethena_payout_apy e using (dt, protocol_name, token_symbol) -- Spark - Ethena Payout + APY
+                  left join morpho_rewards mr using (dt, protocol_name, token_symbol) --Spark - $MORPHO Rewards
          group by 1,
                   2,
                   3,


### PR DESCRIPTION
- adds Morpho rewards 
- uses correct column after column was renamed
- allows for negative values as it might happen in a single day
- correctly calculates fees (fees are higher than the revenue)