### PR TITLE
Add stETH yield tracking and ftAaveYieldWrapper support for Flying Tulip

### DIFF
--- a/fees/flying-tulip.ts
+++ b/fees/flying-tulip.ts
@@ -15,11 +15,29 @@ const WRAPPERS: string[] = [
 
 const yieldClaimedEvent = 'event YieldClaimed(address yieldClaimer, address token, uint256 amount)';
 
+// ftAaveYieldWrapper contract addresses on Ethereum mainnet
+const AAVE_WRAPPERS: string[] = [
+  '0x038f5e5c4ad747036025ffbae1525926bb0bad68', // SCB
+  '0xeee452e8f7bf72f2f42c3ed54acca04b56dcc2a2', // Lemniscap
+  '0xc775262245118c7870a3948a7e5dde89bb25ad2d', // Lemniscap 2
+  '0x918e1bb8030dc51e34814bcc6a582b8530f1a57d', // Tioga Capital
+  '0xa8b2d8de0ef4502ca5e4a2f85abd27fcef28c631', // Hypersphere
+  '0x54b56383d79f80e0466eb1e8ccdaa9c189e79032', // Sigil Fund
+  '0x7c576cb3ff9f28dce25f181734d1e867304524c1', // Amber Group
+  '0xdf6c06f9c7e3807905b387df22ba0397b24381e4', // Paper Ventures
+  '0xfb3342c91e8b74975aaa6bd2b740f797fef9d81c', // Fasanara
+];
+
+const aaveYieldClaimedEvent = 'event YieldClaimed(address indexed caller, address indexed underlying, address indexed aToken, uint256 amount)';
+
 // PUT Marketplace contract
 const PUT_MARKETPLACE = '0x31248663adccdbcad155555b7717697b76cf570c';
 
 // Treasury address
 const TREASURY = '0x1118e1c057211306a40A4d7006C040dbfE1370Cb';
+
+// stETH on Ethereum mainnet
+const STETH = '0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84';
 
 const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
   const dailyFees = options.createBalances();
@@ -38,6 +56,33 @@ const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
     dailyFees.add(token, amount, METRIC.ASSETS_YIELDS);
   });
   
+  // Fetch YieldClaimed events from ftAaveYieldWrapper contracts
+  const aaveLogs = await options.getLogs({
+    targets: AAVE_WRAPPERS,
+    eventAbi: aaveYieldClaimedEvent,
+    flatten: true,
+  });
+
+  aaveLogs.forEach((log: any) => {
+    dailyFees.add(log.underlying, log.amount, METRIC.ASSETS_YIELDS);
+  });
+
+  // Track daily stETH yield via period delta (end balance - start balance)
+  const stethBalanceEnd = await options.api.call({
+    abi: 'erc20:balanceOf',
+    target: STETH,
+    params: [TREASURY],
+  });
+  const stethBalanceStart = await options.fromApi.call({
+    abi: 'erc20:balanceOf',
+    target: STETH,
+    params: [TREASURY],
+  });
+  const stethYield = BigInt(stethBalanceEnd) - BigInt(stethBalanceStart);
+  if (stethYield > 0n) {
+    dailyFees.add(STETH, stethYield, METRIC.ASSETS_YIELDS);
+  }
+
   const tokenReceived = await addTokensReceived({
     options,
     target: TREASURY,


### PR DESCRIPTION
## Summary
- Track stETH yield on treasury wallet (`0x1118e1c057211306a40A4d7006C040dbfE1370Cb`) computed as current stETH balance minus original 2192.991693 WETH principal
- Add 9 ftAaveYieldWrapper contracts (SCB, Lemniscap, Lemniscap 2, Tioga Capital, Hypersphere, Sigil Fund, Amber Group, Paper Ventures, Fasanara) with their `YieldClaimed(address indexed caller, address indexed underlying, address indexed aToken, uint256 amount)` event signature

## Test plan
- [x] Ran `npm test -- fees flying-tulip` — adapter returns $3,358 in Assets Yields + $5 in Marketplace Fees

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added stETH support to yield tracking, recording net stETH yield based on treasury balances.
  * Added Aave wrapper yield sources and processing to include claimed yields in daily totals.
  * Expanded yield fetch flow so additional yield claims are aggregated before final token receipts are computed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->