### PR TITLE
Add Durianfun Launchpad + DurianAMM DEX volume/fees

### DIFF
--- a/dexs/durian-amm/index.ts
+++ b/dexs/durian-amm/index.ts
@@ -56,8 +56,7 @@
  *   dailyFees   = Σ fee        for every Swapped event
  *
  * Fees are split between the project treasury (~0.3 %) and the LP
- * share (~0.7 %), but DefiLlama tracks them in aggregate. There is
- * no governance token, so the treasury portion is realised revenue.
+ * share (~0.7 %)
  *
  * ── Discovery ──────────────────────────────────────────────────────
  *
@@ -74,6 +73,7 @@
 
 import { Adapter, FetchOptions } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
+import { METRIC } from "../../helpers/metrics";
 
 const FACTORY_V45  = "0xdf4f3dB298A9aDe853191F58b4b2a322D47EC005";
 const FACTORY_V466 = "0x89b6b73BD18dbEA0e2218c25c1963fd5FBaB3c87";
@@ -97,19 +97,22 @@ const fetch = async (options: FetchOptions) => {
   const { createBalances, getLogs } = options;
   const dailyVolume = createBalances();
   const dailyFees   = createBalances();
+  const dailySupplySideRevenue = createBalances();
+  const dailyRevenue   = createBalances();
 
   // 1) Enumerate every BCM market ever spawned (historical scan).
   const marketLogs = await Promise.all([
-    getLogs({ target: FACTORY_V45,  eventAbi: TOKEN_CREATED_ABI, fromBlock: 30_999_992 }),
-    getLogs({ target: FACTORY_V466, eventAbi: TOKEN_CREATED_ABI, fromBlock: 31_393_573 }),
+    getLogs({ target: FACTORY_V45,  eventAbi: TOKEN_CREATED_ABI, fromBlock: 30_999_992, cacheInCloud: true }),
+    getLogs({ target: FACTORY_V466, eventAbi: TOKEN_CREATED_ABI, fromBlock: 31_393_573, cacheInCloud: true }),
   ]);
+
   const markets: string[] = marketLogs
     .flat()
     .map((l: any) => (l.market ?? l[1]) as string)
     .filter((a) => a && a !== ZERO);
 
   if (markets.length === 0) {
-    return { dailyVolume, dailyFees, dailyRevenue: dailyFees };
+    return { dailyVolume, dailyFees, dailyRevenue, dailySupplySideRevenue };
   }
 
   // 2) Pull Graduated logs from those markets to discover AMM pools.
@@ -118,66 +121,61 @@ const fetch = async (options: FetchOptions) => {
     targets: markets,
     eventAbi: GRADUATED_ABI,
     fromBlock: 30_999_992,
+    cacheInCloud: true,
   });
   const pools: string[] = gradLogs
     .map((l: any) => (l.ammPool ?? l[2]) as string)
     .filter((a) => a && a !== ZERO);
 
   if (pools.length === 0) {
-    return { dailyVolume, dailyFees, dailyRevenue: dailyFees };
+    return { dailyVolume, dailyFees, dailyRevenue, dailySupplySideRevenue };
   }
-
   // 3) Sum Swapped events from every discovered pool in the daily window.
   const swaps = await getLogs({ targets: pools, eventAbi: SWAPPED_ABI });
 
   for (const log of swaps) {
     const kubForToken = (log as any).kubForToken;
-    const amountIn    = BigInt((log as any).amountIn.toString());
-    const amountOut   = BigInt((log as any).amountOut.toString());
-    const fee         = BigInt((log as any).fee.toString());
+    const amountIn    = BigInt((log as any).amountIn);
+    const amountOut   = BigInt((log as any).amountOut);
+    const fee         = BigInt((log as any).fee);
+    const treasury = (fee * 3n) / 10n;
 
     // Gross KUB notional.
     const volumeKub = kubForToken ? amountIn : (amountOut + fee);
 
-    dailyVolume.add(KKUB, volumeKub.toString());
-    dailyFees.add(KKUB, fee.toString());
+    dailyVolume.add(KKUB, volumeKub);
+    dailyFees.add(KKUB, fee, METRIC.SWAP_FEES);
+    dailyRevenue.add(KKUB, treasury, METRIC.SWAP_FEES);
+    dailySupplySideRevenue.add(KKUB, fee - treasury, METRIC.LP_FEES);
   }
 
