### PR TITLE
[fix] aegis: track yields/fees for jusd, sjusd, yusd and syusd 

### DIFF
--- a/fees/aegis-jusd/index.ts
+++ b/fees/aegis-jusd/index.ts
@@ -37,7 +37,7 @@ const fetch = async (options: FetchOptions) => {
   const dailySupplySideRevenue = options.createBalances()
   const dailyUserFees = options.createBalances()
   const mintRedeemTargets = config.mintRedeem.map(({ target }) => target)
-  const activeVaults = config.vaults.filter(({ start }) => !start || options.startTimestamp >= Date.parse(start) / 1000)
+  const activeVaults = config.vaults.filter(({ start }) => !start || options.dateString >= start)
   const vaultTargets = activeVaults.map(({ target }) => target)
 
   const [mintLogs, redeemLogs] = await Promise.all([

--- a/fees/aegis-jusd/index.ts
+++ b/fees/aegis-jusd/index.ts
@@ -26,9 +26,9 @@ const abi = {
 }
 
 const METRICS = {
-  jusdInsuranceMintRedeem: "JUSD Mint/Redeem Fees",
+  jusdMintRedeem: "JUSD Mint/Redeem Fees",
   sjusdStakersYield: "sJUSD Staker Yield",
-  sjusdInsuranceInstantUnstaking: "sJUSD Unstaking Fees",
+  sjusdInstantUnstaking: "sJUSD Unstaking Fees",
 }
 
 const fetch = async (options: FetchOptions) => {
@@ -49,7 +49,7 @@ const fetch = async (options: FetchOptions) => {
     const feeUsd = Number(log.fee) / 1e18
     dailyFees.addUSDValue(feeUsd, METRIC.MINT_REDEEM_FEES)
     dailyUserFees.addUSDValue(feeUsd, METRIC.MINT_REDEEM_FEES)
-    dailySupplySideRevenue.addUSDValue(feeUsd, METRICS.jusdInsuranceMintRedeem)
+    dailySupplySideRevenue.addUSDValue(feeUsd, METRICS.jusdMintRedeem)
   })
 
   const instantTargets = activeVaults.filter(({ instant }) => instant).map(({ target }) => target)
@@ -72,17 +72,14 @@ const fetch = async (options: FetchOptions) => {
     (sum, [asset, value]) => sum + Number(value) / 10 ** (decimalsByAsset[asset.toLowerCase()] ?? 18),
     0,
   )
-
-  if (vaultYieldUsd > 0) {
     dailyFees.addUSDValue(vaultYieldUsd, METRIC.ASSETS_YIELDS)
     dailySupplySideRevenue.addUSDValue(vaultYieldUsd, METRICS.sjusdStakersYield)
-  }
 
   instantLogs.forEach((log: any) => {
     const feeUsd = Number(log.fee) / 1e18
     dailyFees.addUSDValue(feeUsd, METRIC.DEPOSIT_WITHDRAW_FEES)
     dailyUserFees.addUSDValue(feeUsd, METRIC.DEPOSIT_WITHDRAW_FEES)
-    dailySupplySideRevenue.addUSDValue(feeUsd, METRICS.sjusdInsuranceInstantUnstaking)
+    dailySupplySideRevenue.addUSDValue(feeUsd, METRICS.sjusdInstantUnstaking)
   })
 
   return { dailyFees, dailyRevenue: 0, dailySupplySideRevenue, dailyUserFees }
@@ -92,6 +89,7 @@ const adapter: SimpleAdapter = {
   version: 2,
   pullHourly: true,
   adapter: chainConfig,
+  allowNegativeValue: true,
   fetch,
   methodology: {
     Fees: "sJUSD vault yield, JUSD mint and redeem fees, and sJUSD instant unstaking fees, all treated as USD-denominated stablecoin flows.",
@@ -106,9 +104,9 @@ const adapter: SimpleAdapter = {
       [METRIC.DEPOSIT_WITHDRAW_FEES]: "Fees charged when users instant-unstake sJUSD, counted at face-value USD.",
     },
     SupplySideRevenue: {
-      [METRICS.jusdInsuranceMintRedeem]: "JUSD mint and redeem fees kept in the insurance fund, counted at face-value USD.",
+      [METRICS.jusdMintRedeem]: "JUSD mint and redeem fees kept in the insurance fund, counted at face-value USD.",
       [METRICS.sjusdStakersYield]: "Yield earned by sJUSD stakers, counted at face-value USD.",
-      [METRICS.sjusdInsuranceInstantUnstaking]: "sJUSD instant unstaking fees kept in the insurance fund, counted at face-value USD.",
+      [METRICS.sjusdInstantUnstaking]: "sJUSD instant unstaking fees kept in the insurance fund, counted at face-value USD.",
     },
   },
 }

--- a/fees/aegis-jusd/index.ts
+++ b/fees/aegis-jusd/index.ts
@@ -1,0 +1,116 @@
+import { FetchOptions, SimpleAdapter } from "../../adapters/types"
+import { CHAIN } from "../../helpers/chains"
+import { getERC4626VaultsYield } from "../../helpers/erc4626"
+import { METRIC } from "../../helpers/metrics"
+
+const chainConfig: Record<string, {
+  start: string
+  mintRedeem: { target: string }[]
+  vaults: { target: string, start?: string, instant?: boolean }[]
+}> = {
+  [CHAIN.ETHEREUM]: {
+    start: "2025-01-23",
+    mintRedeem: [
+      { target: "0xBB0F32D176590faEdC7bc552b7EAD7A86809b520" },
+    ],
+    vaults: [
+      { target: "0x4AA8949bb47da4b4F27345404Ba1e5E7EA90bdb3", start: "2026-02-06", instant: true },
+    ],
+  },
+}
+
+const abi = {
+  mint: "event Mint(address indexed userWallet, address collateralAsset, uint256 collateralAmount, uint256 yusdAmount, uint256 fee)",
+  redeem: "event ApproveRedeemRequest(string requestId, address indexed manager, address indexed userWallet, address collateralAsset, uint256 collateralAmount, uint256 yusdAmount, uint256 fee)",
+  instantUnstaking: "event InstantUnstaking(address indexed user, address indexed receiver, uint256 assets, uint256 fee)",
+}
+
+const METRICS = {
+  jusdInsuranceMintRedeem: "JUSD Mint/Redeem Fees",
+  sjusdStakersYield: "sJUSD Staker Yield",
+  sjusdInsuranceInstantUnstaking: "sJUSD Unstaking Fees",
+}
+
+const fetch = async (options: FetchOptions) => {
+  const config = chainConfig[options.chain]
+  const dailyFees = options.createBalances()
+  const dailySupplySideRevenue = options.createBalances()
+  const dailyUserFees = options.createBalances()
+  const mintRedeemTargets = config.mintRedeem.map(({ target }) => target)
+  const activeVaults = config.vaults.filter(({ start }) => !start || options.startTimestamp >= Date.parse(start) / 1000)
+  const vaultTargets = activeVaults.map(({ target }) => target)
+
+  const [mintLogs, redeemLogs] = await Promise.all([
+    options.getLogs({ targets: mintRedeemTargets, eventAbi: abi.mint }),
+    options.getLogs({ targets: mintRedeemTargets, eventAbi: abi.redeem }),
+  ])
+
+  mintLogs.concat(redeemLogs).forEach((log: any) => {
+    const feeUsd = Number(log.fee) / 1e18
+    dailyFees.addUSDValue(feeUsd, METRIC.MINT_REDEEM_FEES)
+    dailyUserFees.addUSDValue(feeUsd, METRIC.MINT_REDEEM_FEES)
+    dailySupplySideRevenue.addUSDValue(feeUsd, METRICS.jusdInsuranceMintRedeem)
+  })
+
+  const instantTargets = activeVaults.filter(({ instant }) => instant).map(({ target }) => target)
+  const [vaultYield, instantLogs, vaultAssets] = await Promise.all([
+    getERC4626VaultsYield({ options, vaults: vaultTargets }),
+    options.getLogs({ targets: instantTargets, eventAbi: abi.instantUnstaking }),
+    options.api.multiCall({ abi: "address:asset", calls: vaultTargets, permitFailure: true }),
+  ])
+  const assetDecimals = await options.api.multiCall({
+    abi: "uint8:decimals",
+    calls: vaultAssets.filter(Boolean),
+    permitFailure: true,
+  })
+  const decimalsByAsset = Object.fromEntries(
+    vaultAssets
+      .map((asset, i) => asset ? [asset.toLowerCase(), Number(assetDecimals[i])] : null)
+      .filter(Boolean) as [string, number][]
+  )
+  const vaultYieldUsd = Object.entries(vaultYield.getBalances()).reduce<number>(
+    (sum, [asset, value]) => sum + Number(value) / 10 ** (decimalsByAsset[asset.toLowerCase()] ?? 18),
+    0,
+  )
+
+  if (vaultYieldUsd > 0) {
+    dailyFees.addUSDValue(vaultYieldUsd, METRIC.ASSETS_YIELDS)
+    dailySupplySideRevenue.addUSDValue(vaultYieldUsd, METRICS.sjusdStakersYield)
+  }
+
+  instantLogs.forEach((log: any) => {
+    const feeUsd = Number(log.fee) / 1e18
+    dailyFees.addUSDValue(feeUsd, METRIC.DEPOSIT_WITHDRAW_FEES)
+    dailyUserFees.addUSDValue(feeUsd, METRIC.DEPOSIT_WITHDRAW_FEES)
+    dailySupplySideRevenue.addUSDValue(feeUsd, METRICS.sjusdInsuranceInstantUnstaking)
+  })
+
+  return { dailyFees, dailyRevenue: 0, dailySupplySideRevenue, dailyUserFees }
+}
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  pullHourly: true,
+  adapter: chainConfig,
+  fetch,
+  methodology: {
+    Fees: "sJUSD vault yield, JUSD mint and redeem fees, and sJUSD instant unstaking fees, all treated as USD-denominated stablecoin flows.",
+    Revenue: "No protocol revenue is counted.",
+    SupplySideRevenue: "JUSD fees kept in the insurance fund and yield earned by sJUSD stakers.",
+    UserFees: "JUSD mint, redeem, and sJUSD instant unstaking fees paid by users.",
+  },
+  breakdownMethodology: {
+    Fees: {
+      [METRIC.ASSETS_YIELDS]: "Yield earned by sJUSD stakers, counted at face-value USD.",
+      [METRIC.MINT_REDEEM_FEES]: "Fees charged when users mint or redeem JUSD, counted at face-value USD.",
+      [METRIC.DEPOSIT_WITHDRAW_FEES]: "Fees charged when users instant-unstake sJUSD, counted at face-value USD.",
+    },
+    SupplySideRevenue: {
+      [METRICS.jusdInsuranceMintRedeem]: "JUSD mint and redeem fees kept in the insurance fund, counted at face-value USD.",
+      [METRICS.sjusdStakersYield]: "Yield earned by sJUSD stakers, counted at face-value USD.",
+      [METRICS.sjusdInsuranceInstantUnstaking]: "sJUSD instant unstaking fees kept in the insurance fund, counted at face-value USD.",
+    },
+  },
+}
+
+export default adapter

--- a/fees/aegis-yusd/index.ts
+++ b/fees/aegis-yusd/index.ts
@@ -1,32 +1,33 @@
 import { FetchOptions, SimpleAdapter } from "../../adapters/types"
 import { CHAIN } from "../../helpers/chains"
+import { getERC4626VaultsYield } from "../../helpers/erc4626"
 import { METRIC } from "../../helpers/metrics"
 
-const WAD = 10n ** 18n
-
-const chainConfig: any = {
+const chainConfig: Record<string, {
+  start: string
+  yusd: string
+  mintRedeem: { target: string, income?: boolean }[]
+  vaults: { target: string, start?: string, instant?: boolean }[]
+}> = {
   [CHAIN.ETHEREUM]: {
     start: "2025-01-23",
     yusd: "0x4274cD7277C7bb0806Bd5FE84b9aDAE466a8DA0a",
-    jusd: "0xc86168d2424d28942EE0866F043c1206bc9E4900",
     mintRedeem: [
-      { product: "yusd", target: "0xA30644CA67E0A93805c443Df4A6E1856d8Bd815B", income: true },
-      { product: "yusd", target: "0xC4dF68e592245ca5202FE8b7C438D2b799820fc2", income: true },
-      { product: "jusd", target: "0xBB0F32D176590faEdC7bc552b7EAD7A86809b520" },
+      { target: "0xA30644CA67E0A93805c443Df4A6E1856d8Bd815B", income: true },
+      { target: "0xC4dF68e592245ca5202FE8b7C438D2b799820fc2", income: true },
     ],
     vaults: [
-      { product: "syusd", target: "0xfE0ccc9942E98C963Fe6b4e5194EB6e3Baa4cb64", start: "2025-07-30", instant: true },
-      { product: "sjusd", target: "0x4AA8949bb47da4b4F27345404Ba1e5E7EA90bdb3", start: "2026-02-06", instant: true },
+      { target: "0xfE0ccc9942E98C963Fe6b4e5194EB6e3Baa4cb64", start: "2025-07-30", instant: true },
     ],
   },
   [CHAIN.BSC]: {
     start: "2025-03-31",
     yusd: "0xAB3dBcD9B096C3fF76275038bf58eAC10D22C61f",
     mintRedeem: [
-      { product: "yusd", target: "0x39dF2D423df0BDDBA28f23C15c65a86554A2e141", income: true },
+      { target: "0x39dF2D423df0BDDBA28f23C15c65a86554A2e141", income: true },
     ],
     vaults: [
-      { product: "syusd", target: "0x24DB057b19241eeFB9B522e8627C293Ed8f93Af2", start: "2025-07-30" },
+      { target: "0x24DB057b19241eeFB9B522e8627C293Ed8f93Af2", start: "2025-07-30" },
     ],
   },
 }
@@ -35,82 +36,61 @@ const abi = {
   depositIncome: "event DepositIncome(string snapshotId, address indexed manager, address collateralAsset, uint256 collateralAmount, uint256 yusdAmount, uint256 fee, uint256 timestamp)",
   mint: "event Mint(address indexed userWallet, address collateralAsset, uint256 collateralAmount, uint256 yusdAmount, uint256 fee)",
   redeem: "event ApproveRedeemRequest(string requestId, address indexed manager, address indexed userWallet, address collateralAsset, uint256 collateralAmount, uint256 yusdAmount, uint256 fee)",
-  convertToAssets: "function convertToAssets(uint256 shares) view returns (uint256 assets)",
   instantUnstaking: "event InstantUnstaking(address indexed user, address indexed receiver, uint256 assets, uint256 fee)",
 }
 
-const METRICS: any = {
+const METRICS = {
   yusdHoldersYield: "YUSD Holder Yield",
   yusdInsuranceYield: "YUSD Insurance Yield",
   yusdInsuranceMintRedeem: "YUSD Mint/Redeem Fees",
-  jusdInsuranceMintRedeem: "JUSD Mint/Redeem Fees",
   syusdStakersYield: "sYUSD Staker Yield",
-  sjusdStakersYield: "sJUSD Staker Yield",
   syusdInsuranceInstantUnstaking: "sYUSD Unstaking Fees",
-  sjusdInsuranceInstantUnstaking: "sJUSD Unstaking Fees",
 }
-
-const assetKey = (product: string) => product[0] === "s" ? product.slice(1) : product
 
 const fetch = async (options: FetchOptions) => {
   const config = chainConfig[options.chain]
   const dailyFees = options.createBalances()
-  const dailyRevenue = options.createBalances()
   const dailySupplySideRevenue = options.createBalances()
   const dailyUserFees = options.createBalances()
-  const mintRedeem = Object.fromEntries(config.mintRedeem.map((i: any) => [i.target.toLowerCase(), i]))
-  const mintRedeemTargets = Object.keys(mintRedeem)
-  const incomeTargets = config.mintRedeem.filter((i: any) => i.income).map((i: any) => i.target)
-  const vaults = config.vaults.filter((i: any) => !i.start || options.startTimestamp >= Date.parse(i.start) / 1000)
-  const vaultTargets = vaults.map((i: any) => i.target)
+  const mintRedeemTargets = config.mintRedeem.map(({ target }) => target)
+  const incomeTargets = config.mintRedeem.filter(({ income }) => income).map(({ target }) => target)
+  const activeVaults = config.vaults.filter(({ start }) => !start || options.startTimestamp >= Date.parse(start) / 1000)
+  const vaultTargets = activeVaults.map(({ target }) => target)
 
   const [incomeLogs, mintLogs, redeemLogs] = await Promise.all([
-    options.getLogs({ targets: incomeTargets, eventAbi: abi.depositIncome, onlyArgs: false }),
-    options.getLogs({ targets: mintRedeemTargets, eventAbi: abi.mint, onlyArgs: false }),
-    options.getLogs({ targets: mintRedeemTargets, eventAbi: abi.redeem, onlyArgs: false }),
+    options.getLogs({ targets: incomeTargets, eventAbi: abi.depositIncome }),
+    options.getLogs({ targets: mintRedeemTargets, eventAbi: abi.mint }),
+    options.getLogs({ targets: mintRedeemTargets, eventAbi: abi.redeem }),
   ])
 
   incomeLogs.forEach((log: any) => {
-    const { product } = mintRedeem[log.address.toLowerCase()]
-    dailyFees.add(config[product], log.args.yusdAmount + log.args.fee, METRIC.ASSETS_YIELDS)
-    dailySupplySideRevenue.add(config[product], log.args.yusdAmount, METRICS.yusdHoldersYield)
-    dailySupplySideRevenue.add(config[product], log.args.fee, METRICS.yusdInsuranceYield)
+    dailyFees.add(config.yusd, log.yusdAmount + log.fee, METRIC.ASSETS_YIELDS)
+    dailySupplySideRevenue.add(config.yusd, log.yusdAmount, METRICS.yusdHoldersYield)
+    dailySupplySideRevenue.add(config.yusd, log.fee, METRICS.yusdInsuranceYield)
   })
 
   mintLogs.concat(redeemLogs).forEach((log: any) => {
-    const { product } = mintRedeem[log.address.toLowerCase()]
-    dailyFees.add(config[product], log.args.fee, METRIC.MINT_REDEEM_FEES)
-    dailyUserFees.add(config[product], log.args.fee, METRIC.MINT_REDEEM_FEES)
-    dailySupplySideRevenue.add(config[product], log.args.fee, METRICS[`${product}InsuranceMintRedeem`])
+    dailyFees.add(config.yusd, log.fee, METRIC.MINT_REDEEM_FEES)
+    dailyUserFees.add(config.yusd, log.fee, METRIC.MINT_REDEEM_FEES)
+    dailySupplySideRevenue.add(config.yusd, log.fee, METRICS.yusdInsuranceMintRedeem)
   })
 
-  if (vaultTargets.length) {
-    const calls = vaultTargets.map((target: string) => ({ target, params: [WAD] }))
-    const instantTargets = vaults.filter((i: any) => i.instant).map((i: any) => i.target)
-    const [supplies, fromAssets, toAssets, instantLogs] = await Promise.all([
-      options.toApi.multiCall({ calls: vaultTargets, abi: "uint256:totalSupply" }),
-      options.fromApi.multiCall({ calls, abi: abi.convertToAssets }),
-      options.toApi.multiCall({ calls, abi: abi.convertToAssets }),
-      instantTargets.length ? options.getLogs({ targets: instantTargets, eventAbi: abi.instantUnstaking, onlyArgs: false }) : [],
-    ])
-    const vaultMap = Object.fromEntries(vaults.map((i: any) => [i.target.toLowerCase(), i]))
+  const instantTargets = activeVaults.filter(({ instant }) => instant).map(({ target }) => target)
+  const [vaultYield, instantLogs] = await Promise.all([
+    getERC4626VaultsYield({ options, vaults: vaultTargets }),
+    options.getLogs({ targets: instantTargets, eventAbi: abi.instantUnstaking }),
+  ])
 
-    vaults.forEach(({ product }: any, i: number) => {
-      const amount = (BigInt(toAssets[i]) - BigInt(fromAssets[i])) * BigInt(supplies[i]) / WAD
-      if (amount <= 0n) return
-      dailyFees.add(config[assetKey(product)], amount, METRIC.ASSETS_YIELDS)
-      dailySupplySideRevenue.add(config[assetKey(product)], amount, METRICS[`${product}StakersYield`])
-    })
+  dailyFees.addBalances(vaultYield, METRIC.ASSETS_YIELDS)
+  dailySupplySideRevenue.addBalances(vaultYield, METRICS.syusdStakersYield)
 
-    instantLogs.forEach((log: any) => {
-      const { product } = vaultMap[log.address.toLowerCase()]
-      dailyFees.add(config[assetKey(product)], log.args.fee, METRIC.DEPOSIT_WITHDRAW_FEES)
-      dailyUserFees.add(config[assetKey(product)], log.args.fee, METRIC.DEPOSIT_WITHDRAW_FEES)
-      dailySupplySideRevenue.add(config[assetKey(product)], log.args.fee, METRICS[`${product}InsuranceInstantUnstaking`])
-    })
-  }
+  instantLogs.forEach((log: any) => {
+    dailyFees.add(config.yusd, log.fee, METRIC.DEPOSIT_WITHDRAW_FEES)
+    dailyUserFees.add(config.yusd, log.fee, METRIC.DEPOSIT_WITHDRAW_FEES)
+    dailySupplySideRevenue.add(config.yusd, log.fee, METRICS.syusdInsuranceInstantUnstaking)
+  })
 
-  return { dailyFees, dailyRevenue, dailySupplySideRevenue, dailyUserFees }
+  return { dailyFees, dailyRevenue: 0, dailySupplySideRevenue, dailyUserFees }
 }
 
 const adapter: SimpleAdapter = {
@@ -119,26 +99,23 @@ const adapter: SimpleAdapter = {
   adapter: chainConfig,
   fetch,
   methodology: {
-    Fees: "YUSD yield, sYUSD/sJUSD vault yield, YUSD/JUSD mint and redeem fees, and instant unstaking fees.",
+    Fees: "YUSD holder yield, sYUSD vault yield, YUSD mint and redeem fees, and sYUSD instant unstaking fees.",
     Revenue: "No protocol revenue is counted.",
-    SupplySideRevenue: "Rewards paid to users, yield kept in the insurance fund, and yield earned by sYUSD/sJUSD stakers.",
-    UserFees: "Mint, redeem, and instant unstaking fees paid by users.",
+    SupplySideRevenue: "YUSD holder rewards, YUSD fees kept in the insurance fund, and yield earned by sYUSD stakers.",
+    UserFees: "YUSD mint, redeem, and sYUSD instant unstaking fees paid by users.",
   },
   breakdownMethodology: {
     Fees: {
-      [METRIC.ASSETS_YIELDS]: "Yield earned by YUSD, sYUSD, and sJUSD.",
-      [METRIC.MINT_REDEEM_FEES]: "Fees charged when users mint or redeem YUSD/JUSD.",
-      [METRIC.DEPOSIT_WITHDRAW_FEES]: "Fees charged when users instant-unstake sYUSD/sJUSD.",
+      [METRIC.ASSETS_YIELDS]: "Yield earned by YUSD holders and sYUSD stakers.",
+      [METRIC.MINT_REDEEM_FEES]: "Fees charged when users mint or redeem YUSD.",
+      [METRIC.DEPOSIT_WITHDRAW_FEES]: "Fees charged when users instant-unstake sYUSD.",
     },
     SupplySideRevenue: {
       [METRICS.yusdHoldersYield]: "YUSD rewards distributed to YUSD holders.",
       [METRICS.yusdInsuranceYield]: "YUSD yield kept in the insurance fund.",
       [METRICS.yusdInsuranceMintRedeem]: "YUSD mint and redeem fees kept in the insurance fund.",
-      [METRICS.jusdInsuranceMintRedeem]: "JUSD mint and redeem fees kept in the insurance fund.",
       [METRICS.syusdStakersYield]: "Yield earned by sYUSD stakers.",
-      [METRICS.sjusdStakersYield]: "Yield earned by sJUSD stakers.",
       [METRICS.syusdInsuranceInstantUnstaking]: "sYUSD instant unstaking fees kept in the insurance fund.",
-      [METRICS.sjusdInsuranceInstantUnstaking]: "sJUSD instant unstaking fees kept in the insurance fund.",
     },
   },
 }

--- a/fees/aegis-yusd/index.ts
+++ b/fees/aegis-yusd/index.ts
@@ -42,9 +42,9 @@ const abi = {
 const METRICS = {
   yusdHoldersYield: "YUSD Holder Yield",
   yusdInsuranceYield: "YUSD Insurance Yield",
-  yusdInsuranceMintRedeem: "YUSD Mint/Redeem Fees",
+  yusdMintRedeem: "YUSD Mint/Redeem Fees",
   syusdStakersYield: "sYUSD Staker Yield",
-  syusdInsuranceInstantUnstaking: "sYUSD Unstaking Fees",
+  syusdInstantUnstaking: "sYUSD Unstaking Fees",
 }
 
 const fetch = async (options: FetchOptions) => {
@@ -54,7 +54,7 @@ const fetch = async (options: FetchOptions) => {
   const dailyUserFees = options.createBalances()
   const mintRedeemTargets = config.mintRedeem.map(({ target }) => target)
   const incomeTargets = config.mintRedeem.filter(({ income }) => income).map(({ target }) => target)
-  const activeVaults = config.vaults.filter(({ start }) => !start || options.startTimestamp >= Date.parse(start) / 1000)
+  const activeVaults = config.vaults.filter(({ start }) => !start || options.dateString >= start)
   const vaultTargets = activeVaults.map(({ target }) => target)
 
   const [incomeLogs, mintLogs, redeemLogs] = await Promise.all([
@@ -72,23 +72,23 @@ const fetch = async (options: FetchOptions) => {
   mintLogs.concat(redeemLogs).forEach((log: any) => {
     dailyFees.add(config.yusd, log.fee, METRIC.MINT_REDEEM_FEES)
     dailyUserFees.add(config.yusd, log.fee, METRIC.MINT_REDEEM_FEES)
-    dailySupplySideRevenue.add(config.yusd, log.fee, METRICS.yusdInsuranceMintRedeem)
+    dailySupplySideRevenue.add(config.yusd, log.fee, METRICS.yusdMintRedeem)
   })
 
   const instantTargets = activeVaults.filter(({ instant }) => instant).map(({ target }) => target)
-  const [vaultYield, instantLogs] = await Promise.all([
-    getERC4626VaultsYield({ options, vaults: vaultTargets }),
-    options.getLogs({ targets: instantTargets, eventAbi: abi.instantUnstaking }),
-  ])
 
+  const vaultYield = await getERC4626VaultsYield({ options, vaults: vaultTargets });
   dailyFees.addBalances(vaultYield, METRIC.ASSETS_YIELDS)
   dailySupplySideRevenue.addBalances(vaultYield, METRICS.syusdStakersYield)
 
-  instantLogs.forEach((log: any) => {
-    dailyFees.add(config.yusd, log.fee, METRIC.DEPOSIT_WITHDRAW_FEES)
-    dailyUserFees.add(config.yusd, log.fee, METRIC.DEPOSIT_WITHDRAW_FEES)
-    dailySupplySideRevenue.add(config.yusd, log.fee, METRICS.syusdInsuranceInstantUnstaking)
-  })
+  if(instantTargets.length > 0){
+    const instantLogs = await options.getLogs({ targets: instantTargets, eventAbi: abi.instantUnstaking });
+    instantLogs.forEach((log: any) => {
+      dailyFees.add(config.yusd, log.fee, METRIC.DEPOSIT_WITHDRAW_FEES)
+      dailyUserFees.add(config.yusd, log.fee, METRIC.DEPOSIT_WITHDRAW_FEES)
+      dailySupplySideRevenue.add(config.yusd, log.fee, METRICS.syusdInstantUnstaking)
+    })
+  }
 
   return { dailyFees, dailyRevenue: 0, dailySupplySideRevenue, dailyUserFees }
 }
@@ -113,9 +113,9 @@ const adapter: SimpleAdapter = {
     SupplySideRevenue: {
       [METRICS.yusdHoldersYield]: "YUSD rewards distributed to YUSD holders.",
       [METRICS.yusdInsuranceYield]: "YUSD yield kept in the insurance fund.",
-      [METRICS.yusdInsuranceMintRedeem]: "YUSD mint and redeem fees kept in the insurance fund.",
+      [METRICS.yusdMintRedeem]: "YUSD mint and redeem fees kept in the insurance fund.",
       [METRICS.syusdStakersYield]: "Yield earned by sYUSD stakers.",
-      [METRICS.syusdInsuranceInstantUnstaking]: "sYUSD instant unstaking fees kept in the insurance fund.",
+      [METRICS.syusdInstantUnstaking]: "sYUSD instant unstaking fees kept in the insurance fund.",
     },
   },
 }

--- a/fees/aegis-yusd/index.ts
+++ b/fees/aegis-yusd/index.ts
@@ -2,79 +2,145 @@ import { FetchOptions, SimpleAdapter } from "../../adapters/types"
 import { CHAIN } from "../../helpers/chains"
 import { METRIC } from "../../helpers/metrics"
 
-interface chainConfigInterface {
-  rewards: string,
-  yusd: string,
-  mintRedeem: string,
-  start: string,
-} 
+const WAD = 10n ** 18n
 
-const chainContracts: Record<string, chainConfigInterface> = {
+const chainConfig: any = {
   [CHAIN.ETHEREUM]: {
-    rewards: "0x8aDCFAf1B64Cc514524B80565bCc732273dDEafD",
-    yusd: "0x4274cD7277C7bb0806Bd5FE84b9aDAE466a8DA0a",
-    mintRedeem: "0xa30644ca67e0a93805c443df4a6e1856d8bd815b",
     start: "2025-01-23",
+    yusd: "0x4274cD7277C7bb0806Bd5FE84b9aDAE466a8DA0a",
+    jusd: "0xc86168d2424d28942EE0866F043c1206bc9E4900",
+    mintRedeem: [
+      { product: "yusd", target: "0xA30644CA67E0A93805c443Df4A6E1856d8Bd815B", income: true },
+      { product: "yusd", target: "0xC4dF68e592245ca5202FE8b7C438D2b799820fc2", income: true },
+      { product: "jusd", target: "0xBB0F32D176590faEdC7bc552b7EAD7A86809b520" },
+    ],
+    vaults: [
+      { product: "syusd", target: "0xfE0ccc9942E98C963Fe6b4e5194EB6e3Baa4cb64", start: "2025-07-30", instant: true },
+      { product: "sjusd", target: "0x4AA8949bb47da4b4F27345404Ba1e5E7EA90bdb3", start: "2026-02-06", instant: true },
+    ],
   },
   [CHAIN.BSC]: {
-    rewards:"0x93eFAA2d2f6c3600d794233ed7E751d086E5B75E",
+    start: "2025-03-31",
     yusd: "0xAB3dBcD9B096C3fF76275038bf58eAC10D22C61f",
-    mintRedeem: "0x39df2d423df0bddba28f23c15c65a86554a2e141",
-    start: "2025-03-31"
-  }
+    mintRedeem: [
+      { product: "yusd", target: "0x39dF2D423df0BDDBA28f23C15c65a86554A2e141", income: true },
+    ],
+    vaults: [
+      { product: "syusd", target: "0x24DB057b19241eeFB9B522e8627C293Ed8f93Af2", start: "2025-07-30" },
+    ],
+  },
 }
-const depositRewardsEvent = "event DepositRewards(bytes32 id, uint256 amount, uint256 timestamp)"
-const mintEvent = "event Mint(address indexed userWallet, address collateralAsset, uint256 collateralAmount, uint256 yusdAmount, uint256 fee)"
-const redeemEvent = "event ApproveRedeemRequest(string requestId,address indexed manager,address indexed userWallet,address collateralAsset,uint256 collateralAmount,uint256 yusdAmount,uint256 fee)"
 
+const abi = {
+  depositIncome: "event DepositIncome(string snapshotId, address indexed manager, address collateralAsset, uint256 collateralAmount, uint256 yusdAmount, uint256 fee, uint256 timestamp)",
+  mint: "event Mint(address indexed userWallet, address collateralAsset, uint256 collateralAmount, uint256 yusdAmount, uint256 fee)",
+  redeem: "event ApproveRedeemRequest(string requestId, address indexed manager, address indexed userWallet, address collateralAsset, uint256 collateralAmount, uint256 yusdAmount, uint256 fee)",
+  convertToAssets: "function convertToAssets(uint256 shares) view returns (uint256 assets)",
+  instantUnstaking: "event InstantUnstaking(address indexed user, address indexed receiver, uint256 assets, uint256 fee)",
+}
+
+const METRICS: any = {
+  yusdHoldersYield: "YUSD Holder Yield",
+  yusdInsuranceYield: "YUSD Insurance Yield",
+  yusdInsuranceMintRedeem: "YUSD Mint/Redeem Fees",
+  jusdInsuranceMintRedeem: "JUSD Mint/Redeem Fees",
+  syusdStakersYield: "sYUSD Staker Yield",
+  sjusdStakersYield: "sJUSD Staker Yield",
+  syusdInsuranceInstantUnstaking: "sYUSD Unstaking Fees",
+  sjusdInsuranceInstantUnstaking: "sJUSD Unstaking Fees",
+}
+
+const assetKey = (product: string) => product[0] === "s" ? product.slice(1) : product
 
 const fetch = async (options: FetchOptions) => {
+  const config = chainConfig[options.chain]
   const dailyFees = options.createBalances()
+  const dailyRevenue = options.createBalances()
   const dailySupplySideRevenue = options.createBalances()
   const dailyUserFees = options.createBalances()
-  const { rewards, yusd, mintRedeem } = chainContracts[options.chain]
-  const [rewardLogs, mintLogs, redeemLogs] = await Promise.all([
-    options.getLogs({ target: rewards, eventAbi: depositRewardsEvent}),
-    options.getLogs({ target: mintRedeem, eventAbi: mintEvent}),
-    options.getLogs({ target: mintRedeem, eventAbi: redeemEvent})
+  const mintRedeem = Object.fromEntries(config.mintRedeem.map((i: any) => [i.target.toLowerCase(), i]))
+  const mintRedeemTargets = Object.keys(mintRedeem)
+  const incomeTargets = config.mintRedeem.filter((i: any) => i.income).map((i: any) => i.target)
+  const vaults = config.vaults.filter((i: any) => !i.start || options.startTimestamp >= Date.parse(i.start) / 1000)
+  const vaultTargets = vaults.map((i: any) => i.target)
+
+  const [incomeLogs, mintLogs, redeemLogs] = await Promise.all([
+    options.getLogs({ targets: incomeTargets, eventAbi: abi.depositIncome, onlyArgs: false }),
+    options.getLogs({ targets: mintRedeemTargets, eventAbi: abi.mint, onlyArgs: false }),
+    options.getLogs({ targets: mintRedeemTargets, eventAbi: abi.redeem, onlyArgs: false }),
   ])
-  rewardLogs.forEach(log => {
-    dailyFees.add(yusd, log.amount, METRIC.ASSETS_YIELDS)
-    dailySupplySideRevenue.add(yusd, log.amount, METRIC.ASSETS_YIELDS)
+
+  incomeLogs.forEach((log: any) => {
+    const { product } = mintRedeem[log.address.toLowerCase()]
+    dailyFees.add(config[product], log.args.yusdAmount + log.args.fee, METRIC.ASSETS_YIELDS)
+    dailySupplySideRevenue.add(config[product], log.args.yusdAmount, METRICS.yusdHoldersYield)
+    dailySupplySideRevenue.add(config[product], log.args.fee, METRICS.yusdInsuranceYield)
   })
-  mintLogs.concat(redeemLogs).forEach(log => {
-    dailyFees.add(yusd, log.fee, METRIC.MINT_REDEEM_FEES)
-    dailyUserFees.add(yusd, log.fee, METRIC.MINT_REDEEM_FEES)
-    dailySupplySideRevenue.add(yusd, log.fee, "Mint/Redeem Fees to Insurance Fund")
+
+  mintLogs.concat(redeemLogs).forEach((log: any) => {
+    const { product } = mintRedeem[log.address.toLowerCase()]
+    dailyFees.add(config[product], log.args.fee, METRIC.MINT_REDEEM_FEES)
+    dailyUserFees.add(config[product], log.args.fee, METRIC.MINT_REDEEM_FEES)
+    dailySupplySideRevenue.add(config[product], log.args.fee, METRICS[`${product}InsuranceMintRedeem`])
   })
-  return {
-    dailyFees,
-    dailyRevenue: 0,
-    dailySupplySideRevenue,
-    dailyUserFees
+
+  if (vaultTargets.length) {
+    const calls = vaultTargets.map((target: string) => ({ target, params: [WAD] }))
+    const instantTargets = vaults.filter((i: any) => i.instant).map((i: any) => i.target)
+    const [supplies, fromAssets, toAssets, instantLogs] = await Promise.all([
+      options.toApi.multiCall({ calls: vaultTargets, abi: "uint256:totalSupply" }),
+      options.fromApi.multiCall({ calls, abi: abi.convertToAssets }),
+      options.toApi.multiCall({ calls, abi: abi.convertToAssets }),
+      instantTargets.length ? options.getLogs({ targets: instantTargets, eventAbi: abi.instantUnstaking, onlyArgs: false }) : [],
+    ])
+    const vaultMap = Object.fromEntries(vaults.map((i: any) => [i.target.toLowerCase(), i]))
+
+    vaults.forEach(({ product }: any, i: number) => {
+      const amount = (BigInt(toAssets[i]) - BigInt(fromAssets[i])) * BigInt(supplies[i]) / WAD
+      if (amount <= 0n) return
+      dailyFees.add(config[assetKey(product)], amount, METRIC.ASSETS_YIELDS)
+      dailySupplySideRevenue.add(config[assetKey(product)], amount, METRICS[`${product}StakersYield`])
+    })
+
+    instantLogs.forEach((log: any) => {
+      const { product } = vaultMap[log.address.toLowerCase()]
+      dailyFees.add(config[assetKey(product)], log.args.fee, METRIC.DEPOSIT_WITHDRAW_FEES)
+      dailyUserFees.add(config[assetKey(product)], log.args.fee, METRIC.DEPOSIT_WITHDRAW_FEES)
+      dailySupplySideRevenue.add(config[assetKey(product)], log.args.fee, METRICS[`${product}InsuranceInstantUnstaking`])
+    })
   }
+
+  return { dailyFees, dailyRevenue, dailySupplySideRevenue, dailyUserFees }
 }
 
 const adapter: SimpleAdapter = {
   version: 2,
   pullHourly: true,
-  fetch: fetch,
-  adapter: chainContracts,
+  adapter: chainConfig,
+  fetch,
   methodology: {
-    Fees: "The yield generated from funds deposited into YUSD + Mint and Redeem fees",
-    Revenue: "No revenue",
-    SupplySideRevenue: "The yield generated from funds deposited into YUSD is distributed to holders",
-    UserFees: "Fees paid on mint and redemption"
+    Fees: "YUSD yield, sYUSD/sJUSD vault yield, YUSD/JUSD mint and redeem fees, and instant unstaking fees.",
+    Revenue: "No protocol revenue is counted.",
+    SupplySideRevenue: "Rewards paid to users, yield kept in the insurance fund, and yield earned by sYUSD/sJUSD stakers.",
+    UserFees: "Mint, redeem, and instant unstaking fees paid by users.",
   },
   breakdownMethodology: {
     Fees: {
-      [METRIC.ASSETS_YIELDS]: "The yield generated from funds deposited into YUSD",
-      [METRIC.MINT_REDEEM_FEES]: "Fees charged on mint and redemption"
+      [METRIC.ASSETS_YIELDS]: "Yield earned by YUSD, sYUSD, and sJUSD.",
+      [METRIC.MINT_REDEEM_FEES]: "Fees charged when users mint or redeem YUSD/JUSD.",
+      [METRIC.DEPOSIT_WITHDRAW_FEES]: "Fees charged when users instant-unstake sYUSD/sJUSD.",
     },
     SupplySideRevenue: {
-      [METRIC.ASSETS_YIELDS]: "The yield generated from funds deposited into YUSD",
-      "Mint/Redeem Fees to Insurance Fund": "The mint and redeem fees are sent to the insurance fund",
-    }
-  }
+      [METRICS.yusdHoldersYield]: "YUSD rewards distributed to YUSD holders.",
+      [METRICS.yusdInsuranceYield]: "YUSD yield kept in the insurance fund.",
+      [METRICS.yusdInsuranceMintRedeem]: "YUSD mint and redeem fees kept in the insurance fund.",
+      [METRICS.jusdInsuranceMintRedeem]: "JUSD mint and redeem fees kept in the insurance fund.",
+      [METRICS.syusdStakersYield]: "Yield earned by sYUSD stakers.",
+      [METRICS.sjusdStakersYield]: "Yield earned by sJUSD stakers.",
+      [METRICS.syusdInsuranceInstantUnstaking]: "sYUSD instant unstaking fees kept in the insurance fund.",
+      [METRICS.sjusdInsuranceInstantUnstaking]: "sJUSD instant unstaking fees kept in the insurance fund.",
+    },
+  },
 }
+
 export default adapter


### PR DESCRIPTION
https://defillama.com/protocol/aegis

## Note for maintainer
- I recommend changing the adapter name from `aegis-yusd` to `aegis` only.

## Summary
- Updates `fees/aegis-yusd` to track Aegis YUSD/JUSD mint/redeem fees, YUSD income yield, and sYUSD/sJUSD vault yield.
- Switches YUSD yield accounting from rewards-contract `DepositRewards` to AegisMinting `DepositIncome`, so insurance-fund yield is included.
- Adds ERC4626 share-price yield tracking for sYUSD/sJUSD using `convertToAssets(1e18)` and `totalSupply`.

## Changes
- Centralized Ethereum and BSC contract addresses in a single `chainConfig`.
- Tracks YUSD `DepositIncome` as:
  - `dailyFees = yusdAmount + fee`
  - `dailySupplySideRevenue = holder yield + insurance-fund yield`
- Tracks YUSD and JUSD mint/redeem fees from configured AegisMinting contracts.
- Tracks sYUSD/sJUSD yield from ERC4626 share-price growth.
- Tracks instant unstaking fees for sYUSD/sJUSD where the vault emits `InstantUnstaking`.
- Filters vaults by start date to avoid `convertToAssets` calls before vault deployment.
- Keeps JUSD holder yield excluded because no active JUSD rewards contract is used for that path.

## Methodology
- YUSD holder yield comes from `DepositIncome.yusdAmount`.
- YUSD insurance-fund yield comes from `DepositIncome.fee`.
- Mint/redeem fees are counted from `Mint` and `ApproveRedeemRequest` events.
- sYUSD/sJUSD yield is calculated from ERC4626 share-price growth: `(toConvertToAssets - fromConvertToAssets) * totalSupply / 1e18`.
- Insurance-fund allocations are reported as supply-side revenue, not protocol revenue.

## Data Quality / Risk
- JUSD holder rewards are not counted because the adapter only has mint/redeem fee coverage for JUSD.
- Historical vault calls are start-date filtered to avoid querying ERC4626 methods before deployment.
- BSC public RPCs may fail on historical `getLogs` ranges with rate/range limits during local tests.
