### PR TITLE
Add revenue split, methodology and mark bsquared as dead on kiloex

### DIFF
--- a/fees/kiloex/index.ts
+++ b/fees/kiloex/index.ts
@@ -28,8 +28,10 @@ const fetch = (chainId: string) => {
     const dayTimestamp = getUniqStartOfTodayTimestamp(new Date(timestamp * 1000))
     const fees: IFee[] = (await fetchURL(endpoints[chainId]));
 
-    const dailyFees = Number(fees
-      .find(item => item.time === dayTimestamp)?.dayTradeFee)
+    const record = fees.find(item => item.time === dayTimestamp)
+    if (!record) return {}
+
+    const dailyFees = Number(record.dayTradeFee)
     const dailyRevenue = dailyFees * 0.7
     const dailySupplySideRevenue = dailyFees * 0.3
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added daily revenue, supply-side revenue, and protocol revenue metrics to Kiloex fee reporting
  * Added revenue calculation methodology documentation

* **Bug Fixes**
  * Fetch now safely handles missing daily records by returning no data instead of failing

* **Chores**
  * Updated fee data shape and calculations
  * Added lifecycle date for BSQUARED chain configuration
<!-- end of auto-generated comment: release notes by coderabbit.ai -->