### PR TITLE
YBTC fees and revenue tracking

### DIFF
--- a/fees/bitlayer-ybtc-family/index.ts
+++ b/fees/bitlayer-ybtc-family/index.ts
@@ -17,7 +17,7 @@ const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
         dailyFees.addToken(yBTCbContract, event.brokerFee);
     }
 
-    return { dailyFees, dailyRevenue: options.createBalances(), dailySupplySideRevenue: dailyFees }
+    return { dailyFees, dailyRevenue: 0, dailySupplySideRevenue: dailyFees }
 }
 
 const adapter: SimpleAdapter = {


### PR DESCRIPTION
**NOTE**

#### Please enable "Allow edits by maintainers" while putting up the PR.

---

> - If you would like to add a `tvl` adapter please submit the PR [here](https://github.com/DefiLlama/DefiLlama-Adapters).

1. Once your adapter has been merged, it takes time to show on the UI. If more than 24 hours have passed, please let us know in Discord.
2. Please fill the form below **only if the PR is for listing a new protocol** else it can be ignored/replaced with reason/details about the PR
3. **For updating listing info** It is a different repo, you can find your listing in this file: https://github.com/DefiLlama/defillama-server/blob/master/defi/src/protocols/data4.ts, you can edit it there and put up a PR
4. Do not edit/push `package.json/package-lock.json` file as part of your changes
5. No need to go to our discord/other channel and announce that you've created a PR, we monitor all PRs and will review it asap

---

[YBTC](https://etherscan.io/address/0xd9E3719F53b61047D5Bbbe9E3FB18eA1E07B1B02) can [only be minted/burned](https://docs.bitlayer.org/docs/YBTCFamily/YBTC/introducing-ybtc) through the [Bitlayer V2 bridge](https://etherscan.io/address/0x4b012E8980ed331a626bA2d2E510B20cB54886de). During withdrawals, a [0.0001 BTC service fee](https://docs.bitlayer.org/docs/BitVMBridge/Multi-Chain/mainnet#bitcoin---ethereum) is applied to the transaction. [Brokers](https://docs.bitlayer.org/docs/BitVMBridge/BBN/joining-bbn#brokers), which are [intermediaries who provide short-term liquidity](https://blog.bitlayer.org/introducing_bitvm_bridge/), facilitate transfers from YBTC (on Ethereum mainnet) to BTC.

Notes: 
- Using [YBTC.B](https://etherscan.io/token/0x2cd3CdB3bd68Eea0d3BE81DA707bC0c8743D7335) as the token reference for `addToken()` since it's listed [on CoinGecko](https://www.coingecko.com/en/coins/yield-btc-b) with BTC price data, while the [YBTC](https://etherscan.io/address/0xd9E3719F53b61047D5Bbbe9E3FB18eA1E07B1B02) token lacks price feeds. Both tokens are pegged to BTC with 8 decimals and [represent the same value](https://docs.bitlayer.org/docs/YBTCFamily/ybtc_family). 
- Returns `dailyRevenue` as zero currently since all fees are seemingly paid to brokers (no mention of protocol split in the documentation). Additionally, `dailySupplySideRevenue` is set to the `dailyFees` value. 

May resolve #4820 
