### PR TITLE
[fix] sailor - replace dead pool metrics source

### DIFF
--- a/dexs/sailor-finance.ts
+++ b/dexs/sailor-finance.ts
@@ -1,64 +1,35 @@
 import { FetchOptions } from '../adapters/types';
-import { getConfig } from '../helpers/cache';
 import { CHAIN } from '../helpers/chains';
-import { addOneToken } from '../helpers/prices';
-import { filterPools2 } from '../helpers/uniswap';
 import { httpGet } from '../utils/fetchURL';
 
-const endpoint = "https://asia-southeast1-ktx-finance-2.cloudfunctions.net/sailor_poolapi/getPoolList";
+const GECKOTERMINAL_POOLS_URL =
+  "https://api.geckoterminal.com/api/v2/networks/sei-evm/dexes/sailor/pools";
+const DEFAULT_FEE_RATE = 0.003;
+const PROTOCOL_FEE_SHARE = 0.16;
+const MAX_PAGES = 10;
 
-const poolSwapEvent = 'event Swap(address indexed sender, address indexed recipient, int256 amount0, int256 amount1, uint160 sqrtPriceX96, uint128 liquidity, int24 tick, uint128 protocolFeesToken0, uint128 protocolFeesToken1)'
+const getFeeRateFromPoolName = (name = "") => {
+  const feeMatch = name.match(/([0-9.]+)%\s*$/);
+  return feeMatch ? Number(feeMatch[1]) / 100 : DEFAULT_FEE_RATE;
+};
 
