### PR TITLE
fix(dexs/alex): replace dead adapter with graphql api

### DIFF
--- a/dexs/alex/index.ts
+++ b/dexs/alex/index.ts
@@ -120,6 +120,12 @@ async function fetchLegacy(dayStart: number): Promise<number> {
     }
   }
 
+  const unresolvedTokens = tokenNames.filter((token) => !(token in prices));
+  if (unresolvedTokens.length) {
+    console.error(`ALEX legacy prices missing for ${dayStart}: ${unresolvedTokens.join(",")}`);
+    return 0;
+  }
+
   let totalUSD = 0;
   for (const snap of Object.values(lastSnap)) {
     const tokenName = snap.token_x.split(".").pop()!;

--- a/dexs/alex/index.ts
+++ b/dexs/alex/index.ts
@@ -1,40 +1,138 @@
-import fetchURL from "../../utils/fetchURL"
-import { Chain } from "../../adapters/types";
+import { postURL } from "../../utils/fetchURL"
 import { SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
-import { getUniqStartOfTodayTimestamp } from "../../helpers/getUniSubgraphVolume";
 
-const historicalVolumeEndpoint = "https://alexgo-io.metabaseapp.com/api/public/dashboard/66cca0ba-7735-46c5-adfb-d80535506f4a/dashcard/464/card/496?parameters=%5B%5D"
+const V2_GQL = "https://gql-v2.alexlab.co/v1/graphql";
+const V1_GQL = "https://gql.alexlab.co/v1/graphql";
 
-interface IVolumeall {
-  volume: string;
-  time: string;
+const V2_DAILY_START = 1720224000; // 2024-07-06
+const V1_1_START = 1683072000;     // 2023-05-03
+
+function startOfDayUTC(timestamp: number): number {
+  const d = new Date(timestamp * 1000);
+  return Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()) / 1000;
 }
 
+// 2024-07-06+: daily aggregates, volume in USD * 1e18
+async function fetchV2Daily(dayStart: number): Promise<number> {
+  const gte = new Date(dayStart * 1000).toISOString();
+  const lt = new Date((dayStart + 86400) * 1000).toISOString();
+  const res = await postURL(V2_GQL, {
+    query: `{
+      sink_mart_amm_pool_v2_1_volume_by_pool_1d(
+        where: { date: { _gte: "${gte}", _lt: "${lt}" } }
+      ) { volume }
+    }`,
+  });
+  const rows: { volume: string }[] = res.data.sink_mart_amm_pool_v2_1_volume_by_pool_1d;
+  return rows.reduce((s, r) => s + Number(r.volume), 0) / 1e18;
+}
+
+// 2023-05-03 to 2024-05-18: per-block snapshots, volume_24h in USD * 1e18
+// Take the last snapshot per pool within the day and sum.
+async function fetchV1_1(dayStart: number): Promise<number> {
+  const dayEnd = dayStart + 86400;
+  const res = await postURL(V2_GQL, {
+    query: `{
+      amm_swap_pool_stats_v1_1(
+        where: { burn_block_time: { _gte: ${dayStart}, _lt: ${dayEnd} } }
+      ) { burn_block_time pool_id volume_24h }
+    }`,
+  });
+  const rows: Array<{ burn_block_time: number; pool_id: number; volume_24h: string }> =
+    res.data.amm_swap_pool_stats_v1_1;
+  const lastVol: Record<number, { ts: number; vol: number }> = {};
+  for (const r of rows) {
+    const entry = lastVol[r.pool_id];
+    if (!entry || r.burn_block_time > entry.ts)
+      lastVol[r.pool_id] = { ts: r.burn_block_time, vol: Number(r.volume_24h) };
+  }
+  return Object.values(lastVol).reduce((s, e) => s + e.vol, 0) / 1e18;
+}
+
+// 2022-01-23 to 2023-05-03: laplace_pool_stats with price conversion.
+// volume_x_24h is in token_x units * 1e8; multiply by USD price.
+async function fetchLegacy(dayStart: number): Promise<number> {
+  const dayEnd = dayStart + 86400;
+  const statsRes = await postURL(V1_GQL, {
+    query: `{
+      laplace_pool_stats(
+        where: { burn_block_time: { _gte: ${dayStart}, _lt: ${dayEnd} } }
+      ) { burn_block_time pool_token token_x volume_x_24h }
+    }`,
+  });
+  const stats: Array<{
+    burn_block_time: number;
+    pool_token: string;
+    token_x: string;
+    volume_x_24h: string;
+  }> = statsRes.data.laplace_pool_stats;
+
+  if (!stats.length) return 0;
+
+  const lastSnap: Record<string, (typeof stats)[0]> = {};
+  for (const r of stats) {
+    const cur = lastSnap[r.pool_token];
+    if (!cur || r.burn_block_time > cur.burn_block_time) lastSnap[r.pool_token] = r;
+  }
+
+  const tokenNames = [
+    ...new Set(Object.values(lastSnap).map((s) => s.token_x.split(".").pop()!)),
+  ];
+
+  const buildPriceQuery = (gte: number, lt: number) => `{
+    laplace_history_price_v2(
+      where: {
+        burn_block_time: { _gte: ${gte}, _lt: ${lt} }
+        token: { _in: ${JSON.stringify(tokenNames)} }
+      }
+      order_by: { burn_block_time: desc }
+    ) { token avg_price_usd }
+  }`;
+
+  let priceRows: Array<{ token: string; avg_price_usd: number }> =
+    (await postURL(V1_GQL, { query: buildPriceQuery(dayStart, dayEnd) }))
+      .data.laplace_history_price_v2;
+
+  if (!priceRows.length) {
+    priceRows = (
+      await postURL(V1_GQL, { query: buildPriceQuery(dayStart - 7 * 86400, dayEnd) })
+    ).data.laplace_history_price_v2;
+  }
+
+  const prices: Record<string, number> = {};
+  for (const r of priceRows) {
+    if (!(r.token in prices)) prices[r.token] = r.avg_price_usd;
+  }
+
+  let totalUSD = 0;
+  for (const snap of Object.values(lastSnap)) {
+    const tokenName = snap.token_x.split(".").pop()!;
+    totalUSD += (Number(snap.volume_x_24h) / 1e8) * (prices[tokenName] ?? 0);
+  }
+  return totalUSD;
+}
 
 const fetch = async (timestamp: number) => {
-  const dayTimestamp = getUniqStartOfTodayTimestamp(new Date(timestamp * 1000))
-  const callhistoricalVolume = (await fetchURL(historicalVolumeEndpoint)).data.rows;
-  const historicalVolume: IVolumeall[] = callhistoricalVolume.map((e: string[] | number[]) => {
-    const [time, volume] = e;
-    return {
-      time,
-      volume
-    };
-  });
+  const dayStart = startOfDayUTC(timestamp);
 
-  const dailyVolume = historicalVolume
-    .find(dayItem => (new Date(dayItem.time).getTime() / 1000) === dayTimestamp)?.volume
+  let dailyVolume: number;
+  if (dayStart >= V2_DAILY_START) {
+    dailyVolume = await fetchV2Daily(dayStart);
+  } else if (dayStart >= V1_1_START) {
+    dailyVolume = await fetchV1_1(dayStart);
+  } else {
+    dailyVolume = await fetchLegacy(dayStart);
+  }
 
-  return {
-    dailyVolume: dailyVolume,
-  };
+  return { dailyVolume: dailyVolume || undefined };
 };
 
 const adapter: SimpleAdapter = {
   adapter: {
     [CHAIN.STACKS]: {
       fetch,
+      start: "2022-01-23",
     },
   },
 };

--- a/dexs/alex/index.ts
+++ b/dexs/alex/index.ts
@@ -90,19 +90,34 @@ async function fetchLegacy(dayStart: number): Promise<number> {
     ) { token avg_price_usd }
   }`;
 
-  let priceRows: Array<{ token: string; avg_price_usd: number }> =
+  const priceRows: Array<{ token: string; avg_price_usd: number }> =
     (await postURL(V1_GQL, { query: buildPriceQuery(dayStart, dayEnd) }))
       .data.laplace_history_price_v2;
 
-  if (!priceRows.length) {
-    priceRows = (
-      await postURL(V1_GQL, { query: buildPriceQuery(dayStart - 7 * 86400, dayEnd) })
-    ).data.laplace_history_price_v2;
-  }
-
   const prices: Record<string, number> = {};
   for (const r of priceRows) {
-    if (!(r.token in prices)) prices[r.token] = r.avg_price_usd;
+    if (!(r.token in prices)) prices[r.token] = Number(r.avg_price_usd);
+  }
+
+  const missingTokens = tokenNames.filter((token) => !(token in prices));
+  if (missingTokens.length) {
+    const backfillRows: Array<{ token: string; avg_price_usd: number }> = (
+      await postURL(V1_GQL, {
+        query: `{
+          laplace_history_price_v2(
+            where: {
+              burn_block_time: { _gte: ${dayStart - 7 * 86400}, _lt: ${dayEnd} }
+              token: { _in: ${JSON.stringify(missingTokens)} }
+            }
+            order_by: { burn_block_time: desc }
+          ) { token avg_price_usd }
+        }`,
+      })
+    ).data.laplace_history_price_v2;
+
+    for (const r of backfillRows) {
+      if (!(r.token in prices)) prices[r.token] = Number(r.avg_price_usd);
+    }
   }
 
   let totalUSD = 0;
@@ -125,7 +140,7 @@ const fetch = async (timestamp: number) => {
     dailyVolume = await fetchLegacy(dayStart);
   }
 
-  return { dailyVolume: dailyVolume || undefined };
+  return { dailyVolume };
 };
 
 const adapter: SimpleAdapter = {


### PR DESCRIPTION
- Fixes broken ALEX DEX volume adapter, the old Metabase endpoint (alexgo-io.metabaseapp.com) was returning 404
- Migrates to ALEX's public GraphQL APIs (gql.alexlab.co, gql-v2.alexlab.co)
- Restores full history back to 2022-01-23

## Data sources by period

| Period | Source | Notes |
|---|---|---|
| 2022-01-23 → 2023-05-03 | `laplace_pool_stats` + `laplace_history_price_v2` | Token volumes × USD price |
| 2023-05-03 → 2024-05-18 | `amm_swap_pool_stats_v1_1` | USD × 1e18, last snapshot per pool per day |
| 2024-07-06 → present | `sink_mart_amm_pool_v2_1_volume_by_pool_1d` | Daily aggregates, USD × 1e18 |

The ~50-day gap (2024-05-18 → 2024-07-06) is due to inactivity during the v1 → v2 contract migration.