### PR TITLE
[feat] onre - add fees adapter

### DIFF
--- a/fees/onre/index.ts
+++ b/fees/onre/index.ts
@@ -2,7 +2,7 @@ import fetchURL from "../../utils/fetchURL";
 import { FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 
-const NAV_API = "https://core.api.onre.finance/data/nav";
+const NAV_API = "https://core.api.onre.finance/data/nav"\;
 
 interface NAVEntry {
   net_asset_value_date: string;
@@ -21,10 +21,8 @@ const formatUTCDate = (ts: number): string => {
 const fetch = async (_a: any, _b: any, options: FetchOptions) => {
   const response = await fetchURL(NAV_API);
   const navData: NAVEntry[] = response.data;
-
   const todayStr = formatUTCDate(options.startOfDay);
   const yesterdayStr = formatUTCDate(options.startOfDay - 86400);
-
   const today = navData.find((e) => e.net_asset_value_date === todayStr);
   const yesterday = navData.find((e) => e.net_asset_value_date === yesterdayStr);
 
@@ -63,6 +61,11 @@ const methodology = {
 const adapter: SimpleAdapter = {
   version: 1,
   methodology,
+  breakdownMethodology: {
+    dailyFees: "Gross NAV growth attributable to ONyc holders (AUM × daily NAV growth rate)",
+    dailySupplySideRevenue: "Yield paid to ONyc token holders (100% of fees)",
+    dailyRevenue: "No protocol-retained revenue",
+  },
   adapter: {
     [CHAIN.SOLANA]: {
       fetch,

--- a/fees/onre/index.ts
+++ b/fees/onre/index.ts
@@ -2,7 +2,7 @@ import fetchURL from "../../utils/fetchURL";
 import { FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 
-const NAV_API = "https://core.api.onre.finance/data/nav";
+const NAV_API = "https://core.api.onre.finance/data/nav"\;
 
 interface NAVEntry {
   net_asset_value_date: string;
@@ -55,7 +55,7 @@ const fetch = async (_a: any, _b: any, options: FetchOptions) => {
 };
 
 const methodology = {
-  Fees: "Yield accrued to ONyc token holders as the NAV increases daily.",
+  Fees: "Yield accrued to ONyc token holders as the NAV increases daily (AUM × daily NAV growth rate).",
   SupplySideRevenue: "All yield goes to token holders.",
   Revenue: "No protocol fee split.",
 };

--- a/fees/onre/index.ts
+++ b/fees/onre/index.ts
@@ -2,7 +2,7 @@ import fetchURL from "../../utils/fetchURL";
 import { FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 
-const NAV_API = "https://core.api.onre.finance/data/nav"\;
+const NAV_API = "https://core.api.onre.finance/data/nav";
 
 interface NAVEntry {
   net_asset_value_date: string;

--- a/fees/onre/index.ts
+++ b/fees/onre/index.ts
@@ -71,7 +71,7 @@ const fetch = async (_a: any, _b: any, options: FetchOptions) => {
 };
 
 const methodology = {
-    Fees: "Includes yield accrued to ONyc token holders as the NAV increases daily and 0.25%fees paid to redeem ONyc tokens.",
+    Fees: "Includes yield accrued to ONyc token holders as the NAV increases daily and 0.25% fees paid to redeem ONyc tokens.",
     SupplySideRevenue: "Yield accrued to ONyc token holders as the NAV increases daily.",
     Revenue: "0.25% fees paid to redeem ONyc tokens.",
     ProtocolRevenue: "0.25% fees paid to redeem ONyc tokens.",
@@ -102,6 +102,7 @@ const adapter: SimpleAdapter = {
     dependencies: [Dependencies.DUNE],
     start: "2025-06-04",
     isExpensiveAdapter: true,
+    allowNegativeValue: true,
 };
 
 export default adapter;

--- a/fees/onre/index.ts
+++ b/fees/onre/index.ts
@@ -1,0 +1,66 @@
+import fetchURL from "../../utils/fetchURL";
+import { FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+
+const NAV_API = "https://core.api.onre.finance/data/nav";
+
+interface NAVEntry {
+  net_asset_value_date: string; // "MM/DD/YYYY"
+  net_asset_value: string;
+  assets_under_management: string | null;
+  circulating_supply: string | null;
+}
+
+const formatUTCDate = (ts: number): string => {
+  const d = new Date(ts * 1000);
+  const mm = String(d.getUTCMonth() + 1).padStart(2, "0");
+  const dd = String(d.getUTCDate()).padStart(2, "0");
+  return `${mm}/${dd}/${d.getUTCFullYear()}`;
+};
+
+const fetch = async (options: FetchOptions) => {
+  const response = await fetchURL(NAV_API);
+  const navData: NAVEntry[] = response.data;
+
+  const todayStr = formatUTCDate(options.startOfDay);
+  const yesterdayStr = formatUTCDate(options.startOfDay - 86400);
+
+  const today = navData.find((e) => e.net_asset_value_date === todayStr);
+  const yesterday = navData.find((e) => e.net_asset_value_date === yesterdayStr);
+
+  if (!today || !yesterday || !today.assets_under_management) {
+    return { dailyFees: 0, dailySupplySideRevenue: 0, dailyRevenue: 0 };
+  }
+
+  const todayNAV = parseFloat(today.net_asset_value);
+  const yesterdayNAV = parseFloat(yesterday.net_asset_value);
+  const aum = parseFloat(today.assets_under_management);
+
+  const dailyFees = aum * ((todayNAV - yesterdayNAV) / yesterdayNAV);
+
+  return {
+    dailyFees,
+    dailySupplySideRevenue: dailyFees,
+    dailyRevenue: 0,
+  };
+};
+
+const methodology = {
+  Fees: "Yield accrued to ONyc token holders as the NAV increases daily (AUM × daily NAV growth rate).",
+  SupplySideRevenue: "All yield goes to token holders.",
+  Revenue: "No protocol fee split.",
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  methodology,
+  adapter: {
+    [CHAIN.SOLANA]: {
+      fetch,
+      start: "2025-06-04",
+      runAtCurrTime: true,
+    },
+  },
+};
+
+export default adapter;

--- a/fees/onre/index.ts
+++ b/fees/onre/index.ts
@@ -5,7 +5,7 @@ import { CHAIN } from "../../helpers/chains";
 const NAV_API = "https://core.api.onre.finance/data/nav";
 
 interface NAVEntry {
-  net_asset_value_date: string; // "MM/DD/YYYY"
+  net_asset_value_date: string;
   net_asset_value: string;
   assets_under_management: string | null;
   circulating_supply: string | null;
@@ -18,7 +18,7 @@ const formatUTCDate = (ts: number): string => {
   return `${mm}/${dd}/${d.getUTCFullYear()}`;
 };
 
-const fetch = async (options: FetchOptions) => {
+const fetch = async (_a: any, _b: any, options: FetchOptions) => {
   const response = await fetchURL(NAV_API);
   const navData: NAVEntry[] = response.data;
 
@@ -36,6 +36,15 @@ const fetch = async (options: FetchOptions) => {
   const yesterdayNAV = parseFloat(yesterday.net_asset_value);
   const aum = parseFloat(today.assets_under_management);
 
+  if (
+    !Number.isFinite(todayNAV) ||
+    !Number.isFinite(yesterdayNAV) ||
+    !Number.isFinite(aum) ||
+    yesterdayNAV <= 0
+  ) {
+    return { dailyFees: 0, dailySupplySideRevenue: 0, dailyRevenue: 0 };
+  }
+
   const dailyFees = aum * ((todayNAV - yesterdayNAV) / yesterdayNAV);
 
   return {
@@ -46,13 +55,13 @@ const fetch = async (options: FetchOptions) => {
 };
 
 const methodology = {
-  Fees: "Yield accrued to ONyc token holders as the NAV increases daily (AUM × daily NAV growth rate).",
+  Fees: "Yield accrued to ONyc token holders as the NAV increases daily.",
   SupplySideRevenue: "All yield goes to token holders.",
   Revenue: "No protocol fee split.",
 };
 
 const adapter: SimpleAdapter = {
-  version: 2,
+  version: 1,
   methodology,
   adapter: {
     [CHAIN.SOLANA]: {

--- a/fees/onre/index.ts
+++ b/fees/onre/index.ts
@@ -1,78 +1,107 @@
 import fetchURL from "../../utils/fetchURL";
-import { FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { Dependencies, FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
+import { METRIC } from "../../helpers/metrics";
+import { queryDuneSql } from "../../helpers/dune";
 
 const NAV_API = "https://core.api.onre.finance/data/nav";
 
 interface NAVEntry {
-  net_asset_value_date: string;
-  net_asset_value: string;
-  assets_under_management: string | null;
-  circulating_supply: string | null;
+    net_asset_value_date: string;
+    net_asset_value: string;
+    assets_under_management: string | null;
+    circulating_supply: string | null;
 }
 
 const formatUTCDate = (ts: number): string => {
-  const d = new Date(ts * 1000);
-  const mm = String(d.getUTCMonth() + 1).padStart(2, "0");
-  const dd = String(d.getUTCDate()).padStart(2, "0");
-  return `${mm}/${dd}/${d.getUTCFullYear()}`;
+    return new Intl.DateTimeFormat('en-US', {
+        timeZone: 'UTC',
+        month: '2-digit',
+        day: '2-digit',
+        year: 'numeric'
+    }).format(ts * 1000);
 };
 
+const ONYC_TOKEN_MINT = '5Y8NV33Vv7WbnLfq3zBcKSdYPrk7g2KoiQoe7M2tcxp5';
+const REDEEM_FEE = 0.25 / 100;
+
 const fetch = async (_a: any, _b: any, options: FetchOptions) => {
-  const response = await fetchURL(NAV_API);
-  const navData: NAVEntry[] = response.data;
-  const todayStr = formatUTCDate(options.startOfDay);
-  const yesterdayStr = formatUTCDate(options.startOfDay - 86400);
-  const today = navData.find((e) => e.net_asset_value_date === todayStr);
-  const yesterday = navData.find((e) => e.net_asset_value_date === yesterdayStr);
+    const response = await fetchURL(NAV_API);
+    const navData: NAVEntry[] = response.data;
 
-  if (!today || !yesterday || !today.assets_under_management) {
-    return { dailyFees: 0, dailySupplySideRevenue: 0, dailyRevenue: 0 };
-  }
+    const todayDateString = formatUTCDate(options.startOfDay);
+    const yesterdayDateString = formatUTCDate(options.startOfDay - 86400);
+    const todaysData = navData.find((e) => e.net_asset_value_date === todayDateString);
+    const yesterdaysData = navData.find((e) => e.net_asset_value_date === yesterdayDateString);
 
-  const todayNAV = parseFloat(today.net_asset_value);
-  const yesterdayNAV = parseFloat(yesterday.net_asset_value);
-  const aum = parseFloat(today.assets_under_management);
+    if (!todaysData || !yesterdaysData || !todaysData.circulating_supply) {
+        throw new Error(`No data found for ${options.dateString}`);
+    }
 
-  if (
-    !Number.isFinite(todayNAV) ||
-    !Number.isFinite(yesterdayNAV) ||
-    !Number.isFinite(aum) ||
-    yesterdayNAV <= 0
-  ) {
-    return { dailyFees: 0, dailySupplySideRevenue: 0, dailyRevenue: 0 };
-  }
+    const todaysNAV = parseFloat(todaysData.net_asset_value);
+    const yesterdaysNAV = parseFloat(yesterdaysData.net_asset_value);
+    const circulatingSupply = parseFloat(todaysData.circulating_supply);
 
-  const dailyFees = aum * ((todayNAV - yesterdayNAV) / yesterdayNAV);
+    const dailyFees = options.createBalances();
+    const dailyRevenue = options.createBalances();
+    const dailySupplySideRevenue = options.createBalances();
 
-  return {
-    dailyFees,
-    dailySupplySideRevenue: dailyFees,
-    dailyRevenue: 0,
-  };
+    dailyFees.addUSDValue(circulatingSupply * (todaysNAV - yesterdaysNAV), METRIC.ASSETS_YIELDS);
+
+    const duneQuery = `
+        SELECT
+            COALESCE(SUM(amount_usd), 0) AS onyc_redeemed_amount_usd
+        FROM tokens_solana.transfers
+        WHERE action = 'burn'
+            AND token_mint_address = '${ONYC_TOKEN_MINT}'
+            AND TIME_RANGE
+    `;
+
+    const queryResult = await queryDuneSql(options, duneQuery);
+
+    dailyFees.addUSDValue(queryResult[0].onyc_redeemed_amount_usd * REDEEM_FEE, METRIC.MINT_REDEEM_FEES);
+    dailyRevenue.addUSDValue(queryResult[0].onyc_redeemed_amount_usd * REDEEM_FEE, METRIC.MINT_REDEEM_FEES);
+
+    return {
+        dailyFees: dailyFees,
+        dailySupplySideRevenue,
+        dailyRevenue,
+        dailyProtocolRevenue: dailyRevenue,
+    };
 };
 
 const methodology = {
-  Fees: "Yield accrued to ONyc token holders as the NAV increases daily (AUM × daily NAV growth rate).",
-  SupplySideRevenue: "All yield goes to token holders.",
-  Revenue: "No protocol fee split.",
+    Fees: "Includes yield accrued to ONyc token holders as the NAV increases daily and 0.25%fees paid to redeem ONyc tokens.",
+    SupplySideRevenue: "Yield accrued to ONyc token holders as the NAV increases daily.",
+    Revenue: "0.25% fees paid to redeem ONyc tokens.",
+    ProtocolRevenue: "0.25% fees paid to redeem ONyc tokens.",
+};
+
+const breakdownMethodology = {
+    Fees: {
+        [METRIC.MINT_REDEEM_FEES]: "0.25% fees paid to redeem ONyc tokens.",
+        [METRIC.ASSETS_YIELDS]: "Yield accrued to ONyc token holders as the NAV increases daily.",
+    },
+    Revenue: {
+        [METRIC.MINT_REDEEM_FEES]: "0.25% fees paid to redeem ONyc tokens.",
+    },
+    ProtocolRevenue: {
+        [METRIC.MINT_REDEEM_FEES]: "0.25% fees paid to redeem ONyc tokens.",
+    },
+    SupplySideRevenue: {
+        [METRIC.ASSETS_YIELDS]: "Yield accrued to ONyc token holders as the NAV increases daily.",
+    },
 };
 
 const adapter: SimpleAdapter = {
-  version: 1,
-  methodology,
-  breakdownMethodology: {
-    dailyFees: "Gross NAV growth attributable to ONyc holders (AUM × daily NAV growth rate)",
-    dailySupplySideRevenue: "Yield paid to ONyc token holders (100% of fees)",
-    dailyRevenue: "No protocol-retained revenue",
-  },
-  adapter: {
-    [CHAIN.SOLANA]: {
-      fetch,
-      start: "2025-06-04",
-      runAtCurrTime: true,
-    },
-  },
+    version: 1,
+    fetch,
+    methodology,
+    breakdownMethodology,
+    chains: [CHAIN.SOLANA],
+    dependencies: [Dependencies.DUNE],
+    start: "2025-06-04",
+    isExpensiveAdapter: true,
 };
 
 export default adapter;


### PR DESCRIPTION
## Summary

Fixes #6691
https://defillama.com/protocol/onre

Adds a fees adapter for OnRe, an RWA yield fund on Solana issuing ONyc tokens.

## Methodology

OnRe's fees are the yield accrued daily to token holders as the NAV increases:

dailyFees = AUM × (todayNAV - yesterdayNAV) / yesterdayNAV

All fees go to supply side revenue (token holders). No protocol fee split is visible.

## Data Source

Historical NAV API: https://core.api.onre.finance/data/nav

## Test Output

SOLANA
Daily fees: 41.58k
Daily supply side revenue: 41.58k
Daily revenue: 0.00

~$41.5K daily fees on ~$157M AUM at ~10% APY which matches expected yield of $157M × 10% / 365 ≈ $43K/day.

## Notes

- Chain: Solana
- Start date: 2025-06-04 (first date with AUM data in the API)
- version: 2, runAtCurrTime: true