### PR TITLE
Add MultiMesh fees adapter

### DIFF
--- a/fees/multimesh/index.ts
+++ b/fees/multimesh/index.ts
@@ -1,0 +1,37 @@
+import { FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+
+const LIFI_FEE_COLLECTOR = "0xbD6C7B0d2f68c2b7805d88388319cfB6EcB50eA9";
+const MULTIMESH_INTEGRATOR = "0x552008c0f6870c2f77e5cC1d2eb9bdff03e30Ea0";
+const FEES_COLLECTED_EVENT = "event FeesCollected(address indexed _token, address indexed _integrator, uint256 _integratorFee, uint256 _lifiFee)";
+
+const fetch = async (options: FetchOptions) => {
+  const dailyFees = options.createBalances();
+  const dailyRevenue = options.createBalances();
+  const logs = await options.getLogs({
+    target: LIFI_FEE_COLLECTOR,
+    eventAbi: FEES_COLLECTED_EVENT,
+    onlyArgs: true,
+  });
+  const multimeshLogs = logs.filter(
+    (log: any) => log._integrator.toLowerCase() === MULTIMESH_INTEGRATOR.toLowerCase()
+  );
+  for (const log of multimeshLogs) {
+    dailyFees.add(log._token, log._integratorFee + log._lifiFee);
+    dailyRevenue.add(log._token, log._integratorFee);
+  }
+  return { dailyFees, dailyRevenue };
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  fetch,
+  chains: [CHAIN.ETHEREUM, CHAIN.ARBITRUM, CHAIN.POLYGON, CHAIN.OPTIMISM, CHAIN.BSC],
+  start: "2025-03-01",
+  methodology: {
+    Fees: "Total fees collected on swaps routed through MultiMesh via LI.FI.",
+    Revenue: "MultiMesh's 15bps integrator fee on all cross-chain swaps.",
+  },
+};
+
+export default adapter;

--- a/fees/multimesh/index.ts
+++ b/fees/multimesh/index.ts
@@ -1,7 +1,13 @@
 import { FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 
-const LIFI_FEE_COLLECTOR = "0xbD6C7B0d2f68c2b7805d88388319cfB6EcB50eA9";
+const LIFI_FEE_COLLECTOR: Partial<Record<string, string>> = {
+  [CHAIN.ETHEREUM]: "0xbD6C7B0d2f68c2b7805d88388319cfB6EcB50eA9",
+  [CHAIN.ARBITRUM]: "0x8021E9F5E4D0C9A08E8b53B4E3776B65b1d89B59",
+  [CHAIN.POLYGON]:  "0xbD6C7B0d2f68c2b7805d88388319cfB6EcB50eA9",
+  [CHAIN.OPTIMISM]: "0xbD6C7B0d2f68c2b7805d88388319cfB6EcB50eA9",
+  [CHAIN.BSC]:      "0xbD6C7B0d2f68c2b7805d88388319cfB6EcB50eA9",
+};
 const MULTIMESH_INTEGRATOR = "0x552008c0f6870c2f77e5cC1d2eb9bdff03e30Ea0";
 const FEES_COLLECTED_EVENT = "event FeesCollected(address indexed _token, address indexed _integrator, uint256 _integratorFee, uint256 _lifiFee)";
 
@@ -9,7 +15,7 @@ const fetch = async (options: FetchOptions) => {
   const dailyFees = options.createBalances();
   const dailyRevenue = options.createBalances();
   const logs = await options.getLogs({
-    target: LIFI_FEE_COLLECTOR,
+    target: LIFI_FEE_COLLECTOR[options.chain] ?? "0xbD6C7B0d2f68c2b7805d88388319cfB6EcB50eA9",
     eventAbi: FEES_COLLECTED_EVENT,
     onlyArgs: true,
   });


### PR DESCRIPTION
##### Name (to be shown on DefiLlama):
MultiMesh

##### Twitter Link:
https://x.com/MultiMesh_01

##### List of audit links if any:

##### Website Link:
https://themultimesh.com

##### Logo (High resolution, will be shown with rounded borders):

##### Current TVL:
0

##### Short Description (to be shown on DefiLlama):
Cross-chain swap aggregator powered by LI.FI routing. Swap any token across Ethereum, Arbitrum, Polygon, Optimism and BNB Chain in one click.

##### Category:
Aggregator

##### Github org/user:
kurzmichael02-hue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * MultiMesh fee and revenue tracking added across Ethereum, Arbitrum, Polygon, Optimism, and BSC.
  * Provides daily aggregated metrics (Fees and Revenue) starting March 1, 2025, with methodology descriptions for each metric.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->