### PR TITLE
Add PumpSpace DEX volume/fees adapter (Avalanche) — V2 + Trident V3

### DIFF
--- a/dexs/pumpspace/index.ts
+++ b/dexs/pumpspace/index.ts
@@ -2,39 +2,24 @@ import { FetchOptions, FetchV2, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 import { getUniV2LogAdapter } from "../../helpers/uniswap";
 import { isCoreAsset } from "../../helpers/prices";
+import { Interface } from "ethers";
 
 /**
- * PumpSpace V2 DEX Adapter (Uniswap V2 fork)
+ * PumpSpace DEX Adapter (Avalanche)
+ * - V2: Uniswap V2 fork (factory Pair Swap logs)
+ * - V3: Trident concentrated liquidity (PoolLogger Swap logs)
  *
- * Factory: 0x26B42c208D8a9d8737A2E5c9C57F4481484d4616
- *
- * Fee model:
- * - Total swap fee: 0.5% (0.005)
- * - 50% of fee (0.25% = 0.0025) sent to feeTo (protocol treasury)
- * - 50% of fee (0.25% = 0.0025) to LPs as supply-side rewards
- *
- * Reference (from contract):
- * function calculateFee(uint256 amount, address swapFeeTo) internal view returns (uint256) {
- *     uint256 swapFeeRate = IDexFactory(factory).swapFeeRate(); // 2
- *     if (swapFeeTo != address(0)) {
- *         uint256 feeAmount = (amount * 5) / 1000;  // 0.5%
- *         uint256 feeToReceive = feeAmount / swapFeeRate;  // /2 = 0.25%
- *         return feeToReceive;
- *     }
- * }
+ * Notes:
+ * - DefiLlama counts DEX volume on ONE side of a swap (to avoid double counting).
+ * - For V3 fees, fee is charged on amountIn (input token).
  */
+
+// --------------------
+// Addresses
+// --------------------
 const V2_FACTORY = "0x26B42c208D8a9d8737A2E5c9C57F4481484d4616";
 
-/**
- * PumpSpace V3 (Trident concentrated liquidity)
- *
- * MiningPoolFactory (mainnet): 0xE749c1cA2EA4f930d1283ad780AdE28625037CeD
- * PoolLogger (mainnet):        0x77c8dfFE4130FE58e5C3c02a2E7ab6DB7f4F474f
- *
- * Protocol fee split:
- * - defaultProtocolFee() = 2000 (bps) -> 20% of fees to protocol
- * - remaining 80% to LPs
- */
+// PumpSpace Trident V3 mainnet (Avalanche)
 const V3_POOL_FACTORY = "0xE749c1cA2EA4f930d1283ad780AdE28625037CeD";
 const V3_POOL_LOGGER = "0x77c8dfFE4130FE58e5C3c02a2E7ab6DB7f4F474f";
 
@@ -43,15 +28,83 @@ const V3_SWAP_EVENT =
   "event Swap(address indexed pool, bool zeroForOne, uint256 amountIn, uint256 amountOut)";
 
 // --------------------
+// Stable-like wrapped tokens (PumpSpace)
+// (Workaround for missing pricing: map to underlying well-priced stables)
+// --------------------
+// const bUSDt = "0x3C594084dC7AB1864AC69DFd01AB77E8f65B83B7";
+const bUSDC = "0x038Dbe3D967bB8389190446DACdfE7B95b44F73D";
+const bAUSD = "0xd211b17Dfe8288D4Fb0dd8EEFF07A6C48fC679D5";
+
+// Underlying stables (Avalanche) - used ONLY for pricing fallback in this adapter
+// If your underlying AUSD differs, replace AVAX_AUSD with the correct token address.
+// const AVAX_USDT = "0x9702230A8Ea53601f5cD2dc00fDBc13d4dF4A8c7";
+const AVAX_USDC = "0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6E";
+const AVAX_AUSD = "0x00000000eFE302BEAA2b3e6e1b18d08D69a9012a";
+
+const STABLE_UNDERLYING_MAP: Record<string, string> = {
+  // [bUSDt.toLowerCase()]: AVAX_USDT,
+  [bUSDC.toLowerCase()]: AVAX_USDC,
+  [bAUSD.toLowerCase()]: AVAX_AUSD,
+};
+
+const isStableLike = (token: string) =>
+  STABLE_UNDERLYING_MAP[token.toLowerCase()] !== undefined;
+
+const unwrapCallResult = (r: any) => {
+  if (r === null || r === undefined) return null;
+  if (typeof r === "object" && "output" in r) return (r as any).output;
+  return r;
+};
+
+const toBigInt = (v: any): bigint => {
+  if (v === null || v === undefined) return 0n;
+  if (typeof v === "bigint") return v;
+  if (typeof v === "number") return BigInt(v);
+  if (typeof v === "string") return BigInt(v);
+  return BigInt(v.toString());
+};
+
+const pow10 = (exp: number): bigint => 10n ** BigInt(exp);
+
+const scaleAmount = (amount: bigint, fromDecimals: number, toDecimals: number): bigint => {
+  if (amount === 0n) return 0n;
+  if (fromDecimals === toDecimals) return amount;
+  if (fromDecimals > toDecimals) return amount / pow10(fromDecimals - toDecimals);
+  return amount * pow10(toDecimals - fromDecimals);
+};
+
+const addWithStableMapping = (
+  balances: any,
+  token: string,
+  amount: bigint,
+  decimalsMap: Map<string, number>
+) => {
+  if (!token || amount <= 0n) return;
+
+  const key = token.toLowerCase();
+  const mapped = STABLE_UNDERLYING_MAP[key];
+  if (!mapped) {
+    balances.add(token, amount);
+    return;
+  }
+
+  const fromDec = decimalsMap.get(key) ?? 18;
+  const toDec = decimalsMap.get(mapped.toLowerCase()) ?? 18;
+  const adjAmount = scaleAmount(amount, fromDec, toDec);
+
+  if (adjAmount > 0n) balances.add(mapped, adjAmount);
+};
+
+// --------------------
 // V2 fetch (as-is)
 // --------------------
 const fetchV2 = getUniV2LogAdapter({
   factory: V2_FACTORY,
   fees: 0.005, // total user fees = 0.5%
-  userFeesRatio: 1, // 100% of 0.5% is paid by user
+  userFeesRatio: 1,
   revenueRatio: 0.5, // 50% of total fees go to protocol (0.25% of volume)
-  protocolRevenueRatio: 0.5, // 50% of total fees go to protocol treasury
-  supplySideRevenueRatio: 0.5, // 50% of total fees go to LPs
+  protocolRevenueRatio: 0.5,
+  supplySideRevenueRatio: 0.5,
 });
 
 // --------------------
@@ -64,9 +117,9 @@ const fetchV3: FetchV2 = async (options: FetchOptions) => {
   const dailyFees = createBalances();
   const dailyProtocolRevenue = createBalances();
   const dailySupplySideRevenue = createBalances();
-  const dailyHoldersRevenue = createBalances(); // not used
+  const dailyHoldersRevenue = createBalances(); // none
 
-  // Pull protocol fee split (bps). Confirmed on-chain: defaultProtocolFee() == 2000 (20%)
+  // defaultProtocolFee() = 2000 bps -> 20% of fees to protocol, 80% to LPs
   let protocolFeeBps = 2000n;
   try {
     const v = await api.call({
@@ -74,8 +127,12 @@ const fetchV3: FetchV2 = async (options: FetchOptions) => {
       abi: "function defaultProtocolFee() view returns (uint256)",
     });
     protocolFeeBps = BigInt(v.toString());
-  } catch {
-    // fallback to 2000 bps
+  } catch (e) {
+    // keep fallback (2000 bps)
+    console.warn(
+      `[pumpspace/v3] failed to read defaultProtocolFee() from ${V3_POOL_FACTORY}, using fallback 2000 bps`,
+      e
+    );
   }
 
   // 10,000 bps = 100%
@@ -84,11 +141,26 @@ const fetchV3: FetchV2 = async (options: FetchOptions) => {
   // swapFee() is in "pips": 1000 = 0.1% => 1,000,000 = 100%
   const SWAP_FEE_DENOMINATOR = 1_000_000n;
 
-  // Load swap logs from PoolLogger for the requested time window
-  const logs: any[] = await getLogs({
-    target: V3_POOL_LOGGER,
-    eventAbi: V3_SWAP_EVENT,
-  });
+  const fromBlock = await options.getStartBlock();
+  const toBlock = await options.getEndBlock();
+
+  const iface = new Interface([V3_SWAP_EVENT]);
+
+  const loadLogs = async (skipIndexer?: boolean) =>
+    getLogs({
+      target: V3_POOL_LOGGER,
+      eventAbi: V3_SWAP_EVENT,
+      fromBlock,
+      toBlock,
+      entireLog: true,
+      cacheInCloud: true,
+      ...(skipIndexer ? { skipIndexer: true } : {}),
+    });
+
+  // 1) Try default (may use indexer/cache)
+  // 2) If empty, fallback to direct RPC mode
+  let logs: any[] = await loadLogs(false);
+  if (!logs.length) logs = await loadLogs(true);
 
   if (!logs.length) {
     return {
@@ -102,13 +174,94 @@ const fetchV3: FetchV2 = async (options: FetchOptions) => {
     };
   }
 
-  // Unique pool list from logs
-  const pools = [...new Set(logs.map((l) => (l.pool as string).toLowerCase()))];
+  // Pre-fetch decimals for stable-like tokens (source + underlying)
+  const stableTokenList = Array.from(
+    new Set([
+      ...Object.keys(STABLE_UNDERLYING_MAP),
+      ...Object.values(STABLE_UNDERLYING_MAP).map((t) => t.toLowerCase()),
+    ])
+  );
+  const decimalsMap = new Map<string, number>();
+  try {
+    const decRes = await api.multiCall({
+      abi: "uint8:decimals",
+      calls: stableTokenList,
+      permitFailure: true,
+    });
+    for (let i = 0; i < stableTokenList.length; i++) {
+      const d = unwrapCallResult(decRes[i]);
+      if (d === null || d === undefined) continue;
+      const n = Number(d.toString());
+      if (!Number.isNaN(n)) decimalsMap.set(stableTokenList[i].toLowerCase(), n);
+    }
+  } catch (e) {
+    // non-fatal; we'll default to 18 if missing
+    console.warn("[pumpspace/v3] decimals multicall failed (non-fatal)", e);
+  }
 
-  // Read pool metadata directly from the pool (IConcentratedLiquidityPool)
+  // Parse logs & collect pools
+  type Swap = {
+    pool: string;
+    zeroForOne: boolean;
+    amountIn: bigint;
+    amountOut: bigint;
+  };
+
+  const swaps: Swap[] = [];
+  const poolSet = new Set<string>();
+
+  for (const l of logs) {
+    // If getLogs already returns parsed args, l might contain fields directly.
+    // If it returns raw logs, parseLog will decode pool as address.
+    const args: any = iface.parseLog(l)?.args ?? l?.args ?? l;
+    if (!args) continue;
+
+    const poolRaw = args.pool ?? args[0] ?? l.pool;
+    if (!poolRaw) continue;
+
+    // pool may appear as bytes32 topic-like string in some environments → normalize to address
+    const poolStr = poolRaw.toString();
+    const pool =
+      poolStr.length === 42
+        ? poolStr
+        : poolStr.length === 66
+          ? ("0x" + poolStr.slice(26))
+          : null;
+    if (!pool) continue;
+
+    const zeroForOne = Boolean(args.zeroForOne ?? args[1]);
+    const amountIn = toBigInt(args.amountIn ?? args[2]);
+    const amountOut = toBigInt(args.amountOut ?? args[3]);
+
+    swaps.push({ pool, zeroForOne, amountIn, amountOut });
+    poolSet.add(pool.toLowerCase());
+  }
+
+  const pools = [...poolSet];
+  if (!pools.length) {
+    return {
+      dailyVolume,
+      dailyFees,
+      dailyUserFees: dailyFees.clone(1),
+      dailyRevenue: dailyProtocolRevenue.clone(1),
+      dailyProtocolRevenue,
+      dailySupplySideRevenue,
+      dailyHoldersRevenue,
+    };
+  }
+
+  // Read pool metadata (IConcentratedLiquidityPool)
   const [token0s, token1s, swapFees] = await Promise.all([
-    api.multiCall({ abi: "address:token0", calls: pools, permitFailure: true }),
-    api.multiCall({ abi: "address:token1", calls: pools, permitFailure: true }),
+    api.multiCall({
+      abi: "address:token0",
+      calls: pools,
+      permitFailure: true,
+    }),
+    api.multiCall({
+      abi: "address:token1",
+      calls: pools,
+      permitFailure: true,
+    }),
     api.multiCall({
       abi: "function swapFee() view returns (uint24)",
       calls: pools,
@@ -116,82 +269,80 @@ const fetchV3: FetchV2 = async (options: FetchOptions) => {
     }),
   ]);
 
-  const meta = new Map<
-    string,
-    { token0: string; token1: string; feePips: bigint }
-  >();
-
+  const meta = new Map<string, { token0: string; token1: string; feePips: bigint }>();
   for (let i = 0; i < pools.length; i++) {
-    const token0 = token0s[i];
-    const token1 = token1s[i];
-    const fee = swapFees[i];
+    const token0 = unwrapCallResult(token0s[i]);
+    const token1 = unwrapCallResult(token1s[i]);
+    const fee = unwrapCallResult(swapFees[i]);
 
-    // token0/token1 must exist to count volume
     if (!token0 || !token1) continue;
 
-    // swapFee might fail; if so, treat as 0 (volume ok, fees skipped)
-    const feePips =
-      fee === null || fee === undefined ? 0n : BigInt(fee.toString());
-
-    meta.set(pools[i], {
-      token0,
-      token1,
-      feePips,
-    });
+    const feePips = fee === null || fee === undefined ? 0n : BigInt(fee.toString());
+    meta.set(pools[i], { token0, token1, feePips });
   }
 
-  // Aggregate balances from logs
-  for (const log of logs) {
-    const pool = (log.pool as string).toLowerCase();
-    const m = meta.get(pool);
+  // Aggregate balances
+  for (const s of swaps) {
+    const m = meta.get(s.pool.toLowerCase());
     if (!m) continue;
 
-    const amountIn = BigInt(log.amountIn.toString());
-    const amountOut = BigInt(log.amountOut.toString());
-    const zeroForOne = Boolean(log.zeroForOne);
+    // tokenIn/tokenOut by direction
+    const tokenIn = s.zeroForOne ? m.token0 : m.token1;
+    const tokenOut = s.zeroForOne ? m.token1 : m.token0;
 
-    // zeroForOne: token0 -> token1
-    // token0 amount exchanged:
-    // - if zeroForOne: token0 = amountIn
-    // - else: token0 = amountOut
-    const amount0 = zeroForOne ? amountIn : amountOut;
+    // token0/token1 absolute amounts exchanged in this swap
+    const amount0 = s.zeroForOne ? s.amountIn : s.amountOut;
+    const amount1 = s.zeroForOne ? s.amountOut : s.amountIn;
 
-    // token1 amount exchanged:
-    // - if zeroForOne: token1 = amountOut
-    // - else: token1 = amountIn
-    const amount1 = zeroForOne ? amountOut : amountIn;
+    // ---- Volume: count on core-asset side to avoid double counting
+    // If neither side is core, prefer stable-like side; else fallback to token1
+    let baseToken: string;
+    let baseAmount: bigint;
 
-    // Count volume on the core-asset side (better pricing coverage)
-    const useToken0 = isCoreAsset(chain, m.token0);
-    const baseToken = useToken0 ? m.token0 : m.token1;
-    const baseAmount = useToken0 ? amount0 : amount1;
+    if (isCoreAsset(chain, m.token0)) {
+      baseToken = m.token0;
+      baseAmount = amount0;
+    } else if (isCoreAsset(chain, m.token1)) {
+      baseToken = m.token1;
+      baseAmount = amount1;
+    } else if (isStableLike(m.token0)) {
+      baseToken = m.token0;
+      baseAmount = amount0;
+    } else if (isStableLike(m.token1)) {
+      baseToken = m.token1;
+      baseAmount = amount1;
+    } else {
+      baseToken = m.token1;
+      baseAmount = amount1;
+    }
 
-    if (baseAmount > 0n) dailyVolume.add(baseToken, baseAmount);
+    addWithStableMapping(dailyVolume, baseToken, baseAmount, decimalsMap);
 
-    // Total fees (in base token units)
-    const feeAmount = (baseAmount * m.feePips) / SWAP_FEE_DENOMINATOR;
-    if (feeAmount <= 0n) continue;
+    // ---- Fees: charged on amountIn (input token)
+    if (m.feePips > 0n && s.amountIn > 0n) {
+      const feeAmount = (s.amountIn * m.feePips) / SWAP_FEE_DENOMINATOR;
+      if (feeAmount > 0n) {
+        addWithStableMapping(dailyFees, tokenIn, feeAmount, decimalsMap);
 
-    dailyFees.add(baseToken, feeAmount);
+        const protocolFeeAmount = (feeAmount * protocolFeeBps) / PROTOCOL_FEE_DENOMINATOR;
+        const lpFeeAmount = feeAmount - protocolFeeAmount;
 
-    // Split fees: protocol vs LPs
-    const protocolFeeAmount =
-      (feeAmount * protocolFeeBps) / PROTOCOL_FEE_DENOMINATOR;
-    const lpFeeAmount = feeAmount - protocolFeeAmount;
-
-    if (protocolFeeAmount > 0n)
-      dailyProtocolRevenue.add(baseToken, protocolFeeAmount);
-    if (lpFeeAmount > 0n) dailySupplySideRevenue.add(baseToken, lpFeeAmount);
+        if (protocolFeeAmount > 0n)
+          addWithStableMapping(dailyProtocolRevenue, tokenIn, protocolFeeAmount, decimalsMap);
+        if (lpFeeAmount > 0n)
+          addWithStableMapping(dailySupplySideRevenue, tokenIn, lpFeeAmount, decimalsMap);
+      }
+    }
   }
 
   return {
     dailyVolume,
     dailyFees,
-    dailyUserFees: dailyFees.clone(1), // user pays total fees
-    dailyRevenue: dailyProtocolRevenue.clone(1), // protocol revenue
-    dailyProtocolRevenue, // treasury share (protocol)
-    dailySupplySideRevenue, // LP share
-    dailyHoldersRevenue, // none
+    dailyUserFees: dailyFees.clone(1),
+    dailyRevenue: dailyProtocolRevenue.clone(1),
+    dailyProtocolRevenue,
+    dailySupplySideRevenue,
+    dailyHoldersRevenue,
   };
 };
 
@@ -211,8 +362,7 @@ const fetch: FetchV2 = async (options: FetchOptions) => {
 
   const merge = (dst: any, src: any) => {
     if (!src) return;
-    if (typeof src === "object" && typeof dst.addBalances === "function")
-      dst.addBalances(src);
+    if (typeof src === "object" && typeof dst.addBalances === "function") dst.addBalances(src);
   };
 
   merge(outDailyVolume, v2.dailyVolume);
@@ -253,11 +403,17 @@ const adapter: SimpleAdapter = {
   start: "2024-12-23",
   methodology: {
     Volume:
-      "DEX swap volume on PumpSpace (V2 + Trident V3) on Avalanche. V2 uses pair Swap logs from the V2 factory. V3 uses PoolLogger Swap(pool, zeroForOne, amountIn, amountOut) logs and reads token0/token1/swapFee from each concentrated liquidity pool.",
-    Fees: "V2 charges 0.5% per swap split 50% LP / 50% protocol treasury. V3 fees are estimated using each pool's swapFee() (pips where 1e6 = 100%).",
+      "DEX swap volume on PumpSpace (V2 + Trident V3) on Avalanche. " +
+      "V2 uses pair Swap logs from the V2 factory. " +
+      "V3 uses PoolLogger Swap(pool, zeroForOne, amountIn, amountOut) logs and reads token0/token1/swapFee from each concentrated liquidity pool. " +
+      "Volume is counted on a single side (core-asset side; fallback to stable-like bUSDt/bUSDC/bAUSD) to avoid double counting.",
+    Fees:
+      "V2 charges 0.5% per swap split 50% LP / 50% protocol treasury. " +
+      "V3 fees are computed on amountIn using each pool's swapFee() (pips where 1e6 = 100%).",
     UserFees: "Users pay V2 0.5% and V3 swapFee() per swap.",
     Revenue:
-      "Protocol-side fees. V2: 50% of total fees. V3: protocol share is determined by MiningPoolFactory.defaultProtocolFee() (bps, currently 2000 = 20% of fees).",
+      "Protocol-side fees. V2: 50% of total fees. " +
+      "V3: protocol share is determined by MiningPoolFactory.defaultProtocolFee() (bps, currently 2000 = 20% of fees).",
     ProtocolRevenue:
       "Treasury share of fees. V2: 50% of fees. V3: defaultProtocolFee() share (currently 20% of fees).",
     SupplySideRevenue:


### PR DESCRIPTION
**NOTE**

#### Please enable "Allow edits by maintainers" while putting up the PR.

---

### What this PR does
- Updates the existing PumpSpace `dexs` adapter to properly include **Trident V3** volume/fees using **PoolLogger Swap logs**, in addition to the existing **V2 (Uniswap V2 fork)** adapter.
- Uses `MiningPoolFactory.defaultProtocolFee()` (currently `2000` bps = **20% of fees**) to split V3 fees into:
  - **ProtocolRevenue/Revenue:** 20%
  - **SupplySideRevenue (LPs):** 80%
- V3 fee calculation is based on **amountIn** (input token), matching how swap fees are charged.

### Addresses (Avalanche)
- V2 Factory: `0x26B42c208D8a9d8737A2E5c9C57F4481484d4616`
- V3 MiningPoolFactory: `0xE749c1cA2EA4f930d1283ad780AdE28625037CeD`
- V3 PoolLogger: `0x77c8dfFE4130FE58e5C3c02a2E7ab6DB7f4F474f`

### Notes about volume vs our dashboard
- Our internal dashboard sums **both swap sides (from + to)**.
- DefiLlama counts volume on **one side only** (core-asset side) to avoid double counting, so the USD number can appear smaller.

### Stable-like token pricing request (bTokens)
DefiLlama already treats `bUSDt` as stable, but `bUSDC` and `bAUSD` are not priced as stables yet.
Could you also mark these as stables (1:1 fully-backed) so USD conversion is correct?

Tokens (Avalanche):
- bUSDt: `0x3C594084dC7AB1864AC69DFd01AB77E8f65B83B7`
- bUSDC: `0x038Dbe3D967bB8389190446DACdfE7B95b44F73D`
- bAUSD: `0xd211b17Dfe8288D4Fb0dd8EEFF07A6C48fC679D5`

---

##### Name (to be shown on DefiLlama):
PumpSpace

##### Twitter Link:
https://twitter.com/pumpspace10000

##### List of audit links if any:
- https://www.cyberscope.io/audits/pumpspace?assessmentIndex=1
- https://github.com/cyberscope-io/audits/blob/main/pumpspace/dexAudit.pdf

##### Website Link:
https://pumpspace.io/

##### Chain:
Avalanche

##### Category:
Dexes

##### forkedFrom:
Uniswap V2, Sushi Trident

##### methodology:
- V2: uses factory pair Swap logs (0.5% fees, split 50% LP / 50% treasury)
- V3: uses PoolLogger Swap logs; reads token0/token1/swapFee from pools; protocol share from defaultProtocolFee() (20%); LPs receive 80%

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added PumpSpace decentralized exchange adapter for the Avalanche blockchain network. Enables comprehensive tracking of daily trading volume, swap fees, protocol revenue, holder fees revenue, and supply-side revenue metrics across both concentrated liquidity pools and standard liquidity pools. Delivers detailed market analytics with full data aggregation from multiple liquidity sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->