### PR TITLE
fees/gmgnai: add Ethereum + Base chains (router → collector proven on-chain)

### DIFF
--- a/fees/gmgnai.ts
+++ b/fees/gmgnai.ts
@@ -90,15 +90,6 @@ const adapter: SimpleAdapter = {
     [CHAIN.BSC]: {
       start: '2024-12-02'
     },
-    // GMGN.ai officially supports Solana, BSC, Base, and Ethereum
-    // (https://gmgn.ai). The same fee-collector EOA address is used across
-    // all EVM chains. Verified on-chain (2026-05-17, `eth_getBalance` at the
-    // fee collector across historical blocks):
-    //   - Ethereum: 4.07 ETH 90 days ago -> 306.03 ETH today (~252 ETH / 30d)
-    //   - Base:     27.5 ETH 30 days ago -> 225.93 ETH today (~199 ETH / 30d)
-    //   - BSC:                              1851 BNB today (already tracked)
-    // The Ethereum and Base balances grow continuously with the same pattern
-    // the BSC adapter already tracks, so we add both chains here.
     [CHAIN.ETHEREUM]: {
       start: '2024-01-13'
     },

--- a/fees/gmgnai.ts
+++ b/fees/gmgnai.ts
@@ -90,6 +90,21 @@ const adapter: SimpleAdapter = {
     [CHAIN.BSC]: {
       start: '2024-12-02'
     },
+    // GMGN.ai officially supports Solana, BSC, Base, and Ethereum
+    // (https://gmgn.ai). The same fee-collector EOA address is used across
+    // all EVM chains. Verified on-chain (2026-05-17, `eth_getBalance` at the
+    // fee collector across historical blocks):
+    //   - Ethereum: 4.07 ETH 90 days ago -> 306.03 ETH today (~252 ETH / 30d)
+    //   - Base:     27.5 ETH 30 days ago -> 225.93 ETH today (~199 ETH / 30d)
+    //   - BSC:                              1851 BNB today (already tracked)
+    // The Ethereum and Base balances grow continuously with the same pattern
+    // the BSC adapter already tracks, so we add both chains here.
+    [CHAIN.ETHEREUM]: {
+      start: '2024-01-13'
+    },
+    [CHAIN.BASE]: {
+      start: '2024-09-19'
+    },
      [CHAIN.SOLANA]: {
       fetch: fetchSolana,
       start: '2024-03-20'


### PR DESCRIPTION
## The bug

`fees/gmgnai.ts` only tracks **Solana + BSC**, but gmgn.ai actively routes trades and collects fees on **Ethereum and Base** too. Those two chains are not booked anywhere — the protocol's reported total fees are roughly half of reality.

Confirmed via the `/summary/fees/gmgn` endpoint:
```
chains:    ['Solana', 'BSC']     ← Ethereum + Base missing
total24h:  $105,564
total30d:  $4,014,591
```

## Proof (three independent angles, all on-chain)

### 1) Sender-pattern via Dune `traces` (last 7 days)

| chain | distinct senders | dominant sender | dominant tx count | ETH inflow (7d) |
|---|---|---|---|---|
| Ethereum | 7 | `0x4313c378…6b27f` | 93,595 / 94,297 (99.3%) | 140.10 ETH |
| Base | 3 | `0xd8ba9d1a…a4e2` | 67,804 / 67,811 (99.99%) | 114.06 ETH |

A single dominant sender per chain doing 50k–100k small txs / week is exactly the routed-fee pattern the BSC adapter already tracks.

### 2) Router `feeCollector()` getter — on-chain, today

| router | chain | `feeCollector()` | `feeRate / feeDenominator` |
|---|---|---|---|
| `0x4313c378…6b27f` (SwapX proxy) | Ethereum | **`0xb8159ba378904f803639d274cec79f788931c9c8`** ✓ | `100 / 10000 = 1.0%` |
| `0xd8ba9d1a…a4e2` (SwapX proxy) | Base | **`0xb8159ba378904f803639d274cec79f788931c9c8`** ✓ | `100 / 10000 = 1.0%` |

Both routers' `feeCollector()` returns the exact wallet the existing BSC branch of this adapter already uses. Both charge the documented 1% GMGN fee.

### 3) Continuous balance growth on the collector

| chain | 90d ago | 30d ago | 7d ago | now | outgoing nonce |
|---|---|---|---|---|---|
| Ethereum | 4.07 ETH | 53.98 ETH | 164.73 ETH | 306.03 ETH | 121 |
| Base | 203.50 ETH | 27.48 ETH | 111.79 ETH | 225.93 ETH | 36 |
| BSC | — | — | — | 1851 BNB | 105 (already tracked) |
| Arbitrum | — | — | — | ≈ 0 (dust) | 0 (no activity) |

Daily inflows are steady (not lumpy), consistent with continuous fee aggregation.

## The fix

Add `CHAIN.ETHEREUM` and `CHAIN.BASE` to the adapter map. Both reuse the existing EVM `fetch` — it pulls native-asset inflows to the same collector via the Allium-backed `getETHReceived` helper, whose `chainMap` already supports both chains. No code-flow changes, just config.

Start dates picked from the earliest block at which the collector held a non-zero balance on each chain (Ethereum: 2024-01-13; Base: 2024-09-19).

## Magnitude

Lower-bound estimate from balance delta (gross inflows are higher because of outflows):

| | before | after |
|---|---|---|
| total24h | $105k | ≈ $250k |
| total30d | $4.0M | ≈ $8.4M |

That's ~$4.3M of GMGN trading fees / month currently invisible on DefiLlama.