### PR TITLE
[Fees] Rainbow Wallet - Add relay bridge revenue to swap fees adapter

### DIFF
--- a/fees/rainbow-wallet.ts
+++ b/fees/rainbow-wallet.ts
@@ -19,6 +19,7 @@ const RainBowRouter = {
   [CHAIN.ZORA]: '0xA61550E9ddD2797E16489db09343162BE98d9483',
   [CHAIN.APECHAIN]: rainbowRouter,
   [CHAIN.GRAVITY]: rainbowRouter,
+  [CHAIN.MONAD]: rainbowRouter,
 }
 
 // Prefetch function that will run once before any fetch calls

--- a/fees/rainbow-wallet.ts
+++ b/fees/rainbow-wallet.ts
@@ -1,6 +1,7 @@
 import { Adapter, Dependencies, FetchOptions, } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
 import { queryDuneSql } from "../helpers/dune";
+import { METRIC } from "../helpers/metrics";
 
 const rainbowRouter = '0x00000000009726632680fb29d3f7a9734e3010e2'
 
@@ -97,26 +98,28 @@ const prefetch = async (options: FetchOptions) => {
             SUM(amount_usd * 0.0085) AS fees
         FROM combined
         GROUP BY 1
-    )
+    ),
 
-    SELECT chain, SUM(volume) AS volume, SUM(fees) AS fees
-    FROM (
-        SELECT chain, volume, fees FROM swap_fees
-        UNION ALL
-        SELECT chain, volume, fees FROM relay_bridge
-    ) all_fees
-    GROUP BY 1
+    total_fees AS (
+        SELECT chain, fee_type, SUM(volume) AS volume, SUM(fees) AS fees
+        FROM (
+            SELECT chain, '${METRIC.SWAP_FEES}' AS fee_type, volume, fees FROM swap_fees
+            UNION ALL
+            SELECT chain, 'Bridge Fees' AS fee_type, volume, fees FROM relay_bridge
+        ) AS all_fees
+        GROUP BY chain, fee_type
+    )
+    SELECT chain, fee_type, volume, fees FROM total_fees
   `);
-};
+  }
 
 const fetch: any = async (timestamp: number, _: any, options: FetchOptions) => {
   const results = options.preFetchedResults || [];
 
-  let dailyFees = 0;
+  const dailyFees = options.createBalances();
   for (const result of results) {
     if (result.chain === options.chain) {
-      dailyFees = result.fees;
-      break;
+      dailyFees.addUSDValue(result.fees, result.fee_type);
     }
   }
 
@@ -129,8 +132,24 @@ const fetch: any = async (timestamp: number, _: any, options: FetchOptions) => {
 }
 
 const methodology = {
-  Fees: "Take 0.85% from trading volume",
-  Revenue: "Take 0.85% from trading volume",
+  Fees: "0.85% fees from trading volume and 0.25% fees from bridge relaying volume",
+  Revenue: "0.85% revenue from trading volume and 0.25% revenue from bridge relaying volume",
+  ProtocolRevenue: "0.85% protocol revenue from trading volume and 0.25% protocol revenue from bridge relaying volume",
+}
+
+const breakdownMethodology = {
+  Fees: {
+    [METRIC.SWAP_FEES]: "0.85% of the volume is fees",
+    'Bridge Fees': "0.25% of the volume is fees",
+  },
+  Revenue: {
+    [METRIC.SWAP_FEES]: "0.85% of the volume is revenue",
+    'Bridge Fees': "0.25% of the volume is revenue",
+  },
+  ProtocolRevenue: {
+    [METRIC.SWAP_FEES]: "0.85% of the volume is protocol revenue",
+    'Bridge Fees': "0.25% of the volume is protocol revenue",
+  }
 }
 
 const adapter: Adapter = {
@@ -140,6 +159,8 @@ const adapter: Adapter = {
   prefetch,
   dependencies: [Dependencies.DUNE],
   methodology,
+  breakdownMethodology,
+  isExpensiveAdapter: true,
 }
 
 export default adapter;

--- a/fees/rainbow-wallet.ts
+++ b/fees/rainbow-wallet.ts
@@ -19,7 +19,6 @@ const RainBowRouter = {
   [CHAIN.ZORA]: '0xA61550E9ddD2797E16489db09343162BE98d9483',
   [CHAIN.APECHAIN]: rainbowRouter,
   [CHAIN.GRAVITY]: rainbowRouter,
-  [CHAIN.MONAD]: rainbowRouter,
 }
 
 // Prefetch function that will run once before any fetch calls
@@ -69,17 +68,42 @@ const prefetch = async (options: FetchOptions) => {
         SELECT blockchain, tx_hash, amount_usd FROM eoa_router_trades
         UNION ALL
         SELECT blockchain, tx_hash, amount_usd FROM smart_wallet_trades
+    ),
+
+    relay_bridge AS (
+        SELECT
+            CASE
+                WHEN origin = 'bnb'         THEN 'bsc'
+                WHEN origin = 'avalanche_c' THEN 'avax'
+                ELSE origin
+            END AS chain,
+            SUM(usd_vol)          AS volume,
+            SUM(usd_vol) * 0.0025 AS fees
+        FROM dune.rainbowdotme.result_rainbow_relay_tx
+        WHERE block_time >= from_unixtime(${options.startTimestamp})
+          AND block_time <  from_unixtime(${options.endTimestamp})
+        GROUP BY 1
+    ),
+
+    swap_fees AS (
+        SELECT
+            CASE
+                WHEN blockchain = 'bnb'         THEN 'bsc'
+                WHEN blockchain = 'avalanche_c' THEN 'avax'
+                ELSE blockchain
+            END AS chain,
+            SUM(amount_usd)          AS volume,
+            SUM(amount_usd * 0.0085) AS fees
+        FROM combined
+        GROUP BY 1
     )
 
-    SELECT
-        CASE
-            WHEN blockchain = 'bnb'         THEN 'bsc'
-            WHEN blockchain = 'avalanche_c' THEN 'avax'
-            ELSE blockchain
-        END AS chain,
-        SUM(amount_usd)          AS volume,
-        SUM(amount_usd * 0.0085) AS fees
-    FROM combined
+    SELECT chain, SUM(volume) AS volume, SUM(fees) AS fees
+    FROM (
+        SELECT chain, volume, fees FROM swap_fees
+        UNION ALL
+        SELECT chain, volume, fees FROM relay_bridge
+    ) all_fees
     GROUP BY 1
   `);
 };


