### PR TITLE
Update Ready Cards revenue methodology

### DIFF
--- a/fees/ready-cards.ts
+++ b/fees/ready-cards.ts
@@ -1,6 +1,7 @@
 import { Dependencies, FetchOptions, SimpleAdapter } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
 import { queryAllium } from "../helpers/allium";
+import { METRIC } from "../helpers/metrics";
 import { getSolanaReceived } from "../helpers/token";
 
 const READY_CARDS_TREASURY = "bvT9KFrAqmRpnb6AsuaJzdVKEVuT5jAVYt3N5CyGvkV";
@@ -17,6 +18,7 @@ const PACK_SALES = "Pack Sales Net Of Buybacks";
 const PACK_SALES_TO_TREASURY = "Pack Sales To Treasury Net Of Buybacks";
 const MARKETPLACE_FEES = "Marketplace Fees";
 const MARKETPLACE_FEES_TO_TREASURY = "Marketplace Fees To Treasury";
+const READY_BUYBACKS = METRIC.TOKEN_BUY_BACK;
 
 async function getReadyBuybackSpends(options: FetchOptions) {
   const buybackSpends = options.createBalances();
@@ -50,10 +52,12 @@ async function getReadyBuybackSpends(options: FetchOptions) {
 
 async function fetch(options: FetchOptions) {
   const received = options.createBalances();
+  const readyBuybackSpends = options.createBalances();
   const dailyFees = options.createBalances();
   const dailyUserFees = options.createBalances();
   const dailyRevenue = options.createBalances();
   const dailyProtocolRevenue = options.createBalances();
+  const dailyHoldersRevenue = options.createBalances();
 
   try {
     await getSolanaReceived({
@@ -65,6 +69,7 @@ async function fetch(options: FetchOptions) {
     });
 
     const buybackSpends = await getReadyBuybackSpends(options);
+    readyBuybackSpends.addBalances(buybackSpends, READY_BUYBACKS);
     received.subtract(buybackSpends);
   } catch (e) {
     console.error(
@@ -81,12 +86,14 @@ async function fetch(options: FetchOptions) {
   dailyRevenue.addUSDValue(0, MARKETPLACE_FEES_TO_TREASURY);
   dailyProtocolRevenue.addBalances(received, PACK_SALES_TO_TREASURY);
   dailyProtocolRevenue.addUSDValue(0, MARKETPLACE_FEES_TO_TREASURY);
+  dailyHoldersRevenue.addBalances(readyBuybackSpends);
 
   return {
     dailyFees,
     dailyUserFees,
     dailyRevenue,
     dailyProtocolRevenue,
+    dailyHoldersRevenue,
   };
 }
 
@@ -95,6 +102,7 @@ const methodology = {
   UserFees: "User payments for Ready Cards pack sales in SOL, USDC, and USDT, net of READY buyback spends. Ready Cards currently charges 0% marketplace fees.",
   Revenue: "Net revenue from Ready Cards pack sales after subtracting SOL, USDC, and USDT spent on READY buybacks. Marketplace fee revenue is currently 0%.",
   ProtocolRevenue: "Net revenue retained by Ready Cards after subtracting SOL, USDC, and USDT spent on READY buybacks. Marketplace fee revenue is currently 0%.",
+  HoldersRevenue: "SOL, USDC, and USDT spent by Ready Cards' treasury to buy back READY tokens.",
 };
 
 const breakdownMethodology = {
@@ -113,6 +121,9 @@ const breakdownMethodology = {
   ProtocolRevenue: {
     [PACK_SALES_TO_TREASURY]: "Pack-sale revenue retained by Ready Cards' operational treasury wallet, net of READY buyback spends.",
     [MARKETPLACE_FEES_TO_TREASURY]: "Ready Cards currently charges 0% marketplace fees, so marketplace fee revenue is 0.",
+  },
+  HoldersRevenue: {
+    [READY_BUYBACKS]: "SOL, USDC, and USDT spent from Ready Cards' treasury in transactions where that wallet receives READY as a buyback.",
   },
 };
 

--- a/fees/ready-cards.ts
+++ b/fees/ready-cards.ts
@@ -14,37 +14,37 @@ const PAYMENT_MINTS = [
   "Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB", // USDT
 ];
 
-const PACK_SALES = "Pack Sales Net Of Buybacks";
-const PACK_SALES_TO_TREASURY = "Pack Sales To Treasury Net Of Buybacks";
-const MARKETPLACE_FEES = "Marketplace Fees";
-const MARKETPLACE_FEES_TO_TREASURY = "Marketplace Fees To Treasury";
+const PACK_SALES = "Pack Sales And Marketplace Fees";
+const CARD_SELLBACKS = "Card Sellbacks";
 const READY_BUYBACKS = METRIC.TOKEN_BUY_BACK;
 
 const paymentMints = PAYMENT_MINTS.map((mint) => `'${mint}'`).join(", ");
 
-async function getReadyBuybackSpends(options: FetchOptions) {
+const tokenBuybackTxs = (options: FetchOptions) => `
+  SELECT DISTINCT ready_in.txn_id
+  FROM solana.assets.transfers ready_in
+  JOIN solana.assets.transfers payment_out
+    ON ready_in.txn_id = payment_out.txn_id
+  WHERE ready_in.to_address = '${READY_CARDS_TREASURY}'
+    AND ready_in.mint = '${READY_MINT}'
+    AND ready_in.from_address != '${READY_CARDS_TREASURY}'
+    AND payment_out.from_address = '${READY_CARDS_TREASURY}'
+    AND payment_out.mint IN (${paymentMints})
+    AND ready_in.block_timestamp BETWEEN TO_TIMESTAMP_NTZ(${options.startTimestamp}) AND TO_TIMESTAMP_NTZ(${options.endTimestamp})
+    AND payment_out.block_timestamp BETWEEN TO_TIMESTAMP_NTZ(${options.startTimestamp}) AND TO_TIMESTAMP_NTZ(${options.endTimestamp})
+`;
+
+async function getReadyTokenBuybackSpends(options: FetchOptions) {
   const buybackSpends = options.createBalances();
 
   const results = await queryAllium(`
-    WITH buyback_txs AS (
-      SELECT DISTINCT ready_in.txn_id
-      FROM solana.assets.transfers ready_in
-      JOIN solana.assets.transfers payment_out
-        ON ready_in.txn_id = payment_out.txn_id
-      WHERE ready_in.to_address = '${READY_CARDS_TREASURY}'
-        AND ready_in.mint = '${READY_MINT}'
-        AND ready_in.from_address != '${READY_CARDS_TREASURY}'
-        AND payment_out.from_address = '${READY_CARDS_TREASURY}'
-        AND payment_out.mint IN (${paymentMints})
-        AND ready_in.block_timestamp BETWEEN TO_TIMESTAMP_NTZ(${options.startTimestamp}) AND TO_TIMESTAMP_NTZ(${options.endTimestamp})
-        AND payment_out.block_timestamp BETWEEN TO_TIMESTAMP_NTZ(${options.startTimestamp}) AND TO_TIMESTAMP_NTZ(${options.endTimestamp})
-    )
+    WITH token_buyback_txs AS (${tokenBuybackTxs(options)})
 
     SELECT mint AS token, SUM(raw_amount) AS amount
     FROM solana.assets.transfers
     WHERE from_address = '${READY_CARDS_TREASURY}'
       AND mint IN (${paymentMints})
-      AND txn_id IN (SELECT txn_id FROM buyback_txs)
+      AND txn_id IN (SELECT txn_id FROM token_buyback_txs)
       AND block_timestamp BETWEEN TO_TIMESTAMP_NTZ(${options.startTimestamp}) AND TO_TIMESTAMP_NTZ(${options.endTimestamp})
     GROUP BY mint
   `);
@@ -56,30 +56,41 @@ async function getReadyBuybackSpends(options: FetchOptions) {
   return buybackSpends;
 }
 
+async function getCardSellbackSpends(options: FetchOptions) {
+  const sellbackSpends = options.createBalances();
+
+  const results = await queryAllium(`
+    WITH token_buyback_txs AS (${tokenBuybackTxs(options)})
+
+    SELECT mint AS token, SUM(raw_amount) AS amount
+    FROM solana.assets.transfers
+    WHERE from_address = '${READY_CARDS_TREASURY}'
+      AND signer = '${READY_CARDS_TREASURY}'
+      AND mint IN (${paymentMints})
+      AND txn_id NOT IN (SELECT txn_id FROM token_buyback_txs)
+      AND block_timestamp BETWEEN TO_TIMESTAMP_NTZ(${options.startTimestamp}) AND TO_TIMESTAMP_NTZ(${options.endTimestamp})
+    GROUP BY mint
+  `);
+
+  results.forEach((row: { token: string; amount: string }) => {
+    sellbackSpends.add(row.token, row.amount);
+  });
+
+  return sellbackSpends;
+}
+
 async function getReadyFees(options: FetchOptions) {
   const readyFees = options.createBalances();
 
   const results = await queryAllium(`
-    WITH buyback_txs AS (
-      SELECT DISTINCT ready_in.txn_id
-      FROM solana.assets.transfers ready_in
-      JOIN solana.assets.transfers payment_out
-        ON ready_in.txn_id = payment_out.txn_id
-      WHERE ready_in.to_address = '${READY_CARDS_TREASURY}'
-        AND ready_in.mint = '${READY_MINT}'
-        AND ready_in.from_address != '${READY_CARDS_TREASURY}'
-        AND payment_out.from_address = '${READY_CARDS_TREASURY}'
-        AND payment_out.mint IN (${paymentMints})
-        AND ready_in.block_timestamp BETWEEN TO_TIMESTAMP_NTZ(${options.startTimestamp}) AND TO_TIMESTAMP_NTZ(${options.endTimestamp})
-        AND payment_out.block_timestamp BETWEEN TO_TIMESTAMP_NTZ(${options.startTimestamp}) AND TO_TIMESTAMP_NTZ(${options.endTimestamp})
-    )
+    WITH token_buyback_txs AS (${tokenBuybackTxs(options)})
 
     SELECT SUM(raw_amount) AS amount
     FROM solana.assets.transfers
     WHERE to_address = '${READY_CARDS_TREASURY}'
       AND mint = '${READY_MINT}'
       AND from_address != '${READY_CARDS_TREASURY}'
-      AND txn_id NOT IN (SELECT txn_id FROM buyback_txs)
+      AND txn_id NOT IN (SELECT txn_id FROM token_buyback_txs)
       AND block_timestamp BETWEEN TO_TIMESTAMP_NTZ(${options.startTimestamp}) AND TO_TIMESTAMP_NTZ(${options.endTimestamp})
   `);
 
@@ -89,82 +100,83 @@ async function getReadyFees(options: FetchOptions) {
 }
 
 async function fetch(options: FetchOptions) {
-  const received = options.createBalances();
-  const readyBuybackSpends = options.createBalances();
+  const grossFees = options.createBalances();
   const dailyFees = options.createBalances();
   const dailyUserFees = options.createBalances();
   const dailyRevenue = options.createBalances();
   const dailyProtocolRevenue = options.createBalances();
+  const dailySupplySideRevenue = options.createBalances();
   const dailyHoldersRevenue = options.createBalances();
 
   try {
     await getSolanaReceived({
       options,
-      balances: received,
+      balances: grossFees,
       target: READY_CARDS_TREASURY,
       mints: PAYMENT_MINTS,
       blacklists: [READY_CARDS_TREASURY],
     });
 
     const readyFees = await getReadyFees(options);
-    const buybackSpends = await getReadyBuybackSpends(options);
+    const cardSellbackSpends = await getCardSellbackSpends(options);
+    const readyTokenBuybackSpends = await getReadyTokenBuybackSpends(options);
 
-    received.addBalances(readyFees);
-    readyBuybackSpends.addBalances(buybackSpends, READY_BUYBACKS);
-    received.subtract(buybackSpends);
+    grossFees.addBalances(readyFees);
+    dailySupplySideRevenue.addBalances(cardSellbackSpends, CARD_SELLBACKS);
+    dailyHoldersRevenue.addBalances(readyTokenBuybackSpends, READY_BUYBACKS);
   } catch (e) {
     console.error(
-      `[ready-cards] failed to fetch Solana net receipts for treasury ${READY_CARDS_TREASURY}`,
+      `[ready-cards] failed to fetch Solana fee data for treasury ${READY_CARDS_TREASURY}`,
       e,
     );
   }
 
-  dailyFees.addBalances(received, PACK_SALES);
-  dailyFees.addUSDValue(0, MARKETPLACE_FEES);
-  dailyUserFees.addBalances(received, PACK_SALES);
-  dailyUserFees.addUSDValue(0, MARKETPLACE_FEES);
-  dailyRevenue.addBalances(received, PACK_SALES_TO_TREASURY);
-  dailyRevenue.addUSDValue(0, MARKETPLACE_FEES_TO_TREASURY);
-  dailyProtocolRevenue.addBalances(received, PACK_SALES_TO_TREASURY);
-  dailyProtocolRevenue.addUSDValue(0, MARKETPLACE_FEES_TO_TREASURY);
-  dailyHoldersRevenue.addBalances(readyBuybackSpends);
+  dailyFees.addBalances(grossFees, PACK_SALES);
+  dailyUserFees.addBalances(grossFees, PACK_SALES);
+
+  dailyRevenue.addBalances(grossFees, PACK_SALES);
+  dailyRevenue.subtract(dailySupplySideRevenue);
+
+  dailyProtocolRevenue.addBalances(dailyRevenue);
+  dailyProtocolRevenue.subtract(dailyHoldersRevenue);
 
   return {
     dailyFees,
     dailyUserFees,
     dailyRevenue,
     dailyProtocolRevenue,
+    dailySupplySideRevenue,
     dailyHoldersRevenue,
   };
 }
 
 const methodology = {
-  Fees: "Net fees from Ready Cards pack sales and marketplace trades after subtracting SOL, USDC, and USDT spent on READY buybacks. Marketplace fees are currently 0%.",
-  UserFees: "User payments for Ready Cards pack sales and marketplace trades in SOL, USDC, USDT, and READY, net of READY buyback spends. Ready Cards currently charges 0% marketplace fees.",
-  Revenue: "Net revenue from Ready Cards pack sales and marketplace trades after subtracting SOL, USDC, and USDT spent on READY buybacks. Marketplace fee revenue is currently 0%.",
-  ProtocolRevenue: "Net revenue retained by Ready Cards after subtracting SOL, USDC, and USDT spent on READY buybacks. Marketplace fee revenue is currently 0%.",
+  Fees: "Gross user payments received by Ready Cards' treasury for pack sales and marketplace fees in SOL, USDC, USDT, and READY.",
+  UserFees: "Gross user payments for Ready Cards pack sales and marketplace trades in SOL, USDC, USDT, and READY.",
+  Revenue: "Ready Cards revenue after subtracting card sellback payouts made from the treasury to users.",
+  ProtocolRevenue: "Revenue retained by Ready Cards after card sellback payouts and READY token buybacks.",
+  SupplySideRevenue: "Card sellback payouts from Ready Cards' treasury to users, such as when users sell opened cards back to Ready Cards.",
   HoldersRevenue: "SOL, USDC, and USDT spent by Ready Cards' treasury to buy back READY tokens.",
 };
 
 const breakdownMethodology = {
   Fees: {
-    [PACK_SALES]: "Payments received by Ready Cards' operational hot wallet for pack purchases and marketplace trades, minus SOL, USDC, and USDT spent from that wallet in transactions where the wallet receives READY as buybacks.",
-    [MARKETPLACE_FEES]: "Ready Cards currently charges 0% marketplace fees.",
+    [PACK_SALES]: "Gross payments received by Ready Cards' operational treasury wallet for pack purchases and marketplace fees. READY receipts are included only when they are not part of READY token buyback transactions.",
   },
   UserFees: {
-    [PACK_SALES]: "Payments made by users for Ready Cards pack purchases and marketplace trades, net of READY buyback spends.",
-    [MARKETPLACE_FEES]: "Ready Cards currently charges 0% marketplace fees.",
+    [PACK_SALES]: "Gross payments made by users for Ready Cards pack purchases and marketplace trades.",
   },
   Revenue: {
-    [PACK_SALES_TO_TREASURY]: "Pack-sale and marketplace-trade revenue retained by Ready Cards' operational treasury wallet, net of READY buyback spends.",
-    [MARKETPLACE_FEES_TO_TREASURY]: "Ready Cards currently charges 0% marketplace fees, so marketplace fee revenue is 0.",
+    [PACK_SALES]: "Gross pack-sale and marketplace-fee revenue minus card sellback payouts to users.",
   },
   ProtocolRevenue: {
-    [PACK_SALES_TO_TREASURY]: "Pack-sale and marketplace-trade revenue retained by Ready Cards' operational treasury wallet, net of READY buyback spends.",
-    [MARKETPLACE_FEES_TO_TREASURY]: "Ready Cards currently charges 0% marketplace fees, so marketplace fee revenue is 0.",
+    [PACK_SALES]: "Revenue retained by Ready Cards after card sellback payouts and READY token buybacks.",
+  },
+  SupplySideRevenue: {
+    [CARD_SELLBACKS]: "Payments from Ready Cards' treasury to users for card sellbacks. Example transaction: 6CEvuPmZjcjP5L6d5CJqVsXzKfRqz8Q9mpERfdpcEUCZgCokf6y3eZQyBaRB77MKgDAXErHciEL5xUdQwUFPYGG.",
   },
   HoldersRevenue: {
-    [READY_BUYBACKS]: "SOL, USDC, and USDT spent from Ready Cards' treasury in transactions where that wallet receives READY as a buyback.",
+    [READY_BUYBACKS]: "SOL, USDC, and USDT spent from Ready Cards' treasury in transactions where that wallet receives READY as a token buyback.",
   },
 };
 

--- a/fees/ready-cards.ts
+++ b/fees/ready-cards.ts
@@ -20,18 +20,24 @@ const MARKETPLACE_FEES = "Marketplace Fees";
 const MARKETPLACE_FEES_TO_TREASURY = "Marketplace Fees To Treasury";
 const READY_BUYBACKS = METRIC.TOKEN_BUY_BACK;
 
+const paymentMints = PAYMENT_MINTS.map((mint) => `'${mint}'`).join(", ");
+
 async function getReadyBuybackSpends(options: FetchOptions) {
   const buybackSpends = options.createBalances();
-  const paymentMints = PAYMENT_MINTS.map((mint) => `'${mint}'`).join(", ");
 
   const results = await queryAllium(`
     WITH buyback_txs AS (
-      SELECT DISTINCT txn_id
-      FROM solana.assets.transfers
-      WHERE to_address = '${READY_CARDS_TREASURY}'
-        AND mint = '${READY_MINT}'
-        AND from_address != '${READY_CARDS_TREASURY}'
-        AND block_timestamp BETWEEN TO_TIMESTAMP_NTZ(${options.startTimestamp}) AND TO_TIMESTAMP_NTZ(${options.endTimestamp})
+      SELECT DISTINCT ready_in.txn_id
+      FROM solana.assets.transfers ready_in
+      JOIN solana.assets.transfers payment_out
+        ON ready_in.txn_id = payment_out.txn_id
+      WHERE ready_in.to_address = '${READY_CARDS_TREASURY}'
+        AND ready_in.mint = '${READY_MINT}'
+        AND ready_in.from_address != '${READY_CARDS_TREASURY}'
+        AND payment_out.from_address = '${READY_CARDS_TREASURY}'
+        AND payment_out.mint IN (${paymentMints})
+        AND ready_in.block_timestamp BETWEEN TO_TIMESTAMP_NTZ(${options.startTimestamp}) AND TO_TIMESTAMP_NTZ(${options.endTimestamp})
+        AND payment_out.block_timestamp BETWEEN TO_TIMESTAMP_NTZ(${options.startTimestamp}) AND TO_TIMESTAMP_NTZ(${options.endTimestamp})
     )
 
     SELECT mint AS token, SUM(raw_amount) AS amount
@@ -48,6 +54,38 @@ async function getReadyBuybackSpends(options: FetchOptions) {
   });
 
   return buybackSpends;
+}
+
+async function getReadyFees(options: FetchOptions) {
+  const readyFees = options.createBalances();
+
+  const results = await queryAllium(`
+    WITH buyback_txs AS (
+      SELECT DISTINCT ready_in.txn_id
+      FROM solana.assets.transfers ready_in
+      JOIN solana.assets.transfers payment_out
+        ON ready_in.txn_id = payment_out.txn_id
+      WHERE ready_in.to_address = '${READY_CARDS_TREASURY}'
+        AND ready_in.mint = '${READY_MINT}'
+        AND ready_in.from_address != '${READY_CARDS_TREASURY}'
+        AND payment_out.from_address = '${READY_CARDS_TREASURY}'
+        AND payment_out.mint IN (${paymentMints})
+        AND ready_in.block_timestamp BETWEEN TO_TIMESTAMP_NTZ(${options.startTimestamp}) AND TO_TIMESTAMP_NTZ(${options.endTimestamp})
+        AND payment_out.block_timestamp BETWEEN TO_TIMESTAMP_NTZ(${options.startTimestamp}) AND TO_TIMESTAMP_NTZ(${options.endTimestamp})
+    )
+
+    SELECT SUM(raw_amount) AS amount
+    FROM solana.assets.transfers
+    WHERE to_address = '${READY_CARDS_TREASURY}'
+      AND mint = '${READY_MINT}'
+      AND from_address != '${READY_CARDS_TREASURY}'
+      AND txn_id NOT IN (SELECT txn_id FROM buyback_txs)
+      AND block_timestamp BETWEEN TO_TIMESTAMP_NTZ(${options.startTimestamp}) AND TO_TIMESTAMP_NTZ(${options.endTimestamp})
+  `);
+
+  readyFees.add(READY_MINT, results[0]?.amount ?? 0);
+
+  return readyFees;
 }
 
 async function fetch(options: FetchOptions) {
@@ -68,7 +106,10 @@ async function fetch(options: FetchOptions) {
       blacklists: [READY_CARDS_TREASURY],
     });
 
+    const readyFees = await getReadyFees(options);
     const buybackSpends = await getReadyBuybackSpends(options);
+
+    received.addBalances(readyFees);
     readyBuybackSpends.addBalances(buybackSpends, READY_BUYBACKS);
     received.subtract(buybackSpends);
   } catch (e) {
@@ -98,28 +139,28 @@ async function fetch(options: FetchOptions) {
 }
 
 const methodology = {
-  Fees: "Net fees from Ready Cards pack sales after subtracting SOL, USDC, and USDT spent on READY buybacks. Marketplace fees are currently 0%.",
-  UserFees: "User payments for Ready Cards pack sales in SOL, USDC, and USDT, net of READY buyback spends. Ready Cards currently charges 0% marketplace fees.",
-  Revenue: "Net revenue from Ready Cards pack sales after subtracting SOL, USDC, and USDT spent on READY buybacks. Marketplace fee revenue is currently 0%.",
+  Fees: "Net fees from Ready Cards pack sales and marketplace trades after subtracting SOL, USDC, and USDT spent on READY buybacks. Marketplace fees are currently 0%.",
+  UserFees: "User payments for Ready Cards pack sales and marketplace trades in SOL, USDC, USDT, and READY, net of READY buyback spends. Ready Cards currently charges 0% marketplace fees.",
+  Revenue: "Net revenue from Ready Cards pack sales and marketplace trades after subtracting SOL, USDC, and USDT spent on READY buybacks. Marketplace fee revenue is currently 0%.",
   ProtocolRevenue: "Net revenue retained by Ready Cards after subtracting SOL, USDC, and USDT spent on READY buybacks. Marketplace fee revenue is currently 0%.",
   HoldersRevenue: "SOL, USDC, and USDT spent by Ready Cards' treasury to buy back READY tokens.",
 };
 
 const breakdownMethodology = {
   Fees: {
-    [PACK_SALES]: "Payments received by Ready Cards' operational hot wallet for pack purchases, minus SOL, USDC, and USDT spent from that wallet in transactions where the wallet receives READY as buybacks.",
+    [PACK_SALES]: "Payments received by Ready Cards' operational hot wallet for pack purchases and marketplace trades, minus SOL, USDC, and USDT spent from that wallet in transactions where the wallet receives READY as buybacks.",
     [MARKETPLACE_FEES]: "Ready Cards currently charges 0% marketplace fees.",
   },
   UserFees: {
-    [PACK_SALES]: "Payments made by users for Ready Cards pack purchases, net of READY buyback spends.",
+    [PACK_SALES]: "Payments made by users for Ready Cards pack purchases and marketplace trades, net of READY buyback spends.",
     [MARKETPLACE_FEES]: "Ready Cards currently charges 0% marketplace fees.",
   },
   Revenue: {
-    [PACK_SALES_TO_TREASURY]: "Pack-sale revenue retained by Ready Cards' operational treasury wallet, net of READY buyback spends.",
+    [PACK_SALES_TO_TREASURY]: "Pack-sale and marketplace-trade revenue retained by Ready Cards' operational treasury wallet, net of READY buyback spends.",
     [MARKETPLACE_FEES_TO_TREASURY]: "Ready Cards currently charges 0% marketplace fees, so marketplace fee revenue is 0.",
   },
   ProtocolRevenue: {
-    [PACK_SALES_TO_TREASURY]: "Pack-sale revenue retained by Ready Cards' operational treasury wallet, net of READY buyback spends.",
+    [PACK_SALES_TO_TREASURY]: "Pack-sale and marketplace-trade revenue retained by Ready Cards' operational treasury wallet, net of READY buyback spends.",
     [MARKETPLACE_FEES_TO_TREASURY]: "Ready Cards currently charges 0% marketplace fees, so marketplace fee revenue is 0.",
   },
   HoldersRevenue: {

--- a/fees/ready-cards.ts
+++ b/fees/ready-cards.ts
@@ -1,0 +1,90 @@
+import { Dependencies, FetchOptions, SimpleAdapter } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+import { getSolanaReceived } from "../helpers/token";
+
+const READY_CARDS_TREASURY = "bvT9KFrAqmRpnb6AsuaJzdVKEVuT5jAVYt3N5CyGvkV";
+
+const PAYMENT_MINTS = [
+  "So11111111111111111111111111111111111111112", // SOL / wSOL
+  "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v", // USDC
+  "Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB", // USDT
+  "HKJHsYJHMVK5VRyHHk5GhvzY9tBAAtPvDkZfDH6RLDTd", // READY
+];
+
+const PACK_SALES = "Pack Sales";
+const PACK_SALES_TO_TREASURY = "Pack Sales To Treasury";
+const MARKETPLACE_FEES = "Marketplace Fees";
+const MARKETPLACE_FEES_TO_TREASURY = "Marketplace Fees To Treasury";
+
+async function fetch(options: FetchOptions) {
+  const received = options.createBalances();
+
+  await getSolanaReceived({
+    options,
+    balances: received,
+    target: READY_CARDS_TREASURY,
+    mints: PAYMENT_MINTS,
+    blacklists: [READY_CARDS_TREASURY],
+  });
+
+  const dailyFees = options.createBalances();
+  const dailyUserFees = options.createBalances();
+  const dailyRevenue = options.createBalances();
+  const dailyProtocolRevenue = options.createBalances();
+
+  dailyFees.addBalances(received, PACK_SALES);
+  dailyFees.addUSDValue(0, MARKETPLACE_FEES);
+  dailyUserFees.addBalances(received, PACK_SALES);
+  dailyUserFees.addUSDValue(0, MARKETPLACE_FEES);
+  dailyRevenue.addBalances(received, PACK_SALES_TO_TREASURY);
+  dailyRevenue.addUSDValue(0, MARKETPLACE_FEES_TO_TREASURY);
+  dailyProtocolRevenue.addBalances(received, PACK_SALES_TO_TREASURY);
+  dailyProtocolRevenue.addUSDValue(0, MARKETPLACE_FEES_TO_TREASURY);
+
+  return {
+    dailyFees,
+    dailyUserFees,
+    dailyRevenue,
+    dailyProtocolRevenue,
+  };
+}
+
+const methodology = {
+  Fees: "Total fees from Ready Cards pack sales and marketplace transactions. Marketplace fees are currently 0%.",
+  UserFees: "User payments for Ready Cards pack sales in SOL, USDC, USDT, and READY. Ready Cards currently charges 0% marketplace fees.",
+  Revenue: "Revenue from Ready Cards pack sales. Marketplace fee revenue is currently 0%.",
+  ProtocolRevenue: "Revenue retained by Ready Cards from pack sales. Marketplace fee revenue is currently 0%.",
+};
+
+const breakdownMethodology = {
+  Fees: {
+    [PACK_SALES]: "Payments received by Ready Cards' operational hot wallet for pack purchases.",
+    [MARKETPLACE_FEES]: "Ready Cards currently charges 0% marketplace fees.",
+  },
+  UserFees: {
+    [PACK_SALES]: "Payments made by users for Ready Cards pack purchases.",
+    [MARKETPLACE_FEES]: "Ready Cards currently charges 0% marketplace fees.",
+  },
+  Revenue: {
+    [PACK_SALES_TO_TREASURY]: "Pack-sale revenue retained by Ready Cards' operational treasury wallet.",
+    [MARKETPLACE_FEES_TO_TREASURY]: "Ready Cards currently charges 0% marketplace fees, so marketplace fee revenue is 0.",
+  },
+  ProtocolRevenue: {
+    [PACK_SALES_TO_TREASURY]: "Pack-sale revenue retained by Ready Cards' operational treasury wallet.",
+    [MARKETPLACE_FEES_TO_TREASURY]: "Ready Cards currently charges 0% marketplace fees, so marketplace fee revenue is 0.",
+  },
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  pullHourly: true,
+  fetch,
+  chains: [CHAIN.SOLANA],
+  start: "2026-04-01",
+  dependencies: [Dependencies.ALLIUM],
+  isExpensiveAdapter: true,
+  methodology,
+  breakdownMethodology,
+};
+
+export default adapter;

--- a/fees/ready-cards.ts
+++ b/fees/ready-cards.ts
@@ -1,20 +1,52 @@
 import { Dependencies, FetchOptions, SimpleAdapter } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
+import { queryAllium } from "../helpers/allium";
 import { getSolanaReceived } from "../helpers/token";
 
 const READY_CARDS_TREASURY = "bvT9KFrAqmRpnb6AsuaJzdVKEVuT5jAVYt3N5CyGvkV";
+
+const READY_MINT = "HKJHsYJHMVK5VRyHHk5GhvzY9tBAAtPvDkZfDH6RLDTd";
 
 const PAYMENT_MINTS = [
   "So11111111111111111111111111111111111111112", // SOL / wSOL
   "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v", // USDC
   "Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB", // USDT
-  "HKJHsYJHMVK5VRyHHk5GhvzY9tBAAtPvDkZfDH6RLDTd", // READY
 ];
 
-const PACK_SALES = "Pack Sales";
-const PACK_SALES_TO_TREASURY = "Pack Sales To Treasury";
+const PACK_SALES = "Pack Sales Net Of Buybacks";
+const PACK_SALES_TO_TREASURY = "Pack Sales To Treasury Net Of Buybacks";
 const MARKETPLACE_FEES = "Marketplace Fees";
 const MARKETPLACE_FEES_TO_TREASURY = "Marketplace Fees To Treasury";
+
+async function getReadyBuybackSpends(options: FetchOptions) {
+  const buybackSpends = options.createBalances();
+  const paymentMints = PAYMENT_MINTS.map((mint) => `'${mint}'`).join(", ");
+
+  const results = await queryAllium(`
+    WITH buyback_txs AS (
+      SELECT DISTINCT txn_id
+      FROM solana.assets.transfers
+      WHERE to_address = '${READY_CARDS_TREASURY}'
+        AND mint = '${READY_MINT}'
+        AND from_address != '${READY_CARDS_TREASURY}'
+        AND block_timestamp BETWEEN TO_TIMESTAMP_NTZ(${options.startTimestamp}) AND TO_TIMESTAMP_NTZ(${options.endTimestamp})
+    )
+
+    SELECT mint AS token, SUM(raw_amount) AS amount
+    FROM solana.assets.transfers
+    WHERE from_address = '${READY_CARDS_TREASURY}'
+      AND mint IN (${paymentMints})
+      AND txn_id IN (SELECT txn_id FROM buyback_txs)
+      AND block_timestamp BETWEEN TO_TIMESTAMP_NTZ(${options.startTimestamp}) AND TO_TIMESTAMP_NTZ(${options.endTimestamp})
+    GROUP BY mint
+  `);
+
+  results.forEach((row: { token: string; amount: string }) => {
+    buybackSpends.add(row.token, row.amount);
+  });
+
+  return buybackSpends;
+}
 
 async function fetch(options: FetchOptions) {
   const received = options.createBalances();
@@ -31,9 +63,12 @@ async function fetch(options: FetchOptions) {
       mints: PAYMENT_MINTS,
       blacklists: [READY_CARDS_TREASURY],
     });
+
+    const buybackSpends = await getReadyBuybackSpends(options);
+    received.subtract(buybackSpends);
   } catch (e) {
     console.error(
-      `[ready-cards] failed to fetch Solana receipts for treasury ${READY_CARDS_TREASURY} and mints ${PAYMENT_MINTS.join(", ")}`,
+      `[ready-cards] failed to fetch Solana net receipts for treasury ${READY_CARDS_TREASURY}`,
       e,
     );
   }
@@ -56,27 +91,27 @@ async function fetch(options: FetchOptions) {
 }
 
 const methodology = {
-  Fees: "Total fees from Ready Cards pack sales and marketplace transactions. Marketplace fees are currently 0%.",
-  UserFees: "User payments for Ready Cards pack sales in SOL, USDC, USDT, and READY. Ready Cards currently charges 0% marketplace fees.",
-  Revenue: "Revenue from Ready Cards pack sales. Marketplace fee revenue is currently 0%.",
-  ProtocolRevenue: "Revenue retained by Ready Cards from pack sales. Marketplace fee revenue is currently 0%.",
+  Fees: "Net fees from Ready Cards pack sales after subtracting SOL, USDC, and USDT spent on READY buybacks. Marketplace fees are currently 0%.",
+  UserFees: "User payments for Ready Cards pack sales in SOL, USDC, and USDT, net of READY buyback spends. Ready Cards currently charges 0% marketplace fees.",
+  Revenue: "Net revenue from Ready Cards pack sales after subtracting SOL, USDC, and USDT spent on READY buybacks. Marketplace fee revenue is currently 0%.",
+  ProtocolRevenue: "Net revenue retained by Ready Cards after subtracting SOL, USDC, and USDT spent on READY buybacks. Marketplace fee revenue is currently 0%.",
 };
 
 const breakdownMethodology = {
   Fees: {
-    [PACK_SALES]: "Payments received by Ready Cards' operational hot wallet for pack purchases.",
+    [PACK_SALES]: "Payments received by Ready Cards' operational hot wallet for pack purchases, minus SOL, USDC, and USDT spent from that wallet in transactions where the wallet receives READY as buybacks.",
     [MARKETPLACE_FEES]: "Ready Cards currently charges 0% marketplace fees.",
   },
   UserFees: {
-    [PACK_SALES]: "Payments made by users for Ready Cards pack purchases.",
+    [PACK_SALES]: "Payments made by users for Ready Cards pack purchases, net of READY buyback spends.",
     [MARKETPLACE_FEES]: "Ready Cards currently charges 0% marketplace fees.",
   },
   Revenue: {
-    [PACK_SALES_TO_TREASURY]: "Pack-sale revenue retained by Ready Cards' operational treasury wallet.",
+    [PACK_SALES_TO_TREASURY]: "Pack-sale revenue retained by Ready Cards' operational treasury wallet, net of READY buyback spends.",
     [MARKETPLACE_FEES_TO_TREASURY]: "Ready Cards currently charges 0% marketplace fees, so marketplace fee revenue is 0.",
   },
   ProtocolRevenue: {
-    [PACK_SALES_TO_TREASURY]: "Pack-sale revenue retained by Ready Cards' operational treasury wallet.",
+    [PACK_SALES_TO_TREASURY]: "Pack-sale revenue retained by Ready Cards' operational treasury wallet, net of READY buyback spends.",
     [MARKETPLACE_FEES_TO_TREASURY]: "Ready Cards currently charges 0% marketplace fees, so marketplace fee revenue is 0.",
   },
 };
@@ -89,6 +124,7 @@ const adapter: SimpleAdapter = {
   start: "2026-04-01",
   dependencies: [Dependencies.ALLIUM],
   isExpensiveAdapter: true,
+  allowNegativeValue: true,
   methodology,
   breakdownMethodology,
 };

--- a/fees/ready-cards.ts
+++ b/fees/ready-cards.ts
@@ -18,19 +18,25 @@ const MARKETPLACE_FEES_TO_TREASURY = "Marketplace Fees To Treasury";
 
 async function fetch(options: FetchOptions) {
   const received = options.createBalances();
-
-  await getSolanaReceived({
-    options,
-    balances: received,
-    target: READY_CARDS_TREASURY,
-    mints: PAYMENT_MINTS,
-    blacklists: [READY_CARDS_TREASURY],
-  });
-
   const dailyFees = options.createBalances();
   const dailyUserFees = options.createBalances();
   const dailyRevenue = options.createBalances();
   const dailyProtocolRevenue = options.createBalances();
+
+  try {
+    await getSolanaReceived({
+      options,
+      balances: received,
+      target: READY_CARDS_TREASURY,
+      mints: PAYMENT_MINTS,
+      blacklists: [READY_CARDS_TREASURY],
+    });
+  } catch (e) {
+    console.error(
+      `[ready-cards] failed to fetch Solana receipts for treasury ${READY_CARDS_TREASURY} and mints ${PAYMENT_MINTS.join(", ")}`,
+      e,
+    );
+  }
 
   dailyFees.addBalances(received, PACK_SALES);
   dailyFees.addUSDValue(0, MARKETPLACE_FEES);

--- a/fees/ready-cards.ts
+++ b/fees/ready-cards.ts
@@ -65,7 +65,6 @@ async function getCardSellbackSpends(options: FetchOptions) {
     SELECT mint AS token, SUM(raw_amount) AS amount
     FROM solana.assets.transfers
     WHERE from_address = '${READY_CARDS_TREASURY}'
-      AND signer = '${READY_CARDS_TREASURY}'
       AND mint IN (${paymentMints})
       AND txn_id NOT IN (SELECT txn_id FROM token_buyback_txs)
       AND block_timestamp BETWEEN TO_TIMESTAMP_NTZ(${options.startTimestamp}) AND TO_TIMESTAMP_NTZ(${options.endTimestamp})
@@ -100,7 +99,6 @@ async function getReadyFees(options: FetchOptions) {
 }
 
 async function fetch(options: FetchOptions) {
-  const grossFees = options.createBalances();
   const dailyFees = options.createBalances();
   const dailyUserFees = options.createBalances();
   const dailyRevenue = options.createBalances();
@@ -109,6 +107,8 @@ async function fetch(options: FetchOptions) {
   const dailyHoldersRevenue = options.createBalances();
 
   try {
+    const grossFees = options.createBalances();
+
     await getSolanaReceived({
       options,
       balances: grossFees,
@@ -122,23 +122,23 @@ async function fetch(options: FetchOptions) {
     const readyTokenBuybackSpends = await getReadyTokenBuybackSpends(options);
 
     grossFees.addBalances(readyFees);
+    dailyFees.addBalances(grossFees, PACK_SALES);
+    dailyUserFees.addBalances(grossFees, PACK_SALES);
+
     dailySupplySideRevenue.addBalances(cardSellbackSpends, CARD_SELLBACKS);
     dailyHoldersRevenue.addBalances(readyTokenBuybackSpends, READY_BUYBACKS);
+
+    dailyRevenue.addBalances(grossFees, PACK_SALES);
+    dailyRevenue.subtract(dailySupplySideRevenue);
+
+    dailyProtocolRevenue.addBalances(dailyRevenue);
+    dailyProtocolRevenue.subtract(dailyHoldersRevenue);
   } catch (e) {
     console.error(
       `[ready-cards] failed to fetch Solana fee data for treasury ${READY_CARDS_TREASURY}`,
       e,
     );
   }
-
-  dailyFees.addBalances(grossFees, PACK_SALES);
-  dailyUserFees.addBalances(grossFees, PACK_SALES);
-
-  dailyRevenue.addBalances(grossFees, PACK_SALES);
-  dailyRevenue.subtract(dailySupplySideRevenue);
-
-  dailyProtocolRevenue.addBalances(dailyRevenue);
-  dailyProtocolRevenue.subtract(dailyHoldersRevenue);
 
   return {
     dailyFees,

--- a/fees/ready-cards.ts
+++ b/fees/ready-cards.ts
@@ -36,7 +36,7 @@ async function getAlliumData(options: FetchOptions) {
         AND payment_out.block_timestamp BETWEEN TO_TIMESTAMP_NTZ(${options.startTimestamp}) AND TO_TIMESTAMP_NTZ(${options.endTimestamp})
     )
 
-    SELECT 'pack_purchases' AS category, mint AS token, SUM(raw_amount) AS amount
+    SELECT 'pack_purchases' AS category, mint AS token, COALESCE(SUM(raw_amount), 0) AS amount
     FROM solana.assets.transfers
     WHERE to_address = '${READY_CARDS_TREASURY}'
       AND mint IN (${paymentMints})
@@ -46,7 +46,7 @@ async function getAlliumData(options: FetchOptions) {
 
     UNION ALL
 
-    SELECT 'card_buybacks' AS category, mint AS token, SUM(raw_amount) AS amount
+    SELECT 'card_buybacks' AS category, mint AS token, COALESCE(SUM(raw_amount), 0) AS amount
     FROM solana.assets.transfers
     WHERE from_address = '${READY_CARDS_TREASURY}'
       AND mint IN (${paymentMints})
@@ -56,7 +56,7 @@ async function getAlliumData(options: FetchOptions) {
 
     UNION ALL
 
-    SELECT 'marketplace_fees' AS category, '${READY_MINT}' AS token, SUM(raw_amount) AS amount
+    SELECT 'marketplace_fees' AS category, '${READY_MINT}' AS token, COALESCE(SUM(raw_amount), 0) AS amount
     FROM solana.assets.transfers
     WHERE to_address = '${READY_CARDS_TREASURY}'
       AND mint = '${READY_MINT}'
@@ -66,7 +66,7 @@ async function getAlliumData(options: FetchOptions) {
 
     UNION ALL
 
-    SELECT 'token_buyback_spends' AS category, mint AS token, SUM(raw_amount) AS amount
+    SELECT 'token_buyback_spends' AS category, mint AS token, COALESCE(SUM(raw_amount), 0) AS amount
     FROM solana.assets.transfers
     WHERE from_address = '${READY_CARDS_TREASURY}'
       AND mint IN (${paymentMints})
@@ -93,7 +93,6 @@ async function getAlliumData(options: FetchOptions) {
 async function fetch(options: FetchOptions) {
     const dailyVolume = options.createBalances();
     const dailyFees = options.createBalances();
-    const dailyUserFees = options.createBalances();
     const dailyHoldersRevenue = options.createBalances();
 
     const { packPurchases, marketplaceFees, cardBuybacks, tokenBuybackSpends } = await getAlliumData(options);
@@ -111,11 +110,9 @@ async function fetch(options: FetchOptions) {
 
     dailyProtocolRevenue.subtract(tokenBuybackSpends, "Token Buyback Spends");
 
-
     return {
         dailyVolume,
         dailyFees,
-        dailyUserFees,
         dailyRevenue,
         dailyProtocolRevenue,
         dailyHoldersRevenue,

--- a/fees/ready-cards.ts
+++ b/fees/ready-cards.ts
@@ -1,42 +1,43 @@
 import { Dependencies, FetchOptions, SimpleAdapter } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
 import { queryAllium } from "../helpers/allium";
-import { METRIC } from "../helpers/metrics";
 
 const READY_CARDS_TREASURY = "bvT9KFrAqmRpnb6AsuaJzdVKEVuT5jAVYt3N5CyGvkV";
-
-const READY_MINT = "HKJHsYJHMVK5VRyHHk5GhvzY9tBAAtPvDkZfDH6RLDTd";
+const MEMO_PROGRAM = "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr";
 
 const PAYMENT_MINTS = [
-    "So11111111111111111111111111111111111111112", // SOL / wSOL
-    "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v", // USDC
-    "Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB", // USDT
+  "So11111111111111111111111111111111111111112", // SOL / wSOL
+  "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v", // USDC
+  "Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB", // USDT
+  "HKJHsYJHMVK5VRyHHk5GhvzY9tBAAtPvDkZfDH6RLDTd", // READY
 ];
+
+const USDT_MINT = "Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB";
+const PACK_RIPS = "Pack Rips";
+const CARD_BUYBACKS = "Card Buybacks";
 
 const paymentMints = PAYMENT_MINTS.map((mint) => `'${mint}'`).join(", ");
 
 async function getAlliumData(options: FetchOptions) {
-    const packPurchases = options.createBalances();
-    const marketplaceFees = options.createBalances();
-    const cardBuybacks = options.createBalances();
-    const tokenBuybackSpends = options.createBalances();
+  const tokenPackRips = options.createBalances();
+  const web2PackRips = options.createBalances();
+  const cardBuybacks = options.createBalances();
 
-    const results = await queryAllium(`
-    WITH token_buyback_txs AS (
-      SELECT DISTINCT ready_in.txn_id
-      FROM solana.assets.transfers ready_in
-      JOIN solana.assets.transfers payment_out
-        ON ready_in.txn_id = payment_out.txn_id
-      WHERE ready_in.to_address = '${READY_CARDS_TREASURY}'
-        AND ready_in.mint = '${READY_MINT}'
-        AND ready_in.from_address != '${READY_CARDS_TREASURY}'
-        AND payment_out.from_address = '${READY_CARDS_TREASURY}'
-        AND payment_out.mint IN (${paymentMints})
-        AND ready_in.block_timestamp BETWEEN TO_TIMESTAMP_NTZ(${options.startTimestamp}) AND TO_TIMESTAMP_NTZ(${options.endTimestamp})
-        AND payment_out.block_timestamp BETWEEN TO_TIMESTAMP_NTZ(${options.startTimestamp}) AND TO_TIMESTAMP_NTZ(${options.endTimestamp})
+  const results = await queryAllium(`
+    WITH web2_memos AS (
+      SELECT
+        txn_id,
+        COALESCE(
+          TRY_PARSE_JSON(parsed):info:memo::STRING,
+          TRY_PARSE_JSON(parsed):memo::STRING,
+          parsed
+        ) AS memo_text
+      FROM solana.raw.instructions
+      WHERE program_id = '${MEMO_PROGRAM}'
+        AND block_timestamp BETWEEN TO_TIMESTAMP_NTZ(${options.startTimestamp}) AND TO_TIMESTAMP_NTZ(${options.endTimestamp})
     )
 
-    SELECT 'pack_purchases' AS category, mint AS token, COALESCE(SUM(raw_amount), 0) AS amount
+    SELECT 'token_pack_rips' AS category, mint AS token, COALESCE(SUM(raw_amount), 0) AS amount
     FROM solana.assets.transfers
     WHERE to_address = '${READY_CARDS_TREASURY}'
       AND mint IN (${paymentMints})
@@ -46,120 +47,98 @@ async function getAlliumData(options: FetchOptions) {
 
     UNION ALL
 
-    SELECT 'card_buybacks' AS category, mint AS token, COALESCE(SUM(raw_amount), 0) AS amount
+    SELECT 'card_buybacks' AS category, '${USDT_MINT}' AS token, COALESCE(SUM(raw_amount), 0) AS amount
     FROM solana.assets.transfers
     WHERE from_address = '${READY_CARDS_TREASURY}'
-      AND mint IN (${paymentMints})
-      AND txn_id NOT IN (SELECT txn_id FROM token_buyback_txs)
-      AND block_timestamp BETWEEN TO_TIMESTAMP_NTZ(${options.startTimestamp}) AND TO_TIMESTAMP_NTZ(${options.endTimestamp})
-    GROUP BY mint
-
-    UNION ALL
-
-    SELECT 'marketplace_fees' AS category, '${READY_MINT}' AS token, COALESCE(SUM(raw_amount), 0) AS amount
-    FROM solana.assets.transfers
-    WHERE to_address = '${READY_CARDS_TREASURY}'
-      AND mint = '${READY_MINT}'
-      AND from_address != '${READY_CARDS_TREASURY}'
-      AND txn_id NOT IN (SELECT txn_id FROM token_buyback_txs)
+      AND mint = '${USDT_MINT}'
+      AND to_address != '${READY_CARDS_TREASURY}'
       AND block_timestamp BETWEEN TO_TIMESTAMP_NTZ(${options.startTimestamp}) AND TO_TIMESTAMP_NTZ(${options.endTimestamp})
 
     UNION ALL
 
-    SELECT 'token_buyback_spends' AS category, mint AS token, COALESCE(SUM(raw_amount), 0) AS amount
-    FROM solana.assets.transfers
-    WHERE from_address = '${READY_CARDS_TREASURY}'
-      AND mint IN (${paymentMints})
-      AND txn_id IN (SELECT txn_id FROM token_buyback_txs)
-      AND block_timestamp BETWEEN TO_TIMESTAMP_NTZ(${options.startTimestamp}) AND TO_TIMESTAMP_NTZ(${options.endTimestamp})
-    GROUP BY mint
+    SELECT 'web2_pack_rips' AS category, 'USD' AS token, COALESCE(SUM(
+      TRY_TO_DOUBLE(REGEXP_SUBSTR(memo_text, '(totalUsd|totalUSD|usd|USD)=([0-9]+(\\.[0-9]+)?)', 1, 1, 'e', 2))
+    ), 0) AS amount
+    FROM web2_memos
+    WHERE memo_text ILIKE 'READY|WEB2|%'
   `);
 
-    results.forEach((row: { category: string; token: string; amount: string }) => {
-        if (row.category === "pack_purchases") {
-            packPurchases.add(row.token, row.amount);
-        } else if (row.category === "card_buybacks") {
-            cardBuybacks.add(row.token, row.amount);
-        } else if (row.category === "marketplace_fees") {
-            marketplaceFees.add(row.token, row.amount);
-        } else if (row.category === "token_buyback_spends") {
-            tokenBuybackSpends.add(row.token, row.amount);
-        }
-    });
+  results.forEach((row: { category: string; token: string; amount: string }) => {
+    if (row.category === "token_pack_rips") {
+      tokenPackRips.add(row.token, row.amount);
+    } else if (row.category === "web2_pack_rips") {
+      web2PackRips.addUSDValue(Number(row.amount), PACK_RIPS);
+    } else if (row.category === "card_buybacks") {
+      cardBuybacks.add(row.token, row.amount);
+    }
+  });
 
-    return { packPurchases, marketplaceFees, cardBuybacks, tokenBuybackSpends };
+  return { tokenPackRips, web2PackRips, cardBuybacks };
 }
 
 async function fetch(options: FetchOptions) {
-    const dailyVolume = options.createBalances();
-    const dailyFees = options.createBalances();
-    const dailyHoldersRevenue = options.createBalances();
+  const dailyVolume = options.createBalances();
+  const grossPackRips = options.createBalances();
+  const costOfRevenue = options.createBalances();
 
-    const { packPurchases, marketplaceFees, cardBuybacks, tokenBuybackSpends } = await getAlliumData(options);
+  const { tokenPackRips, web2PackRips, cardBuybacks } = await getAlliumData(options);
 
-    dailyVolume.add(packPurchases)
+  grossPackRips.add(tokenPackRips, PACK_RIPS);
+  grossPackRips.add(web2PackRips, PACK_RIPS);
+  costOfRevenue.add(cardBuybacks, CARD_BUYBACKS);
+  dailyVolume.add(grossPackRips);
 
-    dailyFees.add(packPurchases, "Pack Purchases");
-    dailyFees.add(marketplaceFees, "Marketplace Fees");
-    dailyFees.subtract(cardBuybacks, "Card Buybacks");
+  const dailyFees = grossPackRips.clone();
+  const dailyUserFees = grossPackRips.clone();
+  const dailyRevenue = grossPackRips.clone();
+  const dailyProtocolRevenue = grossPackRips.clone();
 
-    const dailyRevenue = dailyFees.clone();
-    const dailyProtocolRevenue = dailyFees.clone();
-
-    dailyHoldersRevenue.add(tokenBuybackSpends, METRIC.TOKEN_BUY_BACK);
-
-    dailyProtocolRevenue.subtract(tokenBuybackSpends, "Token Buyback Spends");
-
-    return {
-        dailyVolume,
-        dailyFees,
-        dailyRevenue,
-        dailyProtocolRevenue,
-        dailyHoldersRevenue,
-    };
+  return {
+    dailyVolume,
+    dailyFees,
+    dailyUserFees,
+    dailyRevenue,
+    dailyProtocolRevenue,
+    dailySupplySideRevenue: costOfRevenue,
+    dailyHoldersRevenue: "0",
+  };
 }
 
 const methodology = {
-    Volume: "Total spends on card pack sales",
-    Fees: "Fees collected from card pack sales and marketplace trades after subtracting card buybacks",
-    Revenue: "Revenue from card pack sales and marketplace trades after subtracting card buybacks",
-    ProtocolRevenue: "Revenue retained by protocol after card buybacks and $READY token buybacks",
-    HoldersRevenue: "Part of revenue spent on $READY token buybacks",
+  Volume: "Gross Ready Cards pack-rip value.",
+  Fees: "Gross value spent on Ready Cards pack rips, including token-paid pack rips and web2/spin-credit pack rips recorded through READY|WEB2 on-chain memos. Buybacks are not netted into fees.",
+  UserFees: "Gross value paid or spent by users for Ready Cards pack rips.",
+  Revenue: "Gross pack-rip value before card buybacks/sellbacks.",
+  ProtocolRevenue: "Gross pack-rip value allocated to the Ready Cards protocol before card buybacks/sellbacks.",
+  SupplySideRevenue: "Card buybacks/sellbacks paid out by the protocol, tracked as outbound USDT from the dedicated Ready Cards treasury.",
+  HoldersRevenue: "No token holder revenue is counted for the current Ready Cards model.",
 };
 
 const breakdownMethodology = {
-    Fees: {
-        "Pack Purchases": "Fees collected from card pack sales",
-        "Marketplace Fees": "Fees collected from marketplace trades",
-        "Card Buybacks": "Fees spent on card buybacks",
-    },
-    Revenue: {
-        "Pack Purchases": "Fees collected from card pack sales",
-        "Marketplace Fees": "Fees collected from marketplace trades",
-        "Card Buybacks": "Fees spent on card buybacks",
-    },
-    ProtocolRevenue: {
-        "Pack Purchases": "Fees collected from card pack sales",
-        "Marketplace Fees": "Fees collected from marketplace trades",
-        "Card Buybacks": "Fees spent on card buybacks",
-        "Token Buyback Spends": "Fees spent on $READY token buybacks",
-    },
-    HoldersRevenue: {
-        [METRIC.TOKEN_BUY_BACK]: "Part of revenue going to token buybacks",
-    },
+  Fees: {
+    [PACK_RIPS]: "Gross Ready Cards pack-rip value, including incoming SOL, USDC, USDT, READY, and web2/spin-credit rips recorded through READY|WEB2 on-chain memos.",
+  },
+  Revenue: {
+    [PACK_RIPS]: "Gross Ready Cards pack-rip value before card buybacks/sellbacks.",
+  },
+  ProtocolRevenue: {
+    [PACK_RIPS]: "Gross Ready Cards pack-rip value before card buybacks/sellbacks.",
+  },
+  SupplySideRevenue: {
+    [CARD_BUYBACKS]: "Outbound USDT from the dedicated Ready Cards treasury. Operating expenses and other company payments are handled outside this wallet.",
+  },
 };
 
 const adapter: SimpleAdapter = {
-    version: 2,
-    pullHourly: true,
-    fetch,
-    chains: [CHAIN.SOLANA],
-    start: "2026-04-01",
-    dependencies: [Dependencies.ALLIUM],
-    isExpensiveAdapter: true,
-    allowNegativeValue: true,
-    methodology,
-    breakdownMethodology,
+  version: 2,
+  pullHourly: true,
+  fetch,
+  chains: [CHAIN.SOLANA],
+  start: "2026-04-01",
+  dependencies: [Dependencies.ALLIUM],
+  isExpensiveAdapter: true,
+  methodology,
+  breakdownMethodology,
 };
 
 export default adapter;

--- a/fees/ready-cards.ts
+++ b/fees/ready-cards.ts
@@ -2,45 +2,71 @@ import { Dependencies, FetchOptions, SimpleAdapter } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
 import { queryAllium } from "../helpers/allium";
 import { METRIC } from "../helpers/metrics";
-import { getSolanaReceived } from "../helpers/token";
 
 const READY_CARDS_TREASURY = "bvT9KFrAqmRpnb6AsuaJzdVKEVuT5jAVYt3N5CyGvkV";
 
 const READY_MINT = "HKJHsYJHMVK5VRyHHk5GhvzY9tBAAtPvDkZfDH6RLDTd";
 
 const PAYMENT_MINTS = [
-  "So11111111111111111111111111111111111111112", // SOL / wSOL
-  "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v", // USDC
-  "Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB", // USDT
+    "So11111111111111111111111111111111111111112", // SOL / wSOL
+    "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v", // USDC
+    "Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB", // USDT
 ];
-
-const PACK_SALES = "Pack Sales And Marketplace Fees";
-const CARD_SELLBACKS = "Card Sellbacks";
-const READY_BUYBACKS = METRIC.TOKEN_BUY_BACK;
 
 const paymentMints = PAYMENT_MINTS.map((mint) => `'${mint}'`).join(", ");
 
-const tokenBuybackTxs = (options: FetchOptions) => `
-  SELECT DISTINCT ready_in.txn_id
-  FROM solana.assets.transfers ready_in
-  JOIN solana.assets.transfers payment_out
-    ON ready_in.txn_id = payment_out.txn_id
-  WHERE ready_in.to_address = '${READY_CARDS_TREASURY}'
-    AND ready_in.mint = '${READY_MINT}'
-    AND ready_in.from_address != '${READY_CARDS_TREASURY}'
-    AND payment_out.from_address = '${READY_CARDS_TREASURY}'
-    AND payment_out.mint IN (${paymentMints})
-    AND ready_in.block_timestamp BETWEEN TO_TIMESTAMP_NTZ(${options.startTimestamp}) AND TO_TIMESTAMP_NTZ(${options.endTimestamp})
-    AND payment_out.block_timestamp BETWEEN TO_TIMESTAMP_NTZ(${options.startTimestamp}) AND TO_TIMESTAMP_NTZ(${options.endTimestamp})
-`;
+async function getAlliumData(options: FetchOptions) {
+    const packPurchases = options.createBalances();
+    const marketplaceFees = options.createBalances();
+    const cardBuybacks = options.createBalances();
+    const tokenBuybackSpends = options.createBalances();
 
-async function getReadyTokenBuybackSpends(options: FetchOptions) {
-  const buybackSpends = options.createBalances();
+    const results = await queryAllium(`
+    WITH token_buyback_txs AS (
+      SELECT DISTINCT ready_in.txn_id
+      FROM solana.assets.transfers ready_in
+      JOIN solana.assets.transfers payment_out
+        ON ready_in.txn_id = payment_out.txn_id
+      WHERE ready_in.to_address = '${READY_CARDS_TREASURY}'
+        AND ready_in.mint = '${READY_MINT}'
+        AND ready_in.from_address != '${READY_CARDS_TREASURY}'
+        AND payment_out.from_address = '${READY_CARDS_TREASURY}'
+        AND payment_out.mint IN (${paymentMints})
+        AND ready_in.block_timestamp BETWEEN TO_TIMESTAMP_NTZ(${options.startTimestamp}) AND TO_TIMESTAMP_NTZ(${options.endTimestamp})
+        AND payment_out.block_timestamp BETWEEN TO_TIMESTAMP_NTZ(${options.startTimestamp}) AND TO_TIMESTAMP_NTZ(${options.endTimestamp})
+    )
 
-  const results = await queryAllium(`
-    WITH token_buyback_txs AS (${tokenBuybackTxs(options)})
+    SELECT 'pack_purchases' AS category, mint AS token, SUM(raw_amount) AS amount
+    FROM solana.assets.transfers
+    WHERE to_address = '${READY_CARDS_TREASURY}'
+      AND mint IN (${paymentMints})
+      AND from_address != '${READY_CARDS_TREASURY}'
+      AND block_timestamp BETWEEN TO_TIMESTAMP_NTZ(${options.startTimestamp}) AND TO_TIMESTAMP_NTZ(${options.endTimestamp})
+    GROUP BY mint
 
-    SELECT mint AS token, SUM(raw_amount) AS amount
+    UNION ALL
+
+    SELECT 'card_buybacks' AS category, mint AS token, SUM(raw_amount) AS amount
+    FROM solana.assets.transfers
+    WHERE from_address = '${READY_CARDS_TREASURY}'
+      AND mint IN (${paymentMints})
+      AND txn_id NOT IN (SELECT txn_id FROM token_buyback_txs)
+      AND block_timestamp BETWEEN TO_TIMESTAMP_NTZ(${options.startTimestamp}) AND TO_TIMESTAMP_NTZ(${options.endTimestamp})
+    GROUP BY mint
+
+    UNION ALL
+
+    SELECT 'marketplace_fees' AS category, '${READY_MINT}' AS token, SUM(raw_amount) AS amount
+    FROM solana.assets.transfers
+    WHERE to_address = '${READY_CARDS_TREASURY}'
+      AND mint = '${READY_MINT}'
+      AND from_address != '${READY_CARDS_TREASURY}'
+      AND txn_id NOT IN (SELECT txn_id FROM token_buyback_txs)
+      AND block_timestamp BETWEEN TO_TIMESTAMP_NTZ(${options.startTimestamp}) AND TO_TIMESTAMP_NTZ(${options.endTimestamp})
+
+    UNION ALL
+
+    SELECT 'token_buyback_spends' AS category, mint AS token, SUM(raw_amount) AS amount
     FROM solana.assets.transfers
     WHERE from_address = '${READY_CARDS_TREASURY}'
       AND mint IN (${paymentMints})
@@ -49,148 +75,94 @@ async function getReadyTokenBuybackSpends(options: FetchOptions) {
     GROUP BY mint
   `);
 
-  results.forEach((row: { token: string; amount: string }) => {
-    buybackSpends.add(row.token, row.amount);
-  });
+    results.forEach((row: { category: string; token: string; amount: string }) => {
+        if (row.category === "pack_purchases") {
+            packPurchases.add(row.token, row.amount);
+        } else if (row.category === "card_buybacks") {
+            cardBuybacks.add(row.token, row.amount);
+        } else if (row.category === "marketplace_fees") {
+            marketplaceFees.add(row.token, row.amount);
+        } else if (row.category === "token_buyback_spends") {
+            tokenBuybackSpends.add(row.token, row.amount);
+        }
+    });
 
-  return buybackSpends;
-}
-
-async function getCardSellbackSpends(options: FetchOptions) {
-  const sellbackSpends = options.createBalances();
-
-  const results = await queryAllium(`
-    WITH token_buyback_txs AS (${tokenBuybackTxs(options)})
-
-    SELECT mint AS token, SUM(raw_amount) AS amount
-    FROM solana.assets.transfers
-    WHERE from_address = '${READY_CARDS_TREASURY}'
-      AND mint IN (${paymentMints})
-      AND txn_id NOT IN (SELECT txn_id FROM token_buyback_txs)
-      AND block_timestamp BETWEEN TO_TIMESTAMP_NTZ(${options.startTimestamp}) AND TO_TIMESTAMP_NTZ(${options.endTimestamp})
-    GROUP BY mint
-  `);
-
-  results.forEach((row: { token: string; amount: string }) => {
-    sellbackSpends.add(row.token, row.amount);
-  });
-
-  return sellbackSpends;
-}
-
-async function getReadyFees(options: FetchOptions) {
-  const readyFees = options.createBalances();
-
-  const results = await queryAllium(`
-    WITH token_buyback_txs AS (${tokenBuybackTxs(options)})
-
-    SELECT SUM(raw_amount) AS amount
-    FROM solana.assets.transfers
-    WHERE to_address = '${READY_CARDS_TREASURY}'
-      AND mint = '${READY_MINT}'
-      AND from_address != '${READY_CARDS_TREASURY}'
-      AND txn_id NOT IN (SELECT txn_id FROM token_buyback_txs)
-      AND block_timestamp BETWEEN TO_TIMESTAMP_NTZ(${options.startTimestamp}) AND TO_TIMESTAMP_NTZ(${options.endTimestamp})
-  `);
-
-  readyFees.add(READY_MINT, results[0]?.amount ?? 0);
-
-  return readyFees;
+    return { packPurchases, marketplaceFees, cardBuybacks, tokenBuybackSpends };
 }
 
 async function fetch(options: FetchOptions) {
-  const dailyFees = options.createBalances();
-  const dailyUserFees = options.createBalances();
-  const dailyRevenue = options.createBalances();
-  const dailyProtocolRevenue = options.createBalances();
-  const dailySupplySideRevenue = options.createBalances();
-  const dailyHoldersRevenue = options.createBalances();
+    const dailyVolume = options.createBalances();
+    const dailyFees = options.createBalances();
+    const dailyUserFees = options.createBalances();
+    const dailyHoldersRevenue = options.createBalances();
 
-  try {
-    const grossFees = options.createBalances();
+    const { packPurchases, marketplaceFees, cardBuybacks, tokenBuybackSpends } = await getAlliumData(options);
 
-    await getSolanaReceived({
-      options,
-      balances: grossFees,
-      target: READY_CARDS_TREASURY,
-      mints: PAYMENT_MINTS,
-      blacklists: [READY_CARDS_TREASURY],
-    });
+    dailyVolume.add(packPurchases)
 
-    const readyFees = await getReadyFees(options);
-    const cardSellbackSpends = await getCardSellbackSpends(options);
-    const readyTokenBuybackSpends = await getReadyTokenBuybackSpends(options);
+    dailyFees.add(packPurchases, "Pack Purchases");
+    dailyFees.add(marketplaceFees, "Marketplace Fees");
+    dailyFees.subtract(cardBuybacks, "Card Buybacks");
 
-    grossFees.addBalances(readyFees);
-    dailyFees.addBalances(grossFees, PACK_SALES);
-    dailyUserFees.addBalances(grossFees, PACK_SALES);
+    const dailyRevenue = dailyFees.clone();
+    const dailyProtocolRevenue = dailyFees.clone();
 
-    dailySupplySideRevenue.addBalances(cardSellbackSpends, CARD_SELLBACKS);
-    dailyHoldersRevenue.addBalances(readyTokenBuybackSpends, READY_BUYBACKS);
+    dailyHoldersRevenue.add(tokenBuybackSpends, METRIC.TOKEN_BUY_BACK);
 
-    dailyRevenue.addBalances(grossFees, PACK_SALES);
-    dailyRevenue.subtract(dailySupplySideRevenue);
+    dailyProtocolRevenue.subtract(tokenBuybackSpends, "Token Buyback Spends");
 
-    dailyProtocolRevenue.addBalances(dailyRevenue);
-    dailyProtocolRevenue.subtract(dailyHoldersRevenue);
-  } catch (e) {
-    console.error(
-      `[ready-cards] failed to fetch Solana fee data for treasury ${READY_CARDS_TREASURY}`,
-      e,
-    );
-  }
 
-  return {
-    dailyFees,
-    dailyUserFees,
-    dailyRevenue,
-    dailyProtocolRevenue,
-    dailySupplySideRevenue,
-    dailyHoldersRevenue,
-  };
+    return {
+        dailyVolume,
+        dailyFees,
+        dailyUserFees,
+        dailyRevenue,
+        dailyProtocolRevenue,
+        dailyHoldersRevenue,
+    };
 }
 
 const methodology = {
-  Fees: "Gross user payments received by Ready Cards' treasury for pack sales and marketplace fees in SOL, USDC, USDT, and READY.",
-  UserFees: "Gross user payments for Ready Cards pack sales and marketplace trades in SOL, USDC, USDT, and READY.",
-  Revenue: "Ready Cards revenue after subtracting card sellback payouts made from the treasury to users.",
-  ProtocolRevenue: "Revenue retained by Ready Cards after card sellback payouts and READY token buybacks.",
-  SupplySideRevenue: "Card sellback payouts from Ready Cards' treasury to users, such as when users sell opened cards back to Ready Cards.",
-  HoldersRevenue: "SOL, USDC, and USDT spent by Ready Cards' treasury to buy back READY tokens.",
+    Volume: "Total spends on card pack sales",
+    Fees: "Fees collected from card pack sales and marketplace trades after subtracting card buybacks",
+    Revenue: "Revenue from card pack sales and marketplace trades after subtracting card buybacks",
+    ProtocolRevenue: "Revenue retained by protocol after card buybacks and $READY token buybacks",
+    HoldersRevenue: "Part of revenue spent on $READY token buybacks",
 };
 
 const breakdownMethodology = {
-  Fees: {
-    [PACK_SALES]: "Gross payments received by Ready Cards' operational treasury wallet for pack purchases and marketplace fees. READY receipts are included only when they are not part of READY token buyback transactions.",
-  },
-  UserFees: {
-    [PACK_SALES]: "Gross payments made by users for Ready Cards pack purchases and marketplace trades.",
-  },
-  Revenue: {
-    [PACK_SALES]: "Gross pack-sale and marketplace-fee revenue minus card sellback payouts to users.",
-  },
-  ProtocolRevenue: {
-    [PACK_SALES]: "Revenue retained by Ready Cards after card sellback payouts and READY token buybacks.",
-  },
-  SupplySideRevenue: {
-    [CARD_SELLBACKS]: "Payments from Ready Cards' treasury to users for card sellbacks. Example transaction: 6CEvuPmZjcjP5L6d5CJqVsXzKfRqz8Q9mpERfdpcEUCZgCokf6y3eZQyBaRB77MKgDAXErHciEL5xUdQwUFPYGG.",
-  },
-  HoldersRevenue: {
-    [READY_BUYBACKS]: "SOL, USDC, and USDT spent from Ready Cards' treasury in transactions where that wallet receives READY as a token buyback.",
-  },
+    Fees: {
+        "Pack Purchases": "Fees collected from card pack sales",
+        "Marketplace Fees": "Fees collected from marketplace trades",
+        "Card Buybacks": "Fees spent on card buybacks",
+    },
+    Revenue: {
+        "Pack Purchases": "Fees collected from card pack sales",
+        "Marketplace Fees": "Fees collected from marketplace trades",
+        "Card Buybacks": "Fees spent on card buybacks",
+    },
+    ProtocolRevenue: {
+        "Pack Purchases": "Fees collected from card pack sales",
+        "Marketplace Fees": "Fees collected from marketplace trades",
+        "Card Buybacks": "Fees spent on card buybacks",
+        "Token Buyback Spends": "Fees spent on $READY token buybacks",
+    },
+    HoldersRevenue: {
+        [METRIC.TOKEN_BUY_BACK]: "Part of revenue going to token buybacks",
+    },
 };
 
 const adapter: SimpleAdapter = {
-  version: 2,
-  pullHourly: true,
-  fetch,
-  chains: [CHAIN.SOLANA],
-  start: "2026-04-01",
-  dependencies: [Dependencies.ALLIUM],
-  isExpensiveAdapter: true,
-  allowNegativeValue: true,
-  methodology,
-  breakdownMethodology,
+    version: 2,
+    pullHourly: true,
+    fetch,
+    chains: [CHAIN.SOLANA],
+    start: "2026-04-01",
+    dependencies: [Dependencies.ALLIUM],
+    isExpensiveAdapter: true,
+    allowNegativeValue: true,
+    methodology,
+    breakdownMethodology,
 };
 
 export default adapter;

--- a/fees/ready-cards.ts
+++ b/fees/ready-cards.ts
@@ -91,7 +91,8 @@ async function fetch(options: FetchOptions) {
   const dailyFees = grossPackRips.clone();
   const dailyUserFees = grossPackRips.clone();
   const dailyRevenue = grossPackRips.clone();
-  const dailyProtocolRevenue = grossPackRips.clone();
+  dailyRevenue.subtract(costOfRevenue);
+  const dailyProtocolRevenue = dailyRevenue.clone();
 
   return {
     dailyVolume,
@@ -108,8 +109,8 @@ const methodology = {
   Volume: "Gross Ready Cards pack-rip value.",
   Fees: "Gross value spent on Ready Cards pack rips, including token-paid pack rips and web2/spin-credit pack rips recorded through READY|WEB2 on-chain memos. Buybacks are not netted into fees.",
   UserFees: "Gross value paid or spent by users for Ready Cards pack rips.",
-  Revenue: "Gross pack-rip value before card buybacks/sellbacks.",
-  ProtocolRevenue: "Gross pack-rip value allocated to the Ready Cards protocol before card buybacks/sellbacks.",
+  Revenue: "Net Ready Cards pack-rip revenue after card buybacks/sellbacks.",
+  ProtocolRevenue: "Net Ready Cards pack-rip revenue retained by the protocol after card buybacks/sellbacks.",
   SupplySideRevenue: "Card buybacks/sellbacks paid out by the protocol, tracked as outbound USDT from the dedicated Ready Cards treasury.",
   HoldersRevenue: "No token holder revenue is counted for the current Ready Cards model.",
 };
@@ -118,11 +119,16 @@ const breakdownMethodology = {
   Fees: {
     [PACK_RIPS]: "Gross Ready Cards pack-rip value, including incoming SOL, USDC, USDT, READY, and web2/spin-credit rips recorded through READY|WEB2 on-chain memos.",
   },
+  UserFees: {
+    [PACK_RIPS]: "Gross value paid or spent by users for Ready Cards pack rips.",
+  },
   Revenue: {
-    [PACK_RIPS]: "Gross Ready Cards pack-rip value before card buybacks/sellbacks.",
+    [PACK_RIPS]: "Gross Ready Cards pack-rip value.",
+    [CARD_BUYBACKS]: "Outbound USDT card buybacks/sellbacks netted from gross pack-rip value.",
   },
   ProtocolRevenue: {
-    [PACK_RIPS]: "Gross Ready Cards pack-rip value before card buybacks/sellbacks.",
+    [PACK_RIPS]: "Gross Ready Cards pack-rip value.",
+    [CARD_BUYBACKS]: "Outbound USDT card buybacks/sellbacks netted from gross pack-rip value.",
   },
   SupplySideRevenue: {
     [CARD_BUYBACKS]: "Outbound USDT from the dedicated Ready Cards treasury. Operating expenses and other company payments are handled outside this wallet.",


### PR DESCRIPTION
Follow-up to #6807.

After settlement activity and backfilled data were reviewed, the Ready Cards team identified a major missing revenue path: Stripe-funded spin credits. Users can buy spin credits by credit card through Stripe, then spend those credits on pack rips. That does not create a normal on-chain token payment at rip time, so the original adapter excluded it.

The Ready team has now added on-chain `READY|WEB2` memos for spin-credit pack rips going forward. The memo's USD field represents credits spent and is counted 1:1 as Pack Rips revenue. No Stripe, customer, or card data is exposed on-chain.

Example memo:

`READY|WEB2|pack=Double Down Pack|totalUsd=75|qty=1|method=web2payment`

In this example, `totalUsd=75` means `$75` of spin-credit Pack Rips revenue.

This update also separates gross pack-rip value from buybacks:

- Pack Rips = incoming SOL, USDC, USDT, READY + `READY|WEB2` memo USD value
- Card Buybacks = outbound USDT from the dedicated treasury
- Removes READY token-holder revenue / token buyback handling
- Keeps spin-credit revenue included in total Pack Rips rather than showing a separate public line

Local reconciliation for 2026-04-01 to 2026-05-12 produced:

- Gross Protocol Revenue: $439,101.63
- Card Buybacks / Cost of Revenue: $203,800.71
- Gross Profit / Earnings: $235,300.92
- Fees Annualized: $3,909,075.52
- Net Annualized Earnings: $2,094,752.11
