### PR TITLE
Update Nabla Finance: Add HyperEVM and Monad

### DIFF
--- a/dexs/nabla/index.ts
+++ b/dexs/nabla/index.ts
@@ -239,5 +239,13 @@ export default {
             fetch,
             start: "2025-05-14",
         },
+        [CHAIN.HYPERLIQUID]: {
+            fetch,
+            start: "2025-11-19",
+        },
+        [CHAIN.MONAD]: {
+            fetch,
+            start: "2025-11-24",
+        },
     },
 } as Adapter;


### PR DESCRIPTION
**Summary**
This PR extends Nabla Finance's DEX adapter to support two new blockchain networks: HyperEMV and Monad.

Feel free to visit: https://app.nabla.fi/


**Changes**

- Added HyperEMV support with registry contract, routers, pools, and assets (UETH, UBTC, USDT, WHYPE)

- Added Monad support with registry contract, routers, pools, and assets (WETH, USDC, WBTC, WMON)