### PR TITLE
[fix] ferro - move adapters on-chain

### DIFF
--- a/dexs/ferro/index.ts
+++ b/dexs/ferro/index.ts
@@ -1,29 +1,18 @@
 import { FetchOptions, SimpleAdapter } from "../../adapters/types";
-import { getChainVolume2 } from "../../helpers/getUniSubgraphVolume";
 import { CHAIN } from "../../helpers/chains";
-import request, { gql } from "graphql-request";
+import { getSaddleVolume } from "../../helpers/saddle";
 
-const endpoints = {
-  [CHAIN.CRONOS]: "https://graph.cronoslabs.com/subgraphs/name/ferro/swap",
-};
-
-interface IVolume {
-  volume: string;
-}
+const pools = [
+  '0xe8d13664a42B338F009812Fa5A75199A865dA5cD',
+  '0xa34C0fE36541fB085677c36B4ff0CCF5fa2B32d6',
+  '0x1578C5CF4f8f6064deb167d1eeAD15dF43185afa',
+  '0x5FA9412C2563c0B13CD9F96F0bd1A971F8eBdF96',
+];
 
 const fetchVolume = async (options: FetchOptions) => {
-  const query = gql`
-    {
-      dailyVolumes(where:{timestamp: "${options.startOfDay}"}){
-        timestamp
-        volume
-      }
-    }
-  `
-  const res:IVolume[] = (await request(endpoints[options.chain], query)).dailyVolumes as IVolume[];
-  const dailyVolume = res.reduce((acc, item) => acc + Number(item.volume), 0);
+  const { dailyVolume } = await getSaddleVolume(options, pools);
   return {
-    dailyVolume: dailyVolume,
+    dailyVolume,
   };
 }
 
@@ -38,12 +27,3 @@ const adapter: SimpleAdapter = {
 };
 
 export default adapter;
-
-/* ON chain
-import { CHAIN } from "../helpers/chains";
-import { getSaddleExports } from "../helpers/saddle";
-
-export default getSaddleExports({
-  [CHAIN.CRONOS]: { pools: ['0xe8d13664a42B338F009812Fa5A75199A865dA5cD', '0xa34C0fE36541fB085677c36B4ff0CCF5fa2B32d6', '0x1578C5CF4f8f6064deb167d1eeAD15dF43185afa', '0x5FA9412C2563c0B13CD9F96F0bd1A971F8eBdF96']}
-})
- */

--- a/dexs/ferro/index.ts
+++ b/dexs/ferro/index.ts
@@ -18,6 +18,7 @@ const fetchVolume = async (options: FetchOptions) => {
 
 const adapter: SimpleAdapter = {
   version: 2,
+  pullHourly: true,
   adapter: {
     [CHAIN.CRONOS]: {
       fetch: fetchVolume,

--- a/fees/ferro.ts
+++ b/fees/ferro.ts
@@ -1,38 +1,25 @@
 import { FetchOptions, SimpleAdapter } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
-import request, { gql } from "graphql-request";
+import { getSaddleVolume } from "../helpers/saddle";
 
-const endpoints: any = {
-  [CHAIN.CRONOS]: "https://graph.cronoslabs.com/subgraphs/name/ferro/swap",
-};
-
-interface IVolume {
-  volume: string;
-}
+const pools = [
+  '0xe8d13664a42B338F009812Fa5A75199A865dA5cD',
+  '0xa34C0fE36541fB085677c36B4ff0CCF5fa2B32d6',
+  '0x1578C5CF4f8f6064deb167d1eeAD15dF43185afa',
+  '0x5FA9412C2563c0B13CD9F96F0bd1A971F8eBdF96',
+];
 
 const fetch = async (options: FetchOptions) => {
-  const query = gql`
-    {
-      dailyVolumes(where:{timestamp: "${options.startOfDay}"}){
-        timestamp
-        volume
-      }
-    }
-  `
-  const res:IVolume[] = (await request(endpoints[options.chain], query)).dailyVolumes as IVolume[];
-  const dailyVolume = res.reduce((acc, item) => acc + Number(item.volume), 0);
-  const dailyFees = dailyVolume * (0.04 /100);
-  const dailyUserFees = dailyFees;
-  const dailyRevenue = dailyVolume * (0.02 /100);
-  const dailyHoldersRevenue = dailyVolume * (0.016 /100);
-  const dailySupplySideRevenue = dailyVolume * (0.02 /100);
+  const { dailyVolume, dailyFees, dailyRevenue, dailySupplySideRevenue } = await getSaddleVolume(options, pools);
 
   return {
     dailyFees,
-    dailyUserFees: dailyUserFees,
+    dailyUserFees: dailyFees,
     dailyRevenue,
-    dailyHoldersRevenue: dailyHoldersRevenue,
-    dailySupplySideRevenue: dailySupplySideRevenue,
+    dailyProtocolRevenue: dailyRevenue,
+    dailyHoldersRevenue: dailyRevenue.clone(0.8),
+    dailySupplySideRevenue,
+    dailyVolume,
   };
 }
 

--- a/fees/ferro.ts
+++ b/fees/ferro.ts
@@ -10,22 +10,23 @@ const pools = [
 ];
 
 const fetch = async (options: FetchOptions) => {
-  const { dailyVolume, dailyFees, dailyRevenue, dailySupplySideRevenue } = await getSaddleVolume(options, pools);
+  const { dailyFees, dailyRevenue, dailySupplySideRevenue } = await getSaddleVolume(options, pools);
 
   return {
     dailyFees,
     dailyUserFees: dailyFees,
     dailyRevenue,
-    dailyProtocolRevenue: dailyRevenue,
+    dailyProtocolRevenue: dailyRevenue.clone(0.2),
     dailyHoldersRevenue: dailyRevenue.clone(0.8),
     dailySupplySideRevenue,
-    dailyVolume,
   };
 }
 
 const methodology = {
   Fees: "Ferro charges a 0.04% fee on all swaps",
   Revenue: "0.02% of swap volume goes to the protocol, with 0.016% distributed to token holders and 0.004% to the treasury",
+  ProtocolRevenue: '0.004% of swap volume goes to the protocol',
+  HoldersRevenue: '0.016% of swap volume goes to the token holders',
   SupplySideRevenue: "0.02% of swap volume is distributed to liquidity providers",
 };
 
@@ -49,6 +50,7 @@ const breakdownMethodology = {
 
 const adapter: SimpleAdapter = {
   version: 2,
+  pullHourly: true,
   chains: [CHAIN.CRONOS],
   fetch,
   start: '2022-08-29',


### PR DESCRIPTION
Fixes DefiLlama/dimension-adapters#6515

## Summary
- replace the deleted Cronos Labs `ferro/swap` subgraph in the Ferro fees adapter with on-chain Saddle pool event accounting
- apply the same source migration to the Ferro DEX adapter, which used the same deleted subgraph
- report fees, user fees, protocol revenue, holder revenue, supply-side revenue, and volume from the existing Ferro pool list

## Context
Both Ferro adapters failed because `https://graph.cronoslabs.com/subgraphs/name/ferro/swap` now returns `deployment ferro/swap does not exist`. The Ferro DEX file already carried the pool list for an on-chain Saddle fallback, and `helpers/saddle` computes volume and fee splits from `TokenSwap` logs plus pool `swapStorage`.

## Validation
- `pnpm test fees ferro 2026-04-26`
- `pnpm test dexs ferro 2026-04-26`
- `pnpm run ts-check`