### PR TITLE
track sei on reservior protocol

### DIFF
--- a/fees/reservoir-protocol.ts
+++ b/fees/reservoir-protocol.ts
@@ -2,87 +2,96 @@ import { FetchOptions, FetchResult, SimpleAdapter } from '../adapters/types';
 import { CHAIN } from '../helpers/chains';
 import { METRIC } from '../helpers/metrics';
 
-const RUSD = '0x09D4214C03D01F49544C0448DBE3A27f768F2b34';
-const WSRUSD = '0xd3fD63209FA2D55B07A0f6db36C2f43900be3094';
+const RUSD               = '0x09D4214C03D01F49544C0448DBE3A27f768F2b34';
+const WSRUSD             = '0xd3fD63209FA2D55B07A0f6db36C2f43900be3094';
 const WSRUSD_OFT_ADAPTER = '0xBb431AbD156B960e5B77cC45c75F107e3991258a';
-const SRUSD = '0x738d1115B90efa71AE468F1287fc864775e23a31';
-const SAVING_MODULE = '0x5475611Dffb8ef4d697Ae39df9395513b6E947d7';
-const OFT_ADDRESS = '0x4809010926aec940b550D34a46A52739f996D75D';
+const SRUSD              = '0x738d1115B90efa71AE468F1287fc864775e23a31';
+const SAVING_MODULE      = '0x5475611Dffb8ef4d697Ae39df9395513b6E947d7';
+// PSM on Ethereum (Mint/Redeem + totalValue); same address = wsrUSD OFT on other chains
+const PSM_OFT            = '0x4809010926aec940b550D34a46A52739f996D75D';
 
-const WAD = BigInt('1000000000000000000');
+const WAD         = BigInt('1000000000000000000');
 const PRICE_SCALE = BigInt('100000000');
 
 const convertToAssetsAbi = 'function convertToAssets(uint256 shares) view returns (uint256)';
