### PR TITLE
fix InoSwap aggregator volume and fees tracking

### DIFF
--- a/aggregators/inoswap/index.ts
+++ b/aggregators/inoswap/index.ts
@@ -1,45 +1,84 @@
-import { FetchOptions } from "../../adapters/types";
+import { FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 import { addTokensReceived } from "../../helpers/token";
 
-const ROUTERS = [
-  '0xf514ec27666f2e9669837f4f9eca6405ba38ac64', // current prod router
+const V6_ROUTERS = [
+  '0xd2b7004682d86f305b1418684825194d9451600c', // v6.3 current prod router
+  '0x895115ccbf109afafcf3552825a8c3ebb8446c52', // v6.2 router
+  '0xa50dc0370f82ea71663c7d253481670d045a4e0b', // v6.1 router
+  '0x691cab720d51b5b2c05cf8c96c07ee5ff3b1d652', // v6 router
+]
+
+const LEGACY_FEE_ROUTERS = [
+  '0xf514ec27666f2e9669837f4f9eca6405ba38ac64', // v5 router
   '0x025f45a3ec6e90e8e1db1492554c9b10539ef2fc', // previous v2 router
   '0x95e8f3227ecc2f35213b6fd6fece6b8854a77db5', // legacy router
 ]
 
-const FEE_RECIPIENT = '0x53a7fcdbb5d9a8d6a9f2b83d6e70cd1efdaf76c6'
-const PROTOCOL_FEE_BPS = 10 // 0.10%
+const LEGACY_FEE_RECIPIENT = '0x53a7fcdbb5d9a8d6a9f2b83d6e70cd1efdaf76c6'
+const LEGACY_PROTOCOL_FEE_BPS = 10 // 0.10%
+const SWAPPED_EVENT = 'event Swapped(address indexed user,address indexed tokenIn,address indexed tokenOut,address recipient,uint256 amountIn,uint256 amountOut,uint256 fee)'
+
+const isPositiveAmount = (value: unknown) => {
+  try {
+    return BigInt((value as { toString?: () => string })?.toString?.() ?? String(value ?? 0)) > 0n
+  } catch {
+    return false
+  }
+}
+
+const isAddress = (value: unknown) => /^0x[a-fA-F0-9]{40}$/.test(String(value ?? ''))
 
 const fetch = async (options: FetchOptions) => {
-  const dailyFees = await addTokensReceived({
+  const dailyVolume = options.createBalances()
+  const dailyFees = options.createBalances()
+  const dailyRevenue = options.createBalances()
+
+  const legacyProtocolFees = await addTokensReceived({
     options,
-    target: FEE_RECIPIENT,
-    fromAdddesses: ROUTERS,
+    target: LEGACY_FEE_RECIPIENT,
+    fromAdddesses: LEGACY_FEE_ROUTERS,
   })
 
-  const dailyVolume = dailyFees.clone(10000 / PROTOCOL_FEE_BPS)
+  dailyFees.addBalances(legacyProtocolFees)
+  dailyRevenue.addBalances(legacyProtocolFees)
+  dailyVolume.addBalances(legacyProtocolFees.clone(10000 / LEGACY_PROTOCOL_FEE_BPS))
+
+  const swapLogs = await options.getLogs({
+    targets: V6_ROUTERS,
+    eventAbi: SWAPPED_EVENT,
+    flatten: true,
+  })
+
+  for (const log of swapLogs) {
+    if (!isAddress(log?.tokenIn) || !isPositiveAmount(log?.amountIn)) continue
+    dailyVolume.add(log.tokenIn, log.amountIn)
+
+    if (isAddress(log?.tokenOut) && isPositiveAmount(log?.fee)) {
+      dailyFees.add(log.tokenOut, log.fee)
+    }
+  }
 
   return {
     dailyVolume,
     dailyFees,
-    dailyRevenue: dailyFees,
-    dailyProtocolRevenue: dailyFees,
+    dailyRevenue,
+    dailyProtocolRevenue: dailyRevenue,
     dailyUserFees: dailyFees,
     dailySupplySideRevenue: 0,
   }
 }
 
 const methodology = {
-  Fees: "Onchain Transfer accounting: sum ERC20 transfers sent from InoSwap routers to feeRecipient.",
-  Revenue: "Mirrors fee stream collected in feeRecipient wallet.",
-  ProtocolRevenue: "Mirrors fee stream collected in feeRecipient wallet.",
-  SupplySideRevenue: "Set to 0 until explicit partner/supply-side distribution events are emitted.",
-  UserFees: "Protocol fees paid by users, inferred from feeRecipient inflows.",
-  Volume: "Inferred from feeRecipient inflows using fixed protocol fee 0.10% (volume = fees / 0.001).",
+  Fees: "User fees emitted by v6 Swapped events plus legacy protocol fees sent to the fee recipient.",
+  Revenue: "Legacy protocol revenue is measured from onchain transfers sent by legacy InoSwap routers to the fee recipient wallet. Current v6 protocol fee is 0 bps.",
+  ProtocolRevenue: "Legacy protocol revenue is measured from onchain transfers sent by legacy InoSwap routers to the fee recipient wallet. Current v6 protocol fee is 0 bps.",
+  SupplySideRevenue: "Set to 0 until explicit partner/supply-side distribution events expose token attribution.",
+  UserFees: "Total user fees emitted by InoSwap routers where available.",
+  Volume: "v6+ volume is counted from Swapped(tokenIn, amountIn) events; legacy volume is inferred from the historical 0.10% protocol fee stream.",
 }
 
-const adapter: any = {
+const adapter: SimpleAdapter = {
   version: 2,
   pullHourly: true,
   fetch,

--- a/aggregators/inoswap/index.ts
+++ b/aggregators/inoswap/index.ts
@@ -2,11 +2,8 @@ import { FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 import { addTokensReceived } from "../../helpers/token";
 
-const V6_ROUTERS = [
+const CURRENT_V6_ROUTERS = [
   '0xd2b7004682d86f305b1418684825194d9451600c', // v6.3 current prod router
-  '0x895115ccbf109afafcf3552825a8c3ebb8446c52', // v6.2 router
-  '0xa50dc0370f82ea71663c7d253481670d045a4e0b', // v6.1 router
-  '0x691cab720d51b5b2c05cf8c96c07ee5ff3b1d652', // v6 router
 ]
 
 const LEGACY_FEE_ROUTERS = [
@@ -45,7 +42,7 @@ const fetch = async (options: FetchOptions) => {
   dailyVolume.addBalances(legacyProtocolFees.clone(10000 / LEGACY_PROTOCOL_FEE_BPS))
 
   const swapLogs = await options.getLogs({
-    targets: V6_ROUTERS,
+    targets: CURRENT_V6_ROUTERS,
     eventAbi: SWAPPED_EVENT,
     flatten: true,
   })
@@ -56,6 +53,7 @@ const fetch = async (options: FetchOptions) => {
 
     if (isAddress(log?.tokenOut) && isPositiveAmount(log?.fee)) {
       dailyFees.add(log.tokenOut, log.fee)
+      dailyRevenue.add(log.tokenOut, log.fee)
     }
   }
 
@@ -71,11 +69,11 @@ const fetch = async (options: FetchOptions) => {
 
 const methodology = {
   Fees: "User fees emitted by v6 Swapped events plus legacy protocol fees sent to the fee recipient.",
-  Revenue: "Legacy protocol revenue is measured from onchain transfers sent by legacy InoSwap routers to the fee recipient wallet. Current v6 protocol fee is 0 bps.",
-  ProtocolRevenue: "Legacy protocol revenue is measured from onchain transfers sent by legacy InoSwap routers to the fee recipient wallet. Current v6 protocol fee is 0 bps.",
+  Revenue: "Protocol revenue is measured from v6 Swapped event fees and legacy fee-recipient transfers.",
+  ProtocolRevenue: "Protocol revenue is measured from v6 Swapped event fees and legacy fee-recipient transfers.",
   SupplySideRevenue: "Set to 0 until explicit partner/supply-side distribution events expose token attribution.",
   UserFees: "Total user fees emitted by InoSwap routers where available.",
-  Volume: "v6+ volume is counted from Swapped(tokenIn, amountIn) events; legacy volume is inferred from the historical 0.10% protocol fee stream.",
+  Volume: "Current v6.3 volume is counted from Swapped(tokenIn, amountIn) events; legacy volume is inferred from the historical 0.10% protocol fee stream.",
 }
 
 const adapter: SimpleAdapter = {


### PR DESCRIPTION
## Summary
- update the InoSwap Cronos aggregator adapter to track the current production v6.3 router
- count current production volume from v6.3 `Swapped(tokenIn, amountIn)` events
- count v6.3 emitted swap fees as fees/revenue now that protocol fees are enabled again
- keep the legacy fee-recipient path for historical v5 volume/fee coverage

## Why
The original InoSwap adapter PR (#6009) was moved on-chain after review feedback asked for historical on-chain coverage. Since then InoSwap production moved to v6.3, while the existing adapter only indexes legacy routers and can miss current routed volume.

Current production router: `0xd2b7004682d86f305b1418684825194d9451600c`.

The adapter intentionally does not include earlier v6/v6.1/v6.2 router deployments because those are not the currently connected production router; legacy v5 routers remain covered through the historical fee-recipient path.

## Validation
- `npm run ts-check -- --pretty false`
- `npm test -- aggregators inoswap 1778788800`
  - Cronos daily volume for 2026-05-14 19:00-20:00 UTC: `1.29`
  - daily fees/revenue/protocol revenue are `0.00` for that historical window because it predates the v6.3 protocol fee update