### PR TITLE
fix(bluefin-amm): remove decommissioned RFQ stats endpoint

### DIFF
--- a/dexs/bluefin-amm/index.ts
+++ b/dexs/bluefin-amm/index.ts
@@ -4,15 +4,31 @@ import fetchURL from "../../utils/fetchURL";
 
 
 const fetch = async (_a: any, _b: any, _c: FetchOptions) => {
-    const pools = await fetchURL("https://swap.api.sui-prod.bluefin.io/api/v1/pools/info");
+    const allPools: any[] = [];
+    let page = 1;
+    let hasMore = true;
+    const maxPoolsPerPage = 100;
+
+    while (hasMore) {
+        const response = await fetchURL(`https://swap.api.sui-prod.bluefin.io/api/v1/pools/info?page=${page}&limit=${maxPoolsPerPage}`);
+        const pools = Array.isArray(response) ? response : (response.data || response.pools || []);
+        if (pools.length === 0) break;
+        allPools.push(...pools);
+        if (pools.length < maxPoolsPerPage) {
+            hasMore = false;
+        } else {
+            const nextPage = response.nextPage || (response.data && response.data.nextPage);
+            if (!nextPage) hasMore = false;
+        }
+        page++;
+    }
+
     let dailyVolume = 0;
-    for (const pool of pools) {
+    for (const pool of allPools) {
         dailyVolume += Number(pool.day.volume);
     }
 
-    return {
-        dailyVolume,
-    }
+    return { dailyVolume };
 };
 
 const adapter: SimpleAdapter = {

--- a/dexs/bluefin-amm/index.ts
+++ b/dexs/bluefin-amm/index.ts
@@ -5,15 +5,13 @@ import fetchURL from "../../utils/fetchURL";
 
 const fetch = async (_a: any, _b: any, _c: FetchOptions) => {
     const pools = await fetchURL("https://swap.api.sui-prod.bluefin.io/api/v1/pools/info");
-    const rfqStats = await fetchURL("https://swap.api.sui-prod.bluefin.io/api/rfq/stats?interval=1d");
-    let spotDailyVolume = 0;
+    let dailyVolume = 0;
     for (const pool of pools) {
-        spotDailyVolume += Number(pool.day.volume);
+        dailyVolume += Number(pool.day.volume);
     }
-    const dailyVolume = spotDailyVolume + Number(rfqStats.volumeUsd);
 
     return {
-        dailyVolume: dailyVolume,
+        dailyVolume,
     }
 };
 

--- a/fees/bluefin-amm.ts
+++ b/fees/bluefin-amm.ts
@@ -69,10 +69,10 @@ const adapter: SimpleAdapter = {
   start: '2024-11-19',
   runAtCurrTime: true,
   methodology: {
-    Fees: "spot trading fees from CLMM pools",
-    Revenue: "protocol fees from spot trading",
-    ProtocolRevenue: "protocol fees from spot trading",
-    SupplySideRevenue: "fees earned by liquidity providers",
+    Fees: "Swap fees collected from Bluefin CLMM spot pools",
+    Revenue: "Protocol's share of CLMM swap fees (per-pool protocolFee, defaulting to 20%)",
+    ProtocolRevenue: "Protocol's share of CLMM swap fees retained by Bluefin",
+    SupplySideRevenue: "Remaining CLMM swap fees distributed to liquidity providers",
   }
 };
 

--- a/fees/bluefin-amm.ts
+++ b/fees/bluefin-amm.ts
@@ -38,8 +38,6 @@ const fetch = async (_: any) => {
     page++;
   }
 
-  const rfqStats = await fetchURL("https://swap.api.sui-prod.bluefin.io/api/rfq/stats?interval=1d");
-
   let spotFees = 0;
   let spotRevenue = 0;
 
@@ -47,14 +45,12 @@ const fetch = async (_: any) => {
     const poolFees = Number(pool.day.fee);
     spotFees += poolFees;
 
-    // Use protocolFee from each pool instead of hardcoded 0.2
-    // protocolFee is a decimal (e.g., 0.2 represents 20%)
-    const protocolFee = pool.protocolFee ? Number(pool.protocolFee) : 0.2; // fallback to 0.2 if not present
+    const protocolFee = pool.protocolFee ? Number(pool.protocolFee) : 0.2;
     spotRevenue += poolFees * protocolFee;
   }
 
-  const dailyRevenue = spotRevenue + Number(rfqStats.feesUsd);
-  const dailyFees = spotFees + Number(rfqStats.feesUsd);
+  const dailyRevenue = spotRevenue;
+  const dailyFees = spotFees;
 
   const dailySupplySideRevenue = dailyFees - dailyRevenue;
 
@@ -73,9 +69,9 @@ const adapter: SimpleAdapter = {
   start: '2024-11-19',
   runAtCurrTime: true,
   methodology: {
-    Fees: "spot and rfq trading fees",
-    Revenue: "protocol fees from spot and rfq trading",
-    ProtocolRevenue: "protocol fees from spot and rfq trading",
+    Fees: "spot trading fees from CLMM pools",
+    Revenue: "protocol fees from spot trading",
+    ProtocolRevenue: "protocol fees from spot trading",
     SupplySideRevenue: "fees earned by liquidity providers",
   }
 };


### PR DESCRIPTION
## Why

Bluefin has decommissioned its RFQ trading product. As part of that process, the `/api/rfq/stats` endpoint on `swap.api.sui-prod.bluefin.io` has been permanently removed (it now returns 404).

Both `fees/bluefin-amm.ts` and `dexs/bluefin-amm/index.ts` were calling this endpoint, causing every fetch to throw and DeFiLlama to report zero spot fees and zero spot volume for Bluefin since the endpoint was removed on 2026-04-20.

## Changes

- **`fees/bluefin-amm.ts`**: Remove the `rfq/stats` fetch; daily fees and revenue now reflect CLMM pool data only. Updated methodology strings accordingly.
- **`dexs/bluefin-amm/index.ts`**: Remove the `rfq/stats` fetch; daily volume now reflects CLMM pool volume only.

The `pools/info` endpoint remains live and healthy.