### PR TITLE
[feat] worm: track worm.wtf fees and volume

### DIFF
--- a/dexs/worm-wtf/index.ts
+++ b/dexs/worm-wtf/index.ts
@@ -53,8 +53,8 @@ const fetch = async (options: FetchOptions) => {
   const dailyNotionalVolume = options.createBalances();
 
   rows.forEach((row: any) => {
-    dailyVolume.addUSDValue(Number(row.volume_usd || 0), row.product);
-    dailyNotionalVolume.addUSDValue(Number(row.notional_volume_usd || 0), row.product);
+    dailyVolume.addUSDValue(Number(row.volume_usd || 0));
+    dailyNotionalVolume.addUSDValue(Number(row.notional_volume_usd || 0));
   });
 
   return { dailyVolume, dailyNotionalVolume };
@@ -72,6 +72,7 @@ const adapter: SimpleAdapter = {
   isExpensiveAdapter: true,
   methodology: {
     Volume: "Volume tracks successful Worm trades on Solana.",
+    NiotionalVolume: "Track total notional (after leverage) volume trades on Worm.",
   },
 };
 

--- a/dexs/worm-wtf/index.ts
+++ b/dexs/worm-wtf/index.ts
@@ -1,0 +1,81 @@
+import { Dependencies, FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import { queryDuneSql } from "../../helpers/dune";
+
+const WORM_PROGRAM = "WrgN8d3Xe7qTzZw59kiXaf3fAagHHWg78Mbhkn2dTPD";
+const CREATOR_PROGRAM = "SormXyTMQ69ux8yhn9CBQ8v7UuqepefMHbM5TcNDtkf";
+
+const fetch = async (options: FetchOptions) => {
+  const rows = await queryDuneSql(options, `
+    WITH calls AS (
+      SELECT
+        CASE
+          WHEN executing_account = '${CREATOR_PROGRAM}' THEN 'Creator Markets'
+          WHEN bytearray_to_uint256(bytearray_reverse(bytearray_substring(data, 9, 8))) = 100 THEN 'Normal Markets'
+          ELSE 'Leverage Markets'
+        END AS product,
+        CASE
+          WHEN executing_account = '${CREATOR_PROGRAM}' THEN 100
+          ELSE bytearray_to_uint256(bytearray_reverse(bytearray_substring(data, 9, 8)))
+        END AS leverage_raw,
+        CASE
+          WHEN executing_account = '${CREATOR_PROGRAM}'
+            THEN bytearray_to_uint256(bytearray_reverse(bytearray_substring(data, 9, 8))) / 1e6
+          ELSE bytearray_to_uint256(bytearray_reverse(bytearray_substring(data, 17, 8))) / 1e6
+        END AS collateral_usd
+      FROM solana.instruction_calls
+      WHERE block_time >= from_unixtime(${options.fromTimestamp})
+        AND block_time < from_unixtime(${options.toTimestamp})
+        AND tx_success = true
+        AND (
+          (
+            executing_account = '${WORM_PROGRAM}'
+            AND bytearray_length(data) = 25
+            AND bytearray_substring(data, 1, 8) = 0x87802f4d0f98f031
+            AND bytearray_to_uint256(bytearray_reverse(bytearray_substring(data, 9, 8))) BETWEEN 100 AND 1000
+          )
+          OR (
+            executing_account = '${CREATOR_PROGRAM}'
+            AND bytearray_length(data) = 16
+            AND bytearray_substring(data, 1, 8) = 0x33c29baf6d82606a
+          )
+        )
+    )
+
+    SELECT
+      product,
+      SUM(collateral_usd * leverage_raw / 100.0) AS volume_usd
+    FROM calls
+    GROUP BY 1
+  `);
+
+  const dailyVolume = options.createBalances();
+  rows.forEach((row: any) => dailyVolume.addUSDValue(Number(row.volume_usd || 0), row.product));
+
+  return { dailyVolume };
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  adapter: {
+    [CHAIN.SOLANA]: {
+      fetch,
+      start: "2026-05-04",
+    },
+  },
+  dependencies: [Dependencies.DUNE],
+  isExpensiveAdapter: true,
+  methodology: {
+    dailyVolume:
+      "Volume tracks successful Worm trades on Solana.",
+  },
+  breakdownMethodology: {
+    Volume: {
+      "Normal Markets": "1x market bets where volume equals the USDC amount placed.",
+      "Leverage Markets": "Leveraged market bets where volume equals the USDC amount placed multiplied by leverage.",
+      "Creator Markets": "Creator market bets where volume equals the USDC amount placed.",
+    },
+  },
+};
+
+export default adapter;

--- a/dexs/worm-wtf/index.ts
+++ b/dexs/worm-wtf/index.ts
@@ -43,15 +43,21 @@ const fetch = async (options: FetchOptions) => {
 
     SELECT
       product,
-      SUM(collateral_usd * leverage_raw / 100.0) AS volume_usd
+      SUM(collateral_usd) AS volume_usd,
+      SUM(collateral_usd * leverage_raw / 100.0) AS notional_volume_usd
     FROM calls
     GROUP BY 1
   `);
 
   const dailyVolume = options.createBalances();
-  rows.forEach((row: any) => dailyVolume.addUSDValue(Number(row.volume_usd || 0), row.product));
+  const dailyNotionalVolume = options.createBalances();
 
-  return { dailyVolume };
+  rows.forEach((row: any) => {
+    dailyVolume.addUSDValue(Number(row.volume_usd || 0), row.product);
+    dailyNotionalVolume.addUSDValue(Number(row.notional_volume_usd || 0), row.product);
+  });
+
+  return { dailyVolume, dailyNotionalVolume };
 };
 
 const adapter: SimpleAdapter = {

--- a/dexs/worm-wtf/index.ts
+++ b/dexs/worm-wtf/index.ts
@@ -65,15 +65,7 @@ const adapter: SimpleAdapter = {
   dependencies: [Dependencies.DUNE],
   isExpensiveAdapter: true,
   methodology: {
-    dailyVolume:
-      "Volume tracks successful Worm trades on Solana.",
-  },
-  breakdownMethodology: {
-    Volume: {
-      "Normal Markets": "1x market bets where volume equals the USDC amount placed.",
-      "Leverage Markets": "Leveraged market bets where volume equals the USDC amount placed multiplied by leverage.",
-      "Creator Markets": "Creator market bets where volume equals the USDC amount placed.",
-    },
+    Volume: "Volume tracks successful Worm trades on Solana.",
   },
 };
 

--- a/dexs/worm-wtf/index.ts
+++ b/dexs/worm-wtf/index.ts
@@ -24,8 +24,7 @@ const fetch = async (options: FetchOptions) => {
           ELSE bytearray_to_uint256(bytearray_reverse(bytearray_substring(data, 17, 8))) / 1e6
         END AS collateral_usd
       FROM solana.instruction_calls
-      WHERE block_time >= from_unixtime(${options.fromTimestamp})
-        AND block_time < from_unixtime(${options.toTimestamp})
+      WHERE TIME_RANGE
         AND tx_success = true
         AND (
           (

--- a/fees/worm-wtf/index.ts
+++ b/fees/worm-wtf/index.ts
@@ -1,0 +1,92 @@
+import { Dependencies, FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import { queryDuneSql } from "../../helpers/dune";
+import { METRIC } from "../../helpers/metrics";
+
+const WORM_PROGRAM = "WrgN8d3Xe7qTzZw59kiXaf3fAagHHWg78Mbhkn2dTPD";
+const CREATOR_PROGRAM = "SormXyTMQ69ux8yhn9CBQ8v7UuqepefMHbM5TcNDtkf";
+
+const fetch = async (options: FetchOptions) => {
+  const rows = await queryDuneSql(options, `
+    WITH calls AS (
+      SELECT
+        CASE
+          WHEN executing_account = '${CREATOR_PROGRAM}' THEN 'creator_market'
+          WHEN bytearray_to_uint256(bytearray_reverse(bytearray_substring(data, 9, 8))) = 100 THEN 'normal_market'
+          ELSE 'leverage_market'
+        END AS product,
+        CASE
+          WHEN executing_account = '${CREATOR_PROGRAM}'
+            THEN bytearray_to_uint256(bytearray_reverse(bytearray_substring(data, 9, 8))) / 1e6
+          ELSE bytearray_to_uint256(bytearray_reverse(bytearray_substring(data, 17, 8))) / 1e6
+        END AS collateral_usd
+      FROM solana.instruction_calls
+      WHERE block_time >= from_unixtime(${options.fromTimestamp})
+        AND block_time < from_unixtime(${options.toTimestamp})
+        AND tx_success = true
+        AND (
+          (
+            executing_account = '${WORM_PROGRAM}'
+            AND bytearray_length(data) = 25
+            AND bytearray_substring(data, 1, 8) = 0x87802f4d0f98f031
+            AND bytearray_to_uint256(bytearray_reverse(bytearray_substring(data, 9, 8))) BETWEEN 100 AND 1000
+          )
+          OR (
+            executing_account = '${CREATOR_PROGRAM}'
+            AND bytearray_length(data) = 16
+            AND bytearray_substring(data, 1, 8) = 0x33c29baf6d82606a
+          )
+        )
+    )
+
+    SELECT
+      product,
+      SUM(collateral_usd) * 0.05 AS fees_usd,
+      SUM(collateral_usd) * IF(product = 'creator_market', 0.025, 0.05) AS revenue_usd,
+      SUM(collateral_usd) * IF(product = 'creator_market', 0.025, 0) AS supply_side_revenue_usd
+    FROM calls
+    GROUP BY 1
+  `);
+
+  const dailyFees = options.createBalances();
+  const dailyRevenue = options.createBalances();
+  const dailySupplySideRevenue = options.createBalances();
+
+  rows.forEach((row: any) => {
+    dailyFees.addUSDValue(Number(row.fees_usd), METRIC.TRADING_FEES);
+    dailyRevenue.addUSDValue(Number(row.revenue_usd), METRIC.TRADING_FEES);
+    dailySupplySideRevenue.addUSDValue(Number(row.supply_side_revenue_usd), METRIC.CREATOR_FEES);
+  });
+
+  return { dailyFees, dailyRevenue, dailySupplySideRevenue };
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  adapter: {
+    [CHAIN.SOLANA]: {
+      fetch,
+      start: "2026-05-04",
+    },
+  },
+  dependencies: [Dependencies.DUNE],
+  isExpensiveAdapter: true,
+  methodology: {
+    Fees: "Fees are 5% of the USDC amount bet on Worm markets.",
+    Revenue: "Worm keeps the full 5% fee on normal and leverage markets, and keeps 2.5% on creator markets.",
+    SupplySideRevenue: "Creator market creators receive the other 2.5% fee share.",
+  },
+  breakdownMethodology: {
+    Fees: {
+      [METRIC.TRADING_FEES]: "5% of the USDC amount bet across normal, leverage, and creator markets.",
+    },
+    Revenue: {
+      [METRIC.TRADING_FEES]: "Protocol share of market fees: 5% on normal and leverage markets, 2.5% on creator markets.",
+    },
+    SupplySideRevenue: {
+      [METRIC.CREATOR_FEES]: "Creator share of creator market fees.",
+    },
+  },
+};
+
+export default adapter;

--- a/fees/worm-wtf/index.ts
+++ b/fees/worm-wtf/index.ts
@@ -1,7 +1,6 @@
 import { Dependencies, FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 import { queryDuneSql } from "../../helpers/dune";
-import { METRIC } from "../../helpers/metrics";
 
 const WORM_PROGRAM = "WrgN8d3Xe7qTzZw59kiXaf3fAagHHWg78Mbhkn2dTPD";
 const CREATOR_PROGRAM = "SormXyTMQ69ux8yhn9CBQ8v7UuqepefMHbM5TcNDtkf";
@@ -21,8 +20,7 @@ const fetch = async (options: FetchOptions) => {
           ELSE bytearray_to_uint256(bytearray_reverse(bytearray_substring(data, 17, 8))) / 1e6
         END AS collateral_usd
       FROM solana.instruction_calls
-      WHERE block_time >= from_unixtime(${options.fromTimestamp})
-        AND block_time < from_unixtime(${options.toTimestamp})
+      WHERE TIME_RANGE
         AND tx_success = true
         AND (
           (
@@ -41,9 +39,13 @@ const fetch = async (options: FetchOptions) => {
 
     SELECT
       product,
-      SUM(collateral_usd) * 0.05 AS fees_usd,
-      SUM(collateral_usd) * IF(product = 'creator_market', 0.025, 0.05) AS revenue_usd,
-      SUM(collateral_usd) * IF(product = 'creator_market', 0.025, 0) AS supply_side_revenue_usd
+      SUM(collateral_usd) * IF(product = 'creator_market', 0, 0.05) AS normal_market_fee_usd,
+      SUM(collateral_usd) * IF(product = 'creator_market', 0.05, 0) AS creator_market_fee_usd,
+      
+      SUM(collateral_usd) * IF(product = 'creator_market', 0, 0.05) AS normal_market_revenue_usd,
+      SUM(collateral_usd) * IF(product = 'creator_market', 0.025, 0) AS creator_market_revenue_usd,
+
+      SUM(collateral_usd) * IF(product = 'creator_market', 0.025, 0) AS creator_market_supply_side_revenue_usd
     FROM calls
     GROUP BY 1
   `);
@@ -53,12 +55,16 @@ const fetch = async (options: FetchOptions) => {
   const dailySupplySideRevenue = options.createBalances();
 
   rows.forEach((row: any) => {
-    dailyFees.addUSDValue(Number(row.fees_usd), METRIC.TRADING_FEES);
-    dailyRevenue.addUSDValue(Number(row.revenue_usd), METRIC.TRADING_FEES);
-    dailySupplySideRevenue.addUSDValue(Number(row.supply_side_revenue_usd), METRIC.CREATOR_FEES);
+    dailyFees.addUSDValue(Number(row.normal_market_fee_usd), 'Normal Markets Fees');
+    dailyFees.addUSDValue(Number(row.creator_market_fee_usd), 'Creator Markets Fees');
+
+    dailyRevenue.addUSDValue(Number(row.normal_market_revenue_usd), 'Normal Markets Fees To Protocol');
+    dailyRevenue.addUSDValue(Number(row.creator_market_revenue_usd), 'Creator Markets Fees To Protocol');
+
+    dailySupplySideRevenue.addUSDValue(Number(row.creator_market_supply_side_revenue_usd), 'Creator Markets Fees To Creators');
   });
 
-  return { dailyFees, dailyRevenue, dailySupplySideRevenue };
+  return { dailyFees, dailyRevenue, dailySupplySideRevenue, dailyProtocolRevenue: dailyRevenue };
 };
 
 const adapter: SimpleAdapter = {
@@ -74,17 +80,20 @@ const adapter: SimpleAdapter = {
   methodology: {
     Fees: "Fees are 5% of the USDC amount bet on Worm markets.",
     Revenue: "Worm keeps the full 5% fee on normal and leverage markets, and keeps 2.5% on creator markets.",
+    ProtocolRevenue: "Worm keeps the full 5% fee on normal and leverage markets, and keeps 2.5% on creator markets.",
     SupplySideRevenue: "Creator market creators receive the other 2.5% fee share.",
   },
   breakdownMethodology: {
     Fees: {
-      [METRIC.TRADING_FEES]: "5% of the USDC amount bet across normal, leverage, and creator markets.",
+      "Normal Markets Fees": "5% of the USDC amount bet across normal, leverage markets.",
+      "Creator Markets Fees": "5% of the USDC amount bet across creator markets.",
     },
     Revenue: {
-      [METRIC.TRADING_FEES]: "Protocol share of market fees: 5% on normal and leverage markets, 2.5% on creator markets.",
+      'Normal Markets Fees To Protocol': "Protocol share of market fees: 5% on normal and leverage markets.",
+      'Creator Markets Fees To Protocol': "Protocol share of market fees: 2.5% on creator markets.",
     },
     SupplySideRevenue: {
-      [METRIC.CREATOR_FEES]: "Creator share of creator market fees.",
+      'Creator Markets Fees To Creators': "Creator share of creator market fees.",
     },
   },
 };


### PR DESCRIPTION
Fixes #6573 

## Note
- Worm team declined to provide program/instruction details, so the program IDs, decoded fields, and fee/revenue calculations were derived from on-chain Worm trades placed for testing and verified against the resulting transaction data.
- Current tracking is based on the observed Worm program IDs and instruction layouts for normal, leverage, and creator markets.

## Summary
- Adds Worm (`worm.wtf`) Solana adapters for volume and fees.
- Tracks normal markets, leverage markets, and creator markets from on-chain Worm instruction data via Dune.
- Reports creator-market fee split with protocol revenue and creator supply-side revenue.

## Links
- Website: https://www.worm.wtf/
- Docs: https://docs.worm.wtf/
- X/Twitter: https://x.com/wormdotwtf

