### PR TITLE
Fix/thorwallet fees revenue split

### DIFF
--- a/fees/thorwallet/index.ts
+++ b/fees/thorwallet/index.ts
@@ -18,7 +18,7 @@ const fetch = async (options: FetchOptions) => {
     dailyHoldersRevenue.addUSDValue(parseFloat(data.dailyHoldersRevenue), METRIC.STAKING_REWARDS);
 
     const dailySupplySideRevenue = options.createBalances();
-    dailySupplySideRevenue.addUSDValue(parseFloat(data.dailyRaffleRevenue), 'Raffle Pot Rewards');
+    dailySupplySideRevenue.addUSDValue(parseFloat(data.dailyRaffleRevenue ?? '0'), 'Raffle Pot Rewards');
 
     const dailyRevenue = options.createBalances();
     dailyRevenue.addUSDValue(parseFloat(data.dailyProtocolRevenue), METRIC.PROTOCOL_FEES);

--- a/fees/thorwallet/index.ts
+++ b/fees/thorwallet/index.ts
@@ -11,11 +11,18 @@ const fetch = async (options: FetchOptions) => {
     dailyFees.addUSDValue(parseFloat(breakdown.swapAffiliateFees), 'Swap Affiliate Fees');
     dailyFees.addUSDValue(parseFloat(breakdown.perpCloseFees), 'Perp Close Fees');
 
-    const dailyRevenue = dailyFees.clone(0.45, METRIC.PROTOCOL_FEES);
-    dailyRevenue.add(dailyFees.clone(0.5, METRIC.STAKING_REWARDS), METRIC.STAKING_REWARDS);
-    const dailyProtocolRevenue = dailyFees.clone(0.45, METRIC.PROTOCOL_FEES);
-    const dailyHoldersRevenue = dailyFees.clone(0.5, METRIC.STAKING_REWARDS);
-    const dailySupplySideRevenue = dailyFees.clone(0.05, 'Raffle Pot Rewards');
+    const dailyProtocolRevenue = options.createBalances();
+    dailyProtocolRevenue.addUSDValue(parseFloat(data.dailyProtocolRevenue), METRIC.PROTOCOL_FEES);
+
+    const dailyHoldersRevenue = options.createBalances();
+    dailyHoldersRevenue.addUSDValue(parseFloat(data.dailyHoldersRevenue), METRIC.STAKING_REWARDS);
+
+    const dailySupplySideRevenue = options.createBalances();
+    dailySupplySideRevenue.addUSDValue(parseFloat(data.dailyRaffleRevenue), 'Raffle Pot Rewards');
+
+    const dailyRevenue = options.createBalances();
+    dailyRevenue.addUSDValue(parseFloat(data.dailyProtocolRevenue), METRIC.PROTOCOL_FEES);
+    dailyRevenue.addUSDValue(parseFloat(data.dailyHoldersRevenue), METRIC.STAKING_REWARDS);
 
     return {
         dailyFees,
@@ -28,31 +35,31 @@ const fetch = async (options: FetchOptions) => {
 };
 
 const methodology = {
-    Fees: 'All fees from THORChain, Maya, Chainflip swaps and perps trading.',
+    Fees: 'All affiliate fees from swaps (THORChain, Maya, Near Intents, 1inch, Unizen, Chainflip, Harbor, etc.) plus perpetual trading close fees.',
     UserFees: 'Same as Fees - all fees are paid by users.',
-    Revenue: 'Total protocol and holders revenue from all sources.',
-    ProtocolRevenue: '45% of fees allocated to protocol treasury.',
-    HoldersRevenue: '50% of fees distributed to token holders.',
-    SupplySideRevenue: '5% of fees distributed to in game raffle pot players',
+    Revenue: 'Protocol treasury plus $TITN staker revenue.',
+    ProtocolRevenue: '45% of THORChain/Maya/Near Intents fees + 100% of 1inch/Unizen/Chainflip/Harbor fees + 100% of perpetual close fees, allocated to protocol treasury.',
+    HoldersRevenue: '50% of THORChain/Maya/Near Intents fees distributed to $TITN stakers.',
+    SupplySideRevenue: '5% of THORChain/Maya/Near Intents fees distributed to in-game raffle pot players.',
 };
 
 const breakdownMethodology = {
     Fees: {
-        'Swap Affiliate Fees': 'Affiliate fees from swaps across THORChain, Maya, and Chainflip.',
+        'Swap Affiliate Fees': 'Affiliate fees from swaps across THORChain, Maya, Near Intents, 1inch, Unizen, Chainflip, Harbor, and other integrated DEXes.',
         'Perp Close Fees': 'Fees from closing perpetual trading positions.',
     },
     Revenue: {
-        [METRIC.PROTOCOL_FEES]: '45% of fees allocated to protocol treasury.',
-        [METRIC.STAKING_REWARDS]: '50% of fees distributed to $TITN stakers.',
+        [METRIC.PROTOCOL_FEES]: '45% of THORChain/Maya/Near Intents fees + 100% of other swap fees + 100% of perp close fees, allocated to protocol treasury.',
+        [METRIC.STAKING_REWARDS]: '50% of THORChain/Maya/Near Intents fees distributed to $TITN stakers.',
     },
     ProtocolRevenue: {
-        [METRIC.PROTOCOL_FEES]: '45% of fees allocated to protocol treasury.',
+        [METRIC.PROTOCOL_FEES]: '45% of THORChain/Maya/Near Intents fees + 100% of other swap fees + 100% of perp close fees, allocated to protocol treasury.',
     },
     HoldersRevenue: {
-        [METRIC.STAKING_REWARDS]: '50% of fees distributed to $TITN stakers.',
+        [METRIC.STAKING_REWARDS]: '50% of THORChain/Maya/Near Intents fees distributed to $TITN stakers.',
     },
     SupplySideRevenue: {
-        'Raffle Pot Rewards': '5% of fees distributed to in game raffle pot players',
+        'Raffle Pot Rewards': '5% of THORChain/Maya/Near Intents fees distributed to in-game raffle pot players.',
     }
 };
 

--- a/fees/thorwallet/index.ts
+++ b/fees/thorwallet/index.ts
@@ -1,7 +1,10 @@
 import { FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 import { httpGet } from "../../utils/fetchURL";
-import { METRIC } from "../../helpers/metrics";
+
+const PROTOCOL_LABEL = 'Affiliate & Perp Close Fees To Treasury';
+const STAKERS_LABEL = 'Affiliate Fees To $TITN Stakers';
+const RAFFLE_LABEL = 'Raffle Pot Rewards To Players';
 
 const fetch = async (options: FetchOptions) => {
     const data = await httpGet('https://api-v2-prod.thorwallet.org/defillama/fees');
@@ -12,17 +15,16 @@ const fetch = async (options: FetchOptions) => {
     dailyFees.addUSDValue(parseFloat(breakdown.perpCloseFees), 'Perp Close Fees');
 
     const dailyProtocolRevenue = options.createBalances();
-    dailyProtocolRevenue.addUSDValue(parseFloat(data.dailyProtocolRevenue), METRIC.PROTOCOL_FEES);
+    dailyProtocolRevenue.addUSDValue(parseFloat(data.dailyProtocolRevenue), PROTOCOL_LABEL);
 
     const dailyHoldersRevenue = options.createBalances();
-    dailyHoldersRevenue.addUSDValue(parseFloat(data.dailyHoldersRevenue), METRIC.STAKING_REWARDS);
-
-    const dailySupplySideRevenue = options.createBalances();
-    dailySupplySideRevenue.addUSDValue(parseFloat(data.dailyRaffleRevenue ?? '0'), 'Raffle Pot Rewards');
+    dailyHoldersRevenue.addUSDValue(parseFloat(data.dailyHoldersRevenue), STAKERS_LABEL);
+    dailyHoldersRevenue.addUSDValue(parseFloat(data.dailyRaffleRevenue ?? '0'), RAFFLE_LABEL);
 
     const dailyRevenue = options.createBalances();
-    dailyRevenue.addUSDValue(parseFloat(data.dailyProtocolRevenue), METRIC.PROTOCOL_FEES);
-    dailyRevenue.addUSDValue(parseFloat(data.dailyHoldersRevenue), METRIC.STAKING_REWARDS);
+    dailyRevenue.addUSDValue(parseFloat(data.dailyProtocolRevenue), PROTOCOL_LABEL);
+    dailyRevenue.addUSDValue(parseFloat(data.dailyHoldersRevenue), STAKERS_LABEL);
+    dailyRevenue.addUSDValue(parseFloat(data.dailyRaffleRevenue ?? '0'), RAFFLE_LABEL);
 
     return {
         dailyFees,
@@ -30,17 +32,15 @@ const fetch = async (options: FetchOptions) => {
         dailyRevenue,
         dailyProtocolRevenue,
         dailyHoldersRevenue,
-        dailySupplySideRevenue,
     };
 };
 
 const methodology = {
     Fees: 'All affiliate fees from swaps (THORChain, Maya, Near Intents, 1inch, Unizen, Chainflip, Harbor, etc.) plus perpetual trading close fees.',
     UserFees: 'Same as Fees - all fees are paid by users.',
-    Revenue: 'Protocol treasury plus $TITN staker revenue.',
+    Revenue: 'Protocol treasury plus distributions to $TITN stakers and raffle pot players.',
     ProtocolRevenue: '45% of THORChain/Maya/Near Intents fees + 100% of 1inch/Unizen/Chainflip/Harbor fees + 100% of perpetual close fees, allocated to protocol treasury.',
-    HoldersRevenue: '50% of THORChain/Maya/Near Intents fees distributed to $TITN stakers.',
-    SupplySideRevenue: '5% of THORChain/Maya/Near Intents fees distributed to in-game raffle pot players.',
+    HoldersRevenue: '50% of THORChain/Maya/Near Intents fees distributed to $TITN stakers plus 5% distributed to in-game raffle pot players.',
 };
 
 const breakdownMethodology = {
@@ -49,18 +49,17 @@ const breakdownMethodology = {
         'Perp Close Fees': 'Fees from closing perpetual trading positions.',
     },
     Revenue: {
-        [METRIC.PROTOCOL_FEES]: '45% of THORChain/Maya/Near Intents fees + 100% of other swap fees + 100% of perp close fees, allocated to protocol treasury.',
-        [METRIC.STAKING_REWARDS]: '50% of THORChain/Maya/Near Intents fees distributed to $TITN stakers.',
+        [PROTOCOL_LABEL]: '45% of THORChain/Maya/Near Intents fees + 100% of other swap fees + 100% of perp close fees, allocated to protocol treasury.',
+        [STAKERS_LABEL]: '50% of THORChain/Maya/Near Intents fees distributed to $TITN stakers.',
+        [RAFFLE_LABEL]: '5% of THORChain/Maya/Near Intents fees distributed to in-game raffle pot players.',
     },
     ProtocolRevenue: {
-        [METRIC.PROTOCOL_FEES]: '45% of THORChain/Maya/Near Intents fees + 100% of other swap fees + 100% of perp close fees, allocated to protocol treasury.',
+        [PROTOCOL_LABEL]: '45% of THORChain/Maya/Near Intents fees + 100% of other swap fees + 100% of perp close fees, allocated to protocol treasury.',
     },
     HoldersRevenue: {
-        [METRIC.STAKING_REWARDS]: '50% of THORChain/Maya/Near Intents fees distributed to $TITN stakers.',
+        [STAKERS_LABEL]: '50% of THORChain/Maya/Near Intents fees distributed to $TITN stakers.',
+        [RAFFLE_LABEL]: '5% of THORChain/Maya/Near Intents fees distributed to in-game raffle pot players.',
     },
-    SupplySideRevenue: {
-        'Raffle Pot Rewards': '5% of THORChain/Maya/Near Intents fees distributed to in-game raffle pot players.',
-    }
 };
 
 const adapter: SimpleAdapter = {


### PR DESCRIPTION
It's a fix for recently merged [PR](https://github.com/DefiLlama/dimension-adapters/pull/6353) 

Summary
                                                                                                                                                                                                                 
  The previous adapter recomputed the revenue split client-side as fees × 0.45 / 0.50 / 0.05 across all fee sources. That assumption is wrong for ThorWallet: only THORChain, Maya, and Near Intents fees are    
  split 45/50/5 between protocol treasury / $TITN stakers / raffle pot. Fees from 1inch, Unizen, Chainflip, Harbor, and perpetual close fees go 100% to the protocol treasury for legal/compliance reasons. The
  old math misattributed non-shareable fees to stakers and the raffle pot.                                                                                                                                       
                                                         
  The /defillama/fees endpoint now returns the correctly bucketed dailyProtocolRevenue, dailyHoldersRevenue, and dailyRaffleRevenue fields, so the adapter just passes them through.                             
   
  Changes                                                                                                                                                                                                        
                                                         
  - fees/thorwallet/index.ts: replace dailyFees.clone(0.45/0.5/0.05, …) with direct reads of data.dailyProtocolRevenue, data.dailyHoldersRevenue, data.dailyRaffleRevenue.                                       
  - Update methodology and breakdownMethodology strings to reflect which fee sources are shared vs. 100%-to-treasury.
  - Fall back to '0' for dailyRaffleRevenue until the API change ships to prod — without it, parseFloat(undefined) is NaN and the SDK rejects it. The fallback becomes a no-op once the field is populated.