### PR TITLE
Update treadfi-perps: pass timestamp to TreadTools API

### DIFF
--- a/dexs/treadfi-perps.ts
+++ b/dexs/treadfi-perps.ts
@@ -55,9 +55,9 @@ const getHeaders = () => {
   };
 };
 
-const fetchTreadToolsData = async (startOfDay: number): Promise<TreadToolsApiResponse> => {
+const prefetch = async (options: FetchOptions): Promise<any> => {
   try {
-    const url = `${TREADTOOLS_API_URL}?timestamp=${startOfDay}`;
+    const url = `${TREADTOOLS_API_URL}?timestamp=${options.startOfDay}`;
     const response: TreadToolsApiResponse = await httpGet(url, {
       headers: getHeaders(),
     });
@@ -65,7 +65,6 @@ const fetchTreadToolsData = async (startOfDay: number): Promise<TreadToolsApiRes
     if (response.status !== "ok") {
       throw new Error(`API returned status: ${response.status}`);
     }
-
     return response;
   } catch (error: any) {
     throw new Error(`Failed to fetch TreadTools data: ${error.message}`);
@@ -115,7 +114,7 @@ const fetchParadex = async (_a: any, _b: any, options: FetchOptions) => {
   const dailyVolume = options.createBalances();
   const dailyFees = options.createBalances();
 
-  const treadToolsData = await fetchTreadToolsData(options.startOfDay);
+  const treadToolsData = options.preFetchedResults;
   const paradexData = treadToolsData.data?.paradex;
 
   if (paradexData && typeof paradexData.dailyVolume === "number" && paradexData.dailyVolume > 0) {
@@ -138,7 +137,7 @@ const fetchInk = async (_a: any, _b: any, options: FetchOptions) => {
   const dailyVolume = options.createBalances();
   const dailyFees = options.createBalances();
 
-  const treadToolsData = await fetchTreadToolsData(options.startOfDay);
+  const treadToolsData = options.preFetchedResults;
   const nadoData = treadToolsData.data?.nado;
 
   if (nadoData && typeof nadoData.dailyVolume === "number" && nadoData.dailyVolume > 0) {
@@ -161,7 +160,7 @@ const fetchSolana = async (_a: any, _b: any, options: FetchOptions) => {
   const dailyVolume = options.createBalances();
   const dailyFees = options.createBalances();
 
-  const treadToolsData = await fetchTreadToolsData(options.startOfDay);
+  const treadToolsData = options.preFetchedResults;
   const pacificaData = treadToolsData.data?.pacifica;
   const bybitData = treadToolsData.data?.bybit;
 
@@ -192,7 +191,7 @@ const fetchBsc = async (_a: any, _b: any, options: FetchOptions) => {
   const dailyVolume = options.createBalances();
   const dailyFees = options.createBalances();
 
-  const treadToolsData = await fetchTreadToolsData(options.startOfDay);
+  const treadToolsData = options.preFetchedResults;
   const asterData = treadToolsData.data?.aster;
   const binanceData = treadToolsData.data?.binance;
 
@@ -226,6 +225,7 @@ const methodology = {
 
 const adapter: SimpleAdapter = {
   version: 1,
+  prefetch,
   adapter: {
     [CHAIN.HYPERLIQUID]: {
       fetch: fetchHyperliquid,


### PR DESCRIPTION
## Summary
- Remove in-memory cache from `fetchTreadToolsData` and pass `startOfDay` timestamp as a query parameter to the TreadTools API for date-specific volume lookups
- Add `queriedDate` field to `TreadToolsApiResponse` interface to match updated API response

## Test plan
- [ ] Verify TreadTools API returns correct date-specific data with `?timestamp=` param
- [ ] Confirm volume data is fetched correctly for Paradex, Ink, Solana, and BSC chains

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for pre-fetching TreadTools data to streamline data retrieval and reuse.

* **Improvements**
  * More accurate queried-date handling for TreadTools to improve daily data consistency.
  * Switched to day-scoped fetches (removed in-memory caching) so reported volumes reflect the intended query date.
  * Updated data start dates for Paradex, Ink, Solana and BSC to improve historical coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->