### PR TITLE
fix(reservoir-tools): add `deadFrom` field for deprecated service

### DIFF
--- a/dexs/reservoir-tools-amm.ts
+++ b/dexs/reservoir-tools-amm.ts
@@ -1,40 +1,49 @@
-import { FetchOptions, SimpleAdapter } from "../adapters/types";
-import { CHAIN } from "../helpers/chains";
-import { getGraphDimensions2 } from "../helpers/getUniSubgraph";
+// Reservoir Swap service is no longer available.
+// GraphQL endpoints return 503 errors. Support has been handed over to Protofire.
+// The white-labeled products (Sakura Swap, Whitelabel) should be tracked separately.
+// See issue: https://github.com/DefiLlama/dimension-adapters/issues/5063
 
+import { FetchOptions, SimpleAdapter } from '../adapters/types';
+import { CHAIN } from '../helpers/chains';
+import { getGraphDimensions2 } from '../helpers/getUniSubgraph';
 
 const v2Endpoints: { [s: string]: string } = {
-  [CHAIN.INK]: "https://graph-node.reservoir.tools/subgraphs/name/ink/v2-subgraph",
-  [CHAIN.ZERO]: "https://graph-node.reservoir.tools/subgraphs/name/zero/v2-subgraph",
-  [CHAIN.SHAPE]: "https://graph-node.reservoir.tools/subgraphs/name/shape/v2-subgraph",
-  [CHAIN.ABSTRACT]: "https://graph-node.reservoir.tools/subgraphs/name/abstract/v2-subgraph",
-}
+  [CHAIN.INK]:
+    'https://graph-node.reservoir.tools/subgraphs/name/ink/v2-subgraph',
+  [CHAIN.ZERO]:
+    'https://graph-node.reservoir.tools/subgraphs/name/zero/v2-subgraph',
+  [CHAIN.SHAPE]:
+    'https://graph-node.reservoir.tools/subgraphs/name/shape/v2-subgraph',
+  [CHAIN.ABSTRACT]:
+    'https://graph-node.reservoir.tools/subgraphs/name/abstract/v2-subgraph',
+};
 
 const v2Graph = getGraphDimensions2({
   graphUrls: v2Endpoints,
   totalFees: {
-    factory: "uniswapFactories",
-    field: "totalVolumeUSD",
+    factory: 'uniswapFactories',
+    field: 'totalVolumeUSD',
   },
   feesPercent: {
-    type: "volume",
+    type: 'volume',
     UserFees: 0.3,
     ProtocolRevenue: 0,
     SupplySideRevenue: 0.3,
     HoldersRevenue: 0,
     Revenue: 0,
-    Fees: 0.3
-  }
+    Fees: 0.3,
+  },
 });
 
 const fetch = async (options: FetchOptions) => {
   const res = await v2Graph(options);
-  res['dailyFees'] = res['dailyUserFees']
+  res['dailyFees'] = res['dailyUserFees'];
   return res;
-}
+};
 
 const adapter: SimpleAdapter = {
   version: 2,
+  deadFrom: '2025-12-14',
   adapter: {
     [CHAIN.INK]: {
       fetch,
@@ -52,7 +61,7 @@ const adapter: SimpleAdapter = {
       fetch,
       start: '2025-01-07',
     },
-  }
-}
+  },
+};
 
 export default adapter;

