### PR TITLE
[fix] get-protocol - end unavailable fees source

### DIFF
--- a/fees/get-protocol.ts
+++ b/fees/get-protocol.ts
@@ -81,6 +81,7 @@ const adapter: Adapter = {
     [CHAIN.POLYGON]: {
       fetch: graphs(),
       start: '2021-09-01',
+      deadFrom: '2025-08-01',
     },
   },
   methodology: {


### PR DESCRIPTION
## Summary
- mark the GET Protocol Polygon fees source dead from 2025-08-01
- DefiLlama daily fees stop on 2025-07-31
- the current Graph endpoint returns an auth/payment-required error, so current adapter runs should skip instead of failing

## Validation
- npm test -- fees/get-protocol
- npm run ts-check