### PR TITLE
fix(fees/yakafinance): set deadFrom for dead SEI blocks subgraph

### DIFF
--- a/fees/yakafinance/index.ts
+++ b/fees/yakafinance/index.ts
@@ -9,6 +9,7 @@ const adapter: Adapter = {
         [CHAIN.SEI]: {
             fetch: getFees as any,
             start: '2024-07-01',
+            deadFrom: '2026-03-05',
         },
     },
 };


### PR DESCRIPTION
Closes #6512.

The Yaka Finance fees adapter resolves block numbers via the SEI blocks subgraph at `api.studio.thegraph.com/query/82132/sei-blocks`, which has been deleted (queries return *"deployment u82132/s80587/latest does not exist"*). Even if that were swapped out, public SEI EVM RPCs only serve blocks from `79123881` onward, so the adapter's `2024-07-01` start date can no longer be backfilled from chain data either. Both the volume subgraph and the block lookup paths fail in `pnpm test fees yakafinance`.

Setting `deadFrom: '2026-03-05'` (day after the last non-zero point on `defillama.com/protocol/yaka-finance`) retires the adapter from current fetches while preserving the historical chart. Same playbook as the recently-merged Buffer (#6580), Ribbon (#6551), Premia v2 (#6559), Collex (#6565), and wavex (#6578) fixes.

Note: this adapter is `version: 2` with per-chain config, so `deadFrom` sits inside the SEI chain block rather than at the adapter root.