### PR TITLE
Add Lotto Run volume adapter (Aptos lottery protocol)

### DIFF
--- a/dexs/lotto-run/index.ts
+++ b/dexs/lotto-run/index.ts
@@ -62,8 +62,9 @@ const adapter: SimpleAdapter = {
       start: "2026-03-18",
     },
   },
-  methodology:
-    "Daily volume is the total APT wagered on lottery tickets across all 4 pools, calculated from the difference in cumulative tickets sold between the start and end of each day.",
+  methodology: {
+    Volume: "Daily volume is the total APT wagered on lottery tickets across all 4 pools, calculated from the difference in cumulative tickets sold between the start and end of each day.",
+  }
 };
 
 export default adapter;


### PR DESCRIPTION
## Protocol

- **Name:** Lotto Run
- **Website:** https://lotto.run
- **Chain:** Aptos
- **Category:** Luck Games

## Description

Lotto Run is a decentralized, operatorless lottery protocol on Aptos. Four pools (100, 1K, 10K, 100K APT) run continuously in parallel. Every ticket costs 1 APT. No operator, no house cut, Aptos VRF for verifiable randomness. All four contracts are immutable (upgrade_policy = 2).

## Volume Methodology

Daily volume is the total APT wagered on lottery tickets (ticket sales / wagering volume) across all 4 pools, calculated from the difference in cumulative tickets sold between the start and end of each day.

For each pool:
1. Convert start/end timestamps to Aptos ledger versions via `getVersionFromTimestamp`
2. Call `pool_info(pool_addr)` and `round_state(pool_addr, current_round)` at both versions
3. Compute cumulative tickets sold at each point: `total_draws * pool_size + current_round_sold`
4. Daily tickets = end_total - start_total
5. Each ticket costs 1 APT, so daily volume = daily tickets in APT

This is lottery ticket sales volume, not DEX swap volume.

## Fees / Revenue

Not included. The protocol has zero fees and zero revenue. The 1 APT finalizer bounty is a permissionless public reward, not protocol revenue.

## Pool Contracts (all immutable)

| Pool | Address |
|------|---------|
| 100 APT | `0xc38c49cd3008de7e0f41aadd83155ba1e4e380694db1e48b1f13c404e2451f16` |
| 1K APT | `0x2ee2377b4b358cdf272cb7f3e8d22525c9d42a7db64816605f10f12819421c37` |
| 10K APT | `0x53d1c36ff2af28bf67df3b1b2d2229e6bdf307efd6cacacdff8b4e2c2e1aace8` |
| 100K APT | `0x55a51900d3c7bf85347c260448f7e5ffca9f37bbe8157679dbcb274967fae421` |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Daily lottery volume tracking for the Aptos blockchain.
  * Computes daily APT wagered by measuring ticket count changes across configured lottery pools and converting to APT value.
  * Data availability begins on 2026-03-18.

* **Documentation**
  * Includes a clear methodology describing how daily volume is computed from ticket changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->