### PR TITLE
[fix] aries-markets - encode rate history input

### DIFF
--- a/fees/aries-markets/index.ts
+++ b/fees/aries-markets/index.ts
@@ -20,7 +20,7 @@ const getRateHistoryURL = (timestamp: number, reserveKey: string) => {
   return `${rateURL}${input}`;
 };
 
-const fetch = async (options: FetchOptions) => {
+const fetch = async (_a: any, _b: any, options: FetchOptions) => {
   const reserves = (await fetchURL(reserveURL)).result.data.stats;
 
   let df = 0;
@@ -33,7 +33,7 @@ const fetch = async (options: FetchOptions) => {
     const borrowApr = Number(dayFeesQuery?.borrowApr);
     const totalBorrowed = Number(matchingReserve?.value?.total_borrowed);
 
-    if(isNaN(borrowApr) || isNaN(totalBorrowed)) {
+    if (isNaN(borrowApr) || isNaN(totalBorrowed)) {
       throw new Error(`Invalid data for date ${options.dateString}`);
     }
 
@@ -86,7 +86,7 @@ const breakdownMethodology = {
 };
 
 const adapter: SimpleAdapter = {
-  version: 2,
+  version: 1,
   chains: [CHAIN.APTOS],
   fetch,
   start: "2025-06-15",

--- a/fees/aries-markets/index.ts
+++ b/fees/aries-markets/index.ts
@@ -10,24 +10,38 @@ const USDCReserveKey = "0x9770fa9c725cbd97eb50b2be5f7416efdfd1f1554beb0750d4dae4
 
 const STABLE_COIN_DECIMAL = 6;
 const DAY_IN_YEARS = 365;
+const DAY_IN_SECONDS = 24 * 60 * 60;
 
-const fetch = async (timestamp: number, _: any, options: FetchOptions) => {
+const getStartOfDay = (timestamp: number) => timestamp - (timestamp % DAY_IN_SECONDS);
+
+const getRateHistoryURL = (timestamp: number, reserveKey: string) => {
+  const input = encodeURIComponent(JSON.stringify({
+    fromTs: timestamp,
+    resolutionInHours: 24,
+    reserveKey,
+  }));
+  return `${rateURL}${input}`;
+};
+
+const fetch = async (options: FetchOptions) => {
   const reserves = (await fetchURL(reserveURL)).result.data.stats;
+  const rateHistoryTimestamp = getStartOfDay(options.endTimestamp - DAY_IN_SECONDS);
 
   let df = 0;
   for (const reserveKey of [USDTReserveKey, USDCReserveKey]) {
-    const dayFeesQuery = (await fetchURL(`${rateURL}{%22fromTs%22:${timestamp},%22resolutionInHours%22:24,%22reserveKey%22:%22${reserveKey}%22}`
-    )).result.data[0];
+    const dayFeesQuery = (await fetchURL(getRateHistoryURL(rateHistoryTimestamp, reserveKey))).result.data[0];
 
     const matchingReserve = reserves.find(
       (reserve) => reserve.key === reserveKey
     );
+    const borrowApr = Number(dayFeesQuery?.borrowApr ?? 0);
+    const totalBorrowed = Number(matchingReserve?.value?.total_borrowed ?? 0);
 
     df +=
-      dayFeesQuery?.borrowApr *
-      (matchingReserve?.value.total_borrowed /
-        10 ** STABLE_COIN_DECIMAL /
-        DAY_IN_YEARS || 0);
+      borrowApr *
+      totalBorrowed /
+      10 ** STABLE_COIN_DECIMAL /
+      DAY_IN_YEARS;
   }
 
   const dpr = df * 0.2;

--- a/fees/aries-markets/index.ts
+++ b/fees/aries-markets/index.ts
@@ -10,9 +10,6 @@ const USDCReserveKey = "0x9770fa9c725cbd97eb50b2be5f7416efdfd1f1554beb0750d4dae4
 
 const STABLE_COIN_DECIMAL = 6;
 const DAY_IN_YEARS = 365;
-const DAY_IN_SECONDS = 24 * 60 * 60;
-
-const getStartOfDay = (timestamp: number) => timestamp - (timestamp % DAY_IN_SECONDS);
 
 const getRateHistoryURL = (timestamp: number, reserveKey: string) => {
   const input = encodeURIComponent(JSON.stringify({
@@ -25,17 +22,20 @@ const getRateHistoryURL = (timestamp: number, reserveKey: string) => {
 
 const fetch = async (options: FetchOptions) => {
   const reserves = (await fetchURL(reserveURL)).result.data.stats;
-  const rateHistoryTimestamp = getStartOfDay(options.endTimestamp - DAY_IN_SECONDS);
 
   let df = 0;
   for (const reserveKey of [USDTReserveKey, USDCReserveKey]) {
-    const dayFeesQuery = (await fetchURL(getRateHistoryURL(rateHistoryTimestamp, reserveKey))).result.data[0];
+    const dayFeesQuery = (await fetchURL(getRateHistoryURL(options.startOfDay, reserveKey))).result.data[0];
 
     const matchingReserve = reserves.find(
       (reserve) => reserve.key === reserveKey
     );
-    const borrowApr = Number(dayFeesQuery?.borrowApr ?? 0);
-    const totalBorrowed = Number(matchingReserve?.value?.total_borrowed ?? 0);
+    const borrowApr = Number(dayFeesQuery?.borrowApr);
+    const totalBorrowed = Number(matchingReserve?.value?.total_borrowed);
+
+    if(isNaN(borrowApr) || isNaN(totalBorrowed)) {
+      throw new Error(`Invalid data for date ${options.dateString}`);
+    }
 
     df +=
       borrowApr *


### PR DESCRIPTION
Fixes DefiLlama/dimension-adapters#6526

## Summary
- URL-encode the full Aries `reserve.rateHistory` JSON input instead of manually encoding only quotes
- switch the adapter fetch to the correct v2 `FetchOptions` signature
- use the start day of the actual 24h run window for rate history so no-date CI/current runs do not query an incomplete current UTC day
- guard missing rate/reserve fields so a partial API response cannot produce `NaN` balances

## Context
`pnpm test fees aries-markets 2026-04-26` failed with `Request failed with status code 400`. The Aries rate-history endpoint still returns data when `input` is a fully URL-encoded JSON object, while the previous partially encoded query now fails parsing.

GitHub Actions also runs adapter tests without an explicit date. In that mode, v2 adapters use a rolling 24h window, so the rate-history lookup must align to the start of that window rather than the current UTC day.

## Validation
- `pnpm test fees aries-markets`
- `pnpm test fees aries-markets 2026-04-26`
- `pnpm test fees aries-markets 2026-03-02`
- `pnpm run ts-check`