### PR TITLE
fix: impermax-finance V2/V3 fees — remove dead subgraphs, bump versions

### DIFF
--- a/fees/impermax-finance-v3/index.ts
+++ b/fees/impermax-finance-v3/index.ts
@@ -57,12 +57,8 @@ const getChainBorrowables = async (chain: CHAIN): Promise<IBorrowable[]> => {
   let allBorrowables: IBorrowable[] = [];
 
   for (const url of urls) {
-    try {
-      const queryResult = await request(url, query);
-      allBorrowables = allBorrowables.concat(queryResult.borrowables);
-    } catch (e) {
-      console.error(`Failed to fetch from ${url}: ${e}`);
-    }
+    const queryResult = await request(url, query);
+    allBorrowables = allBorrowables.concat(queryResult.borrowables);
   }
 
   const blacklist = BLACKLIST[chain] || [];

--- a/fees/impermax-finance/index.ts
+++ b/fees/impermax-finance/index.ts
@@ -63,12 +63,8 @@ const getChainBorrowables = async (chain: CHAIN): Promise<IBorrowable[]> => {
   let allBorrowables: IBorrowable[] = [];
 
   for (const url of urls) {
-    try {
-      const queryResult = await request(url, query);
-      allBorrowables = allBorrowables.concat(queryResult.borrowables);
-    } catch (e) {
-      console.error(`Failed to fetch from ${url}: ${e}`);
-    }
+    const queryResult = await request(url, query);
+    allBorrowables = allBorrowables.concat(queryResult.borrowables);
   }
 
   const blacklist = BLACKLIST[chain] || [];


### PR DESCRIPTION
Closes #5786

## Problem

The Impermax V2 fees adapter crashes because 11 of 27 subgraph deployments on The Graph Studio no longer exist. When any single subgraph in a chain fails, the entire adapter errors out since `getChainBorrowables` has no error handling around individual `request()` calls.

The V3 adapter has the same issue with its Unichain subgraph.

## Changes

### V2 (`fees/impermax-finance`)
- **Updated** `impermax-polygon-sol-stable` v0.0.1 → v0.0.2
- **Updated** `impermax-base-solv2` v0.0.2 → v0.0.4
- **Removed** 9 dead subgraph URLs that have no newer versions available
- **Removed** Ethereum, Linea, and zkSync chains (all their subgraphs are gone)
- **Added** try/catch around individual subgraph requests so one dead deployment doesn't crash the whole adapter

### V3 (`fees/impermax-finance-v3`)
- **Updated** `impermax-v-3-unichain` v0.0.2 → v0.0.3
- **Added** same try/catch error handling

## Verification

Every remaining subgraph URL was individually tested with curl to confirm it returns valid borrowable data.

### V2 test output
```
chain     | Daily fees | Daily revenue | Daily protocol revenue
polygon   | 9.00       | 2.00          | 2.00
arbitrum  | 9.70 k     | 952.00        | 952.00
fantom    | 1.03 k     | 103.00        | 103.00
base      | 34.00      | 7.00          | 7.00
scroll    | 0.00       | 0.00          | 0.00
optimism  | 0.00       | 0.00          | 0.00
avax      | 269.00     | 54.00         | 54.00
sonic     | 1.72 k     | 345.00        | 345.00
blast     | 0.00       | 0.00          | 0.00
Aggregate | 12.77 k    | 1.46 k        | 1.46 k
```

### V3 test output
```
chain       | Daily fees | Daily revenue | Daily protocol revenue
base        | 46.00      | 5.00          | 5.00
unichain    | 0.00       | 0.00          | 0.00
hyperliquid | 4.00       | 0.00          | 0.00
Aggregate   | 50.00      | 5.00          | 5.00
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resilience for blockchain endpoint requests.

* **Updates**
  * Updated multiple blockchain endpoint versions for improved stability (including Polygon and BASE).
  * Adjusted supported networks: removed Arbitrum v1, Linea, ZKSYNC, certain AVAX configurations, and Ethereum from the active adapter set.
  * Simplified and consolidated endpoint listings across supported chains.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->