### PR TITLE
[feat] HL-HIP4: add HL builder market filters for HIP-3 and HIP-4

### DIFF
--- a/factory/hyperliquid.ts
+++ b/factory/hyperliquid.ts
@@ -1,4 +1,4 @@
-import { exportBuilderAdapter, exportHIP3DeployerAdapter, exportValidatorStakingAdapter } from "../helpers/hyperliquid";
+import { exportBuilderAdapter, exportHIP3DeployerAdapter, exportValidatorStakingAdapter, type HyperliquidMarket } from "../helpers/hyperliquid";
 import { createFactoryExports } from "./registry";
 
 interface BuilderConfig {
@@ -8,6 +8,7 @@ interface BuilderConfig {
   methodology?: any;
   extraReturnFields?: Record<string, any>;
   breakdownFees?: boolean; // add breakdown fees labels
+  market?: HyperliquidMarket;
 }
 
 // Builder adapter configs for dexs: protocol name -> config
@@ -648,6 +649,7 @@ for (const [name, config] of Object.entries(builderConfigs)) {
     methodology: config.methodology,
     extraReturnFields: config.extraReturnFields,
     breakdownFees: config.breakdownFees,
+    market: config.market,
   });
 }
 for (const [name, config] of Object.entries(hip3DexConfigs)) {
@@ -667,6 +669,7 @@ for (const [name, config] of Object.entries(builderFeesConfigs)) {
     methodology: config.methodology,
     extraReturnFields: config.extraReturnFields,
     breakdownFees: config.breakdownFees,
+    market: config.market,
   });
 }
 

--- a/helpers/hyperliquid.ts
+++ b/helpers/hyperliquid.ts
@@ -10,6 +10,8 @@ import { Balances } from "@defillama/sdk";
 import { findClosest } from "./utils/findClosest";
 import { CHAIN } from "./chains";
 
