### PR TITLE
trojan: net cashback / referral payouts from revenue

### DIFF
--- a/fees/primordium.ts
+++ b/fees/primordium.ts
@@ -1,66 +1,172 @@
+import ADDRESSES from '../helpers/coreAssets.json';
 import { Dependencies, FetchOptions, SimpleAdapter } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
-import { getSolanaReceived } from "../helpers/token";
+import { queryDuneSql } from "../helpers/dune";
 
-const TrojanBotFeeWallets = [
-  '9yMwSPk9mrXSN7yDHUuZurAh1sjbJsfpUqjZ7SvVtdco',
-];
+// Labels for breakdownMethodology compliance.
+const LABELS = {
+  BOT_FEES: 'Trojan Bot Trading Fees',
+  TERMINAL_FEES: 'Trojan Terminal Trading Fees',
+  BOT_REVENUE: 'Trojan Bot Fees To Protocol',
+  TERMINAL_REVENUE: 'Trojan Terminal Fees To Protocol',
+  CASHBACK_REFERRAL: 'Trojan Cashback And Referral Payouts',
+} as const;
 
-const TrojanTerminalFeeWallets = [
+// Bot fee wallet (Telegram bot). Receives per-trade fees AND, twice daily
+// (~00:02 / ~12:02 UTC), signs SystemProgram.transfer batches that pay
+// cashback + referral rewards out to user trading wallets. Each batch tx
+// fans out to ~15 recipients in a single transaction; minimum per-user
+// payout is 0.005 SOL per the team docs.
+const TROJAN_BOT_FEE_WALLET = '9yMwSPk9mrXSN7yDHUuZurAh1sjbJsfpUqjZ7SvVtdco';
+
+// Trojan Terminal fee wallets (website terminal product). Pure inflow —
+// verified zero outflows across 24 h of account_activity history.
+const TROJAN_TERMINAL_FEE_WALLETS = [
   '92Med3qeK7duC5iiYsHX38H2f2twJfRsSx93oNrza2VH',
-  '2jwHNxavSoMZMEDbT1eV9PcPt5dDcayCqM6MkgaPpmWQ', 
-  '65gDv7pZQCZELsNpNYSFEBtNFpWZAbxmRFB6BGMqFkHH', 
-  'BWgb8wR1FEGiu1jCDSKuHKf752W27b4iN6SvoNCiK4qp', 
+  '2jwHNxavSoMZMEDbT1eV9PcPt5dDcayCqM6MkgaPpmWQ',
+  '65gDv7pZQCZELsNpNYSFEBtNFpWZAbxmRFB6BGMqFkHH',
+  'BWgb8wR1FEGiu1jCDSKuHKf752W27b4iN6SvoNCiK4qp',
   '8jgg7moFJkHyTtAv9M6RBSPMp2oXeXhuiUMKW8YbYCWn',
 ];
 
+// Internal treasury sweep destination. The bot wallet periodically performs
+// large (~100 SOL each) sweeps to this SystemProgram EOA, which then forwards
+// via a Squads multisig (`DF1ow4tspfHX9JwWJsAb9epbkA8hmpSEAtxXy1V27QBH`) into
+// a wSOL treasury account (`ATRsNGv2nDw7hSMfkUTBoVUDsFDwN7po7KbecyiGWNB4`).
+// These sweeps are protocol-internal capital movements, NOT user
+// distributions, and must be excluded from cashback accounting.
+const TROJAN_TREASURY_SWEEP_WALLET = 'DrXMnPrFSiHA4JKKrSktTbAFrfvQCixHKvD7zGHxkzJP';
+
+const ALL_FEE_WALLETS = [TROJAN_BOT_FEE_WALLET, ...TROJAN_TERMINAL_FEE_WALLETS];
+
+const formatAddresses = (addresses: string[]) =>
+  addresses.map(a => `'${a}'`).join(', ');
+
 const fetch = async (options: FetchOptions) => {
-  const dailyFees = options.createBalances()
-  
-  const botFees = await getSolanaReceived({ options, targets: TrojanBotFeeWallets })
-  const terminalFees = await getSolanaReceived({ options, targets: TrojanTerminalFeeWallets })
+  const allFeeWalletsSql = formatAddresses(ALL_FEE_WALLETS);
+  const terminalFeeWalletsSql = formatAddresses(TROJAN_TERMINAL_FEE_WALLETS);
 
-  dailyFees.addBalances(botFees, 'Trojan Bot Fees')
-  dailyFees.addBalances(terminalFees, 'Trojan Terminal Fees')
-  
-  // const query = `
-  //   WITH
-  //   allFeePayments AS (
-  //     SELECT
-  //       tx_id,
-  //       balance_change AS fee_token_amount
-  //     FROM
-  //       solana.account_activity
-  //     WHERE
-  //       TIME_RANGE
-  //       AND tx_success
-  //       AND address = '9yMwSPk9mrXSN7yDHUuZurAh1sjbJsfpUqjZ7SvVtdco'
-  //       AND balance_change > 0 
-  //   ),
-  //   botTrades AS (
-  //     SELECT
-  //       trades.tx_id,
-  //       MAX(fee_token_amount) AS fee
-  //     FROM
-  //       dex_solana.trades AS trades
-  //       JOIN allFeePayments AS feePayments ON trades.tx_id = feePayments.tx_id
-  //     WHERE
-  //       TIME_RANGE
-  //       AND trades.trader_id != '7LCZckF6XXGQ1hDY6HFXBKWAtiUgL9QY5vj1C4Bn1Qjj'
-  //     GROUP BY trades.tx_id
-  //   )
-  //   SELECT
-  //     SUM(fee) AS fee
-  //   FROM
-  //     botTrades
-  // `;
+  const query = `
+    WITH
+    -- Per-trade fee inflows to ANY Trojan fee wallet (bot + terminal).
+    allFeePayments AS (
+      SELECT
+        tx_id,
+        address AS fee_wallet,
+        balance_change AS fee_lamports
+      FROM solana.account_activity
+      WHERE TIME_RANGE
+        AND tx_success
+        AND address IN (${allFeeWalletsSql})
+        AND balance_change > 0
+    ),
+    -- Filter to actual DEX trades. dex_solana.trades is the
+    -- spell-decoded view of swap transactions; joining excludes
+    -- arbitrary SOL transfers into the wallet (e.g. team top-ups
+    -- or claims from external sources) so dailyFees is restricted
+    -- to true user trading fees.
+    botTrades AS (
+      SELECT
+        trades.tx_id,
+        feePayments.fee_wallet,
+        MAX(feePayments.fee_lamports) AS fee
+      FROM dex_solana.trades AS trades
+      JOIN allFeePayments AS feePayments
+        ON trades.tx_id = feePayments.tx_id
+      WHERE TIME_RANGE
+        AND trades.trader_id NOT IN (${allFeeWalletsSql})
+      GROUP BY trades.tx_id, feePayments.fee_wallet
+    ),
+    -- Identify the internal treasury sweep tx_ids so we can exclude
+    -- them from cashback accounting. These are the periodic ~100 SOL
+    -- transfers where the bot wallet signs a transfer to the multisig
+    -- staging EOA.
+    treasurySweepTxs AS (
+      SELECT DISTINCT tx_id
+      FROM solana.account_activity
+      WHERE TIME_RANGE
+        AND address = '${TROJAN_TREASURY_SWEEP_WALLET}'
+        AND tx_success
+        AND balance_change > 0
+    ),
+    -- Bot wallet outflows that are user distributions (everything
+    -- except the treasury sweeps). Each such tx is a SystemProgram
+    -- batched transfer fanning out to ~15 user trading wallets at
+    -- a minimum of 0.005 SOL each (per the Trojan docs reward
+    -- policy at docs.trojanonsolana.com).
+    cashbackPayouts AS (
+      SELECT COALESCE(SUM(-balance_change), 0) AS payout_lamports
+      FROM solana.account_activity
+      WHERE TIME_RANGE
+        AND address = '${TROJAN_BOT_FEE_WALLET}'
+        AND tx_success
+        AND balance_change < 0
+        AND tx_id NOT IN (SELECT tx_id FROM treasurySweepTxs)
+    )
+    SELECT
+      (SELECT COALESCE(SUM(fee), 0)
+         FROM botTrades
+        WHERE fee_wallet = '${TROJAN_BOT_FEE_WALLET}') AS bot_fee_lamports,
+      (SELECT COALESCE(SUM(fee), 0)
+         FROM botTrades
+        WHERE fee_wallet IN (${terminalFeeWalletsSql})) AS terminal_fee_lamports,
+      (SELECT payout_lamports FROM cashbackPayouts) AS cashback_payout_lamports
+  `;
 
-  // const fees = await queryDuneSql(options, query);
-  // const dailyFees = options.createBalances();
-  // dailyFees.add(ADDRESSES.solana.SOL, fees[0].fee);
+  const [row] = await queryDuneSql(options, query);
+  const botFee = Number(row?.bot_fee_lamports ?? 0);
+  const terminalFee = Number(row?.terminal_fee_lamports ?? 0);
+  const cashbackPayout = Number(row?.cashback_payout_lamports ?? 0);
 
-  return { dailyFees, dailyRevenue: dailyFees, dailyProtocolRevenue: dailyFees }
-}
+  const dailyFees = options.createBalances();
+  dailyFees.add(ADDRESSES.solana.SOL, botFee, LABELS.BOT_FEES);
+  dailyFees.add(ADDRESSES.solana.SOL, terminalFee, LABELS.TERMINAL_FEES);
+
+  const dailySupplySideRevenue = options.createBalances();
+  dailySupplySideRevenue.add(
+    ADDRESSES.solana.SOL,
+    cashbackPayout,
+    LABELS.CASHBACK_REFERRAL,
+  );
+
+  // Net revenue retained by Trojan, split between the Bot and Terminal
+  // products in proportion to their gross-fee share. Cashback / referral
+  // claims are only emitted by the bot wallet so allocating the supply-side
+  // share strictly by gross-fee share is the closest reasonable mapping.
+  const dailyRevenue = options.createBalances();
+  const totalFee = botFee + terminalFee;
+  if (totalFee > 0) {
+    const botShare = botFee / totalFee;
+    const terminalShare = terminalFee / totalFee;
+    dailyRevenue.add(
+      ADDRESSES.solana.SOL,
+      botFee - cashbackPayout * botShare,
+      LABELS.BOT_REVENUE,
+    );
+    dailyRevenue.add(
+      ADDRESSES.solana.SOL,
+      terminalFee - cashbackPayout * terminalShare,
+      LABELS.TERMINAL_REVENUE,
+    );
+  } else if (cashbackPayout > 0) {
+    // Pure-payout day with zero gross fees: attribute the negative
+    // residual to the bot side (terminal wallets have no observed
+    // outflows so cannot account for it).
+    dailyRevenue.add(
+      ADDRESSES.solana.SOL,
+      -cashbackPayout,
+      LABELS.BOT_REVENUE,
+    );
+  }
+
+  return {
+    dailyFees,
+    dailyUserFees: dailyFees,
+    dailySupplySideRevenue,
+    dailyRevenue,
+    dailyProtocolRevenue: dailyRevenue,
+  };
+};
 
 const adapter: SimpleAdapter = {
   version: 2,
@@ -68,26 +174,46 @@ const adapter: SimpleAdapter = {
   fetch,
   chains: [CHAIN.SOLANA],
   start: '2024-01-04',
-  dependencies: [Dependencies.ALLIUM],
+  dependencies: [Dependencies.DUNE],
+  // Cashback / referral claims are paid in twice-daily batches and can
+  // exceed any single window's gross fee inflow. Letting the negative
+  // through preserves dailyFees = dailyRevenue + dailySupplySideRevenue
+  // across longer windows.
+  allowNegativeValue: true,
   methodology: {
-    Fees: 'All trading fees paid by users while using Trojan bot and Trojan Terminal.',
-    Revenue: 'Fees collected by Trojan protocol.',
-    ProtocolRevenue: "Fees collected by Trojan protocol.",
+    Fees:
+      'Gross per-trade fees collected by Trojan, restricted to DEX trades. Counts SOL inflows to the Trojan bot fee wallet and the five Trojan Terminal fee wallets when the transaction is present in dex_solana.trades — eliminates funding transfers and non-trade inflows.',
+    Revenue:
+      'Net fees retained by Trojan after cashback and referral rewards have been distributed back to users. Computed as dailyFees minus dailySupplySideRevenue and split between the Bot and Terminal products in proportion to their gross-fee share.',
+    ProtocolRevenue:
+      'Identical to Revenue (Trojan has no separate token-holder distribution at present).',
+    SupplySideRevenue:
+      'Cashback and referral rewards paid back to user trading wallets. Per the Trojan rewards program (docs.trojanonsolana.com): up to 35 percent direct referral revenue share, up to 47.5 percent at higher Honors ranks, plus 20 percent (45 percent at higher ranks) cashback on trading fees, paid out in SOL twice a day with a 0.005 SOL minimum per claim. Tracked as outflows from the Trojan bot wallet excluding the periodic large sweeps to the internal multisig staging EOA (DrXMnP...).',
   },
   breakdownMethodology: {
     Fees: {
-      'Trojan Bot Fees': 'Fees paid by users from Trojan Bot.',
-      'Trojan Terminal Fees': 'Fees paid by users from Trojan Terminal.',
+      [LABELS.BOT_FEES]:
+        'Per-trade fees received by the Telegram bot fee wallet 9yMwSPk9... on swaps initiated via the Trojan TG bot.',
+      [LABELS.TERMINAL_FEES]:
+        'Per-trade fees received by the five Trojan Terminal fee wallets (92Med3q, 2jwHNxa, 65gDv7p, BWgb8wR, 8jgg7mo) on swaps initiated via trojan.com terminal.',
     },
     Revenue: {
-      'Trojan Bot Fees': 'Fees paid by users from Trojan Bot.',
-      'Trojan Terminal Fees': 'Fees paid by users from Trojan Terminal.',
+      [LABELS.BOT_REVENUE]:
+        'Bot-side gross fees net of the bot share of cashback / referral payouts (allocated proportionally to gross-fee share).',
+      [LABELS.TERMINAL_REVENUE]:
+        'Terminal-side gross fees net of the terminal share of cashback / referral payouts.',
     },
     ProtocolRevenue: {
-      'Trojan Bot Fees': 'Fees paid by users from Trojan Bot.',
-      'Trojan Terminal Fees': 'Fees paid by users from Trojan Terminal.',
+      [LABELS.BOT_REVENUE]:
+        'Bot-side fees retained by Trojan after cashback / referral distributions.',
+      [LABELS.TERMINAL_REVENUE]:
+        'Terminal-side fees retained by Trojan after cashback / referral distributions.',
     },
-  }
+    SupplySideRevenue: {
+      [LABELS.CASHBACK_REFERRAL]:
+        'Total cashback + referral rewards sent from the Trojan bot wallet to user trading wallets in twice-daily batched SystemProgram transfers (excludes the periodic 100+ SOL sweeps to the internal multisig staging EOA).',
+    },
+  },
 };
 
 export default adapter;


