### PR TITLE
feat: add Futureswap volume and fees adapters

### DIFF
--- a/fees/futureswap.ts
+++ b/fees/futureswap.ts
@@ -28,10 +28,6 @@ const fetch = async (options: FetchOptions) => {
 
   const chainConfig = config[options.chain];
 
-  if (!chainConfig) {
-    throw new Error(`No chain config found for chain: ${options.chain}`);
-  }
-
   const logs = await options.getLogs({
     targets: chainConfig.exchanges,
     eventAbi: abis.positionChanged,


### PR DESCRIPTION
## Summary

- Closes: https://github.com/DefiLlama/dimension-adapters/issues/5144

Adds volume and fees tracking for Futureswap on Arbitrum and Avalanche.

- `dexs/futureswap.ts` - Tracks trading volume from `PositionChanged` events
- `fees/futureswap.ts` - Tracks trading fees (0.05% protocol fee) with revenue distribution
- Uses official contract addresses from [Futureswap documentation](https://docs.futureswap.com/protocol/developer/addresses-abis-and-links)

## Notes

- The adapter tracks only the Futureswap protocol fee (0.05%). The separate 0.05% Uniswap v3 fee paid to Uniswap LPs is not included (https://docs.futureswap.com/protocol/trading/fees).