### PR TITLE
Add SundaeSwap fee adapter

### DIFF
--- a/fees/sundaeswap/index.ts
+++ b/fees/sundaeswap/index.ts
@@ -49,7 +49,6 @@ const fetch = async (options: FetchOptions): Promise<FetchResult> => {
         popular {
           ticks(start: $start, end: $end, interval: All) {
             rich {
-              txFees { quantity asset { id } }
               protocolFees { quantity asset { id } }
               lpFees(unit: Natural) { quantity asset { id } }
             }


### PR DESCRIPTION
This PR adds the fee and revenue adapter for [SundaeSwap](https://defillama.com/protocol/sundaeswap). 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * SundaeSwap fee and revenue tracking integration for Cardano.
  * Provides daily-aggregated metrics: total fees, protocol revenue, and supply-side revenue.
  * Supports ADA and token fee attribution and returns historical time-series starting from the integration's configured start date.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->