### PR TITLE
fix: aggregators: hyperflow: support router v21

### DIFF
--- a/aggregators/hyperflow/index.ts
+++ b/aggregators/hyperflow/index.ts
@@ -1,39 +1,24 @@
-import {
-    FetchOptions,
-    FetchResult,
-    SimpleAdapter,
-} from "../../adapters/types";
+import { FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
-import { addOneToken } from "../../helpers/prices";
+import { httpGet } from "../../utils/fetchURL";
 
-const SwapExecutedEvent =
-    "event Swapped(address sender, address srcToken, address dstToken, address dstReceiver, uint256 spentAmount, uint256 returnAmount)";
+const STATS_API = "https://api.hyperflow.fun/v1/aggregator/stats/daily"
 
-const ROUTER_AGGREGATOR = "0x980B9271A33c4B31214301fAE584B18dBB9731eC";
+const chainConfig: Record<string, { id: number, start: string }> = {
+  [CHAIN.HYPERLIQUID]: { id: 999, start: '2025-06-08' },
+};
 
-const fetch: any = async (options: FetchOptions): Promise<FetchResult> => {
-    const dailyVolume = options.createBalances();
+const fetch = async (_a: any, _b: any, options: FetchOptions) => {
+  const url = `${STATS_API}?chainId=${chainConfig[options.chain].id}&timestamps=${options.startOfDay}`;
+  const dailyVolume = (await httpGet(url)).data?.volumes?.[0].value;
 
-    // Get Swapped events for volume
-    const swapLogs = await options.getLogs({
-        target: ROUTER_AGGREGATOR,
-        eventAbi: SwapExecutedEvent,
-    });
-    for (const swapLog of swapLogs) {
-        addOneToken({ chain: options.chain, balances: dailyVolume, token0: swapLog.srcToken, amount0: swapLog.spentAmount, token1: swapLog.dstToken, amount1: swapLog.returnAmount })
-    }
-
-    return { dailyVolume };
+  return { dailyVolume };
 };
 
 const adapter: SimpleAdapter = {
-    version: 2,
-    fetch,
-    start: "2025-06-08",
-    methodology: {
-        Volume: "Volume is calculated from Swapped events emitted by the HyperFlow aggregator contract.",
-    },
-    chains: [CHAIN.HYPERLIQUID],
+  version: 1,
+  fetch,
+  adapter: chainConfig
 };
 
 export default adapter;


### PR DESCRIPTION
Dear DefiLlama Team,

We have updated HyperFlow to support the new router contract (v21) for partner integration. We would like to submit changes that enable volume tracking for both the existing router (v2) and the new router (v21). Thank you for your support.

Note: HyperFlow volume API has the same format with KyberSwap volume API.