### PR TITLE
refactor: standx fee adapters

### DIFF
--- a/dexs/standx/index.ts
+++ b/dexs/standx/index.ts
@@ -21,10 +21,13 @@ interface MarketInfo {
   v: number[];
 }
 
-const fetch = async (_a: any, _b: any, options: FetchOptions): Promise<FetchResultVolume> => {
-  const dailyVolume = options.createBalances();
+// NOTE: Take MM0 fee rate as reference to estimate trading fees
+export const PERPS_FEE_RATE = 0.0003;
+
+export async function getDailyVolume(options: FetchOptions): Promise<number> {
   const symbolsResponse: SymbolInfo[] = await fetchURL(`${apiEndpoint}/query_symbol_info`);
   const symbols = symbolsResponse.map((item) => item.symbol);
+  let totalVolUsd = 0;
 
   await PromisePool.withConcurrency(1).for(symbols).process(async (symbol) => {
     const marketInfo: MarketInfo = await fetchURLAutoHandleRateLimit(
@@ -33,14 +36,21 @@ const fetch = async (_a: any, _b: any, options: FetchOptions): Promise<FetchResu
     const todaysDataPositions = marketInfo.t
       .map((t: number, i: number) => (t >= options.startOfDay && t < options.endTimestamp ? i : -1))
       .filter((i: number) => i >= 0);
-    const volUsd = todaysDataPositions.reduce((acc: number, i: number) => acc + marketInfo?.v[i] * marketInfo?.c[i], 0);
-    dailyVolume.addUSDValue(volUsd);
+    totalVolUsd += todaysDataPositions.reduce((acc: number, i: number) => acc + marketInfo?.v[i] * marketInfo?.c[i], 0);
     await sleep(1000);
   });
 
-  return {
-    dailyVolume,
-  };
+  return totalVolUsd;
+}
+
+export async function getDailyFees(options: FetchOptions): Promise<number> {
+  return (await getDailyVolume(options)) * PERPS_FEE_RATE;
+}
+
+const fetch = async (_a: any, _b: any, options: FetchOptions): Promise<FetchResultVolume> => {
+  const dailyVolume = options.createBalances();
+  dailyVolume.addUSDValue(await getDailyVolume(options));
+  return { dailyVolume };
 };
 
 const methodology = {

--- a/fees/standx-dusd/index.ts
+++ b/fees/standx-dusd/index.ts
@@ -36,6 +36,7 @@ async function fetchSol(_a: any, _b: any, options: FetchOptions): Promise<FetchR
 
     return {
         dailyFees,
+        dailyRevenue: dailyFees
     }
 }
 

--- a/fees/standx-dusd/index.ts
+++ b/fees/standx-dusd/index.ts
@@ -4,7 +4,6 @@ import { queryDuneSql } from '../../helpers/dune';
 import { METRIC } from "../../helpers/metrics";
 
 const ABIs = {
-    claimYield: "event ClaimYield (address indexed user, uint256 amount)",
     withdrawRequest: "event WithdrawRequest (address indexed user, uint256 amount, uint256 id)"
 }
 
@@ -15,24 +14,16 @@ const STANDX_GATEWAY: any = {
 
 async function fetchSol(_a: any, _b: any, options: FetchOptions): Promise<FetchResult> {
     const dailyFees = options.createBalances();
-    const dailySupplySideRevenue = options.createBalances();
-    const dailyRevenue = options.createBalances();
 
     const duneQuery = `
         SELECT 
-            COALESCE(SUM(CASE WHEN bytearray_substring(data, 1, 8) = 0x314a6f07ba163da5 THEN 
-        bytearray_to_uint256(bytearray_reverse(bytearray_substring(data, 9, 8))) / 1e6 
-    END), 0) AS total_yield,
         COALESCE(SUM(CASE WHEN bytearray_substring(data, 1, 8) = 0x054d7820028fd610 THEN 
         bytearray_to_uint256(bytearray_reverse(bytearray_substring(data, 9, 8))) / 1e6 * 0.001 
     END), 0) AS total_withdrawal_fees
     
     FROM solana.instruction_calls 
     WHERE executing_account = '${STANDX_GATEWAY[options.chain]}' 
-        AND (
-        bytearray_substring(data, 1, 8) = 0x314a6f07ba163da5
-        OR bytearray_substring(data, 1, 8) = 0x054d7820028fd610
-    )
+        AND bytearray_substring(data, 1, 8) = 0x054d7820028fd610
     AND TIME_RANGE
     `
 
@@ -41,63 +32,36 @@ async function fetchSol(_a: any, _b: any, options: FetchOptions): Promise<FetchR
     if (!queryResults && !queryResults.length)
         throw new Error("No results found on dune");
 
-    dailyFees.addUSDValue(queryResults[0].total_yield, METRIC.ASSETS_YIELDS);
-    dailySupplySideRevenue.addUSDValue(queryResults[0].total_yield, METRIC.ASSETS_YIELDS);
-
     dailyFees.addUSDValue(queryResults[0].total_withdrawal_fees, METRIC.DEPOSIT_WITHDRAW_FEES);
-    dailyRevenue.addUSDValue(queryResults[0].total_withdrawal_fees, METRIC.DEPOSIT_WITHDRAW_FEES);
 
     return {
         dailyFees,
-        dailyRevenue,
-        dailySupplySideRevenue,
-        dailyProtocolRevenue: dailyRevenue
     }
 }
 
 async function fetch(_a: any, _b: any, options: FetchOptions): Promise<FetchResult> {
     const dailyFees = options.createBalances();
-    const dailyRevenue = options.createBalances();
-    const dailySupplySideRevenue = options.createBalances();
-
-    const yieldClaimLogs = await options.getLogs({
-        target: STANDX_GATEWAY[options.chain],
-        eventAbi: ABIs.claimYield
-    });
 
     const withdrawRequestLogs = await options.getLogs({
         target: STANDX_GATEWAY[options.chain],
         eventAbi: ABIs.withdrawRequest
     });
 
-    yieldClaimLogs.forEach(claim => {
-        dailyFees.addUSDValue(Number(claim.amount) / 1e6, METRIC.ASSETS_YIELDS);
-        dailySupplySideRevenue.addUSDValue(Number(claim.amount) / 1e6, METRIC.ASSETS_YIELDS);
-    });
-
     withdrawRequestLogs.forEach(request => {
         dailyFees.addUSDValue((Number(request.amount) / 1e6) * (0.1 / 100), METRIC.DEPOSIT_WITHDRAW_FEES);
-        dailyRevenue.addUSDValue((Number(request.amount) / 1e6) * (0.1 / 100), METRIC.DEPOSIT_WITHDRAW_FEES);
     });
 
     return {
         dailyFees,
-        dailyRevenue,
-        dailySupplySideRevenue,
-        dailyProtocolRevenue: dailyRevenue
     }
 }
 
 const methodology = {
-    Fees: "Includes yields received by DUSD holders in standx( via: Staking reward of ETH, SOL or any other assets, 2 Funding fee revenue) and 0.1% withdrawal fees",
-    Revenue: "0.1% withdrawal fees of DUSD",
-    SupplySideRevenue: "Yields distributed to DUSD holders(stablecoin suppliers)",
-    ProtocolRevenue: "0.1% withdrawal fees going to protocol treasury"
+    Fees: "0.1% withdrawal fees of DUSD",
 };
 
 const breakdownMethodology = {
     Fees: {
-        [METRIC.ASSETS_YIELDS]: "Yields received by DUSD holders in standx( via: Staking reward of ETH, SOL or any other assets)",
         [METRIC.DEPOSIT_WITHDRAW_FEES]: "0.1% DUSD withdrawal fees"
     }
 }

--- a/fees/standx-perps/index.ts
+++ b/fees/standx-perps/index.ts
@@ -1,0 +1,63 @@
+import { fetchURLAutoHandleRateLimit } from "../../utils/fetchURL";
+import { FetchOptions, FetchResult, SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import { PromisePool } from "@supercharge/promise-pool";
+import { sleep } from "../../utils/utils";
+import fetchURL from "../../utils/fetchURL";
+import { METRIC } from "../../helpers/metrics";
+
+const apiEndpoint = "https://perps.standx.com/api";
+
+// NOTE: Take MM0 fee rate as reference to estimate trading fees
+const PERPS_FEE_RATE = 0.0003;
+
+interface SymbolInfo {
+  symbol: string;
+  status: string;
+}
+
+interface MarketInfo {
+  s: string;
+  t: number[];
+  c: number[];
+  o: number[];
+  h: number[];
+  l: number[];
+  v: number[];
+}
+
+const fetch = async (_a: any, _b: any, options: FetchOptions): Promise<FetchResult> => {
+  const dailyFees = options.createBalances();
+  const symbolsResponse: SymbolInfo[] = await fetchURL(`${apiEndpoint}/query_symbol_info`);
+  const symbols = symbolsResponse.map((item) => item.symbol);
+
+  await PromisePool.withConcurrency(1).for(symbols).process(async (symbol) => {
+    const marketInfo: MarketInfo = await fetchURLAutoHandleRateLimit(
+      `${apiEndpoint}/kline/history?symbol=${symbol}&from=${options.startOfDay}&to=${options.endTimestamp}&resolution=60&countback=50`,
+    );
+    const todaysDataPositions = marketInfo.t
+      .map((t: number, i: number) => (t >= options.startOfDay && t < options.endTimestamp ? i : -1))
+      .filter((i: number) => i >= 0);
+    const volUsd = todaysDataPositions.reduce((acc: number, i: number) => acc + marketInfo?.v[i] * marketInfo?.c[i], 0);
+    dailyFees.addUSDValue(volUsd * PERPS_FEE_RATE, METRIC.TRADING_FEES);
+    await sleep(1000);
+  });
+
+  return {
+    dailyFees,
+  };
+};
+
+
+const methodology = {
+  Fees: "Perps trading fees estimated as dailyVolume",
+};
+
+const adapter: SimpleAdapter = {
+  fetch,
+  chains: [CHAIN.STANDX],
+  start: '2025-11-24',
+  methodology,
+};
+
+export default adapter;

--- a/fees/standx-perps/index.ts
+++ b/fees/standx-perps/index.ts
@@ -45,6 +45,7 @@ const fetch = async (_a: any, _b: any, options: FetchOptions): Promise<FetchResu
 
   return {
     dailyFees,
+    dailyRevenue: dailyFees,
   };
 };
 

--- a/fees/standx-perps/index.ts
+++ b/fees/standx-perps/index.ts
@@ -1,47 +1,11 @@
-import { fetchURLAutoHandleRateLimit } from "../../utils/fetchURL";
 import { FetchOptions, FetchResult, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
-import { PromisePool } from "@supercharge/promise-pool";
-import { sleep } from "../../utils/utils";
-import fetchURL from "../../utils/fetchURL";
 import { METRIC } from "../../helpers/metrics";
-
-const apiEndpoint = "https://perps.standx.com/api";
-
-// NOTE: Take MM0 fee rate as reference to estimate trading fees
-const PERPS_FEE_RATE = 0.0003;
-
-interface SymbolInfo {
-  symbol: string;
-  status: string;
-}
-
-interface MarketInfo {
-  s: string;
-  t: number[];
-  c: number[];
-  o: number[];
-  h: number[];
-  l: number[];
-  v: number[];
-}
+import { getDailyFees } from "../../dexs/standx";
 
 const fetch = async (_a: any, _b: any, options: FetchOptions): Promise<FetchResult> => {
   const dailyFees = options.createBalances();
-  const symbolsResponse: SymbolInfo[] = await fetchURL(`${apiEndpoint}/query_symbol_info`);
-  const symbols = symbolsResponse.map((item) => item.symbol);
-
-  await PromisePool.withConcurrency(1).for(symbols).process(async (symbol) => {
-    const marketInfo: MarketInfo = await fetchURLAutoHandleRateLimit(
-      `${apiEndpoint}/kline/history?symbol=${symbol}&from=${options.startOfDay}&to=${options.endTimestamp}&resolution=60&countback=50`,
-    );
-    const todaysDataPositions = marketInfo.t
-      .map((t: number, i: number) => (t >= options.startOfDay && t < options.endTimestamp ? i : -1))
-      .filter((i: number) => i >= 0);
-    const volUsd = todaysDataPositions.reduce((acc: number, i: number) => acc + marketInfo?.v[i] * marketInfo?.c[i], 0);
-    dailyFees.addUSDValue(volUsd * PERPS_FEE_RATE, METRIC.TRADING_FEES);
-    await sleep(1000);
-  });
+  dailyFees.addUSDValue(await getDailyFees(options), METRIC.TRADING_FEES);
 
   return {
     dailyFees,


### PR DESCRIPTION
Hi DefiLlama team! 👋

This PR introduces the new standx-perps fee adapter and refactors the existing standx-dusd adapter to ensure data accuracy and transparency.

- Added standx-perps Adapter

Estimated trading volume fees.

The current metric should include fees (previously not present), which track **Perps trading fees** 
<img width="1834" height="954" alt="image" src="https://github.com/user-attachments/assets/8475c007-c727-45f4-9d8f-e8f9a6c8a00e" />


The current metrics track **DUSD withdrawal fees** 
<img width="1838" height="936" alt="image" src="https://github.com/user-attachments/assets/56aa2cdd-d5df-4725-b520-34bddae9b991" />




The current metrics track **Perps trading fees** + **DUSD withdrawal fee** (total fees)
<img width="1854" height="940" alt="image" src="https://github.com/user-attachments/assets/f4c661a5-bd66-4e07-8ca7-9f639ccd4aca" />



- Refactored standx-dusd Adapter:
1. Optimized dailyFees logic: Improved the accuracy of fee data collection for DUSD.
2. Temporarily disabled Revenue fields (dailyRevenue, dailyProtocolRevenue, dailySupplySideRevenue )
The current calculation logic for these fields deviates from the project's actual operations. To avoid user confusion, we have decided to temporarily remove these metrics for methodology recalibration.