-  return { dailyVolume, dailyFees, dailyRevenue: dailyFees };
+  return { dailyVolume, dailyFees, dailyRevenue, dailySupplySideRevenue };
 };
 
 const adapter: Adapter = {
   version: 2,
+  pullHourly: true,
   adapter: {
     [CHAIN.BITKUB]: {
       fetch,
-      // V4.5 factory deploy block 30,999,992 / 2026-04-29.
-      // V4.6.6 spawns later (block 31,393,573) — covered by the same
-      // start because its markets graduate strictly after this date.
       start: "2026-04-29",
-      meta: {
-        methodology: {
-          Volume:
-            "Sum of gross KUB notional from every Swapped event emitted by " +
-            "DurianAMM pools that BondingCurveMarket contracts graduated " +
-            "into. For KUB→token swaps, amountIn is used directly (already " +
-            "gross). For token→KUB swaps, amountOut + fee is used (because " +
-            "amountOut is the net amount the user received after fee). " +
-            "Pools are discovered by scanning Graduated events emitted by " +
-            "BCMs from the V4.5 factory (0xdf4f…C005) and V4.6.6 factory " +
-            "(0x89b6…3c87). Amounts are credited to KKUB and priced via " +
-            "DefiLlama's Bitkub Chain oracle.",
-          Fees:
-            "Sum of the on-chain `fee` field of every Swapped event. " +
-            "Aggregates the treasury share (~0.3 % of gross) and the LP " +
-            "share (~0.7 % of gross), denominated in native KUB.",
-          Revenue:
-            "Equal to Fees. There is no governance token and no " +
-            "external rebate program; both the treasury cut and the LP " +
-            "cut are realised on-chain protocol revenue from the issuer's " +
-            "point of view.",
-        },
-      },
+    },
+  },
+  methodology: {
+    Volume: `Sum of gross KUB notional from every Swapped event emitted by graduated DurianAMM pools`,
+    Fees: "1% fee on every swap",
+    Revenue: "30% of the 1% fee is kept by the protocol treasury",
+    SupplySideRevenue: "70% of the 1% fee goes to liquidity providers",
+  },
+  breakdownMethodology: {
+    Fees: {
+      [METRIC.SWAP_FEES]: "1% trading fee on every swap.",
+    },
+    Revenue: {
+      [METRIC.SWAP_FEES]: "30% of the 1% trading fee is kept by the protocol treasury.",
+    },
+    SupplySideRevenue: {
+      [METRIC.LP_FEES]:   "70% of the 1% trading fee goes to liquidity providers.",
     },
   },
 };

