### PR TITLE
[fix] solstice-usx - move redemption rate source to Pyth Hermes

### DIFF
--- a/fees/solstice-usx/index.ts
+++ b/fees/solstice-usx/index.ts
@@ -7,7 +7,8 @@ import fetchURL from "../../utils/fetchURL";
 const EUSX = '3ThdFZQKM6kRyVGLG48kaPg5TRMhYMKY1iCRa9xop1WC';
 const PYTH_EUSX_REDEMPTION_PRICE_ID = 'f36e12e65d2969b242fb97d3ebaa32ec55d5794189b64d1a07dc4f41425c9378';
 const PYTH_HERMES_PRICE_API = 'https://hermes.pyth.network/v2/updates/price';
-const YIELD_LABEL = 'eUSX Yield Accrual';
+const FEES_YIELD_LABEL = 'eUSX Yield Accrual';
+const SUPPLY_SIDE_YIELD_LABEL = 'eUSX Yield To Holders';
 
 const getRedemptionPrice = async (timestamp: number) => {
   const response = await fetchURL(`${PYTH_HERMES_PRICE_API}/${timestamp}?ids%5B%5D=${PYTH_EUSX_REDEMPTION_PRICE_ID}`);
@@ -44,9 +45,9 @@ const fetch: any = async (_: any, _1: any, options: FetchOptions): Promise<Fetch
   if (!Number.isFinite(dailyYield))
     throw new Error("Pyth API returned invalid EUSX redemption prices");
 
-  dailyFees.addUSDValue(dailyYield, YIELD_LABEL);
+  dailyFees.addUSDValue(dailyYield, FEES_YIELD_LABEL);
   const dailySupplySideRevenue = options.createBalances();
-  dailySupplySideRevenue.addUSDValue(dailyYield, YIELD_LABEL);
+  dailySupplySideRevenue.addUSDValue(dailyYield, SUPPLY_SIDE_YIELD_LABEL);
 
   return {
     dailyFees,
@@ -68,11 +69,13 @@ const adapters: SimpleAdapter = {
   },
   breakdownMethodology: {
     Fees: {
-      [YIELD_LABEL]: 'Daily change in eUSX/USX redemption rate multiplied by total eUSX supply',
+      [FEES_YIELD_LABEL]: 'Daily change in eUSX/USX redemption rate multiplied by total eUSX supply',
     },
+    Revenue: 'No protocol revenue; all eUSX redemption-rate yield is passed through to eUSX holders.',
     SupplySideRevenue: {
-      [YIELD_LABEL]: '100% of eUSX redemption-rate yield is distributed to eUSX holders',
+      [SUPPLY_SIDE_YIELD_LABEL]: '100% of eUSX redemption-rate yield is distributed to eUSX holders',
     },
+    HoldersRevenue: 'Not separately tracked in this adapter; holder distributions are represented in SupplySideRevenue.',
   }
 };
 

--- a/fees/solstice-usx/index.ts
+++ b/fees/solstice-usx/index.ts
@@ -1,4 +1,5 @@
 import { FetchOptions, FetchResultFees, SimpleAdapter } from "../../adapters/types";
+import { PromisePool } from "@supercharge/promise-pool";
 import { CHAIN } from "../../helpers/chains";
 import { getTokenSupply } from '../../helpers/solana';
 import fetchURL from "../../utils/fetchURL";
@@ -6,6 +7,7 @@ import fetchURL from "../../utils/fetchURL";
 const EUSX = '3ThdFZQKM6kRyVGLG48kaPg5TRMhYMKY1iCRa9xop1WC';
 const PYTH_EUSX_REDEMPTION_PRICE_ID = 'f36e12e65d2969b242fb97d3ebaa32ec55d5794189b64d1a07dc4f41425c9378';
 const PYTH_HERMES_PRICE_API = 'https://hermes.pyth.network/v2/updates/price';
+const YIELD_LABEL = 'eUSX Yield Accrual';
 
 const getRedemptionPrice = async (timestamp: number) => {
   const response = await fetchURL(`${PYTH_HERMES_PRICE_API}/${timestamp}?ids%5B%5D=${PYTH_EUSX_REDEMPTION_PRICE_ID}`);
@@ -22,10 +24,19 @@ const getRedemptionPrice = async (timestamp: number) => {
 const fetch: any = async (_: any, _1: any, options: FetchOptions): Promise<FetchResultFees> => {
   const dailyFees = options.createBalances();
 
-  const [priceYesterday, priceToday] = await Promise.all([
-    getRedemptionPrice(options.fromTimestamp),
-    getRedemptionPrice(options.endTimestamp),
-  ]);
+  const { results, errors } = await PromisePool
+    .withConcurrency(2)
+    .for([options.fromTimestamp, options.endTimestamp])
+    .process(async (timestamp) => [timestamp, await getRedemptionPrice(timestamp)] as const);
+
+  if (errors.length > 0) throw errors[0];
+
+  const pricesByTimestamp = new Map(results);
+  const priceYesterday = pricesByTimestamp.get(options.fromTimestamp);
+  const priceToday = pricesByTimestamp.get(options.endTimestamp);
+
+  if (!Number.isFinite(priceYesterday) || !Number.isFinite(priceToday))
+    throw new Error("Pyth Hermes returned incomplete EUSX redemption prices");
 
   const totalSupply = await getTokenSupply(EUSX)
   const dailyYield = (priceToday - priceYesterday) * totalSupply;
@@ -33,12 +44,14 @@ const fetch: any = async (_: any, _1: any, options: FetchOptions): Promise<Fetch
   if (!Number.isFinite(dailyYield))
     throw new Error("Pyth API returned invalid EUSX redemption prices");
 
-  dailyFees.addUSDValue(dailyYield);
+  dailyFees.addUSDValue(dailyYield, YIELD_LABEL);
+  const dailySupplySideRevenue = options.createBalances();
+  dailySupplySideRevenue.addUSDValue(dailyYield, YIELD_LABEL);
 
   return {
     dailyFees,
     dailyRevenue: 0,
-    dailySupplySideRevenue: dailyFees,
+    dailySupplySideRevenue,
   };
 };
 
@@ -52,6 +65,14 @@ const adapters: SimpleAdapter = {
     Fees: 'Yield generated from Solstice various strategies',
     Revenue: 'No protocol revenue (yield fully passed to eUSX holders)',
     SupplySideRevenue: 'Total yield accrued through eUSX price appreciation, distributed to holders',
+  },
+  breakdownMethodology: {
+    Fees: {
+      [YIELD_LABEL]: 'Daily change in eUSX/USX redemption rate multiplied by total eUSX supply',
+    },
+    SupplySideRevenue: {
+      [YIELD_LABEL]: '100% of eUSX redemption-rate yield is distributed to eUSX holders',
+    },
   }
 };
 

--- a/fees/solstice-usx/index.ts
+++ b/fees/solstice-usx/index.ts
@@ -4,22 +4,28 @@ import { getTokenSupply } from '../../helpers/solana';
 import fetchURL from "../../utils/fetchURL";
 
 const EUSX = '3ThdFZQKM6kRyVGLG48kaPg5TRMhYMKY1iCRa9xop1WC';
-const PYTH_EUSX_REDEMPTION_PRICE_API = 'https://insights.pyth.network/historical-prices?symbol=Crypto.EUSX%2FUSX.RR';
+const PYTH_EUSX_REDEMPTION_PRICE_ID = 'f36e12e65d2969b242fb97d3ebaa32ec55d5794189b64d1a07dc4f41425c9378';
+const PYTH_HERMES_PRICE_API = 'https://hermes.pyth.network/v2/updates/price';
+
+const getRedemptionPrice = async (timestamp: number) => {
+  const response = await fetchURL(`${PYTH_HERMES_PRICE_API}/${timestamp}?ids%5B%5D=${PYTH_EUSX_REDEMPTION_PRICE_ID}`);
+  const pythPrice = response?.parsed?.[0]?.price;
+  const price = Number(pythPrice?.price);
+  const exponent = Number(pythPrice?.expo);
+
+  if (!Number.isFinite(price) || !Number.isInteger(exponent))
+    throw new Error(`Pyth Hermes returned invalid EUSX redemption price for ${timestamp}`);
+
+  return price * 10 ** exponent;
+};
 
 const fetch: any = async (_: any, _1: any, options: FetchOptions): Promise<FetchResultFees> => {
   const dailyFees = options.createBalances();
 
-  const response = await fetchURL(`${PYTH_EUSX_REDEMPTION_PRICE_API}&from=${options.fromTimestamp}&to=${options.endTimestamp}&resolution=1H&cluster=pythnet`);
-
-  const prices = Array.isArray(response)
-    ? response.map((point: any) => Number(point?.price)).filter(Number.isFinite)
-    : [];
-
-  if (prices.length < 2)
-    throw new Error("Pyth API returned invalid response");
-
-  const priceYesterday = prices[0];
-  const priceToday = prices[prices.length - 1];
+  const [priceYesterday, priceToday] = await Promise.all([
+    getRedemptionPrice(options.fromTimestamp),
+    getRedemptionPrice(options.endTimestamp),
+  ]);
 
   const totalSupply = await getTokenSupply(EUSX)
   const dailyYield = (priceToday - priceYesterday) * totalSupply;
@@ -38,7 +44,6 @@ const fetch: any = async (_: any, _1: any, options: FetchOptions): Promise<Fetch
 
 const adapters: SimpleAdapter = {
   version: 1,
-  deadFrom: '2026-04-13',
   fetch,
   chains: [CHAIN.SOLANA],
   start: '2025-10-05',

--- a/fees/solstice-usx/index.ts
+++ b/fees/solstice-usx/index.ts
@@ -11,15 +11,23 @@ const fetch: any = async (_: any, _1: any, options: FetchOptions): Promise<Fetch
 
   const response = await fetchURL(`${PYTH_EUSX_REDEMPTION_PRICE_API}&from=${options.fromTimestamp}&to=${options.endTimestamp}&resolution=1H&cluster=pythnet`);
 
-  if (!response || response.length < 2)
-    throw new Error("Pyth API returned invalid reposnse");
+  const prices = Array.isArray(response)
+    ? response.map((point: any) => Number(point?.price)).filter(Number.isFinite)
+    : [];
 
-  const totalResponses = response.length;
-  const priceYesterday = response[0].price;
-  const priceToday = response[totalResponses-1].price;
+  if (prices.length < 2)
+    throw new Error("Pyth API returned invalid response");
+
+  const priceYesterday = prices[0];
+  const priceToday = prices[prices.length - 1];
 
   const totalSupply = await getTokenSupply(EUSX)
-  dailyFees.addUSDValue((priceToday - priceYesterday) * totalSupply);
+  const dailyYield = (priceToday - priceYesterday) * totalSupply;
+
+  if (!Number.isFinite(dailyYield))
+    throw new Error("Pyth API returned invalid EUSX redemption prices");
+
+  dailyFees.addUSDValue(dailyYield);
 
   return {
     dailyFees,
@@ -30,6 +38,7 @@ const fetch: any = async (_: any, _1: any, options: FetchOptions): Promise<Fetch
 
 const adapters: SimpleAdapter = {
   version: 1,
+  deadFrom: '2026-04-13',
   fetch,
   chains: [CHAIN.SOLANA],
   start: '2025-10-05',

--- a/fees/solstice-usx/index.ts
+++ b/fees/solstice-usx/index.ts
@@ -3,11 +3,12 @@ import { PromisePool } from "@supercharge/promise-pool";
 import { CHAIN } from "../../helpers/chains";
 import { getTokenSupply } from '../../helpers/solana';
 import fetchURL from "../../utils/fetchURL";
+import { METRIC } from "../../helpers/metrics";
 
 const EUSX = '3ThdFZQKM6kRyVGLG48kaPg5TRMhYMKY1iCRa9xop1WC';
 const PYTH_EUSX_REDEMPTION_PRICE_ID = 'f36e12e65d2969b242fb97d3ebaa32ec55d5794189b64d1a07dc4f41425c9378';
 const PYTH_HERMES_PRICE_API = 'https://hermes.pyth.network/v2/updates/price';
-const FEES_YIELD_LABEL = 'eUSX Yield Accrual';
+const FEES_YIELD_LABEL = METRIC.ASSETS_YIELDS;
 const SUPPLY_SIDE_YIELD_LABEL = 'eUSX Yield To Holders';
 
 const getRedemptionPrice = async (timestamp: number) => {
@@ -36,7 +37,7 @@ const fetch: any = async (_: any, _1: any, options: FetchOptions): Promise<Fetch
   const priceYesterday = pricesByTimestamp.get(options.fromTimestamp);
   const priceToday = pricesByTimestamp.get(options.endTimestamp);
 
-  if (!Number.isFinite(priceYesterday) || !Number.isFinite(priceToday))
+  if (!priceToday || !priceYesterday || !Number.isFinite(priceYesterday) || !Number.isFinite(priceToday))
     throw new Error("Pyth Hermes returned incomplete EUSX redemption prices");
 
   const totalSupply = await getTokenSupply(EUSX)


### PR DESCRIPTION
## Summary
- replace the retired Pyth Insights historical-prices URL with timestamped Pyth Hermes reads for the EUSX/USX redemption-rate feed
- keep Solstice USX active instead of marking the adapter dead
- validate Pyth price payloads before calculating eUSX daily yield
- add explicit fee/supply-side breakdown labels for the eUSX yield accrual source

## Why
The previous Insights URL now redirects to the Pyth web app, which made current adapter runs fail with invalid price data. The EUSX/USX redemption-rate feed is still available from Hermes by price id, and Hermes supports historical reads at the adapter window boundaries.

Fixes DefiLlama/dimension-adapters#6499.

## Validation
- `pnpm test fees solstice-usx 2026-04-12`
- `pnpm test fees solstice-usx 2026-04-27`
- `pnpm test fees solstice-usx 2026-04-28`
- `pnpm run ts-check`
- `git diff --check`
