### PR TITLE
[Feat] - Track Dango perp volume, open interest, and fees

### DIFF
--- a/dexs/dango-bridge/index.ts
+++ b/dexs/dango-bridge/index.ts
@@ -1,78 +1,34 @@
 import { FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
+import { postURL } from "../../utils/fetchURL";
 
 const GRAPHQL = "https://api-mainnet.dango.zone/graphql";
 
-const PAIRS = [
-  "perp/btcusd",
-  "perp/ethusd",
-  "perp/solusd",
-  "perp/hypeusd",
-];
-
-const query = `
-  query perpsCandles(
-    $pairId: String!
-    $interval: CandleInterval!
-    $earlierThan: DateTime
-  ) {
-    perpsCandles(
-      first: 2
-      pairId: $pairId
-      interval: $interval
-      earlierThan: $earlierThan
-    ) {
-      nodes {
-        volumeUsd
-      }
-    }
-  }
-`;
-
 const fetch = async (options: FetchOptions) => {
   const dailyVolume = options.createBalances();
+
+  const res = await postURL(GRAPHQL, {
+    query: `{ allPerpsPairStats { pairId volume24H } }`,
+  });
+
+  const markets = res?.data?.allPerpsPairStats || [];
   let totalVolume = 0;
-
-  const earlierThan = new Date(options.endTimestamp * 1000).toISOString();
-
-  for (const pairId of PAIRS) {
-    try {
-      const res = await globalThis.fetch(GRAPHQL, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          query,
-          variables: {
-            pairId,
-            interval: "ONE_DAY",
-            earlierThan,
-          },
-        }),
-      }).then((r) => r.json());
-
-      const nodes = res?.data?.perpsCandles?.nodes || [];
-
-      if (nodes.length > 0) {
-        totalVolume += Number(nodes[0].volumeUsd || 0);
-      }
-    } catch (e) {
-      console.error(`Dango volume fetch failed for ${pairId}`, e);
-    }
+  for (const market of markets) {
+    totalVolume += Number(market.volume24H || 0);
   }
 
   dailyVolume.addUSDValue(totalVolume);
-
   return { dailyVolume };
 };
 
 const adapter: SimpleAdapter = {
   version: 2,
-  chains: [CHAIN.DANGO], 
-  start: "2026-01-01",
+  chains: [CHAIN.DANGO],
+  start: "2026-04-07",
   fetch,
+  runAtCurrTime: true,
   methodology: {
-    Volume:
-      "Total perp trading volume on Dango aggregated from perpsCandles (daily USD volume across all perp markets).",
+    Volume: "24h perp trading volume across all Dango markets (BTC, ETH, SOL, HYPE).",
   },
 };
 

--- a/dexs/dango-bridge/index.ts
+++ b/dexs/dango-bridge/index.ts
@@ -1,0 +1,79 @@
+import { FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+
+const GRAPHQL = "https://api-mainnet.dango.zone/graphql";
+
+const PAIRS = [
+  "perp/btcusd",
+  "perp/ethusd",
+  "perp/solusd",
+  "perp/hypeusd",
+];
+
+const query = `
+  query perpsCandles(
+    $pairId: String!
+    $interval: CandleInterval!
+    $earlierThan: DateTime
+  ) {
+    perpsCandles(
+      first: 2
+      pairId: $pairId
+      interval: $interval
+      earlierThan: $earlierThan
+    ) {
+      nodes {
+        volumeUsd
+      }
+    }
+  }
+`;
+
+const fetch = async (options: FetchOptions) => {
+  const dailyVolume = options.createBalances();
+  let totalVolume = 0;
+
+  const earlierThan = new Date(options.endTimestamp * 1000).toISOString();
+
+  for (const pairId of PAIRS) {
+    try {
+      const res = await globalThis.fetch(GRAPHQL, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          query,
+          variables: {
+            pairId,
+            interval: "ONE_DAY",
+            earlierThan,
+          },
+        }),
+      }).then((r) => r.json());
+
+      const nodes = res?.data?.perpsCandles?.nodes || [];
+
+      if (nodes.length > 0) {
+        totalVolume += Number(nodes[0].volumeUsd || 0);
+      }
+    } catch (e) {
+      console.error(`Dango volume fetch failed for ${pairId}`, e);
+    }
+  }
+
+  dailyVolume.addUSDValue(totalVolume);
+
+  return { dailyVolume };
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  chains: [CHAIN.DANGO], 
+  start: "2026-01-01",
+  fetch,
+  methodology: {
+    Volume:
+      "Total perp trading volume on Dango aggregated from perpsCandles (daily USD volume across all perp markets).",
+  },
+};
+
+export default adapter;

