### PR TITLE
[fix] blockscout factory - end unavailable chain fee sources

### DIFF
--- a/factory/blockscout.ts
+++ b/factory/blockscout.ts
@@ -121,7 +121,9 @@ const protocolChainMap: Record<string, string> = {
 }
 
 const deadFromMap: Record<string, string> = {
+  "duck-chain": "2026-01-23",
   "kroma": "2025-06-30",
+  "xchain": "2026-02-12",
 }
 
 const methodologyMap: Record<string, any> = {


### PR DESCRIPTION
## Summary
- mark duck-chain fees dead from 2026-01-23
- mark xchain fees dead from 2026-02-12
- both are Blockscout factory adapters whose current explorer sources fail before returning current chain fee data

## Evidence
- duck-chain current run failed with explorer 522; DefiLlama fees stop on 2026-01-22
- xchain current run failed with TLS certificate mismatch; DefiLlama fees stop on 2026-02-11

## Validation
- npm test -- fees/duck-chain
- npm test -- fees/xchain
- npm run ts-check