### PR TITLE
Fix SyncSwap V3 dexs/fees adapter

### DIFF
--- a/helpers/uniswap.ts
+++ b/helpers/uniswap.ts
@@ -156,25 +156,26 @@ export const getUniV2LogAdapter: any = (v2Config: UniV2Config): FetchV2 => {
 
 const defaultV3SwapEvent = 'event Swap(address indexed sender, address indexed recipient, int256 amount0, int256 amount1, uint160 sqrtPriceX96, uint128 liquidity, int24 tick)'
 const defaultPoolCreatedEvent = 'event PoolCreated(address indexed token0, address indexed token1, uint24 indexed fee, int24 tickSpacing, address pool)'
-const algebraV3PoolCreatedEvent = 'event Pool (address indexed token0, address indexed token1, address pool)'
-const algebraV3SwapEvent = 'event Swap(address indexed sender, address indexed recipient, int256 amount0, int256 amount1, uint160 price, uint128 liquidity, int24 tick, uint24 overrideFee, uint24 pluginFee)'
-export const getUniV3LogAdapter: any = ({ factory, poolCreatedEvent = defaultPoolCreatedEvent, swapEvent = defaultV3SwapEvent, customLogic, isAlgebraV3 = false, isAlgebraV2 = false, userFeesRatio, revenueRatio, protocolRevenueRatio, holdersRevenueRatio, blacklistPools }: UniV3Config): FetchV2 => {
+const defaultAlgebraV3PoolCreatedEvent = 'event Pool (address indexed token0, address indexed token1, address pool)'
+
+export const getUniV3LogAdapter: any = ({ factory, poolCreatedEvent, swapEvent = defaultV3SwapEvent, customLogic, isAlgebraV3 = false, isAlgebraV2 = false, userFeesRatio, revenueRatio, protocolRevenueRatio, holdersRevenueRatio, blacklistPools }: UniV3Config): FetchV2 => {
   const fetch: FetchV2 = async (fetchOptions) => {
     const { createBalances, getLogs, chain, api } = fetchOptions
 
     if (!chain) throw new Error('Wrong version?')
 
+    // Determine which event to use based on parameters
+    // If poolCreatedEvent is explicitly passed, use it
+    // Otherwise, use algebra default for algebra or standard default for others
+    const eventToUse = poolCreatedEvent ?? (isAlgebraV3 ? defaultAlgebraV3PoolCreatedEvent : defaultPoolCreatedEvent)
+
     factory = factory.toLowerCase()
     const cacheKey = `tvl-adapter-cache/cache/logs/${chain}/${factory}.json`
-    const iface = new ethers.Interface([poolCreatedEvent])
-    const algebraIface = new ethers.Interface([algebraV3PoolCreatedEvent])
+    const iface = new ethers.Interface([eventToUse])
     let { logs } = await cache.readCache(cacheKey, { readFromR2Cache: true })
     if (!logs?.length) throw new Error('No pairs found, is there TVL adapter for this already?')
 
-      if (isAlgebraV3)
-      logs = logs.map((log: any) => algebraIface.parseLog(log)?.args)
-    else
-      logs = logs.map((log: any) => iface.parseLog(log)?.args)
+    logs = logs.map((log: any) => iface.parseLog(log)?.args).filter((log: any) => log !== null && log !== undefined)
 
     const pairObject: IJSON<string[]> = {}
     const fees: any = {}


### PR DESCRIPTION
Summary

Fixes an issue where Algebra v3 adapters ignored a custom poolCreatedEvent, causing log decoding failures and zero fees for protocols like SyncSwap v3.
The adapter now correctly selects the event ABI by prioritizing a provided custom event, falling back to the Algebra v3 default, and then to the standard Uni v3 event, ensuring reliable log parsing across different implementations