### PR TITLE
fix: update antfun adapter to support USDC/USDT stablecoin fees

### DIFF
--- a/fees/antfun.ts
+++ b/fees/antfun.ts
@@ -8,53 +8,90 @@ import { queryDuneSql } from "../helpers/dune";
 const fetch: any = async (_a: any, _b: any, options: FetchOptions) => {
   const dailyFees = options.createBalances();
 
+  const FEE_ADDRESSES = [
+    'DXoA7ESQY9jcSTkvqt3rzaDtdAhVp9gbAFPMrcrTFpoF',
+    '4tbYi6gzbEyktazkQuexC5PZvga2NMwtjLVUcT3Cu1th',
+    'G3atyMmJHhE7wY8Xer5c12tGD5ZBxPrzAWvAXa6vrba',
+    'DL11UP6KeoSkXCN42fig9o4VMGhDFQhjmupDduwkXioU',
+    'DBJrXX66XNXDiDuTqG9j1kGJ4z1spgZ4y8ATzi1pLmMs'
+  ];
+
+  const feeAddressesList = FEE_ADDRESSES.map(addr => `'${addr}'`).join(', ');
+
   const query = `
     WITH
     allFeePayments AS (
-      SELECT
+      -- USDC fees from token transfers
+      SELECT DISTINCT
         tx_id,
-        balance_change AS fee_token_amount
+        amount AS fee_token_amount,
+        '${ADDRESSES.solana.USDC}' AS token_mint_address
+      FROM
+        tokens_solana.transfers
+      WHERE
+        TIME_RANGE
+        AND to_owner IN (${feeAddressesList})
+        AND token_mint_address = '${ADDRESSES.solana.USDC}'
+        AND amount > 0
+
+      UNION ALL
+
+      -- USDT fees from token transfers
+      SELECT DISTINCT
+        tx_id,
+        amount AS fee_token_amount,
+        '${ADDRESSES.solana.USDT}' AS token_mint_address
+      FROM
+        tokens_solana.transfers
+      WHERE
+        TIME_RANGE
+        AND to_owner IN (${feeAddressesList})
+        AND token_mint_address = '${ADDRESSES.solana.USDT}'
+        AND amount > 0
+
+      UNION ALL
+
+      -- SOL fees from account activity (if any)
+      SELECT DISTINCT
+        tx_id,
+        balance_change AS fee_token_amount,
+        '${ADDRESSES.solana.SOL}' AS token_mint_address
       FROM
         solana.account_activity
       WHERE
         TIME_RANGE
-        AND address in (
-          'DXoA7ESQY9jcSTkvqt3rzaDtdAhVp9gbAFPMrcrTFpoF',
-          '4tbYi6gzbEyktazkQuexC5PZvga2NMwtjLVUcT3Cu1th',
-          'G3atyMmJHhE7wY8Xer5c12tGD5ZBxPrzAWvAXa6vrba',
-          'DL11UP6KeoSkXCN42fig9o4VMGhDFQhjmupDduwkXioU',
-          'DBJrXX66XNXDiDuTqG9j1kGJ4z1spgZ4y8ATzi1pLmMs'
-        )
+        AND address IN (${feeAddressesList})
         AND tx_success
         AND balance_change > 0
     ),
     botTrades AS (
       SELECT
         trades.tx_id,
-        MAX(fee_token_amount) AS fee
+        feePayments.token_mint_address,
+        MAX(feePayments.fee_token_amount) AS fee
       FROM
         dex_solana.trades AS trades
         JOIN allFeePayments AS feePayments ON trades.tx_id = feePayments.tx_id
       WHERE
         TIME_RANGE
-        AND trades.trader_id not in (
-          'DXoA7ESQY9jcSTkvqt3rzaDtdAhVp9gbAFPMrcrTFpoF',
-          '4tbYi6gzbEyktazkQuexC5PZvga2NMwtjLVUcT3Cu1th',
-          'G3atyMmJHhE7wY8Xer5c12tGD5ZBxPrzAWvAXa6vrba',
-          'DL11UP6KeoSkXCN42fig9o4VMGhDFQhjmupDduwkXioU',
-          'DBJrXX66XNXDiDuTqG9j1kGJ4z1spgZ4y8ATzi1pLmMs'
-        )
-      GROUP BY trades.tx_id
+        AND trades.trader_id NOT IN (${feeAddressesList})
+      GROUP BY trades.tx_id, feePayments.token_mint_address
     )
     SELECT
-      SUM(fee) AS fee
+      token_mint_address,
+      SUM(fee) AS total_fees
     FROM
       botTrades
+    GROUP BY token_mint_address
   `;
 
   const fees = await queryDuneSql(options, query);
-  const feeAmount = fees && fees.length > 0 && fees[0].fee ? fees[0].fee : 0;
-  dailyFees.add(ADDRESSES.solana.SOL, feeAmount);
+  
+  fees.forEach((row: any) => {
+    if (row.token_mint_address && row.total_fees) {
+      dailyFees.add(row.token_mint_address, row.total_fees);
+    }
+  });
 
   return { dailyFees, dailyRevenue: dailyFees, }
 }


### PR DESCRIPTION
## Summary
Fix antfun adapter to correctly track USDC/USDT stablecoin fees instead of SOL.

## Issue
The initial antfun adapter (#4734) was tracking SOL fees, but AntFun primarily uses stablecoins (USDC/USDT) for trading, not SOL.

## Changes
- Updated query to track USDC fees from token transfers
- Updated query to track USDT fees from token transfers  
- Support multi-token fee tracking (USDC, USDT, and SOL if applicable)
- Group fees by token type for accurate reporting

## Important Note
**AntFun primarily uses stablecoins (USDC/USDT) for trading, not SOL.** This fix ensures the adapter correctly tracks the actual fee tokens used by the protocol.

## Testing
Adapter can be tested with:
```bash
pnpm test fees antfun
```

**Please enable "Allow edits by maintainers" for this PR.**