### PR TITLE
feat: add hawkfi fees and rev

### DIFF
--- a/fees/hawkfi.ts
+++ b/fees/hawkfi.ts
@@ -48,7 +48,6 @@ const fetch = async (options: FetchOptions) => {
 
   return {
     dailyFees,
-    dailyUserFees: dailyFees,
     dailyRevenue: dailyProtocolRevenue,
     dailyProtocolRevenue,
     dailySupplySideRevenue,
@@ -57,14 +56,9 @@ const fetch = async (options: FetchOptions) => {
 
 const methodology = {
   Fees: 'Total LP yield generated through HawkFi automated liquidity strategies on Meteora DLMM and Orca Whirlpool. Derived from the 8% performance fee collected (fee_amount / 0.08 = total_yield).',
-  UserFees:
-    'Total LP yield - users pay an 8% performance fee on yield earned, not on principal deposits.',
-  Revenue:
-    '8% performance fee on LP yield and rebalance fees, collected by HawkFi protocol treasury.',
-  ProtocolRevenue:
-    '8% performance fee on LP yield and rebalance fees, collected by HawkFi protocol treasury.',
-  SupplySideRevenue:
-    '92% of LP yield retained by liquidity providers after the HawkFi 8% performance fee.',
+  Revenue: '8% performance fee on LP yield and rebalance fees, collected by HawkFi protocol treasury.',
+  ProtocolRevenue: '8% performance fee on LP yield and rebalance fees, collected by HawkFi protocol treasury.',
+  SupplySideRevenue: '92% of LP yield retained by liquidity providers after the HawkFi 8% performance fee.',
 }
 
 const adapter: SimpleAdapter = {


### PR DESCRIPTION
resolves: #5227 

### Summary

HawkFi adapter to track fees and revenue. HawkFi provides automated liquidity management strategies on Solana DEXs, primarily Meteora DLMM. The protocol charges an 8% performance fee on LP yield and 0.1% rebalance fee for balances <$1000

#### Metrics
- `dailyFees`:  Total LP yield generated (derived from protocol fee / 0.08)
- `dailyUserFees`: Same as dailyFees - users pay 8% on yield earned
- `dailyRevenue`: 8% performance fee and 0.1% rebalance fees collected by HawkFi
- `dailyProtocolRevenue`: 8% performance fee 0.1% rebalance fees to protocol treasury
- `dailySupplySideRevenue`: 92% of yield retained by LPs

#### Data Source
Dune Analytics - queries transfers to HawkFi fee wallet to capture all fees from Meteora, Orca and future dexs

**Addresses**
- Program: `FqGg2Y1FNxMiGd51Q6UETixQWkF5fB92MysbYogRJb3P`
- Fee Wallet: `4K3a2ucXiGvuMJMPNneRDyzmNp6i4RdzXJmBdWwGwPEh`

**Resouces**
- https://hawkfi.ag
- https://hawkfi.gitbook.io/whitepaper

#### Test Results

`pnpm test fees hawkfi`
```
SOLANA 👇
Backfill start time: 5/2/2024
Daily fees: 3.81 k
Daily user fees: 3.81 k
Daily revenue: 305.00
Daily protocol revenue: 305.00
Daily supply side revenue: 3.51 k
End timestamp: 1767351169 (2026-01-02T10:52:49.000Z)
```