### PR DESCRIPTION
Name (as shown on DefiLlama): Rainbow Wallet
Twitter link: https://x.com/rainbowdotme
Website link: https://rainbow.me

## Summary

Updates the existing `rainbow-wallet.ts` adapter to include relay bridge fees alongside swap fees.

Rainbow earns revenue from two sources:
1. **Swap fees** — 0.85% on DEX swap volume routed through the Rainbow router (existing)
2. **Relay bridge fees** — 0.25% on USD volume for cross-chain bridges routed through Rainbow (new)

Both are sourced from Dune and aggregated per chain in a single prefetch query.

## What changed

Added a `relay_bridge` CTE to the existing Dune SQL query that reads from `dune.rainbowdotme.result_rainbow_relay_tx`, applies the same chain name normalisation (bnb → bsc, avalanche_c → avax), and unions the result with swap fees in the final SELECT so each chain row reflects combined daily revenue.

## Methodology

| Metric | Description |
|--------|-------------|
| Fees | 0.85% on DEX swap volume + 0.25% on relay bridge volume, per chain |
| Revenue | All fees go to the Rainbow protocol |
| ProtocolRevenue | Same as Revenue |

## Verification

Tested for 2026-05-12 via the submodule test harness:

| Chain | Daily fees (swap + relay) |
|-------|--------------------------|
| ethereum | \$803 |
| base | \$622 |
| arbitrum | \$77 |
| bsc | \$17 |
| polygon | \$3 |
| **Total** | **\$1,520** |