### PR TITLE
fix near intents' fees

### DIFF
--- a/fees/near-intents/index.ts
+++ b/fees/near-intents/index.ts
@@ -60,9 +60,9 @@ const adapter: SimpleAdapter = {
     },
     methodology: {
         Fees: "Total fees collected by NEAR Intents platform.",
-        SupplySideRevenue: "Part of fees recieved by near intent partners",
-        Revenue: "Revenue collected by NEAR Intents platform",
-        ProtocolRevenue: "Revenue collected by NEAR Intents platform"
+        SupplySideRevenue: "Part of fees recieved by NEAR Intents' partners.",
+        Revenue: "Revenue collected by NEAR Intents platform.",
+        ProtocolRevenue: "All the revenue goes to the protocol treasury."
     },
 };
 


### PR DESCRIPTION
1. Previous endpoint gave internal server error

2. Fee split isnt exactly 50% each, only distribution fees are split 50%

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switched to new revenue.near.org data sources and separated fee vs. revenue inputs for improved accuracy.
  * Updated calculations and now return distinct dailyFees, dailySupplySideRevenue, dailyRevenue, and dailyProtocolRevenue fields.
* **Documentation**
  * Updated public methodology text to reflect new terminology and how revenues/supply-side revenue are reported.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->