### PR TITLE
Orca blacklist pool

### DIFF
--- a/dexs/orca/index.ts
+++ b/dexs/orca/index.ts
@@ -16,6 +16,7 @@ const CONFIG: any = {
         url: statsApiEndpoint,
         blacklistedPools: [
           'EhNTpT8mAi2M9RcKkyEQLh9t9EbhyNKEcnsPAM6qCYEQ', // bad pool very low liquidity
+          '7NYhunVC9ASsrwvEC2hPTEzeZAFC5PDjDnS4M3qkY7Mw', // no liquidity(1.8E19 BTC per WBTC)
         ],
     },
     [CHAIN.ECLIPSE]: {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Added a Solana pool to the exclusion list, preventing it from appearing in metric calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->