### PR TITLE
[fix] illuvium - end unavailable fees source

### DIFF
--- a/fees/illuvium.ts
+++ b/fees/illuvium.ts
@@ -28,6 +28,7 @@ const adapter: Adapter = {
   adapter: {
     [CHAIN.IMMUTABLEX]: {
       fetch: fetchFees,
+      deadFrom: '2026-03-10',
     },
   },
   methodology: {


### PR DESCRIPTION
## Summary
- mark the Illuvium ImmutableX fees source dead from 2026-03-10
- DefiLlama daily fees are zero through 2026-03-09
- the current Immutable transfers endpoint returns HTTP 404 with an empty body, causing current adapter runs to throw while parsing JSON

## Validation
- npm test -- fees/illuvium
- npm run ts-check