### PR TITLE
[feat] MAMO - Track fees and revenue

### DIFF
--- a/fees/mamo.ts
+++ b/fees/mamo.ts
@@ -1,0 +1,43 @@
+import { FetchOptions, SimpleAdapter } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+import { addTokensReceived } from "../helpers/token";
+import ADDRESSES from "../helpers/coreAssets.json";
+
+// MAMO staking contract that receives Aerodrome LP trading fees weekly
+const MAMO_MULTI_REWARDS = "0x7855B0821401Ab078f6Cf457dEAFae775fF6c7A3";
+
+// Reward tokens distributed to MAMO stakers
+const MAMO_TOKEN = "0x7300B37DfdfAb110d83290A29DfB31B1740219fE";
+const cbBTC = ADDRESSES.base.cbBTC;
+
+const fetch = async (options: FetchOptions) => {
+  // Track reward tokens deposited into the staking contract each day
+  const dailyFees = await addTokensReceived({
+    options,
+    targets: [MAMO_MULTI_REWARDS],
+    tokens: [MAMO_TOKEN, cbBTC],
+  });
+
+  return {
+    dailyFees,
+    dailyRevenue: dailyFees,
+    dailyHoldersRevenue: dailyFees,
+  };
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  adapter: {
+    [CHAIN.BASE]: {
+      fetch,
+      start: "2025-09-01",
+    },
+  },
+  methodology: {
+    Fees: "Aerodrome LP trading fees collected by the Mamo protocol and distributed to MAMO stakers.",
+    Revenue: "All fees are distributed to MAMO stakers; no protocol treasury cut.",
+    HoldersRevenue: "100% of fees distributed to MAMO token stakers via the multi-rewards contract.",
+  },
+};
+
+export default adapter;

--- a/fees/mamo.ts
+++ b/fees/mamo.ts
@@ -5,166 +5,184 @@ import ADDRESSES from "../helpers/coreAssets.json";
 
 const MAMO_MULTI_REWARDS = "0x7855B0821401Ab078f6Cf457dEAFae775fF6c7A3";
 const MAMO_TOKEN = "0x7300B37DfdfAb110d83290A29DfB31B1740219fE";
+const MAMO_STRATEGY_REGISTRY = "0x46a5624C2ba92c08aBA4B206297052EDf14baa92";
 
 // Per-asset config hardcoded from mamo-contracts/addresses/8453.json
 const CONFIGS = [
-  {
-    factory: "0x3098360e627E84Fb9dD621F01ea03E325cCEE2c6",
-    mToken: "0xEdc817A28E8B93B03976FBd4a3dDBc9f7D176c22", // Moonwell mUSDC
-    morphoVault: "0xc1256Ae5FF1cf2719D4937adb3bbCCab2E00A2Ca", // Moonwell Flagship USDC
-    token: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913", // USDC
-  },
-  {
-    factory: "0xf8CFdEf5068929e022a50315983043b61E9987f8",
-    mToken: "0xF877ACaFA28c19b96727966690b2f44d35aD5976", // Moonwell mcbBTC
-    morphoVault: "0x543257eF2161176D7C8cD90BA65C2d4CaEF5a796", // MetaMorpho cbBTC
-    token: ADDRESSES.base.cbBTC,
-  },
-  {
-    factory: "0x14bA47Ef0286B345E2B74d26243767268290eE28",
-    mToken: "0x628ff693426583D9a7FB391E54366292F509D457", // Moonwell mWETH
-    morphoVault: "0xa0E430870c4604CcfC7B38Ca7845B1FF653D0ff1", // MetaMorpho WETH
-    token: ADDRESSES.base.WETH,
-  },
+    {
+        mToken: "0xEdc817A28E8B93B03976FBd4a3dDBc9f7D176c22", // Moonwell mUSDC
+        morphoVault: "0xc1256Ae5FF1cf2719D4937adb3bbCCab2E00A2Ca", // Moonwell Flagship USDC
+        underlying: ADDRESSES.base.USDC,
+        underlyingDecimals: 6,
+
+    },
+    {
+        mToken: "0xF877ACaFA28c19b96727966690b2f44d35aD5976", // Moonwell mcbBTC
+        morphoVault: "0x543257eF2161176D7C8cD90BA65C2d4CaEF5a796", // MetaMorpho cbBTC
+        underlying: ADDRESSES.base.cbBTC,
+        underlyingDecimals: 8,
+    },
+    {
+        mToken: "0x628ff693426583D9a7FB391E54366292F509D457", // Moonwell mWETH
+        morphoVault: "0xa0E430870c4604CcfC7B38Ca7845B1FF653D0ff1", // MetaMorpho WETH
+        underlying: ADDRESSES.base.WETH,
+        underlyingDecimals: 18,
+    },
 ];
 
 const STRATEGY_CREATED = "event StrategyCreated(address indexed user, address indexed strategy)";
