### PR TITLE
[Fees] Rainbow Token Launchpad - Add fee adapter for Base chain

### DIFF
--- a/fees/rainbow-token-launchpad.ts
+++ b/fees/rainbow-token-launchpad.ts
@@ -16,36 +16,30 @@ const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
   })
 
   const dailyRevenue = dailyFees.clone(0.5)
-  const dailySupplySideRevenue = dailyFees.clone(0.5)
 
   return {
     dailyFees,
     dailyRevenue,
     dailyProtocolRevenue: dailyRevenue,
-    dailySupplySideRevenue,
   }
 }
 
 const adapter: SimpleAdapter = {
   version: 2,
   methodology: {
-    Fees: 'Liquid charges a 0.2% fee on all token deployments via the Liquid Factory contract on Base',
-    Revenue: 'Rainbow receives 50% of the 0.2% deployment fee as protocol revenue',
-    ProtocolRevenue: 'Rainbow receives 50% of the 0.2% deployment fee as protocol revenue',
-    SupplySideRevenue: 'Liquid retains 50% of the 0.2% deployment fee',
+    Fees: 'Rainbow receives 50% of the 0.2% deployment fee collected by the Liquid Factory contract on Base',
+    Revenue: 'Rainbow receives 50% of the 0.2% deployment fee collected by the Liquid Factory contract on Base',
+    ProtocolRevenue: 'Rainbow receives 50% of the 0.2% deployment fee collected by the Liquid Factory contract on Base',
   },
   breakdownMethodology: {
     Fees: {
-      'Deployment Fees': '0.2% fee charged on all token deployments via the Liquid Factory contract on Base',
+      'Deployment Fees': 'Rainbow receives 50% of the 0.2% deployment fee collected by the Liquid Factory contract on Base',
     },
     Revenue: {
       'Deployment Fees': 'Rainbow receives 50% of deployment fees',
     },
     ProtocolRevenue: {
       'Deployment Fees': 'Rainbow receives 50% of deployment fees',
-    },
-    SupplySideRevenue: {
-      'Deployment Fees': 'Liquid retains 50% of deployment fees',
     },
   },
   adapter: {

--- a/fees/rainbow-token-launchpad.ts
+++ b/fees/rainbow-token-launchpad.ts
@@ -1,53 +1,53 @@
-import { FetchOptions, FetchResultV2, SimpleAdapter } from "../../adapters/types"
-import { CHAIN } from "../../helpers/chains"
-import { addTokensReceived } from "../../helpers/token"
+import { FetchOptions, FetchResultV2, SimpleAdapter } from "../adapters/types"
+import { CHAIN } from "../helpers/chains"
+import { addTokensReceived } from "../helpers/token"
 
 const LIQUID_FACTORY = '0x04F1a284168743759BE6554f607a10CEBdB77760';
 const WETH = '0x4200000000000000000000000000000000000006';
 
 const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
-  const dailyFees = options.createBalances()
-
-  await addTokensReceived({
+  const deploymentFees = await addTokensReceived({
     options,
     targets: [LIQUID_FACTORY],
     token: WETH,
-    balances: dailyFees,
   })
 
-  const dailyRevenue = dailyFees.clone(0.5)
+  const dailyFees = deploymentFees.clone(0.5, 'Deployment Fees from Liquid')
 
   return {
     dailyFees,
-    dailyRevenue,
-    dailyProtocolRevenue: dailyRevenue,
+    dailyRevenue: dailyFees,
+    dailyProtocolRevenue: dailyFees,
   }
+}
+
+const methodology = {
+  Fees: 'Rainbow receives 50% of the 0.2% deployment fee collected by the Liquid Factory contract on Base',
+  Revenue: 'All fees are revenue',
+  ProtocolRevenue: 'All revenue goes to the protocol',
+}
+
+const breakdownMethodology = {
+  Fees: {
+    'Deployment Fees from Liquid': 'Rainbow receives 50% of the 0.2% deployment fee collected by the Liquid Factory contract on Base',
+  },
+  Revenue: {
+    'Deployment Fees from Liquid': 'Rainbow receives 50% of deployment fees',
+  },
+  ProtocolRevenue: {
+    'Deployment Fees from Liquid': 'Rainbow receives 50% of deployment fees',
+  },
 }
 
 const adapter: SimpleAdapter = {
   version: 2,
-  methodology: {
-    Fees: 'Rainbow receives 50% of the 0.2% deployment fee collected by the Liquid Factory contract on Base',
-    Revenue: 'Rainbow receives 50% of the 0.2% deployment fee collected by the Liquid Factory contract on Base',
-    ProtocolRevenue: 'Rainbow receives 50% of the 0.2% deployment fee collected by the Liquid Factory contract on Base',
-  },
-  breakdownMethodology: {
-    Fees: {
-      'Deployment Fees': 'Rainbow receives 50% of the 0.2% deployment fee collected by the Liquid Factory contract on Base',
-    },
-    Revenue: {
-      'Deployment Fees': 'Rainbow receives 50% of deployment fees',
-    },
-    ProtocolRevenue: {
-      'Deployment Fees': 'Rainbow receives 50% of deployment fees',
-    },
-  },
-  adapter: {
-    [CHAIN.BASE]: {
-      fetch,
-      start: '2026-03-14',
-    }
-  },
+  pullHourly: true,
+  chains: [CHAIN.BASE],
+  fetch,
+  start: '2026-03-14',
+  methodology,
+  breakdownMethodology,
+  doublecounted: true, // liquid-protocol
 }
 
 export default adapter

--- a/fees/rainbow-token-launchpad.ts
+++ b/fees/rainbow-token-launchpad.ts
@@ -1,0 +1,41 @@
+import { FetchOptions, FetchResultV2, SimpleAdapter } from "../../adapters/types"
+import { CHAIN } from "../../helpers/chains"
+import { addTokensReceived } from "../../helpers/token"
+
+const LIQUID_FACTORY = '0x04F1a284168743759BE6554f607a10CEBdB77760';
+const WETH = '0x4200000000000000000000000000000000000006';
+
+const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
+  const dailyRevenue = options.createBalances()
+
+  await addTokensReceived({
+    options,
+    targets: [LIQUID_FACTORY],
+    token: WETH,
+    balances: dailyRevenue,
+  })
+
+  dailyRevenue.resizeBy(0.5)
+
+  return {
+    dailyFees: dailyRevenue,
+    dailyRevenue,
+    dailyProtocolRevenue: dailyRevenue,
+  }
+}
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  methodology: {
+    Fees: 'Rainbow receives 50% of the 0.2% deployment fee collected by the Liquid Factory contract on Base',
+    Revenue: 'Rainbow receives 50% of the 0.2% deployment fee collected by the Liquid Factory contract on Base',
+  },
+  adapter: {
+    [CHAIN.BASE]: {
+      fetch,
+      start: '2026-03-14',
+    }
+  },
+}
+
+export default adapter

--- a/fees/rainbow-token-launchpad.ts
+++ b/fees/rainbow-token-launchpad.ts
@@ -6,29 +6,47 @@ const LIQUID_FACTORY = '0x04F1a284168743759BE6554f607a10CEBdB77760';
 const WETH = '0x4200000000000000000000000000000000000006';
 
 const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
-  const dailyRevenue = options.createBalances()
+  const dailyFees = options.createBalances()
 
   await addTokensReceived({
     options,
     targets: [LIQUID_FACTORY],
     token: WETH,
-    balances: dailyRevenue,
+    balances: dailyFees,
   })
 
-  dailyRevenue.resizeBy(0.5)
+  const dailyRevenue = dailyFees.clone(0.5)
+  const dailySupplySideRevenue = dailyFees.clone(0.5)
 
   return {
-    dailyFees: dailyRevenue,
+    dailyFees,
     dailyRevenue,
     dailyProtocolRevenue: dailyRevenue,
+    dailySupplySideRevenue,
   }
 }
 
 const adapter: SimpleAdapter = {
   version: 2,
   methodology: {
-    Fees: 'Rainbow receives 50% of the 0.2% deployment fee collected by the Liquid Factory contract on Base',
-    Revenue: 'Rainbow receives 50% of the 0.2% deployment fee collected by the Liquid Factory contract on Base',
+    Fees: 'Liquid charges a 0.2% fee on all token deployments via the Liquid Factory contract on Base',
+    Revenue: 'Rainbow receives 50% of the 0.2% deployment fee as protocol revenue',
+    ProtocolRevenue: 'Rainbow receives 50% of the 0.2% deployment fee as protocol revenue',
+    SupplySideRevenue: 'Liquid retains 50% of the 0.2% deployment fee',
+  },
+  breakdownMethodology: {
+    Fees: {
+      'Deployment Fees': '0.2% fee charged on all token deployments via the Liquid Factory contract on Base',
+    },
+    Revenue: {
+      'Deployment Fees': 'Rainbow receives 50% of deployment fees',
+    },
+    ProtocolRevenue: {
+      'Deployment Fees': 'Rainbow receives 50% of deployment fees',
+    },
+    SupplySideRevenue: {
+      'Deployment Fees': 'Liquid retains 50% of deployment fees',
+    },
   },
   adapter: {
     [CHAIN.BASE]: {


### PR DESCRIPTION
Name (as shown on DefiLlama): Rainbow Token Launchpad
Twitter link: https://x.com/rainbowdotme
Website link: https://rainbow.me
Chain(s): Base
Child of https://defillama.com/protocol/rainbow


## Summary

Adds a fee adapter for Rainbow Token Launchpad — a token deployment feature within the Rainbow Wallet app.

- Liquid charges a 0.2% fee on all token deployments, splitting protocol revenue with Rainbow
- Fees are collected in WETH on Base to contract `0x04F1a284168743759BE6554f607a10CEBdB77760`
- Uses `addTokensReceived` helper to track inbound WETH transfers
- Rainbow receives 50% of fees as protocol revenue

## Methodology

| Metric | Description |
|--------|-------------|
| Fees | Rainbow's 50% share of the 0.2% deployment fee collected by the Liquid Factory contract |
| Revenue | Rainbow receives 50% of fees accrued to the Liquid Factory contract on Base |
| ProtocolRevenue | Same as Revenue — Rainbow's 50% cut |

Start date: 2026-03-14