### PR TITLE
Fix Convex supply side revenue

### DIFF
--- a/fees/convex.ts
+++ b/fees/convex.ts
@@ -173,6 +173,10 @@ const fetch = async (options: FetchOptions): Promise<FetchResultFees> => {
     dailyFees.addUSDValue(snapshot.cvxRevenueToCvxCrvStakersAmount.toNumber(), 'CVX Revenue')
     dailyFees.addUSDValue(snapshot.threeCrvRevenueToCvxCrvStakersAmount.toNumber(), 'CRV Revenue')
     dailyFees.addUSDValue(snapshot.fxsRevenueToCvxFxsStakersAmount.toNumber(), 'FXS Revenue')
+    dailySupplySideRevenue.addUSDValue(snapshot.crvRevenueToCvxCrvStakersAmount.toNumber(), 'CRV Revenue')
+    dailySupplySideRevenue.addUSDValue(snapshot.cvxRevenueToCvxCrvStakersAmount.toNumber(), 'CVX Revenue')
+    dailySupplySideRevenue.addUSDValue(snapshot.threeCrvRevenueToCvxCrvStakersAmount.toNumber(), 'CRV Revenue')
+    dailySupplySideRevenue.addUSDValue(snapshot.fxsRevenueToCvxFxsStakersAmount.toNumber(), 'FXS Revenue')
 
     // All revenue redirected to LPs
     dailySupplySideRevenue.addUSDValue(snapshot.crvRevenueToLpProvidersAmount.toNumber(), 'CRV Revenue')


### PR DESCRIPTION
Added the staker revenue to supply side revenue. This is part of the financial statement fixes @noateden

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced revenue tracking by adding visibility into supply-side revenue streams for CVX stakeholders and liquidity providers, including tracking of multiple token revenue sources.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->