### PR TITLE
feat: hastra - track fees and revenue

### DIFF
--- a/fees/hastra/index.ts
+++ b/fees/hastra/index.ts
@@ -1,0 +1,67 @@
+import { FetchOptions, SimpleAdapter,Dependencies } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import { queryDuneSql } from "../../helpers/dune";
+
+const WYLDS_MINT = "8fr7WGTVFszfyNWRMXj6fRjZZAnDwmXwEpCrtzmUkdih";
+
+const fetch = async (_a: any, _b: any, options: FetchOptions) => {
+  const dailyFees = options.createBalances();
+  const dailySupplySideRevenue = options.createBalances();
+
+  const query = `
+    SELECT
+      SUM(amount_display) AS total_minted
+    FROM tokens_solana.transfers
+    WHERE
+      token_mint_address = '${WYLDS_MINT}'
+      AND action = 'mint'
+      AND TIME_RANGE
+  `;
+
+  const result = await queryDuneSql(options, query);
+  const totalMinted = Number(result?.[0]?.total_minted ?? 0);
+
+  if (totalMinted > 0) {
+    dailyFees.addUSDValue(totalMinted);
+    dailySupplySideRevenue.addUSDValue(totalMinted);
+  }
+
+  return {
+    dailyFees,
+    dailySupplySideRevenue,
+    dailyRevenue: options.createBalances(),
+    dailyUserFees: dailyFees,
+  };
+};
+
+const methodology = {
+  Fees: "All wYLDS tokens minted on-chain, representing real-world yield from Figure's HELOC lending pools distributed to wYLDS holders and PRIME stakers.",
+  UserFees: "Yield paid by underlying HELOC borrowers, passed on-chain as newly minted wYLDS to token holders.",
+  SupplySideRevenue: "100% of minted wYLDS accrues to wYLDS holders and PRIME stakers. PRIME stakers earn enhanced yield via the increasing wYLDS-per-PRIME exchange rate.",
+  Revenue: "Hastra takes no on-chain protocol fee cut. Figure monetises via off-chain lending spreads on HELOCs.",
+};
+
+const breakdownMethodology = {
+  Fees: {
+    "HELOC Lending Yield": "wYLDS minted each epoch representing yield from Figure's Demo Prime HELOC real estate lending operations.",
+  },
+  UserFees: {
+    "HELOC Lending Yield": "Yield originated from real estate borrowers paying interest on Figure's HELOC lending pools.",
+  },
+  SupplySideRevenue: {
+    "HELOC Lending Yield To Holders": "All minted wYLDS distributed to wYLDS holders and PRIME stakers.",
+  },
+};
+
+const adapter: SimpleAdapter = {
+  version: 1,
+  fetch,
+  chains: [CHAIN.SOLANA],
+  start: "2025-11-21",
+  isExpensiveAdapter: true,
+  dependencies: [Dependencies.DUNE],
+  methodology,
+  breakdownMethodology,
+};
+
+export default adapter;

--- a/fees/hastra/index.ts
+++ b/fees/hastra/index.ts
@@ -4,7 +4,7 @@ import { queryDuneSql } from "../../helpers/dune";
 
 const WYLDS_MINT = "8fr7WGTVFszfyNWRMXj6fRjZZAnDwmXwEpCrtzmUkdih";
 
