### PR TITLE
feat: add chapool adapter

### DIFF
--- a/fees/chapool.ts
+++ b/fees/chapool.ts
@@ -1,6 +1,76 @@
 import { Adapter, Dependencies, FetchOptions, FetchResult } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
-import { queryDune } from "../helpers/dune";
+import { queryDuneSql } from "../helpers/dune";
+
+const dailyRevenueQuery = `
+WITH daily_payments AS (
+    SELECT 
+        DATE(block_time) as payment_date,
+        SUM(varbinary_to_uint256(bytearray_substring(data, 65, 32))) as daily_volume
+    FROM opbnb.logs
+    WHERE 
+        contract_address = 0xEe83640f0ed07d36E799531CC6d87FB4CDcCaC13
+        AND topic0 = 0x32aced27dfd49efcd31ceb0567a1ef533d2ab1481334c3f316047bf16fe1c8e8
+        AND block_number >= 92328871
+    GROUP BY DATE(block_time)
+),
+daily_refunds AS (
+    SELECT 
+        DATE(block_time) as refund_date,
+        SUM(varbinary_to_uint256(bytearray_substring(data, 65, 32))) as daily_refund_volume
+    FROM opbnb.logs
+    WHERE 
+        contract_address = 0xEe83640f0ed07d36E799531CC6d87FB4CDcCaC13
+        AND topic0 = 0x4d60a9438ba7e18c1fed7577dc8932bfe82f683c1e254a5336b6618ab5301641
+        AND block_number >= 92328871
+    GROUP BY DATE(block_time)
+),
+eth_price AS (
+    SELECT price
+    FROM prices.usd
+    WHERE symbol = 'ETH'
+    AND blockchain = 'opbnb'
+    ORDER BY minute DESC
+    LIMIT 1
+)
+SELECT 
+    COALESCE(dp.payment_date, dr.refund_date) as date,
+    (COALESCE(dp.daily_volume, 0) - COALESCE(dr.daily_refund_volume, 0)) / 1e18 as daily_net_revenue_eth,
+    (COALESCE(dp.daily_volume, 0) - COALESCE(dr.daily_refund_volume, 0)) / 1e18 * COALESCE(ep.price, 2500) as daily_net_revenue_usd
+FROM daily_payments dp
+FULL OUTER JOIN daily_refunds dr ON dp.payment_date = dr.refund_date
+CROSS JOIN eth_price ep
+ORDER BY date DESC
+`;
+
+const dailyVolumeQuery = `
+WITH daily_payments AS (
+    SELECT 
+        DATE(block_time) as payment_date,
+        SUM(varbinary_to_uint256(bytearray_substring(data, 65, 32))) as daily_volume
+    FROM opbnb.logs
+    WHERE 
+        contract_address = 0xEe83640f0ed07d36E799531CC6d87FB4CDcCaC13
+        AND topic0 = 0x32aced27dfd49efcd31ceb0567a1ef533d2ab1481334c3f316047bf16fe1c8e8
+        AND block_number >= 92328871
+    GROUP BY DATE(block_time)
+),
+eth_price AS (
+    SELECT price
+    FROM prices.usd
+    WHERE symbol = 'ETH'
+    AND blockchain = 'opbnb'
+    ORDER BY minute DESC
+    LIMIT 1
+)
+SELECT 
+    dp.payment_date as date,
+    dp.daily_volume / 1e18 as daily_volume_eth,
+    (dp.daily_volume / 1e18) * COALESCE(ep.price, 2500) as daily_volume_usd
+FROM daily_payments dp
+CROSS JOIN eth_price ep
+ORDER BY date DESC
+`;
 
 const fetch = async (_timestamp: number, _: any, options: FetchOptions): Promise<FetchResult> => {
   const preFetchedResults = options.preFetchedResults;
@@ -21,7 +91,7 @@ const fetch = async (_timestamp: number, _: any, options: FetchOptions): Promise
     return rowDate === dayStr;
   });
 
-  const dailyRevenue = dailyRevRow ? dailyRevRow.daily_net_usdt : undefined;
+  const dailyRevenue = dailyRevRow ? dailyRevRow.daily_net_revenue_usd : undefined;
   const dailyVolume = dailyVolRow ? dailyVolRow.daily_volume_usd : undefined;
   
   return {
@@ -34,8 +104,8 @@ const fetch = async (_timestamp: number, _: any, options: FetchOptions): Promise
 
 const prefetch = async (options: FetchOptions) => {
   const [dailyRevenue, dailyVolume] = await Promise.all([
-    queryDune("6292099", {}, options),
-    queryDune("6494471", {}, options)
+    queryDuneSql(options, dailyRevenueQuery),
+    queryDuneSql(options, dailyVolumeQuery)
   ]);
 
   return {


### PR DESCRIPTION
Added adapter for Chapool protocol on opBNB chain.

**Changes:**
- Added `fees/chapool.ts` which fetches daily revenue, total revenue, and daily volume from Dune Analytics.

**Dune Queries:**
- Total Revenue: 6441606
- Daily Revenue: 6292099
- Daily Volume: 6494471

**Verification:**
- Tested locally via `npm run test fees chapool`.
- Confirmed data retrieval for valid dates (e.g., 2025-12-26).