### PR TITLE
Add SparkDEX Perps Volume and Fees Adapters

### DIFF
--- a/dexs/sparkdex-perps/index.ts
+++ b/dexs/sparkdex-perps/index.ts
@@ -1,0 +1,61 @@
+import { gql, request } from "graphql-request";
+import {
+  SimpleAdapter,
+  FetchResultVolume,
+} from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import { getTimestampAtStartOfDayUTC } from "../../utils/date";
+
+const endpoint = "https://api.goldsky.com/api/public/project_cm1tgcbwdqg8b01un9jf4a64o/subgraphs/sparkdex-trade/latest/gn";
+
+interface IVolumeStat {
+  cumulativeVolumeUsd: string;
+  volumeUsd: string;
+  id: string;
+}
+
+const fetch = async (timestamp: number): Promise<FetchResultVolume> => {
+  const todaysTimestamp = getTimestampAtStartOfDayUTC(timestamp);
+
+  const graphQuery = gql`
+    query MyQuery {
+      volumeStats(where: {timestamp: ${todaysTimestamp}, period: "daily"}) {
+        cumulativeVolumeUsd
+        id
+        volumeUsd
+      }
+    }
+  `;
+
+  const response = await request(endpoint, graphQuery);
+  const volumeStats: IVolumeStat[] = response.volumeStats;
+
+  let dailyVolumeUSD = BigInt(0);
+
+  volumeStats.forEach((vol) => {
+    dailyVolumeUSD += BigInt(vol.volumeUsd);
+  });
+
+  const finalDailyVolume = parseInt(dailyVolumeUSD.toString()) / 1e18;
+
+  return {
+    dailyVolume: finalDailyVolume.toString(),
+    timestamp: todaysTimestamp,
+  };
+};
+
+const methodology = {
+  dailyVolume: "Total daily trading volume from all perpetual markets on SparkDEX",
+};
+
+const adapter: SimpleAdapter = {
+  adapter: {
+    [CHAIN.FLARE]: {
+      fetch,
+      start: '2024-11-05',
+    },
+  },
+};
+
+export default adapter;
+

--- a/fees/sparkdex-perps/index.ts
+++ b/fees/sparkdex-perps/index.ts
@@ -1,0 +1,76 @@
+import { gql, request } from "graphql-request";
+import { Adapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import { getTimestampAtStartOfDayUTC } from "../../utils/date";
+
+const endpoint = "https://api.goldsky.com/api/public/project_cm1tgcbwdqg8b01un9jf4a64o/subgraphs/sparkdex-trade/latest/gn";
+
+interface IFeeStat {
+  cumulativeFeeUsd: string;
+  feeUsd: string;
+  id: string;
+}
+
+interface ITradingStat {
+  fundingFeeUsd: string;
+  id: string;
+}
+
+const fetch = async (timestamp: number) => {
+  const todaysTimestamp = getTimestampAtStartOfDayUTC(timestamp);
+  const period = "daily";
+
+  const graphQuery = gql`{
+    feeStats(where: {timestamp: ${todaysTimestamp}, period: "${period}"}) {
+      id
+      timestamp
+      period
+      cumulativeFeeUsd
+      feeUsd
+    }
+    tradingStats(where: {timestamp: ${todaysTimestamp}, period: "${period}"}) {
+      id
+      fundingFeeUsd
+    }
+  }`;
+
+  const response = await request(endpoint, graphQuery);
+  const feeStats: IFeeStat[] = response.feeStats;
+  const tradingStats: ITradingStat[] = response.tradingStats;
+
+  let dailyFeeUSD = BigInt(0);
+  let dailyFundingFeeUSD = BigInt(0);
+
+  // Sum up trading fees from feeStats
+  feeStats.forEach((fee) => {
+    dailyFeeUSD += BigInt(fee.feeUsd);
+  });
+
+  // Sum up funding fees from tradingStats
+  tradingStats.forEach((stat) => {
+    dailyFundingFeeUSD += BigInt(stat.fundingFeeUsd);
+  });
+
+  // Total fees = trading fees + funding fees
+  const totalFeeUSD = dailyFeeUSD + dailyFundingFeeUSD;
+  const finalDailyFee = parseInt(totalFeeUSD.toString()) / 1e18;
+
+  return {
+    timestamp: todaysTimestamp,
+    dailyFees: finalDailyFee,
+  };
+};
+
+const adapter: Adapter = {
+  version: 1,
+  adapter: {
+    [CHAIN.FLARE]: {
+      fetch,
+    },
+  },
+  start: '2024-11-05',
+  methodology: "Fees collected from user trading fees and funding fees on SparkDEX perpetual markets",
+};
+
+export default adapter;
+


### PR DESCRIPTION
# Add SparkDEX Perps Volume and Fees Adapters

## Summary
This PR adds volume and fees adapters for SparkDEX perpetual trading protocol on Flare chain.

## Changes
- ✅ Added volume adapter at `dexs/sparkdex-perps/index.ts`
- ✅ Added fees adapter at `fees/sparkdex-perps/index.ts`

## Details

### Volume Adapter
- Queries `volumeStats` from the SparkDEX trade subgraph
- Aggregates daily trading volume across all perpetual markets
- Converts BigInt values to USD (dividing by 1e18)

### Fees Adapter
- Queries both `feeStats` and `tradingStats` from the SparkDEX trade subgraph
- Aggregates trading fees from `feeStats.feeUsd`
- Aggregates funding fees from `tradingStats.fundingFeeUsd`
- Combines both fee types to calculate total daily fees

## Subgraph Information
- **Endpoint**: `https://api.goldsky.com/api/public/project_cm1tgcbwdqg8b01un9jf4a64o/subgraphs/sparkdex-trade/latest/gn`
- **Chain**: Flare
- **Start Date**: 2024-11-05

## Testing
Both adapters have been tested and verified:
- ✅ Volume adapter successfully queries and aggregates volume data
- ✅ Fees adapter successfully queries and aggregates both trading and funding fees
- ✅ All GraphQL queries return expected data structure
- ✅ BigInt to USD conversion works correctly

## Methodology
- **Volume**: Total daily trading volume from all perpetual markets on SparkDEX
- **Fees**: Trading fees (from feeStats) + Funding fees (from tradingStats) collected on SparkDEX perpetual markets

