### PR TITLE
fix: mark fibonacci-dex as dead

### DIFF
--- a/dexs/fibonacci-dex.ts
+++ b/dexs/fibonacci-dex.ts
@@ -1,3 +1,33 @@
+// import { CHAIN } from "../helpers/chains";
+// import { graphDimensionFetch } from "../helpers/getUniSubgraph";
+// import { Adapter } from "../adapters/types";
+
+
+// const fetch = graphDimensionFetch({
+//     graphUrls: {
+//       [CHAIN.FORMNETWORK]: "https://formapi.0xgraph.xyz/api/public/f96b70ac-d704-4e09-b300-ff0fb4992df2/subgraphs/analytics/v0.0.1/gn",
+//     },
+//     dailyVolume: {
+//       factory: "algebraDayData",
+//       field: "volumeUSD",
+//     },
+//     dailyFees: {
+//       factory: "algebraDayData",
+//       field: "feesUSD",
+//     },
+//   });
+  
+//   const adapters: Adapter = {
+//     adapter: {
+//       [CHAIN.FORMNETWORK]: {
+//         fetch,
+//         start: '2024-10-29',
+//       },
+//     },
+//   };
+  
+//   export default adapters;
+
 import { CHAIN } from "../helpers/chains";
 import { Adapter } from "../adapters/types";
 


### PR DESCRIPTION
resolves: #5040 

### Summary

The Fibonacci Dex adapter was failing due to the subgraph API endpoint no longer exists. After investigating further, I have found that Fibonacci Dex are no longer active and the Form network has been sunsetted from `2025-08-15`: [tweet here](https://x.com/0xForm/status/1950968030172733865).

#### Changes
- Marked the adapter as dead from `2025-08-15`
- Replaced the broken subgraph fetch with a function that returns 0 values

