### PR TITLE
[feature] eva - add fees adapter

### DIFF
--- a/fees/eva/index.ts
+++ b/fees/eva/index.ts
@@ -1,6 +1,7 @@
 import request, { gql } from "graphql-request";
 import { FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
+import { METRIC } from "../../helpers/metrics";
 
 const SUBGRAPH_URL = "https://gateway.eva.markets/subgraph";
 
@@ -58,13 +59,14 @@ const fetch = async ({ createBalances, startTimestamp, endTimestamp }: FetchOpti
   const skims = await fetchSkims(startTimestamp, endTimestamp);
   skims.forEach(({ amount, vault }) => {
     const underlying = VAULT_UNDERLYINGS[vault.toLowerCase()];
-    if (underlying) dailyFees.add(underlying, amount);
+    if (underlying) dailyFees.add(underlying, amount, METRIC.ASSETS_YIELDS);
   });
 
   return {
     dailyFees,
     dailyRevenue: dailyFees,
     dailyProtocolRevenue: dailyFees,
+    dailySupplySideRevenue: 0,
   };
 };
 
@@ -77,6 +79,18 @@ const adapter: SimpleAdapter = {
     Fees: "Yield skimmed from eva vault backing after holder obligations are covered.",
     Revenue: "Skimmed yield retained by the eva protocol treasury.",
     ProtocolRevenue: "Skimmed yield retained by the eva protocol treasury.",
+    SupplySideRevenue: "No supply-side revenue is distributed from skimmed yield.",
+  },
+  breakdownMethodology: {
+    Fees: {
+      [METRIC.ASSETS_YIELDS]: "Yield skimmed from eva vault backing after holder obligations are covered.",
+    },
+    Revenue: {
+      [METRIC.ASSETS_YIELDS]: "Skimmed yield retained by the eva protocol treasury.",
+    },
+    ProtocolRevenue: {
+      [METRIC.ASSETS_YIELDS]: "Skimmed yield retained by the eva protocol treasury.",
+    },
   },
 };
 

