### PR TITLE
Feat/track backedfi fee revenue

### DIFF
--- a/fees/backedfi.ts
+++ b/fees/backedfi.ts
@@ -93,7 +93,7 @@ async function getAddressesByChain(products: ApiProduct[], chainName: string): P
   return addresses;
 }
 
-const prefetch = async (options: FetchOptions) => {
+const prefetch = async (_: FetchOptions) => {
   return await getProducts();
 }
 


### PR DESCRIPTION
closes https://github.com/DefiLlama/dimension-adapters/issues/4817


all of xStocks assets are issued by backed fi, so instead of xStocks, backed fees should be tracked.    
see PR https://github.com/DefiLlama/dimension-adapters/pull/4964


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Fee and revenue tracking now available for Backed tokens across multiple blockchain networks
  * Added fee tracking for Backed xStocks with mint and redeem event support
  * Both adapters provide per-chain metrics and detailed fee breakdowns

<!-- end of auto-generated comment: release notes by coderabbit.ai -->