### PR TITLE
fix(move-dollar): use onchain interest for fees

### DIFF
--- a/dexs/thales/parsers.ts
+++ b/dexs/thales/parsers.ts
@@ -54,7 +54,7 @@ export function parseSafeBoxFeePaidEvent(
   dailyRevenue: Balances
 ) {
   const { safeBoxAmount, collateral } = log;
-  dailyRevenue.addToken(collateral, safeBoxAmount);
+  dailyRevenue.addToken(collateral, safeBoxAmount, 'SafeBox Fees');
 }
 
 export function parseSafeBoxSharePaidEvent(
@@ -66,6 +66,6 @@ export function parseSafeBoxSharePaidEvent(
   const { safeBoxAmount } = log;
   const collateral = collateralMapping[contractAddress.toLowerCase()];
   if (collateral) {
-    dailyLPPerformanceFee.addToken(collateral, safeBoxAmount);
+    dailyLPPerformanceFee.addToken(collateral, safeBoxAmount, 'LP Performance Fees');
   }
 }

--- a/fees/move-dollar.ts
+++ b/fees/move-dollar.ts
@@ -72,14 +72,17 @@ const fetch = async (timestamp: number, _chainBlocks: any, options: FetchOptions
 
   const dailyFees = options.createBalances();
   const dailyRevenue = options.createBalances();
+  const dailySupplySideRevenue = options.createBalances();
   const dailyFeesNumber = Number(dailyFeesUsd) / Number(USD_SCALE);
 
   dailyFees.addUSDValue(dailyFeesNumber, BORROW_INTEREST);
   dailyRevenue.addUSDValue(dailyFeesNumber, BORROW_INTEREST);
+  dailySupplySideRevenue.addUSDValue(dailyFeesNumber, BORROW_INTEREST);
 
   return {
     dailyFees,
     dailyRevenue,
+    dailySupplySideRevenue,
   };
 };
 
@@ -92,11 +95,14 @@ const adapter: SimpleAdapter = {
     Revenue: {
       [BORROW_INTEREST]: "Borrow interest retained by the protocol.",
     },
+    SupplySideRevenue: {
+      [BORROW_INTEREST]: "Borrow interest distributed to lenders.",
+    },
   },
   adapter: {
     [CHAIN.APTOS]: {
       fetch,
-      start: '2023-04-05',
+      start: "2023-04-05",
     },
   },
 };

--- a/fees/move-dollar.ts
+++ b/fees/move-dollar.ts
@@ -49,17 +49,23 @@ const fetchResources = async (timestamp: number) => {
   return httpGet(`${APTOS_REST_API}/v1/accounts/${MOVE_DOLLAR_ADDRESS}/resources?ledger_version=${ledgerVersion}&limit=9999`);
 };
 
