### PR TITLE
Add SundaeSwap holders revenue

### DIFF
--- a/fees/sundaeswap/index.ts
+++ b/fees/sundaeswap/index.ts
@@ -96,7 +96,7 @@ const methodology = {
   Revenue: "A fixed ADA cost per transaction that is collected by the protocol",
   SupplySideRevenue: "A percentage cut on all trading volume, paid to Liquidity Providers",
   ProtocolRevenue: "A percentage cut of the fixed ADA cost per transaction that is collected by the protocol",
-  HoldersRevenue: "A percentage cut of the fixed ADA cost per transaction that is collected by the protocol"
+  HoldersRevenue: "A percentage cut of the fixed ADA cost per transaction that is going to holders"
 };
 
 const breakdownMethodology = {


### PR DESCRIPTION
This PR adds the SundaeSwap holders revenue which equates to 15% of the total revenue. It also adjusts the protocol revenue from 100% of revenue to 85%.

Request: Please backfill all fee/revenue data to January 20th, 2022. The backfill did not work when this adapter was merged. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added separate daily revenue trackers for protocol and holders, and exposed both as distinct returned metrics.
  * Revenue split now applies conditionally based on a configured start timestamp.

* **Documentation**
  * Methodology updated to describe protocol and holders percentage shares (replacing prior fixed-cost wording).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->