### PR TITLE
[fix] unicrypt: track new fee wallets for unicrypt

### DIFF
--- a/fees/unicrypt.ts
+++ b/fees/unicrypt.ts
@@ -1,44 +1,166 @@
-import { Adapter, FetchOptions, } from "../adapters/types";
+import { Adapter, Dependencies, FetchOptions } from "../adapters/types";
+import { queryAllium, getAlliumChain } from "../helpers/allium";
 import { CHAIN } from "../helpers/chains";
-import { queryIndexer } from "../helpers/indexer";
 
-const fetch: any = async (timestamp: number, _: any, options: FetchOptions) => {
+const NATIVE_FEES = "Native Locker Fees";
+const TOKEN_FEES = "Token Locker Fees";
+const feeCollectors = [
+  "0xD45dD91DF475bFD944335160f538C1A14888DC1C",
+  "0x12a51944e8349B8e70Ed8e2d9BFbc88Adb4A8F4E",
+  "0x90Cf3e1FB9D1b35Fad621649ca503Ea13cF37163",
+  "0x04bDa42de3bc32Abb00df46004204424d4Cf8287",
+].map(i => i.toLowerCase());
+
+const config: Record<string, { start: string; contracts: string[] }> = {
+  [CHAIN.ETHEREUM]: {
+    start: "2022-10-01",
+    contracts: [
+      "0x663a5c229c09b049e36dcc11a9b0d4a8eb9db214",
+      "0xDba68f07d1b7Ca219f78ae8582C213d975c25cAf",
+      "0x231278edd38b00b07fbd52120cef685b9baebcc1",
+      "0x7f5c649856f900d15c83741f45ae46f5c6858234",
+      "0xFD235968e65B0990584585763f837A5b5330e6DE",
+      "0x30529ac67D5AC5f33a4e7fE533149a567451F023",
+    ],
+  },
+  [CHAIN.BSC]: {
+    start: "2022-10-01",
+    contracts: [
+      "0xc765bddb93b0d1c1a88282ba0fa6b2d00e3e0c83",
+      "0xeaEd594B5926A7D5FBBC61985390BaAf936a6b8d",
+      "0x0d29598ec01fa03665feead91d4fb423f393886c",
+      "0xf1f7f21e2ea80ab110d0f95faa64655688341990",
+      "0xfe88DAB083964C56429baa01F37eC2265AbF1557",
+      "0x62d61D5695013a5AA29a628B83d91e240984b613",
+      "0x4d19c218cD2DE3261E77e3A4ed80FEca8Cb4cba6",
+    ],
+  },
+  [CHAIN.POLYGON]: {
+    start: "2022-10-01",
+    contracts: [
+      "0xadb2437e6f65682b85f814fbc12fec0508a7b1d0",
+      "0x2621816bE08E4279Cf881bc640bE4089BfAf491a",
+      "0xc22218406983bf88bb634bb4bf15fa4e0a1a8c84",
+      "0xd8207e9449647a9668ad3f8ecb97a1f929f81fd1",
+      "0x40f6301edb774e8B22ADC874f6cb17242BaEB8c4",
+    ],
+  },
+  [CHAIN.ARBITRUM]: {
+    start: "2023-03-01",
+    contracts: [
+      "0x275720567e5955f5f2d53a7a1ab8a0fc643de50e",
+      "0x8cb0300Af2A801DC9992225D45399ac56888cBcd",
+      "0xfa104eb3925a27e6263e05acc88f2e983a890637",
+      "0xcb8b00d4018ad6031e28a44bf74616014bfb62ec",
+      "0x6b5360B419e0851b4b81644e0F63c1A9778f2506",
+    ],
+  },
+  [CHAIN.AVAX]: {
+    start: "2022-03-10",
+    contracts: [
+      "0xa9f6aefa5d56db1205f36c34e6482a6d4979b3bb",
+      "0xCa61C60D9Da18fA4e836a1e378Ded3205FcEdfA5",
+      "0x625e1b2e78DC5b978237f9c29DE2910062D80a05",
+    ],
+  },
+  [CHAIN.BASE]: {
+    start: "2024-02-10",
+    contracts: [
+      "0xc4e637d37113192f4f1f060daebd7758de7f4131",
+      "0xA82685520C463A752d5319E6616E4e5fd0215e33",
+      "0x231278edd38b00b07fbd52120cef685b9baebcc1",
+      "0x610b43e981960b45F818A71CD14C91D35cdA8502",
+    ],
+  },
+  [CHAIN.OPTIMISM]: {
+    start: "2024-03-22",
+    contracts: [
+      "0x599886b24B0A625e4912033213d6b6188a1abCA2",
+      "0x1cE6d27F7e5494573684436d99574e8288eBBD2D",
+    ],
+  },
+  [CHAIN.UNICHAIN]: {
+    start: "2025-05-26",
+    contracts: [
+      "0x52D6DbD7939e45094C1A3Df563d9D8fc66943b91",
+    ],
+  },
+};
+
+const addNativeRevenue = async (options: FetchOptions, contracts: string, collectors: string, dailyFees: any) => {
+  const [{ amount }] = await queryAllium(`
+    SELECT COALESCE(SUM(raw_amount), 0) AS amount
+    FROM ${getAlliumChain(options.chain)}.assets.native_token_transfers
+    WHERE to_address IN ${collectors}
+      AND from_address IN ${contracts}
+      AND transfer_type = 'value_transfer'
+      AND block_timestamp >= TO_TIMESTAMP_NTZ(${options.startTimestamp})
+      AND block_timestamp < TO_TIMESTAMP_NTZ(${options.endTimestamp})
+  `);
+
+  dailyFees.addGasToken(amount, NATIVE_FEES);
+};
+
+const addTokenRevenue = async (options: FetchOptions, contracts: string, collectors: string, dailyFees: any) => {
+  const rows = await queryAllium(`
+    SELECT token_address AS token, SUM(raw_amount) AS amount
+    FROM ${getAlliumChain(options.chain)}.assets.erc20_token_transfers
+    WHERE to_address IN ${collectors}
+      AND transaction_to_address IN ${contracts}
+      AND block_timestamp >= TO_TIMESTAMP_NTZ(${options.startTimestamp})
+      AND block_timestamp < TO_TIMESTAMP_NTZ(${options.endTimestamp})
+    GROUP BY token_address
+  `);
+
+  rows.forEach(({ token, amount }: any) => {
+    dailyFees.add(token, amount, TOKEN_FEES);
+  });
+};
+
+const fetch = async (options: FetchOptions) => {
+  const contracts = `( ${config[options.chain].contracts.map(i => `'${i.toLowerCase()}'`).join(", ")} )`;
+  const collectors = `( ${feeCollectors.map(i => `'${i}'`).join(", ")} )`;
   const dailyFees = options.createBalances();
 
-  const transfer_logs = await queryIndexer(`
-        SELECT
-          encode(data, 'hex') AS data,
-          encode(contract_address, 'hex') as contract_address
-        FROM
-          ethereum.event_logs
-        WHERE
-          block_number > 15454990
-          AND contract_address in ('\\xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48', '\\xdac17f958d2ee523a2206206994597c13d831ec7')
-          AND topic_0 = '\\xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef'
-          AND topic_2 = '\\x00000000000000000000000004bda42de3bc32abb00df46004204424d4cf8287'
-          AND block_time BETWEEN llama_replace_date_range;
-          `, options);
-  // 0xcdd1b25d - replay
-  // 0x3593564c - ex
+  await addNativeRevenue(options, contracts, collectors, dailyFees);
+  await addTokenRevenue(options, contracts, collectors, dailyFees);
 
-  transfer_logs.map((a: any) => dailyFees.add('0x' + a.contract_address, Number('0x' + a.data)));
+  return {
+    dailyFees,
+    dailyRevenue: dailyFees,
+    dailyProtocolRevenue: dailyFees,
+  };
+};
 
-  return { timestamp, dailyFees, dailyRevenue: dailyFees, dailyProtocolRevenue: dailyFees, }
-}
+const methodology = {
+  Fees: "Native and Token fees received by fee collector accounts from official locker and vesting contracts.",
+  Revenue: "All tracked fees are retained by UNCX.",
+  ProtocolRevenue: "All tracked fees are retained by UNCX.",
+};
+
+const breakdownMethodology = {
+  Fees: {
+    [NATIVE_FEES]: "Native gas-token fees received by current fee collector accounts.",
+    [TOKEN_FEES]: "ERC20 Token fees received by current fee collector accounts.",
+  },
+  Revenue: {
+    [NATIVE_FEES]: "Native gas-token fees retained by UNCX.",
+    [TOKEN_FEES]: "ERC20 fees retained by UNCX.",
+  },
+  ProtocolRevenue: {
+    [NATIVE_FEES]: "Native gas-token fees retained by UNCX.",
+    [TOKEN_FEES]: "ERC20 fees retained by UNCX.",
+  },
+};
 
 const adapter: Adapter = {
-  adapter: {
-    [CHAIN.ETHEREUM]: {
-      fetch,
-      start: '2022-09-01',
-    }
-  },
-  methodology: {
-    Fees: "Fees paid from users while using all services.",
-    Revenue: "All fees are revenue.",
-    ProtocolRevenue: "All revenue collected by protocol.",
-  },
-
-}
+  version: 2,
+  pullHourly: true,
+  fetch,
+  dependencies: [Dependencies.ALLIUM],
+  adapter: Object.fromEntries(Object.entries(config).map(([chain, { start }]) => [chain, { start }])),
+  methodology,
+  breakdownMethodology,
+};
 
 export default adapter;

