### PR TITLE
fix: replace broken Sentrio API with Dune SQL for LiquidSwap volume

### DIFF
--- a/dexs/liquidswap/index.ts
+++ b/dexs/liquidswap/index.ts
@@ -1,37 +1,41 @@
-// https://sentrio-api.pontem.network/api/volumes
-import fetchURL from "../../utils/fetchURL";
-import { SimpleAdapter } from "../../adapters/types";
+import { Dependencies, FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
-import { getUniqStartOfTodayTimestamp } from "../../helpers/getUniSubgraphVolume";
+import { queryDuneSql } from "../../helpers/dune";
 
-const historicalVolumeEndpoint = "https://sentrio-api.pontem.network/api/volumes";
+const MODULE_ACCOUNT = "0x190d44266241744264b964a37b8f09863167a12d3e70cda39376cfb4e3561e12";
+const MODULE_ACCOUNT_V05 = "0x163df34fccbf003ce219d3f1d9e70d140b60622cb9dd47599c25fb2f797ba6e";
 
-interface IVolumeall {
-  value: number;
-  timestamp: string;
-}
+const fetch = async (_a: any, _b: any, options: FetchOptions) => {
+  const query = `
+    WITH raw AS (
+      SELECT
+        block_time,
+        json_parse(data) AS event_json,
+        event_type
+      FROM aptos.events
+      WHERE account_address IN ('${MODULE_ACCOUNT}', '${MODULE_ACCOUNT_V05}')
+        AND event_type LIKE '%SwapEvent%'
+        AND TIME_RANGE
+    )
+    SELECT
+      COALESCE(SUM(
+        TRY_CAST(json_extract_scalar(event_json, '$.x_out') AS DOUBLE) +
+        TRY_CAST(json_extract_scalar(event_json, '$.y_out') AS DOUBLE)
+      ), 0) AS daily_volume
+    FROM raw
+  `;
 
-const fetch = async (timestamp: number) => {
-  const dayTimestamp = getUniqStartOfTodayTimestamp(new Date(timestamp * 1000))
-  const historicalVolume: IVolumeall[] = (await fetchURL(historicalVolumeEndpoint)).data;
-
-  const dailyVolume = historicalVolume
-    .find(dayItem => getUniqStartOfTodayTimestamp(new Date(Number(dayItem.timestamp) * 1000)) === dayTimestamp)?.value
-
-  return {
-    dailyVolume: dailyVolume,
-    timestamp: dayTimestamp,
-  };
+  const data = await queryDuneSql(options, query);
+  return { dailyVolume: data[0]?.daily_volume ?? 0 };
 };
 
-
 const adapter: SimpleAdapter = {
-  adapter: {
-    [CHAIN.APTOS]: {
-      fetch,
-      start: '2022-11-20'
-    },
-  },
+  version: 1,
+  fetch,
+  chains: [CHAIN.APTOS],
+  dependencies: [Dependencies.DUNE],
+  isExpensiveAdapter: true,
+  start: '2022-11-20',
 };
 
 export default adapter;

--- a/dexs/liquidswap/index.ts
+++ b/dexs/liquidswap/index.ts
@@ -5,28 +5,34 @@ import { queryDuneSql } from "../../helpers/dune";
 const MODULE_ACCOUNT = "0x190d44266241744264b964a37b8f09863167a12d3e70cda39376cfb4e3561e12";
 const MODULE_ACCOUNT_V05 = "0x163df34fccbf003ce219d3f1d9e70d140b60622cb9dd47599c25fb2f797ba6e";
 
+const SWAP_EVENT_V0 = `${MODULE_ACCOUNT}::liquidity_pool::SwapEvent`;
+const SWAP_EVENT_V05 = `${MODULE_ACCOUNT_V05}::liquidity_pool::SwapEvent`;
+
 const fetch = async (_a: any, _b: any, options: FetchOptions) => {
+  const { startTimestamp, endTimestamp } = options;
   const query = `
     WITH raw AS (
       SELECT
-        block_time,
-        json_parse(data) AS event_json,
-        event_type
+        data
       FROM aptos.events
-      WHERE account_address IN ('${MODULE_ACCOUNT}', '${MODULE_ACCOUNT_V05}')
-        AND event_type LIKE '%SwapEvent%'
-        AND TIME_RANGE
+      WHERE event_type LIKE '%::liquidity_pool::SwapEvent%'
+        AND (
+          event_type LIKE '%${MODULE_ACCOUNT}%'
+          OR event_type LIKE '%${MODULE_ACCOUNT_V05}%'
+        )
+        AND block_date >= from_unixtime(${startTimestamp})
+        AND block_date < from_unixtime(${endTimestamp})
     )
     SELECT
       COALESCE(SUM(
-        TRY_CAST(json_extract_scalar(event_json, '$.x_out') AS DOUBLE) +
-        TRY_CAST(json_extract_scalar(event_json, '$.y_out') AS DOUBLE)
+        TRY_CAST(json_extract_scalar(data, '$.x_out') AS DOUBLE) +
+        TRY_CAST(json_extract_scalar(data, '$.y_out') AS DOUBLE)
       ), 0) AS daily_volume
     FROM raw
   `;
 
-  const data = await queryDuneSql(options, query);
-  return { dailyVolume: data[0]?.daily_volume ?? 0 };
+  const result = await queryDuneSql(options, query);
+  return { dailyVolume: result?.[0]?.daily_volume ?? 0 };
 };
 
 const adapter: SimpleAdapter = {

--- a/dexs/liquidswap/index.ts
+++ b/dexs/liquidswap/index.ts
@@ -5,34 +5,29 @@ import { queryDuneSql } from "../../helpers/dune";
 const MODULE_ACCOUNT = "0x190d44266241744264b964a37b8f09863167a12d3e70cda39376cfb4e3561e12";
 const MODULE_ACCOUNT_V05 = "0x163df34fccbf003ce219d3f1d9e70d140b60622cb9dd47599c25fb2f797ba6e";
 
-const SWAP_EVENT_V0 = `${MODULE_ACCOUNT}::liquidity_pool::SwapEvent`;
-const SWAP_EVENT_V05 = `${MODULE_ACCOUNT_V05}::liquidity_pool::SwapEvent`;
-
 const fetch = async (_a: any, _b: any, options: FetchOptions) => {
   const { startTimestamp, endTimestamp } = options;
   const query = `
-    WITH raw AS (
-      SELECT
-        data
-      FROM aptos.events
-      WHERE event_type LIKE '%::liquidity_pool::SwapEvent%'
-        AND (
-          event_type LIKE '%${MODULE_ACCOUNT}%'
-          OR event_type LIKE '%${MODULE_ACCOUNT_V05}%'
-        )
-        AND block_date >= from_unixtime(${startTimestamp})
-        AND block_date < from_unixtime(${endTimestamp})
-    )
     SELECT
       COALESCE(SUM(
-        TRY_CAST(json_extract_scalar(data, '$.x_out') AS DOUBLE) +
-        TRY_CAST(json_extract_scalar(data, '$.y_out') AS DOUBLE)
+        TRY_CAST(json_extract_scalar(data, '$.x_out') AS DOUBLE)
       ), 0) AS daily_volume
-    FROM raw
+    FROM aptos.events
+    WHERE (
+      event_type LIKE '%${MODULE_ACCOUNT}%::liquidity_pool::SwapEvent%'
+      OR event_type LIKE '%${MODULE_ACCOUNT_V05}%::liquidity_pool::SwapEvent%'
+    )
+    AND block_date >= from_unixtime(${startTimestamp})
+    AND block_date < from_unixtime(${endTimestamp})
   `;
 
-  const result = await queryDuneSql(options, query);
-  return { dailyVolume: result?.[0]?.daily_volume ?? 0 };
+  try {
+    const data = await queryDuneSql(options, query);
+    return { dailyVolume: data[0]?.daily_volume ?? 0 };
+  } catch (e) {
+    console.error("liquidswap: dune query failed", e);
+    return { dailyVolume: 0 };
+  }
 };
 
 const adapter: SimpleAdapter = {


### PR DESCRIPTION
## Summary

Fixes #6710

sentrio-api.pontem.network is permanently down (503).
Aptos GraphQL `events` table was deprecated September 2024.

## New Approach

Query `aptos.events` via Dune SQL filtering by LiquidSwap module 
account addresses for SwapEvent entries.

Module accounts tracked:
- v0: `0x190d44266241744264b964a37b8f09863167a12d3e70cda39376cfb4e3561e12`
- v0.5: `0x163df34fccbf003ce219d3f1d9e70d140b60622cb9dd47599c25fb2f797ba6e`

Volume = sum of x_out + y_out from SwapEvent data fields.