### PR TITLE
dedust: switch volume source from deprecated v3 GraphQL to v4 REST

### DIFF
--- a/dexs/dedust/index.ts
+++ b/dexs/dedust/index.ts
@@ -14,7 +14,6 @@ const fetch = async (options: FetchOptions) => {
   let dailyVolume = 0;
   let offset = 0;
 
-  try {
     while (true) {
       const apiResponse = await httpPost(DEDUST_API, {
         offset,
@@ -43,10 +42,6 @@ const fetch = async (options: FetchOptions) => {
       if (offset >= totalPools) break;
       await sleep(3000);
     }
-  } catch (error) {
-    console.error(`dedust dailyVolume fetch failed (offset=${offset}):`, error);
-    return { dailyVolume: 0 };
-  }
 
   return {
     dailyVolume,

--- a/dexs/dedust/index.ts
+++ b/dexs/dedust/index.ts
@@ -1,85 +1,64 @@
-import { postURL } from "../../utils/fetchURL"
 import { CHAIN } from "../../helpers/chains";
 import { FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { httpPost } from "../../utils/fetchURL";
+import { sleep } from "../../utils/utils";
 
-const GRAPHQL_ENDPOINT = 'https://api.dedust.io/v3/graphql';
-
-const POOLS_QUERY = `
-query GetPools($filter: PoolsFiltersInput) {
-    pools(filter: $filter) {
-      address
-      totalSupply
-      type
-      tradeFee
-      assets
-      reserves
-      fees
-      volume
-    }
-  }
-`;
-
-const ASSETS_QUERY = `
-query GetAssets {
-    assets {
-      type
-      address
-      symbol
-      decimals
-      price
-    }
-  }
-`;
-
+// DeDust deprecated the v3 GraphQL `pools { volume }` schema; the endpoint
+// still responds but returns an empty `pools` array regardless of filter,
+// so this adapter was reporting $0 volume since ~2026-04-21. The v4 REST
+// endpoint (also used by `fees/dedust/index.ts`) is the canonical source
+// and exposes `volume_24h_usd` per pool row.
+const DEDUST_API = "https://mainnet.api.dedust.io/v4/api/get_pools";
 
 const fetch = async (options: FetchOptions) => {
-  const assetsList = (await postURL(GRAPHQL_ENDPOINT, {
-    query: ASSETS_QUERY,
-    operationName: 'GetAssets'
-  })).data.assets;
-
-  const assetInfo = {};
-  for (const asset of assetsList) {
-    const address = asset.type == 'native' ? 'native' : 'jetton:' + asset.address;
-    assetInfo[address] = {
-      decimals: asset.decimals,
-      price: Number(asset.price),
-      symbol: asset.symbol
-    }
-  }
-
-  const poolsList = (await postURL(GRAPHQL_ENDPOINT, {
-    query: POOLS_QUERY,
-    operationName: 'GetPools'
-  })).data.pools;
-
   let dailyVolume = 0;
-  for (const pool of poolsList) {
-    const address = pool.address;
-    const leftAddr = pool.assets[0];
-    const rightAddr = pool.assets[1];
-    if (!(leftAddr in assetInfo && rightAddr in assetInfo)) {
-      continue;
-    }
-    const left = assetInfo[leftAddr];
-    const right = assetInfo[rightAddr];
+  let offset = 0;
 
-    dailyVolume += (left.price * Number(pool.volume[0]) / Math.pow(10, left.decimals)
-      + right.price * Number(pool.volume[1]) / Math.pow(10, right.decimals)) / 2;
+  try {
+    while (true) {
+      const apiResponse = await httpPost(DEDUST_API, {
+        offset,
+        limit: 100,
+        sort_by: "volume_24h",
+        sort_direction: "desc",
+        filter_by_type: ["cpmm_v2", "stable", "cpmm_v1"],
+      });
+
+      const poolRows = Array.isArray(apiResponse?.pool_rows) ? apiResponse.pool_rows : [];
+      let lastVolume = 0;
+      for (const poolRow of poolRows) {
+        const rowVolume = Number(poolRow?.volume_24h_usd ?? 0);
+        if (!Number.isFinite(rowVolume)) continue;
+        dailyVolume += rowVolume;
+        lastVolume = rowVolume;
+      }
+
+      // Pools are sorted by volume descending — stop as soon as the tail
+      // drops below $1 to avoid paginating thousands of dormant pools.
+      if (lastVolume < 1) break;
+
+      const totalPools = Number(apiResponse?.total_count ?? 0);
+      if (!Number.isFinite(totalPools) || totalPools <= 0) break;
+      offset += 100;
+      if (offset >= totalPools) break;
+      await sleep(3000);
+    }
+  } catch (error) {
+    console.error(`dedust dailyVolume fetch failed (offset=${offset}):`, error);
+    return { dailyVolume: 0 };
   }
 
   return {
-    dailyVolume: dailyVolume
+    dailyVolume,
   };
 };
-
 
 const adapter: SimpleAdapter = {
   adapter: {
     [CHAIN.TON]: {
       fetch,
       runAtCurrTime: true,
-      start: '2023-04-19',
+      start: "2023-04-19",
     },
   },
 };


### PR DESCRIPTION
## Summary

`dexs/dedust/index.ts` has been reporting **$0 daily volume since ~2026-04-21** because DeDust deprecated their v3 GraphQL endpoint. This PR switches to the v4 REST endpoint that `fees/dedust/index.ts` is already using.

## Bug verification

**1. Production state (DefiLlama API):** `/overview/dexs/ton` shows DeDust 24h/7d/30d volume = $0. Pre-cliff (April 19-20) the adapter reported $200-350k/day consistently.

**2. The v3 GraphQL endpoint is empty.** Probing the exact query the adapter sends:
```
$ curl -sX POST https://api.dedust.io/v3/graphql \
    -d '{"query":"query GetPools { pools(filter: {}) { address volume } }"}'
{"data":{"pools":[]}}
```
The same for `assets`. Schema introspection confirms `pools(filter: PoolsFiltersInput) -> [Pool]` still exists and the `Pool` type still has a `volume` field — the schema looks alive, but no rows are returned regardless of filter shape (tried `{}`, `{ assets: { in: [\"native\"] } }`, etc.).

**3. The chain is healthy.** TonAPI confirms live JettonSwap events on the canonical TON/USDT pool `EQA-X_yo3fzzbDbJ_0bzFWKqtRuZFIRa1sJsveZJ1YpViO3r` in the last minute, and the pool has live reserves (191,403 TON / 380,387 USDT). GeckoTerminal independently shows the top-10 DeDust pools doing roughly $865k+/day. The protocol is active; only the adapter's data source was stale.

## The fix

DeDust's canonical source is `mainnet.api.dedust.io/v4/api/get_pools` — the same endpoint already used by [`fees/dedust/index.ts`](https://github.com/DefiLlama/dimension-adapters/blob/master/fees/dedust/index.ts). It returns per-pool rows with a pre-computed `volume_24h_usd` field, so no asset-price lookup is needed.

```ts
const apiResponse = await httpPost(DEDUST_API, {
  offset, limit: 100,
  sort_by: \"volume_24h\",
  sort_direction: \"desc\",
  filter_by_type: [\"cpmm_v2\", \"stable\", \"cpmm_v1\"],
});
for (const poolRow of apiResponse.pool_rows) {
  dailyVolume += Number(poolRow.volume_24h_usd ?? 0);
}
```

Pagination mirrors the fees adapter exactly — sort by volume descending, stop when the tail falls below $1, otherwise paginate by 100 with a 3s sleep.

## Test plan

- [x] `pnpm run ts-check` clean
- [x] Local adapter run for 2026-05-18 → 2026-05-19: **Daily volume: 1.37 M** (production currently reports $0)
- [x] On-chain cross-check via TonAPI: TON/USDT pool emitting JettonSwap actions in the last minute
- [x] Third-party cross-check via GeckoTerminal: top-10 DeDust pools ~$865k/day, consistent with our $1.37M total across 1,838 pools

## Diff stats

`+34 / -63` — net smaller because the v4 endpoint returns pre-USD volume so we no longer need the GraphQL asset fetch + manual `price * raw_volume / 10^decimals` math.

## Rule-out: protocol-team fix

DeDust's API breakage is upstream of the adapter. The fix here uses the alternative v4 endpoint DeDust themselves recommend (and which their fees adapter already uses), so this doesn't depend on the protocol team patching v3.