### PR TITLE
Add Anoncoin fees adapter

### DIFF
--- a/fees/anoncoin/index.ts
+++ b/fees/anoncoin/index.ts
@@ -1,0 +1,27 @@
+import { Dependencies, FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import { getSolanaReceived } from "../../helpers/token";
+
+const PARTNER_FEE_CLAIMER = 'BKPxAdgwPHXE3ZPZt5XsAovDgUaUufHgZnSAZ3eRWQNW';
+
+const fetch: any = async (options: FetchOptions) => {
+  const dailyFees = await getSolanaReceived({
+    options,
+    target: PARTNER_FEE_CLAIMER,
+  });
+  return { dailyFees, dailyRevenue: dailyFees, dailyProtocolRevenue: dailyFees };
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  adapter: {
+    [CHAIN.SOLANA]: { fetch },
+  },
+  dependencies: [Dependencies.ALLIUM],
+  isExpensiveAdapter: true,
+  methodology: {
+    ProtocolRevenue: "Partner trading fees (SOL) claimed by Anoncoin from Meteora bonding curve and DAMM V2 pools.",
+  },
+};
+
+export default adapter;


### PR DESCRIPTION
https://anoncoin.it/

Adds a fees/revenue adapter for Anoncoin (anoncoin.fun).

**What it tracks:** Partner trading fees (SOL) claimed by Anoncoin from Meteora DBC and DAMM V2 pools.

**Approach:** Uses `getSolanaReceived` to sum SOL transfers to the Anoncoin partner fee claimer wallet.

- dailyFees = dailyRevenue = dailyProtocolRevenue (all claimed partner fees)
- Target wallet: `BKPxAdgwPHXE3ZPZt5XsAovDgUaUufHgZnSAZ3eRWQNW`
- Dependencies: Allium