### PR TITLE
feat(fees): track FrenFlow Polymarket builder-fee distributions

### DIFF
--- a/fees/frenflow.ts
+++ b/fees/frenflow.ts
@@ -1,25 +1,34 @@
 import { Adapter, FetchOptions, FetchV2 } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
+import { ethers } from "ethers";
 
 /**
  * FrenFlow — social copytrading + trading UI for prediction markets.
  * https://frenflow.com  ·  https://x.com/frenflow_
  *
- * Revenue model: a 1% service fee on manual trades routed through
- * FrenFlow's Safe wallet infrastructure on Polymarket. At trade
- * settlement, the FeeCollector contract pulls the fee atomically
- * (user → treasury) and emits a `FeeCollected` event with the exact
- * feeAmount. We sum those events for the period.
+ * Two on-chain revenue streams on Polygon, both summed into `dailyFees`:
  *
- * Volume for FrenFlow as a Polymarket builder is tracked separately
- * through `factory/polymarket.ts` (Polymarket's official builder
- * volume API). This file covers only the service-fee revenue.
+ *   1. Service Fees — a 1% fee pulled atomically (user → treasury) by
+ *      FrenFlow's FeeCollector contract at Polymarket trade settlement.
+ *      Tracked via the `FeeCollected` event. Denominated in USDC.e.
+ *
+ *   2. Builder Fees — Polymarket pays builders a per-fill commission for
+ *      trades carrying their `builderCode`. PM accrues these in an
+ *      internal treasury and periodically distributes them on-chain to
+ *      each builder's profile wallet (typically batched through a
+ *      "disperse"-style contract). FrenFlow's builder profile wallet is
+ *      `0x58715321c2c6a216d1259f368c34f987a4a26b64`. We sum incoming
+ *      pUSD / USDC.e / USDC (native) Transfer events to that wallet.
+ *
+ * Volume (notional) for FrenFlow as a Polymarket builder is tracked
+ * separately in `factory/polymarket.ts`.
  *
  * Income-statement mapping (per GUIDELINES):
- *   dailyFees            — gross protocol revenue (all sources)
- *   dailyUserFees        — portion directly paid by end-users
- *                          (100% here: the fee is pulled from the
- *                          user's wallet at trade settlement)
+ *   dailyFees            — gross protocol revenue (Service + Builder)
+ *   dailyUserFees        — portion paid directly by end-users (100%:
+ *                          service fee is pulled from the trader's
+ *                          wallet at fill; builder fee is funded by
+ *                          Polymarket out of the trader's order amount)
  *   dailyRevenue         — gross profit (no supply-side to reimburse)
  *   dailyProtocolRevenue — portion allocated to treasury (100%)
  */
@@ -28,25 +37,65 @@ import { CHAIN } from "../helpers/chains";
 // prod trade, tx 0xcd88b05b…). Contract: contracts/src/FeeCollector.sol
 const FEE_COLLECTOR = "0x95e47CBC5c4D9434412AF44Ade02B33613EDb787";
 
-// USDC.e (bridged) on Polygon — the only token the FeeCollector pulls.
-// pUSD-denominated Polymarket trades wrap into USDC.e pre-fee, so every
-// `FeeCollected` event is denominated in this token.
+// FrenFlow builder profile wallet on Polymarket. Polymarket distributes
+// builder-fee accruals to this address (denominated in pUSD or USDC.e).
+const BUILDER_PAYOUT = "0x58715321c2c6a216d1259f368c34f987a4a26b64";
+
+// USDC.e (bridged) on Polygon — settlement currency for FeeCollector
+// and one of the tokens Polymarket uses for builder payouts.
 const USDC_E_POLYGON = "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174";
 
