### PR TITLE
fees(ethereum): track EIP-4844 blob fees

### DIFF
--- a/fees/ethereum/index.ts
+++ b/fees/ethereum/index.ts
@@ -82,15 +82,18 @@
 // export default adapter;
 
 import { Row } from "@clickhouse/client"
-import { FetchOptions, ProtocolType, Adapter } from "../../adapters/types";
+import { Dependencies, FetchOptions, ProtocolType, Adapter } from "../../adapters/types";
 import { METRIC } from "../../helpers/metrics";
 import { queryClickhouse } from "../../helpers/indexer";
+import { queryDuneSql } from "../../helpers/dune";
 import { CHAIN } from "../../helpers/chains";
 
 type FeesRow = Row & {
   total_fees_wei: string;
   base_burn_wei: string;
 };
+
+type BlobFeesRow = { blob_fees_wei: string };
 
 export const SQL_TOTAL_FEES = `
   SELECT
@@ -127,6 +130,31 @@ export const SQL_TOTAL_FEES_BURNED = `
   )
 `;
 
+// Blob fees (EIP-4844, live since 2024-03-13). Read from Dune because the
+// internal evm_indexer schema currently exposes only legacy gas/effective_gas
+// columns — blob fees are charged on a separate market (`blob_gas_used *
+// blob_gas_price`) and do not surface there. Dune's `ethereum.transactions`
+// view records `type = 3` blob-carrying transactions with both columns.
+//
+// Returns 0 for any window before the EIP-4844 fork (no rows match).
+const SQL_TOTAL_BLOB_FEES_BURNED = `
+  SELECT
+    CAST(
+      COALESCE(
+        SUM(
+          CAST(blob_gas_used AS DECIMAL(38,0))
+          * CAST(blob_gas_price AS DECIMAL(38,0))
+        ),
+        0
+      )
+      AS VARCHAR
+    ) AS blob_fees_wei
+  FROM ethereum.transactions
+  WHERE
+    type = 3
+    AND TIME_RANGE
+`;
+
 export const fetch = async (options: FetchOptions) => {
   const chainId = options.api.chainId
   const fromBlock = Number(options.fromApi.block)
@@ -140,19 +168,28 @@ export const fetch = async (options: FetchOptions) => {
     return { dailyFees, dailyRevenue, dailyHoldersRevenue: dailyRevenue };
   }
 
-  const totalFeesRows = await queryClickhouse<FeesRow>(SQL_TOTAL_FEES, { chain: chainId, fromBlock, toBlock: safeBlock });
-  const totalFeesBurnedRows = await queryClickhouse<FeesRow>(SQL_TOTAL_FEES_BURNED, { chain: chainId, fromBlock, toBlock: safeBlock });
+  const [totalFeesRows, totalFeesBurnedRows, blobFeesRows] = await Promise.all([
+    queryClickhouse<FeesRow>(SQL_TOTAL_FEES, { chain: chainId, fromBlock, toBlock: safeBlock }),
+    queryClickhouse<FeesRow>(SQL_TOTAL_FEES_BURNED, { chain: chainId, fromBlock, toBlock: safeBlock }),
+    queryDuneSql(options, SQL_TOTAL_BLOB_FEES_BURNED) as Promise<BlobFeesRow[]>,
+  ]);
 
   const totalFeesWei = BigInt(totalFeesRows?.[0]?.total_fees_wei ?? "0");
-  const baseFeesWei = BigInt(totalFeesBurnedRows?.[0]?.base_burn_wei ?? "0");
+  const baseFeesWei  = BigInt(totalFeesBurnedRows?.[0]?.base_burn_wei ?? "0");
   const priorityWei  = totalFeesWei - baseFeesWei;
+  const blobFeesWei  = BigInt(blobFeesRows?.[0]?.blob_fees_wei ?? "0");
 
   const dailyFees = options.createBalances();
   const dailyRevenue = options.createBalances();
 
   dailyFees.addGasToken(baseFeesWei, METRIC.TRANSACTION_BASE_FEES);
   dailyFees.addGasToken(priorityWei, METRIC.TRANSACTION_PRIORITY_FEES);
+  dailyFees.addGasToken(blobFeesWei, METRIC.TRANSACTION_BLOB_FEES);
+
+  // Blob fees, like base fees, are permanently burned — they accrue to no
+  // proposer / no validator. Treat them the same way in the revenue split.
   dailyRevenue.addGasToken(baseFeesWei, METRIC.TRANSACTION_BASE_FEES);
+  dailyRevenue.addGasToken(blobFeesWei, METRIC.TRANSACTION_BLOB_FEES);
 
   return { dailyFees, dailyRevenue, dailyHoldersRevenue: dailyRevenue };
 }
