### PR TITLE
feat(potatoswap): add cumulative volume via subgraph (X Layer)

### DIFF
--- a/dexs/potatoswap.ts
+++ b/dexs/potatoswap.ts
@@ -1,0 +1,38 @@
+import { SimpleAdapter } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+import { request, gql } from "graphql-request";
+
+const endpoint = "https://indexer.potatoswap.finance/subgraphs/id/Qmaeqine8JeSiKV3QCi6JJqzDGryF7D8HCJdqcYxW7nekw";
+
+const query = gql`
+  {
+    pancakeFactories(first: 1) {
+      totalVolumeUSD
+    }
+  }
+`;
+
+async function fetchVolume() {
+  const res = await request(endpoint, query);
+  const volume = Number(res.pancakeFactories[0].totalVolumeUSD);
+  return {
+    totalVolume: volume,
+  };
+}
+
+const methodology = {
+  Volume: "Cumulative swap volume in USD from PotatoSwap subgraph on X Layer network.",
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  methodology,
+  adapter: {
+    [CHAIN.XLAYER]: {
+      fetch: fetchVolume,
+      start: 1713820800, // April 23, 2024
+    },
+  },
+};
+
+export default adapter;


### PR DESCRIPTION
### Summary
This PR adds a **DEX Volume adapter** for PotatoSwap on **X Layer**.

- Source: `pancakeFactories.totalVolumeUSD` from the official PotatoSwap subgraph
- Only **cumulative volume** is reported (no daily breakdown yet)
- Start date aligned with TVL adapter: **2024-04-23 (1713820800)**

### Related links
- Protocol page: https://defillama.com/protocol/potatoswap
- Existing TVL adapter: https://github.com/DefiLlama/DefiLlama-Adapters/blob/main/projects/potatoswap/index.js
- Subgraph endpoint: https://indexer.potatoswap.finance/subgraphs/id/Qmaeqine8JeSiKV3QCi6JJqzDGryF7D8HCJdqcYxW7nekw

### Methodology
Cumulative swap volume in USD is fetched directly from the subgraph field:
