### PR TITLE
[feat] b14g: add b14g fees and revenue adapter

### DIFF
--- a/fees/b14g/index.ts
+++ b/fees/b14g/index.ts
@@ -73,7 +73,7 @@ const addCoreFees = async (options: FetchOptions, dailyFees: Balance, dailyReven
 
   for (const log of await options.getLogs({ target: coreVault, eventAbi: abi.withdrawDirect })) {
     dailyFees.addGasToken(log.fee, METRIC.DEPOSIT_WITHDRAW_FEES);
-    dailyRevenue.addGasToken(log.fee, METRIC.PROTOCOL_FEES);
+    dailyRevenue.addGasToken(log.fee, METRIC.DEPOSIT_WITHDRAW_FEES);
   }
 
   const marketplaceRewardLogs = await options.getLogs({ target: dualBtcVault, eventAbi: abi.claimMarketplaceReward });
@@ -100,8 +100,8 @@ const adapter: SimpleAdapter = {
   adapter: chainConfig,
   methodology: {
     Fees: "Gross yield earned by b14g Core products and Babylon rewards distributed to b14g.",
-    Revenue: "Protocol cut of b14g Core product rewards and Babylon distributed rewards.",
-    ProtocolRevenue: "Protocol cut of b14g Core product rewards and Babylon distributed rewards.",
+    Revenue: "Protocol cut of b14g Core product rewards, Babylon distributed rewards, and instant withdrawal fees.",
+    ProtocolRevenue: "Protocol cut of b14g Core product rewards, Babylon distributed rewards, and instant withdrawal fees.",
     SupplySideRevenue: "Net yield distributed to BTC, CORE, and BABY stakers.",
   },
   breakdownMethodology: {
@@ -111,9 +111,11 @@ const adapter: SimpleAdapter = {
     },
     Revenue: {
       [METRIC.PROTOCOL_FEES]: "Protocol fee charged on b14g Core product rewards and Babylon distributed rewards.",
+      [METRIC.DEPOSIT_WITHDRAW_FEES]: "Instant withdrawal fees charged by the dualCORE vault.",
     },
     ProtocolRevenue: {
       [METRIC.PROTOCOL_FEES]: "Protocol fee charged on b14g Core product rewards and Babylon distributed rewards.",
+      [METRIC.DEPOSIT_WITHDRAW_FEES]: "Instant withdrawal fees charged by the dualCORE vault.",
     },
     SupplySideRevenue: {
       [METRIC.STAKING_REWARDS]: "Net staking rewards distributed to BTC, CORE, and BABY stakers; Babylon rewards are counted fully as supply-side rewards.",

--- a/fees/b14g/index.ts
+++ b/fees/b14g/index.ts
@@ -6,12 +6,11 @@ import { METRIC } from "../../helpers/metrics";
 const DUAL_BTC_FEE_BPS = 1900n;
 const BPS = 10000n;
 const BABY_DECIMALS = 1e6;
-const CORE_START = "2025-01-08";
 const BABYLON_START_TIMESTAMP = 1769724590;
 
 const chainConfig = {
   [CHAIN.CORE]: {
-    start: CORE_START,
+    start: "2025-01-08",
     fetch,
     coreVault: "0xee21ab613d30330823D35Cf91A84cE964808B83F",
     dualBtcVault: "0x13E3eC65EFeB0A4583c852F4FaF6b2Fb31Ff04b1",

--- a/fees/b14g/index.ts
+++ b/fees/b14g/index.ts
@@ -7,7 +7,6 @@ import { METRIC } from "../../helpers/metrics";
 const DUAL_BTC_FEE_BPS = 1900n;
 const BPS = 10000n;
 const BABY_DECIMALS = 1e6;
-const BABYLON_START_TIMESTAMP = 1769724590;
 
 const chainConfig = {
   [CHAIN.CORE]: {
@@ -27,8 +26,7 @@ const abi = {
 };
 
 const addBabylonFees = async (options: FetchOptions, dailyFees: sdk.Balances, dailyRevenue: sdk.Balances, dailySupplySideRevenue: sdk.Balances) => {
-  if (options.endTimestamp <= BABYLON_START_TIMESTAMP) return;
-  const start = new Date(Math.max(options.startTimestamp, BABYLON_START_TIMESTAMP) * 1e3).toISOString();
+  const start = new Date(options.startTimestamp * 1e3).toISOString();
   const end = new Date(options.endTimestamp * 1e3).toISOString();
   const [row] = await queryAllium(`
     WITH attrs AS (
@@ -102,6 +100,7 @@ async function fetch(options: FetchOptions) {
 const adapter: SimpleAdapter = {
   version: 2,
   fetch,
+  pullHourly: true,
   adapter: chainConfig,
   methodology: {
     Fees: "Gross yield earned by b14g Core products and Babylon rewards distributed to b14g.",

--- a/fees/b14g/index.ts
+++ b/fees/b14g/index.ts
@@ -11,9 +11,11 @@ const BABYLON_START_TIMESTAMP = 1769724590;
 const chainConfig = {
   [CHAIN.CORE]: {
     start: "2025-01-08",
-    fetch,
     coreVault: "0xee21ab613d30330823D35Cf91A84cE964808B83F",
     dualBtcVault: "0x13E3eC65EFeB0A4583c852F4FaF6b2Fb31Ff04b1",
+  },
+  [CHAIN.BABYLON]: {
+    start: "2026-01-29",
   },
 };
 
@@ -90,13 +92,17 @@ async function fetch(options: FetchOptions) {
   const dailyFees = options.createBalances();
   const dailyRevenue = options.createBalances();
   const dailySupplySideRevenue = options.createBalances();
-  await addCoreFees(options, dailyFees, dailyRevenue, dailySupplySideRevenue);
-  await addBabylonFees(options, dailyFees, dailyRevenue, dailySupplySideRevenue);
+  if (options.chain === CHAIN.BABYLON) {
+    await addBabylonFees(options, dailyFees, dailyRevenue, dailySupplySideRevenue);
+  } else {
+    await addCoreFees(options, dailyFees, dailyRevenue, dailySupplySideRevenue);
+  }
   return { dailyFees, dailyRevenue, dailyProtocolRevenue: dailyRevenue, dailySupplySideRevenue };
 }
 
 const adapter: SimpleAdapter = {
   version: 2,
+  fetch,
   adapter: chainConfig,
   methodology: {
     Fees: "Gross yield earned by b14g Core products and Babylon rewards distributed to b14g.",

--- a/fees/b14g/index.ts
+++ b/fees/b14g/index.ts
@@ -1,0 +1,127 @@
+import { Dependencies, FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { queryAllium } from "../../helpers/allium";
+import { CHAIN } from "../../helpers/chains";
+import { METRIC } from "../../helpers/metrics";
+
+const DUAL_BTC_FEE_BPS = 1900n;
+const BPS = 10000n;
+const BABY_DECIMALS = 1e6;
+const CORE_START = "2025-01-08";
+const BABYLON_START_TIMESTAMP = 1769724590;
+
+const chainConfig = {
+  [CHAIN.CORE]: {
+    start: CORE_START,
+    fetch,
+    coreVault: "0xee21ab613d30330823D35Cf91A84cE964808B83F",
+    dualBtcVault: "0x13E3eC65EFeB0A4583c852F4FaF6b2Fb31Ff04b1",
+  },
+};
+
+const abi = {
+  coreClaimReward: "event ClaimReward(uint256 reward, uint256 fee)",
+  withdrawDirect: "event WithdrawDirect(address indexed user, uint256 dualCoreAmount, uint256 coreAmount, uint256 fee)",
+  claimMarketplaceReward: "event ClaimMarketplaceReward(uint256 reward)",
+};
+
+type Balance = ReturnType<FetchOptions["createBalances"]>;
+
+const addBabylonFees = async (options: FetchOptions, dailyFees: Balance, dailyRevenue: Balance, dailySupplySideRevenue: Balance) => {
+  if (options.endTimestamp <= BABYLON_START_TIMESTAMP) return;
+  const start = new Date(Math.max(options.startTimestamp, BABYLON_START_TIMESTAMP) * 1e3).toISOString();
+  const end = new Date(options.endTimestamp * 1e3).toISOString();
+  const [row] = await queryAllium(`
+    WITH attrs AS (
+      SELECT transaction_hash, event_index, key, value
+      FROM babylon.raw.event_attributes
+      WHERE TO_DATE(block_timestamp) BETWEEN '${start.slice(0, 10)}' AND '${end.slice(0, 10)}'
+        AND block_timestamp > TO_TIMESTAMP_NTZ('${start}')
+        AND block_timestamp <= TO_TIMESTAMP_NTZ('${end}')
+        AND event_type = 'wasm-b14g-reward-receiver-wasm'
+        AND key IN ('action_type', 'type', 'distribute_reward', 'take_fee')
+    ), events AS (
+      SELECT
+        transaction_hash,
+        event_index,
+        MAX(CASE WHEN key = 'action_type' THEN value END) AS action_type,
+        MAX(CASE WHEN key = 'type' THEN value END) AS reward_type,
+        MAX(CASE WHEN key = 'distribute_reward' THEN value END) AS reward,
+        MAX(CASE WHEN key = 'take_fee' THEN value END) AS fee
+      FROM attrs
+      GROUP BY transaction_hash, event_index
+    )
+    SELECT
+      SUM(TRY_TO_NUMBER(REPLACE(reward, 'ubbn', ''))) AS rewards,
+      SUM(TRY_TO_NUMBER(REPLACE(fee, 'ubbn', ''))) AS fees
+    FROM events
+    WHERE reward_type = 'distribute_reward'
+      AND action_type IN ('BABYStaking', 'CoStaking')
+  `);
+
+  dailyFees.addCGToken("babylon", (Number(row?.rewards ?? 0) + Number(row?.fees ?? 0)) / BABY_DECIMALS, METRIC.STAKING_REWARDS);
+  dailyRevenue.addCGToken("babylon", Number(row?.fees ?? 0) / BABY_DECIMALS, METRIC.PROTOCOL_FEES);
+  dailySupplySideRevenue.addCGToken("babylon", Number(row?.rewards ?? 0) / BABY_DECIMALS, METRIC.STAKING_REWARDS);
+};
+
+const addCoreFees = async (options: FetchOptions, dailyFees: Balance, dailyRevenue: Balance, dailySupplySideRevenue: Balance) => {
+  const { coreVault, dualBtcVault } = chainConfig[CHAIN.CORE];
+
+  for (const log of await options.getLogs({ target: coreVault, eventAbi: abi.coreClaimReward })) {
+    dailyFees.addGasToken(BigInt(log.reward) + BigInt(log.fee), METRIC.STAKING_REWARDS);
+    dailyRevenue.addGasToken(log.fee, METRIC.PROTOCOL_FEES);
+    dailySupplySideRevenue.addGasToken(log.reward, METRIC.STAKING_REWARDS);
+  }
+
+  for (const log of await options.getLogs({ target: coreVault, eventAbi: abi.withdrawDirect })) {
+    dailyFees.addGasToken(log.fee, METRIC.DEPOSIT_WITHDRAW_FEES);
+    dailyRevenue.addGasToken(log.fee, METRIC.PROTOCOL_FEES);
+  }
+
+  const marketplaceRewardLogs = await options.getLogs({ target: dualBtcVault, eventAbi: abi.claimMarketplaceReward });
+  for (const log of marketplaceRewardLogs) {
+    const reward = BigInt(log.reward);
+    const revenue = reward * DUAL_BTC_FEE_BPS / BPS;
+    dailyFees.addGasToken(reward, METRIC.STAKING_REWARDS);
+    dailyRevenue.addGasToken(revenue, METRIC.PROTOCOL_FEES);
+    dailySupplySideRevenue.addGasToken(reward - revenue, METRIC.STAKING_REWARDS);
+  }
+};
+
+async function fetch(options: FetchOptions) {
+  const dailyFees = options.createBalances();
+  const dailyRevenue = options.createBalances();
+  const dailySupplySideRevenue = options.createBalances();
+  await addCoreFees(options, dailyFees, dailyRevenue, dailySupplySideRevenue);
+  await addBabylonFees(options, dailyFees, dailyRevenue, dailySupplySideRevenue);
+  return { dailyFees, dailyRevenue, dailyProtocolRevenue: dailyRevenue, dailySupplySideRevenue };
+}
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  adapter: chainConfig,
+  methodology: {
+    Fees: "Gross yield earned by b14g Core products and Babylon rewards distributed to b14g.",
+    Revenue: "Protocol cut of b14g Core product rewards and Babylon distributed rewards.",
+    ProtocolRevenue: "Protocol cut of b14g Core product rewards and Babylon distributed rewards.",
+    SupplySideRevenue: "Net yield distributed to BTC, CORE, and BABY stakers.",
+  },
+  breakdownMethodology: {
+    Fees: {
+      [METRIC.STAKING_REWARDS]: "Gross staking rewards earned by b14g Core products and Babylon BABYStaking/CoStaking rewards distributed to b14g orders.",
+      [METRIC.DEPOSIT_WITHDRAW_FEES]: "Instant withdrawal fees charged by the dualCORE vault.",
+    },
+    Revenue: {
+      [METRIC.PROTOCOL_FEES]: "Protocol fee charged on b14g Core product rewards and Babylon distributed rewards.",
+    },
+    ProtocolRevenue: {
+      [METRIC.PROTOCOL_FEES]: "Protocol fee charged on b14g Core product rewards and Babylon distributed rewards.",
+    },
+    SupplySideRevenue: {
+      [METRIC.STAKING_REWARDS]: "Net staking rewards distributed to BTC, CORE, and BABY stakers; Babylon rewards are counted fully as supply-side rewards.",
+    },
+  },
+  dependencies: [Dependencies.ALLIUM],
+  isExpensiveAdapter: true,
+};
+
+export default adapter;

--- a/fees/b14g/index.ts
+++ b/fees/b14g/index.ts
@@ -1,3 +1,4 @@
+import * as sdk from "@defillama/sdk";
 import { Dependencies, FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { queryAllium } from "../../helpers/allium";
 import { CHAIN } from "../../helpers/chains";
@@ -25,9 +26,7 @@ const abi = {
   claimMarketplaceReward: "event ClaimMarketplaceReward(uint256 reward)",
 };
 
-type Balance = ReturnType<FetchOptions["createBalances"]>;
-
-const addBabylonFees = async (options: FetchOptions, dailyFees: Balance, dailyRevenue: Balance, dailySupplySideRevenue: Balance) => {
+const addBabylonFees = async (options: FetchOptions, dailyFees: sdk.Balances, dailyRevenue: sdk.Balances, dailySupplySideRevenue: sdk.Balances) => {
   if (options.endTimestamp <= BABYLON_START_TIMESTAMP) return;
   const start = new Date(Math.max(options.startTimestamp, BABYLON_START_TIMESTAMP) * 1e3).toISOString();
   const end = new Date(options.endTimestamp * 1e3).toISOString();
@@ -64,7 +63,7 @@ const addBabylonFees = async (options: FetchOptions, dailyFees: Balance, dailyRe
   dailySupplySideRevenue.addCGToken("babylon", Number(row?.rewards ?? 0) / BABY_DECIMALS, METRIC.STAKING_REWARDS);
 };
 
-const addCoreFees = async (options: FetchOptions, dailyFees: Balance, dailyRevenue: Balance, dailySupplySideRevenue: Balance) => {
+const addCoreFees = async (options: FetchOptions, dailyFees: sdk.Balances, dailyRevenue: sdk.Balances, dailySupplySideRevenue: sdk.Balances) => {
   const { coreVault, dualBtcVault } = chainConfig[CHAIN.CORE];
 
   for (const log of await options.getLogs({ target: coreVault, eventAbi: abi.coreClaimReward })) {
@@ -128,7 +127,6 @@ const adapter: SimpleAdapter = {
     },
   },
   dependencies: [Dependencies.ALLIUM],
-  isExpensiveAdapter: true,
 };
 
 export default adapter;


### PR DESCRIPTION
Tracks fee and revenue for https://defillama.com/protocol/b14g

## Summary
- Adds a new `b14g` fees adapter under `fees/b14g`.
- Tracks Core-side product rewards and Babylon distributed rewards with fee, revenue, protocol revenue, and supply-side revenue breakdowns.

## Changes
- Added Core tracking for `ClaimReward`, `WithdrawDirect`, and `ClaimMarketplaceReward` events.
- Applies the documented 19% protocol cut on dualBTC marketplace rewards.
- Adds Babylon rewards through Allium using `wasm-b14g-reward-receiver-wasm` distribution events for `BABYStaking` and `CoStaking`.
- Uses the exact Core start date from the first tracked Core event: `2025-01-08`.
- Guards Babylon querying until the first tracked Babylon distribution timestamp.

## Methodology
- `dailyFees` includes gross Core staking rewards, instant withdrawal fees, dualBTC marketplace rewards, and Babylon distributed rewards.
- `dailyRevenue` and `dailyProtocolRevenue` include protocol fees from Core rewards and Babylon `take_fee` values.
- `dailySupplySideRevenue` includes net rewards distributed to BTC, CORE, and BABY stakers.
- Babylon rewards are sourced from Allium event attributes and filtered to b14g reward receiver distribution events only.
