### PR TITLE
update and add new hl builders

### DIFF
--- a/dexs/coinpilot-perps.ts
+++ b/dexs/coinpilot-perps.ts
@@ -1,0 +1,27 @@
+import { CHAIN } from "../helpers/chains";
+import { fetchBuilderCodeRevenue } from "../helpers/hyperliquid";
+import { FetchOptions, SimpleAdapter } from "../adapters/types";
+
+// https://www.trycoinpilot.com/
+const HL_BUILDER_ADDRESS = '0xe9935bb291ab3603b4d7862e6f19315f759aa3a4';
+
+const fetch = async (_a: any, _b: any, options: FetchOptions) => {
+  const { dailyVolume, dailyFees, dailyRevenue, dailyProtocolRevenue } = await fetchBuilderCodeRevenue({ options, builder_address: HL_BUILDER_ADDRESS });
+  return { dailyVolume, dailyFees, dailyRevenue, dailyProtocolRevenue };
+};
+
+const methodology = {
+  Fees: 'Trading fees paid by users for perps in CoinPilot Mobile App.',
+  Revenue: 'Fees collected by CoinPilot from Hyperliquid Perps as Builder Revenue.',
+  ProtocolRevenue: 'Fees collected by CoinPilot from Hyperliquid Perps as Builder Revenue.',
+}
+
+const adapter: SimpleAdapter = {
+  version: 1,
+  fetch,
+  chains: [CHAIN.HYPERLIQUID],
+  start: '2025-08-01',
+  methodology,
+};
+
+export default adapter;

--- a/dexs/gemwallet-perps.ts
+++ b/dexs/gemwallet-perps.ts
@@ -1,0 +1,27 @@
+import { CHAIN } from "../helpers/chains";
+import { fetchBuilderCodeRevenue } from "../helpers/hyperliquid";
+import { FetchOptions, SimpleAdapter } from "../adapters/types";
+
+// https://gemwallet.com/
+const HL_BUILDER_ADDRESS = '0x0d9dab1a248f63b0a48965ba8435e4de7497a3dc';
+
+const fetch = async (_a: any, _b: any, options: FetchOptions) => {
+  const { dailyVolume, dailyFees, dailyRevenue, dailyProtocolRevenue } = await fetchBuilderCodeRevenue({ options, builder_address: HL_BUILDER_ADDRESS });
+  return { dailyVolume, dailyFees, dailyRevenue, dailyProtocolRevenue };
+};
+
+const methodology = {
+  Fees: 'Trading fees paid by users for perps in Gem Wallet.',
+  Revenue: 'Fees collected by Gem Wallet from Hyperliquid Perps as Builder Revenue.',
+  ProtocolRevenue: 'Fees collected by Gem Wallet from Hyperliquid Perps as Builder Revenue.',
+}
+
+const adapter: SimpleAdapter = {
+  version: 1,
+  fetch,
+  chains: [CHAIN.HYPERLIQUID],
+  start: '2025-08-01',
+  methodology,
+};
+
+export default adapter;

--- a/dexs/katoshi-perps.ts
+++ b/dexs/katoshi-perps.ts
@@ -1,0 +1,27 @@
+import { CHAIN } from "../helpers/chains";
+import { fetchBuilderCodeRevenue } from "../helpers/hyperliquid";
+import { FetchOptions, SimpleAdapter } from "../adapters/types";
+
+// https://katoshi.ai/
+const HL_BUILDER_ADDRESS = '0x274e3cdb7bdc4805f41a07e3348243ba3e7e5b72';
+
+const fetch = async (_a: any, _b: any, options: FetchOptions) => {
+  const { dailyVolume, dailyFees, dailyRevenue, dailyProtocolRevenue } = await fetchBuilderCodeRevenue({ options, builder_address: HL_BUILDER_ADDRESS });
+  return { dailyVolume, dailyFees, dailyRevenue, dailyProtocolRevenue };
+};
+
+const methodology = {
+  Fees: 'Trading fees paid by users for perps in Katoshi Trading Terminal.',
+  Revenue: 'Fees collected by Katoshi from Hyperliquid Perps as Builder Revenue.',
+  ProtocolRevenue: 'Fees collected by Katoshi from Hyperliquid Perps as Builder Revenue.',
+}
+
+const adapter: SimpleAdapter = {
+  version: 1,
+  fetch,
+  chains: [CHAIN.HYPERLIQUID],
+  start: '2025-08-01',
+  methodology,
+};
+
+export default adapter;

