### PR TITLE
add: affluent fees data

### DIFF
--- a/fees/affluent/index.ts
+++ b/fees/affluent/index.ts
@@ -5,6 +5,8 @@ import { FetchOptions, SimpleAdapter } from "../../adapters/types";
 
 const API_URL = "https://api.affluent.org/v2/api/protocol/financials";
 
+const toUsd = (value: any) => Number(value ?? 0);
+
 type DailyHistory = {
     timestamp: number;
     grossRevenueBorrowInterest: number;
@@ -52,15 +54,15 @@ const fetch = async (_a: any, _b: any, options: FetchOptions) => {
         };
     }
 
-    dailyFees.addUSDValue(dayData.grossRevenueBorrowInterest, METRIC.BORROW_INTEREST);
-    dailyFees.addUSDValue(dayData.grossRevenueVaultYield, METRIC.ASSETS_YIELDS);
-    dailyFees.addUSDValue(dayData.grossRevenueLiquidationFee, METRIC.LIQUIDATION_FEES);
+    dailyFees.addUSDValue(toUsd(dayData.grossRevenueBorrowInterest), METRIC.BORROW_INTEREST);
+    dailyFees.addUSDValue(toUsd(dayData.grossRevenueVaultYield), METRIC.ASSETS_YIELDS);
+    dailyFees.addUSDValue(toUsd(dayData.grossRevenueLiquidationFee), METRIC.LIQUIDATION_FEES);
 
-    dailySupplySideRevenue.addUSDValue(dayData.costOfRevenueBorrowInterestPaidToLender, METRIC.BORROW_INTEREST);
-    dailySupplySideRevenue.addUSDValue(dayData.costOfRevenueVaultYieldPaidToDepositor, METRIC.ASSETS_YIELDS);
-    dailySupplySideRevenue.addUSDValue(dayData.costOfRevenueVaultLiquidationFeePaidToLiquidator, METRIC.LIQUIDATION_FEES);
+    dailySupplySideRevenue.addUSDValue(toUsd(dayData.costOfRevenueBorrowInterestPaidToLender), METRIC.BORROW_INTEREST);
+    dailySupplySideRevenue.addUSDValue(toUsd(dayData.costOfRevenueVaultYieldPaidToDepositor), METRIC.ASSETS_YIELDS);
+    dailySupplySideRevenue.addUSDValue(toUsd(dayData.costOfRevenueVaultLiquidationFeePaidToLiquidator), METRIC.LIQUIDATION_FEES);
 
-    dailyRevenue.addUSDValue(dayData.grossProfit);
+    dailyRevenue.addUSDValue(toUsd(dayData.grossProfit));
 
     return {
         dailyFees,


### PR DESCRIPTION
https://defillama.com/protocol/affluent

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Affluent adapter for the TON chain to track daily financial metrics. Aggregates protocol fees and revenue from borrowing interest, vault yields, and liquidation fees. Simultaneously tracks supply-side revenue distributions to lenders, depositors, and liquidators. Delivers comprehensive daily financial visibility and accounting transparency for measuring protocol performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->