### PR TITLE
[fix] arweave - replace ViewBlock fee source

### DIFF
--- a/fees/arweave/index.ts
+++ b/fees/arweave/index.ts
@@ -1,25 +1,165 @@
 import type { FetchOptions, } from "../../adapters/types";
 import { Adapter, ProtocolType } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
-import { httpGet } from "../../utils/fetchURL";
+import { httpGet, httpPost } from "../../utils/fetchURL";
+import { sleep } from "../../utils/utils";
+
+const ARWEAVE_GATEWAY = 'https://arweave.net';
+const ARWEAVE_GRAPHQL_ENDPOINT = `${ARWEAVE_GATEWAY}/graphql`;
+const WINSTON_PER_AR = 1e12;
+const TRANSACTIONS_PAGE_SIZE = 1000;
+const GRAPHQL_PAGE_DELAY_MS = 250;
+
+type ArweaveInfo = {
+  height: number;
+};
+
+type ArweaveBlock = {
+  height: number;
+  timestamp: number;
+};
+
+type ArweaveTransactionsResponse = {
+  data?: {
+    transactions?: {
+      pageInfo: {
+        hasNextPage: boolean;
+      };
+      edges: Array<{
+        cursor: string;
+        node: {
+          fee?: {
+            winston?: string;
+          };
+        };
+      }>;
+    };
+  };
+  errors?: unknown[];
+};
+
+// `bundledIn: null` keeps the sum to base-layer transactions and excludes
+// indexed bundle data items that do not pay separate L1 fees.
+const TRANSACTIONS_QUERY = `
+  query Transactions($first: Int!, $after: String, $minBlock: Int!, $maxBlock: Int!) {
+    transactions(
+      first: $first
+      after: $after
+      sort: HEIGHT_ASC
+      block: { min: $minBlock, max: $maxBlock }
+      bundledIn: null
+    ) {
+      pageInfo {
+        hasNextPage
+      }
+      edges {
+        cursor
+        node {
+          fee {
+            winston
+          }
+        }
+      }
+    }
+  }
+`;
+
+const withRetry = async <T>(action: () => Promise<T>, retries = 3): Promise<T> => {
+  let lastError: unknown;
+
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    try {
+      return await action();
+    } catch (error) {
+      lastError = error;
+      if (attempt < retries) await sleep((attempt + 1) * 1000);
+    }
+  }
+
+  throw lastError;
+}
+
+const arweaveGet = async <T>(path: string) => withRetry<T>(() => httpGet(`${ARWEAVE_GATEWAY}${path}`));
+
+const arweaveGraphQL = async <T>(query: string, variables: Record<string, unknown>) => withRetry<T>(() => httpPost(ARWEAVE_GRAPHQL_ENDPOINT, {
+  query,
+  variables,
+}, {
+  headers: {
+    'content-type': 'application/json',
+  },
+}));
+
+const getLatestHeight = async () => {
+  const info = await arweaveGet<ArweaveInfo>('/info');
+  if (!Number.isInteger(info.height)) throw new Error('Could not read latest Arweave block height');
+  return info.height;
+}
+
+const getBlockTimestamp = async (height: number) => {
+  const block = await arweaveGet<ArweaveBlock>(`/block/height/${height}`);
+  if (!Number.isInteger(block.timestamp)) throw new Error(`Could not read timestamp for Arweave block ${height}`);
+  return block.timestamp;
+}
+
+const findFirstBlockAtOrAfter = async (timestamp: number, latestHeight: number) => {
+  let low = 0;
+  let high = latestHeight + 1;
+
+  while (low < high) {
+    const mid = Math.floor((low + high) / 2);
+    const blockTimestamp = await getBlockTimestamp(mid);
+
+    if (blockTimestamp < timestamp) {
+      low = mid + 1;
+    } else {
+      high = mid;
+    }
+  }
+
+  return low;
+}
+
+const fetchTransactionFees = async (minBlock: number, maxBlock: number) => {
+  if (maxBlock < minBlock) return 0n;
+
+  let after: string | undefined;
+  let totalWinston = 0n;
+
+  do {
+    const response = await arweaveGraphQL<ArweaveTransactionsResponse>(TRANSACTIONS_QUERY, {
+      first: TRANSACTIONS_PAGE_SIZE,
+      after,
+      minBlock,
+      maxBlock,
+    });
+
+    if (response.errors?.length) throw new Error(`Arweave GraphQL returned ${response.errors.length} error(s)`);
+
+    const transactions = response.data?.transactions;
+    if (!transactions) throw new Error('Arweave GraphQL response did not include transactions');
+
+    transactions.edges.forEach(({ node }) => {
+      totalWinston += BigInt(node.fee?.winston ?? '0');
+    });
+
+    after = transactions.pageInfo.hasNextPage
+      ? transactions.edges[transactions.edges.length - 1]?.cursor
+      : undefined;
+
+    if (after) await sleep(GRAPHQL_PAGE_DELAY_MS);
+  } while (after);
+
+  return totalWinston;
+}
 
 const fetch = async (_a: any, _b: any, options: FetchOptions) => {
-  const dayTimestamp = options.startOfDay * 1000;
+  const latestHeight = await getLatestHeight();
+  const startHeight = await findFirstBlockAtOrAfter(options.startOfDay, latestHeight);
+  const nextDayHeight = await findFirstBlockAtOrAfter(options.startOfDay + 24 * 60 * 60, latestHeight);
+  const totalWinston = await fetchTransactionFees(startHeight, nextDayHeight - 1);
 
-  const data = await httpGet('https://api.viewblock.io/arweave/stats/advanced/charts/txFees?network=mainnet', {
-    headers: {
-      'origin': 'https://arscan.io'
-    }
-  });
-
-  const timestamps = data.day.data[0];
-  const fees = data.day.data[1];
-
-  const index = timestamps.findIndex((ts: number) => ts === dayTimestamp)
-  if (index === -1) {
-    throw new Error(`No data found for date: ${new Date(dayTimestamp).toISOString()}`);
-  }
-  const tokenAmount = parseFloat(fees[index]);
+  const tokenAmount = Number(totalWinston) / WINSTON_PER_AR;
 
   const dailyFees = options.createBalances();
   dailyFees.addCGToken('arweave', tokenAmount)
@@ -39,9 +179,8 @@ const adapter: Adapter = {
   },
   protocolType: ProtocolType.CHAIN,
   methodology: {
-    Fees: 'Fees are collected in AR (Arweave) tokens for each transaction on the Arweave network. The data is fetched from ViewBlock API which aggregates transaction fees from the Arweave blockchain. The fees represent the total amount paid by users for data storage and transfer on the network.'
+    Fees: 'Transaction fees paid by users in AR. Fees are sourced directly from the Arweave gateway by locating the daily block range and summing fee.winston values for base-layer transactions returned by Arweave GraphQL.'
   }
 }
 
 export default adapter;
