### PR TITLE
fix: migrate Reservoir Tools adapter to event logs (AMM)

### DIFF
--- a/dexs/reservoir-tools-amm.ts
+++ b/dexs/reservoir-tools-amm.ts
@@ -2,10 +2,19 @@ import { FetchOptions, SimpleAdapter } from '../adapters/types';
 import { CHAIN } from '../helpers/chains';
 import { getUniV2LogAdapter } from '../helpers/uniswap';
 
-const factories: { [key: string]: string } = {
-  [CHAIN.ABSTRACT]: '0x566d7510dEE58360a64C9827257cF6D0Dc43985E',
-  [CHAIN.INK]: '0xfe57A6BA1951F69aE2Ed4abe23e0f095DF500C04',
-  // [CHAIN.ZERO]: '0x1B4427e212475B12e62f0f142b8AfEf3BC18B559',
+const factories: { [key: string]: { address: string, start: string } } = {
+  [CHAIN.ABSTRACT]: {
+    address: '0x566d7510dEE58360a64C9827257cF6D0Dc43985E',
+    start: '2025-01-07',
+  },
+  [CHAIN.INK]: {
+    address: '0xfe57A6BA1951F69aE2Ed4abe23e0f095DF500C04',
+    start: '2025-01-07',
+  },
+  // [CHAIN.ZERO]: {
+  //   address: '0x1B4427e212475B12e62f0f142b8AfEf3BC18B559',
+  //   start: '2025-01-07',
+  // },
 };
 
 const feeConfigs = {
@@ -16,18 +25,8 @@ const feeConfigs = {
 };
 
 async function fetch(options: FetchOptions) {
-  if (!factories[options.chain]) {
-    return {
-      dailyVolume: 0,
-      dailyFees: 0,
-      dailyRevenue: 0,
-      dailyProtocolRevenue: 0,
-      dailySupplySideRevenue: 0,
-      dailyHoldersRevenue: 0,
-    };
-  }
   const adapter = getUniV2LogAdapter({
-    factory: factories[options.chain],
+    factory: factories[options.chain].address,
     ...feeConfigs,
   });
   const response = await adapter(options);
@@ -46,11 +45,7 @@ const methodology = {
 const adapter: SimpleAdapter = {
   version: 2,
   fetch,
-  adapter: {
-    [CHAIN.ABSTRACT]: { start: '2025-01-07' },
-    [CHAIN.INK]: { start: '2025-01-07' },
-    [CHAIN.ZERO]: { start: '2025-01-07' },
-  },
+  adapter: factories,
   methodology,
 };
 

--- a/dexs/reservoir-tools-clmm.ts
+++ b/dexs/reservoir-tools-clmm.ts
@@ -2,10 +2,19 @@ import { FetchOptions, SimpleAdapter } from '../adapters/types';
 import { CHAIN } from '../helpers/chains';
 import { getUniV3LogAdapter } from '../helpers/uniswap';
 
-const factories: { [key: string]: string } = {
-  [CHAIN.ABSTRACT]: '0xA1160e73B63F322ae88cC2d8E700833e71D0b2a1',
-  [CHAIN.INK]: '0x640887A9ba3A9C53Ed27D0F7e8246A4F933f3424',
-  // [CHAIN.ZERO]: '0xA1160e73B63F322ae88cC2d8E700833e71D0b2a1',
+const factories: { [key: string]: { address: string, start: string } } = {
+  [CHAIN.ABSTRACT]: {
+    address: '0xA1160e73B63F322ae88cC2d8E700833e71D0b2a1',
+    start: '2025-01-07',
+  },
+  [CHAIN.INK]: {
+    address: '0x640887A9ba3A9C53Ed27D0F7e8246A4F933f3424',
+    start: '2025-01-07'
+  },
+  // [CHAIN.ZERO]: {
+  //   address: '0xA1160e73B63F322ae88cC2d8E700833e71D0b2a1',
+  //   start: '2025-12-21'
+  // },
 };
 
 const feeConfigs = {
@@ -16,18 +25,8 @@ const feeConfigs = {
 };
 
 async function fetch(options: FetchOptions) {
-  if (options.chain === CHAIN.ZERO) {
-    return {
-      dailyVolume: 0,
-      dailyFees: 0,
-      dailyRevenue: 0,
-      dailyProtocolRevenue: 0,
-      dailySupplySideRevenue: 0,
-      dailyHoldersRevenue: 0,
-    };
-  }
   const adapter = getUniV3LogAdapter({
-    factory: factories[options.chain],
+    factory: factories[options.chain].address,
     ...feeConfigs,
   });
   const response = await adapter(options);
@@ -46,11 +45,7 @@ const methodology = {
 const adapter: SimpleAdapter = {
   version: 2,
   fetch,
-  adapter: {
-    [CHAIN.ABSTRACT]: { start: '2025-01-07' },
-    [CHAIN.ZERO]: { start: '2025-12-21' },
-    [CHAIN.INK]: { start: '2025-01-07' },
-  },
+  adapter: factories,
   methodology,
 };
 


### PR DESCRIPTION
## Summary

- Fixes: https://github.com/DefiLlama/dimension-adapters/issues/5171

Migrated both Reservoir Tools adapters (AMM) from deprecated GraphQL subgraphs to event logs. The GraphQL endpoints were returning 503 errors after the service was wound down.

## Changes

#### AMM (V2) - `dexs/reservoir-tools-amm.ts`

- ✅ Migrated from GraphQL to event logs
- ✅ Removed `deadFrom` field

**Factory Addresses** (from [official docs](https://web.archive.org/web/20250613231517/https://nft.reservoir.tools/docs/uniswap-contract-deployments)):

- Abstract: `0x566d7510dEE58360a64C9827257cF6D0Dc43985E`
- Ink: `0xfe57A6BA1951F69aE2Ed4abe23e0f095DF500C04`
- Zero: `0x1B4427e212475B12e62f0f142b8AfEf3BC18B559`

#### CLMM (V3) - `dexs/reservoir-tools-clmm.ts`

- Fixed in https://github.com/DefiLlama/dimension-adapters/pull/5324

## Related Issues

- #5063 (AMM)
- #5064 (CLMM)