### PR TITLE
Filter out non perps volume for Paradex

### DIFF
--- a/dexs/paradex/index.ts
+++ b/dexs/paradex/index.ts
@@ -18,7 +18,7 @@ const fetch = async (timestamp: number): Promise<FetchResultVolume> => {
 
   const volumesData = await fetchURL(volumeEndpoint) as IVolumeData
   const timestampStr = new Date(timestamp * 1000).toISOString().split('T')[0] + "T00:00:00Z"
-  const dailyVolume = volumesData.data.rows.find(row => ((row[0] === timestampStr)))?.[2]
+  const dailyVolume = volumesData.data.rows.find(row => ((row[0] === timestampStr && row[1] === 'PERP')))?.[2]
   if (!dailyVolume) throw new Error('record missing!')
 
     return { 


### PR DESCRIPTION
The volume endpoint returns both perp and perp option data. Existing code pulls the first occurrence of the timestamp. This is sometimes PERP and sometimes PERP_OPTION, leading to inaccurate representation of Paradex's perp volume data