### PR TITLE
add noble usdn fee adapter

### DIFF
--- a/fees/noble-usdn.ts
+++ b/fees/noble-usdn.ts
@@ -30,11 +30,9 @@ const adapter: SimpleAdapter = {
       fetch,
       start: "2024-04-01",
       runAtCurrTime: true,
-      meta: {
-        methodology,
-      },
     },
   },
+  methodology,
 };
 
 export default adapter;


### PR DESCRIPTION
adds fees adapter for Noble Dollar (USDN) on Noble chain.

metrics tracked:
- `dailyFees`: fees from USDN swaps
- `dailyRevenue`: revenue from USDN Season 2 vault