--- a/dexs/durian-amm/index.ts
+++ b/dexs/durian-amm/index.ts
@@ -1,0 +1,185 @@
+/**
+ * Durian AMM — post-graduation constant-product DEX adapter.
+ *
+ * PR target: https://github.com/DefiLlama/dimension-adapters
+ * Final path: `dexs/durian-amm/index.ts`
+ *
+ * ── Protocol ───────────────────────────────────────────────────────
+ *
+ * When a Durianfun bonding-curve market hits its graduation
+ * threshold, the BondingCurveMarket (BCM) contract migrates its
+ * reserves to a freshly-deployed `DurianAMM` pool — a single-pair
+ * constant-product AMM that quotes one launchpad token against
+ * native KUB. Each market graduates into its own dedicated AMM
+ * contract; there is no shared factory and no LP token registry.
+ *
+ * Two factory generations spawn BCM markets that graduate into
+ * `DurianAMMV45` and `DurianAMMV466` respectively. The two AMM
+ * contracts emit byte-for-byte identical `Swapped` event ABIs,
+ * so a single adapter covers both.
+ *
+ * ── Event ABIs (confirmed identical V4.5 ⇄ V4.6.6) ─────────────────
+ *
+ *   BCM.Graduated(
+ *       address indexed market,
+ *       address indexed token,
+ *       address indexed ammPool,
+ *       uint256 kubRaised,
+ *       uint256 treasuryFee,
+ *       uint256 creatorReward)
+ *
+ *   AMM.Swapped(
+ *       address indexed trader,
+ *       bool    indexed kubForToken,
+ *       uint256 amountIn,         ← gross if kubForToken (KUB in)
+ *       uint256 amountOut,        ← net  if !kubForToken (KUB out, post-fee)
+ *       uint256 fee,              ← treasury + LP share, in KUB
+ *       uint256 newReserveKub,
+ *       uint256 newReserveToken)
+ *
+ *   Factory.TokenCreated(
+ *       address indexed token,
+ *       address indexed market,
+ *       address indexed creator,
+ *       string name, string symbol,
+ *       uint256 totalSupply, uint256 timestamp)
+ *
+ * ── Volume / Fees methodology ──────────────────────────────────────
+ *
+ *   kubForToken == true   (user buys token with KUB):
+ *       volumeKub = amountIn          (already gross)
+ *
+ *   kubForToken == false  (user sells token for KUB):
+ *       volumeKub = amountOut + fee   (re-add fee to get gross)
+ *
+ *   dailyVolume = Σ volumeKub  for every Swapped event
+ *   dailyFees   = Σ fee        for every Swapped event
+ *
+ * Fees are split between the project treasury (~0.3 %) and the LP
+ * share (~0.7 %), but DefiLlama tracks them in aggregate. There is
+ * no governance token, so the treasury portion is realised revenue.
+ *
+ * ── Discovery ──────────────────────────────────────────────────────
+ *
+ * Pools are *not* tracked by any registry. We discover them by:
+ *   1. Listing every BCM market spawned by either factory
+ *      (TokenCreated since each factory's deploy block).
+ *   2. Reading the `Graduated` event from each market — its 3rd
+ *      indexed param is the AMM pool address.
+ *
+ * This is done historically (since genesis) on every fetch call,
+ * so newly-graduated pools are picked up automatically. Per-day
+ * `Swapped` logs are fetched in the daily window via `getLogs`.
+ */
+
+import { Adapter, FetchOptions } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+
+const FACTORY_V45  = "0xdf4f3dB298A9aDe853191F58b4b2a322D47EC005";
+const FACTORY_V466 = "0x89b6b73BD18dbEA0e2218c25c1963fd5FBaB3c87";
+
+// KKUB (wrapped KUB) — used to price native-KUB notionals in USD via
+// DefiLlama's Bitkub Chain oracle.
+const KKUB = "0x67eBD850304c70d983B2d1b93ea79c7CD6c3F6b5";
+
+const TOKEN_CREATED_ABI =
+  "event TokenCreated(address indexed token, address indexed market, address indexed creator, string name, string symbol, uint256 totalSupply, uint256 timestamp)";
+
+const GRADUATED_ABI =
+  "event Graduated(address indexed market, address indexed token, address indexed ammPool, uint256 kubRaised, uint256 treasuryFee, uint256 creatorReward)";
+
+const SWAPPED_ABI =
+  "event Swapped(address indexed trader, bool indexed kubForToken, uint256 amountIn, uint256 amountOut, uint256 fee, uint256 newReserveKub, uint256 newReserveToken)";
+
+const ZERO = "0x0000000000000000000000000000000000000000";
+
+const fetch = async (options: FetchOptions) => {
+  const { createBalances, getLogs } = options;
+  const dailyVolume = createBalances();
+  const dailyFees   = createBalances();
+
+  // 1) Enumerate every BCM market ever spawned (historical scan).
+  const marketLogs = await Promise.all([
+    getLogs({ target: FACTORY_V45,  eventAbi: TOKEN_CREATED_ABI, fromBlock: 30_999_992 }),
+    getLogs({ target: FACTORY_V466, eventAbi: TOKEN_CREATED_ABI, fromBlock: 31_393_573 }),
+  ]);
+  const markets: string[] = marketLogs
+    .flat()
+    .map((l: any) => (l.market ?? l[1]) as string)
+    .filter((a) => a && a !== ZERO);
+
+  if (markets.length === 0) {
+    return { dailyVolume, dailyFees, dailyRevenue: dailyFees };
+  }
+
+  // 2) Pull Graduated logs from those markets to discover AMM pools.
+  //    Many markets never graduate — that's fine, they emit nothing.
+  const gradLogs = await getLogs({
+    targets: markets,
+    eventAbi: GRADUATED_ABI,
+    fromBlock: 30_999_992,
+  });
+  const pools: string[] = gradLogs
+    .map((l: any) => (l.ammPool ?? l[2]) as string)
+    .filter((a) => a && a !== ZERO);
+
+  if (pools.length === 0) {
+    return { dailyVolume, dailyFees, dailyRevenue: dailyFees };
+  }
+
+  // 3) Sum Swapped events from every discovered pool in the daily window.
+  const swaps = await getLogs({ targets: pools, eventAbi: SWAPPED_ABI });
+
+  for (const log of swaps) {
+    const kubForToken = (log as any).kubForToken;
+    const amountIn    = BigInt((log as any).amountIn.toString());
+    const amountOut   = BigInt((log as any).amountOut.toString());
+    const fee         = BigInt((log as any).fee.toString());
+
+    // Gross KUB notional.
+    const volumeKub = kubForToken ? amountIn : (amountOut + fee);
+
+    dailyVolume.add(KKUB, volumeKub.toString());
+    dailyFees.add(KKUB, fee.toString());
+  }
+
+  return { dailyVolume, dailyFees, dailyRevenue: dailyFees };
+};
+
+const adapter: Adapter = {
+  version: 2,
+  adapter: {
+    [CHAIN.BITKUB]: {
+      fetch,
+      // V4.5 factory deploy block 30,999,992 / 2026-04-29.
+      // V4.6.6 spawns later (block 31,393,573) — covered by the same
+      // start because its markets graduate strictly after this date.
+      start: "2026-04-29",
+      meta: {
+        methodology: {
+          Volume:
+            "Sum of gross KUB notional from every Swapped event emitted by " +
+            "DurianAMM pools that BondingCurveMarket contracts graduated " +
+            "into. For KUB→token swaps, amountIn is used directly (already " +
+            "gross). For token→KUB swaps, amountOut + fee is used (because " +
+            "amountOut is the net amount the user received after fee). " +
+            "Pools are discovered by scanning Graduated events emitted by " +
+            "BCMs from the V4.5 factory (0xdf4f…C005) and V4.6.6 factory " +
+            "(0x89b6…3c87). Amounts are credited to KKUB and priced via " +
+            "DefiLlama's Bitkub Chain oracle.",
+          Fees:
+            "Sum of the on-chain `fee` field of every Swapped event. " +
+            "Aggregates the treasury share (~0.3 % of gross) and the LP " +
+            "share (~0.7 % of gross), denominated in native KUB.",
+          Revenue:
+            "Equal to Fees. There is no governance token and no " +
+            "external rebate program; both the treasury cut and the LP " +
+            "cut are realised on-chain protocol revenue from the issuer's " +
+            "point of view.",
+        },
+      },
+    },
+  },
+};
+
+export default adapter;

