### PR TITLE
[fix] grafun - end unavailable fees sources

### DIFF
--- a/fees/grafun.ts
+++ b/fees/grafun.ts
@@ -54,9 +54,11 @@ const adapter: Adapter = {
   adapter: {
     [CHAIN.BSC]: {
       start: '2024-09-27',
+      deadFrom: '2025-07-19',
     },
     [CHAIN.ETHEREUM]: {
       start: "2024-11-28",
+      deadFrom: '2025-07-19',
     },
   },
   fetch,


### PR DESCRIPTION
## Summary
- mark Grafun BSC and Ethereum fees sources dead from 2025-07-19
- DefiLlama daily fees stop on 2025-07-18
- the current BSC Graph source returns an auth/payment-required error, so current adapter runs should skip instead of failing

## Validation
- npm test -- fees/grafun
- npm run ts-check