### PR TITLE
aerodrome pre-launch token bribe revenue

### DIFF
--- a/dexs/aerodrome-slipstream/index.ts
+++ b/dexs/aerodrome-slipstream/index.ts
@@ -4,6 +4,7 @@ import { CHAIN } from "../../helpers/chains";
 import { addOneToken } from '../../helpers/prices';
 import { ethers } from "ethers";
 import PromisePool from "@supercharge/promise-pool";
+import { handleBribeToken } from "../aerodrome/utils";
 
 const CONFIG = {
   factory: '0x5e7BB104d84c7CB9B682AaC2F3d509f5F406809A',
@@ -24,40 +25,6 @@ const abis = {
   fee: 'uint256:fee'
 }
 
-const PRE_LAUNCH_TOKEN_PRICING = {
-  // SYND token configuration
-  '0x11dc28d01984079b7efe7763b533e6ed9e3722b9': {
-    decimals: 18,
-    ticker: 'SYND',
-    conversionRate: 1.5887, // close VWAP price of SYND launch day on Sept 19, 2025
-    cutoffTimestamp: 1758240000, // September 19, 2025 00:00:00 UTC
-    description: 'SYND to USDC conversion at launch VWAP price'
-  }
-  // Future pre-launch tokens can be added here following the same structure:
-  // '0xtoken_address': {
-  //   decimals: decimals of the token,
-  //   conversionRate: price_per_token,
-  //   cutoffTimestamp: unix_timestamp,
-  //   description: 'Token description'
-  // }
-}
-
-const handlePreLaunchTokenConversion = (
-  token: string, 
-  amount: string, 
-  currentTimestamp: number, 
-  dailyBribesRevenue: sdk.Balances
-): boolean => {
-  const tokenConfig = PRE_LAUNCH_TOKEN_PRICING[token.toLowerCase()]
-  if (!tokenConfig) return false
-  if (currentTimestamp >= tokenConfig.cutoffTimestamp) return false
-
-  const targetToken = '0x833589fcd6edb6e08f4c7c32d4f71b54bda02913'
-  const convertedAmount = (BigInt(amount) * BigInt(Math.floor(tokenConfig.conversionRate * (10 ** 6)))) / BigInt(10 ** tokenConfig.decimals)
-
-  dailyBribesRevenue.add(targetToken, convertedAmount.toString())
-  return true
-}
 
 const getBribes = async (fetchOptions: FetchOptions): Promise<{ dailyBribesRevenue: sdk.Balances }> => {
   const { createBalances, getLogs, startTimestamp } = fetchOptions
@@ -81,10 +48,7 @@ const getBribes = async (fetchOptions: FetchOptions): Promise<{ dailyBribesReven
     const amount = parsedLog!.args.amount
     
     // Try to handle pre-launch token conversion
-    const wasConverted = handlePreLaunchTokenConversion(token, amount, startTimestamp, dailyBribesRevenue)
-    if (!wasConverted) {
-      dailyBribesRevenue.add(token, amount)
-    }
+    handleBribeToken(token, amount, startTimestamp, dailyBribesRevenue)
   })
   return { dailyBribesRevenue }
 }

--- a/dexs/aerodrome/index.ts
+++ b/dexs/aerodrome/index.ts
@@ -27,8 +27,43 @@ const abis = {
   fees: 'function getFee(address pool, bool _stable) external view returns (uint256)'
 }
 
