### PR TITLE
Use Dune SQL for o1 exchange trading volume'

### DIFF
--- a/dexs/o1-exchange/index.ts
+++ b/dexs/o1-exchange/index.ts
@@ -44,11 +44,11 @@ const prefetch = async (options: FetchOptions) => {
 };
 
 const fetch = async (_a: any, _b: any, options: FetchOptions) => {
-  const data = options.preFetchedResults?.[0];
+  const data = options.preFetchedResults[0];
   const cols = chainColumnMap[options.chain];
 
-  const dailyFees = data?.[cols.fees] || 0;
-  const dailyVolume = data?.[cols.volume] || 0;
+  const dailyFees = data[cols.fees];
+  const dailyVolume = data[cols.volume];
 
   return {
     dailyVolume,


### PR DESCRIPTION
Currently, the trading volume of o1.exchange on DefiLlama is undercounted. This is because sdk.Balance uses a fixed USD price to calculate the USD trading volume of WETH. In this PR, it is modified to use Dune as the data source, which can obtain real-time WETH trading prices, making the trading volume more accurate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated O1 Exchange data fetching into a single Dune-powered pipeline for consistent, chain-aware metrics.
  * Removed Solana-specific per-chain fetch; BASE historical metrics start date adjusted to 2025-08-15 (was 2025-07-01).

* **New Features**
  * Adapter now exposes a public prefetch capability and a top-level methodology summary describing Volume, Fees, Revenue and related terms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->