### PR TITLE
[feat] Zest-V2: Track zest v2 fees and revenue across vaults 

### DIFF
--- a/fees/zest-v2/index.ts
+++ b/fees/zest-v2/index.ts
@@ -1,0 +1,111 @@
+import { Adapter, Dependencies, FetchOptions } from "../../adapters/types";
+import { queryAllium } from "../../helpers/allium";
+import { CHAIN } from "../../helpers/chains";
+import { METRIC } from "../../helpers/metrics";
+
+const ZEST_V2_DEPLOYER = "SP1A27KFY4XERQCCRCARCYD1CC5N7M6688BSYADJ7";
+
+// Source: Zest v2 mainnet contracts and vault get-fee-reserve read-only calls.
+const vaultList: [string, string, number, number][] = [
+  ["v0-vault-stx", "blockstack", 6, 1_000],
+  ["v0-vault-sbtc", "bitcoin", 8, 1_000],
+  ["v0-vault-ststx", "stacking-dao", 6, 1_000],
+  ["v0-vault-ststxbtc", "bitcoin", 6, 1_000],
+  ["v0-vault-usdc", "usd-coin", 6, 5_000],
+  ["v0-vault-usdh", "hermetica-usdh", 6, 5_000],
+];
+const VAULTS: Record<string, [string, number, number]> = Object.fromEntries(
+  vaultList.map(([name, ...data]) => [`${ZEST_V2_DEPLOYER}.${name}`, data])
+);
+
+const fetch = async (_a: any, _b: any, options: FetchOptions) => {
+  const dailyFees = options.createBalances();
+  const dailyRevenue = options.createBalances();
+  const dailySupplySideRevenue = options.createBalances();
+  const vaults = Object.keys(VAULTS).map((v) => `'${v}'`).join(",");
+
+  const rows: {
+    contract_id: string;
+    borrow_interest: number;
+    flashloan_fees: number;
+  }[] = await queryAllium(`
+    WITH logs AS (
+      SELECT
+        e.event_contents:contract_log:contract_id::string AS contract_id,
+        e.event_contents:contract_log:value:repr::string AS repr
+      FROM stacks.raw.events e
+      JOIN stacks.raw.transactions t ON e.tx_id = t.tx_id
+      WHERE e.burn_block_time >= TO_TIMESTAMP_NTZ(${options.startOfDay})
+        AND e.burn_block_time < TO_TIMESTAMP_NTZ(${options.endTimestamp})
+        AND t.tx_status = 'success'
+        AND t.canonical
+        AND t.microblock_canonical
+        AND e.event_type = 'smart_contract_log'
+        AND e.event_contents:contract_log:contract_id::string IN (${vaults})
+    )
+    SELECT
+      contract_id,
+      SUM(COALESCE(TRY_TO_NUMBER(REGEXP_SUBSTR(repr, 'interest-paid u([0-9]+)', 1, 1, 'e', 1)), 0)) AS borrow_interest,
+      SUM(COALESCE(TRY_TO_NUMBER(REGEXP_SUBSTR(repr, '\\(action "flashloan"\\).*fee u([0-9]+)', 1, 1, 'e', 1)), 0)) AS flashloan_fees
+    FROM logs
+    WHERE repr LIKE '%(action "system-repay")%'
+      OR repr LIKE '%(action "flashloan")%'
+    GROUP BY contract_id
+  `);
+
+  for (const row of rows) {
+    const [cgId, decimals, reserveFeeBps] = VAULTS[row.contract_id] ?? [];
+    if (!cgId) throw new Error(`Unexpected Zest vault in Allium response: ${row.contract_id}`);
+
+    const scale = 10 ** decimals;
+    const borrowInterest = Number(row.borrow_interest ?? 0) / scale;
+    const flashloanFees = Number(row.flashloan_fees ?? 0) / scale;
+    const protocolInterest = borrowInterest * reserveFeeBps / 10_000;
+
+    dailyFees.addCGToken(cgId, borrowInterest, METRIC.BORROW_INTEREST);
+    dailyFees.addCGToken(cgId, flashloanFees, METRIC.FLASHLOAN_FEES);
+    dailyRevenue.addCGToken(cgId, protocolInterest, METRIC.PROTOCOL_FEES);
+    dailyRevenue.addCGToken(cgId, flashloanFees, METRIC.FLASHLOAN_FEES);
+    dailySupplySideRevenue.addCGToken(cgId, borrowInterest - protocolInterest, METRIC.BORROW_INTEREST);
+  }
+
+  return { dailyFees, dailyRevenue, dailyProtocolRevenue: dailyRevenue, dailySupplySideRevenue };
+};
+
+const methodology = {
+  Fees: "Interest paid by borrowers, plus any flashloan fees paid to Zest v2 vaults.",
+  Revenue: "The share of borrower interest kept by the protocol, plus all flashloan fees.",
+  ProtocolRevenue: "The share of borrower interest kept by the protocol treasury, plus all flashloan fees.",
+  SupplySideRevenue: "The remaining borrower interest paid to vault depositors.",
+};
+
+const breakdownMethodology = {
+  Fees: {
+    [METRIC.BORROW_INTEREST]: "Interest paid when borrowers repay Zest v2 vault loans.",
+    [METRIC.FLASHLOAN_FEES]: "Fees paid by users who take Zest v2 flashloans.",
+  },
+  Revenue: {
+    [METRIC.PROTOCOL_FEES]: "Protocol share of borrower interest sent to the treasury.",
+    [METRIC.FLASHLOAN_FEES]: "Flashloan fees sent to the treasury.",
+  },
+  ProtocolRevenue: {
+    [METRIC.PROTOCOL_FEES]: "Protocol share of borrower interest sent to the treasury.",
+    [METRIC.FLASHLOAN_FEES]: "Flashloan fees sent to the treasury.",
+  },
+  SupplySideRevenue: {
+    [METRIC.BORROW_INTEREST]: "Borrower interest paid to vault depositors after the protocol share.",
+  },
+};
+
+const adapter: Adapter = {
+  version: 1,
+  fetch,
+  chains: [CHAIN.STACKS],
+  start: "2026-01-27",
+  isExpensiveAdapter: true,
+  dependencies: [Dependencies.ALLIUM],
+  methodology,
+  breakdownMethodology,
+};
+
+export default adapter;

