### PR TITLE
Add HitOne total notional volume + fees adapter

### DIFF
--- a/dexs/hitone/index.ts
+++ b/dexs/hitone/index.ts
@@ -1,0 +1,51 @@
+/**
+ * Hit One dimension adapter for DefiLlama.
+ *
+ * Reports:
+ *   - dailyVolume: total notional of perpetual trade events (open, close, add, reduce)
+ *   - dailyFees:   total fees paid by users (open fee + close fee, gross)
+ *
+ * Per-trade data is not emitted on-chain — Hit One aggregates positions at the
+ * WCM venue layer. The adapter hits our public stats endpoint for each hour
+ * DefiLlama polls.
+ *
+ * Source of truth: https://github.com/hit-one/hitone-server/tree/main/docs/defillama-adapter
+ */
+import fetchURL from "../../utils/fetchURL"
+import { FetchOptions, SimpleAdapter } from "../../adapters/types"
+import { CHAIN } from "../../helpers/chains"
+
+const STATS_URL = "https://api.hit.one/api/public/stats/defillama"
+
+interface HitOneStats {
+  start: number
+  end: number
+  volumeUsd: string
+  feesUsd: string
+}
+
+const fetch = async ({ startTimestamp, endTimestamp }: FetchOptions) => {
+  const url = `${STATS_URL}?start=${startTimestamp}&end=${endTimestamp}`
+  const data: HitOneStats = await fetchURL(url)
+
+  return {
+    dailyVolume: Number(data.volumeUsd),
+    dailyFees: Number(data.feesUsd),
+  }
+}
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  pullHourly: true,
+  fetch,
+  chains: [CHAIN.MEGAETH],
+  start: 1776096000, // 2026-04-13 12:00 ET (16:00 UTC) — Hit One public launch
+  methodology: {
+    Volume:
+      "Sum of notional (size × price) across every trade event (open, close, add, reduce) executed on Hit One in the period. Round-trip counts as 2× notional, consistent with GMX/Hyperliquid convention.",
+    Fees:
+      "Gross fees paid by users: 1% of collateral on position open + 5% of realized profit on profitable closes.",
+  },
+}
+
+export default adapter

--- a/dexs/hitone/index.ts
+++ b/dexs/hitone/index.ts
@@ -1,15 +1,14 @@
 /**
- * Hit One dimension adapter for DefiLlama.
+ * Hit One perpetual futures volume adapter.
  *
  * Reports:
  *   - dailyVolume: total notional of perpetual trade events (open, close, add, reduce)
- *   - dailyFees:   total fees paid by users (open fee + close fee, gross)
  *
  * Per-trade data is not emitted on-chain — Hit One aggregates positions at the
  * WCM venue layer. The adapter hits our public stats endpoint for each hour
  * DefiLlama polls.
  *
- * Source of truth: https://github.com/hit-one/hitone-server/tree/main/docs/defillama-adapter
+ * Fees are reported via the sibling adapter at fees/hitone/index.ts.
  */
 import fetchURL from "../../utils/fetchURL"
 import { FetchOptions, SimpleAdapter } from "../../adapters/types"
@@ -28,9 +27,12 @@ const fetch = async ({ startTimestamp, endTimestamp }: FetchOptions) => {
   const url = `${STATS_URL}?start=${startTimestamp}&end=${endTimestamp}`
   const data: HitOneStats = await fetchURL(url)
 
+  if (data?.volumeUsd == null) {
+    throw new Error(`Hit One stats response missing volumeUsd: ${JSON.stringify(data)}`)
+  }
+
   return {
     dailyVolume: Number(data.volumeUsd),
-    dailyFees: Number(data.feesUsd),
   }
 }
 
@@ -43,8 +45,6 @@ const adapter: SimpleAdapter = {
   methodology: {
     Volume:
       "Sum of notional (size × price) across every trade event (open, close, add, reduce) executed on Hit One in the period. Round-trip counts as 2× notional, consistent with GMX/Hyperliquid convention.",
-    Fees:
-      "Gross fees paid by users: 1% of collateral on position open + 5% of realized profit on profitable closes.",
   },
 }
 

