### PR TITLE
fix(users): price dailyGasUsed via native gas token

### DIFF
--- a/users/list.ts
+++ b/users/list.ts
@@ -38,16 +38,23 @@ function getProtocolActiveUsersAdapter(item: typeof routers[0]): Adapter {
     return parseUserResponse(data, item.chains);
   }
 
-  async function fetch(_: any, _1: any, { chain, preFetchedResults, }: FetchOptions) {
+  async function fetch(_: any, _1: any, { chain, preFetchedResults, createBalances }: FetchOptions) {
     if (chain === CHAIN.CHAIN_GLOBAL)
       return {
         dailyActiveUsers: preFetchedResults?.all.users
       }
 
+    // `gas` is the per-chain total tx fee in wei (gas_price * gas_used summed in SQL).
+    // Wrap it in a Balances object via addGasToken so the framework prices it through
+    // the chain's native gas token instead of treating the raw quantity as USD.
+    const gasWei = preFetchedResults?.[chain]?.gas
+    const dailyGasUsed = createBalances()
+    if (gasWei) dailyGasUsed.addGasToken(gasWei)
+
     return {
       dailyActiveUsers: preFetchedResults?.[chain]?.users,
       dailyTransactionsCount: preFetchedResults?.[chain]?.txs,
-      dailyGasUsed: preFetchedResults?.[chain]?.gas,
+      dailyGasUsed,
     }
   }
 

--- a/users/utils/countUsers.ts
+++ b/users/utils/countUsers.ts
@@ -89,7 +89,7 @@ WITH
         ),
         ${chain}_total AS (
             SELECT
-              sum(TX_FEE)/1e18 AS ${chain}_total_gas,
+              TO_VARCHAR(sum(TX_FEE)) AS ${chain}_total_gas,
               count(HASH) AS ${chain}_tx_count
             FROM
             ${chain}


### PR DESCRIPTION
## Summary
- `users/utils/countUsers.ts` was dividing the per-tx fee sum by `1e18` and the resulting native-token quantity was passed straight to `dailyGasUsed`, which the dimension framework treats as a USD value. Result: 1 unit of gas token counted as 1 USD — inflating chains where the gas token is worth < $1.
- Concrete impact on Polymarket (Polygon-only): MATIC ≈ $0.09–0.08, so reported `dailyGasUsed` was roughly **10× the real USD cost**. The same code path also *under*-reports for ETH-priced chains (1 ETH shown as $1).
- Fix keeps the sum in wei (cast to string via `TO_VARCHAR` to avoid JS `Number.MAX_SAFE_INTEGER` truncation — Allium stores `gas_price` / `receipt_gas_used` as `NUMBER(38,0)`, so products of a busy day blow past 2^53), then wraps it in `createBalances().addGasToken(...)` so the framework prices it via each chain's native gas token. This mirrors the pattern used in `fees/chainlink-vrf-v1.ts`.

## Validation
- Allium docs confirm units across Ethereum / Polygon / HyperEVM `raw.transactions`:
  - `gas_price`, `receipt_effective_gas_price` → wei per gas unit
  - `receipt_gas_used` → gas units
  - All stored as `NUMBER(38,0)`
- `gas_price * receipt_gas_used` → wei, exactly what `addGasToken` expects.
