### PR TITLE
Add Calculus DEX volume adapter on BSC

### DIFF
--- a/dexs/calculus/index.ts
+++ b/dexs/calculus/index.ts
@@ -55,6 +55,7 @@ export default {
         [CHAIN.BSC]: {
             fetch,
             start: START_TS,
+            doublecounted: true,
             meta: {
                 methodology: {
                     Volume:


### PR DESCRIPTION
## Overview

This PR adds a **DEX volume adapter** for **Calculus** on BSC.

Calculus is a PancakeSwap v3 liquidity management protocol. Users open managed vaults which deploy PancakeSwap v3 positions. Opening volume can be measured directly from on-chain vault creation events.

---

## Volume Methodology

Daily volume is calculated using the `VaultCreated` event:

- `reserve0` and `reserve1` emitted during vault creation are treated as opening trade volume.
- Volume is counted only for events occurring within the active 24-hour window provided by DefiLlama.
- Closing actions and fees are excluded.
- No off-chain data sources are used.

---

## Chains

- **BSC**

---

## Notes

- Volume reflects **opening volume only**.
- This adapter does not attempt to estimate liquidity movement inside PancakeSwap v3 pools after vault creation.

---

## Checklist

- [x] Tested locally using `pnpm test dexs calculus`
- [x] No additional dependencies added
- [x] No lockfile changes
- [x] Allow edits by maintainers enabled

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added daily opening volume data for Calculus decentralized exchange on Binance Smart Chain.
* **Documentation**
  * Included methodology/metadata describing how daily opening volume is derived from on-chain VaultCreated events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->