### PR TITLE
[feat] Moca: add moca chain support with fees

### DIFF
--- a/factory/blockscout.ts
+++ b/factory/blockscout.ts
@@ -121,6 +121,7 @@ const protocolChainMap: Record<string, string> = {
   "world-mobile": CHAIN.WORLD_MOBILE,
   "rise": CHAIN.RISE,
   "citrea": CHAIN.CITREA,
+  "moca": CHAIN.MOCA,
 }
 
 const deadFromMap: Record<string, string> = {

--- a/helpers/blockscoutFees.ts
+++ b/helpers/blockscoutFees.ts
@@ -140,6 +140,7 @@ export const chainConfigMap: any = {
   [CHAIN.WORLD_MOBILE]: { CGToken: 'world-mobile-token', explorer: 'https://explorer.worldmobile.io', start: '2025-06-01' },
   [CHAIN.RISE]: { CGToken: 'ethereum', explorer: 'https://explorer.risechain.com', start: '2026-01-01' },
   [CHAIN.CITREA]: { CGToken: 'bitcoin', explorer: 'https://explorer.mainnet.citrea.xyz', start: '2025-11-25' },
+  [CHAIN.MOCA]: { CGToken: 'moca-coin', explorer: 'https://scan.mocachain.org', start: '2026-01-26' },
 }
 
 function getTimeString(timestamp: number) {

--- a/helpers/blockscoutFees.ts
+++ b/helpers/blockscoutFees.ts
@@ -140,7 +140,7 @@ export const chainConfigMap: any = {
   [CHAIN.WORLD_MOBILE]: { CGToken: 'world-mobile-token', explorer: 'https://explorer.worldmobile.io', start: '2025-06-01' },
   [CHAIN.RISE]: { CGToken: 'ethereum', explorer: 'https://explorer.risechain.com', start: '2026-01-01' },
   [CHAIN.CITREA]: { CGToken: 'bitcoin', explorer: 'https://explorer.mainnet.citrea.xyz', start: '2025-11-25' },
-  [CHAIN.MOCA]: { CGToken: 'moca-coin', explorer: 'https://scan.mocachain.org', start: '2026-01-26' },
+  [CHAIN.MOCA]: { CGToken: 'mocaverse', explorer: 'https://scan.mocachain.org', start: '2026-01-26' },
 }
 
 function getTimeString(timestamp: number) {

--- a/helpers/chains.ts
+++ b/helpers/chains.ts
@@ -373,4 +373,5 @@ export enum CHAIN {
   RISE = "rise",
   FLUENT = "fluent",
   LUKSO = "lukso",
+  MOCA = "moca",
 }


### PR DESCRIPTION
## Summary
- Adds Moca Network chain fee support through the shared Blockscout fees factory.
- Tracks Moca daily transaction gas fees using the Blockscout `totalfees` endpoint.

## Links
- Website: https://moca.network/
- Docs: https://docs.moca.network/
- Explorer: https://scan.mocachain.org
- X/Twitter: https://x.com/Moca_Network

## Changes
- Added `CHAIN.MOCA` to `helpers/chains.ts`.
- Added Moca Blockscout config in `helpers/blockscoutFees.ts` with `moca-coin` pricing and start date `2026-01-26`.
- Registered the `moca` protocol slug in `factory/blockscout.ts`.

## Methodology
- Counts daily transaction gas fees from Moca Blockscout’s `stats totalfees` endpoint.
- Uses the shared Blockscout chain-fees factory, so Moca follows the same daily aggregation behavior as other Blockscout-backed chain adapters.

## Tests
- `pnpm test fees moca 2026-05-15`
