### PR TITLE
Add Cubic DEX volume/fees adapter

### DIFF
--- a/dexs/cubic/index.ts
+++ b/dexs/cubic/index.ts
@@ -1,0 +1,61 @@
+import { CHAIN } from "../../helpers/chains";
+import { httpGet } from "../../utils/fetchURL";
+import { FetchOptions, SimpleAdapter } from "../../adapters/types";
+
+const API_URL = "https://api.cubee.ee/api/defillama/dimensions";
+
+interface DimensionsResponse {
+  start: number;
+  end: number;
+  dailyVolume: number;
+  dailyFees: number;
+  dailyRevenue: number;
+  dailySupplySideRevenue: number;
+  dailyUserFees: number;
+  dailyProtocolRevenue: number;
+}
+
+const fetch = async (options: FetchOptions) => {
+  const url = `${API_URL}?start=${options.startTimestamp}&end=${options.endTimestamp}`;
+  const data: DimensionsResponse = await httpGet(url);
+
+  return {
+    dailyVolume: data.dailyVolume,
+    dailyFees: data.dailyFees,
+    dailyUserFees: data.dailyUserFees,
+    dailyRevenue: data.dailyRevenue,
+    dailyProtocolRevenue: data.dailyProtocolRevenue,
+    dailySupplySideRevenue: data.dailySupplySideRevenue,
+  };
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  adapter: {
+    [CHAIN.SOLANA]: {
+      fetch,
+      start: "2025-01-01",
+    },
+  },
+  methodology: {
+    Volume: "Sum of swap input USD value across all Cubic pools, computed from on-chain swap events indexed by the Cubic backend.",
+    Fees: "All swap fees paid by users on Cubic pools (LP share + protocol share).",
+    UserFees: "All swap fees paid by users on Cubic pools.",
+    Revenue: "Protocol's share of swap fees on Cubic pools.",
+    ProtocolRevenue: "Protocol's share of swap fees, accruing to the Cubic protocol fees authority.",
+    SupplySideRevenue: "LPs' share of swap fees on Cubic pools.",
+  },
+  breakdownMethodology: {
+    Fees: {
+      "Swap Fees": "Fees collected on every swap, computed from on-chain swap events.",
+    },
+    Revenue: {
+      "Swap Fees To Treasury": "Protocol's share of swap fees.",
+    },
+    SupplySideRevenue: {
+      "Swap Fees To LPs": "LPs' share of swap fees.",
+    },
+  },
+};
+
+export default adapter;

