### PR TITLE
feat(fees): add Arbitrage Inc. fees adapter

### DIFF
--- a/fees/arbitrage-inc.ts
+++ b/fees/arbitrage-inc.ts
@@ -29,8 +29,8 @@ const adapter: Adapter = {
   fetch,
   start: '2024-09-01',
   methodology: {
-    Fees: "We track fees sent to the fee receiver address which represents the developer commission for every arbitrage executed via our frontend integration.",
-    Revenue: "Developer fees are collected from each trade and sent to the designated fee receiver address.",
+    Fees: "We track fees sent to the fee receiver address which represents the developer commission for every swap executed via our frontend integration.",
+    Revenue: "Developer fees (0.1% per swap) are collected from each trade and sent to the designated fee receiver address.",
   },
 };
 


### PR DESCRIPTION
## Project Name
Arbitrage Inc.

## Project Type
DEX Aggregator / Fees

## Methodology
We track fees sent to the address 0xafF5340ECFaf7ce049261cff193f5FED6BDF04E7 which represents the developer commission for every arbitrage executed via our frontend integration.

## Chain
BNB Smart Chain (BSC)

## Adapter Details
- Version: 2
- Start Date: 2024-09-01
- Tracks: Token transfers to fee receiver address

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added fee and revenue tracking for Arbitrage Inc on Binance Smart Chain, with historical data available from September 1, 2024.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->