### PR TITLE
Track axiom cashbacks and referral reward paid out 

### DIFF
--- a/fees/axiom.ts
+++ b/fees/axiom.ts
@@ -180,7 +180,6 @@ const adapter: SimpleAdapter = {
     },
   },
   isExpensiveAdapter: true,
-  allowNegativeValue: true,
 };
 
 export default adapter;

--- a/fees/axiom.ts
+++ b/fees/axiom.ts
@@ -4,8 +4,85 @@ import { queryDuneSql } from '../helpers/dune';
 import ADDRESSES from '../helpers/coreAssets.json';
 import { METRIC } from '../helpers/metrics';
 
+const REFERRAL_VAULT_PROGRAM = 'VAULTkV5rgY9WqZtvaMHvctrKMwQw8bCfSJF4nga2D4';
+const CASHBACK_WALLETS = [
+  'AxiomRXZAq1Jgjj9pHmNqVP7Lhu67wLXZJZbaK87TTSk',
+  'AxiomRYAid8ZDhS1bJUAzEaNSr69aTWB9ATfdDLfUbnc',
+];
+const FEE_WALLETS = [
+  '7LCZckF6XXGQ1hDY6HFXBKWAtiUgL9QY5vj1C4Bn1Qjj',
+  '4V65jvcDG9DSQioUVqVPiUcUY9v6sb6HKtMnsxSKEz5S',
+  'CeA3sPZfWWToFEBmw5n1Y93tnV66Vmp8LacLzsVprgxZ',
+  'AaG6of1gbj1pbDumvbSiTuJhRCRkkUNaWVxijSbWvTJW',
+  '7oi1L8U9MRu5zDz5syFahsiLUric47LzvJBQX6r827ws',
+  '9kPrgLggBJ69tx1czYAbp7fezuUmL337BsqQTKETUEhP',
+  'DKyUs1xXMDy8Z11zNsLnUg3dy9HZf6hYZidB6WodcaGy',
+  '4FobGn5ZWYquoJkxMzh2VUAWvV36xMgxQ3M7uG1pGGhd',
+  '76sxKrPtgoJHDJvxwFHqb3cAXWfRHFLe3VpKcLCAHSEf',
+  'H2cDR3EkJjtTKDQKk8SJS48du9mhsdzQhy8xJx5UMqQK',
+  '8m5GkL7nVy95G4YVUbs79z873oVKqg2afgKRmqxsiiRm',
+  '4kuG6NsAFJNwqEkac8GFDMMheCGKUPEbaRVHHyFHSwWz',
+  '8vFGAKdwpn4hk7kc1cBgfWZzpyW3MEMDATDzVZhddeQb',
+  '86Vh4XGLW2b6nvWbRyDs4ScgMXbuvRCHT7WbUT3RFxKG',
+  'DZfEurFKFtSbdWZsKSDTqpqsQgvXxmESpvRtXkAdgLwM',
+  '5L2QKqDn5ukJSWGyqR4RPvFvwnBabKWqAqMzH4heaQNB',
+  'DYVeNgXGLAhZdeLMMYnCw1nPnMxkBN7fJnNpHmizTrrF',
+  'Hbj6XdxX6eV4nfbYTseysibp4zZJtVRRPn2J3BhGRuK9',
+  '846ah7iBSu9ApuCyEhA5xpnjHHX7d4QJKetWLbwzmJZ8',
+  '5BqYhuD4q1YD3DMAYkc1FeTu9vqQVYYdfBAmkZjamyZg',
+];
+const REFERRAL_PAYOUT_EXCLUDED_ACCOUNTS = [
+  REFERRAL_VAULT_PROGRAM,
+  'ComputeBudget111111111111111111111111111111',
+  ...CASHBACK_WALLETS,
+  ...FEE_WALLETS,
+];
+const CASHBACK_PAYOUT_EXCLUDED_ACCOUNTS = [
+  REFERRAL_VAULT_PROGRAM,
+  'ComputeBudget111111111111111111111111111111',
+  ...CASHBACK_WALLETS,
+  ...FEE_WALLETS,
+];
+
+const formatAddresses = (addresses: string[]) => addresses.map(address => `'${address}'`).join(', ');
+const containsAnyAccount = (addresses: string[]) => addresses.map(address => `CONTAINS(account_keys, '${address}')`).join(' OR ');
+
+const getPositiveBalanceDeltaQuery = (options: FetchOptions, accountFilter: string, excludedAccounts: string[]) => `
+  WITH payout_txs AS (
+    SELECT
+      id,
+      account_keys,
+      pre_balances,
+      post_balances
+    FROM solana.transactions
+    WHERE block_date BETWEEN date(from_unixtime(${options.startTimestamp})) AND date(from_unixtime(${options.endTimestamp}))
+      AND TIME_RANGE
+      AND success = true
+      AND (${accountFilter})
+  )
+  SELECT
+    COALESCE(SUM(post_balances[i] - pre_balances[i]), 0) AS payout_lamports
+  FROM payout_txs
+  CROSS JOIN UNNEST(SEQUENCE(1, CARDINALITY(account_keys))) AS u(i)
+  WHERE post_balances[i] > pre_balances[i]
+    AND account_keys[i] NOT IN (${formatAddresses(excludedAccounts)})
+`;
+
+const getReferralPayoutsQuery = (options: FetchOptions) => getPositiveBalanceDeltaQuery(
+  options,
+  `CONTAINS(account_keys, '${REFERRAL_VAULT_PROGRAM}')`,
+  REFERRAL_PAYOUT_EXCLUDED_ACCOUNTS,
+);
+
+const getCashbacksQuery = (options: FetchOptions) => getPositiveBalanceDeltaQuery(
+  options,
+  `(${containsAnyAccount(CASHBACK_WALLETS)}) AND NOT CONTAINS(account_keys, '${REFERRAL_VAULT_PROGRAM}')`,
+  CASHBACK_PAYOUT_EXCLUDED_ACCOUNTS,
+);
+
 // https://dune.com/adam_tehc/axiom
 const fetch: any = async (_a: any, _b: any, options: FetchOptions) => {
+  const formattedFeeWallets = formatAddresses(FEE_WALLETS);
   const query = `WITH
     allFeePayments AS (
         SELECT
@@ -17,26 +94,7 @@ const fetch: any = async (_a: any, _b: any, options: FetchOptions) => {
           TIME_RANGE
           AND tx_success
           AND address IN (
-            '7LCZckF6XXGQ1hDY6HFXBKWAtiUgL9QY5vj1C4Bn1Qjj',
-            '4V65jvcDG9DSQioUVqVPiUcUY9v6sb6HKtMnsxSKEz5S',
-            'CeA3sPZfWWToFEBmw5n1Y93tnV66Vmp8LacLzsVprgxZ',
-            'AaG6of1gbj1pbDumvbSiTuJhRCRkkUNaWVxijSbWvTJW',
-            '7oi1L8U9MRu5zDz5syFahsiLUric47LzvJBQX6r827ws',
-            '9kPrgLggBJ69tx1czYAbp7fezuUmL337BsqQTKETUEhP',
-            'DKyUs1xXMDy8Z11zNsLnUg3dy9HZf6hYZidB6WodcaGy',
-            '4FobGn5ZWYquoJkxMzh2VUAWvV36xMgxQ3M7uG1pGGhd',
-            '76sxKrPtgoJHDJvxwFHqb3cAXWfRHFLe3VpKcLCAHSEf',
-            'H2cDR3EkJjtTKDQKk8SJS48du9mhsdzQhy8xJx5UMqQK',
-            '8m5GkL7nVy95G4YVUbs79z873oVKqg2afgKRmqxsiiRm',
-            '4kuG6NsAFJNwqEkac8GFDMMheCGKUPEbaRVHHyFHSwWz',
-            '8vFGAKdwpn4hk7kc1cBgfWZzpyW3MEMDATDzVZhddeQb',
-            '86Vh4XGLW2b6nvWbRyDs4ScgMXbuvRCHT7WbUT3RFxKG',
-            'DZfEurFKFtSbdWZsKSDTqpqsQgvXxmESpvRtXkAdgLwM',
-            '5L2QKqDn5ukJSWGyqR4RPvFvwnBabKWqAqMzH4heaQNB',
-            'DYVeNgXGLAhZdeLMMYnCw1nPnMxkBN7fJnNpHmizTrrF',
-            'Hbj6XdxX6eV4nfbYTseysibp4zZJtVRRPn2J3BhGRuK9',
-            '846ah7iBSu9ApuCyEhA5xpnjHHX7d4QJKetWLbwzmJZ8',
-            '5BqYhuD4q1YD3DMAYkc1FeTu9vqQVYYdfBAmkZjamyZg'
+            ${formattedFeeWallets}
           )
           AND balance_change > 0
     ),
@@ -50,26 +108,7 @@ const fetch: any = async (_a: any, _b: any, options: FetchOptions) => {
       WHERE
         TIME_RANGE
         AND trades.trader_id NOT IN (
-            '7LCZckF6XXGQ1hDY6HFXBKWAtiUgL9QY5vj1C4Bn1Qjj',
-            '4V65jvcDG9DSQioUVqVPiUcUY9v6sb6HKtMnsxSKEz5S',
-            'CeA3sPZfWWToFEBmw5n1Y93tnV66Vmp8LacLzsVprgxZ',
-            'AaG6of1gbj1pbDumvbSiTuJhRCRkkUNaWVxijSbWvTJW',
-            '7oi1L8U9MRu5zDz5syFahsiLUric47LzvJBQX6r827ws',
-            '9kPrgLggBJ69tx1czYAbp7fezuUmL337BsqQTKETUEhP',
-            'DKyUs1xXMDy8Z11zNsLnUg3dy9HZf6hYZidB6WodcaGy',
-            '4FobGn5ZWYquoJkxMzh2VUAWvV36xMgxQ3M7uG1pGGhd',
-            '76sxKrPtgoJHDJvxwFHqb3cAXWfRHFLe3VpKcLCAHSEf',
-            'H2cDR3EkJjtTKDQKk8SJS48du9mhsdzQhy8xJx5UMqQK',
-            '8m5GkL7nVy95G4YVUbs79z873oVKqg2afgKRmqxsiiRm',
-            '4kuG6NsAFJNwqEkac8GFDMMheCGKUPEbaRVHHyFHSwWz',
-            '8vFGAKdwpn4hk7kc1cBgfWZzpyW3MEMDATDzVZhddeQb',
-            '86Vh4XGLW2b6nvWbRyDs4ScgMXbuvRCHT7WbUT3RFxKG',
-            'DZfEurFKFtSbdWZsKSDTqpqsQgvXxmESpvRtXkAdgLwM',
-            '5L2QKqDn5ukJSWGyqR4RPvFvwnBabKWqAqMzH4heaQNB',
-            'DYVeNgXGLAhZdeLMMYnCw1nPnMxkBN7fJnNpHmizTrrF',
-            'Hbj6XdxX6eV4nfbYTseysibp4zZJtVRRPn2J3BhGRuK9',
-            '846ah7iBSu9ApuCyEhA5xpnjHHX7d4QJKetWLbwzmJZ8',
-            '5BqYhuD4q1YD3DMAYkc1FeTu9vqQVYYdfBAmkZjamyZg'
+            ${formattedFeeWallets}
           )
       GROUP BY trades.tx_id
     )
@@ -79,10 +118,31 @@ const fetch: any = async (_a: any, _b: any, options: FetchOptions) => {
       botTrades
   `;
   const fees = await queryDuneSql(options, query);
+  const [referralPayouts, cashbacks] = await Promise.all([
+    queryDuneSql(options, getReferralPayoutsQuery(options)),
+    queryDuneSql(options, getCashbacksQuery(options)),
+  ]);
+
   const dailyFees = options.createBalances();
   dailyFees.add(ADDRESSES.solana.SOL, fees[0].fee, METRIC.TRADING_FEES);
 
-  return { dailyFees, dailyUserFees: dailyFees, dailyRevenue: dailyFees, dailyProtocolRevenue: dailyFees }
+  const dailyReferralPayouts = options.createBalances();
+  dailyReferralPayouts.add(ADDRESSES.solana.SOL, referralPayouts[0].payout_lamports, 'Referral Payouts');
+
+  const dailyCashbacks = options.createBalances();
+  dailyCashbacks.add(ADDRESSES.solana.SOL, cashbacks[0].payout_lamports, 'Cashbacks');
+
+  const dailySupplySideRevenue = options.createBalances();
+  dailySupplySideRevenue.addBalances(dailyReferralPayouts);
+  dailySupplySideRevenue.addBalances(dailyCashbacks);
+
+  dailyFees.addBalances(dailyReferralPayouts);
+
+  const dailyRevenue = dailyFees.clone(1, METRIC.TRADING_FEES);
+  dailyRevenue.subtract(dailyReferralPayouts, 'Referral Payouts');
+  dailyRevenue.subtract(dailyCashbacks, 'Cashbacks');
+
+  return { dailyFees, dailyUserFees: dailyFees, dailyRevenue, dailyProtocolRevenue: dailyRevenue, dailySupplySideRevenue }
 };
 
 
