### PR TITLE
fix(fragment): use all Fragment wallets, exclude Treasury flows

### DIFF
--- a/fees/fragment/index.ts
+++ b/fees/fragment/index.ts
@@ -2,47 +2,94 @@ import { FetchOptions, SimpleAdapter, FetchResult, Dependencies } from "../../ad
 import { CHAIN } from "../../helpers/chains";
 import { queryDuneSql } from "../../helpers/dune";
 
-async function fetch(_a: any, _b: any, options: FetchOptions): Promise<FetchResult> {
-  
-    const query = `
-      with received as (
-        select
-          sum(value / 1e9) as ton_received
-          from ton.messages
-          where direction = 'in'
-        and destination in (
-          UPPER('0:852443f8599fe6a5da34fe43049ac4e0beb3071bb2bfb56635ea9421287c283a'), --stars
-          UPPER('0:5e69bec3dfc448c32a5e81b37b619810cf00db6fc41f30cc18f28b89737a8f97'), --ads
-          UPPER('0:408da3b28b6c065a593e10391269baaa9c5f8caebc0c69d9f0aabbab2a99256b') --marketplace
-      ) 
-        and block_time>=from_unixtime(${options.fromTimestamp}) and block_time<from_unixtime(${options.toTimestamp})),
-      sent as (
-        select
-          sum(value / 1e9) as ton_sent
-          from ton.messages
-          where direction = 'out'
-        and source in (
-          UPPER('0:e6f3d8824f46b1efbab9afc684793428c55fed69b46a15a49be69a29bc49e530'), --star rewards
-          UPPER('0:43512860d54980cf24d59868a30e679927fb1373c10964db7500edcdf690abc4') --ad rewards
-      ) 
-        and block_time>=from_unixtime(${options.fromTimestamp}) and block_time<from_unixtime(${options.toTimestamp}))
+/**
+ * Fragment wallet addresses from ton-labels (https://github.com/ton-studio/ton-labels).
+ * Query: SELECT address FROM dune.ton_foundation.dataset_labels WHERE label = 'fragment'
+ *
+ * Covers all known Fragment wallets: Stars, Ads, Premium, Gift Market,
+ * Gateway, username auctions, and Telegram Gifts.
+ */
+const FRAGMENT_ADDRESSES = [
+    '0:E6F3D8824F46B1EFBAB9AFC684793428C55FED69B46A15A49BE69A29BC49E530',
+    '0:5E69BEC3DFC448C32A5E81B37B619810CF00DB6FC41F30CC18F28B89737A8F97',
+    '0:852443F8599FE6A5DA34FE43049AC4E0BEB3071BB2BFB56635EA9421287C283A',
+    '0:408DA3B28B6C065A593E10391269BAAA9C5F8CAEBC0C69D9F0AABBAB2A99256B',
+    '0:43512860D54980CF24D59868A30E679927FB1373C10964DB7500EDCDF690ABC4',
+    '0:158136239ADB15DD59DF90C641F9EFD312CFEB8664F218F4C3E5FCE9D95E6C07',
+    '0:68F3A076D3451A18FD41E05C71B4C020545D46B2757064E65825DED0C49BF02C',
+    '0:80D78A35F955A14B679FAA887FF4CD5BFC0F43B4A4EEA2A7E6927F3701B273C2',
+];
 
-      select  
-        coalesce(ton_received, 0) as ton_received,
-        coalesce(ton_sent, 0) as ton_sent
-      from sent full outer join received on 1=1;`;
+/**
+ * Telegram Treasury wallet. Excluded from fee calculations because it sends
+ * operational funding TO Fragment and receives treasury returns — these are
+ * internal flows, not user fees or creator rewards.
+ */
+const TELEGRAM_TREASURY = '0:8C397C43F9FF0B49659B5D0A302B1A93AF7CCC63E5F5C0C4F25A9DC1F8B47AB3';
+
+async function fetch(_a: any, _b: any, options: FetchOptions): Promise<FetchResult> {
+
+    const fragmentAddressList = FRAGMENT_ADDRESSES.map(a => `'${a}'`).join(', ');
+
+    const query = `
+      WITH fees AS (
+        SELECT SUM(value / 1e9) AS ton_received
+        FROM ton.messages
+        WHERE direction = 'in'
+          AND NOT bounced
+          AND value > 0
+          AND destination IN (${fragmentAddressList})
+          AND source NOT IN (${fragmentAddressList})
+          AND source != '${TELEGRAM_TREASURY}'
+          AND (
+            comment LIKE '%Telegram Stars%Ref#%'
+            OR comment LIKE '%Telegram Ad account top up%Ref#%'
+            OR comment LIKE '%Telegram Premium%Ref#%'
+            OR comment LIKE '%Telegram account top up%Ref#%'
+            OR comment LIKE '%Telegram Gateway%Ref#%'
+            OR comment LIKE '%Prepaid Subscription%Ref#%'
+            OR comment LIKE '%Bot Username Upgrade Fee%'
+            OR comment LIKE '%Fee to upgrade%for bots%Ref#%'
+            OR comment LIKE '%Auction proceeds%'
+            OR comment LIKE '%Fee for making an offer%'
+          )
+          AND block_time >= from_unixtime(${options.fromTimestamp})
+          AND block_time < from_unixtime(${options.toTimestamp})
+      ),
+      supply_side AS (
+        SELECT SUM(value / 1e9) AS ton_sent
+        FROM ton.messages
+        WHERE direction = 'in'
+          AND NOT bounced
+          AND value > 0
+          AND source IN (${fragmentAddressList})
+          AND destination NOT IN (${fragmentAddressList})
+          AND destination != '${TELEGRAM_TREASURY}'
+          AND (
+            comment LIKE '%Reward from Telegram bot%Ref#%'
+            OR comment LIKE '%Reward from Telegram channel%Ref#%'
+            OR comment LIKE '%Reward from Telegram user%Ref#%'
+          )
+          AND block_time >= from_unixtime(${options.fromTimestamp})
+          AND block_time < from_unixtime(${options.toTimestamp})
+      )
+      SELECT
+        COALESCE(fees.ton_received, 0) AS ton_received,
+        COALESCE(supply_side.ton_sent, 0) AS ton_sent
+      FROM fees
+      CROSS JOIN supply_side`;
 
     const queryResults = await queryDuneSql(options, query);
-    
-    if (!queryResults[0] || !queryResults[0].ton_received ||!queryResults[0].ton_sent) {
-      throw new Error('query Dune return null result');
+
+    if (!queryResults[0]) {
+      throw new Error('Dune query returned no results');
     }
-    
+
     const dailyFees = options.createBalances();
-    dailyFees.addCGToken("the-open-network", queryResults[0].ton_received);
+    dailyFees.addCGToken("the-open-network", queryResults[0].ton_received || 0);
 
     const dailySupplySideRevenue = options.createBalances();
-    dailySupplySideRevenue.addCGToken("the-open-network", queryResults[0].ton_sent);
+    dailySupplySideRevenue.addCGToken("the-open-network", queryResults[0].ton_sent || 0);
 
     const dailyRevenue = dailyFees.clone();
     dailyRevenue.subtract(dailySupplySideRevenue);
@@ -56,10 +103,10 @@ async function fetch(_a: any, _b: any, options: FetchOptions): Promise<FetchResu
 }
 
 const methodology = {
-    Fees: "Includes NFT marketplace fees(auction fees of usernames and numbers, telegram premium), fees to buy telegram ads ,stars etc ",
-    Revenue: "All fees excluding ad and star rewards",
-    ProtocolRevenue: "All the revenue goes to protocol",
-    SupplySideRevenue: "Ad rewards and star rewards shared among channel and bot owners"
+    Fees: "User payments to Fragment classified by transaction comments: Telegram Stars purchases, Ads top-ups, Premium subscriptions, Gift Market top-ups, Gateway (SMS auth) top-ups, Premium Giveaway purchases, bot username fees, username auction fees, and NFT offer fees. Excludes auction bids (locked and returned to losers), Gift NFT mints, Telegram Treasury operational flows, and inter-Fragment wallet transfers.",
+    Revenue: "Fees minus supply-side revenue. Note: Stars purchased via Apple Pay/Google Pay are settled off-chain but paid out on-chain in TON, so on-chain revenue may understate actual revenue.",
+    ProtocolRevenue: "Same as Revenue — all retained revenue goes to Telegram (Fragment operator).",
+    SupplySideRevenue: "TON paid to bot developers (Stars revenue share), channel owners (ad revenue share), and individual users (Stars earned by creators). Identified by 'Reward from Telegram bot/channel/user' transaction comments."
 };
 
 const adapter: SimpleAdapter = {
@@ -68,7 +115,6 @@ const adapter: SimpleAdapter = {
     start: '2024-10-01',
     methodology,
     isExpensiveAdapter: true,
-    allowNegativeValue:true, // Revenue can be negative when rewards exceed payments, possibly due to more onchain redeems of offchain purchased stars
     dependencies: [Dependencies.DUNE]
 }
 


### PR DESCRIPTION
## Problem

The current adapter tracks only 3 of Fragment's 8 wallet addresses, missing fees from Premium, Gift Market, Gateway, username auctions, and Telegram Gifts. It also includes Telegram Treasury operational flows as fees, which caused `allowNegativeValue` to be needed.

## Changes

1. **8 Fragment addresses** instead of 3 — sourced from [ton-labels](https://github.com/ton-studio/ton-labels) (`label = 'fragment'`). Adds wallets handling Premium subscriptions, Gift Market, Gateway, and NFT operations.

2. **Exclude Telegram Treasury** (`0:8C397C...B47AB3`) — this wallet sends large operational funding to Fragment (e.g. 10M TON transfers) and receives returns. Not user fees.

3. **Exclude inter-Fragment transfers** — internal wallet rebalancing between Fragment's own wallets.

4. **Validate Dune results** — fail fast on missing/null columns instead of silently defaulting to zero.

5. **Remove `allowNegativeValue`** — no longer needed since Treasury returns no longer contaminate supply-side calculation.

6. Minor: add `NOT bounced`, switch sent query to `direction = 'in'` (standard TON convention).

## Impact

Fees **increase by ~10-14%** (more addresses capture more user traffic). Revenue stays essentially the same (±0.1%). No more negative revenue months.

Comparison query: https://dune.com/queries/6859691/36dadbb0-449d-4883-a120-7fee032d13eb

| Month | Current Fees | Proposed Fees | Change |
|-------|-------------|--------------|--------|
| Oct 2025 | 17.8M TON | 19.7M TON | +11% |
| Jan 2026 | 19.2M TON | 21.8M TON | +14% |
| Feb 2026 | 21.4M TON | 23.7M TON | +11% |

cc @KPHEMRAJ @noateden @FelixBruguera