### PR TITLE
remove duplicate fee additions

### DIFF
--- a/dexs/w-dex/index.ts
+++ b/dexs/w-dex/index.ts
@@ -70,16 +70,12 @@ const fetch = async (options: FetchOptions) => {
 
   dailyFees.addBalances(infraFees, 'InfraFee');
   dailyFees.addBalances(protocolFees, 'ProtocolFee');
+  dailyFees.addBalances(lpFees, 'LPFee');
+
   dailyRevenue.addBalances(protocolFees, 'ProtocolFee');
 
-  dailyFees.addBalances(lpFees, 'LPFee');
   dailySupplySideRevenue.addBalances(lpFees, 'LPFee');
-
-  dailyFees.add(protocolFees, 'ProtocolFee');
-  dailyRevenue.add(protocolFees, 'ProtocolFee');
-
-  dailyFees.add(infraFees, 'InfraFee');
-  dailySupplySideRevenue.add(infraFees, 'InfraFee');
+  dailySupplySideRevenue.addBalances(infraFees, 'InfraFee');
 
   return {
     dailyVolume,


### PR DESCRIPTION
- w-dex was counting `protocolFees` and `infraFees` twice, first through `addBalances()`, then again through `.add()`, which already routes back to `addBalances()`
- This inflated live metrics: `dailyFees` by ~15% and doubled both `dailyRevenue` and `dailyProtocolRevenue`. The revenue/fees ratio showed ~23.5% instead of the expected 13.5%.
- Fixed by consolidating each destination into a single `addBalances()` call. `InfraFee` still remains under `dailySupplySideRevenue`
