### PR TITLE
[fix] collex - end inactive fees adapter

### DIFF
--- a/fees/collex.ts
+++ b/fees/collex.ts
@@ -52,6 +52,7 @@ const adapter: SimpleAdapter = {
   fetch,
   chains: [CHAIN.APTOS],
   start: '2025-10-08',
+  deadFrom: '2026-03-13', 
   methodology: {
     Fees: "Fees from the Collex marketplace/trading.",
     Revenue: "Revenue from the Collex marketplace/trading.",


### PR DESCRIPTION
Fixes #6521 

**Summary**
- Added `deadFrom: '2026-03-13'` since the Collex API (`api.collex.fun`) returns 502 and the last charted fee day on DefiLlama was March 12, 2026

**Validation**
```bash
pnpm test fees collex
# Skipping collex because the adapter ended at Fri, 13 Mar 2026 00:00:00 GMT
```