-

--- a/fees/arweave/index.ts
+++ b/fees/arweave/index.ts
@@ -3,15 +3,20 @@ import { Adapter, ProtocolType } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 import PromisePool from '@supercharge/promise-pool';
 import BigNumber from "bignumber.js";
-import { httpGet } from "../../utils/fetchURL";
+import { httpGet, httpPost } from "../../utils/fetchURL";
 import { sleep } from "../../utils/utils";
 
 const ARWEAVE_GATEWAY = 'https://arweave.net';
+const ARWEAVE_GRAPHQL = `${ARWEAVE_GATEWAY}/graphql`;
 const VIEWBLOCK_FEES_URL = 'https://api.viewblock.io/arweave/stats/advanced/charts/txFees?network=mainnet';
 const DAY_SECONDS = 24 * 60 * 60;
 const WINSTON_PER_AR = 1e12;
-const BLOCK_CONCURRENCY = 8;
-const REWARD_CONCURRENCY = 24;
+const GRAPHQL_BLOCK_CHUNK_SIZE = 3;
+const GRAPHQL_CONCURRENCY = 24;
+const GRAPHQL_PAGE_SIZE = 100;
+const GRAPHQL_REQUEST_TIMEOUT_MS = 1000;
+const GRAPHQL_TOTAL_BUDGET_MS = 3000;
+const ARWEAVE_FEES_LABEL = 'Transaction Fees';
 
 type ArweaveInfo = {
   height: number;
@@ -28,6 +33,33 @@ type ViewBlockFeesResponse = {
     data?: [number[], string[]];
   };
 };
