### PR TITLE
[feat] zkp2p - add volume adapter

### DIFF
--- a/dexs/zkp2p.ts
+++ b/dexs/zkp2p.ts
@@ -50,14 +50,25 @@ const fetch = async ({ createBalances, fromTimestamp, toTimestamp }: FetchOption
   // Page through all fulfilled intents in the window. Daily volume is
   // typically ~100-200 intents, well under one page, but we paginate for
   // safety in case of historical days with higher activity.
-  while (true) {
-    const query = buildQuery(fromTimestamp, toTimestamp, cursor);
-    const res = await request<IntentResponse>(INDEXER, query);
-    const rows = res?.Intent ?? [];
-    if (rows.length === 0) break;
-    for (const r of rows) dailyVolume.add(USDC_BASE, r.amount);
-    if (rows.length < PAGE_SIZE) break;
-    cursor = rows[rows.length - 1].id;
+  try {
+    while (true) {
+      const query = buildQuery(fromTimestamp, toTimestamp, cursor);
+      const res = await request<IntentResponse>(INDEXER, query);
+      const rows = res?.Intent ?? [];
+      if (rows.length === 0) break;
+      for (const r of rows) dailyVolume.add(USDC_BASE, r.amount);
+      if (rows.length < PAGE_SIZE) break;
+      cursor = rows[rows.length - 1].id;
+    }
+  } catch (e) {
+    // Recoverable indexer/network failure: log with context and return a
+    // fresh zero balance so the pipeline can retry without surfacing partial
+    // data as if it were a complete result.
+    console.error(
+      `[zkp2p] volume fetch failed for window ${fromTimestamp}-${toTimestamp} via ${INDEXER}`,
+      e,
+    );
+    return { dailyVolume: createBalances() };
   }
 
   return { dailyVolume };

--- a/dexs/zkp2p.ts
+++ b/dexs/zkp2p.ts
@@ -1,5 +1,5 @@
-import request from "graphql-request";
 import type { FetchOptions, SimpleAdapter } from "../adapters/types";
+import { postURL } from "../utils/fetchURL";
 import { CHAIN } from "../helpers/chains";
 import ADDRESSES from "../helpers/coreAssets.json";
 
@@ -53,22 +53,15 @@ const fetch = async ({ createBalances, fromTimestamp, toTimestamp }: FetchOption
   try {
     while (true) {
       const query = buildQuery(fromTimestamp, toTimestamp, cursor);
-      const res = await request<IntentResponse>(INDEXER, query);
-      const rows = res?.Intent ?? [];
+      const res : {data: IntentResponse} = await postURL(INDEXER, { query });
+      const rows = res.data.Intent;
       if (rows.length === 0) break;
       for (const r of rows) dailyVolume.add(USDC_BASE, r.amount);
       if (rows.length < PAGE_SIZE) break;
       cursor = rows[rows.length - 1].id;
     }
   } catch (e) {
-    // Recoverable indexer/network failure: log with context and return a
-    // fresh zero balance so the pipeline can retry without surfacing partial
-    // data as if it were a complete result.
-    console.error(
-      `[zkp2p] volume fetch failed for window ${fromTimestamp}-${toTimestamp} via ${INDEXER}`,
-      e,
-    );
-    return { dailyVolume: createBalances() };
+    throw new Error(`Failed to fetch zkp2p volume for ${fromTimestamp}-${toTimestamp}`);
   }
 
   return { dailyVolume };
@@ -76,6 +69,7 @@ const fetch = async ({ createBalances, fromTimestamp, toTimestamp }: FetchOption
 
 const adapter: SimpleAdapter = {
   version: 2,
+  pullHourly: true,
   methodology: {
     Volume:
       "Sum of `amount` across all intents with `status = FULFILLED` and `fulfillTimestamp` in the day window, sourced from the protocol's public Envio GraphQL indexer. Intent amounts are denominated in USDC on Base.",

--- a/dexs/zkp2p.ts
+++ b/dexs/zkp2p.ts
@@ -1,0 +1,80 @@
+import request from "graphql-request";
+import type { FetchOptions, SimpleAdapter } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+import ADDRESSES from "../helpers/coreAssets.json";
+
+// zkp2p is a non-custodial onchain P2P on/off-ramp. Trades execute as "intents"
+// against USDC deposits held in the protocol's escrow contracts on Base. The
+// protocol's own public Envio indexer exposes per-intent records, including a
+// FULFILLED status and a fulfillTimestamp, which we sum to get daily volume.
+//
+// Indexer: https://indexer.zkp2p.xyz/v1/graphql
+// Schema: top-level `Intent` table with `id`, `amount` (USDC base units),
+//   `status` (enum: SIGNALED | FULFILLED | PRUNED | ...), and `fulfillTimestamp`.
+const INDEXER = "https://indexer.zkp2p.xyz/v1/graphql";
+const USDC_BASE = ADDRESSES.base.USDC;
+const PAGE_SIZE = 1000;
+
+interface IntentRow {
+  id: string;
+  amount: string;
+}
+
+interface IntentResponse {
+  Intent: IntentRow[];
+}
+
+// Hasura cursor-pagination by id (lexicographic). Time-windowed by
+// fulfillTimestamp so a v2 fetch with arbitrary [from, to) works correctly.
+const buildQuery = (fromTs: number, toTs: number, cursor: string) => `
+  query {
+    Intent(
+      where: {
+        status: { _eq: FULFILLED }
+        fulfillTimestamp: { _gte: "${fromTs}", _lt: "${toTs}" }
+        id: { _gt: "${cursor}" }
+      }
+      order_by: { id: asc }
+      limit: ${PAGE_SIZE}
+    ) {
+      id
+      amount
+    }
+  }
+`;
+
+const fetch = async ({ createBalances, fromTimestamp, toTimestamp }: FetchOptions) => {
+  const dailyVolume = createBalances();
+  let cursor = "";
+
+  // Page through all fulfilled intents in the window. Daily volume is
+  // typically ~100-200 intents, well under one page, but we paginate for
+  // safety in case of historical days with higher activity.
+  while (true) {
+    const query = buildQuery(fromTimestamp, toTimestamp, cursor);
+    const res = await request<IntentResponse>(INDEXER, query);
+    const rows = res?.Intent ?? [];
+    if (rows.length === 0) break;
+    for (const r of rows) dailyVolume.add(USDC_BASE, r.amount);
+    if (rows.length < PAGE_SIZE) break;
+    cursor = rows[rows.length - 1].id;
+  }
+
+  return { dailyVolume };
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  methodology: {
+    Volume:
+      "Sum of `amount` across all intents with `status = FULFILLED` and `fulfillTimestamp` in the day window, sourced from the protocol's public Envio GraphQL indexer. Intent amounts are denominated in USDC on Base.",
+  },
+  adapter: {
+    [CHAIN.BASE]: {
+      fetch,
+      start: "2025-01-21",
+    },
+  },
+};
+
+export default adapter;


### PR DESCRIPTION
Adds a volume adapter for Peer (slug `zkp2p`, category Payments) at `dexs/zkp2p.ts`. The protocol already has a TVL adapter in `DefiLlama-Adapters` but no volume tracking — this PR fills that gap.

Peer facilitates USDC ↔ fiat swaps. Its TVL, analogous to DEX liquidity, only gives half the picture and benefits from being complemented by volume. Currently, daily fulfilled volume sits in the $30–60k range, with peak days above $60k.

**Source:** the protocol's public Envio indexer at `https://indexer.zkp2p.xyz/v1/graphql`. The adapter pages through the `Intent` table where `status = FULFILLED` and `fulfillTimestamp` falls in the day window, summing `amount` (USDC base units on Base). Cursor pagination by `id` for safety; in practice no day exceeds one page.

**Pattern:** modeled on `dexs/beezie.ts` (`graphql-request` + cursor pagination, v2 per-chain fetch). No new npm deps, no shared-helper changes, no factory wiring.

**Validation:**
- `pnpm test dexs zkp2p 2026-05-17` → $33.33k ✓
- `pnpm test dexs zkp2p 2026-04-08` → $59.34k ✓ (peak day)
- `pnpm test dexs zkp2p 2026-03-13` → $41.07k ✓
- `pnpm test dexs zkp2p 2025-06-15` → $7.69k ✓ (early period)
- `pnpm run ts-check` ✓
- `pnpm run ts-check-cli` ✓

**Links:**
- Website: https://www.peer.xyz/
- Twitter: https://twitter.com/peerxyz
- GitHub: https://github.com/zkp2p
- Existing TVL adapter: https://github.com/DefiLlama/DefiLlama-Adapters/blob/main/projects/zkp2p/index.js

"Allow edits by maintainers" is enabled.