### PR TITLE
Add revenues to sparkdex v2 and v3

### DIFF
--- a/dexs/sparkdex-v2/index.ts
+++ b/dexs/sparkdex-v2/index.ts
@@ -1,6 +1,19 @@
+import { SimpleAdapter } from '../../adapters/types'
 import { CHAIN } from '../../helpers/chains'
-import { uniV2Exports } from '../../helpers/uniswap'
+import { getUniV2LogAdapter } from '../../helpers/uniswap'
 
-export default uniV2Exports({
-  [CHAIN.FLARE]: { factory: '0x16b619B04c961E8f4F06C10B42FDAbb328980A89',},
-})
+const adapter: SimpleAdapter = {
+	version: 2,
+	methodology: {
+		Volume: 'Total swap volume',
+		Fees: 'Users pay 0.3% per swap.',
+		UserFees: 'Users pay 0.3% per swap.',
+		Revenue: 'No revenue.',
+		SupplySideRevenue: 'All swap fees are distributed to LPs.',
+	},
+	start: '2024-06-27',
+	chains: [CHAIN.FLARE],
+	fetch: getUniV2LogAdapter({ factory: '0x16b619B04c961E8f4F06C10B42FDAbb328980A89', userFeesRatio: 1, revenueRatio: 0 }),
+}
+
+export default adapter

--- a/dexs/sparkdex-v3/index.ts
+++ b/dexs/sparkdex-v3/index.ts
@@ -1,7 +1,23 @@
 
+import { SimpleAdapter } from '../../adapters/types'
 import { CHAIN } from '../../helpers/chains'
-import { uniV3Exports } from '../../helpers/uniswap'
+import { getUniV3LogAdapter } from '../../helpers/uniswap'
 
-export default uniV3Exports({
-  [CHAIN.FLARE]: { factory: '0xb3fB4f96175f6f9D716c17744e5A6d4BA9da8176',},
-})
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  methodology: {
+    Volume: 'Total swap volume',
+    Fees: 'Swap fees paid by users.',
+    UserFees: 'Swap fees paid by users.',
+    Revenue: '7.5% of the fees go to the protocol.',
+    ProtocolRevenue: '2.5% of the fees go to the SparkDEX Foundation',
+    HoldersRevenue: '5% of the fees are used in buybacks and burns of $SPRK',
+    SupplySideRevenue: '87.5% of swap fees are distributed to LPs and 5% is distributed to $SPRK stakers',
+  },
+  start: '2024-06-27',
+  chains: [CHAIN.FLARE],
+  fetch: getUniV3LogAdapter({ factory: '0xb3fB4f96175f6f9D716c17744e5A6d4BA9da8176', userFeesRatio: 1, revenueRatio: 0.075, protocolRevenueRatio: 0.025, holdersRevenueRatio: 0.05 }),
+}
+
+export default adapter


### PR DESCRIPTION
I've added revenue, supply side revenue and holders revenue to sparkdex v2 and v3 to fix the sparkdex income statement