### PR TITLE
fix RiseX perps volume historical backfill

### DIFF
--- a/dexs/risex-perps/index.ts
+++ b/dexs/risex-perps/index.ts
@@ -28,7 +28,8 @@ const fetch = async (_: any, __: any, options: FetchOptions) => {
             if (marketData.data.data.length !== 1) {
                 todaysData = marketData.data.data.find((data: any) => data.time >= from && data.time < to);
                 if (!todaysData) {
-                    throw new Error(`No data found for market ${marketId}`);
+                    console.warn(`No RiseX candle found for market ${marketId} in [${from}, ${to}), skipping`);
+                    return;
                 }
             }
             else {


### PR DESCRIPTION
Follow up to #6848.
Related to #6845 for volume.

This fixes RiseX perps volume backfill for early historical windows. The adapter starts at `2026-04-01`, but it was using the current market list and then failing the whole day if one of those markets did not have a candle yet. So for those early days, we can miss the whole day’s volume even though some markets did have valid candles.

Before this change:

  `npm test dexs risex-perps 2026-04-02` -> `Error: Failed to fetch data for 1 markets`
  `npm test dexs risex-perps 2026-04-03` -> `Error: Failed to fetch data for 1 markets`
  `npm test dexs risex-perps 2026-04-15` -> `Error: Failed to fetch data for 1 markets`

Missing candle for one market should not invalidate the whole daily volume if the other markets have valid candles.

Tests:

  `npm test dexs risex-perps 2026-04-02` -> `Daily volume: 92.90 k`
  `npm test dexs risex-perps 2026-04-03` -> `Daily volume: 62.10 k`
  `npm test dexs risex-perps 2026-04-15` -> `Daily volume: 153.03 k`
  `npm test dexs risex-perps 2026-05-07` -> `Daily volume: 29.96 M`