### PR TITLE
fix: dragonswap-sei v1 & v3

### DIFF
--- a/dexs/dragonswap-sei-v3/index.ts
+++ b/dexs/dragonswap-sei-v3/index.ts
@@ -7,7 +7,7 @@ const PROTOCOL_FEE_SHARE = 0.25;
 
 const methodology = {
   Fees: "DragonSwap V3 charges per-pool swap fees (0.01%, 0.05%, or 0.3% per swap).",
-  Revenue: "Protocol share of swap fees.",
+  Revenue: "25% of the swap fees collected by the protocol.",
   ProtocolRevenue: "Protocol's 25% share of swap fees, accrued per pool and collected by the treasury.",
   SupplySideRevenue: "Remaining 75% of swap fees distributed to liquidity providers.",
 }

--- a/dexs/dragonswap-sei-v3/index.ts
+++ b/dexs/dragonswap-sei-v3/index.ts
@@ -1,25 +1,43 @@
 import { FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
+import { METRIC } from "../../helpers/metrics";
 import { httpGet } from "../../utils/fetchURL";
+
+const PROTOCOL_FEE_SHARE = 0.25;
+
+const methodology = {
+  Fees: "DragonSwap V3 charges per-pool swap fees (0.01%, 0.05%, or 0.3% per swap).",
+  Revenue: "Protocol share of swap fees.",
+  ProtocolRevenue: "Protocol's 25% share of swap fees, accrued per pool and collected by the treasury.",
+  SupplySideRevenue: "Remaining 75% of swap fees distributed to liquidity providers.",
+}
+
+const breakdownMethodology = {
+  Fees: { [METRIC.SWAP_FEES]: 'Per-pool swap fees (0.01%-0.3%) charged on all token swaps' },
+  Revenue: { [METRIC.PROTOCOL_FEES]: "Protocol's 25% share of swap fees from all active pools" },
+  ProtocolRevenue: { [METRIC.PROTOCOL_FEES]: "Protocol's 25% share of swap fees collected by the treasury" },
+  SupplySideRevenue: { [METRIC.LP_FEES]: "75% of swap fees distributed to liquidity providers" },
+}
 
 const fetch = async (_timestamp: number, _: any, options: FetchOptions): Promise<any> => {
   const dailyVolume = options.createBalances();
   const dailyFees = options.createBalances();
   const dailyRevenue = options.createBalances();
-  
+  const dailyProtocolRevenue = options.createBalances();
+  const dailySupplySideRevenue = options.createBalances();
+
   const { stats: { v3 } } = await httpGet('https://sei-api.dragonswap.app/api/v1/stats');
   const dateData = v3.daily_data.find((i: any) => i.created_at === options.startOfDay);
   if (!dateData) throw Error(`no data found for date ${new Date(options.startOfDay * 1000).toISOString()}`);
-  
+
+  const fees = Number(dateData.fees_usd);
   dailyVolume.addUSDValue(dateData.volume_usd);
-  dailyFees.addUSDValue(dateData.fees_usd);
-  dailyRevenue.addUSDValue(Number(dateData.fees_usd) * 0.25);
-  
-  return {
-    dailyVolume,
-    dailyFees,
-    dailyRevenue,
-  }
+  dailyFees.addUSDValue(fees, METRIC.SWAP_FEES);
+  dailyRevenue.addUSDValue(fees * PROTOCOL_FEE_SHARE, METRIC.PROTOCOL_FEES);
+  dailyProtocolRevenue.addUSDValue(fees * PROTOCOL_FEE_SHARE, METRIC.PROTOCOL_FEES);
+  dailySupplySideRevenue.addUSDValue(fees * (1 - PROTOCOL_FEE_SHARE), METRIC.LP_FEES);
+
+  return { dailyVolume, dailyFees, dailyRevenue, dailyProtocolRevenue, dailySupplySideRevenue }
 }
 
 const adapter: SimpleAdapter = {
@@ -28,7 +46,9 @@ const adapter: SimpleAdapter = {
       fetch,
       start: '2024-05-28',
     },
-  }
+  },
+  methodology,
+  breakdownMethodology,
 }
 
 export default adapter;

