### PR TITLE
[fix] premia - end inactive v2/v3 adapters

### DIFF
--- a/fees/premia-v2.ts
+++ b/fees/premia-v2.ts
@@ -118,6 +118,7 @@ async function getV2Data(url: string, timestamp: number) {
 }
 
 const adapter: SimpleAdapter = {
+  deadFrom: '2026-01-29',
   methodology: {
     Fees: "Taker fees paid by traders on each trade, up to 3% of the option premium.",
     UserFees:

--- a/fees/premia-v3.ts
+++ b/fees/premia-v3.ts
@@ -84,6 +84,7 @@ async function getV3Data(url: string, timestamp: number, options: FetchOptions) 
 }
 
 const adapter: SimpleAdapter = {
+  deadFrom: '2025-12-08',
   methodology: {
     Fees: "Taker fees paid by traders on each trade, up to 3% of the option premium.",
     UserFees:

--- a/options/premia-v2.ts
+++ b/options/premia-v2.ts
@@ -99,6 +99,7 @@ async function getV2Data(url: string, timestamp: string) {
 }
 
 const adapter: SimpleAdapter = {
+  deadFrom: '2026-01-29',
   methodology: {
     UserFees:
       "Traders pay taker fees on each trade up to 3% of the option premium.",

--- a/options/premia-v3.ts
+++ b/options/premia-v3.ts
@@ -42,6 +42,7 @@ async function getV3Data(url: string, timestamp: number, chain: Chain) {
 }
 
 const adapter: SimpleAdapter = {
+  deadFrom: '2025-12-08',
   methodology: {
     UserFees:
       "Traders pay taker fees on each trade up to 3% of the option premium.",


### PR DESCRIPTION
## Summary
- stop Premia v2 fees/options adapters after the last available 2026-01-28 data point
- stop Premia v3 fees/options adapters after the last available 2025-12-07 data point
- preserve existing historical charts while avoiding current runs against unavailable subgraph sources

## Why
Premia v3 still points at a Satsuma endpoint that no longer resolves, and Premia v2 now fails through the paid Graph endpoint. The public fees and options summaries have no current data after the dates above, so the adapters should no longer run for current periods.

Fixes DefiLlama/dimension-adapters#6522.
Fixes DefiLlama/dimension-adapters#6523.

## Validation
- `pnpm test fees premia-v2 2026-04-27`
- `pnpm test fees premia-v3 2026-04-27`
- `pnpm test options premia-v2 2026-04-27`
- `pnpm test options premia-v3 2026-04-27`
