### PR TITLE
Track spaace

### DIFF
--- a/fees/spaace/index.ts
+++ b/fees/spaace/index.ts
@@ -52,7 +52,7 @@ const adapter: SimpleAdapter = {
   version: 2,
   fetch,
   chains: [CHAIN.ETHEREUM],
-  start: '2025-09-01',
+  start: '2023-07-27',
   methodology
 }
 


### PR DESCRIPTION
Update the start date to 2023.7.27
Actually our marketplace started at 2025.9.1
However defillama graph is using wrong data from 2024. So I am updating the start date to 2023 for refreshing the graph.
If you have another approach for refreshing the graph, you can take it.
Thanks