### PR TITLE
feat(skate-amm): add MegaETH chain support

### DIFF
--- a/dexs/skate-amm/index.ts
+++ b/dexs/skate-amm/index.ts
@@ -13,7 +13,8 @@ const skateChainIds: Record<string, number> = {
     [CHAIN.PLUME]: 98866,
     [CHAIN.MANTLE]: 5000,
     [CHAIN.SUI]: 1001,
-    [CHAIN.MONAD]: 143
+    [CHAIN.MONAD]: 143,
+    [CHAIN.MEGAETH]: 4326
 }
 
 const skateDataApi = "https://api.skatechain.org/amm-data/pools/stats";
@@ -65,7 +66,8 @@ const adapter: SimpleAdapter = {
         [CHAIN.PLUME]: { start: '2025-06-02', },
         [CHAIN.MANTLE]: { start: '2025-05-28', },
         [CHAIN.SUI]: { start: '2025-06-22', },
-        [CHAIN.MONAD]: { start: '2025-11-25', }
+        [CHAIN.MONAD]: { start: '2025-11-25', },
+        [CHAIN.MEGAETH]: { start: '2026-02-18', }
     },
 }
 


### PR DESCRIPTION
## Summary
- Adds MegaETH (chain ID 4326) to the skate-amm adapter
- Sets start date to 2026-02-18

## Test plan
- [x] Verify MegaETH pools are returned from the Skate API
- [x] Check volume data is populated for MegaETH

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the MEGAETH chain to the DEX adapter, expanding the available blockchain networks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->