### PR TITLE
Update alphasec-spot: add fees, revenue, supply-side revenue

### DIFF
--- a/dexs/alphasec-spot.ts
+++ b/dexs/alphasec-spot.ts
@@ -1,10 +1,10 @@
+import { SimpleAdapter } from "../adapters/types";
 import { httpGet } from "../utils/fetchURL";
 import { CHAIN } from "../helpers/chains";
-import { FetchOptions } from "../adapters/types";
 
 const API_URL = "https://api.alphasec.trade/api/v1/defillama/stats";
 
-const fetch = async (_options: FetchOptions) => {
+const fetch = async () => {
   const data = await httpGet(API_URL);
   const stats = data.result;
 
@@ -16,11 +16,14 @@ const fetch = async (_options: FetchOptions) => {
   };
 };
 
-export default {
-  version: 2,
-  fetch,
-  runAtCurrTime: true,
-  chains: [CHAIN.ALPHASEC],
+const adapter: SimpleAdapter = {
+  version: 1,
+  adapter: {
+    [CHAIN.ALPHASEC]: {
+      fetch,
+      runAtCurrTime: true,
+    },
+  },
   methodology: {
     Volume: 'Total notional value of all trades executed on the AlphaSec DEX.',
     Fees: 'Total trading fees paid by users before any rebates or commissions are deducted.',
@@ -28,3 +31,5 @@ export default {
     Revenue: 'Total fees minus supply side revenue (rebates and commissions).',
   },
 };
+
+export default adapter;

--- a/fees/alphasec-spot.ts
+++ b/fees/alphasec-spot.ts
@@ -1,3 +1,0 @@
-import adapter from "../dexs/alphasec-spot";
-
-export default adapter;


### PR DESCRIPTION
  Thanks for listing AlphaSec Spot on DefiLlama.

  This PR updates the adapter to report all dimension metrics via a dedicated backend endpoint.

  ### Changes
  - Rewrote `dexs/alphasec-spot.ts` to use `/defillama/stats` API endpoint
  - Now returns `dailyVolume`, `dailyFees`, `dailyRevenue`, `dailySupplySideRevenue`
  - Created `fees/alphasec-spot.ts` as a re-export from the dexs adapter (same pattern as Hyperliquid)
  - Added methodology descriptions
  - Added `version: 2`

  ### Test Results (dexs)
  ALPHASEC 👇
  Daily volume: 54.24 M
  Daily fees: 27.15 k
  Daily revenue: 27.14 k
  Daily supply side revenue: 19.00

  Fees adapter returns identical results (re-export).

  Please feel free to leave any feedback if something needs to be adjusted.

  Cheers, and thank you for all the work you do for the DeFi ecosystem!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive methodology documentation detailing the calculation of Volume, Fees, Revenue, and SupplySideRevenue metrics.

* **Refactor**
  * Updated adapter architecture for improved system organization and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->