### PR TITLE
Added fees for Gitcoin Passport

### DIFF
--- a/fees/gitcoin-passport/index.ts
+++ b/fees/gitcoin-passport/index.ts
@@ -1,6 +1,6 @@
-import { SimpleAdapter } from "../../adapters/types"
+import * as sdk from "@defillama/sdk"
+import { SimpleAdapter, FetchOptions } from "../../adapters/types"
 import { CHAIN } from "../../helpers/chains"
-import { addGasTokensReceived } from "../../helpers/token"
 
 const VERIFIER_CONTRACTS = {
   [CHAIN.ARBITRUM]: "0xc4858e4D177Bf0d14571F91401492d62aa608047",
@@ -8,16 +8,38 @@ const VERIFIER_CONTRACTS = {
   [CHAIN.BASE]: "0x16db23c4b99bbC9A6Bf55dF7a787C9AEFD261185",
   [CHAIN.LINEA]: "0xc94aBf0292Ac04AAC18C251d9C8169a8dd2BBbDC",
   [CHAIN.SCROLL]: "0x16db23c4b99bbC9A6Bf55dF7a787C9AEFD261185",
-  [CHAIN.ZKSYNC]: "0xfCC2d308FD4De098D08f056c424C969d728912bF",
+  // [CHAIN.ZKSYNC]: "0xfCC2d308FD4De098D08f056c424C969d728912bF", // SDK doesn't support zkSync block lookups
 }
 
-const fetchFees = async (options: any) => {
-  const target = VERIFIER_CONTRACTS[options.chain]
-  
-  const dailyFees = await addGasTokensReceived({
-    options,
-    multisig: target,
-  })
+const fetchFees = async (options: FetchOptions) => {
+  const { chain, getFromBlock, getToBlock, createBalances } = options
+
+  const verifier = VERIFIER_CONTRACTS[chain]
+  const dailyFees = createBalances()
+
+  try {
+    const fromBlock = await getFromBlock()
+    const toBlock = await getToBlock()
+
+    const endBalance = await sdk.api.eth.getBalance({
+      target: verifier,
+      block: toBlock,
+      chain,
+    })
+
+    const startBalance = await sdk.api.eth.getBalance({
+      target: verifier,
+      block: fromBlock,
+      chain,
+    })
+
+    const feesAmount = BigInt(endBalance.output) - BigInt(startBalance.output)
+    if (feesAmount > 0n) {
+      dailyFees.addGasToken(feesAmount.toString())
+    }
+  } catch (error) {
+    console.error(`Error fetching fees for ${chain}:`, error)
+  }
 
   return {
     dailyFees,
@@ -28,30 +50,27 @@ const fetchFees = async (options: any) => {
 const adapter: SimpleAdapter = {
   version: 2,
   adapter: {
-    [CHAIN.ARBITRUM]: { 
-      fetch: fetchFees, 
-      start: 1716484395, // 2024-05-23 
+    [CHAIN.ARBITRUM]: {
+      fetch: fetchFees,
+      start: 1716484395, // 2024-05-23
     },
-    [CHAIN.OPTIMISM]: { 
-      fetch: fetchFees, 
-      start: 1692630557, // 2023-08-21 
+    [CHAIN.OPTIMISM]: {
+      fetch: fetchFees,
+      start: 1692630557, // 2023-08-21
     },
-    [CHAIN.BASE]: { 
-      fetch: fetchFees, 
-      start: 1721578563, // 2024-07-21 
+    [CHAIN.BASE]: {
+      fetch: fetchFees,
+      start: 1721578563, // 2024-07-21
     },
-    [CHAIN.LINEA]: { 
-      fetch: fetchFees, 
-      start: 1697478754, // 2023-10-16 
+    [CHAIN.LINEA]: {
+      fetch: fetchFees,
+      start: 1697478754, // 2023-10-16
     },
-    [CHAIN.SCROLL]: { 
-      fetch: fetchFees, 
-      start: 1718977520, // 2024-06-21 
+    [CHAIN.SCROLL]: {
+      fetch: fetchFees,
+      start: 1718977520, // 2024-06-21
     },
-    [CHAIN.ZKSYNC]: { 
-      fetch: fetchFees, 
-      start: 1717590300, // 2024-06-05 
-    },
+   
   },
   methodology: {
     Fees: "Verification fees (~$2 USD in native ETH per attestation) paid when users call verifyAndAttest on GitcoinVerifier contracts to bring Gitcoin Passport data onchain",


### PR DESCRIPTION
This PR addresses the issue https://github.com/DefiLlama/dimension-adapters/issues/2617

### _Methodology_

Verification fees (~$2 USD in native ETH per attestation) paid when users call verifyAndAttest on GitcoinVerifier contracts to bring Gitcoin Passport data onchain

##### Name (to be shown on DefiLlama): Gitcoin Passport

##### Twitter Link:https://x.com/HumnPassport

##### Website Link:https://app.passport.xyz/

##### Logo (High resolution, will be shown with rounded [borders):] 
![YUykPo1H_400x400](https://github.com/user-attachments/assets/e060ddac-ce32-4ae2-bc85-2afc92024d13)

##### Chain: Arbitrum, Optimism, Base, Linea, ZKsync 

