### PR TITLE
Fix dedust - update fee revenue split

### DIFF
--- a/fees/dedust/index.ts
+++ b/fees/dedust/index.ts
@@ -1,83 +1,43 @@
 import { FetchOptions, FetchResultV2 } from '../../adapters/types';
 import { CHAIN } from '../../helpers/chains'
-import { postURL } from "../../utils/fetchURL"
+import { httpPost } from "../../utils/fetchURL"
 import { METRIC } from '../../helpers/metrics';
+import { sleep } from '../../utils/utils';
 
-const GRAPHQL_ENDPOINT = 'https://api.dedust.io/v3/graphql';
-
-const POOLS_QUERY = `
-query GetPools($filter: PoolsFiltersInput) {
-    pools(filter: $filter) {
-      address
-      totalSupply
-      type
-      tradeFee
-      assets
-      reserves
-      fees
-      volume
-    }
-  }
-`;
-
-const ASSETS_QUERY = `
-query GetAssets {
-    assets {
-      type
-      address
-      symbol
-      decimals
-      price
-    }
-  }
-`;
-
-// DeDust CPMM v2 pools and Uranus bonding curves distribute 70% to LPs/token creators.
-const FEES_PERCENT_TO_LP = 0.7;
+const DEDUST_API = 'https://mainnet.api.dedust.io/v4/api/get_pools';
 
 const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
-  const assetsList = (await postURL(GRAPHQL_ENDPOINT, {
-    query: ASSETS_QUERY,
-    operationName: 'GetAssets'
-  })).data.assets;
-
-  const assetInfo: any = {};
-  for (const asset of assetsList) {
-    const address = asset.type == 'native' ? 'native' : 'jetton:' + asset.address;
-    assetInfo[address] = {
-      decimals: asset.decimals,
-      price: Number(asset.price),
-      symbol: asset.symbol
-    }
-  }
-
-  const poolsList = (await postURL(GRAPHQL_ENDPOINT, {
-    query: POOLS_QUERY,
-    operationName: 'GetPools'
-  })).data.pools;
-
-  let swapFees = 0;
-  for (const pool of poolsList) {
-    const leftAddr = pool.assets[0];
-    const rightAddr = pool.assets[1];
-    if (!(leftAddr in assetInfo && rightAddr in assetInfo)) {
-      console.warn("No assets info for pool", pool);
-      continue;
-    }
-    const left = assetInfo[leftAddr];
-    const right = assetInfo[rightAddr];
-
-    swapFees += (left.price * Number(pool.fees[0]) / Math.pow(10, left.decimals)
-      + right.price * Number(pool.fees[1]) / Math.pow(10, right.decimals)) / 2;
-  }
-
   const dailyFees = options.createBalances();
   const dailyRevenue = options.createBalances();
   const dailySupplySideRevenue = options.createBalances();
 
