### PR TITLE
[feat] Moca: add moca chain support with fees

### DIFF
--- a/factory/blockscout.ts
+++ b/factory/blockscout.ts
@@ -120,6 +120,7 @@ const protocolChainMap: Record<string, string> = {
   "mezo": CHAIN.MEZO,
   "world-mobile": CHAIN.WORLD_MOBILE,
   "rise": CHAIN.RISE,
+  "moca": CHAIN.MOCA,
 }
 
 const deadFromMap: Record<string, string> = {

--- a/helpers/blockscoutFees.ts
+++ b/helpers/blockscoutFees.ts
@@ -139,6 +139,7 @@ export const chainConfigMap: any = {
   [CHAIN.MEZO]: { CGToken: 'bitcoin', explorer: 'https://api.explorer.mezo.org', start: '2025-05-06' },
   [CHAIN.WORLD_MOBILE]: { CGToken: 'world-mobile-token', explorer: 'https://explorer.worldmobile.io', start: '2025-06-01' },
   [CHAIN.RISE]: { CGToken: 'ethereum', explorer: 'https://explorer.risechain.com', start: '2026-01-01' },
+  [CHAIN.MOCA]: { CGToken: 'moca-coin', explorer: 'https://scan.mocachain.org', start: '2026-01-26' },
 }
 
 function getTimeString(timestamp: number) {

--- a/helpers/chains.ts
+++ b/helpers/chains.ts
@@ -370,4 +370,5 @@ export enum CHAIN {
   CSC = "csc",
   WORLD_MOBILE = "world_mobile",
   RISE = "rise",
+  MOCA = "moca",
 }


### PR DESCRIPTION
## Summary
- Adds Moca Network chain fee support through the shared Blockscout fees factory.
- Tracks daily transaction gas fees using Moca Blockscout `totalfees` data.

## Changes
- Added `CHAIN.MOCA` to `helpers/chains.ts`.
- Added Moca Blockscout config in `helpers/blockscoutFees.ts` with `moca-coin` pricing and `https://scan.mocachain.org`.
- Registered the `moca` protocol slug in `factory/blockscout.ts`.
