### PR TITLE
Add holders revenue for Swell based on fee flow buybacks

### DIFF
--- a/fees/swell.ts
+++ b/fees/swell.ts
@@ -42,7 +42,7 @@ async function fetch(options: FetchOptions): Promise<FetchResultV2> {
     dailyRevenue,
     dailySupplySideRevenue,
     dailyProtocolRevenue: dailyRevenue,
-    dailyHoldersRevenue: 0,
+    dailyHoldersRevenue: dailyRevenue,
   }
 }
 
@@ -59,7 +59,7 @@ const adapter: Adapter = {
     Revenue: '5% staking rewards are charged by Swell Protocol Treasury.',
     SupplySideRevenue: '90% staking rewards are distributed to ETH stakers and 5% to node operators.',
     ProtocolRevenue: '5% staking rewards are charged by Swell Protocol Treasury.',
-    HoldersRevenue: 'No revenue share to SWELL token holders.',
+    HoldersRevenue: 'Protocol revenue (5% of staking yield) is allocated to SWELL buybacks via auctions. This is used as a proxy for value returned to token holders.',
   },
 };
 

--- a/fees/swell.ts
+++ b/fees/swell.ts
@@ -10,6 +10,7 @@ async function fetch(options: FetchOptions): Promise<FetchResultV2> {
   const dailyFees = options.createBalances()
   const dailyRevenue = options.createBalances()
   const dailySupplySideRevenue = options.createBalances()
+  const dailyHoldersRevenue = options.createBalances()
 
   const exchangeRateBefore = await options.fromApi.call({
     target: swETH,
@@ -35,6 +36,7 @@ async function fetch(options: FetchOptions): Promise<FetchResultV2> {
   
   dailyFees.addGasToken(df)
   dailyRevenue.addGasToken(swellTreasuryRewards)
+  dailyHoldersRevenue.addGasToken(swellTreasuryRewards, 'holders_buyback')
   dailySupplySideRevenue.addGasToken(supplySideRewards)
 
   return {
@@ -42,7 +44,7 @@ async function fetch(options: FetchOptions): Promise<FetchResultV2> {
     dailyRevenue,
     dailySupplySideRevenue,
     dailyProtocolRevenue: dailyRevenue,
-    dailyHoldersRevenue: dailyRevenue,
+    dailyHoldersRevenue,
   }
 }
 
@@ -60,6 +62,20 @@ const adapter: Adapter = {
     SupplySideRevenue: '90% staking rewards are distributed to ETH stakers and 5% to node operators.',
     ProtocolRevenue: '5% staking rewards are charged by Swell Protocol Treasury.',
     HoldersRevenue: 'Protocol revenue (5% of staking yield) is allocated to SWELL buybacks via auctions. This is used as a proxy for value returned to token holders.',
+  },
+  breakdownMethodology: {
+    dailyFees: {
+      fees: 'Total validator rewards'
+    },
+    dailyRevenue: {
+      protocol_revenue: '5% staking yield taken as protocol revenue'
+    },
+    dailySupplySideRevenue: {
+      supply_side: 'Rewards distributed to stakers and node operators'
+    },
+    dailyHoldersRevenue: {
+      holders_buyback: 'Protocol revenue used for SWELL buybacks and burned'
+    }
   },
 };
 

--- a/fees/swell.ts
+++ b/fees/swell.ts
@@ -1,7 +1,7 @@
 import { CHAIN } from "../helpers/chains";
-import { METRIC } from "../helpers/metrics";
 import { Adapter, FetchOptions, FetchResultV2 } from "../adapters/types";
 import { addTokensReceived } from "../helpers/token";
+import { METRIC } from "../helpers/metrics";
 
 // https://docs.swellnetwork.io/swell-staking/sweth-liquid-staking/sweth-v1.0-system-design/rewards-and-distribution/liquid-staking-rewards-and-fees
 
@@ -36,19 +36,21 @@ async function fetch(options: FetchOptions): Promise<FetchResultV2> {
     target: swETH,
     abi: 'uint256:totalSupply',
   })
-  
+
   const totalDeposited = BigInt(totalSupply) * BigInt(exchangeRateBefore) / BigInt(1e18)
-  
+
   // swell distribute 90% rewards to stakers post protocol revenue and node operators cut
   // 90% to stakers, 5% to node operators, 5% to Swell treasury
   const df = Number(totalDeposited) * (exchangeRateAfter - exchangeRateBefore) / 0.9 / 1e18
 
   const swellTreasuryRewards = df * 0.05
-  const supplySideRewards = df - swellTreasuryRewards
-  
-  dailyFees.addGasToken(df)
-  dailyRevenue.addGasToken(swellTreasuryRewards)
-  dailySupplySideRevenue.addGasToken(supplySideRewards)
+  const nodeOperatorsRewards = df * 0.05
+  const stakersRewards = df - swellTreasuryRewards - nodeOperatorsRewards
+
+  dailyFees.addGasToken(df, METRIC.STAKING_REWARDS)
+  dailyRevenue.addGasToken(swellTreasuryRewards, 'Staking rewards to swell')
+  dailySupplySideRevenue.addGasToken(stakersRewards, 'Staking rewards to stakers')
+  dailySupplySideRevenue.addGasToken(nodeOperatorsRewards, 'Staking rewards to node operators')
 
   // ALL SWELL burned to dead address
   await addTokensReceived({
@@ -68,47 +70,64 @@ async function fetch(options: FetchOptions): Promise<FetchResultV2> {
   })
 
   // holders revenue = buyback burns only
-  dailyHoldersRevenue.add(totalBurns)
-  dailyHoldersRevenue.subtract(programmaticBurns)
+  dailyHoldersRevenue.add(totalBurns, METRIC.TOKEN_BUY_BACK)
+  dailyHoldersRevenue.subtract(programmaticBurns, METRIC.TOKEN_BUY_BACK)
+
+  const stakingRevenueToProtocol = await dailyRevenue.clone();
+  stakingRevenueToProtocol.subtract(dailyHoldersRevenue)
+
+  const stakingRevenueRetained = await stakingRevenueToProtocol.getUSDValue();
+  const dailyProtocolRevenue = options.createBalances();
+  dailyProtocolRevenue.addUSDValue(stakingRevenueRetained, 'Staking rewards retained by protocol')
 
   return {
     dailyFees,
     dailyRevenue,
     dailySupplySideRevenue,
-    dailyProtocolRevenue: dailyRevenue,
+    dailyProtocolRevenue,
     dailyHoldersRevenue,
   }
 }
 
+const methodology = {
+  Fees: 'Total staking rewards and fees paid by protocol.',
+  Revenue: '5% staking rewards are charged by swell protocol.',
+  SupplySideRevenue: '90% staking rewards are distributed to ETH stakers and 5% to node operators.',
+  ProtocolRevenue: 'Revenue retained by protocol after buybacks and burns.',
+  HoldersRevenue: 'Executed SWELL buybacks tracked as SWELL transferred to the burn address excluding programmatic burns.',
+}
+
+const breakdownMethodology = {
+  Fees: {
+    [METRIC.STAKING_REWARDS]: 'Total staking rewards and fees paid by protocol.',
+  },
+  Revenue: {
+    'Staking rewards to swell': '5% staking rewards are charged by swell protocol.',
+  },
+  SupplySideRevenue: {
+    'Staking rewards to stakers': '90% staking rewards are distributed to ETH stakers.',
+    'Staking rewards to node operators': '5% staking rewards are distributed to node operators.',
+  },
+  ProtocolRevenue: {
+    'Staking rewards retained by protocol': 'Revenue retained by protocol after buybacks and burns.',
+  },
+  HoldersRevenue: {
+    [METRIC.TOKEN_BUY_BACK]: 'Executed SWELL buybacks tracked as SWELL transferred to the burn address excluding programmatic burns.',
+  },
+}
+
 const adapter: Adapter = {
   version: 2,
+  pullHourly: true,
   adapter: {
     [CHAIN.ETHEREUM]: {
       fetch,
       start: '2023-10-14',
     },
   },
-  methodology: {
-    Fees: 'Total validators fees and rewards from staked ETH.',
-    Revenue: '5% staking rewards are charged by Swell Protocol Treasury.',
-    SupplySideRevenue: '90% staking rewards are distributed to ETH stakers and 5% to node operators.',
-    ProtocolRevenue: '5% staking rewards are charged by Swell Protocol Treasury.',
-    HoldersRevenue: 'Executed SWELL buybacks tracked as SWELL transferred to the burn address excluding programmatic burns.',
-  },
-  breakdownMethodology: {
-    dailyFees: {
-      fees: 'Total validator rewards'
-    },
-    dailyRevenue: {
-      protocol_revenue: '5% staking yield taken as protocol revenue'
-    },
-    dailySupplySideRevenue: {
-      supply_side: 'Rewards distributed to stakers and node operators'
-    },
-    dailyHoldersRevenue: {
-      holders_buyback: 'SWELL transferred to the burn address excluding programmatic burns'
-    }
-  },
+  methodology,
+  breakdownMethodology,
+  allowNegativeValue: true,
 };
 
 export default adapter;

--- a/fees/swell.ts
+++ b/fees/swell.ts
@@ -1,16 +1,28 @@
 import { CHAIN } from "../helpers/chains";
 import { METRIC } from "../helpers/metrics";
 import { Adapter, FetchOptions, FetchResultV2 } from "../adapters/types";
+import { addTokensReceived } from "../helpers/token";
 
 // https://docs.swellnetwork.io/swell-staking/sweth-liquid-staking/sweth-v1.0-system-design/rewards-and-distribution/liquid-staking-rewards-and-fees
 
 const swETH = '0xf951E335afb289353dc249e82926178EaC7DEd78'
+const SWELL = '0x0a6e7ba5042b38349e437ec6db6214aec7b35676'
+const DEAD = '0x000000000000000000000000000000000000dEaD'
+
+const PROGRAMMATIC_BURN_WALLETS = [
+  '0xbc4499e1c9a28b0ac6fc38d6245ddd8a8de07efe',
+  '0x2019fe73c426e74fed2a140d7e5b577117a6dc1a',
+  '0x7815ba83da2e47b3d4386586216e2b1d57c36a6d',
+]
 
 async function fetch(options: FetchOptions): Promise<FetchResultV2> {
   const dailyFees = options.createBalances()
   const dailyRevenue = options.createBalances()
   const dailySupplySideRevenue = options.createBalances()
   const dailyHoldersRevenue = options.createBalances()
+
+  const totalBurns = options.createBalances()
+  const programmaticBurns = options.createBalances()
 
   const exchangeRateBefore = await options.fromApi.call({
     target: swETH,
@@ -36,8 +48,28 @@ async function fetch(options: FetchOptions): Promise<FetchResultV2> {
   
   dailyFees.addGasToken(df)
   dailyRevenue.addGasToken(swellTreasuryRewards)
-  dailyHoldersRevenue.addGasToken(swellTreasuryRewards, 'holders_buyback')
   dailySupplySideRevenue.addGasToken(supplySideRewards)
+
+  // ALL SWELL burned to dead address
+  await addTokensReceived({
+    balances: totalBurns,
+    tokens: [SWELL],
+    targets: [DEAD],
+    options,
+  })
+
+  //programmatic burns
+  await addTokensReceived({
+    balances: programmaticBurns,
+    tokens: [SWELL],
+    targets: [DEAD],
+    fromAdddesses: PROGRAMMATIC_BURN_WALLETS,
+    options,
+  })
+
+  // holders revenue = buyback burns only
+  dailyHoldersRevenue.add(totalBurns)
+  dailyHoldersRevenue.subtract(programmaticBurns)
 
   return {
     dailyFees,
@@ -61,7 +93,7 @@ const adapter: Adapter = {
     Revenue: '5% staking rewards are charged by Swell Protocol Treasury.',
     SupplySideRevenue: '90% staking rewards are distributed to ETH stakers and 5% to node operators.',
     ProtocolRevenue: '5% staking rewards are charged by Swell Protocol Treasury.',
-    HoldersRevenue: 'Protocol revenue (5% of staking yield) is allocated to SWELL buybacks via auctions. This is used as a proxy for value returned to token holders.',
+    HoldersRevenue: 'Executed SWELL buybacks tracked as SWELL transferred to the burn address excluding programmatic burns.',
   },
   breakdownMethodology: {
     dailyFees: {
@@ -74,7 +106,7 @@ const adapter: Adapter = {
       supply_side: 'Rewards distributed to stakers and node operators'
     },
     dailyHoldersRevenue: {
-      holders_buyback: 'Protocol revenue used for SWELL buybacks and burned'
+      holders_buyback: 'SWELL transferred to the burn address excluding programmatic burns'
     }
   },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@clickhouse/client": "^1.15.0",
-        "@defillama/sdk": "^5.0.211",
+        "@defillama/sdk": "^5.0.192",
         "@supercharge/promise-pool": "^3.1.0",
         "@types/async-retry": "^1.4.8",
         "async-retry": "^1.3.3",
@@ -1134,24 +1133,6 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@clickhouse/client": {
-      "version": "1.18.3",
-      "resolved": "https://registry.npmjs.org/@clickhouse/client/-/client-1.18.3.tgz",
-      "integrity": "sha512-340ngdYktL8PLUBK2QKSwe0o02tYfZSz1mSn1uXCEU8TxHvwh9pnQxElf9YHumDGj5gX/IdgxPsJTGMs82Hgug==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@clickhouse/client-common": "1.18.3"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/@clickhouse/client-common": {
-      "version": "1.18.3",
-      "resolved": "https://registry.npmjs.org/@clickhouse/client-common/-/client-common-1.18.3.tgz",
-      "integrity": "sha512-3axzO3zvrsGT5PzDenxgWscltYCNRDbhaHWUgdsmcM9OnW/VnZn9EarOcZogr9P82Z0mQh+Jd2x+p2K4TFD2fA==",
-      "license": "Apache-2.0"
-    },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
@@ -1165,9 +1146,9 @@
       }
     },
     "node_modules/@defillama/sdk": {
-      "version": "5.0.211",
-      "resolved": "https://registry.npmjs.org/@defillama/sdk/-/sdk-5.0.211.tgz",
-      "integrity": "sha512-o4C8hPaRrNLEX31idd9O0GtXPvQYAyUR+n+g5gHd6F73705zInatbrLOJ0ZTaJ5AwwqMx9CXbdi6qKnrc5hVbA==",
+      "version": "5.0.192",
+      "resolved": "https://registry.npmjs.org/@defillama/sdk/-/sdk-5.0.192.tgz",
+      "integrity": "sha512-ClUxV00l+eunuVuVfhaFOwj7s3eZIUGn4xx78EZGvFdXUD1fFf4qAmwTr2sOOOzB67FmdLlj5G7bZM5yeK2YNA==",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.400.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@defillama/sdk": "^5.0.192",
+        "@clickhouse/client": "^1.15.0",
+        "@defillama/sdk": "^5.0.211",
         "@supercharge/promise-pool": "^3.1.0",
         "@types/async-retry": "^1.4.8",
         "async-retry": "^1.3.3",
@@ -1133,6 +1134,24 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/@clickhouse/client": {
+      "version": "1.18.3",
+      "resolved": "https://registry.npmjs.org/@clickhouse/client/-/client-1.18.3.tgz",
+      "integrity": "sha512-340ngdYktL8PLUBK2QKSwe0o02tYfZSz1mSn1uXCEU8TxHvwh9pnQxElf9YHumDGj5gX/IdgxPsJTGMs82Hgug==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@clickhouse/client-common": "1.18.3"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@clickhouse/client-common": {
+      "version": "1.18.3",
+      "resolved": "https://registry.npmjs.org/@clickhouse/client-common/-/client-common-1.18.3.tgz",
+      "integrity": "sha512-3axzO3zvrsGT5PzDenxgWscltYCNRDbhaHWUgdsmcM9OnW/VnZn9EarOcZogr9P82Z0mQh+Jd2x+p2K4TFD2fA==",
+      "license": "Apache-2.0"
+    },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
@@ -1146,9 +1165,9 @@
       }
     },
     "node_modules/@defillama/sdk": {
-      "version": "5.0.192",
-      "resolved": "https://registry.npmjs.org/@defillama/sdk/-/sdk-5.0.192.tgz",
-      "integrity": "sha512-ClUxV00l+eunuVuVfhaFOwj7s3eZIUGn4xx78EZGvFdXUD1fFf4qAmwTr2sOOOzB67FmdLlj5G7bZM5yeK2YNA==",
+      "version": "5.0.211",
+      "resolved": "https://registry.npmjs.org/@defillama/sdk/-/sdk-5.0.211.tgz",
+      "integrity": "sha512-o4C8hPaRrNLEX31idd9O0GtXPvQYAyUR+n+g5gHd6F73705zInatbrLOJ0ZTaJ5AwwqMx9CXbdi6qKnrc5hVbA==",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.400.0",


### PR DESCRIPTION
## Summary

This PR updates the holders revenue metric for Swell to reflect its current tokenomics.

Under the Sweconomics framework, 5% of staking yield is collected as protocol revenue and allocated to SWELL buybacks via a Dutch auction mechanism. The SWELL used in the auction is permanently burned, reducing circulating supply.

Holders revenue is therefore represented by protocol revenue allocated to these buybacks, rather than direct distributions.

## Changes

- Set `dailyHoldersRevenue` equal to protocol revenue
- Updated methodology to reflect revenue-driven buyback mechanism

## Notes

- Buybacks are executed periodically, while revenue accrues continuously.  
- As protocol revenue is fully allocated to buybacks, revenue is used as a proxy for holders revenue in this adapter.

## Additional Context

A Dune dashboard was used to validate the relationship between protocol revenue and buybacks under the new tokenomics:

https://dune.com/swell-network/new-sweconomics-sim

For example, under the "[Actual On-Chain Burn & Estimated Buyback Activity](https://dune.com/swell-network/new-sweconomics-sim#actual-on-chain-burn-estimated-buyback-activity)" section, in April 2026:
- Fee Flow (protocol revenue): ~$7.1k  
- Buyback executed: ~$6k  

This difference reflects the auction mechanism, where revenue accrues continuously but buybacks are executed periodically. Over time, protocol revenue is fully allocated to buybacks.