### PR TITLE
Add fees & revenue adapter for fly.trade

### DIFF
--- a/fees/fly-trade/index.ts
+++ b/fees/fly-trade/index.ts
@@ -1,0 +1,57 @@
+import { SimpleAdapter, FetchOptions } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import { addTokensReceived } from "../../helpers/token";
+
+const SWAP_FEE_ADDRESS = "0xd39B2A01D4dca42F32Ff52244a1b28811e40045F";
+
+const fetch = async (options: FetchOptions) => {
+  const dailyFees = options.createBalances();
+  const dailyRevenue = options.createBalances();
+
+  // Fly protocol swap fees collected by router
+  const fees = await addTokensReceived({
+    options,
+    targets: [SWAP_FEE_ADDRESS],
+  });
+
+  dailyFees.addBalances(fees);
+  dailyRevenue.addBalances(fees);
+
+  return {
+    dailyFees,
+    dailyRevenue,
+    dailyProtocolRevenue: dailyRevenue,
+  };
+};
+
+const methodology = {
+  Fees: "Fly charges a conditional protocol-level swap fee (0.01%–0.1%) on selected long-tail assets and specific trading pairs. Fees are enforced at the router level and transferred to a Fly-controlled fee collector address.",
+  Revenue: "All Fly swap fees are retained by the protocol.",
+  ProtocolRevenue: "100% of Fly swap fees are protocol revenue.",
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  fetch,
+  chains: [
+    CHAIN.ARBITRUM,
+    CHAIN.ETHEREUM,
+    CHAIN.OPTIMISM,
+    CHAIN.BASE,
+    CHAIN.BSC,
+    CHAIN.POLYGON,
+    CHAIN.AVAX,
+    CHAIN.SCROLL,
+    CHAIN.MANTA,
+    CHAIN.TAIKO,
+    CHAIN.METIS,
+    CHAIN.FANTOM,
+    CHAIN.LINEA,
+    CHAIN.INK,
+    CHAIN.BERACHAIN,
+  ],
+  start: "2024-01-01",
+  methodology,
+};
+
+export default adapter;


### PR DESCRIPTION
This PR adds a Fees & Revenue adapter for **fly.trade** and resolves the following issue: https://github.com/DefiLlama/dimension-adapters/issues/5235

## Fee Tracking
- Protocol fees are tracked via on-chain ERC20 token transfers.
- Fees are collected at the router level and transferred to the Fly-controlled fee collector address:
  - `0xd39B2A01D4dca42F32Ff52244a1b28811e40045F`

## Fee Model
- fly.trade applies a conditional protocol-level swap fee (0.01%–0.1%) on selected long-tail assets and specific trading pairs.
- Most swaps incur no protocol fee; therefore, zero-fee days are expected and correct.

## Revenue Attribution
- All collected swap fees are retained by the protocol.
- 100% of fees are classified as protocol revenue.
