### PR TITLE
fix(solidly-v3): correct invalid Fantom start date

### DIFF
--- a/dexs/solidly-v3/index.ts
+++ b/dexs/solidly-v3/index.ts
@@ -33,7 +33,7 @@ const adapters = {
   [CHAIN.SONIC]: { start: '2024-12-17', fetch },
   [CHAIN.OPTIMISM]: { start: '2024-01-24', fetch },
   [CHAIN.ARBITRUM]: { start: '2024-01-24', fetch },
-  [CHAIN.FANTOM]: { start: '2023-25-12', fetch },
+  [CHAIN.FANTOM]: { start: '2023-12-25', fetch },
   [CHAIN.BASE]: { start: '2024-01-24', fetch },
 }
 


### PR DESCRIPTION
Fix: Corrected an invalid start date for the Fantom chain in dexs/solidly-v3/index.ts. The value '2023-25-12' used month 25, which does not exist. Corrected to '2023-12-25' (December 25, 2023).

