### PR TITLE
fix(pyth-network): update all EVM chain fees from OP-PIP-93 : move calculation onchain

### DIFF
--- a/fees/pyth-network/index.ts
+++ b/fees/pyth-network/index.ts
@@ -313,8 +313,7 @@ async function fetchEvm(
     })
 
     const updateCount = updateLogs.length;
-    const feePerUpdate = updateFee || DEFAULT_FEE;
-    dailyFees.addGasToken(BigInt(feePerUpdate) * BigInt(updateCount));
+    dailyFees.addGasToken(BigInt(updateFee) * BigInt(updateCount));
   }
 
   return {


### PR DESCRIPTION
## Problem
The Pyth Core (pyth-network) adapter was showing near-zero fees because most chains used `DEFAULT_FEE = 1n` (1 wei) instead of the actual governance-approved fee values.

**Before:** ~$54/day across 70+ chains (almost all zeros)
**After:** Should reflect actual protocol revenue

## Solution
Updated `feePerUpdateByChain` with all correct fee values from:
- **Source:** [Pyth Docs - Current Fees](https://docs.pyth.network/price-feeds/core/current-fees)
- **Governance:** [OP-PIP-93](https://forum.pyth.network/t/passed-op-pip-93-q1-2026-pyth-core-fee-implementation-evm-chains/2346)

## Fee Updates (examples)
| Chain | Old Fee | New Fee |
|-------|---------|---------|
| Ethereum | 1 wei | 0.000003 ETH |
| Arbitrum | 1 wei | 0.000003 ETH |
| Base | 1 wei | 0.000015 ETH |
| Polygon | 1 wei | 0.1 POL |
| BNB | 1 wei | 0.0000125 BNB |
| Avalanche | (had value) | 0.0005 AVAX |

**Total:** 60+ chains now have correct fee values configured.

## Notes
- Fee values are in native token wei units (18 decimals for most chains)
- Fees are set by Pyth DAO governance and may change quarterly
- Source of truth: `apps/developer-hub/content/docs/price-feeds/core/current-fees.mdx` in pyth-crosschain repo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Fees are now obtained via live on-chain lookup per chain instead of a static mapping.
  * Fee totals are computed using the fetched per-update fee, falling back to a minimal default when unavailable.
  * Methodology text updated to reflect governance-set fees and revenue attribution to the protocol treasury.
  * No public API or adapter shape changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->