### PR TITLE
fix: stride replace stale api

### DIFF
--- a/fees/stride.ts
+++ b/fees/stride.ts
@@ -44,6 +44,7 @@ const adapter: Adapter = {
     celestia: { fetch: fetch("celestia") },
     osmosis: { fetch: fetch("osmosis") },
     dydx: { fetch: fetch("dydx") },
+    // dymension: { fetch: fetch("dymension") },
     juno: { fetch: fetch("juno") },
     stargaze: { fetch: fetch("stargaze") },
     terra: { fetch: fetch("terra") },


### PR DESCRIPTION
resolves: #4979 

### Summary
Stride fees adapter was returning stale data. The previous implementation used `edge.stride.zone/api/{chain}/stats/fees` which stopped updating around June 2024.

~~New approach: Calculate daily fees from on-chain TVL data and APR rates:~~
~~- Fetches total delegations and redemption rate from Polkachu's Stride API~~
~~- Fetches current APR from Stride's API endpoint~~
~~- Calculates: dailyFees = TVL × (APR / 365)~~
~~- Revenue = 10% of fees (Stride's commission)~~

~~This pattern is consistent with other adapters like tarot.ts that calculate fees from TVL × APY when no direct historical data source exists~~

### Changes
- Replaced stale `edge.stride.zone/api/{chain}/stats/fees` endpoint with [https://stride-fees-production.up.railway.app/api/${overriddenChain}/stats/fees](https://stride-fees-production.up.railway.app/api/$%7BoverriddenChain%7D/stats/fees) following feedback from @moonyandfriends

~~Upgraded adapter to version 2 (FetchV2)~~
~~Added chain configurations with proper chain IDs, CoinGecko token IDs, and decimals~~
~~Comment out dymension chain (no longer active on Stride's host zones)~~
~~Added graceful error handling for chains with null APR data~~
~~Updated methodology to document the calculation approach~~
  
~~Some chains show $0 because Stride's APY endpoint returns null for inactive/deprecated chains (dydx, stargaze, comdex, islm)~~