### PR TITLE
morpho: add Plume, Celo, Abstract to fees adapter (verified-active accountants)

### DIFF
--- a/fees/morpho/index.ts
+++ b/fees/morpho/index.ts
@@ -113,6 +113,21 @@ const MorphoBlues: Record<string, MorphoBlueConfig> = {
     blue: "0xD5D960E8C380B724a48AC59E2DfF1b2CB4a1eAee",
     start: "2025-11-23",
   },
+  [CHAIN.PLUME]: {
+    fromBlock: 765994,
+    blue: "0x42b18785CE0Aed7BF7Ca43a39471ED4C0A3e0bB5",
+    start: "2025-04-22",
+  },
+  [CHAIN.CELO]: {
+    fromBlock: 40249329,
+    blue: "0xd24ECdD8C1e0E57a4E26B1a7bbeAa3e95466A569",
+    start: "2025-07-10",
+  },
+  [CHAIN.ABSTRACT]: {
+    fromBlock: 13947713,
+    blue: "0xc85CE8ffdA27b646D269516B8d0Fa6ec2E958B55",
+    start: "2025-07-10",
+  },
   // [CHAIN.STABLE]: {
   //   fromBlock: 4342501,
   //   blue: "0xa40103088A899514E3fe474cD3cc5bf811b1102e",


### PR DESCRIPTION
## Summary

Adds 3 chains to `fees/morpho/index.ts` where Morpho Blue is deployed and emitting `AccrueInterest` events right now, but the fees adapter doesn't cover them.

The TVL adapter at `DefiLlama-Adapters/projects/morpho-blue/index.js` already tracks 30+ chains for Morpho Blue; the fees adapter covers only 19. This PR fills 3 of the 16 missing chains — specifically the ones verified to have active AccrueInterest events on-chain.

## Per-chain verification (on-chain `AccrueInterest` events)

Chunked `eth_getLogs` on each Morpho Blue contract for topic `0x9d9bd501d0657d7dfe415f779a620a62b78bc508ddc0891fbbd8b7ac0f8fce87`:

### ✅ Included — accountants emitting events recently:

| Chain | TVL | Morpho Blue address | Last `AccrueInterest` event |
|---|---|---|---|
| **Plume Mainnet** | $7.7M | `0x42b18785CE0Aed7BF7Ca43a39471ED4C0A3e0bB5` | ~28 minutes ago (7 events in chunk) |
| **Celo** | $0.96M | `0xd24ECdD8C1e0E57a4E26B1a7bbeAa3e95466A569` | ~30 hours ago (4 events in chunk) |
| **Abstract** | $0.81M | `0xc85CE8ffdA27b646D269516B8d0Fa6ec2E958B55` | ~35k blocks ago |

### ❌ Intentionally excluded — `AccrueInterest` is silent in tested window:

| Chain | TVL | Window tested | Events |
|---|---|---|---|
| Flare | $48M | 270k blocks (~5.6 days) | 0 |
| Sei | $33M | 300k blocks (~33 hours) | 0 |
| Etherlink | $3.6M | 270k blocks (~16 days) | 0 |
| TAC | $0.55M | 270k blocks | 0 |
| Citrea, Linea, BSC, xDai, Botanix, Bitlayer, Lisk, Tempo | mostly $0 | varied | 0 |

These chains have markets created but no active borrow activity yet — the Morpho Blue contract is deployed and TVL is supplied, but no one is interacting with markets to drive `AccrueInterest` to fire. Including them would surface $0 indefinitely.

## Source

All addresses copied verbatim from the existing Morpho TVL adapter at `DefiLlama-Adapters/projects/morpho-blue/index.js`. Start dates derived from the actual block timestamp of each chain's `fromBlock`:

```
PLUME    block 765994   = 2025-04-22
CELO     block 40249329 = 2025-07-10
ABSTRACT block 13947713 = 2025-07-10
```

## Risk

Purely additive — no changes to the existing 19 chains' configuration or fetch logic. The adapter already supports the `fromBlock`-based market discovery path (used by Mode, Corn, Hemi, Sonic, etc.) which is what these 3 new entries use.

## Test plan

- [ ] After merge, `/summary/fees/morpho-blue` should show non-zero daily fees for Plume, Celo, and Abstract within the next 24 hours.
- [ ] No regression on existing chains (purely additive change, no shared state).