### PR TITLE
Add supply side revenue to fraxswap

### DIFF
--- a/fees/frax-swap.ts
+++ b/fees/frax-swap.ts
@@ -39,13 +39,16 @@ const fetch = async (timestamp: number, _a: any, options: FetchOptions) => {
   return {
     dailyFees,
     dailyUserFees: dailyFees,
+    dailySupplySideRevenue: dailyFees,
     dailyRevenue: "0",
   };
 };
 
 const methodology = {
   UserFees: "Users pay 0.3% swap fees",
-  Fees: "A 0.3% fee is collected from each swap"
+  Fees: "A 0.3% fee is collected from each swap",
+  SupplySideRevenue: "All fees go to LPs",
+  Revenue: "No revenue"
 }
 
 const adapter: Adapter = {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added daily supply-side revenue tracking to Frax Swap fee metrics
  * Clarified fee distribution methodology: all fees accrue to liquidity providers with no protocol revenue retained

<!-- end of auto-generated comment: release notes by coderabbit.ai -->