### PR TITLE
[feat] Risex: add risex perps volume and oi adapters

### DIFF
--- a/dexs/risex-perps/index.ts
+++ b/dexs/risex-perps/index.ts
@@ -1,0 +1,29 @@
+import { SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import { httpGet } from "../../utils/fetchURL";
+
+// Source: Rise Trade 24h perps volume endpoint.
+// include_bots=false currently returns 429s, so use include_bots=true.
+const VOLUME_API = "https://api.rise.trade/v1/stats/volume?include_bots=true";
+
+const fetch = async () => {
+  const response = await httpGet(VOLUME_API);
+  if (response.data?.total_volume === undefined) {
+    throw new Error("RiseX volume data missing");
+  }
+
+  const dailyVolume = Number(response.data.total_volume);
+  return { dailyVolume };
+};
+
+const adapter: SimpleAdapter = {
+  fetch,
+  chains: [CHAIN.OFF_CHAIN],
+  runAtCurrTime: true,
+  start: "2026-04-01",
+  methodology: {
+    Volume: "24h perpetual trading volume from Rise Trade's stats API, with bots included.",
+  },
+};
+
+export default adapter;

--- a/dexs/risex-perps/index.ts
+++ b/dexs/risex-perps/index.ts
@@ -13,6 +13,10 @@ const fetch = async () => {
   }
 
   const dailyVolume = Number(response.data.total_volume);
+  if (!Number.isFinite(dailyVolume) || dailyVolume < 0) {
+    throw new Error("RiseX volume value invalid");
+  }
+
   return { dailyVolume };
 };
 

