### PR TITLE
fix(solidly-v3): correct invalid Fantom start date

### DIFF
--- a/fees/solidly-v3.ts
+++ b/fees/solidly-v3.ts
@@ -92,7 +92,7 @@ const adapter: Adapter = {
     },
     [CHAIN.FANTOM]: {
       fetch: fetch(CHAIN.FANTOM),
-      start: '2023-25-12',
+      start: '2023-12-25',
     }
   }, 
 }


### PR DESCRIPTION
## Summary

The Solidly V3 Fantom chain start date is set to `'2023-25-12'` (month 25), which is invalid and causes the adapter to skip Fantom entirely:

```
Skipping fantom because the configured start time is Invalid Date
```

### Fix

Changed start date from `'2023-25-12'` to `'2023-12-25'` (December 25, 2023).

This is a date format typo - day and month fields were swapped.