### PR TITLE
temp disable aster oi

### DIFF
--- a/dexs/apollox/index.ts
+++ b/dexs/apollox/index.ts
@@ -71,7 +71,8 @@ const fetch = async () => {
   let dailyVolume = await fetchV1Volume();
   const data = await fetchV2Volume();
   dailyVolume += data.dailyVolume;
-  return { dailyVolume, openInterestAtEnd: data.openInterestAtEnd }
+  //return { dailyVolume, openInterestAtEnd: data.openInterestAtEnd }
+  return {dailyVolume}
 }
 
 export default {


### PR DESCRIPTION
Currently OI is found only in 1 endpoint, which is like 1% of total OI, ,so better to not show anything instead of showing heavily different value