### PR TITLE
[feat] Blockscout-fees: track lukso and fluent chain fees in factory

### DIFF
--- a/factory/blockscout.ts
+++ b/factory/blockscout.ts
@@ -122,6 +122,8 @@ const protocolChainMap: Record<string, string> = {
   "rise": CHAIN.RISE,
   "citrea": CHAIN.CITREA,
   "moca": CHAIN.MOCA,
+  "fluent": CHAIN.FLUENT,
+  "lukso": CHAIN.LUKSO,
 }
 
 const deadFromMap: Record<string, string> = {

--- a/helpers/blockscoutFees.ts
+++ b/helpers/blockscoutFees.ts
@@ -141,6 +141,8 @@ export const chainConfigMap: any = {
   [CHAIN.RISE]: { CGToken: 'ethereum', explorer: 'https://explorer.risechain.com', start: '2026-01-01' },
   [CHAIN.CITREA]: { CGToken: 'bitcoin', explorer: 'https://explorer.mainnet.citrea.xyz', start: '2025-11-25' },
   [CHAIN.MOCA]: { CGToken: 'mocaverse', explorer: 'https://scan.mocachain.org', start: '2026-01-26' },
+  [CHAIN.FLUENT]: { CGToken: 'ethereum', explorer: 'https://fluentscan.xyz' },
+  [CHAIN.LUKSO]: { CGToken: 'lukso-token', explorer: 'https://explorer.execution.mainnet.lukso.network', allStatsApi: 'https://stats-explorer.execution.mainnet.lukso.network' },
 }
 
 function getTimeString(timestamp: number) {

--- a/helpers/blockscoutFees.ts
+++ b/helpers/blockscoutFees.ts
@@ -142,7 +142,7 @@ export const chainConfigMap: any = {
   [CHAIN.CITREA]: { CGToken: 'bitcoin', explorer: 'https://explorer.mainnet.citrea.xyz', start: '2025-11-25' },
   [CHAIN.MOCA]: { CGToken: 'mocaverse', explorer: 'https://scan.mocachain.org', start: '2026-01-26' },
   [CHAIN.FLUENT]: { CGToken: 'ethereum', explorer: 'https://fluentscan.xyz', allStatsApi: 'https://fluentscan.xyz/node-api/proxy' },
-  [CHAIN.LUKSO]: { CGToken: 'lukso-token', explorer: 'https://explorer.execution.mainnet.lukso.network', allStatsApi: 'https://stats-explorer.execution.mainnet.lukso.network' },
+  [CHAIN.LUKSO]: { CGToken: 'lukso-token-2', explorer: 'https://explorer.execution.mainnet.lukso.network', allStatsApi: 'https://stats-explorer.execution.mainnet.lukso.network' },
 }
 
 function getTimeString(timestamp: number) {

--- a/helpers/blockscoutFees.ts
+++ b/helpers/blockscoutFees.ts
@@ -141,7 +141,7 @@ export const chainConfigMap: any = {
   [CHAIN.RISE]: { CGToken: 'ethereum', explorer: 'https://explorer.risechain.com', start: '2026-01-01' },
   [CHAIN.CITREA]: { CGToken: 'bitcoin', explorer: 'https://explorer.mainnet.citrea.xyz', start: '2025-11-25' },
   [CHAIN.MOCA]: { CGToken: 'mocaverse', explorer: 'https://scan.mocachain.org', start: '2026-01-26' },
-  [CHAIN.FLUENT]: { CGToken: 'ethereum', explorer: 'https://fluentscan.xyz' },
+  [CHAIN.FLUENT]: { CGToken: 'ethereum', explorer: 'https://fluentscan.xyz', allStatsApi: 'https://fluentscan.xyz/node-api/proxy' },
   [CHAIN.LUKSO]: { CGToken: 'lukso-token', explorer: 'https://explorer.execution.mainnet.lukso.network', allStatsApi: 'https://stats-explorer.execution.mainnet.lukso.network' },
 }
 


### PR DESCRIPTION
## Summary
- Enabled FLUENT and LUKSO in the Blockscout-backed fee adapter chain routing.
- Updated FLUENT chain configuration to use the correct explorer and stats API endpoints.

## Changes
- Updated `factory/blockscout.ts` to include:
  - `fluent` → `CHAIN.FLUENT`
  - `lukso` → `CHAIN.LUKSO`
- Updated `helpers/blockscoutFees.ts` chain config entries for:
  - `CHAIN.FLUENT` with `explorer: 'https://fluentscan.xyz'` and `allStatsApi: 'https://fluentscan.xyz/node-api/proxy'`
  - `CHAIN.LUKSO` configuration for Blockscout stats/explorer alignment and consistent object formatting.
