### PR TITLE
Refactor doublezero network and add holders and supply side revenue

### DIFF
--- a/fees/doublezero/index.ts
+++ b/fees/doublezero/index.ts
@@ -1,47 +1,60 @@
 // Source: https://dune.com/queries/5920586/9559880
 // https://docs.malbeclabs.com/paying-fees/
+// https://doublezero.xyz/journal/a-primer-to-the-2z-token
 
-import ADDRESSES from '../../helpers/coreAssets.json'
 import { Dependencies, FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 import { queryDuneSql } from "../../helpers/dune";
 
+const doubleZero = 'J6pQQ3FAcJQeWPPGppWRb4nM8jU3wLyYbRrLh7feMfvd'
+
 const fetch: any = async (_a: any, _b: any, options: FetchOptions) => {
   const dailyFees = options.createBalances();
+  const dailySupplySideRevenue = options.createBalances()
+  const dailyHoldersRevenue = options.createBalances()
 
   const query = `
-    WITH initialize_deposit_account AS (
-      SELECT
-        account_arguments[1] AS deposit_account
-      FROM solana.instruction_calls
-      WHERE
-        executing_account = 'dzrevZC94tBLwuHw1dyynZxaXTWyp7yocsinyEVPtt4'
-        AND BYTEARRAY_SUBSTRING(data, 1, 8) = 0x09af49b1ebce3065
-        AND block_date >= TRY_CAST('2025-10-02' AS DATE)
-        AND tx_success
+    WITH txs AS (
+    SELECT 
+        tx_id,
+        instruction_name,
+        data,
+        account_arguments,
+        CAST(args_0[1] AS BIGINT) as amount
+    FROM solana.instruction_calls_decoded
+    WHERE outer_executing_account = 'dzrevZC94tBLwuHw1dyynZxaXTWyp7yocsinyEVPtt4'
+    AND inner_executing_account = 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'
+    AND is_inner = true
+    AND instruction_name IN ('burn', 'transfer')
+    AND TIME_RANGE
+    ),
+    burn_tx_ids AS (
+        SELECT DISTINCT tx_id 
+        FROM txs 
+        WHERE instruction_name = 'burn'
     )
-    SELECT
-      SUM(
-        BYTEARRAY_TO_BIGINT(BYTEARRAY_REVERSE(BYTEARRAY_SUBSTRING(data, 1 + 8, 8))) / 1e9
-      ) AS fee
-    FROM solana.instruction_calls
-    LEFT JOIN initialize_deposit_account
-      ON deposit_account = account_arguments[3]
-    WHERE
-      executing_account = 'dzrevZC94tBLwuHw1dyynZxaXTWyp7yocsinyEVPtt4'
-      AND BYTEARRAY_SUBSTRING(data, 1, 8) = 0xf1858bc4f612713b
-      AND tx_success
-      AND TIME_RANGE
-  `;
+    SELECT         
+      SUM(CASE WHEN b.tx_id IS NULL THEN t.amount ELSE 0 END) AS fees,
+      SUM(CASE WHEN instruction_name = 'burn' THEN amount ELSE 0 END) as holdersRevenue,
+      SUM(CASE WHEN instruction_name = 'transfer' AND b.tx_id IS NOT NULL THEN amount ELSE 0 END) AS supplySideRevenue
+    FROM txs t
+    LEFT JOIN burn_tx_ids b ON t.tx_id = b.tx_id`;
 
   const fees = await queryDuneSql(options, query);
-
-  dailyFees.add(ADDRESSES.solana.SOL, fees[0].fee * 1e9);
+  dailyFees.add(doubleZero, fees[0].fees);
+  dailySupplySideRevenue.add(doubleZero, fees[0].supplySideRevenue)
+  dailyHoldersRevenue.add(doubleZero, fees[0].holdersRevenue)
+  const dailyRevenue = dailyFees.clone()
+  dailyRevenue.subtract(dailySupplySideRevenue)
+  const dailyProtocolRevenue = dailyRevenue.clone()
+  dailyProtocolRevenue.subtract(dailyHoldersRevenue)
 
   return {
     dailyFees,
-    dailyRevenue: dailyFees,
-    dailyProtocolRevenue: dailyFees,
+    dailyRevenue,
+    dailyProtocolRevenue,
+    dailyHoldersRevenue,
+    dailySupplySideRevenue
   }
 }
 
@@ -55,8 +68,10 @@ const adapter: SimpleAdapter = {
   methodology: {
     Fees: "A flat 5% fee is charged on block signature rewards and priority fees. Fees started at epoch 859 (October 4th, 2025) and are denominated in SOL and settled per epoch.",
     Revenue: "5% block reward fees and priority fees are collected by the protocol from validators.",
-    ProtocolRevenue: "5% block reward fees and priority fees are collected by the protocol from validators."
-  }
+    ProtocolRevenue: "The remaining fees after burning and distribution",
+    HoldersRevenue: "Between 10-50% of the collected fees are burned",
+    SupplySideRevenue: "The portion of the collected fees distributed to network contributors"
+  },
 };
 
 export default adapter;


### PR DESCRIPTION
Closes #5703. 
Following the token flow described here: https://doublezero.xyz/journal/a-primer-to-the-2z-token I refactored the fee calculation to track the conversion of the fees collected from SOL to 2Z as fees (example: https://solscan.io/tx/2Pzk5gCbUg9WRY7g7aWbChSSqJ5LAxfbvG4SCJJDYjUrCTvHKWgNVsJ12uEr5aQTGb9kehaQBRAeA5VDViNs1Gns) and added the fee distribution to network contributors as supply side revenue and 2Z burns as holders revenue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Revenue metrics now separately track holders revenue and supply-side revenue alongside protocol revenue for granular financial insights.

* **Refactor**
  * Improved fee extraction methodology and refined protocol revenue calculations for more comprehensive and accurate financial reporting.

* **Documentation**
  * Updated documentation with expanded descriptions of all revenue components and their calculation methods.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->