### PR TITLE
fix flowx-v3 dex volume: replace broken GraphQL API with on-chain events

### DIFF
--- a/dexs/flowx-v3/index.ts
+++ b/dexs/flowx-v3/index.ts
@@ -64,7 +64,9 @@ const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
       if (result.status === "fulfilled" && result.value?.type) {
         try {
           poolCache[id] = parsePoolType(result.value.type);
-        } catch {}
+        } catch (e: any) {
+          console.error(`[flowx-v3] Failed to parse pool type for ${id}: ${e?.message}`);
+        }
       }
     });
   }
@@ -72,8 +74,8 @@ const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
   for (const row of results) {
     const pool = poolCache[row.pool_id];
     if (!pool) continue;
-    if (row.volume_x > 0) dailyVolume.add(pool.coinX, row.volume_x);
-    if (row.volume_y > 0) dailyVolume.add(pool.coinY, row.volume_y);
+    if (row.volume_x > 0) dailyVolume.add(pool.coinX, String(row.volume_x));
+    if (row.volume_y > 0) dailyVolume.add(pool.coinY, String(row.volume_y));
   }
 
   return { dailyVolume };


### PR DESCRIPTION
## Summary

Fixes #5278. FlowX's `getClmmVolume` GraphQL endpoint returns `"0"` for all date ranges — their backend stopped populating CLMM volume data. The protocol is still active on-chain (TVL ~$862K, ~4K swaps/day across 42 pools).

Replaces the broken API with direct on-chain Swap event queries from the FlowX CLMM contract on Sui.

## Methodology

- Query `pool::Swap` events from the FlowX CLMM package (`0x2592...f26d`) using `queryEvents` from `helpers/sui.ts`
- For each unique pool, call `getObject(pool_id)` to resolve token types from the `Pool<CoinX, CoinY>` generic type params (cached + fetched in parallel)
- Count the input side of each swap to avoid double-counting: `amount_x` if `x_for_y`, `amount_y` otherwise
- Use `createBalances()` for USD conversion — same pattern as `typus-perp`

## Test results

`npx ts-node cli/testAdapter.ts dexs flowx-v3` on Feb 20: **$1.18M daily volume**, 4,078 swaps across 42 pools. Top pairs by activity: SUI/STSUI, wUSDC/USDC, USDT/USDC, SUI/USDC.

## Test plan

- [x] `npx ts-node cli/testAdapter.ts dexs flowx-v3` — returns non-zero daily volume
- [x] Historical backfill test with past date — works
- [x] Cross-validated SUI/STSUI pool swap count (1,117) against direct RPC query — exact match

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * FlowX V3 now derives daily volumes from direct on-chain event queries, improving freshness and accuracy of reported volumes.
  * Pool-type parsing and internal caching ensure volumes are attributed to the correct tokens and reduce repeated lookups, improving consistency and performance.
  * Data retrieval flow updated to consolidate results into a unified dailyVolume output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->