### PR TITLE
Add ChimpX AI-powered DeFi aggregator (BNB Chain)

### DIFF
--- a/aggregators/chimpx/index.ts
+++ b/aggregators/chimpx/index.ts
@@ -5,9 +5,6 @@ import { FetchOptions, FetchResultVolume, SimpleAdapter } from "../../adapters/t
 // https://bscscan.com/address/0x8327839597934e1490f90D06F2b0A549dFC7edeB
 const VOLUME_REGISTRY = "0x8327839597934e1490f90D06F2b0A549dFC7edeB";
 
-// Deployment Unix timestamp for block 82131810 on BSC
-const START_TIMESTAMP = 1771505066;
-
 // VolumeRegistered(address indexed user, uint8 indexed actionType, uint256 volumeUsd, bytes32 txRef, uint256 timestamp)
 const EVENT_ABI = "event VolumeRegistered(address indexed user, uint8 indexed actionType, uint256 volumeUsd, bytes32 txRef, uint256 timestamp)";
 
@@ -39,18 +36,11 @@ const adapter: SimpleAdapter = {
   adapter: {
     [CHAIN.BSC]: {
       fetch,
-      start: START_TIMESTAMP,
-      meta: {
-        methodology: {
-          Volume:
-            "Volume is tracked via VolumeRegistered events emitted by the ChimpXVolumeRegistry contract on BNB Chain. The ChimpX backend relayer records USD volume (18 decimals) on-chain after each verified transaction. Covers swaps, bridges, lending, borrowing, staking, unstaking, and perpetuals (long/short) routed through the ChimpX AI-powered DeFi agent.",
-        },
-      },
+      start: '2026-02-19',
     },
   },
   methodology: {
-    Volume:
-      "Volume is tracked via VolumeRegistered events emitted by the ChimpXVolumeRegistry contract on BNB Chain. The ChimpX backend relayer records USD volume (18 decimals) on-chain after each verified transaction. Covers swaps, bridges, lending, borrowing, staking, unstaking, and perpetuals (long/short) routed through the ChimpX AI-powered DeFi agent.",
+    Volume: "Volume is tracked via VolumeRegistered events emitted by the ChimpXVolumeRegistry contract on BNB Chain. The ChimpX backend relayer records USD volume (18 decimals) on-chain after each verified transaction. Covers swaps, bridges, lending, borrowing, staking, unstaking, and perpetuals (long/short) routed through the ChimpX AI-powered DeFi agent.",
   },
 };
 


### PR DESCRIPTION
## Summary

- Adds volume adapter for **ChimpX** — an AI-powered DeFi SuperApp on BNB Chain
- Tracks daily USD volume via `VolumeRegistered` events from the on-chain `ChimpXVolumeRegistry` contract
- Contract: [`0x8327839597934e1490f90D06F2b0A549dFC7edeB`](https://bscscan.com/address/0x8327839597934e1490f90D06F2b0A549dFC7edeB) on BSC mainnet (deployed block 82131810)

## Volume Coverage

Covers all user actions routed through the ChimpX AI agent:
- Swaps (action type 0)
- Bridges (action type 1)
- Lending (action type 2)
- Borrowing (action type 3)
- Staking / Unstaking (action types 4, 5)
- Perpetuals Long / Short (action types 6, 7)

## Methodology

The backend relayer calls `registerVolume()` on the registry contract after each successful transaction, emitting a `VolumeRegistered` event with the USD value (18 decimals). The adapter sums all events within the queried time window to produce `dailyVolume`.

## Test Output

```
BSC 👇
Daily volume: 2.67 k
```

## Links

- Website: https://chimpx.ai
- Contract: https://bscscan.com/address/0x8327839597934e1490f90D06F2b0A549dFC7edeB

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added volume tracking for ChimpX on Binance Smart Chain, reporting normalized daily USD volumes derived from on-chain VolumeRegistered events.
  * Normalizes on-chain values (18-decimal units) to USD and aggregates into daily totals.
  * Documentation updated with a methodology describing event-based volume tracking covering swaps, bridges, lending/borrowing, staking/unstaking, and perpetuals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->