### PR TITLE
Add Tsunami V3 (Ink)

### DIFF
--- a/dexs/tsunami/index.ts
+++ b/dexs/tsunami/index.ts
@@ -1,0 +1,43 @@
+import { CHAIN } from "../../helpers/chains";
+import { SimpleAdapter } from "../../adapters/types";
+import { getGraphDimensions2 } from "../../helpers/getUniSubgraph";
+
+const SUBGRAPH =
+  "https://api.goldsky.com/api/public/project_cmm7vh5xwsa8m01qmdr7w7u62/subgraphs/tsunami-v3/2.4.0/gn";
+
+const graphs = getGraphDimensions2({
+  graphUrls: { [CHAIN.INK]: SUBGRAPH },
+  totalVolume: { factory: "factories", field: "totalVolumeUSD" },
+  totalFees: { factory: "factories", field: "totalFeesUSD" },
+  feesPercent: {
+    type: "fees",
+    UserFees: 100,
+    SupplySideRevenue: 100,
+    Revenue: 0,
+    ProtocolRevenue: 0,
+    HoldersRevenue: 0,
+  },
+});
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  adapter: {
+    [CHAIN.INK]: {
+      fetch: graphs,
+      start: "2026-03-14",
+    },
+  },
+  methodology: {
+    Volume:
+      "Sum of swap volumes across all Tsunami V3 pools, computed from Factory.totalVolumeUSD deltas in the Tsunami V3 subgraph.",
+    Fees:
+      "Sum of swap fees across all Tsunami V3 pools (Factory.totalFeesUSD deltas).",
+    UserFees:
+      "100% of swap fees go to LPs — Tsunami V3 has no protocol-fee switch enabled.",
+    SupplySideRevenue: "Equal to UserFees.",
+    Revenue: "0 — no protocol fee.",
+    ProtocolRevenue: "0 — no protocol fee.",
+  },
+};
+
+export default adapter;


### PR DESCRIPTION
## Summary

Adds a volume + fees adapter for **Tsunami V3**, a Uniswap V3 fork on **Ink** (chain ID 57073).

- Subgraph: `tsunami-v3/2.4.0` on Goldsky (public, unauthenticated)
- Factory: `0xD8B0826150B7686D1F56d6F10E31E58e1BCF1193`
- Launch date: 2026-03-14

## Methodology

- **Volume / Fees**: Factory-level deltas from the Tsunami V3 subgraph (`factories.totalVolumeUSD` / `totalFeesUSD`), via `getGraphDimensions2`.
- **Fee split**: 100% of swap fees → LPs (`SupplySideRevenue`). Tsunami V3 does not enable a protocol-fee switch, so `Revenue`, `ProtocolRevenue`, `HoldersRevenue` are all 0.

## Local test

```
$ npm test -- dexs tsunami
🦙 Running TSUNAMI adapter 🦙
INK 👇
Backfill start time: 14/3/2026
Daily volume: 6.08 k
Daily fees: 56.00
Daily user fees: 56.00
Daily supply side revenue: 56.00
Daily revenue: 0.00
Daily protocol revenue: 0.00
Daily holders revenue: 0.00
```

## Related

Companion TVL adapter PR (Tsunami V3 + Sentry listings): https://github.com/DefiLlama/DefiLlama-Adapters/pull/19081