### PR TITLE
fix: Alphix adapters - remove pullHourly from fees, correct start date

### DIFF
--- a/dexs/alphix.ts
+++ b/dexs/alphix.ts
@@ -56,7 +56,7 @@ const adapter: SimpleAdapter = {
   adapter: {
     [CHAIN.BASE]: {
       fetch,
-      start: "2025-02-09",
+      start: "2026-02-10",
     },
   },
   doublecounted: true,

--- a/fees/alphix.ts
+++ b/fees/alphix.ts
@@ -121,11 +121,10 @@ async function fetch(options: FetchOptions) {
 
 const adapter: SimpleAdapter = {
   version: 2,
-  pullHourly: true,
   adapter: {
     [CHAIN.BASE]: {
       fetch,
-      start: '2025-02-09',
+      start: '2026-02-10',
     },
   },
   methodology: {


### PR DESCRIPTION
- Remove pullHourly from fees adapter (sub-dollar hourly values rounded to 0 by framework's toFixed(0), causing all metrics to show $0)
- Fix start date from 2025-02-09 to 2026-02-10 (actual hook deployment)

**NOTE**

Hi @noateden This PR fixes two issues with the last Alphix updates #6008 :

1. **Remove `pullHourly` from fees adapter** — As already mentioned, Alphix generates ~$11/day in fees, which means each hourly slice is ~$0.45. The framework rounds values to integers via `toFixed(0)`, so every slice becomes $0 and the daily total sums to $0. Removing `pullHourly` and running daily fixes this. (Note: the volume adapter is fine with `pullHourly` since ~$26k/day means each hourly slice is well above $1.)

2. **Fix start date** — Was `2025-02-09` but the hooks were deployed in February 2026 (first tx on hook `0x831c...` is 2026-02-10). Updated to `2026-02-10` on both adapters.

Happy to adjust anything — feel free to reach out!

## Test results

fees/alphix.ts:
Backfill start time: 10/2/2026
Daily fees: 11.00
Daily user fees: 11.00
Daily supply side revenue: 8.00
Daily revenue: 3.00
Daily protocol revenue: 3.00

dexs/alphix.ts:
Backfill start time: 10/2/2026
Daily volume: 26.35k

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Chores**
- Updated data collection adapter configuration with revised effective dates
- Simplified adapter configuration by removing hourly polling frequency requirement

<!-- end of auto-generated comment: release notes by coderabbit.ai -->