### PR TITLE
[fix] suite - end suspended fees source

### DIFF
--- a/fees/suite/index.ts
+++ b/fees/suite/index.ts
@@ -37,6 +37,7 @@ const adapter: Adapter = {
     [CHAIN.SUI]: {
       fetch: fetchSuiteStats,
       start: '2024-09-25',
+      deadFrom: '2025-11-10',
     },
   },
   methodology: {


### PR DESCRIPTION
## Summary

- ends the Suite fees adapter at `2025-11-10`
- the adapter's only upstream source (`https://crypton-be-bk6w.onrender.com/by-day`) now returns a 503 suspended-service page
- DefiLlama's stored Suite fee/revenue charts currently stop at `2025-11-09`, so the adapter now stops on the following day instead of failing current runs

Closes #6505.

## Validation

- `npm test -- fees/suite`
- `npm run ts-check`

Current adapter test output confirms the Sui adapter is skipped because it ended at `Mon, 10 Nov 2025 00:00:00 GMT`.
