### PR TITLE
[fix] Terminal: fix padre revenue by tracking cashbacks/burns

### DIFF
--- a/fees/padre/index.ts
+++ b/fees/padre/index.ts
@@ -5,7 +5,6 @@ import { addGasTokensReceived, addTokensReceived } from '../../helpers/token';
 import { Dependencies, FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 import { queryDuneSql } from "../../helpers/dune";
-import { METRIC } from "../../helpers/metrics";
 const dataAvaliableTill = (Date.now() / 1e3 - 10 * 3600) // 10 hours ago
 const TRADING_TERMINAL_FEES = 'Trading Terminal Fees'
 const CASHBACK_REFERRAL_PAYOUTS = 'Cashback/Referral Payouts'
@@ -71,7 +70,7 @@ async function fetchSolana(options: FetchOptions) {
     ),
     burnWalletInflows AS (
       SELECT
-        COALESCE(SUM(balance_change), 0) AS holders_revenue_amount
+        COALESCE(SUM(balance_change), 0) AS buyback_burn_amount
       FROM
         solana.account_activity
       WHERE
@@ -97,7 +96,7 @@ async function fetchSolana(options: FetchOptions) {
     SELECT
       SUM(fee) AS fee,
       (SELECT payout_amount FROM cashbackPayouts) AS cashback_payout_amount,
-      (SELECT holders_revenue_amount FROM burnWalletInflows) AS holders_revenue_amount
+      (SELECT buyback_burn_amount FROM burnWalletInflows) AS buyback_burn_amount
     FROM
       botTrades
   `;
@@ -105,19 +104,17 @@ async function fetchSolana(options: FetchOptions) {
   const [row] = await queryDuneSql(options, query);
   const tradingFees = Number(row?.fee ?? 0);
   const cashbackPayouts = Number(row?.cashback_payout_amount ?? 0);
-  const holdersRevenue = Number(row?.holders_revenue_amount ?? 0);
+  const buybackBurnAmount = Number(row?.buyback_burn_amount ?? 0);
 
   const dailyFees = options.createBalances();
   const dailySupplySideRevenue = options.createBalances();
   const dailyRevenue = options.createBalances();
-  const dailyHoldersRevenue = options.createBalances();
 
   dailyFees.add(ADDRESSES.solana.SOL, tradingFees, TRADING_TERMINAL_FEES);
   dailySupplySideRevenue.add(ADDRESSES.solana.SOL, cashbackPayouts, CASHBACK_REFERRAL_PAYOUTS);
-  dailyHoldersRevenue.add(ADDRESSES.solana.SOL, holdersRevenue, METRIC.TOKEN_BUY_BACK);
-  dailyRevenue.add(ADDRESSES.solana.SOL, tradingFees - cashbackPayouts - holdersRevenue, TRADING_TERMINAL_FEES);
+  dailyRevenue.add(ADDRESSES.solana.SOL, tradingFees - cashbackPayouts - buybackBurnAmount, TRADING_TERMINAL_FEES);
 
-  return { dailyFees, dailyRevenue, dailyProtocolRevenue: dailyRevenue, dailySupplySideRevenue, dailyHoldersRevenue }
+  return { dailyFees, dailyRevenue, dailyProtocolRevenue: dailyRevenue, dailySupplySideRevenue }
 }
 
 async function fetchEvm(options: FetchOptions) {
@@ -160,9 +157,6 @@ export const breakdownMethodology = {
   SupplySideRevenue: {
     [CASHBACK_REFERRAL_PAYOUTS]: 'All outbound transfers from the cashback/referral wallet.',
   },
-  HoldersRevenue: {
-    [METRIC.TOKEN_BUY_BACK]: 'Funds sent to the burn wallet for token buyback and burn.',
-  },
 }
 
 const adapter: SimpleAdapter = {
@@ -179,7 +173,6 @@ const adapter: SimpleAdapter = {
     Revenue: "Trading terminal fees retained by the protocol after cashback/referral payouts and buyback/burn allocations.",
     ProtocolRevenue: "Trading terminal fees retained by the protocol after cashback/referral payouts and buyback/burn allocations.",
     SupplySideRevenue: "All outbound transfers from the cashback/referral wallet.",
-    HoldersRevenue: "Funds sent to the burn wallet for token buyback and burn.",
   },
   allowNegativeValue: true,
 };

--- a/fees/padre/index.ts
+++ b/fees/padre/index.ts
@@ -5,8 +5,15 @@ import { addGasTokensReceived, addTokensReceived } from '../../helpers/token';
 import { Dependencies, FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 import { queryDuneSql } from "../../helpers/dune";
+import { METRIC } from "../../helpers/metrics";
 const dataAvaliableTill = (Date.now() / 1e3 - 10 * 3600) // 10 hours ago
 const TRADING_TERMINAL_FEES = 'Trading Terminal Fees'
+const CASHBACK_REFERRAL_PAYOUTS = 'Cashback/Referral Payouts'
+const solanaConfig = {
+  mainFeeWallet: 'J5XGHmzrRmnYWbmw45DbYkdZAU2bwERFZ11qCDXPvFB5',
+  feeCashbackWallet: 'DoAsxPQgiyAxyaJNvpAAUb2ups6rbJRdYrCPyWxwRxBb',
+  burnWallet: '9jHrTCwpDANHLNQz5cem6XLUBM8KiTWKe766Br6KVCXM',
+}
 
 const evmChainConfig: any = {
   [CHAIN.ETHEREUM]: {
@@ -21,8 +28,23 @@ const evmChainConfig: any = {
 }
 
 async function fetchSolana(options: FetchOptions) {
+  const { mainFeeWallet, feeCashbackWallet, burnWallet } = solanaConfig
   const query = `
     WITH
+    interfundTransfers AS (
+      SELECT
+        tx_id
+      FROM
+        solana.account_activity
+      WHERE
+        TIME_RANGE
+        AND tx_success
+        AND address IN ('${mainFeeWallet}', '${feeCashbackWallet}')
+      GROUP BY tx_id
+      HAVING
+        SUM(CASE WHEN address = '${mainFeeWallet}' AND balance_change < 0 THEN 1 ELSE 0 END) > 0
+        AND SUM(CASE WHEN address = '${feeCashbackWallet}' AND balance_change > 0 THEN 1 ELSE 0 END) > 0
+    ),
     allFeePayments AS (
       SELECT
         tx_id,
@@ -31,7 +53,30 @@ async function fetchSolana(options: FetchOptions) {
         solana.account_activity
       WHERE
         TIME_RANGE
-        AND address IN ('J5XGHmzrRmnYWbmw45DbYkdZAU2bwERFZ11qCDXPvFB5', 'DoAsxPQgiyAxyaJNvpAAUb2ups6rbJRdYrCPyWxwRxBb')
+        AND address IN ('${mainFeeWallet}', '${feeCashbackWallet}')
+        AND tx_success
+        AND balance_change > 0
+        AND NOT (address = '${feeCashbackWallet}' AND tx_id IN (SELECT tx_id FROM interfundTransfers))
+    ),
+    cashbackPayouts AS (
+      SELECT
+        COALESCE(SUM(-balance_change), 0) AS payout_amount
+      FROM
+        solana.account_activity
+      WHERE
+        TIME_RANGE
+        AND address = '${feeCashbackWallet}'
+        AND tx_success
+        AND balance_change < 0
+    ),
+    burnWalletInflows AS (
+      SELECT
+        COALESCE(SUM(balance_change), 0) AS holders_revenue_amount
+      FROM
+        solana.account_activity
+      WHERE
+        TIME_RANGE
+        AND address = '${burnWallet}'
         AND tx_success
         AND balance_change > 0
     ),
@@ -44,20 +89,35 @@ async function fetchSolana(options: FetchOptions) {
         JOIN allFeePayments AS feePayments ON trades.tx_id = feePayments.tx_id
       WHERE
         TIME_RANGE
-        AND trades.trader_id != 'J5XGHmzrRmnYWbmw45DbYkdZAU2bwERFZ11qCDXPvFB5'
-        AND trades.trader_id != 'DoAsxPQgiyAxyaJNvpAAUb2ups6rbJRdYrCPyWxwRxBb'
+        AND trades.trader_id != '${mainFeeWallet}'
+        AND trades.trader_id != '${feeCashbackWallet}'
+        AND trades.trader_id != '${burnWallet}'
       GROUP BY trades.tx_id
     )
     SELECT
-      SUM(fee) AS fee
+      SUM(fee) AS fee,
+      (SELECT payout_amount FROM cashbackPayouts) AS cashback_payout_amount,
+      (SELECT holders_revenue_amount FROM burnWalletInflows) AS holders_revenue_amount
     FROM
       botTrades
   `;
 
-  const fees = await queryDuneSql(options, query);
+  const [row] = await queryDuneSql(options, query);
+  const tradingFees = Number(row?.fee);
+  const cashbackPayouts = Number(row?.cashback_payout_amount);
+  const holdersRevenue = Number(row?.holders_revenue_amount);
+
   const dailyFees = options.createBalances();
-  dailyFees.add(ADDRESSES.solana.SOL, fees[0].fee || 0);
-  return dailyFees
+  const dailySupplySideRevenue = options.createBalances();
+  const dailyRevenue = options.createBalances();
+  const dailyHoldersRevenue = options.createBalances();
+
+  dailyFees.add(ADDRESSES.solana.SOL, tradingFees, TRADING_TERMINAL_FEES);
+  dailySupplySideRevenue.add(ADDRESSES.solana.SOL, cashbackPayouts, CASHBACK_REFERRAL_PAYOUTS);
+  dailyHoldersRevenue.add(ADDRESSES.solana.SOL, holdersRevenue, METRIC.TOKEN_BUY_BACK);
+  dailyRevenue.add(ADDRESSES.solana.SOL, tradingFees - cashbackPayouts - holdersRevenue, TRADING_TERMINAL_FEES);
+
+  return { dailyFees, dailyRevenue, dailyProtocolRevenue: dailyRevenue, dailySupplySideRevenue, dailyHoldersRevenue }
 }
 
 async function fetchEvm(options: FetchOptions) {
@@ -79,8 +139,9 @@ export const fetch = async (_: any, _1: any, options: FetchOptions) => {
   if (options.endTimestamp > dataAvaliableTill)
     throw new Error("Data not available till 10 hours ago. Please try a date before: " + new Date(dataAvaliableTill * 1e3).toISOString());
 
-  const fees = options.chain === CHAIN.SOLANA ? await fetchSolana(options) : await fetchEvm(options)
+  if (options.chain === CHAIN.SOLANA) return fetchSolana(options)
 
+  const fees = await fetchEvm(options)
   const dailyFees = fees.clone(1, TRADING_TERMINAL_FEES)
 
   return { dailyFees, dailyRevenue: dailyFees }
@@ -91,7 +152,16 @@ export const breakdownMethodology = {
     [TRADING_TERMINAL_FEES]: 'Fees charged on each trade executed through the trading terminal.',
   },
   Revenue: {
-    [TRADING_TERMINAL_FEES]: 'Trading terminal fees retained by the protocol.',
+    [TRADING_TERMINAL_FEES]: 'Trading terminal fees retained by the protocol after cashback/referral payouts.',
+  },
+  ProtocolRevenue: {
+    [TRADING_TERMINAL_FEES]: 'Trading terminal fees retained by the protocol after cashback/referral payouts and buyback/burn allocations.',
+  },
+  SupplySideRevenue: {
+    [CASHBACK_REFERRAL_PAYOUTS]: 'All outbound transfers from the cashback/referral wallet.',
+  },
+  HoldersRevenue: {
+    [METRIC.TOKEN_BUY_BACK]: 'Funds sent to the burn wallet for token buyback and burn.',
   },
 }
 
@@ -106,8 +176,12 @@ const adapter: SimpleAdapter = {
   breakdownMethodology,
   methodology: {
     Fees: "Trading fees paid by users while using Padre bot.",
-    Revenue: "All fees are collected by Padre protocol.",
+    Revenue: "Trading terminal fees retained by the protocol after cashback/referral payouts and buyback/burn allocations.",
+    ProtocolRevenue: "Trading terminal fees retained by the protocol after cashback/referral payouts and buyback/burn allocations.",
+    SupplySideRevenue: "All outbound transfers from the cashback/referral wallet.",
+    HoldersRevenue: "Funds sent to the burn wallet for token buyback and burn.",
   },
+  allowNegativeValue: true,
 };
 
 export default adapter;

--- a/fees/padre/index.ts
+++ b/fees/padre/index.ts
@@ -103,9 +103,9 @@ async function fetchSolana(options: FetchOptions) {
   `;
 
   const [row] = await queryDuneSql(options, query);
-  const tradingFees = Number(row?.fee);
-  const cashbackPayouts = Number(row?.cashback_payout_amount);
-  const holdersRevenue = Number(row?.holders_revenue_amount);
+  const tradingFees = Number(row?.fee ?? 0);
+  const cashbackPayouts = Number(row?.cashback_payout_amount ?? 0);
+  const holdersRevenue = Number(row?.holders_revenue_amount ?? 0);
 
   const dailyFees = options.createBalances();
   const dailySupplySideRevenue = options.createBalances();
@@ -152,7 +152,7 @@ export const breakdownMethodology = {
     [TRADING_TERMINAL_FEES]: 'Fees charged on each trade executed through the trading terminal.',
   },
   Revenue: {
-    [TRADING_TERMINAL_FEES]: 'Trading terminal fees retained by the protocol after cashback/referral payouts.',
+    [TRADING_TERMINAL_FEES]: 'Trading terminal fees retained by the protocol after cashback/referral payouts and buyback/burn allocations.',
   },
   ProtocolRevenue: {
     [TRADING_TERMINAL_FEES]: 'Trading terminal fees retained by the protocol after cashback/referral payouts and buyback/burn allocations.',

--- a/fees/padre/index.ts
+++ b/fees/padre/index.ts
@@ -7,12 +7,6 @@ import { CHAIN } from "../../helpers/chains";
 import { queryDuneSql } from "../../helpers/dune";
 const dataAvaliableTill = (Date.now() / 1e3 - 10 * 3600) // 10 hours ago
 const TRADING_TERMINAL_FEES = 'Trading Terminal Fees'
-const CASHBACK_REFERRAL_PAYOUTS = 'Cashback/Referral Payouts'
-const solanaConfig = {
-  mainFeeWallet: 'J5XGHmzrRmnYWbmw45DbYkdZAU2bwERFZ11qCDXPvFB5',
-  feeCashbackWallet: 'DoAsxPQgiyAxyaJNvpAAUb2ups6rbJRdYrCPyWxwRxBb',
-  burnWallet: '9jHrTCwpDANHLNQz5cem6XLUBM8KiTWKe766Br6KVCXM',
-}
 
 const evmChainConfig: any = {
   [CHAIN.ETHEREUM]: {
@@ -27,23 +21,8 @@ const evmChainConfig: any = {
 }
 
 async function fetchSolana(options: FetchOptions) {
-  const { mainFeeWallet, feeCashbackWallet, burnWallet } = solanaConfig
   const query = `
     WITH
-    interfundTransfers AS (
-      SELECT
-        tx_id
-      FROM
-        solana.account_activity
-      WHERE
-        TIME_RANGE
-        AND tx_success
-        AND address IN ('${mainFeeWallet}', '${feeCashbackWallet}')
-      GROUP BY tx_id
-      HAVING
-        SUM(CASE WHEN address = '${mainFeeWallet}' AND balance_change < 0 THEN 1 ELSE 0 END) > 0
-        AND SUM(CASE WHEN address = '${feeCashbackWallet}' AND balance_change > 0 THEN 1 ELSE 0 END) > 0
-    ),
     allFeePayments AS (
       SELECT
         tx_id,
@@ -52,30 +31,7 @@ async function fetchSolana(options: FetchOptions) {
         solana.account_activity
       WHERE
         TIME_RANGE
-        AND address IN ('${mainFeeWallet}', '${feeCashbackWallet}')
-        AND tx_success
-        AND balance_change > 0
-        AND NOT (address = '${feeCashbackWallet}' AND tx_id IN (SELECT tx_id FROM interfundTransfers))
-    ),
-    cashbackPayouts AS (
-      SELECT
-        COALESCE(SUM(-balance_change), 0) AS payout_amount
-      FROM
-        solana.account_activity
-      WHERE
-        TIME_RANGE
-        AND address = '${feeCashbackWallet}'
-        AND tx_success
-        AND balance_change < 0
-    ),
-    burnWalletInflows AS (
-      SELECT
-        COALESCE(SUM(balance_change), 0) AS buyback_burn_amount
-      FROM
-        solana.account_activity
-      WHERE
-        TIME_RANGE
-        AND address = '${burnWallet}'
+        AND address IN ('J5XGHmzrRmnYWbmw45DbYkdZAU2bwERFZ11qCDXPvFB5', 'DoAsxPQgiyAxyaJNvpAAUb2ups6rbJRdYrCPyWxwRxBb')
         AND tx_success
         AND balance_change > 0
     ),
@@ -88,33 +44,20 @@ async function fetchSolana(options: FetchOptions) {
         JOIN allFeePayments AS feePayments ON trades.tx_id = feePayments.tx_id
       WHERE
         TIME_RANGE
-        AND trades.trader_id != '${mainFeeWallet}'
-        AND trades.trader_id != '${feeCashbackWallet}'
-        AND trades.trader_id != '${burnWallet}'
+        AND trades.trader_id != 'J5XGHmzrRmnYWbmw45DbYkdZAU2bwERFZ11qCDXPvFB5'
+        AND trades.trader_id != 'DoAsxPQgiyAxyaJNvpAAUb2ups6rbJRdYrCPyWxwRxBb'
       GROUP BY trades.tx_id
     )
     SELECT
-      SUM(fee) AS fee,
-      (SELECT payout_amount FROM cashbackPayouts) AS cashback_payout_amount,
-      (SELECT buyback_burn_amount FROM burnWalletInflows) AS buyback_burn_amount
+      SUM(fee) AS fee
     FROM
       botTrades
   `;
 
-  const [row] = await queryDuneSql(options, query);
-  const tradingFees = Number(row?.fee ?? 0);
-  const cashbackPayouts = Number(row?.cashback_payout_amount ?? 0);
-  const buybackBurnAmount = Number(row?.buyback_burn_amount ?? 0);
-
+  const fees = await queryDuneSql(options, query);
   const dailyFees = options.createBalances();
-  const dailySupplySideRevenue = options.createBalances();
-  const dailyRevenue = options.createBalances();
-
-  dailyFees.add(ADDRESSES.solana.SOL, tradingFees, TRADING_TERMINAL_FEES);
-  dailySupplySideRevenue.add(ADDRESSES.solana.SOL, cashbackPayouts, CASHBACK_REFERRAL_PAYOUTS);
-  dailyRevenue.add(ADDRESSES.solana.SOL, tradingFees - cashbackPayouts - buybackBurnAmount, TRADING_TERMINAL_FEES);
-
-  return { dailyFees, dailyRevenue, dailyProtocolRevenue: dailyRevenue, dailySupplySideRevenue }
+  dailyFees.add(ADDRESSES.solana.SOL, fees[0].fee || 0);
+  return dailyFees
 }
 
 async function fetchEvm(options: FetchOptions) {
@@ -136,9 +79,8 @@ export const fetch = async (_: any, _1: any, options: FetchOptions) => {
   if (options.endTimestamp > dataAvaliableTill)
     throw new Error("Data not available till 10 hours ago. Please try a date before: " + new Date(dataAvaliableTill * 1e3).toISOString());
 
-  if (options.chain === CHAIN.SOLANA) return fetchSolana(options)
+  const fees = options.chain === CHAIN.SOLANA ? await fetchSolana(options) : await fetchEvm(options)
 
-  const fees = await fetchEvm(options)
   const dailyFees = fees.clone(1, TRADING_TERMINAL_FEES)
 
   return { dailyFees, dailyRevenue: dailyFees }
@@ -149,13 +91,7 @@ export const breakdownMethodology = {
     [TRADING_TERMINAL_FEES]: 'Fees charged on each trade executed through the trading terminal.',
   },
   Revenue: {
-    [TRADING_TERMINAL_FEES]: 'Trading terminal fees retained by the protocol after cashback/referral payouts and buyback/burn allocations.',
-  },
-  ProtocolRevenue: {
-    [TRADING_TERMINAL_FEES]: 'Trading terminal fees retained by the protocol after cashback/referral payouts and buyback/burn allocations.',
-  },
-  SupplySideRevenue: {
-    [CASHBACK_REFERRAL_PAYOUTS]: 'All outbound transfers from the cashback/referral wallet.',
+    [TRADING_TERMINAL_FEES]: 'Trading terminal fees retained by the protocol.',
   },
 }
 
@@ -170,11 +106,8 @@ const adapter: SimpleAdapter = {
   breakdownMethodology,
   methodology: {
     Fees: "Trading fees paid by users while using Padre bot.",
-    Revenue: "Trading terminal fees retained by the protocol after cashback/referral payouts and buyback/burn allocations.",
-    ProtocolRevenue: "Trading terminal fees retained by the protocol after cashback/referral payouts and buyback/burn allocations.",
-    SupplySideRevenue: "All outbound transfers from the cashback/referral wallet.",
+    Revenue: "All fees are collected by Padre protocol.",
   },
-  allowNegativeValue: true,
 };
 
 export default adapter;

--- a/fees/trading-terminal/index.ts
+++ b/fees/trading-terminal/index.ts
@@ -1,6 +1,164 @@
-import { Dependencies, SimpleAdapter } from "../../adapters/types";
+import ADDRESSES from '../../helpers/coreAssets.json'
+import { addGasTokensReceived, addTokensReceived } from '../../helpers/token';
+// source: https://dune.com/queries/5028370/8311321
+
+import { Dependencies, FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
-import { breakdownMethodology, fetch } from "../padre";
+import { queryDuneSql } from "../../helpers/dune";
+const TRADING_TERMINAL_FEES = 'Trading Terminal Fees'
+const CASHBACK_REFERRAL_PAYOUTS = 'Cashback/Referral Payouts'
+
+const solanaConfig = {
+  mainFeeWallet: 'J5XGHmzrRmnYWbmw45DbYkdZAU2bwERFZ11qCDXPvFB5',
+  feeCashbackWallet: 'DoAsxPQgiyAxyaJNvpAAUb2ups6rbJRdYrCPyWxwRxBb',
+  burnWallet: '9jHrTCwpDANHLNQz5cem6XLUBM8KiTWKe766Br6KVCXM',
+}
+
+const evmChainConfig: any = {
+  [CHAIN.ETHEREUM]: {
+    feeWallet: '0xa74FA823bC8617fa320A966b3d11B0f722eF09eE',
+  },
+  [CHAIN.BSC]: {
+    feeWallet: '0x2b0A28A0A9197F8Af5d1B8371C048e92Dd78B640',
+  },
+  [CHAIN.BASE]: {
+    feeWallet: '0x16388de42c5829fD0E88c8Eb001eF43bfc93F177',
+  },
+}
+
+async function fetchSolana(options: FetchOptions) {
+  const { mainFeeWallet, feeCashbackWallet, burnWallet } = solanaConfig
+  const query = `
+    WITH
+    interfundTransfers AS (
+      SELECT
+        tx_id
+      FROM
+        solana.account_activity
+      WHERE
+        TIME_RANGE
+        AND tx_success
+        AND address IN ('${mainFeeWallet}', '${feeCashbackWallet}')
+      GROUP BY tx_id
+      HAVING
+        SUM(CASE WHEN address = '${mainFeeWallet}' AND balance_change < 0 THEN 1 ELSE 0 END) > 0
+        AND SUM(CASE WHEN address = '${feeCashbackWallet}' AND balance_change > 0 THEN 1 ELSE 0 END) > 0
+    ),
+    allFeePayments AS (
+      SELECT
+        tx_id,
+        balance_change AS fee_token_amount
+      FROM
+        solana.account_activity
+      WHERE
+        TIME_RANGE
+        AND address IN ('${mainFeeWallet}', '${feeCashbackWallet}')
+        AND tx_success
+        AND balance_change > 0
+        AND NOT (address = '${feeCashbackWallet}' AND tx_id IN (SELECT tx_id FROM interfundTransfers))
+    ),
+    cashbackPayouts AS (
+      SELECT
+        COALESCE(SUM(-balance_change), 0) AS payout_amount
+      FROM
+        solana.account_activity
+      WHERE
+        TIME_RANGE
+        AND address = '${feeCashbackWallet}'
+        AND tx_success
+        AND balance_change < 0
+    ),
+    burnWalletInflows AS (
+      SELECT
+        COALESCE(SUM(balance_change), 0) AS buyback_burn_amount
+      FROM
+        solana.account_activity
+      WHERE
+        TIME_RANGE
+        AND address = '${burnWallet}'
+        AND tx_success
+        AND balance_change > 0
+    ),
+    botTrades AS (
+      SELECT
+        trades.tx_id,
+        MAX(fee_token_amount) AS fee
+      FROM
+        dex_solana.trades AS trades
+        JOIN allFeePayments AS feePayments ON trades.tx_id = feePayments.tx_id
+      WHERE
+        TIME_RANGE
+        AND trades.trader_id != '${mainFeeWallet}'
+        AND trades.trader_id != '${feeCashbackWallet}'
+        AND trades.trader_id != '${burnWallet}'
+      GROUP BY trades.tx_id
+    )
+    SELECT
+      SUM(fee) AS fee,
+      (SELECT payout_amount FROM cashbackPayouts) AS cashback_payout_amount,
+      (SELECT buyback_burn_amount FROM burnWalletInflows) AS buyback_burn_amount
+    FROM
+      botTrades
+  `;
+
+  const [row] = await queryDuneSql(options, query);
+  const tradingFees = Number(row?.fee ?? 0);
+  const cashbackPayouts = Number(row?.cashback_payout_amount ?? 0);
+  const buybackBurnAmount = Number(row?.buyback_burn_amount ?? 0);
+
+  const dailyFees = options.createBalances();
+  const dailySupplySideRevenue = options.createBalances();
+  const dailyRevenue = options.createBalances();
+
+  dailyFees.add(ADDRESSES.solana.SOL, tradingFees, TRADING_TERMINAL_FEES);
+  dailySupplySideRevenue.add(ADDRESSES.solana.SOL, cashbackPayouts, CASHBACK_REFERRAL_PAYOUTS);
+  dailyRevenue.add(ADDRESSES.solana.SOL, tradingFees - cashbackPayouts - buybackBurnAmount, TRADING_TERMINAL_FEES);
+
+  return { dailyFees, dailyRevenue, dailyProtocolRevenue: dailyRevenue, dailySupplySideRevenue }
+}
+
+async function fetchEvm(options: FetchOptions) {
+  const config = evmChainConfig[options.chain]
+  const fees = await addGasTokensReceived({
+    options,
+    balances: options.createBalances(),
+    multisig: config.feeWallet,
+  })
+  await addTokensReceived({
+    options,
+    balances: fees,
+    target: config.feeWallet,
+  })
+  return fees
+}
+
+export const fetch = async (_: any, _1: any, options: FetchOptions) => {
+  if (options.chain === CHAIN.SOLANA) return fetchSolana(options)
+
+  const fees = await fetchEvm(options)
+  const dailyFees = fees.clone(1, TRADING_TERMINAL_FEES)
+
+  return {
+    dailyFees,
+    dailyRevenue: dailyFees,
+    dailyProtocolRevenue: dailyFees,
+  }
+}
+
+export const breakdownMethodology = {
+  Fees: {
+    [TRADING_TERMINAL_FEES]: 'Fees charged on each trade executed through the trading terminal.',
+  },
+  Revenue: {
+    [TRADING_TERMINAL_FEES]: 'Trading terminal fees retained by the protocol after cashback/referral payouts and buyback/burn allocations.',
+  },
+  ProtocolRevenue: {
+    [TRADING_TERMINAL_FEES]: 'Trading terminal fees retained by the protocol after cashback/referral payouts and buyback/burn allocations.',
+  },
+  SupplySideRevenue: {
+    [CASHBACK_REFERRAL_PAYOUTS]: 'All outbound transfers from the cashback/referral wallet.',
+  },
+}
 
 const adapter: SimpleAdapter = {
   version: 1,
@@ -16,6 +174,7 @@ const adapter: SimpleAdapter = {
     ProtocolRevenue: "Trading terminal fees retained by Pump.fun after cashback/referral payouts and buyback/burn allocations.",
     SupplySideRevenue: "All outbound transfers from the cashback/referral wallet.",
   },
+  allowNegativeValue: true,
 };
 
 export default adapter;

--- a/fees/trading-terminal/index.ts
+++ b/fees/trading-terminal/index.ts
@@ -12,7 +12,10 @@ const adapter: SimpleAdapter = {
   breakdownMethodology,
   methodology: {
     Fees: "Trading fees paid by users while using Pump Trading Terminal(previously known as Padre).",
-    Revenue: "All fees are collected by Pump.fun.",
+    Revenue: "Trading terminal fees retained by Pump.fun after cashback/referral payouts and buyback/burn allocations.",
+    ProtocolRevenue: "Trading terminal fees retained by Pump.fun after cashback/referral payouts and buyback/burn allocations.",
+    SupplySideRevenue: "All outbound transfers from the cashback/referral wallet.",
+    HoldersRevenue: "Funds sent to the burn wallet for token buyback and burn.",
   },
 };
 

--- a/fees/trading-terminal/index.ts
+++ b/fees/trading-terminal/index.ts
@@ -15,7 +15,6 @@ const adapter: SimpleAdapter = {
     Revenue: "Trading terminal fees retained by Pump.fun after cashback/referral payouts and buyback/burn allocations.",
     ProtocolRevenue: "Trading terminal fees retained by Pump.fun after cashback/referral payouts and buyback/burn allocations.",
     SupplySideRevenue: "All outbound transfers from the cashback/referral wallet.",
-    HoldersRevenue: "Funds sent to the burn wallet for token buyback and burn.",
   },
 };
 

--- a/fees/trading-terminal/index.ts
+++ b/fees/trading-terminal/index.ts
@@ -5,8 +5,12 @@ import { addGasTokensReceived, addTokensReceived } from '../../helpers/token';
 import { Dependencies, FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 import { queryDuneSql } from "../../helpers/dune";
-const TRADING_TERMINAL_FEES = 'Trading Terminal Fees'
-const CASHBACK_REFERRAL_PAYOUTS = 'Cashback/Referral Payouts'
+
+const LABELS = {
+  TRADING_TERMINAL_FEES: 'Trading Terminal Fees',
+  TRADING_TERMINAL_FEES_TO_PROTOCOL: 'Trading Terminal Fees To Protocol',
+  CASHBACK_REFERRAL_PAYOUTS: 'Cashback/Referral Payouts',
+} as const
 
 const solanaConfig = {
   mainFeeWallet: 'J5XGHmzrRmnYWbmw45DbYkdZAU2bwERFZ11qCDXPvFB5',
@@ -110,9 +114,9 @@ async function fetchSolana(options: FetchOptions) {
   const dailySupplySideRevenue = options.createBalances();
   const dailyRevenue = options.createBalances();
 
-  dailyFees.add(ADDRESSES.solana.SOL, tradingFees, TRADING_TERMINAL_FEES);
-  dailySupplySideRevenue.add(ADDRESSES.solana.SOL, cashbackPayouts, CASHBACK_REFERRAL_PAYOUTS);
-  dailyRevenue.add(ADDRESSES.solana.SOL, tradingFees - cashbackPayouts - buybackBurnAmount, TRADING_TERMINAL_FEES);
+  dailyFees.add(ADDRESSES.solana.SOL, tradingFees, LABELS.TRADING_TERMINAL_FEES);
+  dailySupplySideRevenue.add(ADDRESSES.solana.SOL, cashbackPayouts, LABELS.CASHBACK_REFERRAL_PAYOUTS);
+  dailyRevenue.add(ADDRESSES.solana.SOL, tradingFees - cashbackPayouts - buybackBurnAmount, LABELS.TRADING_TERMINAL_FEES_TO_PROTOCOL);
 
   return { dailyFees, dailyRevenue, dailyProtocolRevenue: dailyRevenue, dailySupplySideRevenue }
 }
@@ -136,27 +140,28 @@ export const fetch = async (_: any, _1: any, options: FetchOptions) => {
   if (options.chain === CHAIN.SOLANA) return fetchSolana(options)
 
   const fees = await fetchEvm(options)
-  const dailyFees = fees.clone(1, TRADING_TERMINAL_FEES)
+  const dailyFees = fees.clone(1, LABELS.TRADING_TERMINAL_FEES)
+  const dailyRevenue = fees.clone(1, LABELS.TRADING_TERMINAL_FEES_TO_PROTOCOL)
 
   return {
     dailyFees,
-    dailyRevenue: dailyFees,
-    dailyProtocolRevenue: dailyFees,
+    dailyRevenue,
+    dailyProtocolRevenue: dailyRevenue,
   }
 }
 
 export const breakdownMethodology = {
   Fees: {
-    [TRADING_TERMINAL_FEES]: 'Fees charged on each trade executed through the trading terminal.',
+    [LABELS.TRADING_TERMINAL_FEES]: 'Fees charged on each trade executed through the trading terminal.',
   },
   Revenue: {
-    [TRADING_TERMINAL_FEES]: 'Trading terminal fees retained by the protocol after cashback/referral payouts and buyback/burn allocations.',
+    [LABELS.TRADING_TERMINAL_FEES_TO_PROTOCOL]: 'Trading terminal fees retained by the protocol after cashback/referral payouts and buyback/burn allocations.',
   },
   ProtocolRevenue: {
-    [TRADING_TERMINAL_FEES]: 'Trading terminal fees retained by the protocol after cashback/referral payouts and buyback/burn allocations.',
+    [LABELS.TRADING_TERMINAL_FEES_TO_PROTOCOL]: 'Trading terminal fees retained by the protocol after cashback/referral payouts and buyback/burn allocations.',
   },
   SupplySideRevenue: {
-    [CASHBACK_REFERRAL_PAYOUTS]: 'All outbound transfers from the cashback/referral wallet.',
+    [LABELS.CASHBACK_REFERRAL_PAYOUTS]: 'All outbound transfers from the cashback/referral wallet.',
   },
 }
 


### PR DESCRIPTION
Partial Fix to #6739 


## Summary
- Updates the Padre fees adapter at `fees/padre/index.ts` to split Solana fee accounting across protocol revenue, cashback/referral payouts, and burn-wallet buyback allocations.
- Excludes internal `J5XGH... -> DoAsx...` wallet top-ups from fee counting while continuing to treat `DoAsx...` as both a fee-receiving and cashback-paying wallet.
- Keeps EVM fee wallet behavior unchanged.

## Changes
- Added a Solana wallet config for:
  - main fee wallet: `J5XGHmzrRmnYWbmw45DbYkdZAU2bwERFZ11qCDXPvFB5`
  - fee/cashback wallet: `DoAsxPQgiyAxyaJNvpAAUb2ups6rbJRdYrCPyWxwRxBb`
  - burn wallet: `9jHrTCwpDANHLNQz5cem6XLUBM8KiTWKe766Br6KVCXM`
- Updated the Solana Dune SQL to:
  - identify interfund transfers from `J5XGH...` to `DoAsx...`
  - exclude those interfund inflows from fee counting
  - count all `DoAsx...` outflows as `dailySupplySideRevenue`
  - count all inflows to `9jHrTC...` as `dailyHoldersRevenue`
- Mapped Solana metrics as:
  - `dailyFees`: trade-related fee inflows to Padre fee wallets
  - `dailySupplySideRevenue`: cashback/referral payouts from `DoAsx...`
  - `dailyHoldersRevenue`: buyback/burn allocations sent to `9jHrTC...`
  - `dailyRevenue` / `dailyProtocolRevenue`: `tradingFees - cashbackPayouts - holdersRevenue`
- Cleaned up the Solana path by:
  - destructuring the Solana config once
  - using `const [row] = await queryDuneSql(...)`
  - guarding Dune values with `?? 0`
  - reusing `dailyRevenue` as `dailyProtocolRevenue`
  - preserving `allowNegativeValue: true`

## Methodology
- Solana fee inflows are sourced from `solana.account_activity` and validated against `dex_solana.trades` by `tx_id`.
- The `DoAsx...` wallet is treated as a dual-role wallet:
  - positive inflows may count as fee receipts
  - negative outflows are treated as cashback/referral payouts
- Internal transfers from the main fee wallet to the fee/cashback wallet are excluded from fee accounting to avoid double counting.
- Burn wallet inflows are treated as holder-facing buyback/burn value rather than protocol-retained revenue.
