### PR TITLE
fix(ekubo): revenue per chain

### DIFF
--- a/dexs/ekubo/index.ts
+++ b/dexs/ekubo/index.ts
@@ -43,8 +43,8 @@ const fetch = async (_a: any, _b: any, options: FetchOptions) => {
     dailyFees,
     dailyRevenue,
     dailySupplySideRevenue,
-    dailyHoldersRevenue: 0,
-    dailyProtocolRevenue: dailyRevenue,
+    dailyHoldersRevenue: options.chain === CHAIN.STARKNET ? dailyRevenue : undefined,
+    dailyProtocolRevenue: options.chain === CHAIN.ETHEREUM ? dailyRevenue : undefined,
   };
 }
 


### PR DESCRIPTION
Starknet withdrawal fees go entirely to on-chain EKUBO buybacks via the RevenueBuybacks contract (dailyHoldersRevenue).

Ethereum fees go to the protocol treasury (dailyProtocolRevenue)