### PR TITLE
[feat] Ring-V4: track volume/fees for ring protocol v4 pools.

### DIFF
--- a/dexs/ring-dex-v4.ts
+++ b/dexs/ring-dex-v4.ts
@@ -1,74 +1,121 @@
 import request, { gql } from "graphql-request";
 import { FetchOptions, SimpleAdapter } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
+import { isCoreAsset } from "../helpers/prices";
 
 const chainConfig: any = {
   [CHAIN.ETHEREUM]: {
     endpoint: "https://api-explore-ring-production.up.railway.app",
+    poolManager: "0x000000000004444c5dc75cB358380D2e3dE08A90",
     start: "2025-02-01",
   },
 };
 
-const dayDataQuery = gql`
-  query ringV4PoolDayDatas($date: BigInt!, $limit: Int!, $offset: Int!) {
-    v4PoolDayDatas(limit: $limit, offset: $offset, where: { date: $date }) {
+const swapEvent = "event Swap(bytes32 indexed id, address indexed sender, int128 amount0, int128 amount1, uint160 sqrtPriceX96, uint128 liquidity, int24 tick, uint24 fee)";
+
+const poolsQuery = gql`
+  query ringV4Pools($limit: Int!, $offset: Int!) {
+    v4Pools(limit: $limit, offset: $offset) {
       totalCount
       items {
         poolId
-        volumeUSD
-        untrackedVolumeUSD
-        feesUSD
-        pool {
-          feeTier
+        token0 {
+          address
+          originToken {
+            address
+          }
+        }
+        token1 {
+          address
+          originToken {
+            address
+          }
         }
       }
     }
   }
 `;
 
-async function fetch(_: number, _1: any, options: FetchOptions) {
+const poolsCache: Record<string, Promise<Record<string, string[]>> | undefined> = {};
+
+async function getPools(endpoint: string) {
+  return poolsCache[endpoint] ??= (async () => {
+    const pools: Record<string, string[]> = {}, limit = 100;
+
+    for (let offset = 0; ; offset += limit) {
+      const { v4Pools: { items, totalCount } }: any = await request(endpoint, poolsQuery, { limit, offset });
+
+      items.forEach(({ poolId, token0, token1 }: any) => {
+        pools[poolId.toLowerCase()] = [token0, token1].map(t => (t.originToken?.address || t.address).toLowerCase());
+      })
+
+      if (offset + items.length >= totalCount || items.length < limit) return pools;
+    }
+  })();
+}
+
+async function fetch(options: FetchOptions) {
   const dailyVolume = options.createBalances();
   const dailyFees = options.createBalances();
-  const { endpoint } = chainConfig[options.chain];
-  const limit = 100;
+  const dailySupplySideRevenue = options.createBalances();
+  const { endpoint, poolManager } = chainConfig[options.chain];
+  const pools = await getPools(endpoint);
 
-  for (let offset = 0; ; offset += limit) {
-    const res: any = await request(endpoint, dayDataQuery, {
-      date: String(options.startOfDay),
-      limit,
-      offset,
-    });
+  const events = await options.getLogs({
+    target: poolManager,
+    eventAbi: swapEvent,
+  });
 
-    const items = res.v4PoolDayDatas.items;
-    items.forEach((item: any) => {
-      const itemVolume = Number(item.volumeUSD || 0) || Number(item.untrackedVolumeUSD || 0);
-      const itemFees = Number(item.feesUSD || 0) || itemVolume * Number(item.pool?.feeTier || 0) / 1e6;
+  events.forEach((event: any) => {
+    const pool = pools[String(event.id).toLowerCase()];
+    if (!pool) return;
 
-      if (itemVolume) dailyVolume.addUSDValue(itemVolume);
-      if (itemFees) dailyFees.addUSDValue(itemFees);
-    });
+    const pricedSide = isCoreAsset(options.chain, pool[0]) ? 0 : 1;
+    const token = pool[pricedSide];
+    const rawAmount = BigInt(pricedSide === 0 ? event.amount0 : event.amount1);
+    const amount = rawAmount < 0n ? -rawAmount : rawAmount;
+    const fees = amount * BigInt(event.fee) / 1000000n
 
-    if (offset + items.length >= res.v4PoolDayDatas.totalCount || items.length < limit) break;
-  }
+    dailyVolume.add(token, amount);
+    dailyFees.add(token, fees, "Swap Fees");
+    dailySupplySideRevenue.add(token, fees, "Swap Fees To LPs");
+
+  });
 
   return {
     dailyVolume,
     dailyFees,
     dailyUserFees: dailyFees,
-    dailyRevenue : 0,
-    dailySupplySideRevenue: dailyFees,
+    dailyRevenue: 0,
+    dailySupplySideRevenue,
   };
 }
+const methodology = {
+  Volume: "Volume is calculated from ring pool swap logs.",
+  Fees: "Fees are calculated from swap logs using each swap's fee tier.",
+  UserFees: "Users pay swap fees on each trade.",
+  Revenue: "Ring does not currently take protocol revenue from these v4 pools.",
+  SupplySideRevenue: "All swap fees are treated as liquidity provider revenue.",
+};
+
+const breakdownMethodology = {
+  Fees: {
+    "Swap Fees": "Swap fees paid by users on Ring v4 pools.",
+  },
+  UserFees: {
+    "Swap Fees": "Swap fees paid by users on Ring v4 pools.",
+  },
+  SupplySideRevenue: {
+    "Swap Fees To LPs": "Swap fees distributed to liquidity providers.",
+  },
+};
 
 const adapter: SimpleAdapter = {
-  version: 1,
-  methodology: {
-    Volume: "Volume is taken from Ring's v4 pool data.",
-    Fees: "Fees are taken from Ring's v4 pool data when available. Otherwise, they are estimated from the pool fee tier and daily volume.",
-    UserFees: "Users pay swap fees on each trade.",
-    Revenue: "Ring does not currently take protocol revenue from these v4 pools.",
-    SupplySideRevenue: "All swap fees are treated as liquidity provider revenue.",
-  },
+  version: 2,
+  pullHourly: true,
+  doublecounted: true, //Ring Pools are Uniswap-V4 based custom pools
+  methodology,
+  breakdownMethodology,
   fetch,
   adapter: chainConfig,
 };

--- a/dexs/ring-dex-v4.ts
+++ b/dexs/ring-dex-v4.ts
@@ -1,0 +1,76 @@
+import request, { gql } from "graphql-request";
+import { FetchOptions, SimpleAdapter } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+
+const chainConfig: any = {
+  [CHAIN.ETHEREUM]: {
+    endpoint: "https://api-explore-ring-production.up.railway.app",
+    start: "2025-02-01",
+  },
+};
+
+const dayDataQuery = gql`
+  query ringV4PoolDayDatas($date: BigInt!, $limit: Int!, $offset: Int!) {
+    v4PoolDayDatas(limit: $limit, offset: $offset, where: { date: $date }) {
+      totalCount
+      items {
+        poolId
+        volumeUSD
+        untrackedVolumeUSD
+        feesUSD
+        pool {
+          feeTier
+        }
+      }
+    }
+  }
+`;
+
+async function fetch(_: number, _1: any, options: FetchOptions) {
+  const dailyVolume = options.createBalances();
+  const dailyFees = options.createBalances();
+  const { endpoint } = chainConfig[options.chain];
+  const limit = 100;
+
+  for (let offset = 0; ; offset += limit) {
+    const res: any = await request(endpoint, dayDataQuery, {
+      date: String(options.startOfDay),
+      limit,
+      offset,
+    });
+
+    const items = res.v4PoolDayDatas.items;
+    items.forEach((item: any) => {
+      const itemVolume = Number(item.volumeUSD || 0) || Number(item.untrackedVolumeUSD || 0);
+      const itemFees = Number(item.feesUSD || 0) || itemVolume * Number(item.pool?.feeTier || 0) / 1e6;
+
+      if (itemVolume) dailyVolume.addUSDValue(itemVolume);
+      if (itemFees) dailyFees.addUSDValue(itemFees);
+    });
+
+    if (offset + items.length >= res.v4PoolDayDatas.totalCount || items.length < limit) break;
+  }
+
+  return {
+    dailyVolume,
+    dailyFees,
+    dailyUserFees: dailyFees,
+    dailyRevenue : 0,
+    dailySupplySideRevenue: dailyFees,
+  };
+}
+
+const adapter: SimpleAdapter = {
+  version: 1,
+  methodology: {
+    Volume: "Volume is taken from Ring's v4 pool data.",
+    Fees: "Fees are taken from Ring's v4 pool data when available. Otherwise, they are estimated from the pool fee tier and daily volume.",
+    UserFees: "Users pay swap fees on each trade.",
+    Revenue: "Ring does not currently take protocol revenue from these v4 pools.",
+    SupplySideRevenue: "All swap fees are treated as liquidity provider revenue.",
+  },
+  fetch,
+  adapter: chainConfig,
+};
+
+export default adapter;


### PR DESCRIPTION
## Notes
- Maintainer note: please group this under **Ring Protocol** together with the existing Ring adapter. https://defillama.com/protocol/ring-protocol
- Suggested naming:
  - existing adapter: **Ring V2**
  - new adapter: **Ring V4**

## Summary
- Adds a new `ring-dex-v4` adapter for Ring's Uniswap v4 / Few-wrapped pools on Ethereum.
- Uses Ring's live explore GraphQL data to report daily volume and fees for v4 pools, including Few-wrapped pools where tracked volume can be zero.

## Changes
- Added `dexs/ring-dex-v4.ts`.
- Fetches daily v4 pool data from Ring's explore endpoint:
  - `https://api-explore-ring-production.up.railway.app`
- Uses `v4PoolDayDatas` in paged chunks to collect daily pool activity.
- Counts volume from `volumeUSD`, and falls back to `untrackedVolumeUSD` when tracked volume is zero for Few-wrapped pools.
- Uses `feesUSD` when present, and otherwise derives fees from `feeTier * daily volume`.
- Reports:
  - `dailyVolume`
  - `dailyFees`
  - `dailyUserFees`
  - `dailySupplySideRevenue`
- Sets protocol revenue to zero for the current v4 setup.

## Methodology
- Volume is taken from Ring's v4 pool day data.
- For Few-wrapped pools, `untrackedVolumeUSD` is used when `volumeUSD` is zero.
- Fees are taken from `feesUSD` when available.
- If `feesUSD` is missing or zero, fees are estimated from the pool fee tier and effective daily volume.
- All swap fees are treated as liquidity provider revenue.
- Protocol revenue is reported as zero.

## Tests
- `pnpm test dexs ring-dex-v4`