### PR TITLE
feat:add support for plasma on balancerv3 volume, fees and revenue

### DIFF
--- a/dexs/balancer-v3/index.ts
+++ b/dexs/balancer-v3/index.ts
@@ -11,6 +11,7 @@ const v3ChainMapping: any = {
   [CHAIN.AVAX]: "AVALANCHE",
   [CHAIN.BASE]: "BASE",
   [CHAIN.HYPERLIQUID]: "HYPEREVM",
+  [CHAIN.PLASMA]: "PLASMA",
 };
 
 async function fetch(options: FetchOptions) {


### PR DESCRIPTION
## Description
This PR adds Plasma chain support to the existing Balancer V3 dexs.

Extended balancer/v3 config with Plasma on `v3ChainMapping`
This enables DefiLlama to track Balancer V3 Volume, Fee and Revenue on the Plasma chain.

## Type of change
 - Add new chain
 - Extend existing dexs function (Balancer V3)

## Checklist
- [X] Added Plasm to dexs/balancer-v3/index.ts, on `v3ChainMapping` const

## Additional context
Plasma explorer: https://plasmascan.to/
Chain ID: 9745
Currency: XPL

## Not a new protocol listing
This PR is not adding a new protocol — just extending an existing adapter.
Therefore, fields such as Twitter, audits, logo, etc. are not applicable.