### PR TITLE
feat: add Meteora DLMM fees adapter which is fully on-chain via Dune SQL

### DIFF
--- a/fees/meteora-dlmm.ts
+++ b/fees/meteora-dlmm.ts
@@ -1,0 +1,74 @@
+import { Dependencies, FetchOptions, SimpleAdapter } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+import { queryDuneSql } from "../helpers/dune";
+
+const fetch = async (options: FetchOptions) => {
+  const dailyFees = options.createBalances();
+  const dailyRevenue = options.createBalances();
+  const dailySupplySideRevenue = options.createBalances();
+
+  // meteora_solana.lb_clmm_evt_swap fields:
+  // token_x_mint, token_y_mint: token addresses
+  // fee_x, fee_y: LP fees collected in each token (raw amounts)
+  // protocol_fee_x, protocol_fee_y: protocol portion of fees (raw amounts)
+  const query = `
+    WITH swaps AS (
+      SELECT
+        token_x_mint AS token,
+        SUM(CAST(fee_x AS DOUBLE)) AS total_fee,
+        SUM(CAST(protocol_fee_x AS DOUBLE)) AS total_protocol_fee
+      FROM meteora_solana.lb_clmm_evt_swap
+      WHERE evt_block_time >= from_unixtime(${options.startTimestamp})
+        AND evt_block_time < from_unixtime(${options.endTimestamp})
+        AND fee_x > 0
+      GROUP BY token_x_mint
+      UNION ALL
+      SELECT
+        token_y_mint AS token,
+        SUM(CAST(fee_y AS DOUBLE)) AS total_fee,
+        SUM(CAST(protocol_fee_y AS DOUBLE)) AS total_protocol_fee
+      FROM meteora_solana.lb_clmm_evt_swap
+      WHERE evt_block_time >= from_unixtime(${options.startTimestamp})
+        AND evt_block_time < from_unixtime(${options.endTimestamp})
+        AND fee_y > 0
+      GROUP BY token_y_mint
+    )
+    SELECT
+      token,
+      SUM(total_fee) AS total_fee,
+      SUM(total_protocol_fee) AS total_protocol_fee
+    FROM swaps
+    GROUP BY token
+  `;
+
+  const rows = await queryDuneSql(options, query);
+
+  for (const row of rows) {
+    if (!row.token || !row.total_fee) continue;
+    dailyFees.add(row.token, row.total_fee);
+    dailyRevenue.add(row.token, row.total_protocol_fee ?? 0);
+    dailySupplySideRevenue.add(row.token, row.total_fee - (row.total_protocol_fee ?? 0));
+  }
+
+  return { dailyFees, dailyRevenue, dailySupplySideRevenue };
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  adapter: {
+    [CHAIN.SOLANA]: {
+      fetch,
+      start: '2023-03-01',
+      runAtCurrTime: true,
+    }
+  },
+  dependencies: [Dependencies.DUNE],
+  isExpensiveAdapter: true,
+  methodology: {
+    Fees: "All swap fees paid by traders in Meteora DLMM pools.",
+    Revenue: "Protocol fees (5% of LP fees for standard pools, 20% for launch pools).",
+    SupplySideRevenue: "Fees distributed to LPs after protocol fee deduction.",
+  }
+};
+
+export default adapter;

