### PR TITLE
use blacklisted tokens logic for bungee instead of whitelisted

### DIFF
--- a/helpers/aggregators/bungee.ts
+++ b/helpers/aggregators/bungee.ts
@@ -204,7 +204,7 @@ export async function fetchBungeeData(options: FetchOptions, params: FetchSocket
       // count volune only from non-blacklisted tokens
       const blacklistedTokens = getDefaultDexTokensBlacklisted(options.chain)
       if (blacklistedTokens.length > 0) {
-        swapEvents = swapEvents.filter(log => !blacklistedTokens.includes(formatAddress(log.tokenIn)) && !blacklistedTokens.includes(formatAddress(log.tokenOut)))
+        swapEvents = swapEvents.filter(log => !blacklistedTokens.includes(formatAddress(log.fromToken)) && !blacklistedTokens.includes(formatAddress(log.toToken)))
       }
       for (const event of swapEvents) {
         if (!metadataFilter || (event[6] && event[6].toLowerCase().endsWith(metadataFilter.toLowerCase()))) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Changed swap-volume token filtering from inclusive (whitelist) to exclusive (blacklist) logic, improving how unsupported tokens are excluded during volume calculations and streamlining swap data processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->