### PR TITLE
feat(skate-amm): add Tempo chain support

### DIFF
--- a/dexs/skate-amm/index.ts
+++ b/dexs/skate-amm/index.ts
@@ -69,7 +69,7 @@ const adapter: SimpleAdapter = {
         [CHAIN.SUI]: { start: '2025-06-22', },
         [CHAIN.MONAD]: { start: '2025-11-25', },
         [CHAIN.MEGAETH]: { start: '2026-02-18', },
-        [CHAIN.TEMPO]: { start: '2026-04-14', }
+        [CHAIN.TEMPO]: { start: '2026-04-13', }
     },
 }
 

--- a/dexs/skate-amm/index.ts
+++ b/dexs/skate-amm/index.ts
@@ -14,7 +14,8 @@ const skateChainIds: Record<string, number> = {
     [CHAIN.MANTLE]: 5000,
     [CHAIN.SUI]: 1001,
     [CHAIN.MONAD]: 143,
-    [CHAIN.MEGAETH]: 4326
+    [CHAIN.MEGAETH]: 4326,
+    [CHAIN.TEMPO]: 4217
 }
 
 const skateDataApi = "https://api.skatechain.org/amm-data/pools/stats";
@@ -67,7 +68,8 @@ const adapter: SimpleAdapter = {
         [CHAIN.MANTLE]: { start: '2025-05-28', },
         [CHAIN.SUI]: { start: '2025-06-22', },
         [CHAIN.MONAD]: { start: '2025-11-25', },
-        [CHAIN.MEGAETH]: { start: '2026-02-18', }
+        [CHAIN.MEGAETH]: { start: '2026-02-18', },
+        [CHAIN.TEMPO]: { start: '2026-04-14', }
     },
 }
 

--- a/dexs/skate-amm/index.ts
+++ b/dexs/skate-amm/index.ts
@@ -2,20 +2,20 @@ import { FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 import { httpGet } from "../../utils/fetchURL";
 
-const skateChainIds: Record<string, number> = {
-    [CHAIN.ETHEREUM]: 1,
-    [CHAIN.BSC]: 56,
-    [CHAIN.BASE]: 8453,
-    [CHAIN.ARBITRUM]: 42161,
-    [CHAIN.SOLANA]: 901,
-    [CHAIN.ECLIPSE]: 902,
-    [CHAIN.HYPERLIQUID]: 999,
-    [CHAIN.PLUME]: 98866,
-    [CHAIN.MANTLE]: 5000,
-    [CHAIN.SUI]: 1001,
-    [CHAIN.MONAD]: 143,
-    [CHAIN.MEGAETH]: 4326,
-    [CHAIN.TEMPO]: 4217
+const chainConfig: Record<string, { id: number, start: string }> = {
+    [CHAIN.ETHEREUM]: { id: 1, start: '2025-03-24' },
+    [CHAIN.BSC]: { id: 56, start: '2025-04-07' },
+    [CHAIN.BASE]: { id: 8453, start: '2025-03-17' },
+    [CHAIN.ARBITRUM]: { id: 42161, start: '2025-03-17' },
+    [CHAIN.SOLANA]: { id: 901, start: '2025-04-01' },
+    [CHAIN.ECLIPSE]: { id: 902, start: '2025-04-02' },
+    [CHAIN.HYPERLIQUID]: { id: 999, start: '2025-05-28' },
+    [CHAIN.PLUME]: { id: 98866, start: '2025-06-02' },
+    [CHAIN.MANTLE]: { id: 5000, start: '2025-05-28' },
+    [CHAIN.SUI]: { id: 1001, start: '2025-06-22' },
+    [CHAIN.MONAD]: { id: 143, start: '2025-11-25' },
+    [CHAIN.MEGAETH]: { id: 4326, start: '2026-02-18' },
+    [CHAIN.TEMPO]: { id: 4217, start: '2026-04-13' }
 }
 
 const skateDataApi = "https://api.skatechain.org/amm-data/pools/stats";
@@ -27,7 +27,7 @@ const fetch = async (options: FetchOptions) => {
 
     const tokenVolume_options = {
         params: {
-            chainId: skateChainIds[options.api.chain],
+            chainId: chainConfig[options.api.chain].id,
             startTime: options.startTimestamp,
             endTime: options.endTimestamp,
         }
@@ -56,21 +56,7 @@ const adapter: SimpleAdapter = {
     methodology,
     version: 2,
     fetch,
-    adapter: {
-        [CHAIN.ETHEREUM]: { start: '2025-03-24', },
-        [CHAIN.BSC]: { start: '2025-04-07', },
-        [CHAIN.BASE]: { start: '2025-03-17', },
-        [CHAIN.ARBITRUM]: { start: '2025-03-17', },
-        [CHAIN.SOLANA]: { start: '2025-04-01', },
-        [CHAIN.ECLIPSE]: { start: '2025-04-02', },
-        [CHAIN.HYPERLIQUID]: { start: '2025-05-28', },
-        [CHAIN.PLUME]: { start: '2025-06-02', },
-        [CHAIN.MANTLE]: { start: '2025-05-28', },
-        [CHAIN.SUI]: { start: '2025-06-22', },
-        [CHAIN.MONAD]: { start: '2025-11-25', },
-        [CHAIN.MEGAETH]: { start: '2026-02-18', },
-        [CHAIN.TEMPO]: { start: '2026-04-13', }
-    },
+    adapter: chainConfig,
 }
 
 export default adapter;


### PR DESCRIPTION
## Summary
- Add Tempo chain (ID: 4217) support to skate-amm adapter
- Start date: 2026-04-14

## Test plan
- [ ] Verify adapter builds successfully
- [ ] Confirm Tempo chain data is returned from skatechain API

🤖 Generated with [Claude Code](https://claude.com/claude-code)