### PR TITLE
Add RamsesX Polygon and Arbitrum dex adapters

### DIFF
--- a/dexs/ramses-hl-cl.ts
+++ b/dexs/ramses-hl-cl.ts
@@ -1,6 +1,7 @@
 import { FetchOptions, SimpleAdapter } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
 import request, { gql } from "graphql-request";
+import { METRIC } from "../helpers/metrics";
 
 const RAM_TOKEN_CONTRACT = "0x555570a286F15EbDFE42B66eDE2f724Aa1AB5555";
 const XRAM_TOKEN_CONTRACT = "	0xAE6D5FcE541216BDA471D311425B5412D9f1DEb9";
@@ -98,7 +99,7 @@ async function getBribes(options: FetchOptions) {
 
 async function getTokens(options: FetchOptions, tokens: string[]) {
   const tokenIds = tokens.map((e) => `"${e}"`).join(",");
-  
+
   // Use tokenDayDatas for historical prices instead of block-based queries
   const query = gql`
     query tokenDayDatas($first: Int!, $skip: Int!, $startOfDay: Int!) {
@@ -124,7 +125,7 @@ async function getTokens(options: FetchOptions, tokens: string[]) {
       first,
       skip,
       startOfDay: options.startOfDay,
-    }).then((data) => 
+    }).then((data) =>
       // Transform tokenDayDatas to match expected token format
       data.tokenDayDatas.map((td: any) => ({
         id: td.token.id,
@@ -210,16 +211,25 @@ export async function fetchProtocolDayStats(
 
 const fetch = async (_: any, _1: any, options: FetchOptions) => {
   const stats = await fetchStats(options);
-  const dailyFees = stats.clFeesUSD;
-  const dailyVolume = stats.clVolumeUSD;
-  const dailyHoldersRevenue = stats.clUserFeesRevenueUSD;
-  const dailyProtocolRevenue = stats.clProtocolRevenueUSD;
-  const dailyBribesRevenue = stats.clBribeRevenueUSD;
 
-  const clSupplySideRevenue =
-    stats.clFeesUSD - dailyHoldersRevenue - dailyProtocolRevenue;
-  const dailySupplySideRevenue = clSupplySideRevenue;
-  const dailyRevenue = dailyProtocolRevenue + dailyHoldersRevenue;
+  const dailyVolume = stats.clVolumeUSD;
+
+  const dailyFees = options.createBalances();
+  const dailyHoldersRevenue = options.createBalances();
+  const dailyProtocolRevenue = options.createBalances();
+  const dailySupplySideRevenue = options.createBalances();
+
+  dailyFees.addUSDValue(stats.clFeesUSD, METRIC.SWAP_FEES);
+  dailyHoldersRevenue.addUSDValue(stats.clUserFeesRevenueUSD, 'Swap Fees to holders');
+  dailyProtocolRevenue.addUSDValue(stats.clProtocolRevenueUSD, 'Swap Fees to protocol');
+
+  dailyFees.addUSDValue(stats.clBribeRevenueUSD, 'Bribes');
+  dailyHoldersRevenue.addUSDValue(stats.clBribeRevenueUSD, 'Bribes to holders');
+
+  const dailyRevenue = dailyProtocolRevenue.clone();
+  dailyRevenue.add(dailyHoldersRevenue);
+
+  dailySupplySideRevenue.addUSDValue(stats.clFeesUSD - stats.clUserFeesRevenueUSD - stats.clProtocolRevenueUSD, 'Swap Fees to LPs');
 
   return {
     dailyVolume,
@@ -229,19 +239,38 @@ const fetch = async (_: any, _1: any, options: FetchOptions) => {
     dailyProtocolRevenue,
     dailyRevenue,
     dailySupplySideRevenue,
-    dailyBribesRevenue,
   };
 };
 
-const methodology = {
+export const methodology = {
   Fees: "Fees are collected from users on each swap.",
   Revenue: "Revenue going to the protocol + Token holder Revenue.",
   UserFees: "User pays fees on each swap.",
   ProtocolRevenue: "Revenue going to the protocol.",
   HoldersRevenue: "User fees are distributed among holders.",
-  BribesRevenue: "Bribes are distributed among holders.",
   SupplySideRevenue: "Fees distributed to LPs (from gauged pools).",
-  TokenTax: "xRAM stakers instant exit penalty",
+};
+
+export const breakdownMethodology = {
+  Fees: {
+    [METRIC.SWAP_FEES]: "Fees are collected from users on each swap.",
+    ["Bribes"]: "Bribes paid by protocols",
+  },
+  Revenue: {
+    ["Swap Fees to protocol"]: "Revenue going to the protocol.",
+    ["Swap Fees to holders"]: "User fees are distributed among holders.",
+    ["Bribes to holders"]: "Bribes paid by protocols",
+  },
+  ProtocolRevenue: {
+    ["Swap Fees to protocol"]: "Revenue going to the protocol.",
+  },
+  SupplySideRevenue: {
+    ["Swap Fees to LPs"]: "Fees distributed to LPs (from gauged pools).",
+  },
+  HoldersRevenue: {
+    ["Swap Fees to holders"]: "User fees are distributed among holders.",
+    ["Bribes to holders"]: "Bribes paid by protocols",
+  },
 };
 
 const adapter: SimpleAdapter = {
@@ -249,6 +278,7 @@ const adapter: SimpleAdapter = {
   chains: [CHAIN.HYPERLIQUID],
   start: '2025-11-08',
   methodology,
+  breakdownMethodology,
 };
 
 export default adapter;

--- a/dexs/ramses-hl-cl.ts
+++ b/dexs/ramses-hl-cl.ts
@@ -209,38 +209,75 @@ export async function fetchProtocolDayStats(
   };
 }
 
-const fetch = async (_: any, _1: any, options: FetchOptions) => {
-  const stats = await fetchStats(options);
+type PoolType = 'cl' | 'legacy';
 
-  const dailyVolume = stats.clVolumeUSD;
+interface PoolStats {
+  volumeUSD: number;
+  feesUSD: number;
+  userFeesRevenueUSD: number;
+  protocolRevenueUSD: number;
+  bribeRevenueUSD: number;
+}
 
-  const dailyFees = options.createBalances();
-  const dailyHoldersRevenue = options.createBalances();
-  const dailyProtocolRevenue = options.createBalances();
-  const dailySupplySideRevenue = options.createBalances();
-
-  dailyFees.addUSDValue(stats.clFeesUSD, METRIC.SWAP_FEES);
-  dailyHoldersRevenue.addUSDValue(stats.clUserFeesRevenueUSD, 'Swap Fees to holders');
-  dailyProtocolRevenue.addUSDValue(stats.clProtocolRevenueUSD, 'Swap Fees to protocol');
-
-  dailyFees.addUSDValue(stats.clBribeRevenueUSD, 'Bribes');
-  dailyHoldersRevenue.addUSDValue(stats.clBribeRevenueUSD, 'Bribes to holders');
-
-  const dailyRevenue = dailyProtocolRevenue.clone();
-  dailyRevenue.add(dailyHoldersRevenue);
-
-  dailySupplySideRevenue.addUSDValue(stats.clFeesUSD - stats.clUserFeesRevenueUSD - stats.clProtocolRevenueUSD, 'Swap Fees to LPs');
-
+function getPoolStats(stats: IGraphRes, poolType: PoolType): PoolStats {
+  if (poolType === 'legacy') {
+    return {
+      volumeUSD: stats.legacyVolumeUSD,
+      feesUSD: stats.legacyFeesUSD,
+      userFeesRevenueUSD: stats.legacyUserFeesRevenueUSD,
+      protocolRevenueUSD: stats.legacyProtocolRevenueUSD,
+      bribeRevenueUSD: stats.legacyBribeRevenueUSD,
+    };
+  }
   return {
-    dailyVolume,
-    dailyFees,
-    dailyUserFees: dailyFees,
-    dailyHoldersRevenue,
-    dailyProtocolRevenue,
-    dailyRevenue,
-    dailySupplySideRevenue,
+    volumeUSD: stats.clVolumeUSD,
+    feesUSD: stats.clFeesUSD,
+    userFeesRevenueUSD: stats.clUserFeesRevenueUSD,
+    protocolRevenueUSD: stats.clProtocolRevenueUSD,
+    bribeRevenueUSD: stats.clBribeRevenueUSD,
   };
-};
+}
+
+function createFetchHandler(poolType: PoolType) {
+  return async (_: any, _1: any, options: FetchOptions) => {
+    const stats = await fetchStats(options);
+    const poolStats = getPoolStats(stats, poolType);
+
+    const dailyVolume = poolStats.volumeUSD;
+
+    const dailyFees = options.createBalances();
+    const dailyHoldersRevenue = options.createBalances();
+    const dailyProtocolRevenue = options.createBalances();
+    const dailySupplySideRevenue = options.createBalances();
+
+    dailyFees.addUSDValue(poolStats.feesUSD, METRIC.SWAP_FEES);
+    dailyHoldersRevenue.addUSDValue(poolStats.userFeesRevenueUSD, 'Swap Fees to holders');
+    dailyProtocolRevenue.addUSDValue(poolStats.protocolRevenueUSD, 'Swap Fees to protocol');
+
+    dailyFees.addUSDValue(poolStats.bribeRevenueUSD, 'Bribes');
+    dailyHoldersRevenue.addUSDValue(poolStats.bribeRevenueUSD, 'Bribes to holders');
+
+    const dailyRevenue = dailyProtocolRevenue.clone();
+    dailyRevenue.add(dailyHoldersRevenue);
+
+    dailySupplySideRevenue.addUSDValue(
+      poolStats.feesUSD - poolStats.userFeesRevenueUSD - poolStats.protocolRevenueUSD,
+      'Swap Fees to LPs'
+    );
+
+    return {
+      dailyVolume,
+      dailyFees,
+      dailyUserFees: dailyFees,
+      dailyHoldersRevenue,
+      dailyProtocolRevenue,
+      dailyRevenue,
+      dailySupplySideRevenue,
+    };
+  };
+}
+
+const fetch = createFetchHandler('cl');
 
 export const methodology = {
   Fees: "Fees are collected from users on each swap.",
@@ -273,12 +310,28 @@ export const breakdownMethodology = {
   },
 };
 
-const adapter: SimpleAdapter = {
-  fetch,
-  chains: [CHAIN.HYPERLIQUID],
-  start: '2025-11-08',
-  methodology,
-  breakdownMethodology,
-};
+export function createClAdapter(chain: string, start: string): SimpleAdapter {
+  return {
+    fetch,
+    chains: [chain],
+    start,
+    methodology,
+    breakdownMethodology,
+  };
+}
+
+const legacyFetch = createFetchHandler('legacy');
+
+export function createLegacyAdapter(chain: string, start: string): SimpleAdapter {
+  return {
+    fetch: legacyFetch,
+    chains: [chain],
+    start,
+    methodology,
+    breakdownMethodology,
+  };
+}
+
+const adapter: SimpleAdapter = createClAdapter(CHAIN.HYPERLIQUID, '2025-11-08');
 
 export default adapter;

--- a/dexs/ramses-hl-cl.ts
+++ b/dexs/ramses-hl-cl.ts
@@ -280,12 +280,12 @@ function createFetchHandler(poolType: PoolType) {
 const fetch = createFetchHandler('cl');
 
 export const methodology = {
-  Fees: "Fees are collected from users on each swap.",
+  Fees: "Includes swap fees and bribes paid by protocols",
   Revenue: "Revenue going to the protocol + Token holder Revenue.",
   UserFees: "User pays fees on each swap.",
-  ProtocolRevenue: "Revenue going to the protocol.",
-  HoldersRevenue: "User fees are distributed among holders.",
-  SupplySideRevenue: "Fees distributed to LPs (from gauged pools).",
+  ProtocolRevenue: "Swap fees going to the protocol",
+  HoldersRevenue: "Swap fees distributed to holders and all the bribes go to holders",
+  SupplySideRevenue: "Swap fees distributed to LPs (from gauged pools).",
 };
 
 export const breakdownMethodology = {
@@ -296,7 +296,7 @@ export const breakdownMethodology = {
   Revenue: {
     ["Swap Fees to protocol"]: "Revenue going to the protocol.",
     ["Swap Fees to holders"]: "User fees are distributed among holders.",
-    ["Bribes to holders"]: "Bribes paid by protocols",
+    ["Bribes to holders"]: "Bribes paid by protocols to holders",
   },
   ProtocolRevenue: {
     ["Swap Fees to protocol"]: "Revenue going to the protocol.",
@@ -306,7 +306,7 @@ export const breakdownMethodology = {
   },
   HoldersRevenue: {
     ["Swap Fees to holders"]: "User fees are distributed among holders.",
-    ["Bribes to holders"]: "Bribes paid by protocols",
+    ["Bribes to holders"]: "Bribes paid by protocols to holders",
   },
 };
 

--- a/dexs/ramses-hl-cl.ts
+++ b/dexs/ramses-hl-cl.ts
@@ -6,6 +6,7 @@ const RAM_TOKEN_CONTRACT = "0x555570a286F15EbDFE42B66eDE2f724Aa1AB5555";
 const XRAM_TOKEN_CONTRACT = "	0xAE6D5FcE541216BDA471D311425B5412D9f1DEb9";
 
 export const subgraphEndpoints: any = {
+  [CHAIN.ARBITRUM]: "https://arbitrumv2.kingdomsubgraph.com/subgraphs/name/ramses-pruned",
   [CHAIN.HYPERLIQUID]: "https://hyperevm.kingdomsubgraph.com/subgraphs/name/ramses-v3-pruned/",
   [CHAIN.POLYGON]: "https://polygon.kingdomsubgraph.com/subgraphs/name/ramses-pruned",
 };

--- a/dexs/ramses-hl-cl.ts
+++ b/dexs/ramses-hl-cl.ts
@@ -26,6 +26,8 @@ interface IGraphRes {
   legacyUserFeesRevenueUSD: number;
 }
 
+type IProtocolDayStats = Omit<IGraphRes, "clBribeRevenueUSD" | "legacyBribeRevenueUSD">;
+
 interface IVoteBribe {
   id: string;
   token: { id: string };
@@ -134,36 +136,13 @@ async function getTokens(options: FetchOptions, tokens: string[]) {
 }
 
 export async function fetchStats(options: FetchOptions): Promise<IGraphRes> {
-  const statsQuery = gql`
-    query getProtocolDayData($startOfDay: Int!) {
-      ClProtocolDayData: clProtocolDayDatas(where: { startOfDay: $startOfDay }) {
-        startOfDay
-        volumeUsd: volumeUSD
-        feesUsd: feesUSD
-        voterFeesUsd: voterFeesUSD
-        treasuryFeesUsd: treasuryFeesUSD
-      }
-      LegacyProtocolDayData: legacyProtocolDayDatas(where: { startOfDay: $startOfDay }) {
-        startOfDay
-        volumeUsd: volumeUSD
-        feesUsd: feesUSD
-        voterFeesUsd: voterFeesUSD
-        treasuryFeesUsd: treasuryFeesUSD
-      }
-    }
-  `;
+  const protocolDayStats = await fetchProtocolDayStats(options);
 
   const voteBribes = await getBribes(options);
   const tokenIds = new Set(voteBribes.map((e) => e.token.id));
   tokenIds.add(RAM_TOKEN_CONTRACT.toLowerCase());
 
   const tokens = await getTokens(options, Array.from(tokenIds));
-  const {
-    ClProtocolDayData: clProtocolDayData,
-    LegacyProtocolDayData: legacyProtocolDayData,
-  } = await request(subgraphEndpoints[options.chain], statsQuery, {
-    startOfDay: options.startOfDay,
-  });
 
   const legacyVoteBribes = voteBribes.filter((e) => e.legacyPool);
   const clVoteBribes = voteBribes.filter((e) => e.clPool);
@@ -178,12 +157,46 @@ export async function fetchStats(options: FetchOptions): Promise<IGraphRes> {
   }, 0);
 
   return {
+    ...protocolDayStats,
+    clBribeRevenueUSD: clUserBribeRevenueUSD,
+    legacyBribeRevenueUSD: legacyUserBribeRevenueUSD,
+  };
+};
+
+const statsQuery = gql`
+  query getProtocolDayData($startOfDay: Int!) {
+    ClProtocolDayData: clProtocolDayDatas(where: { startOfDay: $startOfDay }) {
+      startOfDay
+      volumeUsd: volumeUSD
+      feesUsd: feesUSD
+      voterFeesUsd: voterFeesUSD
+      treasuryFeesUsd: treasuryFeesUSD
+    }
+    LegacyProtocolDayData: legacyProtocolDayDatas(where: { startOfDay: $startOfDay }) {
+      startOfDay
+      volumeUsd: volumeUSD
+      feesUsd: feesUSD
+      voterFeesUsd: voterFeesUSD
+      treasuryFeesUsd: treasuryFeesUSD
+    }
+  }
+`;
+
+export async function fetchProtocolDayStats(
+  options: FetchOptions,
+): Promise<IProtocolDayStats> {
+  const {
+    ClProtocolDayData: clProtocolDayData,
+    LegacyProtocolDayData: legacyProtocolDayData,
+  } = await request(subgraphEndpoints[options.chain], statsQuery, {
+    startOfDay: options.startOfDay,
+  });
+
+  return {
     clVolumeUSD: Number(clProtocolDayData?.[0]?.volumeUsd ?? 0),
     clFeesUSD: Number(clProtocolDayData?.[0]?.feesUsd ?? 0),
     legacyVolumeUSD: Number(legacyProtocolDayData?.[0]?.volumeUsd ?? 0),
     legacyFeesUSD: Number(legacyProtocolDayData?.[0]?.feesUsd ?? 0),
-    clBribeRevenueUSD: clUserBribeRevenueUSD,
-    legacyBribeRevenueUSD: legacyUserBribeRevenueUSD,
     clUserFeesRevenueUSD: Number(clProtocolDayData?.[0]?.voterFeesUsd ?? 0),
     legacyUserFeesRevenueUSD: Number(
       legacyProtocolDayData?.[0]?.voterFeesUsd ?? 0,
@@ -191,8 +204,9 @@ export async function fetchStats(options: FetchOptions): Promise<IGraphRes> {
     clProtocolRevenueUSD: Number(clProtocolDayData?.[0]?.treasuryFeesUsd ?? 0),
     legacyProtocolRevenueUSD: Number(
       legacyProtocolDayData?.[0]?.treasuryFeesUsd ?? 0,
-    )  };
-};
+    ),
+  };
+}
 
 const fetch = async (_: any, _1: any, options: FetchOptions) => {
   const stats = await fetchStats(options);

--- a/dexs/ramses-hl-cl.ts
+++ b/dexs/ramses-hl-cl.ts
@@ -7,6 +7,7 @@ const XRAM_TOKEN_CONTRACT = "	0xAE6D5FcE541216BDA471D311425B5412D9f1DEb9";
 
 export const subgraphEndpoints: any = {
   [CHAIN.HYPERLIQUID]: "https://hyperevm.kingdomsubgraph.com/subgraphs/name/ramses-v3-pruned/",
+  [CHAIN.POLYGON]: "https://polygon.kingdomsubgraph.com/subgraphs/name/ramses-pruned",
 };
 
 const subgraphQueryLimit = 1000;

--- a/dexs/ramsesx-arb-cl.ts
+++ b/dexs/ramsesx-arb-cl.ts
@@ -1,0 +1,47 @@
+import { FetchOptions, SimpleAdapter } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+import { fetchStats } from "./ramses-hl-cl";
+
+const fetch = async (_: any, _1: any, options: FetchOptions) => {
+  const stats = await fetchStats(options);
+  const dailyFees = stats.clFeesUSD;
+  const dailyVolume = stats.clVolumeUSD;
+  const dailyHoldersRevenue = stats.clUserFeesRevenueUSD;
+  const dailyProtocolRevenue = stats.clProtocolRevenueUSD;
+  const dailyBribesRevenue = stats.clBribeRevenueUSD;
+
+  const dailySupplySideRevenue =
+    stats.clFeesUSD - dailyHoldersRevenue - dailyProtocolRevenue;
+  const dailyRevenue = dailyProtocolRevenue + dailyHoldersRevenue;
+
+  return {
+    dailyVolume,
+    dailyFees,
+    dailyUserFees: dailyFees,
+    dailyHoldersRevenue,
+    dailyProtocolRevenue,
+    dailyRevenue,
+    dailySupplySideRevenue,
+    dailyBribesRevenue,
+  };
+};
+
+const methodology = {
+  Fees: "Fees are collected from users on each swap.",
+  Revenue: "Revenue going to the protocol + Token holder Revenue.",
+  UserFees: "User pays fees on each swap.",
+  ProtocolRevenue: "Revenue going to the protocol.",
+  HoldersRevenue: "User fees are distributed among holders.",
+  BribesRevenue: "Bribes are distributed among holders.",
+  SupplySideRevenue: "Fees distributed to LPs (from gauged pools).",
+  TokenTax: "xRAM stakers instant exit penalty",
+};
+
+const adapter: SimpleAdapter = {
+  fetch,
+  chains: [CHAIN.ARBITRUM],
+  start: "2026-01-13",
+  methodology,
+};
+
+export default adapter;

--- a/dexs/ramsesx-arb-cl.ts
+++ b/dexs/ramsesx-arb-cl.ts
@@ -6,35 +6,17 @@ const fetch = async (_: any, _1: any, options: FetchOptions) => {
   const stats = await fetchStats(options);
   const dailyFees = stats.clFeesUSD;
   const dailyVolume = stats.clVolumeUSD;
-  const dailyHoldersRevenue = stats.clUserFeesRevenueUSD;
-  const dailyProtocolRevenue = stats.clProtocolRevenueUSD;
-  const dailyBribesRevenue = stats.clBribeRevenueUSD;
-
-  const dailySupplySideRevenue =
-    stats.clFeesUSD - dailyHoldersRevenue - dailyProtocolRevenue;
-  const dailyRevenue = dailyProtocolRevenue + dailyHoldersRevenue;
 
   return {
     dailyVolume,
     dailyFees,
     dailyUserFees: dailyFees,
-    dailyHoldersRevenue,
-    dailyProtocolRevenue,
-    dailyRevenue,
-    dailySupplySideRevenue,
-    dailyBribesRevenue,
   };
 };
 
 const methodology = {
   Fees: "Fees are collected from users on each swap.",
-  Revenue: "Revenue going to the protocol + Token holder Revenue.",
   UserFees: "User pays fees on each swap.",
-  ProtocolRevenue: "Revenue going to the protocol.",
-  HoldersRevenue: "User fees are distributed among holders.",
-  BribesRevenue: "Bribes are distributed among holders.",
-  SupplySideRevenue: "Fees distributed to LPs (from gauged pools).",
-  TokenTax: "xRAM stakers instant exit penalty",
 };
 
 const adapter: SimpleAdapter = {

--- a/dexs/ramsesx-arb-cl.ts
+++ b/dexs/ramsesx-arb-cl.ts
@@ -1,9 +1,9 @@
 import { FetchOptions, SimpleAdapter } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
-import { fetchStats } from "./ramses-hl-cl";
+import { fetchProtocolDayStats } from "./ramses-hl-cl";
 
 const fetch = async (_: any, _1: any, options: FetchOptions) => {
-  const stats = await fetchStats(options);
+  const stats = await fetchProtocolDayStats(options);
   const dailyFees = stats.clFeesUSD;
   const dailyVolume = stats.clVolumeUSD;
 

--- a/dexs/ramsesx-arb-cl.ts
+++ b/dexs/ramsesx-arb-cl.ts
@@ -1,29 +1,46 @@
 import { FetchOptions, SimpleAdapter } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
-import { fetchProtocolDayStats } from "./ramses-hl-cl";
+import { fetchStats, methodology, breakdownMethodology } from "./ramses-hl-cl";
+import { METRIC } from "../helpers/metrics";
 
 const fetch = async (_: any, _1: any, options: FetchOptions) => {
-  const stats = await fetchProtocolDayStats(options);
-  const dailyFees = stats.clFeesUSD;
-  const dailyVolume = stats.clVolumeUSD;
+    const stats = await fetchStats(options);
+    const dailyVolume = stats.clVolumeUSD;
 
-  return {
-    dailyVolume,
-    dailyFees,
-    dailyUserFees: dailyFees,
-  };
-};
+    const dailyFees = options.createBalances();
+    const dailyHoldersRevenue = options.createBalances();
+    const dailyProtocolRevenue = options.createBalances();
+    const dailySupplySideRevenue = options.createBalances();
 
-const methodology = {
-  Fees: "Fees are collected from users on each swap.",
-  UserFees: "User pays fees on each swap.",
+    dailyFees.addUSDValue(stats.clFeesUSD, METRIC.SWAP_FEES);
+    dailyHoldersRevenue.addUSDValue(stats.clUserFeesRevenueUSD, 'Swap Fees to holders');
+    dailyProtocolRevenue.addUSDValue(stats.clProtocolRevenueUSD, 'Swap Fees to protocol');
+
+    dailyFees.addUSDValue(stats.clBribeRevenueUSD, 'Bribes');
+    dailyHoldersRevenue.addUSDValue(stats.clBribeRevenueUSD, 'Bribes to holders');
+
+    const dailyRevenue = dailyProtocolRevenue.clone();
+    dailyRevenue.add(dailyHoldersRevenue);
+
+    dailySupplySideRevenue.addUSDValue(stats.clFeesUSD - stats.clUserFeesRevenueUSD - stats.clProtocolRevenueUSD, 'Swap Fees to LPs');
+
+    return {
+        dailyVolume,
+        dailyFees,
+        dailyUserFees: dailyFees,
+        dailyHoldersRevenue,
+        dailyProtocolRevenue,
+        dailyRevenue,
+        dailySupplySideRevenue,
+    };
 };
 
 const adapter: SimpleAdapter = {
-  fetch,
-  chains: [CHAIN.ARBITRUM],
-  start: "2026-01-13",
-  methodology,
+    fetch,
+    chains: [CHAIN.ARBITRUM],
+    start: "2026-01-13",
+    methodology,
+    breakdownMethodology,
 };
 
 export default adapter;

--- a/dexs/ramsesx-arb-cl.ts
+++ b/dexs/ramsesx-arb-cl.ts
@@ -1,46 +1,4 @@
-import { FetchOptions, SimpleAdapter } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
-import { fetchStats, methodology, breakdownMethodology } from "./ramses-hl-cl";
-import { METRIC } from "../helpers/metrics";
+import { createClAdapter } from "./ramses-hl-cl";
 
-const fetch = async (_: any, _1: any, options: FetchOptions) => {
-    const stats = await fetchStats(options);
-    const dailyVolume = stats.clVolumeUSD;
-
-    const dailyFees = options.createBalances();
-    const dailyHoldersRevenue = options.createBalances();
-    const dailyProtocolRevenue = options.createBalances();
-    const dailySupplySideRevenue = options.createBalances();
-
-    dailyFees.addUSDValue(stats.clFeesUSD, METRIC.SWAP_FEES);
-    dailyHoldersRevenue.addUSDValue(stats.clUserFeesRevenueUSD, 'Swap Fees to holders');
-    dailyProtocolRevenue.addUSDValue(stats.clProtocolRevenueUSD, 'Swap Fees to protocol');
-
-    dailyFees.addUSDValue(stats.clBribeRevenueUSD, 'Bribes');
-    dailyHoldersRevenue.addUSDValue(stats.clBribeRevenueUSD, 'Bribes to holders');
-
-    const dailyRevenue = dailyProtocolRevenue.clone();
-    dailyRevenue.add(dailyHoldersRevenue);
-
-    dailySupplySideRevenue.addUSDValue(stats.clFeesUSD - stats.clUserFeesRevenueUSD - stats.clProtocolRevenueUSD, 'Swap Fees to LPs');
-
-    return {
-        dailyVolume,
-        dailyFees,
-        dailyUserFees: dailyFees,
-        dailyHoldersRevenue,
-        dailyProtocolRevenue,
-        dailyRevenue,
-        dailySupplySideRevenue,
-    };
-};
-
-const adapter: SimpleAdapter = {
-    fetch,
-    chains: [CHAIN.ARBITRUM],
-    start: "2026-01-13",
-    methodology,
-    breakdownMethodology,
-};
-
-export default adapter;
+export default createClAdapter(CHAIN.ARBITRUM, "2026-01-13");

--- a/dexs/ramsesx-arb-legacy.ts
+++ b/dexs/ramsesx-arb-legacy.ts
@@ -7,31 +7,17 @@ const fetch = async (_: any, _1: any, options: FetchOptions) => {
 
   const dailyFees = stats.legacyFeesUSD;
   const dailyVolume = stats.legacyVolumeUSD;
-  const dailyHoldersRevenue = stats.legacyUserFeesRevenueUSD;
-  const dailyProtocolRevenue = stats.legacyProtocolRevenueUSD;
-  const dailyBribesRevenue = stats.legacyBribeRevenueUSD;
 
   return {
     dailyVolume,
     dailyFees,
     dailyUserFees: dailyFees,
-    dailyHoldersRevenue,
-    dailyProtocolRevenue,
-    dailyRevenue: dailyProtocolRevenue + dailyHoldersRevenue,
-    dailySupplySideRevenue:
-      dailyFees - dailyHoldersRevenue - dailyProtocolRevenue,
-    dailyBribesRevenue,
   };
 };
 
 const methodology = {
   Fees: "Fees are collected from users on each swap.",
-  Revenue: "Revenue going to the protocol + Token holder Revenue.",
   UserFees: "User pays fees on each swap.",
-  ProtocolRevenue: "Revenue going to the protocol.",
-  HoldersRevenue: "User fees are distributed among holders.",
-  SupplySideRevenue: "Fees distributed to LPs.",
-  BribesRevenue: "Bribes are distributed among holders.",
 };
 
 const adapter: SimpleAdapter = {

--- a/dexs/ramsesx-arb-legacy.ts
+++ b/dexs/ramsesx-arb-legacy.ts
@@ -1,30 +1,4 @@
-import { FetchOptions, SimpleAdapter } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
-import { fetchProtocolDayStats } from "./ramses-hl-cl";
+import { createLegacyAdapter } from "./ramses-hl-cl";
 
-const fetch = async (_: any, _1: any, options: FetchOptions) => {
-  const stats = await fetchProtocolDayStats(options);
-
-  const dailyFees = stats.legacyFeesUSD;
-  const dailyVolume = stats.legacyVolumeUSD;
-
-  return {
-    dailyVolume,
-    dailyFees,
-    dailyUserFees: dailyFees,
-  };
-};
-
-const methodology = {
-  Fees: "Fees are collected from users on each swap.",
-  UserFees: "User pays fees on each swap.",
-};
-
-const adapter: SimpleAdapter = {
-  fetch,
-  chains: [CHAIN.ARBITRUM],
-  start: "2026-01-28",
-  methodology,
-};
-
-export default adapter;
+export default createLegacyAdapter(CHAIN.ARBITRUM, "2026-01-28");

--- a/dexs/ramsesx-arb-legacy.ts
+++ b/dexs/ramsesx-arb-legacy.ts
@@ -1,0 +1,44 @@
+import { FetchOptions, SimpleAdapter } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+import { fetchStats } from "./ramses-hl-cl";
+
+const fetch = async (_: any, _1: any, options: FetchOptions) => {
+  const stats = await fetchStats(options);
+
+  const dailyFees = stats.legacyFeesUSD;
+  const dailyVolume = stats.legacyVolumeUSD;
+  const dailyHoldersRevenue = stats.legacyUserFeesRevenueUSD;
+  const dailyProtocolRevenue = stats.legacyProtocolRevenueUSD;
+  const dailyBribesRevenue = stats.legacyBribeRevenueUSD;
+
+  return {
+    dailyVolume,
+    dailyFees,
+    dailyUserFees: dailyFees,
+    dailyHoldersRevenue,
+    dailyProtocolRevenue,
+    dailyRevenue: dailyProtocolRevenue + dailyHoldersRevenue,
+    dailySupplySideRevenue:
+      dailyFees - dailyHoldersRevenue - dailyProtocolRevenue,
+    dailyBribesRevenue,
+  };
+};
+
+const methodology = {
+  Fees: "Fees are collected from users on each swap.",
+  Revenue: "Revenue going to the protocol + Token holder Revenue.",
+  UserFees: "User pays fees on each swap.",
+  ProtocolRevenue: "Revenue going to the protocol.",
+  HoldersRevenue: "User fees are distributed among holders.",
+  SupplySideRevenue: "Fees distributed to LPs.",
+  BribesRevenue: "Bribes are distributed among holders.",
+};
+
+const adapter: SimpleAdapter = {
+  fetch,
+  chains: [CHAIN.ARBITRUM],
+  start: "2026-01-28",
+  methodology,
+};
+
+export default adapter;

--- a/dexs/ramsesx-arb-legacy.ts
+++ b/dexs/ramsesx-arb-legacy.ts
@@ -1,9 +1,9 @@
 import { FetchOptions, SimpleAdapter } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
-import { fetchStats } from "./ramses-hl-cl";
+import { fetchProtocolDayStats } from "./ramses-hl-cl";
 
 const fetch = async (_: any, _1: any, options: FetchOptions) => {
-  const stats = await fetchStats(options);
+  const stats = await fetchProtocolDayStats(options);
 
   const dailyFees = stats.legacyFeesUSD;
   const dailyVolume = stats.legacyVolumeUSD;

--- a/dexs/ramsesx-poly-cl.ts
+++ b/dexs/ramsesx-poly-cl.ts
@@ -6,35 +6,17 @@ const fetch = async (_: any, _1: any, options: FetchOptions) => {
   const stats = await fetchStats(options);
   const dailyFees = stats.clFeesUSD;
   const dailyVolume = stats.clVolumeUSD;
-  const dailyHoldersRevenue = stats.clUserFeesRevenueUSD;
-  const dailyProtocolRevenue = stats.clProtocolRevenueUSD;
-  const dailyBribesRevenue = stats.clBribeRevenueUSD;
-
-  const dailySupplySideRevenue =
-    stats.clFeesUSD - dailyHoldersRevenue - dailyProtocolRevenue;
-  const dailyRevenue = dailyProtocolRevenue + dailyHoldersRevenue;
 
   return {
     dailyVolume,
     dailyFees,
     dailyUserFees: dailyFees,
-    dailyHoldersRevenue,
-    dailyProtocolRevenue,
-    dailyRevenue,
-    dailySupplySideRevenue,
-    dailyBribesRevenue,
   };
 };
 
 const methodology = {
   Fees: "Fees are collected from users on each swap.",
-  Revenue: "Revenue going to the protocol + Token holder Revenue.",
   UserFees: "User pays fees on each swap.",
-  ProtocolRevenue: "Revenue going to the protocol.",
-  HoldersRevenue: "User fees are distributed among holders.",
-  BribesRevenue: "Bribes are distributed among holders.",
-  SupplySideRevenue: "Fees distributed to LPs (from gauged pools).",
-  TokenTax: "xRAM stakers instant exit penalty",
 };
 
 const adapter: SimpleAdapter = {

--- a/dexs/ramsesx-poly-cl.ts
+++ b/dexs/ramsesx-poly-cl.ts
@@ -1,0 +1,47 @@
+import { FetchOptions, SimpleAdapter } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+import { fetchStats } from "./ramses-hl-cl";
+
+const fetch = async (_: any, _1: any, options: FetchOptions) => {
+  const stats = await fetchStats(options);
+  const dailyFees = stats.clFeesUSD;
+  const dailyVolume = stats.clVolumeUSD;
+  const dailyHoldersRevenue = stats.clUserFeesRevenueUSD;
+  const dailyProtocolRevenue = stats.clProtocolRevenueUSD;
+  const dailyBribesRevenue = stats.clBribeRevenueUSD;
+
+  const dailySupplySideRevenue =
+    stats.clFeesUSD - dailyHoldersRevenue - dailyProtocolRevenue;
+  const dailyRevenue = dailyProtocolRevenue + dailyHoldersRevenue;
+
+  return {
+    dailyVolume,
+    dailyFees,
+    dailyUserFees: dailyFees,
+    dailyHoldersRevenue,
+    dailyProtocolRevenue,
+    dailyRevenue,
+    dailySupplySideRevenue,
+    dailyBribesRevenue,
+  };
+};
+
+const methodology = {
+  Fees: "Fees are collected from users on each swap.",
+  Revenue: "Revenue going to the protocol + Token holder Revenue.",
+  UserFees: "User pays fees on each swap.",
+  ProtocolRevenue: "Revenue going to the protocol.",
+  HoldersRevenue: "User fees are distributed among holders.",
+  BribesRevenue: "Bribes are distributed among holders.",
+  SupplySideRevenue: "Fees distributed to LPs (from gauged pools).",
+  TokenTax: "xRAM stakers instant exit penalty",
+};
+
+const adapter: SimpleAdapter = {
+  fetch,
+  chains: [CHAIN.POLYGON],
+  start: "2026-01-28",
+  methodology,
+};
+
+export default adapter;

--- a/dexs/ramsesx-poly-cl.ts
+++ b/dexs/ramsesx-poly-cl.ts
@@ -1,9 +1,9 @@
 import { FetchOptions, SimpleAdapter } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
-import { fetchStats } from "./ramses-hl-cl";
+import { fetchProtocolDayStats } from "./ramses-hl-cl";
 
 const fetch = async (_: any, _1: any, options: FetchOptions) => {
-  const stats = await fetchStats(options);
+  const stats = await fetchProtocolDayStats(options);
   const dailyFees = stats.clFeesUSD;
   const dailyVolume = stats.clVolumeUSD;
 

--- a/dexs/ramsesx-poly-cl.ts
+++ b/dexs/ramsesx-poly-cl.ts
@@ -1,29 +1,4 @@
-import { FetchOptions, SimpleAdapter } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
-import { fetchProtocolDayStats } from "./ramses-hl-cl";
+import { createClAdapter } from "./ramses-hl-cl";
 
-const fetch = async (_: any, _1: any, options: FetchOptions) => {
-  const stats = await fetchProtocolDayStats(options);
-  const dailyFees = stats.clFeesUSD;
-  const dailyVolume = stats.clVolumeUSD;
-
-  return {
-    dailyVolume,
-    dailyFees,
-    dailyUserFees: dailyFees,
-  };
-};
-
-const methodology = {
-  Fees: "Fees are collected from users on each swap.",
-  UserFees: "User pays fees on each swap.",
-};
-
-const adapter: SimpleAdapter = {
-  fetch,
-  chains: [CHAIN.POLYGON],
-  start: "2026-01-28",
-  methodology,
-};
-
-export default adapter;
+export default createClAdapter(CHAIN.POLYGON, "2026-01-28");

--- a/dexs/ramsesx-poly-legacy.ts
+++ b/dexs/ramsesx-poly-legacy.ts
@@ -7,31 +7,17 @@ const fetch = async (_: any, _1: any, options: FetchOptions) => {
 
   const dailyFees = stats.legacyFeesUSD;
   const dailyVolume = stats.legacyVolumeUSD;
-  const dailyHoldersRevenue = stats.legacyUserFeesRevenueUSD;
-  const dailyProtocolRevenue = stats.legacyProtocolRevenueUSD;
-  const dailyBribesRevenue = stats.legacyBribeRevenueUSD;
 
   return {
     dailyVolume,
     dailyFees,
     dailyUserFees: dailyFees,
-    dailyHoldersRevenue,
-    dailyProtocolRevenue,
-    dailyRevenue: dailyProtocolRevenue + dailyHoldersRevenue,
-    dailySupplySideRevenue:
-      dailyFees - dailyHoldersRevenue - dailyProtocolRevenue,
-    dailyBribesRevenue,
   };
 };
 
 const methodology = {
   Fees: "Fees are collected from users on each swap.",
-  Revenue: "Revenue going to the protocol + Token holder Revenue.",
   UserFees: "User pays fees on each swap.",
-  ProtocolRevenue: "Revenue going to the protocol.",
-  HoldersRevenue: "User fees are distributed among holders.",
-  SupplySideRevenue: "Fees distributed to LPs.",
-  BribesRevenue: "Bribes are distributed among holders.",
 };
 
 const adapter: SimpleAdapter = {

--- a/dexs/ramsesx-poly-legacy.ts
+++ b/dexs/ramsesx-poly-legacy.ts
@@ -1,30 +1,4 @@
-import { FetchOptions, SimpleAdapter } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
-import { fetchProtocolDayStats } from "./ramses-hl-cl";
+import { createLegacyAdapter } from "./ramses-hl-cl";
 
-const fetch = async (_: any, _1: any, options: FetchOptions) => {
-  const stats = await fetchProtocolDayStats(options);
-
-  const dailyFees = stats.legacyFeesUSD;
-  const dailyVolume = stats.legacyVolumeUSD;
-
-  return {
-    dailyVolume,
-    dailyFees,
-    dailyUserFees: dailyFees,
-  };
-};
-
-const methodology = {
-  Fees: "Fees are collected from users on each swap.",
-  UserFees: "User pays fees on each swap.",
-};
-
-const adapter: SimpleAdapter = {
-  fetch,
-  chains: [CHAIN.POLYGON],
-  start: "2026-01-28",
-  methodology,
-};
-
-export default adapter;
+export default createLegacyAdapter(CHAIN.POLYGON, "2026-01-28");

--- a/dexs/ramsesx-poly-legacy.ts
+++ b/dexs/ramsesx-poly-legacy.ts
@@ -1,0 +1,44 @@
+import { FetchOptions, SimpleAdapter } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+import { fetchStats } from "./ramses-hl-cl";
+
+const fetch = async (_: any, _1: any, options: FetchOptions) => {
+  const stats = await fetchStats(options);
+
+  const dailyFees = stats.legacyFeesUSD;
+  const dailyVolume = stats.legacyVolumeUSD;
+  const dailyHoldersRevenue = stats.legacyUserFeesRevenueUSD;
+  const dailyProtocolRevenue = stats.legacyProtocolRevenueUSD;
+  const dailyBribesRevenue = stats.legacyBribeRevenueUSD;
+
+  return {
+    dailyVolume,
+    dailyFees,
+    dailyUserFees: dailyFees,
+    dailyHoldersRevenue,
+    dailyProtocolRevenue,
+    dailyRevenue: dailyProtocolRevenue + dailyHoldersRevenue,
+    dailySupplySideRevenue:
+      dailyFees - dailyHoldersRevenue - dailyProtocolRevenue,
+    dailyBribesRevenue,
+  };
+};
+
+const methodology = {
+  Fees: "Fees are collected from users on each swap.",
+  Revenue: "Revenue going to the protocol + Token holder Revenue.",
+  UserFees: "User pays fees on each swap.",
+  ProtocolRevenue: "Revenue going to the protocol.",
+  HoldersRevenue: "User fees are distributed among holders.",
+  SupplySideRevenue: "Fees distributed to LPs.",
+  BribesRevenue: "Bribes are distributed among holders.",
+};
+
+const adapter: SimpleAdapter = {
+  fetch,
+  chains: [CHAIN.POLYGON],
+  start: "2026-01-28",
+  methodology,
+};
+
+export default adapter;

--- a/dexs/ramsesx-poly-legacy.ts
+++ b/dexs/ramsesx-poly-legacy.ts
@@ -1,9 +1,9 @@
 import { FetchOptions, SimpleAdapter } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
-import { fetchStats } from "./ramses-hl-cl";
+import { fetchProtocolDayStats } from "./ramses-hl-cl";
 
 const fetch = async (_: any, _1: any, options: FetchOptions) => {
-  const stats = await fetchStats(options);
+  const stats = await fetchProtocolDayStats(options);
 
   const dailyFees = stats.legacyFeesUSD;
   const dailyVolume = stats.legacyVolumeUSD;


### PR DESCRIPTION

## Summary
- add matching RamsesX Polygon and Arbitrum dex adapters using the shared Ramses subgraph flow
- limit these chain adapters to `dailyVolume`, `dailyFees`, and `dailyUserFees` because the linked subgraphs do not expose meaningful bribe or RAM-based stats for these deployments

## Companion PRs
- `DefiLlama-Adapters`: sibling PR in this batch adds the separate RamsesX Polygon/Arbitrum TVL exports https://github.com/DefiLlama/DefiLlama-Adapters/pull/18833
- `defillama-server`: sibling PR in this batch adds the RamsesX Polygon/Arbitrum child metadata under the RamsesX parent https://github.com/DefiLlama/defillama-server/pull/11788
- `icons`: https://github.com/DefiLlama/icons/pull/2358