### PR TITLE
fix: maia-v3 replace broken subgraph with onchain and add to fees

### DIFF
--- a/dexs/maia-v3/index.ts
+++ b/dexs/maia-v3/index.ts
@@ -1,47 +1,35 @@
-import { SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
-import {
-  DEFAULT_DAILY_VOLUME_FACTORY,
-  DEFAULT_TOTAL_VOLUME_FIELD,
-  getGraphDimensions2,
-} from "../../helpers/getUniSubgraph"
+import { uniV3Exports } from "../../helpers/uniswap";
 
-const v3Endpoints = {
-  [CHAIN.METIS]: "https://metis-graph.maiadao.io/uniswap-v3",
-};
+/**
+ * Maia V3 (Unimaia) - Uniswap V3 fork on Metis
+ *
+ * Previous implementation used subgraph at https://metis-graph.maiadao.io/uniswap-v3
+ * but the SSL certificate expired (Oct 7, 2025). Switched to on-chain log-based
+ * data fetching using the factory contract.
+ *
+ */
 
-const v3Graphs = getGraphDimensions2({
-  graphUrls: v3Endpoints,
-  totalVolume: {
-    factory: "factories",
-    field: DEFAULT_TOTAL_VOLUME_FIELD,
-  },
-  feesPercent: {
-    type: "fees",
-    ProtocolRevenue: 10, // 10% of fees are going to protocol
-    HoldersRevenue: 0,
-    UserFees: 100, // User fees are 100% of collected fees
-    SupplySideRevenue: 90, // 90% of fees are going to LPs
-    Revenue: 0 // Revenue is 100% of collected fees
-  }
-});
+const MAIA_V3_FACTORY = "0xf5fd18Cd5325904cC7141cB9Daca1F2F964B9927";
 
 const methodology = {
   UserFees: "User pays 0.01%, 0.05%, 0.30%, or 1% on each swap.",
   ProtocolRevenue: "Protocol receives 10% of fees.",
   SupplySideRevenue: "90% of user fees are distributed among LPs.",
-  HoldersRevenue: "Holders have no revenue."
-}
+  HoldersRevenue: "Holders have no revenue.",
+};
 
-const adapter: SimpleAdapter = {
-  version: 2,
-  adapter: {
-    [CHAIN.METIS]: {
-      fetch: v3Graphs,
-      start: '2023-04-01',
-    }
+const adapter = uniV3Exports({
+  [CHAIN.METIS]: {
+    factory: MAIA_V3_FACTORY,
+    userFeesRatio: 1, // 100% - users pay all fees
+    revenueRatio: 0.1, // 10% goes to revenue (protocol)
+    protocolRevenueRatio: 0.1, // 10% of fees go to protocol
+    holdersRevenueRatio: 0, // 0% to holders
+    start: "2023-04-01",
   },
-  methodology,
-}
+});
+
+adapter.methodology = methodology;
 
 export default adapter;

--- a/fees/maia-v3.ts
+++ b/fees/maia-v3.ts
@@ -1,0 +1,2 @@
+import adapter from "../dexs/maia-v3";
+export default adapter;


### PR DESCRIPTION
resolves: #5042 

### Overview
The Maia V3 fees adapter was failing with the error:
`FetchError: request to https://metis-graph.maiadao.io/uniswap-v3 failed, reason: certificate has expired`
The SSL certificate for Maia's self-hosted subgraph endpoint expired on October 7, 2025 (verified via openssl). The subgraph itself is functional (accessible via browser), but Node.js rejects expired certificates.

### What I Tried
- Verified the certificate expiry using openssl s_client
- Searched for alternative subgraph endpoints:
   - Satsuma (subgraph.satsuma-prod.com) - No Metis deployment
   - The Graph hosted service - No Maia V3 subgraph for Metis
   -  0xGraph (metisapi.0xgraph.xyz) - No Maia deployment
   - Metis Graph (andromeda.thegraph.metis.io) - No response
- Found factory contract address by querying `factory()` on a pool contract from Maia's analytics page
- Checked volume/fees from [maia-v3-analytics](https://v3-info.maiadao.io/#/) are in line with our new implementation (daily fees for 24h are $0.33)

### Changes
1. Switched from subgraph-based (getGraphDimensions2) to onchain log-based data fetching (uniV3Exports)
Uses factory contract: 0xf5fd18Cd5325904cC7141cB9Daca1F2F964B9927
2. created `fees/maia-v3.ts` which re-exports the DEX adapter

### Testing
```
pnpm test dexs maia-v3
METIS 👇
Daily volume: 412.00
Daily fees: 0.00
Daily revenue: 0.00
Daily supply side revenue: 0.00
Daily user fees: 0.00
Daily protocol revenue: 0.00
Daily holders revenue: 0.00
End timestamp: 1765729456 (2025-12-14T16:24:16.000Z)
```

```
pnpm test fees maia-v3
METIS 👇
Daily volume: 412.00
Daily fees: 0.00
Daily revenue: 0.00
Daily supply side revenue: 0.00
Daily user fees: 0.00
Daily protocol revenue: 0.00
Daily holders revenue: 0.00
End timestamp: 1765729470 (2025-12-14T16:24:30.000Z)
```