### PR TITLE
[feat] afiprotocol: add fees and revenue adapter for afiUSD

### DIFF
--- a/fees/afiprotocol/index.ts
+++ b/fees/afiprotocol/index.ts
@@ -1,12 +1,10 @@
 import { FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
-import coreAssets from "../../helpers/coreAssets.json";
 import { METRIC } from "../../helpers/metrics";
 
-const chainConfig: Record<string, { start: string; yield: string, yieldToken: string }> = {
+const chainConfig: Record<string, { start: string; yield: string }> = {
   [CHAIN.ETHEREUM]: {
     yield: "0xb82b080791dFA4aa6Cac8c3f9c0fcb4471C9FEaD",
-    yieldToken: coreAssets.ethereum.USDC,
     start: "2025-08-20",
   },
 };
@@ -24,18 +22,17 @@ const fetch = async (options: FetchOptions) => {
     eventAbi: DISTRIBUTE_YIELD_EVENT,
   });
 
-  const yieldToken = chainConfig[options.chain].yieldToken;
   logs.forEach((log) => {
     const sign = log.profit ? 1n : -1n;
 
     // count all fees from yields
-    dailyFees.add(yieldToken, (log.amount + log.feeAmount) * sign, METRIC.ASSETS_YIELDS);
+    dailyFees.add(log.asset, (log.amount + log.feeAmount) * sign, METRIC.ASSETS_YIELDS);
 
     // breakdown yields to stakers
-    dailySupplySideRevenue.add(yieldToken, log.amount * sign, 'Assets Yields To Stakers');
-    
+    dailySupplySideRevenue.add(log.asset, log.amount * sign, 'Assets Yields To Stakers');
+
     // breakdown performance fees
-    dailyRevenue.add(yieldToken, log.feeAmount * sign, METRIC.PERFORMANCE_FEES);
+    dailyRevenue.add(log.asset, log.feeAmount * sign, METRIC.PERFORMANCE_FEES);
   });
 
   return {

--- a/fees/afiprotocol/index.ts
+++ b/fees/afiprotocol/index.ts
@@ -1,0 +1,79 @@
+import { FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import coreAssets from "../../helpers/coreAssets.json";
+import { METRIC } from "../../helpers/metrics";
+
+const USDC = coreAssets.ethereum.USDC;
+
+const chainConfig: Record<string, { start: string; yield: string }> = {
+  [CHAIN.ETHEREUM]: {
+    yield: "0xb82b080791dFA4aa6Cac8c3f9c0fcb4471C9FEaD",
+    start: "2025-08-23",
+  },
+};
+
+const DISTRIBUTE_YIELD_EVENT =
+  "event DistributeYield(address caller, address indexed asset, address indexed receiver, uint256 amount, uint256 feeAmount, bool profit)";
+
+const fetch = async (options: FetchOptions) => {
+  const dailyFees = options.createBalances();
+  const dailyRevenue = options.createBalances();
+  const dailySupplySideRevenue = options.createBalances();
+
+  const logs = await options.getLogs({
+    target: chainConfig[options.chain].yield,
+    eventAbi: DISTRIBUTE_YIELD_EVENT,
+  });
+
+  logs.forEach((log) => {
+    const sign = log.profit ? 1n : -1n;
+
+    dailyFees.add(USDC, log.amount * sign, METRIC.ASSETS_YIELDS);
+    dailySupplySideRevenue.add(USDC, log.amount * sign, METRIC.ASSETS_YIELDS);
+
+    dailyFees.add(USDC, log.feeAmount * sign, METRIC.PERFORMANCE_FEES);
+    dailyRevenue.add(USDC, log.feeAmount * sign, METRIC.PERFORMANCE_FEES);
+  });
+
+  return {
+    dailyFees,
+    dailyRevenue,
+    dailyProtocolRevenue: dailyRevenue,
+    dailySupplySideRevenue,
+  };
+};
+
+const methodology = {
+  Fees: "Net yield distributed, including holder yield and treasury performance fees.",
+  Revenue: "Performance fees minted to or burned from the AFI treasury.",
+  ProtocolRevenue: "Performance fees minted to or burned from the AFI treasury.",
+  SupplySideRevenue: "Net yield credited to afiUSD holders.",
+};
+
+const breakdownMethodology = {
+  Fees: {
+    [METRIC.ASSETS_YIELDS]: "Net yield credited to afiUSD holders.",
+    [METRIC.PERFORMANCE_FEES]: "Treasury performance fees from afiUSD yield distributions.",
+  },
+  Revenue: {
+    [METRIC.PERFORMANCE_FEES]: "Treasury performance fees from afiUSD yield distributions.",
+  },
+  ProtocolRevenue: {
+    [METRIC.PERFORMANCE_FEES]: "Treasury performance fees from afiUSD yield distributions.",
+  },
+  SupplySideRevenue: {
+    [METRIC.ASSETS_YIELDS]: "Net yield credited to afiUSD holders.",
+  },
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  pullHourly: true,
+  fetch,
+  adapter: chainConfig,
+  allowNegativeValue: true,
+  methodology,
+  breakdownMethodology,
+};
+
+export default adapter;

--- a/fees/afiprotocol/index.ts
+++ b/fees/afiprotocol/index.ts
@@ -3,12 +3,11 @@ import { CHAIN } from "../../helpers/chains";
 import coreAssets from "../../helpers/coreAssets.json";
 import { METRIC } from "../../helpers/metrics";
 
-const USDC = coreAssets.ethereum.USDC;
-
-const chainConfig: Record<string, { start: string; yield: string }> = {
+const chainConfig: Record<string, { start: string; yield: string, yieldToken: string }> = {
   [CHAIN.ETHEREUM]: {
     yield: "0xb82b080791dFA4aa6Cac8c3f9c0fcb4471C9FEaD",
-    start: "2025-07-20",
+    yieldToken: coreAssets.ethereum.USDC,
+    start: "2025-08-20",
   },
 };
 
@@ -25,14 +24,18 @@ const fetch = async (options: FetchOptions) => {
     eventAbi: DISTRIBUTE_YIELD_EVENT,
   });
 
+  const yieldToken = chainConfig[options.chain].yieldToken;
   logs.forEach((log) => {
     const sign = log.profit ? 1n : -1n;
 
-    dailyFees.add(USDC, log.amount * sign, METRIC.ASSETS_YIELDS);
-    dailySupplySideRevenue.add(USDC, log.amount * sign, METRIC.ASSETS_YIELDS);
+    // count all fees from yields
+    dailyFees.add(yieldToken, (log.amount + log.feeAmount) * sign, METRIC.ASSETS_YIELDS);
 
-    dailyFees.add(USDC, log.feeAmount * sign, METRIC.PERFORMANCE_FEES);
-    dailyRevenue.add(USDC, log.feeAmount * sign, METRIC.PERFORMANCE_FEES);
+    // breakdown yields to stakers
+    dailySupplySideRevenue.add(yieldToken, log.amount * sign, 'Assets Yields To Stakers');
+    
+    // breakdown performance fees
+    dailyRevenue.add(yieldToken, log.feeAmount * sign, METRIC.PERFORMANCE_FEES);
   });
 
   return {
@@ -52,8 +55,7 @@ const methodology = {
 
 const breakdownMethodology = {
   Fees: {
-    [METRIC.ASSETS_YIELDS]: "Net yield credited to afiUSD holders.",
-    [METRIC.PERFORMANCE_FEES]: "Treasury performance fees from afiUSD yield distributions.",
+    [METRIC.ASSETS_YIELDS]: "All staking yield credited to afiUSD holders + share to AFI protocol.",
   },
   Revenue: {
     [METRIC.PERFORMANCE_FEES]: "Treasury performance fees from afiUSD yield distributions.",
@@ -62,7 +64,7 @@ const breakdownMethodology = {
     [METRIC.PERFORMANCE_FEES]: "Treasury performance fees from afiUSD yield distributions.",
   },
   SupplySideRevenue: {
-    [METRIC.ASSETS_YIELDS]: "Net yield credited to afiUSD holders.",
+    'Assets Yields To Stakers': "Net yield credited to afiUSD holders.",
   },
 };
 

--- a/fees/afiprotocol/index.ts
+++ b/fees/afiprotocol/index.ts
@@ -8,7 +8,7 @@ const USDC = coreAssets.ethereum.USDC;
 const chainConfig: Record<string, { start: string; yield: string }> = {
   [CHAIN.ETHEREUM]: {
     yield: "0xb82b080791dFA4aa6Cac8c3f9c0fcb4471C9FEaD",
-    start: "2025-08-23",
+    start: "2025-07-20",
   },
 };
 


### PR DESCRIPTION
Tracks fees and revenue for https://defillama.com/protocol/afi-protocol

## Summary
- Adds the AFI Protocol fees adapter for afiUSD on Ethereum.
- Tracks net vault yield, treasury performance fees, and holder supply-side yield from the AFI `Yield.DistributeYield` event.

## Changes
- Added `fees/afiprotocol/index.ts`.
- Uses the AFI Yield contract on Ethereum: `0xb82b080791dFA4aa6Cac8c3f9c0fcb4471C9FEaD`.
- Reports:
  - `dailyFees` as net holder yield plus treasury performance fees.
  - `dailySupplySideRevenue` as net yield credited to afiUSD holders.
  - `dailyRevenue` and `dailyProtocolRevenue` as performance fees minted to or burned from the AFI treasury.
- Enables `allowNegativeValue` so loss distributions are reflected instead of dropped.

## Methodology
- Reads `DistributeYield(address asset, address receiver, uint256 amount, uint256 feeAmount, bool profit)` events.
- For profit distributions, adds `amount` as holder yield and `feeAmount` as treasury performance fees.
- For loss distributions, subtracts `amount` and `feeAmount` using the same labels.