### PR TITLE
fix(fragment): use all Fragment wallets, exclude Treasury flows

### DIFF
--- a/fees/fragment/index.ts
+++ b/fees/fragment/index.ts
@@ -98,6 +98,7 @@ const adapter: SimpleAdapter = {
     start: '2024-10-01',
     methodology,
     isExpensiveAdapter: true,
+    allowNegativeValue: true, // Revenue can be negative when rewards exceed payments due to more onchain redeems of offchain purchased stars
     dependencies: [Dependencies.DUNE]
 }
 


### PR DESCRIPTION
## Problem

The current adapter tracks only 3 of Fragment's 8 wallet addresses, missing fees from Premium, Gift Market, Gateway, username auctions, and Telegram Gifts. It also includes Telegram Treasury operational flows as fees, which caused `allowNegativeValue` to be needed.

## Changes

1. **8 Fragment addresses** instead of 3 — sourced from [ton-labels](https://github.com/ton-studio/ton-labels) (`label = 'fragment'`). Adds wallets handling Premium subscriptions, Gift Market, Gateway, and NFT operations.

2. **Exclude Telegram Treasury** (`0:8C397C...B47AB3`) — this wallet sends large operational funding to Fragment (e.g. 10M TON transfers) and receives returns. Not user fees.

3. **Exclude inter-Fragment transfers** — internal wallet rebalancing between Fragment's own wallets.

4. **Validate Dune results** — fail fast on missing/null columns instead of silently defaulting to zero.

5. **Remove `allowNegativeValue`** — no longer needed since Treasury returns no longer contaminate supply-side calculation.

6. Minor: add `NOT bounced`, switch sent query to `direction = 'in'` (standard TON convention).

## Impact

Fees **increase by ~10-14%** (more addresses capture more user traffic). Revenue stays essentially the same (±0.1%). No more negative revenue months.

Comparison query: https://dune.com/queries/6859691/36dadbb0-449d-4883-a120-7fee032d13eb

| Month | Current Fees | Proposed Fees | Change |
|-------|-------------|--------------|--------|
| Oct 2025 | 17.8M TON | 19.7M TON | +11% |
| Jan 2026 | 19.2M TON | 21.8M TON | +14% |
| Feb 2026 | 21.4M TON | 23.7M TON | +11% |

cc @KPHEMRAJ @noateden @FelixBruguera

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved fee/revenue accuracy by excluding bounced messages and internal transfers; refined aggregation logic.
  * Enhanced error handling with distinct cases for no data vs unexpected result shapes.

* **Documentation**
  * Updated methodology to reflect new fee/revenue definitions.
  * Added note clarifying how off-chain settlements affect reported on-chain revenue.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->