### PR TITLE
add aquifer dex in the style of tesserav, humidifi

### DIFF
--- a/dexs/aquifer/index.ts
+++ b/dexs/aquifer/index.ts
@@ -4,7 +4,7 @@ import { Dependencies, FetchOptions, SimpleAdapter } from "../../adapters/types"
 import { CHAIN } from "../../helpers/chains"
 import { queryDuneSql } from "../../helpers/dune"
 
-const fetch = async (_a:any, _b:any, options: FetchOptions) => {
+const fetch = async (_a: any, _b: any, options: FetchOptions) => {
     const query = `
         with swaps as (
             select
@@ -28,15 +28,17 @@ const fetch = async (_a:any, _b:any, options: FetchOptions) => {
     const data = await queryDuneSql(options, query)
 
     return {
-        dailyVolume: data[0]?.daily_volume ?? 0
+        dailyVolume: Number(data[0].daily_volume) || 0
     }
 }
 
 const adapter: SimpleAdapter = {
+    version: 1,
     fetch,
-    dependencies: [Dependencies.DUNE],
     chains: [CHAIN.SOLANA],
-    start: '2025-09-09',
+    dependencies: [Dependencies.DUNE],
+    isExpensiveAdapter: true,
+    start: '2025-09-07',
 }
 
 export default adapter


### PR DESCRIPTION
**NOTE**

#### Please enable "Allow edits by maintainers" while putting up the PR.

---

> - If you would like to add a `tvl` adapter please submit the PR [here](https://github.com/DefiLlama/DefiLlama-Adapters).

1. Once your adapter has been merged, it takes time to show on the UI. If more than 24 hours have passed, please let us know in Discord.
3. Please fill the form below  **only if the PR is for listing a new protocol** else it can be ignored/replaced with reason/details about the PR
4. **For updating listing info** It is a different repo, you can find your listing in this file: https://github.com/DefiLlama/defillama-server/blob/master/defi/src/protocols/data4.ts, you can  edit it there and put up a PR
5. Do not edit/push `poackage.json/package-lock.json` file as part of your changes
6. No need to go to our discord/other channel and announce that you've created a PR, we monitor all PRs and will review it asap

---
##### Name (to be shown on DefiLlama): 
Aquifer

##### Twitter Link:
http://twitter.com/_aquifer_


##### List of audit links if any: private audit 

##### Website Link:


##### Logo (High resolution, will be shown with rounded borders):


##### Current TVL:
![aquifer](https://github.com/user-attachments/assets/87d0b563-ca86-43cb-985b-5d7030a0185d)


##### Treasury Addresses (if the protocol has treasury)


##### Chain: 
Solana


##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed): (https://api.coingecko.com/api/v3/coins/list)


##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)


##### Short Description (to be shown on DefiLlama):
Aquifer DEX

##### Token address and ticker if any:


##### Category (full list at https://defillama.com/categories) *Please choose only one:


##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.):
##### Implementation Details: Briefly describe how the oracle is integrated into your project:
##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage:

##### forkedFrom (Does your project originate from another project):


##### methodology (what is being counted as tvl, how is tvl being calculated):

Very simple query of dune in spot transaction volume exactly like Tessera and Humidifi


##### Github org/user (Optional, if your code is open source, we can track activity):

All tests passing:

```bash
> adapters@1.0.0 test
> ts-node --transpile-only cli/testAdapter.ts dexs aquifer

🦙 Running AQUIFER adapter 🦙
---------------------------------------------------
Start Date:	Wed, 15 Oct 2025 00:00:00 GMT
End Date:	Thu, 16 Oct 2025 00:00:00 GMT
---------------------------------------------------

waiting for query id 3996608 to complete...
waiting for query id 3996608 to complete...
waiting for query id 3996608 to complete...
waiting for query id 3996608 to complete...
waiting for query id 3996608 to complete...
waiting for query id 3996608 to complete...
waiting for query id 3996608 to complete...
waiting for query id 3996608 to complete...
waiting for query id 3996608 to complete...
waiting for query id 3996608 to complete...
waiting for query id 3996608 to complete...
waiting for query id 3996608 to complete...
waiting for query id 3996608 to complete...
waiting for query id 3996608 to complete...
waiting for query id 3996608 to complete...
waiting for query id 3996608 to complete...
waiting for query id 3996608 to complete...
waiting for query id 3996608 to complete...
waiting for query id 3996608 to complete...
waiting for query id 3996608 to complete...
waiting for query id 3996608 to complete...
waiting for query id 3996608 to complete...
SOLANA 👇
Backfill start time: 9/9/2025
Daily volume: 107.59 M
```

matches raw dune last 24h query
<img width="931" height="833" alt="image" src="https://github.com/user-attachments/assets/2562b972-6da2-41bb-953a-ba3da51a84cb" />

Directly the same adaptater as Tessera and Humidii (probably others)