### PR TITLE
fix(keom): add deadFrom for dead subgraphs

### DIFF
--- a/fees/keom.ts
+++ b/fees/keom.ts
@@ -40,6 +40,7 @@ const fetch = async (timestamp: number, _a: any, options: FetchOptions) => {
 };
 
 const adapter: Adapter = {
+  deadFrom: '2024-11-05',
   adapter: {
     [CHAIN.POLYGON]: {
       fetch,


### PR DESCRIPTION
## Summary

Both Keom Protocol subgraph sources are permanently unavailable, causing the adapter to error on every run.

| Chain | Endpoint | Error |
|---|---|---|
| Polygon | thegraph studio (staging) | `indexing_error` for all dates |
| Manta | Goldsky | 404 "Subgraph not found" |
| Polygon zkEVM | (already commented out) | N/A |

### Context

- Protocol app (`app.keom.io`) returns Cloudflare 530 (origin unreachable)
- TVL dropped from ~$230k (2026-03-17) to ~$66 (current)
- The Polygon subgraph was a "staging" deployment that appears to have been abandoned

### Change

Added `deadFrom: '2024-11-05'` to skip adapter runs after the last known configuration date.