### PR TITLE
Add skipBreakdownValidation flag to multiple adapters

### DIFF
--- a/fees/1dex/index.ts
+++ b/fees/1dex/index.ts
@@ -33,6 +33,7 @@ const adapter: SimpleAdapter = {
   fetch,
   start: "2025-04-26",
   runAtCurrTime: true,
+  skipBreakdownValidation: true, // because cost are not clear
   methodology,
   breakdownMethodology,
 };

--- a/fees/arrakis-v2/index.ts
+++ b/fees/arrakis-v2/index.ts
@@ -44,10 +44,8 @@ const contracts: IAddress = {
   },
 };
 
-async function getVaultsFees(
-  { api, fromApi, toApi, createBalances }: FetchOptions,
-  { helper, factory }: IVault
-) {
+async function fetch({ chain, api, fromApi, toApi, createBalances }: FetchOptions) {
+  const { helper, factory } = contracts[chain];
   const dailyFees = createBalances();
 
   const limit = await api.call({ target: factory, abi: abi.numVaults });
@@ -105,14 +103,11 @@ const breakdownMethodology = {
 
 const adapter: Adapter = {
   version: 2,
-  adapter: {
-    [CHAIN.ETHEREUM]: {
-      fetch: (options: FetchOptions) =>
-        getVaultsFees(options, contracts[CHAIN.ETHEREUM]),
-      start: '2023-08-26',
-    },
-  },
+  fetch,
+  chains: [CHAIN.ETHEREUM],
+  start: '2023-08-26',
   methodology,
+  skipBreakdownValidation: true, // because cost are not clear
   breakdownMethodology,
 };
 

--- a/fees/baker-dao/index.ts
+++ b/fees/baker-dao/index.ts
@@ -38,6 +38,7 @@ const breakdownMethodology = {
 const adapter: Adapter = {
   version: 2,
   chains: [CHAIN.BERACHAIN],
+  skipBreakdownValidation: true, // because cost are not clear
   fetch,
   start: '2025-03-17',
   pullHourly: true,

--- a/fees/bancor-v2.ts
+++ b/fees/bancor-v2.ts
@@ -21,6 +21,7 @@ async function fetch(fetchOptions: FetchOptions) {
 const adapter: SimpleAdapter = {
   version: 2,
   pullHourly: true,
+  skipBreakdownValidation: true, // because cost are not clear
   chains: [CHAIN.ETHEREUM],
   fetch,
   start: '2020-06-20',

--- a/fees/beraborrow/index.ts
+++ b/fees/beraborrow/index.ts
@@ -131,7 +131,7 @@ async function getCollateralVaults(options: FetchOptions): Promise<{[key: string
   return vaults
 }
 
-const fetchFees = async (options: FetchOptions) => {
+const fetch = async (options: FetchOptions) => {
   const dailyFees = options.createBalances();
 
   // get vaults and assets
@@ -315,13 +315,11 @@ const breakdownMethodology = {
 
 const adapter: SimpleAdapter = {
   version: 2,
+  skipBreakdownValidation: true, // because cost are not clear
   pullHourly: true,
-  adapter: {
-    [CHAIN.BERACHAIN]: {
-      fetch: fetchFees,
-      start: "2025-02-14",
-    },
-  },
+  fetch,
+  chains: [CHAIN.BERACHAIN],
+  start: "2025-02-14",
   methodology,
   breakdownMethodology,
 };

--- a/fees/hop-protocol.ts
+++ b/fees/hop-protocol.ts
@@ -127,6 +127,7 @@ const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
 
 const adapter: SimpleAdapter = {
   version: 2,
+  skipBreakdownValidation: true, // because cost are not clear
   adapter: {
     [CHAIN.ARBITRUM]: { fetch, start: '2023-01-01' },
     [CHAIN.BASE]: { fetch, start: '2023-01-01' },

--- a/helpers/balancer.ts
+++ b/helpers/balancer.ts
@@ -109,8 +109,17 @@ type BalancerFeesChainConfig = {
   holderRevenueRatio?: number;
 }
 
+function hasRevenueRatio(config: BalancerFeesChainConfig) {
+  return (
+    config.revenueRatio != null ||
+    config.protocolRevenueRatio != null ||
+    config.holderRevenueRatio != null
+  )
+}
+
 function balancerFeesExports(config: IJSON<BalancerFeesChainConfig>, overrides?: Partial<SimpleAdapter>) {
   const exportObject: BaseAdapter = {}
+  const anyChainHasRevenueRatio = Object.values(config).some(hasRevenueRatio)
   Object.entries(config).map(([chain, chainConfig]) => {
     exportObject[chain] = {
       fetch: getFeesExport(chainConfig.vault, {
@@ -121,7 +130,13 @@ function balancerFeesExports(config: IJSON<BalancerFeesChainConfig>, overrides?:
       start: chainConfig.start,
     }
   })
-  return { version: 2, adapter: exportObject, pullHourly: true, ...overrides } as SimpleAdapter
+  return {
+    version: 2,
+    adapter: exportObject,
+    pullHourly: true,
+    ...(anyChainHasRevenueRatio ? {} : { skipBreakdownValidation: true }),
+    ...overrides,
+  } as SimpleAdapter
 }
 
 const balancerEntries: Record<string, any> = {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Multiple protocol fee adapters now gracefully handle cases where fee structures are undefined by skipping strict validation (1dex, Arrakis V2, Baker DAO, Bancor V2, Beraborrow, Hop Protocol).
  * Improved revenue ratio detection in Balancer adapter configuration.

* **Chores**
  * Streamlined adapter configuration structure for better maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->