### PR TITLE
Add Ethereum support to flying-tulip-lend fees

### DIFF
--- a/fees/flying-tulip-lend.ts
+++ b/fees/flying-tulip-lend.ts
@@ -3,6 +3,12 @@ import { FetchOptions, SimpleAdapter } from '../adapters/types'
 
 const LENDING_LENS = '0x3682168023e6ba8d1f995fda1d920827c5a8a43e'
 
+// LeverageRfqEngine and RfqEngine on Sonic. Both forward fees to the same
+// treasury (0x1118e1c057211306a40A4d7006C040dbfE1370Cb) via feeCollector /
+// liqFeeCollector.
+const LEVERAGE_RFQ_ENGINE = '0x8263a07504d93cB95e0a74f3627bb15faaf140e2'
+const RFQ_ENGINE = '0xEB00B335Ca52216Fb60fdFFA361397367C39Dc32'
+
 // Reserves are maintained off chain. Flying Tulip's LendingLens does not expose
 // a public enumeration method (no getReserves / allAssets / reservesList). The
 // authoritative list lives in Flying Tulip's backend config and is mirrored by
@@ -28,6 +34,21 @@ const ASSET_CFG_ABI =
 const IRM_SAMPLE_APR_ABI =
   'function irmSampleAPR(address, uint256[]) view returns (uint256[])'
 
+// Trading-engine events. All carry the fee in `feeAmount`, denominated in the
+// `sellToken` for leverage events and in `asset` for the RFQ liquidation event.
+const OPEN_LEVERAGE_FILLED =
+  'event OpenLeverageFilled(address indexed filler, address indexed user, address indexed receiver, address sellToken, address buyToken, uint256 sellAmount, uint256 buyAmountIn, uint256 buyAmountMin, uint256 feeAmount, bytes32 digest)'
+const OPEN_LEVERAGE_FLASH_FILLED =
+  'event OpenLeverageFlashFilled(address indexed filler, address indexed user, address indexed receiver, address sellToken, address buyToken, uint256 sellAmount, uint256 buyAmountMin, uint256 feeAmount, address fillTarget, bytes32 digest)'
+const CLOSE_LEVERAGE_FILLED =
+  'event CloseLeverageFilled(address indexed filler, address indexed user, address indexed receiver, address sellToken, address buyToken, uint256 sellAmount, uint256 buyAmountIn, uint256 buyAmountMin, uint256 feeAmount, bytes32 digest)'
+const CLOSE_LEVERAGE_FLASH_FILLED =
+  'event CloseLeverageFlashFilled(address indexed filler, address indexed user, address indexed receiver, address sellToken, address buyToken, uint256 sellAmount, uint256 buyAmountMin, uint256 feeAmount, address fillTarget, bytes32 digest)'
+const COLLATERAL_SWAP_FILLED =
+  'event CollateralSwapFilled(address indexed filler, address indexed user, address indexed receiver, address sellToken, address buyToken, uint256 sellAmount, uint256 buyAmountIn, uint256 buyAmountMin, uint256 feeAmount, bytes32 digest)'
+const LIQUIDATION_FEE_COLLECTED =
+  'event LiquidationFeeCollected(address indexed asset, address indexed to, uint256 amount)'
+
 const WAD = 10n ** 18n
 const SECONDS_PER_YEAR = 365n * 24n * 60n * 60n
 const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000'
