### PR TITLE
Track nest credit fees and revenue

### DIFF
--- a/fees/nest-credit.ts
+++ b/fees/nest-credit.ts
@@ -1,0 +1,84 @@
+import { Adapter, FetchOptions, FetchResultV2 } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+
+// https://docs.nest.credit
+// Nest vaults use the BoringVault architecture on Plume and Ethereum
+const methodology = {
+  Fees: "Total yields generated from real-world asset strategies in Nest vaults.",
+  SupplySideRevenue: "All yields are distributed to vault depositors.",
+};
+
+interface IVault {
+  vault: string;
+  accountant: string;
+}
+
+// Vault contracts from https://docs.nest.credit/developers/smart-contracts
+const VAULTS: IVault[] = [
+  { vault: "0x593cCcA4c4bf58b7526a4C164cEEf4003C6388db", accountant: "0xe0CF451d6E373FF04e8eE3c50340F18AFa6421E1" }, // nAlpha
+  { vault: "0xe72fe64840f4ef80e3ec73a1c749491b5c938cb9", accountant: "0x0b738cd187872b265a689e8e4130c336e76892ec" }, // nTBILL
+  { vault: "0x9fbC367B9Bb966a2A537989817A088AFCaFFDC4c", accountant: "0xAdB076707AbED7D19E3A75d98E77FCDFa4c15D93" }, // vault 3
+  { vault: "0x11113Ff3a60C2450F4b22515cB760417259eE94B", accountant: "0xa67d20A49e6Fe68Cf97E556DB6b2f5DE1dF4dC2f" }, // nBasis
+  { vault: "0xbfc5770631641719cd1cf809d8325b146aed19de", accountant: "0xb00bbbd72a377a34eac434226dd3e0e12d12a55b" }, // vault 5
+  { vault: "0xa5f78b2a0ab85429d2dfbf8b60abc70f4cec066c", accountant: "0x486e0362b0641c0fca21cac2e317f6e21a8b19f3" }, // nCREDIT
+  { vault: "0x2A3e301dbd45c143DFbb7b1CE1C55bf0BBF161cb", accountant: "0xF76bC95969e5Aa32b7b95Bb4caAA1bcbB2dDcAB9" }, // vault 7
+  { vault: "0x29bF22381A5811deC89dC7b46A5Ce57aD02c0240", accountant: "0x7D218B7ce9EE5Ee4D500ba048240537b728E0d25" }, // vault 8
+  { vault: "0x119Dd7dAFf816f29D7eE47596ae5E4bdC4299165", accountant: "0x2Ed2f77a961fc92F73D1087786099c39C894Ed1D" }, // nOpal
+  { vault: "0x1639DcEc3ECE7F610F96a8935db6bCFfBCa2FBFb", accountant: "0x3D649799A16aEfadB3fb1033192182B0F9836b32" }, // vault 10
+];
+
+const abis = {
+  totalSupply: "uint256:totalSupply",
+  decimals: "uint8:decimals",
+  base: "address:base",
+  exchangeRateUpdated: "event ExchangeRateUpdated(uint96 oldRate, uint96 newRate, uint64 currentTime)",
+  getRateInQuoteSafe: "function getRateInQuoteSafe(address quote) view returns (uint256)",
+};
+
+const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
+  const dailyFees = options.createBalances();
+  const dailySupplySideRevenue = options.createBalances();
+
+  for (const { vault, accountant } of VAULTS) {
+    const [totalSupply, decimals, token] = await Promise.all([
+      options.api.call({ target: vault, abi: abis.totalSupply, permitFailure: true }),
+      options.api.call({ target: vault, abi: abis.decimals, permitFailure: true }),
+      options.api.call({ target: accountant, abi: abis.base, permitFailure: true }),
+    ]);
+    if (!totalSupply || !decimals || !token) continue;
+    const vaultRateBase = Number(10 ** Number(decimals));
+
+    // Track yield from exchange rate updates
+    const events = await options.getLogs({
+      eventAbi: abis.exchangeRateUpdated,
+      target: accountant,
+    });
+
+    for (const event of events) {
+      const oldRate = BigInt(event.oldRate);
+      const newRate = BigInt(event.newRate);
+      const growthRate = newRate > oldRate ? Number(newRate - oldRate) : 0;
+      if (growthRate > 0) {
+        const yieldAmount = Number(totalSupply) * growthRate / vaultRateBase;
+        dailyFees.add(token, yieldAmount);
+        dailySupplySideRevenue.add(token, yieldAmount);
+      }
+    }
+  }
+
+  return {
+    dailyFees,
+    dailySupplySideRevenue,
+  };
+};
+
+const adapter: Adapter = {
+  version: 2,
+  methodology,
+  adapter: {
+    [CHAIN.ETHEREUM]: { fetch, start: "2025-03-01" },
+    [CHAIN.PLUME]: { fetch, start: "2025-03-01" },
+  },
+};
+
+export default adapter;

