### PR TITLE
[fix] wavex - handle no-fee days

### DIFF
--- a/fees/wavex/index.ts
+++ b/fees/wavex/index.ts
@@ -19,14 +19,26 @@ const fetch = async (_t: any, _b: any, { chain, startOfDay }: any) => {
   const res = await axios.get(
     `${endpoints[chain]}/stats/fees?timestamp=${todaysTimestamp}`
   );
+  const fees = res.data?.data;
+
+  if (!fees) {
+    return {
+      dailyFees: "0",
+      dailyUserFees: "0",
+      dailyRevenue: "0",
+      dailyProtocolRevenue: "0",
+      dailySupplySideRevenue: "0",
+    };
+  }
+
   const dailyFee =
-    parseInt(res.data.data.mint) +
-    parseInt(res.data.data.burn) +
-    parseInt(res.data.data.marginAndLiquidation) +
-    parseInt(res.data.data.swap);
+    parseInt(fees.mint) +
+    parseInt(fees.burn) +
+    parseInt(fees.marginAndLiquidation) +
+    parseInt(fees.swap);
   const finalDailyFee = dailyFee / 1e30;
   const userFee =
-    parseInt(res.data.data.marginAndLiquidation) + parseInt(res.data.data.swap);
+    parseInt(fees.marginAndLiquidation) + parseInt(fees.swap);
   const finalUserFee = userFee / 1e30;
 
   return {


### PR DESCRIPTION
Fixes DefiLlama/dimension-adapters#6517

## Summary
- handle waveX indexer days where `/stats/fees` returns `data: null`
- return zero fees/revenue for no-fee days instead of throwing while reading fee component fields
- preserve the existing fee split and historical nonzero calculations

## Validation
- `pnpm test fees wavex 2026-01-20`
- `pnpm test fees wavex 2026-04-28`
- `pnpm run ts-check`
- `git diff --check`
