### PR TITLE
[fix] wavex - end inactive fees adapter

### DIFF
--- a/fees/wavex/index.ts
+++ b/fees/wavex/index.ts
@@ -45,6 +45,7 @@ const adapter: Adapter = {
     [CHAIN.SONEIUM]: {
       fetch,
       start: "2024-12-27",
+      deadFrom: "2026-01-03",
     },
   },
 };


### PR DESCRIPTION
## Summary
- Mark Wavex fees adapter as inactive from 2026-01-03, when the API starts returning null data.
- Keeps historical fetches before the cutoff working while avoiding current adapter failures.

## Tests
- pnpm test fees wavex
- pnpm test fees wavex 2026-01-02
- pnpm test fees wavex 2025-01-15
- pnpm run ts-check