### PR TITLE
World Inc: raw asset balances for spot/perp volume and added fees tracking

### DIFF
--- a/dexs/worldinc-perps/shared.ts
+++ b/dexs/worldinc-perps/shared.ts
@@ -1,0 +1,51 @@
+/**
+ * Shared constants and helpers for World Inc (WCM) adapters (fees, spot volume, perp volume).
+ */
+
+export const COMPOSITE_EXCHANGE = "0x5e3Ae52EbA0F9740364Bd5dd39738e1336086A8b";
+export const EXCHANGE_START_BLOCK = 7274994;
+
+export const SPOT_PERP_TRADE_EVENT =
+  "event NewTrade(uint64 indexed buyer, uint64 indexed seller, uint256 spotMatchQuantities, uint256 spotMatchData)";
+
+export const ABI_GET_SPOT =
+  "function getSpotOrderBook(uint32 token1, uint32 token2) external view returns (address, uint32 buyToken, uint32 payToken)";
+export const ABI_GET_PERPS =
+  "function getPerpOrderBook(uint32 token1, uint32 token2) external view returns (address, uint32 buyToken, uint32 payToken)";
+export const ABI_GET_TOKEN_CONFIGS =
+  "function readTokenConfig(uint32 tokenId) external view returns (uint256)";
+
+export const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
+
+const MASK_64 = BigInt("0xFFFFFFFFFFFFFFFF");
+
+export function parseSpotMatchQuantities(smq: bigint) {
+  const fromFee = smq & MASK_64;
+  const toFee = (smq >> 64n) & MASK_64;
+  const fromQuantity = (smq >> 128n) & MASK_64;
+  const toQuantity = (smq >> 192n) & MASK_64;
+  return { fromFee, toFee, fromQuantity, toQuantity };
+}
+
+export function positionRawToErc20Raw(
+  raw: bigint,
+  positionDecimals: number,
+  erc20Decimals: number
+): bigint {
+  if (positionDecimals === erc20Decimals) return raw;
+  if (erc20Decimals >= positionDecimals)
+    return raw * 10n ** BigInt(erc20Decimals - positionDecimals);
+  return raw / 10n ** BigInt(positionDecimals - erc20Decimals);
+}
+
+/** VaultTokenConfig: tokenAddress 0-159, positionDecimals 168, vaultDecimals 176, erc20Decimals 184, tokenId 200 (PublicStruct.sol). */
+export function decodeVaultTokenConfig(vtc: bigint) {
+  const vtcBigInt = BigInt(vtc);
+  const tokenAddress =
+    "0x" + (vtcBigInt & ((1n << 160n) - 1n)).toString(16).padStart(40, "0");
+  const positionDecimals = Number((vtcBigInt >> 168n) & 0xffn);
+  const vaultDecimals = Number((vtcBigInt >> 176n) & 0xffn);
+  const erc20Decimals = Number((vtcBigInt >> 184n) & 0xffn);
+  const tokenId = Number((vtcBigInt >> 200n) & 0xffffffffn);
+  return { tokenAddress, positionDecimals, vaultDecimals, erc20Decimals, tokenId };
+}


### PR DESCRIPTION
**NOTE**

#### Please enable "Allow edits by maintainers" while putting up the PR.

---

> - If you would like to add a `tvl` adapter please submit the PR [here](https://github.com/DefiLlama/DefiLlama-Adapters).

1. Once your adapter has been merged, it takes time to show on the UI. If more than 24 hours have passed, please let us know in Discord.
2. Please fill the form below **only if the PR is for listing a new protocol** else it can be ignored/replaced with reason/details about the PR
3. **For updating listing info** It is a different repo, you can find your listing in this file: https://github.com/DefiLlama/defillama-server/blob/master/defi/src/protocols/data4.ts, you can edit it there and put up a PR
4. Do not edit/push `package.json/package-lock.json` file as part of your changes
5. No need to go to our discord/other channel and announce that you've created a PR, we monitor all PRs and will review it asap

---

Added fees tracking for the protocol

Modified volume tracking to return raw asset balances


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added World Inc (WCM) protocol fees adapter for MEGAETH, computing per-token ERC20-denominated daily fees from spot, perp, lending, and liquidation flows.

* **Refactor**
  * Restructured orderbook/token metadata to include token ERC20 decimals and on-chain addresses; improved cross-decimal normalization and volume/fee aggregation.

* **Chores**
  * Added shared constants and helpers for event parsing and token/quantity conversions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->