### PR TITLE
Split Trends fun adapter into legacy and new curve

### DIFF
--- a/fees/trends-curve.ts
+++ b/fees/trends-curve.ts
@@ -47,12 +47,15 @@ const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
   const dataWatcherData: ICurveFeeData[] = await queryDuneSql(options, curveFeeQuery);
   const dailyFees = options.createBalances();
   const dailyProtocolRevenue = options.createBalances();
+  const dailySupplySideRevenue = options.createBalances();
 
   dataWatcherData.forEach((row) => {
     dailyFees.add(quoteMint, Number(row.total_creator_fees), metrics.CreatorFees);
     dailyFees.add(quoteMint, Number(row.total_protocol_fees), metrics.ProtocolFees);
     dailyFees.add(quoteMint, Number(row.total_referral_fees), metrics.ReferralFees);
 
+    dailySupplySideRevenue.add(quoteMint, Number(row.total_creator_fees), metrics.CreatorFees);
+    dailySupplySideRevenue.add(quoteMint, Number(row.total_referral_fees), metrics.ReferralFees);
     dailyProtocolRevenue.add(quoteMint, Number(row.total_protocol_fees), metrics.ProtocolFees);
   });
 
@@ -61,6 +64,7 @@ const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
     dailyUserFees: dailyFees,
     dailyRevenue: dailyProtocolRevenue,
     dailyProtocolRevenue,
+    dailySupplySideRevenue,
   };
 };
 
@@ -76,6 +80,7 @@ const adapter: SimpleAdapter = {
     UserFees: "Total fees paid by users on Trends",
     Revenue: "All fees collected by Trends.",
     ProtocolRevenue: "All fees collected by Trends.",
+    SupplySideRevenue: "Fee share distributed to creators and referrers.",
   },
   breakdownMethodology: {
     Fees: {
@@ -93,6 +98,10 @@ const adapter: SimpleAdapter = {
     },
     ProtocolRevenue: {
       [metrics.ProtocolFees]: 'Amount of fees paid to Trends protocol.',
+    },
+    SupplySideRevenue: {
+      [metrics.CreatorFees]: 'Creator fee share distributed by Trends.',
+      [metrics.ReferralFees]: 'Referral fee share distributed by Trends.',
     },
   }
 };

--- a/fees/trends.ts
+++ b/fees/trends.ts
@@ -138,12 +138,14 @@ const fetch = async (_a: any, _b: any, options: FetchOptions) => {
   const dammv2Data: IDammv2Data[] = await queryDuneSql(options, dammv2Query);
   const dailyFees = options.createBalances();
   const dailyProtocolRevenue = options.createBalances();
+  const dailySupplySideRevenue = options.createBalances();
 
   dbcData.forEach((row) => {
     dailyFees.add(row.quote_mint, Number(row.total_trading_fees), metrics.TradingFees);
     dailyFees.add(row.quote_mint, Number(row.total_protocol_fees), metrics.ProtocolFees);
     dailyFees.add(row.quote_mint, Number(row.total_referral_fees), metrics.ReferralFees);
-    
+
+    dailySupplySideRevenue.add(row.quote_mint, Number(row.total_referral_fees), metrics.ReferralFees);
     dailyProtocolRevenue.add(row.quote_mint, Number(row.total_protocol_fees), metrics.ProtocolFees);
   });
 
@@ -152,7 +154,9 @@ const fetch = async (_a: any, _b: any, options: FetchOptions) => {
     dailyFees.add(quote_mint, Number(row.total_partner_fees), metrics.PartnerFees);
     dailyFees.add(quote_mint, Number(row.total_protocol_fees), metrics.ProtocolFees);
     dailyFees.add(quote_mint, Number(row.total_referral_fees), metrics.ReferralFees);
-    
+
+    dailySupplySideRevenue.add(quote_mint, Number(row.total_partner_fees), metrics.PartnerFees);
+    dailySupplySideRevenue.add(quote_mint, Number(row.total_referral_fees), metrics.ReferralFees);
     dailyProtocolRevenue.add(quote_mint, Number(row.total_protocol_fees), metrics.ProtocolFees);
   });
 
@@ -161,6 +165,7 @@ const fetch = async (_a: any, _b: any, options: FetchOptions) => {
     dailyUserFees: dailyFees,
     dailyRevenue: dailyProtocolRevenue,
     dailyProtocolRevenue,
+    dailySupplySideRevenue,
   };
 };
 
@@ -175,6 +180,7 @@ const adapter: SimpleAdapter = {
     UserFees: "Total trading fees paid by users.",
     Revenue: "Fees collected by Trends, including trendor rewards.",
     ProtocolRevenue: "All fees collected by Trends, including trendor rewards.",
+    SupplySideRevenue: "Fee share distributed to referrers and partners.",
   },
   breakdownMethodology: {
     Fees: {
@@ -184,12 +190,14 @@ const adapter: SimpleAdapter = {
       [metrics.ProtocolFees]: 'Amount of fees paid to Trends protocol.',
     },
     Revenue: {
-      [metrics.TradingFees]: 'Total trading fees paid by users.',
       [metrics.ProtocolFees]: 'Total fees paid to Trends protocol.',
     },
     ProtocolRevenue: {
-      [metrics.TradingFees]: 'Total trading fees paid by users.',
       [metrics.ProtocolFees]: 'Total fees paid to Trends protocol.',
+    },
+    SupplySideRevenue: {
+      [metrics.PartnerFees]: 'Partner fee share distributed by Trends.',
+      [metrics.ReferralFees]: 'Referral fee share distributed by Trends.',
     },
   }
 };


### PR DESCRIPTION
**NOTE**

#### Please enable "Allow edits by maintainers" while putting up the PR.

---

This PR is not for listing a new protocol.
It updates the existing Trends fun adapter by splitting legacy activity and new curve activity into separate fee adapters.

Changes in this PR:
- renamed the old `fees/trends.ts` to `fees/trends-legacy.ts`
- updated `fees/trends-legacy.ts` queries so it only covers legacy curve activity and does not include the new curve
- expanded `fees/trends-legacy.ts` legacy coverage by adding 2 more legacy configs and including `cp_amm_evt_evtswap2`
- added a new `fees/trends.ts` that only tracks the new curve
- the new `fees/trends.ts` starts from `2026-03-04`

Important protocol name note for reviewers:
- `fees/trends-legacy.ts` should be reviewed as `Trends fun(legacy)`
- `fees/trends.ts` should continue to represent `Trends fun`

The goal of this change is to avoid mixing legacy curve data and new curve data in the same adapter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a fee-tracking adapter for bonding-curve swaps that captures creator, protocol, and referral fees and reports them as user fees, protocol revenue, and supply-side revenue.

* **Refactor**
  * Expanded fee aggregation to include an additional swap event source and updated how partner/referral shares are attributed.
  * Adjusted revenue allocation and accompanying methodology/breakdown wording to reflect the new distribution rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->