### PR TITLE
feat: add Extended Exchange integration to treadfi-perps

### DIFF
--- a/dexs/treadfi-perps.ts
+++ b/dexs/treadfi-perps.ts
@@ -49,8 +49,10 @@ const fetchExtended = async (_a: any, _b: any, options: FetchOptions) => {
   );
 
   if (dayData) {
-    dailyVolume.addCGToken("usd-coin", parseFloat(dayData.volume));
-    dailyFees.addCGToken("usd-coin", parseFloat(dayData.extendedFees));
+    const volume = parseFloat(dayData.volume);
+    const fees = volume * 0.0002; // 2 bps
+    dailyVolume.addCGToken("usd-coin", volume);
+    dailyFees.addCGToken("usd-coin", fees);
   }
 
   return {


### PR DESCRIPTION
## Summary
- Adds Extended Exchange (Starknet) as a second chain for Tread.fi perps adapter
- Fetches daily volume from Extended Exchange builder dashboard API
- Calculates fees at 2 bps on volume (API's extendedFees field returns incorrect values)

## Test plan
- [ ] Verify Hyperliquid data still works
- [ ] Verify Extended Exchange volume is fetched correctly
- [ ] Verify fees are calculated at 2 bps on volume

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended protocol support to include Tread.fi on StarkNet chain with daily volume and fee metrics.
  * Integrated new data source API for comprehensive protocol metrics tracking.
  * Restructured adapter to support multi-chain configurations with chain-specific data sources and timeframes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->