### PR TITLE
Track blend fees/revenue across v1 pools, v2 pools and backstop insurance 

### DIFF
--- a/fees/blend-backstop-v2/index.ts
+++ b/fees/blend-backstop-v2/index.ts
@@ -10,7 +10,7 @@ type BlendBackstopV2Row = {
   backstop_revenue_raw: string | number;
 };
 
-const fetch = async (options: FetchOptions) => {
+const fetch = async (_a: any, _b: any, options: FetchOptions) => {
   const dailyFees = options.createBalances();
   const dailySupplySideRevenue = options.createBalances();
 
@@ -142,7 +142,7 @@ const methodology = {
 };
 
 const adapter: SimpleAdapter = {
-  version: 2,
+  version: 1,
   fetch,
   start: "2025-04-14",
   chains: [CHAIN.STELLAR],

--- a/fees/blend-backstop-v2/index.ts
+++ b/fees/blend-backstop-v2/index.ts
@@ -29,7 +29,7 @@ const fetch = async (options: FetchOptions) => {
       GROUP BY 1
     ),
 
-    parsed AS (
+    reserve_rows AS (
       SELECT DISTINCT
         cd.closed_at,
         cd.ledger_sequence,
@@ -43,8 +43,48 @@ const fetch = async (options: FetchOptions) => {
       JOIN pools p
         ON cd.contract_id = p.pool
       WHERE cd.closed_at < DATE '${options.dateString}' + interval '1' day
-        AND cd.closed_at >= DATE '${options.dateString}' - interval '3' day
         AND json_extract_scalar(json_parse(cd.key_decoded), '$.vec[0].symbol') = 'ResData'
+    ),
+
+    prior_rows AS (
+      SELECT
+        closed_at,
+        ledger_sequence,
+        pool,
+        asset,
+        backstop_credit
+      FROM (
+        SELECT
+          *,
+          ROW_NUMBER() OVER (
+            PARTITION BY pool, asset
+            ORDER BY closed_at DESC, ledger_sequence DESC
+          ) AS rn
+        FROM reserve_rows
+        WHERE closed_at < DATE '${options.dateString}'
+      )
+      WHERE rn = 1
+    ),
+
+    parsed AS (
+      SELECT
+        closed_at,
+        ledger_sequence,
+        pool,
+        asset,
+        backstop_credit
+      FROM reserve_rows
+      WHERE closed_at >= DATE '${options.dateString}'
+
+      UNION ALL
+
+      SELECT
+        closed_at,
+        ledger_sequence,
+        pool,
+        asset,
+        backstop_credit
+      FROM prior_rows
     ),
 
     ordered AS (

--- a/fees/blend-backstop-v2/index.ts
+++ b/fees/blend-backstop-v2/index.ts
@@ -14,6 +14,11 @@ const fetch = async (options: FetchOptions) => {
   const dailyFees = options.createBalances();
   const dailySupplySideRevenue = options.createBalances();
 
+  // Sources:
+  // - v2 backstop PoolBalance keys discover Blend v2 pools.
+  // - Dune stellar.contract_data ResData(asset) snapshots expose backstop_credit.
+  // Backstop earnings are measured as positive backstop_credit growth for each reserve.
+  // User deposits are not counted here because PoolBalance is only used for pool discovery.
   const query = `
     WITH pools AS (
       SELECT

--- a/fees/blend-backstop-v2/index.ts
+++ b/fees/blend-backstop-v2/index.ts
@@ -1,0 +1,117 @@
+import { Dependencies, FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import { queryDuneSql } from "../../helpers/dune";
+import { METRIC } from "../../helpers/metrics";
+
+const V2_BACKSTOP = "CAQQR5SWBXKIGZKPBZDH3KM5GQ5GUTPKB7JAFCINLZBC5WXPJKRG3IM7";
+
+type BlendBackstopV2Row = {
+  asset: string;
+  backstop_revenue_raw: string | number;
+};
+
+const fetch = async (options: FetchOptions) => {
+  const dailyFees = options.createBalances();
+  const dailySupplySideRevenue = options.createBalances();
+
+  const query = `
+    WITH pools AS (
+      SELECT
+        json_extract_scalar(json_parse(cd.key_decoded), '$.vec[1].address') AS pool
+      FROM stellar.contract_data cd
+      WHERE cd.contract_id = '${V2_BACKSTOP}'
+        AND json_extract_scalar(json_parse(cd.key_decoded), '$.vec[0].symbol') = 'PoolBalance'
+      GROUP BY 1
+    ),
+
+    parsed AS (
+      SELECT DISTINCT
+        cd.closed_at,
+        cd.ledger_sequence,
+        cd.contract_id AS pool,
+        json_extract_scalar(json_parse(cd.key_decoded), '$.vec[1].address') AS asset,
+        COALESCE(
+          TRY_CAST(regexp_extract(cd.val_decoded, '"backstop_credit"\\},"val":\\{"i128":"([0-9]+)"', 1) AS DOUBLE),
+          0
+        ) AS backstop_credit
+      FROM stellar.contract_data cd
+      JOIN pools p
+        ON cd.contract_id = p.pool
+      WHERE cd.closed_at < DATE '${options.dateString}' + interval '1' day
+        AND cd.closed_at >= DATE '${options.dateString}' - interval '3' day
+        AND json_extract_scalar(json_parse(cd.key_decoded), '$.vec[0].symbol') = 'ResData'
+    ),
+
+    ordered AS (
+      SELECT
+        *,
+        LAG(backstop_credit) OVER (
+          PARTITION BY pool, asset
+          ORDER BY closed_at, ledger_sequence
+        ) AS prev_backstop_credit
+      FROM parsed
+      WHERE asset IS NOT NULL
+    ),
+
+    daily AS (
+      SELECT
+        DATE(closed_at) AS day,
+        asset,
+        GREATEST(
+          backstop_credit - COALESCE(prev_backstop_credit, backstop_credit),
+          0
+        ) AS backstop_revenue_raw
+      FROM ordered
+    )
+
+    SELECT
+      asset,
+      SUM(backstop_revenue_raw) AS backstop_revenue_raw
+    FROM daily
+    WHERE day = DATE '${options.dateString}'
+    GROUP BY 1
+    HAVING SUM(backstop_revenue_raw) > 0
+  `;
+
+  const rows: BlendBackstopV2Row[] = await queryDuneSql(options, query);
+
+  rows.forEach(({ asset, backstop_revenue_raw }) => {
+    const backstopRevenue = Number(backstop_revenue_raw);
+    dailyFees.add(asset, backstopRevenue, METRIC.BORROW_INTEREST);
+    dailySupplySideRevenue.add(asset, backstopRevenue, "Borrow Interest To Backstop");
+  });
+
+  return {
+    dailyFees,
+    dailySupplySideRevenue,
+    dailyRevenue: 0,
+    dailyProtocolRevenue: 0,
+  };
+};
+
+const methodology = {
+  Fees: "Interest paid by Blend v2 borrowers that goes to backstop depositors.",
+  SupplySideRevenue: "Interest paid to backstop depositors for providing pool insurance.",
+  Revenue: "The Blend protocol does not keep treasury revenue from backstop interest.",
+  ProtocolRevenue: "The Blend protocol does not keep treasury revenue from backstop interest.",
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  fetch,
+  start: "2025-04-14",
+  chains: [CHAIN.STELLAR],
+  dependencies: [Dependencies.DUNE],
+  isExpensiveAdapter: true,
+  methodology,
+  breakdownMethodology: {
+    Fees: {
+      [METRIC.BORROW_INTEREST]: "Borrower interest credited to the v2 backstop, measured from reserve backstop_credit growth.",
+    },
+    SupplySideRevenue: {
+      "Borrow Interest To Backstop": "Borrower interest paid to Blend v2 backstop depositors.",
+    },
+  },
+};
+
+export default adapter;

--- a/fees/blend-pools-v2/index.ts
+++ b/fees/blend-pools-v2/index.ts
@@ -11,7 +11,7 @@ type BlendV2Row = {
   backstop_revenue_raw: string | number;
 };
 
-const fetch = async (options: FetchOptions) => {
+const fetch = async (_a: any, _b: any, options: FetchOptions) => {
   const dailyFees = options.createBalances();
   const dailySupplySideRevenue = options.createBalances();
 
@@ -171,7 +171,7 @@ const methodology = {
 };
 
 const adapter: SimpleAdapter = {
-  version: 2,
+  version: 1,
   fetch,
   start: "2025-04-14",
   chains: [CHAIN.STELLAR],

--- a/fees/blend-pools-v2/index.ts
+++ b/fees/blend-pools-v2/index.ts
@@ -30,7 +30,7 @@ const fetch = async (options: FetchOptions) => {
       GROUP BY 1
     ),
 
-    parsed AS (
+    reserve_rows AS (
       SELECT DISTINCT
         cd.closed_at,
         cd.ledger_sequence,
@@ -46,8 +46,54 @@ const fetch = async (options: FetchOptions) => {
       JOIN pools p
         ON cd.contract_id = p.pool
       WHERE cd.closed_at < DATE '${options.dateString}' + interval '1' day
-        AND cd.closed_at >= DATE '${options.dateString}' - interval '3' day
         AND json_extract_scalar(json_parse(cd.key_decoded), '$.vec[0].symbol') = 'ResData'
+    ),
+
+    prior_rows AS (
+      SELECT
+        closed_at,
+        ledger_sequence,
+        pool,
+        asset,
+        d_rate,
+        d_supply,
+        backstop_credit
+      FROM (
+        SELECT
+          *,
+          ROW_NUMBER() OVER (
+            PARTITION BY pool, asset
+            ORDER BY closed_at DESC, ledger_sequence DESC
+          ) AS rn
+        FROM reserve_rows
+        WHERE closed_at < DATE '${options.dateString}'
+      )
+      WHERE rn = 1
+    ),
+
+    parsed AS (
+      SELECT
+        closed_at,
+        ledger_sequence,
+        pool,
+        asset,
+        d_rate,
+        d_supply,
+        backstop_credit
+      FROM reserve_rows
+      WHERE closed_at >= DATE '${options.dateString}'
+
+      UNION ALL
+
+      SELECT
+        closed_at,
+        ledger_sequence,
+        pool,
+        asset,
+        d_rate,
+        d_supply,
+        backstop_credit
+      FROM prior_rows
     ),
 
     ordered AS (
@@ -91,12 +137,7 @@ const fetch = async (options: FetchOptions) => {
     SELECT
       asset,
       SUM(borrow_interest_raw) AS borrow_interest_raw,
-      SUM(
-        CASE
-          WHEN backstop_revenue_raw <= borrow_interest_raw THEN backstop_revenue_raw
-          ELSE 0
-        END
-      ) AS backstop_revenue_raw
+      SUM(backstop_revenue_raw) AS backstop_revenue_raw
     FROM daily
     WHERE day = DATE '${options.dateString}'
     GROUP BY 1
@@ -107,7 +148,7 @@ const fetch = async (options: FetchOptions) => {
 
   rows.forEach(({ asset, borrow_interest_raw, backstop_revenue_raw }) => {
     const borrowInterest = Number(borrow_interest_raw);
-    const backstopRevenue = Number(backstop_revenue_raw);
+    const backstopRevenue = Math.min(Number(backstop_revenue_raw), borrowInterest);
     const lenderRevenue = Math.max(borrowInterest - backstopRevenue, 0);
 
     dailyFees.add(asset, lenderRevenue, METRIC.BORROW_INTEREST);

--- a/fees/blend-pools-v2/index.ts
+++ b/fees/blend-pools-v2/index.ts
@@ -15,6 +15,11 @@ const fetch = async (options: FetchOptions) => {
   const dailyFees = options.createBalances();
   const dailySupplySideRevenue = options.createBalances();
 
+  // Sources:
+  // - v2 backstop PoolBalance keys discover Blend v2 pools.
+  // - Dune stellar.contract_data ResData(asset) snapshots provide d_rate, d_supply, and backstop_credit.
+  // Borrower interest = previous d_supply * max(current d_rate - previous d_rate, 0) / 1e12.
+  // This adapter reports only the lender share: borrower interest minus backstop_credit growth.
   const query = `
     WITH pools AS (
       SELECT
@@ -137,7 +142,7 @@ const adapter: SimpleAdapter = {
       [METRIC.BORROW_INTEREST]: "Interest paid by borrowers to lenders. It is calculated from debt rate growth, then excludes the portion credited to the backstop.",
     },
     SupplySideRevenue: {
-     "Borrow Interest To Lenders": "Borrower interest paid to users who supplied assets to Blend v2 pools.",
+      "Borrow Interest To Lenders": "Borrower interest paid to users who supplied assets to Blend v2 pools.",
     },
   },
 };

--- a/fees/blend-pools-v2/index.ts
+++ b/fees/blend-pools-v2/index.ts
@@ -1,0 +1,145 @@
+import { Dependencies, FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import { queryDuneSql } from "../../helpers/dune";
+import { METRIC } from "../../helpers/metrics";
+
+const V2_BACKSTOP = "CAQQR5SWBXKIGZKPBZDH3KM5GQ5GUTPKB7JAFCINLZBC5WXPJKRG3IM7";
+
+type BlendV2Row = {
+  asset: string;
+  borrow_interest_raw: string | number;
+  backstop_revenue_raw: string | number;
+};
+
+const fetch = async (options: FetchOptions) => {
+  const dailyFees = options.createBalances();
+  const dailySupplySideRevenue = options.createBalances();
+
+  const query = `
+    WITH pools AS (
+      SELECT
+        json_extract_scalar(json_parse(cd.key_decoded), '$.vec[1].address') AS pool
+      FROM stellar.contract_data cd
+      WHERE cd.contract_id = '${V2_BACKSTOP}'
+        AND json_extract_scalar(json_parse(cd.key_decoded), '$.vec[0].symbol') = 'PoolBalance'
+      GROUP BY 1
+    ),
+
+    parsed AS (
+      SELECT DISTINCT
+        cd.closed_at,
+        cd.ledger_sequence,
+        cd.contract_id AS pool,
+        json_extract_scalar(json_parse(cd.key_decoded), '$.vec[1].address') AS asset,
+        TRY_CAST(regexp_extract(cd.val_decoded, '"d_rate"\\},"val":\\{"i128":"([0-9]+)"', 1) AS DOUBLE) AS d_rate,
+        TRY_CAST(regexp_extract(cd.val_decoded, '"d_supply"\\},"val":\\{"i128":"([0-9]+)"', 1) AS DOUBLE) AS d_supply,
+        COALESCE(
+          TRY_CAST(regexp_extract(cd.val_decoded, '"backstop_credit"\\},"val":\\{"i128":"([0-9]+)"', 1) AS DOUBLE),
+          0
+        ) AS backstop_credit
+      FROM stellar.contract_data cd
+      JOIN pools p
+        ON cd.contract_id = p.pool
+      WHERE cd.closed_at < DATE '${options.dateString}' + interval '1' day
+        AND cd.closed_at >= DATE '${options.dateString}' - interval '3' day
+        AND json_extract_scalar(json_parse(cd.key_decoded), '$.vec[0].symbol') = 'ResData'
+    ),
+
+    ordered AS (
+      SELECT
+        *,
+        LAG(d_rate) OVER (
+          PARTITION BY pool, asset
+          ORDER BY closed_at, ledger_sequence
+        ) AS prev_d_rate,
+        LAG(d_supply) OVER (
+          PARTITION BY pool, asset
+          ORDER BY closed_at, ledger_sequence
+        ) AS prev_d_supply,
+        LAG(backstop_credit) OVER (
+          PARTITION BY pool, asset
+          ORDER BY closed_at, ledger_sequence
+        ) AS prev_backstop_credit
+      FROM parsed
+      WHERE asset IS NOT NULL
+        AND d_rate IS NOT NULL
+        AND d_supply IS NOT NULL
+    ),
+
+    daily AS (
+      SELECT
+        DATE(closed_at) AS day,
+        asset,
+        GREATEST(
+          COALESCE(prev_d_supply, 0)
+            * GREATEST(d_rate - COALESCE(prev_d_rate, d_rate), 0)
+            / 1e12,
+          0
+        ) AS borrow_interest_raw,
+        GREATEST(
+          backstop_credit - COALESCE(prev_backstop_credit, backstop_credit),
+          0
+        ) AS backstop_revenue_raw
+      FROM ordered
+    )
+
+    SELECT
+      asset,
+      SUM(borrow_interest_raw) AS borrow_interest_raw,
+      SUM(
+        CASE
+          WHEN backstop_revenue_raw <= borrow_interest_raw THEN backstop_revenue_raw
+          ELSE 0
+        END
+      ) AS backstop_revenue_raw
+    FROM daily
+    WHERE day = DATE '${options.dateString}'
+    GROUP BY 1
+    HAVING SUM(borrow_interest_raw) > 0
+  `;
+
+  const rows: BlendV2Row[] = await queryDuneSql(options, query);
+
+  rows.forEach(({ asset, borrow_interest_raw, backstop_revenue_raw }) => {
+    const borrowInterest = Number(borrow_interest_raw);
+    const backstopRevenue = Number(backstop_revenue_raw);
+    const lenderRevenue = Math.max(borrowInterest - backstopRevenue, 0);
+
+    dailyFees.add(asset, lenderRevenue, METRIC.BORROW_INTEREST);
+    if (lenderRevenue > 0) dailySupplySideRevenue.add(asset, lenderRevenue, "Borrow Interest To Lenders");
+  });
+
+  return {
+    dailyFees,
+    dailySupplySideRevenue,
+    dailyRevenue: 0,
+    dailyProtocolRevenue: 0,
+  };
+};
+
+const methodology = {
+  Fees: "Interest paid by Blend v2 borrowers that goes to lenders.",
+  SupplySideRevenue: "Lender component of Blend v2 borrow interest paid to pool suppliers after the backstop share.",
+  Revenue: "Blend v2 does not retain protocol revenue from pool borrow interest.",
+  ProtocolRevenue: "Blend v2 does not retain treasury revenue from pool borrow interest.",
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  fetch,
+  start: "2025-04-14",
+  chains: [CHAIN.STELLAR],
+  dependencies: [Dependencies.DUNE],
+  isExpensiveAdapter: true,
+  methodology,
+  breakdownMethodology: {
+    Fees: {
+      [METRIC.BORROW_INTEREST]: "Interest paid by borrowers to lenders. It is calculated from debt rate growth, then excludes the portion credited to the backstop.",
+    },
+    SupplySideRevenue: {
+     "Borrow Interest To Lenders": "Borrower interest paid to users who supplied assets to Blend v2 pools.",
+    },
+  },
+};
+
+export default adapter;

--- a/fees/blend-pools/index.ts
+++ b/fees/blend-pools/index.ts
@@ -19,6 +19,10 @@ const fetch = async (options: FetchOptions) => {
   const dailyFees = options.createBalances();
   const dailySupplySideRevenue = options.createBalances();
 
+  // Source: Dune stellar.contract_data snapshots of Blend pool ResData(asset).
+  // Blend debt rates are scaled by 1e12, so borrower interest per update is:
+  // previous d_supply * max(current d_rate - previous d_rate, 0) / 1e12.
+  // A 3-day lookback gives LAG() a prior reserve state before the target day.
   const query = `
     WITH parsed AS (
       SELECT DISTINCT
@@ -106,7 +110,7 @@ const adapter: SimpleAdapter = {
   methodology,
   breakdownMethodology: {
     Fees: {
-      [METRIC.BORROW_INTEREST]: "Total interest paid by Blend v1 borrowers, calculated from debt rate growth."
+      [METRIC.BORROW_INTEREST]: "Total interest paid by Blend v1 borrowers, calculated from debt rate growth.",
     },
     SupplySideRevenue: {
       "Borrow Interest To Lenders And Backstop": "Total v1 borrow interest paid to pool suppliers and backstop participants.",

--- a/fees/blend-pools/index.ts
+++ b/fees/blend-pools/index.ts
@@ -22,9 +22,9 @@ const fetch = async (options: FetchOptions) => {
   // Source: Dune stellar.contract_data snapshots of Blend pool ResData(asset).
   // Blend debt rates are scaled by 1e12, so borrower interest per update is:
   // previous d_supply * max(current d_rate - previous d_rate, 0) / 1e12.
-  // A 3-day lookback gives LAG() a prior reserve state before the target day.
+  // The latest snapshot before the target day seeds LAG() for inactive reserves.
   const query = `
-    WITH parsed AS (
+    WITH reserve_rows AS (
       SELECT DISTINCT
         cd.closed_at,
         cd.ledger_sequence,
@@ -35,8 +35,51 @@ const fetch = async (options: FetchOptions) => {
       FROM stellar.contract_data cd
       WHERE cd.contract_id IN (${V1_POOLS.map((pool) => `'${pool}'`).join(", ")})
         AND cd.closed_at < DATE '${options.dateString}' + interval '1' day
-        AND cd.closed_at >= DATE '${options.dateString}' - interval '3' day
         AND json_extract_scalar(json_parse(cd.key_decoded), '$.vec[0].symbol') = 'ResData'
+    ),
+
+    prior_rows AS (
+      SELECT
+        closed_at,
+        ledger_sequence,
+        pool,
+        asset,
+        d_rate,
+        d_supply
+      FROM (
+        SELECT
+          *,
+          ROW_NUMBER() OVER (
+            PARTITION BY pool, asset
+            ORDER BY closed_at DESC, ledger_sequence DESC
+          ) AS rn
+        FROM reserve_rows
+        WHERE closed_at < DATE '${options.dateString}'
+      )
+      WHERE rn = 1
+    ),
+
+    parsed AS (
+      SELECT
+        closed_at,
+        ledger_sequence,
+        pool,
+        asset,
+        d_rate,
+        d_supply
+      FROM reserve_rows
+      WHERE closed_at >= DATE '${options.dateString}'
+
+      UNION ALL
+
+      SELECT
+        closed_at,
+        ledger_sequence,
+        pool,
+        asset,
+        d_rate,
+        d_supply
+      FROM prior_rows
     ),
 
     ordered AS (

--- a/fees/blend-pools/index.ts
+++ b/fees/blend-pools/index.ts
@@ -1,0 +1,117 @@
+import { Dependencies, FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import { queryDuneSql } from "../../helpers/dune";
+import { METRIC } from "../../helpers/metrics";
+
+const V1_POOLS = [
+  "CDVQVKOY2YSXS2IC7KN6MNASSHPAO7UN2UR2ON4OI2SKMFJNVAMDX6DP",
+  "CAQF5KNOFIGRI24NQRRGUPD46Q45MGMXZMRTQFXS25Y4NZVNPT34GM6S",
+  "CBP7NO6F7FRDHSOFQBT2L2UWYIZ2PU76JKVRYAQTG3KZSQLYAOKIF2WB",
+  "CDE65QK2ROZ32V2LVLBOKYPX47TYMYO37Z6ASQTBRTBNK53C7C6QF4Y7",
+];
+
+type BlendV1Row = {
+  asset: string;
+  borrow_interest_raw: string | number;
+};
+
+const fetch = async (options: FetchOptions) => {
+  const dailyFees = options.createBalances();
+  const dailySupplySideRevenue = options.createBalances();
+
+  const query = `
+    WITH parsed AS (
+      SELECT DISTINCT
+        cd.closed_at,
+        cd.ledger_sequence,
+        cd.contract_id AS pool,
+        json_extract_scalar(json_parse(cd.key_decoded), '$.vec[1].address') AS asset,
+        TRY_CAST(regexp_extract(cd.val_decoded, '"d_rate"\\},"val":\\{"i128":"([0-9]+)"', 1) AS DOUBLE) AS d_rate,
+        TRY_CAST(regexp_extract(cd.val_decoded, '"d_supply"\\},"val":\\{"i128":"([0-9]+)"', 1) AS DOUBLE) AS d_supply
+      FROM stellar.contract_data cd
+      WHERE cd.contract_id IN (${V1_POOLS.map((pool) => `'${pool}'`).join(", ")})
+        AND cd.closed_at < DATE '${options.dateString}' + interval '1' day
+        AND cd.closed_at >= DATE '${options.dateString}' - interval '3' day
+        AND json_extract_scalar(json_parse(cd.key_decoded), '$.vec[0].symbol') = 'ResData'
+    ),
+
+    ordered AS (
+      SELECT
+        *,
+        LAG(d_rate) OVER (
+          PARTITION BY pool, asset
+          ORDER BY closed_at, ledger_sequence
+        ) AS prev_d_rate,
+        LAG(d_supply) OVER (
+          PARTITION BY pool, asset
+          ORDER BY closed_at, ledger_sequence
+        ) AS prev_d_supply
+      FROM parsed
+      WHERE asset IS NOT NULL
+        AND d_rate IS NOT NULL
+        AND d_supply IS NOT NULL
+    ),
+
+    daily AS (
+      SELECT
+        DATE(closed_at) AS day,
+        asset,
+        GREATEST(
+          COALESCE(prev_d_supply, 0)
+            * GREATEST(d_rate - COALESCE(prev_d_rate, d_rate), 0)
+            / 1e12,
+          0
+        ) AS borrow_interest_raw
+      FROM ordered
+    )
+
+    SELECT
+      asset,
+      SUM(borrow_interest_raw) AS borrow_interest_raw
+    FROM daily
+    WHERE day = DATE '${options.dateString}'
+    GROUP BY 1
+    HAVING SUM(borrow_interest_raw) > 0
+  `;
+
+  const rows: BlendV1Row[] = await queryDuneSql(options, query);
+
+  rows.forEach(({ asset, borrow_interest_raw }) => {
+    dailyFees.add(asset, Number(borrow_interest_raw), METRIC.BORROW_INTEREST);
+    dailySupplySideRevenue.add(asset, Number(borrow_interest_raw), "Borrow Interest To Lenders And Backstop");
+  });
+
+  return {
+    dailyFees,
+    dailySupplySideRevenue,
+    dailyRevenue: 0,
+    dailyProtocolRevenue: 0,
+  };
+};
+
+const methodology = {
+  Fees: "Total borrow interest accrued across Blend v1 pools.",
+  SupplySideRevenue: "All Blend v1 borrow interest is paid to pool suppliers and backstop participants.",
+  Revenue: "Blend v1 does not retain protocol revenue from pool borrow interest.",
+  ProtocolRevenue: "Blend v1 does not retain treasury revenue from pool borrow interest.",
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  fetch,
+  start: "2024-05-02",
+  chains: [CHAIN.STELLAR],
+  dependencies: [Dependencies.DUNE],
+  isExpensiveAdapter: true,
+  methodology,
+  breakdownMethodology: {
+    Fees: {
+      [METRIC.BORROW_INTEREST]: "Total interest paid by Blend v1 borrowers, calculated from debt rate growth."
+    },
+    SupplySideRevenue: {
+      "Borrow Interest To Lenders And Backstop": "Total v1 borrow interest paid to pool suppliers and backstop participants.",
+    },
+  },
+};
+
+export default adapter;

--- a/fees/blend-pools/index.ts
+++ b/fees/blend-pools/index.ts
@@ -15,7 +15,7 @@ type BlendV1Row = {
   borrow_interest_raw: string | number;
 };
 
-const fetch = async (options: FetchOptions) => {
+const fetch = async (_a: any, _b: any, options: FetchOptions) => {
   const dailyFees = options.createBalances();
   const dailySupplySideRevenue = options.createBalances();
 
@@ -144,7 +144,7 @@ const methodology = {
 };
 
 const adapter: SimpleAdapter = {
-  version: 2,
+  version: 1,
   fetch,
   start: "2024-05-02",
   chains: [CHAIN.STELLAR],


### PR DESCRIPTION

Fixes fees for all blend pools https://defillama.com/protocol/blend

## Summary
- Adds Stellar fee adapters for Blend v1 pools, Blend v2 lender earnings, and Blend v2 backstop earnings.
- Uses Dune `stellar.contract_data` reserve state to calculate borrow interest from Blend pool debt-rate growth.
- Reports Blend protocol revenue as `0` because borrower interest is paid to lenders and backstop depositors rather than retained by the protocol treasury.

## Changes
- Added `fees/blend-pools` for Blend v1 pool borrow interest.
  - Tracks UI-confirmed v1 active/frozen pools.
  - Reports v1 borrow interest as supply-side revenue to lenders/backstop participants without splitting the v1 backstop share, since v1 backstop balance changes include deposits.
- Added `fees/blend-pools-v2` for Blend v2 lender earnings.
  - Discovers v2 pools dynamically from the v2 backstop `PoolBalance` registry.
  - Reports lender share of borrower interest net of `backstop_credit` growth.
- Added `fees/blend-backstop-v2` for Blend v2 backstop earnings.
  - Tracks borrower interest credited to v2 backstop depositors from reserve `backstop_credit` growth.
- Added methodology and breakdown methodology labels for all fee and supply-side revenue rows.

## Methodology
- Borrow interest is calculated from Blend reserve state:
  - `borrow_interest = previous_d_supply * (d_rate - previous_d_rate) / 1e12`
- V2 backstop earnings are calculated from reserve backstop accounting:
  - `backstop_interest = backstop_credit - previous_backstop_credit`
- Amounts are added as raw Stellar token units so the DefiLlama balances/pricing layer can apply token decimals.
- V2 total borrower interest is represented by combining:
  - `blend-pools-v2` lender share
  - `blend-backstop-v2` backstop share


## Tests
- `pnpm test -- fees blend-pools 2026-05-06`
  - `Daily fees: 0.00`
  - `Daily supply side revenue: 0.00`
  - `Daily revenue: 0.00`
  - `Daily protocol revenue: 0.00`
  - Note: v1 raw fees for `2026-05-05` were nonzero but tiny and rounded to `0.00`.
  -   -   - 
- `pnpm test -- fees blend-pools-v2 2026-05-06`
  - `Daily fees: 12.58 k`
  - `Daily supply side revenue: 12.58 k`
  - `Daily revenue: 0.00`
  - `Daily protocol revenue: 0.00`
  -   -   - 
- `pnpm test -- fees blend-backstop-v2 2026-05-06`
  - `Daily fees: 2.97 k`
  - `Daily supply side revenue: 2.97 k`
  - `Daily revenue: 0.00`
  - `Daily protocol revenue: 0.00`
  -   -   - 
- Additional v1 spot checks:
  - `pnpm test -- fees blend-pools 2025-06-15`
    - `Daily fees: 0.37`
    - `Daily supply side revenue: 0.37`
    - `Daily revenue: 0.00`
    - `Daily protocol revenue: 0.00`
    -     -     - 
  - `pnpm test -- fees blend-pools 2024-09-11`
    - `Daily fees: 1.42`
    - `Daily supply side revenue: 1.42`
    - `Daily revenue: 0.00`
    - `Daily protocol revenue: 0.00`

## Validation
- Backtested with rough ui apr calculations results are near about same.
- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Blend protocol v1 and v2 support for Stellar network
  * Enabled fee and supply-side revenue tracking for Blend pools and backstop mechanisms
  * Implemented daily metric collection via Dune integration

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DefiLlama/dimension-adapters/pull/6831)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->