### PR TITLE
Add Rocket volume/fees adapter - Perpetual Futures DEX

### DIFF
--- a/dexs/rocket/index.ts
+++ b/dexs/rocket/index.ts
@@ -13,9 +13,9 @@
  * API Docs: https://rocketfoundation.gitbook.io/rocket-docs/rocket/api
  */
 
-import { SimpleAdapter, FetchResultVolume, FetchResult, FetchOptions } from "../../adapters/types";
+import { SimpleAdapter, FetchResult, FetchOptions } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
-import fetchURL from "../../utils/fetchURL";
+import fetchURL, { fetchURLAutoHandleRateLimit } from "../../utils/fetchURL";
 import PromisePool from "@supercharge/promise-pool";
 import { METRIC } from "../../helpers/metrics";
 
@@ -38,7 +38,7 @@ const fetch = async (_a: any, _b: any, options: FetchOptions): Promise<FetchResu
     await PromisePool.withConcurrency(1)
         .for(instruments)
         .process(async (instrumentId) => {
-            const candleData = await fetchURL(
+            const candleData = await fetchURLAutoHandleRateLimit(
                 `${ROCKET_API}/candles?instrumentId=${encodeURIComponent(instrumentId)}&interval=1d&startTime=${startTime}&endTime=${startTime + 86399999}`
             );
             const candles: any[] = candleData.candles || [];


### PR DESCRIPTION
## Protocol: Rocket

- **Website:** https://beta.rocketfi.io/trade
- - **Category:** Derivatives / Perpetual Futures DEX
- - **Chain:** Rocket Chain (custom L1 - high-performance blockchain for trading derivatives)
- - **TVL adapter:** Already submitted as PR #18501 to DefiLlama-Adapters
- - **API Docs:** https://rocketfoundation.gitbook.io/rocket-docs/rocket/api
### What this adapter tracks

- **Daily Volume:** Summed from OHLCV candle data across all perpetual instruments
- - **Daily Fees:** Calculated as volume * avg fee rate (0.01% maker / 0.01% taker)
- - **Daily Revenue:** Protocol revenue from trading fees
### How it works

1. Fetches all instruments from `GET /instruments`
2. 2. For each instrument, pulls 24 x 1h candles from `GET /candles`
3. 3. Sums quote volume (or base volume * close price) across all candles
4. 4. Calculates fees as volume * 0.01% average fee rate
### Current stats (from Rocket UI)

- 24h Volume: ~$21,000+
- - Open Interest: ~$163
- - Trades: ~2,500/day
- - Fee rate: 0.01% maker / 0.01% taker
#### Please enable "Allow edits by maintainers" while putting up the PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Rocket support (off-chain) providing daily trading metrics: volume, fees, and revenue.
  * Data availability begins 2026-02-18; metrics returned with timestamps as strings.
  * Daily fees, revenue, and protocol revenue are derived from reported daily volumes (fees = revenue = protocol revenue).
* **Documentation**
  * Includes methodology and breakdown text describing how volume, fees, and revenue are calculated; aggregation tolerates partial data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->