### PR TITLE
Add wash-screen action that auto-comments on `verify data` issues

### DIFF
--- a/.github/workflows/wash-screen.yml
+++ b/.github/workflows/wash-screen.yml
@@ -1,0 +1,109 @@
+name: wash-screen
+on:
+  issues:
+    types: [labeled]
+
+permissions:
+  issues: write
+
+jobs:
+  screen:
+    if: github.event.label.name == 'verify data'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out detector
+        uses: actions/checkout@v4
+        with:
+          repository: bornsl0ppy/defillama-wash-detector
+          path: detector
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      - name: Extract protocol slug from issue body
+        id: slug
+        env:
+          BODY: ${{ github.event.issue.body }}
+        run: |
+          python3 - <<'PY' >> "$GITHUB_OUTPUT"
+          import os, re
+          body = os.environ.get("BODY", "") or ""
+          m = re.search(r"defillama\.com/protocol/([\w\-\.]+)", body)
+          print(f"value={m.group(1) if m else ''}")
+          PY
+
+      - name: Run wash-detector
+        id: screen
+        if: steps.slug.outputs.value != ''
+        env:
+          LLAMA_API_KEY: ${{ secrets.LLAMA_API_KEY }}
+        working-directory: detector
+        run: |
+          set -e
+          PYTHONPATH=src python3 -m wash_detector screen "${{ steps.slug.outputs.value }}" > report.md
+          # Pull the verdict line out so the next steps can branch on it.
+          verdict=$(grep -m1 -oE 'Verdict:\*\* [^·]+' report.md | sed -E 's/^Verdict:\*\* +//; s/ +$//' || true)
+          echo "verdict=$verdict" >> "$GITHUB_OUTPUT"
+
+      - name: Comment with full report
+        if: |
+          steps.slug.outputs.value != '' &&
+          steps.screen.outcome == 'success' &&
+          !contains(steps.screen.outputs.verdict, 'LOOKS NORMAL')
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const body = fs.readFileSync('detector/report.md', 'utf8');
+            await github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body,
+            });
+
+      - name: Acknowledge clean verdict
+        if: |
+          steps.slug.outputs.value != '' &&
+          steps.screen.outcome == 'success' &&
+          contains(steps.screen.outputs.verdict, 'LOOKS NORMAL')
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const slug = '${{ steps.slug.outputs.value }}';
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            await github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `Wash-screen ran. Verdict: **LOOKS NORMAL**. No automated red flags for \`${slug}\` — proceed with manual investigation. ([run](${runUrl}))`,
+            });
+
+      - name: Note missing slug
+        if: steps.slug.outputs.value == ''
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            await github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `Wash-screen could not extract a \`defillama.com/protocol/<slug>\` URL from this issue body. Skipping automated screen. ([run](${runUrl}))`,
+            });
+
+      - name: Report failure
+        if: failure() && steps.slug.outputs.value != ''
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const slug = '${{ steps.slug.outputs.value }}';
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            await github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `Wash-screen failed for \`${slug}\`. ([run logs](${runUrl}))`,
+            });


### PR DESCRIPTION
## What

Adds `.github/workflows/wash-screen.yml` — a GitHub Action that fires on
every issue labeled `verify data` and posts a pre-filled anomaly snapshot
as a comment (TVL, 30d volume, Vol/TVL ratio, peer-cohort z-score, the
specific findings that fired).

The detector itself lives in a separate public repo:
[bornsl0ppy/defillama-wash-detector](https://github.com/bornsl0ppy/defillama-wash-detector)
— stdlib-only Python, 13 tests, no dependencies added to this repo. The
workflow checks it out at runtime via `actions/checkout`.

## Why

Triage on `verify data` issues currently starts from a blank slate every
time — the assignee hand-pulls TVL, volume history, peer comparisons before
the investigation can begin. This pre-fills that step in the same report
shape as kanerep's investigation on #5552 (sunx).

A live sweep of `/overview/dexs` from the public DefiLlama API surfaced 8
strong-anomaly candidates (score ≥ 80) — 7 of which have no existing
`verify data` issue. Sample reports linked from the detector repo's README.

## Behaviour

Every `verify data` label event produces exactly one comment within ~30
seconds. Absence of a comment unambiguously means the workflow didn't fire.

| Outcome | Comment posted? |
|---|---|
| Strong anomaly / manual review / mild anomalies | Full markdown report ([sample](https://github.com/bornsl0ppy/defillama-wash-detector/blob/main/samples/paycash.md)) |
| Looks normal | One-line acknowledgement with run URL |
| Slug regex didn't match | One-line "couldn't extract slug" |
| Detector crashed (API 5xx, etc.) | One-line failure comment with run URL |
| Label other than `verify data` applied | Workflow doesn't fire |

## Footprint

- One YAML file. No detector code, no dependencies added to this repo.
- Free GitHub Actions minutes (public repo). ~10s per fire.
- Optional `LLAMA_API_KEY` repo secret unlocks the perp branch
  (`/overview/derivatives` is gated). Not required for v1.
- Reuses the same `actions/github-script@v7` pattern already in
  `.github/workflows/comment.yml` — no new third-party action introduced.
- Disable instantly by deleting the workflow file.

## Test plan

- [ ] Apply `verify data` label to a test issue containing a
      `defillama.com/protocol/<slug>` URL → comment appears within 30s
- [ ] Strong-anomaly slug (e.g. `paycash`) → full markdown report
- [ ] Clean-verdict slug (e.g. `uniswap-v3`) → one-line ack
- [ ] Issue body without a slug URL → "couldn't extract slug" comment
- [ ] Confirm `permissions: issues: write` is sufficient (no other tokens needed)

## Related

- Detector source + rule reference: https://github.com/bornsl0ppy/defillama-wash-detector
- Sample reports: https://github.com/bornsl0ppy/defillama-wash-detector/tree/main/samples
- Gold-standard report-format inspiration: kanerep's investigation on #5552