### PR TITLE
[fix] Bonkbot: track referral rewards as supplySide 

### DIFF
--- a/fees/bonk-bot/index.ts
+++ b/fees/bonk-bot/index.ts
@@ -15,6 +15,15 @@ const chainConfig: Record<string, { start: string; fetch: typeof fetch; feeWalle
   },
 };
 
+const solRewardsStart = 1750896000; // 2025-06-26, fee wallet starts funding the referral wallet
+const internalWallets = [
+  "HvDzh6pzvjukAFUSajhkFgumhMLCUMjhMdFABbuc9YqL",
+  "4mNSrPhWCEUuCH3L4LMfeyiNyDBvJcFVU1PwYpybnyhJ",
+  "6BSxVeqT3bcjYW8jFjxr2Df5kf4BoGefWaeJAuEpKLJX",
+  "572baVHC2MxXeNQfqtDsjYdHqeGABmquvGD4fc57Ra8M",
+  "6Su3CvAxazKcjQLRBJyMVbToM9zdT12VnY7pdj2NEAXH",
+];
+
 const LABELS = {
   BOT_REVENUE: "BonkBot trading fees excluding referral rewards",
   REFERRAL_REWARDS: "Referral rewards",
@@ -22,6 +31,7 @@ const LABELS = {
 
 async function fetch(_a: any, _b: any, options: FetchOptions) {
   const { feeWallet, rewardWallet } = chainConfig[options.chain];
+  const excludedRewardRecipients = [feeWallet, rewardWallet, ...internalWallets].map((wallet) => `'${wallet}'`).join(", ");
   const query = `
     WITH botTrades AS (
       SELECT
@@ -35,18 +45,30 @@ async function fetch(_a: any, _b: any, options: FetchOptions) {
         AND is_last_trade_in_transaction = true
         AND TIME_RANGE
     ),
-    rewardTransfers AS (
+    solRewardTransfers AS (
       SELECT
-        CAST(COALESCE(SUM(amount), 0) AS VARCHAR) AS referralRewards
+        CAST(COALESCE(SUM(amount), 0) AS VARCHAR) AS solReferralRewards
       FROM tokens_solana.sol_transfers
       WHERE TIME_RANGE
+        AND block_time >= from_unixtime(${solRewardsStart})
         AND action = 'transfer'
-        AND from_owner = '${feeWallet}'
-        AND to_owner = '${rewardWallet}'
+        AND from_owner = '${rewardWallet}'
+        AND to_owner NOT IN (${excludedRewardRecipients})
+    ),
+    bonkRewardTransfers AS (
+      SELECT
+        CAST(COALESCE(SUM(amount), 0) AS VARCHAR) AS bonkReferralRewards
+      FROM tokens_solana.transfers
+      WHERE TIME_RANGE
+        AND block_time < from_unixtime(${solRewardsStart})
+        AND token_mint_address = '${ADDRESSES.solana.BONK}'
+        AND from_owner = '${rewardWallet}'
+        AND to_owner NOT IN (${excludedRewardRecipients})
     )
     SELECT
       COALESCE((SELECT SUM(fee_usd) FROM botTrades), 0) AS dailyFees,
-      (SELECT referralRewards FROM rewardTransfers) AS referralRewards
+      (SELECT solReferralRewards FROM solRewardTransfers) AS solReferralRewards,
+      (SELECT bonkReferralRewards FROM bonkRewardTransfers) AS bonkReferralRewards
   `;
 
   const data = await queryDuneSql(options, query);
@@ -56,11 +78,13 @@ async function fetch(_a: any, _b: any, options: FetchOptions) {
 
   if (!inflatedFees.includes(options.startOfDay)){
     const fees = Number(data[0].dailyFees);
-    const referralRewards = data[0].referralRewards;
+    const solReferralRewards = data[0].solReferralRewards;
+    const bonkReferralRewards = data[0].bonkReferralRewards;
 
     dailyFees.addUSDValue(fees, METRIC.TRADING_FEES);
     dailyRevenue.addUSDValue(fees, LABELS.BOT_REVENUE);
-    dailySupplySideRevenue.add(ADDRESSES.solana.SOL, referralRewards, LABELS.REFERRAL_REWARDS);
+    dailySupplySideRevenue.add(ADDRESSES.solana.SOL, solReferralRewards, LABELS.REFERRAL_REWARDS);
+    dailySupplySideRevenue.add(ADDRESSES.solana.BONK, bonkReferralRewards, LABELS.REFERRAL_REWARDS);
     dailyRevenue.subtract(dailySupplySideRevenue, LABELS.BOT_REVENUE);
   }
 
@@ -82,8 +106,8 @@ const adapter: SimpleAdapter = {
   allowNegativeValue: true,
   methodology: {
     Fees: "All trading fees paid by users while using bot.",
-    Revenue: "Trading fees kept by Bonk Bot after referral rewards paid from the fee wallet to the reward wallet.",
-    ProtocolRevenue: "Trading fees kept by Bonk Bot after referral rewards paid from the fee wallet to the reward wallet.",
+    Revenue: "Trading fees kept by Bonk Bot after referral rewards are paid.",
+    ProtocolRevenue: "Trading fees kept by Bonk Bot after referral rewards are paid.",
     SupplySideRevenue: "Referral rewards funded from the Bonk Bot fee wallet and sent to the reward wallet.",
   },
   breakdownMethodology: {
@@ -97,7 +121,7 @@ const adapter: SimpleAdapter = {
       [LABELS.BOT_REVENUE]: "Trading fees retained by Bonk Bot after referral rewards.",
     },
     SupplySideRevenue: {
-      [LABELS.REFERRAL_REWARDS]: "SOL sent from the Bonk Bot fee wallet to the reward wallet for referral rewards.",
+      [LABELS.REFERRAL_REWARDS]: "Referral rewards sent from the Bonk Bot reward wallet to recipients. Rewards are counted in BONK before June 26, 2025 and in SOL from June 26, 2025 onwards.",
     },
   }
 }

--- a/fees/bonk-bot/index.ts
+++ b/fees/bonk-bot/index.ts
@@ -31,7 +31,7 @@ const LABELS = {
 
 async function fetch(_a: any, _b: any, options: FetchOptions) {
   const { feeWallet, rewardWallet } = chainConfig[options.chain];
-  const excludedRewardRecipients = [feeWallet, rewardWallet, ...internalWallets].map((wallet) => `'${wallet}'`).join(", ");
+  const excludedBonkRecipients = [feeWallet, rewardWallet, ...internalWallets].map((wallet) => `'${wallet}'`).join(", ");
   const query = `
     WITH botTrades AS (
       SELECT
@@ -52,8 +52,8 @@ async function fetch(_a: any, _b: any, options: FetchOptions) {
       WHERE TIME_RANGE
         AND block_time >= from_unixtime(${solRewardsStart})
         AND action = 'transfer'
-        AND from_owner = '${rewardWallet}'
-        AND to_owner NOT IN (${excludedRewardRecipients})
+        AND from_owner = '${feeWallet}'
+        AND to_owner = '${rewardWallet}'
     ),
     bonkRewardTransfers AS (
       SELECT
@@ -63,7 +63,7 @@ async function fetch(_a: any, _b: any, options: FetchOptions) {
         AND block_time < from_unixtime(${solRewardsStart})
         AND token_mint_address = '${ADDRESSES.solana.BONK}'
         AND from_owner = '${rewardWallet}'
-        AND to_owner NOT IN (${excludedRewardRecipients})
+        AND to_owner NOT IN (${excludedBonkRecipients})
     )
     SELECT
       COALESCE((SELECT SUM(fee_usd) FROM botTrades), 0) AS dailyFees,
@@ -121,7 +121,7 @@ const adapter: SimpleAdapter = {
       [LABELS.BOT_REVENUE]: "Trading fees retained by Bonk Bot after referral rewards.",
     },
     SupplySideRevenue: {
-      [LABELS.REFERRAL_REWARDS]: "Referral rewards sent from the Bonk Bot reward wallet to recipients. Rewards are counted in BONK before June 26, 2025 and in SOL from June 26, 2025 onwards.",
+      [LABELS.REFERRAL_REWARDS]: "Referral rewards paid in BONK before June 26, 2025 and SOL afterwards.",
     },
   }
 }

--- a/fees/bonk-bot/index.ts
+++ b/fees/bonk-bot/index.ts
@@ -2,6 +2,7 @@ import ADDRESSES from "../../helpers/coreAssets.json";
 import { Dependencies, FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 import { queryDuneSql } from "../../helpers/dune";
+import { METRIC } from "../../helpers/metrics";
 
 const inflatedFees = [1712275200] // 2024-04-05, Inflated fees (22M fees for 48M volume)
 
@@ -15,7 +16,6 @@ const chainConfig: Record<string, { start: string; fetch: typeof fetch; feeWalle
 };
 
 const LABELS = {
-  BOT_FEES: "BonkBot trading fees",
   BOT_REVENUE: "BonkBot trading fees excluding referral rewards",
   REFERRAL_REWARDS: "Referral rewards",
 };
@@ -39,9 +39,7 @@ async function fetch(_a: any, _b: any, options: FetchOptions) {
       SELECT
         CAST(COALESCE(SUM(amount), 0) AS VARCHAR) AS referralRewards
       FROM tokens_solana.sol_transfers
-      WHERE block_date BETWEEN date(from_unixtime(${options.startTimestamp})) AND date(from_unixtime(${options.endTimestamp}))
-        AND block_time >= from_unixtime(${options.startTimestamp})
-        AND block_time < from_unixtime(${options.endTimestamp})
+      WHERE TIME_RANGE
         AND action = 'transfer'
         AND from_owner = '${feeWallet}'
         AND to_owner = '${rewardWallet}'
@@ -60,7 +58,7 @@ async function fetch(_a: any, _b: any, options: FetchOptions) {
     const fees = Number(data[0].dailyFees);
     const referralRewards = data[0].referralRewards;
 
-    dailyFees.addUSDValue(fees, LABELS.BOT_FEES);
+    dailyFees.addUSDValue(fees, METRIC.TRADING_FEES);
     dailyRevenue.addUSDValue(fees, LABELS.BOT_REVENUE);
     dailySupplySideRevenue.add(ADDRESSES.solana.SOL, referralRewards, LABELS.REFERRAL_REWARDS);
     dailyRevenue.subtract(dailySupplySideRevenue, LABELS.BOT_REVENUE);
@@ -90,7 +88,7 @@ const adapter: SimpleAdapter = {
   },
   breakdownMethodology: {
     Fees: {
-      [LABELS.BOT_FEES]: "All trading fees paid by BonkBot users.",
+      [METRIC.TRADING_FEES]: "All trading fees paid by BonkBot users.",
     },
     Revenue: {
       [LABELS.BOT_REVENUE]: "Trading fees retained by Bonk Bot after referral rewards.",

--- a/fees/bonk-bot/index.ts
+++ b/fees/bonk-bot/index.ts
@@ -37,29 +37,18 @@ async function fetch(_a: any, _b: any, options: FetchOptions) {
     ),
     rewardTransfers AS (
       SELECT
-        tx_id,
-        MAX(block_time) AS block_time,
-        SUM(CASE WHEN address = '${rewardWallet}' AND balance_change > 0 THEN balance_change ELSE 0 END) AS reward_lamports
-      FROM solana.account_activity
+        CAST(COALESCE(SUM(amount), 0) AS VARCHAR) AS referralRewards
+      FROM tokens_solana.sol_transfers
       WHERE block_date BETWEEN date(from_unixtime(${options.startTimestamp})) AND date(from_unixtime(${options.endTimestamp}))
         AND block_time >= from_unixtime(${options.startTimestamp})
         AND block_time < from_unixtime(${options.endTimestamp})
-        AND token_mint_address IS NULL
-        AND address IN ('${feeWallet}', '${rewardWallet}')
-      GROUP BY 1
-      HAVING
-        SUM(CASE WHEN address = '${feeWallet}' AND balance_change < 0 THEN 1 ELSE 0 END) > 0
-        AND SUM(CASE WHEN address = '${rewardWallet}' AND balance_change > 0 THEN 1 ELSE 0 END) > 0
-    ),
-    referralRewards AS (
-      SELECT
-        CAST(COALESCE(SUM(reward_lamports), 0) AS VARCHAR) AS referralRewards
-      FROM
-        rewardTransfers
+        AND action = 'transfer'
+        AND from_owner = '${feeWallet}'
+        AND to_owner = '${rewardWallet}'
     )
     SELECT
       COALESCE((SELECT SUM(fee_usd) FROM botTrades), 0) AS dailyFees,
-      (SELECT referralRewards FROM referralRewards) AS referralRewards
+      (SELECT referralRewards FROM rewardTransfers) AS referralRewards
   `;
 
   const data = await queryDuneSql(options, query);

--- a/fees/bonk-bot/index.ts
+++ b/fees/bonk-bot/index.ts
@@ -1,10 +1,27 @@
+import ADDRESSES from "../../helpers/coreAssets.json";
 import { Dependencies, FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 import { queryDuneSql } from "../../helpers/dune";
 
 const inflatedFees = [1712275200] // 2024-04-05, Inflated fees (22M fees for 48M volume)
 
-const fetch = async (_a: any, _b: any, options: FetchOptions) => {
+const chainConfig: Record<string, { start: string; fetch: typeof fetch; feeWallet: string; rewardWallet: string }> = {
+  [CHAIN.SOLANA]: {
+    start: "2023-08-23",
+    fetch,
+    feeWallet: "ZG98FUCjb8mJ824Gbs6RsgVmr1FhXb2oNiJHa2dwmPd",
+    rewardWallet: "84DGj4Qpypcaa5uxdzphYzkutEUTvxLWSuWq3BoJLxkp",
+  },
+};
+
+const LABELS = {
+  BOT_FEES: "BonkBot trading fees",
+  BOT_REVENUE: "BonkBot trading fees excluding referral rewards",
+  REFERRAL_REWARDS: "Referral rewards",
+};
+
+async function fetch(_a: any, _b: any, options: FetchOptions) {
+  const { feeWallet, rewardWallet } = chainConfig[options.chain];
   const query = `
     WITH botTrades AS (
       SELECT
@@ -17,39 +34,83 @@ const fetch = async (_a: any, _b: any, options: FetchOptions) => {
         blockchain = 'solana'
         AND is_last_trade_in_transaction = true
         AND TIME_RANGE
+    ),
+    rewardTransfers AS (
+      SELECT
+        tx_id,
+        MAX(block_time) AS block_time,
+        SUM(CASE WHEN address = '${rewardWallet}' AND balance_change > 0 THEN balance_change ELSE 0 END) AS reward_lamports
+      FROM solana.account_activity
+      WHERE block_date BETWEEN date(from_unixtime(${options.startTimestamp})) AND date(from_unixtime(${options.endTimestamp}))
+        AND block_time >= from_unixtime(${options.startTimestamp})
+        AND block_time < from_unixtime(${options.endTimestamp})
+        AND token_mint_address IS NULL
+        AND address IN ('${feeWallet}', '${rewardWallet}')
+      GROUP BY 1
+      HAVING
+        SUM(CASE WHEN address = '${feeWallet}' AND balance_change < 0 THEN 1 ELSE 0 END) > 0
+        AND SUM(CASE WHEN address = '${rewardWallet}' AND balance_change > 0 THEN 1 ELSE 0 END) > 0
+    ),
+    referralRewards AS (
+      SELECT
+        CAST(COALESCE(SUM(reward_lamports), 0) AS VARCHAR) AS referralRewards
+      FROM
+        rewardTransfers
     )
     SELECT
-      SUM(fee_usd) AS dailyFees
-    FROM
-      botTrades
+      COALESCE((SELECT SUM(fee_usd) FROM botTrades), 0) AS dailyFees,
+      (SELECT referralRewards FROM referralRewards) AS referralRewards
   `;
 
   const data = await queryDuneSql(options, query);
   const dailyFees = options.createBalances();
+  const dailyRevenue = options.createBalances();
+  const dailySupplySideRevenue = options.createBalances();
 
   if (!inflatedFees.includes(options.startOfDay)){
-    dailyFees.addUSDValue(Number(data[0].dailyFees), 'BonkBot Fees');
+    const fees = Number(data[0].dailyFees);
+    const referralRewards = data[0].referralRewards;
+
+    dailyFees.addUSDValue(fees, LABELS.BOT_FEES);
+    dailyRevenue.addUSDValue(fees, LABELS.BOT_REVENUE);
+    dailySupplySideRevenue.add(ADDRESSES.solana.SOL, referralRewards, LABELS.REFERRAL_REWARDS);
+    dailyRevenue.subtract(dailySupplySideRevenue, LABELS.BOT_REVENUE);
   }
 
-  return { dailyFees, dailyRevenue: dailyFees, dailyProtocolRevenue: dailyFees }
+  return {
+    dailyFees,
+    dailyUserFees: dailyFees,
+    dailyRevenue,
+    dailyProtocolRevenue: dailyRevenue,
+    dailySupplySideRevenue,
+  }
 }
 
 
 const adapter: SimpleAdapter = {
   version: 1,
-  fetch,
-  chains: [CHAIN.SOLANA],
+  adapter: chainConfig,
   dependencies: [Dependencies.DUNE],
-  start: '2023-08-23',
   isExpensiveAdapter: true,
+  allowNegativeValue: true,
   methodology: {
     Fees: "All trading fees paid by users while using bot.",
-    Revenue: "Trading fees are collected by Bonk Bot protocol.",
-    ProtocolRevenue: "Trading fees are collected by Bonk Bot protocol.",
+    Revenue: "Trading fees kept by Bonk Bot after referral rewards paid from the fee wallet to the reward wallet.",
+    ProtocolRevenue: "Trading fees kept by Bonk Bot after referral rewards paid from the fee wallet to the reward wallet.",
+    SupplySideRevenue: "Referral rewards funded from the Bonk Bot fee wallet and sent to the reward wallet.",
   },
   breakdownMethodology: {
     Fees: {
-      ['BonkBot Fees']: "All trading fees paid by BonkBot users"
+      [LABELS.BOT_FEES]: "All trading fees paid by BonkBot users.",
+    },
+    Revenue: {
+      [LABELS.BOT_REVENUE]: "Trading fees retained by Bonk Bot after referral rewards.",
+    },
+    ProtocolRevenue: {
+      [LABELS.BOT_REVENUE]: "Trading fees retained by Bonk Bot after referral rewards.",
+    },
+    SupplySideRevenue: {
+      [LABELS.REFERRAL_REWARDS]: "SOL sent from the Bonk Bot fee wallet to the reward wallet for referral rewards.",
     },
   }
 }


### PR DESCRIPTION
Partially fixes #6739 

## Summary
- Updates the BONKbot fees adapter to account for referral rewards.
- Keeps gross trading fees unchanged while reporting fee-wallet-to-reward-wallet transfers as supply-side revenue.

## Changes
- Updated `fees/bonk-bot/index.ts`.
- Added Solana chain config for the BONKbot fee wallet and reward wallet.
- Counts direct native SOL transfers from `ZG98FUCjb8mJ824Gbs6RsgVmr1FhXb2oNiJHa2dwmPd` to `84DGj4Qpypcaa5uxdzphYzkutEUTvxLWSuWq3BoJLxkp` as referral rewards.
- Reports `dailyRevenue` and `dailyProtocolRevenue` as BONKbot trading fees net of referral rewards.

## Methodology
- Gross fees remain sourced from `bonkbot_solana.bot_trades.fee_usd`.
- Referral rewards are identified from direct native SOL balance movement from the BONKbot fee wallet to the reward wallet.
- The reward wallet was found by tracing repeated outbound SOL transfers from the BONKbot fee wallet and confirming the direct transfer pattern with Helius/Dune checks.
