### PR TITLE
[fix] rezerve-money - end inactive Shadow fee source

### DIFF
--- a/fees/rezerve-money/index.ts
+++ b/fees/rezerve-money/index.ts
@@ -4,14 +4,12 @@ import { fetchBond } from "./bonds";
 import { fetchRebases } from "./rebases";
 import { fetchFeesFromShadow } from "./shadow";
 
-const SHADOW_FEES_END = 1761955200; // 2025-11-01
-
 const fetch = async (options: FetchOptions) => {
   const dailyFees = options.createBalances();
   const dailyRevenue = options.createBalances();
   const dailyHoldersRevenue = options.createBalances();
 
-  if (options.startOfDay < SHADOW_FEES_END) await fetchFeesFromShadow(dailyFees, options);
+  await fetchFeesFromShadow(dailyFees, options);
   await fetchBond(dailyFees, dailyRevenue, options);
   await fetchRebases(dailyHoldersRevenue, options);
 
@@ -34,6 +32,7 @@ const adapter: SimpleAdapter = {
     [CHAIN.SONIC]: {
       fetch,
       start: "2025-06-13",
+      deadFrom: "2025-11-01"
     },
   },
   methodology,

--- a/fees/rezerve-money/index.ts
+++ b/fees/rezerve-money/index.ts
@@ -4,12 +4,14 @@ import { fetchBond } from "./bonds";
 import { fetchRebases } from "./rebases";
 import { fetchFeesFromShadow } from "./shadow";
 
+const SHADOW_FEES_END = 1761955200; // 2025-11-01
+
 const fetch = async (options: FetchOptions) => {
   const dailyFees = options.createBalances();
   const dailyRevenue = options.createBalances();
   const dailyHoldersRevenue = options.createBalances();
 
-  await fetchFeesFromShadow(dailyFees, options);
+  if (options.startOfDay < SHADOW_FEES_END) await fetchFeesFromShadow(dailyFees, options);
   await fetchBond(dailyFees, dailyRevenue, options);
   await fetchRebases(dailyHoldersRevenue, options);
 


### PR DESCRIPTION
## Summary
- Stop querying Rezerve Money's Shadow POL fee source after 2025-11-01, when that fee source flatlined.
- Keeps the remaining on-chain bond/rebase fee sources running instead of failing the whole adapter on the removed Shadow subgraph deployment.

## Tests
- pnpm test fees rezerve-money
- pnpm test fees rezerve-money 2025-11-03
- pnpm test fees rezerve-money 2025-11-05
- pnpm run ts-check