### PR TITLE
Add TideSwap adapters: DEX volume, fees, aggregator (Ink L2)

### DIFF
--- a/aggregators/tideswap/index.ts
+++ b/aggregators/tideswap/index.ts
@@ -24,11 +24,19 @@ const fetch = async (options: FetchOptions) => {
     dailyVolume.add(token, BigInt(amount) * BigInt(10000) / BigInt(FEE_BPS));
   }
 
-  return { dailyVolume };
+  return {
+    dailyVolume,
+    dailyFees,
+    dailyRevenue: dailyFees,
+    dailyProtocolRevenue: dailyFees,
+  };
 };
 
 const methodology = {
   Volume: "Aggregated swap volume on Ink L2, back-calculated from the 0.05% integrator fee collected by the TideSwap treasury on 0x-routed swaps.",
+  Fees: "TideSwap charges a 0.05% integrator fee on swaps routed through 0x. LI.FI-routed swaps have no TideSwap fee.",
+  Revenue: "100% of fees go to the TideSwap treasury (Gnosis Safe).",
+  ProtocolRevenue: "All revenue is protocol revenue.",
 };
 
 const adapter: SimpleAdapter = {


### PR DESCRIPTION
##### Name (to be shown on DefiLlama):
TideSwap

##### Twitter Link:
https://x.com/TideSwapInk

##### List of audit links if any:
Unmodified Uniswap V2 contracts (battle-tested since 2020)

##### Website Link:
https://tideswap.app

##### Logo (High resolution, will be shown with rounded borders):
Already listed via TVL adapter (DefiLlama-Adapters #18234)

##### Current TVL:
$66 (early stage, pools recently seeded)

##### Treasury Addresses (if the protocol has treasury)
0x647128722e6aC0FDF10C1c5bEB9d37C66cE6f907 (Gnosis Safe on Ink)

##### Chain:
Ink (57073)

##### Coingecko ID:


##### Coinmarketcap ID:


##### Short Description (to be shown on DefiLlama):
Meta-aggregator DEX on Ink L2 comparing 0x, LI.FI, and native Uniswap V2 pools

##### Token address and ticker if any:


##### Category:
Dexes

##### Oracle Provider(s):
N/A (AMM uses constant product formula)

##### Implementation Details:
N/A

##### Documentation/Proof:
https://tideswap.app/docs

##### forkedFrom:
Uniswap V2

##### methodology:
DEX volume: Swap events from Uniswap V2 pools via uniV2Exports. Fees: 0.05% integrator fee on 0x-routed swaps tracked via treasury token transfers. Aggregator volume: back-calculated from treasury fees.

##### Github org/user:
Cryptodian1

##### Does this project have a referral program?
No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Restructured Tideswap adapter with simplified configuration.
  * Updated adapter output to return daily volume data only.
  * Removed unused code paths and improved overall code structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->