### PR TITLE
update fees calculation for privacy cash

### DIFF
--- a/fees/privacy-cash/index.ts
+++ b/fees/privacy-cash/index.ts
@@ -5,7 +5,8 @@ import { queryDuneSql } from "../../helpers/dune";
 const fetch = async (_a: any, _b: any, options: FetchOptions) => {
   const query = `
     select 
-      sum(case when balance_change/power(10, 9) > 0 then balance_change/power(10, 9) end) as deposits
+      sum(case when balance_change/power(10, 9) > 0 then balance_change/power(10, 9) end) as deposits,
+      count(case when balance_change/power(10, 9) > 0 then 1 end) as deposit_count
     from solana.account_activity
     where address = '4AV2Qzp3N4c9RfzyEbNZs2wqWfW4EwKnnxFAZCndvfGh'
     and block_time > TIMESTAMP '2025-08-15 00:00:00 UTC' 
@@ -13,8 +14,9 @@ const fetch = async (_a: any, _b: any, options: FetchOptions) => {
   `
   const result = await queryDuneSql(options, query);
   const dailyFees = options.createBalances();
-  dailyFees.addCGToken('solana', Number(result[0].deposits) * (0.0025));
-
+  const depositVolume = Number(result[0].deposits) * 0.0035;
+  const depositCount = Number(result[0].deposit_count) * 0.006;
+  dailyFees.addCGToken('solana', depositVolume + depositCount);
   return {
     dailyFees,
     dailyUserFees: dailyFees,
@@ -25,9 +27,9 @@ const fetch = async (_a: any, _b: any, options: FetchOptions) => {
 }
 
 const methodology = {
-  Fees: "0.25% Fee on each private transaction",
-  Revenue: "0.25% Fee on each private transaction",
-  ProtocolRevenue: "0.25% Fee on each private transaction",
+  Fees: "0.35% + 0.006 SOL on each withdrawal",
+  Revenue: "0.35% + 0.006 SOL on each withdrawal",
+  ProtocolRevenue: "0.35% + 0.006 SOL on each withdrawal",
 }
 
 const adapter: Adapter = {


### PR DESCRIPTION
Current fees are outdated for Privacy Cash.

If you go to their app (https://privacycash.org/), connect your wallet, enter an amount, and you'll clearly see the fees are (0.35%  + 0.006 SOL) on withdrawals.

<img width="458" height="375" alt="Screenshot 2025-10-29 at 10 04 28 AM" src="https://github.com/user-attachments/assets/bc46e288-1d44-4ac1-9314-3700209f1e93" />
