### PR TITLE
dexs/lunarbase: support dark pools v2 accounting

### DIFF
--- a/dexs/lunarbase/index.ts
+++ b/dexs/lunarbase/index.ts
@@ -1,12 +1,19 @@
 import { FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
-import { addOneToken } from "../../helpers/prices";
 import { METRIC } from "../../helpers/metrics";
 
-const CURVE_PMMS = [
-    "0x6Ccc8223532fff07f47EF4311BEB3647326894Ab",
-    "0x00003bf45Ce34Bf1BeA78669f9A40ee630e11b99",
-];
+const POOLS = [
+    {
+        address: "0x6Ccc8223532fff07f47EF4311BEB3647326894Ab",
+        feeModel: "legacy",
+    },
+    {
+        address: "0x00003bf45Ce34Bf1BeA78669f9A40ee630e11b99",
+        feeModel: "dark_pools_v2",
+    },
+] as const;
+
+const POOL_ADDRESSES = POOLS.map(({ address }) => address);
 
 const poolAbis = {
     tokenX: "address:X",
@@ -38,7 +45,7 @@ const fetch = async (options: FetchOptions) => {
     const toBlock = await options.getToBlock();
 
     const swapLogs = await options.getLogs({
-        targets: CURVE_PMMS,
+        targets: POOL_ADDRESSES,
         eventAbi: swapEvent,
         flatten: false,
         toBlock,
@@ -46,14 +53,14 @@ const fetch = async (options: FetchOptions) => {
 
     // `options.api` is already pinned to this slice's `toBlock`, so these reads stay historical.
     const [tokenXs, tokenYs, treasuryShareBpsValues, totalBpsValues] = await Promise.all([
-        options.api.multiCall({ abi: poolAbis.tokenX, calls: CURVE_PMMS, permitFailure: true }),
-        options.api.multiCall({ abi: poolAbis.tokenY, calls: CURVE_PMMS, permitFailure: true }),
-        options.api.multiCall({ abi: poolAbis.treasuryShareBps, calls: CURVE_PMMS, permitFailure: true }),
-        options.api.multiCall({ abi: poolAbis.bps, calls: CURVE_PMMS, permitFailure: true }),
+        options.api.multiCall({ abi: poolAbis.tokenX, calls: POOL_ADDRESSES, permitFailure: true }),
+        options.api.multiCall({ abi: poolAbis.tokenY, calls: POOL_ADDRESSES, permitFailure: true }),
+        options.api.multiCall({ abi: poolAbis.treasuryShareBps, calls: POOL_ADDRESSES, permitFailure: true }),
+        options.api.multiCall({ abi: poolAbis.bps, calls: POOL_ADDRESSES, permitFailure: true }),
     ]);
 
-    for (let i = 0; i < CURVE_PMMS.length; i++) {
-        const pool = CURVE_PMMS[i];
+    for (let i = 0; i < POOLS.length; i++) {
+        const { address: pool, feeModel } = POOLS[i];
         const tokenX = tokenXs[i];
         const tokenY = tokenYs[i];
         const logs = swapLogs[i];
@@ -64,26 +71,43 @@ const fetch = async (options: FetchOptions) => {
 
         const treasuryShareBps = treasuryShareBpsValues[i];
         const totalBps = totalBpsValues[i];
-        if (isInvalidCallResult(treasuryShareBps) || isInvalidCallResult(totalBps)) {
+        if (feeModel === "legacy" && (isInvalidCallResult(treasuryShareBps) || isInvalidCallResult(totalBps))) {
             console.warn(`Skipping LunarBase pool ${pool} at block ${toBlock}: failed to resolve fee split params`);
+            continue;
+        }
+        if (isInvalidCallResult(totalBps)) {
+            console.warn(`Skipping LunarBase pool ${pool} at block ${toBlock}: failed to resolve BPS`);
             continue;
         }
 
         for (const log of logs) {
             const { xToY, dx, dy, fee } = log;
-            addOneToken({ chain: options.chain, balances: dailyVolume, token0: tokenX, token1: tokenY, amount0: dx, amount1: dy });
+            // `SwapExecuted` encodes amounts per pool axis, so input-side volume is:
+            // xToY -> dx (X in), yToX -> dy (Y in).
+            const volumeToken = xToY ? tokenX : tokenY;
+            const volumeAmount = xToY ? dx : dy;
+            dailyVolume.add(volumeToken, volumeAmount);
 
-            // Fee is taken from the output side: xToY -> fee in Y, yToX -> fee in X
+            // Fee is taken from the output side: xToY -> fee in Y, yToX -> fee in X.
             const feeToken = xToY ? tokenY : tokenX;
-            dailyFees.add(feeToken, fee, METRIC.SWAP_FEES);
+            const feeBig = toBigIntOrZero(fee);
+            dailyFees.add(feeToken, feeBig, METRIC.SWAP_FEES);
 
-            const feeBig = toBigIntOrZero(fee), treasuryShareBpsBig = toBigIntOrZero(treasuryShareBps), totalBpsBig = toBigIntOrZero(totalBps);
+            if (feeModel === "legacy") {
+                const treasuryShareBpsBig = toBigIntOrZero(treasuryShareBps);
+                const totalBpsBig = toBigIntOrZero(totalBps);
 
-            // Split: treasury gets treasuryShareBps/BPS, LPs get the rest
-            const protocolFee = totalBpsBig > 0n ? (feeBig * treasuryShareBpsBig) / totalBpsBig : 0n;
-            const supplySideFee = feeBig - protocolFee;
-            dailyProtocolRevenue.add(feeToken, protocolFee, METRIC.SWAP_FEES);
-            dailySupplySideRevenue.add(feeToken, supplySideFee, METRIC.SWAP_FEES);
+                // Legacy PMM pools expose a direct treasuryShare/BPS split.
+                const protocolFee = totalBpsBig > 0n ? (feeBig * treasuryShareBpsBig) / totalBpsBig : 0n;
+                const supplySideFee = feeBig - protocolFee;
+                dailyProtocolRevenue.add(feeToken, protocolFee, METRIC.SWAP_FEES);
+                dailySupplySideRevenue.add(feeToken, supplySideFee, METRIC.SWAP_FEES);
+                continue;
+            }
+
+            // V2 dark_pools route swap fees into treasury/partner accounting, not LP swap-fee buckets.
+            // We count the swap fee and treat it as protocol-side until router-level partner rebates are surfaced.
+            dailyProtocolRevenue.add(feeToken, feeBig, METRIC.SWAP_FEES);
         }
 
     }
@@ -124,6 +148,7 @@ const breakdownMethodology = {
         [METRIC.SWAP_FEES]: "Swap fees that going to the protocol.",
     },
 };
+
 const adapter: SimpleAdapter = {
     version: 2,
     pullHourly: true,

--- a/dexs/lunarbase/index.ts
+++ b/dexs/lunarbase/index.ts
@@ -14,6 +14,9 @@ const POOLS = [
 ] as const;
 
 const POOL_ADDRESSES = POOLS.map(({ address }) => address);
+const LEGACY_POOL_ADDRESSES = POOLS
+    .filter(({ feeModel }) => feeModel === "legacy")
+    .map(({ address }) => address);
 
 const poolAbis = {
     tokenX: "address:X",
@@ -52,12 +55,21 @@ const fetch = async (options: FetchOptions) => {
     });
 
     // `options.api` is already pinned to this slice's `toBlock`, so these reads stay historical.
-    const [tokenXs, tokenYs, treasuryShareBpsValues, totalBpsValues] = await Promise.all([
+    const [tokenXs, tokenYs, legacyTreasuryShareBpsValues, legacyTotalBpsValues] = await Promise.all([
         options.api.multiCall({ abi: poolAbis.tokenX, calls: POOL_ADDRESSES, permitFailure: true }),
         options.api.multiCall({ abi: poolAbis.tokenY, calls: POOL_ADDRESSES, permitFailure: true }),
-        options.api.multiCall({ abi: poolAbis.treasuryShareBps, calls: POOL_ADDRESSES, permitFailure: true }),
-        options.api.multiCall({ abi: poolAbis.bps, calls: POOL_ADDRESSES, permitFailure: true }),
+        options.api.multiCall({ abi: poolAbis.treasuryShareBps, calls: LEGACY_POOL_ADDRESSES, permitFailure: true }),
+        options.api.multiCall({ abi: poolAbis.bps, calls: LEGACY_POOL_ADDRESSES, permitFailure: true }),
     ]);
+    const legacyPoolParamsByAddress = new Map(
+        LEGACY_POOL_ADDRESSES.map((address, index) => [
+            address,
+            {
+                treasuryShareBps: legacyTreasuryShareBpsValues[index],
+                totalBps: legacyTotalBpsValues[index],
+            },
+        ]),
+    );
 
     for (let i = 0; i < POOLS.length; i++) {
         const { address: pool, feeModel } = POOLS[i];
@@ -69,14 +81,11 @@ const fetch = async (options: FetchOptions) => {
             throw new Error(`Failed to resolve token pair for ${pool}`);
         }
 
-        const treasuryShareBps = treasuryShareBpsValues[i];
-        const totalBps = totalBpsValues[i];
+        const legacyPoolParams = legacyPoolParamsByAddress.get(pool);
+        const treasuryShareBps = legacyPoolParams?.treasuryShareBps;
+        const totalBps = legacyPoolParams?.totalBps;
         if (feeModel === "legacy" && (isInvalidCallResult(treasuryShareBps) || isInvalidCallResult(totalBps))) {
             console.warn(`Skipping LunarBase pool ${pool} at block ${toBlock}: failed to resolve fee split params`);
-            continue;
-        }
-        if (isInvalidCallResult(totalBps)) {
-            console.warn(`Skipping LunarBase pool ${pool} at block ${toBlock}: failed to resolve BPS`);
             continue;
         }
 


### PR DESCRIPTION
## Summary

Updated the LunarBase adapter to properly support the new Dark Pools V2 pool.

## What changed

- Kept support for the legacy LunarBase PMM pool
- Added V2-specific handling for `0x00003bf45Ce34Bf1BeA78669f9A40ee630e11b99`
- Stopped treating the V2 pool as a legacy PMM pool with `treasuryShareBps()`
- Counted V2 volume directly from `SwapExecuted`
- Counted V2 swap fees without applying the legacy LP/protocol fee split logic
- Preserved the legacy fee split logic for the original pool

## Why

The new V2 pool uses a different accounting model than the legacy PMM pool.

Because of that, the previous adapter logic could skip the V2 pool entirely when trying to read legacy-only fee split parameters, which caused LunarBase volume to be undercounted when activity was happening through V2.

## Validation

- `npm run ts-check -- --pretty false`
- `npm test -- dexs lunarbase 2026-04-17`
