### PR TITLE
dexs/lunarbase: update V2 pool address

### DIFF
--- a/dexs/lunarbase/index.ts
+++ b/dexs/lunarbase/index.ts
@@ -5,7 +5,7 @@ import { METRIC } from "../../helpers/metrics";
 
 const CURVE_PMMS = [
     "0x6Ccc8223532fff07f47EF4311BEB3647326894Ab",
-    "0x000027B106df9f417980Bc4EdaDD1087c6f01B99",
+    "0x00003bf45Ce34Bf1BeA78669f9A40ee630e11b99",
 ];
 
 const poolAbis = {


### PR DESCRIPTION
## Summary

Updated the LunarBase V2 pool address in the adapter.

## What changed

- Replaced the previous V2 pool address:
  - `0x000027B106df9f417980Bc4EdaDD1087c6f01B99`
- With the new V2 pool address:
  - `0x00003bf45Ce34Bf1BeA78669f9A40ee630e11b99`

## Validation

- `npm run ts-check -- --pretty false`
- `npm test -- dexs lunarbase 2026-04-13`