--- a/dexs/metascalp-perps.ts
+++ b/dexs/metascalp-perps.ts
@@ -1,0 +1,27 @@
+import { CHAIN } from "../helpers/chains";
+import { fetchBuilderCodeRevenue } from "../helpers/hyperliquid";
+import { FetchOptions, SimpleAdapter } from "../adapters/types";
+
+// https://metascalp.io
+const HL_BUILDER_ADDRESS = '0xa9ab442f9dfe752dc74b666c41e7a0498baf8687';
+
+const fetch = async (_a: any, _b: any, options: FetchOptions) => {
+  const { dailyVolume, dailyFees, dailyRevenue, dailyProtocolRevenue } = await fetchBuilderCodeRevenue({ options, builder_address: HL_BUILDER_ADDRESS });
+  return { dailyVolume, dailyFees, dailyRevenue, dailyProtocolRevenue };
+};
+
+const methodology = {
+  Fees: 'Trading fees paid by users for perps in Metascalp Trading Terminal.',
+  Revenue: 'Fees collected by Metascalp from Hyperliquid Perps as Builder Revenue.',
+  ProtocolRevenue: 'Fees collected by Metascalp from Hyperliquid Perps as Builder Revenue.',
+}
+
+const adapter: SimpleAdapter = {
+  version: 1,
+  fetch,
+  chains: [CHAIN.HYPERLIQUID],
+  start: '2025-09-11',
+  methodology,
+};
+
+export default adapter;

--- a/dexs/onekey-perps.ts
+++ b/dexs/onekey-perps.ts
@@ -1,0 +1,27 @@
+import { CHAIN } from "../helpers/chains";
+import { fetchBuilderCodeRevenue } from "../helpers/hyperliquid";
+import { FetchOptions, SimpleAdapter } from "../adapters/types";
+
+// https://onekey.so/
+const HL_BUILDER_ADDRESS = '0x9b12e858da780a96876e3018780cf0d83359b0bb';
+
+const fetch = async (_a: any, _b: any, options: FetchOptions) => {
+  const { dailyVolume, dailyFees, dailyRevenue, dailyProtocolRevenue } = await fetchBuilderCodeRevenue({ options, builder_address: HL_BUILDER_ADDRESS });
+  return { dailyVolume, dailyFees, dailyRevenue, dailyProtocolRevenue };
+};
+
+const methodology = {
+  Fees: 'Trading fees paid by users for perps in OneKey Wallet.',
+  Revenue: 'Fees collected by OneKey from Hyperliquid Perps as Builder Revenue.',
+  ProtocolRevenue: 'Fees collected by OneKey from Hyperliquid Perps as Builder Revenue.',
+}
+
+const adapter: SimpleAdapter = {
+  version: 1,
+  fetch,
+  chains: [CHAIN.HYPERLIQUID],
+  start: '2025-08-20',
+  methodology,
+};
+
+export default adapter;

--- a/dexs/splashos-perps.ts
+++ b/dexs/splashos-perps.ts
@@ -1,0 +1,27 @@
+import { CHAIN } from "../helpers/chains";
+import { fetchBuilderCodeRevenue } from "../helpers/hyperliquid";
+import { FetchOptions, SimpleAdapter } from "../adapters/types";
+
+// https://splashwallet.xyz/
+const HL_BUILDER_ADDRESS = '0xe9935bb291ab3603b4d7862e6f19315f759aa3a4';
+
+const fetch = async (_a: any, _b: any, options: FetchOptions) => {
+  const { dailyVolume, dailyFees, dailyRevenue, dailyProtocolRevenue } = await fetchBuilderCodeRevenue({ options, builder_address: HL_BUILDER_ADDRESS });
+  return { dailyVolume, dailyFees, dailyRevenue, dailyProtocolRevenue };
+};
+
+const methodology = {
+  Fees: 'Trading fees paid by users for perps in SplashOS Mobile App.',
+  Revenue: 'Fees collected by SplashOS from Hyperliquid Perps as Builder Revenue.',
+  ProtocolRevenue: 'Fees collected by SplashOS from Hyperliquid Perps as Builder Revenue.',
+}
+
+const adapter: SimpleAdapter = {
+  version: 1,
+  fetch,
+  chains: [CHAIN.HYPERLIQUID],
+  start: '2025-08-01',
+  methodology,
+};
+
+export default adapter;

