### PR TITLE
[feat] user-stats: add dune evm stats helpers & factory 

### DIFF
--- a/factory/duneEvmStats.ts
+++ b/factory/duneEvmStats.ts
@@ -2,18 +2,24 @@ import { CHAIN } from "../helpers/chains";
 import { duneChainStats, DuneChainStatsMode } from "../helpers/duneChainStats";
 import { createFactoryExports } from "./registry";
 
-const configs: Record<string, { start: string; table: string }> = {
-  [CHAIN.ABSTRACT]: { start: "2024-10-25", table: "abstract.transactions" },
-  [CHAIN.LINEA]: { start: "2023-07-06", table: "linea.transactions" },
-  [CHAIN.OP_BNB]: { start: "2023-08-11", table: "opbnb.transactions" },
-  [CHAIN.RONIN]: { start: "2021-01-25", table: "ronin.transactions" },
-  [CHAIN.SONIC]: { start: "2024-12-01", table: "sonic.transactions" },
-  [CHAIN.SOPHON]: { start: "2024-10-21", table: "sophon.transactions" },
+type ProtocolConfig = {
+  chain: string;
+  start: string;
+  table: string;
+};
+
+const protocolConfigMap: Record<string, ProtocolConfig> = {
+  "abstract": { chain: CHAIN.ABSTRACT, start: "2024-10-25", table: "abstract.transactions" },
+  "linea": { chain: CHAIN.LINEA, start: "2023-07-06", table: "linea.transactions" },
+  "op_bnb": { chain: CHAIN.OP_BNB, start: "2023-08-11", table: "opbnb.transactions" },
+  "ronin": { chain: CHAIN.RONIN, start: "2021-01-25", table: "ronin.transactions" },
+  "sonic": { chain: CHAIN.SONIC, start: "2024-12-01", table: "sonic.transactions" },
+  "sophon": { chain: CHAIN.SOPHON, start: "2024-10-21", table: "sophon.transactions" },
 };
 
 const buildProtocols = (mode?: DuneChainStatsMode) => Object.fromEntries(
-  Object.entries(configs).map(([chain, { start, table }]) => [
-    chain,
+  Object.entries(protocolConfigMap).map(([name, { chain, start, table }]) => [
+    name,
     duneChainStats(chain, start, table, mode),
   ])
 );

--- a/factory/duneEvmStats.ts
+++ b/factory/duneEvmStats.ts
@@ -1,0 +1,22 @@
+import { CHAIN } from "../helpers/chains";
+import { duneChainStats, DuneChainStatsMode } from "../helpers/duneChainStats";
+import { createFactoryExports } from "./registry";
+
+const configs: Record<string, { start: string; table: string }> = {
+  [CHAIN.ABSTRACT]: { start: "2024-10-25", table: "abstract.transactions" },
+  [CHAIN.LINEA]: { start: "2023-07-06", table: "linea.transactions" },
+  [CHAIN.OP_BNB]: { start: "2023-08-11", table: "opbnb.transactions" },
+  [CHAIN.RONIN]: { start: "2021-01-25", table: "ronin.transactions" },
+  [CHAIN.SONIC]: { start: "2024-12-01", table: "sonic.transactions" },
+  [CHAIN.SOPHON]: { start: "2024-10-21", table: "sophon.transactions" },
+};
+
+const buildProtocols = (mode?: DuneChainStatsMode) => Object.fromEntries(
+  Object.entries(configs).map(([chain, { start, table }]) => [
+    chain,
+    duneChainStats(chain, start, table, mode),
+  ])
+);
+
+export const { protocolList, getAdapter } = createFactoryExports(buildProtocols());
+export const newUsers = createFactoryExports(buildProtocols("new-users"));

--- a/factory/registry.ts
+++ b/factory/registry.ts
@@ -101,9 +101,11 @@ const factoriesByAdapterType: { [adapterType: string]: string[] } = {
   ],
   'active-users': [
     'users/list',
+    'duneEvmStats',
   ],
   'new-users': [
     'users/list:newUsers',
+    'duneEvmStats:newUsers',
   ]
 };
 

--- a/helpers/GUIDELINES.md
+++ b/helpers/GUIDELINES.md
@@ -46,6 +46,7 @@ Add a new helper when:
 |------|-----------|----------|
 | `chains.ts` | `CHAIN` constants | All supported chain identifiers |
 | `dune.ts` | Dune query helpers | Dune Analytics integration |
+| `duneChainStats.ts` | `duneChainStats`, `getDuneEvmActiveUsers`, `getDuneEvmNewUsers` | Chain-level EVM active/new user stats from Dune transaction tables |
 | `allium.ts` | Allium query helpers | Allium DB queries |
 | `indexer.ts` | `queryIndexer` | DefiLlama indexer queries |
 | `getBlock.ts` | Block lookup helpers | Get blocks by timestamp |

--- a/helpers/duneChainStats.ts
+++ b/helpers/duneChainStats.ts
@@ -1,0 +1,65 @@
+import { Dependencies, FetchOptions, SimpleAdapter } from "../adapters/types";
+import { queryDuneSql } from "./dune";
+
+type DuneEvmStatsRow = {
+  active_users: number;
+  gas_used: number;
+  new_users: number;
+  tx_count: number;
+};
+
+export type DuneChainStatsMode = "active-users" | "new-users";
+
+/** Tracks active users, transactions, and gas from Dune EVM transaction tables. */
+export const getDuneEvmActiveUsers = async (options: FetchOptions, table = "CHAIN.transactions") => {
+  const [row]: DuneEvmStatsRow[] = await queryDuneSql(options, `
+    SELECT
+      COUNT(*) AS tx_count,
+      COUNT(DISTINCT "from") AS active_users,
+      SUM(gas_used) AS gas_used
+    FROM ${table}
+    WHERE success = true
+      AND "from" IS NOT NULL
+      AND block_date >= CAST(from_unixtime(${options.startTimestamp}) AS date)
+      AND block_date <= CAST(from_unixtime(${options.endTimestamp}) AS date)
+      AND block_time > from_unixtime(${options.startTimestamp})
+      AND block_time <= from_unixtime(${options.endTimestamp})
+  `);
+
+  return {
+    dailyActiveUsers: row?.active_users ?? 0,
+    dailyTransactionsCount: row?.tx_count ?? 0,
+    dailyGasUsed: row?.gas_used ?? 0,
+  };
+};
+
+/** Tracks new users from Dune EVM transaction tables using nonce-zero senders. */
+export const getDuneEvmNewUsers = async (options: FetchOptions, table = "CHAIN.transactions") => {
+  const [row]: DuneEvmStatsRow[] = await queryDuneSql(options, `
+    SELECT COUNT(DISTINCT CASE WHEN nonce = 0 THEN "from" END) AS new_users
+    FROM ${table}
+    WHERE success = true
+      AND "from" IS NOT NULL
+      AND block_date >= CAST(from_unixtime(${options.startTimestamp}) AS date)
+      AND block_date <= CAST(from_unixtime(${options.endTimestamp}) AS date)
+      AND block_time > from_unixtime(${options.startTimestamp})
+      AND block_time <= from_unixtime(${options.endTimestamp})
+  `);
+
+  return { dailyNewUsers: row?.new_users ?? 0 };
+};
+
+export function duneChainStats(chain: string, start: string, table = "CHAIN.transactions", mode: DuneChainStatsMode = "active-users"): SimpleAdapter {
+  return {
+    version: 2,
+    dependencies: [Dependencies.DUNE],
+    adapter: {
+      [chain]: {
+        fetch: (options: FetchOptions) => mode === "new-users"
+          ? getDuneEvmNewUsers(options, table)
+          : getDuneEvmActiveUsers(options, table),
+        start,
+      },
+    },
+  };
+}


### PR DESCRIPTION
Half Implementation Using Blockscout Is Here #6859 

## Summary
- Adds a Dune-backed EVM chain stats factory for `active-users` and `new-users`.
- Covers additional chains with standard Dune transaction tables: Abstract, Linea, OP BNB, Ronin, Sonic, and Sophon.

## Changes
- Added `helpers/duneChainStats.ts` with shared Dune SQL fetchers for:
  - `dailyActiveUsers`
  - `dailyTransactionsCount`
  - `dailyGasUsed`
  - `dailyNewUsers`
- Added `factory/duneEvmStats.ts` to export chain-level adapters from one config.
- Wired the factory into `factory/registry.ts` for both `active-users` and `new-users`.

## Methodology
- Active users are counted as distinct successful transaction senders.
- Transaction count is the count of successful transactions in the daily window.
- Gas used is summed from successful transactions.
- New users are counted as distinct successful transaction senders with `nonce = 0`.
- Queries use Dune transaction tables and filter by both `block_date` and `block_time` for the requested adapter window.