-const fetch = async (options: FetchOptions) => {
-  const { poolStats } = await getConfig('sailor-v3/sei', endpoint)
-  const filterObject: any = {
-    fetchOptions: options,
-    pairs: [],
-    token0s: [],
-    token1s: [],
+const fetchPools = async () => {
+  const pools: any[] = [];
+
+  for (let page = 1; page <= MAX_PAGES; page++) {
+    const response = await httpGet(`${GECKOTERMINAL_POOLS_URL}?page=${page}`);
+    const pagePools = response?.data ?? [];
+    if (!pagePools.length) break;
+    pools.push(...pagePools);
   }
 
-  poolStats.forEach((pool: any) => {
-    filterObject.pairs.push(pool.id)
-    filterObject.token0s.push(pool.token0.id)
-    filterObject.token1s.push(pool.token1.id)
-  })
-
-  const { pairs } = await filterPools2(filterObject)
-  const filteredPoolStats = poolStats.filter((pool: any) => pairs.includes(pool.id))
-
-  const dailyVolume = options.createBalances()
-  const dailyFees = options.createBalances()
-
-  const logs = await options.getLogs({
-    eventAbi: poolSwapEvent,
-    targets: filteredPoolStats.map((item: any) => item.id),
-    flatten: false,
-  })
-
-  for (let i = 0; i < filteredPoolStats.length; i++) {
-    const feeRate = Number(filteredPoolStats[i].feeTier) / 1e6
-    for (const log of logs[i]) {
-      addOneToken({ chain: options.chain, balances: dailyVolume, token0: filteredPoolStats[i].token0.id, token1: filteredPoolStats[i].token1.id, amount0: Math.abs(Number(log.amount0)), amount1: Math.abs(Number(log.amount1)) })
-      addOneToken({ chain: options.chain, balances: dailyFees, token0: filteredPoolStats[i].token0.id, token1: filteredPoolStats[i].token1.id, amount0: Math.abs(Number(log.amount0)) * feeRate, amount1: Math.abs(Number(log.amount1)) * feeRate })
-    }
-  }
-
-  return {
-    dailyVolume,
-    dailyFees,
-    dailyUserFees: dailyFees,
-    dailyRevenue: dailyFees.clone(0.16),
-    dailyHoldersRevenue: 0,
-    dailyProtocolRevenue: dailyFees.clone(0.16),
-    dailySupplySideRevenue: dailyFees.clone(0.84),
-  }
+  return pools;
 };
 
 const methodology = {
-  Fees: "Sailor-Finance protocol swap fee (0.3% per swap).",
-  UserFees: "Sailor-Finance protocol swap fee (0.3% per swap).",
-  Revenue: "Fees distributed to the LP providers (84% of total accumulated fees).",
+  Fees: "Sailor-Finance swap fees, calculated from each pool's 24h volume and advertised fee tier.",
+  UserFees: "Sailor-Finance swap fees, calculated from each pool's 24h volume and advertised fee tier.",
+  Revenue: "Fees sent to the protocol wallet (16% of total accumulated fees).",
   ProtocolRevenue: "Fees sent to the protocol wallet (16% of total accumulated fees), is used to provide benefits to users in custom ways.",
   SupplySideRevenue: "There are 84% swap fees distributed to LPs.",
 };
@@ -72,25 +43,28 @@ const blacklistPools: Array<string> = [
 ];
 
 const fetchV1 = async (_a: any, _b: any, _: FetchOptions) => {
-  const { poolStats } = await httpGet('https://asia-southeast1-ktx-finance-2.cloudfunctions.net/sailor_poolapi/getPoolList');
-  
+  const pools = await fetchPools();
   let dailyVolume = 0;
   let dailyFees = 0;
-  for (const pool of poolStats.filter((i: any) => Number(i.tvl) > 200)) {
-    const volumeToTvl = pool.tvl>0?pool.day.volume/pool.tvl:0;
-    if (volumeToTvl<10 && !blacklistPools.includes(String(pool.id).toLowerCase())) {
-      dailyVolume += Number(pool.day.volume);
-      dailyFees += Number(pool.day.volume) * Number(pool.feeTier) / 1e6;
-    }
+
+  for (const { attributes } of pools) {
+    if (blacklistPools.includes(String(attributes.address).toLowerCase())) continue;
+
+    const volume = Number(attributes.volume_usd?.h24 ?? 0);
+    if (!Number.isFinite(volume) || volume <= 0) continue;
+
+    dailyVolume += volume;
+    dailyFees += volume * getFeeRateFromPoolName(attributes.name);
   }
+  const dailyRevenue = dailyFees * PROTOCOL_FEE_SHARE;
 
   return {
     dailyVolume,
     dailyFees,
     dailyUserFees: dailyFees,
-    dailyRevenue: dailyFees * 0.16,
-    dailyProtocolRevenue: dailyFees * 0.16,
-    dailySupplySideRevenue: dailyFees * 0.84,
+    dailyRevenue,
+    dailyProtocolRevenue: dailyRevenue,
+    dailySupplySideRevenue: dailyFees - dailyRevenue,
     dailyHoldersRevenue: 0,
   }
 }

--- a/dexs/sailor-finance.ts
+++ b/dexs/sailor-finance.ts
@@ -1,12 +1,13 @@
 import { FetchOptions } from '../adapters/types';
 import { CHAIN } from '../helpers/chains';
-import { httpGet } from '../utils/fetchURL';
+import { fetchURLAutoHandleRateLimit } from '../utils/fetchURL';
+import { sleep } from '../utils/utils';
 
 const GECKOTERMINAL_POOLS_URL =
   "https://api.geckoterminal.com/api/v2/networks/sei-evm/dexes/sailor/pools";
 const DEFAULT_FEE_RATE = 0.003;
 const PROTOCOL_FEE_SHARE = 0.16;
-const MAX_PAGES = 10;
+const MAX_PAGES = 20;
 
 const getFeeRateFromPoolName = (name = "") => {
   const feeMatch = name.match(/([0-9.]+)%\s*$/);
@@ -17,10 +18,11 @@ const fetchPools = async () => {
   const pools: any[] = [];
 
   for (let page = 1; page <= MAX_PAGES; page++) {
-    const response = await httpGet(`${GECKOTERMINAL_POOLS_URL}?page=${page}`);
+    const response = await fetchURLAutoHandleRateLimit(`${GECKOTERMINAL_POOLS_URL}?page=${page}`);
     const pagePools = response?.data ?? [];
     if (!pagePools.length) break;
     pools.push(...pagePools);
+    await sleep(1000);
   }
 
   return pools;
@@ -42,7 +44,7 @@ const blacklistPools: Array<string> = [
   '0xad00786c2ba76f08c92e7847456015728f98ac56', // bad pool - very low liquidity
 ];
 
-const fetchV1 = async (_a: any, _b: any, _: FetchOptions) => {
+const fetch = async (_a: any, _b: any, _: FetchOptions) => {
   const pools = await fetchPools();
   let dailyVolume = 0;
   let dailyFees = 0;
@@ -50,7 +52,7 @@ const fetchV1 = async (_a: any, _b: any, _: FetchOptions) => {
   for (const { attributes } of pools) {
     if (blacklistPools.includes(String(attributes.address).toLowerCase())) continue;
 
-    const volume = Number(attributes.volume_usd?.h24 ?? 0);
+    const volume = Number(attributes.volume_usd.h24);
     if (!Number.isFinite(volume) || volume <= 0) continue;
 
     dailyVolume += volume;
@@ -72,10 +74,7 @@ const fetchV1 = async (_a: any, _b: any, _: FetchOptions) => {
 export default {
   version: 1,
   methodology,
-  adapter: {
-    [CHAIN.SEI]: {
-      fetch: fetchV1,
-      runAtCurrTime: true,
-    }
-  },
+  runAtCurrTime: true,
+  fetch,
+  chains: [CHAIN.SEI],
 }


### PR DESCRIPTION
## Summary
- replace Sailor's dead Cloud Functions pool endpoint, which now returns 404, with GeckoTerminal's Sailor pool feed
- compute current 24h volume from active Sailor pools
- derive fees from each pool's advertised fee tier and keep the existing 16% protocol / 84% LP split

Closes #6708.

## Validation
- `npm run test dexs sailor-finance`
- `npm run test dexs sailor-finance 2026-04-30`

Note: the local runner still logs the existing Sei block lookup warnings before executing this current-window adapter, but the adapter completes successfully.