### PR TITLE
fix: fees benqi staked avax methodology typos

### DIFF
--- a/fees/benqi-staked-avax.ts
+++ b/fees/benqi-staked-avax.ts
@@ -44,11 +44,12 @@ const fetchFees = async (options: FetchOptions) => {
 
 const methodology = {
   Fees: 'Total yields from staked Avax.',
-  Revenue: '10 % of the total yields are charged by Benqi.',
+  Revenue: '10% of the total yields are charged by Benqi.',
   ProtocolRevenue: 'All revenue goes to the protocol.',
   HoldersRevenue: 'No revenue share to QI token holders.',
   SupplySideRevenue: 'Stakers earn 90% AVAX staking rewards.',
 }
+
 const adapters: SimpleAdapter = {
   version: 2,
   methodology,


### PR DESCRIPTION
resolves: #5043 

The Benqi Staked Avax fees adapter had typos in the methodology object keys that could affect how metrics are displayed

### Changes Made
- fixed `HoldersRevneue` > `HoldersRevenue`
- fixed `SupplySideRevneue` > `SupplySideRevenue`

### Verification Process
To ensure the fee calculation was accurate (not just the typos), I did additional research:
**1. Cross referenced with [Benqi Documentation](https://docs.benqi.fi/benqi-liquid-staking/overview)**
- Confirmed protocol takes 10% of staking rewards as revenue
- Confirmed stakers receive 90% of rewards

**2. Verified Protocol Fee Onchain**
queried `protocolRewardShare()` on the sAVAX contract (`0x2b2C81e08f1Af8835a78Bb2A90AE924ACE0eA4bE`):
`100000000000000000`
This confirms the 10/90 split used in the adapter is correct

**3. Compared Calculation Methods**
- current method - total fees = 2898.40 avax
- `AccrueRewards` Events - total fees = 2897.42 avax

**Test results**
```pnpm test fees benqi-staked-avax

AVAX 👇
Backfill start time: 13/2/2022
Daily fees: 37.72 k
Daily revenue: 3.77 k
Daily protocol revenue: 3.77 k
Daily supply side revenue: 33.94 k
Daily holders revenue: 0.00```