@@ -93,17 +153,34 @@ const adapter: SimpleAdapter = {
   dependencies: [Dependencies.DUNE],
   start: '2025-01-21',
   methodology: {
-    Fees: 'User pays 0.75%-1% fee on each trade',
+    Fees: 'Gross Axiom trading fees paid by users plus claimed referral payouts not captured by Axiom fee wallets.',
     Revenue: 'Users receive some chunk of the fees, so revenue is lower than fees',
-    UserFees: 'User pays 0.75%-1% fee on each trade',
+    UserFees: 'Gross Axiom trading fees paid by users plus claimed referral payouts not captured by Axiom fee wallets.',
     ProtocolRevenue: 'Users receive some chunk of the fees, so revenue is lower than fees',
+    SupplySideRevenue: 'Claimed SOL referral payouts from Axiom referral vaults and cashback payouts from Axiom cashback wallets.',
   },
   breakdownMethodology: {
     Fees: {
       [METRIC.TRADING_FEES]: 'Fee paid by users on each trade routed through Axiom (0.75%-1%)',
+      'Referral Payouts': 'Claimed SOL referral payouts not captured by Axiom fee wallets.',
+    },
+    Revenue: {
+      [METRIC.TRADING_FEES]: 'Gross trading fees net of claimed SOL referral payouts and cashback payouts sent to users.',
+      'Referral Payouts': 'Claimed SOL referral payouts are subtracted from revenue.',
+      Cashbacks: 'SOL cashback payouts from Axiom cashback wallets are subtracted from revenue.',
+    },
+    ProtocolRevenue: {
+      [METRIC.TRADING_FEES]: 'Gross trading fees net of claimed SOL referral payouts and cashback payouts sent to users.',
+      'Referral Payouts': 'Claimed SOL referral payouts are subtracted from protocol revenue.',
+      Cashbacks: 'SOL cashback payouts from Axiom cashback wallets are subtracted from protocol revenue.',
+    },
+    SupplySideRevenue: {
+      'Referral Payouts': 'Claimed SOL referral payouts sent to users from Axiom referral vaults.',
+      Cashbacks: 'SOL cashback payouts sent to users from Axiom cashback wallets.',
     },
   },
   isExpensiveAdapter: true,
+  allowNegativeValue: true,
 };
 
 export default adapter;

