### PR TITLE
Add fidelity digital interest token fees and revenue adapter

### DIFF
--- a/fees/fidelity-digital-interest/index.ts
+++ b/fees/fidelity-digital-interest/index.ts
@@ -1,0 +1,224 @@
+import { FetchOptions, FetchResultV2, SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import { httpGet, httpPost } from "../../utils/fetchURL";
+
+const FDIT = "0x48ab4e39ac59f4e88974804b04a991b3a402717f";
+const FUND_NO = "9053";
+// Fidelity public fund data for FYOXX / FDIT:
+// https://institutional.fidelity.com/app/fund/data/9053.json
+// Historical prices/yields form posts to this endpoint with fundNo/startDate/endDate.
+// https://institutional.fidelity.com/app/funds/hpdy
+const FIDELITY_FUND_DATA_URL = "https://institutional.fidelity.com/app/fund/data/9053.json";
+const FIDELITY_HISTORICAL_PRICING_URL = "https://institutional.fidelity.com/app/funds/historicalFundPricing";
+const FDIT_DIVIDENDS = "FDIT Dividends";
+const FDIT_DIVIDENDS_TO_HOLDERS = "FDIT Dividends To Holders";
+const FDIT_NET_FUND_EXPENSES = "FDIT Net Fund Expenses";
+const FDIT_NET_FUND_EXPENSES_TO_FIDELITY = "FDIT Net Fund Expenses To Fidelity";
+
+type FidelityFeatureInformation = {
+  featureCode: string;
+  featureValue: string;
+}[];
+
+type PricingData = {
+  milRate?: number;
+  featureInformation?: FidelityFeatureInformation;
+};
+
+type HistoricalPricingResponse = {
+  status: string;
+  featureInformation?: FidelityFeatureInformation;
+  prices?: {
+    date: string;
+    milRate: string;
+  }[];
+};
+
+type FundDataResponse = {
+  historicalPricingYield?: {
+    prices?: {
+      date: string;
+      milRateAndYieldInstance?: {
+        milRate: number | string;
+      };
+    }[];
+  }[];
+  overview?: {
+    featureInformation?: FidelityFeatureInformation;
+  };
+  prices?: {
+    milrateYields?: {
+      milrateDate: string;
+      milrate: number | string;
+    }[];
+  }[];
+};
+
+function toFidelityDate(dateString: string) {
+  const [year, month, day] = dateString.split("-");
+  return `${month}/${day}/${year}`;
+}
+
+function fromFidelityDate(dateString: string) {
+  const [month, day, year] = dateString.split("/");
+  return `${year}-${month.padStart(2, "0")}-${day.padStart(2, "0")}`;
+}
+
+function parsePercent(value?: string) {
+  if (!value) return undefined;
+
+  const match = value.match(/[\d.]+/);
+  if (!match) return undefined;
+
+  return Number(match[0]) / 100;
+}
+
+function getNetExpenseRatio(features: FidelityFeatureInformation = []) {
+  const byCode = Object.fromEntries(features.map((feature) => [feature.featureCode, feature.featureValue]));
+  // Fidelity feature codes:
+  // ERAER = expenses net of all reductions, NTEXP = total annual operating expenses after waiver/reimbursement,
+  // MGFEE = management fee. SEC summary prospectus lists 0.25% gross management fee and 0.20% net expenses.
+  // https://www.sec.gov/Archives/edgar/data/917286/000113322825007437/ftdf-efp16750_497k.htm
+  const netExpenseRatio =
+    parsePercent(byCode.ERAER) ??
+    parsePercent(byCode.NTEXP) ??
+    parsePercent(byCode.MGFEE);
+
+  if (netExpenseRatio === undefined) {
+    throw new Error("No Fidelity expense ratio found");
+  }
+
+  return netExpenseRatio;
+}
+
+async function getHistoricalPricing(dateString: string): Promise<PricingData> {
+  const date = toFidelityDate(dateString);
+  const body = new URLSearchParams({
+    fundNo: FUND_NO,
+    startDate: date,
+    endDate: date,
+  });
+
+  const response: HistoricalPricingResponse = await httpPost(
+    FIDELITY_HISTORICAL_PRICING_URL,
+    body.toString(),
+    {
+      headers: {
+        "content-type": "application/x-www-form-urlencoded; charset=UTF-8",
+      },
+    }
+  );
+
+  if (response.status !== "success") {
+    throw new Error(`Fidelity historical pricing request failed for ${dateString}`);
+  }
+
+  const price = response.prices?.find((item) => item.date === dateString);
+  return {
+    milRate: price?.milRate ? Number(price.milRate) : undefined,
+    featureInformation: response.featureInformation,
+  };
+}
+
+async function getFundDataPricing(dateString: string): Promise<PricingData> {
+  const response: FundDataResponse = await httpGet(FIDELITY_FUND_DATA_URL);
+  const featureInformation = response.overview?.featureInformation;
+  const historicalPrice = response.historicalPricingYield
+    ?.flatMap((item) => item.prices ?? [])
+    .find((item) => item.date === toFidelityDate(dateString));
+
+  if (historicalPrice?.milRateAndYieldInstance?.milRate) {
+    return {
+      milRate: Number(historicalPrice.milRateAndYieldInstance.milRate),
+      featureInformation,
+    };
+  }
+
+  const milrateYield = response.prices
+    ?.flatMap((price) => price.milrateYields ?? [])
+    .find((item) => fromFidelityDate(item.milrateDate) === dateString);
+
+  return {
+    milRate: milrateYield?.milrate ? Number(milrateYield.milrate) : undefined,
+    featureInformation,
+  };
+}
+
+const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
+  let pricing = await getFundDataPricing(options.dateString);
+
+  if (pricing.milRate === undefined) {
+    pricing = await getHistoricalPricing(options.dateString);
+  }
+
+  if (pricing.milRate === undefined) {
+    throw new Error(`No Fidelity mil-rate found for ${options.dateString}`);
+  }
+
+  const supply = await options.fromApi.call({
+    target: FDIT,
+    abi: "erc20:totalSupply",
+  });
+
+  const fditSupply = Number(supply) / 1e18;
+  const netExpenseRatio = getNetExpenseRatio(pricing.featureInformation);
+  const periodInYears = (options.endTimestamp - options.startTimestamp) / (365 * 24 * 60 * 60);
+
+  const dailyDividends = fditSupply * pricing.milRate;
+  const dailyFundFees = fditSupply * netExpenseRatio * periodInYears;
+
+  const dailyFees = options.createBalances();
+  const dailySupplySideRevenue = options.createBalances();
+  const dailyRevenue = options.createBalances();
+
+  // Fidelity money market mil-rates are daily dividend amounts per $1 NAV share.
+  // Because FDIT/FYOXX targets a $1 NAV, supply in shares is also the USD AUM base for these calculations.
+  dailyFees.addUSDValue(dailyDividends, FDIT_DIVIDENDS);
+  dailyFees.addUSDValue(dailyFundFees, FDIT_NET_FUND_EXPENSES);
+  dailySupplySideRevenue.addUSDValue(dailyDividends, FDIT_DIVIDENDS_TO_HOLDERS);
+  dailyRevenue.addUSDValue(dailyFundFees, FDIT_NET_FUND_EXPENSES_TO_FIDELITY);
+
+  return {
+    dailyFees,
+    dailyRevenue,
+    dailyProtocolRevenue: dailyRevenue,
+    dailySupplySideRevenue,
+  };
+};
+
+const methodology = {
+  Fees: "Daily dividends paid to FDIT holders plus fund expenses accrued by Fidelity Treasury Digital Fund - OnChain Class.",
+  Revenue: "Net annual operating expenses after fee waivers or reimbursements, accrued daily on FDIT AUM.",
+  ProtocolRevenue: "Net annual operating expenses after fee waivers or reimbursements, accrued daily on FDIT AUM.",
+  SupplySideRevenue: "Daily dividends paid to FDIT holders, calculated from Fidelity's daily mil-rate and start-of-day FDIT supply.",
+};
+
+const breakdownMethodology = {
+  Fees: {
+    [FDIT_DIVIDENDS]: "Daily dividends paid to FDIT holders from Fidelity's published mil-rate.",
+    [FDIT_NET_FUND_EXPENSES]: "Net fund expenses accrued daily using Fidelity's expense ratio.",
+  },
+  Revenue: {
+    [FDIT_NET_FUND_EXPENSES_TO_FIDELITY]: "Net fund expenses accrued daily to Fidelity using Fidelity's expense ratio.",
+  },
+  ProtocolRevenue: {
+    [FDIT_NET_FUND_EXPENSES_TO_FIDELITY]: "Net fund expenses accrued daily to Fidelity using Fidelity's expense ratio.",
+  },
+  SupplySideRevenue: {
+    [FDIT_DIVIDENDS_TO_HOLDERS]: "Daily dividends paid to FDIT holders from Fidelity's published mil-rate.",
+  },
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  methodology,
+  breakdownMethodology,
+  adapter: {
+    [CHAIN.ETHEREUM]: {
+      fetch,
+      start: "2025-08-04",
+    },
+  },
+};
+
+export default adapter;

