### PR TITLE
fix(donut): correct fee calculation with proper WETH pricing

### DIFF
--- a/fees/donut/index.ts
+++ b/fees/donut/index.ts
@@ -1,6 +1,8 @@
 import { SimpleAdapter, FetchOptions } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 
+// dailyFees = treasury + provider fees (20% of price) - excludes the 80% miner fee (0-sum transfer between old miner/it's counted as cost)
+
 const MINER_ADDRESS = "0xF69614F4Ee8D4D3879dd53d5A039eB3114C794F6";
 const WETH_ADDRESS = "0x4200000000000000000000000000000000000006"; // WETH on Base
 


### PR DESCRIPTION
## Summary
- Fix fee calculation to use WETH token address for proper USD pricing
- Use BigInt for precision in fee calculations
- Correct methodology descriptions

## Issue
Fee calculation was using `addUSDValue()` incorrectly, causing fees to display ~$1,571 instead of actual ~$70k.

## Fix
- Use `dailyFees.add(WETH_ADDRESS, amount)` instead of `addUSDValue()`
- Properly calculate supply side revenue (miner + provider)

## Fee Distribution (from contract)
| Recipient | Percentage |
|-----------|------------|
| Miner | 80% |
| Treasury | 15% |
| Frontend Provider | 5% |

## Test Results
```
Daily fees: 70.73 k
Daily revenue: 10.61 k (15%)
Daily supply side revenue: 60.12 k (85%)
```

## Contracts
- Miner: `0xF69614F4Ee8D4D3879dd53d5A039eB3114C794F6`