### PR TITLE
Add Nad.fun V2 metrics

### DIFF
--- a/dexs/nad-fun.ts
+++ b/dexs/nad-fun.ts
@@ -561,7 +561,11 @@ async function addV2Metrics(options: FetchOptions, balances: MetricsBalances) {
         logs.forEach((rawLog) => {
           const pair = rawLog.address.toLowerCase();
           const meta = pairMeta[pair];
-          if (!meta?.quoteToken) return;
+          if (!meta?.quoteToken) {
+            throw new Error(
+              `Missing quoteToken for NadFunPair ${pair}: ${JSON.stringify(meta ?? null)}`,
+            );
+          }
 
           const quoteIsToken0 =
             meta.quoteToken.toLowerCase() === meta.token0.toLowerCase();

--- a/dexs/nad-fun.ts
+++ b/dexs/nad-fun.ts
@@ -1,4 +1,5 @@
 import { ethers } from "ethers";
+import PromisePool from "@supercharge/promise-pool";
 import { Adapter, FetchOptions, FetchResultV2 } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
 import { METRIC } from "../helpers/metrics";
@@ -6,6 +7,7 @@ import { METRIC } from "../helpers/metrics";
 type Balances = ReturnType<FetchOptions["createBalances"]>;
 
 const BPS = 10_000n;
+const MON = 10n ** 18n;
 const V1_FEE_RATE_DENOMINATOR = 1_000_000n;
 
 const v1 = {
@@ -58,6 +60,10 @@ const v2Abi = {
   Swap:
     "event Swap(address indexed sender, uint256 amount0In, uint256 amount1In, uint256 amount0Out, uint256 amount1Out, address indexed to)",
   Transfer: "event Transfer(address indexed from, address indexed to, uint256 value)",
+  allPairsLength: "uint256:allPairsLength",
+  allPairs: "function allPairs(uint256) view returns (address)",
+  token0: "address:token0",
+  token1: "address:token1",
   feeReceiver: "address:feeReceiver",
   getQuoteToken: "function getQuoteToken(address token) view returns (address)",
   getFeeConfig:
@@ -105,6 +111,8 @@ const metrics = {
 
 const transferTopic =
   "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef";
+const swapTopic =
+  "0xd78ad95fa46c994b6551d0da85fc275fe613ce37657fb8d5e3d130840159d822";
 const monEquivalentQuoteTokens = new Set(
   v2.monEquivalentQuoteTokens.map((token) => token.toLowerCase()),
 );
@@ -182,6 +190,35 @@ function toTopicAddress(address: string): string {
   return ethers.zeroPadValue(address, 32);
 }
 
+async function getLogsInBlockChunks(
+  options: FetchOptions,
+  params: Parameters<FetchOptions["getLogs"]>[0],
+  blockStep = 10_000,
+) {
+  const fromBlock = await options.getFromBlock();
+  const toBlock = await options.getToBlock();
+  const ranges: [number, number][] = [];
+
+  for (let startBlock = fromBlock; startBlock <= toBlock; startBlock += blockStep) {
+    ranges.push([startBlock, Math.min(startBlock + blockStep - 1, toBlock)]);
+  }
+
+  const allLogs: any[] = [];
+  await PromisePool.withConcurrency(5)
+    .for(ranges)
+    .process(async ([fromBlock, toBlock]) => {
+      const logs = await options.getLogs({
+        ...params,
+        fromBlock,
+        toBlock,
+        skipCache: true,
+      });
+      allLogs.push(...logs);
+    });
+
+  return allLogs;
+}
+
 async function addV1Metrics(options: FetchOptions, balances: MetricsBalances) {
   const { dailyFees, dailyVolume, dailyRevenue, dailySupplySideRevenue } =
     balances;
@@ -237,17 +274,20 @@ async function addV1Metrics(options: FetchOptions, balances: MetricsBalances) {
         left.blockNumber - right.blockNumber,
     );
 
-  dailyFees.addGasToken(10 * creationLogs.length * 1e18, metrics.CreationFees);
   dailyFees.addGasToken(
-    3_000 * graduateLogs.length * 1e18,
+    10n * BigInt(creationLogs.length) * MON,
+    metrics.CreationFees,
+  );
+  dailyFees.addGasToken(
+    3_000n * BigInt(graduateLogs.length) * MON,
     metrics.GraduationFees,
   );
   dailyRevenue.addGasToken(
-    10 * creationLogs.length * 1e18,
+    10n * BigInt(creationLogs.length) * MON,
     metrics.CreationFees,
   );
   dailyRevenue.addGasToken(
-    3_000 * graduateLogs.length * 1e18,
+    3_000n * BigInt(graduateLogs.length) * MON,
     metrics.GraduationFees,
   );
 
@@ -280,8 +320,8 @@ async function addV1Metrics(options: FetchOptions, balances: MetricsBalances) {
       foundationAmount: string | number;
       creatorAmount: string | number;
     }) => {
-      const foundationAmount = Number(log.foundationAmount);
-      const creatorAmount = Number(log.creatorAmount);
+      const foundationAmount = toBigInt(log.foundationAmount);
+      const creatorAmount = toBigInt(log.creatorAmount);
 
       dailyFees.addGasToken(foundationAmount, metrics.FoundationFees);
       dailyFees.addGasToken(creatorAmount, metrics.CreatorsFees);
@@ -293,68 +333,89 @@ async function addV1Metrics(options: FetchOptions, balances: MetricsBalances) {
   );
 
   buyLogs.forEach((log) => {
-    const fee = (Number(log.amountIn) * 1) / 100; // 1% fee on buys
+    const amountIn = toBigInt(log.amountIn);
+    const fee = amountIn / 100n; // 1% fee on buys
     dailyFees.addGasToken(fee, metrics.BuyFees);
     dailyRevenue.addGasToken(fee, metrics.BuyFees);
-    dailyVolume.addGasToken(Number(log.amountIn));
+    dailyVolume.addGasToken(amountIn);
   });
 
   sellLogs.forEach((log) => {
-    const fee = (Number(log.amountOut) * 1) / 100; // 1% fee on sells
+    const amountOut = toBigInt(log.amountOut);
+    const fee = amountOut / 100n; // 1% fee on sells
     dailyFees.addGasToken(fee, metrics.SellFees);
     dailyRevenue.addGasToken(fee, metrics.SellFees);
-    dailyVolume.addGasToken(log.amountOut);
+    dailyVolume.addGasToken(amountOut);
   });
 }
 
 async function getV2PairMetadata(options: FetchOptions) {
-  const pairLogs: any[] = [];
-
-  await options.streamLogs({
+  const pairCountResult = await options.api.call({
     target: v2.nadFunFactory,
-    eventAbi: v2Abi.PairCreated,
-    fromBlock: v2.startBlock,
-    processor: (logs: any[]) => {
-      pairLogs.push(...logs);
-    },
+    abi: v2Abi.allPairsLength,
   });
+  const pairCount = Number(toBigInt(pairCountResult));
 
-  const pairs = pairLogs.map((log: any) => log.pair as string);
+  if (pairCount === 0) return { pairs: [], pairMeta: {} };
+
+  const pairCalls = Array.from({ length: pairCount }, (_, index) => ({
+    target: v2.nadFunFactory,
+    params: [index],
+  }));
+  const pairs = (
+    await options.api.multiCall({
+      abi: v2Abi.allPairs,
+      calls: pairCalls,
+    })
+  ).map((pair: string) => pair.toLowerCase());
   const pairMeta: Record<string, V2PairMeta> = {};
 
-  pairLogs.forEach((log: any) => {
-    const pair = (log.pair as string).toLowerCase();
-    const token0 = log.token0 as string;
-    const token1 = log.token1 as string;
+  const [token0s, token1s, configs] = await Promise.all([
+    options.api.multiCall({
+      abi: v2Abi.token0,
+      calls: pairs,
+      permitFailure: true,
+    }),
+    options.api.multiCall({
+      abi: v2Abi.token1,
+      calls: pairs,
+      permitFailure: true,
+    }),
+    options.api.multiCall({
+      target: v2.feeCollector,
+      abi: v2Abi.getFeeConfig,
+      calls: pairs.map((pair: string) => ({ params: [pair] })),
+      permitFailure: true,
+    }),
+  ]);
+
+  pairs.forEach((pair: string, index: number) => {
+    const token0 = token0s[index] as string | undefined;
+    const token1 = token1s[index] as string | undefined;
+    if (!token0 || !token1) {
+      throw new Error(`Missing token metadata for NadFunPair ${pair}`);
+    }
     const knownQuoteToken = [token0, token1].find((token) =>
       monEquivalentQuoteTokens.has(token.toLowerCase()),
     );
+    const config = configs[index];
 
     pairMeta[pair] = {
       token0,
       token1,
-      quoteToken: knownQuoteToken,
-    };
-  });
-
-  if (pairs.length === 0) return { pairs, pairMeta };
-
-  const configs = await options.api.multiCall({
-    target: v2.feeCollector,
-    abi: v2Abi.getFeeConfig,
-    calls: pairs.map((pair: string) => ({ params: [pair] })),
-    permitFailure: true,
-  });
-
-  configs.forEach((config: any, index: number) => {
-    if (!config) return;
-    const pair = pairs[index].toLowerCase();
-    pairMeta[pair] = {
-      ...pairMeta[pair],
-      quoteToken: config.quoteToken,
-      creatorFeeRate: Number(config.creatorFeeRate),
-      curveProtocolFeeRate: Number(config.curveProtocolFeeRate),
-      dexProtocolFeeRate: Number(config.dexProtocolFeeRate),
+      quoteToken: config?.quoteToken ?? knownQuoteToken,
+      creatorFeeRate:
+        config?.creatorFeeRate === undefined
+          ? undefined
+          : Number(config.creatorFeeRate),
+      curveProtocolFeeRate:
+        config?.curveProtocolFeeRate === undefined
+          ? undefined
+          : Number(config.curveProtocolFeeRate),
+      dexProtocolFeeRate:
+        config?.dexProtocolFeeRate === undefined
+          ? undefined
+          : Number(config.dexProtocolFeeRate),
     };
   });
 
@@ -392,37 +453,37 @@ async function addV2ProtocolTransfers(
 ) {
   if (!quoteTokens.length) return;
 
-  const logsByToken = await options.getLogs({
+  const quoteTokenSet = new Set(quoteTokens.map((token) => token.toLowerCase()));
+  const logs = await getLogsInBlockChunks(options, {
     targets: quoteTokens,
-    flatten: false,
-    noTarget: true,
     eventAbi: v2Abi.Transfer,
     topics: [
       transferTopic,
       toTopicAddress(source),
       toTopicAddress(feeReceiver),
     ],
+    entireLog: true,
+    parseLog: true,
   });
 
-  logsByToken.forEach((logs: any[], index: number) => {
-    const quoteToken = quoteTokens[index];
-    logs.forEach((rawLog) => {
-      const log = logArgs<{ value: string | number | bigint }>(rawLog);
+  logs.forEach((rawLog) => {
+    const quoteToken = (rawLog.address ?? rawLog.source)?.toLowerCase();
+    if (!quoteTokenSet.has(quoteToken)) return;
+    const log = logArgs<{ value: string | number | bigint }>(rawLog);
+    addQuoteBalance(
+      revenueBalances,
+      quoteToken,
+      log.value,
+      metrics.V2ProtocolFees,
+    );
+    if (feeBalances) {
       addQuoteBalance(
-        revenueBalances,
+        feeBalances,
         quoteToken,
         log.value,
         metrics.V2ProtocolFees,
       );
-      if (feeBalances) {
-        addQuoteBalance(
-          feeBalances,
-          quoteToken,
-          log.value,
-          metrics.V2ProtocolFees,
-        );
-      }
-    });
+    }
   });
 }
 
@@ -452,17 +513,17 @@ async function addV2Metrics(options: FetchOptions, balances: MetricsBalances) {
 
   const [curveBuyLogs, curveSellLogs, collectLogs, { pairs, pairMeta }] =
     await Promise.all([
-      options.getLogs({
+      getLogsInBlockChunks(options, {
         target: v2.bondingCurve,
         eventAbi: v2Abi.Buy,
         onlyArgs: false,
       }),
-      options.getLogs({
+      getLogsInBlockChunks(options, {
         target: v2.bondingCurve,
         eventAbi: v2Abi.Sell,
         onlyArgs: false,
       }),
-      options.getLogs({
+      getLogsInBlockChunks(options, {
         target: v2.feeCollector,
         eventAbi: v2Abi.Collect,
         onlyArgs: false,
@@ -556,57 +617,62 @@ async function addV2Metrics(options: FetchOptions, balances: MetricsBalances) {
   });
 
   if (pairs.length > 0) {
-    await options.streamLogs({
-      targets: pairs,
-      eventAbi: v2Abi.Swap,
-      entireLog: true,
-      targetsFilter: pairs,
-      processor: (logs: any[]) => {
-        logs.forEach((rawLog) => {
-          const pair = rawLog.address.toLowerCase();
-          const meta = pairMeta[pair];
-          if (!meta?.quoteToken) {
-            throw new Error(
-              `Missing quoteToken for NadFunPair ${pair}: ${JSON.stringify(meta ?? null)}`,
-            );
-          }
-
-          const quoteIsToken0 =
-            meta.quoteToken.toLowerCase() === meta.token0.toLowerCase();
-          const log = logArgs<{
-            amount0In: string | number | bigint;
-            amount1In: string | number | bigint;
-            amount0Out: string | number | bigint;
-            amount1Out: string | number | bigint;
-          }>(rawLog);
-
-          const quoteIn = quoteIsToken0
-            ? toBigInt(log.amount0In)
-            : toBigInt(log.amount1In);
-          const quoteOut = quoteIsToken0
-            ? toBigInt(log.amount0Out)
-            : toBigInt(log.amount1Out);
-          const quoteVolume = quoteIn + quoteOut;
-          const lpFee = mulBps(quoteVolume, 25n); // NadFunPair LP_FEE_RATE = 0.25%
-          const protocolLpFee = lpFee / 5n; // _mintFee captures 1/5 of LP fees
-          const supplySideLpFee = lpFee - protocolLpFee;
-
-          addQuoteBalance(dailyVolume, meta.quoteToken, quoteVolume);
-          addQuoteBalance(dailyFees, meta.quoteToken, lpFee, metrics.V2LpFees);
-          addQuoteBalance(
-            dailyRevenue,
-            meta.quoteToken,
-            protocolLpFee,
-            metrics.V2ProtocolFees,
-          );
-          addQuoteBalance(
-            dailySupplySideRevenue,
-            meta.quoteToken,
-            supplySideLpFee,
-            metrics.V2LpFees,
-          );
-        });
+    const pairSet = new Set(pairs);
+    const swapLogs = await getLogsInBlockChunks(
+      options,
+      {
+        noTarget: true,
+        eventAbi: v2Abi.Swap,
+        topics: [swapTopic],
+        entireLog: true,
+        parseLog: true,
       },
+    );
+
+    swapLogs.forEach((rawLog) => {
+      const pair = (rawLog.address ?? rawLog.source)?.toLowerCase();
+      if (!pairSet.has(pair)) return;
+      const meta = pairMeta[pair];
+      if (!meta?.quoteToken || !meta.token0 || !meta.token1) {
+        throw new Error(
+          `Missing metadata for NadFunPair ${pair}: ${JSON.stringify(meta ?? null)}`,
+        );
+      }
+
+      const quoteIsToken0 =
+        meta.quoteToken!.toLowerCase() === meta.token0.toLowerCase();
+      const log = logArgs<{
+        amount0In: string | number | bigint;
+        amount1In: string | number | bigint;
+        amount0Out: string | number | bigint;
+        amount1Out: string | number | bigint;
+      }>(rawLog);
+
+      const quoteIn = quoteIsToken0
+        ? toBigInt(log.amount0In)
+        : toBigInt(log.amount1In);
+      const quoteOut = quoteIsToken0
+        ? toBigInt(log.amount0Out)
+        : toBigInt(log.amount1Out);
+      const quoteVolume = quoteIn + quoteOut;
+      const lpFee = mulBps(quoteVolume, 25n); // NadFunPair LP_FEE_RATE = 0.25%
+      const protocolLpFee = lpFee / 5n; // _mintFee captures 1/5 of LP fees
+      const supplySideLpFee = lpFee - protocolLpFee;
+
+      addQuoteBalance(dailyVolume, meta.quoteToken, quoteVolume);
+      addQuoteBalance(dailyFees, meta.quoteToken, lpFee, metrics.V2LpFees);
+      addQuoteBalance(
+        dailyRevenue,
+        meta.quoteToken,
+        protocolLpFee,
+        metrics.V2ProtocolFees,
+      );
+      addQuoteBalance(
+        dailySupplySideRevenue,
+        meta.quoteToken,
+        supplySideLpFee,
+        metrics.V2LpFees,
+      );
     });
   }
 

--- a/dexs/nad-fun.ts
+++ b/dexs/nad-fun.ts
@@ -552,54 +552,53 @@ async function addV2Metrics(options: FetchOptions, balances: MetricsBalances) {
   });
 
   if (pairs.length > 0) {
-    const swapLogsByPair = await options.getLogs({
+    await options.streamLogs({
       targets: pairs,
       eventAbi: v2Abi.Swap,
-      flatten: false,
-    });
+      entireLog: true,
+      targetsFilter: pairs,
+      processor: (logs: any[]) => {
+        logs.forEach((rawLog) => {
+          const pair = rawLog.address.toLowerCase();
+          const meta = pairMeta[pair];
+          if (!meta?.quoteToken) return;
 
-    swapLogsByPair.forEach((logs: any[], index: number) => {
-      const pair = pairs[index].toLowerCase();
-      const meta = pairMeta[pair];
-      if (!meta?.quoteToken) return;
+          const quoteIsToken0 =
+            meta.quoteToken.toLowerCase() === meta.token0.toLowerCase();
+          const log = logArgs<{
+            amount0In: string | number | bigint;
+            amount1In: string | number | bigint;
+            amount0Out: string | number | bigint;
+            amount1Out: string | number | bigint;
+          }>(rawLog);
 
-      const quoteIsToken0 =
-        meta.quoteToken.toLowerCase() === meta.token0.toLowerCase();
+          const quoteIn = quoteIsToken0
+            ? toBigInt(log.amount0In)
+            : toBigInt(log.amount1In);
+          const quoteOut = quoteIsToken0
+            ? toBigInt(log.amount0Out)
+            : toBigInt(log.amount1Out);
+          const quoteVolume = quoteIn + quoteOut;
+          const lpFee = mulBps(quoteVolume, 25n); // NadFunPair LP_FEE_RATE = 0.25%
+          const protocolLpFee = lpFee / 5n; // _mintFee captures 1/5 of LP fees
+          const supplySideLpFee = lpFee - protocolLpFee;
 
-      logs.forEach((rawLog) => {
-        const log = logArgs<{
-          amount0In: string | number | bigint;
-          amount1In: string | number | bigint;
-          amount0Out: string | number | bigint;
-          amount1Out: string | number | bigint;
-        }>(rawLog);
-
-        const quoteIn = quoteIsToken0
-          ? toBigInt(log.amount0In)
-          : toBigInt(log.amount1In);
-        const quoteOut = quoteIsToken0
-          ? toBigInt(log.amount0Out)
-          : toBigInt(log.amount1Out);
-        const quoteVolume = quoteIn + quoteOut;
-        const lpFee = mulBps(quoteVolume, 25n); // NadFunPair LP_FEE_RATE = 0.25%
-        const protocolLpFee = lpFee / 5n; // _mintFee captures 1/5 of LP fees
-        const supplySideLpFee = lpFee - protocolLpFee;
-
-        addQuoteBalance(dailyVolume, meta.quoteToken, quoteVolume);
-        addQuoteBalance(dailyFees, meta.quoteToken, lpFee, metrics.V2LpFees);
-        addQuoteBalance(
-          dailyRevenue,
-          meta.quoteToken,
-          protocolLpFee,
-          metrics.V2ProtocolFees,
-        );
-        addQuoteBalance(
-          dailySupplySideRevenue,
-          meta.quoteToken,
-          supplySideLpFee,
-          metrics.V2LpFees,
-        );
-      });
+          addQuoteBalance(dailyVolume, meta.quoteToken, quoteVolume);
+          addQuoteBalance(dailyFees, meta.quoteToken, lpFee, metrics.V2LpFees);
+          addQuoteBalance(
+            dailyRevenue,
+            meta.quoteToken,
+            protocolLpFee,
+            metrics.V2ProtocolFees,
+          );
+          addQuoteBalance(
+            dailySupplySideRevenue,
+            meta.quoteToken,
+            supplySideLpFee,
+            metrics.V2LpFees,
+          );
+        });
+      },
     });
   }
 

--- a/dexs/nad-fun.ts
+++ b/dexs/nad-fun.ts
@@ -425,6 +425,9 @@ async function addV2ProtocolTransfers(
 async function addV2Metrics(options: FetchOptions, balances: MetricsBalances) {
   const { dailyFees, dailyVolume, dailyRevenue, dailySupplySideRevenue } =
     balances;
+
+  if ((await options.getEndBlock()) < v2.startBlock) return;
+
   let feeReceiver: string;
   try {
     feeReceiver = await options.api.call({
@@ -432,13 +435,15 @@ async function addV2Metrics(options: FetchOptions, balances: MetricsBalances) {
       abi: v2Abi.feeReceiver,
     });
   } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
     console.error("Nad.fun V2 feeReceiver lookup failed", {
       protocolManager: v2.protocolManager,
       err,
     });
-    // V2 addresses are configured ahead of production deployment. Skip V2
-    // accounting until the ProtocolManager exists on the indexed chain.
-    return;
+    if (/not deployed|contract not found|no contract|empty code/i.test(message)) {
+      return;
+    }
+    throw err;
   }
 
   const [curveBuyLogs, curveSellLogs, collectLogs, { pairs, pairMeta }] =

--- a/dexs/nad-fun.ts
+++ b/dexs/nad-fun.ts
@@ -308,11 +308,15 @@ async function addV1Metrics(options: FetchOptions, balances: MetricsBalances) {
 }
 
 async function getV2PairMetadata(options: FetchOptions) {
-  const pairLogs = await options.getLogs({
+  const pairLogs: any[] = [];
+
+  await options.streamLogs({
     target: v2.nadFunFactory,
     eventAbi: v2Abi.PairCreated,
     fromBlock: v2.startBlock,
-    cacheInCloud: true,
+    processor: (logs: any[]) => {
+      pairLogs.push(...logs);
+    },
   });
 
   const pairs = pairLogs.map((log: any) => log.pair as string);

--- a/dexs/nad-fun.ts
+++ b/dexs/nad-fun.ts
@@ -211,7 +211,6 @@ async function getLogsInBlockChunks(
         ...params,
         fromBlock,
         toBlock,
-        skipCache: true,
       });
       allLogs.push(...logs);
     });
@@ -621,7 +620,7 @@ async function addV2Metrics(options: FetchOptions, balances: MetricsBalances) {
     const swapLogs = await getLogsInBlockChunks(
       options,
       {
-        noTarget: true,
+        targets: [...pairSet],
         eventAbi: v2Abi.Swap,
         topics: [swapTopic],
         entireLog: true,

--- a/dexs/nad-fun.ts
+++ b/dexs/nad-fun.ts
@@ -6,7 +6,7 @@ import { METRIC } from "../helpers/metrics";
 type Balances = ReturnType<FetchOptions["createBalances"]>;
 
 const BPS = 10_000n;
-const V1_FEE_RATE_DENOMINATOR = 1_000_000;
+const V1_FEE_RATE_DENOMINATOR = 1_000_000n;
 
 const v1 = {
   startBlock: 37_709_836,
@@ -65,9 +65,9 @@ const v2Abi = {
 };
 
 interface FeeRates {
-  communityRate: number;
-  creatorRate: number;
-  foundationRate: number;
+  communityRate: bigint;
+  creatorRate: bigint;
+  foundationRate: bigint;
 }
 
 interface FeeRateChange extends FeeRates {
@@ -110,29 +110,22 @@ const monEquivalentQuoteTokens = new Set(
 );
 
 function parseFeeConfig(config: {
-  communityTreasuryFeeRate: number;
-  creatorTreasuryFeeRate: number;
-  foundationTreasuryFeeRate: number;
+  communityTreasuryFeeRate: string | number | bigint;
+  creatorTreasuryFeeRate: string | number | bigint;
+  foundationTreasuryFeeRate: string | number | bigint;
 }): FeeRates {
   return {
-    communityRate:
-      Number(config.communityTreasuryFeeRate) / V1_FEE_RATE_DENOMINATOR,
-    creatorRate:
-      Number(config.creatorTreasuryFeeRate) / V1_FEE_RATE_DENOMINATOR,
-    foundationRate:
-      Number(config.foundationTreasuryFeeRate) / V1_FEE_RATE_DENOMINATOR,
+    communityRate: toBigInt(config.communityTreasuryFeeRate),
+    creatorRate: toBigInt(config.creatorTreasuryFeeRate),
+    foundationRate: toBigInt(config.foundationTreasuryFeeRate),
   };
 }
 
 function parseV1SetConfigParams(params: any): FeeRates {
   return parseFeeConfig({
-    communityTreasuryFeeRate: Number(
-      params.communityTreasuryFeeRate ?? params[0],
-    ),
-    creatorTreasuryFeeRate: Number(params.creatorTreasuryFeeRate ?? params[1]),
-    foundationTreasuryFeeRate: Number(
-      params.foundationTreasuryFeeRate ?? params[2],
-    ),
+    communityTreasuryFeeRate: params.communityTreasuryFeeRate ?? params[0],
+    creatorTreasuryFeeRate: params.creatorTreasuryFeeRate ?? params[1],
+    foundationTreasuryFeeRate: params.foundationTreasuryFeeRate ?? params[2],
   });
 }
 
@@ -231,10 +224,11 @@ async function addV1Metrics(options: FetchOptions, balances: MetricsBalances) {
   const periodStartRates = parseFeeConfig(startConfigResult);
   const v1RateHistory = setConfigLogs
     .map((rawLog: any) => {
-      const log = logArgs<{ params: any }>(rawLog);
+      const log = logArgs<{ params?: any }>(rawLog);
+      const params = log.params ?? (log as any)[0] ?? (rawLog as any)[0] ?? log;
       return {
         blockNumber: Number(rawLog.blockNumber),
-        ...parseV1SetConfigParams(log.params ?? log[0] ?? log),
+        ...parseV1SetConfigParams(params),
       };
     })
     .filter((change: FeeRateChange) => Number.isFinite(change.blockNumber))
@@ -264,25 +258,21 @@ async function addV1Metrics(options: FetchOptions, balances: MetricsBalances) {
       Number.isFinite(blockNumber)
         ? getV1FeeRatesAtBlock(v1RateHistory, blockNumber, periodStartRates)
         : periodStartRates;
-    const collectFee = Number(log.monAmount);
+    const collectFee = toBigInt(log.monAmount);
+    const foundationFee =
+      (collectFee * foundationRate) / V1_FEE_RATE_DENOMINATOR;
+    const communityFee =
+      (collectFee * communityRate) / V1_FEE_RATE_DENOMINATOR;
+    const creatorFee = (collectFee * creatorRate) / V1_FEE_RATE_DENOMINATOR;
 
-    dailyFees.addGasToken(collectFee * foundationRate, metrics.FoundationFees);
-    dailyFees.addGasToken(collectFee * communityRate, metrics.CommunityFees);
-    dailyFees.addGasToken(collectFee * creatorRate, metrics.CreatorsFees);
+    dailyFees.addGasToken(foundationFee, metrics.FoundationFees);
+    dailyFees.addGasToken(communityFee, metrics.CommunityFees);
+    dailyFees.addGasToken(creatorFee, metrics.CreatorsFees);
 
-    dailyRevenue.addGasToken(
-      collectFee * foundationRate,
-      metrics.FoundationFees,
-    );
+    dailyRevenue.addGasToken(foundationFee, metrics.FoundationFees);
 
-    dailySupplySideRevenue.addGasToken(
-      collectFee * communityRate,
-      metrics.CommunityFees,
-    );
-    dailySupplySideRevenue.addGasToken(
-      collectFee * creatorRate,
-      metrics.CreatorsFees,
-    );
+    dailySupplySideRevenue.addGasToken(communityFee, metrics.CommunityFees);
+    dailySupplySideRevenue.addGasToken(creatorFee, metrics.CreatorsFees);
   });
 
   distributedLogs.forEach(
@@ -441,7 +431,11 @@ async function addV2Metrics(options: FetchOptions, balances: MetricsBalances) {
       target: v2.protocolManager,
       abi: v2Abi.feeReceiver,
     });
-  } catch {
+  } catch (err) {
+    console.error("Nad.fun V2 feeReceiver lookup failed", {
+      protocolManager: v2.protocolManager,
+      err,
+    });
     // V2 addresses are configured ahead of production deployment. Skip V2
     // accounting until the ProtocolManager exists on the indexed chain.
     return;
@@ -526,7 +520,6 @@ async function addV2Metrics(options: FetchOptions, balances: MetricsBalances) {
     const totalRate = creatorRate + protocolRate;
 
     if (totalRate === 0) {
-      addQuoteBalance(dailyFees, meta?.quoteToken, amount, METRIC.SWAP_FEES);
       return;
     }
 

--- a/dexs/nad-fun.ts
+++ b/dexs/nad-fun.ts
@@ -1,11 +1,36 @@
+import { ethers } from "ethers";
 import { Adapter, FetchOptions, FetchResultV2 } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
+import { METRIC } from "../helpers/metrics";
 
-const bondingCurve = "0xA7283d07812a02AFB7C09B60f8896bCEA3F90aCE";
-const lpManager = "0xAebe5522749b65eaE7b2A35c593145CC3128b515";
-const feeDistributor = "0x1d91A6339f6C484aD9A29dac34d2403E8688A423";
+type Balances = ReturnType<FetchOptions["createBalances"]>;
 
-const abi = {
+const BPS = 10_000n;
+const V1_FEE_RATE_DENOMINATOR = 1_000_000;
+
+const v1 = {
+  startBlock: 37_709_836,
+  bondingCurve: "0xA7283d07812a02AFB7C09B60f8896bCEA3F90aCE",
+  lpManager: "0xAebe5522749b65eaE7b2A35c593145CC3128b515",
+  feeDistributor: "0x1d91A6339f6C484aD9A29dac34d2403E8688A423",
+};
+
+// V2 deployment addresses. Keep this block isolated so production address
+// updates do not touch the accounting logic below.
+const v2 = {
+  startBlock: 73_856_000,
+  bondingCurve: "0x9f3832732923252A21044F21eE6bd87F09514ae4",
+  protocolManager: "0x71F846A560a4d68F53e5bd34ED084E7992f171C7",
+  feeCollector: "0xE1C8b73343f5A83EBe165BE90470d84B00e33022",
+  nadFunFactory: "0xA25b13127e63ddae6d0b35570FF3D39dBD621001",
+  // WMON/LVMON are both treated as MON-denominated quote assets.
+  monEquivalentQuoteTokens: [
+    "0x3bd359C1119dA7Da1D913D1C4D2B7c461115433A",
+    "0x91b81bfbe3A747230F0529Aa28d8b2Bc898E6D56",
+  ],
+};
+
+const v1Abi = {
   CurveBuy:
     "event CurveBuy(address indexed sender, address indexed token, uint256 amountIn, uint256 amountOut)",
   CurveCreate:
@@ -18,8 +43,25 @@ const abi = {
     "event LpManagerCollect(address indexed token, address indexed pool, uint256 monAmount, uint256 tokenAmount, uint256 lastCollectTime)",
   Distributed:
     "event Distributed(address indexed token, uint256 tokenAmount, uint256 monReceived, uint256 foundationAmount, uint256 creatorAmount)",
+  SetConfig:
+    "event SetConfig(tuple(uint24 communityTreasuryFeeRate, uint24 creatorTreasuryFeeRate, uint24 foundationTreasuryFeeRate) params)",
   config:
     "function config() view returns (uint24 communityTreasuryFeeRate, uint24 creatorTreasuryFeeRate, uint24 foundationTreasuryFeeRate)",
+};
+
+const v2Abi = {
+  Buy: "event Buy(address indexed token, address indexed buyer, uint256 quoteIn, uint256 tokenOut)",
+  Sell: "event Sell(address indexed token, address indexed seller, uint256 tokenIn, uint256 quoteOut)",
+  Collect: "event Collect(address indexed token, address indexed pair, uint256 amount)",
+  PairCreated:
+    "event PairCreated(address indexed token0, address indexed token1, address pair, uint256 pairCount)",
+  Swap:
+    "event Swap(address indexed sender, uint256 amount0In, uint256 amount1In, uint256 amount0Out, uint256 amount1Out, address indexed to)",
+  Transfer: "event Transfer(address indexed from, address indexed to, uint256 value)",
+  feeReceiver: "address:feeReceiver",
+  getQuoteToken: "function getQuoteToken(address token) view returns (address)",
+  getFeeConfig:
+    "function getFeeConfig(address pair) view returns (address baseToken, address quoteToken, uint16 creatorFeeRate, uint16 curveProtocolFeeRate, uint16 dexProtocolFeeRate)",
 };
 
 interface FeeRates {
@@ -28,16 +70,24 @@ interface FeeRates {
   foundationRate: number;
 }
 
-function parseFeeConfig(config: {
-  communityTreasuryFeeRate: number;
-  creatorTreasuryFeeRate: number;
-  foundationTreasuryFeeRate: number;
-}): FeeRates {
-  return {
-    communityRate: Number(config.communityTreasuryFeeRate) / 1_000_000,
-    creatorRate: Number(config.creatorTreasuryFeeRate) / 1_000_000,
-    foundationRate: Number(config.foundationTreasuryFeeRate) / 1_000_000,
-  };
+interface FeeRateChange extends FeeRates {
+  blockNumber: number;
+}
+
+interface MetricsBalances {
+  dailyFees: Balances;
+  dailyVolume: Balances;
+  dailyRevenue: Balances;
+  dailySupplySideRevenue: Balances;
+}
+
+interface V2PairMeta {
+  token0: string;
+  token1: string;
+  quoteToken?: string;
+  creatorFeeRate?: number;
+  curveProtocolFeeRate?: number;
+  dexProtocolFeeRate?: number;
 }
 
 const metrics = {
@@ -48,36 +98,150 @@ const metrics = {
   FoundationFees: "Foundation Fees from LPs",
   BuyFees: "Buy Fees",
   SellFees: "Sell Fees",
+  V2ProtocolFees: METRIC.PROTOCOL_FEES,
+  V2CreatorFees: METRIC.CREATOR_FEES,
+  V2LpFees: METRIC.LP_FEES,
 };
 
-// https://github.com/Naddotfun/contract-v3-abi
-const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
-  const dailyFees = options.createBalances();
-  const dailyVolume = options.createBalances();
-  const dailyRevenue = options.createBalances();
-  const dailySupplySideRevenue = options.createBalances();
+const transferTopic =
+  "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef";
+const monEquivalentQuoteTokens = new Set(
+  v2.monEquivalentQuoteTokens.map((token) => token.toLowerCase()),
+);
 
-  // Read fee config at period's end block (api is bound to toBlock per period)
+function parseFeeConfig(config: {
+  communityTreasuryFeeRate: number;
+  creatorTreasuryFeeRate: number;
+  foundationTreasuryFeeRate: number;
+}): FeeRates {
+  return {
+    communityRate:
+      Number(config.communityTreasuryFeeRate) / V1_FEE_RATE_DENOMINATOR,
+    creatorRate:
+      Number(config.creatorTreasuryFeeRate) / V1_FEE_RATE_DENOMINATOR,
+    foundationRate:
+      Number(config.foundationTreasuryFeeRate) / V1_FEE_RATE_DENOMINATOR,
+  };
+}
+
+function parseV1SetConfigParams(params: any): FeeRates {
+  return parseFeeConfig({
+    communityTreasuryFeeRate: Number(
+      params.communityTreasuryFeeRate ?? params[0],
+    ),
+    creatorTreasuryFeeRate: Number(params.creatorTreasuryFeeRate ?? params[1]),
+    foundationTreasuryFeeRate: Number(
+      params.foundationTreasuryFeeRate ?? params[2],
+    ),
+  });
+}
+
+function getV1FeeRatesAtBlock(
+  rateHistory: FeeRateChange[],
+  blockNumber: number,
+  fallbackRates: FeeRates,
+): FeeRates {
+  let rates = fallbackRates;
+
+  for (const change of rateHistory) {
+    if (change.blockNumber > blockNumber) break;
+    rates = change;
+  }
+
+  return rates;
+}
+
+function logArgs<T = any>(log: any): T {
+  return (log.args ?? log) as T;
+}
+
+function toBigInt(value: string | number | bigint): bigint {
+  return typeof value === "bigint" ? value : BigInt(value.toString());
+}
+
+function mulBps(amount: string | number | bigint, bps: number | bigint): bigint {
+  return (toBigInt(amount) * BigInt(bps)) / BPS;
+}
+
+function addQuoteBalance(
+  balances: Balances,
+  quoteToken: string | undefined,
+  amount: string | number | bigint,
+  label?: string,
+) {
+  const value = toBigInt(amount);
+  if (value === 0n || !quoteToken) return;
+
+  if (monEquivalentQuoteTokens.has(quoteToken.toLowerCase())) {
+    balances.addGasToken(value, label);
+  } else {
+    balances.add(quoteToken, value, label);
+  }
+}
+
+function unique(values: string[]): string[] {
+  return Array.from(
+    new Set(values.filter(Boolean).map((value) => value.toLowerCase())),
+  );
+}
+
+function toTopicAddress(address: string): string {
+  return ethers.zeroPadValue(address, 32);
+}
+
+async function addV1Metrics(options: FetchOptions, balances: MetricsBalances) {
+  const { dailyFees, dailyVolume, dailyRevenue, dailySupplySideRevenue } =
+    balances;
+
   const [
-    configResult,
+    startConfigResult,
     creationLogs,
     buyLogs,
     sellLogs,
     graduateLogs,
     lpManagerCollectLogs,
     distributedLogs,
+    setConfigLogs,
   ] = await Promise.all([
-    options.api.call({ target: lpManager, abi: abi.config }),
-    options.getLogs({ target: bondingCurve, eventAbi: abi.CurveCreate }),
-    options.getLogs({ target: bondingCurve, eventAbi: abi.CurveBuy }),
-    options.getLogs({ target: bondingCurve, eventAbi: abi.CurveSell }),
-    options.getLogs({ target: bondingCurve, eventAbi: abi.CurveGraduate }),
-    options.getLogs({ target: lpManager, eventAbi: abi.LpManagerCollect }),
-    options.getLogs({ target: feeDistributor, eventAbi: abi.Distributed }),
+    options.fromApi.call({ target: v1.lpManager, abi: v1Abi.config }),
+    options.getLogs({ target: v1.bondingCurve, eventAbi: v1Abi.CurveCreate }),
+    options.getLogs({ target: v1.bondingCurve, eventAbi: v1Abi.CurveBuy }),
+    options.getLogs({ target: v1.bondingCurve, eventAbi: v1Abi.CurveSell }),
+    options.getLogs({
+      target: v1.bondingCurve,
+      eventAbi: v1Abi.CurveGraduate,
+    }),
+    options.getLogs({
+      target: v1.lpManager,
+      eventAbi: v1Abi.LpManagerCollect,
+      onlyArgs: false,
+    }),
+    options.getLogs({
+      target: v1.feeDistributor,
+      eventAbi: v1Abi.Distributed,
+    }),
+    options.getLogs({
+      target: v1.lpManager,
+      eventAbi: v1Abi.SetConfig,
+      onlyArgs: false,
+      cacheInCloud: true,
+    }),
   ]);
 
-  const { communityRate, creatorRate, foundationRate } =
-    parseFeeConfig(configResult);
+  const periodStartRates = parseFeeConfig(startConfigResult);
+  const v1RateHistory = setConfigLogs
+    .map((rawLog: any) => {
+      const log = logArgs<{ params: any }>(rawLog);
+      return {
+        blockNumber: Number(rawLog.blockNumber),
+        ...parseV1SetConfigParams(log.params ?? log[0] ?? log),
+      };
+    })
+    .filter((change: FeeRateChange) => Number.isFinite(change.blockNumber))
+    .sort(
+      (left: FeeRateChange, right: FeeRateChange) =>
+        left.blockNumber - right.blockNumber,
+    );
 
   dailyFees.addGasToken(10 * creationLogs.length * 1e18, metrics.CreationFees);
   dailyFees.addGasToken(
@@ -93,7 +257,13 @@ const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
     metrics.GraduationFees,
   );
 
-  lpManagerCollectLogs.forEach((log: { monAmount: string | number }) => {
+  lpManagerCollectLogs.forEach((rawLog: any) => {
+    const log = logArgs<{ monAmount: string | number }>(rawLog);
+    const blockNumber = Number(rawLog.blockNumber);
+    const { communityRate, creatorRate, foundationRate } =
+      Number.isFinite(blockNumber)
+        ? getV1FeeRatesAtBlock(v1RateHistory, blockNumber, periodStartRates)
+        : periodStartRates;
     const collectFee = Number(log.monAmount);
 
     dailyFees.addGasToken(collectFee * foundationRate, metrics.FoundationFees);
@@ -145,6 +315,334 @@ const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
     dailyRevenue.addGasToken(fee, metrics.SellFees);
     dailyVolume.addGasToken(log.amountOut);
   });
+}
+
+async function getV2PairMetadata(options: FetchOptions) {
+  const pairLogs = await options.getLogs({
+    target: v2.nadFunFactory,
+    eventAbi: v2Abi.PairCreated,
+    fromBlock: v2.startBlock,
+    cacheInCloud: true,
+  });
+
+  const pairs = pairLogs.map((log: any) => log.pair as string);
+  const pairMeta: Record<string, V2PairMeta> = {};
+
+  pairLogs.forEach((log: any) => {
+    const pair = (log.pair as string).toLowerCase();
+    const token0 = log.token0 as string;
+    const token1 = log.token1 as string;
+    const knownQuoteToken = [token0, token1].find((token) =>
+      monEquivalentQuoteTokens.has(token.toLowerCase()),
+    );
+
+    pairMeta[pair] = {
+      token0,
+      token1,
+      quoteToken: knownQuoteToken,
+    };
+  });
+
+  if (pairs.length === 0) return { pairs, pairMeta };
+
+  const configs = await options.api.multiCall({
+    target: v2.feeCollector,
+    abi: v2Abi.getFeeConfig,
+    calls: pairs.map((pair: string) => ({ params: [pair] })),
+    permitFailure: true,
+  });
+
+  configs.forEach((config: any, index: number) => {
+    if (!config) return;
+    const pair = pairs[index].toLowerCase();
+    pairMeta[pair] = {
+      ...pairMeta[pair],
+      quoteToken: config.quoteToken,
+      creatorFeeRate: Number(config.creatorFeeRate),
+      curveProtocolFeeRate: Number(config.curveProtocolFeeRate),
+      dexProtocolFeeRate: Number(config.dexProtocolFeeRate),
+    };
+  });
+
+  return { pairs, pairMeta };
+}
+
+async function getV2TokenQuoteMap(options: FetchOptions, tokens: string[]) {
+  const uniqueTokens = unique(tokens);
+  const tokenQuoteMap: Record<string, string> = {};
+
+  if (uniqueTokens.length === 0) return tokenQuoteMap;
+
+  const quoteTokens = await options.api.multiCall({
+    target: v2.bondingCurve,
+    abi: v2Abi.getQuoteToken,
+    calls: uniqueTokens.map((token: string) => ({ params: [token] })),
+    permitFailure: true,
+  });
+
+  quoteTokens.forEach((quoteToken: string | undefined, index: number) => {
+    if (!quoteToken) return;
+    tokenQuoteMap[uniqueTokens[index].toLowerCase()] = quoteToken;
+  });
+
+  return tokenQuoteMap;
+}
+
+async function addV2ProtocolTransfers(
+  options: FetchOptions,
+  quoteTokens: string[],
+  source: string,
+  feeReceiver: string,
+  revenueBalances: Balances,
+  feeBalances?: Balances,
+) {
+  if (!quoteTokens.length) return;
+
+  const logsByToken = await options.getLogs({
+    targets: quoteTokens,
+    flatten: false,
+    noTarget: true,
+    eventAbi: v2Abi.Transfer,
+    topics: [
+      transferTopic,
+      toTopicAddress(source),
+      toTopicAddress(feeReceiver),
+    ],
+  });
+
+  logsByToken.forEach((logs: any[], index: number) => {
+    const quoteToken = quoteTokens[index];
+    logs.forEach((rawLog) => {
+      const log = logArgs<{ value: string | number | bigint }>(rawLog);
+      addQuoteBalance(
+        revenueBalances,
+        quoteToken,
+        log.value,
+        metrics.V2ProtocolFees,
+      );
+      if (feeBalances) {
+        addQuoteBalance(
+          feeBalances,
+          quoteToken,
+          log.value,
+          metrics.V2ProtocolFees,
+        );
+      }
+    });
+  });
+}
+
+async function addV2Metrics(options: FetchOptions, balances: MetricsBalances) {
+  const { dailyFees, dailyVolume, dailyRevenue, dailySupplySideRevenue } =
+    balances;
+  let feeReceiver: string;
+  try {
+    feeReceiver = await options.api.call({
+      target: v2.protocolManager,
+      abi: v2Abi.feeReceiver,
+    });
+  } catch {
+    // V2 addresses are configured ahead of production deployment. Skip V2
+    // accounting until the ProtocolManager exists on the indexed chain.
+    return;
+  }
+
+  const [curveBuyLogs, curveSellLogs, collectLogs, { pairs, pairMeta }] =
+    await Promise.all([
+      options.getLogs({
+        target: v2.bondingCurve,
+        eventAbi: v2Abi.Buy,
+        onlyArgs: false,
+      }),
+      options.getLogs({
+        target: v2.bondingCurve,
+        eventAbi: v2Abi.Sell,
+        onlyArgs: false,
+      }),
+      options.getLogs({
+        target: v2.feeCollector,
+        eventAbi: v2Abi.Collect,
+        onlyArgs: false,
+      }),
+      getV2PairMetadata(options),
+    ]);
+
+  const curveTokens = unique([
+    ...curveBuyLogs.map(
+      (rawLog: any) => logArgs<{ token: string }>(rawLog).token,
+    ),
+    ...curveSellLogs.map(
+      (rawLog: any) => logArgs<{ token: string }>(rawLog).token,
+    ),
+  ]);
+
+  const tokenQuoteMap = await getV2TokenQuoteMap(options, curveTokens);
+
+  const quoteTokens = unique([
+    ...v2.monEquivalentQuoteTokens,
+    ...Object.values(tokenQuoteMap),
+    ...Object.values(pairMeta)
+      .map((meta) => meta.quoteToken)
+      .filter((token): token is string => Boolean(token)),
+  ]);
+
+  const curveTradeTxs = new Set<string>();
+
+  curveBuyLogs.forEach((rawLog: any) => {
+    const log = logArgs<{ token: string; quoteIn: string | number | bigint }>(
+      rawLog,
+    );
+    if (rawLog.transactionHash) curveTradeTxs.add(rawLog.transactionHash);
+    addQuoteBalance(
+      dailyVolume,
+      tokenQuoteMap[log.token.toLowerCase()],
+      log.quoteIn,
+    );
+  });
+
+  curveSellLogs.forEach((rawLog: any) => {
+    const log = logArgs<{ token: string; quoteOut: string | number | bigint }>(
+      rawLog,
+    );
+    if (rawLog.transactionHash) curveTradeTxs.add(rawLog.transactionHash);
+    addQuoteBalance(
+      dailyVolume,
+      tokenQuoteMap[log.token.toLowerCase()],
+      log.quoteOut,
+    );
+  });
+
+  collectLogs.forEach((rawLog: any) => {
+    const log = logArgs<{
+      pair: string;
+      amount: string | number | bigint;
+    }>(rawLog);
+    const meta = pairMeta[log.pair.toLowerCase()];
+    const amount = toBigInt(log.amount);
+    const creatorRate = meta?.creatorFeeRate ?? 0;
+    const protocolRate = curveTradeTxs.has(rawLog.transactionHash)
+      ? meta?.curveProtocolFeeRate ?? 0
+      : meta?.dexProtocolFeeRate ?? 0;
+    const totalRate = creatorRate + protocolRate;
+
+    if (totalRate === 0) {
+      addQuoteBalance(dailyFees, meta?.quoteToken, amount, METRIC.SWAP_FEES);
+      return;
+    }
+
+    const creatorFee = (amount * BigInt(creatorRate)) / BigInt(totalRate);
+    const protocolFee = amount - creatorFee;
+
+    addQuoteBalance(
+      dailyFees,
+      meta?.quoteToken,
+      protocolFee,
+      metrics.V2ProtocolFees,
+    );
+    addQuoteBalance(
+      dailyFees,
+      meta?.quoteToken,
+      creatorFee,
+      metrics.V2CreatorFees,
+    );
+    addQuoteBalance(
+      dailySupplySideRevenue,
+      meta?.quoteToken,
+      creatorFee,
+      metrics.V2CreatorFees,
+    );
+  });
+
+  if (pairs.length > 0) {
+    const swapLogsByPair = await options.getLogs({
+      targets: pairs,
+      eventAbi: v2Abi.Swap,
+      flatten: false,
+    });
+
+    swapLogsByPair.forEach((logs: any[], index: number) => {
+      const pair = pairs[index].toLowerCase();
+      const meta = pairMeta[pair];
+      if (!meta?.quoteToken) return;
+
+      const quoteIsToken0 =
+        meta.quoteToken.toLowerCase() === meta.token0.toLowerCase();
+
+      logs.forEach((rawLog) => {
+        const log = logArgs<{
+          amount0In: string | number | bigint;
+          amount1In: string | number | bigint;
+          amount0Out: string | number | bigint;
+          amount1Out: string | number | bigint;
+        }>(rawLog);
+
+        const quoteIn = quoteIsToken0
+          ? toBigInt(log.amount0In)
+          : toBigInt(log.amount1In);
+        const quoteOut = quoteIsToken0
+          ? toBigInt(log.amount0Out)
+          : toBigInt(log.amount1Out);
+        const quoteVolume = quoteIn + quoteOut;
+        const lpFee = mulBps(quoteVolume, 25n); // NadFunPair LP_FEE_RATE = 0.25%
+        const protocolLpFee = lpFee / 5n; // _mintFee captures 1/5 of LP fees
+        const supplySideLpFee = lpFee - protocolLpFee;
+
+        addQuoteBalance(dailyVolume, meta.quoteToken, quoteVolume);
+        addQuoteBalance(dailyFees, meta.quoteToken, lpFee, metrics.V2LpFees);
+        addQuoteBalance(
+          dailyRevenue,
+          meta.quoteToken,
+          protocolLpFee,
+          metrics.V2ProtocolFees,
+        );
+        addQuoteBalance(
+          dailySupplySideRevenue,
+          meta.quoteToken,
+          supplySideLpFee,
+          metrics.V2LpFees,
+        );
+      });
+    });
+  }
+
+  // FeeCollector -> feeReceiver transfers are the exact protocol revenue portion
+  // of creator/protocol trade fees already counted above in dailyFees.
+  await addV2ProtocolTransfers(
+    options,
+    quoteTokens,
+    v2.feeCollector,
+    feeReceiver,
+    dailyRevenue,
+  );
+
+  // BondingCurve -> feeReceiver transfers are direct protocol fees such as
+  // deploy, graduation, sniping, and protocol-only curve fees. These are both
+  // user fees and protocol revenue.
+  await addV2ProtocolTransfers(
+    options,
+    quoteTokens,
+    v2.bondingCurve,
+    feeReceiver,
+    dailyRevenue,
+    dailyFees,
+  );
+}
+
+const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
+  const dailyFees = options.createBalances();
+  const dailyVolume = options.createBalances();
+  const dailyRevenue = options.createBalances();
+  const dailySupplySideRevenue = options.createBalances();
+
+  const balances = {
+    dailyFees,
+    dailyVolume,
+    dailyRevenue,
+    dailySupplySideRevenue,
+  };
+
+  await addV1Metrics(options, balances);
+  await addV2Metrics(options, balances);
 
   return {
     dailyVolume,
@@ -164,47 +662,59 @@ const adapter: Adapter = {
   version: 2,
   pullHourly: true,
   methodology: {
-    Fees: "Protocol fees are generated from Bonding Curve token actions (create, buy, sell, graduate) and from post-graduation LP manager fee collections.",
+    Fees:
+      "V1 fees are counted from the legacy bonding curve, LP manager, and fee distributor events. Legacy LP manager splits use the initial fee split and subsequent SetConfig event history. V2 fees include protocol fees, creator fees, and NadFunPair LP swap fees. Creator fees are included in total fees but excluded from protocol revenue.",
     Revenue:
-      "All fees generated on the Bonding Curve itself (create, buy, sell, graduate) are counted as protocol revenue. For post-graduation LP manager collections, the Foundation share (configured on-chain via LpManager.config()) is treated as protocol revenue.",
-    ProtocolRevenue: "All revenue goes to Foundation Treasury.",
+      "V1 protocol revenue follows the legacy fee accounting. V2 protocol revenue includes actual quote-token transfers to the protocol fee receiver plus the protocol share of NadFunPair LP fees. Creator fees are not counted as protocol revenue.",
+    ProtocolRevenue:
+      "Protocol revenue is the protocol-controlled share of fees, excluding creator/vault fees.",
     SupplySideRevenue:
-      "Community and Creator shares of fees collected by the LP Manager on graduated pools, as configured on-chain via LpManager.config().",
+      "Supply-side revenue includes creator/vault fees and LP fees retained by liquidity providers.",
   },
   breakdownMethodology: {
     Fees: {
       [metrics.CreationFees]:
-        "10 MON fee charged when a new token is created on the Bonding Curve.",
+        "V1 10 MON fee charged when a new token is created on the bonding curve.",
       [metrics.GraduationFees]:
-        "Flat 3,000 MON fee charged when a token graduates from the Bonding Curve to the DEX pool.",
+        "V1 flat 3,000 MON fee charged when a token graduates from the bonding curve to the DEX pool.",
       [metrics.BuyFees]:
-        "1% fee charged on the MON input amount for Bonding Curve buy trades.",
+        "V1 1% fee charged on the MON input amount for bonding curve buy trades.",
       [metrics.SellFees]:
-        "1% fee charged on the token output amount for Bonding Curve sell trades.",
+        "V1 1% fee charged on the MON output amount for bonding curve sell trades.",
       [metrics.FoundationFees]:
-        "Foundation share of fees collected by the LP Manager on graduated pools (rate from on-chain config).",
+        "V1 foundation share of fees collected by the legacy LP manager or fee distributor. LP manager rates follow SetConfig event history.",
       [metrics.CommunityFees]:
-        "Community share of fees collected by the LP Manager on graduated pools (rate from on-chain config).",
+        "V1 community share of fees collected by the legacy LP manager. LP manager rates follow SetConfig event history.",
       [metrics.CreatorsFees]:
-        "Creator share of fees collected by the LP Manager on graduated pools (rate from on-chain config).",
+        "V1 creator share of fees collected by the legacy LP manager or fee distributor. LP manager rates follow SetConfig event history.",
+      [metrics.V2ProtocolFees]:
+        "V2 protocol fees from bonding curve operations and protocol fee shares from V2 trades.",
+      [metrics.V2CreatorFees]:
+        "V2 creator fees accrued from bonding curve and DEX trades.",
+      [metrics.V2LpFees]:
+        "V2 0.25% NadFunPair LP swap fee.",
     },
     Revenue: {
       [metrics.CreationFees]:
-        "10 MON fee charged when a new token is created on the Bonding Curve.",
+        "V1 10 MON fee charged when a new token is created on the bonding curve.",
       [metrics.GraduationFees]:
-        "Flat 3,000 MON fee charged when a token graduates from the Bonding Curve to the DEX pool.",
+        "V1 flat 3,000 MON fee charged when a token graduates from the bonding curve to the DEX pool.",
       [metrics.BuyFees]:
-        "1% fee charged on the MON input amount for Bonding Curve buy trades.",
+        "V1 1% fee charged on the MON input amount for bonding curve buy trades.",
       [metrics.SellFees]:
-        "1% fee charged on the token output amount for Bonding Curve sell trades.",
+        "V1 1% fee charged on the MON output amount for bonding curve sell trades.",
       [metrics.FoundationFees]:
-        "Foundation share of fees collected by the LP Manager on graduated pools (rate from on-chain config).",
+        "V1 foundation share of fees collected by the legacy LP manager or fee distributor. LP manager rates follow SetConfig event history.",
+      [metrics.V2ProtocolFees]:
+        "V2 protocol-controlled fee revenue. Creator fees are excluded.",
     },
     SupplySideRevenue: {
       [metrics.CommunityFees]:
-        "Community share of fees collected by the LP Manager on graduated pools (rate from on-chain config).",
+        "V1 community share of fees collected by the legacy LP manager. LP manager rates follow SetConfig event history.",
       [metrics.CreatorsFees]:
-        "Creator share of fees collected by the LP Manager on graduated pools (rate from on-chain config).",
+        "V1 creator share of fees collected by the legacy LP manager or fee distributor. LP manager rates follow SetConfig event history.",
+      [metrics.V2CreatorFees]: "V2 creator/vault fee share.",
+      [metrics.V2LpFees]: "V2 LP fee share retained by liquidity providers.",
     },
   },
 };


### PR DESCRIPTION
Updates the Nad.fun DEX adapter to include V2 while preserving V1 accounting.

- Adds V2 BondingCurve, FeeCollector, Factory, and Pair accounting
- Tracks V2 volume, protocol fees, creator fees, LP fees, protocol revenue, and supply-side revenue
- Keeps V1 event accounting and adds SetConfig-based LP fee split history

Checks:
- git diff --check
- npx ts-node --transpile-only -e "require('./dexs/nad-fun')"