### PR TITLE
fix: deal with `feeProtocol` in uniswap-v3 (potatoswap-v3)

### DIFF
--- a/dexs/potatoswap-v3.ts
+++ b/dexs/potatoswap-v3.ts
@@ -7,7 +7,7 @@ const methodology = {
   Fees: "Total fees paid by users on every swap, determined by the pool's fee tier (e.g., 0.01%, 0.05%, 0.30%, 1.00%).",
   UserFees: "Total fees paid by users (same as Fees).",
   Revenue: "Protocol revenue represents the share of swap fees diverted to the protocol. This share is set on a per-pool basis and can be updated by governance. Default share is 0%.",
-  ProtocolRevenue: "Calculated per-pool. If a pool's slot0() returns N > 0 for feeProtocol, the protocol revenue for that pool is (Total Fees / N).",
+  ProtocolRevenue: "Calculated per-pool. feeProtocol is a uint8 containing two uint4 values: feeProtocol0 (lower 4 bits) and feeProtocol1 (upper 4 bits). If feeProtocol0 = x1 and feeProtocol1 = x2, protocol revenue = Total Fees * (1/x1 + 1/x2) / 2. If only one is set, protocol revenue = Total Fees * 1/x.",
   SupplySideRevenue: "The portion of swap fees distributed to Liquidity Providers (LPs). This is (Total Fees - Protocol Revenue) for each pool.",
 };
 
@@ -47,12 +47,30 @@ async function fetch(_timestamp: number, _chainBlocks: any, options: FetchOption
     dailyVolume = dailyVolume.plus(poolVolume24h);
     dailyFees = dailyFees.plus(poolFees24h);
 
-    const protocolFeeShare = Number(slot0Results[i].feeProtocol);
-
-    if (protocolFeeShare > 0) {
-      // Use .div() and .minus() for accurate calculations
-      const poolProtocolRevenue = poolFees24h.div(protocolFeeShare);
-      
+    // Extract feeProtocol0 (lower 4 bits) and feeProtocol1 (upper 4 bits)
+    const feeProtocolValue = Number(slot0Results[i].feeProtocol);
+    const feeProtocol0 = feeProtocolValue & 0x0F;
+    const feeProtocol1 = (feeProtocolValue >> 4) & 0x0F;
+    
+    // For combined USD fees, we use the average of (1/feeProtocol0 + 1/feeProtocol1) / 2
+    let protocolRevenueRatio = new BigNumber(0);
+    
+    if (feeProtocol0 > 0 && feeProtocol1 > 0) {
+      // Both tokens have protocol fee: average of (1/x1 + 1/x2) / 2
+      const ratio0 = new BigNumber(1).div(feeProtocol0);
+      const ratio1 = new BigNumber(1).div(feeProtocol1);
+      protocolRevenueRatio = ratio0.plus(ratio1).div(2);
+    } else if (feeProtocol0 > 0) {
+      // Only token0 has protocol fee
+      protocolRevenueRatio = new BigNumber(1).div(feeProtocol0);
+    } else if (feeProtocol1 > 0) {
+      // Only token1 has protocol fee
+      protocolRevenueRatio = new BigNumber(1).div(feeProtocol1);
+    }
+    
+    if (protocolRevenueRatio.gt(0)) {
+      // Protocol revenue = Total Fees * protocolRevenueRatio
+      const poolProtocolRevenue = poolFees24h.times(protocolRevenueRatio);
       dailyRevenue = dailyRevenue.plus(poolProtocolRevenue);
     }
   }


### PR DESCRIPTION
## Fix: Correctly parse Uniswap V3 feeProtocol for protocol revenue calculation

### Problem
The code incorrectly treated `feeProtocol` as a single value. In Uniswap V3, `feeProtocol` is a `uint8` containing two `uint4` values:
- Lower 4 bits: `feeProtocol0` (token0 protocol fee rate)
- Upper 4 bits: `feeProtocol1` (token1 protocol fee rate)

### Solution
- Extract both `feeProtocol0` and `feeProtocol1` using bitwise operations
- Calculate protocol revenue ratio: `(1/feeProtocol0 + 1/feeProtocol1) / 2` when both are set, or `1/x` when only one is set
- Use multiplication: `Total Fees × protocolRevenueRatio` instead of division

This ensures accurate protocol revenue calculation that matches Uniswap V3's fee mechanism.
