### PR TITLE
[feat] Telemetry(Bonk-terminal): Add telementry fee/revenue adapter

### DIFF
--- a/fees/telemetry.ts
+++ b/fees/telemetry.ts
@@ -1,0 +1,116 @@
+import ADDRESSES from "../helpers/coreAssets.json";
+import { Dependencies, FetchOptions, SimpleAdapter } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+import { queryDuneSql } from "../helpers/dune";
+
+const LABELS = {
+  TERMINAL_FEES: "Trading fees paid by users",
+  TERMINAL_REVENUE: "Trading fees excluding referral or cashback rewards",
+  REWARDS: "Referral or cashback rewards",
+};
+
+const chainConfig: Record<string, { start: string; feeWallet: string; rewardWallet: string }> = {
+  [CHAIN.SOLANA]: {
+    start: "2025-08-12",
+    feeWallet: "FBYmU5XbRgX2DV2i2SpPPpHpXmf6mdZS98wQChmUyMba",
+    rewardWallet: "84DGj4Qpypcaa5uxdzphYzkutEUTvxLWSuWq3BoJLxkp",
+  },
+};
+
+const fetch = async (options: FetchOptions) => {
+  const { feeWallet, rewardWallet } = chainConfig[options.chain];
+  const query = `
+    WITH
+    walletActivity AS (
+      SELECT
+        tx_id,
+        SUM(CASE WHEN address = '${feeWallet}' AND balance_change > 0 THEN balance_change ELSE 0 END) AS fee_lamports,
+        SUM(CASE WHEN address = '${rewardWallet}' AND balance_change > 0 THEN balance_change ELSE 0 END) AS reward_lamports,
+        MAX(CASE WHEN address = '${feeWallet}' THEN 1 ELSE 0 END) AS fee_wallet_rows
+      FROM solana.account_activity
+      WHERE block_date BETWEEN date(from_unixtime(${options.startTimestamp})) AND date(from_unixtime(${options.endTimestamp}))
+        AND TIME_RANGE
+        AND tx_success
+        AND token_mint_address IS NULL
+        AND address IN ('${feeWallet}', '${rewardWallet}')
+      GROUP BY 1
+    ),
+    rewardPayouts AS (
+      SELECT
+        COALESCE(SUM(reward_lamports), 0) AS reward_lamports
+      FROM walletActivity
+      WHERE fee_wallet_rows > 0
+    ),
+    botTrades AS (
+      SELECT tx_id
+      FROM dex_solana.trades
+      WHERE block_month BETWEEN CAST(date_trunc('month', date(from_unixtime(${options.startTimestamp}))) AS date) AND CAST(date_trunc('month', date(from_unixtime(${options.endTimestamp}))) AS date)
+        AND block_date BETWEEN date(from_unixtime(${options.startTimestamp})) AND date(from_unixtime(${options.endTimestamp}))
+        AND TIME_RANGE
+        AND trader_id = '${feeWallet}'
+      GROUP BY 1
+    )
+    SELECT
+      CAST(COALESCE(SUM(CASE WHEN botTrades.tx_id IS NULL THEN fee_lamports ELSE 0 END), 0) AS VARCHAR) AS fees,
+      CAST((SELECT reward_lamports FROM rewardPayouts) AS VARCHAR) AS cashback_rewards
+    FROM walletActivity
+    LEFT JOIN botTrades ON walletActivity.tx_id = botTrades.tx_id
+  `;
+
+  const [result] = await queryDuneSql(options, query);
+  const fees = result?.fees ?? 0;
+  const cashbackRewards = result?.cashback_rewards ?? 0;
+  const revenue = (BigInt(fees) - BigInt(cashbackRewards)).toString();
+
+  const dailyFees = options.createBalances();
+  const dailyRevenue = options.createBalances();
+  const dailySupplySideRevenue = options.createBalances();
+
+  dailyFees.add(ADDRESSES.solana.SOL, fees, LABELS.TERMINAL_FEES);
+  dailyRevenue.add(ADDRESSES.solana.SOL, revenue, LABELS.TERMINAL_REVENUE);
+  dailySupplySideRevenue.add(ADDRESSES.solana.SOL, cashbackRewards, LABELS.REWARDS);
+
+  return {
+    dailyFees,
+    dailyUserFees: dailyFees,
+    dailyRevenue,
+    dailyProtocolRevenue: dailyRevenue,
+    dailySupplySideRevenue,
+  };
+};
+
+const methodology = {
+  Fees: "All SOL inflows to Telemetry's main fee wallet.",
+  UserFees: "All SOL inflows to Telemetry's main fee wallet.",
+  Revenue: "Trading fees kept by Telemetry after referral or cashback rewards paid from the fee wallet.",
+  ProtocolRevenue: "Trading fees kept by Telemetry after referral or cashback rewards paid from the fee wallet.",
+  SupplySideRevenue: "SOL referral or cashback rewards paid from Telemetry's rewards account.",
+};
+
+const breakdownMethodology = {
+  Fees: {
+    [LABELS.TERMINAL_FEES]: "All SOL inflows to Telemetry's fee wallet.",
+  },
+  Revenue: {
+    [LABELS.TERMINAL_REVENUE]: "Trading fees retained by Telemetry after referral or cashback rewards.",
+  },
+  ProtocolRevenue: {
+    [LABELS.TERMINAL_REVENUE]: "Trading fees retained by Telemetry after referral or cashback rewards.",
+  },
+  SupplySideRevenue: {
+    [LABELS.REWARDS]: "SOL referral or cashback rewards paid from Telemetry's rewards account.",
+  },
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  fetch,
+  adapter: chainConfig,
+  dependencies: [Dependencies.DUNE],
+  isExpensiveAdapter: true,
+  allowNegativeValue: true,
+  methodology,
+  breakdownMethodology,
+};
+
+export default adapter;

