### PR TITLE
Add Hyperlane fees adapter

### DIFF
--- a/fees/hyperlane.ts
+++ b/fees/hyperlane.ts
@@ -78,7 +78,7 @@ const PROTOCOL_FEE_PAID_EVENT =
   "event ProtocolFeePaid(address indexed sender, uint256 fee)";
 
 const INTERCHAIN_FEE_LABEL = "Interchain Gas Payments";
-const PROTOCOL_FEE_LABEL = "Protocol Fees";
+const PROTOCOL_FEE_LABEL = "Protocol Fee Hook Fees";
 const REQUIRED_REGISTRY_KEYS = new Set(["interchainGasPaymaster", "protocolFee", "mailbox"]);
 
 // Standard zeroed response used whenever a chain is unsupported, pre-index,
@@ -215,7 +215,10 @@ async function getRegistry() {
       ).length;
       if (!parsedCandidateCount) throw new Error("Failed to parse any Hyperlane candidate chains from addresses.yaml");
       return parsed;
-    })();
+    })().catch((error) => {
+      registryPromise = null;
+      throw error;
+    });
   }
 
   return registryPromise;
@@ -229,7 +232,10 @@ async function getMetadata() {
       const parsed = parseMetadata(data);
       if (!Object.keys(parsed).length) throw new Error("Failed to parse Hyperlane metadata.yaml");
       return parsed;
-    })();
+    })().catch((error) => {
+      metadataPromise = null;
+      throw error;
+    });
   }
 
   return metadataPromise;

