### PR TITLE
feat(fees): add FrenFlow adapter

### DIFF
--- a/factory/polymarket.ts
+++ b/factory/polymarket.ts
@@ -5,6 +5,7 @@ const dexsConfigs: Record<string, { builder: string; start: string }> = {
   "based-predict": { builder: "Based", start: "2025-11-18" },
   "betmoar-fun": { builder: "betmoar", start: "2025-10-17" },
   "flowbot-prediction": { builder: "FlowBot", start: "2025-12-31" },
+  "frenflow": { builder: "FrenFlow", start: "2026-02-16" },
   "polycule": { builder: "Polycule", start: "2025-11-03" },
   "polytraderpro": { builder: "polytraderpro", start: "2025-10-22" },
   "stand-trade": { builder: "standtrade", start: "2025-10-10" },

--- a/fees/frenflow.ts
+++ b/fees/frenflow.ts
@@ -1,19 +1,27 @@
-import { Adapter, FetchOptions } from "../adapters/types";
+import { Adapter, FetchOptions, FetchV2 } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
 
 /**
  * FrenFlow — social copytrading + trading UI for prediction markets.
  * https://frenflow.com  ·  https://x.com/frenflow_
  *
- * Revenue model: a service fee (default 1%, dynamic on certain venues)
- * on every trade routed through FrenFlow's Safe wallet infrastructure
- * on Polymarket. At trade settlement, the FeeCollector contract pulls
- * the fee atomically (user → treasury) and emits a `FeeCollected` event
- * with the exact feeAmount. We sum those events for the period.
+ * Revenue model: a 1% service fee on manual trades routed through
+ * FrenFlow's Safe wallet infrastructure on Polymarket. At trade
+ * settlement, the FeeCollector contract pulls the fee atomically
+ * (user → treasury) and emits a `FeeCollected` event with the exact
+ * feeAmount. We sum those events for the period.
  *
- * Kalshi (Solana via DFlow) and Predict.fun (BSC) settle through
- * separate fee paths not yet tracked in this adapter. They account
- * for a small share of current volume and will be added as they grow.
+ * Volume for FrenFlow as a Polymarket builder is tracked separately
+ * through `factory/polymarket.ts` (Polymarket's official builder
+ * volume API). This file covers only the service-fee revenue.
+ *
+ * Income-statement mapping (per GUIDELINES):
+ *   dailyFees            — gross protocol revenue (all sources)
+ *   dailyUserFees        — portion directly paid by end-users
+ *                          (100% here: the fee is pulled from the
+ *                          user's wallet at trade settlement)
+ *   dailyRevenue         — gross profit (no supply-side to reimburse)
+ *   dailyProtocolRevenue — portion allocated to treasury (100%)
  */
 
 // Production FeeCollector on Polygon — live since 2026-04-20 (first V2
@@ -25,12 +33,11 @@ const FEE_COLLECTOR = "0x95e47CBC5c4D9434412AF44Ade02B33613EDb787";
 // `FeeCollected` event is denominated in this token.
 const USDC_E_POLYGON = "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174";
 
-const fetch: any = async ({ getLogs, createBalances }: FetchOptions) => {
+const FEE_LABEL = "Service Fees";
+
+const fetch: FetchV2 = async ({ getLogs, createBalances }: FetchOptions) => {
   const dailyFees = createBalances();
 
-  // Direct event-level aggregation. `feeAmount` is uint256 in USDC.e
-  // native decimals (6); DefiLlama's `balances.add(token, amount)`
-  // handles the decimals + market price internally.
   const logs = await getLogs({
     target: FEE_COLLECTOR,
     eventAbi:
@@ -38,11 +45,12 @@ const fetch: any = async ({ getLogs, createBalances }: FetchOptions) => {
   });
 
   for (const log of logs) {
-    dailyFees.add(USDC_E_POLYGON, log.feeAmount);
+    dailyFees.add(USDC_E_POLYGON, log.feeAmount, FEE_LABEL);
   }
 
   return {
     dailyFees,
+    dailyUserFees: dailyFees,
     dailyRevenue: dailyFees,
     dailyProtocolRevenue: dailyFees,
   };
@@ -56,7 +64,9 @@ const adapter: Adapter = {
   pullHourly: true,
   methodology: {
     Fees:
-      "Service fee (default 1%) pulled atomically user → treasury inside FrenFlow's FeeCollector contract on Polygon at Polymarket trade settlement.",
+      "Service fee (1%) pulled atomically user → treasury inside FrenFlow's FeeCollector contract on Polygon at Polymarket trade settlement.",
+    UserFees:
+      "100% of fees come directly from end-user wallets (the fee is transferFrom'd from the trader at fill).",
     Revenue:
       "All service fees flow directly to the FrenFlow treasury. No liquidity providers.",
     ProtocolRevenue:
@@ -64,12 +74,18 @@ const adapter: Adapter = {
   },
   breakdownMethodology: {
     Fees: {
-      "Service Fees":
-        "Per-trade service fee on Polymarket trades routed through FrenFlow. Denominated in USDC.e. Kalshi (Solana via DFlow) and Predict.fun (BSC) fee paths are not yet tracked in this adapter.",
+      [FEE_LABEL]:
+        "Per-trade 1% service fee on Polymarket trades routed through FrenFlow. Denominated in USDC.e. Tracked from the `FeeCollected` event on the FeeCollector contract.",
+    },
+    UserFees: {
+      [FEE_LABEL]: "Same as Fees — paid directly from the trader's wallet.",
     },
     Revenue: {
-      "Service Fees":
+      [FEE_LABEL]:
         "100% of collected service fees flow to the FrenFlow treasury at `0xb9e912e55454Ce284C38ccFED5b7fbbF327E689b`.",
+    },
+    ProtocolRevenue: {
+      [FEE_LABEL]: "Same as Revenue — fully retained by the protocol.",
     },
   },
 };

--- a/fees/frenflow.ts
+++ b/fees/frenflow.ts
@@ -1,0 +1,77 @@
+import { Adapter, FetchOptions } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+
+/**
+ * FrenFlow — social copytrading + trading UI for prediction markets.
+ * https://frenflow.com  ·  https://x.com/frenflow_
+ *
+ * Revenue model: a service fee (default 1%, dynamic on certain venues)
+ * on every trade routed through FrenFlow's Safe wallet infrastructure
+ * on Polymarket. At trade settlement, the FeeCollector contract pulls
+ * the fee atomically (user → treasury) and emits a `FeeCollected` event
+ * with the exact feeAmount. We sum those events for the period.
+ *
+ * Kalshi (Solana via DFlow) and Predict.fun (BSC) settle through
+ * separate fee paths not yet tracked in this adapter. They account
+ * for a small share of current volume and will be added as they grow.
+ */
+
+// Production FeeCollector on Polygon — live since 2026-04-20 (first V2
+// prod trade, tx 0xcd88b05b…). Contract: contracts/src/FeeCollector.sol
+const FEE_COLLECTOR = "0x95e47CBC5c4D9434412AF44Ade02B33613EDb787";
+
+// USDC.e (bridged) on Polygon — the only token the FeeCollector pulls.
+// pUSD-denominated Polymarket trades wrap into USDC.e pre-fee, so every
+// `FeeCollected` event is denominated in this token.
+const USDC_E_POLYGON = "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174";
+
+const fetch: any = async ({ getLogs, createBalances }: FetchOptions) => {
+  const dailyFees = createBalances();
+
+  // Direct event-level aggregation. `feeAmount` is uint256 in USDC.e
+  // native decimals (6); DefiLlama's `balances.add(token, amount)`
+  // handles the decimals + market price internally.
+  const logs = await getLogs({
+    target: FEE_COLLECTOR,
+    eventAbi:
+      "event FeeCollected(bytes32 indexed fillId, address indexed user, bytes32 indexed tokenId, uint8 service, uint256 tradeAmount, uint256 feeAmount, uint256 feeBps, uint256 timestamp)",
+  });
+
+  for (const log of logs) {
+    dailyFees.add(USDC_E_POLYGON, log.feeAmount);
+  }
+
+  return {
+    dailyFees,
+    dailyRevenue: dailyFees,
+    dailyProtocolRevenue: dailyFees,
+  };
+};
+
+const adapter: Adapter = {
+  version: 2,
+  chains: [CHAIN.POLYGON],
+  fetch,
+  start: "2026-04-20",
+  pullHourly: true,
+  methodology: {
+    Fees:
+      "Service fee (default 1%) pulled atomically user → treasury inside FrenFlow's FeeCollector contract on Polygon at Polymarket trade settlement.",
+    Revenue:
+      "All service fees flow directly to the FrenFlow treasury. No liquidity providers.",
+    ProtocolRevenue:
+      "Same as Revenue — 100% of collected fees are retained by the protocol.",
+  },
+  breakdownMethodology: {
+    Fees: {
+      "Service Fees":
+        "Per-trade service fee on Polymarket trades routed through FrenFlow. Denominated in USDC.e. Kalshi (Solana via DFlow) and Predict.fun (BSC) fee paths are not yet tracked in this adapter.",
+    },
+    Revenue: {
+      "Service Fees":
+        "100% of collected service fees flow to the FrenFlow treasury at `0xb9e912e55454Ce284C38ccFED5b7fbbF327E689b`.",
+    },
+  },
+};
+
+export default adapter;


### PR DESCRIPTION
## FrenFlow

Social copytrading + trading UI for Polymarket, Kalshi, and Predict.fun.

- **Website**: https://frenflow.com
- **Twitter**: https://x.com/frenflow_
- **Repo**: https://github.com/frenflow/frenflow_v1

## Revenue model

1% service fee on manual trades routed through FrenFlow's Safe wallet infrastructure on Polymarket. The fee is pulled atomically (user → treasury) inside the ${'`'}FeeCollector${'`'} contract at trade settlement, and emits a ${'`'}FeeCollected${'`'} event with the exact ${'`'}feeAmount${'`'}.

## Adapter methodology

Sums ${'`'}FeeCollected.feeAmount${'`'} per hour for the production FeeCollector on Polygon. Event-level aggregation — no token-transfer noise, no API dependency, fully on-chain.

## Contracts

- **FeeCollector** (prod, Polygon): [${'`'}0x95e47CBC5c4D9434412AF44Ade02B33613EDb787${'`'}](https://polygonscan.com/address/0x95e47CBC5c4D9434412AF44Ade02B33613EDb787) — live since 2026-04-20
- **Treasury**: [${'`'}0xb9e912e55454Ce284C38ccFED5b7fbbF327E689b${'`'}](https://polygonscan.com/address/0xb9e912e55454Ce284C38ccFED5b7fbbF327E689b) — final fee destination
- **First prod trade**: [${'`'}0xcd88b05b…${'`'}](https://polygonscan.com/tx/0xcd88b05b) (Scream 7 YES, verified tx)

Kalshi (Solana via DFlow) and Predict.fun (BSC) use separate fee paths not yet tracked here; will be added as they grow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)