### PR TITLE
Add ton4you fees adapter

### DIFF
--- a/fees/ton4you/index.ts
+++ b/fees/ton4you/index.ts
@@ -1,114 +1,33 @@
 import { CHAIN } from '../../helpers/chains'
-import { FetchV2, SimpleAdapter } from '../../adapters/types'
-import fetchURL from '../../utils/fetchURL'
+import { FetchOptions, SimpleAdapter } from '../../adapters/types'
+import { httpGet } from '../../utils/fetchURL'
 
-const METRICS_URL = 'https://ton4u.io/api/defillama/metrics'
+const METRICS_URL = (timestmap: number) => `https://ton4u.io/api/defillama/metrics?date=${new Date(timestmap * 1000).toISOString().split('T')[0]}`;
 
-type MetricsVariantDaily = {
-	fees_usd?: number | string
-}
+const fetch = async (_a: any, _b: any, options: FetchOptions) => {
+  const dailyFees = options.createBalances();
+  
+  const responseData: any = await httpGet(METRICS_URL(options.startOfDay))
+  for (const [key, variant] of Object.entries(responseData.variants)) {
+    if (String(key).toLowerCase() === 'demo') continue;
 
-type MetricsVariant = {
-	daily?: MetricsVariantDaily
-}
-
-type MetricsPayload = {
-	// `variants` is a per-settlement-asset breakdown (t4u/usdt/...) aggregated for the UTC day.
-	// A single protocol-wide daily fees number is derived by summing all non-demo variants.
-	variants?: Record<string, MetricsVariant>
-}
-
-function parseFiniteNumber(value: unknown) {
-	const n = Number(value)
-	return Number.isFinite(n) ? n : undefined
-}
-
-function computeDailyFeesUsd(payload: MetricsPayload) {
-	const variants = payload?.variants ?? {}
-	const entries = Object.entries(variants)
-	if (entries.length === 0) return undefined
-
-	let total = 0
-	let any = false
-
-	for (const [key, variant] of entries) {
-		// Never include demo buckets even if present.
-		if (String(key).toLowerCase() === 'demo') continue
-
-		const feesUsd = parseFiniteNumber(variant?.daily?.fees_usd)
-		if (feesUsd === undefined) continue
-		if (feesUsd < 0) continue
-
-		total += feesUsd
-		any = true
+    dailyFees.addUSDValue(Number((variant as any).daily.fees_usd || 0));
 	}
 
-	// `0` is a valid daily value (no activity). If none of the variants expose a parseable value,
-	// treat it as an invalid / incompatible payload rather than silently returning 0.
-	return any ? total : undefined
-}
-
-const fetch: FetchV2 = async (options) => {
-	// DefiLlama runs the adapter for a specific day window. Our backend endpoint expects a unix timestamp
-	// and returns daily aggregates for the UTC day containing that timestamp.
-	// Important: for V2 adapters, `startTimestamp` is derived from a `[from,to)` window and can be offset by -1s,
-	// which may select the previous UTC day. `toTimestamp` (or `endTimestamp - 1`) reliably targets the intended day.
-	//
-	// The Ton4You metrics endpoint also supports an explicit `day=YYYY-MM-DD` selector, which is unambiguous and
-	// matches the DefiLlama adapter runner's UTC day bucketing. We prefer it when available and fall back to timestamp.
-	const dayTimestamp = Number(
-		(options as any)?.startOfDay ??
-			(options as any)?.toTimestamp ??
-			(typeof (options as any)?.endTimestamp === 'number' ? (options as any).endTimestamp - 1 : undefined) ??
-			(options as any)?.startTimestamp ??
-			(options as any)?.timestamp,
-	)
-	if (!Number.isFinite(dayTimestamp)) throw new Error('Invalid adapter timestamp')
-
-	let response: MetricsPayload | undefined
-	const dayString = String((options as any)?.dateString ?? '').trim()
-	if (dayString) {
-		try {
-			response = (await fetchURL(`${METRICS_URL}?day=${encodeURIComponent(dayString)}`)) as MetricsPayload
-		} catch {
-			response = undefined
-		}
-	}
-	if (!response) {
-		response = (await fetchURL(`${METRICS_URL}?timestamp=${dayTimestamp}`)) as MetricsPayload
-	}
-	const dailyFeesUsd = computeDailyFeesUsd(response)
-	if (dailyFeesUsd === undefined) throw new Error('Invalid Ton4You metrics response')
-
-	// Ton4You currently routes fees to service/referral NFTs (holders-like distribution),
-	// so we report them as holders revenue too.
+	// Ton4You currently routes fees to service/referral NFTs (holders-like distribution), but we don't count these revneue as holders revenue
 	return {
-		dailyFees: dailyFeesUsd,
-		dailyUserFees: dailyFeesUsd,
-		dailyRevenue: dailyFeesUsd,
-		dailyHoldersRevenue: dailyFeesUsd,
+		dailyFees: dailyFees,
+		dailyUserFees: dailyFees,
+    dailyRevenue: dailyFees,
 	}
 }
 
 const adapter: SimpleAdapter = {
 	methodology: {
-		Fees: (
-			'Ton4You fees are defined as the protocol service fee plus the referral reward that is paid out when a position is settled. ' +
-			'The protocol supports multiple settlement assets (jettons), so fees are tracked per settlement asset ("variant") and aggregated ' +
-			'over a UTC day. This adapter fetches the daily breakdown and reports a single protocol-wide daily value by summing all live variants ' +
-			'(excluding demo/test variants if present).'
-		),
-		DataSource: (
-			'A public Ton4You metrics endpoint that serves daily aggregates derived from on-chain pool state and position settlement activity. ' +
-			'The adapter selects the UTC day using DefiLlama\'s `dateString` (YYYY-MM-DD) when available, and falls back to a unix timestamp. ' +
-			'The response corresponds to a single UTC day bucket.'
-		),
-		RevenueMapping: (
-			'The adapter reports dailyFees, dailyUserFees, dailyRevenue, and dailyHoldersRevenue as the same USD value. ' +
-			'This reflects that fees are paid by users on settlement and are distributed to protocol stakeholders (service/referral NFT holders).'
-		),
+    Fees: 'Ton4You fees are defined as the protocol service fee plus the referral reward that is paid out when a position is settled.',
+    UsersFees: 'Users payd service fee plus the referral reward a position is settled.',
+		Revenue: 'All fees are revenue.',
 	},
-	version: 2,
 	adapter: {
 		[CHAIN.TON]: {
 			start: '2026-01-01',


### PR DESCRIPTION
##### Name (to be shown on DefiLlama):

  Ton4You

  ##### Twitter Link:

  https://twitter.com/ton4uofficial

  ##### List of audit links if any:

  N/A

  ##### Website Link:

  https://ton4u.io

  ##### Logo (High resolution, will be shown with rounded borders):

  https://ton4u.io/icons/logo.jpeg

  ##### Current TVL:

  ~$6.24k (local adapter test output on 2026-01-27; TVL varies with pool balances)

  ##### Treasury Addresses (if the protocol has treasury)

  N/A

  ##### Chain:

  TON

  ##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed): (https://api.coingecko.com/api/v3/coins/list)

  (leave empty)

  ##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed): (https://api.coinmarketcap.com/data-api/v3/map/all?
  listing_status=active,inactive,untracked&start=1&limit=10000)

  (leave empty)

  ##### Short Description (to be shown on DefiLlama):

  On-chain binary options protocol on TON with multiple settlement jettons (T4U, USDT, etc.).

  ##### Token address and ticker if any:

  T4U — ton:EQA0nLHHeZrT1SwWrBd8N5_5CKXJQFL7CnPYDLLnw-sIqoBq

  ##### Category (full list at https://defillama.com/categories) *Please choose only one:

  Options

  ##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.):

  N/A (TVL is computed from on-chain balances; no oracle required for TVL)

  ##### Implementation Details: Briefly describe how the oracle is integrated into your project:

  N/A

  ##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage:

  N/A

  ##### forkedFrom (Does your project originate from another project):

  N/A

  ##### methodology (what is being counted as tvl, how is tvl being calculated):

  TVL is computed on-chain as the sum of the live pool balances of Ton4You settlement jettons held by the protocol pool contracts on TON. The adapter queries jetton balances for the configured pool
  owner addresses and sums them (excluding any demo/test assets if present).

  ##### Github org/user (Optional, if your code is open source, we can track activity):

  N/A

  ##### Does this project have a referral program?

  Yes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Ton4You fees adapter providing daily fee metrics.
  * Query support via date string (YYYY-MM-DD) or timestamp.
  * Shows daily fees, user fees, and revenue; data available from 2026-01-01 (holders revenue not provided).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->