### PR TITLE
feat: add kyros fees / rev adapter

### DIFF
--- a/helpers/queries/kyros.sql
+++ b/helpers/queries/kyros.sql
@@ -2,9 +2,10 @@
   Kyros - Liquid Restaking Protocol on Solana
   
   This query tracks:
-  1. JitoSOL staking rewards (Kyros's proportional share based on vault holdings)
+  1. Total JitoSOL staking rewards (for proportional share calculation in adapter)
   2. TipRouter NCN rewards (restaking rewards)
-  3. Withdrawal fees (protocol revenue)
+  3. Jito Restaking rewards
+  4. Withdrawal fees (protocol revenue)
   
   Sources:
   - JitoSOL staking rewards: solana.rewards from Jito stake accounts
@@ -24,109 +25,98 @@
 WITH 
 -- Get Jito stake accounts for staking rewards
 jito_stake_accounts AS (
-  SELECT DISTINCT account_stakeAccount as stake_account
-  FROM stake_program_solana.stake_call_delegatestake
-  WHERE account_stakeAuthority = '6iQKfEyhr3bZMotVkW6beNZz5CPAkiwvgV2CTje9pVSS'
-  UNION ALL
-  SELECT 'BgKUXdS29YcHCFrPm5M8oLHiTzZaMDjsebggjoaQ6KFL' AS stake_account
+    SELECT DISTINCT account_stakeAccount AS stake_account
+    FROM stake_program_solana.stake_call_delegatestake
+    WHERE account_stakeAuthority = '6iQKfEyhr3bZMotVkW6beNZz5CPAkiwvgV2CTje9pVSS'
+    UNION ALL
+    SELECT 'BgKUXdS29YcHCFrPm5M8oLHiTzZaMDjsebggjoaQ6KFL' AS stake_account
 ),
--- Total JitoSOL staking rewards for the period
-total_jitosol_staking_rewards AS (
-  SELECT SUM(lamports) as total_rewards
-  FROM jito_stake_accounts sa
-  LEFT JOIN solana.rewards r ON r.recipient = sa.stake_account
-  WHERE r.reward_type = 'Staking'
-    AND r.block_time >= from_unixtime({{start}})
-    AND r.block_time <= from_unixtime({{end}})
+
+-- Total JitoSOL staking rewards
+-- Returns total in SOL (divided by 1e9)
+staking_rewards AS (
+    SELECT
+        SUM(lamports) / 1e9 AS total_rewards_sol
+    FROM jito_stake_accounts sa
+    LEFT JOIN solana.rewards r ON r.recipient = sa.stake_account
+        AND r.reward_type = 'Staking'
+        AND r.block_time >= from_unixtime({{start}})
+        AND r.block_time <= from_unixtime({{end}})
 ),
--- Kyros's JitoSOL balance in vaults (average over period for proportional calculation)
-kyros_jitosol_balance AS (
-  SELECT AVG(balance) as avg_balance
-  FROM (
-    SELECT SUM(post_balance) as balance
-    FROM solana.account_activity
-    WHERE address IN ('{{kysol_vault}}')
-      AND token_mint_address = 'J1toso1uCk3RLmjorhTtrVwY9HJ7X8V9yYac6Y7kGCPn'
-      AND block_time >= from_unixtime({{start}})
-      AND block_time <= from_unixtime({{end}})
-    GROUP BY block_time
-  ) balances
-),
--- Total JitoSOL supply (for proportional calculation)
-jitosol_total_supply AS (
-  SELECT 14000000 * 1e9 as total_supply -- Approximate JitoSOL supply ~14M
-),
--- Calculate Kyros's proportional share of staking rewards
-kyros_staking_rewards AS (
-  SELECT
-    'staking' as source,
-    'So11111111111111111111111111111111111111112' as mint,
-    COALESCE(
-      (kb.avg_balance / ts.total_supply) * tr.total_rewards,
-      0
-    ) as amount,
-    0 as usd_amount
-  FROM total_jitosol_staking_rewards tr
-  CROSS JOIN kyros_jitosol_balance kb
-  CROSS JOIN jitosol_total_supply ts
-),
+
 -- TipRouter NCN rewards distributed to Kyros vaults
 tip_router_rewards AS (
-  SELECT
-    token_mint_address as mint,
-    SUM(amount) as amount,
-    SUM(amount_usd) as usd_amount
-  FROM tokens_solana.transfers
-  WHERE to_owner IN (
-    '{{kysol_vault}}',
-    '{{kyjto_vault}}',
-    '{{kykyros_vault}}'
-  )
-    AND outer_executing_account = '{{tip_router}}'
-    AND block_time >= from_unixtime({{start}})
-    AND block_time <= from_unixtime({{end}})
-  GROUP BY token_mint_address
+    SELECT
+        token_mint_address AS mint,
+        SUM(amount) AS amount,
+        SUM(amount_usd) AS usd_amount
+    FROM tokens_solana.transfers
+    WHERE to_owner IN (
+        '{{kysol_vault}}',
+        '{{kyjto_vault}}',
+        '{{kykyros_vault}}'
+    )
+        AND outer_executing_account = '{{tip_router}}'
+        AND block_time >= from_unixtime({{start}})
+        AND block_time <= from_unixtime({{end}})
+    GROUP BY token_mint_address
 ),
--- Rewards from Jito Restaking program (other NCN distributions)
+
+-- Rewards from Jito Restaking program
 restaking_rewards AS (
-  SELECT
-    token_mint_address as mint,
-    SUM(amount) as amount,
-    SUM(amount_usd) as usd_amount
-  FROM tokens_solana.transfers
-  WHERE to_owner IN (
-    '{{kysol_vault}}',
-    '{{kyjto_vault}}',
-    '{{kykyros_vault}}'
-  )
-    AND outer_executing_account = '{{jito_restaking}}'
-    AND block_time >= from_unixtime({{start}})
-    AND block_time <= from_unixtime({{end}})
-  GROUP BY token_mint_address
+    SELECT
+        token_mint_address AS mint,
+        SUM(amount) AS amount,
+        SUM(amount_usd) AS usd_amount
+    FROM tokens_solana.transfers
+    WHERE to_owner IN (
+        '{{kysol_vault}}',
+        '{{kyjto_vault}}',
+        '{{kykyros_vault}}'
+    )
+        AND outer_executing_account = '{{jito_restaking}}'
+        AND block_time >= from_unixtime({{start}})
+        AND block_time <= from_unixtime({{end}})
+    GROUP BY token_mint_address
 ),
+
 -- Withdrawal fees received by Kyros main authority
 protocol_fees AS (
-  SELECT
-    token_mint_address as mint,
-    SUM(amount) as amount,
-    SUM(amount_usd) as usd_amount
-  FROM tokens_solana.transfers
-  WHERE to_owner = '{{main_authority}}'
-    AND from_owner NOT IN (
-      '{{kysol_vault}}',
-      '{{kyjto_vault}}',
-      '{{kykyros_vault}}'
-    )
-    AND block_time >= from_unixtime({{start}})
-    AND block_time <= from_unixtime({{end}})
-  GROUP BY token_mint_address
+    SELECT
+        token_mint_address AS mint,
+        SUM(amount) AS amount,
+        SUM(amount_usd) AS usd_amount
+    FROM tokens_solana.transfers
+    WHERE to_owner = '{{main_authority}}'
+        AND from_owner NOT IN (
+            '{{kysol_vault}}',
+            '{{kyjto_vault}}',
+            '{{kykyros_vault}}'
+        )
+        AND block_time >= from_unixtime({{start}})
+        AND block_time <= from_unixtime({{end}})
+    GROUP BY token_mint_address
 )
--- Combine all fee sources
-SELECT source, mint, amount, usd_amount FROM kyros_staking_rewards WHERE amount > 0
-UNION ALL
-SELECT 'tip_router' as source, mint, amount, usd_amount FROM tip_router_rewards WHERE amount > 0
-UNION ALL
-SELECT 'restaking' as source, mint, amount, usd_amount FROM restaking_rewards WHERE amount > 0
-UNION ALL
-SELECT 'protocol' as source, mint, amount, usd_amount FROM protocol_fees WHERE amount > 0
 
+-- Return total staking rewards (adapter applies proportional share)
+SELECT 
+    'staking' AS source,
+    'So11111111111111111111111111111111111111112' AS mint,
+    COALESCE(total_rewards_sol, 0) AS amount,
+    NULL AS usd_amount
+FROM staking_rewards
+
+UNION ALL
+
+SELECT 'tip_router' AS source, mint, amount, usd_amount 
+FROM tip_router_rewards WHERE amount > 0
+
+UNION ALL
+
+SELECT 'restaking' AS source, mint, amount, usd_amount 
+FROM restaking_rewards WHERE amount > 0
+
+UNION ALL
+
+SELECT 'protocol' AS source, mint, amount, usd_amount 
+FROM protocol_fees WHERE amount > 0


### PR DESCRIPTION
resolves: #5225 

### Summary 
Kyros is a liquid restaking protocol built on Jito (Re)staking on Solana. It offers liquid restaking tokens (kySOL, kyJTO, kuKYROS) that combine staking rewards, mev rewards, and restaking rewards into a single token

#### Fee sources
- `dailyFees`: TipRouter NCN rewards + restaking rewards distributed to Kyros vaults
- `dailyRevenue/dailyProtocolRevenue`: Management fees collected by Kyros protocol
- `dailySupplySideRevenue`: Restaking rewards distributed to kySOL/kyJTO/kyKROS holders

#### Fee Breakdown
- MEV Rewards: TipRouter NCN rewards (0.15% of MEV tips allocated to JitoSOL/JTO vault stakers)
- Staking Rewards: Other restaking rewards from NCN operators
- Management Fees: Kyros share of withdrawal fees (0.1% of 0.2% total)

#### Technical Details
- Uses Dune for data sourcing
- Tracks transfers from TipRouter (`RouterBmuRBkPUbgEDMtdvTZ75GBdSREZR5uGUxxxpb`) and Jito Restaking (`RestkWeAVL8fRGgzhfeoqFhsqKRchg6aa1XrcH96z4Q`) programs to Kyros vaults
- Note: Base JitoSOL staking rewards are tracked separately by the `jito-staked-sol adapter` - this adapter only tracks restaking-specific rewards to avoid double counting

#### Resources
- https://app.kyros.fi
- https://docs.kyros.fi

#### Testing
The fees and protocol revenue can differ across different days depending on withdrawals, and the cadence of mev/staking rewards etc. 
`pnpm test fees kyros 2025-12-27`

```
SOLANA 👇
Backfill start time: 29/10/2024
Daily fees: 178.00
Daily revenue: 31.00
Daily protocol revenue: 31.00
Daily supply side revenue: 148.00
```

