### PR TITLE
dexs(sai-perps): add volume and fee adapter for Sai perps app

### DIFF
--- a/helpers/getBlock.ts
+++ b/helpers/getBlock.ts
@@ -1,8 +1,8 @@
 import { Chain, ChainBlocks } from "../adapters/types";
 import { CHAIN } from "./chains";
-import * as sdk from "@defillama/sdk";
+import * as sdk from "@defillama/sdk"
 import { httpGet, httpPost } from "../utils/fetchURL";
-const retry = require("async-retry");
+const retry = require("async-retry")
 
 const blacklistedChains: string[] = [
   "juno",
@@ -43,7 +43,6 @@ const blacklistedChains: string[] = [
   "persistence",
   "sui",
   "neutron",
-  "nibiru",
   "terra2",
   "move",
   "heco",
@@ -53,97 +52,82 @@ const blacklistedChains: string[] = [
   CHAIN.ICP,
 ];
 
-const cache = {} as any;
+const cache = {
 
-async function getBlock(
-  timestamp: number,
-  chain: Chain,
-  chainBlocks = {} as ChainBlocks,
-) {
+} as any
+
+async function getBlock(timestamp: number, chain: Chain, chainBlocks = {} as ChainBlocks) {
   try {
-    if (!cache[chain]) cache[chain] = {};
-    if (!cache[chain][timestamp])
-      cache[chain][timestamp] = _getBlock(timestamp, chain, {});
-    const block = await cache[chain][timestamp];
-    if (block) chainBlocks[chain] = block;
-    return block;
+    if (!cache[chain]) cache[chain] = {}
+    if (!cache[chain][timestamp]) cache[chain][timestamp] = _getBlock(timestamp, chain, {})
+    const block = await cache[chain][timestamp]
+    if (block) chainBlocks[chain] = block
+    return block
   } catch (e) {
-    console.log("error fetching block" + chain + " " + (e as any)?.message);
-    return null;
+    console.log('error fetching block' + chain + ' ' + (e as any)?.message)
+    return null
   }
 }
 
-async function _getBlock(
-  timestamp: number,
-  chain: Chain,
-  chainBlocks = {} as ChainBlocks,
-) {
+async function _getBlock(timestamp: number, chain: Chain, chainBlocks = {} as ChainBlocks) {
   if (blacklistedChains.includes(chain)) {
-    return null;
+    return null
   }
-  if (chainBlocks[chain] !== undefined) return chainBlocks[chain];
+  if (chainBlocks[chain] !== undefined)
+    return chainBlocks[chain]
 
-  let block: number | undefined;
+  let block: number | undefined
   try {
-    if (chain === CHAIN.WAVES) timestamp = Math.floor(timestamp * 1000);
+    if (chain === CHAIN.WAVES)
+      timestamp = Math.floor(timestamp * 1000)
 
-    if (chain === CHAIN.TON) block = await getTonBlock(timestamp);
-    else block = await sdk.blocks.getBlockNumber(chain, timestamp);
+    if (chain === CHAIN.TON)
+      block = await getTonBlock(timestamp)
+    else
+      block = await sdk.blocks.getBlockNumber(chain, timestamp)
   } catch (e) {
-    console.log("error fetching block", e);
+    console.log('error fetching block', e)
   }
 
   if (block) {
-    chainBlocks[chain] = block;
-    return block;
+    chainBlocks[chain] = block
+    return block
   }
 
-  block = Number(
-    await retry(
-      async () =>
-        (
-          await httpGet(`https://coins.llama.fi/block/${chain}/${timestamp}`, {
-            timeout: 10000,
-          }).catch((e) => {
-            throw new Error(
-              `Error getting block: ${chain} ${timestamp} ${e.message}`,
-            );
-          })
-        )?.height,
-      { retries: 1 },
-    ),
-  );
+  block = Number((await retry(async () => (await httpGet(`https://coins.llama.fi/block/${chain}/${timestamp}`, { timeout: 10000 }).catch((e) => {
+    throw new Error(`Error getting block: ${chain} ${timestamp} ${e.message}`)
+  }))?.height, { retries: 1 })));
 
-  if (block) chainBlocks[chain] = block;
-  return block;
+  if (block) chainBlocks[chain] = block
+  return block
   // https://base.blockscout.com
   // https://explorer.kava.io
   //return sdk.api.util.lookupBlock(timestamp, { chain }).then(blockData => blockData.block)
+
 }
 
 async function getTonBlock(unixTS: number) {
-  const data = await httpGet(
-    `https://toncenter.com/api/v2/lookupBlock?workchain=-1&shard=-1&unixtime=${unixTS}`,
-  );
-  return data.result.seqno;
+  const data = await httpGet(`https://toncenter.com/api/v2/lookupBlock?workchain=-1&shard=-1&unixtime=${unixTS}`)
+  return data.result.seqno
 }
 
 async function getBlocks(chain: Chain, timestamps: number[]) {
-  return Promise.all(timestamps.map((t) => getBlock(t, chain, {})));
+  return Promise.all(timestamps.map(t => getBlock(t, chain, {})))
 }
 
-const canGetBlock = (chain: string) =>
-  Object.keys(sdk.api2.config.providers).includes(chain);
+const canGetBlock = (chain: string) => Object.keys(sdk.api2.config.providers).includes(chain)
 
 async function getHydrationBlock(unixTs: number) {
-  const data = await httpPost(
-    "https://hydration.api.subscan.io/api/scan/block",
-    {
-      block_timestamp: unixTs,
-      only_head: true,
-    },
-  );
-  return data.data.block_num;
+  const data = await httpPost('https://hydration.api.subscan.io/api/scan/block', {
+    "block_timestamp": unixTs,
+    "only_head": true
+  })
+  return data.data.block_num
 }
 
-export { getBlock, canGetBlock, getBlocks, getHydrationBlock };
+export {
+  getBlock,
+  canGetBlock,
+  getBlocks,
+  getHydrationBlock,
+}


### PR DESCRIPTION
## Purpose

Adds volume and fee revenue details for Sai:
https://defillama.com/protocol/sai

<!-- #### Please enable "Allow edits by maintainers" while putting up the PR. -->

## Methodology

```bash
pnpm test dexs sai-perps 2026-02-21
```

- **New adapter**: `dexs/sai-perps/index.ts` — Adapter v2, single fetch from https://sai-api.nibiru.fi/dexpal/v1/stats, which supports `?date=YYYY-MM-DD` historical fills.
- **Historical backfill**: Uses `?date=${options.dateString}` so the framework can request past days (e.g. backfill from 2026-01-01)
- **Metrics**: `dailyVolume` (trading_volume_24h), `dailyFees` (accrued_trading_fees_24h)
- **Chain config**: Added `nibiru` to `blacklistedChains` in `helpers/getBlock.ts` so the adapter skips block lookup and relies on the REST API’s date-based queries


---

- Closes https://github.com/NibiruChain/sai-website/issues/383


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Sai‑NIBIRU perpetuals: daily trading volume, accumulated fees, and end‑of‑day open interest are now tracked and available (start date: 2026-01-01).

* **Chores**
  * Updated block lookup handling to exclude the NIBIRU chain, improving resilience of block retrieval.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->