### PR TITLE
feat: add lighter buybacks

### DIFF
--- a/fees/lighterv2/index.ts
+++ b/fees/lighterv2/index.ts
@@ -115,8 +115,7 @@ const methodology = {
   Fees: 'Maker and taker fees paid by premium accounts on the Lighter DEX',
   Revenue: 'All trading fees are protocol revenue',
   ProtocolRevenue: 'All trading fees go to the protocol treasury',
-  HoldersRevenue:
-    'LIT token buybacks executed by the treasury account. The protocol uses fees to buy back LIT tokens from the market.',
+  HoldersRevenue: 'LIT token buybacks from treasury. The protocol uses fees to buy back LIT tokens from the market.',
 }
 
 const breakdownMethodology = {
@@ -131,18 +130,15 @@ const breakdownMethodology = {
   },
   HoldersRevenue: {
     [METRIC.TOKEN_BUY_BACK]:
-      'LIT token buybacks from treasury account trades. Buybacks can be tracked at https://app.lighter.xyz/explorer/accounts/0',
+      'LIT token buybacks from treasury. Buybacks can be tracked at https://app.lighter.xyz/explorer/accounts/0',
   },
 }
 
 const adapter: SimpleAdapter = {
   version: 2,
-  adapter: {
-    [CHAIN.ZK_LIGHTER]: {
-      fetch,
-      start: '2025-10-22',
-    },
-  },
+  fetch,
+  chains: [CHAIN.ZK_LIGHTER],
+  start: '2025-10-22',
   methodology,
   breakdownMethodology,
 }


### PR DESCRIPTION
resolves: #5551 

### Summary 
adds `dailyHolderRevenue` tracking for LIT token buybacks executed by the Lighter protocol treasury

#### Data Sources
Explorer API:[https://explorer.elliot.ai/api/accounts/0/logs]( https://explorer.elliot.ai/api/accounts/0/logs)

#### How Buybacks Are Identified
The treasury account (index 0) executes LIT buybacks on the LIT/USDC spot market:
- Account: 0 (labeled "main account" in explorer UI, l1_address: 0x000...0)
- Market: 2049 (LIT/USDC spot)
- Direction: is_taker_ask = 0 (treasury is buying, not selling)
- Calculation: SUM(price * size) for all matching trades

#### API Documentation
Explorer API: [https://apidocs.lighter.xyz/reference/get_accounts-param-logs](https://apidocs.lighter.xyz/reference/get_accounts-param-logs)
Treasury explorer: [https://app.lighter.xyz/explorer/accounts/0](https://app.lighter.xyz/explorer/accounts/0)

#### Notes
Buybacks were verified against on-chain data:
- Jan 5, 2026: 958 trades, 165,790.13 LIT purchased, $505,732 USD spent
- Jan 7, 2026: 1,667 trades, 100,000 LIT purchased, $288,113 USD spent

#### Testing 
`pnpm test fees lighterv2 2026-01-06`
`pnpm test fees lighterv2 2026-01-08`

```
ZKLIGHTER 👇
Backfill start time: 22/10/2025
Daily fees: 265.58 k
Daily revenue: 265.58 k
Daily protocol revenue: 265.58 k
Daily holders revenue: 505.73 k
End timestamp: 1767657599 (2026-01-05T23:59:59.000Z)
```

```
ZKLIGHTER 👇
Backfill start time: 22/10/2025
Daily fees: 196.86 k
Daily revenue: 196.86 k
Daily protocol revenue: 196.86 k
Daily holders revenue: 288.11 k
End timestamp: 1767830399 (2026-01-07T23:59:59.000Z)
```