### PR TITLE
update aquifer data parsing to proper dune table, it was very under-represented before 

### DIFF
--- a/dexs/aquifer/index.ts
+++ b/dexs/aquifer/index.ts
@@ -5,27 +5,27 @@ import { CHAIN } from "../../helpers/chains"
 import { queryDuneSql } from "../../helpers/dune"
 
 const fetch = async (_a: any, _b: any, options: FetchOptions) => {
-  const query = `
+    const query = `
     select
-      sum(amount_usd) as daily_volume
+      coalesce(sum(amount_usd), 0) as daily_volume
     from dex_solana.trades
     where TIME_RANGE
       and project = 'aquifer'
   `
-  const data = await queryDuneSql(options, query)
+    const data = await queryDuneSql(options, query)
 
-  return {
-    dailyVolume: Number(data?.[0]?.daily_volume) || 0,
-  }
+    return {
+        dailyVolume: data[0].daily_volume,
+    }
 }
 
 const adapter: SimpleAdapter = {
-  version: 1,
-  fetch,
-  chains: [CHAIN.SOLANA],
-  dependencies: [Dependencies.DUNE],
-  isExpensiveAdapter: true,
-  start: '2025-09-07',
+    version: 1,
+    fetch,
+    chains: [CHAIN.SOLANA],
+    dependencies: [Dependencies.DUNE],
+    isExpensiveAdapter: true,
+    start: '2025-09-07',
 }
 
 export default adapter


### PR DESCRIPTION
THIS PR is just an UPDATE to the current simple adapter that already exists
it just updates the Dune query to use a correctly parsed table
The account structure needed to be parsed properly and Dune has done it
Before it was under-representing volume by quite a lot because the query was too simple for the account structure

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified Aquifer DEX data aggregation to compute daily trade totals using direct trade sources instead of the previous per-account transfer approach.
  * Ensured missing data yields a zero default, improving reliability of displayed totals.
  * No changes to public interfaces or visible behavior; result formatting and outputs remain consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->