### PR TITLE
Fix Frax revenue

### DIFF
--- a/fees/frax-amo.ts
+++ b/fees/frax-amo.ts
@@ -47,7 +47,7 @@ const fetch = async (timestamp: number, _: any, options: FetchOptions): Promise<
   return {
     timestamp,
     dailyFees,
-    dailyRevenue: dailyFees,
+    dailyRevenue: dailyProtocolRevenue,
     dailyProtocolRevenue: dailyProtocolRevenue,
     dailySupplySideRevenue: dailySupplySideRevenue,
   };
@@ -90,7 +90,7 @@ const adapter: SimpleAdapter = {
   version: 1,
   methodology: {
     Fees: 'Total interest paid to users by borrowing FRAX.',
-    Revenue: 'Total interest paid to users by borrowing FRAX.',
+    Revenue: 'Amount of interest collected by Frax Finance.',
     ProtocolRevenue: 'Amount of interest collected by Frax Finance.',
     SupplySideRevenue: 'Amount of interest paid to lenders.',
   }


### PR DESCRIPTION
Changed the revenue to equal protocol revenue and updated the methodology. Part of the Financial Statement fixes @noateden

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated revenue reporting to correctly reflect protocol revenue instead of fees collected, providing more accurate revenue metrics.

* **Documentation**
  * Refined revenue description to clarify that metrics represent interest collected by Frax Finance rather than interest paid to users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->