### PR TITLE
[fix] tezos - move chain fees to TzKT

### DIFF
--- a/fees/tezos.ts
+++ b/fees/tezos.ts
@@ -2,25 +2,80 @@ import { Adapter, FetchOptions, ProtocolType } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
 import { httpGet } from "../utils/fetchURL";
 
+const TZKT_API = "https://api.tzkt.io/v1";
+const MUTEZ_PER_XTZ = 1e6;
+const ONE_DAY = 24 * 60 * 60;
+const BLOCK_PAGE_SIZE = 10_000;
 
-const fetch = async (_a: any, _b: any, options: FetchOptions) => {
-  const timestamp = options.startOfDay * 1000;
+function getDayIso(timestamp: number) {
+  return new Date(timestamp * 1000).toISOString().slice(0, 10);
+}
 
-  const myHeaders: Record<string, string> = {
-    "Accept": "*/*",
-    "x-api-key": "N73XLD3QT7WJ5E14MHP41MOH8D6MWSN"
-  };
+function getDayStartIso(timestamp: number) {
+  return `${getDayIso(timestamp)}T00:00:00Z`;
+}
 
-  const transaction_counts = await httpGet("https://emu.mainnet.prod.tzstats.trili.tech/series/block?columns=time,fee,burned_supply&end_date=now&fill=none&collapse=1d&limit=1000", { headers: myHeaders })
+function getDayStartTimestamp(timestamp: number) {
+  return Date.parse(getDayStartIso(timestamp)) / 1000;
+}
 
-  const daily_transactions = transaction_counts.find((txs: any) =>
-    txs[0] === timestamp
+async function getDailyBlockFees(startOfDay: number) {
+  const start = getDayStartIso(startOfDay);
+  const end = getDayStartIso(startOfDay + ONE_DAY);
+  let offset = 0;
+  let totalFees = 0;
+
+  while (true) {
+    const fees = await httpGet(
+      `${TZKT_API}/blocks?timestamp.ge=${start}&timestamp.lt=${end}&select=fees&limit=${BLOCK_PAGE_SIZE}&offset=${offset}`
+    );
+
+    if (!Array.isArray(fees)) throw new Error("TzKT blocks response is not an array");
+
+    fees.forEach((fee) => {
+      const value = Number(fee);
+      if (!Number.isFinite(value)) throw new Error(`Invalid Tezos block fee: ${fee}`);
+      totalFees += value;
+    });
+
+    if (fees.length < BLOCK_PAGE_SIZE) break;
+    offset += BLOCK_PAGE_SIZE;
+  }
+
+  return totalFees;
+}
+
+async function getDailyBurnedSupply(startOfDay: number) {
+  const previousDay = getDayStartIso(startOfDay - ONE_DAY);
+  const currentDay = getDayStartIso(startOfDay);
+
+  const snapshots = await httpGet(
+    `${TZKT_API}/statistics/daily?date.in=${previousDay},${currentDay}&select=date,totalBurned&sort.asc=date`
   );
+
+  if (!Array.isArray(snapshots)) throw new Error("TzKT statistics response is not an array");
+
+  const previous = snapshots.find(({ date }: any) => date === previousDay)?.totalBurned ?? 0;
+  const current = snapshots.find(({ date }: any) => date === currentDay)?.totalBurned;
+
+  if (current === undefined) throw new Error(`Missing Tezos burn snapshot for ${currentDay}`);
+
+  const burned = Number(current) - Number(previous);
+  if (!Number.isFinite(burned)) throw new Error(`Invalid Tezos burned supply for ${currentDay}`);
+
+  return Math.max(burned, 0);
+}
+
+const fetch = async (options: FetchOptions) => {
+  const targetDay = getDayStartTimestamp(options.startTimestamp);
+  const dailyBlockFees = await getDailyBlockFees(targetDay);
+  const dailyBurnedSupply = await getDailyBurnedSupply(targetDay);
+
   const dailyFees = options.createBalances();
   const dailyRevenue = options.createBalances();
 
-  dailyFees.addCGToken('tezos', daily_transactions[1] + daily_transactions[2]);
-  dailyRevenue.addCGToken('tezos', daily_transactions[2]);
+  dailyFees.addCGToken('tezos', (dailyBlockFees + dailyBurnedSupply) / MUTEZ_PER_XTZ);
+  dailyRevenue.addCGToken('tezos', dailyBurnedSupply / MUTEZ_PER_XTZ);
 
   return {
     dailyFees,
@@ -30,7 +85,7 @@ const fetch = async (_a: any, _b: any, options: FetchOptions) => {
 };
 
 const adapter: Adapter = {
-  version: 1,
+  version: 2,
   fetch,
   chains: [CHAIN.TEZOS],
   start: '2018-06-30', // Tezos mainnet launch date

--- a/fees/tezos.ts
+++ b/fees/tezos.ts
@@ -7,12 +7,8 @@ const MUTEZ_PER_XTZ = 1e6;
 const ONE_DAY = 24 * 60 * 60;
 const BLOCK_PAGE_SIZE = 10_000;
 
-function getDayIso(timestamp: number) {
-  return new Date(timestamp * 1000).toISOString().slice(0, 10);
-}
-
 function getDayStartIso(timestamp: number) {
-  return `${getDayIso(timestamp)}T00:00:00Z`;
+  return `${new Date(timestamp * 1000).toISOString().slice(0, 10)}T00:00:00Z`;
 }
 
 function getDayStartTimestamp(timestamp: number) {
@@ -66,7 +62,7 @@ async function getDailyBurnedSupply(startOfDay: number) {
   return Math.max(burned, 0);
 }
 
-const fetch = async (options: FetchOptions) => {
+const fetch = async (_a: any, _b: any, options: FetchOptions) => {
   const targetDay = getDayStartTimestamp(options.startTimestamp);
   const dailyBlockFees = await getDailyBlockFees(targetDay);
   const dailyBurnedSupply = await getDailyBurnedSupply(targetDay);
@@ -85,14 +81,15 @@ const fetch = async (options: FetchOptions) => {
 };
 
 const adapter: Adapter = {
-  version: 2,
+  version: 1,
   fetch,
   chains: [CHAIN.TEZOS],
   start: '2018-06-30', // Tezos mainnet launch date
   protocolType: ProtocolType.CHAIN,
   methodology: {
     Fees: 'Total transaction fees paid by users for gas + storage fees',
-    Revenue: 'Amount of tez burned, including storage fees, allocation fees, double baking/attestation punishments, etc.'
+    Revenue: 'Amount of tez burned, including storage fees, allocation fees, double baking/attestation punishments, etc.',
+    HoldersRevenue: 'Amount of tez burned, including storage fees, allocation fees, double baking/attestation punishments, etc.'
   }
 };
 


### PR DESCRIPTION
## Summary
- replace the retired TzStats fees source with public TzKT endpoints
- sum daily Tezos block fees from paginated block data
- compute daily burned tez by diffing TzKT daily `totalBurned` snapshots
- anchor the calculation to the completed UTC day at the start of the test window so no-date current runs do not require an unfinished daily snapshot
- keep the existing income statement treatment: fees are block fees plus burns, revenue/holders revenue is burned tez

## Why
The previous `emu.mainnet.prod.tzstats.trili.tech` source no longer resolves, so the Tezos chain-fees adapter fails before returning current data. TzKT is the maintained public Tezos indexer API and exposes the block fee and daily burn data needed for the same methodology.

Fixes DefiLlama/dimension-adapters#6495.

## Validation
- `pnpm test fees tezos`
- `pnpm test fees tezos 2026-04-27`
- `pnpm test fees tezos 2026-01-24`
- `git diff --check`
