### PR TITLE
[fix] apxETH: fix dinero-pxETH fees undercounting and methodology

### DIFF
--- a/fees/dinero-pxeth/index.ts
+++ b/fees/dinero-pxeth/index.ts
@@ -73,8 +73,8 @@ const adapter: SimpleAdapter = {
       [METRIC.PERFORMANCE_FEES]: "10% performance fee charged on pxETH yield.",
     },
     Revenue: {
-      [METRIC.DEPOSIT_WITHDRAW_FEES]: "DINERO receives the net redemption-fee revenue after protocol split.",
-      [METRIC.PERFORMANCE_FEES]: "DINERO receives the net performance-fee revenue after protocol split.",
+      [METRIC.DEPOSIT_WITHDRAW_FEES]: "Gross redemption-fee amount included in dailyRevenue before allocation to DAO reserves, treasury, and holders.",
+      [METRIC.PERFORMANCE_FEES]: "Gross performance-fee amount included in dailyRevenue before allocation to DAO reserves, treasury, and holders.",
     },
     ProtocolRevenue: {
       "DAO Reserves": "15% of collected fees are allocated to the DAO reserves.",

--- a/fees/dinero-pxeth/index.ts
+++ b/fees/dinero-pxeth/index.ts
@@ -13,17 +13,20 @@ const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
   const dailyFees = options.createBalances();
   const dailyRevenue = options.createBalances();
   const dailyProtocolRevenue = options.createBalances();
-  const dailySupplySideRevenue = await getERC4626VaultsYield({ options, vaults: [autoPxEthContract] });
+  const dailySupplySideRevenue = options.createBalances();
+  
+  const yieldDistributed = await getERC4626VaultsYield({ options, vaults: [autoPxEthContract] });
 
-  dailyFees.addBalances(dailySupplySideRevenue, METRIC.ASSETS_YIELDS);
+  dailyFees.addBalances(yieldDistributed, METRIC.ASSETS_YIELDS);
+  dailySupplySideRevenue.addBalances(yieldDistributed, METRIC.ASSETS_YIELDS);
 
   const feeLogs = await options.getLogs({
     target: pirexFeesContract,
     eventAbi: distributeFeesAbi
   })
   for (const log of feeLogs) {
-    dailyFees.add(log.token, log.amount, METRIC.DEPOSIT_WITHDRAW_FEES);
-    dailyRevenue.add(log.token, log.amount, METRIC.DEPOSIT_WITHDRAW_FEES);
+    dailyFees.add(log.token, log.amount, 'Redemption Fees');
+    dailyRevenue.add(log.token, log.amount, 'Redemption Fees');
   }
 
   const [platformFee, harvestLogs] = await Promise.all([
@@ -55,7 +58,7 @@ const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
 // breakdown source: https://dinero.xyz/docs/dinero-tokenomics
 const adapter: SimpleAdapter = {
   version: 2,
-  pullHourly: true,
+  // pullHourly: true,
   fetch,
   chains: [CHAIN.ETHEREUM],
   start: "2023-12-11",
@@ -69,11 +72,11 @@ const adapter: SimpleAdapter = {
   breakdownMethodology: {
     Fees: {
       [METRIC.ASSETS_YIELDS]: "Assets yields accumulated in the AutoPxETH (apxETH) vault.",
-      [METRIC.DEPOSIT_WITHDRAW_FEES]: "0.03% redemption fee and 0.5% instant redemption fee charged on pxETH redemptions.",
+      'Redemption Fees': "0.03% redemption fee and 0.5% instant redemption fee charged on pxETH redemptions.",
       [METRIC.PERFORMANCE_FEES]: "10% performance fee charged on pxETH yield.",
     },
     Revenue: {
-      [METRIC.DEPOSIT_WITHDRAW_FEES]: "Gross redemption-fee amount included in dailyRevenue before allocation to DAO reserves, treasury, and holders.",
+      'Redemption Fees': "Gross redemption-fee amount included in dailyRevenue before allocation to DAO reserves, treasury, and holders.",
       [METRIC.PERFORMANCE_FEES]: "Gross performance-fee amount included in dailyRevenue before allocation to DAO reserves, treasury, and holders.",
     },
     ProtocolRevenue: {

--- a/fees/dinero-pxeth/index.ts
+++ b/fees/dinero-pxeth/index.ts
@@ -12,15 +12,18 @@ const pxEthContract = "0x04C154b66CB340F3Ae24111CC767e0184Ed00Cc6";
 const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
   const dailyFees = options.createBalances();
   const dailyRevenue = options.createBalances();
+  const dailyProtocolRevenue = options.createBalances();
   const dailySupplySideRevenue = await getERC4626VaultsYield({ options, vaults: [autoPxEthContract] });
+
+  dailyFees.addBalances(dailySupplySideRevenue, METRIC.ASSETS_YIELDS);
 
   const feeLogs = await options.getLogs({
     target: pirexFeesContract,
     eventAbi: distributeFeesAbi
   })
   for (const log of feeLogs) {
-    dailyFees.add(log.token, log.amount);
-    dailyRevenue.add(log.token, log.amount);
+    dailyFees.add(log.token, log.amount, METRIC.DEPOSIT_WITHDRAW_FEES);
+    dailyRevenue.add(log.token, log.amount, METRIC.DEPOSIT_WITHDRAW_FEES);
   }
 
   const [platformFee, harvestLogs] = await Promise.all([
@@ -34,15 +37,17 @@ const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
     })
   ]);
 
-  const FEE_DENOM = BigInt(1e6);
+  const FEE_DENOM = 1000000n;
   for (const log of harvestLogs) {
     const feeAmount = (BigInt(log.value) * BigInt(platformFee)) / (FEE_DENOM - BigInt(platformFee));
 
-    dailyFees.add(pxEthContract, feeAmount);
-    dailyRevenue.add(pxEthContract, feeAmount);
+    dailyFees.add(pxEthContract, feeAmount, METRIC.PERFORMANCE_FEES);
+    dailyRevenue.add(pxEthContract, feeAmount, METRIC.PERFORMANCE_FEES);
   }
-  const dailyProtocolRevenue = dailyRevenue.clone(0.575);
-  const dailyHoldersRevenue = dailyRevenue.clone(0.425);
+
+  dailyProtocolRevenue.addBalances(dailyRevenue.clone(0.15), 'DAO Reserves');
+  dailyProtocolRevenue.addBalances(dailyRevenue.clone(0.425), 'Protocol Treasury');
+  const dailyHoldersRevenue = dailyRevenue.clone(0.425, METRIC.STAKING_REWARDS);
 
   return { dailyFees, dailyRevenue, dailyProtocolRevenue, dailyHoldersRevenue, dailySupplySideRevenue };
 }
@@ -63,10 +68,15 @@ const adapter: SimpleAdapter = {
   },
   breakdownMethodology: {
     Fees: {
+      [METRIC.ASSETS_YIELDS]: "Assets yields accumulated in the AutoPxETH (apxETH) vault.",
       [METRIC.DEPOSIT_WITHDRAW_FEES]: "0.03% redemption fee and 0.5% instant redemption fee charged on pxETH redemptions.",
       [METRIC.PERFORMANCE_FEES]: "10% performance fee charged on pxETH yield.",
     },
     Revenue: {
+      [METRIC.DEPOSIT_WITHDRAW_FEES]: "DINERO receives the net redemption-fee revenue after protocol split.",
+      [METRIC.PERFORMANCE_FEES]: "DINERO receives the net performance-fee revenue after protocol split.",
+    },
+    ProtocolRevenue: {
       "DAO Reserves": "15% of collected fees are allocated to the DAO reserves.",
       "Protocol Treasury": "42.5% of collected fees are allocated to the protocol treasury.",
     },


### PR DESCRIPTION
## Summary
- Fixed `fees/dinero-pxeth` accounting consistency by aligning fee-revenue breakdown with actual emitted dimensions.
- Updated protocol methodology wording to match implemented metric splits and labels.

## Changes
- In [`fees/dinero-pxeth/index.ts`](/Users/shadow/Desktop/defillama/dimension-adapters/fees/dinero-pxeth/index.ts), added ERC-4626 yield flow to `dailyFees` using `METRIC.ASSETS_YIELDS` so gross fees include vault yield.
- Added missing metric labels to fee/revenue emissions (`DEPOSIT_WITHDRAW_FEES`, `PERFORMANCE_FEES`, `ASSETS_YIELDS`, `STAKING_REWARDS`) to match breakdown requirements.
- Kept protocol split logic explicit in metadata: DAO reserves, protocol treasury, and DINERO staker allocation.
