### PR TITLE
TopStrike: track pack shop primary mints alongside trading

### DIFF
--- a/dexs/topstrike/index.ts
+++ b/dexs/topstrike/index.ts
@@ -143,10 +143,6 @@ const methodology = {
 };
 
 const breakdownMethodology = {
-    Volume: {
-        'Trading Volume': "Gross ETH traded on share buys/sells",
-        'Pack Sales': "Pack shop primary mints (quantity × pricePerToken from the active claim condition, native ETH only)",
-    },
     Fees: {
         [METRIC.TRADING_FEES]: "Trading fees paid by users",
         'Pack Sales': "Pack shop primary mints — full sale value accrues to the protocol",

--- a/dexs/topstrike/index.ts
+++ b/dexs/topstrike/index.ts
@@ -24,6 +24,7 @@ const GET_CLAIM_CONDITION_ABI =
     "function getClaimConditionById(uint256 _tokenId, uint256 _conditionId) view returns ((uint256 startTimestamp, uint256 maxClaimableSupply, uint256 supplyClaimed, uint256 quantityLimitPerWallet, bytes32 merkleRoot, uint256 pricePerToken, address currency, string metadata) condition)";
 
 const NATIVE_ETH = "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee";
+const NULL_ADDRESS = "0x0000000000000000000000000000000000000000";
 
 // Trade.feeInWei carries the total user-paid fee on every fee-generating path
 // (IPO buy + all sells). UserSharesChanged.totalFeesInWei is emitted 1:1 with
@@ -63,7 +64,7 @@ const fetch = async (options: FetchOptions) => {
         // Sell: priceInWei is net; gross = priceInWei + feeInWei
         const fee = log.feeInWei;
         const grossVolume = log.isBuy ? log.priceInWei : log.priceInWei + fee;
-        dailyVolume.addGasToken(grossVolume, 'Trading Volume');
+        dailyVolume.addGasToken(grossVolume);
         dailyFees.addGasToken(fee, METRIC.TRADING_FEES);
     }
 
@@ -110,14 +111,12 @@ const fetch = async (options: FetchOptions) => {
 
         for (const log of claimLogs) {
             const cond = priceByPair.get(pairKey(log.tokenId, log.claimConditionIndex));
-            // Skip ERC-20 priced drops — we only attribute native-ETH packs to
-            // the gas-token balances stream. If pack pricing ever moves to a
-            // stablecoin, extend here with an addToken branch.
-            if (!cond || cond.currency !== NATIVE_ETH) continue;
+            if (!cond) continue;
+            if(cond.currency === NATIVE_ETH) cond.currency = NULL_ADDRESS;
             const paid = cond.price * BigInt(log.quantityClaimed);
             if (paid === 0n) continue;
-            dailyVolume.addGasToken(paid, 'Pack Sales');
-            dailyFees.addGasToken(paid, 'Pack Sales');
+            dailyVolume.add(cond.currency, paid);
+            dailyFees.add(cond.currency, paid, 'Pack Sales');
         }
     }
 

--- a/dexs/topstrike/index.ts
+++ b/dexs/topstrike/index.ts
@@ -2,7 +2,8 @@ import { FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 import { METRIC } from "../../helpers/metrics";
 
-const CONTRACT = "0xf3393dC9E747225FcA0d61BfE588ba2838AFb077";
+const TRADING_CONTRACT = "0xf3393dC9E747225FcA0d61BfE588ba2838AFb077";
+const PACKSHOP_CONTRACT = "0xd303fccf599648f89ccfa483f10da4a92e3dabd5";
 
 const TRADE_EVENT_ABI =
     "event Trade(address indexed trader, uint256 indexed playerId, bool isBuy, uint256 amountInUnits, uint256 priceInWei, uint256 feeInWei, uint256 newSupplyInUnits, bool isIPOWindow)";
@@ -12,6 +13,17 @@ const REFERRAL_FEE_PAID_ABI =
 
 const ETH_PRIZE_DEPOSITED_ABI =
     "event EthPrizeDeposited(uint256 amountInWei)";
+
+// Thirdweb DropERC1155 pack shop. TokensClaimed carries quantity but not
+// price — we look up pricePerToken via getClaimConditionById for each
+// unique (tokenId, claimConditionIndex) pair seen in the day's logs.
+const TOKENS_CLAIMED_ABI =
+    "event TokensClaimed(uint256 indexed claimConditionIndex, address indexed claimer, address indexed receiver, uint256 tokenId, uint256 quantityClaimed)";
+
+const GET_CLAIM_CONDITION_ABI =
+    "function getClaimConditionById(uint256 _tokenId, uint256 _conditionId) view returns ((uint256 startTimestamp, uint256 maxClaimableSupply, uint256 supplyClaimed, uint256 quantityLimitPerWallet, bytes32 merkleRoot, uint256 pricePerToken, address currency, string metadata) condition)";
+
+const NATIVE_ETH = "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee";
 
 // Trade.feeInWei carries the total user-paid fee on every fee-generating path
 // (IPO buy + all sells). UserSharesChanged.totalFeesInWei is emitted 1:1 with
@@ -27,6 +39,11 @@ const ETH_PRIZE_DEPOSITED_ABI =
 //      ReferralFeeRedirectedToProtocol is emitted instead — correctly
 //      excluded from supplySideRevenue)
 //   Protocol treasury   -> fees - prize - referral
+//
+// Pack shop primary mints have no holder/referral split: the full sale value
+// flows to the primary sale recipient (protocol treasury), so we book pack
+// sales under dailyFees with the 'Pack Sales' label and they fall through to
+// dailyRevenue via the existing fees − supplySide derivation.
 
 const fetch = async (options: FetchOptions) => {
     const dailyVolume = options.createBalances();
@@ -34,10 +51,11 @@ const fetch = async (options: FetchOptions) => {
     const dailyRevenue = options.createBalances();
     const dailySupplySideRevenue = options.createBalances();
 
-    const [tradeLogs, referralLogs, prizeLogs] = await Promise.all([
-        options.getLogs({ target: CONTRACT, eventAbi: TRADE_EVENT_ABI }),
-        options.getLogs({ target: CONTRACT, eventAbi: REFERRAL_FEE_PAID_ABI }),
-        options.getLogs({ target: CONTRACT, eventAbi: ETH_PRIZE_DEPOSITED_ABI }),
+    const [tradeLogs, referralLogs, prizeLogs, claimLogs] = await Promise.all([
+        options.getLogs({ target: TRADING_CONTRACT, eventAbi: TRADE_EVENT_ABI }),
+        options.getLogs({ target: TRADING_CONTRACT, eventAbi: REFERRAL_FEE_PAID_ABI }),
+        options.getLogs({ target: TRADING_CONTRACT, eventAbi: ETH_PRIZE_DEPOSITED_ABI }),
+        options.getLogs({ target: PACKSHOP_CONTRACT, eventAbi: TOKENS_CLAIMED_ABI }),
     ]);
 
     for (const log of tradeLogs) {
@@ -45,7 +63,7 @@ const fetch = async (options: FetchOptions) => {
         // Sell: priceInWei is net; gross = priceInWei + feeInWei
         const fee = log.feeInWei;
         const grossVolume = log.isBuy ? log.priceInWei : log.priceInWei + fee;
-        dailyVolume.addGasToken(grossVolume);
+        dailyVolume.addGasToken(grossVolume, 'Trading Volume');
         dailyFees.addGasToken(fee, METRIC.TRADING_FEES);
     }
 
@@ -55,6 +73,52 @@ const fetch = async (options: FetchOptions) => {
 
     for (const log of prizeLogs) {
         dailySupplySideRevenue.addGasToken(log.amountInWei, 'Prize Pool Rewards');
+    }
+
+    if (claimLogs.length > 0) {
+        // Dedupe (tokenId, conditionIndex) pairs before resolving prices — many
+        // claims share the same active condition during a single window.
+        const pairKey = (tokenId: any, conditionId: any) =>
+            `${tokenId.toString()}-${conditionId.toString()}`;
+        const uniquePairs = new Map<string, { tokenId: any; conditionId: any }>();
+        for (const log of claimLogs) {
+            const key = pairKey(log.tokenId, log.claimConditionIndex);
+            if (!uniquePairs.has(key)) {
+                uniquePairs.set(key, {
+                    tokenId: log.tokenId,
+                    conditionId: log.claimConditionIndex,
+                });
+            }
+        }
+        const pairs = [...uniquePairs.values()];
+        const conditions = await options.api.multiCall({
+            target: PACKSHOP_CONTRACT,
+            abi: GET_CLAIM_CONDITION_ABI,
+            calls: pairs.map((p) => ({ params: [p.tokenId, p.conditionId] })),
+            permitFailure: true,
+        });
+
+        const priceByPair = new Map<string, { price: bigint; currency: string }>();
+        pairs.forEach((p, i) => {
+            const c = conditions[i];
+            if (!c) return;
+            priceByPair.set(pairKey(p.tokenId, p.conditionId), {
+                price: BigInt(c.pricePerToken),
+                currency: String(c.currency).toLowerCase(),
+            });
+        });
+
+        for (const log of claimLogs) {
+            const cond = priceByPair.get(pairKey(log.tokenId, log.claimConditionIndex));
+            // Skip ERC-20 priced drops — we only attribute native-ETH packs to
+            // the gas-token balances stream. If pack pricing ever moves to a
+            // stablecoin, extend here with an addToken branch.
+            if (!cond || cond.currency !== NATIVE_ETH) continue;
+            const paid = cond.price * BigInt(log.quantityClaimed);
+            if (paid === 0n) continue;
+            dailyVolume.addGasToken(paid, 'Pack Sales');
+            dailyFees.addGasToken(paid, 'Pack Sales');
+        }
     }
 
     const revenue = await dailyFees.getUSDValue() - await dailySupplySideRevenue.getUSDValue();
@@ -71,19 +135,26 @@ const fetch = async (options: FetchOptions) => {
 };
 
 const methodology = {
-    Fees: "Total fees paid by traders, includes buy and sell fees",
-    UserFees: "Trading fees paid by users",
-    Revenue: "Part of fees retained by the protocol",
+    Volume: "Gross ETH traded on share buys/sells plus pack shop primary mint sales",
+    Fees: "Trading fees on buy/sell plus the full value of pack shop primary mints (no holder split on packs)",
+    UserFees: "Total ETH paid by users — trading fees plus pack shop purchase prices",
+    Revenue: "Part of fees retained by the protocol (trading fees minus prize/referral payouts, plus 100% of pack sales)",
     ProtocolRevenue: "All the revenue goes to the protocol",
-    SupplySideRevenue: "Includes referral rewards and prize pool rewards",
+    SupplySideRevenue: "Includes referral rewards and prize pool rewards (trading only — packs do not split)",
 };
 
 const breakdownMethodology = {
+    Volume: {
+        'Trading Volume': "Gross ETH traded on share buys/sells",
+        'Pack Sales': "Pack shop primary mints (quantity × pricePerToken from the active claim condition, native ETH only)",
+    },
     Fees: {
         [METRIC.TRADING_FEES]: "Trading fees paid by users",
+        'Pack Sales': "Pack shop primary mints — full sale value accrues to the protocol",
     },
     UserFees: {
         [METRIC.TRADING_FEES]: "Trading fees paid by users",
+        'Pack Sales': "Pack shop primary mints — full sale value accrues to the protocol",
     },
     Revenue: {
         [METRIC.PROTOCOL_FEES]: "Part of fees retained by the protocol",


### PR DESCRIPTION
Extends the existing TopStrike adapter (`dexs/topstrike/index.ts`) to track the protocol's new Thirdweb DropERC1155 pack shop alongside the share-trading contract, exposed as labeled streams in the breakdown view.

- **Website:** https://topstrike.io
- **Chain:** MegaETH
- **Trading contract** (already tracked): [`0xf3393dC9E747225FcA0d61BfE588ba2838AFb077`](https://megaeth.blockscout.com/address/0xf3393dC9E747225FcA0d61BfE588ba2838AFb077)
- **Pack shop contract** (new): [`0xd303fccf599648f89ccfa483f10da4a92e3dabd5`](https://megaeth.blockscout.com/address/0xd303fccf599648f89ccfa483f10da4a92e3dabd5)

## How pack metrics are computed

`TokensClaimed(claimConditionIndex, claimer, receiver, tokenId, quantityClaimed)` emits on every successful claim but doesn't carry price. For each unique `(tokenId, claimConditionIndex)` pair seen in the day's logs, a single `getClaimConditionById` multiCall resolves the active condition's `pricePerToken` + `currency`; volume per claim is `pricePerToken × quantityClaimed`.

Native-ETH drops only. ERC-20 priced drops are skipped (not in current product scope; would need an `addToken` branch).

## Where pack flows land

Pack shop revenue is a primary mint with **no holder or referral split** — the full sale value goes to the protocol's `primarySaleRecipient`. So:

- `dailyVolume` gets `'Trading Volume'` (existing) and `'Pack Sales'` (new) labels
- `dailyFees` / `dailyUserFees` get the existing `Trading Fees` label and a new `'Pack Sales'` label carrying the full pack price
- `dailyRevenue` / `dailyProtocolRevenue` pick up the pack contribution via the existing `fees − supplySide` derivation (since no part of pack revenue lands in `dailySupplySideRevenue`)

## Local test — 24h ending 2026-05-16 10:00 UTC

```
npm test dexs topstrike
```

| Metric | Total | Labeled breakdown |
|---|---:|---|
| Daily volume | $58.07k | Trading $47.20k (81.3%) • Pack Sales $10.87k (18.7%) |
| Daily fees | $14.27k | Pack Sales $10.87k (76.2%) • Trading Fees $3.40k (23.8%) |
| Daily revenue | $12.09k | Protocol Fees $12.09k (100%) |
| Daily supply-side revenue | $2.18k | Prize Pool Rewards $2.03k (93.3%) • Referral Rewards $0.15k (6.7%) |

A single pack drop hour (18:00 UTC, 15 May) accounted for all $10.87k of pack volume. In that hour, `fees / volume ≈ 99%` for the pack stream vs `~3-7%` for the trading stream — confirming the two streams are segregated and there's no double-counting.

## Checklist

- [x] Uses `options.getLogs` for events + `options.api.multiCall` for price resolution (no external RPC dependency)
- [x] Tested locally with `npm test dexs topstrike` — clean output, expected breakdown via `runAdapter({ withMetadata: true })`
- [x] Methodology + `breakdownMethodology` updated to describe the new label
- [x] `allowNegativeValue: true` retained — when a quiet hour has prize-pool inflows above trading fees, the residual revenue can still go negative; the invariant is preserved on the trading side
