### PR TITLE
feat(fees): add Arbitrage Inc. fees adapter

### DIFF
--- a/fees/arbitrage-inc/index.ts
+++ b/fees/arbitrage-inc/index.ts
@@ -2,39 +2,50 @@ import { Adapter, FetchOptions } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
 import { addTokensReceived } from "../helpers/token";
 
-const FEE_RECEIVER = '0xafF5340ECFaf7ce049261cff193f5FED6BDF04E7'.toLowerCase();
-
-const TOKENS = [
-  '0xbb4CdB9CBd36B01bD1cBaEBf2E08E7023b076de6', // WBNB
-  '0xe9e7CEA3DedcA698478E4cbC3F78dF2E8C6E2F8B', // BUSD
-  '0x55d398326f99059fF775485246999027B3197955', // USDT
-  '0x7130d2A12B9BCbFAe4f2634d864A1BCe1767a8D0', // BTCB
-  '0x2170Ed0880ac9A755fd29B2688956BD959F933F8', // ETH
-];
+const FEE_RECEIVER = '0xafF5340ECFaf7ce049261cff193f5FED6BDF04E7';
 
 const fetch = async (options: FetchOptions) => {
-  const dailyFees = await addTokensReceived({
-    options,
-    tokens: TOKENS,
-    targets: [FEE_RECEIVER],
-    skipIndexer: true,
-  });
+    const fees = await addTokensReceived({
+        options,
+        target: FEE_RECEIVER,
+    });
 
-  return {
-    dailyFees,
-    dailyRevenue: dailyFees,
-  };
+    const dailyFees = options.createBalances();
+    dailyFees.add(fees, 'Developer Fees');
+
+    return {
+        dailyFees,
+        dailyRevenue: dailyFees,
+        dailyProtocolRevenue: dailyFees,
+    };
+};
+
+const methodology = {
+    Fees: "We track fees sent to the fee receiver address which represents the developer commission for every swap executed via our frontend integration.",
+    Revenue: "Developer fees (0.1% per swap) are collected from each trade and sent to the designated fee receiver address.",
+    ProtocolRevenue: "Developer fees (0.1% per swap) are collected from each trade and sent to the designated fee receiver address.",
+};
+
+const breakdownMethodology = {
+    Fees: {
+        'Developer Fees': "Developer fees (0.1% per swap) are collected from each trade and sent to the designated fee receiver address.",
+    },
+    Revenue: {
+        'Developer Fees': "Developer fees (0.1% per swap) are collected from each trade and sent to the designated fee receiver address.",
+    },
+    ProtocolRevenue: {
+        'Developer Fees': "Developer fees (0.1% per swap) are collected from each trade and sent to the designated fee receiver address.",
+    },
 };
 
 const adapter: Adapter = {
-  version: 2,
-  chains: [CHAIN.BSC],
-  fetch,
-  start: '2024-09-01',
-  methodology: {
-    Fees: "We track fees sent to the fee receiver address which represents the developer commission for every swap executed via our frontend integration.",
-    Revenue: "Developer fees (0.1% per swap) are collected from each trade and sent to the designated fee receiver address.",
-  },
+    version: 2,
+    pullHourly: true,
+    chains: [CHAIN.BSC],
+    fetch,
+    start: '2026-03-23',
+    methodology,
+    breakdownMethodology,
 };
 
 export default adapter;


### PR DESCRIPTION
## Project Name
Arbitrage Inc.

## Project Type
DEX Aggregator / Fees

## Website
https://arbitrage-inc.exchange

## Twitter
@Arbitrageincept

## Methodology
We track fees sent to the address 0xafF5340ECFaf7ce049261cff193f5FED6BDF04E7 which represents the developer commission (0.1%) for every swap executed via our frontend integration.

## Chain
BNB Smart Chain (BSC)

## Fees Adapter
This adapter tracks fees received by the developer fee receiver address on BSC.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Arbitrage Inc fee tracking support for Binance Smart Chain. The new adapter monitors developer fees and platform revenue metrics with hourly data updates, enabling real-time tracking of revenue breakdowns. Historical data collection begins from March 23, 2026.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->