-  dailyFees.addUSDValue(swapFees, METRIC.SWAP_FEES);
-  dailyRevenue.addUSDValue(swapFees * (1 - FEES_PERCENT_TO_LP), METRIC.PROTOCOL_FEES);
-  dailySupplySideRevenue.addUSDValue(swapFees * FEES_PERCENT_TO_LP, METRIC.LP_FEES);
+  let offset = 0;
+
+  while (true) {
+    const apiResponse = await httpPost(DEDUST_API, {
+      offset,
+      limit: 100,
+      sort_by: "volume_24h",
+      sort_direction: "desc",
+      filter_by_type: ["cpmm_v2", "stable", "cpmm_v1"]
+    });
+    let lastVolume = 0;
+    for (const poolRow of apiResponse.pool_rows) {
+      for (const pool of poolRow.pools) {
+        const lpRatio = (Number(pool.lp_fee) / (Number(pool.protocol_fee) + Number(pool.lp_fee)));
+
+        dailyFees.addUSDValue(Number(pool.fees_24h_usd), METRIC.SWAP_FEES);
+        dailyRevenue.addUSDValue(Number(pool.fees_24h_usd) * (1 - lpRatio), METRIC.PROTOCOL_FEES);
+        dailySupplySideRevenue.addUSDValue(Number(pool.fees_24h_usd) * lpRatio, METRIC.LP_FEES);
+      }
+      lastVolume = Number(poolRow.volume_24h_usd);
+    }
+    if (lastVolume < 1) break;
+    const totalPools = apiResponse.total_count;
+    offset += 100;
+    if (offset >= totalPools) break;
+    await sleep(3000);
+  }
 
   return {
     dailyUserFees: dailyFees,
@@ -88,21 +48,25 @@ const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
 }
 
 const methodology = {
-  Fees: "Swap fees paid by users, ranging from 0.1% to 1% depending on the pool.",
-  UserFees: "User pays fee on each swap (depends on pool, 0.1% - 1%).",
-  Revenue: "Protocol receives 30% of fees, it is distributed among DUST stakers.",
-  SupplySideRevenue: "70% of user fees are distributed among LPs/token creators.",
+  Fees: "Swap fees paid by users, ranging from 0.05% to 5% depending on the pool.",
+  UserFees: "User pays fee on each swap (depends on pool, 0.05% - 5%).",
+  Revenue: "Protocol receives 20%(stable and CPMM v1) and 30%(CPMM v2) of fees, it is distributed to DUST stakers.",
+  HoldersRevenue: "20% of fees(stable and CPMM v1) and 30% of fees(CPMM v2) are distributed among DUST token stakers.",
+  SupplySideRevenue: "80%(stable and CPMM v1) and 70%(CPMM v2) of user fees are distributed among LPs.",
 }
 
 const breakdownMethodology = {
   Fees: {
-    [METRIC.SWAP_FEES]: "Fees paid by users on token swaps, ranging from 0.1% to 1% depending on the liquidity pool"
+    [METRIC.SWAP_FEES]: "Fees paid by users on token swaps, ranging from 0.05% to 5% depending on the liquidity pool"
   },
   Revenue: {
-    [METRIC.PROTOCOL_FEES]: "30% of swap fees distributed to DUST token stakers as protocol revenue"
+    [METRIC.STAKING_REWARDS]: "20% of swap fees(stable and CPMM v1) and 30% of swap fees(CPMM v2) distributed to DUST token stakers as protocol revenue"
+  },
+  HoldersRevenue: {
+    [METRIC.STAKING_REWARDS]: "20% of swap fees(stable and CPMM v1) and 30% of swap fees(CPMM v2) distributed to DUST token stakers as protocol revenue"
   },
   SupplySideRevenue: {
-    [METRIC.LP_FEES]: "70% of swap fees distributed to liquidity providers/token creators"
+    [METRIC.LP_FEES]: "80% of swap fees(stable and CPMM v1) and 70% of swap fees(CPMM v2) distributed to liquidity providers who supply capital to pools"
   }
 }
 

--- a/fees/dedust/index.ts
+++ b/fees/dedust/index.ts
@@ -32,8 +32,8 @@ query GetAssets {
   }
 `;
 
-// LPs get 80% of fees
-const FEES_PERCENT_TO_LP = 0.8;
+// DeDust CPMM v2 pools and Uranus bonding curves distribute 70% to LPs/token creators.
+const FEES_PERCENT_TO_LP = 0.7;
 
 const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
   const assetsList = (await postURL(GRAPHQL_ENDPOINT, {
@@ -90,8 +90,8 @@ const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
 const methodology = {
   Fees: "Swap fees paid by users, ranging from 0.1% to 1% depending on the pool.",
   UserFees: "User pays fee on each swap (depends on pool, 0.1% - 1%).",
-  Revenue: "Protocol receives 20% of fees, it is distributed among DUST stakers.",
-  SupplySideRevenue: "80% of user fees are distributed among LPs.",
+  Revenue: "Protocol receives 30% of fees, it is distributed among DUST stakers.",
+  SupplySideRevenue: "70% of user fees are distributed among LPs/token creators.",
 }
 
 const breakdownMethodology = {
@@ -99,10 +99,10 @@ const breakdownMethodology = {
     [METRIC.SWAP_FEES]: "Fees paid by users on token swaps, ranging from 0.1% to 1% depending on the liquidity pool"
   },
   Revenue: {
-    [METRIC.PROTOCOL_FEES]: "20% of swap fees distributed to DUST token stakers as protocol revenue"
+    [METRIC.PROTOCOL_FEES]: "30% of swap fees distributed to DUST token stakers as protocol revenue"
   },
   SupplySideRevenue: {
-    [METRIC.LP_FEES]: "80% of swap fees distributed to liquidity providers who supply capital to pools"
+    [METRIC.LP_FEES]: "70% of swap fees distributed to liquidity providers/token creators"
   }
 }
 


### PR DESCRIPTION
https://github.com/DefiLlama/dimension-adapters/issues/6337

## Summary
- Aligns protocol revenue and supply-side revenue methodology with the Uranus/CPMM v2 fee split described in the issue.
- Keeps the existing DeDust GraphQL source and fee calculation unchanged.

## Testing
- [x] npm run ts-check
- [x] npm test -- fees dedust

## Notes
- This does not add x1000 terminal fees; it corrects the current DeDust pool fee attribution only.