### PR TITLE
feat: add VEAX perp adapter

### DIFF
--- a/factory/orderly.ts
+++ b/factory/orderly.ts
@@ -19,6 +19,16 @@ const feesConfigs: Record<string, Config> = {
     },
   },
   "kodiak-perps": { broker_id: "kodiak", start: "2025-10-1" },
+  "veax-perp": {
+    broker_id: "veaxdex",
+    start: "2025-10-16",
+    methodology: {
+      Volume: "Maker/taker volume routed through VEAX's Orderly broker.",
+      Fees: "Builder fees collected by VEAX on Orderly Network.",
+      Revenue: "All builder fees collected by VEAX.",
+      ProtocolRevenue: "All revenue goes to the protocol.",
+    },
+  },
   "what-exchange": { broker_id: "what_exchange", start: "2024-06-13" },
   "woofi-pro-perp": { broker_id: "woofi_pro", start: "2023-10-26" },
   "oklong": {

--- a/helpers/orderly.ts
+++ b/helpers/orderly.ts
@@ -2,43 +2,30 @@ import { Adapter, FetchOptions } from "../adapters/types";
 import { httpGet } from "../utils/fetchURL";
 import { CHAIN } from "./chains";
 
-type BuilderDailyStats = {
-  date: string
-  dateString?: string
-  builderFee: string
-  takerVolume: string
-  makerVolume: string
-}
-
-type BuilderMethodology = Record<string, string>
-
-type BuilderConfig = {
-  broker_id: string
-  start?: string
-  revenueRatio?: number,
-  protocolRevenueRatio?: number,
-  holderRevenueRatio?: number,
-  methodology?: BuilderMethodology
-}
-
-const statsCache: Record<string, Promise<Record<string, BuilderDailyStats>>> = {}
-const defaultBuilderMethodology = {
+const statsCache: any = {}
+const defaulyBuilderMethodology = {
   Volume: 'Maker/taker volume that flow through the interface',
   Fees: "Builder Fees collected from Orderly Network",
   Revenue: "builder fees",
   ProtocolRevenue: "All the revenue go to the protocol",
 }
 
-export function getBuilderExports({ broker_id, start, revenueRatio = 1, protocolRevenueRatio = 1, methodology = defaultBuilderMethodology, holderRevenueRatio }: BuilderConfig): Adapter {
+export function getBuilderExports({ broker_id, start, revenueRatio = 1, protocolRevenueRatio = 1, methodology = defaulyBuilderMethodology, holderRevenueRatio }: {
+  broker_id: string
+  start?: string
+  revenueRatio?: number,
+  protocolRevenueRatio?: number,
+  holderRevenueRatio?: number,
+  methodology?: any
+}): Adapter {
 
   const url = `https://api.orderly.org/md/volume/builder/daily_stats?broker_id=${broker_id}`
 
   async function fetch(_: any, _1: any, { dateString }: FetchOptions) {
-    if (!statsCache[broker_id]) statsCache[broker_id] = httpGet(url).then((data: BuilderDailyStats[]) => {
-      const dateDataMap: Record<string, BuilderDailyStats> = {}
-      data.forEach((i) => {
+    if (!statsCache[broker_id]) statsCache[broker_id] = httpGet(url).then(data => {
+      const dateDataMap: any = {}
+      data.forEach((i: any) => {
         dateDataMap[i.date.slice(0, 10)] = i
-        if (i.dateString) dateDataMap[i.dateString] = i
       })
       return dateDataMap
     })

--- a/helpers/orderly.ts
+++ b/helpers/orderly.ts
@@ -2,30 +2,43 @@ import { Adapter, FetchOptions } from "../adapters/types";
 import { httpGet } from "../utils/fetchURL";
 import { CHAIN } from "./chains";
 
-const statsCache: any = {}
-const defaulyBuilderMethodology = {
+type BuilderDailyStats = {
+  date: string
+  dateString?: string
+  builderFee: string
+  takerVolume: string
+  makerVolume: string
+}
+
+type BuilderMethodology = Record<string, string>
+
+type BuilderConfig = {
+  broker_id: string
+  start?: string
+  revenueRatio?: number,
+  protocolRevenueRatio?: number,
+  holderRevenueRatio?: number,
+  methodology?: BuilderMethodology
+}
+
+const statsCache: Record<string, Promise<Record<string, BuilderDailyStats>>> = {}
+const defaultBuilderMethodology = {
   Volume: 'Maker/taker volume that flow through the interface',
   Fees: "Builder Fees collected from Orderly Network",
   Revenue: "builder fees",
   ProtocolRevenue: "All the revenue go to the protocol",
 }
 
-export function getBuilderExports({ broker_id, start, revenueRatio = 1, protocolRevenueRatio = 1, methodology = defaulyBuilderMethodology, holderRevenueRatio }: {
-  broker_id: string
-  start?: string
-  revenueRatio?: number,
-  protocolRevenueRatio?: number,
-  holderRevenueRatio?: number,
-  methodology?: any
-}): Adapter {
+export function getBuilderExports({ broker_id, start, revenueRatio = 1, protocolRevenueRatio = 1, methodology = defaultBuilderMethodology, holderRevenueRatio }: BuilderConfig): Adapter {
 
   const url = `https://api.orderly.org/md/volume/builder/daily_stats?broker_id=${broker_id}`
 
   async function fetch(_: any, _1: any, { dateString }: FetchOptions) {
-    if (!statsCache[broker_id]) statsCache[broker_id] = httpGet(url).then(data => {
-      const dateDataMap: any = {}
-      data.forEach((i: any) => {
+    if (!statsCache[broker_id]) statsCache[broker_id] = httpGet(url).then((data: BuilderDailyStats[]) => {
+      const dateDataMap: Record<string, BuilderDailyStats> = {}
+      data.forEach((i) => {
         dateDataMap[i.date.slice(0, 10)] = i
+        if (i.dateString) dateDataMap[i.dateString] = i
       })
       return dateDataMap
     })


### PR DESCRIPTION
https://perpdex.veax.com/
Sibling of https://defillama.com/protocol/veax

## Summary
- Adds VEAX Perp through the existing Orderly builder factory.
- Uses VEAX's Orderly broker id `veaxdex` with the first available builder stats date.
- Adds VEAX-specific methodology and tightens Orderly builder stats typing/date indexing.

## Methodology
- Volume is maker + taker volume routed through VEAX's Orderly broker.
- Fees/revenue use builder fees from Orderly's broker daily stats.
- Start date is the first available VEAX builder stats day: 2025-10-16.

## Test Plan
- `npm test -- dexs veax-perp 2025-10-20`
- `npm test -- fees veax-perp 2025-10-20`
- `npm test -- dexs what-exchange 2025-10-20`
- `npm test -- fees what-exchange 2025-10-20`
- `npm test -- dexs kodiak-perps 2025-11-02`

Closes #6530