### PR TITLE
Add Lazy Summer Protocol fees/revenue adapter

### DIFF
--- a/fees/lazy-summer-protocol/index.ts
+++ b/fees/lazy-summer-protocol/index.ts
@@ -56,6 +56,7 @@ async function fetch(options: FetchOptions): Promise<FetchResultV2> {
       const tipAccruedLogs = await options.getLogs({
         targets: fleetCommanders,
         eventAbi: "event TipAccrued(uint256 tipAmount)",
+        flatten: false,
       });
       for (let i = 0; i < assets.length; i++) {
         if (assets[i]) {


### PR DESCRIPTION
Adding adapter to existing `lazy-summer-protocol` tvl listing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a multi-chain fee adapter for Ethereum, Base, Arbitrum, Sonic, and Hyperliquid.
  * Aggregates daily fees per asset from fleet activity and tip events, resolving asset balances.
  * Computes daily revenue breakdowns (supply-side, protocol, holders) with versioned metadata and published methodology.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->