### PR TITLE
Fixs ENS Fees/Revenue Adapter 

### DIFF
--- a/fees/ens.ts
+++ b/fees/ens.ts
@@ -1,20 +1,37 @@
 import { Adapter, FetchOptions } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
 
-const abi_event = {
+/* ---------- ABIs ---------- */
+
+// v4
+const abi_v4 = {
   nameRegistered:
     "event NameRegistered(string name,bytes32 indexed label,address indexed owner,uint256 baseCost,uint256 premium,uint256 expires)",
   nameRenewed:
     "event NameRenewed(string name,bytes32 indexed label,uint256 cost,uint256 expires)",
 };
 
+// v5
+const abi_v5 = {
+  nameRegistered:
+    "event NameRegistered(string name,bytes32 indexed label,address indexed owner,uint256 cost,uint256 expires)",
+  nameRenewed:
+    "event NameRenewed(string name,bytes32 indexed label,uint256 cost,uint256 expires)",
+};
+
+/* ---------- Contracts ---------- */
+
 const address_v4 = "0x283af0b28c62c092c9727f1ee09c02ca627eb7f5";
 const address_v5 = "0x253553366da8546fc250f225fe3d25d0c782303b";
 
+/* ---------- Methodology ---------- */
+
 const methodology = {
-  Fees: "Registration and renewal costs",
-  Revenue: "Registration and renewal costs",
+  Fees: "ENS name registration and renewal costs",
+  Revenue: "ENS name registration and renewal costs",
 };
+
+/* ---------- Adapter ---------- */
 
 const adapter: Adapter = {
   version: 2,
@@ -23,26 +40,40 @@ const adapter: Adapter = {
       fetch: async (options: FetchOptions) => {
         const dailyFees = options.createBalances();
 
-        const registeredLogs = await options.getLogs({
-          targets: [address_v4, address_v5],
-          eventAbi: abi_event.nameRegistered,
+        /* ----- v4 registrations ----- */
+        const v4Registered = await options.getLogs({
+          target: address_v4,
+          eventAbi: abi_v4.nameRegistered,
         });
 
-        const renewedLogs = await options.getLogs({
-          targets: [address_v4, address_v5],
-          eventAbi: abi_event.nameRenewed,
+        v4Registered.forEach((tx: any) => {
+          const total = Number(tx.baseCost) + Number(tx.premium);
+          if (total / 1e18 < 10) {
+            dailyFees.addGasToken(total);
+          }
         });
 
-        renewedLogs.map((tx: any) => {
+        /* ----- v5 registrations ----- */
+        const v5Registered = await options.getLogs({
+          target: address_v5,
+          eventAbi: abi_v5.nameRegistered,
+        });
+
+        v5Registered.forEach((tx: any) => {
           if (Number(tx.cost) / 1e18 < 10) {
             dailyFees.addGasToken(tx.cost);
           }
         });
 
-        registeredLogs.map((tx: any) => {
-          const total = Number(tx.baseCost) + Number(tx.premium);
-          if (total / 1e18 < 10) {
-            dailyFees.addGasToken(total);
+        /* ----- renewals (same for v4 & v5) ----- */
+        const renewedLogs = await options.getLogs({
+          targets: [address_v4, address_v5],
+          eventAbi: abi_v4.nameRenewed,
+        });
+
+        renewedLogs.forEach((tx: any) => {
+          if (Number(tx.cost) / 1e18 < 10) {
+            dailyFees.addGasToken(tx.cost);
           }
         });
 


### PR DESCRIPTION
### 🧠 Summary
Adds a new adapter for **Ethereum Name Service (ENS)** to track daily fees from **domain registrations** and **renewals** on Ethereum mainnet.

---

### 🔧 Changes
- Added `ENS` adapter under `fees/` directory.  
- Integrated `NameRegistered` and `NameRenewed` event tracking from ENS v4 and v5 contracts.  
- Calculated total costs from both `baseCost` and `premium` fields.  
- Ensured only valid, small-value transactions are included (<10 ETH).  
- Set adapter start date to **2023-02-23** (epoch: `1677110400`).  

---

### ⭕Addresses Issue: https://github.com/DefiLlama/dimension-adapters/issues/5211