### PR TITLE
Alphix: add AlphixLVRFee hook pools, remove deprecated ETH/USDC pool

### DIFF
--- a/dexs/alphix.ts
+++ b/dexs/alphix.ts
@@ -15,12 +15,16 @@ const config: Record<string, ChainConfig> = {
     poolManager: "0x498581ff718922c3f8e6a244956af099b2652b2b",
     pools: [
       {
-        id: "0x71c06960eee8003ebf3f869caa480d7032c7088850d951f04de5b46d86ada017",
-        token: "0x4200000000000000000000000000000000000006", // WETH
+        id: "0xebb666a5c6449b83536950b975d74deb32aca1537a501b58161a896816b04da6",
+        token: "0x4200000000000000000000000000000000000006", // ETH/USDC (AlphixLVRFee)
+      },
+      {
+        id: "0x3860784278e9e481ffd0888430ab2af8f2bb1180069f31cde9e1066728bbe73b",
+        token: "0x4200000000000000000000000000000000000006", // ETH/cbBTC (AlphixLVRFee)
       },
       {
         id: "0xaf9168a5026bd5e398863dc1d0a0513fe21417792f9df4889571fd68d2d8cd71",
-        token: "0x820c137fa70c8691f0e44dc420a5e53c168921dc", // USDS
+        token: "0x820c137fa70c8691f0e44dc420a5e53c168921dc", // USDS/USDC
       },
     ],
   },

--- a/fees/alphix.ts
+++ b/fees/alphix.ts
@@ -16,11 +16,13 @@ const config: Record<string, ChainConfig> = {
   [CHAIN.BASE]: {
     poolManager: '0x498581ff718922c3f8e6a244956af099b2652b2b',
     pools: [
-      { id: '0x71c06960eee8003ebf3f869caa480d7032c7088850d951f04de5b46d86ada017', token: '0x4200000000000000000000000000000000000006' }, // WETH
-      { id: '0xaf9168a5026bd5e398863dc1d0a0513fe21417792f9df4889571fd68d2d8cd71', token: '0x820c137fa70c8691f0e44dc420a5e53c168921dc' }, // USDS
+      // AlphixLVRFee hook (0x7cBbfF9C4fcd74B221C535F4fB4B1Db04F1B9044) — pure swap fee, no lending
+      { id: '0xebb666a5c6449b83536950b975d74deb32aca1537a501b58161a896816b04da6', token: '0x4200000000000000000000000000000000000006' }, // ETH/USDC
+      { id: '0x3860784278e9e481ffd0888430ab2af8f2bb1180069f31cde9e1066728bbe73b', token: '0x4200000000000000000000000000000000000006' }, // ETH/cbBTC
+      // Alphix rehypothecation hooks
+      { id: '0xaf9168a5026bd5e398863dc1d0a0513fe21417792f9df4889571fd68d2d8cd71', token: '0x820c137fa70c8691f0e44dc420a5e53c168921dc' }, // USDS/USDC
     ],
     hooks: [
-      '0x831cfdf7c0e194f5369f204b3dd2481b843d60c0',
       '0x0e4b892df7c5bcf5010faf4aa106074e555660c0',
     ],
     wrappers: [


### PR DESCRIPTION
Hi! This PR updates the Alphix adapters with our new AlphixLVRFee hook deployment on Base:

- **Add 2 new pools** on the AlphixLVRFee hook (`0x7cBbfF9C4fcd74B221C535F4fB4B1Db04F1B9044`):
  - ETH/USDC (pool `0xebb666...`)
  - ETH/cbBTC (pool `0x386078...`)
- **Remove deprecated ETH/USDC pool** (`0x71c069...` on old hook `0x831c...`) — nearly no volume remaining
- The new hook is a pure dynamic fee hook (no lending/rehypothecation), so it only contributes swap fees and volume

Happy to adjust anything!

## Test results (2026-03-29)

fees/alphix.ts:
base:      Daily fees: 10.00 | Supply side: 8.00 | Protocol: 2.00
arbitrum:  Daily fees: 3.00  | Supply side: 2.00 | Protocol: 1.00
Aggregate: Daily fees: 13.00

dexs/alphix.ts:
base:      Daily volume: 16.87k
arbitrum:  Daily volume: 58.69k
Aggregate: Daily volume: 75.56k

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for two new trading pairs on Base chain Alphix: ETH/USDC and ETH/cbBTC.
  * Updated pool configuration to reflect the new liquidity pools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->