### PR TITLE
fix(unisubgraph): don't zero dailyVolume when totalFeesField is unset

### DIFF
--- a/helpers/getUniSubgraphVolume.ts
+++ b/helpers/getUniSubgraphVolume.ts
@@ -116,10 +116,12 @@ function getChainVolume2({
       // Gate fees zero-out on totalFeesField — configs that derive fees from
       // volume via feeConfig leave prevTotalFees intentionally undefined, and
       // a combined check would zero out a healthy prevTotal alongside it.
-      if (!prevTotal) {
+      // Use === undefined so a legitimately-zero prev cumulative (new protocol)
+      // produces a correct diff instead of being treated as missing data.
+      if (prevTotal === undefined) {
         response.dailyVolume = 0;
       }
-      if (totalFeesField && !prevTotalFees) {
+      if (totalFeesField && prevTotalFees === undefined) {
         response.dailyFees = 0;
       }
 

--- a/helpers/getUniSubgraphVolume.ts
+++ b/helpers/getUniSubgraphVolume.ts
@@ -113,8 +113,13 @@ function getChainVolume2({
       if (totalFeesField)
         response.dailyFees = totalFees - prevTotalFees
 
-      if (!prevTotalFees || !prevTotal) {
+      // Gate fees zero-out on totalFeesField — configs that derive fees from
+      // volume via feeConfig leave prevTotalFees intentionally undefined, and
+      // a combined check would zero out a healthy prevTotal alongside it.
+      if (!prevTotal) {
         response.dailyVolume = 0;
+      }
+      if (totalFeesField && !prevTotalFees) {
         response.dailyFees = 0;
       }
 


### PR DESCRIPTION
## Summary

`getChainVolume2` in `helpers/getUniSubgraphVolume.ts` resets `dailyVolume` whenever `prevTotalFees` is falsy, but **`prevTotalFees` is intentionally undefined for callers that don't pass `totalFeesField`** — which is most subgraph adapters (they derive fees from volume via `feeConfig`).

Net effect: every such adapter has been silently returning `dailyVolume = 0` since the guard was added.

## Root cause

[#6472](https://github.com/DefiLlama/dimension-adapters/pull/6472) (commit [477226590](https://github.com/DefiLlama/dimension-adapters/commit/477226590406d3328fbdc584c9077062e456170b), merged 2026-04-23) added:

```ts
if (!prevTotalFees || !prevTotal) {
  response.dailyVolume = 0;
  response.dailyFees = 0;
}
```

When the caller doesn't pass `totalFeesField`, `prevTotalFees` is set to `undefined` by design at line 106, so `!prevTotalFees` is always true and the body always runs — `dailyVolume` is zeroed regardless of `prevTotal`'s validity.

## Confirmed-affected adapters

All have the same fall-off pattern — last non-zero day is `1776816000` (2026-04-21 UTC), then $0 for every day since, while the underlying subgraph keeps indexing and the protocol keeps trading.

| Adapter | Pre-regression daily | Now | Notes |
|---|---|---|---|
| `pulsex-v1` fees | ~$25k | $0 | factoriesName: `pulseXFactories`, no totalFeesField, uses feeConfig |
| `pulsex-v2` fees | ~$4k | $0 | same pattern |
| `pulsex-stableswap` vol | ~$266k | $0 | volume-only, no totalFeesField |
| `defi-swap` fees | ~$133 | $0 | uses feeConfig |
| `balancer-v1` vol | ~$90k | $0 | `getChainVolume2` direct caller, no totalFeesField |
| `solidly-v3` vol (5/6 chains) | non-zero | $0 | Ethereum/Optimism/Arbitrum/Fantom/Sonic — Base survives only because it uses `getUniV3LogAdapter` instead |

In total, **9 of 13 files** in the codebase that call `getChainVolume2`/`univ2Adapter2` don't pass `totalFeesField`, so every one of them was getting `dailyVolume = 0`.

## Proof the subgraphs are healthy

PulseX V1 (one example), as of this PR:

\`\`\`
$ curl -X POST 'https://graph.pulsechain.com/subgraphs/name/pulsechain/pulsex' \
       -d '{\"query\":\"{ pulseXFactories(block:{number:26530800}) { totalVolumeUSD } }\"}'
{\"data\":{\"pulseXFactories\":[{\"totalVolumeUSD\":\"19520578718.265...\"}]}}

$ # ...and 24h earlier:
$ curl -X POST 'https://graph.pulsechain.com/subgraphs/name/pulsechain/pulsex' \
       -d '{\"query\":\"{ pulseXFactories(block:{number:26522596}) { totalVolumeUSD } }\"}'
{\"data\":{\"pulseXFactories\":[{\"totalVolumeUSD\":\"19519365857.890...\"}]}}
\`\`\`

Diff = ~$1.21M daily volume. `dailyFees` at 0.0029 = ~$3.5k. DefiLlama currently reports `$0`.

## Fix

Split the single guard into two:

\`\`\`diff
-      if (!prevTotalFees || !prevTotal) {
+      if (!prevTotal) {
         response.dailyVolume = 0;
+      }
+      if (totalFeesField && !prevTotalFees) {
         response.dailyFees = 0;
       }
\`\`\`

- **Volume**: only zeroed when `prevTotal` is missing (the genuine \"prev day data unavailable\" case the original PR was trying to handle).
- **Fees**: only zeroed when `totalFeesField` was actually queried AND `prevTotalFees` is missing. For callers that compute fees via `feeConfig`, `dailyFees` is left undefined here and produced downstream by `handleFeeConfig` from `dailyVolume`.

Strictly safer behavior than the current code — it cannot produce non-zero output in any case where the current code produces $0.

## Test plan

- [ ] Run `pnpm test fees pulsex-v1` and confirm non-zero dailyFees
- [ ] Run `pnpm test fees pulsex-v2`
- [ ] Run `pnpm test fees defi-swap`
- [ ] Run `pnpm test dexs pulsex-stableswap`
- [ ] Run `pnpm test dexs balancer-v1`
- [ ] Run `pnpm test dexs solidly-v3` and confirm Ethereum/Optimism/Arbitrum/Fantom/Sonic all report non-zero (Base unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)