### PR TITLE
Use on-chain pool fees for Blackhole AMM fee calculations

### DIFF
--- a/dexs/blackhole.ts
+++ b/dexs/blackhole.ts
@@ -41,12 +41,8 @@ const fetch: FetchV2 = async (fetchOptions) => {
   });
   const fees = await api.multiCall({
     abi: 'function getFee(address,bool) view returns (uint256)',
-    calls: pairIds.map((pairId, i) => {
-      return {
-        target: Factory,
-        params: [pairId, stable[i]],
-      }
-    }),
+    target: Factory,
+    calls: pairIds.map((pairId, i) => ({ params: [pairId, stable[i]] })),
     permitFailure: false,
   });
   const lpSupplies = await api.multiCall({
@@ -56,12 +52,8 @@ const fetch: FetchV2 = async (fetchOptions) => {
   });
   const gauges = await api.multiCall({
     abi: 'function gauges(address) view returns (address)',
-    calls: pairIds.map(pairid => {
-      return {
-        target: GaugeManager,
-        params: [pairid],
-      }
-    }),
+    target: GaugeManager,
+    calls: pairIds.map(pairid => ({ params: [pairid] })),
     permitFailure: true,
   });
   const gaugeSupplies = await api.multiCall({


### PR DESCRIPTION
The current Blackhole AMM implementation calculates fee and revenue metrics by applying a fixed 0.3% fee to all swaps. This is incorrect, as each Blackhole AMM pool has a specific fee configured on-chain. So the current implementation underestimates the fees for pools that have a higher fee and overestimates fees for pools that have a lower fee. This pull request fixes that by retrieving the actual on-chain pool fee and using that in the fee and revenue calculations.

### Changes
* Removed the `SwapFee` variable with the hardcoded 0.3% fee.
* Added a multicall to retrieve the `stable` status for each pool.
* Added a multicall to retrieve the pool fee for each pool by calling the `getFee(address,stable)` method on the Factory contract.
* Use the actual pool fee in the fee and revenue calculations. On-chain fees are scaled by 10_000, so the code takes that into account.
* Small style cleanup by changing a couple of `fetchOptions.api.multiCall` calls to `api.multiCall`.

### Tests
I used the following test command to get the numbers for a couple of different days and compared them to the numbers mentioned on the Blackhole statistics page:

`ts-node --transpile-only cli/testAdapter.ts dexs blackhole 2025-11-23`

The output of this command before applying my fix:
```
> adapters@1.0.0 test
> ts-node --transpile-only cli/testAdapter.ts dexs blackhole 2025-11-23

🦙 Running BLACKHOLE adapter 🦙
---------------------------------------------------
Start Date:	Sat, 22 Nov 2025 00:00:00 GMT
End Date:	Sun, 23 Nov 2025 00:00:00 GMT
---------------------------------------------------

AVAX 👇
Daily volume: 1.26 M
Daily fees: 3.77 k
Daily user fees: 3.77 k
Daily revenue: 3.74 k
Daily supply side revenue: 27.00
Daily protocol revenue: 0.00
Daily holders revenue: 3.74 k
End timestamp: 1763855999 (2025-11-22T23:59:59.000Z)
```

And the output of this command after my fix:

```
> adapters@1.0.0 test
> ts-node --transpile-only cli/testAdapter.ts dexs blackhole 2025-11-23

🦙 Running BLACKHOLE adapter 🦙
---------------------------------------------------
Start Date:	Sat, 22 Nov 2025 00:00:00 GMT
End Date:	Sun, 23 Nov 2025 00:00:00 GMT
---------------------------------------------------

AVAX 👇
Daily volume: 1.24 M
Daily fees: 7.79 k
Daily user fees: 7.79 k
Daily revenue: 7.73 k
Daily supply side revenue: 61.00
Daily protocol revenue: 0.00
Daily holders revenue: 7.73 k
End timestamp: 1763855999 (2025-11-22T23:59:59.000Z)
```

As you can see, the fees and revenue increased. This is what I expected, as most AMM pools on Blackhole have a fee of 0.5% or 0.7%.

The fees still don't match the numbers reported by Blackhole on their own statistics page. For example, the fees reported by them for the day of the examples above are $14,260. It is not clear which methodology they use on their statistics page, but there can be a number of reasons for this mismatch (different day boundaries, pricing calculations, etc). However, the changes in this pull request objectively improve the numbers that will be shown on DefiLlama by using actual pool fees in the calculations and not a fixed 0.3% fee for all pools.