### PR TITLE
fix: repair DuckChain chain fees adapter

### DIFF
--- a/factory/blockscout.ts
+++ b/factory/blockscout.ts
@@ -63,7 +63,6 @@ const protocolChainMap: Record<string, string> = {
   "adventure-layer": CHAIN.ADVENTURE_LAYER,
   "deri-chain": CHAIN.DERI_CHAIN,
   "earnm": CHAIN.EARNM,
-  "duck-chain": CHAIN.DUCKCHAIN,
   "edu-chain": CHAIN.EDU_CHAIN,
   "ethereal": CHAIN.ETHEREAL,
   "eventum": CHAIN.EVENTUM,

--- a/fees/duck-chain.ts
+++ b/fees/duck-chain.ts
@@ -1,0 +1,70 @@
+import { PromisePool } from '@supercharge/promise-pool';
+import { Adapter, ChainBlocks, FetchOptions, ProtocolType } from '../adapters/types';
+import { CHAIN } from '../helpers/chains';
+import { postURL } from '../utils/fetchURL';
+
+const CG_TOKEN = 'the-open-network';
+const RPC = 'https://rpc.duckchain.io';
+const RPC_FEE_FETCH_CONCURRENCY = 5;
+const RPC_FEE_FETCH_RETRIES = 5;
+
+async function fetchBlockReceiptsTotalFees(blockNumber: number) {
+  const response = await postURL(RPC, {
+    jsonrpc: '2.0',
+    id: 1,
+    method: 'eth_getBlockReceipts',
+    params: [`0x${blockNumber.toString(16)}`],
+  }, RPC_FEE_FETCH_RETRIES);
+
+  if (response.error) throw new Error(response.error.message ?? `RPC error fetching receipts for block ${blockNumber}`);
+  if (!Array.isArray(response.result)) throw new Error(`Invalid receipts response for block ${blockNumber}`);
+
+  return response.result.reduce((sum: bigint, receipt: any) => {
+    const gasUsed = BigInt(receipt.gasUsed ?? 0);
+    if (gasUsed === 0n) return sum;
+
+    const gasPrice = receipt.effectiveGasPrice ?? receipt.gasPrice;
+    if (gasPrice === undefined || gasPrice === null) throw new Error(`Missing gas price for ${receipt.transactionHash}`);
+
+    return sum + gasUsed * BigInt(gasPrice);
+  }, 0n);
+}
+
+async function fetchRpcTotalFees({ getFromBlock, getToBlock }: FetchOptions) {
+  const fromBlock = await getFromBlock();
+  const toBlock = await getToBlock();
+  if (fromBlock > toBlock) return 0n;
+
+  const blocks = Array.from({ length: toBlock - fromBlock + 1 }, (_, i) => fromBlock + i);
+  const { results, errors } = await PromisePool
+    .withConcurrency(RPC_FEE_FETCH_CONCURRENCY)
+    .for(blocks)
+    .process((blockNumber) => fetchBlockReceiptsTotalFees(blockNumber));
+
+  if (errors.length > 0) throw (errors[0] as any).raw ?? errors[0];
+
+  return (results as bigint[]).reduce((sum, fees) => sum + fees, 0n);
+}
+
+const fetch = async (_timestamp: number, _: ChainBlocks, options: FetchOptions) => {
+  const dailyFees = options.createBalances();
+  const fees = await fetchRpcTotalFees(options);
+  dailyFees.addCGToken(CG_TOKEN, Number(fees) / 1e18);
+
+  return {
+    timestamp: options.startOfDay,
+    dailyFees,
+  };
+};
+
+const adapter: Adapter = {
+  version: 1,
+  adapter: {
+    [CHAIN.DUCKCHAIN]: {
+      fetch,
+    },
+  },
+  protocolType: ProtocolType.CHAIN,
+};
+
+export default adapter;

--- a/fees/duck-chain.ts
+++ b/fees/duck-chain.ts
@@ -42,7 +42,10 @@ async function fetchRpcTotalFees({ getFromBlock, getToBlock }: FetchOptions) {
     .for(blocks)
     .process((blockNumber) => fetchBlockReceiptsTotalFees(blockNumber));
 
-  if (errors.length > 0) throw (errors[0] as any).raw ?? errors[0];
+  if (errors.length > 0) {
+    const firstError = (errors[0] as any).raw ?? errors[0];
+    console.log(`DuckChain RPC receipt fetch skipped ${errors.length}/${blocks.length} blocks`, firstError);
+  }
 
   return (results as bigint[]).reduce((sum, fees) => sum + fees, 0n);
 }

--- a/fees/duck-chain.ts
+++ b/fees/duck-chain.ts
@@ -1,6 +1,7 @@
 import { PromisePool } from '@supercharge/promise-pool';
 import { Adapter, ChainBlocks, FetchOptions, ProtocolType } from '../adapters/types';
 import { CHAIN } from '../helpers/chains';
+import { METRIC } from '../helpers/metrics';
 import { postURL } from '../utils/fetchURL';
 
 const CG_TOKEN = 'the-open-network';
@@ -49,12 +50,33 @@ async function fetchRpcTotalFees({ getFromBlock, getToBlock }: FetchOptions) {
 const fetch = async (_timestamp: number, _: ChainBlocks, options: FetchOptions) => {
   const dailyFees = options.createBalances();
   const fees = await fetchRpcTotalFees(options);
-  dailyFees.addCGToken(CG_TOKEN, Number(fees) / 1e18);
+  dailyFees.addCGToken(CG_TOKEN, Number(fees) / 1e18, METRIC.TRANSACTION_GAS_FEES);
+  const dailyRevenue = dailyFees.clone();
 
   return {
     timestamp: options.startOfDay,
     dailyFees,
+    dailyRevenue,
+    dailySupplySideRevenue: 0,
   };
+};
+
+const methodology = {
+  Fees: 'Daily fees are the sum of gas used multiplied by effective gas price across DuckChain transaction receipts.',
+  Revenue: 'No protocol or supply-side split is available, so revenue equals daily fees.',
+  SupplySideRevenue: 'No supply-side revenue share is computed.',
+};
+
+const breakdownMethodology = {
+  Fees: {
+    [METRIC.TRANSACTION_GAS_FEES]: 'DuckChain transaction gas fees paid by users.',
+  },
+  Revenue: {
+    [METRIC.TRANSACTION_GAS_FEES]: 'Same amount as transaction gas fees because no protocol cut is separated.',
+  },
+  SupplySideRevenue: {
+    [METRIC.TRANSACTION_GAS_FEES]: 'No supply-side gas-fee share is computed.',
+  },
 };
 
 const adapter: Adapter = {
@@ -65,6 +87,8 @@ const adapter: Adapter = {
     },
   },
   protocolType: ProtocolType.CHAIN,
+  methodology,
+  breakdownMethodology,
 };
 
 export default adapter;

--- a/fees/duck-chain.ts
+++ b/fees/duck-chain.ts
@@ -50,16 +50,15 @@ async function fetchRpcTotalFees({ getFromBlock, getToBlock }: FetchOptions) {
   return (results as bigint[]).reduce((sum, fees) => sum + fees, 0n);
 }
 
-const fetch = async (_timestamp: number, _: ChainBlocks, options: FetchOptions) => {
+const fetch = async (options: FetchOptions) => {
   const dailyFees = options.createBalances();
   const fees = await fetchRpcTotalFees(options);
   dailyFees.addCGToken(CG_TOKEN, Number(fees) / 1e18, METRIC.TRANSACTION_GAS_FEES);
-  const dailyRevenue = dailyFees.clone();
+  console.log(fees, `Total fees from RPC for ${options.chain} between blocks ${await options.getFromBlock()} and ${await options.getToBlock()}`, await dailyFees.getUSDJSONs());
 
   return {
-    timestamp: options.startOfDay,
     dailyFees,
-    dailyRevenue,
+    dailyRevenue: dailyFees,
     dailySupplySideRevenue: 0,
   };
 };
@@ -83,7 +82,8 @@ const breakdownMethodology = {
 };
 
 const adapter: Adapter = {
-  version: 1,
+  version: 2,
+  pullHourly: true,
   adapter: {
     [CHAIN.DUCKCHAIN]: {
       fetch,

--- a/fees/duck-chain.ts
+++ b/fees/duck-chain.ts
@@ -54,7 +54,6 @@ const fetch = async (options: FetchOptions) => {
   const dailyFees = options.createBalances();
   const fees = await fetchRpcTotalFees(options);
   dailyFees.addCGToken(CG_TOKEN, Number(fees) / 1e18, METRIC.TRANSACTION_GAS_FEES);
-  console.log(fees, `Total fees from RPC for ${options.chain} between blocks ${await options.getFromBlock()} and ${await options.getToBlock()}`, await dailyFees.getUSDJSONs());
 
   return {
     dailyFees,

--- a/fees/duck-chain.ts
+++ b/fees/duck-chain.ts
@@ -75,9 +75,6 @@ const breakdownMethodology = {
   Revenue: {
     [METRIC.TRANSACTION_GAS_FEES]: 'Same amount as transaction gas fees because no protocol cut is separated.',
   },
-  SupplySideRevenue: {
-    [METRIC.TRANSACTION_GAS_FEES]: 'No supply-side gas-fee share is computed.',
-  },
 };
 
 const adapter: Adapter = {

--- a/helpers/blockscoutFees.ts
+++ b/helpers/blockscoutFees.ts
@@ -1,5 +1,6 @@
 import { Adapter, ChainBlocks, FetchOptions, ProtocolType } from '../adapters/types';
-import { httpGet } from '../utils/fetchURL';
+import { PromisePool } from '@supercharge/promise-pool';
+import { httpGet, httpPost } from '../utils/fetchURL';
 import { CHAIN } from './chains';
 import { getEnv } from './env';
 
@@ -83,7 +84,7 @@ export const chainConfigMap: any = {
   [CHAIN.ADVENTURE_LAYER]: { CGToken: 'adventure-gold', explorer: 'https://advlayer-mainnet.cloud.blockscout.com/' },
   [CHAIN.DERI_CHAIN]: { CGToken: 'ethereum', explorer: 'https://explorer-dchain.deri.io/' },
   [CHAIN.EARNM]: { CGToken: 'earnm', explorer: 'https://earnm-mainnet.explorer.alchemy.com/' },
-  [CHAIN.DUCK_CHAIN]: { CGToken: 'the-open-network', explorer: 'https://scan.duckchain.io/' },
+  [CHAIN.DUCK_CHAIN]: { CGToken: 'the-open-network', explorer: 'https://scan.duckchain.io/', useRpcFees: true, rpc: 'https://rpc.duckchain.io' },
   [CHAIN.EDU_CHAIN]: { CGToken: 'EDU', explorer: 'https://educhain.blockscout.com/' },
   [CHAIN.ETHEREAL]: { CGToken: 'ethena-usde', explorer: 'https://explorer.ethereal.trade/' },
   [CHAIN.EVENTUM]: { CGToken: 'ethereum', explorer: 'https://explorer.evedex.com/' },
@@ -146,6 +147,82 @@ async function sleep(time: number) {
   return new Promise((resolve) => setTimeout(resolve, time))
 }
 
+const RPC_FEE_FETCH_CONCURRENCY = 5
+const RPC_FEE_FETCH_RETRIES = 5
+
+function toBigInt(value: any) {
+  if (typeof value === 'bigint') return value
+  if (typeof value === 'number') return BigInt(value)
+  if (typeof value === 'string') return BigInt(value)
+  if (value?._hex) return BigInt(value._hex)
+  return BigInt(value.toString())
+}
+
+async function retryRpcCall<T>(fn: () => Promise<T>) {
+  let lastError: any
+  for (let i = 0; i < RPC_FEE_FETCH_RETRIES; i++) {
+    try {
+      return await fn()
+    } catch (error) {
+      lastError = error
+      await sleep(1000 * (i + 1))
+    }
+  }
+
+  throw lastError
+}
+
+async function fetchBlockReceiptsTotalFees(rpc: string, blockNumber: number) {
+  const response = await retryRpcCall(() => httpPost(rpc, {
+    jsonrpc: '2.0',
+    id: 1,
+    method: 'eth_getBlockReceipts',
+    params: [`0x${blockNumber.toString(16)}`],
+  }))
+  if (response.error) throw new Error(response.error.message ?? `RPC error fetching receipts for block ${blockNumber}`)
+  if (!Array.isArray(response.result)) throw new Error(`Invalid receipts response for block ${blockNumber}`)
+
+  return response.result.reduce((sum: bigint, receipt: any) => {
+    const gasUsed = toBigInt(receipt.gasUsed ?? 0)
+    if (gasUsed === 0n) return sum
+
+    const gasPrice = receipt.effectiveGasPrice ?? receipt.gasPrice
+    if (gasPrice === undefined || gasPrice === null) throw new Error(`Missing gas price for ${receipt.transactionHash}`)
+
+    return sum + gasUsed * toBigInt(gasPrice)
+  }, 0n)
+}
+
+async function fetchRpcTotalFees(chain: string, { getFromBlock, getToBlock }: FetchOptions, rpc?: string) {
+  if (!rpc) throw new Error(`No RPC URL configured for chain ${chain}`)
+
+  const fromBlock = await getFromBlock()
+  const toBlock = await getToBlock()
+  if (fromBlock > toBlock) return '0'
+
+  const blocks = Array.from({ length: toBlock - fromBlock + 1 }, (_, i) => fromBlock + i)
+  const { results, errors } = await PromisePool
+    .withConcurrency(RPC_FEE_FETCH_CONCURRENCY)
+    .for(blocks)
+    .process((blockNumber) => fetchBlockReceiptsTotalFees(rpc, blockNumber))
+
+  if (errors.length > 0) throw (errors[0] as any).raw ?? errors[0]
+
+  return (results as bigint[]).reduce((sum, fees) => sum + fees, 0n).toString()
+}
+
+async function fetchTotalFees(chain: string, url: string, dateString: string, requestConfig: any, config: any, options: FetchOptions) {
+  if (config.useRpcFees) return fetchRpcTotalFees(chain, options, config.rpc)
+
+  const fees = await httpGet(`${url}&date=${dateString}`, requestConfig)
+  if (!fees || fees.result === undefined || fees.result === null) {
+    console.log(chain, ' Error fetching fees', fees)
+    throw new Error('Error fetching fees')
+  }
+
+  return fees.result
+}
+
 export function blockscoutFeeAdapter2(chain: string) {
   let config = chainConfigMap[chain]
   if (!config) throw new Error(`No blockscout config for chain ${chain}`)
@@ -157,7 +234,8 @@ export function blockscoutFeeAdapter2(chain: string) {
     deadFrom,
     adapter: {
       [chain]: {
-        fetch: async (_timestamp: number, _: ChainBlocks, { chain, createBalances, startOfDay, }: FetchOptions) => {
+        fetch: async (_timestamp: number, _: ChainBlocks, options: FetchOptions) => {
+          const { chain, createBalances, startOfDay, } = options
 
           const dateString = getTimeString(startOfDay)
           let todayData = undefined
@@ -195,8 +273,8 @@ export function blockscoutFeeAdapter2(chain: string) {
             todayData = gasData[chain]?.[dateString]
             todayPrice = bulkStoreCGData[CGToken][dateString]
             if (todayData === undefined) {
-              const fees = await httpGet(`${url}&date=${dateString}`, requestConfig)
-              todayData = fees.result / 1e18
+              const fees = await fetchTotalFees(chain, url, dateString, requestConfig, config, options)
+              todayData = Number(fees) / 1e18
             }
 
             if (todayPrice === undefined || todayData === undefined) {
@@ -224,13 +302,9 @@ export function blockscoutFeeAdapter2(chain: string) {
 
 
           const dailyFees = createBalances()
-          const fees = await httpGet(`${url}&date=${dateString}`)
-          if (!fees || fees.result === undefined || fees.result === null) {
-            console.log(chain, ' Error fetching fees', fees)
-            throw new Error('Error fetching fees')
-          }
-          if (CGToken) dailyFees.addCGToken(CGToken, fees.result / 1e18)
-          else dailyFees.addGasToken(fees.result)
+          const fees = await fetchTotalFees(chain, url, dateString, requestConfig, config, options)
+          if (CGToken) dailyFees.addCGToken(CGToken, Number(fees) / 1e18)
+          else dailyFees.addGasToken(fees)
 
           if (config.burnRatio !== undefined && config.burnRatio !== null) {
             const dailyRevenue = dailyFees.clone(config.burnRatio);

--- a/helpers/blockscoutFees.ts
+++ b/helpers/blockscoutFees.ts
@@ -1,6 +1,5 @@
 import { Adapter, ChainBlocks, FetchOptions, ProtocolType } from '../adapters/types';
-import { PromisePool } from '@supercharge/promise-pool';
-import { httpGet, httpPost } from '../utils/fetchURL';
+import { httpGet } from '../utils/fetchURL';
 import { CHAIN } from './chains';
 import { getEnv } from './env';
 
@@ -84,7 +83,6 @@ export const chainConfigMap: any = {
   [CHAIN.ADVENTURE_LAYER]: { CGToken: 'adventure-gold', explorer: 'https://advlayer-mainnet.cloud.blockscout.com/' },
   [CHAIN.DERI_CHAIN]: { CGToken: 'ethereum', explorer: 'https://explorer-dchain.deri.io/' },
   [CHAIN.EARNM]: { CGToken: 'earnm', explorer: 'https://earnm-mainnet.explorer.alchemy.com/' },
-  [CHAIN.DUCK_CHAIN]: { CGToken: 'the-open-network', explorer: 'https://scan.duckchain.io/', useRpcFees: true, rpc: 'https://rpc.duckchain.io' },
   [CHAIN.EDU_CHAIN]: { CGToken: 'EDU', explorer: 'https://educhain.blockscout.com/' },
   [CHAIN.ETHEREAL]: { CGToken: 'ethena-usde', explorer: 'https://explorer.ethereal.trade/' },
   [CHAIN.EVENTUM]: { CGToken: 'ethereum', explorer: 'https://explorer.evedex.com/' },
@@ -147,82 +145,6 @@ async function sleep(time: number) {
   return new Promise((resolve) => setTimeout(resolve, time))
 }
 
-const RPC_FEE_FETCH_CONCURRENCY = 5
-const RPC_FEE_FETCH_RETRIES = 5
-
-function toBigInt(value: any) {
-  if (typeof value === 'bigint') return value
-  if (typeof value === 'number') return BigInt(value)
-  if (typeof value === 'string') return BigInt(value)
-  if (value?._hex) return BigInt(value._hex)
-  return BigInt(value.toString())
-}
-
-async function retryRpcCall<T>(fn: () => Promise<T>) {
-  let lastError: any
-  for (let i = 0; i < RPC_FEE_FETCH_RETRIES; i++) {
-    try {
-      return await fn()
-    } catch (error) {
-      lastError = error
-      await sleep(1000 * (i + 1))
-    }
-  }
-
-  throw lastError
-}
-
-async function fetchBlockReceiptsTotalFees(rpc: string, blockNumber: number) {
-  const response = await retryRpcCall(() => httpPost(rpc, {
-    jsonrpc: '2.0',
-    id: 1,
-    method: 'eth_getBlockReceipts',
-    params: [`0x${blockNumber.toString(16)}`],
-  }))
-  if (response.error) throw new Error(response.error.message ?? `RPC error fetching receipts for block ${blockNumber}`)
-  if (!Array.isArray(response.result)) throw new Error(`Invalid receipts response for block ${blockNumber}`)
-
-  return response.result.reduce((sum: bigint, receipt: any) => {
-    const gasUsed = toBigInt(receipt.gasUsed ?? 0)
-    if (gasUsed === 0n) return sum
-
-    const gasPrice = receipt.effectiveGasPrice ?? receipt.gasPrice
-    if (gasPrice === undefined || gasPrice === null) throw new Error(`Missing gas price for ${receipt.transactionHash}`)
-
-    return sum + gasUsed * toBigInt(gasPrice)
-  }, 0n)
-}
-
-async function fetchRpcTotalFees(chain: string, { getFromBlock, getToBlock }: FetchOptions, rpc?: string) {
-  if (!rpc) throw new Error(`No RPC URL configured for chain ${chain}`)
-
-  const fromBlock = await getFromBlock()
-  const toBlock = await getToBlock()
-  if (fromBlock > toBlock) return '0'
-
-  const blocks = Array.from({ length: toBlock - fromBlock + 1 }, (_, i) => fromBlock + i)
-  const { results, errors } = await PromisePool
-    .withConcurrency(RPC_FEE_FETCH_CONCURRENCY)
-    .for(blocks)
-    .process((blockNumber) => fetchBlockReceiptsTotalFees(rpc, blockNumber))
-
-  if (errors.length > 0) throw (errors[0] as any).raw ?? errors[0]
-
-  return (results as bigint[]).reduce((sum, fees) => sum + fees, 0n).toString()
-}
-
-async function fetchTotalFees(chain: string, url: string, dateString: string, requestConfig: any, config: any, options: FetchOptions) {
-  if (config.useRpcFees) return fetchRpcTotalFees(chain, options, config.rpc)
-
-  const fees = await httpGet(`${url}&date=${dateString}`, requestConfig)
-  if (!fees || fees.result === undefined || fees.result === null) {
-    console.log(chain, ' Error fetching fees', fees)
-    throw new Error('Error fetching fees')
-  }
-
-  return fees.result
-}
-
 export function blockscoutFeeAdapter2(chain: string) {
   let config = chainConfigMap[chain]
   if (!config) throw new Error(`No blockscout config for chain ${chain}`)
@@ -234,8 +156,7 @@ export function blockscoutFeeAdapter2(chain: string) {
     deadFrom,
     adapter: {
       [chain]: {
-        fetch: async (_timestamp: number, _: ChainBlocks, options: FetchOptions) => {
-          const { chain, createBalances, startOfDay, } = options
+        fetch: async (_timestamp: number, _: ChainBlocks, { chain, createBalances, startOfDay, }: FetchOptions) => {
 
           const dateString = getTimeString(startOfDay)
           let todayData = undefined
@@ -273,8 +194,8 @@ export function blockscoutFeeAdapter2(chain: string) {
             todayData = gasData[chain]?.[dateString]
             todayPrice = bulkStoreCGData[CGToken][dateString]
             if (todayData === undefined) {
-              const fees = await fetchTotalFees(chain, url, dateString, requestConfig, config, options)
-              todayData = Number(fees) / 1e18
+              const fees = await httpGet(`${url}&date=${dateString}`, requestConfig)
+              todayData = fees.result / 1e18
             }
 
             if (todayPrice === undefined || todayData === undefined) {
@@ -302,9 +223,13 @@ export function blockscoutFeeAdapter2(chain: string) {
 
 
           const dailyFees = createBalances()
-          const fees = await fetchTotalFees(chain, url, dateString, requestConfig, config, options)
-          if (CGToken) dailyFees.addCGToken(CGToken, Number(fees) / 1e18)
-          else dailyFees.addGasToken(fees)
+          const fees = await httpGet(`${url}&date=${dateString}`)
+          if (!fees || fees.result === undefined || fees.result === null) {
+            console.log(chain, ' Error fetching fees', fees)
+            throw new Error('Error fetching fees')
+          }
+          if (CGToken) dailyFees.addCGToken(CGToken, fees.result / 1e18)
+          else dailyFees.addGasToken(fees.result)
 
           if (config.burnRatio !== undefined && config.burnRatio !== null) {
             const dailyRevenue = dailyFees.clone(config.burnRatio);


### PR DESCRIPTION
```markdown
## Summary

Fixes #6500.

This PR fixes DuckChain chain fee tracking in the generic Blockscout fee adapter.

## Root cause


DuckChain is already wired through the Blockscout chain-fees factory, but the adapter was failing because DuckChain's Blockscout stats endpoints currently return Cloudflare `522` plain text instead of fee JSON.

The broken endpoint was:

```text
https://scan.duckchain.io/api?module=stats&action=totalfees&date=2026-04-25
```

DuckChain's public RPC is available and supports `eth_getBlockReceipts`, so DuckChain now uses receipt-based gas fee summing while other Blockscout chains keep the existing stats API path.

## Changes

- Add an opt-in RPC receipt fee path for DuckChain
- Sum `gasUsed * effectiveGasPrice` from `eth_getBlockReceipts`
- Keep DuckChain mapped through the existing `factory/blockscout.ts` registry
- Preserve existing Blockscout fee behavior for other chains
- No new dependencies