### PR TITLE
fix clober-v2 volume and fees missing after #5957

### DIFF
--- a/dexs/clober-v2/index.ts
+++ b/dexs/clober-v2/index.ts
@@ -82,16 +82,16 @@ const fetch: FetchV2 = async ({ getLogs, createBalances, chain, api }: FetchOpti
     if (!target || !bookId) continue
     const book = booksByKey.get(`${target}-${bookId}`)
     if (!book) continue
-    const quoteAmount = Number(event.args.unit) * Number(book.unitSize)
+    const quoteAmount = BigInt(event.args.unit) * BigInt(book.unitSize)
     dailyVolume.add(book.quote, quoteAmount)
     const { bps, usesQuote } = parseFeeInfo(BigInt(book.takerPolicy))
     if (usesQuote) {
-      dailyFees.add(book.quote, (quoteAmount * bps) / 10000)
+      dailyFees.add(book.quote, (quoteAmount * BigInt(bps)) / 10000n)
     }
   }
 
-  swapEvents.forEach((i) => dailyVolume.add(i.outToken, Number(i.amountOut)))
-  feeCollectedEvents.forEach((i) => dailyFees.add(i.token, Number(i.amount)))
+  for (const i of swapEvents) { dailyVolume.add(i.outToken, Number(i.amountOut)) }
+  for (const i of feeCollectedEvents) { dailyFees.add(i.token, Number(i.amount)) }
 
   return { dailyVolume, dailyFees, dailyRevenue: dailyFees, dailyProtocolRevenue: dailyFees, dailyHoldersRevenue: '0' }
 }


### PR DESCRIPTION
## Summary
- closes #5981
- removes aggressive throw statements that crashed the adapter on any unexpected event
- removes the unguarded fallback `api.call` that caused the full adapter to fail when a single book lookup failed
- replaces `withMetadata: true` multicall (non-standard in this repo) with `permitFailure: true` — individual call failures return null instead of crashing the batch
- keeps the composite `contract-bookId` key from #5957 which correctly handles the BASE dual-contract collision from #5956
- skips unresolvable events with `continue` instead of throwing — standard pattern in this repo

## Root cause
The fallback `api.call` added in #5957 had no `permitFailure`, so any single failed book lookup threw an unhandled exception that wiped all data for that date on the backend

## Validation
- `npm test -- dexs clober-v2 2026-02-24` — base 1.26M, monad 1.37M
- `npm test -- dexs clober-v2 2026-02-20` — base 1.43M, monad 1.22M
- `npm test -- dexs clober-v2 2024-12-01` — base 128 (historical)
- `npm test -- fees clober-v2 2026-02-20` — matches dexs output

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for multiple contract addresses per chain and a unified fetch entrypoint for global data retrieval.

* **Bug Fixes**
  * Improved deduplication of events to avoid duplicates.
  * More accurate daily volume, fee and revenue calculations with better handling of missing data.

* **Refactor**
  * Faster, batched metadata retrieval and streamlined event processing for improved performance and reliability.
* **Other**
  * Conditional handling of swap and fee events when gateway routing is present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->