### PR TITLE
fix(cyberperp): correct cursor for pagination

### DIFF
--- a/fees/cyberperp.ts
+++ b/fees/cyberperp.ts
@@ -28,7 +28,7 @@ const buildQuery = (cursor: string | null, eventType: string) => gql`
     ) {
       pageInfo {
         hasNextPage
-        endCursor
+        startCursor
       }
       edges {
         node {
@@ -114,7 +114,7 @@ const fetchEvents = async (
 
     const shouldContinue = processor(response.events.edges, from, to, acc);
     if (!shouldContinue) break;
-    cursor = response.events.pageInfo.endCursor;
+    cursor = response.events.pageInfo.startCursor;
   }
 };
 


### PR DESCRIPTION
Description:
This PR fixes a data duplication bug in the Iota Move event fetching logic that was introduced in the previous version.

The Problem:
Using endCursor with last and before filters in the GraphQL query caused the pagination to overlap. This resulted in the same events being fetched and counted multiple times across different pages.

The Fix:
Switched from endCursor to startCursor for the pagination anchor.

This ensures that each subsequent request correctly moves backward to older events without including records from the current page.

Verification:
Verified the fix by logging event IDs and cursors during the fetch process.

Transaction IDs now correctly decrease per page, and no duplicate events are detected in the logs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed pagination behavior when retrieving multiple batches of data to ensure correct sequential fetching.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->