### PR TITLE
[fix] xchain - end inactive fees adapter

### DIFF
--- a/helpers/blockscoutFees.ts
+++ b/helpers/blockscoutFees.ts
@@ -93,7 +93,7 @@ export const chainConfigMap: any = {
   [CHAIN.MIND_NETWORK]: { CGToken: 'ethereum', explorer: 'https://explorer.mindnetwork.xyz/' },
   [CHAIN.MOLTEN_NETWORK]: { CGToken: 'molten-2', explorer: 'https://molten.calderaexplorer.xyz/' },
   [CHAIN.SYNDICATE]: { CGToken: 'syndicate-3', explorer: 'https://explorer.syndicate.io/' },
-  [CHAIN.XCHAIN]: { CGToken: 'ethereum', explorer: 'https://xchain-explorer.kuma.bid/' },
+  [CHAIN.XCHAIN]: { CGToken: 'ethereum', explorer: 'https://xchain-explorer.kuma.bid/', deadFrom: '2026-01-24' },
   [CHAIN.SHIBARIUM]: { CGToken: 'bone-shibaswap', explorer: 'https://shibariumscan.io/' },
   [CHAIN.VANA]: { CGToken: 'vana', explorer: 'https://vanascan.io/' },
   [CHAIN.NEO_X_MAINNET]: { CGToken: "gas", explorer: "https://xexplorer.neo.org/" },


### PR DESCRIPTION
## Summary
- Mark the XChain fees adapter inactive from 2026-01-24, after the chain fee chart drops to zero and the Blockscout endpoint stops serving valid API responses.
- Prevents current runs from failing on the broken explorer TLS/API host.

## Tests
- pnpm test fees xchain
- pnpm run ts-check

## Notes
- Historical requests against the old explorer still fail because `xchain-explorer.kuma.bid` now resolves to a Conduit host with a mismatched certificate and the direct Conduit host returns 502/404 for the API.