### PR TITLE
feat: add fees tracking to Gate Perps adapter

### DIFF
--- a/dexs/gate-perps.ts
+++ b/dexs/gate-perps.ts
@@ -17,6 +17,7 @@ async function fetchGateData(dateString: string): Promise<any> {
 
   return {
     dailyVolume: data.volume,
+    dailyFees: data.fees,
   };
 }
 


### PR DESCRIPTION
This PR adds fee tracking for the Gate Perps DEX adapter.

Data source:
https://api.gateperps.com/api/v4/dex_futures/usdt/contract_stats/defillama?date=%s&broker=aden

The endpoint returns:
{
  volume: number,
  fees: number
}

The adapter now returns:
- dailyVolume
- dailyFees

Start date: 2025-10-15