### PR TITLE
feat(dexs): add Velox DEX adapter

### DIFF
--- a/dexs/velox/index.ts
+++ b/dexs/velox/index.ts
@@ -1,0 +1,51 @@
+import { SimpleAdapter, FetchOptions } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+
+const FACTORY_ADDRESS = "0xa28dBAE4D926067F4c343aA8071e833b04C8b99E";
+const PAIR_ADDRESS = "0x07597448E67374D5F4dcc63CA3703f44369bE112";
+
+const pairAbi = {
+  "Swap": "event Swap(address indexed sender, uint amount0In, uint amount1In, uint amount0Out, uint amount1Out, address indexed to)"
+};
+
+const fetch = async (options: FetchOptions) => {
+  const dailyVolume = options.createBalances();
+  
+  const logs = await options.getLogs({
+    target: PAIR_ADDRESS,
+    eventAbi: pairAbi.Swap,
+  });
+
+  logs.forEach((log: any) => {
+    const amount0In = log.amount0In;
+    const amount1In = log.amount1In;
+
+    if (amount0In > 0) {
+      dailyVolume.add("base:0x4200000000000000000000000000000000000006", amount0In);
+    }
+    if (amount1In > 0) {
+      dailyVolume.add("base:0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913", amount1In);
+    }
+  });
+
+  return {
+    dailyVolume,
+  };
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  adapter: {
+    [CHAIN.BASE]: {
+      fetch,
+      start: "2026-03-08",
+      meta: {
+        methodology: {
+          Volume: "Sum of all swap input amounts from Swap events on the Velox DEX pair contracts",
+        },
+      },
+    },
+  },
+};
+
+export default adapter;


### PR DESCRIPTION
## Summary
- Adds Velox DEX adapter for the dexs dashboard
- Velox is a Uniswap V2 fork on Base with 0.01% swap fee

## Contract Addresses (Base Mainnet)
| Contract | Address |
|----------|---------|
| Factory | `0xa28dBAE4D926067F4c343aA8071e833b04C8b99E` |
| Router | `0x47a76Cf3cE4ba9Ce8619e1b7aBa5d6817B5Ffc29` |
| WETH/USDC Pair | `0x07597448E67374D5F4dcc63CA3703f44369bE112` |

## Dimensions Tracked
- `dailyVolume`: Sum of swap input amounts from Swap events

## Test Results
```
npm test dexs velox
```
Adapter runs successfully and fetches Swap events from the pair contract.

## Links
- BaseScan Factory: https://basescan.org/address/0xa28dBAE4D926067F4c343aA8071e833b04C8b99E
- BaseScan Pair: https://basescan.org/address/0x07597448E67374D5F4dcc63CA3703f44369bE112

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Integrated Velox DEX adapter for BASE chain with daily volume metrics aggregation from swap events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->