### PR TITLE
Add Hash PayLink fees adapter

### DIFF
--- a/fees/hashpaylink.ts
+++ b/fees/hashpaylink.ts
@@ -1,0 +1,84 @@
+import { FetchOptions, SimpleAdapter } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+import ADDRESSES from "../helpers/coreAssets.json";
+import { ethers } from "ethers";
+
+const EVM_TREASURY = "0xcE5dF9e1115F81a2Fc2F65941B20B820d508e753";
+const EVM_TREASURY_TOPIC = ethers.zeroPadValue(EVM_TREASURY, 32);
+const LABEL = "Hash PayLink Settlement Fees";
+
+const USDC_BY_CHAIN: Record<string, string> = {
+  [CHAIN.BASE]: ADDRESSES.base.USDC,
+  [CHAIN.ARBITRUM]: ADDRESSES.arbitrum.USDC_CIRCLE,
+};
+
+const zeroResult = (options: FetchOptions) => {
+  const dailyFees = options.createBalances();
+  return {
+    dailyFees,
+    dailyUserFees: dailyFees,
+    dailyRevenue: dailyFees,
+    dailyProtocolRevenue: dailyFees,
+  };
+};
+
+const fetchEVM = async (options: FetchOptions) => {
+  const dailyFees = options.createBalances();
+  const token = USDC_BY_CHAIN[options.chain];
+
+  try {
+    const logs = await options.getLogs({
+      target: token,
+      eventAbi: "event Transfer(address indexed from, address indexed to, uint256 value)",
+      topics: [
+        "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
+        null as any,
+        EVM_TREASURY_TOPIC,
+      ],
+    });
+
+    logs.forEach((log) => dailyFees.add(token, log.value, LABEL));
+  } catch (error) {
+    console.error(`[hashpaylink:${options.chain}] recoverable fetch failure`, error);
+    return zeroResult(options);
+  }
+
+  return {
+    dailyFees,
+    dailyUserFees: dailyFees,
+    dailyRevenue: dailyFees,
+    dailyProtocolRevenue: dailyFees,
+  };
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  pullHourly: true,
+  start: "2026-05-01",
+  adapter: {
+    [CHAIN.BASE]: { fetch: fetchEVM },
+    [CHAIN.ARBITRUM]: { fetch: fetchEVM },
+  },
+  methodology: {
+    Fees: "Hash PayLink charges a 0.2% platform fee on successful payment settlement. Sponsored smart-wallet payments may also route a small USDC gas recovery amount to the treasury in the same settlement.",
+    UserFees: "Fees are paid by payers as part of the Hash PayLink payment transaction.",
+    Revenue: "All tracked fees are collected by the Hash PayLink treasury.",
+    ProtocolRevenue: "All tracked fees accrue to the Hash PayLink protocol treasury.",
+  },
+  breakdownMethodology: {
+    Fees: {
+      [LABEL]: "USDC transfers received by the Hash PayLink treasury from payment settlement flows.",
+    },
+    UserFees: {
+      [LABEL]: "USDC platform fees and sponsored gas recovery amounts paid by users during settlement.",
+    },
+    Revenue: {
+      [LABEL]: "100% of tracked settlement fees are protocol revenue.",
+    },
+    ProtocolRevenue: {
+      [LABEL]: "100% of tracked settlement fees accrue to the protocol treasury.",
+    },
+  },
+};
+
+export default adapter;

--- a/fees/hashpaylink.ts
+++ b/fees/hashpaylink.ts
@@ -1,48 +1,19 @@
 import { FetchOptions, SimpleAdapter } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
-import ADDRESSES from "../helpers/coreAssets.json";
-import { ethers } from "ethers";
+import { addTokensReceived } from "../helpers/token";
 
 const EVM_TREASURY = "0xcE5dF9e1115F81a2Fc2F65941B20B820d508e753";
-const EVM_TREASURY_TOPIC = ethers.zeroPadValue(EVM_TREASURY, 32);
-const LABEL = "Hash PayLink Settlement Fees";
+const LABEL = "Payment Fees";
 
