### PR TITLE
Track world mobile chain fee

### DIFF
--- a/factory/blockscout.ts
+++ b/factory/blockscout.ts
@@ -118,6 +118,7 @@ const protocolChainMap: Record<string, string> = {
   "megaeth": CHAIN.MEGAETH,
   "katana-chain": CHAIN.KATANA,
   "coti": CHAIN.COTI,
+  "world-mobile": CHAIN.WORLD_MOBILE,
 }
 
 const deadFromMap: Record<string, string> = {

--- a/helpers/blockscoutFees.ts
+++ b/helpers/blockscoutFees.ts
@@ -137,6 +137,7 @@ export const chainConfigMap: any = {
   [CHAIN.MEGAETH]: { CGToken: 'ethereum', explorer: 'https://megaeth.blockscout.com/' },
   [CHAIN.KATANA]: { CGToken: 'ethereum', explorer: 'https://explorer.katanarpc.com/' },
   [CHAIN.COTI]: { CGToken: 'coti', explorer: 'https://mainnet.cotiscan.io/' },
+  [CHAIN.WORLD_MOBILE]: { CGToken: 'world-mobile-token', explorer: 'https://explorer.worldmobile.io', start: '2025-06-01' },
 }
 
 function getTimeString(timestamp: number) {

--- a/helpers/chains.ts
+++ b/helpers/chains.ts
@@ -368,4 +368,5 @@ export enum CHAIN {
   DARWINIA = "darwinia",
   DANGO = "dango",
   CSC = "csc",
+  WORLD_MOBILE = "world_mobile",
 }


### PR DESCRIPTION
fixes #6668

### Summary
                                                                                
  - Add World Mobile Chain fees tracking using Blockscout API                   
  - Explorer: https://explorer.worldmobile.io                                   
  - CoinGecko token: world-mobile-token (WMTX)                                  
  https://explorer.worldmobile.io/api?module=stats&action=totalfees&date=2026-05-01