### PR TITLE
fix(pika-protocol-v4): correct fix split

### DIFF
--- a/aggregators/superswap/index.ts
+++ b/aggregators/superswap/index.ts
@@ -55,7 +55,7 @@ const adapter: SimpleAdapter = {
   fetch,
   adapter: chainConfig,
   methodology: {
-    dailyVolume: "Volume is calculated by summing the amountIn values from Route events emitted by SuperSwap router contracts across all supported chains."
+    Volume: "Volume is calculated by summing the amountIn values from Route events emitted by SuperSwap router contracts across all supported chains."
   },
 }
 

--- a/dexs/grizzly-trade-derivatives-v2/index.ts
+++ b/dexs/grizzly-trade-derivatives-v2/index.ts
@@ -50,7 +50,7 @@ const fetch = () => {
 };
 
 const methodology = {
-  dailyVolume:
+  Volume:
     "Total cumulativeVolumeUsd for specified chain for the given day",
 };
 

--- a/dexs/metavault-derivatives-v2/index.ts
+++ b/dexs/metavault-derivatives-v2/index.ts
@@ -60,7 +60,7 @@ const fetch = (endpoint) => {
 };
 
 const methodology = {
-  dailyVolume:
+  Volume:
     "Total cumulativeVolumeUsd for specified chain for the given day",
 }
 

--- a/dexs/pika-protocol-v4/index.ts
+++ b/dexs/pika-protocol-v4/index.ts
@@ -42,12 +42,12 @@ const fetch = async (options: FetchOptions) => {
 };
 
 const methodology = {
-  dailyVolume: "Notional volume of positions opened and closed (margin * leverage).",
-  dailyFees: "Trading fees paid by traders on opening and closing positions.",
-  dailyRevenue: "Fees retained by the protocol after the LP/vault share (50% of fees).",
-  dailySupplySideRevenue: "50% of trading fees distributed to the vault (liquidity providers).",
-  dailyHoldersRevenue: "30% of trading fees distributed to PIKA token stakers.",
-  dailyProtocolRevenue: "20% of trading fees sent to the protocol treasury.",
+  Volume: "Notional volume of positions opened and closed (margin * leverage).",
+  Fees: "Trading fees paid by traders on opening and closing positions.",
+  Revenue: "Fees retained by the protocol after the LP/vault share (50% of fees).",
+  SupplySideRevenue: "50% of trading fees distributed to the vault (liquidity providers).",
+  HoldersRevenue: "30% of trading fees distributed to PIKA token stakers.",
+  ProtocolRevenue: "20% of trading fees sent to the protocol treasury.",
 };
 
 const adapter: SimpleAdapter = {

--- a/dexs/pika-protocol-v4/index.ts
+++ b/dexs/pika-protocol-v4/index.ts
@@ -29,13 +29,25 @@ const fetch = async (options: FetchOptions) => {
     dailyFees.addUSDValue(Number(log.fee) / 1e8);
   }
 
+  // Pika v4 trading fee split: 50% to the vault (LPs), 30% to PIKA stakers,
+  // 20% to the protocol treasury.
   return {
     dailyVolume,
     dailyFees,
     dailyRevenue: dailyFees.clone(0.5),
-    dailyProtocolRevenue: dailyFees.clone(0.5),
     dailySupplySideRevenue: dailyFees.clone(0.5),
+    dailyHoldersRevenue: dailyFees.clone(0.3),
+    dailyProtocolRevenue: dailyFees.clone(0.2),
   };
+};
+
+const methodology = {
+  dailyVolume: "Notional volume of positions opened and closed (margin * leverage).",
+  dailyFees: "Trading fees paid by traders on opening and closing positions.",
+  dailyRevenue: "Fees retained by the protocol after the LP/vault share (50% of fees).",
+  dailySupplySideRevenue: "50% of trading fees distributed to the vault (liquidity providers).",
+  dailyHoldersRevenue: "30% of trading fees distributed to PIKA token stakers.",
+  dailyProtocolRevenue: "20% of trading fees sent to the protocol treasury.",
 };
 
 const adapter: SimpleAdapter = {
@@ -47,6 +59,7 @@ const adapter: SimpleAdapter = {
       start: "2023-06-28",
     },
   },
+  methodology,
 };
 
 export default adapter;

--- a/dexs/pika-protocol-v4/index.ts
+++ b/dexs/pika-protocol-v4/index.ts
@@ -29,8 +29,10 @@ const fetch = async (options: FetchOptions) => {
     dailyFees.addUSDValue(Number(log.fee) / 1e8);
   }
 
-  // Pika v4 trading fee split: 50% to the vault (LPs), 30% to PIKA stakers,
-  // 20% to the protocol treasury.
+  // Fee split sources:
+  //   - 50% vault (LPs) / 50% protocol: https://docs.pikaprotocol.com/features
+  //   - 30% of total fees to PIKA stakers: https://docs.pikaprotocol.com/reward-program
+  //   → remaining 20% goes to protocol treasury (50% protocol share − 30% stakers)
   return {
     dailyVolume,
     dailyFees,

--- a/dexs/quickswap-perps/index.ts
+++ b/dexs/quickswap-perps/index.ts
@@ -13,7 +13,7 @@ const methodology = {
     OpenInterest: 'builder code openInterest from Symmio Perps Trades.',
   },
   quickswap: {
-    dailyVolume: "Total cumulativeVolumeUsd for specified chain for the given day",
+    Volume: "Total cumulativeVolumeUsd for specified chain for the given day",
   },
 };
 

--- a/dexs/rfx-rfx-swap.ts
+++ b/dexs/rfx-rfx-swap.ts
@@ -56,7 +56,7 @@ const fetch = async (_timestamp: number, _block: any, options: FetchOptions) => 
 };
 
 const methodology = {
-  dailyVolume: "Sum of daily swap or margin volume for RFX subgraph.",
+  Volume: "Sum of daily swap or margin volume for RFX subgraph.",
 };
 
 const adapter: SimpleAdapter = {

--- a/dexs/rfx-rfx-trade.ts
+++ b/dexs/rfx-rfx-trade.ts
@@ -56,7 +56,7 @@ const fetch = async (_timestamp: number, _block: any, options: FetchOptions) => 
 };
 
 const methodology = {
-  dailyVolume: "Sum of daily swap or margin volume for RFX subgraph.",
+  Volume: "Sum of daily swap or margin volume for RFX subgraph.",
 };
 
 const adapter: SimpleAdapter = {

--- a/dexs/turbolev/index.ts
+++ b/dexs/turbolev/index.ts
@@ -38,7 +38,7 @@ const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
 };
 
 const methodology = {
-  dailyVolume:
+  Volume:
     "Sum of daily perpetual trading volume from POSITION_OPENED events within the requested period, grouped by token.",
 };
 

--- a/dexs/unidex-unidex.ts
+++ b/dexs/unidex-unidex.ts
@@ -57,7 +57,7 @@ const fetch = (chain: Chain) => {
 };
 
 const methodology = {
-  dailyVolume: "Sum of cumulativeVolumeUsd for all products on the specified chain for the given day",
+  Volume: "Sum of cumulativeVolumeUsd for all products on the specified chain for the given day",
 };
 
 const adapter: SimpleAdapter = {


### PR DESCRIPTION
- Fixes Pika v4 fee/revenue breakdow: 50% to LPs, 30% to stakers, 20% to protocol treasury
- Adds `dailySupplySideRevenue` and `dailyHoldersRevenue`
- Adds methodology descriptions