### PR TITLE
Add Rheon DEX aggregator (Avalanche)

### DIFF
--- a/aggregators/rheon/index.ts
+++ b/aggregators/rheon/index.ts
@@ -23,7 +23,8 @@ const fetch = async ({ getLogs, createBalances }: FetchOptions) => {
 
 export default {
   version: 2,
-  adapter: {
-    [CHAIN.AVAX]: { fetch, start: "2026-04-01" },
-  },
+  pullHourly: true,
+  fetch,
+  chains: [CHAIN.AVAX],
+  start: "2026-04-14",
 };

--- a/aggregators/rheon/index.ts
+++ b/aggregators/rheon/index.ts
@@ -24,6 +24,6 @@ const fetch = async ({ getLogs, createBalances }: FetchOptions) => {
 export default {
   version: 2,
   adapter: {
-    [CHAIN.AVAX]: { fetch, start: "2026-04-14" },
+    [CHAIN.AVAX]: { fetch, start: "2026-04-01" },
   },
 };

--- a/aggregators/rheon/index.ts
+++ b/aggregators/rheon/index.ts
@@ -26,5 +26,5 @@ export default {
   pullHourly: true,
   fetch,
   chains: [CHAIN.AVAX],
-  start: "2026-04-14",
+  start: "2026-04-13",
 };

--- a/aggregators/rheon/index.ts
+++ b/aggregators/rheon/index.ts
@@ -1,0 +1,29 @@
+import type { FetchOptions } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+
+const AGGREGATOR = "0x311D2A611C59F11516256e14683fB6d9Bc3A97a4";
+
+const swapEvent =
+  "event SwapExecuted(address indexed tokenIn, address indexed tokenOut, uint256 amountIn, uint256 amountOut, address indexed recipient)";
+
+const fetch = async ({ getLogs, createBalances }: FetchOptions) => {
+  const dailyVolume = createBalances();
+
+  const logs = await getLogs({
+    target: AGGREGATOR,
+    eventAbi: swapEvent,
+  });
+
+  for (const log of logs) {
+    dailyVolume.add(log.tokenIn, log.amountIn);
+  }
+
+  return { dailyVolume };
+};
+
+export default {
+  version: 2,
+  adapter: {
+    [CHAIN.AVAX]: { fetch, start: "2026-04-14" },
+  },
+};


### PR DESCRIPTION
## Rheon — MCMF-based DEX aggregator on Avalanche C-Chain

**Website:** https://rheon.xyz
**Contract:** [0x311D2A611C59F11516256e14683fB6d9Bc3A97a4](https://snowscan.xyz/address/0x311D2A611C59F11516256e14683fB6d9Bc3A97a4)

Rheon routes swaps across 15+ Avalanche DEX protocols (TraderJoe V1/V2, Pangolin, PangolinV3, UniswapV3, PharaohCL, Curve, DODO, KyberSwap, and more) using a Min-Cost Max-Flow solver for optimal split routing.

The adapter reads `SwapExecuted` events from the verified GodAggregator contract to track daily volume.