### PR TITLE
Blacklist spectra-v2 pool with wrong data

### DIFF
--- a/dexs/spectra-v2.ts
+++ b/dexs/spectra-v2.ts
@@ -114,7 +114,7 @@ const chains: {
     start: "2025-06-01",
     protocolSubgraphUrl:
       "https://api.goldsky.com/api/public/project_cm55feuq3euos01xjb3w504ls/subgraphs/spectra-hyperevm/prod/gn",
-    blacklistPools: ["0x60f393a4a7e41aae2bfa0f401e1f114c3ad088f6"]
+    blacklistPools: ["0x60f393a4a7e41aae2bfa0f401e1f114c3ad088f6"] // Returns inflated values, for example this 4$ transaction returns 195k in volume: https://hyperevmscan.io/tx/0x4502e2238e3def500bc11387c40ab85b08b062b9572619a9a4051b36f7b4fb84
   },
   [CHAIN.KATANA]: {
     id: 747474,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated HYPERLIQUID chain configuration to add a specific pool address to the blacklist.
  * This change adjusts which pools are considered during internal aggregation processes for daily metrics, aligning HYPERLIQUID’s exclusions with existing patterns across other supported networks.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->