### PR TITLE
Add router to LiquidCore adapter

### DIFF
--- a/dexs/liquidcore.ts
+++ b/dexs/liquidcore.ts
@@ -14,15 +14,12 @@ const fetch = async (options: FetchOptions): Promise<FetchResult> => {
     target: LIQUIDCORE_ROUTER,
     abi: "function getPools() external view returns (address[])",
   });
-
-  const logs = (await Promise.all(
-    pools.map((pool: string) => 
-      options.getLogs({
-        target: pool,
-        eventAbi: SwapEvent,
-      })
-    )
-  )).flat();
+  
+  const logs = await options.getLogs({
+    targets: pools,
+    eventAbi: SwapEvent,
+    flatten: true,
+  })
 
   for (const log of logs) {
     // Track volume using the input token amount
@@ -36,6 +33,7 @@ const fetch = async (options: FetchOptions): Promise<FetchResult> => {
     dailyVolume,
     dailyFees,
     dailyRevenue: dailyFees,
+    dailyProtocolRevenue: dailyFees,
   };
 };
 
@@ -43,6 +41,7 @@ const methodology = {
   Volume: "Volume is calculated from the amountIn of all Swap events on LiquidCore pools.",
   Fees: "All swap fees collected by LiquidCore pools.",
   Revenue: "All swap fees go to protocol revenue (100% protocol-owned liquidity).",
+  ProtocolRevenue: "All swap fees go to protocol revenue (100% protocol-owned liquidity).",
 };
 
 const adapter: SimpleAdapter = {


### PR DESCRIPTION
This adapter is already live.

We have deployed a router so new pools are dynamically discovered by the adapter and we have switched over to a 100% POL model. 100% of revenue is now kept by the protocol instead of 10% as we are the only depositors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined revenue metrics reporting for Liquidcore DEX, consolidating multiple revenue types into a unified daily fee metric for clarity.
  * Enhanced pool data retrieval by shifting from static configuration to dynamic router-based approach, improving data accuracy and flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->