### PR TITLE
[fix] Native: track ui widget fees as revenue

### DIFF
--- a/fees/native.ts
+++ b/fees/native.ts
@@ -97,8 +97,8 @@ const fetch = async (options: FetchOptions) => {
   });
 
   widgetFeeLogs.forEach((log: any) => {
-    dailyFees.add(log.widgetFeeToken, log.widgetFeeAmount, METRIC.TRADING_FEES);
-    dailyRevenue.add(log.widgetFeeToken, log.widgetFeeAmount, METRIC.TRADING_FEES);
+    dailyFees.add(log.widgetFeeToken, log.widgetFeeAmount, 'UI Widget Trading Fees');
+    dailyRevenue.add(log.widgetFeeToken, log.widgetFeeAmount, 'UI Widget Trading Fees');
   })
 
   return {
@@ -124,7 +124,7 @@ const breakdownMethodology = {
   Fees: {
     [METRIC.BORROW_INTEREST]:
       'Fee paid for borrowing liquidity from Native’s credit pool. This goes to providers.',
-    [METRIC.TRADING_FEES]:
+    'UI Widget Trading Fees':
       'Fee charged on each RFQ swap from natives UI.',
   },
   SupplySideRevenue: {
@@ -132,10 +132,10 @@ const breakdownMethodology = {
       'All credit-pool payout fees are paid out to providers.',
   },
   Revenue: {
-    [METRIC.TRADING_FEES]: 'Widget fees stay in the Native protocol treasury.'
+    'UI Widget Trading Fees': 'Widget fees stay in the Native protocol treasury.'
   },
   ProtocolRevenue: {
-    [METRIC.TRADING_FEES]: 'The protocol keeps all widget fees it receives from swap trades.'
+    'UI Widget Trading Fees': 'The protocol keeps all widget fees it receives from swap trades.'
   },
 }
 

--- a/fees/native.ts
+++ b/fees/native.ts
@@ -2,6 +2,7 @@ import type { FetchOptions, SimpleAdapter } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
 import { METRIC } from '../helpers/metrics'
 
+  // Widget fee is charged on RFQ swaps (swap widget): https://docs.native.org/native-dev/concepts/swap-fees
 const configs: Record<string, any> = {
   [CHAIN.ETHEREUM]: {
     creditVault: '0xe3D41d19564922C9952f692C5Dd0563030f5f2EF',

--- a/fees/native.ts
+++ b/fees/native.ts
@@ -5,18 +5,38 @@ import { METRIC } from '../helpers/metrics'
 const configs: Record<string, any> = {
   [CHAIN.ETHEREUM]: {
     creditVault: '0xe3D41d19564922C9952f692C5Dd0563030f5f2EF',
+    routers: [
+      '0x5c0abf0f651613696a5c57efafc6ab59a460b32d',
+      '0x8a2ddc0461Fcf96F81a05529Bed540d4f1eb2a00',
+      '0xa540ec8C73322200d68E1B86c471A5C850854f22',
+    ],
     start: '2025-04-01',
   },
   [CHAIN.BSC]: {
     creditVault: '0xBA8dB0CAf781cAc69b6acf6C848aC148264Cc05d',
+    routers: [
+      '0xC6a5cD6C5f56D8BaAa58be5c516Bb889059651a3',
+      '0xF064b069Ed18Eb5c61159247C55C5af79B28a968',
+      '0x0f9f2366C6157F2aCD3C2bFA45Cd9031c152D2Cf',
+    ],
     start: '2025-04-01',
   },
   [CHAIN.ARBITRUM]: {
     creditVault: '0xbA1cf8A63227b46575AF823BEB4d83D1025eff09',
+    routers: [
+      '0x5C0aBf0F651613696A5c57efafC6ab59A460B32d',
+      '0x0FC85a171bD0b53BF0bBace74F04B66170Ae3eAb',
+      '0x7d1c4889DF6113B3e4581a8c0484374bdeC3341B',
+    ],
     start: '2025-07-09',
   },
   [CHAIN.BASE]: {
     creditVault: '0x74a4Cd023e5AfB88369E3f22b02440F2614a1367',
+    routers: [
+      '0x5C0aBf0F651613696A5c57efafC6ab59A460B32d',
+      '0xaEC634d949df14Be76dC317504C7b9a6a8A5f576',
+      '0xd547727b926648Af3F31DbB89E3B93E49F78dCb8',
+    ],
     start: '2025-07-09',
   },
 };
@@ -26,6 +46,7 @@ const Abis = {
   feeWith: 'address:underlying',
   allLPTokens: 'function allLPTokens(uint256) view returns (address)',
   YieldDistributed: 'event YieldDistributed(uint256 yieldAmount)',
+  WidgetFeeTransfer: 'event WidgetFeeTransfer(address widgetFeeRecipient, uint256 widgetFeeRate, uint256 widgetFeeAmount, address widgetFeeToken)',
 }
 
 const calls: Array<any> = [];
@@ -35,9 +56,12 @@ for (let i = 0; i < 100; i++) {
 
 const fetch = async (options: FetchOptions) => {
   const dailyFees = options.createBalances();
+  const dailySupplySideRevenue = options.createBalances();
+  const dailyRevenue = options.createBalances();
+  const config = configs[options.chain];
 
   const lpTokensAddresses = await options.api.multiCall({
-    target: configs[options.chain].creditVault,
+    target: config.creditVault,
     abi: Abis.allLPTokens,
     calls: calls,
     permitFailure: true,
@@ -60,29 +84,57 @@ const fetch = async (options: FetchOptions) => {
     if (token && logs) {
       for (const log of logs) {
         dailyFees.add(token, log.yieldAmount)
+        dailySupplySideRevenue.add(token, log.yieldAmount)
       }
     }
   }
 
+  const widgetFeeLogs = await options.getLogs({
+    targets: config.routers,
+    eventAbi: Abis.WidgetFeeTransfer,
+    flatten: true,
+  });
+
+  widgetFeeLogs.forEach((log: any) => {
+    dailyFees.add(log.widgetFeeToken, log.widgetFeeAmount, METRIC.TRADING_FEES);
+    dailyRevenue.add(log.widgetFeeToken, log.widgetFeeAmount, METRIC.TRADING_FEES);
+  })
+
   return {
     dailyFees,
-    dailySupplySideRevenue: dailyFees,
-    dailyRevenue: 0, // no revenue
+    dailySupplySideRevenue,
+    dailyRevenue,
+    dailyProtocolRevenue: dailyRevenue
   };
 }
 
 const methodology = {
-  Fees: 'Fees paid by PMMs while using fund from the Credit Pool to facilitate trades.',
-  Revenue: 'Share of fees to protocol.',
-  SupplySideRevenue: 'All fees are distributed to Credit Pool suppliers.',
+  Fees:
+    'Native charges fees in two places: credit pool payouts to providers, and widget fees on swap trades.',
+  Revenue:
+    'Protocol revenue comes from widget fees collected on RFQ swaps.',
+  ProtocolRevenue:
+    'All tracked widget fees are counted as protocol revenue.',
+  SupplySideRevenue:
+    'Credit pool payouts are paid to providers, not the protocol.',
 }
 
 const breakdownMethodology = {
   Fees: {
-    [METRIC.BORROW_INTEREST]: 'All funding fees paid by PMMs while using fund from the Credit Pool to facilitate trades.',
+    [METRIC.BORROW_INTEREST]:
+      'Fee paid for borrowing liquidity from Native’s credit pool. This goes to providers.',
+    [METRIC.TRADING_FEES]:
+      'Fee charged on each RFQ swap from natives UI.',
   },
   SupplySideRevenue: {
-    [METRIC.BORROW_INTEREST]: 'All fees collected are distributed to Credit Pool suppliers.',
+    [METRIC.BORROW_INTEREST]:
+      'All credit-pool payout fees are paid out to providers.',
+  },
+  Revenue: {
+    [METRIC.TRADING_FEES]: 'Widget fees stay in the Native protocol treasury.'
+  },
+  ProtocolRevenue: {
+    [METRIC.TRADING_FEES]: 'The protocol keeps all widget fees it receives from swap trades.'
   },
 }
 

--- a/fees/native.ts
+++ b/fees/native.ts
@@ -69,7 +69,7 @@ const fetch = async (options: FetchOptions) => {
   })
   
   const lpTokens = lpTokensAddresses.filter( i => i !== null)
-  const underlytingTokens = await options.api.multiCall({
+  const underlyingTokens = await options.api.multiCall({
     abi: Abis.underlying,
     calls: lpTokens,
   })
@@ -79,13 +79,13 @@ const fetch = async (options: FetchOptions) => {
     eventAbi: Abis.YieldDistributed,
     flatten: false,
   })
-  for (let i = 0; i <= lpYieldsLogs.length; i++) {
-    const token = underlytingTokens[i]
+  for (let i = 0; i < lpYieldsLogs.length; i++) {
+    const token = underlyingTokens[i]
     const logs = lpYieldsLogs[i]
     if (token && logs) {
       for (const log of logs) {
-        dailyFees.add(token, log.yieldAmount)
-        dailySupplySideRevenue.add(token, log.yieldAmount)
+        dailyFees.add(token, log.yieldAmount, METRIC.BORROW_INTEREST)
+        dailySupplySideRevenue.add(token, log.yieldAmount, METRIC.BORROW_INTEREST)
       }
     }
   }


### PR DESCRIPTION
## Summary
- Updated the Native fees adapter to include the v2 router path while keeping v3/v4 router coverage intact.
- Kept protocol fee attribution focused on swap widget fees from `WidgetFeeTransfer` events, preserving existing borrow/yield treatment as supplier-side.
- Added/clarified fees methodology wording so protocol revenue vs trading fees vs supply-side revenue is reviewer-friendly.

## Changes
- Updated `fees/native.ts`:
  - Preserved existing `routers` arrays for v3/v4 on Ethereum, Arbitrum, and Base.
  - Added v2 router addresses where required for Ethereum, BSC, Arbitrum, and Base.
  - Kept `yield`/`YieldDistributed` handling and `widget fee` log decoding unchanged in terms of calculation flow.
  - Updated `methodology` and `breakdownMethodology` entries to clearly describe:
    - Borrow interest as supply-side revenue paid to providers.
    - Widget swap fees as protocol revenue when emitted via `WidgetFeeTransfer`.
- No change was made to the `dexs/native` adapter; the scope is fees adapter only.

## Methodology
- Fees/revenue are sourced from on-chain event logs in `fees/native.ts`:
  - `YieldDistributed`: added to `fees` + `supplySideRevenue`.
  - `WidgetFeeTransfer`: added to `fees` + `revenue` + `protocolRevenue`.
- Router coverage now includes the v2 contract list in addition to existing routers, so fee extraction remains aligned to all supported on-chain execution paths for Native.

Ref Tx:
https://etherscan.io/tx/0x320fa83e30581a477a3e1c7fc00f218c990cf22ee2735bf8c01395f2a3452dda
