### PR TITLE
Hibachi - support V2 adapter

### DIFF
--- a/dexs/hibachi/index.ts
+++ b/dexs/hibachi/index.ts
@@ -31,26 +31,16 @@ const fetch: FetchV2 = async (options: FetchOptions) => {
       (d) => d.chain_name.toLowerCase() === options.chain.toLowerCase()
     )?.volume ?? 0;
 
-  const output = {
-    dailyVolume: chain_volume.toString(),
-    timestamp: new Date(Math.floor(Number(response.timestamp))).getTime() / 1000,
+  return {
+    dailyVolume: chain_volume
   };
-
-  return output;
 };
 
 const adapter: SimpleAdapter = {
   version: 2,
-  adapter: {
-    [CHAIN.ARBITRUM]: {
-      fetch,
-      start: "2025-06-01",
-    },
-    [CHAIN.BASE]: {
-      fetch,
-      start: "2025-06-01",
-    },
-  },
+  fetch,
+  start: '2025-06-01',
+  chains: [CHAIN.ARBITRUM, CHAIN.BASE],
 };
 
 export default adapter;


### PR DESCRIPTION
We've recently added support for querying historical data through this endpoint. Here we 
- replace the V1 adapter with V2 to make use of this
- correct response fields 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the adapter's data-fetching mechanism with improved timestamp handling for more precise data retrieval.
  * Enhanced code safety and maintainability through internal improvements.

* **Chores**
  * Bumped adapter version to 2, reflecting significant underlying updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->