### PR TITLE
Add rise adapter

### DIFF
--- a/dexs/rise.ts
+++ b/dexs/rise.ts
@@ -1,0 +1,34 @@
+import { FetchOptions, SimpleAdapter } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+import fetchURL from "../utils/fetchURL";
+
+const ENDPOINT = "https://public.rise.rich/public/defillama/dex-volume";
+
+interface VolumeResponse {
+  totalVolumeUsd: number;
+}
+
+const fetch = async (_a: any, _b: any, options: FetchOptions) => {
+  const url = `${ENDPOINT}?from=${options.startTimestamp}&to=${options.endTimestamp}`;
+  const res: VolumeResponse = await fetchURL(url);
+
+  const dailyVolume = options.createBalances();
+  dailyVolume.addUSDValue(Number(res?.totalVolumeUsd) || 0);
+  return { dailyVolume };
+};
+
+const adapter: SimpleAdapter = {
+  version: 1,
+  adapter: {
+    [CHAIN.SOLANA]: {
+      fetch,
+      start: "2026-04-02",
+    },
+  },
+  methodology: {
+    Volume:
+      "Buy/sell/create trade notional plus borrow and repay amounts on rise.rich bonding-curve markets, USD-valued at the collateral price.",
+  },
+};
+
+export default adapter;

--- a/dexs/rise.ts
+++ b/dexs/rise.ts
@@ -5,15 +5,26 @@ import fetchURL from "../utils/fetchURL";
 const ENDPOINT = "https://public.rise.rich/public/defillama/dex-volume";
 
 interface VolumeResponse {
-  totalVolumeUsd: number;
+  breakdown: {
+    volume_buy: number;
+    volume_sell: number;
+    volume_borrow: number;
+    volume_repay: number;
+  };
 }
 
 const fetch = async (_a: any, _b: any, options: FetchOptions) => {
   const url = `${ENDPOINT}?from=${options.startTimestamp}&to=${options.endTimestamp}`;
   const res: VolumeResponse = await fetchURL(url);
 
+  // DEX dashboard tracks swap-only volume. Borrow/repay are lending operations
+  // and excluded here; the lending fee is still surfaced in fees/rise.ts.
+  // `volume_buy` already includes 'create' (the first buy of a new market).
+  const tradeVolume =
+    (res?.breakdown?.volume_buy || 0) + (res?.breakdown?.volume_sell || 0);
+
   const dailyVolume = options.createBalances();
-  dailyVolume.addUSDValue(Number(res?.totalVolumeUsd) || 0);
+  dailyVolume.addUSDValue(tradeVolume);
   return { dailyVolume };
 };
 
@@ -27,7 +38,7 @@ const adapter: SimpleAdapter = {
   },
   methodology: {
     Volume:
-      "Buy/sell/create trade notional plus borrow and repay amounts on rise.rich bonding-curve markets, USD-valued at the collateral price.",
+      "Sum of buy/sell trade notional on rise.rich bonding-curve markets, USD-valued at the collateral price. 'Buy' includes the initial mint ('create') of a new market. Borrow/repay activity is excluded from DEX volume and surfaced via the fees adapter.",
   },
 };
 

--- a/dexs/rise.ts
+++ b/dexs/rise.ts
@@ -2,6 +2,7 @@ import { FetchOptions, SimpleAdapter } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
 import fetchURL from "../utils/fetchURL";
 
