### PR TITLE
Add Matrixdock fees adapter

### DIFF
--- a/fees/matrixdock-gold/index.ts
+++ b/fees/matrixdock-gold/index.ts
@@ -1,0 +1,144 @@
+import { ethers } from "ethers";
+import { Adapter, FetchOptions } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import ADDRESSES from "../../helpers/coreAssets.json";
+
+// Matrixdock XAUm sources:
+// XAUm FAQ / fees: https://matrixdock.gitbook.io/matrixdock-docs/english/gold-token-xaum/faq
+// XAUm contract addresses: https://matrixdock.gitbook.io/matrixdock-docs/english/gold-token-xaum/smart-contract/contract-address
+
+// XAUm Ethereum MTokenMain address is from the Matrixdock contract-address docs.
+const XAUM = "0x2103E845C5E135493Bb6c2A4f0B8651956eA8682";
+// Deployment/start block supplied from verified contract deployment history.
+const XAUM_START_BLOCK = 20624233;
+const XAUM_START_TIMESTAMP = 1724803200; // 2024-08-28
+// XAUm FAQ: redemption fee is 0.25%.
+const XAUM_REDEMPTION_FEE_BPS = 25;
+const BPS = 10_000n;
+const REDEEM_EVENT =
+  "event Redeem(address indexed customer, uint256 amount, bytes data)";
+const TRANSFER_EVENT =
+  "event Transfer(address indexed from, address indexed to, uint256 value)";
+const XAUM_REDEMPTION_FEES = "XAUm Redemption Fees";
+
+const getFromBlock = async (options: FetchOptions, productStartBlock: number) => {
+  return Math.max(await options.getFromBlock(), productStartBlock);
+};
+
+const addRedemptionFees = async (
+  options: FetchOptions,
+  balances: {
+    dailyFees: ReturnType<FetchOptions["createBalances"]>;
+    dailyRevenue: ReturnType<FetchOptions["createBalances"]>;
+  },
+) => {
+  const fromBlock = await getFromBlock(options, XAUM_START_BLOCK);
+  const operator = (await options.api.call({
+    target: XAUM,
+    // Matrixdock MToken redeem burns from operator and emits customer in Redeem.
+    abi: "function operator() view returns (address)",
+  })).toLowerCase();
+
+  const [redeemLogs, burnLogs] = await Promise.all([
+    options.getLogs({
+      target: XAUM,
+      eventAbi: REDEEM_EVENT,
+      fromBlock,
+      entireLog: true,
+      parseLog: true,
+      skipIndexer: true,
+    }),
+    options.getLogs({
+      target: XAUM,
+      eventAbi: TRANSFER_EVENT,
+      fromBlock,
+      topics: [
+        null as any,
+        null as any,
+        ethers.zeroPadValue(ADDRESSES.null, 32),
+      ],
+      entireLog: true,
+      parseLog: true,
+      skipIndexer: true,
+    }),
+  ]);
+
+  const burnsByTxAndOperator = new Map<string, bigint>();
+  burnLogs.forEach((log) => {
+    if (!log.transactionHash) return;
+    const txHash = log.transactionHash.toLowerCase();
+    const from = log.args.from.toLowerCase();
+    if (from !== operator) return;
+    const key = `${txHash}:${from}`;
+    const previous = burnsByTxAndOperator.get(key) ?? 0n;
+    burnsByTxAndOperator.set(key, previous + BigInt(log.args.value.toString()));
+  });
+
+  const redeemsByTxAndOperator = new Map<string, bigint>();
+  redeemLogs.forEach((log) => {
+    const amount = BigInt(log.args.amount.toString());
+    const txHash = log.transactionHash?.toLowerCase();
+    if (!txHash) {
+      throw new Error(`XAUm Redeem burn safety check failed for tx ${txHash ?? "unknown"}`);
+    }
+
+    const key = `${txHash}:${operator}`;
+    const previous = redeemsByTxAndOperator.get(key) ?? 0n;
+    redeemsByTxAndOperator.set(key, previous + amount);
+  });
+
+  redeemsByTxAndOperator.forEach((amount, key) => {
+    const txHash = key.split(":")[0];
+    if (burnsByTxAndOperator.get(key) !== amount) {
+      throw new Error(`XAUm Redeem burn safety check failed for tx ${txHash}`);
+    }
+
+    const redemptionFee = amount * BigInt(XAUM_REDEMPTION_FEE_BPS) / BPS;
+    balances.dailyFees.add(XAUM, redemptionFee, XAUM_REDEMPTION_FEES);
+    balances.dailyRevenue.add(XAUM, redemptionFee, XAUM_REDEMPTION_FEES);
+  });
+};
+
+const fetch = async (options: FetchOptions) => {
+  const dailyFees = options.createBalances();
+  const dailyRevenue = options.createBalances();
+
+  if (options.toTimestamp >= XAUM_START_TIMESTAMP) {
+    await addRedemptionFees(options, { dailyFees, dailyRevenue });
+  }
+
+  return {
+    dailyFees,
+    dailyRevenue,
+    dailyProtocolRevenue: dailyRevenue,
+  };
+};
+
+const adapter: Adapter = {
+  version: 2,
+  pullHourly: true,
+  adapter: {
+    [CHAIN.ETHEREUM]: {
+      fetch,
+      start: "2024-08-28",
+    },
+  },
+  methodology: {
+    Fees: "XAUm redemption fees.",
+    Revenue: "XAUm redemption fees accounted as protocol revenue.",
+    ProtocolRevenue: "Same as Revenue.",
+  },
+  breakdownMethodology: {
+    Fees: {
+      [XAUM_REDEMPTION_FEES]: "0.25% fee charged on XAUm redemption orders.",
+    },
+    Revenue: {
+      [XAUM_REDEMPTION_FEES]: "0.25% XAUm redemption fee, validated against the matching burn Transfer from the MToken operator in the same transaction.",
+    },
+    ProtocolRevenue: {
+      [XAUM_REDEMPTION_FEES]: "XAUm redemption fee accounted as protocol revenue.",
+    },
+  },
+};
+
+export default adapter;

