### PR TITLE
[feat] fidelity-crypto-fund: Track FBTC, FETH, FSOL ETF fees (OFF_CHAIN)

### DIFF
--- a/fees/fidelity-crypto-fund/index.ts
+++ b/fees/fidelity-crypto-fund/index.ts
@@ -1,62 +1,37 @@
 import { FetchOptions, FetchResult, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 import { METRIC } from "../../helpers/metrics";
-import { httpGet, httpPost } from "../../utils/fetchURL";
+import { httpGet } from "../../utils/fetchURL";
 
-const FIDELITY_BASE_URL = "https://digital.fidelity.com/prgw/digital/research";
+const ROBINHOOD_API_URL = "https://bonfire.robinhood.com/instruments";
 const MANAGEMENT_FEE = 0.0025;
 const ONE_YEAR_IN_SECONDS = 365 * 24 * 60 * 60;
-const headers = {
-  "user-agent": "Mozilla/5.0",
-  "accept": "application/json,text/html",
-  "referer": `${FIDELITY_BASE_URL}/quote/dashboard/summary?symbol=FBTC`,
-};
 
 const funds = [
   {
     symbol: "FBTC",
+    id: "efe26023-af80-41de-b83c-6ce41b5ecf65",
     feeStart: 1722470400,
   },
   {
     symbol: "FETH",
+    id: "06374427-17f3-46fa-8b63-b2f0b60f62d8",
     feeStart: 1735689600,
   },
   {
     symbol: "FSOL",
+    id: "d6d17376-e25b-4331-911d-3f93bd765311",
     feeStart: 1779148800,
   },
 ];
 
 type Fund = typeof funds[number];
 
-function parseNumber(value: any, label: string, symbol: string) {
-  const parsed = Number(`${value}`.replace(/[$,%]/g, ""));
-  if (!Number.isFinite(parsed)) throw new Error(`Could not parse ${label} for ${symbol} from Fidelity quote API`);
-  return parsed;
-}
 
-async function getFidelityRequestOptions() {
-  const { data, headers: responseHeaders } = await httpGet(`${FIDELITY_BASE_URL}/api/tokens`, { headers }, { withMetadata: true });
-  const cookie = (responseHeaders["set-cookie"] ?? []).map((cookie: string) => cookie.split(";")[0]).join("; ");
-  return {
-    headers: {
-      ...headers,
-      "content-type": "application/json",
-      "origin": "https://digital.fidelity.com",
-      "X-CSRF-TOKEN": data.csrfToken,
-      cookie,
-    },
-  };
-}
 
-async function getFundAum({ symbol }: Fund, requestOptions: any) {
-  const response = await httpPost(`${FIDELITY_BASE_URL}/api/quote`, { symbol }, requestOptions);
-  const quoteData = response.quoteData;
-  if (!quoteData) throw new Error(`Missing quote data for ${symbol} from Fidelity quote API`);
-
-  const nav = parseNumber(quoteData.etfNavPriceOffer ?? quoteData.navPreviousDay?.value, "NAV", symbol);
-  const sharesOutstanding = parseNumber(quoteData.short?.freeFloatShares, "shares outstanding", symbol);
-  return nav * sharesOutstanding;
+async function getFundFees({ id, activeDuration }: Fund & { activeDuration: number }) {
+  const response = await httpGet(`${ROBINHOOD_API_URL}/${id}/etp-details`);
+  return response.aum * MANAGEMENT_FEE * activeDuration / ONE_YEAR_IN_SECONDS;
 }
 
 async function fetch(_timestamp: number, _chainBlocks: any, options: FetchOptions): Promise<FetchResult> {
@@ -68,12 +43,11 @@ async function fetch(_timestamp: number, _chainBlocks: any, options: FetchOption
     }))
     .filter((fund) => fund.activeDuration);
 
-  const requestOptions = await getFidelityRequestOptions();
-  for (const fund of activeFunds) {
-    const aum = await getFundAum(fund, requestOptions);
-    const managementFee = aum * MANAGEMENT_FEE * fund.activeDuration / ONE_YEAR_IN_SECONDS;
 
-    dailyFees.addUSDValue(managementFee, METRIC.MANAGEMENT_FEES);
+  for (const fund of activeFunds) {
+    
+    const fees = await getFundFees(fund)
+    dailyFees.addUSDValue(fees, METRIC.MANAGEMENT_FEES);
   }
 
   return {
@@ -91,7 +65,7 @@ const methodology = {
 
 const breakdownMethodology = {
   Fees: {
-    [METRIC.MANAGEMENT_FEES]: "0.25% annual management fees on AUM after each fund's waiver period.",
+    [METRIC.MANAGEMENT_FEES]: "Annual management fees on AUM after each fund's waiver period, using Robinhood ETP AUM and gross expense ratio data.",
   },
   Revenue: {
     [METRIC.MANAGEMENT_FEES]: "Management fees retained by Fidelity.",

--- a/fees/fidelity-crypto-fund/index.ts
+++ b/fees/fidelity-crypto-fund/index.ts
@@ -1,0 +1,114 @@
+import { FetchOptions, FetchResult, SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import { METRIC } from "../../helpers/metrics";
+import { httpGet, httpPost } from "../../utils/fetchURL";
+
+const FIDELITY_BASE_URL = "https://digital.fidelity.com/prgw/digital/research";
+const MANAGEMENT_FEE = 0.0025;
+const ONE_YEAR_IN_SECONDS = 365 * 24 * 60 * 60;
+const headers = {
+  "user-agent": "Mozilla/5.0",
+  "accept": "application/json,text/html",
+  "referer": `${FIDELITY_BASE_URL}/quote/dashboard/summary?symbol=FBTC`,
+};
+
+const funds = [
+  {
+    symbol: "FBTC",
+    feeStart: 1722470400,
+  },
+  {
+    symbol: "FETH",
+    feeStart: 1735689600,
+  },
+  {
+    symbol: "FSOL",
+    feeStart: 1779148800,
+  },
+];
+
+type Fund = typeof funds[number];
+
+function parseNumber(value: any, label: string, symbol: string) {
+  const parsed = Number(`${value}`.replace(/[$,%]/g, ""));
+  if (!Number.isFinite(parsed)) throw new Error(`Could not parse ${label} for ${symbol} from Fidelity quote API`);
+  return parsed;
+}
+
+async function getFidelityRequestOptions() {
+  const { data, headers: responseHeaders } = await httpGet(`${FIDELITY_BASE_URL}/api/tokens`, { headers }, { withMetadata: true });
+  const cookie = (responseHeaders["set-cookie"] ?? []).map((cookie: string) => cookie.split(";")[0]).join("; ");
+  return {
+    headers: {
+      ...headers,
+      "content-type": "application/json",
+      "origin": "https://digital.fidelity.com",
+      "X-CSRF-TOKEN": data.csrfToken,
+      cookie,
+    },
+  };
+}
+
+async function getFundAum({ symbol }: Fund, requestOptions: any) {
+  const response = await httpPost(`${FIDELITY_BASE_URL}/api/quote`, { symbol }, requestOptions);
+  const quoteData = response.quoteData;
+  if (!quoteData) throw new Error(`Missing quote data for ${symbol} from Fidelity quote API`);
+
+  const nav = parseNumber(quoteData.etfNavPriceOffer ?? quoteData.navPreviousDay?.value, "NAV", symbol);
+  const sharesOutstanding = parseNumber(quoteData.short?.freeFloatShares, "shares outstanding", symbol);
+  return nav * sharesOutstanding;
+}
+
+async function fetch(_timestamp: number, _chainBlocks: any, options: FetchOptions): Promise<FetchResult> {
+  const dailyFees = options.createBalances();
+  const activeFunds = funds
+    .map((fund) => ({
+      ...fund,
+      activeDuration: Math.max(options.toTimestamp - Math.max(options.fromTimestamp, fund.feeStart), 0),
+    }))
+    .filter((fund) => fund.activeDuration);
+
+  const requestOptions = await getFidelityRequestOptions();
+  for (const fund of activeFunds) {
+    const aum = await getFundAum(fund, requestOptions);
+    const managementFee = aum * MANAGEMENT_FEE * fund.activeDuration / ONE_YEAR_IN_SECONDS;
+
+    dailyFees.addUSDValue(managementFee, METRIC.MANAGEMENT_FEES);
+  }
+
+  return {
+    dailyFees,
+    dailyRevenue: dailyFees,
+    dailyProtocolRevenue: dailyFees,
+  };
+}
+
+const methodology = {
+  Fees: "Management fees charged by Fidelity's spot crypto exchange-traded products.",
+  Revenue: "All management fees are retained by Fidelity.",
+  ProtocolRevenue: "All management fees are retained by Fidelity.",
+};
+
+const breakdownMethodology = {
+  Fees: {
+    [METRIC.MANAGEMENT_FEES]: "0.25% annual management fees on AUM after each fund's waiver period.",
+  },
+  Revenue: {
+    [METRIC.MANAGEMENT_FEES]: "Management fees retained by Fidelity.",
+  },
+  ProtocolRevenue: {
+    [METRIC.MANAGEMENT_FEES]: "Management fees retained by Fidelity.",
+  },
+};
+
+const adapter: SimpleAdapter = {
+  version: 1,
+  fetch,
+  chains: [CHAIN.OFF_CHAIN],
+  methodology,
+  breakdownMethodology,
+  runAtCurrTime: true,
+  start: "2024-07-31",
+};
+
+export default adapter;

--- a/fees/fidelity-crypto-fund/index.ts
+++ b/fees/fidelity-crypto-fund/index.ts
@@ -4,6 +4,10 @@ import { METRIC } from "../../helpers/metrics";
 import { httpGet } from "../../utils/fetchURL";
 
 const ROBINHOOD_API_URL = "https://bonfire.robinhood.com/instruments";
+// https://digital.fidelity.com/prgw/digital/research/quote/dashboard/summary?symbol=FSOL.
+// https://digital.fidelity.com/prgw/digital/research/quote/dashboard/summary?symbol=FBTC
+// https://digital.fidelity.com/prgw/digital/research/quote/dashboard/summary?symbol=FETH
+// https://www.fidelity.com/etfs/crypto-funds
 const MANAGEMENT_FEE = 0.0025;
 const ONE_YEAR_IN_SECONDS = 365 * 24 * 60 * 60;
 
@@ -27,11 +31,12 @@ const funds = [
 
 type Fund = typeof funds[number];
 
-
-
 async function getFundFees({ id, activeDuration }: Fund & { activeDuration: number }) {
   const response = await httpGet(`${ROBINHOOD_API_URL}/${id}/etp-details`);
-  return response.aum * MANAGEMENT_FEE * activeDuration / ONE_YEAR_IN_SECONDS;
+  const expenseRatio = response.gross_expense_ratio === undefined || response.gross_expense_ratio === null
+    ? MANAGEMENT_FEE
+    : Number(response.gross_expense_ratio) / 100;
+  return Number(response.aum) * expenseRatio * activeDuration / ONE_YEAR_IN_SECONDS;
 }
 
 async function fetch(_timestamp: number, _chainBlocks: any, options: FetchOptions): Promise<FetchResult> {


### PR DESCRIPTION
Implements Fidelity-Crypto-Fund : https://github.com/DefiLlama/dimension-adapters/pull/6781#issuecomment-4432919131
@bheluga 

## Summary
- Adds a fees adapter for Fidelity spot crypto exchange-traded products under `fees/fidelity-crypto-fund`.
- Tracks management fees for FBTC, FETH, and FSOL using Fidelity public quote data.
- Reports all management fees as fees, revenue, and protocol revenue because Fidelity retains the management fee.

## Changes
- Added a v1 off-chain fees adapter at `fees/fidelity-crypto-fund/index.ts`.
- Uses Fidelity's public research quote API to fetch NAV and shares outstanding, then estimates AUM as `NAV * sharesOutstanding`.
- Applies the 0.25% annual management fee pro rata over the requested daily window after each fund's fee start date.
- Uses `METRIC.MANAGEMENT_FEES` for fee, revenue, and protocol revenue breakdown labels.
- Sets `runAtCurrTime: true` because the Fidelity quote endpoint provides current snapshot data rather than historical AUM.

## Methodology
- Counts management fees for Fidelity's spot crypto ETPs: FBTC, FETH, and FSOL.
- Calculates fees as current AUM multiplied by the 0.25% annual management fee, prorated by the active duration in the daily window.
- Excludes FSOL staking yield because Fidelity does not expose a clean daily machine-readable staking reward feed in the quote API.
- Treats all ma