### PR TITLE
fix: typo, 'styart' should be 'start' in somnex-perps adapter

### DIFF
--- a/dexs/somnex-perps.ts
+++ b/dexs/somnex-perps.ts
@@ -5,7 +5,7 @@ import { request, } from "graphql-request";
 export default {
   chains: [CHAIN.SOMNIA],
   fetch,
-  styart: '2025-09-02',
+  start: '2025-09-02',
 }
 
 


### PR DESCRIPTION
## Summary

fixed a typo in the somnex-perps adapter so the start date is recognised.