### PR TITLE
[update] Enso - Change volume fetch to dedicated endpoint

### DIFF
--- a/aggregators/enso/index.ts
+++ b/aggregators/enso/index.ts
@@ -1,116 +1,63 @@
+import { httpGet } from "../../utils/fetchURL";
 import { CHAIN } from "../../helpers/chains";
-import { Dependencies, FetchOptions } from "../../adapters/types";
-import { queryDuneSql } from "../../helpers/dune";
+import { FetchOptions,  } from "../../adapters/types";
 
-const chains: Record<string, { duneChain: string; start: string }> = {
-  [CHAIN.ETHEREUM]: { duneChain: "ethereum", start: "2023-06-22" },
-  [CHAIN.OPTIMISM]: { duneChain: "optimism", start: "2023-09-19" },
-  [CHAIN.BSC]: { duneChain: "binance", start: "2023-09-20" },
-  [CHAIN.POLYGON]: { duneChain: "polygon", start: "2023-09-05" },
-  [CHAIN.BASE]: { duneChain: "base", start: "2023-12-24" },
-  [CHAIN.ARBITRUM]: { duneChain: "arbitrum", start: "2023-09-11" },
-  [CHAIN.BERACHAIN]: { duneChain: "berachain", start: "2025-01-25" },
-  [CHAIN.LINEA]: { duneChain: "linea", start: "2023-12-14" },
-  [CHAIN.SONIC]: { duneChain: "sonic", start: "2025-01-01" },
-  [CHAIN.UNICHAIN]: { duneChain: "unichain", start: "2025-01-01" },
-  [CHAIN.HYPERLIQUID]: { duneChain: "hyperevm", start: "2025-01-01" },
-  [CHAIN.KATANA]: { duneChain: "katana", start: "2025-01-01" },
-  [CHAIN.PLUME]: { duneChain: "plume", start: "2025-01-01" },
-  [CHAIN.ZKSYNC]: { duneChain: "zksync", start: "2025-01-01" },
-  [CHAIN.AVAX]: { duneChain: "avalanche_c", start: "2023-01-01" },
-  [CHAIN.XDAI]: { duneChain: "gnosis", start: "2023-01-01" },
-  [CHAIN.PLASMA]: { duneChain: "plasma", start: "2025-10-01" },
-  [CHAIN.MONAD]: { duneChain: "monad", start: "2025-11-01" },
+const chains: Record<string, { id: number; start: string }> = {
+    [CHAIN.ETHEREUM]: { id: 1, start: "2026-04-01" },
+    [CHAIN.OPTIMISM]: { id: 10, start: "2026-04-01" },
+    [CHAIN.BSC]: { id: 56, start: "2026-04-01" },
+    [CHAIN.XDAI]: { id: 100, start: "2026-04-01" },
+    [CHAIN.UNICHAIN]: { id: 130, start: "2026-04-01" },
+    [CHAIN.POLYGON]: { id: 137, start: "2026-04-01" },
+    [CHAIN.MONAD]: { id: 143, start: "2026-04-01" },
+    [CHAIN.SONIC]: { id: 146, start: "2026-04-01" },
+    [CHAIN.ZKSYNC]: { id: 324, start: "2026-04-01" },
+    [CHAIN.WC]: { id: 480, start: "2026-04-01" },
+    [CHAIN.HYPERLIQUID]:{ id: 999, start: "2026-04-01" },
+    [CHAIN.SONEIUM]: { id: 1868, start: "2026-04-01" },
+    [CHAIN.TEMPO]: { id: 4217, start: "2026-04-01" },
+    [CHAIN.BASE]: { id: 8453, start: "2026-04-01" },
+    [CHAIN.PLASMA]: { id: 9745, start: "2026-04-01" },
+    [CHAIN.ARBITRUM]: { id: 42161, start: "2026-04-01" },
+    [CHAIN.AVAX]: { id: 43114, start: "2026-04-01" },
+    [CHAIN.INK]: { id: 57073, start: "2026-04-01" },
+    [CHAIN.LINEA]: { id: 59144, start: "2026-04-01" },
+    [CHAIN.BERACHAIN]: { id: 80094, start: "2026-04-01" },
+    [CHAIN.PLUME]: { id: 98866, start: "2026-04-01" },
+    [CHAIN.KATANA]: { id: 747474, start: "2026-04-01" },
 };
 
-// Prefetch function that will run once before any fetch calls
-const prefetch = async (options: FetchOptions) => {
-  const { startTimestamp, endTimestamp } = options;
-  
-  return queryDuneSql(options, `
-    WITH base_query AS (
-        SELECT DISTINCT chain FROM dune.enso_finance.result_ethereum_token_transfers_with_prices
-    ),
-    Filtered_Transactions AS (
-        SELECT *
-        FROM dune.enso_finance.result_ethereum_token_transfers_with_prices
-        WHERE block_time >= from_unixtime(${startTimestamp})
-        AND block_time < from_unixtime(${endTimestamp})
-    ),
-    Aggregated_Volume_Time_Range AS (
-        SELECT
-            chain,
-            COALESCE(SUM(dollar_value), 0) AS volume_timerange
-        FROM Filtered_Transactions
-        GROUP BY chain
-    ),
-    Additional_Volume_Berachain AS (
-        SELECT
-            'berachain' AS chain,
-            COALESCE(SUM(extra_volume), 0) AS additional_volume_timerange
-        FROM (
-            SELECT DATE '2025-02-05' AS extra_date, 1106583664 AS extra_volume
-            UNION ALL
-            SELECT DATE '2025-02-04', 1435404805
-            UNION ALL
-            SELECT DATE '2025-02-03', 410460104
-        ) AS extra
-        WHERE extra_date >= CAST(from_unixtime(${startTimestamp}) AS DATE)
-          AND extra_date < CAST(from_unixtime(${endTimestamp}) AS DATE)
-    ),
-    Final_Volume AS (
-        SELECT
-            vtimerange.chain,
-            COALESCE(vtimerange.volume_timerange, 0) AS volume_timerange
-        FROM Aggregated_Volume_Time_Range vtimerange
-
-        UNION ALL
-
-        SELECT
-            chain,
-            additional_volume_timerange AS volume_timerange
-        FROM Additional_Volume_Berachain
-    )
-    SELECT
-        chain AS blockchain,
-        volume_timerange
-    FROM Final_Volume
-    ORDER BY volume_timerange DESC
-  `);
-};
+const toUtcDay = (timestamp: number) =>
+    new Date(timestamp * 1000).toISOString().slice(0, 10);
 
 const fetchVolume = async (_: any, _1: any, options: FetchOptions) => {
-  const { endTimestamp, chain } = options;
-  const chainConfig = chains[chain];
-  if (!chainConfig) throw new Error(`Chain configuration not found for: ${chain}`);
-
-  const data = options.preFetchedResults || [];
-  const chainData = data.find(item => item.blockchain === chainConfig.duneChain.toLowerCase());
-  
-  if (!chainData) {
+    const { endTimestamp, chain } = options;
+    const chainConfig = chains[chain];
+    if (!chainConfig) {
+        throw new Error(`Chain configuration not found for: ${chain}`);
+    }
+    const day = toUtcDay(endTimestamp);
+    const url = `https://api.enso.finance/api/v1/reporting/volume/defillama?chainId=${chainConfig.id}&from=${day}&to=${day}`;
+    const response = await httpGet(url, {
+        headers: {
+            origin: "https://defillama.com"
+        },
+    });
     return {
-      dailyVolume: 0,
-      timestamp: endTimestamp,
+        dailyVolume: response?.[0]?.publishedVolumeUsd ?? "0",
+        timestamp: endTimestamp,
     };
-  }
-
-  return {
-    dailyVolume: chainData.volume_timerange,
-    timestamp: endTimestamp,
-  };
 };
 
 const adapter: any = {
-  version: 1,
-  isExpensiveAdapter: true,
-  dependencies: [Dependencies.DUNE],
-  adapter: Object.fromEntries(
-    Object.entries(chains).map(([chain, { start }]) => [
-      chain,
-      { fetch: fetchVolume, start },
-    ])
-  ),
-  prefetch: prefetch,
+    version: 1,
+    isExpensiveAdapter: false,
+    adapter: Object.fromEntries(
+        Object.entries(chains).map(([chain, { start }]) => [
+            chain,
+            { fetch: fetchVolume, start },
+        ])
+    ),
 };
 
 export default adapter;

--- a/aggregators/enso/index.ts
+++ b/aggregators/enso/index.ts
@@ -1,30 +1,30 @@
 import { httpGet } from "../../utils/fetchURL";
 import { CHAIN } from "../../helpers/chains";
-import { FetchOptions,  } from "../../adapters/types";
+import { FetchOptions } from "../../adapters/types";
 
 const chains: Record<string, { id: number; start: string }> = {
-    [CHAIN.ETHEREUM]: { id: 1, start: "2026-03-31" },
-    [CHAIN.OPTIMISM]: { id: 10, start: "2026-03-31" },
-    [CHAIN.BSC]: { id: 56, start: "2026-03-31" },
-    [CHAIN.XDAI]: { id: 100, start: "2026-03-31" },
-    [CHAIN.UNICHAIN]: { id: 130, start: "2026-03-31" },
-    [CHAIN.POLYGON]: { id: 137, start: "2026-03-31" },
-    [CHAIN.MONAD]: { id: 143, start: "2026-03-31" },
-    [CHAIN.SONIC]: { id: 146, start: "2026-03-31" },
-    [CHAIN.ZKSYNC]: { id: 324, start: "2026-03-31" },
+    [CHAIN.ETHEREUM]: { id: 1, start: "2023-06-22" },
+    [CHAIN.OPTIMISM]: { id: 10, start: "2023-09-19" },
+    [CHAIN.BSC]: { id: 56, start: "2023-09-20" },
+    [CHAIN.XDAI]: { id: 100, start: "2023-01-01" },
+    [CHAIN.UNICHAIN]: { id: 130, start: "2025-01-01" },
+    [CHAIN.POLYGON]: { id: 137, start: "2023-09-05" },
+    [CHAIN.MONAD]: { id: 143, start: "2025-11-01" },
+    [CHAIN.SONIC]: { id: 146, start: "2025-01-01" },
+    [CHAIN.ZKSYNC]: { id: 324, start: "2025-01-01" },
     [CHAIN.WC]: { id: 480, start: "2026-03-31" },
-    [CHAIN.HYPERLIQUID]:{ id: 999, start: "2026-03-31" },
+    [CHAIN.HYPERLIQUID]:{ id: 999, start: "2025-01-01" },
     [CHAIN.SONEIUM]: { id: 1868, start: "2026-03-31" },
     [CHAIN.TEMPO]: { id: 4217, start: "2026-03-31" },
-    [CHAIN.BASE]: { id: 8453, start: "2026-03-31" },
-    [CHAIN.PLASMA]: { id: 9745, start: "2026-03-31" },
-    [CHAIN.ARBITRUM]: { id: 42161, start: "2026-03-31" },
-    [CHAIN.AVAX]: { id: 43114, start: "2026-03-31" },
+    [CHAIN.BASE]: { id: 8453, start: "2023-12-24" },
+    [CHAIN.PLASMA]: { id: 9745, start: "2025-10-01" },
+    [CHAIN.ARBITRUM]: { id: 42161, start: "2023-09-11" },
+    [CHAIN.AVAX]: { id: 43114, start: "2023-01-01" },
     [CHAIN.INK]: { id: 57073, start: "2026-03-31" },
-    [CHAIN.LINEA]: { id: 59144, start: "2026-03-31" },
-    [CHAIN.BERACHAIN]: { id: 80094, start: "2026-03-31" },
-    [CHAIN.PLUME]: { id: 98866, start: "2026-03-31" },
-    [CHAIN.KATANA]: { id: 747474, start: "2026-03-31" },
+    [CHAIN.LINEA]: { id: 59144, start: "2023-12-14" },
+    [CHAIN.BERACHAIN]: { id: 80094, start: "2025-01-25" },
+    [CHAIN.PLUME]: { id: 98866, start: "2025-01-01" },
+    [CHAIN.KATANA]: { id: 747474, start: "2025-01-01" },
 };
 
 const toUtcDay = (timestamp: number) =>

--- a/aggregators/enso/index.ts
+++ b/aggregators/enso/index.ts
@@ -3,32 +3,39 @@ import { CHAIN } from "../../helpers/chains";
 import { FetchOptions,  } from "../../adapters/types";
 
 const chains: Record<string, { id: number; start: string }> = {
-    [CHAIN.ETHEREUM]: { id: 1, start: "2026-04-01" },
-    [CHAIN.OPTIMISM]: { id: 10, start: "2026-04-01" },
-    [CHAIN.BSC]: { id: 56, start: "2026-04-01" },
-    [CHAIN.XDAI]: { id: 100, start: "2026-04-01" },
-    [CHAIN.UNICHAIN]: { id: 130, start: "2026-04-01" },
-    [CHAIN.POLYGON]: { id: 137, start: "2026-04-01" },
-    [CHAIN.MONAD]: { id: 143, start: "2026-04-01" },
-    [CHAIN.SONIC]: { id: 146, start: "2026-04-01" },
-    [CHAIN.ZKSYNC]: { id: 324, start: "2026-04-01" },
-    [CHAIN.WC]: { id: 480, start: "2026-04-01" },
-    [CHAIN.HYPERLIQUID]:{ id: 999, start: "2026-04-01" },
-    [CHAIN.SONEIUM]: { id: 1868, start: "2026-04-01" },
-    [CHAIN.TEMPO]: { id: 4217, start: "2026-04-01" },
-    [CHAIN.BASE]: { id: 8453, start: "2026-04-01" },
-    [CHAIN.PLASMA]: { id: 9745, start: "2026-04-01" },
-    [CHAIN.ARBITRUM]: { id: 42161, start: "2026-04-01" },
-    [CHAIN.AVAX]: { id: 43114, start: "2026-04-01" },
-    [CHAIN.INK]: { id: 57073, start: "2026-04-01" },
-    [CHAIN.LINEA]: { id: 59144, start: "2026-04-01" },
-    [CHAIN.BERACHAIN]: { id: 80094, start: "2026-04-01" },
-    [CHAIN.PLUME]: { id: 98866, start: "2026-04-01" },
-    [CHAIN.KATANA]: { id: 747474, start: "2026-04-01" },
+    [CHAIN.ETHEREUM]: { id: 1, start: "2026-03-31" },
+    [CHAIN.OPTIMISM]: { id: 10, start: "2026-03-31" },
+    [CHAIN.BSC]: { id: 56, start: "2026-03-31" },
+    [CHAIN.XDAI]: { id: 100, start: "2026-03-31" },
+    [CHAIN.UNICHAIN]: { id: 130, start: "2026-03-31" },
+    [CHAIN.POLYGON]: { id: 137, start: "2026-03-31" },
+    [CHAIN.MONAD]: { id: 143, start: "2026-03-31" },
+    [CHAIN.SONIC]: { id: 146, start: "2026-03-31" },
+    [CHAIN.ZKSYNC]: { id: 324, start: "2026-03-31" },
+    [CHAIN.WC]: { id: 480, start: "2026-03-31" },
+    [CHAIN.HYPERLIQUID]:{ id: 999, start: "2026-03-31" },
+    [CHAIN.SONEIUM]: { id: 1868, start: "2026-03-31" },
+    [CHAIN.TEMPO]: { id: 4217, start: "2026-03-31" },
+    [CHAIN.BASE]: { id: 8453, start: "2026-03-31" },
+    [CHAIN.PLASMA]: { id: 9745, start: "2026-03-31" },
+    [CHAIN.ARBITRUM]: { id: 42161, start: "2026-03-31" },
+    [CHAIN.AVAX]: { id: 43114, start: "2026-03-31" },
+    [CHAIN.INK]: { id: 57073, start: "2026-03-31" },
+    [CHAIN.LINEA]: { id: 59144, start: "2026-03-31" },
+    [CHAIN.BERACHAIN]: { id: 80094, start: "2026-03-31" },
+    [CHAIN.PLUME]: { id: 98866, start: "2026-03-31" },
+    [CHAIN.KATANA]: { id: 747474, start: "2026-03-31" },
 };
 
 const toUtcDay = (timestamp: number) =>
     new Date(timestamp * 1000).toISOString().slice(0, 10);
+
+const prefetch = async (options: FetchOptions) => {
+    const { endTimestamp } = options;
+    const day = toUtcDay(endTimestamp);
+    const url = `https://api.enso.finance/api/v1/reporting/volume/defillama?from=${day}&to=${day}`;
+    return httpGet(url, { headers: { origin: "https://defillama.com", }, });
+};
 
 const fetchVolume = async (_: any, _1: any, options: FetchOptions) => {
     const { endTimestamp, chain } = options;
@@ -36,22 +43,20 @@ const fetchVolume = async (_: any, _1: any, options: FetchOptions) => {
     if (!chainConfig) {
         throw new Error(`Chain configuration not found for: ${chain}`);
     }
-    const day = toUtcDay(endTimestamp);
-    const url = `https://api.enso.finance/api/v1/reporting/volume/defillama?chainId=${chainConfig.id}&from=${day}&to=${day}`;
-    const response = await httpGet(url, {
-        headers: {
-            origin: "https://defillama.com"
-        },
-    });
+    const data = (options.preFetchedResults || []) as Array<{
+        chainId: number;
+        publishedVolumeUsd: number;
+    }>;
+    const chainData = data.find((item) => item.chainId === chainConfig.id);
     return {
-        dailyVolume: response?.[0]?.publishedVolumeUsd ?? "0",
+        dailyVolume: chainData?.publishedVolumeUsd ?? 0,
         timestamp: endTimestamp,
     };
 };
 
 const adapter: any = {
     version: 1,
-    isExpensiveAdapter: false,
+    prefetch,
     adapter: Object.fromEntries(
         Object.entries(chains).map(([chain, { start }]) => [
             chain,

--- a/aggregators/enso/index.ts
+++ b/aggregators/enso/index.ts
@@ -31,8 +31,8 @@ const toUtcDay = (timestamp: number) =>
     new Date(timestamp * 1000).toISOString().slice(0, 10);
 
 const prefetch = async (options: FetchOptions) => {
-    const { endTimestamp } = options;
-    const day = toUtcDay(endTimestamp);
+    const { startOfDay } = options;
+    const day = toUtcDay(startOfDay);
     const url = `https://api.enso.finance/api/v1/reporting/volume/defillama?from=${day}&to=${day}`;
     return httpGet(url, { headers: { origin: "https://defillama.com", }, });
 };


### PR DESCRIPTION
This is update for existing volume fetch on Enso aggregator.

We've created a dedicated endpoint for tracking volume going through Enso replacing Dune queries. 

Internally Enso has better awareness of niche token prices as well as support for volume of various use cases. There are also guards in place for miss-priced tokens and volume calculation errors, that are way more verbose than what Dune could support.

This change will make DefiLlama volume dashboard for Enso reflect reality better.