### PR TITLE
Add Flying Tulip fees adapter

### DIFF
--- a/fees/flying-tulip.ts
+++ b/fees/flying-tulip.ts
@@ -50,7 +50,7 @@ const adapter: Adapter = {
   adapter: {
     [CHAIN.ETHEREUM]: {
       fetch,
-      start: '2025-02-20', // PutManager deployment date
+      start: '2026-01-20', // First YieldClaimed event
     }
   },
   methodology,


### PR DESCRIPTION
## Summary
- Adds fees adapter for Flying Tulip protocol on Ethereum
- Tracks yield revenue from wrapper contracts (USDC, WETH, USDT, USDS, USDTb, USDe)
- Uses YieldClaimed events to calculate daily fees and protocol revenue

## Test Results
```
ETHEREUM
Daily fees: 1.73 k
Daily revenue: 1.73 k
Daily protocol revenue: 1.73 k
```

## Related
- TVL adapter: https://github.com/DefiLlama/DefiLlama-Adapters/pull/17723

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added fee and revenue tracking for Flying Tulip on Ethereum, providing daily fees, daily revenue, and protocol revenue metrics starting from February 20, 2025.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->