### PR TITLE
fix(pyth-pro): use wallet owner addresses instead of token accounts

### DIFF
--- a/fees/pyth-pro/index.ts
+++ b/fees/pyth-pro/index.ts
@@ -9,22 +9,24 @@ import { queryDuneSql } from "../../helpers/dune";
 
 // Douro Labs is the official Pyth Pro data distributor
 // They pay 60% of subscription revenue to the Pyth DAO
-const DOURO_LABS_ADDRESS = "C6G3jRs1SD7GSNxvKNHJZy7aSar7eZiLioPpDRFFtKTf";
-const PYTH_DAO_ADDRESS = "5Unq3fgfSNdyeGjiq2Pu5XAQUJWo2rauKGErbUyxqUGe";
+// Note: These are wallet OWNER addresses, not token account addresses
+// Dune's tokens_solana.transfers uses owner addresses in from_owner/to_owner fields
+const DOURO_LABS_WALLET = "2ru31e9g8RF2mSSNgTQ11QMb166NE6LJccmBqGJM8xxy";
+const PYTH_DAO_WALLET = "Gx4MBPb1vqZLJajZmsKLg8fGw9ErhoKsR8LeKcCKFyak";
 const USDC_MINT = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
 
 const fetch = async (_t: any, _a: any, options: FetchOptions) => {
   const dailyFees = options.createBalances();
 
-  // Query USDC transfers from Douro Labs to Pyth DAO
+  // Query USDC transfers from Douro Labs wallet to Pyth DAO wallet
   const query = `
     SELECT
       SUM(amount) as total_amount
     FROM tokens_solana.transfers
     WHERE block_time BETWEEN FROM_UNIXTIME(${options.startTimestamp}) AND FROM_UNIXTIME(${options.endTimestamp})
       AND token_mint_address = '${USDC_MINT}'
-      AND from_owner = '${DOURO_LABS_ADDRESS}'
-      AND to_owner = '${PYTH_DAO_ADDRESS}'
+      AND from_owner = '${DOURO_LABS_WALLET}'
+      AND to_owner = '${PYTH_DAO_WALLET}'
   `;
 
   const res = await queryDuneSql(options, query);


### PR DESCRIPTION
## Problem
The Pyth Pro adapter was showing no data because it used **token account addresses** (ATAs) instead of **wallet owner addresses**.

Dune's `tokens_solana.transfers` table uses wallet owner addresses in `from_owner`/`to_owner` fields, not the token account addresses.

## The Fix

| Field | Old (Token Account) | New (Wallet Owner) |
|-------|--------------------|--------------------|
| Douro Labs | `C6G3jRs1SD7GSNxvKNHJZy7aSar7eZiLioPpDRFFtKTf` | `2ru31e9g8RF2mSSNgTQ11QMb166NE6LJccmBqGJM8xxy` |
| Pyth DAO | `5Unq3fgfSNdyeGjiq2Pu5XAQUJWo2rauKGErbUyxqUGe` | `Gx4MBPb1vqZLJajZmsKLg8fGw9ErhoKsR8LeKcCKFyak` |

## Verification
Analyzed all 4 USDC payments from Douro Labs to Pyth DAO:

| Date | Amount | Tx |
|------|--------|---|
| Dec 2, 2025 | $157,333 | [79Tvg8Q...](https://explorer.solana.com/tx/79Tvg8QKBerYkzSDrcqyrY1bopX5ZAqs7L51kbteAuvzwkVhtG7nUJpcz32LFqGJevZHotvqqERmUTA3D5MGhiD) |
| Jan 5, 2026 | $54,245 | [3fFk421...](https://explorer.solana.com/tx/3fFk421UJCNZCj62gPBUb7Y3iorCp3DFNfCADhnJskk9SJQ2prtGCWDY9uau1ZWBZMjQbb4rsXxE3CCHRvhvMAvG) |
| Feb 3, 2026 | $73,700 | [3WrYYPo...](https://explorer.solana.com/tx/3WrYYPoyynVScsJMtixXnaHEBv6Q3siCTyipVDLxdvcUSgwC3qLSYo1AhuxdjQJfgUPSaik6YCDht3qpc8Pah4nX) |
| Mar 3, 2026 | $107,900 | [4pV9cPv...](https://explorer.solana.com/tx/4pV9cPvyMQBBi8MizrJYM92U5DS1n1SdKNVarDqEmPEwwiepTcGUy3NtZe8CPWAuFoDpfTVf44qQ6PHZTcEV9DeR) |
| **Total** | **$393,178** | |

All transactions show the same pattern:
- `authority` = `2ru31e9g8RF2mSSNgTQ11QMb166NE6LJccmBqGJM8xxy` (Douro Labs wallet)
- `destination owner` = `Gx4MBPb1vqZLJajZmsKLg8fGw9ErhoKsR8LeKcCKFyak` (Pyth DAO wallet)

Current DAO USDC balance: ~$246,655 (after some withdrawals for token buybacks)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Updated wallet owner address filtering in fee and revenue calculation queries. The system now correctly identifies and sums USDC transfer flows using updated wallet owner references, ensuring accurate reporting of fees and revenues across all tracked transfers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->