### PR TITLE
feat: add blockchain-capital fee/revenue adapter

### DIFF
--- a/fees/blockchain-capital/index.ts
+++ b/fees/blockchain-capital/index.ts
@@ -11,79 +11,56 @@ const ONE_YEAR_IN_SECONDS = 365 * 24 * 60 * 60;
 
 const priceFeedAbi = "function latestAnswer() view returns (int256)";
 
-async function fetch(options: FetchOptions) {
-  const dailyFees = options.createBalances();
-  const dailyRevenue = options.createBalances();
-  const dailySupplySideRevenue = options.createBalances();
+async function fetch(_a: any, _b: any, options: FetchOptions) {
+    const dailyFees = options.createBalances();
 
-  const priceBefore = await options.fromApi.call({ target: PRICE_FEED, abi: priceFeedAbi });
-  const priceAfter = await options.toApi.call({ target: PRICE_FEED, abi: priceFeedAbi });
+    const priceAfter = await options.toApi.call({ target: PRICE_FEED, abi: priceFeedAbi });
 
-  const currentPrice = priceAfter / 10 ** REDSTONE_ORACLE_DECIMALS;
-  const priceChange = (priceAfter - priceBefore) / 10 ** REDSTONE_ORACLE_DECIMALS;
+    const currentPrice = priceAfter / 10 ** REDSTONE_ORACLE_DECIMALS;
 
-  const totalSupply = await options.api.call({
-    target: BCAP_TOKEN,
-    abi: "function totalSupply() view returns (uint256)",
-  });
-  const totalSupplyAfterDecimals = totalSupply / 10 ** TOKEN_DECIMALS;
+    const totalSupply = await options.api.call({
+        target: BCAP_TOKEN,
+        abi: "function totalSupply() view returns (uint256)",
+    });
+    const totalSupplyAfterDecimals = totalSupply / 10 ** TOKEN_DECIMALS;
 
-  const managementFeesForPeriod =
-    (currentPrice *
-      totalSupplyAfterDecimals *
-      MANAGEMENT_FEE *
-      (options.toTimestamp - options.fromTimestamp)) /
-    ONE_YEAR_IN_SECONDS;
-  const yieldForPeriod = priceChange * totalSupplyAfterDecimals;
+    const managementFeesForPeriod =
+        currentPrice * totalSupplyAfterDecimals * MANAGEMENT_FEE * (options.toTimestamp - options.fromTimestamp) / ONE_YEAR_IN_SECONDS;
 
-  dailyFees.addUSDValue(managementFeesForPeriod, METRIC.MANAGEMENT_FEES);
-  dailyRevenue.addUSDValue(managementFeesForPeriod, METRIC.MANAGEMENT_FEES);
+    dailyFees.addUSDValue(managementFeesForPeriod, METRIC.MANAGEMENT_FEES);
 
-  dailyFees.addUSDValue(yieldForPeriod, METRIC.ASSETS_YIELDS);
-  dailySupplySideRevenue.addUSDValue(yieldForPeriod, METRIC.ASSETS_YIELDS);
-
-  return {
-    dailyFees,
-    dailyRevenue,
-    dailyProtocolRevenue: dailyRevenue,
-    dailySupplySideRevenue,
-  };
+    return {
+        dailyFees,
+        dailyRevenue: dailyFees,
+        dailyProtocolRevenue: dailyFees,
+    };
 }
 
 const methodology = {
-  Fees: "Yields calculated from BCAP NAV change and 2.5% management fees",
-  Revenue: "Includes 2.5% management fees collected by the protocol",
-  ProtocolRevenue: "Includes 2.5% management fees collected by the protocol",
-  SupplySideRevenue: "Yields calculated from BCAP NAV change",
+    Fees: "Includes 2.5% management fees collected by the protocol",
+    Revenue: "Includes 2.5% management fees collected by the protocol",
+    ProtocolRevenue: "Includes 2.5% management fees collected by the protocol",
 };
 
 const breakdownMethodology = {
-  Fees: {
-    [METRIC.ASSETS_YIELDS]: "Yields calculated from BCAP NAV change",
-    [METRIC.MANAGEMENT_FEES]: "2.5% management fees collected by the protocol",
-  },
-  Revenue: {
-    [METRIC.MANAGEMENT_FEES]: "2.5% management fees collected by the protocol",
-  },
-  ProtocolRevenue: {
-    [METRIC.MANAGEMENT_FEES]: "2.5% management fees collected by the protocol",
-  },
-  SupplySideRevenue: {
-    [METRIC.ASSETS_YIELDS]: "Yields calculated from BCAP NAV change",
-  },
+    Fees: {
+        [METRIC.MANAGEMENT_FEES]: "2.5% management fees collected by the protocol",
+    },
+    Revenue: {
+        [METRIC.MANAGEMENT_FEES]: "2.5% management fees collected by the protocol",
+    },
+    ProtocolRevenue: {
+        [METRIC.MANAGEMENT_FEES]: "2.5% management fees collected by the protocol",
+    },
 };
 
 const adapter: SimpleAdapter = {
-  version: 2,
-  fetch,
-  breakdownMethodology,
-  methodology,
-  adapter: {
-    [CHAIN.ERA]: {
-      start: "2025-05-06",
-    },
-  },
-  allowNegativeValue: true,
+    version: 1, //oracle price updates once a day
+    fetch,
+    breakdownMethodology,
+    methodology,
+    chains: [CHAIN.ERA],
+    start: '2025-03-08'
 };
 
 export default adapter;

--- a/fees/blockchain-capital/index.ts
+++ b/fees/blockchain-capital/index.ts
@@ -1,0 +1,109 @@
+import { FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import { METRIC } from "../../helpers/metrics";
+import * as sdk from "@defillama/sdk";
+
+const BCAP_TOKEN = "0x57fD71a86522Dc06D6255537521886057c1772A3";
+const PRICE_FEED = "0x0eF2418216476Ab5264821070B8c24b6B458F796";
+const TOKEN_DECIMALS = 2;
+const REDSTONE_ORACLE_DECIMALS = 8;
+const MANAGEMENT_FEE = 2.5 / 100;
+const ONE_YEAR_IN_SECONDS = 365 * 24 * 60 * 60;
+
+async function prefetch(options: FetchOptions) {
+  const apiFrom = new sdk.ChainApi({ chain: CHAIN.ERA, timestamp: options.fromTimestamp });
+  const apiTo = new sdk.ChainApi({ chain: CHAIN.ERA, timestamp: options.toTimestamp });
+
+  await apiFrom.getBlock();
+  await apiTo.getBlock();
+
+  const priceBefore = await apiFrom.call({
+    target: PRICE_FEED,
+    abi: "function latestAnswer() view returns (int256)",
+  });
+
+  const priceAfter = await apiTo.call({
+    target: PRICE_FEED,
+    abi: "function latestAnswer() view returns (int256)",
+  });
+
+  return {
+    priceChange: (priceAfter - priceBefore) / 10 ** REDSTONE_ORACLE_DECIMALS,
+    currentPrice: priceAfter / 10 ** REDSTONE_ORACLE_DECIMALS,
+  };
+}
+
+async function fetch(_: any, __: any, options: FetchOptions) {
+  const dailyFees = options.createBalances();
+  const dailyRevenue = options.createBalances();
+  const dailySupplySideRevenue = options.createBalances();
+
+  const priceChange = options.preFetchedResults.priceChange;
+  const currentPrice = options.preFetchedResults.currentPrice;
+
+  const totalSupply = await options.api.call({
+    target: BCAP_TOKEN,
+    abi: "function totalSupply() view returns (uint256)",
+  });
+  const totalSupplyAfterDecimals = totalSupply / 10 ** TOKEN_DECIMALS;
+
+  const managementFeesForPeriod =
+    (currentPrice *
+      totalSupplyAfterDecimals *
+      MANAGEMENT_FEE *
+      (options.toTimestamp - options.fromTimestamp)) /
+    ONE_YEAR_IN_SECONDS;
+  const yieldForPeriod = priceChange * totalSupplyAfterDecimals;
+
+  dailyFees.addUSDValue(managementFeesForPeriod, METRIC.MANAGEMENT_FEES);
+  dailyRevenue.addUSDValue(managementFeesForPeriod, METRIC.MANAGEMENT_FEES);
+
+  dailyFees.addUSDValue(yieldForPeriod, METRIC.ASSETS_YIELDS);
+  dailySupplySideRevenue.addUSDValue(yieldForPeriod, METRIC.ASSETS_YIELDS);
+
+  return {
+    dailyFees,
+    dailyRevenue,
+    dailyProtocolRevenue: dailyRevenue,
+    dailySupplySideRevenue,
+  };
+}
+
+const methodology = {
+  Fees: "Yields calculated from BCAP NAV change and 2.5% management fees",
+  Revenue: "Includes 2.5% management fees collected by the protocol",
+  ProtocolRevenue: "Includes 2.5% management fees collected by the protocol",
+  SupplySideRevenue: "Yields calculated from BCAP NAV change",
+};
+
+const breakdownMethodology = {
+  Fees: {
+    [METRIC.ASSETS_YIELDS]: "Yields calculated from BCAP NAV change",
+    [METRIC.MANAGEMENT_FEES]: "2.5% management fees collected by the protocol",
+  },
+  Revenue: {
+    [METRIC.MANAGEMENT_FEES]: "2.5% management fees collected by the protocol",
+  },
+  ProtocolRevenue: {
+    [METRIC.MANAGEMENT_FEES]: "2.5% management fees collected by the protocol",
+  },
+  SupplySideRevenue: {
+    [METRIC.ASSETS_YIELDS]: "Yields calculated from BCAP NAV change",
+  },
+};
+
+const adapter: SimpleAdapter = {
+  version: 1,
+  prefetch,
+  fetch,
+  breakdownMethodology,
+  methodology,
+  adapter: {
+    [CHAIN.ERA]: {
+      start: "2025-09-09",
+    },
+  },
+  allowNegativeValue: true,
+};
+
+export default adapter;

--- a/fees/blockchain-capital/index.ts
+++ b/fees/blockchain-capital/index.ts
@@ -80,7 +80,7 @@ const adapter: SimpleAdapter = {
   methodology,
   adapter: {
     [CHAIN.ERA]: {
-      start: "2025-03-14",
+      start: "2025-05-06",
     },
   },
   allowNegativeValue: true,

--- a/fees/blockchain-capital/index.ts
+++ b/fees/blockchain-capital/index.ts
@@ -1,7 +1,6 @@
 import { FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 import { METRIC } from "../../helpers/metrics";
-import * as sdk from "@defillama/sdk";
 
 const BCAP_TOKEN = "0x57fD71a86522Dc06D6255537521886057c1772A3";
 const PRICE_FEED = "0x0eF2418216476Ab5264821070B8c24b6B458F796";
@@ -10,36 +9,18 @@ const REDSTONE_ORACLE_DECIMALS = 8;
 const MANAGEMENT_FEE = 2.5 / 100;
 const ONE_YEAR_IN_SECONDS = 365 * 24 * 60 * 60;
 
-async function prefetch(options: FetchOptions) {
-  const apiFrom = new sdk.ChainApi({ chain: CHAIN.ERA, timestamp: options.fromTimestamp });
-  const apiTo = new sdk.ChainApi({ chain: CHAIN.ERA, timestamp: options.toTimestamp });
-
-  await apiFrom.getBlock();
-  await apiTo.getBlock();
-
-  const priceBefore = await apiFrom.call({
-    target: PRICE_FEED,
-    abi: "function latestAnswer() view returns (int256)",
-  });
-
-  const priceAfter = await apiTo.call({
-    target: PRICE_FEED,
-    abi: "function latestAnswer() view returns (int256)",
-  });
-
-  return {
-    priceChange: (priceAfter - priceBefore) / 10 ** REDSTONE_ORACLE_DECIMALS,
-    currentPrice: priceAfter / 10 ** REDSTONE_ORACLE_DECIMALS,
-  };
-}
+const priceFeedAbi = "function latestAnswer() view returns (int256)";
 
 async function fetch(_: any, __: any, options: FetchOptions) {
   const dailyFees = options.createBalances();
   const dailyRevenue = options.createBalances();
   const dailySupplySideRevenue = options.createBalances();
 
-  const priceChange = options.preFetchedResults.priceChange;
-  const currentPrice = options.preFetchedResults.currentPrice;
+  const priceBefore = await options.fromApi.call({ target: PRICE_FEED, abi: priceFeedAbi });
+  const priceAfter = await options.toApi.call({ target: PRICE_FEED, abi: priceFeedAbi });
+
+  const currentPrice = priceAfter / 10 ** REDSTONE_ORACLE_DECIMALS;
+  const priceChange = (priceAfter - priceBefore) / 10 ** REDSTONE_ORACLE_DECIMALS;
 
   const totalSupply = await options.api.call({
     target: BCAP_TOKEN,
@@ -93,8 +74,7 @@ const breakdownMethodology = {
 };
 
 const adapter: SimpleAdapter = {
-  version: 1,
-  prefetch,
+  version: 1, // redstone NAV ticks daily at best
   fetch,
   breakdownMethodology,
   methodology,

--- a/fees/blockchain-capital/index.ts
+++ b/fees/blockchain-capital/index.ts
@@ -11,7 +11,7 @@ const ONE_YEAR_IN_SECONDS = 365 * 24 * 60 * 60;
 
 const priceFeedAbi = "function latestAnswer() view returns (int256)";
 
-async function fetch(_: any, __: any, options: FetchOptions) {
+async function fetch(options: FetchOptions) {
   const dailyFees = options.createBalances();
   const dailyRevenue = options.createBalances();
   const dailySupplySideRevenue = options.createBalances();
@@ -74,13 +74,13 @@ const breakdownMethodology = {
 };
 
 const adapter: SimpleAdapter = {
-  version: 1, // redstone NAV ticks daily at best
+  version: 2,
   fetch,
   breakdownMethodology,
   methodology,
   adapter: {
     [CHAIN.ERA]: {
-      start: "2025-09-09",
+      start: "2025-03-14",
     },
   },
   allowNegativeValue: true,


### PR DESCRIPTION
## Summary
> Closes #6703

The adapter mirrors [`fees/acred/index.ts`](https://github.com/DefiLlama/dimension-adapters/blob/master/fees/acred/index.ts) (Apollo Diversified Credit) 

- assumes **2.5% flat management fee** per [this source](https://app.rwa.xyz/assets/BCAP).
- utilizes [redstone price feed](https://app.redstone.finance/push-feeds/BCAP_FUNDAMENTAL/zksyncMultiFeed) for net asset value (NAV) data source

## Verification

`pnpm test fees blockchain-capital <date>`:

```
=== 2026-04-25 ===  pre-revaluation, NAV flat
Daily fees:                $51.65k <- mgmt only ($760M × 2.5% / 365)
Daily revenue:             $51.65k
Daily supply side revenue:  $0.00

=== 2026-04-28 ===  Securitize NAV re-mark day
Daily fees:               $209.55M <-  mgmt + the entire one-day NAV step-up
Daily revenue:             $66.00k <-  mgmt only (now AUM ~$963M)
Daily supply side revenue: $209.49M <- priceChange x supply

=== 2026-04-30 ===  post-revaluation, NAV flat again
Daily fees:                $66.00k
Daily revenue:              $66.00k
Daily supply side revenue:   $0.00
``` 
`$963M × 2.5% / 365 = $66k` matches expected `dailyRevenue`.

## Notes on scope
- **25% performance fee excluded from the calculation**
 BCAP charges 2.5% annual management + 25% carry on profits. The carry is dropped from this adapter on purpose. The published NAV is already **net of accrued carry on realised gains**.
- [Twitter link for the protocol](https://twitter.com/blockchaincap) no longer works. 

 