### PR TITLE
[fix] buffer-finance - end unavailable fees source

### DIFF
--- a/fees/buffer/index.ts
+++ b/fees/buffer/index.ts
@@ -59,6 +59,7 @@ const adapter: Adapter = {
   fetch,
   chains: [CHAIN.ARBITRUM],
   start: '2023-01-29',
+  deadFrom: '2025-07-17',
   methodology,
   breakdownMethodology,
 };


### PR DESCRIPTION
## Summary
- mark the Buffer Finance Arbitrum fees source dead from 2025-07-17
- DefiLlama daily fees stop on 2025-07-16
- the current Satsuma subgraph host no longer resolves, so current adapter runs should skip instead of failing

## Validation
- npm test -- fees/buffer
- npm run ts-check