-const FACTORY_DEPLOY_BLOCK = 20_000_000; // Base ~Jul 2025
+const STRATEGY_ADDED = "event StrategyAdded (address indexed user, address strategy, address implementation)";
+const STRATEGY_DEPLOYED_BLOCK = 30235637;
 
 const fetch = async (options: FetchOptions) => {
-  const dailySupplySideRevenue = options.createBalances();
+    const dailySupplySideRevenue = options.createBalances();
 
-  for (const config of CONFIGS) {
-    const logs = await options.getLogs({
-      target: config.factory,
-      eventAbi: STRATEGY_CREATED,
-      fromBlock: FACTORY_DEPLOY_BLOCK,
+    const strategies = await options.getLogs({
+        target: MAMO_STRATEGY_REGISTRY,
+        eventAbi: STRATEGY_ADDED,
+        fromBlock: STRATEGY_DEPLOYED_BLOCK,
+        cacheInCloud: true,
+    })
+
+    const mTokens = await options.api.multiCall({
+        abi: "address:mToken",
+        calls: strategies.map((s) => ({ target: s.strategy })),
+        permitFailure: true,
+    })
+
+    const morphoVaults = await options.api.multiCall({
+        abi: "address:metaMorphoVault",
+        calls: strategies.map((s) => ({ target: s.strategy })),
+        permitFailure: true,
+    })
+
+    const mTokenToStrategies = new Map<string, typeof strategies>()
+    mTokens.forEach((mToken, index) => {
+        if (mToken) {
+            const existing = mTokenToStrategies.get(mToken) || []
+            existing.push(strategies[index])
+            mTokenToStrategies.set(mToken, existing)
+        }
+    })
+
+    const morphoVaultToStrategies = new Map<string, typeof strategies>()
+    morphoVaults.forEach((morphoVault, index) => {
+        if (morphoVault) {
+            const existing = morphoVaultToStrategies.get(morphoVault) || []
+            existing.push(strategies[index])
+            morphoVaultToStrategies.set(morphoVault, existing)
+        }
+    })
+
+    const [mTokenPriceBeforeArray, mTokenPriceAfterArray] = await Promise.all([
+        options.fromApi.multiCall({
+            abi: "function exchangeRateStored() view returns (uint256)",
+            calls: CONFIGS.map((c) => ({ target: c.mToken })),
+            permitFailure: true,
+        }),
+        options.toApi.multiCall({
+            abi: "function exchangeRateStored() view returns (uint256)",
+            calls: CONFIGS.map((c) => ({ target: c.mToken })),
+            permitFailure: true,
+        }),
+    ])
+
+    const PRICE_QUERY = "1000000000000000000";
+
+    const [morphoVaultPriceBeforeArray, morphoVaultPriceAfterArray] = await Promise.all([
+        options.fromApi.multiCall({
+            abi: "function convertToAssets(uint256) view returns (uint256)",
+            calls: CONFIGS.map((c) => ({ target: c.morphoVault, params: [PRICE_QUERY] })),
+            permitFailure: true,
+        }),
+        options.toApi.multiCall({
+            abi: "function convertToAssets(uint256) view returns (uint256)",
+            calls: CONFIGS.map((c) => ({ target: c.morphoVault, params: [PRICE_QUERY] })),
+            permitFailure: true,
+        }),
+    ])
+
+
+    let index = 0;
+    for (let i = 0; i < CONFIGS.length; i++) {
+        const config = CONFIGS[i];
+        const mTokenExchangeRateDecimals = 18 + config.underlyingDecimals - 8;
+        const mTokenPriceBefore = mTokenPriceBeforeArray[i] / 10 ** mTokenExchangeRateDecimals;
+        const mTokenPriceAfter = mTokenPriceAfterArray[i] / 10 ** mTokenExchangeRateDecimals;
+        const morphoVaultPriceBefore = morphoVaultPriceBeforeArray[i] / 10 ** config.underlyingDecimals;
+        const morphoVaultPriceAfter = morphoVaultPriceAfterArray[i] / 10 ** config.underlyingDecimals
+
+        const strategies = mTokenToStrategies.get(config.mToken);
+
+        if (!strategies || !mTokenPriceBefore || !mTokenPriceAfter || !morphoVaultPriceBefore || !morphoVaultPriceAfter) continue;
+
+        const strategyMtokenBalances = await options.api.multiCall({
+            abi: "function balanceOf(address) view returns (uint256)",
+            calls: strategies.map((s) => ({ target: config.mToken, params: [s] })),
+            permitFailure: true,
+        })
+        const strategyMorphoVaultBalances = await options.api.multiCall({
+            abi: "function balanceOf(address) view returns (uint256)",
+            calls: strategies.map((s) => ({ target: config.morphoVault, params: [s] })),
+            permitFailure: true,
+        })
+
+        const totalMTokenBalance = strategyMtokenBalances.reduce((sum, balance) => sum + Number(balance ?? 0) / 10 ** 8, 0);
+        const totalMorphoVaultBalance = strategyMorphoVaultBalances.reduce((sum, balance) => sum + Number(balance ?? 0) / 10 ** config.underlyingDecimals, 0);
+
+        dailySupplySideRevenue.add(config.underlying, (mTokenPriceAfter - mTokenPriceBefore) * totalMTokenBalance, 'Moonwell Yield');
+        dailySupplySideRevenue.add(config.underlying, (morphoVaultPriceAfter - morphoVaultPriceBefore) * totalMorphoVaultBalance, 'MetaMorpho Yield');
+        index++;
+    }
+
+    // Aerodrome LP fees distributed to MAMO stakers
+    const dailyHoldersRevenue = await addTokensReceived({
+        options,
+        targets: [MAMO_MULTI_REWARDS],
+        tokens: [MAMO_TOKEN, ADDRESSES.base.cbBTC],
     });
 
-    // Safely extract strategy addresses — handle both direct and args-wrapped shapes
-    const strategies: string[] = logs
-      .map((l: any) => l.strategy ?? l.args?.strategy)
-      .filter((s: any): s is string => typeof s === "string" && s.startsWith("0x"));
+    const dailyFees = options.createBalances();
+    dailyFees.addBalances(dailySupplySideRevenue);
+    dailyFees.addBalances(dailyHoldersRevenue);
 
-    if (!strategies.length) continue;
-
-    const mTokenBalCalls = strategies.map((s) => ({ target: config.mToken, params: [s] }));
-    const morphoShareCalls = strategies.map((s) => ({ target: config.morphoVault, params: [s] }));
-    const PRICE_QUERY = "1000000000000000000"; // 1e18 shares
-
-    try {
-      // All balance/rate calls in parallel
-      const [
-        mTokenBals,
-        ratesFrom, ratesTo,
-        morphoShares,
-        pricesFrom, pricesTo,
-      ] = await Promise.all([
-        options.toApi.multiCall({
-          abi: "function balanceOf(address) view returns (uint256)",
-          calls: mTokenBalCalls,
-          permitFailure: true,
-        }),
-        options.fromApi.multiCall({
-          abi: "function exchangeRateStored() view returns (uint256)",
-          calls: [{ target: config.mToken, params: [] }],
-          permitFailure: true,
-        }),
-        options.toApi.multiCall({
-          abi: "function exchangeRateStored() view returns (uint256)",
-          calls: [{ target: config.mToken, params: [] }],
-          permitFailure: true,
-        }),
-        options.toApi.multiCall({
-          abi: "function balanceOf(address) view returns (uint256)",
-          calls: morphoShareCalls,
-          permitFailure: true,
-        }),
-        options.fromApi.multiCall({
-          abi: "function convertToAssets(uint256) view returns (uint256)",
-          calls: [{ target: config.morphoVault, params: [PRICE_QUERY] }],
-          permitFailure: true,
-        }),
-        options.toApi.multiCall({
-          abi: "function convertToAssets(uint256) view returns (uint256)",
-          calls: [{ target: config.morphoVault, params: [PRICE_QUERY] }],
-          permitFailure: true,
-        }),
-      ]);
-
-      const rateFrom = ratesFrom[0];
-      const rateTo = ratesTo[0];
-      const morphoPriceFrom = pricesFrom[0];
-      const morphoPriceTo = pricesTo[0];
-
-      // Moonwell yield: totalMTokenShares × Δ(exchangeRate) / 1e18
-      if (rateFrom != null && rateTo != null) {
-        const totalMTokenShares = mTokenBals.reduce(
-          (sum: number, b: any) => sum + Number(b ?? 0), 0
-        );
-        const mTokenYield = totalMTokenShares * (Number(rateTo) - Number(rateFrom)) / 1e18;
-        if (mTokenYield > 0) dailySupplySideRevenue.add(config.token, mTokenYield, 'Moonwell Yield');
-      }
-
-      // MetaMorpho yield: totalMorphoShares × Δ(pricePerShare) / 1e18
-      if (morphoPriceFrom != null && morphoPriceTo != null) {
-        const totalMorphoShares = morphoShares.reduce(
-          (sum: number, b: any) => sum + Number(b ?? 0), 0
-        );
-        const morphoYield = totalMorphoShares * (Number(morphoPriceTo) - Number(morphoPriceFrom)) / 1e18;
-        if (morphoYield > 0) dailySupplySideRevenue.add(config.token, morphoYield, 'MetaMorpho Yield');
-      }
-    } catch (_e) {
-      // Skip supply-side for this config if RPC fails for this block range
-    }
-  }
-
-  // Aerodrome LP fees distributed to MAMO stakers
-  const dailyHoldersRevenue = await addTokensReceived({
-    options,
-    targets: [MAMO_MULTI_REWARDS],
-    tokens: [MAMO_TOKEN, ADDRESSES.base.cbBTC],
-  });
-
-  const dailyFees = options.createBalances();
-  dailyFees.addBalances(dailySupplySideRevenue);
-  dailyFees.addBalances(dailyHoldersRevenue);
-
-  return {
-    dailyFees,
-    dailySupplySideRevenue,
-    dailyHoldersRevenue,
-  };
+    return {
+        dailyFees,
+        dailyRevenue: dailyHoldersRevenue,
+        dailySupplySideRevenue,
+        dailyHoldersRevenue,
+    };
 };
 
-const adapter: SimpleAdapter = {
-  version: 2,
-  pullHourly: true,
-  adapter: {
-    [CHAIN.BASE]: {
-      fetch,
-      start: "2025-09-01",
-    },
-  },
-  methodology: {
+const methodology = {
     Fees: "Yield earned by Mamo strategy depositors from Moonwell/MetaMorpho positions plus Aerodrome LP fees distributed to MAMO stakers.",
     SupplySideRevenue: "Interest accrued on user deposits via Moonwell mToken exchange rate growth and MetaMorpho vault share price growth.",
     HoldersRevenue: "Aerodrome LP trading fees distributed to MAMO stakers via the multi-rewards contract.",
-  },
-  breakdownMethodology: {
+}
+
+const breakdownMethodology = {
     Fees: {
-      'Moonwell Yield': 'Interest accrued on strategy deposits in Moonwell mToken markets (USDC/WETH/cbBTC), measured via exchangeRateStored delta.',
-      'MetaMorpho Yield': 'Yield from MetaMorpho vault share price appreciation on strategy deposits (USDC/WETH/cbBTC), measured via convertToAssets delta.',
-      'Aerodrome LP Fees': 'Aerodrome LP trading fees distributed to MAMO stakers via the multi-rewards contract.',
+        'Moonwell Yield': 'Interest accrued on strategy deposits in Moonwell mToken markets (USDC/WETH/cbBTC), measured via exchangeRateStored delta.',
+        'MetaMorpho Yield': 'Yield from MetaMorpho vault share price appreciation on strategy deposits (USDC/WETH/cbBTC), measured via convertToAssets delta.',
+        'Aerodrome LP Fees': 'Aerodrome LP trading fees distributed to MAMO stakers via the multi-rewards contract.',
     },
     SupplySideRevenue: {
-      'Moonwell Yield': 'Moonwell lending interest distributed to Mamo strategy depositors.',
-      'MetaMorpho Yield': 'MetaMorpho vault yield distributed to Mamo strategy depositors.',
+        'Moonwell Yield': 'Interest accrued on strategy deposits in Moonwell mToken markets (USDC/WETH/cbBTC), measured via exchangeRateStored delta.',
+        'MetaMorpho Yield': 'Yield from MetaMorpho vault share price appreciation on strategy deposits (USDC/WETH/cbBTC), measured via convertToAssets delta.',
     },
     HoldersRevenue: {
-      'Aerodrome LP Fees': 'Aerodrome LP trading fees (MAMO token and cbBTC) distributed to MAMO stakers via the multi-rewards contract.',
+        'Aerodrome LP Fees': 'Aerodrome LP trading fees distributed to MAMO stakers via the multi-rewards contract.',
     },
-  },
+}
+
+const adapter: SimpleAdapter = {
+    version: 2,
+    pullHourly: true,
+    chains: [CHAIN.BASE],
+    fetch,
+    start: "2025-05-14",
+    methodology,
+    breakdownMethodology,
 };
 
 export default adapter;

--- a/fees/mamo.ts
+++ b/fees/mamo.ts
@@ -155,10 +155,14 @@ const adapter: SimpleAdapter = {
     Fees: {
       'Moonwell Yield': 'Interest accrued on strategy deposits in Moonwell mToken markets (USDC/WETH/cbBTC), measured via exchangeRateStored delta.',
       'MetaMorpho Yield': 'Yield from MetaMorpho vault share price appreciation on strategy deposits (USDC/WETH/cbBTC), measured via convertToAssets delta.',
+      'Aerodrome LP Fees': 'Aerodrome LP trading fees distributed to MAMO stakers via the multi-rewards contract.',
     },
     SupplySideRevenue: {
       'Moonwell Yield': 'Moonwell lending interest distributed to Mamo strategy depositors.',
       'MetaMorpho Yield': 'MetaMorpho vault yield distributed to Mamo strategy depositors.',
+    },
+    HoldersRevenue: {
+      'Aerodrome LP Fees': 'Aerodrome LP trading fees (MAMO token and cbBTC) distributed to MAMO stakers via the multi-rewards contract.',
     },
   },
 };

--- a/fees/mamo.ts
+++ b/fees/mamo.ts
@@ -103,7 +103,7 @@ const fetch = async (options: FetchOptions) => {
           (sum: number, b: any) => sum + Number(b ?? 0), 0
         );
         const mTokenYield = totalMTokenShares * (Number(rateTo) - Number(rateFrom)) / 1e18;
-        if (mTokenYield > 0) dailySupplySideRevenue.add(config.token, mTokenYield);
+        if (mTokenYield > 0) dailySupplySideRevenue.add(config.token, mTokenYield, 'Moonwell Yield');
       }
 
       // MetaMorpho yield: totalMorphoShares × Δ(pricePerShare) / 1e18
@@ -112,7 +112,7 @@ const fetch = async (options: FetchOptions) => {
           (sum: number, b: any) => sum + Number(b ?? 0), 0
         );
         const morphoYield = totalMorphoShares * (Number(morphoPriceTo) - Number(morphoPriceFrom)) / 1e18;
-        if (morphoYield > 0) dailySupplySideRevenue.add(config.token, morphoYield);
+        if (morphoYield > 0) dailySupplySideRevenue.add(config.token, morphoYield, 'MetaMorpho Yield');
       }
     } catch (_e) {
       // Skip supply-side for this config if RPC fails for this block range
@@ -150,6 +150,16 @@ const adapter: SimpleAdapter = {
     Fees: "Yield earned by Mamo strategy depositors from Moonwell/MetaMorpho positions plus Aerodrome LP fees distributed to MAMO stakers.",
     SupplySideRevenue: "Interest accrued on user deposits via Moonwell mToken exchange rate growth and MetaMorpho vault share price growth.",
     HoldersRevenue: "Aerodrome LP trading fees distributed to MAMO stakers via the multi-rewards contract.",
+  },
+  breakdownMethodology: {
+    Fees: {
+      'Moonwell Yield': 'Interest accrued on strategy deposits in Moonwell mToken markets (USDC/WETH/cbBTC), measured via exchangeRateStored delta.',
+      'MetaMorpho Yield': 'Yield from MetaMorpho vault share price appreciation on strategy deposits (USDC/WETH/cbBTC), measured via convertToAssets delta.',
+    },
+    SupplySideRevenue: {
+      'Moonwell Yield': 'Moonwell lending interest distributed to Mamo strategy depositors.',
+      'MetaMorpho Yield': 'MetaMorpho vault yield distributed to Mamo strategy depositors.',
+    },
   },
 };
 

