### PR TITLE
fix: protocol fee/revenue calc changes

### DIFF
--- a/fees/strata-markets/index.ts
+++ b/fees/strata-markets/index.ts
@@ -103,7 +103,7 @@ const fetch = async (options: FetchOptions) => {
   const totalRevenue = performanceFee + redemptionFeesReserve;
 
   // SupplySide Revenue: Gross Yield - 2*Performance Fees + Redemption Fees kept by Tranche
-  const supplySideRevenue = (grossYield - (2 * performanceFee)) + redemptionFeesTranche;
+  const supplySideRevenue = grossYield - performanceFee + redemptionFeesTranche;
 
   dailyFees.add(USDE, totalFees);
   dailyRevenue.add(USDE, totalRevenue);


### PR DESCRIPTION
### Summary

Fixed fee related calculations for Strata. 

Important:
1. Earlier, we were accounting for deposits as well into the yield. Deposits and withdrawals do not account for the yield generated. 
2. Also accounted for the treasury transfers manually in this fix

#### Name (to be shown on DefiLlama)
Strata

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Revised fee model from NAV/reserve-based to a yield-based approach incorporating net user flows, admin reserve adjustments, and shared redemption fees; recomputed fees, protocol revenue, and supply-side revenue. Daily metrics updated accordingly.

* **New Features**
  * Added public constants and events to surface fee, deposit/withdrawal, and reserve-reduction data.
  * Adapter bumped to version 2 and now allows negative reported values.

* **Documentation**
  * Methodology updated to describe the yield-based calculations and fee-sharing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->