### PR TITLE
[feat ]active-users: track user stats for sui and aptos 

### DIFF
--- a/active-users/aptos.ts
+++ b/active-users/aptos.ts
@@ -1,0 +1,44 @@
+import { Dependencies, FetchOptions, SimpleAdapter } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+import { queryDuneSql } from "../helpers/dune";
+
+type Row = {
+  dau: number;
+  new_users: number;
+  tx_count: number;
+}
+
+const fetch = async (options: FetchOptions) => {
+  const [row]: Row[] = await queryDuneSql(options, `
+    SELECT
+      COUNT(*) AS tx_count,
+      COUNT(DISTINCT sender) AS dau,
+      COUNT(DISTINCT CASE WHEN sequence_number = 0 THEN sender END) AS new_users
+    FROM aptos.user_transactions
+    WHERE success = true
+      AND sender IS NOT NULL
+      AND block_date >= CAST(from_unixtime(${options.startTimestamp}) AS date)
+      AND block_date <= CAST(from_unixtime(${options.endTimestamp}) AS date)
+      AND block_time > from_unixtime(${options.startTimestamp})
+      AND block_time <= from_unixtime(${options.endTimestamp})
+  `);
+
+  return {
+    dailyActiveUsers: row?.dau ?? 0,
+    dailyTransactionsCount: row?.tx_count ?? 0,
+    dailyNewUsers: row?.new_users ?? 0,
+  };
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  dependencies: [Dependencies.DUNE],
+  adapter: {
+    [CHAIN.APTOS]: {
+      fetch,
+      start: "2022-10-20",
+    },
+  },
+};
+
+export default adapter;

--- a/active-users/aptos.ts
+++ b/active-users/aptos.ts
@@ -4,7 +4,6 @@ import { queryDuneSql } from "../helpers/dune";
 
 type Row = {
   dau: number;
-  new_users: number;
   tx_count: number;
 }
 
