### PR TITLE
DefiTuna Liquidity fees adapter

### DIFF
--- a/fees/defituna-liquidity/index.ts
+++ b/fees/defituna-liquidity/index.ts
@@ -2,11 +2,11 @@ import fetchURL from "../../utils/fetchURL";
 import { FetchOptions, FetchResult, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 
-const BASE_AMM_URL =
-  "https://api.defituna.com/api/v1/integration/defillama/amm-revenues";
+const BASE_TUNA_URL =
+  "https://api.defituna.com/api/v1/integration/defillama/tuna-revenues";
 
 const getUrl = (startTime: number, endTime: number): string => {
-  return `${BASE_AMM_URL}?from_timestamp=${startTime}&to_timestamp=${endTime}`;
+  return `${BASE_TUNA_URL}?from_timestamp=${startTime}&to_timestamp=${endTime}`;
 };
 
 const fetch = async (options: FetchOptions): Promise<FetchResult> => {
@@ -14,31 +14,27 @@ const fetch = async (options: FetchOptions): Promise<FetchResult> => {
   const response = await fetchURL(url);
 
   return {
-    dailyVolume: response.volumeUsd || 0,
     dailyFees: response.feesUsd || 0,
     dailyUserFees: response.feesUsd || 0,
     dailyRevenue: response.revenuesUsd || 0,
     dailyProtocolRevenue: response.protocolRevenueUsd || 0,
     dailyHoldersRevenue: (response.revenuesUsd - response.protocolRevenueUsd) || 0,
-    dailySupplySideRevenue: (response.feesUsd - response.revenuesUsd) || 0,
   };
 };
 
 const methodology = {
-  Volume: "Total trading volume of the AMM",
-  Fees: "Total amount of fees paid by users on AMM swaps",
+  Fees: "Total fees paid by users of DefiTuna Liquidity services",
   UserFees: "Same as Fees (explicitly denotes fees paid directly by end-users)",
-  Revenue: "Portion of fees retained as AMM protocol revenue (commonly ~10%)",
+  Revenue: "All fees collected by DefiTuna Liquidity are counted as revenue",
   ProtocolRevenue: "Share of revenue allocated to the protocol treasury, determined by its fixed 500M TUNA holdings",
   HoldersRevenue: "Share of revenue distributed to TUNA token holders, proportional to their share of the circulating TUNA supply (excluding the treasury’s 500M)",
-  SupplySideRevenue: "Portion of AMM fees distributed to liquidity providers (LPs), usually ~90%",
 };
 
 const adapter: SimpleAdapter = {
   version: 2,
   fetch,
   chains: [CHAIN.SOLANA],
-  start: "2025-06-03",
+  start: "2024-11-29",
   methodology,
 };
 


### PR DESCRIPTION
Fees adapter for DefiTuna Liquidity (project number 6760 on the server). The adapter pulls the required data from our server’s endpoint. The data is available for an arbitrary time interval. In this project, all fees go directly into revenue, so the values are the same.

I also made some minor changes to the DefiTuna AMM adapter: switched the URL from the dev server to prod and slightly edited the methodology text.