### PR TITLE
Fix canto chain fees

### DIFF
--- a/helpers/blockscoutFees.ts
+++ b/helpers/blockscoutFees.ts
@@ -229,8 +229,7 @@ export function blockscoutFeeAdapter2(chain: string) {
             console.log(chain, ' Error fetching fees', fees)
             throw new Error('Error fetching fees')
           }
-          if (chain == CHAIN.CANTO && CGToken) dailyFees.addCGToken(CGToken, fees.gas_used_today * fees.gas_prices.average / 1e18)
-          else if (CGToken) dailyFees.addCGToken(CGToken, fees.result / 1e18)
+          if (CGToken) dailyFees.addCGToken(CGToken, fees.result / 1e18)
           else dailyFees.addGasToken(fees.result)
 
           if (config.burnRatio !== undefined && config.burnRatio !== null) {


### PR DESCRIPTION
## Summary                                                                                                     
                                                                                                              
  - Remove broken Canto-specific fee calculation in blockscout helper that relied on gas_used_today and
  gas_prices.average fields no longer returned by the Canto explorer API                                      
  - Canto's explorer now returns the standard blockscout result format, so it uses the same code path as all
  other chains, https://explorer.plexnode.wtf/api?module=stats&action=totalfees&date=2025-01-01 
  
Fixes #6519