### PR TITLE
Add Legend Trade as Hyperliquid builder interface

### DIFF
--- a/factory/hyperliquid.ts
+++ b/factory/hyperliquid.ts
@@ -127,6 +127,15 @@ const builderConfigs: Record<string, BuilderConfig> = {
   },
   "gtr-trade-perps": { addresses: ["0x5ef4deeb76f87d979d0ddc8c51f5b4f65d1c972a"], start: "2025-06-17" },
   "hyprearn-perps": { addresses: ["0x70cf605bb180daf00c3e2f1ca3df5bb602664452"], start: "2025-09-01" },
+  "legend-trade": {
+    addresses: ["0x4E65de9ca0ABe3D36f7E3D7a7cE9f0dbe406a412"],
+    start: "2026-01-28",
+    methodology: {
+      Fees: "Trading fees paid by users for perps on Legend.",
+      Revenue: "Builder code fees collected by Legend from Hyperliquid Perps.",
+      ProtocolRevenue: "Builder code fees collected by Legend from Hyperliquid Perps.",
+    },
+  },
   "katoshi-perps": {
     addresses: ["0x274e3cdb7bdc4805f41a07e3348243ba3e7e5b72"],
     start: "2025-08-01",
@@ -310,6 +319,15 @@ const builderFeesConfigs: Record<string, BuilderConfig> = {
       Fees: "builder code revenue from Hyperliquid Perps Trades.",
       Revenue: "builder code revenue from Hyperliquid Perps Trades.",
       ProtocolRevenue: "builder code revenue from Hyperliquid Perps Trades.",
+    },
+  },
+  "legend-trade": {
+    addresses: ["0x4E65de9ca0ABe3D36f7E3D7a7cE9f0dbe406a412"],
+    start: "2026-01-28",
+    methodology: {
+      Fees: "Trading fees paid by users for perps on Legend.",
+      Revenue: "Builder code fees collected by Legend from Hyperliquid Perps.",
+      ProtocolRevenue: "Builder code fees collected by Legend from Hyperliquid Perps.",
     },
   },
   "liminal-perps": {

--- a/factory/hyperliquid.ts
+++ b/factory/hyperliquid.ts
@@ -128,8 +128,8 @@ const builderConfigs: Record<string, BuilderConfig> = {
   "gtr-trade-perps": { addresses: ["0x5ef4deeb76f87d979d0ddc8c51f5b4f65d1c972a"], start: "2025-06-17" },
   "hyprearn-perps": { addresses: ["0x70cf605bb180daf00c3e2f1ca3df5bb602664452"], start: "2025-09-01" },
   "legend-trade": {
-    addresses: ["0x4E65de9ca0ABe3D36f7E3D7a7cE9f0dbe406a412"],
-    start: "2026-01-28",
+    addresses: ["0x4e65de9ca0abe3d36f7e3d7a7ce9f0dbe406a412"],
+    start: "2026-01-29",
     methodology: {
       Fees: "Trading fees paid by users for perps on Legend.",
       Revenue: "Builder code fees collected by Legend from Hyperliquid Perps.",
@@ -322,8 +322,8 @@ const builderFeesConfigs: Record<string, BuilderConfig> = {
     },
   },
   "legend-trade": {
-    addresses: ["0x4E65de9ca0ABe3D36f7E3D7a7cE9f0dbe406a412"],
-    start: "2026-01-28",
+    addresses: ["0x4e65de9ca0abe3d36f7e3d7a7ce9f0dbe406a412"],
+    start: "2026-01-29",
     methodology: {
       Fees: "Trading fees paid by users for perps on Legend.",
       Revenue: "Builder code fees collected by Legend from Hyperliquid Perps.",


### PR DESCRIPTION
## Summary

Adds Legend Trade as a Hyperliquid builder interface adapter for both dexs volume and fees tracking.

- **Builder address:** `0x4E65de9ca0ABe3D36f7E3D7a7cE9f0dbe406a412`
- **Start date:** 2026-01-28
- **Builder fee:** 0.05% on perps trades

## Links

- **Website:** https://legend.trade
- **Twitter:** https://x.com/legendtrade

## Changes

Added `legend-trade` entry to:
- `builderConfigs` (dexs volume tracking)
- `builderFeesConfigs` (fees tracking)

Uses the existing `exportBuilderAdapter` factory pattern — no new dependencies or helpers needed.