-const fetch = async (_a: any, _b: any, options: FetchOptions) => {
+const fetch = async (options: FetchOptions) => {
   const dailyFees = options.createBalances();
   const dailySupplySideRevenue = options.createBalances();
 
@@ -22,8 +22,8 @@ const fetch = async (_a: any, _b: any, options: FetchOptions) => {
   const totalMinted = Number(result?.[0]?.total_minted ?? 0);
 
   if (totalMinted > 0) {
-    dailyFees.addUSDValue(totalMinted);
-    dailySupplySideRevenue.addUSDValue(totalMinted);
+    dailyFees.addUSDValue(totalMinted, "HELOC Lending Yield");
+    dailySupplySideRevenue.addUSDValue(totalMinted, "HELOC Lending Yield To Holders");
   }
 
   return {
@@ -36,7 +36,7 @@ const fetch = async (_a: any, _b: any, options: FetchOptions) => {
 
 const methodology = {
   Fees: "All wYLDS tokens minted on-chain, representing real-world yield from Figure's HELOC lending pools distributed to wYLDS holders and PRIME stakers.",
-  UserFees: "Yield paid by underlying HELOC borrowers, passed on-chain as newly minted wYLDS to token holders.",
+  UserFees: "Yield originated from real estate borrowers paying interest on Figure's HELOC lending pools.",
   SupplySideRevenue: "100% of minted wYLDS accrues to wYLDS holders and PRIME stakers. PRIME stakers earn enhanced yield via the increasing wYLDS-per-PRIME exchange rate.",
   Revenue: "Hastra takes no on-chain protocol fee cut. Figure monetises via off-chain lending spreads on HELOCs.",
 };
@@ -54,7 +54,7 @@ const breakdownMethodology = {
 };
 
 const adapter: SimpleAdapter = {
-  version: 1,
+  version: 2,
   fetch,
   chains: [CHAIN.SOLANA],
   start: "2025-11-21",

--- a/fees/hastra/index.ts
+++ b/fees/hastra/index.ts
@@ -4,6 +4,10 @@ import { queryDuneSql } from "../../helpers/dune";
 
 const WYLDS_MINT = "8fr7WGTVFszfyNWRMXj6fRjZZAnDwmXwEpCrtzmUkdih";
 
+const VAULT_STAKE_WYLDS_ACCOUNT = "FvkbfMm98jefJWrqkvXvsSZ9RFaRBae8k6c1jaYA5vY3";
+
+const VAULT_STAKE_OWNER = "DT7z9w9fGJ6sH7vmGbPCa5JLi2xp6XPrL61z2gctzmHb";
+
 const fetch = async (options: FetchOptions) => {
   const dailyFees = options.createBalances();
   const dailySupplySideRevenue = options.createBalances();
@@ -15,6 +19,8 @@ const fetch = async (options: FetchOptions) => {
     WHERE
       token_mint_address = '${WYLDS_MINT}'
       AND action = 'mint'
+      AND to_token_account = '${VAULT_STAKE_WYLDS_ACCOUNT}'
+      AND to_owner = '${VAULT_STAKE_OWNER}'
       AND TIME_RANGE
   `;
 
@@ -30,26 +36,21 @@ const fetch = async (options: FetchOptions) => {
     dailyFees,
     dailySupplySideRevenue,
     dailyRevenue: options.createBalances(),
-    dailyUserFees: dailyFees,
   };
 };
 
 const methodology = {
-  Fees: "All wYLDS tokens minted on-chain, representing real-world yield from Figure's HELOC lending pools distributed to wYLDS holders and PRIME stakers.",
-  UserFees: "Yield originated from real estate borrowers paying interest on Figure's HELOC lending pools.",
-  SupplySideRevenue: "100% of minted wYLDS accrues to wYLDS holders and PRIME stakers. PRIME stakers earn enhanced yield via the increasing wYLDS-per-PRIME exchange rate.",
+  Fees: "wYLDS tokens minted into the vault-stake account via publish_rewards, representing real-world yield from Figure's HELOC lending pools distributed to PRIME stakers.",
+  SupplySideRevenue: "All minted wYLDS accrues to PRIME stakers by increasing the wYLDS-per-PRIME exchange rate.",
   Revenue: "Hastra takes no on-chain protocol fee cut. Figure monetises via off-chain lending spreads on HELOCs.",
 };
 
 const breakdownMethodology = {
   Fees: {
-    "HELOC Lending Yield": "wYLDS minted each epoch representing yield from Figure's Demo Prime HELOC real estate lending operations.",
-  },
-  UserFees: {
-    "HELOC Lending Yield": "Yield originated from real estate borrowers paying interest on Figure's HELOC lending pools.",
+    "HELOC Lending Yield": "wYLDS minted hourly into the vault-stake account via publish_rewards CPI from vault-mint, funded by Figure's Demo Prime HELOC lending operations.",
   },
   SupplySideRevenue: {
-    "HELOC Lending Yield To Holders": "All minted wYLDS distributed to wYLDS holders and PRIME stakers.",
+    "HELOC Lending Yield To Holders": "All minted wYLDS increase the wYLDS-per-PRIME ratio, fully accruing to PRIME stakers.",
   },
 };
 

--- a/fees/hastra/index.ts
+++ b/fees/hastra/index.ts
@@ -36,6 +36,7 @@ const fetch = async (options: FetchOptions) => {
     dailyFees,
     dailySupplySideRevenue,
     dailyRevenue: options.createBalances(),
+    dailyUserFees: options.createBalances(),
   };
 };
 
@@ -43,6 +44,7 @@ const methodology = {
   Fees: "wYLDS tokens minted into the vault-stake account via publish_rewards, representing real-world yield from Figure's HELOC lending pools distributed to PRIME stakers.",
   SupplySideRevenue: "All minted wYLDS accrues to PRIME stakers by increasing the wYLDS-per-PRIME exchange rate.",
   Revenue: "Hastra takes no on-chain protocol fee cut. Figure monetises via off-chain lending spreads on HELOCs.",
+  UserFees: "Users pay no on-chain fees. Yield originates from off-chain HELOC borrowers paying interest to Figure.",
 };
 
 const breakdownMethodology = {
@@ -51,6 +53,12 @@ const breakdownMethodology = {
   },
   SupplySideRevenue: {
     "HELOC Lending Yield To Holders": "All minted wYLDS increase the wYLDS-per-PRIME ratio, fully accruing to PRIME stakers.",
+  },
+  Revenue: {
+    "Protocol Revenue": "Hastra takes no on-chain protocol fee cut.",
+  },
+  UserFees: {
+    "User Fees": "Users pay no on-chain fees. Yield originates from off-chain HELOC borrowers.",
   },
 };
 

--- a/fees/hastra/index.ts
+++ b/fees/hastra/index.ts
@@ -1,6 +1,7 @@
-import { FetchOptions, SimpleAdapter,Dependencies } from "../../adapters/types";
+import { FetchOptions, SimpleAdapter, Dependencies } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 import { queryDuneSql } from "../../helpers/dune";
+import { METRIC } from "../../helpers/metrics";
 
 const WYLDS_MINT = "8fr7WGTVFszfyNWRMXj6fRjZZAnDwmXwEpCrtzmUkdih";
 
@@ -8,69 +9,56 @@ const VAULT_STAKE_WYLDS_ACCOUNT = "FvkbfMm98jefJWrqkvXvsSZ9RFaRBae8k6c1jaYA5vY3"
 
 const VAULT_STAKE_OWNER = "DT7z9w9fGJ6sH7vmGbPCa5JLi2xp6XPrL61z2gctzmHb";
 
-const fetch = async (options: FetchOptions) => {
-  const dailyFees = options.createBalances();
-  const dailySupplySideRevenue = options.createBalances();
+const fetch = async (_a: any, _b: any, options: FetchOptions) => {
+    const dailyFees = options.createBalances();
 
-  const query = `
-    SELECT
-      SUM(amount_display) AS total_minted
-    FROM tokens_solana.transfers
-    WHERE
-      token_mint_address = '${WYLDS_MINT}'
-      AND action = 'mint'
-      AND to_token_account = '${VAULT_STAKE_WYLDS_ACCOUNT}'
-      AND to_owner = '${VAULT_STAKE_OWNER}'
-      AND TIME_RANGE
+    const query = `
+        SELECT
+            COALESCE(SUM(amount_display), 0) AS total_minted
+        FROM tokens_solana.transfers
+        WHERE
+            token_mint_address = '${WYLDS_MINT}'
+            AND action = 'mint'
+            AND to_token_account = '${VAULT_STAKE_WYLDS_ACCOUNT}'
+            AND to_owner = '${VAULT_STAKE_OWNER}'
+            AND TIME_RANGE
   `;
 
-  const result = await queryDuneSql(options, query);
-  const totalMinted = Number(result?.[0]?.total_minted ?? 0);
+    const result = await queryDuneSql(options, query);
+    const dailyYields = result[0].total_minted;
 
-  if (totalMinted > 0) {
-    dailyFees.addUSDValue(totalMinted, "HELOC Lending Yield");
-    dailySupplySideRevenue.addUSDValue(totalMinted, "HELOC Lending Yield To Holders");
-  }
+    dailyFees.addUSDValue(dailyYields, METRIC.ASSETS_YIELDS);
 
-  return {
-    dailyFees,
-    dailySupplySideRevenue,
-    dailyRevenue: options.createBalances(),
-    dailyUserFees: options.createBalances(),
-  };
+    return {
+        dailyFees,
+        dailySupplySideRevenue: dailyFees
+    };
 };
 
 const methodology = {
-  Fees: "wYLDS tokens minted into the vault-stake account via publish_rewards, representing real-world yield from Figure's HELOC lending pools distributed to PRIME stakers.",
-  SupplySideRevenue: "All minted wYLDS accrues to PRIME stakers by increasing the wYLDS-per-PRIME exchange rate.",
-  Revenue: "Hastra takes no on-chain protocol fee cut. Figure monetises via off-chain lending spreads on HELOCs.",
-  UserFees: "Users pay no on-chain fees. Yield originates from off-chain HELOC borrowers paying interest to Figure.",
+    Fees: "wYLDS tokens minted into the vault-stake account via publish_rewards",
+    SupplySideRevenue: "Yields accumulated based on wYLDS holdings",
+    Revenue: "Hastra takes no on-chain protocol fee cut. Figure monetises via off-chain lending spreads on HELOCs.",
 };
 
 const breakdownMethodology = {
-  Fees: {
-    "HELOC Lending Yield": "wYLDS minted hourly into the vault-stake account via publish_rewards CPI from vault-mint, funded by Figure's Demo Prime HELOC lending operations.",
-  },
-  SupplySideRevenue: {
-    "HELOC Lending Yield To Holders": "All minted wYLDS increase the wYLDS-per-PRIME ratio, fully accruing to PRIME stakers.",
-  },
-  Revenue: {
-    "Protocol Revenue": "Hastra takes no on-chain protocol fee cut.",
-  },
-  UserFees: {
-    "User Fees": "Users pay no on-chain fees. Yield originates from off-chain HELOC borrowers.",
-  },
+    Fees: {
+        [METRIC.ASSETS_YIELDS]: "wYLDS minted hourly into the vault-stake account via publish_rewards CPI from vault-mint, funded by Figure's Demo Prime HELOC lending operations.",
+    },
+    SupplySideRevenue: {
+        [METRIC.ASSETS_YIELDS]: "Yields accumulated based on wYLDS holdings",
+    },
 };
 
 const adapter: SimpleAdapter = {
-  version: 2,
-  fetch,
-  chains: [CHAIN.SOLANA],
-  start: "2025-11-21",
-  isExpensiveAdapter: true,
-  dependencies: [Dependencies.DUNE],
-  methodology,
-  breakdownMethodology,
+    version: 1,
+    fetch,
+    chains: [CHAIN.SOLANA],
+    start: "2025-11-21",
+    isExpensiveAdapter: true,
+    dependencies: [Dependencies.DUNE],
+    methodology,
+    breakdownMethodology,
 };
 
 export default adapter;


### PR DESCRIPTION
Closes #6690 

## Description
Adds a new fees adapter for Hastra — a Solana-based RWA yield protocol backed by Figure's HELOC lending pools.

The adapter tracks:
- Daily fees from all wYLDS token mint events on Solana
- Daily supply side revenue (100% of yield passed to wYLDS holders and PRIME stakers)
- Daily user fees (yield originated from HELOC borrowers)
- Daily revenue = 0 (Hastra takes no on-chain protocol cut)

## Methodology
Hastra's yield is tracked by querying all `mint` action transfers of the wYLDS token (`8fr7WGTVFszfyNWRMXj6fRjZZAnDwmXwEpCrtzmUkdih`) on Solana via Dune's `tokens_solana.transfers` table.

Every wYLDS mint event represents real-world yield from Figure's Demo Prime HELOC lending operations being distributed on-chain to token holders. wYLDS is pegged 1:1 to USDC so `amount_display` maps directly to USD value.

**Fee model:** Pure pass-through — 100% of minted yield goes to supply side (wYLDS holders earn base yield, PRIME stakers earn enhanced yield via the increasing wYLDS-per-PRIME exchange rate). Protocol takes no on-chain fee cut.

## Verification:
```
npm test fees hastra
npm test fees hastra 2026-04-01
npm test fees hastra 2026-01-15
```

## Output Screenshot :

<img width="1840" height="1412" alt="image" src="https://github.com/user-attachments/assets/8c906a2f-9c95-4e76-bd97-30733f997ed3" />
