### PR TITLE
[feat] megacube - add active users adapter

### DIFF
--- a/active-users/megacube.ts
+++ b/active-users/megacube.ts
@@ -1,0 +1,49 @@
+import { FetchOptions, SimpleAdapter } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+
+const MEGACUBE_V5 = "0x7ab966239f3b8cff285594c761424f11b672fd78";
+
+const BLOCK_DESTROYED_EVENT =
+  "event BlockDestroyed(address indexed destroyer, uint256 indexed layerId, uint256 containerId, uint256 blockId, uint256 licenseId)";
+
+const fetch = async ({ getLogs }: FetchOptions) => {
+  const logs = await getLogs({
+    target: MEGACUBE_V5,
+    eventAbi: BLOCK_DESTROYED_EVENT,
+    entireLog: true,
+  });
+
+  const users = new Set<string>();
+  const transactions = new Set<string>();
+
+  logs.forEach((log: any) => {
+    const destroyer = log.args?.destroyer;
+    const transactionHash = log.transactionHash;
+
+    if (destroyer) users.add(destroyer.toLowerCase());
+    if (transactionHash) transactions.add(transactionHash.toLowerCase());
+  });
+
+  return {
+    dailyActiveUsers: users.size,
+    dailyTransactionsCount: transactions.size,
+  };
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  adapter: {
+    [CHAIN.MEGAETH]: {
+      fetch,
+      start: "2026-04-22",
+    },
+  },
+  methodology: {
+    DailyActiveUsers:
+      "Counts unique destroyer addresses that emitted at least one BlockDestroyed event through the MegaCubeV5 contract.",
+    DailyTransactionsCount:
+      "Counts unique transaction hashes that emitted one or more BlockDestroyed events through the MegaCubeV5 contract. Batch mining operations are counted as one transaction.",
+  },
+};
+
+export default adapter;

--- a/active-users/megacube.ts
+++ b/active-users/megacube.ts
@@ -13,25 +13,22 @@ const fetch = async ({ getLogs }: FetchOptions) => {
     entireLog: true,
   });
 
-  const users = new Set<string>();
   const transactions = new Set<string>();
 
   logs.forEach((log: any) => {
-    const destroyer = log.args?.destroyer;
     const transactionHash = log.transactionHash;
 
-    if (destroyer) users.add(destroyer.toLowerCase());
     if (transactionHash) transactions.add(transactionHash.toLowerCase());
   });
 
   return {
-    dailyActiveUsers: users.size,
     dailyTransactionsCount: transactions.size,
   };
 };
 
 const adapter: SimpleAdapter = {
   version: 2,
+  pullHourly: true,
   adapter: {
     [CHAIN.MEGAETH]: {
       fetch,
@@ -39,8 +36,6 @@ const adapter: SimpleAdapter = {
     },
   },
   methodology: {
-    DailyActiveUsers:
-      "Counts unique destroyer addresses that emitted at least one BlockDestroyed event through the MegaCubeV5 contract.",
     DailyTransactionsCount:
       "Counts unique transaction hashes that emitted one or more BlockDestroyed events through the MegaCubeV5 contract. Batch mining operations are counted as one transaction.",
   },


### PR DESCRIPTION
## Summary
- Add a MegaCube active-users adapter for MegaETH.
- Count mining activity from `BlockDestroyed` logs on the production `MegaCubeV5` contract.
- Report unique transaction hashes as `dailyTransactionsCount`, so batch mining operations count as one transaction.

## Test plan
- `MEGAETH_RPC="https://rpc.megacorp.global" npm test active-users megacube 2026-04-27`

## Notes
- This intentionally does not report `dailyActiveUsers` with `pullHourly`, because the active-users pipeline sums hourly numeric outputs and would overcount operators active in multiple hours. The adapter focuses on mining transaction count, which is hourly-additive.