### PR TITLE
fix: dailyBribesRevenue/dailyTokenTaxes across shadow, ocelex, lithos

### DIFF
--- a/dexs/earnium/index.ts
+++ b/dexs/earnium/index.ts
@@ -16,7 +16,7 @@ const fetch = async (_a:any, _b:any, options:FetchOptions) => {
   const dailyFees = Number(earniumData.fees24h)
   const dailyVolume = Number(earniumData.volume24h)
   const dailyProtocolRevenue = dailyFees * 0.01;
-  const dailySupplySideRevenue = dailyFees * 0.9;
+  const dailySupplySideRevenue = dailyFees * 0.99; // 90% LPs + 9% referrers
 
   return {
     dailyVolume,
@@ -33,7 +33,7 @@ const methodology = {
   Revenue: "1% of swap fees goes to protocol",
   ProtocolRevenue: "1% of swap fees goes to protocol",
   HoldersRevenue: "No holders revenue",
-  SupplySideRevenue: "90% of swap fees goes to LPs"
+  SupplySideRevenue: "99% of swap fees goes to LPs (90%) and referrers (9%)"
 }
 
 const adapter: SimpleAdapter = {

--- a/dexs/earnium/index.ts
+++ b/dexs/earnium/index.ts
@@ -65,6 +65,7 @@ const adapter: SimpleAdapter = {
   breakdownMethodology,
   chains: [CHAIN.APTOS],
   start: '2025-08-10',
+  deadFrom: '2026-03-06',
 };
 
 export default adapter;

--- a/dexs/earnium/index.ts
+++ b/dexs/earnium/index.ts
@@ -13,14 +13,26 @@ const config_rule = {
 const fetch = async (_a:any, _b:any, options:FetchOptions) => {
   const url = "https://api.earnium.io/api/v1/tool/defillama/dimension-adapter?timestamp=" + options.startOfDay;
   const earniumData = (await httpGet(url, config_rule)).data;
-  const dailyFees = Number(earniumData.fees24h)
+  const rawFees = Number(earniumData.fees24h)
   const dailyVolume = Number(earniumData.volume24h)
-  const dailyProtocolRevenue = dailyFees * 0.01;
-  const dailySupplySideRevenue = dailyFees * 0.99; // 90% LPs + 9% referrers
+
+  const dailyFees = options.createBalances()
+  dailyFees.addUSDValue(rawFees, 'Swap Fees')
+
+  const dailyUserFees = options.createBalances()
+  dailyUserFees.addUSDValue(rawFees, 'Swap Fees')
+
+  const dailyProtocolRevenue = options.createBalances()
+  dailyProtocolRevenue.addUSDValue(rawFees * 0.01, 'Protocol Fee')
+
+  const dailySupplySideRevenue = options.createBalances()
+  dailySupplySideRevenue.addUSDValue(rawFees * 0.90, 'LP Fees')
+  dailySupplySideRevenue.addUSDValue(rawFees * 0.09, 'Referrer Fees')
 
   return {
     dailyVolume,
     dailyFees,
+    dailyUserFees,
     dailyRevenue: dailyProtocolRevenue,
     dailyProtocolRevenue,
     dailySupplySideRevenue,
@@ -36,9 +48,21 @@ const methodology = {
   SupplySideRevenue: "99% of swap fees goes to LPs (90%) and referrers (9%)"
 }
 
+const breakdownMethodology = {
+  Fees: { 'Swap Fees': 'Fees paid by traders on each swap.' },
+  UserFees: { 'Swap Fees': 'Fees paid by traders on each swap.' },
+  Revenue: { 'Protocol Fee': '1% of swap fees going to the protocol.' },
+  ProtocolRevenue: { 'Protocol Fee': '1% of swap fees going to the protocol.' },
+  SupplySideRevenue: {
+    'LP Fees': '90% of swap fees distributed to liquidity providers.',
+    'Referrer Fees': '9% of swap fees paid to referring addresses.',
+  },
+}
+
 const adapter: SimpleAdapter = {
   fetch,
   methodology,
+  breakdownMethodology,
   chains: [CHAIN.APTOS],
   start: '2025-08-10',
 };

--- a/dexs/lithos/index.ts
+++ b/dexs/lithos/index.ts
@@ -91,7 +91,7 @@ const getDailyBribesRevenue = async (
     if (!token) return;
 
     const amount = normaliseAmount(log?.reward ?? log?.amount ?? log?.[1] ?? 0);
-    dailyBribesRevenue.add(token, amount);
+    dailyBribesRevenue.add(token, amount, 'Voting Bribes');
   });
 
   return dailyBribesRevenue;
@@ -100,17 +100,17 @@ const getDailyBribesRevenue = async (
 const fetch: FetchV2 = async (fetchOptions: FetchOptions) => {
   const { dailyVolume, dailyFees: swapFees } = await baseFetch(fetchOptions);
 
+  // External bribes: only goes to veLITH holders, NOT into fees/revenue
   const dailyHoldersRevenue = await getDailyBribesRevenue(fetchOptions);
 
-  const dailyUserFees = swapFees.clone(1);
-  const dailyProtocolRevenue = swapFees.clone(PROTOCOL_FEE_SHARE);
-  const dailySupplySideRevenue = swapFees.clone(LP_FEE_SHARE);
+  const dailyUserFees = swapFees.clone(1, 'Swap Fees');
+  const dailyProtocolRevenue = swapFees.clone(PROTOCOL_FEE_SHARE, 'Protocol Fee');
+  const dailySupplySideRevenue = swapFees.clone(LP_FEE_SHARE, 'LP Fees');
 
+  // Revenue = only protocol cut from swaps, bribes excluded
   const dailyRevenue = dailyProtocolRevenue.clone(1);
-  dailyRevenue.addBalances(dailyHoldersRevenue);
 
-  const dailyFees = swapFees.clone(1);
-  dailyFees.addBalances(dailyHoldersRevenue);
+  const dailyFees = swapFees.clone(1, 'Swap Fees');
 
   return {
     dailyVolume,
@@ -124,20 +124,31 @@ const fetch: FetchV2 = async (fetchOptions: FetchOptions) => {
 };
 
 const methodology = {
-  Fees: "Users pay 0.25% on volatile swaps and 0.05% on stable swaps, plus external incentives deposited into Lithos bribe contracts.",
+  Fees: "Users pay 0.25% on volatile swaps and 0.05% on stable swaps.",
   UserFees: "Users are charged the full swap fee on every trade.",
-  Revenue: "12% treasury share of swap fees plus external bribes/incentives distributed to veLITH voters.",
-  ProtocolRevenue: "12% treasury share of collected swap fees.",
+  Revenue: "12% of swap fees going to the protocol treasury.",
+  ProtocolRevenue: "12% of collected swap fees going to the protocol treasury.",
   HoldersRevenue: "External incentives deposited into Lithos bribe contracts for veLITH voters.",
-  SupplySideRevenue: "88% of collected swap fees accrue to LPs via internal fee bribes.",
+  SupplySideRevenue: "88% of collected swap fees accruing to LPs.",
+};
+
+const breakdownMethodology = {
+  Fees: { 'Swap Fees': 'Fees paid by traders on volatile (0.25%) and stable (0.05%) swaps.' },
+  UserFees: { 'Swap Fees': 'Fees paid by traders on volatile (0.25%) and stable (0.05%) swaps.' },
+  Revenue: { 'Protocol Fee': '12% of swap fees going to the protocol treasury.' },
+  ProtocolRevenue: { 'Protocol Fee': '12% of swap fees going to the protocol treasury.' },
+  SupplySideRevenue: { 'LP Fees': '88% of swap fees distributed to liquidity providers.' },
+  HoldersRevenue: { 'Voting Bribes': 'External incentives deposited into Lithos bribe contracts for veLITH voters.' },
 };
 
 const adapter: SimpleAdapter = {
   version: 2,
+  pullHourly: true,
   fetch,
   start: START_DATE,
   chains: [CHAIN.PLASMA],
   methodology,
+  breakdownMethodology,
 };
 
 export default adapter;

--- a/dexs/lithos/index.ts
+++ b/dexs/lithos/index.ts
@@ -98,15 +98,19 @@ const getDailyBribesRevenue = async (
 };
 
 const fetch: FetchV2 = async (fetchOptions: FetchOptions) => {
-  const { dailyVolume, dailyFees } = await baseFetch(fetchOptions);
+  const { dailyVolume, dailyFees: swapFees } = await baseFetch(fetchOptions);
 
-  const dailyBribesRevenue = await getDailyBribesRevenue(fetchOptions);
+  const dailyHoldersRevenue = await getDailyBribesRevenue(fetchOptions);
 
-  const dailyUserFees = dailyFees.clone(1);
-  const dailyProtocolRevenue = dailyFees.clone(PROTOCOL_FEE_SHARE);
-  const dailySupplySideRevenue = dailyFees.clone(LP_FEE_SHARE);
+  const dailyUserFees = swapFees.clone(1);
+  const dailyProtocolRevenue = swapFees.clone(PROTOCOL_FEE_SHARE);
+  const dailySupplySideRevenue = swapFees.clone(LP_FEE_SHARE);
+
   const dailyRevenue = dailyProtocolRevenue.clone(1);
-  const dailyHoldersRevenue = dailyBribesRevenue.clone(1);
+  dailyRevenue.addBalances(dailyHoldersRevenue);
+
+  const dailyFees = swapFees.clone(1);
+  dailyFees.addBalances(dailyHoldersRevenue);
 
   return {
     dailyVolume,
@@ -115,16 +119,15 @@ const fetch: FetchV2 = async (fetchOptions: FetchOptions) => {
     dailyRevenue,
     dailyProtocolRevenue,
     dailySupplySideRevenue,
-    dailyBribesRevenue,
     dailyHoldersRevenue,
   };
 };
 
 const methodology = {
-  Fees: "Users pay 0.25% on volatile swaps and 0.05% on stable swaps.",
+  Fees: "Users pay 0.25% on volatile swaps and 0.05% on stable swaps, plus external incentives deposited into Lithos bribe contracts.",
   UserFees: "Users are charged the full swap fee on every trade.",
-  Revenue: "12% of collected swap fees accrue to the Lithos protocol treasury.",
-  ProtocolRevenue: "Same as Revenue (12% treasury share of swap fees).",
+  Revenue: "12% treasury share of swap fees plus external bribes/incentives distributed to veLITH voters.",
+  ProtocolRevenue: "12% treasury share of collected swap fees.",
   HoldersRevenue: "External incentives deposited into Lithos bribe contracts for veLITH voters.",
   SupplySideRevenue: "88% of collected swap fees accrue to LPs via internal fee bribes.",
 };

--- a/dexs/ocelex/index.ts
+++ b/dexs/ocelex/index.ts
@@ -56,19 +56,29 @@ const fetch = async (options: FetchOptions) => {
   const adapter = getUniV3LogAdapter({ factory: '0x03057ae6294292b299a1863420edD65e0197AFEf', ...config })
   const otherMetrics = await adapter(options)
 
+  const bribes = await fees_bribes(options)
+  const dailyFees = options.createBalances()
+  dailyFees.addBalances(otherMetrics.dailyFees)
+  dailyFees.addBalances(bribes)
+  const dailyRevenue = options.createBalances()
+  dailyRevenue.addBalances(bribes)
+
   return {
     ...otherMetrics,
-    dailyBribesRevenue: await fees_bribes(options),
+    dailyFees,
+    dailyRevenue,
+    dailyHoldersRevenue: bribes,
   }
 }
 
 const adapter: SimpleAdapter = {
   version: 2,
   methodology: {
-    Fees: 'Users pay dynamic fees per swap.',
+    Fees: 'Users pay dynamic fees per swap, plus voting bribes/incentives paid by protocols.',
     UserFees: 'Users pay dynamic fees per swap.',
-    Revenue: 'No revenue',
+    Revenue: 'Voting bribes/incentives distributed to veOCX holders.',
     ProtocolRevenue: 'No protocol revenue.',
+    HoldersRevenue: 'Voting bribes/incentives distributed to veOCX holders.',
     SupplySideRevenue: 'Swap fees distributed to LPs.',
   },
   adapter: {

--- a/dexs/ocelex/index.ts
+++ b/dexs/ocelex/index.ts
@@ -46,8 +46,8 @@ export const fees_bribes = async ({
     eventAbi: event_reward_added,
   });
   logs.map((e: any) => {
-    if (e.rewardToken.toLowerCase() === bveOCX) dailyFees.add(OCX, e.reward);
-    else dailyFees.add(e.rewardToken, e.reward);
+    if (e.rewardToken.toLowerCase() === bveOCX) dailyFees.add(OCX, e.reward, 'Voting Bribes');
+    else dailyFees.add(e.rewardToken, e.reward, 'Voting Bribes');
   });
   return dailyFees;
 };
@@ -56,30 +56,42 @@ const fetch = async (options: FetchOptions) => {
   const adapter = getUniV3LogAdapter({ factory: '0x03057ae6294292b299a1863420edD65e0197AFEf', ...config })
   const otherMetrics = await adapter(options)
 
+  // External voting bribes: only in holdersRevenue
   const bribes = await fees_bribes(options)
-  const dailyFees = options.createBalances()
-  dailyFees.addBalances(otherMetrics.dailyFees)
-  dailyFees.addBalances(bribes)
-  const dailyRevenue = options.createBalances()
-  dailyRevenue.addBalances(bribes)
 
   return {
     ...otherMetrics,
-    dailyFees,
-    dailyRevenue,
     dailyHoldersRevenue: bribes,
   }
 }
 
 const adapter: SimpleAdapter = {
   version: 2,
+  pullHourly: true,
   methodology: {
-    Fees: 'Users pay dynamic fees per swap, plus voting bribes/incentives paid by protocols.',
+    Fees: 'Users pay dynamic fees per swap.',
     UserFees: 'Users pay dynamic fees per swap.',
-    Revenue: 'Voting bribes/incentives distributed to veOCX holders.',
+    Revenue: 'No protocol revenue from swaps (all swap fees go to LPs).',
     ProtocolRevenue: 'No protocol revenue.',
-    HoldersRevenue: 'Voting bribes/incentives distributed to veOCX holders.',
-    SupplySideRevenue: 'Swap fees distributed to LPs.',
+    HoldersRevenue: 'Voting bribes/incentives deposited by protocols and distributed to veOCX holders.',
+    SupplySideRevenue: 'All swap fees distributed to LPs.',
+  },
+  breakdownMethodology: {
+    UserFees: {
+      'Trading fees': 'Swap fees paid by traders.',
+    },
+    Revenue: {
+      'Protocol fees': 'No protocol cut — all swap fees go to LPs.',
+    },
+    SupplySideRevenue: {
+      'LP fees': 'All swap fees distributed to liquidity providers.',
+    },
+    ProtocolRevenue: {
+      'Protocol fees': 'No protocol cut — all swap fees go to LPs.',
+    },
+    HoldersRevenue: {
+      'Voting Bribes': 'External incentives deposited by protocols to attract veOCX voter liquidity.',
+    },
   },
   adapter: {
     [CHAIN.ZIRCUIT]: { fetch, start: '2024-09-27' },

--- a/dexs/shadow-exchange.ts
+++ b/dexs/shadow-exchange.ts
@@ -29,7 +29,6 @@ const fetch = async (options: FetchOptions) => {
   const dailyVolume = createBalances();
   const dailyHoldersRevenue = createBalances()
   const dailyProtocolRevenue = createBalances()
-  const dailyTokenTaxes = createBalances()
   const dailySupplySideRevenue = createBalances()
   const [toBlock, fromBlock] = await Promise.all([getToBlock(), getFromBlock()])
   const poolsWithGauges = await api.call({ target: CONFIG.voter, abi: "address[]:getAllPools"}).then(contracts => contracts.map((contract: string) => contract.toLowerCase()))
@@ -45,9 +44,8 @@ const fetch = async (options: FetchOptions) => {
     shadowPenaltyAmount += Number(log.amount) / 1e18;
   }
 
-  // Calculate xSHADOW rebase revenue in USD
-  dailyTokenTaxes.add(SHADOW_TOKEN_CONTRACT, shadowPenaltyAmount)
-  dailyFees.add(SHADOW_TOKEN_CONTRACT, shadowPenaltyAmount)
+  // xSHADOW instant-exit penalty is redistributed to remaining xSHADOW holders
+  dailyHoldersRevenue.add(SHADOW_TOKEN_CONTRACT, shadowPenaltyAmount)
 
   const iface = new ethers.Interface([eventAbis.event_poolCreated, eventAbis.event_swap])
 
@@ -127,31 +125,34 @@ const fetch = async (options: FetchOptions) => {
 
   if (errorFound) throw errorFound
   const { dailyBribesRevenue } = await getBribes(options, eventAbis.event_gaugeCreated, CONFIG.voter, CONFIG.factory)
+  // Exclude bribes by external protocols
+  const dailyUserFees = createBalances()
+  dailyUserFees.addBalances(dailyHoldersRevenue)
+  dailyUserFees.addBalances(dailySupplySideRevenue)
+  dailyUserFees.addBalances(dailyProtocolRevenue)
+  dailyHoldersRevenue.addBalances(dailyBribesRevenue)
   dailyRevenue.addBalances(dailyProtocolRevenue)
   dailyRevenue.addBalances(dailyHoldersRevenue)
   dailyFees.addBalances(dailyRevenue)
   dailyFees.addBalances(dailySupplySideRevenue)
 
-  return { 
-    dailyVolume, 
+  return {
+    dailyVolume,
     dailyFees,
-    dailyUserFees: dailyFees, 
-    dailyRevenue, 
-    dailyHoldersRevenue, 
+    dailyUserFees,
+    dailyRevenue,
+    dailyHoldersRevenue,
     dailySupplySideRevenue,
-    dailyProtocolRevenue, 
-    dailyBribesRevenue 
+    dailyProtocolRevenue,
   }
 };
 
 const methodology = {
   Fees: "User pays fees on each swap.",
-  UserFees: "User pays fees on each swap.",
+  UserFees: "Swap fees paid by traders.",
   ProtocolRevenue: "Revenue going to the protocol.",
-  HoldersRevenue: "User fees are distributed among holders.",
-  BribesRevenue: "Bribes are distributed among holders.",
+  HoldersRevenue: "Fees from gauged pools, voting bribes, and the xSHADOW instant-exit penalty are all distributed among xSHADOW holders.",
   SupplySideRevenue: "Fees distributed to LPs (from gauged pools).",
-  TokenTax: "xSHADOW stakers instant exit penalty",
 };
 
 const adapter: SimpleAdapter = {

--- a/dexs/shadow-exchange.ts
+++ b/dexs/shadow-exchange.ts
@@ -24,14 +24,12 @@ const CONFIG = {
 
 const fetch = async (options: FetchOptions) => {
   const { api, createBalances, getToBlock, getFromBlock, chain, getLogs } = options
-  const dailyFees = createBalances()
-  const dailyRevenue = createBalances()
   const dailyVolume = createBalances();
-  const dailyHoldersRevenue = createBalances()
-  const dailyProtocolRevenue = createBalances()
-  const dailySupplySideRevenue = createBalances()
+  const gaugedFees = createBalances()
+  const supplySideFees = createBalances()
+  const protocolFees = createBalances()
   const [toBlock, fromBlock] = await Promise.all([getToBlock(), getFromBlock()])
-  const poolsWithGauges = await api.call({ target: CONFIG.voter, abi: "address[]:getAllPools"}).then(contracts => contracts.map((contract: string) => contract.toLowerCase()))
+  const poolsWithGauges = await api.call({ target: CONFIG.voter, abi: "address[]:getAllPools" }).then(contracts => contracts.map((contract: string) => contract.toLowerCase()))
   const poolsWithGaugesSet = new Set(poolsWithGauges)
   const InstantExitLogs = await getLogs({
     target: XSHADOW_TOKEN_CONTRACT,
@@ -44,9 +42,6 @@ const fetch = async (options: FetchOptions) => {
     shadowPenaltyAmount += Number(log.amount) / 1e18;
   }
 
-  // xSHADOW instant-exit penalty is redistributed to remaining xSHADOW holders
-  dailyHoldersRevenue.add(SHADOW_TOKEN_CONTRACT, shadowPenaltyAmount)
-
   const iface = new ethers.Interface([eventAbis.event_poolCreated, eventAbis.event_swap])
 
   const pairObject: IJSON<string[]> = {}
@@ -57,9 +52,9 @@ const fetch = async (options: FetchOptions) => {
     pairObject[log.pool] = [log.token0, log.token1]
   })
 
-  const filteredPools = await filterPools({ api: api, pairs: pairObject, createBalances: createBalances})
+  const filteredPools = await filterPools({ api: api, pairs: pairObject, createBalances: createBalances })
   const poolAddresses = Object.keys(filteredPools)
-  const fees = await api.multiCall({ abi: 'uint256:fee',  calls: poolAddresses })
+  const fees = await api.multiCall({ abi: 'uint256:fee', calls: poolAddresses })
   const aeroPoolSet = new Set()
   const poolInfoMap = {} as any
   poolAddresses.forEach((pair, index) => {
@@ -110,11 +105,11 @@ const fetch = async (options: FetchOptions) => {
           const fee1 = amount1 * fee
           addOneToken({ chain, balances: dailyVolume, token0, token1, amount0, amount1 })
           if (hasGauge) {
-            addOneToken({ chain, balances: dailyHoldersRevenue, token0, token1, amount0: fee0, amount1: fee1 })
+            addOneToken({ chain, balances: gaugedFees, token0, token1, amount0: fee0, amount1: fee1 })
           }
           else {
-            addOneToken({ chain, balances: dailySupplySideRevenue, token0, token1, amount0: fee0 * 0.95, amount1: fee1 * 0.95 })
-            addOneToken({ chain, balances: dailyProtocolRevenue, token0, token1, amount0: fee0 * 0.05, amount1: fee1 * 0.05 })
+            addOneToken({ chain, balances: supplySideFees, token0, token1, amount0: fee0 * 0.95, amount1: fee1 * 0.95 })
+            addOneToken({ chain, balances: protocolFees, token0, token1, amount0: fee0 * 0.05, amount1: fee1 * 0.05 })
           }
         })
       } catch (e) {
@@ -125,15 +120,30 @@ const fetch = async (options: FetchOptions) => {
 
   if (errorFound) throw errorFound
   const { dailyBribesRevenue } = await getBribes(options, eventAbis.event_gaugeCreated, CONFIG.voter, CONFIG.factory)
-  // Exclude bribes by external protocols
-  const dailyUserFees = createBalances()
-  dailyUserFees.addBalances(dailyHoldersRevenue)
+
+  const dailyHoldersRevenue = createBalances()
+  dailyHoldersRevenue.addBalances(gaugedFees, 'Gauged Pool Fees')
+  dailyHoldersRevenue.add(SHADOW_TOKEN_CONTRACT, shadowPenaltyAmount, 'xSHADOW Exit Penalty')
+
+  const dailySupplySideRevenue = createBalances()
+  dailySupplySideRevenue.addBalances(supplySideFees, 'Swap Fees To LPs')
+
+  const dailyProtocolRevenue = createBalances()
+  dailyProtocolRevenue.addBalances(protocolFees, 'Protocol Fee')
+
+  // UserFees = all user-paid swap fees + exit penalty (before external bribes)
+  const dailyUserFees = dailyHoldersRevenue.clone(1)
   dailyUserFees.addBalances(dailySupplySideRevenue)
   dailyUserFees.addBalances(dailyProtocolRevenue)
-  dailyHoldersRevenue.addBalances(dailyBribesRevenue)
-  dailyRevenue.addBalances(dailyProtocolRevenue)
-  dailyRevenue.addBalances(dailyHoldersRevenue)
-  dailyFees.addBalances(dailyRevenue)
+
+  const feeDerivedHoldersRevenue = dailyHoldersRevenue.clone(1)
+  // External bribes only in holdersRevenue, not in fees/revenue
+  dailyHoldersRevenue.addBalances(dailyBribesRevenue, 'Voting Bribes')
+
+  const dailyRevenue = dailyProtocolRevenue.clone(1)
+  dailyRevenue.addBalances(feeDerivedHoldersRevenue)
+
+  const dailyFees = dailyRevenue.clone(1)
   dailyFees.addBalances(dailySupplySideRevenue)
 
   return {
@@ -148,17 +158,49 @@ const fetch = async (options: FetchOptions) => {
 };
 
 const methodology = {
-  Fees: "User pays fees on each swap.",
-  UserFees: "Swap fees paid by traders.",
-  ProtocolRevenue: "Revenue going to the protocol.",
-  HoldersRevenue: "Fees from gauged pools, voting bribes, and the xSHADOW instant-exit penalty are all distributed among xSHADOW holders.",
-  SupplySideRevenue: "Fees distributed to LPs (from gauged pools).",
+  Fees: "Swap fees paid by traders on all pools, plus xSHADOW instant-exit penalties.",
+  UserFees: "Swap fees paid by traders and xSHADOW instant-exit penalties.",
+  ProtocolRevenue: "5% of non-gauged pool fees going to the protocol treasury.",
+  HoldersRevenue: "Fees from gauged pools, voting bribes, and the xSHADOW instant-exit penalty distributed to xSHADOW holders.",
+  SupplySideRevenue: "95% of non-gauged pool fees distributed to LPs.",
+};
+
+const breakdownMethodology = {
+  Fees: {
+    'Gauged Pool Fees': 'Swap fees from gauge-enabled pools.',
+    'xSHADOW Exit Penalty': 'Instant-exit penalty paid by users redeeming xSHADOW early.',
+    'Swap Fees To LPs': '95% of swap fees from non-gauged pools distributed to LPs.',
+    'Protocol Fee': '5% of swap fees from non-gauged pools going to the protocol treasury.',
+  },
+  UserFees: {
+    'Gauged Pool Fees': 'Swap fees paid by traders on gauge-enabled pools.',
+    'xSHADOW Exit Penalty': 'Instant-exit penalty paid by users redeeming xSHADOW early.',
+    'Swap Fees To LPs': 'Swap fees paid by traders on non-gauged pools (LP portion).',
+    'Protocol Fee': 'Swap fees paid by traders on non-gauged pools (protocol portion).',
+  },
+  Revenue: {
+    'Gauged Pool Fees': 'Swap fees from gauged pools distributed to xSHADOW holders.',
+    'xSHADOW Exit Penalty': 'xSHADOW instant-exit penalty redistributed to remaining holders.',
+    'Protocol Fee': '5% of swap fees from non-gauged pools going to the protocol treasury.',
+  },
+  HoldersRevenue: {
+    'Gauged Pool Fees': 'Swap fees from gauged pools distributed to xSHADOW holders.',
+    'xSHADOW Exit Penalty': 'xSHADOW instant-exit penalty redistributed to remaining holders.',
+    'Voting Bribes': 'External incentives deposited by protocols to attract xSHADOW voter liquidity.',
+  },
+  SupplySideRevenue: {
+    'Swap Fees To LPs': '95% of swap fees from non-gauged pools distributed to LPs.',
+  },
+  ProtocolRevenue: {
+    'Protocol Fee': '5% of swap fees from non-gauged pools going to the protocol treasury.',
+  },
 };
 
 const adapter: SimpleAdapter = {
   version: 2,
   pullHourly: true,
   methodology,
+  breakdownMethodology,
   fetch,
   chains: [CHAIN.SONIC],
   start: "2024-12-27"

--- a/dexs/shadow-legacy.ts
+++ b/dexs/shadow-legacy.ts
@@ -136,28 +136,32 @@ const fetch = async (fetchOptions: FetchOptions): Promise<FetchResult> => {
   if (errorFound) throw errorFound
 
   const { dailyBribesRevenue } = await getBribes(fetchOptions, eventAbis.event_gaugeCreated, CONFIG.voter, CONFIG.factory)
+  // Exclude bribes by external protocols
+  const dailyUserFees = createBalances()
+  dailyUserFees.addBalances(dailyHoldersRevenue)
+  dailyUserFees.addBalances(dailySupplySideRevenue)
+  dailyUserFees.addBalances(dailyProtocolRevenue)
+  dailyHoldersRevenue.addBalances(dailyBribesRevenue)
   dailyRevenue.addBalances(dailyProtocolRevenue)
   dailyRevenue.addBalances(dailyHoldersRevenue)
   dailyFees.addBalances(dailyRevenue)
   dailyFees.addBalances(dailySupplySideRevenue)
 
-  return { 
-    dailyVolume, 
+  return {
+    dailyVolume,
     dailyFees,
-    dailyUserFees: dailyFees, 
-    dailyRevenue, 
-    dailyHoldersRevenue, 
+    dailyUserFees,
+    dailyRevenue,
+    dailyHoldersRevenue,
     dailySupplySideRevenue,
-    dailyProtocolRevenue, 
-    dailyBribesRevenue 
+    dailyProtocolRevenue,
   }
 }
 const methodology = {
   Fees: "User pays fees on each swap.",
-  UserFees: "User pays fees on each swap.",
+  UserFees: "Swap fees paid by traders.",
   ProtocolRevenue: "Revenue going to the protocol.",
-  HoldersRevenue: "User fees are distributed among holders.",
-  BribesRevenue: "Bribes are distributed among holders.",
+  HoldersRevenue: "Fees from gauged pools and voting bribes are distributed among xSHADOW holders.",
   SupplySideRevenue: "Fees distributed to LPs (from gauged pools).",
 };
 

--- a/dexs/shadow-legacy.ts
+++ b/dexs/shadow-legacy.ts
@@ -33,7 +33,7 @@ export const getBribes = async (fetchOptions: FetchOptions, gaugeCreatedEvent: s
   const bribes_contract = logs_gauge_created
     .filter((log) => (log.address || log.source).toLowerCase() === voter.toLowerCase())
   const pools = bribes_contract.map(log => log.args.pool.toLowerCase())
-  const poolsFactories = (await fetchOptions.api.multiCall({ abi:'address:factory', calls: pools}))
+  const poolsFactories = (await fetchOptions.api.multiCall({ abi: 'address:factory', calls: pools }))
   const bribes_contracts_v2 = bribes_contract.filter((_, index) => poolsFactories[index].toLowerCase() === factory.toLowerCase()).map((log) => log.args.feeDistributor.toLowerCase())
   const bribeSet = new Set(bribes_contracts_v2)
 
@@ -52,11 +52,9 @@ export const getBribes = async (fetchOptions: FetchOptions, gaugeCreatedEvent: s
 const fetch = async (fetchOptions: FetchOptions): Promise<FetchResult> => {
   const { api, createBalances, getToBlock, getFromBlock, chain, getLogs } = fetchOptions
   const dailyVolume = createBalances()
-  const dailyFees = createBalances()
-  const dailyRevenue = createBalances()
-  const dailyHoldersRevenue = createBalances()
-  const dailySupplySideRevenue = createBalances()
-  const dailyProtocolRevenue = createBalances() 
+  const gaugedFees = createBalances()
+  const supplySideFees = createBalances()
+  const protocolFees = createBalances()
   const [toBlock, fromBlock] = await Promise.all([getToBlock(), getFromBlock()])
 
   const cacheKey = `tvl-adapter-cache/cache/uniswap-forks/${CONFIG.factory.toLowerCase()}-${chain}.json`
@@ -65,9 +63,9 @@ const fetch = async (fetchOptions: FetchOptions): Promise<FetchResult> => {
   pairs.forEach((pair: string, i: number) => {
     pairObject[pair] = [token0s[i], token1s[i]]
   })
-  const filteredPools = await filterPools({ api: api, pairs: pairObject, createBalances: createBalances})
+  const filteredPools = await filterPools({ api: api, pairs: pairObject, createBalances: createBalances })
   const poolAddresses = Object.keys(filteredPools)
-  const fees = await api.multiCall({ abi: abis.fee,  calls: poolAddresses })
+  const fees = await api.multiCall({ abi: abis.fee, calls: poolAddresses })
   const feeRecipients = await api.multiCall({ abi: 'address:feeRecipient', calls: poolAddresses })
   const aeroPoolSet = new Set()
   const poolInfoMap = {} as any
@@ -120,11 +118,11 @@ const fetch = async (fetchOptions: FetchOptions): Promise<FetchResult> => {
           const fee1 = amount1 * fee
           addOneToken({ chain, balances: dailyVolume, token0, token1, amount0, amount1 })
           if (hasGauge) {
-            addOneToken({ chain, balances: dailyHoldersRevenue, token0, token1, amount0: fee0, amount1: fee1 })
+            addOneToken({ chain, balances: gaugedFees, token0, token1, amount0: fee0, amount1: fee1 })
           }
           else {
-            addOneToken({ chain, balances: dailySupplySideRevenue, token0, token1, amount0: fee0 * 0.95, amount1: fee1 * 0.95 })
-            addOneToken({ chain, balances: dailyProtocolRevenue, token0, token1, amount0: fee0 * 0.05, amount1: fee1 * 0.05 })
+            addOneToken({ chain, balances: supplySideFees, token0, token1, amount0: fee0 * 0.95, amount1: fee1 * 0.95 })
+            addOneToken({ chain, balances: protocolFees, token0, token1, amount0: fee0 * 0.05, amount1: fee1 * 0.05 })
           }
         })
       } catch (e) {
@@ -136,15 +134,30 @@ const fetch = async (fetchOptions: FetchOptions): Promise<FetchResult> => {
   if (errorFound) throw errorFound
 
   const { dailyBribesRevenue } = await getBribes(fetchOptions, eventAbis.event_gaugeCreated, CONFIG.voter, CONFIG.factory)
-  // Exclude bribes by external protocols
-  const dailyUserFees = createBalances()
-  dailyUserFees.addBalances(dailyHoldersRevenue)
+
+  const dailyHoldersRevenue = createBalances()
+  dailyHoldersRevenue.addBalances(gaugedFees, 'Gauged Pool Fees')
+
+  const dailySupplySideRevenue = createBalances()
+  dailySupplySideRevenue.addBalances(supplySideFees, 'Swap Fees To LPs')
+
+  const dailyProtocolRevenue = createBalances()
+  dailyProtocolRevenue.addBalances(protocolFees, 'Protocol Fee')
+
+  // UserFees = all user-paid swap fees (before external bribes)
+  const dailyUserFees = dailyHoldersRevenue.clone(1)
   dailyUserFees.addBalances(dailySupplySideRevenue)
   dailyUserFees.addBalances(dailyProtocolRevenue)
-  dailyHoldersRevenue.addBalances(dailyBribesRevenue)
-  dailyRevenue.addBalances(dailyProtocolRevenue)
-  dailyRevenue.addBalances(dailyHoldersRevenue)
-  dailyFees.addBalances(dailyRevenue)
+
+  // Snapshot pre-bribe holders revenue for fee/revenue rollups
+  const feeDerivedHoldersRevenue = dailyHoldersRevenue.clone(1)
+  // External bribes only in holdersRevenue, not in fees/revenue
+  dailyHoldersRevenue.addBalances(dailyBribesRevenue, 'Voting Bribes')
+
+  const dailyRevenue = dailyProtocolRevenue.clone(1)
+  dailyRevenue.addBalances(feeDerivedHoldersRevenue)
+
+  const dailyFees = dailyRevenue.clone(1)
   dailyFees.addBalances(dailySupplySideRevenue)
 
   return {
@@ -158,11 +171,38 @@ const fetch = async (fetchOptions: FetchOptions): Promise<FetchResult> => {
   }
 }
 const methodology = {
-  Fees: "User pays fees on each swap.",
+  Fees: "Swap fees paid by traders on all pools.",
   UserFees: "Swap fees paid by traders.",
-  ProtocolRevenue: "Revenue going to the protocol.",
-  HoldersRevenue: "Fees from gauged pools and voting bribes are distributed among xSHADOW holders.",
-  SupplySideRevenue: "Fees distributed to LPs (from gauged pools).",
+  ProtocolRevenue: "5% of non-gauged pool fees going to the protocol treasury.",
+  HoldersRevenue: "Fees from gauged pools and voting bribes distributed to xSHADOW holders.",
+  SupplySideRevenue: "95% of non-gauged pool fees distributed to LPs.",
+};
+
+const breakdownMethodology = {
+  Fees: {
+    'Gauged Pool Fees': 'Swap fees from gauge-enabled pools.',
+    'Swap Fees To LPs': '95% of swap fees from non-gauged pools distributed to LPs.',
+    'Protocol Fee': '5% of swap fees from non-gauged pools going to the protocol treasury.',
+  },
+  UserFees: {
+    'Gauged Pool Fees': 'Swap fees paid by traders on gauge-enabled pools.',
+    'Swap Fees To LPs': 'Swap fees paid by traders on non-gauged pools (LP portion).',
+    'Protocol Fee': 'Swap fees paid by traders on non-gauged pools (protocol portion).',
+  },
+  Revenue: {
+    'Gauged Pool Fees': 'Swap fees from gauged pools distributed to xSHADOW holders.',
+    'Protocol Fee': '5% of swap fees from non-gauged pools going to the protocol treasury.',
+  },
+  HoldersRevenue: {
+    'Gauged Pool Fees': 'Swap fees from gauged pools distributed to xSHADOW holders.',
+    'Voting Bribes': 'External incentives deposited by protocols to attract xSHADOW voter liquidity.',
+  },
+  SupplySideRevenue: {
+    'Swap Fees To LPs': '95% of swap fees from non-gauged pools distributed to LPs.',
+  },
+  ProtocolRevenue: {
+    'Protocol Fee': '5% of swap fees from non-gauged pools going to the protocol treasury.',
+  },
 };
 
 const adapter: SimpleAdapter = {
@@ -170,6 +210,7 @@ const adapter: SimpleAdapter = {
   pullHourly: true,
   fetch,
   methodology,
+  breakdownMethodology,
   chains: [CHAIN.SONIC],
   start: '2025-02-02',
 }


### PR DESCRIPTION
Migrate deprecated dailyBribesRevenue / dailyTokenTaxes to dailyHoldersRevenue

Removes the two deprecated fee fields across four adapters, routing their values into dailyHoldersRevenue and maintaining income-statement consistency (fees = revenue + supply-side):