### PR TITLE
feat: truemarkets volume

### DIFF
--- a/dexs/truemarkets.ts
+++ b/dexs/truemarkets.ts
@@ -169,6 +169,7 @@ const methodology = {
     'Volume is calculated from Swap events on TrueMarkets prediction market pools. V1 markets use Uniswap V3 pools (USDC pairs), V2 markets use Uniswap V4 pools (TYD pairs). Only the stablecoin side of swaps is counted.',
   Fees: 'Fees are tracked via PoolFeeTracked events from the FeeCollector contract (V4 pools only).',
   Revenue: 'All collected fees are considered protocol revenue.',
+  ProtocolRevenue: 'All collected fees are considered protocol revenue.',
 }
 
 const adapter: SimpleAdapter = {


### PR DESCRIPTION
resolves: #5351 

### Summary
Adds a new adapter to track volume and fees for TrueMarkets, a fully onchain prediction market protocol on Base that uses Uniswap V4 for trading YES/NO outcome tokens.

#### Metrics Tracked
- Daily Volume - from Uniswap V4 Swap events and Legacy V3 pools
- Daily Fees - from PoolFeeTracked events on FeeCollector
- Daily Revenue / Protocol Revenue - all fees go to protocol

#### Changes
- Fetches PoolFeeTracked events from the FeeCollector contract to identify TrueMarkets pool IDs
- Queries Uniswap V4 Position Manager to get pool configuration (currency0/currency1)
- Fetches Swap events from Uniswap V4 Pool Manager, filtered by TrueMarkets pool IDs
- Calculates volume from the TYD (True Yield Dollar) side of each swap, treated as USDC equivalent

**Additional notes**
- TYD is a yield-bearing stablecoin backed 1:1 by USDC (ERC-4626 vault powered by Yearn)
- Volume is calculated from the TYD side of swaps only (not outcome tokens) to represent USD value
- Pool token order (currency0 vs currency1) is determined dynamically from on-chain pool configuration

**Resources**
- https://docs.truemarkets.org/
- https://github.com/truemarketsorg/true-contracts/blob/main/network_config.json

**Test Results**
`pnpm test dexs truemarkets 2025-12-23`
```
BASE 👇
Backfill start time: 19/12/2024
Daily volume: 4.18 k
Daily fees: 5.00
Daily revenue: 5.00
Daily protocol revenue: 5.00
```