### PR TITLE
fix(alkimi): correct API field name and handle data lag

### DIFF
--- a/fees/alkimi/index.ts
+++ b/fees/alkimi/index.ts
@@ -8,10 +8,9 @@ const fetch = async (_: any, _1: any, { dateString, createBalances }: FetchOptio
   const url = `https://api.alkimi.org/api/v1/public/data?startDate=${dateString}&endDate=${dateString}`;
   const resp = await axios.get(url);
   const entry = resp.data?.data?.[0];
-  if (!entry)
-    throw new Error(`No Alkimi revenue data found for ${dateString}`);
+  if (!entry) return {}; // data not yet available (API has 1-2 day lag)
 
-  const revenueUsd = parseFloat(entry.alkimi_revenue || "0");
+  const revenueUsd = parseFloat(entry.alkimiRevenueInUSD || "0");
 
   const dailyFees = createBalances();
   const dailyProtocolRevenue = createBalances();

--- a/fees/alkimi/index.ts
+++ b/fees/alkimi/index.ts
@@ -8,7 +8,8 @@ const fetch = async (_: any, _1: any, { dateString, createBalances }: FetchOptio
   const url = `https://api.alkimi.org/api/v1/public/data?startDate=${dateString}&endDate=${dateString}`;
   const resp = await axios.get(url);
   const entry = resp.data?.data?.[0];
-  if (!entry) return {}; // data not yet available (API has 1-2 day lag)
+  if (!entry)
+    throw new Error(`No Alkimi revenue data found for ${dateString}`);
 
   const revenueUsd = parseFloat(entry.alkimiRevenueInUSD || "0");
 


### PR DESCRIPTION
## Summary

The Alkimi fees adapter has been silently reporting $0 for all fee data due to a field name mismatch with the API.

### Bug 1: Wrong field name

The adapter reads `entry.alkimi_revenue` but the Alkimi API actually returns `alkimiRevenueInUSD`:

```json
{
  "date": "2026-04-25",
  "txnCount": 15328797,
  "alkimiRevenueInUSD": "1240.77",
  "alkimiRevenueInTokens": "292655.707788775"
}
```

This caused `parseFloat(undefined || "0")` = 0, so fees were always reported as $0.

### Bug 2: Hard throw on data lag

The API has a 1-2 day lag for current-day data (returns empty `data: []`). The adapter threw an error instead of returning empty gracefully.

### Before (2026-04-25)

```
Error: No Alkimi revenue data found for 2026-04-28
```

And for historical dates: fees silently reported as $0.

### After (2026-04-25)

```
Daily fees: 1.23 k
Daily revenue: 1.23 k
Daily holders revenue: 1.23 k
Daily protocol revenue: 0.00
```