### PR TITLE
[feat] Axiom: add BSC fees and cashback tracking

### DIFF
--- a/fees/axiom.ts
+++ b/fees/axiom.ts
@@ -1,61 +1,78 @@
 import { Dependencies, FetchOptions, SimpleAdapter } from '../adapters/types';
 import { CHAIN } from '../helpers/chains';
-import { queryDuneSql } from '../helpers/dune';
 import ADDRESSES from '../helpers/coreAssets.json';
-import { METRIC } from '../helpers/metrics';
+import { queryDuneSql } from '../helpers/dune';
 
-const REFERRAL_VAULT_PROGRAM = 'VAULTkV5rgY9WqZtvaMHvctrKMwQw8bCfSJF4nga2D4';
+const LABELS = {
+  TRADING_FEES: 'Trading Fees',
+  TRADING_FEES_TO_PROTOCOL: 'Trading Fees To Protocol',
+  REFERRAL_PAYOUTS: 'Referral Payouts',
+  CASHBACK_PAYOUTS: 'Cashback Payouts',
+} as const;
 
-const CASHBACK_WALLETS = [
-  'AxiomRXZAq1Jgjj9pHmNqVP7Lhu67wLXZJZbaK87TTSk',
-  'AxiomRYAid8ZDhS1bJUAzEaNSr69aTWB9ATfdDLfUbnc',
-];
-const FEE_WALLETS = [
-  '7LCZckF6XXGQ1hDY6HFXBKWAtiUgL9QY5vj1C4Bn1Qjj',
-  '4V65jvcDG9DSQioUVqVPiUcUY9v6sb6HKtMnsxSKEz5S',
-  'CeA3sPZfWWToFEBmw5n1Y93tnV66Vmp8LacLzsVprgxZ',
-  'AaG6of1gbj1pbDumvbSiTuJhRCRkkUNaWVxijSbWvTJW',
-  '7oi1L8U9MRu5zDz5syFahsiLUric47LzvJBQX6r827ws',
-  '9kPrgLggBJ69tx1czYAbp7fezuUmL337BsqQTKETUEhP',
-  'DKyUs1xXMDy8Z11zNsLnUg3dy9HZf6hYZidB6WodcaGy',
-  '4FobGn5ZWYquoJkxMzh2VUAWvV36xMgxQ3M7uG1pGGhd',
-  '76sxKrPtgoJHDJvxwFHqb3cAXWfRHFLe3VpKcLCAHSEf',
-  'H2cDR3EkJjtTKDQKk8SJS48du9mhsdzQhy8xJx5UMqQK',
-  '8m5GkL7nVy95G4YVUbs79z873oVKqg2afgKRmqxsiiRm',
-  '4kuG6NsAFJNwqEkac8GFDMMheCGKUPEbaRVHHyFHSwWz',
-  '8vFGAKdwpn4hk7kc1cBgfWZzpyW3MEMDATDzVZhddeQb',
-  '86Vh4XGLW2b6nvWbRyDs4ScgMXbuvRCHT7WbUT3RFxKG',
-  'DZfEurFKFtSbdWZsKSDTqpqsQgvXxmESpvRtXkAdgLwM',
-  '5L2QKqDn5ukJSWGyqR4RPvFvwnBabKWqAqMzH4heaQNB',
-  'DYVeNgXGLAhZdeLMMYnCw1nPnMxkBN7fJnNpHmizTrrF',
-  'Hbj6XdxX6eV4nfbYTseysibp4zZJtVRRPn2J3BhGRuK9',
-  '846ah7iBSu9ApuCyEhA5xpnjHHX7d4QJKetWLbwzmJZ8',
-  '5BqYhuD4q1YD3DMAYkc1FeTu9vqQVYYdfBAmkZjamyZg',
-];
 
