### PR TITLE
Add supply side revenue to Meteora DBC

### DIFF
--- a/dexs/meteora-dbc/index.ts
+++ b/dexs/meteora-dbc/index.ts
@@ -75,6 +75,7 @@ const fetch = async (_a: any, _b: any, options: FetchOptions) => {
     const dailyVolume = options.createBalances();
     const dailyFees = options.createBalances();
     const dailyProtocolRevenue = options.createBalances();
+    const dailySupplySideRevenue = options.createBalances();
 
     const accepted_quote_mints = [
         'So11111111111111111111111111111111111111112',
@@ -88,6 +89,7 @@ const fetch = async (_a: any, _b: any, options: FetchOptions) => {
         dailyVolume.add(row.quote_mint, Number(row.total_volume));
         dailyFees.add(row.quote_mint, totalFees);
         dailyProtocolRevenue.add(row.quote_mint, Number(row.total_protocol_fees));
+        dailySupplySideRevenue.add(row.quote_mint, Number(row.total_trading_fees) + Number(row.total_referral_fees))
     });
 
     return {
@@ -96,6 +98,7 @@ const fetch = async (_a: any, _b: any, options: FetchOptions) => {
         dailyUserFees: dailyFees,
         dailyRevenue: dailyProtocolRevenue,
         dailyProtocolRevenue,
+        dailySupplySideRevenue
     };
 };
 
@@ -109,7 +112,8 @@ const adapter: SimpleAdapter = {
     methodology: {
         Fees: "Trading fees paid by users.",
         Revenue: "Protocol fees collected by Meteora DBC protocol.",
-        ProtocolRevenue: "Protocol fees collected by Meteora DBC protocol."
+        ProtocolRevenue: "Protocol fees collected by Meteora DBC protocol.",
+        SupplySideRevenue: "The portion of the trading fees paid to LPs and referrals."
     }
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced daily supply-side revenue tracking for Meteora DEX by aggregating trading and referral fees.
  * Supply-side revenue metric now accumulated per quote asset alongside existing daily volume, fees, and protocol revenue.
  * New public supply-side revenue metric exposed through adapter with comprehensive methodology documentation for improved financial transparency and reporting capabilities.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->