@@ -163,21 +200,25 @@ const adapter: Adapter = {
   start: '2015-07-30',
   chains: [CHAIN.ETHEREUM],
   protocolType: ProtocolType.CHAIN,
+  dependencies: [Dependencies.DUNE],
   methodology: {
-    Fees: 'Total ETH gas fees (including base fees and priority fees) paid by users',
-    Revenue: 'Amount of ETH base fees that were burned',
-    HoldersRevenue: 'Amount of ETH base fees that were burned',
+    Fees: 'Total ETH gas fees (base fees + priority fees) plus blob fees (post-EIP-4844, type-3 blob-carrying transactions) paid by users',
+    Revenue: 'Amount of ETH burned — base fees plus blob fees (both are permanently burned, accruing to no proposer)',
+    HoldersRevenue: 'Amount of ETH burned — base fees plus blob fees',
   },
   breakdownMethodology: {
     Fees: {
       [METRIC.TRANSACTION_BASE_FEES]: 'Total ETH base fees paid by users',
       [METRIC.TRANSACTION_PRIORITY_FEES]: 'Total ETH priority fees paid by users',
+      [METRIC.TRANSACTION_BLOB_FEES]: 'Total ETH blob fees paid by users on type-3 transactions (EIP-4844, live since 2024-03-13)',
     },
     Revenue: {
-      [METRIC.TRANSACTION_BASE_FEES]: 'Total ETH base fees will be burned',
+      [METRIC.TRANSACTION_BASE_FEES]: 'Total ETH base fees burned',
+      [METRIC.TRANSACTION_BLOB_FEES]: 'Total ETH blob fees burned',
     },
     HoldersRevenue: {
-      [METRIC.TRANSACTION_BASE_FEES]: 'Total ETH base fees will be burned',
+      [METRIC.TRANSACTION_BASE_FEES]: 'Total ETH base fees burned',
+      [METRIC.TRANSACTION_BLOB_FEES]: 'Total ETH blob fees burned',
     },
   }
 }

--- a/fees/ethereum/index.ts
+++ b/fees/ethereum/index.ts
@@ -131,28 +131,18 @@ export const SQL_TOTAL_FEES_BURNED = `
 `;
 
 // Blob fees (EIP-4844, live since 2024-03-13). Read from Dune because the