### PR DESCRIPTION
Closes part of #6739 — the Trojan side. Axiom (#6789, merged) and Padre (#6997) have already landed the same pattern for their bots; this PR brings Trojan in line.

## Summary

The Trojan bot fee wallet (`9yMwSPk9mrXSN7yDHUuZurAh1sjbJsfpUqjZ7SvVtdco`) plays a dual role:
- **Inflow side** — collects per-trade fees on every swap routed through the Telegram bot.
- **Outflow side** — twice a day (`~00:02` and `~12:02 UTC`) it signs `SystemProgram` transfer batches that pay cashback + referral rewards out to user trading wallets.

The current adapter only counts the inflow side and treats every lamport the bot wallet receives as protocol revenue. That over-states `dailyRevenue` and leaves `dailySupplySideRevenue` empty, even though the cashback program is documented at [docs.trojanonsolana.com](https://docs.trojanonsolana.com/) (up to 35% direct referral revenue share, up to 47.5% at higher Honors ranks, plus 20–45% cashback on trading fees, min `0.005 SOL` per claim, twice a day).

This PR:
1. Adds the cashback / referral outflow to `dailySupplySideRevenue`.
2. Subtracts it from `dailyRevenue`, split between the Bot and Terminal products in proportion to gross-fee share.
3. Excludes the periodic internal treasury sweeps from the cashback figure — those are protocol-internal capital moves, not user distributions.
4. Switches the dune spell dependency from `ALLIUM` to `DUNE` and tightens the fee query so only DEX-trade fees are counted (joins `solana.account_activity` to `dex_solana.trades`).

## How the classification works

The bot wallet's outflows are a mix of two distinct things, and they have to be told apart before either can be billed correctly:

| Tx type | Recipients per tx | Sweep dest present? | Where the SOL goes |
|---|---|---|---|
| **Cashback / referral batch** | 4–15 user trading wallets | No | individual users |
| **Treasury sweep** | exactly 1 | Yes (`DrXMnP...`) | Squads multisig → wSOL treasury |

The SQL adds a `treasurySweepTxs` CTE that enumerates all outflow `tx_id`s in which `DrXMnPrFSiHA4JKKrSktTbAFrfvQCixHKvD7zGHxkzJP` receives a positive `balance_change`. The `cashbackPayouts` CTE then sums every bot-wallet outflow whose `tx_id` is **not** in that set. Clean, no heuristics on amount or recipient count.

## Addresses (Solana mainnet)

| Role | Address |
|---|---|
| Trojan bot fee wallet | `9yMwSPk9mrXSN7yDHUuZurAh1sjbJsfpUqjZ7SvVtdco` |
| Trojan terminal fee wallets | `92Med3qeK7duC5iiYsHX38H2f2twJfRsSx93oNrza2VH` |
|  | `2jwHNxavSoMZMEDbT1eV9PcPt5dDcayCqM6MkgaPpmWQ` |
|  | `65gDv7pZQCZELsNpNYSFEBtNFpWZAbxmRFB6BGMqFkHH` |
|  | `BWgb8wR1FEGiu1jCDSKuHKf752W27b4iN6SvoNCiK4qp` |
|  | `8jgg7moFJkHyTtAv9M6RBSPMp2oXeXhuiUMKW8YbYCWn` |
| Internal sweep destination (EOA) | `DrXMnPrFSiHA4JKKrSktTbAFrfvQCixHKvD7zGHxkzJP` |
| Squads multisig (downstream of sweep dest) | `DF1ow4tspfHX9JwWJsAb9epbkA8hmpSEAtxXy1V27QBH` |
| wSOL treasury (downstream of multisig) | `ATRsNGv2nDw7hSMfkUTBoVUDsFDwN7po7KbecyiGWNB4` |

## On-chain verification

I walked the bot wallet's last 24 hours of transactions through the Helius enhanced-tx API and applied the same `(bot_delta < 0)` + `(sweep_dest in recipients?)` rule that the SQL uses. Window ends 2026-05-19.

**Cadence — strict twice-daily:**

```
hr 00 UTC: 147 outflow txs   ← midnight batch
hr 01–11:    0 outflow txs
hr 12 UTC: 107 outflow txs   ← noon batch
hr 13–23:    0 outflow txs
```

Zero outflows in 22 of 24 hours. Matches the schedule in the docs.

**Volume split (24h):**

| Bucket | Txs | SOL | USD @ \$85.27 |
|---|---|---|---|
| Cashback / referral batch | 252 | 128.15 | \$10,927 |
| Treasury sweep | 2 | 239.06 | \$20,385 |

**Recipient distribution (cashback only):**
- Avg recipients per cashback tx: 14.9 (min 4, max 15) — fixed batch size capped at 15
- Unique recipients across 24h: **2,794**

This number was the question I spent the longest on. Trojan has many more than 2,794 daily traders — but the `0.005 SOL` minimum threshold means only users whose 12h cashback accrual clears that bar get paid in a given batch. The rest roll into a later one as their balance grows. Numbers are consistent with the rewards-program design.

**Spot-check on known tx_ids (5 cashback + 2 sweep):**

All 7 classified correctly under the SQL rule:

```
Cashback batch txs (12:02 UTC noon batch, 2026-05-18)
  Xw39S6axmwtTbRX5zkY8msuzXYQUrCNBGqS7iTj1GwZo...  → CASHBACK         15 recipients
  5S2wKrkKVRtYJ5XxRuueFRYNxkiMNjyHyao6cPHaUAho...  → CASHBACK         15 recipients
  3xoZwVtJQaj3t67gDr9BPtvBxCiroYVA9VzEudS7PCa1...  → CASHBACK         15 recipients
  WfDxJxTzSRd5BV8V8xZctTWhiSdPWVGeeftW7J29Xdyk...  → CASHBACK         15 recipients
  4EZPu8RohyRdKcM6maMaX8GqC1HKp7UXJ8QMCwE8bUfd...  → CASHBACK         15 recipients

Treasury sweeps (single-recipient, recipient = DrXMnP...)
  4DMah379k1eJP1aZNJbqB25TH8BRyvYgPCqzwceNLc3H...  → TREASURY_SWEEP    1 recipient
  5VsArDdxrnUCzKJkuGgvuweQE4rfzft1ZCN8RBdrr4Sz...  → TREASURY_SWEEP    1 recipient
```

## Adapter math after this change

```
dailyFees                = bot_per_trade_fees + terminal_per_trade_fees
dailySupplySideRevenue   = bot_cashback_payouts  (terminal wallets have zero outflows in 24h)
dailyRevenue             = dailyFees - dailySupplySideRevenue
                           (split bot/terminal by gross-fee share)
dailyProtocolRevenue     = dailyRevenue
```

`allowNegativeValue: true` is added because the cashback batches can exceed a single hourly window's gross fees, and `pullHourly: true` is on. The invariant `dailyFees = dailyRevenue + dailySupplySideRevenue` then holds across longer windows.

## breakdownMethodology

| Label | Goes into | Description |
|---|---|---|
| `Trojan Bot Trading Fees` | Fees | Per-trade fees on the Telegram bot wallet |
| `Trojan Terminal Trading Fees` | Fees | Per-trade fees on the five terminal wallets |
| `Trojan Bot Fees To Protocol` | Revenue, ProtocolRevenue | Bot-side gross fees net of bot-share of cashback |
| `Trojan Terminal Fees To Protocol` | Revenue, ProtocolRevenue | Terminal-side gross fees net of terminal-share of cashback |
| `Trojan Cashback And Referral Payouts` | SupplySideRevenue | Bot-wallet outflows excluding the sweep tx_ids |

## Test plan

- [x] Verified the 7 spot-check tx_ids classify correctly via Helius
- [x] Verified the twice-daily cadence holds across a full 24h window
- [x] Verified unique-recipient count is consistent with the docs' 0.005 SOL minimum
- [x] Verified `DrXMnP...` is not a Trojan terminal/fee wallet (single-recipient sweeps only)
- [x] Verified the wSOL treasury account `ATRsNG...` holds ~20k SOL (downstream of the multisig)
- [ ] Run from Dune dashboard against `start_date = 2024-01-04` to confirm no negative-value blow-up over historical windows

"Allow edits by maintainers" is enabled.