-const balanceOfAbi = 'function balanceOf(address) view returns (uint256)';
+const balanceOfAbi       = 'function balanceOf(address) view returns (uint256)';
 
 async function prefetch(options: FetchOptions): Promise<any> {
+  const { fromApi, toApi } = options;
+
+  // Exchange rates at window boundaries — used to derive yield per share
   const [wsrRateFrom, wsrRateTo, priceFrom, priceTo] = await Promise.all([
-    options.fromApi.call({ target: WSRUSD, abi: convertToAssetsAbi, params: [WAD.toString()], chain: CHAIN.ETHEREUM }),
-    options.toApi.call({ target: WSRUSD, abi: convertToAssetsAbi, params: [WAD.toString()], chain: CHAIN.ETHEREUM }),
-    options.fromApi.call({ target: SAVING_MODULE, abi: 'uint256:currentPrice', chain: CHAIN.ETHEREUM }),
-    options.toApi.call({ target: SAVING_MODULE, abi: 'uint256:currentPrice', chain: CHAIN.ETHEREUM }),
+    fromApi.call({ target: WSRUSD,        abi: convertToAssetsAbi, params: [WAD.toString()] }),
+    toApi.call({   target: WSRUSD,        abi: convertToAssetsAbi, params: [WAD.toString()] }),
+    fromApi.call({ target: SAVING_MODULE, abi: 'uint256:currentPrice' }),
+    toApi.call({   target: SAVING_MODULE, abi: 'uint256:currentPrice' }),
   ]);
-  // Return as strings so BigInt precision survives any framework serialisation
+
   return {
     wsrRateFrom: wsrRateFrom.toString(),
-    wsrRateTo: wsrRateTo.toString(),
-    priceFrom: priceFrom.toString(),
-    priceTo: priceTo.toString(),
+    wsrRateTo:   wsrRateTo.toString(),
+    priceFrom:   priceFrom.toString(),
+    priceTo:     priceTo.toString(),
   };
 }
 
 async function fetch(options: FetchOptions): Promise<FetchResult> {
   const { wsrRateFrom, wsrRateTo, priceFrom, priceTo } = options.preFetchedResults;
   const wsrRateDelta = BigInt(wsrRateTo) - BigInt(wsrRateFrom);
-  const srPriceDelta = BigInt(priceTo) - BigInt(priceFrom);
+  const srPriceDelta = BigInt(priceTo)   - BigInt(priceFrom);
 
-  const dailyFees = options.createBalances();
+  const dailyFees              = options.createBalances();
+  const dailyRevenue           = options.createBalances();
+  const dailySupplySideRevenue = options.createBalances();
 
   if (options.chain === CHAIN.ETHEREUM) {
     const [wsrSupply, wsrLocked, srSupply] = await Promise.all([
       options.api.call({ target: WSRUSD, abi: 'uint256:totalSupply' }),
       options.api.call({ target: WSRUSD, abi: balanceOfAbi, params: [WSRUSD_OFT_ADAPTER] }),
-      options.api.call({ target: SRUSD, abi: 'uint256:totalSupply' }),
+      options.api.call({ target: SRUSD,  abi: 'uint256:totalSupply' }),
     ]);
-    const wsrYield = (BigInt(wsrSupply) - BigInt(wsrLocked)) * wsrRateDelta / WAD;
-    const srYield = BigInt(srSupply) * srPriceDelta / PRICE_SCALE;
-    if (wsrYield !== 0n) dailyFees.add(RUSD, wsrYield, METRIC.ASSETS_YIELDS);
-    if (srYield !== 0n) dailyFees.add(RUSD, srYield, METRIC.ASSETS_YIELDS);
+
+    // Gross Protocol Revenue = yield on ALL wsrUSD obligations (bridged + circulating) + srUSD.
+    // The wsrUSD exchange rate is set by the protocol to reflect total income across all assets
+    // (on-chain DeFi vaults and off-chain RWA), so totalSupply × Δrate is the gross income proxy.
+    const wsrTotalYield   = BigInt(wsrSupply) * wsrRateDelta / WAD;
+    const srYield         = BigInt(srSupply)  * srPriceDelta  / PRICE_SCALE;
+    const totalGrossYield = wsrTotalYield + srYield;
+    if (totalGrossYield !== 0n) dailyFees.add(RUSD, totalGrossYield, METRIC.ASSETS_YIELDS);
+
+    // Cost of Revenue = yield distributed to CIRCULATING wsrUSD holders on Ethereum + srUSD holders.
+    const wsrCircYield = (BigInt(wsrSupply) - BigInt(wsrLocked)) * wsrRateDelta / WAD;
+    const supplySide   = wsrCircYield + srYield;
+    if (supplySide !== 0n) dailySupplySideRevenue.add(RUSD, supplySide, METRIC.ASSETS_YIELDS);
+
+    // Gross Profit = yield on wsrUSD locked in OFT adapter (backing bridged cross-chain supply).
+    const retained = wsrTotalYield - wsrCircYield; // = wsrLocked × wsrRateDelta / WAD
+    if (retained !== 0n) dailyRevenue.add(RUSD, retained, METRIC.ASSETS_YIELDS);
   } else {
-    const supply = await options.api.call({ target: OFT_ADDRESS, abi: 'uint256:totalSupply' });
+    // Non-Ethereum chains: supply-side revenue = yield on bridged wsrUSD OFT holders
+    const supply = await options.api.call({ target: PSM_OFT, abi: 'uint256:totalSupply' });
     const yield_ = BigInt(supply) * wsrRateDelta / WAD;
-    if (yield_ !== 0n) dailyFees.add(RUSD, yield_, METRIC.ASSETS_YIELDS);
+    if (yield_ !== 0n) dailySupplySideRevenue.add(RUSD, yield_, METRIC.ASSETS_YIELDS);
   }
 
-  return { dailyFees, dailyRevenue: 0, dailySupplySideRevenue: dailyFees };
+  return { dailyFees, dailyRevenue, dailySupplySideRevenue };
 }
 
 const methodology = {
-  Fees: 'Total yield distributed to wsrUSD and srUSD holders, measured as circulating supply × Δ(exchange rate).',
-  Revenue: 'No protocol revenue retained — all yield passes through to holders.',
-  SupplySideRevenue: 'Total yield distributed to wsrUSD and srUSD holders.',
-};
-
-const breakdownMethodology = {
-  Fees: {
-    [METRIC.ASSETS_YIELDS]: 'Total yield distributed to wsrUSD and srUSD holders.',
-  },
-  SupplySideRevenue: {
-    [METRIC.ASSETS_YIELDS]: 'Total yield distributed to wsrUSD and srUSD holders.',
-  },
+  Fees: 'Total yield committed to all wsrUSD and srUSD holders (wsrUSD.totalSupply × Δ(exchange rate) + srUSD.totalSupply × Δ(price)), proxying gross protocol income across on-chain DeFi and off-chain RWA assets.',
+  Revenue: 'Yield accruing to wsrUSD locked in the cross-chain OFT adapter — the spread the protocol retains before distributing to bridged-chain holders.',
+  SupplySideRevenue: 'Yield distributed to wsrUSD and srUSD holders on each chain (per-chain circulating supply × Δ exchange rate).',
 };
 
 const adapter: SimpleAdapter = {
   version: 2,
   prefetch,
   fetch,
-  pullHourly: true,
   methodology,
-  breakdownMethodology,
   adapter: {
     [CHAIN.ETHEREUM]: { start: '2025-04-17' },
     [CHAIN.ARBITRUM]: { start: '2025-05-12' },
-    [CHAIN.MONAD]: { start: '2026-01-01' },
+    [CHAIN.MONAD]:    { start: '2026-01-01' },
   },
   allowNegativeValue: true,
   doublecounted: true,

--- a/fees/reservoir-protocol.ts
+++ b/fees/reservoir-protocol.ts
@@ -82,7 +82,7 @@ const adapter: SimpleAdapter = {
   adapter: {
     [CHAIN.ETHEREUM]: { start: '2025-04-17' },
     [CHAIN.ARBITRUM]: { start: '2025-05-12' },
-    [CHAIN.SEI]: {start: '2025-06-13'},
+    [CHAIN.SEI]: { start: '2025-06-13' },
     [CHAIN.MONAD]: { start: '2026-01-01' },
   },
   allowNegativeValue: true,

--- a/fees/reservoir-protocol.ts
+++ b/fees/reservoir-protocol.ts
@@ -1,113 +1,74 @@
 import { FetchOptions, FetchResult, SimpleAdapter } from '../adapters/types';
 import { CHAIN } from '../helpers/chains';
 import { METRIC } from '../helpers/metrics';
-import * as sdk from "@defillama/sdk";
 
-const RUSD               = '0x09D4214C03D01F49544C0448DBE3A27f768F2b34';
-const WSRUSD             = '0xd3fD63209FA2D55B07A0f6db36C2f43900be3094';
+const RUSD = '0x09D4214C03D01F49544C0448DBE3A27f768F2b34';
+const WSRUSD = '0xd3fD63209FA2D55B07A0f6db36C2f43900be3094';
 const WSRUSD_OFT_ADAPTER = '0xBb431AbD156B960e5B77cC45c75F107e3991258a';
-const SRUSD              = '0x738d1115B90efa71AE468F1287fc864775e23a31';
-const SAVING_MODULE      = '0x5475611Dffb8ef4d697Ae39df9395513b6E947d7';
-// PSM on Ethereum; same address = wsrUSD OFT on non-Ethereum chains
-const PSM_OFT            = '0x4809010926aec940b550D34a46A52739f996D75D';
+const SRUSD = '0x738d1115B90efa71AE468F1287fc864775e23a31';
+const SAVING_MODULE = '0x5475611Dffb8ef4d697Ae39df9395513b6E947d7';
+const OFT_ADDRESS = '0x4809010926aec940b550D34a46A52739f996D75D';
 
-const WAD         = BigInt('1000000000000000000');
+const WAD = BigInt('1000000000000000000');
 const PRICE_SCALE = BigInt('100000000');
 
 const convertToAssetsAbi = 'function convertToAssets(uint256 shares) view returns (uint256)';
-const balanceOfAbi       = 'function balanceOf(address) view returns (uint256)';
+const balanceOfAbi = 'function balanceOf(address) view returns (uint256)';
 
 async function prefetch(options: FetchOptions): Promise<any> {
-  const { fromApi, toApi } = options;
-
-  // Pin to CHAIN.ETHEREUM explicitly — these contracts are Ethereum-only.
   const [wsrRateFrom, wsrRateTo, priceFrom, priceTo] = await Promise.all([
-    fromApi.call({ chain: CHAIN.ETHEREUM, target: WSRUSD,        abi: convertToAssetsAbi, params: [WAD.toString()] }),
-    toApi.call({   chain: CHAIN.ETHEREUM, target: WSRUSD,        abi: convertToAssetsAbi, params: [WAD.toString()] }),
-    fromApi.call({ chain: CHAIN.ETHEREUM, target: SAVING_MODULE, abi: 'uint256:currentPrice' }),
-    toApi.call({   chain: CHAIN.ETHEREUM, target: SAVING_MODULE, abi: 'uint256:currentPrice' }),
+    options.fromApi.call({ target: WSRUSD, abi: convertToAssetsAbi, params: [WAD.toString()], chain: CHAIN.ETHEREUM }),
+    options.toApi.call({ target: WSRUSD, abi: convertToAssetsAbi, params: [WAD.toString()], chain: CHAIN.ETHEREUM }),
+    options.fromApi.call({ target: SAVING_MODULE, abi: 'uint256:currentPrice', chain: CHAIN.ETHEREUM }),
+    options.toApi.call({ target: SAVING_MODULE, abi: 'uint256:currentPrice', chain: CHAIN.ETHEREUM }),
   ]);
-
-  // Sum bridged wsrUSD OFT supply across all non-Ethereum chains so that
-  // Ethereum-side revenue can be netted to avoid double-counting with the
-  // per-chain supply-side revenue reported below.
-  const arbApi = new sdk.ChainApi({ chain: CHAIN.ARBITRUM, timestamp: options.toTimestamp });
-  const monApi = new sdk.ChainApi({ chain: CHAIN.MONAD,    timestamp: options.toTimestamp });
-  await Promise.allSettled([arbApi.getBlock(), monApi.getBlock()]);
-  const [wsrArbRes, wsrMonRes] = await Promise.allSettled([
-    arbApi.call({ target: PSM_OFT, abi: 'uint256:totalSupply' }),
-    monApi.call({ target: PSM_OFT, abi: 'uint256:totalSupply' }),
-  ]);
-  const wsrArbSupply = wsrArbRes.status === 'fulfilled' ? wsrArbRes.value : '0';
-  const wsrMonSupply = wsrMonRes.status === 'fulfilled' ? wsrMonRes.value : '0';
-
+  // Return as strings so BigInt precision survives any framework serialisation
   return {
-    wsrRateFrom:      wsrRateFrom.toString(),
-    wsrRateTo:        wsrRateTo.toString(),
-    priceFrom:        priceFrom.toString(),
-    priceTo:          priceTo.toString(),
-    wsrBridgedSupply: (BigInt(wsrArbSupply || '0') + BigInt(wsrMonSupply || '0')).toString(),
+    wsrRateFrom: wsrRateFrom.toString(),
+    wsrRateTo: wsrRateTo.toString(),
+    priceFrom: priceFrom.toString(),
+    priceTo: priceTo.toString(),
   };
 }
 
 async function fetch(options: FetchOptions): Promise<FetchResult> {
-  const { wsrRateFrom, wsrRateTo, priceFrom, priceTo, wsrBridgedSupply } = options.preFetchedResults;
+  const { wsrRateFrom, wsrRateTo, priceFrom, priceTo } = options.preFetchedResults;
   const wsrRateDelta = BigInt(wsrRateTo) - BigInt(wsrRateFrom);
-  const srPriceDelta = BigInt(priceTo)   - BigInt(priceFrom);
+  const srPriceDelta = BigInt(priceTo) - BigInt(priceFrom);
 
-  const dailyFees              = options.createBalances();
-  const dailyRevenue           = options.createBalances();
-  const dailySupplySideRevenue = options.createBalances();
+  const dailyFees = options.createBalances();
 
   if (options.chain === CHAIN.ETHEREUM) {
     const [wsrSupply, wsrLocked, srSupply] = await Promise.all([
       options.api.call({ target: WSRUSD, abi: 'uint256:totalSupply' }),
       options.api.call({ target: WSRUSD, abi: balanceOfAbi, params: [WSRUSD_OFT_ADAPTER] }),
-      options.api.call({ target: SRUSD,  abi: 'uint256:totalSupply' }),
+      options.api.call({ target: SRUSD, abi: 'uint256:totalSupply' }),
     ]);
-
-    // Gross Protocol Revenue = total yield committed to ALL wsrUSD + srUSD holders.
-    // The wsrUSD exchange rate reflects total protocol earnings (on-chain DeFi + off-chain RWA).
-    const wsrTotalYield   = BigInt(wsrSupply) * wsrRateDelta / WAD;
-    const srYield         = BigInt(srSupply)  * srPriceDelta  / PRICE_SCALE;
-    const totalGrossYield = wsrTotalYield + srYield;
-    if (totalGrossYield !== 0n) dailyFees.add(RUSD, totalGrossYield, METRIC.ASSETS_YIELDS);
-
-    // Cost of Revenue = yield distributed to CIRCULATING wsrUSD holders on Ethereum + srUSD holders.
-    const wsrCircYield = (BigInt(wsrSupply) - BigInt(wsrLocked)) * wsrRateDelta / WAD;
-    const supplySide   = wsrCircYield + srYield;
-    if (supplySide !== 0n) dailySupplySideRevenue.add(RUSD, supplySide, METRIC.ASSETS_YIELDS);
-
-    // Gross Profit = yield on wsrUSD locked in OFT adapter that is NOT distributed as
-    // supply-side revenue on any non-Ethereum chain. Nets out wsrArb + wsrMon so that
-    // fees = revenue + Σ(supply_side per chain) holds at the aggregate level.
-    const wsrProtocolYield = (BigInt(wsrLocked) - BigInt(wsrBridgedSupply)) * wsrRateDelta / WAD;
-    if (wsrProtocolYield !== 0n) dailyRevenue.add(RUSD, wsrProtocolYield, METRIC.ASSETS_YIELDS);
+    const wsrYield = (BigInt(wsrSupply) - BigInt(wsrLocked)) * wsrRateDelta / WAD;
+    const srYield = BigInt(srSupply) * srPriceDelta / PRICE_SCALE;
+    if (wsrYield !== 0n) dailyFees.add(RUSD, wsrYield, METRIC.ASSETS_YIELDS);
+    if (srYield !== 0n) dailyFees.add(RUSD, srYield, METRIC.ASSETS_YIELDS);
   } else {
-    // Non-Ethereum chains: supply-side revenue = yield on bridged wsrUSD OFT supply.
-    const supply = await options.api.call({ target: PSM_OFT, abi: 'uint256:totalSupply' });
+    const supply = await options.api.call({ target: OFT_ADDRESS, abi: 'uint256:totalSupply' });
     const yield_ = BigInt(supply) * wsrRateDelta / WAD;
-    if (yield_ !== 0n) dailySupplySideRevenue.add(RUSD, yield_, METRIC.ASSETS_YIELDS);
+    if (yield_ !== 0n) dailyFees.add(RUSD, yield_, METRIC.ASSETS_YIELDS);
   }
 
-  return { dailyFees, dailyRevenue, dailySupplySideRevenue };
+  return { dailyFees, dailyRevenue: 0, dailySupplySideRevenue: dailyFees };
 }
 
 const methodology = {
-  Fees: 'Total yield committed to all wsrUSD and srUSD holders (wsrUSD.totalSupply × Δ(exchange rate) + srUSD.totalSupply × Δ(price)), proxying gross protocol income across on-chain DeFi and off-chain RWA assets.',
-  Revenue: 'Yield on wsrUSD locked in the OFT adapter that is not distributed on any non-Ethereum chain — the net protocol-retained spread after accounting for all cross-chain pass-throughs.',
-  SupplySideRevenue: 'Yield distributed to wsrUSD and srUSD holders on each chain (per-chain circulating supply × Δ exchange rate).',
+  Fees: 'Total yield distributed to wsrUSD and srUSD holders, measured as circulating supply × Δ(exchange rate).',
+  Revenue: 'No protocol revenue retained — all yield passes through to holders.',
+  SupplySideRevenue: 'Total yield distributed to wsrUSD and srUSD holders.',
 };
 
 const breakdownMethodology = {
   Fees: {
-    [METRIC.ASSETS_YIELDS]: 'Total yield committed to all wsrUSD and srUSD holders',
-  },
-  Revenue: {
-    [METRIC.ASSETS_YIELDS]: 'Yield on wsrUSD locked in OFT adapter net of cross-chain distributions',
+    [METRIC.ASSETS_YIELDS]: 'Total yield distributed to wsrUSD and srUSD holders.',
   },
   SupplySideRevenue: {
-    [METRIC.ASSETS_YIELDS]: 'Yield distributed to wsrUSD and srUSD holders per chain',
+    [METRIC.ASSETS_YIELDS]: 'Total yield distributed to wsrUSD and srUSD holders.',
   },
 };
 
@@ -115,12 +76,14 @@ const adapter: SimpleAdapter = {
   version: 2,
   prefetch,
   fetch,
+  pullHourly: true,
   methodology,
   breakdownMethodology,
   adapter: {
     [CHAIN.ETHEREUM]: { start: '2025-04-17' },
     [CHAIN.ARBITRUM]: { start: '2025-05-12' },
-    [CHAIN.MONAD]:    { start: '2026-01-01' },
+    [CHAIN.SEI]: {start: '2025-06-13'},
+    [CHAIN.MONAD]: { start: '2026-01-01' },
   },
   allowNegativeValue: true,
   doublecounted: true,

--- a/fees/reservoir-protocol.ts
+++ b/fees/reservoir-protocol.ts
@@ -1,13 +1,14 @@
 import { FetchOptions, FetchResult, SimpleAdapter } from '../adapters/types';
 import { CHAIN } from '../helpers/chains';
 import { METRIC } from '../helpers/metrics';
+import * as sdk from "@defillama/sdk";
 
 const RUSD               = '0x09D4214C03D01F49544C0448DBE3A27f768F2b34';
 const WSRUSD             = '0xd3fD63209FA2D55B07A0f6db36C2f43900be3094';
 const WSRUSD_OFT_ADAPTER = '0xBb431AbD156B960e5B77cC45c75F107e3991258a';
 const SRUSD              = '0x738d1115B90efa71AE468F1287fc864775e23a31';
 const SAVING_MODULE      = '0x5475611Dffb8ef4d697Ae39df9395513b6E947d7';
-// PSM on Ethereum (Mint/Redeem + totalValue); same address = wsrUSD OFT on other chains
+// PSM on Ethereum; same address = wsrUSD OFT on non-Ethereum chains
 const PSM_OFT            = '0x4809010926aec940b550D34a46A52739f996D75D';
 
 const WAD         = BigInt('1000000000000000000');
@@ -19,24 +20,38 @@ const balanceOfAbi       = 'function balanceOf(address) view returns (uint256)';
 async function prefetch(options: FetchOptions): Promise<any> {
   const { fromApi, toApi } = options;
 
-  // Exchange rates at window boundaries — used to derive yield per share
+  // Pin to CHAIN.ETHEREUM explicitly — these contracts are Ethereum-only.
   const [wsrRateFrom, wsrRateTo, priceFrom, priceTo] = await Promise.all([
-    fromApi.call({ target: WSRUSD,        abi: convertToAssetsAbi, params: [WAD.toString()] }),
-    toApi.call({   target: WSRUSD,        abi: convertToAssetsAbi, params: [WAD.toString()] }),
-    fromApi.call({ target: SAVING_MODULE, abi: 'uint256:currentPrice' }),
-    toApi.call({   target: SAVING_MODULE, abi: 'uint256:currentPrice' }),
+    fromApi.call({ chain: CHAIN.ETHEREUM, target: WSRUSD,        abi: convertToAssetsAbi, params: [WAD.toString()] }),
+    toApi.call({   chain: CHAIN.ETHEREUM, target: WSRUSD,        abi: convertToAssetsAbi, params: [WAD.toString()] }),
+    fromApi.call({ chain: CHAIN.ETHEREUM, target: SAVING_MODULE, abi: 'uint256:currentPrice' }),
+    toApi.call({   chain: CHAIN.ETHEREUM, target: SAVING_MODULE, abi: 'uint256:currentPrice' }),
   ]);
 
+  // Sum bridged wsrUSD OFT supply across all non-Ethereum chains so that
+  // Ethereum-side revenue can be netted to avoid double-counting with the
+  // per-chain supply-side revenue reported below.
+  const arbApi = new sdk.ChainApi({ chain: CHAIN.ARBITRUM, timestamp: options.toTimestamp });
+  const monApi = new sdk.ChainApi({ chain: CHAIN.MONAD,    timestamp: options.toTimestamp });
+  await Promise.allSettled([arbApi.getBlock(), monApi.getBlock()]);
+  const [wsrArbRes, wsrMonRes] = await Promise.allSettled([
+    arbApi.call({ target: PSM_OFT, abi: 'uint256:totalSupply' }),
+    monApi.call({ target: PSM_OFT, abi: 'uint256:totalSupply' }),
+  ]);
+  const wsrArbSupply = wsrArbRes.status === 'fulfilled' ? wsrArbRes.value : '0';
+  const wsrMonSupply = wsrMonRes.status === 'fulfilled' ? wsrMonRes.value : '0';
+
   return {
-    wsrRateFrom: wsrRateFrom.toString(),
-    wsrRateTo:   wsrRateTo.toString(),
-    priceFrom:   priceFrom.toString(),
-    priceTo:     priceTo.toString(),
+    wsrRateFrom:      wsrRateFrom.toString(),
+    wsrRateTo:        wsrRateTo.toString(),
+    priceFrom:        priceFrom.toString(),
+    priceTo:          priceTo.toString(),
+    wsrBridgedSupply: (BigInt(wsrArbSupply || '0') + BigInt(wsrMonSupply || '0')).toString(),
   };
 }
 
 async function fetch(options: FetchOptions): Promise<FetchResult> {
-  const { wsrRateFrom, wsrRateTo, priceFrom, priceTo } = options.preFetchedResults;
+  const { wsrRateFrom, wsrRateTo, priceFrom, priceTo, wsrBridgedSupply } = options.preFetchedResults;
   const wsrRateDelta = BigInt(wsrRateTo) - BigInt(wsrRateFrom);
   const srPriceDelta = BigInt(priceTo)   - BigInt(priceFrom);
 
@@ -51,9 +66,8 @@ async function fetch(options: FetchOptions): Promise<FetchResult> {
       options.api.call({ target: SRUSD,  abi: 'uint256:totalSupply' }),
     ]);
 
-    // Gross Protocol Revenue = yield on ALL wsrUSD obligations (bridged + circulating) + srUSD.
-    // The wsrUSD exchange rate is set by the protocol to reflect total income across all assets
-    // (on-chain DeFi vaults and off-chain RWA), so totalSupply × Δrate is the gross income proxy.
+    // Gross Protocol Revenue = total yield committed to ALL wsrUSD + srUSD holders.
+    // The wsrUSD exchange rate reflects total protocol earnings (on-chain DeFi + off-chain RWA).
     const wsrTotalYield   = BigInt(wsrSupply) * wsrRateDelta / WAD;
     const srYield         = BigInt(srSupply)  * srPriceDelta  / PRICE_SCALE;
     const totalGrossYield = wsrTotalYield + srYield;
@@ -64,11 +78,13 @@ async function fetch(options: FetchOptions): Promise<FetchResult> {
     const supplySide   = wsrCircYield + srYield;
     if (supplySide !== 0n) dailySupplySideRevenue.add(RUSD, supplySide, METRIC.ASSETS_YIELDS);
 
-    // Gross Profit = yield on wsrUSD locked in OFT adapter (backing bridged cross-chain supply).
-    const retained = wsrTotalYield - wsrCircYield; // = wsrLocked × wsrRateDelta / WAD
-    if (retained !== 0n) dailyRevenue.add(RUSD, retained, METRIC.ASSETS_YIELDS);
+    // Gross Profit = yield on wsrUSD locked in OFT adapter that is NOT distributed as
+    // supply-side revenue on any non-Ethereum chain. Nets out wsrArb + wsrMon so that
+    // fees = revenue + Σ(supply_side per chain) holds at the aggregate level.
+    const wsrProtocolYield = (BigInt(wsrLocked) - BigInt(wsrBridgedSupply)) * wsrRateDelta / WAD;
+    if (wsrProtocolYield !== 0n) dailyRevenue.add(RUSD, wsrProtocolYield, METRIC.ASSETS_YIELDS);
   } else {
-    // Non-Ethereum chains: supply-side revenue = yield on bridged wsrUSD OFT holders
+    // Non-Ethereum chains: supply-side revenue = yield on bridged wsrUSD OFT supply.
     const supply = await options.api.call({ target: PSM_OFT, abi: 'uint256:totalSupply' });
     const yield_ = BigInt(supply) * wsrRateDelta / WAD;
     if (yield_ !== 0n) dailySupplySideRevenue.add(RUSD, yield_, METRIC.ASSETS_YIELDS);
@@ -79,8 +95,20 @@ async function fetch(options: FetchOptions): Promise<FetchResult> {
 
 const methodology = {
   Fees: 'Total yield committed to all wsrUSD and srUSD holders (wsrUSD.totalSupply × Δ(exchange rate) + srUSD.totalSupply × Δ(price)), proxying gross protocol income across on-chain DeFi and off-chain RWA assets.',
-  Revenue: 'Yield accruing to wsrUSD locked in the cross-chain OFT adapter — the spread the protocol retains before distributing to bridged-chain holders.',
+  Revenue: 'Yield on wsrUSD locked in the OFT adapter that is not distributed on any non-Ethereum chain — the net protocol-retained spread after accounting for all cross-chain pass-throughs.',
   SupplySideRevenue: 'Yield distributed to wsrUSD and srUSD holders on each chain (per-chain circulating supply × Δ exchange rate).',
+};
+
+const breakdownMethodology = {
+  Fees: {
+    [METRIC.ASSETS_YIELDS]: 'Total yield committed to all wsrUSD and srUSD holders',
+  },
+  Revenue: {
+    [METRIC.ASSETS_YIELDS]: 'Yield on wsrUSD locked in OFT adapter net of cross-chain distributions',
+  },
+  SupplySideRevenue: {
+    [METRIC.ASSETS_YIELDS]: 'Yield distributed to wsrUSD and srUSD holders per chain',
+  },
 };
 
 const adapter: SimpleAdapter = {
@@ -88,6 +116,7 @@ const adapter: SimpleAdapter = {
   prefetch,
   fetch,
   methodology,
+  breakdownMethodology,
   adapter: {
     [CHAIN.ETHEREUM]: { start: '2025-04-17' },
     [CHAIN.ARBITRUM]: { start: '2025-05-12' },


### PR DESCRIPTION
## Summary

Replaces the ERC4626 `AssetAdapter.totalValue()` approach from PR #6856 which produces −$7M/day fees after the protocol migrated capital out of those tracked adapter contracts into direct vault positions.

**New formula:**
```
dailyFees = wsrTotalSupply × Δ(convertToAssets(1e18)) / 1e18
          + srTotalSupply  × Δ(SAVING_MODULE.currentPrice()) / 1e8
```

The wsrUSD exchange rate is set by the protocol to reflect total earnings across on-chain DeFi vaults **and** off-chain RWA arrangements — making rate appreciation × total supply the most reliable gross income proxy available on-chain.

**Income statement breakdown (Ethereum):**
- `dailyFees` = wsrTotalSupply × wsrRateDelta / WAD + srTotalSupply × srPriceDelta / PRICE_SCALE
- `dailySupplySideRevenue` = wsrCirculatingSupply × wsrRateDelta / WAD + srTotalSupply × srPriceDelta / PRICE_SCALE
- `dailyRevenue` = wsrLockedInOFTAdapter × wsrRateDelta / WAD (yield on bridged cross-chain supply)

Non-Ethereum chains: supply side = bridged wsrUSD OFT totalSupply × wsrRateDelta / WAD.

## Test results (2026-04-15)

| Chain     | Fees    | Revenue | Supply side |
|-----------|---------|---------|-------------|
| Ethereum  | $25.71K | $3.25K  | $22.45K     |
| Arbitrum  | —       | —       | $316        |
| Monad     | —       | —       | $1.82K      |
| **Aggregate** | **$25.71K** | **$3.25K** | **$24.59K** |

CSV target (April 2026 daily avg): fees $24,960 · supply side ~$22,500 · revenue $4,150.  
March 2026 supply side was exact vs CSV. Revenue is a lower bound — the full spread is partly from off-chain income not observable on-chain.

## Test command

```
npm test fees reservoir-protocol 2026-04-15
```