### PR TITLE
fix: calculate Extended Exchange fees at 2 bps

### DIFF
--- a/dexs/treadfi-perps.ts
+++ b/dexs/treadfi-perps.ts
@@ -49,8 +49,10 @@ const fetchExtended = async (_a: any, _b: any, options: FetchOptions) => {
   );
 
   if (dayData) {
-    dailyVolume.addCGToken("usd-coin", parseFloat(dayData.volume));
-    dailyFees.addCGToken("usd-coin", parseFloat(dayData.extendedFees));
+    const volume = parseFloat(dayData.volume);
+    const fees = volume * 0.0002; // 2 bps
+    dailyVolume.addCGToken("usd-coin", volume);
+    dailyFees.addCGToken("usd-coin", fees);
   }
 
   return {


### PR DESCRIPTION
## Summary
- Calculate Extended Exchange fees at 2 bps instead of using API value

## Test plan
- Verify fee calculations are correct with the 2 bps rate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Extended Exchange as an additional data source for the Tread.fi protocol adapter.
  * Enabled multi-source data collection to provide more comprehensive volume and fee metrics.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->