### PR TITLE
[feat] synthetix-v4: track synthetix perps volume and oi

### DIFF
--- a/dexs/synthetix-v4/index.ts
+++ b/dexs/synthetix-v4/index.ts
@@ -1,0 +1,47 @@
+import { CHAIN } from "../../helpers/chains";
+import { httpPost } from "../../utils/fetchURL";
+
+const API = "https://papi.synthetix.io/v1/info";
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+const post = async (params: any) => {
+  const res = await httpPost(API, { params }, { headers: { "User-Agent": "defillama-dimension-adapters/1.0" } });
+  if (res.status !== "ok" || res.response === undefined) throw new Error(`Synthetix API error: ${params.action}`);
+  return res.response;
+};
+
+const fetch = async (_: any, __: any, options: any) => {
+  const startMs = options.startOfDay * 1000;
+  const endMs = startMs + DAY_MS;
+  const dailyVolume = options.createBalances();
+  const markets = Object.values(await post({ action: "getMarketPrices" })).filter((market: any) => market?.symbol);
+
+  for (const market of markets as any[]) {
+    try {
+      const { candles } = await post({ action: "getCandles", symbol: market.symbol, interval: "1d", startTime: startMs, endTime: endMs, limit: 0 });
+      const dailyCandles = (candles || []).filter((candle: any) => candle.openTime >= startMs && candle.openTime < endMs);
+      if (!dailyCandles.length) {
+        console.warn(`No Synthetix V4 candle found for ${market.symbol} in [${startMs}, ${endMs}), skipping`);
+        continue;
+      }
+      dailyCandles.forEach((candle: any) => dailyVolume.addUSDValue(Number(candle.quoteVolume || 0)));
+    } catch (e) {
+      console.warn(`Failed to fetch Synthetix V4 candle for ${market.symbol} in [${startMs}, ${endMs}), skipping: ${String(e)}`);
+    }
+  }
+
+  return { dailyVolume };
+};
+
+const methodology = {
+  dailyVolume: "24h perpetual trading volume from Synthetix-v4.",
+};
+
+const adapter = {
+  fetch,
+  chains: [CHAIN.ETHEREUM],
+  start: "2025-12-18",
+  methodology,
+};
+
+export default adapter;

--- a/dexs/synthetix-v4/index.ts
+++ b/dexs/synthetix-v4/index.ts
@@ -1,47 +1,51 @@
 import { CHAIN } from "../../helpers/chains";
-import { httpPost } from "../../utils/fetchURL";
+import { postURL } from "../../utils/fetchURL";
+import { sleep } from "../../utils/utils";
 
 const API = "https://papi.synthetix.io/v1/info";
 const DAY_MS = 24 * 60 * 60 * 1000;