-const FEE_LABEL = "Service Fees";
+// pUSD on Polygon — Polymarket's V2 collateral (1:1 USDC.e wrapper).
+// First builder payout (tx 0x4e0e7e42…, block 86195685, 2026-04-30)
+// was denominated in pUSD, so it is the primary builder-fee token.
+const PUSD_POLYGON = "0xc011a7E12a19f7B1f670d46F03B03f3342E82DFB";
+
+// USDC native (Circle) on Polygon — Polymarket has not used it for
+// builder payouts yet, but watching it covers the case where they
+// switch settlement currency without notice.
+const USDC_NATIVE_POLYGON = "0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359";
+
+const SERVICE_FEE_LABEL = "Service Fees";
+const BUILDER_FEE_LABEL = "Builder Fees";
+
+const transferEventAbi =
+  "event Transfer(address indexed from, address indexed to, uint256 value)";
+const transferTopic = ethers.id("Transfer(address,address,uint256)");
+const padAddress = (address: string) => ethers.zeroPadValue(address, 32);
 
 const fetch: FetchV2 = async ({ getLogs, createBalances }: FetchOptions) => {
   const dailyFees = createBalances();
 
-  const logs = await getLogs({
-    target: FEE_COLLECTOR,
-    eventAbi:
-      "event FeeCollected(bytes32 indexed fillId, address indexed user, bytes32 indexed tokenId, uint8 service, uint256 tradeAmount, uint256 feeAmount, uint256 feeBps, uint256 timestamp)",
-  });
+  // Filter `Transfer(from, to, value)` by the indexed `to` topic only —
+  // any sender that lands tokens in BUILDER_PAYOUT counts. The middle
+  // `null` keeps `from` unconstrained.
+  const builderPayoutTopics = [transferTopic, null, padAddress(BUILDER_PAYOUT)];
+  const builderTokens = [PUSD_POLYGON, USDC_E_POLYGON, USDC_NATIVE_POLYGON];
 
-  for (const log of logs) {
-    dailyFees.add(USDC_E_POLYGON, log.feeAmount, FEE_LABEL);
+  const [feeCollectedLogs, ...builderInflowsByToken] = await Promise.all([
+    getLogs({
+      target: FEE_COLLECTOR,
+      eventAbi:
+        "event FeeCollected(bytes32 indexed fillId, address indexed user, bytes32 indexed tokenId, uint8 service, uint256 tradeAmount, uint256 feeAmount, uint256 feeBps, uint256 timestamp)",
+    }),
+    ...builderTokens.map((token) =>
+      getLogs({
+        target: token,
+        eventAbi: transferEventAbi,
+        topics: builderPayoutTopics as any,
+      })
+    ),
+  ]);
+
+  for (const log of feeCollectedLogs) {
+    dailyFees.add(USDC_E_POLYGON, log.feeAmount, SERVICE_FEE_LABEL);
   }
+  builderInflowsByToken.forEach((inflows, i) => {
+    const token = builderTokens[i];
+    for (const log of inflows) {
+      dailyFees.add(token, log.value, BUILDER_FEE_LABEL);
+    }
+  });
 
   return {
     dailyFees,
@@ -64,28 +113,35 @@ const adapter: Adapter = {
   pullHourly: true,
   methodology: {
     Fees:
-      "Service fee (1%) pulled atomically user → treasury inside FrenFlow's FeeCollector contract on Polygon at Polymarket trade settlement.",
+      "Two streams: (1) 1% service fee pulled atomically by FrenFlow's FeeCollector contract at trade settlement, and (2) Polymarket builder-fee distributions to FrenFlow's builder profile wallet (paid in pUSD or USDC.e on a Polymarket-defined cadence).",
     UserFees:
-      "100% of fees come directly from end-user wallets (the fee is transferFrom'd from the trader at fill).",
+      "100% of fees originate from end-user trades. Service fees are transferFrom'd from the trader at fill; builder fees come out of the trader's order amount via Polymarket and are forwarded to FrenFlow.",
     Revenue:
-      "All service fees flow directly to the FrenFlow treasury. No liquidity providers.",
+      "All fees flow to FrenFlow treasury / builder wallet. No liquidity providers.",
     ProtocolRevenue:
       "Same as Revenue — 100% of collected fees are retained by the protocol.",
   },
   breakdownMethodology: {
     Fees: {
-      [FEE_LABEL]:
-        "Per-trade 1% service fee on Polymarket trades routed through FrenFlow. Denominated in USDC.e. Tracked from the `FeeCollected` event on the FeeCollector contract.",
+      [SERVICE_FEE_LABEL]:
+        "Per-trade 1% service fee on Polymarket trades routed through FrenFlow. Denominated in USDC.e. Tracked from the `FeeCollected` event on the FeeCollector contract `0x95e47CBC5c4D9434412AF44Ade02B33613EDb787`.",
+      [BUILDER_FEE_LABEL]:
+        "Polymarket builder-fee distributions to FrenFlow's builder profile wallet `0x58715321c2c6a216d1259f368c34f987a4a26b64`. Tracked as incoming `Transfer` events of pUSD, USDC.e, or USDC (native) to that wallet — all settlement currencies Polymarket has used or could use for builder payouts.",
     },
     UserFees: {
-      [FEE_LABEL]: "Same as Fees — paid directly from the trader's wallet.",
+      [SERVICE_FEE_LABEL]: "Same as Fees — paid directly from the trader's wallet.",
+      [BUILDER_FEE_LABEL]:
+        "Same as Fees — funded out of the trader's notional via Polymarket.",
     },
     Revenue: {
-      [FEE_LABEL]:
+      [SERVICE_FEE_LABEL]:
         "100% of collected service fees flow to the FrenFlow treasury at `0xb9e912e55454Ce284C38ccFED5b7fbbF327E689b`.",
+      [BUILDER_FEE_LABEL]:
+        "100% of builder distributions are retained by FrenFlow.",
     },
     ProtocolRevenue: {
-      [FEE_LABEL]: "Same as Revenue — fully retained by the protocol.",
+      [SERVICE_FEE_LABEL]: "Same as Revenue — fully retained by the protocol.",
+      [BUILDER_FEE_LABEL]: "Same as Revenue — fully retained by the protocol.",
     },
   },
 };

--- a/fees/frenflow.ts
+++ b/fees/frenflow.ts
@@ -6,29 +6,30 @@ import { ethers } from "ethers";
  * FrenFlow — social copytrading + trading UI for prediction markets.
  * https://frenflow.com  ·  https://x.com/frenflow_
  *
- * Two on-chain revenue streams on Polygon, both summed into `dailyFees`:
+ * Two on-chain revenue streams on Polygon:
  *
  *   1. Service Fees — a 1% fee pulled atomically (user → treasury) by
  *      FrenFlow's FeeCollector contract at Polymarket trade settlement.
  *      Tracked via the `FeeCollected` event. Denominated in USDC.e.
+ *      Counted as both `dailyFees` and `dailyUserFees` because the
+ *      fee is debited from the trader's wallet at fill time.
  *
  *   2. Builder Fees — Polymarket pays builders a per-fill commission for
  *      trades carrying their `builderCode`. PM accrues these in an
  *      internal treasury and periodically distributes them on-chain to
  *      each builder's profile wallet (typically batched through a
  *      "disperse"-style contract). FrenFlow's builder profile wallet is
- *      `0x58715321c2c6a216d1259f368c34f987a4a26b64`. We sum incoming
- *      pUSD / USDC.e / USDC (native) Transfer events to that wallet.
+ *      `0x58715321c2c6a216d1259f368c34f987a4a26b64`. Counted in
+ *      `dailyFees` / `dailyRevenue` but NOT `dailyUserFees`, because PM
+ *      pays them on a settlement cadence (not user-atomic) and the
+ *      distribution day rarely matches the trade day.
  *
  * Volume (notional) for FrenFlow as a Polymarket builder is tracked
  * separately in `factory/polymarket.ts`.
  *
  * Income-statement mapping (per GUIDELINES):
  *   dailyFees            — gross protocol revenue (Service + Builder)
- *   dailyUserFees        — portion paid directly by end-users (100%:
- *                          service fee is pulled from the trader's
- *                          wallet at fill; builder fee is funded by
- *                          Polymarket out of the trader's order amount)
+ *   dailyUserFees        — Service Fees only (atomic, user-paid)
  *   dailyRevenue         — gross profit (no supply-side to reimburse)
  *   dailyProtocolRevenue — portion allocated to treasury (100%)
  */
@@ -55,6 +56,23 @@ const PUSD_POLYGON = "0xc011a7E12a19f7B1f670d46F03B03f3342E82DFB";
 // switch settlement currency without notice.
 const USDC_NATIVE_POLYGON = "0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359";
 
+// Sanctioned senders for Polymarket builder-fee distributions. We only
+// credit Builder Fees from `Transfer` events whose `from` address is in
+// this allowlist, so unrelated transfers (top-ups, refunds, mistaken
+// sends) into BUILDER_PAYOUT are not misclassified as protocol revenue.
+//
+// Known senders so far:
+//  - 0xd7a0535c… : EOA used for the first PM builder distribution
+//                  (tx 0x4e0e7e42, block 86195685, 2026-04-30) which
+//                  paid 27 builders via a disperse contract
+//                  (0xd152f549…). The Transfer events show the EOA in
+//                  the indexed `from` slot, not the disperse contract.
+//
+// If Polymarket rotates its hot wallet, add the new EOA here.
+const KNOWN_PM_BUILDER_PAYOUT_SENDERS = new Set(
+  ["0xd7a0535cd4349145ac47693803988d59c015d4ba"].map((a) => a.toLowerCase())
+);
+
 const SERVICE_FEE_LABEL = "Service Fees";
 const BUILDER_FEE_LABEL = "Builder Fees";
 
@@ -65,43 +83,63 @@ const padAddress = (address: string) => ethers.zeroPadValue(address, 32);
 
 const fetch: FetchV2 = async ({ getLogs, createBalances }: FetchOptions) => {
   const dailyFees = createBalances();
+  const dailyUserFees = createBalances();
+  const dailyRevenue = createBalances();
 
   // Filter `Transfer(from, to, value)` by the indexed `to` topic only —
-  // any sender that lands tokens in BUILDER_PAYOUT counts. The middle
-  // `null` keeps `from` unconstrained.
+  // the middle `null` keeps `from` unconstrained at the RPC level so we
+  // can post-filter against KNOWN_PM_BUILDER_PAYOUT_SENDERS in JS.
   const builderPayoutTopics = [transferTopic, null, padAddress(BUILDER_PAYOUT)];
   const builderTokens = [PUSD_POLYGON, USDC_E_POLYGON, USDC_NATIVE_POLYGON];
 
-  const [feeCollectedLogs, ...builderInflowsByToken] = await Promise.all([
-    getLogs({
-      target: FEE_COLLECTOR,
-      eventAbi:
-        "event FeeCollected(bytes32 indexed fillId, address indexed user, bytes32 indexed tokenId, uint8 service, uint256 tradeAmount, uint256 feeAmount, uint256 feeBps, uint256 timestamp)",
-    }),
-    ...builderTokens.map((token) =>
+  // Service fees are required and must throw on failure. Builder probes
+  // are best-effort across three tokens — wrap them in `allSettled` so a
+  // transient RPC error on one token does not drop the service-fee
+  // stream for the period.
+  const feeCollectedLogs = await getLogs({
+    target: FEE_COLLECTOR,
+    eventAbi:
+      "event FeeCollected(bytes32 indexed fillId, address indexed user, bytes32 indexed tokenId, uint8 service, uint256 tradeAmount, uint256 feeAmount, uint256 feeBps, uint256 timestamp)",
+  });
+
+  const builderInflowsByToken = await Promise.allSettled(
+    builderTokens.map((token) =>
       getLogs({
         target: token,
         eventAbi: transferEventAbi,
         topics: builderPayoutTopics as any,
       })
-    ),
-  ]);
+    )
+  );
 
   for (const log of feeCollectedLogs) {
     dailyFees.add(USDC_E_POLYGON, log.feeAmount, SERVICE_FEE_LABEL);
+    dailyUserFees.add(USDC_E_POLYGON, log.feeAmount, SERVICE_FEE_LABEL);
+    dailyRevenue.add(USDC_E_POLYGON, log.feeAmount, SERVICE_FEE_LABEL);
   }
-  builderInflowsByToken.forEach((inflows, i) => {
+
+  builderInflowsByToken.forEach((result, i) => {
     const token = builderTokens[i];
-    for (const log of inflows) {
+    if (result.status === "rejected") {
+      console.error(
+        `frenflow: builder-fee Transfer query failed for token ${token}:`,
+        result.reason
+      );
+      return;
+    }
+    for (const log of result.value) {
+      const from = String(log.from).toLowerCase();
+      if (!KNOWN_PM_BUILDER_PAYOUT_SENDERS.has(from)) continue;
       dailyFees.add(token, log.value, BUILDER_FEE_LABEL);
+      dailyRevenue.add(token, log.value, BUILDER_FEE_LABEL);
     }
   });
 
   return {
     dailyFees,
-    dailyUserFees: dailyFees,
-    dailyRevenue: dailyFees,
-    dailyProtocolRevenue: dailyFees,
+    dailyUserFees,
+    dailyRevenue,
+    dailyProtocolRevenue: dailyRevenue,
   };
 };
 
@@ -113,11 +151,11 @@ const adapter: Adapter = {
   pullHourly: true,
   methodology: {
     Fees:
-      "Two streams: (1) 1% service fee pulled atomically by FrenFlow's FeeCollector contract at trade settlement, and (2) Polymarket builder-fee distributions to FrenFlow's builder profile wallet (paid in pUSD or USDC.e on a Polymarket-defined cadence).",
+      "Two streams: (1) 1% service fee pulled atomically by FrenFlow's FeeCollector contract at trade settlement, and (2) Polymarket builder-fee distributions to FrenFlow's builder profile wallet, restricted to a sanctioned sender allowlist (paid in pUSD or USDC.e on a Polymarket-defined cadence).",
     UserFees:
-      "100% of fees originate from end-user trades. Service fees are transferFrom'd from the trader at fill; builder fees come out of the trader's order amount via Polymarket and are forwarded to FrenFlow.",
+      "Service fees only — these are transferFrom'd from the trader's wallet atomically at fill time. Builder fees are excluded because Polymarket pays them on its own settlement cadence, not at the user trade.",
     Revenue:
-      "All fees flow to FrenFlow treasury / builder wallet. No liquidity providers.",
+      "Service fees plus Polymarket builder distributions. All flow to FrenFlow treasury / builder wallet. No liquidity providers.",
     ProtocolRevenue:
       "Same as Revenue — 100% of collected fees are retained by the protocol.",
   },
@@ -126,12 +164,10 @@ const adapter: Adapter = {
       [SERVICE_FEE_LABEL]:
         "Per-trade 1% service fee on Polymarket trades routed through FrenFlow. Denominated in USDC.e. Tracked from the `FeeCollected` event on the FeeCollector contract `0x95e47CBC5c4D9434412AF44Ade02B33613EDb787`.",
       [BUILDER_FEE_LABEL]:
-        "Polymarket builder-fee distributions to FrenFlow's builder profile wallet `0x58715321c2c6a216d1259f368c34f987a4a26b64`. Tracked as incoming `Transfer` events of pUSD, USDC.e, or USDC (native) to that wallet — all settlement currencies Polymarket has used or could use for builder payouts.",
+        "Polymarket builder-fee distributions to FrenFlow's builder profile wallet `0x58715321c2c6a216d1259f368c34f987a4a26b64`. Tracked as incoming `Transfer` events of pUSD, USDC.e, or USDC (native), restricted to a sanctioned sender allowlist of known Polymarket payout EOAs to avoid counting unrelated inflows as fees.",
     },
     UserFees: {
-      [SERVICE_FEE_LABEL]: "Same as Fees — paid directly from the trader's wallet.",
-      [BUILDER_FEE_LABEL]:
-        "Same as Fees — funded out of the trader's notional via Polymarket.",
+      [SERVICE_FEE_LABEL]: "Paid directly from the trader's wallet at fill.",
     },
     Revenue: {
       [SERVICE_FEE_LABEL]:

--- a/fees/frenflow.ts
+++ b/fees/frenflow.ts
@@ -86,28 +86,43 @@ const fetch: FetchV2 = async ({ getLogs, createBalances }: FetchOptions) => {
   const dailyUserFees = createBalances();
   const dailyRevenue = createBalances();
 
-  // Filter `Transfer(from, to, value)` by the indexed `to` topic only —
-  // the middle `null` keeps `from` unconstrained at the RPC level so we
-  // can post-filter against KNOWN_PM_BUILDER_PAYOUT_SENDERS in JS.
-  const builderPayoutTopics = [transferTopic, null, padAddress(BUILDER_PAYOUT)];
+  // Filter Transfer events by indexed `from` topic so the Llama Indexer
+  // can serve the query directly (single-topic post-event-signature
+  // filters are the well-supported case). We then check `log.to` in JS
+  // to ensure the destination is BUILDER_PAYOUT — that's the secondary
+  // gate that prevents counting any unrelated transfer between the
+  // sanctioned sender and a third party.
   const builderTokens = [PUSD_POLYGON, USDC_E_POLYGON, USDC_NATIVE_POLYGON];
+  const builderPayoutLower = BUILDER_PAYOUT.toLowerCase();
 
   // Service fees are required and must throw on failure. Builder probes
-  // are best-effort across three tokens — wrap them in `allSettled` so a
-  // transient RPC error on one token does not drop the service-fee
-  // stream for the period.
+  // are best-effort across (sender × token) pairs — wrap them in
+  // `allSettled` so a transient RPC error on one probe does not drop
+  // the service-fee stream for the period.
   const feeCollectedLogs = await getLogs({
     target: FEE_COLLECTOR,
     eventAbi:
       "event FeeCollected(bytes32 indexed fillId, address indexed user, bytes32 indexed tokenId, uint8 service, uint256 tradeAmount, uint256 feeAmount, uint256 feeBps, uint256 timestamp)",
   });
 
-  const builderInflowsByToken = await Promise.allSettled(
-    builderTokens.map((token) =>
+  const knownSenders = Array.from(KNOWN_PM_BUILDER_PAYOUT_SENDERS);
+  const probes: { sender: string; token: string }[] = [];
+  for (const sender of knownSenders) {
+    for (const token of builderTokens) probes.push({ sender, token });
+  }
+  // skipIndexer because the Llama Indexer's coverage of arbitrary
+  // ERC-20 Transfer events is incomplete for tokens that aren't part
+  // of a pre-tracked protocol (pUSD/USDC.e Polymarket payouts have
+  // returned empty in production CI runs even when the underlying
+  // events exist on-chain). RPC fallback honors the topic1 filter
+  // natively and is fine for the small per-slice volume.
+  const builderProbeResults = await Promise.allSettled(
+    probes.map(({ sender, token }) =>
       getLogs({
         target: token,
         eventAbi: transferEventAbi,
-        topics: builderPayoutTopics as any,
+        topics: [transferTopic, padAddress(sender)] as any,
+        skipIndexer: true,
       })
     )
   );
@@ -118,18 +133,18 @@ const fetch: FetchV2 = async ({ getLogs, createBalances }: FetchOptions) => {
     dailyRevenue.add(USDC_E_POLYGON, log.feeAmount, SERVICE_FEE_LABEL);
   }
 
-  builderInflowsByToken.forEach((result, i) => {
-    const token = builderTokens[i];
+  builderProbeResults.forEach((result, i) => {
+    const { sender, token } = probes[i];
     if (result.status === "rejected") {
       console.error(
-        `frenflow: builder-fee Transfer query failed for token ${token}:`,
+        `frenflow: builder-fee Transfer query failed for sender=${sender} token=${token}:`,
         result.reason
       );
       return;
     }
     for (const log of result.value) {
-      const from = String(log.from).toLowerCase();
-      if (!KNOWN_PM_BUILDER_PAYOUT_SENDERS.has(from)) continue;
+      const to = String(log.to).toLowerCase();
+      if (to !== builderPayoutLower) continue;
       dailyFees.add(token, log.value, BUILDER_FEE_LABEL);
       dailyRevenue.add(token, log.value, BUILDER_FEE_LABEL);
     }

--- a/fees/frenflow.ts
+++ b/fees/frenflow.ts
@@ -1,6 +1,6 @@
 import { Adapter, FetchOptions, FetchV2 } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
-import { ethers } from "ethers";
+import { addTokensReceived } from "../helpers/token";
 
 /**
  * FrenFlow — social copytrading + trading UI for prediction markets.
@@ -76,12 +76,8 @@ const KNOWN_PM_BUILDER_PAYOUT_SENDERS = new Set(
 const SERVICE_FEE_LABEL = "Service Fees";
 const BUILDER_FEE_LABEL = "Builder Fees";
 
-const transferEventAbi =
-  "event Transfer(address indexed from, address indexed to, uint256 value)";
-const transferTopic = ethers.id("Transfer(address,address,uint256)");
-const padAddress = (address: string) => ethers.zeroPadValue(address, 32);
-
-const fetch: FetchV2 = async ({ getLogs, createBalances }: FetchOptions) => {
+const fetch: FetchV2 = async (options: FetchOptions) => {
+  const { getLogs, createBalances } = options;
   const dailyFees = createBalances();
   const dailyUserFees = createBalances();
   const dailyRevenue = createBalances();
@@ -93,12 +89,7 @@ const fetch: FetchV2 = async ({ getLogs, createBalances }: FetchOptions) => {
   // gate that prevents counting any unrelated transfer between the
   // sanctioned sender and a third party.
   const builderTokens = [PUSD_POLYGON, USDC_E_POLYGON, USDC_NATIVE_POLYGON];
-  const builderPayoutLower = BUILDER_PAYOUT.toLowerCase();
-
-  // Service fees are required and must throw on failure. Builder probes
-  // are best-effort across (sender × token) pairs — wrap them in
-  // `allSettled` so a transient RPC error on one probe does not drop
-  // the service-fee stream for the period.
+  
   const feeCollectedLogs = await getLogs({
     target: FEE_COLLECTOR,
     eventAbi:
@@ -106,49 +97,22 @@ const fetch: FetchV2 = async ({ getLogs, createBalances }: FetchOptions) => {
   });
 
   const knownSenders = Array.from(KNOWN_PM_BUILDER_PAYOUT_SENDERS);
-  const probes: { sender: string; token: string }[] = [];
-  for (const sender of knownSenders) {
-    for (const token of builderTokens) probes.push({ sender, token });
-  }
-  // skipIndexer because the Llama Indexer's coverage of arbitrary
-  // ERC-20 Transfer events is incomplete for tokens that aren't part
-  // of a pre-tracked protocol (pUSD/USDC.e Polymarket payouts have
-  // returned empty in production CI runs even when the underlying
-  // events exist on-chain). RPC fallback honors the topic1 filter
-  // natively and is fine for the small per-slice volume.
-  const builderProbeResults = await Promise.allSettled(
-    probes.map(({ sender, token }) =>
-      getLogs({
-        target: token,
-        eventAbi: transferEventAbi,
-        topics: [transferTopic, padAddress(sender)] as any,
-        skipIndexer: true,
-      })
-    )
-  );
+
+  const builderFees = await addTokensReceived({
+    options,
+    tokens: builderTokens,
+    fromAdddesses: knownSenders,
+    target: BUILDER_PAYOUT
+  })
+
+  dailyFees.add(builderFees, BUILDER_FEE_LABEL);
+  dailyRevenue.add(builderFees, BUILDER_FEE_LABEL);
 
   for (const log of feeCollectedLogs) {
     dailyFees.add(USDC_E_POLYGON, log.feeAmount, SERVICE_FEE_LABEL);
     dailyUserFees.add(USDC_E_POLYGON, log.feeAmount, SERVICE_FEE_LABEL);
     dailyRevenue.add(USDC_E_POLYGON, log.feeAmount, SERVICE_FEE_LABEL);
   }
-
-  builderProbeResults.forEach((result, i) => {
-    const { sender, token } = probes[i];
-    if (result.status === "rejected") {
-      console.error(
-        `frenflow: builder-fee Transfer query failed for sender=${sender} token=${token}:`,
-        result.reason
-      );
-      return;
-    }
-    for (const log of result.value) {
-      const to = String(log.to).toLowerCase();
-      if (to !== builderPayoutLower) continue;
-      dailyFees.add(token, log.value, BUILDER_FEE_LABEL);
-      dailyRevenue.add(token, log.value, BUILDER_FEE_LABEL);
-    }
-  });
 
   return {
     dailyFees,
@@ -158,43 +122,42 @@ const fetch: FetchV2 = async ({ getLogs, createBalances }: FetchOptions) => {
   };
 };
 
+const methodology = {
+  Fees: "Two streams: (1) 1% service fee pulled atomically by FrenFlow's FeeCollector contract at trade settlement, and (2) Polymarket builder-fee distributions to FrenFlow's builder profile wallet, restricted to a sanctioned sender allowlist (paid in pUSD or USDC.e on a Polymarket-defined cadence).",
+  UserFees: "Service fees only — these are transferFrom'd from the trader's wallet atomically at fill time. Builder fees are excluded because Polymarket pays them on its own settlement cadence, not at the user trade.",
+  Revenue: "Service fees plus Polymarket builder distributions. All flow to FrenFlow treasury / builder wallet. No liquidity providers.",
+  ProtocolRevenue: "Same as Revenue — 100% of collected fees are retained by the protocol.",
+}
+
+const breakdownMethodology = {
+  Fees: {
+    [SERVICE_FEE_LABEL]:
+      "Per-trade 1% service fee on Polymarket trades routed through FrenFlow. Denominated in USDC.e. Tracked from the `FeeCollected` event on the FeeCollector contract `0x95e47CBC5c4D9434412AF44Ade02B33613EDb787`.",
+    [BUILDER_FEE_LABEL]:
+      "Polymarket builder-fee distributions to FrenFlow's builder profile wallet `0x58715321c2c6a216d1259f368c34f987a4a26b64`. Tracked as incoming `Transfer` events of pUSD, USDC.e, or USDC (native), restricted to a sanctioned sender allowlist of known Polymarket payout EOAs to avoid counting unrelated inflows as fees.",
+  },
+  UserFees: {
+    [SERVICE_FEE_LABEL]: "Paid directly from the trader's wallet at fill.",
+  },
+  Revenue: {
+    [SERVICE_FEE_LABEL]:
+      "100% of collected service fees flow to the FrenFlow treasury at `0xb9e912e55454Ce284C38ccFED5b7fbbF327E689b`.",
+    [BUILDER_FEE_LABEL]:
+      "100% of builder distributions are retained by FrenFlow.",
+  },
+  ProtocolRevenue: {
+    [SERVICE_FEE_LABEL]: "Same as Revenue — fully retained by the protocol.",
+    [BUILDER_FEE_LABEL]: "Same as Revenue — fully retained by the protocol.",
+  },
+}
 const adapter: Adapter = {
   version: 2,
   chains: [CHAIN.POLYGON],
   fetch,
   start: "2026-04-20",
   pullHourly: true,
-  methodology: {
-    Fees:
-      "Two streams: (1) 1% service fee pulled atomically by FrenFlow's FeeCollector contract at trade settlement, and (2) Polymarket builder-fee distributions to FrenFlow's builder profile wallet, restricted to a sanctioned sender allowlist (paid in pUSD or USDC.e on a Polymarket-defined cadence).",
-    UserFees:
-      "Service fees only — these are transferFrom'd from the trader's wallet atomically at fill time. Builder fees are excluded because Polymarket pays them on its own settlement cadence, not at the user trade.",
-    Revenue:
-      "Service fees plus Polymarket builder distributions. All flow to FrenFlow treasury / builder wallet. No liquidity providers.",
-    ProtocolRevenue:
-      "Same as Revenue — 100% of collected fees are retained by the protocol.",
-  },
-  breakdownMethodology: {
-    Fees: {
-      [SERVICE_FEE_LABEL]:
-        "Per-trade 1% service fee on Polymarket trades routed through FrenFlow. Denominated in USDC.e. Tracked from the `FeeCollected` event on the FeeCollector contract `0x95e47CBC5c4D9434412AF44Ade02B33613EDb787`.",
-      [BUILDER_FEE_LABEL]:
-        "Polymarket builder-fee distributions to FrenFlow's builder profile wallet `0x58715321c2c6a216d1259f368c34f987a4a26b64`. Tracked as incoming `Transfer` events of pUSD, USDC.e, or USDC (native), restricted to a sanctioned sender allowlist of known Polymarket payout EOAs to avoid counting unrelated inflows as fees.",
-    },
-    UserFees: {
-      [SERVICE_FEE_LABEL]: "Paid directly from the trader's wallet at fill.",
-    },
-    Revenue: {
-      [SERVICE_FEE_LABEL]:
-        "100% of collected service fees flow to the FrenFlow treasury at `0xb9e912e55454Ce284C38ccFED5b7fbbF327E689b`.",
-      [BUILDER_FEE_LABEL]:
-        "100% of builder distributions are retained by FrenFlow.",
-    },
-    ProtocolRevenue: {
-      [SERVICE_FEE_LABEL]: "Same as Revenue — fully retained by the protocol.",
-      [BUILDER_FEE_LABEL]: "Same as Revenue — fully retained by the protocol.",
-    },
-  },
+  breakdownMethodology,
+  methodology,
 };
 
 export default adapter;


### PR DESCRIPTION
## Summary

Extends the existing FrenFlow service-fee adapter (PR #6481) with a second on-chain revenue stream: **builder-fee distributions** Polymarket pays to FrenFlow's builder profile wallet for trades carrying our `builderCode`.

## What changed

- Adds `Builder Fees` breakdown alongside the existing `Service Fees`.
- Watches incoming `Transfer(_, to=BUILDER_PAYOUT, _)` events on three tokens (pUSD, USDC.e, USDC native) into FrenFlow's builder profile wallet `0x58715321c2c6a216d1259f368c34f987a4a26b64`.
- Updates `methodology` and `breakdownMethodology` so DefiLlama displays the two streams separately.

## Why now

The first builder payout to any Polymarket builder happened on **2026-04-30** (tx [`0x4e0e7e42…`](https://polygonscan.com/tx/0x4e0e7e4296167ea28fb92f8058409514459c8a4d5c994511b22e6e913010d5c3), block `86195685`). It was a single batched distribution (~\$3,087 pUSD across 27 builders) routed through a disperse-style contract; FrenFlow received \$0.32 in pUSD. Without this change that payout — and every future one — would be invisible in DefiLlama.

The pUSD denomination matched the existing `factory/polymarket.ts` builder-volume entry and our internal CLOB builder-trades aggregate (`clob.polymarket.com/builder/trades?builder_code=0x1a907452…`) to the cent.

## Why three tokens

Polymarket has only paid in pUSD so far, but their builder fee accrues in an internal treasury (`0x115f48dc…`) that holds value in pUSD. They could switch to USDC.e or USDC native without notice. The three-token watch costs nothing extra (empty `getLogs` results when those tokens aren't used) and prevents silent revenue gaps if the settlement currency changes.

## Why a recipient-only filter

The middle topic is `null` because builder distributions can come from any sender (today: an EOA via a disperse contract; future: possibly a different contract). Filtering only by the indexed `to` topic keeps the adapter robust to any sender rotation.

## Verification

- On-chain check on the pUSD payout block range returns the expected single log:
  `eth_getLogs target=pUSD topics=[Transfer, null, padAddress(BUILDER_PAYOUT)] → 1 log, value 317400 (= \$0.3174 pUSD)`.
- `Balances.getUSDJSONs()` resolves it to **\$0.324** at the historical price (pUSD price \$1.00 confidence 0.99 in DefiLlama price oracle).
- `labelBreakdown` returns `{"Builder Fees": 0.324}` cleanly alongside existing `Service Fees`.

## Test plan

- [ ] DefiLlama CI runs `npm test fees frenflow` against a recent backfill window covering 2026-04-30 (the first payout day) and confirms a non-zero `Builder Fees` row in the breakdown.
- [ ] Inspect the breakdown on the live page once the adapter rolls out: https://defillama.com/protocol/frenflow