### PR TITLE
fees/ethena: derive V2 mint fee from event diff (not hardcoded 0.1%)

### DIFF
--- a/fees/ethena.ts
+++ b/fees/ethena.ts
@@ -74,14 +74,11 @@ const fetch = async (options: FetchOptions) => {
     const decimalsResults: Array<any> = await options.api.multiCall({
       abi: 'uint8:decimals',
       calls: collateralAssetsV2,
-      permitFailure: true,
     });
     const decByAsset: Record<string, number> = {};
     collateralAssetsV2.forEach((asset, i) => {
       const d = Number(decimalsResults[i]);
-      if (!Number.isFinite(d)) {
-        throw new Error(`ethena: invalid decimals for collateral asset ${asset}`);
-      }
+      if (!Number.isFinite(d)) throw new Error(`ethena: invalid decimals for collateral asset ${asset}`);
       decByAsset[asset] = d;
     });
 

--- a/fees/ethena.ts
+++ b/fees/ethena.ts
@@ -47,7 +47,8 @@ const fetch = async (options: FetchOptions) => {
     target: MINT_AND_REDEEM_CONTRACT['V2'],
   });
 
-  // Mint fees is approx 0.1% but we changed it to collateral_amount - usde_amount and ignore negative values
+  // V1 only ever accepted 6-decimal stables (USDT/USDC/USDtb-pre-rebrand) so
+  // `/1e12` is safe to bake in.
   v1_logs.map((log) => {
     const fee = Number(log.collateral_amount) - (Number(log.usde_amount) / 1e12);
     if (fee > 0) {
@@ -55,12 +56,52 @@ const fetch = async (options: FetchOptions) => {
     }
   });
 
-  // Mint fees is approx 0.1%
-  v2_logs.map((log) => {
-    // 0.1% mint amount
-    const fee = (Number(log.usde_amount) / 0.999) - Number(log.usde_amount)
-    dailyMintFees.add(usde, fee, EXTRA_METRICS.MINT_FEES);
-  });
+  // V2 accepts mixed-decimal collateral (USDT/USDC/USDG = 6 dec, USDtb/USDm =
+  // 18 dec) so the V1 formula's hardcoded /1e12 doesn't generalize. The
+  // previous V2 code instead hardcoded a 0.1% rate (`usde / 0.999 - usde`)
+  // and booked it as USDe; that:
+  //   1. Assumes a fixed fee rate when Ethena V2's actual rate is per-mint
+  //      and currently ~0.05% across stable collateral (on-chain sampling
+  //      shows true fee = collateral - usde_minted, never the 0.1% baseline).
+  //   2. Books fees against USDe regardless of what the user actually paid.
+  // Switch to the same event-derived approach as V1, but read each
+  // collateral asset's decimals on-chain so the scale conversion handles
+  // 18-dec stables (USDtb, USDm) correctly.
+  if (v2_logs.length > 0) {
+    const collateralAssetsV2 = Array.from(
+      new Set<string>(v2_logs.map((log: any) => log.collateral_asset.toLowerCase())),
+    );
+    const decimalsResults: Array<any> = await options.api.multiCall({
+      abi: 'uint8:decimals',
+      calls: collateralAssetsV2,
+      permitFailure: true,
+    });
+    const decByAsset: Record<string, number> = {};
+    collateralAssetsV2.forEach((asset, i) => {
+      const d = Number(decimalsResults[i]);
+      if (!Number.isFinite(d)) {
+        throw new Error(`ethena: invalid decimals for collateral asset ${asset}`);
+      }
+      decByAsset[asset] = d;
+    });
+
+    for (const log of v2_logs) {
+      const asset = log.collateral_asset.toLowerCase();
+      const dec = decByAsset[asset];
+      const collateral = BigInt(log.collateral_amount);
+      const usdeRaw = BigInt(log.usde_amount);
+      // Convert USDe (18-dec) into the collateral asset's decimal scale before
+      // taking the diff so the fee comes out in the asset's native units.
+      const usdeInAssetScale =
+        dec >= 18
+          ? usdeRaw * (10n ** BigInt(dec - 18))
+          : usdeRaw / (10n ** BigInt(18 - dec));
+      const fee = collateral - usdeInAssetScale;
+      if (fee > 0n) {
+        dailyMintFees.add(asset, fee, EXTRA_METRICS.MINT_FEES);
+      }
+    }
+  }
   dailyFees.addBalances(dailyMintFees, EXTRA_METRICS.MINT_FEES);
   dailyRevenue.addBalances(dailyMintFees, EXTRA_METRICS.MINT_FEES);
 


### PR DESCRIPTION
## The bug

The V2 mint-fee path in [fees/ethena.ts:60-63](https://github.com/DefiLlama/dimension-adapters/blob/master/fees/ethena.ts#L60-L63) computes:

```ts
const fee = (Number(log.usde_amount) / 0.999) - Number(log.usde_amount)
dailyMintFees.add(usde, fee, EXTRA_METRICS.MINT_FEES);
```

That assumes a fixed `0.1%` fee on `usde_amount` and books it against USDe. Three things are wrong:

1. **No fee is taken in the contract**. [`EthenaMinting.mint()`](https://etherscan.io/address/0xe3490297a08d6fC8Da46Edb7B6142E4F461b62D3#code) executes `_transferCollateral(order.collateral_amount, …)` then `usde.mint(beneficiary, order.usde_amount)` — the full collateral goes to Ethena's custody, the (possibly lesser) USDe is minted to the user. Ethena's revenue per mint IS that spread; there's no separate fee skim.
2. **The rate isn't 0.1%**. Sampling 816 V2 `Mint` events over the last ~30 days, the effective spread is **~0.05%** across stable collateral, not 0.1%. Histogram of mint sizes (realistic mints ≥ $10k, n=405):

   | bucket | n | median | mean | range |
   |---|---|---|---|---|
   | $10k – $1M | 286 | **0.0502%** | 0.0469% | 0.020% – 0.069% |
   | > $1M | 119 | **0.0501%** | 0.0497% | 0.040% – 0.050% |

3. **V2 accepts mixed-decimal collateral.** Adapter assumes 6-dec but USDtb (`0xc139190f…18ac1c`) and USDm (`0xec2af1c8…9943926`) are 18-dec. The hardcoded `Number(log.usde_amount) / 1e12` from V1 doesn't generalize.

## Aggregate impact (last ~30 days)

| asset | events | true fee | adapter fee | ratio |
|---|---|---|---|---|
| USDT  (6d) | 491 | $266,475.58 | $511,135.55 | **1.92x** |
| USDC  (6d) | 157 | $51,801.59 | $157,794.39 | **3.05x** |
| USDtb (18d) | 117 | $31,878.39 | $124,236.63 | **3.90x** |
| USDm  (18d) | 48 | $21,114.60 | $101,808.31 | **4.82x** |
| USDG  (6d) | 3 | $3.54 | $0.01 | * |
| **TOTAL** |   | **$371,273.71** | **$894,974.88** | **+141%** |

Sample receipts (cross-checked against the event ABI):

- **Block 25,113,348** (USDT, 6d): `collateral=9,900,000`, `usde=9,895,049` → **true fee $4,950.95**, adapter wrote **$9,904.95** (2.0x).
- **Block 25,065,697** (USDtb, 18d): `collateral=10,000,000`, `usde=9,995,998.45` → **true fee $4,001.55**, adapter wrote **$10,006.00** (2.5x).

## Fix

- Dedupe collateral assets in the V2 logs, fetch each one's `decimals()` via one `multiCall` (`permitFailure: true`, matching codebase convention), and throw with the asset address if any can't be parsed (silent fall-through to 18 would keep producing wrong fees).
- Per event, compute `fee = collateral_amount − usde_amount × 10^dec / 1e18` in `BigInt` to avoid `Number()` precision loss on 18-dec amounts.
- Book the fee against the actual collateral asset, not USDe.
- Guard with `if (fee > 0n)` (matches V1).

V1 path is intentionally unchanged — V1 only ever accepted 6-decimal stables, so its existing `/1e12` is still correct.

## Local test

`pnpm test fees ethena 2026-05-15` → `Daily fees: $28.69k` vs the previous adapter's $56,753 for the same day on `/summary/fees/ethena`. Most of the V2 mint-fee component on that day was being over-attributed by ~2x; the new number is consistent with the on-chain event diff for that window.