### PR TITLE
fix(invariant): update stats API endpoints

### DIFF
--- a/dexs/invariant/index.ts
+++ b/dexs/invariant/index.ts
@@ -3,9 +3,9 @@ import { CHAIN } from "../../helpers/chains";
 import axios from "axios";
 import { FetchResult } from "../../adapters/types";
 const solanaStatsApiEndpoint =
-  "https://stats.invariant.app/svm/full_snap/mainnet";
+  "https://stats.invariant.app/solana/intervals/solana-mainnet?interval=daily";
 const eclipseStatsApiEndpoint =
-  "https://stats.invariant.app/svm/full_snap/eclipse-mainnet";
+  "https://stats.invariant.app/eclipse/intervals/eclipse-mainnet?interval=daily";
 
 type StatsApiResponse = {
   data: {


### PR DESCRIPTION
Fixes #6511

## Summary

Switches the Invariant adapter to the new Solana and Eclipse stats endpoints.

## Changes

- updated Solana to the new daily interval endpoint
- updated Eclipse to the new daily interval endpoint
- kept existing `dailyVolume` and `dailyFees` logic unchanged
