### PR TITLE
[fix] SuperSwap - add aggregator chain coverage

### DIFF
--- a/aggregators/superswap/index.ts
+++ b/aggregators/superswap/index.ts
@@ -1,66 +1,52 @@
-import ADDRESSES from '../../helpers/coreAssets.json'
 import { FetchOptions, SimpleAdapter } from "../../adapters/types"
 import { CHAIN } from "../../helpers/chains"
+import ADDRESSES from '../../helpers/coreAssets.json'
 
-const address = '0x5839389261D1F38aac7c8E91DcDa85646bEcB414'
 const event_route = 'event Route(address indexed from,address to,address indexed tokenIn,address indexed tokenOut,uint256 amountIn,uint256 amountOutMin,uint256 amountOut)'
 
-const tokenMapping = {
-  [ADDRESSES.flow.stgUSDC]: {
-    id:'usd-coin',
-    decimals: 6
-  },
-  [ADDRESSES.GAS_TOKEN_2]: {
-    id: 'ethereum',
-    decimals: 18
-  },
-  '0x0200C29006150606B650577BBE7B6248F58470c1': {
-    id: 'tether',
-    decimals: 6
-  },
-  [ADDRESSES.optimism.WETH_1]: {
-    id: 'ethereum',
-    decimals: 18
-  },
-  "0xD642B49d10cc6e1BC1c6945725667c35e0875f22": {
-    id: 'purple',
-    decimals: 18
-  },
-  "0xbf0cAfCbaaF0be8221Ae8d630500984eDC908861": {
-    id: 'squidswap',
-    decimals: 18
-  },
-  '0xCa5f2cCBD9C40b32657dF57c716De44237f80F05': {
-    id: 'kraken-ink',
-    decimals: 18
-  },
-  "0x0c5E2D1C98cd265C751e02F8F3293bC5764F9111": {
-    id: 'shroomy',
-    decimals: 18
-  },
-  '0xCb95A3840c8eA5F0D4E78B67eC897Df84d17c5e6': {
-    id: 'kraken-ink',
-    decimals: 18
+const contracts: Record<string, string[]> = {
+  [CHAIN.ETHEREUM]: ['0x50b1E6ab68E6BeD281C27810dEd0c293C3a20B4D'],
+  [CHAIN.OPTIMISM]: ['0x5ECcD3f2eB245d20Db0e26934961576C1D1B0438'],
+  [CHAIN.BSC]: ['0x51abC29C7b7611333Ba56cfe6B10dC1ff089786E'],
+  [CHAIN.UNICHAIN]: ['0xB4f358117356E63761537316a4Fdbc0bFCFAA070'],
+  [CHAIN.POLYGON]: ['0xb511c2CF878e950e5598C1c3e47e546930A1AEa5'],
+  [CHAIN.ERA]: ['0xec598F086899eD1EE56F8666a31ed19e57453725'],
+  [CHAIN.WC]: ['0x2b7279D1227CC4838e15f473b8e1718ACBEc4292'],
+  [CHAIN.LISK]: ['0x756d003c2aacFBAB59C29aFC49933B952bd9E600'],
+  [CHAIN.SONEIUM]: ['0x756d003c2aacFBAB59C29aFC49933B952bd9E600'],
+  [CHAIN.BASE]: ['0x19FD96207f7B5c55403BE736897f7C1109C8314E'],
+  [CHAIN.MODE]: ['0x919150CC162573d9BdCa1887E557b3208b536C99'],
+  [CHAIN.ARBITRUM]: ['0x8b9Ffff3d567cc578752D455BCb7BE86fa60F5b8'],
+  [CHAIN.INK]: [
+    '0x5839389261D1F38aac7c8E91DcDa85646bEcB414',
+    '0x9f64D99eA5BA69d2E6a5f19a923A26fbdfB370B9',
+  ],
+  [CHAIN.LINEA]: ['0x20b46e8b753093cFf78276832b92DE1A952dcF74'],
+  [CHAIN.BLAST]: ['0x756d003c2aacFBAB59C29aFC49933B952bd9E600'],
+  [CHAIN.SCROLL]: ['0x9326cA5FdDc0B6F758BE54Cfe0Ea39eDa56B1459'],
+  [CHAIN.ZORA]: ['0x919150CC162573d9BdCa1887E557b3208b536C99'],
+  [CHAIN.MONAD]: ['0xDa69f96C1d2DF824a11354d423dc84106AAA411a'],
+  [CHAIN.MEGAETH]: ['0x3A735e9A60304A59EB4492A90D6d0C529631b50e'],
+  [CHAIN.PLASMA]: ['0x2b7279D1227CC4838e15f473b8e1718ACBEc4292'],
+  [CHAIN.HYPERLIQUID]: ['0x2b7279D1227CC4838e15f473b8e1718ACBEc4292'],
+}
+
+const addAmount = (dailyVolume: ReturnType<FetchOptions['createBalances']>, token: string, amount: string) => {
+  if (token.toLowerCase() === ADDRESSES.GAS_TOKEN_2.toLowerCase()) {
+    dailyVolume.addGasToken(amount)
+  } else {
+    dailyVolume.add(token, amount)
   }
 }
+
 const fetchVolume = async (options: FetchOptions) => {
   const logs = await options.getLogs({
-    target: address,
+    targets: contracts[options.chain],
     eventAbi: event_route,
   })
   const dailyVolume = options.createBalances()
   logs.forEach(log => {
-    if (tokenMapping[log.tokenOut]) {
-      dailyVolume.addCGToken(
-        tokenMapping[log.tokenOut].id,
-        Number(log.amountOut) / 10 ** tokenMapping[log.tokenOut].decimals,
-      )
-    } else if (tokenMapping[log.tokenIn]) {
-      dailyVolume.addCGToken(
-        tokenMapping[log.tokenIn].id,
-        Number(log.amountIn) / 10 ** tokenMapping[log.tokenIn].decimals,
-      )
-    }
+    addAmount(dailyVolume, log.tokenIn, log.amountIn)
   })
   return {
     dailyVolume: dailyVolume
@@ -70,11 +56,29 @@ const fetchVolume = async (options: FetchOptions) => {
 const adapter: SimpleAdapter = {
   version: 2,
   pullHourly: true,
+  fetch: fetchVolume,
   adapter: {
-    [CHAIN.INK]: {
-      fetch: fetchVolume,
-      start: '2025-01-07',
-    },
+    [CHAIN.ETHEREUM]: { start: '2026-02-10' },
+    [CHAIN.OPTIMISM]: { start: '2026-02-10' },
+    [CHAIN.BSC]: { start: '2026-02-10' },
+    [CHAIN.UNICHAIN]: { start: '2026-02-10' },
+    [CHAIN.POLYGON]: { start: '2026-02-10' },
+    [CHAIN.ERA]: { start: '2026-02-10' },
+    [CHAIN.WC]: { start: '2026-02-10' },
+    [CHAIN.LISK]: { start: '2026-02-10' },
+    [CHAIN.SONEIUM]: { start: '2026-02-10' },
+    [CHAIN.BASE]: { start: '2026-02-10' },
+    [CHAIN.MODE]: { start: '2026-02-10' },
+    [CHAIN.ARBITRUM]: { start: '2026-02-10' },
+    [CHAIN.INK]: { start: '2026-02-10' },
+    [CHAIN.LINEA]: { start: '2026-02-10' },
+    [CHAIN.BLAST]: { start: '2026-02-10' },
+    [CHAIN.SCROLL]: { start: '2026-02-10' },
+    [CHAIN.ZORA]: { start: '2026-02-10' },
+    [CHAIN.MONAD]: { start: '2026-02-10' },
+    [CHAIN.MEGAETH]: { start: '2026-02-10' },
+    [CHAIN.PLASMA]: { start: '2026-02-10' },
+    [CHAIN.HYPERLIQUID]: { start: '2026-02-10' },
   },
 }
 

--- a/aggregators/superswap/index.ts
+++ b/aggregators/superswap/index.ts
@@ -40,8 +40,12 @@ const addAmount = (dailyVolume: ReturnType<FetchOptions['createBalances']>, toke
 }
 
 const fetchVolume = async (options: FetchOptions) => {
+  const targets = contracts[options.chain]
+  if (!targets?.length) {
+    throw new Error(`No contracts configured for chain: ${options.chain}`)
+  }
   const logs = await options.getLogs({
-    targets: contracts[options.chain],
+    targets,
     eventAbi: event_route,
   })
   const dailyVolume = options.createBalances()
@@ -57,6 +61,9 @@ const adapter: SimpleAdapter = {
   version: 2,
   pullHourly: true,
   fetch: fetchVolume,
+  methodology: {
+    dailyVolume: "Volume is calculated by summing the amountIn values from Route events emitted by SuperSwap router contracts across all supported chains."
+  },
   adapter: {
     [CHAIN.ETHEREUM]: { start: '2026-02-10' },
     [CHAIN.OPTIMISM]: { start: '2026-02-10' },

--- a/aggregators/superswap/index.ts
+++ b/aggregators/superswap/index.ts
@@ -1,57 +1,49 @@
 import { FetchOptions, SimpleAdapter } from "../../adapters/types"
 import { CHAIN } from "../../helpers/chains"
-import ADDRESSES from '../../helpers/coreAssets.json'
 
 const event_route = 'event Route(address indexed from,address to,address indexed tokenIn,address indexed tokenOut,uint256 amountIn,uint256 amountOutMin,uint256 amountOut)'
 
-const contracts: Record<string, string[]> = {
-  [CHAIN.ETHEREUM]: ['0x50b1E6ab68E6BeD281C27810dEd0c293C3a20B4D'],
-  [CHAIN.OPTIMISM]: ['0x5ECcD3f2eB245d20Db0e26934961576C1D1B0438'],
-  [CHAIN.BSC]: ['0x51abC29C7b7611333Ba56cfe6B10dC1ff089786E'],
-  [CHAIN.UNICHAIN]: ['0xB4f358117356E63761537316a4Fdbc0bFCFAA070'],
-  [CHAIN.POLYGON]: ['0xb511c2CF878e950e5598C1c3e47e546930A1AEa5'],
-  [CHAIN.ERA]: ['0xec598F086899eD1EE56F8666a31ed19e57453725'],
-  [CHAIN.WC]: ['0x2b7279D1227CC4838e15f473b8e1718ACBEc4292'],
-  [CHAIN.LISK]: ['0x756d003c2aacFBAB59C29aFC49933B952bd9E600'],
-  [CHAIN.SONEIUM]: ['0x756d003c2aacFBAB59C29aFC49933B952bd9E600'],
-  [CHAIN.BASE]: ['0x19FD96207f7B5c55403BE736897f7C1109C8314E'],
-  [CHAIN.MODE]: ['0x919150CC162573d9BdCa1887E557b3208b536C99'],
-  [CHAIN.ARBITRUM]: ['0x8b9Ffff3d567cc578752D455BCb7BE86fa60F5b8'],
-  [CHAIN.INK]: [
-    '0x5839389261D1F38aac7c8E91DcDa85646bEcB414',
-    '0x9f64D99eA5BA69d2E6a5f19a923A26fbdfB370B9',
-  ],
-  [CHAIN.LINEA]: ['0x20b46e8b753093cFf78276832b92DE1A952dcF74'],
-  [CHAIN.BLAST]: ['0x756d003c2aacFBAB59C29aFC49933B952bd9E600'],
-  [CHAIN.SCROLL]: ['0x9326cA5FdDc0B6F758BE54Cfe0Ea39eDa56B1459'],
-  [CHAIN.ZORA]: ['0x919150CC162573d9BdCa1887E557b3208b536C99'],
-  [CHAIN.MONAD]: ['0xDa69f96C1d2DF824a11354d423dc84106AAA411a'],
-  [CHAIN.MEGAETH]: ['0x3A735e9A60304A59EB4492A90D6d0C529631b50e'],
-  [CHAIN.PLASMA]: ['0x2b7279D1227CC4838e15f473b8e1718ACBEc4292'],
-  [CHAIN.HYPERLIQUID]: ['0x2b7279D1227CC4838e15f473b8e1718ACBEc4292'],
+const chainConfig: Record<string, { start: string, contracts: string[] }> = {
+  [CHAIN.ETHEREUM]: { start: '2026-02-10', contracts: ['0x50b1E6ab68E6BeD281C27810dEd0c293C3a20B4D'] },
+  [CHAIN.OPTIMISM]: { start: '2026-02-10', contracts: ['0x5ECcD3f2eB245d20Db0e26934961576C1D1B0438'] },
+  [CHAIN.BSC]: { start: '2026-02-10', contracts: ['0x51abC29C7b7611333Ba56cfe6B10dC1ff089786E'] },
+  [CHAIN.UNICHAIN]: { start: '2026-02-10', contracts: ['0xB4f358117356E63761537316a4Fdbc0bFCFAA070'] },
+  [CHAIN.POLYGON]: { start: '2026-02-10', contracts: ['0xb511c2CF878e950e5598C1c3e47e546930A1AEa5'] },
+  [CHAIN.ERA]: { start: '2026-02-10', contracts: ['0xec598F086899eD1EE56F8666a31ed19e57453725'] },
+  [CHAIN.WC]: { start: '2026-02-10', contracts: ['0x2b7279D1227CC4838e15f473b8e1718ACBEc4292'] },
+  [CHAIN.LISK]: { start: '2026-02-10', contracts: ['0x756d003c2aacFBAB59C29aFC49933B952bd9E600'] },
+  [CHAIN.SONEIUM]: { start: '2026-02-10', contracts: ['0x756d003c2aacFBAB59C29aFC49933B952bd9E600'] },
+  [CHAIN.BASE]: { start: '2026-02-10', contracts: ['0x19FD96207f7B5c55403BE736897f7C1109C8314E'] },
+  [CHAIN.MODE]: { start: '2026-02-10', contracts: ['0x919150CC162573d9BdCa1887E557b3208b536C99'] },
+  [CHAIN.ARBITRUM]: { start: '2026-02-10', contracts: ['0x8b9Ffff3d567cc578752D455BCb7BE86fa60F5b8'] },
+  [CHAIN.INK]: {
+    start: '2025-01-07', contracts: [
+      '0x5839389261D1F38aac7c8E91DcDa85646bEcB414',
+      '0x9f64D99eA5BA69d2E6a5f19a923A26fbdfB370B9',
+    ]
+  },
+  [CHAIN.LINEA]: { start: '2026-02-10', contracts: ['0x20b46e8b753093cFf78276832b92DE1A952dcF74'] },
+  [CHAIN.BLAST]: { start: '2026-02-10', contracts: ['0x756d003c2aacFBAB59C29aFC49933B952bd9E600'] },
+  [CHAIN.SCROLL]: { start: '2026-02-10', contracts: ['0x9326cA5FdDc0B6F758BE54Cfe0Ea39eDa56B1459'] },
+  [CHAIN.ZORA]: { start: '2026-02-10', contracts: ['0x919150CC162573d9BdCa1887E557b3208b536C99'] },
+  [CHAIN.MONAD]: { start: '2026-02-10', contracts: ['0xDa69f96C1d2DF824a11354d423dc84106AAA411a'] },
+  [CHAIN.MEGAETH]: { start: '2026-02-10', contracts: ['0x3A735e9A60304A59EB4492A90D6d0C529631b50e'] },
+  [CHAIN.PLASMA]: { start: '2026-02-10', contracts: ['0x2b7279D1227CC4838e15f473b8e1718ACBEc4292'] },
+  [CHAIN.HYPERLIQUID]: { start: '2026-02-10', contracts: ['0x2b7279D1227CC4838e15f473b8e1718ACBEc4292'] },
 }
 
-const addAmount = (dailyVolume: ReturnType<FetchOptions['createBalances']>, token: string, amount: string) => {
-  if (token.toLowerCase() === ADDRESSES.GAS_TOKEN_2.toLowerCase()) {
-    dailyVolume.addGasToken(amount)
-  } else {
-    dailyVolume.add(token, amount)
-  }
-}
+const fetch = async (options: FetchOptions) => {
+  const { contracts } = chainConfig[options.chain]
 
-const fetchVolume = async (options: FetchOptions) => {
-  const targets = contracts[options.chain]
-  if (!targets?.length) {
-    throw new Error(`No contracts configured for chain: ${options.chain}`)
-  }
   const logs = await options.getLogs({
-    targets,
+    targets: contracts,
     eventAbi: event_route,
   })
+
   const dailyVolume = options.createBalances()
-  logs.forEach(log => {
-    addAmount(dailyVolume, log.tokenIn, log.amountIn)
-  })
+
+  logs.forEach(log => dailyVolume.add(log.tokenIn, log.amountIn))
+
   return {
     dailyVolume: dailyVolume
   }
@@ -60,32 +52,10 @@ const fetchVolume = async (options: FetchOptions) => {
 const adapter: SimpleAdapter = {
   version: 2,
   pullHourly: true,
-  fetch: fetchVolume,
+  fetch,
+  adapter: chainConfig,
   methodology: {
     dailyVolume: "Volume is calculated by summing the amountIn values from Route events emitted by SuperSwap router contracts across all supported chains."
-  },
-  adapter: {
-    [CHAIN.ETHEREUM]: { start: '2026-02-10' },
-    [CHAIN.OPTIMISM]: { start: '2026-02-10' },
-    [CHAIN.BSC]: { start: '2026-02-10' },
-    [CHAIN.UNICHAIN]: { start: '2026-02-10' },
-    [CHAIN.POLYGON]: { start: '2026-02-10' },
-    [CHAIN.ERA]: { start: '2026-02-10' },
-    [CHAIN.WC]: { start: '2026-02-10' },
-    [CHAIN.LISK]: { start: '2026-02-10' },
-    [CHAIN.SONEIUM]: { start: '2026-02-10' },
-    [CHAIN.BASE]: { start: '2026-02-10' },
-    [CHAIN.MODE]: { start: '2026-02-10' },
-    [CHAIN.ARBITRUM]: { start: '2026-02-10' },
-    [CHAIN.INK]: { start: '2026-02-10' },
-    [CHAIN.LINEA]: { start: '2026-02-10' },
-    [CHAIN.BLAST]: { start: '2026-02-10' },
-    [CHAIN.SCROLL]: { start: '2026-02-10' },
-    [CHAIN.ZORA]: { start: '2026-02-10' },
-    [CHAIN.MONAD]: { start: '2026-02-10' },
-    [CHAIN.MEGAETH]: { start: '2026-02-10' },
-    [CHAIN.PLASMA]: { start: '2026-02-10' },
-    [CHAIN.HYPERLIQUID]: { start: '2026-02-10' },
   },
 }
 


### PR DESCRIPTION
## Summary

- Adds SuperSwap aggregator volume tracking across the supported `SuperSwap.sol` deployments.
- Uses chain-specific router targets for Ethereum, Optimism, BSC, Unichain, Polygon, zkSync Era, World Chain, Lisk, Soneium, Base, Mode, Arbitrum, Ink, Linea, Blast, Scroll, Zora, Monad, MegaETH, Plasma, and HyperEVM.
- Keeps the existing Ink router and adds the newer Ink deployment alongside it.
- Counts routed volume from `Route` event `amountIn` values.
- Sets all chain start dates to `2026-02-10`.
- Adds methodology for the aggregator volume calculation.
