### PR TITLE
Add tokenstore fee tracking

### DIFF
--- a/fees/tokenstore/config.ts
+++ b/fees/tokenstore/config.ts
@@ -1,0 +1,84 @@
+type AccountModifierRecord = {
+    user: string,
+    takerFeeDiscount: number,
+    feeRebate: number,
+    fromBlock: number,
+}
+
+type DefaultModifierRecord = {
+    fromBlock: number,
+    takerFeeDiscount: number,
+    feeRebate: number,
+}
+
+// Certain accounts were granted special fee modifiers
+// Account modifiers contract: 0x6927d2026BefAAd51eB6Cf48A0C612453F46eC09  
+const accountModifiers: AccountModifierRecord[] = [
+    {
+        user: "0xb0C8851D241285F78a8ca7f97bb09252d2387552",
+        takerFeeDiscount: 50,
+        feeRebate: 50,
+        fromBlock: 4646689,
+    },
+    {
+        user: "0xF10488e5C0214001ccF5479AB62F437006d49d00",
+        takerFeeDiscount: 100,
+        feeRebate: 100,
+        fromBlock: 4667712,
+    },
+    {
+        user: "0x67422ED6742cEEE17dB28ef0E3230261c1D1f47c",
+        takerFeeDiscount: 100,
+        feeRebate: 100,
+        fromBlock: 4667722,
+    },
+    {
+        user: "0x139F74f0d8A5ca94c269D5c3E3c453D3385ceA49",
+        takerFeeDiscount: 100,
+        feeRebate: 100,
+        fromBlock: 4667739,
+    },
+    {
+        user: "0x3b19F71B8cA2eac636e0EaFE264A865Bd5467DF6",
+        takerFeeDiscount: 100,
+        feeRebate: 100,
+        fromBlock: 4722361,
+    },
+    {
+        user: "0x0C35303Acf2c11316F4664dADda30Fe0fa682768",
+        takerFeeDiscount: 100,
+        feeRebate: 100,
+        fromBlock: 4722361,
+    },
+]
+
+// Default fee modifiers were applied to all users
+const defaultModifiers: DefaultModifierRecord[] = [
+    {
+        fromBlock: 4257315,
+        takerFeeDiscount: 100,
+        feeRebate: 0,
+    },
+    {
+        fromBlock: 4328554,
+        takerFeeDiscount: 0,
+        feeRebate: 100,
+    },
+    {
+        fromBlock: 4479823,
+        takerFeeDiscount: 0,
+        feeRebate: 0,
+    },
+    {
+        fromBlock: 5339045,
+        takerFeeDiscount: 90,
+        feeRebate: 0,
+    },
+    {
+        fromBlock: 5534354,
+        takerFeeDiscount: 0,
+        feeRebate: 0,
+    },
+]
+
+export { accountModifiers, defaultModifiers };

