### PR TITLE
Add Flare and Katana chain fee adapters

### DIFF
--- a/fees/flare.ts
+++ b/fees/flare.ts
@@ -1,0 +1,4 @@
+import { CHAIN } from "../helpers/chains";
+import { blockscoutFeeAdapter2 } from "../helpers/blockscoutFees";
+
+export default blockscoutFeeAdapter2(CHAIN.FLARE);

--- a/fees/katana.ts
+++ b/fees/katana.ts
@@ -1,0 +1,4 @@
+import { CHAIN } from "../helpers/chains";
+import { blockscoutFeeAdapter2 } from "../helpers/blockscoutFees";
+
+export default blockscoutFeeAdapter2(CHAIN.KATANA);


### PR DESCRIPTION
## Summary

Adds chain fee adapters for Flare and Katana by wiring the existing `blockscoutFeeAdapter2` helper to the existing Blockscout configs for both chains.

This addresses two of the chain-fee gaps called out in #4933 without adding new data-source logic: `helpers/blockscoutFees.ts` already contains validated config for `CHAIN.FLARE` and `CHAIN.KATANA`, but there were no adapter entrypoints under `fees/`.

## Tests

- `pnpm test fees flare 2026-04-20`
- `pnpm test fees katana 2026-04-20`
- `pnpm run ts-check`
