### PR TITLE
Mark sudo finance dead

### DIFF
--- a/dexs/sudofinance/index.ts
+++ b/dexs/sudofinance/index.ts
@@ -27,6 +27,7 @@ const adapter: SimpleAdapter = {
   chains: [CHAIN.SUI],
   fetch,
   start: '2024-01-05',
+  deadFrom: '2026-01-01', //migrated to zo 
 };
 
 export default adapter;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Sudo Finance adapter metadata to indicate the service will be migrated effective January 1, 2026.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->