### PR TITLE
Add Clutch Anvil AMM volume + fees adapter

### DIFF
--- a/dexs/clutch-anvil/index.ts
+++ b/dexs/clutch-anvil/index.ts
@@ -1,0 +1,149 @@
+import { FetchOptions, FetchResult, SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import { addOneToken } from "../../helpers/prices";
+
+// Clutch Anvil AMM — permissionless NFT AMM. Each market deploys an
+// `NFTAMMVault` that swaps an ERC20 token (paired 1:N to a specific NFT
+// collection) against NFT inventory. Buys/sells emit:
+//
+//   event NFTSold(
+//     address indexed seller, uint256 indexed tokenId,
+//     uint256 grossPayout, uint256 netPayout,
+//     uint256 protocolFee, uint256 stakerFee
+//   )
+//   event NFTBought(
+//     address indexed buyer, uint256 indexed tokenId,
+//     uint256 totalCost, uint256 baseCost,
+//     uint256 protocolFee, uint256 stakerFee, bool isSpecific
+//   )
+//
+// Volume = sum of `totalCost` (buys) + `grossPayout` (sells), denominated
+// in each market's own ERC20 token. DefiLlama prices the tokens into USD.
+//
+// Fees = sum of `protocolFee + stakerFee` from both events. Protocol fee is
+// burned (deflationary on the token), staker fee streams to the staking
+// vault as rewards. We expose the full fee tranche as protocol revenue.
+
+const FACTORY_BY_CHAIN: Record<string, { factory: string; fromBlock: number }> = {
+  [CHAIN.ETHEREUM]: {
+    factory: "0xEA095646EC6A56EDbFEe84cCcf23eFCec12566A0",
+    fromBlock: 24720104,
+  },
+  [CHAIN.BASE]: {
+    factory: "0x5ef900789a0faa1fDE3e9796441B62b66f0ab2Aa",
+    fromBlock: 45593260,
+  },
+  [CHAIN.APECHAIN]: {
+    factory: "0x87B62309B6fF4FA184C89919351bEbd3AC11Fc84",
+    fromBlock: 34900822,
+  },
+};
+
+const MARKET_CREATED_ABI =
+  "event MarketCreated(uint256 indexed marketId, address indexed collection, address indexed token, address escrow, address ammVault, address loanVault, address stakingVault, address governor, bool governanceEnabled)";
+
+const NFT_BOUGHT_ABI =
+  "event NFTBought(address indexed buyer, uint256 indexed tokenId, uint256 totalCost, uint256 baseCost, uint256 protocolFee, uint256 stakerFee, bool isSpecific)";
+
+const NFT_SOLD_ABI =
+  "event NFTSold(address indexed seller, uint256 indexed tokenId, uint256 grossPayout, uint256 netPayout, uint256 protocolFee, uint256 stakerFee)";
+
+const fetch = async (options: FetchOptions): Promise<FetchResult> => {
+  const { chain, createBalances, getLogs } = options;
+  const { factory, fromBlock } = FACTORY_BY_CHAIN[chain];
+
+  const dailyVolume = createBalances();
+  const dailyFees = createBalances();
+
+  const markets = await getLogs({
+    target: factory,
+    fromBlock,
+    eventAbi: MARKET_CREATED_ABI,
+    onlyArgs: true,
+    cacheInCloud: true,
+  });
+
+  const ammByToken = new Map<string, string>();
+  markets.forEach((m: any) => {
+    if (!m?.ammVault || !m?.token) return;
+    ammByToken.set(m.ammVault.toLowerCase(), m.token.toLowerCase());
+  });
+
+  const ammVaults = Array.from(ammByToken.keys());
+  if (ammVaults.length === 0) {
+    return { dailyVolume, dailyFees, dailyRevenue: dailyFees };
+  }
+
+  const [buyLogs, sellLogs] = await Promise.all([
+    getLogs({
+      targets: ammVaults,
+      eventAbi: NFT_BOUGHT_ABI,
+      flatten: true,
+      entireLog: true,
+    }),
+    getLogs({
+      targets: ammVaults,
+      eventAbi: NFT_SOLD_ABI,
+      flatten: true,
+      entireLog: true,
+    }),
+  ]);
+
+  for (const log of buyLogs) {
+    const vault = (log.address || log.source || "").toLowerCase();
+    const token = ammByToken.get(vault);
+    if (!token) continue;
+    const totalCost = BigInt(log.args?.totalCost ?? log.totalCost ?? 0);
+    const protocolFee = BigInt(log.args?.protocolFee ?? log.protocolFee ?? 0);
+    const stakerFee = BigInt(log.args?.stakerFee ?? log.stakerFee ?? 0);
+    dailyVolume.add(token, totalCost.toString());
+    dailyFees.add(token, (protocolFee + stakerFee).toString());
+  }
+
+  for (const log of sellLogs) {
+    const vault = (log.address || log.source || "").toLowerCase();
+    const token = ammByToken.get(vault);
+    if (!token) continue;
+    const grossPayout = BigInt(log.args?.grossPayout ?? log.grossPayout ?? 0);
+    const protocolFee = BigInt(log.args?.protocolFee ?? log.protocolFee ?? 0);
+    const stakerFee = BigInt(log.args?.stakerFee ?? log.stakerFee ?? 0);
+    dailyVolume.add(token, grossPayout.toString());
+    dailyFees.add(token, (protocolFee + stakerFee).toString());
+  }
+
+  return {
+    dailyVolume,
+    dailyFees,
+    dailyRevenue: dailyFees,
+  };
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  adapter: {
+    [CHAIN.ETHEREUM]: {
+      fetch,
+      start: "2026-03-23",
+      meta: {
+        methodology: {
+          Volume:
+            "Sum of buy totalCost and sell grossPayout from NFTBought + NFTSold events across every AMM vault deployed by the Clutch Anvil factory.",
+          Fees:
+            "Sum of protocolFee + stakerFee fields from NFTBought + NFTSold events. Protocol fee is burned; staker fee streams to the NFT staking vault as rewards.",
+          Revenue:
+            "Equal to Fees — the entire fee tranche is returned to the protocol (burn) or to NFT stakers.",
+        },
+      },
+    },
+    [CHAIN.BASE]: {
+      fetch,
+      start: "2026-04-01",
+    },
+    [CHAIN.APECHAIN]: {
+      fetch,
+      start: "2026-02-15",
+    },
+  },
+};
+
+export default adapter;

--- a/dexs/clutch-anvil/index.ts
+++ b/dexs/clutch-anvil/index.ts
@@ -1,5 +1,6 @@
 import { FetchOptions, FetchResult, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
+import { METRIC } from "../../helpers/metrics";
 
 // Clutch Anvil AMM — permissionless NFT AMM. Each market deploys an
 // `NFTAMMVault` that swaps an ERC20 token (paired 1:N to a specific NFT
@@ -55,7 +56,8 @@ const fetch = async (options: FetchOptions): Promise<FetchResult> => {
   const { factory, fromBlock } = chainsConfig[chain];
 
   const dailyVolume = createBalances();
-  const dailyFees = createBalances();  
+  const dailyFees = createBalances();
+  const dailySupplySideRevenue = createBalances();  
 
   const markets = await getLogs({
     target: factory,
@@ -72,7 +74,7 @@ const fetch = async (options: FetchOptions): Promise<FetchResult> => {
 
   const ammVaults = Array.from(ammByToken.keys());
   if (ammVaults.length === 0) {
-    return { dailyVolume, dailyFees, dailyRevenue: dailyFees };
+    return { dailyVolume, dailyFees, dailyRevenue: 0, dailySupplySideRevenue };
   }
 
   const [buyLogs, sellLogs] = await Promise.all([
@@ -98,7 +100,9 @@ const fetch = async (options: FetchOptions): Promise<FetchResult> => {
     const token = ammByToken.get(vault);
     if (!token) continue;
     dailyVolume.add(token, args.totalCost);
-    dailyFees.add(token, (args.protocolFee + args.stakerFee));
+    dailyFees.add(token, (args.protocolFee + args.stakerFee), METRIC.TRADING_FEES);
+    dailySupplySideRevenue.add(token, args.protocolFee, 'Fees to NFT burn');
+    dailySupplySideRevenue.add(token, args.stakerFee, 'Fees to NFT stakers');
   }
 
   for (const log of sellLogs) {
@@ -107,14 +111,16 @@ const fetch = async (options: FetchOptions): Promise<FetchResult> => {
     const token = ammByToken.get(vault);
     if (!token) continue;
     dailyVolume.add(token, args.grossPayout);
-    dailyFees.add(token, (args.protocolFee + args.stakerFee));
+    dailyFees.add(token, (args.protocolFee + args.stakerFee), METRIC.TRADING_FEES);
+    dailySupplySideRevenue.add(token, args.protocolFee, 'Fees to NFT burn');
+    dailySupplySideRevenue.add(token, args.stakerFee, 'Fees to NFT stakers');
   }
 
   return {
     dailyVolume,
     dailyFees,
     dailyRevenue: 0,
-    dailySupplySideRevenue: dailyFees,
+    dailySupplySideRevenue,
   };
 };
 
@@ -125,12 +131,23 @@ const methodology = {
   SupplySideRevenue: "Includes NFTs burned from protocol revenue and staker fees distributed to the NFT stakers",
 }
 
+const breakdownMethodology = {
+  Fees: {
+    [METRIC.TRADING_FEES]: "Sum of protocolFee + stakerFee fields from NFTBought + NFTSold events. Protocol fee is burned; staker fee streams to the NFT staking vault as rewards.",
+  },
+  SupplySideRevenue: {
+    'Fees to NFT burn': "Sum of protocolFee fields from NFTBought + NFTSold events. Protocol fee is burned directly rewarding NFT holders (supply side)",
+    'Fees to NFT stakers': "Sum of stakerFee fields from NFTBought + NFTSold events. Staker fee streams to the NFT staking vault as rewards.",
+  },
+}
+
 const adapter: SimpleAdapter = {
   version: 2,
   pullHourly: true,
   fetch,
   adapter: chainsConfig,
   methodology,
+  breakdownMethodology,
 };
 
 export default adapter;

--- a/dexs/clutch-anvil/index.ts
+++ b/dexs/clutch-anvil/index.ts
@@ -113,14 +113,16 @@ const fetch = async (options: FetchOptions): Promise<FetchResult> => {
   return {
     dailyVolume,
     dailyFees,
-    dailyRevenue: dailyFees,
+    dailyRevenue: 0,
+    dailySupplySideRevenue: dailyFees,
   };
 };
 
 const methodology = {
   Volume: "Sum of buy totalCost and sell grossPayout from NFTBought + NFTSold events across every AMM vault deployed by the Clutch Anvil factory.",
   Fees: "Sum of protocolFee + stakerFee fields from NFTBought + NFTSold events. Protocol fee is burned; staker fee streams to the NFT staking vault as rewards.",
-  Revenue: "Equal to Fees — the entire fee tranche is returned to the protocol (burn) or to NFT stakers.",
+  Revenue: "No revenue",
+  SupplySideRevenue: "Includes NFTs burned from protocol revenue and staker fees distributed to the NFT stakers",
 }
 
 const adapter: SimpleAdapter = {

--- a/dexs/clutch-anvil/index.ts
+++ b/dexs/clutch-anvil/index.ts
@@ -1,6 +1,5 @@
 import { FetchOptions, FetchResult, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
-import { addOneToken } from "../../helpers/prices";
 
 // Clutch Anvil AMM — permissionless NFT AMM. Each market deploys an
 // `NFTAMMVault` that swaps an ERC20 token (paired 1:N to a specific NFT
@@ -24,18 +23,21 @@ import { addOneToken } from "../../helpers/prices";
 // burned (deflationary on the token), staker fee streams to the staking
 // vault as rewards. We expose the full fee tranche as protocol revenue.
 
-const FACTORY_BY_CHAIN: Record<string, { factory: string; fromBlock: number }> = {
+const chainsConfig: Record<string, { factory: string; fromBlock: number; start: string }> = {
   [CHAIN.ETHEREUM]: {
     factory: "0xEA095646EC6A56EDbFEe84cCcf23eFCec12566A0",
     fromBlock: 24720104,
+    start: "2026-03-23",
   },
   [CHAIN.BASE]: {
     factory: "0x5ef900789a0faa1fDE3e9796441B62b66f0ab2Aa",
     fromBlock: 45593260,
+    start: "2026-04-01",
   },
   [CHAIN.APECHAIN]: {
     factory: "0x87B62309B6fF4FA184C89919351bEbd3AC11Fc84",
     fromBlock: 34900822,
+    start: "2026-02-15",
   },
 };
 
@@ -50,16 +52,15 @@ const NFT_SOLD_ABI =
 
 const fetch = async (options: FetchOptions): Promise<FetchResult> => {
   const { chain, createBalances, getLogs } = options;
-  const { factory, fromBlock } = FACTORY_BY_CHAIN[chain];
+  const { factory, fromBlock } = chainsConfig[chain];
 
   const dailyVolume = createBalances();
-  const dailyFees = createBalances();
+  const dailyFees = createBalances();  
 
   const markets = await getLogs({
     target: factory,
     fromBlock,
-    eventAbi: MARKET_CREATED_ABI,
-    onlyArgs: true,
+    eventAbi: MARKET_CREATED_ABI, 
     cacheInCloud: true,
   });
 
@@ -80,35 +81,33 @@ const fetch = async (options: FetchOptions): Promise<FetchResult> => {
       eventAbi: NFT_BOUGHT_ABI,
       flatten: true,
       entireLog: true,
+      parseLog: true,
     }),
     getLogs({
       targets: ammVaults,
       eventAbi: NFT_SOLD_ABI,
       flatten: true,
       entireLog: true,
+      parseLog: true,
     }),
   ]);
 
   for (const log of buyLogs) {
-    const vault = (log.address || log.source || "").toLowerCase();
+    const args = log.args;
+    const vault = log.address.toLowerCase();
     const token = ammByToken.get(vault);
     if (!token) continue;
-    const totalCost = BigInt(log.args?.totalCost ?? log.totalCost ?? 0);
-    const protocolFee = BigInt(log.args?.protocolFee ?? log.protocolFee ?? 0);
-    const stakerFee = BigInt(log.args?.stakerFee ?? log.stakerFee ?? 0);
-    dailyVolume.add(token, totalCost.toString());
-    dailyFees.add(token, (protocolFee + stakerFee).toString());
+    dailyVolume.add(token, args.totalCost);
+    dailyFees.add(token, (args.protocolFee + args.stakerFee));
   }
 
   for (const log of sellLogs) {
-    const vault = (log.address || log.source || "").toLowerCase();
+    const args = log.args;
+    const vault = log.address.toLowerCase();
     const token = ammByToken.get(vault);
     if (!token) continue;
-    const grossPayout = BigInt(log.args?.grossPayout ?? log.grossPayout ?? 0);
-    const protocolFee = BigInt(log.args?.protocolFee ?? log.protocolFee ?? 0);
-    const stakerFee = BigInt(log.args?.stakerFee ?? log.stakerFee ?? 0);
-    dailyVolume.add(token, grossPayout.toString());
-    dailyFees.add(token, (protocolFee + stakerFee).toString());
+    dailyVolume.add(token, args.grossPayout);
+    dailyFees.add(token, (args.protocolFee + args.stakerFee));
   }
 
   return {
@@ -118,32 +117,18 @@ const fetch = async (options: FetchOptions): Promise<FetchResult> => {
   };
 };
 
+const methodology = {
+  Volume: "Sum of buy totalCost and sell grossPayout from NFTBought + NFTSold events across every AMM vault deployed by the Clutch Anvil factory.",
+  Fees: "Sum of protocolFee + stakerFee fields from NFTBought + NFTSold events. Protocol fee is burned; staker fee streams to the NFT staking vault as rewards.",
+  Revenue: "Equal to Fees — the entire fee tranche is returned to the protocol (burn) or to NFT stakers.",
+}
+
 const adapter: SimpleAdapter = {
   version: 2,
-  adapter: {
-    [CHAIN.ETHEREUM]: {
-      fetch,
-      start: "2026-03-23",
-      meta: {
-        methodology: {
-          Volume:
-            "Sum of buy totalCost and sell grossPayout from NFTBought + NFTSold events across every AMM vault deployed by the Clutch Anvil factory.",
-          Fees:
-            "Sum of protocolFee + stakerFee fields from NFTBought + NFTSold events. Protocol fee is burned; staker fee streams to the NFT staking vault as rewards.",
-          Revenue:
-            "Equal to Fees — the entire fee tranche is returned to the protocol (burn) or to NFT stakers.",
-        },
-      },
-    },
-    [CHAIN.BASE]: {
-      fetch,
-      start: "2026-04-01",
-    },
-    [CHAIN.APECHAIN]: {
-      fetch,
-      start: "2026-02-15",
-    },
-  },
+  pullHourly: true,
+  fetch,
+  adapter: chainsConfig,
+  methodology,
 };
 
 export default adapter;


### PR DESCRIPTION
Companion volume + fees adapter for the Clutch Anvil AMM TVL adapter ([DefiLlama-Adapters #19313](https://github.com/DefiLlama/DefiLlama-Adapters/pull/19313)).

## Name (to be shown on DefiLlama):
Clutch Anvil AMM

## Twitter Link:
https://x.com/clutchmarkets

## List of audit links if any:
N/A (contracts verified on Etherscan/Basescan/Apescan)

## Website Link:
https://anvil.clutch.market

## Logo:
https://anvil.clutch.market/clutch-logo.png

## Chain:
Ethereum, Base, ApeChain

## Short Description:
Clutch Anvil AMM is a permissionless NFT AMM. Each market deploys an `NFTAMMVault` that swaps an ERC20 token (paired 1:N to a specific NFT collection) against NFT inventory. Volume + fees are aggregated across every market deployed by the canonical factory on each chain.

## Token addresses and tickers:
- K9 (Pixel Pups market, Ethereum): 0xbc920c7Fa25D3Cd5606394aa4C6751d71DCb7930
- PUPCUP (World Pup Coin market, Ethereum): 0x884649f1fE3Bf3Ae0Bd720Eaf660cB561dcE39ef

## Category:
NFT Marketplace

## methodology:
- **Volume**: Sum of `totalCost` from `NFTBought` events plus `grossPayout` from `NFTSold` events across every AMM vault discovered via `MarketCreated` logs on the canonical factory contract per chain.
- **Fees**: Sum of `protocolFee + stakerFee` fields from the same two events. Protocol fee is burned (deflationary); staker fee streams to the staking vault as rewards.
- **Revenue**: Equal to Fees — the entire fee tranche is returned to the protocol (burn) or to NFT stakers.

## Github org/user:
https://github.com/clutchmarkets

## Live test output:
```
chain     | Daily volume | Daily fees | Daily revenue
ethereum  | 2.81 k       | 91.00      | 91.00
base      | 0.00         | 0.00       | 0.00
apechain  | 0.00         | 0.00       | 0.00
Aggregate | 2.81 k       | 91.00      | 91.00
```

Base + ApeChain currently show $0 only because the market ERC20 tokens are not yet priced by DefiLlama's pricing layer. Both chains' event logs are read correctly — the values will populate automatically as the market tokens gain DEX liquidity.

## Does this project have a referral program?
No

Made with [Cursor](https://cursor.com)