### PR TITLE
feat: adding enosys loans for fee tracking

### DIFF
--- a/fees/enosys-loans.ts
+++ b/fees/enosys-loans.ts
@@ -1,0 +1,8 @@
+import { CHAIN } from "../helpers/chains";
+import { liquityV2Exports } from "../helpers/liquity";
+
+export default liquityV2Exports({
+  [CHAIN.FLARE]: {
+    collateralRegistry: "0x9474206bc035D03d142264fd9913d1D51246d3AC",
+  },
+});


### PR DESCRIPTION
the enosys team has recently deployed a liquity v2 suite on the flare network and we would like to track fees for it. If I submitted the wrong adapter or if there is more that can be added please let me know. 
The tvl adapter PR can be found https://github.com/DefiLlama/DefiLlama-Adapters/pull/17389