### PR TITLE
Backfill missing flashtrade values due to API issue

### DIFF
--- a/dexs/flashtrade/index.ts
+++ b/dexs/flashtrade/index.ts
@@ -17,7 +17,10 @@ const pools = [
     // keep historical pools
     "Community.3",
 ]
-
+/**
+ * NOTE: API experienced outage on 2025-01-27 and 2025-01-28.
+ * Data is now available.
+ */
 const fetch = async (_a: any, _b: any, options: FetchOptions) => {
     const targetDate = new Date(options.startOfDay * 1000).toISOString().split('T')[0];
 


### PR DESCRIPTION
## Fix: Refill Missing Volume Data - API Outage Recovery

### Description
Our Flash Trade DEX API experienced an outage on **2025-01-27 and 2025-01-28**, resulting in missing volume data for those dates in DefiLlama. The API is now fully operational and contains all historical data for the affected dates.

### Changes
- Updated dexs adapter with notification comment about the outage
- No code logic changes required - adapter correctly fetches data from API

### Issue Details
- **Affected Dates**: 2025-01-27, 2025-01-28
- **Status**: API is fixed and data is available
- **Data Available**: Yes, all volume data is present in the API

### Action Required
Please perform a **full reindex from start date (2023-12-29) to today** to:
1. Populate the missing volume data for 2025-01-27 and 2025-01-28
2. Ensure data integrity across the entire historical range
3. Sync DefiLlama with the current API state

### Files Changed
- `dexs/flash-trade.ts` - Added comment noting API outage and reindex requirement

### Testing
Adapter has been tested and correctly queries volume data from the API for all dates.

### Notes for Maintainers
The adapter is functioning correctly. The outage was on the API side, not the adapter. A manual reindex is needed to refetch and populate the missing 2 days of data in DefiLlama's database.

Thank you!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation noting an API outage on January 27-28, 2025 with subsequent data availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->