--- a/fees/matrixdock-gold/index.ts
+++ b/fees/matrixdock-gold/index.ts
@@ -1,40 +1,38 @@
-import { Adapter, FetchOptions } from "../../adapters/types";
+import type { FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 import { METRIC } from "../../helpers/metrics";
+import { httpGet } from "../../utils/fetchURL";
 
 // Matrixdock XAUm sources:
 // XAUm FAQ / fees: https://matrixdock.gitbook.io/matrixdock-docs/english/gold-token-xaum/faq
 // XAUm contract addresses: https://matrixdock.gitbook.io/matrixdock-docs/english/gold-token-xaum/smart-contract/contract-address
+// XAUm mint/redeem transparency API: https://www.matrixdock.com/transparency/on-chain-transactions
 
-// XAUm Ethereum MTokenMain address is from the Matrixdock contract-address docs.
-const XAUM = "0x2103E845C5E135493Bb6c2A4f0B8651956eA8682";
 // XAUm FAQ: redemption fee is 0.25%.
-const XAUM_REDEMPTION_FEE_BPS = 25;
-const BPS = 10_000n;
-const XAUM_PRICE_START_TIMESTAMP = 1733184000;
-const EVENTS = {
-  redeem: "event Redeem(address indexed customer, uint256 amount, bytes data)",
+const REDEMPTION_FEE = 0.0025;
+const API = "https://www.matrixdock.com/rwa/anon/website/api/v1/transparency/issue-redeem/list?symbol=XAUM";
+
+const getRecords = async (options: FetchOptions) => {
+  const items = [];
+  for (let offset = 0; ; offset += 1000) {
+    const { data } = await httpGet(`${API}&offset=${offset}&limit=1000`);
+    for (const record of data.items) {
+      const timestamp = record.tx_time / 1000;
+      if (timestamp < options.fromTimestamp) return items;
+      if (record.record_type === "REDEEM" && timestamp < options.toTimestamp) items.push(record);
+    }
+    if (offset + data.items.length >= data.total) return items;
+  }
 };
 
 const fetch = async (options: FetchOptions) => {
   const dailyFees = options.createBalances();
   const dailyRevenue = options.createBalances();
-
-  const redeemLogs = await options.getLogs({
-    target: XAUM,
-    eventAbi: EVENTS.redeem,
-    fromBlock: await options.getFromBlock(),
-  });
-
-  for (const log of redeemLogs) {
-    const fee = BigInt(log.amount.toString()) * BigInt(XAUM_REDEMPTION_FEE_BPS) / BPS;
-    if (options.toTimestamp < XAUM_PRICE_START_TIMESTAMP) {
-      dailyFees.addCGToken("pax-gold", Number(fee) / 1e18, METRIC.MINT_REDEEM_FEES);
-      dailyRevenue.addCGToken("pax-gold", Number(fee) / 1e18, METRIC.MINT_REDEEM_FEES);
-    } else {
-      dailyFees.add(XAUM, fee, METRIC.MINT_REDEEM_FEES);
-      dailyRevenue.add(XAUM, fee, METRIC.MINT_REDEEM_FEES);
-    }
+  const records = await getRecords(options);
+  for (const record of records) {
+    const fee = Number(record.fine_weight) * REDEMPTION_FEE;
+    dailyFees.addCGToken("pax-gold", fee, METRIC.MINT_REDEEM_FEES);
+    dailyRevenue.addCGToken("pax-gold", fee, METRIC.MINT_REDEEM_FEES);
   }
 
   return {
@@ -44,26 +42,25 @@ const fetch = async (options: FetchOptions) => {
   };
 };
 
-const adapter: Adapter = {
+const adapter: SimpleAdapter = {
   version: 2,
-  pullHourly: true,
   adapter: {
-    [CHAIN.ETHEREUM]: {
+    [CHAIN.CHAIN_GLOBAL]: {
       fetch,
       start: "2024-08-27",
     },
   },
   methodology: {
-    Fees: "XAUm redemption fees.",
+    Fees: "XAUm redemption fees from Matrixdock's mint/redeem transparency records.",
     Revenue: "XAUm redemption fees accounted as protocol revenue.",
     ProtocolRevenue: "XAUm redemption fees accounted as protocol revenue.",
   },
   breakdownMethodology: {
     Fees: {
-      [METRIC.MINT_REDEEM_FEES]: "0.25% fee charged on XAUm redemption orders.",
+      [METRIC.MINT_REDEEM_FEES]: "0.25% fee charged on XAUm redemption orders across supported networks.",
     },
     Revenue: {
-      [METRIC.MINT_REDEEM_FEES]: "0.25% XAUm redemption fee from Redeem events.",
+      [METRIC.MINT_REDEEM_FEES]: "0.25% XAUm redemption fee from Matrixdock mint/redeem transparency records.",
     },
     ProtocolRevenue: {
       [METRIC.MINT_REDEEM_FEES]: "XAUm redemption fee accounted as protocol revenue.",

--- a/fees/matrixdock-gold/index.ts
+++ b/fees/matrixdock-gold/index.ts
@@ -1,7 +1,6 @@
-import { ethers } from "ethers";
 import { Adapter, FetchOptions } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
-import ADDRESSES from "../../helpers/coreAssets.json";
+import { METRIC } from "../../helpers/metrics";
 
 // Matrixdock XAUm sources:
 // XAUm FAQ / fees: https://matrixdock.gitbook.io/matrixdock-docs/english/gold-token-xaum/faq
@@ -9,102 +8,33 @@ import ADDRESSES from "../../helpers/coreAssets.json";
 
 // XAUm Ethereum MTokenMain address is from the Matrixdock contract-address docs.
 const XAUM = "0x2103E845C5E135493Bb6c2A4f0B8651956eA8682";
-// Deployment/start block supplied from verified contract deployment history.
-const XAUM_START_BLOCK = 20624233;
-const XAUM_START_TIMESTAMP = 1724803200; // 2024-08-28
 // XAUm FAQ: redemption fee is 0.25%.
 const XAUM_REDEMPTION_FEE_BPS = 25;
 const BPS = 10_000n;
-const REDEEM_EVENT =
-  "event Redeem(address indexed customer, uint256 amount, bytes data)";
-const TRANSFER_EVENT =
-  "event Transfer(address indexed from, address indexed to, uint256 value)";
-const XAUM_REDEMPTION_FEES = "XAUm Redemption Fees";
-
-const getFromBlock = async (options: FetchOptions, productStartBlock: number) => {
-  return Math.max(await options.getFromBlock(), productStartBlock);
-};
-
-const addRedemptionFees = async (
-  options: FetchOptions,
-  balances: {
-    dailyFees: ReturnType<FetchOptions["createBalances"]>;
-    dailyRevenue: ReturnType<FetchOptions["createBalances"]>;
-  },
-) => {
-  const fromBlock = await getFromBlock(options, XAUM_START_BLOCK);
-  const operator = (await options.api.call({
-    target: XAUM,
-    // Matrixdock MToken redeem burns from operator and emits customer in Redeem.
-    abi: "function operator() view returns (address)",
-  })).toLowerCase();
-
-  const [redeemLogs, burnLogs] = await Promise.all([
-    options.getLogs({
-      target: XAUM,
-      eventAbi: REDEEM_EVENT,
-      fromBlock,
-      entireLog: true,
-      parseLog: true,
-      skipIndexer: true,
-    }),
-    options.getLogs({
-      target: XAUM,
-      eventAbi: TRANSFER_EVENT,
-      fromBlock,
-      topics: [
-        null as any,
-        null as any,
-        ethers.zeroPadValue(ADDRESSES.null, 32),
-      ],
-      entireLog: true,
-      parseLog: true,
-      skipIndexer: true,
-    }),
-  ]);
-
-  const burnsByTxAndOperator = new Map<string, bigint>();
-  burnLogs.forEach((log) => {
-    if (!log.transactionHash) return;
-    const txHash = log.transactionHash.toLowerCase();
-    const from = log.args.from.toLowerCase();
-    if (from !== operator) return;
-    const key = `${txHash}:${from}`;
-    const previous = burnsByTxAndOperator.get(key) ?? 0n;
-    burnsByTxAndOperator.set(key, previous + BigInt(log.args.value.toString()));
-  });
-
-  const redeemsByTxAndOperator = new Map<string, bigint>();
-  redeemLogs.forEach((log) => {
-    const amount = BigInt(log.args.amount.toString());
-    const txHash = log.transactionHash?.toLowerCase();
-    if (!txHash) {
-      throw new Error(`XAUm Redeem burn safety check failed for tx ${txHash ?? "unknown"}`);
-    }
-
-    const key = `${txHash}:${operator}`;
-    const previous = redeemsByTxAndOperator.get(key) ?? 0n;
-    redeemsByTxAndOperator.set(key, previous + amount);
-  });
-
-  redeemsByTxAndOperator.forEach((amount, key) => {
-    const txHash = key.split(":")[0];
-    if (burnsByTxAndOperator.get(key) !== amount) {
-      throw new Error(`XAUm Redeem burn safety check failed for tx ${txHash}`);
-    }
-
-    const redemptionFee = amount * BigInt(XAUM_REDEMPTION_FEE_BPS) / BPS;
-    balances.dailyFees.add(XAUM, redemptionFee, XAUM_REDEMPTION_FEES);
-    balances.dailyRevenue.add(XAUM, redemptionFee, XAUM_REDEMPTION_FEES);
-  });
+const XAUM_PRICE_START_TIMESTAMP = 1733184000;
+const EVENTS = {
+  redeem: "event Redeem(address indexed customer, uint256 amount, bytes data)",
 };
 
 const fetch = async (options: FetchOptions) => {
   const dailyFees = options.createBalances();
   const dailyRevenue = options.createBalances();
 
-  if (options.toTimestamp >= XAUM_START_TIMESTAMP) {
-    await addRedemptionFees(options, { dailyFees, dailyRevenue });
+  const redeemLogs = await options.getLogs({
+    target: XAUM,
+    eventAbi: EVENTS.redeem,
+    fromBlock: await options.getFromBlock(),
+  });
+
+  for (const log of redeemLogs) {
+    const fee = BigInt(log.amount.toString()) * BigInt(XAUM_REDEMPTION_FEE_BPS) / BPS;
+    if (options.toTimestamp < XAUM_PRICE_START_TIMESTAMP) {
+      dailyFees.addCGToken("pax-gold", Number(fee) / 1e18, METRIC.MINT_REDEEM_FEES);
+      dailyRevenue.addCGToken("pax-gold", Number(fee) / 1e18, METRIC.MINT_REDEEM_FEES);
+    } else {
+      dailyFees.add(XAUM, fee, METRIC.MINT_REDEEM_FEES);
+      dailyRevenue.add(XAUM, fee, METRIC.MINT_REDEEM_FEES);
+    }
   }
 
   return {
@@ -120,23 +50,23 @@ const adapter: Adapter = {
   adapter: {
     [CHAIN.ETHEREUM]: {
       fetch,
-      start: "2024-08-28",
+      start: "2024-08-27",
     },
   },
   methodology: {
     Fees: "XAUm redemption fees.",
     Revenue: "XAUm redemption fees accounted as protocol revenue.",
-    ProtocolRevenue: "Same as Revenue.",
+    ProtocolRevenue: "XAUm redemption fees accounted as protocol revenue.",
   },
   breakdownMethodology: {
     Fees: {
-      [XAUM_REDEMPTION_FEES]: "0.25% fee charged on XAUm redemption orders.",
+      [METRIC.MINT_REDEEM_FEES]: "0.25% fee charged on XAUm redemption orders.",
     },
     Revenue: {
-      [XAUM_REDEMPTION_FEES]: "0.25% XAUm redemption fee, validated against the matching burn Transfer from the MToken operator in the same transaction.",
+      [METRIC.MINT_REDEEM_FEES]: "0.25% XAUm redemption fee from Redeem events.",
     },
     ProtocolRevenue: {
-      [XAUM_REDEMPTION_FEES]: "XAUm redemption fee accounted as protocol revenue.",
+      [METRIC.MINT_REDEEM_FEES]: "XAUm redemption fee accounted as protocol revenue.",
     },
   },
 };

--- a/fees/matrixdock-silver/index.ts
+++ b/fees/matrixdock-silver/index.ts
@@ -1,0 +1,221 @@
+import { ethers } from "ethers";
+import { Adapter, FetchOptions } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import ADDRESSES from "../../helpers/coreAssets.json";
+
+// Matrixdock XAGm sources:
+// XAGm FAQ / fees: https://matrixdock.gitbook.io/matrixdock-docs/english/silver-token-xagm/faq
+// XAGm token design / reconcileSupply fee model: https://matrixdock.gitbook.io/matrixdock-docs/english/silver-token-xagm/token-design
+// XAGm contract addresses: https://matrixdock.gitbook.io/matrixdock-docs/english/silver-token-xagm/smart-contract/contract-address
+
+// XAGm Ethereum MTokenMain address is from the Matrixdock contract-address docs.
+const XAGM = "0x123ffe0a3C62878dcbee2742227dc8990058d9E1";
+// Deployment/start block supplied from verified contract deployment history.
+const XAGM_START_BLOCK = 24618377;
+const XAGM_START_TIMESTAMP = 1773014400; // 2026-03-09
+// XAGm FAQ: redemption fee is 0.50%.
+const XAGM_REDEMPTION_FEE_BPS = 50;
+const BPS = 10_000n;
+const RECONCILE_SUPPLY_EVENT =
+  "event ReconcileSupply(uint64 lastReconcileTime, uint64 thisReconcileTime, uint256 amount)";
+const REDEEM_EVENT =
+  "event Redeem(address indexed customer, uint256 amount, bytes data)";
+const TRANSFER_EVENT =
+  "event Transfer(address indexed from, address indexed to, uint256 value)";
+
+const XAGM_CUSTODY_FEES = "XAGm Custody Fees";
+const XAGM_REDEMPTION_FEES = "XAGm Redemption Fees";
+
+const getFromBlock = async (options: FetchOptions, productStartBlock: number) => {
+  return Math.max(await options.getFromBlock(), productStartBlock);
+};
+
+const addXagmCustodyFees = async (
+  options: FetchOptions,
+  balances: {
+    dailyFees: ReturnType<FetchOptions["createBalances"]>;
+    dailyRevenue: ReturnType<FetchOptions["createBalances"]>;
+  },
+) => {
+  const feeCollector = (await options.api.call({
+    target: XAGM,
+    // XAGm MToken exposes feeCollector; reconcileSupply mints custody fees to it.
+    abi: "function feeCollector() view returns (address)",
+  })).toLowerCase();
+
+  const fromBlock = await getFromBlock(options, XAGM_START_BLOCK);
+  const [reconcileLogs, transferLogs] = await Promise.all([
+    options.getLogs({
+      target: XAGM,
+      eventAbi: RECONCILE_SUPPLY_EVENT,
+      fromBlock,
+      entireLog: true,
+      parseLog: true,
+      skipIndexer: true,
+    }),
+    options.getLogs({
+      target: XAGM,
+      eventAbi: TRANSFER_EVENT,
+      fromBlock,
+      topics: [
+        null as any,
+        ethers.zeroPadValue(ADDRESSES.null, 32),
+        ethers.zeroPadValue(feeCollector, 32),
+      ],
+      entireLog: true,
+      parseLog: true,
+      skipIndexer: true,
+    }),
+  ]);
+
+  const feeMintsByTx = new Map<string, bigint>();
+  transferLogs.forEach((log) => {
+    if (!log.transactionHash) return;
+    const txHash = log.transactionHash.toLowerCase();
+    const previous = feeMintsByTx.get(txHash) ?? 0n;
+    feeMintsByTx.set(txHash, previous + BigInt(log.args.value.toString()));
+  });
+
+  const reconcileMintsByTx = new Map<string, bigint>();
+  reconcileLogs.forEach((log) => {
+    const amount = BigInt(log.args.amount.toString());
+    const txHash = log.transactionHash?.toLowerCase();
+    if (!txHash) {
+      throw new Error(`XAGm ReconcileSupply fee mint safety check failed for tx ${txHash ?? "unknown"}`);
+    }
+
+    const previous = reconcileMintsByTx.get(txHash) ?? 0n;
+    reconcileMintsByTx.set(txHash, previous + amount);
+  });
+
+  reconcileMintsByTx.forEach((amount, txHash) => {
+    if (feeMintsByTx.get(txHash) !== amount) {
+      throw new Error(`XAGm ReconcileSupply fee mint safety check failed for tx ${txHash}`);
+    }
+
+    balances.dailyFees.add(XAGM, amount, XAGM_CUSTODY_FEES);
+    balances.dailyRevenue.add(XAGM, amount, XAGM_CUSTODY_FEES);
+  });
+};
+
+const addRedemptionFees = async (
+  options: FetchOptions,
+  balances: {
+    dailyFees: ReturnType<FetchOptions["createBalances"]>;
+    dailyRevenue: ReturnType<FetchOptions["createBalances"]>;
+  },
+) => {
+  const fromBlock = await getFromBlock(options, XAGM_START_BLOCK);
+  const operator = (await options.api.call({
+    target: XAGM,
+    // Matrixdock MToken redeem burns from operator and emits customer in Redeem.
+    abi: "function operator() view returns (address)",
+  })).toLowerCase();
+
+  const [redeemLogs, burnLogs] = await Promise.all([
+    options.getLogs({
+      target: XAGM,
+      eventAbi: REDEEM_EVENT,
+      fromBlock,
+      entireLog: true,
+      parseLog: true,
+      skipIndexer: true,
+    }),
+    options.getLogs({
+      target: XAGM,
+      eventAbi: TRANSFER_EVENT,
+      fromBlock,
+      topics: [
+        null as any,
+        null as any,
+        ethers.zeroPadValue(ADDRESSES.null, 32),
+      ],
+      entireLog: true,
+      parseLog: true,
+      skipIndexer: true,
+    }),
+  ]);
+
+  const burnsByTxAndOperator = new Map<string, bigint>();
+  burnLogs.forEach((log) => {
+    if (!log.transactionHash) return;
+    const txHash = log.transactionHash.toLowerCase();
+    const from = log.args.from.toLowerCase();
+    if (from !== operator) return;
+    const key = `${txHash}:${from}`;
+    const previous = burnsByTxAndOperator.get(key) ?? 0n;
+    burnsByTxAndOperator.set(key, previous + BigInt(log.args.value.toString()));
+  });
+
+  const redeemsByTxAndOperator = new Map<string, bigint>();
+  redeemLogs.forEach((log) => {
+    const amount = BigInt(log.args.amount.toString());
+    const txHash = log.transactionHash?.toLowerCase();
+    if (!txHash) {
+      throw new Error(`XAGm Redeem burn safety check failed for tx ${txHash ?? "unknown"}`);
+    }
+
+    const key = `${txHash}:${operator}`;
+    const previous = redeemsByTxAndOperator.get(key) ?? 0n;
+    redeemsByTxAndOperator.set(key, previous + amount);
+  });
+
+  redeemsByTxAndOperator.forEach((amount, key) => {
+    const txHash = key.split(":")[0];
+    if (burnsByTxAndOperator.get(key) !== amount) {
+      throw new Error(`XAGm Redeem burn safety check failed for tx ${txHash}`);
+    }
+
+    const redemptionFee = amount * BigInt(XAGM_REDEMPTION_FEE_BPS) / BPS;
+    balances.dailyFees.add(XAGM, redemptionFee, XAGM_REDEMPTION_FEES);
+    balances.dailyRevenue.add(XAGM, redemptionFee, XAGM_REDEMPTION_FEES);
+  });
+};
+
+const fetch = async (options: FetchOptions) => {
+  const dailyFees = options.createBalances();
+  const dailyRevenue = options.createBalances();
+
+  if (options.toTimestamp >= XAGM_START_TIMESTAMP) {
+    await addXagmCustodyFees(options, { dailyFees, dailyRevenue });
+    await addRedemptionFees(options, { dailyFees, dailyRevenue });
+  }
+
+  return {
+    dailyFees,
+    dailyRevenue,
+    dailyProtocolRevenue: dailyRevenue,
+  };
+};
+
+const adapter: Adapter = {
+  version: 2,
+  pullHourly: true,
+  adapter: {
+    [CHAIN.ETHEREUM]: {
+      fetch,
+      start: "2026-03-09",
+    },
+  },
+  methodology: {
+    Fees: "XAGm custody fees minted by reconcileSupply and XAGm redemption fees.",
+    Revenue: "XAGm custody and redemption fees accounted as protocol revenue.",
+    ProtocolRevenue: "Same as Revenue.",
+  },
+  breakdownMethodology: {
+    Fees: {
+      [XAGM_CUSTODY_FEES]: "XAGm custody fees minted to the fee collector during ReconcileSupply events.",
+      [XAGM_REDEMPTION_FEES]: "0.50% fee charged on XAGm redemption orders.",
+    },
+    Revenue: {
+      [XAGM_CUSTODY_FEES]: "XAGm custody fees minted to the fee collector during ReconcileSupply events, validated against the matching mint Transfer in the same transaction.",
+      [XAGM_REDEMPTION_FEES]: "0.50% XAGm redemption fee, validated against the matching burn Transfer from the MToken operator in the same transaction.",
+    },
+    ProtocolRevenue: {
+      [XAGM_CUSTODY_FEES]: "XAGm custody fee accounted as protocol revenue.",
+      [XAGM_REDEMPTION_FEES]: "XAGm redemption fee accounted as protocol revenue.",
+    },
+  },
+};
+
+export default adapter;

--- a/fees/matrixdock-silver/index.ts
+++ b/fees/matrixdock-silver/index.ts
@@ -1,7 +1,6 @@
-import { ethers } from "ethers";
 import { Adapter, FetchOptions } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
-import ADDRESSES from "../../helpers/coreAssets.json";
+import { METRIC } from "../../helpers/metrics";
 
 // Matrixdock XAGm sources:
 // XAGm FAQ / fees: https://matrixdock.gitbook.io/matrixdock-docs/english/silver-token-xagm/faq
@@ -10,175 +9,48 @@ import ADDRESSES from "../../helpers/coreAssets.json";
 
 // XAGm Ethereum MTokenMain address is from the Matrixdock contract-address docs.
 const XAGM = "0x123ffe0a3C62878dcbee2742227dc8990058d9E1";
-// Deployment/start block supplied from verified contract deployment history.
-const XAGM_START_BLOCK = 24618377;
-const XAGM_START_TIMESTAMP = 1773014400; // 2026-03-09
+const XAGM_MINTER = "0xdA29ad84566C3bfdEe6009F6c0f6bEb6686A71A2";
 // XAGm FAQ: redemption fee is 0.50%.
 const XAGM_REDEMPTION_FEE_BPS = 50;
 const BPS = 10_000n;
-const RECONCILE_SUPPLY_EVENT =
-  "event ReconcileSupply(uint64 lastReconcileTime, uint64 thisReconcileTime, uint256 amount)";
-const REDEEM_EVENT =
-  "event Redeem(address indexed customer, uint256 amount, bytes data)";
-const TRANSFER_EVENT =
-  "event Transfer(address indexed from, address indexed to, uint256 value)";
-
-const XAGM_CUSTODY_FEES = "XAGm Custody Fees";
-const XAGM_REDEMPTION_FEES = "XAGm Redemption Fees";
-
-const getFromBlock = async (options: FetchOptions, productStartBlock: number) => {
-  return Math.max(await options.getFromBlock(), productStartBlock);
-};
-
-const addXagmCustodyFees = async (
-  options: FetchOptions,
-  balances: {
-    dailyFees: ReturnType<FetchOptions["createBalances"]>;
-    dailyRevenue: ReturnType<FetchOptions["createBalances"]>;
-  },
-) => {
-  const feeCollector = (await options.api.call({
-    target: XAGM,
-    // XAGm MToken exposes feeCollector; reconcileSupply mints custody fees to it.
-    abi: "function feeCollector() view returns (address)",
-  })).toLowerCase();
-
-  const fromBlock = await getFromBlock(options, XAGM_START_BLOCK);
-  const [reconcileLogs, transferLogs] = await Promise.all([
-    options.getLogs({
-      target: XAGM,
-      eventAbi: RECONCILE_SUPPLY_EVENT,
-      fromBlock,
-      entireLog: true,
-      parseLog: true,
-      skipIndexer: true,
-    }),
-    options.getLogs({
-      target: XAGM,
-      eventAbi: TRANSFER_EVENT,
-      fromBlock,
-      topics: [
-        null as any,
-        ethers.zeroPadValue(ADDRESSES.null, 32),
-        ethers.zeroPadValue(feeCollector, 32),
-      ],
-      entireLog: true,
-      parseLog: true,
-      skipIndexer: true,
-    }),
-  ]);
-
-  const feeMintsByTx = new Map<string, bigint>();
-  transferLogs.forEach((log) => {
-    if (!log.transactionHash) return;
-    const txHash = log.transactionHash.toLowerCase();
-    const previous = feeMintsByTx.get(txHash) ?? 0n;
-    feeMintsByTx.set(txHash, previous + BigInt(log.args.value.toString()));
-  });
-
-  const reconcileMintsByTx = new Map<string, bigint>();
-  reconcileLogs.forEach((log) => {
-    const amount = BigInt(log.args.amount.toString());
-    const txHash = log.transactionHash?.toLowerCase();
-    if (!txHash) {
-      throw new Error(`XAGm ReconcileSupply fee mint safety check failed for tx ${txHash ?? "unknown"}`);
-    }
-
-    const previous = reconcileMintsByTx.get(txHash) ?? 0n;
-    reconcileMintsByTx.set(txHash, previous + amount);
-  });
-
-  reconcileMintsByTx.forEach((amount, txHash) => {
-    if (feeMintsByTx.get(txHash) !== amount) {
-      throw new Error(`XAGm ReconcileSupply fee mint safety check failed for tx ${txHash}`);
-    }
-
-    balances.dailyFees.add(XAGM, amount, XAGM_CUSTODY_FEES);
-    balances.dailyRevenue.add(XAGM, amount, XAGM_CUSTODY_FEES);
-  });
-};
-
-const addRedemptionFees = async (
-  options: FetchOptions,
-  balances: {
-    dailyFees: ReturnType<FetchOptions["createBalances"]>;
-    dailyRevenue: ReturnType<FetchOptions["createBalances"]>;
-  },
-) => {
-  const fromBlock = await getFromBlock(options, XAGM_START_BLOCK);
-  const operator = (await options.api.call({
-    target: XAGM,
-    // Matrixdock MToken redeem burns from operator and emits customer in Redeem.
-    abi: "function operator() view returns (address)",
-  })).toLowerCase();
-
-  const [redeemLogs, burnLogs] = await Promise.all([
-    options.getLogs({
-      target: XAGM,
-      eventAbi: REDEEM_EVENT,
-      fromBlock,
-      entireLog: true,
-      parseLog: true,
-      skipIndexer: true,
-    }),
-    options.getLogs({
-      target: XAGM,
-      eventAbi: TRANSFER_EVENT,
-      fromBlock,
-      topics: [
-        null as any,
-        null as any,
-        ethers.zeroPadValue(ADDRESSES.null, 32),
-      ],
-      entireLog: true,
-      parseLog: true,
-      skipIndexer: true,
-    }),
-  ]);
-
-  const burnsByTxAndOperator = new Map<string, bigint>();
-  burnLogs.forEach((log) => {
-    if (!log.transactionHash) return;
-    const txHash = log.transactionHash.toLowerCase();
-    const from = log.args.from.toLowerCase();
-    if (from !== operator) return;
-    const key = `${txHash}:${from}`;
-    const previous = burnsByTxAndOperator.get(key) ?? 0n;
-    burnsByTxAndOperator.set(key, previous + BigInt(log.args.value.toString()));
-  });
-
-  const redeemsByTxAndOperator = new Map<string, bigint>();
-  redeemLogs.forEach((log) => {
-    const amount = BigInt(log.args.amount.toString());
-    const txHash = log.transactionHash?.toLowerCase();
-    if (!txHash) {
-      throw new Error(`XAGm Redeem burn safety check failed for tx ${txHash ?? "unknown"}`);
-    }
-
-    const key = `${txHash}:${operator}`;
-    const previous = redeemsByTxAndOperator.get(key) ?? 0n;
-    redeemsByTxAndOperator.set(key, previous + amount);
-  });
-
-  redeemsByTxAndOperator.forEach((amount, key) => {
-    const txHash = key.split(":")[0];
-    if (burnsByTxAndOperator.get(key) !== amount) {
-      throw new Error(`XAGm Redeem burn safety check failed for tx ${txHash}`);
-    }
-
-    const redemptionFee = amount * BigInt(XAGM_REDEMPTION_FEE_BPS) / BPS;
-    balances.dailyFees.add(XAGM, redemptionFee, XAGM_REDEMPTION_FEES);
-    balances.dailyRevenue.add(XAGM, redemptionFee, XAGM_REDEMPTION_FEES);
-  });
+const EVENTS = {
+  reconcileSupply: "event ReconcileSupply(uint64 lastReconcileTime, uint64 thisReconcileTime, uint256 amount)",
+  redeem: "event Redeem(address indexed customer, uint256 amount, bytes data)",
+  redeemRequest: "event RedeemRequest(address indexed transferredToken, address indexed forToken, address indexed requestor, address pool, uint256 amount, uint256 preprice, uint256 slippage, bytes extraData)",
 };
 
 const fetch = async (options: FetchOptions) => {
   const dailyFees = options.createBalances();
   const dailyRevenue = options.createBalances();
+  const fromBlock = await options.getFromBlock();
 
-  if (options.toTimestamp >= XAGM_START_TIMESTAMP) {
-    await addXagmCustodyFees(options, { dailyFees, dailyRevenue });
-    await addRedemptionFees(options, { dailyFees, dailyRevenue });
+  const reconcileSupplyLogs = await options.getLogs({
+    target: XAGM,
+    eventAbi: EVENTS.reconcileSupply,
+    fromBlock,
+  });
+
+  for (const log of reconcileSupplyLogs) {
+    const amount = BigInt(log.amount.toString());
+    dailyFees.add(XAGM, amount, METRIC.MANAGEMENT_FEES);
+    dailyRevenue.add(XAGM, amount, METRIC.MANAGEMENT_FEES);
+  }
+
+  const redeemRequestLogs = await options.getLogs({
+    target: XAGM_MINTER,
+    eventAbi: EVENTS.redeemRequest,
+    fromBlock,
+  });
+  const redeemLogs = await options.getLogs({
+    target: XAGM,
+    eventAbi: EVENTS.redeem,
+    fromBlock,
+  });
+
+  for (const log of redeemRequestLogs.concat(redeemLogs)) {
+    const fee = BigInt(log.amount.toString()) * BigInt(XAGM_REDEMPTION_FEE_BPS) / BPS;
+    dailyFees.add(XAGM, fee, METRIC.MINT_REDEEM_FEES);
+    dailyRevenue.add(XAGM, fee, METRIC.MINT_REDEEM_FEES);
   }
 
   return {
@@ -200,20 +72,20 @@ const adapter: Adapter = {
   methodology: {
     Fees: "XAGm custody fees minted by reconcileSupply and XAGm redemption fees.",
     Revenue: "XAGm custody and redemption fees accounted as protocol revenue.",
-    ProtocolRevenue: "Same as Revenue.",
+    ProtocolRevenue: "XAGm custody and redemption fees accounted as protocol revenue.",
   },
   breakdownMethodology: {
     Fees: {
-      [XAGM_CUSTODY_FEES]: "XAGm custody fees minted to the fee collector during ReconcileSupply events.",
-      [XAGM_REDEMPTION_FEES]: "0.50% fee charged on XAGm redemption orders.",
+      [METRIC.MANAGEMENT_FEES]: "XAGm custody fees from ReconcileSupply events.",
+      [METRIC.MINT_REDEEM_FEES]: "0.50% fee charged on XAGm redemption orders.",
     },
     Revenue: {
-      [XAGM_CUSTODY_FEES]: "XAGm custody fees minted to the fee collector during ReconcileSupply events, validated against the matching mint Transfer in the same transaction.",
-      [XAGM_REDEMPTION_FEES]: "0.50% XAGm redemption fee, validated against the matching burn Transfer from the MToken operator in the same transaction.",
+      [METRIC.MANAGEMENT_FEES]: "XAGm custody fees from ReconcileSupply events.",
+      [METRIC.MINT_REDEEM_FEES]: "0.50% XAGm redemption fee from minter RedeemRequest events.",
     },
     ProtocolRevenue: {
-      [XAGM_CUSTODY_FEES]: "XAGm custody fee accounted as protocol revenue.",
-      [XAGM_REDEMPTION_FEES]: "XAGm redemption fee accounted as protocol revenue.",
+      [METRIC.MANAGEMENT_FEES]: "XAGm custody fee accounted as protocol revenue.",
+      [METRIC.MINT_REDEEM_FEES]: "XAGm redemption fee accounted as protocol revenue.",
     },
   },
 };

--- a/fees/matrixdock-silver/index.ts
+++ b/fees/matrixdock-silver/index.ts
@@ -1,90 +1,155 @@
-import { Adapter, FetchOptions } from "../../adapters/types";
+import type { FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { Dependencies } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
+import { queryDuneSql } from "../../helpers/dune";
 import { METRIC } from "../../helpers/metrics";
+import { httpGet } from "../../utils/fetchURL";
 
 // Matrixdock XAGm sources:
 // XAGm FAQ / fees: https://matrixdock.gitbook.io/matrixdock-docs/english/silver-token-xagm/faq
-// XAGm token design / reconcileSupply fee model: https://matrixdock.gitbook.io/matrixdock-docs/english/silver-token-xagm/token-design
-// XAGm contract addresses: https://matrixdock.gitbook.io/matrixdock-docs/english/silver-token-xagm/smart-contract/contract-address
+// XAGm token design / FRS fee model: https://matrixdock.gitbook.io/matrixdock-docs/english/silver-token-xagm/token-design
+// XAGm mint/redeem transparency API: https://www.matrixdock.com/transparency/on-chain-transactions
 
-// XAGm Ethereum MTokenMain address is from the Matrixdock contract-address docs.
-const XAGM = "0x123ffe0a3C62878dcbee2742227dc8990058d9E1";
-const XAGM_MINTER = "0xdA29ad84566C3bfdEe6009F6c0f6bEb6686A71A2";
-// XAGm FAQ: redemption fee is 0.50%.
-const XAGM_REDEMPTION_FEE_BPS = 50;
-const BPS = 10_000n;
-const EVENTS = {
-  reconcileSupply: "event ReconcileSupply(uint64 lastReconcileTime, uint64 thisReconcileTime, uint256 amount)",
-  redeem: "event Redeem(address indexed customer, uint256 amount, bytes data)",
-  redeemRequest: "event RedeemRequest(address indexed transferredToken, address indexed forToken, address indexed requestor, address pool, uint256 amount, uint256 preprice, uint256 slippage, bytes extraData)",
+const CG_TOKEN = "matrixdock-silver";
+const API = "https://www.matrixdock.com/rwa/anon/website/api/v1/transparency/issue-redeem/list?symbol=XAGM";
+const REDEMPTION_FEE = 0.005;
+const chainConfig = {
+  [CHAIN.CHAIN_GLOBAL]: { start: "2026-03-09" },
+  [CHAIN.ETHEREUM]: { start: "2026-03-09", xagm: "0x123ffe0a3C62878dcbee2742227dc8990058d9E1" },
+  [CHAIN.SUI]: { start: "2026-04-22" },
+};
+
+const getRecords = async (options: FetchOptions) => {
+  const items = [];
+  for (let offset = 0; ; offset += 1000) {
+    const { data } = await httpGet(`${API}&offset=${offset}&limit=1000`);
+    for (const record of data.items) {
+      const timestamp = record.tx_time / 1000;
+      if (timestamp < options.fromTimestamp) return items;
+      if (record.record_type === "REDEEM" && timestamp < options.toTimestamp) items.push(record);
+    }
+    if (offset + data.items.length >= data.total) return items;
+  }
+};
+
+const getSuiData = async (options: FetchOptions) => {
+  const data: any[] = await queryDuneSql(options, `
+    WITH states AS (
+      SELECT
+        timestamp_ms,
+        CAST(COALESCE(json_extract_scalar(object_json, '$.fields.oz_per_token_base'), json_extract_scalar(object_json, '$.content.fields.oz_per_token_base'), json_extract_scalar(object_json, '$.oz_per_token_base')) AS DOUBLE) AS oz_per_token_base,
+        CAST(COALESCE(json_extract_scalar(object_json, '$.fields.annual_fee_rate'), json_extract_scalar(object_json, '$.content.fields.annual_fee_rate'), json_extract_scalar(object_json, '$.annual_fee_rate')) AS DOUBLE) AS annual_fee_rate,
+        CAST(COALESCE(json_extract_scalar(object_json, '$.fields.oz_per_token_base_time'), json_extract_scalar(object_json, '$.content.fields.oz_per_token_base_time'), json_extract_scalar(object_json, '$.oz_per_token_base_time')) AS DOUBLE) AS oz_per_token_base_time
+      FROM sui.objects
+      WHERE object_id = 0xc2aa8379b988f31442f2435d61b739ca34872f841a2ee304e4d19c4152f12b4c
+        AND date >= DATE '2026-04-22'
+        AND timestamp_ms < ${options.toTimestamp * 1000}
+    ),
+    from_state AS (
+      SELECT * FROM states
+      WHERE timestamp_ms <= ${options.fromTimestamp * 1000}
+      ORDER BY timestamp_ms DESC
+      LIMIT 1
+    ),
+    to_state AS (
+      SELECT * FROM states
+      ORDER BY timestamp_ms DESC
+      LIMIT 1
+    ),
+    xagm_txs AS (
+      SELECT DISTINCT transaction_digest
+      FROM sui.transaction_objects
+      WHERE object_id = 0xc2aa8379b988f31442f2435d61b739ca34872f841a2ee304e4d19c4152f12b4c
+        AND date >= DATE '2026-04-22'
+        AND timestamp_ms < ${options.toTimestamp * 1000}
+    ),
+    supply AS (
+      SELECT SUM(
+        CASE
+          WHEN event_type = '0x4fffa6fa7410f28aee62153a61f18c53e478365604f9ee4f70c558a742eabf2f::mtoken::MintEvent' AND json_extract_scalar(event_json, '$.et') = '0' THEN CAST(json_extract_scalar(event_json, '$.amount') AS DOUBLE)
+          WHEN event_type = '0x4fffa6fa7410f28aee62153a61f18c53e478365604f9ee4f70c558a742eabf2f::mtoken::CCReceiveTokenEvent' THEN CAST(json_extract_scalar(event_json, '$.amount') AS DOUBLE)
+          WHEN event_type IN ('0x4fffa6fa7410f28aee62153a61f18c53e478365604f9ee4f70c558a742eabf2f::mtoken::RedeemEvent', '0x4fffa6fa7410f28aee62153a61f18c53e478365604f9ee4f70c558a742eabf2f::mtoken::CCSendTokenEvent') THEN -CAST(json_extract_scalar(event_json, '$.amount') AS DOUBLE)
+        END
+      ) / 1e9 AS supply
+      FROM sui.events
+      WHERE transaction_digest IN (SELECT transaction_digest FROM xagm_txs)
+        AND event_type IN (
+          '0x4fffa6fa7410f28aee62153a61f18c53e478365604f9ee4f70c558a742eabf2f::mtoken::MintEvent',
+          '0x4fffa6fa7410f28aee62153a61f18c53e478365604f9ee4f70c558a742eabf2f::mtoken::CCReceiveTokenEvent',
+          '0x4fffa6fa7410f28aee62153a61f18c53e478365604f9ee4f70c558a742eabf2f::mtoken::RedeemEvent',
+          '0x4fffa6fa7410f28aee62153a61f18c53e478365604f9ee4f70c558a742eabf2f::mtoken::CCSendTokenEvent'
+        )
+        AND date >= DATE '2026-04-22'
+        AND timestamp_ms < ${options.toTimestamp * 1000}
+    )
+    SELECT s.supply, from_state.oz_per_token_base AS from_base, from_state.annual_fee_rate AS from_rate, from_state.oz_per_token_base_time AS from_time, to_state.oz_per_token_base AS to_base, to_state.annual_fee_rate AS to_rate, to_state.oz_per_token_base_time AS to_time
+    FROM supply s, from_state, to_state
+  `, { extraUIDKey: "matrixdock-silver-sui-supply" });
+
+  return data[0] || {};
 };
 
 const fetch = async (options: FetchOptions) => {
   const dailyFees = options.createBalances();
   const dailyRevenue = options.createBalances();
-  const fromBlock = await options.getFromBlock();
 
-  const reconcileSupplyLogs = await options.getLogs({
-    target: XAGM,
-    eventAbi: EVENTS.reconcileSupply,
-    fromBlock,
-  });
-
-  for (const log of reconcileSupplyLogs) {
-    const amount = BigInt(log.amount.toString());
-    dailyFees.add(XAGM, amount, METRIC.MANAGEMENT_FEES);
-    dailyRevenue.add(XAGM, amount, METRIC.MANAGEMENT_FEES);
+  if (options.chain === CHAIN.CHAIN_GLOBAL) {
+    const records = await getRecords(options);
+    for (const record of records) {
+      const fee = Number(record.fine_weight) * REDEMPTION_FEE;
+      dailyFees.addCGToken(CG_TOKEN, fee, METRIC.MINT_REDEEM_FEES);
+      dailyRevenue.addCGToken(CG_TOKEN, fee, METRIC.MINT_REDEEM_FEES);
+    }
   }
 
-  const redeemRequestLogs = await options.getLogs({
-    target: XAGM_MINTER,
-    eventAbi: EVENTS.redeemRequest,
-    fromBlock,
-  });
-  const redeemLogs = await options.getLogs({
-    target: XAGM,
-    eventAbi: EVENTS.redeem,
-    fromBlock,
-  });
-
-  for (const log of redeemRequestLogs.concat(redeemLogs)) {
-    const fee = BigInt(log.amount.toString()) * BigInt(XAGM_REDEMPTION_FEE_BPS) / BPS;
-    dailyFees.add(XAGM, fee, METRIC.MINT_REDEEM_FEES);
-    dailyRevenue.add(XAGM, fee, METRIC.MINT_REDEEM_FEES);
+  if (options.chain === CHAIN.ETHEREUM) {
+    const logs = await options.getLogs({
+      target: chainConfig[CHAIN.ETHEREUM].xagm,
+      eventAbi: "event ReconcileSupply(uint64 lastReconcileTime, uint64 thisReconcileTime, uint256 amount)",
+      fromBlock: await options.getFromBlock(),
+    });
+    for (const log of logs) {
+      const fee = Number(log.amount) / 1e9;
+      dailyFees.addCGToken(CG_TOKEN, fee, METRIC.MANAGEMENT_FEES);
+      dailyRevenue.addCGToken(CG_TOKEN, fee, METRIC.MANAGEMENT_FEES);
+    }
   }
 
-  return {
-    dailyFees,
-    dailyRevenue,
-    dailyProtocolRevenue: dailyRevenue,
-  };
+  if (options.chain === CHAIN.SUI) {
+    const data = await getSuiData(options);
+    const oz = (base: number, rate: number, time: number, timestamp: number) => base - Math.floor(rate * Math.max(0, Math.floor((timestamp - time) / 86400)) / 365);
+    const feeOz = oz(Number(data.from_base), Number(data.from_rate), Number(data.from_time), options.fromTimestamp) - oz(Number(data.to_base), Number(data.to_rate), Number(data.to_time), options.toTimestamp);
+    if (feeOz > 0) {
+      const fee = Number(data.supply || 0) * feeOz / oz(Number(data.to_base), Number(data.to_rate), Number(data.to_time), options.toTimestamp);
+      dailyFees.addCGToken(CG_TOKEN, fee, METRIC.MANAGEMENT_FEES);
+      dailyRevenue.addCGToken(CG_TOKEN, fee, METRIC.MANAGEMENT_FEES);
+    }
+  }
+
+  return { dailyFees, dailyRevenue, dailyProtocolRevenue: dailyRevenue };
 };
 
-const adapter: Adapter = {
+const adapter: SimpleAdapter = {
   version: 2,
-  pullHourly: true,
-  adapter: {
-    [CHAIN.ETHEREUM]: {
-      fetch,
-      start: "2026-03-09",
-    },
-  },
+  dependencies: [Dependencies.DUNE],
+  fetch,
+  adapter: chainConfig,
   methodology: {
-    Fees: "XAGm custody fees minted by reconcileSupply and XAGm redemption fees.",
+    Fees: "XAGm custody fees and redemption fees.",
     Revenue: "XAGm custody and redemption fees accounted as protocol revenue.",
     ProtocolRevenue: "XAGm custody and redemption fees accounted as protocol revenue.",
   },
   breakdownMethodology: {
     Fees: {
-      [METRIC.MANAGEMENT_FEES]: "XAGm custody fees from ReconcileSupply events.",
-      [METRIC.MINT_REDEEM_FEES]: "0.50% fee charged on XAGm redemption orders.",
+      [METRIC.MANAGEMENT_FEES]: "XAGm custody fees from Ethereum ReconcileSupply events and Sui FRS ozPerToken accrual.",
+      [METRIC.MINT_REDEEM_FEES]: "0.50% fee charged on XAGm redemption orders from Matrixdock mint/redeem transparency records.",
     },
     Revenue: {
-      [METRIC.MANAGEMENT_FEES]: "XAGm custody fees from ReconcileSupply events.",
-      [METRIC.MINT_REDEEM_FEES]: "0.50% XAGm redemption fee from minter RedeemRequest events.",
+      [METRIC.MANAGEMENT_FEES]: "XAGm custody fees accounted as protocol revenue.",
+      [METRIC.MINT_REDEEM_FEES]: "XAGm redemption fee accounted as protocol revenue.",
     },
     ProtocolRevenue: {
-      [METRIC.MANAGEMENT_FEES]: "XAGm custody fee accounted as protocol revenue.",
+      [METRIC.MANAGEMENT_FEES]: "XAGm custody fees accounted as protocol revenue.",
       [METRIC.MINT_REDEEM_FEES]: "XAGm redemption fee accounted as protocol revenue.",
     },
   },

--- a/fees/matrixdock-silver/index.ts
+++ b/fees/matrixdock-silver/index.ts
@@ -1,7 +1,5 @@
 import type { FetchOptions, SimpleAdapter } from "../../adapters/types";
-import { Dependencies } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
-import { queryDuneSql } from "../../helpers/dune";
 import { METRIC } from "../../helpers/metrics";
 import { httpGet } from "../../utils/fetchURL";
 
@@ -16,7 +14,6 @@ const REDEMPTION_FEE = 0.005;
 const chainConfig = {
   [CHAIN.CHAIN_GLOBAL]: { start: "2026-03-09" },
   [CHAIN.ETHEREUM]: { start: "2026-03-09", xagm: "0x123ffe0a3C62878dcbee2742227dc8990058d9E1" },
-  [CHAIN.SUI]: { start: "2026-04-22" },
 };
 
 const getRecords = async (options: FetchOptions) => {
@@ -30,63 +27,6 @@ const getRecords = async (options: FetchOptions) => {
     }
     if (offset + data.items.length >= data.total) return items;
   }
-};
-
-const getSuiData = async (options: FetchOptions) => {
-  const data: any[] = await queryDuneSql(options, `
-    WITH states AS (
-      SELECT
-        timestamp_ms,
-        CAST(COALESCE(json_extract_scalar(object_json, '$.fields.oz_per_token_base'), json_extract_scalar(object_json, '$.content.fields.oz_per_token_base'), json_extract_scalar(object_json, '$.oz_per_token_base')) AS DOUBLE) AS oz_per_token_base,
-        CAST(COALESCE(json_extract_scalar(object_json, '$.fields.annual_fee_rate'), json_extract_scalar(object_json, '$.content.fields.annual_fee_rate'), json_extract_scalar(object_json, '$.annual_fee_rate')) AS DOUBLE) AS annual_fee_rate,
-        CAST(COALESCE(json_extract_scalar(object_json, '$.fields.oz_per_token_base_time'), json_extract_scalar(object_json, '$.content.fields.oz_per_token_base_time'), json_extract_scalar(object_json, '$.oz_per_token_base_time')) AS DOUBLE) AS oz_per_token_base_time
-      FROM sui.objects
-      WHERE object_id = 0xc2aa8379b988f31442f2435d61b739ca34872f841a2ee304e4d19c4152f12b4c
-        AND date >= DATE '2026-04-22'
-        AND timestamp_ms < ${options.toTimestamp * 1000}
-    ),
-    from_state AS (
-      SELECT * FROM states
-      WHERE timestamp_ms <= ${options.fromTimestamp * 1000}
-      ORDER BY timestamp_ms DESC
-      LIMIT 1
-    ),
-    to_state AS (
-      SELECT * FROM states
-      ORDER BY timestamp_ms DESC
-      LIMIT 1
-    ),
-    xagm_txs AS (
-      SELECT DISTINCT transaction_digest
-      FROM sui.transaction_objects
-      WHERE object_id = 0xc2aa8379b988f31442f2435d61b739ca34872f841a2ee304e4d19c4152f12b4c
-        AND date >= DATE '2026-04-22'
-        AND timestamp_ms < ${options.toTimestamp * 1000}
-    ),
-    supply AS (
-      SELECT SUM(
-        CASE
-          WHEN event_type = '0x4fffa6fa7410f28aee62153a61f18c53e478365604f9ee4f70c558a742eabf2f::mtoken::MintEvent' AND json_extract_scalar(event_json, '$.et') = '0' THEN CAST(json_extract_scalar(event_json, '$.amount') AS DOUBLE)
-          WHEN event_type = '0x4fffa6fa7410f28aee62153a61f18c53e478365604f9ee4f70c558a742eabf2f::mtoken::CCReceiveTokenEvent' THEN CAST(json_extract_scalar(event_json, '$.amount') AS DOUBLE)
-          WHEN event_type IN ('0x4fffa6fa7410f28aee62153a61f18c53e478365604f9ee4f70c558a742eabf2f::mtoken::RedeemEvent', '0x4fffa6fa7410f28aee62153a61f18c53e478365604f9ee4f70c558a742eabf2f::mtoken::CCSendTokenEvent') THEN -CAST(json_extract_scalar(event_json, '$.amount') AS DOUBLE)
-        END
-      ) / 1e9 AS supply
-      FROM sui.events
-      WHERE transaction_digest IN (SELECT transaction_digest FROM xagm_txs)
-        AND event_type IN (
-          '0x4fffa6fa7410f28aee62153a61f18c53e478365604f9ee4f70c558a742eabf2f::mtoken::MintEvent',
-          '0x4fffa6fa7410f28aee62153a61f18c53e478365604f9ee4f70c558a742eabf2f::mtoken::CCReceiveTokenEvent',
-          '0x4fffa6fa7410f28aee62153a61f18c53e478365604f9ee4f70c558a742eabf2f::mtoken::RedeemEvent',
-          '0x4fffa6fa7410f28aee62153a61f18c53e478365604f9ee4f70c558a742eabf2f::mtoken::CCSendTokenEvent'
-        )
-        AND date >= DATE '2026-04-22'
-        AND timestamp_ms < ${options.toTimestamp * 1000}
-    )
-    SELECT s.supply, from_state.oz_per_token_base AS from_base, from_state.annual_fee_rate AS from_rate, from_state.oz_per_token_base_time AS from_time, to_state.oz_per_token_base AS to_base, to_state.annual_fee_rate AS to_rate, to_state.oz_per_token_base_time AS to_time
-    FROM supply s, from_state, to_state
-  `, { extraUIDKey: "matrixdock-silver-sui-supply" });
-
-  return data[0] || {};
 };
 
 const fetch = async (options: FetchOptions) => {
@@ -115,23 +55,11 @@ const fetch = async (options: FetchOptions) => {
     }
   }
 
-  if (options.chain === CHAIN.SUI) {
-    const data = await getSuiData(options);
-    const oz = (base: number, rate: number, time: number, timestamp: number) => base - Math.floor(rate * Math.max(0, Math.floor((timestamp - time) / 86400)) / 365);
-    const feeOz = oz(Number(data.from_base), Number(data.from_rate), Number(data.from_time), options.fromTimestamp) - oz(Number(data.to_base), Number(data.to_rate), Number(data.to_time), options.toTimestamp);
-    if (feeOz > 0) {
-      const fee = Number(data.supply || 0) * feeOz / oz(Number(data.to_base), Number(data.to_rate), Number(data.to_time), options.toTimestamp);
-      dailyFees.addCGToken(CG_TOKEN, fee, METRIC.MANAGEMENT_FEES);
-      dailyRevenue.addCGToken(CG_TOKEN, fee, METRIC.MANAGEMENT_FEES);
-    }
-  }
-
   return { dailyFees, dailyRevenue, dailyProtocolRevenue: dailyRevenue };
 };
 
 const adapter: SimpleAdapter = {
   version: 2,
-  dependencies: [Dependencies.DUNE],
   fetch,
   adapter: chainConfig,
   methodology: {
@@ -141,7 +69,7 @@ const adapter: SimpleAdapter = {
   },
   breakdownMethodology: {
     Fees: {
-      [METRIC.MANAGEMENT_FEES]: "XAGm custody fees from Ethereum ReconcileSupply events and Sui FRS ozPerToken accrual.",
+      [METRIC.MANAGEMENT_FEES]: "XAGm custody fees from Ethereum ReconcileSupply events, which mint fee tokens covering the global token obligation across all chains.",
       [METRIC.MINT_REDEEM_FEES]: "0.50% fee charged on XAGm redemption orders from Matrixdock mint/redeem transparency records.",
     },
     Revenue: {

--- a/fees/matrixdock/index.ts
+++ b/fees/matrixdock/index.ts
@@ -1,37 +1,17 @@
 import BigNumber from "bignumber.js";
-import { ethers } from "ethers";
 import { Adapter, FetchOptions } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
-import ADDRESSES from "../../helpers/coreAssets.json";
 
-// Matrixdock docs:
+// Matrixdock STBT sources:
 // STBT FAQ / fees: https://matrixdock.gitbook.io/matrixdock-docs/english/treasury-bill-token-stbt/faq
-// XAUm FAQ / fees: https://matrixdock.gitbook.io/matrixdock-docs/english/gold-token-xaum/faq
-// XAUm contract addresses: https://matrixdock.gitbook.io/matrixdock-docs/english/gold-token-xaum/smart-contract/contract-address
-// XAGm FAQ / fees: https://matrixdock.gitbook.io/matrixdock-docs/english/silver-token-xagm/faq
-// XAGm token design / reconcileSupply fee model: https://matrixdock.gitbook.io/matrixdock-docs/english/silver-token-xagm/token-design
-// XAGm contract addresses: https://matrixdock.gitbook.io/matrixdock-docs/english/silver-token-xagm/smart-contract/contract-address
+// Matrixdock announcement: STBT custodian fee reduced from 0.35% p.a. to 0.20% p.a.
+// Effective 2026-04-28 00:00 UTC+8, i.e. 2026-04-27 16:00 UTC.
 
 // STBT contract address is from the STBT docs. It emits InterestsDistributed for holder rebases.
 const STBT = "0x530824da86689c9c17cdc2871ff29b058345b44a";
-// XAGm and XAUm Ethereum MTokenMain addresses are from their Matrixdock contract-address docs.
-const XAGM = "0x123ffe0a3C62878dcbee2742227dc8990058d9E1";
-const XAUM = "0x2103E845C5E135493Bb6c2A4f0B8651956eA8682";
-// Deployment/start blocks supplied from verified contract deployment history.
+// Deployment/start block supplied from verified contract deployment history.
 const STBT_START_BLOCK = 16431887;
-const XAUM_START_BLOCK = 20624233;
-const XAGM_START_BLOCK = 24618377;
-const XAUM_START_TIMESTAMP = 1724803200; // 2024-08-28
-const XAGM_START_TIMESTAMP = 1773014400; // 2026-03-09
-// XAGm FAQ: redemption fee is 0.50%.
-const XAGM_REDEMPTION_FEE_BPS = 50;
-// XAUm FAQ: redemption fee is 0.25%.
-const XAUM_REDEMPTION_FEE_BPS = 25;
-const BPS = 10_000n;
-
 const YEAR_SECONDS = 365 * 24 * 60 * 60;
-// Matrixdock announcement: STBT custodian fee reduced from 0.35% p.a. to 0.20% p.a.
-// Effective 2026-04-28 00:00 UTC+8, i.e. 2026-04-27 16:00 UTC.
 const FEE_CHANGE_TIMESTAMP = 1777305600; // 2026-04-28 00:00 UTC+8
 const STBT_FEE_SCHEDULE = [
   { fromTimestamp: 0, feeApy: 0.0035 },
@@ -40,19 +20,10 @@ const STBT_FEE_SCHEDULE = [
 
 const INTERESTS_DISTRIBUTED_EVENT =
   "event InterestsDistributed(int256 interest, uint256 newTotalSupply, uint256 interestFromTime, uint256 interestToTime)";
-const RECONCILE_SUPPLY_EVENT =
-  "event ReconcileSupply(uint64 lastReconcileTime, uint64 thisReconcileTime, uint256 amount)";
-const REDEEM_EVENT =
-  "event Redeem(address indexed customer, uint256 amount, bytes data)";
-const TRANSFER_EVENT =
-  "event Transfer(address indexed from, address indexed to, uint256 value)";
 
 const STBT_YIELD = "STBT Yield";
 const STBT_YIELD_TO_HOLDERS = "STBT Yield To Holders";
 const STBT_CUSTODIAN_FEES = "STBT Custodian Fees";
-const XAGM_CUSTODY_FEES = "XAGm Custody Fees";
-const XAGM_REDEMPTION_FEES = "XAGm Redemption Fees";
-const XAUM_REDEMPTION_FEES = "XAUm Redemption Fees";
 
 const toUsd = (amount: BigNumber) => amount.div(1e18).toNumber();
 
@@ -82,14 +53,10 @@ const getStbtCustodianFee = (supply: BigNumber, fromTimestamp: number, toTimesta
   return fee;
 };
 
-const addStbtFees = async (
-  options: FetchOptions,
-  balances: {
-    dailyFees: ReturnType<FetchOptions["createBalances"]>;
-    dailySupplySideRevenue: ReturnType<FetchOptions["createBalances"]>;
-    dailyRevenue: ReturnType<FetchOptions["createBalances"]>;
-  },
-) => {
+const fetch = async (options: FetchOptions) => {
+  const dailyFees = options.createBalances();
+  const dailySupplySideRevenue = options.createBalances();
+  const dailyRevenue = options.createBalances();
   const fromBlock = await getFromBlock(options, STBT_START_BLOCK);
   const logs = await options.getLogs({
     target: STBT,
@@ -112,197 +79,10 @@ const addStbtFees = async (
     const protocolFee = getStbtCustodianFee(preRebaseSupply, interestFromTime, interestToTime);
     const grossYield = netYield.plus(protocolFee);
 
-    balances.dailyFees.addUSDValue(toUsd(grossYield), STBT_YIELD);
-    balances.dailySupplySideRevenue.addUSDValue(toUsd(netYield), STBT_YIELD_TO_HOLDERS);
-    balances.dailyRevenue.addUSDValue(toUsd(protocolFee), STBT_CUSTODIAN_FEES);
+    dailyFees.addUSDValue(toUsd(grossYield), STBT_YIELD);
+    dailySupplySideRevenue.addUSDValue(toUsd(netYield), STBT_YIELD_TO_HOLDERS);
+    dailyRevenue.addUSDValue(toUsd(protocolFee), STBT_CUSTODIAN_FEES);
   });
-};
-
-const addRedemptionFees = async (
-  options: FetchOptions,
-  balances: {
-    dailyFees: ReturnType<FetchOptions["createBalances"]>;
-    dailyRevenue: ReturnType<FetchOptions["createBalances"]>;
-  },
-  config: {
-    token: string;
-    feeBps: number;
-    label: string;
-    symbol: string;
-    fromBlock: number;
-  },
-) => {
-  const fromBlock = await getFromBlock(options, config.fromBlock);
-  const operator = (await options.api.call({
-    target: config.token,
-    // Matrixdock MToken redeem burns from operator and emits customer in Redeem.
-    abi: "function operator() view returns (address)",
-  })).toLowerCase();
-
-  const [redeemLogs, burnLogs] = await Promise.all([
-    options.getLogs({
-      target: config.token,
-      eventAbi: REDEEM_EVENT,
-      fromBlock,
-      entireLog: true,
-      parseLog: true,
-      skipIndexer: true,
-    }),
-    options.getLogs({
-      target: config.token,
-      eventAbi: TRANSFER_EVENT,
-      fromBlock,
-      topics: [
-        null as any,
-        null as any,
-        ethers.zeroPadValue(ADDRESSES.null, 32),
-      ],
-      entireLog: true,
-      parseLog: true,
-      skipIndexer: true,
-    }),
-  ]);
-
-  const burnsByTxAndOperator = new Map<string, bigint>();
-  burnLogs.forEach((log) => {
-    if (!log.transactionHash) return;
-    const txHash = log.transactionHash.toLowerCase();
-    const from = log.args.from.toLowerCase();
-    if (from !== operator) return;
-    const key = `${txHash}:${from}`;
-    const previous = burnsByTxAndOperator.get(key) ?? 0n;
-    burnsByTxAndOperator.set(key, previous + BigInt(log.args.value.toString()));
-  });
-
-  const redeemsByTxAndOperator = new Map<string, bigint>();
-  redeemLogs.forEach((log) => {
-    const amount = BigInt(log.args.amount.toString());
-    const txHash = log.transactionHash?.toLowerCase();
-    if (!txHash) {
-      throw new Error(`${config.symbol} Redeem burn safety check failed for tx ${txHash ?? "unknown"}`);
-    }
-
-    const key = `${txHash}:${operator}`;
-    const previous = redeemsByTxAndOperator.get(key) ?? 0n;
-    redeemsByTxAndOperator.set(key, previous + amount);
-  });
-
-  redeemsByTxAndOperator.forEach((amount, key) => {
-    const txHash = key.split(":")[0];
-    if (burnsByTxAndOperator.get(key) !== amount) {
-      throw new Error(`${config.symbol} Redeem burn safety check failed for tx ${txHash}`);
-    }
-
-    const redemptionFee = amount * BigInt(config.feeBps) / BPS;
-    balances.dailyFees.add(config.token, redemptionFee, config.label);
-    balances.dailyRevenue.add(config.token, redemptionFee, config.label);
-  });
-};
-
-const addXagmFees = async (
-  options: FetchOptions,
-  balances: {
-    dailyFees: ReturnType<FetchOptions["createBalances"]>;
-    dailyRevenue: ReturnType<FetchOptions["createBalances"]>;
-  },
-) => {
-  if (options.toTimestamp < XAGM_START_TIMESTAMP) return;
-
-  const feeCollector = (await options.api.call({
-    target: XAGM,
-    // XAGm MToken exposes feeCollector; reconcileSupply mints custody fees to it.
-    abi: "function feeCollector() view returns (address)",
-  })).toLowerCase();
-
-  const fromBlock = await getFromBlock(options, XAGM_START_BLOCK);
-  const [reconcileLogs, transferLogs] = await Promise.all([
-    options.getLogs({
-      target: XAGM,
-      eventAbi: RECONCILE_SUPPLY_EVENT,
-      fromBlock,
-      entireLog: true,
-      parseLog: true,
-      skipIndexer: true,
-    }),
-    options.getLogs({
-      target: XAGM,
-      eventAbi: TRANSFER_EVENT,
-      fromBlock,
-      topics: [
-        null as any,
-        ethers.zeroPadValue(ADDRESSES.null, 32),
-        ethers.zeroPadValue(feeCollector, 32),
-      ],
-      entireLog: true,
-      parseLog: true,
-      skipIndexer: true,
-    }),
-  ]);
-
-  const feeMintsByTx = new Map<string, bigint>();
-  transferLogs.forEach((log) => {
-    if (!log.transactionHash) return;
-    const txHash = log.transactionHash.toLowerCase();
-    const previous = feeMintsByTx.get(txHash) ?? 0n;
-    feeMintsByTx.set(txHash, previous + BigInt(log.args.value.toString()));
-  });
-
-  const reconcileMintsByTx = new Map<string, bigint>();
-  reconcileLogs.forEach((log) => {
-    const amount = BigInt(log.args.amount.toString());
-    const txHash = log.transactionHash?.toLowerCase();
-    if (!txHash) {
-      throw new Error(`XAGm ReconcileSupply fee mint safety check failed for tx ${txHash ?? "unknown"}`);
-    }
-
-    const previous = reconcileMintsByTx.get(txHash) ?? 0n;
-    reconcileMintsByTx.set(txHash, previous + amount);
-  });
-
-  reconcileMintsByTx.forEach((amount, txHash) => {
-    if (feeMintsByTx.get(txHash) !== amount) {
-      throw new Error(`XAGm ReconcileSupply fee mint safety check failed for tx ${txHash}`);
-    }
-
-    balances.dailyFees.add(XAGM, amount, XAGM_CUSTODY_FEES);
-    balances.dailyRevenue.add(XAGM, amount, XAGM_CUSTODY_FEES);
-  });
-
-  await addRedemptionFees(options, balances, {
-    token: XAGM,
-    feeBps: XAGM_REDEMPTION_FEE_BPS,
-    label: XAGM_REDEMPTION_FEES,
-    symbol: "XAGm",
-    fromBlock: XAGM_START_BLOCK,
-  });
-};
-
-const addXaumFees = async (
-  options: FetchOptions,
-  balances: {
-    dailyFees: ReturnType<FetchOptions["createBalances"]>;
-    dailyRevenue: ReturnType<FetchOptions["createBalances"]>;
-  },
-) => {
-  if (options.toTimestamp < XAUM_START_TIMESTAMP) return;
-
-  await addRedemptionFees(options, balances, {
-    token: XAUM,
-    feeBps: XAUM_REDEMPTION_FEE_BPS,
-    label: XAUM_REDEMPTION_FEES,
-    symbol: "XAUm",
-    fromBlock: XAUM_START_BLOCK,
-  });
-};
-
-const fetch = async (options: FetchOptions) => {
-  const dailyFees = options.createBalances();
-  const dailySupplySideRevenue = options.createBalances();
-  const dailyRevenue = options.createBalances();
-
-  await addStbtFees(options, { dailyFees, dailySupplySideRevenue, dailyRevenue });
-  await addXagmFees(options, { dailyFees, dailyRevenue });
-  await addXaumFees(options, { dailyFees, dailyRevenue });
 
   return {
     dailyFees,
@@ -322,32 +102,23 @@ const adapter: Adapter = {
     },
   },
   methodology: {
-    Fees: "Matrixdock fees include gross STBT yield before custodian fees, XAGm custody fees minted by reconcileSupply, and XAGm/XAUm redemption fees.",
+    Fees: "Gross STBT asset yield before custodian fees.",
     SupplySideRevenue: "Net STBT interest distributed to holders through InterestsDistributed rebases.",
-    Revenue: "STBT custodian fees, XAGm custody fees, and XAGm/XAUm redemption fees, accounted as protocol revenue.",
+    Revenue: "STBT custodian fees accounted as protocol revenue.",
     ProtocolRevenue: "Same as Revenue.",
   },
   breakdownMethodology: {
     Fees: {
       [STBT_YIELD]: "Gross STBT asset yield before custodian fees. The STBT custodian fee is 0.35% p.a. before 2026-04-28 00:00 UTC+8 and 0.20% p.a. after.",
-      [XAGM_CUSTODY_FEES]: "XAGm custody fees minted to the fee collector during ReconcileSupply events.",
-      [XAGM_REDEMPTION_FEES]: "0.50% fee charged on XAGm redemption orders.",
-      [XAUM_REDEMPTION_FEES]: "0.25% fee charged on XAUm redemption orders.",
     },
     SupplySideRevenue: {
       [STBT_YIELD_TO_HOLDERS]: "Net STBT interest distributed to holders via the InterestsDistributed event.",
     },
     Revenue: {
       [STBT_CUSTODIAN_FEES]: "STBT custodian fee calculated from pre-rebase STBT supply over each positive rebase period, using the applicable annual rate.",
-      [XAGM_CUSTODY_FEES]: "XAGm custody fees minted to the fee collector during ReconcileSupply events, validated against the matching mint Transfer in the same transaction.",
-      [XAGM_REDEMPTION_FEES]: "0.50% XAGm redemption fee, validated against the matching burn Transfer from the redeeming customer in the same transaction.",
-      [XAUM_REDEMPTION_FEES]: "0.25% XAUm redemption fee, validated against the matching burn Transfer from the redeeming customer in the same transaction.",
     },
     ProtocolRevenue: {
       [STBT_CUSTODIAN_FEES]: "STBT custodian fee accounted as protocol revenue.",
-      [XAGM_CUSTODY_FEES]: "XAGm custody fee accounted as protocol revenue.",
-      [XAGM_REDEMPTION_FEES]: "XAGm redemption fee accounted as protocol revenue.",
-      [XAUM_REDEMPTION_FEES]: "XAUm redemption fee accounted as protocol revenue.",
     },
   },
 };

--- a/fees/matrixdock/index.ts
+++ b/fees/matrixdock/index.ts
@@ -1,0 +1,334 @@
+import BigNumber from "bignumber.js";
+import { ethers } from "ethers";
+import { Adapter, FetchOptions } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import ADDRESSES from "../../helpers/coreAssets.json";
+
+// Matrixdock docs:
+// STBT FAQ / fees: https://matrixdock.gitbook.io/matrixdock-docs/english/treasury-bill-token-stbt/faq
+// XAUm FAQ / fees: https://matrixdock.gitbook.io/matrixdock-docs/english/gold-token-xaum/faq
+// XAUm contract addresses: https://matrixdock.gitbook.io/matrixdock-docs/english/gold-token-xaum/smart-contract/contract-address
+// XAGm FAQ / fees: https://matrixdock.gitbook.io/matrixdock-docs/english/silver-token-xagm/faq
+// XAGm token design / reconcileSupply fee model: https://matrixdock.gitbook.io/matrixdock-docs/english/silver-token-xagm/token-design
+// XAGm contract addresses: https://matrixdock.gitbook.io/matrixdock-docs/english/silver-token-xagm/smart-contract/contract-address
+
+// STBT contract address is from the STBT docs. It emits InterestsDistributed for holder rebases.
+const STBT = "0x530824da86689c9c17cdc2871ff29b058345b44a";
+// XAGm and XAUm Ethereum MTokenMain addresses are from their Matrixdock contract-address docs.
+const XAGM = "0x123ffe0a3C62878dcbee2742227dc8990058d9E1";
+const XAUM = "0x2103E845C5E135493Bb6c2A4f0B8651956eA8682";
+// Deployment/start blocks supplied from verified contract deployment history.
+const STBT_START_BLOCK = 16431887;
+const XAUM_START_BLOCK = 20624233;
+const XAGM_START_BLOCK = 24618377;
+const XAUM_START_TIMESTAMP = 1724803200; // 2024-08-28
+const XAGM_START_TIMESTAMP = 1773014400; // 2026-03-09
+// XAGm FAQ: redemption fee is 0.50%.
+const XAGM_REDEMPTION_FEE_BPS = 50;
+// XAUm FAQ: redemption fee is 0.25%.
+const XAUM_REDEMPTION_FEE_BPS = 25;
+const BPS = 10_000n;
+
+const YEAR_SECONDS = 365 * 24 * 60 * 60;
+// Matrixdock announcement: STBT custodian fee reduced from 0.35% p.a. to 0.20% p.a.
+// Effective 2026-04-28 00:00 UTC+8, i.e. 2026-04-27 16:00 UTC.
+const FEE_CHANGE_TIMESTAMP = 1777305600; // 2026-04-28 00:00 UTC+8
+const STBT_FEE_SCHEDULE = [
+  { fromTimestamp: 0, feeApy: 0.0035 },
+  { fromTimestamp: FEE_CHANGE_TIMESTAMP, feeApy: 0.002 },
+];
+
+const INTERESTS_DISTRIBUTED_EVENT =
+  "event InterestsDistributed(int256 interest, uint256 newTotalSupply, uint256 interestFromTime, uint256 interestToTime)";
+const RECONCILE_SUPPLY_EVENT =
+  "event ReconcileSupply(uint64 lastReconcileTime, uint64 thisReconcileTime, uint256 amount)";
+const REDEEM_EVENT =
+  "event Redeem(address indexed customer, uint256 amount, bytes data)";
+const TRANSFER_EVENT =
+  "event Transfer(address indexed from, address indexed to, uint256 value)";
+
+const STBT_YIELD = "STBT Yield";
+const STBT_YIELD_TO_HOLDERS = "STBT Yield To Holders";
+const STBT_CUSTODIAN_FEES = "STBT Custodian Fees";
+const XAGM_CUSTODY_FEES = "XAGm Custody Fees";
+const XAGM_REDEMPTION_FEES = "XAGm Redemption Fees";
+const XAUM_REDEMPTION_FEES = "XAUm Redemption Fees";
+
+const toUsd = (amount: BigNumber) => amount.div(1e18).toNumber();
+
+const getFromBlock = async (options: FetchOptions, productStartBlock: number) => {
+  return Math.max(await options.getFromBlock(), productStartBlock);
+};
+
+const getStbtCustodianFee = (supply: BigNumber, fromTimestamp: number, toTimestamp: number) => {
+  let fee = new BigNumber(0);
+
+  for (let i = 0; i < STBT_FEE_SCHEDULE.length; i++) {
+    const currentRate = STBT_FEE_SCHEDULE[i];
+    const nextRate = STBT_FEE_SCHEDULE[i + 1];
+    const periodStart = Math.max(fromTimestamp, currentRate.fromTimestamp);
+    const periodEnd = Math.min(toTimestamp, nextRate?.fromTimestamp ?? toTimestamp);
+
+    if (periodEnd <= periodStart) continue;
+
+    fee = fee.plus(
+      supply
+        .times(currentRate.feeApy)
+        .times(periodEnd - periodStart)
+        .div(YEAR_SECONDS),
+    );
+  }
+
+  return fee;
+};
+
+const addStbtFees = async (
+  options: FetchOptions,
+  balances: {
+    dailyFees: ReturnType<FetchOptions["createBalances"]>;
+    dailySupplySideRevenue: ReturnType<FetchOptions["createBalances"]>;
+    dailyRevenue: ReturnType<FetchOptions["createBalances"]>;
+  },
+) => {
+  const fromBlock = await getFromBlock(options, STBT_START_BLOCK);
+  const logs = await options.getLogs({
+    target: STBT,
+    eventAbi: INTERESTS_DISTRIBUTED_EVENT,
+    fromBlock,
+  });
+
+  logs.forEach((log) => {
+    const netYield = new BigNumber(log.interest.toString());
+    if (!netYield.gt(0)) return;
+
+    const interestFromTime = Number(log.interestFromTime);
+    const interestToTime = Number(log.interestToTime);
+    if (interestToTime <= interestFromTime) return;
+
+    const newTotalSupply = new BigNumber(log.newTotalSupply.toString());
+    const preRebaseSupply = newTotalSupply.minus(netYield);
+    if (!preRebaseSupply.gt(0)) return;
+
+    const protocolFee = getStbtCustodianFee(preRebaseSupply, interestFromTime, interestToTime);
+    const grossYield = netYield.plus(protocolFee);
+
+    balances.dailyFees.addUSDValue(toUsd(grossYield), STBT_YIELD);
+    balances.dailySupplySideRevenue.addUSDValue(toUsd(netYield), STBT_YIELD_TO_HOLDERS);
+    balances.dailyRevenue.addUSDValue(toUsd(protocolFee), STBT_CUSTODIAN_FEES);
+  });
+};
+
+const addRedemptionFees = async (
+  options: FetchOptions,
+  balances: {
+    dailyFees: ReturnType<FetchOptions["createBalances"]>;
+    dailyRevenue: ReturnType<FetchOptions["createBalances"]>;
+  },
+  config: {
+    token: string;
+    feeBps: number;
+    label: string;
+    symbol: string;
+    fromBlock: number;
+  },
+) => {
+  const fromBlock = await getFromBlock(options, config.fromBlock);
+  const operator = (await options.api.call({
+    target: config.token,
+    // Matrixdock MToken redeem burns from operator and emits customer in Redeem.
+    abi: "function operator() view returns (address)",
+  })).toLowerCase();
+
+  const [redeemLogs, burnLogs] = await Promise.all([
+    options.getLogs({
+      target: config.token,
+      eventAbi: REDEEM_EVENT,
+      fromBlock,
+      entireLog: true,
+      parseLog: true,
+      skipIndexer: true,
+    }),
+    options.getLogs({
+      target: config.token,
+      eventAbi: TRANSFER_EVENT,
+      fromBlock,
+      topics: [
+        null as any,
+        null as any,
+        ethers.zeroPadValue(ADDRESSES.null, 32),
+      ],
+      entireLog: true,
+      parseLog: true,
+      skipIndexer: true,
+    }),
+  ]);
+
+  const burnsByTxAndOperator = new Map<string, bigint>();
+  burnLogs.forEach((log) => {
+    if (!log.transactionHash) return;
+    const txHash = log.transactionHash.toLowerCase();
+    const from = log.args.from.toLowerCase();
+    if (from !== operator) return;
+    const key = `${txHash}:${from}`;
+    const previous = burnsByTxAndOperator.get(key) ?? 0n;
+    burnsByTxAndOperator.set(key, previous + BigInt(log.args.value.toString()));
+  });
+
+  redeemLogs.forEach((log) => {
+    const amount = BigInt(log.args.amount.toString());
+    const txHash = log.transactionHash?.toLowerCase();
+    const key = `${txHash}:${operator}`;
+
+    if (!txHash || burnsByTxAndOperator.get(key) !== amount) {
+      throw new Error(`${config.symbol} Redeem burn safety check failed for tx ${txHash ?? "unknown"}`);
+    }
+
+    const redemptionFee = amount * BigInt(config.feeBps) / BPS;
+    balances.dailyFees.add(config.token, redemptionFee, config.label);
+    balances.dailyRevenue.add(config.token, redemptionFee, config.label);
+  });
+};
+
+const addXagmFees = async (
+  options: FetchOptions,
+  balances: {
+    dailyFees: ReturnType<FetchOptions["createBalances"]>;
+    dailyRevenue: ReturnType<FetchOptions["createBalances"]>;
+  },
+) => {
+  if (options.toTimestamp < XAGM_START_TIMESTAMP) return;
+
+  const feeCollector = (await options.api.call({
+    target: XAGM,
+    // XAGm MToken exposes feeCollector; reconcileSupply mints custody fees to it.
+    abi: "function feeCollector() view returns (address)",
+  })).toLowerCase();
+
+  const fromBlock = await getFromBlock(options, XAGM_START_BLOCK);
+  const [reconcileLogs, transferLogs] = await Promise.all([
+    options.getLogs({
+      target: XAGM,
+      eventAbi: RECONCILE_SUPPLY_EVENT,
+      fromBlock,
+      entireLog: true,
+      parseLog: true,
+      skipIndexer: true,
+    }),
+    options.getLogs({
+      target: XAGM,
+      eventAbi: TRANSFER_EVENT,
+      fromBlock,
+      topics: [
+        null as any,
+        ethers.zeroPadValue(ADDRESSES.null, 32),
+        ethers.zeroPadValue(feeCollector, 32),
+      ],
+      entireLog: true,
+      parseLog: true,
+      skipIndexer: true,
+    }),
+  ]);
+
+  const feeMintsByTx = new Map<string, bigint>();
+  transferLogs.forEach((log) => {
+    if (!log.transactionHash) return;
+    const txHash = log.transactionHash.toLowerCase();
+    const previous = feeMintsByTx.get(txHash) ?? 0n;
+    feeMintsByTx.set(txHash, previous + BigInt(log.args.value.toString()));
+  });
+
+  reconcileLogs.forEach((log) => {
+    const amount = BigInt(log.args.amount.toString());
+    const txHash = log.transactionHash?.toLowerCase();
+    if (!txHash || feeMintsByTx.get(txHash) !== amount) {
+      throw new Error(`XAGm ReconcileSupply fee mint safety check failed for tx ${txHash ?? "unknown"}`);
+    }
+
+    balances.dailyFees.add(XAGM, amount, XAGM_CUSTODY_FEES);
+    balances.dailyRevenue.add(XAGM, amount, XAGM_CUSTODY_FEES);
+  });
+
+  await addRedemptionFees(options, balances, {
+    token: XAGM,
+    feeBps: XAGM_REDEMPTION_FEE_BPS,
+    label: XAGM_REDEMPTION_FEES,
+    symbol: "XAGm",
+    fromBlock: XAGM_START_BLOCK,
+  });
+};
+
+const addXaumFees = async (
+  options: FetchOptions,
+  balances: {
+    dailyFees: ReturnType<FetchOptions["createBalances"]>;
+    dailyRevenue: ReturnType<FetchOptions["createBalances"]>;
+  },
+) => {
+  if (options.toTimestamp < XAUM_START_TIMESTAMP) return;
+
+  await addRedemptionFees(options, balances, {
+    token: XAUM,
+    feeBps: XAUM_REDEMPTION_FEE_BPS,
+    label: XAUM_REDEMPTION_FEES,
+    symbol: "XAUm",
+    fromBlock: XAUM_START_BLOCK,
+  });
+};
+
+const fetch = async (options: FetchOptions) => {
+  const dailyFees = options.createBalances();
+  const dailySupplySideRevenue = options.createBalances();
+  const dailyRevenue = options.createBalances();
+
+  await addStbtFees(options, { dailyFees, dailySupplySideRevenue, dailyRevenue });
+  await addXagmFees(options, { dailyFees, dailyRevenue });
+  await addXaumFees(options, { dailyFees, dailyRevenue });
+
+  return {
+    dailyFees,
+    dailySupplySideRevenue,
+    dailyRevenue,
+    dailyProtocolRevenue: dailyRevenue,
+  };
+};
+
+const adapter: Adapter = {
+  version: 2,
+  adapter: {
+    [CHAIN.ETHEREUM]: {
+      fetch,
+      start: "2023-01-18",
+    },
+  },
+  methodology: {
+    Fees: "Matrixdock fees include gross STBT yield before custodian fees, XAGm custody fees minted by reconcileSupply, and XAGm/XAUm redemption fees.",
+    SupplySideRevenue: "Net STBT interest distributed to holders through InterestsDistributed rebases.",
+    Revenue: "STBT custodian fees, XAGm custody fees, and XAGm/XAUm redemption fees, accounted as protocol revenue.",
+    ProtocolRevenue: "Same as Revenue.",
+  },
+  breakdownMethodology: {
+    Fees: {
+      [STBT_YIELD]: "Gross STBT asset yield before custodian fees. The STBT custodian fee is 0.35% p.a. before 2026-04-28 00:00 UTC+8 and 0.20% p.a. after.",
+      [XAGM_CUSTODY_FEES]: "XAGm custody fees minted to the fee collector during ReconcileSupply events.",
+      [XAGM_REDEMPTION_FEES]: "0.50% fee charged on XAGm redemption orders.",
+      [XAUM_REDEMPTION_FEES]: "0.25% fee charged on XAUm redemption orders.",
+    },
+    SupplySideRevenue: {
+      [STBT_YIELD_TO_HOLDERS]: "Net STBT interest distributed to holders via the InterestsDistributed event.",
+    },
+    Revenue: {
+      [STBT_CUSTODIAN_FEES]: "STBT custodian fee calculated from pre-rebase STBT supply over each positive rebase period, using the applicable annual rate.",
+      [XAGM_CUSTODY_FEES]: "XAGm custody fees minted to the fee collector during ReconcileSupply events, validated against the matching mint Transfer in the same transaction.",
+      [XAGM_REDEMPTION_FEES]: "0.50% XAGm redemption fee, validated against the matching burn Transfer from the redeeming customer in the same transaction.",
+      [XAUM_REDEMPTION_FEES]: "0.25% XAUm redemption fee, validated against the matching burn Transfer from the redeeming customer in the same transaction.",
+    },
+    ProtocolRevenue: {
+      [STBT_CUSTODIAN_FEES]: "STBT custodian fee accounted as protocol revenue.",
+      [XAGM_CUSTODY_FEES]: "XAGm custody fee accounted as protocol revenue.",
+      [XAGM_REDEMPTION_FEES]: "XAGm redemption fee accounted as protocol revenue.",
+      [XAUM_REDEMPTION_FEES]: "XAUm redemption fee accounted as protocol revenue.",
+    },
+  },
+};
+
+export default adapter;

--- a/fees/matrixdock/index.ts
+++ b/fees/matrixdock/index.ts
@@ -174,13 +174,23 @@ const addRedemptionFees = async (
     burnsByTxAndOperator.set(key, previous + BigInt(log.args.value.toString()));
   });
 
+  const redeemsByTxAndOperator = new Map<string, bigint>();
   redeemLogs.forEach((log) => {
     const amount = BigInt(log.args.amount.toString());
     const txHash = log.transactionHash?.toLowerCase();
-    const key = `${txHash}:${operator}`;
-
-    if (!txHash || burnsByTxAndOperator.get(key) !== amount) {
+    if (!txHash) {
       throw new Error(`${config.symbol} Redeem burn safety check failed for tx ${txHash ?? "unknown"}`);
+    }
+
+    const key = `${txHash}:${operator}`;
+    const previous = redeemsByTxAndOperator.get(key) ?? 0n;
+    redeemsByTxAndOperator.set(key, previous + amount);
+  });
+
+  redeemsByTxAndOperator.forEach((amount, key) => {
+    const txHash = key.split(":")[0];
+    if (burnsByTxAndOperator.get(key) !== amount) {
+      throw new Error(`${config.symbol} Redeem burn safety check failed for tx ${txHash}`);
     }
 
     const redemptionFee = amount * BigInt(config.feeBps) / BPS;
@@ -237,11 +247,21 @@ const addXagmFees = async (
     feeMintsByTx.set(txHash, previous + BigInt(log.args.value.toString()));
   });
 
+  const reconcileMintsByTx = new Map<string, bigint>();
   reconcileLogs.forEach((log) => {
     const amount = BigInt(log.args.amount.toString());
     const txHash = log.transactionHash?.toLowerCase();
-    if (!txHash || feeMintsByTx.get(txHash) !== amount) {
+    if (!txHash) {
       throw new Error(`XAGm ReconcileSupply fee mint safety check failed for tx ${txHash ?? "unknown"}`);
+    }
+
+    const previous = reconcileMintsByTx.get(txHash) ?? 0n;
+    reconcileMintsByTx.set(txHash, previous + amount);
+  });
+
+  reconcileMintsByTx.forEach((amount, txHash) => {
+    if (feeMintsByTx.get(txHash) !== amount) {
+      throw new Error(`XAGm ReconcileSupply fee mint safety check failed for tx ${txHash}`);
     }
 
     balances.dailyFees.add(XAGM, amount, XAGM_CUSTODY_FEES);
@@ -294,6 +314,7 @@ const fetch = async (options: FetchOptions) => {
 
 const adapter: Adapter = {
   version: 2,
+  pullHourly: true,
   adapter: {
     [CHAIN.ETHEREUM]: {
       fetch,

--- a/fees/matrixdock/index.ts
+++ b/fees/matrixdock/index.ts
@@ -1,6 +1,7 @@
 import BigNumber from "bignumber.js";
 import { Adapter, FetchOptions } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
+import { METRIC } from "../../helpers/metrics";
 
 // Matrixdock STBT sources:
 // STBT FAQ / fees: https://matrixdock.gitbook.io/matrixdock-docs/english/treasury-bill-token-stbt/faq
@@ -9,59 +10,31 @@ import { CHAIN } from "../../helpers/chains";
 
 // STBT contract address is from the STBT docs. It emits InterestsDistributed for holder rebases.
 const STBT = "0x530824da86689c9c17cdc2871ff29b058345b44a";
-// Deployment/start block supplied from verified contract deployment history.
-const STBT_START_BLOCK = 16431887;
 const YEAR_SECONDS = 365 * 24 * 60 * 60;
-const FEE_CHANGE_TIMESTAMP = 1777305600; // 2026-04-28 00:00 UTC+8
 const STBT_FEE_SCHEDULE = [
   { fromTimestamp: 0, feeApy: 0.0035 },
-  { fromTimestamp: FEE_CHANGE_TIMESTAMP, feeApy: 0.002 },
+  { fromTimestamp: 1777305600, feeApy: 0.002 },
 ];
 
-const INTERESTS_DISTRIBUTED_EVENT =
-  "event InterestsDistributed(int256 interest, uint256 newTotalSupply, uint256 interestFromTime, uint256 interestToTime)";
-
-const STBT_YIELD = "STBT Yield";
-const STBT_YIELD_TO_HOLDERS = "STBT Yield To Holders";
-const STBT_CUSTODIAN_FEES = "STBT Custodian Fees";
-
-const toUsd = (amount: BigNumber) => amount.div(1e18).toNumber();
-
-const getFromBlock = async (options: FetchOptions, productStartBlock: number) => {
-  return Math.max(await options.getFromBlock(), productStartBlock);
+const EVENTS = {
+  interestsDistributed: "event InterestsDistributed(int256 interest, uint256 newTotalSupply, uint256 interestFromTime, uint256 interestToTime)",
 };
 
-const getStbtCustodianFee = (supply: BigNumber, fromTimestamp: number, toTimestamp: number) => {
-  let fee = new BigNumber(0);
-
-  for (let i = 0; i < STBT_FEE_SCHEDULE.length; i++) {
-    const currentRate = STBT_FEE_SCHEDULE[i];
-    const nextRate = STBT_FEE_SCHEDULE[i + 1];
-    const periodStart = Math.max(fromTimestamp, currentRate.fromTimestamp);
-    const periodEnd = Math.min(toTimestamp, nextRate?.fromTimestamp ?? toTimestamp);
-
-    if (periodEnd <= periodStart) continue;
-
-    fee = fee.plus(
-      supply
-        .times(currentRate.feeApy)
-        .times(periodEnd - periodStart)
-        .div(YEAR_SECONDS),
-    );
-  }
-
-  return fee;
-};
+const getStbtCustodianFee = (supply: BigNumber, from: number, to: number) =>
+  STBT_FEE_SCHEDULE.reduce((fee, { fromTimestamp, feeApy }, i) => {
+    const start = Math.max(from, fromTimestamp);
+    const end = Math.min(to, STBT_FEE_SCHEDULE[i + 1]?.fromTimestamp ?? to);
+    return end <= start ? fee : fee.plus(supply.times(feeApy).times(end - start).div(YEAR_SECONDS));
+  }, new BigNumber(0));
 
 const fetch = async (options: FetchOptions) => {
   const dailyFees = options.createBalances();
   const dailySupplySideRevenue = options.createBalances();
   const dailyRevenue = options.createBalances();
-  const fromBlock = await getFromBlock(options, STBT_START_BLOCK);
   const logs = await options.getLogs({
     target: STBT,
-    eventAbi: INTERESTS_DISTRIBUTED_EVENT,
-    fromBlock,
+    eventAbi: EVENTS.interestsDistributed,
+    fromBlock: await options.getFromBlock(),
   });
 
   logs.forEach((log) => {
@@ -79,9 +52,9 @@ const fetch = async (options: FetchOptions) => {
     const protocolFee = getStbtCustodianFee(preRebaseSupply, interestFromTime, interestToTime);
     const grossYield = netYield.plus(protocolFee);
 
-    dailyFees.addUSDValue(toUsd(grossYield), STBT_YIELD);
-    dailySupplySideRevenue.addUSDValue(toUsd(netYield), STBT_YIELD_TO_HOLDERS);
-    dailyRevenue.addUSDValue(toUsd(protocolFee), STBT_CUSTODIAN_FEES);
+    dailyFees.addUSDValue(grossYield.div(1e18).toNumber(), METRIC.ASSETS_YIELDS);
+    dailySupplySideRevenue.addUSDValue(netYield.div(1e18).toNumber(), METRIC.ASSETS_YIELDS);
+    dailyRevenue.addUSDValue(protocolFee.div(1e18).toNumber(), METRIC.MANAGEMENT_FEES);
   });
 
   return {
@@ -105,20 +78,20 @@ const adapter: Adapter = {
     Fees: "Gross STBT asset yield before custodian fees.",
     SupplySideRevenue: "Net STBT interest distributed to holders through InterestsDistributed rebases.",
     Revenue: "STBT custodian fees accounted as protocol revenue.",
-    ProtocolRevenue: "Same as Revenue.",
+    ProtocolRevenue: "STBT custodian fees accounted as protocol revenue.",
   },
   breakdownMethodology: {
     Fees: {
-      [STBT_YIELD]: "Gross STBT asset yield before custodian fees. The STBT custodian fee is 0.35% p.a. before 2026-04-28 00:00 UTC+8 and 0.20% p.a. after.",
+      [METRIC.ASSETS_YIELDS]: "Gross STBT asset yield before custodian fees. The STBT custodian fee is 0.35% p.a. before 2026-04-28 00:00 UTC+8 and 0.20% p.a. after.",
     },
     SupplySideRevenue: {
-      [STBT_YIELD_TO_HOLDERS]: "Net STBT interest distributed to holders via the InterestsDistributed event.",
+      [METRIC.ASSETS_YIELDS]: "Net STBT interest distributed to holders via the InterestsDistributed event.",
     },
     Revenue: {
-      [STBT_CUSTODIAN_FEES]: "STBT custodian fee calculated from pre-rebase STBT supply over each positive rebase period, using the applicable annual rate.",
+      [METRIC.MANAGEMENT_FEES]: "STBT custodian fee calculated from pre-rebase STBT supply over each positive rebase period, using the applicable annual rate.",
     },
     ProtocolRevenue: {
-      [STBT_CUSTODIAN_FEES]: "STBT custodian fee accounted as protocol revenue.",
+      [METRIC.MANAGEMENT_FEES]: "STBT custodian fee accounted as protocol revenue.",
     },
   },
 };


### PR DESCRIPTION
Closes #6694

## Matrixdock fees adapter

Adds a unified Matrixdock fees adapter covering:

- STBT treasury bill token
- XAGm silver token
- XAUm gold token

## Methodology

### STBT

Tracks `InterestsDistributed` rebases.

- `dailyFees`: gross STBT yield before custodian fees
- `dailySupplySideRevenue`: net yield distributed to STBT holders
- `dailyRevenue`: STBT custodian fee
- `dailyProtocolRevenue`: same as revenue

Custodian fee schedule:

- 0.35% p.a. before 2026-04-28 00:00 UTC+8
- 0.20% p.a. from 2026-04-28 00:00 UTC+8

### XAGm

Tracks silver custody and redemption fees.

- Custody fees from `ReconcileSupply`
- Validates custody fee mints against `Transfer(0x0 -> feeCollector)`
- Redemption fees calculated as 0.50% of `Redeem.amount`
- Validates redemptions against `Transfer(operator -> 0x0)`

### XAUm

Tracks gold redemption fees.

- Redemption fees calculated as 0.25% of `Redeem.amount`
- Validates redemptions against `Transfer(operator -> 0x0)`

## Tests

```bash
pnpm run ts-check
pnpm test fees matrixdock 2025-01-21