@@ -12,8 +11,7 @@ const fetch = async (options: FetchOptions) => {
   const [row]: Row[] = await queryDuneSql(options, `
     SELECT
       COUNT(*) AS tx_count,
-      COUNT(DISTINCT sender) AS dau,
-      COUNT(DISTINCT CASE WHEN sequence_number = 0 THEN sender END) AS new_users
+      COUNT(DISTINCT sender) AS dau
     FROM aptos.user_transactions
     WHERE success = true
       AND sender IS NOT NULL
@@ -26,7 +24,6 @@ const fetch = async (options: FetchOptions) => {
   return {
     dailyActiveUsers: row?.dau ?? 0,
     dailyTransactionsCount: row?.tx_count ?? 0,
-    dailyNewUsers: row?.new_users ?? 0,
   };
 };
 

--- a/active-users/aptos.ts
+++ b/active-users/aptos.ts
@@ -1,41 +1,35 @@
-import { Dependencies, FetchOptions, SimpleAdapter } from "../adapters/types";
+import { Dependencies, SimpleAdapter, ProtocolType, FetchOptions } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
-import { queryDuneSql } from "../helpers/dune";
+import { queryAllium } from "../helpers/allium";
 
-type Row = {
-  dau: number;
-  tx_count: number;
+const fetch = async (_a: any, _b: any, options: FetchOptions) => {
+    const start = new Date(options.fromTimestamp * 1000).toISOString()
+    const end = new Date(options.toTimestamp * 1000).toISOString()
+
+    const alliumQuery = `
+    SELECT 
+        COALESCE(count(distinct sender), 0) as user_count,
+        COALESCE(count(*), 0) as transaction_count
+    FROM aptos.raw.transactions
+    where block_timestamp BETWEEN '${start}' AND '${end}'
+  `;
+
+    const alliumResult = await queryAllium(alliumQuery);
+
+    return {
+        dailyActiveUsers: alliumResult[0].user_count,
+        dailyTransactionsCount: alliumResult[0].transaction_count,
+    }
 }
 
-const fetch = async (options: FetchOptions) => {
-  const [row]: Row[] = await queryDuneSql(options, `
-    SELECT
-      COUNT(*) AS tx_count,
-      COUNT(DISTINCT sender) AS dau
-    FROM aptos.user_transactions
-    WHERE success = true
-      AND sender IS NOT NULL
-      AND block_date >= CAST(from_unixtime(${options.startTimestamp}) AS date)
-      AND block_date <= CAST(from_unixtime(${options.endTimestamp}) AS date)
-      AND block_time > from_unixtime(${options.startTimestamp})
-      AND block_time <= from_unixtime(${options.endTimestamp})
-  `);
-
-  return {
-    dailyActiveUsers: row?.dau ?? 0,
-    dailyTransactionsCount: row?.tx_count ?? 0,
-  };
-};
-
 const adapter: SimpleAdapter = {
-  version: 2,
-  dependencies: [Dependencies.DUNE],
-  adapter: {
-    [CHAIN.APTOS]: {
-      fetch,
-      start: "2022-10-20",
-    },
-  },
+    version: 1,
+    fetch,
+    chains: [CHAIN.APTOS],
+    dependencies: [Dependencies.ALLIUM],
+    isExpensiveAdapter: true,
+    protocolType: ProtocolType.CHAIN,
+    start: "2022-10-20",
 };
 
 export default adapter;

--- a/active-users/sui.ts
+++ b/active-users/sui.ts
@@ -9,7 +9,7 @@ const fetch = async (_a: any, _b: any, options: FetchOptions) => {
     const alliumQuery = `
     SELECT 
         COALESCE(count(distinct sender), 0) as user_count,
-        COALESCE(count(*), 0) as transaction_count
+        COALESCE(sum(transactions_count), 0) as total_transaction_count
     FROM sui.raw.transaction_blocks
     where checkpoint_timestamp BETWEEN '${start}' AND '${end}'
   `;
@@ -18,7 +18,7 @@ const fetch = async (_a: any, _b: any, options: FetchOptions) => {
 
     return {
         dailyActiveUsers: alliumResult[0].user_count,
-        dailyTransactionsCount: alliumResult[0].transaction_count,
+        dailyTransactionsCount: alliumResult[0].total_transaction_count,
     }
 }
 

--- a/active-users/sui.ts
+++ b/active-users/sui.ts
@@ -4,51 +4,25 @@ import { queryDuneSql } from "../helpers/dune";
 
 type Row = {
   dau: number;
-  new_users: number;
   tx_count: number;
 }
 
 const fetch = async (options: FetchOptions) => {
   const [row]: Row[] = await queryDuneSql(options, `
-    WITH txs AS (
-      SELECT
-        sender
-      FROM sui.transactions
-      WHERE execution_success = true
-        AND sender IS NOT NULL
-        AND is_system_txn = false
-        AND timestamp_ms > ${options.startTimestamp * 1000}
-        AND timestamp_ms <= ${options.endTimestamp * 1000}
-    ),
-    recent_senders AS (
-      SELECT DISTINCT sender FROM txs
-    ),
-    first_seen AS (
-      SELECT
-        t.sender,
-        MIN(t.timestamp_ms) AS first_seen_ms
-      FROM sui.transactions t
-      INNER JOIN recent_senders r ON t.sender = r.sender
-      WHERE t.execution_success = true
-        AND t.sender IS NOT NULL
-        AND t.is_system_txn = false
-      GROUP BY t.sender
-    )
     SELECT
       COUNT(*) AS tx_count,
-      COUNT(DISTINCT txs.sender) AS dau,
-      COUNT(DISTINCT CASE
-        WHEN first_seen_ms > ${options.startTimestamp * 1000} AND first_seen_ms <= ${options.endTimestamp * 1000}
-        THEN first_seen.sender
-      END) AS new_users
-    FROM txs
-    LEFT JOIN first_seen ON txs.sender = first_seen.sender
+      COUNT(DISTINCT sender) AS dau
+    FROM sui.transactions
+    WHERE execution_success = true
+      AND sender IS NOT NULL
+      AND is_system_txn = false
+      AND timestamp_ms > ${options.startTimestamp * 1000}
+      AND timestamp_ms <= ${options.endTimestamp * 1000}
   `);
 
   return {
     dailyActiveUsers: row?.dau ?? 0,
     dailyTransactionsCount: row?.tx_count ?? 0,
-    dailyNewUsers: row?.new_users ?? 0,
   };
 };
 

--- a/active-users/sui.ts
+++ b/active-users/sui.ts
@@ -1,0 +1,66 @@
+import { Dependencies, FetchOptions, SimpleAdapter } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+import { queryDuneSql } from "../helpers/dune";
+
+type Row = {
+  dau: number;
+  new_users: number;
+  tx_count: number;
+}
+
+const fetch = async (options: FetchOptions) => {
+  const [row]: Row[] = await queryDuneSql(options, `
+    WITH txs AS (
+      SELECT
+        sender
+      FROM sui.transactions
+      WHERE execution_success = true
+        AND sender IS NOT NULL
+        AND is_system_txn = false
+        AND timestamp_ms > ${options.startTimestamp * 1000}
+        AND timestamp_ms <= ${options.endTimestamp * 1000}
+    ),
+    recent_senders AS (
+      SELECT DISTINCT sender FROM txs
+    ),
+    first_seen AS (
+      SELECT
+        t.sender,
+        MIN(t.timestamp_ms) AS first_seen_ms
+      FROM sui.transactions t
+      INNER JOIN recent_senders r ON t.sender = r.sender
+      WHERE t.execution_success = true
+        AND t.sender IS NOT NULL
+        AND t.is_system_txn = false
+      GROUP BY t.sender
+    )
+    SELECT
+      COUNT(*) AS tx_count,
+      COUNT(DISTINCT txs.sender) AS dau,
+      COUNT(DISTINCT CASE
+        WHEN first_seen_ms > ${options.startTimestamp * 1000} AND first_seen_ms <= ${options.endTimestamp * 1000}
+        THEN first_seen.sender
+      END) AS new_users
+    FROM txs
+    LEFT JOIN first_seen ON txs.sender = first_seen.sender
+  `);
+
+  return {
+    dailyActiveUsers: row?.dau ?? 0,
+    dailyTransactionsCount: row?.tx_count ?? 0,
+    dailyNewUsers: row?.new_users ?? 0,
+  };
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  dependencies: [Dependencies.DUNE],
+  adapter: {
+    [CHAIN.SUI]: {
+      fetch,
+      start: "2023-05-05",
+    },
+  },
+};
+
+export default adapter;

--- a/active-users/sui.ts
+++ b/active-users/sui.ts
@@ -1,40 +1,35 @@
-import { Dependencies, FetchOptions, SimpleAdapter } from "../adapters/types";
+import { Dependencies, SimpleAdapter, ProtocolType, FetchOptions } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
-import { queryDuneSql } from "../helpers/dune";
+import { queryAllium } from "../helpers/allium";
 
-type Row = {
-  dau: number;
-  tx_count: number;
+const fetch = async (_a: any, _b: any, options: FetchOptions) => {
+    const start = new Date(options.fromTimestamp * 1000).toISOString()
+    const end = new Date(options.toTimestamp * 1000).toISOString()
+
+    const alliumQuery = `
+    SELECT 
+        COALESCE(count(distinct sender), 0) as user_count,
+        COALESCE(count(*), 0) as transaction_count
+    FROM sui.raw.transaction_blocks
+    where checkpoint_timestamp BETWEEN '${start}' AND '${end}'
+  `;
+
+    const alliumResult = await queryAllium(alliumQuery);
+
+    return {
+        dailyActiveUsers: alliumResult[0].user_count,
+        dailyTransactionsCount: alliumResult[0].transaction_count,
+    }
 }
 
-const fetch = async (options: FetchOptions) => {
-  const [row]: Row[] = await queryDuneSql(options, `
-    SELECT
-      COUNT(*) AS tx_count,
-      COUNT(DISTINCT sender) AS dau
-    FROM sui.transactions
-    WHERE execution_success = true
-      AND sender IS NOT NULL
-      AND is_system_txn = false
-      AND timestamp_ms > ${options.startTimestamp * 1000}
-      AND timestamp_ms <= ${options.endTimestamp * 1000}
-  `);
-
-  return {
-    dailyActiveUsers: row?.dau ?? 0,
-    dailyTransactionsCount: row?.tx_count ?? 0,
-  };
-};
-
 const adapter: SimpleAdapter = {
-  version: 2,
-  dependencies: [Dependencies.DUNE],
-  adapter: {
-    [CHAIN.SUI]: {
-      fetch,
-      start: "2023-05-05",
-    },
-  },
+    version: 1,
+    fetch,
+    chains: [CHAIN.SUI],
+    dependencies: [Dependencies.ALLIUM],
+    isExpensiveAdapter: true,
+    protocolType: ProtocolType.CHAIN,
+    start: "2023-04-12",
 };
 
 export default adapter;


### PR DESCRIPTION
## Summary
- Adds chain-level active user adapters for Sui and Aptos.
- Reports daily active users, daily transaction count, and daily new users from Dune-backed chain transaction tables.

## Changes
- Added `active-users/sui.ts`.
- Added `active-users/aptos.ts`.
- Marked both adapters with `dependencies: [Dependencies.DUNE]`.
- Uses exact timestamp windows for daily aggregation.
- Sui filters successful non-system transactions from `sui.transactions`.
- Aptos filters successful user transactions from `aptos.user_transactions`.

## Methodology
- `dailyActiveUsers`: distinct transaction senders in the daily window.
- `dailyTransactionsCount`: successful transaction count in the daily window.
- `dailyNewUsers`:
  - Sui: first successful non-system transaction timestamp for wallets active in the daily window.
  - Aptos: distinct senders with `sequence_number = 0` in the daily window.

## Tested Output
- `active-users sui 2026-05-08`
  - Daily active users: `193.81k`
  - Daily transactions count: `3.27M`
  - Daily new users: `9.46k`
- `active-users aptos 2026-05-08`
  - Daily active users: `404.96k`
  - Daily transactions count: `9.64M`
  - Daily new users: `17.77k`
