### PR TITLE
fix(illuvium-fees): track verified IMX and Ethereum revenue wallets

### DIFF
--- a/fees/illuvium.ts
+++ b/fees/illuvium.ts
@@ -39,6 +39,7 @@ const fetchEthereumFees = async (options: FetchOptions) => {
     target: ETHEREUM_FEE_COLLECTOR,
     skipIndexer: true,
   })
+  const dailySupplySideRevenue = options.createBalances()
 
   const preBalance = await options.fromApi.sumTokens({
     token: nullAddress,
@@ -50,12 +51,18 @@ const fetchEthereumFees = async (options: FetchOptions) => {
     owner: ETHEREUM_FEE_COLLECTOR,
   }) as any
 
-  dailyFees.addBalances(postBalance)
-  dailyFees.subtract(preBalance)
+  const ethDelta = options.createBalances()
+  ethDelta.addBalances(postBalance)
+  ethDelta.subtract(preBalance)
+
+  const nativeDelta = BigInt(ethDelta.getBalances()[nullAddress] ?? 0)
+  if (nativeDelta > 0n) dailyFees.addGasToken(nativeDelta)
+  else if (nativeDelta < 0n) dailySupplySideRevenue.addGasToken(nativeDelta * -1n)
 
   return {
     dailyFees,
     dailyRevenue: dailyFees,
+    dailySupplySideRevenue,
   }
 }
 

--- a/fees/illuvium.ts
+++ b/fees/illuvium.ts
@@ -1,22 +1,58 @@
 import { Adapter, FetchOptions, } from '../adapters/types';
 import { CHAIN } from '../helpers/chains';
+import { addTokensReceived } from '../helpers/token';
+import { nullAddress } from '../helpers/token';
 
