### PR TITLE
[fix] privacy-pools: track deposit and relayer fees on deposit/withdrawals

### DIFF
--- a/fees/privacy-pools.ts
+++ b/fees/privacy-pools.ts
@@ -1,56 +1,113 @@
-import { BaseAdapter, FetchOptions, SimpleAdapter } from "../adapters/types";
+import { FetchOptions, SimpleAdapter } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
+import ADDRESSES from "../helpers/coreAssets.json";
 
+const BPS = 10_000n;
 
+const METRICS = {
+  DEPOSIT_FEES: "Deposit Vetting Fees",
+  RELAYER_FEES: "Relayer Fees",
+}
 
-const config = {
+const abis = {
+  deposited: "event Deposited(address indexed depositor, address indexed pool, uint256 commitment, uint256 amount)",
+  withdrawalRelayed: "event WithdrawalRelayed(address indexed relayer, address indexed recipient, address indexed asset, uint256 amount, uint256 feeAmount)",
+  asset: "function ASSET() view returns (address)",
+  assetConfig: "function assetConfig(address asset) view returns (address pool, uint256 minimumDepositAmount, uint256 vettingFeeBPS, uint256 maxRelayFeeBPS)",
+}
+
+const token = (asset: string) => asset.toLowerCase() === "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee" ? ADDRESSES.null : asset;
+
+const chainConfig: Record<string, { entrypoint: string, start: string }> = {
   [CHAIN.ETHEREUM]: {
-    pools: [
-      '0x6818809eefce719e480a7526d76bd3e561526b46',
-    ]
+    entrypoint: "0x6818809eefce719e480a7526d76bd3e561526b46",
+    start: "2025-03-30",
   },
-
   [CHAIN.ARBITRUM]: {
-    pools: [
-      '0x44192215FEd782896BE2CE24E0Bfbf0BF825d15E',
-    ]
+    entrypoint: "0x44192215FEd782896BE2CE24E0Bfbf0BF825d15E",
+    start: "2025-11-27",
   },
-
   [CHAIN.OPTIMISM]: {
-    pools: [
-      '0x44192215FEd782896BE2CE24E0Bfbf0BF825d15E',
-    ]
+    entrypoint: "0x44192215FEd782896BE2CE24E0Bfbf0BF825d15E",
+    start: "2025-11-27",
   },
 }
 
+const fetch = async (options: FetchOptions) => {
+  const { entrypoint } = chainConfig[options.chain];
+  const dailyFees = options.createBalances();
+  const dailyRevenue = options.createBalances();
+  const dailySupplySideRevenue = options.createBalances();
 
-const adapters: SimpleAdapter = {
-  adapter: {},
+  const deposits = await options.getLogs({ target: entrypoint, eventAbi: abis.deposited });
+  if (deposits.length) {
+    const pools = [...new Set(deposits.map(log => log.pool.toLowerCase()))];
+    const assets: string[] = await options.api.multiCall({ abi: abis.asset, calls: pools });
+    const configs = await options.api.multiCall({
+      target: entrypoint,
+      abi: abis.assetConfig,
+      calls: [...new Set(assets.map(asset => asset.toLowerCase()))],
+    });
+
+    const poolToAsset = Object.fromEntries(pools.map((pool, i) => [pool, assets[i]]));
+    const poolToFeeBps = Object.fromEntries(configs.map((config: any) => [
+      String(config.pool ?? config[0]).toLowerCase(),
+      BigInt(config.vettingFeeBPS ?? config[2]),
+    ]));
+
+    deposits.forEach(log => {
+      const pool = log.pool.toLowerCase();
+      const feeBps = poolToFeeBps[pool];
+      if (!feeBps) return;
+
+      const fee = BigInt(log.amount) * feeBps / (BPS - feeBps);
+      dailyFees.add(token(poolToAsset[pool]), fee, METRICS.DEPOSIT_FEES);
+      dailyRevenue.add(token(poolToAsset[pool]), fee, METRICS.DEPOSIT_FEES);
+    });
+  }
+
+  const relays = await options.getLogs({ target: entrypoint, eventAbi: abis.withdrawalRelayed });
+  relays.forEach(log => {
+    dailyFees.add(token(log.asset), log.feeAmount, METRICS.RELAYER_FEES);
+    dailySupplySideRevenue.add(token(log.asset), log.feeAmount,METRICS.RELAYER_FEES);
+  });
+
+  return {
+    dailyFees,
+    dailyRevenue,
+    dailyProtocolRevenue: dailyRevenue,
+    dailySupplySideRevenue,
+  };
+}
+
+const methodology = {
+  Fees: "Deposit vetting fees retained by protocol plus relayer fees paid on withdrawals.",
+  Revenue: "Deposit vetting fees retained by the protocol.",
+  ProtocolRevenue: "Deposit vetting fees retained by the protocol.",
+  SupplySideRevenue: "Relayer fees paid to withdrawal relayers.",
+}
+
+const adapter: SimpleAdapter = {
   version: 2,
   pullHourly: true,
-  methodology: {
-    Fees: "Fees paid by users using privicy services."
+  fetch,
+  adapter: chainConfig,
+  methodology,
+  breakdownMethodology: {
+    Fees: {
+      [METRICS.DEPOSIT_FEES]: "Deposit fee deducted by the Entrypoint before funds are forwarded to the Privacy Pool.",
+      [METRICS.RELAYER_FEES]: "Fee paid to relayers when users withdraw through the Entrypoint relay.",
+    },
+    Revenue: {
+      [METRICS.DEPOSIT_FEES]: "Deposit vetting fees retained by the Entrypoint and withdrawable by the protocol owner.",
+    },
+    ProtocolRevenue: {
+      [METRICS.DEPOSIT_FEES]: "Deposit vetting fees retained by the Entrypoint and withdrawable by the protocol owner.",
+    },
+    SupplySideRevenue: {
+      [METRICS.RELAYER_FEES]: "Relayer fees paid to third-party relayers for processing private withdrawals.",
+    },
   },
 };
 
-Object.entries(config).forEach(([chain, { pools }]) => {
-  (adapters.adapter as BaseAdapter)[chain] = {
-    fetch: async (options: FetchOptions) => {
-      const dailyFees = options.createBalances();
-      const logs = await options.getLogs({
-        targets: pools,
-        eventAbi: "event FeesWithdrawn(address asset, address _recipient, uint256 amount)",
-      });
-
-      logs.forEach(log => {
-        dailyFees.add(log.asset, log.amount);
-      });
-
-      return {
-        dailyFees,
-      };
-    },
-  }
-});
-
-export default adapters;
+export default adapter;


### PR DESCRIPTION

Fixes fees for https://defillama.com/protocol/privacy-pools

## Summary
- Updates the Privacy Pools fees adapter to account for user-paid fees at the event level instead of protocol owner fee withdrawals.
- Adds full fees dashboard accounting for Ethereum, Arbitrum, and Optimism: fees, revenue, protocol revenue, and supply-side revenue.
- Website: https://privacypools.com
- Twitter/X: https://x.com/0xprivacypools

## Changes
- Updated `fees/privacy-pools.ts` to use a top-level `fetch` function with `adapter: chainConfig`.
- Added per-chain `entrypoint` and `start` config for Ethereum, Arbitrum, and Optimism.
- Replaced `FeesWithdrawn` tracking with:
  - `Deposited` events for protocol-retained deposit vetting fees.
  - `WithdrawalRelayed` events for relayer fees paid on relayed withdrawals.
- Uses multicalls to resolve pool assets via `ASSET()` and active fee settings via `assetConfig(asset)`.
- Normalizes Privacy Pools' native asset sentinel to `ADDRESSES.null` for native ETH pricing.
- Adds breakdown methodology labels for deposit vetting fees and relayer fees.

## Methodology
- `dailyFees` includes deposit vetting fees retained by the Entrypoint plus relayer fees paid by users on relayed withdrawals.
- `dailyRevenue` and `dailyProtocolRevenue` include deposit vetting fees retained by the protocol.
- `dailySupplySideRevenue` includes relayer fees paid to third-party relayers.
- Deposit fee amounts are reconstructed from the post-fee `Deposited.amount` and the configured `vettingFeeBPS`.
