### PR TITLE
Feat: update volume for FlowX Perps

### DIFF
--- a/dexs/flowx-perps/index.ts
+++ b/dexs/flowx-perps/index.ts
@@ -3,15 +3,15 @@ import { CHAIN } from "../../helpers/chains";
 import fetchURL from "../../utils/fetchURL";
 
 const fetch = async ({ fromTimestamp, toTimestamp }: FetchOptions) => {
-  const volume = await fetchURL(`https://api.flowx.finance/flowx-be/api/perp-tracking/volume-in-timerange?startTime=${fromTimestamp * 1000}&endTime=${toTimestamp * 1000}`);
+  const dailyVolume = await fetchURL(`https://api.flowx.finance/flowx-be/api/perp-tracking/volume-in-timerange?startTime=${fromTimestamp * 1000}&endTime=${toTimestamp * 1000}`);
 
-  return { dailyVolume: volume };
+  return { dailyVolume };
 };
 
 const adapter: SimpleAdapter = {
   version: 2,
   fetch,
-  chains: [CHAIN.SUI],
+  chains: [CHAIN.HYPERLIQUID],
   start: "2025-10-01",
 };
 


### PR DESCRIPTION
Hey guys,
We would like to update more volume for FlowX Perps.
We prefer this url like that: https://defillama.com/protocol/flowx-perp.
The perp volume should be in FlowX protocol: https://defillama.com/protocol/flowx-finance

With perp volume we use hyperliquid as liquidity source, so you don't need to include volume to total volume.

Thank for reviewing my PR <3
