### PR TITLE
feat: add vii-finance volume and fees

### DIFF
--- a/fees/vii-finance.ts
+++ b/fees/vii-finance.ts
@@ -8,6 +8,7 @@ const curatorConfig: CuratorConfig = {
   },
   vaults: {
     [CHAIN.UNICHAIN]: {
+      start: '2025-09-01',
       eulerVaultOwners: [
         '0x12e74f3C61F6b4d17a9c3Fdb3F42e8f18a8bB394',
       ],


### PR DESCRIPTION

- TVL is already being tracked at: https://defillama.com/protocol/vii-finance
- This PR is to track the volume and fees generated by the uniswap v4 pools with [yield harvesting hook](https://docs.vii.finance/Architecture/yield-harvesting-hook). 