### PR TITLE
Add FluidTokens fees adapter

### DIFF
--- a/fees/fluidtokens/index.ts
+++ b/fees/fluidtokens/index.ts
@@ -18,6 +18,10 @@ interface FluidTokensFeesResponse {
   stats: {
     totalFeesLovelace: number;
     totalFeesAda: number;
+    totalRevenueLovelace: number;
+    totalRevenueAda: number;
+    totalProtocolRevenueLovelace: number;
+    totalProtocolRevenueAda: number;
     adaDirectLovelace: number;
     adaDirectAda: number;
     adaFromTokensLovelace: number;
@@ -39,26 +43,34 @@ const fetch = async (options: FetchOptions): Promise<FetchResult> => {
   if (
     !response?.stats ||
     typeof response.stats.totalFeesAda !== "number" ||
+    typeof response.stats.totalRevenueAda !== "number" ||
+    typeof response.stats.totalProtocolRevenueAda !== "number" ||
     !Number.isFinite(response.stats.totalFeesAda) ||
+    !Number.isFinite(response.stats.totalRevenueAda) ||
+    !Number.isFinite(response.stats.totalProtocolRevenueAda) ||
     response.stats.totalFeesAda < 0 ||
+    response.stats.totalRevenueAda < 0 ||
+    response.stats.totalProtocolRevenueAda < 0 ||
     response.date !== dateString
   ) {
     throw new Error(`Fees data not found for FluidTokens on ${dateString}`);
   }
 
-  if (
-    response.status !== "final" ||
-    response.hoursCovered < response.hoursExpected
-  ) {
-    return {};
-  }
-
   const dailyFees = options.createBalances();
+  const dailyRevenue = options.createBalances();
+  const dailyProtocolRevenue = options.createBalances();
+
   dailyFees.addCGToken("cardano", Number(response.stats.totalFeesAda));
+  dailyRevenue.addCGToken("cardano", Number(response.stats.totalRevenueAda));
+  dailyProtocolRevenue.addCGToken(
+    "cardano",
+    Number(response.stats.totalProtocolRevenueAda)
+  );
 
   return {
     dailyFees,
-    dailyRevenue: dailyFees,
+    dailyRevenue,
+    dailyProtocolRevenue,
   };
 };
 
@@ -67,12 +79,16 @@ const adapter: Adapter = {
   adapter: {
     [CHAIN.CARDANO]: {
       fetch,
-      start: "2026-02-28",
+      start: "2026-03-02",
     },
   },
   methodology: {
     Fees:
-      "Gross value received by the FluidTokens fee address, sourced from the FluidTokens daily fees endpoint and denominated in ADA.",
+      "Gross value received by the FluidTokens treasury-only fee address, sourced from the FluidTokens daily fees endpoint and denominated in ADA.",
+    Revenue:
+      "All value received by the treasury-only FluidTokens fee address is treated as protocol revenue.",
+    ProtocolRevenue:
+      "Because the tracked address is treasury-only, all recorded revenue is classified as protocol treasury revenue.",
   },
 };
 


### PR DESCRIPTION
Adds a new Cardano fees adapter for FluidTokens.

### What this PR does
- adds a new adapter at `fees/fluidtokens/index.ts`
- reads daily fees from:
  - `https://api.fluidtokens.com/liquidity/fees/daily?date=YYYY-MM-DD`
- maps `stats.totalFeesAda` to `dailyFees` in `cardano`
- uses `start: "2026-02-28"`

### Endpoint response used
Example response:
```json
{
  "_id": "69a2e822907537348113737d",
  "address": "addr1x9z4cq2qm23tvtn4uxeuzf8arnvqgqw6whzjh3r8jqkxdk4f02nfch7l297055r7z37fwamryqrd3en97sp7jq7gtffsfkk0p6",
  "date": "2026-02-28",
  "__v": 0,
  "createdAt": "2026-02-28T13:05:38.549Z",
  "hoursCovered": 17,
  "hoursExpected": 17,
  "stats": {
    "totalFeesLovelace": 10000000,
    "totalFeesAda": 10,
    "adaDirectLovelace": 10000000,
    "adaDirectAda": 10,
    "adaFromTokensLovelace": 0,
    "adaFromTokensAda": 0,
    "pricedTokensCount": 0,
    "unpricedTokensCount": 0
  },
  "status": "provisional",
  "timestamp": "2026-02-28T17:05:38.405Z",
  "updatedAt": "2026-02-28T17:05:38.548Z"
}


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Integrated FluidTokens daily-fees data source for Cardano.
  * Provides daily Fees, Revenue, and ProtocolRevenue figures derived from FluidTokens.
  * Adds data validation and error handling to ensure accuracy for requested dates.
  * Data coverage begins March 2, 2026.
  * Includes methodology describing how Fees, Revenue, and ProtocolRevenue are computed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->