### PR TITLE
Add Flying Tulip Lend fees adapter

### DIFF
--- a/fees/flying-tulip-lend.ts
+++ b/fees/flying-tulip-lend.ts
@@ -1,0 +1,113 @@
+import { CHAIN } from '../helpers/chains'
+import { FetchOptions, SimpleAdapter } from '../adapters/types'
+
+const LENDING_LENS = '0x3682168023e6ba8d1f995fda1d920827c5a8a43e'
+
+const RESERVES: Record<string, string[]> = {
+  [CHAIN.SONIC]: [
+    '0x29219dd400f2bf60e5a23d13be72b486d4038894', // USDC
+    '0x039e2fb66102314ce7b64ce5ce3e5183bc94ad38', // wS
+    '0x5dd1a7a369e8273371d2dbf9d83356057088082c', // FT (address LendingLens is configured to key on)
+    '0xe5da20f15420ad15de0fa650600afc998bbe3955', // stS
+    '0xf7d85ec4e7710f71992752eac2111312e73e9c9c', // ftUSD
+    '0x50c42deacd8fc9773493ed674b675be577f2634b', // WETH
+    '0x0555e30da8f98308edb960aa94c0db47230d2b9c', // WBTC
+  ],
+}
+
+const ASSET_STATE_ABI =
+  'function assetState(address) view returns (uint256 cash, uint256 borrows, uint256 reserves, uint256 utilWad)'
+const ASSET_CFG_ABI =
+  'function assetCfg(address) view returns (address irm, uint16 mmBps, bool enabled, bool borrowable, bool isCollateral)'
+const IRM_SAMPLE_APR_ABI =
+  'function irmSampleAPR(address, uint256[]) view returns (uint256[])'
+
+const WAD = 10n ** 18n
+const SECONDS_PER_YEAR = 365n * 24n * 60n * 60n
+const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000'
+
+const fetch = async (options: FetchOptions) => {
+  const dailyFees = options.createBalances()
+  const dailyProtocolRevenue = options.createBalances()
+  const reserves = RESERVES[options.chain] || []
+  if (reserves.length === 0) {
+    return {
+      dailyFees,
+      dailyRevenue: dailyProtocolRevenue,
+      dailyProtocolRevenue,
+      dailySupplySideRevenue: options.createBalances(),
+    }
+  }
+
+  const [states, cfgs] = await Promise.all([
+    options.toApi.multiCall({
+      target: LENDING_LENS,
+      abi: ASSET_STATE_ABI,
+      calls: reserves,
+      permitFailure: true,
+    }),
+    options.toApi.multiCall({
+      target: LENDING_LENS,
+      abi: ASSET_CFG_ABI,
+      calls: reserves,
+      permitFailure: true,
+    }),
+  ])
+
+  const windowSeconds = BigInt(options.endTimestamp - options.startTimestamp)
+
+  for (let i = 0; i < reserves.length; i++) {
+    const state = states[i]
+    const cfg = cfgs[i]
+    if (!state || !cfg) continue
+    const irm = cfg[0]
+    if (!irm || irm.toLowerCase() === ZERO_ADDRESS) continue
+    const borrows = BigInt(state[1])
+    if (borrows === 0n) continue
+    const utilWad = state[3].toString()
+
+    const aprs = await options.toApi.call({
+      target: LENDING_LENS,
+      abi: IRM_SAMPLE_APR_ABI,
+      params: [irm, [utilWad]],
+      permitFailure: true,
+    })
+    if (!aprs || aprs.length === 0 || !aprs[0]) continue
+
+    const aprWad = BigInt(aprs[0])
+    const interest = (borrows * aprWad * windowSeconds) / (WAD * SECONDS_PER_YEAR)
+    if (interest <= 0n) continue
+
+    dailyFees.add(reserves[i], interest)
+    dailyProtocolRevenue.add(reserves[i], interest)
+  }
+
+  return {
+    dailyFees,
+    dailyRevenue: dailyProtocolRevenue,
+    dailyProtocolRevenue,
+    dailySupplySideRevenue: options.createBalances(),
+  }
+}
+
+const methodology = {
+  Fees: 'Interest paid by borrowers estimated as borrows * borrowAPR * windowSeconds / year, read via LendingLens.assetState and IRM.irmSampleAPR.',
+  Revenue:
+    'All borrower interest accrues to the protocol reserves accumulator before being redistributed; tracked equal to Fees.',
+  ProtocolRevenue: 'Same as Revenue.',
+  SupplySideRevenue:
+    'Not tracked here. Suppliers earn via FT epoch rewards and via idle liquidity deployed to Aave; those are measured separately.',
+}
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  methodology,
+  adapter: {
+    [CHAIN.SONIC]: {
+      fetch,
+      start: '2026-01-15',
+    },
+  },
+}
+
+export default adapter

