### PR TITLE
Fix FAITH protocol revenue classification (all fees are protocol-controlled)

### DIFF
--- a/fees/faith/index.ts
+++ b/fees/faith/index.ts
@@ -14,15 +14,10 @@ const fetch = async (options: FetchOptions) => {
   const stats: FaithStats = await fetchURL(url);
 
   const dailyFees = Number(stats.current.feesUsd24h || 0);
-
-  // All fees are collected into protocol-controlled vaults
   const dailyRevenue = dailyFees;
-  const dailyProtocolRevenue = dailyFees;
 
-  // Portion of fees earmarked for holder value (buyback/burn)
-  // If 8% of volume goes to FAITH buyback/burn and fees are 10% of volume,
-  // then this is 80% of fees.
-  const dailyHoldersRevenue = dailyFees * 0.80;
+  const dailyProtocolRevenue = Number(dailyFees * 0.09) // 0.9% — Ops Vault (gas, infra, seasons, maintenance)
+  const dailyHoldersRevenue = Number(dailyFees * 0.8); // 80% of revenue goes to burn and buybacks
 
   return {
     dailyFees,
@@ -38,13 +33,11 @@ const adapter: Adapter = {
   fetch,
   start: "2025-11-24",
   methodology: {
-    Fees: "10% fee taken from total SUI deployed into Tests of Faith over the requested day window (reported in USD).",
-    Revenue: "All collected fees are counted as revenue.",
-    ProtocolRevenue:
-      "All fees are routed into protocol-controlled vaults (treasury + ops + other routing); counted as protocol revenue.",
-    HoldersRevenue:
-      "Portion of fees used for FAITH buyback/burn/staking (8% of volume = 80% of fees).",
-  },
+    Fees: "10% protocol fee taken from deployed SUI during Tests of Faith over the requested day window.",
+    Revenue: "All protocol fees collected by FAITH count as revenue, which is 10% of volume.",
+    ProtocolRevenue: "0.9% — Ops Vault (gas, infra, seasons, maintenance)",
+    HoldersRevenue: "80% of revenue goes to burn and FAITH buybacks",
+  }
 };
 
 export default adapter;


### PR DESCRIPTION
This PR corrects the FAITH fees adapter to reflect the intended accounting:

- All fees (10% of volume) are routed into protocol-controlled vaults
- `ProtocolRevenue` is therefore set to 100% of fees
- `HoldersRevenue` represents the portion of fees allocated to FAITH buyback/burn

No volume metrics are reported (aligned with ORE/GODL-style luck/game protocols).

Local test:
```
pnpm test fees faith

🦙 Running FAITH adapter 🦙
---------------------------------------------------
Start Date:	Thu, 18 Dec 2025 19:48:37 GMT
End Date:	Fri, 19 Dec 2025 19:48:37 GMT
---------------------------------------------------

SUI 👇
Backfill start time: 24/11/2025
Daily fees: 2.48 k
Daily revenue: 2.48 k
Daily protocol revenue: 2.48 k
Daily holders revenue: 1.99 k
End timestamp: 1766173716 (2025-12-19T19:48:36.000Z)
```