### PR TITLE
fix liquidswap volume

### DIFF
--- a/dexs/liquidswap/index.ts
+++ b/dexs/liquidswap/index.ts
@@ -1,4 +1,4 @@
-import { Dependencies, FetchOptions, FetchResultV2, SimpleAdapter } from "../../adapters/types";
+import { Dependencies, FetchOptions, FetchResult, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 import { queryDuneSql } from "../../helpers/dune";
 
@@ -10,7 +10,7 @@ const LIQUIDSWAP_SWAP_EVENT_PREFIXES = [
 // Existing dashboard history currently ends at 2025-10-21 from the old Pontem/Sentrio source.
 const START_DATE = "2025-10-22";
 
-const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
+const fetch = async (_a: any, _b: any, options: FetchOptions): Promise<FetchResult> => {
   const eventFilters = LIQUIDSWAP_SWAP_EVENT_PREFIXES
     .map((prefix) => `event_type LIKE '${prefix}%'`)
     .join(" OR ");
@@ -59,7 +59,7 @@ const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
 };
 
 const adapter: SimpleAdapter = {
-  version: 2,
+  version: 1,
   adapter: {
     [CHAIN.APTOS]: {
       fetch,

--- a/dexs/liquidswap/index.ts
+++ b/dexs/liquidswap/index.ts
@@ -1,37 +1,73 @@
-// https://sentrio-api.pontem.network/api/volumes
-import fetchURL from "../../utils/fetchURL";
-import { SimpleAdapter } from "../../adapters/types";
+import { Dependencies, FetchOptions, FetchResultV2, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
-import { getUniqStartOfTodayTimestamp } from "../../helpers/getUniSubgraphVolume";
+import { queryDuneSql } from "../../helpers/dune";
 
-const historicalVolumeEndpoint = "https://sentrio-api.pontem.network/api/volumes";
+const LIQUIDSWAP_SWAP_EVENT_PREFIXES = [
+  "0x190d44266241744264b964a37b8f09863167a12d3e70cda39376cfb4e3561e12::liquidity_pool::SwapEvent<",
+  "0x163df34fccbf003ce219d3f1d9e70d140b60622cb9dd47599c25fb2f797ba6e::liquidity_pool::SwapEvent<",
+];
 
-interface IVolumeall {
-  value: number;
-  timestamp: string;
-}
+// Existing dashboard history currently ends at 2025-10-21 from the old Pontem/Sentrio source.
+const START_DATE = "2025-10-22";
 
-const fetch = async (timestamp: number) => {
-  const dayTimestamp = getUniqStartOfTodayTimestamp(new Date(timestamp * 1000))
-  const historicalVolume: IVolumeall[] = (await fetchURL(historicalVolumeEndpoint)).data;
+const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
+  const eventFilters = LIQUIDSWAP_SWAP_EVENT_PREFIXES
+    .map((prefix) => `event_type LIKE '${prefix}%'`)
+    .join(" OR ");
 
-  const dailyVolume = historicalVolume
-    .find(dayItem => getUniqStartOfTodayTimestamp(new Date(Number(dayItem.timestamp) * 1000)) === dayTimestamp)?.value
+  const query = `
+    WITH raw_swaps AS (
+      SELECT
+        TRIM(REGEXP_EXTRACT(event_type, 'SwapEvent<([^,]+), *([^,]+),', 1)) AS token_x,
+        TRIM(REGEXP_EXTRACT(event_type, 'SwapEvent<([^,]+), *([^,]+),', 2)) AS token_y,
+        TRY_CAST(JSON_EXTRACT_SCALAR(JSON_PARSE(data), '$.x_in') AS DECIMAL(38, 0)) AS x_in,
+        TRY_CAST(JSON_EXTRACT_SCALAR(JSON_PARSE(data), '$.y_in') AS DECIMAL(38, 0)) AS y_in
+      FROM aptos.events
+      WHERE block_date >= FROM_UNIXTIME(${options.startTimestamp})
+        AND block_date < FROM_UNIXTIME(${options.endTimestamp})
+        AND block_time >= FROM_UNIXTIME(${options.startTimestamp})
+        AND block_time < FROM_UNIXTIME(${options.endTimestamp})
+        AND tx_success = TRUE
+        AND (${eventFilters})
+    ),
+    volume_by_token AS (
+      SELECT token_x AS token, SUM(COALESCE(x_in, 0)) AS amount
+      FROM raw_swaps
+      GROUP BY 1
 
-  return {
-    dailyVolume: dailyVolume,
-    timestamp: dayTimestamp,
-  };
+      UNION ALL
+
+      SELECT token_y AS token, SUM(COALESCE(y_in, 0)) AS amount
+      FROM raw_swaps
+      GROUP BY 1
+    )
+    SELECT
+      token,
+      CAST(SUM(amount) AS VARCHAR) AS amount
+    FROM volume_by_token
+    WHERE token IS NOT NULL
+    GROUP BY 1
+    HAVING SUM(amount) > 0
+  `;
+
+  const dailyVolume = options.createBalances();
+  const rows: { token: string; amount: string }[] = await queryDuneSql(options, query);
+
+  rows.forEach(({ token, amount }) => dailyVolume.add(token, amount));
+
+  return { dailyVolume };
 };
 
-
 const adapter: SimpleAdapter = {
+  version: 2,
   adapter: {
     [CHAIN.APTOS]: {
       fetch,
-      start: '2022-11-20'
+      start: START_DATE,
     },
   },
+  dependencies: [Dependencies.DUNE],
+  isExpensiveAdapter: true,
 };
 
 export default adapter;


### PR DESCRIPTION
## Summary

Closes #6710

Liquidswap volume is currently broken because the old Pontem/Sentrio endpoint the adapter used is no longer available:

`https://sentrio-api.pontem.network/api/volumes`

This PR replaces that dead endpoint with a Dune query over `aptos.events`, using Liquidswap `SwapEvent` logs to rebuild daily volume from the input side of swaps.

The query covers both Liquidswap deployments I found activity for:

- `0x190d44266241744264b964a37b8f09863167a12d3e70cda39376cfb4e3561e12`
- `0x163df34fccbf003ce219d3f1d9e70d140b60622cb9dd47599c25fb2f797ba6e`

## Historical data

I’m intentionally starting the new source from `2025-10-22`, which is the day after the last existing datapoint.

The old API returned already-aggregated USD volume, and I couldn’t reproduce its exact methodology from public data. The new query is on-chain: it sums raw swap input amounts and lets DefiLlama price those token balances. When I compared a few historical days, the numbers were directionally similar but not identical.

This keeps the existing chart history as-is and only resumes tracking from where the old source stopped. That avoids rewriting old dashboard data with a slightly different methodology but gets the adapter live again.

## Validation

```bash
pnpm run ts-check
pnpm test dexs liquidswap 2025-10-23
```