### PR TITLE
Fix Pangea Swap fees (Migrate to factory address)

### DIFF
--- a/dexs/pangea-swap/index.ts
+++ b/dexs/pangea-swap/index.ts
@@ -28,7 +28,18 @@ const fetch = async ({ api, createBalances, getLogs }: FetchOptions) => {
   const dailyVolume = createBalances();
   const dailyFees = createBalances();
 
-  if (!activePools.length) return { dailyVolume, dailyFees, dailyUserFees: dailyFees.clone() };
+  if (!activePools.length) {
+    const dailyRevenue = dailyFees.clone(PROTOCOL_FEE_RATIO);
+    const dailySupplySideRevenue = dailyFees.clone(1 - PROTOCOL_FEE_RATIO);
+    return {
+      dailyVolume,
+      dailyFees,
+      dailyUserFees: dailyFees.clone(),
+      dailyRevenue,
+      dailyProtocolRevenue: dailyRevenue,
+      dailySupplySideRevenue,
+    };
+  }
 
   const [factories, token0s, token1s, swapFees] = await Promise.all([
     api.multiCall({ abi: ABIS.factory, calls: activePools, permitFailure: true }),
@@ -98,6 +109,23 @@ const adapter: SimpleAdapter = {
     Revenue: "Pangea pool contracts route 10% of swap fees to protocol revenue.",
     ProtocolRevenue: "10% of swap fees collected by the protocol.",
     SupplySideRevenue: "90% of swap fees distributed to liquidity providers.",
+  },
+  breakdownMethodology: {
+    Fees: {
+      "Swap fees": "Fees paid by users on Pangea Swap trades.",
+    },
+    Revenue: {
+      "Protocol fees": "Protocol revenue, equal to 10% of swap fees.",
+    },
+    ProtocolRevenue: {
+      "Protocol fees": "Protocol revenue, equal to 10% of swap fees.",
+    },
+    SupplySideRevenue: {
+      "LP fees": "Supply-side revenue, equal to 90% of swap fees.",
+    },
+    HoldersRevenue: {
+      "Holder fees": "No holder revenue is currently allocated.",
+    },
   },
 };
 

--- a/dexs/pangea-swap/index.ts
+++ b/dexs/pangea-swap/index.ts
@@ -1,41 +1,103 @@
-import { gql, GraphQLClient } from "graphql-request";
-import { SimpleAdapter } from "../../adapters/types";
+import { FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
-import { getUniqStartOfTodayTimestamp } from "../../helpers/getUniSubgraphVolume";
 
-const getDailyVolume = () => {
-  return gql` query value {
-      summation {
-          tradingVolume1D
-          totalValueLocked
-          totalVirtualLocked
-      }
-  }`
-}
+const MASTER_DEPLOYER = "0xEB4B1CE03bb947Ce23ABd1403dF7C9B86004178d";
+const POOL_LOGGER = "0x002A422533cccEeA9aBF9e56e2A25d72672891bC";
+const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
 
-const graphQLClient = new GraphQLClient("https://api.pangeaswap.com/graphql");
+const ABIS = {
+  whitelistedFactories: "function whitelistedFactories(address factory) view returns (bool)",
+  factory: "address:factory",
+  token0: "address:token0",
+  token1: "address:token1",
+  swapFee: "uint24:swapFee",
+  swap: "event Swap(address indexed pool, bool zeroForOne, uint256 amountIn, uint256 amountOut)",
+};
 
-const getGQLClient = () => {
-  return graphQLClient
-}
+const PROTOCOL_FEE_RATIO = 0.1;
+const SWAP_FEE_DENOMINATOR = 1_000_000n;
 
-const fetch = async (timestamp: number) => {
-  const dayTimestamp = getUniqStartOfTodayTimestamp(new Date(timestamp * 1000));
-  const dailyVolume = (await getGQLClient().request(getDailyVolume()))?.summation?.tradingVolume1D;
+const fetch = async ({ api, createBalances, getLogs }: FetchOptions) => {
+  const logs = await getLogs({
+    target: POOL_LOGGER,
+    eventAbi: ABIS.swap,
+    skipIndexer: true,
+  });
+
+  const activePools = Array.from(new Set(logs.map((log: any) => log.pool.toLowerCase())));
+  const dailyVolume = createBalances();
+  const dailyFees = createBalances();
+
+  if (!activePools.length) return { dailyVolume, dailyFees, dailyUserFees: dailyFees.clone() };
+
+  const [factories, token0s, token1s, swapFees] = await Promise.all([
+    api.multiCall({ abi: ABIS.factory, calls: activePools, permitFailure: true }),
+    api.multiCall({ abi: ABIS.token0, calls: activePools, permitFailure: true }),
+    api.multiCall({ abi: ABIS.token1, calls: activePools, permitFailure: true }),
+    api.multiCall({ abi: ABIS.swapFee, calls: activePools, permitFailure: true }),
+  ]);
+
+  const whitelistedFactories = await api.multiCall({
+    target: MASTER_DEPLOYER,
+    abi: ABIS.whitelistedFactories,
+    calls: factories.map((factory) => ({ params: [factory ?? ZERO_ADDRESS] })),
+    permitFailure: true,
+  });
+
+  const poolInfo: Record<string, { token0: string; token1: string; swapFee: bigint }> = {};
+  activePools.forEach((pool: string, i: number) => {
+    if (!factories[i] || !token0s[i] || !token1s[i] || !swapFees[i] || !whitelistedFactories[i]) return;
+
+    poolInfo[pool.toLowerCase()] = {
+      token0: token0s[i],
+      token1: token1s[i],
+      swapFee: BigInt(swapFees[i]),
+    };
+  });
+
+  logs.forEach((log: any) => {
+    const pool = log.pool.toLowerCase();
+    if (!poolInfo[pool]) return;
+
+    const { token0, token1, swapFee } = poolInfo[pool];
+    const tokenIn = log.zeroForOne ? token0 : token1;
+    const tokenOut = log.zeroForOne ? token1 : token0;
+    const amountOut = BigInt(log.amountOut);
+    const feeAmount = (amountOut * swapFee) / (SWAP_FEE_DENOMINATOR - swapFee);
+
+    dailyVolume.add(tokenIn, log.amountIn);
+    dailyFees.add(tokenOut, feeAmount);
+  });
+
+  const dailyRevenue = dailyFees.clone(PROTOCOL_FEE_RATIO);
+  const dailySupplySideRevenue = dailyFees.clone(1 - PROTOCOL_FEE_RATIO);
 
   return {
-    timestamp: dayTimestamp,
-    dailyVolume: dailyVolume ? dailyVolume.toString() : undefined,
-  }
-}
+    dailyVolume,
+    dailyFees,
+    dailyUserFees: dailyFees.clone(),
+    dailyRevenue,
+    dailyProtocolRevenue: dailyRevenue,
+    dailySupplySideRevenue,
+  };
+};
 
 const adapter: SimpleAdapter = {
+  version: 2,
+  pullHourly: true,
   adapter: {
     [CHAIN.KLAYTN]: {
       fetch,
-      runAtCurrTime: true,
-      deadFrom: "2025-12-31",
+      start: "2022-08-18",
     },
+  },
+  methodology: {
+    Volume: "Swap volume from Pangea Trident-style pools registered in MasterDeployer and deployed by whitelisted factories, counted from the input token side of PoolLogger swap events.",
+    Fees: "Trading fees paid by users, computed from each pool's swapFee() in pips. Pangea deducts fees from output, so fees are derived from the net amountOut.",
+    UserFees: "Trading fees paid by users.",
+    Revenue: "Pangea pool contracts route 10% of swap fees to protocol revenue.",
+    ProtocolRevenue: "10% of swap fees collected by the protocol.",
+    SupplySideRevenue: "90% of swap fees distributed to liquidity providers.",
   },
 };
 

--- a/dexs/pangea-swap/index.ts
+++ b/dexs/pangea-swap/index.ts
@@ -34,6 +34,7 @@ const adapter: SimpleAdapter = {
     [CHAIN.KLAYTN]: {
       fetch,
       runAtCurrTime: true,
+      deadFrom: "2025-12-31",
     },
   },
 };

--- a/dexs/pangea-swap/index.ts
+++ b/dexs/pangea-swap/index.ts
@@ -1,5 +1,6 @@
 import { FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
+import { METRIC } from "../../helpers/metrics";
 
 const MASTER_DEPLOYER = "0xEB4B1CE03bb947Ce23ABd1403dF7C9B86004178d";
 const POOL_LOGGER = "0x002A422533cccEeA9aBF9e56e2A25d72672891bC";
@@ -27,19 +28,6 @@ const fetch = async ({ api, createBalances, getLogs }: FetchOptions) => {
   const activePools = Array.from(new Set(logs.map((log: any) => log.pool.toLowerCase())));
   const dailyVolume = createBalances();
   const dailyFees = createBalances();
-
-  if (!activePools.length) {
-    const dailyRevenue = dailyFees.clone(PROTOCOL_FEE_RATIO);
-    const dailySupplySideRevenue = dailyFees.clone(1 - PROTOCOL_FEE_RATIO);
-    return {
-      dailyVolume,
-      dailyFees,
-      dailyUserFees: dailyFees.clone(),
-      dailyRevenue,
-      dailyProtocolRevenue: dailyRevenue,
-      dailySupplySideRevenue,
-    };
-  }
 
   const [factories, token0s, token1s, swapFees] = await Promise.all([
     api.multiCall({ abi: ABIS.factory, calls: activePools, permitFailure: true }),
@@ -77,16 +65,16 @@ const fetch = async ({ api, createBalances, getLogs }: FetchOptions) => {
     const feeAmount = (amountOut * swapFee) / (SWAP_FEE_DENOMINATOR - swapFee);
 
     dailyVolume.add(tokenIn, log.amountIn);
-    dailyFees.add(tokenOut, feeAmount);
+    dailyFees.add(tokenOut, feeAmount, METRIC.SWAP_FEES);
   });
 
-  const dailyRevenue = dailyFees.clone(PROTOCOL_FEE_RATIO);
-  const dailySupplySideRevenue = dailyFees.clone(1 - PROTOCOL_FEE_RATIO);
+  const dailyRevenue = dailyFees.clone(PROTOCOL_FEE_RATIO, METRIC.PROTOCOL_FEES);
+  const dailySupplySideRevenue = dailyFees.clone(1 - PROTOCOL_FEE_RATIO, METRIC.LP_FEES);
 
   return {
     dailyVolume,
     dailyFees,
-    dailyUserFees: dailyFees.clone(),
+    dailyUserFees: dailyFees,
     dailyRevenue,
     dailyProtocolRevenue: dailyRevenue,
     dailySupplySideRevenue,
@@ -112,19 +100,16 @@ const adapter: SimpleAdapter = {
   },
   breakdownMethodology: {
     Fees: {
-      "Swap fees": "Fees paid by users on Pangea Swap trades.",
+      [METRIC.SWAP_FEES]: "Fees paid by users on Pangea Swap trades.",
     },
     Revenue: {
-      "Protocol fees": "Protocol revenue, equal to 10% of swap fees.",
+      [METRIC.PROTOCOL_FEES]: "Protocol revenue, equal to 10% of swap fees.",
     },
     ProtocolRevenue: {
-      "Protocol fees": "Protocol revenue, equal to 10% of swap fees.",
+      [METRIC.PROTOCOL_FEES]: "Protocol revenue, equal to 10% of swap fees.",
     },
     SupplySideRevenue: {
-      "LP fees": "Supply-side revenue, equal to 90% of swap fees.",
-    },
-    HoldersRevenue: {
-      "Holder fees": "No holder revenue is currently allocated.",
+      [METRIC.LP_FEES]: "Supply-side revenue, equal to 90% of swap fees.",
     },
   },
 };


### PR DESCRIPTION
Fixes #6713 

## Fix Pangea Swap fees

This fixes Pangea Swap fees by reading swaps from `PoolLogger`.

The pool does the swap, but `PoolLogger` emits the swap event, so the adapter now uses that log and checks the pool factory through `MasterDeployer`.

`pullHourly` is enabled because Klaytn/Kaia RPCs limit large log ranges.