### PR TITLE
Add holders revenue to fees in Sparkdex V3.1

### DIFF
--- a/fees/sparkdex-v3-1/index.ts
+++ b/fees/sparkdex-v3-1/index.ts
@@ -58,6 +58,7 @@ const graphs = (graphUrls: ChainEndpoints) => {
       const burned = BigInt(log.xSPRKAmount) - BigInt(log.sprkAmount);
       if (burned > 0) {
         dailyHoldersRevenue.add(CONTRACT_SPARK_TOKEN, burned);
+        dailyFees.add(CONTRACT_SPARK_TOKEN, burned)
       }
     });
 


### PR DESCRIPTION
The holders revenue from SPRK burns was not being added to fees