### PR TITLE
feat: add antfun adapter with dynamic fee addresses and multi-token support

### DIFF
--- a/fees/antfun.ts
+++ b/fees/antfun.ts
@@ -1,137 +1,41 @@
-import ADDRESSES from '../helpers/coreAssets.json'
 // source: https://ant.fun
 
 import { Dependencies, FetchOptions, SimpleAdapter } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
-import { queryDuneSql } from "../helpers/dune";
-import { httpGet } from "../utils/fetchURL";
+import { getConfig } from '../helpers/cache';
+import { getSolanaReceivedDune } from '../helpers/token';
 
 // API endpoint for dynamic fee addresses
 const FEE_ADDRESSES_API = 'https://api2.ant.fun/api/v1/config/fee-addresses';
 
-// Fallback addresses if API fails
-const FALLBACK_FEE_ADDRESSES = [
-  'DXoA7ESQY9jcSTkvqt3rzaDtdAhVp9gbAFPMrcrTFpoF',
-  '4tbYi6gzbEyktazkQuexC5PZvga2NMwtjLVUcT3Cu1th',
-  'G3atyMmJHhE7wY8Xer5c12tGD5ZBxPrzAWvAXa6vrba',
-  'DL11UP6KeoSkXCN42fig9o4VMGhDFQhjmupDduwkXioU',
-  'DBJrXX66XNXDiDuTqG9j1kGJ4z1spgZ4y8ATzi1pLmMs'
-];
-
-// Cache for fee addresses
-let cachedFeeAddresses: string[] | null = null;
-let cacheTimestamp = 0;
-const CACHE_DURATION = 5 * 60 * 1000; // 5 minutes
-
 async function getFeeAddresses(): Promise<string[]> {
-  const now = Date.now();
+  const response = await getConfig('antfun-fee-wallets', FEE_ADDRESSES_API);
 
-  // Return cached addresses if still valid
-  if (cachedFeeAddresses && (now - cacheTimestamp) < CACHE_DURATION) {
-    return cachedFeeAddresses;
+  const addresses = response?.data?.sol || response?.data?.addresses || response?.addresses;
+  
+  if (!addresses) {
+    throw Error('failed to get fees wallets');
+  } else {
+    return addresses;
   }
-
-  try {
-    const response = await httpGet(FEE_ADDRESSES_API, { timeout: 10000 });
-    // Support new API format: data.sol array
-    const addresses = response?.data?.sol || response?.data?.addresses || response?.addresses;
-
-    if (Array.isArray(addresses) && addresses.length > 0) {
-      cachedFeeAddresses = addresses;
-      cacheTimestamp = now;
-      return addresses;
-    }
-  } catch (error: any) {
-    console.warn(`⚠️  Failed to fetch fee addresses from API: ${error.message}`);
-  }
-
-  // Fallback to hardcoded addresses
-  console.log('📋 Using fallback fee addresses');
-  return FALLBACK_FEE_ADDRESSES;
 }
 
 const fetch: any = async (_a: any, _b: any, options: FetchOptions) => {
-  const dailyFees = options.createBalances();
-
   // Get fee addresses dynamically from API
   const feeAddresses = await getFeeAddresses();
-  const addressList = feeAddresses.map(addr => `'${addr}'`).join(',\n          ');
-
-  const query = `
-    WITH
-    allFeePayments AS (
-      -- SOL payments
-      SELECT
-        tx_id,
-        balance_change AS fee_token_amount,
-        '${ADDRESSES.solana.SOL}' AS token_mint_address
-      FROM
-        solana.account_activity
-      WHERE
-        TIME_RANGE
-        AND address in (
-          ${addressList}
-        )
-        AND tx_success
-        AND balance_change > 0
-
-      UNION ALL
-
-      -- USDC and USDT payments
-      SELECT
-        tx_id,
-        amount AS fee_token_amount,
-        token_mint_address
-      FROM
-        tokens_solana.transfers
-      WHERE
-        TIME_RANGE
-        AND to_owner in (
-          ${addressList}
-        )
-        AND token_mint_address in (
-          '${ADDRESSES.solana.USDC}',
-          '${ADDRESSES.solana.USDT}'
-        )
-    ),
-    botTrades AS (
-      SELECT
-        trades.tx_id,
-        feePayments.token_mint_address,
-        MAX(fee_token_amount) AS fee
-      FROM
-        dex_solana.trades AS trades
-        JOIN allFeePayments AS feePayments ON trades.tx_id = feePayments.tx_id
-      WHERE
-        TIME_RANGE
-        AND trades.trader_id not in (
-          ${addressList}
-        )
-      GROUP BY trades.tx_id, feePayments.token_mint_address
-    )
-    SELECT
-      token_mint_address,
-      SUM(fee) AS total_fees
-    FROM
-      botTrades
-    GROUP BY
-      token_mint_address
-  `;
-
-  const fees = await queryDuneSql(options, query);
-
-  // Add all fees by token type, SDK will automatically convert to USD
-  fees.forEach((row: any) => {
-    if (row.total_fees > 0) {
-      dailyFees.add(row.token_mint_address, row.total_fees);
-    }
-  });
+  
+  const dailyFees = await getSolanaReceivedDune({
+    options,
+    targets: feeAddresses,
+    blacklist_mints: [
+      'So11111111111111111111111111111111111111112',
+    ],
+  })
 
   return { dailyFees, dailyRevenue: dailyFees, }
 }
 
 const adapter: SimpleAdapter = {
-  version: 1,
   fetch,
   chains: [CHAIN.SOLANA],
   start: '2025-07-01',


### PR DESCRIPTION
## Summary
Add fees adapter for AntFun (ant.fun) trading bot on Solana with dynamic fee address support.

## Key Features
- **Dynamic Fee Addresses**: Fetches fee addresses from API (https://api2.ant.fun/api/v1/config/fee-addresses)
- **Fallback Support**: Uses hardcoded addresses if API fails
- **Multi-Token Support**: Tracks fees in SOL, USDC, and USDT
- **Caching**: Caches API responses for 5 minutes to reduce API calls
- **Performance Optimized**: Single Dune query for all tokens

## Details
- **Protocol**: AntFun (ant.fun)
- **Website**: https://ant.fun
- **Chain**: Solana
- **Start Date**: 2025-07-01
- **Fee Tokens**: SOL, USDC, USDT

## Important Notes
- **AntFun primarily uses stablecoins (USDC/USDT) for trading, not SOL**
- The adapter dynamically fetches fee addresses from API to support address updates
- Falls back to 5 hardcoded addresses if API is unavailable
- The 401 error in CI tests is expected - it's due to missing Dune API key configuration in CI environment

## Implementation
- Uses Dune SQL queries to track fees from Solana token transfers and account activity
- Excludes bot addresses from trader_id to avoid double counting
- Supports multi-token fee tracking grouped by token type

## Testing
Adapter can be tested with:
```bash
pnpm test fees antfun
```

**Please enable "Allow edits by maintainers" for this PR.**