### PR TITLE
track standx-dusd fees

### DIFF
--- a/fees/standx-dusd/index.ts
+++ b/fees/standx-dusd/index.ts
@@ -38,7 +38,7 @@ async function fetchSol(_a: any, _b: any, options: FetchOptions): Promise<FetchR
 
     const queryResults = await queryDuneSql(options, duneQuery);
 
-    if(!queryResults)
+    if (!queryResults && !queryResults.length)
         throw new Error("No results found on dune");
 
     dailyFees.addUSDValue(queryResults[0].total_yield, METRIC.ASSETS_YIELDS);


### PR DESCRIPTION
To be listed as child at https://defillama.com/protocol/standx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Standx DUSD fee tracking for Solana and BSC. Provides daily analytics for yields and withdrawal fees, with detailed breakdowns of total fees, supply-side revenue, and protocol revenue for each chain. Data is presented in consistent daily metrics to support fee and revenue monitoring across supported networks.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->