### PR TITLE
Add BisonFi DEX volume adapter on Solana

### DIFF
--- a/dexs/bisonfi/index.ts
+++ b/dexs/bisonfi/index.ts
@@ -1,50 +1,7 @@
-import { CHAIN } from "../../helpers/chains";
-import { FetchOptions, FetchResultVolume } from "../../adapters/types";
-import { queryDuneSql } from "../../helpers/dune";
+import { alliumSolanaDexExport } from "../../helpers/alliumDex";
 
-const BISONFI_PROGRAM = "BiSoNHVpsVZW2F7rx2eQ59yQwKxzU5NvBcmKshCSUypi";
-
-/**
- * BisonFi volume attribution:
- * - Identify Solana transactions that invoke the BisonFi program
- * - Sum USD-denominated swap volume from dex_solana.trades for those txs
- *
- * This approach ensures only BisonFi-executed spot trades are counted.
- */
-const fetchSolana = async (
-  _timestamp: number,
-  _block: any,
-  options: FetchOptions
-): Promise<FetchResultVolume> => {
-  const startTimestamp = options.fromTimestamp;
-  const endTimestamp = options.toTimestamp;
-
-  const rows = await queryDuneSql(
-    options,
-    `
-    WITH txs AS (
-      SELECT DISTINCT tx_id
-      FROM solana.instruction_calls
-      WHERE executing_account = '${BISONFI_PROGRAM}'
-        AND block_time >= from_unixtime(${startTimestamp})
-        AND block_time < from_unixtime(${endTimestamp})
-    )
-    SELECT
-      COALESCE(SUM(t.amount_usd), 0) AS volume_usd
-    FROM dex_solana.trades t
-    INNER JOIN txs ON txs.tx_id = t.tx_id
-    WHERE t.block_time >= from_unixtime(${startTimestamp})
-      AND t.block_time < from_unixtime(${endTimestamp})
-    `
-  );
-
-  const volumeUsd = Number(rows?.[0]?.volume_usd ?? 0);
-  return { dailyVolume: `${volumeUsd}` };
-};
-
-export default {
-  name: "bisonfi",
-  chains: [CHAIN.SOLANA],
-  fetch: fetchSolana,
-  start: "2025-12-01",
-};
+export default alliumSolanaDexExport(
+  "bisonfi",
+  "bisonfi",
+  "2025-12-01"
+);


### PR DESCRIPTION
**Summary**
Adds daily DEX volume tracking for **BisonFi**.

This adapter attributes volume by identifying on-chain transactions that invoke the BisonFi program and aggregating the corresponding USD-denominated swap volume from Solana DEX trade data and aligned with DefiLlama’s established Solana DEX methodology.

**Methodology**
Daily volume is computed fully on-chain in two steps:

**1. Transaction identification**
All Solana transactions that invoke the BisonFi program  
`E1aVFBGrfSLR2TB2Hd1Lh3XY4txznZqBoy5DdbhbC2DH`  E1aVFBGrfSLR2TB2Hd1Lh3XY4txznZqBoy5DdbhbC2DH

E1aVFBGrfSLR2TB2Hd1Lh3XY4txznZqBoy5DdbhbC2DH
are identified using `solana.instruction_calls`.

**2. Volume aggregation**
USD trade volume is summed from `dex_solana.trades` for the identified transaction hashes.  
This table already normalizes swap amounts to USD where pricing is available.

This approach ensures:
- Only trades executed through the BisonFi program are counted
- No reliance on protocol-reported, off-chain, or self-published metrics
- Consistency with existing Solana DEX volume accounting across DefiLlama

**Implementation Details**
- Uses Dune SQL via the existing `queryDuneSql` helper
- Joins `solana.instruction_calls` and `dex_solana.trades` on `tx_id`
- Single-query approach avoids large `IN` clauses and reduces query overhead
- Queries are time-bounded using DefiLlama adapter timestamps
- No protocol-specific APIs, subgraphs, or off-chain endpoints are used

**Note:**  
This adapter relies on Dune’s Solana datasets, which may result in slightly higher execution latency during local testing. This is consistent with other Solana DEX adapters and prioritizes correctness and completeness of historical volume.

**Scope**
- **Chain:** Solana  
- **Coverage:** Spot trades executed via the BisonFi program  
- **Start date:** 2025-12-01 (protocol launch window)

**Verification**
The adapter can be verified locally using the test runner:

```bash
pnpm test dexs bisonfi 2025-12-15
# Daily volume: 4.35 M
```
```bash
pnpm test dexs bisonfi 2025-12-30
# Daily volume: 110.18 M
```
```bash
pnpm test dexs bisonfi 2026-01-01
# Daily volume: 100.48 M
```
```bash
pnpm test dexs bisonfi 2026-01-03
# Daily volume: 83.56 M
```
These results are consistent across multiple dates and confirm correct attribution of BisonFi DEX volume.


