### PR TITLE
fix(bisq): update volume endpoint

### DIFF
--- a/dexs/bisq/index.ts
+++ b/dexs/bisq/index.ts
@@ -2,7 +2,7 @@ import fetchURL from "../../utils/fetchURL"
 import { ChainBlocks, FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 
-const historicalVolumeEndpoint = "https://markets.bisq.services/api/volumes?interval=day"
+const historicalVolumeEndpoint = "https://markets.bisq.network/api/volumes?interval=day"
 
 interface IVolumeall {
   volume: string;


### PR DESCRIPTION
Closes #6717

## Context

The Bisq volume adapter was calling `markets.bisq.services`, which no longer resolves. Bisq's markets API is available at `markets.bisq.network` with the same `/api/volumes?interval=day` response shape.

## Changes

- Point the Bisq volume adapter at the live Bisq markets API host.

## Tests

```bash
pnpm test dexs bisq
git diff --check
```