### PR TITLE
[fix] bucket-protocol - end legacy BUCK fees source

### DIFF
--- a/fees/bucket-protocol/index.ts
+++ b/fees/bucket-protocol/index.ts
@@ -49,6 +49,7 @@ const adapter: Adapter = {
     [CHAIN.SUI]: {
       fetch: fetchBucketStats,
       start: "2024-02-29",
+      deadFrom: "2025-09-01",
     },
   },
 }

--- a/fees/bucket-protocol/index.ts
+++ b/fees/bucket-protocol/index.ts
@@ -49,7 +49,7 @@ const adapter: Adapter = {
     [CHAIN.SUI]: {
       fetch: fetchBucketStats,
       start: "2024-02-29",
-      deadFrom: "2025-09-01",
+      deadFrom: "2025-10-08",
     },
   },
 }


### PR DESCRIPTION
## Summary
- mark the legacy Bucket Protocol fees source as ended after its last available fee window
- preserve historical legacy Bucket/CDP fee rows through the final working open-api day
- leave current Bucket USDB/V2 fees active through the existing `bucket-protocol-v2` backend adapter

## Context
- Fixes DefiLlama/dimension-adapters#6496.
- The old `open-api.bucketprotocol.io/api/fees` endpoint no longer returns daily fee data for current dates.
- Bucket's current docs describe the legacy BUCK/CDP to USDB/CDP migration, while `bucket-protocol-v2` continues to report current fees from `backend.bucketprotocol.io/api/fee/dailystatus`.

## Validation
- `pnpm test fees bucket-protocol 2025-10-08`
- `pnpm test fees bucket-protocol 2025-10-09`
- `pnpm test fees bucket-protocol 2025-10-10`
- `pnpm test fees bucket-protocol 2026-04-28`
- `pnpm test fees bucket-protocol-v2 2026-04-28`
- `pnpm run ts-check`
- `git diff --check`
