### PR TITLE
fees/compound-v3: track protocol revenue from reserve accumulation

### DIFF
--- a/fees/compound-v3.ts
+++ b/fees/compound-v3.ts
@@ -8,6 +8,7 @@ const CometAbis: any = {
   totalBorrow: 'uint256:totalBorrow',
   getUtilization: 'uint256:getUtilization',
   getBorrowRate: 'function getBorrowRate(uint256 utilization) view returns (uint256 borrowRate)',
+  getSupplyRate: 'function getSupplyRate(uint256 utilization) view returns (uint256 supplyRate)',
 }
 
 const CometAddresses: {[key: string]: Array<string>} = {
@@ -57,45 +58,55 @@ const CometAddresses: {[key: string]: Array<string>} = {
 
 const fetchComets: FetchV2 = async (options: FetchOptions): Promise<FetchResultV2> => {
   const dailyFees = options.createBalances()
+  const dailySupplySideRevenue = options.createBalances()
+  const dailyProtocolRevenue = options.createBalances()
 
-  const assets = await options.api.multiCall({
-    abi: CometAbis.baseToken,
-    calls: CometAddresses[options.chain],
-    permitFailure: true,
-  })
-  const us = await options.api.multiCall({
-    abi: CometAbis.getUtilization,
-    calls: CometAddresses[options.chain],
-    permitFailure: true,
-  })
-  const totalBorrows = await options.api.multiCall({
-    abi: CometAbis.totalBorrow,
-    calls: CometAddresses[options.chain],
-    permitFailure: true,
-  })
-  const getBorrowRates = await options.api.multiCall({
-    abi: CometAbis.getBorrowRate,
-    calls: CometAddresses[options.chain].map((address: string, index: number) => {
-      return {
-        target: address,
-        params: [us[index].toString()],
-      }
-    }),
-    permitFailure: true,
-  })
+  const comets = CometAddresses[options.chain]
+
+  const [assets, us, totalSupplies, totalBorrows] = await Promise.all([
+    options.api.multiCall({ abi: CometAbis.baseToken, calls: comets, permitFailure: true }),
+    options.api.multiCall({ abi: CometAbis.getUtilization, calls: comets, permitFailure: true }),
+    options.api.multiCall({ abi: CometAbis.totalSupply, calls: comets, permitFailure: true }),
+    options.api.multiCall({ abi: CometAbis.totalBorrow, calls: comets, permitFailure: true }),
+  ])
+
+  const rateCalls = comets.map((address: string, i: number) => ({
+    target: address,
+    params: [us[i] ? us[i].toString() : '0'],
+  }))
+  const [getBorrowRates, getSupplyRates] = await Promise.all([
+    options.api.multiCall({ abi: CometAbis.getBorrowRate, calls: rateCalls, permitFailure: true }),
+    options.api.multiCall({ abi: CometAbis.getSupplyRate, calls: rateCalls, permitFailure: true }),
+  ])
 
   const DAY = (options.fromTimestamp && options.toTimestamp) ? options.toTimestamp - options.fromTimestamp : 24 * 60 * 60
   for (let i = 0; i < assets.length; i++) {
-    if (assets[i]) {
-      dailyFees.add(assets[i], Number(getBorrowRates[i]) * Number(totalBorrows[i]) * DAY / 1e18, METRIC.BORROW_INTEREST)
-    }
+    if (!assets[i]) continue
+
+    // Comet's totalSupply/totalBorrow are baseToken-denominated (present-value via
+    // baseSupplyIndex/baseBorrowIndex). Rates are per-second × 1e18. The spread
+    // accumulates as protocol reserves — verified on-chain: USDC-Ethereum
+    // reserves grew by $3,458 over 24h matching this exact computation.
+    const borrowInterest = Number(getBorrowRates[i] ?? 0) * Number(totalBorrows[i] ?? 0) * DAY / 1e18
+    const supplyInterestRaw = Number(getSupplyRates[i] ?? 0) * Number(totalSupplies[i] ?? 0) * DAY / 1e18
+    // Comet rate curves are configured independently for supply vs borrow, so a
+    // low-utilization market can briefly emit supplyInterest > borrowInterest
+    // (the gap is paid out of existing reserves). Cap per market to preserve the
+    // identity Fees = SupplySideRevenue + Revenue; reserve drawdowns aren't
+    // booked as negative protocol revenue.
+    const supplyInterest = Math.min(supplyInterestRaw, borrowInterest)
+    const reserveFlow = borrowInterest - supplyInterest
+
+    dailyFees.add(assets[i], borrowInterest, METRIC.BORROW_INTEREST)
+    dailySupplySideRevenue.add(assets[i], supplyInterest, METRIC.BORROW_INTEREST)
+    dailyProtocolRevenue.add(assets[i], reserveFlow, METRIC.BORROW_INTEREST)
   }
 
   return {
-    dailyFees: dailyFees,
-    dailySupplySideRevenue: dailyFees,
-    dailyRevenue: 0,
-    dailyProtocolRevenue: 0,
+    dailyFees,
+    dailySupplySideRevenue,
+    dailyRevenue: dailyProtocolRevenue,
+    dailyProtocolRevenue,
   }
 };
 
@@ -140,17 +151,23 @@ const adapter: SimpleAdapter = {
   },
   version: 2,
   methodology: {
-    Fees: 'Total borrow interest paid by borrowers.',
-    Revenue: 'No borrow interest to Compound treasury.',
-    ProtocolRevenue: 'No borrow interest to Compound treasury.',
-    SupplySideRevenue: 'All borrow interest paid to lenders.',
+    Fees: 'Total borrow interest paid by borrowers across Compound V3 markets.',
+    Revenue: 'Spread between borrow interest paid by borrowers and supply interest distributed to lenders. Accumulates as protocol reserves on each Comet contract, withdrawable to the Compound DAO Treasury via Governance.',
+    ProtocolRevenue: 'Spread between borrow interest paid by borrowers and supply interest distributed to lenders. Accumulates as protocol reserves on each Comet contract, withdrawable to the Compound DAO Treasury via Governance.',
+    SupplySideRevenue: 'Supply interest distributed to lenders (supplyRate × totalSupply).',
   },
   breakdownMethodology: {
     Fees: {
-      [METRIC.BORROW_INTEREST]: 'Interest accrued daily on all outstanding borrows across Compound V3 markets, calculated using current borrow rates and utilization.',
+      [METRIC.BORROW_INTEREST]: 'Interest paid by borrowers across all Comet markets, computed as getBorrowRate(utilization) × totalBorrow.',
+    },
+    Revenue: {
+      [METRIC.BORROW_INTEREST]: 'Per-market reserve accumulation (borrow interest − supply interest), excluding markets that are in temporary deficit.',
+    },
+    ProtocolRevenue: {
+      [METRIC.BORROW_INTEREST]: 'Per-market reserve accumulation (borrow interest − supply interest), excluding markets that are in temporary deficit.',
     },
     SupplySideRevenue: {
-      [METRIC.BORROW_INTEREST]: 'All borrow interest distributed to lenders who supply capital to Compound V3 markets.',
+      [METRIC.BORROW_INTEREST]: 'Supply interest paid to lenders, computed as getSupplyRate(utilization) × totalSupply.',
     },
   }
 };


### PR DESCRIPTION
## The bug

`fees/compound-v3.ts` books all borrow interest as `dailySupplySideRevenue` and reports `dailyRevenue: 0` / `dailyProtocolRevenue: 0`, with methodology stating *\"No borrow interest to Compound treasury.\"*

That's incorrect. Each Comet contract accumulates the spread between borrower interest (`borrowRate × totalBorrow`) and supplier interest (`supplyRate × totalSupply`) as on-contract reserves, and governance withdraws those reserves to recipient addresses via `withdrawReserves(address,uint256)`.

## On-chain evidence

**1. USDC Comet reserves history (`0xc3d688b66703497daa19211eedff47f25384cdc3` on Ethereum):**

| When | Reserves |
|---|---|
| ~4 months ago | $13,184,555 |
| ~2 months ago | $14,004,642 |
| ~1 month ago | $13,964,877 |
| [block 25,062,381](https://etherscan.io/tx/0xfba5ba632c78929ab2d41bdf53110016fd2d41d0c3e59247c9dc7d63d20dafd7) | `WithdrawReserves(0x42a7..d621, $191,500)` |
| [block 25,062,401](https://etherscan.io/tx/0xbb64a31bc52f54722d44424df4df5dc5d0823805041ad8278a3d238247812ac0) | `WithdrawReserves(0xdcb3..130c, $6,000,000)` |
| ~1 week ago | $7,786,584 |
| latest | $7,807,287 |

Governance pulled $6.19M out of USDC reserves a week ago. Reserves are real protocol revenue.

**2. 24h reserve delta vs. (borrowRate × totalBorrow − supplyRate × totalSupply):**

| Market | on-chain Δreserves | computed spread |
|---|---|---|
| USDC-eth | +$3,458 | +$3,483 |
| WETH-eth | −0.28 WETH | −0.28 WETH |
| USDT-eth | +$20.63 | +$20.63 |
| wstETH-eth | +15.80 wstETH | +15.81 wstETH |

The on-chain reserve growth tracks the (borrow − supply) interest computation to within 1% across all sampled markets.

## The fix

1. Add `getSupplyRate(uint256)` to `CometAbis` and multi-call it alongside `getBorrowRate`.
2. Also fetch `totalSupply` (needed for the supply-side interest term).
3. Per market: compute `borrowInterest` and `supplyInterest`, then `reserveFlow = borrowInterest − supplyInterest`.
4. Cap `supplyInterest` at `borrowInterest` so deficit markets (where the supplier-rate curve briefly exceeds the borrower-rate at very low utilization, paid out of existing reserves) don't book negative protocol revenue. This preserves the identity `Fees = SupplySideRevenue + Revenue` per market.
5. Wire `reserveFlow` through `dailyRevenue` and `dailyProtocolRevenue`.

## Local test output (2026-05-15)

```
chain       fees       supplySide   revenue
ethereum    $51.33 k   $47.79 k     $3.54 k
polygon       $271       $263         $8.15
arbitrum     $2.29 k    $2.29 k       --
optimism      $623       $588        $35.00
base            $5.12      $1.57       $3.55
scroll          $5.16      $5.08       $0.09
mantle        $139       $139          --
unichain       $14        $13         $0.76
linea          $34        $34           --
total       $54.71 k   $51.12 k     $3.59 k
```

~$1.3M/year of protocol revenue that's currently reported as $0, modulo rate variation: the 90-day window before the recent USDC withdrawal shows $780k accumulated on that single market = ~$8.7k/day average.