+const retries = 3;
+const headers = { "User-Agent": "defillama-dimension-adapters/1.0" };
 
 const post = async (params: any) => {
-  const res = await httpPost(API, { params }, { headers: { "User-Agent": "defillama-dimension-adapters/1.0" } });
-  if (res.status !== "ok" || res.response === undefined) throw new Error(`Synthetix API error: ${params.action}`);
-  return res.response;
+    const res = await postURL(API, { params }, retries, { headers });
+    if (res.status !== "ok" || res.response === undefined) throw new Error(`Synthetix API error: ${params.action}`);
+    return res.response;
 };
 
 const fetch = async (_: any, __: any, options: any) => {
-  const startMs = options.startOfDay * 1000;
-  const endMs = startMs + DAY_MS;
-  const dailyVolume = options.createBalances();
-  const markets = Object.values(await post({ action: "getMarketPrices" })).filter((market: any) => market?.symbol);
+    const startMs = options.startOfDay * 1000;
+    const endMs = startMs + DAY_MS;
+    const dailyVolume = options.createBalances();
+    const markets = Object.values(await post({ action: "getMarketPrices" })).filter((market: any) => market?.symbol);
 
-  for (const market of markets as any[]) {
-    try {
-      const { candles } = await post({ action: "getCandles", symbol: market.symbol, interval: "1d", startTime: startMs, endTime: endMs, limit: 0 });
-      const dailyCandles = (candles || []).filter((candle: any) => candle.openTime >= startMs && candle.openTime < endMs);
-      if (!dailyCandles.length) {
-        console.warn(`No Synthetix V4 candle found for ${market.symbol} in [${startMs}, ${endMs}), skipping`);
-        continue;
-      }
-      dailyCandles.forEach((candle: any) => dailyVolume.addUSDValue(Number(candle.quoteVolume || 0)));
-    } catch (e) {
-      console.warn(`Failed to fetch Synthetix V4 candle for ${market.symbol} in [${startMs}, ${endMs}), skipping: ${String(e)}`);
+    for (const market of markets as any[]) {
+        try {
+            const { candles } = await post({ action: "getCandles", symbol: market.symbol, interval: "1d", startTime: startMs, endTime: endMs, limit: 0 });
+            const dailyCandles = (candles || []).filter((candle: any) => candle.openTime >= startMs && candle.openTime < endMs);
+            if (!dailyCandles.length) {
+                console.warn(`No Synthetix V4 candle found for ${market.symbol} in [${startMs}, ${endMs}), skipping`);
+                continue;
+            }
+            dailyCandles.forEach((candle: any) => dailyVolume.addUSDValue(Number(candle.quoteVolume || 0)));
+            await sleep(500);
+        } catch (e) {
+            console.warn(`Failed to fetch Synthetix V4 candle for ${market.symbol} in [${startMs}, ${endMs}), skipping: ${String(e)}`);
+        }
     }
-  }
 
-  return { dailyVolume };
+    return { dailyVolume };
 };
 
 const methodology = {
-  dailyVolume: "24h perpetual trading volume from Synthetix-v4.",
+    Volume: "24h perpetual trading volume from Synthetix-v4.",
 };
 
 const adapter = {
-  fetch,
-  chains: [CHAIN.ETHEREUM],
-  start: "2025-12-18",
-  methodology,
+    fetch,
+    chains: [CHAIN.ETHEREUM],
+    start: "2025-12-18",
+    methodology,
 };
 
 export default adapter;

--- a/open-interest/synthetix-v4.ts
+++ b/open-interest/synthetix-v4.ts
@@ -1,10 +1,12 @@
-import { CHAIN } from "../../helpers/chains";
-import { httpPost } from "../../utils/fetchURL";
+import { CHAIN } from "../helpers/chains";
+import { postURL } from "../utils/fetchURL";
 
 const API = "https://papi.synthetix.io/v1/info";
+const retries = 3;
+const headers = { "User-Agent": "defillama-dimension-adapters/1.0" };
 
 const post = async (params: any) => {
-  const res = await httpPost(API, { params }, { headers: { "User-Agent": "defillama-dimension-adapters/1.0" } });
+  const res = await postURL(API, { params }, retries, { headers });
   if (res.status !== "ok" || res.response === undefined) throw new Error(`Synthetix API error: ${params.action}`);
   return res.response;
 };
@@ -38,13 +40,9 @@ const fetch = async (options: any) => {
 
 const adapter = {
   version: 2,
-  adapter: {
-    [CHAIN.ETHEREUM]: {
-      fetch,
-      runAtCurrTime: true,
-      start: "2025-12-18",
-    },
-  },
+  runAtCurrTime: true,
+  fetch,
+  chains: [CHAIN.ETHEREUM],
 };
 
 export default adapter;

--- a/open-interest/synthetix-v4.ts
+++ b/open-interest/synthetix-v4.ts
@@ -20,15 +20,12 @@ const fetch = async (options: any) => {
 
   openInterest.forEach(({ symbol, longOpenInterest, shortOpenInterest }: any) => {
     const price = marketPrices[symbol];
-    if (!price) throw new Error(`Missing Synthetix mark price for ${symbol} open interest`);
-
-    const markPrice = Number(price.markPrice || 0);
-    const longOpenInterestUsd = Number(longOpenInterest || 0) * markPrice;
-    const shortOpenInterestUsd = Number(shortOpenInterest || 0) * markPrice;
-
-    openInterestAtEnd.addUSDValue(longOpenInterestUsd + shortOpenInterestUsd);
-    longOpenInterestAtEnd.addUSDValue(longOpenInterestUsd);
-    shortOpenInterestAtEnd.addUSDValue(shortOpenInterestUsd);
+    if (!price || !price.markPrice || !longOpenInterest || !shortOpenInterest) {
+      throw new Error(`Missing Synthetix mark price or open interest for ${symbol}`);
+    }
+    openInterestAtEnd.addUSDValue(Number(price.markPrice) * (Number(longOpenInterest) + Number(shortOpenInterest)));
+    longOpenInterestAtEnd.addUSDValue(Number(price.markPrice) * Number(longOpenInterest));
+    shortOpenInterestAtEnd.addUSDValue(Number(price.markPrice) * Number(shortOpenInterest));
   });
 
   return {

--- a/open-interest/synthetix-v4/index.ts
+++ b/open-interest/synthetix-v4/index.ts
@@ -1,0 +1,50 @@
+import { CHAIN } from "../../helpers/chains";
+import { httpPost } from "../../utils/fetchURL";
+
+const API = "https://papi.synthetix.io/v1/info";
+
+const post = async (params: any) => {
+  const res = await httpPost(API, { params }, { headers: { "User-Agent": "defillama-dimension-adapters/1.0" } });
+  if (res.status !== "ok" || res.response === undefined) throw new Error(`Synthetix API error: ${params.action}`);
+  return res.response;
+};
+
+const fetch = async (options: any) => {
+  const openInterestAtEnd = options.createBalances();
+  const longOpenInterestAtEnd = options.createBalances();
+  const shortOpenInterestAtEnd = options.createBalances();
+  const marketPrices = await post({ action: "getMarketPrices" });
+  const openInterest = await post({ action: "getOpenInterest" });
+
+  openInterest.forEach(({ symbol, longOpenInterest, shortOpenInterest }: any) => {
+    const price = marketPrices[symbol];
+    if (!price) throw new Error(`Missing Synthetix mark price for ${symbol} open interest`);
+
+    const markPrice = Number(price.markPrice || 0);
+    const longOpenInterestUsd = Number(longOpenInterest || 0) * markPrice;
+    const shortOpenInterestUsd = Number(shortOpenInterest || 0) * markPrice;
+
+    openInterestAtEnd.addUSDValue(longOpenInterestUsd + shortOpenInterestUsd);
+    longOpenInterestAtEnd.addUSDValue(longOpenInterestUsd);
+    shortOpenInterestAtEnd.addUSDValue(shortOpenInterestUsd);
+  });
+
+  return {
+    openInterestAtEnd,
+    longOpenInterestAtEnd,
+    shortOpenInterestAtEnd,
+  };
+};
+
+const adapter = {
+  version: 2,
+  adapter: {
+    [CHAIN.ETHEREUM]: {
+      fetch,
+      runAtCurrTime: true,
+      start: "2025-12-18",
+    },
+  },
+};
+
+export default adapter;


### PR DESCRIPTION
Track v4 https://defillama.com/protocol/synthetix

## Summary
- Adds Synthetix V4 adapters for Ethereum perp volume and open interest.
- Uses Synthetix's public REST API to aggregate all active markets.

## Changes
- Added `dexs/synthetix-v4` for daily perp volume from `1d` candle `quoteVolume`.
- Added `open-interest/synthetix-v4` for current total, long, and short open interest.
- Skips individual markets with missing historical candles so newly added markets do not break older backfills.

## Methodology
- Volume sums Synthetix V4 candle `quoteVolume` across all active markets returned by `getMarketPrices`.
- Open interest uses `getOpenInterest` and market prices from `getMarketPrices` to report USD notional.

## Links
- Website: https://synthetix.io/
- Twitter: https://x.com/synthetix_io

## Tests
- `pnpm test dexs synthetix-v4 2026-05-12`
- `pnpm test open-interest synthetix-v4`
