### PR TITLE
[feat] thales - add fees adapter

### DIFF
--- a/dexs/thales/index.ts
+++ b/dexs/thales/index.ts
@@ -1,9 +1,9 @@
 /**
  * Thales Options Adapter
  *
- * Fee/Revenue/HoldersRevenue Calculation (all equal):
- * - SafeBoxFeePaid events from AMM contracts (AMM fees)
- * - SafeBoxSharePaid events from LP contracts (LP performance fees)
+ * Fee/Revenue Calculation:
+ * - SafeBoxFeePaid events from AMM contracts (AMM fees) count as revenue/holders revenue
+ * - SafeBoxSharePaid events from LP contracts (LP performance fees) count as supply-side revenue
  * - Volume: Tracked from various market creation and trading events
  */
 
@@ -96,8 +96,9 @@ export async function fetch(options: FetchOptions): Promise<FetchResultV2> {
     dailyVolume: dailyPremiumVolume,
     dailyNotionalVolume: dailyNotionalVolume,
     dailyFees,
-    dailyRevenue: dailyFees,
-    dailyHoldersRevenue: dailyFees,
+    dailyRevenue,
+    dailyHoldersRevenue: dailyRevenue,
+    dailySupplySideRevenue: dailyLPPerformanceFee,
     dailyProtocolRevenue: 0,
   };
 }
@@ -114,9 +115,10 @@ const adapter: Adapter = {
   },
   methodology: {
     Fees: "Fees collected from AMM trades and LP performance fees",
-    Revenue: "Total revenue from AMM fees and LP performance fees, all distributed to $OVER token holders",
+    Revenue: "SafeBox fees from AMM trades distributed to $OVER token holders",
+    SupplySideRevenue: "LP performance fees collected from LP positions",
     ProtocolRevenue: "Protocol doesn't keep any revenue",
-    HoldersRevenue: "100% of revenue (AMM fees + LP fees) goes to $OVER token buybacks",
+    HoldersRevenue: "SafeBox fees from AMM trades go to $OVER token buybacks",
   },
   breakdownMethodology: {
     Fees: {
@@ -125,11 +127,12 @@ const adapter: Adapter = {
     },
     Revenue: {
       "SafeBox Fees": "AMM fees distributed to $OVER token holders via buybacks",
-      "LP Performance Fees": "LP fees distributed to $OVER token holders via buybacks",
+    },
+    SupplySideRevenue: {
+      "LP Performance Fees": "Performance fees collected from LP positions via SafeBoxSharePaid events",
     },
     HoldersRevenue: {
       "SafeBox Fees": "AMM fees redistributed to $OVER token holders",
-      "LP Performance Fees": "LP fees redistributed to $OVER token holders",
     },
   },
 };

--- a/dexs/thales/index.ts
+++ b/dexs/thales/index.ts
@@ -118,6 +118,20 @@ const adapter: Adapter = {
     ProtocolRevenue: "Protocol doesn't keep any revenue",
     HoldersRevenue: "100% of revenue (AMM fees + LP fees) goes to $OVER token buybacks",
   },
+  breakdownMethodology: {
+    Fees: {
+      "SafeBox Fees": "AMM fees collected from sports AMM v2, Thales AMM, Ranged AMM, Speed Markets, and Chained Speed Markets",
+      "LP Performance Fees": "Performance fees collected from LP positions via SafeBoxSharePaid events",
+    },
+    Revenue: {
+      "SafeBox Fees": "AMM fees distributed to $OVER token holders via buybacks",
+      "LP Performance Fees": "LP fees distributed to $OVER token holders via buybacks",
+    },
+    HoldersRevenue: {
+      "SafeBox Fees": "AMM fees redistributed to $OVER token holders",
+      "LP Performance Fees": "LP fees redistributed to $OVER token holders",
+    },
+  },
 };
 
 export default adapter;

--- a/dexs/thales/parsers.ts
+++ b/dexs/thales/parsers.ts
@@ -54,7 +54,7 @@ export function parseSafeBoxFeePaidEvent(
   dailyRevenue: Balances
 ) {
   const { safeBoxAmount, collateral } = log;
-  dailyRevenue.addToken(collateral, safeBoxAmount);
+  dailyRevenue.addToken(collateral, safeBoxAmount, "SafeBox Fees");
 }
 
 export function parseSafeBoxSharePaidEvent(
@@ -66,6 +66,6 @@ export function parseSafeBoxSharePaidEvent(
   const { safeBoxAmount } = log;
   const collateral = collateralMapping[contractAddress.toLowerCase()];
   if (collateral) {
-    dailyLPPerformanceFee.addToken(collateral, safeBoxAmount);
+    dailyLPPerformanceFee.addToken(collateral, safeBoxAmount, "LP Performance Fees");
   }
 }

--- a/fees/thales.ts
+++ b/fees/thales.ts
@@ -1,0 +1,3 @@
+import adapter from "../dexs/thales";
+
+export default adapter;


### PR DESCRIPTION
## Summary
- Expose the existing Thales/Overtime adapter under `fees/thales` so fee tracking is available from the fees category.
- Reuse the current onchain SafeBox fee/revenue logic from `dexs/thales` instead of duplicating implementation.

## Tests
- `npm run ts-check`
- `npm test -- fees thales 1777420800`

Closes #2602