### PR TITLE
Adjust Stakedao fees and methodology

### DIFF
--- a/fees/stakedao/index.ts
+++ b/fees/stakedao/index.ts
@@ -56,7 +56,7 @@ const adapter: Adapter = {
     Revenue: "Staking rewards earned by StakeDAO and veSDT holders",
     ProtocolRevenue: "Staking rewards earned by StakeDAO ",
     HoldersRevenue: "Staking rewards earned by veSDT holders",
-    BribesRevenueb: "Liquidity incentives that support sdToken/token liquidity pools via vote incentives",
+    BribesRevenue: "Liquidity incentives that support sdToken/token liquidity pools via vote incentives",
   }
 };
 


### PR DESCRIPTION
The fees collected by the Liquidity Fee Recipent contract are used to incentivize voting campaigns, so I moved it to bribes revenue instead of user fees and removed it from the total fee calculation

https://docs.stakedao.org/lockerfees#fee-structure

@noateden This is part of the financial statement fixes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected fee aggregation by removing an unintended recipient from daily fee targets.

* **Changes**
  * Renamed public revenue field to emphasize bribes-related revenue.
  * Updated reported daily metric to show bribes revenue instead of the prior user-fee metric, clarifying fee composition.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->