### PR TITLE
[fix] Beezie: undefined adddress bug (onlyArgs: false)

### DIFF
--- a/fees/beezie.ts
+++ b/fees/beezie.ts
@@ -104,6 +104,7 @@ const fetchClawFees = async (options: FetchOptions, clawMachines: string[], vers
     const logs = await options.getLogs({
       targets: validMachines,
       eventAbi: clawMachineV2Abi.played,
+      onlyArgs:false,
     });
 
     for (const log of logs) {
@@ -111,13 +112,14 @@ const fetchClawFees = async (options: FetchOptions, clawMachines: string[], vers
       const token = machineToToken.get(machine);
       if (!token) continue;
 
-      dailyFees.add(token, BigInt(log.amount.toString()) * 500n / 10_000n, "Claw Machine Fees");
+      dailyFees.add(token, BigInt(log.args.amount.toString()) * 500n / 10_000n, "Claw Machine Fees");
     }
   } else {
     // V1: Played(user, amount, commission) — commission goes to protocol
     const logs = await options.getLogs({
       targets: validMachines,
       eventAbi: clawMachineV1Abi.played,
+      onlyArgs: false,
     });
 
     for (const log of logs) {
@@ -125,7 +127,7 @@ const fetchClawFees = async (options: FetchOptions, clawMachines: string[], vers
       const token = machineToToken.get(machine);
       if (!token) continue;
 
-      dailyFees.add(token, log.commission, "Claw Machine Fees");
+      dailyFees.add(token, log.args.commission, "Claw Machine Fees");
     }
   }
 


### PR DESCRIPTION
## Results with only args true 
<img width="819" height="189" alt="Screenshot 2026-05-18 at 1 34 08 PM" src="https://github.com/user-attachments/assets/bda1f2ab-5df6-4c95-a495-bd88fe27adcf" />

## Result with only args false 
<img width="819" height="203" alt="Screenshot 2026-05-18 at 1 35 43 PM" src="https://github.com/user-attachments/assets/404ec690-d181-4393-b0ca-168057caaade" />

@noateden keeping onlyArgs true will undercount the fees as the addresses will be undefined hence the loop skips the claw machines 