+export type HyperliquidMarket = "all" | "hip3" | "hip4";
+
 /**
  * Fetches builder code revenue directly from HyperLiquid's LZ4 compressed CSV files
  *
@@ -28,17 +30,21 @@ export const LLAMA_HL_INDEXER_SNAPSHOTS_FROM_TIME = 1776211200;
 export const fetchBuilderCodeRevenue = async ({
   options,
   builder_address,
+  market = "all",
 }: {
   options: FetchOptions;
   builder_address: string;
+  market?: HyperliquidMarket;
 }) => {
   const startTimestamp = options.startOfDay;
   const dailyFees = options.createBalances();
   const dailyVolume = options.createBalances();
+  const isHIP3Market = market === "hip3";
+  const isHIP4Market = market === "hip4";
 
   // try with llama hl indexer
   const endpoint = getEnv("LLAMA_HL_INDEXER");
-  if (startTimestamp >= LLAMA_HL_INDEXER_FROM_TIME && endpoint) {
+  if (market === "all" && startTimestamp >= LLAMA_HL_INDEXER_FROM_TIME && endpoint) {
     const dateString = new Date(startTimestamp * 1000)
       .toISOString()
       .split("T")[0]
@@ -114,11 +120,11 @@ export const fetchBuilderCodeRevenue = async ({
       .split("\n")
       .filter((line) => line.trim().length > 0);
     const headers = lines[0].split(",").map((h: string) => h.trim());
-    const builderFeeIndex = headers.findIndex(
-      (h: string) => h === "builder_fee",
-    );
+    const builderFeeIndex = headers.findIndex((h: string) => h === "builder_fee");
+    const coinIndex = headers.findIndex((h: string) => h === "coin");
     const pxIndex = headers.findIndex((h: string) => h === "px");
     const szIndex = headers.findIndex((h: string) => h === "sz");
+    if ((isHIP3Market || isHIP4Market) && coinIndex === -1) throw new Error(`missing coin column for ${market} builder fills`);
 
     let totalBuilderFees = 0;
     let totalVolume = 0;
@@ -129,6 +135,16 @@ export const fetchBuilderCodeRevenue = async ({
         const values = line.split(",");
 
         if (values.length >= Math.max(builderFeeIndex, pxIndex, szIndex) + 1) {
+          const coin = values[coinIndex]?.trim();
+
+          // Source: asset ID docs; HIP-3 perps use {dex}:{coin}, HIP-4 outcomes use #<encoding>.
+          if (isHIP3Market && !coin?.includes(":")) {
+            continue;
+          }
+          if (isHIP4Market && !/^#\d+$/.test(coin)) {
+            continue;
+          }
+
           const builderFee = parseFloat(values[builderFeeIndex]) || 0;
           const px = parseFloat(values[pxIndex]) || 0;
           const sz = parseFloat(values[szIndex]) || 0;
@@ -540,10 +556,11 @@ export const exportHIP3DeployerAdapter = (
 
 export const exportBuilderAdapter = (
   builderAddresses: Array<string>,
-  props: { start?: string; deadFrom?: string; methodology?: any; extraReturnFields?: Record<string, any>, breakdownFees?: boolean },
+  props: { start?: string; deadFrom?: string; methodology?: any; extraReturnFields?: Record<string, any>, breakdownFees?: boolean, market?: HyperliquidMarket },
 ) => {
   const extraFields = props.extraReturnFields || {};
   const startDate = props.start ? props.start : "2025-08-01";
+  const market = props.market || "all";
   const adapter: SimpleAdapter = {
     version: 1,
     doublecounted: true, // all metrics are double-counted to hyperliquid
@@ -560,6 +577,7 @@ export const exportBuilderAdapter = (
             const result = await fetchBuilderCodeRevenue({
               options,
               builder_address: address,
+              market,
             });
             dailyVolume.addBalances(result.dailyVolume);
             dailyFees.addBalances(result.dailyFees, props.breakdownFees ? 'Hyperliquid Builder Code Fees' : undefined);
@@ -580,6 +598,24 @@ export const exportBuilderAdapter = (
     },
     methodology: props.methodology
       ? props.methodology
+      : market === "hip3"
+      ? {
+          Volume:
+            "Total volume from users trading Hyperliquid HIP-3 builder-deployed perpetual markets.",
+          Fees: "Builder code revenue from Hyperliquid HIP-3 builder-deployed perpetual trades.",
+          Revenue: "Builder code revenue from Hyperliquid HIP-3 builder-deployed perpetual trades.",
+          ProtocolRevenue:
+            "Builder code revenue from Hyperliquid HIP-3 builder-deployed perpetual trades.",
+        }
+      : market === "hip4"
+      ? {
+          Volume:
+            "Total volume from users trading Hyperliquid HIP-4 outcome markets.",
+          Fees: "Builder code revenue from Hyperliquid HIP-4 outcome-market trades.",
+          Revenue: "Builder code revenue from Hyperliquid HIP-4 outcome-market trades.",
+          ProtocolRevenue:
+            "Builder code revenue from Hyperliquid HIP-4 outcome-market trades.",
+        }
       : {
           Volume:
             " Total volume from users were settled to Hyperliquid Perps Trades.",


### PR DESCRIPTION
## Summary
- Adds optional Hyperliquid builder-fill market filters for HIP-3 builder-deployed perpetuals and HIP-4 outcome markets.
- Keeps the existing `market: "all"` behavior unchanged for current Hyperliquid builder adapters.

## Changes
- Added `HyperliquidMarket = "all" | "hip3" | "hip4"` to `helpers/hyperliquid.ts`.
- Extended `fetchBuilderCodeRevenue` and `exportBuilderAdapter` to accept an optional `market` parameter.
- Preserved the existing Llama Hyperliquid indexer path only for `market: "all"`.
- Added CSV filtering for builder fills:
  - `hip3` includes only HIP-3 builder-deployed perp rows where `coin` uses `{dex}:{coin}`.
  - `hip4` includes only HIP-4 outcome rows where `coin` uses `#<encoding>`.
- Passed the optional `market` config through `factory/hyperliquid.ts` for builder-based dexs and fees exports.

## Methodology
- `all` tracks existing aggregate Hyperliquid builder-code volume and fees.
- `hip3` tracks builder-code fills for HIP-3 builder-deployed perpetual markets only.
- `hip4` tracks builder-code fills for HIP-4 outcome markets only.
- HIP-3 and HIP-4 identification follows Hyperliquid asset ID documentation:
  - HIP-3 builder-deployed perps use `{dex}:{coin}`.
  - HIP-4 outcomes use `#<encoding>`.

## Tests
- `pnpm ts-check`
- `pnpm test fees based-app 2026-05-10`
- `pnpm test dexs based-app`
  - `all`: daily volume `21.76M`, daily fees/revenue/protocol revenue `3.45k`
  - `hip4`: daily volume `68.00`, daily fees/revenue/protocol revenue `0.00`
  - `hip3`: daily volume `8.34M`, daily fees/revenue/protocol revenue `178.00`