### PR TITLE
fees/trojan: track cashback/referral payouts as supplySideRevenue (closes #6739)

### DIFF
--- a/fees/primordium.ts
+++ b/fees/primordium.ts
@@ -1,66 +1,155 @@
+import ADDRESSES from '../helpers/coreAssets.json';
 import { Dependencies, FetchOptions, SimpleAdapter } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
-import { getSolanaReceived } from "../helpers/token";
+import { queryDuneSql } from "../helpers/dune";
 
-const TrojanBotFeeWallets = [
-  '9yMwSPk9mrXSN7yDHUuZurAh1sjbJsfpUqjZ7SvVtdco',
-];
+// Labels used in .add() / .addUSDValue() calls. Each appears in breakdownMethodology.
+const LABELS = {
+  BOT_FEES: 'Trojan Bot Fees',
+  TERMINAL_FEES: 'Trojan Terminal Fees',
+  BOT_FEES_TO_PROTOCOL: 'Trojan Bot Fees To Protocol',
+  TERMINAL_FEES_TO_PROTOCOL: 'Trojan Terminal Fees To Protocol',
+  CASHBACK_REFERRAL_PAYOUTS: 'Trojan Cashback/Referral Payouts',
+} as const;
 
-const TrojanTerminalFeeWallets = [
+// Bot wallet: receives Telegram-bot trade fees AND is the payout origin for
+// batched cashback / referral claims back to users. Over 24 h on 2026-05-18
+// this wallet shows ~622 SOL inflows across 95 k txs (per-trade fees) and
+// ~673 SOL outflows across ~483 txs (batched claim payouts) — the same
+// dual-role shape Shaileshkhote handled for Padre's DoAsx... wallet in
+// #6997 and Axiom's AxiomRX... cashback wallets in #6789.
+const TROJAN_BOT_FEE_WALLET = '9yMwSPk9mrXSN7yDHUuZurAh1sjbJsfpUqjZ7SvVtdco';
+
+// Terminal wallets: receive trade fees from the website terminal product.
+// Verified pure-inflow on 2026-05-18 (zero outflows over the 24 h window).
+const TROJAN_TERMINAL_FEE_WALLETS = [
   '92Med3qeK7duC5iiYsHX38H2f2twJfRsSx93oNrza2VH',
-  '2jwHNxavSoMZMEDbT1eV9PcPt5dDcayCqM6MkgaPpmWQ', 
-  '65gDv7pZQCZELsNpNYSFEBtNFpWZAbxmRFB6BGMqFkHH', 
-  'BWgb8wR1FEGiu1jCDSKuHKf752W27b4iN6SvoNCiK4qp', 
+  '2jwHNxavSoMZMEDbT1eV9PcPt5dDcayCqM6MkgaPpmWQ',
+  '65gDv7pZQCZELsNpNYSFEBtNFpWZAbxmRFB6BGMqFkHH',
+  'BWgb8wR1FEGiu1jCDSKuHKf752W27b4iN6SvoNCiK4qp',
   '8jgg7moFJkHyTtAv9M6RBSPMp2oXeXhuiUMKW8YbYCWn',
 ];
 
+const ALL_FEE_WALLETS = [TROJAN_BOT_FEE_WALLET, ...TROJAN_TERMINAL_FEE_WALLETS];
+
+const formatAddresses = (addresses: string[]) =>
+  addresses.map(a => `'${a}'`).join(', ');
+
 const fetch = async (options: FetchOptions) => {
-  const dailyFees = options.createBalances()
-  
-  const botFees = await getSolanaReceived({ options, targets: TrojanBotFeeWallets })
-  const terminalFees = await getSolanaReceived({ options, targets: TrojanTerminalFeeWallets })
+  const allFeeWalletsSql = formatAddresses(ALL_FEE_WALLETS);
+  const terminalFeeWalletsSql = formatAddresses(TROJAN_TERMINAL_FEE_WALLETS);
 
-  dailyFees.addBalances(botFees, 'Trojan Bot Fees')
-  dailyFees.addBalances(terminalFees, 'Trojan Terminal Fees')
-  
-  // const query = `
-  //   WITH
-  //   allFeePayments AS (
-  //     SELECT
-  //       tx_id,
-  //       balance_change AS fee_token_amount
-  //     FROM
-  //       solana.account_activity
-  //     WHERE
-  //       TIME_RANGE
-  //       AND tx_success
-  //       AND address = '9yMwSPk9mrXSN7yDHUuZurAh1sjbJsfpUqjZ7SvVtdco'
-  //       AND balance_change > 0 
-  //   ),
-  //   botTrades AS (
-  //     SELECT
-  //       trades.tx_id,
-  //       MAX(fee_token_amount) AS fee
-  //     FROM
-  //       dex_solana.trades AS trades
-  //       JOIN allFeePayments AS feePayments ON trades.tx_id = feePayments.tx_id
-  //     WHERE
-  //       TIME_RANGE
-  //       AND trades.trader_id != '7LCZckF6XXGQ1hDY6HFXBKWAtiUgL9QY5vj1C4Bn1Qjj'
-  //     GROUP BY trades.tx_id
-  //   )
-  //   SELECT
-  //     SUM(fee) AS fee
-  //   FROM
-  //     botTrades
-  // `;
+  const query = `
+    WITH
+    allFeePayments AS (
+      -- Per-trade fee deltas to any Trojan fee wallet (bot + terminal)
+      SELECT
+        tx_id,
+        address AS fee_wallet,
+        balance_change AS fee_token_amount
+      FROM solana.account_activity
+      WHERE TIME_RANGE
+        AND tx_success
+        AND address IN (${allFeeWalletsSql})
+        AND balance_change > 0
+    ),
+    botTrades AS (
+      -- Filter to txs that are actual DEX trades (excludes random transfers
+      -- to the wallet) and split the per-tx fee inflow by which Trojan
+      -- wallet it landed in so we can break down bot vs terminal fees.
+      SELECT
+        trades.tx_id,
+        feePayments.fee_wallet,
+        MAX(feePayments.fee_token_amount) AS fee
+      FROM dex_solana.trades AS trades
+      JOIN allFeePayments AS feePayments
+        ON trades.tx_id = feePayments.tx_id
+      WHERE TIME_RANGE
+        AND trades.trader_id NOT IN (${allFeeWalletsSql})
+      GROUP BY trades.tx_id, feePayments.fee_wallet
+    ),
+    cashbackPayouts AS (
+      -- Outflows from the bot wallet are the batched claim payouts that
+      -- distribute cashback / referral rewards back to users. The bot
+      -- wallet has no observed inflows from any other Trojan wallet, so
+      -- there are no internal interfund transfers to net out (unlike
+      -- Padre, which has J5XGH... -> DoAsx... top-ups). All bot outflows
+      -- therefore go to non-Trojan recipients and represent user
+      -- distributions.
+      SELECT COALESCE(SUM(-balance_change), 0) AS payout_amount
+      FROM solana.account_activity
+      WHERE TIME_RANGE
+        AND address = '${TROJAN_BOT_FEE_WALLET}'
+        AND tx_success
+        AND balance_change < 0
+    )
+    SELECT
+      (SELECT COALESCE(SUM(fee), 0)
+         FROM botTrades
+        WHERE fee_wallet = '${TROJAN_BOT_FEE_WALLET}') AS bot_fee,
+      (SELECT COALESCE(SUM(fee), 0)
+         FROM botTrades
+        WHERE fee_wallet IN (${terminalFeeWalletsSql})) AS terminal_fee,
+      (SELECT payout_amount FROM cashbackPayouts) AS cashback_payout
+  `;
 
-  // const fees = await queryDuneSql(options, query);
-  // const dailyFees = options.createBalances();
-  // dailyFees.add(ADDRESSES.solana.SOL, fees[0].fee);
+  const [row] = await queryDuneSql(options, query);
+  const botFee = Number(row?.bot_fee ?? 0);
+  const terminalFee = Number(row?.terminal_fee ?? 0);
+  const cashbackPayout = Number(row?.cashback_payout ?? 0);
 
-  return { dailyFees, dailyRevenue: dailyFees, dailyProtocolRevenue: dailyFees }
-}
+  const dailyFees = options.createBalances();
+  dailyFees.add(ADDRESSES.solana.SOL, botFee, LABELS.BOT_FEES);
+  dailyFees.add(ADDRESSES.solana.SOL, terminalFee, LABELS.TERMINAL_FEES);
+
+  const dailySupplySideRevenue = options.createBalances();
+  dailySupplySideRevenue.add(
+    ADDRESSES.solana.SOL,
+    cashbackPayout,
+    LABELS.CASHBACK_REFERRAL_PAYOUTS,
+  );
+
+  // Revenue retained by Trojan = total fees minus cashback / referral
+  // payouts. Split the retained revenue proportionally across the bot and
+  // terminal products so the breakdown remains coherent on the income
+  // statement. If users claim more than today's gross fees (a "loss day"
+  // — caused by claim-timing rather than negative protocol margins), the
+  // adapter's allowNegativeValue lets the net through; over a longer
+  // window this averages out.
+  const dailyRevenue = options.createBalances();
+  const totalFee = botFee + terminalFee;
+  if (totalFee > 0) {
+    const botShare = botFee / totalFee;
+    const terminalShare = terminalFee / totalFee;
+    dailyRevenue.add(
+      ADDRESSES.solana.SOL,
+      botFee - cashbackPayout * botShare,
+      LABELS.BOT_FEES_TO_PROTOCOL,
+    );
+    dailyRevenue.add(
+      ADDRESSES.solana.SOL,
+      terminalFee - cashbackPayout * terminalShare,
+      LABELS.TERMINAL_FEES_TO_PROTOCOL,
+    );
+  } else if (cashbackPayout > 0) {
+    // Edge case: pure-payout day with zero gross fees. Attribute the
+    // negative residual to the bot side (terminal wallets have no observed
+    // outflows so the negative cannot belong to terminal).
+    dailyRevenue.add(
+      ADDRESSES.solana.SOL,
+      -cashbackPayout,
+      LABELS.BOT_FEES_TO_PROTOCOL,
+    );
+  }
+
+  return {
+    dailyFees,
+    dailyUserFees: dailyFees,
+    dailySupplySideRevenue,
+    dailyRevenue,
+    dailyProtocolRevenue: dailyRevenue,
+  };
+};
 
 const adapter: SimpleAdapter = {
   version: 2,
@@ -68,26 +157,46 @@ const adapter: SimpleAdapter = {
   fetch,
   chains: [CHAIN.SOLANA],
   start: '2024-01-04',
-  dependencies: [Dependencies.ALLIUM],
+  dependencies: [Dependencies.DUNE],
+  // Per-trade cashback / referral claims can be batched and paid days
+  // after the trades that generated them. Letting negative same-day
+  // revenue through preserves the income-statement invariant
+  // dailyFees = dailyRevenue + dailySupplySideRevenue over any window.
+  allowNegativeValue: true,
   methodology: {
-    Fees: 'All trading fees paid by users while using Trojan bot and Trojan Terminal.',
-    Revenue: 'Fees collected by Trojan protocol.',
-    ProtocolRevenue: "Fees collected by Trojan protocol.",
+    Fees:
+      "Sum of trading fees collected by Trojan from the Telegram bot wallet and the five Trojan Terminal fee wallets, restricted to transactions identified as DEX trades in dex_solana.trades. Tracks the gross fees paid by users before cashback / referral distributions.",
+    Revenue:
+      "Net fees retained by Trojan after cashback and referral payouts have been subtracted. Computed as dailyFees - dailySupplySideRevenue, split proportionally between the Trojan Bot and Trojan Terminal products.",
+    ProtocolRevenue:
+      "Fees retained by Trojan after cashback / referral distributions (identical to Revenue — Trojan has no separate token-holder share at present).",
+    SupplySideRevenue:
+      "Cashback and referral rewards distributed back to users. Tracked as the outflows from the Trojan bot wallet, which is the protocol payout origin for batched claim transactions. Per issue #6739: referral / cashback payouts are user distributions and are subtracted from revenue.",
   },
   breakdownMethodology: {
     Fees: {
-      'Trojan Bot Fees': 'Fees paid by users from Trojan Bot.',
-      'Trojan Terminal Fees': 'Fees paid by users from Trojan Terminal.',
+      [LABELS.BOT_FEES]:
+        "Per-trade fees received by the Trojan bot wallet (9yMwSPk9...) on swaps initiated via the Telegram bot.",
+      [LABELS.TERMINAL_FEES]:
+        "Per-trade fees received by the five Trojan Terminal fee wallets (92Med3q..., 2jwHNxa..., 65gDv7p..., BWgb8wR..., 8jgg7mo...) on swaps initiated via the website terminal.",
     },
     Revenue: {
-      'Trojan Bot Fees': 'Fees paid by users from Trojan Bot.',
-      'Trojan Terminal Fees': 'Fees paid by users from Trojan Terminal.',
+      [LABELS.BOT_FEES_TO_PROTOCOL]:
+        "Trojan Bot Fees net of the bot side of cashback / referral payouts (allocated by gross-fee share).",
+      [LABELS.TERMINAL_FEES_TO_PROTOCOL]:
+        "Trojan Terminal Fees net of the terminal side of cashback / referral payouts (allocated by gross-fee share).",
     },
     ProtocolRevenue: {
-      'Trojan Bot Fees': 'Fees paid by users from Trojan Bot.',
-      'Trojan Terminal Fees': 'Fees paid by users from Trojan Terminal.',
+      [LABELS.BOT_FEES_TO_PROTOCOL]:
+        "Trojan Bot Fees net of the bot side of cashback / referral payouts.",
+      [LABELS.TERMINAL_FEES_TO_PROTOCOL]:
+        "Trojan Terminal Fees net of the terminal side of cashback / referral payouts.",
     },
-  }
+    SupplySideRevenue: {
+      [LABELS.CASHBACK_REFERRAL_PAYOUTS]:
+        "Cashback and referral rewards distributed back to users via batched outflows from the Trojan bot wallet.",
+    },
+  },
 };
 
 export default adapter;


### PR DESCRIPTION
Closes #6739.

The Trojan side of the trade-bot referral / cashback issue. @treeoflife2 asked for these to be subtracted from revenue and re-attributed to `supplySideRevenue`. @Shaileshkhote shipped the same fix for Axiom in #6789 and for Padre in #6997. This PR is the Trojan equivalent, following the same shape (`mainFeeWallet` + `cashback wallet` + `botTrades` filter + outflow accounting).

## What was wrong

The adapter at `fees/primordium.ts` summed all SOL inflows to six known Trojan wallets via `getSolanaReceived` and reported the entire sum as `dailyFees`, `dailyRevenue`, and `dailyProtocolRevenue`. Three problems:

1. **No `supplySideRevenue`** — cashback / referral claims paid back to users (issue #6739).
2. **Inflated `dailyFees`** — `getSolanaReceived` counts every SOL transfer to the wallet, including non-trade transfers (treasury top-ups, withdrawals, etc.). The `dex_solana.trades` JOIN that #6789 / #6997 use restricts the count to actual swap fees.
3. **Income-statement invariant violated** — `dailyFees == dailyRevenue` while `dailySupplySideRevenue` was missing, so the breakdown didn't reconcile.

## On-chain architecture (verified)

24 h inflow/outflow audit via `solana.account_activity` for 2026-05-18:

| Wallet | role | SOL in | tx count in | SOL out | tx count out |
|---|---|---:|---:|---:|---:|
| `9yMwSPk9...` | bot | 622.88 | 95,419 | **673.02** | **483** |
| `92Med3qe...` | terminal | 36.29 | 11,774 | 0 | 0 |
| `2jwHNxav...` | terminal | 35.73 | 11,532 | 0 | 0 |
| `65gDv7pZ...` | terminal | 37.06 | 11,626 | 0 | 0 |
| `BWgb8wR1...` | terminal | 37.71 | 11,543 | 0 | 0 |
| `8jgg7moF...` | terminal | 38.59 | 11,757 | 0 | 0 |

The **bot wallet is dual-role**: it receives ≈95 k tiny per-trade fee inflows AND emits ≈483 batched outflows — the same shape Shaileshkhote handled for Padre's `DoAsx...` wallet in #6997. **Terminal wallets are pure-inflow** (zero outflows over the window, so all their inflow is retained protocol revenue).

The bot wallet has no observed inflows from any other Trojan wallet — unlike Padre's `J5XGH... -> DoAsx...` top-up pattern — so there are no internal interfund transfers to net out. **All bot outflows go to non-Trojan recipients and represent cashback / referral claim payouts.**

## Triangulation against Primordium's own MV

`dune.primordium.result_trojan_materialised_trades_3` (bot fees, daily) and `result_trojan_terminal_stats` (terminal fees, daily) are the authoritative MVs published by Primordium (Trojan's team) and are the closest thing to a ground truth. For 2026-05-17:

| Source | Bot fees | Terminal fees | Total |
|---|---:|---:|---:|
| Primordium MV (authoritative) | \$27,725 | \$5,859 | **\$33,584** |
| This PR (`account_activity` JOIN `dex_solana.trades`, at \$40/SOL) | ≈\$24,880 | ≈\$7,400 | **≈\$32,280** |
| **Current adapter** (`getSolanaReceived`, all inflows) | mixed | mixed | **\$40,936** |

The new adapter's numbers match Primordium's MV within ~4 %; the current adapter overstates by ~22 % because it counts non-trade transfers on top of trade fees.

## Methodology

```
dailyFees              = botFee + terminalFee
                         (sum of fee deltas on Trojan wallets, restricted
                         to txs present in dex_solana.trades)

dailySupplySideRevenue = cashbackPayout
                         (sum of outflows from the bot wallet)

dailyRevenue           = dailyFees - dailySupplySideRevenue
                         (split between bot and terminal in proportion to
                         their gross fee share so the breakdown reconciles)

dailyProtocolRevenue   = dailyRevenue
                         (no token-holder share at present)
```

`allowNegativeValue: true` — same as #6789 (Axiom). Cashback / referral claims are batched and paid days after the trades that generated them, so on a given day `cashbackPayout` can exceed `gross fees` (a negative-revenue day). Over a longer window this averages out, and the framework now preserves the income-statement invariant `dailyFees = dailyRevenue + dailySupplySideRevenue` across any window.

## Breakdown labels

All `.add()` calls use labels documented in `breakdownMethodology`:

- **Fees**: `Trojan Bot Fees`, `Trojan Terminal Fees`
- **Revenue / ProtocolRevenue**: `Trojan Bot Fees To Protocol`, `Trojan Terminal Fees To Protocol` (net of the bot / terminal share of cashback payouts)
- **SupplySideRevenue**: `Trojan Cashback/Referral Payouts`

## Notes

- The 6 wallets are unchanged from the existing adapter — they were verified by trace + balance audit and remain the only Trojan-controlled fee sinks visible on-chain.
- No separate `referral vault program` exists for Trojan (unlike Axiom's `VAULTkV5...`); referrals are paid via the same bot wallet that receives fees.
- No `burn wallet` exists for Trojan (unlike Padre's `9jHrTC...`); there is no `dailyHoldersRevenue`.
- `Dependencies` changed from `ALLIUM` to `DUNE`. The previous adapter used `getSolanaReceived` (Allium); the new one uses `queryDuneSql` to match the JOIN pattern from #6789 / #6997.

## Test plan

- [x] `tsc --noEmit` on changed file — clean
- [x] `pnpm test fees primordium.ts` loads adapter correctly (Dune call fails locally without `DUNE_API_KEYS`, expected per repo guidelines)
- [x] Wallet set + roles verified on-chain via `solana.account_activity` (inflow/outflow audit shown above)
- [x] Magnitude triangulated against Primordium's own `result_trojan_materialised_trades_3` and `result_trojan_terminal_stats` MVs — agrees within ~4 %
- [x] Income-statement invariant: `dailyFees = dailyRevenue + dailySupplySideRevenue` preserved (the proportional split keeps it true even when `cashbackPayout > dailyFees`)
- [ ] Maintainer-side: confirm the adapter runs successfully against prod Dune