### PR TITLE
Uniswap fee switch

### DIFF
--- a/dexs/uniswap-v2.ts
+++ b/dexs/uniswap-v2.ts
@@ -170,10 +170,10 @@ const fetch = async (_t:any, _tb: any , options: FetchOptions) => {
 const methodology = {
   Fees: "User pays 0.3% fees on each swap.",
   UserFees: "User pays 0.3% fees on each swap.",
-  Revenue: 'From 28 Dec 2025, 17% (0% before) fees on Ethereum, From 8 Mar 2026, 17% (0% before) fees on Optimism, Arbitrum, Base, Celo, Zora, XLayer chains shared to buy back and burn UNI.',
+  Revenue: 'From 28 Dec 2025, 17% (0% before) fees on Ethereum, From 8 Mar 2026, 17% (0% before) fees on Optimism, Arbitrum, Base, Zora, XLayer chains shared to buy back and burn UNI.',
   ProtocolRevenue: 'Protocol make no revenue.',
-  SupplySideRevenue: 'From 28 Dec 2025, 83% (100% before) fees on Ethereum are distributed to LPs, From 8 Mar 2026, 83% (100% before) fees on Optimism, Arbitrum, Base, Celo, Zora, XLayer chains are distributed to LPs.',
-  HoldersRevenue: 'From 28 Dec 2025, 17% (0% before) fees on Ethereum shared to buy back and burn UNI, From 8 Mar 2026, 17% (0% before) fees on Optimism, Arbitrum, Base, Celo, Zora, XLayer chains shared to buy back and burn UNI.',
+  SupplySideRevenue: 'From 28 Dec 2025, 83% (100% before) fees on Ethereum are distributed to LPs, From 8 Mar 2026, 83% (100% before) fees on Optimism, Arbitrum, Base, Zora, XLayer chains are distributed to LPs.',
+  HoldersRevenue: 'From 28 Dec 2025, 17% (0% before) fees on Ethereum shared to buy back and burn UNI, From 8 Mar 2026, 17% (0% before) fees on Optimism, Arbitrum, Base, Zora, XLayer chains shared to buy back and burn UNI.',
 }
 
 const adapter: Adapter = {

--- a/dexs/uniswap-v3.ts
+++ b/dexs/uniswap-v3.ts
@@ -123,7 +123,7 @@ const methodology = {
   UserFees: "User pays fees on each swap.",
   Revenue: 'From 28 Dec 2025, a portion of fees a collected to buy back and burn UNI on Ethereum, From 8 Mar 2026, a portion of fees a collected to buy back and burn UNI on Optimism, Arbitrum, Base, Celo, WC, Zora, XLayer.',
   ProtocolRevenue: 'Protocol make no revenue.',
-  SupplySideRevenue: 'All fees are distributed to LPs.',
+  SupplySideRevenue: 'Fees distributed to LPs post protocol fee collection',
   HoldersRevenue: 'From 28 Dec 2025, a portion of fees a collected to buy back and burn UNI on Ethereum, From 8 Mar 2026, a portion of fees a collected to buy back and burn UNI on Optimism, Arbitrum, Base, Celo, WC, Zora, XLayer.',
 }
 
@@ -275,7 +275,7 @@ async function customUniswapGetLogsAdapter(props: { options: FetchOptions, facto
 function getRevenueShare(fee: number, options: FetchOptions): number {
   if (!FEE_SWITCH_DATE[options.chain] || options.dateString < FEE_SWITCH_DATE[options.chain]) return 0;
   if (fee === 0.0001) return 0.000025;
-  if (fee === 0.0005) return 0.0000125;
+  if (fee === 0.0005) return 0.000125;
   if (fee === 0.003) return 0.0005;
   if (fee === 0.01) return 0.001666;
   return 0;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Uniswap V2 and V3 methodology descriptions to reflect multi-chain fee sharing changes.

* **Updates**
  * Implemented date-gated revenue ratio switching across multiple blockchain networks.
  * Enhanced fee sharing configuration with per-chain activation thresholds effective March 8, 2026.
  * Adjusted revenue allocation across Ethereum, Base, Optimism, Arbitrum, Zora, XLayer, and Celo.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->