--- a/dexs/risex-perps/index.ts
+++ b/dexs/risex-perps/index.ts
@@ -1,33 +1,57 @@
-import { SimpleAdapter } from "../../adapters/types";
+import { FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
-import { httpGet } from "../../utils/fetchURL";
+import fetchURL, { fetchURLAutoHandleRateLimit } from "../../utils/fetchURL";
+import { PromisePool } from "@supercharge/promise-pool";
+import { sleep } from "../../utils/utils";
 
-// Source: Rise Trade 24h perps volume endpoint.
-// include_bots=false currently returns 429s, so use include_bots=true.
-const VOLUME_API = "https://api.rise.trade/v1/stats/volume?include_bots=true";
+const RISEX_API_URL = "https://api.rise.trade/api/v1";
 
-const fetch = async () => {
-  const response = await httpGet(VOLUME_API);
-  if (response.data?.total_volume === undefined) {
-    throw new Error("RiseX volume data missing");
-  }
+const ONE_DAY_IN_SECONDS = 60 * 60 * 24;
+const NANOSECONDS_IN_SECOND = 1000000000;
 
-  const dailyVolume = Number(response.data.total_volume);
-  if (!Number.isFinite(dailyVolume) || dailyVolume < 0) {
-    throw new Error("RiseX volume value invalid");
-  }
+const fetch = async (_: any, __: any, options: FetchOptions) => {
+    const marketsResponse = await fetchURL(`${RISEX_API_URL}/markets`);
 
-  return { dailyVolume };
+    const marketIds = marketsResponse.data.markets.map((market: any) => Number(market.market_id));
+
+    const nanosecondsInOneDay = ONE_DAY_IN_SECONDS * NANOSECONDS_IN_SECOND;
+    const from = options.startOfDay * NANOSECONDS_IN_SECOND;
+    const to = from + nanosecondsInOneDay;
+
+    const dailyVolume = options.createBalances();
+
+    const { errors } = await PromisePool.withConcurrency(1)
+        .for(marketIds)
+        .process(async (marketId) => {
+            const marketData = await fetchURLAutoHandleRateLimit(`${RISEX_API_URL}/trading-view-data?market_id=${marketId}&interval=${nanosecondsInOneDay}&from=${from}&to=${to}`);
+            let todaysData;
+            if (marketData.data.data.length !== 1) {
+                todaysData = marketData.data.data.find((data: any) => data.time >= from && data.time < to);
+                if (!todaysData) {
+                    throw new Error(`No data found for market ${marketId}`);
+                }
+            }
+            else {
+                todaysData = marketData.data.data[0];
+            }
+            dailyVolume.addUSDValue(Number(todaysData.close) * Number(todaysData.volume));
+            await sleep(1000);
+        });
+
+    if (errors?.length) {
+        throw new Error(`Failed to fetch data for ${errors.length} markets`);
+    }
+
+    return { dailyVolume };
 };
 
 const adapter: SimpleAdapter = {
-  fetch,
-  chains: [CHAIN.OFF_CHAIN],
-  runAtCurrTime: true,
-  start: "2026-04-01",
-  methodology: {
-    Volume: "24h perpetual trading volume from Rise Trade's stats API, with bots included.",
-  },
+    fetch,
+    chains: [CHAIN.RISE],
+    start: "2026-04-01",
+    methodology: {
+        Volume: "24h perpetual trading volume from Rise Trade's API.",
+    },
 };
 
 export default adapter;

--- a/open-interest/risex-perps-oi.ts
+++ b/open-interest/risex-perps-oi.ts
@@ -1,48 +1,30 @@
-import { SimpleAdapter } from "../adapters/types";
+import { FetchOptions, SimpleAdapter } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
-import { httpGet } from "../utils/fetchURL";
+import fetchURL from "../utils/fetchURL";
 
-// Source: Rise Trade markets endpoint. OI is reported in base units and priced with mark price.
 const MARKETS_API = "https://api.rise.trade/v1/markets";
 
-type Market = {
-  available?: boolean;
-  visible?: boolean;
-  open_interest?: string;
-  mark_price?: string;
-  index_price?: string;
-  last_price?: string;
-};
+const fetch = async (_: any, __: any, _options: FetchOptions) => {
+    const response = await fetchURL(MARKETS_API);
+    const markets = response.data?.markets;
 
-const fetch = async () => {
-  const response = await httpGet(MARKETS_API);
-  const markets: Market[] = response.data?.markets ?? [];
-  if (!markets.length) {
-    throw new Error("RiseX markets data missing");
-  }
-
-  const openInterestAtEnd = markets.reduce((total: number, market: Market, i: number) => {
-    if (market.available === false || market.visible === false) return total;
-
-    const rawOpenInterest = market.open_interest;
-    const rawPrice = market.mark_price ?? market.index_price ?? market.last_price;
-    const openInterest = Number(rawOpenInterest);
-    const price = Number(rawPrice);
-    if (!Number.isFinite(openInterest) || !Number.isFinite(price) || openInterest < 0 || price < 0) {
-      throw new Error(`RiseX market numeric data invalid at index ${i}`);
+    if (!markets?.length) {
+        throw new Error("RiseX markets data missing");
     }
 
-    return total + openInterest * price;
-  }, 0);
+    const openInterestAtEnd = markets.reduce((total: number, market: any) => {
+        if (!market.available) return total;
+        return total + Number(market.open_interest) * Number(market.mark_price);
+    }, 0);
 
-  return { openInterestAtEnd };
+    return { openInterestAtEnd };
 };
 
 const adapter: SimpleAdapter = {
-  fetch,
-  chains: [CHAIN.OFF_CHAIN],
-  runAtCurrTime: true,
-  start: "2026-04-01",
+    version: 2,
+    fetch,
+    chains: [CHAIN.RISE],
+    runAtCurrTime: true,
 };
 
 export default adapter;

--- a/open-interest/risex-perps-oi.ts
+++ b/open-interest/risex-perps-oi.ts
@@ -1,0 +1,42 @@
+import { SimpleAdapter } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+import { httpGet } from "../utils/fetchURL";
+
+// Source: Rise Trade markets endpoint. OI is reported in base units and priced with mark price.
+const MARKETS_API = "https://api.rise.trade/v1/markets";
+
+type Market = {
+  available?: boolean;
+  visible?: boolean;
+  open_interest?: string;
+  mark_price?: string;
+  index_price?: string;
+  last_price?: string;
+};
+
+const fetch = async () => {
+  const response = await httpGet(MARKETS_API);
+  const markets: Market[] = response.data?.markets ?? [];
+  if (!markets.length) {
+    throw new Error("RiseX markets data missing");
+  }
+
+  const openInterestAtEnd = markets.reduce((total: number, market: Market) => {
+    if (market.available === false || market.visible === false) return total;
+
+    const openInterest = Number(market.open_interest ?? 0);
+    const price = Number(market.mark_price ?? market.index_price ?? market.last_price ?? 0);
+    return total + openInterest * price;
+  }, 0);
+
+  return { openInterestAtEnd };
+};
+
+const adapter: SimpleAdapter = {
+  fetch,
+  chains: [CHAIN.OFF_CHAIN],
+  runAtCurrTime: true,
+  start: "2026-04-01",
+};
+
+export default adapter;

--- a/open-interest/risex-perps-oi.ts
+++ b/open-interest/risex-perps-oi.ts
@@ -21,11 +21,17 @@ const fetch = async () => {
     throw new Error("RiseX markets data missing");
   }
 
-  const openInterestAtEnd = markets.reduce((total: number, market: Market) => {
+  const openInterestAtEnd = markets.reduce((total: number, market: Market, i: number) => {
     if (market.available === false || market.visible === false) return total;
 
-    const openInterest = Number(market.open_interest ?? 0);
-    const price = Number(market.mark_price ?? market.index_price ?? market.last_price ?? 0);
+    const rawOpenInterest = market.open_interest;
+    const rawPrice = market.mark_price ?? market.index_price ?? market.last_price;
+    const openInterest = Number(rawOpenInterest);
+    const price = Number(rawPrice);
+    if (!Number.isFinite(openInterest) || !Number.isFinite(price) || openInterest < 0 || price < 0) {
+      throw new Error(`RiseX market numeric data invalid at index ${i}`);
+    }
+
     return total + openInterest * price;
   }, 0);
 


### PR DESCRIPTION
Fixes #6845 
https://defillama.com/protocol/risex

## Summary
- Adds RiseX perpetuals adapters for DEX volume and open interest.
- Uses Rise Trade API endpoints to report current 24h perps volume and current market open interest.

## Changes
- Added `dexs/risex-perps` for `dailyVolume` on `CHAIN.OFF_CHAIN`.
- Added `open-interest/risex-perps-oi.ts` for `openInterestAtEnd` on `CHAIN.OFF_CHAIN`.
- Added explicit missing-data checks so API shape issues fail loudly instead of returning silent zeroes.

## Methodology
- Volume is sourced from `https://api.rise.trade/v1/stats/volume?include_bots=true` using `data.total_volume`.
- Open interest is calculated from `https://api.rise.trade/v1/markets` as `sum(open_interest * mark_price)` across visible/available markets, falling back to `index_price` or `last_price` if needed.
- Adapters use default v1/current-time behavior because the Rise Trade endpoints return current API aggregates rather than timestamp-filtered historical data.
