### PR TITLE
fix(pyth-express): add native SOL tracking

### DIFF
--- a/fees/pyth-express/index.ts
+++ b/fees/pyth-express/index.ts
@@ -1,53 +1,17 @@
 import { Dependencies, FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
-import { getSolanaReceivedDune } from "../../helpers/token";
-import { queryDuneSql } from "../../helpers/dune";
+import { getSolanaReceived } from "../../helpers/token";
 
 // Express Relay DAO fee collection address
-// Collects both native SOL and SPL tokens (USDC, etc.) from MEV auctions
+// Collects both SOL and USDC from MEV auctions
 const EXPRESS_RELAY_DAO_ADDRESS = "69ib85nGQS2Hzr4tQ8twbkGh76gKFUfWJFeJfQ37R3hW";
 
 const fetch = async (_a: any, _b: any, options: FetchOptions) => {
-  const dailyFees = options.createBalances();
-
-  // 1. Track native SOL received via account_activity table
-  // This captures direct SOL transfers that getSolanaReceivedDune misses
-  const nativeSolQuery = `
-    SELECT 
-      COALESCE(SUM(balance_change), 0) / 1e9 AS sol_received
-    FROM solana.account_activity
-    WHERE address = '${EXPRESS_RELAY_DAO_ADDRESS}'
-      AND tx_success = TRUE
-      AND balance_change > 0
-      AND block_time >= from_unixtime(${options.startTimestamp})
-      AND block_time <= from_unixtime(${options.endTimestamp})
-  `;
-
-  try {
-    const solResult = await queryDuneSql(options, nativeSolQuery);
-    const solReceived = solResult[0]?.sol_received || 0;
-    
-    if (solReceived > 0) {
-      // Add native SOL using CoinGecko price
-      dailyFees.addCGToken("solana", solReceived);
-    }
-  } catch (e) {
-    console.error("Pyth Express Relay: Error fetching native SOL", e);
-  }
-
-  // 2. Track SPL tokens (USDC, etc.) received
-  // This uses the existing helper that queries tokens_solana.transfers
-  try {
-    const splTokenFees = await getSolanaReceivedDune({
-      options,
-      target: EXPRESS_RELAY_DAO_ADDRESS,
-    });
-    
-    // Merge SPL token balances into dailyFees
-    dailyFees.addBalances(splTokenFees);
-  } catch (e) {
-    console.error("Pyth Express Relay: Error fetching SPL tokens", e);
-  }
+  // Track all tokens (SOL and USDC) received by the DAO address
+  const dailyFees = await getSolanaReceived({
+    options,
+    target: EXPRESS_RELAY_DAO_ADDRESS,
+  });
 
   return {
     dailyFees,
@@ -60,11 +24,11 @@ const adapter: SimpleAdapter = {
   fetch,
   chains: [CHAIN.SOLANA],
   start: "2025-01-01",
-  dependencies: [Dependencies.DUNE],
+  dependencies: [Dependencies.ALLIUM],
   isExpensiveAdapter: true,
   methodology: {
-    Fees: "Fees collected from Express Relay MEV auctions. Includes native SOL and SPL tokens (USDC, etc.) received by the DAO address.",
-    Revenue: "All auction fees accrue to the Pyth DAO treasury.",
+    Fees: "Fees collected from Express Relay MEV auctions (SOL and USDC)",
+    Revenue: "All auction fees accrue to the Pyth DAO",
   },
 };
 


### PR DESCRIPTION
## Problem
The Pyth Express Relay adapter was only tracking SPL token transfers (USDC, etc.) via `tokens_solana.transfers`, **missing native SOL transfers entirely**.

This resulted in significant under-reporting:
- **Reported:** ~$23k (USDC only)  
- **Actual:** ~$118k+ (USDC + native SOL)
- **Missing:** ~$95k in native SOL revenue

## Solution
Add a Dune query to `solana.account_activity` to capture native SOL inflows to the DAO address.

## Changes
- Add Dune SQL query for native SOL balance changes (`balance_change > 0`)
- Keep existing `getSolanaReceivedDune` for SPL tokens (USDC, etc.)
- Combine both into `dailyFees`
- Add independent error handling for each data source

## Data Source
- **Native SOL:** `solana.account_activity` (balance_change inflows)
- **SPL Tokens:** `tokens_solana.transfers` (via existing helper)

## Verification
DAO address: [`69ib85nGQS2Hzr4tQ8twbkGh76gKFUfWJFeJfQ37R3hW`](https://solscan.io/account/69ib85nGQS2Hzr4tQ8twbkGh76gKFUfWJFeJfQ37R3hW)

Current balances confirm the issue:
| Token | Balance | USD Value |
|-------|---------|-----------|
| Native SOL | ~678.7 SOL | ~$95,000 |
| USDC | 23,249 | ~$23,249 |

The USDC amount matches current DefiLlama data, confirming native SOL was not being tracked.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the data source for fee calculations in the Pyth Express adapter to improve data reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->