### PR TITLE
Add Kreo fees adapter

### DIFF
--- a/fees/kreo.ts
+++ b/fees/kreo.ts
@@ -31,7 +31,7 @@ const adapter: SimpleAdapter = {
   version: 2,
   pullHourly: true,
   chains: [CHAIN.POLYGON],
-  start: "2026-03-13",
+  start: "2026-03-08",
   methodology,
   fetch,
 };


### PR DESCRIPTION
## Project Name
Kreo

## Category
Fees

## Twitter
https://x.com/kreoapp

## Methodology
- Fees: Counts all inbound USDC.e transfers into Kreo's Polygon fee wallet.
- UserFees: Assumed equal to fees.
- Revenue: Assumed equal to fees.
- ProtocolRevenue: Assumed equal to fees.

## Data Sources
- Fee wallet provided directly by the Kreo team:
  - `0x96EE5C63d51e2dB627a5597BfE76da26EF6800D9`
- Polygon USDC.e token:
  - `0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174`

## Notes
- This adapter tracks inbound USDC.e transfers to the Kreo Polygon fee wallet.
- Current implementation assumes all inflows to the fee wallet are protocol fees retained by Kreo.
- Start date is set to `2026-03-13` based on team confirmation timing and can be updated if needed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Kreo protocol adapter for Polygon with automatic hourly data collection.
  * Tracks daily metrics for fees, user fees, revenue, and protocol revenue; aggregates token receipts to compute fees.
  * Active from March 13, 2026.

* **Documentation**
  * Includes a brief methodology describing data sources and aggregation approach.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->