--- a/fees/nest-credit.ts
+++ b/fees/nest-credit.ts
@@ -32,7 +32,6 @@ const abis = {
   decimals: "uint8:decimals",
   base: "address:base",
   exchangeRateUpdated: "event ExchangeRateUpdated(uint96 oldRate, uint96 newRate, uint64 currentTime)",
-  getRateInQuoteSafe: "function getRateInQuoteSafe(address quote) view returns (uint256)",
 };
 
 const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
@@ -45,6 +44,7 @@ const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
       options.api.call({ target: vault, abi: abis.decimals, permitFailure: true }),
       options.api.call({ target: accountant, abi: abis.base, permitFailure: true }),
     ]);
+
     if (!totalSupply || !decimals || !token) continue;
     const vaultRateBase = Number(10 ** Number(decimals));
 

--- a/fees/nest-credit.ts
+++ b/fees/nest-credit.ts
@@ -1,148 +1,156 @@
 import { Adapter, FetchOptions, FetchResultV2 } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
 import { METRIC } from "../helpers/metrics";
-import * as sdk from "@defillama/sdk";
-import { httpGet } from "../utils/fetchURL";
-
-// https://docs.nest.credit
-const methodology = {
-  Fees: "Total yields generated from real-world asset strategies in Nest vaults, including platform fees.",
-  Revenue: "Platform fees collected by Nest Credit protocol.",
-  ProtocolRevenue: "Platform fees collected by Nest Credit protocol.",
-  SupplySideRevenue: "Yields distributed to vault depositors after protocol fees.",
-};
-
-interface IVault {
-  vault: string;
-  accountant: string;
-}
+import { getConfig } from "../helpers/cache";
 
 const VAULTS_API = "https://api.nest.credit/v1/vaults";
 
-async function getVaults(): Promise<IVault[]> {
-  const { data } = await httpGet(VAULTS_API);
-  return data
-    .filter((v: any) => v.slug !== "nest-test-vault")
-    .map((v: any) => ({
-      vault: v.vaultAddress,
-      accountant: v.accountantAddress,
-    }));
-}
-
 const FEE_RATE_BASE = 1e4;
+const YEAR_IN_SECS = 365 * 24 * 60 * 60;
 
 const abis = {
-  totalSupply: "uint256:totalSupply",
-  decimals: "uint8:decimals",
-  base: "address:base",
-  exchangeRateUpdated: "event ExchangeRateUpdated(uint96 oldRate, uint96 newRate, uint64 currentTime)",
-  // V1: payoutAddress, feesOwedInBase, totalSharesLastUpdate, exchangeRate, upper, lower, lastUpdateTimestamp, isPaused, minimumUpdateDelay, platformFee
-  accountantStateV1: "function accountantState() view returns(address,uint128,uint128,uint96,uint16,uint16,uint64,bool,uint32,uint16)",
+    totalSupply: "uint256:totalSupply",
+    decimals: "uint8:decimals",
+    base: "address:base",
+    exchangeRateUpdated: "event ExchangeRateUpdated(uint96 oldRate, uint96 newRate, uint64 currentTime)",
+    // V1: payoutAddress, feesOwedInBase, totalSharesLastUpdate, exchangeRate, upper, lower, lastUpdateTimestamp, isPaused, minimumUpdateDelay, platformFee
+    accountantStateV1: "function accountantState() view returns(address,uint128,uint128,uint96,uint16,uint16,uint64,bool,uint32,uint16)",
 };
 
