### PR TITLE
[fix] rezerve-money - end unavailable fees source

### DIFF
--- a/fees/rezerve-money/index.ts
+++ b/fees/rezerve-money/index.ts
@@ -32,7 +32,7 @@ const adapter: SimpleAdapter = {
     [CHAIN.SONIC]: {
       fetch,
       start: "2025-06-13",
-      deadFrom: "2026-04-05",
+      deadFrom: "2026-04-05", // Shadow core-full subgraph deployment no longer exists.
     },
   },
   methodology,

--- a/fees/rezerve-money/index.ts
+++ b/fees/rezerve-money/index.ts
@@ -32,6 +32,7 @@ const adapter: SimpleAdapter = {
     [CHAIN.SONIC]: {
       fetch,
       start: "2025-06-13",
+      deadFrom: "2026-04-05",
     },
   },
   methodology,


### PR DESCRIPTION
## Summary
- mark the Rezerve Money Sonic fees source dead from 2026-04-05
- DefiLlama daily fees are zero through 2026-04-04 and no current data is available afterward
- the current Shadow subgraph source returns "deployment core-full does not exist", causing current adapter runs to throw before returning dimensions

## Validation
- npm test -- fees/rezerve-money
- npm run ts-check