### PR TITLE
[fix] Maestro-Bot: account referral rewards as supplySide revenue

### DIFF
--- a/fees/maestro.ts
+++ b/fees/maestro.ts
@@ -4,6 +4,7 @@ import { getAlliumChain, queryAllium } from "../helpers/allium";
 import ADDRESSES from "../helpers/coreAssets.json";
 import { METRIC } from "../helpers/metrics";
 
+// Wallets are from personal research findings, not Maestro team docs.
 const LABELS = {
   BOT_REVENUE: 'Trading fees excluding referral rewards',
   REWARDS: 'Referral rewards',
@@ -20,7 +21,7 @@ const chainConfig: any = {
   [CHAIN.SOLANA]: {
     start: '2024-03-05',
     feeAddresses: ['MaestroUL88UBnZr3wfoN7hqmNWFi3ZYCGqZoJJHE36', 'FRMxAnZgkW58zbYcE7Bxqsg99VWpJh6sMP5xLzAWNabN'],
-    // Maestro-funded wallet that relays SOL referral rewards to users.
+    // Reward relay memo: MaestroReferral.
     rewardRelay: 'BNuebGMyAsrLytsS13whc3qUqbnM9mVwUJcumD31m5zA',
   },
   // [CHAIN.TRON]: {

--- a/fees/maestro.ts
+++ b/fees/maestro.ts
@@ -2,11 +2,11 @@ import { CHAIN } from "../helpers/chains";
 import { SimpleAdapter, FetchOptions, Dependencies, } from "../adapters/types";
 import { getAlliumChain, queryAllium } from "../helpers/allium";
 import ADDRESSES from "../helpers/coreAssets.json";
+import { METRIC } from "../helpers/metrics";
 
 const LABELS = {
-  BOT_FEES: 'Trading fees paid by users',
   BOT_REVENUE: 'Trading fees excluding referral rewards',
-  REFERRAL_FEES: 'Referral rewards',
+  REWARDS: 'Referral rewards',
 }
 
 // const TONFeeAddress = 'TXNP92LYmnPZzqnXwwsmotizTcNyPGxxEv'
@@ -40,37 +40,28 @@ async function fetchEVM(options: FetchOptions) {
   const feeAddress = config.feeAddress!.toLowerCase()
   const rewardFundingSources = [config.feeAddress, config.dispatcher].filter(Boolean).map((address: string) => `'${address.toLowerCase()}'`).join(', ')
   const internalAddresses = Object.values(chainConfig).flatMap((config: any) => [config.feeAddress, config.dispatcher, config.rewardRelay]).filter((address: any) => address?.startsWith?.('0x')).map((address: string) => `'${address.toLowerCase()}'`).join(', ')
-  const rewardsQuery = config.rewardRelay ? `
-    SELECT COALESCE(SUM(raw_amount), 0) AS amount
-    FROM ${chainKey}.assets.native_token_transfers
-    WHERE to_address = '${config.rewardRelay.toLowerCase()}'
-      AND from_address IN (${rewardFundingSources})
-      AND transfer_type = 'value_transfer'
-      AND raw_amount > 0
-      AND block_timestamp >= TO_TIMESTAMP_NTZ(${options.startTimestamp})
-      AND block_timestamp < TO_TIMESTAMP_NTZ(${options.endTimestamp})
-  ` : 'SELECT 0 AS amount'
+  const rewardFilter = config.rewardRelay ? `OR (to_address = '${config.rewardRelay.toLowerCase()}' AND from_address IN (${rewardFundingSources}))` : ''
 
   const query = `
-    SELECT
-      (SELECT COALESCE(SUM(raw_amount), 0)
+    WITH data AS (
+      SELECT
+      COALESCE(SUM(CASE WHEN to_address = '${feeAddress}' AND from_address NOT IN (${internalAddresses}) THEN TRY_TO_DECIMAL(raw_amount_str, 38, 0) ELSE 0 END), 0) AS fees,
+      COALESCE(SUM(CASE WHEN ${config.rewardRelay ? `to_address = '${config.rewardRelay.toLowerCase()}' AND from_address IN (${rewardFundingSources})` : 'FALSE'} THEN TRY_TO_DECIMAL(raw_amount_str, 38, 0) ELSE 0 END), 0) AS referral_rewards
       FROM ${chainKey}.assets.native_token_transfers
-      WHERE to_address = '${feeAddress}'
-        AND from_address NOT IN (${internalAddresses})
-        AND transfer_type = 'value_transfer'
+      WHERE transfer_type = 'value_transfer'
         AND raw_amount > 0
         AND block_timestamp >= TO_TIMESTAMP_NTZ(${options.startTimestamp})
         AND block_timestamp < TO_TIMESTAMP_NTZ(${options.endTimestamp})
-      ) AS fees,
-      (SELECT amount FROM (${rewardsQuery})) AS referral_rewards
+        AND (to_address = '${feeAddress}' ${rewardFilter})
+    )
+    SELECT TO_VARCHAR(fees) AS fees, TO_VARCHAR(referral_rewards) AS referral_rewards, TO_VARCHAR(fees - referral_rewards) AS revenue FROM data
   `
 
   const result = (await queryAllium(query))[0]
-  const revenue = (BigInt(result.fees ?? 0) - BigInt(result.referral_rewards ?? 0)).toString()
 
-  dailyFees.addGasToken(result.fees, LABELS.BOT_FEES)
-  dailyRevenue.addGasToken(revenue, LABELS.BOT_REVENUE)
-  dailySupplySideRevenue.addGasToken(result.referral_rewards, LABELS.REFERRAL_FEES)
+  dailyFees.addGasToken(result.fees, METRIC.TRADING_FEES)
+  dailyRevenue.addGasToken(result.revenue, LABELS.BOT_REVENUE)
+  dailySupplySideRevenue.addGasToken(result.referral_rewards, LABELS.REWARDS)
   return { dailyFees, dailyRevenue, dailyProtocolRevenue: dailyRevenue, dailySupplySideRevenue }
 }
 
@@ -81,39 +72,30 @@ async function fetchSolana(options: FetchOptions) {
   const dailySupplySideRevenue = options.createBalances()
   const feeAddresses = config.feeAddresses.map((address: string) => `'${address}'`).join(', ')
   const query = `
-    SELECT
-      (SELECT COALESCE(SUM(raw_amount), 0)
+    WITH data AS (
+      SELECT
+      COALESCE(SUM(CASE WHEN to_address IN (${feeAddresses}) AND from_address NOT IN (${feeAddresses}) THEN TRY_TO_DECIMAL(raw_amount_str, 38, 0) ELSE 0 END), 0) AS fees,
+      COALESCE(SUM(CASE WHEN to_address = '${config.rewardRelay}' AND from_address IN (${feeAddresses}) THEN TRY_TO_DECIMAL(raw_amount_str, 38, 0) ELSE 0 END), 0) AS referral_rewards
       FROM solana.assets.transfers
-      WHERE to_address IN (${feeAddresses})
-        AND from_address NOT IN (${feeAddresses})
-        AND mint = '${ADDRESSES.solana.SOL}'
+      WHERE mint = '${ADDRESSES.solana.SOL}'
         AND transfer_type = 'sol_transfer'
         AND raw_amount > 0
         AND block_timestamp >= TO_TIMESTAMP_NTZ(${options.startTimestamp})
         AND block_timestamp < TO_TIMESTAMP_NTZ(${options.endTimestamp})
-      ) AS fees,
-      (SELECT COALESCE(SUM(raw_amount), 0)
-      FROM solana.assets.transfers
-      WHERE to_address = '${config.rewardRelay}'
-        AND from_address IN (${feeAddresses})
-        AND mint = '${ADDRESSES.solana.SOL}'
-        AND transfer_type = 'sol_transfer'
-        AND raw_amount > 0
-        AND block_timestamp >= TO_TIMESTAMP_NTZ(${options.startTimestamp})
-        AND block_timestamp < TO_TIMESTAMP_NTZ(${options.endTimestamp})
-      ) AS referral_rewards
+        AND (to_address IN (${feeAddresses}) OR to_address = '${config.rewardRelay}')
+    )
+    SELECT TO_VARCHAR(fees) AS fees, TO_VARCHAR(referral_rewards) AS referral_rewards, TO_VARCHAR(fees - referral_rewards) AS revenue FROM data
   `
 
   const result = (await queryAllium(query))[0]
-  const revenue = (BigInt(result.fees ?? 0) - BigInt(result.referral_rewards ?? 0)).toString()
 
-  dailyFees.add(ADDRESSES.solana.SOL, result.fees, LABELS.BOT_FEES)
-  dailyRevenue.add(ADDRESSES.solana.SOL, revenue, LABELS.BOT_REVENUE)
-  dailySupplySideRevenue.add(ADDRESSES.solana.SOL, result.referral_rewards, LABELS.REFERRAL_FEES)
+  dailyFees.add(ADDRESSES.solana.SOL, result.fees, METRIC.TRADING_FEES)
+  dailyRevenue.add(ADDRESSES.solana.SOL, result.revenue, LABELS.BOT_REVENUE)
+  dailySupplySideRevenue.add(ADDRESSES.solana.SOL, result.referral_rewards, LABELS.REWARDS)
   return { dailyFees, dailyRevenue, dailyProtocolRevenue: dailyRevenue, dailySupplySideRevenue }
 } 
 
-async function fetch(options: FetchOptions) {
+async function fetch(_a: any, _b: any, options: FetchOptions) {
   return options.chain === CHAIN.SOLANA ? fetchSolana(options) : fetchEVM(options)
 }
 
@@ -126,7 +108,7 @@ const methodology = {
 
 const breakdownMethodology = {
   Fees: {
-    [LABELS.BOT_FEES]: "Trading fees paid by users while using Maestro bot.",
+    [METRIC.TRADING_FEES]: "Trading fees paid by users while using Maestro bot.",
   },
   Revenue: {
     [LABELS.BOT_REVENUE]: "Trading fees kept by Maestro after referral rewards.",
@@ -135,13 +117,12 @@ const breakdownMethodology = {
     [LABELS.BOT_REVENUE]: "Trading fees kept by Maestro after referral rewards.",
   },
   SupplySideRevenue: {
-    [LABELS.REFERRAL_FEES]: "Referral rewards paid to Maestro users.",
+    [LABELS.REWARDS]: "Referral rewards paid to Maestro users.",
   },
 }
 
 const adapter: SimpleAdapter = {
-  version: 2,
-  pullHourly: true,
+  version: 1,
   fetch,
   adapter: chainConfig,
   methodology,

--- a/fees/maestro.ts
+++ b/fees/maestro.ts
@@ -5,6 +5,8 @@ import ADDRESSES from "../helpers/coreAssets.json";
 import { METRIC } from "../helpers/metrics";
 
 // Wallets are from personal research findings, not Maestro team docs.
+// verfied based on the memo as 'maestro referral' in tx
+
 const LABELS = {
   BOT_REVENUE: 'Trading fees excluding referral rewards',
   REWARDS: 'Referral rewards',

--- a/fees/maestro.ts
+++ b/fees/maestro.ts
@@ -1,64 +1,156 @@
 import { CHAIN } from "../helpers/chains";
 import { SimpleAdapter, FetchOptions, Dependencies, } from "../adapters/types";
-import { addTokensReceived, getETHReceived, getSolanaReceived } from "../helpers/token";
+import { getAlliumChain, queryAllium } from "../helpers/allium";
+import ADDRESSES from "../helpers/coreAssets.json";
 
-const dispatcher: any = {
-  [CHAIN.ETHEREUM]: "0x2ff99ee6b22aedaefd8fd12497e504b18983cb14",
-  [CHAIN.BSC]: "0x7176456e98443a7000b44e09149a540d06733965",
-  [CHAIN.ARBITRUM]: "0x34b5561c30a152b5882c8924973f19df698470f4",
-  [CHAIN.BASE]: "0x2CDF4CAdF2272B77475732446Ba664443277E8C1",
-  [CHAIN.TRON]: "0xeabcabB91FC7191ecc2002FAc9e269C96d914BAB"
+const LABELS = {
+  BOT_FEES: 'Trading fees paid by users',
+  BOT_REVENUE: 'Trading fees excluding referral rewards',
+  REFERRAL_FEES: 'Referral rewards',
 }
 
-const feesAddress = '0xB0999731f7c2581844658A9d2ced1be0077b7397'
 // const TONFeeAddress = 'TXNP92LYmnPZzqnXwwsmotizTcNyPGxxEv'
+const chainConfig: any = {
+  [CHAIN.ETHEREUM]: { start: '2022-07-01', feeAddress: '0xB0999731f7c2581844658A9d2ced1be0077b7397', dispatcher: '0x2ff99ee6b22aedaefd8fd12497e504b18983cb14', rewardRelay: '0x5314A41f27BFe2fDe86CCd4B6f08c398Be538D8f' },
+  [CHAIN.BSC]: { start: '2022-07-01', feeAddress: '0xB0999731f7c2581844658A9d2ced1be0077b7397', dispatcher: '0x7176456e98443a7000b44e09149a540d06733965', rewardRelay: '0x5314A41f27BFe2fDe86CCd4B6f08c398Be538D8f' },
+  [CHAIN.ARBITRUM]: { start: '2022-07-01', feeAddress: '0xB0999731f7c2581844658A9d2ced1be0077b7397', dispatcher: '0x34b5561c30a152b5882c8924973f19df698470f4', rewardRelay: '0x5314A41f27BFe2fDe86CCd4B6f08c398Be538D8f' },
+  [CHAIN.BASE]: { start: '2024-06-19', feeAddress: '0xB0999731f7c2581844658A9d2ced1be0077b7397', dispatcher: '0x2CDF4CAdF2272B77475732446Ba664443277E8C1', rewardRelay: '0x5314A41f27BFe2fDe86CCd4B6f08c398Be538D8f' },
+  [CHAIN.SONIC]: { start: '2025-02-26', feeAddress: '0xB0999731f7c2581844658A9d2ced1be0077b7397' },
+  [CHAIN.AVAX]: { start: '2025-06-08', feeAddress: '0xB0999731f7c2581844658A9d2ced1be0077b7397' },
+  [CHAIN.SOLANA]: {
+    fetch: fetchSolana,
+    start: '2024-03-05',
+    feeAddresses: ['MaestroUL88UBnZr3wfoN7hqmNWFi3ZYCGqZoJJHE36', 'FRMxAnZgkW58zbYcE7Bxqsg99VWpJh6sMP5xLzAWNabN'],
+    // Maestro-funded wallet that relays SOL referral rewards to users.
+    rewardRelay: 'BNuebGMyAsrLytsS13whc3qUqbnM9mVwUJcumD31m5zA',
+  },
+  // [CHAIN.TRON]: {
+  //   start: '2022-07-01',
+  //   feeAddress: '0xB0999731f7c2581844658A9d2ced1be0077b7397',
+  //   dispatcher: '0xeabcabB91FC7191ecc2002FAc9e269C96d914BAB',
+  // },
+  // [CHAIN.HYPERLIQUID]: { start: '2025-05-27' },
+}
+
+async function fetchEVM(options: FetchOptions) {
+  const config = chainConfig[options.chain]
+  const dailyFees = options.createBalances()
+  const dailyRevenue = options.createBalances()
+  const dailyProtocolRevenue = options.createBalances()
+  const dailySupplySideRevenue = options.createBalances()
+  const chainKey = getAlliumChain(options.chain)
+  const feeAddress = config.feeAddress!.toLowerCase()
+  const rewardFundingSources = [config.feeAddress, config.dispatcher].filter(Boolean).map((address: string) => `'${address.toLowerCase()}'`).join(', ')
+  const internalAddresses = Object.values(chainConfig).flatMap((config: any) => [config.feeAddress, config.dispatcher, config.rewardRelay]).filter((address: any) => address?.startsWith?.('0x')).map((address: string) => `'${address.toLowerCase()}'`).join(', ')
+  const rewardsQuery = config.rewardRelay ? `
+    SELECT COALESCE(SUM(raw_amount), 0) AS amount
+    FROM ${chainKey}.assets.native_token_transfers
+    WHERE to_address = '${config.rewardRelay.toLowerCase()}'
+      AND from_address IN (${rewardFundingSources})
+      AND transfer_type = 'value_transfer'
+      AND raw_amount > 0
+      AND block_timestamp >= TO_TIMESTAMP_NTZ(${options.startTimestamp})
+      AND block_timestamp < TO_TIMESTAMP_NTZ(${options.endTimestamp})
+  ` : 'SELECT 0 AS amount'
+
+  const query = `
+    SELECT
+      (SELECT COALESCE(SUM(raw_amount), 0)
+      FROM ${chainKey}.assets.native_token_transfers
+      WHERE to_address = '${feeAddress}'
+        AND from_address NOT IN (${internalAddresses})
+        AND transfer_type = 'value_transfer'
+        AND raw_amount > 0
+        AND block_timestamp >= TO_TIMESTAMP_NTZ(${options.startTimestamp})
+        AND block_timestamp < TO_TIMESTAMP_NTZ(${options.endTimestamp})
+      ) AS fees,
+      (SELECT amount FROM (${rewardsQuery})) AS referral_rewards
+  `
+
+  const result = (await queryAllium(query))[0]
+  const revenue = (BigInt(result.fees ?? 0) - BigInt(result.referral_rewards ?? 0)).toString()
+
+  dailyFees.addGasToken(result.fees, LABELS.BOT_FEES)
+  dailyRevenue.addGasToken(revenue, LABELS.BOT_REVENUE)
+  dailySupplySideRevenue.addGasToken(result.referral_rewards, LABELS.REFERRAL_FEES)
+  return { dailyFees, dailyRevenue, dailyProtocolRevenue: dailyRevenue, dailySupplySideRevenue }
+}
+
+async function fetchSolana(options: FetchOptions) {
+  const config = chainConfig[CHAIN.SOLANA]
+  const dailyFees = options.createBalances()
+  const dailyRevenue = options.createBalances()
+  const dailyProtocolRevenue = options.createBalances()
+  const dailySupplySideRevenue = options.createBalances()
+  const feeAddresses = config.feeAddresses.map((address: string) => `'${address}'`).join(', ')
+  const query = `
+    SELECT
+      (SELECT COALESCE(SUM(raw_amount), 0)
+      FROM solana.assets.transfers
+      WHERE to_address IN (${feeAddresses})
+        AND from_address NOT IN (${feeAddresses})
+        AND mint = '${ADDRESSES.solana.SOL}'
+        AND transfer_type = 'sol_transfer'
+        AND raw_amount > 0
+        AND block_timestamp >= TO_TIMESTAMP_NTZ(${options.startTimestamp})
+        AND block_timestamp < TO_TIMESTAMP_NTZ(${options.endTimestamp})
+      ) AS fees,
+      (SELECT COALESCE(SUM(raw_amount), 0)
+      FROM solana.assets.transfers
+      WHERE to_address = '${config.rewardRelay}'
+        AND from_address IN (${feeAddresses})
+        AND mint = '${ADDRESSES.solana.SOL}'
+        AND transfer_type = 'sol_transfer'
+        AND raw_amount > 0
+        AND block_timestamp >= TO_TIMESTAMP_NTZ(${options.startTimestamp})
+        AND block_timestamp < TO_TIMESTAMP_NTZ(${options.endTimestamp})
+      ) AS referral_rewards
+  `
+
+  const result = (await queryAllium(query))[0]
+  const revenue = (BigInt(result.fees ?? 0) - BigInt(result.referral_rewards ?? 0)).toString()
+
+  dailyFees.add(ADDRESSES.solana.SOL, result.fees, LABELS.BOT_FEES)
+  dailyRevenue.add(ADDRESSES.solana.SOL, revenue, LABELS.BOT_REVENUE)
+  dailySupplySideRevenue.add(ADDRESSES.solana.SOL, result.referral_rewards, LABELS.REFERRAL_FEES)
+  return { dailyFees, dailyRevenue, dailyProtocolRevenue: dailyRevenue, dailySupplySideRevenue }
+} 
 
 async function fetch(options: FetchOptions) {
-  const dailyFees = options.createBalances()
-  // const have_dispatcher = Object.keys(dispatcher).includes(options.chain)
-
-  // if (have_dispatcher) {
-  //   const logs = await options.getLogs({ target: dispatcher[options.chain], eventAbi: 'event BalanceTransfer (address to, uint256 amount)', })
-  //   logs.map((log: any) => dailyFees.addGasToken(log.amount))
-  // } else {
-  await addTokensReceived({ options, target: feesAddress, balances: dailyFees })
-  await getETHReceived({ options, target: feesAddress, balances: dailyFees })
-  // }
-
-  return { dailyFees, dailyRevenue: dailyFees, dailyProtocolRevenue: dailyFees }
-}
-
-const fetchSolana: any = async (options: FetchOptions) => {
-  const dailyFees = await getSolanaReceived({ options, targets: ['MaestroUL88UBnZr3wfoN7hqmNWFi3ZYCGqZoJJHE36', 'FRMxAnZgkW58zbYcE7Bxqsg99VWpJh6sMP5xLzAWNabN'] })
-  return { dailyFees, dailyRevenue: dailyFees, dailyProtocolRevenue: dailyFees }
+  return options.chain === CHAIN.SOLANA ? fetchSolana(options) : fetchEVM(options)
 }
 
 const methodology = {
   Fees: "All trading fees paid by users while using Maestro bot.",
-  Revenue: "Trading fees are collected by Maestro protocol.",
-  ProtocolRevenue: "Trading fees are collected by Maestro protocol.",
+  Revenue: "Trading fees kept by Maestro protocol after referral rewards.",
+  ProtocolRevenue: "Trading fees kept by Maestro protocol after referral rewards.",
+  SupplySideRevenue: "Referral rewards paid to Maestro users.",
+}
+
+const breakdownMethodology = {
+  Fees: {
+    [LABELS.BOT_FEES]: "Trading fees paid by users while using Maestro bot.",
+  },
+  Revenue: {
+    [LABELS.BOT_REVENUE]: "Trading fees kept by Maestro after referral rewards.",
+  },
+  ProtocolRevenue: {
+    [LABELS.BOT_REVENUE]: "Trading fees kept by Maestro after referral rewards.",
+  },
+  SupplySideRevenue: {
+    [LABELS.REFERRAL_FEES]: "Referral rewards paid to Maestro users.",
+  },
 }
 
 const adapter: SimpleAdapter = {
   version: 2,
   pullHourly: true,
   fetch,
-  adapter: {
-    [CHAIN.ETHEREUM]: { start: '2022-07-01', },
-    [CHAIN.BSC]: { start: '2022-07-01', },
-    [CHAIN.ARBITRUM]: { start: '2022-07-01', },
-    [CHAIN.BASE]: { start: '2024-06-19', },
-    [CHAIN.SONIC]: { start: '2025-02-26', },
-    [CHAIN.AVAX]: { start: '2025-06-08', },
-    // [CHAIN.TRON]: { start: '2022-07-01', },
-    // [CHAIN.HYPERLIQUID]: { start: '2025-05-27', },
-    [CHAIN.SOLANA]: {
-      fetch: fetchSolana,
-      start: '2024-03-05',
-    },
-  },
+  adapter: chainConfig,
   methodology,
+  breakdownMethodology,
   dependencies: [Dependencies.ALLIUM],
+  allowNegativeValue: true,
   isExpensiveAdapter: true
 }
 

--- a/fees/maestro.ts
+++ b/fees/maestro.ts
@@ -18,7 +18,6 @@ const chainConfig: any = {
   [CHAIN.SONIC]: { start: '2025-02-26', feeAddress: '0xB0999731f7c2581844658A9d2ced1be0077b7397' },
   [CHAIN.AVAX]: { start: '2025-06-08', feeAddress: '0xB0999731f7c2581844658A9d2ced1be0077b7397' },
   [CHAIN.SOLANA]: {
-    fetch: fetchSolana,
     start: '2024-03-05',
     feeAddresses: ['MaestroUL88UBnZr3wfoN7hqmNWFi3ZYCGqZoJJHE36', 'FRMxAnZgkW58zbYcE7Bxqsg99VWpJh6sMP5xLzAWNabN'],
     // Maestro-funded wallet that relays SOL referral rewards to users.
@@ -36,7 +35,6 @@ async function fetchEVM(options: FetchOptions) {
   const config = chainConfig[options.chain]
   const dailyFees = options.createBalances()
   const dailyRevenue = options.createBalances()
-  const dailyProtocolRevenue = options.createBalances()
   const dailySupplySideRevenue = options.createBalances()
   const chainKey = getAlliumChain(options.chain)
   const feeAddress = config.feeAddress!.toLowerCase()
@@ -80,7 +78,6 @@ async function fetchSolana(options: FetchOptions) {
   const config = chainConfig[CHAIN.SOLANA]
   const dailyFees = options.createBalances()
   const dailyRevenue = options.createBalances()
-  const dailyProtocolRevenue = options.createBalances()
   const dailySupplySideRevenue = options.createBalances()
   const feeAddresses = config.feeAddresses.map((address: string) => `'${address}'`).join(', ')
   const query = `


### PR DESCRIPTION
Partially fixes #6739 

## Summary
- Adds referral reward accounting to the existing Maestro fees adapter.
- Reports Maestro revenue after deducting referral rewards.

## Changes
- Added reward relay wallet tracking for EVM chains and Solana.
- Counts native-token funding into referral reward relay wallets as `dailySupplySideRevenue`.
- Added labeled breakdowns for trading fees, revenue, and referral rewards.

## Methodology
- Keeps existing Maestro fee wallet tracking for native-token trading fees.
- Subtracts referral rewards from `dailyRevenue` and `dailyProtocolRevenue`.
- Excludes ERC20 and SPL token transfers because Maestro fees accrue in native tokens.

## Reward Relay Identification
- EVM reward relay was identified from Maestro dispatcher transactions that fund the same recipient wallet across Ethereum, BSC, Arbitrum, and Base.
- Solana reward relay was identified by tracing SOL transfers funded by the Maestro Solana fee wallet into a wallet that relays referral rewards.
