### PR TITLE
fix: changes default creator_fee_pct from 0 to 50

### DIFF
--- a/helpers/queries/bags.sql
+++ b/helpers/queries/bags.sql
@@ -43,6 +43,7 @@ WITH
                     '$.SwapResult.trading_fee'
                 ) AS DECIMAL(38,0)
             ) AS trading_fee,
+            -- Default to 50% for v1 configs not in evtcreateconfigv2 (pre-August Meteora update)
             COALESCE(c.creator_fee_pct, 50) AS creator_fee_pct
         FROM meteora_solana.dynamic_bonding_curve_evt_evtswap s
         JOIN dbc_pools p


### PR DESCRIPTION
# Bags Revenue Fix

This is in regards to earlier data not showing any revenue.

The issue is we look for creator trading fee pct in `evtcreateconfigv2` but i checked and that event appears only after meteoras update in august. we also have 141k total configs but only 86k show up there, so 55k from the v1 time. so the revenue is always 0 because of the left join on a not-found config.

i ran the same sql query for dune after changing it, for both q2 and q3, and i get exactly 1/2 of fees reported which is good.