--- a/fees/fidelity-digital-interest/index.ts
+++ b/fees/fidelity-digital-interest/index.ts
@@ -1,4 +1,4 @@
-import { FetchOptions, FetchResultV2, SimpleAdapter } from "../../adapters/types";
+import { FetchOptions, FetchResult, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 import { httpGet, httpPost } from "../../utils/fetchURL";
 
@@ -76,13 +76,12 @@ function parsePercent(value?: string) {
 function getNetExpenseRatio(features: FidelityFeatureInformation = []) {
   const byCode = Object.fromEntries(features.map((feature) => [feature.featureCode, feature.featureValue]));
   // Fidelity feature codes:
-  // ERAER = expenses net of all reductions, NTEXP = total annual operating expenses after waiver/reimbursement,
-  // MGFEE = management fee. SEC summary prospectus lists 0.25% gross management fee and 0.20% net expenses.
+  // ERAER = expenses net of all reductions, NTEXP = total annual operating expenses after waiver/reimbursement.
+  // MGFEE is the gross management fee, so it is not used as a net-expense fallback.
   // https://www.sec.gov/Archives/edgar/data/917286/000113322825007437/ftdf-efp16750_497k.htm
   const netExpenseRatio =
     parsePercent(byCode.ERAER) ??
-    parsePercent(byCode.NTEXP) ??
-    parsePercent(byCode.MGFEE);
+    parsePercent(byCode.NTEXP);
 
   if (netExpenseRatio === undefined) {
     throw new Error("No Fidelity expense ratio found");
@@ -144,7 +143,7 @@ async function getFundDataPricing(dateString: string): Promise<PricingData> {
   };
 }
 
-const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
+const fetch = async (_: any, _1: any, options: FetchOptions): Promise<FetchResult> => {
   let pricing = await getFundDataPricing(options.dateString);
 
   if (pricing.milRate === undefined) {
@@ -162,10 +161,9 @@ const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
 
   const fditSupply = Number(supply) / 1e18;
   const netExpenseRatio = getNetExpenseRatio(pricing.featureInformation);
-  const periodInYears = (options.endTimestamp - options.startTimestamp) / (365 * 24 * 60 * 60);
 
   const dailyDividends = fditSupply * pricing.milRate;
-  const dailyFundFees = fditSupply * netExpenseRatio * periodInYears;
+  const dailyFundFees = fditSupply * netExpenseRatio / 365;
 
   const dailyFees = options.createBalances();
   const dailySupplySideRevenue = options.createBalances();
@@ -210,7 +208,7 @@ const breakdownMethodology = {
 };
 
 const adapter: SimpleAdapter = {
-  version: 2,
+  version: 1,
   methodology,
   breakdownMethodology,
   adapter: {

--- a/fees/fidelity-digital-interest/index.ts
+++ b/fees/fidelity-digital-interest/index.ts
@@ -1,154 +1,51 @@
-import { FetchOptions, FetchResult, SimpleAdapter } from "../../adapters/types";
+import { SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
+import { METRIC } from "../../helpers/metrics";
 import { httpGet, httpPost } from "../../utils/fetchURL";
 
 const FDIT = "0x48ab4e39ac59f4e88974804b04a991b3a402717f";
 const FUND_NO = "9053";
-// Fidelity public fund data for FYOXX / FDIT:
-// https://institutional.fidelity.com/app/fund/data/9053.json
-// Historical prices/yields form posts to this endpoint with fundNo/startDate/endDate.
-// https://institutional.fidelity.com/app/funds/hpdy
+// Source: Fidelity FYOXX/FDIT fund data and historical pricing APIs; SEC prospectus uses ERAER/NTEXP as net expense ratios.
 const FIDELITY_FUND_DATA_URL = "https://institutional.fidelity.com/app/fund/data/9053.json";
 const FIDELITY_HISTORICAL_PRICING_URL = "https://institutional.fidelity.com/app/funds/historicalFundPricing";
-const FDIT_DIVIDENDS = "FDIT Dividends";
-const FDIT_DIVIDENDS_TO_HOLDERS = "FDIT Dividends To Holders";
-const FDIT_NET_FUND_EXPENSES = "FDIT Net Fund Expenses";
-const FDIT_NET_FUND_EXPENSES_TO_FIDELITY = "FDIT Net Fund Expenses To Fidelity";
 
-type FidelityFeatureInformation = {
-  featureCode: string;
-  featureValue: string;
-}[];
-
-type PricingData = {
-  milRate?: number;
-  featureInformation?: FidelityFeatureInformation;
-};
-
-type HistoricalPricingResponse = {
-  status: string;
-  featureInformation?: FidelityFeatureInformation;
-  prices?: {
-    date: string;
-    milRate: string;
-  }[];
-};
-
-type FundDataResponse = {
-  historicalPricingYield?: {
-    prices?: {
-      date: string;
-      milRateAndYieldInstance?: {
-        milRate: number | string;
-      };
-    }[];
-  }[];
-  overview?: {
-    featureInformation?: FidelityFeatureInformation;
-  };
-  prices?: {
-    milrateYields?: {
-      milrateDate: string;
-      milrate: number | string;
-    }[];
-  }[];
-};
-
-function toFidelityDate(dateString: string) {
+const toFidelityDate = (dateString: string) => {
   const [year, month, day] = dateString.split("-");
   return `${month}/${day}/${year}`;
-}
+};
 
-function fromFidelityDate(dateString: string) {
-  const [month, day, year] = dateString.split("/");
-  return `${year}-${month.padStart(2, "0")}-${day.padStart(2, "0")}`;
-}
+const parsePercent = (value?: string) => Number(value?.match(/[\d.]+/)?.[0]) / 100 || undefined;
 
-function parsePercent(value?: string) {
-  if (!value) return undefined;
+async function getPricing(dateString: string) {
+  const response: any = await httpGet(FIDELITY_FUND_DATA_URL);
+  const featureInformation = response.overview?.featureInformation;
+  const fidelityDate = toFidelityDate(dateString);
+  const price =
+    response.historicalPricingYield
+    ?.flatMap((item: any) => item.prices ?? [])
+    .find((item: any) => item.date === fidelityDate)?.milRateAndYieldInstance?.milRate ??
+    response.prices
+      ?.flatMap((price: any) => price.milrateYields ?? [])
+      .find((item: any) => item.milrateDate === fidelityDate)?.milrate;
 
-  const match = value.match(/[\d.]+/);
-  if (!match) return undefined;
+  if (price) return { milRate: Number(price), featureInformation };
 
-  return Number(match[0]) / 100;
-}
-
-function getNetExpenseRatio(features: FidelityFeatureInformation = []) {
-  const byCode = Object.fromEntries(features.map((feature) => [feature.featureCode, feature.featureValue]));
-  // Fidelity feature codes:
-  // ERAER = expenses net of all reductions, NTEXP = total annual operating expenses after waiver/reimbursement.
-  // MGFEE is the gross management fee, so it is not used as a net-expense fallback.
-  // https://www.sec.gov/Archives/edgar/data/917286/000113322825007437/ftdf-efp16750_497k.htm
-  const netExpenseRatio =
-    parsePercent(byCode.ERAER) ??
-    parsePercent(byCode.NTEXP);
-
-  if (netExpenseRatio === undefined) {
-    throw new Error("No Fidelity expense ratio found");
-  }
-
-  return netExpenseRatio;
-}
-
-async function getHistoricalPricing(dateString: string): Promise<PricingData> {
-  const date = toFidelityDate(dateString);
-  const body = new URLSearchParams({
-    fundNo: FUND_NO,
-    startDate: date,
-    endDate: date,
-  });
-
-  const response: HistoricalPricingResponse = await httpPost(
+  const historical: any = await httpPost(
     FIDELITY_HISTORICAL_PRICING_URL,
-    body.toString(),
-    {
-      headers: {
-        "content-type": "application/x-www-form-urlencoded; charset=UTF-8",
-      },
-    }
+    new URLSearchParams({ fundNo: FUND_NO, startDate: fidelityDate, endDate: fidelityDate }).toString(),
+    { headers: { "content-type": "application/x-www-form-urlencoded; charset=UTF-8" } }
   );
 
-  if (response.status !== "success") {
-    throw new Error(`Fidelity historical pricing request failed for ${dateString}`);
-  }
+  if (historical.status !== "success") throw new Error(`Fidelity historical pricing request failed for ${dateString}`);
 
-  const price = response.prices?.find((item) => item.date === dateString);
   return {
-    milRate: price?.milRate ? Number(price.milRate) : undefined,
-    featureInformation: response.featureInformation,
+    milRate: Number(historical.prices?.find((item: any) => item.date === dateString)?.milRate) || undefined,
+    featureInformation: historical.featureInformation ?? featureInformation,
   };
 }
 
-async function getFundDataPricing(dateString: string): Promise<PricingData> {
-  const response: FundDataResponse = await httpGet(FIDELITY_FUND_DATA_URL);
-  const featureInformation = response.overview?.featureInformation;
-  const historicalPrice = response.historicalPricingYield
-    ?.flatMap((item) => item.prices ?? [])
-    .find((item) => item.date === toFidelityDate(dateString));
-
-  if (historicalPrice?.milRateAndYieldInstance?.milRate) {
-    return {
-      milRate: Number(historicalPrice.milRateAndYieldInstance.milRate),
-      featureInformation,
-    };
-  }
-
-  const milrateYield = response.prices
-    ?.flatMap((price) => price.milrateYields ?? [])
-    .find((item) => fromFidelityDate(item.milrateDate) === dateString);
-
-  return {
-    milRate: milrateYield?.milrate ? Number(milrateYield.milrate) : undefined,
-    featureInformation,
-  };
-}
-
-const fetch = async (_: any, _1: any, options: FetchOptions): Promise<FetchResult> => {
-  let pricing = await getFundDataPricing(options.dateString);
-
-  if (pricing.milRate === undefined) {
-    pricing = await getHistoricalPricing(options.dateString);
-  }
+const fetch = async (_: any, _1: any, options: any) => {
+  const pricing = await getPricing(options.dateString);
 
   if (pricing.milRate === undefined) {
     throw new Error(`No Fidelity mil-rate found for ${options.dateString}`);
@@ -158,9 +55,11 @@ const fetch = async (_: any, _1: any, options: FetchOptions): Promise<FetchResul
     target: FDIT,
     abi: "erc20:totalSupply",
   });
-
+  const ratios = Object.fromEntries((pricing.featureInformation ?? []).map((i: any) => [i.featureCode, i.featureValue]));
+  const netExpenseRatio = parsePercent(ratios.ERAER) ?? parsePercent(ratios.NTEXP);
   const fditSupply = Number(supply) / 1e18;
-  const netExpenseRatio = getNetExpenseRatio(pricing.featureInformation);
+
+  if (netExpenseRatio === undefined) throw new Error("No Fidelity expense ratio found");
 
   const dailyDividends = fditSupply * pricing.milRate;
   const dailyFundFees = fditSupply * netExpenseRatio / 365;
@@ -169,12 +68,10 @@ const fetch = async (_: any, _1: any, options: FetchOptions): Promise<FetchResul
   const dailySupplySideRevenue = options.createBalances();
   const dailyRevenue = options.createBalances();
 
-  // Fidelity money market mil-rates are daily dividend amounts per $1 NAV share.
-  // Because FDIT/FYOXX targets a $1 NAV, supply in shares is also the USD AUM base for these calculations.
-  dailyFees.addUSDValue(dailyDividends, FDIT_DIVIDENDS);
-  dailyFees.addUSDValue(dailyFundFees, FDIT_NET_FUND_EXPENSES);
-  dailySupplySideRevenue.addUSDValue(dailyDividends, FDIT_DIVIDENDS_TO_HOLDERS);
-  dailyRevenue.addUSDValue(dailyFundFees, FDIT_NET_FUND_EXPENSES_TO_FIDELITY);
+  dailyFees.addUSDValue(dailyDividends, METRIC.ASSETS_YIELDS);
+  dailyFees.addUSDValue(dailyFundFees, METRIC.MANAGEMENT_FEES);
+  dailySupplySideRevenue.addUSDValue(dailyDividends, METRIC.ASSETS_YIELDS);
+  dailyRevenue.addUSDValue(dailyFundFees, METRIC.MANAGEMENT_FEES);
 
   return {
     dailyFees,
@@ -193,17 +90,17 @@ const methodology = {
 
 const breakdownMethodology = {
   Fees: {
-    [FDIT_DIVIDENDS]: "Daily dividends paid to FDIT holders from Fidelity's published mil-rate.",
-    [FDIT_NET_FUND_EXPENSES]: "Net fund expenses accrued daily using Fidelity's expense ratio.",
+    [METRIC.ASSETS_YIELDS]: "Daily dividends paid to FDIT holders from Fidelity's published mil-rate.",
+    [METRIC.MANAGEMENT_FEES]: "Net fund expenses accrued daily using Fidelity's expense ratio.",
   },
   Revenue: {
-    [FDIT_NET_FUND_EXPENSES_TO_FIDELITY]: "Net fund expenses accrued daily to Fidelity using Fidelity's expense ratio.",
+    [METRIC.MANAGEMENT_FEES]: "Net fund expenses accrued daily to Fidelity using Fidelity's expense ratio.",
   },
   ProtocolRevenue: {
-    [FDIT_NET_FUND_EXPENSES_TO_FIDELITY]: "Net fund expenses accrued daily to Fidelity using Fidelity's expense ratio.",
+    [METRIC.MANAGEMENT_FEES]: "Net fund expenses accrued daily to Fidelity using Fidelity's expense ratio.",
   },
   SupplySideRevenue: {
-    [FDIT_DIVIDENDS_TO_HOLDERS]: "Daily dividends paid to FDIT holders from Fidelity's published mil-rate.",
+    [METRIC.ASSETS_YIELDS]: "Daily dividends paid to FDIT holders from Fidelity's published mil-rate.",
   },
 };
 

--- a/fees/fidelity-digital-interest/index.ts
+++ b/fees/fidelity-digital-interest/index.ts
@@ -1,46 +1,31 @@
 import { SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 import { METRIC } from "../../helpers/metrics";
-import { httpGet, httpPost } from "../../utils/fetchURL";
+import { httpPost } from "../../utils/fetchURL";
 
 const FDIT = "0x48ab4e39ac59f4e88974804b04a991b3a402717f";
 const FUND_NO = "9053";
-// Source: Fidelity FYOXX/FDIT fund data and historical pricing APIs; SEC prospectus uses ERAER/NTEXP as net expense ratios.
-const FIDELITY_FUND_DATA_URL = "https://institutional.fidelity.com/app/fund/data/9053.json";
+// Source: Fidelity FYOXX/FDIT historical pricing API; SEC prospectus lists 0.2% net annual fund expenses.
 const FIDELITY_HISTORICAL_PRICING_URL = "https://institutional.fidelity.com/app/funds/historicalFundPricing";
+const NET_EXPENSE_RATIO = 0.002;
 
 const toFidelityDate = (dateString: string) => {
   const [year, month, day] = dateString.split("-");
   return `${month}/${day}/${year}`;
 };
 
-const parsePercent = (value?: string) => Number(value?.match(/[\d.]+/)?.[0]) / 100 || undefined;
-
 async function getPricing(dateString: string) {
-  const response: any = await httpGet(FIDELITY_FUND_DATA_URL);
-  const featureInformation = response.overview?.featureInformation;
   const fidelityDate = toFidelityDate(dateString);
-  const price =
-    response.historicalPricingYield
-    ?.flatMap((item: any) => item.prices ?? [])
-    .find((item: any) => item.date === fidelityDate)?.milRateAndYieldInstance?.milRate ??
-    response.prices
-      ?.flatMap((price: any) => price.milrateYields ?? [])
-      .find((item: any) => item.milrateDate === fidelityDate)?.milrate;
-
-  if (price) return { milRate: Number(price), featureInformation };
-
-  const historical: any = await httpPost(
+  const response: any = await httpPost(
     FIDELITY_HISTORICAL_PRICING_URL,
     new URLSearchParams({ fundNo: FUND_NO, startDate: fidelityDate, endDate: fidelityDate }).toString(),
     { headers: { "content-type": "application/x-www-form-urlencoded; charset=UTF-8" } }
   );
 
-  if (historical.status !== "success") throw new Error(`Fidelity historical pricing request failed for ${dateString}`);
+  if (response.status !== "success") throw new Error(`Fidelity historical pricing request failed for ${dateString}`);
 
   return {
-    milRate: Number(historical.prices?.find((item: any) => item.date === dateString)?.milRate) || undefined,
-    featureInformation: historical.featureInformation ?? featureInformation,
+    milRate: Number(response.prices?.find((item: any) => item.date === dateString)?.milRate) || undefined,
   };
 }
 
@@ -55,14 +40,10 @@ const fetch = async (_: any, _1: any, options: any) => {
     target: FDIT,
     abi: "erc20:totalSupply",
   });
-  const ratios = Object.fromEntries((pricing.featureInformation ?? []).map((i: any) => [i.featureCode, i.featureValue]));
-  const netExpenseRatio = parsePercent(ratios.ERAER) ?? parsePercent(ratios.NTEXP);
   const fditSupply = Number(supply) / 1e18;
 
-  if (netExpenseRatio === undefined) throw new Error("No Fidelity expense ratio found");
-
   const dailyDividends = fditSupply * pricing.milRate;
-  const dailyFundFees = fditSupply * netExpenseRatio / 365;
+  const dailyFundFees = fditSupply * NET_EXPENSE_RATIO / 365;
 
   const dailyFees = options.createBalances();
   const dailySupplySideRevenue = options.createBalances();


### PR DESCRIPTION
Fixes #6692 

## Summary

Adds a fees adapter for Fidelity Digital Interest Token (FDIT), the tokenized OnChain class of Fidelity Treasury Digital Fund (FYOXX).

## Methodology

- Uses Fidelity fund number `9053` for FYOXX/FDIT data.
- Uses on-chain FDIT total supply on Ethereum as the AUM base, since FDIT targets a `$1` NAV.
- Uses Fidelity daily `milRate` to calculate dividends paid to holders.
- Uses Fidelity net expense ratio to calculate fund fee revenue.

## Metrics

- `dailyFees`: FDIT dividends paid to holders + net fund expenses
- `dailySupplySideRevenue`: FDIT dividends paid to holders
- `dailyRevenue`: net fund expenses charged by Fidelity
- `dailyProtocolRevenue`: same as `dailyRevenue`

## Sources

- Website: https://institutional.fidelity.com/app/funds-and-products/9053/fidelity-treasury-digital-fund-onchain-class-fyoxx.html
- Fund data API: https://institutional.fidelity.com/app/fund/data/9053.json
- Historical prices/yields: https://institutional.fidelity.com/app/funds/hpdy
- SEC summary prospectus: https://www.sec.gov/Archives/edgar/data/917286/000113322825007437/ftdf-efp16750_497k.htm
- FDIT token: https://etherscan.io/token/0x48ab4e39ac59f4e88974804b04a991b3a402717f
