### PR TITLE
blacklist sfrxUSD/eliteRingsScUSD

### DIFF
--- a/fees/impermax-finance/blacklist.ts
+++ b/fees/impermax-finance/blacklist.ts
@@ -87,7 +87,8 @@ const blacklistedLendingPools = {
     "0x8dc6fae7fedd7a60ecbb27c17af830f5811d773e", //MMTH-BTC.b
   ],
   sonic: [
-    "0xd9de9f15994182518a688933d09787a9a9fb5bc9" // s/shadow stakedlp
+    "0xd9de9f15994182518a688933d09787a9a9fb5bc9", // s/shadow stakedlp
+    "0xc49f877f44a821e40b8253f7cc988d17857db918" // sfrxUSD/eliteRingsScUSD stakedLp on equalizer
   ]
 };
 


### PR DESCRIPTION
eliteRingsScUSD is a liquidwrapper for veUSD on Sonic which is a locked version of wstkscUSD which blew up because of Stream Finance incident. This borrowable is overreporting fees massively due to it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated blockchain address configuration to enhance security and transaction validation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->