### PR TITLE
[fix] spiko - track asset yields

### DIFF
--- a/fees/spiko/index.ts
+++ b/fees/spiko/index.ts
@@ -35,7 +35,7 @@ const funds: Record<string, Record<string, FundConfig>> = {
 
 const ORACLE_PRICE_ABI =
   "function latestRoundData() view returns (uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound)";
-const ORACLE_DECIMALS = 6;
+const ORACLE_DECIMALS_ABI = "function decimals() view returns (uint8)";
 const MANAGEMENT_FEE_RATE = 0.25 / 100;
 const YEAR_IN_SECONDS = 365 * 24 * 60 * 60;
 
@@ -43,7 +43,7 @@ const getOracleAnswer = (priceData: any) =>
   new BigNumber((priceData.answer ?? priceData[1]).toString());
 
 const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
-  const { api, createBalances, chain, fromApi, toApi } = options;
+  const { createBalances, chain, fromApi, toApi } = options;
   const dailyFees = createBalances();
   const dailyRevenue = createBalances();
   const dailySupplySideRevenue = createBalances();
@@ -51,25 +51,45 @@ const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
   const tokens = chainFunds.map(({ token }) => token);
   const oracles = chainFunds.map(({ oracle }) => oracle);
 
-  const [totalSuppliesBefore, totalSuppliesAfter, pricesBefore, pricesAfter] =
-    await Promise.all([
-      fromApi.multiCall({
-        calls: tokens,
-        abi: "erc20:totalSupply",
-      }),
-      toApi.multiCall({
-        calls: tokens,
-        abi: "erc20:totalSupply",
-      }),
-      fromApi.multiCall({
-        calls: oracles,
-        abi: ORACLE_PRICE_ABI,
-      }),
-      toApi.multiCall({
-        calls: oracles,
-        abi: ORACLE_PRICE_ABI,
-      }),
-    ]);
+  let totalSuppliesBefore: any[];
+  let totalSuppliesAfter: any[];
+  let pricesBefore: any[];
+  let pricesAfter: any[];
+  let oracleDecimals: any[];
+
+  try {
+    [totalSuppliesBefore, totalSuppliesAfter, pricesBefore, pricesAfter, oracleDecimals] =
+      await Promise.all([
+        fromApi.multiCall({
+          calls: tokens,
+          abi: "erc20:totalSupply",
+        }),
+        toApi.multiCall({
+          calls: tokens,
+          abi: "erc20:totalSupply",
+        }),
+        fromApi.multiCall({
+          calls: oracles,
+          abi: ORACLE_PRICE_ABI,
+        }),
+        toApi.multiCall({
+          calls: oracles,
+          abi: ORACLE_PRICE_ABI,
+        }),
+        toApi.multiCall({
+          calls: oracles,
+          abi: ORACLE_DECIMALS_ABI,
+        }),
+      ]);
+  } catch (error) {
+    console.error(`[spiko] failed to fetch chain=${chain} supply/oracle data`, error);
+    return {
+      dailyFees,
+      dailyRevenue,
+      dailyProtocolRevenue: dailyRevenue,
+      dailySupplySideRevenue,
+    };
+  }
 
   const periodInYears = new BigNumber(options.toTimestamp - options.fromTimestamp).div(
     YEAR_IN_SECONDS,
@@ -79,8 +99,9 @@ const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
     const totalSupplyBefore = new BigNumber(totalSuppliesBefore[index].toString());
     const totalSupplyAfter = new BigNumber(totalSuppliesAfter[index].toString());
     const averageSupply = totalSupplyBefore.plus(totalSupplyAfter).div(2);
-    const priceBefore = getOracleAnswer(pricesBefore[index]).div(10 ** ORACLE_DECIMALS);
-    const priceAfter = getOracleAnswer(pricesAfter[index]).div(10 ** ORACLE_DECIMALS);
+    const oracleScale = new BigNumber(10).pow(Number(oracleDecimals[index].toString()));
+    const priceBefore = getOracleAnswer(pricesBefore[index]).div(oracleScale);
+    const priceAfter = getOracleAnswer(pricesAfter[index]).div(oracleScale);
 
     const priceIncrease = priceAfter.minus(priceBefore);
     if (priceAfter.gt(0) && priceIncrease.gt(0)) {

--- a/fees/spiko/index.ts
+++ b/fees/spiko/index.ts
@@ -1,6 +1,4 @@
 // https://docs.spiko.xyz/spiko-mmfs/fees
-
-import BigNumber from "bignumber.js";
 import { Adapter, FetchOptions, FetchResultV2 } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 import { METRIC } from "../../helpers/metrics";
@@ -8,6 +6,7 @@ import { METRIC } from "../../helpers/metrics";
 type FundConfig = {
   token: string;
   oracle: string;
+  asset: string;
 };
 
 const funds: Record<string, Record<string, FundConfig>> = {
@@ -15,38 +14,38 @@ const funds: Record<string, Record<string, FundConfig>> = {
     EUTBL: {
       token: "0xa0769f7A8fC65e47dE93797b4e21C073c117Fc80",
       oracle: "0x29503f31B73F0734455942Eb888E13acA1588a4e",
+      asset: "euro-coin"
     },
     USTBL: {
       token: "0xe4880249745eAc5F1eD9d8F7DF844792D560e750",
       oracle: "0x021289588cd81dC1AC87ea91e91607eEF68303F5",
+      asset: "usd-coin"
     },
   },
   [CHAIN.POLYGON]: {
     EUTBL: {
       token: "0xa0769f7A8fC65e47dE93797b4e21C073c117Fc80",
       oracle: "0x29503f31B73F0734455942Eb888E13acA1588a4e",
+      asset: "euro-coin"
     },
     USTBL: {
       token: "0xe4880249745eAc5F1eD9d8F7DF844792D560e750",
       oracle: "0x021289588cd81dC1AC87ea91e91607eEF68303F5",
+      asset: "usd-coin"
     },
   },
 };
 
 const ORACLE_PRICE_ABI =
-  "function latestRoundData() view returns (uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound)";
-const ORACLE_DECIMALS_ABI = "function decimals() view returns (uint8)";
+  "function latestRoundData() view returns (uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound)";;
 const MANAGEMENT_FEE_RATE = 0.25 / 100;
 const YEAR_IN_SECONDS = 365 * 24 * 60 * 60;
+const ORACLE_DECIMALS = 6;
+const TOKEN_DECIMALS = 5;
 
-const getOracleAnswer = (priceData: any) =>
-  new BigNumber((priceData.answer ?? priceData[1]).toString());
-
-const toBaseUnits = (amount: BigNumber) =>
-  amount.integerValue(BigNumber.ROUND_FLOOR).toFixed(0);
 
 const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
-  const { createBalances, chain, fromApi, toApi } = options;
+  const { createBalances, chain, fromApi, toApi, fromTimestamp, toTimestamp } = options;
   const dailyFees = createBalances();
   const dailyRevenue = createBalances();
   const dailySupplySideRevenue = createBalances();
@@ -54,70 +53,43 @@ const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
   const tokens = chainFunds.map(({ token }) => token);
   const oracles = chainFunds.map(({ oracle }) => oracle);
 
-  let totalSuppliesBefore: any[];
-  let totalSuppliesAfter: any[];
-  let pricesBefore: any[];
-  let pricesAfter: any[];
-  let oracleDecimals: any[];
+  const [totalSupplies, pricesBefore, pricesAfter] =
+    await Promise.all([
+      toApi.multiCall({
+        calls: tokens,
+        abi: "erc20:totalSupply",
+        permitFailure: true,
+      }),
+      fromApi.multiCall({
+        calls: oracles,
+        abi: ORACLE_PRICE_ABI,
+        permitFailure: true,
+      }),
+      toApi.multiCall({
+        calls: oracles,
+        abi: ORACLE_PRICE_ABI,
+        permitFailure: true,
+      }),
+    ]);
 
-  try {
-    [totalSuppliesBefore, totalSuppliesAfter, pricesBefore, pricesAfter, oracleDecimals] =
-      await Promise.all([
-        fromApi.multiCall({
-          calls: tokens,
-          abi: "erc20:totalSupply",
-        }),
-        toApi.multiCall({
-          calls: tokens,
-          abi: "erc20:totalSupply",
-        }),
-        fromApi.multiCall({
-          calls: oracles,
-          abi: ORACLE_PRICE_ABI,
-        }),
-        toApi.multiCall({
-          calls: oracles,
-          abi: ORACLE_PRICE_ABI,
-        }),
-        toApi.multiCall({
-          calls: oracles,
-          abi: ORACLE_DECIMALS_ABI,
-        }),
-      ]);
-  } catch (error) {
-    console.error(`[spiko] failed to fetch chain=${chain} supply/oracle data`, error);
-    return {
-      dailyFees,
-      dailyRevenue,
-      dailyProtocolRevenue: dailyRevenue,
-      dailySupplySideRevenue,
-    };
-  }
+  const periodInYears = (toTimestamp - fromTimestamp) / YEAR_IN_SECONDS;
 
-  const periodInYears = new BigNumber(options.toTimestamp - options.fromTimestamp).div(
-    YEAR_IN_SECONDS,
-  );
+  chainFunds.forEach(({ asset }, index) => {
+    if (!totalSupplies[index] || !pricesBefore[index] || !pricesAfter[index]) return;
 
-  chainFunds.forEach(({ token }, index) => {
-    const totalSupplyBefore = new BigNumber(totalSuppliesBefore[index].toString());
-    const totalSupplyAfter = new BigNumber(totalSuppliesAfter[index].toString());
-    const averageSupply = totalSupplyBefore.plus(totalSupplyAfter).div(2);
-    const oracleScale = new BigNumber(10).pow(Number(oracleDecimals[index].toString()));
-    const priceBefore = getOracleAnswer(pricesBefore[index]).div(oracleScale);
-    const priceAfter = getOracleAnswer(pricesAfter[index]).div(oracleScale);
+    const totalSupply = totalSupplies[index] / (10 ** TOKEN_DECIMALS);
+    const oraclePriceBefore = Number(pricesBefore[index].answer);
+    const oraclePriceAfter = Number(pricesAfter[index].answer);
 
-    const priceIncrease = priceAfter.minus(priceBefore);
-    if (priceAfter.gt(0) && priceIncrease.gt(0)) {
-      const assetYield = averageSupply.times(priceIncrease).div(priceAfter);
-      const assetYieldBaseUnits = toBaseUnits(assetYield);
-      dailyFees.add(token, assetYieldBaseUnits, METRIC.ASSETS_YIELDS);
-      dailySupplySideRevenue.add(token, assetYieldBaseUnits, METRIC.ASSETS_YIELDS);
-    }
+    const priceChange = (oraclePriceAfter - oraclePriceBefore) / (10 ** ORACLE_DECIMALS);
+    const assetYield = totalSupply * priceChange;
 
-    const managementFee = averageSupply.times(MANAGEMENT_FEE_RATE).times(periodInYears);
-    const managementFeeBaseUnits = toBaseUnits(managementFee);
-    dailyFees.add(token, managementFeeBaseUnits, METRIC.MANAGEMENT_FEES);
-    dailyRevenue.add(token, managementFeeBaseUnits, METRIC.MANAGEMENT_FEES);
+    dailyFees.addCGToken(asset, assetYield, METRIC.ASSETS_YIELDS);
+    dailySupplySideRevenue.addCGToken(asset, assetYield, METRIC.ASSETS_YIELDS);
+
+    const managementFee = totalSupply * MANAGEMENT_FEE_RATE * periodInYears;
+    dailyFees.addCGToken(asset, managementFee, METRIC.MANAGEMENT_FEES);
+    dailyRevenue.addCGToken(asset, managementFee, METRIC.MANAGEMENT_FEES);
   });
 
   return {
@@ -149,20 +121,19 @@ const breakdownMethodology = {
   SupplySideRevenue: {
     [METRIC.ASSETS_YIELDS]: "Positive EUTBL/USTBL NAV growth from the official Spiko on-chain oracle.",
   },
-  HoldersRevenue: {},
 };
 
 const adapter: Adapter = {
   methodology,
   breakdownMethodology,
   version: 2,
+  pullHourly: true,
+  fetch,
   adapter: {
     [CHAIN.ETHEREUM]: {
-      fetch,
       start: '2024-05-01',
     },
     [CHAIN.POLYGON]: {
-      fetch,
       start: '2024-04-20',
     },
   },

--- a/fees/spiko/index.ts
+++ b/fees/spiko/index.ts
@@ -1,79 +1,126 @@
 // https://docs.spiko.xyz/spiko-mmfs/fees
 
+import BigNumber from "bignumber.js";
 import { Adapter, FetchOptions, FetchResultV2 } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
+import { METRIC } from "../../helpers/metrics";
 
-const funds: Record<string, Record<string, string>> = {
+type FundConfig = {
+  token: string;
+  oracle: string;
+};
+
+const funds: Record<string, Record<string, FundConfig>> = {
   [CHAIN.ETHEREUM]: {
-    EUTBL: "0xa0769f7A8fC65e47dE93797b4e21C073c117Fc80",
-    USTBL: "0xe4880249745eAc5F1eD9d8F7DF844792D560e750",
+    EUTBL: {
+      token: "0xa0769f7A8fC65e47dE93797b4e21C073c117Fc80",
+      oracle: "0x29503f31B73F0734455942Eb888E13acA1588a4e",
+    },
+    USTBL: {
+      token: "0xe4880249745eAc5F1eD9d8F7DF844792D560e750",
+      oracle: "0x021289588cd81dC1AC87ea91e91607eEF68303F5",
+    },
   },
   [CHAIN.POLYGON]: {
-    EUTBL: "0xa0769f7A8fC65e47dE93797b4e21C073c117Fc80",
-    USTBL: "0xe4880249745eAc5F1eD9d8F7DF844792D560e750",
+    EUTBL: {
+      token: "0xa0769f7A8fC65e47dE93797b4e21C073c117Fc80",
+      oracle: "0x29503f31B73F0734455942Eb888E13acA1588a4e",
+    },
+    USTBL: {
+      token: "0xe4880249745eAc5F1eD9d8F7DF844792D560e750",
+      oracle: "0x021289588cd81dC1AC87ea91e91607eEF68303F5",
+    },
   },
 };
 
-const calcFees = (totalSupply: number, isEUTBL: boolean) => {
-  const baseFeeRate = 0.1;
-  const performanceFeeRate = 0.3;
-  const revenueRate = 0.15;
-  const minAumForFees = 100 * 1e6;
+const ORACLE_PRICE_ABI =
+  "function latestRoundData() view returns (uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound)";
+const ORACLE_DECIMALS = 6;
+const MANAGEMENT_FEE_RATE = 0.25 / 100;
+const YEAR_IN_SECONDS = 365 * 24 * 60 * 60;
 
-  const managementFee =
-    isEUTBL && totalSupply <= minAumForFees ? 0 : baseFeeRate;
-  const totalFeesBalance =
-    (totalSupply * (managementFee + performanceFeeRate)) / 100;
-  const totalRevenuesBalance =
-    (totalSupply *
-      (isEUTBL && totalSupply <= minAumForFees ? 0 : revenueRate)) /
-    100;
+const getOracleAnswer = (priceData: any) =>
+  new BigNumber((priceData.answer ?? priceData[1]).toString());
+
+const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
+  const { api, createBalances, chain, fromApi, toApi } = options;
+  const dailyFees = createBalances();
+  const dailyRevenue = createBalances();
+  const dailySupplySideRevenue = createBalances();
+  const chainFunds = Object.values(funds[chain]);
+  const tokens = chainFunds.map(({ token }) => token);
+  const oracles = chainFunds.map(({ oracle }) => oracle);
+
+  const [totalSupplies, pricesBefore, pricesAfter] = await Promise.all([
+    api.multiCall({
+      calls: tokens,
+      abi: "erc20:totalSupply",
+    }),
+    fromApi.multiCall({
+      calls: oracles,
+      abi: ORACLE_PRICE_ABI,
+    }),
+    toApi.multiCall({
+      calls: oracles,
+      abi: ORACLE_PRICE_ABI,
+    }),
+  ]);
+
+  const periodInYears = new BigNumber(options.toTimestamp - options.fromTimestamp).div(
+    YEAR_IN_SECONDS,
+  );
+
+  chainFunds.forEach(({ token }, index) => {
+    const totalSupply = new BigNumber(totalSupplies[index].toString());
+    const priceBefore = getOracleAnswer(pricesBefore[index]).div(10 ** ORACLE_DECIMALS);
+    const priceAfter = getOracleAnswer(pricesAfter[index]).div(10 ** ORACLE_DECIMALS);
+
+    const priceIncrease = priceAfter.minus(priceBefore);
+    if (priceAfter.gt(0) && priceIncrease.gt(0)) {
+      const assetYield = totalSupply.times(priceIncrease).div(priceAfter);
+      dailyFees.add(token, assetYield.toNumber(), METRIC.ASSETS_YIELDS);
+      dailySupplySideRevenue.add(token, assetYield.toNumber(), METRIC.ASSETS_YIELDS);
+    }
+
+    const managementFee = totalSupply.times(MANAGEMENT_FEE_RATE).times(periodInYears);
+    dailyFees.add(token, managementFee.toNumber(), METRIC.MANAGEMENT_FEES);
+    dailyRevenue.add(token, managementFee.toNumber(), METRIC.MANAGEMENT_FEES);
+  });
 
   return {
-    fees: totalFeesBalance,
-    revenues: totalRevenuesBalance,
+    dailyFees,
+    dailyRevenue,
+    dailyProtocolRevenue: dailyRevenue,
+    dailySupplySideRevenue,
   };
 };
 
-const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
-  const { api, createBalances, chain } = options;
-  const dailyFees = createBalances();
-  const dailyRevenues = createBalances();
-  const { EUTBL, USTBL } = funds[chain];
-
-  const totalSupplies = await api.multiCall({
-    calls: [EUTBL, USTBL],
-    abi: "erc20:totalSupply",
-  });
-
-  const [eutlbSupply, ustblSupply] = [EUTBL, USTBL].map((fund, index) => {
-    const totalSupply: number = totalSupplies[index];
-    return { fund, totalSupply };
-  });
-
-  const ustblFees = calcFees(ustblSupply.totalSupply, false);
-  const eutblFees = calcFees(eutlbSupply.totalSupply, true);
-
-  const feesDatas = [
-    { ...ustblFees, fund: ustblSupply.fund },
-    { ...eutblFees, fund: eutlbSupply.fund },
-  ];
-
-  feesDatas.forEach(({ fund, fees, revenues }) => {
-    dailyFees.add(fund, fees / 365);
-    dailyRevenues.add(fund, revenues / 365);
-  });
-
-  return { dailyFees, dailyRevenue: dailyRevenues };
+const methodology = {
+  Fees: "Includes positive NAV growth from EUTBL/USTBL asset yields and Spiko's annual management fee.",
+  Revenue: "Spiko management fees, charged at 0.25% annually on fund assets.",
+  ProtocolRevenue: "Spiko management fees, charged at 0.25% annually on fund assets.",
+  SupplySideRevenue: "Positive NAV growth from EUTBL and USTBL asset yields distributed to token holders.",
 };
 
-const methodology = {
-  Fees: 'Total yields are generated from investment assets.',
-  Revenue: '15% yields are collected by Spiko protocol.',
-}
+const breakdownMethodology = {
+  Fees: {
+    [METRIC.ASSETS_YIELDS]: "Positive EUTBL/USTBL NAV growth from the official Spiko on-chain oracle.",
+    [METRIC.MANAGEMENT_FEES]: "0.25% annual management fee charged on fund assets.",
+  },
+  Revenue: {
+    [METRIC.MANAGEMENT_FEES]: "0.25% annual management fee charged on fund assets.",
+  },
+  ProtocolRevenue: {
+    [METRIC.MANAGEMENT_FEES]: "0.25% annual management fee charged on fund assets.",
+  },
+  SupplySideRevenue: {
+    [METRIC.ASSETS_YIELDS]: "Positive EUTBL/USTBL NAV growth from the official Spiko on-chain oracle.",
+  },
+};
 
 const adapter: Adapter = {
   methodology,
+  breakdownMethodology,
   version: 2,
   adapter: {
     [CHAIN.ETHEREUM]: {

--- a/fees/spiko/index.ts
+++ b/fees/spiko/index.ts
@@ -42,6 +42,9 @@ const YEAR_IN_SECONDS = 365 * 24 * 60 * 60;
 const getOracleAnswer = (priceData: any) =>
   new BigNumber((priceData.answer ?? priceData[1]).toString());
 
+const toBaseUnits = (amount: BigNumber) =>
+  amount.integerValue(BigNumber.ROUND_FLOOR).toFixed(0);
+
 const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
   const { createBalances, chain, fromApi, toApi } = options;
   const dailyFees = createBalances();
@@ -106,13 +109,15 @@ const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
     const priceIncrease = priceAfter.minus(priceBefore);
     if (priceAfter.gt(0) && priceIncrease.gt(0)) {
       const assetYield = averageSupply.times(priceIncrease).div(priceAfter);
-      dailyFees.add(token, assetYield.toNumber(), METRIC.ASSETS_YIELDS);
-      dailySupplySideRevenue.add(token, assetYield.toNumber(), METRIC.ASSETS_YIELDS);
+      const assetYieldBaseUnits = toBaseUnits(assetYield);
+      dailyFees.add(token, assetYieldBaseUnits, METRIC.ASSETS_YIELDS);
+      dailySupplySideRevenue.add(token, assetYieldBaseUnits, METRIC.ASSETS_YIELDS);
     }
 
     const managementFee = averageSupply.times(MANAGEMENT_FEE_RATE).times(periodInYears);
-    dailyFees.add(token, managementFee.toNumber(), METRIC.MANAGEMENT_FEES);
-    dailyRevenue.add(token, managementFee.toNumber(), METRIC.MANAGEMENT_FEES);
+    const managementFeeBaseUnits = toBaseUnits(managementFee);
+    dailyFees.add(token, managementFeeBaseUnits, METRIC.MANAGEMENT_FEES);
+    dailyRevenue.add(token, managementFeeBaseUnits, METRIC.MANAGEMENT_FEES);
   });
 
   return {

--- a/fees/spiko/index.ts
+++ b/fees/spiko/index.ts
@@ -51,38 +51,45 @@ const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
   const tokens = chainFunds.map(({ token }) => token);
   const oracles = chainFunds.map(({ oracle }) => oracle);
 
-  const [totalSupplies, pricesBefore, pricesAfter] = await Promise.all([
-    api.multiCall({
-      calls: tokens,
-      abi: "erc20:totalSupply",
-    }),
-    fromApi.multiCall({
-      calls: oracles,
-      abi: ORACLE_PRICE_ABI,
-    }),
-    toApi.multiCall({
-      calls: oracles,
-      abi: ORACLE_PRICE_ABI,
-    }),
-  ]);
+  const [totalSuppliesBefore, totalSuppliesAfter, pricesBefore, pricesAfter] =
+    await Promise.all([
+      fromApi.multiCall({
+        calls: tokens,
+        abi: "erc20:totalSupply",
+      }),
+      toApi.multiCall({
+        calls: tokens,
+        abi: "erc20:totalSupply",
+      }),
+      fromApi.multiCall({
+        calls: oracles,
+        abi: ORACLE_PRICE_ABI,
+      }),
+      toApi.multiCall({
+        calls: oracles,
+        abi: ORACLE_PRICE_ABI,
+      }),
+    ]);
 
   const periodInYears = new BigNumber(options.toTimestamp - options.fromTimestamp).div(
     YEAR_IN_SECONDS,
   );
 
   chainFunds.forEach(({ token }, index) => {
-    const totalSupply = new BigNumber(totalSupplies[index].toString());
+    const totalSupplyBefore = new BigNumber(totalSuppliesBefore[index].toString());
+    const totalSupplyAfter = new BigNumber(totalSuppliesAfter[index].toString());
+    const averageSupply = totalSupplyBefore.plus(totalSupplyAfter).div(2);
     const priceBefore = getOracleAnswer(pricesBefore[index]).div(10 ** ORACLE_DECIMALS);
     const priceAfter = getOracleAnswer(pricesAfter[index]).div(10 ** ORACLE_DECIMALS);
 
     const priceIncrease = priceAfter.minus(priceBefore);
     if (priceAfter.gt(0) && priceIncrease.gt(0)) {
-      const assetYield = totalSupply.times(priceIncrease).div(priceAfter);
+      const assetYield = averageSupply.times(priceIncrease).div(priceAfter);
       dailyFees.add(token, assetYield.toNumber(), METRIC.ASSETS_YIELDS);
       dailySupplySideRevenue.add(token, assetYield.toNumber(), METRIC.ASSETS_YIELDS);
     }
 
-    const managementFee = totalSupply.times(MANAGEMENT_FEE_RATE).times(periodInYears);
+    const managementFee = averageSupply.times(MANAGEMENT_FEE_RATE).times(periodInYears);
     dailyFees.add(token, managementFee.toNumber(), METRIC.MANAGEMENT_FEES);
     dailyRevenue.add(token, managementFee.toNumber(), METRIC.MANAGEMENT_FEES);
   });
@@ -116,6 +123,7 @@ const breakdownMethodology = {
   SupplySideRevenue: {
     [METRIC.ASSETS_YIELDS]: "Positive EUTBL/USTBL NAV growth from the official Spiko on-chain oracle.",
   },
+  HoldersRevenue: {},
 };
 
 const adapter: Adapter = {


### PR DESCRIPTION
## Summary
- replace the static annualized Spiko fee estimate with NAV-delta accounting from Spiko's on-chain EUTBL/USTBL oracles
- report positive EUTBL/USTBL NAV growth as both fees and supply-side revenue
- keep Spiko's 0.25% annual management fee separated as protocol revenue with breakdown labels

Closes #6686.

## Validation
- `npm run test fees spiko 2026-04-29`
- `npm run test fees spiko 2026-04-28`
- `npm run test fees spiko`