### PR TITLE
[fix] ribbon - end inactive fees adapter

### DIFF
--- a/fees/ribbon/index.ts
+++ b/fees/ribbon/index.ts
@@ -82,6 +82,7 @@ const fetch = async (
 
 const adapter: Adapter = {
   version: 2,
+  deadFrom: '2025-04-22',
   adapter: {
     [CHAIN.ETHEREUM]: {
       fetch,


### PR DESCRIPTION
Fixes DefiLlama/dimension-adapters#6528

## Summary
- add a `deadFrom` date for Ribbon fees using the last available DeFiLlama fee chart day, 2025-04-22
- preserve historical Ribbon fee data while preventing current runs from querying the now-gated subgraphs

## Context
`pnpm test fees ribbon 2026-04-26` currently fails against The Graph with `auth error: payment required for subsequent requests for this API key`. DeFiLlama fee summary has no current 24h/48h data for Ribbon and its last charted fee day is 2025-04-22.

## Validation
- `pnpm test fees ribbon 2026-04-26`
- `pnpm run ts-check`