### PR TITLE
stellaswap-v4: fix correct revenue distribution

### DIFF
--- a/dexs/stellaswap-v4/index.ts
+++ b/dexs/stellaswap-v4/index.ts
@@ -15,20 +15,33 @@ const fetch = async (_timestamp: number, _: any, options: FetchOptions): Promise
     }`;
   const url = sdk.graph.modifyEndpoint('LgiKJnsTspbsPBLqDPqULPtnAdSZP6LfPCSo3GWuJ5a');
   const req = await request(url, query);
+
+  // 15% treasury, 1.5% Algebra infra, 83.5% veSTELLA voters.
+  const COMMUNITY_FEE = 0.22       // protocol vault share of total swap fees
+  const LP_SHARE = 1 - COMMUNITY_FEE
+  const TREASURY = 0.15            // of the community vault
+  const ALGEBRA = 0.015            // of the community vault (infra licence)
+  const VESTELLA = 0.835           // of the community vault
+
+  const feesUSD = Number(req.algebraDayData?.feesUSD ?? 0)
+  const protocolRevenue = feesUSD * COMMUNITY_FEE * TREASURY
+  const holdersRevenue = feesUSD * COMMUNITY_FEE * VESTELLA
   return {
-    dailyVolume: req.algebraDayData?.volumeUSD,
-    dailyFees: req.algebraDayData?.feesUSD,
-    dailyRevenue: req.algebraDayData?.feesUSD,
-    dailyProtocolRevenue: req.algebraDayData?.feesUSD * 0.15,
-    dailyHoldersRevenue: req.algebraDayData?.feesUSD * 0.835,
+    dailyVolume: Number(req.algebraDayData?.volumeUSD ?? 0),
+    dailyFees: feesUSD,
+    dailySupplySideRevenue: feesUSD * (LP_SHARE + COMMUNITY_FEE * ALGEBRA),
+    dailyRevenue: protocolRevenue + holdersRevenue,
+    dailyProtocolRevenue: protocolRevenue,
+    dailyHoldersRevenue: holdersRevenue,
   }
 }
 
 const methodology = {
   Fees: 'All trading fees paid by users.',
-  Revenue: '15% for treasury, 1.5% for algebra, 83.5% to veSTELLA voters',
-  ProtocolRevenue: '15% for treasury',
-  HoldersRevenue: '83.5% to veSTELLA voters',
+  SupplySideRevenue: '78% of swap fees retained by liquidity providers in-pool, plus the 1.5% Algebra infrastructure cut of the 22% community vault (~0.33% of total fees), totalling ~78.33% of total fees.',
+  Revenue: 'The 22% protocol community vault, minus the Algebra infra cut: ~21.67% of total fees (15% treasury + 83.5% veSTELLA of the 22% vault).',
+  ProtocolRevenue: '15% of the 22% community vault to treasury (~3.3% of total fees).',
+  HoldersRevenue: '83.5% of the 22% community vault to veSTELLA voters (~18.37% of total fees).',
 }
 
 const adapter: SimpleAdapter = {


### PR DESCRIPTION
* Added `dailySupplySideRevenue` (~78.33%): 78% LP fees + Algebra infra fee (1.5% of the 22% vault)
* Fixed `dailyRevenue` to `protocolRevenue + holdersRevenue` (~21.67%), not total `feesUSD`
* Fixed `dailyProtocolRevenue` to 15% of the 22% vault (~3.3%)
* Fixed `dailyHoldersRevenue` to 83.5% of the 22% vault (~18.37%)

### Fee Split

| Recipient       | Share   |
| --------------- | ------- |
| LPs             | 78%     |
| Algebra infra   | ~0.33%  |
| Treasury        | 3.3%    |
| veSTELLA voters | ~18.37% |