### PR TITLE
fix(dzap): update volume adapters for backfill + rate limits

### DIFF
--- a/aggregators/dzap/index.ts
+++ b/aggregators/dzap/index.ts
@@ -1,134 +1,30 @@
 import { FetchOptions, SimpleAdapter } from "../../adapters/types";
-import { httpGet } from "../../utils/fetchURL";
+import {
+  DZAP_SUPPORTED_CHAINS,
+  fetchChainWiseVolumeFromDZapAPI,
+} from "../../helpers/aggregators/dzap";
 import { CHAIN } from "../../helpers/chains";
 
-const CHAIN_VOLUME_API = "https://api.dzap.io/v1/volume/chain";
-
-const chains: Record<string, number> = {
-  [CHAIN.ETHEREUM]: 1,
-  [CHAIN.OPTIMISM]: 10,
-  [CHAIN.FLARE]: 14,
-  [CHAIN.CRONOS]: 25,
-  [CHAIN.ROOTSTOCK]: 30,
-  [CHAIN.TELOS]: 40,
-  [CHAIN.XDC]: 50,
-  [CHAIN.BSC]: 56,
-  [CHAIN.XDAI]: 100,
-  [CHAIN.FUSE]: 122,
-  [CHAIN.UNICHAIN]: 130,
-  [CHAIN.MONAD]: 143,
-  [CHAIN.POLYGON]: 137,
-  [CHAIN.SONIC]: 146,
-  [CHAIN.MANTA]: 169,
-  [CHAIN.MINT]: 185,
-  [CHAIN.XLAYER]: 196,
-  [CHAIN.OP_BNB]: 204,
-  [CHAIN.BSQUARED]: 223,
-  [CHAIN.LENS]: 232,
-  [CHAIN.FANTOM]: 250,
-  [CHAIN.FRAXTAL]: 252,
-  [CHAIN.KROMA]: 255,
-  [CHAIN.BOBA]: 288,
-  [CHAIN.ZKSYNC]: 324,
-  [CHAIN.PULSECHAIN]: 369,
-  [CHAIN.WC]: 480,
-  [CHAIN.STABLE]: 988,
-  [CHAIN.HYPERLIQUID]: 998,
-  [CHAIN.BITCOIN]: 1000,
-  [CHAIN.METIS]: 1088,
-  [CHAIN.POLYGON_ZKEVM]: 1101,
-  [CHAIN.CORE]: 1116,
-  [CHAIN.MOONBEAM]: 1284,
-  [CHAIN.MOONRIVER]: 1285,
-  [CHAIN.SEI]: 1329,
-  [CHAIN.STORY]: 1514,
-  [CHAIN.GRAVITY]: 1625,
-  [CHAIN.SONEIUM]: 1868,
-  [CHAIN.SWELLCHAIN]: 1923,
-  [CHAIN.RONIN]: 2020,
-  [CHAIN.KAVA]: 2222,
-  [CHAIN.ABSTRACT]: 2741,
-  [CHAIN.MORPH]: 2818,
-  [CHAIN.MERLIN]: 4200,
-  [CHAIN.MEGAETH]: 4326,
-  [CHAIN.MANTLE]: 5000,
-  [CHAIN.BAHAMUT]: 5165,
-  [CHAIN.ZETA]: 7000,
-  [CHAIN.BASE]: 8453,
-  [CHAIN.KLAYTN]: 8217,
-  [CHAIN.PLASMA]: 9745,
-  [CHAIN.IMX]: 13371,
-  [CHAIN.SUI]: 19219,
-  [CHAIN.APECHAIN]: 33139,
-  [CHAIN.MODE]: 34443,
-  [CHAIN.ARBITRUM]: 42161,
-  [CHAIN.CELO]: 42220,
-  [CHAIN.ZKFAIR]: 42766,
-  [CHAIN.HEMI]: 43111,
-  [CHAIN.AVAX]: 43114,
-  [CHAIN.ZIRCUIT]: 48900,
-  [CHAIN.SUPERPOSITION]: 55244,
-  [CHAIN.INK]: 57073,
-  [CHAIN.LINEA]: 59144,
-  [CHAIN.BOB]: 60808,
-  [CHAIN.BERACHAIN]: 80094,
-  [CHAIN.BLAST]: 81457,
-  [CHAIN.PLUME]: 98866,
-  [CHAIN.TAIKO]: 167000,
-  [CHAIN.BITLAYER]: 200901,
-  [CHAIN.SCROLL]: 534352,
-  [CHAIN.KATANA]: 747474,
-  [CHAIN.SOLANA]: 7565164,
-  [CHAIN.AURORA]: 1313161554,
-};
-
-interface ApiResponse {
-  swap: {
-    allTime: number;
-    last24Hours: number;
-    last7Days: number;
-    last30Days: number;
-    last90Days: number;
-  };
-  bridge: {
-    allTime: number;
-    last24Hours: number;
-    last7Days: number;
-    last30Days: number;
-    last90Days: number;
-  };
-}
-
-const prefetch = async (_: FetchOptions) => {
-  const data: any = {};
-  for (const chain of Object.keys(chains)) {
-    await new Promise((resolve) => setTimeout(resolve, 13000));
-    data[chain] = await httpGet(
-      `${CHAIN_VOLUME_API}?chainId=${chains[chain as keyof typeof chains]}`,
-    );
-  }
-  return data;
-};
+const prefetch = async (options: FetchOptions) =>
+  fetchChainWiseVolumeFromDZapAPI({ ...options, txType: "swap" });
 
 const fetch = async (_a: any, _b: any, options: FetchOptions) => {
-  const data: ApiResponse = options.preFetchedResults[options.chain];
-
-  let dailyVolume = data.swap.last24Hours;
-
   // bad data, wash trade
   if (options.startOfDay === 1750982400 && options.chain === CHAIN.ARBITRUM) {
-    dailyVolume = 0;
+    return {
+      dailyVolume: 0,
+    };
   }
-
+  const volume = options.preFetchedResults[options.chain] ?? 0;
   return {
-    dailyVolume,
+    dailyVolume: volume,
   };
 };
 
 const adapter: SimpleAdapter = {
   version: 1,
   fetch,
-  chains: Object.keys(chains),
+  chains: Object.values(DZAP_SUPPORTED_CHAINS),
   start: "2023-01-01",
   runAtCurrTime: true,
   prefetch,

--- a/aggregators/dzap/index.ts
+++ b/aggregators/dzap/index.ts
@@ -1,8 +1,5 @@
 import { FetchOptions, SimpleAdapter } from "../../adapters/types";
-import {
-  DZAP_SUPPORTED_CHAINS,
-  fetchChainWiseVolumeFromDZapAPI,
-} from "../../helpers/aggregators/dzap";
+import { DZAP_SUPPORTED_CHAINS, fetchChainWiseVolumeFromDZapAPI } from "../../helpers/aggregators/dzap";
 import { CHAIN } from "../../helpers/chains";
 
 const prefetch = async (options: FetchOptions) =>
@@ -26,7 +23,6 @@ const adapter: SimpleAdapter = {
   fetch,
   chains: Object.values(DZAP_SUPPORTED_CHAINS),
   start: "2023-01-01",
-  runAtCurrTime: true,
   prefetch,
 };
 

--- a/bridge-aggregators/dzap/index.ts
+++ b/bridge-aggregators/dzap/index.ts
@@ -1,12 +1,5 @@
-import {
-  FetchOptions,
-  FetchResultV2,
-  SimpleAdapter,
-} from "../../adapters/types";
-import {
-  DZAP_SUPPORTED_CHAINS,
-  fetchChainWiseVolumeFromDZapAPI,
-} from "../../helpers/aggregators/dzap";
+import { FetchOptions, FetchResultV2, SimpleAdapter } from "../../adapters/types";
+import { DZAP_SUPPORTED_CHAINS, fetchChainWiseVolumeFromDZapAPI } from "../../helpers/aggregators/dzap";
 
 const prefetch = async (options: FetchOptions): Promise<FetchResultV2> =>
   fetchChainWiseVolumeFromDZapAPI({ ...options, txType: "bridge" });
@@ -22,7 +15,6 @@ const fetch = async (_a: any, _b: any, options: FetchOptions) => {
 const adapter: SimpleAdapter = {
   version: 1,
   fetch,
-  pullHourly: true,
   chains: Object.values(DZAP_SUPPORTED_CHAINS),
   start: "2023-01-01",
   prefetch,

--- a/bridge-aggregators/dzap/index.ts
+++ b/bridge-aggregators/dzap/index.ts
@@ -1,130 +1,31 @@
-import { FetchOptions, SimpleAdapter } from "../../adapters/types";
-import { httpGet } from "../../utils/fetchURL";
-import { CHAIN } from "../../helpers/chains";
+import {
+  FetchOptions,
+  FetchResultV2,
+  SimpleAdapter,
+} from "../../adapters/types";
+import {
+  DZAP_SUPPORTED_CHAINS,
+  fetchChainWiseVolumeFromDZapAPI,
+} from "../../helpers/aggregators/dzap";
 
-const CHAIN_VOLUME_API = "https://api.dzap.io/v1/volume/chain";
-
-const chains: Record<string, number> = {
-  [CHAIN.ETHEREUM]: 1,
-  [CHAIN.OPTIMISM]: 10,
-  [CHAIN.FLARE]: 14,
-  [CHAIN.CRONOS]: 25,
-  [CHAIN.ROOTSTOCK]: 30,
-  [CHAIN.TELOS]: 40,
-  [CHAIN.XDC]: 50,
-  [CHAIN.BSC]: 56,
-  [CHAIN.XDAI]: 100,
-  [CHAIN.FUSE]: 122,
-  [CHAIN.UNICHAIN]: 130,
-  [CHAIN.MONAD]: 143,
-  [CHAIN.POLYGON]: 137,
-  [CHAIN.SONIC]: 146,
-  [CHAIN.MANTA]: 169,
-  [CHAIN.MINT]: 185,
-  [CHAIN.XLAYER]: 196,
-  [CHAIN.OP_BNB]: 204,
-  [CHAIN.BSQUARED]: 223,
-  [CHAIN.LENS]: 232,
-  [CHAIN.FANTOM]: 250,
-  [CHAIN.FRAXTAL]: 252,
-  [CHAIN.KROMA]: 255,
-  [CHAIN.BOBA]: 288,
-  [CHAIN.ZKSYNC]: 324,
-  [CHAIN.PULSECHAIN]: 369,
-  [CHAIN.WC]: 480,
-  [CHAIN.STABLE]: 988,
-  [CHAIN.HYPERLIQUID]: 998,
-  [CHAIN.BITCOIN]: 1000,
-  [CHAIN.METIS]: 1088,
-  [CHAIN.POLYGON_ZKEVM]: 1101,
-  [CHAIN.CORE]: 1116,
-  [CHAIN.MOONBEAM]: 1284,
-  [CHAIN.MOONRIVER]: 1285,
-  [CHAIN.SEI]: 1329,
-  [CHAIN.STORY]: 1514,
-  [CHAIN.GRAVITY]: 1625,
-  [CHAIN.SONEIUM]: 1868,
-  [CHAIN.SWELLCHAIN]: 1923,
-  [CHAIN.RONIN]: 2020,
-  [CHAIN.KAVA]: 2222,
-  [CHAIN.ABSTRACT]: 2741,
-  [CHAIN.MORPH]: 2818,
-  [CHAIN.MERLIN]: 4200,
-  [CHAIN.MEGAETH]: 4326,
-  [CHAIN.MANTLE]: 5000,
-  [CHAIN.BAHAMUT]: 5165,
-  [CHAIN.ZETA]: 7000,
-  [CHAIN.BASE]: 8453,
-  [CHAIN.KLAYTN]: 8217,
-  [CHAIN.PLASMA]: 9745,
-  [CHAIN.IMX]: 13371,
-  [CHAIN.SUI]: 19219,
-  [CHAIN.APECHAIN]: 33139,
-  [CHAIN.MODE]: 34443,
-  [CHAIN.ARBITRUM]: 42161,
-  [CHAIN.CELO]: 42220,
-  [CHAIN.ZKFAIR]: 42766,
-  [CHAIN.HEMI]: 43111,
-  [CHAIN.AVAX]: 43114,
-  [CHAIN.ZIRCUIT]: 48900,
-  [CHAIN.SUPERPOSITION]: 55244,
-  [CHAIN.INK]: 57073,
-  [CHAIN.LINEA]: 59144,
-  [CHAIN.BOB]: 60808,
-  [CHAIN.BERACHAIN]: 80094,
-  [CHAIN.BLAST]: 81457,
-  [CHAIN.PLUME]: 98866,
-  [CHAIN.TAIKO]: 167000,
-  [CHAIN.BITLAYER]: 200901,
-  [CHAIN.SCROLL]: 534352,
-  [CHAIN.KATANA]: 747474,
-  [CHAIN.SOLANA]: 7565164,
-  [CHAIN.AURORA]: 1313161554,
-};
-
-interface ApiResponse {
-  swap: {
-    allTime: number;
-    last24Hours: number;
-    last7Days: number;
-    last30Days: number;
-    last90Days: number;
-  };
-  bridge: {
-    allTime: number;
-    last24Hours: number;
-    last7Days: number;
-    last30Days: number;
-    last90Days: number;
-  };
-}
-
-const prefetch = async (options: FetchOptions) => {
-  const data: Record<string, any> = {};
-  for (const chain of Object.keys(chains)) {
-    await new Promise((resolve) => setTimeout(resolve, 13000));
-    data[chain] = await httpGet(
-      `${CHAIN_VOLUME_API}?chainId=${chains[chain as keyof typeof chains]}`,
-    );
-  }
-  return data;
-};
+const prefetch = async (options: FetchOptions): Promise<FetchResultV2> =>
+  fetchChainWiseVolumeFromDZapAPI({ ...options, txType: "bridge" });
 
 const fetch = async (_a: any, _b: any, options: FetchOptions) => {
-  const data: ApiResponse = options.preFetchedResults[options.chain];
+  const volume = options.preFetchedResults[options.chain] ?? 0;
 
   return {
-    dailyBridgeVolume: data.bridge.last24Hours,
+    dailyBridgeVolume: volume,
   };
 };
 
 const adapter: SimpleAdapter = {
   version: 1,
   fetch,
-  chains: Object.keys(chains),
+  pullHourly: true,
+  chains: Object.values(DZAP_SUPPORTED_CHAINS),
   start: "2023-01-01",
   prefetch,
-  runAtCurrTime: true,
 };
 
 export default adapter;

--- a/helpers/aggregators/dzap.ts
+++ b/helpers/aggregators/dzap.ts
@@ -1,0 +1,127 @@
+import { FetchOptions, FetchResultV2 } from "../../adapters/types";
+import { httpGet } from "../../utils/fetchURL";
+import { CHAIN } from "../../helpers/chains";
+
+export const DZAP_VOLUME_CHAIN_URL = "https://api.dzap.io/v1/volume/chain";
+
+export const DZAP_SUPPORTED_CHAINS: Record<number, CHAIN> = {
+  1: CHAIN.ETHEREUM,
+  10: CHAIN.OPTIMISM,
+  14: CHAIN.FLARE,
+  25: CHAIN.CRONOS,
+  30: CHAIN.ROOTSTOCK,
+  40: CHAIN.TELOS,
+  50: CHAIN.XDC,
+  56: CHAIN.BSC,
+  100: CHAIN.XDAI,
+  122: CHAIN.FUSE,
+  130: CHAIN.UNICHAIN,
+  137: CHAIN.POLYGON,
+  143: CHAIN.MONAD,
+  146: CHAIN.SONIC,
+  169: CHAIN.MANTA,
+  185: CHAIN.MINT,
+  196: CHAIN.XLAYER,
+  204: CHAIN.OP_BNB,
+  223: CHAIN.BSQUARED,
+  232: CHAIN.LENS,
+  250: CHAIN.FANTOM,
+  252: CHAIN.FRAXTAL,
+  255: CHAIN.KROMA,
+  288: CHAIN.BOBA,
+  324: CHAIN.ZKSYNC,
+  369: CHAIN.PULSECHAIN,
+  480: CHAIN.WC,
+  988: CHAIN.STABLE,
+  998: CHAIN.HYPERLIQUID,
+  1000: CHAIN.BITCOIN,
+  1088: CHAIN.METIS,
+  1101: CHAIN.POLYGON_ZKEVM,
+  1116: CHAIN.CORE,
+  1284: CHAIN.MOONBEAM,
+  1285: CHAIN.MOONRIVER,
+  1329: CHAIN.SEI,
+  1514: CHAIN.STORY,
+  1625: CHAIN.GRAVITY,
+  1868: CHAIN.SONEIUM,
+  1923: CHAIN.SWELLCHAIN,
+  2020: CHAIN.RONIN,
+  2222: CHAIN.KAVA,
+  2741: CHAIN.ABSTRACT,
+  2818: CHAIN.MORPH,
+  4114: CHAIN.CITREA,
+  4200: CHAIN.MERLIN,
+  4217: CHAIN.TEMPO,
+  4326: CHAIN.MEGAETH,
+  5000: CHAIN.MANTLE,
+  5165: CHAIN.BAHAMUT,
+  7000: CHAIN.ZETA,
+  8453: CHAIN.BASE,
+  8217: CHAIN.KLAYTN,
+  9745: CHAIN.PLASMA,
+  13371: CHAIN.IMX,
+  19219: CHAIN.SUI,
+  33139: CHAIN.APECHAIN,
+  34443: CHAIN.MODE,
+  42161: CHAIN.ARBITRUM,
+  42220: CHAIN.CELO,
+  42766: CHAIN.ZKFAIR,
+  43111: CHAIN.HEMI,
+  43114: CHAIN.AVAX,
+  48900: CHAIN.ZIRCUIT,
+  55244: CHAIN.SUPERPOSITION,
+  57073: CHAIN.INK,
+  59144: CHAIN.LINEA,
+  60808: CHAIN.BOB,
+  80094: CHAIN.BERACHAIN,
+  81457: CHAIN.BLAST,
+  98866: CHAIN.PLUME,
+  167000: CHAIN.TAIKO,
+  200901: CHAIN.BITLAYER,
+  534352: CHAIN.SCROLL,
+  747474: CHAIN.KATANA,
+  7565164: CHAIN.SOLANA,
+  1313161554: CHAIN.AURORA,
+};
+
+export type DzapVolumeSide = {
+  allTime: number;
+  last24Hours: number;
+};
+
+export type DzapChainVolumeRow = {
+  swap: DzapVolumeSide;
+  bridge: DzapVolumeSide;
+};
+
+function normalizeVolume(
+  raw: Partial<DzapChainVolumeRow> | undefined,
+  txType: "swap" | "bridge"
+): number {
+  return raw?.[txType]?.last24Hours ?? 0;
+}
+
+export async function fetchChainWiseVolumeFromDZapAPI(
+  options: FetchOptions & { txType: "swap" | "bridge" }
+): Promise<FetchResultV2> {
+  const startDate = new Date(options.fromTimestamp * 1000).toISOString();
+  const endDate = new Date(options.toTimestamp * 1000).toISOString();
+  const query = new URLSearchParams({
+    txType: options.txType,
+    startDate,
+    endDate,
+  });
+
+  const url = `${DZAP_VOLUME_CHAIN_URL}?${query.toString()}`;
+  const raw = (await httpGet(url)) as Partial<
+    Record<number, DzapChainVolumeRow>
+  >;
+  return Object.fromEntries(
+    Object.entries(raw).flatMap(([chainIdStr, data]) => {
+      const chainId = Number(chainIdStr);
+      const chainName = DZAP_SUPPORTED_CHAINS[chainId];
+      if (!chainName) return [];
+      return [[chainName, normalizeVolume(data, options.txType)] as const];
+    })
+  );
+}


### PR DESCRIPTION
This updates the DZAP adapters to use the new Volume API behavior where a single request returns chain-wise results for all chains, avoiding per-chain request loops and reducing rate-limit issues.

It also adds backfill support by passing startDate / endDate filters.