### PR TITLE
Add loopscale(solana) fees & revenue adapter 

### DIFF
--- a/fees/loopscale/index.ts
+++ b/fees/loopscale/index.ts
@@ -1,0 +1,123 @@
+import { FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import { METRIC } from "../../helpers/metrics";
+import { httpPost } from "../../utils/fetchURL";
+
+// Sources:
+// - Vault API endpoint used by the Loopscale app: https://tars.loopscale.com/v1/markets/lending_vaults/info
+// - Vault mechanics, fees, rewards, and liquidation penalty docs:
+//   https://docs.loopscale.com/protocol-concepts/loopscale-vaults
+// - User-facing vault yield flow:
+//   https://docs.loopscale.com/using-loopscale/earn
+const API_URL = "https://tars.loopscale.com/v1/markets/lending_vaults/info";
+const SECONDS_PER_DAY = 24 * 60 * 60;
+const FEE_DENOMINATOR = 1e6;
+
+interface LoopscaleVaultResponse {
+  lendVaults: Array<{
+    vaultRewardsSchedules?: Array<{
+      rewardMint?: string;
+      rewardStartTime?: string | number;
+      rewardEndTime?: string | number;
+      emissionsPerSecond?: string | number;
+    }>;
+    vaultStrategy?: {
+      strategy?: {
+        principalMint?: string;
+        interestPerSecond?: string | number;
+        interestFee?: string | number;
+        closed?: boolean;
+      };
+    };
+  }>;
+  total?: number;
+}
+
+const toNumber = (value: string | number | undefined) => Number(value || 0);
+
+const fetch = async (options: FetchOptions) => {
+  const dailyFees = options.createBalances();
+  const dailyRevenue = options.createBalances();
+  const dailySupplySideRevenue = options.createBalances();
+  const now = Date.now() / 1000;
+
+  // This endpoint is a current vault snapshot. It exposes each vault strategy's
+  // current interestPerSecond and interestFee, plus curator-configured reward
+  // schedules when includeRewards is enabled.
+  const response: LoopscaleVaultResponse = await httpPost(API_URL, {
+    page: 0,
+    pageSize: 50,
+    includeRewards: true,
+  });
+
+  response.lendVaults.forEach(({ vaultRewardsSchedules, vaultStrategy }) => {
+    const strategy = vaultStrategy?.strategy;
+    if (strategy && !strategy.closed && strategy.principalMint) {
+      // Loopscale vault yield is generated from borrower interest. interestFee
+      // is the curator/manager share of interest earned, denominated in 1e6.
+      const dailyInterest = toNumber(strategy.interestPerSecond) * SECONDS_PER_DAY;
+
+      if (dailyInterest) {
+        const revenueShare = toNumber(strategy.interestFee) / FEE_DENOMINATOR;
+        const dailyProtocolInterest = dailyInterest * revenueShare;
+        const dailyLenderInterest = dailyInterest - dailyProtocolInterest;
+
+        dailyFees.add(strategy.principalMint, dailyInterest, METRIC.BORROW_INTEREST);
+        dailyRevenue.add(strategy.principalMint, dailyProtocolInterest, METRIC.CURATORS_FEES);
+        dailySupplySideRevenue.add(strategy.principalMint, dailyLenderInterest, METRIC.BORROW_INTEREST);
+      }
+    }
+
+    vaultRewardsSchedules?.forEach((schedule) => {
+      const rewardStartTime = toNumber(schedule.rewardStartTime);
+      const rewardEndTime = toNumber(schedule.rewardEndTime);
+      if (!schedule.rewardMint || now < rewardStartTime || now > rewardEndTime) return;
+
+      // Curators can deposit reward tokens for proportional distribution to
+      // suppliers. Count active emissions as supplier yield, not protocol revenue.
+      const dailyRewards = toNumber(schedule.emissionsPerSecond) * SECONDS_PER_DAY;
+      if (!dailyRewards) return;
+
+      dailyFees.add(schedule.rewardMint, dailyRewards, METRIC.ASSETS_YIELDS);
+      dailySupplySideRevenue.add(schedule.rewardMint, dailyRewards, METRIC.ASSETS_YIELDS);
+    });
+  });
+
+  return {
+    dailyFees,
+    dailyRevenue,
+    dailyProtocolRevenue: dailyRevenue,
+    dailySupplySideRevenue,
+  };
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  fetch,
+  chains: [CHAIN.SOLANA],
+  runAtCurrTime: true,
+  methodology: {
+    Fees: "Loopscale Vault fees and yield from the current vault snapshot: borrower interest paid into vault strategies plus active curator-funded reward emissions. Loopscale docs describe Vaults as single-asset lending vaults where borrower interest flows back to depositors, and rewards schedules are curator-deposited tokens distributed to suppliers.",
+    Revenue: "Curator/manager interest fees from Loopscale Vaults. Loopscale's Vault docs define Interest Fees as a curator-defined percentage of interest earned.",
+    ProtocolRevenue: "Curator/manager interest fees from Loopscale Vaults, using each strategy's interestFee field from the vault API.",
+    SupplySideRevenue: "Supplier yield from Loopscale Vaults: borrower interest remaining after curator/manager interest fees, plus active curator-funded reward emissions distributed to depositors.",
+  },
+  breakdownMethodology: {
+    Fees: {
+      [METRIC.BORROW_INTEREST]: "Current daily run-rate borrower interest from Loopscale Vault strategies. Loopscale docs state that Vault capital is allocated to borrower-facing markets and interest from borrowers flows back to the Vault.",
+      [METRIC.ASSETS_YIELDS]: "Current active reward tokens from Loopscale Vault reward schedules. Loopscale docs state that curators may deposit tokens to be automatically distributed proportionally to suppliers.",
+    },
+    Revenue: {
+      [METRIC.CURATORS_FEES]: "Curator/manager share of Vault interest earned, calculated from each strategy's interestFee. Loopscale docs define Interest Fees as a percentage of interest earned.",
+    },
+    ProtocolRevenue: {
+      [METRIC.CURATORS_FEES]: "Curator/manager share of Vault interest earned, calculated from each strategy's interestFee. Loopscale docs define Interest Fees as a percentage of interest earned.",
+    },
+    SupplySideRevenue: {
+      [METRIC.BORROW_INTEREST]: "Borrower interest flowing back to Vault depositors after curator/manager interest fees.",
+      [METRIC.ASSETS_YIELDS]: "Curator-funded reward tokens distributed to Vault depositors while the reward schedule is active.",
+    },
+  },
+};
+
+export default adapter;

--- a/fees/loopscale/index.ts
+++ b/fees/loopscale/index.ts
@@ -2,6 +2,7 @@ import { FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 import { METRIC } from "../../helpers/metrics";
 import { httpPost } from "../../utils/fetchURL";
+import { sleep } from "../../utils/utils";
 
 // Sources:
 // - Vault API endpoint used by the Loopscale app: https://tars.loopscale.com/v1/markets/lending_vaults/info
@@ -14,122 +15,103 @@ const SECONDS_PER_DAY = 24 * 60 * 60;
 const FEE_DENOMINATOR = 1e6;
 
 interface LoopscaleVaultResponse {
-  lendVaults: Array<{
-    vaultRewardsSchedules?: Array<{
-      rewardMint?: string;
-      rewardStartTime?: string | number;
-      rewardEndTime?: string | number;
-      emissionsPerSecond?: string | number;
+    lendVaults: Array<{
+        vaultRewardsSchedules?: Array<{
+            rewardMint?: string;
+            rewardStartTime?: string | number;
+            rewardEndTime?: string | number;
+            emissionsPerSecond?: string | number;
+        }>;
+        vaultStrategy?: {
+            strategy?: {
+                principalMint?: string;
+                interestPerSecond?: string | number;
+                interestFee?: string | number;
+                closed?: boolean;
+            };
+        };
     }>;
-    vaultStrategy?: {
-      strategy?: {
-        principalMint?: string;
-        interestPerSecond?: string | number;
-        interestFee?: string | number;
-        closed?: boolean;
-      };
-    };
-  }>;
-  total?: number;
+    total?: number;
 }
 
 const toNumber = (value: string | number | undefined) => Number(value || 0);
 
 const fetch = async (options: FetchOptions) => {
-  const dailyFees = options.createBalances();
-  const dailyRevenue = options.createBalances();
-  const dailySupplySideRevenue = options.createBalances();
-  const now = Date.now() / 1000;
+    const dailyFees = options.createBalances();
+    const dailyRevenue = options.createBalances();
+    const dailySupplySideRevenue = options.createBalances();
+    const now = Date.now() / 1000;
 
-  // This endpoint is a current vault snapshot. It exposes each vault strategy's
-  // current interestPerSecond and interestFee, plus curator-configured reward
-  // schedules when includeRewards is enabled.
-  const PAGE_SIZE = 50;
-  const allVaults: LoopscaleVaultResponse["lendVaults"] = [];
-  let page = 0;
-  let total = Infinity;
+    // This endpoint is a current vault snapshot. It exposes each vault strategy's
+    // current interestPerSecond and interestFee, plus curator-configured reward
+    // schedules when includeRewards is enabled.
+    const PAGE_SIZE = 50;
+    const allVaults: LoopscaleVaultResponse["lendVaults"] = [];
+    let page = 0;
+    let total = Infinity;
 
-  while (allVaults.length < total) {
-    const response: LoopscaleVaultResponse = await httpPost(API_URL, {
-      page,
-      pageSize: PAGE_SIZE,
-      includeRewards: true,
-    });
-    const vaults = response.lendVaults ?? [];
-    allVaults.push(...vaults);
-    total = response.total ?? allVaults.length;
-    if (vaults.length < PAGE_SIZE) break; // no more pages
-    page++;
-  }
-
-  allVaults.forEach(({ vaultRewardsSchedules, vaultStrategy }) => {
-    const strategy = vaultStrategy?.strategy;
-    if (strategy && !strategy.closed && strategy.principalMint) {
-      // Loopscale vault yield is generated from borrower interest. interestFee
-      // is the curator/manager share of interest earned, denominated in 1e6.
-      const dailyInterest = toNumber(strategy.interestPerSecond) * SECONDS_PER_DAY;
-
-      if (dailyInterest) {
-        const revenueShare = toNumber(strategy.interestFee) / FEE_DENOMINATOR;
-        const dailyProtocolInterest = dailyInterest * revenueShare;
-        const dailyLenderInterest = dailyInterest - dailyProtocolInterest;
-
-        dailyFees.add(strategy.principalMint, dailyInterest, METRIC.BORROW_INTEREST);
-        dailyRevenue.add(strategy.principalMint, dailyProtocolInterest, METRIC.CURATORS_FEES);
-        dailySupplySideRevenue.add(strategy.principalMint, dailyLenderInterest, METRIC.BORROW_INTEREST);
-      }
+    while (allVaults.length < total) {
+        const response: LoopscaleVaultResponse = await httpPost(API_URL, {
+            page,
+            pageSize: PAGE_SIZE,
+            includeRewards: true,
+        });
+        const vaults = response.lendVaults ?? [];
+        allVaults.push(...vaults);
+        total = response.total ?? allVaults.length;
+        console.dir(vaults, { depth: null })
+        if (vaults.length < PAGE_SIZE) break; // no more pages
+        page++;
+        await sleep(3000);
     }
 
-    vaultRewardsSchedules?.forEach((schedule) => {
-      const rewardStartTime = toNumber(schedule.rewardStartTime);
-      const rewardEndTime = toNumber(schedule.rewardEndTime);
-      if (!schedule.rewardMint || now < rewardStartTime || now > rewardEndTime) return;
+    allVaults.forEach(({ vaultRewardsSchedules, vaultStrategy }) => {
+        const strategy = vaultStrategy?.strategy;
+        if (strategy && !strategy.closed && strategy.principalMint) {
+            // Loopscale vault yield is generated from borrower interest. interestFee
+            // is the curator/manager share of interest earned, denominated in 1e6.
+            const dailyInterest = toNumber(strategy.interestPerSecond) * SECONDS_PER_DAY;
 
-      // Curators can deposit reward tokens for proportional distribution to
-      // suppliers. Count active emissions as supplier yield, not protocol revenue.
-      const dailyRewards = toNumber(schedule.emissionsPerSecond) * SECONDS_PER_DAY;
-      if (!dailyRewards) return;
+            if (dailyInterest) {
+                const curatorFeeRate = toNumber(strategy.interestFee) / FEE_DENOMINATOR;
+                const dailyCuratorFee = dailyInterest * curatorFeeRate;
+                const dailyBorrowerInterest = dailyInterest - dailyCuratorFee;
 
-      dailyFees.add(schedule.rewardMint, dailyRewards, METRIC.ASSETS_YIELDS);
-      dailySupplySideRevenue.add(schedule.rewardMint, dailyRewards, METRIC.ASSETS_YIELDS);
+                dailyFees.add(strategy.principalMint, dailyInterest, METRIC.BORROW_INTEREST);
+                dailySupplySideRevenue.add(strategy.principalMint, dailyCuratorFee, METRIC.CURATORS_FEES);
+                dailySupplySideRevenue.add(strategy.principalMint, dailyBorrowerInterest, METRIC.BORROW_INTEREST);
+            }
+        }
     });
-  });
 
-  return {
-    dailyFees,
-    dailyRevenue,
-    dailyProtocolRevenue: dailyRevenue,
-    dailySupplySideRevenue,
-  };
+    return {
+        dailyFees,
+        dailyRevenue,
+        dailyProtocolRevenue: dailyRevenue,
+        dailySupplySideRevenue,
+    };
 };
 
 const adapter: SimpleAdapter = {
-  version: 2,
-  fetch,
-  chains: [CHAIN.SOLANA],
-  runAtCurrTime: true,
-  methodology: {
-    Fees: "Loopscale Vault fees and yield from the current vault snapshot: borrower interest paid into vault strategies plus active curator-funded reward emissions. Loopscale docs describe Vaults as single-asset lending vaults where borrower interest flows back to depositors, and rewards schedules are curator-deposited tokens distributed to suppliers.",
-    Revenue: "Curator/manager interest fees from Loopscale Vaults. Loopscale's Vault docs define Interest Fees as a curator-defined percentage of interest earned.",
-    ProtocolRevenue: "Curator/manager interest fees from Loopscale Vaults, using each strategy's interestFee field from the vault API.",
-    SupplySideRevenue: "Supplier yield from Loopscale Vaults: borrower interest remaining after curator/manager interest fees, plus active curator-funded reward emissions distributed to depositors.",
-  },
-  breakdownMethodology: {
-    Fees: {
-      [METRIC.BORROW_INTEREST]: "Current daily run-rate borrower interest from Loopscale Vault strategies. Loopscale docs state that Vault capital is allocated to borrower-facing markets and interest from borrowers flows back to the Vault.",
-      [METRIC.ASSETS_YIELDS]: "Current active reward tokens from Loopscale Vault reward schedules. Loopscale docs state that curators may deposit tokens to be automatically distributed proportionally to suppliers.",
+    version: 2,
+    fetch,
+    chains: [CHAIN.SOLANA],
+    runAtCurrTime: true,
+    methodology: {
+        Fees: "Loopscale Vault fees and yield from the current vault snapshot: borrower interest paid into vault strategies",
+        Revenue: "No revenue from Loopscale Vaults",
+        ProtocolRevenue: "No revenue from Loopscale Vaults",
+        SupplySideRevenue: "Includes borrower interest and curator fees",
     },
-    Revenue: {
-      [METRIC.CURATORS_FEES]: "Curator/manager share of Vault interest earned, calculated from each strategy's interestFee. Loopscale docs define Interest Fees as a percentage of interest earned.",
+    breakdownMethodology: {
+        Fees: {
+            [METRIC.BORROW_INTEREST]: "Current daily run-rate borrower interest from Loopscale Vault strategies. Loopscale docs state that Vault capital is allocated to borrower-facing markets and interest from borrowers flows back to the Vault.",
+        },
+        SupplySideRevenue: {
+            [METRIC.BORROW_INTEREST]: "Borrower interest flowing back to Vault depositors after curator fees.",
+            [METRIC.CURATORS_FEES]: "Curator fees from Loopscale Vault strategies",
+        },
     },
-    ProtocolRevenue: {
-      [METRIC.CURATORS_FEES]: "Curator/manager share of Vault interest earned, calculated from each strategy's interestFee. Loopscale docs define Interest Fees as a percentage of interest earned.",
-    },
-    SupplySideRevenue: {
-      [METRIC.BORROW_INTEREST]: "Borrower interest flowing back to Vault depositors after curator/manager interest fees.",
-      [METRIC.ASSETS_YIELDS]: "Curator-funded reward tokens distributed to Vault depositors while the reward schedule is active.",
-    },
-  },
 };
 
 export default adapter;

--- a/fees/loopscale/index.ts
+++ b/fees/loopscale/index.ts
@@ -40,7 +40,6 @@ const fetch = async (options: FetchOptions) => {
     const dailyFees = options.createBalances();
     const dailyRevenue = options.createBalances();
     const dailySupplySideRevenue = options.createBalances();
-    const now = Date.now() / 1000;
 
     // This endpoint is a current vault snapshot. It exposes each vault strategy's
     // current interestPerSecond and interestFee, plus curator-configured reward
@@ -59,7 +58,6 @@ const fetch = async (options: FetchOptions) => {
         const vaults = response.lendVaults ?? [];
         allVaults.push(...vaults);
         total = response.total ?? allVaults.length;
-        console.dir(vaults, { depth: null })
         if (vaults.length < PAGE_SIZE) break; // no more pages
         page++;
         await sleep(3000);

--- a/fees/loopscale/index.ts
+++ b/fees/loopscale/index.ts
@@ -44,13 +44,25 @@ const fetch = async (options: FetchOptions) => {
   // This endpoint is a current vault snapshot. It exposes each vault strategy's
   // current interestPerSecond and interestFee, plus curator-configured reward
   // schedules when includeRewards is enabled.
-  const response: LoopscaleVaultResponse = await httpPost(API_URL, {
-    page: 0,
-    pageSize: 50,
-    includeRewards: true,
-  });
+  const PAGE_SIZE = 50;
+  const allVaults: LoopscaleVaultResponse["lendVaults"] = [];
+  let page = 0;
+  let total = Infinity;
 
-  response.lendVaults.forEach(({ vaultRewardsSchedules, vaultStrategy }) => {
+  while (allVaults.length < total) {
+    const response: LoopscaleVaultResponse = await httpPost(API_URL, {
+      page,
+      pageSize: PAGE_SIZE,
+      includeRewards: true,
+    });
+    const vaults = response.lendVaults ?? [];
+    allVaults.push(...vaults);
+    total = response.total ?? allVaults.length;
+    if (vaults.length < PAGE_SIZE) break; // no more pages
+    page++;
+  }
+
+  allVaults.forEach(({ vaultRewardsSchedules, vaultStrategy }) => {
     const strategy = vaultStrategy?.strategy;
     if (strategy && !strategy.closed && strategy.principalMint) {
       // Loopscale vault yield is generated from borrower interest. interestFee


### PR DESCRIPTION

Fixes #5212

https://defillama.com/protocol/loopscale

## Summary

Adds a new Loopscale fees adapter for Solana.

## Methodology

- Uses Loopscale's current lending vault API snapshot.
- Counts daily borrower interest from active vault strategies as `dailyFees`.
- Splits borrower interest into:
  - `dailyRevenue` / `dailyProtocolRevenue`: curator/manager interest fee share
  - `dailySupplySideRevenue`: remaining interest flowing back to vault depositors
- Counts active curator-funded vault reward emissions as supplier yield in `dailyFees` and `dailySupplySideRevenue`.
- Marks the adapter `runAtCurrTime: true` because the source API is a current snapshot / daily run-rate source, not a historical fee endpoint.