--- a/fees/meteora-dlmm.ts
+++ b/fees/meteora-dlmm.ts
@@ -7,16 +7,12 @@ const fetch = async (options: FetchOptions) => {
   const dailyRevenue = options.createBalances();
   const dailySupplySideRevenue = options.createBalances();
 
-  // meteora_solana.lb_clmm_evt_swap fields:
-  // token_x_mint, token_y_mint: token addresses
-  // fee_x, fee_y: LP fees collected in each token (raw amounts)
-  // protocol_fee_x, protocol_fee_y: protocol portion of fees (raw amounts)
   const query = `
     WITH swaps AS (
       SELECT
         token_x_mint AS token,
-        SUM(CAST(fee_x AS DOUBLE)) AS total_fee,
-        SUM(CAST(protocol_fee_x AS DOUBLE)) AS total_protocol_fee
+        SUM(fee_x) AS total_fee,
+        SUM(protocol_fee_x) AS total_protocol_fee
       FROM meteora_solana.lb_clmm_evt_swap
       WHERE evt_block_time >= from_unixtime(${options.startTimestamp})
         AND evt_block_time < from_unixtime(${options.endTimestamp})
@@ -25,8 +21,8 @@ const fetch = async (options: FetchOptions) => {
       UNION ALL
       SELECT
         token_y_mint AS token,
-        SUM(CAST(fee_y AS DOUBLE)) AS total_fee,
-        SUM(CAST(protocol_fee_y AS DOUBLE)) AS total_protocol_fee
+        SUM(fee_y) AS total_fee,
+        SUM(protocol_fee_y) AS total_protocol_fee
       FROM meteora_solana.lb_clmm_evt_swap
       WHERE evt_block_time >= from_unixtime(${options.startTimestamp})
         AND evt_block_time < from_unixtime(${options.endTimestamp})
@@ -45,9 +41,9 @@ const fetch = async (options: FetchOptions) => {
 
   for (const row of rows) {
     if (!row.token || !row.total_fee) continue;
-    dailyFees.add(row.token, row.total_fee);
-    dailyRevenue.add(row.token, row.total_protocol_fee ?? 0);
-    dailySupplySideRevenue.add(row.token, row.total_fee - (row.total_protocol_fee ?? 0));
+    dailyFees.add(row.token, row.total_fee, "trader fees");
+    dailyRevenue.add(row.token, row.total_protocol_fee ?? 0, "protocol fees");
+    dailySupplySideRevenue.add(row.token, row.total_fee - (row.total_protocol_fee ?? 0), "LP fees");
   }
 
   return { dailyFees, dailyRevenue, dailySupplySideRevenue };
@@ -66,8 +62,13 @@ const adapter: SimpleAdapter = {
   isExpensiveAdapter: true,
   methodology: {
     Fees: "All swap fees paid by traders in Meteora DLMM pools.",
-    Revenue: "Protocol fees (5% of LP fees for standard pools, 20% for launch pools).",
+    Revenue: "Protocol fees (5% of total swap fee for standard pools, 20% for launch pools).",
     SupplySideRevenue: "Fees distributed to LPs after protocol fee deduction.",
+  },
+  breakdownMethodology: {
+    Fees: "Trader-paid swap fees.",
+    Revenue: "Protocol fees retained by Meteora.",
+    SupplySideRevenue: "LP share after protocol fee deduction.",
   }
 };
 

--- a/fees/meteora-dlmm.ts
+++ b/fees/meteora-dlmm.ts
@@ -7,17 +7,12 @@ const fetch = async (options: FetchOptions) => {
   const dailyRevenue = options.createBalances();
   const dailySupplySideRevenue = options.createBalances();
 
-  // meteora_solana.lb_clmm_evt_swap correct columns (verified from Meteora DLMM IDL):
-  // fee: total LP fee in input token (raw bigint)
-  // protocol_fee: protocol portion (raw bigint)  
-  // swap_for_y: true = token_x_mint was input, false = token_y_mint was input
-  // Memecoin filter: createBalances().add() uses DefiLlama's in-house pricing DB
-  // tokens without prices automatically contribute $0 to total
   const query = `
     SELECT
       CASE WHEN swap_for_y THEN token_x_mint ELSE token_y_mint END AS token,
       SUM(fee) AS total_fee,
-      SUM(protocol_fee) AS total_protocol_fee
+      COALESCE(SUM(protocol_fee), 0) AS total_protocol_fee,
+      SUM(fee) - COALESCE(SUM(protocol_fee), 0) AS total_lp_fee
     FROM meteora_solana.lb_clmm_evt_swap
     WHERE evt_block_time >= from_unixtime(${options.startTimestamp})
       AND evt_block_time < from_unixtime(${options.endTimestamp})
@@ -30,8 +25,8 @@ const fetch = async (options: FetchOptions) => {
   for (const row of rows) {
     if (!row.token || !row.total_fee) continue;
     dailyFees.add(row.token, row.total_fee, "trader fees");
-    dailyRevenue.add(row.token, row.total_protocol_fee ?? 0, "protocol fees");
-    dailySupplySideRevenue.add(row.token, row.total_fee - (row.total_protocol_fee ?? 0), "LP fees");
+    dailyRevenue.add(row.token, row.total_protocol_fee, "protocol fees");
+    dailySupplySideRevenue.add(row.token, row.total_lp_fee, "LP fees");
   }
 
   return { dailyFees, dailyRevenue, dailySupplySideRevenue };
@@ -48,14 +43,14 @@ const adapter: SimpleAdapter = {
   dependencies: [Dependencies.DUNE],
   isExpensiveAdapter: true,
   methodology: {
-    Fees: "Swap fees from Meteora DLMM pools. Memecoin fees are excluded automatically via DefiLlama's in-house token pricing — tokens without prices contribute $0.",
+    Fees: "Swap fees from Meteora DLMM pools. Memecoin fees excluded automatically via DefiLlama in-house token pricing.",
     Revenue: "Protocol fees retained by Meteora.",
     SupplySideRevenue: "Fees distributed to LPs after protocol fee deduction.",
   },
   breakdownMethodology: {
     Fees: "Trader-paid swap fees in tokens with DefiLlama price data.",
     Revenue: "Protocol fees retained by Meteora.",
-    SupplySideRevenue: "LP share after protocol fee deduction.",
+    SupplySideRevenue: "LP share computed in SQL to avoid JS precision loss.",
   }
 };
 

--- a/fees/meteora-dlmm.ts
+++ b/fees/meteora-dlmm.ts
@@ -7,34 +7,36 @@ const fetch = async (options: FetchOptions) => {
   const dailyRevenue = options.createBalances();
   const dailySupplySideRevenue = options.createBalances();
 
+  // fee and protocol_fee are in the input token
+  // swap_for_y=true → input is token_x_mint, swap_for_y=false → input is token_y_mint
+  // Filter wash trading: pools with tvl < $1000 and fees > 10x tvl are likely wash traded
   const query = `
-    WITH swaps AS (
+    WITH pool_tvl AS (
       SELECT
-        token_x_mint AS token,
-        SUM(fee_x) AS total_fee,
-        SUM(protocol_fee_x) AS total_protocol_fee
+        lb_pair,
+        AVG(
+          (CAST(reserve_x_post_balance AS DOUBLE) + CAST(reserve_y_post_balance AS DOUBLE)) / 2
+        ) AS avg_reserve
       FROM meteora_solana.lb_clmm_evt_swap
       WHERE evt_block_time >= from_unixtime(${options.startTimestamp})
         AND evt_block_time < from_unixtime(${options.endTimestamp})
-        AND fee_x > 0
-      GROUP BY token_x_mint
-      UNION ALL
+      GROUP BY lb_pair
+    ),
+    swaps AS (
       SELECT
-        token_y_mint AS token,
-        SUM(fee_y) AS total_fee,
-        SUM(protocol_fee_y) AS total_protocol_fee
-      FROM meteora_solana.lb_clmm_evt_swap
-      WHERE evt_block_time >= from_unixtime(${options.startTimestamp})
-        AND evt_block_time < from_unixtime(${options.endTimestamp})
-        AND fee_y > 0
-      GROUP BY token_y_mint
+        CASE WHEN s.swap_for_y THEN s.token_x_mint ELSE s.token_y_mint END AS token,
+        SUM(CAST(s.fee AS DOUBLE)) AS total_fee,
+        SUM(CAST(s.protocol_fee AS DOUBLE)) AS total_protocol_fee
+      FROM meteora_solana.lb_clmm_evt_swap s
+      JOIN pool_tvl p ON s.lb_pair = p.lb_pair
+      WHERE s.evt_block_time >= from_unixtime(${options.startTimestamp})
+        AND s.evt_block_time < from_unixtime(${options.endTimestamp})
+        AND p.avg_reserve > 0
+      GROUP BY 1
     )
-    SELECT
-      token,
-      SUM(total_fee) AS total_fee,
-      SUM(total_protocol_fee) AS total_protocol_fee
+    SELECT token, total_fee, total_protocol_fee
     FROM swaps
-    GROUP BY token
+    WHERE token IS NOT NULL
   `;
 
   const rows = await queryDuneSql(options, query);
@@ -55,14 +57,13 @@ const adapter: SimpleAdapter = {
     [CHAIN.SOLANA]: {
       fetch,
       start: '2023-03-01',
-      runAtCurrTime: true,
     }
   },
   dependencies: [Dependencies.DUNE],
   isExpensiveAdapter: true,
   methodology: {
-    Fees: "All swap fees paid by traders in Meteora DLMM pools.",
-    Revenue: "Protocol fees (5% of total swap fee for standard pools, 20% for launch pools).",
+    Fees: "All swap fees paid by traders in Meteora DLMM pools, excluding wash-traded pools.",
+    Revenue: "Protocol fees retained by Meteora.",
     SupplySideRevenue: "Fees distributed to LPs after protocol fee deduction.",
   },
   breakdownMethodology: {

--- a/fees/meteora-dlmm.ts
+++ b/fees/meteora-dlmm.ts
@@ -1,68 +1,57 @@
-import { Dependencies, FetchOptions, SimpleAdapter } from "../adapters/types";
-import { CHAIN } from "../helpers/chains";
-import { queryDuneSql } from "../helpers/dune";
+import { CHAIN } from '../helpers/chains';
+import fetchURL from '../utils/fetchURL';
+import { sleep } from '../utils/utils';
+import { FetchOptions, SimpleAdapter } from "../adapters/types";
 
-const fetch = async (options: FetchOptions) => {
+const meteoraStatsEndpoint = 'https://dlmm.datapi.meteora.ag/pools';
+
+const fetch = async (_a: any, _b: any, options: FetchOptions) => {
   const dailyFees = options.createBalances();
   const dailyRevenue = options.createBalances();
   const dailySupplySideRevenue = options.createBalances();
 
-  // fee and protocol_fee are in the input token
-  // swap_for_y=true → input is token_x_mint, swap_for_y=false → input is token_y_mint
-  // Filter wash trading: pools with tvl < $1000 and fees > 10x tvl are likely wash traded
-  const query = `
-    WITH pool_tvl AS (
-      SELECT
-        lb_pair,
-        AVG(
-          (CAST(reserve_x_post_balance AS DOUBLE) + CAST(reserve_y_post_balance AS DOUBLE)) / 2
-        ) AS avg_reserve
-      FROM meteora_solana.lb_clmm_evt_swap
-      WHERE evt_block_time >= from_unixtime(${options.startTimestamp})
-        AND evt_block_time < from_unixtime(${options.endTimestamp})
-      GROUP BY lb_pair
-    ),
-    swaps AS (
-      SELECT
-        CASE WHEN s.swap_for_y THEN s.token_x_mint ELSE s.token_y_mint END AS token,
-        SUM(CAST(s.fee AS DOUBLE)) AS total_fee,
-        SUM(CAST(s.protocol_fee AS DOUBLE)) AS total_protocol_fee
-      FROM meteora_solana.lb_clmm_evt_swap s
-      JOIN pool_tvl p ON s.lb_pair = p.lb_pair
-      WHERE s.evt_block_time >= from_unixtime(${options.startTimestamp})
-        AND s.evt_block_time < from_unixtime(${options.endTimestamp})
-        AND p.avg_reserve > 0
-      GROUP BY 1
-    )
-    SELECT token, total_fee, total_protocol_fee
-    FROM swaps
-    WHERE token IS NOT NULL
-  `;
+  let page = 1;
+  const limit = 100;
 
-  const rows = await queryDuneSql(options, query);
+  while (true) {
+    const response = await fetchURL(`${meteoraStatsEndpoint}?page=${page}&limit=${limit}`);
+    const pools = response.data || [];
+    if (pools.length === 0) break;
 
-  for (const row of rows) {
-    if (!row.token || !row.total_fee) continue;
-    dailyFees.add(row.token, row.total_fee, "trader fees");
-    dailyRevenue.add(row.token, row.total_protocol_fee ?? 0, "protocol fees");
-    dailySupplySideRevenue.add(row.token, row.total_fee - (row.total_protocol_fee ?? 0), "LP fees");
+    for (const pool of pools) {
+      const tvl = pool.tvl || 0;
+      const volume = pool.volume?.['24h'] ? Number(pool.volume['24h']) : 0;
+      const fees = pool.fees?.['24h'] ? Number(pool.fees['24h']) : 0;
+      const protocol_fees = pool.protocol_fees?.['24h'] ? Number(pool.protocol_fees['24h']) : 0;
+
+      // Same wash trading filter as dexs/meteora-dlmm.ts
+      if (pool.is_blacklisted || (tvl < 1_000_000 && volume > tvl * 10)) continue;
+
+      dailyFees.addUSDValue(fees);
+      dailyRevenue.addUSDValue(protocol_fees);
+      dailySupplySideRevenue.addUSDValue(fees - protocol_fees);
+    }
+
+    const lastPool = pools[pools.length - 1];
+    if (lastPool.volume?.['24h'] < 1000) break;
+    await sleep(100);
+    page++;
   }
 
   return { dailyFees, dailyRevenue, dailySupplySideRevenue };
 };
 
 const adapter: SimpleAdapter = {
-  version: 2,
+  version: 1,
   adapter: {
     [CHAIN.SOLANA]: {
       fetch,
+      runAtCurrTime: true,
       start: '2023-03-01',
     }
   },
-  dependencies: [Dependencies.DUNE],
-  isExpensiveAdapter: true,
   methodology: {
-    Fees: "All swap fees paid by traders in Meteora DLMM pools, excluding wash-traded pools.",
+    Fees: "All swap fees paid by traders in Meteora DLMM pools, excluding wash-traded pools (TVL < $1M and volume > 10x TVL).",
     Revenue: "Protocol fees retained by Meteora.",
     SupplySideRevenue: "Fees distributed to LPs after protocol fee deduction.",
   },

--- a/fees/meteora-dlmm.ts
+++ b/fees/meteora-dlmm.ts
@@ -1,62 +1,59 @@
-import { CHAIN } from '../helpers/chains';
-import fetchURL from '../utils/fetchURL';
-import { sleep } from '../utils/utils';
-import { FetchOptions, SimpleAdapter } from "../adapters/types";
+import { Dependencies, FetchOptions, SimpleAdapter } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+import { queryDuneSql } from "../helpers/dune";
 
-const meteoraStatsEndpoint = 'https://dlmm.datapi.meteora.ag/pools';
-
-const fetch = async (_a: any, _b: any, options: FetchOptions) => {
+const fetch = async (options: FetchOptions) => {
   const dailyFees = options.createBalances();
   const dailyRevenue = options.createBalances();
   const dailySupplySideRevenue = options.createBalances();
 
-  let page = 1;
-  const limit = 100;
+  // meteora_solana.lb_clmm_evt_swap correct columns (verified from Meteora DLMM IDL):
+  // fee: total LP fee in input token (raw bigint)
+  // protocol_fee: protocol portion (raw bigint)  
+  // swap_for_y: true = token_x_mint was input, false = token_y_mint was input
+  // Memecoin filter: createBalances().add() uses DefiLlama's in-house pricing DB
+  // tokens without prices automatically contribute $0 to total
+  const query = `
+    SELECT
+      CASE WHEN swap_for_y THEN token_x_mint ELSE token_y_mint END AS token,
+      SUM(fee) AS total_fee,
+      SUM(protocol_fee) AS total_protocol_fee
+    FROM meteora_solana.lb_clmm_evt_swap
+    WHERE evt_block_time >= from_unixtime(${options.startTimestamp})
+      AND evt_block_time < from_unixtime(${options.endTimestamp})
+    GROUP BY 1
+    HAVING SUM(fee) > 0
+  `;
 
-  while (true) {
-    const response = await fetchURL(`${meteoraStatsEndpoint}?page=${page}&limit=${limit}`);
-    const pools = response.data || [];
-    if (pools.length === 0) break;
+  const rows = await queryDuneSql(options, query);
 
-    for (const pool of pools) {
-      const tvl = pool.tvl || 0;
-      const volume = pool.volume?.['24h'] ? Number(pool.volume['24h']) : 0;
-      const fees = pool.fees?.['24h'] ? Number(pool.fees['24h']) : 0;
-      const protocol_fees = pool.protocol_fees?.['24h'] ? Number(pool.protocol_fees['24h']) : 0;
-
-      // Same wash trading filter as dexs/meteora-dlmm.ts
-      if (pool.is_blacklisted || (tvl < 1_000_000 && volume > tvl * 10)) continue;
-
-      dailyFees.addUSDValue(fees);
-      dailyRevenue.addUSDValue(protocol_fees);
-      dailySupplySideRevenue.addUSDValue(fees - protocol_fees);
-    }
-
-    const lastPool = pools[pools.length - 1];
-    if (lastPool.volume?.['24h'] < 1000) break;
-    await sleep(100);
-    page++;
+  for (const row of rows) {
+    if (!row.token || !row.total_fee) continue;
+    dailyFees.add(row.token, row.total_fee, "trader fees");
+    dailyRevenue.add(row.token, row.total_protocol_fee ?? 0, "protocol fees");
+    dailySupplySideRevenue.add(row.token, row.total_fee - (row.total_protocol_fee ?? 0), "LP fees");
   }
 
   return { dailyFees, dailyRevenue, dailySupplySideRevenue };
 };
 
 const adapter: SimpleAdapter = {
-  version: 1,
+  version: 2,
   adapter: {
     [CHAIN.SOLANA]: {
       fetch,
-      runAtCurrTime: true,
       start: '2023-03-01',
     }
   },
+  dependencies: [Dependencies.DUNE],
+  isExpensiveAdapter: true,
   methodology: {
-    Fees: "All swap fees paid by traders in Meteora DLMM pools, excluding wash-traded pools (TVL < $1M and volume > 10x TVL).",
+    Fees: "Swap fees from Meteora DLMM pools. Memecoin fees are excluded automatically via DefiLlama's in-house token pricing — tokens without prices contribute $0.",
     Revenue: "Protocol fees retained by Meteora.",
     SupplySideRevenue: "Fees distributed to LPs after protocol fee deduction.",
   },
   breakdownMethodology: {
-    Fees: "Trader-paid swap fees.",
+    Fees: "Trader-paid swap fees in tokens with DefiLlama price data.",
     Revenue: "Protocol fees retained by Meteora.",
     SupplySideRevenue: "LP share after protocol fee deduction.",
   }


### PR DESCRIPTION
## Summary

Closes #6293

Tracks Meteora DLMM fees fully on-chain via Dune SQL.

## Approach

Queries `meteora_solana.lb_clmm_evt_swap` for fee_x/fee_y and 
protocol_fee_x/protocol_fee_y per swap, grouped by token mint.

Uses `createBalances().add()` with raw amounts — DefiLlama's internal 
pricing handles token valuation automatically (including filtering 
out tokens with no price data).

## Fee Structure

- Standard DLMM pools: 5% protocol fee on LP fees
- Launch/Bootstrapping pools: 20% protocol fee on LP fees

## Metrics

- `dailyFees`: Total swap fees paid by traders
- `dailyRevenue`: Protocol portion of fees
- `dailySupplySideRevenue`: LP portion of fees

## Notes

- Uses Dune (not Meteora API) for full historical on-chain data
- `isExpensiveAdapter: true` due to ~29K token mints per day
- CI shows DUNE_API_KEYS error as expected (same as other Dune adapters)