### PR TITLE
Somnia revenue

### DIFF
--- a/fees/somnia.ts
+++ b/fees/somnia.ts
@@ -7,16 +7,12 @@ const info = {
     methodology: {
         Fees: 'Total SOMI gas fees paid by users (gas usage × gas unit price, after any discounts)',
         Revenue: '50% of total fees are burned',
-        HoldersRevenue: '50% of total fees are burned',
     },
     breakdownMethodology: {
         Fees: {
             [METRIC.TRANSACTION_GAS_FEES]: 'Total SOMI fees paid by users'
         },
         Revenue: {
-            [METRIC.TRANSACTION_GAS_FEES]: '50% share of total SOMI fees will be burned'
-        },
-        HoldersRevenue: {
             [METRIC.TRANSACTION_GAS_FEES]: '50% share of total SOMI fees will be burned'
         },
     }

--- a/helpers/blockscoutFees.ts
+++ b/helpers/blockscoutFees.ts
@@ -161,7 +161,6 @@ export function blockscoutFeeAdapter2(chain: string) {
               timestamp: startOfDay,
               dailyFees,
               dailyRevenue,
-              dailyHoldersRevenue: dailyRevenue
             }
           }
 


### PR DESCRIPTION
According to docs, half of all Somnia fees are burned : https://docs.somnia.network/concepts/tokenomics/gas-fees
