### PR TITLE
fix: account for katana perps exchange contract upgrade

### DIFF
--- a/dexs/katana-perps.ts
+++ b/dexs/katana-perps.ts
@@ -1,7 +1,9 @@
 import { CHAIN } from "../helpers/chains";
 import { FetchOptions, FetchResultV2, SimpleAdapter } from "../adapters/types";
 
-const EXCHANGE_CONTRACT = '0x835Ba5b1B202773A94Daaa07168b26B22584637a';
+const OLD_EXCHANGE_CONTRACT = '0x835Ba5b1B202773A94Daaa07168b26B22584637a';
+const NEW_EXCHANGE_CONTRACT = '0x62230CeA619F734cc215bB8074bbF07bE4Eb633e';
+const UPGRADE_TIMESTAMP = 1777300239; // Apr-27-2026 02:30:39 PM UTC
 const QUOTE_TOKEN = '0x203A662b0BD271A6ed5a60EdFbd04bFce608FD36';
 // Event quantities are in pips (8 decimals), USDC is 6 decimals
 const PIP_DECIMALS_ADJUSTMENT = 1e2;
@@ -14,7 +16,11 @@ async function fetch(options: FetchOptions): Promise<FetchResultV2> {
   const dailyVolume = options.createBalances();
   const dailyFees = options.createBalances();
 
-  const logs = await options.getLogs({ target: EXCHANGE_CONTRACT, eventAbi: ABIS.TradeExecuted });
+  const targets: string[] = [];
+  if (options.fromTimestamp < UPGRADE_TIMESTAMP) targets.push(OLD_EXCHANGE_CONTRACT);
+  if (options.toTimestamp >= UPGRADE_TIMESTAMP) targets.push(NEW_EXCHANGE_CONTRACT);
+
+  const logs = await options.getLogs({ targets, eventAbi: ABIS.TradeExecuted });
   for (const log of logs) {
     dailyVolume.add(QUOTE_TOKEN, Number(log.quoteQuantity) / PIP_DECIMALS_ADJUSTMENT);
     dailyFees.add(QUOTE_TOKEN, Math.abs(Number(log.makerFeeQuantity)) / PIP_DECIMALS_ADJUSTMENT, 'Maker Fees');


### PR DESCRIPTION
The Katana Perps Exchange contract was upgraded at Apr-27-2026 02:30:39 PM +UTC. This PR fixes the adapter to source events from the correct Exchange contract version based on requested timestamp