### PR TITLE
[fix] jpg-store - end unavailable fees source

### DIFF
--- a/fees/jpg-store/index.ts
+++ b/fees/jpg-store/index.ts
@@ -25,6 +25,7 @@ const adapter: Adapter = {
     [CHAIN.CARDANO]: {
       fetch,
       start: "2024-06-08",
+      deadFrom: "2025-08-23",
     },
   },
   methodology: {


### PR DESCRIPTION
## Summary

- ends the JPG Store fees adapter from `2025-08-23`
- the adapter's only upstream source (`https://tidelabs.io/api/defillama/jpg-store/fees`) now refuses connections, including for historical windows
- DefiLlama's stored JPG Store fee/user-fee/revenue charts currently stop at `2025-08-22`, so this prevents current adapter runs from querying a dead source past the last available datapoint

Closes #6513.

## Validation

- `npm test -- fees/jpg-store`
- `npm run ts-check`

The adapter test confirms Cardano is skipped because the adapter ended at `Sat, 23 Aug 2025 00:00:00 GMT`.
