### PR TITLE
feat(open-interest/flashtrade): add adapter

### DIFF
--- a/open-interest/flashtrade-oi.ts
+++ b/open-interest/flashtrade-oi.ts
@@ -1,0 +1,51 @@
+import { FetchOptions, SimpleAdapter } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+import { httpGet } from "../utils/fetchURL";
+
+type Snapshot = {
+  token: string;
+  timestamp: string;
+  longUsd: number;
+  shortUsd: number;
+  total: number;
+};
+
+type Response = {
+  timestamp: string;
+  openInterest: Snapshot[];
+};
+
+const fetch = async (options: FetchOptions) => {
+  // Midnight of the next UTC day -- the exact instant boundary of the
+  // requested day. The backend's cron writes a snapshot at every HH:00 UTC,
+  // so this lands on the 00:00-next-day row (= OI at end of requested day).
+  // For "today" no next-day row exists yet; the endpoint falls back to the
+  // latest available hourly snapshot.
+  const endOfDay = options.startOfDay + 86400;
+  const { openInterest } = (await httpGet(
+    `https://api.prod.flash.trade/open-interest/at?timestamp=${endOfDay}`
+  )) as Response;
+
+  let longOpenInterestAtEnd = 0;
+  let shortOpenInterestAtEnd = 0;
+  for (const snap of openInterest) {
+    longOpenInterestAtEnd += snap.longUsd || 0;
+    shortOpenInterestAtEnd += snap.shortUsd || 0;
+  }
+
+  return {
+    openInterestAtEnd: longOpenInterestAtEnd + shortOpenInterestAtEnd,
+    longOpenInterestAtEnd,
+    shortOpenInterestAtEnd,
+  };
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  fetch,
+  chains: [CHAIN.SOLANA],
+  // Earliest date the OpenInterest table has data for (BTC/SOL/ETH).
+  start: '2023-12-29',
+};
+
+export default adapter;


### PR DESCRIPTION
https://defillama.com/protocol/flashtrade
## Summary

Adds an open-interest adapter for FlashTrade (Solana perp DEX). Reports per-day OI sourced from a new `https://api.prod.flash.trade/open-interest/at` endpoint backed by the protocol's hourly OpenInterest snapshots.

For each requested UTC day the adapter queries the snapshot at exactly midnight of the next UTC day — the cron's hour-mark sample representing OI at end of the requested day. Returns USD scalars for `openInterestAtEnd`, `longOpenInterestAtEnd`, `shortOpenInterestAtEnd` by summing across all listed tokens.

USD scalars (rather than `addCGToken`) because most listed tokens — synthetic FX (USDJPY, USDCNH, EUR, GBP), commodities (XAU, XAG, NATGAS, CRUDEOIL), equities (NVDA, TSLA, AAPL, AMD, AMZN, SPY, MEGA), and newer crypto (HYPE, FARTCOIN, etc.) — lack CoinGecko IDs. Same pattern as ``hyperliquid-perp-oi``.

Historical backfill starts ``2023-12-29`` (earliest BTC/SOL/ETH OI snapshots in the source DB).

## Test plan

- [x] Endpoint returns ``HTTP 200`` with expected JSON shape (verified against ``api.prod.flash.trade``)
- [x] Adapter typechecks via ``npm run ts-check``
- [ ] DefiLlama CI runs ``fetch`` for a recent UTC day and produces non-zero ``openInterestAtEnd``