+const chainConfig: Record<string, { start: string, chainNameInApi: string }> = {
+    [CHAIN.ETHEREUM]: { start: "2025-03-01", chainNameInApi: "mainnet" },
+    [CHAIN.PLUME]: { start: "2025-03-01", chainNameInApi: "plume" },
+    [CHAIN.BSC]: { start: "2025-03-01", chainNameInApi: "bsc" },
+    [CHAIN.ARBITRUM]: { start: "2025-03-01", chainNameInApi: "arbitrum" },
+    [CHAIN.PLASMA]: { start: "2025-11-01", chainNameInApi: "plasma" },
+    [CHAIN.WC]: { start: "2025-12-17", chainNameInApi: "worldchain" },
+}
+
+async function prefetch() {
+    const { data } = await getConfig('nestcredit', VAULTS_API);
+    return data
+        .filter((v: any) => v.slug !== "nest-test-vault")
+        .map((v: any) => ({
+            vault: v.vaultAddress,
+            accountant: v.accountantAddress,
+            chains: Object.keys(v.chain),
+        }));
+}
+
 const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
-  const dailyFees = options.createBalances();
-  const dailySupplySideRevenue = options.createBalances();
-  const dailyProtocolRevenue = options.createBalances();
+    const dailyFees = options.createBalances();
+    const dailySupplySideRevenue = options.createBalances();
+    const dailyProtocolRevenue = options.createBalances();
 
-  const vaults = await getVaults();
+    const { chainNameInApi } = chainConfig[options.chain];
 
