### PR TITLE
Add Megamble fees/revenue adapter.

### DIFF
--- a/fees/megamble.ts
+++ b/fees/megamble.ts
@@ -21,7 +21,6 @@ const fetch = async (options: FetchOptions) => {
   const dailyFees = options.createBalances();
   const dailyRevenue = options.createBalances();
   const dailySupplySideRevenue = options.createBalances();
-  const dailyUserFees = options.createBalances();
 
   const clickLogs = await options.getLogs({
     target: GAME_CONTRACT,
@@ -31,11 +30,6 @@ const fetch = async (options: FetchOptions) => {
 
   const totalClicks = clickLogs.length;
   const totalSpend = BigInt(totalClicks) * BigInt(CLICK_PRICE);
-
-  // dailyUserFees = only direct ETH clicks (credit clicks were pre-paid)
-  const directClicks = clickLogs.filter((log: any) => !log.usedCredit);
-  const directSpend = BigInt(directClicks.length) * BigInt(CLICK_PRICE);
-  dailyUserFees.addGasToken(directSpend);
 
   // dailyFees = 15% of all clicks (10% treasury + 5% referral)
   const totalFeesAmount = (totalSpend * BigInt(15)) / BigInt(100);
@@ -51,20 +45,26 @@ const fetch = async (options: FetchOptions) => {
 
   return {
     dailyFees,
+    dailyUserFees: dailyFees,
     dailyRevenue,
+    dailyProtocolRevenue: dailyRevenue,
     dailySupplySideRevenue,
-    dailyUserFees,
   };
+};
+
+const methodology = {
+  Fees: "15% of the pot amount is charged as fees , 85% to winner",
+  Revenue: "10% of the pot amount is revenue",
+  ProtocolRevenue: "10% of the pot amount is protocol revenue",
+  SupplySideRevenue: "5% of the pot amount goes to the referrer",
 };
 
 const adapter: Adapter = {
   version: 2,
-  adapter: {
-    [CHAIN.MEGAETH]: {
-      fetch,
-      start: 1771459200,
-    },
-  },
+  fetch,
+  chains: [CHAIN.MEGAETH],
+  start: "2026-02-19",
+  methodology,
 };
 
 export default adapter;


### PR DESCRIPTION
Add Megamble fees/revenue adapter.

**NOTE**

#### Please enable "Allow edits by maintainers" while putting up the PR.

---

> - If you would like to add a `tvl` adapter please submit the PR [here](https://github.com/DefiLlama/DefiLlama-Adapters).

1. Once your adapter has been merged, it takes time to show on the UI. If more than 24 hours have passed, please let us know in Discord.
2. Please fill the form below **only if the PR is for listing a new protocol** else it can be ignored/replaced with reason/details about the PR 3. **For updating listing info** It is a different repo, you can find your listing in this file: https://github.com/DefiLlama/defillama-server/blob/master/defi/src/protocols/data4.ts, you can edit it there and put up a PR 4. Do not edit/push `package.json/package-lock.json` file as part of your changes 5. No need to go to our discord/other channel and announce that you've created a PR, we monitor all PRs and will review it asap

---

##### Name (to be shown on DefiLlama): Megamble

##### Twitter Link: https://x.com/megamble_xyz

##### List of audit links if any: Verified contracts on MegaETH Explorer — https://mega.etherscan.io/address/0x051B5a8B20F3e49E073Cf7A37F4fE2e5117Af3b6#code

##### Website Link: https://megamble.xyz/

##### Logo (High resolution, will be shown with rounded borders): Included in TVL adapter PR (DefiLlama-Adapters #18241)

##### Current TVL: ~$10 (early stage, live since Feb 19 2026)

##### Treasury Addresses (if the protocol has treasury): 0x21CbC99a2E8c68F1C2955991E07c0C22ea895Da1

##### Chain: MegaETH

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed):

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed):

##### Short Description (to be shown on DefiLlama): Fully on-chain competitive last-clicker-wins game on MegaETH with integrated swap & bridge aggregator.

##### Token address and ticker if any: N/A

##### Category (full list at https://defillama.com/categories) *Please choose only one: Gaming

##### Oracle Provider(s): None — game uses on-chain pseudo-randomness (block.timestamp, block.prevrandao, nonce) for end-game probability.

##### Implementation Details: No external oracle. End-game probability escalates based on click count using keccak256 hash of block data and internal nonce.

##### Documentation/Proof: Contract source verified on MegaETH Explorer — https://mega.etherscan.io/address/0x051B5a8B20F3e49E073Cf7A37F4fE2e5117Af3b6#code

##### forkedFrom (Does your project originate from another project): No — original game mechanic built from scratch.

##### methodology (what is being counted as fees, how are fees being calculated):

**Fee structure:**
Every click costs 0.001 ETH. On each click, 15% (0.00015 ETH) is taken as protocol fee. The remaining 85% goes to the pot.

When a game ends, the pot is split: 85% to the winner, 15% to the protocol treasury.

**Dimensions provided:**
- `dailyUserFees`: Total ETH spent by players (number of clicks × 0.001 ETH)
- `dailyFees`: Protocol fees — 15% of each click + 15% of each pot at game end
- `dailyRevenue`: Same as dailyFees — all protocol fees go to treasury for monthly USDm distributions

**Events used:**
- `Clicked(uint256 indexed round, address indexed player, string username, uint256 clickNumber, uint256 potAfter, bool usedCredit)`
- `GameEnded(uint256 indexed round, address indexed winner, string winnerName, uint256 prize, uint256 totalClicks, uint256 totalPot)`

**Smart contracts (verified Feb 19, 2026):**
- Game: `0x051B5a8B20F3e49E073Cf7A37F4fE2e5117Af3b6`
- Profiles: `0x9F0708145BCCD1F5B16F610cB8a75A63fA4A9a24`

##### Github org/user (Optional, if your code is open source, we can track activity): isonips

##### Does this project have a referral program? Yes — 5% perpetual referral earnings on every click made by referred players.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds fee tracking for Megamble on MegaETH: computes daily totals for user gas fees (direct clicks), protocol fees (15% of user spend), and splits revenue into dailyRevenue (10%) and dailySupplySideRevenue (5%), with aggregated daily metrics for reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->