### PR TITLE
Add Lithos Dex adapter with Uni-V2 fees and bribe revenue collection

### DIFF
--- a/dexs/lithos/index.ts
+++ b/dexs/lithos/index.ts
@@ -2,6 +2,7 @@
 import { FetchOptions, FetchV2, SimpleAdapter } from "../../adapters/types";
 import { getUniV2LogAdapter } from "../../helpers/uniswap";
 import { CHAIN } from "../../helpers/chains";
+import PromisePool from "@supercharge/promise-pool";
 
 const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
 const VOLATILE_FEE = 0.0025; // 25 bps


### PR DESCRIPTION
Introduce a new adapter for the Lithos Dex that supports Uni-V2 fees and implements functionality for collecting bribe revenue. This enhances the revenue tracking capabilities for users interacting with the Lithos protocol.