### PR TITLE
[fix] Aegis-yusd: allow negative value for erc4626 vault

### DIFF
--- a/fees/aegis-yusd/index.ts
+++ b/fees/aegis-yusd/index.ts
@@ -96,6 +96,7 @@ const fetch = async (options: FetchOptions) => {
 const adapter: SimpleAdapter = {
   version: 2,
   pullHourly: true,
+  allowNegativeValue: true,
   adapter: chainConfig,
   fetch,
   methodology: {


### PR DESCRIPTION
@bheluga Added allow negative value for yusd too as its a erc4626 vault and can accure negative yields.