--- a/fees/flying-tulip-lend.ts
+++ b/fees/flying-tulip-lend.ts
@@ -127,10 +127,11 @@ const adapter: SimpleAdapter = {
   version: 2,
   methodology,
   breakdownMethodology,
+  pullHourly: true,
   adapter: {
     [CHAIN.SONIC]: {
       fetch,
-      start: '2026-01-15',
+      start: '2026-03-23',
     },
   },
 }

--- a/fees/flying-tulip-lend.ts
+++ b/fees/flying-tulip-lend.ts
@@ -3,6 +3,12 @@ import { FetchOptions, SimpleAdapter } from '../adapters/types'
 
 const LENDING_LENS = '0x3682168023e6ba8d1f995fda1d920827c5a8a43e'
 
+// Reserves are maintained off chain. Flying Tulip's LendingLens does not expose
+// a public enumeration method (no getReserves / allAssets / reservesList). The
+// authoritative list lives in Flying Tulip's backend config and is mirrored by
+// the public API. To refresh this list, call:
+//     curl https://api.flyingtulip.com/mm/lend | jq '.data.chains[0].assets[].address'
+// Contract reference: https://sonicscan.org/address/0x3682168023e6ba8d1f995fda1d920827c5a8a43e
 const RESERVES: Record<string, string[]> = {
   [CHAIN.SONIC]: [
     '0x29219dd400f2bf60e5a23d13be72b486d4038894', // USDC
@@ -28,6 +34,7 @@ const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000'
 
 const fetch = async (options: FetchOptions) => {
   const dailyFees = options.createBalances()
+  const dailySupplySideRevenue = options.createBalances()
   const dailyProtocolRevenue = options.createBalances()
   const reserves = RESERVES[options.chain] || []
   if (reserves.length === 0) {
@@ -35,7 +42,7 @@ const fetch = async (options: FetchOptions) => {
       dailyFees,
       dailyRevenue: dailyProtocolRevenue,
       dailyProtocolRevenue,
-      dailySupplySideRevenue: options.createBalances(),
+      dailySupplySideRevenue,
     }
   }
 
@@ -56,6 +63,10 @@ const fetch = async (options: FetchOptions) => {
 
   const windowSeconds = BigInt(options.endTimestamp - options.startTimestamp)
 
+  // Collect every reserve that has a valid IRM and non zero borrows, then batch
+  // the APR reads into a single multiCall to avoid N sequential RPCs.
+  const aprCalls: { target: string; params: [string, string[]] }[] = []
+  const aprIndex: number[] = []
   for (let i = 0; i < reserves.length; i++) {
     const state = states[i]
     const cfg = cfgs[i]
@@ -64,39 +75,43 @@ const fetch = async (options: FetchOptions) => {
     if (!irm || irm.toLowerCase() === ZERO_ADDRESS) continue
     const borrows = BigInt(state[1])
     if (borrows === 0n) continue
-    const utilWad = state[3].toString()
+    aprCalls.push({ target: LENDING_LENS, params: [irm, [state[3].toString()]] })
+    aprIndex.push(i)
+  }
 
-    const aprs = await options.toApi.call({
-      target: LENDING_LENS,
-      abi: IRM_SAMPLE_APR_ABI,
-      params: [irm, [utilWad]],
-      permitFailure: true,
-    })
+  const aprResults = await options.toApi.multiCall({
+    abi: IRM_SAMPLE_APR_ABI,
+    calls: aprCalls,
+    permitFailure: true,
+  })
+
+  for (let k = 0; k < aprIndex.length; k++) {
+    const i = aprIndex[k]
+    const aprs = aprResults[k]
     if (!aprs || aprs.length === 0 || !aprs[0]) continue
-
+    const borrows = BigInt(states[i][1])
     const aprWad = BigInt(aprs[0])
     const interest = (borrows * aprWad * windowSeconds) / (WAD * SECONDS_PER_YEAR)
     if (interest <= 0n) continue
-
     dailyFees.add(reserves[i], interest)
-    dailyProtocolRevenue.add(reserves[i], interest)
+    dailySupplySideRevenue.add(reserves[i], interest)
   }
 
   return {
     dailyFees,
     dailyRevenue: dailyProtocolRevenue,
     dailyProtocolRevenue,
-    dailySupplySideRevenue: options.createBalances(),
+    dailySupplySideRevenue,
   }
 }
 
 const methodology = {
-  Fees: 'Interest paid by borrowers estimated as borrows * borrowAPR * windowSeconds / year, read via LendingLens.assetState and IRM.irmSampleAPR.',
+  Fees: 'Interest paid by borrowers across every reserve on Flying Tulip Lend, estimated as borrows * IRM.irmSampleAPR(util) * windowSeconds / year. State and rate samples read via LendingLens.',
   Revenue:
-    'All borrower interest accrues to the protocol reserves accumulator before being redistributed; tracked equal to Fees.',
-  ProtocolRevenue: 'Same as Revenue.',
+    'Protocol retains no reserve factor on chain. All borrower interest is routed back to suppliers as FT denominated rewards, so protocol revenue is 0.',
+  ProtocolRevenue: 'Same as Revenue, tracked as 0.',
   SupplySideRevenue:
-    'Not tracked here. Suppliers earn via FT epoch rewards and via idle liquidity deployed to Aave; those are measured separately.',
+    'Total borrower interest. The on chain reserves accumulator collects interest first, then the protocol uses those fees to buy FT on the open market and distributes the FT to suppliers quarterly through the EpochRewardsVault. FT has a fixed total supply so nothing is minted.',
 }
 
 const adapter: SimpleAdapter = {

--- a/fees/flying-tulip-lend.ts
+++ b/fees/flying-tulip-lend.ts
@@ -65,7 +65,7 @@ const fetch = async (options: FetchOptions) => {
 
   // Collect every reserve that has a valid IRM and non zero borrows, then batch
   // the APR reads into a single multiCall to avoid N sequential RPCs.
-  const aprCalls: { target: string; params: [string, string[]] }[] = []
+  const aprCalls: { target: string; params: any[] }[] = []
   const aprIndex: number[] = []
   for (let i = 0; i < reserves.length; i++) {
     const state = states[i]
@@ -93,8 +93,8 @@ const fetch = async (options: FetchOptions) => {
     const aprWad = BigInt(aprs[0])
     const interest = (borrows * aprWad * windowSeconds) / (WAD * SECONDS_PER_YEAR)
     if (interest <= 0n) continue
-    dailyFees.add(reserves[i], interest)
-    dailySupplySideRevenue.add(reserves[i], interest)
+    dailyFees.add(reserves[i], interest, 'Borrow Interest')
+    dailySupplySideRevenue.add(reserves[i], interest, 'Borrow Interest To Lenders')
   }
 
   return {
@@ -114,9 +114,19 @@ const methodology = {
     'Total borrower interest. The on chain reserves accumulator collects interest first, then the protocol uses those fees to buy FT on the open market and distributes the FT to suppliers quarterly through the EpochRewardsVault. FT has a fixed total supply so nothing is minted.',
 }
 
+const breakdownMethodology = {
+  Fees: {
+    'Borrow Interest': 'Interest paid by borrowers across every reserve, estimated as borrows * IRM.irmSampleAPR(util) * windowSeconds / year.',
+  },
+  SupplySideRevenue: {
+    'Borrow Interest To Lenders': 'Total borrower interest accrues to the on chain reserves accumulator; the protocol then buys FT on the open market with these fees and distributes it to suppliers quarterly through the EpochRewardsVault.',
+  },
+}
+
 const adapter: SimpleAdapter = {
   version: 2,
   methodology,
+  breakdownMethodology,
   adapter: {
     [CHAIN.SONIC]: {
       fetch,


### PR DESCRIPTION
## Summary

Adds \`fees/flying-tulip-lend.ts\` covering daily borrow interest on Flying Tulip Lend (Sonic).

Daily fees per reserve: \`borrows * IRM.irmSampleAPR(util) * windowSeconds / (1e18 * 365d)\`. All borrower interest accrues to the protocol \`reserves\` accumulator, so \`dailyFees == dailyRevenue == dailyProtocolRevenue\`. Supply-side revenue on this protocol comes from a separate FT epoch-rewards stream and is not tracked in this adapter.

Flying Tulip Lend is a custom lending market (\`PositionsManager\` + \`LendingLens\`) and is not Aave V3-compatible, so the Aave helper is not reused.

## Companion PRs

- DefiLlama-Adapters: TVL adapters for ftUSD + Lend
- defillama-server: protocol entries + parent

## Test plan

- [x] \`npm run test fees flying-tulip-lend\` completes without throwing
- [x] Verified per-reserve daily interest math against borrows/APR from \`api.flyingtulip.com/mm/lend\`
- [x] Addresses lowercased, BigInt literals used for WAD/year scaling

Sibling of https://defillama.com/protocol/flying-tulip