### PR TITLE
Update doublezero network fee calculation

### DIFF
--- a/fees/doublezero/index.ts
+++ b/fees/doublezero/index.ts
@@ -37,7 +37,7 @@ const fetch: any = async (_a: any, _b: any, options: FetchOptions) => {
     LEFT JOIN burn_tx_ids b ON t.tx_id = b.tx_id`;
 
   const fees = await queryDuneSql(options, query);
-  dailyFees.add(doubleZero, fees[0].fees);
+  dailyFees.add(doubleZero, fees?.[0]?.fees ?? 0);
   const dailySupplySideRevenue = dailyFees.clone(0.9)
   const dailyHoldersRevenue = dailyFees.clone(0.1)
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Revenue reporting simplified: daily holders = 10% of collected fees, daily supply-side = 90%; protocol revenue set to 0. Metrics now derived from fees only.
* **Documentation**
  * Methodology clarified: Revenue = 10% of collected fees; Holders = 10% burned; Supply-side = 90% distributed; Protocol revenue = none.
* **Data/Display**
  * Daily metrics surfaced: dailyFees, dailyRevenue, dailyProtocolRevenue, dailyHoldersRevenue, dailySupplySideRevenue.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->