### PR TITLE
feat(bulk-trade-perps): add bulk trade perps volume and oi tracking

### DIFF
--- a/dexs/bulk-trade-perps/index.ts
+++ b/dexs/bulk-trade-perps/index.ts
@@ -17,19 +17,39 @@ type StatsResponse = {
 };
 
 const fetch: FetchV2 = async () => {
-  const data = await httpGet(STATS_URL) as StatsResponse;
+  const data = await httpGet(STATS_URL) as Partial<StatsResponse>;
+  const timestamp = Number(data?.timestamp);
+  const dailyVolume = Number(data?.volume?.totalUsd);
+  const openInterest = Number(data?.openInterest?.totalUsd);
+
+  if (!Number.isFinite(timestamp)) {
+    throw new Error("Bulk Trade stats payload missing/invalid timestamp");
+  }
 
   // Bulk's stats endpoint is a live 24h rolling snapshot, so we only trust it
   // when the server timestamp is recent.
-  if (Math.abs(Date.now() - data.timestamp) > ONE_DAY_MS) {
+  if (Math.abs(Date.now() - timestamp) > ONE_DAY_MS) {
     throw new Error("Bulk Trade stats are stale (older than 24h)");
+  }
+
+  if (!Number.isFinite(dailyVolume) || !Number.isFinite(openInterest)) {
+    console.error("Bulk Trade stats payload missing/invalid numeric fields", {
+      dailyVolume: data?.volume?.totalUsd,
+      openInterest: data?.openInterest?.totalUsd,
+      timestamp,
+    });
+
+    return {
+      dailyVolume: 0,
+      openInterestAtEnd: 0,
+    };
   }
 
   return {
     // The API returns exchange-wide USD volume for the trailing 24h window.
-    dailyVolume: data.volume?.totalUsd ?? 0,
+    dailyVolume,
     // Open interest is already normalized to total USD notional.
-    openInterestAtEnd: data.openInterest?.totalUsd ?? 0,
+    openInterestAtEnd: openInterest,
   };
 };
 
@@ -43,7 +63,7 @@ const adapter: SimpleAdapter = {
     [CHAIN.OFF_CHAIN]: {
       fetch,
       runAtCurrTime: true,
-      start: "2025-12-01",
+      start: "2026-03-16",
     },
   },
   methodology: {

--- a/dexs/bulk-trade-perps/index.ts
+++ b/dexs/bulk-trade-perps/index.ts
@@ -1,0 +1,55 @@
+import { FetchV2, SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import { httpGet } from "../../utils/fetchURL";
+
+const STATS_URL = "https://exchange-api.bulk.trade/api/v1/stats?period=1d";
+const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+
+type StatsResponse = {
+  timestamp: number;
+  period: string;
+  volume: {
+    totalUsd: number;
+  };
+  openInterest: {
+    totalUsd: number;
+  };
+};
+
+const fetch: FetchV2 = async () => {
+  const data = await httpGet(STATS_URL) as StatsResponse;
+
+  // Bulk's stats endpoint is a live 24h rolling snapshot, so we only trust it
+  // when the server timestamp is recent.
+  if (Math.abs(Date.now() - data.timestamp) > ONE_DAY_MS) {
+    throw new Error("Bulk Trade stats are stale (older than 24h)");
+  }
+
+  return {
+    // The API returns exchange-wide USD volume for the trailing 24h window.
+    dailyVolume: data.volume?.totalUsd ?? 0,
+    // Open interest is already normalized to total USD notional.
+    openInterestAtEnd: data.openInterest?.totalUsd ?? 0,
+  };
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  // Bulk currently exposes only a current rolling snapshot. The documented 7d,
+  // 30d and 1y period params still return the same 24h stats, so backfill and
+  // true historical timetravel are not reliable yet.
+  timetravel: false,
+  adapter: {
+    [CHAIN.OFF_CHAIN]: {
+      fetch,
+      runAtCurrTime: true,
+      start: "2025-12-01",
+    },
+  },
+  methodology: {
+    Volume: "Volume uses Bulk Trade's public /stats endpoint and reads the exchange-level 24h rolling USD volume. Historical backfill is not supported because Bulk currently documents all period values as returning the same 24h rolling stats.",
+    OpenInterest: "Open interest uses Bulk Trade's public /stats endpoint and reads the exchange-level total USD open interest from the current snapshot.",
+  },
+};
+
+export default adapter;


### PR DESCRIPTION
Fixes #6306 

##### Name (to be shown on DefiLlama):
Bulk Trade

##### Twitter Link:
https://x.com/bulktrade

##### List of audit links if any:
None publicly documented in the Bulk docs/site at the time of writing.

##### Website Link:
https://www.bulk.trade/

##### Logo (High resolution, will be shown with rounded borders):
https://drive.google.com/drive/folders/139lR7uN0FFNv_0aGDhQHKmjUfw__cXkR?usp=sharing

##### Current TVL:
N/A for this PR (this PR adds a derivatives volume / open interest adapter, not a TVL adapter)

##### Treasury Addresses (if the protocol has treasury)
N/A / not publicly documented

##### Chain:
Solana

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed): (https://api.coingecko.com/api/v3/coins/list)


##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)


##### Short Description (to be shown on DefiLlama):
Bulk Trade is a decentralized perpetuals exchange with a CLOB-based trading engine, USDC-margined perps, and portfolio margin, built on BULK, a specialized execution layer that runs alongside Solana.

##### Token address and ticker if any:
No public token documented

##### Category (full list at https://defillama.com/categories) *Please choose only one:
Derivatives

##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.):
Pyth

##### Implementation Details: Briefly describe how the oracle is integrated into your project:
Bulk uses Pyth as the external spot reference for each asset. Oracle price updates are submitted through `PythOracle` actions into the executor, then pass through a price filter / volatility guard before being accepted. Mark price is then computed using a composite model that includes the oracle input.

##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage:
- Oracle / mark price docs: https://docs.bulk.trade/bulk-exchange/Price-Indices
- Contract specs: https://docs.bulk.trade/bulk-exchange/Contract-Specifications
- Architecture overview: https://docs.bulk.trade/architecture/overview

##### forkedFrom (Does your project originate from another project):
Not publicly documented / none disclosed

##### methodology (what is being counted as tvl, how is tvl being calculated):
This PR does not add a TVL adapter. For the dimensions adapter, we count Bulk Trade’s exchange-wide 24h rolling USD volume and current total USD open interest from Bulk’s public `/stats` endpoint. The adapter is marked `timetravel: false` because Bulk currently documents the `7d`, `30d`, `90d`, and `1y` period params as still returning the same 24h rolling stats rather than true historical windows.

##### Github org/user (Optional, if your code is open source, we can track activity):
Not publicly listed in the docs/site

##### Does this project have a referral program?
Referral program is not live yet. Bulk docs currently say “Coming soon”:
https://docs.bulk.trade/bulk-exchange/referral
