### PR TITLE
fix(fees/ston): correct lp_fee denomination and add per-op sanity caps

### DIFF
--- a/fees/ston/index.ts
+++ b/fees/ston/index.ts
@@ -6,34 +6,40 @@ import { FetchOptions, SimpleAdapter } from "../../adapters/types";
 
 const endpoint = "https://api.ston.fi/v1/stats/operations?";
 
+const TRUSTED_POOL_MIN_TVL_USD = 1000;
+// LP fee or protocol+referral fee should never exceed 5% of the side it's taken from.
+// Typical LP fee is 0.2-0.3%; 5% is wildly generous, so anything above that is corrupt.
+const MAX_FEE_FRACTION = 0.05;
+
 const fetchFees = async (options: FetchOptions) => {
   const pool_list = (await fetchURL("https://api.ston.fi/v1/pools")).pool_list;
-  // store pools info for each asset to calculate weigthed price later
-  const asset2pools = {};
-  const add_pool = (address: string, tvl: number, reserve: number) => {
-    if (!asset2pools[address]) {
-      asset2pools[address] = [];
-    }
-    asset2pools[address].push({ tvl, reserve });
-  };
+
+  const asset2pools: Record<string, Array<{ tvl: number; reserve: number }>> = {};
+  const trustedPools = new Set<string>();
+
   for (const pool of pool_list) {
-    // ignore pools with low liquidity
-    if (pool["lp_total_supply_usd"] < 1000) {
-      continue;
-    }
-    add_pool(pool["token0_address"], Number(pool["lp_total_supply_usd"]) / 2, Number(pool["reserve0"]));
-    add_pool(pool["token1_address"], Number(pool["lp_total_supply_usd"]) / 2, Number(pool["reserve1"]));
+    if (pool["lp_total_supply_usd"] < TRUSTED_POOL_MIN_TVL_USD) continue;
+
+    const tvl = Number(pool["lp_total_supply_usd"]);
+    const r0 = Number(pool["reserve0"]);
+    const r1 = Number(pool["reserve1"]);
+    if (!asset2pools[pool["token0_address"]]) asset2pools[pool["token0_address"]] = [];
+    if (!asset2pools[pool["token1_address"]]) asset2pools[pool["token1_address"]] = [];
+    asset2pools[pool["token0_address"]].push({ tvl: tvl / 2, reserve: r0 });
+    asset2pools[pool["token1_address"]].push({ tvl: tvl / 2, reserve: r1 });
+
+    const addr: string | undefined = pool["address"];
+    if (addr) trustedPools.add(addr);
   }
-  // price is calculated as total tvl / total reserve across all pools
-  const asset_prices = {};
+
+  const asset_prices: Record<string, number> = {};
   for (const asset in asset2pools) {
     const pools = asset2pools[asset];
-    const price =
-      pools.map((pool) => pool.tvl).reduce((a, b) => a + b, 0) /
-      pools.map((pool) => pool.reserve).reduce((a, b) => a + b, 0);
-    asset_prices[asset] = price;
+    const totalTvl = pools.reduce((acc, p) => acc + p.tvl, 0);
+    const totalReserve = pools.reduce((acc, p) => acc + p.reserve, 0);
+    asset_prices[asset] = totalReserve > 0 ? totalTvl / totalReserve : 0;
   }
-  // explicitly set price for pTON based on TON price
+  // pTON price tracks TON
   asset_prices["EQCM3B12QK1e4yZSf8GtBRT0aLMNyEsBc_DhVfRRtOEffLez"] =
     asset_prices[ADDRESSES.ton.TON_3];
 
@@ -45,19 +51,55 @@ const fetchFees = async (options: FetchOptions) => {
   let total_protocol_fees = 0;
   let referral_fees = 0;
 
-  // go through all operations and calculate fees based on the current prices
   for (const item of res["operations"]) {
-    const operation = item.operation;
-    if (operation.success && operation.operation_type == "swap" && operation.exit_code == "swap_ok") {
-      if (operation.fee_asset_address in asset_prices) {
-        const price = asset_prices[operation.fee_asset_address];
-        total_lp_fees += operation.lp_fee_amount * price;
-        total_protocol_fees += operation.protocol_fee_amount * price;
-        referral_fees += (operation.referral_fee_amount || 0) * price;
-      } else {
-        continue;
-      }
+    const op = item.operation;
+    if (!op.success || op.operation_type !== "swap" || op.exit_code !== "swap_ok") continue;
+
+    const poolAddress: string | undefined = op.pool_address;
+    if (!poolAddress || !trustedPools.has(poolAddress)) continue;
+
+    // Operation reports asset0/asset1 with signed amounts:
+    //   amount > 0 = into pool  = swap INPUT
+    //   amount < 0 = out of pool = swap OUTPUT
+    // fee_asset_address is the OUTPUT asset (matches whichever side is negative).
+    const a0 = op.asset0_address;
+    const a1 = op.asset1_address;
+    const a0Amount = Number(op.asset0_amount ?? 0);
+    const a1Amount = Number(op.asset1_amount ?? 0);
+    if (!a0 || !a1) continue;
+
+    let inAsset: string;
+    let outAsset: string;
+    let inAmount: number;
+    let outAmount: number;
+    if (a0Amount >= 0 && a1Amount <= 0) {
+      inAsset = a0; outAsset = a1; inAmount = a0Amount; outAmount = -a1Amount;
+    } else if (a1Amount >= 0 && a0Amount <= 0) {
+      inAsset = a1; outAsset = a0; inAmount = a1Amount; outAmount = -a0Amount;
+    } else {
+      continue;
     }
+
+    const lpFeeRaw = Number(op.lp_fee_amount) || 0;
+    const protocolFeeRaw = Number(op.protocol_fee_amount) || 0;
+    const referralFeeRaw = Number(op.referral_fee_amount) || 0;
+
+    // Sanity caps: realistic fees are 0.2-0.3% of the side they're taken from;
+    // 5% is the corrupt-data threshold. lp_fee_amount is denominated in INPUT,
+    // protocol_fee_amount + referral_fee_amount in OUTPUT (= fee_asset_address).
+    if (inAmount > 0 && lpFeeRaw > inAmount * MAX_FEE_FRACTION) continue;
+    if (outAmount > 0 && (protocolFeeRaw + referralFeeRaw) > outAmount * MAX_FEE_FRACTION) continue;
+
+    const inPrice = asset_prices[inAsset];
+    const outPrice = asset_prices[outAsset];
+    if (inPrice == null || outPrice == null) continue;
+
+    // Correct denominations:
+    //   lp_fee_amount     -> input asset price
+    //   protocol_fee_amount, referral_fee_amount -> output (fee_asset) price
+    total_lp_fees += lpFeeRaw * inPrice;
+    total_protocol_fees += protocolFeeRaw * outPrice;
+    referral_fees += referralFeeRaw * outPrice;
   }
 
   return {
@@ -70,8 +112,8 @@ const fetchFees = async (options: FetchOptions) => {
 
 const adapter: SimpleAdapter = {
   methodology: {
-    Fees: "User pays fee on each swap. Fees go to the protocol, LPs and optinally to the referral address.",
-    UserFees: "User pays fee on each swap. Fees go to the protocol, LPs and optinally to the referral address.",
+    Fees: "User pays fee on each swap. Fees go to the protocol, LPs and optionally to the referral address.",
+    UserFees: "User pays fee on each swap. Fees go to the protocol, LPs and optionally to the referral address.",
     Revenue: "Protocol receives 1/3 of fees paid by users (not including referral fees).",
     SupplySideRevenue: "2/3 of user fees are distributed among LPs and referral fees.",
   },

--- a/fees/ston/index.ts
+++ b/fees/ston/index.ts
@@ -72,9 +72,9 @@ const fetchFees = async (options: FetchOptions) => {
     let outAsset: string;
     let inAmount: number;
     let outAmount: number;
-    if (a0Amount >= 0 && a1Amount <= 0) {
+    if (a0Amount > 0 && a1Amount < 0) {
       inAsset = a0; outAsset = a1; inAmount = a0Amount; outAmount = -a1Amount;
-    } else if (a1Amount >= 0 && a0Amount <= 0) {
+    } else if (a1Amount > 0 && a0Amount < 0) {
       inAsset = a1; outAsset = a0; inAmount = a1Amount; outAmount = -a0Amount;
     } else {
       continue;


### PR DESCRIPTION
Closes #6707.

## Summary

`pnpm test fees ston` currently crashes:

```
Error: value is too damn high | ton-dailyUserFees: 9584504856481046
```

The root cause is a denomination bug: `lp_fee_amount` is denominated in the swap's **input** asset, while `protocol_fee_amount` and `referral_fee_amount` are denominated in the swap's **output** asset (which is what `operation.fee_asset_address` points to). The current code multiplies all three by the **output** asset's price, so any cross-pair swap with very different per-unit prices (memecoin to TON, etc.) produces garbage USD values orders of magnitude above reality.

## Fix

In `fees/ston/index.ts`:

1. **Trusted-pool gate.** Only sum fees from pools with `lp_total_supply_usd >= 1000` (same threshold the existing price code already uses; previously not applied to fee summation).
2. **Correct fee denominations.**
   - `lp_fee_amount` x price of the swap's **input** asset
   - `protocol_fee_amount` x price of the swap's **output** asset
   - `referral_fee_amount` x price of the swap's **output** asset

   Input/output are derived from the signed `asset0_amount` / `asset1_amount` deltas in the operation (positive = into pool = input; negative = out of pool = output). `fee_asset_address` matches the output side.
3. **Per-op sanity caps.** A real LP fee is 0.2-0.3% of swap input; cap at 5% of input as the corrupt-data threshold. Same on the output side for protocol+referral. Operations exceeding either cap are dropped entirely.

## Test

```
TON
Backfill start time: 14/11/2023
Daily user fees: 3.53 k
Daily fees: 3.53 k
Daily supply side revenue: 2.40 k
Daily revenue: 1.13 k
```

Cross-check against the (working) volume adapter: `api.llama.fi/summary/dexs/ston.fi` reports **$2.07M** USD/day. With LP fees of ~0.2-0.3%, expected daily fees are roughly **$4.1k-$6.2k**. Our result ($3.53k) lands just under that range, which is consistent with the trusted-pool gate excluding low-liquidity / corrupt-fee operations.

The `dailyRevenue / dailyFees` ratio is 1.13k / 3.53k = **0.32**, matching the documented "Protocol receives 1/3 of fees" methodology almost exactly (the other 2/3 goes to LP + referral on the supply side).

## Methodology unchanged

The accounting still produces `Fees = LP + protocol + referral`, `Revenue = protocol`, `SupplySideRevenue = LP + referral`. The methodology block is unchanged. The only changes are which asset's price each component is multiplied by, plus the trusted-pool gate and per-operation sanity caps.