### PR TITLE
Add XAUE fees adapter

### DIFF
--- a/fees/xaue/index.ts
+++ b/fees/xaue/index.ts
@@ -4,72 +4,70 @@ import { METRIC } from "../../helpers/metrics";
 
 // Protocol reference: https://xaue.com/xaue_protocol_info_en.v1.pdf
 // The document describes XAUE value accrual through Oracle NAV growth and does not disclose protocol fee rates.
-const XAUE = "0xd5D6840ed95F58FAf537865DcA15D5f99195F87a";
-const ORACLE = "0x0618BD112C396060d2b37B537b3d92e757644169";
-
-const PRICE_DECIMALS = 18n;
+const ADDRESSES = {
+    XAUE: "0xd5D6840ed95F58FAf537865DcA15D5f99195F87a",
+    ORACLE: "0x0618BD112C396060d2b37B537b3d92e757644169",
+    XAUT: "0x68749665FF8D2d112Fa859AA293F07A622782F38",
+    XAUE_DECIMALS: 18n,
+    XAUT_DECIMALS: 6n,
+    PRICE_DECIMALS: 18n,
+}
 
 const ABIS = {
-  totalSupply: "uint256:totalSupply",
-  getLatestPrice: "uint256:getLatestPrice",
-  asset: "address:asset",
-  assetDecimals: "uint8:assetDecimals",
-  decimals: "uint8:decimals",
+    totalSupply: "uint256:totalSupply",
+    getLatestPrice: "uint256:getLatestPrice",
 };
 
 const fetch = async (options: FetchOptions) => {
-  const dailyFees = options.createBalances();
-  const dailySupplySideRevenue = options.createBalances();
-  const dailyRevenue = options.createBalances();
+    const dailyFees = options.createBalances();
+    const dailySupplySideRevenue = options.createBalances();
+    const dailyRevenue = options.createBalances();
 
-  const [priceStart, priceEnd, totalSupply, asset, assetDecimals, shareDecimals] = await Promise.all([
-    options.fromApi.call({ abi: ABIS.getLatestPrice, target: ORACLE }),
-    options.toApi.call({ abi: ABIS.getLatestPrice, target: ORACLE }),
-    options.fromApi.call({ abi: ABIS.totalSupply, target: XAUE }),
-    options.fromApi.call({ abi: ABIS.asset, target: XAUE }),
-    options.fromApi.call({ abi: ABIS.assetDecimals, target: XAUE }),
-    options.fromApi.call({ abi: ABIS.decimals, target: XAUE }),
-  ]);
+    const [priceStart, priceEnd, totalSupply] = await Promise.all([
+        options.fromApi.call({ abi: ABIS.getLatestPrice, target: ADDRESSES.ORACLE }),
+        options.toApi.call({ abi: ABIS.getLatestPrice, target: ADDRESSES.ORACLE }),
+        options.fromApi.call({ abi: ABIS.totalSupply, target: ADDRESSES.XAUE }),
+    ]);
 
-  const priceDelta = BigInt(priceEnd) - BigInt(priceStart);
+    const priceDelta = BigInt(priceEnd) - BigInt(priceStart);
 
-  if (priceDelta > 0n) {
-    const conversionScale = 10n ** (BigInt(shareDecimals) + PRICE_DECIMALS - BigInt(assetDecimals));
+    const conversionScale = 10n ** (ADDRESSES.XAUE_DECIMALS + ADDRESSES.PRICE_DECIMALS - ADDRESSES.XAUT_DECIMALS);
     const yieldInAsset = (BigInt(totalSupply) * priceDelta) / conversionScale;
-    dailyFees.add(asset, yieldInAsset, METRIC.ASSETS_YIELDS);
-    dailySupplySideRevenue.add(asset, yieldInAsset, METRIC.ASSETS_YIELDS);
-  }
+    dailyFees.add(ADDRESSES.XAUT, yieldInAsset, METRIC.ASSETS_YIELDS);
+    dailySupplySideRevenue.add(ADDRESSES.XAUT, yieldInAsset, METRIC.ASSETS_YIELDS);
 
-  return {
-    dailyFees,
-    dailyRevenue,
-    dailyProtocolRevenue: dailyRevenue,
-    dailySupplySideRevenue,
-  };
+    return {
+        dailyFees,
+        dailyRevenue,
+        dailyProtocolRevenue: dailyRevenue,
+        dailySupplySideRevenue,
+    };
 };
 
