### PR TITLE
Pyth Entropy: Add missing chains (SEI, TAIKO, STORY) + improve methodology

### DIFF
--- a/fees/pyth-entropy/index.ts
+++ b/fees/pyth-entropy/index.ts
@@ -19,7 +19,7 @@ const chainConfig: Record<string, { start: string, chainName: string }> = {
     [CHAIN.KLAYTN]: { start: '2024-06-22', chainName: 'kaia' },
     [CHAIN.APECHAIN]: { start: '2024-10-03', chainName: 'apechain' },
     [CHAIN.MONAD]: { start: '2025-11-24', chainName: 'monad' },
-    [CHAIN.SEI]: { start: '2024-08-15', chainName: 'sei-evm' },
+    // [CHAIN.SEI]: { start: '2024-08-15', chainName: 'sei-evm' },
     [CHAIN.TAIKO]: { start: '2024-06-05', chainName: 'taiko' },
     [CHAIN.STORY]: { start: '2025-03-06', chainName: 'story' },
 };


### PR DESCRIPTION
## Summary
Adds 3 missing chains to the Pyth Entropy fee adapter and improves methodology descriptions.

## Changes

### New Chains Added
| Chain | Fortuna Name | Start Date |
|-------|--------------|------------|
| SEI | sei-evm | 2024-08-15 |
| TAIKO | taiko | 2024-06-05 |
| STORY | story | 2025-03-06 |

### Code Improvements
- Enable previously commented-out chains (TAIKO, STORY)
- Add null check for `chainInfo` to prevent errors when chain config not found
- Improve methodology descriptions to clarify fee structure:
  - **Total fee** = Provider fee + Protocol fee
  - **Provider fees** → Providers (supply side revenue)
  - **Protocol fees** → Pyth DAO treasury (currently minimal at 1 wei)

### Not Included
- **B3 chain** is live on Entropy but not yet in DefiLlama's chains helper (`helpers/chains.ts`)

## Context
Pyth Entropy is deployed on 20 chains per the [Fortuna API](https://fortuna.dourolabs.app/v1/chains/configs). This PR brings coverage from 16 to 19 chains.

## References
- [Fortuna API configs](https://fortuna.dourolabs.app/v1/chains/configs)
- [Q1 2026 Pyth Entropy Onchain Fees](https://forum.pyth.network/t/q1-2026-pyth-entropy-onchain-fees/2317) - explains Provider vs Protocol fee structure
- [Pyth Entropy Chainlist](https://docs.pyth.network/entropy/chainlist)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for SEI and STORY chains; restored Taiko chain configuration.
  * Adapter now exposes version 2.

* **Bug Fixes**
  * More resilient chain lookup to avoid runtime errors when a chain is missing.
  * Improved fee retrieval with layered fallbacks to ensure fee data is returned.

* **Documentation**
  * Updated methodology to clarify total-fee composition and current/future governance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->