### PR TITLE
Add PayoutBatchCompleted event query for the v2 on-chain payout contract alongside the existing v1 payment_vault DepositEvent query, preserving all historical revenue data.

### DIFF
--- a/fees/czt.ts
+++ b/fees/czt.ts
@@ -5,15 +5,18 @@ import { queryDuneSql } from "../helpers/dune";
 // ─── Contract addresses ────────────────────────────────────────────────────
 // v1 — old payment_vault contract (historical, Feb 2026 – ~Mar 2026)
 const VAULT_ADDRESS_V1 =
-  "0x982577d229191b0227cf90574c2be5bf842a73f4728f7386f7402420123fb4a6";
+    "0x982577d229191b0227cf90574c2be5bf842a73f4728f7386f7402420123fb4a6";
 
 // v2 — creator_payout module (CompanionzAI payout contract, deployed Mar 2026)
 const PAYOUT_CONTRACT_ADDRESS = "0xfdeec7040478f26c48ed0b58b45153f593d8df7f45eea0b6f7c1f9b6df000967";
 
+const V1_LAST_TXN_DATE = "2026-03-01"
+const V2_DEPLOYED_DATE = "2026-03-15"
+
 const fetch = async (_a: any, _b: any, options: FetchOptions) => {
-  // ── v1: DepositEvent from old payment_vault ────────────────────────────
-  // Covers all historical revenue up until v1 contract was superseded.
-  const queryV1 = `
+    // ── v1: DepositEvent from old payment_vault ────────────────────────────
+    // Covers all historical revenue up until v1 contract was superseded.
+    const queryV1 = `
     SELECT
       COALESCE(SUM(CAST(JSON_EXTRACT_SCALAR(data, '$.amount') AS DOUBLE)) / 1e6, 0) AS revenue
     FROM aptos.events
@@ -22,15 +25,15 @@ const fetch = async (_a: any, _b: any, options: FetchOptions) => {
       AND block_time < from_unixtime(${options.endTimestamp})
   `;
 
-  // ── v2: PayoutBatchCompleted from creator_payout module ───────────────
-  // Each on-chain payout settlement emits one PayoutBatchCompleted event
-  // with total_usdt_micro = total USDT (6 decimals) sent to creators that day.
-  // This represents the protocol's daily creator revenue settled on-chain.
-  //
-  // NOTE: The v2 adapter also tracks individual payment inscriptions via
-  // PayoutInscription events, but summing PayoutBatchCompleted is sufficient
-  // and cheaper for DeFiLlama indexing (one event per daily batch).
-  const queryV2 = `
+    // ── v2: PayoutBatchCompleted from creator_payout module ───────────────
+    // Each on-chain payout settlement emits one PayoutBatchCompleted event
+    // with total_usdt_micro = total USDT (6 decimals) sent to creators that day.
+    // This represents the protocol's daily creator revenue settled on-chain.
+    //
+    // NOTE: The v2 adapter also tracks individual payment inscriptions via
+    // PayoutInscription events, but summing PayoutBatchCompleted is sufficient
+    // and cheaper for DeFiLlama indexing (one event per daily batch).
+    const queryV2 = `
     SELECT
       COALESCE(SUM(CAST(JSON_EXTRACT_SCALAR(data, '$.total_usdt_micro') AS DOUBLE)) / 1e6, 0) AS revenue
     FROM aptos.events
@@ -39,36 +42,40 @@ const fetch = async (_a: any, _b: any, options: FetchOptions) => {
       AND block_time < from_unixtime(${options.endTimestamp})
   `;
 
-  const [resultsV1, resultsV2] = await Promise.all([
-    queryDuneSql(options, queryV1),
-    queryDuneSql(options, queryV2),
-  ]);
+    if (options.dateString > V1_LAST_TXN_DATE && options.dateString < V2_DEPLOYED_DATE) {
+        return {
+            dailyFees: 0,
+            dailyRevenue: 0,
+            dailyProtocolRevenue: 0,
+        };
+    }
 
-  const revenueV1 = Number(resultsV1[0]?.revenue ?? 0);
-  const revenueV2 = Number(resultsV2[0]?.revenue ?? 0);
-  const dailyRevenue = revenueV1 + revenueV2;
+    const duneQuery = options.dateString >= V2_DEPLOYED_DATE ? queryV2 : queryV1;
 
-  return {
-    dailyFees: dailyRevenue,
-    dailyRevenue: dailyRevenue,
-    dailyProtocolRevenue: dailyRevenue,
-  };
+    const results = await queryDuneSql(options, duneQuery);
+    const revenue = results[0].revenue;
+
+    return {
+        dailyFees: revenue,
+        dailyRevenue: revenue,
+        dailyProtocolRevenue: revenue,
+    };
 };
 
 const methodology = {
-  Fees: "All USDT payments from users subscribing to AI character content on CompanionzAI",
-  Revenue: "100% of user payments are protocol revenue, distributed daily to character creators",
-  ProtocolRevenue: "Daily USDT settled on-chain to creator wallets via the payout contract",
+    Fees: "All USDT payments from users subscribing to AI character content on CompanionzAI",
+    Revenue: "100% of user payments are protocol revenue, distributed daily to character creators",
+    ProtocolRevenue: "Daily USDT settled on-chain to creator wallets via the payout contract",
 };
 
 const adapter: Adapter = {
-  version: 1,
-  dependencies: [Dependencies.DUNE],
-  fetch,
-  chains: [CHAIN.APTOS],
-  start: "2026-02-15",
-  methodology,
-  isExpensiveAdapter: true,
+    version: 1,
+    dependencies: [Dependencies.DUNE],
+    fetch,
+    chains: [CHAIN.APTOS],
+    start: "2026-02-15",
+    methodology,
+    isExpensiveAdapter: true,
 };
 
 export default adapter;


### PR DESCRIPTION
**NOTE**

#### Please enable "Allow edits by maintainers" while putting up the PR.

---

> - If you would like to add a `tvl` adapter please submit the PR [here](https://github.com/DefiLlama/DefiLlama-Adapters).

1. Once your adapter has been merged, it takes time to show on the UI. If more than 24 hours have passed, please let us know in Discord.
2. Please fill the form below **only if the PR is for listing a new protocol** else it can be ignored/replaced with reason/details about the PR
3. **For updating listing info** It is a different repo, you can find your listing in this file: https://github.com/DefiLlama/defillama-server/blob/master/defi/src/protocols/data4.ts, you can edit it there and put up a PR
4. Do not edit/push `package.json/package-lock.json` file as part of your changes
5. No need to go to our discord/other channel and announce that you've created a PR, we monitor all PRs and will review it asap

---

**NOTE:** This is an update to an existing fees/revenue adapter (CZT), not a new protocol listing. Adding v2 contract support alongside existing v1 historical data.

**Reason for PR:** CZT migrated from the original `payment_vault` contract (v1) to a new `creator_payout` contract (v2) deployed March 2026. The adapter now queries both contracts so historical v1 revenue is preserved and new v2 revenue is tracked going forward.

---

##### Name (to be shown on DefiLlama):
CZT

##### Twitter Link:
https://x.com/CZTapp

##### List of audit links if any:
None (contract deployed and tested on mainnet)

##### Website Link:
https://czt.app

##### Logo (High resolution, will be shown with rounded borders):
https://futraichat.s3.ap-south-1.amazonaws.com/random/CZLOGO.jpg

##### Current TVL:
N/A (This is a fees adapter, not a TVL adapter)

##### Treasury Addresses (if the protocol has treasury)
0x3990800eda66bc94a713537eec146975e09d6e953da7eda62df5e7a3ef00f63c

##### Chain:
Aptos

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed):

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed):

