### PR TITLE
Add Flying Tulip fees adapter

### DIFF
--- a/fees/flying-tulip.ts
+++ b/fees/flying-tulip.ts
@@ -11,12 +11,19 @@ const WRAPPERS: string[] = [
   '0xe6880Fc961b1235c46552E391358A270281b5625', // USDe Wrapper
 ];
 
+// PUT Marketplace contract
+const PUT_MARKETPLACE = '0x31248663adccdbcad155555b7717697b76cf570c';
+
+// Treasury address
+const TREASURY = '0x1118e1c057211306a40A4d7006C040dbfE1370Cb';
+
 const yieldClaimedEvent = 'event YieldClaimed(address yieldClaimer, address token, uint256 amount)';
+const transferEvent = 'event Transfer(address indexed from, address indexed to, uint256 value)';
 
 const methodology = {
-  Fees: "Yield generated from deposited assets in Flying Tulip wrappers.",
-  Revenue: "Protocol revenue from claimed yield.",
-  ProtocolRevenue: "100% of yield goes to protocol treasury.",
+  Fees: "Yield generated from deposited assets in Flying Tulip wrappers plus marketplace fees from PUT trades.",
+  Revenue: "Protocol revenue from claimed yield and marketplace fees.",
+  ProtocolRevenue: "100% of yield and marketplace fees go to protocol treasury.",
 }
 
 const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
@@ -24,16 +31,36 @@ const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
   const dailyRevenue = options.createBalances();
 
   // Fetch YieldClaimed events from all wrappers
-  const logs = await options.getLogs({
+  const yieldLogs = await options.getLogs({
     targets: WRAPPERS,
     eventAbi: yieldClaimedEvent,
     flatten: true,
   });
 
   // Each YieldClaimed event contains the token and amount
-  logs.forEach((log: any) => {
+  yieldLogs.forEach((log: any) => {
     const token = log.token;
     const amount = log.amount;
+    dailyFees.add(token, amount);
+    dailyRevenue.add(token, amount);
+  });
+
+  // Fetch marketplace fees - Transfer events from PUT marketplace to treasury
+  // Transfer events are emitted by token contracts, so we query by topics (from=marketplace, to=treasury)
+  const marketplaceLogs = await options.getLogs({
+    noTarget: true,
+    topics: [
+      '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef', // Transfer(address,address,uint256)
+      '0x00000000000000000000000031248663adccdbcad155555b7717697b76cf570c', // from = PUT marketplace (padded)
+      '0x0000000000000000000000001118e1c057211306a40a4d7006c040dbfe1370cb', // to = treasury (padded)
+    ],
+  });
+
+  // Each Transfer event to treasury is a marketplace fee
+  // The token is the contract that emitted the event (log.address)
+  marketplaceLogs.forEach((log: any) => {
+    const token = log.address;
+    const amount = log.data; // amount is in data for non-indexed Transfer
     dailyFees.add(token, amount);
     dailyRevenue.add(token, amount);
   });


### PR DESCRIPTION
## Summary
- Add marketplace fees tracking from PUT marketplace transfers to treasury

## Test Results
```
Daily fees: 2.25 k (up from 1.73 k)
Daily revenue: 2.25 k
Daily protocol revenue: 2.25 k
```

## Contracts
- PUT Marketplace: `0x31248663adccdbcad155555b7717697b76cf570c`
- Treasury: `0x1118e1c057211306a40A4d7006C040dbfE1370Cb`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Marketplace fees are now included in daily fee and revenue calculations.
  * Protocol revenue tracking now encompasses marketplace-derived fees for complete metrics visibility.
  * Fee tracking methodology has been enhanced with improved data collection mechanisms.
  * Daily fee and revenue metrics now reflect both protocol yield and marketplace fee contributions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->