### PR TITLE
Add NanoStack adapter (volume + fees)

### DIFF
--- a/dexs/nanostack/index.ts
+++ b/dexs/nanostack/index.ts
@@ -1,0 +1,56 @@
+import fetchURL from "../../utils/fetchURL";
+import { FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+
+const API_BASE = "https://api.nano-labs.io";
+const volumeEndpoint = (start: number, end: number) =>
+  `${API_BASE}/v1/stats/volume?start=${start}&end=${end}`;
+
+const methodology = {
+  Volume: "Daily trade volume routed through NanoStack's cross-chain execution fabric.",
+  Fees: "Fees collected at 8-15 bps per execution, varying by trade size.",
+  Revenue: "All fees accrue to the NanoStack protocol treasury.",
+};
+
+const fetch = async (options: FetchOptions) => {
+  const data = await fetchURL(
+    volumeEndpoint(options.startOfDay, options.startOfDay + 86400)
+  );
+
+  return {
+    dailyVolume: data.dailyVolume,
+    dailyFees: data.dailyFees,
+    dailyUserFees: data.dailyUserFees,
+    dailyRevenue: data.dailyRevenue,
+    dailyProtocolRevenue: data.dailyProtocolRevenue,
+  };
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  adapter: {
+    [CHAIN.BASE]: {
+      fetch,
+      start: "2025-12-01",
+    },
+    [CHAIN.ETHEREUM]: {
+      fetch,
+      start: "2025-12-01",
+    },
+    [CHAIN.ARBITRUM]: {
+      fetch,
+      start: "2025-12-01",
+    },
+    [CHAIN.OPTIMISM]: {
+      fetch,
+      start: "2025-12-01",
+    },
+    [CHAIN.SOLANA]: {
+      fetch,
+      start: "2025-12-01",
+    },
+  },
+  methodology,
+};
+
+export default adapter;

--- a/dexs/nanostack/index.ts
+++ b/dexs/nanostack/index.ts
@@ -50,7 +50,7 @@ const adapter: SimpleAdapter = {
       start: "2025-12-01",
     },
   },
-  methodology,
+  methodology
 };
 
 export default adapter;


### PR DESCRIPTION
Hi! Submitting a volume/fees adapter for NanoStack — a cross-chain execution fabric operating across 86 chains. Happy to adjust the adapter based on your feedback.

## What is NanoStack?

NanoStack is a cross-chain execution substrate that routes trades directly through on-chain liquidity pools. No external routing contracts — all execution is handled natively with 8-15 bps fees.

## Adapter details

- **Type:** DEX (volume + fees)
- **Chains:** Base (primary), Ethereum, Arbitrum, Optimism, Solana
- **API:** `https://api.nano-labs.io/v1/stats/volume`
- **Metrics returned:** dailyVolume, dailyFees, dailyUserFees, dailyRevenue, dailyProtocolRevenue
- **Fee structure:** 8-15 bps per execution (size-dependent), 100% to protocol treasury
- **Version:** 2

## Links

- Website: https://nano-labs.io
- API: https://api.nano-labs.io
- GitHub: https://github.com/nano-labs-io/NanoStack

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
- Integrated NanoStack as a new data source for comprehensive analytics
- Tracks daily volume, fees, and revenue metrics across supported blockchains
- Available on Base, Ethereum, Arbitrum, Optimism, and Solana networks
- Historical data tracking begins from December 1, 2025

<!-- end of auto-generated comment: release notes by coderabbit.ai -->