### PR TITLE
Remove pullHourly from flying-tulip-lend (reports 0 fees)

### DIFF
--- a/fees/flying-tulip-lend.ts
+++ b/fees/flying-tulip-lend.ts
@@ -127,7 +127,6 @@ const adapter: SimpleAdapter = {
   version: 2,
   methodology,
   breakdownMethodology,
-  pullHourly: true,
   adapter: {
     [CHAIN.SONIC]: {
       fetch,

--- a/fees/flying-tulip-lend.ts
+++ b/fees/flying-tulip-lend.ts
@@ -32,7 +32,7 @@ const WAD = 10n ** 18n
 const SECONDS_PER_YEAR = 365n * 24n * 60n * 60n
 const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000'
 
-const fetch = async (options: FetchOptions) => {
+const fetch = async (_a: any, _b: any, options: FetchOptions) => {
   const dailyFees = options.createBalances()
   const dailySupplySideRevenue = options.createBalances()
   const dailyProtocolRevenue = options.createBalances()
@@ -124,7 +124,7 @@ const breakdownMethodology = {
 }
 
 const adapter: SimpleAdapter = {
-  version: 2,
+  version: 1, // Interests are low, no need to run every hour
   methodology,
   breakdownMethodology,
   adapter: {


### PR DESCRIPTION
## Summary

The merged adapter from #6457 has \`pullHourly: true\`, which the test runner slices into 24 hourly windows. Flying Tulip Lend currently has about \$10.8k of borrows protocol wide, so per hour interest is roughly \$0.04 combined across all reserves. runAdapter rounds each slice USD to an integer before aggregation, so the 24 slice sum is \$0 and the CI comment reports zero fees even though the underlying math is correct.

Removing \`pullHourly: true\` switches back to a single daily window and the adapter reports the expected \~\$1 of fees and \~\$1 of supply side revenue today. pullHourly can be reintroduced once borrows grow past the point where per hour figures stay above the integer rounding threshold (roughly \$1M of borrows assuming a 1 to 2 percent APR).

## Before / After

Before (hourly, from CI bot on #6457):

\`\`\`
Slice 0..23: Daily fees: 0.00 each
TOTAL DAILY AGGREGATED:
  Daily fees: 0.00
  Daily supply side revenue: 0.00
\`\`\`

After (local \`npm run test fees flying-tulip-lend.ts\`):

\`\`\`
SONIC
  Daily fees: 1.00
  Daily revenue: 0.00
  Daily protocol revenue: 0.00
  Daily supply side revenue: 1.00
\`\`\`

## Test plan

- [x] \`npm run test fees flying-tulip-lend.ts\` reports non zero daily fees
- [x] Numbers match manual calc: \$10.8k borrows \* weighted APR \* 1 day / year \~= \$0.54