### PR TITLE
Add CipherDLMM (Orbit Finance) volume + fees adapter

### DIFF
--- a/dexs/orbit-finance.ts
+++ b/dexs/orbit-finance.ts
@@ -62,7 +62,7 @@ const fetch = async (_a: any, _b: any, options: FetchOptions) => {
     `;
 
     const data = await queryDuneSql(options, query);
-    const dailyVolume = data[0]?.daily_volume ?? 0;
+    const dailyVolume = data[0].daily_volume;
 
     return {
         dailyVolume,


### PR DESCRIPTION
## Summary
- Adds volume and fees adapter for **CipherDLMM (Orbit Finance)** — a concentrated liquidity DLMM on Solana
- Program ID: `Fn3fA3fjsmpULNL7E9U79jKTe1KHxPtQeWdURCbJXCnM`
- Fetches 24h volume from the [Orbit DEX adapter API](https://orbit-dex.api.cipherlabsx.com/api/v1/pools), converts to USD via quote token prices
- Fees = volume × pool fee rate (`base_fee_bps / 10000`)

## Methodology
- **Volume**: Sum of 24h swap volume across all CipherDLMM pools, converted to USD
- **Fees**: Volume × per-pool fee rate

## Links
- Website: [orbitdex.io](https://orbitdex.io)
- Adapter API: `https://orbit-dex.api.cipherlabsx.com`
- Source: [github.com/Cipherlabsx/cipher-integrations](https://github.com/Cipherlabsx/cipher-integrations)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Orbit Finance DEX on Solana, providing daily USD-denominated volume and fee metrics across liquidity pools.
  * Volume is computed as the sum of per-swap USD-valued inputs; fees calculated as volume × 2% (average fee rate).
  * Methodology notes: per-swap max USD input used as volume, with dynamic weighting as additional pools participate; returns zero when no activity is found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->