### PR TITLE
fix(privex): delist COTI chain via deadFrom (closes #5723, supersedes #6907)

### DIFF
--- a/dexs/privex/index.ts
+++ b/dexs/privex/index.ts
@@ -25,6 +25,7 @@ const chainConfig = {
   [CHAIN.COTI]: {
     chainId: 2632500,
     start: '2025-01-01', // January 1, 2025
+    deadFrom: '2026-05-09', // delisted: wash-trading evidence + subgraph unreliable (see #5723, #6907)
     accountSource: '0xbf318724218ced9a3ff7cfc642c71a0ca1952b0f',
     endpoint: 'https://graph-symmio.prvx.io/subgraphs/name/coti-perps-analytics',
   },


### PR DESCRIPTION
Follows @noateden's review on #6907:
> need to verify data, don't remove chain in the adapter, if it was wash-trading, delist it instead

This PR applies that guidance: COTI chain config stays in the adapter, with \`deadFrom: '2026-05-09'\` so historical data is preserved and DefiLlama stops reporting from that date forward.

## Why delist COTI

**1. Wash-trading evidence (documented in #5723)**

Reproduced again on 2026-03-02 (historical, pre-subgraph-outage):

| chain | tradeVolume | platformFee | fee/volume |
|-------|------------:|------------:|-----------:|
| Base  | \$560,490   | \$168.00    | 0.030% (canonical Symmio ~5 bps) |
| COTI  | \$259,084,310 | \$65.00   | **0.000025%** (~1,200x smaller) |

Same pattern on COTI throughout the 30-day window:
- \`activeUsers\` 217-442/day with \`newUsers = 0\` on 27 of 30 days
- 11k-53k quotes/day across ~220 active users (50-100 trades/user/day, robotic)
- \`openTradeVolume ≈ closeTradeVolume\` per user within 0.5% same day (round-trips)
- Top \"user\" \`0x61109a6eb070a860b1da2a38f93ca2b884b54f90\` is the protocol's own Solver (\`AgentSolver\`), counted as a regular trader

**2. Subgraph reliability**

As of today (2026-05-11), \`https://graph-symmio.prvx.io/subgraphs/name/coti-perps-analytics\` returns:
\`\`\`json
{\"response\":{\"errors\":[{\"message\":\"Store error: database unavailable\"}]}}
\`\`\`
Even pre-existing days can no longer be retrieved cleanly.

## Diff

\`\`\`diff
   [CHAIN.COTI]: {
     chainId: 2632500,
     start: '2025-01-01',
+    deadFrom: '2026-05-09',
     accountSource: '0xbf318724218ced9a3ff7cfc642c71a0ca1952b0f',
     endpoint: 'https://graph-symmio.prvx.io/subgraphs/name/coti-perps-analytics',
   },
\`\`\`

1 line added across 1 file. Pattern matches \`dexs/ash-perp/index.ts:32\` per-chain \`deadFrom\` precedent.

## Test (after fix)

\`\`\`
$ pnpm run test dexs privex
Skipping coti because the adapter ended at Sat, 09 May 2026 00:00:00 GMT 
BASE 👇
Daily volume: 0.00  (base side currently quiet)

$ pnpm run test dexs privex 2026-03-02
chain | Daily volume | Daily fees
base  | \$560.49 k   | \$168.00     (canonical Symmio fee rate preserved)
\`\`\`