### PR TITLE
Update Strike Finance fees adapter to v2

### DIFF
--- a/fees/strike-finance/index.ts
+++ b/fees/strike-finance/index.ts
@@ -28,6 +28,9 @@ const adapter: Adapter = {
     Revenue: "All trading fees collected by the platform.",
     HoldersRevenue: "100% of all trading fees collected by the platform goes to $STRIKE holders.",
   },
+  breakdownMethodology: {
+    "Trading Fees": "Fees collected from trades executed on the Strike Finance.",
+  },
 };
 
 export default adapter;

--- a/fees/strike-finance/index.ts
+++ b/fees/strike-finance/index.ts
@@ -1,36 +1,16 @@
-import { Adapter, FetchOptions, FetchResult } from "../../adapters/types";
+import { Adapter, FetchOptions } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 import fetchURL from "../../utils/fetchURL";
-import { METRIC } from "../../helpers/metrics"
 
-const fetch = async (options: FetchOptions): Promise<FetchResult> => {
-  const dailyFees = options.createBalances();
-  const dailySupplySideRevenue = options.createBalances();
-  const dailyHoldersRevenue = options.createBalances()
-  const { daily } = await fetchURL(
-    `https://beta.strikefinance.org/api/analytics/fees?from=${options.startTimestamp}&to=${options.endTimestamp}`
+const fetch = async (options: FetchOptions) => {
+  const data = await fetchURL(
+    `https://app.strikefinance.org/api/analytics/fees?from=${options.startTimestamp}&to=${options.endTimestamp}`
   );
 
-  dailyFees.addCGToken("cardano", Number(daily.totalRevenueByAsset.ADA));
-  dailySupplySideRevenue.addCGToken("cardano", Number(daily.liquidationRevenueByAsset.ADA || 0), METRIC.LIQUIDATION_FEES)
-  dailySupplySideRevenue.addCGToken("cardano", Number(daily.tradingRevenueByAsset.ADA || 0), METRIC.LP_FEES)
-  dailySupplySideRevenue.addCGToken("cardano", Number(daily.lpOpenFeesByAsset.ADA || 0), METRIC.OPEN_CLOSE_FEES)
-  dailyHoldersRevenue.addCGToken("cardano", Number(daily.stakingOpenFeesByAsset.ADA || 0), METRIC.OPEN_CLOSE_FEES);
-
-  if (daily.totalRevenueByAsset.SNEK) {
-    dailyFees.addCGToken("snek", Number(daily.totalRevenueByAsset.SNEK));
-    dailySupplySideRevenue.addCGToken("snek", Number(daily.liquidationRevenueByAsset.SNEK || 0), METRIC.LIQUIDATION_FEES)
-    dailySupplySideRevenue.addCGToken("snek", Number(daily.tradingRevenueByAsset.SNEK || 0), METRIC.LP_FEES)
-    dailySupplySideRevenue.addCGToken("snek", Number(daily.lpOpenFeesByAsset.SNEK || 0), METRIC.OPEN_CLOSE_FEES)
-    dailyHoldersRevenue.addCGToken("snek", Number(daily.stakingOpenFeesByAsset.SNEK || 0), METRIC.OPEN_CLOSE_FEES);
-  }
-
   return {
-    dailyFees,
-    dailySupplySideRevenue,
-    dailyRevenue: dailyHoldersRevenue,
-    dailyHoldersRevenue,
-    dailyProtocolRevenue: 0,
+    dailyFees: data.totalFees,
+    dailyRevenue: data.totalFees,
+    dailyHoldersRevenue: data.totalFees,
   };
 };
 
@@ -42,24 +22,12 @@ const adapter: Adapter = {
       start: "2025-05-16",
     },
   },
-  allowNegativeValue: true, // bad liquidation
+  allowNegativeValue: true,
   methodology: {
-    Fees: "All trading fees associated with opening a perpetual position.",
-    SupplySideRevenue: "Includes liquidation fees, trader losses, borrow and open fees",
-    Revenue: "Strike keeps a portion of opening fees.",
-    ProtocolRevenue: "No protocol revenue.",
-    HoldersRevenue: "100% of the opening fees that goes to Strike is distributed to $STRIKE"
+    Fees: "All trading fees collected by the platform.",
+    Revenue: "All trading fees collected by the platform.",
+    HoldersRevenue: "100% of all trading fees collected by the platform goes to $STRIKE holders.",
   },
-  breakdownMethodology: {
-    SupplySideRevenue: {
-        [METRIC.LIQUIDATION_FEES]: "100% of liquidated collateral from positions that get liquidated goes to LPs",
-        [METRIC.LP_FEES]: "100% of trader losses when positions close at a loss and 100% of hourly borrow fees paid by traders go to LPs",
-        [METRIC.OPEN_CLOSE_FEES]: "A percentage of opening fees charged when traders open new positions goes to LPs"
-    },
-    HoldersRevenue: {
-      [METRIC.OPEN_CLOSE_FEES]: "100% of the opening fees that goes to Strike is distributed to $STRIKE stakers once every 3 epochs"
-    }
-  }
 };
 
 export default adapter;

--- a/fees/strike-finance/index.ts
+++ b/fees/strike-finance/index.ts
@@ -7,10 +7,14 @@ const fetch = async (options: FetchOptions) => {
     `https://app.strikefinance.org/api/analytics/fees?from=${options.startTimestamp}&to=${options.endTimestamp}`
   );
 
+  const dailyFees = options.createBalances()
+
+  dailyFees.addUSDValue(data.totalFees, 'Trading Fees');
+  
   return {
-    dailyFees: data.totalFees,
-    dailyRevenue: data.totalFees,
-    dailyHoldersRevenue: data.totalFees,
+    dailyFees,
+    dailyRevenue: dailyFees,
+    dailyHoldersRevenue: dailyFees,
   };
 };
 
@@ -29,7 +33,15 @@ const adapter: Adapter = {
     HoldersRevenue: "100% of all trading fees collected by the platform goes to $STRIKE holders.",
   },
   breakdownMethodology: {
-    "Trading Fees": "Fees collected from trades executed on the Strike Finance.",
+    Fees: {
+      "Trading Fees": "Fees collected from trades executed on the Strike Finance.",
+    },
+    Revenue: {
+      "Trading Fees": "Fees collected from trades executed on the Strike Finance.",
+    },
+    HoldersRevenue: {
+      "Trading Fees": "100% of all trading fees collected by the platform goes to $STRIKE holders.",
+    },
   },
 };
 


### PR DESCRIPTION
## Summary
- Switch API endpoint from beta to app.strikefinance.org
- Return fees in USD instead of per-asset native token balances (ADA/SNEK)
- Simplify fetch to single totalFees field (v1 + v2 combined)
- Update methodology descriptions

## Test
```
npx ts-node cli/testAdapter.ts fees strike-finance
```