### PR TITLE
fix: elfi adapter volume and use onchain logs

### DIFF
--- a/dexs/elfi/index.ts
+++ b/dexs/elfi/index.ts
@@ -30,21 +30,17 @@ const fetch = async ({ getLogs, chain, createBalances }: FetchOptions) => {
   const abiCoder = ethers.AbiCoder.defaultAbiCoder()
 
   logs.forEach((log: any) => {
-    try {
-      const decoded = abiCoder.decode(ORDER_INFO_TYPES, log.data)
-      const orderInfo = decoded[0]
-      const fillQty = decoded[1]
+    const decoded = abiCoder.decode(ORDER_INFO_TYPES, log.data)
+    const orderInfo = decoded[0]
+    const fillQty = decoded[1]
 
-      const qty = orderInfo.qty
-      const volume = fillQty > 0n ? fillQty : qty
-      if (volume === 0n) return
+    const qty = orderInfo.qty
+    const volume = fillQty > 0n ? fillQty : qty
+    if (volume === 0n) return
 
-      // Convert from 1e18 to USD with bigint-safe scaling (keep 6 decimals)
-      const volumeUsd = Number(volume / 10n ** 12n) / 1e6
-      dailyVolume.addCGToken('tether', volumeUsd)
-    } catch {
-      // Skip logs that fail to decode
-    }
+    // Convert from 1e18 to USD with bigint-safe scaling (keep 6 decimals)
+    const volumeUsd = Number(volume / 10n ** 12n) / 1e6
+    dailyVolume.addCGToken('tether', volumeUsd)
   })
 
   return {


### PR DESCRIPTION
resolves: #5111

### Summary
The adapter was failing due to the satsuma subgraphs being deprecated and not returning any up to date volume data. After investigating onchain and I identified the event topic and data structure for order fills, we can now use logs to track the volume. I discovered 2 new subgraphs, but these require a bearer token to call. 

Old subgraphs
- `https://subgraph.satsuma-prod.com/216876ddeec8/0xyzs-team--959441/elfi_arbitrum/api`
- `https://subgraph.satsuma-prod.com/216876ddeec8/0xyzs-team--959441/elfi_stats_base/api`

#### Changes
- Refactored ELFI adapter to use onchain logs to calculate the volume

Cross-checked our onchain volume figures with new subgraphs here:

**Arbitrum:**
https://thegraph.com/explorer/subgraphs/4zwiZepNaBQ6B7WzLEtyAeArGJkMwCpGz1NHV6pMHBHR?view=Query&chain=arbitrum-one

**Base:** 
https://thegraph.com/explorer/subgraphs/9uiLT5jqJfXtQiE3dwHKc8TzqJLsu1UmkC9mgcYuj23i?view=Query&chain=arbitrum-one

using this query for both:
```
{
  globalStats(first: 5) {
    id
    totalVolume
  }
  dailyVolumes(first: 5, orderBy:date, orderDirection: desc) {
    id
    date
    volume
    totalVolume
  }
}
```

```
Arbitrum
2025-12-18  41,205,446.889  
2025-12-17  47,256,778.910 
2025-12-16  40,657,900.614 
2025-12-15  39,336,014.222 

Base 
2025-12-18 107,156,737.358 
2025-12-17 118,615,637.890  
2025-12-16 107,098,812.134  
2025-12-15  83,055,831.583  
```