### PR TITLE
Add GRIDer adapter

### DIFF
--- a/factory/hyperliquid.ts
+++ b/factory/hyperliquid.ts
@@ -197,7 +197,18 @@ const builderConfigs: Record<string, BuilderConfig> = {
   "supurr-perps": { addresses: ["0x36be02a397e969e010ccbd7333f4169f66b8989f"], start: "2025-09-19" },
   "unigox-perps": { addresses: ["0xf8ead1ecc72dfbb87cdd7bf78450f7cf68d046a3"], start: "2025-09-01" },
   "uxuy-perps": { addresses: ["0x2e266a0f40e9f5bca48f5df1686aab10b1b68ec8"], start: "2025-10-20" },
-  "wunder-perps": { addresses: ["0x75982eb8b734b24b653b39e308489a428041f162"], start: "2025-10-19" }
+  "wunder-perps": { addresses: ["0x75982eb8b734b24b653b39e308489a428041f162"], start: "2025-10-19" },
+  "grider": {
+    addresses: ["0x0176337c97bb884b8ac4be2276a5c779ab1156b9"],
+    start: "2026-03-08",
+    methodology: {
+      Fees: "0.008% builder code fees paid by users on Hyperliquid Perps trades opened via GRIDer's grid trading bots.",
+      Revenue: "0.008% builder code fees collected by GRIDer from Hyperliquid Perps grid trading.",
+      ProtocolRevenue: "0.008% builder code fees collected by GRIDer from Hyperliquid Perps grid trading.",
+      HoldersRevenue: "No token, no fees distributed to holders",
+    },
+    extraReturnFields: { dailyHoldersRevenue: "0" },
+  }
 };
 
 // Builder fees configs: protocol name -> config
@@ -478,6 +489,17 @@ const builderFeesConfigs: Record<string, BuilderConfig> = {
       Revenue: "builder code revenue from Hyperliquid Perps Trades.",
       ProtocolRevenue: "builder code revenue from Hyperliquid Perps Trades.",
     },
+  },
+  "grider": {
+    addresses: ["0x0176337c97bb884b8ac4be2276a5c779ab1156b9"],
+    start: "2026-03-08",
+    methodology: {
+      Fees: "0.008% builder code fees paid by users on Hyperliquid Perps trades opened via GRIDer's grid trading bots.",
+      Revenue: "0.008% builder code fees collected by GRIDer from Hyperliquid Perps grid trading.",
+      ProtocolRevenue: "0.008% builder code fees collected by GRIDer from Hyperliquid Perps grid trading.",
+      HoldersRevenue: "No token, no fees distributed to holders",
+    },
+    extraReturnFields: { dailyHoldersRevenue: "0" },
   }
 };
 

--- a/factory/hyperliquid.ts
+++ b/factory/hyperliquid.ts
@@ -198,16 +198,13 @@ const builderConfigs: Record<string, BuilderConfig> = {
   "unigox-perps": { addresses: ["0xf8ead1ecc72dfbb87cdd7bf78450f7cf68d046a3"], start: "2025-09-01" },
   "uxuy-perps": { addresses: ["0x2e266a0f40e9f5bca48f5df1686aab10b1b68ec8"], start: "2025-10-20" },
   "wunder-perps": { addresses: ["0x75982eb8b734b24b653b39e308489a428041f162"], start: "2025-10-19" },
-  "grider": {
-    addresses: ["0x0176337c97bb884b8ac4be2276a5c779ab1156b9"],
-    start: "2026-03-08",
+  "grider-perps": {
+    addresses: ["0x0176337c97bb884b8ac4be2276a5c779ab1156b9"], start: "2026-03-08",
     methodology: {
       Fees: "0.008% builder code fees paid by users on Hyperliquid Perps trades opened via GRIDer's grid trading bots.",
       Revenue: "0.008% builder code fees collected by GRIDer from Hyperliquid Perps grid trading.",
       ProtocolRevenue: "0.008% builder code fees collected by GRIDer from Hyperliquid Perps grid trading.",
-      HoldersRevenue: "No token, no fees distributed to holders",
     },
-    extraReturnFields: { dailyHoldersRevenue: "0" },
   }
 };
 
@@ -489,17 +486,6 @@ const builderFeesConfigs: Record<string, BuilderConfig> = {
       Revenue: "builder code revenue from Hyperliquid Perps Trades.",
       ProtocolRevenue: "builder code revenue from Hyperliquid Perps Trades.",
     },
-  },
-  "grider": {
-    addresses: ["0x0176337c97bb884b8ac4be2276a5c779ab1156b9"],
-    start: "2026-03-08",
-    methodology: {
-      Fees: "0.008% builder code fees paid by users on Hyperliquid Perps trades opened via GRIDer's grid trading bots.",
-      Revenue: "0.008% builder code fees collected by GRIDer from Hyperliquid Perps grid trading.",
-      ProtocolRevenue: "0.008% builder code fees collected by GRIDer from Hyperliquid Perps grid trading.",
-      HoldersRevenue: "No token, no fees distributed to holders",
-    },
-    extraReturnFields: { dailyHoldersRevenue: "0" },
   }
 };
 


### PR DESCRIPTION
Adds GRIDer to the Hyperliquid builder code factory.

## What is GRIDer

GRIDer is a non-custodial grid trading platform on Hyperliquid Perps. Users connect their wallet, approve a trading-only agent wallet, and GRIDer runs grid strategies 24/7. GRIDer earns the standard 0.008% Hyperliquid builder code fee on perps trades opened through its grids.

- Website: https://grider.xyz
- App: https://app.grider.xyz
- Twitter/X: https://x.com/griderxyz
- Discord: https://discord.gg/zVnw2tPbmZ
- Hypurr Collective: https://www.hypurr.co/ecosystem-projects/grider

## What this PR adds

A `"grider"` entry in both `builderConfigs` (dexs/volume) and `builderFeesConfigs` (fees/revenue) inside `factory/hyperliquid.ts`.

- Builder address: `0x0176337c97bb884b8ac4be2276a5c779ab1156b9`
- First fills observed: `2026-03-08`
- Builder fee rate: `0.008%`
- No token, no holder distribution -> `dailyHoldersRevenue: "0"`

## Verification

Verified locally:

```
$ pnpm test fees grider
Backfill start time: 8/3/2026
Daily volume: 36.81 k
Daily fees: 2.95
Daily revenue: 2.95
Daily protocol revenue: 2.95
Daily holders revenue: 0.00

$ pnpm ts-check
(exit 0)
```

Fee math sanity check: 36.81k * 0.008% = $2.94, matches reported $2.95.
