### PR TITLE
fix paradex oi

### DIFF
--- a/open-interest/paradex.ts
+++ b/open-interest/paradex.ts
@@ -4,19 +4,12 @@ import { CHAIN } from "../helpers/chains";
 
 // const historicalVolumeEndpoint = (market: string, start: number, end: number) => `https://api.prod.paradex.trade/v1/markets/summary?market=${market}&start=${start}&end=${end}`
 // historicalVolumeEndpoint also has the OI data, but its very heavy endpoint
-const marketsEndpoint = "https://api.prod.paradex.trade/v1/markets"
-const marketsSummaryEndpoint = (market: string) => `https://api.prod.paradex.trade/v1/markets/summary?market=${market}`
+const marketsSummaryEndpoint = "https://api.prod.paradex.trade/v1/markets/summary?MARKET=ALL"
 
 const fetch = async (_a: FetchOptions) => {
-  const markets = (await fetchURL(marketsEndpoint)).results
-  console.log(markets.length)
+  const markets = (await fetchURL(marketsSummaryEndpoint)).results;
 
-  let openInterestAtEnd = 0
-  for (const market of markets) {
-    if (market.asset_kind !== 'PERP') continue
-    const openInterest = (await fetchURL(marketsSummaryEndpoint(market.symbol))).results[0]
-    openInterestAtEnd += Number(openInterest.open_interest) * Number(openInterest.mark_price)
-  }
+  const openInterestAtEnd = markets.reduce((acc: number, market: any) => acc + +(market.open_interest || 0) * +(market.underlying_price||0),0);
 
   return { openInterestAtEnd }
 };


### PR DESCRIPTION
I think there is no need to separate perp_options as they are more of perps than options (the same reason why paradex options was removed from defillama)