### PR TITLE
Track sudoswap v2 volume

### DIFF
--- a/dexs/sudoswap-v2/index.ts
+++ b/dexs/sudoswap-v2/index.ts
@@ -2,31 +2,40 @@ import { Dependencies, FetchOptions, SimpleAdapter } from "../../adapters/types"
 import { queryDuneSql } from "../../helpers/dune";
 import { CHAIN } from "../../helpers/chains";
 
-const fetch = async (_a: any, _b: any, options: FetchOptions) => {
-	const data = await queryDuneSql(options, `
+const chainConfig: Record<string, any> = {
+    [CHAIN.ETHEREUM]: { duneChain: "ethereum", start: "2023-05-22" },
+    [CHAIN.ARBITRUM]: { duneChain: "arbitrum", start: "2024-01-20" },
+    [CHAIN.BASE]: { duneChain: "base", start: "2023-11-01" },
+}
+
+const prefetch = async (options: FetchOptions) => {
+    const duneResult = await queryDuneSql(options, `
     SELECT
+      blockchain,
       COALESCE(SUM(amount_usd), 0) as usd_volume
     FROM nft.trades
     WHERE project = 'sudoswap'
       AND version = 'v2'
-      AND blockchain = 'CHAIN'
       AND TIME_RANGE
-  `);
+    GROUP BY blockchain
+    `);
+    return duneResult;
+};
 
-	const dailyVolume = options.createBalances();
-	dailyVolume.addUSDValue(data[0].usd_volume);
-	return { dailyVolume };
+const fetch = async (_a: any, _b: any, options: FetchOptions) => {
+    const duneResult = options.preFetchedResults;
+    const dailyVolume = duneResult.find((item: any) => item.blockchain === chainConfig[options.chain].duneChain)?.usd_volume || 0;
+
+    return { dailyVolume };
 };
 
 const adapter: SimpleAdapter = {
-	version: 1,
-	adapter: {
-		[CHAIN.ETHEREUM]: { fetch, start: "2023-05-22" },
-		[CHAIN.ARBITRUM]: { fetch, start: "2024-01-20" },
-		[CHAIN.BASE]: { fetch, start: "2023-11-01" },
-	},
-	dependencies: [Dependencies.DUNE],
-	isExpensiveAdapter: true,
+    prefetch,
+    fetch,
+    version: 1,
+    adapter: chainConfig,
+    dependencies: [Dependencies.DUNE],
+    isExpensiveAdapter: true,
 };
 
 export default adapter;

--- a/dexs/sudoswap-v2/index.ts
+++ b/dexs/sudoswap-v2/index.ts
@@ -1,0 +1,32 @@
+import { Dependencies, FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { queryDuneSql } from "../../helpers/dune";
+import { CHAIN } from "../../helpers/chains";
+
+const fetch = async (_a: any, _b: any, options: FetchOptions) => {
+	const data = await queryDuneSql(options, `
+    SELECT
+      COALESCE(SUM(amount_usd), 0) as usd_volume
+    FROM nft.trades
+    WHERE project = 'sudoswap'
+      AND version = 'v2'
+      AND blockchain = 'CHAIN'
+      AND TIME_RANGE
+  `);
+
+	const dailyVolume = options.createBalances();
+	dailyVolume.addUSDValue(data[0].usd_volume);
+	return { dailyVolume };
+};
+
+const adapter: SimpleAdapter = {
+	version: 1,
+	adapter: {
+		[CHAIN.ETHEREUM]: { fetch, start: "2023-05-22" },
+		[CHAIN.ARBITRUM]: { fetch, start: "2024-01-20" },
+		[CHAIN.BASE]: { fetch, start: "2023-11-01" },
+	},
+	dependencies: [Dependencies.DUNE],
+	isExpensiveAdapter: true,
+};
+
+export default adapter;


### PR DESCRIPTION
### Summary    
                                                                                                              
  - Update sudoswap v2 adapter to use Dune Analytics (nft.trades) as data source
  - Track only sudoswap v2 volume on Ethereum, Arbitrum, and Base
  
closes #6670