--- a/dexs/durianfun-launchpad/index.ts
+++ b/dexs/durianfun-launchpad/index.ts
@@ -1,0 +1,179 @@
+/**
+ * Durianfun Launchpad — bonding-curve DEX adapter.
+ *
+ * PR target: https://github.com/DefiLlama/dimension-adapters
+ * Final path: `dexs/durianfun-launchpad/index.ts`
+ *
+ * ── Protocol ───────────────────────────────────────────────────────
+ *
+ * Durianfun is a pump.fun-style exponential bonding-curve launchpad
+ * on Bitkub Chain (chainId 96). Each token launched by the factory
+ * spawns its own `BondingCurveMarket` contract that price-discovers
+ * via a sealed reserve until the graduation threshold, after which
+ * liquidity is migrated to a `DurianAMM` pool (covered by a separate
+ * adapter, `durian-amm`).
+ *
+ * Two generations of the factory are LIVE and indexed together so the
+ * volume series is continuous:
+ *
+ *   V4.5   — `0xdf4f3dB298A9aDe853191F58b4b2a322D47EC005` (deploy
+ *            block 30,999,992 / 2026-04-29). Fee = 0.9 % treasury +
+ *            0.1 % creator = 1.0 % total. Verified.
+ *   V4.6.6 — `0x89b6b73BD18dbEA0e2218c25c1963fd5FBaB3c87` (deploy
+ *            block 31,393,573). Same event ABIs; adds referral
+ *            routing but trade-side events are byte-for-byte
+ *            identical to V4.5.
+ *
+ * ── Event ABIs (confirmed identical V4.5 ⇄ V4.6.6) ─────────────────
+ *
+ *   Factory.TokenCreated(
+ *       address indexed token,
+ *       address indexed market,
+ *       address indexed creator,
+ *       string name, string symbol,
+ *       uint256 totalSupply, uint256 timestamp)
+ *
+ *   Market.TokensBought(
+ *       address indexed buyer,
+ *       uint256 kubIn,        ← gross KUB spent (includes fee)
+ *       uint256 tokensOut,
+ *       uint256 fee,          ← treasury + creator share, in KUB
+ *       uint256 newKubRaised,
+ *       uint256 price)
+ *
+ *   Market.TokensSold(
+ *       address indexed seller,
+ *       uint256 tokensIn,
+ *       uint256 kubOut,       ← NET KUB the user received (fee already taken)
+ *       uint256 fee,          ← treasury + creator share, in KUB
+ *       uint256 newKubRaised,
+ *       uint256 price)
+ *
+ * ── Volume / Fees methodology ──────────────────────────────────────
+ *
+ *   dailyVolume  = Σ buy.kubIn  +  Σ (sell.kubOut + sell.fee)
+ *                  (gross KUB notional, matching the convention used
+ *                   by Uniswap-style adapters in this repo)
+ *   dailyFees    = Σ buy.fee    +  Σ sell.fee
+ *   dailyRevenue = dailyFees                ← 100 % captured by the
+ *                                              project treasury +
+ *                                              token creator; no LP
+ *                                              and no governance
+ *                                              token to dilute.
+ *
+ * Amounts are denominated in native KUB; we credit them to KKUB
+ * (0x67eBD8…F6b5) so DefiLlama's per-chain oracle prices them in USD.
+ *
+ * ── Why we enumerate markets via TokenCreated ──────────────────────
+ *
+ * Each BCM is a fresh contract; we discover them by scanning every
+ * `TokenCreated` log emitted by either factory since genesis (NOT
+ * limited to the daily window — DefiLlama's `getLogs` with no
+ * fromBlock fetches the per-day window for the trade events, but we
+ * need ALL historical markets so trades in surviving (pre-grad)
+ * markets are still indexed today).
+ */
+
+import { Adapter, FetchOptions } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+
+const FACTORY_V45  = "0xdf4f3dB298A9aDe853191F58b4b2a322D47EC005";
+const FACTORY_V466 = "0x89b6b73BD18dbEA0e2218c25c1963fd5FBaB3c87";
+
+// KKUB (wrapped KUB) — the priced token DefiLlama's Bitkub oracle
+// resolves. Native-KUB amounts are credited to this address.
+const KKUB = "0x67eBD850304c70d983B2d1b93ea79c7CD6c3F6b5";
+
+const TOKEN_CREATED_ABI =
+  "event TokenCreated(address indexed token, address indexed market, address indexed creator, string name, string symbol, uint256 totalSupply, uint256 timestamp)";
+
+const TOKENS_BOUGHT_ABI =
+  "event TokensBought(address indexed buyer, uint256 kubIn, uint256 tokensOut, uint256 fee, uint256 newKubRaised, uint256 price)";
+
+const TOKENS_SOLD_ABI =
+  "event TokensSold(address indexed seller, uint256 tokensIn, uint256 kubOut, uint256 fee, uint256 newKubRaised, uint256 price)";
+
+const fetch = async (options: FetchOptions) => {
+  const { createBalances, getLogs } = options;
+  const dailyVolume = createBalances();
+  const dailyFees   = createBalances();
+
+  // 1) Enumerate every BCM market spawned by either factory.
+  //    `fromBlock: 0` here means "from each factory's deploy block";
+  //    the dimension-adapters helper handles per-chain genesis offsets,
+  //    but we pass `entireLog: true` so we get all historical markets,
+  //    not just today's freshly-created ones.
+  const factoryLogs = await Promise.all([
+    getLogs({ target: FACTORY_V45,  eventAbi: TOKEN_CREATED_ABI, onlyArgs: true, entireLog: false, fromBlock: 30_999_992 }),
+    getLogs({ target: FACTORY_V466, eventAbi: TOKEN_CREATED_ABI, onlyArgs: true, entireLog: false, fromBlock: 31_393_573 }),
+  ]);
+  const markets: string[] = factoryLogs
+    .flat()
+    .map((l: any) => (l.market ?? l[1]) as string)
+    .filter((a) => a && a !== "0x0000000000000000000000000000000000000000");
+
+  if (markets.length === 0) {
+    return { dailyVolume, dailyFees, dailyRevenue: dailyFees };
+  }
+
+  // 2) Pull TokensBought + TokensSold from every market in the daily
+  //    window. `getLogs` with `targets:` fans out across markets and
+  //    transparently chunks per-RPC limits.
+  const [buys, sells] = await Promise.all([
+    getLogs({ targets: markets, eventAbi: TOKENS_BOUGHT_ABI }),
+    getLogs({ targets: markets, eventAbi: TOKENS_SOLD_ABI }),
+  ]);
+
+  for (const log of buys) {
+    // Gross KUB volume — `kubIn` already includes the fee.
+    dailyVolume.add(KKUB, (log as any).kubIn);
+    dailyFees.add(KKUB,   (log as any).fee);
+  }
+
+  for (const log of sells) {
+    // `kubOut` is NET (post-fee). Gross = kubOut + fee.
+    const kubOut = BigInt((log as any).kubOut.toString());
+    const fee    = BigInt((log as any).fee.toString());
+    dailyVolume.add(KKUB, (kubOut + fee).toString());
+    dailyFees.add(KKUB,   fee.toString());
+  }
+
+  return { dailyVolume, dailyFees, dailyRevenue: dailyFees };
+};
+
+const adapter: Adapter = {
+  version: 2,
+  adapter: {
+    [CHAIN.BITKUB]: {
+      fetch,
+      // First V4.5 market was created at block 30,999,992 on
+      // 2026-04-29 (factory deploy tx).
+      start: "2026-04-29",
+      meta: {
+        methodology: {
+          Volume:
+            "Sum of gross KUB notional from every TokensBought / TokensSold " +
+            "event emitted by BondingCurveMarket contracts spawned by the " +
+            "V4.5 factory (0xdf4f…C005) and V4.6.6 factory (0x89b6…3c87). " +
+            "Buy volume = kubIn (gross, fee inclusive); sell volume = " +
+            "kubOut + fee (gross, fee re-added because kubOut is post-fee). " +
+            "Amounts are credited to KKUB and priced via DefiLlama's Bitkub " +
+            "Chain oracle. Both factory generations share byte-identical " +
+            "trade event ABIs and are summed into a single series.",
+          Fees:
+            "Sum of the on-chain `fee` field of every TokensBought / " +
+            "TokensSold event. Equal to 0.9 % treasury + 0.1 % creator = " +
+            "1.0 % of gross KUB notional under V4.5; V4.6.6 keeps the same " +
+            "1.0 % aggregate split. Field denominated in native KUB.",
+          Revenue:
+            "Equal to Fees. 100 % of trading fees accrue to the protocol " +
+            "treasury and token creator — there are no LPs to share with " +
+            "during the bonding-curve phase and no governance-token " +
+            "emissions diluting the take.",
+        },
+      },
+    },
+  },
+};
+
+export default adapter;