--- a/dexs/cubic/index.ts
+++ b/dexs/cubic/index.ts
@@ -1,79 +1,57 @@
-import { Dependencies, FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
-import { queryDuneSql } from "../../helpers/dune";
+import { httpGet } from "../../utils/fetchURL";
+import { FetchOptions, SimpleAdapter } from "../../adapters/types";
 
-// Cubic Pool program (Solana mainnet).
-const PROGRAM_ID = "8iQtGj9mcUfFUGaiCpPy89swC3s8YTC8FhVZWfgeZhwu";
+const API_URL = "https://api.cubee.ee/api/defillama/dimensions";
 
-// Anchor instruction discriminator for `swap` (first 8 bytes of the
-// instruction data). Source: contracts/idl/cubic_pool.json
-const SWAP_DISCRIMINATOR_HEX = "f8c69e91e17587c8";
-
-// Anchor `swap` instruction layout:
-//   data[1..=8]   = discriminator
-//   data[9..=16]  = amount_in (u64, little-endian)
-//   data[17..=24] = minimum_amount_out (u64, le)  — unused here
-//   data[25]      = token_in_index (u8)            — unused here
-//   data[26]      = token_out_index (u8)           — unused here
-//
-// account_arguments (1-indexed in Trino):
-//   [1] pool
-//   [2] token_mint_in   ← used to attribute volume to a token
-//   [3] token_mint_out
-//   [4] user_token_account_in
-//   [5] user_token_account_out
-//   [6] vault_in
-//   [7] vault_out
-//   [8] user
-//   [9] token_program_in
-//  [10] token_program_out
+interface DimensionsResponse {
+  start: number;
+  end: number;
+  dailyVolume: number;
+  dailyFees: number;
+  dailySupplySideRevenue: number;
+}
 
 const fetch = async (options: FetchOptions) => {
-  const dailyVolume = options.createBalances();
+  const url = `${API_URL}?start=${options.startTimestamp}&end=${options.endTimestamp}`;
+  const data: DimensionsResponse = await httpGet(url);
 
-  const rows = await queryDuneSql(
-    options,
-    `WITH cubic_swaps AS (
-      SELECT
-        bytearray_to_bigint(bytearray_reverse(bytearray_substring(data, 9, 8))) AS amount_in,
-        account_arguments[2] AS token_mint_in
-      FROM solana.instruction_calls
-      WHERE executing_account = '${PROGRAM_ID}'
-        AND bytearray_substring(data, 1, 8) = from_hex('${SWAP_DISCRIMINATOR_HEX}')
-        AND block_time >= from_unixtime(${options.startTimestamp})
-        AND block_time < from_unixtime(${options.endTimestamp})
-        AND tx_success = true
-    )
-    SELECT
-      token_mint_in,
-      SUM(amount_in) AS total_amount
-    FROM cubic_swaps
-    WHERE amount_in > 0
-    GROUP BY token_mint_in`
-  );
-
-  for (const row of rows) {
-    dailyVolume.add(row.token_mint_in, row.total_amount);
+  if (
+    !data ||
+    data.dailyVolume == null ||
+    data.dailyFees == null ||
+    data.dailySupplySideRevenue == null
+  ) {
+    throw new Error(
+      `Cubic API returned invalid response from ${url}: ${JSON.stringify(data)}`
+    );
   }
 
+  const dailyRevenue = data.dailyFees - data.dailySupplySideRevenue;
+
   return {
-    dailyVolume,
+    dailyVolume: data.dailyVolume,
+    dailyFees: data.dailyFees,
+    dailyUserFees: data.dailyFees,
+    dailyRevenue,
+    dailySupplySideRevenue: data.dailySupplySideRevenue,
   };
 };
 
 const adapter: SimpleAdapter = {
   version: 2,
-  dependencies: [Dependencies.DUNE],
   adapter: {
     [CHAIN.SOLANA]: {
       fetch,
-      start: "2026-05-01",
+      start: "2025-01-01",
     },
   },
-  isExpensiveAdapter: true,
   methodology: {
-    Volume:
-      "Sum of `amount_in` parsed directly from on-chain Cubic `swap` instructions on Solana, attributed to the input token mint. Computed via Dune SQL over `solana.instruction_calls` filtered by program id and the swap-instruction discriminator.",
+    Volume: "Sum of swap input USD value across all Cubic pools, computed from on-chain swap events indexed by the Cubic backend.",
+    Fees: "All swap fees paid by users on Cubic pools (LP share + protocol share).",
+    UserFees: "All swap fees paid by users on Cubic pools.",
+    Revenue: "Protocol's share of swap fees on Cubic pools (dailyFees - dailySupplySideRevenue), accruing to the Cubic protocol fees authority.",
+    SupplySideRevenue: "LPs' share of swap fees on Cubic pools.",
   },
 };
 

--- a/dexs/cubic/index.ts
+++ b/dexs/cubic/index.ts
@@ -1,57 +1,79 @@
+import { Dependencies, FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
-import { httpGet } from "../../utils/fetchURL";
-import { FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { queryDuneSql } from "../../helpers/dune";
 
-const API_URL = "https://api.cubee.ee/api/defillama/dimensions";
+// Cubic Pool program (Solana mainnet).
+const PROGRAM_ID = "8iQtGj9mcUfFUGaiCpPy89swC3s8YTC8FhVZWfgeZhwu";
 
-interface DimensionsResponse {
-  start: number;
-  end: number;
-  dailyVolume: number;
-  dailyFees: number;
-  dailySupplySideRevenue: number;
-}
+// Anchor instruction discriminator for `swap` (first 8 bytes of the
+// instruction data). Source: contracts/idl/cubic_pool.json
+const SWAP_DISCRIMINATOR_HEX = "f8c69e91e17587c8";
+
+// Anchor `swap` instruction layout:
+//   data[1..=8]   = discriminator
+//   data[9..=16]  = amount_in (u64, little-endian)
+//   data[17..=24] = minimum_amount_out (u64, le)  — unused here
+//   data[25]      = token_in_index (u8)            — unused here
+//   data[26]      = token_out_index (u8)           — unused here
+//
+// account_arguments (1-indexed in Trino):
+//   [1] pool
+//   [2] token_mint_in   ← used to attribute volume to a token
+//   [3] token_mint_out
+//   [4] user_token_account_in
+//   [5] user_token_account_out
+//   [6] vault_in
+//   [7] vault_out
+//   [8] user
+//   [9] token_program_in
+//  [10] token_program_out
 
 const fetch = async (options: FetchOptions) => {
-  const url = `${API_URL}?start=${options.startTimestamp}&end=${options.endTimestamp}`;
-  const data: DimensionsResponse = await httpGet(url);
+  const dailyVolume = options.createBalances();
 
-  if (
-    !data ||
-    data.dailyVolume == null ||
-    data.dailyFees == null ||
-    data.dailySupplySideRevenue == null
-  ) {
-    throw new Error(
-      `Cubic API returned invalid response from ${url}: ${JSON.stringify(data)}`
-    );
+  const rows = await queryDuneSql(
+    options,
+    `WITH cubic_swaps AS (
+      SELECT
+        bytearray_to_bigint(bytearray_reverse(bytearray_substring(data, 9, 8))) AS amount_in,
+        account_arguments[2] AS token_mint_in
+      FROM solana.instruction_calls
+      WHERE executing_account = '${PROGRAM_ID}'
+        AND bytearray_substring(data, 1, 8) = from_hex('${SWAP_DISCRIMINATOR_HEX}')
+        AND block_time >= from_unixtime(${options.startTimestamp})
+        AND block_time < from_unixtime(${options.endTimestamp})
+        AND tx_success = true
+    )
+    SELECT
+      token_mint_in,
+      SUM(amount_in) AS total_amount
+    FROM cubic_swaps
+    WHERE amount_in > 0
+    GROUP BY token_mint_in`
+  );
+
+  for (const row of rows) {
+    dailyVolume.add(row.token_mint_in, row.total_amount);
   }
 
-  const dailyRevenue = data.dailyFees - data.dailySupplySideRevenue;
-
   return {
-    dailyVolume: data.dailyVolume,
-    dailyFees: data.dailyFees,
-    dailyUserFees: data.dailyFees,
-    dailyRevenue,
-    dailySupplySideRevenue: data.dailySupplySideRevenue,
+    dailyVolume,
   };
 };
 
 const adapter: SimpleAdapter = {
   version: 2,
+  dependencies: [Dependencies.DUNE],
   adapter: {
     [CHAIN.SOLANA]: {
       fetch,
-      start: "2025-01-01",
+      start: "2026-05-01",
     },
   },
+  isExpensiveAdapter: true,
   methodology: {
-    Volume: "Sum of swap input USD value across all Cubic pools, computed from on-chain swap events indexed by the Cubic backend.",
-    Fees: "All swap fees paid by users on Cubic pools (LP share + protocol share).",
-    UserFees: "All swap fees paid by users on Cubic pools.",
-    Revenue: "Protocol's share of swap fees on Cubic pools (dailyFees - dailySupplySideRevenue), accruing to the Cubic protocol fees authority.",
-    SupplySideRevenue: "LPs' share of swap fees on Cubic pools.",
+    Volume:
+      "Sum of `amount_in` parsed directly from on-chain Cubic `swap` instructions on Solana, attributed to the input token mint. Computed via Dune SQL over `solana.instruction_calls` filtered by program id and the swap-instruction discriminator.",
   },
 };
 

--- a/dexs/cubic/index.ts
+++ b/dexs/cubic/index.ts
@@ -9,22 +9,31 @@ interface DimensionsResponse {
   end: number;
   dailyVolume: number;
   dailyFees: number;
-  dailyRevenue: number;
   dailySupplySideRevenue: number;
-  dailyUserFees: number;
-  dailyProtocolRevenue: number;
 }
 
 const fetch = async (options: FetchOptions) => {
   const url = `${API_URL}?start=${options.startTimestamp}&end=${options.endTimestamp}`;
   const data: DimensionsResponse = await httpGet(url);
 
+  if (
+    !data ||
+    data.dailyVolume == null ||
+    data.dailyFees == null ||
+    data.dailySupplySideRevenue == null
+  ) {
+    throw new Error(
+      `Cubic API returned invalid response from ${url}: ${JSON.stringify(data)}`
+    );
+  }
+
+  const dailyRevenue = data.dailyFees - data.dailySupplySideRevenue;
+
   return {
     dailyVolume: data.dailyVolume,
     dailyFees: data.dailyFees,
-    dailyUserFees: data.dailyUserFees,
-    dailyRevenue: data.dailyRevenue,
-    dailyProtocolRevenue: data.dailyProtocolRevenue,
+    dailyUserFees: data.dailyFees,
+    dailyRevenue,
     dailySupplySideRevenue: data.dailySupplySideRevenue,
   };
 };
@@ -41,20 +50,8 @@ const adapter: SimpleAdapter = {
     Volume: "Sum of swap input USD value across all Cubic pools, computed from on-chain swap events indexed by the Cubic backend.",
     Fees: "All swap fees paid by users on Cubic pools (LP share + protocol share).",
     UserFees: "All swap fees paid by users on Cubic pools.",
-    Revenue: "Protocol's share of swap fees on Cubic pools.",
-    ProtocolRevenue: "Protocol's share of swap fees, accruing to the Cubic protocol fees authority.",
+    Revenue: "Protocol's share of swap fees on Cubic pools (dailyFees - dailySupplySideRevenue), accruing to the Cubic protocol fees authority.",
     SupplySideRevenue: "LPs' share of swap fees on Cubic pools.",
-  },
-  breakdownMethodology: {
-    Fees: {
-      "Swap Fees": "Fees collected on every swap, computed from on-chain swap events.",
-    },
-    Revenue: {
-      "Swap Fees To Treasury": "Protocol's share of swap fees.",
-    },
-    SupplySideRevenue: {
-      "Swap Fees To LPs": "LPs' share of swap fees.",
-    },
   },
 };
 


### PR DESCRIPTION
Cubic is a Solana DEX with weighted multi-token pools (up to 10 tokens) and virtual balances. Adapter consumes the public Cubic backend API at api.cubee.ee, which aggregates on-chain swap events from the Cubic indexer.

Website: https://cubee.ee
Twitter: https://x.com/cubee_ee

**NOTE**

#### Please enable "Allow edits by maintainers" while putting up the PR.

---

> - If you would like to add a `tvl` adapter please submit the PR [here](https://github.com/DefiLlama/DefiLlama-Adapters).

1. Once your adapter has been merged, it takes time to show on the UI. If more than 24 hours have passed, please let us know in Discord.
2. Please fill the form below **only if the PR is for listing a new protocol** else it can be ignored/replaced with reason/details about the PR
3. **For updating listing info** It is a different repo, you can find your listing in this file: https://github.com/DefiLlama/defillama-server/blob/master/defi/src/protocols/data4.ts, you can edit it there and put up a PR
4. Do not edit/push `package.json/package-lock.json` file as part of your changes
5. No need to go to our discord/other channel and announce that you've created a PR, we monitor all PRs and will review it asap

---
⏺ ##### Name (to be shown on DefiLlama):
  Cubic

  ##### Twitter Link:
  https://x.com/cubee_ee

  ##### List of audit links if any:
  https://x.com/cubee_ee/status/2048777501996896704

  ##### Website Link:
  https://cubee.ee

  ##### Logo (High resolution, will be shown with rounded borders):
  Submitted in a separate PR to DefiLlama/icons — file `assets/protocols/cubic.svg`.

  ##### Current TVL:
  ~$246 (early mainnet — protocol just launched). Verified locally via `node test.js projects/cubic/index.js`.

  ##### Treasury Addresses (if the protocol has treasury)
  Protocol fees authority PDA owner: `3jiojHZbjJQ7QLMGSTjFwxVEmx4NtuRy34nLAmsJME81` (collects the protocol's share of swap fees per pool). No
  separate treasury wallet at this time.

  ##### Chain:
  Solana

  ##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed): (https://api.coingecko.com/api/v3/coins/list)


  ##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed):
  (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)


  ##### Short Description (to be shown on DefiLlama):
  Cubic is a Solana DEX with weighted multi-token pools (up to 10 tokens) and virtual balances that let LPs concentrate liquidity within
  configurable price ranges. Swap fee and protocol fee share are configurable per pool.

  ##### Token address and ticker if any:
  None.

  ##### Category (full list at https://defillama.com/categories) *Please choose only one:
  Dexes

  ##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.):
  None — pricing is determined by the on-chain weighted-pool curve. No external oracle is consulted for swaps.

  ##### Implementation Details: Briefly describe how the oracle is integrated into your project:
  Not applicable. Cubic does not use an external oracle; spot prices are derived directly from pool reserves via the weighted-pool invariant.

  ##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage:
  N/A. Source code: https://github.com/cubee-ee. On-chain program: `8iQtGj9mcUfFUGaiCpPy89swC3s8YTC8FhVZWfgeZhwu` (Solana mainnet).

  ##### forkedFrom (Does your project originate from another project):
  None. Original implementation. Weighted-pool math is conceptually similar to Balancer V2, but Cubic adds virtual balances for leverage / range
   concentration.

  ##### methodology (what is being counted as tvl, how is tvl being calculated):
  The adapter calls `getProgramAccounts` on the Cubic program `8iQtGj9mcUfFUGaiCpPy89swC3s8YTC8FhVZWfgeZhwu` to fetch every `CubicPool` account,
   decodes each via the program IDL, and for each active pool derives the per-token vault as `ATA(pool, mint, token_program)` (Cubic supports
  both SPL Token and Token-2022, so the token program is read per-token from the pool state). All vault balances are summed via `sumTokens2` and
   priced through DefiLlama's standard token-price layer. Disabled pools are skipped.

  ##### Github org/user (Optional, if your code is open source, we can track activity):
  https://github.com/cubee-ee

  ##### Does this project have a referral program?
  we will lunch soon