### PR TITLE
Add Rainbow Predictions fee adapter

### DIFF
--- a/fees/rainbow-predictions.ts
+++ b/fees/rainbow-predictions.ts
@@ -1,0 +1,58 @@
+import { FetchOptions, FetchResultV2, SimpleAdapter } from "../adapters/types"
+import { CHAIN } from "../helpers/chains"
+import { addTokensReceived } from "../helpers/token"
+
+// Rainbow Wallet predictions fee wallet on Polygon
+const RainbowFeeWallet = '0x757758506d6a4F8a433F8BECaFd52545f9Cb050a';
+
+// USDC.e on Polygon
+const USDC_E = '0x2791bca1f2de4661ed88a30c99a7a9449aa84174';
+
+const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
+  const dailyFees = options.createBalances()
+  const dailyRevenue = options.createBalances()
+
+  const fees = await addTokensReceived({
+    options,
+    targets: [RainbowFeeWallet],
+    token: USDC_E,
+  })
+
+  dailyFees.add(fees, 'Trading Fees');
+  dailyRevenue.add(fees, 'Trading Fees');
+
+  return {
+    dailyFees,
+    dailyRevenue,
+    dailyProtocolRevenue: dailyRevenue,
+  }
+}
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  pullHourly: true,
+  methodology: {
+    Fees: 'Rainbow Wallet charges ~1% of shares value on prediction market trades',
+    Revenue: 'All fees go to the Rainbow protocol fee wallet',
+    ProtocolRevenue: 'All fees go to the Rainbow protocol fee wallet',
+  },
+  breakdownMethodology: {
+    Fees: {
+      'Trading Fees': 'USDC.e fee charged on each prediction market open/close trade',
+    },
+    Revenue: {
+      'Trading Fees': 'All trading fees flow to the Rainbow fee wallet',
+    },
+    ProtocolRevenue: {
+      'Trading Fees': 'All trading fees flow to the Rainbow fee wallet',
+    },
+  },
+  adapter: {
+    [CHAIN.POLYGON]: {
+      fetch: fetch,
+      start: '2025-12-01',
+    }
+  },
+}
+
+export default adapter


### PR DESCRIPTION
Name (as shown on DefiLlama): Rainbow Predictions
Twitter link: https://x.com/rainbowdotme
Website link: https://rainbow.me
Chain(s): Polygon

## Summary

Adds a fee adapter for Rainbow Predictions — a prediction market feature within the Rainbow Wallet app.

- Tracks ~1% trading fees on prediction market trades (open/close)
- Fees are collected in USDC.e on Polygon to fee wallet `0x757758506d6a4F8a433F8BECaFd52545f9Cb050a`
- Uses `addTokensReceived` helper to track inbound USDC.e transfers
- All fees are protocol revenue

## Methodology

| Metric | Description |
|--------|-------------|
| Fees | ~1% of shares value charged on each prediction market trade |
| Revenue | All fees flow to Rainbow protocol fee wallet |
| ProtocolRevenue | Same as Revenue — no supply-side split |

Start date: 2025-12-01

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Rainbow Wallet fee and revenue tracking adapter for Polygon network
  * Provides daily visibility into trading fees and protocol revenue metrics
  * Automatically refreshes on an hourly schedule for real-time updates
  * Includes detailed methodology documentation for fee and revenue attribution

<!-- end of auto-generated comment: release notes by coderabbit.ai -->