### PR TITLE
Fixed SSV network Fee adapter

### DIFF
--- a/fees/ssv-network.ts
+++ b/fees/ssv-network.ts
@@ -41,9 +41,11 @@ const fetch = async (_: any, _1: any, options: FetchOptions) => {
   const dailyNetworkEarningsIncrease = Math.max(0, Number(endNetworkEarnings) - Number(startNetworkEarnings));
 
   // Convert to SSV tokens
+  // getNetworkFee() returns total fees collected
+  // getNetworkEarnings() returns total revenue (protocol earnings)
   const totalFees = weiToSSV(dailyNetworkFeeIncrease.toString());
   const networkRevenue = weiToSSV(dailyNetworkEarningsIncrease.toString());
-  const operatorRevenue = Math.max(0, totalFees - networkRevenue); // Remaining goes to operators
+  const operatorRevenue = Math.max(0, totalFees - networkRevenue);
 
   // Add to balances
   dailyFees.addCGToken(SSV_COINGECKO_ID, totalFees);


### PR DESCRIPTION
Addresses issue: https://github.com/DefiLlama/dimension-adapters/issues/5597
 
This adapter tracks fees and revenue for the SSV Network. Previously, it relied on a GraphQL subgraph API that was discontinued and no longer available. To resolve this, the adapter was updated to fetch fee and revenue data directly from the SSV Network contract using on-chain calls to getNetworkFee() and getNetworkEarnings() functions. The adapter calculates daily changes by comparing values at the start and end of each period, providing accurate real-time fee tracking from the blockchain.

Source: https://docs.ssv.network/developers/smart-contracts/