### PR TITLE
fix: correct BulbaSwap start dates (Morph launched in 2024, not 2021)

### DIFF
--- a/dexs/bulbaswap-v2.ts
+++ b/dexs/bulbaswap-v2.ts
@@ -37,7 +37,7 @@ const adapter: SimpleAdapter = {
   adapter: {
     [CHAIN.MORPH]: {
       fetch: fetchV2Data,
-      start: '2021-04-14',
+      start: '2024-10-27',
     },
   },
 };

--- a/dexs/bulbaswap-v3.ts
+++ b/dexs/bulbaswap-v3.ts
@@ -33,7 +33,7 @@ const adapter: SimpleAdapter = {
   adapter: {
     [CHAIN.MORPH]: {
       fetch: fetchV3Data,
-      start: '2021-04-14',
+      start: '2024-10-19',
     },
   },
 };

--- a/fees/bulbaswap-v2.ts
+++ b/fees/bulbaswap-v2.ts
@@ -37,7 +37,7 @@ const adapter: SimpleAdapter = {
   adapter: {
     [CHAIN.MORPH]: {
       fetch: fetchV2Data,
-      start: '2021-04-14',
+      start: '2024-10-27',
     },
   },
 };


### PR DESCRIPTION
## Summary

Three BulbaSwap adapter files set `start: '2021-04-14'` despite BulbaSwap launching on Morph chain in October 2024 — producing ~3.5 years of leading-zero data points before the protocol existed.

## Evidence

| Adapter | First non-zero day in production |
|---|---|
| `bulbaswap-v2` | 2024-10-27 ([`/summary/fees/bulbaswap-v2`](https://api.llama.fi/summary/fees/bulbaswap-v2)) |
| `bulbaswap-v3` | 2024-10-19 ([`/summary/dexs/bulbaswap-v3`](https://api.llama.fi/summary/dexs/bulbaswap-v3)) |
| Protocol `bulbaswap` listing | first TVL on 2024-10-30 ([`/protocol/bulbaswap`](https://api.llama.fi/protocol/bulbaswap)) |

Morph (MorphL2) chain itself didn't reach mainnet until late 2024, so `2021-04-14` is impossible — it appears to be a copy-paste from another template.

## Fix

| File | Before | After |
|---|---|---|
| `dexs/bulbaswap-v2.ts:40` | `'2021-04-14'` | `'2024-10-27'` |
| `dexs/bulbaswap-v3.ts:36` | `'2021-04-14'` | `'2024-10-19'` |
| `fees/bulbaswap-v2.ts:40` | `'2021-04-14'` | `'2024-10-27'` |

`fees/bulbaswap-v3.ts` already had a correct date (`'2024-10-29'`) and is left untouched.

## Local test

```
$ pnpm run test dexs bulbaswap-v2
MORPH 👇 Backfill start time: 27/10/2024  Daily volume: $1.70k

$ pnpm run test dexs bulbaswap-v3
MORPH 👇 Backfill start time: 19/10/2024  Daily volume: $265.98k

$ pnpm run test fees bulbaswap-v2
MORPH 👇 Backfill start time: 27/10/2024  Daily fees: $5.95
```

All three adapters return valid data with the corrected start dates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)