### PR TITLE
fix: STON - include referral swaps in fees

### DIFF
--- a/fees/ston/index.ts
+++ b/fees/ston/index.ts
@@ -5,6 +5,7 @@ import fetchURL from "../../utils/fetchURL";
 import { FetchOptions, SimpleAdapter } from "../../adapters/types";
 
 const endpoint = "https://api.ston.fi/v1/stats/operations?";
+const swapExitCodes = new Set(["swap_ok", "swap_ok_ref"]);
 
 const fetchFees = async (options: FetchOptions) => {
   const pool_list = (await fetchURL("https://api.ston.fi/v1/pools")).pool_list;
@@ -48,7 +49,7 @@ const fetchFees = async (options: FetchOptions) => {
   // go through all operations and calculate fees based on the current prices
   for (const item of res["operations"]) {
     const operation = item.operation;
-    if (operation.success && operation.operation_type == "swap" && operation.exit_code == "swap_ok") {
+    if (operation.success && operation.operation_type == "swap" && swapExitCodes.has(operation.exit_code)) {
       if (operation.fee_asset_address in asset_prices) {
         const price = asset_prices[operation.fee_asset_address];
         total_lp_fees += operation.lp_fee_amount * price;


### PR DESCRIPTION

## Reason/details

This is not a new protocol listing.

This PR updates the existing STON.fi fees adapter to include referral swap operations in fee calculations.

STON.fi exposes referral swaps as successful swap operations with:

- `operation_type = "swap"`
- `success = true`
- `exit_code = "swap_ok_ref"`

These operations include the same fee fields used by the adapter:

- `lp_fee_amount`
- `protocol_fee_amount`
- `referral_fee_amount`
- `fee_asset_address`

Previously the adapter only counted `swap_ok`, which skipped `swap_ok_ref` operations and undercounted fees, including referral fees.

## Change

Adds an explicit allowed exit-code set:

```ts
const swapExitCodes = new Set(["swap_ok", "swap_ok_ref"]);
```
and uses it when counting successful swap operations.

## Tests

- `npm run ts-check -- --pretty false`
- `npm run test -- fees ston 2026-04-23`
