### PR TITLE
adds shapeswap-v3 and shapeswap-v2 dimension adapter slugs

### DIFF
--- a/factory/uniV2.ts
+++ b/factory/uniV2.ts
@@ -728,7 +728,7 @@ const configs: Record<string, Record<string, any>> = {
     [CHAIN.ZERO]: { factory: '0x1B4427e212475B12e62f0f142b8AfEf3BC18B559', start: '2025-01-07', userFeesRatio: 1, revenueRatio: 0, protocolRevenueRatio: 0, holdersRevenueRatio: 0 },
   },
   "shapeswap-v2": {
-    [CHAIN.SHAPE]: { factory: '0xb411eAF2f2070822B26E372E3Ea63c5060BA45E6', start: '2025-01-07', userFeesRatio: 1, revenueRatio: 0, protocolRevenueRatio: 0, holdersRevenueRatio: 0 },
+    [CHAIN.SHAPE]: { factory: '0xb411eAF2f2070822B26E372E3Ea63c5060BA45E6', start: '2024-12-13', userFeesRatio: 1, revenueRatio: 0, protocolRevenueRatio: 0, holdersRevenueRatio: 0 },
   },
   "hyperjump": {
     [CHAIN.BSC]: { factory: '0xac653ce27e04c6ac565fd87f18128ad33ca03ba2', start: '2020-11-10' },

--- a/factory/uniV2.ts
+++ b/factory/uniV2.ts
@@ -727,6 +727,9 @@ const configs: Record<string, Record<string, any>> = {
     [CHAIN.INK]: { factory: '0xfe57A6BA1951F69aE2Ed4abe23e0f095DF500C04', start: '2025-01-07', userFeesRatio: 1, revenueRatio: 0, protocolRevenueRatio: 0, holdersRevenueRatio: 0 },
     [CHAIN.ZERO]: { factory: '0x1B4427e212475B12e62f0f142b8AfEf3BC18B559', start: '2025-01-07', userFeesRatio: 1, revenueRatio: 0, protocolRevenueRatio: 0, holdersRevenueRatio: 0 },
   },
+  "shapeswap-v2": {
+    [CHAIN.SHAPE]: { factory: '0xb411eAF2f2070822B26E372E3Ea63c5060BA45E6', start: '2025-01-07', userFeesRatio: 1, revenueRatio: 0, protocolRevenueRatio: 0, holdersRevenueRatio: 0 },
+  },
   "hyperjump": {
     [CHAIN.BSC]: { factory: '0xac653ce27e04c6ac565fd87f18128ad33ca03ba2', start: '2020-11-10' },
     [CHAIN.FANTOM]: { factory: '0x991152411A7B5A14A8CF0cDDE8439435328070dF', start: '2021-04-19' },
@@ -1095,6 +1098,14 @@ const methodologyMap: Record<string, any> = {
     SupplySideRevenue: 'Swap fees distributed to LPs.',
   },
   "reservoir-tools-amm": {
+    Fees: 'Swap fees paid by users on each trade.',
+    UserFees: 'User pays fees on each swap.',
+    Revenue: 'Protocol has no revenue.',
+    ProtocolRevenue: 'Protocol has no revenue.',
+    SupplySideRevenue: 'All user fees are distributed among LPs.',
+    HoldersRevenue: 'Holders have no revenue.',
+  },
+  "shapeswap-v2": {
     Fees: 'Swap fees paid by users on each trade.',
     UserFees: 'User pays fees on each swap.',
     Revenue: 'Protocol has no revenue.',

--- a/factory/uniV3.ts
+++ b/factory/uniV3.ts
@@ -275,6 +275,10 @@ const configs: Record<string, Record<string, any>> = {
     [CHAIN.ABSTRACT]: { factory: '0xA1160e73B63F322ae88cC2d8E700833e71D0b2a1', start: '2025-01-07', userFeesRatio: 1, revenueRatio: 0, protocolRevenueRatio: 0, holdersRevenueRatio: 0 },
     [CHAIN.INK]: { factory: '0x640887A9ba3A9C53Ed27D0F7e8246A4F933f3424', start: '2025-01-07', userFeesRatio: 1, revenueRatio: 0, protocolRevenueRatio: 0, holdersRevenueRatio: 0 },
     [CHAIN.ZERO]: { factory: '0xA1160e73B63F322ae88cC2d8E700833e71D0b2a1', start: '2025-12-21', userFeesRatio: 1, revenueRatio: 0, protocolRevenueRatio: 0, holdersRevenueRatio: 0 },
+    [CHAIN.REDSTONE]: { factory: '0xece75613Aa9b1680f0421E5B2eF376DF68aa83Bb', start: '2025-01-07', userFeesRatio: 1, revenueRatio: 0, protocolRevenueRatio: 0, holdersRevenueRatio: 0 },
+  },
+  "shapeswap-v3": {
+    [CHAIN.SHAPE]: { factory: '0xeCf9288395797Da137f663a7DD0F0CDF918776F8', start: '2025-01-07', userFeesRatio: 1, revenueRatio: 0, protocolRevenueRatio: 0, holdersRevenueRatio: 0 },
   },
   "enosys": {
     [CHAIN.FLARE]: { factory: '0x17AA157AC8C54034381b840Cb8f6bf7Fc355f0de', start: "2025-03-03", userFeesRatio: 1, revenueRatio: 0.1, protocolRevenueRatio: 0.1 },
@@ -429,6 +433,14 @@ const methodologyMap: Record<string, any> = {
     SupplySideRevenue: "87.5% of swap fees are distributed to LPs and 5% is distributed to $SPRK stakers",
   },
   "reservoir-tools-clmm": {
+    Fees: "Swap fees paid by users on each trade.",
+    UserFees: "User pays fees on each swap.",
+    Revenue: "Protocol has no revenue.",
+    ProtocolRevenue: "Protocol has no revenue.",
+    SupplySideRevenue: "All user fees are distributed among LPs.",
+    HoldersRevenue: "Holders have no revenue.",
+  },
+  "shapeswap-v3": {
     Fees: "Swap fees paid by users on each trade.",
     UserFees: "User pays fees on each swap.",
     Revenue: "Protocol has no revenue.",

--- a/factory/uniV3.ts
+++ b/factory/uniV3.ts
@@ -278,7 +278,7 @@ const configs: Record<string, Record<string, any>> = {
     [CHAIN.REDSTONE]: { factory: '0xece75613Aa9b1680f0421E5B2eF376DF68aa83Bb', start: '2025-01-07', userFeesRatio: 1, revenueRatio: 0, protocolRevenueRatio: 0, holdersRevenueRatio: 0 },
   },
   "shapeswap-v3": {
-    [CHAIN.SHAPE]: { factory: '0xeCf9288395797Da137f663a7DD0F0CDF918776F8', start: '2025-01-07', userFeesRatio: 1, revenueRatio: 0, protocolRevenueRatio: 0, holdersRevenueRatio: 0 },
+    [CHAIN.SHAPE]: { factory: '0xeCf9288395797Da137f663a7DD0F0CDF918776F8', start: '2024-12-09', userFeesRatio: 1, revenueRatio: 0, protocolRevenueRatio: 0, holdersRevenueRatio: 0 },
   },
   "enosys": {
     [CHAIN.FLARE]: { factory: '0x17AA157AC8C54034381b840Cb8f6bf7Fc355f0de', start: "2025-03-03", userFeesRatio: 1, revenueRatio: 0.1, protocolRevenueRatio: 0.1 },


### PR DESCRIPTION

##### Name (to be shown on DefiLlama):

ShapeSwap (V3 CLMM). PR also adds a sibling entry **ShapeSwap AMM** for the V2 deployment.

##### Twitter Link:

https://x.com/shape

##### List of audit links if any:

None.

##### Website Link:

https://shapeswap.xyz/

##### Logo (High resolution, will be shown with rounded borders):

- rsz_shape.png — 2000×2000 (high quality)
- rsz_shape.jpg — 400×400

Both are referenced in `defi/src/protocols/data6.ts` via `${baseIconsUrl}/<name>.jpg`.

##### Current TVL:

~$80,515 on-chain.

Source: Shape Uniswap V3 subgraph at `https://graph.swap.w3us.site/subgraphs/name/shape/uniswap-v3`, factory `0xeCf9288395797Da137f663a7DD0F0CDF918776F8`.

DefiLlama currently shows ~$31,937 for Shape because **USDC.e is unpriced** in the oracle. The same PR adds the missing mapping in `coins/src/adapters/tokenMapping.json`, lifting reported TVL to match on-chain.

##### Treasury Addresses (if the protocol has treasury):

None.

##### Chain:

Shape (chain ID `360`).

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed):

https://www.coingecko.com/en/coins/shape

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed):

Leave empty.

(Reference: https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)

##### Short Description (to be shown on DefiLlama):

Concentrated-liquidity DEX on Shape chain. Uniswap V3 fork with a companion V2/AMM deployment.

##### Token address and ticker if any:

The protocol does not have its own token. Major traded tokens on Shape:

| Symbol | Address |
|---|---|
| WETH | `0x4200000000000000000000000000000000000006` |
| USDC.e | `0xdb7DD8B00EdC5778Fe00B2408bf35C7c054f8BBe` |
| SHAPE | `0x360aac543a23dbcefa8049d4c4d8b18da1cca360` (wrapped Shape native gas token) |

##### Category (full list at https://defillama.com/categories) *Please choose only one:

Dexs

##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.):

None (relies on Uniswap V3 native on-chain TWAP from pool tick observations).

##### Implementation Details: Briefly describe how the oracle is integrated into your project:

ShapeSwap is a Uniswap V3 fork. Pool prices are derived on-chain from `slot0.sqrtPriceX96` and the tick observation array; no external oracle is consulted by the protocol.

##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage:

- Uniswap V3 oracle reference: https://docs.uniswap.org/concepts/protocol/oracle
- ShapeSwap V3 factory on-chain: https://shapescan.xyz/address/0xeCf9288395797Da137f663a7DD0F0CDF918776F8
- Live subgraph: https://graph.swap.w3us.site/subgraphs/name/shape/uniswap-v3

##### forkedFrom (Does your project originate from another project):

- ShapeSwap (V3 CLMM): forks **Uniswap V3** — DefiLlama `forkedFromIds: ["2198"]`
- ShapeSwap AMM (V2): forks **Uniswap V2** — DefiLlama `forkedFromIds: ["2197"]`

##### methodology (what is being counted as tvl, how is tvl being calculated):

**TVL** is the USD value of token balances held by all pools deployed by the ShapeSwap factories on Shape:

| Variant | Factory | Module |
|---|---|---|
| V3 / CLMM | `0xeCf9288395797Da137f663a7DD0F0CDF918776F8` | `shapeswap-v3/index.js` (registry: `DefiLlama-Adapters/registries/uniswapV3.js`) |
| V2 / AMM | `0xb411eAF2f2070822B26E372E3Ea63c5060BA45E6` | `shapeswap-v2/index.js` (registry: `DefiLlama-Adapters/registries/uniswapV2.js`) |

Pool list is discovered from the factory's `PoolCreated` / `PairCreated` events. ERC20 balances are read on-chain from each pool address. USD conversion uses the DefiLlama coins-API oracle.

**Volume** and **fees** use the on-chain Swap-event path via `dimension-adapters/factory/uniV3.ts` slug `shapeswap-v3` (and `factory/uniV2.ts` slug `shapeswap-v2` for the AMM). Fees = volume × pool fee tier. All user fees are distributed to LPs; protocol takes no fee.

##### Github org/user (Optional, if your code is open source, we can track activity):

protofire

##### Does this project have a referral program?

No.