### PR TITLE
fix(pyth-pro): add PYTH token payment support per CO-PIP-104

### DIFF
--- a/fees/pyth-pro/index.ts
+++ b/fees/pyth-pro/index.ts
@@ -13,34 +13,48 @@ import { queryDuneSql } from "../../helpers/dune";
 // Dune's tokens_solana.transfers uses owner addresses in from_owner/to_owner fields
 const DOURO_LABS_WALLET = "2ru31e9g8RF2mSSNgTQ11QMb166NE6LJccmBqGJM8xxy";
 const PYTH_DAO_WALLET = "Gx4MBPb1vqZLJajZmsKLg8fGw9ErhoKsR8LeKcCKFyak";
+
+// Token mints
 const USDC_MINT = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
+const PYTH_MINT = "HZ1JovNiVvGrGNiiYvEozEVgZ58xaU3RKwX8eACQBCt3";
 
 const fetch = async (_t: any, _a: any, options: FetchOptions) => {
   const dailyFees = options.createBalances();
 
-  // Query USDC transfers from Douro Labs wallet to Pyth DAO wallet
+  // Query both USDC and PYTH transfers from Douro Labs wallet to Pyth DAO wallet
+  // Per CO-PIP-104, Douro Labs can pay in PYTH tokens and/or USDC
+  // April 2026 was the first PYTH-only distribution
   const query = `
     SELECT
+      token_mint_address,
       SUM(amount) as total_amount
     FROM tokens_solana.transfers
     WHERE block_time BETWEEN FROM_UNIXTIME(${options.startTimestamp}) AND FROM_UNIXTIME(${options.endTimestamp})
-      AND token_mint_address = '${USDC_MINT}'
+      AND token_mint_address IN ('${USDC_MINT}', '${PYTH_MINT}')
       AND from_owner = '${DOURO_LABS_WALLET}'
       AND to_owner = '${PYTH_DAO_WALLET}'
+    GROUP BY token_mint_address
   `;
 
   const res = await queryDuneSql(options, query);
-  const amount = res[0]?.total_amount || 0;
 
-  if (amount > 0) {
-    // USDC has 6 decimals
-    dailyFees.add(ADDRESSES.solana.USDC, amount);
+  for (const row of res) {
+    const amount = row?.total_amount || 0;
+    if (amount > 0) {
+      if (row.token_mint_address === USDC_MINT) {
+        // USDC has 6 decimals
+        dailyFees.add(ADDRESSES.solana.USDC, amount);
+      } else if (row.token_mint_address === PYTH_MINT) {
+        // PYTH has 6 decimals
+        dailyFees.addCGToken("pyth-network", amount / 1e6);
+      }
+    }
   }
 
   // Total fees = revenue / 0.6 (since Douro keeps 40%)
   // But we only track what reaches the DAO as revenue
   return {
-    dailyFees: dailyFees, // We report received amount as fees
+    dailyFees: dailyFees,
     dailyRevenue: dailyFees,
   };
 };
@@ -52,7 +66,7 @@ const adapter: SimpleAdapter = {
   start: "2025-01-01",
   dependencies: [Dependencies.DUNE],
   methodology: {
-    Fees: "USDC payments from Douro Labs (Pyth Pro data distributor) to Pyth DAO",
+    Fees: "USDC and/or PYTH payments from Douro Labs (Pyth Pro data distributor) to Pyth DAO. Per CO-PIP-104, payments can be made in PYTH tokens, USDC, or a combination.",
     Revenue:
       "Pyth DAO receives 60% of Pyth Pro subscription revenue from Douro Labs",
   },

--- a/fees/pyth-pro/index.ts
+++ b/fees/pyth-pro/index.ts
@@ -1,10 +1,5 @@
-import {
-  Dependencies,
-  FetchOptions,
-  SimpleAdapter,
-} from "../../adapters/types";
+import { Dependencies, FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
-import ADDRESSES from "../../helpers/coreAssets.json";
 import { queryDuneSql } from "../../helpers/dune";
 
 // Douro Labs is the official Pyth Pro data distributor
@@ -13,48 +8,35 @@ import { queryDuneSql } from "../../helpers/dune";
 // Dune's tokens_solana.transfers uses owner addresses in from_owner/to_owner fields
 const DOURO_LABS_WALLET = "2ru31e9g8RF2mSSNgTQ11QMb166NE6LJccmBqGJM8xxy";
 const PYTH_DAO_WALLET = "Gx4MBPb1vqZLJajZmsKLg8fGw9ErhoKsR8LeKcCKFyak";
-
-// Token mints
 const USDC_MINT = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
 const PYTH_MINT = "HZ1JovNiVvGrGNiiYvEozEVgZ58xaU3RKwX8eACQBCt3";
 
 const fetch = async (_t: any, _a: any, options: FetchOptions) => {
   const dailyFees = options.createBalances();
 
-  // Query both USDC and PYTH transfers from Douro Labs wallet to Pyth DAO wallet
-  // Per CO-PIP-104, Douro Labs can pay in PYTH tokens and/or USDC
-  // April 2026 was the first PYTH-only distribution
+  // Query USDC transfers from Douro Labs wallet to Pyth DAO wallet
   const query = `
     SELECT
       token_mint_address,
-      SUM(amount) as total_amount
+      COALESCE(SUM(amount), 0) as total_amount
     FROM tokens_solana.transfers
     WHERE block_time BETWEEN FROM_UNIXTIME(${options.startTimestamp}) AND FROM_UNIXTIME(${options.endTimestamp})
       AND token_mint_address IN ('${USDC_MINT}', '${PYTH_MINT}')
       AND from_owner = '${DOURO_LABS_WALLET}'
       AND to_owner = '${PYTH_DAO_WALLET}'
-    GROUP BY token_mint_address
+      GROUP BY token_mint_address
   `;
 
   const res = await queryDuneSql(options, query);
 
-  for (const row of res) {
-    const amount = row?.total_amount || 0;
-    if (amount > 0) {
-      if (row.token_mint_address === USDC_MINT) {
-        // USDC has 6 decimals
-        dailyFees.add(ADDRESSES.solana.USDC, amount);
-      } else if (row.token_mint_address === PYTH_MINT) {
-        // PYTH has 6 decimals
-        dailyFees.addCGToken("pyth-network", amount / 1e6);
-      }
-    }
+  for (const tokenFees of res) {
+    dailyFees.add(tokenFees.token_mint_address, tokenFees.total_amount);
   }
 
   // Total fees = revenue / 0.6 (since Douro keeps 40%)
   // But we only track what reaches the DAO as revenue
   return {
-    dailyFees: dailyFees,
+    dailyFees: dailyFees, // We report received amount as fees
     dailyRevenue: dailyFees,
   };
 };
@@ -65,10 +47,10 @@ const adapter: SimpleAdapter = {
   chains: [CHAIN.SOLANA],
   start: "2025-01-01",
   dependencies: [Dependencies.DUNE],
+  isExpensiveAdapter: true,
   methodology: {
-    Fees: "USDC and/or PYTH payments from Douro Labs (Pyth Pro data distributor) to Pyth DAO. Per CO-PIP-104, payments can be made in PYTH tokens, USDC, or a combination.",
-    Revenue:
-      "Pyth DAO receives 60% of Pyth Pro subscription revenue from Douro Labs",
+    Fees: "60% of Pyth Pro subscription revenue from Douro Labs, paid in USDC and PYTH",
+    Revenue: "60% of Pyth Pro subscription revenue from Douro Labs, paid in USDC and PYTH",
   },
 };
 


### PR DESCRIPTION
## Summary

Starting April 2026, Douro Labs can pay Pyth DAO in **PYTH tokens and/or USDC** per governance proposal [CO-PIP-104](https://forum.pyth.network/t/passed-co-pip-104-pyth-pro-governance-payment-currency-flexibility/2480).

The current adapter only tracks USDC transfers, missing PYTH token payments entirely.

## Changes

- Add PYTH token mint constant
- Modify Dune query to track both USDC and PYTH transfers
- Use `addCGToken('pyth-network', ...)` for PYTH to ensure proper USD conversion
- Update methodology to reflect the payment flexibility

## Impact

April 2026 distribution was **5,059,107 PYTH ($229,132 USD)** — the first PYTH-only payment. This was not captured by the current adapter.

Going forward, distributions may be:
- PYTH only
- USDC only
- A combination of both

## References

- [CO-PIP-104: Payment Currency Flexibility](https://forum.pyth.network/t/passed-co-pip-104-pyth-pro-governance-payment-currency-flexibility/2480)
- [April 2026 Douro Labs Report](https://forum.pyth.network/t/pyth-pro-douro-labs-report-april-2026/2508)
- [April 2026 Transaction (5,059,107 PYTH)](https://solscan.io/tx/2mP8RsJx6WufLrMEoLZtxwQdZEKxPVuLDuWq7wQzxxXRiJzx1Y81MottZStGhL1EjS8LuMgJU6fUUypLjgrCuQ81)