+// onchain query : https://github.com/DefiLlama/dimension-adapters/pull/6765
 const ENDPOINT = "https://public.rise.rich/public/defillama/dex-volume";
 
 interface VolumeResponse {
@@ -17,29 +18,31 @@ const fetch = async (_a: any, _b: any, options: FetchOptions) => {
   const url = `${ENDPOINT}?from=${options.startTimestamp}&to=${options.endTimestamp}`;
   const res: VolumeResponse = await fetchURL(url);
 
+  if(!res || !res.breakdown) {
+    throw new Error(`No data found for date ${options.dateString}`);
+  }
+
   // DEX dashboard tracks swap-only volume. Borrow/repay are lending operations
   // and excluded here; the lending fee is still surfaced in fees/rise.ts.
   // `volume_buy` already includes 'create' (the first buy of a new market).
-  const tradeVolume =
-    (res?.breakdown?.volume_buy || 0) + (res?.breakdown?.volume_sell || 0);
+  const tradeVolume = (res.breakdown.volume_buy || 0) + (res.breakdown.volume_sell || 0);
 
   const dailyVolume = options.createBalances();
   dailyVolume.addUSDValue(tradeVolume);
   return { dailyVolume };
 };
 
+const methodology = {
+  Volume:
+    "Sum of buy/sell trade notional on rise.rich bonding-curve markets, USD-valued at the collateral price. 'Buy' includes the initial mint ('create') of a new market. Borrow/repay activity is excluded from DEX volume and surfaced via the fees adapter.",
+};
+
 const adapter: SimpleAdapter = {
   version: 1,
-  adapter: {
-    [CHAIN.SOLANA]: {
-      fetch,
-      start: "2026-04-02",
-    },
-  },
-  methodology: {
-    Volume:
-      "Sum of buy/sell trade notional on rise.rich bonding-curve markets, USD-valued at the collateral price. 'Buy' includes the initial mint ('create') of a new market. Borrow/repay activity is excluded from DEX volume and surfaced via the fees adapter.",
-  },
+  chains: [CHAIN.SOLANA],
+  start: "2026-04-02",
+  fetch,
+  methodology,
 };
 
 export default adapter;

--- a/fees/rise.ts
+++ b/fees/rise.ts
@@ -1,0 +1,116 @@
+import { FetchOptions, SimpleAdapter } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+import fetchURL from "../utils/fetchURL";
+
+const ENDPOINT = "https://public.rise.rich/public/defillama/fees";
+
+interface FeesResponse {
+  totalFeesUsd: number;
+  totalRevenueUsd: number;
+  totalProtocolRevenueUsd: number;
+  totalSupplySideRevenueUsd: number;
+  breakdown: {
+    trade_fees: number;
+    borrow_fees: number;
+  };
+}
+
+// Labels reused across every dimension so the breakdown is consistent.
+const TRADE_FEES_LABEL = "Trade Fees";
+const BORROW_FEES_LABEL = "Borrow Fees";
+
+// Of every fee collected:
+//   25%   → creator + floor (on-chain, supply-side)
+//   75%   → rise team wallet (= revenue)
+//     ├─ 75% × 75% = 56.25% → rise treasury (protocolRevenue)
+//     └─ 75% × 25% = 18.75% → off-chain ops (not surfaced)
+const REVENUE_RATIO = 0.75;
+const PROTOCOL_REVENUE_RATIO = 0.5625;
+const SUPPLY_SIDE_REVENUE_RATIO = 0.25;
+
+const fetch = async (_a: any, _b: any, options: FetchOptions) => {
+  const url = `${ENDPOINT}?from=${options.startTimestamp}&to=${options.endTimestamp}`;
+  const res: FeesResponse = await fetchURL(url);
+
+  const tradeFees = Number(res?.breakdown?.trade_fees) || 0;
+  const borrowFees = Number(res?.breakdown?.borrow_fees) || 0;
+
+  const dailyFees = options.createBalances();
+  const dailyRevenue = options.createBalances();
+  const dailyProtocolRevenue = options.createBalances();
+  const dailySupplySideRevenue = options.createBalances();
+
+  dailyFees.addUSDValue(tradeFees, TRADE_FEES_LABEL);
+  dailyFees.addUSDValue(borrowFees, BORROW_FEES_LABEL);
+
+  dailyRevenue.addUSDValue(tradeFees * REVENUE_RATIO, TRADE_FEES_LABEL);
+  dailyRevenue.addUSDValue(borrowFees * REVENUE_RATIO, BORROW_FEES_LABEL);
+
+  dailyProtocolRevenue.addUSDValue(
+    tradeFees * PROTOCOL_REVENUE_RATIO,
+    TRADE_FEES_LABEL,
+  );
+  dailyProtocolRevenue.addUSDValue(
+    borrowFees * PROTOCOL_REVENUE_RATIO,
+    BORROW_FEES_LABEL,
+  );
+
+  dailySupplySideRevenue.addUSDValue(
+    tradeFees * SUPPLY_SIDE_REVENUE_RATIO,
+    TRADE_FEES_LABEL,
+  );
+  dailySupplySideRevenue.addUSDValue(
+    borrowFees * SUPPLY_SIDE_REVENUE_RATIO,
+    BORROW_FEES_LABEL,
+  );
+
+  return {
+    dailyFees,
+    dailyRevenue,
+    dailyProtocolRevenue,
+    dailySupplySideRevenue,
+  };
+};
+
+const methodology = {
+  Fees: "1.25% on every buy/sell trade and 3% on every borrow (gross principal). Includes both bonding-curve trading fees and lending fees.",
+  Revenue:
+    "75% of total fees collected by the rise team wallet (on-chain protocol share, before any internal split).",
+  ProtocolRevenue:
+    "56.25% of total fees — the rise treasury share (75% of the team wallet's 75% gross share).",
+  SupplySideRevenue:
+    "25% of total fees paid to creators and the per-market floor reserve (split per-market by creator_fee_percent).",
+};
+
+const breakdownMethodology = {
+  Fees: {
+    [TRADE_FEES_LABEL]: "1.25% of trade notional on buy/sell/create transactions.",
+    [BORROW_FEES_LABEL]: "3% of gross borrow principal taken at borrow time.",
+  },
+  Revenue: {
+    [TRADE_FEES_LABEL]: "75% of trade fees flowing to the rise team wallet.",
+    [BORROW_FEES_LABEL]: "75% of borrow fees flowing to the rise team wallet.",
+  },
+  ProtocolRevenue: {
+    [TRADE_FEES_LABEL]: "56.25% of trade fees ending up in the rise treasury.",
+    [BORROW_FEES_LABEL]: "56.25% of borrow fees ending up in the rise treasury.",
+  },
+  SupplySideRevenue: {
+    [TRADE_FEES_LABEL]: "25% of trade fees split between the market creator and the market's floor reserve.",
+    [BORROW_FEES_LABEL]: "25% of borrow fees split between the market creator and the market's floor reserve.",
+  },
+};
+
+const adapter: SimpleAdapter = {
+  version: 1,
+  adapter: {
+    [CHAIN.SOLANA]: {
+      fetch,
+      start: "2026-04-02",
+    },
+  },
+  methodology,
+  breakdownMethodology,
+};
+
+export default adapter;

--- a/fees/rise.ts
+++ b/fees/rise.ts
@@ -16,58 +16,45 @@ interface FeesResponse {
 }
 
 // Labels reused across every dimension so the breakdown is consistent.
-const TRADE_FEES_LABEL = "Trade Fees";
+const TRADING_FEES_LABEL = "Trading Fees";
 const BORROW_FEES_LABEL = "Borrow Fees";
 
 // Of every fee collected:
 //   25%   → creator + floor (on-chain, supply-side)
 //   75%   → rise team wallet (= revenue)
 //     ├─ 75% × 75% = 56.25% → rise treasury (protocolRevenue)
-//     └─ 75% × 25% = 18.75% → off-chain ops (not surfaced)
+//     └─ 75% × 25% = 18.75% → off-chain ops (not surfaced) -> Not handling this as we dont have metric for OE
 const REVENUE_RATIO = 0.75;
-const PROTOCOL_REVENUE_RATIO = 0.5625;
 const SUPPLY_SIDE_REVENUE_RATIO = 0.25;
 
 const fetch = async (_a: any, _b: any, options: FetchOptions) => {
   const url = `${ENDPOINT}?from=${options.startTimestamp}&to=${options.endTimestamp}`;
   const res: FeesResponse = await fetchURL(url);
 
-  const tradeFees = Number(res?.breakdown?.trade_fees) || 0;
-  const borrowFees = Number(res?.breakdown?.borrow_fees) || 0;
+  if (!res || !res.breakdown) {
+    throw new Error(`No data found for date ${options.dateString}`);
+  }
+
+  const tradeFees = Number(res.breakdown.trade_fees) || 0;
+  const borrowFees = Number(res.breakdown.borrow_fees) || 0;
 
   const dailyFees = options.createBalances();
   const dailyRevenue = options.createBalances();
-  const dailyProtocolRevenue = options.createBalances();
   const dailySupplySideRevenue = options.createBalances();
 
-  dailyFees.addUSDValue(tradeFees, TRADE_FEES_LABEL);
+  dailyFees.addUSDValue(tradeFees, TRADING_FEES_LABEL);
   dailyFees.addUSDValue(borrowFees, BORROW_FEES_LABEL);
 
-  dailyRevenue.addUSDValue(tradeFees * REVENUE_RATIO, TRADE_FEES_LABEL);
-  dailyRevenue.addUSDValue(borrowFees * REVENUE_RATIO, BORROW_FEES_LABEL);
+  dailyRevenue.addUSDValue(tradeFees * REVENUE_RATIO, "Trading fees to team wallet");
+  dailyRevenue.addUSDValue(borrowFees * REVENUE_RATIO, "Borrow fees to team wallet");
 
-  dailyProtocolRevenue.addUSDValue(
-    tradeFees * PROTOCOL_REVENUE_RATIO,
-    TRADE_FEES_LABEL,
-  );
-  dailyProtocolRevenue.addUSDValue(
-    borrowFees * PROTOCOL_REVENUE_RATIO,
-    BORROW_FEES_LABEL,
-  );
-
-  dailySupplySideRevenue.addUSDValue(
-    tradeFees * SUPPLY_SIDE_REVENUE_RATIO,
-    TRADE_FEES_LABEL,
-  );
-  dailySupplySideRevenue.addUSDValue(
-    borrowFees * SUPPLY_SIDE_REVENUE_RATIO,
-    BORROW_FEES_LABEL,
-  );
+  dailySupplySideRevenue.addUSDValue(tradeFees * SUPPLY_SIDE_REVENUE_RATIO, "Trading fees to creator and floor reserve");
+  dailySupplySideRevenue.addUSDValue(borrowFees * SUPPLY_SIDE_REVENUE_RATIO, "Borrow fees to creator and floor reserve");
 
   return {
     dailyFees,
     dailyRevenue,
-    dailyProtocolRevenue,
+    dailyProtocolRevenue: dailyRevenue,
     dailySupplySideRevenue,
   };
 };
@@ -77,38 +64,35 @@ const methodology = {
   Revenue:
     "75% of total fees collected by the rise team wallet (on-chain protocol share, before any internal split).",
   ProtocolRevenue:
-    "56.25% of total fees — the rise treasury share (75% of the team wallet's 75% gross share).",
+    "75% of total fees collected by the rise team wallet (on-chain protocol share, before any internal split).",
   SupplySideRevenue:
     "25% of total fees paid to creators and the per-market floor reserve (split per-market by creator_fee_percent).",
 };
 
 const breakdownMethodology = {
   Fees: {
-    [TRADE_FEES_LABEL]: "1.25% of trade notional on buy/sell/create transactions.",
+    [TRADING_FEES_LABEL]: "1.25% of trade notional on buy/sell/create transactions.",
     [BORROW_FEES_LABEL]: "3% of gross borrow principal taken at borrow time.",
   },
   Revenue: {
-    [TRADE_FEES_LABEL]: "75% of trade fees flowing to the rise team wallet.",
-    [BORROW_FEES_LABEL]: "75% of borrow fees flowing to the rise team wallet.",
+    ["Trading fees to team wallet"]: "75% of trade fees flowing to the rise team wallet.",
+    ["Borrow fees to team wallet"]: "75% of borrow fees flowing to the rise team wallet.",
   },
   ProtocolRevenue: {
-    [TRADE_FEES_LABEL]: "56.25% of trade fees ending up in the rise treasury.",
-    [BORROW_FEES_LABEL]: "56.25% of borrow fees ending up in the rise treasury.",
+    ["Trading fees to team wallet"]: "75% of trade fees ending up in the rise treasury.",
+    ["Borrow fees to team wallet"]: "75% of borrow fees ending up in the rise treasury.",
   },
   SupplySideRevenue: {
-    [TRADE_FEES_LABEL]: "25% of trade fees split between the market creator and the market's floor reserve.",
-    [BORROW_FEES_LABEL]: "25% of borrow fees split between the market creator and the market's floor reserve.",
+    ["Trading fees to creator and floor reserve"]: "25% of trade fees split between the market creator and the market's floor reserve.",
+    ["Borrow fees to creator and floor reserve"]: "25% of borrow fees split between the market creator and the market's floor reserve.",
   },
 };
 
 const adapter: SimpleAdapter = {
   version: 1,
-  adapter: {
-    [CHAIN.SOLANA]: {
-      fetch,
-      start: "2026-04-02",
-    },
-  },
+  chains: [CHAIN.SOLANA],
+  start: "2026-04-02",
+  fetch,
   methodology,
   breakdownMethodology,
 };


### PR DESCRIPTION
## Rise

Adapter for [Rise](https://rise.rich) — a Solana bonding-curve launchpad with built-in lending against bonded tokens.

- Website: https://rise.rich
- Twitter: https://x.com/risedotrich

## What's included

- `dexs/rise.ts` — daily volume (buy + sell + create + borrow + repay), USD-valued at the collateral price.
- `fees/rise.ts` — daily fees with breakdown for trade fees (1.25%) and borrow fees (3% of gross principal), plus revenue / protocolRevenue / supplySideRevenue split.

## Fee economics

- **Trade fee** = 1.25% on every buy/sell/create.
- **Borrow fee** = 3% of gross principal, taken at borrow time.

Of every fee collected:
- 25% → creator + floor (supply-side, on-chain split)
- 75% → rise team wallet (revenue)
  - 75% × 75% = 56.25% → rise treasury (`protocolRevenue`)
  - 75% × 25% = 18.75% → off-chain ops (not surfaced)

## Data source

Both adapters call public read-only endpoints exposed by the rise backend at `https://public.rise.rich/public/defillama/...`. The backend serves pre-aggregated cumulative volume per type from a snapshot table populated hourly from on-chain market_transaction events, so each call is a constant-time DB lookup.

## Test

```
npm test dexs rise
npm test fees rise
```

Both return non-zero values on the live endpoint.
