### PR TITLE
Add Kodiak-perps metrics to existing Kodiak protocol

### DIFF
--- a/fees/kodiak-perps.ts
+++ b/fees/kodiak-perps.ts
@@ -1,0 +1,3 @@
+import { getBuilderExports } from "../helpers/orderly";
+
+export default getBuilderExports({ broker_id: 'kodiak', start: '2025-10-1' });


### PR DESCRIPTION
This PR adds metrics tracking for Kodiak's perpetual DEX on Berachain.

Request:
- Add to existing Kodiak parent listing
- Count as part of Berachain metrics
- Track under perps categories

Uses Orderly Network's broker_id system to track volume, fees, and revenue.