### PR TITLE
Add Orderly broker adapter for COIN360

### DIFF
--- a/dexs/orderly-broker-coin360/index.ts
+++ b/dexs/orderly-broker-coin360/index.ts
@@ -1,0 +1,14 @@
+import { getBuilderExports } from "../../helpers/orderly";
+
+const methodology = {
+  Volume: "Maker/taker volume that flow through the interface",
+  Fees: "Builder Fees collected from Orderly Network",
+  Revenue: "All the fees collected",
+  ProtocolRevenue: "All the revenue goes to the protocol",
+};
+
+export default getBuilderExports({
+  broker_id: "coin360",
+  start: "2025-10-13",
+  methodology,
+});


### PR DESCRIPTION
Adds an Orderly Network broker adapter for COIN360 (broker_id: coin360) using Orderly builder daily stats.
Start date: 2025-10-13 (first day available from API).
Reports daily volume and fees.