### PR TITLE
add venum aggregator adapter

### DIFF
--- a/aggregators/venum/index.ts
+++ b/aggregators/venum/index.ts
@@ -1,0 +1,36 @@
+import { Adapter, FetchV2 } from "../../adapters/types";
+import { httpGet } from "../../utils/fetchURL";
+import { CHAIN } from "../../helpers/chains";
+
+const volumeEndpoint = "https://api.venum.dev/v1/stats/volume";
+
+const fetch: FetchV2 = async ({ startTimestamp, endTimestamp }) => {
+  const stats = await httpGet(volumeEndpoint, {
+    params: {
+      from: startTimestamp,
+      to: endTimestamp,
+    },
+  });
+
+  return {
+    dailyVolume: stats?.volumeUsd,
+  };
+};
+
+const adapter: Adapter = {
+  version: 2,
+  adapter: {
+    [CHAIN.SOLANA]: {
+      fetch,
+      start: '2026-04-01',
+      meta: {
+        methodology: {
+          Volume:
+            "Volume routed via the Venum aggregator frontend/API to underlying Solana DEX programs (Orca, Meteora, Raydium, etc). Each swap is recorded server-side only after the transaction is confirmed on-chain (signature verified via /v1/tx/:signature), priced from live pool quotes, deduped by signature, and served from /v1/stats/volume.",
+        },
+      },
+    },
+  },
+};
+
+export default adapter;

--- a/aggregators/venum/index.ts
+++ b/aggregators/venum/index.ts
@@ -5,32 +5,33 @@ import { CHAIN } from "../../helpers/chains";
 const volumeEndpoint = "https://api.venum.dev/v1/stats/volume";
 
 const fetch: FetchV2 = async ({ startTimestamp, endTimestamp }) => {
-  const stats = await httpGet(volumeEndpoint, {
-    params: {
-      from: startTimestamp,
-      to: endTimestamp,
-    },
-  });
+    const stats = await httpGet(volumeEndpoint, {
+        params: {
+            from: startTimestamp,
+            to: endTimestamp - 1,
+        },
+    });
 
-  return {
-    dailyVolume: stats?.volumeUsd,
-  };
+    if (!stats) {
+        throw new Error('No stats found');
+    }
+
+    return {
+        dailyVolume: stats.volumeUsd,
+    };
+};
+
+const methodology = {
+    Volume:
+        "Volume routed via the Venum aggregator frontend/API to underlying Solana DEX programs (Orca, Meteora, Raydium, etc). Each swap is recorded server-side only after the transaction is confirmed on-chain (signature verified via /v1/tx/:signature), priced from live pool quotes, deduped by signature, and served from /v1/stats/volume.",
 };
 
 const adapter: Adapter = {
-  version: 2,
-  adapter: {
-    [CHAIN.SOLANA]: {
-      fetch,
-      start: '2026-04-01',
-      meta: {
-        methodology: {
-          Volume:
-            "Volume routed via the Venum aggregator frontend/API to underlying Solana DEX programs (Orca, Meteora, Raydium, etc). Each swap is recorded server-side only after the transaction is confirmed on-chain (signature verified via /v1/tx/:signature), priced from live pool quotes, deduped by signature, and served from /v1/stats/volume.",
-        },
-      },
-    },
-  },
+    version: 2,
+    fetch,
+    chains: [CHAIN.SOLANA],
+    start: '2026-04-01',
+    methodology,
 };
 
 export default adapter;


### PR DESCRIPTION
##### Name (to be shown on DefiLlama):
Venum Swap

##### Twitter Link:
https://x.com/venumdev

##### List of audit links if any:
N/A

##### Website Link:
https://swap.venum.dev

##### Logo (High resolution, will be shown with rounded borders):
https://www.venum.dev/logo-512.png

##### Current TVL:
N/A

##### Treasury Addresses (if the protocol has treasury)
N/A

##### Chain:
Solana

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed): (https://api.coingecko.com/api/v3/coins/list)

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)

##### Short Description (to be shown on DefiLlama):
Solana DEX aggregator built on the Venum API.

##### Token address and ticker if any:
No token

##### Category (full list at https://defillama.com/categories) *Please choose only one:
DEX Aggregator

##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.):
N/A for this volume adapter. Routed swap volume is recorded server-side from confirmed swaps.

##### Implementation Details: Briefly describe how the oracle is integrated into your project:
This PR adds the Venum Swap aggregator volume adapter. It reads from the public endpoint:
`https://api.venum.dev/v1/stats/volume?from=<unix>&to=<unix>`
The endpoint returns routed USD swap volume and swap count for the requested window.

##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage:
- https://docs.venum.dev/api/stats
- https://api.venum.dev/v1/stats/volume?from=0

##### forkedFrom (Does your project originate from another project):
No

##### methodology (what is being counted as tvl, how is tvl being calculated):
This adapter reports aggregator volume, not TVL.
Volume counts swaps routed through Venum Swap and recorded only after the transaction is confirmed on-chain. Each landed swap is deduped by signature and priced in USD at recording time. The adapter reads the aggregated windowed result from `/v1/stats/volume`.

##### Github org/user (Optional, if your code is open source, we can track activity):
https://github.com/venumhq

##### Does this project have a referral program?
No