### PR TITLE
Enable backfill for alphasec-spot adapter

### DIFF
--- a/dexs/alphasec-spot.ts
+++ b/dexs/alphasec-spot.ts
@@ -1,35 +1,56 @@
 import { SimpleAdapter, FetchOptions, ChainBlocks } from "../adapters/types";
 import { httpGet } from "../utils/fetchURL";
 import { CHAIN } from "../helpers/chains";
+import { METRIC } from "../helpers/metrics";
 
 const API_URL = "https://api.alphasec.trade/api/v1/defillama/stats";
+
+const metrics = {
+  TradingRebatesAndCommissions: "Trading Rebates and Commissions",
+};
 
 const fetch = async (_ts: number, _: ChainBlocks, options: FetchOptions) => {
   const url = `${API_URL}?startOfDay=${options.startOfDay}`;
   const data = await httpGet(url);
   const stats = data.result;
 
+  const dailyFees = options.createBalances();
+  const dailyRevenue = options.createBalances();
+  const dailySupplySideRevenue = options.createBalances();
+
+  dailyFees.addUSDValue(stats.dailyFees, METRIC.TRADING_FEES);
+  dailyRevenue.addUSDValue(stats.dailyRevenue, METRIC.PROTOCOL_FEES);
+  dailySupplySideRevenue.addUSDValue(stats.dailySupplySideRevenue, metrics.TradingRebatesAndCommissions);
+
   return {
     dailyVolume: stats.dailyVolume,
-    dailyFees: stats.dailyFees,
-    dailyRevenue: stats.dailyRevenue,
-    dailySupplySideRevenue: stats.dailySupplySideRevenue,
+    dailyFees,
+    dailyRevenue,
+    dailySupplySideRevenue,
   };
 };
 
 const adapter: SimpleAdapter = {
   version: 1,
-  adapter: {
-    [CHAIN.ALPHASEC]: {
-      fetch,
-      start: 1764720000,
-    },
-  },
+  fetch,
+  chains: [CHAIN.ALPHASEC],
+  start: '2025-12-02',
   methodology: {
     Volume: 'Total notional value of all trades executed on the AlphaSec DEX.',
     Fees: 'Total trading fees paid by users before any rebates or commissions are deducted.',
     SupplySideRevenue: 'Rebates and commissions paid to ecosystem participants.',
     Revenue: 'Total fees minus supply side revenue (rebates and commissions).',
+  },
+  breakdownMethodology: {
+    Fees: {
+      [METRIC.TRADING_FEES]: 'Trading fees charged on all trades executed on the AlphaSec DEX, calculated as a percentage of trade notional value and paid by users before any rebates or incentives are applied.',
+    },
+    Revenue: {
+      [METRIC.PROTOCOL_FEES]: 'Protocol revenue retained by AlphaSec after paying out trading rebates and commissions to market makers, referrers, and other ecosystem participants.',
+    },
+    SupplySideRevenue: {
+      [metrics.TradingRebatesAndCommissions]: 'Trading rebates and commissions paid to ecosystem participants including market makers, referrers, and other liquidity providers to incentivize trading activity and liquidity provision.',
+    },
   },
 };
 


### PR DESCRIPTION
Follow-up to https://github.com/DefiLlama/dimension-adapters/pull/5836#discussion_r2779515048 as discussed with @bheluga — our backend API now supports the `startOfDay` parameter for historical daily stats.

## Changes

- Import `FetchOptions` and update fetch signature to accept `(timestamp, _, options)` per version 1 convention
- Pass `options.startOfDay` as query parameter to backend API
- Update response field mapping to match new flat API response (`stats.dailyVolume` instead of `stats.volume.daily`, etc.)
- Replace `runAtCurrTime: true` with `start: 1764720000` (December 3, 2025 — our exchange launch date)

---
## Question: Re-processing historical data

Since our exchange has been tracked since around December 17, 2025, the existing data between Dec 17 and now was collected via `runAtCurrTime: true` (which only captured the latest 24h snapshot at the time of each collection).

With backfill enabled, our API can now return accurate daily stats for each specific day going back to launch (December 3, 2025). Could you confirm that DefiLlama's backfill process will overwrite the previously collected data points with the more accurate backfilled values? Just want to make sure the historical data ends up correct.

Thank you!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adapter now exposes a top-level fetch, chain list and a fixed start date for consistent data retrieval.

* **Updates**
  * Fetching uses an explicit start-of-day parameter and initializes dedicated daily balance objects for fees, revenue and supply-side revenue.
  * Returned fields aligned to the adapter's updated daily data shape and include a new trading rebates metric.

* **Documentation**
  * Added a breakdown methodology mapping Fees, Revenue, and Supply-Side Revenue to metrics and descriptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->