### PR TITLE
Add Pizza City fees adapter (Base)

### DIFF
--- a/fees/pizza-city.ts
+++ b/fees/pizza-city.ts
@@ -1,17 +1,10 @@
-import { Adapter, FetchOptions } from "../adapters/types";
+import { SimpleAdapter } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
 
 const BOSS_BAKER_AUCTION = '0x272cD704E5A90b63E3B595744785262d32997B2f';
 const WETH = '0x4200000000000000000000000000000000000006';
 
-const methodology = {
-  Fees: "Total ETH bid into Dutch auctions (100% of pot)",
-  Revenue: "Protocol revenue only - 15% of auction pot sent to Treasury for permanent LP",
-  ProtocolRevenue: "15% of auction pot converted to permanently locked Uniswap V3 liquidity",
-  SupplySideRevenue: "85% distributed to participants: 80% to Boss Bakers (previous round winners), 5% to Street Fees (UI/referrals), 0.1% to Settler",
-};
-
-const fetch = async ({ getLogs, createBalances }: FetchOptions) => {
+const fetch = async ({ getLogs, createBalances }: any) => {
   const logs = await getLogs({
     target: BOSS_BAKER_AUCTION,
     eventAbi: 'event RoundClearable(uint256 indexed roundId, uint256 clearingPrice, uint256 totalPot, uint256 bidderCount)',
@@ -24,20 +17,15 @@ const fetch = async ({ getLogs, createBalances }: FetchOptions) => {
 
   for (const log of logs) {
     const totalPot = log.totalPot;
-    if (!totalPot || totalPot === 0n) continue;
+    if (!totalPot || totalPot === BigInt(0)) continue;
     
-    // Total fees = 100% of pot (all ETH flowing through auctions)
     dailyFees.add(WETH, totalPot);
     
-    // Protocol Revenue = 15% (Treasury - builds permanent LP)
-    const protocolShare = totalPot * 15n / 100n;
+    const protocolShare = totalPot * BigInt(15) / BigInt(100);
     dailyProtocolRevenue.add(WETH, protocolShare);
-    
-    // Revenue = protocolRevenue only (per DefiLlama: revenue = holdersRevenue + protocolRevenue)
     dailyRevenue.add(WETH, protocolShare);
     
-    // Supply Side = 85% (80% Boss Bakers + 5% Street Fees + 0.1% Settler)
-    dailySupplySideRevenue.add(WETH, totalPot * 85n / 100n);
+    dailySupplySideRevenue.add(WETH, totalPot * BigInt(85) / BigInt(100));
   }
 
   return {
@@ -48,17 +36,21 @@ const fetch = async ({ getLogs, createBalances }: FetchOptions) => {
   };
 };
 
-const adapter: Adapter = {
+const adapter: SimpleAdapter = {
   version: 2,
   adapter: {
     [CHAIN.BASE]: {
       fetch,
       start: '2025-12-19',
-      meta: {
-        methodology,
-      },
     },
   },
+};
+
+adapter.methodology = {
+  Fees: "Total ETH bid into Dutch auctions (100% of pot)",
+  Revenue: "Protocol revenue only - 15% of auction pot sent to Treasury for permanent LP",
+  ProtocolRevenue: "15% of auction pot converted to permanently locked Uniswap V3 liquidity",
+  SupplySideRevenue: "85% distributed to participants: 80% to Boss Bakers, 5% Street Fees, 0.1% Settler",
 };
 
 export default adapter;


### PR DESCRIPTION
## Pizza City - Base

Gamified DeFi protocol on Base featuring Dutch auctions for "city takeovers". The protocol emits $PIZZA tokens over 2 years with aggressive 30-day halving epochs.

### How It Works
- Users bid ETH in Dutch auctions to "take over" the city
- Winners earn $PIZZA emissions during the next round
- Rounds settle every ~30 minutes as the Dutch auction price decays

### TVL Components
- **Staking**: PIZZA tokens staked for rewards & governance power
- **Pool2**: Permanently locked Uniswap V3 PIZZA/WETH liquidity (protocol-owned)

### Fee Distribution (per round)
- 80% to Boss Bakers (previous round winners)
- 15% to Treasury (builds permanent LP)
- 5% to Street Fees (UI/referrals)
- 0.1% to Settler (tx executor)

### Contracts (Base)
- Auction: `0x272cD704E5A90b63E3B595744785262d32997B2f`
- PIZZA Token: `0x13b628fF6Db92070C0FBad79523240E0f5DeFb07`
- Staking: `0x2166Ea481f03778c969667675dBD6A4FdAa9FE78`
- Treasury: `0xc6b4694b906EA134595D3400364d7Acc319684ec`
- POL Manager: `0x2f90126a7a35351D8C522aa751059e77cF477C2B`

### Links
- Website: https://www.pizzacity.app/
- Farcaster: https://farcaster.xyz/~/channel/pizzacity