+const PRE_LAUNCH_TOKEN_PRICING = {
+  // SYND token configuration
+  '0x11dc28d01984079b7efe7763b533e6ed9e3722b9': {
+    decimals: 18,
+    ticker: 'SYND',
+    conversionRate: 1.5887, // close VWAP price of SYND launch day on Sept 19, 2025
+    cutoffTimestamp: 1758240000, // September 19, 2025 00:00:00 UTC
+    description: 'SYND to USDC conversion at launch VWAP price'
+  }
+  // Future pre-launch tokens can be added here following the same structure:
+  // '0xtoken_address': {
+  //   decimals: decimals of the token,
+  //   conversionRate: price_per_token,
+  //   cutoffTimestamp: unix_timestamp,
+  //   description: 'Token description'
+  // }
+}
+
+const handlePreLaunchTokenConversion = (
+  token: string, 
+  amount: string, 
+  currentTimestamp: number, 
+  dailyBribesRevenue: sdk.Balances
+): boolean => {
+  const tokenConfig = PRE_LAUNCH_TOKEN_PRICING[token.toLowerCase()]
+  if (!tokenConfig) return false
+  if (currentTimestamp >= tokenConfig.cutoffTimestamp) return false
+
+  const targetToken = '0x833589fcd6edb6e08f4c7c32d4f71b54bda02913'
+  const convertedAmount = (BigInt(amount) * BigInt(Math.floor(tokenConfig.conversionRate * (10 ** 6)))) / BigInt(10 ** tokenConfig.decimals)
+
+  dailyBribesRevenue.add(targetToken, convertedAmount.toString())
+  return true
+}
+
 const getBribes = async (fetchOptions: FetchOptions): Promise<{ dailyBribesRevenue: sdk.Balances }> => {
-  const { createBalances, } = fetchOptions
+  const { createBalances, startTimestamp } = fetchOptions
   const iface = new ethers.Interface([eventAbis.event_notify_reward]);
 
   const dailyBribesRevenue = createBalances()
@@ -45,8 +80,16 @@ const getBribes = async (fetchOptions: FetchOptions): Promise<{ dailyBribesReven
     const contract = (log.address || log.source).toLowerCase()
     if (!bribeSet.has(contract)) return;
     const parsedLog = iface.parseLog(log)
-    dailyBribesRevenue.add(parsedLog!.args.reward, parsedLog!.args.amount)
+    const token = parsedLog!.args.reward.toLowerCase()
+    const amount = parsedLog!.args.amount
+    
+    // Try to handle pre-launch token conversion
+    const wasConverted = handlePreLaunchTokenConversion(token, amount, startTimestamp, dailyBribesRevenue)
+    if (!wasConverted) {
+      dailyBribesRevenue.add(token, amount)
+    }
   })
+
   return { dailyBribesRevenue }
 }
 

--- a/dexs/aerodrome/utils.ts
+++ b/dexs/aerodrome/utils.ts
@@ -1,0 +1,26 @@
+import * as sdk from '@defillama/sdk';
+
+export const PRE_LAUNCH_TOKEN_PRICING = {
+  '0x11dc28d01984079b7efe7763b533e6ed9e3722b9': {
+    decimals: 18,
+    conversionRate: 1.5887,
+    cutoffTimestamp: 1758240000
+  }
+}
+
+export const handleBribeToken = (
+  token: string,
+  amount: string,
+  currentTimestamp: number,
+  dailyBribesRevenue: sdk.Balances
+): void => {
+  const tokenConfig = PRE_LAUNCH_TOKEN_PRICING[token.toLowerCase()]
+  
+  if (!tokenConfig || currentTimestamp >= tokenConfig.cutoffTimestamp) {
+    dailyBribesRevenue.add(token, amount)
+    return
+  }
+  
+  const convertedAmount = (Number(amount) * tokenConfig.conversionRate) / (10 ** tokenConfig.decimals)
+  dailyBribesRevenue.addUSDValue(convertedAmount)
+}


### PR DESCRIPTION
the Community Launch program on Aerodrome, with the SYND launch as the first in the queue. That has made a big splash on our revenues and pushed it to an ATH of $18M last epoch.

The way Community Launch works is that, instead of paying a hefty tax (5-10% of the supply + $$$) to CEXs & MMs for listing, projects could fairly and cheaply launch on Aerodrome with the Community Launch program. In the Syndicate case, they merely deposited 1% of their supply as voting incentives for veAERO voters pre-launch, and has since received a significant valuation post launch. Thanks to the good synergy between Aerodrome and SYND, our revenues from the last epoch reached an all time high as well!

https://dune.com/x_drome_analytics/aerodrome-protocol-investor-report

It works like the normal bribing voting rewards & gauge. But pricing of bribe incentives pre-launch needs to be handled differently, as 1) tokens are bribed pre epoch flip 2) no liquidity/prices prior to flip as the token has not been launched 3) Bribe incentives from the epoch of 09-11 should be priced by the hourly TWAPs on 09-18