### PR TITLE
Fix getHydrationBlock helper

### DIFF
--- a/helpers/getBlock.ts
+++ b/helpers/getBlock.ts
@@ -118,7 +118,7 @@ async function getBlocks(chain: Chain, timestamps: number[]) {
 const canGetBlock = (chain: string) => Object.keys(sdk.api2.config.providers).includes(chain)
 
 async function getHydrationBlock(unixTs: number) {
-  const data = await httpPost('https://hydradx.api.subscan.io/api/scan/block', {
+  const data = await httpPost('https://hydration.api.subscan.io/api/scan/block', {
     "block_timestamp": unixTs,
     "only_head": true
   })


### PR DESCRIPTION
The `getHydrationBlock` helper method currently fails because it's using an incorrect URL for the API request to get the block number for a Unix timestamp. This PR updates the API call to use the correct URL. 

This also fixes https://github.com/DefiLlama/dimension-adapters/issues/5067.