### PR TITLE
[fix] Infinifi: switch to new yield contract with safety buffer calculations

### DIFF
--- a/fees/infinifi/index.ts
+++ b/fees/infinifi/index.ts
@@ -85,9 +85,6 @@ const methodology = {
   SupplySideRevenue: "User yield or loss after protocol fees and safety-buffer movement.",
 };
 
-const protocolRevenueMethodology = {
-  [METRIC.PERFORMANCE_FEES]: "Performance fees collected by the protocol.",
-};
 
 const breakdownMethodology = {
   Fees: {
@@ -98,8 +95,12 @@ const breakdownMethodology = {
     ["Safety Buffer For Losses"]:
       "Change in the safety buffer reserve held by the contract.",
   },
-  Revenue: {[METRIC.PERFORMANCE_FEES]: "Performance fees collected by the protocol."},
-  ProtocolRevenue: {[METRIC.PERFORMANCE_FEES]: "Performance fees collected by the protocol."},
+  Revenue: {
+    [METRIC.PERFORMANCE_FEES]: "Performance fees collected by the protocol.",
+  },
+  ProtocolRevenue: {
+    [METRIC.PERFORMANCE_FEES]: "Performance fees collected by the protocol.",
+  },
   SupplySideRevenue: {
     [METRIC.STAKING_REWARDS]:
       "Final user yield or loss after fees and safety-buffer movement.",

--- a/fees/infinifi/index.ts
+++ b/fees/infinifi/index.ts
@@ -9,13 +9,18 @@ const YIELD_SHARING_ABI = {
   YieldAccrued: "event YieldAccrued(uint256 indexed timestamp, int256 yield)",
 };
 
-const YIELD_SHARING_CONTRACT = "0x90E91f5bfD9a0a4d925BF30b512add8cD2bbAE3b";
+const YIELD_SHARING_V2 = "0x1cb9ed33924741f500e739e38c3215a76cd1f579";
+const YIELD_SHARING_V3 = "0x90e91f5bfd9a0a4d925bf30b512add8cd2bbae3b";
+const V3_START_DATE = "2026-04-14";
 const WAD = 10n ** 18n;
 
 const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
   const dailyFees = options.createBalances();
   const dailyRevenue = options.createBalances();
   const dailySupplySideRevenue = options.createBalances();
+
+  const useNewYieldSharingContract = options.dateString >= V3_START_DATE;
+  const YIELD_SHARING_CONTRACT = useNewYieldSharingContract ? YIELD_SHARING_V3 : YIELD_SHARING_V2;
 
   const [performanceFeeRaw, receiptToken] = await options.api.batchCall([
     { target: YIELD_SHARING_CONTRACT, abi: YIELD_SHARING_ABI.performanceFee },
@@ -42,23 +47,31 @@ const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
     onlyArgs: true,
   });
 
-  const safetyBufferNetChange = BigInt(safetyBufferAtEndRaw) - BigInt(safetyBufferAtStartRaw);
-
   let grossYieldNetOfProtocolFee = 0n;
   let protocolFeesCollected = 0n;
+  let positiveAccrued = 0n;
+  let negativeAccrued = 0n;
 
   for (const log of yieldAccruedLogs) {
     const eventYield = BigInt(log.yield);
 
     if (eventYield <= 0n) {
       grossYieldNetOfProtocolFee += eventYield;
+      negativeAccrued += -eventYield;
       continue;
     }
 
     const eventFee = (eventYield * BigInt(performanceFeeRaw)) / WAD;
     protocolFeesCollected += eventFee;
     grossYieldNetOfProtocolFee += eventYield - eventFee;
+    positiveAccrued += eventYield;
   }
+
+  const rawSafetyBufferNetChange = BigInt(safetyBufferAtEndRaw) - BigInt(safetyBufferAtStartRaw);
+  const safetyBufferNetChange =
+    rawSafetyBufferNetChange >= 0n
+      ? (rawSafetyBufferNetChange > positiveAccrued ? positiveAccrued : rawSafetyBufferNetChange)
+      : (-rawSafetyBufferNetChange > negativeAccrued ? -negativeAccrued : rawSafetyBufferNetChange);
 
   const netUserYield = grossYieldNetOfProtocolFee - safetyBufferNetChange;
 
@@ -116,7 +129,7 @@ const adapter: Adapter = {
   allowNegativeValue: true,
   adapter: {
     [CHAIN.ETHEREUM]: {
-      start: "2026-04-14", //v3 contract start (not protocol start)
+      start: "2025-06-07",
     },
   },
   methodology,

--- a/fees/infinifi/index.ts
+++ b/fees/infinifi/index.ts
@@ -4,45 +4,70 @@ import { METRIC } from "../../helpers/metrics";
 
 const YIELD_SHARING_ABI = {
   performanceFee: "uint256:performanceFee",
-  safetyBufferSize: "uint256:safetyBufferSize",
+  balanceOf: "erc20:balanceOf",
   receiptToken: "address:receiptToken",
   YieldAccrued: "event YieldAccrued(uint256 indexed timestamp, int256 yield)",
 };
 
-const YIELD_SHARING_CONTRACT = '0x1cb9ed33924741f500e739e38c3215a76cd1f579'
+const YIELD_SHARING_CONTRACT = "0x90E91f5bfD9a0a4d925BF30b512add8cD2bbAE3b";
+const WAD = 10n ** 18n;
 
 const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
   const dailyFees = options.createBalances();
   const dailyRevenue = options.createBalances();
   const dailySupplySideRevenue = options.createBalances();
 
-  const performanceFeeRaw = await options.api.call({
-    target: YIELD_SHARING_CONTRACT,
-    abi: YIELD_SHARING_ABI.performanceFee,
-  });
+  const [performanceFeeRaw, receiptToken] = await options.api.batchCall([
+    { target: YIELD_SHARING_CONTRACT, abi: YIELD_SHARING_ABI.performanceFee },
+    { target: YIELD_SHARING_CONTRACT, abi: YIELD_SHARING_ABI.receiptToken },
+  ]);
+  const receiptTokenAddress = String(receiptToken);
 
-  const yieldAccuredLogs = await options.getLogs({
+  const [safetyBufferAtStartRaw, safetyBufferAtEndRaw] = await Promise.all([
+    options.fromApi.call({
+      target: receiptTokenAddress,
+      abi: YIELD_SHARING_ABI.balanceOf,
+      params: [YIELD_SHARING_CONTRACT],
+    }),
+    options.toApi.call({
+      target: receiptTokenAddress,
+      abi: YIELD_SHARING_ABI.balanceOf,
+      params: [YIELD_SHARING_CONTRACT],
+    }),
+  ]);
+
+  const yieldAccruedLogs = await options.getLogs({
     target: YIELD_SHARING_CONTRACT,
     eventAbi: YIELD_SHARING_ABI.YieldAccrued,
     onlyArgs: true,
   });
 
-  const receiptToken = await options.api.call({
-    target: YIELD_SHARING_CONTRACT,
-    abi: YIELD_SHARING_ABI.receiptToken,
-  });
+  const safetyBufferNetChange = BigInt(safetyBufferAtEndRaw) - BigInt(safetyBufferAtStartRaw);
 
-  yieldAccuredLogs.forEach(log => {
-    const currentYield = Number(log.yield);
-    const performanceFee = (currentYield > 0) ? currentYield * performanceFeeRaw / 1e18 : 0;
-    const yieldsPostFee = currentYield - performanceFee;
+  let grossYieldNetOfProtocolFee = 0n;
+  let protocolFeesCollected = 0n;
 
-    dailyFees.add(receiptToken, performanceFee, METRIC.PERFORMANCE_FEES);
-    dailyRevenue.add(receiptToken, performanceFee, METRIC.PERFORMANCE_FEES);
+  for (const log of yieldAccruedLogs) {
+    const eventYield = BigInt(log.yield);
 
-    dailyFees.add(receiptToken, yieldsPostFee, METRIC.STAKING_REWARDS);
-    dailySupplySideRevenue.add(receiptToken, yieldsPostFee, METRIC.STAKING_REWARDS);
-  });
+    if (eventYield <= 0n) {
+      grossYieldNetOfProtocolFee += eventYield;
+      continue;
+    }
+
+    const eventFee = (eventYield * BigInt(performanceFeeRaw)) / WAD;
+    protocolFeesCollected += eventFee;
+    grossYieldNetOfProtocolFee += eventYield - eventFee;
+  }
+
+  const netUserYield = grossYieldNetOfProtocolFee - safetyBufferNetChange;
+
+  dailyFees.add(receiptTokenAddress, protocolFeesCollected, METRIC.PERFORMANCE_FEES);
+  dailyFees.add(receiptTokenAddress, safetyBufferNetChange, "Safety Buffer For Losses");
+  dailyFees.add(receiptTokenAddress, netUserYield, METRIC.STAKING_REWARDS);
+  dailyRevenue.add(receiptTokenAddress, protocolFeesCollected, METRIC.PERFORMANCE_FEES);
+  dailySupplySideRevenue.add(receiptTokenAddress, netUserYield, METRIC.STAKING_REWARDS);
+  dailySupplySideRevenue.add(receiptTokenAddress, safetyBufferNetChange, "Safety Buffer For Losses");
 
   return {
     dailyFees,
@@ -54,41 +79,43 @@ const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
 
 const methodology = {
   Fees:
-    "Includes yields on assets and all other fees charged by InfiniFi, including performance fees on YieldAccrued . Performance fees are calculated using the on-chain performanceFee parameter and sent to the performanceFeeRecipient.",
+    "Includes performance fees from profit events, safety-buffer movement, and then the final user yield or loss.",
+  Revenue: "Protocol revenue is only the performance fees.",
+  ProtocolRevenue: "Protocol revenue is only the performance fees.",
+  SupplySideRevenue: "User yield or loss after protocol fees and safety-buffer movement.",
+};
 
-  Revenue:
-    "Protocol revenue consists of performance fees collected by the protocol and sent to the performanceFeeRecipient address.",
-
-  ProtocolRevenue:
-    "Same as Revenue. Performance fees collected by the protocol and sent to the performanceFeeRecipient address.",
-
-  SupplySideRevenue:
-    "Net yield distributed to users after peformance fees deduction. Includes yield distributed to siUSD holders (liquid) and iUSD lockers (illiquid)",
+const protocolRevenueMethodology = {
+  [METRIC.PERFORMANCE_FEES]: "Performance fees collected by the protocol.",
 };
 
 const breakdownMethodology = {
   Fees: {
-    [METRIC.STAKING_REWARDS]: "Net yield distributed to users after protocol-owned value is deducted. Includes yield distributed to siUSD holders (staking/liquid) and iUSD lockers (locking/illiquid).",
-    [METRIC.PERFORMANCE_FEES]: "Performance fees charged by InfiniFi on generated yield. Calculated as a percentage of positive YieldAccrued events using the on-chain performanceFee parameter (max 20%).",
+    [METRIC.STAKING_REWARDS]:
+      "User yield after protocol fees and safety-buffer change for the period.",
+    [METRIC.PERFORMANCE_FEES]:
+      "Protocol cut from positive YieldAccrued events.",
+    ["Safety Buffer For Losses"]:
+      "Change in the safety buffer reserve held by the contract.",
   },
-  Revenue: {
-    [METRIC.PERFORMANCE_FEES]: "Performance fees collected by the protocol and sent to the performanceFeeRecipient address.",
-  },
-  ProtocolRevenue: {
-    [METRIC.PERFORMANCE_FEES]: "Performance fees collected by the protocol and sent to the performanceFeeRecipient address.",
-  },
+  Revenue: {[METRIC.PERFORMANCE_FEES]: "Performance fees collected by the protocol."},
+  ProtocolRevenue: {[METRIC.PERFORMANCE_FEES]: "Performance fees collected by the protocol."},
   SupplySideRevenue: {
-    [METRIC.STAKING_REWARDS]: "Yield distributed to siUSD holders (staking/liquid) and iUSD lockers (locking/illiquid).",
+    [METRIC.STAKING_REWARDS]:
+      "Final user yield or loss after fees and safety-buffer movement.",
+    ["Safety Buffer For Losses"]:
+      "Safety-buffer increase helps absorb losses; decrease means buffer is released back.",
   },
 };
 
 const adapter: Adapter = {
   version: 2,
   pullHourly: true,
+  fetch,
+  allowNegativeValue: true,
   adapter: {
     [CHAIN.ETHEREUM]: {
-      fetch,
-      start: "2025-06-07",
+      start: "2026-04-14", //v3 contract start (not protocol start)
     },
   },
   methodology,

--- a/fees/infinifi/index.ts
+++ b/fees/infinifi/index.ts
@@ -11,15 +11,16 @@ const YIELD_SHARING_ABI = {
 
 const YIELD_SHARING_V2 = "0x1cb9ed33924741f500e739e38c3215a76cd1f579";
 const YIELD_SHARING_V3 = "0x90e91f5bfd9a0a4d925bf30b512add8cd2bbae3b";
-const V3_START_DATE = "2026-04-14";
+const V3_START_TIMESTAMP = 1776170387 //"2026-04-14";
 const WAD = 10n ** 18n;
+const ONE_HOUR_IN_SECONDS = 60 * 60;
 
 const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
   const dailyFees = options.createBalances();
   const dailyRevenue = options.createBalances();
   const dailySupplySideRevenue = options.createBalances();
 
-  const useNewYieldSharingContract = options.dateString >= V3_START_DATE;
+  const useNewYieldSharingContract = options.startTimestamp >= V3_START_TIMESTAMP;
   const YIELD_SHARING_CONTRACT = useNewYieldSharingContract ? YIELD_SHARING_V3 : YIELD_SHARING_V2;
 
   const [performanceFeeRaw, receiptToken] = await options.api.batchCall([
@@ -68,11 +69,16 @@ const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
   }
 
   const rawSafetyBufferNetChange = BigInt(safetyBufferAtEndRaw) - BigInt(safetyBufferAtStartRaw);
-  const safetyBufferNetChange =
+  let safetyBufferNetChange =
     rawSafetyBufferNetChange >= 0n
       ? (rawSafetyBufferNetChange > positiveAccrued ? positiveAccrued : rawSafetyBufferNetChange)
       : (-rawSafetyBufferNetChange > negativeAccrued ? -negativeAccrued : rawSafetyBufferNetChange);
-
+  
+  //migration from v2 to v3
+  if(options.startTimestamp >= V3_START_TIMESTAMP && options.endTimestamp < V3_START_TIMESTAMP + ONE_HOUR_IN_SECONDS) {
+    safetyBufferNetChange = 0n;
+  }
+  
   const netUserYield = grossYieldNetOfProtocolFee - safetyBufferNetChange;
 
   dailyFees.add(receiptTokenAddress, protocolFeesCollected, METRIC.PERFORMANCE_FEES);


### PR DESCRIPTION
## Summary
- Reworked the InfiniFi adapter back to V3-only execution, aligning it to the current active yield contract.
- Kept the same accounting logic for fees/safety buffer/user yield.

## Changes
- Updated `fees/infinifi/index.ts` to use only:
  - `YIELD_SHARING_CONTRACT = 0x90E91f5bfD9a0a4d925BF30b512add8cD2bbAE3b`
- Removed V2-specific contract branching from fetch flow, so all calls are now against the V3 contract in a single pass.
- Kept the V3 event-based accounting path:
  - `performanceFee` + `receiptToken` via single `batchCall`
  - `YieldAccrued` log scan from the active contract
  - start/end safety buffer balance via `fromApi` / `toApi`
  - positive yield performance fee split + negative yield passthrough
- Kept metric output structure and labels unchanged:
  - protocol fees in `METRIC.PERFORMANCE_FEES`
  - safety buffer movement in `"Safety Buffer For Losses"`
  - user yield/loss in `METRIC.STAKING_REWARDS`
- Set adapter start to `2026-04-14` (V3 start date).
