### PR TITLE
Add MineBean fees adapter (BASE)

### DIFF
--- a/fees/minebean.ts
+++ b/fees/minebean.ts
@@ -1,0 +1,91 @@
+import { FetchOptions, SimpleAdapter } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+
+const GRID_MINING = '0x9632495bDb93FD6B0740Ab69cc6c71C9c01da4f0';
+const TREASURY = '0x38F6E74148D6904286131e190d879A699fE3Aeb3';
+
+// GridMining fee constants (basis points, matching contract)
+const ADMIN_FEE_BPS = 100n;   // 1% of totalDeployed
+const VAULT_FEE_BPS = 1000n;  // 10% of losersPool after admin
+const BPS = 10000n;
+
+// Settlement math (from GridMining._calculateSettlementFees):
+//   adminFee       = totalDeployed × 1%
+//   losersPool     = totalDeployed - winnersDeployed
+//   losersAdmin    = losersPool × 1%
+//   vaultAmount    = (losersPool - losersAdmin) × 10%
+//   totalWinnings  = (losersPool - losersAdmin) - vaultAmount
+//
+// So totalWinnings = losersPool × 0.99 × 0.9 = losersPool × 8910 / 10000
+// We can derive losersPool from totalWinnings, then calculate all fees.
+
+const fetch = async (options: FetchOptions) => {
+  const dailyFees = options.createBalances();
+  const dailyProtocolRevenue = options.createBalances();
+  const dailyHoldersRevenue = options.createBalances();
+
+  // VaultReceived gives exact vault fee per round (no derivation needed)
+  const vaultLogs = await options.getLogs({
+    target: TREASURY,
+    eventAbi: 'event VaultReceived(uint256 amount, uint256 vaultedETH)',
+  });
+
+  vaultLogs.forEach(log => {
+    dailyFees.addGasToken(log.amount);
+    dailyHoldersRevenue.addGasToken(log.amount);
+  });
+
+  // RoundSettled gives totalWinnings + winnersDeployed to derive admin fees
+  const roundLogs = await options.getLogs({
+    target: GRID_MINING,
+    eventAbi: 'event RoundSettled(uint64 indexed roundId, uint8 winningBlock, address topMiner, uint256 totalWinnings, uint256 topMinerReward, uint256 beanpotAmount, bool isSplit, uint256 topMinerSeed, uint256 winnersDeployed)',
+  });
+
+  roundLogs.forEach(log => {
+    const totalWinnings = log.totalWinnings;
+    const winnersDeployed = log.winnersDeployed;
+
+    // Derive losersPool: totalWinnings = losersPool × (BPS - ADMIN) / BPS × (BPS - VAULT) / BPS
+    // = losersPool × 9900 × 9000 / 10000^2 = losersPool × 8910 / 10000
+    const losersPool = totalWinnings > 0n
+      ? totalWinnings * BPS * BPS / ((BPS - ADMIN_FEE_BPS) * (BPS - VAULT_FEE_BPS))
+      : 0n;
+    const totalDeployed = losersPool + winnersDeployed;
+
+    // Admin fees: 1% on totalDeployed + 1% on losersPool
+    const adminFee = totalDeployed * ADMIN_FEE_BPS / BPS;
+    const losersAdminFee = losersPool * ADMIN_FEE_BPS / BPS;
+    const totalAdminFees = adminFee + losersAdminFee;
+
+    dailyFees.addGasToken(totalAdminFees);
+    dailyProtocolRevenue.addGasToken(totalAdminFees);
+  });
+
+  return {
+    dailyFees,
+    dailyUserFees: dailyFees,
+    dailyRevenue: dailyFees,
+    dailyProtocolRevenue,
+    dailyHoldersRevenue,
+  };
+};
+
+const methodology = {
+  Fees: 'Fees extracted per round: 1% admin fee on totalDeployed, 1% admin fee on losers pool, and 10% vault fee on losers pool after admin. Variable effective rate depending on winner/loser ratio.',
+  Revenue: 'All extracted fees (admin + vault) are protocol revenue.',
+  ProtocolRevenue: 'Admin fees (1% of totalDeployed + 1% of losers pool) sent to feeCollector wallet for protocol operations.',
+  HoldersRevenue: 'Vault fee (10% of losers pool after admin) funds automated BEAN buybacks — 90% burned, 10% distributed to BEAN stakers.',
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  adapter: {
+    [CHAIN.BASE]: {
+      fetch,
+      start: '2026-02-25',
+    },
+  },
+  methodology,
+};
+
+export default adapter;


