### PR TITLE
feat(fees): add Land Bid fees adapter

### DIFF
--- a/dexs/landbid.ts
+++ b/dexs/landbid.ts
@@ -60,8 +60,8 @@ async function fetch(options: FetchOptions) {
         else if(log.recipient === PROTOCOL_LP_PROVIDER) lpfeeRatioReceivedByProtocol = 1;
         else continue;
 
-        dailyFees.addToken(token0, log.amount0 * lpfeeRatioReceivedByProtocol, METRIC.LP_FEES);
-        dailyFees.addToken(token1, log.amount1 * lpfeeRatioReceivedByProtocol, METRIC.LP_FEES);
+        dailyFees.addToken(token0, Number(log.amount0) * lpfeeRatioReceivedByProtocol, METRIC.LP_FEES);
+        dailyFees.addToken(token1, Number(log.amount1) * lpfeeRatioReceivedByProtocol, METRIC.LP_FEES);
     }
 
     return {

--- a/dexs/landbid.ts
+++ b/dexs/landbid.ts
@@ -1,13 +1,21 @@
 import { FetchOptions, SimpleAdapter } from "../adapters/types";
 import { METRIC } from "../helpers/metrics";
 import { CHAIN } from "../helpers/chains";
+import ADDRESSES from "../helpers/coreAssets.json"
 
 const WORLD_MINER = "0xbc25d77953425041C3f09ea4b731a873E00036EA";
+const UNCX_UNVI3_LOCKER = "0x231278eDd38B00B07fBd52120CEf685B9BaEBCC1";
+const LAND_WETH_UNIV3_LP = "0xf630370cBFEB1d04c5C7B564143010E8d30b4e10";
+const PROTOCOL_LP_PROVIDER = "0x258007980c06Ae309851774cCd703023D91f4879";
+const LAND_TOKEN = "0xB738b1568F08B0d6894a580Ef805E9298ebFaB46";
 
 const CONQUER_EVENT =
     "event Conquer(uint8 indexed continentId,address indexed newHolder,address indexed prevHolder,uint256 price,uint256 prevHolderPayout,uint256 tokensAccrued)";
 
+const LP_FEE_COLLECTED_EVENT = "event Collect (address indexed owner, address recipient, int24 indexed tickLower, int24 indexed tickUpper, uint128 amount0, uint128 amount1)"
+
 const BASE_FEE_BPS = 10000;
+const UNCX_FEE_SHARE = 2/100;
 
 async function fetch(options: FetchOptions) {
     const dailyVolume = options.createBalances();
@@ -31,10 +39,29 @@ async function fetch(options: FetchOptions) {
         eventAbi: CONQUER_EVENT,
     });
 
+    const lpFeesCollectedLogs = await options.getLogs({
+        target: LAND_WETH_UNIV3_LP,
+        eventAbi: LP_FEE_COLLECTED_EVENT,
+    })
+
     for (const log of conquerEvents) {
         dailyVolume.addGasToken(log.price);
         dailyFees.addGasToken(Number(log.price) * devFees, METRIC.PROTOCOL_FEES);
         dailyFees.addGasToken(Number(log.price) * lpFees, "Fees to protocol owned liquidity");
+    }
+
+    const token0 = ADDRESSES.base.WETH;
+    const token1 = LAND_TOKEN;
+
+    for(const log of lpFeesCollectedLogs) {
+        let lpfeeRatioReceivedByProtocol = 0;
+        
+        if(log.recipient === UNCX_UNVI3_LOCKER) lpfeeRatioReceivedByProtocol = 1 - UNCX_FEE_SHARE;
+        else if(log.recipient === PROTOCOL_LP_PROVIDER) lpfeeRatioReceivedByProtocol = 1;
+        else continue;
+
+        dailyFees.addToken(token0, log.amount0 * lpfeeRatioReceivedByProtocol, METRIC.LP_FEES);
+        dailyFees.addToken(token1, log.amount1 * lpfeeRatioReceivedByProtocol, METRIC.LP_FEES);
     }
 
     return {
@@ -46,23 +73,26 @@ async function fetch(options: FetchOptions) {
 }
 
 const methodology = {
-    Volume: "ETH paid by users when conquering continents in the Land Bid game.",
-    Fees: "15% of the conquer amount is fees, of which 10% goes to protocol owned liquidity on uniswap and 5% goes to the team",
-    Revenue: "15% of the conquer amount is revenue, of which 10% goes to protocol owned liquidity on uniswap and 5% goes to the team",
-    ProtocolRevenue: "15% of the conquer amount is protocol revenue, of which 10% goes to protocol owned liquidity on uniswap and 5% goes to the team",
+    Volume: "Includes ETH paid by users when conquering continents in the Land Bid game and fees earned by providing liquidity to the uniswap pool",
+    Fees: "Includes 15% of the land bid game conquer amount, of which 10% goes to protocol owned liquidity on uniswap and 5% goes to the team and fees earned by providing liquidity to the uniswap pool",
+    Revenue: "Includes 15% of the land bid game conquer amount, of which 10% goes to protocol owned liquidity on uniswap and 5% goes to the team and fees earned by providing liquidity to the uniswap pool",
+    ProtocolRevenue: "Includes 15% of the land bid game conquer amount, of which 10% goes to protocol owned liquidity on uniswap and 5% goes to the team and fees earned by providing liquidity to the uniswap pool",
 };
 
 const breakdownMethodology = {
     Fees: {
         [METRIC.PROTOCOL_FEES]: "5% of the conquer amount goes to the team",
+        [METRIC.LP_FEES]: "Fees earned by providing liquidity to the uniswap pool",
         "Fees to protocol owned liquidity": "10% of the conquer amount goes to protocol owned liquidity on uniswap",
     },
     Revenue: {
         [METRIC.PROTOCOL_FEES]: "5% of the conquer amount goes to the team",
+        [METRIC.LP_FEES]: "Fees earned by providing liquidity to the uniswap pool",
         "Fees to protocol owned liquidity": "10% of the conquer amount goes to protocol owned liquidity on uniswap",
     },
     ProtocolRevenue: {
         [METRIC.PROTOCOL_FEES]: "5% of the conquer amount goes to the team",
+        [METRIC.LP_FEES]: "Fees earned by providing liquidity to the uniswap pool",
         "Fees to protocol owned liquidity": "10% of the conquer amount goes to protocol owned liquidity on uniswap",
     },
 };

--- a/fees/landbid.ts
+++ b/fees/landbid.ts
@@ -1,0 +1,91 @@
+import { FetchOptions, SimpleAdapter } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+
+const WORLD_MINER = "0xbc25d77953425041C3f09ea4b731a873E00036EA";
+const START_DATE = "2026-05-05";
+const CONQUER_PAYMENTS = "Conquer payments";
+
+const CONQUER_EVENT =
+  "event Conquer(uint8 indexed continentId,address indexed newHolder,address indexed prevHolder,uint256 price,uint256 prevHolderPayout,uint256 tokensAccrued)";
+
+function eventArg(log: any, name: string, index: number) {
+  return log.args?.[name] ?? log.args?.[index] ?? log[name] ?? log[index];
+}
+
+function toBigInt(value: any): bigint {
+  return BigInt(value?.toString?.() ?? value ?? 0);
+}
+
+async function fetch(options: FetchOptions) {
+  const dailyFees = options.createBalances();
+  const dailyUserFees = options.createBalances();
+  const dailyRevenue = options.createBalances();
+  const dailyProtocolRevenue = options.createBalances();
+
+  const conquerEvents = await options.getLogs({
+    target: WORLD_MINER,
+    eventAbi: CONQUER_EVENT,
+    skipIndexer: true,
+    skipCacheRead: true,
+  });
+
+  let dailyConquerVolume = 0n;
+
+  for (const log of conquerEvents) {
+    dailyConquerVolume += toBigInt(eventArg(log, "price", 3));
+  }
+
+  dailyFees.addGasToken(dailyConquerVolume, CONQUER_PAYMENTS);
+  dailyUserFees.addGasToken(dailyConquerVolume, CONQUER_PAYMENTS);
+  dailyRevenue.addGasToken(dailyConquerVolume, CONQUER_PAYMENTS);
+  dailyProtocolRevenue.addGasToken(dailyConquerVolume, CONQUER_PAYMENTS);
+
+  return {
+    dailyFees,
+    dailyUserFees,
+    dailyRevenue,
+    dailyProtocolRevenue,
+  };
+}
+
+const methodology = {
+  Fees:
+    "100% of ETH paid by users to conquer continents flows through Land Bid protocol contracts. This represents total Conquer payment volume facilitated by the protocol.",
+  UserFees:
+    "Users pay ETH to conquer continents. The full Conquer payment is counted as user fees under Land Bid's submitted methodology.",
+  Revenue:
+    "Same as Fees. The protocol receives 100% of Conquer payments and redistributes them according to game mechanics: 85% to previous holders as instant game payouts, 10% to protocol-owned Uniswap V3 liquidity, and 5% to team operations.",
+  ProtocolRevenue:
+    "Same as Revenue for Land Bid's submitted methodology. All Conquer payments are processed by protocol contracts before redistribution.",
+};
+
+const breakdownMethodology = {
+  Fees: {
+    [CONQUER_PAYMENTS]:
+      "ETH paid by users when conquering continents in the Land Bid game.",
+  },
+  UserFees: {
+    [CONQUER_PAYMENTS]:
+      "ETH paid by users when conquering continents in the Land Bid game.",
+  },
+  Revenue: {
+    [CONQUER_PAYMENTS]:
+      "Conquer payments processed by Land Bid protocol contracts before redistribution according to game mechanics.",
+  },
+  ProtocolRevenue: {
+    [CONQUER_PAYMENTS]:
+      "Conquer payments processed by Land Bid protocol contracts before redistribution according to game mechanics.",
+  },
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  pullHourly: true,
+  fetch,
+  chains: [CHAIN.BASE],
+  start: START_DATE,
+  methodology,
+  breakdownMethodology,
+};
+
+export default adapter;

--- a/fees/landbid.ts
+++ b/fees/landbid.ts
@@ -1,91 +1,80 @@
 import { FetchOptions, SimpleAdapter } from "../adapters/types";
+import { METRIC } from "../helpers/metrics";
 import { CHAIN } from "../helpers/chains";
 
 const WORLD_MINER = "0xbc25d77953425041C3f09ea4b731a873E00036EA";
-const START_DATE = "2026-05-05";
-const CONQUER_PAYMENTS = "Conquer payments";
 
 const CONQUER_EVENT =
-  "event Conquer(uint8 indexed continentId,address indexed newHolder,address indexed prevHolder,uint256 price,uint256 prevHolderPayout,uint256 tokensAccrued)";
+    "event Conquer(uint8 indexed continentId,address indexed newHolder,address indexed prevHolder,uint256 price,uint256 prevHolderPayout,uint256 tokensAccrued)";
 
-function eventArg(log: any, name: string, index: number) {
-  return log.args?.[name] ?? log.args?.[index] ?? log[name] ?? log[index];
-}
-
-function toBigInt(value: any): bigint {
-  return BigInt(value?.toString?.() ?? value ?? 0);
-}
+const BASE_FEE_BPS = 10000;
 
 async function fetch(options: FetchOptions) {
-  const dailyFees = options.createBalances();
-  const dailyUserFees = options.createBalances();
-  const dailyRevenue = options.createBalances();
-  const dailyProtocolRevenue = options.createBalances();
+    const dailyVolume = options.createBalances();
+    const dailyFees = options.createBalances();
 
-  const conquerEvents = await options.getLogs({
-    target: WORLD_MINER,
-    eventAbi: CONQUER_EVENT,
-    skipIndexer: true,
-    skipCacheRead: true,
-  });
+    const lpFeeBps = await options.api.call({
+        target: WORLD_MINER,
+        abi: "function lpFeeBps() view returns (uint256)",
+    })
 
-  let dailyConquerVolume = 0n;
+    const devFeeBps = await options.api.call({
+        target: WORLD_MINER,
+        abi: "function devFeeBps() view returns (uint256)",
+    })
 
-  for (const log of conquerEvents) {
-    dailyConquerVolume += toBigInt(eventArg(log, "price", 3));
-  }
+    const lpFees = Number(lpFeeBps) / BASE_FEE_BPS;
+    const devFees = Number(devFeeBps) / BASE_FEE_BPS;
 
-  dailyFees.addGasToken(dailyConquerVolume, CONQUER_PAYMENTS);
-  dailyUserFees.addGasToken(dailyConquerVolume, CONQUER_PAYMENTS);
-  dailyRevenue.addGasToken(dailyConquerVolume, CONQUER_PAYMENTS);
-  dailyProtocolRevenue.addGasToken(dailyConquerVolume, CONQUER_PAYMENTS);
+    const conquerEvents = await options.getLogs({
+        target: WORLD_MINER,
+        eventAbi: CONQUER_EVENT,
+    });
 
-  return {
-    dailyFees,
-    dailyUserFees,
-    dailyRevenue,
-    dailyProtocolRevenue,
-  };
+    for (const log of conquerEvents) {
+        dailyVolume.addGasToken(log.price);
+        dailyFees.addGasToken(Number(log.price) * devFees, METRIC.PROTOCOL_FEES);
+        dailyFees.addGasToken(Number(log.price) * lpFees, "Fees to protocol owned liquidity");
+    }
+
+    return {
+        dailyVolume,
+        dailyFees,
+        dailyRevenue: dailyFees,
+        dailyProtocolRevenue: dailyFees,
+    };
 }
 
 const methodology = {
-  Fees:
-    "100% of ETH paid by users to conquer continents flows through Land Bid protocol contracts. This represents total Conquer payment volume facilitated by the protocol.",
-  UserFees:
-    "Users pay ETH to conquer continents. The full Conquer payment is counted as user fees under Land Bid's submitted methodology.",
-  Revenue:
-    "Same as Fees. The protocol receives 100% of Conquer payments and redistributes them according to game mechanics: 85% to previous holders as instant game payouts, 10% to protocol-owned Uniswap V3 liquidity, and 5% to team operations.",
-  ProtocolRevenue:
-    "Same as Revenue for Land Bid's submitted methodology. All Conquer payments are processed by protocol contracts before redistribution.",
+    Volume: "ETH paid by users when conquering continents in the Land Bid game.",
+    Fees: "15% of the conquer amount is fees, of which 10% goes to protocol owned liquidity on uniswap and 5% goes to the team",
+    Revenue: "15% of the conquer amount is revenue, of which 10% goes to protocol owned liquidity on uniswap and 5% goes to the team",
+    ProtocolRevenue: "15% of the conquer amount is protocol revenue, of which 10% goes to protocol owned liquidity on uniswap and 5% goes to the team",
 };
 
 const breakdownMethodology = {
-  Fees: {
-    [CONQUER_PAYMENTS]:
-      "ETH paid by users when conquering continents in the Land Bid game.",
-  },
-  UserFees: {
-    [CONQUER_PAYMENTS]:
-      "ETH paid by users when conquering continents in the Land Bid game.",
-  },
-  Revenue: {
-    [CONQUER_PAYMENTS]:
-      "Conquer payments processed by Land Bid protocol contracts before redistribution according to game mechanics.",
-  },
-  ProtocolRevenue: {
-    [CONQUER_PAYMENTS]:
-      "Conquer payments processed by Land Bid protocol contracts before redistribution according to game mechanics.",
-  },
+    Fees: {
+        [METRIC.PROTOCOL_FEES]: "5% of the conquer amount goes to the team",
+        "Fees to protocol owned liquidity": "10% of the conquer amount goes to protocol owned liquidity on uniswap",
+    },
+    Revenue: {
+        [METRIC.PROTOCOL_FEES]: "5% of the conquer amount goes to the team",
+        "Fees to protocol owned liquidity": "10% of the conquer amount goes to protocol owned liquidity on uniswap",
+    },
+    ProtocolRevenue: {
+        [METRIC.PROTOCOL_FEES]: "5% of the conquer amount goes to the team",
+        "Fees to protocol owned liquidity": "10% of the conquer amount goes to protocol owned liquidity on uniswap",
+    },
 };
 
 const adapter: SimpleAdapter = {
-  version: 2,
-  pullHourly: true,
-  fetch,
-  chains: [CHAIN.BASE],
-  start: START_DATE,
-  methodology,
-  breakdownMethodology,
+    version: 2,
+    pullHourly: true,
+    fetch,
+    chains: [CHAIN.BASE],
+    start: "2026-05-05",
+    methodology,
+    breakdownMethodology,
 };
 
 export default adapter;


### PR DESCRIPTION
Land Bid is a competitive on-chain continent mining game on Base. This adapter tracks WorldMiner.Conquer events and reports Conquer payments as fees and revenue under Land Bid's 100% flow-through methodology.

**NOTE**

#### "Allow edits by maintainers" is enabled.

---

##### Name (to be shown on DefiLlama):

Land Bid

##### Twitter Link:

https://x.com/landbidbase

##### List of audit links if any:

N/A

##### Website Link:

https://landbid.xyz

##### Logo (High resolution, will be shown with rounded borders):

<img width="1000" height="1000" alt="LandBid_PfP_Defillama" src="https://github.com/user-attachments/assets/fad1e8a4-c684-4afb-9340-39c5127e0513" />


##### Current TVL:

N/A for this fees adapter. TVL adapter is not included in this PR.

##### Treasury Addresses (if the protocol has treasury)

N/A

##### Chain:

Base

##### Coingecko ID:

N/A

##### Coinmarketcap ID:

N/A

##### Short Description (to be shown on DefiLlama):

Land Bid is a competitive on-chain continent mining game on Base where players pay ETH to conquer continents and earn LAND tokens through ongoing gameplay.

##### Token address and ticker if any:

LAND: 0xB738b1568F08B0d6894a580Ef805E9298ebFaB46

##### Category:

Gamified Mining

##### Oracle Provider(s):

N/A. This adapter reads on-chain events directly.

##### Implementation Details:

The adapter reads Conquer events from the WorldMiner contract on Base and sums Conquer.price as daily fees and daily revenue.

##### Documentation/Proof:

WorldMiner: https://basescan.org/address/0xbc25d77953425041C3f09ea4b731a873E00036EA

LAND token: https://basescan.org/token/0xB738b1568F08B0d6894a580Ef805E9298ebFaB46

Website: https://landbid.xyz

##### forkedFrom:

N/A

##### methodology:

100% of Conquer payments flow through the Land Bid protocol contracts before redistribution according to game mechanics:
- 85% to previous holders as instant game payouts
- 10% to protocol-owned Uniswap V3 liquidity
- 5% to team operations

Adapter reports:
- dailyFees: 100% of Conquer.price
- dailyRevenue: same as fees
- dailyProtocolRevenue: same as revenue

##### Github org/user:

https://github.com/landbidbase

##### Does this project have a referral program?

No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added data adapter for the BASE chain with hourly metrics collection starting May 5, 2026
  * Tracks trading volume, protocol and liquidity provider fees, and revenue attribution
  * Analyzes smart contract events to compute daily metrics
  * Includes detailed methodology and breakdown documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->