--- a/fees/tokenstore/index.ts
+++ b/fees/tokenstore/index.ts
@@ -1,0 +1,90 @@
+import { FetchResultV2, FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import { accountModifiers, defaultModifiers } from "./config";
+
+const tokenStore = "0x1cE7AE555139c5EF5A57CC8d814a867ee6Ee33D8"
+
+const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
+
+    const dailyFees = options.createBalances()
+
+    const trades = await options.api.getLogs({
+        target: tokenStore,
+        eventAbi: 'event Trade(address tokenGet, uint amountGet, address tokenGive, uint amountGive, address get, address give, uint nonce)',
+        fromBlock: await options.getFromBlock(),
+        toBlock: await options.getToBlock(),
+    })
+    if (trades.length === 0) return { dailyFees, dailyRevenue: dailyFees }
+
+    // The global fee value was never changed by the owner: 0x44a93F553Bd529c19386b2DDfA30F458B0bc3B20
+    const feePercentage = await options.api.call({
+        target: tokenStore,
+        abi: 'function fee() view returns (uint256)'
+    })
+
+    // Apply fees to each trade while accounting for any fee modifiers
+    trades.forEach((trade: any) => {
+        // Fee is paid in the tokenGet (amountGet)
+        const feeTakeValue = (BigInt(trade.args.amountGet) * BigInt(feePercentage)) / BigInt(1e18)
+
+        let makerAccountRebate = 0
+        let takerAccountDiscount = 0
+        let defaultDiscount = 0
+        let defaultRebate = 0
+
+        // Check if the user (_caller/Give/Taker) has a discount modifier
+        const giveAccountMod = accountModifiers.find(
+            mod => mod.user.toLowerCase() === trade.args.give.toLowerCase() &&
+                mod.fromBlock <= trade.blockNumber
+        )
+        if (giveAccountMod) takerAccountDiscount = giveAccountMod.takerFeeDiscount
+
+        // Check if the user (_user/Get/Maker) has a rebate modifier
+        const getAccountMod = accountModifiers.find(
+            mod => mod.user.toLowerCase() === trade.args.get.toLowerCase() &&
+                mod.fromBlock <= trade.blockNumber
+        )
+        if (getAccountMod) makerAccountRebate = getAccountMod.feeRebate
+
+        const defaultMod = defaultModifiers.find((mod, i) => {
+            const nextBlock = defaultModifiers[i + 1]?.fromBlock || Infinity
+            return mod.fromBlock <= trade.blockNumber && trade.blockNumber < nextBlock
+        })
+        if (defaultMod) {
+            defaultDiscount = defaultMod.takerFeeDiscount
+            defaultRebate = defaultMod.feeRebate
+        }
+
+        // The larger of the two values is always applied when comparing default vs account-specific modifiers
+        const discount = Math.max(defaultDiscount, takerAccountDiscount)
+        const rebate = Math.max(defaultRebate, makerAccountRebate)
+
+        // First apply discount
+        let fee = feeTakeValue
+        fee = (fee * BigInt(100 - discount)) / BigInt(100)
+
+        // Then apply rebate
+        const rebateValue = (fee * BigInt(rebate)) / BigInt(100)
+        const protocolFee = fee - rebateValue
+
+        dailyFees.add(trade.args.tokenGet, protocolFee)
+    })
+
+    return { dailyFees, dailyRevenue: dailyFees }
+}
+
+
+const adapter: SimpleAdapter = {
+    methodology: {
+        Fees: 'Users pay fees on each swap.',
+        Revenue: 'The protocol earns revenue from trading fees.',
+    },
+    version: 2,
+    adapter: {
+        [CHAIN.ETHEREUM]: {
+            fetch: fetch,
+        },
+    },
+};
+
+export default adapter;


### PR DESCRIPTION
**NOTE**

#### Please enable "Allow edits by maintainers" while putting up the PR.

---

> - If you would like to add a `tvl` adapter please submit the PR [here](https://github.com/DefiLlama/DefiLlama-Adapters).

1. Once your adapter has been merged, it takes time to show on the UI. If more than 24 hours have passed, please let us know in Discord.
3. Please fill the form below  **only if the PR is for listing a new protocol** else it can be ignored/replaced with reason/details about the PR
4. **For updating listing info** It is a different repo, you can find your listing in this file: https://github.com/DefiLlama/defillama-server/blob/master/defi/src/protocols/data4.ts, you can  edit it there and put up a PR
5. Do not edit/push `poackage.json/package-lock.json` file as part of your changes
6. No need to go to our discord/other channel and announce that you've created a PR, we monitor all PRs and will review it asap

---

Add fee tracking for [tokenstore]()

Note: The `config.ts` static data is obviously less than ideal, however:
1. The protocol was last active more than 5 years ago ([frontend shutdown](https://x.com/TokenDotStore/status/1267588299243298816) in June 2020).
2. The [owner](https://etherscan.io/address/0x44a93F553Bd529c19386b2DDfA30F458B0bc3B20) hasn't updated these values since 2018.
3. The [AccountModifiers](https://etherscan.io/address/0x6927d2026befaad51eb6cf48a0c612453f46ec09#code) contract doesn't emit any events when these values are updated, so I can't retrieve logs for the transactions.
4. The owner only interacted with the AccountModifiers contract [11 times](https://etherscan.io/address/0x6927d2026befaad51eb6cf48a0c612453f46ec09) (From September 2017 - April 2018).

The protocol is ancient and was popular in 2018, if we can't easily retrieve the AccountModifiers transactions dynamically, then I hope the static object is sufficient.