### PR TITLE
fix: pcs holders revenue

### DIFF
--- a/dexs/pancakeswap/bscv2.ts
+++ b/dexs/pancakeswap/bscv2.ts
@@ -57,7 +57,7 @@ export async function getBscV2Data(options: FetchOptions): Promise<FetchResultV2
     dailyUserFees: dailyVolume.clone(0.0025),
     dailyRevenue: dailyVolume.clone(0.0008),
     dailySupplySideRevenue: dailyVolume.clone(0.0017),
-    dailyProtocolRevenue: dailyVolume.clone(0.0000225),
-    dailyHoldersRevenue: dailyVolume.clone(0.0000575),
+    dailyProtocolRevenue: dailyVolume.clone(0.000225),
+    dailyHoldersRevenue: dailyVolume.clone(0.000575),
   }
 }


### PR DESCRIPTION
should resolve https://github.com/DefiLlama/dimension-adapters/issues/3257
Of all burn amount https://pancakeswap.finance/burn-dashboard , only v2 was too off due to decimal error, I think now it should be fine