### PR TITLE
[fix] llamalend - move to onchain

### DIFF
--- a/fees/llamalend.ts
+++ b/fees/llamalend.ts
@@ -43,6 +43,7 @@ const graphs = (graphUrls: ChainEndpoints) => {
 
 
 const adapter: Adapter = {
+  deadFrom: '2026-01-09',
   adapter: {
     [CHAIN.ETHEREUM]: {
       fetch: graphs(endpoints)(CHAIN.ETHEREUM),

--- a/fees/llamalend.ts
+++ b/fees/llamalend.ts
@@ -1,63 +1,77 @@
-import * as sdk from "@defillama/sdk";
 import { Adapter } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
-import { request, } from "graphql-request";
-import type { ChainBlocks, ChainEndpoints, FetchOptions } from "../adapters/types"
-import { Chain } from  "../adapters/types";
+import type { FetchOptions } from "../adapters/types"
 
-const endpoints = {
-  [CHAIN.ETHEREUM]: sdk.graph.modifyEndpoint('7cG6NVPRm4CQmfVsh4d1bYGqaWNazRyVTn3xuvdDRNPi'),
+const POOL_ADDRESS = '0x55F9F26b3d7a4459205c70994c11775629530eA5'
+const DEPLOY_BLOCK = 15819910
+
+const ABIs = {
+  poolCreated: 'event PoolCreated(address indexed,address indexed ,address)',
+  loanCreated: 'event LoanCreated(uint256 indexed loanId, uint256 nft, uint256 interest, uint256 startTime, uint216 borrowed)',
+  ownerOf: 'function ownerOf(uint256 tokenId) view returns (address)',
 }
-const ONE_DAY_IN_SECONDS = 60 * 60 * 24
 
-interface IGraph {
-  interest: string;
-  borrowed: string;
-}
-const graphs = (graphUrls: ChainEndpoints) => {
-  return (chain: Chain) => {
-    return async (timestamp: number , _: ChainBlocks, { createBalances, getToBlock }: FetchOptions) => {
-      const dailyFees = createBalances();
-      const block = await getToBlock()
-      const graphQuery = `
-      {
-        loans(where:{owner_not: null}, block:{ number: ${block}}) {
-          interest
-          borrowed
-        }
-      }
-      `;
+const fetch = async (options: FetchOptions) => {
+  const dailyFees = options.createBalances();
 
-      const graphRes: IGraph[] = (await request(graphUrls[chain], graphQuery)).loans;
-      graphRes.map((b: IGraph) => dailyFees.addGasToken((Number(b.interest) * Number(b.borrowed) * ONE_DAY_IN_SECONDS / 1e18)))
+  const poolCreatedLogs = await options.getLogs({
+    target: POOL_ADDRESS,
+    eventAbi: ABIs.poolCreated,
+    fromBlock: DEPLOY_BLOCK,
+    cacheInCloud: true,
+  })
 
-      return {
-        timestamp: timestamp,
-        dailyFees,
-        dailyUserFees: dailyFees,
-        dailySupplySideRevenue: dailyFees,
-      };
-    };
+  const pools = poolCreatedLogs.map(log => log[2]);
+
+  const loans = await options.getLogs({
+    targets: pools,
+    eventAbi: ABIs.loanCreated,
+    fromBlock: DEPLOY_BLOCK,
+    cacheInCloud: true,
+    flatten: false,
+  });
+
+  const owners = await options.api.multiCall({
+    abi: ABIs.ownerOf,
+    calls: pools.flatMap((pool, poolIndex) =>
+      loans[poolIndex].map((loan: any) => ({ target: pool, params: [loan.loanId] }))
+    ),
+    permitFailure: true,
+  });
+
+  loans.flat().forEach((loan, index) => {
+    const isLoanActive = owners[index]
+    if (isLoanActive) {
+      const dailyInterest = BigInt(loan.interest) * BigInt(loan.borrowed) * BigInt(options.endTimestamp - options.startTimestamp) / 10n ** 18n;
+      dailyFees.addGasToken(dailyInterest);
+    }
+  });
+
+  return {
+    dailyFees,
+    dailyUserFees: dailyFees,
+    dailySupplySideRevenue: dailyFees,
+    dailyRevenue: 0,
+    dailyProtocolRevenue: 0,
+    dailyHoldersRevenue: 0,
   };
 };
 
 
 const adapter: Adapter = {
-  deadFrom: '2026-01-09',
-  adapter: {
-    [CHAIN.ETHEREUM]: {
-      fetch: graphs(endpoints)(CHAIN.ETHEREUM),
-      start: '2022-11-01',
-    },
-  },
-        methodology: {
-          Fees: "Interest paid by borrowers",
-          UserFees: "Interest paid to borrow ETH",
-          SupplySideRevenue: "Interest paid to NFTs lenders",
-          Revenue: "Governance have no revenue",
-          HoldersRevenue: "Token holders have no revenue",
-          ProtocolRevenue: "Protocol have no revenue"
-        }
+  version: 2,
+  pullHourly: true,
+  fetch,
+  start: '2022-11-01',
+  chains: [CHAIN.ETHEREUM],
+  methodology: {
+    Fees: "Interest paid by borrowers",
+    UserFees: "Interest paid to borrow ETH",
+    SupplySideRevenue: "Interest paid to NFTs lenders",
+    Revenue: "Governance have no revenue",
+    HoldersRevenue: "Token holders have no revenue",
+    ProtocolRevenue: "Protocol have no revenue"
+  }
 }
 
 export default adapter;


### PR DESCRIPTION
Fixes DefiLlama/dimension-adapters#6527

## Summary
- add a `deadFrom` date for the legacy Llamalend fees adapter using the last available DeFiLlama fee chart day, 2026-01-09
- keep historical Llamalend fee data intact while avoiding current runs against the gated subgraph endpoint

## Context
`pnpm test fees llamalend 2026-04-26` currently fails against The Graph with `auth error: payment required for subsequent requests for this API key`. DeFiLlama fee summary has no current 24h/48h data for `llamalend`, and the last charted fee day is 2026-01-09.

## Validation
- `pnpm test fees llamalend 2026-04-26`
- `pnpm run ts-check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Updates**
  * LlamaLend fees adapter upgraded to version 2 with improved data collection methodology and hourly update frequency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DefiLlama/dimension-adapters/pull/6552)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->