### PR TITLE
update fee and dex adapter for permute

### DIFF
--- a/dexs/permute/index.ts
+++ b/dexs/permute/index.ts
@@ -3,19 +3,27 @@ import { CHAIN } from "../../helpers/chains"
 import fetchURL from "../../utils/fetchURL";
 import { getTimestampAtStartOfDayUTC } from "../../utils/date";
 
-const photonBridgeEndpoint = "https://bridge.superproof.ai/bridge"
+const permuteEndpoint = "https://api.permute.finance/bridge"
 
 const chainMapping = {
-  ETH: CHAIN.ETHEREUM,
   BTC: CHAIN.BITCOIN,
+  ETH: CHAIN.ETHEREUM,
+  AVAXC: CHAIN.AVAX,
+  ARBITRUM: CHAIN.ARBITRUM,
+  BSC: CHAIN.BSC,
+  TRON: CHAIN.TRON,
+  LTC: CHAIN.LITECOIN,
+  BCH: CHAIN.BITCOIN_CASH,
+  DOGE: CHAIN.DOGE,
+  SOL: CHAIN.SOLANA,
 }
 
-const CHAINS = ['BTC', 'ETH']
+const CHAINS = ['BTC', 'ETH', 'AVAXC', 'ARBITRUM', 'BSC', 'TRON', 'LTC', 'BCH', 'DOGE', 'SOL']
 
 const getFetchForChain = (chainShortName: string) => {
   return async (_a: any, _b: any, options: FetchOptions) => {
     const startOfDay = getTimestampAtStartOfDayUTC(options.startOfDay);
-    const volumeForDay = await fetchURL(photonBridgeEndpoint.concat(`/dashboard/vol/chain/day?chain=${chainShortName}&timestamp=${startOfDay}`))
+    const volumeForDay = await fetchURL(permuteEndpoint.concat(`/dashboard/vol/chain/day?chain=${chainShortName}&timestamp=${startOfDay}`))
 
     const dailyVolume = volumeForDay.day_vol
 

--- a/fees/permute/index.ts
+++ b/fees/permute/index.ts
@@ -3,19 +3,27 @@ import { CHAIN } from "../../helpers/chains"
 import { httpGet } from "../../utils/fetchURL";
 import { getTimestampAtStartOfDayUTC } from "../../utils/date";
 
-const photonBridgeEndpoint = "https://bridge.superproof.ai/bridge"
+const permuteEndpoint = "https://api.permute.finance/bridge"
 
 const chainMapping = {
-  ETH: CHAIN.ETHEREUM,
   BTC: CHAIN.BITCOIN,
+  ETH: CHAIN.ETHEREUM,
+  AVAXC: CHAIN.AVAX,
+  ARBITRUM: CHAIN.ARBITRUM,
+  BSC: CHAIN.BSC,
+  TRON: CHAIN.TRON,
+  LTC: CHAIN.LITECOIN,
+  BCH: CHAIN.BITCOIN_CASH,
+  DOGE: CHAIN.DOGE,
+  SOL: CHAIN.SOLANA,
 }
 
-const CHAINS = ['BTC', 'ETH']
+const CHAINS = ['BTC', 'ETH', 'AVAXC', 'ARBITRUM', 'BSC', 'TRON', 'LTC', 'BCH', 'DOGE', 'SOL']
 
 const getFetchForChain = (chainShortName: string) => {
   return async (_a: any, _b: any, options: FetchOptions) => {
     const startOfDay = getTimestampAtStartOfDayUTC(options.startOfDay);
-    const feesForChainAndDay = await httpGet(photonBridgeEndpoint.concat(`/dashboard/fees/chain/day?chain=${chainShortName}&timestamp=${startOfDay}`))
+    const feesForChainAndDay = await httpGet(permuteEndpoint.concat(`/dashboard/fees/chain/day?chain=${chainShortName}&timestamp=${startOfDay}`))
 
     let dailyFees = feesForChainAndDay.total_fees
     let dailyRevenue = feesForChainAndDay.electron_fees


### PR DESCRIPTION
##### Name (to be shown on DefiLlama): 
Permute

##### Twitter Link:
https://x.com/permute_finance

##### Website Link:
https://permute.finance/

##### Logo (High resolution, will be shown with rounded borders):
![PFP_BLACK BG (2)](https://github.com/user-attachments/assets/696d5ca9-7d0f-482b-8b82-99caa04e6d61)

##### Short Description (to be shown on DefiLlama):
Permute is a native Bitcoin bridge that enables BTC holders to move liquidity directly into DeFi ecosystems such as Ethereum, Avalanche, Arbitrum, BNB and more at ultra-low fees. Native BTC can finally move seamlessly across chains, unlocking lending, yield, and utility that was once out of reach.

##### Category
Dexs

Update reason ->
1. Protocol name change BitcoinBridge -> Permute
2. Update api endpoint
3. Add more supported chains