### PR TITLE
Add Solid Fuse vault to fees adapter

### DIFF
--- a/fees/solid-yield.ts
+++ b/fees/solid-yield.ts
@@ -175,14 +175,14 @@ async function fetch(options: FetchOptions): Promise<FetchResultV2> {
     })
 
     const exchangeRate = vault.accountantAbiVersion === 1 ? Number(getAccountantState[3]) : Number(getAccountantState[4])
-    const paltformFeeRate = vault.accountantAbiVersion === 1 ? Number(getAccountantState[9]) : Number(getAccountantState[10])
+    const platformFeeRate = vault.accountantAbiVersion === 1 ? Number(getAccountantState[9]) : Number(getAccountantState[10])
 
     const totalDeposited = Number(totalSupply) * Number(exchangeRate) / vaultRateBase
 
     // platform fees changred by Solid Yield per year of total assets in vault
     const yearInSecs = 365 * 24 * 60 * 60
     const timespan = options.toApi.timestamp && options.fromApi.timestamp ? Number(options.toApi.timestamp) - Number(options.fromApi.timestamp) : 86400
-    const platformFee = totalDeposited * (paltformFeeRate / AccountantFeeRateBase) * timespan / yearInSecs
+    const platformFee = totalDeposited * (platformFeeRate / AccountantFeeRateBase) * timespan / yearInSecs
 
     dailyFees.add(token, platformFee)
     dailyProtocolRevenue.add(token, platformFee)


### PR DESCRIPTION
## Summary
- Adds the new Solid Fuse boring vault (`0xb33c8F0b0816fd147FCF896C594a3ef408845e2C`) on the Fuse chain to the existing `solid-yield` fees adapter
- The vault uses WFUSE as its base asset and tracks performance fees and platform fees
- Uses the same accountant ABI version 2 as the existing Solid vaults

## Changes
- `fees/solid-yield.ts`: Added the new Fuse vault address to the `BoringVaults[CHAIN.FUSE]` array

## Test
```bash
npm test fees solid-yield
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for an additional vault on the Fuse chain.

* **Bug Fixes**
  * Corrected platform fee calculation to ensure fees are computed accurately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->