### PR TITLE
Fix TreadFi Perps volume accuracy

### DIFF
--- a/dexs/treadfi-perps.ts
+++ b/dexs/treadfi-perps.ts
@@ -188,6 +188,9 @@ const fetchBsc = async (_a: any, _b: any, options: FetchOptions) => {
 
   return {
     dailyVolume,
+    dailyFees: 0, // no fees
+    dailyRevenue: 0,
+    dailyProtocolRevenue: 0,
   };
 };
 


### PR DESCRIPTION
## Summary

Fixes volume overcounting for Hyperliquid and Extended/Starknet chains. The previous approach used builder APIs for volume, which captured ALL users of the builder code — not just TreadFi MMBot orders. This overcounted HL volume by ~4.5x and Extended by ~3.6x.

## What changed

- **HL + Extended volume**: Now sourced from TreadTools API (MMBot orders only). Fees still come from builder APIs (actual builder fee revenue — unchanged).
- **BSC**: Removed fees (volume only).
- **HL start date**: Updated to 2025-10-05 (when TreadTools data begins).

## Addressing the revert (#6061)

@bheluga the previous PR was reverted because the last 3 days showed the same data. That was caused by a 3-day lag in our data pipeline — not the adapter code. We've since:

1. **Reduced pipeline lag from 3 days to 1 day** — our ClickHouse workflow now produces data through yesterday (runs daily at 6am UTC)
2. **No date fallback** — the TreadTools API does exact date matching only. If a date doesn't exist, it returns empty. No stale data is ever repeated.
3. **Verified the data is current** — pipeline was triggered and data now extends through 2026-03-03 (yesterday). Each day has unique volume numbers.

### Verification (simulated API responses):
| Date | HL Volume | Extended | Paradex | Ink | Solana | BSC | Total |
|------|-----------|----------|---------|-----|--------|-----|-------|
| Mar 1 | $47.0M | $815K | $5.7M | $5.6M | $863K | $1.8M | $61.8M |
| Mar 2 | $129.6M | $1.5M | $7.4M | $5.6M | $551K | $15.1M | $159.8M |
| Mar 3 | $176.7M | $821K | $10.4M | $7.9M | $483K | $6.6M | $202.9M |
| Mar 4 (today) | empty | empty | empty | empty | empty | empty | $0 (correct) |

No two days share the same data. Please backfill.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced volume data accuracy for Hyperliquid and Extended via new external volume sources
  * Updated Hyperliquid historical data start date to October 5, 2025

* **Changes**
  * BSC adapter now returns daily volume only; fee, revenue, and protocol revenue fields are zeroed/removed
  * Other chains retain existing behavior with no visible functional changes
<!-- end of auto-generated comment: release notes by coderabbit.ai -->