### PR TITLE
try Olympus fees fix

### DIFF
--- a/fees/olympus-dao.ts
+++ b/fees/olympus-dao.ts
@@ -570,7 +570,7 @@ function fetchBerachainCexSettlements(options: FetchOptions) {
   const fees = options.createBalances();
 
   for (const s of BERA_CEX_SETTLEMENTS) {
-    if (options.fromTimestamp + 1 === s.timestamp)
+    if (options.fromTimestamp === s.timestamp)
       fees.addUSDValue(s.usdAmount);
   }
   return fees;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Fixed timestamp boundary matching for Berachain CEX settlement fee calculations. The settlement matching logic was adjusted to recognize settlements at exact timestamp boundaries instead of requiring an offset, improving accuracy of fee calculations and ensuring settlements are processed at the correct time intervals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->