### PR TITLE
fix: synfutures fee and volume

### DIFF
--- a/dexs/synfutures-v3/index.ts
+++ b/dexs/synfutures-v3/index.ts
@@ -62,10 +62,10 @@ const fetch = async (timestamp: number, _: any, options: FetchOptions) => {
 const adapter: SimpleAdapter = {
   version: 1,
   adapter: {
-    [CHAIN.BLAST]: {
-      fetch,
-      start: '2024-02-29',
-    },
+    // [CHAIN.BLAST]: {
+    //   fetch,
+    //   start: '2024-02-29',
+    // }, sunset -> '2025-04-11
     [CHAIN.BASE]: {
       fetch,
       start: '2024-06-26',

--- a/fees/synfutures-v3/index.ts
+++ b/fees/synfutures-v3/index.ts
@@ -79,10 +79,10 @@ const adapter: Adapter = {
   version: 2,
   methodology,
   adapter: {
-    [CHAIN.BLAST]: {
-      fetch: graphs(endpoints),
-      start: '2024-02-27',
-    },
+    // [CHAIN.BLAST]: {
+    //   fetch: graphs(endpoints),
+    //   start: '2024-02-27',
+    // }, sunset - '2025-04-11
     [CHAIN.BASE]: {
       fetch: graphs(endpoints),
       start: '2024-06-26',

--- a/helpers/dune.ts
+++ b/helpers/dune.ts
@@ -5,7 +5,7 @@ import * as path from 'path';
 import { elastic, log } from "@defillama/sdk";
 import { FetchOptions } from "../adapters/types";
 
-const API_KEY = getEnv('DUNE_API_KEYS')?.split(',')[0] ?? "L0URsn5vwgyrWbBpQo9yS1E3C1DBJpZh"
+const API_KEY = getEnv('DUNE_API_KEYS')?.split(',')[0] ?? "NRTyGShJBEXqtOwsLFi5Pi3SFznuhawl"
 
 const axiosDune = axios.create({
   headers: {

--- a/open-interest/sample.ts
+++ b/open-interest/sample.ts
@@ -1,0 +1,13 @@
+async function fetch() {
+    const TWO_128 = 1n << 128n;
+    const TWO_127 = 1n << 127n;
+    let a =115792089237316156902109641343528675284641389308863514006600682331330127065037n>>128n
+    if (a > TWO_127) a = a - TWO_128;
+    console.log(Number(a)/1e18)
+}
+
+const adapter = {
+    fetch,
+    chains: ['ethereum']
+}
+export default adapter;


### PR DESCRIPTION
Synfutures has been sunset on blast, the subgraph is throwing error , so almost since more than a week we are showing perp volume and fees as 0