--- a/dexs/durianfun-launchpad/index.ts
+++ b/dexs/durianfun-launchpad/index.ts
@@ -49,21 +49,6 @@
  *       uint256 newKubRaised,
  *       uint256 price)
  *
- * ── Volume / Fees methodology ──────────────────────────────────────
- *
- *   dailyVolume  = Σ buy.kubIn  +  Σ (sell.kubOut + sell.fee)
- *                  (gross KUB notional, matching the convention used
- *                   by Uniswap-style adapters in this repo)
- *   dailyFees    = Σ buy.fee    +  Σ sell.fee
- *   dailyRevenue = dailyFees                ← 100 % captured by the
- *                                              project treasury +
- *                                              token creator; no LP
- *                                              and no governance
- *                                              token to dilute.
- *
- * Amounts are denominated in native KUB; we credit them to KKUB
- * (0x67eBD8…F6b5) so DefiLlama's per-chain oracle prices them in USD.
- *
  * ── Why we enumerate markets via TokenCreated ──────────────────────
  *
  * Each BCM is a fresh contract; we discover them by scanning every
@@ -76,6 +61,7 @@
 
 import { Adapter, FetchOptions } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
+import { METRIC } from "../../helpers/metrics"
 
 const FACTORY_V45  = "0xdf4f3dB298A9aDe853191F58b4b2a322D47EC005";
 const FACTORY_V466 = "0x89b6b73BD18dbEA0e2218c25c1963fd5FBaB3c87";