### PR DESCRIPTION
**NOTE**

#### Please enable "Allow edits by maintainers" while putting up the PR.

---

> - If you would like to add a `tvl` adapter please submit the PR [here](https://github.com/DefiLlama/DefiLlama-Adapters).

1. Once your adapter has been merged, it takes time to show on the UI. If more than 24 hours have passed, please let us know in Discord.
2. Please fill the form below **only if the PR is for listing a new protocol** else it can be ignored/replaced with reason/details about the PR
3. **For updating listing info** It is a different repo, you can find your listing in this file: https://github.com/DefiLlama/defillama-server/blob/master/defi/src/protocols/data4.ts, you can edit it there and put up a PR
4. Do not edit/push `package.json/package-lock.json` file as part of your changes
5. No need to go to our discord/other channel and announce that you've created a PR, we monitor all PRs and will review it asap

---

##### Name (to be shown on DefiLlama): MineBean

##### Twitter Link: https://x.com/minebean_

##### List of audit links if any:

##### Website Link: https://minebean.com/

##### Logo (High resolution, will be shown with rounded borders): https://imagedelivery.net/GyRgSdgDhHz2WNR4fvaN-Q/0e548f28-3729-463a-6feb-9dbdbfbb8c00/public

##### Current TVL: $51,542.48

##### Treasury Addresses (if the protocol has treasury): 0x38F6E74148D6904286131e190d879A699fE3Aeb3

##### Chain: Base (8453)

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed): (https://api.coingecko.com/api/v3/coins/list)

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)

##### Short Description (to be shown on DefiLlama): BEAN is a gamified mining protocol on Base. Players compete in continuous 60-second rounds to earn ETH and BEAN tokens, Competitive gaming mechanics layered with DeFi infrastructure.

##### Token address and ticker if any: 0x5c72992b83E74c4D5200A8E8920fB946214a5A5D (BEAN)

##### Category (full list at https://defillama.com/categories) \*Please choose only one: Gamified Mining

##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.): Chainlink VRF, TWAP

##### Implementation Details: Briefly describe how the oracle is integrated into your project: Chainlink VRF v2.5 is used to generate verifiable random winning blocks each round. Built-in BEAN token TWAP oracle provides slippage protection for Treasury buybacks via Uniswap V4.

##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage: https://www.minebean.com/about.

Contract where TWAP is used: https://basescan.org/address/0x5c72992b83E74c4D5200A8E8920fB946214a5A5D#code

Contract where chainlink VRF is used: https://basescan.org/address/0x9632495bDb93FD6B0740Ab69cc6c71C9c01da4f0#code

##### forkedFrom (Does your project originate from another project):

##### methodology (what is being counted as tvl, how is tvl being calculated): 10% of the losing pool is sent to the Treasury for automated BEAN buybacks. 90% of purchased BEAN is permanently burned, 10% distributed to BEAN stakers as yield. Variable effective rate per round depending on winner/loser ratio. Fees tracked from on-chain events.

##### Github org/user (Optional, if your code is open source, we can track activity): https://github.com/nu11dotfun

##### Does this project have a referral program?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new adapter that tracks daily fees, protocol revenue, and holder rewards for a grid-mining protocol.
  * Derives totals (fees, protocol revenue, holders revenue) from on-chain events and distributes them across daily metrics.
  * Available on the BASE chain with an included methodology describing how fees and revenues are calculated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->