### PR TITLE
pingu exchange : remove arbitrum

### DIFF
--- a/dexs/pingu/index.ts
+++ b/dexs/pingu/index.ts
@@ -11,18 +11,13 @@ interface IGraph {
 	id: string;
 }
 
-const ARBITRUM_URL = 'https://api.studio.thegraph.com/query/75208/pingu-arb-2/0.0.1/';
-const ARBITRUM_ASSETS = [ADDRESSES.arbitrum.USDC_CIRCLE, ADDRESSES.null];
-
+// G3dQNfEnDw4q3bn6QRSJUmcLzi7JKTDGYGWwPeYWYa6X
 const MONAD_URL = 'https://api.studio.thegraph.com/query/75208/pingu-mon/0.0.2/';
+
 const MONAD_USDC = "0x754704Bc059F8C67012fEd69BC8A327a5aafb603";
 const MONAD_ASSETS = [MONAD_USDC, ADDRESSES.null];
 
 const CONFIGS: Record<string, any> = {
-  [CHAIN.ARBITRUM]: {
-    graph: ARBITRUM_URL,
-    assets: ARBITRUM_ASSETS,
-  },
   [CHAIN.MONAD]: {
     graph: MONAD_URL,
     assets: MONAD_ASSETS,
@@ -59,10 +54,6 @@ const fetch = async (timestamp: number, _: any, { chain, createBalances }: Fetch
 
 const adapter: SimpleAdapter = {
 	adapter: {
-		[CHAIN.ARBITRUM]: {
-			fetch: fetch,
-			start: '2024-01-10',
-		},
 		[CHAIN.MONAD]: {
 			fetch: fetch,
 			start: '2025-11-24',


### PR DESCRIPTION
We have finally decided to delete the Arbitrum data because we have sunset and the protocol is no longer active on the chain.