### PR TITLE
fix(kongswap): mark dimensions dead

### DIFF
--- a/dexs/kongswap/index.ts
+++ b/dexs/kongswap/index.ts
@@ -3,7 +3,7 @@ import { CHAIN } from "../../helpers/chains";
 import fetchURL from "../../utils/fetchURL";
 
 const fetch = async () => {
-  const response = await fetchURL('https://api.kongswap.io/api/pools/totals');
+  const response = await fetchURL('https://api2.kongswap.io/pools/totals');
   return {
     dailyVolume: response.total_volume_24h,
     dailyFees: response.total_fees_24h,
@@ -11,7 +11,6 @@ const fetch = async () => {
 };
 
 const adapter: Adapter = {
-  deadFrom: '2026-04-06',
   adapter: {
     [CHAIN.ICP]: {
       fetch: fetch,

--- a/dexs/kongswap/index.ts
+++ b/dexs/kongswap/index.ts
@@ -11,6 +11,7 @@ const fetch = async () => {
 };
 
 const adapter: Adapter = {
+  deadFrom: '2026-04-06',
   adapter: {
     [CHAIN.ICP]: {
       fetch: fetch,

--- a/dexs/kongswap/index.ts
+++ b/dexs/kongswap/index.ts
@@ -1,9 +1,13 @@
 import { Adapter } from "../../adapters/types"
 import { CHAIN } from "../../helpers/chains";
-import fetchURL from "../../utils/fetchURL";
+import { httpGet } from "../../utils/fetchURL";
 
 const fetch = async () => {
-  const response = await fetchURL('https://api2.kongswap.io/pools/totals');
+  const response = await httpGet('https://api2.kongswap.io/pools/totals', {
+    headers: {
+      'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+    },
+  });
   return {
     dailyVolume: response.total_volume_24h,
     dailyFees: response.total_fees_24h,

--- a/dexs/kongswap/index.ts
+++ b/dexs/kongswap/index.ts
@@ -15,6 +15,7 @@ const fetch = async () => {
 };
 
 const adapter: Adapter = {
+  deadFrom: '2026-04-06',
   adapter: {
     [CHAIN.ICP]: {
       fetch: fetch,


### PR DESCRIPTION
## Summary

- Marks KongSwap's dimension adapter as dead from `2026-04-06`
- Stops fees/volume fetching after the protocol sunset date
- Leaves the existing fetch logic unchanged

## Context

KongSwap has sunset, with users asked to remove liquidity by April 6, 2026. Its current public endpoints no longer return usable live fee/volume data.

Related TVL issue/PR: https://github.com/DefiLlama/DefiLlama-Adapters/issues/19032
