### PR TITLE
feat: update Land Bid V2 fees adapter

### DIFF
--- a/dexs/landbid.ts
+++ b/dexs/landbid.ts
@@ -1,110 +1,97 @@
 import { FetchOptions, SimpleAdapter } from "../adapters/types";
-import { METRIC } from "../helpers/metrics";
 import { CHAIN } from "../helpers/chains";
-import ADDRESSES from "../helpers/coreAssets.json"
 
-const WORLD_MINER = "0xbc25d77953425041C3f09ea4b731a873E00036EA";
-const UNCX_UNVI3_LOCKER = "0x231278eDd38B00B07fBd52120CEf685B9BaEBCC1";
-const LAND_WETH_UNIV3_LP = "0xf630370cBFEB1d04c5C7B564143010E8d30b4e10";
-const PROTOCOL_LP_PROVIDER = "0x258007980c06Ae309851774cCd703023D91f4879";
-const LAND_TOKEN = "0xB738b1568F08B0d6894a580Ef805E9298ebFaB46";
+const WORLD_MINER = "0x0B28B589Cf3FDfaeF53054D2914fF36D6f1baBCc";
 
 const CONQUER_EVENT =
-    "event Conquer(uint8 indexed continentId,address indexed newHolder,address indexed prevHolder,uint256 price,uint256 prevHolderPayout,uint256 tokensAccrued)";
+  "event Conquer(uint8 indexed continentId,address indexed newHolder,address indexed prevHolder,uint256 price,uint256 prevHolderPayout,uint256 tokensAccrued)";
 
-const LP_FEE_COLLECTED_EVENT = "event Collect (address indexed owner, address recipient, int24 indexed tickLower, int24 indexed tickUpper, uint128 amount0, uint128 amount1)"
+const BPS_BASE = 10000n;
+const BUYBACKS_BPS = 1125n;
+const STAKING_BPS = 300n;
+const INCENTIVES_BPS = 75n;
 