--- a/fees/hyperlane.ts
+++ b/fees/hyperlane.ts
@@ -1,0 +1,346 @@
+/**
+ * Hyperlane core-fee adapter.
+ *
+ * Accounting model:
+ * - dailyFees: gross user-paid interchain delivery fees from InterchainGasPaymaster GasPayment events
+ * - dailyRevenue / dailyProtocolRevenue: protocol-retained fees from ProtocolFeePaid events
+ *
+ * Data sources:
+ * - chains/addresses.yaml for deployed Hyperlane contract addresses
+ * - chains/metadata.yaml for production/testnet/availability/indexing metadata
+ *
+ * Resilience policy:
+ * - if one chain cannot resolve blocks or logs, that chain returns zero and the run continues
+ * - chain list is limited to a curated Hyperlane EVM candidate set, and failing chains degrade to zero
+ */
+import { FetchOptions, SimpleAdapter } from "../adapters/types";
+import { getConfig } from "../helpers/cache";
+
+type ChainConfig = {
+  mailbox?: string;
+  interchainGasPaymaster?: string;
+  protocolFee?: string;
+};
+
+type ChainMetadata = {
+  protocol?: string;
+  isTestnet?: boolean;
+  availabilityStatus?: string;
+  indexFrom?: number;
+};
+
+// These Hyperlane registry endpoints follow the same source-of-truth approach used
+// by Hyperlane's TVL adapter in DefiLlama-Adapters.
+
+const REGISTRY_URL =
+  "https://raw.githubusercontent.com/hyperlane-xyz/hyperlane-registry/main/chains/addresses.yaml";
+const METADATA_URL =
+  "https://raw.githubusercontent.com/hyperlane-xyz/hyperlane-registry/main/chains/metadata.yaml";
+
+const CHAIN_MAP: Record<string, string> = {
+  avalanche: "avax",
+  gnosis: "xdai",
+  hyperevm: "hyperliquid",
+  plume: "plume_mainnet",
+  swell: "swellchain",
+  zoramainnet: "zora",
+};
+
+const HYPERLANE_CHAIN_CANDIDATES = [
+  "arbitrum",
+  "avax",
+  "base",
+  "blast",
+  "bsc",
+  "bsquared",
+  "celo",
+  "ethereum",
+  "ink",
+  "linea",
+  "mantle",
+  "metis",
+  "mode",
+  "optimism",
+  "polygon",
+  "scroll",
+  "sonic",
+  "swellchain",
+  "unichain",
+  "vana",
+  "xdai",
+  "zora",
+];
+
+const SUPPORTED_CHAINS = HYPERLANE_CHAIN_CANDIDATES;
+
+const GAS_PAYMENT_EVENT =
+  "event GasPayment(bytes32 indexed messageId, uint32 indexed destinationDomain, uint256 gasAmount, uint256 payment)";
+const PROTOCOL_FEE_PAID_EVENT =
+  "event ProtocolFeePaid(address indexed sender, uint256 fee)";
+
+const INTERCHAIN_FEE_LABEL = "Interchain Gas Payments";
+const PROTOCOL_FEE_LABEL = "Protocol Fees";
+const REQUIRED_REGISTRY_KEYS = new Set(["interchainGasPaymaster", "protocolFee", "mailbox"]);
+
+// Standard zeroed response used whenever a chain is unsupported, pre-index,
+// or temporarily unhealthy so the adapter can continue for the rest.
+function emptyResponse(options: FetchOptions) {
+  const dailyFees = options.createBalances();
+  const dailyRevenue = options.createBalances();
+
+  return {
+    dailyFees,
+    dailyRevenue,
+    dailyProtocolRevenue: dailyRevenue,
+  };
+}
+
+function sanitizeYamlLine(rawLine: string) {
+  const line = rawLine.replace(/\t/g, "    ");
+  let out = "";
+  let quote: '"' | "'" | null = null;
+
+  for (let i = 0; i < line.length; i++) {
+    const char = line[i];
+    if ((char === '"' || char === "'") && line[i - 1] !== "\\") {
+      quote = quote === char ? null : (char as '"' | "'");
+      out += char;
+      continue;
+    }
+
+    if (char === "#" && !quote) break;
+    out += char;
+  }
+
+  return out.trimEnd();
+}
+
+function parseScalar(rawValue: string) {
+  return rawValue.trim().replace(/^["']|["']$/g, "");
+}
+
+function parseRegistry(yaml: string): Record<string, ChainConfig> {
+  const registry: Record<string, ChainConfig> = {};
+  let currentChain = "";
+
+  for (const rawLine of yaml.split(/\r?\n/)) {
+    const line = sanitizeYamlLine(rawLine);
+    if (!line.trim() || line.trim().startsWith("#")) continue;
+
+    const indent = line.search(/\S/);
+    if (indent === 0 && line.endsWith(":")) {
+      currentChain = line.slice(0, -1).trim();
+      registry[currentChain] = {};
+      continue;
+    }
+
+    if (indent !== 2 || !currentChain) continue;
+    const match = line.match(/^\s{2}([\w-]+):\s*(.+?)\s*$/);
+    if (!match) continue;
+
+    const [, key, rawValue] = match;
+    if (REQUIRED_REGISTRY_KEYS.has(key)) registry[currentChain][key as keyof ChainConfig] = parseScalar(rawValue);
+  }
+
+  return registry;
+}
+
+function parseMetadata(yaml: string): Record<string, ChainMetadata> {
+  const metadata: Record<string, ChainMetadata> = {};
+  let currentChain = "";
+  let currentSection = "";
+
+  for (const rawLine of yaml.split(/\r?\n/)) {
+    const line = sanitizeYamlLine(rawLine);
+    if (!line.trim() || line.trim().startsWith("#")) continue;
+
+    const indent = line.search(/\S/);
+    if (indent === 0 && line.endsWith(":")) {
+      currentChain = line.slice(0, -1).trim();
+      currentSection = "";
+      metadata[currentChain] = {};
+      continue;
+    }
+
+    if (!currentChain) continue;
+
+    if (indent === 2 && line.endsWith(":")) {
+      currentSection = line.trim().slice(0, -1);
+      continue;
+    }
+
+    const rootMatch = line.match(/^\s{2}([\w-]+):\s*(.+?)\s*$/);
+    if (indent === 2 && rootMatch) {
+      const [, key, rawValue] = rootMatch;
+      const value = parseScalar(rawValue);
+      if (key === "protocol") metadata[currentChain].protocol = value;
+      else if (key === "isTestnet") metadata[currentChain].isTestnet = value === "true";
+      continue;
+    }
+
+    const nestedMatch = line.match(/^\s{4}([\w-]+):\s*(.+?)\s*$/);
+    if (indent === 4 && nestedMatch) {
+      const [, key, rawValue] = nestedMatch;
+      const value = parseScalar(rawValue);
+      if (currentSection === "availability" && key === "status")
+        metadata[currentChain].availabilityStatus = value;
+      else if (currentSection === "index" && key === "from")
+        metadata[currentChain].indexFrom = Number(value);
+    }
+  }
+
+  return metadata;
+}
+
+let registryPromise: Promise<Record<string, ChainConfig>> | null = null;
+let metadataPromise: Promise<Record<string, ChainMetadata>> | null = null;
+
+async function getRegistry() {
+  if (!registryPromise) {
+    registryPromise = (async () => {
+      const data = await getConfig("hyperlane/addresses", REGISTRY_URL);
+      if (typeof data !== "string") throw new Error("Hyperlane registry fetch did not return YAML text");
+      const parsed = parseRegistry(data);
+      const parsedCandidateCount = HYPERLANE_CHAIN_CANDIDATES.filter((chain) =>
+        Object.entries(parsed).some(([registryChain, config]) =>
+          (CHAIN_MAP[registryChain] ?? registryChain) === chain && !!config.interchainGasPaymaster
+        )
+      ).length;
+      if (!parsedCandidateCount) throw new Error("Failed to parse any Hyperlane candidate chains from addresses.yaml");
+      return parsed;
+    })();
+  }
+
+  return registryPromise;
+}
+
+async function getMetadata() {
+  if (!metadataPromise) {
+    metadataPromise = (async () => {
+      const data = await getConfig("hyperlane/metadata", METADATA_URL);
+      if (typeof data !== "string") throw new Error("Hyperlane metadata fetch did not return YAML text");
+      const parsed = parseMetadata(data);
+      if (!Object.keys(parsed).length) throw new Error("Failed to parse Hyperlane metadata.yaml");
+      return parsed;
+    })();
+  }
+
+  return metadataPromise;
+}
+
+async function getChainConfig(chain: string) {
+  const [registry, metadata] = await Promise.all([getRegistry(), getMetadata()]);
+
+  for (const [registryChain, config] of Object.entries(registry)) {
+    const mappedChain = CHAIN_MAP[registryChain] ?? registryChain;
+    if (mappedChain !== chain) continue;
+    if (!config.interchainGasPaymaster?.startsWith("0x")) return undefined;
+    return {
+      config,
+      metadata: metadata[registryChain] ?? metadata[mappedChain],
+    };
+  }
+}
+
+async function fetch(options: FetchOptions) {
+  // Resolve per-chain contracts dynamically from Hyperlane's registry.
+  const chainData = await getChainConfig(options.chain);
+  if (!chainData?.config?.interchainGasPaymaster) return emptyResponse(options);
+
+  const { config, metadata } = chainData;
+
+  // Only run on production EVM chains that Hyperlane metadata marks as available.
+  if (metadata?.isTestnet || metadata?.availabilityStatus === "disabled" || metadata?.protocol !== "ethereum")
+    return emptyResponse(options);
+
+  let fromBlock: number | null = null;
+  let toBlock: number | null = null;
+  try {
+    fromBlock = await options.getStartBlock();
+    toBlock = await options.getEndBlock();
+  } catch {
+    return emptyResponse(options);
+  }
+
+  if (fromBlock == null || toBlock == null) {
+    return emptyResponse(options);
+  }
+
+  if (metadata?.indexFrom && toBlock < metadata.indexFrom) return emptyResponse(options);
+  const effectiveFromBlock = metadata?.indexFrom ? Math.max(fromBlock, metadata.indexFrom) : fromBlock;
+  if (effectiveFromBlock > toBlock) return emptyResponse(options);
+
+  const dailyFees = options.createBalances();
+  const dailyRevenue = options.createBalances();
+
+  try {
+    // Gross Hyperlane core fees paid by users for message delivery.
+    const gasPayments = await options.getLogs({
+      fromBlock: effectiveFromBlock,
+      toBlock,
+      target: config.interchainGasPaymaster,
+      eventAbi: GAS_PAYMENT_EVENT,
+    });
+
+    gasPayments.forEach((log: any) => {
+      dailyFees.addGasToken(log.payment, INTERCHAIN_FEE_LABEL);
+    });
+
+    if (config.protocolFee?.startsWith("0x")) {
+      try {
+        // Protocol-retained fee hook revenue. On many chains this is currently zero
+        // because the fee hook is configured but protocolFee() is disabled.
+        const protocolFeePayments = await options.getLogs({
+          fromBlock: effectiveFromBlock,
+          toBlock,
+          target: config.protocolFee,
+          eventAbi: PROTOCOL_FEE_PAID_EVENT,
+        });
+
+        protocolFeePayments.forEach((log: any) => {
+          dailyRevenue.addGasToken(log.fee, PROTOCOL_FEE_LABEL);
+        });
+      } catch {}
+    }
+
+    return {
+      dailyFees,
+      dailyRevenue,
+      dailyProtocolRevenue: dailyRevenue,
+    };
+  } catch {
+    // Chain-level runtime issues degrade to zero so the rest of the adapter can continue,
+    // but registry/metadata parsing failures still surface above because they affect all chains.
+    return emptyResponse(options);
+  }
+}
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  chains: SUPPORTED_CHAINS,
+  start: "2025-01-01",
+  fetch,
+  methodology: {
+    Fees: "Tracks gross user-paid interchain delivery fees by summing Hyperlane InterchainGasPaymaster GasPayment events on each origin chain, with contract addresses loaded dynamically from Hyperlane's registry.",
+    Revenue:
+      "Tracks retained Hyperlane protocol fee revenue by summing ProtocolFeePaid events emitted by Hyperlane's ProtocolFee hook contracts when configured in the Hyperlane registry.",
+    ProtocolRevenue:
+      "Same as Revenue: sums ProtocolFeePaid events emitted by Hyperlane's ProtocolFee hook contracts when configured in the Hyperlane registry.",
+  },
+  breakdownMethodology: {
+    dailyFees: {
+      [INTERCHAIN_FEE_LABEL]:
+        "Sum of payment values emitted in Hyperlane InterchainGasPaymaster GasPayment events.",
+    },
+    dailyRevenue: {
+      [PROTOCOL_FEE_LABEL]:
+        "Sum of fee values emitted in Hyperlane ProtocolFeePaid events.",
+    },
+    dailyProtocolRevenue: {
+      [PROTOCOL_FEE_LABEL]:
+        "Sum of fee values emitted in Hyperlane ProtocolFeePaid events.",
+    },
+  },
+};
+
+export default adapter;

--- a/fees/hyperlane.ts
+++ b/fees/hyperlane.ts
@@ -2,7 +2,8 @@
  * Hyperlane core-fee adapter.
  *
  * Accounting model:
- * - dailyFees: gross user-paid interchain delivery fees from InterchainGasPaymaster GasPayment events
+ * - dailyFees: total user-paid Hyperlane fees from InterchainGasPaymaster GasPayment events plus ProtocolFeePaid events
+ * - dailySupplySideRevenue: relayer compensation from InterchainGasPaymaster GasPayment events
  * - dailyRevenue / dailyProtocolRevenue: protocol-retained fees from ProtocolFeePaid events
  *
  * Data sources:
@@ -71,8 +72,6 @@ const HYPERLANE_CHAIN_CANDIDATES = [
   "zora",
 ];
 
-const SUPPORTED_CHAINS = HYPERLANE_CHAIN_CANDIDATES;
-
 const GAS_PAYMENT_EVENT =
   "event GasPayment(bytes32 indexed messageId, uint32 indexed destinationDomain, uint256 gasAmount, uint256 payment)";
 const PROTOCOL_FEE_PAID_EVENT =
@@ -87,14 +86,19 @@ const REQUIRED_REGISTRY_KEYS = new Set(["interchainGasPaymaster", "protocolFee",
 function emptyResponse(options: FetchOptions) {
   const dailyFees = options.createBalances();
   const dailyRevenue = options.createBalances();
+  const dailySupplySideRevenue = options.createBalances();
 
   return {
     dailyFees,
     dailyRevenue,
+    dailySupplySideRevenue,
     dailyProtocolRevenue: dailyRevenue,
   };
 }
 
+// The Hyperlane registry files currently use a simple scalar YAML shape:
+// exact 2-space indentation, simple key:value pairs, and no multi-line or
+// complex YAML features for the fields this adapter reads.
 function sanitizeYamlLine(rawLine: string) {
   const line = rawLine.replace(/\t/g, "    ");
   let out = "";
@@ -115,10 +119,13 @@ function sanitizeYamlLine(rawLine: string) {
   return out.trimEnd();
 }
 
+// Registry values are expected to be simple quoted/unquoted scalars only.
 function parseScalar(rawValue: string) {
   return rawValue.trim().replace(/^["']|["']$/g, "");
 }
 
+// addresses.yaml is expected to resolve into a flat per-chain object whose
+// relevant scalar fields match REQUIRED_REGISTRY_KEYS / ChainConfig.
 function parseRegistry(yaml: string): Record<string, ChainConfig> {
   const registry: Record<string, ChainConfig> = {};
   let currentChain = "";
@@ -258,7 +265,8 @@ async function fetch(options: FetchOptions) {
   try {
     fromBlock = await options.getStartBlock();
     toBlock = await options.getEndBlock();
-  } catch {
+  } catch (error) {
+    console.error("[hyperlane] block lookup failed", { chain: options.chain, error });
     return emptyResponse(options);
   }
 
@@ -272,9 +280,10 @@ async function fetch(options: FetchOptions) {
 
   const dailyFees = options.createBalances();
   const dailyRevenue = options.createBalances();
+  const dailySupplySideRevenue = options.createBalances();
 
   try {
-    // Gross Hyperlane core fees paid by users for message delivery.
+    // Relayer compensation paid by users for message delivery.
     const gasPayments = await options.getLogs({
       fromBlock: effectiveFromBlock,
       toBlock,
@@ -284,6 +293,7 @@ async function fetch(options: FetchOptions) {
 
     gasPayments.forEach((log: any) => {
       dailyFees.addGasToken(log.payment, INTERCHAIN_FEE_LABEL);
+      dailySupplySideRevenue.addGasToken(log.payment, INTERCHAIN_FEE_LABEL);
     });
 
     if (config.protocolFee?.startsWith("0x")) {
@@ -298,43 +308,67 @@ async function fetch(options: FetchOptions) {
         });
 
         protocolFeePayments.forEach((log: any) => {
+          dailyFees.addGasToken(log.fee, PROTOCOL_FEE_LABEL);
           dailyRevenue.addGasToken(log.fee, PROTOCOL_FEE_LABEL);
         });
-      } catch {}
+      } catch (error) {
+        console.error("[hyperlane] ProtocolFeePaid log fetch failed", {
+          chain: options.chain,
+          target: config.protocolFee,
+          event: PROTOCOL_FEE_PAID_EVENT,
+          error,
+        });
+      }
     }
 
     return {
       dailyFees,
       dailyRevenue,
+      dailySupplySideRevenue,
       dailyProtocolRevenue: dailyRevenue,
     };
-  } catch {
+  } catch (error) {
     // Chain-level runtime issues degrade to zero so the rest of the adapter can continue,
     // but registry/metadata parsing failures still surface above because they affect all chains.
+    console.error("[hyperlane] GasPayment log fetch failed", {
+      chain: options.chain,
+      target: config.interchainGasPaymaster,
+      event: GAS_PAYMENT_EVENT,
+      error,
+    });
     return emptyResponse(options);
   }
 }
 
 const adapter: SimpleAdapter = {
   version: 2,
-  chains: SUPPORTED_CHAINS,
+  chains: HYPERLANE_CHAIN_CANDIDATES,
   start: "2025-01-01",
+  pullHourly: true,
   fetch,
   methodology: {
-    Fees: "Tracks gross user-paid interchain delivery fees by summing Hyperlane InterchainGasPaymaster GasPayment events on each origin chain, with contract addresses loaded dynamically from Hyperlane's registry.",
+    Fees: "Tracks total user-paid Hyperlane fees by summing InterchainGasPaymaster GasPayment events and ProtocolFeePaid events on each origin chain, with contract addresses loaded dynamically from Hyperlane's registry.",
     Revenue:
       "Tracks retained Hyperlane protocol fee revenue by summing ProtocolFeePaid events emitted by Hyperlane's ProtocolFee hook contracts when configured in the Hyperlane registry.",
+    SupplySideRevenue:
+      "Tracks relayer compensation by summing InterchainGasPaymaster GasPayment events, which represent delivery fees paid through Hyperlane's relayer path.",
     ProtocolRevenue:
       "Same as Revenue: sums ProtocolFeePaid events emitted by Hyperlane's ProtocolFee hook contracts when configured in the Hyperlane registry.",
   },
   breakdownMethodology: {
     dailyFees: {
       [INTERCHAIN_FEE_LABEL]:
-        "Sum of payment values emitted in Hyperlane InterchainGasPaymaster GasPayment events.",
+        "Sum of relayer compensation values emitted in Hyperlane InterchainGasPaymaster GasPayment events.",
+      [PROTOCOL_FEE_LABEL]:
+        "Sum of protocol-retained fee values emitted in Hyperlane ProtocolFeePaid events.",
     },
     dailyRevenue: {
       [PROTOCOL_FEE_LABEL]:
         "Sum of fee values emitted in Hyperlane ProtocolFeePaid events.",
+    },
+    dailySupplySideRevenue: {
+      [INTERCHAIN_FEE_LABEL]:
+        "Sum of payment values emitted in Hyperlane InterchainGasPaymaster GasPayment events.",
     },
     dailyProtocolRevenue: {
       [PROTOCOL_FEE_LABEL]:

--- a/fees/hyperlane.ts
+++ b/fees/hyperlane.ts
@@ -2,177 +2,172 @@ import { Adapter, Dependencies, FetchOptions } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
 import { queryDuneSql } from "../helpers/dune";
 
-type HyperlaneFee = {
-  chain: string;
-  payment: string;
-  hyperlane_payment: string;
-  other_payment: string;
-}
-
 type ChainConfig = {
-  start: string;
-  duneSchema: string;
-  igp: string;
+    start: string;
+    duneSchema: string;
+    igp: string;
 }
 
 const chainConfig: Record<string, ChainConfig> = {
-  [CHAIN.ARBITRUM]: {
-    start: "2025-01-01",
-    duneSchema: "hyperlane_v3_arbitrum",
-    igp: "0x3b6044acd6767f017e99318aa6ef93b7b06a5a22",
-  },
-  [CHAIN.AVAX]: {
-    start: "2025-01-01",
-    duneSchema: "hyperlane_v3_avalanche_c",
-    igp: "0x95519ba800bbd0d34eeae026fec620ad978176c0",
-  },
-  [CHAIN.BSC]: {
-    start: "2025-01-01",
-    duneSchema: "hyperlane_v3_bnb",
-    igp: "0x78e25e7f84416e69b9339b0a6336eb6efff6b451",
-  },
-  [CHAIN.BASE]: {
-    start: "2025-01-01",
-    duneSchema: "hyperlane_v3_base",
-    igp: "0xc3f23848ed2e04c0c6d41bd7804fa8f89f940b94",
-  },
-  [CHAIN.BLAST]: {
-    start: "2025-01-01",
-    duneSchema: "hyperlane_v3_blast",
-    igp: "0xb3fccd379ad66ced0c91028520c64226611a48c9",
-  },
-  [CHAIN.CELO]: {
-    start: "2025-01-01",
-    duneSchema: "hyperlane_v3_celo",
-    igp: "0x571f1435613381208477ac5d6974310d88ac7cb7",
-  },
-  [CHAIN.ETHEREUM]: {
-    start: "2025-01-01",
-    duneSchema: "hyperlane_v3_ethereum",
-    igp: "0x9e6b1022be9bbf5afd152483dad9b88911bc8611",
-  },
-  [CHAIN.XDAI]: {
-    start: "2025-01-01",
-    duneSchema: "hyperlane_v3_gnosis",
-    igp: "0xdd260b99d302f0a3ff885728c086f729c06f227f",
-  },
-  [CHAIN.LINEA]: {
-    start: "2025-01-01",
-    duneSchema: "hyperlane_v3_linea",
-    igp: "0x8105a095368f1a184ccea86cce21318b5ee5be28",
-  },
-  [CHAIN.OPTIMISM]: {
-    start: "2025-01-01",
-    duneSchema: "hyperlane_v3_optimism",
-    igp: "0xd8a76c4d91fcbb7cc8ea795dfdf870e48368995c",
-  },
-  [CHAIN.POLYGON]: {
-    start: "2025-01-01",
-    duneSchema: "hyperlane_v3_polygon",
-    igp: "0x0071740bf129b05c4684abfbbed248d80971cce2",
-  },
-  [CHAIN.POLYGON_ZKEVM]: {
-    start: "2025-01-01",
-    duneSchema: "hyperlane_v3_zkevm",
-    igp: "0x0d63128d887159d63de29497dfa45afc7c699ae4",
-  },
-  [CHAIN.SCROLL]: {
-    start: "2025-01-01",
-    duneSchema: "hyperlane_v3_scroll",
-    igp: "0xbf12ef4b9f307463d3fb59c3604f294ddce287e2",
-  },
-  [CHAIN.MANTLE]: {
-    start: "2025-01-01",
-    duneSchema: "hyperlane_v3_mantle",
-    igp: "0x8105a095368f1a184ccea86cce21318b5ee5be28",
-  },
+    [CHAIN.ARBITRUM]: {
+        start: "2023-10-25",
+        duneSchema: "hyperlane_v3_arbitrum",
+        igp: "0x3b6044acd6767f017e99318aa6ef93b7b06a5a22",
+    },
+    [CHAIN.AVAX]: {
+        start: "2023-10-25",
+        duneSchema: "hyperlane_v3_avalanche_c",
+        igp: "0x95519ba800bbd0d34eeae026fec620ad978176c0",
+    },
+    [CHAIN.BSC]: {
+        start: "2023-10-25",
+        duneSchema: "hyperlane_v3_bnb",
+        igp: "0x78e25e7f84416e69b9339b0a6336eb6efff6b451",
+    },
+    [CHAIN.BASE]: {
+        start: "2023-10-25",
+        duneSchema: "hyperlane_v3_base",
+        igp: "0xc3f23848ed2e04c0c6d41bd7804fa8f89f940b94",
+    },
+    [CHAIN.BLAST]: {
+        start: "2024-04-25",
+        duneSchema: "hyperlane_v3_blast",
+        igp: "0xb3fccd379ad66ced0c91028520c64226611a48c9",
+    },
+    [CHAIN.CELO]: {
+        start: "2023-10-25",
+        duneSchema: "hyperlane_v3_celo",
+        igp: "0x571f1435613381208477ac5d6974310d88ac7cb7",
+    },
+    [CHAIN.ETHEREUM]: {
+        start: "2023-10-25",
+        duneSchema: "hyperlane_v3_ethereum",
+        igp: "0x9e6b1022be9bbf5afd152483dad9b88911bc8611",
+    },
+    [CHAIN.XDAI]: {
+        start: "2023-10-25",
+        duneSchema: "hyperlane_v3_gnosis",
+        igp: "0xdd260b99d302f0a3ff885728c086f729c06f227f",
+    },
+    [CHAIN.LINEA]: {
+        start: "2024-06-05",
+        duneSchema: "hyperlane_v3_linea",
+        igp: "0x8105a095368f1a184ccea86cce21318b5ee5be28",
+    },
+    [CHAIN.OPTIMISM]: {
+        start: "2023-10-25",
+        duneSchema: "hyperlane_v3_optimism",
+        igp: "0xd8a76c4d91fcbb7cc8ea795dfdf870e48368995c",
+    },
+    [CHAIN.POLYGON]: {
+        start: "2023-10-25",
+        duneSchema: "hyperlane_v3_polygon",
+        igp: "0x0071740bf129b05c4684abfbbed248d80971cce2",
+    },
+    [CHAIN.POLYGON_ZKEVM]: {
+        start: "2023-10-25",
+        duneSchema: "hyperlane_v3_zkevm",
+        igp: "0x0d63128d887159d63de29497dfa45afc7c699ae4",
+    },
+    [CHAIN.SCROLL]: {
+        start: "2023-10-25",
+        duneSchema: "hyperlane_v3_scroll",
+        igp: "0xbf12ef4b9f307463d3fb59c3604f294ddce287e2",
+    },
+    [CHAIN.MANTLE]: {
+        start: "2024-06-25",
+        duneSchema: "hyperlane_v3_mantle",
+        igp: "0x8105a095368f1a184ccea86cce21318b5ee5be28",
+    },
 };
 
 const IGP_FEES = "Interchain Gas Payments";
 
 const selectGasPayments = ([chain, config]: [string, ChainConfig], options: FetchOptions) => `
-  select
-    '${chain}' as chain,
-    payment,
-    contract_address = ${config.igp} as is_hyperlane_relayer
-  from ${config.duneSchema}.InterchainGasPaymaster_evt_GasPayment
-  where evt_block_time >= from_unixtime(${options.startTimestamp})
-    and evt_block_time < from_unixtime(${options.endTimestamp})
+    SELECT
+      '${chain}' AS chain,
+      payment,
+      contract_address = ${config.igp} AS is_hyperlane_relayer
+    FROM
+      ${config.duneSchema}.InterchainGasPaymaster_evt_GasPayment
+    WHERE
+      evt_block_time >= FROM_UNIXTIME(${options.startTimestamp})
+      AND evt_block_time < FROM_UNIXTIME(${options.endTimestamp})
 `;
 
-const query = (options: FetchOptions) => `
-with gas_payments as (
-${Object.entries(chainConfig).map(config => selectGasPayments(config, options)).join("  union all")}
-)
-select
-  chain,
-  sum(payment) as payment,
-  sum(if(is_hyperlane_relayer, payment, 0)) as hyperlane_payment,
-  sum(if(is_hyperlane_relayer, 0, payment)) as other_payment
-from gas_payments
-group by 1
+const query = (options: FetchOptions) => {
+    const gasPaymentQuery = Object.entries(chainConfig).map((config) => selectGasPayments(config, options)).join("\n    UNION ALL\n");
+    return `
+    WITH gas_payments AS (${gasPaymentQuery})
+    SELECT
+        chain,
+        SUM(payment) AS payment,
+        SUM(IF(is_hyperlane_relayer, payment, 0)) AS hyperlane_payment,
+        SUM(IF(is_hyperlane_relayer, 0, payment)) AS other_payment
+    FROM gas_payments
+    GROUP BY chain
 `;
+}
 
 const prefetch = (options: FetchOptions) =>
-  queryDuneSql(options, query(options), { extraUIDKey: "hyperlane-fees" });
+    queryDuneSql(options, query(options), { extraUIDKey: "hyperlane-fees" });
 
-const fetch = async (options: FetchOptions) => {
-  const event = (options.preFetchedResults as HyperlaneFee[] | undefined)?.find(row =>
-    row.chain === options.chain
-  );
-  const dailyFees = options.createBalances();
-  const dailySupplySideRevenue = options.createBalances();
-  const dailyRevenue = options.createBalances();
+const fetch = async (_a: any, _b: any, options: FetchOptions) => {
+    const event = options.preFetchedResults?.find((row: any) => row.chain === options.chain);
+    const dailyFees = options.createBalances();
+    const dailySupplySideRevenue = options.createBalances();
+    const dailyRevenue = options.createBalances();
 
-  if (event?.payment) {
-    dailyFees.addGasToken(event.payment, IGP_FEES);
-    dailyRevenue.addGasToken(event.hyperlane_payment, IGP_FEES);
-    dailySupplySideRevenue.addGasToken(event.other_payment, IGP_FEES);
-  }
+    if (event?.payment) {
+        dailyFees.addGasToken(event.payment, IGP_FEES);
+        dailyRevenue.addGasToken(event.hyperlane_payment, IGP_FEES);
+        dailySupplySideRevenue.addGasToken(event.other_payment, IGP_FEES);
+    }
 
-  return {
-    dailyFees,
-    dailyUserFees: dailyFees,
-    dailySupplySideRevenue,
-    dailyRevenue,
-    dailyProtocolRevenue: dailyRevenue,
-  };
+    return {
+        dailyFees,
+        dailyUserFees: dailyFees,
+        dailySupplySideRevenue,
+        dailyRevenue,
+        dailyProtocolRevenue: dailyRevenue,
+    };
 };
 
 const methodology = {
-  UserFees: "User-paid Hyperlane interchain gas payments from InterchainGasPaymaster GasPayment events.",
-  Fees: "User-paid Hyperlane interchain gas payments from InterchainGasPaymaster GasPayment events.",
-  SupplySideRevenue: "Gross IGP payments to non-Hyperlane relayer contracts when present.",
-  Revenue: "Gross IGP payments to Hyperlane-published relayer contracts.",
-  ProtocolRevenue: "Gross IGP payments to Hyperlane-published relayer contracts.",
+    UserFees: "User-paid Hyperlane interchain gas payments from InterchainGasPaymaster GasPayment events.",
+    Fees: "User-paid Hyperlane interchain gas payments from InterchainGasPaymaster GasPayment events.",
+    SupplySideRevenue: "Gross IGP payments to non-Hyperlane relayer contracts when present.",
+    Revenue: "Gross IGP payments to Hyperlane-published relayer contracts.",
+    ProtocolRevenue: "Gross IGP payments to Hyperlane-published relayer contracts.",
 };
 
 const breakdownMethodology = {
-  Fees: {
-    [IGP_FEES]: "GasPayment payment fees from Hyperlane InterchainGasPaymaster.",
-  },
-  UserFees: {
-    [IGP_FEES]: "User paid fees from Hyperlane InterchainGasPaymaster.",
-  },
-  SupplySideRevenue: {
-    [IGP_FEES]: "Gross IGP payments to non-Hyperlane relayer contracts when present.",
-  },
-  Revenue: {
-    [IGP_FEES]: "Gross IGP payments to Hyperlane-published relayer contracts.",
-  },
-  ProtocolRevenue: {
-    [IGP_FEES]: "Gross IGP payments to Hyperlane-published relayer contracts.",
-  },
+    Fees: {
+        [IGP_FEES]: "GasPayment fees from Hyperlane InterchainGasPaymaster.",
+    },
+    UserFees: {
+        [IGP_FEES]: "User paid fees from Hyperlane InterchainGasPaymaster.",
+    },
+    SupplySideRevenue: {
+        [IGP_FEES]: "Gross IGP payments to non-Hyperlane relayer contracts when present.",
+    },
+    Revenue: {
+        [IGP_FEES]: "Gross IGP payments to Hyperlane-published relayer contracts.",
+    },
+    ProtocolRevenue: {
+        [IGP_FEES]: "Gross IGP payments to Hyperlane-published relayer contracts.",
+    },
 };
 
 const adapter: Adapter = {
-  version: 2,
-  adapter: chainConfig,
-  prefetch,
-  fetch,
-  methodology,
-  breakdownMethodology,
-  dependencies: [Dependencies.DUNE],
+    version: 1,
+    adapter: chainConfig,
+    prefetch,
+    fetch,
+    methodology,
+    breakdownMethodology,
+    dependencies: [Dependencies.DUNE],
+    isExpensiveAdapter: true,
 };
 
 export default adapter;

--- a/fees/hyperlane.ts
+++ b/fees/hyperlane.ts
@@ -170,7 +170,6 @@ const adapter: Adapter = {
   adapter: chainConfig,
   prefetch,
   fetch,
-  pullHourly: true,
   methodology,
   breakdownMethodology,
   dependencies: [Dependencies.DUNE],

--- a/fees/hyperlane.ts
+++ b/fees/hyperlane.ts
@@ -1,386 +1,179 @@
-/**
- * Hyperlane core-fee adapter.
- *
- * Accounting model:
- * - dailyFees: total user-paid Hyperlane fees from InterchainGasPaymaster GasPayment events plus ProtocolFeePaid events
- * - dailySupplySideRevenue: relayer compensation from InterchainGasPaymaster GasPayment events
- * - dailyRevenue / dailyProtocolRevenue: protocol-retained fees from ProtocolFeePaid events
- *
- * Data sources:
- * - chains/addresses.yaml for deployed Hyperlane contract addresses
- * - chains/metadata.yaml for production/testnet/availability/indexing metadata
- *
- * Resilience policy:
- * - if one chain cannot resolve blocks or logs, that chain returns zero and the run continues
- * - chain list is limited to a curated Hyperlane EVM candidate set, and failing chains degrade to zero
- */
-import { FetchOptions, SimpleAdapter } from "../adapters/types";
-import { getConfig } from "../helpers/cache";
+import { Adapter, Dependencies, FetchOptions } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+import { queryDuneSql } from "../helpers/dune";
+
+type HyperlaneFee = {
+  chain: string;
+  payment: string;
+  hyperlane_payment: string;
+  other_payment: string;
+}
 
 type ChainConfig = {
-  mailbox?: string;
-  interchainGasPaymaster?: string;
-  protocolFee?: string;
+  start: string;
+  duneSchema: string;
+  igp: string;
+}
+
+const chainConfig: Record<string, ChainConfig> = {
+  [CHAIN.ARBITRUM]: {
+    start: "2025-01-01",
+    duneSchema: "hyperlane_v3_arbitrum",
+    igp: "0x3b6044acd6767f017e99318aa6ef93b7b06a5a22",
+  },
+  [CHAIN.AVAX]: {
+    start: "2025-01-01",
+    duneSchema: "hyperlane_v3_avalanche_c",
+    igp: "0x95519ba800bbd0d34eeae026fec620ad978176c0",
+  },
+  [CHAIN.BSC]: {
+    start: "2025-01-01",
+    duneSchema: "hyperlane_v3_bnb",
+    igp: "0x78e25e7f84416e69b9339b0a6336eb6efff6b451",
+  },
+  [CHAIN.BASE]: {
+    start: "2025-01-01",
+    duneSchema: "hyperlane_v3_base",
+    igp: "0xc3f23848ed2e04c0c6d41bd7804fa8f89f940b94",
+  },
+  [CHAIN.BLAST]: {
+    start: "2025-01-01",
+    duneSchema: "hyperlane_v3_blast",
+    igp: "0xb3fccd379ad66ced0c91028520c64226611a48c9",
+  },
+  [CHAIN.CELO]: {
+    start: "2025-01-01",
+    duneSchema: "hyperlane_v3_celo",
+    igp: "0x571f1435613381208477ac5d6974310d88ac7cb7",
+  },
+  [CHAIN.ETHEREUM]: {
+    start: "2025-01-01",
+    duneSchema: "hyperlane_v3_ethereum",
+    igp: "0x9e6b1022be9bbf5afd152483dad9b88911bc8611",
+  },
+  [CHAIN.XDAI]: {
+    start: "2025-01-01",
+    duneSchema: "hyperlane_v3_gnosis",
+    igp: "0xdd260b99d302f0a3ff885728c086f729c06f227f",
+  },
+  [CHAIN.LINEA]: {
+    start: "2025-01-01",
+    duneSchema: "hyperlane_v3_linea",
+    igp: "0x8105a095368f1a184ccea86cce21318b5ee5be28",
+  },
+  [CHAIN.OPTIMISM]: {
+    start: "2025-01-01",
+    duneSchema: "hyperlane_v3_optimism",
+    igp: "0xd8a76c4d91fcbb7cc8ea795dfdf870e48368995c",
+  },
+  [CHAIN.POLYGON]: {
+    start: "2025-01-01",
+    duneSchema: "hyperlane_v3_polygon",
+    igp: "0x0071740bf129b05c4684abfbbed248d80971cce2",
+  },
+  [CHAIN.POLYGON_ZKEVM]: {
+    start: "2025-01-01",
+    duneSchema: "hyperlane_v3_zkevm",
+    igp: "0x0d63128d887159d63de29497dfa45afc7c699ae4",
+  },
+  [CHAIN.SCROLL]: {
+    start: "2025-01-01",
+    duneSchema: "hyperlane_v3_scroll",
+    igp: "0xbf12ef4b9f307463d3fb59c3604f294ddce287e2",
+  },
+  [CHAIN.MANTLE]: {
+    start: "2025-01-01",
+    duneSchema: "hyperlane_v3_mantle",
+    igp: "0x8105a095368f1a184ccea86cce21318b5ee5be28",
+  },
 };
 
-type ChainMetadata = {
-  protocol?: string;
-  isTestnet?: boolean;
-  availabilityStatus?: string;
-  indexFrom?: number;
-};
+const IGP_FEES = "Interchain Gas Payments";
 
-// These Hyperlane registry endpoints follow the same source-of-truth approach used
-// by Hyperlane's TVL adapter in DefiLlama-Adapters.
+const selectGasPayments = ([chain, config]: [string, ChainConfig], options: FetchOptions) => `
+  select
+    '${chain}' as chain,
+    payment,
+    contract_address = ${config.igp} as is_hyperlane_relayer
+  from ${config.duneSchema}.InterchainGasPaymaster_evt_GasPayment
+  where evt_block_time >= from_unixtime(${options.startTimestamp})
+    and evt_block_time < from_unixtime(${options.endTimestamp})
+`;
 
-const REGISTRY_URL =
-  "https://raw.githubusercontent.com/hyperlane-xyz/hyperlane-registry/main/chains/addresses.yaml";
-const METADATA_URL =
-  "https://raw.githubusercontent.com/hyperlane-xyz/hyperlane-registry/main/chains/metadata.yaml";
+const query = (options: FetchOptions) => `
+with gas_payments as (
+${Object.entries(chainConfig).map(config => selectGasPayments(config, options)).join("  union all")}
+)
+select
+  chain,
+  sum(payment) as payment,
+  sum(if(is_hyperlane_relayer, payment, 0)) as hyperlane_payment,
+  sum(if(is_hyperlane_relayer, 0, payment)) as other_payment
+from gas_payments
+group by 1
+`;
 
-const CHAIN_MAP: Record<string, string> = {
-  avalanche: "avax",
-  gnosis: "xdai",
-  hyperevm: "hyperliquid",
-  plume: "plume_mainnet",
-  swell: "swellchain",
-  zoramainnet: "zora",
-};
+const prefetch = (options: FetchOptions) =>
+  queryDuneSql(options, query(options), { extraUIDKey: "hyperlane-fees" });
 
-const HYPERLANE_CHAIN_CANDIDATES = [
-  "arbitrum",
-  "avax",
-  "base",
-  "blast",
-  "bsc",
-  "bsquared",
-  "celo",
-  "ethereum",
-  "ink",
-  "linea",
-  "mantle",
-  "metis",
-  "mode",
-  "optimism",
-  "polygon",
-  "scroll",
-  "sonic",
-  "swellchain",
-  "unichain",
-  "vana",
-  "xdai",
-  "zora",
-];
-
-const GAS_PAYMENT_EVENT =
-  "event GasPayment(bytes32 indexed messageId, uint32 indexed destinationDomain, uint256 gasAmount, uint256 payment)";
-const PROTOCOL_FEE_PAID_EVENT =
-  "event ProtocolFeePaid(address indexed sender, uint256 fee)";
-
-const INTERCHAIN_FEE_LABEL = "Interchain Gas Payments";
-const PROTOCOL_FEE_LABEL = "Protocol Fee Hook Fees";
-const REQUIRED_REGISTRY_KEYS = new Set(["interchainGasPaymaster", "protocolFee", "mailbox"]);
-
-// Standard zeroed response used whenever a chain is unsupported, pre-index,
-// or temporarily unhealthy so the adapter can continue for the rest.
-function emptyResponse(options: FetchOptions) {
+const fetch = async (options: FetchOptions) => {
+  const event = (options.preFetchedResults as HyperlaneFee[] | undefined)?.find(row =>
+    row.chain === options.chain
+  );
   const dailyFees = options.createBalances();
-  const dailyRevenue = options.createBalances();
   const dailySupplySideRevenue = options.createBalances();
+  const dailyRevenue = options.createBalances();
+
+  if (event?.payment) {
+    dailyFees.addGasToken(event.payment, IGP_FEES);
+    dailyRevenue.addGasToken(event.hyperlane_payment, IGP_FEES);
+    dailySupplySideRevenue.addGasToken(event.other_payment, IGP_FEES);
+  }
 
   return {
     dailyFees,
-    dailyRevenue,
+    dailyUserFees: dailyFees,
     dailySupplySideRevenue,
+    dailyRevenue,
     dailyProtocolRevenue: dailyRevenue,
   };
-}
+};
 
-// The Hyperlane registry files currently use a simple scalar YAML shape:
-// exact 2-space indentation, simple key:value pairs, and no multi-line or
-// complex YAML features for the fields this adapter reads.
-function sanitizeYamlLine(rawLine: string) {
-  const line = rawLine.replace(/\t/g, "    ");
-  let out = "";
-  let quote: '"' | "'" | null = null;
+const methodology = {
+  UserFees: "User-paid Hyperlane interchain gas payments from InterchainGasPaymaster GasPayment events.",
+  Fees: "User-paid Hyperlane interchain gas payments from InterchainGasPaymaster GasPayment events.",
+  SupplySideRevenue: "Gross IGP payments to non-Hyperlane relayer contracts when present.",
+  Revenue: "Gross IGP payments to Hyperlane-published relayer contracts.",
+  ProtocolRevenue: "Gross IGP payments to Hyperlane-published relayer contracts.",
+};
 
-  for (let i = 0; i < line.length; i++) {
-    const char = line[i];
-    if ((char === '"' || char === "'") && line[i - 1] !== "\\") {
-      quote = quote === char ? null : (char as '"' | "'");
-      out += char;
-      continue;
-    }
+const breakdownMethodology = {
+  Fees: {
+    [IGP_FEES]: "GasPayment payment fees from Hyperlane InterchainGasPaymaster.",
+  },
+  UserFees: {
+    [IGP_FEES]: "User paid fees from Hyperlane InterchainGasPaymaster.",
+  },
+  SupplySideRevenue: {
+    [IGP_FEES]: "Gross IGP payments to non-Hyperlane relayer contracts when present.",
+  },
+  Revenue: {
+    [IGP_FEES]: "Gross IGP payments to Hyperlane-published relayer contracts.",
+  },
+  ProtocolRevenue: {
+    [IGP_FEES]: "Gross IGP payments to Hyperlane-published relayer contracts.",
+  },
+};
 
-    if (char === "#" && !quote) break;
-    out += char;
-  }
-
-  return out.trimEnd();
-}
-
-// Registry values are expected to be simple quoted/unquoted scalars only.
-function parseScalar(rawValue: string) {
-  return rawValue.trim().replace(/^["']|["']$/g, "");
-}
-
-// addresses.yaml is expected to resolve into a flat per-chain object whose
-// relevant scalar fields match REQUIRED_REGISTRY_KEYS / ChainConfig.
-function parseRegistry(yaml: string): Record<string, ChainConfig> {
-  const registry: Record<string, ChainConfig> = {};
-  let currentChain = "";
-
-  for (const rawLine of yaml.split(/\r?\n/)) {
-    const line = sanitizeYamlLine(rawLine);
-    if (!line.trim() || line.trim().startsWith("#")) continue;
-
-    const indent = line.search(/\S/);
-    if (indent === 0 && line.endsWith(":")) {
-      currentChain = line.slice(0, -1).trim();
-      registry[currentChain] = {};
-      continue;
-    }
-
-    if (indent !== 2 || !currentChain) continue;
-    const match = line.match(/^\s{2}([\w-]+):\s*(.+?)\s*$/);
-    if (!match) continue;
-
-    const [, key, rawValue] = match;
-    if (REQUIRED_REGISTRY_KEYS.has(key)) registry[currentChain][key as keyof ChainConfig] = parseScalar(rawValue);
-  }
-
-  return registry;
-}
-
-function parseMetadata(yaml: string): Record<string, ChainMetadata> {
-  const metadata: Record<string, ChainMetadata> = {};
-  let currentChain = "";
-  let currentSection = "";
-
-  for (const rawLine of yaml.split(/\r?\n/)) {
-    const line = sanitizeYamlLine(rawLine);
-    if (!line.trim() || line.trim().startsWith("#")) continue;
-
-    const indent = line.search(/\S/);
-    if (indent === 0 && line.endsWith(":")) {
-      currentChain = line.slice(0, -1).trim();
-      currentSection = "";
-      metadata[currentChain] = {};
-      continue;
-    }
-
-    if (!currentChain) continue;
-
-    if (indent === 2 && line.endsWith(":")) {
-      currentSection = line.trim().slice(0, -1);
-      continue;
-    }
-
-    const rootMatch = line.match(/^\s{2}([\w-]+):\s*(.+?)\s*$/);
-    if (indent === 2 && rootMatch) {
-      const [, key, rawValue] = rootMatch;
-      const value = parseScalar(rawValue);
-      if (key === "protocol") metadata[currentChain].protocol = value;
-      else if (key === "isTestnet") metadata[currentChain].isTestnet = value === "true";
-      continue;
-    }
-
-    const nestedMatch = line.match(/^\s{4}([\w-]+):\s*(.+?)\s*$/);
-    if (indent === 4 && nestedMatch) {
-      const [, key, rawValue] = nestedMatch;
-      const value = parseScalar(rawValue);
-      if (currentSection === "availability" && key === "status")
-        metadata[currentChain].availabilityStatus = value;
-      else if (currentSection === "index" && key === "from")
-        metadata[currentChain].indexFrom = Number(value);
-    }
-  }
-
-  return metadata;
-}
-
-let registryPromise: Promise<Record<string, ChainConfig>> | null = null;
-let metadataPromise: Promise<Record<string, ChainMetadata>> | null = null;
-
-async function getRegistry() {
-  if (!registryPromise) {
-    registryPromise = (async () => {
-      const data = await getConfig("hyperlane/addresses", REGISTRY_URL);
-      if (typeof data !== "string") throw new Error("Hyperlane registry fetch did not return YAML text");
-      const parsed = parseRegistry(data);
-      const parsedCandidateCount = HYPERLANE_CHAIN_CANDIDATES.filter((chain) =>
-        Object.entries(parsed).some(([registryChain, config]) =>
-          (CHAIN_MAP[registryChain] ?? registryChain) === chain && !!config.interchainGasPaymaster
-        )
-      ).length;
-      if (!parsedCandidateCount) throw new Error("Failed to parse any Hyperlane candidate chains from addresses.yaml");
-      return parsed;
-    })().catch((error) => {
-      registryPromise = null;
-      throw error;
-    });
-  }
-
-  return registryPromise;
-}
-
-async function getMetadata() {
-  if (!metadataPromise) {
-    metadataPromise = (async () => {
-      const data = await getConfig("hyperlane/metadata", METADATA_URL);
-      if (typeof data !== "string") throw new Error("Hyperlane metadata fetch did not return YAML text");
-      const parsed = parseMetadata(data);
-      if (!Object.keys(parsed).length) throw new Error("Failed to parse Hyperlane metadata.yaml");
-      return parsed;
-    })().catch((error) => {
-      metadataPromise = null;
-      throw error;
-    });
-  }
-
-  return metadataPromise;
-}
-
-async function getChainConfig(chain: string) {
-  const [registry, metadata] = await Promise.all([getRegistry(), getMetadata()]);
-
-  for (const [registryChain, config] of Object.entries(registry)) {
-    const mappedChain = CHAIN_MAP[registryChain] ?? registryChain;
-    if (mappedChain !== chain) continue;
-    if (!config.interchainGasPaymaster?.startsWith("0x")) return undefined;
-    return {
-      config,
-      metadata: metadata[registryChain] ?? metadata[mappedChain],
-    };
-  }
-}
-
-async function fetch(options: FetchOptions) {
-  // Resolve per-chain contracts dynamically from Hyperlane's registry.
-  const chainData = await getChainConfig(options.chain);
-  if (!chainData?.config?.interchainGasPaymaster) return emptyResponse(options);
-
-  const { config, metadata } = chainData;
-
-  // Only run on production EVM chains that Hyperlane metadata marks as available.
-  if (metadata?.isTestnet || metadata?.availabilityStatus === "disabled" || metadata?.protocol !== "ethereum")
-    return emptyResponse(options);
-
-  let fromBlock: number | null = null;
-  let toBlock: number | null = null;
-  try {
-    fromBlock = await options.getStartBlock();
-    toBlock = await options.getEndBlock();
-  } catch (error) {
-    console.error("[hyperlane] block lookup failed", { chain: options.chain, error });
-    return emptyResponse(options);
-  }
-
-  if (fromBlock == null || toBlock == null) {
-    return emptyResponse(options);
-  }
-
-  if (metadata?.indexFrom && toBlock < metadata.indexFrom) return emptyResponse(options);
-  const effectiveFromBlock = metadata?.indexFrom ? Math.max(fromBlock, metadata.indexFrom) : fromBlock;
-  if (effectiveFromBlock > toBlock) return emptyResponse(options);
-
-  const dailyFees = options.createBalances();
-  const dailyRevenue = options.createBalances();
-  const dailySupplySideRevenue = options.createBalances();
-
-  try {
-    // Relayer compensation paid by users for message delivery.
-    const gasPayments = await options.getLogs({
-      fromBlock: effectiveFromBlock,
-      toBlock,
-      target: config.interchainGasPaymaster,
-      eventAbi: GAS_PAYMENT_EVENT,
-    });
-
-    gasPayments.forEach((log: any) => {
-      dailyFees.addGasToken(log.payment, INTERCHAIN_FEE_LABEL);
-      dailySupplySideRevenue.addGasToken(log.payment, INTERCHAIN_FEE_LABEL);
-    });
-
-    if (config.protocolFee?.startsWith("0x")) {
-      try {
-        // Protocol-retained fee hook revenue. On many chains this is currently zero
-        // because the fee hook is configured but protocolFee() is disabled.
-        const protocolFeePayments = await options.getLogs({
-          fromBlock: effectiveFromBlock,
-          toBlock,
-          target: config.protocolFee,
-          eventAbi: PROTOCOL_FEE_PAID_EVENT,
-        });
-
-        protocolFeePayments.forEach((log: any) => {
-          dailyFees.addGasToken(log.fee, PROTOCOL_FEE_LABEL);
-          dailyRevenue.addGasToken(log.fee, PROTOCOL_FEE_LABEL);
-        });
-      } catch (error) {
-        console.error("[hyperlane] ProtocolFeePaid log fetch failed", {
-          chain: options.chain,
-          target: config.protocolFee,
-          event: PROTOCOL_FEE_PAID_EVENT,
-          error,
-        });
-      }
-    }
-
-    return {
-      dailyFees,
-      dailyRevenue,
-      dailySupplySideRevenue,
-      dailyProtocolRevenue: dailyRevenue,
-    };
-  } catch (error) {
-    // Chain-level runtime issues degrade to zero so the rest of the adapter can continue,
-    // but registry/metadata parsing failures still surface above because they affect all chains.
-    console.error("[hyperlane] GasPayment log fetch failed", {
-      chain: options.chain,
-      target: config.interchainGasPaymaster,
-      event: GAS_PAYMENT_EVENT,
-      error,
-    });
-    return emptyResponse(options);
-  }
-}
-
-const adapter: SimpleAdapter = {
+const adapter: Adapter = {
   version: 2,
-  chains: HYPERLANE_CHAIN_CANDIDATES,
-  start: "2025-01-01",
-  pullHourly: true,
+  adapter: chainConfig,
+  prefetch,
   fetch,
-  methodology: {
-    Fees: "Tracks total user-paid Hyperlane fees by summing InterchainGasPaymaster GasPayment events and ProtocolFeePaid events on each origin chain, with contract addresses loaded dynamically from Hyperlane's registry.",
-    Revenue:
-      "Tracks retained Hyperlane protocol fee revenue by summing ProtocolFeePaid events emitted by Hyperlane's ProtocolFee hook contracts when configured in the Hyperlane registry.",
-    SupplySideRevenue:
-      "Tracks relayer compensation by summing InterchainGasPaymaster GasPayment events, which represent delivery fees paid through Hyperlane's relayer path.",
-    ProtocolRevenue:
-      "Same as Revenue: sums ProtocolFeePaid events emitted by Hyperlane's ProtocolFee hook contracts when configured in the Hyperlane registry.",
-  },
-  breakdownMethodology: {
-    dailyFees: {
-      [INTERCHAIN_FEE_LABEL]:
-        "Sum of relayer compensation values emitted in Hyperlane InterchainGasPaymaster GasPayment events.",
-      [PROTOCOL_FEE_LABEL]:
-        "Sum of protocol-retained fee values emitted in Hyperlane ProtocolFeePaid events.",
-    },
-    dailyRevenue: {
-      [PROTOCOL_FEE_LABEL]:
-        "Sum of fee values emitted in Hyperlane ProtocolFeePaid events.",
-    },
-    dailySupplySideRevenue: {
-      [INTERCHAIN_FEE_LABEL]:
-        "Sum of payment values emitted in Hyperlane InterchainGasPaymaster GasPayment events.",
-    },
-    dailyProtocolRevenue: {
-      [PROTOCOL_FEE_LABEL]:
-        "Sum of fee values emitted in Hyperlane ProtocolFeePaid events.",
-    },
-  },
+  pullHourly: true,
+  methodology,
+  breakdownMethodology,
+  dependencies: [Dependencies.DUNE],
 };
 
 export default adapter;


### PR DESCRIPTION
Fixes #6572

Adds a Hyperlane core fees adapter at `fees/hyperlane.ts`.

Tracked metrics:
- `dailyFees`: summed from Hyperlane `InterchainGasPaymaster` `GasPayment` events
- `dailyRevenue` / `dailyProtocolRevenue`: summed from Hyperlane `ProtocolFeePaid` events

Details:
- uses Hyperlane registry `chains/addresses.yaml` for deployed contract addresses
- uses Hyperlane registry `chains/metadata.yaml` for chain metadata and index start hints
- limited to curated Hyperlane EVM chains as per Hyperlane Defillama-Adapters
- per-chain runtime failures degrade to zero so the adapter continues for other chains

Validation:
- `pnpm test fees hyperlane 2026-04-20`
- `pnpm test fees hyperlane 2025-05-01`

Notes:
- on many chains, `protocolFee()` is configured to `0`, so `dailyRevenue` / `dailyProtocolRevenue` may legitimately remain zero while `dailyFees` is non-zero
