### PR TITLE
track helix fees (burned relayer share)

### DIFF
--- a/fees/helix.ts
+++ b/fees/helix.ts
@@ -1,0 +1,41 @@
+import { FetchOptions } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+import { httpGet } from "../utils/fetchURL";
+
+interface IHelixFeesDailyData {
+  date: string;
+  fees_usd: number;
+}
+
+interface IHelixFeesResponse {
+  days: IHelixFeesDailyData[];
+  total_fees_usd: number;
+}
+
+const URL = "https://bigquery-api-636134865280.europe-west1.run.app/helix_fees";
+
+const fetch = async (_: number, _t: any, options: FetchOptions) => {
+  const res: IHelixFeesResponse = await httpGet(`${URL}?start_date=${options.dateString}`);
+  if (res.days.length !== 1) throw new Error("No Helix fee data found for the given date: " + options.dateString);
+
+  const dailyFees = options.createBalances();
+  dailyFees.addUSDValue(res.total_fees_usd, "Helix Relayer Share");
+
+  return {
+    dailyFees,
+    dailyRevenue: dailyFees,
+    dailyHoldersRevenue: dailyFees,
+  };
+};
+
+export default {
+  methodology: {
+    Fees: "40% of exchange fees on spot and derivative fills routed through Helix (orders submitted with fee_recipient = inj1zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3t5qxqh, the null fee recipient sentinel). Helix forfeits its 40% relayer share to the exchange module's auction basket.",
+    Revenue: "100% of Helix's relayer share. Helix does not keep any of this revenue — all of it is deposited into the auction basket, sold for INJ, and burned.",
+    HoldersRevenue: "100% of Helix's relayer share. The burned INJ accrues to all INJ holders via supply reduction.",
+  },
+  fetch,
+  start: "2023-02-16",
+  chains: [CHAIN.INJECTIVE],
+  doublecounted: true,
+};


### PR DESCRIPTION
## Summary

Adds `fees/helix.ts`, a fees/revenue adapter for Helix (already listed with volume adapters at `dexs/helix-helix.ts` and `dexs/helix-helix-perp.ts`).

## Why

Helix is the dominant frontend on Injective's exchange module. Orders submitted via Helix set `fee_recipient` to the null-address sentinel `inj1zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3t5qxqh`, which **forfeits the 40% relayer share** to the exchange module's auction basket — where it's sold for INJ and burned alongside the community's 60% share.

Today this flow isn't attributed anywhere:
- `fees/injective.ts` reports the full auction burn at the **chain** level (as "Auction Fees"), which includes Helix's forfeited 40%.
- `dexs/helix-helix*.ts` track Helix **volume** only, not fees.
- Helix's protocol page shows $0 in fees/revenue, even though a large share of the chain's auction-burn is directly attributable to it.

This adapter credits Helix on its protocol page for the 40% relayer share of fees generated by Helix-routed fills.

## Methodology

```
helix_fees(date) = Σ (exchange_fee_usd) on fills where fee_recipient == inj1zyg3…xqh
                   × 0.40   (constant relayer_fee_share_rate, not overridden per market)
```

- **Fees** = Revenue = HoldersRevenue — all of it is burned as INJ, accruing to holders via supply reduction.
- **`doublecounted: true`** — the same dollars are already counted at the chain level in `fees/injective.ts` "Auction Fees". This flag keeps Helix's revenue on its own protocol page without inflating the Injective chain rollup.

## Backend data source

Uses the same `bigquery-api-636134865280.europe-west1.run.app` service that powers `fees/injective.ts`, `dexs/injective-spot.ts`, `dexs/injective-derivatives.ts`, and `open-interest/injective-derivatives.ts`.

Proposed new endpoint (not yet provisioned):

```
GET /helix_fees?start_date=YYYY-MM-DD
→ { days: [{ date, fees_usd }], total_fees_usd }
```

The SQL filter on the existing fee-event dataset is straightforward — filter spot + derivative fill events by `fee_recipient = 'inj1zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3t5qxqh'` and multiply the fee amount by 0.4.

Happy to coordinate on endpoint shape if you'd like to adjust the request/response schema before merging.

## Test plan

- [ ] Backend: provision `/helix_fees` endpoint on the bigquery-api service
- [ ] Verify adapter returns a sensible daily number (expected order of magnitude: low‑four to low-five figures USD/day at current Injective volumes)
- [ ] Verify it shows on the Helix protocol page but not on the Injective chain revenue rollup