### PR TITLE
track falcon finance yield

### DIFF
--- a/fees/falcon-finance/index.ts
+++ b/fees/falcon-finance/index.ts
@@ -7,54 +7,51 @@ const susdfToken = "0xc8CF6D7991f15525488b2A83Df53468D682Ba4B0";
 const sffToken = "0x1a0C3FfCbd101c6f2f6650DED9964c4A568C4D72";
 
 async function fetch(options: FetchOptions): Promise<FetchResultV2> {
-    // sUSDf and sFF staking vault yield
-    const balance = await getERC4626VaultsYield({ options, vaults: [susdfToken, sffToken] })
-    const dailyFees = balance.clone(1)
+  // sUSDf and sFF staking vault yield
+  const dailyFees = await getERC4626VaultsYield({ options, vaults: [susdfToken, sffToken] })
 
-    // FalconPosition nft rewards
-    const nftFeeEvents = await options.getLogs({
-        target: "0x8407e9864F42374Cb9DACfDEDe0e6962d634edCB",
-        eventAbi: "event FeesCollected(uint256 indexed tokenId, uint256 amount)",
-    })
-    const totalNftFees = nftFeeEvents.reduce((acc, event) => acc + Number(event.amount), 0)
-    const assetValue = await options.api.call({
-        target: susdfToken,
-        abi: 'function convertToAssets(uint256 shares) view returns (uint256)',
-        params: [totalNftFees.toString()],
-    })
-    dailyFees.add(usdfToken, assetValue);
+  // FalconPosition nft rewards
+  const nftFeeEvents = await options.getLogs({
+    target: "0x8407e9864F42374Cb9DACfDEDe0e6962d634edCB",
+    eventAbi: "event FeesCollected(uint256 indexed tokenId, uint256 amount)",
+  })
+  const totalNftFees = nftFeeEvents.reduce((acc, event) => acc + Number(event.amount), 0)
+  const assetValue = await options.api.call({
+    target: susdfToken,
+    abi: 'function convertToAssets(uint256 shares) view returns (uint256)',
+    params: [totalNftFees.toString()],
+  })
+  dailyFees.add(usdfToken, assetValue);
 
-    // FF Staking contract rewards
-    const rewardEvents = await options.getLogs({
-        target: "0x1E7fFB2cc2B0D9672b3E615dD5669C06F8673CAe",
-        eventAbi: "event RewardPaid(address indexed user, uint256 reward)",
-    });
-    for (const event of rewardEvents) {
-        dailyFees.add(usdfToken, event.reward);
-    }
+  // FF Staking contract rewards
+  const rewardEvents = await options.getLogs({
+    target: "0x1E7fFB2cc2B0D9672b3E615dD5669C06F8673CAe",
+    eventAbi: "event RewardPaid(address indexed user, uint256 reward)",
+  });
+  for (const event of rewardEvents) {
+    dailyFees.add(usdfToken, event.reward);
+  }
 
-    return {
-        dailyFees,
-        dailySupplySideRevenue: dailyFees,
-        dailyRevenue: 0,
-    }
+  return {
+    dailyFees,
+    dailyRevenue: 0,
+    dailyProtocolRevenue: 0,
+    dailySupplySideRevenue: dailyFees,
+  }
 }
 
 const methodology = {
-    Fees: 'Yield generated from sUSDf vault, sFF vault, FalconPosition NFT staking, and FF token staking.',
-    SupplySideRevenue: 'All yield is distributed to stakers.',
-    Revenue: 'No revenue is collected for the protocol inside the Falcon Finance smart contracts.',
+  Fees: 'Yield generated from sUSDf vault, sFF vault, FalconPosition NFT staking, and FF token staking.',
+  Revenue: 'No revenue is collected for the protocol inside the Falcon Finance smart contracts.',
+  SupplySideRevenue: 'All yield is distributed to stakers.',
 }
 
 const adapter: SimpleAdapter = {
-    version: 2,
-    adapter: {
-        [CHAIN.ETHEREUM]: {
-            fetch,
-            start: '2025-02-10',
-        }
-    },
-    methodology,
+  version: 2,
+  fetch,
+  chains: [CHAIN.ETHEREUM],
+  start: '2025-02-10',
+  methodology,
 }
 
 export default adapter;


### PR DESCRIPTION
**NOTE**

#### Please enable "Allow edits by maintainers" while putting up the PR.

---

> - If you would like to add a `tvl` adapter please submit the PR [here](https://github.com/DefiLlama/DefiLlama-Adapters).

1. Once your adapter has been merged, it takes time to show on the UI. If more than 24 hours have passed, please let us know in Discord.
2. Please fill the form below **only if the PR is for listing a new protocol** else it can be ignored/replaced with reason/details about the PR
3. **For updating listing info** It is a different repo, you can find your listing in this file: https://github.com/DefiLlama/defillama-server/blob/master/defi/src/protocols/data4.ts, you can edit it there and put up a PR
4. Do not edit/push `package.json/package-lock.json` file as part of your changes
5. No need to go to our discord/other channel and announce that you've created a PR, we monitor all PRs and will review it asap

---

I don't believe the protocol charges any [fees](https://docs.falcon.finance/resources/frequently-asked-questions-faq#who-bears-the-cost-of-minting-redeeming) to use its smart contracts currently (additionally, the [frontend](https://app.falcon.finance/swap/mint) shows the fee as _"FREE"_ and the [insurance fund address](https://docs.falcon.finance/resources/insurance-fund) hasn't received any tokens since the initial $10,000,000 deposit). 

There is a single method inside the [sUSDf](https://etherscan.io/address/0x0d132bee412e6619a4863aeedad97541bfda3f34#code) and [sFF](https://etherscan.io/address/0x80216d0218d4cee3cbc65068ab29c0e973cd896c#code) contracts that allows the protocol to redistribute funds from _"restricted"_ addresses to the treasury (this is the **only** time the `TREASURY` address is referenced in the contract). Although it has never been used, it could be tracked like so: 

```ts
 // Redistribution events from restricted sUSDf stakers to the treasury
    const dailyRevenue = options.createBalances()
    const redistributionEvents = await options.getLogs({
        target: susdfToken,
        eventAbi: "event LockedAmountRedistributed(address indexed from, bool sharesBurned, uint256 amount)",
    })
    let amount = 0;
    for (const event of redistributionEvents) {
        if (event.sharesBurned == false) {
            amount += Number(event.amount);
        }
    }
    const _assetValue = await options.api.call({
        target: susdfToken,
        abi: 'function convertToAssets(uint256 shares) view returns (uint256)',
        params: [amount],
    })
    dailyRevenue.add(usdfToken, Number(_assetValue));

    return {
        dailyFees,
        dailySupplySideRevenue: dailyFees,
        dailyRevenue: 0,
    }
```


They also have an [XAUt staking contract](https://etherscan.io/address/0x11d13fce0858050ffa1aa8784b96cd244e2bbf84#code), but it is not mentioned anywhere in their documentation yet and has low activity, so I ignored it.

May resolve #4785 
