### PR TITLE
Remove Paradex from treadfi-perps

### DIFF
--- a/dexs/treadfi-perps.ts
+++ b/dexs/treadfi-perps.ts
@@ -87,6 +87,9 @@ const fetchParadex = async (_a: any, _b: any, options: FetchOptions) => {
 
   return {
     dailyVolume,
+    dailyFees: 0,
+    dailyRevenue: 0,
+    dailyProtocolRevenue: 0,
   };
 };
 


### PR DESCRIPTION
Removes Paradex chain entry and fetch function from treadfi-perps adapter. Paradex generates no revenue for Tread.fi.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Paradex now reports only daily volume; daily fees, daily revenue, and protocol revenue are no longer returned.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->