-const USDC_BY_CHAIN: Record<string, string> = {
-  [CHAIN.BASE]: ADDRESSES.base.USDC,
-  [CHAIN.ARBITRUM]: ADDRESSES.arbitrum.USDC_CIRCLE,
-};
+const fetchEvm = async (options: FetchOptions) => {
+  const paymentFees = await addTokensReceived({
+    options,
+    target: EVM_TREASURY,
+  })
 
-const zeroResult = (options: FetchOptions) => {
   const dailyFees = options.createBalances();
-  return {
-    dailyFees,
-    dailyUserFees: dailyFees,
-    dailyRevenue: dailyFees,
-    dailyProtocolRevenue: dailyFees,
-  };
-};
-
-const fetchEVM = async (options: FetchOptions) => {
-  const dailyFees = options.createBalances();
-  const token = USDC_BY_CHAIN[options.chain];
-
-  try {
-    const logs = await options.getLogs({
-      target: token,
-      eventAbi: "event Transfer(address indexed from, address indexed to, uint256 value)",
-      topics: [
-        "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
-        null as any,
-        EVM_TREASURY_TOPIC,
-      ],
-    });
-
-    logs.forEach((log) => dailyFees.add(token, log.value, LABEL));
-  } catch (error) {
-    console.error(`[hashpaylink:${options.chain}] recoverable fetch failure`, error);
-    return zeroResult(options);
-  }
-
+  dailyFees.add(paymentFees, LABEL);
+  
   return {
     dailyFees,
     dailyUserFees: dailyFees,
@@ -54,10 +25,15 @@ const fetchEVM = async (options: FetchOptions) => {
 const adapter: SimpleAdapter = {
   version: 2,
   pullHourly: true,
-  start: "2026-05-01",
   adapter: {
-    [CHAIN.BASE]: { fetch: fetchEVM },
-    [CHAIN.ARBITRUM]: { fetch: fetchEVM },
+    [CHAIN.ARBITRUM]: {
+      fetch: fetchEvm,
+      start: "2026-05-01",
+    },
+    [CHAIN.BASE]: {
+      fetch: fetchEvm,
+      start: "2026-05-01",
+    },
   },
   methodology: {
     Fees: "Hash PayLink charges a 0.2% platform fee on successful payment settlement. Sponsored smart-wallet payments may also route a small USDC gas recovery amount to the treasury in the same settlement.",


### PR DESCRIPTION
Adds a DeFiLlama fees/revenue adapter for Hash PayLink.

  Website: https://hashpaylink.com
  Twitter/X: https://x.com/Hash_PayLink
  Docs: https://github.com/Cyano88/hashkey-paylink/blob/main/DOCS.md
  GitHub: https://github.com/Cyano88/hashkey-paylink

  ##### Name (to be shown on DefiLlama):
  Hash PayLink

  ##### Twitter Link:
  https://x.com/Hash_PayLink

  ##### List of audit links if any:
  N/A

  ##### Website Link:
  https://hashpaylink.com

  ##### Logo (High resolution, will be shown with rounded borders):
  https://hashpaylink.com/icon.png

  ##### Current TVL:
  N/A - Hash PayLink is non-custodial/stateless and does not hold user funds.

  ##### Treasury Addresses (if the protocol has treasury)
  EVM: 0xcE5dF9e1115F81a2Fc2F65941B20B820d508e753
  Solana treasury owner: Gs7RTc4iW5HE7r1s9AC2UwgEhb4uJ5vxZ9idFHh6x73J
  Solana receiving ATA: CqCSLFzicqrm9E85bK9TxqT9fv2MSdLg7X3yjfvA3jsy
  Starknet: 0x0483AB5539B281c08777F1C8337Beeba05c2610feDcbA191B989E35eDc2767C3

  ##### Chain:
  Base, Arbitrum

 Solana and Starknet treasury addresses are known and will be added in a follow-up adapter update once the data source can run cleanly in DeFiLlama CI.

  ##### Coingecko ID:
  N/A

  ##### Coinmarketcap ID:
  N/A

  ##### Short Description:
  Hash PayLink is a non-custodial USDC payment link platform for gasless/contactless stablecoin settlement. Merchants create payment links and QR codes, while payer funds settle directly on-chain with a
  transparent 0.2% platform fee.

  ##### Token address and ticker if any:
  N/A

  ##### Category:
  Payments

  ##### Oracle Provider(s):
  N/A

  ##### Implementation Details:
  N/A - Hash PayLink does not rely on an oracle for settlement. Payment amounts and fee splits are executed directly on-chain.

  ##### Documentation/Proof:
  https://github.com/Cyano88/hashkey-paylink/blob/main/DOCS.md
  https://github.com/Cyano88/hashkey-paylink

  ##### forkedFrom:
  N/A

  ##### methodology:
  This PR is for a fees/revenue adapter, not TVL. Hash PayLink is non-custodial/stateless, so TVL is not counted. The adapter tracks USDC protocol fees routed to Hash PayLink treasury addresses. Hash PayLink
  charges a 0.2% platform fee on successful payment settlement. Sponsored smart-wallet payments may also route a small USDC gas recovery amount to the treasury in the same settlement.

  ##### Github org/user:
  https://github.com/Cyano88

  ##### Does this project have a referral program?
  No

  Local validation:
  - `npm run ts-check` passed
  - `npm run test -- fees hashpaylink.ts` passed