### PR TITLE
Add saturn protocol fees and revenue adapter

### DIFF
--- a/fees/saturn-protocol/index.ts
+++ b/fees/saturn-protocol/index.ts
@@ -1,0 +1,110 @@
+import { Adapter, FetchOptions } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import { METRIC } from "../../helpers/metrics";
+
+const USDAT = "0x23238f20b894f29041f48D88eE91131C395Aaa71";
+const sUSDat = "0xD166337499E176bbC38a1FBd113Ab144e5bd2Df7";
+const STRC_ORACLE = "0x5f7eCD0D045c393da6cb6c933c671AC305A871BF";
+const BPS = 10000n;
+const PERFORMANCE_FEE_BPS = 1000n;
+
+// Sources:
+// - USDat / sUSDat docs: https://saturncredit.gitbook.io/saturn-docs/solution
+// - Fee and reserve docs: https://saturncredit.gitbook.io/saturn-docs/operations-and-governance/protocol-fee-and-risk-reserve
+// - Verified contracts: https://etherscan.io/address/0xD166337499E176bbC38a1FBd113Ab144e5bd2Df7#code
+// - M0 JMI yield model: https://docs.m0.org/build/models/treasury/jmi/overview/
+const Event = {
+  Deposit: "event Deposit(address indexed sender,address indexed owner,uint256 assets,uint256 shares)",
+  RewardsReceived: "event RewardsReceived(uint256 strcAmount,uint256 amount)",
+  YieldClaimed: "event YieldClaimed(uint256 amount)",
+};
+const ABI = {
+  depositFeeBps: "uint256:depositFeeBps",
+  getPrice: "function getPrice() view returns (uint256 price, uint8 priceDecimals)",
+};
+
+const fetch = async (options: FetchOptions) => {
+  const dailyFees = options.createBalances();
+  const dailyUserFees = options.createBalances();
+  const dailyRevenue = options.createBalances();
+  const dailyProtocolRevenue = options.createBalances();
+  const dailySupplySideRevenue = options.createBalances();
+
+  const depositLogs = await options.getLogs({ target: sUSDat, eventAbi: Event.Deposit });
+  const rewardLogs = await options.getLogs({ target: sUSDat, eventAbi: Event.RewardsReceived });
+  const usdatYieldLogs = await options.getLogs({ target: USDAT, eventAbi: Event.YieldClaimed });
+
+  if (depositLogs.length) {
+    const feeBpsRaw = await options.api.call({ target: sUSDat, abi: ABI.depositFeeBps });
+    const feeBps = BigInt(feeBpsRaw);
+    if (feeBps) {
+      depositLogs.forEach((log: any) => {
+        // Deposit.assets is net of fees, so gross up the net amount to recover the deposit fee.
+        const denominator = BPS - feeBps;
+        const fee = (BigInt(log.assets) * feeBps + denominator - 1n) / denominator;
+        dailyFees.add(USDAT, fee, METRIC.DEPOSIT_WITHDRAW_FEES);
+        dailyUserFees.add(USDAT, fee, METRIC.DEPOSIT_WITHDRAW_FEES);
+        dailyRevenue.add(USDAT, fee, METRIC.DEPOSIT_WITHDRAW_FEES);
+        dailyProtocolRevenue.add(USDAT, fee, METRIC.DEPOSIT_WITHDRAW_FEES);
+      });
+    }
+  }
+
+  const price = await options.api.call({ target: STRC_ORACLE, abi: ABI.getPrice });
+  const strcPrice = BigInt((price as any).price ?? (price as any)[0]);
+  const priceDecimals = BigInt((price as any).priceDecimals ?? (price as any)[1]);
+  rewardLogs.forEach((log: any) => {
+    // RewardsReceived is the amount received by sUSDat holders; gross up to include Saturn's 10% fee.
+    const amount = BigInt(log.strcAmount) * strcPrice / 10n ** priceDecimals;
+    const protocolFee = amount * PERFORMANCE_FEE_BPS / (BPS - PERFORMANCE_FEE_BPS);
+    dailyFees.add(USDAT, amount + protocolFee, METRIC.ASSETS_YIELDS);
+    dailyRevenue.add(USDAT, protocolFee, METRIC.PERFORMANCE_FEES);
+    dailyProtocolRevenue.add(USDAT, protocolFee, METRIC.PERFORMANCE_FEES);
+    dailySupplySideRevenue.add(USDAT, amount, METRIC.ASSETS_YIELDS);
+  });
+
+  usdatYieldLogs.forEach((log: any) => {
+    // USDat reserve yield is minted to Saturn's yield recipient by the M0 JMI YieldToOne model.
+    dailyFees.add(USDAT, log.amount, METRIC.ASSETS_YIELDS);
+    dailyRevenue.add(USDAT, log.amount, METRIC.ASSETS_YIELDS);
+    dailyProtocolRevenue.add(USDAT, log.amount, METRIC.ASSETS_YIELDS);
+  });
+
+  return { dailyFees, dailyUserFees, dailyRevenue, dailyProtocolRevenue, dailySupplySideRevenue };
+};
+
+const adapter: Adapter = {
+  version: 2,
+  pullHourly: true,
+  chains: [CHAIN.ETHEREUM],
+  start: "2026-03-20",
+  fetch,
+  methodology: {
+    Fees: "Fees include any sUSDat deposit fees, rewards added to the sUSDat vault, and USDat reserve yield claimed by Saturn.",
+    UserFees: "Users may pay a fee when depositing USDat into sUSDat.",
+    Revenue: "Saturn earns sUSDat deposit fees, USDat reserve yield, and 10% of sUSDat STRC rewards.",
+    ProtocolRevenue: "Saturn earns sUSDat deposit fees, USDat reserve yield, and 10% of sUSDat STRC rewards.",
+    SupplySideRevenue: "sUSDat holders earn the STRC rewards received by the vault as the value of each sUSDat share increases.",
+  },
+  breakdownMethodology: {
+    Fees: {
+      [METRIC.DEPOSIT_WITHDRAW_FEES]: "Fees paid when users deposit USDat into sUSDat.",
+      [METRIC.ASSETS_YIELDS]: "Yield from STRC rewards added to sUSDat and from USDat reserves claimed by Saturn.",
+    },
+    Revenue: {
+      [METRIC.DEPOSIT_WITHDRAW_FEES]: "Deposit fees kept by Saturn.",
+      [METRIC.ASSETS_YIELDS]: "USDat reserve yield claimed by Saturn.",
+      [METRIC.PERFORMANCE_FEES]: "Saturn's 10% fee on gross sUSDat STRC rewards.",
+    },
+    ProtocolRevenue: {
+      [METRIC.DEPOSIT_WITHDRAW_FEES]: "Deposit fees kept by Saturn.",
+      [METRIC.ASSETS_YIELDS]: "USDat reserve yield claimed by Saturn.",
+      [METRIC.PERFORMANCE_FEES]: "Saturn's 10% fee on gross sUSDat STRC rewards.",
+    },
+    SupplySideRevenue: {
+      [METRIC.ASSETS_YIELDS]: "STRC rewards received by the vault and earned by sUSDat holders through a higher vault share price.",
+    },
+  },
+};
+
+export default adapter;