-const adapter: SimpleAdapter = {
-  version: 2,
-  adapter: {
-    [CHAIN.ETHEREUM]: {
-      fetch,
-      start: "2026-03-24", // first full UTC day after block 24718738, Mar-23-2026 07:30:59 AM UTC
-    },
-  },
-  methodology: {
+const methodology = {
     Fees: "Yield accrued to XAUE holders from Oracle NAV growth. The Oracle computes NAV linearly from baseNetValue and currentAPR; daily yield is start-of-period XAUE supply multiplied by the NAV increase.",
     Revenue: "No protocol revenue or management/performance fee is disclosed in the protocol information document, so revenue is reported as zero.",
     ProtocolRevenue: "No protocol revenue or management/performance fee is disclosed in the protocol information document, so protocol revenue is reported as zero.",
     SupplySideRevenue: "Yield accrued to XAUE holders through XAUE NAV appreciation, denominated in XAUt.",
-  },
-  breakdownMethodology: {
+}
+
+const breakdownMethodology = {
     Fees: {
-      [METRIC.ASSETS_YIELDS]: "Yield generated from XAUE Oracle NAV appreciation.",
+        [METRIC.ASSETS_YIELDS]: "Yield generated from XAUE Oracle NAV appreciation.",
     },
     SupplySideRevenue: {
-      [METRIC.ASSETS_YIELDS]: "Yield distributed to XAUE holders through NAV appreciation.",
+        [METRIC.ASSETS_YIELDS]: "Yield distributed to XAUE holders through NAV appreciation.",
     },
-  },
+}
+
+const adapter: SimpleAdapter = {
+    version: 2,
+    chains: [CHAIN.ETHEREUM],
+    fetch,
+    start: "2026-03-24", // first full UTC day after block 24718738, Mar-23-2026 07:30:59 AM UTC
+    methodology,
+    breakdownMethodology,
+    allowNegativeValue: true,
 };
 
 export default adapter;

--- a/fees/xaue/index.ts
+++ b/fees/xaue/index.ts
@@ -1,0 +1,75 @@
+import { FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import { METRIC } from "../../helpers/metrics";
+
+// Protocol reference: https://xaue.com/xaue_protocol_info_en.v1.pdf
+// The document describes XAUE value accrual through Oracle NAV growth and does not disclose protocol fee rates.
+const XAUE = "0xd5D6840ed95F58FAf537865DcA15D5f99195F87a";
+const ORACLE = "0x0618BD112C396060d2b37B537b3d92e757644169";
+
+const PRICE_DECIMALS = 18n;
+
+const ABIS = {
+  totalSupply: "uint256:totalSupply",
+  getLatestPrice: "uint256:getLatestPrice",
+  asset: "address:asset",
+  assetDecimals: "uint8:assetDecimals",
+  decimals: "uint8:decimals",
+};
+
+const fetch = async (options: FetchOptions) => {
+  const dailyFees = options.createBalances();
+  const dailySupplySideRevenue = options.createBalances();
+  const dailyRevenue = options.createBalances();
+
+  const [priceStart, priceEnd, totalSupply, asset, assetDecimals, shareDecimals] = await Promise.all([
+    options.fromApi.call({ abi: ABIS.getLatestPrice, target: ORACLE }),
+    options.toApi.call({ abi: ABIS.getLatestPrice, target: ORACLE }),
+    options.fromApi.call({ abi: ABIS.totalSupply, target: XAUE }),
+    options.fromApi.call({ abi: ABIS.asset, target: XAUE }),
+    options.fromApi.call({ abi: ABIS.assetDecimals, target: XAUE }),
+    options.fromApi.call({ abi: ABIS.decimals, target: XAUE }),
+  ]);
+
+  const priceDelta = BigInt(priceEnd) - BigInt(priceStart);
+
+  if (priceDelta > 0n) {
+    const conversionScale = 10n ** (BigInt(shareDecimals) + PRICE_DECIMALS - BigInt(assetDecimals));
+    const yieldInAsset = (BigInt(totalSupply) * priceDelta) / conversionScale;
+    dailyFees.add(asset, yieldInAsset, METRIC.ASSETS_YIELDS);
+    dailySupplySideRevenue.add(asset, yieldInAsset, METRIC.ASSETS_YIELDS);
+  }
+
+  return {
+    dailyFees,
+    dailyRevenue,
+    dailyProtocolRevenue: dailyRevenue,
+    dailySupplySideRevenue,
+  };
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  adapter: {
+    [CHAIN.ETHEREUM]: {
+      fetch,
+      start: "2026-03-24", // first full UTC day after block 24718738, Mar-23-2026 07:30:59 AM UTC
+    },
+  },
+  methodology: {
+    Fees: "Yield accrued to XAUE holders from Oracle NAV growth. The Oracle computes NAV linearly from baseNetValue and currentAPR; daily yield is start-of-period XAUE supply multiplied by the NAV increase.",
+    Revenue: "No protocol revenue or management/performance fee is disclosed in the protocol information document, so revenue is reported as zero.",
+    ProtocolRevenue: "No protocol revenue or management/performance fee is disclosed in the protocol information document, so protocol revenue is reported as zero.",
+    SupplySideRevenue: "Yield accrued to XAUE holders through XAUE NAV appreciation, denominated in XAUt.",
+  },
+  breakdownMethodology: {
+    Fees: {
+      [METRIC.ASSETS_YIELDS]: "Yield generated from XAUE Oracle NAV appreciation.",
+    },
+    SupplySideRevenue: {
+      [METRIC.ASSETS_YIELDS]: "Yield distributed to XAUE holders through NAV appreciation.",
+    },
+  },
+};
+
+export default adapter;


### PR DESCRIPTION
Fixes #6700 


## Summary

Adds a fees adapter for XAUE on Ethereum.

XAUE accrues value through Oracle NAV growth. The adapter reads XAUE supply and Oracle NAV at the start/end of the period, then reports the NAV increase as holder yield.

## Methodology

- `dailyFees`: Yield accrued from XAUE Oracle NAV appreciation.
- `dailySupplySideRevenue`: Same yield distributed to XAUE holders through NAV appreciation.
- `dailyRevenue`: `0`, because the protocol documentation and contract ABIs do not disclose protocol, management, performance, mint, or redemption fees.
- `dailyProtocolRevenue`: `0`, for the same reason.

## Implementation

- Uses on-chain contract calls only.
- Reads `getLatestPrice()` from the XAUE Oracle.
- Reads `totalSupply()`, `asset()`, `assetDecimals()`, and `decimals()` from the XAUE FundToken.
- Starts from `2026-03-24`, the first full UTC day after Ethereum block `24718738` (`Mar-23-2026 07:30:59 UTC`).