@@ -97,28 +83,20 @@ const fetch = async (options: FetchOptions) => {
   const { createBalances, getLogs } = options;
   const dailyVolume = createBalances();
   const dailyFees   = createBalances();
+  const dailyRevenue = createBalances();
+  const dailySupplySideRevenue   = createBalances();
 
   // 1) Enumerate every BCM market spawned by either factory.
-  //    `fromBlock: 0` here means "from each factory's deploy block";
-  //    the dimension-adapters helper handles per-chain genesis offsets,
-  //    but we pass `entireLog: true` so we get all historical markets,
-  //    not just today's freshly-created ones.
   const factoryLogs = await Promise.all([
-    getLogs({ target: FACTORY_V45,  eventAbi: TOKEN_CREATED_ABI, onlyArgs: true, entireLog: false, fromBlock: 30_999_992 }),
-    getLogs({ target: FACTORY_V466, eventAbi: TOKEN_CREATED_ABI, onlyArgs: true, entireLog: false, fromBlock: 31_393_573 }),
+    getLogs({ target: FACTORY_V45,  eventAbi: TOKEN_CREATED_ABI, onlyArgs: true, entireLog: false, fromBlock: 30_999_992, cacheInCloud: true }),
+    getLogs({ target: FACTORY_V466, eventAbi: TOKEN_CREATED_ABI, onlyArgs: true, entireLog: false, fromBlock: 31_393_573, cacheInCloud: true }),
   ]);
   const markets: string[] = factoryLogs
     .flat()
     .map((l: any) => (l.market ?? l[1]) as string)
     .filter((a) => a && a !== "0x0000000000000000000000000000000000000000");
 
-  if (markets.length === 0) {
-    return { dailyVolume, dailyFees, dailyRevenue: dailyFees };
-  }
-
   // 2) Pull TokensBought + TokensSold from every market in the daily
-  //    window. `getLogs` with `targets:` fans out across markets and
-  //    transparently chunks per-RPC limits.
   const [buys, sells] = await Promise.all([
     getLogs({ targets: markets, eventAbi: TOKENS_BOUGHT_ABI }),
     getLogs({ targets: markets, eventAbi: TOKENS_SOLD_ABI }),
@@ -126,52 +104,53 @@ const fetch = async (options: FetchOptions) => {
 
   for (const log of buys) {
     // Gross KUB volume — `kubIn` already includes the fee.
-    dailyVolume.add(KKUB, (log as any).kubIn);
-    dailyFees.add(KKUB,   (log as any).fee);
+    const kubIn = BigInt((log as any).kubIn);
+    const fee = BigInt((log as any).fee);
+    const treasury = (fee * 9n) / 10n;  
+    dailyVolume.add(KKUB, kubIn);
+    dailyFees.add(KKUB,fee, METRIC.SWAP_FEES);
+    dailyRevenue.add(KKUB, treasury, METRIC.SWAP_FEES);
+    dailySupplySideRevenue.add(KKUB, fee - treasury, METRIC.CREATOR_FEES);
   }
 
   for (const log of sells) {
     // `kubOut` is NET (post-fee). Gross = kubOut + fee.
-    const kubOut = BigInt((log as any).kubOut.toString());
-    const fee    = BigInt((log as any).fee.toString());
-    dailyVolume.add(KKUB, (kubOut + fee).toString());
-    dailyFees.add(KKUB,   fee.toString());
+    const kubOut = BigInt((log as any).kubOut);
+    const fee    = BigInt((log as any).fee);
+    const treasury = (fee * 9n) / 10n;
+    dailyVolume.add(KKUB, (kubOut + fee));
+    dailyFees.add(KKUB, fee, METRIC.SWAP_FEES);
+    dailyRevenue.add(KKUB, treasury, METRIC.SWAP_FEES);
+    dailySupplySideRevenue.add(KKUB, fee - treasury, METRIC.CREATOR_FEES);
   }
 
-  return { dailyVolume, dailyFees, dailyRevenue: dailyFees };
+  return { dailyVolume, dailyFees, dailyRevenue, dailySupplySideRevenue };
 };
 
 const adapter: Adapter = {
   version: 2,
+  pullHourly: true,
   adapter: {
     [CHAIN.BITKUB]: {
       fetch,
-      // First V4.5 market was created at block 30,999,992 on
-      // 2026-04-29 (factory deploy tx).
       start: "2026-04-29",
-      meta: {
-        methodology: {
-          Volume:
-            "Sum of gross KUB notional from every TokensBought / TokensSold " +
-            "event emitted by BondingCurveMarket contracts spawned by the " +
-            "V4.5 factory (0xdf4f…C005) and V4.6.6 factory (0x89b6…3c87). " +
-            "Buy volume = kubIn (gross, fee inclusive); sell volume = " +
-            "kubOut + fee (gross, fee re-added because kubOut is post-fee). " +
-            "Amounts are credited to KKUB and priced via DefiLlama's Bitkub " +
-            "Chain oracle. Both factory generations share byte-identical " +
-            "trade event ABIs and are summed into a single series.",
-          Fees:
-            "Sum of the on-chain `fee` field of every TokensBought / " +
-            "TokensSold event. Equal to 0.9 % treasury + 0.1 % creator = " +
-            "1.0 % of gross KUB notional under V4.5; V4.6.6 keeps the same " +
-            "1.0 % aggregate split. Field denominated in native KUB.",
-          Revenue:
-            "Equal to Fees. 100 % of trading fees accrue to the protocol " +
-            "treasury and token creator — there are no LPs to share with " +
-            "during the bonding-curve phase and no governance-token " +
-            "emissions diluting the take.",
-        },
-      },
+    },
+  },
+  methodology: {
+    Volume: `Sum of gross KUB notional from every TokensBought / TokensSold event emitted by BondingCurveMarket contracts`,
+    Fees: "1% fee on every swap",
+    Revenue: "90% of the 1% fee is kept by the protocol",
+    SupplySideRevenue: "10% of the 1% fee goes to token creators",
+  },
+  breakdownMethodology: {
+    Fees: {
+      [METRIC.SWAP_FEES]:    "1% fee on every swap.",
+    },
+    Revenue: {
+      [METRIC.SWAP_FEES]:    "90% of the 1% trading fee is kept by the protocol.",
+    },
+    SupplySideRevenue: {
+      [METRIC.CREATOR_FEES]: "10% of the 1% trading fee goes to token creators.",
     },
   },
 };


### PR DESCRIPTION
## Durianfun Launchpad + DurianAMM — DEX volume + fees

Adds two DEX adapters for Durianfun's native trading surfaces on Bitkub Chain. Companion to the existing aggregator dimension adapter (#6944) and TVL adapters (DefiLlama-Adapters #19263).

### A) `dexs/durianfun-launchpad` — Bonding-curve DEX volume
- Indexes `TokensBought` + `TokensSold` events from every market spawned by V4.5 + V4.6.6 factories
- Volume = KUB notional per trade (fee-inclusive on the buy side, fee-re-added on the sell side)
- Fees = on-chain `fee` field from each event
- Revenue = fees

### B) `dexs/durian-amm` — Graduated-token AMM volume
- Indexes `Swapped` events from every DurianAMM pool created when a bonding-curve market graduates
- Pool discovery: factory → `TokenCreated` (markets) → `Graduated` (AMM pools)
- Volume = KUB-side notional (`amountIn` when `kubForToken=true`, else `amountOut + fee`)
- Fees from event `fee` field

### Chain
- **Bitkub Chain** (chainId 96, key `bitkub` — already registered, adapter `durianfun` exists upstream)

### V4.5 vs V4.6.6
Trade events are **byte-identical** between V4.5 and V4.6.6 — single ABI handles both. V4.6.6 adds additional events (`ReferralPaid`, `PaymentAccrued`, `Skimmed`) that don't affect volume/fee accounting and are ignored.

### Contracts (KUB Mainnet chainId 96)

- Launchpad V4.5 factory: `0xdf4f3dB298A9aDe853191F58b4b2a322D47EC005` (start block 30,999,992 · 2026-04-29)
- Launchpad V4.6.6 factory: `0x89b6b73BD18dbEA0e2218c25c1963fd5FBaB3c87` (start block 31,393,573 · 2026-04-30)
- DurianAMM pools — discovered dynamically via `Graduated` events from both BCM versions

### Project info

- Website: https://durianfun.xyz
- Twitter: @durianfunlabs
- Docs: https://durianandfun.gitbook.io/durianfun/
- Logo: https://durianfun.xyz/og-image-v2.png

### Note on double-counting with aggregator (#6944)

Trades routed through the DurianAggregator router emit `Swapped` on the router AND `TokensBought`/`TokensSold` on the underlying BCM. This is the standard DEX-vs-aggregator pattern (Uniswap vs 1inch on DefiLlama) — each adapter sums its own venue, and DefiLlama's UI categorizes them under separate pages (DEX list vs Aggregator list).