--- a/dexs/reservoir-tools-clmm.ts
+++ b/dexs/reservoir-tools-clmm.ts
@@ -1,13 +1,25 @@
-import { FetchOptions, SimpleAdapter } from "../adapters/types";
-import { CHAIN } from "../helpers/chains";
-import { DEFAULT_TOTAL_VOLUME_FIELD, getGraphDimensions2 } from "../helpers/getUniSubgraph";
+// Reservoir Swap service is no longer available.
+// GraphQL endpoints return 503 errors. Support has been handed over to Protofire.
+// The white-labeled products (Sakura Swap, Whitelabel) should be tracked separately.
+// See issue: https://github.com/DefiLlama/dimension-adapters/issues/5064
+
+import { FetchOptions, SimpleAdapter } from '../adapters/types';
+import { CHAIN } from '../helpers/chains';
+import {
+  DEFAULT_TOTAL_VOLUME_FIELD,
+  getGraphDimensions2,
+} from '../helpers/getUniSubgraph';
 
 const v3Endpoints: { [key: string]: string } = {
-  [CHAIN.ABSTRACT]: "https://graph-node.reservoir.tools/subgraphs/name/abstract/v3-subgraph",
-  [CHAIN.ZERO]: "https://graph-node.reservoir.tools/subgraphs/name/zero/v3-subgraph",
-  [CHAIN.SHAPE]: "https://graph-node.reservoir.tools/subgraphs/name/shape/v3-subgraph",
-  [CHAIN.REDSTONE]: "https://graph-node.reservoir.tools/subgraphs/name/redstone/v3-subgraph",
-}
+  [CHAIN.ABSTRACT]:
+    'https://graph-node.reservoir.tools/subgraphs/name/abstract/v3-subgraph',
+  [CHAIN.ZERO]:
+    'https://graph-node.reservoir.tools/subgraphs/name/zero/v3-subgraph',
+  [CHAIN.SHAPE]:
+    'https://graph-node.reservoir.tools/subgraphs/name/shape/v3-subgraph',
+  [CHAIN.REDSTONE]:
+    'https://graph-node.reservoir.tools/subgraphs/name/redstone/v3-subgraph',
+};
 
 // https://graph-node.internal.reservoir.tools/subgraphs/name/abstract/v3-subgraph
 // https://graph-node.internal.reservoir.tools/subgraphs/name/zero/v3-subgraph
@@ -18,44 +30,48 @@ const v3Endpoints: { [key: string]: string } = {
 const v3Graphs = getGraphDimensions2({
   graphUrls: v3Endpoints,
   totalVolume: {
-    factory: "factories",
+    factory: 'factories',
     field: DEFAULT_TOTAL_VOLUME_FIELD,
   },
   feesPercent: {
-    type: "fees",
+    type: 'fees',
     ProtocolRevenue: 0,
     HoldersRevenue: 0,
     UserFees: 100, // User fees are 100% of collected fees
     SupplySideRevenue: 100, // 100% of fees are going to LPs
-    Revenue: 0 // Revenue is 100% of collected fees
-  }
+    Revenue: 0, // Revenue is 100% of collected fees
+  },
 });
-
 
 const adapters: SimpleAdapter = {
   version: 2,
+  deadFrom: '2025-12-14',
   adapter: {
     [CHAIN.ABSTRACT]: {
-      fetch: (options: FetchOptions) =>  {
-        return v3Graphs(options)
-      }
+      fetch: (options: FetchOptions) => {
+        return v3Graphs(options);
+      },
+      start: '2025-01-07',
     },
     [CHAIN.ZERO]: {
-      fetch: (options: FetchOptions) =>  {
-        return v3Graphs(options)
-      }
+      fetch: (options: FetchOptions) => {
+        return v3Graphs(options);
+      },
+      start: '2025-01-07',
     },
     [CHAIN.SHAPE]: {
-      fetch: (options: FetchOptions) =>  {
-        return v3Graphs(options)
-      }
+      fetch: (options: FetchOptions) => {
+        return v3Graphs(options);
+      },
+      start: '2025-01-07',
     },
     // [CHAIN.REDSTONE]: {
     //   fetch: (options: FetchOptions) =>  {
     //     return v3Graphs(options)
     //   }
+    //   start: '2025-01-07',
     // },
-  }
-}
+  },
+};
 
-export default adapters
+export default adapters;


### PR DESCRIPTION
## Summary

- Fixes: https://github.com/DefiLlama/dimension-adapters/issues/5063 & https://github.com/DefiLlama/dimension-adapters/issues/5064

Marks Reservoir Tools AMM and CLMM adapters as deprecated by adding the `deadFrom` field. The service is no longer available and GraphQL endpoints return 503 errors.

> **See:** _https://github.com/DefiLlama/dimension-adapters/issues/5063#issuecomment-3657963804_

## Changes

- Added `deadFrom: '2025-12-14'` to both adapters
- Added explanatory comments about service deprecation and Protofire handover
- Added issue references for tracking