### PR TITLE
remove 3 day lag from treadfi data

### DIFF
--- a/dexs/treadfi-perps.ts
+++ b/dexs/treadfi-perps.ts
@@ -61,7 +61,7 @@ const fetchHyperliquid = async (_a: any, _b: any, options: FetchOptions) => {
   const treadToolsData = options.preFetchedResults;
   const hlData = treadToolsData.data?.hyperliquid;
   if (hlData && typeof hlData.dailyVolume === "number" && hlData.dailyVolume > 0) {
-    dailyVolume.addCGToken("usd-coin", hlData.dailyVolume);
+    dailyVolume.addUSDValue(hlData.dailyVolume);
   }
 
   // Fees from builder API (actual builder fee revenue)
@@ -80,7 +80,7 @@ const fetchExtended = async (_a: any, _b: any, options: FetchOptions) => {
   const treadToolsData = options.preFetchedResults;
   const extendedData = treadToolsData.data?.extended;
   if (extendedData && typeof extendedData.dailyVolume === "number" && extendedData.dailyVolume > 0) {
-    dailyVolume.addCGToken("usd-coin", extendedData.dailyVolume);
+    dailyVolume.addUSDValue(extendedData.dailyVolume);
   }
 
   // Fees from builder API (actual builder fee revenue)
@@ -101,7 +101,7 @@ const fetchParadex = async (_a: any, _b: any, options: FetchOptions) => {
   const paradexData = treadToolsData.data?.paradex;
 
   if (paradexData && typeof paradexData.dailyVolume === "number" && paradexData.dailyVolume > 0) {
-    dailyVolume.addCGToken("usd-coin", paradexData.dailyVolume);
+    dailyVolume.addUSDValue(paradexData.dailyVolume);
   }
 
   return {
@@ -123,8 +123,8 @@ const fetchInk = async (_a: any, _b: any, options: FetchOptions) => {
   if (nadoData && typeof nadoData.dailyVolume === "number" && nadoData.dailyVolume > 0) {
     const volume = nadoData.dailyVolume;
     const fees = volume * TREADTOOLS_FEE_RATE;
-    dailyVolume.addCGToken("usd-coin", volume);
-    dailyFees.addCGToken("usd-coin", fees);
+    dailyVolume.addUSDValue(volume);
+    dailyFees.addUSDValue(fees);
   }
 
   return {
@@ -154,8 +154,8 @@ const fetchSolana = async (_a: any, _b: any, options: FetchOptions) => {
 
   if (totalVolume > 0) {
     const fees = totalVolume * TREADTOOLS_FEE_RATE;
-    dailyVolume.addCGToken("usd-coin", totalVolume);
-    dailyFees.addCGToken("usd-coin", fees);
+    dailyVolume.addUSDValue(totalVolume);
+    dailyFees.addUSDValue(fees);
   }
 
   return {
@@ -183,7 +183,7 @@ const fetchBsc = async (_a: any, _b: any, options: FetchOptions) => {
   }
 
   if (totalVolume > 0) {
-    dailyVolume.addCGToken("usd-coin", totalVolume);
+    dailyVolume.addUSDValue(totalVolume);
   }
 
   return {


### PR DESCRIPTION
Remove 3 day lag in data and bring end date up to current date. Please backfill the data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved data sourcing accuracy for perpetuals trading metrics across multiple networks.
  * Enhanced error handling and validation for API authentication.

* **Chores**
  * Updated data availability start date for Hyperliquid perpetuals (2025-10-05).
  * Enforced API key authentication requirement for data collection.
  * Simplified BSC perpetuals reporting by removing unused data fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->