--- a/fees/hitone/index.ts
+++ b/fees/hitone/index.ts
@@ -1,15 +1,17 @@
 /**
- * Hit One dimension adapter for DefiLlama.
+ * Hit One perpetual futures fees adapter.
  *
  * Reports:
- *   - dailyVolume: total notional of perpetual trade events (open, close, add, reduce)
- *   - dailyFees:   total fees paid by users (open fee + close fee, gross)
+ *   - dailyFees:   gross fees paid by users (1% on open + 5% of realized profit on close)
+ *   - dailyRevenue: equal to dailyFees — Hit One has no supply-side party (no LPs,
+ *                   stakers, integrators, or external referral beneficiaries that siphon
+ *                   before the protocol), so 100% of gross fees accrue to the protocol.
  *
  * Per-trade data is not emitted on-chain — Hit One aggregates positions at the
  * WCM venue layer. The adapter hits our public stats endpoint for each hour
  * DefiLlama polls.
  *
- * Source of truth: https://github.com/hit-one/hitone-server/tree/main/docs/defillama-adapter
+ * Volume is reported via the sibling adapter at dexs/hitone/index.ts.
  */
 import fetchURL from "../../utils/fetchURL"
 import { FetchOptions, SimpleAdapter } from "../../adapters/types"
@@ -24,13 +26,22 @@ interface HitOneStats {
   feesUsd: string
 }
 
-const fetch = async ({ startTimestamp, endTimestamp }: FetchOptions) => {
+const fetch = async ({ startTimestamp, endTimestamp, createBalances }: FetchOptions) => {
   const url = `${STATS_URL}?start=${startTimestamp}&end=${endTimestamp}`
   const data: HitOneStats = await fetchURL(url)
 
+  if (data?.feesUsd == null) {
+    throw new Error(`Hit One stats response missing feesUsd: ${JSON.stringify(data)}`)
+  }
+
+  const feesUsd = Number(data.feesUsd)
+  const dailyFees = createBalances()
+  dailyFees.addUSDValue(feesUsd, 'Perp Trading Fees')
+
+  // Revenue equals Fees: no supply-side party takes a cut before the protocol.
   return {
-    dailyVolume: Number(data.volumeUsd),
-    dailyFees: Number(data.feesUsd),
+    dailyFees,
+    dailyRevenue: dailyFees,
   }
 }
 
@@ -41,10 +52,19 @@ const adapter: SimpleAdapter = {
   chains: [CHAIN.MEGAETH],
   start: 1776096000, // 2026-04-13 12:00 ET (16:00 UTC) — Hit One public launch
   methodology: {
-    Volume:
-      "Sum of notional (size × price) across every trade event (open, close, add, reduce) executed on Hit One in the period. Round-trip counts as 2× notional, consistent with GMX/Hyperliquid convention.",
     Fees:
       "Gross fees paid by users: 1% of collateral on position open + 5% of realized profit on profitable closes.",
+    Revenue:
+      "All user-paid fees accrue to the Hit One protocol — there is no supply-side party (LPs, stakers, integrators, external referral beneficiaries) that takes a share before the protocol. Revenue equals Fees.",
+  },
+  breakdownMethodology: {
+    Fees: {
+      'Perp Trading Fees':
+        '1% of collateral on position open + 5% of realized profit on profitable close.',
+    },
+    Revenue: {
+      'Perp Trading Fees': '100% of user-paid trading fees retained by the protocol.',
+    },
   },
 }
 

--- a/fees/hitone/index.ts
+++ b/fees/hitone/index.ts
@@ -1,0 +1,51 @@
+/**
+ * Hit One dimension adapter for DefiLlama.
+ *
+ * Reports:
+ *   - dailyVolume: total notional of perpetual trade events (open, close, add, reduce)
+ *   - dailyFees:   total fees paid by users (open fee + close fee, gross)
+ *
+ * Per-trade data is not emitted on-chain — Hit One aggregates positions at the
+ * WCM venue layer. The adapter hits our public stats endpoint for each hour
+ * DefiLlama polls.
+ *
+ * Source of truth: https://github.com/hit-one/hitone-server/tree/main/docs/defillama-adapter
+ */
+import fetchURL from "../../utils/fetchURL"
+import { FetchOptions, SimpleAdapter } from "../../adapters/types"
+import { CHAIN } from "../../helpers/chains"
+
+const STATS_URL = "https://api.hit.one/api/public/stats/defillama"
+
+interface HitOneStats {
+  start: number
+  end: number
+  volumeUsd: string
+  feesUsd: string
+}
+
+const fetch = async ({ startTimestamp, endTimestamp }: FetchOptions) => {
+  const url = `${STATS_URL}?start=${startTimestamp}&end=${endTimestamp}`
+  const data: HitOneStats = await fetchURL(url)
+
+  return {
+    dailyVolume: Number(data.volumeUsd),
+    dailyFees: Number(data.feesUsd),
+  }
+}
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  pullHourly: true,
+  fetch,
+  chains: [CHAIN.MEGAETH],
+  start: 1776096000, // 2026-04-13 12:00 ET (16:00 UTC) — Hit One public launch
+  methodology: {
+    Volume:
+      "Sum of notional (size × price) across every trade event (open, close, add, reduce) executed on Hit One in the period. Round-trip counts as 2× notional, consistent with GMX/Hyperliquid convention.",
+    Fees:
+      "Gross fees paid by users: 1% of collateral on position open + 5% of realized profit on profitable closes.",
+  },
+}
+
+export default adapter


