### PR TITLE
Fix tBTC fee calculation

### DIFF
--- a/fees/tbtc.ts
+++ b/fees/tbtc.ts
@@ -1,22 +1,83 @@
 import ADDRESSES from '../helpers/coreAssets.json'
 import { FetchOptions, SimpleAdapter } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
+import { METRIC } from "../helpers/metrics";
+import { ethers } from "ethers";
 
+const BRIDGE = '0x5e4861a80B55f035D899f66772117F00FA0E8e7B'
+const BANK = '0x65Fbae61ad2C8836fFbFB502A0dA41b0789D9Fc6'
+const SATOSHI_MULTIPLIER = 10n ** 10n
 
-const eventUnminted = 'event Unminted(address indexed from,uint256 amount)'
+const eventBalanceIncreased = 'event BalanceIncreased(address indexed owner,uint256 amount)'
+const eventBalanceTransferred = 'event BalanceTransferred(address indexed from,address indexed to,uint256 amount)'
+const eventTreasuryUpdated = 'event TreasuryUpdated(address treasury)'
+
+const topicBalanceIncreased = ethers.id('BalanceIncreased(address,uint256)')
+const topicBalanceTransferred = ethers.id('BalanceTransferred(address,address,uint256)')
+const topicTreasuryUpdated = ethers.id('TreasuryUpdated(address)')
+
+const padAddress = (address: string) => ethers.zeroPadValue(address, 32)
+const normalizeAddress = (address: string) => address.toLowerCase()
+const toBigInt = (amount: any) => BigInt(amount.toString())
+
+const getTreasuryAddresses = async (options: FetchOptions) => {
+  const [startTreasury, endTreasury, treasuryUpdateLogs] = await Promise.all([
+    options.fromApi.call({ target: BRIDGE, abi: 'address:treasury' }),
+    options.toApi.call({ target: BRIDGE, abi: 'address:treasury' }),
+    options.getLogs({
+      target: BRIDGE,
+      eventAbi: eventTreasuryUpdated,
+      topics: [topicTreasuryUpdated],
+    }),
+  ])
+
+  const treasuries = new Set<string>([
+    normalizeAddress(startTreasury),
+    normalizeAddress(endTreasury),
+  ])
+
+  treasuryUpdateLogs.forEach((log: any) => {
+    treasuries.add(normalizeAddress(log.treasury))
+  })
+
+  return Array.from(treasuries)
+}
+
 const fetch = async (options: FetchOptions) => {
-  const logs = await options.getLogs({
-    target: '0x9C070027cdC9dc8F82416B2e5314E11DFb4FE3CD',
-    eventAbi: eventUnminted,
-  })
+  const treasuryAddresses = await getTreasuryAddresses(options)
+  const logSets = await Promise.all(
+    treasuryAddresses.map((treasury) =>
+      Promise.all([
+        options.getLogs({
+          target: BANK,
+          eventAbi: eventBalanceIncreased,
+          topics: [topicBalanceIncreased, padAddress(treasury)],
+        }),
+        options.getLogs({
+          target: BANK,
+          eventAbi: eventBalanceTransferred,
+          topics: [
+            topicBalanceTransferred,
+            padAddress(BRIDGE),
+            padAddress(treasury),
+          ],
+        }),
+      ])
+    )
+  )
+
   const dailyFees = options.createBalances()
-  logs.forEach((log) => {
-    const amount = log.amount
-    dailyFees.add(ADDRESSES.ethereum.tBTC, amount)
+  logSets.flat(2).forEach((log: any) => {
+    dailyFees.add(
+      ADDRESSES.ethereum.tBTC,
+      toBigInt(log.amount) * SATOSHI_MULTIPLIER,
+      METRIC.MINT_REDEEM_FEES
+    )
   })
-  dailyFees.resizeBy(0.002)
+
   return {
     dailyFees,
+    dailyUserFees: dailyFees,
     dailyRevenue: dailyFees,
     dailyProtocolRevenue: dailyFees,
   }
@@ -33,9 +94,10 @@ const adapter: SimpleAdapter = {
     }
   },
   methodology: {
-    Fees: "Charged 0.2% on unminted tbtc.",
-    Revenue: "Charged 0.2% on unminted tbtc.",
-    ProtocolRevenue: "Charged 0.2% on unminted tbtc.",
+    Fees: "tBTC treasury fees from minting and redemptions, tracked from Bank balance movements to the Bridge treasury. These movements contain the post-rebate amounts, so RebateStaking reductions are excluded.",
+    UserFees: "Same as fees; treasury fees paid by minters and redeemers.",
+    Revenue: "All tBTC treasury fees are protocol revenue.",
+    ProtocolRevenue: "All tBTC treasury fees are protocol revenue.",
   },
 }
 export default adapter;

--- a/fees/tbtc.ts
+++ b/fees/tbtc.ts
@@ -83,6 +83,19 @@ const fetch = async (options: FetchOptions) => {
   }
 }
 
+const methodology = {
+  Fees: "tBTC treasury fees from minting and redemptions, tracked from Bank balance movements to the Bridge treasury. These movements contain the post-rebate amounts, so RebateStaking reductions are excluded.",
+  UserFees: "Same as fees; treasury fees from minting and redemptions.",
+  Revenue: "All tBTC treasury fees paid by minting and redemptions are protocol revenue.",
+  ProtocolRevenue: "All tBTC treasury fees paid by minting and redemptions are protocol revenue.",
+}
+
+const breakdownMethodology = {
+  Fees: {
+    [METRIC.MINT_REDEEM_FEES]: "tBTC treasury fees from minting and redemptions, tracked from Bank balance movements to the Bridge treasury. These movements contain the post-rebate amounts, so RebateStaking reductions are excluded.",
+  },
+}
+
 
 const adapter: SimpleAdapter = {
   version: 2,
@@ -93,11 +106,7 @@ const adapter: SimpleAdapter = {
       start: '2023-01-23',
     }
   },
-  methodology: {
-    Fees: "tBTC treasury fees from minting and redemptions, tracked from Bank balance movements to the Bridge treasury. These movements contain the post-rebate amounts, so RebateStaking reductions are excluded.",
-    UserFees: "Same as fees; treasury fees paid by minters and redeemers.",
-    Revenue: "All tBTC treasury fees are protocol revenue.",
-    ProtocolRevenue: "All tBTC treasury fees are protocol revenue.",
-  },
+  methodology,
+  breakdownMethodology,
 }
 export default adapter;


### PR DESCRIPTION
## Summary
- replace the Unminted * 0.2% estimate with actual Bank treasury balance movements
- include deposit/mint treasury fees via BalanceIncreased(treasury)
- include redemption treasury fees via BalanceTransferred(Bridge, treasury)
- resolve treasury addresses dynamically from start/end blocks and TreasuryUpdated logs
- convert Bank satoshi-denominated amounts to tBTC token decimals

## Notes
This captures post-rebate amounts because tBTC applies RebateStaking before Bridge writes treasury fees to Bank.

## Test
- npm run test -- fees tbtc 2026-04-23
- npx tsc --noEmit --skipLibCheck --target ES2020 --moduleResolution node --module commonjs --esModuleInterop --resolveJsonModule fees/tbtc.ts
- git diff --check