### PR TITLE
Fix volume not working for flash, Depreacate Community.3

### DIFF
--- a/dexs/flashtrade/index.ts
+++ b/dexs/flashtrade/index.ts
@@ -12,6 +12,9 @@ const pools = [
     "Community.2",
     "Trump.1",
     "Ore.1",
+    
+    // keep historical pools
+    "Community.3",
 ]
 
 const fetch = async (_a: any, _b: any, options: FetchOptions) => {

--- a/fees/flashtrade.ts
+++ b/fees/flashtrade.ts
@@ -29,6 +29,9 @@ const pools = [
   "Community.2",
   "Trump.1",
   "Ore.1",
+  
+  // keep historical pools
+  "Community.3",
 ]
 
 const fetch = async (_a: any, _b: any, options: FetchOptions): Promise<FetchResultFees> => {
@@ -80,6 +83,7 @@ const fetch = async (_a: any, _b: any, options: FetchOptions): Promise<FetchResu
       "Governance.1": 0.30,
       "Community.1": 0.00,
       "Community.2": 0.00,
+      "Community.3": 0.05,
       "Trump.1": 0.05,
       "Ore.1": 0.10,
     };


### PR DESCRIPTION
This PR fixes the issue where volume is not calculated incase any of the HTTP requests fails. 

1. Deprecates Community.3 pool
2. Adds Ore.1 pool
3. Continue when an API call returns a unexpected response.