### PR DESCRIPTION
Hit One is a perpetual futures trading platform on MegaETH. Trades are aggregated off-chain at the venue layer (similar to Hyperliquid's model), so per-trade data is served from a public stats endpoint rather than indexed from on-chain events.

Adapter details:
- Endpoint: https://api.hit.one/api/public/stats/defillama
- v2 SimpleAdapter, pullHourly: true
- Chain: MEGAETH
- Start: 2026-04-13 12:00 ET (1776096000, public launch)

Methodology:
- Volume: sum of notional (size × price) across all trade events (open, close, add, reduce). Round-trip = 2× notional, per the GMX/Hyperliquid convention.
- Fees: gross fees paid by users — 1% of collateral on open + 5% of realized profit on profitable close.

Verified locally via:
  npm test dexs hitone 2026-04-19 npm test fees hitone 2026-04-19

**NOTE**

#### Please enable "Allow edits by maintainers" while putting up the PR.

---

> - If you would like to add a `tvl` adapter please submit the PR [here](https://github.com/DefiLlama/DefiLlama-Adapters).

1. Once your adapter has been merged, it takes time to show on the UI. If more than 24 hours have passed, please let us know in Discord.
2. Please fill the form below **only if the PR is for listing a new protocol** else it can be ignored/replaced with reason/details about the PR
3. **For updating listing info** It is a different repo, you can find your listing in this file: https://github.com/DefiLlama/defillama-server/blob/master/defi/src/protocols/data4.ts, you can edit it there and put up a PR
4. Do not edit/push `package.json/package-lock.json` file as part of your changes
5. No need to go to our discord/other channel and announce that you've created a PR, we monitor all PRs and will review it asap

---

##### Name (to be shown on DefiLlama):
Hit One
##### Twitter Link:
https://x.com/hitdotone
##### List of audit links if any:

##### Website Link:
https://app.hit.one/

##### Logo (High resolution, will be shown with rounded borders):
<img width="1024" height="1024" alt="HitOne-Wordmark-White-alpharemoved (1)" src="https://github.com/user-attachments/assets/3ec0e39e-2eed-4861-8781-a6f9d5e941a3" />

##### Chain:
MegaEth

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed): (https://api.coingecko.com/api/v3/coins/list)

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)

##### Short Description (to be shown on DefiLlama):
Hit One is a suite of market-based risk games built on top of DeFi primitives such as perpetual futures, options, and prediction markets.

##### Token address and ticker if any:
No Token

##### Category (full list at https://defillama.com/categories) \*Please choose only one:
Interface

##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.):
Redstone

##### Implementation Details: Briefly describe how the oracle is integrated into your project:
Real-Time Price feed, powers our charts.

##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage:
N/A

##### forkedFrom (Does your project originate from another project):
N/A

##### methodology (what is being counted as tvl, how is tvl being calculated):
No TVL

##### Github org/user (Optional, if your code is open source, we can track activity):
@zakhap

##### Does this project have a referral program?
Yes.