### PR TITLE
Add Hashlock Markets - Cross-chain OTC HTLC volume adapter (Ethereum + Sui)

### DIFF
--- a/dexs/hashlock-markets/ethereum.ts
+++ b/dexs/hashlock-markets/ethereum.ts
@@ -1,0 +1,46 @@
+import { FetchOptions, FetchResultV2 } from "../../adapters/types";
+import ADDRESSES from "../../helpers/coreAssets.json";
+
+// Hashlock Markets Ethereum mainnet HTLC contracts.
+// Source: https://github.com/Hashlock-Tech/hashlock-markets/blob/main/contracts/deployments-mainnet.json
+const CONTRACTS = {
+  HashedTimelockEther: "0x0CEDC56b17d714dA044954EE26F38e90eC10434A",
+  HashedTimelockEtherFee: "0xfBAEA1423b5FBeCE89998da6820902fD8f159014",
+  HashedTimelockERC20Fee: "0x4B65490D140Bab3DB828C2386e21646Ed8c4D072",
+} as const;
+
+// Withdraw events: only emitted on successful preimage redemption (settled leg).
+// Refunded HTLCs emit HTLCETH_Refund / HTLCERC20_Refund instead, which are NOT counted.
+const ABIS = {
+  HTLCETH_Withdraw:
+    "event HTLCETH_Withdraw(bytes32 indexed contractId, address indexed receiver, bytes32 preimage, uint256 amount)",
+  HTLCERC20_Withdraw:
+    "event HTLCERC20_Withdraw(bytes32 indexed contractId, address indexed receiver, bytes32 preimage, uint256 amount, address tokenContract)",
+};
+
+const ETHEREUM_NATIVE = ADDRESSES.ethereum.WETH; // price-feed proxy for native ETH
+
+export async function fetchEthereum(options: FetchOptions): Promise<FetchResultV2> {
+  const dailyVolume = options.createBalances();
+
+  // Native-ETH HTLCs (no-fee + fee variants share the same Withdraw event signature).
+  const ethLogs = await options.getLogs({
+    targets: [CONTRACTS.HashedTimelockEther, CONTRACTS.HashedTimelockEtherFee],
+    eventAbi: ABIS.HTLCETH_Withdraw,
+    flatten: true,
+  });
+  for (const log of ethLogs) {
+    dailyVolume.add(ETHEREUM_NATIVE, log.amount);
+  }
+
+  // ERC-20 HTLCs (fee variant only — base ERC20 contract was not deployed on mainnet).
+  const erc20Logs = await options.getLogs({
+    target: CONTRACTS.HashedTimelockERC20Fee,
+    eventAbi: ABIS.HTLCERC20_Withdraw,
+  });
+  for (const log of erc20Logs) {
+    dailyVolume.add(log.tokenContract, log.amount);
+  }
+
+  return { dailyVolume };
+}

--- a/dexs/hashlock-markets/ethereum.ts
+++ b/dexs/hashlock-markets/ethereum.ts
@@ -1,13 +1,6 @@
 import { FetchOptions, FetchResultV2 } from "../../adapters/types";
 import ADDRESSES from "../../helpers/coreAssets.json";
-
-// Hashlock Markets Ethereum mainnet HTLC contracts.
-// Source: https://github.com/Hashlock-Tech/hashlock-markets/blob/main/contracts/deployments-mainnet.json
-const CONTRACTS = {
-  HashedTimelockEther: "0x0CEDC56b17d714dA044954EE26F38e90eC10434A",
-  HashedTimelockEtherFee: "0xfBAEA1423b5FBeCE89998da6820902fD8f159014",
-  HashedTimelockERC20Fee: "0x4B65490D140Bab3DB828C2386e21646Ed8c4D072",
-} as const;
+import { buildHashlockLegIndex, isSourceLeg, ETH_HTLC_CONTRACTS } from "./shared";
 
 // Withdraw events: only emitted on successful preimage redemption (settled leg).
 // Refunded HTLCs emit HTLCETH_Refund / HTLCERC20_Refund instead, which are NOT counted.
