### PR TITLE
Fix Lido supply side revenue

### DIFF
--- a/fees/lido.ts
+++ b/fees/lido.ts
@@ -31,8 +31,8 @@ const fetch = async (timestamp: number, _a: any, options: FetchOptions) => {
   const graphRes = await request(endpoints[options.chain], graphQuery);
 
   const dailyTotalRevenueUSD = Number(graphRes.financialsDailySnapshot.dailyTotalRevenueUSD)
-  const dailySupplySideRevenueUSD = Number(graphRes.financialsDailySnapshot.dailySupplySideRevenueUSD)
   const dailyProtocolRevenueUSD = dailyTotalRevenueUSD * PROTOCOL_FEE_RATIO
+  const dailySupplySideRevenueUSD = dailyTotalRevenueUSD - dailyProtocolRevenueUSD
 
   // MEV and execution rewards
   const mevFeesETH = options.createBalances()


### PR DESCRIPTION
The subgraph is returning the same value for total revenue and supply side revenue, I changed the supply side revenue calculation
@noateden This is part of the financial statement fixes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated financial revenue calculation methodology to derive supply-side revenue from total and protocol revenue components, ensuring consistency across financial metrics.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->