### PR TITLE
Add Probable TVL adapter (BSC)

### DIFF
--- a/helpers/sumTokens.ts
+++ b/helpers/sumTokens.ts
@@ -1,0 +1,20 @@
+import { ChainApi } from '@defillama/sdk'
+
+type SumTokensExportOptions = {
+  owner?: string
+  owners?: string[]
+  tokens?: string[]
+  tokensAndOwners?: [string, string][]
+}
+
+export const sumTokensExport = ({ owner, owners, tokens, tokensAndOwners }: SumTokensExportOptions) => {
+  const resolvedOwners = owners ?? (owner ? [owner] : [])
+  return async (api: ChainApi) => {
+    if (tokensAndOwners?.length) {
+      await api.sumTokens({ tokensAndOwners })
+    } else if (resolvedOwners.length && tokens?.length) {
+      await api.sumTokens({ owners: resolvedOwners, tokens })
+    }
+    return api.getBalances()
+  }
+}

--- a/projects/probable/index.ts
+++ b/projects/probable/index.ts
@@ -1,0 +1,10 @@
+import { sumTokensExport } from '../../helpers/sumTokens'
+
+const TREASURY = '0x364d05055614B506e2b9A287E4ac34167204cA83'
+const USDT = '0x55d398326f99059fF775485246999027B3197955'
+
+export default {
+  bsc: {
+    tvl: sumTokensExport({ owner: TREASURY, tokens: [USDT] }),
+  },
+}


### PR DESCRIPTION
### Summary

This PR adds a TVL adapter for **Probable** on **BSC**.

- TVL is calculated as the USDT balance held by the treasury address on BSC.
- Treasury: `0x364d05055614B506e2b9A287E4ac34167204cA83`
- Token counted: USDT (`0x55d398326f99059fF775485246999027B3197955`)

### Methodology

Counts USDT held directly by the Probable treasury on BSC.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a flexible token summation helper module supporting multiple configuration options for owner and token specifications.
  * Added TVL data source for the Probable project on Binance Smart Chain, configured to track treasury holdings in USDT.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->