### PR TITLE
Fix Fragment TON fee addresses

### DIFF
--- a/fees/fragment/index.ts
+++ b/fees/fragment/index.ts
@@ -4,7 +4,7 @@ import { queryDuneSql } from "../../helpers/dune";
 
 /**
  * All Fragment wallet addresses from ton-labels (https://github.com/ton-studio/ton-labels).
- * Query: SELECT address FROM dune.ton_foundation.dataset_labels WHERE label IN ('fragment', 'fragment.ton')
+ * Query: SELECT address FROM dune.ton_foundation.dataset_labels WHERE label = 'fragment'
  */
 const FRAGMENT_ADDRESSES = [
   '0:E6F3D8824F46B1EFBAB9AFC684793428C55FED69B46A15A49BE69A29BC49E530',
@@ -15,7 +15,6 @@ const FRAGMENT_ADDRESSES = [
   '0:158136239ADB15DD59DF90C641F9EFD312CFEB8664F218F4C3E5FCE9D95E6C07',
   '0:68F3A076D3451A18FD41E05C71B4C020545D46B2757064E65825DED0C49BF02C',
   '0:80D78A35F955A14B679FAA887FF4CD5BFC0F43B4A4EEA2A7E6927F3701B273C2',
-  '0:B314658F1E64345FD1B9FC5C4044530FFB329C5A433F87093947D40D4F53F80D',
 ];
 
 /**


### PR DESCRIPTION
Fixes the Fragment fees calculation on TON by removing the `fragment.ton` merchant address from the Fragment wallet set.

Context:
- Follow-up to #6862 by @treeoflife2.
- That PR changed the label source to include both `fragment` and `fragment.ton`, adding `0:B314658F1E64345FD1B9FC5C4044530FFB329C5A433F87093947D40D4F53F80D`.
- `fragment.ton` is a separate merchant label and is not related to Fragment, so including it in `FRAGMENT_ADDRESSES` affects Fragment fee/revenue calculations incorrectly.

Changes:
- Restore the source query comment to `label = 'fragment'`.
- Remove `0:B314658F1E64345FD1B9FC5C4044530FFB329C5A433F87093947D40D4F53F80D` from `FRAGMENT_ADDRESSES`.

Links:
- DefiLlama TON fees page: https://defillama.com/fees/chain/ton
- Address: https://tonviewer.com/UQCzFGWPHmQ0X9G5_FxARFMP-zKcWkM_hwk5R9QNT1P4DYzx
- Fragment website: https://fragment.com

Verification:
- `git diff --check`

TON data review note:
Please tag me (@ohld) on TON blockchain data changes. I am Head of Data at TON Foundation and lead TON Dune integration, so I can verify labels and fee/revenue numbers before merge.

Contacts if needed: https://t.me/okhlopkov / https://www.linkedin.com/in/danokhlopkov/