### PR TITLE
Tempo: add Stablecoin DEX (CLOB) volume adapter

### DIFF
--- a/dexs/tempo-stable-dex/index.ts
+++ b/dexs/tempo-stable-dex/index.ts
@@ -1,51 +1,6 @@
 import { FetchOptions, FetchResultV2, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 
-/**
- * Tempo Stablecoin DEX — daily spot volume.
- *
- * The Stablecoin DEX is a precompile predeployed at a fixed address on every
- * Tempo node (chainId 4217). It is a true on-chain CLOB (Central Limit Order
- * Book): users place price-tick-bound limit orders against base/quote pairs,
- * and matching is price-time priority, not constant-product.
- *
- *   Source:    https://github.com/tempoxyz/tempo/tree/main/crates/precompiles/src/stablecoin_dex
- *   Spec:      https://docs.tempo.xyz/protocol/exchange
- *   Predeploy: https://docs.tempo.xyz/quickstart/predeployed-contracts
- *
- * Event model:
- *
- *   event OrderPlaced(uint128 indexed orderId, address indexed maker,
- *                     address indexed token, uint128 amount, bool isBid,
- *                     int16 tick, bool isFlipOrder, int16 flipTick);
- *
- *   event OrderFilled(uint128 indexed orderId, address indexed maker,
- *                     address indexed taker, uint128 amountFilled,
- *                     bool partialFill);
- *
- * OrderFilled only carries the orderId — the base token and price-tick live
- * in OrderPlaced, which can fire any time before the fill. A same-window
- * log scan therefore misses fills against earlier-placed orders. We resolve
- * that by caching OrderPlaced from chain genesis (`fromBlock: 1`,
- * `cacheInCloud: true`) so the historical scan is paid once and subsequent
- * runs only fetch the delta. Each fill's `amountFilled` (base-token units)
- * is then added to the balances bag keyed by base token, and DefiLlama's
- * pricing layer resolves USD.
- *
- * Because `orderId` is monotonically incrementing (`next_order_id` in the
- * precompile, never reused) and OrderPlaced is fired exactly once per order,
- * the lookup is unambiguous. Cancelled orders never fill, so OrderCancelled
- * is not consulted.
- *
- * `maxBlockRange: 99_000` keeps each eth_getLogs call under Tempo's 100k-block
- * RPC limit; without it, Tempo's RPC rejects single-shot 24-hour spans
- * (~170k blocks at ~0.5s block time).
- *
- * The CLOB has no protocol fee (orderbook.rs has no fee escrow), so this
- * adapter reports volume only; cross-stable swap fees route through the
- * separate Fee AMM precompile already covered by `fees/tempo-fee-amm.ts`.
- */
-
 const STABLECOIN_DEX = "0xdec0000000000000000000000000000000000000";
 
 const eventOrderPlaced =
@@ -54,49 +9,31 @@ const eventOrderPlaced =
 const eventOrderFilled =
     "event OrderFilled(uint128 indexed orderId, address indexed maker, address indexed taker, uint128 amountFilled, bool partialFill)";
 
-type OrderMeta = { token: string };
-
 const methodology = {
-    Volume:
-        "Sum of OrderFilled.amountFilled emitted by Tempo's Stablecoin DEX precompile (0xdec0…0000) over the day, denominated in each fill's base-token units. The base token is recovered by joining each OrderFilled.orderId to the OrderPlaced event that introduced the order — OrderFilled itself is sparse and does not carry the token address. OrderPlaced is fetched from chain genesis with cloud caching, so the join covers fills against orders placed any time prior to the window. Fills against orders we cannot resolve (none expected in steady state) are dropped rather than mis-priced.",
+    Volume: "Sum of OrderFilled.amountFilled emitted by Tempo's Stablecoin DEX precompile (0xdec0…0000) over the day, denominated in each fill's base-token units.",
 };
 
 const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
     const dailyVolume = options.createBalances();
 
-    // Build orderId → token from every OrderPlaced ever emitted.
-    // cacheInCloud keeps the historical scan cheap on subsequent runs.
-    // fromBlock: 1 because block 0 is genesis (no logs) and SDK rejects
-    // fromBlock=0 as falsy. maxBlockRange caps each request at 99k blocks,
-    // under Tempo's 100k-block eth_getLogs limit.
-    const placedLogs = await options.getLogs({
+    const orderPlacedLogs = await options.getLogs({
         target: STABLECOIN_DEX,
         eventAbi: eventOrderPlaced,
         fromBlock: 6200000,
         cacheInCloud: true,
     });
 
-    const orderMap = new Map<string, OrderMeta>();
-    for (const log of placedLogs) {
-        orderMap.set(String(log.orderId), {
-            token: String(log.token).toLowerCase(),
-        });
-    }
+    const orderMap: Map<string, string> = new Map(orderPlacedLogs.map(log => [String(log.orderId), log.token]));
 
-    // Daily fills, scoped to the window provided by the cron.
-    const fillLogs = await options.getLogs({
+    const orderFilledLogs = await options.getLogs({
         target: STABLECOIN_DEX,
         eventAbi: eventOrderFilled,
     });
 
-    for (const fill of fillLogs) {
-        const meta = orderMap.get(String(fill.orderId));
-        if (!meta) continue; // unmappable — order placed before our cache window
-
-        // amountFilled is in base-token smallest units (6 decimals for every TIP-20
-        // stablecoin Tempo currently lists). Adding by token lets DefiLlama's
-        // pricing layer resolve to USD per registered stablecoin price.
-        dailyVolume.add(meta.token, BigInt(fill.amountFilled));
+    for (const orderFilledLog of orderFilledLogs) {
+        const orderToken = orderMap.get(String(orderFilledLog.orderId));
+        if (!orderToken) continue;
+        dailyVolume.add(orderToken, BigInt(orderFilledLog.amountFilled));
     }
 
     return { dailyVolume };
@@ -104,14 +41,11 @@ const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
 
 const adapter: SimpleAdapter = {
     version: 2,
+    fetch,
     pullHourly: true,
     methodology,
-    adapter: {
-        [CHAIN.TEMPO]: {
-            fetch,
-            start: "2026-03-18", // Tempo Mainnet "Presto" launch (chainId 4217)
-        },
-    },
+    chains: [CHAIN.TEMPO],
+    start: "2026-03-18", // Tempo Mainnet "Presto" launch (chainId 4217)
 };
 
 export default adapter;

--- a/dexs/tempo-stable-dex/index.ts
+++ b/dexs/tempo-stable-dex/index.ts
@@ -49,73 +49,69 @@ import { CHAIN } from "../../helpers/chains";
 const STABLECOIN_DEX = "0xdec0000000000000000000000000000000000000";
 
 const eventOrderPlaced =
-  "event OrderPlaced(uint128 indexed orderId, address indexed maker, address indexed token, uint128 amount, bool isBid, int16 tick, bool isFlipOrder, int16 flipTick)";
+    "event OrderPlaced(uint128 indexed orderId, address indexed maker, address indexed token, uint128 amount, bool isBid, int16 tick, bool isFlipOrder, int16 flipTick)";
 
 const eventOrderFilled =
-  "event OrderFilled(uint128 indexed orderId, address indexed maker, address indexed taker, uint128 amountFilled, bool partialFill)";
+    "event OrderFilled(uint128 indexed orderId, address indexed maker, address indexed taker, uint128 amountFilled, bool partialFill)";
 
 type OrderMeta = { token: string };
 
 const methodology = {
-  Volume:
-    "Sum of OrderFilled.amountFilled emitted by Tempo's Stablecoin DEX precompile (0xdec0…0000) over the day, denominated in each fill's base-token units. The base token is recovered by joining each OrderFilled.orderId to the OrderPlaced event that introduced the order — OrderFilled itself is sparse and does not carry the token address. OrderPlaced is fetched from chain genesis with cloud caching, so the join covers fills against orders placed any time prior to the window. Fills against orders we cannot resolve (none expected in steady state) are dropped rather than mis-priced.",
+    Volume:
+        "Sum of OrderFilled.amountFilled emitted by Tempo's Stablecoin DEX precompile (0xdec0…0000) over the day, denominated in each fill's base-token units. The base token is recovered by joining each OrderFilled.orderId to the OrderPlaced event that introduced the order — OrderFilled itself is sparse and does not carry the token address. OrderPlaced is fetched from chain genesis with cloud caching, so the join covers fills against orders placed any time prior to the window. Fills against orders we cannot resolve (none expected in steady state) are dropped rather than mis-priced.",
 };
 
 const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
-  const dailyVolume = options.createBalances();
+    const dailyVolume = options.createBalances();
 
-  // Build orderId → token from every OrderPlaced ever emitted.
-  // cacheInCloud keeps the historical scan cheap on subsequent runs.
-  // fromBlock: 1 because block 0 is genesis (no logs) and SDK rejects
-  // fromBlock=0 as falsy. maxBlockRange caps each request at 99k blocks,
-  // under Tempo's 100k-block eth_getLogs limit.
-  const placedLogs = await options.getLogs({
-    target: STABLECOIN_DEX,
-    eventAbi: eventOrderPlaced,
-    fromBlock: 1,
-    cacheInCloud: true,
-    skipIndexer: true,
-    ...({ maxBlockRange: 99_000 } as any),
-  });
-
-  const orderMap = new Map<string, OrderMeta>();
-  for (const log of placedLogs) {
-    orderMap.set(String(log.orderId), {
-      token: String(log.token).toLowerCase(),
+    // Build orderId → token from every OrderPlaced ever emitted.
+    // cacheInCloud keeps the historical scan cheap on subsequent runs.
+    // fromBlock: 1 because block 0 is genesis (no logs) and SDK rejects
+    // fromBlock=0 as falsy. maxBlockRange caps each request at 99k blocks,
+    // under Tempo's 100k-block eth_getLogs limit.
+    const placedLogs = await options.getLogs({
+        target: STABLECOIN_DEX,
+        eventAbi: eventOrderPlaced,
+        fromBlock: 6200000,
+        cacheInCloud: true,
     });
-  }
 
-  // Daily fills, scoped to the window provided by the cron.
-  const fillLogs = await options.getLogs({
-    target: STABLECOIN_DEX,
-    eventAbi: eventOrderFilled,
-    skipIndexer: true,
-    ...({ maxBlockRange: 99_000 } as any),
-  });
+    const orderMap = new Map<string, OrderMeta>();
+    for (const log of placedLogs) {
+        orderMap.set(String(log.orderId), {
+            token: String(log.token).toLowerCase(),
+        });
+    }
 
-  for (const fill of fillLogs) {
-    const meta = orderMap.get(String(fill.orderId));
-    if (!meta) continue; // unmappable — order placed before our cache window
+    // Daily fills, scoped to the window provided by the cron.
+    const fillLogs = await options.getLogs({
+        target: STABLECOIN_DEX,
+        eventAbi: eventOrderFilled,
+    });
 
-    // amountFilled is in base-token smallest units (6 decimals for every TIP-20
-    // stablecoin Tempo currently lists). Adding by token lets DefiLlama's
-    // pricing layer resolve to USD per registered stablecoin price.
-    dailyVolume.add(meta.token, BigInt(fill.amountFilled));
-  }
+    for (const fill of fillLogs) {
+        const meta = orderMap.get(String(fill.orderId));
+        if (!meta) continue; // unmappable — order placed before our cache window
 
-  return { dailyVolume };
+        // amountFilled is in base-token smallest units (6 decimals for every TIP-20
+        // stablecoin Tempo currently lists). Adding by token lets DefiLlama's
+        // pricing layer resolve to USD per registered stablecoin price.
+        dailyVolume.add(meta.token, BigInt(fill.amountFilled));
+    }
+
+    return { dailyVolume };
 };
 
 const adapter: SimpleAdapter = {
-  version: 2,
-  pullHourly: true,
-  methodology,
-  adapter: {
-    [CHAIN.TEMPO]: {
-      fetch,
-      start: "2026-03-18", // Tempo Mainnet "Presto" launch (chainId 4217)
+    version: 2,
+    pullHourly: true,
+    methodology,
+    adapter: {
+        [CHAIN.TEMPO]: {
+            fetch,
+            start: "2026-03-18", // Tempo Mainnet "Presto" launch (chainId 4217)
+        },
     },
-  },
 };
 
 export default adapter;

--- a/dexs/tempo-stable-dex/index.ts
+++ b/dexs/tempo-stable-dex/index.ts
@@ -1,0 +1,121 @@
+import { FetchOptions, FetchResultV2, SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+
+/**
+ * Tempo Stablecoin DEX — daily spot volume.
+ *
+ * The Stablecoin DEX is a precompile predeployed at a fixed address on every
+ * Tempo node (chainId 4217). It is a true on-chain CLOB (Central Limit Order
+ * Book): users place price-tick-bound limit orders against base/quote pairs,
+ * and matching is price-time priority, not constant-product.
+ *
+ *   Source:    https://github.com/tempoxyz/tempo/tree/main/crates/precompiles/src/stablecoin_dex
+ *   Spec:      https://docs.tempo.xyz/protocol/exchange
+ *   Predeploy: https://docs.tempo.xyz/quickstart/predeployed-contracts
+ *
+ * Event model:
+ *
+ *   event OrderPlaced(uint128 indexed orderId, address indexed maker,
+ *                     address indexed token, uint128 amount, bool isBid,
+ *                     int16 tick, bool isFlipOrder, int16 flipTick);
+ *
+ *   event OrderFilled(uint128 indexed orderId, address indexed maker,
+ *                     address indexed taker, uint128 amountFilled,
+ *                     bool partialFill);
+ *
+ * OrderFilled only carries the orderId — the base token and price-tick live
+ * in OrderPlaced, which can fire any time before the fill. A same-window
+ * log scan therefore misses fills against earlier-placed orders. We resolve
+ * that by caching OrderPlaced from chain genesis (`fromBlock: 1`,
+ * `cacheInCloud: true`) so the historical scan is paid once and subsequent
+ * runs only fetch the delta. Each fill's `amountFilled` (base-token units)
+ * is then added to the balances bag keyed by base token, and DefiLlama's
+ * pricing layer resolves USD.
+ *
+ * Because `orderId` is monotonically incrementing (`next_order_id` in the
+ * precompile, never reused) and OrderPlaced is fired exactly once per order,
+ * the lookup is unambiguous. Cancelled orders never fill, so OrderCancelled
+ * is not consulted.
+ *
+ * `maxBlockRange: 99_000` keeps each eth_getLogs call under Tempo's 100k-block
+ * RPC limit; without it, Tempo's RPC rejects single-shot 24-hour spans
+ * (~170k blocks at ~0.5s block time).
+ *
+ * The CLOB has no protocol fee (orderbook.rs has no fee escrow), so this
+ * adapter reports volume only; cross-stable swap fees route through the
+ * separate Fee AMM precompile already covered by `fees/tempo-fee-amm.ts`.
+ */
+
+const STABLECOIN_DEX = "0xdec0000000000000000000000000000000000000";
+
+const eventOrderPlaced =
+  "event OrderPlaced(uint128 indexed orderId, address indexed maker, address indexed token, uint128 amount, bool isBid, int16 tick, bool isFlipOrder, int16 flipTick)";
+
+const eventOrderFilled =
+  "event OrderFilled(uint128 indexed orderId, address indexed maker, address indexed taker, uint128 amountFilled, bool partialFill)";
+
+type OrderMeta = { token: string };
+
+const methodology = {
+  Volume:
+    "Sum of OrderFilled.amountFilled emitted by Tempo's Stablecoin DEX precompile (0xdec0…0000) over the day, denominated in each fill's base-token units. The base token is recovered by joining each OrderFilled.orderId to the OrderPlaced event that introduced the order — OrderFilled itself is sparse and does not carry the token address. OrderPlaced is fetched from chain genesis with cloud caching, so the join covers fills against orders placed any time prior to the window. Fills against orders we cannot resolve (none expected in steady state) are dropped rather than mis-priced.",
+};
+
+const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
+  const dailyVolume = options.createBalances();
+
+  // Build orderId → token from every OrderPlaced ever emitted.
+  // cacheInCloud keeps the historical scan cheap on subsequent runs.
+  // fromBlock: 1 because block 0 is genesis (no logs) and SDK rejects
+  // fromBlock=0 as falsy. maxBlockRange caps each request at 99k blocks,
+  // under Tempo's 100k-block eth_getLogs limit.
+  const placedLogs = await options.getLogs({
+    target: STABLECOIN_DEX,
+    eventAbi: eventOrderPlaced,
+    fromBlock: 1,
+    cacheInCloud: true,
+    skipIndexer: true,
+    ...({ maxBlockRange: 99_000 } as any),
+  });
+
+  const orderMap = new Map<string, OrderMeta>();
+  for (const log of placedLogs) {
+    orderMap.set(String(log.orderId), {
+      token: String(log.token).toLowerCase(),
+    });
+  }
+
+  // Daily fills, scoped to the window provided by the cron.
+  const fillLogs = await options.getLogs({
+    target: STABLECOIN_DEX,
+    eventAbi: eventOrderFilled,
+    skipIndexer: true,
+    ...({ maxBlockRange: 99_000 } as any),
+  });
+
+  for (const fill of fillLogs) {
+    const meta = orderMap.get(String(fill.orderId));
+    if (!meta) continue; // unmappable — order placed before our cache window
+
+    // amountFilled is in base-token smallest units (6 decimals for every TIP-20
+    // stablecoin Tempo currently lists). Adding by token lets DefiLlama's
+    // pricing layer resolve to USD per registered stablecoin price.
+    dailyVolume.add(meta.token, BigInt(fill.amountFilled));
+  }
+
+  return { dailyVolume };
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  pullHourly: true,
+  methodology,
+  adapter: {
+    [CHAIN.TEMPO]: {
+      fetch,
+      start: "2026-03-18", // Tempo Mainnet "Presto" launch (chainId 4217)
+    },
+  },
+};
+
+export default adapter;


### PR DESCRIPTION
## Summary

Daily volume adapter for **Tempo's Stablecoin DEX**, a precompile-level CLOB predeployed at `0xdec0000000000000000000000000000000000000` on Tempo Mainnet (chainId 4217).

```
$ npx ts-node --transpile-only cli/testAdapter.ts dexs tempo-stable-dex
🦙 Running TEMPO-STABLE-DEX adapter 🦙
Start Date:  Sat, 02 May 2026 18:36:54 GMT
End Date:    Sun, 03 May 2026 18:36:54 GMT

TEMPO 👇
Daily volume: 21.56 k
```

## Event model

The Stablecoin DEX is a true CLOB — orders are placed against a price-tick grid and matched price-time-priority. Two volume-relevant events:

```solidity
event OrderPlaced(
  uint128 indexed orderId, address indexed maker, address indexed token,
  uint128 amount, bool isBid, int16 tick, bool isFlipOrder, int16 flipTick
);

event OrderFilled(
  uint128 indexed orderId, address indexed maker, address indexed taker,
  uint128 amountFilled, bool partialFill
);
```

`OrderFilled` only carries the `orderId` — the base token and price-tick live in the `OrderPlaced` event, which can fire any time before the fill. A same-window log scan misses fills against earlier-placed orders.

## How the adapter handles it

1. **OrderPlaced cached from genesis.** Fetched with `fromBlock: 1`, `cacheInCloud: true` so the historical scan is paid once; subsequent runs only fetch the delta. This builds an `orderId → token` table.
2. **Daily fills.** OrderFilled fetched for the cron's window only.
3. **Volume aggregation.** Each `amountFilled` (base-token smallest units) is added to the balances bag keyed by base token. DefiLlama's pricing layer resolves USD per registered stablecoin price.

`orderId` is monotonically incrementing in the precompile (`next_order_id`, never reused) and OrderPlaced fires exactly once per order, so the lookup is unambiguous. Cancelled orders never fill, so OrderCancelled is not consulted.

## Tempo-specific options

- `fromBlock: 1` — block 0 is genesis (no logs) and SDK's `getLogs` rejects `fromBlock=0` as falsy.
- `maxBlockRange: 99_000` — Tempo's RPC caps `eth_getLogs` at 100k blocks per call. Without chunking, single-shot 24-hour spans (~170k blocks at the chain's ~0.5s block time) get truncated.
- `skipIndexer: true` — Tempo isn't on DefiLlama's log indexer yet.

## Verified against on-chain

Direct RPC count for the test window `[17,889,211, 18,063,094]` (the cli's translation of `2026-05-02 18:36 UTC → 2026-05-03 18:36 UTC`):

| Source | Fills |
|---|---|
| Direct `eth_getLogs` (50k chunks) | 4,782 |
| This adapter | 4,782 |

Token breakdown (test day):

| Base token | Daily volume |
|---|---|
| USDC.e (`0x20c0…b9537d11c60e8b50`) | $20,254 (94%) |
| EURAU (`0x20c0…14f22ca97301eb73`) | $1,296 |
| cUSD (`0x20c0…0520792dcccccccc`) | $17 |
| **Total** | **$21,567** |

The CLOB is currently dominated by USDC.e/pathUSD, consistent with USDC.e being the primary inbound bridge route on Tempo (Stargate v2). pathUSD is the universal quote token (per [docs.tempo.xyz/protocol/exchange/quote-tokens#pathusd](https://docs.tempo.xyz/protocol/exchange/quote-tokens#pathusd)), so it doesn't appear on the base side of any pair.

## Out of scope

- **Protocol fees.** The CLOB itself has no fee escrow (orderbook.rs has none); cross-stable swap fees route through the separate Fee AMM precompile, already covered by the merged Fee AMM adapter ([#6682](https://github.com/DefiLlama/dimension-adapters/pull/6682)).
- **`maxBlockRange` typing.** Currently passed via `as any` because the field isn't in `FetchGetLogsOptions` — the SDK accepts it via `...rest`. Happy to follow up with a typing PR if helpful.

## Companion PRs (Tempo Mainnet integration set)

- [DefiLlama-Adapters #19015](https://github.com/DefiLlama/DefiLlama-Adapters/pull/19015) — TVL coverage (stable-dex refactor + Fee AMM TVL) — open
- [peggedassets-server #773](https://github.com/DefiLlama/peggedassets-server/pull/773) — pathUSD pegged + 9 stablecoin Tempo extends — open
- [dimension-adapters #6682](https://github.com/DefiLlama/dimension-adapters/pull/6682) — Fee AMM protocol fees adapter — merged 2026-05-02
- [bridges-server #478](https://github.com/DefiLlama/bridges-server/pull/478) — Stargate v2 Tempo OFT spoke bridge volume — merged 2026-05-01
- [defillama-sdk #214](https://github.com/DefiLlama/defillama-sdk/pull/214) — adds official Tempo RPC to providers.json — open
