### PR TITLE
fix(syncswap): migrate ERA and Scroll to self-hosted subgraph

### DIFF
--- a/dexs/syncswap/index.ts
+++ b/dexs/syncswap/index.ts
@@ -1,12 +1,11 @@
-import * as sdk from "@defillama/sdk";
 import { FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 import { gql, request } from "graphql-request";
 
 const endpoints: { [key: string]: string } = {
-  [CHAIN.ERA]: sdk.graph.modifyEndpoint('3PCPSyJXMuC26Vi37w7Q6amJdEJgMDYppfW9sma91uhj'),
+  [CHAIN.ERA]: 'https://graph1.syncswap.xyz/subgraphs/name/syncswap/syncswap-zksync',
   [CHAIN.LINEA]: 'https://graph1.syncswap.xyz/subgraphs/name/syncswap/syncswap-linea',
-  [CHAIN.SCROLL]: sdk.graph.modifyEndpoint('9ZCxNv8qiz97b5AEMnafsixYG7c2mnGp5Yk325p3gz9e'),
+  [CHAIN.SCROLL]: 'https://graph1.syncswap.xyz/subgraphs/name/syncswap/syncswap-scroll',
   [CHAIN.SOPHON]: 'https://graph1.syncswap.xyz/subgraphs/name/syncswap/syncswap-sophon',
 };
 


### PR DESCRIPTION
## Summary

Fixes #6093

The Graph gateway endpoints for **ERA (zkSync)** and **Scroll** chains return `payment required` errors, completely breaking the SyncSwap classic DEX adapter for these chains.

### Changes

- Switched ERA and Scroll subgraph endpoints from `sdk.graph.modifyEndpoint()` (paid Graph gateway) to SyncSwap's self-hosted subgraph at `graph1.syncswap.xyz`
- This is consistent with the existing Linea and Sophon endpoints which already use the same self-hosted infrastructure
- Removed unused `@defillama/sdk` import

### Before (ERA chain)

```
ERROR: auth error: payment required for subsequent requests for this API key
```

### After

```
chain     | Daily volume | Daily fees | Daily user fees | Daily supply side revenue
era       | 235.69 k     | 707.00     | 707.00          | 707.00
linea     | 50.87 k      | 153.00     | 153.00          | 153.00
scroll    | 40.69 k      | 122.00     | 122.00          | 122.00
Aggregate | 327.25 k     | 982.00     | 982.00          | 982.00
```

All three chains now return correct volume and fee data through SyncSwap's own subgraph infrastructure.