### PR TITLE
Refactor O1 Exchange Adapter to use Dune SQL for fetching trading fees and volume

### DIFF
--- a/dexs/o1-exchange/index.ts
+++ b/dexs/o1-exchange/index.ts
@@ -1,43 +1,74 @@
 import { Dependencies, FetchOptions, SimpleAdapter } from '../../adapters/types';
 import { CHAIN } from '../../helpers/chains';
-import { addTokensReceived, getETHReceived, getSolanaReceived } from '../../helpers/token';
+import { queryDuneSql } from '../../helpers/dune';
 
-// source: https://dune.com/queries/6136041/9815523
+// source: https://dune.com/queries/6136041
+
+const sql = `
+  WITH solana_transfers AS (
+    SELECT
+      block_date,
+      SUM(amount_usd) AS trading_fees_usd,
+      SUM(amount_usd) * 100 AS trading_volume_usd
+    FROM tokens_solana.transfers
+    WHERE
+      to_owner = 'FUzZ2SPwLPAKaHubxQzRsk9K8dXb4YBMR6hTrYEMFFZc'
+      AND TIME_RANGE
+    GROUP BY
+      block_date
+  ), base_transfers AS (
+    SELECT
+      block_date,
+      SUM(amount_usd) AS trading_fees_usd,
+      SUM(amount_usd) * 100 AS trading_volume_usd
+    FROM tokens_base.transfers
+    WHERE
+      (
+        "to" IN (0x1E493E7CF969FD7607A8ACe7198f6C02e5eF85A4, 0xc98218Df72975EE1472919d2685e5BD215Baaad4)
+        AND TIME_RANGE
+        AND tx_from <> "to"
+      )
+    GROUP BY
+      block_date
+  )
+  SELECT
+    COALESCE(solana.block_date, base.block_date) AS block_date,
+    COALESCE(solana.trading_fees_usd, 0) + COALESCE(base.trading_fees_usd, 0) AS combined_trading_fees_usd,
+    COALESCE(solana.trading_volume_usd, 0) + COALESCE(base.trading_volume_usd, 0) AS combined_trading_volume_usd,
+    COALESCE(solana.trading_fees_usd, 0) AS solana_trading_fees_usd,
+    COALESCE(solana.trading_volume_usd, 0) AS solana_trading_volume_usd,
+    COALESCE(base.trading_fees_usd, 0) AS base_trading_fees_usd,
+    COALESCE(base.trading_volume_usd, 0) AS base_trading_volume_usd
+  FROM solana_transfers AS solana
+  FULL OUTER JOIN base_transfers AS base
+    ON solana.block_date = base.block_date
+  ORDER BY
+    block_date DESC
+`;
+
+const chainColumnMap: Record<string, { fees: string; volume: string }> = {
+  [CHAIN.SOLANA]: { fees: 'solana_trading_fees_usd', volume: 'solana_trading_volume_usd' },
+  [CHAIN.BASE]: { fees: 'base_trading_fees_usd', volume: 'base_trading_volume_usd' },
+};
 
 const fetch: any = async (_a: any, _b: any, options: FetchOptions) => {
-  const targets = [
-    '0x1E493E7CF969FD7607A8ACe7198f6C02e5eF85A4',
-    '0xc98218Df72975EE1472919d2685e5BD215Baaad4'
-  ];
+  const data = (await queryDuneSql(options, sql))[0];
+  const cols = chainColumnMap[options.chain];
 
-  const dailyFees = await addTokensReceived({ options, targets });
-  await getETHReceived({ options, targets, balances: dailyFees, notFromSenders: ['0x4200000000000000000000000000000000000006'] });
-  const dailyVolume = dailyFees.clone(100);
+  const dailyFees = data?.[cols.fees] || 0;
+  const dailyVolume = data?.[cols.volume] || 0;
 
-  return { dailyFees, dailyUserFees: dailyFees, dailyRevenue: dailyFees, dailyProtocolRevenue: dailyFees, dailyVolume };
-}
-
-  
-const fetchSol: any = async (_a: any, _b: any, options: FetchOptions) => {
-  const targets = [
-    'FUzZ2SPwLPAKaHubxQzRsk9K8dXb4YBMR6hTrYEMFFZc',
-    'HG73jy6opRQwgTaynUeT6MxX6h3mshNWLPGHme4HdiYy'
-  ];
-
-  const dailyFees = await getSolanaReceived({
-    blacklists: targets,
-    options,
-    targets,
-  });
-  
-  const dailyVolume = dailyFees.clone(100);
-
-  return { dailyFees, dailyUserFees: dailyFees, dailyRevenue: dailyFees, dailyProtocolRevenue: dailyFees, dailyVolume }; 
-}
+  return {
+    dailyFees,
+    dailyUserFees: dailyFees,
+    dailyRevenue: dailyFees,
+    dailyProtocolRevenue: dailyFees,
+    dailyVolume,
+  };
+};
 
 const adapter: SimpleAdapter = {
   version: 1,
-  fetch,
   methodology: {
     Volume: 'Total trading volume is calculated as fees multiplied by 100, since trading fees are 1% of the volume.',
     Fees: 'User pays 1% fee on each trade',
@@ -47,16 +78,16 @@ const adapter: SimpleAdapter = {
   },
   adapter: {
     [CHAIN.SOLANA]: {
-      fetch: fetchSol,
+      fetch,
       start: '2025-07-01',
     },
     [CHAIN.BASE]: {
-      fetch: fetch,
-      start: '2025-07-01',
+      fetch,
+      start: '2025-08-01',
     },
   },
   isExpensiveAdapter: true,
-  dependencies: [Dependencies.ALLIUM],
+  dependencies: [Dependencies.DUNE],
 };
 
 export default adapter;


### PR DESCRIPTION
Currently, the trading volume of o1.exchange on DefiLlama is undercounted. This is because sdk.Balance uses a fixed USD price to calculate the USD trading volume of WETH. In this PR, it is modified to use Dune as the data source, which can obtain real-time WETH trading prices, making the trading volume more accurate.

https://dune.com/queries/5682491 