--- a/fees/eva/index.ts
+++ b/fees/eva/index.ts
@@ -1,0 +1,83 @@
+import request, { gql } from "graphql-request";
+import { FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+
+const SUBGRAPH_URL = "https://gateway.eva.markets/subgraph";
+
+const VAULT_UNDERLYINGS: Record<string, string> = {
+  "0x741bd193b6b40f8703d2e116fd1965421f290f58": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+  "0x501ebf66d76a96d4fb26ccead42957653e16b8b8": "0xdac17f958d2ee523a2206206994597c13d831ec7",
+  "0xdbecd077c1c2fefdcb75f547d1b5a73bf8207e4c": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+};
+
+type VaultSkim = {
+  amount: string;
+  vault: string;
+};
+
+type VaultSkimsResponse = {
+  VaultSkim: VaultSkim[];
+};
+
+const query = gql`
+  query VaultSkims($start: numeric!, $end: numeric!, $offset: Int!) {
+    VaultSkim(
+      where: { timestamp: { _gte: $start, _lt: $end } }
+      order_by: { timestamp: asc }
+      limit: 1000
+      offset: $offset
+    ) {
+      amount
+      vault
+    }
+  }
+`;
+
+async function fetchSkims(start: number, end: number) {
+  const skims: VaultSkim[] = [];
+  let offset = 0;
+
+  while (true) {
+    const response = await request<VaultSkimsResponse>(SUBGRAPH_URL, query, {
+      start: String(start),
+      end: String(end),
+      offset,
+    });
+
+    skims.push(...response.VaultSkim);
+    if (response.VaultSkim.length < 1000) break;
+    offset += 1000;
+  }
+
+  return skims;
+}
+
+const fetch = async ({ createBalances, startTimestamp, endTimestamp }: FetchOptions) => {
+  const dailyFees = createBalances();
+
+  const skims = await fetchSkims(startTimestamp, endTimestamp);
+  skims.forEach(({ amount, vault }) => {
+    const underlying = VAULT_UNDERLYINGS[vault.toLowerCase()];
+    if (underlying) dailyFees.add(underlying, amount);
+  });
+
+  return {
+    dailyFees,
+    dailyRevenue: dailyFees,
+    dailyProtocolRevenue: dailyFees,
+  };
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  fetch,
+  chains: [CHAIN.ETHEREUM],
+  start: "2026-03-24",
+  methodology: {
+    Fees: "Yield skimmed from eva vault backing after holder obligations are covered.",
+    Revenue: "Skimmed yield retained by the eva protocol treasury.",
+    ProtocolRevenue: "Skimmed yield retained by the eva protocol treasury.",
+  },
+};
+
+export default adapter;

--- a/fees/eva/index.ts
+++ b/fees/eva/index.ts
@@ -95,6 +95,7 @@ const fetch = async ({ createBalances, startTimestamp, endTimestamp }: FetchOpti
 
 const adapter: SimpleAdapter = {
   version: 2,
+  pullHourly: true,
   fetch,
   chains: [CHAIN.ETHEREUM],
   start: "2026-03-24",

--- a/fees/eva/index.ts
+++ b/fees/eva/index.ts
@@ -87,9 +87,9 @@ const fetch = async ({ createBalances, startTimestamp, endTimestamp }: FetchOpti
 
   return {
     dailyFees,
-    dailyRevenue: dailyFees,
-    dailyProtocolRevenue: dailyFees,
-    dailySupplySideRevenue: 0,
+    dailyRevenue: 0,
+    dailyProtocolRevenue: 0,
+    dailySupplySideRevenue: dailyFees,
   };
 };
 
@@ -100,19 +100,16 @@ const adapter: SimpleAdapter = {
   start: "2026-03-24",
   methodology: {
     Fees: "Yield skimmed from eva vault backing after holder obligations are covered.",
-    Revenue: "Skimmed yield retained by the eva protocol treasury.",
-    ProtocolRevenue: "Skimmed yield retained by the eva protocol treasury.",
-    SupplySideRevenue: "No supply-side revenue is distributed from skimmed yield.",
+    Revenue: "eva retains no protocol revenue from skimmed yield.",
+    ProtocolRevenue: "eva retains no protocol revenue from skimmed yield.",
+    SupplySideRevenue: "Skimmed yield is allocated back to users through LP incentives.",
   },
   breakdownMethodology: {
     Fees: {
       [METRIC.ASSETS_YIELDS]: "Yield skimmed from eva vault backing after holder obligations are covered.",
     },
-    Revenue: {
-      [METRIC.ASSETS_YIELDS]: "Skimmed yield retained by the eva protocol treasury.",
-    },
-    ProtocolRevenue: {
-      [METRIC.ASSETS_YIELDS]: "Skimmed yield retained by the eva protocol treasury.",
+    SupplySideRevenue: {
+      [METRIC.ASSETS_YIELDS]: "Skimmed yield allocated back to users through LP incentives.",
     },
   },
 };

--- a/fees/eva/index.ts
+++ b/fees/eva/index.ts
@@ -5,22 +5,25 @@ import { METRIC } from "../../helpers/metrics";
 
 const SUBGRAPH_URL = "https://gateway.eva.markets/subgraph";
 
-const VAULT_UNDERLYINGS: Record<string, string> = {
-  "0x741bd193b6b40f8703d2e116fd1965421f290f58": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
-  "0x501ebf66d76a96d4fb26ccead42957653e16b8b8": "0xdac17f958d2ee523a2206206994597c13d831ec7",
-  "0xdbecd077c1c2fefdcb75f547d1b5a73bf8207e4c": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
-};
-
 type VaultSkim = {
   amount: string;
   vault: string;
+};
+
+type Vault = {
+  address: string;
+  underlying: string;
 };
 
 type VaultSkimsResponse = {
   VaultSkim: VaultSkim[];
 };
 
-const query = gql`
+type VaultsResponse = {
+  Vault: Vault[];
+};
+
+const skimsQuery = gql`
   query VaultSkims($start: numeric!, $end: numeric!, $offset: Int!) {
     VaultSkim(
       where: { timestamp: { _gte: $start, _lt: $end } }
@@ -34,12 +37,21 @@ const query = gql`
   }
 `;
 
+const vaultsQuery = gql`
+  query Vaults {
+    Vault(limit: 1000) {
+      address
+      underlying
+    }
+  }
+`;
+
 async function fetchSkims(start: number, end: number) {
   const skims: VaultSkim[] = [];
   let offset = 0;
 
   while (true) {
-    const response = await request<VaultSkimsResponse>(SUBGRAPH_URL, query, {
+    const response = await request<VaultSkimsResponse>(SUBGRAPH_URL, skimsQuery, {
       start: String(start),
       end: String(end),
       offset,
@@ -53,13 +65,24 @@ async function fetchSkims(start: number, end: number) {
   return skims;
 }
 
+async function fetchVaultUnderlyings() {
+  const response = await request<VaultsResponse>(SUBGRAPH_URL, vaultsQuery);
+
+  return Object.fromEntries(response.Vault.map(({ address, underlying }) => [address.toLowerCase(), underlying]));
+}
+
 const fetch = async ({ createBalances, startTimestamp, endTimestamp }: FetchOptions) => {
   const dailyFees = createBalances();
 
-  const skims = await fetchSkims(startTimestamp, endTimestamp);
+  const [skims, vaultUnderlyings] = await Promise.all([
+    fetchSkims(startTimestamp, endTimestamp),
+    fetchVaultUnderlyings(),
+  ]);
+
   skims.forEach(({ amount, vault }) => {
-    const underlying = VAULT_UNDERLYINGS[vault.toLowerCase()];
-    if (underlying) dailyFees.add(underlying, amount, METRIC.ASSETS_YIELDS);
+    const underlying = vaultUnderlyings[vault.toLowerCase()];
+    if (!underlying) throw new Error(`eva: unmapped vault ${vault}`);
+    dailyFees.add(underlying, amount, METRIC.ASSETS_YIELDS);
   });
 
   return {


### PR DESCRIPTION
## Summary

Adds an eva fees adapter.

The adapter queries the eva gateway subgraph for `VaultSkim` records and reports skims as fees. These skims are allocated back to users through LP incentives, so eva protocol revenue is reported as zero.

## Listing details

- Project: eva
- Website: https://www.eva.markets
- Twitter: https://x.com/eva_markets
- Logo: https://www.eva.markets/figma/eva-logo.svg
- Chain: Ethereum
- Category: RWA

## Methodology

Daily fees are the sum of `VaultSkim.amount` events for each vault during the requested UTC window, mapped to the vault's underlying token. The same amount is reported as supply-side revenue because skimmed yield is allocated back to users through LP incentives. Daily revenue and daily protocol revenue are reported as zero.

## Validation

```bash
npm test fees eva
npm test fees eva 2026-04-16
npm run build
```