--- a/fees/zest-v2/index.ts
+++ b/fees/zest-v2/index.ts
@@ -5,37 +5,44 @@ import { METRIC } from "../../helpers/metrics";
 
 const ZEST_V2_DEPLOYER = "SP1A27KFY4XERQCCRCARCYD1CC5N7M6688BSYADJ7";
 
+interface VaultData {
+    suffix: string;
+    cgId: string;
+    decimals: number;
+    reserveFactorBps: number;
+}
+
 // Source: Zest v2 mainnet contracts and vault get-fee-reserve read-only calls.
-const vaultList: [string, string, number, number][] = [
-  ["v0-vault-stx", "blockstack", 6, 1_000],
-  ["v0-vault-sbtc", "bitcoin", 8, 1_000],
-  ["v0-vault-ststx", "stacking-dao", 6, 1_000],
-  ["v0-vault-ststxbtc", "bitcoin", 6, 1_000],
-  ["v0-vault-usdc", "usd-coin", 6, 5_000],
-  ["v0-vault-usdh", "hermetica-usdh", 6, 5_000],
+const vaultList: VaultData[] = [
+    { suffix: "v0-vault-stx", cgId: "blockstack", decimals: 6, reserveFactorBps: 1_000 },
+    { suffix: "v0-vault-sbtc", cgId: "bitcoin", decimals: 8, reserveFactorBps: 1_000 },
+    { suffix: "v0-vault-ststx", cgId: "stacking-dao", decimals: 6, reserveFactorBps: 1_000 },
+    { suffix: "v0-vault-ststxbtc", cgId: "bitcoin", decimals: 6, reserveFactorBps: 1_000 },
+    { suffix: "v0-vault-usdc", cgId: "usd-coin", decimals: 6, reserveFactorBps: 5_000 },
+    { suffix: "v0-vault-usdh", cgId: "hermetica-usdh", decimals: 6, reserveFactorBps: 5_000 },
 ];
-const VAULTS: Record<string, [string, number, number]> = Object.fromEntries(
-  vaultList.map(([name, ...data]) => [`${ZEST_V2_DEPLOYER}.${name}`, data])
+const VAULTS: Record<string, VaultData> = Object.fromEntries(
+    vaultList.map((vault) => [`${ZEST_V2_DEPLOYER}.${vault.suffix}`, vault])
 );
 
-const fetch = async (_a: any, _b: any, options: FetchOptions) => {
-  const dailyFees = options.createBalances();
-  const dailyRevenue = options.createBalances();
-  const dailySupplySideRevenue = options.createBalances();
-  const vaults = Object.keys(VAULTS).map((v) => `'${v}'`).join(",");
+const fetch = async (options: FetchOptions) => {
+    const dailyFees = options.createBalances();
+    const dailyRevenue = options.createBalances();
+    const dailySupplySideRevenue = options.createBalances();
+    const vaults = Object.keys(VAULTS).map((v) => `'${v}'`).join(",");
 
-  const rows: {
-    contract_id: string;
-    borrow_interest: number;
-    flashloan_fees: number;
-  }[] = await queryAllium(`
+    const rows: {
+        contract_id: string;
+        borrow_interest: number;
+        flashloan_fees: number;
+    }[] = await queryAllium(`
     WITH logs AS (
       SELECT
         e.event_contents:contract_log:contract_id::string AS contract_id,
         e.event_contents:contract_log:value:repr::string AS repr
       FROM stacks.raw.events e
       JOIN stacks.raw.transactions t ON e.tx_id = t.tx_id
-      WHERE e.burn_block_time >= TO_TIMESTAMP_NTZ(${options.startOfDay})
+      WHERE e.burn_block_time >= TO_TIMESTAMP_NTZ(${options.startTimestamp})
         AND e.burn_block_time < TO_TIMESTAMP_NTZ(${options.endTimestamp})
         AND t.tx_status = 'success'
         AND t.canonical
@@ -53,59 +60,61 @@ const fetch = async (_a: any, _b: any, options: FetchOptions) => {
     GROUP BY contract_id
   `);
 
-  for (const row of rows) {
-    const [cgId, decimals, reserveFeeBps] = VAULTS[row.contract_id] ?? [];
-    if (!cgId) throw new Error(`Unexpected Zest vault in Allium response: ${row.contract_id}`);
+    for (const row of rows) {
+        const vault = VAULTS[row.contract_id];
+        if (!vault) throw new Error(`Unexpected Zest vault in Allium response: ${row.contract_id}`);
+        const { cgId, decimals, reserveFactorBps } = vault;
 
-    const scale = 10 ** decimals;
-    const borrowInterest = Number(row.borrow_interest ?? 0) / scale;
-    const flashloanFees = Number(row.flashloan_fees ?? 0) / scale;
-    const protocolInterest = borrowInterest * reserveFeeBps / 10_000;
+        const scale = 10 ** decimals;
+        const borrowInterest = Number(row.borrow_interest ?? 0) / scale;
+        const flashloanFees = Number(row.flashloan_fees ?? 0) / scale;
+        const protocolInterest = borrowInterest * reserveFactorBps / 10_000;
 
-    dailyFees.addCGToken(cgId, borrowInterest, METRIC.BORROW_INTEREST);
-    dailyFees.addCGToken(cgId, flashloanFees, METRIC.FLASHLOAN_FEES);
-    dailyRevenue.addCGToken(cgId, protocolInterest, METRIC.PROTOCOL_FEES);
-    dailyRevenue.addCGToken(cgId, flashloanFees, METRIC.FLASHLOAN_FEES);
-    dailySupplySideRevenue.addCGToken(cgId, borrowInterest - protocolInterest, METRIC.BORROW_INTEREST);
-  }
+        dailyFees.addCGToken(cgId, borrowInterest, METRIC.BORROW_INTEREST);
+        dailyFees.addCGToken(cgId, flashloanFees, METRIC.FLASHLOAN_FEES);
+        dailyRevenue.addCGToken(cgId, protocolInterest, METRIC.PROTOCOL_FEES);
+        dailyRevenue.addCGToken(cgId, flashloanFees, METRIC.FLASHLOAN_FEES);
+        dailySupplySideRevenue.addCGToken(cgId, borrowInterest - protocolInterest, METRIC.BORROW_INTEREST);
+    }
 
-  return { dailyFees, dailyRevenue, dailyProtocolRevenue: dailyRevenue, dailySupplySideRevenue };
+    return { dailyFees, dailyRevenue, dailyProtocolRevenue: dailyRevenue, dailySupplySideRevenue };
 };
 
 const methodology = {
-  Fees: "Interest paid by borrowers, plus any flashloan fees paid to Zest v2 vaults.",
-  Revenue: "The share of borrower interest kept by the protocol, plus all flashloan fees.",
-  ProtocolRevenue: "The share of borrower interest kept by the protocol treasury, plus all flashloan fees.",
-  SupplySideRevenue: "The remaining borrower interest paid to vault depositors.",
+    Fees: "Interest paid by borrowers, plus any flashloan fees paid to Zest v2 vaults.",
+    Revenue: "The share of borrower interest kept by the protocol, plus all flashloan fees.",
+    ProtocolRevenue: "The share of borrower interest kept by the protocol treasury, plus all flashloan fees.",
+    SupplySideRevenue: "The remaining borrower interest paid to vault depositors.",
 };
 
 const breakdownMethodology = {
-  Fees: {
-    [METRIC.BORROW_INTEREST]: "Interest paid when borrowers repay Zest v2 vault loans.",
-    [METRIC.FLASHLOAN_FEES]: "Fees paid by users who take Zest v2 flashloans.",
-  },
-  Revenue: {
-    [METRIC.PROTOCOL_FEES]: "Protocol share of borrower interest sent to the treasury.",
-    [METRIC.FLASHLOAN_FEES]: "Flashloan fees sent to the treasury.",
-  },
-  ProtocolRevenue: {
-    [METRIC.PROTOCOL_FEES]: "Protocol share of borrower interest sent to the treasury.",
-    [METRIC.FLASHLOAN_FEES]: "Flashloan fees sent to the treasury.",
-  },
-  SupplySideRevenue: {
-    [METRIC.BORROW_INTEREST]: "Borrower interest paid to vault depositors after the protocol share.",
-  },
+    Fees: {
+        [METRIC.BORROW_INTEREST]: "Interest paid when borrowers repay Zest v2 vault loans.",
+        [METRIC.FLASHLOAN_FEES]: "Fees paid by users who take Zest v2 flashloans.",
+    },
+    Revenue: {
+        [METRIC.PROTOCOL_FEES]: "Protocol share of borrower interest sent to the treasury.",
+        [METRIC.FLASHLOAN_FEES]: "Flashloan fees sent to the treasury.",
+    },
+    ProtocolRevenue: {
+        [METRIC.PROTOCOL_FEES]: "Protocol share of borrower interest sent to the treasury.",
+        [METRIC.FLASHLOAN_FEES]: "Flashloan fees sent to the treasury.",
+    },
+    SupplySideRevenue: {
+        [METRIC.BORROW_INTEREST]: "Borrower interest paid to vault depositors after the protocol share.",
+    },
 };
 
 const adapter: Adapter = {
-  version: 1,
-  fetch,
-  chains: [CHAIN.STACKS],
-  start: "2026-01-27",
-  isExpensiveAdapter: true,
-  dependencies: [Dependencies.ALLIUM],
-  methodology,
-  breakdownMethodology,
+    version: 2,
+    pullHourly: true,
+    fetch,
+    chains: [CHAIN.STACKS],
+    start: "2026-01-27",
+    isExpensiveAdapter: true,
+    dependencies: [Dependencies.ALLIUM],
+    methodology,
+    breakdownMethodology,
 };
 
 export default adapter;


### PR DESCRIPTION
> Maintainer note: please run the Zest Protocol adapter with an Allium API key to confirm the Stacks `event_contents:contract_log:value:repr` JSON path used by the query.

Tracks Zest V2 https://defillama.com/protocol/zest-v2

## Summary
- Adds the Zest Protocol v2 fees and revenue adapter for Stacks under `fees/zest-protocol`.
- Reports borrower interest, flashloan fees, protocol revenue, and supply-side revenue from v2 vault contract logs.
- Uses CoinGecko-priced balances for STX, sBTC, stSTX, USDC, and USDH vault activity.

## Changes
- Added a v1 adapter that queries `stacks.raw.events` through Allium and filters successful canonical Stacks transactions.
- Tracks Zest v2 vault contracts for STX, sBTC, stSTX, stSTXbtc, USDC, and USDH.
- Applies vault reserve-fee bps to split borrower interest between protocol revenue and supply-side revenue.
- Counts flashloan fees as fees and protocol revenue, not supply-side revenue.
- Added user-readable methodology and metric breakdowns for borrower interest, protocol fees, and flashloan fees.

## Methodology
- Fees: borrower interest paid through successful `system-repay` logs plus flashloan fees paid to Zest v2 vaults.
- Revenue / ProtocolRevenue: protocol reserve share of borrower interest plus all flashloan fees.
- SupplySideRevenue: borrower interest remaining for vault depositors after the protocol reserve share.
- Time windows use `options.startOfDay` to `options.endTimestamp` for daily v1 adapter boundaries.

## Data Quality / Risk
- Allium docs confirm the Stacks raw events and transactions tables used here, but the nested `event_contents` shape should be validated with a live Allium run.
- Adapter is marked expensive because it scans Stacks raw event logs.
