### PR TITLE
fix: update bmx base subgraph to v0.0.2

### DIFF
--- a/dexs/bmx/index.ts
+++ b/dexs/bmx/index.ts
@@ -10,7 +10,7 @@ const startTimestamps: { [chain: string]: number } = {
 };
 const endpoints: { [key: string]: string } = {
   [CHAIN.BASE]:
-    "https://api.goldsky.com/api/public/project_cm2x72f7p4cnq01x5fuy95ihm/subgraphs/bmx-base-stats/0.0.1/gn",
+    "https://api.goldsky.com/api/public/project_cm2x72f7p4cnq01x5fuy95ihm/subgraphs/bmx-base-stats/0.0.2/gn",
   [CHAIN.MODE]:
     "https://api.goldsky.com/api/public/project_cm2x72f7p4cnq01x5fuy95ihm/subgraphs/bmx-mode-stats/0.0.1/gn",
 };

--- a/fees/bmx.ts
+++ b/fees/bmx.ts
@@ -6,7 +6,7 @@ import { getTimestampAtStartOfDayUTC } from "../utils/date";
 
 const endpoints: { [key: string]: string } = {
   [CHAIN.BASE]:
-    "https://api.goldsky.com/api/public/project_cm2x72f7p4cnq01x5fuy95ihm/subgraphs/bmx-base-stats/0.0.1/gn",
+    "https://api.goldsky.com/api/public/project_cm2x72f7p4cnq01x5fuy95ihm/subgraphs/bmx-base-stats/0.0.2/gn",
   [CHAIN.MODE]:
     "https://api.goldsky.com/api/public/project_cm2x72f7p4cnq01x5fuy95ihm/subgraphs/bmx-mode-stats/0.0.1/gn",
 };
@@ -45,7 +45,7 @@ const graphs: FetchV2 = async ({ chain, endTimestamp }) => {
       dailySupplySideRevenue: 0,
     }
   }
-  
+
   const dailyFee =
     parseInt(graphRes.feeStat.mint) +
     parseInt(graphRes.feeStat.burn) +


### PR DESCRIPTION
resolves: #5044 

Subgraph was returning 404 error because it was outdated. I tested both base and mode subgraph versions, it appears only base has been updated to `0.0.2`

**Before:**
<img width="773" height="451" alt="Screenshot 2025-12-14 at 10 35 10" src="https://github.com/user-attachments/assets/ea226c14-ecb6-42fa-a6b6-f1c48249b888" />

**After:**
<img width="775" height="311" alt="Screenshot 2025-12-14 at 10 37 04" src="https://github.com/user-attachments/assets/2b019958-b54f-4216-be9d-5eee8d240ca6" />

