### PR TITLE
Add SimpleDEX DEX adapter (XPR Network)

### DIFF
--- a/dexs/simpledex/index.ts
+++ b/dexs/simpledex/index.ts
@@ -21,7 +21,6 @@ const adapter: SimpleAdapter = {
     version: 2,
     fetch,
     chains: [CHAIN.PROTON],
-    start: "2026-02-15",
     runAtCurrTime: true,
 };
 


### PR DESCRIPTION
**Name:** SimpleDEX
**Twitter Link:** https://x.com/protonnz
**Website Link:** https://dex.protonnz.com
**Logo:** https://dex.protonnz.com/simpledex-logo.png
**Chain:** XPR Network (Proton)
**Short Description:** Community DEX and token launchpad on XPR Network with AMM pools, bonding curve launches, and atomic graduation
**Category:** Dexes
**Methodology:**

- **Volume:** Total USD value of swaps across all pools, tracked by the SimpleDEX indexer which indexes swap transfers from Hyperion history
- **Fees:** 0.3% default swap fee on all trades
- **Revenue:** 33.33% of fees go to protonnz
- **Supply-side revenue:** 66.67% of fees go to liquidity providers

## Summary

SimpleDEX is a community DEX and token launchpad on XPR Network (Proton). It features AMM constant-product pools with bonding curve token launches that atomically graduate to DEX liquidity. This adapter fetches pre-computed daily volume, fees, and revenue data from the SimpleDEX indexer API at `https://indexer.protonnz.com/api/defillama/summary`.

The TVL adapter already exists in DefiLlama-Adapters (PR #18182, merged Feb 27).

## Fields returned

| Field | Description |
|-------|-------------|
| `dailyVolume` | 24h swap volume in USD |
| `totalVolume` | All-time swap volume in USD |
| `dailyFees` | 24h total fees (0.3% of volume) |
| `dailyUserFees` | Same as dailyFees (users pay all fees) |
| `dailyRevenue` | protonnz share (33.33% of fees) |
| `dailySupplySideRevenue` | LP share (66.67% of fees) |
| `totalFees` | All-time total fees |
| `totalRevenue` | All-time protonnz revenue |

## Test

```bash
curl -s https://indexer.protonnz.com/api/defillama/summary | jq
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new decentralized exchange adapter for the Proton network that provides daily trading volume, aggregated fees, daily user fees, protocol revenue, and supply-side revenue. Metrics are exposed for use in dashboards and reports and are produced on current-time runs for up-to-date data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->