### PR TITLE
fix galaswap volume and fees

### DIFF
--- a/dexs/galaswap-v3.ts
+++ b/dexs/galaswap-v3.ts
@@ -21,14 +21,18 @@ async function fetch(_: any, _2: any, _3: FetchOptions) {
   return {
     dailyVolume: data.volume,
     dailyFees: data.fees,
-    dailySupplySideRevenue: data.fees
+    dailyRevenue:0,
+    dailySupplySideRevenue: data.fees,
+    dailyProtocolRevenue: 0,
   }
 }
 
 const methodology = {
   Fees: "Swap fees paid by users",
+  Revenue: "No revenue",
   Volume: "Galaswap trade volume",
-  SupplySideRevenue: "All the fees goes to liquidity providers"
+  SupplySideRevenue: "All the fees goes to liquidity providers",
+  ProtocolRevenue: "No protocol revenue",
 };
 
 export default {


### PR DESCRIPTION
We are reporting way higher numbers than what is displayed on their UI. (https://swap.gala.com/explore) (76M vs 334K)
Probably due to their api bug 