### PR TITLE
fees: Add Jade adapter

### DIFF
--- a/fees/jade/index.ts
+++ b/fees/jade/index.ts
@@ -1,0 +1,43 @@
+import {
+  Dependencies,
+  FetchOptions,
+  SimpleAdapter,
+} from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import { oreHelperCountSolBalanceDiff } from "../ore";
+
+const fetch: any = async (_a: any, _b: any, options: FetchOptions) => {
+  const dailyFees = await oreHelperCountSolBalanceDiff(
+    options,
+    "F4Uwd5sQT8go5r6iiejrVc2iurYSc2dA4RKvX3cLB8e3"
+  );
+
+  const dailyProtocolRevenue = dailyFees.clone(0.01);
+  const dailyHoldersRevenue = dailyFees.clone(0.99);
+
+  return {
+    dailyFees,
+    dailyRevenue: dailyFees,
+    dailyProtocolRevenue,
+    dailyHoldersRevenue,
+  };
+};
+
+const adapter: SimpleAdapter = {
+  version: 1,
+  fetch,
+  chains: [CHAIN.SOLANA],
+  start: "2026-04-30",
+  dependencies: [Dependencies.DUNE],
+  methodology: {
+    Fees:
+      "Counts SOL inbound to Jade's Treasury PDA F4Uwd5sQT8go5r6iiejrVc2iurYSc2dA4RKvX3cLB8e3, populated each round-reset with the SOL miners deployed on the Jade board.",
+    Revenue: "All collected SOL fees count as revenue.",
+    ProtocolRevenue:
+      "1% of revenue is allocated to the protocol fee collector.",
+    HoldersRevenue:
+      "99% of revenue funds JADE buyback-and-burn, distributing value to JADE stakers.",
+  },
+};
+
+export default adapter;