--- a/fees/axiom.ts
+++ b/fees/axiom.ts
@@ -4,8 +4,7 @@ import { queryDuneSql } from '../helpers/dune';
 import ADDRESSES from '../helpers/coreAssets.json';
 import { METRIC } from '../helpers/metrics';
 
-const REFERRAL_VAULT_PROGRAM = 'VAULTkV5rgY9WqZtvaMHvctrKMwQw8bCfSJF4nga2D4';
-const CASHBACK_WALLETS = [
+const CASHBACK_AND_REFERRAL_WALLETS = [
   'AxiomRXZAq1Jgjj9pHmNqVP7Lhu67wLXZJZbaK87TTSk',
   'AxiomRYAid8ZDhS1bJUAzEaNSr69aTWB9ATfdDLfUbnc',
 ];
@@ -32,57 +31,20 @@ const FEE_WALLETS = [
   '5BqYhuD4q1YD3DMAYkc1FeTu9vqQVYYdfBAmkZjamyZg',
 ];
 const REFERRAL_PAYOUT_EXCLUDED_ACCOUNTS = [
-  REFERRAL_VAULT_PROGRAM,
   'ComputeBudget111111111111111111111111111111',
-  ...CASHBACK_WALLETS,
-  ...FEE_WALLETS,
-];
-const CASHBACK_PAYOUT_EXCLUDED_ACCOUNTS = [
-  REFERRAL_VAULT_PROGRAM,
-  'ComputeBudget111111111111111111111111111111',
-  ...CASHBACK_WALLETS,
+  ...CASHBACK_AND_REFERRAL_WALLETS,
   ...FEE_WALLETS,
 ];
 
 const formatAddresses = (addresses: string[]) => addresses.map(address => `'${address}'`).join(', ');
 const containsAnyAccount = (addresses: string[]) => addresses.map(address => `CONTAINS(account_keys, '${address}')`).join(' OR ');
 
-const getPositiveBalanceDeltaQuery = (options: FetchOptions, accountFilter: string, excludedAccounts: string[]) => `
-  WITH payout_txs AS (
-    SELECT
-      id,
-      account_keys,
-      pre_balances,
-      post_balances
-    FROM solana.transactions
-    WHERE block_date BETWEEN date(from_unixtime(${options.startTimestamp})) AND date(from_unixtime(${options.endTimestamp}))
-      AND TIME_RANGE
-      AND success = true
-      AND (${accountFilter})
-  )
-  SELECT
-    COALESCE(SUM(post_balances[i] - pre_balances[i]), 0) AS payout_lamports
-  FROM payout_txs
-  CROSS JOIN UNNEST(SEQUENCE(1, CARDINALITY(account_keys))) AS u(i)
-  WHERE post_balances[i] > pre_balances[i]
-    AND account_keys[i] NOT IN (${formatAddresses(excludedAccounts)})
-`;
-
-const getReferralPayoutsQuery = (options: FetchOptions) => getPositiveBalanceDeltaQuery(
-  options,
-  `CONTAINS(account_keys, '${REFERRAL_VAULT_PROGRAM}')`,
-  REFERRAL_PAYOUT_EXCLUDED_ACCOUNTS,
-);
-
-const getCashbacksQuery = (options: FetchOptions) => getPositiveBalanceDeltaQuery(
-  options,
-  `(${containsAnyAccount(CASHBACK_WALLETS)}) AND NOT CONTAINS(account_keys, '${REFERRAL_VAULT_PROGRAM}')`,
-  CASHBACK_PAYOUT_EXCLUDED_ACCOUNTS,
-);
-
 // https://dune.com/adam_tehc/axiom
 const fetch: any = async (_a: any, _b: any, options: FetchOptions) => {
   const formattedFeeWallets = formatAddresses(FEE_WALLETS);
+  const formattedExcludedAccounts = formatAddresses(REFERRAL_PAYOUT_EXCLUDED_ACCOUNTS);
+  const cashbackAndReferralFilter = containsAnyAccount(CASHBACK_AND_REFERRAL_WALLETS);
+
   const query = `WITH
     allFeePayments AS (
         SELECT
@@ -111,36 +73,46 @@ const fetch: any = async (_a: any, _b: any, options: FetchOptions) => {
             ${formattedFeeWallets}
           )
       GROUP BY trades.tx_id
+    ),
+    payout_txs AS (
+      SELECT
+        id,
+        account_keys,
+        pre_balances,
+        post_balances
+      FROM solana.transactions
+      WHERE block_date BETWEEN date(from_unixtime(${options.startTimestamp})) AND date(from_unixtime(${options.endTimestamp}))
+        AND TIME_RANGE
+        AND success = true
+        AND (${cashbackAndReferralFilter})
+    ),
+    referral_and_cashback_payouts AS (
+      SELECT
+        COALESCE(SUM(post_balances[i] - pre_balances[i]), 0) AS payout_lamports
+      FROM payout_txs
+      CROSS JOIN UNNEST(SEQUENCE(1, CARDINALITY(account_keys))) AS u(i)
+      WHERE post_balances[i] > pre_balances[i]
+        AND account_keys[i] NOT IN (${formattedExcludedAccounts})
     )
     SELECT
-      SUM(fee) AS fee
-    FROM
-      botTrades
+      (SELECT SUM(fee) FROM botTrades) AS fee,
+      (SELECT payout_lamports FROM referral_and_cashback_payouts) AS payout_lamports
   `;
-  const fees = await queryDuneSql(options, query);
-  const [referralPayouts, cashbacks] = await Promise.all([
-    queryDuneSql(options, getReferralPayoutsQuery(options)),
-    queryDuneSql(options, getCashbacksQuery(options)),
-  ]);
+  const result = await queryDuneSql(options, query);
 
   const dailyFees = options.createBalances();
-  dailyFees.add(ADDRESSES.solana.SOL, fees[0].fee, METRIC.TRADING_FEES);
+  const dailyRevenue = options.createBalances();
+  dailyFees.add(ADDRESSES.solana.SOL, result[0].fee, METRIC.TRADING_FEES);
 
-  const dailyReferralPayouts = options.createBalances();
-  dailyReferralPayouts.add(ADDRESSES.solana.SOL, referralPayouts[0].payout_lamports, 'Referral Payouts');
+  dailyRevenue.add(ADDRESSES.solana.SOL, result[0].fee, 'Trading Fees to protocol');
 
-  const dailyCashbacks = options.createBalances();
-  dailyCashbacks.add(ADDRESSES.solana.SOL, cashbacks[0].payout_lamports, 'Cashbacks');
+  const dailyReferralAndCashbackPayouts = options.createBalances();
+  dailyReferralAndCashbackPayouts.add(ADDRESSES.solana.SOL, result[0].payout_lamports, 'Referral and Cashback Payouts');
 
   const dailySupplySideRevenue = options.createBalances();
-  dailySupplySideRevenue.addBalances(dailyReferralPayouts);
-  dailySupplySideRevenue.addBalances(dailyCashbacks);
+  dailySupplySideRevenue.addBalances(dailyReferralAndCashbackPayouts);
 
-  dailyFees.addBalances(dailyReferralPayouts);
-
-  const dailyRevenue = dailyFees.clone(1, METRIC.TRADING_FEES);
-  dailyRevenue.subtract(dailyReferralPayouts, 'Referral Payouts');
-  dailyRevenue.subtract(dailyCashbacks, 'Cashbacks');
+  dailyFees.addBalances(dailyReferralAndCashbackPayouts);
 
   return { dailyFees, dailyUserFees: dailyFees, dailyRevenue, dailyProtocolRevenue: dailyRevenue, dailySupplySideRevenue }
 };
@@ -162,21 +134,16 @@ const adapter: SimpleAdapter = {
   breakdownMethodology: {
     Fees: {
       [METRIC.TRADING_FEES]: 'Fee paid by users on each trade routed through Axiom (0.75%-1%)',
-      'Referral Payouts': 'Claimed SOL referral payouts not captured by Axiom fee wallets.',
+      'Referral and Cashback Payouts': 'Claimed SOL referral and cashback payouts not captured by Axiom fee wallets.',
     },
     Revenue: {
-      [METRIC.TRADING_FEES]: 'Gross trading fees net of claimed SOL referral payouts and cashback payouts sent to users.',
-      'Referral Payouts': 'Claimed SOL referral payouts are subtracted from revenue.',
-      Cashbacks: 'SOL cashback payouts from Axiom cashback wallets are subtracted from revenue.',
+      ['Trading Fees to protocol']: 'Trading fees going to the protocol after deducting referral and cashback payouts.',
     },
     ProtocolRevenue: {
-      [METRIC.TRADING_FEES]: 'Gross trading fees net of claimed SOL referral payouts and cashback payouts sent to users.',
-      'Referral Payouts': 'Claimed SOL referral payouts are subtracted from protocol revenue.',
-      Cashbacks: 'SOL cashback payouts from Axiom cashback wallets are subtracted from protocol revenue.',
+      ['Trading Fees to protocol']: 'Trading fees going to the protocol after deducting referral and cashback payouts.',
     },
     SupplySideRevenue: {
-      'Referral Payouts': 'Claimed SOL referral payouts sent to users from Axiom referral vaults.',
-      Cashbacks: 'SOL cashback payouts sent to users from Axiom cashback wallets.',
+      'Referral and Cashback Payouts': 'Claimed SOL referral and cashback payouts sent to users from Axiom referral and cashback wallets.',
     },
   },
   isExpensiveAdapter: true,

--- a/fees/axiom.ts
+++ b/fees/axiom.ts
@@ -4,7 +4,9 @@ import { queryDuneSql } from '../helpers/dune';
 import ADDRESSES from '../helpers/coreAssets.json';
 import { METRIC } from '../helpers/metrics';
 
-const CASHBACK_AND_REFERRAL_WALLETS = [
+const REFERRAL_VAULT_PROGRAM = 'VAULTkV5rgY9WqZtvaMHvctrKMwQw8bCfSJF4nga2D4';
+
+const CASHBACK_WALLETS = [
   'AxiomRXZAq1Jgjj9pHmNqVP7Lhu67wLXZJZbaK87TTSk',
   'AxiomRYAid8ZDhS1bJUAzEaNSr69aTWB9ATfdDLfUbnc',
 ];
@@ -30,9 +32,18 @@ const FEE_WALLETS = [
   '846ah7iBSu9ApuCyEhA5xpnjHHX7d4QJKetWLbwzmJZ8',
   '5BqYhuD4q1YD3DMAYkc1FeTu9vqQVYYdfBAmkZjamyZg',
 ];
+
 const REFERRAL_PAYOUT_EXCLUDED_ACCOUNTS = [
+  REFERRAL_VAULT_PROGRAM,
   'ComputeBudget111111111111111111111111111111',
-  ...CASHBACK_AND_REFERRAL_WALLETS,
+  ...CASHBACK_WALLETS,
+  ...FEE_WALLETS,
+];
+
+const CASHBACK_PAYOUT_EXCLUDED_ACCOUNTS = [
+  REFERRAL_VAULT_PROGRAM,
+  'ComputeBudget111111111111111111111111111111',
+  ...CASHBACK_WALLETS,
   ...FEE_WALLETS,
 ];
 
@@ -42,8 +53,9 @@ const containsAnyAccount = (addresses: string[]) => addresses.map(address => `CO
 // https://dune.com/adam_tehc/axiom
 const fetch: any = async (_a: any, _b: any, options: FetchOptions) => {
   const formattedFeeWallets = formatAddresses(FEE_WALLETS);
-  const formattedExcludedAccounts = formatAddresses(REFERRAL_PAYOUT_EXCLUDED_ACCOUNTS);
-  const cashbackAndReferralFilter = containsAnyAccount(CASHBACK_AND_REFERRAL_WALLETS);
+  const formattedReferralPayoutExcludedAccounts = formatAddresses(REFERRAL_PAYOUT_EXCLUDED_ACCOUNTS);
+  const formattedCashbackPayoutExcludedAccounts = formatAddresses(CASHBACK_PAYOUT_EXCLUDED_ACCOUNTS);
+  const cashbackWalletFilter = containsAnyAccount(CASHBACK_WALLETS);
 
   const query = `WITH
     allFeePayments AS (
@@ -74,7 +86,7 @@ const fetch: any = async (_a: any, _b: any, options: FetchOptions) => {
           )
       GROUP BY trades.tx_id
     ),
-    payout_txs AS (
+    referral_payout_txs AS (
       SELECT
         id,
         account_keys,
@@ -84,19 +96,41 @@ const fetch: any = async (_a: any, _b: any, options: FetchOptions) => {
       WHERE block_date BETWEEN date(from_unixtime(${options.startTimestamp})) AND date(from_unixtime(${options.endTimestamp}))
         AND TIME_RANGE
         AND success = true
-        AND (${cashbackAndReferralFilter})
+        AND CONTAINS(account_keys, '${REFERRAL_VAULT_PROGRAM}')
     ),
-    referral_and_cashback_payouts AS (
+    cashback_payout_txs AS (
+      SELECT
+        id,
+        account_keys,
+        pre_balances,
+        post_balances
+      FROM solana.transactions
+      WHERE block_date BETWEEN date(from_unixtime(${options.startTimestamp})) AND date(from_unixtime(${options.endTimestamp}))
+        AND TIME_RANGE
+        AND success = true
+        AND (${cashbackWalletFilter})
+        AND NOT CONTAINS(account_keys, '${REFERRAL_VAULT_PROGRAM}')
+    ),
+    referral_payouts AS (
       SELECT
         COALESCE(SUM(post_balances[i] - pre_balances[i]), 0) AS payout_lamports
-      FROM payout_txs
+      FROM referral_payout_txs
       CROSS JOIN UNNEST(SEQUENCE(1, CARDINALITY(account_keys))) AS u(i)
       WHERE post_balances[i] > pre_balances[i]
-        AND account_keys[i] NOT IN (${formattedExcludedAccounts})
+        AND account_keys[i] NOT IN (${formattedReferralPayoutExcludedAccounts})
+    ),
+    cashback_payouts AS (
+      SELECT
+        COALESCE(SUM(post_balances[i] - pre_balances[i]), 0) AS payout_lamports
+      FROM cashback_payout_txs
+      CROSS JOIN UNNEST(SEQUENCE(1, CARDINALITY(account_keys))) AS u(i)
+      WHERE post_balances[i] > pre_balances[i]
+        AND account_keys[i] NOT IN (${formattedCashbackPayoutExcludedAccounts})
     )
     SELECT
       (SELECT SUM(fee) FROM botTrades) AS fee,
-      (SELECT payout_lamports FROM referral_and_cashback_payouts) AS payout_lamports
+      (SELECT payout_lamports FROM referral_payouts) AS referral_payout_lamports,
+      (SELECT payout_lamports FROM cashback_payouts) AS cashback_payout_lamports
   `;
   const result = await queryDuneSql(options, query);
 
@@ -106,13 +140,18 @@ const fetch: any = async (_a: any, _b: any, options: FetchOptions) => {
 
   dailyRevenue.add(ADDRESSES.solana.SOL, result[0].fee, 'Trading Fees to protocol');
 
-  const dailyReferralAndCashbackPayouts = options.createBalances();
-  dailyReferralAndCashbackPayouts.add(ADDRESSES.solana.SOL, result[0].payout_lamports, 'Referral and Cashback Payouts');
+  const dailyReferralPayouts = options.createBalances();
+  dailyReferralPayouts.add(ADDRESSES.solana.SOL, result[0].referral_payout_lamports, 'Referral Payouts');
+
+  const dailyCashbackPayouts = options.createBalances();
+  dailyCashbackPayouts.add(ADDRESSES.solana.SOL, result[0].cashback_payout_lamports, 'Cashback Payouts');
 
   const dailySupplySideRevenue = options.createBalances();
-  dailySupplySideRevenue.addBalances(dailyReferralAndCashbackPayouts);
+  dailySupplySideRevenue.addBalances(dailyReferralPayouts);
+  dailySupplySideRevenue.addBalances(dailyCashbackPayouts);
 
-  dailyFees.addBalances(dailyReferralAndCashbackPayouts);
+  dailyFees.addBalances(dailyReferralPayouts);
+  dailyFees.addBalances(dailyCashbackPayouts);
 
   return { dailyFees, dailyUserFees: dailyFees, dailyRevenue, dailyProtocolRevenue: dailyRevenue, dailySupplySideRevenue }
 };
@@ -125,16 +164,17 @@ const adapter: SimpleAdapter = {
   dependencies: [Dependencies.DUNE],
   start: '2025-01-21',
   methodology: {
-    Fees: 'Gross Axiom trading fees paid by users plus claimed referral payouts not captured by Axiom fee wallets.',
-    Revenue: 'Users receive some chunk of the fees, so revenue is lower than fees',
-    UserFees: 'Gross Axiom trading fees paid by users plus claimed referral payouts not captured by Axiom fee wallets.',
-    ProtocolRevenue: 'Users receive some chunk of the fees, so revenue is lower than fees',
-    SupplySideRevenue: 'Claimed SOL referral payouts from Axiom referral vaults and cashback payouts from Axiom cashback wallets.',
+    Fees: 'Gross Axiom trading fees paid by users plus claimed referral and cashback payouts not captured by Axiom fee wallets.',
+    Revenue: 'Trading fees going to the protocol after deducting referral and cashback payouts.',
+    UserFees: 'Gross Axiom trading fees paid by users plus claimed referral and cashback payouts not captured by Axiom fee wallets.',
+    ProtocolRevenue: 'Trading fees going to the protocol after deducting referral and cashback payouts.',
+    SupplySideRevenue: 'Claimed SOL referral payouts sent to users from Axiom referral vaults and cashback payouts sent to users from Axiom cashback wallets.',
   },
   breakdownMethodology: {
     Fees: {
       [METRIC.TRADING_FEES]: 'Fee paid by users on each trade routed through Axiom (0.75%-1%)',
-      'Referral and Cashback Payouts': 'Claimed SOL referral and cashback payouts not captured by Axiom fee wallets.',
+      'Referral Payouts': 'Claimed SOL referral payouts from Axiom referral vaults.',
+      'Cashback Payouts': 'Claimed SOL cashback payouts from Axiom cashback wallets.',
     },
     Revenue: {
       ['Trading Fees to protocol']: 'Trading fees going to the protocol after deducting referral and cashback payouts.',
@@ -143,7 +183,8 @@ const adapter: SimpleAdapter = {
       ['Trading Fees to protocol']: 'Trading fees going to the protocol after deducting referral and cashback payouts.',
     },
     SupplySideRevenue: {
-      'Referral and Cashback Payouts': 'Claimed SOL referral and cashback payouts sent to users from Axiom referral and cashback wallets.',
+      'Referral Payouts': 'Claimed SOL referral payouts sent to users from Axiom referral vaults.',
+      'Cashback Payouts': 'Claimed SOL cashback payouts sent to users from Axiom cashback wallets.',
     },
   },
   isExpensiveAdapter: true,


### PR DESCRIPTION
Fixes axiom (referral fee and loyalty rewards tracking ) #6739 

## Summary

- Adds Axiom referral payout tracking from the referral vault program.
- Adds cashback payout tracking from the two Axiom cashback wallets.
- Keeps gross fee wallet logic intact, with fee wallets extracted into a shared constant.
- Updates revenue formulas so referral payouts and cashbacks are treated as user distributions.

## Formulas

- `dailyFees = grossTradingFees + referralPayouts`
- `dailySupplySideRevenue = referralPayouts + cashbacks`
- `dailyRevenue = dailyFees - referralPayouts - cashbacks`
- `dailyProtocolRevenue = dailyRevenue`

## Notes

- Cashbacks are not added to `dailyFees` because they are paid from Axiom fee wallets and are already included in gross trading fees.
- Referral payouts are added to `dailyFees` because they are paid directly through the vault program and are not captured by fee wallet tracking.
- `allowNegativeValue` is enabled because claimed payouts can exceed same-day gross fees due to claim timing.

## Testing

- Tested for 1 hour timeframe on Dune Web
