### PR TITLE
Add datadex revenue tracking

### DIFF
--- a/fees/datadex/index.ts
+++ b/fees/datadex/index.ts
@@ -1,0 +1,16 @@
+import { CHAIN } from '../../helpers/chains';
+import { uniV3Exports } from '../../helpers/uniswap';
+import { SimpleAdapter } from '../../adapters/types';
+
+const methodology = {
+    Fees: "Swap fees collected from users on each trade.",
+    Revenue: "Configurable portion of the swap fees collected from users.",
+    ProtocolRevenue: "When set, the protocol receives a portion of trade fees.",
+};
+
+const adapters: SimpleAdapter = uniV3Exports({
+    [CHAIN.VANA]: { factory: "0xc2a0d530e57B1275fbce908031DA636f95EA1E38", protocolRevenueRatio: 1 / 10 },
+})
+
+adapters.methodology = methodology;
+export default adapters;


### PR DESCRIPTION
**NOTE**

#### Please enable "Allow edits by maintainers" while putting up the PR.

---

> - If you would like to add a `tvl` adapter please submit the PR [here](https://github.com/DefiLlama/DefiLlama-Adapters).

1. Once your adapter has been merged, it takes time to show on the UI. If more than 24 hours have passed, please let us know in Discord.
3. Please fill the form below  **only if the PR is for listing a new protocol** else it can be ignored/replaced with reason/details about the PR
4. **For updating listing info** It is a different repo, you can find your listing in this file: https://github.com/DefiLlama/defillama-server/blob/master/defi/src/protocols/data4.ts, you can  edit it there and put up a PR
5. Do not edit/push `poackage.json/package-lock.json` file as part of your changes
6. No need to go to our discord/other channel and announce that you've created a PR, we monitor all PRs and will review it asap

---


Add revenue tracking for [datadex](https://defillama.com/protocol/datadex)

Note: Some pools have a 0 `feeProtocol` value instead of 170 (10%), but these pools have low volume, so the revenue output was the same.