### PR TITLE
feat: add fragmetric fees

### DIFF
--- a/fees/fragmetric/index.ts
+++ b/fees/fragmetric/index.ts
@@ -129,28 +129,16 @@ const fetch = async (_a: any, _b: any, options: FetchOptions) => {
     }
   }
 
-  // Track FRAG token buybacks using Solana helper
-  await getSolanaReceivedDune({
+  const treasuryBalanceReceived = await getSolanaReceivedDune({
     options,
-    balances: dailyHoldersRevenue,
     target: FRAGMETRIC.TREASURY_WALLET,
   })
-
-  // Apply buyback metric label to balances
-  const balancesData = dailyHoldersRevenue.getBalances()
-  for (const [tokenKey, amount] of Object.entries(balancesData)) {
-    if (amount) {
-      const token = tokenKey.includes(':') ? tokenKey.split(':')[1] : tokenKey
-
-      dailyHoldersRevenue.removeTokenBalance(tokenKey) // Remove unlabelled balance
-      dailyHoldersRevenue.add(token, amount, METRIC.TOKEN_BUY_BACK)
-    }
-  }
+  dailyHoldersRevenue.add(treasuryBalanceReceived, METRIC.TOKEN_BUY_BACK)
 
   return {
     dailyFees,
     dailyRevenue,
-    dailyProtocolRevenue: dailyRevenue,
+    dailyProtocolRevenue: 0,
     dailySupplySideRevenue,
     dailyHoldersRevenue,
   }
@@ -160,11 +148,11 @@ const methodology = {
   Fees: 'Total fees generated from Fragmetric LRTs, including protocol revenue and user reward claims.',
   Revenue:
     "Protocol fees captured in Fund Treasury accounts, Program Revenue account, and Jito Restaking Vault. Includes fragSOL/fragJTO fees and protocol's share of Jito restaking rewards (SW1TCH).",
-  ProtocolRevenue: 'Same as Revenue - protocol fees captured by Fragmetric.',
+  ProtocolRevenue: 'Fragmetric uses 100% of protocol revenue to buy back FRAG tokens.',
   SupplySideRevenue:
     'Staking and restaking rewards claimed by LRT holders. Tracked via transfers from Reward Token Reserve accounts.',
   HoldersRevenue:
-    'FRAG token buybacks funded by 100% of protocol fees. Tracks FRAG tokens purchased and transferred to the Treasury Wallet, reducing circulating supply and benefiting token holders.',
+    'FRAG token buybacks funded by 100% of protocol revenue. Tracks FRAG tokens purchased and transferred to the Treasury Wallet, reducing circulating supply and benefiting token holders.',
 }
 
 const breakdownMethodology = {
@@ -182,7 +170,7 @@ const breakdownMethodology = {
     [METRIC.ASSETS_YIELDS]: 'User claims of other staking/yield rewards',
   },
   HoldersRevenue: {
-    [METRIC.TOKEN_BUY_BACK]: 'FRAG tokens purchased using protocol fees and sent to Treasury',
+    [METRIC.TOKEN_BUY_BACK]: 'FRAG tokens purchased using protocol revenue and sent to Treasury',
   },
 }
 


### PR DESCRIPTION
resolves: #5218 

## Summary
Adds fees and revenue tracking for Fragmetric, a Liquid Restaking Protocol on Solana offering 5 LRT products (fragSOL, fragJTO, fragBTC, FRAG², fragSWTCH) built on the FRAG-22 architecture. Buybacks also tracked. 

### Metrics
**Protocol Revenue**
Fees captured by Fragmetric via transfers to:
- Fund Treasury accounts (fragSOL Fund, fragJTO Fund)
- Program Revenue account (`XEhpR3UauMkARQ8ztwaU9Kbv16jEpBbXs9ftELka9wj`)

**Supply Side Revenue**
Staking/restaking rewards distributed to LRT holders via transfers from:
- Reward token reserve accounts

**Total fees**
Sum of protocol rev + supply side rev

**DailyHoldersRevenue**
FRAG buybacks to the treasury account (`6dSWUQt6sbA6B26Jjzwa3JAQPXFVAQbzWY1X7xLqkRKD`

### Implementation
Uses dune sql queries on `tokens_solana.transfers` to retrieve rewards and revenue

### Resources
- https://github.com/fragmetric-labs/fragmetric-contracts
- https://docs.fragmetric.xyz/protocol/module/fund/accounting
- https://docs.fragmetric.xyz/protocol/module/reward/overview
- https://docs.fragmetric.xyz/dev/solana-programs
- https://x.com/fragmetric/status/201019447544503914

### Testing
`pnpm test fees fragmetric 2026-01-10`
```
Daily fees: 19.40 k
Daily revenue: 13.01 k
Daily protocol revenue: 13.01 k
Daily supply side revenue: 6.38 k
Daily holders revenue: 2.04 k
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added Fragmetric adapter for Solana to compute and categorize protocol and user revenue for Fragmetric LRTs
* Tracks multiple revenue sources including management fees, protocol fees, staking rewards, and token buybacks
* Provides daily aggregated metrics on fees, revenue, supply-side revenue, and holder returns

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->