--- a/dexs/treadfi-perps.ts
+++ b/dexs/treadfi-perps.ts
@@ -1,0 +1,27 @@
+import { CHAIN } from "../helpers/chains";
+import { fetchBuilderCodeRevenue } from "../helpers/hyperliquid";
+import { FetchOptions, SimpleAdapter } from "../adapters/types";
+
+// https://www.tread.fi/
+const HL_BUILDER_ADDRESS = '0x999a4b5f268a8fbf33736feff360d462ad248dbf';
+
+const fetch = async (_a: any, _b: any, options: FetchOptions) => {
+  const { dailyVolume, dailyFees, dailyRevenue, dailyProtocolRevenue } = await fetchBuilderCodeRevenue({ options, builder_address: HL_BUILDER_ADDRESS });
+  return { dailyVolume, dailyFees, dailyRevenue, dailyProtocolRevenue };
+};
+
+const methodology = {
+  Fees: 'Trading fees paid by users for perps in Tread.fi perps trading terminal.',
+  Revenue: 'Fees collected by Tread.fi from Hyperliquid Perps as Builder Revenue.',
+  ProtocolRevenue: 'Fees collected by Tread.fi from Hyperliquid Perps as Builder Revenue.',
+}
+
+const adapter: SimpleAdapter = {
+  version: 1,
+  fetch,
+  chains: [CHAIN.HYPERLIQUID],
+  start: '2025-08-01',
+  methodology,
+};
+
+export default adapter;

--- a/fees/okto-wallet.ts
+++ b/fees/okto-wallet.ts
@@ -2,10 +2,25 @@ import { CHAIN } from '../helpers/chains'
 import { FetchOptions, SimpleAdapter } from '../adapters/types'
 import { fetchBuilderCodeRevenue } from '../helpers/hyperliquid'
 
-const OKTO_BUILDER_ADDRESS = '0x05984fd37db96dc2a11a09519a8def556e80590b'
+const OKTO_BUILDER_ADDRESSES = [
+  '0x05984fd37db96dc2a11a09519a8def556e80590b',
+  '0x4fe1141b9066f3777f4bd4d4ac9d216173031dc1',
+]
 
 const fetch = async (_a: any, _b: any, options: FetchOptions) => {
-  const { dailyVolume, dailyFees, dailyRevenue, dailyProtocolRevenue } = await fetchBuilderCodeRevenue({ options, builder_address: OKTO_BUILDER_ADDRESS });
+  const dailyVolume = options.createBalances()
+  const dailyFees = options.createBalances()
+  const dailyRevenue = options.createBalances()
+  const dailyProtocolRevenue = options.createBalances()
+  
+  for (const address of OKTO_BUILDER_ADDRESSES) {
+    const result = await fetchBuilderCodeRevenue({ options, builder_address: address });
+    dailyVolume.addBalances(result.dailyVolume)
+    dailyFees.addBalances(result.dailyFees)
+    dailyRevenue.addBalances(result.dailyRevenue)
+    dailyProtocolRevenue.addBalances(result.dailyProtocolRevenue)
+  }
+  
 
   return {
     dailyVolume,


### PR DESCRIPTION
New Hyperliquid Builders perps:
https://www.trycoinpilot.com/
https://onekey.so/
https://gemwallet.com/
https://katoshi.ai/
https://metascalp.io
https://splashwallet.xyz/
https://www.tread.fi/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added perps data adapters for seven new platforms (CoinPilot, Gem Wallet, Katoshi, Metascalp, OneKey, SplashOS, and Tread.fi) on Hyperliquid chain.
  * Expanded Okto Wallet adapter to support multiple builder addresses with aggregated metrics collection.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->