### PR TITLE
feat(nextrare): add fees adapter

### DIFF
--- a/fees/nextrare/index.ts
+++ b/fees/nextrare/index.ts
@@ -29,6 +29,7 @@
 
 import { FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
+import { METRIC } from "../../helpers/metrics";
 
 const GIFT_CARD = "0x7D7d2c07196feFBD334B127136bCA1BD8EafFBF1";
 
@@ -36,115 +37,113 @@ const GIFT_CARD = "0x7D7d2c07196feFBD334B127136bCA1BD8EafFBF1";
 // USDm to users while live, so historical sellback is the *union* of
 // payouts via every pool ever authorized on either vault.
 const VAULTS: { addr: string; deployBlock: number }[] = [
-  { addr: "0x6D6A11ED1fA9aEc8c1fAb2d6168Fb33276d634EA", deployBlock: 0xbfd660 }, // 12_572_896
-  { addr: "0xa51eAFEfcCeeBF6970500761F49B9bcBd9F1E68e", deployBlock: 0xcc63c4 }, // 13_394_884
+    { addr: "0x6D6A11ED1fA9aEc8c1fAb2d6168Fb33276d634EA", deployBlock: 12572896 },
+    { addr: "0xa51eAFEfcCeeBF6970500761F49B9bcBd9F1E68e", deployBlock: 13394884 },
 ];
 
-const GIFT_CARD_TOKEN_ID  = 1;
-const PRICE_PER_CARD_USD  = 5;
-const ZERO                = "0x0000000000000000000000000000000000000000";
+const GIFT_CARD_TOKEN_ID = 1;
+const PRICE_PER_CARD_USD = 5;
+const ZERO = "0x0000000000000000000000000000000000000000";
 
 const TRANSFER_SINGLE =
-  "event TransferSingle(address indexed operator, address indexed from, address indexed to, uint256 id, uint256 value)";
+    "event TransferSingle(address indexed operator, address indexed from, address indexed to, uint256 id, uint256 value)";
 const POOL_UPDATED =
-  "event PoolUpdated(address indexed pool, bool authorized)";
+    "event PoolUpdated(address indexed pool, bool authorized)";
 const SETTLED =
-  "event Settled(uint64 indexed drawId, bool kept, uint256 value)";
+    "event Settled(uint64 indexed drawId, bool kept, uint256 value)";
 
 const LABEL_PACK_OPEN = "Pack Open";
-const LABEL_SELLBACK  = "Sellback Refund";
+const LABEL_SELLBACK = "Sellback Refund";
 
 const fetch = async (options: FetchOptions) => {
-  const dailyFees              = options.createBalances(); // gross
-  const dailySupplySideRevenue = options.createBalances(); // refund cost
-  const dailyRevenue           = options.createBalances(); // net = fees − supply-side
+    const dailyFees = options.createBalances(); // gross
+    const dailySupplySideRevenue = options.createBalances(); // refund cost
+    const dailyRevenue = options.createBalances(); // net = fees − supply-side
 
-  // 1) Pack opens — gift cards burned today, valued at $5 each.
-  const burnLogs = await options.getLogs({
-    target: GIFT_CARD,
-    eventAbi: TRANSFER_SINGLE,
-  });
-  for (const log of burnLogs) {
-    if (String(log.to).toLowerCase() !== ZERO) continue;
-    if (Number(log.id) !== GIFT_CARD_TOKEN_ID) continue;
-    const usd = Number(log.value) * PRICE_PER_CARD_USD;
-    dailyFees.addUSDValue(usd, LABEL_PACK_OPEN);
-    dailyRevenue.addUSDValue(usd, LABEL_PACK_OPEN);
-  }
+    // 1) Pack opens — gift cards burned today, valued at $5 each.
+    const burnLogs = await options.getLogs({
+        target: GIFT_CARD,
+        eventAbi: TRANSFER_SINGLE,
+    });
+    for (const log of burnLogs) {
+        if (String(log.to).toLowerCase() !== ZERO) continue;
+        if (Number(log.id) !== GIFT_CARD_TOKEN_ID) continue;
+        const usd = Number(log.value) * PRICE_PER_CARD_USD;
+        dailyFees.addUSDValue(usd, LABEL_PACK_OPEN);
+    }
 
-  // 2) Enumerate every GachaPool ever authorized on either vault.
-  //    A pool that's been deauthorized still emitted real Settled events
-  //    while it was live, so we want the union of "ever authorized=true"
-  //    across both vaults — not just currently-active pools. Cheap
-  //    (<20 events total ever) and forward-compatible with the
-  //    deploy-new-pool flow.
-  const everAuthorized = new Set<string>();
-  for (const v of VAULTS) {
+    // 2) Enumerate every GachaPool ever authorized on either vault.
+    //    A pool that's been deauthorized still emitted real Settled events
+    //    while it was live, so we want the union of "ever authorized=true"
+    //    across both vaults — not just currently-active pools. Cheap
+    //    (<20 events total ever) and forward-compatible with the
+    //    deploy-new-pool flow.
+    const everAuthorized = new Set<string>();
     const poolEvents = await options.getLogs({
-      target: v.addr,
-      eventAbi: POOL_UPDATED,
-      fromBlock: v.deployBlock,
-      cacheInCloud: true,
+        targets: [...VAULTS.map(v => v.addr)],
+        eventAbi: POOL_UPDATED,
+        fromBlock: Math.min(...VAULTS.map(v => v.deployBlock)),
+        cacheInCloud: true,
     });
     for (const ev of poolEvents) {
-      if (ev.authorized) everAuthorized.add(String(ev.pool).toLowerCase());
+        if (ev.authorized) everAuthorized.add(String(ev.pool).toLowerCase());
     }
-  }
 
-  // 3) Sellback refunds — Settled(kept=false, value) from every pool that
-  //    was ever authorized. `value` is USDm wei (18 decimals); USDm trades
-  //    1:1 with USD. Booked positive on supply-side, negative on revenue.
-  for (const pool of everAuthorized) {
-    const settled = await options.getLogs({ target: pool, eventAbi: SETTLED });
+    // 3) Sellback refunds — Settled(kept=false, value) from every pool that
+    //    was ever authorized. `value` is USDm wei (18 decimals); USDm trades
+    //    1:1 with USD. Booked positive on supply-side, negative on revenue.
+    const settled = await options.getLogs({ targets: [...everAuthorized], eventAbi: SETTLED });
     for (const log of settled) {
-      if (log.kept) continue; // kept=true means NFT mint; `value` is a tokenId, not money.
-      const usd = Number(log.value) / 1e18;
-      dailySupplySideRevenue.addUSDValue(usd, LABEL_SELLBACK);
-      dailyRevenue.addUSDValue(-usd, LABEL_SELLBACK);
+        if (log.kept) continue; // kept=true means NFT mint; `value` is a tokenId, not money.
+        const usd = Number(log.value) / 1e18;
+        dailySupplySideRevenue.addUSDValue(usd, LABEL_SELLBACK);
     }
-  }
 
-  return {
-    dailyFees,
-    dailyRevenue,
-    dailySupplySideRevenue,
-    dailyProtocolRevenue: dailyRevenue,
-  };
+    const revenue = dailyFees.clone();
+    revenue.subtract(dailySupplySideRevenue);
+
+    const revenueInUsd = await revenue.getUSDValue();
+    dailyRevenue.addUSDValue(revenueInUsd, METRIC.PROTOCOL_FEES);
+
+    return {
+        dailyFees,
+        dailyRevenue,
+        dailySupplySideRevenue,
+        dailyProtocolRevenue: dailyRevenue,
+    };
 };
 
 const methodology = {
-  Fees:              "Gross protocol fees on MegaETH: gift cards burned on pack opens (× $5 each).",
-  SupplySideRevenue: "USDm paid back to users via SellbackVault when they choose to sell back rather than keep an NFT — i.e. refunds.",
-  Revenue:           "Net protocol revenue = Fees − SupplySideRevenue. The amount the NextRare treasury actually retains after refunds.",
-  ProtocolRevenue:   "Same as Revenue — 100% accrues to the treasury (no LP, no holders, no split).",
+    Fees: "Gross protocol fees on MegaETH: gift cards burned on pack opens (× $5 each).",
+    SupplySideRevenue: "USDm paid back to users via SellbackVault when they choose to sell back rather than keep an NFT — i.e. refunds.",
+    Revenue: "Net protocol revenue = Fees − SupplySideRevenue. The amount the NextRare treasury actually retains after refunds.",
+    ProtocolRevenue: "Same as Revenue — 100% accrues to the treasury (no LP, no holders, no split).",
 };
 
 const breakdownMethodology = {
-  Fees: {
-    [LABEL_PACK_OPEN]: "Gift cards burned by GachaPool.draw() (each card = $5). Detected via ERC-1155 TransferSingle to address(0) on the GiftCard contract, id=1.",
-  },
-  SupplySideRevenue: {
-    [LABEL_SELLBACK]: "USDm paid out by SellbackVault (current and prior) when a user opts not to keep an NFT. Detected via Settled(kept=false, value) on every GachaPool ever authorized on either vault.",
-  },
-  Revenue: {
-    [LABEL_PACK_OPEN]: "Pack-open spending accrues to the NextRare treasury.",
-    [LABEL_SELLBACK]:  "Sellback refunds reduce net revenue.",
-  },
-  ProtocolRevenue: {
-    [LABEL_PACK_OPEN]: "Pack-open spending accrues to the NextRare treasury.",
-    [LABEL_SELLBACK]:  "Sellback refunds reduce protocol revenue.",
-  },
+    Fees: {
+        [LABEL_PACK_OPEN]: "Gift cards burned by GachaPool.draw() (each card = $5). Detected via ERC-1155 TransferSingle to address(0) on the GiftCard contract, id=1.",
+    },
+    SupplySideRevenue: {
+        [LABEL_SELLBACK]: "USDm paid out by SellbackVault (current and prior) when a user opts not to keep an NFT. Detected via Settled(kept=false, value) on every GachaPool ever authorized on either vault.",
+    },
+    Revenue: {
+        [METRIC.PROTOCOL_FEES]: "The amount the NextRare treasury actually retains after refunds.",
+    },
+    ProtocolRevenue: {
+        [METRIC.PROTOCOL_FEES]: "The amount the NextRare treasury actually retains after refunds.",
+    },
 };
 
 const adapter: SimpleAdapter = {
-  version: 2,
-  pullHourly: true,
-  allowNegativeValue: true,
-  adapter: {
-    [CHAIN.MEGAETH]: { fetch, start: "2026-03-23" },
-  },
-  methodology,
-  breakdownMethodology,
+    version: 2,
+    pullHourly: true,
+    allowNegativeValue: true,
+    fetch,
+    chains: [CHAIN.MEGAETH],
+    start: "2026-03-23",
+    methodology,
+    breakdownMethodology,
 };
 
 export default adapter;

--- a/fees/nextrare/index.ts
+++ b/fees/nextrare/index.ts
@@ -1,112 +1,135 @@
-// NextRare — cross-chain NFT gacha protocol.
+// NextRare — cross-chain NFT gacha protocol on MegaETH.
 //
-// Tracks daily user payments via the Collector contract's own typed events
-// (`Deposited` + `CrossmintPurchase`) emitted by the CREATE2-deployed Collector
-// at the same address on every supported chain.
+// Net protocol fees:
+//   dailyFees = (gift cards burned on pack opens × $5) − (USDm sellback payouts)
 //
-// These events are emitted by the Collector — not by the token contract —
-// because Collector uses `transferFrom(user, treasury, amount)` to forward
-// funds directly to the Safe treasury. The ERC-20 Transfer event therefore
-// has `from=user, to=treasury` with no Collector address in topics, so we
-// must hook the typed events.
+// A user buys gift cards (each = $5), opens packs by burning them, and may
+// sell unwanted draws back to the SellbackVault for USDm. The protocol earns
+// nothing on a card that is bought and then sold back, so gross deposits
+// overstate true earnings — this adapter measures the *net*.
 //
-// Both events carry amount fields normalized to 6 decimals by the contract's
-// `_normalize()` function before emission, so every log is priced as canonical
-// USDC @ $1 regardless of source-chain token decimals (handles BSC 18-decimal
-// USDC/USDT and MegaETH 18-decimal USDm uniformly).
+// All flows live on MegaETH. The Collector contract on Base/Arbitrum/BSC/
+// Mantle/HyperEVM/Monad is a cross-chain on-ramp into a MegaETH gift-card
+// mint; it is intentionally not measured here, since deposits there can be
+// fully refunded via sellback after settlement.
 //
-// Economics: user payments for gacha packs are non-refundable and accrue
-// 100% to the NextRare treasury — there is no LP, no external holders, no
-// revenue split. We therefore report Fees == Revenue == ProtocolRevenue.
+// Sources of truth:
+//   Burns    — GiftCard ERC-1155 TransferSingle to address(0), id=1.
+//              BURNER_ROLE is granted only to GachaPool, which only burns on
+//              draws paid in gift cards, so this filter equals "spending".
+//   Sellback — GachaPool.Settled(drawId, kept=false, value) where `value` is
+//              the USDm wei amount paid out. SellbackVault has been redeployed
+//              once, so we enumerate the union of every pool ever authorized
+//              on either vault by replaying their PoolUpdated logs since
+//              deploy. Pools that are now deauthorized still emitted real
+//              Settled events while live and must be counted.
 
 import { FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 
-// Same CREATE2 address on every EVM chain.
-const COLLECTOR = "0x0000000032B93DAf5c6Ff220cB2D03624CB56302";
+const GIFT_CARD = "0x7D7d2c07196feFBD334B127136bCA1BD8EafFBF1";
 
-const DEPOSITED_EVENT =
-  "event Deposited(address indexed from, address indexed to, uint64 indexed intentId, uint64 amount, address token)";
+// SellbackVault has been redeployed once. Both vaults paid out real
+// USDm to users while live, so historical sellback is the *union* of
+// payouts via every pool ever authorized on either vault.
+const VAULTS: { addr: string; deployBlock: number }[] = [
+  { addr: "0x6D6A11ED1fA9aEc8c1fAb2d6168Fb33276d634EA", deployBlock: 0xbfd660 }, // 12_572_896
+  { addr: "0xa51eAFEfcCeeBF6970500761F49B9bcBd9F1E68e", deployBlock: 0xcc63c4 }, // 13_394_884
+];
 
-const CROSSMINT_EVENT =
-  "event CrossmintPurchase(address indexed from, address indexed to, uint16 quantity, uint64 normalizedAmount, address token)";
+const GIFT_CARD_TOKEN_ID  = 1;
+const PRICE_PER_CARD_USD  = 5;
+const ZERO                = "0x0000000000000000000000000000000000000000";
 
-// Labels (must exactly match keys in breakdownMethodology below).
-const LABEL_CROSS_CHAIN = "Cross-chain Deposit";
-const LABEL_CROSSMINT   = "Crossmint Purchase";
+const TRANSFER_SINGLE =
+  "event TransferSingle(address indexed operator, address indexed from, address indexed to, uint256 id, uint256 value)";
+const POOL_UPDATED =
+  "event PoolUpdated(address indexed pool, bool authorized)";
+const SETTLED =
+  "event Settled(uint64 indexed drawId, bool kept, uint256 value)";
 
-// Collector CREATE2-deployed on all chains on 2026-03-23.
-const config: Record<string, { start: string }> = {
-  [CHAIN.BASE]:        { start: "2026-03-23" },
-  [CHAIN.ARBITRUM]:    { start: "2026-03-23" },
-  [CHAIN.BSC]:         { start: "2026-03-23" },
-  [CHAIN.MANTLE]:      { start: "2026-03-23" },
-  [CHAIN.HYPERLIQUID]: { start: "2026-03-23" },
-  [CHAIN.MONAD]:       { start: "2026-03-23" },
-  [CHAIN.MEGAETH]:     { start: "2026-03-23" },
-};
+const LABEL_PACK_OPEN = "Pack Open";
+const LABEL_SELLBACK  = "Sellback Refund";
 
 const fetch = async (options: FetchOptions) => {
-  const dailyFees    = options.createBalances();
-  const dailyRevenue = options.createBalances();
+  const dailyFees = options.createBalances();
 
-  const [deposits, crossmints] = await Promise.all([
-    options.getLogs({ target: COLLECTOR, eventAbi: DEPOSITED_EVENT }),
-    options.getLogs({ target: COLLECTOR, eventAbi: CROSSMINT_EVENT }),
-  ]);
+  // 1) Pack opens — gift cards burned today, valued at $5 each.
+  const burnLogs = await options.getLogs({
+    target: GIFT_CARD,
+    eventAbi: TRANSFER_SINGLE,
+  });
+  for (const log of burnLogs) {
+    if (String(log.to).toLowerCase() !== ZERO) continue;
+    if (Number(log.id) !== GIFT_CARD_TOKEN_ID) continue;
+    const cards = Number(log.value);
+    dailyFees.addUSDValue(cards * PRICE_PER_CARD_USD, LABEL_PACK_OPEN);
+  }
 
-  // Convert 6-decimal BigInt amounts directly to USD — treats every payment
-  // as $1 stable regardless of source token (sidesteps per-chain price
-  // lookups for USDm/bridged USDC/USDT variants).
-  deposits.forEach((log: any) => {
-    const usd = Number(log.amount) / 1e6;
-    dailyFees.addUSDValue(usd, LABEL_CROSS_CHAIN);
-    dailyRevenue.addUSDValue(usd, LABEL_CROSS_CHAIN);
-  });
-  crossmints.forEach((log: any) => {
-    const usd = Number(log.normalizedAmount) / 1e6;
-    dailyFees.addUSDValue(usd, LABEL_CROSSMINT);
-    dailyRevenue.addUSDValue(usd, LABEL_CROSSMINT);
-  });
+  // 2) Enumerate every GachaPool ever authorized on either vault.
+  //    A pool that's been deauthorized still emitted real Settled events
+  //    while it was live, so we want the union of "ever authorized=true"
+  //    across both vaults — not just currently-active pools. Cheap
+  //    (<20 events total ever) and forward-compatible with the
+  //    deploy-new-pool flow.
+  const everAuthorized = new Set<string>();
+  for (const v of VAULTS) {
+    const poolEvents = await options.getLogs({
+      target: v.addr,
+      eventAbi: POOL_UPDATED,
+      fromBlock: v.deployBlock,
+      cacheInCloud: true,
+    });
+    for (const ev of poolEvents) {
+      if (ev.authorized) everAuthorized.add(String(ev.pool).toLowerCase());
+    }
+  }
+
+  // 3) Sellback refunds — Settled(kept=false, value) from every pool that
+  //    was ever authorized. `value` is USDm wei (18 decimals). USDm trades
+  //    1:1 with USD, so we record it directly as a negative USD amount.
+  for (const pool of everAuthorized) {
+    const settled = await options.getLogs({ target: pool, eventAbi: SETTLED });
+    for (const log of settled) {
+      if (log.kept) continue; // kept=true means NFT mint; `value` is a tokenId, not money.
+      const usd = Number(log.value) / 1e18;
+      dailyFees.addUSDValue(-usd, LABEL_SELLBACK);
+    }
+  }
 
   return {
     dailyFees,
-    dailyRevenue,
-    dailyProtocolRevenue: dailyRevenue,
+    dailyRevenue:         dailyFees,
+    dailyProtocolRevenue: dailyFees,
   };
 };
 
 const methodology = {
-  Fees: "Gross user payments for gacha pack purchases into the NextRare Collector contract on every supported chain.",
-  Revenue: "User payments are non-refundable and accrue 100% to the NextRare treasury — no LP or external holders.",
-  ProtocolRevenue: "Same as Revenue — the NextRare treasury captures all user payments.",
+  Fees: "Net protocol fees on MegaETH: gift cards burned on pack opens (× $5 each) minus USDm paid back to users via SellbackVault. The protocol earns nothing on a card that is bought and then sold back, so gross deposits would overstate true earnings.",
+  Revenue:         "Same as Fees — 100% accrues to the NextRare treasury (no LP, no holders, no split).",
+  ProtocolRevenue: "Same as Fees — the NextRare treasury captures the net.",
 };
 
 const breakdownMethodology = {
   Fees: {
-    [LABEL_CROSS_CHAIN]:
-      "USDC/USDT on Base/Arbitrum/BSC/Mantle/HyperEVM/Monad (or USDm on MegaETH) paid via Collector.deposit(), settled cross-chain into a MegaETH GiftCard mint.",
-    [LABEL_CROSSMINT]:
-      "Purchases made directly through Crossmint (credit-card / non-crypto checkout) via Collector.mint().",
+    [LABEL_PACK_OPEN]: "Gift cards burned by GachaPool.draw() (each card = $5). Detected via ERC-1155 TransferSingle to address(0) on the GiftCard contract, id=1.",
+    [LABEL_SELLBACK]:  "USDm paid out by SellbackVault (current and prior) when a user opts not to keep an NFT. Detected via Settled(kept=false, value) on every GachaPool ever authorized on either vault. Recorded as a negative.",
   },
   Revenue: {
-    [LABEL_CROSS_CHAIN]: "Cross-chain deposits accrue to the NextRare treasury.",
-    [LABEL_CROSSMINT]:   "Crossmint purchases accrue to the NextRare treasury.",
+    [LABEL_PACK_OPEN]: "Pack-open spending accrues to the NextRare treasury.",
+    [LABEL_SELLBACK]:  "Sellback payouts are funded from the treasury via SellbackVault — recorded as a negative.",
   },
   ProtocolRevenue: {
-    [LABEL_CROSS_CHAIN]: "Cross-chain deposits accrue to the NextRare treasury.",
-    [LABEL_CROSSMINT]:   "Crossmint purchases accrue to the NextRare treasury.",
+    [LABEL_PACK_OPEN]: "Pack-open spending accrues to the NextRare treasury.",
+    [LABEL_SELLBACK]:  "Sellback payouts are funded from the treasury via SellbackVault — recorded as a negative.",
   },
 };
 
-const adapters: Record<string, { fetch: typeof fetch; start: string }> = {};
-Object.keys(config).forEach((chain) => {
-  adapters[chain] = { fetch, start: config[chain].start };
-});
-
 const adapter: SimpleAdapter = {
   version: 2,
-  adapter: adapters,
+  adapter: {
+    [CHAIN.MEGAETH]: { fetch, start: "2026-03-23" },
+  },
   methodology,
   breakdownMethodology,
 };

--- a/fees/nextrare/index.ts
+++ b/fees/nextrare/index.ts
@@ -92,11 +92,13 @@ const fetch = async (options: FetchOptions) => {
     // 3) Sellback refunds — Settled(kept=false, value) from every pool that
     //    was ever authorized. `value` is USDm wei (18 decimals); USDm trades
     //    1:1 with USD. Booked positive on supply-side, negative on revenue.
+    if(everAuthorized.size > 0) {
     const settled = await options.getLogs({ targets: [...everAuthorized], eventAbi: SETTLED });
     for (const log of settled) {
-        if (log.kept) continue; // kept=true means NFT mint; `value` is a tokenId, not money.
-        const usd = Number(log.value) / 1e18;
-        dailySupplySideRevenue.addUSDValue(usd, LABEL_SELLBACK);
+            if (log.kept) continue; // kept=true means NFT mint; `value` is a tokenId, not money.
+            const usd = Number(log.value) / 1e18;
+            dailySupplySideRevenue.addUSDValue(usd, LABEL_SELLBACK);
+        }
     }
 
     const revenue = dailyFees.clone();
@@ -141,7 +143,7 @@ const adapter: SimpleAdapter = {
     allowNegativeValue: true,
     fetch,
     chains: [CHAIN.MEGAETH],
-    start: "2026-03-23",
+    start: "2026-04-06",
     methodology,
     breakdownMethodology,
 };

--- a/fees/nextrare/index.ts
+++ b/fees/nextrare/index.ts
@@ -1,8 +1,8 @@
 // NextRare — cross-chain NFT gacha protocol.
 //
-// Tracks daily user payment volume via the Collector contract's own typed
-// events (`Deposited` + `CrossmintPurchase`) emitted by the CREATE2-deployed
-// Collector at the same address on every supported chain.
+// Tracks daily user payments via the Collector contract's own typed events
+// (`Deposited` + `CrossmintPurchase`) emitted by the CREATE2-deployed Collector
+// at the same address on every supported chain.
 //
 // These events are emitted by the Collector — not by the token contract —
 // because Collector uses `transferFrom(user, treasury, amount)` to forward
@@ -14,6 +14,10 @@
 // `_normalize()` function before emission, so every log is priced as canonical
 // USDC @ $1 regardless of source-chain token decimals (handles BSC 18-decimal
 // USDC/USDT and MegaETH 18-decimal USDm uniformly).
+//
+// Economics: user payments for gacha packs are non-refundable and accrue
+// 100% to the NextRare treasury — there is no LP, no external holders, no
+// revenue split. We therefore report Fees == Revenue == ProtocolRevenue.
 
 import { FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
@@ -31,6 +35,10 @@ const DEPOSITED_EVENT =
 const CROSSMINT_EVENT =
   "event CrossmintPurchase(address indexed from, address indexed to, uint16 quantity, uint64 normalizedAmount, address token)";
 
+// Labels (must exactly match keys in breakdownMethodology below).
+const LABEL_CROSS_CHAIN = "Cross-chain Deposit";
+const LABEL_CROSSMINT   = "Crossmint Purchase";
+
 // Collector CREATE2-deployed on all chains on 2026-03-23.
 const config: Record<string, { start: string }> = {
   [CHAIN.BASE]:        { start: "2026-03-23" },
@@ -43,19 +51,51 @@ const config: Record<string, { start: string }> = {
 };
 
 const fetch = async (options: FetchOptions) => {
-  const dailyVolume = options.createBalances();
+  const dailyFees    = options.createBalances();
+  const dailyRevenue = options.createBalances();
 
   const [deposits, crossmints] = await Promise.all([
     options.getLogs({ target: COLLECTOR, eventAbi: DEPOSITED_EVENT }),
     options.getLogs({ target: COLLECTOR, eventAbi: CROSSMINT_EVENT }),
   ]);
 
-  // Both `amount` and `normalizedAmount` are already 6-decimal-normalized
-  // by Collector._normalize() before emission — price as ethereum-USDC @ $1.
-  deposits.forEach((log: any) => dailyVolume.add(USDC_ETHEREUM, log.amount));
-  crossmints.forEach((log: any) => dailyVolume.add(USDC_ETHEREUM, log.normalizedAmount));
+  deposits.forEach((log: any) => {
+    dailyFees.add(USDC_ETHEREUM, log.amount, LABEL_CROSS_CHAIN);
+    dailyRevenue.add(USDC_ETHEREUM, log.amount, LABEL_CROSS_CHAIN);
+  });
+  crossmints.forEach((log: any) => {
+    dailyFees.add(USDC_ETHEREUM, log.normalizedAmount, LABEL_CROSSMINT);
+    dailyRevenue.add(USDC_ETHEREUM, log.normalizedAmount, LABEL_CROSSMINT);
+  });
 
-  return { dailyVolume };
+  return {
+    dailyFees,
+    dailyRevenue,
+    dailyProtocolRevenue: dailyRevenue,
+  };
+};
+
+const methodology = {
+  Fees: "Gross user payments for gacha pack purchases into the NextRare Collector contract on every supported chain.",
+  Revenue: "User payments are non-refundable and accrue 100% to the NextRare treasury — no LP or external holders.",
+  ProtocolRevenue: "Same as Revenue — the NextRare treasury captures all user payments.",
+};
+
+const breakdownMethodology = {
+  Fees: {
+    [LABEL_CROSS_CHAIN]:
+      "USDC/USDT on Base/Arbitrum/BSC/Mantle/HyperEVM/Monad (or USDm on MegaETH) paid via Collector.deposit(), settled cross-chain into a MegaETH GiftCard mint.",
+    [LABEL_CROSSMINT]:
+      "Purchases made directly through Crossmint (credit-card / non-crypto checkout) via Collector.mint().",
+  },
+  Revenue: {
+    [LABEL_CROSS_CHAIN]: "Cross-chain deposits accrue to the NextRare treasury.",
+    [LABEL_CROSSMINT]:   "Crossmint purchases accrue to the NextRare treasury.",
+  },
+  ProtocolRevenue: {
+    [LABEL_CROSS_CHAIN]: "Cross-chain deposits accrue to the NextRare treasury.",
+    [LABEL_CROSSMINT]:   "Crossmint purchases accrue to the NextRare treasury.",
+  },
 };
 
 const adapters: Record<string, { fetch: typeof fetch; start: string }> = {};
@@ -66,6 +106,8 @@ Object.keys(config).forEach((chain) => {
 const adapter: SimpleAdapter = {
   version: 2,
   adapter: adapters,
+  methodology,
+  breakdownMethodology,
 };
 
 export default adapter;

--- a/fees/nextrare/index.ts
+++ b/fees/nextrare/index.ts
@@ -1,17 +1,20 @@
-// NextRare — cross-chain NFT gacha protocol on MegaETH.
+// NextRare — TCG gacha protocol on MegaETH.
 //
-// Net protocol fees:
-//   dailyFees = (gift cards burned on pack opens × $5) − (USDm sellback payouts)
+// Income statement:
+//   dailyFees              = gift cards burned on pack opens × $5     (gross spend)
+//   dailySupplySideRevenue = USDm paid back to users via SellbackVault (refund cost)
+//   dailyRevenue           = dailyFees − dailySupplySideRevenue       (net to treasury)
+//   dailyProtocolRevenue   = dailyRevenue                              (no holders/LP split)
 //
 // A user buys gift cards (each = $5), opens packs by burning them, and may
 // sell unwanted draws back to the SellbackVault for USDm. The protocol earns
-// nothing on a card that is bought and then sold back, so gross deposits
-// overstate true earnings — this adapter measures the *net*.
+// nothing on a card that is bought and then sold back, so net revenue is the
+// difference between gross spend and refunds.
 //
 // All flows live on MegaETH. The Collector contract on Base/Arbitrum/BSC/
 // Mantle/HyperEVM/Monad is a cross-chain on-ramp into a MegaETH gift-card
-// mint; it is intentionally not measured here, since deposits there can be
-// fully refunded via sellback after settlement.
+// mint; deposits there are fully refundable via sellback after settlement,
+// so they are not measured as fees here.
 //
 // Sources of truth:
 //   Burns    — GiftCard ERC-1155 TransferSingle to address(0), id=1.
@@ -52,7 +55,9 @@ const LABEL_PACK_OPEN = "Pack Open";
 const LABEL_SELLBACK  = "Sellback Refund";
 
 const fetch = async (options: FetchOptions) => {
-  const dailyFees = options.createBalances();
+  const dailyFees              = options.createBalances(); // gross
+  const dailySupplySideRevenue = options.createBalances(); // refund cost
+  const dailyRevenue           = options.createBalances(); // net = fees − supply-side
 
   // 1) Pack opens — gift cards burned today, valued at $5 each.
   const burnLogs = await options.getLogs({
@@ -62,8 +67,9 @@ const fetch = async (options: FetchOptions) => {
   for (const log of burnLogs) {
     if (String(log.to).toLowerCase() !== ZERO) continue;
     if (Number(log.id) !== GIFT_CARD_TOKEN_ID) continue;
-    const cards = Number(log.value);
-    dailyFees.addUSDValue(cards * PRICE_PER_CARD_USD, LABEL_PACK_OPEN);
+    const usd = Number(log.value) * PRICE_PER_CARD_USD;
+    dailyFees.addUSDValue(usd, LABEL_PACK_OPEN);
+    dailyRevenue.addUSDValue(usd, LABEL_PACK_OPEN);
   }
 
   // 2) Enumerate every GachaPool ever authorized on either vault.
@@ -86,47 +92,54 @@ const fetch = async (options: FetchOptions) => {
   }
 
   // 3) Sellback refunds — Settled(kept=false, value) from every pool that
-  //    was ever authorized. `value` is USDm wei (18 decimals). USDm trades
-  //    1:1 with USD, so we record it directly as a negative USD amount.
+  //    was ever authorized. `value` is USDm wei (18 decimals); USDm trades
+  //    1:1 with USD. Booked positive on supply-side, negative on revenue.
   for (const pool of everAuthorized) {
     const settled = await options.getLogs({ target: pool, eventAbi: SETTLED });
     for (const log of settled) {
       if (log.kept) continue; // kept=true means NFT mint; `value` is a tokenId, not money.
       const usd = Number(log.value) / 1e18;
-      dailyFees.addUSDValue(-usd, LABEL_SELLBACK);
+      dailySupplySideRevenue.addUSDValue(usd, LABEL_SELLBACK);
+      dailyRevenue.addUSDValue(-usd, LABEL_SELLBACK);
     }
   }
 
   return {
     dailyFees,
-    dailyRevenue:         dailyFees,
-    dailyProtocolRevenue: dailyFees,
+    dailyRevenue,
+    dailySupplySideRevenue,
+    dailyProtocolRevenue: dailyRevenue,
   };
 };
 
 const methodology = {
-  Fees: "Net protocol fees on MegaETH: gift cards burned on pack opens (× $5 each) minus USDm paid back to users via SellbackVault. The protocol earns nothing on a card that is bought and then sold back, so gross deposits would overstate true earnings.",
-  Revenue:         "Same as Fees — 100% accrues to the NextRare treasury (no LP, no holders, no split).",
-  ProtocolRevenue: "Same as Fees — the NextRare treasury captures the net.",
+  Fees:              "Gross protocol fees on MegaETH: gift cards burned on pack opens (× $5 each).",
+  SupplySideRevenue: "USDm paid back to users via SellbackVault when they choose to sell back rather than keep an NFT — i.e. refunds.",
+  Revenue:           "Net protocol revenue = Fees − SupplySideRevenue. The amount the NextRare treasury actually retains after refunds.",
+  ProtocolRevenue:   "Same as Revenue — 100% accrues to the treasury (no LP, no holders, no split).",
 };
 
 const breakdownMethodology = {
   Fees: {
     [LABEL_PACK_OPEN]: "Gift cards burned by GachaPool.draw() (each card = $5). Detected via ERC-1155 TransferSingle to address(0) on the GiftCard contract, id=1.",
-    [LABEL_SELLBACK]:  "USDm paid out by SellbackVault (current and prior) when a user opts not to keep an NFT. Detected via Settled(kept=false, value) on every GachaPool ever authorized on either vault. Recorded as a negative.",
+  },
+  SupplySideRevenue: {
+    [LABEL_SELLBACK]: "USDm paid out by SellbackVault (current and prior) when a user opts not to keep an NFT. Detected via Settled(kept=false, value) on every GachaPool ever authorized on either vault.",
   },
   Revenue: {
     [LABEL_PACK_OPEN]: "Pack-open spending accrues to the NextRare treasury.",
-    [LABEL_SELLBACK]:  "Sellback payouts are funded from the treasury via SellbackVault — recorded as a negative.",
+    [LABEL_SELLBACK]:  "Sellback refunds reduce net revenue.",
   },
   ProtocolRevenue: {
     [LABEL_PACK_OPEN]: "Pack-open spending accrues to the NextRare treasury.",
-    [LABEL_SELLBACK]:  "Sellback payouts are funded from the treasury via SellbackVault — recorded as a negative.",
+    [LABEL_SELLBACK]:  "Sellback refunds reduce protocol revenue.",
   },
 };
 
 const adapter: SimpleAdapter = {
   version: 2,
+  pullHourly: true,
+  allowNegativeValue: true,
   adapter: {
     [CHAIN.MEGAETH]: { fetch, start: "2026-03-23" },
   },

--- a/fees/nextrare/index.ts
+++ b/fees/nextrare/index.ts
@@ -1,0 +1,71 @@
+// NextRare — cross-chain NFT gacha protocol.
+//
+// Tracks daily user payment volume via the Collector contract's own typed
+// events (`Deposited` + `CrossmintPurchase`) emitted by the CREATE2-deployed
+// Collector at the same address on every supported chain.
+//
+// These events are emitted by the Collector — not by the token contract —
+// because Collector uses `transferFrom(user, treasury, amount)` to forward
+// funds directly to the Safe treasury. The ERC-20 Transfer event therefore
+// has `from=user, to=treasury` with no Collector address in topics, so we
+// must hook the typed events.
+//
+// Both events carry amount fields normalized to 6 decimals by the contract's
+// `_normalize()` function before emission, so every log is priced as canonical
+// USDC @ $1 regardless of source-chain token decimals (handles BSC 18-decimal
+// USDC/USDT and MegaETH 18-decimal USDm uniformly).
+
+import { FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+
+// Same CREATE2 address on every EVM chain.
+const COLLECTOR = "0x0000000032B93DAf5c6Ff220cB2D03624CB56302";
+
+// Canonical USDC on Ethereum — $1-stable pricing proxy. Collector emits
+// amounts already normalized to 6 decimals, matching USDC's decimals.
+const USDC_ETHEREUM = "0xA0b86991c6218b36c1d19d4a2e9Eb0cE3606eB48";
+
+const DEPOSITED_EVENT =
+  "event Deposited(address indexed from, address indexed to, uint64 indexed intentId, uint64 amount, address token)";
+
+const CROSSMINT_EVENT =
+  "event CrossmintPurchase(address indexed from, address indexed to, uint16 quantity, uint64 normalizedAmount, address token)";
+
+// Collector CREATE2-deployed on all chains on 2026-03-23.
+const config: Record<string, { start: string }> = {
+  [CHAIN.BASE]:        { start: "2026-03-23" },
+  [CHAIN.ARBITRUM]:    { start: "2026-03-23" },
+  [CHAIN.BSC]:         { start: "2026-03-23" },
+  [CHAIN.MANTLE]:      { start: "2026-03-23" },
+  [CHAIN.HYPERLIQUID]: { start: "2026-03-23" },
+  [CHAIN.MONAD]:       { start: "2026-03-23" },
+  [CHAIN.MEGAETH]:     { start: "2026-03-23" },
+};
+
+const fetch = async (options: FetchOptions) => {
+  const dailyVolume = options.createBalances();
+
+  const [deposits, crossmints] = await Promise.all([
+    options.getLogs({ target: COLLECTOR, eventAbi: DEPOSITED_EVENT }),
+    options.getLogs({ target: COLLECTOR, eventAbi: CROSSMINT_EVENT }),
+  ]);
+
+  // Both `amount` and `normalizedAmount` are already 6-decimal-normalized
+  // by Collector._normalize() before emission — price as ethereum-USDC @ $1.
+  deposits.forEach((log: any) => dailyVolume.add(USDC_ETHEREUM, log.amount));
+  crossmints.forEach((log: any) => dailyVolume.add(USDC_ETHEREUM, log.normalizedAmount));
+
+  return { dailyVolume };
+};
+
+const adapters: Record<string, { fetch: typeof fetch; start: string }> = {};
+Object.keys(config).forEach((chain) => {
+  adapters[chain] = { fetch, start: config[chain].start };
+});
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  adapter: adapters,
+};
+
+export default adapter;

--- a/fees/nextrare/index.ts
+++ b/fees/nextrare/index.ts
@@ -25,10 +25,6 @@ import { CHAIN } from "../../helpers/chains";
 // Same CREATE2 address on every EVM chain.
 const COLLECTOR = "0x0000000032B93DAf5c6Ff220cB2D03624CB56302";
 
-// Canonical USDC on Ethereum — $1-stable pricing proxy. Collector emits
-// amounts already normalized to 6 decimals, matching USDC's decimals.
-const USDC_ETHEREUM = "0xA0b86991c6218b36c1d19d4a2e9Eb0cE3606eB48";
-
 const DEPOSITED_EVENT =
   "event Deposited(address indexed from, address indexed to, uint64 indexed intentId, uint64 amount, address token)";
 
@@ -59,13 +55,18 @@ const fetch = async (options: FetchOptions) => {
     options.getLogs({ target: COLLECTOR, eventAbi: CROSSMINT_EVENT }),
   ]);
 
+  // Convert 6-decimal BigInt amounts directly to USD — treats every payment
+  // as $1 stable regardless of source token (sidesteps per-chain price
+  // lookups for USDm/bridged USDC/USDT variants).
   deposits.forEach((log: any) => {
-    dailyFees.add(USDC_ETHEREUM, log.amount, LABEL_CROSS_CHAIN);
-    dailyRevenue.add(USDC_ETHEREUM, log.amount, LABEL_CROSS_CHAIN);
+    const usd = Number(log.amount) / 1e6;
+    dailyFees.addUSDValue(usd, LABEL_CROSS_CHAIN);
+    dailyRevenue.addUSDValue(usd, LABEL_CROSS_CHAIN);
   });
   crossmints.forEach((log: any) => {
-    dailyFees.add(USDC_ETHEREUM, log.normalizedAmount, LABEL_CROSSMINT);
-    dailyRevenue.add(USDC_ETHEREUM, log.normalizedAmount, LABEL_CROSSMINT);
+    const usd = Number(log.normalizedAmount) / 1e6;
+    dailyFees.addUSDValue(usd, LABEL_CROSSMINT);
+    dailyRevenue.addUSDValue(usd, LABEL_CROSSMINT);
   });
 
   return {


### PR DESCRIPTION
## Summary
Website https://nextrare.cards/
- Adds [fees/nextrare/index.ts](fees/nextrare/index.ts) tracking daily user-payment volume for NextRare, a cross-chain NFT gacha protocol.
- Hooks the Collector contract's typed events (`Deposited` + `CrossmintPurchase`) at CREATE2 address `0x0000000032B93DAf5c6Ff220cB2D03624CB56302` on every supported chain.
- Amounts are 6-decimal-normalized by the contract before emission, so every log is priced as canonical USDC @ `$1` — handles BSC 18-decimal tokens and MegaETH 18-decimal USDm uniformly.

## Context
Users pay USDC/USDT on Base, Arbitrum, BSC, Mantle, HyperEVM, Monad (or USDm on MegaETH) to open randomized card packs. Kept cards mint as ERC-721 NFTs on MegaETH.

Collector deployed 2026-03-23 (start dates set accordingly). Volume is captured via the contract's typed events rather than raw ERC-20 `Transfer` events because Collector forwards `transferFrom(user, treasury, amount)` — the Transfer event has `from=user, to=treasury` with no Collector address in topics.

No TVL adapter will be submitted: Collector is a pass-through and Safe balances are operational float, not user-locked value. Listing metadata will land separately in defillama-server (`module: "dummy.js"`, same pattern as Collector Crypt id 6675).

## Test plan
- [x] `npx tsc --noEmit fees/nextrare/index.ts` — passes
- [x] `npm test -- fees nextrare` — runs without errors (zero volume in last-24h test window; full backfill expected on first index)
- [ ] Reviewer smoke test against live chain data