### PR TITLE
feat: add Pleasing Gold fees adapter

### DIFF
--- a/fees/pleasing-gold.ts
+++ b/fees/pleasing-gold.ts
@@ -1,0 +1,47 @@
+import { SimpleAdapter, FetchOptions } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+
+const PSWAP_CONTRACT = "0x3D084Fc4Cc4D5A0B8d6B6517341f359505b35336";
+const PGOLD = "0x3e76BB02286BFeAA89DD35f11253f2CbCE634F91";
+// PUSD is pegged 1:1 to USDT on Arbitrum
+const PUSD = "0xc8fb643d18f1e53698cfda5c8fdf0cdc03c1dbec";
+
+const swapPGOLDToPUSD = "event SwapPGOLDToPUSD(address indexed user, uint256 inAmount, uint256 outAmount, uint256 fee)";
+const swapPUSDToPGOLD = "event SwapPUSDToPGOLD(address indexed user, uint256 inAmount, uint256 outAmount, uint256 fee)";
+
+const fetch = async (options: FetchOptions) => {
+  const dailyFees = options.createBalances();
+
+  const [logs1, logs2] = await Promise.all([
+    options.getLogs({ target: PSWAP_CONTRACT, eventAbi: swapPGOLDToPUSD }),
+    options.getLogs({ target: PSWAP_CONTRACT, eventAbi: swapPUSDToPGOLD }),
+  ]);
+
+  // SwapPGOLDToPUSD: fee is in PUSD (18 decimals, USD-pegged)
+  for (const log of logs1) {
+    dailyFees.add(PUSD, log.fee);
+  }
+
+  // SwapPUSDToPGOLD: fee is in PGOLD
+  for (const log of logs2) {
+    dailyFees.add(PGOLD, log.fee);
+  }
+
+  return { dailyFees, dailyRevenue: dailyFees };
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  adapter: {
+    [CHAIN.ARBITRUM]: {
+      fetch,
+      start: '2025-10-29',
+    }
+  },
+  methodology: {
+    Fees: "Fees collected on PGOLD<>PUSD swaps via the Pleasing Golden spot market.",
+    Revenue: "All swap fees go to the protocol.",
+  }
+};
+
+export default adapter;

--- a/fees/pleasing-gold.ts
+++ b/fees/pleasing-gold.ts
@@ -4,7 +4,7 @@ import { CHAIN } from "../helpers/chains";
 const PSWAP_CONTRACT = "0x3D084Fc4Cc4D5A0B8d6B6517341f359505b35336";
 const PGOLD = "0x3e76BB02286BFeAA89DD35f11253f2CbCE634F91";
 // PUSD is pegged 1:1 to USDT on Arbitrum
-const PUSD = "0xc8fb643d18f1e53698cfda5c8fdf0cdc03c1dbec";
+const USDT = "0xfd086bc7cd5c481dcc9c85ebe478a1c0b69fcbb9"; // PUSD is 1:1 redeemable for USDT
 
 const swapPGOLDToPUSD = "event SwapPGOLDToPUSD(address indexed user, uint256 inAmount, uint256 outAmount, uint256 fee)";
 const swapPUSDToPGOLD = "event SwapPUSDToPGOLD(address indexed user, uint256 inAmount, uint256 outAmount, uint256 fee)";
