### PR TITLE
feat: add blacklist wallets to opinion

### DIFF
--- a/dexs/opinion/index.ts
+++ b/dexs/opinion/index.ts
@@ -38,6 +38,8 @@ async function fetch(options: FetchOptions): Promise<FetchResult> {
   })
 
   orderFilledLogs.forEach((order: any) => {
+    dailyFees.addUSDValue(Number(order.fee) / 1e18)
+
     const maker = (order.maker || '').toString().toLowerCase()
     const taker = (order.taker || '').toString().toLowerCase()
 
@@ -48,7 +50,6 @@ async function fetch(options: FetchOptions): Promise<FetchResult> {
     const tradeVolume =
       Number(order.makerAssetId == 0 ? order.makerAmountFilled : order.takerAmountFilled) / 1e18
     dailyVolume.addUSDValue(Number(tradeVolume) / 2)
-    dailyFees.addUSDValue(Number(order.fee) / 1e18)
   })
 
   return {


### PR DESCRIPTION
### Summary 
Add a blacklist to exclude suspicious trading wallets from opinion protocol volume

Based on on-chain analysis, we identified a circular trading cluster responsible for ~$115M in non-economic (wash) volume, materially inflating reported volume. The blacklist removes only wallets that meet strict, objective criteria and documents the rationale clearly in the adapter.

### Evidence

#### Confirmed Circular Wash Trading Cluster
Data sample from 15th Nov & Jan 1st
| Wallet | Approx. Volume | Pattern |
|------|----------------|---------|
| `0xd006...` (Hub) | $54.7M | Trades 98%+ with only 2, 4, 5, 6 |
| `0xc233...` | $21.7M | 85% of volume with Hub |
| `0xb76b...` | $19.0M | 84% of volume with Hub |
| `0x418a...` | $10.1M | 99% of volume with Hub (only 2 counterparties) |
| `0x6c33...` | $9.4M | 99% of volume with Hub |


#### Key Findings
- The hub wallet’s top trader shows ~90% offsetting volume repeatedly trading both YES and NO on the same markets
- Partner wallets (5 and 6) trade ~99% of their volume exclusively with the hub wallet
- Total circular (wash) volume identified: ~$115M
- OI between 136-267% on these dates which indicates a lot of turnover compared with polymarket 22-33% over the same dates

This pattern is consistent with coordinated circular trading, not competitive market making

#### Detection Criteria

Wallets were flagged only when all of the following conditions were met:

- Top-3 counterparty concentration >90%
- Offsetting volume >70% (buying both sides of the same market)
- Unique counterparties <10
- Sustained behaviour across multiple periods

These thresholds are intentionally conservative to avoid false positives

#### Changes

- Added `WASH_TRADING_BLACKLIST` containing 5 confirmed circular wash traders
- Updated `fetch()` to skip trades where either maker or taker is blacklisted
- Updated adapter methodology to explicitly document excluded wallets and rationale

#### Notes
- This blacklist is intended as a temporary mitigation
- Documented in-code to ensure transparency and future re-evaluation