### PR TITLE
added fee adapter for donut

### DIFF
--- a/fees/donut/index.ts
+++ b/fees/donut/index.ts
@@ -46,10 +46,10 @@ const adapter: SimpleAdapter = {
   chains: [CHAIN.BASE],
   start: '2025-11-07',
   methodology: {
-    Fees: 'Fees collected from the miner',
-    Revenue: 'Revenue collected from the treasury',
-    ProtocolRevenue: 'Protocol revenue',
-    SupplySideRevenue: 'Supply side revenue',
+    Fees: 'mining 5% frontend fee',
+    Revenue: 'Fees going to the treasury',
+    ProtocolRevenue: 'Mining fees going to the protocol',
+    SupplySideRevenue: 'fees earned by miners',
   }
 };
 


### PR DESCRIPTION
##### Name:

Donut

##### Twitter Link:

https://x.com/Glaze_Corp

##### List of audit links if any:



##### Website Link:

https://www.glazecorp.io/

##### Logo :

https://www.glaze.click/logo.jpg

##### Current TVL:

~$642k (Pooled DONUT ~ 618,523 {$321K} and Pooled WETH ~102.70 {$321K})

##### Treasury Addresses (if the protocol has treasury)

##### Chain:

Base

##### Coingecko ID:

##### Coinmarketcap ID:

##### Short Description (to be shown on DefiLlama):

Donut is a decentralized mining protocol on Base where users spend ETH to mine DONUT tokens. The protocol features a rotating "King Glazer" mechanism, automated difficulty adjustments, and a treasury system.

##### Token address and ticker if any:

DONUT: 0xAE4a37d554C6D6F3E398546d8566B25052e0169C

##### Category:

Onchain Capital Allocator

##### Oracle Provider(s):

None (Protocol uses internal pricing mechanism based on time-decay auctions)

##### Implementation Details:

The protocol uses a Dutch auction mechanism for mining, where the price to mine decays over time within an epoch.

##### Documentation/Proof:

https://www.glaze.click/learn

##### forkedFrom:

None

##### methodology:

TVL counts the tokens locked in the Miner contract, Multicall contract, and the Liquidity Pool (Uniswap V2). Fees are calculated based on the ETH spent by miners to mint DONUT. Revenue is the portion of fees sent to the Treasury.

##### Github org/user:

https://github.com/0xedev

##### Does this project have a referral program?

Yes, each mining frontend takes 5% of the fee.

