### PR TITLE
track CheapGM

### DIFF
--- a/fees/CheapGM/index.ts
+++ b/fees/CheapGM/index.ts
@@ -8,9 +8,8 @@ const CHAINS = [
   'scroll','mantle','linea','zksync','taiko','blast','mode','zora','metis',
   'cronos','celo','conflux','ronin','lisk',
   'berachain','core','redstone','morph','zircuit',
-  'apechain','ancient8','degen','botanix','mezo','bob','world-chain',
+  'apechain','ancient8','degen','botanix','mezo','bob',
   'abstract','soneium','ink','unichain','plume','gravity','sonic','manta',
-  'polygon-zkevm',
 ] as const;
 
 function buildFetch(chain: string) {


### PR DESCRIPTION
##### Name (to be shown on DefiLlama):
CheapGM

##### Twitter Link:
https://x.com/gmcheap

##### List of audit links if any:
https://app.solidproof.io/projects/cheap-gm

##### Website Link:
https://www.gm.cheap/

##### Logo (High resolution, will be shown with rounded borders):
https://avatars.githubusercontent.com/u/223655668?s=200&v=4

##### Current TVL:
0 (TVL adapter was submitted separately in DefiLlama-Adapters; this PR is only for Revenue)

##### Treasury Addresses (if the protocol has treasury)
0x21ad6eF3979638d8e73747f22B92C4AadE145D82  (same treasury address across EVM chains)

##### Chain:
Base, Optimism, Arbitrum, Ethereum, BSC, Polygon, Scroll, Mantle, Linea, zkSync Era, Taiko, Blast, Mode, Zora, Metis, Cronos, Celo, Conflux, Ronin, Lisk, Berachain, Core, Redstone, Morph, Zircuit, ApeChain, Ancient8, Degen, Botanix, Mezo, BOB, World Chain, Abstract, Soneium, Ink, Unichain, Plume, Gravity, Sonic, Manta Pacific
*(If any slug isn’t supported in Dimensions yet, we’ll remove/rename it during review.)*

##### Coingecko ID:

##### Coinmarketcap ID:


##### Short Description (to be shown on DefiLlama):
GM is a minimalist on-chain “gm/mint” service with referral logic and a fixed fee in the native token. The protocol does not accept deposits (TVL = 0); key metrics are Revenue/Fees.

##### Token address and ticker if any:
N/A

##### Category (full list at https://defillama.com/categories) *Please choose only one:*
Other  *(“Payments” is also acceptable if reviewers prefer.)*

##### Oracle Provider(s) / Implementation / Documentation:
None — the protocol does not use price oracles.

##### forkedFrom (Does your project originate from another project):
No

##### methodology (what is being counted as tvl, how is tvl being calculated):
**Revenue methodology:** we compute `dailyRevenue` as the **daily net inflow** into the treasury address `0x21ad6eF3979638d8e73747f22B92C4AadE145D82` in the **native gas token** of each chain: end-of-day balance minus start-of-day balance. On days with outbound treasury payments, the value will be lower than gross inflows (Fees). This adapter intentionally does not compute `dailyFees` or `dailySupplySideRevenue`; those can be added in a future PR by parsing contract logs (event `GMSent`) and using `tx.value` for gross fees and referral splits. Start date: 2025-08-11.

##### Github org/user (Optional, if your code is open source, we can track activity):
https://github.com/CheapGM