### PR TITLE
Add Metric DEX volume adapter

### DIFF
--- a/dexs/metric/index.ts
+++ b/dexs/metric/index.ts
@@ -1,0 +1,76 @@
+import { FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import { httpGet } from "../../utils/fetchURL";
+
+const API_BASE = "https://api.metric.xyz";
+
+const API_CHAIN_NAMES: Record<string, string> = {
+  [CHAIN.ETHEREUM]: "ethereum",
+  [CHAIN.BASE]: "base",
+  [CHAIN.ARBITRUM]: "arbitrum",
+  [CHAIN.BSC]: "bsc",
+  [CHAIN.AVAX]: "avax",
+  [CHAIN.POLYGON]: "polygon",
+};
+
+const SwapEvent =
+  "event Swap(address sender, address recipient, bool exactInput, int128 amount0Delta, int128 amount1Delta, int16 newTick, uint104 newPositionInBin)";
+
+const methodology = {
+  Volume:
+    "Sum of all input token amounts from Swap events across every pool deployed by the Metric factory.",
+};
+
+interface PoolMeta {
+  poolAddress: string;
+  token0: string;
+  token1: string;
+}
+
+const fetch = async (options: FetchOptions) => {
+  const dailyVolume = options.createBalances();
+  const chainName = API_CHAIN_NAMES[options.chain];
+
+  const pools: PoolMeta[] = await httpGet(`${API_BASE}/${chainName}/metadata`);
+  if (!pools.length) return { dailyVolume };
+
+  const poolAddresses = pools.map((p) => p.poolAddress);
+  const tokensByIndex = pools.map((p) => ({ token0: p.token0, token1: p.token1 }));
+
+  const allLogs = await options.getLogs({
+    targets: poolAddresses,
+    eventAbi: SwapEvent,
+    flatten: false,
+  });
+
+  (allLogs as any[][]).forEach((logs: any[], index: number) => {
+    if (!logs.length) return;
+    const { token0, token1 } = tokensByIndex[index];
+    for (const log of logs) {
+      const amount0 = BigInt(log.amount0Delta);
+      const amount1 = BigInt(log.amount1Delta);
+      if (amount0 > 0n) {
+        dailyVolume.add(token0, amount0);
+      } else if (amount1 > 0n) {
+        dailyVolume.add(token1, amount1);
+      }
+    }
+  });
+
+  return { dailyVolume };
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  adapter: {
+    [CHAIN.ETHEREUM]: { fetch, start: "2026-02-23" },
+    [CHAIN.BASE]: { fetch, start: "2026-04-05" },
+    [CHAIN.ARBITRUM]: { fetch, start: "2026-02-17" },
+    [CHAIN.BSC]: { fetch, start: "2026-02-23" },
+    [CHAIN.AVAX]: { fetch, start: "2026-02-23" },
+    [CHAIN.POLYGON]: { fetch, start: "2026-02-23" },
+  },
+  methodology,
+};
+
+export default adapter;


### PR DESCRIPTION
## Summary
Adds a volume adapter for Metric protocol.

## Details
- **Dashboard**: dexs
- **Chain**: Ethereum, Base, BSC, Arbitrum, Polygon, AVAX
- **Factory**: 0xe22F9fc0f04486dE25ed6CF1800a4a47aFD82e0C
- **Data source**: API (Pools metadata), on-chain event logs (Swap)
- **Dimensions**: dailyVolume
- **twitter**: https://x.com/Metricxyz

 ## Testing
 \`\`\`
 npm test dexs metric
 npm test dexs metric 2025-04-08
 \`\`\`