### PR TITLE
Mark Chainge Finance dead

### DIFF
--- a/dexs/chainge-finance/index.ts
+++ b/dexs/chainge-finance/index.ts
@@ -19,6 +19,7 @@ const fetch = async (timestamp: number) => {
 };
 
 const adapter: SimpleAdapter = {
+  deadFrom: "2026-04-01",
   adapter: {
     [CHAIN.FUSION]: {
       fetch,


### PR DESCRIPTION
## Summary

- Marks Chainge Finance DEX adapter as dead from `2026-05-01`.
- Website appears to link to a phishing site.
- API is no longer responsive.
- Twitter has been inactive since late 2025.

## Issues

Closes #6711