### PR TITLE
Add two new DEXs (GateFun and GateSwap) on GateLayer chain.

### DIFF
--- a/dexs/gatefun/index.ts
+++ b/dexs/gatefun/index.ts
@@ -3,7 +3,7 @@ import { CHAIN } from "../../helpers/chains";
 
 
 const CONTRACTS: Record<string, string> = {
-  [CHAIN.GATELAYER]: "0x7C8FbD15E4c8B722920C1570A4704622D5391113",
+  [CHAIN.GATE_LAYER]: "0x7C8FbD15E4c8B722920C1570A4704622D5391113",
 };
 
 const EVENT_TRADE =
@@ -29,7 +29,7 @@ const adapter: SimpleAdapter = {
 	Volume: 'Total swap volume collected from gatefun contract 0x7C8FbD15E4c8B722920C1570A4704622D5391113',
   },
   start: '2025-09-27',
-  chains: [CHAIN.GATELAYER],
+  chains: [CHAIN.GATE_LAYER],
   fetch,
 }
 

--- a/dexs/gateswap/index.ts
+++ b/dexs/gateswap/index.ts
@@ -8,7 +8,7 @@ const adapter: SimpleAdapter = {
 		Volume: 'Total swap volume collected from factory 0xaD8d59f3e026c02Aed0DAdFB46Ceca127030DFa2',
 	},
 	start: '2025-09-27',
-	chains: [CHAIN.GATELAYER],
+	chains: [CHAIN.GATE_LAYER],
 	fetch: getUniV2LogAdapter({ 
         factory: '0xaD8d59f3e026c02Aed0DAdFB46Ceca127030DFa2', 
         fees: 0, 

--- a/helpers/chains.ts
+++ b/helpers/chains.ts
@@ -278,7 +278,6 @@ export enum CHAIN {
   MEZO = "mezo",
   ETHEREAL = "ethereal",
   FLUENCE = "fluence",
-  GATELAYER = "gatelayer",
   MONAD = "monad",
   SKALE = "skale",
 }


### PR DESCRIPTION
Add two new DEXs (GateFun and GateSwap) on GateLayer chain.

### GateFun
- Volume calculated from Trade events
- Token amounts converted to USD using internal price API

### GateSwap
- Using helpers/uniswap/getUniV2LogAdapter
- The getUniV2LogAdapter method has been enhanced with a configurable frequency-limiting capability, preserving its existing behavior.

Ready for review.