### PR TITLE
options/paradex: fix stale Perp_Option adapter, migrate to current options product

### DIFF
--- a/options/paradex/index.ts
+++ b/options/paradex/index.ts
@@ -2,34 +2,49 @@ import fetchURL from "../../utils/fetchURL"
 import { FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 
-// Options Daily Volume - rolling window of recent daily options volume
+// Options Daily Volume (notional) - rolling window of recent daily options volume
 const dailyVolumeEndpoint = 'https://tradeparadigm.metabaseapp.com/api/public/dashboard/e4d7b84d-f95f-48eb-b7a6-141b3dcef4e2/dashcard/27263/card/32012?parameters=%5B%5D'
+// Options Daily Premium - rolling window of recent daily options premium volume
+const dailyPremiumEndpoint = 'https://tradeparadigm.metabaseapp.com/api/public/dashboard/e4d7b84d-f95f-48eb-b7a6-141b3dcef4e2/dashcard/28546/card/32935?parameters=%5B%5D'
 
-interface DailyVolumeCache {
-  [date: string]: number
+interface DailyCache {
+  [date: string]: { notional: number, premium: number }
 }
 
-let dailyVolumeCache: DailyVolumeCache | null = null
+let dailyCache: DailyCache | null = null
 
-const fetchDailyVolumeCache = async (): Promise<DailyVolumeCache> => {
-  if (dailyVolumeCache) return dailyVolumeCache
-  const { data: { rows } } = await fetchURL(dailyVolumeEndpoint)
-  dailyVolumeCache = {}
-  for (const row of rows) {
-    // Row format: [DAY, VOLUME]
+const fetchDailyCache = async (): Promise<DailyCache> => {
+  if (dailyCache) return dailyCache
+  const [volumeRes, premiumRes] = await Promise.all([
+    fetchURL(dailyVolumeEndpoint),
+    fetchURL(dailyPremiumEndpoint),
+  ])
+  const cache: DailyCache = {}
+  // Notional card row format: [DAY, VOLUME]
+  for (const row of volumeRes.data.rows) {
     const date = row[0].slice(0, 10) // "2026-04-08T00:00:00Z" -> "2026-04-08"
-    dailyVolumeCache[date] = Number(row[1] ?? 0)
+    cache[date] = { notional: Number(row[1] ?? 0), premium: 0 }
   }
-  return dailyVolumeCache
+  // Premium card row format: [DAY, PREMIUM_VOLUME, CUMULATIVE_PREMIUM_VOLUME]
+  for (const row of premiumRes.data.rows) {
+    const date = row[0].slice(0, 10)
+    if (!cache[date]) cache[date] = { notional: 0, premium: 0 }
+    cache[date].premium = Number(row[1] ?? 0)
+  }
+  dailyCache = cache
+  return dailyCache
 }
 
 const fetch = async (options: FetchOptions) => {
   const { startOfDay } = options
-  const cache = await fetchDailyVolumeCache()
+  const cache = await fetchDailyCache()
   const dateKey = new Date(startOfDay * 1000).toISOString().slice(0, 10)
-  const dailyNotionalVolume = cache[dateKey]
-  if (dailyNotionalVolume === undefined) throw new Error(`No Paradex options volume data for ${dateKey}`)
-  return { dailyNotionalVolume }
+  const entry = cache[dateKey]
+  if (!entry) throw new Error(`No Paradex options volume data for ${dateKey}`)
+  return {
+    dailyNotionalVolume: entry.notional,
+    dailyPremiumVolume: entry.premium,
+  }
 }
 
 const adapter: SimpleAdapter = {

--- a/options/paradex/index.ts
+++ b/options/paradex/index.ts
@@ -1,38 +1,45 @@
 import fetchURL from "../../utils/fetchURL"
-import { FetchResultOptions, SimpleAdapter } from "../../adapters/types";
+import { FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 
-const volumeEndpoint = 'https://tradeparadigm.metabaseapp.com/api/public/dashboard/e4d7b84d-f95f-48eb-b7a6-141b3dcef4e2/dashcard/7734/card/6988'
+// Options Daily Volume - rolling window of recent daily options volume
+const dailyVolumeEndpoint = 'https://tradeparadigm.metabaseapp.com/api/public/dashboard/e4d7b84d-f95f-48eb-b7a6-141b3dcef4e2/dashcard/27263/card/32012?parameters=%5B%5D'
 
-interface IVolumeData {
-  data: {
-    rows: [string, string, number][];
-  }
+interface DailyVolumeCache {
+  [date: string]: number
 }
 
-const fetch = async (timestamp: number): Promise<FetchResultOptions> => {
-  const volumesData = await fetchURL(volumeEndpoint) as IVolumeData
-  const timestampStr = new Date(timestamp * 1000).toISOString().split('T')[0] + "T00:00:00Z"
-  
-  // Find the Perp_Option data for the requested date
-  const dailyVolume = volumesData.data.rows.find(row => ((row[0] === timestampStr) && (row[1] === 'Perp_Option')))?.[2]
-  
-  if (!dailyVolume) throw new Error('Perp_Option record missing for date: ' + timestampStr)
-  
-  return { 
-    timestamp,
-    dailyNotionalVolume: dailyVolume,
-    dailyPremiumVolume: 0,
-  };
-};
+let dailyVolumeCache: DailyVolumeCache | null = null
+
+const fetchDailyVolumeCache = async (): Promise<DailyVolumeCache> => {
+  if (dailyVolumeCache) return dailyVolumeCache
+  const { data: { rows } } = await fetchURL(dailyVolumeEndpoint)
+  dailyVolumeCache = {}
+  for (const row of rows) {
+    // Row format: [DAY, VOLUME]
+    const date = row[0].slice(0, 10) // "2026-04-08T00:00:00Z" -> "2026-04-08"
+    dailyVolumeCache[date] = Number(row[1] ?? 0)
+  }
+  return dailyVolumeCache
+}
+
+const fetch = async (options: FetchOptions) => {
+  const { startOfDay } = options
+  const cache = await fetchDailyVolumeCache()
+  const dateKey = new Date(startOfDay * 1000).toISOString().slice(0, 10)
+  const dailyNotionalVolume = cache[dateKey]
+  if (dailyNotionalVolume === undefined) throw new Error(`No Paradex options volume data for ${dateKey}`)
+  return { dailyNotionalVolume }
+}
 
 const adapter: SimpleAdapter = {
+  version: 2,
   adapter: {
     [CHAIN.PARADEX]: {
       fetch,
-      start: '2025-03-29',
+      start: '2026-03-25',
     },
   },
-};
+}
 
-export default adapter;
+export default adapter


### PR DESCRIPTION
## Summary
The existing Paradex options adapter filtered for rows where the product label is `Perp_Option`, a discontinued product. Paradex's current options product uses `market_type = OPTION` and has its own dedicated Metabase cards on the public Platform Stats dashboard.

This PR:
- Points the adapter at the new Options Daily Volume card (notional)
- Populates `dailyPremiumVolume` from the new Options Daily Premium card (previously hardcoded to `0`)
- Upgrades to v2 `FetchOptions` (matching `dexs/paradex` style)
- Module-caches the dashcard responses so a single pair of HTTP calls serves all timestamps
- Sets `start: '2026-03-25'`, the earliest date currently in the card

Paradex options launched recently, hence the limited backfill window.

## Test plan
- [x] `pnpm test options paradex 2026-04-06` → notional `$386.43k` / premium `$10.59k` (ratio 2.74%, in line with peer DeFi options venues like Derive)
- [x] `pnpm test options paradex 2026-03-27` → matches dashcard
- [x] `pnpm test options paradex 2026-02-01` → correctly skipped (pre-start)