### PR TITLE
[update] stableflow - extend chainMap with additional chains and update API request.

### DIFF
--- a/bridge-aggregators/stableflow/index.ts
+++ b/bridge-aggregators/stableflow/index.ts
@@ -25,10 +25,23 @@ const chainMap: Record<string, string> = {
     [CHAIN.TRON]: "tron",
     [CHAIN.APTOS]: "aptos",
     [CHAIN.BASE]: "base",
+    [CHAIN.TON]: "ton",
+    [CHAIN.MANTLE]: "mantle",
+    [CHAIN.MEGAETH]: "megaeth",
+    [CHAIN.INK]: "ink",
+    [CHAIN.STABLE]: "stable",
+    [CHAIN.CELO]: "celo",
+    [CHAIN.SEI]: "sei",
+    [CHAIN.FLARE]: "flare",
+    [CHAIN.FRAXTAL]: "frax",
+    [CHAIN.SUI]: "sui",
+    [CHAIN.KATANA]: "katana",
 };
 
 const prefetch: FetchV2 = async () => {
-    const res = await fetchURL(api);
+    const url = new URL(api);
+    url.searchParams.set("project", "stableflow");
+    const res = await fetchURL(url.toString());
     return res.data;
 };
 


### PR DESCRIPTION
**Description**
This PR is an **update to an existing adapter** (**StableFlow** bridge aggregator) and does not require the full protocol listing template.

**Key Changes:**
- **Expanded Chain Support:** Added 11 new chains to the `chainMap`:
    - TON, Mantle, MegaETH, Ink, Stable, Celo, Sei, Flare, Fraxtal, Sui, and Katana.
- **API Request Update:** Updated the `prefetch` function to use the `URL` constructor for better URL management and added the `project=stableflow` query parameter to ensure accurate data retrieval from the endpoint.
- **Implementation Details:** The adapter now dynamically exports all supported chains via `Object.keys(chainMap)`.


**Verification:**
The adapter has been tested locally via `testAdapter.ts` and successfully returns volume data for active chains (e.g., Ethereum, Solana, BSC) while initializing new chains with $0$ volume where data is pending.