### PR TITLE
fix: improve adapter to correctly calculate holders revenue

### DIFF
--- a/dexs/balancer-v3/index.ts
+++ b/dexs/balancer-v3/index.ts
@@ -11,14 +11,24 @@ const v3ChainMapping: any = {
   [CHAIN.AVAX]: "AVALANCHE",
   [CHAIN.BASE]: "BASE",
   [CHAIN.HYPERLIQUID]: "HYPEREVM",
+  [CHAIN.PLASMA]: "PLASMA",
 };
+
+const HOLDERS_SHARE_OF_PROTOCOL = 0.825;
+
+const n = (x: any) => (Number.isFinite(Number(x)) ? Number(x) : 0);
 
 async function fetch(options: FetchOptions) {
   const dailyVolume = options.createBalances();
   const dailyFees = options.createBalances();
   const dailyUserFees = options.createBalances();
-  const dailyRevenue = options.createBalances();
+
+  const dailyProtocolRevenueGross = options.createBalances();
   const dailySupplySideRevenue = options.createBalances();
+
+  const dailyHoldersRevenue = options.createBalances();
+  const dailyProtocolRevenueNet = options.createBalances();
+  const dailyRevenue = options.createBalances();
 
   const query = `query {
   pools: poolGetPools(
@@ -43,23 +53,57 @@ async function fetch(options: FetchOptions) {
   }
 }`;
   const { pools } = await request("https://api-v3.balancer.fi/graphql", query);
-  pools.forEach((pool: any) => {
-    dailyVolume.addUSDValue(+pool.dynamicData.volume24h);
 
-    dailyFees.addUSDValue(+pool.dynamicData.fees24h, METRIC.SWAP_FEES);
-    dailyUserFees.addUSDValue(+pool.dynamicData.fees24h, METRIC.SWAP_FEES);
-    dailyRevenue.addUSDValue(+(pool.dynamicData.fees24h * 0.5), METRIC.SWAP_FEES); // 50% of fees go to the protocol
-    dailySupplySideRevenue.addUSDValue(+pool.dynamicData.fees24h * 0.5, METRIC.SWAP_FEES); // 50% of fees goes to the supply side
-    
+  let protocolGrossSum = 0;
+  let supplySideSum = 0;
+  pools.forEach((pool: any) => {
+    const fees24h = n(pool?.dynamicData?.fees24h);
+    const vol24h = n(pool?.dynamicData?.volume24h);
+    const yield24h = n(pool?.dynamicData?.yieldCapture24h);
+
+    dailyVolume.addUSDValue(vol24h);
+
+    dailyFees.addUSDValue(fees24h, METRIC.SWAP_FEES);
+    dailyUserFees.addUSDValue(fees24h, METRIC.SWAP_FEES);
+
+    dailyProtocolRevenueGross.addUSDValue(fees24h * 0.5, METRIC.SWAP_FEES);
+    dailySupplySideRevenue.addUSDValue(fees24h * 0.5, METRIC.SWAP_FEES); // 50% of fees goes to the supply side
+
+    protocolGrossSum += fees24h * 0.5;
+    supplySideSum += fees24h * 0.5;
+
     // subgraph error on hyperlqiuid yields
     if (options.chain !== CHAIN.HYPERLIQUID) {
-      dailyFees.addUSDValue(+pool.dynamicData.yieldCapture24h, METRIC.ASSETS_YIELDS);
-      dailyRevenue.addUSDValue(+(pool.dynamicData.yieldCapture24h * 0.1), METRIC.ASSETS_YIELDS); // 10% of yield capture goes to the protocol
-      dailySupplySideRevenue.addUSDValue(+pool.dynamicData.yieldCapture24h * 0.9, METRIC.ASSETS_YIELDS); // 90% of yield capture goes to the supply side
+      dailyFees.addUSDValue(yield24h, METRIC.ASSETS_YIELDS);
+      dailyProtocolRevenueGross.addUSDValue(
+        +(yield24h * 0.1),
+        METRIC.ASSETS_YIELDS
+      ); // 10% of yield capture goes to the protocol
+      dailySupplySideRevenue.addUSDValue(yield24h * 0.9, METRIC.ASSETS_YIELDS); // 90% of yield capture goes to the supply side
+
+      protocolGrossSum += yield24h * 0.1;
+      supplySideSum += yield24h * 0.9;
     }
   });
 
-  return { dailyFees, dailyUserFees, dailyVolume, dailyRevenue, dailyProtocolRevenue: dailyRevenue, dailySupplySideRevenue };
+  const holdersUSD = protocolGrossSum * HOLDERS_SHARE_OF_PROTOCOL;
+  const protocolNetUSD = protocolGrossSum - holdersUSD;
+
+  if (holdersUSD > 0) dailyHoldersRevenue.addUSDValue(holdersUSD);
+  if (protocolNetUSD > 0) dailyProtocolRevenueNet.addUSDValue(protocolNetUSD);
+
+  dailyRevenue.addBalances(dailyHoldersRevenue);
+  dailyRevenue.addBalances(dailyProtocolRevenueNet);
+
+  return {
+    dailyFees,
+    dailyUserFees,
+    dailyVolume,
+    dailyRevenue,
+    dailyProtocolRevenue: dailyProtocolRevenueNet,
+    dailyHoldersRevenue,
+    dailySupplySideRevenue,
+  };
 }
 
 const adapter: SimpleAdapter = {
@@ -70,31 +114,45 @@ const adapter: SimpleAdapter = {
   methodology: {
     Fees: "Fees earned from all the trades and yields.",
     UserFees: "Fees earned from all the trades.",
-    Revenue: "Revenue earned by the protocol, which is 50% of the trade fees and 10% of the yield capture.",
-    ProtocolRevenue: "Revenue earned by the protocol, which is 50% of the trade fees and 10% of the yield capture.",
-    SupplySideRevenue: "Revenue earned by the supply side, which is 90% of the yield capture and 50% of the fees.",
+    Revenue:
+      "Revenue earned by the protocol, which is 50% of the trade fees and 10% of the yield capture.",
+    ProtocolRevenue:
+      "Revenue earned by the protocol, which is 50% of the trade fees and 10% of the yield capture.",
+    HoldersRevenue:
+      "Portion of protocol revenue distributed to token holders (e.g., veBAL/BAL), parameterized here.",
+    SupplySideRevenue:
+      "Revenue earned by the supply side, which is 90% of the yield capture and 50% of the fees.",
   },
   breakdownMethodology: {
     Fees: {
-      [METRIC.SWAP_FEES]: 'Swap fees paid by users from all trades.',
-      [METRIC.ASSETS_YIELDS]: 'Yields captured from all assets in liquity pools.',
+      [METRIC.SWAP_FEES]: "Swap fees paid by users from all trades.",
+      [METRIC.ASSETS_YIELDS]:
+        "Yields captured from all assets in liquity pools.",
     },
     UserFees: {
-      [METRIC.SWAP_FEES]: 'Swap fees paid by users from all trades.',
+      [METRIC.SWAP_FEES]: "Swap fees paid by users from all trades.",
     },
     Revenue: {
-      [METRIC.SWAP_FEES]: '50% of swap fees paid by users from all trades.',
-      [METRIC.ASSETS_YIELDS]: '10% of yields captured from all assets in liquity pools.',
+      [METRIC.SWAP_FEES]: "50% of swap fees paid by users from all trades.",
+      [METRIC.ASSETS_YIELDS]:
+        "10% of yields captured from all assets in liquity pools.",
     },
     ProtocolRevenue: {
-      [METRIC.SWAP_FEES]: '50% of swap fees paid by users from all trades.',
-      [METRIC.ASSETS_YIELDS]: '10% of yields captured from all assets in liquity pools.',
+      [METRIC.SWAP_FEES]: "50% of swap fees paid by users from all trades.",
+      [METRIC.ASSETS_YIELDS]:
+        "10% of yields captured from all assets in liquity pools.",
+    },
+    HoldersRevenue: {
+      [METRIC.SWAP_FEES]: "Share of protocol revenue sent to token holders.",
+      [METRIC.ASSETS_YIELDS]:
+        "Share of protocol revenue from yield capture sent to token holders.",
     },
     SupplySideRevenue: {
-      [METRIC.SWAP_FEES]: '50% of swap fees paid by users from all trades.',
-      [METRIC.ASSETS_YIELDS]: '90% of yields captured from all assets in liquity pools.',
+      [METRIC.SWAP_FEES]: "50% of swap fees paid by users from all trades.",
+      [METRIC.ASSETS_YIELDS]:
+        "90% of yields captured from all assets in liquity pools.",
     },
-  }
+  },
 };
 
 export default adapter;


### PR DESCRIPTION
## Description

This PR fixes the Balancer V3 adapter, improving the holder revenue calculations to compute the values correctly.

## Type of change

Iterate throw protocol and supply side fees, so the `dailyHoldersRevenue` can compute the values correctly.

```typescript

// For each blockchain, sum the fees according to the weight of each participant (protocol or supply side).
    protocolGrossSum += fees24h * 0.5;
    supplySideSum += fees24h * 0.5;

    if (options.chain !== CHAIN.HYPERLIQUID) {
      protocolGrossSum += yield24h * 0.1;
      supplySideSum += yield24h * 0.9;
  }

```

## Checklist

- [X] Add `dailyHoldersRevenue` to metrics;
- [X] Better description for compute process of all values (revenue, fees,...)
