### PR TITLE
feat: add HoneyPlay fee/revenue adapters for Sui

### DIFF
--- a/fees/honeyplay-marketplace/index.ts
+++ b/fees/honeyplay-marketplace/index.ts
@@ -9,12 +9,15 @@ const MARKETPLACE_PACKAGE = "0xdad0749c40a7adfbdd1b9e46d2f24d6cfec2dfc3a5ead61c6
 // On-chain config (from mainnet Marketplace object)
 const GGSUI_SHARE_PCT = 15; // 15% of commission → ggSUI staking rewards
 
-// Safe wrapper: queryEvents crashes on empty results (data[data.length-1] is undefined)
+// Safe wrapper: queryEvents crashes on empty results (data[data.length-1].timestampMs is undefined)
 async function safeQueryEvents(params: any): Promise<any[]> {
   try {
     return await queryEvents(params);
-  } catch {
-    return [];
+  } catch (e: any) {
+    if (e?.message?.includes("Cannot read properties of undefined") || e instanceof TypeError) {
+      return [];
+    }
+    throw e;
   }
 }
 


### PR DESCRIPTION
Add fee and revenue tracking for three HoneyPlay protocol products on Sui:

- honeyplay-lsd: ggSUI liquid staking vault (validator rewards + redemption fees)
- honeyplay-amm: AMM swap fees, liquidity fees, flash loan fees
- honeyplay-marketplace: NFT marketplace commissions and creator royalties

**NOTE**

#### Please enable "Allow edits by maintainers" while putting up the PR.

---

> - If you would like to add a `tvl` adapter please submit the PR [here](https://github.com/DefiLlama/DefiLlama-Adapters).

1. Once your adapter has been merged, it takes time to show on the UI. If more than 24 hours have passed, please let us know in Discord.
2. Please fill the form below **only if the PR is for listing a new protocol** else it can be ignored/replaced with reason/details about the PR
3. **For updating listing info** It is a different repo, you can find your listing in this file: https://github.com/DefiLlama/defillama-server/blob/master/defi/src/protocols/data4.ts, you can edit it there and put up a PR
4. Do not edit/push `package.json/package-lock.json` file as part of your changes
5. No need to go to our discord/other channel and announce that you've created a PR, we monitor all PRs and will review it asap

---

##### Name (to be shown on DefiLlama):
HoneyPlay

##### Twitter Link:
https://x.com/HoneyPlaydotfun

##### List of audit links if any:

##### Website Link:
https://honeyplay.fun/

##### Logo (High resolution, will be shown with rounded borders):
https://assets.honeyplay.fun/assets/HoneyLogo.png

##### Current TVL:
~10 SUI (recently deployed)

##### Treasury Addresses (if the protocol has treasury)
Fee Collector (SUI): 0x9d466f8f15a1643224ae00dd57c7df65d81778c05a5136011d59ecbc191d89fa
Fee Collector (HONEY): 0xa11cc2476daab89fe5a13cbced622e937ecea598e3cad1ef7eec6b77265b5382
HoneyYield: 0x459f26f4a08476e26f48be4d779f0d1a85e4a1fee1e7eb3208b3c1adb5dd7d37

##### Chain:
Sui

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed): (https://api.coingecko.com/api/v3/coins/list)

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)

##### Short Description (to be shown on DefiLlama):
DeFi infrastructure on Sui with programmable token taxes (HoneyTax), AMM with multi-curve support, NFT marketplace, and ggSUI liquid staking.

##### Token address and ticker if any:
HONEY - 0x6b829fa0c8676b5d13287751db53d0eca8083d4184fc5c9d0b9796610af09d50
GGSUI (liquid staked SUI) - 0xe26df07c978d6e6dce9e1ba1cfea035553dac7d57b75e7d574338bfc7d670185

##### Category (full list at https://defillama.com/categories) \*Please choose only one:
DEX

##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.):

##### Implementation Details: Briefly describe how the oracle is integrated into your project:

##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage:

##### forkedFrom (Does your project originate from another project):
NO

##### methodology (what is being counted as tvl, how is tvl being calculated):
 This PR adds fee/revenue tracking for three HoneyPlay products on Sui:
                                                                                                                                                     
  1. **honeyplay-lsd** (ggSUI Liquid Staking):                                                                                                       
     - Fees: Total validator staking rewards (gross, before protocol cut) + instant unstake redemption fees (0.01%)                                  
     - Revenue: 10% protocol fee on validator staking rewards                                                                                        
     - Supply Side: 90% of validator rewards to ggSUI holders + 100% of redemption fees                                                            

  2. **honeyplay-amm** (AMM):
     - Fees: Swap fees (creator fee + total AMM fee), liquidity add/remove fees, flash loan fees
     - Revenue: Protocol fee portion (50% of AMM fee by default)
     - Supply Side: LP fee portion (remaining 50% of AMM fee) stays in pool reserves

  3. **honeyplay-marketplace** (NFT Marketplace):
     - Fees: 2% platform commission on all NFT sales + creator royalties
     - Revenue: Full 2% platform commission
     - Supply Side: 15% of commission redistributed to ggSUI stakers
     
##### Github org/user (Optional, if your code is open source, we can track activity):
LifeOrDream

##### Does this project have a referral program?
No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Honeyplay AMM: daily aggregation of swap, liquidity and flash-loan fees with revenue and supply-side breakdowns on SUI.
  * Honeyplay LSD: daily ggSUI vault metrics including rewards, redemption fees, protocol revenue and supply-side calculations.
  * Honeyplay Marketplace: daily marketplace fee tracking capturing commissions, royalties, protocol revenue and staking-share distributions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->