### PR TITLE
[feat] Kaio: track managment fees for kaio

### DIFF
--- a/fees/kaio/index.ts
+++ b/fees/kaio/index.ts
@@ -1,0 +1,62 @@
+import { FetchOptions, FetchResult, SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import { METRIC } from "../../helpers/metrics";
+import { fetchURLAutoHandleRateLimit } from "../../utils/fetchURL";
+
+const KAIO_TVL_API = "https://api.kaio.xyz/api/v1/tvl";
+const YEAR_IN_SECONDS = 365 * 24 * 60 * 60;
+
+// Source: RWA.xyz asset pages list annual management fees for each KAIO fund.
+const MANAGEMENT_FEE_RATES: Record<string, number> = {
+  VOLTx: 0.0105, // https://app.rwa.xyz/assets/VOLTx
+  MACROx: 0.005, // https://app.rwa.xyz/assets/MACROx
+  SCOPEx: 0.005, // https://app.rwa.xyz/assets/SCOPEx
+  CASHx: 0.0015, // https://app.rwa.xyz/assets/CASHx
+};
+
+async function fetch(_a: any, _b: any, options: FetchOptions): Promise<FetchResult> {
+  const { assets } = await fetchURLAutoHandleRateLimit(KAIO_TVL_API);
+  if (!assets?.length) throw new Error("Missing KAIO TVL assets");
+
+  const periodInYears = (options.toTimestamp - options.fromTimestamp) / YEAR_IN_SECONDS;
+  const dailyFees = options.createBalances();
+  const dailyRevenue = options.createBalances();
+
+  for (const { symbol, tvl } of assets) {
+    const managementFees = (tvl || 0) * (MANAGEMENT_FEE_RATES[symbol] || 0) * periodInYears;
+
+    dailyFees.addUSDValue(managementFees, METRIC.MANAGEMENT_FEES);
+    dailyRevenue.addUSDValue(managementFees, METRIC.MANAGEMENT_FEES);
+  }
+
+  return {
+    dailyFees,
+    dailyRevenue,
+    dailyProtocolRevenue: dailyRevenue,
+  };
+}
+
+const adapter: SimpleAdapter = {
+  fetch,
+  chains: [CHAIN.CHAIN_GLOBAL],
+  methodology: {
+    Fees: "Estimated daily management fees from KAIO's current TVL and the annual fund fee rates listed on RWA.xyz.",
+    Revenue: "Management fees are counted as protocol revenue.",
+    ProtocolRevenue: "All estimated management fee revenue is attributed to the protocol.",
+  },
+  breakdownMethodology: {
+    Fees: {
+      [METRIC.MANAGEMENT_FEES]: "Estimated management fees from KAIO's current TVL and the annual fund fee rates listed on RWA.xyz.",
+    },
+    Revenue: {
+      [METRIC.MANAGEMENT_FEES]: "Management fees are counted as protocol revenue.",
+    },
+    ProtocolRevenue: {
+      [METRIC.MANAGEMENT_FEES]: "All estimated management fee revenue is attributed to the protocol.",
+    },
+  },
+  runAtCurrTime: true,
+  start: "2026-05-13",
+};
+
+export default adapter;

--- a/fees/kaio/index.ts
+++ b/fees/kaio/index.ts
@@ -23,6 +23,9 @@ const chainConfig = {
     [CHAIN.NEAR]: "Near",
     [CHAIN.APTOS]: "Aptos",
     [CHAIN.SOLANA]: "Solana",
+    [CHAIN.XDC]: "XDC",
+    [CHAIN.INJECTIVE]: "Injective",
+    [CHAIN.HEDERA]: "Hedera",
 }
 
 async function prefetch(_options: FetchOptions) {
@@ -46,11 +49,10 @@ async function fetch(_a: any, _b: any, options: FetchOptions): Promise<FetchResu
 
     if (options.chain === CHAIN.ETHEREUM) {
         for (const asset of assets) {
-            const managementFees = (asset.tvl || 0) * (MANAGEMENT_FEE_RATES[asset.symbol] || 0) * periodInYears;
-
-            if(asset.tvl > 10_000_000 && MANAGEMENT_FEE_RATES[asset.symbol] === undefined) {
+            if (asset.tvl > 10_000_000 && MANAGEMENT_FEE_RATES[asset.symbol] === undefined) {
                 throw new Error(`Missing management fee rate for ${asset.symbol}`);
             }
+            const managementFees = (asset.tvl || 0) * (MANAGEMENT_FEE_RATES[asset.symbol] || 0) * periodInYears;
 
             dailyFees.addUSDValue(managementFees, METRIC.MANAGEMENT_FEES);
             dailyRevenue.addUSDValue(managementFees, METRIC.MANAGEMENT_FEES);
@@ -59,7 +61,7 @@ async function fetch(_a: any, _b: any, options: FetchOptions): Promise<FetchResu
             for (const asset of chaindata.assets) {
                 const symbol = instrumentIdToSymbol.get(asset.instrumentId);
                 if (!symbol) continue;
-                const managementFees = (asset.tvl || 0) * (MANAGEMENT_FEE_RATES[symbol]) * periodInYears;
+                const managementFees = (asset.tvl || 0) * (MANAGEMENT_FEE_RATES[symbol] || 0) * periodInYears;
                 dailyFees.addUSDValue(-1 * managementFees, METRIC.MANAGEMENT_FEES);
                 dailyRevenue.addUSDValue(-1 * managementFees, METRIC.MANAGEMENT_FEES);
             }

--- a/fees/kaio/index.ts
+++ b/fees/kaio/index.ts
@@ -1,62 +1,109 @@
 import { FetchOptions, FetchResult, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 import { METRIC } from "../../helpers/metrics";
-import { fetchURLAutoHandleRateLimit } from "../../utils/fetchURL";
+import fetchURL from "../../utils/fetchURL";
 
 const KAIO_TVL_API = "https://api.kaio.xyz/api/v1/tvl";
 const YEAR_IN_SECONDS = 365 * 24 * 60 * 60;
 
 // Source: RWA.xyz asset pages list annual management fees for each KAIO fund.
 const MANAGEMENT_FEE_RATES: Record<string, number> = {
-  VOLTx: 0.0105, // https://app.rwa.xyz/assets/VOLTx
-  MACROx: 0.005, // https://app.rwa.xyz/assets/MACROx
-  SCOPEx: 0.005, // https://app.rwa.xyz/assets/SCOPEx
-  CASHx: 0.0015, // https://app.rwa.xyz/assets/CASHx
+    VOLTx: 0.0105, // https://app.rwa.xyz/assets/VOLTx
+    MACROx: 0.005, // https://app.rwa.xyz/assets/MACROx
+    SCOPEx: 0.005, // https://app.rwa.xyz/assets/SCOPEx
+    CASHx: 0.0015, // https://app.rwa.xyz/assets/CASHx
 };
 
+const chainConfig = {
+    [CHAIN.ETHEREUM]: "",
+    [CHAIN.POLYGON]: "Polygon",
+    [CHAIN.AVAX]: "Avalanche",
+    [CHAIN.IMMUTABLEX]: "Immutable",
+    [CHAIN.SUI]: "Sui",
+    [CHAIN.NEAR]: "Near",
+    [CHAIN.APTOS]: "Aptos",
+    [CHAIN.SOLANA]: "Solana",
+}
+
+async function prefetch(_options: FetchOptions) {
+    const { assets } = await fetchURL(KAIO_TVL_API);
+    const receipts = await fetchURL(`${KAIO_TVL_API}/receipts`);
+    return {
+        assets,
+        receipts,
+    }
+}
+
 async function fetch(_a: any, _b: any, options: FetchOptions): Promise<FetchResult> {
-  const { assets } = await fetchURLAutoHandleRateLimit(KAIO_TVL_API);
-  if (!assets?.length) throw new Error("Missing KAIO TVL assets");
+    const { assets, receipts } = options.preFetchedResults;
+    if (!assets?.length) throw new Error("Missing KAIO TVL assets");
 
-  const periodInYears = (options.toTimestamp - options.fromTimestamp) / YEAR_IN_SECONDS;
-  const dailyFees = options.createBalances();
-  const dailyRevenue = options.createBalances();
+    const instrumentIdToSymbol: Map<string, string> = new Map(assets.map((asset: any) => [asset.instrumentId, asset.symbol]));
 
-  for (const { symbol, tvl } of assets) {
-    const managementFees = (tvl || 0) * (MANAGEMENT_FEE_RATES[symbol] || 0) * periodInYears;
+    const periodInYears = (options.toTimestamp - options.fromTimestamp) / YEAR_IN_SECONDS;
+    const dailyFees = options.createBalances();
+    const dailyRevenue = options.createBalances();
 
-    dailyFees.addUSDValue(managementFees, METRIC.MANAGEMENT_FEES);
-    dailyRevenue.addUSDValue(managementFees, METRIC.MANAGEMENT_FEES);
-  }
+    if (options.chain === CHAIN.ETHEREUM) {
+        for (const asset of assets) {
+            const managementFees = (asset.tvl || 0) * (MANAGEMENT_FEE_RATES[asset.symbol] || 0) * periodInYears;
 
-  return {
-    dailyFees,
-    dailyRevenue,
-    dailyProtocolRevenue: dailyRevenue,
-  };
+            if(asset.tvl > 10_000_000 && MANAGEMENT_FEE_RATES[asset.symbol] === undefined) {
+                throw new Error(`Missing management fee rate for ${asset.symbol}`);
+            }
+
+            dailyFees.addUSDValue(managementFees, METRIC.MANAGEMENT_FEES);
+            dailyRevenue.addUSDValue(managementFees, METRIC.MANAGEMENT_FEES);
+        }
+        for (const chaindata of receipts.chains) {
+            for (const asset of chaindata.assets) {
+                const symbol = instrumentIdToSymbol.get(asset.instrumentId);
+                if (!symbol) continue;
+                const managementFees = (asset.tvl || 0) * (MANAGEMENT_FEE_RATES[symbol]) * periodInYears;
+                dailyFees.addUSDValue(-1 * managementFees, METRIC.MANAGEMENT_FEES);
+                dailyRevenue.addUSDValue(-1 * managementFees, METRIC.MANAGEMENT_FEES);
+            }
+        }
+    }
+    else {
+        const { assets } = receipts.chains.find((data: any) => data.chain === chainConfig[options.chain]);
+        for (const asset of assets) {
+            const symbol = instrumentIdToSymbol.get(asset.instrumentId);
+            if (!symbol) continue;
+            const managementFees = (asset.tvl || 0) * (MANAGEMENT_FEE_RATES[symbol] || 0) * periodInYears;
+            dailyFees.addUSDValue(managementFees, METRIC.MANAGEMENT_FEES);
+            dailyRevenue.addUSDValue(managementFees, METRIC.MANAGEMENT_FEES);
+        }
+    }
+
+    return {
+        dailyFees,
+        dailyRevenue,
+        dailyProtocolRevenue: dailyRevenue,
+    };
 }
 
 const adapter: SimpleAdapter = {
-  fetch,
-  chains: [CHAIN.CHAIN_GLOBAL],
-  methodology: {
-    Fees: "Estimated daily management fees from KAIO's current TVL and the annual fund fee rates listed on RWA.xyz.",
-    Revenue: "Management fees are counted as protocol revenue.",
-    ProtocolRevenue: "All estimated management fee revenue is attributed to the protocol.",
-  },
-  breakdownMethodology: {
-    Fees: {
-      [METRIC.MANAGEMENT_FEES]: "Estimated management fees from KAIO's current TVL and the annual fund fee rates listed on RWA.xyz.",
+    prefetch,
+    fetch,
+    chains: Object.keys(chainConfig),
+    methodology: {
+        Fees: "Estimated daily management fees from KAIO's current TVL and the annual fund fee rates listed on RWA.xyz.",
+        Revenue: "Management fees are counted as protocol revenue.",
+        ProtocolRevenue: "All estimated management fee revenue is attributed to the protocol.",
     },
-    Revenue: {
-      [METRIC.MANAGEMENT_FEES]: "Management fees are counted as protocol revenue.",
+    breakdownMethodology: {
+        Fees: {
+            [METRIC.MANAGEMENT_FEES]: "Estimated management fees from KAIO's current TVL and the annual fund fee rates listed on RWA.xyz.",
+        },
+        Revenue: {
+            [METRIC.MANAGEMENT_FEES]: "Management fees are counted as protocol revenue.",
+        },
+        ProtocolRevenue: {
+            [METRIC.MANAGEMENT_FEES]: "All estimated management fee revenue is attributed to the protocol.",
+        },
     },
-    ProtocolRevenue: {
-      [METRIC.MANAGEMENT_FEES]: "All estimated management fee revenue is attributed to the protocol.",
-    },
-  },
-  runAtCurrTime: true,
-  start: "2026-05-13",
+    runAtCurrTime: true,
 };
 
 export default adapter;


### PR DESCRIPTION
Tracks protocol revenue for https://defillama.com/protocol/kaio

## Summary
- Adds a KAIO fees adapter for estimated management fees.
- Uses KAIO's public TVL endpoint and RWA.xyz annual fund fee rates for VOLTx, MACROx, SCOPEx, and CASHx.

## Changes
- Added `fees/kaio`.
- Reports `dailyFees`, `dailyRevenue`, and `dailyProtocolRevenue` on `chain_global`.
- Uses `fetchURLAutoHandleRateLimit` for the KAIO TVL API request.
- Adds methodology and breakdown methodology for `METRIC.MANAGEMENT_FEES`.

## Methodology
- Estimates daily management fees from current KAIO TVL.
- Applies annual management fee rates listed on RWA.xyz: VOLTx 1.05%, MACROx 0.5%, SCOPEx 0.5%, and CASHx 0.15%.
- Treats all estimated management fees as protocol revenue.

## Data Quality / Risk
- The adapter uses KAIO's current TVL API and is marked with `runAtCurrTime: true`; it does not backfill historical TVL.
- The calculation excludes subscription/redemption settlement fees and only covers management fee estimates.

## Tests
- `pnpm test fees kaio`