### PR TITLE
Fix opensea seaport

### DIFF
--- a/fees/opensea/seaport.ts
+++ b/fees/opensea/seaport.ts
@@ -38,12 +38,13 @@ export const fetch = async ({ createBalances, getLogs, chain, }: FetchOptions) =
     const biggestValue = recipients.reduce((a: any, b: any) => a.amount > b.amount ? a : b)
 
     recipients.forEach((consideration: any) => {
+      if (consideration.recipient === biggestValue.recipient) return; // this is sent to the NFT owner, doesn't include fees
       dailyFees.add(consideration.token, consideration.amount)
       if (feeCollectorSet.has(consideration.recipient.toLowerCase())) {
         dailyRevenue.add(consideration.token, consideration.amount)
       }
       else {
-        dailySupplySideRevenue.add(consideration.token, consideration.amount) // this is sent to the NFT owner
+        dailySupplySideRevenue.add(consideration.token, consideration.amount)
       }
     })
   })


### PR DESCRIPTION
Fixed a mistake on opensea seaport that overcounted the fees

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined OpenSea Seaport fee calculation to exclude the largest recipient's share from fee aggregates, improving accuracy of platform fee and revenue metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->