### PR TITLE
Add deltadefi volume and fees adapter

### DIFF
--- a/dexs/deltadefi/index.ts
+++ b/dexs/deltadefi/index.ts
@@ -4,16 +4,16 @@ import { httpGet } from "../../utils/fetchURL";
 
 const VOLUME_API = "https://api-internal-metrics.deltadefi.io/public/volume/daily";
 
-const fetch = async ({ startOfDay }: any) => {
-  const response = await httpGet(`${VOLUME_API}?timestamp=${startOfDay}`);
+const fetch = async (timestamp: number) => {
+  const response = await httpGet(`${VOLUME_API}?timestamp=${timestamp}`);
   return {
     dailyVolume: response.volume_usd,
-    timestamp: startOfDay,
+    timestamp,
   };
 };
 
 const adapter: SimpleAdapter = {
-  version: 2,
+  version: 1,
   adapter: {
     [CHAIN.CARDANO]: {
       fetch,

--- a/fees/deltadefi/index.ts
+++ b/fees/deltadefi/index.ts
@@ -4,19 +4,19 @@ import { httpGet } from "../../utils/fetchURL";
 
 const FEES_API = "https://api-internal-metrics.deltadefi.io/public/fees/daily";
 
-const fetch = async ({ startOfDay }: any) => {
-  const response = await httpGet(`${FEES_API}?timestamp=${startOfDay}`);
+const fetch = async (timestamp: number) => {
+  const response = await httpGet(`${FEES_API}?timestamp=${timestamp}`);
   const dailyFees = response.daily_fees_usd;
 
   return {
     dailyFees,
     dailyRevenue: dailyFees,
-    timestamp: startOfDay,
+    timestamp,
   };
 };
 
 const adapter: Adapter = {
-  version: 2,
+  version: 1,
   adapter: {
     [CHAIN.CARDANO]: {
       fetch,


### PR DESCRIPTION
Title: add deltadefi volume and fees adapters                                                                                                                                    
                                                                                                                                                                                   
Body:                                                                                                                                                                            

This PR adds volume and fees/revenue adapters for DeltaDeFi (already listed on DefiLlama for TVL).

Summary

- Add DEX volume adapter (dexs/deltadefi/index.ts)
- Add fees/revenue adapter (fees/deltadefi/index.ts)
- Both call DeltaDeFi's public API returning daily data in USD

---
Name: DeltaDeFi

Twitter Link: https://x.com/DeltaDeFi

Website Link: https://www.deltadefi.io/

Chain: Cardano

Category: Dexes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * DeltaFi DEX integration added for Cardano, providing daily trading volume and fees metrics.
  * Automated daily retrieval of volume, fees, and revenue figures with timestamps for accurate day-by-day reporting.
  * Historical data availability starting 2026-01-26.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->