### PR TITLE
PullHourly small fix

### DIFF
--- a/adapters/types.ts
+++ b/adapters/types.ts
@@ -45,7 +45,6 @@ export type FetchOptions = {
   getEndBlock: () => Promise<number>,
   dateString: string,
   preFetchedResults?: any,
-  moduleUID?: string, // randomly generated unique identifier for the module, useful for caching
   startOfDayId?: string, // id used in some subgraphs to identify daily data, usually it's the startOfDay timestamp divided by 86400
 }
 


### PR DESCRIPTION
```
🦙 Running 8DX-AGGREGATOR adapter 🦙
---------------------------------------------------
Start Date:     Wed, 18 Feb 2026 06:00:00 GMT      
End Date:       Thu, 19 Feb 2026 06:00:00 GMT      
---------------------------------------------------

Slice 0:
Start Date:     Wed, 18 Feb 2026 06:00:00 GMT       
End Date:       Wed, 18 Feb 2026 07:00:00 GMT       
--------------------------------------------------- 

ETHEREUM 👇
Backfill start time: 21/9/2025
Daily volume: 0.00
End timestamp: 1771397999 (2026-02-18T06:59:59.000Z)


Slice 1:
Start Date:     Wed, 18 Feb 2026 07:00:00 GMT       
End Date:       Wed, 18 Feb 2026 08:00:00 GMT       
--------------------------------------------------- 

ETHEREUM 👇
Backfill start time: 21/9/2025
Daily volume: 0.00
End timestamp: 1771401599 (2026-02-18T07:59:59.000Z)


Slice 2:
Start Date:     Wed, 18 Feb 2026 08:00:00 GMT      
End Date:       Wed, 18 Feb 2026 09:00:00 GMT      
---------------------------------------------------

ETHEREUM 👇
Backfill start time: 21/9/2025
Daily volume: 0.00
End timestamp: 1771405199 (2026-02-18T08:59:59.000Z)


Slice 3:
Start Date:     Wed, 18 Feb 2026 09:00:00 GMT
End Date:       Wed, 18 Feb 2026 10:00:00 GMT
---------------------------------------------------

ETHEREUM 👇
Backfill start time: 21/9/2025
Daily volume: 0.00
End timestamp: 1771408799 (2026-02-18T09:59:59.000Z)


Slice 4:
Start Date:     Wed, 18 Feb 2026 10:00:00 GMT
End Date:       Wed, 18 Feb 2026 11:00:00 GMT
---------------------------------------------------

ETHEREUM 👇
Backfill start time: 21/9/2025
Daily volume: 0.00
End timestamp: 1771412399 (2026-02-18T10:59:59.000Z)


Slice 5:
Start Date:     Wed, 18 Feb 2026 11:00:00 GMT
End Date:       Wed, 18 Feb 2026 12:00:00 GMT
---------------------------------------------------

ETHEREUM 👇
Backfill start time: 21/9/2025
Daily volume: 0.00
End timestamp: 1771415999 (2026-02-18T11:59:59.000Z)


Slice 6:
Start Date:     Wed, 18 Feb 2026 12:00:00 GMT
End Date:       Wed, 18 Feb 2026 13:00:00 GMT
---------------------------------------------------

ETHEREUM 👇
Backfill start time: 21/9/2025
Daily volume: 0.00
End timestamp: 1771419599 (2026-02-18T12:59:59.000Z)


Slice 7:
Start Date:     Wed, 18 Feb 2026 13:00:00 GMT
End Date:       Wed, 18 Feb 2026 14:00:00 GMT
---------------------------------------------------

ETHEREUM 👇
Backfill start time: 21/9/2025
Daily volume: 0.00
End timestamp: 1771423199 (2026-02-18T13:59:59.000Z)


Slice 8:
Start Date:     Wed, 18 Feb 2026 14:00:00 GMT
End Date:       Wed, 18 Feb 2026 15:00:00 GMT
---------------------------------------------------

ETHEREUM 👇
Backfill start time: 21/9/2025
Daily volume: 0.00
End timestamp: 1771426799 (2026-02-18T14:59:59.000Z)


Slice 9:
Start Date:     Wed, 18 Feb 2026 15:00:00 GMT
End Date:       Wed, 18 Feb 2026 16:00:00 GMT
---------------------------------------------------

ETHEREUM 👇
Backfill start time: 21/9/2025
Daily volume: 0.00
End timestamp: 1771430399 (2026-02-18T15:59:59.000Z)


Slice 10:
Start Date:     Wed, 18 Feb 2026 16:00:00 GMT
End Date:       Wed, 18 Feb 2026 17:00:00 GMT
---------------------------------------------------

ETHEREUM 👇
Backfill start time: 21/9/2025
Daily volume: 0.00
End timestamp: 1771433999 (2026-02-18T16:59:59.000Z)


Slice 11:
Start Date:     Wed, 18 Feb 2026 17:00:00 GMT
End Date:       Wed, 18 Feb 2026 18:00:00 GMT
---------------------------------------------------

ETHEREUM 👇
Backfill start time: 21/9/2025
Daily volume: 0.00
End timestamp: 1771437599 (2026-02-18T17:59:59.000Z)


Slice 12:
Start Date:     Wed, 18 Feb 2026 18:00:00 GMT
End Date:       Wed, 18 Feb 2026 19:00:00 GMT
---------------------------------------------------

ETHEREUM 👇
Backfill start time: 21/9/2025
Daily volume: 12.00
End timestamp: 1771441199 (2026-02-18T18:59:59.000Z)


Slice 13:
Start Date:     Wed, 18 Feb 2026 19:00:00 GMT
End Date:       Wed, 18 Feb 2026 20:00:00 GMT
---------------------------------------------------

ETHEREUM 👇
Backfill start time: 21/9/2025
Daily volume: 0.00
End timestamp: 1771444799 (2026-02-18T19:59:59.000Z)


Slice 14:
Start Date:     Wed, 18 Feb 2026 20:00:00 GMT
End Date:       Wed, 18 Feb 2026 21:00:00 GMT
---------------------------------------------------

ETHEREUM 👇
Backfill start time: 21/9/2025
Daily volume: 0.00
End timestamp: 1771448399 (2026-02-18T20:59:59.000Z)


Slice 15:
Start Date:     Wed, 18 Feb 2026 21:00:00 GMT
End Date:       Wed, 18 Feb 2026 22:00:00 GMT
---------------------------------------------------

ETHEREUM 👇
Backfill start time: 21/9/2025
Daily volume: 0.00
End timestamp: 1771451999 (2026-02-18T21:59:59.000Z)


Slice 16:
Start Date:     Wed, 18 Feb 2026 22:00:00 GMT
End Date:       Wed, 18 Feb 2026 23:00:00 GMT
---------------------------------------------------

ETHEREUM 👇
Backfill start time: 21/9/2025
Daily volume: 0.00
End timestamp: 1771455599 (2026-02-18T22:59:59.000Z)


Slice 17:
Start Date:     Wed, 18 Feb 2026 23:00:00 GMT
End Date:       Thu, 19 Feb 2026 00:00:00 GMT
---------------------------------------------------

ETHEREUM 👇
Backfill start time: 21/9/2025
Daily volume: 0.00
End timestamp: 1771459199 (2026-02-18T23:59:59.000Z)


Slice 18:
Start Date:     Thu, 19 Feb 2026 00:00:00 GMT
End Date:       Thu, 19 Feb 2026 01:00:00 GMT
---------------------------------------------------

ETHEREUM 👇
Backfill start time: 21/9/2025
Daily volume: 0.00
End timestamp: 1771462799 (2026-02-19T00:59:59.000Z)


Slice 19:
Start Date:     Thu, 19 Feb 2026 01:00:00 GMT
End Date:       Thu, 19 Feb 2026 02:00:00 GMT
---------------------------------------------------

ETHEREUM 👇
Backfill start time: 21/9/2025
Daily volume: 0.00
End timestamp: 1771466399 (2026-02-19T01:59:59.000Z)


Slice 20:
Start Date:     Thu, 19 Feb 2026 02:00:00 GMT
End Date:       Thu, 19 Feb 2026 03:00:00 GMT
---------------------------------------------------

ETHEREUM 👇
Backfill start time: 21/9/2025
Daily volume: 0.00
End timestamp: 1771469999 (2026-02-19T02:59:59.000Z)


Slice 21:
Start Date:     Thu, 19 Feb 2026 03:00:00 GMT
End Date:       Thu, 19 Feb 2026 04:00:00 GMT
---------------------------------------------------

ETHEREUM 👇
Backfill start time: 21/9/2025
Daily volume: 0.00
End timestamp: 1771473599 (2026-02-19T03:59:59.000Z)


Slice 22:
Start Date:     Thu, 19 Feb 2026 04:00:00 GMT
End Date:       Thu, 19 Feb 2026 05:00:00 GMT
---------------------------------------------------

ETHEREUM 👇
Backfill start time: 21/9/2025
Daily volume: 0.00
End timestamp: 1771477199 (2026-02-19T04:59:59.000Z)


Slice 23:
Start Date:     Thu, 19 Feb 2026 05:00:00 GMT
End Date:       Thu, 19 Feb 2026 06:00:00 GMT
---------------------------------------------------

ETHEREUM 👇
Backfill start time: 21/9/2025
Daily volume: 0.00
End timestamp: 1771480799 (2026-02-19T05:59:59.000Z)



====== TOTAL DAILY AGGREGATED (sum of slots per chain) ======

ETHEREUM 👇
End timestamp: 1771480799 (2026-02-19T05:59:59.000Z)
Daily volume: 12.00
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Configuration parameters now offer greater flexibility with optional settings
  * Batch processing operations now include time window management capabilities

* **Refactor**
  * Streamlined public adapter interface for improved clarity

<!-- end of auto-generated comment: release notes by coderabbit.ai -->