--- a/fees/telemetry.ts
+++ b/fees/telemetry.ts
@@ -2,9 +2,9 @@ import ADDRESSES from "../helpers/coreAssets.json";
 import { Dependencies, FetchOptions, SimpleAdapter } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
 import { queryDuneSql } from "../helpers/dune";
+import { METRIC } from "../helpers/metrics";
 
 const LABELS = {
-  TERMINAL_FEES: "Trading fees paid by users",
   TERMINAL_REVENUE: "Trading fees excluding referral or cashback rewards",
   REWARDS: "Referral or cashback rewards",
 };
@@ -17,7 +17,7 @@ const chainConfig: Record<string, { start: string; feeWallet: string; rewardWall
   },
 };
 
-const fetch = async (options: FetchOptions) => {
+async function fetch(_a: any, _b: any, options: FetchOptions) {
   const { feeWallet, rewardWallet } = chainConfig[options.chain];
   const query = `
     WITH
@@ -28,8 +28,7 @@ const fetch = async (options: FetchOptions) => {
         SUM(CASE WHEN address = '${rewardWallet}' AND balance_change > 0 THEN balance_change ELSE 0 END) AS reward_lamports,
         MAX(CASE WHEN address = '${feeWallet}' THEN 1 ELSE 0 END) AS fee_wallet_rows
       FROM solana.account_activity
-      WHERE block_date BETWEEN date(from_unixtime(${options.startTimestamp})) AND date(from_unixtime(${options.endTimestamp}))
-        AND TIME_RANGE
+      WHERE TIME_RANGE
         AND tx_success
         AND token_mint_address IS NULL
         AND address IN ('${feeWallet}', '${rewardWallet}')
@@ -44,9 +43,7 @@ const fetch = async (options: FetchOptions) => {
     botTrades AS (
       SELECT tx_id
       FROM dex_solana.trades
-      WHERE block_month BETWEEN CAST(date_trunc('month', date(from_unixtime(${options.startTimestamp}))) AS date) AND CAST(date_trunc('month', date(from_unixtime(${options.endTimestamp}))) AS date)
-        AND block_date BETWEEN date(from_unixtime(${options.startTimestamp})) AND date(from_unixtime(${options.endTimestamp}))
-        AND TIME_RANGE
+      WHERE TIME_RANGE
         AND trader_id = '${feeWallet}'
       GROUP BY 1
     )
@@ -66,7 +63,7 @@ const fetch = async (options: FetchOptions) => {
   const dailyRevenue = options.createBalances();
   const dailySupplySideRevenue = options.createBalances();
 
-  dailyFees.add(ADDRESSES.solana.SOL, fees, LABELS.TERMINAL_FEES);
+  dailyFees.add(ADDRESSES.solana.SOL, fees, METRIC.TRADING_FEES);
   dailyRevenue.add(ADDRESSES.solana.SOL, revenue, LABELS.TERMINAL_REVENUE);
   dailySupplySideRevenue.add(ADDRESSES.solana.SOL, cashbackRewards, LABELS.REWARDS);
 
@@ -77,7 +74,7 @@ const fetch = async (options: FetchOptions) => {
     dailyProtocolRevenue: dailyRevenue,
     dailySupplySideRevenue,
   };
-};
+}
 
 const methodology = {
   Fees: "All SOL inflows to Telemetry's main fee wallet.",
@@ -89,7 +86,7 @@ const methodology = {
 
 const breakdownMethodology = {
   Fees: {
-    [LABELS.TERMINAL_FEES]: "All SOL inflows to Telemetry's fee wallet.",
+    [METRIC.TRADING_FEES]: "All SOL inflows to Telemetry's fee wallet.",
   },
   Revenue: {
     [LABELS.TERMINAL_REVENUE]: "Trading fees retained by Telemetry after referral or cashback rewards.",
@@ -103,7 +100,7 @@ const breakdownMethodology = {
 };
 
 const adapter: SimpleAdapter = {
-  version: 2,
+  version: 1,
   fetch,
   adapter: chainConfig,
   dependencies: [Dependencies.DUNE],


### PR DESCRIPTION
## Summary
- Adds a new fees adapter for Telemetry, the Solana web/mobile trading terminal by BONKbot.
- Tracks Telemetry fees, revenue, user fees, protocol revenue, and referral/cashback rewards on Solana.
- Website: https://telemetry.io/
- Twitter/X: https://x.com/bonkbot_io

## New Protocol Listing
##### Name (to be shown on DefiLlama):
Telemetry

##### Twitter Link:
https://x.com/bonkbot_io

##### List of audit links if any:


##### Website Link:
https://telemetry.io/

##### Chain:
Solana


##### Short Description (to be shown on DefiLlama):
Telemetry is a Solana trading and analytics terminal by BONKbot, offering web and mobile trading, token discovery, wallet tracking, and referral/cashback rewards.

##### methodology (what is being counted as tvl, how is tvl being calculated):
N/A; this PR adds a fees adapter, not a TVL adapter.


##### Does this project have a referral program?
Yes

## Changes
- Added `fees/telemetry.ts` as a new v2 Dune-backed fees adapter.
- Added Solana chain config with Telemetry's main fee wallet, rewards account, and public launch start date of `2025-08-12`.
- Reports SOL-denominated `dailyFees`, `dailyUserFees`, `dailyRevenue`, `dailyProtocolRevenue`, and `dailySupplySideRevenue`.
- Added breakdown labels and methodology for trading fees, retained protocol revenue, and referral/cashback rewards.

## Methodology
- Fees are counted as native SOL inflows to Telemetry's main fee wallet.
- Bot-trade protection excludes transactions where the fee wallet itself appears as the trader in `dex_solana.trades`.
- Supply-side revenue counts SOL referral/cashback rewards paid from the fee wallet to the Telemetry rewards account.
- Revenue and protocol revenue are calculated as fees minus referral/cashback rewards.
- Uses Dune `solana.account_activity` for native SOL balance changes, with timestamp/date filters for the requested fetch window.

## Data Quality / Risk
- Telemetry is related to BONKbot, so overlap with the existing `fees/bonk-bot` adapter was checked. The BONKbot adapter uses Dune's curated `bonkbot_solana.bot_trades` table and does not include fee receiver addresses.
- A sample overlap check for `2026-05-10` found no transaction overlap between BONKbot rows and Telemetry fee-wallet inflows.
- The adapter start date uses the public Telemetry launch/rewards window beginning `2025-08-12`.

## Tests
- `pnpm test fees telemetry 2026-05-11`