### PR TITLE
fix: add decimal conversion to katana perps adapter

### DIFF
--- a/dexs/katana-perps.ts
+++ b/dexs/katana-perps.ts
@@ -3,6 +3,8 @@ import { FetchOptions, FetchResultV2, SimpleAdapter } from "../adapters/types";
 
 const EXCHANGE_CONTRACT = '0x835Ba5b1B202773A94Daaa07168b26B22584637a';
 const QUOTE_TOKEN = '0x203A662b0BD271A6ed5a60EdFbd04bFce608FD36';
+// Event quantities are in pips (8 decimals), USDC is 6 decimals
+const PIP_DECIMALS_ADJUSTMENT = 1e2;
 
 const ABIS = {
   TradeExecuted: 'event TradeExecuted (address buyWallet, address sellWallet, string baseAssetSymbol, string quoteAssetSymbol, uint64 baseQuantity, uint64 quoteQuantity, uint8 makerSide, int64 makerFeeQuantity, uint64 takerFeeQuantity)',
@@ -14,9 +16,9 @@ async function fetch(options: FetchOptions): Promise<FetchResultV2> {
 
   const logs = await options.getLogs({ target: EXCHANGE_CONTRACT, eventAbi: ABIS.TradeExecuted });
   for (const log of logs) {
-    dailyVolume.add(QUOTE_TOKEN, log.quoteQuantity);
-    dailyFees.add(QUOTE_TOKEN, Math.abs(Number(log.makerFeeQuantity)), 'Maker Fees');
-    dailyFees.add(QUOTE_TOKEN, log.takerFeeQuantity, 'Taker Fees');
+    dailyVolume.add(QUOTE_TOKEN, Number(log.quoteQuantity) / PIP_DECIMALS_ADJUSTMENT);
+    dailyFees.add(QUOTE_TOKEN, Math.abs(Number(log.makerFeeQuantity)) / PIP_DECIMALS_ADJUSTMENT, 'Maker Fees');
+    dailyFees.add(QUOTE_TOKEN, Number(log.takerFeeQuantity) / PIP_DECIMALS_ADJUSTMENT, 'Taker Fees');
   }
 
   return {


### PR DESCRIPTION
Fix incorrect decimal units that were previously causing quantities to be 100x over-reported.

Before merging this PR, please confirm that previous incorrect values will be backfilled with corrected decimal-scaled values. If not, we would rather remove this adapter entirely as a sudden 100x drop in volume is a bad look for our charts.