### PR TITLE
feat: add Anome adapter (Volume & Activity)

### DIFF
--- a/dexs/anome/index.ts
+++ b/dexs/anome/index.ts
@@ -4,6 +4,7 @@ import { CHAIN } from "../../helpers/chains";
 const MARKET_CONTRACT = "0x210d75B7C94aDf9FC1a2bCd047D76890479234e3"; 
 const BSC_USDT = "0x55d398326f99059fF775485246999027B3197955";
 const TRANSFER_TOPIC = "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef";
+const TRANSFER_EVENT = "event Transfer(address indexed from, address indexed to, uint256 value)";
 
 const topic0_address = (address: string) => "0x000000000000000000000000" + address.toLowerCase().replace('0x', '');
 
@@ -15,7 +16,7 @@ const fetch = async (options: FetchOptions) => {
   const logsIn = await getLogs({
     target: BSC_USDT,
     topics: [TRANSFER_TOPIC, null as any, topic0_address(MARKET_CONTRACT)],
-    eventAbi: 'event Transfer(address indexed from, address indexed to, uint256 value)',
+    eventAbi: TRANSFER_EVENT,
     onlyArgs: true,
   });
 
@@ -23,7 +24,7 @@ const fetch = async (options: FetchOptions) => {
   const logsOut = await getLogs({
     target: BSC_USDT,
     topics: [TRANSFER_TOPIC, topic0_address(MARKET_CONTRACT), null as any],
-    eventAbi: 'event Transfer(address indexed from, address indexed to, uint256 value)',
+    eventAbi: TRANSFER_EVENT,
     onlyArgs: true,
   });
 
@@ -36,12 +37,9 @@ const fetch = async (options: FetchOptions) => {
 
 const adapter: SimpleAdapter = {
   version: 2,
-  adapter: {
-    [CHAIN.BSC]: {
-      fetch,
-      start: 0, 
-    },
-  },
+  fetch,
+  chains: [CHAIN.BSC],
+  start: '2025-10-25', 
 };
 
 export default adapter;

--- a/users/routers/routerAddresses.ts
+++ b/users/routers/routerAddresses.ts
@@ -2435,13 +2435,13 @@ export default (
       },
     },
     {
-        id: "7139",
-        name: "Anome",
-        addresses: {
-            bsc: [
-                "0x210d75B7C94aDf9FC1a2bCd047D76890479234e3"
-            ],
-        },
+      id: "7139",
+      name: "Anome",
+      addresses: {
+        bsc: [
+          "0x210d75B7C94aDf9FC1a2bCd047D76890479234e3"
+        ],
+      },
     },
 
   ] as ProtocolAddresses[]


### PR DESCRIPTION
**Context:**
Anome is an NFT Marketplace on BSC.

**Methodology:**
1. **Volume:** calculated by summing up both incoming and outgoing USDT transfers from the Market Contract (`0x210d...`).
   - Inflow = User Buy (USDT -> Market)
   - Outflow = User Redeem (Market -> USDT)
2. **Activity:** Added market contract to router addresses to track Daily Active Users (DAU).

**Contracts:**
- BSC Market: 0x210d75B7C94aDf9FC1a2bCd047D76890479234e3

**Website:**
https://anome.xyz