### PR TITLE
wstkscusd baddebt

### DIFF
--- a/fees/silo-finance-v2/index.ts
+++ b/fees/silo-finance-v2/index.ts
@@ -125,6 +125,10 @@ const badDebtSiloMapping: BadDebtSiloMapping = {
     {
       silo: "0x61ffbead1d4dc9ffba35eb16fd6cadee9b37b2aa", //smsUSD
       timestamp: 1762128000 // 2025-11-03
+    },
+    {
+      silo: "0x6030ad53d90ec2fb67f3805794dbb3fa5fd6eb64", //pt-wstkusd
+      timestamp: 1762128000 // 2025-11-03
     }
   ],
 };


### PR DESCRIPTION
Add another baddebt silo, wstkscUSD was hit by stream

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated bad debt silo configuration for the SONIC chain with new entry data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->