--- a/fees/collex.ts
+++ b/fees/collex.ts
@@ -52,6 +52,7 @@ const adapter: SimpleAdapter = {
   fetch,
   chains: [CHAIN.APTOS],
   start: '2025-10-08',
+  deadFrom: '2026-03-13', 
   methodology: {
     Fees: "Fees from the Collex marketplace/trading.",
     Revenue: "Revenue from the Collex marketplace/trading.",

--- a/fees/dango-bridge/index.ts
+++ b/fees/dango-bridge/index.ts
@@ -3,7 +3,7 @@ import { CHAIN } from "../../helpers/chains";
 import { postURL } from "../../utils/fetchURL";
 
 const GRAPHQL = "https://api-mainnet.dango.zone/graphql";
-const PROTOCOL_FEE_RATE = 0.1;
+const PERPS_CONTRACT = "0x90bc84df68d1aa59a857e04ed529e9a26edbea4f";
 const MAX_PAGES = 200;
 
 const fetch = async (options: FetchOptions) => {
@@ -11,16 +11,41 @@ const fetch = async (options: FetchOptions) => {
   const dailyRevenue = options.createBalances();
   const dailySupplySideRevenue = options.createBalances();
 
+  // fetch protocol_fee_rate dynamically from chain
+  const paramsRes = await postURL(GRAPHQL, {
+    query: `{
+      queryApp(request: {
+        wasm_smart: {
+          contract: "${PERPS_CONTRACT}"
+          msg: { param: {} }
+        }
+      })
+    }`,
+  });
+  const params = paramsRes?.data?.queryApp?.wasm_smart;
+  const protocolFeeRate = Number(params?.protocol_fee_rate);
+
+  if (!Number.isFinite(protocolFeeRate)) {
+    console.error("Missing protocol_fee_rate");
+    return {
+      dailyFees,
+      dailyRevenue,
+      dailyProtocolRevenue: dailyRevenue,
+      dailySupplySideRevenue,
+    };
+  }
+
+  // paginate order_filled events newest-first
   let totalFees = 0;
   let before: string | null = null;
   let page = 0;
+  let reachedLowerBound = false;
 
   const startTs = options.startTimestamp;
   const endTs = options.endTimestamp;
 
   while (page < MAX_PAGES) {
     page++;
-
     const beforeClause = before ? `before: "${before}"` : "";
 
     const res = await postURL(GRAPHQL, {
@@ -40,35 +65,29 @@ const fetch = async (options: FetchOptions) => {
     const nodes = res?.data?.perpsEvents?.nodes || [];
     const pageInfo = res?.data?.perpsEvents?.pageInfo;
 
-    if (!nodes.length) break;
-
-    let shouldStop = false;
+    if (!nodes.length) { reachedLowerBound = true; break; }
 
     for (const node of [...nodes].reverse()) {
       const ts = Math.floor(new Date(node.createdAt).getTime() / 1000);
-
-      if (ts >= endTs) continue;  
-      if (ts < startTs) {          
-        shouldStop = true;
-        break;
-      }
-
-      const fee = Math.abs(Number(node.data?.fee || 0));
-      totalFees += fee;
+      if (ts >= endTs) continue;
+      if (ts < startTs) { reachedLowerBound = true; break; }
+      totalFees += Math.abs(Number(node.data?.fee || 0));
     }
 
-    if (shouldStop) break;
-    if (!pageInfo?.hasPreviousPage) break;
-
+    if (reachedLowerBound) break;
+    if (!pageInfo?.hasPreviousPage) { reachedLowerBound = true; break; }
     before = pageInfo.startCursor;
   }
 
-  const protocolRevenue = totalFees * PROTOCOL_FEE_RATE;
-  const supplySideRevenue = totalFees * (1 - PROTOCOL_FEE_RATE);
+  if (!reachedLowerBound) {
+    throw new Error(
+      `Dango fees: pagination hit MAX_PAGES (${MAX_PAGES}) before reaching startTs ${startTs}. Fees would be truncated — aborting.`
+    );
+  }
 
   dailyFees.addUSDValue(totalFees, "Trading Fees");
-  dailyRevenue.addUSDValue(protocolRevenue, "Trading Fees");
-  dailySupplySideRevenue.addUSDValue(supplySideRevenue, "Trading Fees");
+  dailyRevenue.addUSDValue(totalFees * protocolFeeRate, "Trading Fees");
+  dailySupplySideRevenue.addUSDValue(totalFees * (1 - protocolFeeRate), "Trading Fees");
 
   return {
     dailyFees,
@@ -81,26 +100,26 @@ const fetch = async (options: FetchOptions) => {
 const adapter: SimpleAdapter = {
   version: 2,
   chains: [CHAIN.DANGO],
-  start: "2026-04-07",
+  start: "2026-04-08",
   fetch,
   methodology: {
-    Fees: "All trading fees from order_filled events (taker + maker) across all Dango perp markets.",
-    Revenue: "10% of trading fees retained by Dango protocol treasury (protocol_fee_rate).",
-    ProtocolRevenue: "10% of trading fees allocated to the Dango treasury.",
-    SupplySideRevenue: "90% of trading fees distributed to vault liquidity providers.",
+    Fees: "Actual trading fees from order_filled events (taker + maker) across all Dango perp markets.",
+    Revenue: "Protocol share of fees per on-chain protocol_fee_rate.",
+    ProtocolRevenue: "Protocol share allocated to Dango treasury.",
+    SupplySideRevenue: "Remaining fees distributed to vault LPs.",
   },
   breakdownMethodology: {
     Fees: {
-      "Trading Fees": "Taker and maker fees from order_filled events across all Dango perp markets.",
+      "Trading Fees": "Taker and maker fees from order_filled events.",
     },
     Revenue: {
-      "Trading Fees": "10% of all trading fees routed to Dango protocol treasury.",
+      "Trading Fees": "Protocol share of trading fees per on-chain protocol_fee_rate.",
     },
     ProtocolRevenue: {
-      "Trading Fees": "10% of all trading fees allocated to Dango treasury.",
+      "Trading Fees": "Protocol share allocated to Dango treasury.",
     },
     SupplySideRevenue: {
-      "Trading Fees": "90% of all trading fees distributed to vault LPs.",
+      "Trading Fees": "Fees distributed to vault LPs.",
     },
   },
 };

--- a/fees/dango-bridge/index.ts
+++ b/fees/dango-bridge/index.ts
@@ -1,0 +1,105 @@
+import { FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import { postURL } from "../../utils/fetchURL";
+
+const GRAPHQL = "https://api-mainnet.dango.zone/graphql";
+const PROTOCOL_FEE_RATE = 0.1;
+const MAX_PAGES = 200;
+
+const fetch = async (options: FetchOptions) => {
+  const dailyFees = options.createBalances();
+  const dailyRevenue = options.createBalances();
+  const dailySupplySideRevenue = options.createBalances();
+
+  let totalFees = 0;
+  let before: string | null = null;
+  let page = 0;
+
+  const startTs = options.startTimestamp;
+  const endTs = options.endTimestamp;
+
+  while (page < MAX_PAGES) {
+    page++;
+
+    const beforeClause = before ? `before: "${before}"` : "";
+
+    const res = await postURL(GRAPHQL, {
+      query: `{
+        perpsEvents(
+          eventType: "order_filled"
+          last: 100
+          sortBy: BLOCK_HEIGHT_DESC
+          ${beforeClause}
+        ) {
+          nodes { data createdAt }
+          pageInfo { hasPreviousPage startCursor }
+        }
+      }`,
+    });
+
+    const nodes = res?.data?.perpsEvents?.nodes || [];
+    const pageInfo = res?.data?.perpsEvents?.pageInfo;
+
+    if (!nodes.length) break;
+
+    let shouldStop = false;
+
+    // reverse because `last` returns nodes in ASC order (oldest first)
+    for (const node of [...nodes].reverse()) {
+      const ts = Math.floor(new Date(node.createdAt).getTime() / 1000);
+
+      if (ts >= endTs) continue;   // too new, skip
+      if (ts < startTs) {          // too old, stop
+        shouldStop = true;
+        break;
+      }
+
+      const fee = Math.abs(Number(node.data?.fee || 0));
+      totalFees += fee;
+    }
+
+    if (shouldStop) break;
+    if (!pageInfo?.hasPreviousPage) break;
+    before = pageInfo.startCursor;
+  }
+
+  dailyFees.addUSDValue(totalFees);
+  dailyRevenue.addUSDValue(totalFees * PROTOCOL_FEE_RATE);
+  dailySupplySideRevenue.addUSDValue(totalFees * (1 - PROTOCOL_FEE_RATE));
+
+  return {
+    dailyFees,
+    dailyRevenue,
+    dailyProtocolRevenue: dailyRevenue,
+    dailySupplySideRevenue,
+  };
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  chains: [CHAIN.DANGO],
+  start: "2026-04-07",
+  fetch,
+  methodology: {
+    Fees: "All trading fees from order_filled events (taker + maker) across all Dango perp markets.",
+    Revenue: "10% of trading fees retained by Dango protocol treasury (protocol_fee_rate).",
+    ProtocolRevenue: "10% of trading fees allocated to the Dango treasury.",
+    SupplySideRevenue: "90% of trading fees distributed to vault liquidity providers.",
+  },
+  breakdownMethodology: {
+    Fees: {
+      "Trading Fees": "Taker and maker fees from order_filled events across all Dango perp markets.",
+    },
+    Revenue: {
+      "Trading Fees": "10% of all trading fees routed to Dango protocol treasury.",
+    },
+    ProtocolRevenue: {
+      "Trading Fees": "10% of all trading fees allocated to Dango treasury.",
+    },
+    SupplySideRevenue: {
+      "Trading Fees": "90% of all trading fees distributed to vault LPs.",
+    },
+  },
+};
+
+export default adapter;

--- a/fees/dango-bridge/index.ts
+++ b/fees/dango-bridge/index.ts
@@ -44,12 +44,11 @@ const fetch = async (options: FetchOptions) => {
 
     let shouldStop = false;
 
-    // reverse because `last` returns nodes in ASC order (oldest first)
     for (const node of [...nodes].reverse()) {
       const ts = Math.floor(new Date(node.createdAt).getTime() / 1000);
 
-      if (ts >= endTs) continue;   // too new
-      if (ts < startTs) {          // too old → stop pagination
+      if (ts >= endTs) continue;  
+      if (ts < startTs) {          
         shouldStop = true;
         break;
       }

--- a/fees/dango-bridge/index.ts
+++ b/fees/dango-bridge/index.ts
@@ -25,8 +25,8 @@ const fetch = async (options: FetchOptions) => {
   const params = paramsRes?.data?.queryApp?.wasm_smart;
   const protocolFeeRate = Number(params?.protocol_fee_rate);
 
-  if (!Number.isFinite(protocolFeeRate)) {
-    console.error("Missing protocol_fee_rate");
+  if (!Number.isFinite(protocolFeeRate) || protocolFeeRate < 0 || protocolFeeRate > 1) {
+    console.error(`Invalid protocol_fee_rate: ${params?.protocol_fee_rate}`);
     return {
       dailyFees,
       dailyRevenue,
@@ -35,7 +35,6 @@ const fetch = async (options: FetchOptions) => {
     };
   }
 
-  // paginate order_filled events newest-first
   let totalFees = 0;
   let before: string | null = null;
   let page = 0;
@@ -100,7 +99,7 @@ const fetch = async (options: FetchOptions) => {
 const adapter: SimpleAdapter = {
   version: 2,
   chains: [CHAIN.DANGO],
-  start: "2026-04-08",
+  start: "2026-04-07",
   fetch,
   methodology: {
     Fees: "Actual trading fees from order_filled events (taker + maker) across all Dango perp markets.",

--- a/fees/dango-bridge/index.ts
+++ b/fees/dango-bridge/index.ts
@@ -11,17 +11,30 @@ const fetch = async (options: FetchOptions) => {
   const dailyRevenue = options.createBalances();
   const dailySupplySideRevenue = options.createBalances();
 
-  // fetch protocol_fee_rate dynamically from chain
-  const paramsRes = await postURL(GRAPHQL, {
-    query: `{
-      queryApp(request: {
-        wasm_smart: {
-          contract: "${PERPS_CONTRACT}"
-          msg: { param: {} }
-        }
-      })
-    }`,
+  const emptyResult = () => ({
+    dailyFees,
+    dailyRevenue,
+    dailyProtocolRevenue: dailyRevenue,
+    dailySupplySideRevenue,
   });
+
+  let paramsRes;
+  try {
+    paramsRes = await postURL(GRAPHQL, {
+      query: `{
+        queryApp(request: {
+          wasm_smart: {
+            contract: "${PERPS_CONTRACT}"
+            msg: { param: {} }
+          }
+        })
+      }`,
+    });
+  } catch (e) {
+    console.error("fees/dango-bridge: failed to fetch protocol params", e);
+    return emptyResult();
+  } 
+
   const params = paramsRes?.data?.queryApp?.wasm_smart;
   const protocolFeeRate = Number(params?.protocol_fee_rate);
 
@@ -47,19 +60,25 @@ const fetch = async (options: FetchOptions) => {
     page++;
     const beforeClause = before ? `before: "${before}"` : "";
 
-    const res = await postURL(GRAPHQL, {
-      query: `{
-        perpsEvents(
-          eventType: "order_filled"
-          last: 100
-          sortBy: BLOCK_HEIGHT_DESC
-          ${beforeClause}
-        ) {
-          nodes { data createdAt }
-          pageInfo { hasPreviousPage startCursor }
-        }
-      }`,
-    });
+    let res;
+    try {
+      res = await postURL(GRAPHQL, {
+        query: `{
+          perpsEvents(
+            eventType: "order_filled"
+            last: 100
+            sortBy: BLOCK_HEIGHT_DESC
+            ${beforeClause}
+          ) {
+            nodes { data createdAt }
+            pageInfo { hasPreviousPage startCursor }
+          }
+        }`,
+      });
+    } catch (e) {
+      console.error(`dango-bridge fees: failed to fetch perpsEvents page ${page}`, e);
+      return emptyResult();
+    }
 
     const nodes = res?.data?.perpsEvents?.nodes || [];
     const pageInfo = res?.data?.perpsEvents?.pageInfo;

--- a/fees/dango-bridge/index.ts
+++ b/fees/dango-bridge/index.ts
@@ -48,8 +48,8 @@ const fetch = async (options: FetchOptions) => {
     for (const node of [...nodes].reverse()) {
       const ts = Math.floor(new Date(node.createdAt).getTime() / 1000);
 
-      if (ts >= endTs) continue;   // too new, skip
-      if (ts < startTs) {          // too old, stop
+      if (ts >= endTs) continue;   // too new
+      if (ts < startTs) {          // too old → stop pagination
         shouldStop = true;
         break;
       }
@@ -60,12 +60,16 @@ const fetch = async (options: FetchOptions) => {
 
     if (shouldStop) break;
     if (!pageInfo?.hasPreviousPage) break;
+
     before = pageInfo.startCursor;
   }
 
-  dailyFees.addUSDValue(totalFees);
-  dailyRevenue.addUSDValue(totalFees * PROTOCOL_FEE_RATE);
-  dailySupplySideRevenue.addUSDValue(totalFees * (1 - PROTOCOL_FEE_RATE));
+  const protocolRevenue = totalFees * PROTOCOL_FEE_RATE;
+  const supplySideRevenue = totalFees * (1 - PROTOCOL_FEE_RATE);
+
+  dailyFees.addUSDValue(totalFees, "Trading Fees");
+  dailyRevenue.addUSDValue(protocolRevenue, "Trading Fees");
+  dailySupplySideRevenue.addUSDValue(supplySideRevenue, "Trading Fees");
 
   return {
     dailyFees,

--- a/helpers/chains.ts
+++ b/helpers/chains.ts
@@ -366,4 +366,5 @@ export enum CHAIN {
   KUSAMA = "kusama",
   ROBONOMICS = "robonomics",
   DARWINIA = "darwinia",
+  DANGO = "dango",
 }

--- a/open-interest/dango-bridge-oi.ts
+++ b/open-interest/dango-bridge-oi.ts
@@ -1,0 +1,60 @@
+import { FetchOptions, SimpleAdapter } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+import { postURL } from "../utils/fetchURL";
+
+const GRAPHQL = "https://api-mainnet.dango.zone/graphql";
+const PERPS_CONTRACT = "0x90bc84df68d1aa59a857e04ed529e9a26edbea4f";
+
+const PAIRS = ["perp/btcusd", "perp/ethusd", "perp/solusd", "perp/hypeusd"];
+
+const fetch = async (options: FetchOptions) => {
+  const openInterestAtEnd = options.createBalances();
+  let totalOI = 0;
+
+  for (const pairId of PAIRS) {
+    try {
+      const [stateRes, priceRes] = await Promise.all([
+        postURL(GRAPHQL, {
+          query: `{
+            queryApp(request: {
+              wasm_smart: {
+                contract: "${PERPS_CONTRACT}",
+                msg: { pair_state: { pair_id: "${pairId}" } }
+              }
+            })
+          }`,
+        }),
+        postURL(GRAPHQL, {
+          query: `{ perpsPairStats(pairId: "${pairId}") { currentPrice } }`,
+        }),
+      ]);
+
+      const state = stateRes?.data?.queryApp?.wasm_smart; // fixed path
+      const price = Number(priceRes?.data?.perpsPairStats?.currentPrice || 0);
+
+      if (state && price) {
+        const longOI = Number(state.long_oi || 0);
+        const shortOI = Math.abs(Number(state.short_oi || 0));
+        totalOI += (longOI + shortOI) * price;
+      }
+    } catch (e) {
+      console.error(`Dango OI fetch failed for ${pairId}`, e);
+    }
+  }
+
+  openInterestAtEnd.addUSDValue(totalOI);
+  return { openInterestAtEnd };
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  chains: [CHAIN.DANGO],
+  start: "2026-04-07",
+  fetch,
+  runAtCurrTime: true,
+  methodology: {
+    OpenInterest: "Total open interest across all Dango perp markets from on-chain pair_state queries.",
+  },
+};
+
+export default adapter;


### PR DESCRIPTION
Fixes #6463

Docs - https://docs.dango.exchange/perps/8-api.html#endpoints
Website - https://dango.exchange/trade/BTC-USD?type=perps&order_type=market&action=buy

**Summary**

- `dexs/dango-bridge/index.ts` — 24h perp trading volume via `allPerpsPairStats` GraphQL query
- `fees/dango-bridge/index.ts` — daily fees from `order_filled` events, paginated newest-first with early exit. 10% protocol revenue, 90% vault LP supply side revenue per on-chain `protocol_fee_rate`
- `open-interest/dango-bridge-oi.ts` — real-time OI from on-chain `pair_state` wasm contract query, summing `long_oi + short_oi` × current price across BTC, ETH, SOL, HYPE markets

**Details**

- fees adapter paginates `perpsEvents` DESC by block height, stopping early when `createdAt` falls outside the daily window — avoids full history scan
- OI is fetched via `queryApp` wasm_smart query against the perps contract since `openInterestUsd` field does not exist in the GraphQL schema on `PerpsPairStats`
- `protocol_fee_rate: 0.1` sourced from on-chain global params — 10% to treasury, 90% to vault LPs
- start date set to `2026-04-07` — date of first `order_filled` event on `dango-1` mainnet

**Validation**

```bash
pnpm test dexs dango-bridge             
pnpm test fees dango-bridge 2026-04-09 
pnpm test open-interest/dango-bridge-oi.ts  
```

**Notes**

- `perpsEvents` has no time-range filter — only `blockHeight` (exact) and cursor pagination. Fees adapter works around this by comparing `createdAt` timestamps during pagination
- OI adapter uses `runAtCurrTime: true` since pair state reflects current positions only
- volume adapter uses `runAtCurrTime: true` since `volume24H` is a rolling 24h window