##### Short Description (to be shown on DefiLlama):
Creator revenue tracking protocol on Aptos. Enables users to subscribe to AI character content with USDT payments, with 100% of fees distributed daily to content creators on-chain.

##### Token address and ticker if any:
Uses USDT (LayerZero bridged on Aptos): `0x357b0b74bc833e95a115ad22604854d6b0fca151cecd94111770e5d6ffc9dc2b`

##### Category (full list at https://defillama.com/categories) *Please choose only one:
SoFi

##### Oracle Provider(s):
N/A (No oracle required — tracks on-chain payout events directly)

##### Implementation Details:
N/A

##### Documentation/Proof:
- v1 Contract (historical): https://explorer.aptoslabs.com/account/0x982577d229191b0227cf90574c2be5bf842a73f4728f7386f7402420123fb4a6?network=mainnet
- v2 Contract (current): https://explorer.aptoslabs.com/account/0xfdeec7040478f26c48ed0b58b45153f593d8df7f45eea0b6f7c1f9b6df000967/modules/packages/CreatorPayout?network=mainnet

##### forkedFrom (Does your project originate from another project):
None (Original implementation)

##### methodology (what is being counted as tvl, how is tvl being calculated):
**Fees Methodology:**
- v1 (Feb 2026 – Mar 2026): Tracks `DepositEvent` from the original `payment_vault` contract. Amount field is USDT in 6-decimal micro-units.
- v2 (Mar 2026 – present): Tracks `PayoutBatchCompleted` from the new `creator_payout` contract. `total_usdt_micro` field represents the total USDT settled on-chain to creators each day.
- Both queries run in parallel and are summed to produce the daily total.
- 100% of payments are counted as protocol revenue — all fees flow to content creators.

##### Github org/user (Optional, if your code is open source, we can track activity):

##### Does this project have a referral program?
No

---

## What changed

- Added `PAYOUT_CONTRACT_ADDRESS` constant pointing to the v2 `creator_payout` contract
- Added `queryV2` querying `PayoutBatchCompleted` events from the v2 contract
- Both v1 and v2 queries run in parallel via `Promise.all` and are summed
- All original v1 code, methodology, and adapter config left unchanged

## Contract Details

| | v1 | v2 |
|---|---|---|
| Address | `0x982577...fb4a6` | `0xfdeec7...0967` |
| Module | `payment_vault` | `creator_payout` |
| Event | `DepositEvent` | `PayoutBatchCompleted` |
| Field | `amount` | `total_usdt_micro` |
| Period | Feb 2026 – Mar 2026 | Mar 2026 – present |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated fee and revenue aggregation to combine two on‑chain revenue sources, returning consolidated daily figures for fees, revenue, and protocol revenue with explicit per‑source time bounds for more accurate accounting.

* **Documentation**
  * Expanded methodology and in‑app descriptions to explain dual‑source aggregation and clarified how on‑chain settlements and payouts are reflected in reported data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->