### PR TITLE
[fix] levvy-for-tokens - end unavailable fees source

### DIFF
--- a/fees/levvy-fi-tokens/index.ts
+++ b/fees/levvy-fi-tokens/index.ts
@@ -21,6 +21,7 @@ export default {
     [CHAIN.CARDANO]: {
       fetch: fetch,
       start: '2023-10-11',
+      deadFrom: '2025-10-03',
     },
   },
 };


### PR DESCRIPTION
## Summary
- Mark the Cardano levvy-for-tokens fees source dead from 2025-10-03.
- DefiLlama's fee chart has its last data point on 2025-10-02.
- The upstream Demeter endpoint now returns HTTP 503 (`failure to get a peer from the ring-balancer`), so current adapter runs should skip cleanly instead of querying an unavailable source.

Closes #6504

## Validation
- npm test -- fees/levvy-fi-tokens
- npm run ts-check
