### PR TITLE
feat(pool-party): add volume + fees adapters (Canton AMM, Phase 1)

### DIFF
--- a/dexs/pool-party/index.ts
+++ b/dexs/pool-party/index.ts
@@ -11,6 +11,10 @@ import { httpGet } from "../../utils/fetchURL";
  * Pool Party reports volume per token across all pools. In an AMM each swap
  * touches both sides of a pair, so the sum across instruments is 2× the true
  * single-side trading volume. We halve before pricing.
+ *
+ * runAtCurrTime: true — Pool Party API exposes a current rolling-24h snapshot
+ * only (no historical backfill / time-travel). Tells the dimension-adapters
+ * framework not to request past-window data.
  */
 
 const VOLUME_URL =
@@ -66,6 +70,7 @@ const methodology = {
 const adapter: SimpleAdapter = {
   version: 2,
   methodology,
+  runAtCurrTime: true,
   adapter: {
     [CHAIN.CANTON]: {
       fetch,

--- a/dexs/pool-party/index.ts
+++ b/dexs/pool-party/index.ts
@@ -1,0 +1,77 @@
+import { CHAIN } from "../../helpers/chains";
+import { FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { httpGet } from "../../utils/fetchURL";
+
+/*
+ * Pool Party — Canton Network AMM (volume)
+ *
+ * Source: https://api-mainnet.cantonwallet.com/canton/pool-party/public/v1/volume?period=24h
+ * Spec:   https://github.com/0xsend/canton-monorepo/issues/3481
+ *
+ * Pool Party reports volume per token across all pools. In an AMM each swap
+ * touches both sides of a pair, so the sum across instruments is 2× the true
+ * single-side trading volume. We halve before pricing.
+ */
+
+const VOLUME_URL =
+  "https://api-mainnet.cantonwallet.com/canton/pool-party/public/v1/volume?period=24h";
+
+// Pool Party SDK instrument IDs (stable per Send Foundation):
+//   "Amulet"  : Canton Coin (CC) — priced via coingecko:canton-network
+//   "USDCx"   : bridged USDC on Canton — priced as USDC ($1 stable proxy)
+//   CUSD UUID : Send's privacy stablecoin — priced as USDC ($1 stable proxy)
+//
+// Brale issues multiple instruments (CUSD + SBC) from the same issuer party;
+// only the CUSD UUID below is in scope. Unknown instrument IDs are skipped.
+const CUSD_INSTRUMENT_ID = "481871d4-ca56-42a8-b2d3-4b7d28742946";
+
+const fetch = async (options: FetchOptions) => {
+  const data: any = await httpGet(VOLUME_URL);
+  const dailyVolume = options.createBalances();
+
+  for (const [instrumentId, amount] of Object.entries(
+    (data && data.volume) || {},
+  )) {
+    const value = Number(amount as string);
+    if (!Number.isFinite(value) || value <= 0) continue;
+
+    // AMM volumes are double-counted across both sides of every swap.
+    const single = value / 2;
+
+    if (instrumentId === "Amulet") {
+      // CC gas token; DefiLlama Canton pricing assumes 18-decimal atomic units.
+      dailyVolume.add("coingecko:canton-network", single * 1e18);
+    } else if (
+      instrumentId === "USDCx" ||
+      instrumentId === CUSD_INSTRUMENT_ID
+    ) {
+      // USDC pricing (6 decimals).
+      dailyVolume.add("coingecko:usd-coin", single * 1e6);
+    }
+  }
+
+  return { dailyVolume };
+};
+
+const methodology = {
+  Volume:
+    "24h spot/swap volume across CC, CUSD, and USDCx pools, fetched from " +
+    "Pool Party's public API on Send Foundation's validator " +
+    "(api-mainnet.cantonwallet.com). Per-token volumes are halved to " +
+    "single-count AMM swaps. CC priced via canton-network on CoinGecko; " +
+    "CUSD and USDCx priced as USDC ($1 stable proxy) since neither has a " +
+    "direct CoinGecko listing.",
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  methodology,
+  adapter: {
+    [CHAIN.CANTON]: {
+      fetch,
+      start: "2026-04-30",
+    },
+  },
+};
+
+export default adapter;

--- a/fees/pool-party/index.ts
+++ b/fees/pool-party/index.ts
@@ -11,6 +11,10 @@ import { httpGet } from "../../utils/fetchURL";
  * Phase 1: only `totalFees` is populated. supplySideRevenue / protocolRevenue /
  * holdersRevenue are intentionally null per AGW-PPUB-017 (Send Phase 2 spec
  * depends on PQS materialized views for per-swap fee attribution).
+ *
+ * runAtCurrTime: true — Pool Party API exposes a current rolling-24h snapshot
+ * only (no historical backfill / time-travel). Tells the dimension-adapters
+ * framework not to request past-window data.
  */
 
 const FEES_URL =
@@ -63,6 +67,7 @@ const methodology = {
 const adapter: SimpleAdapter = {
   version: 2,
   methodology,
+  runAtCurrTime: true,
   adapter: {
     [CHAIN.CANTON]: {
       fetch,

--- a/fees/pool-party/index.ts
+++ b/fees/pool-party/index.ts
@@ -1,0 +1,74 @@
+import { CHAIN } from "../../helpers/chains";
+import { FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { httpGet } from "../../utils/fetchURL";
+
+/*
+ * Pool Party — Canton Network AMM (fees)
+ *
+ * Source: https://api-mainnet.cantonwallet.com/canton/pool-party/public/v1/fees?period=24h
+ * Spec:   https://github.com/0xsend/canton-monorepo/issues/3481
+ *
+ * Phase 1: only `totalFees` is populated. supplySideRevenue / protocolRevenue /
+ * holdersRevenue are intentionally null per AGW-PPUB-017 (Send Phase 2 spec
+ * depends on PQS materialized views for per-swap fee attribution).
+ */
+
+const FEES_URL =
+  "https://api-mainnet.cantonwallet.com/canton/pool-party/public/v1/fees?period=24h";
+
+// Pool Party SDK instrument IDs (stable per Send Foundation):
+//   "Amulet"  : Canton Coin (CC) — priced via coingecko:canton-network
+//   "USDCx"   : bridged USDC on Canton — priced as USDC ($1 stable proxy)
+//   CUSD UUID : Send's privacy stablecoin — priced as USDC ($1 stable proxy)
+//
+// Fees are not double-counted (collected once per swap, in a single token).
+const CUSD_INSTRUMENT_ID = "481871d4-ca56-42a8-b2d3-4b7d28742946";
+
+const fetch = async (options: FetchOptions) => {
+  const data: any = await httpGet(FEES_URL);
+  const dailyFees = options.createBalances();
+
+  for (const [instrumentId, amount] of Object.entries(
+    (data && data.totalFees) || {},
+  )) {
+    const value = Number(amount as string);
+    if (!Number.isFinite(value) || value <= 0) continue;
+
+    if (instrumentId === "Amulet") {
+      dailyFees.add("coingecko:canton-network", value * 1e18);
+    } else if (
+      instrumentId === "USDCx" ||
+      instrumentId === CUSD_INSTRUMENT_ID
+    ) {
+      dailyFees.add("coingecko:usd-coin", value * 1e6);
+    }
+  }
+
+  // Phase 1: dailyUserFees mirrors dailyFees. Revenue split (LP/protocol/holders)
+  // intentionally omitted; will land when Send ships Phase 2 fee attribution.
+  return { dailyFees, dailyUserFees: dailyFees };
+};
+
+const methodology = {
+  Fees:
+    "All swap fees collected by Pool Party (24h), fetched from Pool Party's " +
+    "public API on Send Foundation's validator (api-mainnet.cantonwallet.com). " +
+    "CC fees priced via canton-network on CoinGecko; CUSD and USDCx fees " +
+    "priced as USDC ($1 stable proxy). Phase 2 will populate " +
+    "supplySideRevenue, protocolRevenue, and holdersRevenue once Send's " +
+    "per-swap fee attribution views are available.",
+  UserFees: "All fees paid by users on swaps.",
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  methodology,
+  adapter: {
+    [CHAIN.CANTON]: {
+      fetch,
+      start: "2026-04-30",
+    },
+  },
+};
+
+export default adapter;


### PR DESCRIPTION
## Summary

Adds two dimension adapters for Pool Party — the first AMM on Canton Network, built by Send Foundation:

- dexs/pool-party/index.ts — 24h spot/swap volume
- fees/pool-party/index.ts — 24h swap fees (totalFees only, Phase 1)

Both adapters consume Pool Party's new public API on Send Foundation's validator. Companion to the TVL adapter PR: DefiLlama/DefiLlama-Adapters#19041.

## Listing info

- Name: Pool Party
- Website: https://poolparty.fun/
- Twitter: https://x.com/Send (handle: `Send`)
- Chain: Canton
- Category: Dexes
- Logo: https://info.send.it/img/PoolParty_Icon.png

## Data source

Public, unauthenticated, KV-backed Cloudflare Worker:
https://api-mainnet.cantonwallet.com/canton/pool-party/public/v1

- 60 RPM/IP rate limit
- 5-minute snapshot cadence
- Cache-Control: public, max-age=300, s-maxage=900, stale-while-revalidate=3600
- Spec lives in Send's private monorepo (0xsend/canton-monorepo issue 3481, PR 3512); happy to share details if needed

## Methodology

Volume — fetches /volume?period=24h. The API returns per-token volumes summed across all pools; in an AMM each swap touches both sides of a pair, so the per-token sum is 2x the true single-side trading volume. The adapter halves before pricing.

Fees — fetches /fees?period=24h. Returns totalFees per token; not double-counted (fees collected once per swap in a single token). dailyUserFees mirrors dailyFees for now. supplySideRevenue, protocolRevenue, holdersRevenue are intentionally null per Send's Phase 1 spec — Phase 2 will populate these once their per-swap fee attribution views ship.

## Pricing

Pool Party returns three instrumentId keys:

- Amulet = Canton Coin (CC), priced via coingecko:canton-network (18-decimal atomic units, matches the existing wcc convention)
- USDCx = bridged USDC on Canton, priced as USDC ($1 stable proxy, 6-decimal atomic units)
- 481871d4-ca56-42a8-b2d3-4b7d28742946 = CUSD (Send's privacy stablecoin), priced as USDC ($1 stable proxy)

The CUSD UUID is hardcoded — Brale issues multiple instruments (CUSD + SBC) from the same issuer party, only CUSD is in scope. Unknown instrument IDs are silently skipped.

## Verification

```
curl -s 'https://api-mainnet.cantonwallet.com/canton/pool-party/public/v1/volume?period=24h' | jq
curl -s 'https://api-mainnet.cantonwallet.com/canton/pool-party/public/v1/fees?period=24h' | jq
```

Live numbers (latest snapshot): ~$640K rolling 24h volume after halving, ~$160 daily fees.

## Notes

- No new dependencies, no pnpm-lock.yaml changes.
- version: 2 adapters using the modern createBalances() pattern; DefiLlama prices client-side.
- start: '2026-04-30' — API deployment date.
- Phase 2 will land in a follow-up PR once Send ships per-swap fee attribution.