### PR TITLE
[feat] B²  : track incentives for bsquared  B² 

### DIFF
--- a/incentives/bsquared/index.ts
+++ b/incentives/bsquared/index.ts
@@ -1,0 +1,58 @@
+import { FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+
+// Source: https://buzz.bsquared.network/
+const WAD = 10n ** 18n;
+const FARMING_REWARDS = "0xd5B5f1CA0fa5636ac54b0a0007BA374A1513346e";
+const MINING_REWARDS = "0x8dc7F4565D72aBD3E40EFBB92063eC8bfca39570";
+const B2 = "bsquared-network";
+
+const MINING_EVENTS = [
+  "event GetReward(address indexed user, uint256 phase, uint256 reward, uint256 time)",
+  "event GetRewardToBSC(address indexed user, uint256 phase, uint256 reward, uint256 time, address airdrop_address, bytes32 message_id)",
+];
+
+const toB2 = (amount: bigint) => Number(amount / WAD) + Number(amount % WAD) / 1e18;
+
+const fetch = async (options: FetchOptions) => {
+  const tokenIncentives = options.createBalances();
+  let b2Incentives = 0n;
+  const [fromBlock, toBlock] = await Promise.all([options.getStartBlock(), options.getEndBlock()]);
+
+  const [b2PerBlock, startBlock, endBlock] = await options.api.batchCall([
+    { target: FARMING_REWARDS, abi: "function b2PerBlock() view returns (uint256)" },
+    { target: FARMING_REWARDS, abi: "function startBlock() view returns (uint256)" },
+    { target: FARMING_REWARDS, abi: "function endBlock() view returns (uint256)" },
+  ]);
+  const activeBlocks = Math.max(0, Math.min(toBlock, Number(endBlock)) - Math.max(fromBlock, Number(startBlock)));
+  b2Incentives += BigInt(activeBlocks) * BigInt(b2PerBlock);
+
+  for (const eventAbi of MINING_EVENTS) {
+    const logs = await options.getLogs({
+      target: MINING_REWARDS,
+      eventAbi,
+    });
+    logs.forEach((log: any) => {
+      b2Incentives += BigInt(log.reward);
+    });
+  }
+
+  tokenIncentives.addCGToken(B2, toB2(b2Incentives));
+  return { tokenIncentives };
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  adapter: {
+    [CHAIN.BSQUARED]: {
+      fetch,
+      start: "2025-04-30",
+    },
+  },
+  methodology: {
+    tokenIncentives:
+      "B2 incentives include the on-chain Buzz Farming B2/block reward schedule and B2 Mining Rig rewards claimed from the mining rewards contract. Partner points displayed in Buzz are excluded because they are off-chain or partner-side rewards.",
+  },
+};
+
+export default adapter;


### PR DESCRIPTION
Tracks incentive for https://defillama.com/protocol/b2-buzz https://defillama.com/protocol/buzz-farming

## Summary
- Adds a B² Network (`bsquared`) incentives adapter for Buzz on B² mainnet.
- Reports B2 token incentives from on-chain Buzz Farming emissions and claimed Buzz Mining rewards.

## Changes
- Added `incentives/bsquared/index.ts` for the B² mainnet incentives export.
- Reads Buzz Farming reward schedule from the farming rewards contract and counts active B2 emissions for the requested block window.
- Aggregates B2 Mining Rig rewards from `GetReward` and `GetRewardToBSC` events on the mining rewards contract.
- Uses CoinGecko token pricing via `addCGToken("bsquared-network", ...)`.
- Documents the Buzz source URL and excludes partner points because they are off-chain or partner-side rewards.

## Methodology
- `tokenIncentives` includes B2 rewards emitted by the Buzz Farming contract plus B2 rewards claimed through the Buzz Mining rewards contract.
- Partner points shown in the Buzz app are excluded to avoid counting rewards that are not directly emitted by the on-chain Buzz contracts.

## Tests
- `pnpm test incentives bsquared 2025-05-14`
- `pnpm test incentives bsquared`