--- a/dexs/dragonswap-sei/index.ts
+++ b/dexs/dragonswap-sei/index.ts
@@ -7,7 +7,7 @@ const PROTOCOL_FEE_SHARE = 0.3;
 
 const methodology = {
   Fees: "DragonSwap protocol swap fee (0.3% per swap).",
-    Revenue: "When the protocol fee switch is enabled, the protocol takes 30% of swap fees",
+  Revenue: "The protocol's 30% cut of swap fees collected by the treasury.",
   ProtocolRevenue: "The protocol's 30% cut of swap fees collected by the treasury.",
   SupplySideRevenue: "Fees distributed to the LP providers (70% of total accumulated fees).",
 }

--- a/dexs/dragonswap-sei/index.ts
+++ b/dexs/dragonswap-sei/index.ts
@@ -3,10 +3,13 @@ import { CHAIN } from "../../helpers/chains";
 import { METRIC } from "../../helpers/metrics";
 import { httpGet } from "../../utils/fetchURL";
 
+const PROTOCOL_FEE_SHARE = 0.3;
+
 const methodology = {
   Fees: "DragonSwap protocol swap fee (0.3% per swap).",
+    Revenue: "When the protocol fee switch is enabled, the protocol takes 30% of swap fees",
+  ProtocolRevenue: "The protocol's 30% cut of swap fees collected by the treasury.",
   SupplySideRevenue: "Fees distributed to the LP providers (70% of total accumulated fees).",
-  ProtocolRevenue: "Fees sent to the protocol wallet (30% of total accumulated fees), is used to provide benefits to users in custom ways."
 }
 
 const breakdownMethodology = {
@@ -14,7 +17,13 @@ const breakdownMethodology = {
     [METRIC.SWAP_FEES]: '0.3% fee charged on all token swaps on DragonSwap DEX',
   },
   Revenue: {
-    [METRIC.PROTOCOL_FEES]: '30% of swap fees retained by protocol treasury for user benefits and development',
+    [METRIC.PROTOCOL_FEES]: "30% of swap fees accrued to the protocol",
+  },
+  ProtocolRevenue: {
+    [METRIC.PROTOCOL_FEES]: "30% of swap fees collected by the protocol treasury",
+  },
+  SupplySideRevenue: {
+    [METRIC.LP_FEES]: '70% of swap fees distributed to liquidity providers',
   },
 }
 
@@ -22,21 +31,26 @@ const fetch = async (_timestamp: number, _: any, options: FetchOptions): Promise
   const dailyVolume = options.createBalances();
   const dailyFees = options.createBalances();
   const dailyRevenue = options.createBalances();
+  const dailyProtocolRevenue = options.createBalances();
   const dailySupplySideRevenue = options.createBalances();
-  
+
   const { stats: { v2 } } = await httpGet('https://sei-api.dragonswap.app/api/v1/stats');
   const dateData = v2.daily_data.find((i: any) => i.created_at === options.startOfDay);
   if (!dateData) throw Error(`no data found for date ${new Date(options.startOfDay * 1000).toISOString()}`);
-  
-  dailyVolume.addUSDValue(dateData.volume_usd, METRIC.SWAP_FEES);
-  dailyFees.addUSDValue(dateData.fees_usd, METRIC.SWAP_FEES);
-  dailyRevenue.addUSDValue(Number(dateData.fees_usd) * 0.3, METRIC.SWAP_FEES);
-  dailySupplySideRevenue.addUSDValue(Number(dateData.fees_usd) * 0.7, METRIC.SWAP_FEES);
-  
+
+  const fees = Number(dateData.fees_usd);
+  dailyVolume.addUSDValue(dateData.volume_usd);
+  dailyFees.addUSDValue(fees, METRIC.SWAP_FEES);
+  dailyRevenue.addUSDValue(fees * PROTOCOL_FEE_SHARE, METRIC.PROTOCOL_FEES);
+  dailyProtocolRevenue.addUSDValue(fees * PROTOCOL_FEE_SHARE, METRIC.PROTOCOL_FEES);
+  dailySupplySideRevenue.addUSDValue(fees * (1 - PROTOCOL_FEE_SHARE), METRIC.LP_FEES);
+
   return {
     dailyVolume,
     dailyFees,
     dailyRevenue,
+    dailyProtocolRevenue,
+    dailySupplySideRevenue,
   }
 }
 
@@ -52,4 +66,3 @@ const adapter: SimpleAdapter = {
 }
 
 export default adapter;
-


### PR DESCRIPTION
dragonswap: fixed missing revenue fields and metric labels in both `dragonswap-sei` and `dragonswap-sei-v3`.

* `dailySupplySideRevenue` was computed but not returned
* `dailyProtocolRevenue` was missing entirely
* Added missing methodology docs for V3 
