### PR TITLE
[fix] aave-chan - restore fee history

### DIFF
--- a/fees/aavechan.ts
+++ b/fees/aavechan.ts
@@ -12,6 +12,7 @@ type AaveCollectorStream = {
 }
 
 const STREAMS: AaveCollectorStream[] = [
+  // CreateStream: block 19847355, 2024-05-11T14:21:59Z, tx 0x555405ac26f71bf76ce2ae4550523e94b5f7a2ca1179b40c21eedf6d1628fd6e.
   {
     streamId: 100034,
     tokenAddress: "0x40D16FC0246aD3160Ccc09B8D0D3A2cD28aE6C2f",
@@ -19,6 +20,8 @@ const STREAMS: AaveCollectorStream[] = [
     stopTime: 1746973319,
     ratePerSecond: 31709791983764586n,
   },
+  // CreateStream: block 23754744, 2025-11-08T13:09:35Z, tx 0x138d1ee42253e852aebfe53644db4c05bf85853373a698b85a5e8297fc21959d.
+  // CancelStream: block 24613978, 2026-03-08T16:36:11Z, tx 0xbe58a065c938fa64e141a3303be9bfc042de319431a62abd43f40b787f9f3b45.
   {
     streamId: 100070,
     tokenAddress: "0x18eFE565A5373f430e2F809b97De30335B3ad96A",

--- a/fees/aavechan.ts
+++ b/fees/aavechan.ts
@@ -2,48 +2,77 @@ import { FetchOptions, FetchResultV2, SimpleAdapter } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
 import { METRIC } from "../helpers/metrics";
 
-const SUPERFLUID_CONTRACT = "0x464C71f6c2F760DdA6093dCB91C24c39e5d6e18c";
-const STREAM_ID = 100034;
-
-const ABI = {
-  getStream:  "function getStream(uint256 streamId) view returns (address sender, address recipient, uint256 deposit, address tokenAddress, uint256 startTime, uint256 stopTime, uint256 remainingBalance, uint256 ratePerSecond)"
+type AaveCollectorStream = {
+  streamId: number;
+  tokenAddress: string;
+  startTime: number;
+  stopTime: number;
+  canceledAt?: number;
+  ratePerSecond: bigint;
 }
+
+const STREAMS: AaveCollectorStream[] = [
+  {
+    streamId: 100034,
+    tokenAddress: "0x40D16FC0246aD3160Ccc09B8D0D3A2cD28aE6C2f",
+    startTime: 1715437319,
+    stopTime: 1746973319,
+    ratePerSecond: 31709791983764586n,
+  },
+  {
+    streamId: 100070,
+    tokenAddress: "0x18eFE565A5373f430e2F809b97De30335B3ad96A",
+    startTime: 1762607375,
+    stopTime: 1794143375,
+    canceledAt: 1772987771,
+    ratePerSecond: 95129375951293759n,
+  },
+];
 
 const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
   const dailyFees = options.createBalances();
+  const dailyProtocolRevenue = options.createBalances();
 
-  const stream = await options.toApi.call({
-    abi: ABI.getStream,
-    target: SUPERFLUID_CONTRACT,
-    params: [STREAM_ID]
-  });
+  for (const stream of STREAMS) {
+    const endTime = Math.min(stream.stopTime, stream.canceledAt ?? stream.stopTime);
+    const activeStart = Math.max(options.startTimestamp, stream.startTime);
+    const activeEnd = Math.min(options.endTimestamp, endTime);
+    const activeSeconds = activeEnd - activeStart;
+    if (activeSeconds <= 0) continue;
 
-  const ratePerSecond = stream.ratePerSecond;
-  const SECONDS_PER_DAY = 86400;
-  const dailyRate = ratePerSecond * SECONDS_PER_DAY;
-
-  dailyFees.add(stream.tokenAddress, dailyRate, METRIC.MANAGEMENT_FEES);
+    const fees = stream.ratePerSecond * BigInt(activeSeconds);
+    dailyFees.add(stream.tokenAddress, fees, METRIC.MANAGEMENT_FEES);
+    dailyProtocolRevenue.add(stream.tokenAddress, fees, METRIC.MANAGEMENT_FEES);
+  }
 
   return {
     dailyFees,
-    dailyRevenue: dailyFees,
+    dailyRevenue: dailyProtocolRevenue,
+    dailyProtocolRevenue,
   };
 }
 
 const breakdownMethodology = {
   Fees: {
-    [METRIC.MANAGEMENT_FEES]: 'Daily fees calculated from the AAVE incentive stream rate distributed to AaveChan via a Superfluid constant flow agreement.',
+    [METRIC.MANAGEMENT_FEES]: 'Fees accrued linearly from Aave Collector streams distributed to Aave-Chan.',
+  },
+  Revenue: {
+    [METRIC.MANAGEMENT_FEES]: 'Fees accrued linearly from Aave Collector streams distributed to Aave-Chan.',
+  },
+  ProtocolRevenue: {
+    [METRIC.MANAGEMENT_FEES]: 'Fees accrued linearly from Aave Collector streams distributed to Aave-Chan.',
   },
 };
 
 const adapter: SimpleAdapter = {
   fetch,
   chains: [CHAIN.ETHEREUM],
-  start: "2023-01-01",
+  start: "2024-05-11",
   version: 2,
   methodology: {
-    Fees: "Incentive stream distribution via Superfluid.",
-    Revenue: "Incentive stream distribution via Superfluid.",
+    Fees: "Aave Collector stream distributions to Aave-Chan.",
+    Revenue: "Aave Collector stream distributions to Aave-Chan.",
+    ProtocolRevenue: "Aave Collector stream distributions to Aave-Chan.",
   },
   breakdownMethodology,
 }

--- a/fees/aavechan.ts
+++ b/fees/aavechan.ts
@@ -71,6 +71,7 @@ const adapter: SimpleAdapter = {
   fetch,
   chains: [CHAIN.ETHEREUM],
   start: "2024-05-11",
+  deadFrom: "2026-03-08",
   version: 2,
   methodology: {
     Fees: "Aave Collector stream distributions to Aave-Chan.",


### PR DESCRIPTION
## Summary
- Restore Aave-Chan fee history by replacing the deleted-stream getStream lookup with explicit Aave Collector stream intervals for streams 100034 and 100070.
- Clip stream accounting to the active seconds in each adapter window, including the stream 100070 cancellation time.
- Return fees, revenue, and protocol revenue from the same verified stream accrual.

## Context
- Fixes DefiLlama/dimension-adapters#6514.
- Stream data was verified from Aave Collector CreateStream and CancelStream logs.
- The previous adapter called getStream on a stream id that now reverts after deletion/cancellation, so current runs could fail instead of returning the historical stream accrual.

## Validation
- pnpm test fees aavechan 2025-02-03
- pnpm test fees aavechan 2026-02-03
- pnpm test fees aavechan 2026-04-26
- pnpm run ts-check
- pnpm run build
