### PR TITLE
feat: add dflow prediction vol/fees

### DIFF
--- a/dexs/dflow-prediction/index.ts
+++ b/dexs/dflow-prediction/index.ts
@@ -90,6 +90,7 @@ const adapter: SimpleAdapter = {
   start: '2025-11-23',
   chains: [CHAIN.SOLANA],
   isExpensiveAdapter: true,
+  doublecounted: true,
   dependencies: [Dependencies.DUNE],
   methodology,
 }


### PR DESCRIPTION
resolves: #5580 

### Summary
Adds volume and fees tracking for DFlow Prediction Markets on Solana, powered by the Kalshi CLP (Concurrent Liquidity Program)

#### Added
- `dexs/dflow-prediction/index.ts` 

#### Technical Details
Program ID: `pReDicTmksnPfkfiz33ndSdbe2dY43KYPg4U2dbvHvb`

Collateral Tokens:
- CASH (`CASHx9KJUStyftLFWGvEVf59SGeG9sh5FfcnZMVPCASH`) - pegged to $1
- USDC (`EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v`)

Key Addresses:
- CASH Settlement Vault: `AgfNbTUmTK75HcpDCsuTDarj2iapJCbNSr2pzcCXRBS`
- USDC Settlement Vault: `6k797rx8d5xUBsfCgp7LDrsvvnnxjKf2MjQkx6kvdPDw`
- Fee Account: `8psNvWTrdNTiVRNzAgsou9kETXNJm2SXZyaKuJraVRtf`

#### Methodology
- Volume: Transfers to settlement vault owners (actual trade value deposited)
- Fees: Transfers to fee account. Fee formula: scale * p * (1 - p) * c
- Revenue: All fees are protocol revenue

#### Data Sources
- Uses Dune Analytics (solana.instruction_calls + tokens_solana.transfers)
- CASH token uses raw amount (no USD pricing in Dune, but pegged to $1)
- USDC uses amount_usd from Dune

#### Testing
`pnpm run test dexs dflow-prediction 2026-01-01`
```
SOLANA 👇
Backfill start time: 23/11/2025
Daily volume: 208.71 k
Daily fees: 4.61 k
Daily revenue: 4.61 k
Daily protocol revenue: 4.61 k
Daily holders revenue: 0.00
```