### PR TITLE
feat: add tau labs fees

### DIFF
--- a/fees/taulabs.ts
+++ b/fees/taulabs.ts
@@ -21,7 +21,7 @@ import { METRIC } from '../helpers/metrics'
 const factoryConfig: Record<string, { factory: string; startBlock: number }> = {
   [CHAIN.ETHEREUM]: {
     factory: '0x7c9119fbb87eb1a08224ad225362bdec213007e2',
-    startBlock: 21831587,
+    startBlock: 23120188, // first vault created
   },
 }
 
@@ -194,8 +194,8 @@ const breakdownMethodology = {
 const adapter: SimpleAdapter = {
   version: 2,
   adapter: {
-    [CHAIN.ETHEREUM]: { fetch, start: '2025-04-09' },
-    [CHAIN.FLOW]: { fetch, start: '2025-06-19' },
+    [CHAIN.ETHEREUM]: { fetch, start: '2025-08-12' },
+    [CHAIN.FLOW]: { fetch, start: '2025-06-20' },
   },
   methodology,
   breakdownMethodology,


### PR DESCRIPTION
resolves: #5309 

### Summary
Adds a fees and revenue adapter for TAU Labs (Plasma Vaults) - ERC4626 yield vaults operating on Ethereum and Flow.

#### Key features:
- Tracks management fees via ManagementFeeRealized events (0.3-0.8% annual, varies by vault)
- Calculates performance fees from vault yield using on-chain fee rates (2-10%, varies by vault)
- Supports 7 vaults on Ethereum and 1 vault on Flow

#### Main vaults can be found with their specific details on IPOR here:
- https://app.ipor.io/fusion/ethereum/0x6f66b845604dad6e80b2a1472e6cacbbe66a8c40/settings
- https://app.ipor.io/fusion/ethereum/0xb0f56bb0bf13ee05fef8cd2d8df5ffdfcac7a74f/settings
- https://app.ipor.io/fusion/ethereum/0x43a32d4f6c582f281c52393f8f9e5ace1d4a1e68/settings
- https://app.ipor.io/fusion/ethereum/0xe48cdd5ecec5aa53e630a7b4df12f79067b68dac/settings
- https://app.ipor.io/fusion/ethereum/0x63103375659d0aa94e9f35df15be01a3dd1ae9c0/settings
- https://app.ipor.io/fusion/ethereum/0xc50b2d51fd1e2ac67a9c09eaf63c24ea2465c64b/settings
