### PR TITLE
fix(fees): Update FlareBank adapter — fix metric keys, add Blazeswap LP

### DIFF
--- a/fees/flarebank/index.ts
+++ b/fees/flarebank/index.ts
@@ -140,6 +140,10 @@ const breakdownMethodology = {
     [METRIC.SWAP_FEES]: "A 1% fee is charged on swaps via LP pools",
     [METRIC.TRADING_FEES]: "A 1% fee is charged on peer-to-peer BANK transfers",
   },
+  ProtocolRevenue: {
+    [METRIC.MINT_REDEEM_FEES]: "15% of fees go to the team and 5% to the DAO",
+    [METRIC.SWAP_FEES]: "15% of fees go to the team and 5% to the DAO"
+  },
   HoldersRevenue: {
     [METRIC.MINT_REDEEM_FEES]: "80% of the fees are paid as dividends to BANK holders",
     [METRIC.SWAP_FEES]: "80% of the fees are paid as dividends to BANK holders"


### PR DESCRIPTION
## FlareBank Fees Adapter Fix

**Protocol:** FlareBank (https://flrbank.com)
**Chain:** Flare Network

### Changes

1. **Fix metric key mismatch** — Use `METRIC.MINT_REDEEM_FEES`, `METRIC.SWAP_FEES`, `METRIC.TRADING_FEES` constants instead of custom fee label strings. The old custom labels caused fees to display as zero on DefiLlama.

2. **Add Blazeswap LP** (`0xd41787672e9C887eF66C42a4c60F00E6e71a762D`) for swap detection alongside Enosys V2 and SparkDex V2.

3. **Fix burn event field name** — `ethEarned` matches the actual contract event signature (was `ethereumEarned`).

4. **Cleaner revenue split** — Use `resizeBy()` instead of manual BigInt arithmetic for 80/20 holder/protocol split.

5. **Correct start date** — `2025-02-13` (protocol launch).

### Fee Structure (unchanged)

| Action | Fee | Distribution |
|--------|-----|-------------|
| Mint | 10% of WFLR | 80% holders, 15% team, 5% DAO |
| Burn | 10% of WFLR | 80% holders, 15% team, 5% DAO |
| Transfer | 1% of BANK | 80% holders, 15% team, 5% DAO |
| LP Swap | 1% of BANK | 80% holders, 15% team, 5% DAO |

### Contract
- BANK Token: `0x194726F6C2aE988f1Ab5e1C943c17e591a6f6059`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Fee parsing moved to explicit log-based handling; mint/burn fee calculations updated to derive 10% equivalents.
  * Transfer handling reworked: internal/excluded transfers filtered; 1% fee applied to non-excluded transfers.
  * LP address normalization and swap-detection added; swaps classified separately from trading fees.
  * Daily revenue split standardized to 80% holders / 20% protocol.
  * Adapter public surface consolidated: top-level chains/version/fetch/start/methodology/breakdown fields introduced; legacy nesting removed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->