### PR TITLE
Add NYM Fee Tracking to River Protocol Adapter

### DIFF
--- a/fees/river/config.ts
+++ b/fees/river/config.ts
@@ -47,4 +47,14 @@ export const config: Record<string, ChainConfig> = {
         stableCoin: '0xb4818BB69478730EF4e33Cc068dD94278e2766cB',
         start: '2025-02-21',
     },
+    [CHAIN.SONIC]: {
+        satoshiXapp: '0x07BbC5A83B83a5C440D1CAedBF1081426d0AA4Ec',
+        stableCoin: '0xb4818BB69478730EF4e33Cc068dD94278e2766cB',
+        start: '2025-06-10',
+    },
+    [CHAIN.XLAYER]: {
+        satoshiXapp: '0xB4d4793a1CD57b6EceBADf6FcbE5aEd03e8e93eC',
+        stableCoin: '0xceF6c74Ce218c0E1F48cA2430635D0a65Cd3737A',
+        start: '2025-08-28',
+    },
 }

--- a/fees/river/index.ts
+++ b/fees/river/index.ts
@@ -120,7 +120,7 @@ const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
     })
 
     // Process NYM Protocol fees
-    // NYM Swap In: Users swap assets -> debtToken (feeIn: ~0.05%)
+    // NYM Swap In: Users swap assets -> debtToken (feeIn: ~0.5%)
     nymSwapInLogs.forEach((log) => {
         if (log.fee && log.fee > 0n) {
             // Fees are in debtToken (stableCoin)
@@ -129,7 +129,7 @@ const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
         }
     })
 
-    // NYM Swap Out (Scheduled): Users swap debtToken -> assets (feeOut: ~1.00%)
+    // NYM Swap Out (Scheduled): Users swap debtToken -> assets (feeOut: ~5.00%)
     nymWithdrawalScheduledLogs.forEach((log) => {
         if (log.fee && log.fee > 0n) {
             // Fees are in debtToken (stableCoin)
@@ -201,8 +201,8 @@ export default {
             [METRICS.BorrowFees]: 'One-time borrow fees paid by borrowers.',
             [METRICS.RedemptionFee]: 'Redemption fees paid by borrowers.',
             [METRICS.GasCompensation]: 'Gas compensations paid when liquidations are triggered.',
-            [METRICS.NymSwapInFee]: 'Swap in fees when users exchange collateral assets for debtToken. Rate: ~0.05% (5 bps).',
-            [METRICS.NymSwapOutFee]: 'Swap out fees when users schedule exchanges of debtToken for collateral assets. Rate: ~1.00% (100 bps).',
+            [METRICS.NymSwapInFee]: 'Swap in fees when users exchange collateral assets for debtToken. Rate: ~0.5% (50 bps).',
+            [METRICS.NymSwapOutFee]: 'Swap out fees when users schedule exchanges of debtToken for collateral assets. Rate: ~5.00% (500 bps).',
         },
         Revenue: {
             [METRICS.BorrowFees]: 'One-time borrow fees paid by borrowers.',


### PR DESCRIPTION
Adds Nexus Yield Manager (NYM) fee tracking to the existing River adapter.
NYM is a Peg Stability Module deployed on the same `satoshiXapp` contract address.

### New Metrics
- NYM Swap In Fees (~0.5%)
- NYM Swap Out Fees (~5.00%)

### Changes
- Added 3 NYM event listeners
- Filters privileged transactions (fee = 0)
- All fees distributed to RewardManager → stakers
- Existing River metrics unaffected

Both protocols share the same contract address (Diamond facet pattern), making combined tracking efficient.