-const REFERRAL_PAYOUT_EXCLUDED_ACCOUNTS = [
-  REFERRAL_VAULT_PROGRAM,
-  'ComputeBudget111111111111111111111111111111',
-  ...CASHBACK_WALLETS,
-  ...FEE_WALLETS,
-];
+const chainConfig = {
+  [CHAIN.SOLANA]: {
+    start: '2025-01-21',
+    referralVaultProgram: 'VAULTkV5rgY9WqZtvaMHvctrKMwQw8bCfSJF4nga2D4',
+    cashbackWallets: [
+      'AxiomRXZAq1Jgjj9pHmNqVP7Lhu67wLXZJZbaK87TTSk',
+      'AxiomRYAid8ZDhS1bJUAzEaNSr69aTWB9ATfdDLfUbnc',
+    ],
+    feeWallets: [
+      '7LCZckF6XXGQ1hDY6HFXBKWAtiUgL9QY5vj1C4Bn1Qjj',
+      '4V65jvcDG9DSQioUVqVPiUcUY9v6sb6HKtMnsxSKEz5S',
+      'CeA3sPZfWWToFEBmw5n1Y93tnV66Vmp8LacLzsVprgxZ',
+      'AaG6of1gbj1pbDumvbSiTuJhRCRkkUNaWVxijSbWvTJW',
+      '7oi1L8U9MRu5zDz5syFahsiLUric47LzvJBQX6r827ws',
+      '9kPrgLggBJ69tx1czYAbp7fezuUmL337BsqQTKETUEhP',
+      'DKyUs1xXMDy8Z11zNsLnUg3dy9HZf6hYZidB6WodcaGy',
+      '4FobGn5ZWYquoJkxMzh2VUAWvV36xMgxQ3M7uG1pGGhd',
+      '76sxKrPtgoJHDJvxwFHqb3cAXWfRHFLe3VpKcLCAHSEf',
+      'H2cDR3EkJjtTKDQKk8SJS48du9mhsdzQhy8xJx5UMqQK',
+      '8m5GkL7nVy95G4YVUbs79z873oVKqg2afgKRmqxsiiRm',
+      '4kuG6NsAFJNwqEkac8GFDMMheCGKUPEbaRVHHyFHSwWz',
+      '8vFGAKdwpn4hk7kc1cBgfWZzpyW3MEMDATDzVZhddeQb',
+      '86Vh4XGLW2b6nvWbRyDs4ScgMXbuvRCHT7WbUT3RFxKG',
+      'DZfEurFKFtSbdWZsKSDTqpqsQgvXxmESpvRtXkAdgLwM',
+      '5L2QKqDn5ukJSWGyqR4RPvFvwnBabKWqAqMzH4heaQNB',
+      'DYVeNgXGLAhZdeLMMYnCw1nPnMxkBN7fJnNpHmizTrrF',
+      'Hbj6XdxX6eV4nfbYTseysibp4zZJtVRRPn2J3BhGRuK9',
+      '846ah7iBSu9ApuCyEhA5xpnjHHX7d4QJKetWLbwzmJZ8',
+      '5BqYhuD4q1YD3DMAYkc1FeTu9vqQVYYdfBAmkZjamyZg',
+    ],
+  },
+  [CHAIN.BSC]: {
+    start: '2026-01-25',
+    tradeContract: '0x325098a6291a412bba7a52531ef05ac5dd7d5d6e',
+    feeReceiver: '0xdec29d79e8cdf009d2fa33e0558cb5648481cac3',
+    supplySideExcludedReceiver: '0x43d2a6763fcdb002328c2754a2bad82ec24b35fc',
+  },
+} as const;
 
-const CASHBACK_PAYOUT_EXCLUDED_ACCOUNTS = [
-  REFERRAL_VAULT_PROGRAM,
-  'ComputeBudget111111111111111111111111111111',
-  ...CASHBACK_WALLETS,
-  ...FEE_WALLETS,
-];
+const formatAddresses = (addresses: readonly string[]) => addresses.map((address) => `'${address}'`).join(', ');
+const containsAnyAccount = (addresses: readonly string[]) => addresses.map((address) => `CONTAINS(account_keys, '${address}')`).join(' OR ');
 
