### PR TITLE
fix edgex

### DIFF
--- a/dexs/edgeX/index.ts
+++ b/dexs/edgeX/index.ts
@@ -4,13 +4,13 @@ import { CHAIN } from "../../helpers/chains";
 
 const summaryEndpoint = "https://pro.edgex.exchange/api/v1/public/quote/getTicketSummary?period=LAST_DAY_1";
 
-const fetch = async (_a:any,_b:any,_c:any): Promise<FetchResultVolume> => {
+const fetch = async (_a: any, _b: any, _c: any): Promise<FetchResultVolume> => {
   const previousDayTradeSummary = await fetchURL(summaryEndpoint);
-  
+
   const openInterestAtEnd = previousDayTradeSummary.data.tickerSummary.openInterest;
   const dailyVolume = previousDayTradeSummary.data.tickerSummary.value;
 
-  return{
+  return {
     dailyVolume,
     openInterestAtEnd
   }
@@ -21,6 +21,7 @@ const adapter: SimpleAdapter = {
     [CHAIN.EDGEX]: {
       fetch,
       start: '2024-08-06',
+      runAtCurrTime: true,
     },
   },
 };


### PR DESCRIPTION
Closes: https://github.com/DefiLlama/dimension-adapters/issues/5069
Edgex volume calculation had too many api calls , removed un-necessary parts to reduce chances of failure