### PR TITLE
feat(aden): remove acquisition date restriction and deadFrom

### DIFF
--- a/fees/aden/index.ts
+++ b/fees/aden/index.ts
@@ -25,8 +25,7 @@ import fetchURL from "../../utils/fetchURL";
 // }
 
 async function fetch(_a: any, _b: any, options: FetchOptions): Promise<any> {
-  const aquisitionDate = +new Date('2025-11-12') / 1000
-  if (options.chain !== CHAIN.GATE_LAYER ||  options.startOfDay > aquisitionDate) {
+  if (options.chain !== CHAIN.GATE_LAYER) {
     return {
       dailyVolume: 0,
       dailyFees: 0,
@@ -48,7 +47,7 @@ async function fetch(_a: any, _b: any, options: FetchOptions): Promise<any> {
   const dailyVolume = options.createBalances();
   const dailyHoldersRevenue = options.createBalances();
 
-  dailyFees.addUSDValue(Number(data.fees), 'Builder fees');
+  dailyFees.addUSDValue(Number(data.fees), "Builder fees");
   dailyVolume.addUSDValue(Number(data.volume));
 
   return {
@@ -68,7 +67,8 @@ const methodology = {
 
 const breakdownMethodology = {
   Fees: {
-    "Builder fees": "Fees collected from perpetual trading on Gate Layer Network, charged at 0.4 basis points on taker volume",
+    "Builder fees":
+      "Fees collected from perpetual trading on Gate Layer Network, charged at 0.4 basis points on taker volume",
   },
 };
 
@@ -77,8 +77,7 @@ const adapter: SimpleAdapter = {
   fetch,
   chains: [CHAIN.GATE_LAYER, CHAIN.ORDERLY, CHAIN.OFF_CHAIN],
   doublecounted: true,
-  start: '2025-07-19',
-  deadFrom: '2026-03-08',  // aquired by gate
+  start: "2025-07-19",
   methodology,
   breakdownMethodology,
 };


### PR DESCRIPTION
- Remove aquisitionDate check that limited data to pre-acquisition dates
- Remove deadFrom field (was set to 2026-03-08 for Gate acquisition)
- Minor formatting: normalize string quotes

**NOTE**

#### Please enable "Allow edits by maintainers" while putting up the PR.

This PR updates the Aden fees adapter after the Gate acquisition:
Remove acquisition date restriction — Dropped the aquisitionDate check (2025-11-12) that limited data to pre-acquisition dates. The adapter now returns fees for all dates on Gate Layer instead of returning zeros for dates after the acquisition.
Remove deadFrom field — Removed deadFrom: "2026-03-08" that was added for the Gate acquisition. The protocol is no longer marked as deprecated.
Formatting — Normalized string quotes to double quotes and adjusted line breaks in breakdownMethodology.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Simplified fee adapter logic by removing restrictive conditions, improving the availability of fee calculation data across broader network scenarios.
  * Updated adapter configuration by standardizing value formatting and removing legacy date-related metadata properties for improved code clarity.

* **Style**
  * Corrected string literal formatting in fee calculation logging for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->