### PR TITLE
synfutures-v3: switch volume source from subgraph to on-chain Trade events

### DIFF
--- a/dexs/synfutures-v3/index.ts
+++ b/dexs/synfutures-v3/index.ts
@@ -6,7 +6,15 @@ import { FetchOptions, SimpleAdapter } from "../../adapters/types";
 // Instrument contract; new markets show up here automatically, so the adapter
 // is forward-compatible with future SynFutures listings without manual config.
 // Docs: https://docs.synfutures.com/protocol/smart-contract-addresses/base-network
-const GATE = "0x208B443983D8BcC8578e9D86Db23FbA547071270";
+
+const chainConfig = {
+  [CHAIN.BASE]: {
+    gate: "0x208B443983D8BcC8578e9D86Db23FbA547071270",
+  },
+  [CHAIN.BLAST]: {
+    gate: "0x6A372dBc1968f4a07cf2ce352f410962A972c257",
+  }
+}
 
 // Each Instrument contract emits exactly one Trade event per taker fill. The
 // `entryNotional` field is the position's notional value in the quote token,
@@ -22,6 +30,8 @@ const TRADE_EVENT_ABI =
 
 const fetch = async (options: FetchOptions) => {
   const dailyVolume = options.createBalances();
+
+  const GATE = chainConfig[options.chain].gate;
 
   const instruments: string[] = await options.api.call({
     target: GATE,
@@ -56,10 +66,17 @@ const methodology = {
 
 const adapter: SimpleAdapter = {
   version: 2,
-  fetch,
-  chains: [CHAIN.BASE],
-  start: "2024-06-26",
   pullHourly: true,
+  fetch,
+  adapter: {
+    [CHAIN.BASE]: {
+      start: "2024-06-26",
+    },
+    [CHAIN.BLAST]: {
+      start: "2024-02-29",
+      deadFrom: "2025-04-11", //sunset
+    },
+  },
   methodology,
 };
 

--- a/dexs/synfutures-v3/index.ts
+++ b/dexs/synfutures-v3/index.ts
@@ -1,76 +1,66 @@
-import BigNumber from "bignumber.js";
-import request from "graphql-request";
 import { CHAIN } from "../../helpers/chains";
 import { FetchOptions, SimpleAdapter } from "../../adapters/types";
 
-const info: { [key: string]: any } = {
-  [CHAIN.BLAST]: {
-    subgraph: "https://api.synfutures.com/thegraph/v3-blast",
-    chainId: 81457,
-  },
-  [CHAIN.BASE]: {
-    subgraph: "https://api.synfutures.com/thegraph/v3-base",
-    chainId: 8453,
-  }
-};
+// Gate is the SynFutures V3 entry point on Base. It exposes
+// `getAllInstruments() returns (address[])` which enumerates every deployed
+// Instrument contract; new markets show up here automatically, so the adapter
+// is forward-compatible with future SynFutures listings without manual config.
+// Docs: https://docs.synfutures.com/protocol/smart-contract-addresses/base-network
+const GATE = "0x208B443983D8BcC8578e9D86Db23FbA547071270";
 
-function convertDecimals(value: string | number, decimals: number) {
-  if (decimals > 18) {
-    return new BigNumber(value).multipliedBy(10 ** (decimals - 18)).toString();
-  } else if (decimals < 18) {
-    return new BigNumber(value).dividedToIntegerBy(10 ** (18 - decimals)).toString();
-  } else {
-    return value;
-  }
-}
+// Each Instrument contract emits exactly one Trade event per taker fill. The
+// `entryNotional` field is the position's notional value in the quote token,
+// scaled internally to 18 decimals regardless of the quote token's native
+// decimals — so `entryNotional / 1e18` is the trade's USD-equivalent notional
+// directly. Verified against the subgraph: a full 65-instrument sweep over
+// 24h on 2026-05-20 sums to $65.49M, matching the v3-base subgraph's $64.6M
+// for the same window within ~1%.
+const TRADE_EVENT_ABI =
+  "event Trade(uint32 indexed expiry, address indexed trader, int256 size, " +
+  "uint256 amount, int256 takenSize, uint256 takenValue, uint256 entryNotional, " +
+  "uint16 feeRatio, uint160 sqrtPX96, uint256 mark)";
 
-const fetch = async (timestamp: number, _: any, options: FetchOptions) => {
+const fetch = async (options: FetchOptions) => {
   const dailyVolume = options.createBalances();
 
-  const graphQL = `{
-      amms(where: {status_in: [TRADING, SETTLING]}) {
-          instrument {
-              quote {
-                  id
-                  decimals
-              }
-          }
-          hourlyDataList(where: {timestamp_gte: ${options.startTimestamp}, timestamp_lte: ${options.endTimestamp - 1}}, orderBy: timestamp, orderDirection: desc) {
-              volume
-          }
-      }
-  }`;
+  const instruments: string[] = await options.api.call({
+    target: GATE,
+    abi: "function getAllInstruments() view returns (address[])",
+  });
 
-  const data = await request(info[options.chain].subgraph, graphQL);
+  const logs = await options.getLogs({
+    targets: instruments,
+    eventAbi: TRADE_EVENT_ABI,
+    flatten: true,
+  });
 
-  for (const {
-    hourlyDataList,
-    instrument: {
-      quote: { id, decimals },
-    },
-  } of data.amms) {
-    for (const { volume } of hourlyDataList) {
-      dailyVolume.addToken(id, convertDecimals(volume, decimals));
-    }
+  for (const log of logs) {
+    dailyVolume.addUSDValue(Number(log.entryNotional) / 1e18);
   }
 
-  return {
-    dailyVolume,
-  };
+  return { dailyVolume };
+};
+
+const methodology = {
+  Volume:
+    "Taker-side notional volume summed from the on-chain `Trade(... uint256 " +
+    "entryNotional ...)` event that every SynFutures V3 Instrument contract " +
+    "emits once per fill. The full list of Instrument addresses is enumerated " +
+    "per-fetch via `Gate.getAllInstruments()` (no hard-coded contract list, so " +
+    "new markets are picked up automatically). The protocol scales " +
+    "`entryNotional` internally to 18 decimals regardless of the quote token's " +
+    "native decimals, so `entryNotional / 1e18` is the trade's USD-equivalent " +
+    "notional directly. Replaces the previous subgraph-based query for a " +
+    "trustless data source.",
 };
 
 const adapter: SimpleAdapter = {
-  version: 1,
-  adapter: {
-    // [CHAIN.BLAST]: {
-    //   fetch,
-    //   start: '2024-02-29',
-    // }, sunset -> '2025-04-11
-    [CHAIN.BASE]: {
-      fetch,
-      start: '2024-06-26',
-    },
-  },
+  version: 2,
+  fetch,
+  chains: [CHAIN.BASE],
+  start: "2024-06-26",
+  pullHourly: true,
+  methodology,
 };
 
 export default adapter;


### PR DESCRIPTION
Addresses ask #2 of #4883 — *"try to update the adapter to use on chain data if possible."*

## Bug / motivation

`dexs/synfutures-v3/index.ts` reads daily volume from SynFutures' self-hosted subgraph at `api.synfutures.com/thegraph/v3-base`. That makes DefiLlama's number dependent on a centralized indexer. This PR replaces it with direct on-chain reads against the SynFutures V3 Gate + Instrument contracts.

## Approach

Two on-chain reads per fetch:

1. **`Gate.getAllInstruments() view returns (address[])`** enumerates every deployed Instrument contract. Currently 65 on Base; new markets show up here automatically, so the adapter is forward-compatible with future SynFutures listings without manual config changes.

2. **`getLogs(Trade)` across all Instrument addresses** for the day's window. Each Trade event carries `entryNotional` — the position's notional value in the quote token, scaled internally to 18 decimals regardless of the quote's native decimals. So `entryNotional / 1e18` is the trade's USD-equivalent notional directly.

Event signature (lifted from SynFutures' [official `oyster-sdk`](https://github.com/synfutures/oyster-sdk/blob/main/src/abis/Instrument.json)):

```solidity
event Trade(
  uint32  indexed expiry,
  address indexed trader,
  int256  size,
  uint256 amount,
  int256  takenSize,
  uint256 takenValue,
  uint256 entryNotional,
  uint16  feeRatio,
  uint160 sqrtPX96,
  uint256 mark
)
// topic[0] = 0x4858d822a60a8f40ed0ced2eff407b999867b6dc5a641e8154e7a77d5992e1b2
```

## On-chain verification

Swept all 65 instruments over a 24h window ending 2026-05-20:

| Metric | Value |
|---|---:|
| Trade events | 2,141 |
| Active instruments | 2 of 65 |
| Sum of `entryNotional / 1e18` | **\$65,485,547** |
| Subgraph (same window) | ~\$64,605,432 |
| Match | ~1% |

Local adapter test on the same window:
```
🦙 Running SYNFUTURES-V3 adapter 🦙
Start Date:	Tue, 19 May 2026 00:00:00 GMT
End Date:	Wed, 20 May 2026 00:00:00 GMT
---------------------------------------------------
BASE 👇
Daily volume: 65.53 M
```

Active instruments in the window:

| Instrument address | Symbol (per docs) | 24h notional |
|---|---|---:|
| `0xec6c44e704eb1932ec5fe1e4aba58db6fee71460` | BTC-USDC-LINK | \$35.3M |
| `0x04d72fb4803b4e02f14971e5bd092375eb330749` | ETH-USDC-LINK | \$30.2M |

The other 63 Instruments returned zero Trade events (expired or low-activity markets); the adapter handles them via the same code path with no special casing.

## Diff

Net `+42 / -55` LOC. What's dropped:

- `graphql-request` and `bignumber.js` imports — no longer needed.
- The `convertDecimals` helper — `entryNotional` is already USD-scaled on-chain.
- The Blast `subgraph` config block — was already commented as *"sunset -> 2025-04-11"* in the existing file; removed for clarity (Blast adapter was already disabled).

## On the wash-trading angle (ask #1 of the issue)

g1nt0ki also asked to investigate whether the volume is wash trading. While verifying this PR I found that the 2,141 Trade events in 24h came from only **13 unique trader addresses** on the BTC-USDC-LINK instrument (top-1 concentration 20%, top-2 27% combined). Per the team's established pattern on wash-trading findings (see #6907 / #6913 closure feedback from @noateden), the evidence belongs in an issue comment rather than as adapter-side filtering — I will post the detailed data on #4883 immediately after this PR opens.

## Out of scope

- **Monday Trade fork** (ask #3 of the issue) — it's deployed on Monad, not Base. Different chain, different file. Follow-up PR once their on-chain addresses are public.

## Test plan

- [x] `pnpm run ts-check` clean
- [x] Local `node test.js` (transpiled) reports \`Daily volume: 65.53 M\` on the test window
- [x] Sum matches subgraph within 1% over the same window
- [x] Spot-checked the suspect tx from the issue body (`0x90a1e19c…7191f7`, block 38,916,871) — decoded correctly via the new Trade ABI

Allow edits by maintainers: enabled.