### PR TITLE
update-lagoon-fee-tracking

### DIFF
--- a/fees/lagoon/config.ts
+++ b/fees/lagoon/config.ts
@@ -10,6 +10,7 @@ interface InfraConfig {
     start: string;
 
     factories: Array<FactoryConfig>;
+    feeRegistry: string;
 
     // custom vaults
     vaults: Array<string>;
@@ -29,6 +30,7 @@ export const InfraConfigs: InfraConfig = {
         fromBlock: 22218451,
       },
     ],
+    feeRegistry: '0x6dA4D1859bA1d02D095D2246142CdAd52233e27C',
     vaults: [
       '0x07ed467acD4ffd13023046968b0859781cb90D9B', // 9Summits Flagship ETH
       '0x03D1eC0D01b659b89a87eAbb56e4AF5Cb6e14BFc', // 9Summits Flagship USDC
@@ -53,6 +55,7 @@ export const InfraConfigs: InfraConfig = {
         fromBlock: 324144504,
       },
     ],
+    feeRegistry: '0x6dA4D1859bA1d02D095D2246142CdAd52233e27C',
     vaults: [
       '0x99CD0b8b32B15922f0754Fddc21323b5278c5261',
     ],
@@ -69,6 +72,7 @@ export const InfraConfigs: InfraConfig = {
         fromBlock: 62519141,
       },
     ],
+    feeRegistry: '0xD7F69ba99c6981Eab5579Aa16871Ae94c509d578',
     vaults: [],
   },
   [CHAIN.BASE]: {
@@ -83,6 +87,7 @@ export const InfraConfigs: InfraConfig = {
         fromBlock: 29100401,
       },
     ],
+    feeRegistry: '0x6dA4D1859bA1d02D095D2246142CdAd52233e27C',
     vaults: [
       "0xFCE2064B4221C54651B21c868064a23695E78f09", // 722Capital-ETH
       "0x8092cA384D44260ea4feaf7457B629B8DC6f88F0", // DeTrade Core USDC
@@ -97,6 +102,7 @@ export const InfraConfigs: InfraConfig = {
         fromBlock: 23119208,
       },
     ],
+    feeRegistry: '0xC81Dd51239119Db80D5a6E1B7347F3C3BC8674d9',
     vaults: [],
   },
   [CHAIN.MONAD]: {
@@ -107,6 +113,7 @@ export const InfraConfigs: InfraConfig = {
         fromBlock: 36249718,
       },
     ],
+    feeRegistry: '0xBf994c358f939011595AB4216AC005147863f9D6',
     vaults: [],
   },
   //  [CHAIN.BERACHAIN]: {

--- a/fees/lagoon/index.ts
+++ b/fees/lagoon/index.ts
@@ -30,17 +30,11 @@ async function fetch(options: FetchOptions): Promise<FetchResultV2> {
     });
     vaults = vaults.concat(events.map((e: any) => e.proxy))
   }
-  if (vaults.length === 0) {
-    return { dailyFees, dailyRevenue, dailySupplySideRevenue, dailyProtocolRevenue };
-  }
+  if (vaults.length === 0) return { dailyFees, dailyRevenue, dailySupplySideRevenue, dailyProtocolRevenue };
 
-  const rolesStorage = await options.api.call({
-    target: vaults[0],
-    abi: Abis.getRolesStorage
-  })
   const protocolRates = await options.api.multiCall({
     abi: Abis.protocolRate,
-    calls: vaults.map(vault => ({ target: rolesStorage.feeRegistry, params: [vault] })),
+    calls: vaults.map(vault => ({ target: InfraConfigs[options.chain].feeRegistry, params: [vault] })),
     permitFailure: true
   })
   const assets = await options.api.multiCall({ abi: 'address:asset', calls: vaults, permitFailure: true })


### PR DESCRIPTION
**NOTE**

#### Please enable "Allow edits by maintainers" while putting up the PR.

---

> - If you would like to add a `tvl` adapter please submit the PR [here](https://github.com/DefiLlama/DefiLlama-Adapters).

1. Once your adapter has been merged, it takes time to show on the UI. If more than 24 hours have passed, please let us know in Discord.
2. Please fill the form below **only if the PR is for listing a new protocol** else it can be ignored/replaced with reason/details about the PR
3. **For updating listing info** It is a different repo, you can find your listing in this file: https://github.com/DefiLlama/defillama-server/blob/master/defi/src/protocols/data4.ts, you can edit it there and put up a PR
4. Do not edit/push `package.json/package-lock.json` file as part of your changes
5. No need to go to our discord/other channel and announce that you've created a PR, we monitor all PRs and will review it asap

---

I think the protocol fee rate can be updated on a per-vault basis, causing the constant `0.1` fee rate to calculate slightly inaccurate protocol revenue. 

For example, this [transaction on Arbitrum](https://arbiscan.io/tx/0x717f49e7490f5f1a153354d5a07258af45d44d3a30bd3afce99307d89a771760) shows ~817 shares being sent to the `feeReceiver` but doesn't show any shares being minted to the `protocolFeeReceiver`. Then, on the vault's [FeeRegistry](https://arbiscan.io/address/0x6dA4D1859bA1d02D095D2246142CdAd52233e27C) contract, we can [call protocolRate()](https://arbiscan.io/address/0x6dA4D1859bA1d02D095D2246142CdAd52233e27C#readProxyContract#F8) with the [vault address](https://arbiscan.io/address/0xF79DDe44f003710bf2f7Bad3bFEb13472fe07fe7) as input to see that the rate for that vault is `0` BPS. The protocol fee initially appears to be constant since it's mentioned as 10% in the [documentation here](https://docs.lagoon.finance/vault/fees#maximum-fee-limits), but in [another place](https://docs.lagoon.finance/overview/faq#does-the-protocol-charge-fees) it says _"currently no vault is subject to fees"_ (the documentation also mentions the protocol fee maximum being 30%, which implies it can be updated within the 0-30% range).


I also commented out the berachain `InfraConfig` object since neither factory has deployed any vaults:
- https://berascan.com/address/0x245d1C095a0fFa6f1Af0f7Df81818DeFc9Cfc69D
- https://berascan.com/address/0x7CF8cF276450BD568187fDC0b0959D30eC599853

Their [berachain subgraph](https://api.goldsky.com/api/public/project_cmbrqvox367cy01y96gi91bis/subgraphs/lagoon-berachain-mainnet-vault/prod/gn) returns two empty arrays when given this query:

```
query MyQuery {
  proxyDeployeds {
    proxy
  }
  beaconProxyDeployeds {
    proxy
  }
}
```
