### PR TITLE
Hybra-v4 fee integrated

### DIFF
--- a/dexs/hybra-v4.ts
+++ b/dexs/hybra-v4.ts
@@ -1,11 +1,11 @@
-import { SimpleAdapter } from "../adapters/types";
+import { FetchOptions, SimpleAdapter } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
-import { getUniV3LogAdapter } from "../helpers/uniswap";
 import { addOneToken } from "../helpers/prices";
 import { request } from "graphql-request";
 
-const poolCreatedEvent = 'event PoolCreated(address indexed token0, address indexed token1, int24 indexed tickSpacing, address pool)'
 const swapEvent = 'event Swap(address indexed sender, address indexed recipient, int256 amount0, int256 amount1, uint160 sqrtPriceX96, uint128 liquidity, int24 tick)'
+
+const FACTORY = '0x32b9dA73215255d50D84FeB51540B75acC1324c2';
 
 const FEE_SUBGRAPH_URL = 'https://api.goldsky.com/api/public/project_cmbj707z4cd9901sib1f6cu0c/subgraphs/fee-setting/fee-setting/gn';
 
@@ -33,9 +33,62 @@ interface SetCustomFee {
 	block_number: string;
 }
 
-const customLogic = async ({ pairObject, dailyVolume, filteredPairs, fetchOptions }: any) => {
-	const { api, getLogs, chain, createBalances } = fetchOptions;
-	const poolAddresses = Object.keys(filteredPairs);
+async function fetch(options: FetchOptions) {
+	const allPoolsLength = await options.api.call({
+		target: FACTORY,
+		abi: 'uint256:allPoolsLength',
+	});
+	const allPoolsCalls: any = [];
+	for (let i = 0; i < Number(allPoolsLength); i++) {
+		allPoolsCalls.push({ params: [i] })
+	}
+	const allPools = await options.api.multiCall({
+		target: FACTORY,
+		abi: 'function allPools(uint) view returns (address)',
+		calls: allPoolsCalls,
+	});
+
+	const token0Addresses = await options.api.multiCall({ abi: 'address:token0', calls: allPools });
+	const token1Addresses = await options.api.multiCall({ abi: 'address:token1', calls: allPools });
+
+	const pairObject: Record<string, Array<string>> = {}
+	for (let i = 0; i < Number(allPoolsLength); i++) {
+		pairObject[allPools[i]] = [
+			token0Addresses[i],
+			token1Addresses[i],
+		]
+	}
+
+	const allLogs = await options.getLogs({
+		targets: allPools,
+		eventAbi: swapEvent,
+		flatten: false
+	});
+
+	const dailyVolume = options.createBalances();
+	allLogs.forEach((logs, index) => {
+		if (!logs.length) return;
+		const pool = allPools[index];
+		const [token0, token1] = pairObject[pool];
+
+		for (const log of logs) {
+			addOneToken({
+				chain: options.chain,
+				balances: dailyVolume,
+				token0,
+				token1,
+				amount0: log.amount0.toString(),
+				amount1: log.amount1.toString()
+			});
+		}
+	})
+
+	return await customLogic({ pairObject, dailyVolume, allLogs, fetchOptions: options })
+}
+
+const customLogic = async ({ pairObject, dailyVolume, allLogs, fetchOptions }: any) => {
+	const { api, chain, createBalances } = fetchOptions;
+	const poolAddresses = Object.keys(pairObject);
 
 	// 1. Get all SetCustomFee events from GraphQL to track fee history
 	const query = `
@@ -93,15 +146,8 @@ const customLogic = async ({ pairObject, dailyVolume, filteredPairs, fetchOption
 		}
 	});
 
-	// 4. Get swap events
+	// 4. Process each swap with the correct historical fee
 	const dailyFees = createBalances();
-	const allLogs = await getLogs({
-		targets: poolAddresses,
-		eventAbi: swapEvent,
-		flatten: false
-	});
-
-	// 5. Process each swap with the correct historical fee
 	allLogs.forEach((logs: any, index: number) => {
 		if (!logs.length) return;
 		const pool = poolAddresses[index];
@@ -147,7 +193,7 @@ const customLogic = async ({ pairObject, dailyVolume, filteredPairs, fetchOption
 const adapter: SimpleAdapter = {
 	version: 2,
 	methodology: {
-		Volume: 'Total swap volume collected from factory 0x32b9dA73215255d50D84FeB51540B75acC1324c2',
+		Volume: `Total swap volume collected from factory ${FACTORY}`,
 		Fees: 'Users paid dynamic fees per swap.',
 		UserFees: 'Users paid dynamic fees per swap.',
 		Revenue: '25% swap fees collected by protocol Treasury.',
@@ -156,12 +202,7 @@ const adapter: SimpleAdapter = {
 	},
 	start: '2025-10-17',
 	chains: [CHAIN.HYPERLIQUID],
-	fetch: getUniV3LogAdapter({
-		factory: '0x32b9dA73215255d50D84FeB51540B75acC1324c2',
-		poolCreatedEvent,
-		swapEvent,
-		customLogic
-	}),
+	fetch,
 }
 
 export default adapter


### PR DESCRIPTION

When integrating dimension-adapters for hybra-v4, I got this error:

Error: No pairs found, is there TVL adapter for this already?

The TVL adapter (DefiLlama-Adapters) was working fine a few days ago.

Notes
	•	hybra-v4 uses dynamic fees — the fee rate changes in real time, but the swap event doesn’t emit the fee value.
	•	Would it be fine if I query the current fee on-chain for each swap event? Or is there a better approach to handle dynamic fees efficiently?
	•	For v2/v3 I used The Graph for pool data, but since it was replaced by getUniV3LogAdapter, I’m not sure if Graph is still allowed for v4.

Any guidance on this would be appreciated!