--- a/fees/saturn-protocol/index.ts
+++ b/fees/saturn-protocol/index.ts
@@ -77,7 +77,7 @@ const adapter: Adapter = {
   version: 2,
   pullHourly: true,
   chains: [CHAIN.ETHEREUM],
-  start: "2026-03-20",
+  start: "2026-03-10",
   fetch,
   methodology: {
     Fees: "Fees include any sUSDat deposit fees, rewards added to the sUSDat vault, and USDat reserve yield claimed by Saturn.",

--- a/fees/saturn-protocol/index.ts
+++ b/fees/saturn-protocol/index.ts
@@ -4,9 +4,9 @@ import { METRIC } from "../../helpers/metrics";
 
 const USDAT = "0x23238f20b894f29041f48D88eE91131C395Aaa71";
 const sUSDat = "0xD166337499E176bbC38a1FBd113Ab144e5bd2Df7";
-const STRC_ORACLE = "0x5f7eCD0D045c393da6cb6c933c671AC305A871BF";
-const BPS = 10000n;
-const PERFORMANCE_FEE_BPS = 1000n;
+const BPS = 10000;
+const PERFORMANCE_FEE_BPS = 1000;
+const sUSDatDecimals = 18;
 
 // Sources:
 // - USDat / sUSDat docs: https://saturncredit.gitbook.io/saturn-docs/solution
@@ -14,97 +14,101 @@ const PERFORMANCE_FEE_BPS = 1000n;
 // - Verified contracts: https://etherscan.io/address/0xD166337499E176bbC38a1FBd113Ab144e5bd2Df7#code
 // - M0 JMI yield model: https://docs.m0.org/build/models/treasury/jmi/overview/
 const Event = {
-  Deposit: "event Deposit(address indexed sender,address indexed owner,uint256 assets,uint256 shares)",
-  RewardsReceived: "event RewardsReceived(uint256 strcAmount,uint256 amount)",
-  YieldClaimed: "event YieldClaimed(uint256 amount)",
+    Deposit: "event Deposit(address indexed sender,address indexed owner,uint256 assets,uint256 shares)",
+    RewardsReceived: "event RewardsReceived(uint256 strcAmount,uint256 amount)",
+    YieldClaimed: "event YieldClaimed(uint256 amount)",
 };
 const ABI = {
-  depositFeeBps: "uint256:depositFeeBps",
-  getPrice: "function getPrice() view returns (uint256 price, uint8 priceDecimals)",
+    depositFeeBps: "uint256:depositFeeBps",
+    getPrice: "function getPrice() view returns (uint256 price, uint8 priceDecimals)",
 };
 
 const fetch = async (options: FetchOptions) => {
-  const dailyFees = options.createBalances();
-  const dailyUserFees = options.createBalances();
-  const dailyRevenue = options.createBalances();
-  const dailyProtocolRevenue = options.createBalances();
-  const dailySupplySideRevenue = options.createBalances();
+    const dailyRevenue = options.createBalances();
+    const dailySupplySideRevenue = options.createBalances();
 
-  const depositLogs = await options.getLogs({ target: sUSDat, eventAbi: Event.Deposit });
-  const rewardLogs = await options.getLogs({ target: sUSDat, eventAbi: Event.RewardsReceived });
-  const usdatYieldLogs = await options.getLogs({ target: USDAT, eventAbi: Event.YieldClaimed });
+    const depositLogs = await options.getLogs({ target: sUSDat, eventAbi: Event.Deposit });
 
-  if (depositLogs.length) {
-    const feeBpsRaw = await options.api.call({ target: sUSDat, abi: ABI.depositFeeBps });
-    const feeBps = BigInt(feeBpsRaw);
-    if (feeBps) {
-      depositLogs.forEach((log: any) => {
-        // Deposit.assets is net of fees, so gross up the net amount to recover the deposit fee.
-        const denominator = BPS - feeBps;
-        const fee = (BigInt(log.assets) * feeBps + denominator - 1n) / denominator;
-        dailyFees.add(USDAT, fee, METRIC.DEPOSIT_WITHDRAW_FEES);
-        dailyUserFees.add(USDAT, fee, METRIC.DEPOSIT_WITHDRAW_FEES);
-        dailyRevenue.add(USDAT, fee, METRIC.DEPOSIT_WITHDRAW_FEES);
-        dailyProtocolRevenue.add(USDAT, fee, METRIC.DEPOSIT_WITHDRAW_FEES);
-      });
+    if (depositLogs.length) {
+        const feeBps = await options.api.call({ target: sUSDat, abi: ABI.depositFeeBps });
+        if (feeBps) {
+            depositLogs.forEach((log: any) => {
+                // Deposit.assets is net of fees, so gross up the net amount to recover the deposit fee.
+                const denominator = BPS - feeBps;
+                const fee = Number(log.assets) * feeBps / denominator;
+                dailyRevenue.add(USDAT, fee, METRIC.DEPOSIT_WITHDRAW_FEES);
+            });
+        }
     }
-  }
 
-  const price = await options.api.call({ target: STRC_ORACLE, abi: ABI.getPrice });
-  const strcPrice = BigInt((price as any).price ?? (price as any)[0]);
-  const priceDecimals = BigInt((price as any).priceDecimals ?? (price as any)[1]);
-  rewardLogs.forEach((log: any) => {
-    // RewardsReceived is the amount received by sUSDat holders; gross up to include Saturn's 10% fee.
-    const amount = BigInt(log.strcAmount) * strcPrice / 10n ** priceDecimals;
-    const protocolFee = amount * PERFORMANCE_FEE_BPS / (BPS - PERFORMANCE_FEE_BPS);
-    dailyFees.add(USDAT, amount + protocolFee, METRIC.ASSETS_YIELDS);
-    dailyRevenue.add(USDAT, protocolFee, METRIC.PERFORMANCE_FEES);
-    dailyProtocolRevenue.add(USDAT, protocolFee, METRIC.PERFORMANCE_FEES);
-    dailySupplySideRevenue.add(USDAT, amount, METRIC.ASSETS_YIELDS);
-  });
+    const [priceBefore, priceAfter, totalSupply] = await Promise.all([
+        options.fromApi.call({
+            target: sUSDat,
+            abi: 'function convertToAssets(uint256 shares) external view returns (uint256)',
+            params: ['1000000000000000000'],
+        }),
+        options.toApi.call({
+            target: sUSDat,
+            abi: 'function convertToAssets(uint256 shares) external view returns (uint256)',
+            params: ['1000000000000000000'],
+        }),
+        options.api.call({
+            target: sUSDat,
+            abi: 'uint256:totalSupply',
+        }),
+    ])
 
-  usdatYieldLogs.forEach((log: any) => {
-    // USDat reserve yield is minted to Saturn's yield recipient by the M0 JMI YieldToOne model.
-    dailyFees.add(USDAT, log.amount, METRIC.ASSETS_YIELDS);
-    dailyRevenue.add(USDAT, log.amount, METRIC.ASSETS_YIELDS);
-    dailyProtocolRevenue.add(USDAT, log.amount, METRIC.ASSETS_YIELDS);
-  });
+    const yieldForPeriod = (priceAfter - priceBefore) * totalSupply / 10 ** sUSDatDecimals;
+    const performanceFee = yieldForPeriod * PERFORMANCE_FEE_BPS / (BPS - PERFORMANCE_FEE_BPS);
 
-  return { dailyFees, dailyUserFees, dailyRevenue, dailyProtocolRevenue, dailySupplySideRevenue };
+    dailyRevenue.add(USDAT, performanceFee, METRIC.PERFORMANCE_FEES);
+    dailySupplySideRevenue.add(USDAT, yieldForPeriod, METRIC.ASSETS_YIELDS);
+
+    const dailyFees = dailyRevenue.clone();
+    dailyFees.add(dailySupplySideRevenue);
+
+    return {
+        dailyFees,
+        dailyRevenue,
+        dailySupplySideRevenue,
+        dailyProtocolRevenue: dailyRevenue,
+    };
+};
+
+const methodology = {
+    Fees: "Fees include sUSDat deposit fees if any, asset yields from sUSDat price appreciation and 10% perfomance fee on the yield generated by sUSDat",
+    Revenue: "Saturn earns sUSDat deposit fees, and 10% performance fee on the yield generated by sUSDat.",
+    ProtocolRevenue: "Saturn earns sUSDat deposit fees, and 10% performance fee on the yield generated by sUSDat.",
+    SupplySideRevenue: "Yield generated by sUSDat price appreciation.",
+};
+
+const breakdownMethodology = {
+    Fees: {
+        [METRIC.DEPOSIT_WITHDRAW_FEES]: "Fees paid when users deposit USDat into sUSDat.",
+        [METRIC.ASSETS_YIELDS]: "Yield generated by sUSDat price appreciation.",
+        [METRIC.PERFORMANCE_FEES]: "10% performance fee on the yield generated by sUSDat.",
+    },
+    Revenue: {
+        [METRIC.DEPOSIT_WITHDRAW_FEES]: "Deposit fees kept by Saturn.",
+        [METRIC.PERFORMANCE_FEES]: "10% performance fee on the yield generated by sUSDat.",
+    },
+    ProtocolRevenue: {
+        [METRIC.DEPOSIT_WITHDRAW_FEES]: "Deposit fees kept by Saturn.",
+        [METRIC.PERFORMANCE_FEES]: "10% performance fee on the yield generated by sUSDat.",
+    },
+    SupplySideRevenue: {
+        [METRIC.ASSETS_YIELDS]: "Yield generated by sUSDat price appreciation.",
+    },
 };
 
 const adapter: Adapter = {
-  version: 2,
-  pullHourly: true,
-  chains: [CHAIN.ETHEREUM],
-  start: "2026-03-10",
-  fetch,
-  methodology: {
-    Fees: "Fees include any sUSDat deposit fees, rewards added to the sUSDat vault, and USDat reserve yield claimed by Saturn.",
-    UserFees: "Users may pay a fee when depositing USDat into sUSDat.",
-    Revenue: "Saturn earns sUSDat deposit fees, USDat reserve yield, and 10% of sUSDat STRC rewards.",
-    ProtocolRevenue: "Saturn earns sUSDat deposit fees, USDat reserve yield, and 10% of sUSDat STRC rewards.",
-    SupplySideRevenue: "sUSDat holders earn the STRC rewards received by the vault as the value of each sUSDat share increases.",
-  },
-  breakdownMethodology: {
-    Fees: {
-      [METRIC.DEPOSIT_WITHDRAW_FEES]: "Fees paid when users deposit USDat into sUSDat.",
-      [METRIC.ASSETS_YIELDS]: "Yield from STRC rewards added to sUSDat and from USDat reserves claimed by Saturn.",
-    },
-    Revenue: {
-      [METRIC.DEPOSIT_WITHDRAW_FEES]: "Deposit fees kept by Saturn.",
-      [METRIC.ASSETS_YIELDS]: "USDat reserve yield claimed by Saturn.",
-      [METRIC.PERFORMANCE_FEES]: "Saturn's 10% fee on gross sUSDat STRC rewards.",
-    },
-    ProtocolRevenue: {
-      [METRIC.DEPOSIT_WITHDRAW_FEES]: "Deposit fees kept by Saturn.",
-      [METRIC.ASSETS_YIELDS]: "USDat reserve yield claimed by Saturn.",
-      [METRIC.PERFORMANCE_FEES]: "Saturn's 10% fee on gross sUSDat STRC rewards.",
-    },
-    SupplySideRevenue: {
-      [METRIC.ASSETS_YIELDS]: "STRC rewards received by the vault and earned by sUSDat holders through a higher vault share price.",
-    },
-  },
+    version: 2,
+    pullHourly: true,
+    chains: [CHAIN.ETHEREUM],
+    start: "2026-03-10",
+    fetch,
+    methodology,
+    breakdownMethodology,
 };
 
 export default adapter;

--- a/fees/saturn-protocol/index.ts
+++ b/fees/saturn-protocol/index.ts
@@ -109,6 +109,7 @@ const adapter: Adapter = {
     fetch,
     methodology,
     breakdownMethodology,
+    allowNegativeValue: true,
 };
 
 export default adapter;


### PR DESCRIPTION
Tracks fees and revenue for saturn-credit https://defillama.com/protocol/saturn

## Summary

Adds the Saturn Protocol fee adapter on Ethereum.

Tracks:
- sUSDat deposit fees, reconstructed from ERC4626 `Deposit.assets` and `depositFeeBps`
- sUSDat STRC rewards, valued through the STRC oracle
- Saturn’s 10% performance fee on gross sUSDat STRC rewards
- USDat reserve yield claimed by Saturn through `YieldClaimed`

## Methodology

sUSDat deposit fees are calculated from the net ERC4626 deposit amount because `Deposit.assets` is emitted after fees.

sUSDat STRC rewards are treated as the amount received by vault holders. The adapter values those rewards using the STRC oracle, then grosses them up to account for Saturn’s 10% performance fee.

USDat reserve yield is counted from the `YieldClaimed(uint256 amount)` event on the USDat contract and attributed to protocol revenue.
