### PR TITLE
fix(pika-protocol-v4): correct fee split to 50/50 vault/protocol

### DIFF
--- a/dexs/pika-protocol-v4/index.ts
+++ b/dexs/pika-protocol-v4/index.ts
@@ -29,27 +29,25 @@ const fetch = async (options: FetchOptions) => {
     dailyFees.addUSDValue(Number(log.fee) / 1e8);
   }
 
-  // Fee split sources:
-  //   - 50% vault (LPs) / 50% protocol: https://docs.pikaprotocol.com/features
-  //   - 30% of total fees to PIKA stakers: https://docs.pikaprotocol.com/reward-program
-  //   → remaining 20% goes to protocol treasury (50% protocol share − 30% stakers)
+  // Fee split: _updatePendingRewards splits reward * ratio / 1e4 per bucket.
+  // Contract source: https://sourcify.dev/server/repository/contracts/full_match/10/0x8c9b6a4a4e61f4635e8e375e05ff98db5516d25e/sources/contracts/perp/PikaPerpV4.sol
+  // Current on-chain values: protocolRewardRatio=5000, pikaRewardRatio=0 (PIKA staking disabled).
+  // → 50% to vault (LPs), 50% to protocol treasury, 0% to PIKA stakers.
   return {
     dailyVolume,
     dailyFees,
     dailyRevenue: dailyFees.clone(0.5),
     dailySupplySideRevenue: dailyFees.clone(0.5),
-    dailyHoldersRevenue: dailyFees.clone(0.3),
-    dailyProtocolRevenue: dailyFees.clone(0.2),
+    dailyProtocolRevenue: dailyFees.clone(0.5),
   };
 };
 
 const methodology = {
   Volume: "Notional volume of positions opened and closed (margin * leverage).",
   Fees: "Trading fees paid by traders on opening and closing positions.",
-  Revenue: "Fees retained by the protocol after the LP/vault share (50% of fees).",
+  Revenue: "50% of trading fees retained by the protocol (protocolRewardRatio=5000/10000).",
   SupplySideRevenue: "50% of trading fees distributed to the vault (liquidity providers).",
-  HoldersRevenue: "30% of trading fees distributed to PIKA token stakers.",
-  ProtocolRevenue: "20% of trading fees sent to the protocol treasury.",
+  ProtocolRevenue: "50% of trading fees sent to the protocol treasury.",
 };
 
 const adapter: SimpleAdapter = {

--- a/dexs/pika-protocol-v4/index.ts
+++ b/dexs/pika-protocol-v4/index.ts
@@ -1,11 +1,21 @@
 import { FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 
-const PIKA_PERP = "0x8c9b6a4a4e61f4635e8e375e05ff98db5516d25e";
+//https://pikaprotocol.medium.com/important-update-for-pika-token-0db98f47558a
+const PIKA_TOKEN_SUNSET_DATE = "2023-11-12";
+const NEW_CONTRACT_DEPLOY_TIME = 1706358483; //2024-01-27
+
+const PIKA_PERP_OLD = "0x9b86B2Be8eDB2958089E522Fe0eB7dD5935975AB";
+const PIKA_PERP_NEW = "0x8c9b6a4a4e61f4635e8e375e05ff98db5516d25e";
 
 const fetch = async (options: FetchOptions) => {
   const dailyVolume = options.createBalances();
   const dailyFees = options.createBalances();
+
+  const PIKA_PERP = options.fromTimestamp >= NEW_CONTRACT_DEPLOY_TIME ? PIKA_PERP_NEW : PIKA_PERP_OLD;
+
+  const holdersRevenueRatio = options.dateString >= PIKA_TOKEN_SUNSET_DATE ? 0 : 0.3;
+  const protocolRevenueRatio = 0.5 - holdersRevenueRatio;
 
   const [newPositionLogs, closePositionLogs] = await Promise.all([
     options.getLogs({
@@ -29,25 +39,27 @@ const fetch = async (options: FetchOptions) => {
     dailyFees.addUSDValue(Number(log.fee) / 1e8);
   }
 
-  // Fee split: _updatePendingRewards splits reward * ratio / 1e4 per bucket.
-  // Contract source: https://sourcify.dev/server/repository/contracts/full_match/10/0x8c9b6a4a4e61f4635e8e375e05ff98db5516d25e/sources/contracts/perp/PikaPerpV4.sol
-  // Current on-chain values: protocolRewardRatio=5000, pikaRewardRatio=0 (PIKA staking disabled).
-  // → 50% to vault (LPs), 50% to protocol treasury, 0% to PIKA stakers.
+  // Fee split sources:
+  //   - 50% vault (LPs) / 50% protocol: https://docs.pikaprotocol.com/features
+  //   - 30% of total fees to PIKA stakers: https://docs.pikaprotocol.com/reward-program
+  //   → remaining 20% goes to protocol treasury (50% protocol share − 30% stakers)
   return {
     dailyVolume,
     dailyFees,
     dailyRevenue: dailyFees.clone(0.5),
     dailySupplySideRevenue: dailyFees.clone(0.5),
-    dailyProtocolRevenue: dailyFees.clone(0.5),
+    dailyHoldersRevenue: dailyFees.clone(holdersRevenueRatio),
+    dailyProtocolRevenue: dailyFees.clone(protocolRevenueRatio),
   };
 };
 
 const methodology = {
   Volume: "Notional volume of positions opened and closed (margin * leverage).",
   Fees: "Trading fees paid by traders on opening and closing positions.",
-  Revenue: "50% of trading fees retained by the protocol (protocolRewardRatio=5000/10000).",
+  Revenue: "Fees retained by the protocol after the LP/vault share (50% of fees).",
   SupplySideRevenue: "50% of trading fees distributed to the vault (liquidity providers).",
-  ProtocolRevenue: "50% of trading fees sent to the protocol treasury.",
+  HoldersRevenue: "30% of trading fees distributed to PIKA token stakers.",
+  ProtocolRevenue: "20% of trading fees sent to the protocol treasury.",
 };
 
 const adapter: SimpleAdapter = {


### PR DESCRIPTION
Follows up on #7029. The previously merged split (50/30/20) was based on the original docs, but the live contract has pikaRewardRatio=0 and protocolRewardRatio=5000 — PIKA staking was disabled when the token was retired. https://docs.pikaprotocol.com/pika-token

Actual split: 50% vault (LPs) / 50% protocol treasury.

Verified via:

cast call on 0x8c9b6a4a4e61f4635e8e375e05ff98db5516d25e (Optimism)
_updatePendingRewards in contract source: https://sourcify.dev/server/repository/contracts/full_match/10/0x8c9b6a4a4e61f4635e8e375e05ff98db5516d25e/sources/contracts/perp/PikaPerpV4.sol