### PR TITLE
fix: mira-ly graph endpoint

### DIFF
--- a/dexs/mira-ly/index.ts
+++ b/dexs/mira-ly/index.ts
@@ -3,7 +3,7 @@ import { FetchOptions, SimpleAdapter } from "../../adapters/types"
 import { CHAIN } from "../../helpers/chains"
 import { httpPost } from "../../utils/fetchURL";
 
-const graphUrl = 'https://mira-dex.squids.live/mira-indexer@v2/api/graphql'
+const graphUrl = 'https://mira-dex.squids.live/mira-indexer@v3/api/graphql'
 
 const fetchVolume = async (timestamp: number, _:any, options: FetchOptions) => {
   const start = options.startOfDay;


### PR DESCRIPTION
v2 indexer is unreachable, replaced it with v3