### PR TITLE
fix(fees/buffer): set deadFrom for DNS-dead Satsuma subgraph endpoint

### DIFF
--- a/fees/buffer/index.ts
+++ b/fees/buffer/index.ts
@@ -59,6 +59,7 @@ const adapter: Adapter = {
   fetch,
   chains: [CHAIN.ARBITRUM],
   start: '2023-01-29',
+  deadFrom: '2025-07-17',
   methodology,
   breakdownMethodology,
 };


### PR DESCRIPTION
Closes #6503.

The Buffer Finance fees adapter calls a Satsuma-hosted subgraph at `subgraph.satsuma-prod.com/.../bufferfinance/v2.5-arbitrum-mainnet/api` whose hostname no longer resolves DNS. `pnpm test fees buffer` fails with `ENOTFOUND` for every fetch; nothing has been ingested since mid-2025.

Setting `deadFrom: '2025-07-17'` retires the adapter from current fetches while preserving the historical chart on `defillama.com/protocol/buffer-finance`. Same playbook as the recently-merged Ribbon (#6551), Premia v2 (#6559), Collex (#6565), and wavex (#6578) fixes.

The chosen date is the day after the last non-zero fee point on the protocol's historical chart (last value `2025-07-16` per `https://api.llama.fi/summary/fees/buffer-finance`).