### PR TITLE
Add B402 fees adapter (Base)

### DIFF
--- a/fees/b402.ts
+++ b/fees/b402.ts
@@ -1,50 +1,37 @@
 import { FetchOptions, SimpleAdapter } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
+import { addTokensReceived } from "../helpers/token";
+import ADDRESSES from "../helpers/coreAssets.json";
 
 const FEE_COLLECTOR = "0x2dBe91FF25ABd5419435656a7bccD269EC358Ea4";
-const USDC = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913";
 
-const addressToTopic = (addr: string) =>
-  "0x" + addr.slice(2).toLowerCase().padStart(64, "0");
+const fetch = async (options: FetchOptions) => {
+    const dailyFees = options.createBalances();
 
-const fetch = async ({ createBalances, getLogs }: FetchOptions) => {
-  const dailyFees = createBalances();
+    await addTokensReceived({ options, target: FEE_COLLECTOR, balances: dailyFees, token: ADDRESSES.base.USDC })
 
-  const logs = await getLogs({
-    target: USDC,
-    eventAbi:
-      "event Transfer(address indexed from, address indexed to, uint256 value)",
-    topics: [null as any, null as any, addressToTopic(FEE_COLLECTOR)],
-  });
-
-  for (const log of logs) {
-    dailyFees.add(USDC, log.value);
-  }
-
-  return {
-    dailyFees,
-    dailyUserFees: dailyFees,
-    dailyRevenue: dailyFees,
-    dailyProtocolRevenue: dailyFees,
-  };
+    return {
+        dailyFees,
+        dailyUserFees: dailyFees,
+        dailyRevenue: dailyFees,
+        dailyProtocolRevenue: dailyFees,
+    };
 };
 
 const methodology = {
-  Fees: "Tiered fees on private shielded transactions: $0.05 base + 0.05% (<$1k), 0.08% ($1k-$10k), 0.10% (>$10k). Collected as USDC transfers to fee collector at shield time.",
-  UserFees: "All fees are paid by users performing private shielded transactions.",
-  Revenue: "100% of fees are protocol revenue.",
-  ProtocolRevenue: "B402 receives 100% of collected fees.",
+    Fees: "Tiered fees on private shielded transactions: $0.05 base + 0.05% (<$1k), 0.08% ($1k-$10k), 0.10% (>$10k). Collected as USDC transfers to fee collector at shield time.",
+    UserFees: "All fees are paid by users performing private shielded transactions.",
+    Revenue: "100% of fees are protocol revenue.",
+    ProtocolRevenue: "B402 receives 100% of collected fees.",
 };
 
 const adapter: SimpleAdapter = {
-  version: 2,
-  adapter: {
-    [CHAIN.BASE]: {
-      fetch,
-      start: "2026-02-20",
-    },
-  },
-  methodology,
+    version: 2,
+    pullHourly: true,
+    fetch,
+    chains: [CHAIN.BASE],
+    start: "2026-02-20",
+    methodology,
 };
 
 export default adapter;


### PR DESCRIPTION
## Summary
- Adds fee tracking for B402 on Base
- Tracks USDC transfers to fee collector (`0x2dBe91FF25ABd5419435656a7bccD269EC358Ea4`) via ERC-20 Transfer events
- Tiered fee structure: $0.05 base + 0.05% (<$1k), 0.08% ($1k-$10k), 0.10% (>$10k)
- Fee collection started 2026-02-20

## Links
- Website: https://b402.ai
- Fee collector: https://basescan.org/address/0x2dBe91FF25ABd5419435656a7bccD269EC358Ea4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Fee tracking for the BASE chain: provides daily fees, daily user fees, daily revenue, and daily protocol revenue.
  * Data collection starts 2026-02-20 and supports hourly pulls.
  * Includes documented methodology describing how fees, user fees, revenue, and protocol revenue are calculated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->