### PR TITLE
Add SundaeSwap fee adapter

### DIFF
--- a/dexs/sundaeswap/index.ts
+++ b/dexs/sundaeswap/index.ts
@@ -1,7 +1,6 @@
 import fetchURL from "../../utils/fetchURL";
-import { FetchOptions, FetchResult, FetchResultV2, FetchResultVolume, SimpleAdapter } from "../../adapters/types";
+import { FetchOptions, FetchResult, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
-import { getTimestampAtStartOfDayUTC } from "../../utils/date";
 
 const historicalVolumeEndpoint = "https://stats.sundaeswap.finance/api/defillama/v0/global-stats/2100"
 
@@ -10,32 +9,22 @@ interface IVolumeall {
   day: string;
 }
 
-const fetch = async (_,_a:any,{ createBalances, startOfDay }: FetchOptions): Promise<FetchResult> => {
-  const dailyVolume = createBalances()
-  const dayTimestamp = getTimestampAtStartOfDayUTC(startOfDay);
-  const dateStr = new Date(dayTimestamp * 1000).toISOString().split('T')[0];
+const fetch = async (_a: any, _b: any, options: FetchOptions): Promise<FetchResult> => {
+  const dailyVolume = options.createBalances()
+  const dateStr = new Date(options.startOfDay * 1000).toISOString().split('T')[0];
   const historicalVolume: IVolumeall[] = (await fetchURL(historicalVolumeEndpoint)).response;
   const volume = historicalVolume.find(dayItem => dayItem.day === dateStr)?.volumeLovelace as any
-  if (!volume) {
-    return {
-      timestamp: dayTimestamp,
-    }
-  }
+  if (!volume) return { dailyVolume };
   dailyVolume.addGasToken(volume)
-  return {
-    timestamp: dayTimestamp,
-    dailyVolume,
-  };
+
+  return { dailyVolume };
 };
 
 const adapter: SimpleAdapter = {
   version: 1,
-  adapter: {
-    [CHAIN.CARDANO]: {
-      fetch,
-      start: '2022-02-01',
-    },
-  },
+  chains: [CHAIN.CARDANO],
+  fetch,
+  start: '2022-02-01',
 };
 
 export default adapter;

--- a/fees/sundaeswap/index.ts
+++ b/fees/sundaeswap/index.ts
@@ -1,49 +1,44 @@
 import { request } from "graphql-request";
 import { Adapter, FetchOptions, FetchResult } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
+import { METRIC } from "../../helpers/metrics";
 
 const ADA_ID = "ada.lovelace";
 const endpoint = "https://api.sundae.fi/graphql";
 
 const formatDate = (ts: number) => {
-    const d = new Date(ts * 1000);
-    return `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, "0")}-${String(
-        d.getUTCDate()
-    ).padStart(2, "0")} ${String(d.getUTCHours()).padStart(2, "0")}:${String(
-        d.getUTCMinutes()
-    ).padStart(2, "0")}:${String(d.getUTCSeconds()).padStart(2, "0")}`;
+  return new Date(ts * 1000).toISOString().replace('T', ' ').substring(0, 19);
 };
 
 const formatAsset = (assetId: string) => {
-    const [policy, name] = assetId.split(".");
-    return name ? policy + name : assetId;
+  const [policy, name] = assetId.split(".");
+  return name ? policy + name : assetId;
 };
 
 const addFee = (
-    balanceObj: any,
-    assetId: string,
-    quantity: string,
+  balanceObj: any,
+  assetId: string,
+  quantity: string,
 ) => {
-    if (!assetId) return;
+  if (!assetId) return;
 
-    if (assetId === ADA_ID) {
-        const amount = Number(quantity) / 1e6;
-        balanceObj.addCGToken("cardano", amount);
-    } else {
-        balanceObj.addToken(formatAsset(assetId), Number(quantity));
-    }
+  if (assetId === ADA_ID) {
+    const amount = Number(quantity) / 1e6;
+    balanceObj.addCGToken("cardano", amount);
+  } else {
+    balanceObj.addToken(formatAsset(assetId), Number(quantity));
+  }
 };
 
 const fetch = async (options: FetchOptions): Promise<FetchResult> => {
-    const dailyFees = options.createBalances();
-    const dailyRevenue = options.createBalances();
-    const dailySupplySideRevenue = options.createBalances();
-    const dailyProtocolRevenue = options.createBalances();
+  const dailyFees = options.createBalances();
+  const dailyRevenue = options.createBalances();
+  const dailySupplySideRevenue = options.createBalances();
 
-    const start = formatDate(options.startTimestamp);
-    const end = formatDate(options.endTimestamp);
+  const start = formatDate(options.startTimestamp);
+  const end = formatDate(options.endTimestamp);
 
-    const query = `
+  const query = `
     query fetchPools($start: String!, $end: String!) {
       pools {
         popular {
@@ -58,46 +53,57 @@ const fetch = async (options: FetchOptions): Promise<FetchResult> => {
     }
   `;
 
-    const data = await request(endpoint, query, { start, end });
-    const pools = data?.pools?.popular ?? [];
+  const data = await request(endpoint, query, { start, end });
+  const pools = data?.pools?.popular ?? [];
 
-    for (const pool of pools) {
-        const richEntries = pool?.ticks?.rich ?? [];
+  for (const pool of pools) {
+    const richEntries = pool?.ticks?.rich ?? [];
 
-        for (const entry of richEntries) {
-            const { lpFees, protocolFees } = entry;
+    for (const entry of richEntries) {
+      const { lpFees, protocolFees } = entry;
 
-            if (lpFees?.asset?.id) {
-                addFee(dailyFees, lpFees.asset.id, lpFees.quantity);
-                addFee(dailySupplySideRevenue, lpFees.asset.id, lpFees.quantity);
-            }
+      if (lpFees?.asset?.id) {
+        addFee(dailySupplySideRevenue, lpFees.asset.id, lpFees.quantity);
+      }
 
-            if (protocolFees?.asset?.id) {
-                addFee(dailyFees, protocolFees.asset.id, protocolFees.quantity);
-                addFee(dailyRevenue, protocolFees.asset.id, protocolFees.quantity);
-                addFee(dailyProtocolRevenue, protocolFees.asset.id, protocolFees.quantity);
-            }
-        }
+      if (protocolFees?.asset?.id) {
+        addFee(dailyRevenue, protocolFees.asset.id, protocolFees.quantity);
+      }
     }
+  }
 
-    return { dailyFees, dailyRevenue, dailySupplySideRevenue, dailyProtocolRevenue };
+  dailyFees.addBalances(dailySupplySideRevenue, METRIC.LP_FEES);
+  dailyFees.addBalances(dailyRevenue, METRIC.PROTOCOL_FEES);
+
+  return {
+    dailyFees,
+    dailyRevenue,
+    dailySupplySideRevenue,
+    dailyProtocolRevenue: dailyRevenue
+  };
+};
+
+const methodology = {
+  Fees: "The total trading fees paid by users, excluding L1 transaction fees",
+  Revenue: "A fixed ADA cost per transaction that is collected by the protocol",
+  SupplySideRevenue: "A percentage cut on all trading volume, paid to Liquidity Providers",
+  ProtocolRevenue: "A fixed ADA cost per transaction that is collected by the protocol",
+};
+
+const breakdownMethodology = {
+  Fees: {
+    [METRIC.LP_FEES]: "A percentage cut on all trading volume, paid to Liquidity Providers",
+    [METRIC.PROTOCOL_FEES]: "A fixed ADA cost per transaction that is collected by the protocol"
+  }
 };
 
 const adapter: Adapter = {
-    version: 2,
-    adapter: {
-        [CHAIN.CARDANO]: {
-            fetch,
-            start: "2022-01-20",
-        },
-    },
-    allowNegativeValue: false,
-    methodology: {
-        Fees: "The total trading fees paid by users, excluding L1 transaction fees",
-        Revenue: "A fixed ADA cost per transaction that is collected by the protocol",
-        SupplySideRevenue: "A percentage cut on all trading volume, paid to Liquidity Providers",
-        ProtocolRevenue: "A fixed ADA cost per transaction that is collected by the protocol",
-    },
+  version: 2,
+  chains: [CHAIN.CARDANO],
+  fetch,
+  start: "2022-01-20",
+  methodology,
+  breakdownMethodology,
 };
 
 export default adapter;


### PR DESCRIPTION
This PR adds the fee and revenue adapter for [SundaeSwap](https://defillama.com/protocol/sundaeswap). 

Methodology:
Fees: The total trading fees paid by users, excluding L1 transaction fees
Revenue: A fixed ADA cost per transaction that is collected by the protocol
SupplySideRevenue: A percentage cut on all trading volume, paid to Liquidity Providers
ProtocolRevenue: A fixed ADA cost per transaction that is collected by the protocol

Chain:
Cardano
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added SundaeSwap fee metrics for Cardano: daily fees, revenue, supply-side revenue, and protocol revenue (historical from 2022-01-20).

* **Enhancements**
  * Simplified SundaeSwap DEX adapter to a single-chain setup.
  * Standardized daily volume reporting to always return a consistent dailyVolume payload.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->