### PR TITLE
feat: add MegaETH chain fees adapter

### DIFF
--- a/fees/megaeth.ts
+++ b/fees/megaeth.ts
@@ -1,14 +1,21 @@
+import { FetchOptions, ProtocolType, SimpleAdapter } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
-import { ProtocolType, SimpleAdapter } from "../adapters/types";
-import { etherscanFeeAdapter } from "../helpers/etherscanFees";
+import { getEtherscanFees } from "../helpers/etherscanFees";
+
+const fetch = async (_a: any, _b: any, options: FetchOptions) => {
+  const amount = await getEtherscanFees(options, 'https://mega.etherscan.io/chart/transactionfee?output=csv')
+  const dailyFees = options.createBalances()
+  dailyFees.addCGToken('ethereum', amount / 1e18)
+
+  return { dailyFees };
+}
 
 const adapter: SimpleAdapter = {
-  ...etherscanFeeAdapter(
-    CHAIN.MEGAETH,
-    'https://mega.etherscan.io/chart/transactionfee?output=csv',
-    'ethereum'
-  ),
+  version: 1,
+  fetch,
+  chains: [CHAIN.MEGAETH],
   start: '2026-01-30',
-};
+  protocolType: ProtocolType.CHAIN,
+}
 
 export default adapter;


### PR DESCRIPTION
This PR adds chain-level fee tracking for MegaETH.

**Approach:** Uses the Etherscan CSV endpoint (same pattern as Taiko, Moonbeam, XDC).

- **Source:** https://mega.etherscan.io/chart/transactionfee?output=csv
- **Gas token:** ETH (`CGToken: ethereum`)
- **Chain ID:** 4326
- **Data available from:** 2026-01-30 (mainnet launch)
- **Chain constant:** `CHAIN.MEGAETH` already exists in `helpers/chains.ts`

---

This is a chain-level fee adapter (`protocolType: CHAIN`), not a protocol adapter. No new npm packages added.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for MegaETH network fee tracking: retrieves transaction fee data from the MegaETH explorer and reports daily fees, with data available starting January 30, 2026.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->