### PR TITLE
[feat] grelfswap - Add fees adapter

### DIFF
--- a/fees/grelfswap/index.ts
+++ b/fees/grelfswap/index.ts
@@ -1,38 +1,38 @@
-import { SimpleAdapter } from "../../adapters/types";
+import { FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
+import { METRIC } from "../../helpers/metrics";
 import { httpGet } from "../../utils/fetchURL";
 
-const fetchFees = async ({ startTimestamp }: { startTimestamp: number }) => {
+const fetchFees = async (_t: any, _b: any, options: FetchOptions) => {
+  const dailyFees = options.createBalances()
   const data = await httpGet(
-    `https://grelfswap.com/api/defillama/fees?startTimestamp=${startTimestamp}`
+    `https://grelfswap.com/api/defillama/fees?startTimestamp=${options.startTimestamp}`
   );
+  if (!data || data.dailyFeesUsd === undefined) {
+    throw new Error(`No data found for ${options.startTimestamp}`);
+  }
+  dailyFees.addUSDValue(data.dailyFeesUsd, METRIC.SWAP_FEES)
   return {
-    dailyFees: Number(data?.dailyFeesUsd ?? 0),
-    dailyRevenue: Number(data?.dailyFeesUsd ?? 0),
-    timestamp: startTimestamp,
+    dailyFees,
+    dailyRevenue: dailyFees,
   };
 };
 
 const adapter: SimpleAdapter = {
-  version: 2,
-  adapter: {
-    [CHAIN.HEDERA]: {
-      fetch: fetchFees,
-      start: 1762473600,
-      meta: {
-        methodology: {
-          Fees: "Platform fees collected on each swap (USD value of the fee taken from the input token).",
-          Revenue: "All platform fees go to the protocol treasury.",
-        },
-        breakdownMethodology: {
-          Fees: {
-            "Swap Fees": "Platform fee on the input token of each swap, computed as (feeAmount / fromAmount) × valueUsd at execution time.",
-          },
-          Revenue: {
-            "Swap Fees To Protocol": "Entire platform swap fee is retained by the protocol treasury (no token-holder distribution).",
-          },
-        },
-      },
+  version: 1,
+  chains: [CHAIN.HEDERA],
+  fetch: fetchFees,
+  start: '2025-11-07',
+  methodology: {
+    Fees: "Platform fees collected on each swap (USD value of the fee taken from the input token).",
+    Revenue: "All platform fees go to the protocol treasury.",
+  },
+  breakdownMethodology: {
+    Fees: {
+      [METRIC.SWAP_FEES]: "Platform fee on the input token of each swap, computed as (feeAmount / fromAmount) × valueUsd at execution time.",
+    },
+    Revenue: {
+      [METRIC.SWAP_FEES]: "Entire platform swap fee is retained by the protocol treasury (no token-holder distribution).",
     },
   },
 };

--- a/fees/grelfswap/index.ts
+++ b/fees/grelfswap/index.ts
@@ -1,0 +1,32 @@
+import { SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+
+const fetchFees = async ({ startTimestamp }: { startTimestamp: number }) => {
+  const response = await globalThis.fetch(
+    `https://grelfswap.com/api/defillama/fees?startTimestamp=${startTimestamp}`
+  );
+  const data = await response.json();
+  return {
+    dailyFees: data.dailyFeesUsd,
+    dailyRevenue: data.dailyFeesUsd,
+    timestamp: startTimestamp,
+  };
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  adapter: {
+    [CHAIN.HEDERA]: {
+      fetch: fetchFees,
+      start: 1762473600,
+      meta: {
+        methodology: {
+          Fees: "Platform fees collected on each swap (USD value of the fee taken from the input token).",
+          Revenue: "All platform fees go to the protocol treasury.",
+        },
+      },
+    },
+  },
+};
+
+export default adapter;

--- a/fees/grelfswap/index.ts
+++ b/fees/grelfswap/index.ts
@@ -1,14 +1,14 @@
 import { SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
+import { httpGet } from "../../utils/fetchURL";
 
 const fetchFees = async ({ startTimestamp }: { startTimestamp: number }) => {
-  const response = await globalThis.fetch(
+  const data = await httpGet(
     `https://grelfswap.com/api/defillama/fees?startTimestamp=${startTimestamp}`
   );
-  const data = await response.json();
   return {
-    dailyFees: data.dailyFeesUsd,
-    dailyRevenue: data.dailyFeesUsd,
+    dailyFees: Number(data?.dailyFeesUsd ?? 0),
+    dailyRevenue: Number(data?.dailyFeesUsd ?? 0),
     timestamp: startTimestamp,
   };
 };
@@ -23,6 +23,14 @@ const adapter: SimpleAdapter = {
         methodology: {
           Fees: "Platform fees collected on each swap (USD value of the fee taken from the input token).",
           Revenue: "All platform fees go to the protocol treasury.",
+        },
+        breakdownMethodology: {
+          Fees: {
+            "Swap Fees": "Platform fee on the input token of each swap, computed as (feeAmount / fromAmount) × valueUsd at execution time.",
+          },
+          Revenue: {
+            "Swap Fees To Protocol": "Entire platform swap fee is retained by the protocol treasury (no token-holder distribution).",
+          },
         },
       },
     },


### PR DESCRIPTION
Adds a fees adapter for GrelfSwap, complementing the volume adapter merged previously (protocol id 7713 on defillama-server).

- Endpoint: https://grelfswap.com/api/defillama/fees?startTimestamp={unix}
- Returns: { dailyFeesUsd, totalFeesUsd }
- Methodology: Platform fees are collected on the input token of each swap. USD value is computed at execution time as (feeAmount / fromAmount) × valueUsd, using the swap's recorded input notional. Stored per-swap in our database, summed by day.
- Revenue equals fees (no token-holder distribution).
- Start timestamp: 1762473600 (mainnet launch).

Will follow up with a PR on defillama-server to add fees: "grelfswap" to the dimensions field on entry 7713 once this merges.

Re-opening this PR with the correct base — the previous one (#1 on GrelfSwap/dimension-adapters) was accidentally targeted at my fork instead of upstream. Closed and recreated here against DefiLlama/dimension-adapters:master.