-  for (const { vault, accountant } of vaults) {
-    const [totalSupply, decimals, token] = await Promise.all([
-      options.api.call({ target: vault, abi: abis.totalSupply, permitFailure: true }),
-      options.api.call({ target: vault, abi: abis.decimals, permitFailure: true }),
-      options.api.call({ target: accountant, abi: abis.base, permitFailure: true }),
+    const vaults = options.preFetchedResults.filter((v: any) => v.chains.includes(chainNameInApi)).map((v: any) => (v.vault));
+    const accountants = options.preFetchedResults.filter((v: any) => v.chains.includes(chainNameInApi)).map((v: any) => (v.accountant));
+
+    const [totalSupplies, decimals, tokens, accountantStates] = await Promise.all([
+        options.api.multiCall({
+            abi: abis.totalSupply,
+            calls: vaults,
+            permitFailure: true,
+        }),
+        options.api.multiCall({
+            abi: abis.decimals,
+            calls: vaults,
+            permitFailure: true,
+        }),
+        options.api.multiCall({
+            abi: abis.base,
+            calls: accountants,
+            permitFailure: true,
+        }),
+        options.api.multiCall({
+            abi: abis.accountantStateV1,
+            calls: accountants,
+            permitFailure: true,
+        }),
     ]);
 
-    if (!totalSupply || !decimals || !token) continue;
-    const vaultRateBase = Number(10 ** Number(decimals));
-
-    // Track yield from exchange rate updates
-    const rawLogs = await options.getLogs({
-      eventAbi: abis.exchangeRateUpdated,
-      target: accountant,
-      entireLog: true,
+    const exchangeRateUpdatedLogs = await options.getLogs({
+        eventAbi: abis.exchangeRateUpdated,
+        targets: accountants,
+        flatten: false,
     });
 
-    for (const log of rawLogs) {
-      const { oldRate, newRate } = (log as any).args;
-      const growthRate = newRate > oldRate ? Number(newRate - oldRate) : 0;
-      if (growthRate > 0) {
-        const blockNumber = Number(log.blockNumber);
+    const timespan = options.toTimestamp - options.fromTimestamp;
 
-        const totalSupplyAtBlock = await sdk.api2.abi.call({
-          abi: abis.totalSupply,
-          target: vault,
-          block: blockNumber,
-          chain: options.chain,
-          permitFailure: true,
-        });
+    for (let i = 0; i < vaults.length; i++) {
+        const totalSupply = totalSupplies[i];
+        const decimal = decimals[i];
+        const token = tokens[i];
 
-        const supply = totalSupplyAtBlock || totalSupply;
-        const supplySideYield = Number(supply) * growthRate / vaultRateBase;
+        if (!totalSupply || !decimal || !token) continue;
+        const vaultRateBase = Number(10 ** Number(decimal));
 
-        dailyFees.add(token, supplySideYield, METRIC.ASSETS_YIELDS);
-        dailySupplySideRevenue.add(token, supplySideYield, METRIC.ASSETS_YIELDS);
-      }
+        for (const { oldRate, newRate } of exchangeRateUpdatedLogs[i]) {
+            const rateChange = Number(newRate - oldRate);
+            const supplySideYield = Number(totalSupply) * rateChange / vaultRateBase;
+
+            dailyFees.add(token, supplySideYield, METRIC.ASSETS_YIELDS);
+            dailySupplySideRevenue.add(token, supplySideYield, METRIC.ASSETS_YIELDS);
+        }
+
+        const accountantState = accountantStates[i];
+        if (!accountantState) continue;
+
+        const exchangeRate = Number(accountantState[3]);
+        const managementFeeRate = Number(accountantState[9]);
+
+        if (managementFeeRate > 0) {
+            const totalDeposited = Number(totalSupply) * exchangeRate / vaultRateBase;
+            const managementFee = totalDeposited * (managementFeeRate / FEE_RATE_BASE) * timespan / YEAR_IN_SECS;
+
+            dailyFees.add(token, managementFee, METRIC.MANAGEMENT_FEES);
+            dailyProtocolRevenue.add(token, managementFee, METRIC.MANAGEMENT_FEES);
+        }
     }
 
-    // Calculate platform fees from V1 accountantState
-    const accountantState = await options.api.call({
-      target: accountant,
-      abi: abis.accountantStateV1,
-      permitFailure: true,
-    });
-
-    if (accountantState) {
-      const exchangeRate = Number(accountantState[3]);
-      const platformFeeRate = Number(accountantState[9]);
-      if (platformFeeRate > 0) {
-        const totalDeposited = Number(totalSupply) * exchangeRate / vaultRateBase;
-        const yearInSecs = 365 * 24 * 60 * 60;
-        const timespan = options.toTimestamp - options.fromTimestamp;
-        const platformFee = totalDeposited * (platformFeeRate / FEE_RATE_BASE) * timespan / yearInSecs;
-
-        dailyFees.add(token, platformFee, METRIC.MANAGEMENT_FEES);
-        dailyProtocolRevenue.add(token, platformFee, METRIC.MANAGEMENT_FEES);
-      }
-    }
-  }
-
-  return {
-    dailyFees,
-    dailyRevenue: dailyProtocolRevenue,
-    dailyProtocolRevenue,
-    dailySupplySideRevenue,
-  };
+    return {
+        dailyFees,
+        dailyRevenue: dailyProtocolRevenue,
+        dailyProtocolRevenue,
+        dailySupplySideRevenue,
+    };
 };
 
 const breakdownMethodology = {
-  Fees: {
-    [METRIC.ASSETS_YIELDS]: "Yields generated from real-world asset strategies in Nest vaults.",
-    [METRIC.MANAGEMENT_FEES]: "Annualized platform fees charged on total assets under management.",
-  },
-  Revenue: {
-    [METRIC.MANAGEMENT_FEES]: "Platform fees collected by Nest Credit protocol.",
-  },
-  ProtocolRevenue: {
-    [METRIC.MANAGEMENT_FEES]: "Platform fees collected by Nest Credit protocol.",
-  },
-  SupplySideRevenue: {
-    [METRIC.ASSETS_YIELDS]: "Yields distributed to vault depositors after protocol fees.",
-  },
+    Fees: {
+        [METRIC.ASSETS_YIELDS]: "Yields generated from real-world asset strategies in Nest vaults.",
+        [METRIC.MANAGEMENT_FEES]: "Annualized platform fees charged on total assets under management.",
+    },
+    Revenue: {
+        [METRIC.MANAGEMENT_FEES]: "Platform fees collected by Nest Credit protocol.",
+    },
+    ProtocolRevenue: {
+        [METRIC.MANAGEMENT_FEES]: "Platform fees collected by Nest Credit protocol.",
+    },
+    SupplySideRevenue: {
+        [METRIC.ASSETS_YIELDS]: "Yields distributed to vault depositors after protocol fees.",
+    },
+};
+
+// https://docs.nest.credit
+const methodology = {
+    Fees: "Total yields generated from real-world asset strategies in Nest vaults, including platform fees.",
+    Revenue: "Platform fees collected by Nest Credit protocol.",
+    ProtocolRevenue: "Platform fees collected by Nest Credit protocol.",
+    SupplySideRevenue: "Yields distributed to vault depositors after protocol fees.",
 };
 
 const adapter: Adapter = {
-  version: 2,
-  methodology,
-  breakdownMethodology,
-  adapter: {
-    [CHAIN.ETHEREUM]: { fetch, start: "2025-03-01" },
-    [CHAIN.PLUME]: { fetch, start: "2025-03-01" },
-    [CHAIN.BSC]: { fetch, start: "2025-03-01" },
-    [CHAIN.ARBITRUM]: { fetch, start: "2025-03-01" },
-    [CHAIN.PLASMA]: { fetch, start: "2025-11-01" },
-  },
+    version: 2,
+    prefetch,
+    fetch,
+    pullHourly: true,
+    methodology,
+    breakdownMethodology,
+    adapter: chainConfig,
+    doublecounted: true,
+    allowNegativeValue: true,
 };
 
 export default adapter;

--- a/fees/nest-credit.ts
+++ b/fees/nest-credit.ts
@@ -1,11 +1,15 @@
 import { Adapter, FetchOptions, FetchResultV2 } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
+import { METRIC } from "../helpers/metrics";
+import * as sdk from "@defillama/sdk";
+import { httpGet } from "../utils/fetchURL";
 
 // https://docs.nest.credit
-// Nest vaults use the BoringVault architecture on Plume and Ethereum
 const methodology = {
-  Fees: "Total yields generated from real-world asset strategies in Nest vaults.",
-  SupplySideRevenue: "All yields are distributed to vault depositors.",
+  Fees: "Total yields generated from real-world asset strategies in Nest vaults, including platform fees.",
+  Revenue: "Platform fees collected by Nest Credit protocol.",
+  ProtocolRevenue: "Platform fees collected by Nest Credit protocol.",
+  SupplySideRevenue: "Yields distributed to vault depositors after protocol fees.",
 };
 
 interface IVault {
@@ -13,32 +17,37 @@ interface IVault {
   accountant: string;
 }
 
-// Vault contracts from https://docs.nest.credit/developers/smart-contracts
-const VAULTS: IVault[] = [
-  { vault: "0x593cCcA4c4bf58b7526a4C164cEEf4003C6388db", accountant: "0xe0CF451d6E373FF04e8eE3c50340F18AFa6421E1" }, // nAlpha
-  { vault: "0xe72fe64840f4ef80e3ec73a1c749491b5c938cb9", accountant: "0x0b738cd187872b265a689e8e4130c336e76892ec" }, // nTBILL
-  { vault: "0x9fbC367B9Bb966a2A537989817A088AFCaFFDC4c", accountant: "0xAdB076707AbED7D19E3A75d98E77FCDFa4c15D93" }, // vault 3
-  { vault: "0x11113Ff3a60C2450F4b22515cB760417259eE94B", accountant: "0xa67d20A49e6Fe68Cf97E556DB6b2f5DE1dF4dC2f" }, // nBasis
-  { vault: "0xbfc5770631641719cd1cf809d8325b146aed19de", accountant: "0xb00bbbd72a377a34eac434226dd3e0e12d12a55b" }, // vault 5
-  { vault: "0xa5f78b2a0ab85429d2dfbf8b60abc70f4cec066c", accountant: "0x486e0362b0641c0fca21cac2e317f6e21a8b19f3" }, // nCREDIT
-  { vault: "0x2A3e301dbd45c143DFbb7b1CE1C55bf0BBF161cb", accountant: "0xF76bC95969e5Aa32b7b95Bb4caAA1bcbB2dDcAB9" }, // vault 7
-  { vault: "0x29bF22381A5811deC89dC7b46A5Ce57aD02c0240", accountant: "0x7D218B7ce9EE5Ee4D500ba048240537b728E0d25" }, // vault 8
-  { vault: "0x119Dd7dAFf816f29D7eE47596ae5E4bdC4299165", accountant: "0x2Ed2f77a961fc92F73D1087786099c39C894Ed1D" }, // nOpal
-  { vault: "0x1639DcEc3ECE7F610F96a8935db6bCFfBCa2FBFb", accountant: "0x3D649799A16aEfadB3fb1033192182B0F9836b32" }, // vault 10
-];
+const VAULTS_API = "https://api.nest.credit/v1/vaults";
+
+async function getVaults(): Promise<IVault[]> {
+  const { data } = await httpGet(VAULTS_API);
+  return data
+    .filter((v: any) => v.slug !== "nest-test-vault")
+    .map((v: any) => ({
+      vault: v.vaultAddress,
+      accountant: v.accountantAddress,
+    }));
+}
+
+const FEE_RATE_BASE = 1e4;
 
 const abis = {
   totalSupply: "uint256:totalSupply",
   decimals: "uint8:decimals",
   base: "address:base",
   exchangeRateUpdated: "event ExchangeRateUpdated(uint96 oldRate, uint96 newRate, uint64 currentTime)",
+  // V1: payoutAddress, feesOwedInBase, totalSharesLastUpdate, exchangeRate, upper, lower, lastUpdateTimestamp, isPaused, minimumUpdateDelay, platformFee
+  accountantStateV1: "function accountantState() view returns(address,uint128,uint128,uint96,uint16,uint16,uint64,bool,uint32,uint16)",
 };
 
 const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
   const dailyFees = options.createBalances();
   const dailySupplySideRevenue = options.createBalances();
+  const dailyProtocolRevenue = options.createBalances();
 
-  for (const { vault, accountant } of VAULTS) {
+  const vaults = await getVaults();
+
+  for (const { vault, accountant } of vaults) {
     const [totalSupply, decimals, token] = await Promise.all([
       options.api.call({ target: vault, abi: abis.totalSupply, permitFailure: true }),
       options.api.call({ target: vault, abi: abis.decimals, permitFailure: true }),
@@ -49,35 +58,90 @@ const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
     const vaultRateBase = Number(10 ** Number(decimals));
 
     // Track yield from exchange rate updates
-    const events = await options.getLogs({
+    const rawLogs = await options.getLogs({
       eventAbi: abis.exchangeRateUpdated,
       target: accountant,
+      entireLog: true,
     });
 
-    for (const event of events) {
-      const oldRate = BigInt(event.oldRate);
-      const newRate = BigInt(event.newRate);
+    for (const log of rawLogs) {
+      const { oldRate, newRate } = (log as any).args;
       const growthRate = newRate > oldRate ? Number(newRate - oldRate) : 0;
       if (growthRate > 0) {
-        const yieldAmount = Number(totalSupply) * growthRate / vaultRateBase;
-        dailyFees.add(token, yieldAmount);
-        dailySupplySideRevenue.add(token, yieldAmount);
+        const blockNumber = Number(log.blockNumber);
+
+        const totalSupplyAtBlock = await sdk.api2.abi.call({
+          abi: abis.totalSupply,
+          target: vault,
+          block: blockNumber,
+          chain: options.chain,
+          permitFailure: true,
+        });
+
+        const supply = totalSupplyAtBlock || totalSupply;
+        const supplySideYield = Number(supply) * growthRate / vaultRateBase;
+
+        dailyFees.add(token, supplySideYield, METRIC.ASSETS_YIELDS);
+        dailySupplySideRevenue.add(token, supplySideYield, METRIC.ASSETS_YIELDS);
+      }
+    }
+
+    // Calculate platform fees from V1 accountantState
+    const accountantState = await options.api.call({
+      target: accountant,
+      abi: abis.accountantStateV1,
+      permitFailure: true,
+    });
+
+    if (accountantState) {
+      const exchangeRate = Number(accountantState[3]);
+      const platformFeeRate = Number(accountantState[9]);
+      if (platformFeeRate > 0) {
+        const totalDeposited = Number(totalSupply) * exchangeRate / vaultRateBase;
+        const yearInSecs = 365 * 24 * 60 * 60;
+        const timespan = options.toTimestamp - options.fromTimestamp;
+        const platformFee = totalDeposited * (platformFeeRate / FEE_RATE_BASE) * timespan / yearInSecs;
+
+        dailyFees.add(token, platformFee, METRIC.MANAGEMENT_FEES);
+        dailyProtocolRevenue.add(token, platformFee, METRIC.MANAGEMENT_FEES);
       }
     }
   }
 
   return {
     dailyFees,
+    dailyRevenue: dailyProtocolRevenue,
+    dailyProtocolRevenue,
     dailySupplySideRevenue,
   };
+};
+
+const breakdownMethodology = {
+  Fees: {
+    [METRIC.ASSETS_YIELDS]: "Yields generated from real-world asset strategies in Nest vaults.",
+    [METRIC.MANAGEMENT_FEES]: "Annualized platform fees charged on total assets under management.",
+  },
+  Revenue: {
+    [METRIC.MANAGEMENT_FEES]: "Platform fees collected by Nest Credit protocol.",
+  },
+  ProtocolRevenue: {
+    [METRIC.MANAGEMENT_FEES]: "Platform fees collected by Nest Credit protocol.",
+  },
+  SupplySideRevenue: {
+    [METRIC.ASSETS_YIELDS]: "Yields distributed to vault depositors after protocol fees.",
+  },
 };
 
 const adapter: Adapter = {
   version: 2,
   methodology,
+  breakdownMethodology,
   adapter: {
     [CHAIN.ETHEREUM]: { fetch, start: "2025-03-01" },
     [CHAIN.PLUME]: { fetch, start: "2025-03-01" },
+    [CHAIN.BSC]: { fetch, start: "2025-03-01" },
+    [CHAIN.ARBITRUM]: { fetch, start: "2025-03-01" },
+    [CHAIN.PLASMA]: { fetch, start: "2025-11-01" },
   },
 };
 


### PR DESCRIPTION
### Summary                                                                                                       
                                                                                                                
  Track Nest Credit fees and revenue across Ethereum and Plume chains.                                    
                                                                                                                
  Nest vaults use the BoringVault architecture. The adapter tracks yield generated by each vault through   
  ExchangeRateUpdated events emitted by the Accountant contracts. When the exchange rate increases (share price 
  goes up), the yield is calculated as totalSupply * (newRate - oldRate) / rateBase.
                                                                                                                
  Fee structure: Nest currently charges 0% protocol fees — all yield goes to vault depositors , 10 vaults are tracked including nAlpha, nTBILL, nCREDIT, nBasis, and nOpal, with contract addresses sourced from the official docs.                                                                               
                                                                                                                
  Chains: Ethereum and Plume (same contract addresses on both chains)
  
  fixes #6696