### PR TITLE
Update Fragment wallet addresses and refine Telegram wallet handling

### DIFF
--- a/fees/fragment/index.ts
+++ b/fees/fragment/index.ts
@@ -4,7 +4,7 @@ import { queryDuneSql } from "../../helpers/dune";
 
 /**
  * All Fragment wallet addresses from ton-labels (https://github.com/ton-studio/ton-labels).
- * Query: SELECT address FROM dune.ton_foundation.dataset_labels WHERE label = 'fragment'
+ * Query: SELECT address FROM dune.ton_foundation.dataset_labels WHERE label IN ('fragment', 'fragment.ton')
  */
 const FRAGMENT_ADDRESSES = [
   '0:E6F3D8824F46B1EFBAB9AFC684793428C55FED69B46A15A49BE69A29BC49E530',
@@ -15,13 +15,19 @@ const FRAGMENT_ADDRESSES = [
   '0:158136239ADB15DD59DF90C641F9EFD312CFEB8664F218F4C3E5FCE9D95E6C07',
   '0:68F3A076D3451A18FD41E05C71B4C020545D46B2757064E65825DED0C49BF02C',
   '0:80D78A35F955A14B679FAA887FF4CD5BFC0F43B4A4EEA2A7E6927F3701B273C2',
+  '0:B314658F1E64345FD1B9FC5C4044530FFB329C5A433F87093947D40D4F53F80D',
 ];
 
 /**
- * Telegram Treasury wallet — sends operational funding to Fragment and
- * receives returns. Excluded to avoid counting internal flows as fees.
+ * Telegram-controlled wallets (label = 'telegram' in ton-labels). These send
+ * operational funding to Fragment and receive returns. Excluded on both sides
+ * to avoid counting internal Telegram <-> Fragment flows as user fees or payouts.
  */
-const TELEGRAM_TREASURY = '0:8C397C43F9FF0B49659B5D0A302B1A93AF7CCC63E5F5C0C4F25A9DC1F8B47AB3';
+const TELEGRAM_WALLETS = [
+  '0:8C397C43F9FF0B49659B5D0A302B1A93AF7CCC63E5F5C0C4F25A9DC1F8B47AB3', // Telegram Treasury
+  '0:2ECF5E47D591EB67FA6C56B02B6BB1DE6A530855E16AD3082EAA59859E8D5FDC', // Telegram Team
+  '0:99DC29AD86155121C8B0CE9B75542D1714F06B3FA42F5472D97BF61DC78E9048', // Telegram operations deployer/funder (vesting & validator wallets)
+];
 
 async function fetch(_a: any, _b: any, options: FetchOptions): Promise<FetchResult> {
   // Workaround for dune indexing issue
@@ -33,6 +39,7 @@ async function fetch(_a: any, _b: any, options: FetchOptions): Promise<FetchResu
   }
 
   const fragmentAddressList = FRAGMENT_ADDRESSES.map(a => `'${a}'`).join(', ');
+  const telegramAddressList = TELEGRAM_WALLETS.map(a => `'${a}'`).join(', ');
 
   const query = `
     WITH fees AS (
@@ -43,7 +50,7 @@ async function fetch(_a: any, _b: any, options: FetchOptions): Promise<FetchResu
         AND value > 0
         AND destination IN (${fragmentAddressList})
         AND source NOT IN (${fragmentAddressList})
-        AND source != '${TELEGRAM_TREASURY}'
+        AND source NOT IN (${telegramAddressList})
         AND block_time >= from_unixtime(${options.fromTimestamp})
         AND block_time < from_unixtime(${options.toTimestamp})
     ),
@@ -55,7 +62,7 @@ async function fetch(_a: any, _b: any, options: FetchOptions): Promise<FetchResu
         AND value > 0
         AND source IN (${fragmentAddressList})
         AND destination NOT IN (${fragmentAddressList})
-        AND destination != '${TELEGRAM_TREASURY}'
+        AND destination NOT IN (${telegramAddressList})
         AND block_time >= from_unixtime(${options.fromTimestamp})
         AND block_time < from_unixtime(${options.toTimestamp})
     )
@@ -94,11 +101,11 @@ async function fetch(_a: any, _b: any, options: FetchOptions): Promise<FetchResu
 }
 
 const methodology = {
-  Fees: "All TON payments received by Fragment wallets, excluding Telegram Treasury operational flows and inter-Fragment wallet transfers. Covers: Telegram Stars, Ads, Premium, Gift Market, Gateway, username auctions, and Telegram Gifts.",
+  Fees: "All TON payments received by Fragment wallets, excluding Telegram-controlled wallet flows and inter-Fragment wallet transfers. Covers: Telegram Stars, Ads, Premium, Gift Market, Gateway, username auctions, and Telegram Gifts.",
   UserFees: "Same as Fees: TON payments made by users to Fragment wallets on TON.",
   Revenue: "Fees minus supply-side revenue. Note: Stars purchased via Apple Pay/Google Pay are settled off-chain but paid out on-chain, so on-chain revenue may understate actual revenue.",
   ProtocolRevenue: "Same as Revenue — all retained revenue goes to Telegram (Fragment operator).",
-  SupplySideRevenue: "All TON paid out by Fragment wallets to external addresses, excluding Telegram Treasury returns and inter-Fragment transfers. Primarily: bot developer rewards, channel owner rewards, and user Stars rewards."
+  SupplySideRevenue: "All TON paid out by Fragment wallets to external addresses, excluding Telegram-controlled wallet returns and inter-Fragment transfers. Primarily: bot developer rewards, channel owner rewards, and user Stars rewards."
 };
 
 const adapter: SimpleAdapter = {


### PR DESCRIPTION
* Modify SQL query to include 'fragment.ton' label for Fragment wallet addresses.
* Replace single Telegram Treasury address with an array of Telegram-controlled wallets for better clarity and accuracy in fee calculations.
* Update methodology descriptions to reflect changes in wallet handling and ensure accurate fee reporting.
