### PR TITLE
fees/csc: exclude zero-fee system transactions

### DIFF
--- a/fees/csc.ts
+++ b/fees/csc.ts
@@ -14,7 +14,13 @@ async function fetch(_a: any, _b: any, options: FetchOptions) {
         throw new Error(`No data found for ${options.dateString}`);
     }
 
-    const transactionCount = todaysData.add;
+    // CSC reports `add` (all txs) = `add_common` (user txs) + `add_system` (~432/day
+    // validator → 0x...0x1000/0x1001 precompile calls that have gasPrice=0). The
+    // `average_fee` field is the per-user-tx average — confirmed because
+    // `gas_used / average_gas_used` equals `add_common` exactly each day, and a
+    // sampled system tx (block 51330000) shows gasPrice=0. Multiplying `add` by
+    // `average_fee` therefore overcounts the zero-fee system txs.
+    const transactionCount = Number(todaysData.add_common);
     const averageTransactionFee = Number(todaysData.average_fee);
 
     dailyFees.addCGToken('coinex-token', transactionCount * averageTransactionFee);


### PR DESCRIPTION
Closes #6497.

## The bug

`fees/csc.ts` computes daily fees as `todaysData.add * todaysData.average_fee`, but `add` is the total tx count (including `add_system` validator txs that pay zero gas), while `average_fee` is averaged over user transactions only.

## On-chain proof

Validator transactions on CSC are calls from the block proposer to system precompiles. Block [51330000](https://www.coinex.net/dex/transactions?block=51330000) shows three of them:

```
from = 0x62f7f2f03d... (block miner)
to   = 0x0000000000000000000000000000000000001000  (and ...0x1001)
gas  = 9223372036854775807   (sentinel int64 max)
gasPrice = 0
gasUsed (block-level) = 0
```

They fire at a near-constant ~432/day, which matches `add_system` in the API.

## API math proof

If `average_fee` were averaged over `add` (including the zero-fee system txs), then `average_gas_used` would also be averaged over `add`. It isn't — `gas_used / average_gas_used` equals **`add_common`** exactly every day:

| date | gas_used | avg_gas_used | implied count | add_common | add |
|---|---|---|---|---|---|
| 2026-05-14 | 211,297,651 | 109,197 | 1935 | **1935** | 2367 |
| 2026-05-15 | 203,680,437 | 111,973 | 1819 | **1819** | 2251 |

By the same arithmetic, `average_fee` is the per-user-tx average. Multiplying it by `add` was overcounting by `add / add_common` ≈ 1.24×.

## Effect

```
2026-05-15 (CET=$0.0248):
  old: 2251  × 0.05606 = 126.20 CET = $3.13
  new: 1819  × 0.05606 = 101.98 CET = $2.53
```

Local `pnpm test fees csc 2026-05-15` returns `Daily fees: 2.53`.