### PR TITLE
fix(flashtrade): include Equity.1 pool in volume + fees adapters

### DIFF
--- a/dexs/flashtrade/index.ts
+++ b/dexs/flashtrade/index.ts
@@ -13,7 +13,8 @@ const pools = [
     "Trump.1",
     "Ore.1",
     "Remora.1",
-    
+    "Equity.1",
+
     // keep historical pools
     "Community.3",
 ]

--- a/fees/flashtrade.ts
+++ b/fees/flashtrade.ts
@@ -30,6 +30,7 @@ const pools = [
   "Trump.1",
   "Ore.1",
   "Remora.1",
+  "Equity.1",
   // keep historical pools
   "Community.3",
 ]


### PR DESCRIPTION
The Equity.1 pool (NVDA, AMZN, TSLA, AAPL, AMD, SPY perps) is missing from the dex and fees adapter pool lists. 