+
+type ArweaveGraphqlTransactionEdge = {
+  cursor?: string;
+  node?: {
+    fee?: {
+      winston?: string;
+    };
+  };
+};
+
+type ArweaveGraphqlResponse = {
+  data?: {
+    transactions?: {
+      pageInfo?: {
+        hasNextPage?: boolean;
+      };
+      edges?: ArweaveGraphqlTransactionEdge[];
+    };
+  };
+  errors?: { message?: string }[];
+};
+
+class ArweaveGraphqlBudgetExceededError extends Error {
+  constructor() {
+    super(`Arweave GraphQL fee aggregation exceeded ${GRAPHQL_TOTAL_BUDGET_MS}ms budget`);
+  }
+}
 
 const withRetry = async <T>(action: () => Promise<T>, retries = 3): Promise<T> => {
   let lastError: unknown;
@@ -97,61 +129,142 @@ const fetchViewBlockFees = async (startOfDay: number) => {
   return fee;
 }
 
-const getTransactionReward = async (txId: string) => {
-  const reward = String(await arweaveGet<string>(`/tx/${txId}/reward`)).trim();
-  if (!/^\d+$/.test(reward)) throw new Error(`Invalid Arweave reward for tx ${txId}`);
-  return BigInt(reward);
+const fetchGraphqlFeePage = async (minBlock: number, maxBlock: number, after?: string) => {
+  const query = `
+    query ArweaveTransactionFees($minBlock: Int!, $maxBlock: Int!, $first: Int!, $after: String) {
+      transactions(first: $first, after: $after, block: { min: $minBlock, max: $maxBlock }) {
+        pageInfo {
+          hasNextPage
+        }
+        edges {
+          cursor
+          node {
+            fee {
+              winston
+            }
+          }
+        }
+      }
+    }
+  `;
+
+  const response = await withRetry<ArweaveGraphqlResponse>(() => httpPost(
+    ARWEAVE_GRAPHQL,
+    {
+      query,
+      variables: {
+        minBlock,
+        maxBlock,
+        first: GRAPHQL_PAGE_SIZE,
+        after,
+      },
+    },
+    { timeout: GRAPHQL_REQUEST_TIMEOUT_MS },
+  ));
+
+  if (response.errors?.length) {
+    throw new Error(`Arweave GraphQL fee query failed: ${response.errors.map(error => error.message).join('; ')}`);
+  }
+
+  const transactions = response.data?.transactions;
+  if (!transactions || !Array.isArray(transactions.edges)) {
+    throw new Error(`Arweave GraphQL did not return transactions for blocks ${minBlock}-${maxBlock}`);
+  }
+
+  return transactions;
 }
 
-const getBlockTransactionIds = async (height: number) => {
-  const block = await arweaveGet<ArweaveBlock>(`/block/height/${height}`);
-  if (!Array.isArray(block.txs)) throw new Error(`Could not read transactions for Arweave block ${height}`);
-  return block.txs;
+const assertWithinGraphqlBudget = (deadline: number) => {
+  if (Date.now() > deadline) throw new ArweaveGraphqlBudgetExceededError();
 }
 
-const fetchNodeRewardFees = async (options: FetchOptions) => {
+const sumGraphqlFeeRange = async ({ minBlock, maxBlock }: { minBlock: number, maxBlock: number }, deadline: number) => {
+  let after: string | undefined;
+  let totalWinston = 0n;
+
+  do {
+    assertWithinGraphqlBudget(deadline);
+    const transactions = await fetchGraphqlFeePage(minBlock, maxBlock, after);
+    const edges = transactions.edges;
+
+    for (const edge of edges) {
+      const winston = edge.node?.fee?.winston;
+      if (!winston || !/^\d+$/.test(winston)) throw new Error(`Invalid Arweave fee value in blocks ${minBlock}-${maxBlock}`);
+      totalWinston += BigInt(winston);
+    }
+
+    after = transactions.pageInfo?.hasNextPage
+      ? edges[edges.length - 1]?.cursor
+      : undefined;
+
+    if (transactions.pageInfo?.hasNextPage && !after) {
+      throw new Error(`Arweave GraphQL pagination inconsistency for blocks ${minBlock}-${maxBlock}: hasNextPage=true without cursor`);
+    }
+  } while (after);
+
+  return totalWinston;
+}
+
+const chunkBlockRange = (startHeight: number, endHeight: number) => {
+  const chunks = [];
+  for (let minBlock = startHeight; minBlock <= endHeight; minBlock += GRAPHQL_BLOCK_CHUNK_SIZE) {
+    chunks.push({
+      minBlock,
+      maxBlock: Math.min(minBlock + GRAPHQL_BLOCK_CHUNK_SIZE - 1, endHeight),
+    });
+  }
+  return chunks;
+}
+
+const fetchGatewayFees = async (options: FetchOptions) => {
   const latestHeight = await getLatestHeight();
   const startHeight = await findFirstBlockAtOrAfter(options.startOfDay, latestHeight);
   const nextDayHeight = await findFirstBlockAtOrAfter(options.startOfDay + DAY_SECONDS, latestHeight);
   if (nextDayHeight <= startHeight) return new BigNumber(0);
 
-  const heights = Array.from({ length: nextDayHeight - startHeight }, (_, index) => startHeight + index);
-  const { results: txIdGroups, errors: blockErrors } = await PromisePool
-    .withConcurrency(BLOCK_CONCURRENCY)
-    .for(heights)
-    .process(getBlockTransactionIds);
-  if (blockErrors.length) throw blockErrors[0];
+  const deadline = Date.now() + GRAPHQL_TOTAL_BUDGET_MS;
+  let graphQLError: unknown;
+  const chunks = chunkBlockRange(startHeight, nextDayHeight - 1);
+  const { results, errors } = await PromisePool
+    .withConcurrency(GRAPHQL_CONCURRENCY)
+    .for(chunks)
+    .handleError((error, _chunk, pool) => {
+      graphQLError = error;
+      pool.stop();
+    })
+    .process(async (chunk) => {
+      assertWithinGraphqlBudget(deadline);
+      return sumGraphqlFeeRange(chunk, deadline);
+    });
+  if (graphQLError) throw graphQLError;
+  if (errors.length) throw errors[0];
 
-  const txIds = txIdGroups.flat();
-  const { results: rewards, errors: rewardErrors } = await PromisePool
-    .withConcurrency(REWARD_CONCURRENCY)
-    .for(txIds)
-    .process(getTransactionReward);
-  if (rewardErrors.length) throw rewardErrors[0];
-
-  const totalWinston = rewards.reduce((total, reward) => total + reward, 0n);
+  const totalWinston = results.reduce((total, reward) => total + reward, 0n);
   return new BigNumber(totalWinston.toString()).div(WINSTON_PER_AR);
 }
 
 const getDailyFees = async (options: FetchOptions) => {
   try {
-    const viewBlockFees = await fetchViewBlockFees(options.startOfDay);
-    if (viewBlockFees !== undefined) return viewBlockFees;
+    return await fetchGatewayFees(options);
   } catch (error) {
-    console.error(`Failed to fetch Arweave fees from ViewBlock, falling back to Arweave node data`, error);
+    console.error(`Failed to fetch Arweave fees from gateway GraphQL, falling back to ViewBlock: ${error instanceof Error ? error.message : error}`);
   }
 
-  return fetchNodeRewardFees(options);
+  const viewBlockFees = await fetchViewBlockFees(options.startOfDay);
+  if (viewBlockFees !== undefined) return viewBlockFees;
+  throw new Error(`ViewBlock did not return Arweave fees for ${new Date(options.startOfDay * 1000).toISOString()}`);
 }
 
 const fetch = async (_a: any, _b: any, options: FetchOptions) => {
   const tokenAmount = (await getDailyFees(options)).toNumber();
 
   const dailyFees = options.createBalances();
-  dailyFees.addCGToken('arweave', tokenAmount)
+  dailyFees.addCGToken('arweave', tokenAmount, ARWEAVE_FEES_LABEL)
 
   return {
-    dailyFees
+    dailyFees,
+    dailySupplySideRevenue: dailyFees,
+    dailyRevenue: 0,
   }
 }
 
@@ -164,10 +277,14 @@ const adapter: Adapter = {
     },
   },
   protocolType: ProtocolType.CHAIN,
-  skipBreakdownValidation: true,
   methodology: {
-    Fees: 'Transaction fees paid by users in AR. Daily totals are sourced from ViewBlock/Arscan. If that chart is unavailable for a day, the adapter falls back to Arweave node data by locating the daily block range and summing each base-layer transaction reward field.'
-  }
+    Fees: 'Transaction fees paid by users in AR. Daily totals are sourced from Arweave gateway GraphQL by locating the UTC day block range and summing each transaction fee.winston value. ViewBlock/Arscan is kept only as a recovery fallback if the gateway is unavailable.',
+    SupplySideRevenue: 'Transaction fees are paid to Arweave miners/storage providers.',
+    Revenue: 'No protocol revenue is reported for Arweave transaction fees.',
+  },
+  breakdownMethodology: {
+    [ARWEAVE_FEES_LABEL]: 'Base-layer AR transaction fees summed from Arweave gateway GraphQL fee.winston values for transactions confirmed in the UTC day block range.',
+  },
 }
 
 export default adapter;

--- a/fees/arweave/index.ts
+++ b/fees/arweave/index.ts
@@ -1,15 +1,17 @@
 import type { FetchOptions, } from "../../adapters/types";
 import { Adapter, ProtocolType } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
+import PromisePool from '@supercharge/promise-pool';
 import BigNumber from "bignumber.js";
-import { httpGet, httpPost } from "../../utils/fetchURL";
+import { httpGet } from "../../utils/fetchURL";
 import { sleep } from "../../utils/utils";
 
 const ARWEAVE_GATEWAY = 'https://arweave.net';
-const ARWEAVE_GRAPHQL_ENDPOINT = `${ARWEAVE_GATEWAY}/graphql`;
+const VIEWBLOCK_FEES_URL = 'https://api.viewblock.io/arweave/stats/advanced/charts/txFees?network=mainnet';
+const DAY_SECONDS = 24 * 60 * 60;
 const WINSTON_PER_AR = 1e12;
-const TRANSACTIONS_PAGE_SIZE = 1000;
-const GRAPHQL_PAGE_DELAY_MS = 250;
+const BLOCK_CONCURRENCY = 8;
+const REWARD_CONCURRENCY = 24;
 
 type ArweaveInfo = {
   height: number;
@@ -18,52 +20,14 @@ type ArweaveInfo = {
 type ArweaveBlock = {
   height: number;
   timestamp: number;
+  txs?: string[];
 };
 
-type ArweaveTransactionsResponse = {
-  data?: {
-    transactions?: {
-      pageInfo: {
-        hasNextPage: boolean;
-      };
-      edges: Array<{
-        cursor: string;
-        node: {
-          fee?: {
-            winston?: string;
-          };
-        };
-      }>;
-    };
+type ViewBlockFeesResponse = {
+  day?: {
+    data?: [number[], string[]];
   };
-  errors?: unknown[];
 };
-
-// `bundledIn: null` keeps the sum to base-layer transactions and excludes
-// indexed bundle data items that do not pay separate L1 fees.
-const TRANSACTIONS_QUERY = `
-  query Transactions($first: Int!, $after: String, $minBlock: Int!, $maxBlock: Int!) {
-    transactions(
-      first: $first
-      after: $after
-      sort: HEIGHT_ASC
-      block: { min: $minBlock, max: $maxBlock }
-      bundledIn: null
-    ) {
-      pageInfo {
-        hasNextPage
-      }
-      edges {
-        cursor
-        node {
-          fee {
-            winston
-          }
-        }
-      }
-    }
-  }
-`;
 
 const withRetry = async <T>(action: () => Promise<T>, retries = 3): Promise<T> => {
   let lastError: unknown;
@@ -81,15 +45,6 @@ const withRetry = async <T>(action: () => Promise<T>, retries = 3): Promise<T> =
 }
 
 const arweaveGet = async <T>(path: string) => withRetry<T>(() => httpGet(`${ARWEAVE_GATEWAY}${path}`));
-
-const arweaveGraphQL = async <T>(query: string, variables: Record<string, unknown>) => withRetry<T>(() => httpPost(ARWEAVE_GRAPHQL_ENDPOINT, {
-  query,
-  variables,
-}, {
-  headers: {
-    'content-type': 'application/json',
-  },
-}));
 
 const getLatestHeight = async () => {
   const info = await arweaveGet<ArweaveInfo>('/info');
@@ -121,52 +76,76 @@ const findFirstBlockAtOrAfter = async (timestamp: number, latestHeight: number) 
   return low;
 }
 
-const fetchTransactionFees = async (minBlock: number, maxBlock: number) => {
-  if (maxBlock < minBlock) return 0n;
-
-  let after: string | undefined;
-  let totalWinston = 0n;
-
-  do {
-    const response = await arweaveGraphQL<ArweaveTransactionsResponse>(TRANSACTIONS_QUERY, {
-      first: TRANSACTIONS_PAGE_SIZE,
-      after,
-      minBlock,
-      maxBlock,
-    });
-
-    if (response.errors?.length) throw new Error(`Arweave GraphQL returned ${response.errors.length} error(s)`);
-
-    const transactions = response.data?.transactions;
-    if (!transactions) throw new Error('Arweave GraphQL response did not include transactions');
-
-    transactions.edges.forEach(({ node }) => {
-      totalWinston += BigInt(node.fee?.winston ?? '0');
-    });
-
-    if (transactions.pageInfo.hasNextPage) {
-      const nextCursor = transactions.edges[transactions.edges.length - 1]?.cursor;
-      if (!nextCursor) {
-        throw new Error(`Arweave GraphQL returned hasNextPage=true with ${transactions.edges.length} edge(s)`);
-      }
-      after = nextCursor;
-    } else {
-      after = undefined;
+const fetchViewBlockFees = async (startOfDay: number) => {
+  const data = await withRetry<ViewBlockFeesResponse>(() => httpGet(VIEWBLOCK_FEES_URL, {
+    headers: {
+      origin: 'https://arscan.io'
     }
+  }));
 
-    if (after) await sleep(GRAPHQL_PAGE_DELAY_MS);
-  } while (after);
+  const timestamps = data.day?.data?.[0];
+  const fees = data.day?.data?.[1];
+  if (!Array.isArray(timestamps) || !Array.isArray(fees)) throw new Error('ViewBlock did not return Arweave fee chart data');
 
-  return totalWinston;
+  const dayTimestamp = startOfDay * 1000;
+  const index = timestamps.findIndex((timestamp) => timestamp === dayTimestamp);
+  if (index === -1) return undefined;
+
+  const fee = new BigNumber(fees[index]);
+  if (!fee.isFinite()) throw new Error(`Invalid ViewBlock Arweave fee value for ${new Date(dayTimestamp).toISOString()}`);
+
+  return fee;
+}
+
+const getTransactionReward = async (txId: string) => {
+  const reward = String(await arweaveGet<string>(`/tx/${txId}/reward`)).trim();
+  if (!/^\d+$/.test(reward)) throw new Error(`Invalid Arweave reward for tx ${txId}`);
+  return BigInt(reward);
+}
+
+const getBlockTransactionIds = async (height: number) => {
+  const block = await arweaveGet<ArweaveBlock>(`/block/height/${height}`);
+  if (!Array.isArray(block.txs)) throw new Error(`Could not read transactions for Arweave block ${height}`);
+  return block.txs;
+}
+
+const fetchNodeRewardFees = async (options: FetchOptions) => {
+  const latestHeight = await getLatestHeight();
+  const startHeight = await findFirstBlockAtOrAfter(options.startOfDay, latestHeight);
+  const nextDayHeight = await findFirstBlockAtOrAfter(options.startOfDay + DAY_SECONDS, latestHeight);
+  if (nextDayHeight <= startHeight) return new BigNumber(0);
+
+  const heights = Array.from({ length: nextDayHeight - startHeight }, (_, index) => startHeight + index);
+  const { results: txIdGroups, errors: blockErrors } = await PromisePool
+    .withConcurrency(BLOCK_CONCURRENCY)
+    .for(heights)
+    .process(getBlockTransactionIds);
+  if (blockErrors.length) throw blockErrors[0];
+
+  const txIds = txIdGroups.flat();
+  const { results: rewards, errors: rewardErrors } = await PromisePool
+    .withConcurrency(REWARD_CONCURRENCY)
+    .for(txIds)
+    .process(getTransactionReward);
+  if (rewardErrors.length) throw rewardErrors[0];
+
+  const totalWinston = rewards.reduce((total, reward) => total + reward, 0n);
+  return new BigNumber(totalWinston.toString()).div(WINSTON_PER_AR);
+}
+
+const getDailyFees = async (options: FetchOptions) => {
+  try {
+    const viewBlockFees = await fetchViewBlockFees(options.startOfDay);
+    if (viewBlockFees !== undefined) return viewBlockFees;
+  } catch (error) {
+    console.error(`Failed to fetch Arweave fees from ViewBlock, falling back to Arweave node data`, error);
+  }
+
+  return fetchNodeRewardFees(options);
 }
 
 const fetch = async (_a: any, _b: any, options: FetchOptions) => {
-  const latestHeight = await getLatestHeight();
-  const startHeight = await findFirstBlockAtOrAfter(options.startOfDay, latestHeight);
-  const nextDayHeight = await findFirstBlockAtOrAfter(options.startOfDay + 24 * 60 * 60, latestHeight);
-  const totalWinston = await fetchTransactionFees(startHeight, nextDayHeight - 1);
-
-  const tokenAmount = new BigNumber(totalWinston.toString()).div(WINSTON_PER_AR).toNumber();
+  const tokenAmount = (await getDailyFees(options)).toNumber();
 
   const dailyFees = options.createBalances();
   dailyFees.addCGToken('arweave', tokenAmount)
@@ -187,7 +166,7 @@ const adapter: Adapter = {
   protocolType: ProtocolType.CHAIN,
   skipBreakdownValidation: true,
   methodology: {
-    Fees: 'Transaction fees paid by users in AR. Fees are sourced directly from the Arweave gateway by locating the daily block range and summing fee.winston values for base-layer transactions returned by Arweave GraphQL.'
+    Fees: 'Transaction fees paid by users in AR. Daily totals are sourced from ViewBlock/Arscan. If that chart is unavailable for a day, the adapter falls back to Arweave node data by locating the daily block range and summing each base-layer transaction reward field.'
   }
 }
 

--- a/fees/arweave/index.ts
+++ b/fees/arweave/index.ts
@@ -1,6 +1,7 @@
 import type { FetchOptions, } from "../../adapters/types";
 import { Adapter, ProtocolType } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
+import BigNumber from "bignumber.js";
 import { httpGet, httpPost } from "../../utils/fetchURL";
 import { sleep } from "../../utils/utils";
 
@@ -143,9 +144,15 @@ const fetchTransactionFees = async (minBlock: number, maxBlock: number) => {
       totalWinston += BigInt(node.fee?.winston ?? '0');
     });
 
-    after = transactions.pageInfo.hasNextPage
-      ? transactions.edges[transactions.edges.length - 1]?.cursor
-      : undefined;
+    if (transactions.pageInfo.hasNextPage) {
+      const nextCursor = transactions.edges[transactions.edges.length - 1]?.cursor;
+      if (!nextCursor) {
+        throw new Error(`Arweave GraphQL returned hasNextPage=true with ${transactions.edges.length} edge(s)`);
+      }
+      after = nextCursor;
+    } else {
+      after = undefined;
+    }
 
     if (after) await sleep(GRAPHQL_PAGE_DELAY_MS);
   } while (after);
@@ -159,7 +166,7 @@ const fetch = async (_a: any, _b: any, options: FetchOptions) => {
   const nextDayHeight = await findFirstBlockAtOrAfter(options.startOfDay + 24 * 60 * 60, latestHeight);
   const totalWinston = await fetchTransactionFees(startHeight, nextDayHeight - 1);
 
-  const tokenAmount = Number(totalWinston) / WINSTON_PER_AR;
+  const tokenAmount = new BigNumber(totalWinston.toString()).div(WINSTON_PER_AR).toNumber();
 
   const dailyFees = options.createBalances();
   dailyFees.addCGToken('arweave', tokenAmount)
@@ -178,6 +185,7 @@ const adapter: Adapter = {
     },
   },
   protocolType: ProtocolType.CHAIN,
+  skipBreakdownValidation: true,
   methodology: {
     Fees: 'Transaction fees paid by users in AR. Fees are sourced directly from the Arweave gateway by locating the daily block range and summing fee.winston values for base-layer transactions returned by Arweave GraphQL.'
   }


### PR DESCRIPTION
## Summary
- replace the ViewBlock transaction-fee API with direct Arweave gateway data
- derive the daily block range from Arweave block timestamps
- sum `fee.winston` for base-layer transactions via Arweave GraphQL using `bundledIn: null`, with retry/pacing around gateway requests

Fixes #6637

## Validation
- `pnpm run ts-check`
- `pnpm test fees arweave 2018-06-10`
- `pnpm test fees arweave 2024-01-02`
- `pnpm test fees arweave`