-const fetch = async (timestamp: number, _chainBlocks: any, options: FetchOptions) => {
-  const resources: AptosResource[] = await fetchResources(timestamp);
+const fetch = async (options: FetchOptions) => {
+  const resources: AptosResource[] = await fetchResources(options.toTimestamp);
   const liabilities: Record<string, bigint> = {};
   const annualRates: Record<string, bigint> = {};
 
   resources.forEach(({ type, data }) => {
     const vaultCollateral = extractCollateral(type, "Vaults");
-    if (vaultCollateral) liabilities[vaultCollateral] = parseAptosInteger(data.total_liability, "total_liability", type);
+    if (vaultCollateral) {
+      if (data.total_liability == null) throw new Error(`Missing total_liability for ${type}`);
+      liabilities[vaultCollateral] = parseAptosInteger(data.total_liability, "total_liability", type);
+    }
 
     const paramsCollateral = extractCollateral(type, "VaultCollateralParams");
-    if (paramsCollateral) annualRates[paramsCollateral] = parseAptosInteger(data.interest_annual_rate_ratio?.v, "interest_annual_rate_ratio.v", type);
+    if (paramsCollateral) {
+      if (data.interest_annual_rate_ratio?.v == null) throw new Error(`Missing interest_annual_rate_ratio.v for ${type}`);
+      annualRates[paramsCollateral] = parseAptosInteger(data.interest_annual_rate_ratio.v, "interest_annual_rate_ratio.v", type);
+    }
   });
 
   const windowSeconds = options.endTimestamp - options.startTimestamp;
@@ -77,7 +83,6 @@ const fetch = async (timestamp: number, _chainBlocks: any, options: FetchOptions
 
   dailyFees.addUSDValue(dailyFeesNumber, BORROW_INTEREST);
   dailyRevenue.addUSDValue(dailyFeesNumber, BORROW_INTEREST);
-  dailySupplySideRevenue.addUSDValue(dailyFeesNumber, BORROW_INTEREST);
 
   return {
     dailyFees,
@@ -87,6 +92,7 @@ const fetch = async (timestamp: number, _chainBlocks: any, options: FetchOptions
 };
 
 const adapter: SimpleAdapter = {
+  version: 2,
   methodology: "Estimates borrower interest from Move Dollar vault liabilities and annual rates stored on-chain. MOD is treated as USD-pegged.",
   breakdownMethodology: {
     Fees: {

--- a/fees/move-dollar.ts
+++ b/fees/move-dollar.ts
@@ -4,9 +4,11 @@ import { httpGet } from "../utils/fetchURL";
 
 const APTOS_REST_API = "https://api.mainnet.aptoslabs.com";
 const MOVE_DOLLAR_ADDRESS = "0x6f986d146e4a90b828d8c12c14b6f4e003fdff11a8eecceceb63744363eaac01";
-const FIXED_POINT_64 = 2 ** 64;
-const MOD_DECIMALS = 1e8;
+const FIXED_POINT_64 = 1n << 64n;
+const MOD_DECIMALS = 100_000_000n;
 const YEAR_SECONDS = 365 * 24 * 60 * 60;
+const USD_SCALE = 1_000_000n;
+const BORROW_INTEREST = "Borrow interest";
 
 interface AptosResource {
   type: string;
@@ -15,6 +17,14 @@ interface AptosResource {
 
 const extractCollateral = (type: string, resource: string) =>
   type.match(new RegExp(`${MOVE_DOLLAR_ADDRESS}::vault::${resource}<(.+)>$`))?.[1];
+
+const parseAptosInteger = (value: unknown, field: string, type: string) => {
+  if (typeof value !== "string" || !/^\d+$/.test(value)) {
+    throw new Error(`Invalid ${field} for ${type}`);
+  }
+
+  return BigInt(value);
+};
 
 const getVersionFromTimestamp = async (timestamp: number) => {
   const ledger = await httpGet(`${APTOS_REST_API}/v1`);
@@ -41,29 +51,48 @@ const fetchResources = async (timestamp: number) => {
 
 const fetch = async (timestamp: number, _chainBlocks: any, options: FetchOptions) => {
   const resources: AptosResource[] = await fetchResources(timestamp);
-  const liabilities: Record<string, number> = {};
-  const annualRates: Record<string, number> = {};
+  const liabilities: Record<string, bigint> = {};
+  const annualRates: Record<string, bigint> = {};
 
   resources.forEach(({ type, data }) => {
     const vaultCollateral = extractCollateral(type, "Vaults");
-    if (vaultCollateral) liabilities[vaultCollateral] = Number(data.total_liability ?? 0) / MOD_DECIMALS;
+    if (vaultCollateral) liabilities[vaultCollateral] = parseAptosInteger(data.total_liability, "total_liability", type);
 
     const paramsCollateral = extractCollateral(type, "VaultCollateralParams");
-    if (paramsCollateral) annualRates[paramsCollateral] = Number(data.interest_annual_rate_ratio?.v ?? 0) / FIXED_POINT_64;
+    if (paramsCollateral) annualRates[paramsCollateral] = parseAptosInteger(data.interest_annual_rate_ratio?.v, "interest_annual_rate_ratio.v", type);
   });
 
   const windowSeconds = options.endTimestamp - options.startTimestamp;
-  const dailyFees = Object.entries(liabilities).reduce((sum, [collateral, liability]) => {
-    return sum + liability * (annualRates[collateral] ?? 0) * windowSeconds / YEAR_SECONDS;
-  }, 0);
+  const dailyFeesUsd = Object.entries(liabilities).reduce((sum, [collateral, liability]) => {
+    const annualRate = annualRates[collateral];
+    if (annualRate === undefined) throw new Error(`Missing annual interest rate for ${collateral}`);
+
+    return sum + liability * annualRate * BigInt(windowSeconds) * USD_SCALE / MOD_DECIMALS / FIXED_POINT_64 / BigInt(YEAR_SECONDS);
+  }, 0n);
+
+  const dailyFees = options.createBalances();
+  const dailyRevenue = options.createBalances();
+  const dailyFeesNumber = Number(dailyFeesUsd) / Number(USD_SCALE);
+
+  dailyFees.addUSDValue(dailyFeesNumber, BORROW_INTEREST);
+  dailyRevenue.addUSDValue(dailyFeesNumber, BORROW_INTEREST);
 
   return {
     dailyFees,
+    dailyRevenue,
   };
 };
 
 const adapter: SimpleAdapter = {
   methodology: "Estimates borrower interest from Move Dollar vault liabilities and annual rates stored on-chain. MOD is treated as USD-pegged.",
+  breakdownMethodology: {
+    Fees: {
+      [BORROW_INTEREST]: "Interest accrued by Move Dollar borrowers during the requested window.",
+    },
+    Revenue: {
+      [BORROW_INTEREST]: "Borrow interest retained by the protocol.",
+    },
+  },
   adapter: {
     [CHAIN.APTOS]: {
       fetch,

--- a/fees/move-dollar.ts
+++ b/fees/move-dollar.ts
@@ -1,25 +1,61 @@
-import fetchURL from "../utils/fetchURL";
-import { SimpleAdapter } from "../adapters/types";
+import { FetchOptions, SimpleAdapter } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
+import { httpGet } from "../utils/fetchURL";
 
-const feesQueryURL = "https://app.thala.fi/api/defillama/protocol-fee-chart?timeframe=";
+const APTOS_REST_API = "https://api.mainnet.aptoslabs.com";
+const MOVE_DOLLAR_ADDRESS = "0x6f986d146e4a90b828d8c12c14b6f4e003fdff11a8eecceceb63744363eaac01";
+const FIXED_POINT_64 = 2 ** 64;
+const MOD_DECIMALS = 1e8;
+const YEAR_SECONDS = 365 * 24 * 60 * 60;
 
-const feesEndpoint = (endTimestamp: number, timeframe: string) =>
-  endTimestamp
-    ? feesQueryURL + timeframe + `&endTimestamp=${endTimestamp}`
-    : feesQueryURL + timeframe;
-
-interface IVolumeall {
-  value: number;
-  timestamp: string;
+interface AptosResource {
+  type: string;
+  data: any;
 }
 
-const fetch = async (timestamp: number) => {
-  const dayFeesQuery = (await fetchURL(feesEndpoint(timestamp, "1D")))?.data;
-  const dailyFees = dayFeesQuery.reduce(
-    (partialSum: number, a: IVolumeall) => partialSum + a.value,
-    0
-  );
+const extractCollateral = (type: string, resource: string) =>
+  type.match(new RegExp(`${MOVE_DOLLAR_ADDRESS}::vault::${resource}<(.+)>$`))?.[1];
+
+const getVersionFromTimestamp = async (timestamp: number) => {
+  const ledger = await httpGet(`${APTOS_REST_API}/v1`);
+  const targetMicros = timestamp * 1e6;
+  if (Number(ledger.ledger_timestamp) <= targetMicros) return ledger.ledger_version;
+
+  let low = Number(ledger.oldest_ledger_version ?? 0);
+  let high = Number(ledger.ledger_version);
+
+  while (low < high) {
+    const mid = Math.ceil((low + high) / 2);
+    const block = await httpGet(`${APTOS_REST_API}/v1/blocks/by_version/${mid}`);
+    if (Number(block.block_timestamp) <= targetMicros) low = Number(block.last_version);
+    else high = Number(block.first_version) - 1;
+  }
+
+  return low;
+};
+
+const fetchResources = async (timestamp: number) => {
+  const ledgerVersion = await getVersionFromTimestamp(timestamp);
+  return httpGet(`${APTOS_REST_API}/v1/accounts/${MOVE_DOLLAR_ADDRESS}/resources?ledger_version=${ledgerVersion}&limit=9999`);
+};
+
+const fetch = async (timestamp: number, _chainBlocks: any, options: FetchOptions) => {
+  const resources: AptosResource[] = await fetchResources(timestamp);
+  const liabilities: Record<string, number> = {};
+  const annualRates: Record<string, number> = {};
+
+  resources.forEach(({ type, data }) => {
+    const vaultCollateral = extractCollateral(type, "Vaults");
+    if (vaultCollateral) liabilities[vaultCollateral] = Number(data.total_liability ?? 0) / MOD_DECIMALS;
+
+    const paramsCollateral = extractCollateral(type, "VaultCollateralParams");
+    if (paramsCollateral) annualRates[paramsCollateral] = Number(data.interest_annual_rate_ratio?.v ?? 0) / FIXED_POINT_64;
+  });
+
+  const windowSeconds = options.endTimestamp - options.startTimestamp;
+  const dailyFees = Object.entries(liabilities).reduce((sum, [collateral, liability]) => {
+    return sum + liability * (annualRates[collateral] ?? 0) * windowSeconds / YEAR_SECONDS;
+  }, 0);
 
   return {
     dailyFees,
@@ -27,6 +63,7 @@ const fetch = async (timestamp: number) => {
 };
 
 const adapter: SimpleAdapter = {
+  methodology: "Estimates borrower interest from Move Dollar vault liabilities and annual rates stored on-chain. MOD is treated as USD-pegged.",
   adapter: {
     [CHAIN.APTOS]: {
       fetch,


### PR DESCRIPTION
## Summary
- Fixes #6516 by replacing the dead Thala `protocol-fee-chart` API with Aptos on-chain data.
- Estimates borrower interest from Move Dollar vault liabilities and annual interest rates at the requested ledger version.
- Keeps the adapter active instead of using `deadFrom`, since Move Dollar is still live.

## Testing
- [x] npm run ts-check
- [x] npm test -- fees move-dollar.ts 2025-12-12
- [x] npm test -- fees move-dollar.ts

## Notes
- MOD is treated as USD-pegged for fee reporting, matching the existing Thala CDP methodology of borrower interest.