### PR TITLE
[fix] pendle - remove duplicate asset whitelist fetch

### DIFF
--- a/fees/pendle.ts
+++ b/fees/pendle.ts
@@ -85,7 +85,6 @@ const chainConfig: IConfig = {
 
 const fetch = async (options: FetchOptions) => {
   const { chain } = options;
-  await getWhitelistedAssets(options.api);
   const { api, getLogs } = options;
 
   const dailyFees = options.createBalances()


### PR DESCRIPTION
## Summary

Removes an extra `getWhitelistedAssets()` call from the Pendle fees adapter. The result was discarded and the same helper is called again immediately afterward to get `markets`, `sys`, and `marketToSy`, so each adapter run was doing duplicate config/API work before processing logs.

This does not change fee classification or reported values; it just avoids the redundant lookup.

## Validation

- `npm run ts-check -- --pretty false`
- `npm test -- fees pendle 2025-10-01` attempted, but the current adapter run fails after startup in the SDK ABI/log fallback path with `Cannot read properties of undefined (reading 'success')` when Llama Indexer env is unavailable. The change is before that path and only removes a discarded duplicate call.

Related: #6334 already appears addressed on master for the September 2025 protocol revenue gate; this is a small cleanup found while auditing that issue.
