### PR TITLE
feat: add AlloX aggregator volume + fees adapter

### DIFF
--- a/aggregators/allox/index.ts
+++ b/aggregators/allox/index.ts
@@ -2,7 +2,6 @@ import { Adapter, FetchOptions } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 
 const FEE_RECIPIENT = "0x6A80f57ac54123cB71e6c79B3935A381b87B4308";
-const FEE_BPS = 25;
 
 const TRANSFER_TOPIC =
   "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef";
@@ -14,25 +13,27 @@ const START_DATE: Record<string, string> = {
 };
 
 const fetch = async (options: FetchOptions) => {
-    const dailyVolume = options.createBalances();
-  
-    // Pad to 32 bytes (12 zero bytes + 20-byte address) for topic position 2 (indexed `to`).
+  const dailyVolume = options.createBalances();
+
+  try {
     const recipientTopic =
       "0x" + "0".repeat(24) + FEE_RECIPIENT.slice(2).toLowerCase();
-  
+
     const logs = await options.getLogs({
       noTarget: true,
       topics: [TRANSFER_TOPIC, null as any, recipientTopic],
     });
-  
+
     for (const log of logs as any[]) {
       dailyVolume.add(log.address, BigInt(log.data) * BigInt(400));
     }
-  
-    return { dailyVolume };
-  };
-  
-  
+  } catch (err) {
+    console.error(`[ALLOX:volume] getLogs failed on chain:`, err);
+    // Return 0 volume for this chain so other chains keep working.
+  }
+
+  return { dailyVolume };
+};
 
 const adapter: Adapter = {
   version: 2,
@@ -42,6 +43,7 @@ const adapter: Adapter = {
       {
         fetch,
         start: START_DATE[chain],
+        pullHourly: true,
         meta: {
           methodology: {
             Volume:

--- a/aggregators/allox/index.ts
+++ b/aggregators/allox/index.ts
@@ -1,0 +1,61 @@
+import { Adapter, FetchOptions } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+
+const FEE_RECIPIENT = "0x6A80f57ac54123cB71e6c79B3935A381b87B4308";
+const FEE_BPS = 25;
+
+const TRANSFER_TOPIC =
+  "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef";
+
+const START_DATE: Record<string, string> = {
+  [CHAIN.BSC]:      "2026-03-17",
+  [CHAIN.BASE]:     "2026-04-22",
+  [CHAIN.ETHEREUM]: "2026-05-05",
+};
+
+const fetch = async (options: FetchOptions) => {
+    const dailyVolume = options.createBalances();
+  
+    // Pad to 32 bytes (12 zero bytes + 20-byte address) for topic position 2 (indexed `to`).
+    const recipientTopic =
+      "0x" + "0".repeat(24) + FEE_RECIPIENT.slice(2).toLowerCase();
+  
+    const logs = await options.getLogs({
+      noTarget: true,
+      topics: [TRANSFER_TOPIC, null as any, recipientTopic],
+    });
+  
+    for (const log of logs as any[]) {
+      dailyVolume.add(log.address, BigInt(log.data) * BigInt(400));
+    }
+  
+    return { dailyVolume };
+  };
+  
+  
+
+const adapter: Adapter = {
+  version: 2,
+  adapter: Object.fromEntries(
+    Object.keys(START_DATE).map((chain) => [
+      chain,
+      {
+        fetch,
+        start: START_DATE[chain],
+        meta: {
+          methodology: {
+            Volume:
+              "Total USD value of swaps AlloX routed through Uniswap " +
+              "(V2/V3/V4 Universal Router) and PancakeSwap (Universal Router). " +
+              "Derived from ERC20 Transfer events landing at the fee recipient " +
+              `(${FEE_RECIPIENT}). AlloX takes a fixed 0.25% portion of each ` +
+              "swap output via PAY_PORTION / V4 TAKE_PORTION, so daily volume " +
+              "= sum of recipient inflows × 400.",
+          },
+        },
+      },
+    ])
+  ),
+};
+
+export default adapter;

--- a/aggregators/allox/index.ts
+++ b/aggregators/allox/index.ts
@@ -1,63 +1,39 @@
 import { Adapter, FetchOptions } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
+import { addTokensReceived } from "../../helpers/token";
 
 const FEE_RECIPIENT = "0x6A80f57ac54123cB71e6c79B3935A381b87B4308";
 
-const TRANSFER_TOPIC =
-  "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef";
-
-const START_DATE: Record<string, string> = {
-  [CHAIN.BSC]:      "2026-03-17",
-  [CHAIN.BASE]:     "2026-04-22",
-  [CHAIN.ETHEREUM]: "2026-05-05",
+const configs: Record<string, any> = {
+  [CHAIN.BSC]: {
+    start: "2026-03-17",
+  },
+  [CHAIN.BASE]: {
+    start: "2026-04-22",
+  },
+  [CHAIN.ETHEREUM]: {
+    start: "2026-05-05",
+  },
 };
 
 const fetch = async (options: FetchOptions) => {
-  const dailyVolume = options.createBalances();
+  const dailyFees = await addTokensReceived({
+    options,
+    target: FEE_RECIPIENT,
+  });
 
-  try {
-    const recipientTopic =
-      "0x" + "0".repeat(24) + FEE_RECIPIENT.slice(2).toLowerCase();
-
-    const logs = await options.getLogs({
-      noTarget: true,
-      topics: [TRANSFER_TOPIC, null as any, recipientTopic],
-    });
-
-    for (const log of logs as any[]) {
-      dailyVolume.add(log.address, BigInt(log.data) * BigInt(400));
-    }
-  } catch (err) {
-    console.error(`[ALLOX:volume] getLogs failed on chain:`, err);
-    // Return 0 volume for this chain so other chains keep working.
-  }
-
-  return { dailyVolume };
+  // flat 0.25% fee on trades, volume is scaled by 400
+  return { dailyVolume: dailyFees.clone(4) };
 };
 
 const adapter: Adapter = {
   version: 2,
-  adapter: Object.fromEntries(
-    Object.keys(START_DATE).map((chain) => [
-      chain,
-      {
-        fetch,
-        start: START_DATE[chain],
-        pullHourly: true,
-        meta: {
-          methodology: {
-            Volume:
-              "Total USD value of swaps AlloX routed through Uniswap " +
-              "(V2/V3/V4 Universal Router) and PancakeSwap (Universal Router). " +
-              "Derived from ERC20 Transfer events landing at the fee recipient " +
-              `(${FEE_RECIPIENT}). AlloX takes a fixed 0.25% portion of each ` +
-              "swap output via PAY_PORTION / V4 TAKE_PORTION, so daily volume " +
-              "= sum of recipient inflows × 400.",
-          },
-        },
-      },
-    ])
-  ),
+  pullHourly: true,
+  adapter: configs,
+  fetch,
+  methodology: {
+    Volume: 'Total USD value of swaps AlloX routed through Uniswap (V2/V3/V4 Universal Router) and PancakeSwap (Universal Router).',
+  }
 };
 
 export default adapter;

--- a/fees/allox/index.ts
+++ b/fees/allox/index.ts
@@ -1,92 +1,63 @@
 import { Adapter, FetchOptions } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
+import { addTokensReceived } from "../../helpers/token";
 
 const FEE_RECIPIENT = "0x6A80f57ac54123cB71e6c79B3935A381b87B4308";
 
-const MESSAGE_CONTRACTS: Record<string, string> = {
-  [CHAIN.ETHEREUM]: "0xd33f10222a9783d30cb3a4dab51fed1a045c81e0",
-  [CHAIN.BSC]:      "0x0b3e65149C84A0aB56B199DeA3C48965a0569225",
-  [CHAIN.BASE]:     "0xf3e05a607c97006b37d2b2789e17c3a832ba56f0",
+const configs: Record<string, any> = {
+  [CHAIN.BSC]: {
+    start: "2026-03-17",
+    messageContract: "0x0b3e65149C84A0aB56B199DeA3C48965a0569225",
+  },
+  [CHAIN.BASE]: {
+    start: "2026-04-22",
+    messageContract: "0xf3e05a607c97006b37d2b2789e17c3a832ba56f0",
+  },
+  [CHAIN.ETHEREUM]: {
+    start: "2026-05-05",
+    messageContract: "0xd33f10222a9783d30cb3a4dab51fed1a045c81e0",
+  },
 };
 
-const TRANSFER_TOPIC =
-  "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef";
+const fetch = async (options: FetchOptions) => {
+  const dailyTradeFees = await addTokensReceived({
+    options,
+    target: FEE_RECIPIENT,
+  });
 
-const START_DATE: Record<string, string> = {
-  [CHAIN.BSC]:      "2026-03-17",
-  [CHAIN.BASE]:     "2026-04-22",
-  [CHAIN.ETHEREUM]: "2026-05-05",
-};
+  const dailyMessageFees = await addTokensReceived({
+    options,
+    target: configs[options.chain].messageContract,
+  });
 
-const padAddress = (addr: string): string =>
-  "0x" + "0".repeat(24) + addr.slice(2).toLowerCase();
-
-const fetch = (chain: string) => async (options: FetchOptions) => {
   const dailyFees = options.createBalances();
 
-  // 1) Swap fees — 0.25% of every swap output collected at FEE_RECIPIENT.
-  try {
-    const swapLogs = await options.getLogs({
-      noTarget: true,
-      topics: [TRANSFER_TOPIC, null as any, padAddress(FEE_RECIPIENT)],
-    });
-    for (const log of swapLogs as any[]) {
-      dailyFees.add(log.address, BigInt(log.data), "swap");
-    }
-  } catch (err) {
-    console.error(`[ALLOX:fees:swap] getLogs failed on ${chain}:`, err);
-  }
-
-  // 2) Chat-message purchase revenue (per-chain contract).
-  const messageContract = MESSAGE_CONTRACTS[chain];
-  if (messageContract) {
-    try {
-      const msgLogs = await options.getLogs({
-        noTarget: true,
-        topics: [TRANSFER_TOPIC, null as any, padAddress(messageContract)],
-      });
-      for (const log of msgLogs as any[]) {
-        dailyFees.add(log.address, BigInt(log.data), "messages");
-      }
-    } catch (err) {
-      console.error(`[ALLOX:fees:messages] getLogs failed on ${chain}:`, err);
-    }
-  }
-
-  return { dailyFees, dailyRevenue: dailyFees };
+  dailyFees.add(dailyTradeFees, 'Trading Fees');
+  dailyFees.add(dailyMessageFees, 'Message Fees');
+  
+  return { dailyFees, dailyRevenue: dailyFees, dailyProtocolRevenue: dailyFees };
 };
 
 const adapter: Adapter = {
   version: 2,
-  adapter: Object.fromEntries(
-    Object.keys(START_DATE).map((chain) => [
-      chain,
-      {
-        fetch: fetch(chain),
-        start: START_DATE[chain],
-        pullHourly: true,
-        meta: {
-          methodology: {
-            Fees:
-              "Two streams aggregated:\n" +
-              `1) Swap fees: 0.25% of every swap output collected at ${FEE_RECIPIENT}.\n` +
-              "2) Chat-message revenue: user payments to the AlloX message-purchase contract on each chain.",
-            Revenue: "AlloX retains 100% of fees (no third-party LP cut). Revenue == Fees.",
-          },
-          breakdownMethodology: {
-            Fees: {
-              swap: `0.25% of swap output collected at ${FEE_RECIPIENT}.`,
-              messages: "User payments for chat-message credits sent to the AlloX message-purchase contract on each chain.",
-            },
-            Revenue: {
-              swap: "Same as swap fees (AlloX retains 100%).",
-              messages: "Same as message fees (AlloX retains 100%).",
-            },
-          },
-        },
-      },
-    ])
-  ),
+  pullHourly: true,
+  fetch,
+  adapter: configs,
+  methodology: {
+    Fees: 'Swap fees: 0.25% of every swap output collected + Chat-message fees: user payments to the AlloX message-purchase',
+    Revenue: 'Swap fees: 0.25% of every swap output collected + user payments to the AlloX message-purchase',
+    ProtocolRevenue: 'Swap fees: 0.25% of every swap output collected + user payments to the AlloX message-purchase',
+  },
+  breakdownMethodology: {
+    Fees: {
+      'Trading Fees': 'Swap fees: 0.25% of every swap output collected',
+      'Message Fees': 'Chat-message fees: user payments to the AlloX message-purchase',
+    },
+    Revenue: {
+      'Trading Fees': 'Swap fees: 0.25% of every swap output collected',
+      'Message Fees': 'Chat-message fees: user payments to the AlloX message-purchase',
+    },
+  }
 };
 
 export default adapter;

--- a/fees/allox/index.ts
+++ b/fees/allox/index.ts
@@ -1,0 +1,78 @@
+import { Adapter, FetchOptions } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+
+const FEE_RECIPIENT = "0x6A80f57ac54123cB71e6c79B3935A381b87B4308";
+
+const MESSAGE_CONTRACTS: Record<string, string> = {
+  [CHAIN.ETHEREUM]: "0xd33f10222a9783d30cb3a4dab51fed1a045c81e0",
+  [CHAIN.BSC]:      "0x0b3e65149C84A0aB56B199DeA3C48965a0569225",
+  [CHAIN.BASE]:     "0xf3e05a607c97006b37d2b2789e17c3a832ba56f0",
+};
+
+const TRANSFER_TOPIC =
+  "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef";
+
+const START_DATE: Record<string, string> = {
+  [CHAIN.BSC]:      "2026-03-17",
+  [CHAIN.BASE]:     "2026-04-22",
+  [CHAIN.ETHEREUM]: "2026-05-05",
+};
+
+const padAddress = (addr: string): string =>
+  "0x" + "0".repeat(24) + addr.slice(2).toLowerCase();
+
+const fetch = (chain: string) => async (options: FetchOptions) => {
+    const dailyFees = options.createBalances();
+  
+    const swapFeeTopic =
+      "0x" + "0".repeat(24) + FEE_RECIPIENT.slice(2).toLowerCase();
+  
+    const swapFeeLogs = await options.getLogs({
+      noTarget: true,
+      topics: [TRANSFER_TOPIC, null as any, swapFeeTopic],
+    });
+    for (const log of swapFeeLogs as any[]) {
+      dailyFees.add(log.address, BigInt(log.data));
+    }
+  
+    const messageContract = MESSAGE_CONTRACTS[chain];
+    if (messageContract) {
+      const messageTopic =
+        "0x" + "0".repeat(24) + messageContract.slice(2).toLowerCase();
+      const msgLogs = await options.getLogs({
+        noTarget: true,
+        topics: [TRANSFER_TOPIC, null as any, messageTopic],
+      });
+      for (const log of msgLogs as any[]) {
+        dailyFees.add(log.address, BigInt(log.data));
+      }
+    }
+  
+    return { dailyFees, dailyRevenue: dailyFees };
+  };
+  
+  
+
+const adapter: Adapter = {
+  version: 2,
+  adapter: Object.fromEntries(
+    Object.keys(START_DATE).map((chain) => [
+      chain,
+      {
+        fetch: fetch(chain),
+        start: START_DATE[chain],
+        meta: {
+          methodology: {
+            Fees:
+              "Two streams aggregated:\n" +
+              `1) Swap fees: 0.25% of every swap output collected at ${FEE_RECIPIENT}.\n` +
+              "2) Chat-message revenue: user payments to the AlloX message-purchase contract on each chain.",
+            Revenue: "AlloX retains 100% of fees (no third-party LP cut). Revenue == Fees.",
+          },
+        },
+      },
+    ])
+  ),
+};
+
+export default adapter;

--- a/fees/allox/index.ts
+++ b/fees/allox/index.ts
@@ -22,36 +22,39 @@ const padAddress = (addr: string): string =>
   "0x" + "0".repeat(24) + addr.slice(2).toLowerCase();
 
 const fetch = (chain: string) => async (options: FetchOptions) => {
-    const dailyFees = options.createBalances();
-  
-    const swapFeeTopic =
-      "0x" + "0".repeat(24) + FEE_RECIPIENT.slice(2).toLowerCase();
-  
-    const swapFeeLogs = await options.getLogs({
+  const dailyFees = options.createBalances();
+
+  // 1) Swap fees — 0.25% of every swap output collected at FEE_RECIPIENT.
+  try {
+    const swapLogs = await options.getLogs({
       noTarget: true,
-      topics: [TRANSFER_TOPIC, null as any, swapFeeTopic],
+      topics: [TRANSFER_TOPIC, null as any, padAddress(FEE_RECIPIENT)],
     });
-    for (const log of swapFeeLogs as any[]) {
-      dailyFees.add(log.address, BigInt(log.data));
+    for (const log of swapLogs as any[]) {
+      dailyFees.add(log.address, BigInt(log.data), "swap");
     }
-  
-    const messageContract = MESSAGE_CONTRACTS[chain];
-    if (messageContract) {
-      const messageTopic =
-        "0x" + "0".repeat(24) + messageContract.slice(2).toLowerCase();
+  } catch (err) {
+    console.error(`[ALLOX:fees:swap] getLogs failed on ${chain}:`, err);
+  }
+
+  // 2) Chat-message purchase revenue (per-chain contract).
+  const messageContract = MESSAGE_CONTRACTS[chain];
+  if (messageContract) {
+    try {
       const msgLogs = await options.getLogs({
         noTarget: true,
-        topics: [TRANSFER_TOPIC, null as any, messageTopic],
+        topics: [TRANSFER_TOPIC, null as any, padAddress(messageContract)],
       });
       for (const log of msgLogs as any[]) {
-        dailyFees.add(log.address, BigInt(log.data));
+        dailyFees.add(log.address, BigInt(log.data), "messages");
       }
+    } catch (err) {
+      console.error(`[ALLOX:fees:messages] getLogs failed on ${chain}:`, err);
     }
-  
-    return { dailyFees, dailyRevenue: dailyFees };
-  };
-  
-  
+  }
+
+  return { dailyFees, dailyRevenue: dailyFees };
+};
 
 const adapter: Adapter = {
   version: 2,
@@ -61,6 +64,7 @@ const adapter: Adapter = {
       {
         fetch: fetch(chain),
         start: START_DATE[chain],
+        pullHourly: true,
         meta: {
           methodology: {
             Fees:
@@ -68,6 +72,16 @@ const adapter: Adapter = {
               `1) Swap fees: 0.25% of every swap output collected at ${FEE_RECIPIENT}.\n` +
               "2) Chat-message revenue: user payments to the AlloX message-purchase contract on each chain.",
             Revenue: "AlloX retains 100% of fees (no third-party LP cut). Revenue == Fees.",
+          },
+          breakdownMethodology: {
+            Fees: {
+              swap: `0.25% of swap output collected at ${FEE_RECIPIENT}.`,
+              messages: "User payments for chat-message credits sent to the AlloX message-purchase contract on each chain.",
+            },
+            Revenue: {
+              swap: "Same as swap fees (AlloX retains 100%).",
+              messages: "Same as message fees (AlloX retains 100%).",
+            },
           },
         },
       },


### PR DESCRIPTION
## AlloX - aggregator volume + fees & revenue

AlloX is an AI-driven DeFi portfolio platform that aggregates swap execution
across Uniswap (V2/V3/V4 Universal Router) and PancakeSwap (Universal Router)
on Ethereum, BNB Chain, and Base. Users describe a portfolio in natural
language, AlloX races all available UR routes per token, executes via Permit2
batch permits, and takes a flat 0.25% fee on every swap output.

### Methodology

**Fee recipient (same address all chains):** `0x6A80f57ac54123cB71e6c79B3935A381b87B4308`

**Volume** = total USD value of swaps AlloX routed. Derived from ERC20 Transfer
events landing at the fee recipient - every swap emits a 0.25% PAY_PORTION
(Uniswap V3) / TAKE_PORTION (V4) / SDK fee (PCS) to this address, so
`daily volume = sum of recipient ERC20 inflows × 400`.

**Fees** = the same Transfer inflows directly (no × 400 multiplier), plus
ERC20 inflows to the AlloX message-purchase contracts on each chain
(Ethereum: `0xd33f10222a9783d30cb3a4dab51fed1a045c81e0`,
BNB: `0x0b3e65149C84A0aB56B199DeA3C48965a0569225`,
Base: `0xf3e05a607c97006b37d2b2789e17c3a832ba56f0`).

**Revenue** = Fees (AlloX retains 100% of the take, no third-party LP cut).

### Start dates

- BSC: 2026-03-17 (first PCS UR swap with 0.25% fee)
- Base: 2026-04-22 (Base chain support added)
- Ethereum: 2026-05-05 (Ethereum chain support added)

### Verification

Tested locally with `cli/testAdapter.ts`:

**Volume:**
```
chain     | Daily volume | Start Time
bsc       | 1.22 k       | 17/3/2026
base      | 653.00       | 22/4/2026
ethereum  | 3.98         | 5/5/2026
Aggregate | 1.87 k       |
```

**Fees:**
```
chain     | Daily fees | Daily revenue | Start Time
bsc       | 3.04       | 3.04          | 17/3/2026
base      | 1.63       | 1.63          | 22/4/2026
ethereum  | 0.01       | 0.01          | 5/5/2026
Aggregate | 4.68       | 4.68          |
```

Fees ≈ Volume × 0.0025 across all chains - cross-validates the 0.25% fee math.

### Links

- Website: https://allox.ai
- Twitter: [@alloxdotai](https://x.com/alloxdotai)
- Audit: https://skynet.certik.com/projects/allox
