### PR TITLE
Add COTI analytics endpoint to Symmio

### DIFF
--- a/dexs/symmio/index.ts
+++ b/dexs/symmio/index.ts
@@ -24,7 +24,8 @@ const config: Partial<Record<Chain, string>> = {
   [CHAIN.MANTLE]: 'https://api.goldsky.com/api/public/project_cm1hfr4527p0f01u85mz499u8/subgraphs/mantle_analytics/latest/gn',
   [CHAIN.BERACHAIN]: 'https://api.goldsky.com/api/public/project_cm1hfr4527p0f01u85mz499u8/subgraphs/bera_analytics/latest/gn',
   [CHAIN.MODE]: 'https://api.goldsky.com/api/public/project_cm1hfr4527p0f01u85mz499u8/subgraphs/mode_analytics/latest/gn',
-  [CHAIN.SONIC]: 'https://api.goldsky.com/api/public/project_cm1hfr4527p0f01u85mz499u8/subgraphs/sonic_analytics/latest/gn'
+  [CHAIN.SONIC]: 'https://api.goldsky.com/api/public/project_cm1hfr4527p0f01u85mz499u8/subgraphs/sonic_analytics/latest/gn',
+  [CHAIN.COTI]: 'https://graph-symmio.prvx.io/subgraphs/name/coti-perps-analytics'
 }
 
 const methodology = {


### PR DESCRIPTION
A major contributor to Symmio’s daily volume is now on the Coti chain, and it was missing from the adapter configuration.
