### PR TITLE
feat(donut): add LP burns and governance strategy fees

### DIFF
--- a/fees/donut/index.ts
+++ b/fees/donut/index.ts
@@ -1,16 +1,24 @@
 import { SimpleAdapter, FetchOptions } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 
-// dailyFees = treasury + provider fees (20% of price) - excludes the 80% miner fee (0-sum transfer between old miner/it's counted as cost)
+// Miner fees: treasury + provider fees (20% of price)
+// Auction fees: LP tokens burned
+// Governance fees: tokens paid to acquire WETH from DAO strategies (dynamically fetched)
 
 const MINER_ADDRESS = "0xF69614F4Ee8D4D3879dd53d5A039eB3114C794F6";
-const WETH_ADDRESS = "0x4200000000000000000000000000000000000006"; // WETH on Base
+const AUCTION_ADDRESS = "0xC23E316705Feef0922F0651488264db90133ED38";
+const VOTER_ADDRESS = "0x1fAfC7Ec84ee588F1836833a4217b8a3e6632522";
+
+// Token addresses on Base
+const WETH_ADDRESS = "0x4200000000000000000000000000000000000006";
+const LP_TOKEN_ADDRESS = "0xD1DbB2E56533C55C3A637D13C53aeEf65c5D5703"; // DONUT/WETH LP
 
 const fetch = async (_a: any, _b: any, options: FetchOptions) => {
   const dailyFees = options.createBalances();
   const dailyRevenue = options.createBalances();
   const dailySupplySideRevenue = options.createBalances();
 
+  // 1. Miner fees (treasury + provider)
   const dailyTreasuryLogs = await options.getLogs({
     target: MINER_ADDRESS,
     eventAbi: "event Miner__TreasuryFee(address indexed treasury, uint256 amount)",
@@ -23,6 +31,40 @@ const fetch = async (_a: any, _b: any, options: FetchOptions) => {
     onlyArgs: true,
   });
 
+  // 2. Old Auction LP token burns
+  const dailyAuctionLogs = await options.getLogs({
+    target: AUCTION_ADDRESS,
+    eventAbi: "event Auction__Buy(address indexed buyer, address indexed assetsReceiver, uint256 paymentAmount)",
+    onlyArgs: true,
+  });
+
+  // 3. Dynamically fetch all governance strategies from Voter contract
+  const strategies: string[] = await options.api.call({
+    target: VOTER_ADDRESS,
+    abi: "function getStrategies() external view returns (address[])",
+  });
+
+  // Get payment token for each strategy
+  const paymentTokens: string[] = await Promise.all(
+    strategies.map((strategy: string) =>
+      options.api.call({
+        target: strategy,
+        abi: "function paymentToken() external view returns (address)",
+      })
+    )
+  );
+
+  // Fetch Strategy__Buy events from all strategies
+  const strategyLogsPromises = strategies.map((addr: string) =>
+    options.getLogs({
+      target: addr,
+      eventAbi: "event Strategy__Buy(address indexed buyer, address indexed assetsReceiver, uint256 revenueAmount, uint256 paymentAmount)",
+      onlyArgs: true,
+    })
+  );
+  const allStrategyLogs = await Promise.all(strategyLogsPromises);
+
+  // Sum miner fees
   let totalTreasuryWei = BigInt(0);
   for (const log of dailyTreasuryLogs) {
     totalTreasuryWei += BigInt(log.amount);
@@ -33,11 +75,36 @@ const fetch = async (_a: any, _b: any, options: FetchOptions) => {
     totalProviderWei += BigInt(log.amount);
   }
 
-  const totalFeesWei = totalTreasuryWei + totalProviderWei;
+  // Sum auction LP burns
+  let totalAuctionLpWei = BigInt(0);
+  for (const log of dailyAuctionLogs) {
+    totalAuctionLpWei += BigInt(log.paymentAmount);
+  }
 
-  dailyFees.add(WETH_ADDRESS, totalFeesWei);
+  // Add WETH fees from mining
+  dailyFees.add(WETH_ADDRESS, totalTreasuryWei + totalProviderWei);
   dailyRevenue.add(WETH_ADDRESS, totalTreasuryWei);
   dailySupplySideRevenue.add(WETH_ADDRESS, totalProviderWei);
+
+  // Add LP tokens burned from old auction
+  dailyFees.add(LP_TOKEN_ADDRESS, totalAuctionLpWei);
+  dailyRevenue.add(LP_TOKEN_ADDRESS, totalAuctionLpWei);
+
+  // Add governance strategy payments (tokens paid to DAO)
+  for (let i = 0; i < strategies.length; i++) {
+    const logs = allStrategyLogs[i];
+    const paymentToken = paymentTokens[i];
+
+    let totalPayment = BigInt(0);
+    for (const log of logs) {
+      totalPayment += BigInt(log.paymentAmount);
+    }
+
+    if (totalPayment > 0) {
+      dailyFees.add(paymentToken, totalPayment);
+      dailyRevenue.add(paymentToken, totalPayment);
+    }
+  }
 
   return {
     dailyFees,
@@ -54,10 +121,10 @@ const adapter: SimpleAdapter = {
   chains: [CHAIN.BASE],
   start: '2025-11-07',
   methodology: {
-    Fees: 'Treasury fees (15-20%) + provider fees (0-5%) from mining payments.',
-    Revenue: 'Treasury fees from each mining payment (15-20% of payments)',
-    ProtocolRevenue: 'Treasury fees from each mining payment (15-20% of payments)',
-    SupplySideRevenue: 'provider fees from each mining payment (0-5% of payments)',
+    Fees: 'Mining fees (treasury 15-20% + provider 0-5%), LP tokens burned via auction, and tokens paid through governance strategies (DONUT, LP, USDC, cbBTC).',
+    Revenue: 'Treasury fees + LP burned + governance strategy payments to DAO',
+    ProtocolRevenue: 'Treasury fees + LP burned + governance strategy payments to DAO',
+    SupplySideRevenue: 'Provider fees from mining payments (0-5%)',
   }
 };
 


### PR DESCRIPTION
## Summary
- Track LP tokens burned via Auction contract
- Dynamically fetch governance strategies from Voter contract
- Track payments (DONUT, LP, USDC, cbBTC) through strategy auctions
- Auto-discovers new strategies when added to Voter

## Fee Sources

| Source | Contract | Token |
|--------|----------|-------|
| Mining Treasury | Miner | WETH (15-20%) |
| Mining Provider | Miner | WETH (0-5%) |
| LP Burns | Auction | DONUT/WETH LP |
| Strategy 0 | Voter→Strategy | DONUT |
| Strategy 1 | Voter→Strategy | DONUT-ETH LP |
| Strategy 2 | Voter→Strategy | USDC |
| Strategy 3 | Voter→Strategy | cbBTC |

## Dynamic Strategy Discovery
New strategies added to the Voter contract are automatically tracked without code changes.

## Test Results
```
Daily fees: 12.44 k
Daily revenue: 9.33 k
Daily protocol revenue: 9.33 k
Daily supply side revenue: 3.11 k
```

## Contracts
- Miner: `0xF69614F4Ee8D4D3879dd53d5A039eB3114C794F6`
- Auction: `0xC23E316705Feef0922F0651488264db90133ED38`
- Voter: `0x1fAfC7Ec84ee588F1836833a4217b8a3e6632522`

🤖 Generated with [Claude Code](https://claude.com/claude-code)