### PR TITLE
fix: syncswap fees from pool config

### DIFF
--- a/dexs/syncswap/index.ts
+++ b/dexs/syncswap/index.ts
@@ -10,35 +10,74 @@ const endpoints: { [key: string]: string } = {
 };
 
 async function getGraphData(_t: any, _b: any, options: FetchOptions) {
-  const dateId = Math.floor(options.startOfDay / 86400);
-  const query = gql`
+  const pairDayRes = await request(endpoints[options.chain], gql`
     {
-      dayData(id: "${dateId}") {
+      pairDayDatas(first: 1000, orderBy: dailyVolumeUSD, orderDirection: desc, where: { date: ${options.startOfDay} }) {
+        pairAddress
         dailyVolumeUSD
       }
     }
-  `
-  const graphRes = await request(endpoints[options.chain], query, {
-    headers: {
-      'user-agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.3',
-      'origin': 'https://syncswap.xyz',
+  `);
+
+  const pairDayDatas: { pairAddress: string; dailyVolumeUSD: string }[] = pairDayRes.pairDayDatas;
+
+  if (pairDayDatas.length === 0) {
+    return { dailyVolume: 0, dailyFees: 0, dailyUserFees: 0, dailyRevenue: 0, dailySupplySideRevenue: 0 };
+  }
+
+  const pairAddresses = pairDayDatas.map((p) => p.pairAddress.toLowerCase());
+  const pairFeeRes = await request(endpoints[options.chain], gql`
+    {
+      pairs(first: 1000, where: { id_in: ${JSON.stringify(pairAddresses)} }) {
+        id
+        swapFee01Min
+        swapFee01Max
+        swapFee10Min
+        swapFee10Max
+        protocolFee
+      }
     }
-  });
+  `);
+
+  const feeByPair: Record<string, any> = {};
+  for (const p of pairFeeRes.pairs) {
+    feeByPair[p.id.toLowerCase()] = p;
+  }
+
+  let dailyVolume = 0;
+  let dailyFees = 0;
+  let dailyRevenue = 0;
+
+  for (const r of pairDayDatas) {
+    const vol = Number(r.dailyVolumeUSD);
+    dailyVolume += vol;
+    const pair = feeByPair[r.pairAddress.toLowerCase()];
+    if (!pair) continue;
+    const swapFee = (
+      Number(pair.swapFee01Min) + Number(pair.swapFee01Max) +
+      Number(pair.swapFee10Min) + Number(pair.swapFee10Max)
+    ) / 4 / 1e5;
+    const fee = vol * swapFee;
+    dailyFees += fee;
+    dailyRevenue += fee * Number(pair.protocolFee) / 1e5;
+  }
 
   return {
-    dailyVolume: Number(graphRes.dayData.dailyVolumeUSD),
-    dailyFees: Number(graphRes.dayData.dailyVolumeUSD) * (0.3 / 100),
-    dailyUserFees: Number(graphRes.dayData.dailyVolumeUSD) * (0.3 / 100),
-    dailySupplySideRevenue: Number(graphRes.dayData.dailyVolumeUSD) * (0.3 / 100),
-  }
+    dailyVolume,
+    dailyFees,
+    dailyUserFees: dailyFees,
+    dailyRevenue,
+    dailySupplySideRevenue: dailyFees - dailyRevenue,
+  };
 }
 
 const methodology = {
-    Volume: "Count token swap volume from SyncSwap subgraphs.",
-    Fees: "All fees comes from users by swap token on SyncSwap.",
-    UserFees: "Users pay fees for every swap on SyncSwap.",
-    SupplySideRevenue: "All swap fees paid to LPs.",
-}
+  Volume: "Count token swap volume from SyncSwap subgraphs.",
+  Fees: "All swap fees paid by users.",
+  UserFees: "Users pay fees for every swap on SyncSwap.",
+  Revenue: "Protocol's share of swap fees.",
+  SupplySideRevenue: "LP share of swap fees after the protocol fee cut.",
+};
 
 const adapter: SimpleAdapter = {
   methodology,
@@ -52,10 +91,10 @@ const adapter: SimpleAdapter = {
       fetch: getGraphData,
       start: '2024-03-06',
     },
-    // [CHAIN.SOPHON]: {
-    //   fetch: getGraphDataV2,
-    //   start: '2024-03-06',
-    // },
+    [CHAIN.SOPHON]: {
+      fetch: getGraphData,
+      start: '2024-03-06',
+    },
     [CHAIN.SCROLL]: {
       fetch: getGraphData,
       start: '2024-03-06',

--- a/dexs/syncswap/index.ts
+++ b/dexs/syncswap/index.ts
@@ -21,9 +21,8 @@ async function getGraphData(_t: any, _b: any, options: FetchOptions) {
 
   const pairDayDatas: { pairAddress: string; dailyVolumeUSD: string }[] = pairDayRes.pairDayDatas;
 
-  if (pairDayDatas.length === 0) {
-    return { dailyVolume: 0, dailyFees: 0, dailyUserFees: 0, dailyRevenue: 0, dailySupplySideRevenue: 0 };
-  }
+  if (pairDayDatas.length === 0)
+    return { dailyVolume: 0, dailyFees: 0, dailyRevenue: 0, dailySupplySideRevenue: 0 };
 
   const pairAddresses = pairDayDatas.map((p) => p.pairAddress.toLowerCase());
   const pairFeeRes = await request(endpoints[options.chain], gql`
@@ -49,15 +48,15 @@ async function getGraphData(_t: any, _b: any, options: FetchOptions) {
   let dailyRevenue = 0;
 
   for (const r of pairDayDatas) {
-    const vol = Number(r.dailyVolumeUSD);
-    dailyVolume += vol;
     const pair = feeByPair[r.pairAddress.toLowerCase()];
     if (!pair) continue;
+    const vol = Number(r.dailyVolumeUSD);
     const swapFee = (
       Number(pair.swapFee01Min) + Number(pair.swapFee01Max) +
       Number(pair.swapFee10Min) + Number(pair.swapFee10Max)
     ) / 4 / 1e5;
     const fee = vol * swapFee;
+    dailyVolume += vol;
     dailyFees += fee;
     dailyRevenue += fee * Number(pair.protocolFee) / 1e5;
   }
@@ -65,16 +64,14 @@ async function getGraphData(_t: any, _b: any, options: FetchOptions) {
   return {
     dailyVolume,
     dailyFees,
-    dailyUserFees: dailyFees,
     dailyRevenue,
     dailySupplySideRevenue: dailyFees - dailyRevenue,
   };
 }
 
 const methodology = {
-  Volume: "Count token swap volume from SyncSwap subgraphs.",
-  Fees: "All swap fees paid by users.",
-  UserFees: "Users pay fees for every swap on SyncSwap.",
+  Volume: "Token swap volume from SyncSwap subgraphs.",
+  Fees: "Swap fees paid by users, computed per-pool using each pool's on-chain swap fee rate. For dynamic Aqua pools the rate is approximated as the average of the configured min/max bounds.",
   Revenue: "Protocol's share of swap fees.",
   SupplySideRevenue: "LP share of swap fees after the protocol fee cut.",
 };
@@ -93,7 +90,7 @@ const adapter: SimpleAdapter = {
     },
     [CHAIN.SOPHON]: {
       fetch: getGraphData,
-      start: '2024-03-06',
+      start: '2024-12-16',
     },
     [CHAIN.SCROLL]: {
       fetch: getGraphData,


### PR DESCRIPTION
The adapter used a flat 0.3% fee across all pools/chains and attributed 100% of fees to LPs. SyncSwap fees are pool-specific, and pools route ~30% to the protocol via `protocolFee`. Sophon was also disabled.

### Changes

* Compute fees from each pool’s actual `swapFee` (`/1e5`) and daily volume.
* Add `dailyRevenue` and correctly split protocol vs LP revenue using on-chain `protocolFee`.
* Re-enable Sophon support.
* Remove unnecessary request headers.

### Impact (2026-05-12 sample)

* Daily fees reduced ~29% (previously overstated by flat 0.3%).
* `dailyRevenue` now populated; `dailySupplySideRevenue` corrected.
* Sophon adds ~$15.9k/day previously missing volume.