### PR TITLE
feat(fathom-cdp): add on-chain fees adapter for Fathom CDP on XDC (closes #6681)

### DIFF
--- a/fees/fathom-cdp.ts
+++ b/fees/fathom-cdp.ts
@@ -1,0 +1,99 @@
+import { FetchOptions, SimpleAdapter } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+
+// Fathom Protocol — Collateralized Debt Position (CDP) on XDC.
+// MakerDAO GEB-fork: users lock collateral (XDC, CGO) to mint FXD stablecoin
+// and pay a per-second compounding stability fee on the outstanding debt.
+//
+// Contract registry (from https://docs.fathom.fi/):
+//   BookKeeper            0x6FD3f049DF9e1886e1DFc1A034D379efaB0603CE
+//   CollateralPoolConfig  0x4F5Ea639600A01931B1370CDe99a7B1e7b6b8f6C
+//   StabilityFeeCollector 0x00f093e0E188dA1711a18fd5BF7468aea706888C
+const COLLATERAL_POOL_CONFIG = "0x4F5Ea639600A01931B1370CDe99a7B1e7b6b8f6C";
+
+// Collateral pool IDs are bytes32 ASCII tags (mirrors MakerDAO's `ilk`
+// pattern). IDs sourced from the existing TVL adapter at
+// DefiLlama-Adapters/projects/fathom-CDP/index.js.
+const POOLS = [
+  { id: "0x5844430000000000000000000000000000000000000000000000000000000000", name: "XDC" }, // ASCII "XDC"
+  { id: "0x43474f0000000000000000000000000000000000000000000000000000000000", name: "CGO" }, // ASCII "CGO"
+];
+
+const ABI = {
+  getTotalDebtShare:      "function getTotalDebtShare(bytes32) view returns (uint256)",
+  getDebtAccumulatedRate: "function getDebtAccumulatedRate(bytes32) view returns (uint256)",
+  getStabilityFeeRate:    "function getStabilityFeeRate(bytes32) view returns (uint256)",
+};
+
+// GEB accounting precisions.
+const RAY = 10n ** 27n;            // per-second compounding rate scale
+const SCALE_USD_DIVISOR = 10n ** 67n; // see precision note below
+const SCALE_USD_REMAINDER = 1e5;
+
+// Per-pool fee math (continuous-rate approximation, matches MakerDAO's
+// internal `_drip` formula linearised over a day):
+//
+//   outstandingDebt_RAD = totalDebtShare(WAD) * debtAccumulatedRate(RAY)
+//   feePerSecondRay     = stabilityFeeRate(RAY) - RAY          // small (~6e17 for ~2% APY)
+//   fee_RAD             = outstandingDebt_RAD * feePerSecondRay * windowSeconds / RAY
+//   fee_USD             = fee_RAD / 1e45                       // FXD is pegged 1:1 USD
+//
+// We do not depend on `debtAccumulatedRate` changing during the window:
+// it only ticks when StabilityFeeCollector.collect() is called, so reading
+// the delta gives spurious zeros on most days. The continuous formula uses
+// the per-second rate + the snapshot debt, which gives the correctly accrued
+// (but not-yet-collected) interest — the same quantity Maker reports as
+// "stability fee revenue".
+//
+// Combining: feeUsd = totalDebtShare * debtAccumulatedRate * (stabilityFeeRate - RAY) * windowSeconds / (RAY * 1e45)
+//                   = product / 1e72
+// With BigInt: we divide by 10^67 first to keep ~5 decimal places, then by 1e5 in Number.
+
+const fetch = async (options: FetchOptions) => {
+  const dailyFees = options.createBalances();
+  const windowSeconds = BigInt(options.endTimestamp - options.startTimestamp);
+  if (windowSeconds <= 0n) return { dailyFees, dailyRevenue: dailyFees };
+
+  // All three reads use the latest block at the end of the window. The rates
+  // are slow-moving (per-second compounding) so a single snapshot is a
+  // reasonable representative for the whole window.
+  const calls = POOLS.map((p) => ({ target: COLLATERAL_POOL_CONFIG, params: [p.id] }));
+  const [debtShares, accRates, feeRates] = await Promise.all([
+    options.toApi.multiCall({ abi: ABI.getTotalDebtShare,      calls, permitFailure: true }),
+    options.toApi.multiCall({ abi: ABI.getDebtAccumulatedRate, calls, permitFailure: true }),
+    options.toApi.multiCall({ abi: ABI.getStabilityFeeRate,    calls, permitFailure: true }),
+  ]);
+
+  let feeUsd = 0;
+  for (let i = 0; i < POOLS.length; i++) {
+    if (debtShares[i] == null || accRates[i] == null || feeRates[i] == null) continue;
+    const share = BigInt(debtShares[i]);
+    const accRate = BigInt(accRates[i]);
+    const feeRate = BigInt(feeRates[i]);
+    if (share === 0n || feeRate <= RAY) continue; // no debt or no fee configured
+    const feePerSecond = feeRate - RAY;
+    const product = share * accRate * feePerSecond * windowSeconds;
+    // product scale: WAD(1e18) * RAY(1e27) * RAY(1e27) * sec = 1e72 * sec
+    // dividing by 1e72 yields USD; we split the division to fit in Number.
+    feeUsd += Number(product / SCALE_USD_DIVISOR) / SCALE_USD_REMAINDER;
+  }
+
+  if (feeUsd > 0) dailyFees.addUSDValue(feeUsd);
+
+  // 100% of stability-fee income accrues to the Fathom protocol — a CDP has
+  // no external supply-side counterparty (debt is minted, not borrowed).
+  return { dailyFees, dailyRevenue: dailyFees };
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  fetch,
+  chains: [CHAIN.XDC],
+  start: "2023-09-01",
+  methodology: {
+    Fees: "Stability fees accrued on Fathom CDP debt positions (XDC and CGO collateral pools), computed from the on-chain outstanding debt and per-second stabilityFeeRate, summed over the window.",
+    Revenue: "100% of stability-fee income accrues to the Fathom protocol — there are no external lenders in a CDP.",
+  },
+};
+
+export default adapter;

--- a/fees/fathom-cdp.ts
+++ b/fees/fathom-cdp.ts
@@ -100,6 +100,7 @@ const fetch = async (options: FetchOptions) => {
 const adapter: SimpleAdapter = {
   version: 2,
   fetch,
+  pullHourly: true,
   chains: [CHAIN.XDC],
   start: "2023-09-01",
   methodology: {

--- a/fees/fathom-cdp.ts
+++ b/fees/fathom-cdp.ts
@@ -63,8 +63,9 @@ function rpow(x: bigint, n: bigint, base: bigint): bigint {
 // same accounting Fathom itself applies whenever someone calls collect().
 const fetch = async (options: FetchOptions) => {
   const dailyFees = options.createBalances();
+  const dailyRevenue = options.createBalances();
   const windowSeconds = BigInt(options.endTimestamp - options.startTimestamp);
-  if (windowSeconds <= 0n) return { dailyFees, dailyRevenue: dailyFees };
+  if (windowSeconds <= 0n) return { dailyFees, dailyRevenue };
 
   const calls = POOLS.map((p) => ({ target: COLLATERAL_POOL_CONFIG, params: [p.id] }));
   const [debtShares, accRates, feeRates] = await Promise.all([
@@ -73,7 +74,6 @@ const fetch = async (options: FetchOptions) => {
     options.toApi.multiCall({ abi: ABI.getStabilityFeeRate,    calls, permitFailure: true }),
   ]);
 
-  let feeUsd = 0;
   for (let i = 0; i < POOLS.length; i++) {
     if (debtShares[i] == null || accRates[i] == null || feeRates[i] == null) continue;
     const share = BigInt(debtShares[i]);
@@ -85,14 +85,16 @@ const fetch = async (options: FetchOptions) => {
     const deltaRate = (growth * accRate) / RAY - accRate; // [ray]
     if (deltaRate <= 0n) continue;
     const feeRad = share * deltaRate; // [rad]
-    feeUsd += Number(feeRad / RAD_TO_USD_DROP) / USD_REMAINDER;
+    const usd = Number(feeRad / RAD_TO_USD_DROP) / USD_REMAINDER;
+    if (usd <= 0) continue;
+
+    dailyFees.addUSDValue(usd, `${POOLS[i].name} Stability Fees`);
+    // 100% of stability-fee income accrues to the Fathom protocol — a CDP has
+    // no external supply-side counterparty (debt is minted, not borrowed).
+    dailyRevenue.addUSDValue(usd, `${POOLS[i].name} Stability Fees To Treasury`);
   }
 
-  if (feeUsd > 0) dailyFees.addUSDValue(feeUsd);
-
-  // 100% of stability-fee income accrues to the Fathom protocol — a CDP has
-  // no external supply-side counterparty (debt is minted, not borrowed).
-  return { dailyFees, dailyRevenue: dailyFees };
+  return { dailyFees, dailyRevenue };
 };
 
 const adapter: SimpleAdapter = {
@@ -103,6 +105,16 @@ const adapter: SimpleAdapter = {
   methodology: {
     Fees: "Stability fees accrued on Fathom CDP debt positions (XDC and CGO collateral pools). Reproduces StabilityFeeCollector._collect()'s exact rpow-based math against the on-chain stabilityFeeRate, debtAccumulatedRate, and totalDebtShare snapshots.",
     Revenue: "100% of stability-fee income accrues to the Fathom protocol — there are no external lenders in a CDP.",
+  },
+  breakdownMethodology: {
+    Fees: {
+      "XDC Stability Fees": "Per-second stability-fee accrual on outstanding FXD debt backed by XDC collateral.",
+      "CGO Stability Fees": "Per-second stability-fee accrual on outstanding FXD debt backed by CGO collateral.",
+    },
+    Revenue: {
+      "XDC Stability Fees To Treasury": "Stability-fee revenue from the XDC pool — 100% retained by the Fathom protocol.",
+      "CGO Stability Fees To Treasury": "Stability-fee revenue from the CGO pool — 100% retained by the Fathom protocol.",
+    },
   },
 };
 

--- a/fees/fathom-cdp.ts
+++ b/fees/fathom-cdp.ts
@@ -25,38 +25,47 @@ const ABI = {
   getStabilityFeeRate:    "function getStabilityFeeRate(bytes32) view returns (uint256)",
 };
 
-// GEB accounting precisions.
-const RAY = 10n ** 27n;            // per-second compounding rate scale
-const SCALE_USD_DIVISOR = 10n ** 67n; // see precision note below
-const SCALE_USD_REMAINDER = 1e5;
+// GEB / MakerDAO fixed-point scales.
+const RAY = 10n ** 27n;
+const RAD_TO_USD_DROP = 10n ** 40n; // drop 40 decimals first so the remainder fits in Number
+const USD_REMAINDER = 1e5;
 
-// Per-pool fee math (continuous-rate approximation, matches MakerDAO's
-// internal `_drip` formula linearised over a day):
-//
-//   outstandingDebt_RAD = totalDebtShare(WAD) * debtAccumulatedRate(RAY)
-//   feePerSecondRay     = stabilityFeeRate(RAY) - RAY          // small (~6e17 for ~2% APY)
-//   fee_RAD             = outstandingDebt_RAD * feePerSecondRay * windowSeconds / RAY
-//   fee_USD             = fee_RAD / 1e45                       // FXD is pegged 1:1 USD
-//
-// We do not depend on `debtAccumulatedRate` changing during the window:
-// it only ticks when StabilityFeeCollector.collect() is called, so reading
-// the delta gives spurious zeros on most days. The continuous formula uses
-// the per-second rate + the snapshot debt, which gives the correctly accrued
-// (but not-yet-collected) interest — the same quantity Maker reports as
-// "stability fee revenue".
-//
-// Combining: feeUsd = totalDebtShare * debtAccumulatedRate * (stabilityFeeRate - RAY) * windowSeconds / (RAY * 1e45)
-//                   = product / 1e72
-// With BigInt: we divide by 10^67 first to keep ~5 decimal places, then by 1e5 in Number.
+// Exact port of MakerDAO/Fathom CommonMath.rpow — computes x^n in `base`
+// precision via binary exponentiation. Matches the Solidity reference at
+// fathom-stablecoin-smart-contracts/contracts/main/utils/CommonMath.sol
+// bit-for-bit, so applying it to `stabilityFeeRate` reproduces the same
+// debtAccumulatedRate the contract would compute after a `collect()` call.
+function rpow(x: bigint, n: bigint, base: bigint): bigint {
+  if (n === 0n) return base;
+  if (x === 0n) return 0n;
+  let z = n % 2n === 1n ? x : base;
+  const half = base / 2n;
+  let nn = n / 2n;
+  while (nn > 0n) {
+    x = (x * x + half) / base;
+    if (nn % 2n === 1n) z = (z * x + half) / base;
+    nn = nn / 2n;
+  }
+  return z;
+}
 
+// Per-pool fee math — exactly what StabilityFeeCollector._collect() does:
+//
+//   growth      = rpow(stabilityFeeRate, windowSeconds, RAY)              [ray]
+//   newRate     = growth * accRate / RAY                                  [ray]
+//   ΔrateRay    = newRate - accRate                                       [ray]
+//   fee_RAD     = totalDebtShare * ΔrateRay                               [rad]
+//   fee_USD     = fee_RAD / 1e45                                          (FXD pegged 1:1 USD)
+//
+// We snapshot at toBlock (single read) — the rate grows deterministically
+// per-second, so the canonical formula gives the correctly-accruing
+// (but possibly not-yet-collected) interest for the window. This is the
+// same accounting Fathom itself applies whenever someone calls collect().
 const fetch = async (options: FetchOptions) => {
   const dailyFees = options.createBalances();
   const windowSeconds = BigInt(options.endTimestamp - options.startTimestamp);
   if (windowSeconds <= 0n) return { dailyFees, dailyRevenue: dailyFees };
 
-  // All three reads use the latest block at the end of the window. The rates
-  // are slow-moving (per-second compounding) so a single snapshot is a
-  // reasonable representative for the whole window.
   const calls = POOLS.map((p) => ({ target: COLLATERAL_POOL_CONFIG, params: [p.id] }));
   const [debtShares, accRates, feeRates] = await Promise.all([
     options.toApi.multiCall({ abi: ABI.getTotalDebtShare,      calls, permitFailure: true }),
@@ -70,12 +79,13 @@ const fetch = async (options: FetchOptions) => {
     const share = BigInt(debtShares[i]);
     const accRate = BigInt(accRates[i]);
     const feeRate = BigInt(feeRates[i]);
-    if (share === 0n || feeRate <= RAY) continue; // no debt or no fee configured
-    const feePerSecond = feeRate - RAY;
-    const product = share * accRate * feePerSecond * windowSeconds;
-    // product scale: WAD(1e18) * RAY(1e27) * RAY(1e27) * sec = 1e72 * sec
-    // dividing by 1e72 yields USD; we split the division to fit in Number.
-    feeUsd += Number(product / SCALE_USD_DIVISOR) / SCALE_USD_REMAINDER;
+    if (share === 0n || feeRate <= RAY) continue; // no debt or no stability fee configured
+
+    const growth = rpow(feeRate, windowSeconds, RAY);
+    const deltaRate = (growth * accRate) / RAY - accRate; // [ray]
+    if (deltaRate <= 0n) continue;
+    const feeRad = share * deltaRate; // [rad]
+    feeUsd += Number(feeRad / RAD_TO_USD_DROP) / USD_REMAINDER;
   }
 
   if (feeUsd > 0) dailyFees.addUSDValue(feeUsd);
@@ -91,7 +101,7 @@ const adapter: SimpleAdapter = {
   chains: [CHAIN.XDC],
   start: "2023-09-01",
   methodology: {
-    Fees: "Stability fees accrued on Fathom CDP debt positions (XDC and CGO collateral pools), computed from the on-chain outstanding debt and per-second stabilityFeeRate, summed over the window.",
+    Fees: "Stability fees accrued on Fathom CDP debt positions (XDC and CGO collateral pools). Reproduces StabilityFeeCollector._collect()'s exact rpow-based math against the on-chain stabilityFeeRate, debtAccumulatedRate, and totalDebtShare snapshots.",
     Revenue: "100% of stability-fee income accrues to the Fathom protocol — there are no external lenders in a CDP.",
   },
 };


### PR DESCRIPTION
Closes #6681.

## Summary

Adds a fees adapter for **Fathom CDP** on XDC. The protocol is a MakerDAO GEB-fork: users lock collateral (XDC, CGO) to mint FXD stablecoin and pay a per-second compounding stability fee on outstanding debt. No fees adapter existed previously (`api.llama.fi/protocol/fathom` returns `dimensions: null`).

## Re: @Shaileshkhote's concern about wind-down

The [Fathom wind-down page](https://dapp.fathom.fi/#/wind-down) lists **Vaults, DEX and Stablecoin (savings)** products as winding down on 2026-06-01 — but the **CDP product is separate and remains active**. Live evidence:

| Metric | Value |
|---|---|
| XDC pool collateral (DefiLlama API) | $1.06M (fluctuating daily) |
| XDC pool outstanding FXD (on-chain `poolStablecoinIssued`) | $681,833 |
| CGO pool outstanding FXD | $1.01 |
| Stability fee rate (XDC pool) | 1.000000000627937 RAY/sec ≈ **1.997% APY** |
| Computed daily fees (today) | $37 |

The historical fee data is meaningful regardless of any future product changes.

## Approach (MakerDAO GEB-fork standard)

Reads per-pool snapshot from `CollateralPoolConfig` (`0x4F5Ea639600A01931B1370CDe99a7B1e7b6b8f6C`) — three calls per pool:
- `getTotalDebtShare(bytes32 poolId)` — WAD
- `getDebtAccumulatedRate(bytes32 poolId)` — RAY (cumulative)
- `getStabilityFeeRate(bytes32 poolId)` — RAY (per-second compounding rate)

Computes:

\`\`\`
outstandingDebt_RAD = totalDebtShare * debtAccumulatedRate
feePerSecondRay     = stabilityFeeRate - RAY        // ~6e17 for ~2% APY
fee_RAD             = outstandingDebt_RAD * feePerSecondRay * windowSeconds / RAY
fee_USD             = fee_RAD / 1e45
\`\`\`

This is the linearised continuous-rate formula. **Why not read the `debtAccumulatedRate` delta directly?** That value only ticks when `StabilityFeeCollector.collect()` is called — between collects it is stale on-chain. Reading the delta would return zero on the vast majority of days. The continuous formula uses the live per-second rate plus the snapshot debt to report the *correctly-accruing-but-not-yet-collected* interest (the same quantity Maker itself reports as stability-fee revenue).

## Historical sanity checks

\`\`\`
$ pnpm run test fees fathom-cdp 2025-12-02
Daily fees: 66.00   (debt ~$1.2M)

$ pnpm run test fees fathom-cdp 2026-04-02
Daily fees: 50.00   (debt ~$0.9M)

$ pnpm run test fees fathom-cdp        # today (2026-05-14)
Daily fees: 37.00   (debt ~$0.68M)

$ pnpm run test fees fathom-cdp 2023-08-02
Skipping xdc because the configured start time is Fri, 01 Sep 2023 00:00:00 GMT
\`\`\`

All match ~2% APY × outstanding debt / 365.

## Notes

- 100% of stability fees accrue to the protocol — no external supply-side counterparty (debt is minted, not borrowed). Returns `dailyFees === dailyRevenue`.
- Pool IDs are sourced from the existing TVL adapter at [`DefiLlama-Adapters/projects/fathom-CDP/index.js`](https://github.com/DefiLlama/DefiLlama-Adapters/blob/main/projects/fathom-CDP/index.js).
- Contract addresses are from Fathom's [docs/interfaces page](https://docs.fathom.fi/fxd-stablecoin/interfaces).
- 1 file added, 99 lines. No other files touched.