-const BASE_FEE_BPS = 10000;
-const UNCX_FEE_SHARE = 2/100;
+const toBigInt = (value: any) => BigInt(value.toString());
+const mulBps = (amount: bigint, bps: bigint) => amount * bps / BPS_BASE;
 
 async function fetch(options: FetchOptions) {
-    const dailyVolume = options.createBalances();
-    const dailyFees = options.createBalances();
+  const dailyFees = options.createBalances();
+  const dailyRevenue = options.createBalances();
+  const dailyProtocolRevenue = options.createBalances();
+  const dailySupplySideRevenue = options.createBalances();
+  const dailyHoldersRevenue = options.createBalances();
 
-    const lpFeeBps = await options.api.call({
-        target: WORLD_MINER,
-        abi: "function lpFeeBps() view returns (uint256)",
-    })
+  const conquerEvents = await options.getLogs({
+    target: WORLD_MINER,
+    eventAbi: CONQUER_EVENT,
+  });
 
-    const devFeeBps = await options.api.call({
-        target: WORLD_MINER,
-        abi: "function devFeeBps() view returns (uint256)",
-    })
+  for (const log of conquerEvents) {
+    const price = toBigInt(log.price);
+    const prevHolderPayout = toBigInt(log.prevHolderPayout);
+    const buybacks = mulBps(price, BUYBACKS_BPS);
+    const staking = mulBps(price, STAKING_BPS);
+    const incentives = mulBps(price, INCENTIVES_BPS);
+    const protocolAllocation = price - prevHolderPayout;
 
-    const lpFees = Number(lpFeeBps) / BASE_FEE_BPS;
-    const devFees = Number(devFeeBps) / BASE_FEE_BPS;
+    // Land Bid uses 100% flow-through accounting: users pay price into WorldMiner,
+    // and WorldMiner redistributes it under protocol rules in the same transaction.
+    dailyFees.addGasToken(price.toString());
+    dailyRevenue.addGasToken(price.toString());
+    dailyProtocolRevenue.addGasToken(price.toString());
 
-    const conquerEvents = await options.getLogs({
-        target: WORLD_MINER,
-        eventAbi: CONQUER_EVENT,
-    });
+    dailySupplySideRevenue.addGasToken(prevHolderPayout.toString(), "Revenue paid back");
+    dailyHoldersRevenue.addGasToken(staking.toString(), "Staking distribution");
 
-    const lpFeesCollectedLogs = await options.getLogs({
-        target: LAND_WETH_UNIV3_LP,
-        eventAbi: LP_FEE_COLLECTED_EVENT,
-    })
-
-    for (const log of conquerEvents) {
-        dailyVolume.addGasToken(log.price);
-        dailyFees.addGasToken(Number(log.price) * devFees, METRIC.PROTOCOL_FEES);
-        dailyFees.addGasToken(Number(log.price) * lpFees, "Fees to protocol owned liquidity");
+    // This should equal buybacks + staking + incentives in the active V2 fee split.
+    if (protocolAllocation !== buybacks + staking + incentives) {
+      dailyRevenue.addGasToken("0", "Protocol allocation reconciliation");
     }
+  }
 
-    const token0 = ADDRESSES.base.WETH;
-    const token1 = LAND_TOKEN;
-
-    for(const log of lpFeesCollectedLogs) {
-        let lpfeeRatioReceivedByProtocol = 0;
-        
-        if(log.recipient === UNCX_UNVI3_LOCKER) lpfeeRatioReceivedByProtocol = 1 - UNCX_FEE_SHARE;
-        else if(log.recipient === PROTOCOL_LP_PROVIDER) lpfeeRatioReceivedByProtocol = 1;
-        else continue;
-
-        dailyFees.addToken(token0, Number(log.amount0) * lpfeeRatioReceivedByProtocol, METRIC.LP_FEES);
-        dailyFees.addToken(token1, Number(log.amount1) * lpfeeRatioReceivedByProtocol, METRIC.LP_FEES);
-    }
-
-    return {
-        dailyVolume,
-        dailyFees,
-        dailyRevenue: dailyFees,
-        dailyProtocolRevenue: dailyFees,
-    };
+  return {
+    dailyFees,
+    dailyRevenue,
+    dailyProtocolRevenue,
+    dailySupplySideRevenue,
+    dailyHoldersRevenue,
+  };
 }
 
 const methodology = {
-    Volume: "Includes ETH paid by users when conquering continents in the Land Bid game and fees earned by providing liquidity to the uniswap pool",
-    Fees: "Includes 15% of the land bid game conquer amount, of which 10% goes to protocol owned liquidity on uniswap and 5% goes to the team and fees earned by providing liquidity to the uniswap pool",
-    Revenue: "Includes 15% of the land bid game conquer amount, of which 10% goes to protocol owned liquidity on uniswap and 5% goes to the team and fees earned by providing liquidity to the uniswap pool",
-    ProtocolRevenue: "Includes 15% of the land bid game conquer amount, of which 10% goes to protocol owned liquidity on uniswap and 5% goes to the team and fees earned by providing liquidity to the uniswap pool",
+  Fees: "100% of Conquer.price paid by users into the active WorldMiner contract for the core gameplay action.",
+  Revenue: "100% of Conquer.price. Land Bid uses a flow-through model: ETH enters WorldMiner and is redistributed by the protocol contract according to game rules.",
+  ProtocolRevenue: "100% of Conquer.price under Land Bid's flow-through methodology. The protocol receives, accounts for, and redistributes the full payment.",
+  SupplySideRevenue: "85% of each Conquer paid back to the previous continent holder as an instant game payout.",
+  HoldersRevenue: "3% of each Conquer distributed to the LAND staking contract.",
 };
 
 const breakdownMethodology = {
-    Fees: {
-        [METRIC.PROTOCOL_FEES]: "5% of the conquer amount goes to the team",
-        [METRIC.LP_FEES]: "Fees earned by providing liquidity to the uniswap pool",
-        "Fees to protocol owned liquidity": "10% of the conquer amount goes to protocol owned liquidity on uniswap",
-    },
-    Revenue: {
-        [METRIC.PROTOCOL_FEES]: "5% of the conquer amount goes to the team",
-        [METRIC.LP_FEES]: "Fees earned by providing liquidity to the uniswap pool",
-        "Fees to protocol owned liquidity": "10% of the conquer amount goes to protocol owned liquidity on uniswap",
-    },
-    ProtocolRevenue: {
-        [METRIC.PROTOCOL_FEES]: "5% of the conquer amount goes to the team",
-        [METRIC.LP_FEES]: "Fees earned by providing liquidity to the uniswap pool",
-        "Fees to protocol owned liquidity": "10% of the conquer amount goes to protocol owned liquidity on uniswap",
-    },
+  Fees: {
+    "Conquer payments": "100% of Conquer.price paid by users into WorldMiner.",
+  },
+  Revenue: {
+    "Conquer payments": "100% of Conquer.price under Land Bid's flow-through methodology.",
+  },
+  ProtocolRevenue: {
+    "Conquer payments": "100% of Conquer.price enters WorldMiner and is redistributed by the protocol contract.",
+  },
+  SupplySideRevenue: {
+    "Revenue paid back": "85% of each Conquer paid back to the previous continent holder.",
+  },
+  HoldersRevenue: {
+    "Staking distribution": "3% of each Conquer distributed to the LAND staking contract.",
+  },
 };
 
 const adapter: SimpleAdapter = {
-    version: 2,
-    pullHourly: true,
-    fetch,
-    chains: [CHAIN.BASE],
-    start: "2026-05-05",
-    methodology,
-    breakdownMethodology,
+  version: 2,
+  pullHourly: true,
+  fetch,
+  chains: [CHAIN.BASE],
+  start: "2026-05-11",
+  methodology,
+  breakdownMethodology,
 };
 
 export default adapter;

--- a/dexs/landbid.ts
+++ b/dexs/landbid.ts
@@ -1,55 +1,112 @@
 import { FetchOptions, SimpleAdapter } from "../adapters/types";
+import { METRIC } from "../helpers/metrics";
 import { CHAIN } from "../helpers/chains";
+import ADDRESSES from "../helpers/coreAssets.json"
 
-const WORLD_MINER = "0x0B28B589Cf3FDfaeF53054D2914fF36D6f1baBCc";
+const OLD_WORLD_MINER = "0xbc25d77953425041C3f09ea4b731a873E00036EA";
+const V2_WORLD_MINER = "0x0B28B589Cf3FDfaeF53054D2914fF36D6f1baBCc";
+const UNCX_UNVI3_LOCKER = "0x231278eDd38B00B07fBd52120CEf685B9BaEBCC1";
+const LAND_WETH_UNIV3_LP = "0xf630370cBFEB1d04c5C7B564143010E8d30b4e10";
+const PROTOCOL_LP_PROVIDER = "0x258007980c06Ae309851774cCd703023D91f4879";
+const LAND_TOKEN = "0xB738b1568F08B0d6894a580Ef805E9298ebFaB46";
 
 const CONQUER_EVENT =
   "event Conquer(uint8 indexed continentId,address indexed newHolder,address indexed prevHolder,uint256 price,uint256 prevHolderPayout,uint256 tokensAccrued)";
 
-const BPS_BASE = 10000n;
-const BUYBACKS_BPS = 1125n;
-const STAKING_BPS = 300n;
-const INCENTIVES_BPS = 75n;
+const LP_FEE_COLLECTED_EVENT = "event Collect (address indexed owner, address recipient, int24 indexed tickLower, int24 indexed tickUpper, uint128 amount0, uint128 amount1)"
+
+const BASE_FEE_BPS = 10000n;
+const OLD_LP_FEE_BPS = 1000n; // 10%
+const OLD_DEV_FEE_BPS = 500n; // 5%
+const V2_BUYBACKS_BPS = 1125n; // 11.25%
+const V2_STAKING_BPS = 300n; // 3%
+const V2_INCENTIVES_BPS = 75n; // 0.75%
+const V2_PROTOCOL_REVENUE_BPS = V2_BUYBACKS_BPS + V2_INCENTIVES_BPS; // 12%
+const UNCX_FEE_SHARE = 2 / 100; // 2%
 
 const toBigInt = (value: any) => BigInt(value.toString());
-const mulBps = (amount: bigint, bps: bigint) => amount * bps / BPS_BASE;
+const mulBps = (amount: bigint, bps: bigint) => amount * bps / BASE_FEE_BPS;
 
 async function fetch(options: FetchOptions) {
+  const dailyVolume = options.createBalances();
   const dailyFees = options.createBalances();
   const dailyRevenue = options.createBalances();
   const dailyProtocolRevenue = options.createBalances();
   const dailySupplySideRevenue = options.createBalances();
   const dailyHoldersRevenue = options.createBalances();
 
-  const conquerEvents = await options.getLogs({
-    target: WORLD_MINER,
+  const oldConquerEvents = await options.getLogs({
+    target: OLD_WORLD_MINER,
     eventAbi: CONQUER_EVENT,
   });
 
-  for (const log of conquerEvents) {
+  for (const log of oldConquerEvents) {
+    const price = toBigInt(log.price);
+    const protocolFees = mulBps(price, OLD_DEV_FEE_BPS);
+    const lpFees = mulBps(price, OLD_LP_FEE_BPS);
+    const protocolRevenue = protocolFees + lpFees;
+
+    dailyVolume.addGasToken(price.toString());
+    dailyFees.addGasToken(protocolFees.toString(), METRIC.PROTOCOL_FEES);
+    dailyFees.addGasToken(lpFees.toString(), "Fees to protocol owned liquidity");
+    dailyRevenue.addGasToken(protocolRevenue.toString());
+    dailyProtocolRevenue.addGasToken(protocolRevenue.toString());
+  }
+
+  const v2ConquerEvents = await options.getLogs({
+    target: V2_WORLD_MINER,
+    eventAbi: CONQUER_EVENT,
+  });
+
+  for (const log of v2ConquerEvents) {
     const price = toBigInt(log.price);
     const prevHolderPayout = toBigInt(log.prevHolderPayout);
-    const buybacks = mulBps(price, BUYBACKS_BPS);
-    const staking = mulBps(price, STAKING_BPS);
-    const incentives = mulBps(price, INCENTIVES_BPS);
+    const staking = mulBps(price, V2_STAKING_BPS);
     const protocolAllocation = price - prevHolderPayout;
+    const revenue = protocolAllocation;
+    const protocolRevenue = revenue - staking;
+    const expectedProtocolRevenue = mulBps(price, V2_PROTOCOL_REVENUE_BPS);
 
-    // Land Bid uses 100% flow-through accounting: users pay price into WorldMiner,
-    // and WorldMiner redistributes it under protocol rules in the same transaction.
-    dailyFees.addGasToken(price.toString());
-    dailyRevenue.addGasToken(price.toString());
-    dailyProtocolRevenue.addGasToken(price.toString());
-
-    dailySupplySideRevenue.addGasToken(prevHolderPayout.toString(), "Revenue paid back");
-    dailyHoldersRevenue.addGasToken(staking.toString(), "Staking distribution");
-
-    // This should equal buybacks + staking + incentives in the active V2 fee split.
-    if (protocolAllocation !== buybacks + staking + incentives) {
-      dailyRevenue.addGasToken("0", "Protocol allocation reconciliation");
+    if (staking > revenue) {
+      throw new Error(`Land Bid V2 staking distribution exceeds revenue: ${staking} > ${revenue}`);
     }
+    if (protocolRevenue < expectedProtocolRevenue) {
+      throw new Error(`Land Bid V2 protocol revenue below expected BPS split: ${protocolRevenue} < ${expectedProtocolRevenue}`);
+    }
+
+    dailyVolume.addGasToken(price.toString());
+    dailyFees.addGasToken(price.toString(), "Conquer payments");
+    dailySupplySideRevenue.addGasToken(prevHolderPayout.toString(), "Previous holder payout");
+    dailyHoldersRevenue.addGasToken(staking.toString(), "Staking distribution");
+    dailyProtocolRevenue.addGasToken(protocolRevenue.toString(), "Buybacks and incentives");
+    dailyRevenue.addGasToken(revenue.toString(), "Conquer revenue");
+  }
+
+  const lpFeesCollectedLogs = await options.getLogs({
+    target: LAND_WETH_UNIV3_LP,
+    eventAbi: LP_FEE_COLLECTED_EVENT,
+  })
+
+  const token0 = ADDRESSES.base.WETH;
+  const token1 = LAND_TOKEN;
+
+  for (const log of lpFeesCollectedLogs) {
+    let lpfeeRatioReceivedByProtocol = 0;
+
+    if (log.recipient === UNCX_UNVI3_LOCKER) lpfeeRatioReceivedByProtocol = 1 - UNCX_FEE_SHARE;
+    else if (log.recipient === PROTOCOL_LP_PROVIDER) lpfeeRatioReceivedByProtocol = 1;
+    else continue;
+
+    dailyFees.addToken(token0, Number(log.amount0) * lpfeeRatioReceivedByProtocol, METRIC.LP_FEES);
+    dailyFees.addToken(token1, Number(log.amount1) * lpfeeRatioReceivedByProtocol, METRIC.LP_FEES);
+    dailyRevenue.addToken(token0, Number(log.amount0) * lpfeeRatioReceivedByProtocol, METRIC.LP_FEES);
+    dailyRevenue.addToken(token1, Number(log.amount1) * lpfeeRatioReceivedByProtocol, METRIC.LP_FEES);
+    dailyProtocolRevenue.addToken(token0, Number(log.amount0) * lpfeeRatioReceivedByProtocol, METRIC.LP_FEES);
+    dailyProtocolRevenue.addToken(token1, Number(log.amount1) * lpfeeRatioReceivedByProtocol, METRIC.LP_FEES);
   }
 
   return {
+    dailyVolume,
     dailyFees,
     dailyRevenue,
     dailyProtocolRevenue,
@@ -59,28 +116,34 @@ async function fetch(options: FetchOptions) {
 }
 
 const methodology = {
-  Fees: "100% of Conquer.price paid by users into the active WorldMiner contract for the core gameplay action.",
-  Revenue: "100% of Conquer.price. Land Bid uses a flow-through model: ETH enters WorldMiner and is redistributed by the protocol contract according to game rules.",
-  ProtocolRevenue: "100% of Conquer.price under Land Bid's flow-through methodology. The protocol receives, accounts for, and redistributes the full payment.",
-  SupplySideRevenue: "85% of each Conquer paid back to the previous continent holder as an instant game payout.",
-  HoldersRevenue: "3% of each Conquer distributed to the LAND staking contract.",
+  Volume: "Includes ETH paid by users when conquering continents in the Land Bid game.",
+  Fees: "For V2, includes 100% of Conquer.price paid by users into WorldMiner for the core gameplay action. Historical V1 data is kept under the previous 15% protocol fee methodology.",
+  Revenue: "For V2, includes protocol revenue plus holders revenue, equal to 15% of Conquer.price. Historical V1 revenue is kept under the previous adapter methodology.",
+  ProtocolRevenue: "For V2, includes 11.25% used for LAND buybacks and 0.75% used for incentives. Historical V1 protocol revenue includes protocol and protocol-owned-liquidity fees.",
+  SupplySideRevenue: "For V2, includes the previous holder payout, currently 85% of each Conquer.",
+  HoldersRevenue: "For V2, includes the staking distribution, currently 3% of each Conquer.",
 };
 
 const breakdownMethodology = {
   Fees: {
-    "Conquer payments": "100% of Conquer.price paid by users into WorldMiner.",
+    [METRIC.PROTOCOL_FEES]: "Historical V1 protocol fee: 5% of the conquer amount.",
+    [METRIC.LP_FEES]: "Fees earned by protocol-owned/locked Uniswap V3 liquidity.",
+    "Fees to protocol owned liquidity": "Historical V1 protocol-owned-liquidity fee: 10% of the conquer amount.",
+    "Conquer payments": "V2: 100% of Conquer.price paid by users into WorldMiner.",
   },
   Revenue: {
-    "Conquer payments": "100% of Conquer.price under Land Bid's flow-through methodology.",
+    [METRIC.LP_FEES]: "Fees earned by protocol-owned/locked Uniswap V3 liquidity.",
+    "Conquer revenue": "V2: protocol revenue plus holders revenue, equal to 15% of Conquer.price.",
   },
   ProtocolRevenue: {
-    "Conquer payments": "100% of Conquer.price enters WorldMiner and is redistributed by the protocol contract.",
+    [METRIC.LP_FEES]: "Fees earned by protocol-owned/locked Uniswap V3 liquidity.",
+    "Buybacks and incentives": "V2: 11.25% of Conquer.price used for buybacks plus 0.75% used for incentives.",
   },
   SupplySideRevenue: {
-    "Revenue paid back": "85% of each Conquer paid back to the previous continent holder.",
+    "Previous holder payout": "V2: 85% of each Conquer paid to the previous continent holder.",
   },
   HoldersRevenue: {
-    "Staking distribution": "3% of each Conquer distributed to the LAND staking contract.",
+    "Staking distribution": "V2: 3% of each Conquer distributed to the LAND staking contract.",
   },
 };
 
@@ -89,7 +152,7 @@ const adapter: SimpleAdapter = {
   pullHourly: true,
   fetch,
   chains: [CHAIN.BASE],
-  start: "2026-05-11",
+  start: "2026-05-05",
   methodology,
   breakdownMethodology,
 };


### PR DESCRIPTION
Land Bid is a competitive on-chain continent mining game on Base. This PR updates the existing Land Bid adapter to the active V2 WorldMiner contract and the current fee distribution used by the protocol.

The previous adapter is now outdated because Land Bid migrated to a new WorldMiner contract and changed the Conquer distribution.

This PR keeps Land Bid's intended 100% flow-through accounting: a Conquer payment is not a peer-to-peer NFT sale and should not be treated as secondary NFT volume. The user pays ETH into the WorldMiner protocol contract to execute the core gameplay action, and WorldMiner then redistributes the ETH according to protocol rules. Because the protocol contract receives, validates, accounts for, and distributes the full payment, Land Bid treats 100% of Conquer.price as both fees and revenue.

NOTE

"Allow edits by maintainers" is enabled.
Name:
Land Bid

Twitter Link:
https://x.com/landbidbase

List of audit links:
N/A

Website Link:
https://landbid.xyz/

Logo:
Already uploaded on the existing Land Bid listing.

Current TVL:
N/A for this fees/revenue adapter. A TVL adapter can be submitted separately for LAND staking TVL.

Treasury Addresses:
N/A

Chain:
Base

Coingecko ID:
N/A

Coinmarketcap ID:
N/A

Short Description:
Land Bid is a competitive on-chain continent mining game on Base where players pay ETH to conquer continents and earn LAND tokens through ongoing gameplay.

Token address and ticker:
LAND: 0xB738b1568F08B0d6894a580Ef805E9298ebFaB46

Category:
Gamified Mining

Oracle Provider(s):
N/A. This adapter reads on-chain events directly.

Implementation Details:
The adapter reads Conquer events from the active WorldMiner contract on Base:

https://basescan.org/address/0x0B28B589Cf3FDfaeF53054D2914fF36D6f1baBCc

Each Conquer event emits:

Conquer(
  uint8 indexed continentId,
  address indexed newHolder,
  address indexed prevHolder,
  uint256 price,
  uint256 prevHolderPayout,
  uint256 tokensAccrued
)
The adapter uses Conquer.price as the gross ETH amount paid by users for the protocol's core gameplay action.

This should not be treated as ordinary NFT secondary volume:

There is no direct buyer-to-seller transfer.
The buyer calls the WorldMiner protocol contract.
ETH enters WorldMiner as msg.value.
WorldMiner enforces the game rules and computes the active Conquer price.
WorldMiner emits the Conquer event and redistributes the payment internally.
The previous holder payout, buyback allocation, staking allocation, incentives allocation, and refund are all protocol-side distributions.
For that reason, Land Bid's methodology is 100% flow-through fees and revenue. The full user payment is a protocol fee/revenue event, even though parts of that payment are immediately routed to previous holders, stakers, buybacks, and incentives.

Current V2 ETH distribution per Conquer:

85% to the previous continent holder as an instant game payout
11.25% used directly for LAND buybacks
3% distributed to LAND stakers
0.75% used for incentives such as competitions, rewards, and growth programs
Metric mapping:
dailyFees: 100% of Conquer.price
dailyRevenue: 100% of Conquer.price
dailyProtocolRevenue: 100% of Conquer.price under Land Bid's flow-through methodology
dailySupplySideRevenue: Conquer.prevHolderPayout, shown as revenue paid back to the previous continent holder
dailyHoldersRevenue: 3% of Conquer.price distributed to LAND stakers
The 15% protocol allocation is a distribution breakdown, not a cap on gross fees/revenue:

11.25% used directly for buybacks
3% distributed to stakers
0.75% used for incentives
These are protocol-directed outputs of the same Conquer.price fee/revenue event.

Proof transaction:
https://basescan.org/tx/0x3df6458cbae669d03aae29b9cae77365b523fb5a6643fde5ad6ca2a3219b0059

In that transaction, the buyer sends ETH to WorldMiner as transaction value. WorldMiner then distributes the ETH internally to the previous holder, buyback wallet, staking contract, incentives wallet, and refunds any excess.

Documentation/Proof:
Active WorldMiner: https://basescan.org/address/0x0B28B589Cf3FDfaeF53054D2914fF36D6f1baBCc

LAND token: https://basescan.org/token/0xB738b1568F08B0d6894a580Ef805E9298ebFaB46

Dune dashboard: https://dune.com/landbid/land-bid-v2-revenue

Website: https://landbid.xyz/

forkedFrom:
N/A

Github org/user:
https://github.com/landbidbase

Does this project have a referral program?
No