### PR TITLE
feat: add Pacifica fee/revenue adapter

### DIFF
--- a/fees/pacifica.ts
+++ b/fees/pacifica.ts
@@ -3,7 +3,7 @@ import { Adapter, FetchOptions } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
 import fetchURL from "../utils/fetchURL";
 
-const fetch = async (options: FetchOptions) => {
+const fetch = async () => {
   const { data } = await fetchURL('https://api.pacifica.fi/api/v1/info/prices');
   const dailyVolume = data.reduce((a: number, b: { volume_24h: string }) => a + Number(b.volume_24h), 0);
   const avgFeeRate = 0.00035; // 0.035%


### PR DESCRIPTION
- Track daily fees from perpetual trading
- Calculate revenue as 20% of total fees
- Use official Pacifica API for volume data
- Base fees: 0.02% maker / 0.05% taker
- Addresses issue #5245
