### PR TITLE
Fix volume in Polymarket to prevent double-counting of taker+maker vol

### DIFF
--- a/dexs/polymarket/index.ts
+++ b/dexs/polymarket/index.ts
@@ -60,6 +60,7 @@ const fetch = async (_a: any, _b: any, options: FetchOptions) => {
         where b.evt_block_number > 50505492
             and evt_block_time >= from_unixtime(${options.startTimestamp})
             and evt_block_time < from_unixtime(${options.endTimestamp})
+
         UNION ALL
 
         SELECT
@@ -86,10 +87,7 @@ const fetch = async (_a: any, _b: any, options: FetchOptions) => {
             )
             AND pl.block_number >= 4023680
             AND pl.contract_address in (
-                SELECT
-                *
-                FROM
-                markets
+                SELECT * FROM markets
             )
             and pl.block_time >= from_unixtime(${options.startTimestamp})
             and pl.block_time < from_unixtime(${options.endTimestamp})
@@ -99,7 +97,10 @@ const fetch = async (_a: any, _b: any, options: FetchOptions) => {
   options.api.log(data);
 
   const dailyVolume = options.createBalances();
-  dailyVolume.addUSDValue(data[0].total_volume_usd);
+
+  // Polymarket emits two OrderFilled events per trade (maker + taker), so summing them directly double-counts volume. Dividing by 2 converts this into true one-sided volume. This also normalizes swaps and merge/split fills, where maker and taker amounts can differ but still represent the same underlying trade, preventing inflated totals
+
+  dailyVolume.addUSDValue(data[0].total_volume_usd / 2);
 
   return { dailyVolume }
 }


### PR DESCRIPTION
Polymarket emits an OrderFilled event for both sides of every trade - one reflecting the maker’s perspective and one reflecting the taker’s. If we sum these events directly, every trade is counted twice. Dividing the total by 2 converts this into a correct one-sided volume that reflects the actual economic size of trades. This adjustment is also important for swaps and merge/split operations: in these cases the maker and taker may have different asset movements or token amounts, but they still represent a single matched trade. Without dividing by 2, these complex fills would artificially inflate volume. By normalizing this way, we ensure consistent, accurate volume reporting across all trade types