### PR TITLE
Fix Hyperliquid fees to include all token types

### DIFF
--- a/helpers/hyperliquid.ts
+++ b/helpers/hyperliquid.ts
@@ -300,7 +300,7 @@ export async function queryHyperliquidIndexer(
     // add fees from perps trading
     for (const [coin, fees] of Object.entries(item.perpsFeeByTokens)) {
       if (CoinGeckoMaps[coin]) {
-        dailyPerpRevenue.addCGToken(CoinGeckoMaps[coin], fees);
+        dailyPerpRevenue.addCGToken(CoinGeckoMaps[coin], Number(fees || 0));
       }
     }
 


### PR DESCRIPTION
## Summary
- Perp fees, builder fees, and builder code revenue were only counting USDC — missing USDT0, USDH, USDA, USDE, etc.
- Now iterates all tokens in `perpsFeeByTokens`, builder `feeByTokens`, and `fetchBuilderCodeRevenue` via `CoinGeckoMaps`, matching how spot fees already worked.
- Added USDA to `CoinGeckoMaps`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved revenue and fee calculation accuracy by iterating over per-token fee data and including only recognized tokens in metrics.

* **New Features**
  * Added support for USDA (angle-usd) price mapping so USDA-denominated fees are included in revenue tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->