### PR TITLE
Add fees & revenue adapter for Predict Fun

### DIFF
--- a/fees/predict-fun/index.ts
+++ b/fees/predict-fun/index.ts
@@ -1,0 +1,43 @@
+import { SimpleAdapter, FetchOptions } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import { addTokensReceived } from "../../helpers/token";
+
+const PREDICT_FEE_TREASURY = "0x7625B1c374b0D1546d87c0ab66229461007f1e33";
+
+const USDT_BSC = "0x55d398326f99059fF775485246999027B3197955";
+
+const fetch = async (options: FetchOptions) => {
+  const dailyFees = options.createBalances();
+
+  const fees = await addTokensReceived({
+    options,
+    targets: [PREDICT_FEE_TREASURY],
+    tokens: [USDT_BSC],
+  });
+
+  dailyFees.addBalances(fees);
+
+  return {
+    dailyFees,
+    dailyUserFees: dailyFees,
+    dailyRevenue: dailyFees,
+    dailyProtocolRevenue: dailyFees,
+  };
+};
+
+const methodology = {
+  Fees: "Predict.fun charges taker-only trading fees on prediction market trades. Fees are finalized at settlement and collected in USDT.",
+  UserFees: "Taker fees paid by users when executing trades on Predict.fun markets.",
+  Revenue: "All collected trading fees are retained by the protocol.",
+  ProtocolRevenue: "100% of fees are protocol revenue.",
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  fetch,
+  chains: [CHAIN.BSC],
+  start: "2025-12-10",
+  methodology,
+};
+
+export default adapter;


### PR DESCRIPTION
This PR adds a Fees & Revenue adapter for **predict.fun** and resolves: https://github.com/DefiLlama/dimension-adapters/issues/5388

## Fee Tracking
- Taker-only trading fees are tracked via on-chain ERC20 token transfers.
- Fees are collected in Binance-Peg USD on BSC and transferred to the Predict.fun treasury:
  - `0x7625B1c374b0D1546d87c0ab66229461007f1e33`

## Fee Model
- Makers pay no fees.
- Takers pay a variable fee based on share price at settlement.
- Fees are finalized on-chain during merge/withdraw operations.

## Revenue Attribution
- All collected fees are retained by the protocol.
- 100% of fees are classified as protocol revenue.