@@ -22,23 +15,34 @@ const ETHEREUM_NATIVE = ADDRESSES.ethereum.WETH; // price-feed proxy for native 
 
 export async function fetchEthereum(options: FetchOptions): Promise<FetchResultV2> {
   const dailyVolume = options.createBalances();
+  const legIndex = await buildHashlockLegIndex(options);
 
   // Native-ETH HTLCs (no-fee + fee variants share the same Withdraw event signature).
   const ethLogs = await options.getLogs({
-    targets: [CONTRACTS.HashedTimelockEther, CONTRACTS.HashedTimelockEtherFee],
+    targets: [ETH_HTLC_CONTRACTS.HashedTimelockEther, ETH_HTLC_CONTRACTS.HashedTimelockEtherFee],
     eventAbi: ABIS.HTLCETH_Withdraw,
     flatten: true,
   });
   for (const log of ethLogs) {
+    const contractId = String(log.contractId).toLowerCase();
+    const leg = legIndex.byEthContractId.get(contractId);
+    // No matching Create in the 48h lookback window: paired-leg attribution
+    // can't be determined here. Skip rather than risk double-counting.
+    if (!leg) continue;
+    if (!isSourceLeg(legIndex, leg)) continue;
     dailyVolume.add(ETHEREUM_NATIVE, log.amount);
   }
 
   // ERC-20 HTLCs (fee variant only — base ERC20 contract was not deployed on mainnet).
   const erc20Logs = await options.getLogs({
-    target: CONTRACTS.HashedTimelockERC20Fee,
+    target: ETH_HTLC_CONTRACTS.HashedTimelockERC20Fee,
     eventAbi: ABIS.HTLCERC20_Withdraw,
   });
   for (const log of erc20Logs) {
+    const contractId = String(log.contractId).toLowerCase();
+    const leg = legIndex.byEthContractId.get(contractId);
+    if (!leg) continue;
+    if (!isSourceLeg(legIndex, leg)) continue;
     dailyVolume.add(log.tokenContract, log.amount);
   }
 

--- a/dexs/hashlock-markets/index.ts
+++ b/dexs/hashlock-markets/index.ts
@@ -1,0 +1,31 @@
+import { FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import { fetchEthereum } from "./ethereum";
+import { fetchSui } from "./sui";
+
+const methodology = {
+  Volume:
+    "Settled trade volume from on-chain HTLC withdraw events. Hashlock Markets is a cross-chain OTC venue: takers post sealed-bid RFQs, market makers respond, both sides lock funds in HTLCs (Hash Time-Locked Contracts) on their respective chains using a shared sha256 hash. When the taker reveals the preimage, both legs settle atomically; otherwise both refund after the timelock. " +
+    "Per-chain dailyVolume = sum of HTLC withdraw notional on that chain in the day window. " +
+    "Each cross-chain trade emits one withdraw event per leg (one per chain), so the protocol-level total is approximately 2x the unique-trade USD value. The `doublecounted: true` flag is set so DefiLlama can deduplicate at protocol level. " +
+    "Ethereum: amount is read directly from the Withdraw event. Sui: amount is read from the corresponding HTLCLocked event (joined by htlc_id), counted only when the HTLC was claimed (not refunded). " +
+    "Refunded HTLCs are excluded from volume on both chains. Full methodology: https://hashlock.markets/methodology",
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  doublecounted: true,
+  methodology,
+  adapter: {
+    [CHAIN.ETHEREUM]: {
+      fetch: fetchEthereum,
+      start: "2026-04-09",
+    },
+    [CHAIN.SUI]: {
+      fetch: fetchSui,
+      start: "2026-05-01",
+    },
+  },
+};
+
+export default adapter;

--- a/dexs/hashlock-markets/index.ts
+++ b/dexs/hashlock-markets/index.ts
@@ -8,13 +8,14 @@ const methodology = {
     "Settled trade volume from on-chain HTLC withdraw events. Hashlock Markets is a cross-chain OTC venue: takers post sealed-bid RFQs, market makers respond, both sides lock funds in HTLCs (Hash Time-Locked Contracts) on their respective chains using a shared sha256 hash. When the taker reveals the preimage, both legs settle atomically; otherwise both refund after the timelock. " +
     "Per-chain dailyVolume = sum of HTLC withdraw notional on that chain in the day window. " +
     "Each cross-chain trade emits one withdraw event per leg (one per chain), so the protocol-level total is approximately 2x the unique-trade USD value. The `doublecounted: true` flag is set so DefiLlama can deduplicate at protocol level. " +
-    "Ethereum: amount is read directly from the Withdraw event. Sui: amount is read from the corresponding HTLCLocked event (joined by htlc_id), counted only when the HTLC was claimed (not refunded). " +
+    "Ethereum: amount is read directly from the Withdraw event. Sui: amount is read from the HTLCLocked event, counted for all non-refunded locks on lock day. Sui's HTLCClaimed event does not carry amount, so claim-day attribution is not possible; lock-day counting eliminates cross-midnight gaps. " +
     "Refunded HTLCs are excluded from volume on both chains. Full methodology: https://hashlock.markets/methodology",
 };
 
 const adapter: SimpleAdapter = {
   version: 2,
   doublecounted: true,
+  pullHourly: true,
   methodology,
   adapter: {
     [CHAIN.ETHEREUM]: {

--- a/dexs/hashlock-markets/index.ts
+++ b/dexs/hashlock-markets/index.ts
@@ -1,20 +1,18 @@
-import { FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 import { fetchEthereum } from "./ethereum";
 import { fetchSui } from "./sui";
 
 const methodology = {
   Volume:
-    "Settled trade volume from on-chain HTLC withdraw events. Hashlock Markets is a cross-chain OTC venue: takers post sealed-bid RFQs, market makers respond, both sides lock funds in HTLCs (Hash Time-Locked Contracts) on their respective chains using a shared sha256 hash. When the taker reveals the preimage, both legs settle atomically; otherwise both refund after the timelock. " +
-    "Per-chain dailyVolume = sum of HTLC withdraw notional on that chain in the day window. " +
-    "Each cross-chain trade emits one withdraw event per leg (one per chain), so the protocol-level total is approximately 2x the unique-trade USD value. The `doublecounted: true` flag is set so DefiLlama can deduplicate at protocol level. " +
-    "Ethereum: amount is read directly from the Withdraw event. Sui: amount is read from the HTLCLocked event, counted for all non-refunded locks on lock day. Sui's HTLCClaimed event does not carry amount, so claim-day attribution is not possible; lock-day counting eliminates cross-midnight gaps. " +
+    "Settled trade volume from on-chain HTLC events. Hashlock Markets is a cross-chain OTC venue: takers post sealed-bid RFQs, market makers respond, both sides lock funds in HTLCs (Hash Time-Locked Contracts) on their respective chains using a shared sha256 hash. When the taker reveals the preimage, both legs settle atomically; otherwise both refund after the timelock. " +
+    "Each cross-chain trade emits one withdraw event per leg (one on each chain), but a trade is counted ONCE — on the source leg, defined as the chain where the taker deposits and the maker withdraws after preimage reveal. The source leg is identified deterministically as the leg with the longest timelock among all legs sharing the same hashlock; per the atomic-swap protocol, the source-leg timelock is always strictly greater than the destination-leg timelock to ensure preimage propagation safety. " +
+    "Ethereum: source-leg HTLCETH_Withdraw and HTLCERC20_Withdraw amounts are read directly from the event. Sui: source-leg HTLCLocked amount is read from the lock event and attributed to lock day (Sui's HTLCClaimed event does not carry amount, so claim-day attribution is not possible; lock-day counting eliminates cross-midnight gaps). " +
     "Refunded HTLCs are excluded from volume on both chains. Full methodology: https://hashlock.markets/methodology",
 };
 
 const adapter: SimpleAdapter = {
   version: 2,
-  doublecounted: true,
   pullHourly: true,
   methodology,
   adapter: {

--- a/dexs/hashlock-markets/shared.ts
+++ b/dexs/hashlock-markets/shared.ts
@@ -1,0 +1,187 @@
+import * as sdk from "@defillama/sdk";
+import { FetchOptions } from "../../adapters/types";
+import { queryEvents } from "../../helpers/sui";
+
+// Cross-leg attribution: each cross-chain HTLC trade emits one Locked/Created
+// event per leg, sharing the same `hashlock`. Per Hashlock Markets' atomic-swap
+// protocol, the SOURCE leg (where the taker deposits, equivalently where the
+// maker withdraws after preimage reveal) ALWAYS has a strictly longer timelock
+// than the destination leg. We attribute the trade's volume to the source leg
+// only, never to both legs — this is what bheluga@DefiLlama specified in the
+// PR review (no `doublecounted` flag; single-count per trade on the
+// taker-deposit / maker-withdraw chain).
+
+// 48h lookback window for cross-leg matching. Hashlock timelocks are bounded
+// well under 24h in practice; 48h gives a comfortable margin for paired legs
+// that lock close to a window boundary.
+const LOOKBACK_SECONDS = 48 * 60 * 60;
+
+// Hashlock Markets Ethereum mainnet HTLC contracts.
+// Source: https://github.com/Hashlock-Tech/hashlock-markets/blob/main/contracts/deployments-mainnet.json
+export const ETH_HTLC_CONTRACTS = {
+  HashedTimelockEther: "0x0CEDC56b17d714dA044954EE26F38e90eC10434A",
+  HashedTimelockEtherFee: "0xfBAEA1423b5FBeCE89998da6820902fD8f159014",
+  HashedTimelockERC20Fee: "0x4B65490D140Bab3DB828C2386e21646Ed8c4D072",
+} as const;
+
+// Event ABIs. Note: HashedTimelockEther (no-fee) and HashedTimelockEtherFee
+// (with fee) emit events with the SAME name `HTLCETH_New` but DIFFERENT
+// signatures (the fee variant has 4 extra fee-recipient/rebate fields), so
+// they hash to different topic0 values and must be queried separately.
+const ABI_HTLCETH_NEW_NO_FEE =
+  "event HTLCETH_New(bytes32 indexed contractId, address indexed sender, address indexed receiver, uint256 amount, bytes32 hashlock, uint256 timelock)";
+const ABI_HTLCETH_NEW_FEE =
+  "event HTLCETH_New(bytes32 indexed contractId, address indexed sender, address indexed receiver, uint256 amount, bytes32 hashlock, uint256 timelock, address feeRecipient, uint16 feeBps, address rebateRecipient, uint16 rebateBps)";
+const ABI_HTLCERC20_NEW_FEE =
+  "event HTLCERC20_New(bytes32 indexed contractId, address indexed sender, address indexed receiver, address tokenContract, uint256 amount, bytes32 hashlock, uint256 timelock, address feeRecipient, uint16 feeBps, address rebateRecipient, uint16 rebateBps)";
+
+// Hashlock Markets Sui mainnet HTLC package.
+export const SUI_PACKAGE =
+  "0xd0f016aaec58d79c9108866b35e59412e3e95d7252464858c8141345f44bad0e";
+export const SUI_MODULE = "htlc";
+
+export type ChainName = "ethereum" | "sui";
+
+export interface Leg {
+  chain: ChainName;
+  /** 0x-prefixed lowercase hex string. */
+  hashlock: string;
+  /** contractId on Ethereum, htlc_id on Sui — uniquely identifies a leg on its chain. */
+  legId: string;
+  /** Unix milliseconds. */
+  timelockMs: number;
+}
+
+export interface LegIndex {
+  byHashlock: Map<string, Leg[]>;
+  byEthContractId: Map<string, Leg>;
+  bySuiHtlcId: Map<string, Leg>;
+}
+
+function normalizeHashlock(input: unknown): string {
+  if (typeof input === "string") {
+    const s = input.toLowerCase();
+    return s.startsWith("0x") ? s : `0x${s}`;
+  }
+  if (Array.isArray(input)) {
+    const hex = (input as number[])
+      .map((b) => Number(b).toString(16).padStart(2, "0"))
+      .join("");
+    return `0x${hex.toLowerCase()}`;
+  }
+  return "";
+}
+
+async function getEthBlock(timestamp: number): Promise<number> {
+  // sdk.blocks.getBlockNumber is the modern API for chain-agnostic timestamp -> block resolution.
+  const block = await (sdk.blocks as any).getBlockNumber("ethereum", timestamp);
+  return typeof block === "number" ? block : (block?.number ?? block);
+}
+
+async function pullEthereumLegs(
+  startTs: number,
+  endTs: number
+): Promise<Leg[]> {
+  const fromBlock = await getEthBlock(startTs);
+  const toBlock = await getEthBlock(endTs);
+
+  const out: Leg[] = [];
+
+  const callsCfg = [
+    { target: ETH_HTLC_CONTRACTS.HashedTimelockEther, eventAbi: ABI_HTLCETH_NEW_NO_FEE },
+    { target: ETH_HTLC_CONTRACTS.HashedTimelockEtherFee, eventAbi: ABI_HTLCETH_NEW_FEE },
+    { target: ETH_HTLC_CONTRACTS.HashedTimelockERC20Fee, eventAbi: ABI_HTLCERC20_NEW_FEE },
+  ];
+
+  for (const cfg of callsCfg) {
+    const logs = await sdk.indexer.getLogs({
+      chain: "ethereum",
+      target: cfg.target,
+      eventAbi: cfg.eventAbi,
+      fromBlock,
+      toBlock,
+      onlyArgs: true,
+    });
+    for (const ev of logs as any[]) {
+      out.push({
+        chain: "ethereum",
+        hashlock: normalizeHashlock(ev.hashlock),
+        legId: String(ev.contractId).toLowerCase(),
+        timelockMs: Number(ev.timelock) * 1000,
+      });
+    }
+  }
+
+  return out;
+}
+
+async function pullSuiLegs(startTs: number, endTs: number): Promise<Leg[]> {
+  const events: any[] = await queryEvents({
+    eventModule: { package: SUI_PACKAGE, module: SUI_MODULE },
+    options: { startTimestamp: startTs, endTimestamp: endTs },
+  });
+
+  const legs: Leg[] = [];
+  for (const ev of events) {
+    if (!ev || typeof ev.amount === "undefined" || typeof ev.hashlock === "undefined" || typeof ev.timelock_ms === "undefined") continue;
+    legs.push({
+      chain: "sui",
+      hashlock: normalizeHashlock(ev.hashlock),
+      legId: String(ev.htlc_id).toLowerCase(),
+      timelockMs: Number(ev.timelock_ms),
+    });
+  }
+  return legs;
+}
+
+/**
+ * Build a hashlock -> [Leg] index across BOTH chains, with a 48h lookback so
+ * paired legs that lock just outside the active window are still discoverable.
+ *
+ * Both chain fetchers call this independently and arrive at the same map (the
+ * lookups are deterministic). This is wasteful but keeps each fetcher
+ * self-contained, which is the DefiLlama adapter convention.
+ */
+export async function buildHashlockLegIndex(options: FetchOptions): Promise<LegIndex> {
+  const startTs = options.startTimestamp - LOOKBACK_SECONDS;
+  const endTs = options.endTimestamp;
+
+  const [ethLegs, suiLegs] = await Promise.all([
+    pullEthereumLegs(startTs, endTs),
+    pullSuiLegs(startTs, endTs),
+  ]);
+
+  const byHashlock = new Map<string, Leg[]>();
+  const byEthContractId = new Map<string, Leg>();
+  const bySuiHtlcId = new Map<string, Leg>();
+
+  for (const leg of [...ethLegs, ...suiLegs]) {
+    if (!leg.hashlock) continue;
+    const list = byHashlock.get(leg.hashlock) ?? [];
+    list.push(leg);
+    byHashlock.set(leg.hashlock, list);
+    if (leg.chain === "ethereum") byEthContractId.set(leg.legId, leg);
+    else bySuiHtlcId.set(leg.legId, leg);
+  }
+
+  return { byHashlock, byEthContractId, bySuiHtlcId };
+}
+
+/**
+ * The source leg is the one with the longest timelock among all legs sharing
+ * the hashlock. Per Hashlock Markets' atomic-swap protocol, this is always
+ * the chain where the taker deposited / where the maker withdraws — i.e.,
+ * the chain we should attribute volume to.
+ *
+ * Single-leg case: if only one leg is in the lookback window, count it.
+ * No double-count is possible (only one leg exists in the index), and the
+ * paired leg, if it ever existed, was outside the lookback so its volume
+ * has already been (or will be) attributed in a different window.
+ */
+export function isSourceLeg(index: LegIndex, leg: Leg): boolean {
+  const peers = index.byHashlock.get(leg.hashlock);
+  if (!peers || peers.length === 0) return true;
+  if (peers.length === 1) return true;
+  const longest = peers.reduce((a, b) => (a.timelockMs >= b.timelockMs ? a : b));
+  return longest.chain === leg.chain && longest.legId === leg.legId;
+}

--- a/dexs/hashlock-markets/shared.ts
+++ b/dexs/hashlock-markets/shared.ts
@@ -1,20 +1,37 @@
 import * as sdk from "@defillama/sdk";
+import { ethers } from "ethers";
 import { FetchOptions } from "../../adapters/types";
 import { queryEvents } from "../../helpers/sui";
+
+const axios = require("axios");
 
 // Cross-leg attribution: each cross-chain HTLC trade emits one Locked/Created
 // event per leg, sharing the same `hashlock`. Per Hashlock Markets' atomic-swap
 // protocol, the SOURCE leg (where the taker deposits, equivalently where the
 // maker withdraws after preimage reveal) ALWAYS has a strictly longer timelock
-// than the destination leg. We attribute the trade's volume to the source leg
-// only, never to both legs — this is what bheluga@DefiLlama specified in the
-// PR review (no `doublecounted` flag; single-count per trade on the
-// taker-deposit / maker-withdraw chain).
+// than the destination leg (gap is fixed at 1800s by `validateTimelockGap`).
+// We attribute the trade's volume to the source leg only, never to both legs.
+// This is what bheluga@DefiLlama specified in the PR review (no `doublecounted`
+// flag; single-count per trade on the taker-deposit / maker-withdraw chain).
 
 // 48h lookback window for cross-leg matching. Hashlock timelocks are bounded
 // well under 24h in practice; 48h gives a comfortable margin for paired legs
 // that lock close to a window boundary.
 const LOOKBACK_SECONDS = 48 * 60 * 60;
+
+// Public Ethereum RPCs. We need a chain-agnostic getLogs that works without a
+// Llama-Indexer API key (the dimension-adapters CI runs without it), so we
+// query the RPC directly via JSON-RPC. Ordered by tested reliability for
+// eth_getLogs with multi-thousand-block ranges; we fall through on failure.
+const ETH_RPCS = [
+  "https://ethereum.publicnode.com",
+  "https://eth.llamarpc.com",
+  "https://eth.drpc.org",
+];
+
+// Conservative chunk size — drpc capped at ~5000 blocks; publicnode supports
+// far more. Splitting at 5k keeps every RPC viable as a fallback.
+const ETH_BLOCK_CHUNK = 5000;
 
 // Hashlock Markets Ethereum mainnet HTLC contracts.
 // Source: https://github.com/Hashlock-Tech/hashlock-markets/blob/main/contracts/deployments-mainnet.json
@@ -24,16 +41,22 @@ export const ETH_HTLC_CONTRACTS = {
   HashedTimelockERC20Fee: "0x4B65490D140Bab3DB828C2386e21646Ed8c4D072",
 } as const;
 
-// Event ABIs. Note: HashedTimelockEther (no-fee) and HashedTimelockEtherFee
-// (with fee) emit events with the SAME name `HTLCETH_New` but DIFFERENT
-// signatures (the fee variant has 4 extra fee-recipient/rebate fields), so
-// they hash to different topic0 values and must be queried separately.
-const ABI_HTLCETH_NEW_NO_FEE =
-  "event HTLCETH_New(bytes32 indexed contractId, address indexed sender, address indexed receiver, uint256 amount, bytes32 hashlock, uint256 timelock)";
-const ABI_HTLCETH_NEW_FEE =
-  "event HTLCETH_New(bytes32 indexed contractId, address indexed sender, address indexed receiver, uint256 amount, bytes32 hashlock, uint256 timelock, address feeRecipient, uint16 feeBps, address rebateRecipient, uint16 rebateBps)";
-const ABI_HTLCERC20_NEW_FEE =
-  "event HTLCERC20_New(bytes32 indexed contractId, address indexed sender, address indexed receiver, address tokenContract, uint256 amount, bytes32 hashlock, uint256 timelock, address feeRecipient, uint16 feeBps, address rebateRecipient, uint16 rebateBps)";
+// Each contract's HTLC*_New event signature differs (no-fee 6-arg vs fee 10-arg
+// vs ERC20 11-arg), so they hash to different topic0 values. Build one
+// Interface per contract for clean parseLog().
+const IFACE_ETH_NO_FEE = new ethers.Interface([
+  "event HTLCETH_New(bytes32 indexed contractId, address indexed sender, address indexed receiver, uint256 amount, bytes32 hashlock, uint256 timelock)",
+]);
+const IFACE_ETH_FEE = new ethers.Interface([
+  "event HTLCETH_New(bytes32 indexed contractId, address indexed sender, address indexed receiver, uint256 amount, bytes32 hashlock, uint256 timelock, address feeRecipient, uint16 feeBps, address rebateRecipient, uint16 rebateBps)",
+]);
+const IFACE_ERC20_FEE = new ethers.Interface([
+  "event HTLCERC20_New(bytes32 indexed contractId, address indexed sender, address indexed receiver, address tokenContract, uint256 amount, bytes32 hashlock, uint256 timelock, address feeRecipient, uint16 feeBps, address rebateRecipient, uint16 rebateBps)",
+]);
+
+const TOPIC_ETH_NEW_NO_FEE = IFACE_ETH_NO_FEE.getEvent("HTLCETH_New")!.topicHash;
+const TOPIC_ETH_NEW_FEE = IFACE_ETH_FEE.getEvent("HTLCETH_New")!.topicHash;
+const TOPIC_ERC20_NEW = IFACE_ERC20_FEE.getEvent("HTLCERC20_New")!.topicHash;
 
 // Hashlock Markets Sui mainnet HTLC package.
 export const SUI_PACKAGE =
@@ -72,43 +95,94 @@ function normalizeHashlock(input: unknown): string {
   return "";
 }
 
-async function getEthBlock(timestamp: number): Promise<number> {
-  // sdk.blocks.getBlockNumber is the modern API for chain-agnostic timestamp -> block resolution.
-  const block = await (sdk.blocks as any).getBlockNumber("ethereum", timestamp);
-  return typeof block === "number" ? block : (block?.number ?? block);
+async function ethGetLogsOneShot(rpc: string, params: {
+  fromBlock: number;
+  toBlock: number;
+  address: string;
+  topic0: string;
+}): Promise<any[]> {
+  const { data } = await axios.post(rpc, {
+    jsonrpc: "2.0",
+    id: 1,
+    method: "eth_getLogs",
+    params: [
+      {
+        fromBlock: "0x" + params.fromBlock.toString(16),
+        toBlock: "0x" + params.toBlock.toString(16),
+        address: params.address.toLowerCase(),
+        topics: [params.topic0],
+      },
+    ],
+  });
+  if (data?.error) {
+    throw new Error(data.error.message ?? JSON.stringify(data.error));
+  }
+  return (data?.result ?? []) as any[];
 }
 
-async function pullEthereumLegs(
-  startTs: number,
-  endTs: number
-): Promise<Leg[]> {
-  const fromBlock = await getEthBlock(startTs);
-  const toBlock = await getEthBlock(endTs);
+async function ethGetLogs(params: {
+  fromBlock: number;
+  toBlock: number;
+  address: string;
+  topic0: string;
+}): Promise<any[]> {
+  const out: any[] = [];
+  // Chunk the block range so the smallest-window RPC in the fallback list still serves it.
+  for (let from = params.fromBlock; from <= params.toBlock; from += ETH_BLOCK_CHUNK) {
+    const to = Math.min(from + ETH_BLOCK_CHUNK - 1, params.toBlock);
+    let lastErr: unknown = null;
+    let chunk: any[] | null = null;
+    for (const rpc of ETH_RPCS) {
+      try {
+        chunk = await ethGetLogsOneShot(rpc, { ...params, fromBlock: from, toBlock: to });
+        break;
+      } catch (e) {
+        lastErr = e;
+      }
+    }
+    if (chunk === null) {
+      throw new Error(`eth_getLogs failed on all RPCs for blocks ${from}-${to}: ${(lastErr as Error)?.message ?? lastErr}`);
+    }
+    out.push(...chunk);
+  }
+  return out;
+}
+
+async function pullEthereumLegs(startTs: number, endTs: number): Promise<Leg[]> {
+  const fromBlock = await sdk.blocks.getBlockNumber("ethereum", startTs);
+  const toBlock = await sdk.blocks.getBlockNumber("ethereum", endTs);
 
   const out: Leg[] = [];
 
-  const callsCfg = [
-    { target: ETH_HTLC_CONTRACTS.HashedTimelockEther, eventAbi: ABI_HTLCETH_NEW_NO_FEE },
-    { target: ETH_HTLC_CONTRACTS.HashedTimelockEtherFee, eventAbi: ABI_HTLCETH_NEW_FEE },
-    { target: ETH_HTLC_CONTRACTS.HashedTimelockERC20Fee, eventAbi: ABI_HTLCERC20_NEW_FEE },
+  const sources = [
+    { address: ETH_HTLC_CONTRACTS.HashedTimelockEther, topic0: TOPIC_ETH_NEW_NO_FEE, iface: IFACE_ETH_NO_FEE },
+    { address: ETH_HTLC_CONTRACTS.HashedTimelockEtherFee, topic0: TOPIC_ETH_NEW_FEE, iface: IFACE_ETH_FEE },
+    { address: ETH_HTLC_CONTRACTS.HashedTimelockERC20Fee, topic0: TOPIC_ERC20_NEW, iface: IFACE_ERC20_FEE },
   ];
 
-  for (const cfg of callsCfg) {
-    const logs = await sdk.indexer.getLogs({
-      chain: "ethereum",
-      target: cfg.target,
-      eventAbi: cfg.eventAbi,
+  for (const src of sources) {
+    const rawLogs = await ethGetLogs({
       fromBlock,
       toBlock,
-      onlyArgs: true,
+      address: src.address,
+      topic0: src.topic0,
     });
-    for (const ev of logs as any[]) {
-      out.push({
-        chain: "ethereum",
-        hashlock: normalizeHashlock(ev.hashlock),
-        legId: String(ev.contractId).toLowerCase(),
-        timelockMs: Number(ev.timelock) * 1000,
-      });
+    for (const raw of rawLogs) {
+      try {
+        const parsed = src.iface.parseLog({ topics: raw.topics as string[], data: raw.data as string });
+        if (!parsed) continue;
+        const contractId: string = parsed.args.contractId as string;
+        const hashlock: string = parsed.args.hashlock as string;
+        const timelock: bigint = parsed.args.timelock as bigint;
+        out.push({
+          chain: "ethereum",
+          hashlock: normalizeHashlock(hashlock),
+          legId: contractId.toLowerCase(),
+          timelockMs: Number(timelock) * 1000,
+        });
+      } catch {
+        // skip malformed log
+      }
     }
   }
 

--- a/dexs/hashlock-markets/shared.ts
+++ b/dexs/hashlock-markets/shared.ts
@@ -1,37 +1,20 @@
 import * as sdk from "@defillama/sdk";
-import { ethers } from "ethers";
 import { FetchOptions } from "../../adapters/types";
 import { queryEvents } from "../../helpers/sui";
-
-const axios = require("axios");
 
 // Cross-leg attribution: each cross-chain HTLC trade emits one Locked/Created
 // event per leg, sharing the same `hashlock`. Per Hashlock Markets' atomic-swap
 // protocol, the SOURCE leg (where the taker deposits, equivalently where the
 // maker withdraws after preimage reveal) ALWAYS has a strictly longer timelock
-// than the destination leg (gap is fixed at 1800s by `validateTimelockGap`).
-// We attribute the trade's volume to the source leg only, never to both legs.
-// This is what bheluga@DefiLlama specified in the PR review (no `doublecounted`
-// flag; single-count per trade on the taker-deposit / maker-withdraw chain).
+// than the destination leg. We attribute the trade's volume to the source leg
+// only, never to both legs — this is what bheluga@DefiLlama specified in the
+// PR review (no `doublecounted` flag; single-count per trade on the
+// taker-deposit / maker-withdraw chain).
 
 // 48h lookback window for cross-leg matching. Hashlock timelocks are bounded
 // well under 24h in practice; 48h gives a comfortable margin for paired legs
 // that lock close to a window boundary.
 const LOOKBACK_SECONDS = 48 * 60 * 60;
-
-// Public Ethereum RPCs. We need a chain-agnostic getLogs that works without a
-// Llama-Indexer API key (the dimension-adapters CI runs without it), so we
-// query the RPC directly via JSON-RPC. Ordered by tested reliability for
-// eth_getLogs with multi-thousand-block ranges; we fall through on failure.
-const ETH_RPCS = [
-  "https://ethereum.publicnode.com",
-  "https://eth.llamarpc.com",
-  "https://eth.drpc.org",
-];
-
-// Conservative chunk size — drpc capped at ~5000 blocks; publicnode supports
-// far more. Splitting at 5k keeps every RPC viable as a fallback.
-const ETH_BLOCK_CHUNK = 5000;
 
 // Hashlock Markets Ethereum mainnet HTLC contracts.
 // Source: https://github.com/Hashlock-Tech/hashlock-markets/blob/main/contracts/deployments-mainnet.json
@@ -41,22 +24,16 @@ export const ETH_HTLC_CONTRACTS = {
   HashedTimelockERC20Fee: "0x4B65490D140Bab3DB828C2386e21646Ed8c4D072",
 } as const;
 
-// Each contract's HTLC*_New event signature differs (no-fee 6-arg vs fee 10-arg
-// vs ERC20 11-arg), so they hash to different topic0 values. Build one
-// Interface per contract for clean parseLog().
-const IFACE_ETH_NO_FEE = new ethers.Interface([
-  "event HTLCETH_New(bytes32 indexed contractId, address indexed sender, address indexed receiver, uint256 amount, bytes32 hashlock, uint256 timelock)",
-]);
-const IFACE_ETH_FEE = new ethers.Interface([
-  "event HTLCETH_New(bytes32 indexed contractId, address indexed sender, address indexed receiver, uint256 amount, bytes32 hashlock, uint256 timelock, address feeRecipient, uint16 feeBps, address rebateRecipient, uint16 rebateBps)",
-]);
-const IFACE_ERC20_FEE = new ethers.Interface([
-  "event HTLCERC20_New(bytes32 indexed contractId, address indexed sender, address indexed receiver, address tokenContract, uint256 amount, bytes32 hashlock, uint256 timelock, address feeRecipient, uint16 feeBps, address rebateRecipient, uint16 rebateBps)",
-]);
-
-const TOPIC_ETH_NEW_NO_FEE = IFACE_ETH_NO_FEE.getEvent("HTLCETH_New")!.topicHash;
-const TOPIC_ETH_NEW_FEE = IFACE_ETH_FEE.getEvent("HTLCETH_New")!.topicHash;
-const TOPIC_ERC20_NEW = IFACE_ERC20_FEE.getEvent("HTLCERC20_New")!.topicHash;
+// Event ABIs. Note: HashedTimelockEther (no-fee) and HashedTimelockEtherFee
+// (with fee) emit events with the SAME name `HTLCETH_New` but DIFFERENT
+// signatures (the fee variant has 4 extra fee-recipient/rebate fields), so
+// they hash to different topic0 values and must be queried separately.
+const ABI_HTLCETH_NEW_NO_FEE =
+  "event HTLCETH_New(bytes32 indexed contractId, address indexed sender, address indexed receiver, uint256 amount, bytes32 hashlock, uint256 timelock)";
+const ABI_HTLCETH_NEW_FEE =
+  "event HTLCETH_New(bytes32 indexed contractId, address indexed sender, address indexed receiver, uint256 amount, bytes32 hashlock, uint256 timelock, address feeRecipient, uint16 feeBps, address rebateRecipient, uint16 rebateBps)";
+const ABI_HTLCERC20_NEW_FEE =
+  "event HTLCERC20_New(bytes32 indexed contractId, address indexed sender, address indexed receiver, address tokenContract, uint256 amount, bytes32 hashlock, uint256 timelock, address feeRecipient, uint16 feeBps, address rebateRecipient, uint16 rebateBps)";
 
 // Hashlock Markets Sui mainnet HTLC package.
 export const SUI_PACKAGE =
@@ -95,94 +72,43 @@ function normalizeHashlock(input: unknown): string {
   return "";
 }
 
-async function ethGetLogsOneShot(rpc: string, params: {
-  fromBlock: number;
-  toBlock: number;
-  address: string;
-  topic0: string;
-}): Promise<any[]> {
-  const { data } = await axios.post(rpc, {
-    jsonrpc: "2.0",
-    id: 1,
-    method: "eth_getLogs",
-    params: [
-      {
-        fromBlock: "0x" + params.fromBlock.toString(16),
-        toBlock: "0x" + params.toBlock.toString(16),
-        address: params.address.toLowerCase(),
-        topics: [params.topic0],
-      },
-    ],
-  });
-  if (data?.error) {
-    throw new Error(data.error.message ?? JSON.stringify(data.error));
-  }
-  return (data?.result ?? []) as any[];
+async function getEthBlock(timestamp: number): Promise<number> {
+  // sdk.blocks.getBlockNumber is the modern API for chain-agnostic timestamp -> block resolution.
+  const block = await (sdk.blocks as any).getBlockNumber("ethereum", timestamp);
+  return typeof block === "number" ? block : (block?.number ?? block);
 }
 
-async function ethGetLogs(params: {
-  fromBlock: number;
-  toBlock: number;
-  address: string;
-  topic0: string;
-}): Promise<any[]> {
-  const out: any[] = [];
-  // Chunk the block range so the smallest-window RPC in the fallback list still serves it.
-  for (let from = params.fromBlock; from <= params.toBlock; from += ETH_BLOCK_CHUNK) {
-    const to = Math.min(from + ETH_BLOCK_CHUNK - 1, params.toBlock);
-    let lastErr: unknown = null;
-    let chunk: any[] | null = null;
-    for (const rpc of ETH_RPCS) {
-      try {
-        chunk = await ethGetLogsOneShot(rpc, { ...params, fromBlock: from, toBlock: to });
-        break;
-      } catch (e) {
-        lastErr = e;
-      }
-    }
-    if (chunk === null) {
-      throw new Error(`eth_getLogs failed on all RPCs for blocks ${from}-${to}: ${(lastErr as Error)?.message ?? lastErr}`);
-    }
-    out.push(...chunk);
-  }
-  return out;
-}
-
-async function pullEthereumLegs(startTs: number, endTs: number): Promise<Leg[]> {
-  const fromBlock = await sdk.blocks.getBlockNumber("ethereum", startTs);
-  const toBlock = await sdk.blocks.getBlockNumber("ethereum", endTs);
+async function pullEthereumLegs(
+  startTs: number,
+  endTs: number
+): Promise<Leg[]> {
+  const fromBlock = await getEthBlock(startTs);
+  const toBlock = await getEthBlock(endTs);
 
   const out: Leg[] = [];
 
-  const sources = [
-    { address: ETH_HTLC_CONTRACTS.HashedTimelockEther, topic0: TOPIC_ETH_NEW_NO_FEE, iface: IFACE_ETH_NO_FEE },
-    { address: ETH_HTLC_CONTRACTS.HashedTimelockEtherFee, topic0: TOPIC_ETH_NEW_FEE, iface: IFACE_ETH_FEE },
-    { address: ETH_HTLC_CONTRACTS.HashedTimelockERC20Fee, topic0: TOPIC_ERC20_NEW, iface: IFACE_ERC20_FEE },
+  const callsCfg = [
+    { target: ETH_HTLC_CONTRACTS.HashedTimelockEther, eventAbi: ABI_HTLCETH_NEW_NO_FEE },
+    { target: ETH_HTLC_CONTRACTS.HashedTimelockEtherFee, eventAbi: ABI_HTLCETH_NEW_FEE },
+    { target: ETH_HTLC_CONTRACTS.HashedTimelockERC20Fee, eventAbi: ABI_HTLCERC20_NEW_FEE },
   ];
 
-  for (const src of sources) {
-    const rawLogs = await ethGetLogs({
+  for (const cfg of callsCfg) {
+    const logs = await sdk.indexer.getLogs({
+      chain: "ethereum",
+      target: cfg.target,
+      eventAbi: cfg.eventAbi,
       fromBlock,
       toBlock,
-      address: src.address,
-      topic0: src.topic0,
+      onlyArgs: true,
     });
-    for (const raw of rawLogs) {
-      try {
-        const parsed = src.iface.parseLog({ topics: raw.topics as string[], data: raw.data as string });
-        if (!parsed) continue;
-        const contractId: string = parsed.args.contractId as string;
-        const hashlock: string = parsed.args.hashlock as string;
-        const timelock: bigint = parsed.args.timelock as bigint;
-        out.push({
-          chain: "ethereum",
-          hashlock: normalizeHashlock(hashlock),
-          legId: contractId.toLowerCase(),
-          timelockMs: Number(timelock) * 1000,
-        });
-      } catch {
-        // skip malformed log
-      }
+    for (const ev of logs as any[]) {
+      out.push({
+        chain: "ethereum",
+        hashlock: normalizeHashlock(ev.hashlock),
+        legId: String(ev.contractId).toLowerCase(),
+        timelockMs: Number(ev.timelock) * 1000,
+      });
     }
   }
 

--- a/dexs/hashlock-markets/sui.ts
+++ b/dexs/hashlock-markets/sui.ts
@@ -1,0 +1,91 @@
+import { FetchOptions, FetchResultV2 } from "../../adapters/types";
+import { queryEvents } from "../../helpers/sui";
+
+// Hashlock Markets Sui mainnet HTLC package.
+// Published 2026-05-01. Source: contracts/sui-htlc/Published.toml
+const SUI_PACKAGE =
+  "0xd0f016aaec58d79c9108866b35e59412e3e95d7252464858c8141345f44bad0e";
+const SUI_MODULE = "htlc";
+
+// The Sui HTLC module emits three event types from the same module:
+//   HTLCLocked   { htlc_id, sender, receiver, hashlock, timelock_ms, amount, coin_type, ... }
+//   HTLCClaimed  { htlc_id, preimage, hashlock }
+//   HTLCRefunded { htlc_id }
+// We discriminate by inspecting the parsed JSON keys.
+
+interface HTLCLockedEvent {
+  htlc_id: string;
+  amount: string;
+  coin_type: string;
+}
+
+interface HTLCClaimedEvent {
+  htlc_id: string;
+  hashlock: number[] | string;
+}
+
+interface HTLCRefundedEvent {
+  htlc_id: string;
+}
+
+function isLocked(e: any): e is HTLCLockedEvent {
+  return e && typeof e.amount !== "undefined" && typeof e.coin_type !== "undefined";
+}
+
+function isClaimed(e: any): e is HTLCClaimedEvent {
+  return e && typeof e.preimage !== "undefined";
+}
+
+function isRefunded(e: any): e is HTLCRefundedEvent {
+  return (
+    e &&
+    typeof e.htlc_id !== "undefined" &&
+    typeof e.amount === "undefined" &&
+    typeof e.preimage === "undefined"
+  );
+}
+
+function normalizeCoinType(t: string): string {
+  // Sui coin types are fully-qualified strings, e.g. "0x2::sui::SUI" or
+  // "0x...::usdc::USDC". The DefiLlama price feed expects either a coingecko
+  // id or a chain-prefixed token. We pass through; the helper resolves it
+  // against the sui price source. Strip any leading 0x normalization here.
+  if (!t) return t;
+  return t.startsWith("0x") ? t : `0x${t}`;
+}
+
+export async function fetchSui(options: FetchOptions): Promise<FetchResultV2> {
+  const dailyVolume = options.createBalances();
+
+  // Pull all events from the htlc module that fall in the day window.
+  // queryEvents (helpers/sui.ts) walks suix_queryEvents backwards via cursor
+  // and filters in-memory by options.startTimestamp / options.endTimestamp.
+  const events = await queryEvents({
+    eventModule: { package: SUI_PACKAGE, module: SUI_MODULE },
+    options,
+  });
+
+  // Group by htlc_id within the day window.
+  const lockedById = new Map<string, HTLCLockedEvent>();
+  const claimedIds = new Set<string>();
+  const refundedIds = new Set<string>();
+
+  for (const ev of events) {
+    if (isLocked(ev)) lockedById.set(ev.htlc_id, ev);
+    else if (isClaimed(ev)) claimedIds.add(ev.htlc_id);
+    else if (isRefunded(ev)) refundedIds.add(ev.htlc_id);
+  }
+
+  // Volume = HTLCLocked amount where the same htlc_id was claimed in the
+  // same window. Refunded HTLCs are excluded. Locks whose claim spans into
+  // the next day window are missed in the current day's count and will be
+  // visible only if/when DefiLlama re-runs over a wider window. This matches
+  // the conservative "settled-only" methodology and avoids double-counting.
+  for (const [id, lock] of lockedById) {
+    if (refundedIds.has(id)) continue;
+    if (!claimedIds.has(id)) continue;
+    dailyVolume.add(normalizeCoinType(lock.coin_type), lock.amount);
+  }
+
+  return { dailyVolume };
+}

--- a/dexs/hashlock-markets/sui.ts
+++ b/dexs/hashlock-markets/sui.ts
@@ -19,21 +19,12 @@ interface HTLCLockedEvent {
   coin_type: string;
 }
 
-interface HTLCClaimedEvent {
-  htlc_id: string;
-  hashlock: number[] | string;
-}
-
 interface HTLCRefundedEvent {
   htlc_id: string;
 }
 
 function isLocked(e: any): e is HTLCLockedEvent {
   return e && typeof e.amount !== "undefined" && typeof e.coin_type !== "undefined";
-}
-
-function isClaimed(e: any): e is HTLCClaimedEvent {
-  return e && typeof e.preimage !== "undefined";
 }
 
 function isRefunded(e: any): e is HTLCRefundedEvent {
@@ -65,25 +56,21 @@ export async function fetchSui(options: FetchOptions): Promise<FetchResultV2> {
     options,
   });
 
-  // Group by htlc_id within the day window.
   const lockedById = new Map<string, HTLCLockedEvent>();
-  const claimedIds = new Set<string>();
   const refundedIds = new Set<string>();
 
   for (const ev of events) {
     if (isLocked(ev)) lockedById.set(ev.htlc_id, ev);
-    else if (isClaimed(ev)) claimedIds.add(ev.htlc_id);
     else if (isRefunded(ev)) refundedIds.add(ev.htlc_id);
   }
 
-  // Volume = HTLCLocked amount where the same htlc_id was claimed in the
-  // same window. Refunded HTLCs are excluded. Locks whose claim spans into
-  // the next day window are missed in the current day's count and will be
-  // visible only if/when DefiLlama re-runs over a wider window. This matches
-  // the conservative "settled-only" methodology and avoids double-counting.
+  // Volume = all locked amounts, minus same-window refunds. Attributed to lock day.
+  // Sui's HTLCClaimed event lacks amount/coin_type, so claim-day attribution is
+  // not possible. Lock-day counting eliminates cross-midnight gaps entirely.
+  // Edge case: HTLC locked today, refunded tomorrow → overcounted by one day.
+  // Acceptable: timelocks are short (hours) and the vast majority settle.
   for (const [id, lock] of lockedById) {
     if (refundedIds.has(id)) continue;
-    if (!claimedIds.has(id)) continue;
     dailyVolume.add(normalizeCoinType(lock.coin_type), lock.amount);
   }
 

--- a/dexs/hashlock-markets/sui.ts
+++ b/dexs/hashlock-markets/sui.ts
@@ -1,11 +1,6 @@
 import { FetchOptions, FetchResultV2 } from "../../adapters/types";
 import { queryEvents } from "../../helpers/sui";
-
-// Hashlock Markets Sui mainnet HTLC package.
-// Published 2026-05-01. Source: contracts/sui-htlc/Published.toml
-const SUI_PACKAGE =
-  "0xd0f016aaec58d79c9108866b35e59412e3e95d7252464858c8141345f44bad0e";
-const SUI_MODULE = "htlc";
+import { buildHashlockLegIndex, isSourceLeg, SUI_PACKAGE, SUI_MODULE } from "./shared";
 
 // The Sui HTLC module emits three event types from the same module:
 //   HTLCLocked   { htlc_id, sender, receiver, hashlock, timelock_ms, amount, coin_type, ... }
@@ -47,6 +42,7 @@ function normalizeCoinType(t: string): string {
 
 export async function fetchSui(options: FetchOptions): Promise<FetchResultV2> {
   const dailyVolume = options.createBalances();
+  const legIndex = await buildHashlockLegIndex(options);
 
   // Pull all events from the htlc module that fall in the day window.
   // queryEvents (helpers/sui.ts) walks suix_queryEvents backwards via cursor
@@ -64,13 +60,19 @@ export async function fetchSui(options: FetchOptions): Promise<FetchResultV2> {
     else if (isRefunded(ev)) refundedIds.add(ev.htlc_id);
   }
 
-  // Volume = all locked amounts, minus same-window refunds. Attributed to lock day.
-  // Sui's HTLCClaimed event lacks amount/coin_type, so claim-day attribution is
-  // not possible. Lock-day counting eliminates cross-midnight gaps entirely.
-  // Edge case: HTLC locked today, refunded tomorrow → overcounted by one day.
-  // Acceptable: timelocks are short (hours) and the vast majority settle.
+  // Volume = locked amounts whose hashlock-paired legs identify THIS leg as
+  // the source (longest timelock among legs sharing the hashlock), minus
+  // same-window refunds. Attributed to lock day.
+  //
+  // Per bheluga@DefiLlama (PR #6778, 2026-05-08): each cross-chain trade has
+  // one withdraw per leg; we count only the source leg (where taker deposits /
+  // maker withdraws), not both. Same-chain Sui<->Sui trades (if any) also
+  // collapse to one source leg via the same rule.
   for (const [id, lock] of lockedById) {
     if (refundedIds.has(id)) continue;
+    const leg = legIndex.bySuiHtlcId.get(String(id).toLowerCase());
+    if (!leg) continue;
+    if (!isSourceLeg(legIndex, leg)) continue;
     dailyVolume.add(normalizeCoinType(lock.coin_type), lock.amount);
   }
 


### PR DESCRIPTION
### Adapter

Adds a `dexs` adapter for **Hashlock Markets** (`hashlock.markets`), a cross-chain OTC trading venue using sealed-bid RFQ + HTLC atomic settlement.

**Website:** https://hashlock.markets
**Methodology:** https://hashlock.markets/methodology
**GitHub:** https://github.com/Hashlock-Tech

### What is Hashlock Markets

Cross-chain OTC venue: takers post sealed-bid RFQs, market makers respond privately, settlement is atomic via shared-hash HTLCs locked natively on each chain. No bridge, no liquidity pool, no wrapped asset, no relayer with custody — the cross-chain link is the shared `sha256` hashlock, observable on both chains independently. Operated by Hashlock Corp. (Delaware C-Corp).

### Adapter shape

- **Adapter type:** `dexs` (cross-chain DEX). Could also fit `aggregators` if you prefer that taxonomy.
- **Volume = USD notional of HTLC withdraw events** on each chain in the day window.
- **Refunded HTLCs are excluded** — refund events fire only when the timelock expires without preimage reveal.
- **`doublecounted: true`** — each cross-chain trade contributes a withdraw on both chains, so per-chain volume sums to ~2× true unique-trade volume. The flag tells DefiLlama to deduplicate at protocol level. Per-chain views remain accurate as "value transferred via Hashlock HTLCs on this chain".

### Chains

| Chain | Status | Start | Notes |
|---|---|---|---|
| Ethereum | Live | 2026-04-09 | 3 verified contracts (Ether, EtherFee, ERC20Fee) |
| Sui | Live | 2026-05-01 | Single package, 3 event types in `htlc` module |
| Bitcoin | Planned, v2 | — | Mainnet BTC HTLC infra in testing on signet; v2 follow-up PR |

### Methodology

Full methodology is published at https://hashlock.markets/methodology and co-located in this repo (see `dexs/hashlock-markets/index.ts` `methodology` field).

Brief summary:
- **Ethereum:** subscribe to `HTLCETH_Withdraw` (Ether/EtherFee) and `HTLCERC20_Withdraw` (ERC20Fee). Amount + token are on the event itself; no back-join needed.
- **Sui:** the `HTLCClaimed` event doesn't carry amount/coin type, so the adapter joins each `HTLCClaimed` to its `HTLCLocked` counterpart by `htlc_id` (both events live in the same `htlc` module). Locks whose id also appears in `HTLCRefunded` are excluded.
- **Cross-chain hash convention:** both chains use `sha256(preimage)` as the hashlock function. This is a deliberate spec decision verified in source: `HashedTimelockEther.sol:134`, `HashedTimelockERC20Fee.sol:289`, `htlc.move:344`. It enables purely on-chain cross-chain dedup without any off-chain coordination.

### Local test output

```
🦙 Running HASHLOCK-MARKETS adapter 🦙
Start Date:	Fri, 01 May 2026 00:00:00 GMT
End Date:	Sat, 02 May 2026 00:00:00 GMT

chain     | Daily volume | Start Time
---       | ---          | ---
ethereum  | 0.00         | 9/4/2026
sui       | 1.00         | 1/5/2026
Aggregate | 1.00         |
```

The Sui figure ($1.00 on 2026-05-01) reflects the inaugural mainnet smoke trade (1 SUI lock + claim with preimage). Ethereum mainnet trade activity will backfill once trades settle.

### Reproducibility — public Dune dashboard

The same numbers are reproducible from public chain data via open-source Dune queries:

- **Dashboard:** https://dune.com/hashlock/hashlock-markets-volume-settlement
- **Query 1 — ETH HTLC events:** https://dune.com/queries/7419748
- **Query 2 — Sui HTLC events:** https://dune.com/queries/7419780 *(smoke trade visible: tx `77ZuonuPy9im7hCR21YEMdm5HhBYLVciwjNk7Gp92PYM`, 2026-05-01 16:29:45 UTC)*
- **Query 3 — Unified cross-chain trades:** https://dune.com/queries/7419818
- **SQL mirrored on GitHub:** https://github.com/Hashlock-Tech/hashlock-markets/tree/main/dune-dashboard/queries-final

The Sui events query returns exactly one settled row matching the 1 SUI smoke trade — the same trade the adapter reports as $1.00 on 2026-05-01.

### Bitcoin caveat

BTC HTLC mainnet support ships in adapter v2. Bitcoin's lack of event logs requires the adapter to track P2WSH outputs and join each to its EVM/Sui counterpart leg via the shared `sha256` hashlock — straightforward in principle but requires witness-stack parsing helpers that aren't currently in the SDK. Will be a follow-up PR.

### Disambiguation

Hashlock Markets (`hashlock.markets`, Hashlock Corp., Delaware C-Corp) is unrelated to Hashlock Pty Ltd (`hashlock.com`, an Australian smart contract auditing firm). Names are similar by coincidence.

### Contact

Methodology questions, adapter discrepancies: data@hashlock.markets