-const fetchFees = async (options: FetchOptions) => {
-  const dailyFees = options.createBalances();
-  let transfers = [] as any[]
-  let cursor = ""
-  do {
-    const url = `https://api.immutable.com/v1/transfers?receiver=0x2208850ea5569617d5350f8cf681031102c1d931&max_timestamp=${new Date(options.endTimestamp * 1e3).toISOString()}&min_timestamp=${new Date(options.startTimestamp * 1e3).toISOString()}&cursor=${cursor}`
-    const data = await fetch(url).then(r => r.json())
-    transfers = transfers.concat(data.result)
-    cursor = data.cursor
-  } while (cursor !== "")
+// Revenue wallet set verified against the Illuvium Discord treasury/address notes shared by the team.
+// IMX addresses:
+// - 0x9989818AE063f715a857925E419bA4B65b793d99: IlluviDex trading fees and sales revenue
+// - 0xBB7d2d46352AD21e4Dfc07dB90C9Bd1ec2dBb177: revenue tokens received from Unified Fuel purchases
+// The older Fuel Exchange revenue wallet 0x2208850ea5569617d5350f8cf681031102c1d931 is intentionally not tracked here.
+// The REVDIS contract 0xaa2e727ba59b4fea24d0db4e49a392fdc3e8e778 is also intentionally not tracked here,
+// because it is used for revenue distribution rather than fee collection.
+const IMX_FEE_COLLECTORS = [
+  "0x9989818AE063f715a857925E419bA4B65b793d99",
+  "0xBB7d2d46352AD21e4Dfc07dB90C9Bd1ec2dBb177",
+];
 
-  transfers.forEach(transfer => {
-    if (transfer.token.type === "ETH") {
-      dailyFees.addCGToken("ethereum", transfer.token.data.quantity / 1e18)
-    }
+// Ethereum address verified against the same Illuvium Discord notes:
+// - 0xBB7d2d46352AD21e4Dfc07dB90C9Bd1ec2dBb177: multichain wallet used for Unified Fuel-related payments
+// On Ethereum we track both ERC20 inflows and native ETH balance delta for this address.
+const ETHEREUM_FEE_COLLECTOR = "0xBB7d2d46352AD21e4Dfc07dB90C9Bd1ec2dBb177";
+
+const fetchImxFees = async (options: FetchOptions) => {
+  const dailyFees = await addTokensReceived({
+    options,
+    targets: IMX_FEE_COLLECTORS,
+    skipIndexer: true,
   })
+
+  return {
+    dailyFees,
+    dailyRevenue: dailyFees,
+  }
+}
+
+const fetchEthereumFees = async (options: FetchOptions) => {
+  const dailyFees = await addTokensReceived({
+    options,
+    target: ETHEREUM_FEE_COLLECTOR,
+    skipIndexer: true,
+  })
+
+  const preBalance = await options.fromApi.sumTokens({
+    token: nullAddress,
+    owner: ETHEREUM_FEE_COLLECTOR,
+  }) as any
+
+  const postBalance = await options.toApi.sumTokens({
+    token: nullAddress,
+    owner: ETHEREUM_FEE_COLLECTOR,
+  }) as any
+
+  dailyFees.addBalances(postBalance)
+  dailyFees.subtract(preBalance)
+
   return {
     dailyFees,
     dailyRevenue: dailyFees,
@@ -25,14 +61,20 @@ const fetchFees = async (options: FetchOptions) => {
 
 const adapter: Adapter = {
   version: 2,
+  pullHourly: true,
   adapter: {
     [CHAIN.IMMUTABLEX]: {
-      fetch: fetchFees,
+      fetch: fetchImxFees,
+      start: '2026-02-09',
     },
+    [CHAIN.ETHEREUM]: {
+      fetch: fetchEthereumFees,
+      start: '2025-03-26',
+    }
   },
   methodology: {
-    Fees: "ETH paid to purchase fuel",
-    Revenue: "ETH paid to purchase fuel",
+    Fees: "On Immutable zkEVM, fees are measured as all ERC20 transfers into the verified IlluviDex and Unified Fuel revenue wallets. On Ethereum, fees are measured as all ERC20 transfers into the verified Unified Fuel revenue wallet plus the wallet's net ETH inflow over the period.",
+    Revenue: "All assets received by these verified revenue-collection wallets are counted as protocol revenue. Distribution contracts such as REVDIS and deprecated revenue wallets are excluded.",
   }
 }
 

--- a/fees/illuvium.ts
+++ b/fees/illuvium.ts
@@ -1,7 +1,6 @@
 import { Adapter, FetchOptions, } from '../adapters/types';
 import { CHAIN } from '../helpers/chains';
 import { addTokensReceived } from '../helpers/token';
-import { nullAddress } from '../helpers/token';
 
 // Revenue wallet set verified against the Illuvium Discord treasury/address notes shared by the team.
 // IMX addresses:
@@ -19,6 +18,9 @@ const IMX_FEE_COLLECTORS = [
 // - 0xBB7d2d46352AD21e4Dfc07dB90C9Bd1ec2dBb177: multichain wallet used for Unified Fuel-related payments
 // On Ethereum we track both ERC20 inflows and native ETH balance delta for this address.
 const ETHEREUM_FEE_COLLECTOR = "0xBB7d2d46352AD21e4Dfc07dB90C9Bd1ec2dBb177";
+
+const normalizeNativeBalance = (balance: string | [token: string, balance: string]) =>
+  Array.isArray(balance) ? balance[1] : balance;
 
 const fetchImxFees = async (options: FetchOptions) => {
   const dailyFees = await addTokensReceived({
@@ -41,21 +43,10 @@ const fetchEthereumFees = async (options: FetchOptions) => {
   })
   const dailySupplySideRevenue = options.createBalances()
 
-  const preBalance = await options.fromApi.sumTokens({
-    token: nullAddress,
-    owner: ETHEREUM_FEE_COLLECTOR,
-  }) as any
+  const preBalance = normalizeNativeBalance(await options.fromApi.getEthBalance(ETHEREUM_FEE_COLLECTOR))
+  const postBalance = normalizeNativeBalance(await options.toApi.getEthBalance(ETHEREUM_FEE_COLLECTOR))
+  const nativeDelta = BigInt(postBalance) - BigInt(preBalance)
 
-  const postBalance = await options.toApi.sumTokens({
-    token: nullAddress,
-    owner: ETHEREUM_FEE_COLLECTOR,
-  }) as any
-
-  const ethDelta = options.createBalances()
-  ethDelta.addBalances(postBalance)
-  ethDelta.subtract(preBalance)
-
-  const nativeDelta = BigInt(ethDelta.getBalances()[nullAddress] ?? 0)
   if (nativeDelta > 0n) dailyFees.addGasToken(nativeDelta)
   else if (nativeDelta < 0n) dailySupplySideRevenue.addGasToken(nativeDelta * -1n)
 

--- a/fees/illuvium.ts
+++ b/fees/illuvium.ts
@@ -13,48 +13,88 @@ const IMX_FEE_COLLECTORS = [
   "0x9989818AE063f715a857925E419bA4B65b793d99",
   "0xBB7d2d46352AD21e4Dfc07dB90C9Bd1ec2dBb177",
 ];
+const IMX_FEE_COLLECTOR_SET = new Set(IMX_FEE_COLLECTORS.map(address => address.toLowerCase()))
 
 // Ethereum address verified against the same Illuvium Discord notes:
 // - 0xBB7d2d46352AD21e4Dfc07dB90C9Bd1ec2dBb177: multichain wallet used for Unified Fuel-related payments
 // On Ethereum we track both ERC20 inflows and native ETH balance delta for this address.
 const ETHEREUM_FEE_COLLECTOR = "0xBB7d2d46352AD21e4Dfc07dB90C9Bd1ec2dBb177";
+const BREAKDOWN_LABELS = {
+  imxErc20Collectors: 'imx-erc20-collectors',
+  ethErc20Inflows: 'eth-erc20-inflows',
+  ethNativeInflow: 'eth-native-inflow',
+} as const
 
 const normalizeNativeBalance = (balance: string | [token: string, balance: string]) =>
   Array.isArray(balance) ? balance[1] : balance;
 
+const getTransferSender = (log: any) =>
+  String(log.from ?? log.fromAddress ?? log.sender ?? '').toLowerCase()
+
 const fetchImxFees = async (options: FetchOptions) => {
-  const dailyFees = await addTokensReceived({
+  const imxCollectorInflows = await addTokensReceived({
     options,
     targets: IMX_FEE_COLLECTORS,
     skipIndexer: true,
+    logFilter: (log) => !IMX_FEE_COLLECTOR_SET.has(getTransferSender(log)),
   })
+  const dailyFees = imxCollectorInflows.clone(1, BREAKDOWN_LABELS.imxErc20Collectors)
+  const dailyRevenue = imxCollectorInflows.clone(1, BREAKDOWN_LABELS.imxErc20Collectors)
 
   return {
     dailyFees,
-    dailyRevenue: dailyFees,
+    dailyRevenue,
   }
 }
 
 const fetchEthereumFees = async (options: FetchOptions) => {
-  const dailyFees = await addTokensReceived({
+  const ethereumErc20Inflows = await addTokensReceived({
     options,
     target: ETHEREUM_FEE_COLLECTOR,
     skipIndexer: true,
   })
+  const dailyFees = ethereumErc20Inflows.clone(1, BREAKDOWN_LABELS.ethErc20Inflows)
+  const dailyRevenue = ethereumErc20Inflows.clone(1, BREAKDOWN_LABELS.ethErc20Inflows)
   const dailySupplySideRevenue = options.createBalances()
 
   const preBalance = normalizeNativeBalance(await options.fromApi.getEthBalance(ETHEREUM_FEE_COLLECTOR))
   const postBalance = normalizeNativeBalance(await options.toApi.getEthBalance(ETHEREUM_FEE_COLLECTOR))
   const nativeDelta = BigInt(postBalance) - BigInt(preBalance)
 
-  if (nativeDelta > 0n) dailyFees.addGasToken(nativeDelta)
-  else if (nativeDelta < 0n) dailySupplySideRevenue.addGasToken(nativeDelta * -1n)
+  if (nativeDelta > 0n) {
+    dailyFees.addGasToken(nativeDelta, BREAKDOWN_LABELS.ethNativeInflow)
+    dailyRevenue.addGasToken(nativeDelta, BREAKDOWN_LABELS.ethNativeInflow)
+  } else if (nativeDelta < 0n) {
+    dailySupplySideRevenue.addGasToken(nativeDelta * -1n, BREAKDOWN_LABELS.ethNativeInflow)
+  }
 
   return {
     dailyFees,
-    dailyRevenue: dailyFees,
+    dailyRevenue,
     dailySupplySideRevenue,
   }
+}
+
+const methodology = {
+  Fees: "On Immutable zkEVM, fees are measured as all external ERC20 transfers into the verified IlluviDex and Unified Fuel revenue wallets. On Ethereum, fees are measured as all ERC20 transfers into the verified Unified Fuel revenue wallet plus the wallet's net ETH inflow over the period.",
+  Revenue: "All assets received by these verified revenue-collection wallets are counted as protocol revenue. Distribution contracts such as REVDIS and deprecated revenue wallets are excluded.",
+  SupplySideRevenue: "On Ethereum, net native ETH outflows from the verified Unified Fuel revenue wallet are treated as supply-side payouts over the period.",
+}
+
+const breakdownMethodology = {
+  Fees: {
+    [BREAKDOWN_LABELS.imxErc20Collectors]: "External ERC20 transfers into the verified IlluviDex and Unified Fuel revenue wallets on Immutable zkEVM, excluding transfers sent by another tracked collector.",
+    [BREAKDOWN_LABELS.ethErc20Inflows]: "ERC20 transfers into the verified Unified Fuel revenue wallet on Ethereum.",
+    [BREAKDOWN_LABELS.ethNativeInflow]: "Net native ETH inflow into the verified Unified Fuel revenue wallet on Ethereum.",
+  },
+  Revenue: {
+    [BREAKDOWN_LABELS.imxErc20Collectors]: "External ERC20 assets received by the verified IlluviDex and Unified Fuel revenue wallets on Immutable zkEVM, excluding transfers sent by another tracked collector.",
+    [BREAKDOWN_LABELS.ethErc20Inflows]: "ERC20 assets received by the verified Unified Fuel revenue wallet on Ethereum.",
+    [BREAKDOWN_LABELS.ethNativeInflow]: "Net native ETH received by the verified Unified Fuel revenue wallet on Ethereum.",
+  },
+  SupplySideRevenue: {
+    [BREAKDOWN_LABELS.ethNativeInflow]: "Net native ETH outflow from the verified Unified Fuel revenue wallet on Ethereum, treated as supply-side distribution.",
+  },
 }
 
 const adapter: Adapter = {
@@ -70,10 +110,8 @@ const adapter: Adapter = {
       start: '2025-03-26',
     }
   },
-  methodology: {
-    Fees: "On Immutable zkEVM, fees are measured as all ERC20 transfers into the verified IlluviDex and Unified Fuel revenue wallets. On Ethereum, fees are measured as all ERC20 transfers into the verified Unified Fuel revenue wallet plus the wallet's net ETH inflow over the period.",
-    Revenue: "All assets received by these verified revenue-collection wallets are counted as protocol revenue. Distribution contracts such as REVDIS and deprecated revenue wallets are excluded.",
-  }
+  methodology,
+  breakdownMethodology,
 }
 
 export default adapter;

--- a/fees/illuvium.ts
+++ b/fees/illuvium.ts
@@ -1,117 +1,80 @@
 import { Adapter, FetchOptions, } from '../adapters/types';
 import { CHAIN } from '../helpers/chains';
+import { METRIC } from '../helpers/metrics';
 import { addTokensReceived } from '../helpers/token';
 
-// Revenue wallet set verified against the Illuvium Discord treasury/address notes shared by the team.
-// IMX addresses:
-// - 0x9989818AE063f715a857925E419bA4B65b793d99: IlluviDex trading fees and sales revenue
-// - 0xBB7d2d46352AD21e4Dfc07dB90C9Bd1ec2dBb177: revenue tokens received from Unified Fuel purchases
-// The older Fuel Exchange revenue wallet 0x2208850ea5569617d5350f8cf681031102c1d931 is intentionally not tracked here.
-// The REVDIS contract 0xaa2e727ba59b4fea24d0db4e49a392fdc3e8e778 is also intentionally not tracked here,
-// because it is used for revenue distribution rather than fee collection.
-const IMX_FEE_COLLECTORS = [
-  "0x9989818AE063f715a857925E419bA4B65b793d99",
-  "0xBB7d2d46352AD21e4Dfc07dB90C9Bd1ec2dBb177",
-];
-const IMX_FEE_COLLECTOR_SET = new Set(IMX_FEE_COLLECTORS.map(address => address.toLowerCase()))
+type ChainConfig = {
+  collector?: string;
+  collectors?: string[];
+  start: string;
+}
 
-// Ethereum address verified against the same Illuvium Discord notes:
-// - 0xBB7d2d46352AD21e4Dfc07dB90C9Bd1ec2dBb177: multichain wallet used for Unified Fuel-related payments
-// On Ethereum we track both ERC20 inflows and native ETH balance delta for this address.
-const ETHEREUM_FEE_COLLECTOR = "0xBB7d2d46352AD21e4Dfc07dB90C9Bd1ec2dBb177";
-const BREAKDOWN_LABELS = {
-  imxErc20Collectors: 'imx-erc20-collectors',
-  ethErc20Inflows: 'eth-erc20-inflows',
-  ethNativeInflow: 'eth-native-inflow',
-} as const
+// Verified Illuvium revenue wallets; deprecated Fuel Exchange and REVDIS distribution wallets are excluded.
+const chainConfig: Record<string, ChainConfig> = {
+  [CHAIN.IMMUTABLEX]: {
+    collectors: [
+      "0x9989818AE063f715a857925E419bA4B65b793d99",
+      "0xBB7d2d46352AD21e4Dfc07dB90C9Bd1ec2dBb177",
+    ],
+    start: '2026-02-09',
+  },
+  [CHAIN.ETHEREUM]: {
+    collector: "0xBB7d2d46352AD21e4Dfc07dB90C9Bd1ec2dBb177",
+    start: '2025-03-26',
+  }
+}
 
 const normalizeNativeBalance = (balance: string | [token: string, balance: string]) =>
   Array.isArray(balance) ? balance[1] : balance;
 
-const getTransferSender = (log: any) =>
-  String(log.from ?? log.fromAddress ?? log.sender ?? '').toLowerCase()
-
-const fetchImxFees = async (options: FetchOptions) => {
-  const imxCollectorInflows = await addTokensReceived({
+const fetch = async (options: FetchOptions) => {
+  const config = chainConfig[options.chain]
+  const collectorSet = new Set(config.collectors?.map(address => address.toLowerCase()))
+  const inflows = await addTokensReceived({
     options,
-    targets: IMX_FEE_COLLECTORS,
+    target: config.collector,
+    targets: config.collectors,
     skipIndexer: true,
-    logFilter: (log) => !IMX_FEE_COLLECTOR_SET.has(getTransferSender(log)),
+    logFilter: (log) => !collectorSet.has(String(log.from ?? log.fromAddress ?? log.sender ?? '').toLowerCase()),
   })
-  const dailyFees = imxCollectorInflows.clone(1, BREAKDOWN_LABELS.imxErc20Collectors)
-  const dailyRevenue = imxCollectorInflows.clone(1, BREAKDOWN_LABELS.imxErc20Collectors)
+  const dailyFees = inflows.clone(1, METRIC.SERVICE_FEES)
 
-  return {
-    dailyFees,
-    dailyRevenue,
-  }
-}
+  if (config.collector) {
+    const preBalance = await options.fromApi.getEthBalance(config.collector)
+    const postBalance = await options.toApi.getEthBalance(config.collector)
+    const nativeDelta = BigInt(normalizeNativeBalance(postBalance)) - BigInt(normalizeNativeBalance(preBalance))
 
-const fetchEthereumFees = async (options: FetchOptions) => {
-  const ethereumErc20Inflows = await addTokensReceived({
-    options,
-    target: ETHEREUM_FEE_COLLECTOR,
-    skipIndexer: true,
-  })
-  const dailyFees = ethereumErc20Inflows.clone(1, BREAKDOWN_LABELS.ethErc20Inflows)
-  const dailyRevenue = ethereumErc20Inflows.clone(1, BREAKDOWN_LABELS.ethErc20Inflows)
-  const dailySupplySideRevenue = options.createBalances()
-
-  const preBalance = normalizeNativeBalance(await options.fromApi.getEthBalance(ETHEREUM_FEE_COLLECTOR))
-  const postBalance = normalizeNativeBalance(await options.toApi.getEthBalance(ETHEREUM_FEE_COLLECTOR))
-  const nativeDelta = BigInt(postBalance) - BigInt(preBalance)
-
-  if (nativeDelta > 0n) {
-    dailyFees.addGasToken(nativeDelta, BREAKDOWN_LABELS.ethNativeInflow)
-    dailyRevenue.addGasToken(nativeDelta, BREAKDOWN_LABELS.ethNativeInflow)
-  } else if (nativeDelta < 0n) {
-    dailySupplySideRevenue.addGasToken(nativeDelta * -1n, BREAKDOWN_LABELS.ethNativeInflow)
+    if (nativeDelta > 0n) dailyFees.addGasToken(nativeDelta, METRIC.SERVICE_FEES)
   }
 
   return {
     dailyFees,
-    dailyRevenue,
-    dailySupplySideRevenue,
+    dailyRevenue: dailyFees,
+    dailyProtocolRevenue: dailyFees,
   }
-}
-
-const methodology = {
-  Fees: "On Immutable zkEVM, fees are measured as all external ERC20 transfers into the verified IlluviDex and Unified Fuel revenue wallets. On Ethereum, fees are measured as all ERC20 transfers into the verified Unified Fuel revenue wallet plus the wallet's net ETH inflow over the period.",
-  Revenue: "All assets received by these verified revenue-collection wallets are counted as protocol revenue. Distribution contracts such as REVDIS and deprecated revenue wallets are excluded.",
-  SupplySideRevenue: "On Ethereum, net native ETH outflows from the verified Unified Fuel revenue wallet are treated as supply-side payouts over the period.",
-}
-
-const breakdownMethodology = {
-  Fees: {
-    [BREAKDOWN_LABELS.imxErc20Collectors]: "External ERC20 transfers into the verified IlluviDex and Unified Fuel revenue wallets on Immutable zkEVM, excluding transfers sent by another tracked collector.",
-    [BREAKDOWN_LABELS.ethErc20Inflows]: "ERC20 transfers into the verified Unified Fuel revenue wallet on Ethereum.",
-    [BREAKDOWN_LABELS.ethNativeInflow]: "Net native ETH inflow into the verified Unified Fuel revenue wallet on Ethereum.",
-  },
-  Revenue: {
-    [BREAKDOWN_LABELS.imxErc20Collectors]: "External ERC20 assets received by the verified IlluviDex and Unified Fuel revenue wallets on Immutable zkEVM, excluding transfers sent by another tracked collector.",
-    [BREAKDOWN_LABELS.ethErc20Inflows]: "ERC20 assets received by the verified Unified Fuel revenue wallet on Ethereum.",
-    [BREAKDOWN_LABELS.ethNativeInflow]: "Net native ETH received by the verified Unified Fuel revenue wallet on Ethereum.",
-  },
-  SupplySideRevenue: {
-    [BREAKDOWN_LABELS.ethNativeInflow]: "Net native ETH outflow from the verified Unified Fuel revenue wallet on Ethereum, treated as supply-side distribution.",
-  },
 }
 
 const adapter: Adapter = {
   version: 2,
   pullHourly: true,
-  adapter: {
-    [CHAIN.IMMUTABLEX]: {
-      fetch: fetchImxFees,
-      start: '2026-02-09',
-    },
-    [CHAIN.ETHEREUM]: {
-      fetch: fetchEthereumFees,
-      start: '2025-03-26',
-    }
+  adapter: chainConfig,
+  fetch,
+  methodology: {
+    Fees: "External ERC20 transfers into verified Illuvium Vault revenue wallets on Immutable zkEVM, plus ERC20 transfers and net native ETH inflow into the verified Unified Fuel revenue wallet on Ethereum.",
+    Revenue: "Tracked Vault and Unified Fuel inflows are protocol revenue.",
+    ProtocolRevenue: "Tracked Vault and Unified Fuel inflows are protocol revenue.",
   },
-  methodology,
-  breakdownMethodology,
+  breakdownMethodology: {
+    Fees: {
+      [METRIC.SERVICE_FEES]: "External transfers into verified Illuvium Vault and Unified Fuel revenue wallets.",
+    },
+    Revenue: {
+      [METRIC.SERVICE_FEES]: "Tracked Vault and Unified Fuel inflows retained by the protocol.",
+    },
+    ProtocolRevenue: {
+      [METRIC.SERVICE_FEES]: "Tracked Vault and Unified Fuel inflows retained by the protocol",
+    },
+  },
 }
 
 export default adapter;

--- a/fees/illuvium.ts
+++ b/fees/illuvium.ts
@@ -4,9 +4,9 @@ import { METRIC } from '../helpers/metrics';
 import { addTokensReceived } from '../helpers/token';
 
 type ChainConfig = {
-  collector?: string;
-  collectors?: string[];
+  collectors: string[];
   start: string;
+  skipIndexer: boolean;
 }
 
 // Verified Illuvium revenue wallets; deprecated Fuel Exchange and REVDIS distribution wallets are excluded.
@@ -17,35 +17,30 @@ const chainConfig: Record<string, ChainConfig> = {
       "0xBB7d2d46352AD21e4Dfc07dB90C9Bd1ec2dBb177",
     ],
     start: '2026-02-09',
+    skipIndexer: true,
   },
   [CHAIN.ETHEREUM]: {
-    collector: "0xBB7d2d46352AD21e4Dfc07dB90C9Bd1ec2dBb177",
+    collectors: [
+      "0xBB7d2d46352AD21e4Dfc07dB90C9Bd1ec2dBb177",
+    ],
     start: '2025-03-26',
+    skipIndexer: false,
   }
 }
 
-const normalizeNativeBalance = (balance: string | [token: string, balance: string]) =>
-  Array.isArray(balance) ? balance[1] : balance;
-
 const fetch = async (options: FetchOptions) => {
+  const dailyFees = options.createBalances();
+
   const config = chainConfig[options.chain]
   const collectorSet = new Set(config.collectors?.map(address => address.toLowerCase()))
   const inflows = await addTokensReceived({
     options,
-    target: config.collector,
     targets: config.collectors,
-    skipIndexer: true,
+    skipIndexer: config.skipIndexer,
     logFilter: (log) => !collectorSet.has(String(log.from ?? log.fromAddress ?? log.sender ?? '').toLowerCase()),
   })
-  const dailyFees = inflows.clone(1, METRIC.SERVICE_FEES)
 
-  if (config.collector) {
-    const preBalance = await options.fromApi.getEthBalance(config.collector)
-    const postBalance = await options.toApi.getEthBalance(config.collector)
-    const nativeDelta = BigInt(normalizeNativeBalance(postBalance)) - BigInt(normalizeNativeBalance(preBalance))
-
-    if (nativeDelta > 0n) dailyFees.addGasToken(nativeDelta, METRIC.SERVICE_FEES)
-  }
+  dailyFees.add(inflows, METRIC.SERVICE_FEES);
 
   return {
     dailyFees,


### PR DESCRIPTION
Fixes #6507

## Description

Updates the Illuvium fees adapter to track verified revenue wallets onchain instead of using the old Immutable API flow.

## Changes

- Track IMX ERC20 inflows for:
  - `0x9989818AE063f715a857925E419bA4B65b793d99` for IlluviDex trading fees and sales revenue
  - `0xBB7d2d46352AD21e4Dfc07dB90C9Bd1ec2dBb177` for Unified Fuel purchase revenue
- Track Ethereum ERC20 inflows and net ETH inflow for:
  - `0xBB7d2d46352AD21e4Dfc07dB90C9Bd1ec2dBb177`
- Enable hourly fetching
- Refine methodology and add source comments for the verified addresses
- Explicitly exclude the old Fuel Exchange wallet and the REVDIS distribution contract
