### PR TITLE
fix(move-dollar): add deadFrom and fix crash on empty API response

### DIFF
--- a/fees/move-dollar.ts
+++ b/fees/move-dollar.ts
@@ -16,7 +16,8 @@ interface IVolumeall {
 
 const fetch = async (timestamp: number) => {
   const dayFeesQuery = (await fetchURL(feesEndpoint(timestamp, "1D")))?.data;
-  const dailyFees = (dayFeesQuery ?? []).reduce(
+  const items = Array.isArray(dayFeesQuery) ? dayFeesQuery : [];
+  const dailyFees = items.reduce(
     (partialSum: number, a: IVolumeall) => partialSum + a.value,
     0
   );

--- a/fees/move-dollar.ts
+++ b/fees/move-dollar.ts
@@ -16,7 +16,7 @@ interface IVolumeall {
 
 const fetch = async (timestamp: number) => {
   const dayFeesQuery = (await fetchURL(feesEndpoint(timestamp, "1D")))?.data;
-  const dailyFees = dayFeesQuery.reduce(
+  const dailyFees = (dayFeesQuery ?? []).reduce(
     (partialSum: number, a: IVolumeall) => partialSum + a.value,
     0
   );
@@ -27,6 +27,7 @@ const fetch = async (timestamp: number) => {
 };
 
 const adapter: SimpleAdapter = {
+  deadFrom: '2025-12-14',
   adapter: {
     [CHAIN.APTOS]: {
       fetch,


### PR DESCRIPTION
## Summary

Fixes #6516

Thala's `protocol-fee-chart` API (`app.thala.fi`) returns empty `{}` for dates after 2025-12-13, causing the adapter to crash with `Cannot read properties of undefined (reading 'reduce')`.

### Changes

1. **Add `deadFrom: '2025-12-14'`** - Thala API stopped returning fee data after Dec 13, 2025. Verified by probing the API across date ranges.
2. **Add null-safe fallback** `(dayFeesQuery ?? [])` to prevent crash on empty API responses for historical backfills near the cutoff.

### Before

```
TypeError: Cannot read properties of undefined (reading 'reduce')
    at fetch (fees/move-dollar.ts:19:34)
```

### After

```
Skipping aptos because the adapter ended at Sun, 14 Dec 2025 00:00:00 GMT
```