### PR TITLE
feat: add MineBTC fee adapter

### DIFF
--- a/fees/minebtc.ts
+++ b/fees/minebtc.ts
@@ -1,0 +1,58 @@
+import { Dependencies, FetchOptions, SimpleAdapter } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+import { getSolanaReceived } from "../helpers/token";
+
+// MineBTC Program: Hw9uxvtmQdS57N6aNwJA5iqjSqzhRDdopCHgm8EPwkqx
+// Fee structure: 10% protocol fee on all SOL bets
+//   - 1% -> staker SOL rewards vault (supply-side)
+//   - 9% -> SOL treasury, further split:
+//       - 80% (7.2% of bets) -> dogeBTC buybacks (holders)
+//       - 20% (1.8% of bets) -> team multisig (protocol)
+const SOL_TREASURY = "6rBKBaVK2m8rGjHXa65ohjWjD3B3VGDSKUpJrxraPmX1";
+
+const fetch = async (options: FetchOptions) => {
+  // SOL treasury receives 9% of all bets placed (the other 1% goes to staker vault)
+  const dailyRevenue = await getSolanaReceived({ options, targets: [SOL_TREASURY] });
+
+  // Total protocol fees = 10% of bets; treasury = 9/10 of that
+  const dailyFees = dailyRevenue.clone(10 / 9);
+
+  // Supply-side: staker SOL rewards = 1% of bets = 1/9 of treasury inflow
+  const dailySupplySideRevenue = dailyRevenue.clone(1 / 9);
+
+  // Protocol revenue: 20% of treasury -> team multisig
+  const dailyProtocolRevenue = dailyRevenue.clone(0.2);
+
+  // Holders revenue: 80% of treasury -> dogeBTC buybacks
+  const dailyHoldersRevenue = dailyRevenue.clone(0.8);
+
+  return {
+    dailyFees,
+    dailyUserFees: dailyFees,
+    dailyRevenue,
+    dailyProtocolRevenue,
+    dailyHoldersRevenue,
+    dailySupplySideRevenue,
+  };
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  adapter: {
+    [CHAIN.SOLANA]: {
+      fetch,
+      start: "2025-12-16",
+    },
+  },
+  dependencies: [Dependencies.ALLIUM],
+  isExpensiveAdapter: true,
+  methodology: {
+    Fees: "10% protocol fee on all SOL bets placed in MineBTC faction warfare rounds.",
+    Revenue: "9% of bets flow to the protocol treasury for buybacks and team earnings.",
+    ProtocolRevenue: "20% of treasury (1.8% of total bets) distributed to team multisig as dev earnings.",
+    HoldersRevenue: "80% of treasury (7.2% of total bets) used for dogeBTC token buybacks, benefiting holders.",
+    SupplySideRevenue: "1% of bets distributed as SOL staking rewards to dogeBTC and LP stakers of the winning faction.",
+  },
+};
+
+export default adapter;


### PR DESCRIPTION
Track fees from MineBTC Solana faction warfare betting game. 10% protocol fee on all SOL bets: 1% staker rewards (supply-side), 7.2% dogeBTC buybacks (holders), 1.8% team earnings (protocol).

**NOTE**

#### Please enable "Allow edits by maintainers" while putting up the PR.

---

> - If you would like to add a `tvl` adapter please submit the PR [here](https://github.com/DefiLlama/DefiLlama-Adapters).

1. Once your adapter has been merged, it takes time to show on the UI. If more than 24 hours have passed, please let us know in Discord.
2. Please fill the form below **only if the PR is for listing a new protocol** else it can be ignored/replaced with reason/details about the PR
3. **For updating listing info** It is a different repo, you can find your listing in this file: https://github.com/DefiLlama/defillama-server/blob/master/defi/src/protocols/data4.ts, you can edit it there and put up a PR
4. Do not edit/push `package.json/package-lock.json` file as part of your changes
5. No need to go to our discord/other channel and announce that you've created a PR, we monitor all PRs and will review it asap

---

##### Name (to be shown on DefiLlama):
MineBTC

##### Twitter Link:
https://x.com/minebtcdotfun
  
##### List of audit links if any:

##### Website Link:
https://minebtc.fun

##### Logo (High resolution, will be shown with rounded borders):
https://assets.minebtc.fun/btc-logo.png

##### Current TVL:
$12 (just launched, protocol vaults seeded with minimal SOL)


##### Treasury Addresses (if the protocol has treasury)
  - SOL Treasury: 6rBKBaVK2m8rGjHXa65ohjWjD3B3VGDSKUpJrxraPmX1
  - Doges Treasury: 3burVzSiwhZgix68DyWqa8rhd5USUhBq9sAHZDBtxRSq
  - Buybacks SOL Vault: DbDXDZtp88iQAFy9y1iJCyZ6toxGG29AEH6BcVembr6n
  
  
##### Chain:
Solana


##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed): (https://api.coingecko.com/api/v3/coins/list)

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)

##### Short Description (to be shown on DefiLlama):
A speculative entertainment and betting experiment building a fully AI-driven reserve currency on Solana. Players compete in 60-second faction warfare rounds to mine $dogeBTC — a deflationary Token-2022 with self-adjusting emissions that respond to market conditions. Features evolvable AI-generated Doge NFTs that power lore, gaming, and an AI content engine.

##### Token address and ticker if any:
BwMCF5LSHPvrR8pLVvcsa4k1AMg4VWVnMWUiNEXMtLkE — $dogeBTC (Token-2022 with 1% transfer tax)

##### Category (full list at https://defillama.com/categories) \*Please choose only one:
Gamified Mining 

##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.):

##### Implementation Details: Briefly describe how the oracle is integrated into your project:

##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage:
https://gameplay.minebtc.fun/introduction

##### forkedFrom (Does your project originate from another project):
No

##### methodology (what is being counted as tvl, how is tvl being calculated):
TVL includes SOL in betting prize pot and staker reward vault, staked DogeBTC in custodian vault, DogeBTC in faction treasury and NFT floor sweep vaults. Staked LP tokens are valued by their pro-rata share of underlying SOL and DogeBTC in the Raydium pool (using total LP supply from pool state, which includes burned LP).
    
##### Github org/user (Optional, if your code is open source, we can track activity):
LifeOrDream

##### Does this project have a referral program?
Yes — referrers earn 3% of referred users' staking rewards, and referred users receive a 1% bonus.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added MineBTC fee adapter for Solana, enabling tracking of daily fees and revenue distribution across multiple streams including user fees, supply-side revenue, protocol revenue, and holders revenue.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->