### PR TITLE
feat(myriadmarkets): add BSC chain support

### DIFF
--- a/fees/myriadmarkets/index.ts
+++ b/fees/myriadmarkets/index.ts
@@ -4,6 +4,7 @@ import { CHAIN } from "../../helpers/chains";
 const MARKETS = {
   [CHAIN.ABSTRACT]: '0x3e0F5F8F5Fb043aBFA475C0308417Bf72c463289',
   [CHAIN.LINEA]: '0x39e66ee6b2ddaf4defded3038e0162180dbef340',
+  [CHAIN.BSC]: '0x39e66ee6b2ddaf4defded3038e0162180dbef340',
 }
 
 const abi = {
@@ -94,6 +95,7 @@ const adapter: SimpleAdapter = {
   adapter: {
     [CHAIN.ABSTRACT]: { start: '2025-07-06', },
     [CHAIN.LINEA]: { start: '2025-08-01', },
+    [CHAIN.BSC]: { start: '2025-10-29', }
   },
   methodology
 };


### PR DESCRIPTION
## feat(myriadmarkets): add BSC chain support

## Summary
Myriad Markets has deployed on BSC using the same core market contract address as on Linea.  
This PR adds BSC support to the fees adapter by extending `MARKETS` and the adapter config to include BSC.

## Changes
- Added `CHAIN.BSC` entry to `MARKETS`, using the verified contract:
  `0x39e66ee6b2ddaf4defded3038e0162180dbef340`
- Added corresponding `start` date for BSC.
- No logic, ABI, or methodology changes were required.

## Methodology
Same as Abstract and Linea:
- Enumerate all markets via `getMarkets()`
- Fetch market metadata using `getMarketAltData()`
- Fetch fee structures using `getMarketFees()`
- Aggregate buy/sell fees, supply-side revenue, and protocol revenue from `MarketActionTx` logs

On BSC, the underlying token returned by the contract is:
`0x55d398326f99059fF775485246999027B3197955` (USDT)

## Tests
Locally ran:
```bash
pnpm test fees myriadmarkets
```

Abstract and Linea chains run successfully.
BSC:
	•State calls (getMarkets, getMarketAltData, getMarketFees) all work correctly and return expected values.
	•Historical log scanning fails on local public RPC endpoints due to BSC pruning (missing trie node, state at block is pruned).


## Notes

BSC fees support is ready and fully aligned with existing Myriad chains.
Local RPC limitations are the only reason BSC doesn’t pass the full local test.