### PR TITLE
Add TopStrike volume adapter

### DIFF
--- a/dexs/topstrike/index.ts
+++ b/dexs/topstrike/index.ts
@@ -1,16 +1,17 @@
 import { FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
+import { METRIC } from "../../helpers/metrics";
 
 const CONTRACT = "0xf3393dC9E747225FcA0d61BfE588ba2838AFb077";
 
 const TRADE_EVENT_ABI =
-  "event Trade(address indexed trader, uint256 indexed playerId, bool isBuy, uint256 amountInUnits, uint256 priceInWei, uint256 feeInWei, uint256 newSupplyInUnits, bool isIPOWindow)";
+    "event Trade(address indexed trader, uint256 indexed playerId, bool isBuy, uint256 amountInUnits, uint256 priceInWei, uint256 feeInWei, uint256 newSupplyInUnits, bool isIPOWindow)";
 
 const REFERRAL_FEE_PAID_ABI =
-  "event ReferralFeePaid(address indexed referrer, address indexed user, uint256 amountInWei)";
+    "event ReferralFeePaid(address indexed referrer, address indexed user, uint256 amountInWei)";
 
 const ETH_PRIZE_DEPOSITED_ABI =
-  "event EthPrizeDeposited(uint256 amountInWei)";
+    "event EthPrizeDeposited(uint256 amountInWei)";
 
 // Trade.feeInWei carries the total user-paid fee on every fee-generating path
 // (IPO buy + all sells). UserSharesChanged.totalFeesInWei is emitted 1:1 with
@@ -28,97 +29,83 @@ const ETH_PRIZE_DEPOSITED_ABI =
 //   Protocol treasury   -> fees - prize - referral
 
 const fetch = async (options: FetchOptions) => {
-  const dailyVolume = options.createBalances();
-  const dailyFees = options.createBalances();
-  const dailyRevenue = options.createBalances();
-  const dailyProtocolRevenue = options.createBalances();
-  const dailyHoldersRevenue = options.createBalances();
-  const dailySupplySideRevenue = options.createBalances();
+    const dailyVolume = options.createBalances();
+    const dailyFees = options.createBalances();
+    const dailyRevenue = options.createBalances();
+    const dailySupplySideRevenue = options.createBalances();
 
-  const [tradeLogs, referralLogs, prizeLogs] = await Promise.all([
-    options.getLogs({ target: CONTRACT, eventAbi: TRADE_EVENT_ABI }),
-    options.getLogs({ target: CONTRACT, eventAbi: REFERRAL_FEE_PAID_ABI }),
-    options.getLogs({ target: CONTRACT, eventAbi: ETH_PRIZE_DEPOSITED_ABI }),
-  ]);
+    const [tradeLogs, referralLogs, prizeLogs] = await Promise.all([
+        options.getLogs({ target: CONTRACT, eventAbi: TRADE_EVENT_ABI }),
+        options.getLogs({ target: CONTRACT, eventAbi: REFERRAL_FEE_PAID_ABI }),
+        options.getLogs({ target: CONTRACT, eventAbi: ETH_PRIZE_DEPOSITED_ABI }),
+    ]);
 
-  let feeSum = 0n;
-  let referralSum = 0n;
-  let prizeSum = 0n;
+    for (const log of tradeLogs) {
+        // Buy:  priceInWei is gross (includes IPO fees when active)
+        // Sell: priceInWei is net; gross = priceInWei + feeInWei
+        const fee = log.feeInWei;
+        const grossVolume = log.isBuy ? log.priceInWei : log.priceInWei + fee;
+        dailyVolume.addGasToken(grossVolume);
+        dailyFees.addGasToken(fee, METRIC.TRADING_FEES);
+    }
 
-  for (const log of tradeLogs) {
-    // Buy:  priceInWei is gross (includes IPO fees when active)
-    // Sell: priceInWei is net; gross = priceInWei + feeInWei
-    const gross = log.isBuy
-      ? BigInt(log.priceInWei)
-      : BigInt(log.priceInWei) + BigInt(log.feeInWei);
-    dailyVolume.addGasToken(gross);
+    for (const log of referralLogs) {
+        dailySupplySideRevenue.addGasToken(log.amountInWei, 'Referral Rewards');
+    }
 
-    const fee = BigInt(log.feeInWei);
-    dailyFees.addGasToken(fee);
-    feeSum += fee;
-  }
+    for (const log of prizeLogs) {
+        dailySupplySideRevenue.addGasToken(log.amountInWei, 'Prize Pool Rewards');
+    }
 
-  for (const log of referralLogs) {
-    const amt = BigInt(log.amountInWei);
-    dailySupplySideRevenue.addGasToken(amt);
-    referralSum += amt;
-  }
+    const revenue = await dailyFees.getUSDValue() - await dailySupplySideRevenue.getUSDValue();
+    dailyRevenue.addUSDValue(revenue, METRIC.PROTOCOL_FEES);
 
-  for (const log of prizeLogs) {
-    const amt = BigInt(log.amountInWei);
-    dailyHoldersRevenue.addGasToken(amt);
-    prizeSum += amt;
-  }
-
-  // Invariant: the three fee components must not exceed gross fees. If this
-  // ever trips, the split events are out of sync with Trade (e.g. a new fee
-  // source was added on-chain) and we fail fast rather than publish an
-  // inconsistent income statement.
-  if (referralSum + prizeSum > feeSum) {
-    throw new Error(
-      `TopStrike fee splits exceed collected fees: fees=${feeSum} referral=${referralSum} prize=${prizeSum}`,
-    );
-  }
-
-  const protocolShare = feeSum - referralSum - prizeSum;
-  if (protocolShare > 0n) dailyProtocolRevenue.addGasToken(protocolShare);
-
-  const revenueShare = feeSum - referralSum;
-  if (revenueShare > 0n) dailyRevenue.addGasToken(revenueShare);
-
-  return {
-    dailyVolume,
-    dailyFees,
-    dailyRevenue,
-    dailyProtocolRevenue,
-    dailyHoldersRevenue,
-    dailySupplySideRevenue,
-  };
+    return {
+        dailyVolume,
+        dailyFees,
+        dailyUserFees: dailyFees,
+        dailyRevenue,
+        dailyProtocolRevenue: dailyRevenue,
+        dailySupplySideRevenue,
+    };
 };
 
 const methodology = {
-  Volume:
-    "Gross ETH traded through buySharesByLots/buySharesByUnits and the corresponding sell functions, summed from Trade events.",
-  Fees: "Total fees paid by traders, summed from Trade.feeInWei. Includes IPO buy fees (prize + protocol portions) and sell fees (prize + protocol + referral portions).",
-  Revenue:
-    "Fees retained by the protocol ecosystem (treasury + on-chain prize pool), i.e. dailyFees minus referral payouts.",
-  ProtocolRevenue:
-    "Protocol treasury share of fees, derived as dailyFees - prize pool inflows - referral payouts.",
-  HoldersRevenue:
-    "Prize pool inflows (EthPrizeDeposited) — redistributed on-chain to share holders via subsequent EthPrizeAwarded payouts.",
-  SupplySideRevenue:
-    "Referral fees paid to external referrers (ReferralFeePaid). Excludes cases where referrer transfer fails and the amount is redirected to the protocol.",
+    Fees: "Total fees paid by traders, includes buy and sell fees",
+    UserFees: "Trading fees paid by users",
+    Revenue: "Part of fees retained by the protocol",
+    ProtocolRevenue: "All the revenue goes to the protocol",
+    SupplySideRevenue: "Includes referral rewards and prize pool rewards",
+};
+
+const breakdownMethodology = {
+    Fees: {
+        [METRIC.TRADING_FEES]: "Trading fees paid by users",
+    },
+    UserFees: {
+        [METRIC.TRADING_FEES]: "Trading fees paid by users",
+    },
+    Revenue: {
+        [METRIC.PROTOCOL_FEES]: "Part of fees retained by the protocol",
+    },
+    ProtocolRevenue: {
+        [METRIC.PROTOCOL_FEES]: "All the revenue goes to the protocol",
+    },
+    SupplySideRevenue: {
+        'Referral Rewards': "Referral rewards paid to referrers",
+        'Prize Pool Rewards': "Prize pool rewards paid to users holding fractional shares of football players",
+    },
 };
 
 const adapter: SimpleAdapter = {
-  version: 2,
-  adapter: {
-    [CHAIN.MEGAETH]: {
-      fetch,
-      start: "2026-01-11",
-    },
-  },
-  methodology,
+    version: 2,
+    pullHourly: true,
+    fetch,
+    chains: [CHAIN.MEGAETH],
+    start: "2026-01-11",
+    methodology,
+    breakdownMethodology,
+    allowNegativeValue: true, //when prize pool + referral rewards exceed fees
 };
 
 export default adapter;

--- a/dexs/topstrike/index.ts
+++ b/dexs/topstrike/index.ts
@@ -6,24 +6,98 @@ const CONTRACT = "0xf3393dC9E747225FcA0d61BfE588ba2838AFb077";
 const TRADE_EVENT_ABI =
   "event Trade(address indexed trader, uint256 indexed playerId, bool isBuy, uint256 amountInUnits, uint256 priceInWei, uint256 feeInWei, uint256 newSupplyInUnits, bool isIPOWindow)";
 
+const REFERRAL_FEE_PAID_ABI =
+  "event ReferralFeePaid(address indexed referrer, address indexed user, uint256 amountInWei)";
+
+const ETH_PRIZE_DEPOSITED_ABI =
+  "event EthPrizeDeposited(uint256 amountInWei)";
+
+// Trade.feeInWei carries the total user-paid fee on every fee-generating path
+// (IPO buy + all sells). UserSharesChanged.totalFeesInWei is emitted 1:1 with
+// each Trade and carries the same value, so summing Trade.feeInWei captures
+// all fees without double-counting.
+//
+// Fee flow:
+//   fees = prizePool + protocolTreasury + referrer(optional)
+// Events used for the split:
+//   EthPrizeDeposited   -> prize pool inflow (holders revenue)
+//   ReferralFeePaid     -> actual referrer payouts (supply-side revenue)
+//     (if referrer transfer fails the amount is redirected to protocol and
+//      ReferralFeeRedirectedToProtocol is emitted instead — correctly
+//      excluded from supplySideRevenue)
+//   Protocol treasury   -> fees - prize - referral
+
 const fetch = async (options: FetchOptions) => {
   const dailyVolume = options.createBalances();
+  const dailyFees = options.createBalances();
+  const dailyRevenue = options.createBalances();
+  const dailyProtocolRevenue = options.createBalances();
+  const dailyHoldersRevenue = options.createBalances();
+  const dailySupplySideRevenue = options.createBalances();
 
-  const logs = await options.getLogs({
-    target: CONTRACT,
-    eventAbi: TRADE_EVENT_ABI,
-  });
+  const [tradeLogs, referralLogs, prizeLogs] = await Promise.all([
+    options.getLogs({ target: CONTRACT, eventAbi: TRADE_EVENT_ABI }),
+    options.getLogs({ target: CONTRACT, eventAbi: REFERRAL_FEE_PAID_ABI }),
+    options.getLogs({ target: CONTRACT, eventAbi: ETH_PRIZE_DEPOSITED_ABI }),
+  ]);
 
-  for (const log of logs) {
+  let feeSum = 0n;
+  let referralSum = 0n;
+  let prizeSum = 0n;
+
+  for (const log of tradeLogs) {
     // Buy:  priceInWei is gross (includes IPO fees when active)
     // Sell: priceInWei is net; gross = priceInWei + feeInWei
     const gross = log.isBuy
       ? BigInt(log.priceInWei)
       : BigInt(log.priceInWei) + BigInt(log.feeInWei);
     dailyVolume.addGasToken(gross);
+
+    const fee = BigInt(log.feeInWei);
+    dailyFees.addGasToken(fee);
+    feeSum += fee;
   }
 
-  return { dailyVolume };
+  for (const log of referralLogs) {
+    const amt = BigInt(log.amountInWei);
+    dailySupplySideRevenue.addGasToken(amt);
+    referralSum += amt;
+  }
+
+  for (const log of prizeLogs) {
+    const amt = BigInt(log.amountInWei);
+    dailyHoldersRevenue.addGasToken(amt);
+    prizeSum += amt;
+  }
+
+  const protocolShare = feeSum - referralSum - prizeSum;
+  if (protocolShare > 0n) dailyProtocolRevenue.addGasToken(protocolShare);
+
+  const revenueShare = feeSum - referralSum;
+  if (revenueShare > 0n) dailyRevenue.addGasToken(revenueShare);
+
+  return {
+    dailyVolume,
+    dailyFees,
+    dailyRevenue,
+    dailyProtocolRevenue,
+    dailyHoldersRevenue,
+    dailySupplySideRevenue,
+  };
+};
+
+const methodology = {
+  Volume:
+    "Gross ETH traded through buySharesByLots/buySharesByUnits and the corresponding sell functions, summed from Trade events.",
+  Fees: "Total fees paid by traders, summed from Trade.feeInWei. Includes IPO buy fees (prize + protocol portions) and sell fees (prize + protocol + referral portions).",
+  Revenue:
+    "Fees retained by the protocol ecosystem (treasury + on-chain prize pool), i.e. dailyFees minus referral payouts.",
+  ProtocolRevenue:
+    "Protocol treasury share of fees, derived as dailyFees - prize pool inflows - referral payouts.",
+  HoldersRevenue:
+    "Prize pool inflows (EthPrizeDeposited) — redistributed on-chain to share holders via subsequent EthPrizeAwarded payouts.",
+  SupplySideRevenue:
+    "Referral fees paid to external referrers (ReferralFeePaid). Excludes cases where referrer transfer fails and the amount is redirected to the protocol.",
 };
 
 const adapter: SimpleAdapter = {
@@ -34,6 +108,7 @@ const adapter: SimpleAdapter = {
       start: "2026-01-11",
     },
   },
+  methodology,
 };
 
 export default adapter;

--- a/dexs/topstrike/index.ts
+++ b/dexs/topstrike/index.ts
@@ -1,0 +1,39 @@
+import { FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+
+const CONTRACT = "0xf3393dC9E747225FcA0d61BfE588ba2838AFb077";
+
+const TRADE_EVENT_ABI =
+  "event Trade(address indexed trader, uint256 indexed playerId, bool isBuy, uint256 amountInUnits, uint256 priceInWei, uint256 feeInWei, uint256 newSupplyInUnits, bool isIPOWindow)";
+
+const fetch = async (options: FetchOptions) => {
+  const dailyVolume = options.createBalances();
+
+  const logs = await options.getLogs({
+    target: CONTRACT,
+    eventAbi: TRADE_EVENT_ABI,
+  });
+
+  for (const log of logs) {
+    // Buy:  priceInWei is gross (includes IPO fees when active)
+    // Sell: priceInWei is net; gross = priceInWei + feeInWei
+    const gross = log.isBuy
+      ? BigInt(log.priceInWei)
+      : BigInt(log.priceInWei) + BigInt(log.feeInWei);
+    dailyVolume.addGasToken(gross);
+  }
+
+  return { dailyVolume };
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  adapter: {
+    [CHAIN.MEGAETH]: {
+      fetch,
+      start: "2026-01-11",
+    },
+  },
+};
+
+export default adapter;

--- a/dexs/topstrike/index.ts
+++ b/dexs/topstrike/index.ts
@@ -70,6 +70,16 @@ const fetch = async (options: FetchOptions) => {
     prizeSum += amt;
   }
 
+  // Invariant: the three fee components must not exceed gross fees. If this
+  // ever trips, the split events are out of sync with Trade (e.g. a new fee
+  // source was added on-chain) and we fail fast rather than publish an
+  // inconsistent income statement.
+  if (referralSum + prizeSum > feeSum) {
+    throw new Error(
+      `TopStrike fee splits exceed collected fees: fees=${feeSum} referral=${referralSum} prize=${prizeSum}`,
+    );
+  }
+
   const protocolShare = feeSum - referralSum - prizeSum;
   if (protocolShare > 0n) dailyProtocolRevenue.addGasToken(protocolShare);
 


### PR DESCRIPTION
Adds a volume adapter for **TopStrike**, a fractional-share trading platform for football players on MegaETH.

- **Website:** https://topstrike.io
- **Twitter:** [@TopStrikeIO](https://twitter.com/TopStrikeIO)
- **Chain:** MegaETH (chain ID 4326)
- **Contract:** [`0xf3393dC9E747225FcA0d61BfE588ba2838AFb077`](https://megaeth.blockscout.com/address/0xf3393dC9E747225FcA0d61BfE588ba2838AFb077)
- **Adapter:** `dexs/topstrike/index.ts`

**How it works:** sums the `priceInWei` field of the `Trade` event for daily volume. For sells, `priceInWei` is net-of-fees so the adapter adds `feeInWei` back to report gross notional (matching DEX convention). For buys, `priceInWei` is already gross (includes IPO fees when active).

**Category preference:** Prediction Markets (peer: Polymarket) rather than Dexs — happy to adjust as recommended.

- [x] Uses `options.getLogs` (no external RPC dependency)
- [x] Tested locally with `npm test dexs topstrike` — non-zero daily volume on MEGAETH
- [x] Verified against internal stats (matches within a few dollars of internal 1-day total)