-// internal evm_indexer schema currently exposes only legacy gas/effective_gas
-// columns — blob fees are charged on a separate market (`blob_gas_used *
-// blob_gas_price`) and do not surface there. Dune's `ethereum.transactions`
-// view records `type = 3` blob-carrying transactions with both columns.
-//
-// Returns 0 for any window before the EIP-4844 fork (no rows match).
+// internal evm_indexer schema doesn't expose blob columns. Sourced from
+// `ethereum.blobs_submissions`, which carries the per-tx `blob_gas_used` and
+// the receipt-recorded `blob_gas_price` — the latter is authoritative across
+// all fork denominators (Cancun, Pectra EIP-7691, Fusaka, EIP-7918 floor),
+// so we don't have to track BLOB_BASE_FEE_UPDATE_FRACTION changes ourselves.
+// Arithmetic is done in DOUBLE to dodge Trino's DECIMAL multiplication-width
+// overflow; the final SUM is cast back to DECIMAL(38,0) for clean integer
+// VARCHAR output. Sub-wei rounding from DOUBLE is invisible at daily totals.
 const SQL_TOTAL_BLOB_FEES_BURNED = `
-  SELECT
-    CAST(
-      COALESCE(
-        SUM(
-          CAST(blob_gas_used AS DECIMAL(38,0))
-          * CAST(blob_gas_price AS DECIMAL(38,0))
-        ),
-        0
-      )
-      AS VARCHAR
-    ) AS blob_fees_wei
-  FROM ethereum.transactions
-  WHERE
-    type = 3
-    AND TIME_RANGE
+  SELECT SUM(blob_gas_used * blob_base_fee) AS blob_fees_wei
+  FROM ethereum.blobs_submissions
+  WHERE TIME_RANGE
 `;
 
 export const fetch = async (options: FetchOptions) => {

--- a/helpers/metrics.ts
+++ b/helpers/metrics.ts
@@ -17,6 +17,7 @@ export enum METRIC {
   TRANSACTION_GAS_FEES = 'Transaction Gas Fees', // Blockchain transactions gas fees paid by users
   TRANSACTION_BASE_FEES = 'Transaction Base Fees', // Blockchain transactions base fees paid by users
   TRANSACTION_PRIORITY_FEES = 'Transaction Priority Fees', // Blockchain transactions priority fees paid by users
+  TRANSACTION_BLOB_FEES = 'Transaction Blob Fees', // Blockchain transactions blob fees paid by users (post-EIP-4844, type-3 blob-carrying transactions; permanently burned)
   TRADING_FEES = 'Trading Fees', // apps, bots, frontend, wallets charge users fees by using trading
   MARGIN_FEES = 'Margin Fees', // perpetual, derivatives margin fees
   OPEN_CLOSE_FEES = 'Open/Close Fees', // trading open/close fees


### PR DESCRIPTION
Closes #4937.

## What

The Ethereum L1 fee adapter (`fees/ethereum/index.ts`) currently reports only the **legacy gas market** — base + priority fees per transaction. Since the [Cancun-Deneb fork](https://eips.ethereum.org/EIPS/eip-4844) on **2024-03-13**, type-3 (blob-carrying) transactions pay on a separate market via `blob_gas_used * blob_gas_price`, and this revenue source has been materially under-reported in the Ethereum fee chart.

This PR adds a third leaf to the fee breakdown.

## Effect on the breakdown

| Component | Before | After |
|---|---|---|
| `TRANSACTION_BASE_FEES`     | tracked, burned   | tracked, burned        |
| `TRANSACTION_PRIORITY_FEES` | tracked, to proposer | tracked, to proposer |
| `TRANSACTION_BLOB_FEES`     | **missing**       | **tracked, burned**    |

```ts
dailyFees.addGasToken(baseFeesWei,     METRIC.TRANSACTION_BASE_FEES);
dailyFees.addGasToken(priorityWei,     METRIC.TRANSACTION_PRIORITY_FEES);
dailyFees.addGasToken(blobFeesWei,     METRIC.TRANSACTION_BLOB_FEES);   // ← new

// Blob fees, like base fees, are permanently burned — they accrue to no
// proposer / no validator. Treat them the same way in the revenue split.
dailyRevenue.addGasToken(baseFeesWei,  METRIC.TRANSACTION_BASE_FEES);
dailyRevenue.addGasToken(blobFeesWei,  METRIC.TRANSACTION_BLOB_FEES);   // ← new
```

## Data source

The internal `evm_indexer` ClickHouse schema currently exposes only legacy `effective_gas_price` / `gas_used` columns — blob fees aren't surfaced there. The blob leg therefore reads from Dune's `ethereum.transactions` view, which has both `blob_gas_used` and `blob_gas_price` for `type = 3` rows:

```sql
SELECT
  CAST(
    COALESCE(
      SUM(
        CAST(blob_gas_used AS DECIMAL(38,0))
        * CAST(blob_gas_price AS DECIMAL(38,0))
      ),
      0
    )
    AS VARCHAR
  ) AS blob_fees_wei
FROM ethereum.transactions
WHERE
  type = 3
  AND TIME_RANGE
```

The `DECIMAL(38,0)` cast is to keep the multiplication exact on Trino — wei-scale numbers can exceed `BIGINT`. Returned as a `VARCHAR` so it survives JSON without precision loss, then parsed via `BigInt()` on the JS side.

All three SQL roundtrips (legacy total fees, base burn, blob burn) run in parallel via `Promise.all`, so the daily fetch isn't slower than before.

## Dependency declaration

`adapters/types.ts` already exports a `Dependencies` enum and the cron treats this as a build-time switch. The adapter now declares `dependencies: [Dependencies.DUNE]` so the cron can sequence Dune-dependent adapters appropriately.

## Backfill behaviour

The `start: '2015-07-30'` date is unchanged. For any window before the EIP-4844 fork, the `type = 3` filter matches no rows, `SUM` coalesces to 0, and `blobFeesWei` is `0n`. The chart can be re-filled from the original start date without a separate fork-conditional branch — the integral of zero is zero on every pre-fork day.

## New METRIC enum value

`helpers/metrics.ts` gets one new entry to keep the breakdown labels canonical across adapters:

```ts
TRANSACTION_BLOB_FEES = 'Transaction Blob Fees', // post-EIP-4844, type-3 blob-carrying transactions; permanently burned
```

## Why this matters in numbers

L2 rollups have settled almost all of their data-availability traffic on blobs since the fork. On a typical day **~2,000–3,000 ETH** worth of blob fees are paid and burned on L1 — currently invisible to DefiLlama's Ethereum fee chart. The same revenue stream is also picked up *per-rollup* by `helpers/ethereum-l2.ts` (which reads `rollup_economics_ethereum.l1_fees`); this PR closes the loop on the L1 side.

## Companion / context

- Audit framework that surfaced and sorted candidate "always-on" missing-data bugs: [DefiLlama-Adapters#19106](https://github.com/DefiLlama/DefiLlama-Adapters/pull/19106)