-const formatAddresses = (addresses: string[]) => addresses.map(address => `'${address}'`).join(', ');
-const containsAnyAccount = (addresses: string[]) => addresses.map(address => `CONTAINS(account_keys, '${address}')`).join(' OR ');
+async function fetchSolana(options: FetchOptions) {
+  const solanaConfig = chainConfig[CHAIN.SOLANA];
+  const REFERRAL_PAYOUT_EXCLUDED_ACCOUNTS = [
+    solanaConfig.referralVaultProgram,
+    'ComputeBudget111111111111111111111111111111',
+    ...solanaConfig.cashbackWallets,
+    ...solanaConfig.feeWallets,
+  ];
 
-// https://dune.com/adam_tehc/axiom
-const fetch: any = async (_a: any, _b: any, options: FetchOptions) => {
-  const formattedFeeWallets = formatAddresses(FEE_WALLETS);
+  const CASHBACK_PAYOUT_EXCLUDED_ACCOUNTS = [
+    solanaConfig.referralVaultProgram,
+    'ComputeBudget111111111111111111111111111111',
+    ...solanaConfig.cashbackWallets,
+    ...solanaConfig.feeWallets,
+  ];
+
+  const formattedFeeWallets = formatAddresses(solanaConfig.feeWallets);
   const formattedReferralPayoutExcludedAccounts = formatAddresses(REFERRAL_PAYOUT_EXCLUDED_ACCOUNTS);
   const formattedCashbackPayoutExcludedAccounts = formatAddresses(CASHBACK_PAYOUT_EXCLUDED_ACCOUNTS);
-  const cashbackWalletFilter = containsAnyAccount(CASHBACK_WALLETS);
+  const cashbackWalletFilter = containsAnyAccount(solanaConfig.cashbackWallets);
 
   const query = `WITH
     allFeePayments AS (
@@ -96,7 +113,7 @@ const fetch: any = async (_a: any, _b: any, options: FetchOptions) => {
       WHERE block_date BETWEEN date(from_unixtime(${options.startTimestamp})) AND date(from_unixtime(${options.endTimestamp}))
         AND TIME_RANGE
         AND success = true
-        AND CONTAINS(account_keys, '${REFERRAL_VAULT_PROGRAM}')
+        AND CONTAINS(account_keys, '${solanaConfig.referralVaultProgram}')
     ),
     cashback_payout_txs AS (
       SELECT
@@ -109,7 +126,7 @@ const fetch: any = async (_a: any, _b: any, options: FetchOptions) => {
         AND TIME_RANGE
         AND success = true
         AND (${cashbackWalletFilter})
-        AND NOT CONTAINS(account_keys, '${REFERRAL_VAULT_PROGRAM}')
+        AND NOT CONTAINS(account_keys, '${solanaConfig.referralVaultProgram}')
     ),
     referral_payouts AS (
       SELECT
@@ -133,18 +150,17 @@ const fetch: any = async (_a: any, _b: any, options: FetchOptions) => {
       (SELECT payout_lamports FROM cashback_payouts) AS cashback_payout_lamports
   `;
   const result = await queryDuneSql(options, query);
-
   const dailyFees = options.createBalances();
   const dailyRevenue = options.createBalances();
-  dailyFees.add(ADDRESSES.solana.SOL, result[0].fee, METRIC.TRADING_FEES);
+  dailyFees.add(ADDRESSES.solana.SOL, result[0].fee, LABELS.TRADING_FEES);
 
-  dailyRevenue.add(ADDRESSES.solana.SOL, result[0].fee, 'Trading Fees to protocol');
+  dailyRevenue.add(ADDRESSES.solana.SOL, result[0].fee, LABELS.TRADING_FEES_TO_PROTOCOL);
 
   const dailyReferralPayouts = options.createBalances();
-  dailyReferralPayouts.add(ADDRESSES.solana.SOL, result[0].referral_payout_lamports, 'Referral Payouts');
+  dailyReferralPayouts.add(ADDRESSES.solana.SOL, result[0].referral_payout_lamports, LABELS.REFERRAL_PAYOUTS);
 
   const dailyCashbackPayouts = options.createBalances();
-  dailyCashbackPayouts.add(ADDRESSES.solana.SOL, result[0].cashback_payout_lamports, 'Cashback Payouts');
+  dailyCashbackPayouts.add(ADDRESSES.solana.SOL, result[0].cashback_payout_lamports, LABELS.CASHBACK_PAYOUTS);
 
   const dailySupplySideRevenue = options.createBalances();
   dailySupplySideRevenue.addBalances(dailyReferralPayouts);
@@ -153,40 +169,89 @@ const fetch: any = async (_a: any, _b: any, options: FetchOptions) => {
   dailyFees.addBalances(dailyReferralPayouts);
   dailyFees.addBalances(dailyCashbackPayouts);
 
-  return { dailyFees, dailyUserFees: dailyFees, dailyRevenue, dailyProtocolRevenue: dailyRevenue, dailySupplySideRevenue }
-};
+  return { dailyFees, dailyRevenue, dailyProtocolRevenue: dailyRevenue, dailySupplySideRevenue }
+}
+
+
+async function fetchBsc(options: FetchOptions) {
+  const bscConfig = chainConfig[CHAIN.BSC];
+  const dailyFees = options.createBalances();
+  const dailySupplySideRevenue = options.createBalances();
+  const dailyRevenue = options.createBalances();
+
+  const [{ fees_amount, supply_side_amount }] = await queryDuneSql(options, `
+    SELECT
+      COALESCE(SUM(CASE
+        WHEN "from" = ${bscConfig.tradeContract}
+         AND "to" = ${bscConfig.feeReceiver}
+        THEN value
+        ELSE 0
+      END), 0) AS fees_amount,
+      COALESCE(SUM(CASE
+        WHEN "from" = ${bscConfig.feeReceiver}
+         AND "to" <> ${bscConfig.supplySideExcludedReceiver}
+        THEN value
+        ELSE 0
+      END), 0) AS supply_side_amount
+    FROM bnb.traces
+    WHERE block_time >= from_unixtime(${options.startTimestamp})
+      AND block_time < from_unixtime(${options.endTimestamp})
+      AND success = true
+      AND value > 0
+      AND (
+        ("from" = ${bscConfig.tradeContract} AND "to" = ${bscConfig.feeReceiver})
+        OR
+        ("from" = ${bscConfig.feeReceiver} AND "to" <> ${bscConfig.supplySideExcludedReceiver})
+      )
+  `);
+
+  dailyFees.addGasToken(fees_amount, LABELS.TRADING_FEES);
+  dailySupplySideRevenue.addGasToken(supply_side_amount, LABELS.CASHBACK_PAYOUTS);
+  dailyRevenue.addGasToken((BigInt(fees_amount) - BigInt(supply_side_amount)).toString(), LABELS.TRADING_FEES_TO_PROTOCOL);
+
+  return {
+    dailyFees,
+    dailyRevenue,
+    dailyProtocolRevenue: dailyRevenue,
+    dailySupplySideRevenue,
+  };
+}
+
+const fetch: any = async (_a: any, _b: any, options: FetchOptions) => {
+  if (options.chain === CHAIN.SOLANA) return fetchSolana(options);
+  return fetchBsc(options);
+}
 
 
 const adapter: SimpleAdapter = {
   version: 1,
-  fetch,
-  chains: [CHAIN.SOLANA],
   dependencies: [Dependencies.DUNE],
-  start: '2025-01-21',
+  allowNegativeValue: true, //claims may happen at later date
+  fetch,
   methodology: {
-    Fees: 'Gross Axiom trading fees paid by users plus claimed referral and cashback payouts not captured by Axiom fee wallets.',
-    Revenue: 'Trading fees going to the protocol after deducting referral and cashback payouts.',
-    UserFees: 'Gross Axiom trading fees paid by users plus claimed referral and cashback payouts not captured by Axiom fee wallets.',
-    ProtocolRevenue: 'Trading fees going to the protocol after deducting referral and cashback payouts.',
-    SupplySideRevenue: 'Claimed SOL referral payouts sent to users from Axiom referral vaults and cashback payouts sent to users from Axiom cashback wallets.',
+    Fees: 'Gross Axiom trading fees paid by users plus claimed referral and cashback payouts',
+    Revenue: 'Revenue is fees retained by Axiom after deducting referral and cashback payouts.',
+    ProtocolRevenue: 'Protocol revenue is the portion of fees retained by Axiom after deducting referral and cashback payouts.',
+    SupplySideRevenue: 'Claimed SOL cashback/referral payouts from Axiom cashback wallets, plus native BNB cashback/referral payouts sent out from the BNB Chain fee receiver.',
   },
   breakdownMethodology: {
     Fees: {
-      [METRIC.TRADING_FEES]: 'Fee paid by users on each trade routed through Axiom (0.75%-1%)',
-      'Referral Payouts': 'Claimed SOL referral payouts from Axiom referral vaults.',
-      'Cashback Payouts': 'Claimed SOL cashback payouts from Axiom cashback wallets.',
+      [LABELS.TRADING_FEES]: 'Trading fees paid by Axiom users. On Solana these are matched from fee-wallet trade payments, and on BNB Chain these are native BNB transfers from the trade contract to the fee receiver.',
+      [LABELS.REFERRAL_PAYOUTS]: 'Claimed SOL referral payouts from Axiom referral vaults.',
+      [LABELS.CASHBACK_PAYOUTS]: 'Claimed SOL cashback payouts from Axiom cashback wallets, plus native BNB cashback/referral payouts sent out from the BNB Chain fee receiver.',
     },
     Revenue: {
-      ['Trading Fees to protocol']: 'Trading fees going to the protocol after deducting referral and cashback payouts.',
+      [LABELS.TRADING_FEES_TO_PROTOCOL]: 'Trading fees going to the protocol after deducting referral and cashback payouts.',
     },
     ProtocolRevenue: {
-      ['Trading Fees to protocol']: 'Trading fees going to the protocol after deducting referral and cashback payouts.',
+      [LABELS.TRADING_FEES_TO_PROTOCOL]: 'Trading fees going to the protocol after deducting referral and cashback payouts.',
     },
     SupplySideRevenue: {
-      'Referral Payouts': 'Claimed SOL referral payouts sent to users from Axiom referral vaults.',
-      'Cashback Payouts': 'Claimed SOL cashback payouts sent to users from Axiom cashback wallets.',
+      [LABELS.REFERRAL_PAYOUTS]: 'Claimed SOL referral payouts sent to users from Axiom referral vaults.',
+      [LABELS.CASHBACK_PAYOUTS]: 'Claimed SOL cashback payouts from Axiom cashback wallets, plus native BNB cashback/referral payouts sent out from the BNB Chain fee receiver.',
     },
   },
+  adapter: chainConfig,
   isExpensiveAdapter: true,
 };
 

--- a/fees/axiom.ts
+++ b/fees/axiom.ts
@@ -5,7 +5,7 @@ import { queryDuneSql } from '../helpers/dune';
 
 const LABELS = {
   TRADING_FEES: 'Trading Fees',
-  TRADING_FEES_TO_PROTOCOL: 'Trading Fees To Protocol',
+  TRADING_FEES_TO_PROTOCOL: 'Trading Fees to protocol',
   REFERRAL_PAYOUTS: 'Referral Payouts',
   CASHBACK_PAYOUTS: 'Cashback Payouts',
 } as const;


### PR DESCRIPTION
## Summary
- Adds BSC fee and revenue support to `fees/axiom.ts`.
- Tracks native BNB fee inflows from the Axiom trade contract to the fee receiver and treats fee-receiver outflows as cashback/referral supply-side payouts.
- Excludes transfers from the BSC fee receiver to `0x43d2a6763fCDB002328c2754a2baD82eC24B35fc` from supply-side revenue.

## Changes
- Extended the Axiom fees adapter to support BSC in addition to the existing Solana logic.
- Added BSC chain config for the trade contract, fee receiver, excluded receiver, and start date in `fees/axiom.ts`.
- Implemented BSC daily aggregation using `bnb.traces` via Dune:
  - `dailyFees`: native BNB sent from `0x325098a6291A412bba7a52531eF05ac5DD7d5d6E` to `0xdeC29d79E8CdF009d2fA33e0558CB5648481CAC3`
  - `dailySupplySideRevenue`: native BNB sent out from `0xdeC29d79E8CdF009d2fA33e0558CB5648481CAC3`, excluding transfers to `0x43d2a6763fCDB002328c2754a2baD82eC24B35fc`
  - `dailyRevenue` / `dailyProtocolRevenue`: `dailyFees - dailySupplySideRevenue`
- Enabled `allowNegativeValue: true` to support days where BSC payouts exceed same-day fee inflows.

## Methodology
- BSC-only: counts native BNB transfers only.
- Revenue is reported net of cashback/referral payout outflows from the fee receiver.
- Transfers from the fee receiver to the excluded BSC address are ignored and not counted as supply-side revenue.
