### PR TITLE
Add Yearn holders revenue

### DIFF
--- a/fees/yearn-finance.ts
+++ b/fees/yearn-finance.ts
@@ -28,7 +28,7 @@ const breakdownMethodology = {
   },
   HoldersRevenue: {
     [METRIC.ASSETS_YIELDS]: '90% of the Performance fees go to stYFI stakers',
-    [METRIC.MANAGEMENT_FEES]: '90% of the Management fees to to stYFI stakers',
+    [METRIC.MANAGEMENT_FEES]: '90% of the Management fees go to stYFI stakers',
   },
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Holders Revenue stream and delayed split that directs a portion of protocol revenue to holders starting at a future launch date.
  * Daily holder revenue is now tracked and included in combined daily revenue reporting.

* **Documentation**
  * Updated revenue methodology and breakdown descriptions to document the new Holders Revenue tracking and distribution.

* **Public Data**
  * API/reporting now returns holder revenue alongside daily revenue and related fee breakdowns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->