### PR TITLE
dexs/printr-protocol: add Solana bonding curve volume (Dune-based)

### DIFF
--- a/dexs/printr-protocol/index.ts
+++ b/dexs/printr-protocol/index.ts
@@ -12,7 +12,6 @@ const TOKEN_TRADE_EVENT =
 const GET_CURVE_ABI =
   "function getCurve(address token) view returns (tuple(address basePair, uint16 totalCurves, uint256 maxTokenSupply, uint256 virtualReserve, uint256 reserve, uint256 completionThreshold))";
 
-const PRINTR_SOLANA_BONDING_CURVE_PROGRAM = "dbcij3LWUppWqq96dh6gJWwBifmcGfLSB5D4DuSMaqN";
 const PRINTR_SOLANA_CREATOR = "82VbBzGtb8v5wFx1TM6iaMmLyRSLy8WeqA123orjHGzL";
 
 // 1% total bonding curve swap fee
@@ -86,68 +85,61 @@ const fetchEvm = async ({ getLogs, createBalances, api }: FetchOptions) => {
 };
 
 interface ISolanaFeeRow {
-  quote_mint: string;
-  total_trading_fees: string | number;
-  total_protocol_fees: string | number;
-  total_referral_fees: string | number;
+printr_fee_total_usd: string | number;
 }
 
 const fetchSolana = async (options: FetchOptions) => {
-  const rows: ISolanaFeeRow[] = await queryDuneSql(options, `
-    WITH printr_created_mints AS (
-  SELECT DISTINCT base_mint AS meme_mint
-  FROM meteora_solana.dynamic_bonding_curve_evt_evtinitializepool
-  WHERE creator = '${PRINTR_SOLANA_CREATOR}'
-    AND evt_block_time >= TIMESTAMP '${START}'
-),
-    printr_dbc_pools AS (
-      SELECT DISTINCT
-        account_config,
-        account_quote_mint
-      FROM meteora_solana.dynamic_bonding_curve_call_initialize_virtual_pool_with_spl_token
-      WHERE account_base_mint IN (SELECT meme_mint FROM printr_created_mints)
+  const [row = { printr_fee_total_usd: 0 }] = await queryDuneSql(options, `
+    WITH printr_tokens AS (
+      SELECT DISTINCT base_mint AS token
+      FROM meteora_solana.dynamic_bonding_curve_evt_evtinitializepool
+      WHERE creator = '${PRINTR_SOLANA_CREATOR}'
     ),
-    swap_events AS (
+    trades_dedup AS (
       SELECT
-        p.account_quote_mint AS quote_mint,
-        CAST(JSON_EXTRACT_SCALAR(s.swap_result, '$.SwapResult.trading_fee') AS DECIMAL(38,0)) AS trading_fee,
-        CAST(JSON_EXTRACT_SCALAR(s.swap_result, '$.SwapResult.protocol_fee') AS DECIMAL(38,0)) AS protocol_fee,
-        CAST(JSON_EXTRACT_SCALAR(s.swap_result, '$.SwapResult.referral_fee') AS DECIMAL(38,0)) AS referral_fee
-      FROM meteora_solana.dynamic_bonding_curve_evt_evtswap s
-      JOIN printr_dbc_pools p ON s.config = p.account_config
-      WHERE s.evt_executing_account = '${PRINTR_SOLANA_BONDING_CURVE_PROGRAM}'
-        AND s.evt_block_time >= from_unixtime(${options.startTimestamp})
-        AND s.evt_block_time < from_unixtime(${options.endTimestamp})
+        t.project,
+        t.version_name,
+        t.tx_id,
+        COALESCE(t.outer_instruction_index, 0) AS o_idx,
+        COALESCE(t.inner_instruction_index, 0) AS i_idx,
+        MAX(t.amount_usd) AS amount_usd
+      FROM dex_solana.trades t
+      WHERE t.block_month >= CAST(DATE_TRUNC('month', from_unixtime(${options.startTimestamp})) AS date)
+        AND t.block_time >= from_unixtime(${options.startTimestamp})
+        AND t.block_time < from_unixtime(${options.endTimestamp})
+        AND (
+          t.token_bought_mint_address IN (SELECT token FROM printr_tokens)
+          OR t.token_sold_mint_address IN (SELECT token FROM printr_tokens)
+        )
+      GROUP BY 1, 2, 3, 4, 5
+    ),
+    agg AS (
+      SELECT
+        COALESCE(SUM(CASE WHEN project = 'meteora' AND version_name = 'dbc' THEN amount_usd ELSE 0 END), 0) AS dbc_volume_usd,
+        COALESCE(SUM(CASE WHEN NOT (project = 'meteora' AND version_name = 'dbc') THEN amount_usd ELSE 0 END), 0) AS grad_volume_usd
+      FROM trades_dedup
     )
     SELECT
-      quote_mint,
-      SUM(COALESCE(trading_fee, 0)) AS total_trading_fees,
-      SUM(COALESCE(protocol_fee, 0)) AS total_protocol_fees,
-      SUM(COALESCE(referral_fee, 0)) AS total_referral_fees
-    FROM swap_events
-    GROUP BY 1
-  `)
+      ROUND(0.004 * dbc_volume_usd + 0.002 * grad_volume_usd, 2) AS printr_fee_total_usd
+    FROM agg
+  `);
 
-  const dailyFees = options.createBalances()
-  const dailyRevenue = options.createBalances()
-  const dailyProtocolRevenue = options.createBalances()
-  const dailySupplySideRevenue = options.createBalances()
+  const dailyFees = options.createBalances();
+  dailyFees.addUSDValue(Number(row.printr_fee_total_usd));
 
-  rows.forEach((row) => {
-    dailyFees.add(row.quote_mint, Number(row.total_trading_fees))
-    dailyRevenue.add(row.quote_mint, Number(row.total_protocol_fees))
-    dailyProtocolRevenue.add(row.quote_mint, Number(row.total_protocol_fees))
-    dailySupplySideRevenue.add(row.quote_mint, Number(row.total_referral_fees))
-  })
+  const dailyRevenue = dailyFees.clone();
+  const dailyProtocolRevenue = dailyFees.clone();
+  const dailyHoldersRevenue = options.createBalances();
+  const dailySupplySideRevenue = options.createBalances();
 
   return {
     dailyFees,
-    dailyUserFees: dailyFees,
     dailyRevenue,
     dailyProtocolRevenue,
+    dailyHoldersRevenue,
     dailySupplySideRevenue,
-  }
-}
+  };
+};
 
 const fetch = async (options: FetchOptions) => {
   if (options.chain === CHAIN.SOLANA) return fetchSolana(options)

--- a/dexs/printr-protocol/index.ts
+++ b/dexs/printr-protocol/index.ts
@@ -1,8 +1,10 @@
-import { FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { Dependencies, FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
+import { queryDuneSql } from "../../helpers/dune";
 import { METRIC } from "../../helpers/metrics";
 
 const PRINTR_CONTRACT = "0xb77726291b125515d0a7affeea2b04f2ff243172";
+const START = '2025-10-14';
 
 const TOKEN_TRADE_EVENT =
   "event TokenTrade(address indexed token, address indexed trader, bool isBuy, uint256 amount, uint256 cost, uint256 priceAfter, uint256 issuedSupply, uint256 reserve)";
@@ -10,11 +12,36 @@ const TOKEN_TRADE_EVENT =
 const GET_CURVE_ABI =
   "function getCurve(address token) view returns (tuple(address basePair, uint16 totalCurves, uint256 maxTokenSupply, uint256 virtualReserve, uint256 reserve, uint256 completionThreshold))";
 
+const PRINTR_SOLANA_BONDING_CURVE_PROGRAM = "dbcij3LWUppWqq96dh6gJWwBifmcGfLSB5D4DuSMaqN";
+const PRINTR_SOLANA_LAUNCH_PROGRAM = "T8HsGYv7sMk3kTnyaRqZrbRPuntYzdh12evXBkprint";
+const SOLANA_WSOL = "So11111111111111111111111111111111111111112";
+const SOLANA_USDC = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
+
 // 1% total bonding curve swap fee
 // Fee split: 25% creator, 25% memecoin reserve, 40% buyback, 10% team
 const FEE_RATE = 1 / 100;
 
-const fetch = async ({ getLogs, createBalances, api }: FetchOptions) => {
+const getFeeBreakdownFromVolume = (dailyVolume: ReturnType<FetchOptions["createBalances"]>) => {
+  // Derive fee breakdown from volume
+  const dailyFees = dailyVolume.clone(FEE_RATE, METRIC.SWAP_FEES); // 1% total fee
+  const dailyRevenue = dailyVolume.clone(FEE_RATE * 0.1, METRIC.PROTOCOL_FEES);
+  dailyRevenue.add(dailyVolume.clone(FEE_RATE * 0.25, 'Memecoin Reserve'));
+  dailyRevenue.add(dailyVolume.clone(FEE_RATE * 0.4, METRIC.TOKEN_BUY_BACK));
+  const dailyProtocolRevenue = dailyVolume.clone(FEE_RATE * 0.1, METRIC.PROTOCOL_FEES);
+  dailyProtocolRevenue.add(dailyVolume.clone(FEE_RATE * 0.25, 'Memecoin Reserve'));
+  const dailyHoldersRevenue = dailyVolume.clone(FEE_RATE * 0.4, METRIC.TOKEN_BUY_BACK);
+  const dailySupplySideRevenue = dailyVolume.clone(FEE_RATE * 0.25, METRIC.CREATOR_FEES);
+
+  return {
+    dailyFees,
+    dailyRevenue,
+    dailyProtocolRevenue,
+    dailyHoldersRevenue,
+    dailySupplySideRevenue,
+  }
+}
+
+const fetchEvm = async ({ getLogs, createBalances, api }: FetchOptions) => {
   const dailyVolume = createBalances();
 
   const tradeLogs = await getLogs({
@@ -54,29 +81,81 @@ const fetch = async ({ getLogs, createBalances, api }: FetchOptions) => {
     dailyVolume.add(basePair, log.cost);
   }
 
-  // Derive fee breakdown from volume
-  const dailyFees = dailyVolume.clone(FEE_RATE, METRIC.SWAP_FEES); // 1% total fee
-  const dailyRevenue = dailyVolume.clone(FEE_RATE * 0.1, METRIC.PROTOCOL_FEES);
-  dailyRevenue.add(dailyVolume.clone(FEE_RATE * 0.25, 'Memecoin Reserve'));
-  dailyRevenue.add(dailyVolume.clone(FEE_RATE * 0.4, METRIC.TOKEN_BUY_BACK));
-  const dailyProtocolRevenue = dailyVolume.clone(FEE_RATE * 0.1, METRIC.PROTOCOL_FEES);
-  dailyProtocolRevenue.add(dailyVolume.clone(FEE_RATE * 0.25, 'Memecoin Reserve'));
-  const dailyHoldersRevenue = dailyVolume.clone(FEE_RATE * 0.4, METRIC.TOKEN_BUY_BACK);
-  const dailySupplySideRevenue = dailyVolume.clone(FEE_RATE * 0.25, METRIC.CREATOR_FEES);
-
   return {
     dailyVolume,
-    dailyFees,
-    dailyRevenue,
-    dailyProtocolRevenue,
-    dailyHoldersRevenue,
-    dailySupplySideRevenue,
+    ...getFeeBreakdownFromVolume(dailyVolume),
   };
 };
 
+interface ISolanaVolumeRow {
+  payment_mint: string;
+  payment_amount: string | number;
+}
+
+const fetchSolana = async (_a: any, _b: any, options: FetchOptions) => {
+  // Methodology alignment with EVM:
+  // EVM tracks TokenTrade.cost in the basePair token.
+  // Solana DBC swap events expose the quote mint and quote leg amount directly:
+  //  - trade_direction = 1: user pays quote mint as amount_in
+  //  - trade_direction = 0: user receives quote mint as output_amount
+  // In both cases we accumulate the quote/payment leg by mint.
+  const rows: ISolanaVolumeRow[] = await queryDuneSql(options, `
+    WITH printr_created_mints AS (
+      SELECT DISTINCT token_mint_address AS meme_mint
+      FROM tokens_solana.transfers
+      WHERE action = 'mint'
+        AND outer_executing_account = '${PRINTR_SOLANA_LAUNCH_PROGRAM}'
+        AND block_time >= TIMESTAMP '${START}'
+        AND token_mint_address NOT IN ('${SOLANA_WSOL}', '${SOLANA_USDC}')
+    ),
+    printr_dbc_pools AS (
+      -- account_base_mint is the launched/traded meme token mint for each DBC config.
+      SELECT DISTINCT
+        account_config,
+        account_quote_mint,
+        account_base_mint AS meme_mint
+      FROM meteora_solana.dynamic_bonding_curve_call_initialize_virtual_pool_with_spl_token
+      WHERE account_base_mint IN (SELECT meme_mint FROM printr_created_mints)
+    ),
+    printr_swaps AS (
+      SELECT
+        p.account_quote_mint AS payment_mint,
+        CASE
+          WHEN s.trade_direction = 1 THEN COALESCE(s.amount_in, 0)
+          ELSE COALESCE(CAST(JSON_EXTRACT_SCALAR(s.swap_result, '$.SwapResult.output_amount') AS DECIMAL(38,0)), 0)
+        END AS payment_amount
+      FROM meteora_solana.dynamic_bonding_curve_evt_evtswap s
+      JOIN printr_dbc_pools p ON s.config = p.account_config
+      WHERE s.evt_executing_account = '${PRINTR_SOLANA_BONDING_CURVE_PROGRAM}'
+        AND s.evt_block_time >= from_unixtime(${options.startTimestamp})
+        AND s.evt_block_time < from_unixtime(${options.endTimestamp})
+    )
+    SELECT
+      payment_mint,
+      SUM(payment_amount) AS payment_amount
+    FROM printr_swaps
+    GROUP BY payment_mint
+  `)
+
+  const dailyVolume = options.createBalances()
+  rows.forEach((row) => {
+    dailyVolume.add(row.payment_mint, row.payment_amount)
+  })
+
+  return {
+    dailyVolume,
+    ...getFeeBreakdownFromVolume(dailyVolume),
+  }
+}
+
+const fetch = async (options: FetchOptions) => {
+  if (options.chain === CHAIN.SOLANA) return fetchSolana(null, null, options)
+  return fetchEvm(options)
+}
+
 const methodology = {
   Volume:
-    "Total trading volume from all Printr tokens across all supported chains (Solana, Base, BNB, Ethereum, Monad, Avalanche, Mantle, Arbitrum), tracked via on-chain trade events, denominated in the base pair token",
+    "Total trading volume from Printr bonding curve buys and sells, tracked as payment-side trade cost. On EVM this is TokenTrade.cost in the curve base pair token; on Solana this is the quote/payment mint leg from DBC swap events (amount_in for buys, quote output_amount for sells).",
   Fees: "Printr charges a 1% fee on all bonding curve swaps.",
   Revenue:
     "75% of trading fees: team (10%), protocol-controlled memecoin reserve (25%), and buyback (40%).",
@@ -112,9 +191,10 @@ const breakdownMethodology = {
 const adapter: SimpleAdapter = {
   version: 2,
   pullHourly: true,
+  dependencies: [Dependencies.DUNE],
   fetch,
-  start: '2025-10-14',
-  chains: [CHAIN.ARBITRUM, CHAIN.BASE, CHAIN.AVAX, CHAIN.MANTLE, CHAIN.MONAD, CHAIN.BSC, CHAIN.ETHEREUM],
+  start: START,
+  chains: [CHAIN.ARBITRUM, CHAIN.BASE, CHAIN.AVAX, CHAIN.MANTLE, CHAIN.MONAD, CHAIN.BSC, CHAIN.ETHEREUM, CHAIN.SOLANA],
   methodology,
   breakdownMethodology,
 };

--- a/dexs/printr-protocol/index.ts
+++ b/dexs/printr-protocol/index.ts
@@ -13,9 +13,7 @@ const GET_CURVE_ABI =
   "function getCurve(address token) view returns (tuple(address basePair, uint16 totalCurves, uint256 maxTokenSupply, uint256 virtualReserve, uint256 reserve, uint256 completionThreshold))";
 
 const PRINTR_SOLANA_BONDING_CURVE_PROGRAM = "dbcij3LWUppWqq96dh6gJWwBifmcGfLSB5D4DuSMaqN";
-const PRINTR_SOLANA_LAUNCH_PROGRAM = "T8HsGYv7sMk3kTnyaRqZrbRPuntYzdh12evXBkprint";
-const SOLANA_WSOL = "So11111111111111111111111111111111111111112";
-const SOLANA_USDC = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
+const PRINTR_SOLANA_CREATOR = "82VbBzGtb8v5wFx1TM6iaMmLyRSLy8WeqA123orjHGzL";
 
 // 1% total bonding curve swap fee
 // Fee split: 25% creator, 25% memecoin reserve, 40% buyback, 10% team
@@ -97,13 +95,11 @@ interface ISolanaFeeRow {
 const fetchSolana = async (options: FetchOptions) => {
   const rows: ISolanaFeeRow[] = await queryDuneSql(options, `
     WITH printr_created_mints AS (
-      SELECT DISTINCT token_mint_address AS meme_mint
-      FROM tokens_solana.transfers
-      WHERE action = 'mint'
-        AND outer_executing_account = '${PRINTR_SOLANA_LAUNCH_PROGRAM}'
-        AND block_time >= TIMESTAMP '${START}'
-        AND token_mint_address NOT IN ('${SOLANA_WSOL}', '${SOLANA_USDC}')
-    ),
+  SELECT DISTINCT base_mint AS meme_mint
+  FROM meteora_solana.dynamic_bonding_curve_evt_evtinitializepool
+  WHERE creator = '${PRINTR_SOLANA_CREATOR}'
+    AND evt_block_time >= TIMESTAMP '${START}'
+),
     printr_dbc_pools AS (
       SELECT DISTINCT
         account_config,

--- a/dexs/printr-protocol/index.ts
+++ b/dexs/printr-protocol/index.ts
@@ -87,19 +87,15 @@ const fetchEvm = async ({ getLogs, createBalances, api }: FetchOptions) => {
   };
 };
 
-interface ISolanaVolumeRow {
-  payment_mint: string;
-  payment_amount: string | number;
+interface ISolanaFeeRow {
+  quote_mint: string;
+  total_trading_fees: string | number;
+  total_protocol_fees: string | number;
+  total_referral_fees: string | number;
 }
 
-const fetchSolana = async (_a: any, _b: any, options: FetchOptions) => {
-  // Methodology alignment with EVM:
-  // EVM tracks TokenTrade.cost in the basePair token.
-  // Solana DBC swap events expose the quote mint and quote leg amount directly:
-  //  - trade_direction = 1: user pays quote mint as amount_in
-  //  - trade_direction = 0: user receives quote mint as output_amount
-  // In both cases we accumulate the quote/payment leg by mint.
-  const rows: ISolanaVolumeRow[] = await queryDuneSql(options, `
+const fetchSolana = async (options: FetchOptions) => {
+  const rows: ISolanaFeeRow[] = await queryDuneSql(options, `
     WITH printr_created_mints AS (
       SELECT DISTINCT token_mint_address AS meme_mint
       FROM tokens_solana.transfers
@@ -109,21 +105,18 @@ const fetchSolana = async (_a: any, _b: any, options: FetchOptions) => {
         AND token_mint_address NOT IN ('${SOLANA_WSOL}', '${SOLANA_USDC}')
     ),
     printr_dbc_pools AS (
-      -- account_base_mint is the launched/traded meme token mint for each DBC config.
       SELECT DISTINCT
         account_config,
-        account_quote_mint,
-        account_base_mint AS meme_mint
+        account_quote_mint
       FROM meteora_solana.dynamic_bonding_curve_call_initialize_virtual_pool_with_spl_token
       WHERE account_base_mint IN (SELECT meme_mint FROM printr_created_mints)
     ),
-    printr_swaps AS (
+    swap_events AS (
       SELECT
-        p.account_quote_mint AS payment_mint,
-        CASE
-          WHEN s.trade_direction = 1 THEN COALESCE(s.amount_in, 0)
-          ELSE COALESCE(CAST(JSON_EXTRACT_SCALAR(s.swap_result, '$.SwapResult.output_amount') AS DECIMAL(38,0)), 0)
-        END AS payment_amount
+        p.account_quote_mint AS quote_mint,
+        CAST(JSON_EXTRACT_SCALAR(s.swap_result, '$.SwapResult.trading_fee') AS DECIMAL(38,0)) AS trading_fee,
+        CAST(JSON_EXTRACT_SCALAR(s.swap_result, '$.SwapResult.protocol_fee') AS DECIMAL(38,0)) AS protocol_fee,
+        CAST(JSON_EXTRACT_SCALAR(s.swap_result, '$.SwapResult.referral_fee') AS DECIMAL(38,0)) AS referral_fee
       FROM meteora_solana.dynamic_bonding_curve_evt_evtswap s
       JOIN printr_dbc_pools p ON s.config = p.account_config
       WHERE s.evt_executing_account = '${PRINTR_SOLANA_BONDING_CURVE_PROGRAM}'
@@ -131,31 +124,43 @@ const fetchSolana = async (_a: any, _b: any, options: FetchOptions) => {
         AND s.evt_block_time < from_unixtime(${options.endTimestamp})
     )
     SELECT
-      payment_mint,
-      SUM(payment_amount) AS payment_amount
-    FROM printr_swaps
-    GROUP BY payment_mint
+      quote_mint,
+      SUM(COALESCE(trading_fee, 0)) AS total_trading_fees,
+      SUM(COALESCE(protocol_fee, 0)) AS total_protocol_fees,
+      SUM(COALESCE(referral_fee, 0)) AS total_referral_fees
+    FROM swap_events
+    GROUP BY 1
   `)
 
-  const dailyVolume = options.createBalances()
+  const dailyFees = options.createBalances()
+  const dailyRevenue = options.createBalances()
+  const dailyProtocolRevenue = options.createBalances()
+  const dailySupplySideRevenue = options.createBalances()
+
   rows.forEach((row) => {
-    dailyVolume.add(row.payment_mint, row.payment_amount)
+    dailyFees.add(row.quote_mint, Number(row.total_trading_fees))
+    dailyRevenue.add(row.quote_mint, Number(row.total_protocol_fees))
+    dailyProtocolRevenue.add(row.quote_mint, Number(row.total_protocol_fees))
+    dailySupplySideRevenue.add(row.quote_mint, Number(row.total_referral_fees))
   })
 
   return {
-    dailyVolume,
-    ...getFeeBreakdownFromVolume(dailyVolume),
+    dailyFees,
+    dailyUserFees: dailyFees,
+    dailyRevenue,
+    dailyProtocolRevenue,
+    dailySupplySideRevenue,
   }
 }
 
 const fetch = async (options: FetchOptions) => {
-  if (options.chain === CHAIN.SOLANA) return fetchSolana(null, null, options)
+  if (options.chain === CHAIN.SOLANA) return fetchSolana(options)
   return fetchEvm(options)
 }
 
 const methodology = {
   Volume:
-    "Total trading volume from Printr bonding curve buys and sells, tracked as payment-side trade cost. On EVM this is TokenTrade.cost in the curve base pair token; on Solana this is the quote/payment mint leg from DBC swap events (amount_in for buys, quote output_amount for sells).",
+    "EVM-only trading volume from Printr bonding curve swaps, denominated in the base pair token via TokenTrade.cost. Solana bonding curve volume is tracked under Meteora and excluded here.",
   Fees: "Printr charges a 1% fee on all bonding curve swaps.",
   Revenue:
     "75% of trading fees: team (10%), protocol-controlled memecoin reserve (25%), and buyback (40%).",

--- a/dexs/printr-protocol/index.ts
+++ b/dexs/printr-protocol/index.ts
@@ -38,7 +38,7 @@ const getFeeBreakdownFromVolume = (dailyVolume: ReturnType<FetchOptions["createB
   }
 }
 
-const fetchEvm = async ({ getLogs, createBalances, api }: FetchOptions) => {
+const fetchEvm = async (_a: any, _b: any, { getLogs, createBalances, api }: FetchOptions) => {
   const dailyVolume = createBalances();
 
   const tradeLogs = await getLogs({
@@ -84,16 +84,14 @@ const fetchEvm = async ({ getLogs, createBalances, api }: FetchOptions) => {
   };
 };
 
-interface ISolanaFeeRow {
-printr_fee_total_usd: string | number;
-}
 
-const fetchSolana = async (options: FetchOptions) => {
+const fetchSolana = async (_a: any, _b: any, options: FetchOptions) => {
   const [row = { printr_fee_total_usd: 0 }] = await queryDuneSql(options, `
     WITH printr_tokens AS (
       SELECT DISTINCT base_mint AS token
       FROM meteora_solana.dynamic_bonding_curve_evt_evtinitializepool
       WHERE creator = '${PRINTR_SOLANA_CREATOR}'
+      AND evt_block_date >= DATE '${START}'
     ),
     trades_dedup AS (
       SELECT
@@ -125,10 +123,10 @@ const fetchSolana = async (options: FetchOptions) => {
   `);
 
   const dailyFees = options.createBalances();
-  dailyFees.addUSDValue(Number(row.printr_fee_total_usd));
+  dailyFees.addUSDValue(Number(row.printr_fee_total_usd), METRIC.SWAP_FEES);
 
-  const dailyRevenue = dailyFees.clone();
-  const dailyProtocolRevenue = dailyFees.clone();
+  const dailyRevenue = dailyFees.clone(1, METRIC.PROTOCOL_FEES);
+  const dailyProtocolRevenue = dailyFees.clone(1, METRIC.PROTOCOL_FEES);
   const dailyHoldersRevenue = options.createBalances();
   const dailySupplySideRevenue = options.createBalances();
 
@@ -141,9 +139,9 @@ const fetchSolana = async (options: FetchOptions) => {
   };
 };
 
-const fetch = async (options: FetchOptions) => {
-  if (options.chain === CHAIN.SOLANA) return fetchSolana(options)
-  return fetchEvm(options)
+const fetch = async (_a: any, _b: any, options: FetchOptions) => {
+  if (options.chain === CHAIN.SOLANA) return fetchSolana(_a, _b, options)
+  return fetchEvm(_a, _b, options)
 }
 
 const methodology = {
@@ -182,14 +180,14 @@ const breakdownMethodology = {
 }
 
 const adapter: SimpleAdapter = {
-  version: 2,
-  pullHourly: true,
+  version: 1,
   dependencies: [Dependencies.DUNE],
   fetch,
   start: START,
   chains: [CHAIN.ARBITRUM, CHAIN.BASE, CHAIN.AVAX, CHAIN.MANTLE, CHAIN.MONAD, CHAIN.BSC, CHAIN.ETHEREUM, CHAIN.SOLANA],
   methodology,
   breakdownMethodology,
+  isExpensiveAdapter: true,
 };
 
 export default adapter;


### PR DESCRIPTION
## Summary

Add Solana bonding curve volume support for Printr protocol.

This extends the existing EVM implementation by reconstructing Solana volume from Meteora Dynamic Bonding Curve (DBC) swap events.

## Methodology

To align with EVM logic (TokenTrade.cost in base pair token), Solana volume is reconstructed as the payment-side (quote mint) amount:

- For buys: `amount_in` (user pays quote token)
- For sells: `output_amount` (user receives quote token)

To avoid counting unrelated swaps from the shared Meteora DBC program, the scope is restricted to Printr-created tokens:

1. Derive Printr token universe:
   - `tokens_solana.transfers`
   - filter `action = 'mint'`
   - filter `outer_executing_account = Printr launch program`
   - exclude WSOL and USDC

2. Map tokens to DBC pools:
   - `dynamic_bonding_curve_call_initialize_virtual_pool_with_spl_token`
   - match on `account_base_mint`

3. Aggregate swaps:
   - `dynamic_bonding_curve_evt_evtswap`
   - join on `config = account_config`
   - group by quote/payment mint

## Notes

- This adapter uses `queryDuneSql` and depends on Dune datasets.
- The CI failure in this PR is due to missing `DUNE_API_KEYS` in the fork environment.
- Similar Dune-backed adapters already exist in the repository.

Please let me know if Dune-backed adapters are acceptable for this integration.