### PR TITLE
track chatter shield fees and revenue

### DIFF
--- a/fees/chattershield/index.ts
+++ b/fees/chattershield/index.ts
@@ -7,7 +7,7 @@ const FEE_RECEIVER_MULTISIG = "0xEF5EAB85EDCb1Cad33491C1f576Dd356dB7d63b9";
 const SHIELD_TOKEN = "0xd8B90D2e680ea535eAcCe1b025c998B347892f68";
 const HOLDERS_SHARE_MULIPLE = 0.4;
 
-const fetch: any = async (options: FetchOptions) => {
+const fetch: any = async (_a: any, _b: any, options: FetchOptions) => {
     const dailyFees = await addTokensReceived({
         tokens: [ADDRESSES.ethereum.USDC, SHIELD_TOKEN],
         target: FEE_RECEIVER_MULTISIG,


### PR DESCRIPTION
Closes : https://github.com/DefiLlama/dimension-adapters/issues/2606

##### Name (to be shown on DefiLlama): Chatter Shield

##### Twitter Link: https://x.com/chattershield

##### Website Link: https://www.chattershield.io/

##### Chain: Ethereum

##### Short Description (to be shown on DefiLlama): Chatter Shield is an X/Twitter raiding bot that integrates directly into Telegram groups, designed to augment community interaction with designated tweets.

##### Token address and ticker if any: 0xd8B90D2e680ea535eAcCe1b025c998B347892f68

##### Category (full list at https://defillama.com/categories) \*Please choose only one: Developer tools