--- a/fees/mamo.ts
+++ b/fees/mamo.ts
@@ -5,18 +5,126 @@ import ADDRESSES from "../helpers/coreAssets.json";
 
 const MAMO_MULTI_REWARDS = "0x7855B0821401Ab078f6Cf457dEAFae775fF6c7A3";
 const MAMO_TOKEN = "0x7300B37DfdfAb110d83290A29DfB31B1740219fE";
-const cbBTC = ADDRESSES.base.cbBTC;
+
+// Per-asset config hardcoded from mamo-contracts/addresses/8453.json
+const CONFIGS = [
+  {
+    factory: "0x3098360e627E84Fb9dD621F01ea03E325cCEE2c6",
+    mToken: "0xEdc817A28E8B93B03976FBd4a3dDBc9f7D176c22", // Moonwell mUSDC
+    morphoVault: "0xc1256Ae5FF1cf2719D4937adb3bbCCab2E00A2Ca", // Moonwell Flagship USDC
+    token: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913", // USDC
+  },
+  {
+    factory: "0xf8CFdEf5068929e022a50315983043b61E9987f8",
+    mToken: "0xF877ACaFA28c19b96727966690b2f44d35aD5976", // Moonwell mcbBTC
+    morphoVault: "0x543257eF2161176D7C8cD90BA65C2d4CaEF5a796", // MetaMorpho cbBTC
+    token: ADDRESSES.base.cbBTC,
+  },
+  {
+    factory: "0x14bA47Ef0286B345E2B74d26243767268290eE28",
+    mToken: "0x628ff693426583D9a7FB391E54366292F509D457", // Moonwell mWETH
+    morphoVault: "0xa0E430870c4604CcfC7B38Ca7845B1FF653D0ff1", // MetaMorpho WETH
+    token: ADDRESSES.base.WETH,
+  },
+];
+
+const STRATEGY_CREATED = "event StrategyCreated(address indexed user, address indexed strategy)";
+const FACTORY_DEPLOY_BLOCK = 20_000_000; // Base ~Jul 2025
 
 const fetch = async (options: FetchOptions) => {
-  const dailyFees = await addTokensReceived({
+  const dailySupplySideRevenue = options.createBalances();
+
+  for (const config of CONFIGS) {
+    const logs = await options.getLogs({
+      target: config.factory,
+      eventAbi: STRATEGY_CREATED,
+      fromBlock: FACTORY_DEPLOY_BLOCK,
+    });
+
+    // Safely extract strategy addresses — handle both direct and args-wrapped shapes
+    const strategies: string[] = logs
+      .map((l: any) => l.strategy ?? l.args?.strategy)
+      .filter((s: any): s is string => typeof s === "string" && s.startsWith("0x"));
+
+    if (!strategies.length) continue;
+
+    const mTokenBalCalls = strategies.map((s) => ({ target: config.mToken, params: [s] }));
+    const morphoShareCalls = strategies.map((s) => ({ target: config.morphoVault, params: [s] }));
+    const PRICE_QUERY = "1000000000000000000"; // 1e18 shares
+
+    // All balance/rate calls in parallel, using multiCall for scalar rates too
+    const [
+      mTokenBals,
+      [rateFrom], [rateTo],
+      morphoShares,
+      [morphoPriceFrom], [morphoPriceTo],
+    ] = await Promise.all([
+      options.toApi.multiCall({
+        abi: "function balanceOf(address) view returns (uint256)",
+        calls: mTokenBalCalls,
+        permitFailure: true,
+      }),
+      options.fromApi.multiCall({
+        abi: "uint256:exchangeRateStored",
+        calls: [config.mToken],
+        permitFailure: true,
+      }),
+      options.toApi.multiCall({
+        abi: "uint256:exchangeRateStored",
+        calls: [config.mToken],
+        permitFailure: true,
+      }),
+      options.toApi.multiCall({
+        abi: "function balanceOf(address) view returns (uint256)",
+        calls: morphoShareCalls,
+        permitFailure: true,
+      }),
+      options.fromApi.multiCall({
+        abi: "function convertToAssets(uint256) view returns (uint256)",
+        calls: [{ target: config.morphoVault, params: [PRICE_QUERY] }],
+        permitFailure: true,
+      }),
+      options.toApi.multiCall({
+        abi: "function convertToAssets(uint256) view returns (uint256)",
+        calls: [{ target: config.morphoVault, params: [PRICE_QUERY] }],
+        permitFailure: true,
+      }),
+    ]);
+
+    // Moonwell yield: totalMTokenShares × Δ(exchangeRate) / 1e18
+    if (rateFrom != null && rateTo != null) {
+      const totalMTokenShares = mTokenBals.reduce(
+        (sum: number, b: any) => sum + Number(b ?? 0), 0
+      );
+      const mTokenYield = totalMTokenShares * (Number(rateTo) - Number(rateFrom)) / 1e18;
+      if (mTokenYield > 0) dailySupplySideRevenue.add(config.token, mTokenYield);
+    }
+
+    // MetaMorpho yield: totalMorphoShares × Δ(pricePerShare) / 1e18
+    if (morphoPriceFrom != null && morphoPriceTo != null) {
+      const totalMorphoShares = morphoShares.reduce(
+        (sum: number, b: any) => sum + Number(b ?? 0), 0
+      );
+      const morphoYield = totalMorphoShares * (Number(morphoPriceTo) - Number(morphoPriceFrom)) / 1e18;
+      if (morphoYield > 0) dailySupplySideRevenue.add(config.token, morphoYield);
+    }
+  }
+
+  // Aerodrome LP fees distributed to MAMO stakers
+  const dailyHoldersRevenue = await addTokensReceived({
     options,
     targets: [MAMO_MULTI_REWARDS],
-    tokens: [MAMO_TOKEN, cbBTC],
+    tokens: [MAMO_TOKEN, ADDRESSES.base.cbBTC],
   });
+
+  const dailyFees = options.createBalances();
+  dailyFees.addBalances(dailySupplySideRevenue);
+  dailyFees.addBalances(dailyHoldersRevenue);
 
   return {
     dailyFees,
-    dailyHoldersRevenue: dailyFees,
+    dailySupplySideRevenue,
+    dailyHoldersRevenue,
   };
 };
 
@@ -30,8 +138,9 @@ const adapter: SimpleAdapter = {
     },
   },
   methodology: {
-    Fees: "Aerodrome LP trading fees collected by the Mamo protocol and distributed to MAMO stakers.",
-    HoldersRevenue: "100% of fees distributed to MAMO token stakers via the multi-rewards contract.",
+    Fees: "Yield earned by Mamo strategy depositors from Moonwell/MetaMorpho positions plus Aerodrome LP fees distributed to MAMO stakers.",
+    SupplySideRevenue: "Interest accrued on user deposits via Moonwell mToken exchange rate growth and MetaMorpho vault share price growth.",
+    HoldersRevenue: "Aerodrome LP trading fees distributed to MAMO stakers via the multi-rewards contract.",
   },
 };
 

