### PR TITLE
Add Api3 curator fees

### DIFF
--- a/factory/curators.ts
+++ b/factory/curators.ts
@@ -41,6 +41,14 @@ const configs: Record<string, CuratorConfig> = {
       },
     },
   },
+  "api3": {
+    vaults: {
+      [CHAIN.ETHEREUM]: {
+        morphoVaultOwners: ['0x9f0566F2E8Ff51901DD0C0E7aad937A94931f75C', '0x5a9AA3219dD1cBEF6A18Fd221464E071DF2677c2'],
+        morphoVaultV2Owners: ['0x9f0566F2E8Ff51901DD0C0E7aad937A94931f75C', '0x5a9AA3219dD1cBEF6A18Fd221464E071DF2677c2'],
+      },
+    },
+  },
   "apostro": {
     vaults: {
       [CHAIN.ETHEREUM]: {


### PR DESCRIPTION
Hello DefiLlama team!

This PR adds curator fees for Api3 from their curated Morpho vaults.

https://app.morpho.org/ethereum/vault/0x54210d3f1A066413891AF9E17210E787d5C6e3f4/kabu-usdc
https://app.morpho.org/ethereum/vault/0xe2221Aa07ec3266DA87763E2b1e28d07A8a4e53b/api3-core-usdc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for API3 protocol configuration with Ethereum vault owner address management capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->