### PR TITLE
[fix] invariant - end unavailable fees source

### DIFF
--- a/dexs/invariant/index.ts
+++ b/dexs/invariant/index.ts
@@ -42,11 +42,13 @@ const adapter: SimpleAdapter = {
       fetch: fetchSolana,
       runAtCurrTime: true,
       start: "2022-03-22",
+      deadFrom: "2025-12-09",
     },
     [CHAIN.ECLIPSE]: {
       fetch: fetchEclipse,
       runAtCurrTime: true,
       start: "2024-12-22",
+      deadFrom: "2025-12-09",
     },
   },
 };


### PR DESCRIPTION
## Summary
- mark Invariant Solana and Eclipse stats sources dead from 2025-12-09
- DefiLlama daily fees stop on 2025-12-08
- the current Invariant stats endpoints return HTTP 500 / FUNCTION_INVOCATION_FAILED, so current adapter runs should skip instead of failing

## Validation
- npm test -- dexs/invariant
- npm run ts-check