### PR TITLE
Added fees for vaulta-rex

### DIFF
--- a/helpers/chains.ts
+++ b/helpers/chains.ts
@@ -310,6 +310,5 @@ export enum CHAIN {
   OG = "0g",
   FOGO = "fogo",
   PROVENANCE = "provenance",
-  VAULTA = "vaulta",
   SPACE_AND_TIME = "space_and_time",
 }


### PR DESCRIPTION
This PR addresses the issue : https://github.com/DefiLlama/dimension-adapters/issues/5196


## Vaulta REX Adapter - Fee Calculation

This adapter calculates daily fees generated by the  Vaulta REX.

**Fee Calculation:**
- Fetches `current_rate_of_increase` from the `rexretpool` smart contract table, which represents the EOS amount added to the REX pool per 10-minute distribution interval
- Multiplies by 144 daily intervals: `Daily Fees (EOS) = (current_rate_of_increase / 10,000) × 144`
- Converts to USD using real-time EOS price from CoinGecko API

**Revenue Model:**
- 100% of collected fees (CPU/NET rentals, RAM trading fees, and name auction proceeds) are distributed to REX token holders proportionally
- No protocol fee or burn mechanism

**Data Sources:**
- EOS blockchain: Multiple public RPC endpoints with automatic fallback for reliability
- Price data: CoinGecko API

**Key Features:**
- Uses `current_rate_of_increase` as the authoritative metric for actual fee flow rate
- Automatic endpoint failover across 7 EOS node providers
- Real-time USD conversion based on current EOS spot price