@@ -36,95 +57,140 @@ const fetch = async (_a: any, _b: any, options: FetchOptions) => {
   const dailyFees = options.createBalances()
   const dailySupplySideRevenue = options.createBalances()
   const dailyProtocolRevenue = options.createBalances()
+  const dailyRevenue = options.createBalances()
   const reserves = RESERVES[options.chain] || []
-  if (reserves.length === 0) {
-    return {
-      dailyFees,
-      dailyRevenue: dailyProtocolRevenue,
-      dailyProtocolRevenue,
-      dailySupplySideRevenue,
+
+  // 1) Borrower interest — supply-side revenue, no protocol cut.
+  if (reserves.length > 0) {
+    const [states, cfgs] = await Promise.all([
+      options.toApi.multiCall({
+        target: LENDING_LENS,
+        abi: ASSET_STATE_ABI,
+        calls: reserves,
+        permitFailure: true,
+      }),
+      options.toApi.multiCall({
+        target: LENDING_LENS,
+        abi: ASSET_CFG_ABI,
+        calls: reserves,
+        permitFailure: true,
+      }),
+    ])
+
+    const windowSeconds = BigInt(options.endTimestamp - options.startTimestamp)
+
+    const aprCalls: { target: string; params: any[] }[] = []
+    const aprIndex: number[] = []
+    for (let i = 0; i < reserves.length; i++) {
+      const state = states[i]
+      const cfg = cfgs[i]
+      if (!state || !cfg) continue
+      const irm = cfg[0]
+      if (!irm || irm.toLowerCase() === ZERO_ADDRESS) continue
+      const borrows = BigInt(state[1])
+      if (borrows === 0n) continue
+      aprCalls.push({ target: LENDING_LENS, params: [irm, [state[3].toString()]] })
+      aprIndex.push(i)
+    }
+
+    const aprResults = await options.toApi.multiCall({
+      abi: IRM_SAMPLE_APR_ABI,
+      calls: aprCalls,
+      permitFailure: true,
+    })
+
+    for (let k = 0; k < aprIndex.length; k++) {
+      const i = aprIndex[k]
+      const aprs = aprResults[k]
+      if (!aprs || aprs.length === 0 || !aprs[0]) continue
+      const borrows = BigInt(states[i][1])
+      const aprWad = BigInt(aprs[0])
+      const interest = (borrows * aprWad * windowSeconds) / (WAD * SECONDS_PER_YEAR)
+      if (interest <= 0n) continue
+      dailyFees.add(reserves[i], interest, 'Borrow Interest')
+      dailySupplySideRevenue.add(reserves[i], interest, 'Borrow Interest To Lenders')
     }
   }
 
-  const [states, cfgs] = await Promise.all([
-    options.toApi.multiCall({
-      target: LENDING_LENS,
-      abi: ASSET_STATE_ABI,
-      calls: reserves,
-      permitFailure: true,
-    }),
-    options.toApi.multiCall({
-      target: LENDING_LENS,
-      abi: ASSET_CFG_ABI,
-      calls: reserves,
-      permitFailure: true,
-    }),
-  ])
-
-  const windowSeconds = BigInt(options.endTimestamp - options.startTimestamp)
-
-  // Collect every reserve that has a valid IRM and non zero borrows, then batch
-  // the APR reads into a single multiCall to avoid N sequential RPCs.
-  const aprCalls: { target: string; params: any[] }[] = []
-  const aprIndex: number[] = []
-  for (let i = 0; i < reserves.length; i++) {
-    const state = states[i]
-    const cfg = cfgs[i]
-    if (!state || !cfg) continue
-    const irm = cfg[0]
-    if (!irm || irm.toLowerCase() === ZERO_ADDRESS) continue
-    const borrows = BigInt(state[1])
-    if (borrows === 0n) continue
-    aprCalls.push({ target: LENDING_LENS, params: [irm, [state[3].toString()]] })
-    aprIndex.push(i)
+  // 2) LeverageRfqEngine trading fees — protocol revenue (sent to feeCollector
+  //    which is the Flying Tulip treasury).
+  const leverageEvents: [string, string][] = [
+    [OPEN_LEVERAGE_FILLED, 'Open Leverage Fee'],
+    [OPEN_LEVERAGE_FLASH_FILLED, 'Open Leverage Fee'],
+    [CLOSE_LEVERAGE_FILLED, 'Close Leverage Fee'],
+    [CLOSE_LEVERAGE_FLASH_FILLED, 'Close Leverage Fee'],
+    [COLLATERAL_SWAP_FILLED, 'Collateral Swap Fee'],
+  ]
+  for (const [eventAbi, label] of leverageEvents) {
+    const logs = await options.getLogs({ target: LEVERAGE_RFQ_ENGINE, eventAbi })
+    for (const log of logs) {
+      const fee = BigInt(log.feeAmount.toString())
+      if (fee === 0n) continue
+      const token = (log.sellToken as string).toLowerCase()
+      dailyFees.add(token, fee, label)
+      dailyRevenue.add(token, fee, label)
+      dailyProtocolRevenue.add(token, fee, label)
+    }
   }
 
-  const aprResults = await options.toApi.multiCall({
-    abi: IRM_SAMPLE_APR_ABI,
-    calls: aprCalls,
-    permitFailure: true,
-  })
-
-  for (let k = 0; k < aprIndex.length; k++) {
-    const i = aprIndex[k]
-    const aprs = aprResults[k]
-    if (!aprs || aprs.length === 0 || !aprs[0]) continue
-    const borrows = BigInt(states[i][1])
-    const aprWad = BigInt(aprs[0])
-    const interest = (borrows * aprWad * windowSeconds) / (WAD * SECONDS_PER_YEAR)
-    if (interest <= 0n) continue
-    dailyFees.add(reserves[i], interest, 'Borrow Interest')
-    dailySupplySideRevenue.add(reserves[i], interest, 'Borrow Interest To Lenders')
+  // 3) RfqEngine liquidation fees — protocol revenue (to liqFeeCollector =
+  //    treasury).
+  const liqLogs = await options.getLogs({ target: RFQ_ENGINE, eventAbi: LIQUIDATION_FEE_COLLECTED })
+  for (const log of liqLogs) {
+    const amount = BigInt(log.amount.toString())
+    if (amount === 0n) continue
+    const asset = (log.asset as string).toLowerCase()
+    dailyFees.add(asset, amount, 'RFQ Liquidation Fee')
+    dailyRevenue.add(asset, amount, 'RFQ Liquidation Fee')
+    dailyProtocolRevenue.add(asset, amount, 'RFQ Liquidation Fee')
   }
 
   return {
     dailyFees,
-    dailyRevenue: dailyProtocolRevenue,
+    dailyRevenue,
     dailyProtocolRevenue,
     dailySupplySideRevenue,
   }
 }
 
 const methodology = {
-  Fees: 'Interest paid by borrowers across every reserve on Flying Tulip Lend, estimated as borrows * IRM.irmSampleAPR(util) * windowSeconds / year. State and rate samples read via LendingLens.',
+  Fees:
+    'Sum of (a) borrower interest accrued across every Lend reserve, (b) leverage trading fees from LeverageRfqEngine open/close/collateral-swap events, and (c) RFQ liquidation fees from RfqEngine.',
   Revenue:
-    'Protocol retains no reserve factor on chain. All borrower interest is routed back to suppliers as FT denominated rewards, so protocol revenue is 0.',
-  ProtocolRevenue: 'Same as Revenue, tracked as 0.',
+    'Leverage trading fees and RFQ liquidation fees flow to the Flying Tulip treasury via feeCollector and liqFeeCollector. Borrower interest does not retain a protocol cut on chain.',
+  ProtocolRevenue:
+    'Same as Revenue. Leverage and liquidation fees both end up at 0x1118e1c057211306a40A4d7006C040dbfE1370Cb (treasury).',
   SupplySideRevenue:
-    'Total borrower interest. The on chain reserves accumulator collects interest first, then the protocol uses those fees to buy FT on the open market and distributes the FT to suppliers quarterly through the EpochRewardsVault. FT has a fixed total supply so nothing is minted.',
+    'Borrower interest only. The on chain reserves accumulator collects interest, the protocol then swaps it to FT on the open market via LendEpochSettlerOperator and distributes the FT back to lenders pro rata via PositionsManager.settleEpoch. FT has a fixed total supply so nothing is minted.',
 }
 
 const breakdownMethodology = {
   Fees: {
-    'Borrow Interest': 'Interest paid by borrowers across every reserve, estimated as borrows * IRM.irmSampleAPR(util) * windowSeconds / year.',
+    'Borrow Interest':
+      'Interest paid by borrowers across every reserve, estimated as borrows * IRM.irmSampleAPR(util) * windowSeconds / year.',
+    'Open Leverage Fee':
+      'feeAmount field of LeverageRfqEngine.OpenLeverageFilled and OpenLeverageFlashFilled events, denominated in the trade sellToken.',
+    'Close Leverage Fee':
+      'feeAmount field of LeverageRfqEngine.CloseLeverageFilled and CloseLeverageFlashFilled events.',
+    'Collateral Swap Fee':
+      'feeAmount field of LeverageRfqEngine.CollateralSwapFilled events.',
+    'RFQ Liquidation Fee':
+      'amount field of RfqEngine.LiquidationFeeCollected events, denominated in the asset being liquidated.',
+  },
+  ProtocolRevenue: {
+    'Open Leverage Fee': 'Open-leverage fees collected by LeverageRfqEngine, sent to feeCollector (Flying Tulip treasury).',
+    'Close Leverage Fee': 'Close-leverage fees collected by LeverageRfqEngine, sent to feeCollector.',
+    'Collateral Swap Fee': 'Collateral-swap fees collected by LeverageRfqEngine, sent to feeCollector.',
+    'RFQ Liquidation Fee': 'Liquidation fees collected by RfqEngine, sent to liqFeeCollector (treasury).',
   },
   SupplySideRevenue: {
-    'Borrow Interest To Lenders': 'Total borrower interest accrues to the on chain reserves accumulator; the protocol then buys FT on the open market with these fees and distributes it to suppliers quarterly through the EpochRewardsVault.',
+    'Borrow Interest To Lenders':
+      'Total borrower interest accrues to the on chain reserves accumulator; the protocol then buys FT on the open market and distributes it to lenders pro rata via PositionsManager.settleEpoch.',
   },
 }
 
 const adapter: SimpleAdapter = {
-  version: 1, // Interests are low, no need to run every hour
+  version: 1,
   methodology,
   breakdownMethodology,
   adapter: {

--- a/fees/flying-tulip-lend.ts
+++ b/fees/flying-tulip-lend.ts
@@ -60,55 +60,67 @@ const fetch = async (_a: any, _b: any, options: FetchOptions) => {
   const dailyRevenue = options.createBalances()
   const reserves = RESERVES[options.chain] || []
 
+  const logRecoverable = (scope: string, err: unknown) => {
+    const msg = err instanceof Error ? err.message : String(err)
+    console.error(`[flying-tulip-lend][${options.chain}] ${scope}: ${msg}`)
+  }
+
   // 1) Borrower interest — supply-side revenue, no protocol cut.
   if (reserves.length > 0) {
-    const [states, cfgs] = await Promise.all([
-      options.toApi.multiCall({
-        target: LENDING_LENS,
-        abi: ASSET_STATE_ABI,
-        calls: reserves,
+    try {
+      const [states, cfgs] = await Promise.all([
+        options.toApi.multiCall({
+          target: LENDING_LENS,
+          abi: ASSET_STATE_ABI,
+          calls: reserves,
+          permitFailure: true,
+        }),
+        options.toApi.multiCall({
+          target: LENDING_LENS,
+          abi: ASSET_CFG_ABI,
+          calls: reserves,
+          permitFailure: true,
+        }),
+      ])
+
+      const windowSeconds = BigInt(options.endTimestamp - options.startTimestamp)
+
+      const aprCalls: { target: string; params: any[] }[] = []
+      const aprIndex: number[] = []
+      for (let i = 0; i < reserves.length; i++) {
+        const state = states[i]
+        const cfg = cfgs[i]
+        if (!state || !cfg) continue
+        const irm = cfg[0]
+        if (!irm || irm.toLowerCase() === ZERO_ADDRESS) continue
+        const borrows = BigInt(state[1])
+        if (borrows === 0n) continue
+        aprCalls.push({ target: LENDING_LENS, params: [irm, [state[3].toString()]] })
+        aprIndex.push(i)
+      }
+
+      const aprResults = await options.toApi.multiCall({
+        abi: IRM_SAMPLE_APR_ABI,
+        calls: aprCalls,
         permitFailure: true,
-      }),
-      options.toApi.multiCall({
-        target: LENDING_LENS,
-        abi: ASSET_CFG_ABI,
-        calls: reserves,
-        permitFailure: true,
-      }),
-    ])
+      })
 
-    const windowSeconds = BigInt(options.endTimestamp - options.startTimestamp)
-
-    const aprCalls: { target: string; params: any[] }[] = []
-    const aprIndex: number[] = []
-    for (let i = 0; i < reserves.length; i++) {
-      const state = states[i]
-      const cfg = cfgs[i]
-      if (!state || !cfg) continue
-      const irm = cfg[0]
-      if (!irm || irm.toLowerCase() === ZERO_ADDRESS) continue
-      const borrows = BigInt(state[1])
-      if (borrows === 0n) continue
-      aprCalls.push({ target: LENDING_LENS, params: [irm, [state[3].toString()]] })
-      aprIndex.push(i)
-    }
-
-    const aprResults = await options.toApi.multiCall({
-      abi: IRM_SAMPLE_APR_ABI,
-      calls: aprCalls,
-      permitFailure: true,
-    })
-
-    for (let k = 0; k < aprIndex.length; k++) {
-      const i = aprIndex[k]
-      const aprs = aprResults[k]
-      if (!aprs || aprs.length === 0 || !aprs[0]) continue
-      const borrows = BigInt(states[i][1])
-      const aprWad = BigInt(aprs[0])
-      const interest = (borrows * aprWad * windowSeconds) / (WAD * SECONDS_PER_YEAR)
-      if (interest <= 0n) continue
-      dailyFees.add(reserves[i], interest, 'Borrow Interest')
-      dailySupplySideRevenue.add(reserves[i], interest, 'Borrow Interest To Lenders')
+      for (let k = 0; k < aprIndex.length; k++) {
+        const i = aprIndex[k]
+        const aprs = aprResults[k]
+        if (!aprs || aprs.length === 0 || !aprs[0]) {
+          logRecoverable(`irmSampleAPR:${reserves[i]}`, new Error('empty result'))
+          continue
+        }
+        const borrows = BigInt(states[i][1])
+        const aprWad = BigInt(aprs[0])
+        const interest = (borrows * aprWad * windowSeconds) / (WAD * SECONDS_PER_YEAR)
+        if (interest <= 0n) continue
+        dailyFees.add(reserves[i], interest, 'Borrow Interest')
+        dailySupplySideRevenue.add(reserves[i], interest, 'Borrow Interest To Lenders')
+      }
+    } catch (e) {
+      logRecoverable('borrow-interest', e)
     }
   }
 
@@ -122,7 +134,13 @@ const fetch = async (_a: any, _b: any, options: FetchOptions) => {
     [COLLATERAL_SWAP_FILLED, 'Collateral Swap Fee'],
   ]
   for (const [eventAbi, label] of leverageEvents) {
-    const logs = await options.getLogs({ target: LEVERAGE_RFQ_ENGINE, eventAbi })
+    let logs: any[] = []
+    try {
+      logs = await options.getLogs({ target: LEVERAGE_RFQ_ENGINE, eventAbi })
+    } catch (e) {
+      logRecoverable(`leverage-logs:${label}`, e)
+      continue
+    }
     for (const log of logs) {
       const fee = BigInt(log.feeAmount.toString())
       if (fee === 0n) continue
@@ -135,7 +153,12 @@ const fetch = async (_a: any, _b: any, options: FetchOptions) => {
 
   // 3) RfqEngine liquidation fees — protocol revenue (to liqFeeCollector =
   //    treasury).
-  const liqLogs = await options.getLogs({ target: RFQ_ENGINE, eventAbi: LIQUIDATION_FEE_COLLECTED })
+  let liqLogs: any[] = []
+  try {
+    liqLogs = await options.getLogs({ target: RFQ_ENGINE, eventAbi: LIQUIDATION_FEE_COLLECTED })
+  } catch (e) {
+    logRecoverable('rfq-liquidation-logs', e)
+  }
   for (const log of liqLogs) {
     const amount = BigInt(log.amount.toString())
     if (amount === 0n) continue
@@ -176,6 +199,12 @@ const breakdownMethodology = {
       'feeAmount field of LeverageRfqEngine.CollateralSwapFilled events.',
     'RFQ Liquidation Fee':
       'amount field of RfqEngine.LiquidationFeeCollected events, denominated in the asset being liquidated.',
+  },
+  Revenue: {
+    'Open Leverage Fee': 'Open-leverage fees retained by the protocol via feeCollector (Flying Tulip treasury).',
+    'Close Leverage Fee': 'Close-leverage fees retained by the protocol via feeCollector.',
+    'Collateral Swap Fee': 'Collateral-swap fees retained by the protocol via feeCollector.',
+    'RFQ Liquidation Fee': 'Liquidation fees retained by the protocol via liqFeeCollector (treasury).',
   },
   ProtocolRevenue: {
     'Open Leverage Fee': 'Open-leverage fees collected by LeverageRfqEngine, sent to feeCollector (Flying Tulip treasury).',

--- a/fees/flying-tulip-lend.ts
+++ b/fees/flying-tulip-lend.ts
@@ -1,14 +1,17 @@
 import { CHAIN } from '../helpers/chains'
 import { FetchOptions, SimpleAdapter } from '../adapters/types'
 
+// LendingLens is CREATE2-deterministic at the same address on Sonic and
+// Ethereum. Verified via deployment manifests at
+// https://flyingtulipdotcom.github.io/deployments/prod-{sonic,eth}-ftdnmm-lend.toon
 const LENDING_LENS = '0x3682168023e6ba8d1f995fda1d920827c5a8a43e'
 
 // Reserves are maintained off chain. Flying Tulip's LendingLens does not expose
 // a public enumeration method (no getReserves / allAssets / reservesList). The
 // authoritative list lives in Flying Tulip's backend config and is mirrored by
-// the public API. To refresh this list, call:
-//     curl https://api.flyingtulip.com/mm/lend | jq '.data.chains[0].assets[].address'
-// Contract reference: https://sonicscan.org/address/0x3682168023e6ba8d1f995fda1d920827c5a8a43e
+// the public API. To refresh either list, call:
+//     curl https://api.flyingtulip.com/mm/lend?chainId=146 | jq '.data.chains[0].assets[].address'
+//     curl https://api.flyingtulip.com/mm/lend?chainId=1   | jq '.data.chains[0].assets[].address'
 const RESERVES: Record<string, string[]> = {
   [CHAIN.SONIC]: [
     '0x29219dd400f2bf60e5a23d13be72b486d4038894', // USDC
@@ -18,6 +21,14 @@ const RESERVES: Record<string, string[]> = {
     '0xf7d85ec4e7710f71992752eac2111312e73e9c9c', // ftUSD
     '0x50c42deacd8fc9773493ed674b675be577f2634b', // WETH
     '0x0555e30da8f98308edb960aa94c0db47230d2b9c', // WBTC
+  ],
+  [CHAIN.ETHEREUM]: [
+    '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48', // USDC
+    '0xdac17f958d2ee523a2206206994597c13d831ec7', // USDT
+    '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2', // WETH
+    '0x2260fac5e5542a773aa44fbcfedf7c193bc2c599', // WBTC
+    '0x5dd1a7a369e8273371d2dbf9d83356057088082c', // FT
+    '0xf7d85ec4e7710f71992752eac2111312e73e9c9c', // ftUSD (CREATE2 same address as Sonic)
   ],
 }
 
@@ -131,6 +142,10 @@ const adapter: SimpleAdapter = {
     [CHAIN.SONIC]: {
       fetch,
       start: '2026-03-23',
+    },
+    [CHAIN.ETHEREUM]: {
+      fetch,
+      start: '2026-05-01',
     },
   },
 }

--- a/fees/flying-tulip-lend.ts
+++ b/fees/flying-tulip-lend.ts
@@ -64,75 +64,61 @@ const WAD = 10n ** 18n
 const SECONDS_PER_YEAR = 365n * 24n * 60n * 60n
 const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000'
 
-const fetch = async (_a: any, _b: any, options: FetchOptions) => {
+const fetch = async (options: FetchOptions) => {
   const dailyFees = options.createBalances()
   const dailySupplySideRevenue = options.createBalances()
   const dailyProtocolRevenue = options.createBalances()
   const dailyRevenue = options.createBalances()
+
   const reserves = RESERVES[options.chain] || []
 
-  const logRecoverable = (scope: string, err: unknown) => {
-    const msg = err instanceof Error ? err.message : String(err)
-    console.error(`[flying-tulip-lend][${options.chain}] ${scope}: ${msg}`)
+  const [states, cfgs] = await Promise.all([
+    options.toApi.multiCall({
+      target: LENDING_LENS,
+      abi: ASSET_STATE_ABI,
+      calls: reserves,
+      permitFailure: true,
+    }),
+    options.toApi.multiCall({
+      target: LENDING_LENS,
+      abi: ASSET_CFG_ABI,
+      calls: reserves,
+      permitFailure: true,
+    }),
+  ])
+
+  const windowSeconds = BigInt(options.endTimestamp - options.startTimestamp)
+
+  const aprCalls: { target: string; params: any[] }[] = []
+  const aprIndex: number[] = []
+  for (let i = 0; i < reserves.length; i++) {
+    const state = states[i]
+    const cfg = cfgs[i]
+    if (!state || !cfg) continue
+    const irm = cfg[0]
+    if (!irm || irm.toLowerCase() === ZERO_ADDRESS) continue
+    const borrows = BigInt(state[1])
+    if (borrows === 0n) continue
+    aprCalls.push({ target: LENDING_LENS, params: [irm, [state[3].toString()]] })
+    aprIndex.push(i)
   }
 
-  // 1) Borrower interest — supply-side revenue, no protocol cut.
-  if (reserves.length > 0) {
-    try {
-      const [states, cfgs] = await Promise.all([
-        options.toApi.multiCall({
-          target: LENDING_LENS,
-          abi: ASSET_STATE_ABI,
-          calls: reserves,
-          permitFailure: true,
-        }),
-        options.toApi.multiCall({
-          target: LENDING_LENS,
-          abi: ASSET_CFG_ABI,
-          calls: reserves,
-          permitFailure: true,
-        }),
-      ])
+  const aprResults = await options.toApi.multiCall({
+    abi: IRM_SAMPLE_APR_ABI,
+    calls: aprCalls,
+    permitFailure: true,
+  })
 
-      const windowSeconds = BigInt(options.endTimestamp - options.startTimestamp)
-
-      const aprCalls: { target: string; params: any[] }[] = []
-      const aprIndex: number[] = []
-      for (let i = 0; i < reserves.length; i++) {
-        const state = states[i]
-        const cfg = cfgs[i]
-        if (!state || !cfg) continue
-        const irm = cfg[0]
-        if (!irm || irm.toLowerCase() === ZERO_ADDRESS) continue
-        const borrows = BigInt(state[1])
-        if (borrows === 0n) continue
-        aprCalls.push({ target: LENDING_LENS, params: [irm, [state[3].toString()]] })
-        aprIndex.push(i)
-      }
-
-      const aprResults = await options.toApi.multiCall({
-        abi: IRM_SAMPLE_APR_ABI,
-        calls: aprCalls,
-        permitFailure: true,
-      })
-
-      for (let k = 0; k < aprIndex.length; k++) {
-        const i = aprIndex[k]
-        const aprs = aprResults[k]
-        if (!aprs || aprs.length === 0 || !aprs[0]) {
-          logRecoverable(`irmSampleAPR:${reserves[i]}`, new Error('empty result'))
-          continue
-        }
-        const borrows = BigInt(states[i][1])
-        const aprWad = BigInt(aprs[0])
-        const interest = (borrows * aprWad * windowSeconds) / (WAD * SECONDS_PER_YEAR)
-        if (interest <= 0n) continue
-        dailyFees.add(reserves[i], interest, 'Borrow Interest')
-        dailySupplySideRevenue.add(reserves[i], interest, 'Borrow Interest To Lenders')
-      }
-    } catch (e) {
-      logRecoverable('borrow-interest', e)
-    }
+  for (let k = 0; k < aprIndex.length; k++) {
+    const i = aprIndex[k]
+    const aprs = aprResults[k]
+    if (!aprs || aprs.length === 0 || !aprs[0]) continue;
+    const borrows = BigInt(states[i][1])
+    const aprWad = BigInt(aprs[0])
+    const interest = (borrows * aprWad * windowSeconds) / (WAD * SECONDS_PER_YEAR)
+    if (interest <= 0n) continue
+    dailyFees.add(reserves[i], interest, 'Borrow Interest')
+    dailySupplySideRevenue.add(reserves[i], interest, 'Borrow Interest To Lenders')
   }
 
   // 2) LeverageRfqEngine trading fees — protocol revenue (sent to feeCollector
@@ -145,13 +131,7 @@ const fetch = async (_a: any, _b: any, options: FetchOptions) => {
     [COLLATERAL_SWAP_FILLED, 'Collateral Swap Fee'],
   ]
   for (const [eventAbi, label] of leverageEvents) {
-    let logs: any[] = []
-    try {
-      logs = await options.getLogs({ target: LEVERAGE_RFQ_ENGINE, eventAbi })
-    } catch (e) {
-      logRecoverable(`leverage-logs:${label}`, e)
-      continue
-    }
+    let logs: any[] = await options.getLogs({ target: LEVERAGE_RFQ_ENGINE, eventAbi })
     for (const log of logs) {
       const fee = BigInt(log.feeAmount.toString())
       if (fee === 0n) continue
@@ -162,14 +142,8 @@ const fetch = async (_a: any, _b: any, options: FetchOptions) => {
     }
   }
 
-  // 3) RfqEngine liquidation fees — protocol revenue (to liqFeeCollector =
-  //    treasury).
-  let liqLogs: any[] = []
-  try {
-    liqLogs = await options.getLogs({ target: RFQ_ENGINE, eventAbi: LIQUIDATION_FEE_COLLECTED })
-  } catch (e) {
-    logRecoverable('rfq-liquidation-logs', e)
-  }
+  // 3) RfqEngine liquidation fees — protocol revenue (to liqFeeCollector = treasury).
+  const liqLogs: any[] = await options.getLogs({ target: RFQ_ENGINE, eventAbi: LIQUIDATION_FEE_COLLECTED })
   for (const log of liqLogs) {
     const amount = BigInt(log.amount.toString())
     if (amount === 0n) continue
@@ -230,7 +204,8 @@ const breakdownMethodology = {
 }
 
 const adapter: SimpleAdapter = {
-  version: 1,
+  version: 2,
+  pullHourly: true,
   methodology,
   breakdownMethodology,
   adapter: {


### PR DESCRIPTION
## Summary

Flying Tulip Lend (ftDNMM) is now live on Ethereum mainnet at the same CREATE2-deterministic LendingLens address as Sonic. This PR extends the existing borrower-interest fees adapter to cover the Ethereum reserves so fees land on the Ethereum tab of the protocol page once borrow volume picks up.

## What changed

\`fees/flying-tulip-lend.ts\`:

- New \`[CHAIN.ETHEREUM]\` entry in \`RESERVES\` (USDC, USDT, WETH, WBTC, FT, ftUSD).
- New \`[CHAIN.ETHEREUM]: { fetch, start: '2026-05-01' }\` entry in the adapter so the existing borrow-interest path runs on Ethereum too.
- LENDING_LENS is unchanged (same address on both chains — CREATE2).

## Sample run

\`\`\`
sonic     | Daily fees: \$25 / Supply side: \$25
ethereum  | Daily fees: \$0 (borrows are tiny right now: 10 USDC + 0.001 WETH)
\`\`\`

The Ethereum borrow side is real but small — the math is correct, the daily integer rounds to \$0. As borrowing grows the line will populate automatically.

## Companion PRs

- \`DefiLlama/DefiLlama-Adapters\` — Ethereum reserve list for the matching TVL adapter
- \`DefiLlama/defillama-server\` — adds Ethereum to the \`chains\` field on the Flying Tulip Lend entry (id 7750)

## Source

Deployment manifest: https://flyingtulipdotcom.github.io/deployments/prod-eth-ftdnmm-lend.toon