### PR TITLE
fix(users): add Blockscout-backed active and new user coverage

### DIFF
--- a/users/chains.ts
+++ b/users/chains.ts
@@ -69,6 +69,18 @@ function getBlockscoutChart(data: any, baseUrl: string, from: string, metric: st
     return data.chart as BlockscoutStatsChartItem[]
 }
 
+function parseBlockscoutValue(point: BlockscoutStatsChartItem | undefined, baseUrl: string, from: string, metric: string) {
+    const rawValue = point?.value
+    if (rawValue === null || rawValue === undefined || rawValue === "")
+        throw new Error(`Malformed Blockscout ${metric} payload for ${baseUrl} on ${from}`)
+
+    const value = Number(rawValue)
+    if (!Number.isFinite(value))
+        throw new Error(`Malformed Blockscout ${metric} payload for ${baseUrl} on ${from}`)
+
+    return value
+}
+
 // Blockscout stats-service exposes daily tx, active account, and new account series.
 function getBlockscoutUsersChain(baseUrl: string) {
     return async (start: number, end: number) => {
@@ -90,10 +102,10 @@ function getBlockscoutUsersChain(baseUrl: string) {
         const userChart = getBlockscoutChart(userData, baseUrl, from, "stats")
         const txPoint = txChart.find((item) => item.date === from)
         const userPoint = userChart.find((item) => item.date === from)
-        const txcount = Number(txPoint?.value)
-        const usercount = Number(userPoint?.value)
+        const txcount = parseBlockscoutValue(txPoint, baseUrl, from, "stats")
+        const usercount = parseBlockscoutValue(userPoint, baseUrl, from, "stats")
 
-        if (!txPoint || !userPoint || !Number.isFinite(txcount) || !Number.isFinite(usercount))
+        if (!txPoint || !userPoint)
             throw new Error(`Malformed Blockscout stats payload for ${baseUrl} on ${from}`)
 
         return [{
@@ -112,9 +124,9 @@ function getBlockscoutNewUsersChain(baseUrl: string) {
         const newUserData = await httpGet(`${baseUrl}/stats-service/api/v1/lines/newAccounts?from=${from}&to=${to}&resolution=DAY`)
         const newUserChart = getBlockscoutChart(newUserData, baseUrl, from, "new users")
         const newUserPoint = newUserChart.find((item) => item.date === from)
-        const usercount = Number(newUserPoint?.value)
+        const usercount = parseBlockscoutValue(newUserPoint, baseUrl, from, "new users")
 
-        if (!newUserPoint || !Number.isFinite(usercount))
+        if (!newUserPoint)
             throw new Error(`Malformed Blockscout new users payload for ${baseUrl} on ${from}`)
 
         return [{

--- a/users/chains.ts
+++ b/users/chains.ts
@@ -1,5 +1,5 @@
 import { queryAllium } from "../helpers/allium";
-import PromisePool from "@supercharge/promise-pool";
+import { PromisePool } from "@supercharge/promise-pool";
 import fetchURL, { httpGet } from "../utils/fetchURL";
 import { CHAIN } from "../helpers/chains";
 

--- a/users/chains.ts
+++ b/users/chains.ts
@@ -71,7 +71,7 @@ function getBlockscoutChart(data: any, baseUrl: string, from: string, metric: st
 
 function parseBlockscoutValue(point: BlockscoutStatsChartItem | undefined, baseUrl: string, from: string, metric: string) {
     const rawValue = point?.value
-    if (rawValue === null || rawValue === undefined || rawValue === "")
+    if (rawValue === null || rawValue === undefined || (typeof rawValue === "string" && rawValue.trim() === ""))
         throw new Error(`Malformed Blockscout ${metric} payload for ${baseUrl} on ${from}`)
 
     const value = Number(rawValue)

--- a/users/chains.ts
+++ b/users/chains.ts
@@ -80,7 +80,7 @@ function parseBlockscoutValue(point: BlockscoutStatsChartItem | undefined, baseU
         throw new Error(`Malformed Blockscout ${metric} payload for ${baseUrl} on ${from}`)
 
     const value = typeof rawValue === "number" ? rawValue : Number(rawValue)
-    if (!Number.isFinite(value))
+    if (!Number.isFinite(value) || !Number.isInteger(value) || value < 0)
         throw new Error(`Malformed Blockscout ${metric} payload for ${baseUrl} on ${from}`)
 
     return value

--- a/users/chains.ts
+++ b/users/chains.ts
@@ -70,11 +70,16 @@ function getBlockscoutChart(data: any, baseUrl: string, from: string, metric: st
 }
 
 function parseBlockscoutValue(point: BlockscoutStatsChartItem | undefined, baseUrl: string, from: string, metric: string) {
-    const rawValue = point?.value
-    if (rawValue === null || rawValue === undefined || (typeof rawValue === "string" && rawValue.trim() === ""))
+    const rawValue: unknown = point?.value
+    if (
+        rawValue === null ||
+        rawValue === undefined ||
+        (typeof rawValue !== "string" && typeof rawValue !== "number") ||
+        (typeof rawValue === "string" && rawValue.trim() === "")
+    )
         throw new Error(`Malformed Blockscout ${metric} payload for ${baseUrl} on ${from}`)
 
-    const value = Number(rawValue)
+    const value = typeof rawValue === "number" ? rawValue : Number(rawValue)
     if (!Number.isFinite(value))
         throw new Error(`Malformed Blockscout ${metric} payload for ${baseUrl} on ${from}`)
 

--- a/users/chains.ts
+++ b/users/chains.ts
@@ -54,6 +54,58 @@ async function elrondUsers(start: number, end: number) {
     }];
 }
 
+const toDateString = (d: number) => new Date(d * 1e3).toISOString().slice(0, 10)
+type BlockscoutStatsChartItem = {
+    date: string,
+    date_to: string,
+    value: string,
+}
+
+// Blockscout stats-service exposes daily tx, active account, and new account series.
+function getBlockscoutUsersChain(baseUrl: string) {
+    return async (start: number, end: number) => {
+        const from = toDateString(start)
+        const to = toDateString(end - 1)
+
+        const [txData, userData] = await Promise.all([
+            httpGet(`${baseUrl}/stats-service/api/v1/lines/newTxns?from=${from}&to=${to}&resolution=DAY`),
+            httpGet(`${baseUrl}/stats-service/api/v1/lines/activeAccounts?from=${from}&to=${to}&resolution=DAY`),
+        ])
+
+        const txPoint = (txData.chart as BlockscoutStatsChartItem[]).find((item) => item.date === from)
+        const userPoint = (userData.chart as BlockscoutStatsChartItem[]).find((item) => item.date === from)
+        const txcount = Number(txPoint?.value)
+        const usercount = Number(userPoint?.value)
+
+        if (!txPoint || !userPoint || !Number.isFinite(txcount) || !Number.isFinite(usercount))
+            throw new Error(`Malformed Blockscout stats payload for ${baseUrl} on ${from}`)
+
+        return [{
+            usercount,
+            txcount,
+        }]
+    }
+}
+
+// New-user coverage comes from the dedicated newAccounts series.
+function getBlockscoutNewUsersChain(baseUrl: string) {
+    return async (start: number, end: number) => {
+        const from = toDateString(start)
+        const to = toDateString(end - 1)
+
+        const newUserData = await httpGet(`${baseUrl}/stats-service/api/v1/lines/newAccounts?from=${from}&to=${to}&resolution=DAY`)
+        const newUserPoint = (newUserData.chart as BlockscoutStatsChartItem[]).find((item) => item.date === from)
+        const usercount = Number(newUserPoint?.value)
+
+        if (!newUserPoint || !Number.isFinite(usercount))
+            throw new Error(`Malformed Blockscout new users payload for ${baseUrl} on ${from}`)
+
+        return [{
+            usercount,
+        }]
+    }
+}
+
 function getAlliumUsersChain(chain: string) {
     return async (start: number, end: number) => {
         let fromField = chain === "starknet" ? "sender_address" : "from_address"
@@ -82,7 +134,6 @@ const alliumChainMap: Record<string, string> = {
     arbitrum: CHAIN.ARBITRUM,
     avalanche: CHAIN.AVAX,
     ethereum: CHAIN.ETHEREUM,
-    optimism: CHAIN.OPTIMISM,
     polygon: CHAIN.POLYGON,
     tron: CHAIN.TRON,
     base: CHAIN.BASE,
@@ -94,6 +145,30 @@ const alliumChainMap: Record<string, string> = {
 }
 
 const alliumExports = Object.keys(alliumChainMap).map(c => ({ name: c, id: c, getUsers: getAlliumUsersChain(c), getNewUsers: getAlliumNewUsersChain(c), chain: alliumChainMap[c], type: 'chain' }))
+
+const blockscoutChainMap: Record<string, { chain: string, baseUrl: string }> = {
+    astar: { chain: CHAIN.ASTAR, baseUrl: "https://astar.blockscout.com" },
+    filecoin: { chain: CHAIN.FILECOIN, baseUrl: "https://filecoin.blockscout.com" },
+    fuse: { chain: CHAIN.FUSE, baseUrl: "https://explorer.fuse.io" },
+    ink: { chain: CHAIN.INK, baseUrl: "https://explorer.inkonchain.com" },
+    lightlink_phoenix: { chain: CHAIN.LIGHTLINK_PHOENIX, baseUrl: "https://phoenix.lightlink.io" },
+    lisk: { chain: CHAIN.LISK, baseUrl: "https://blockscout.lisk.com" },
+    optimism: { chain: CHAIN.OPTIMISM, baseUrl: "https://explorer.optimism.io" },
+    redstone: { chain: CHAIN.REDSTONE, baseUrl: "https://explorer.redstone.xyz" },
+    rootstock: { chain: CHAIN.ROOTSTOCK, baseUrl: "https://rootstock.blockscout.com" },
+    soneium: { chain: CHAIN.SONEIUM, baseUrl: "https://soneium.blockscout.com" },
+    unichain: { chain: CHAIN.UNICHAIN, baseUrl: "https://unichain.blockscout.com" },
+    zksync: { chain: CHAIN.ZKSYNC, baseUrl: "https://zksync.blockscout.com" },
+}
+
+const blockscoutExports = Object.entries(blockscoutChainMap).map(([name, config]) => ({
+    name,
+    id: name,
+    getUsers: getBlockscoutUsersChain(config.baseUrl),
+    getNewUsers: getBlockscoutNewUsersChain(config.baseUrl),
+    chain: config.chain,
+    type: 'chain'
+}))
 
 export default [
     {
@@ -151,4 +226,4 @@ export default [
     type: "chain",
     chain: chain.chain,
     getUsers: (start: number, end: number) => chain.getUsers(start, end).then(u => typeof u === "object" ? u : ({ all: { users: u } })),
-} as ChainUserConfig)).concat(alliumExports)
+} as ChainUserConfig)).concat(alliumExports, blockscoutExports)

--- a/users/chains.ts
+++ b/users/chains.ts
@@ -1,4 +1,5 @@
 import { queryAllium } from "../helpers/allium";
+import PromisePool from "@supercharge/promise-pool";
 import fetchURL, { httpGet } from "../utils/fetchURL";
 import { CHAIN } from "../helpers/chains";
 
@@ -61,19 +62,34 @@ type BlockscoutStatsChartItem = {
     value: string,
 }
 
+function getBlockscoutChart(data: any, baseUrl: string, from: string, metric: string) {
+    if (!Array.isArray(data?.chart))
+        throw new Error(`Malformed Blockscout ${metric} payload for ${baseUrl} on ${from}`)
+
+    return data.chart as BlockscoutStatsChartItem[]
+}
+
 // Blockscout stats-service exposes daily tx, active account, and new account series.
 function getBlockscoutUsersChain(baseUrl: string) {
     return async (start: number, end: number) => {
         const from = toDateString(start)
         const to = toDateString(end - 1)
 
-        const [txData, userData] = await Promise.all([
-            httpGet(`${baseUrl}/stats-service/api/v1/lines/newTxns?from=${from}&to=${to}&resolution=DAY`),
-            httpGet(`${baseUrl}/stats-service/api/v1/lines/activeAccounts?from=${from}&to=${to}&resolution=DAY`),
-        ])
+        const { results, errors } = await PromisePool.withConcurrency(2).for([
+            { key: "tx", url: `${baseUrl}/stats-service/api/v1/lines/newTxns?from=${from}&to=${to}&resolution=DAY` },
+            { key: "users", url: `${baseUrl}/stats-service/api/v1/lines/activeAccounts?from=${from}&to=${to}&resolution=DAY` },
+        ]).process(async ({ key, url }) => ({ key, data: await httpGet(url) }))
 
-        const txPoint = (txData.chart as BlockscoutStatsChartItem[]).find((item) => item.date === from)
-        const userPoint = (userData.chart as BlockscoutStatsChartItem[]).find((item) => item.date === from)
+        if (errors.length)
+            throw errors[0]
+
+        const dataByKey = Object.fromEntries((results as { key: string, data: any }[]).map(({ key, data }) => [key, data]))
+        const txData = dataByKey.tx
+        const userData = dataByKey.users
+        const txChart = getBlockscoutChart(txData, baseUrl, from, "stats")
+        const userChart = getBlockscoutChart(userData, baseUrl, from, "stats")
+        const txPoint = txChart.find((item) => item.date === from)
+        const userPoint = userChart.find((item) => item.date === from)
         const txcount = Number(txPoint?.value)
         const usercount = Number(userPoint?.value)
 
@@ -94,7 +110,8 @@ function getBlockscoutNewUsersChain(baseUrl: string) {
         const to = toDateString(end - 1)
 
         const newUserData = await httpGet(`${baseUrl}/stats-service/api/v1/lines/newAccounts?from=${from}&to=${to}&resolution=DAY`)
-        const newUserPoint = (newUserData.chart as BlockscoutStatsChartItem[]).find((item) => item.date === from)
+        const newUserChart = getBlockscoutChart(newUserData, baseUrl, from, "new users")
+        const newUserPoint = newUserChart.find((item) => item.date === from)
         const usercount = Number(newUserPoint?.value)
 
         if (!newUserPoint || !Number.isFinite(usercount))


### PR DESCRIPTION
Partially Fixes #6465

## Summary

This PR adds Blockscout-backed user metrics to the users factory and moves supported chains onto Blockscout as a direct source for:

- `dailyActiveUsers`
- `dailyTransactionsCount`
- `dailyNewUsers`

## What changed

- Added Blockscout helpers in `users/chains.ts` for:
  - active users + tx count via:
    - `stats-service/api/v1/lines/activeAccounts`
    - `stats-service/api/v1/lines/newTxns`
  - new users via:
    - `stats-service/api/v1/lines/newAccounts`
- Added Blockscout-backed chain registry entries for:
  - `astar`
  - `filecoin`
  - `fuse`
  - `ink`
  - `lightlink_phoenix`
  - `lisk`
  - `optimism`
  - `redstone`
  - `rootstock`
  - `soneium`
  - `unichain`
  - `zksync`
- Moved `optimism` off the Allium chain map and onto the Blockscout-backed path
- Kept `users/list.ts` unchanged for new-users behavior by exposing explicit `getNewUsers` handlers from `users/chains.ts`
- Added small inline comments around the Blockscout helpers for readability
- Updated failure handling so malformed/missing Blockscout payloads throw instead of being published as fake zero-activity days

## Why

Some chains expose reliable daily user/account metrics directly through Blockscout `stats-service`, which lets us:
- add coverage for chains not already covered by Allium
- align active/new user metrics to the explorer-native daily series
- avoid silently recording bad zeroes when the upstream source fails

## Notes

- This PR only adds the Blockscout-backed user path and related chain mappings
- No Allium helper logic was changed beyond removing `optimism` from the Allium map


## Results

| Chain | Daily active users | Daily tx count | Daily new users |
| --- | ---: | ---: | ---: |
| optimism | 16.34k | 1.19M | 4.97k |
| ink | 33.03k | 424.36k | 382 |
| unichain | 3.27k | 726.96k | 105 |
| lisk | 391 | 51.99k | 10 |
| rootstock | 212 | 8.00k | 10 |
| fuse | 8.22k | 42.71k | 40 |
| astar | 117 | 5.19k | 4 |
| filecoin | 2.20k | 38.99k | 188 |
| zksync | 3.27k | 18.58k | 293 |
| soneium | 19.32k | 1.09M | 220 |
| redstone | 43 | 43.39k | 2 |
| lightlink_phoenix | 120 | 66.95k | 0 |


## Testing

```bash
for chain in optimism ink unichain lisk rootstock fuse astar filecoin zksync soneium redstone lightlink_phoenix; do
  pnpm test active-users "$chain"
  pnpm test new-users "$chain"
done