@@ -19,7 +19,7 @@ const fetch = async (options: FetchOptions) => {
 
   // SwapPGOLDToPUSD: fee is in PUSD (18 decimals, USD-pegged)
   for (const log of logs1) {
-    dailyFees.add(PUSD, log.fee);
+    dailyFees.add(USDT, log.fee);
   }
 
   // SwapPUSDToPGOLD: fee is in PGOLD

--- a/fees/pleasing-gold.ts
+++ b/fees/pleasing-gold.ts
@@ -3,45 +3,46 @@ import { CHAIN } from "../helpers/chains";
 
 const PSWAP_CONTRACT = "0x3D084Fc4Cc4D5A0B8d6B6517341f359505b35336";
 const PGOLD = "0x3e76BB02286BFeAA89DD35f11253f2CbCE634F91";
-// PUSD is pegged 1:1 to USDT on Arbitrum
-const USDT = "0xfd086bc7cd5c481dcc9c85ebe478a1c0b69fcbb9"; // PUSD is 1:1 redeemable for USDT
+const PUSD = "0xC8Fb643D18F1e53698CFDa5c8Fdf0cdC03C1dBec"
 
-const swapPGOLDToPUSD = "event SwapPGOLDToPUSD(address indexed user, uint256 inAmount, uint256 outAmount, uint256 fee)";
-const swapPUSDToPGOLD = "event SwapPUSDToPGOLD(address indexed user, uint256 inAmount, uint256 outAmount, uint256 fee)";
+const swapPGOLDToPUSD = "event SwapPGOLDToPUSD(address user, uint256 inAmount, uint256 outAmount, uint256 fee)";
+const swapPUSDToPGOLD = "event SwapPUSDToPGOLD(address user, uint256 inAmount, uint256 outAmount, uint256 fee)";
 
 const fetch = async (options: FetchOptions) => {
-  const dailyFees = options.createBalances();
+    const dailyFees = options.createBalances();
 
-  const [logs1, logs2] = await Promise.all([
-    options.getLogs({ target: PSWAP_CONTRACT, eventAbi: swapPGOLDToPUSD }),
-    options.getLogs({ target: PSWAP_CONTRACT, eventAbi: swapPUSDToPGOLD }),
-  ]);
+    const [pGoldToPUSDLogs, pUSDToPGOLDLogs] = await Promise.all([
+        options.getLogs({ target: PSWAP_CONTRACT, eventAbi: swapPGOLDToPUSD }),
+        options.getLogs({ target: PSWAP_CONTRACT, eventAbi: swapPUSDToPGOLD }),
+    ]);
 
-  // SwapPGOLDToPUSD: fee is in PUSD (18 decimals, USD-pegged)
-  for (const log of logs1) {
-    dailyFees.add(USDT, log.fee);
-  }
+    // SwapPGOLDToPUSD: fee is in PUSD (18 decimals, USD-pegged)
+    for (const log of pGoldToPUSDLogs) {
+        dailyFees.add(PUSD, log.fee);
+    }
 
-  // SwapPUSDToPGOLD: fee is in PGOLD
-  for (const log of logs2) {
-    dailyFees.add(PGOLD, log.fee);
-  }
+    // SwapPUSDToPGOLD: fee is in PGOLD
+    for (const log of pUSDToPGOLDLogs) {
+        dailyFees.add(PGOLD, log.fee);
+    }
 
-  return { dailyFees, dailyRevenue: dailyFees };
+    return { dailyFees, dailyRevenue: 0, dailySupplySideRevenue: dailyFees };
 };
 
 const adapter: SimpleAdapter = {
-  version: 2,
-  adapter: {
-    [CHAIN.ARBITRUM]: {
-      fetch,
-      start: '2025-10-29',
+    version: 2,
+    pullHourly: true,
+    adapter: {
+        [CHAIN.ARBITRUM]: {
+            fetch,
+            start: '2025-10-29',
+        }
+    },
+    methodology: {
+        Fees: "Fees collected on PGOLD<>PUSD swaps via the Pleasing Golden spot market.",
+        Revenue: "No revenue",
+        SupplySideRevenue: "All the fees collected on PGOLD<>PUSD swaps generates yield for PGOLD stakers.",
     }
-  },
-  methodology: {
-    Fees: "Fees collected on PGOLD<>PUSD swaps via the Pleasing Golden spot market.",
-    Revenue: "All swap fees go to the protocol.",
-  }
 };
 
 export default adapter;


### PR DESCRIPTION
## Summary

Closes #6695

Tracks fees from PGOLD<>PUSD swaps on the Pleasing Golden spot market.

## Contract

pSwap Contract: `0x3D084Fc4Cc4D5A0B8d6B6517341f359505b35336` (Arbitrum)

## Fee Events

- `SwapPGOLDToPUSD` — fee paid in PUSD (18 decimals, USD-pegged)
- `SwapPUSDToPGOLD` — fee paid in PGOLD

## Notes

- Adapter returns 0 on days with no swaps (infrequent activity)
- Start date: 2025-10-29 (Pleasing Golden launch)