### PR TITLE
Add start timestamp to pangolin

### DIFF
--- a/fees/pangolin.ts
+++ b/fees/pangolin.ts
@@ -1,6 +1,7 @@
 import { graph } from "@defillama/sdk";
 import { CHAIN } from "../helpers/chains";
 import { univ2DimensionAdapter2 } from "../helpers/getUniSubgraph";
+import { BaseAdapter } from "../adapters/types";
 
 const adapter = univ2DimensionAdapter2({
   graphUrls: {
@@ -28,6 +29,7 @@ const adapter = univ2DimensionAdapter2({
     Revenue: "Governance revenue is 0.05% trading fees",
   }
 });
+(adapter.adapter as BaseAdapter).avax.start = 1612828800;
 
 
 export default adapter;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected AVAX network start timestamp, ensuring accurate historical fee data from Feb 9, 2021.
  * Improved AVAX initialization, reducing cases where fee data appeared missing or partial.
  * Users should now see complete, consistent AVAX metrics across charts, reports, and exports.
  * Enhances reliability of time-series trends and comparisons involving AVAX.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->