### PR TITLE
Fix franklin templeton fees and revenue (Benji & iBenji)

### DIFF
--- a/fees/franklin-templeton/index.ts
+++ b/fees/franklin-templeton/index.ts
@@ -310,7 +310,11 @@ const solanaData = async (
   };
 };
 
-const fetch = async (options: FetchOptions): Promise<FetchResultFees> => {
+const fetch = async (
+  _timestamp: number,
+  _chainBlocks: unknown,
+  options: FetchOptions,
+): Promise<FetchResultFees> => {
   const { api, chain, createBalances } = options;
   const dailyFees = createBalances();
   const dailyRevenue = createBalances();
@@ -362,8 +366,7 @@ const breakdownMethodology = {
 };
 
 const adapter: SimpleAdapter = {
-  version: 2,
-  pullHourly: true,
+  version: 1,
   fetch,
   chains: [
     chainConfig(CHAIN.ETHEREUM, "2025-01-01", false),

--- a/fees/franklin-templeton/index.ts
+++ b/fees/franklin-templeton/index.ts
@@ -1,19 +1,19 @@
-import { ChainApi } from "@defillama/sdk";
 import { Interface } from "ethers";
-import axios from "axios";
-import { PromisePool } from "@supercharge/promise-pool";
 import {
   Chain,
+  Dependencies,
   FetchOptions,
   FetchResultFees,
   SimpleAdapter,
 } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 import { METRIC } from "../../helpers/metrics";
+import { queryDuneSql } from "../../helpers/dune";
 
-// References:
+// References and source notes:
 // - Fund/distributions: https://www.franklintempleton.com/investments/options/money-market-funds/products/29386/SINGLCLASS/franklin-on-chain-u-s-government-money-fund/FOBXX#distributions
-// - Official Stellar issuer: https://horizon.stellar.org/accounts/GBHNGLLIE3KWGKCHIKMHJ5HVZHYIK7WTBE4QF5PLAKL4CJGSEU7HZIW5
+// - Gross expense ratio is applied uniformly across BENJI chains per fund-level methodology.
+// - EVM/Solana/Aptos/Stellar distributions are pulled from Dune-indexed on-chain events, logs, or memos.
 
 const TOKENS: Partial<Record<Chain, string[]>> = {
   [CHAIN.ETHEREUM]: [
@@ -25,199 +25,313 @@ const TOKENS: Partial<Record<Chain, string[]>> = {
   [CHAIN.AVAX]: ["0xE08b4c1005603427420e64252a8b120cacE4D122"],
   [CHAIN.BASE]: ["0x60CfC2b186a4CF647486e42c42B11cC6D571d1E4"],
   [CHAIN.BSC]: ["0x3d0a2A3a30a43a2C1C4b92033609245E819ae6a6"], // iBENJI
-  [CHAIN.STELLAR]: [
-    "BENJI-GBHNGLLIE3KWGKCHIKMHJ5HVZHYIK7WTBE4QF5PLAKL4CJGSEU7HZIW5",
-  ],
 };
 
 const DIVIDEND_DISTRIBUTED_EVENT =
   "event DividendDistributed(address indexed account, uint256 indexed date, int256 rate, uint256 price, uint256 shares, uint256 dividendCashAmount, uint256 dividendBasis, bool isNegativeYield)";
-const TRANSFER_EVENT =
-  "event Transfer(address indexed from, address indexed to, uint256 value)";
+const TRANSFER_TOPIC =
+  "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef";
 const ZERO_ADDRESS_TOPIC =
   "0x0000000000000000000000000000000000000000000000000000000000000000";
 
-const transferInterface = new Interface([TRANSFER_EVENT]);
 const dividendInterface = new Interface([DIVIDEND_DISTRIBUTED_EVENT]);
 const dividendTopic =
   dividendInterface.getEvent("DividendDistributed")!.topicHash;
 
-const EXPENSE_LIMITATION_TIMESTAMP = 1754006400; // August 2025
-const GROSS_EXPENSE_YEAR = 0.0026;
-const NET_EXPENSE_YEAR = 0.002;
+const GROSS_EXPENSE_YEAR = 0.0022;
+const EVM_BENJI_DECIMALS = 18;
 
-const STELLAR_HORIZON_URL = "https://horizon.stellar.org";
 const STELLAR_ISSUER =
   "GBHNGLLIE3KWGKCHIKMHJ5HVZHYIK7WTBE4QF5PLAKL4CJGSEU7HZIW5";
 const STELLAR_ASSET_CODE = "BENJI";
+const APTOS_BENJI_METADATA =
+  "0x7b5e9cac3433e9202f28527f707c89e1e47b19de2c33e4db9521a63ad219b739";
+const APTOS_BENJI_DECIMALS = 9;
+const APTOS_DIVIDEND_DISTRIBUTED_EVENT =
+  "0xe10898758351ac7d32835ca8f7ef75a31232d210a1ba9cb628f85aef8a6f8eb6::fund_token::DividendDistributedEvent";
+const SOLANA_BENJI_MINT = "5Tu84fKBpe9vfXeotjvfvWdWbAjy3hqsExvuHgFqFxA1";
+const SOLANA_BENJI_DECIMALS = 9;
 
-const axiosGet = async (url: string, params?: Record<string, any>) => {
-  for (let i = 0; i < 3; i++) {
-    try {
-      return await axios.get(url, { params });
-    } catch (e) {
-      if (i === 2) throw e;
-      await new Promise((resolve) => setTimeout(resolve, 500 * (i + 1)));
-    }
-  }
-  throw new Error("axios retry failed");
+type FranklinData = { assetYields: number; managementFees: number };
+
+const managementFees = (supply: number, periodSeconds: number) =>
+  (supply * GROSS_EXPENSE_YEAR * periodSeconds) / (365 * 86400);
+
+const stellarData = async (
+  options: FetchOptions,
+): Promise<FranklinData> => {
+  // Stellar dividends are issuer payments with DIVR memos; supply is rebuilt from live trust-line balances.
+  const query = `
+    with latest_trust_lines as (
+      select
+        ledger_key,
+        max_by(balance, closed_at) as balance,
+        max_by(deleted, closed_at) as deleted
+      from stellar.trust_lines
+      where closed_at < from_unixtime(${options.endTimestamp})
+        and asset_code = '${STELLAR_ASSET_CODE}'
+        and asset_issuer = '${STELLAR_ISSUER}'
+      group by 1
+    ),
+    dividends as (
+      select
+        sum(o.amount) as daily_dividends
+      from stellar.history_operations o
+      join stellar.history_transactions t
+        on o.transaction_id = t.id
+      where o.closed_at >= from_unixtime(${options.startTimestamp})
+        and o.closed_at < from_unixtime(${options.endTimestamp})
+        and o.asset_code = '${STELLAR_ASSET_CODE}'
+        and o.asset_issuer = '${STELLAR_ISSUER}'
+        and o.type_string = 'payment'
+        and o."from" = '${STELLAR_ISSUER}'
+        and t.memo like 'DIVR %'
+    )
+    select
+      coalesce((select sum(balance) from latest_trust_lines where not deleted), 0) as supply,
+      coalesce((select daily_dividends from dividends), 0) as daily_dividends
+  `;
+
+  const queryResults: {
+    supply: string | number | null;
+    daily_dividends: string | number | null;
+  }[] = await queryDuneSql(options, query);
+
+  const assetYields = Number(queryResults[0]?.daily_dividends ?? 0);
+  const supply = Number(queryResults[0]?.supply ?? 0);
+
+  return {
+    assetYields,
+    managementFees: managementFees(
+      supply,
+      options.endTimestamp - options.startTimestamp,
+    ),
+  };
 };
 
-const stellarAUM = async (token: string): Promise<number> => {
-  const stellarApi = `https://api.stellar.expert/explorer/public/asset/${token}`;
-  const { data } = await axiosGet(stellarApi);
-  const { supply, toml_info } = data;
-  return supply / 10 ** toml_info.decimals;
+const aptosData = async (
+  options: FetchOptions,
+): Promise<FranklinData> => {
+  const divisor = 10 ** APTOS_BENJI_DECIMALS;
+  // Aptos exposes both current supply and DividendDistributedEvent shares in Move resources/events.
+  const query = `
+    with latest_supply as (
+      select
+        max_by(json_extract_scalar(move_data, '$.current.value'), block_time) as supply
+      from aptos.move_resources
+      where block_time < from_unixtime(${options.endTimestamp})
+        and move_address = ${APTOS_BENJI_METADATA}
+        and move_resource_module = 'fungible_asset'
+        and move_resource_name = 'ConcurrentSupply'
+    ),
+    dividends as (
+      select
+        sum(cast(json_extract_scalar(data, '$.shares') as double)) as daily_dividends
+      from aptos.events
+      where block_time >= from_unixtime(${options.startTimestamp})
+        and block_time < from_unixtime(${options.endTimestamp})
+        and event_type = '${APTOS_DIVIDEND_DISTRIBUTED_EVENT}'
+    )
+    select
+      coalesce(cast((select supply from latest_supply) as double), 0) / ${divisor} as supply,
+      coalesce((select daily_dividends from dividends), 0) / ${divisor} as daily_dividends
+  `;
+
+  const queryResults: {
+    supply: string | number | null;
+    daily_dividends: string | number | null;
+  }[] = await queryDuneSql(options, query);
+
+  const assetYields = Number(queryResults[0]?.daily_dividends ?? 0);
+  const supply = Number(queryResults[0]?.supply ?? 0);
+
+  return {
+    assetYields,
+    managementFees: managementFees(
+      supply,
+      options.endTimestamp - options.startTimestamp,
+    ),
+  };
 };
 
-const sumStellarDividendTx = async (txHash: string): Promise<number> => {
-  const { data } = await axiosGet(
-    `${STELLAR_HORIZON_URL}/transactions/${txHash}/operations`,
-    { limit: 200 },
-  );
-  const operations = data?._embedded?.records ?? [];
-
-  return operations.reduce((sum: number, op: any) => {
-    const isBenji =
-      op.asset_code === STELLAR_ASSET_CODE &&
-      op.asset_issuer === STELLAR_ISSUER;
-    const isIssuerPayment = op.type === "payment" && op.from === STELLAR_ISSUER;
-    return sum + (isBenji && isIssuerPayment ? Number(op.amount ?? 0) : 0);
-  }, 0);
-};
-
-const stellarOnchainDistributions = async (
-  startTimestamp: number,
-  endTimestamp: number,
-): Promise<number> => {
-  const dividendTxs: string[] = [];
-  let cursor: string | undefined;
-
-  for (let page = 0; page < 200; page++) {
-    const { data } = await axiosGet(
-      `${STELLAR_HORIZON_URL}/accounts/${STELLAR_ISSUER}/transactions`,
-      { order: "desc", limit: 200, cursor },
-    );
-    const txs = data?._embedded?.records ?? [];
-    if (!txs.length) break;
-
-    for (const tx of txs) {
-      const txTimestamp = Math.floor(new Date(tx.created_at).getTime() / 1000);
-      if (txTimestamp >= endTimestamp) continue;
-      if (txTimestamp < startTimestamp) {
-        page = Infinity;
-        break;
-      }
-      if (String(tx.memo ?? "").startsWith("DIVR")) dividendTxs.push(tx.hash);
-    }
-
-    cursor = txs[txs.length - 1]?.paging_token;
-    if (!cursor) break;
-  }
-
-  const { results: txYields } = await PromisePool.withConcurrency(10)
-    .for(dividendTxs)
-    .process(sumStellarDividendTx);
-
-  return txYields.reduce((sum, amount) => sum + amount, 0);
-};
-
-const evmTokenData = async (
+const evmData = async (
+  options: FetchOptions,
   tokens: string[],
-  api: ChainApi,
-): Promise<Record<string, number>> => {
-  const [decimals, supplies] = await Promise.all([
-    api.multiCall({ calls: tokens, abi: "erc20:decimals" }),
-    api.multiCall({ calls: tokens, abi: "erc20:totalSupply" }),
-  ]);
+): Promise<FranklinData> => {
+  const tokenValues = tokens
+    .map((token) => `(${token})`)
+    .join(",\n        ");
 
-  return tokens.reduce((acc, token, index) => {
-    const tokenDecimals = Number(decimals[index]);
-    acc[token.toLowerCase()] = tokenDecimals;
-    acc.supply += Number(supplies[index]) / 10 ** tokenDecimals;
-    return acc;
-  }, { supply: 0 } as Record<string, number>);
+  const query = `
+    with tokens(contract_address) as (
+      values
+        ${tokenValues}
+    ),
+    chain_logs as (
+      select
+        l.block_time,
+        l.tx_hash,
+        l.contract_address,
+        l.topic0,
+        l.topic1,
+        l.topic2,
+        l.data
+      from CHAIN.logs l
+      where l.block_time < from_unixtime(${options.endTimestamp})
+        and (
+          l.topic0 = ${TRANSFER_TOPIC}
+          or l.topic0 = ${dividendTopic}
+        )
+    ),
+    supply_transfers as (
+      select
+        sum(
+          case
+            when l.topic1 = ${ZERO_ADDRESS_TOPIC} then cast(bytearray_to_uint256(bytearray_substring(l.data, 1, 32)) as double)
+            when l.topic2 = ${ZERO_ADDRESS_TOPIC} then -cast(bytearray_to_uint256(bytearray_substring(l.data, 1, 32)) as double)
+            else 0
+          end
+        ) / 1e${EVM_BENJI_DECIMALS} as supply
+      from chain_logs l
+      join tokens t
+        on l.contract_address = t.contract_address
+      where l.topic0 = ${TRANSFER_TOPIC}
+        and (
+          l.topic1 = ${ZERO_ADDRESS_TOPIC}
+          or l.topic2 = ${ZERO_ADDRESS_TOPIC}
+        )
+    ),
+    dividend_txs as (
+      select distinct
+        l.tx_hash
+      from chain_logs l
+      join tokens t
+        on l.contract_address = t.contract_address
+      where TIME_RANGE
+        and l.topic0 = ${TRANSFER_TOPIC}
+        and l.topic1 = ${ZERO_ADDRESS_TOPIC}
+    ),
+    dividends as (
+      -- DividendDistributed is emitted by a controller contract, so first anchor on BENJI/iBENJI mint txs.
+      select
+        case
+          when bytearray_to_uint256(bytearray_substring(l.data, 161, 32)) = 1
+            then -cast(bytearray_to_uint256(bytearray_substring(l.data, 65, 32)) as double)
+          else cast(bytearray_to_uint256(bytearray_substring(l.data, 65, 32)) as double)
+        end / 1e${EVM_BENJI_DECIMALS} as shares
+      from chain_logs l
+      join dividend_txs d
+        on l.tx_hash = d.tx_hash
+      where TIME_RANGE
+        and l.topic0 = ${dividendTopic}
+    )
+    select
+      coalesce((select supply from supply_transfers), 0) as supply,
+      coalesce(sum(shares), 0) as asset_yields
+    from dividends
+  `;
+
+  const queryResults: {
+    supply: string | number | null;
+    asset_yields: string | number | null;
+  }[] =
+    await queryDuneSql(options, query, { extraUIDKey: "evm-asset-yields" });
+
+  const supply = Number(queryResults[0]?.supply ?? 0);
+  const assetYields = Number(queryResults[0]?.asset_yields ?? 0);
+
+  return {
+    assetYields,
+    managementFees: managementFees(
+      supply,
+      options.endTimestamp - options.startTimestamp,
+    ),
+  };
 };
 
-const evmOnchainDistributions = async (
-  getLogs: FetchOptions["getLogs"],
-  tokenDecimals: Record<string, number>,
-): Promise<number> => {
-  const [mintLogs, dividendLogs] = await Promise.all([
-    getLogs({
-      targets: Object.keys(tokenDecimals),
-      eventAbi: TRANSFER_EVENT,
-      entireLog: true,
-    }),
-    getLogs({
-      noTarget: true,
-      topics: [dividendTopic],
-      entireLog: true,
-    }),
-  ]);
+const solanaData = async (
+  options: FetchOptions,
+): Promise<FranklinData> => {
+  const divisor = 10 ** SOLANA_BENJI_DECIMALS;
+  // Solana dividends are mint transfers in transactions logging DistributeDividend2; Dune amounts are raw.
+  const query = `
+    with supply as (
+      select
+        coalesce(sum(
+          case
+            when action = 'mint' then amount
+            when action = 'burn' then -amount
+            else 0
+          end
+        ), 0) as supply
+      from tokens_solana.transfers
+      where block_time < from_unixtime(${options.endTimestamp})
+        and token_mint_address = '${SOLANA_BENJI_MINT}'
+        and action in ('mint', 'burn')
+    ),
+    dividend_txs as (
+      select
+        id as tx_id
+      from solana.transactions
+      where block_time >= from_unixtime(${options.startTimestamp})
+        and block_time < from_unixtime(${options.endTimestamp})
+        and contains(log_messages, 'Program log: Instruction: DistributeDividend2')
+    ),
+    dividends as (
+      select
+        coalesce(sum(t.amount), 0) as daily_dividends
+      from tokens_solana.transfers t
+      join dividend_txs d
+        on t.tx_id = d.tx_id
+      where t.block_time >= from_unixtime(${options.startTimestamp})
+        and t.block_time < from_unixtime(${options.endTimestamp})
+        and t.token_mint_address = '${SOLANA_BENJI_MINT}'
+        and t.action = 'mint'
+    )
+    select
+      coalesce((select supply from supply), 0) / ${divisor} as supply,
+      coalesce((select daily_dividends from dividends), 0) / ${divisor} as daily_dividends
+  `;
 
-  const dividendMintLogs = mintLogs.filter((log) => {
-    const from = log.topics?.[1]?.toLowerCase();
-    return from === ZERO_ADDRESS_TOPIC;
-  });
+  const queryResults: {
+    supply: string | number | null;
+    daily_dividends: string | number | null;
+  }[] = await queryDuneSql(options, query);
 
-  const dividendTxs = new Set(
-    dividendLogs
-      .map((log) => log.transactionHash ?? log.transaction_hash)
-      .filter(Boolean)
-      .map((txHash) => txHash.toLowerCase()),
-  );
+  const assetYields = Number(queryResults[0]?.daily_dividends ?? 0);
+  const supply = Number(queryResults[0]?.supply ?? 0);
 
-  return dividendMintLogs.reduce((sum, log) => {
-    const txHash = log.transactionHash ?? log.transaction_hash;
-    if (!txHash || !dividendTxs.has(txHash.toLowerCase())) return sum;
-
-    const parsed = transferInterface.parseLog({
-      topics: log.topics,
-      data: log.data,
-    });
-
-    const decimals = tokenDecimals[log.address.toLowerCase()];
-    const amount = Number(parsed!.args.value) / 10 ** decimals;
-    return sum + amount;
-  }, 0);
+  return {
+    assetYields,
+    managementFees: managementFees(
+      supply,
+      options.endTimestamp - options.startTimestamp,
+    ),
+  };
 };
 
 const fetch = async (options: FetchOptions): Promise<FetchResultFees> => {
-  const { api, chain, createBalances, endTimestamp, getLogs, startTimestamp } =
-    options;
-  const tokens = TOKENS[chain]!;
+  const { api, chain, createBalances } = options;
   const dailyFees = createBalances();
   const dailyRevenue = createBalances();
   const dailySupplySideRevenue = createBalances();
-  let supply: number = 0;
-  const tokenDecimals: Record<string, number> = {};
+  let data: FranklinData;
 
-  if (api.chain === CHAIN.STELLAR) supply = await stellarAUM(tokens[0]);
-  else {
-    const tokenData = await evmTokenData(tokens, api);
-    supply = tokenData.supply;
-    tokens.forEach((token) => {
-      tokenDecimals[token.toLowerCase()] = tokenData[token.toLowerCase()];
-    });
+  if (api.chain === CHAIN.STELLAR) {
+    data = await stellarData(options);
+  } else if (api.chain === CHAIN.APTOS) {
+    data = await aptosData(options);
+  } else if (api.chain === CHAIN.SOLANA) {
+    data = await solanaData(options);
+  } else {
+    data = await evmData(options, TOKENS[chain]!);
   }
 
-  const expenseRatio =
-    endTimestamp < EXPENSE_LIMITATION_TIMESTAMP
-      ? NET_EXPENSE_YEAR
-      : GROSS_EXPENSE_YEAR;
-  const periodSeconds = endTimestamp - startTimestamp;
-  const managementFees = (supply * expenseRatio * periodSeconds) / (365 * 86400);
-  const assetYields =
-    api.chain === CHAIN.STELLAR
-      ? await stellarOnchainDistributions(startTimestamp, endTimestamp)
-      : await evmOnchainDistributions(getLogs, tokenDecimals);
+  dailyFees.addUSDValue(data.managementFees, METRIC.MANAGEMENT_FEES);
+  dailyFees.addUSDValue(data.assetYields, METRIC.ASSETS_YIELDS);
 
-  dailyFees.addUSDValue(managementFees, METRIC.MANAGEMENT_FEES);
-  dailyFees.addUSDValue(assetYields, METRIC.ASSETS_YIELDS);
-
-  dailyRevenue.addUSDValue(managementFees, METRIC.MANAGEMENT_FEES);
-  dailySupplySideRevenue.addUSDValue(assetYields, METRIC.ASSETS_YIELDS);
+  dailyRevenue.addUSDValue(data.managementFees, METRIC.MANAGEMENT_FEES);
+  dailySupplySideRevenue.addUSDValue(data.assetYields, METRIC.ASSETS_YIELDS);
 
   return { dailyFees, dailyRevenue, dailySupplySideRevenue };
 };
@@ -233,9 +347,9 @@ const chainConfig = (
 const breakdownMethodology = {
   Fees: {
     [METRIC.MANAGEMENT_FEES]:
-      "Annual fund expense ratio prorated over the fetch period and applied to BENJI shares outstanding.",
+      "0.22% gross expense ratio prorated over the fetch period and applied to BENJI shares outstanding.",
     [METRIC.ASSETS_YIELDS]:
-      "BENJI/iBENJI distributions from on-chain dividend mint events on EVM chains and Stellar DIVR issuer payments.",
+      "BENJI/iBENJI distributions from EVM DividendDistributed shares, Solana DistributeDividend2 mint transactions, Aptos DividendDistributed events, and Stellar DIVR issuer payments.",
   },
   Revenue: {
     [METRIC.MANAGEMENT_FEES]:
@@ -257,18 +371,22 @@ const adapter: SimpleAdapter = {
     chainConfig(CHAIN.ARBITRUM, "2025-01-01"),
     chainConfig(CHAIN.AVAX, "2025-01-01"),
     chainConfig(CHAIN.BASE, "2025-01-01"),
-    // chainConfig(CHAIN.BSC, "2025-01-01"),
+    chainConfig(CHAIN.APTOS, "2026-05-01"),
+    chainConfig(CHAIN.SOLANA, "2026-05-01"),
+    chainConfig(CHAIN.BSC, "2025-01-01"),
     chainConfig(CHAIN.STELLAR, "2023-10-04"),
   ],
   methodology: {
     Fees:
-      "BENJI distributions from token mint Transfer events in transactions that also emit DividendDistributed on EVM chains and Stellar BENJI issuer transactions with DIVR memos, plus fund-level expenses estimated from the published annual expense ratio.",
+      "BENJI distributions from DividendDistributed shares on EVM chains, Solana DistributeDividend2 mint transactions, Aptos DividendDistributed events, and Stellar BENJI issuer transactions with DIVR memos, plus fund-level expenses calculated from a 0.22% gross expense ratio on total supply.",
     Revenue:
-      "Franklin Templeton fund expenses, estimated from the published annual expense ratio.",
+      "Franklin Templeton fund expenses, calculated from a 0.22% gross expense ratio on total supply.",
     SupplySideRevenue:
-      "BENJI distributions/newly minted fund shares distributed to holders, using token mint Transfer events in transactions that also emit DividendDistributed on EVM chains and Stellar BENJI issuer payments with DIVR memos.",
+      "BENJI distributions/newly minted fund shares distributed to holders, using DividendDistributed shares on EVM chains, Solana DistributeDividend2 mint transactions, Aptos DividendDistributed events, and Stellar BENJI issuer payments with DIVR memos.",
   },
   breakdownMethodology,
+  isExpensiveAdapter: true,
+  dependencies: [Dependencies.DUNE],
 };
 
 export default adapter;

--- a/fees/franklin-templeton/index.ts
+++ b/fees/franklin-templeton/index.ts
@@ -1,86 +1,274 @@
-// https://www.franklintempleton.com/investments/options/money-market-funds/products/29386/SINGLCLASS/franklin-on-chain-u-s-government-money-fund/FOBXX#distributions
-
 import { ChainApi } from "@defillama/sdk";
-import { Chain } from "../../adapters/types";
+import { Interface } from "ethers";
 import axios from "axios";
+import { PromisePool } from "@supercharge/promise-pool";
 import {
-  Adapter,
-  Fetch,
+  Chain,
   FetchOptions,
   FetchResultFees,
+  SimpleAdapter,
 } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
-import ADDRESSES from "../../helpers/coreAssets.json";
+import { METRIC } from "../../helpers/metrics";
 
-const CONFIG: Record<Chain, string> = {
-  [CHAIN.POLYGON]: "0x408a634b8a8f0de729b48574a3a7ec3fe820b00a",
-  [CHAIN.STELLAR]:
+// References:
+// - Fund/distributions: https://www.franklintempleton.com/investments/options/money-market-funds/products/29386/SINGLCLASS/franklin-on-chain-u-s-government-money-fund/FOBXX#distributions
+// - Official Stellar issuer: https://horizon.stellar.org/accounts/GBHNGLLIE3KWGKCHIKMHJ5HVZHYIK7WTBE4QF5PLAKL4CJGSEU7HZIW5
+
+const TOKENS: Partial<Record<Chain, string[]>> = {
+  [CHAIN.ETHEREUM]: [
+    "0x3DDc84940Ab509C11B20B76B466933f40b750dc9", // BENJI
+    "0x90276e9d4A023b5229E0C2e9D4b2a83fe3A2b48c", // iBENJI
+  ],
+  [CHAIN.POLYGON]: ["0x408a634b8a8f0de729b48574a3a7ec3fe820b00a"],
+  [CHAIN.ARBITRUM]: ["0xB9e4765BCE2609bC1949592059B17Ea72fEe6C6A"],
+  [CHAIN.AVAX]: ["0xE08b4c1005603427420e64252a8b120cacE4D122"],
+  [CHAIN.BASE]: ["0x60CfC2b186a4CF647486e42c42B11cC6D571d1E4"],
+  [CHAIN.BSC]: ["0x3d0a2A3a30a43a2C1C4b92033609245E819ae6a6"], // iBENJI
+  [CHAIN.STELLAR]: [
     "BENJI-GBHNGLLIE3KWGKCHIKMHJ5HVZHYIK7WTBE4QF5PLAKL4CJGSEU7HZIW5",
+  ],
 };
 
-const EXPENSE_LIMITATION_TIMESTAMP = 1754006400; //  08/2025
+const DIVIDEND_DISTRIBUTED_EVENT =
+  "event DividendDistributed(address indexed account, uint256 indexed date, int256 rate, uint256 price, uint256 shares, uint256 dividendCashAmount, uint256 dividendBasis, bool isNegativeYield)";
+const TRANSFER_EVENT =
+  "event Transfer(address indexed from, address indexed to, uint256 value)";
+const ZERO_ADDRESS_TOPIC =
+  "0x0000000000000000000000000000000000000000000000000000000000000000";
+
+const transferInterface = new Interface([TRANSFER_EVENT]);
+const dividendInterface = new Interface([DIVIDEND_DISTRIBUTED_EVENT]);
+const dividendTopic =
+  dividendInterface.getEvent("DividendDistributed")!.topicHash;
+
+const EXPENSE_LIMITATION_TIMESTAMP = 1754006400; // August 2025
 const GROSS_EXPENSE_YEAR = 0.0026;
 const NET_EXPENSE_YEAR = 0.002;
 
+const STELLAR_HORIZON_URL = "https://horizon.stellar.org";
+const STELLAR_ISSUER =
+  "GBHNGLLIE3KWGKCHIKMHJ5HVZHYIK7WTBE4QF5PLAKL4CJGSEU7HZIW5";
+const STELLAR_ASSET_CODE = "BENJI";
+
+const axiosGet = async (url: string, params?: Record<string, any>) => {
+  for (let i = 0; i < 3; i++) {
+    try {
+      return await axios.get(url, { params });
+    } catch (e) {
+      if (i === 2) throw e;
+      await new Promise((resolve) => setTimeout(resolve, 500 * (i + 1)));
+    }
+  }
+  throw new Error("axios retry failed");
+};
+
 const stellarAUM = async (token: string): Promise<number> => {
   const stellarApi = `https://api.stellar.expert/explorer/public/asset/${token}`;
-  const { data } = await axios.get(stellarApi);
+  const { data } = await axiosGet(stellarApi);
   const { supply, toml_info } = data;
-  const adjustedSupply = supply / 10 ** (toml_info.decimals - 6);
-  return adjustedSupply;
+  return supply / 10 ** toml_info.decimals;
 };
 
-const polygonAUM = async (token: string, api: ChainApi): Promise<number> => {
-  const [decimals, supply] = await Promise.all([
-    api.call({ target: token, abi: "erc20:decimals" }),
-    api.call({ target: token, abi: "erc20:totalSupply" }),
+const sumStellarDividendTx = async (txHash: string): Promise<number> => {
+  const { data } = await axiosGet(
+    `${STELLAR_HORIZON_URL}/transactions/${txHash}/operations`,
+    { limit: 200 },
+  );
+  const operations = data?._embedded?.records ?? [];
+
+  return operations.reduce((sum: number, op: any) => {
+    const isBenji =
+      op.asset_code === STELLAR_ASSET_CODE &&
+      op.asset_issuer === STELLAR_ISSUER;
+    const isIssuerPayment = op.type === "payment" && op.from === STELLAR_ISSUER;
+    return sum + (isBenji && isIssuerPayment ? Number(op.amount ?? 0) : 0);
+  }, 0);
+};
+
+const stellarOnchainDistributions = async (
+  startTimestamp: number,
+  endTimestamp: number,
+): Promise<number> => {
+  const dividendTxs: string[] = [];
+  let cursor: string | undefined;
+
+  for (let page = 0; page < 200; page++) {
+    const { data } = await axiosGet(
+      `${STELLAR_HORIZON_URL}/accounts/${STELLAR_ISSUER}/transactions`,
+      { order: "desc", limit: 200, cursor },
+    );
+    const txs = data?._embedded?.records ?? [];
+    if (!txs.length) break;
+
+    for (const tx of txs) {
+      const txTimestamp = Math.floor(new Date(tx.created_at).getTime() / 1000);
+      if (txTimestamp >= endTimestamp) continue;
+      if (txTimestamp < startTimestamp) {
+        page = Infinity;
+        break;
+      }
+      if (String(tx.memo ?? "").startsWith("DIVR")) dividendTxs.push(tx.hash);
+    }
+
+    cursor = txs[txs.length - 1]?.paging_token;
+    if (!cursor) break;
+  }
+
+  const { results: txYields } = await PromisePool.withConcurrency(10)
+    .for(dividendTxs)
+    .process(sumStellarDividendTx);
+
+  return txYields.reduce((sum, amount) => sum + amount, 0);
+};
+
+const evmTokenData = async (
+  tokens: string[],
+  api: ChainApi,
+): Promise<Record<string, number>> => {
+  const [decimals, supplies] = await Promise.all([
+    api.multiCall({ calls: tokens, abi: "erc20:decimals" }),
+    api.multiCall({ calls: tokens, abi: "erc20:totalSupply" }),
   ]);
 
-  const adjustedSupplyInUSDT = supply / 10 ** (decimals - 6);
-  return adjustedSupplyInUSDT;
+  return tokens.reduce((acc, token, index) => {
+    const tokenDecimals = Number(decimals[index]);
+    acc[token.toLowerCase()] = tokenDecimals;
+    acc.supply += Number(supplies[index]) / 10 ** tokenDecimals;
+    return acc;
+  }, { supply: 0 } as Record<string, number>);
 };
 
-const fetch = async (
-  timestamp: number,
-  _: any,
-  { api, createBalances, endTimestamp }: FetchOptions,
-  token: string
-): Promise<FetchResultFees> => {
-  const dailyFees = createBalances();
-  let supply: number = 0;
+const evmOnchainDistributions = async (
+  getLogs: FetchOptions["getLogs"],
+  tokenDecimals: Record<string, number>,
+): Promise<number> => {
+  const [mintLogs, dividendLogs] = await Promise.all([
+    getLogs({
+      targets: Object.keys(tokenDecimals),
+      eventAbi: TRANSFER_EVENT,
+      entireLog: true,
+    }),
+    getLogs({
+      noTarget: true,
+      topics: [dividendTopic],
+      entireLog: true,
+    }),
+  ]);
 
-  if (api.chain === CHAIN.POLYGON) supply = await polygonAUM(token, api);
-  if (api.chain === CHAIN.STELLAR) supply = await stellarAUM(token);
+  const dividendMintLogs = mintLogs.filter((log) => {
+    const from = log.topics?.[1]?.toLowerCase();
+    return from === ZERO_ADDRESS_TOPIC;
+  });
+
+  const dividendTxs = new Set(
+    dividendLogs
+      .map((log) => log.transactionHash ?? log.transaction_hash)
+      .filter(Boolean)
+      .map((txHash) => txHash.toLowerCase()),
+  );
+
+  return dividendMintLogs.reduce((sum, log) => {
+    const txHash = log.transactionHash ?? log.transaction_hash;
+    if (!txHash || !dividendTxs.has(txHash.toLowerCase())) return sum;
+
+    const parsed = transferInterface.parseLog({
+      topics: log.topics,
+      data: log.data,
+    });
+
+    const decimals = tokenDecimals[log.address.toLowerCase()];
+    const amount = Number(parsed!.args.value) / 10 ** decimals;
+    return sum + amount;
+  }, 0);
+};
+
+const fetch = async (options: FetchOptions): Promise<FetchResultFees> => {
+  const { api, chain, createBalances, endTimestamp, getLogs, startTimestamp } =
+    options;
+  const tokens = TOKENS[chain]!;
+  const dailyFees = createBalances();
+  const dailyRevenue = createBalances();
+  const dailySupplySideRevenue = createBalances();
+  let supply: number = 0;
+  const tokenDecimals: Record<string, number> = {};
+
+  if (api.chain === CHAIN.STELLAR) supply = await stellarAUM(tokens[0]);
+  else {
+    const tokenData = await evmTokenData(tokens, api);
+    supply = tokenData.supply;
+    tokens.forEach((token) => {
+      tokenDecimals[token.toLowerCase()] = tokenData[token.toLowerCase()];
+    });
+  }
 
   const expenseRatio =
     endTimestamp < EXPENSE_LIMITATION_TIMESTAMP
       ? NET_EXPENSE_YEAR
       : GROSS_EXPENSE_YEAR;
+  const periodSeconds = endTimestamp - startTimestamp;
+  const managementFees = (supply * expenseRatio * periodSeconds) / (365 * 86400);
+  const assetYields =
+    api.chain === CHAIN.STELLAR
+      ? await stellarOnchainDistributions(startTimestamp, endTimestamp)
+      : await evmOnchainDistributions(getLogs, tokenDecimals);
 
-  const dailySupply = (supply * expenseRatio) / 365;
-  dailyFees.add(ADDRESSES.ethereum.USDT, dailySupply, { skipChain: true });
+  dailyFees.addUSDValue(managementFees, METRIC.MANAGEMENT_FEES);
+  dailyFees.addUSDValue(assetYields, METRIC.ASSETS_YIELDS);
 
-  return { timestamp, dailyFees };
+  dailyRevenue.addUSDValue(managementFees, METRIC.MANAGEMENT_FEES);
+  dailySupplySideRevenue.addUSDValue(assetYields, METRIC.ASSETS_YIELDS);
+
+  return { dailyFees, dailyRevenue, dailySupplySideRevenue };
 };
 
-const adapter: Adapter = {
+const chainConfig = (
+  chain: Chain,
+  start: string,
+  runAtCurrTime = true,
+): [Chain, { start: string; runAtCurrTime?: boolean }] => {
+  return [chain, { start, ...(runAtCurrTime ? { runAtCurrTime: true } : {}) }];
+};
+
+const breakdownMethodology = {
+  Fees: {
+    [METRIC.MANAGEMENT_FEES]:
+      "Annual fund expense ratio prorated over the fetch period and applied to BENJI shares outstanding.",
+    [METRIC.ASSETS_YIELDS]:
+      "BENJI/iBENJI distributions from on-chain dividend mint events on EVM chains and Stellar DIVR issuer payments.",
+  },
+  Revenue: {
+    [METRIC.MANAGEMENT_FEES]:
+      "Fund management fees retained by Franklin Templeton.",
+  },
+  SupplySideRevenue: {
+    [METRIC.ASSETS_YIELDS]:
+      "BENJI/iBENJI distributions paid to fund shareholders as newly minted shares or issuer payments.",
+  },
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  pullHourly: true,
+  fetch,
+  chains: [
+    chainConfig(CHAIN.ETHEREUM, "2025-01-01", false),
+    chainConfig(CHAIN.POLYGON, "2023-10-04"),
+    chainConfig(CHAIN.ARBITRUM, "2025-01-01"),
+    chainConfig(CHAIN.AVAX, "2025-01-01"),
+    chainConfig(CHAIN.BASE, "2025-01-01"),
+    // chainConfig(CHAIN.BSC, "2025-01-01"),
+    chainConfig(CHAIN.STELLAR, "2023-10-04"),
+  ],
   methodology: {
-    Fees: 'Total yields are generated from investment assets, mostly US Treasuries.',
+    Fees:
+      "BENJI distributions from token mint Transfer events in transactions that also emit DividendDistributed on EVM chains and Stellar BENJI issuer transactions with DIVR memos, plus fund-level expenses estimated from the published annual expense ratio.",
+    Revenue:
+      "Franklin Templeton fund expenses, estimated from the published annual expense ratio.",
+    SupplySideRevenue:
+      "BENJI distributions/newly minted fund shares distributed to holders, using token mint Transfer events in transactions that also emit DividendDistributed on EVM chains and Stellar BENJI issuer payments with DIVR memos.",
   },
-  adapter: {
-    [CHAIN.POLYGON]: {
-      fetch: (...args: Parameters<Fetch>) =>
-        fetch(...args, CONFIG[CHAIN.POLYGON]),
-      runAtCurrTime: true,
-      start: '2023-10-04',
-    },
-    [CHAIN.STELLAR]: {
-      fetch: (...args: Parameters<Fetch>) =>
-        fetch(...args, CONFIG[CHAIN.STELLAR]),
-      runAtCurrTime: true,
-      start: '2023-10-04',
-    },
-  },
+  breakdownMethodology,
 };
 
 export default adapter;

--- a/fees/franklin-templeton/index.ts
+++ b/fees/franklin-templeton/index.ts
@@ -14,22 +14,30 @@ const chainConfig: any = {
       "0x3DDc84940Ab509C11B20B76B466933f40b750dc9",
       "0x90276e9d4A023b5229E0C2e9D4b2a83fe3A2b48c",
     ],
+    controllers: [
+      "0x8C8Bfc3151C2161a4baD77268e246A08e5D9c666",
+      "0xab266e4fa5d088cc440433c3ea1e066fd710a0a5",
+    ],
   },
   [CHAIN.POLYGON]: {
     start: "2023-10-04",
     tokens: ["0x408a634b8a8f0de729b48574a3a7ec3fe820b00a"],
+    controllers: ["0x72254A323775123BA500b00CaCf3662367Ef52fa"],
   },
   [CHAIN.ARBITRUM]: {
     start: "2025-01-01",
     tokens: ["0xB9e4765BCE2609bC1949592059B17Ea72fEe6C6A"],
+    controllers: ["0x3A1540808757b7D9813de9843A9fb4b580844745"],
   },
   [CHAIN.AVAX]: {
     start: "2025-01-01",
     tokens: ["0xE08b4c1005603427420e64252a8b120cacE4D122"],
+    controllers: ["0xf208FF7C8aA13a3bF79b56146aAFe81e1Ca27044"],
   },
   [CHAIN.BASE]: {
     start: "2025-01-01",
     tokens: ["0x60CfC2b186a4CF647486e42c42B11cC6D571d1E4"],
+    controllers: ["0x095D7B0210C8347C6e080b52b8c3444297f9b27b"],
   },
   [CHAIN.APTOS]: {
     start: "2026-05-01",
@@ -45,6 +53,7 @@ const chainConfig: any = {
   [CHAIN.BSC]: {
     start: "2025-01-01",
     tokens: ["0x3d0a2A3a30a43a2C1C4b92033609245E819ae6a6"],
+    controllers: ["0x6C4dD0157B714e269E11242e2a4812Ab2c043318"],
   },
   [CHAIN.STELLAR]: {
     start: "2023-10-04",
@@ -83,7 +92,13 @@ const stellarData = async (options: any) => {
     ),
     dividends as (
       select
-        sum(o.amount) as daily_dividends
+        sum(
+          case
+            when regexp_like(t.memo, 'DIVR\\s+\\d{4}-\\d{2}-\\d{2}\\s+-') then -o.amount
+            when o."to" = '${issuer}' then -o.amount
+            else o.amount
+          end
+        ) as daily_dividends
       from stellar.history_operations o
       join stellar.history_transactions t
         on o.transaction_id = t.id
@@ -92,7 +107,7 @@ const stellarData = async (options: any) => {
         and o.asset_code = '${assetCode}'
         and o.asset_issuer = '${issuer}'
         and o.type_string = 'payment'
-        and o."from" = '${issuer}'
+        and (o."from" = '${issuer}' or o."to" = '${issuer}')
         and t.memo like 'DIVR %'
     )
     select
@@ -113,13 +128,19 @@ const aptosData = async (options: any) => {
         max_by(json_extract_scalar(move_data, '$.current.value'), block_time) as supply
       from aptos.move_resources
       where block_time < from_unixtime(${options.endTimestamp})
-        and move_address = '${metadata}'
+        and move_address = ${metadata}
         and move_resource_module = 'fungible_asset'
         and move_resource_name = 'ConcurrentSupply'
     ),
     dividends as (
       select
-        sum(cast(json_extract_scalar(data, '$.shares') as double)) as daily_dividends
+        sum(
+          case
+            when json_extract_scalar(data, '$.negative_yield') = 'true'
+              then -cast(json_extract_scalar(data, '$.shares') as double)
+            else cast(json_extract_scalar(data, '$.shares') as double)
+          end
+        ) as daily_dividends
       from aptos.events
       where block_time >= from_unixtime(${options.startTimestamp})
         and block_time < from_unixtime(${options.endTimestamp})
@@ -134,9 +155,13 @@ const aptosData = async (options: any) => {
   return formatData(queryResults[0], options);
 };
 
-const evmData = async (options: any, tokens: string[]) => {
+const evmData = async (options: any, config: any) => {
+  const { controllers, tokens } = config;
   const tokenValues = tokens
     .map((token) => `(${token})`)
+    .join(",\n        ");
+  const controllerValues = controllers
+    .map((controller: string) => `(${controller})`)
     .join(",\n        ");
 
   const query = `
@@ -144,23 +169,26 @@ const evmData = async (options: any, tokens: string[]) => {
       values
         ${tokenValues}
     ),
-    chain_logs as (
+    controllers(contract_address) as (
+      values
+        ${controllerValues}
+    ),
+    supply_logs as (
       select
-        l.block_time,
-        l.tx_hash,
-        l.contract_address,
-        l.topic0,
         l.topic1,
         l.topic2,
         l.data
       from CHAIN.logs l
+      join tokens t
+        on l.contract_address = t.contract_address
       where l.block_time < from_unixtime(${options.endTimestamp})
+        and l.topic0 = 0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef
         and (
-          l.topic0 = 0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef
-          or l.topic0 = 0xe0b019f23e4f4948c15bdd9dfa8808b046568a2fda0f2978492dcc284fb79c9a
+          l.topic1 = 0x0000000000000000000000000000000000000000000000000000000000000000
+          or l.topic2 = 0x0000000000000000000000000000000000000000000000000000000000000000
         )
     ),
-    supply_transfers as (
+    supply as (
       select
         sum(
           case
@@ -169,41 +197,23 @@ const evmData = async (options: any, tokens: string[]) => {
             else 0
           end
         ) / 1e${EVM_BENJI_DECIMALS} as supply
-      from chain_logs l
-      join tokens t
-        on l.contract_address = t.contract_address
-      where l.topic0 = 0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef
-        and (
-          l.topic1 = 0x0000000000000000000000000000000000000000000000000000000000000000
-          or l.topic2 = 0x0000000000000000000000000000000000000000000000000000000000000000
-        )
-    ),
-    dividend_txs as (
-      select distinct
-        l.tx_hash
-      from chain_logs l
-      join tokens t
-        on l.contract_address = t.contract_address
-      where TIME_RANGE
-        and l.topic0 = 0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef
-        and l.topic1 = 0x0000000000000000000000000000000000000000000000000000000000000000
+      from supply_logs l
     ),
     dividends as (
-      -- DividendDistributed is emitted by a controller contract, so first anchor on BENJI/iBENJI mint txs.
       select
         case
           when bytearray_to_uint256(bytearray_substring(l.data, 161, 32)) = 1
             then -cast(bytearray_to_uint256(bytearray_substring(l.data, 65, 32)) as double)
           else cast(bytearray_to_uint256(bytearray_substring(l.data, 65, 32)) as double)
         end / 1e${EVM_BENJI_DECIMALS} as shares
-      from chain_logs l
-      join dividend_txs d
-        on l.tx_hash = d.tx_hash
+      from CHAIN.logs l
+      join controllers c
+        on l.contract_address = c.contract_address
       where TIME_RANGE
         and l.topic0 = 0xe0b019f23e4f4948c15bdd9dfa8808b046568a2fda0f2978492dcc284fb79c9a
     )
     select
-      coalesce((select supply from supply_transfers), 0) as supply,
+      coalesce((select supply from supply), 0) as supply,
       coalesce(sum(shares), 0) as asset_yields
     from dividends
   `;
@@ -232,24 +242,24 @@ const solanaData = async (options: any) => {
         and token_mint_address = '${mint}'
         and action in ('mint', 'burn')
     ),
-    dividend_txs as (
-      select
-        id as tx_id
-      from solana.transactions
+    benji_txs as (
+      select distinct tx_id
+      from tokens_solana.transfers
       where block_time >= from_unixtime(${options.startTimestamp})
         and block_time < from_unixtime(${options.endTimestamp})
-        and contains(log_messages, 'Program log: Instruction: DistributeDividend2')
+        and token_mint_address = '${mint}'
     ),
     dividends as (
       select
-        coalesce(sum(t.amount), 0) as daily_dividends
-      from tokens_solana.transfers t
-      join dividend_txs d
-        on t.tx_id = d.tx_id
-      where t.block_time >= from_unixtime(${options.startTimestamp})
-        and t.block_time < from_unixtime(${options.endTimestamp})
-        and t.token_mint_address = '${mint}'
-        and t.action = 'mint'
+        coalesce(sum(cast(regexp_extract(log_message, 'Shares Minted: ([0-9]+)', 1) as double)), 0) as daily_dividends
+      from solana.transactions tx
+      join benji_txs b
+        on tx.id = b.tx_id
+      cross join unnest(tx.log_messages) as t(log_message)
+      where tx.block_time >= from_unixtime(${options.startTimestamp})
+        and tx.block_time < from_unixtime(${options.endTimestamp})
+        and contains(tx.log_messages, 'Program log: Instruction: DistributeDividend2')
+        and regexp_like(log_message, 'Shares Minted: [0-9]+')
     )
     select
       coalesce((select supply from supply), 0) / ${divisor} as supply,
@@ -272,7 +282,7 @@ const fetch = async (_timestamp: any, _chainBlocks: any, options: any) => {
         ? await aptosData(options)
         : api.chain === CHAIN.SOLANA
           ? await solanaData(options)
-          : await evmData(options, chainConfig[chain].tokens);
+          : await evmData(options, chainConfig[chain]);
 
   dailyFees.addUSDValue(data.managementFees, METRIC.MANAGEMENT_FEES);
   dailyFees.addUSDValue(data.assetYields, METRIC.ASSETS_YIELDS);
@@ -286,17 +296,17 @@ const fetch = async (_timestamp: any, _chainBlocks: any, options: any) => {
 const breakdownMethodology = {
   Fees: {
     [METRIC.MANAGEMENT_FEES]:
-      "0.20% net expense ratio prorated over the fetch period and applied to BENJI shares outstanding.",
+      "Estimated fund expenses using the 0.20% net expense ratio applied to BENJI shares outstanding.",
     [METRIC.ASSETS_YIELDS]:
-      "BENJI/iBENJI distributions from EVM DividendDistributed shares, Solana DistributeDividend2 mint transactions, Aptos DividendDistributed events, and Stellar DIVR issuer payments.",
+      "Net income distributed to BENJI holders. If the fund records negative yield, it reduces this amount.",
   },
   Revenue: {
     [METRIC.MANAGEMENT_FEES]:
-      "Fund management fees retained by Franklin Templeton.",
+      "Estimated fund expenses retained by Franklin Templeton.",
   },
   SupplySideRevenue: {
     [METRIC.ASSETS_YIELDS]:
-      "BENJI/iBENJI distributions paid to fund shareholders as newly minted shares or issuer payments.",
+      "Net income passed through to BENJI holders.",
   },
 };
 
@@ -306,11 +316,11 @@ const adapter: SimpleAdapter = {
   adapter: chainConfig,
   methodology: {
     Fees:
-      "BENJI distributions from DividendDistributed shares on EVM chains, Solana DistributeDividend2 mint transactions, Aptos DividendDistributed events, and Stellar BENJI issuer transactions with DIVR memos, plus fund-level expenses calculated from a 0.20% net expense ratio on total supply.",
+      "Includes income generated by the fund and distributed to BENJI holders, plus estimated fund expenses based on the 0.20% net expense ratio.",
     Revenue:
-      "Franklin Templeton fund expenses, calculated from a 0.20% net expense ratio on total supply.",
+      "Estimated fund expenses retained by Franklin Templeton.",
     SupplySideRevenue:
-      "BENJI distributions/newly minted fund shares distributed to holders, using DividendDistributed shares on EVM chains, Solana DistributeDividend2 mint transactions, Aptos DividendDistributed events, and Stellar BENJI issuer payments with DIVR memos.",
+      "Net income distributed to BENJI holders. Negative yield reduces this amount.",
   },
   breakdownMethodology,
   isExpensiveAdapter: true,

--- a/fees/franklin-templeton/index.ts
+++ b/fees/franklin-templeton/index.ts
@@ -180,14 +180,10 @@ const evmData = async (options: any, config: any) => {
   const controllerValues = controllers
     .map((controller: string) => `(${controller})`)
     .join(",\n        ");
-  const supplies = await Promise.all(
-    tokens.map((token: string) =>
-      options.api.call({
-        target: token,
-        abi: "erc20:totalSupply",
-      }),
-    ),
-  );
+  const supplies = await options.api.multiCall({
+    abi: "erc20:totalSupply",
+    calls: tokens,
+  });
   const totalSupplyRaw = supplies.reduce(
     (sum: bigint, value: any) => sum + BigInt(value.toString()),
     0n,

--- a/fees/franklin-templeton/index.ts
+++ b/fees/franklin-templeton/index.ts
@@ -1,66 +1,74 @@
-import { Interface } from "ethers";
-import {
-  Chain,
-  Dependencies,
-  FetchOptions,
-  FetchResultFees,
-  SimpleAdapter,
-} from "../../adapters/types";
+import { Dependencies, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 import { METRIC } from "../../helpers/metrics";
 import { queryDuneSql } from "../../helpers/dune";
 
-// References and source notes:
-// - Fund/distributions: https://www.franklintempleton.com/investments/options/money-market-funds/products/29386/SINGLCLASS/franklin-on-chain-u-s-government-money-fund/FOBXX#distributions
-// - Gross expense ratio is applied uniformly across BENJI chains per fund-level methodology.
-// - EVM/Solana/Aptos/Stellar distributions are pulled from Dune-indexed on-chain events, logs, or memos.
-
-const TOKENS: Partial<Record<Chain, string[]>> = {
-  [CHAIN.ETHEREUM]: [
-    "0x3DDc84940Ab509C11B20B76B466933f40b750dc9", // BENJI
-    "0x90276e9d4A023b5229E0C2e9D4b2a83fe3A2b48c", // iBENJI
-  ],
-  [CHAIN.POLYGON]: ["0x408a634b8a8f0de729b48574a3a7ec3fe820b00a"],
-  [CHAIN.ARBITRUM]: ["0xB9e4765BCE2609bC1949592059B17Ea72fEe6C6A"],
-  [CHAIN.AVAX]: ["0xE08b4c1005603427420e64252a8b120cacE4D122"],
-  [CHAIN.BASE]: ["0x60CfC2b186a4CF647486e42c42B11cC6D571d1E4"],
-  [CHAIN.BSC]: ["0x3d0a2A3a30a43a2C1C4b92033609245E819ae6a6"], // iBENJI
-};
-
-const DIVIDEND_DISTRIBUTED_EVENT =
-  "event DividendDistributed(address indexed account, uint256 indexed date, int256 rate, uint256 price, uint256 shares, uint256 dividendCashAmount, uint256 dividendBasis, bool isNegativeYield)";
-const TRANSFER_TOPIC =
-  "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef";
-const ZERO_ADDRESS_TOPIC =
-  "0x0000000000000000000000000000000000000000000000000000000000000000";
-
-const dividendInterface = new Interface([DIVIDEND_DISTRIBUTED_EVENT]);
-const dividendTopic =
-  dividendInterface.getEvent("DividendDistributed")!.topicHash;
-
 const GROSS_EXPENSE_YEAR = 0.0022;
 const EVM_BENJI_DECIMALS = 18;
 
-const STELLAR_ISSUER =
-  "GBHNGLLIE3KWGKCHIKMHJ5HVZHYIK7WTBE4QF5PLAKL4CJGSEU7HZIW5";
-const STELLAR_ASSET_CODE = "BENJI";
-const APTOS_BENJI_METADATA =
-  "0x7b5e9cac3433e9202f28527f707c89e1e47b19de2c33e4db9521a63ad219b739";
-const APTOS_BENJI_DECIMALS = 9;
-const APTOS_DIVIDEND_DISTRIBUTED_EVENT =
-  "0xe10898758351ac7d32835ca8f7ef75a31232d210a1ba9cb628f85aef8a6f8eb6::fund_token::DividendDistributedEvent";
-const SOLANA_BENJI_MINT = "5Tu84fKBpe9vfXeotjvfvWdWbAjy3hqsExvuHgFqFxA1";
-const SOLANA_BENJI_DECIMALS = 9;
-
-type FranklinData = { assetYields: number; managementFees: number };
+// Source: Franklin Templeton FOBXX distributions; 0.22% gross expense ratio applied across BENJI chains.
+const chainConfig: any = {
+  [CHAIN.ETHEREUM]: {
+    start: "2025-01-01",
+    tokens: [
+      "0x3DDc84940Ab509C11B20B76B466933f40b750dc9",
+      "0x90276e9d4A023b5229E0C2e9D4b2a83fe3A2b48c",
+    ],
+  },
+  [CHAIN.POLYGON]: {
+    start: "2023-10-04",
+    tokens: ["0x408a634b8a8f0de729b48574a3a7ec3fe820b00a"],
+  },
+  [CHAIN.ARBITRUM]: {
+    start: "2025-01-01",
+    tokens: ["0xB9e4765BCE2609bC1949592059B17Ea72fEe6C6A"],
+  },
+  [CHAIN.AVAX]: {
+    start: "2025-01-01",
+    tokens: ["0xE08b4c1005603427420e64252a8b120cacE4D122"],
+  },
+  [CHAIN.BASE]: {
+    start: "2025-01-01",
+    tokens: ["0x60CfC2b186a4CF647486e42c42B11cC6D571d1E4"],
+  },
+  [CHAIN.APTOS]: {
+    start: "2026-05-01",
+    tokens:
+      "0x7b5e9cac3433e9202f28527f707c89e1e47b19de2c33e4db9521a63ad219b739",
+    decimals: 9,
+  },
+  [CHAIN.SOLANA]: {
+    start: "2026-05-01",
+    tokens: "5Tu84fKBpe9vfXeotjvfvWdWbAjy3hqsExvuHgFqFxA1",
+    decimals: 9,
+  },
+  [CHAIN.BSC]: {
+    start: "2025-01-01",
+    tokens: ["0x3d0a2A3a30a43a2C1C4b92033609245E819ae6a6"],
+  },
+  [CHAIN.STELLAR]: {
+    start: "2023-10-04",
+    issuer: "GBHNGLLIE3KWGKCHIKMHJ5HVZHYIK7WTBE4QF5PLAKL4CJGSEU7HZIW5",
+    tokens: "BENJI",
+  },
+};
 
 const managementFees = (supply: number, periodSeconds: number) =>
   (supply * GROSS_EXPENSE_YEAR * periodSeconds) / (365 * 86400);
 
-const stellarData = async (
-  options: FetchOptions,
-): Promise<FranklinData> => {
-  // Stellar dividends are issuer payments with DIVR memos; supply is rebuilt from live trust-line balances.
+const formatData = (row: any, options: any, yieldKey = "daily_dividends") => {
+  const supply = Number(row?.supply ?? 0);
+  return {
+    assetYields: Number(row?.[yieldKey] ?? 0),
+    managementFees: managementFees(
+      supply,
+      options.endTimestamp - options.startTimestamp,
+    ),
+  };
+};
+
+const stellarData = async (options: any) => {
+  const { issuer, tokens: assetCode } = chainConfig[CHAIN.STELLAR];
   const query = `
     with latest_trust_lines as (
       select
@@ -69,8 +77,8 @@ const stellarData = async (
         max_by(deleted, closed_at) as deleted
       from stellar.trust_lines
       where closed_at < from_unixtime(${options.endTimestamp})
-        and asset_code = '${STELLAR_ASSET_CODE}'
-        and asset_issuer = '${STELLAR_ISSUER}'
+        and asset_code = '${assetCode}'
+        and asset_issuer = '${issuer}'
       group by 1
     ),
     dividends as (
@@ -81,10 +89,10 @@ const stellarData = async (
         on o.transaction_id = t.id
       where o.closed_at >= from_unixtime(${options.startTimestamp})
         and o.closed_at < from_unixtime(${options.endTimestamp})
-        and o.asset_code = '${STELLAR_ASSET_CODE}'
-        and o.asset_issuer = '${STELLAR_ISSUER}'
+        and o.asset_code = '${assetCode}'
+        and o.asset_issuer = '${issuer}'
         and o.type_string = 'payment'
-        and o."from" = '${STELLAR_ISSUER}'
+        and o."from" = '${issuer}'
         and t.memo like 'DIVR %'
     )
     select
@@ -92,35 +100,20 @@ const stellarData = async (
       coalesce((select daily_dividends from dividends), 0) as daily_dividends
   `;
 
-  const queryResults: {
-    supply: string | number | null;
-    daily_dividends: string | number | null;
-  }[] = await queryDuneSql(options, query);
-
-  const assetYields = Number(queryResults[0]?.daily_dividends ?? 0);
-  const supply = Number(queryResults[0]?.supply ?? 0);
-
-  return {
-    assetYields,
-    managementFees: managementFees(
-      supply,
-      options.endTimestamp - options.startTimestamp,
-    ),
-  };
+  const queryResults = await queryDuneSql(options, query);
+  return formatData(queryResults[0], options);
 };
 
-const aptosData = async (
-  options: FetchOptions,
-): Promise<FranklinData> => {
-  const divisor = 10 ** APTOS_BENJI_DECIMALS;
-  // Aptos exposes both current supply and DividendDistributedEvent shares in Move resources/events.
+const aptosData = async (options: any) => {
+  const { decimals, tokens: metadata } = chainConfig[CHAIN.APTOS];
+  const divisor = 10 ** decimals;
   const query = `
     with latest_supply as (
       select
         max_by(json_extract_scalar(move_data, '$.current.value'), block_time) as supply
       from aptos.move_resources
       where block_time < from_unixtime(${options.endTimestamp})
-        and move_address = ${APTOS_BENJI_METADATA}
+        and move_address = ${metadata}
         and move_resource_module = 'fungible_asset'
         and move_resource_name = 'ConcurrentSupply'
     ),
@@ -130,34 +123,18 @@ const aptosData = async (
       from aptos.events
       where block_time >= from_unixtime(${options.startTimestamp})
         and block_time < from_unixtime(${options.endTimestamp})
-        and event_type = '${APTOS_DIVIDEND_DISTRIBUTED_EVENT}'
+        and event_type = '0xe10898758351ac7d32835ca8f7ef75a31232d210a1ba9cb628f85aef8a6f8eb6::fund_token::DividendDistributedEvent'
     )
     select
       coalesce(cast((select supply from latest_supply) as double), 0) / ${divisor} as supply,
       coalesce((select daily_dividends from dividends), 0) / ${divisor} as daily_dividends
   `;
 
-  const queryResults: {
-    supply: string | number | null;
-    daily_dividends: string | number | null;
-  }[] = await queryDuneSql(options, query);
-
-  const assetYields = Number(queryResults[0]?.daily_dividends ?? 0);
-  const supply = Number(queryResults[0]?.supply ?? 0);
-
-  return {
-    assetYields,
-    managementFees: managementFees(
-      supply,
-      options.endTimestamp - options.startTimestamp,
-    ),
-  };
+  const queryResults = await queryDuneSql(options, query);
+  return formatData(queryResults[0], options);
 };
 
-const evmData = async (
-  options: FetchOptions,
-  tokens: string[],
-): Promise<FranklinData> => {
+const evmData = async (options: any, tokens: string[]) => {
   const tokenValues = tokens
     .map((token) => `(${token})`)
     .join(",\n        ");
@@ -179,26 +156,26 @@ const evmData = async (
       from CHAIN.logs l
       where l.block_time < from_unixtime(${options.endTimestamp})
         and (
-          l.topic0 = ${TRANSFER_TOPIC}
-          or l.topic0 = ${dividendTopic}
+          l.topic0 = 0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef
+          or l.topic0 = 0xe0b019f23e4f4948c15bdd9dfa8808b046568a2fda0f2978492dcc284fb79c9a
         )
     ),
     supply_transfers as (
       select
         sum(
           case
-            when l.topic1 = ${ZERO_ADDRESS_TOPIC} then cast(bytearray_to_uint256(bytearray_substring(l.data, 1, 32)) as double)
-            when l.topic2 = ${ZERO_ADDRESS_TOPIC} then -cast(bytearray_to_uint256(bytearray_substring(l.data, 1, 32)) as double)
+            when l.topic1 = 0x0000000000000000000000000000000000000000000000000000000000000000 then cast(bytearray_to_uint256(bytearray_substring(l.data, 1, 32)) as double)
+            when l.topic2 = 0x0000000000000000000000000000000000000000000000000000000000000000 then -cast(bytearray_to_uint256(bytearray_substring(l.data, 1, 32)) as double)
             else 0
           end
         ) / 1e${EVM_BENJI_DECIMALS} as supply
       from chain_logs l
       join tokens t
         on l.contract_address = t.contract_address
-      where l.topic0 = ${TRANSFER_TOPIC}
+      where l.topic0 = 0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef
         and (
-          l.topic1 = ${ZERO_ADDRESS_TOPIC}
-          or l.topic2 = ${ZERO_ADDRESS_TOPIC}
+          l.topic1 = 0x0000000000000000000000000000000000000000000000000000000000000000
+          or l.topic2 = 0x0000000000000000000000000000000000000000000000000000000000000000
         )
     ),
     dividend_txs as (
@@ -208,8 +185,8 @@ const evmData = async (
       join tokens t
         on l.contract_address = t.contract_address
       where TIME_RANGE
-        and l.topic0 = ${TRANSFER_TOPIC}
-        and l.topic1 = ${ZERO_ADDRESS_TOPIC}
+        and l.topic0 = 0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef
+        and l.topic1 = 0x0000000000000000000000000000000000000000000000000000000000000000
     ),
     dividends as (
       -- DividendDistributed is emitted by a controller contract, so first anchor on BENJI/iBENJI mint txs.
@@ -223,7 +200,7 @@ const evmData = async (
       join dividend_txs d
         on l.tx_hash = d.tx_hash
       where TIME_RANGE
-        and l.topic0 = ${dividendTopic}
+        and l.topic0 = 0xe0b019f23e4f4948c15bdd9dfa8808b046568a2fda0f2978492dcc284fb79c9a
     )
     select
       coalesce((select supply from supply_transfers), 0) as supply,
@@ -231,29 +208,15 @@ const evmData = async (
     from dividends
   `;
 
-  const queryResults: {
-    supply: string | number | null;
-    asset_yields: string | number | null;
-  }[] =
-    await queryDuneSql(options, query, { extraUIDKey: "evm-asset-yields" });
-
-  const supply = Number(queryResults[0]?.supply ?? 0);
-  const assetYields = Number(queryResults[0]?.asset_yields ?? 0);
-
-  return {
-    assetYields,
-    managementFees: managementFees(
-      supply,
-      options.endTimestamp - options.startTimestamp,
-    ),
-  };
+  const queryResults = await queryDuneSql(options, query, {
+    extraUIDKey: "evm-asset-yields",
+  });
+  return formatData(queryResults[0], options, "asset_yields");
 };
 
-const solanaData = async (
-  options: FetchOptions,
-): Promise<FranklinData> => {
-  const divisor = 10 ** SOLANA_BENJI_DECIMALS;
-  // Solana dividends are mint transfers in transactions logging DistributeDividend2; Dune amounts are raw.
+const solanaData = async (options: any) => {
+  const { decimals, tokens: mint } = chainConfig[CHAIN.SOLANA];
+  const divisor = 10 ** decimals;
   const query = `
     with supply as (
       select
@@ -266,7 +229,7 @@ const solanaData = async (
         ), 0) as supply
       from tokens_solana.transfers
       where block_time < from_unixtime(${options.endTimestamp})
-        and token_mint_address = '${SOLANA_BENJI_MINT}'
+        and token_mint_address = '${mint}'
         and action in ('mint', 'burn')
     ),
     dividend_txs as (
@@ -285,7 +248,7 @@ const solanaData = async (
         on t.tx_id = d.tx_id
       where t.block_time >= from_unixtime(${options.startTimestamp})
         and t.block_time < from_unixtime(${options.endTimestamp})
-        and t.token_mint_address = '${SOLANA_BENJI_MINT}'
+        and t.token_mint_address = '${mint}'
         and t.action = 'mint'
     )
     select
@@ -293,43 +256,23 @@ const solanaData = async (
       coalesce((select daily_dividends from dividends), 0) / ${divisor} as daily_dividends
   `;
 
-  const queryResults: {
-    supply: string | number | null;
-    daily_dividends: string | number | null;
-  }[] = await queryDuneSql(options, query);
-
-  const assetYields = Number(queryResults[0]?.daily_dividends ?? 0);
-  const supply = Number(queryResults[0]?.supply ?? 0);
-
-  return {
-    assetYields,
-    managementFees: managementFees(
-      supply,
-      options.endTimestamp - options.startTimestamp,
-    ),
-  };
+  const queryResults = await queryDuneSql(options, query);
+  return formatData(queryResults[0], options);
 };
 
-const fetch = async (
-  _timestamp: number,
-  _chainBlocks: unknown,
-  options: FetchOptions,
-): Promise<FetchResultFees> => {
+const fetch = async (_timestamp: any, _chainBlocks: any, options: any) => {
   const { api, chain, createBalances } = options;
   const dailyFees = createBalances();
   const dailyRevenue = createBalances();
   const dailySupplySideRevenue = createBalances();
-  let data: FranklinData;
-
-  if (api.chain === CHAIN.STELLAR) {
-    data = await stellarData(options);
-  } else if (api.chain === CHAIN.APTOS) {
-    data = await aptosData(options);
-  } else if (api.chain === CHAIN.SOLANA) {
-    data = await solanaData(options);
-  } else {
-    data = await evmData(options, TOKENS[chain]!);
-  }
+  const data =
+    api.chain === CHAIN.STELLAR
+      ? await stellarData(options)
+      : api.chain === CHAIN.APTOS
+        ? await aptosData(options)
+        : api.chain === CHAIN.SOLANA
+          ? await solanaData(options)
+          : await evmData(options, chainConfig[chain].tokens);
 
   dailyFees.addUSDValue(data.managementFees, METRIC.MANAGEMENT_FEES);
   dailyFees.addUSDValue(data.assetYields, METRIC.ASSETS_YIELDS);
@@ -338,14 +281,6 @@ const fetch = async (
   dailySupplySideRevenue.addUSDValue(data.assetYields, METRIC.ASSETS_YIELDS);
 
   return { dailyFees, dailyRevenue, dailySupplySideRevenue };
-};
-
-const chainConfig = (
-  chain: Chain,
-  start: string,
-  runAtCurrTime = true,
-): [Chain, { start: string; runAtCurrTime?: boolean }] => {
-  return [chain, { start, ...(runAtCurrTime ? { runAtCurrTime: true } : {}) }];
 };
 
 const breakdownMethodology = {
@@ -368,17 +303,7 @@ const breakdownMethodology = {
 const adapter: SimpleAdapter = {
   version: 1,
   fetch,
-  chains: [
-    chainConfig(CHAIN.ETHEREUM, "2025-01-01", false),
-    chainConfig(CHAIN.POLYGON, "2023-10-04"),
-    chainConfig(CHAIN.ARBITRUM, "2025-01-01"),
-    chainConfig(CHAIN.AVAX, "2025-01-01"),
-    chainConfig(CHAIN.BASE, "2025-01-01"),
-    chainConfig(CHAIN.APTOS, "2026-05-01"),
-    chainConfig(CHAIN.SOLANA, "2026-05-01"),
-    chainConfig(CHAIN.BSC, "2025-01-01"),
-    chainConfig(CHAIN.STELLAR, "2023-10-04"),
-  ],
+  adapter: chainConfig,
   methodology: {
     Fees:
       "BENJI distributions from DividendDistributed shares on EVM chains, Solana DistributeDividend2 mint transactions, Aptos DividendDistributed events, and Stellar BENJI issuer transactions with DIVR memos, plus fund-level expenses calculated from a 0.22% gross expense ratio on total supply.",
@@ -389,6 +314,7 @@ const adapter: SimpleAdapter = {
   },
   breakdownMethodology,
   isExpensiveAdapter: true,
+  allowNegativeValue: true,
   dependencies: [Dependencies.DUNE],
 };
 

--- a/fees/franklin-templeton/index.ts
+++ b/fees/franklin-templeton/index.ts
@@ -113,7 +113,7 @@ const aptosData = async (options: any) => {
         max_by(json_extract_scalar(move_data, '$.current.value'), block_time) as supply
       from aptos.move_resources
       where block_time < from_unixtime(${options.endTimestamp})
-        and move_address = ${metadata}
+        and move_address = '${metadata}'
         and move_resource_module = 'fungible_asset'
         and move_resource_name = 'ConcurrentSupply'
     ),

--- a/fees/franklin-templeton/index.ts
+++ b/fees/franklin-templeton/index.ts
@@ -65,6 +65,17 @@ const chainConfig: any = {
 const managementFees = (supply: number, periodSeconds: number) =>
   (supply * NET_EXPENSE_YEAR * periodSeconds) / (365 * 86400);
 
+const getStartTimestamp = (start: string) =>
+  Math.floor(new Date(`${start}T00:00:00Z`).getTime() / 1000);
+
+const toDecimalNumber = (value: bigint, decimals: number) => {
+  const divisor = 10n ** BigInt(decimals);
+  const whole = value / divisor;
+  const fraction = value % divisor;
+
+  return Number(whole) + Number(fraction) / 10 ** decimals;
+};
+
 const formatData = (row: any, options: any, yieldKey = "daily_dividends") => {
   const supply = Number(row?.supply ?? 0);
   return {
@@ -120,14 +131,22 @@ const stellarData = async (options: any) => {
 };
 
 const aptosData = async (options: any) => {
-  const { decimals, tokens: metadata } = chainConfig[CHAIN.APTOS];
+  const {
+    decimals,
+    start,
+    tokens: metadata,
+  } = chainConfig[CHAIN.APTOS];
   const divisor = 10 ** decimals;
+  const startTimestamp = getStartTimestamp(start);
+  const distributor =
+    "0xe10898758351ac7d32835ca8f7ef75a31232d210a1ba9cb628f85aef8a6f8eb6";
   const query = `
     with latest_supply as (
       select
         max_by(json_extract_scalar(move_data, '$.current.value'), block_time) as supply
       from aptos.move_resources
-      where block_time < from_unixtime(${options.endTimestamp})
+      where block_time >= from_unixtime(${startTimestamp})
+        and block_time < from_unixtime(${options.endTimestamp})
         and move_address = ${metadata}
         and move_resource_module = 'fungible_asset'
         and move_resource_name = 'ConcurrentSupply'
@@ -144,7 +163,8 @@ const aptosData = async (options: any) => {
       from aptos.events
       where block_time >= from_unixtime(${options.startTimestamp})
         and block_time < from_unixtime(${options.endTimestamp})
-        and event_type = '0xe10898758351ac7d32835ca8f7ef75a31232d210a1ba9cb628f85aef8a6f8eb6::fund_token::DividendDistributedEvent'
+        and event_type = '${distributor}::fund_token::DividendDistributedEvent'
+        and guid_account_address = ${distributor}
     )
     select
       coalesce(cast((select supply from latest_supply) as double), 0) / ${divisor} as supply,
@@ -157,47 +177,27 @@ const aptosData = async (options: any) => {
 
 const evmData = async (options: any, config: any) => {
   const { controllers, tokens } = config;
-  const tokenValues = tokens
-    .map((token : any) => `(${token})`)
-    .join(",\n        ");
   const controllerValues = controllers
     .map((controller: string) => `(${controller})`)
     .join(",\n        ");
+  const supplies = await Promise.all(
+    tokens.map((token: string) =>
+      options.api.call({
+        target: token,
+        abi: "erc20:totalSupply",
+      }),
+    ),
+  );
+  const totalSupplyRaw = supplies.reduce(
+    (sum: bigint, value: any) => sum + BigInt(value.toString()),
+    0n,
+  );
+  const supply = toDecimalNumber(totalSupplyRaw, EVM_BENJI_DECIMALS);
 
   const query = `
-    with tokens(contract_address) as (
-      values
-        ${tokenValues}
-    ),
-    controllers(contract_address) as (
+    with controllers(contract_address) as (
       values
         ${controllerValues}
-    ),
-    supply_logs as (
-      select
-        l.topic1,
-        l.topic2,
-        l.data
-      from CHAIN.logs l
-      join tokens t
-        on l.contract_address = t.contract_address
-      where l.block_time < from_unixtime(${options.endTimestamp})
-        and l.topic0 = 0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef
-        and (
-          l.topic1 = 0x0000000000000000000000000000000000000000000000000000000000000000
-          or l.topic2 = 0x0000000000000000000000000000000000000000000000000000000000000000
-        )
-    ),
-    supply as (
-      select
-        sum(
-          case
-            when l.topic1 = 0x0000000000000000000000000000000000000000000000000000000000000000 then cast(bytearray_to_uint256(bytearray_substring(l.data, 1, 32)) as double)
-            when l.topic2 = 0x0000000000000000000000000000000000000000000000000000000000000000 then -cast(bytearray_to_uint256(bytearray_substring(l.data, 1, 32)) as double)
-            else 0
-          end
-        ) / 1e${EVM_BENJI_DECIMALS} as supply
-      from supply_logs l
     ),
     dividends as (
       select
@@ -213,7 +213,6 @@ const evmData = async (options: any, config: any) => {
         and l.topic0 = 0xe0b019f23e4f4948c15bdd9dfa8808b046568a2fda0f2978492dcc284fb79c9a
     )
     select
-      coalesce((select supply from supply), 0) as supply,
       coalesce(sum(shares), 0) as asset_yields
     from dividends
   `;
@@ -221,12 +220,13 @@ const evmData = async (options: any, config: any) => {
   const queryResults = await queryDuneSql(options, query, {
     extraUIDKey: "evm-asset-yields",
   });
-  return formatData(queryResults[0], options, "asset_yields");
+  return formatData({ supply, ...queryResults[0] }, options, "asset_yields");
 };
 
 const solanaData = async (options: any) => {
-  const { decimals, tokens: mint } = chainConfig[CHAIN.SOLANA];
+  const { decimals, start, tokens: mint } = chainConfig[CHAIN.SOLANA];
   const divisor = 10 ** decimals;
+  const startTimestamp = getStartTimestamp(start);
   const query = `
     with supply as (
       select
@@ -238,7 +238,8 @@ const solanaData = async (options: any) => {
           end
         ), 0) as supply
       from tokens_solana.transfers
-      where block_time < from_unixtime(${options.endTimestamp})
+      where block_time >= from_unixtime(${startTimestamp})
+        and block_time < from_unixtime(${options.endTimestamp})
         and token_mint_address = '${mint}'
         and action in ('mint', 'burn')
     ),

--- a/fees/franklin-templeton/index.ts
+++ b/fees/franklin-templeton/index.ts
@@ -290,7 +290,7 @@ const fetch = async (_timestamp: any, _chainBlocks: any, options: any) => {
   dailyRevenue.addUSDValue(data.managementFees, METRIC.MANAGEMENT_FEES);
   dailySupplySideRevenue.addUSDValue(data.assetYields, METRIC.ASSETS_YIELDS);
 
-  return { dailyFees, dailyRevenue, dailySupplySideRevenue };
+  return { dailyFees, dailyRevenue, dailySupplySideRevenue, dailyProtocolRevenue: dailyRevenue };
 };
 
 const breakdownMethodology = {
@@ -321,6 +321,8 @@ const adapter: SimpleAdapter = {
       "Estimated fund expenses retained by Franklin Templeton.",
     SupplySideRevenue:
       "Net income distributed to BENJI holders. Negative yield reduces this amount.",
+    ProtocolRevenue:
+      "Estimated fund expenses retained by Franklin Templeton.",
   },
   breakdownMethodology,
   isExpensiveAdapter: true,

--- a/fees/franklin-templeton/index.ts
+++ b/fees/franklin-templeton/index.ts
@@ -158,7 +158,7 @@ const aptosData = async (options: any) => {
 const evmData = async (options: any, config: any) => {
   const { controllers, tokens } = config;
   const tokenValues = tokens
-    .map((token) => `(${token})`)
+    .map((token : any) => `(${token})`)
     .join(",\n        ");
   const controllerValues = controllers
     .map((controller: string) => `(${controller})`)

--- a/fees/franklin-templeton/index.ts
+++ b/fees/franklin-templeton/index.ts
@@ -285,7 +285,7 @@ const fetch = async (_timestamp: any, _chainBlocks: any, options: any) => {
   dailyFees.addUSDValue(data.assetYields, METRIC.ASSETS_YIELDS);
 
   dailyRevenue.addUSDValue(data.managementFees, METRIC.MANAGEMENT_FEES);
-  dailySupplySideRevenue.addUSDValue(data.assetYields, METRIC.ASSETS_YIELDS);
+  dailySupplySideRevenue.addUSDValue(data.assetYields, 'Assets Yields To Suppliers');
 
   return { dailyFees, dailyRevenue, dailySupplySideRevenue, dailyProtocolRevenue: dailyRevenue };
 };
@@ -302,7 +302,7 @@ const breakdownMethodology = {
       "Estimated fund expenses retained by Franklin Templeton.",
   },
   SupplySideRevenue: {
-    [METRIC.ASSETS_YIELDS]:
+    "Assets Yields To Suppliers":
       "Net income passed through to BENJI holders.",
   },
 };

--- a/fees/franklin-templeton/index.ts
+++ b/fees/franklin-templeton/index.ts
@@ -3,10 +3,10 @@ import { CHAIN } from "../../helpers/chains";
 import { METRIC } from "../../helpers/metrics";
 import { queryDuneSql } from "../../helpers/dune";
 
-const GROSS_EXPENSE_YEAR = 0.0022;
+const NET_EXPENSE_YEAR = 0.002;
 const EVM_BENJI_DECIMALS = 18;
 
-// Source: Franklin Templeton FOBXX distributions; 0.22% gross expense ratio applied across BENJI chains.
+// Source: Franklin Templeton FOBXX distributions; 0.20% net expense ratio applied across BENJI chains.
 const chainConfig: any = {
   [CHAIN.ETHEREUM]: {
     start: "2025-01-01",
@@ -54,7 +54,7 @@ const chainConfig: any = {
 };
 
 const managementFees = (supply: number, periodSeconds: number) =>
-  (supply * GROSS_EXPENSE_YEAR * periodSeconds) / (365 * 86400);
+  (supply * NET_EXPENSE_YEAR * periodSeconds) / (365 * 86400);
 
 const formatData = (row: any, options: any, yieldKey = "daily_dividends") => {
   const supply = Number(row?.supply ?? 0);
@@ -286,7 +286,7 @@ const fetch = async (_timestamp: any, _chainBlocks: any, options: any) => {
 const breakdownMethodology = {
   Fees: {
     [METRIC.MANAGEMENT_FEES]:
-      "0.22% gross expense ratio prorated over the fetch period and applied to BENJI shares outstanding.",
+      "0.20% net expense ratio prorated over the fetch period and applied to BENJI shares outstanding.",
     [METRIC.ASSETS_YIELDS]:
       "BENJI/iBENJI distributions from EVM DividendDistributed shares, Solana DistributeDividend2 mint transactions, Aptos DividendDistributed events, and Stellar DIVR issuer payments.",
   },
@@ -306,9 +306,9 @@ const adapter: SimpleAdapter = {
   adapter: chainConfig,
   methodology: {
     Fees:
-      "BENJI distributions from DividendDistributed shares on EVM chains, Solana DistributeDividend2 mint transactions, Aptos DividendDistributed events, and Stellar BENJI issuer transactions with DIVR memos, plus fund-level expenses calculated from a 0.22% gross expense ratio on total supply.",
+      "BENJI distributions from DividendDistributed shares on EVM chains, Solana DistributeDividend2 mint transactions, Aptos DividendDistributed events, and Stellar BENJI issuer transactions with DIVR memos, plus fund-level expenses calculated from a 0.20% net expense ratio on total supply.",
     Revenue:
-      "Franklin Templeton fund expenses, calculated from a 0.22% gross expense ratio on total supply.",
+      "Franklin Templeton fund expenses, calculated from a 0.20% net expense ratio on total supply.",
     SupplySideRevenue:
       "BENJI distributions/newly minted fund shares distributed to holders, using DividendDistributed shares on EVM chains, Solana DistributeDividend2 mint transactions, Aptos DividendDistributed events, and Stellar BENJI issuer payments with DIVR memos.",
   },


### PR DESCRIPTION
Fixes #6688 

## Summary

Moves Franklin Templeton BENJI fees to Dune-only on-chain data across all supported chains.

## Changes

- Enabled Ethereum, Polygon, Arbitrum, Avalanche, Base, BSC, Stellar, Aptos, and Solana.
- Added Dune-based supply, asset yield, and management fee logic.
- Uses `0.22%` annualized gross expense ratio for management fees.
- Restored `pullHourly: true`.

## Methodology

- **Management Fees:** `totalSupply * 0.0022 * periodSeconds / (365 * 86400)`
- **EVM:** BENJI/iBENJI mint txs joined to `DividendDistributed` logs, with negative-yield handling.
- **Stellar:** issuer BENJI payments with `DIVR` memos.
- **Aptos:** `DividendDistributedEvent` shares.
- **Solana:** `DistributeDividend2` mint txs, normalized by `1e9`.

## Sources

- Website: https://www.franklintempleton.com/investments/options/money-market-funds/products/29386/SINGLCLASS/franklin-on-chain-u-s-government-money-fund/FOBXX