--- a/fees/jade/index.ts
+++ b/fees/jade/index.ts
@@ -1,12 +1,8 @@
-import {
-  Dependencies,
-  FetchOptions,
-  SimpleAdapter,
-} from "../../adapters/types";
+import { Dependencies, FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 import { oreHelperCountSolBalanceDiff } from "../ore";
 
-const fetch: any = async (options: FetchOptions) => {
+const fetch: any = async (_a: any, _b: any, options: FetchOptions) => {
   const dailyFees = await oreHelperCountSolBalanceDiff(
     options,
     "F4Uwd5sQT8go5r6iiejrVc2iurYSc2dA4RKvX3cLB8e3"
@@ -27,21 +23,18 @@ const fetch: any = async (options: FetchOptions) => {
 };
 
 const adapter: SimpleAdapter = {
-  version: 2,
+  version: 1,
   fetch,
   chains: [CHAIN.SOLANA],
   start: "2026-04-30",
   dependencies: [Dependencies.DUNE],
+  isExpensiveAdapter: true,
   methodology: {
-    Fees:
-      "Counts SOL inbound to Jade's Treasury PDA F4Uwd5sQT8go5r6iiejrVc2iurYSc2dA4RKvX3cLB8e3, populated each round-reset with the SOL miners deployed on the Jade board.",
+    Fees: "Counts SOL inbound to Jade's Treasury PDA F4Uwd5sQT8go5r6iiejrVc2iurYSc2dA4RKvX3cLB8e3, populated each round-reset with the SOL miners deployed on the Jade board.",
     Revenue: "1% of collected SOL fees, allocated to the protocol fee collector.",
-    ProtocolRevenue:
-      "1% of fees is allocated to the protocol fee collector.",
-    SupplySideRevenue:
-      "99% of fees funds JADE buyback-and-burn, distributed to JADE stakers.",
-    HoldersRevenue:
-      "99% of fees funds JADE buyback-and-burn, distributed to JADE stakers.",
+    ProtocolRevenue: "1% of fees is allocated to the protocol fee collector.",
+    SupplySideRevenue: "99% of fees funds JADE buyback-and-burn, distributed to JADE stakers.",
+    HoldersRevenue: "99% of fees funds JADE buyback-and-burn, distributed to JADE stakers.",
   },
 };
 

--- a/fees/jade/index.ts
+++ b/fees/jade/index.ts
@@ -6,25 +6,28 @@ import {
 import { CHAIN } from "../../helpers/chains";
 import { oreHelperCountSolBalanceDiff } from "../ore";
 
-const fetch: any = async (_a: any, _b: any, options: FetchOptions) => {
+const fetch: any = async (options: FetchOptions) => {
   const dailyFees = await oreHelperCountSolBalanceDiff(
     options,
     "F4Uwd5sQT8go5r6iiejrVc2iurYSc2dA4RKvX3cLB8e3"
   );
 
+  const dailyRevenue = dailyFees.clone(0.01);
   const dailyProtocolRevenue = dailyFees.clone(0.01);
+  const dailySupplySideRevenue = dailyFees.clone(0.99);
   const dailyHoldersRevenue = dailyFees.clone(0.99);
 
   return {
     dailyFees,
-    dailyRevenue: dailyFees,
+    dailyRevenue,
     dailyProtocolRevenue,
+    dailySupplySideRevenue,
     dailyHoldersRevenue,
   };
 };
 
 const adapter: SimpleAdapter = {
-  version: 1,
+  version: 2,
   fetch,
   chains: [CHAIN.SOLANA],
   start: "2026-04-30",
@@ -32,11 +35,13 @@ const adapter: SimpleAdapter = {
   methodology: {
     Fees:
       "Counts SOL inbound to Jade's Treasury PDA F4Uwd5sQT8go5r6iiejrVc2iurYSc2dA4RKvX3cLB8e3, populated each round-reset with the SOL miners deployed on the Jade board.",
-    Revenue: "All collected SOL fees count as revenue.",
+    Revenue: "1% of collected SOL fees, allocated to the protocol fee collector.",
     ProtocolRevenue:
-      "1% of revenue is allocated to the protocol fee collector.",
+      "1% of fees is allocated to the protocol fee collector.",
+    SupplySideRevenue:
+      "99% of fees funds JADE buyback-and-burn, distributed to JADE stakers.",
     HoldersRevenue:
-      "99% of revenue funds JADE buyback-and-burn, distributing value to JADE stakers.",
+      "99% of fees funds JADE buyback-and-burn, distributed to JADE stakers.",
   },
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@clickhouse/client": "^1.15.0",
-        "@defillama/sdk": "^5.0.211",
+        "@defillama/sdk": "^5.0.192",
         "@supercharge/promise-pool": "^3.1.0",
         "@types/async-retry": "^1.4.8",
         "async-retry": "^1.3.3",
@@ -1134,24 +1133,6 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@clickhouse/client": {
-      "version": "1.18.3",
-      "resolved": "https://registry.npmjs.org/@clickhouse/client/-/client-1.18.3.tgz",
-      "integrity": "sha512-340ngdYktL8PLUBK2QKSwe0o02tYfZSz1mSn1uXCEU8TxHvwh9pnQxElf9YHumDGj5gX/IdgxPsJTGMs82Hgug==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@clickhouse/client-common": "1.18.3"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/@clickhouse/client-common": {
-      "version": "1.18.3",
-      "resolved": "https://registry.npmjs.org/@clickhouse/client-common/-/client-common-1.18.3.tgz",
-      "integrity": "sha512-3axzO3zvrsGT5PzDenxgWscltYCNRDbhaHWUgdsmcM9OnW/VnZn9EarOcZogr9P82Z0mQh+Jd2x+p2K4TFD2fA==",
-      "license": "Apache-2.0"
-    },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
@@ -1165,9 +1146,9 @@
       }
     },
     "node_modules/@defillama/sdk": {
-      "version": "5.0.211",
-      "resolved": "https://registry.npmjs.org/@defillama/sdk/-/sdk-5.0.211.tgz",
-      "integrity": "sha512-o4C8hPaRrNLEX31idd9O0GtXPvQYAyUR+n+g5gHd6F73705zInatbrLOJ0ZTaJ5AwwqMx9CXbdi6qKnrc5hVbA==",
+      "version": "5.0.192",
+      "resolved": "https://registry.npmjs.org/@defillama/sdk/-/sdk-5.0.192.tgz",
+      "integrity": "sha512-ClUxV00l+eunuVuVfhaFOwj7s3eZIUGn4xx78EZGvFdXUD1fFf4qAmwTr2sOOOzB67FmdLlj5G7bZM5yeK2YNA==",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.400.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@defillama/sdk": "^5.0.192",
+        "@clickhouse/client": "^1.15.0",
+        "@defillama/sdk": "^5.0.211",
         "@supercharge/promise-pool": "^3.1.0",
         "@types/async-retry": "^1.4.8",
         "async-retry": "^1.3.3",
@@ -1133,6 +1134,24 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/@clickhouse/client": {
+      "version": "1.18.3",
+      "resolved": "https://registry.npmjs.org/@clickhouse/client/-/client-1.18.3.tgz",
+      "integrity": "sha512-340ngdYktL8PLUBK2QKSwe0o02tYfZSz1mSn1uXCEU8TxHvwh9pnQxElf9YHumDGj5gX/IdgxPsJTGMs82Hgug==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@clickhouse/client-common": "1.18.3"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@clickhouse/client-common": {
+      "version": "1.18.3",
+      "resolved": "https://registry.npmjs.org/@clickhouse/client-common/-/client-common-1.18.3.tgz",
+      "integrity": "sha512-3axzO3zvrsGT5PzDenxgWscltYCNRDbhaHWUgdsmcM9OnW/VnZn9EarOcZogr9P82Z0mQh+Jd2x+p2K4TFD2fA==",
+      "license": "Apache-2.0"
+    },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
@@ -1146,9 +1165,9 @@
       }
     },
     "node_modules/@defillama/sdk": {
-      "version": "5.0.192",
-      "resolved": "https://registry.npmjs.org/@defillama/sdk/-/sdk-5.0.192.tgz",
-      "integrity": "sha512-ClUxV00l+eunuVuVfhaFOwj7s3eZIUGn4xx78EZGvFdXUD1fFf4qAmwTr2sOOOzB67FmdLlj5G7bZM5yeK2YNA==",
+      "version": "5.0.211",
+      "resolved": "https://registry.npmjs.org/@defillama/sdk/-/sdk-5.0.211.tgz",
+      "integrity": "sha512-o4C8hPaRrNLEX31idd9O0GtXPvQYAyUR+n+g5gHd6F73705zInatbrLOJ0ZTaJ5AwwqMx9CXbdi6qKnrc5hVbA==",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.400.0",


### PR DESCRIPTION
Adds a fees adapter for Jade (Solana-native ORE fork).

**Companion listing PR:** https://github.com/DefiLlama/DefiLlama-Adapters/pull/19055

## What this adapter tracks

Jade's revenue model mirrors ORE/GODL: SOL is "deployed" by miners onto a board each round, and when the round resets, that SOL flows on-chain into the Jade Treasury PDA `F4Uwd5sQT8go5r6iiejrVc2iurYSc2dA4RKvX3cLB8e3`.

This adapter reuses ORE's `oreHelperCountSolBalanceDiff` Dune helper, pointed at Jade's Treasury PDA, with the same 1% protocol / 99% holders split GODL uses.

- `Fees`: SOL inbound to the Treasury PDA per day
- `Revenue` = Fees
- `ProtocolRevenue` = 1% (admin fee collector)
- `HoldersRevenue` = 99% (funds JADE buyback-and-burn → distributed to JADE stakers)

`start: "2026-04-30"` — Jade mainnet launch date.

## Verification

- Treasury PDA verified on-chain: seeds `[b"treasury"]` under program `Bk5DGR9UcaBoYDNm5SZPCLGxoa6JhDayxivoAa36cgiJ` → `F4Uwd5sQT8go5r6iiejrVc2iurYSc2dA4RKvX3cLB8e3`.
- Pattern is a near-exact mirror of `fees/godl/index.ts`.
- No new npm dependencies added; no `pnpm-lock.yaml` changes.