### PR TITLE
Add surf-liquid volume and fees/revenue adapters

### DIFF
--- a/fees/surf-liquid.ts
+++ b/fees/surf-liquid.ts
@@ -125,14 +125,14 @@ const fetch = async (options: FetchOptions) => {
     if (shares === 0n) continue;
 
     const idx = morphoVaultIndex.get(morphoVault)!;
-    const endAssetsValue =
-      BigInt(endSupply[idx] || "1") > 0n
-        ? (shares * BigInt(endAssets[idx] || "0")) / BigInt(endSupply[idx] || "1")
-        : 0n;
-    const startAssetsValue =
-      BigInt(startSupply[idx] || "1") > 0n
-        ? (shares * BigInt(startAssets[idx] || "0")) / BigInt(startSupply[idx] || "1")
-        : 0n;
+    const endSupplyBig = BigInt(endSupply[idx] ?? "0");
+    const endAssetsValue = endSupplyBig > 0n
+      ? (shares * BigInt(endAssets[idx] ?? "0")) / endSupplyBig
+      : 0n;
+    const startSupplyBig = BigInt(startSupply[idx] ?? "0");
+    const startAssetsValue = startSupplyBig > 0n
+      ? (shares * BigInt(startAssets[idx] ?? "0")) / startSupplyBig
+      : 0n;
     const yieldAmount = endAssetsValue > startAssetsValue ? endAssetsValue - startAssetsValue : 0n;
 
     if (yieldAmount <= 0n) continue;


### PR DESCRIPTION
## Summary
- **Volume adapter** (`dexs/surf-liquid.ts`): Tracks total capital flow through Surf Liquid protocol including vault deposits, withdrawals, and rebalances across V1/V2/V3 vaults, SURF staking events, and CreatorBid subscriptions
- **Fees/Revenue adapter** (`fees/surf-liquid.ts`): Tracks protocol fees used for SURF token buybacks via the buyback wallet

## Test results
- Daily volume: ~$247k (Feb 28), ~$84k (Nov 30), ~$9k (Jan 14)
- Daily fees/revenue: ~$573 (Mar 10), ~$5 (Feb 26) — buybacks are batched, not daily

## Contracts
- V1 Vaults: 10 hardcoded addresses (no factory)
- V2 Factory: `0x1D283b668F947E03E8ac8ce8DA5505020434ea0E` (Base)
- V3 Factory: `0xf1d64dee9f8e109362309a4bfbb523c8e54fa1aa` (Base)
- SURF Staking: `0xB0fDFc081310A5914c2d2c97e7582F4De12FA9d6` (Base)
- SURF Token: `0xcdca2eaae4a8a6b83d7a3589946c2301040dafbf` (Base)
- Buyback Wallet: `0x8b4D9e217F7dd65a423ea465E2699eB08b82Ca7d` (Base)

## Methodology
- **Volume**: Sum of all deposit, withdrawal, rebalance, staking, and CreatorBid event amounts (denominated in their native tokens: USDC, WETH, cbBTC, SURF)
- **Fees/Revenue**: All tokens received by the buyback wallet, representing protocol revenue used to buy back SURF tokens

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for tracking SURF buyback liquidity revenue on the BASE chain with per-allocation yield calculations and a 10% performance fee applied.
  * Provides daily breakdowns of fees, protocol revenue (reported as zero), holders revenue, and supply-side revenue; ships as a v2 adapter starting 2025-10-01 with embedded methodology metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->