### PR TITLE
fix(metropolis-amm): replace broken subgraph with uniV2 log adapter

### DIFF
--- a/dexs/metropolis-amm/index.ts
+++ b/dexs/metropolis-amm/index.ts
@@ -1,22 +1,4 @@
-import { CHAIN } from "../../helpers/chains";
-import { FetchOptions } from "../../adapters/types";
-import { httpPost } from "../../utils/fetchURL";
-
-
-const fetch = async (_: number, _block: any, { startOfDayId }: FetchOptions) => {
-  const query = `query { uniswapDayData(id: ${startOfDayId}) { dailyVolumeUSD } }`;
-  const { data: { uniswapDayData: { dailyVolumeUSD } } } = await httpPost('https://sonic-graph-b.metropolis.exchange/subgraphs/name/metropolis/sonic-dex-1', { query })
-  const dailyVolume = +dailyVolumeUSD
-  const dailyFees = dailyVolume * 0.3/100
-  return {
-    dailyVolume,
-    dailyFees,
-    dailySupplySideRevenue: dailyFees * 0.6,
-    dailyRevenue: dailyFees * 0.4,
-    dailyProtocolRevenue: dailyFees * 0.1,
-    dailyHoldersRevenue: dailyFees * 0.3,
-  }
-};
+import { uniV2Exports } from "../../helpers/uniswap";
 
 const methodology = {
   Fees: "0.3% of the trading volume",
@@ -26,9 +8,18 @@ const methodology = {
   HoldersRevenue: "30% of the swap fees",
 };
 
-export default {
-  fetch,
-  start: "2024-12-16",
-  chains: [CHAIN.SONIC],
-  methodology,
-}
+const adapter = uniV2Exports({
+  sonic: {
+    factory: "0x1570300e9cFEC66c9Fb0C8bc14366C86EB170Ad0",
+    fees: 0.003,
+    userFeesRatio: 1,
+    revenueRatio: 0.4,
+    holdersRevenueRatio: 0.3,
+    protocolRevenueRatio: 0.1,
+    start: "2024-12-16",
+  },
+});
+
+adapter.methodology = methodology;
+
+export default adapter;


### PR DESCRIPTION

Problem

The self-hosted subgraph at sonic-graph-b.metropolis.exchange has been returning HTTP 503 for 12+ days. No Goldsky or Graph Network alternative exists for this protocol. Every day since 2026-05-04 reports $0 volume on the dashboard.

Fix

Replace the broken subgraph query with uniV2Exports using the on-chain V2 Factory (0x1570300e9cFEC66c9Fb0C8bc14366C86EB170Ad0). Reads Swap events directly from Sonic — no external indexer dependency.

Fee structure unchanged from original adapter:

	•	Total fee: 0.3%
	•	Supply side: 60% of fees
	•	Revenue: 40% of fees
	•	Holders revenue: 30% of fees
	•	Protocol revenue: 10% of fees

cc @0xjosaphat