--- a/fees/mamo.ts
+++ b/fees/mamo.ts
@@ -3,15 +3,11 @@ import { CHAIN } from "../helpers/chains";
 import { addTokensReceived } from "../helpers/token";
 import ADDRESSES from "../helpers/coreAssets.json";
 
-// MAMO staking contract that receives Aerodrome LP trading fees weekly
 const MAMO_MULTI_REWARDS = "0x7855B0821401Ab078f6Cf457dEAFae775fF6c7A3";
-
-// Reward tokens distributed to MAMO stakers
 const MAMO_TOKEN = "0x7300B37DfdfAb110d83290A29DfB31B1740219fE";
 const cbBTC = ADDRESSES.base.cbBTC;
 
 const fetch = async (options: FetchOptions) => {
-  // Track reward tokens deposited into the staking contract each day
   const dailyFees = await addTokensReceived({
     options,
     targets: [MAMO_MULTI_REWARDS],
@@ -20,13 +16,13 @@ const fetch = async (options: FetchOptions) => {
 
   return {
     dailyFees,
-    dailyRevenue: dailyFees,
     dailyHoldersRevenue: dailyFees,
   };
 };
 
 const adapter: SimpleAdapter = {
   version: 2,
+  pullHourly: true,
   adapter: {
     [CHAIN.BASE]: {
       fetch,
@@ -35,7 +31,6 @@ const adapter: SimpleAdapter = {
   },
   methodology: {
     Fees: "Aerodrome LP trading fees collected by the Mamo protocol and distributed to MAMO stakers.",
-    Revenue: "All fees are distributed to MAMO stakers; no protocol treasury cut.",
     HoldersRevenue: "100% of fees distributed to MAMO token stakers via the multi-rewards contract.",
   },
 };

--- a/fees/mamo.ts
+++ b/fees/mamo.ts
@@ -2,176 +2,44 @@ import { FetchOptions, SimpleAdapter } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
 import { addTokensReceived } from "../helpers/token";
 import ADDRESSES from "../helpers/coreAssets.json";
+import { METRIC } from "../helpers/metrics";
 
 const MAMO_MULTI_REWARDS = "0x7855B0821401Ab078f6Cf457dEAFae775fF6c7A3";
 const MAMO_TOKEN = "0x7300B37DfdfAb110d83290A29DfB31B1740219fE";
-const MAMO_STRATEGY_REGISTRY = "0x46a5624C2ba92c08aBA4B206297052EDf14baa92";
-
-// Per-asset config hardcoded from mamo-contracts/addresses/8453.json
-const CONFIGS = [
-    {
-        mToken: "0xEdc817A28E8B93B03976FBd4a3dDBc9f7D176c22", // Moonwell mUSDC
-        morphoVault: "0xc1256Ae5FF1cf2719D4937adb3bbCCab2E00A2Ca", // Moonwell Flagship USDC
-        underlying: ADDRESSES.base.USDC,
-        underlyingDecimals: 6,
-
-    },
-    {
-        mToken: "0xF877ACaFA28c19b96727966690b2f44d35aD5976", // Moonwell mcbBTC
-        morphoVault: "0x543257eF2161176D7C8cD90BA65C2d4CaEF5a796", // MetaMorpho cbBTC
-        underlying: ADDRESSES.base.cbBTC,
-        underlyingDecimals: 8,
-    },
-    {
-        mToken: "0x628ff693426583D9a7FB391E54366292F509D457", // Moonwell mWETH
-        morphoVault: "0xa0E430870c4604CcfC7B38Ca7845B1FF653D0ff1", // MetaMorpho WETH
-        underlying: ADDRESSES.base.WETH,
-        underlyingDecimals: 18,
-    },
-];
-
-const STRATEGY_CREATED = "event StrategyCreated(address indexed user, address indexed strategy)";
-const STRATEGY_ADDED = "event StrategyAdded (address indexed user, address strategy, address implementation)";
-const STRATEGY_DEPLOYED_BLOCK = 30235637;
 
 const fetch = async (options: FetchOptions) => {
-    const dailySupplySideRevenue = options.createBalances();
-
-    const strategies = await options.getLogs({
-        target: MAMO_STRATEGY_REGISTRY,
-        eventAbi: STRATEGY_ADDED,
-        fromBlock: STRATEGY_DEPLOYED_BLOCK,
-        cacheInCloud: true,
-    })
-
-    const mTokens = await options.api.multiCall({
-        abi: "address:mToken",
-        calls: strategies.map((s) => ({ target: s.strategy })),
-        permitFailure: true,
-    })
-
-    const morphoVaults = await options.api.multiCall({
-        abi: "address:metaMorphoVault",
-        calls: strategies.map((s) => ({ target: s.strategy })),
-        permitFailure: true,
-    })
-
-    const mTokenToStrategies = new Map<string, typeof strategies>()
-    mTokens.forEach((mToken, index) => {
-        if (mToken) {
-            const existing = mTokenToStrategies.get(mToken) || []
-            existing.push(strategies[index])
-            mTokenToStrategies.set(mToken, existing)
-        }
-    })
-
-    const morphoVaultToStrategies = new Map<string, typeof strategies>()
-    morphoVaults.forEach((morphoVault, index) => {
-        if (morphoVault) {
-            const existing = morphoVaultToStrategies.get(morphoVault) || []
-            existing.push(strategies[index])
-            morphoVaultToStrategies.set(morphoVault, existing)
-        }
-    })
-
-    const [mTokenPriceBeforeArray, mTokenPriceAfterArray] = await Promise.all([
-        options.fromApi.multiCall({
-            abi: "function exchangeRateStored() view returns (uint256)",
-            calls: CONFIGS.map((c) => ({ target: c.mToken })),
-            permitFailure: true,
-        }),
-        options.toApi.multiCall({
-            abi: "function exchangeRateStored() view returns (uint256)",
-            calls: CONFIGS.map((c) => ({ target: c.mToken })),
-            permitFailure: true,
-        }),
-    ])
-
-    const PRICE_QUERY = "1000000000000000000";
-
-    const [morphoVaultPriceBeforeArray, morphoVaultPriceAfterArray] = await Promise.all([
-        options.fromApi.multiCall({
-            abi: "function convertToAssets(uint256) view returns (uint256)",
-            calls: CONFIGS.map((c) => ({ target: c.morphoVault, params: [PRICE_QUERY] })),
-            permitFailure: true,
-        }),
-        options.toApi.multiCall({
-            abi: "function convertToAssets(uint256) view returns (uint256)",
-            calls: CONFIGS.map((c) => ({ target: c.morphoVault, params: [PRICE_QUERY] })),
-            permitFailure: true,
-        }),
-    ])
-
-
-    let index = 0;
-    for (let i = 0; i < CONFIGS.length; i++) {
-        const config = CONFIGS[i];
-        const mTokenExchangeRateDecimals = 18 + config.underlyingDecimals - 8;
-        const mTokenPriceBefore = mTokenPriceBeforeArray[i] / 10 ** mTokenExchangeRateDecimals;
-        const mTokenPriceAfter = mTokenPriceAfterArray[i] / 10 ** mTokenExchangeRateDecimals;
-        const morphoVaultPriceBefore = morphoVaultPriceBeforeArray[i] / 10 ** config.underlyingDecimals;
-        const morphoVaultPriceAfter = morphoVaultPriceAfterArray[i] / 10 ** config.underlyingDecimals
-
-        const strategies = mTokenToStrategies.get(config.mToken);
-
-        if (!strategies || !mTokenPriceBefore || !mTokenPriceAfter || !morphoVaultPriceBefore || !morphoVaultPriceAfter) continue;
-
-        const strategyMtokenBalances = await options.api.multiCall({
-            abi: "function balanceOf(address) view returns (uint256)",
-            calls: strategies.map((s) => ({ target: config.mToken, params: [s] })),
-            permitFailure: true,
-        })
-        const strategyMorphoVaultBalances = await options.api.multiCall({
-            abi: "function balanceOf(address) view returns (uint256)",
-            calls: strategies.map((s) => ({ target: config.morphoVault, params: [s] })),
-            permitFailure: true,
-        })
-
-        const totalMTokenBalance = strategyMtokenBalances.reduce((sum, balance) => sum + Number(balance ?? 0) / 10 ** 8, 0);
-        const totalMorphoVaultBalance = strategyMorphoVaultBalances.reduce((sum, balance) => sum + Number(balance ?? 0) / 10 ** config.underlyingDecimals, 0);
-
-        dailySupplySideRevenue.add(config.underlying, (mTokenPriceAfter - mTokenPriceBefore) * totalMTokenBalance, 'Moonwell Yield');
-        dailySupplySideRevenue.add(config.underlying, (morphoVaultPriceAfter - morphoVaultPriceBefore) * totalMorphoVaultBalance, 'MetaMorpho Yield');
-        index++;
-    }
 
     // Aerodrome LP fees distributed to MAMO stakers
-    const dailyHoldersRevenue = await addTokensReceived({
+    const stakingRewards = await addTokensReceived({
         options,
         targets: [MAMO_MULTI_REWARDS],
         tokens: [MAMO_TOKEN, ADDRESSES.base.cbBTC],
     });
 
-    const dailyFees = options.createBalances();
-    dailyFees.addBalances(dailySupplySideRevenue);
-    dailyFees.addBalances(dailyHoldersRevenue);
+    const dailyFees = stakingRewards.clone(1, METRIC.STAKING_REWARDS);
 
     return {
         dailyFees,
-        dailyRevenue: dailyHoldersRevenue,
-        dailySupplySideRevenue,
-        dailyHoldersRevenue,
+        dailyRevenue: dailyFees,
+        dailyHoldersRevenue: dailyFees
     };
 };
 
 const methodology = {
-    Fees: "Yield earned by Mamo strategy depositors from Moonwell/MetaMorpho positions plus Aerodrome LP fees distributed to MAMO stakers.",
-    SupplySideRevenue: "Interest accrued on user deposits via Moonwell mToken exchange rate growth and MetaMorpho vault share price growth.",
+    Fees: "Aerodrome LP fees distributed to MAMO stakers.",
+    Revenue: "Aerodrome LP fees distributed to MAMO stakers.",
     HoldersRevenue: "Aerodrome LP trading fees distributed to MAMO stakers via the multi-rewards contract.",
 }
 
 const breakdownMethodology = {
     Fees: {
-        'Moonwell Yield': 'Interest accrued on strategy deposits in Moonwell mToken markets (USDC/WETH/cbBTC), measured via exchangeRateStored delta.',
-        'MetaMorpho Yield': 'Yield from MetaMorpho vault share price appreciation on strategy deposits (USDC/WETH/cbBTC), measured via convertToAssets delta.',
-        'Aerodrome LP Fees': 'Aerodrome LP trading fees distributed to MAMO stakers via the multi-rewards contract.',
+       [METRIC.STAKING_REWARDS]: 'Aerodrome LP fees distributed to MAMO stakers.',
     },
-    SupplySideRevenue: {
-        'Moonwell Yield': 'Interest accrued on strategy deposits in Moonwell mToken markets (USDC/WETH/cbBTC), measured via exchangeRateStored delta.',
-        'MetaMorpho Yield': 'Yield from MetaMorpho vault share price appreciation on strategy deposits (USDC/WETH/cbBTC), measured via convertToAssets delta.',
+    Revenue: {
+        [METRIC.STAKING_REWARDS]: 'Aerodrome LP fees distributed to MAMO stakers.',
     },
     HoldersRevenue: {
-        'Aerodrome LP Fees': 'Aerodrome LP trading fees distributed to MAMO stakers via the multi-rewards contract.',
+        [METRIC.STAKING_REWARDS]: 'Aerodrome LP fees distributed to MAMO stakers.',
     },
 }
 
@@ -180,7 +48,7 @@ const adapter: SimpleAdapter = {
     pullHourly: true,
     chains: [CHAIN.BASE],
     fetch,
-    start: "2025-05-14",
+    start: "2025-07-18",
     methodology,
     breakdownMethodology,
 };

--- a/fees/mamo.ts
+++ b/fees/mamo.ts
@@ -33,7 +33,7 @@ const methodology = {
 
 const breakdownMethodology = {
     Fees: {
-       [METRIC.STAKING_REWARDS]: 'Aerodrome LP fees distributed to MAMO stakers.',
+        [METRIC.STAKING_REWARDS]: 'Aerodrome LP fees distributed to MAMO stakers.',
     },
     Revenue: {
         [METRIC.STAKING_REWARDS]: 'Aerodrome LP fees distributed to MAMO stakers.',
@@ -51,6 +51,7 @@ const adapter: SimpleAdapter = {
     start: "2025-07-18",
     methodology,
     breakdownMethodology,
+    doublecounted: true, //aerodrome
 };
 
 export default adapter;

--- a/fees/mamo.ts
+++ b/fees/mamo.ts
@@ -52,61 +52,70 @@ const fetch = async (options: FetchOptions) => {
     const morphoShareCalls = strategies.map((s) => ({ target: config.morphoVault, params: [s] }));
     const PRICE_QUERY = "1000000000000000000"; // 1e18 shares
 
-    // All balance/rate calls in parallel, using multiCall for scalar rates too
-    const [
-      mTokenBals,
-      [rateFrom], [rateTo],
-      morphoShares,
-      [morphoPriceFrom], [morphoPriceTo],
-    ] = await Promise.all([
-      options.toApi.multiCall({
-        abi: "function balanceOf(address) view returns (uint256)",
-        calls: mTokenBalCalls,
-        permitFailure: true,
-      }),
-      options.fromApi.multiCall({
-        abi: "uint256:exchangeRateStored",
-        calls: [config.mToken],
-        permitFailure: true,
-      }),
-      options.toApi.multiCall({
-        abi: "uint256:exchangeRateStored",
-        calls: [config.mToken],
-        permitFailure: true,
-      }),
-      options.toApi.multiCall({
-        abi: "function balanceOf(address) view returns (uint256)",
-        calls: morphoShareCalls,
-        permitFailure: true,
-      }),
-      options.fromApi.multiCall({
-        abi: "function convertToAssets(uint256) view returns (uint256)",
-        calls: [{ target: config.morphoVault, params: [PRICE_QUERY] }],
-        permitFailure: true,
-      }),
-      options.toApi.multiCall({
-        abi: "function convertToAssets(uint256) view returns (uint256)",
-        calls: [{ target: config.morphoVault, params: [PRICE_QUERY] }],
-        permitFailure: true,
-      }),
-    ]);
+    try {
+      // All balance/rate calls in parallel
+      const [
+        mTokenBals,
+        ratesFrom, ratesTo,
+        morphoShares,
+        pricesFrom, pricesTo,
+      ] = await Promise.all([
+        options.toApi.multiCall({
+          abi: "function balanceOf(address) view returns (uint256)",
+          calls: mTokenBalCalls,
+          permitFailure: true,
+        }),
+        options.fromApi.multiCall({
+          abi: "function exchangeRateStored() view returns (uint256)",
+          calls: [{ target: config.mToken, params: [] }],
+          permitFailure: true,
+        }),
+        options.toApi.multiCall({
+          abi: "function exchangeRateStored() view returns (uint256)",
+          calls: [{ target: config.mToken, params: [] }],
+          permitFailure: true,
+        }),
+        options.toApi.multiCall({
+          abi: "function balanceOf(address) view returns (uint256)",
+          calls: morphoShareCalls,
+          permitFailure: true,
+        }),
+        options.fromApi.multiCall({
+          abi: "function convertToAssets(uint256) view returns (uint256)",
+          calls: [{ target: config.morphoVault, params: [PRICE_QUERY] }],
+          permitFailure: true,
+        }),
+        options.toApi.multiCall({
+          abi: "function convertToAssets(uint256) view returns (uint256)",
+          calls: [{ target: config.morphoVault, params: [PRICE_QUERY] }],
+          permitFailure: true,
+        }),
+      ]);
 
-    // Moonwell yield: totalMTokenShares × Δ(exchangeRate) / 1e18
-    if (rateFrom != null && rateTo != null) {
-      const totalMTokenShares = mTokenBals.reduce(
-        (sum: number, b: any) => sum + Number(b ?? 0), 0
-      );
-      const mTokenYield = totalMTokenShares * (Number(rateTo) - Number(rateFrom)) / 1e18;
-      if (mTokenYield > 0) dailySupplySideRevenue.add(config.token, mTokenYield);
-    }
+      const rateFrom = ratesFrom[0];
+      const rateTo = ratesTo[0];
+      const morphoPriceFrom = pricesFrom[0];
+      const morphoPriceTo = pricesTo[0];
 
-    // MetaMorpho yield: totalMorphoShares × Δ(pricePerShare) / 1e18
-    if (morphoPriceFrom != null && morphoPriceTo != null) {
-      const totalMorphoShares = morphoShares.reduce(
-        (sum: number, b: any) => sum + Number(b ?? 0), 0
-      );
-      const morphoYield = totalMorphoShares * (Number(morphoPriceTo) - Number(morphoPriceFrom)) / 1e18;
-      if (morphoYield > 0) dailySupplySideRevenue.add(config.token, morphoYield);
+      // Moonwell yield: totalMTokenShares × Δ(exchangeRate) / 1e18
+      if (rateFrom != null && rateTo != null) {
+        const totalMTokenShares = mTokenBals.reduce(
+          (sum: number, b: any) => sum + Number(b ?? 0), 0
+        );
+        const mTokenYield = totalMTokenShares * (Number(rateTo) - Number(rateFrom)) / 1e18;
+        if (mTokenYield > 0) dailySupplySideRevenue.add(config.token, mTokenYield);
+      }
+
+      // MetaMorpho yield: totalMorphoShares × Δ(pricePerShare) / 1e18
+      if (morphoPriceFrom != null && morphoPriceTo != null) {
+        const totalMorphoShares = morphoShares.reduce(
+          (sum: number, b: any) => sum + Number(b ?? 0), 0
+        );
+        const morphoYield = totalMorphoShares * (Number(morphoPriceTo) - Number(morphoPriceFrom)) / 1e18;
+        if (morphoYield > 0) dailySupplySideRevenue.add(config.token, morphoYield);
+      }
+    } catch (_e) {
+      // Skip supply-side for this config if RPC fails for this block range
     }
   }
 


### PR DESCRIPTION
## MAMO Fees Adapter

Website: https://mamo.bot/

### What this tracks

**Supply-Side Revenue** — yield accrued by user strategy depositors:
- Moonwell mToken exchange rate growth: `totalMTokenShares × Δ(exchangeRateStored) / 1e18`
- MetaMorpho vault share price growth: `totalMorphoShares × Δ(convertToAssets(1e18)) / 1e18`
- Strategy addresses enumerated via each factory's `StrategyCreated` events (from block 20,000,000)

**Holders Revenue** — Aerodrome LP trading fees distributed to MAMO stakers via `MAMO_MULTI_REWARDS`

**Total Fees** = Supply-Side Revenue + Holders Revenue

### Contracts

| Role | Address |
|------|---------|
| MAMO Multi-Rewards | `0x7855B0821401Ab078f6Cf457dEAFae775fF6c7A3` |
| USDC Factory | `0x3098360e627E84Fb9dD621F01ea03E325cCEE2c6` |
| cbBTC Factory | `0xf8CFdEf5068929e022a50315983043b61E9987f8` |
| WETH Factory | `0x14bA47Ef0286B345E2B74d26243767268290eE28` |

### Test output

```
🦙 Running MAMO adapter 🦙
---------------------------------------------------
Start Date: Thu, 07 May 2026 16:00:00 GMT
End Date:   Fri, 08 May 2026 16:00:00 GMT
---------------------------------------------------
(1/24) start: 4 PM - 07/05  | fees - 18.00   | supply side revenue - 7.66  | holders revenue - 10.00
(2/24) start: 5 PM - 07/05  | fees - 108.00  | supply side revenue - 7.84  | holders revenue - 100.00
(3/24) start: 6 PM - 07/05  | fees - 3.23 k  | supply side revenue - 7.51  | holders revenue - 3.22 k
(4/24) start: 7 PM - 07/05  | fees - 321.00  | supply side revenue - 7.55  | holders revenue - 313.00
(5/24) start: 8 PM - 07/05  | fees - 9.04    | supply side revenue - 7.40  | holders revenue - 1.64
(6/24) start: 9 PM - 07/05  | fees - 381.00  | supply side revenue - 7.77  | holders revenue - 373.00
```

Supply-side revenue consistently ~$7-8/hour from Moonwell/MetaMorpho yield; holders revenue varies with Aerodrome LP distributions.