### PR TITLE
Add SwapWizard aggregator adapter

### DIFF
--- a/aggregators/swapwizard/index.ts
+++ b/aggregators/swapwizard/index.ts
@@ -2,39 +2,38 @@ import { FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 
 const SWAP_WIZARD_CORE: Record<string, string> = {
-  [CHAIN.ETHEREUM]: "0x649A382ab2aecEc5c1B9ac956c4CdaCEDaC96c80",
-  [CHAIN.BSC]: "0x22E51c8090086502227a66D2A2E1335D7A5B1aEC",
-  [CHAIN.POLYGON]: "0xc1409502815C4274e2e4F0c5EE3a32d0ce76f2c9",
-  [CHAIN.BASE]: "0xA2ae391D0740Cb8C8aA40dB7c076591A8b5A2A4d",
-  [CHAIN.ARBITRUM]: "0xA8E28f3c117B922867c78039adD25f07D23C5f6E",
+    [CHAIN.ETHEREUM]: "0x649A382ab2aecEc5c1B9ac956c4CdaCEDaC96c80",
+    [CHAIN.BSC]: "0x22E51c8090086502227a66D2A2E1335D7A5B1aEC",
+    [CHAIN.POLYGON]: "0xc1409502815C4274e2e4F0c5EE3a32d0ce76f2c9",
+    [CHAIN.BASE]: "0xA2ae391D0740Cb8C8aA40dB7c076591A8b5A2A4d",
+    [CHAIN.ARBITRUM]: "0xA8E28f3c117B922867c78039adD25f07D23C5f6E",
 };
 
 const swapEvent =
-  "event SwapExecuted(uint256 indexed dexIdx, address indexed impl, address indexed caller, address tokenIn, address tokenOut, uint256 amountIn, uint256 amountOut)";
+    "event SwapExecuted(uint256 indexed dexIdx, address indexed impl, address indexed caller, address tokenIn, address tokenOut, uint256 amountIn, uint256 amountOut)";
 
 const fetch = async ({ getLogs, createBalances, chain }: FetchOptions) => {
-  const dailyVolume = createBalances();
-  try {
-    const logs = await getLogs({
-      target: SWAP_WIZARD_CORE[chain],
-      eventAbi: swapEvent,
+    const dailyVolume = createBalances();
+
+    const swapLogs = await getLogs({
+        target: SWAP_WIZARD_CORE[chain],
+        eventAbi: swapEvent,
     });
-    logs.forEach((log: any) => dailyVolume.add(log.tokenOut, log.amountOut));
-  } catch (e) {
-    console.error(`SwapWizard ${chain} (${SWAP_WIZARD_CORE[chain]}) fetch failed:`, e);
-  }
-  return { dailyVolume };
+
+    swapLogs.forEach((log: any) => dailyVolume.add(log.tokenOut, log.amountOut));
+
+    return { dailyVolume };
 };
 
 const adapter: SimpleAdapter = {
-  version: 2,
-  pullHourly: true,
-  fetch,
-  start: "2026-05-19",
-  chains: Object.keys(SWAP_WIZARD_CORE),
-  methodology: {
-    Volume: "Swap volume tracked via SwapExecuted events emitted by the SwapWizard aggregator contracts on each chain.",
-  },
+    version: 2,
+    pullHourly: true,
+    fetch,
+    start: "2026-05-19",
+    chains: Object.keys(SWAP_WIZARD_CORE),
+    methodology: {
+        Volume: "Swap volume tracked via SwapExecuted events emitted by the SwapWizard aggregator contracts on each chain.",
+    },
 };
 
 export default adapter;

--- a/aggregators/swapwizard/index.ts
+++ b/aggregators/swapwizard/index.ts
@@ -14,16 +14,21 @@ const swapEvent =
 
 const fetch = async ({ getLogs, createBalances, chain }: FetchOptions) => {
   const dailyVolume = createBalances();
-  const logs = await getLogs({
-    target: SWAP_WIZARD_CORE[chain],
-    eventAbi: swapEvent,
-  });
-  logs.forEach((log: any) => dailyVolume.add(log.tokenOut, log.amountOut));
+  try {
+    const logs = await getLogs({
+      target: SWAP_WIZARD_CORE[chain],
+      eventAbi: swapEvent,
+    });
+    logs.forEach((log: any) => dailyVolume.add(log.tokenOut, log.amountOut));
+  } catch (e) {
+    console.error(`SwapWizard ${chain} (${SWAP_WIZARD_CORE[chain]}) fetch failed:`, e);
+  }
   return { dailyVolume };
 };
 
 const adapter: SimpleAdapter = {
   version: 2,
+  pullHourly: true,
   fetch,
   start: "2026-05-19",
   chains: Object.keys(SWAP_WIZARD_CORE),

--- a/aggregators/swapwizard/index.ts
+++ b/aggregators/swapwizard/index.ts
@@ -25,7 +25,7 @@ const fetch = async ({ getLogs, createBalances, chain }: FetchOptions) => {
 const adapter: SimpleAdapter = {
   version: 2,
   fetch,
-  start: "2026-05-20",
+  start: "2026-05-19",
   chains: Object.keys(SWAP_WIZARD_CORE),
   methodology: {
     Volume: "Swap volume tracked via SwapExecuted events emitted by the SwapWizard aggregator contracts on each chain.",

--- a/aggregators/swapwizard/index.ts
+++ b/aggregators/swapwizard/index.ts
@@ -1,0 +1,35 @@
+import { FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+
+const SWAP_WIZARD_CORE: Record<string, string> = {
+  [CHAIN.ETHEREUM]: "0x649A382ab2aecEc5c1B9ac956c4CdaCEDaC96c80",
+  [CHAIN.BSC]: "0x22E51c8090086502227a66D2A2E1335D7A5B1aEC",
+  [CHAIN.POLYGON]: "0xc1409502815C4274e2e4F0c5EE3a32d0ce76f2c9",
+  [CHAIN.BASE]: "0xA2ae391D0740Cb8C8aA40dB7c076591A8b5A2A4d",
+  [CHAIN.ARBITRUM]: "0xA8E28f3c117B922867c78039adD25f07D23C5f6E",
+};
+
+const swapEvent =
+  "event SwapExecuted(uint256 indexed dexIdx, address indexed impl, address indexed caller, address tokenIn, address tokenOut, uint256 amountIn, uint256 amountOut)";
+
+const fetch = async ({ getLogs, createBalances, chain }: FetchOptions) => {
+  const dailyVolume = createBalances();
+  const logs = await getLogs({
+    target: SWAP_WIZARD_CORE[chain],
+    eventAbi: swapEvent,
+  });
+  logs.forEach((log: any) => dailyVolume.add(log.tokenOut, log.amountOut));
+  return { dailyVolume };
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  fetch,
+  start: "2026-05-20",
+  chains: Object.keys(SWAP_WIZARD_CORE),
+  methodology: {
+    Volume: "Swap volume tracked via SwapExecuted events emitted by the SwapWizard aggregator contracts on each chain.",
+  },
+};
+
+export default adapter;


### PR DESCRIPTION
## Summary
- Adds a new aggregator adapter for [SwapWizard](https://swapwizard.xyz), a DeFi execution layer and DEX aggregator
- Tracks daily swap volume via `SwapExecuted` events from SwapWizard contracts
- Supported chains: Ethereum, BSC, Polygon, Base, Arbitrum

## Test
```
npm test aggregators swapwizard
```

Tested locally — returns volume correctly from on-chain events.