### PR TITLE
chore: add detailed error for fetching builder code rev 

### DIFF
--- a/fees/rainbow-perps.ts
+++ b/fees/rainbow-perps.ts
@@ -3,30 +3,36 @@ import { FetchOptions, SimpleAdapter } from '../adapters/types'
 import { fetchBuilderCodeRevenue } from '../helpers/hyperliquid'
 
 const RAINBOW_BUILDER_ADDRESS = '0x60dc8e3dad2e4e0738e813b9cb09b9c00b5e0fc9'
+const RAINBOW_BUILDER_NAME = 'Rainbow'
 
 const fetch = async (_a: any, _b: any, options: FetchOptions) => {
-    const { dailyVolume, dailyFees, dailyRevenue, dailyProtocolRevenue } = await fetchBuilderCodeRevenue({ options, builder_address: RAINBOW_BUILDER_ADDRESS });
+  const { dailyVolume, dailyFees, dailyRevenue, dailyProtocolRevenue } =
+    await fetchBuilderCodeRevenue({
+      options,
+      builder_address: RAINBOW_BUILDER_ADDRESS,
+      builder_name: RAINBOW_BUILDER_NAME,
+    })
 
-    return {
-        dailyVolume,
-        dailyFees,
-        dailyRevenue,
-        dailyProtocolRevenue,
-    }
+  return {
+    dailyVolume,
+    dailyFees,
+    dailyRevenue,
+    dailyProtocolRevenue,
+  }
 }
 
 const methodology = {
-    Fees: 'builder code revenue from Hyperliquid Perps Trades.',
-    Revenue: 'builder code revenue from Hyperliquid Perps Trades.',
-    ProtocolRevenue: 'builder code revenue from Hyperliquid Perps Trades.',
+  Fees: 'builder code revenue from Hyperliquid Perps Trades.',
+  Revenue: 'builder code revenue from Hyperliquid Perps Trades.',
+  ProtocolRevenue: 'builder code revenue from Hyperliquid Perps Trades.',
 }
 
 const adapter: SimpleAdapter = {
-    fetch,
-    chains: [CHAIN.HYPERLIQUID],
-    start: '2025-09-15',
-    methodology,
-    doublecounted: true,
+  fetch,
+  chains: [CHAIN.HYPERLIQUID],
+  start: '2025-09-15',
+  methodology,
+  doublecounted: true,
 }
 
-export default adapter;
+export default adapter


### PR DESCRIPTION
closes:  #4440 

### Summary
The rainbow-perps adapter was throwing an unhelpful error message when testing with recent dates, because HyperLiquid's CSV endpoint has a 1-2 day data delay.

#### Changes 
- Improve the error message in `helpers/hyperliquid.ts` to explain the expected delay and try testing with an older date. 

#### Testing

`pnpm test fees rainbow-perps 2025-12-16`
```
HYPERLIQUID 👇
Backfill start time: 15/9/2025
Daily volume: 2.65 M
Daily fees: 1.32 k
Daily revenue: 1.32 k
Daily protocol revenue: 1.32 k
```

`pnpm test fees rainbow-perps`
```
------ ERROR ------
Error: Builder fee data for Rainbow is not available for 20251216. HyperLiquid's CSV endpoint typically has a 1-2 day delay. Try testing with an older date (e.g., 2-3 days ago).
    at fetchBuilderCodeRevenue (/Users/kanerep/Documents/Personal Projects/open-source/defillama/dimension-adapters/helpers/hyperliquid.ts:178:15)
    at processTicksAndRejections (node:internal/process/task_queues:105:5)
Builder fee data for Rainbow is not available for 20251216. HyperLiquid's CSV endpoint typically has a 1-2 day delay. Try testing with an older date (e.g., 2-3 days ago).
```