### PR TITLE
Add VIRTUS Protocol DEX adapters for basic AMM and CL pools on Base

### DIFF
--- a/dexs/virtus-protocol-cl/index.ts
+++ b/dexs/virtus-protocol-cl/index.ts
@@ -1,0 +1,74 @@
+import { FetchOptions, FetchResult, SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import { addOneToken } from '../../helpers/prices';
+
+const CONFIG = {
+  CLFactory: '0x0e5Ab24beBdA7e5Bb3961f7E9b3532a83aE86B48',
+  fromBlock: 42960000,
+}
+
+const swapEvent = 'event Swap(address indexed sender, address indexed recipient, int256 amount0, int256 amount1, uint160 sqrtPriceX96, uint128 liquidity, int24 tick)'
+const poolCreatedEvent = 'event PoolCreated(address indexed token0, address indexed token1, int24 indexed tickSpacing, address pool)'
+
+const fetch = async (fetchOptions: FetchOptions): Promise<FetchResult> => {
+  const { api, createBalances, chain, getLogs } = fetchOptions
+  const dailyVolume = createBalances()
+  const dailyFees = createBalances()
+
+  const rawPools = await getLogs({
+    target: CONFIG.CLFactory,
+    fromBlock: CONFIG.fromBlock,
+    eventAbi: poolCreatedEvent,
+    cacheInCloud: true,
+    skipIndexer: true,
+  })
+
+  if (!rawPools?.length) return { dailyVolume, dailyFees }
+
+  const pools = rawPools.map((i: any) => i.pool.toLowerCase())
+  const fees = await api.multiCall({ abi: 'uint256:fee', calls: pools, permitFailure: true })
+
+  const poolTokens: Record<string, [string, string]> = {}
+  const poolFees: Record<string, number> = {}
+  const validPools: string[] = []
+
+  rawPools.forEach(({ token0, token1, pool }: any, index: number) => {
+    const p = pool.toLowerCase()
+    const rawFee = fees[index]
+    if (rawFee === null || rawFee === undefined) return;
+    poolTokens[p] = [token0, token1]
+    poolFees[p] = rawFee / 1e6
+    validPools.push(p)
+  })
+
+  if (!validPools.length) return { dailyVolume, dailyFees }
+
+  const allLogs = await getLogs({ targets: validPools, eventAbi: swapEvent, flatten: false })
+
+  allLogs.forEach((logs: any, index: number) => {
+    if (!logs?.length) return;
+    const pool = validPools[index]
+    const [token0, token1] = poolTokens[pool]
+    const fee = poolFees[pool]
+    logs.forEach((log: any) => {
+      const amount0 = Number(log.amount0)
+      const amount1 = Number(log.amount1)
+      addOneToken({ chain, balances: dailyVolume, token0, token1, amount0, amount1 })
+      addOneToken({ chain, balances: dailyFees, token0, token1, amount0: amount0 * fee, amount1: amount1 * fee })
+    })
+  })
+
+  return { dailyVolume, dailyFees, dailyRevenue: dailyFees, dailyHoldersRevenue: dailyFees }
+}
+
+const adapters: SimpleAdapter = {
+  version: 2,
+  adapter: {
+    [CHAIN.BASE]: {
+      fetch: fetch as any,
+      start: '2026-03-05',
+    }
+  }
+}
+
+export default adapters

--- a/dexs/virtus-protocol/index.ts
+++ b/dexs/virtus-protocol/index.ts
@@ -1,0 +1,78 @@
+import { FetchOptions, FetchResult, SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import { addOneToken } from '../../helpers/prices';
+
+const CONFIG = {
+  PoolFactory: '0x7F03ae4452192b0E280fB0d4f9c225DDa88C7623',
+}
+
+const swapEvent = 'event Swap(address indexed sender, address indexed to, uint256 amount0In, uint256 amount1In, uint256 amount0Out, uint256 amount1Out)'
+
+const factoryAbis = {
+  allPoolsLength: 'uint256:allPoolsLength',
+  allPools: 'function allPools(uint256) external view returns (address)',
+  getFee: 'function getFee(address pool, bool _stable) external view returns (uint256)',
+}
+
+const fetch = async (fetchOptions: FetchOptions): Promise<FetchResult> => {
+  const { createBalances, api, chain, getLogs } = fetchOptions
+  const dailyVolume = createBalances()
+  const dailyFees = createBalances()
+
+  const poolCount = await api.call({ target: CONFIG.PoolFactory, abi: factoryAbis.allPoolsLength })
+  if (!poolCount || Number(poolCount) === 0) return { dailyVolume, dailyFees }
+
+  const calls = []
+  for (let i = 0; i < Number(poolCount); i++) {
+    calls.push({ target: CONFIG.PoolFactory, params: [i] })
+  }
+  const pools: string[] = await api.multiCall({ abi: factoryAbis.allPools, calls })
+  const token0s: string[] = await api.multiCall({ abi: 'address:token0', calls: pools })
+  const token1s: string[] = await api.multiCall({ abi: 'address:token1', calls: pools })
+  const stables: boolean[] = await api.multiCall({ abi: 'bool:stable', calls: pools, permitFailure: true })
+
+  const fees = await api.multiCall({
+    abi: factoryAbis.getFee,
+    target: CONFIG.PoolFactory,
+    calls: pools.map((pool, i) => ({ params: [pool, stables[i] ?? false] })),
+    permitFailure: true,
+  })
+
+  const poolTokens: Record<string, [string, string]> = {}
+  const poolFees: Record<string, number> = {}
+  pools.forEach((pool, index) => {
+    const p = pool.toLowerCase()
+    poolTokens[p] = [token0s[index], token1s[index]]
+    poolFees[p] = (fees[index] ?? 30) / 1e4
+  })
+
+  const targets = pools.map(p => p.toLowerCase())
+  const allLogs = await getLogs({ targets, eventAbi: swapEvent, flatten: false })
+
+  allLogs.forEach((logs: any, index: number) => {
+    if (!logs?.length) return;
+    const pool = targets[index]
+    const [token0, token1] = poolTokens[pool]
+    const fee = poolFees[pool]
+    logs.forEach((log: any) => {
+      const amount0 = Number(log.amount0In) + Number(log.amount0Out)
+      const amount1 = Number(log.amount1In) + Number(log.amount1Out)
+      addOneToken({ chain, balances: dailyVolume, token0, token1, amount0, amount1 })
+      addOneToken({ chain, balances: dailyFees, token0, token1, amount0: amount0 * fee, amount1: amount1 * fee })
+    })
+  })
+
+  return { dailyVolume, dailyFees, dailyRevenue: dailyFees, dailyHoldersRevenue: dailyFees }
+}
+
+const adapters: SimpleAdapter = {
+  version: 2,
+  adapter: {
+    [CHAIN.BASE]: {
+      fetch: fetch as any,
+      start: '2026-03-05',
+    }
+  }
+}
+
+export default adapters


### PR DESCRIPTION
Adds on-chain DEX volume/fees adapters for VIRTUS Protocol (Aerodrome fork) on Base mainnet.

Website: https://virtus-protocol.com
Twitter: https://x.com/VirtusCEO

- `dexs/virtus-protocol/` — Basic AMM pools (PoolFactory: 0x7F03ae4452192b0E280fB0d4f9c225DDa88C7623)
- `dexs/virtus-protocol-cl/` — Concentrated Liquidity pools (CLFactory: 0x0e5Ab24beBdA7e5Bb3961f7E9b3532a83aE86B48)

Both read swap events directly from on-chain contracts. No backend API dependency.

Tested with `ts-node cli/testAdapter.ts dexs virtus-protocol` and `virtus-protocol-cl`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Virtus Protocol adapter for Base chain — collects daily swap volumes and fees, exposing daily volume and revenue metrics.
  * Added Virtus Protocol Concentrated Liquidity adapter for Base chain — collects per-pool swap volumes and fees, exposing daily volume and revenue metrics (including holders revenue).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->