--- a/fees/unicrypt.ts
+++ b/fees/unicrypt.ts
@@ -158,7 +158,7 @@ const adapter: Adapter = {
   pullHourly: true,
   fetch,
   dependencies: [Dependencies.ALLIUM],
-  adapter: Object.fromEntries(Object.entries(config).map(([chain, { start }]) => [chain, { start }])),
+  adapter: config,
   methodology,
   breakdownMethodology,
 };


### PR DESCRIPTION
Fixes fees for https://defillama.com/protocol/uncx-network

## Notes
-Please test the adapter with allium and let me know if there are any changes to be made.
- This adapter does not fully value Uniswap V2 LP-token fees today. Proper valuation would require either unwrapping LP fee transfers into token0/token1 reserves and valuing both underlying assets, or tracking LP removal transactions from fee wallets and valuing the withdrawn underlying assets. This limitation only affects the Uniswap V2 locker fee path.

## Summary
- Adds UNCX Network / UniCrypt fee tracking from trusted locker and vesting contract fee flows.
- Counts native and ERC20 fees received by current fee collector accounts across supported chains.
- Reports all tracked fees as fees, revenue, and protocol revenue because the collected fees are retained by UNCX.

## Changes
- Uses Allium queries to track native gas-token transfers from official locker/vesting contracts to trusted fee collectors.
- Uses chain-specific Allium `assets.erc20_token_transfers` tables for ERC20 fee transfers to fee collectors.
- Covers Ethereum, BSC, Polygon, Arbitrum, Avalanche, Base, Optimism, and Unichain.
- Includes V2 lockers, vesting contracts, Uniswap V3/V3.1/latest lockers, and V4 lockers where deployed.

## Methodology
- Native fees are counted when the transfer originates from an official UNCX locker/vesting contract and lands in a trusted fee collector.
- ERC20 fees are counted when the transfer lands in a trusted fee collector inside a transaction sent to an official UNCX locker/vesting contract.
- Fee collectors are hardcoded from current contract fee-account reads, including vesting `FEES().feeAddress` and V3/V4 `AUTO_COLLECT_ACCOUNT`.
- LP-token fee transfers are counted as token balances, but may not receive reliable USD pricing unless the LP token is priced by downstream pricing.
