### PR TITLE
[feat] Zest-V1: add fees and revenue adapter for V1 markets

### DIFF
--- a/fees/zest/index.ts
+++ b/fees/zest/index.ts
@@ -4,25 +4,30 @@ import { CHAIN } from "../../helpers/chains";
 import { METRIC } from "../../helpers/metrics";
 
 const FIXED_ONE = 100_000_000;
+const ZEST_V1_DEPLOYER = "SP2VCQJGH7PHP2DJK7Z0V48AGBHQAW3R3ZW1QF4N";
+
+interface AssetData {
+  contract: string;
+  cgId: string;
+  decimals: number;
+}
+
+const assetList: AssetData[] = [
+  { contract: `${ZEST_V1_DEPLOYER}.wstx`, cgId: "blockstack", decimals: 6 },
+  { contract: "SP4SZE494VC2YC5JYG7AYFQ44F5Q4PYV7DVMDPBG.ststx-token", cgId: "stacking-dao", decimals: 6 },
+  { contract: "SP3Y2ZSH8P7D50B0VBTSX11S7XSG24M1VB9YFQA4K.token-aeusdc", cgId: "usd-coin", decimals: 6 },
+  { contract: "SPN5AKG35QZSK2M8GAMR4AFX45659RJHDW353HSG.usdh-token-v1", cgId: "hermetica-usdh", decimals: 8 },
+  { contract: "SM3VDXK3WZZSA84XXFKAFAF15NNZX32CTSG82JFQ4.sbtc-token", cgId: "bitcoin", decimals: 8 },
+  { contract: "SP4SZE494VC2YC5JYG7AYFQ44F5Q4PYV7DVMDPBG.ststxbtc-token-v2", cgId: "bitcoin", decimals: 6 },
+];
+const ASSETS: Record<string, AssetData> = Object.fromEntries(assetList.map((asset) => [asset.contract, asset]));
+const ASSET_FILTER = Object.keys(ASSETS).map((asset) => `'${asset}'`).join(",");
 
 const chainConfig = {
-  [CHAIN.STACKS]: {
-    start: "2024-02-23",
-    deployer: "SP2VCQJGH7PHP2DJK7Z0V48AGBHQAW3R3ZW1QF4N",
-    assets: {
-      "SP2VCQJGH7PHP2DJK7Z0V48AGBHQAW3R3ZW1QF4N.wstx": ["blockstack", 6],
-      "SP4SZE494VC2YC5JYG7AYFQ44F5Q4PYV7DVMDPBG.ststx-token": ["stacking-dao", 6],
-      "SP3Y2ZSH8P7D50B0VBTSX11S7XSG24M1VB9YFQA4K.token-aeusdc": ["usd-coin", 6],
-      "SPN5AKG35QZSK2M8GAMR4AFX45659RJHDW353HSG.usdh-token-v1": ["hermetica-usdh", 8],
-      "SM3VDXK3WZZSA84XXFKAFAF15NNZX32CTSG82JFQ4.sbtc-token": ["bitcoin", 8],
-      "SP4SZE494VC2YC5JYG7AYFQ44F5Q4PYV7DVMDPBG.ststxbtc-token-v2": ["bitcoin", 6],
-    } as Record<string, [string, number]>,
-  },
+  [CHAIN.STACKS]: { start: "2024-02-23" },
 };
-const config = chainConfig[CHAIN.STACKS];
-const ASSET_FILTER = `'${Object.keys(config.assets).join("','")}'`;
 
-const fetch = async (_a: any, _b: any, options: FetchOptions) => {
+const fetch = async (options: FetchOptions) => {
   const dailyFees = options.createBalances();
   const dailyRevenue = options.createBalances();
   const dailySupplySideRevenue = options.createBalances();
@@ -48,7 +53,7 @@ const fetch = async (_a: any, _b: any, options: FetchOptions) => {
         AND t.canonical
         AND t.microblock_canonical
         AND e.event_type = 'smart_contract_log'
-        AND e.event_contents:contract_log:contract_id::string = '${config.deployer}.pool-reserve-data'
+        AND e.event_contents:contract_log:contract_id::string = '${ZEST_V1_DEPLOYER}.pool-reserve-data'
         AND e.event_contents:contract_log:value:repr::string LIKE '%(type "set-reserve-state")%'
     ),
     reserve_events AS (
@@ -96,7 +101,7 @@ const fetch = async (_a: any, _b: any, options: FetchOptions) => {
           AND t.canonical
           AND t.microblock_canonical
           AND e.event_type = 'smart_contract_log'
-          AND e.event_contents:contract_log:contract_id::string LIKE '${config.deployer}.pool-borrow%'
+          AND e.event_contents:contract_log:contract_id::string LIKE '${ZEST_V1_DEPLOYER}.pool-borrow%'
           AND e.event_contents:contract_log:value:repr::string LIKE '%(type "flashloan")%'
       )
       WHERE asset IN (${ASSET_FILTER})
@@ -116,7 +121,7 @@ const fetch = async (_a: any, _b: any, options: FetchOptions) => {
   `);
 
   for (const row of rows) {
-    const [cgId, decimals] = config.assets[row.asset];
+    const { cgId, decimals } = ASSETS[row.asset];
     const scale = 10 ** decimals;
     const borrowInterest = Number(row.borrow_interest ?? 0) / scale;
     const protocolInterest = Number(row.protocol_interest ?? 0) / scale;
@@ -161,9 +166,10 @@ const breakdownMethodology = {
 };
 
 const adapter: Adapter = {
-  version: 1,
+  version: 2,
   fetch,
   adapter: chainConfig,
+  pullHourly: true,
   isExpensiveAdapter: true,
   dependencies: [Dependencies.ALLIUM],
   methodology,

--- a/fees/zest/index.ts
+++ b/fees/zest/index.ts
@@ -1,0 +1,173 @@
+import { Adapter, Dependencies, FetchOptions } from "../../adapters/types";
+import { queryAllium } from "../../helpers/allium";
+import { CHAIN } from "../../helpers/chains";
+import { METRIC } from "../../helpers/metrics";
+
+const FIXED_ONE = 100_000_000;
+
+const chainConfig = {
+  [CHAIN.STACKS]: {
+    start: "2024-02-23",
+    deployer: "SP2VCQJGH7PHP2DJK7Z0V48AGBHQAW3R3ZW1QF4N",
+    assets: {
+      "SP2VCQJGH7PHP2DJK7Z0V48AGBHQAW3R3ZW1QF4N.wstx": ["blockstack", 6],
+      "SP4SZE494VC2YC5JYG7AYFQ44F5Q4PYV7DVMDPBG.ststx-token": ["stacking-dao", 6],
+      "SP3Y2ZSH8P7D50B0VBTSX11S7XSG24M1VB9YFQA4K.token-aeusdc": ["usd-coin", 6],
+      "SPN5AKG35QZSK2M8GAMR4AFX45659RJHDW353HSG.usdh-token-v1": ["hermetica-usdh", 8],
+      "SM3VDXK3WZZSA84XXFKAFAF15NNZX32CTSG82JFQ4.sbtc-token": ["bitcoin", 8],
+      "SP4SZE494VC2YC5JYG7AYFQ44F5Q4PYV7DVMDPBG.ststxbtc-token-v2": ["bitcoin", 6],
+    } as Record<string, [string, number]>,
+  },
+};
+const config = chainConfig[CHAIN.STACKS];
+const ASSET_FILTER = `'${Object.keys(config.assets).join("','")}'`;
+
+const fetch = async (_a: any, _b: any, options: FetchOptions) => {
+  const dailyFees = options.createBalances();
+  const dailyRevenue = options.createBalances();
+  const dailySupplySideRevenue = options.createBalances();
+
+  const rows: {
+    asset: string;
+    borrow_interest: number;
+    protocol_interest: number;
+    flashloan_fees: number;
+    flashloan_protocol_fees: number;
+  }[] = await queryAllium(`
+    WITH reserve_events_raw AS (
+      SELECT
+        e.tx_id,
+        e.event_index,
+        e.burn_block_time,
+        REGEXP_SUBSTR(e.event_contents:contract_log:value:repr::string, '\\(key ''([^'']+)''\\)\\)\\) \\(type "set-reserve-state"\\)', 1, 1, 'e', 1) AS asset,
+        TRY_TO_NUMBER(REGEXP_SUBSTR(e.event_contents:contract_log:value:repr::string, '\\(accrued-to-treasury u([0-9]+)\\)', 1, 1, 'e', 1)) AS accrued
+      FROM stacks.raw.events e
+      JOIN stacks.raw.transactions t ON e.tx_id = t.tx_id
+      WHERE e.burn_block_time < TO_TIMESTAMP_NTZ(${options.endTimestamp})
+        AND t.tx_status = 'success'
+        AND t.canonical
+        AND t.microblock_canonical
+        AND e.event_type = 'smart_contract_log'
+        AND e.event_contents:contract_log:contract_id::string = '${config.deployer}.pool-reserve-data'
+        AND e.event_contents:contract_log:value:repr::string LIKE '%(type "set-reserve-state")%'
+    ),
+    reserve_events AS (
+      SELECT * FROM reserve_events_raw
+      WHERE burn_block_time >= TO_TIMESTAMP_NTZ(${options.startOfDay}) AND asset IN (${ASSET_FILTER})
+      UNION ALL
+      SELECT * FROM (
+        SELECT * FROM reserve_events_raw
+        WHERE burn_block_time < TO_TIMESTAMP_NTZ(${options.startOfDay}) AND asset IN (${ASSET_FILTER})
+        QUALIFY ROW_NUMBER() OVER (PARTITION BY asset ORDER BY burn_block_time DESC, tx_id DESC, event_index DESC) = 1
+      )
+    ),
+    treasury_deltas AS (
+      SELECT
+        burn_block_time,
+        asset,
+        GREATEST(accrued - LAG(accrued) OVER (PARTITION BY asset ORDER BY burn_block_time, tx_id, event_index), 0) AS protocol_interest
+      FROM reserve_events
+    ),
+    borrow_interest AS (
+      SELECT
+        d.asset,
+        protocol_interest * ${FIXED_ONE} / CASE
+          WHEN burn_block_time >= TO_TIMESTAMP_NTZ('2026-04-28 13:43:29') THEN 95000000
+          WHEN burn_block_time >= TO_TIMESTAMP_NTZ('2026-03-02 14:17:00') THEN 50000000
+          WHEN burn_block_time >= TO_TIMESTAMP_NTZ('2026-02-17 18:31:03') THEN 20000000
+          ELSE 10000000
+        END AS borrow_interest,
+        d.protocol_interest
+      FROM treasury_deltas d
+      WHERE d.burn_block_time >= TO_TIMESTAMP_NTZ(${options.startOfDay})
+        AND d.protocol_interest > 0
+    ),
+    flashloans AS (
+      SELECT * FROM (
+        SELECT
+          REGEXP_SUBSTR(e.event_contents:contract_log:value:repr::string, '\\(asset ''([^'']+)''\\)', 1, 1, 'e', 1) AS asset,
+          TRY_TO_NUMBER(REGEXP_SUBSTR(e.event_contents:contract_log:value:repr::string, '\\(amount-fee u([0-9]+)\\)', 1, 1, 'e', 1)) AS flashloan_fees,
+          TRY_TO_NUMBER(REGEXP_SUBSTR(e.event_contents:contract_log:value:repr::string, '\\(protocol-fee u([0-9]+)\\)', 1, 1, 'e', 1)) AS flashloan_protocol_fees
+        FROM stacks.raw.events e
+        JOIN stacks.raw.transactions t ON e.tx_id = t.tx_id
+        WHERE e.burn_block_time >= TO_TIMESTAMP_NTZ(${options.startOfDay})
+          AND e.burn_block_time < TO_TIMESTAMP_NTZ(${options.endTimestamp})
+          AND t.tx_status = 'success'
+          AND t.canonical
+          AND t.microblock_canonical
+          AND e.event_type = 'smart_contract_log'
+          AND e.event_contents:contract_log:contract_id::string LIKE '${config.deployer}.pool-borrow%'
+          AND e.event_contents:contract_log:value:repr::string LIKE '%(type "flashloan")%'
+      )
+      WHERE asset IN (${ASSET_FILTER})
+    )
+    SELECT
+      asset,
+      SUM(borrow_interest) AS borrow_interest,
+      SUM(protocol_interest) AS protocol_interest,
+      SUM(flashloan_fees) AS flashloan_fees,
+      SUM(flashloan_protocol_fees) AS flashloan_protocol_fees
+    FROM (
+      SELECT asset, borrow_interest, protocol_interest, 0 AS flashloan_fees, 0 AS flashloan_protocol_fees FROM borrow_interest
+      UNION ALL
+      SELECT asset, 0 AS borrow_interest, 0 AS protocol_interest, flashloan_fees, flashloan_protocol_fees FROM flashloans
+    )
+    GROUP BY asset
+  `);
+
+  for (const row of rows) {
+    const [cgId, decimals] = config.assets[row.asset];
+    const scale = 10 ** decimals;
+    const borrowInterest = Number(row.borrow_interest ?? 0) / scale;
+    const protocolInterest = Number(row.protocol_interest ?? 0) / scale;
+    const flashloanFees = Number(row.flashloan_fees ?? 0) / scale;
+    const flashloanProtocolFees = Number(row.flashloan_protocol_fees ?? 0) / scale;
+
+    dailyFees.addCGToken(cgId, borrowInterest, METRIC.BORROW_INTEREST);
+    dailyFees.addCGToken(cgId, flashloanFees, METRIC.FLASHLOAN_FEES);
+    dailyRevenue.addCGToken(cgId, protocolInterest, METRIC.PROTOCOL_FEES);
+    dailyRevenue.addCGToken(cgId, flashloanProtocolFees, METRIC.FLASHLOAN_FEES);
+    dailySupplySideRevenue.addCGToken(cgId, borrowInterest - protocolInterest, METRIC.BORROW_INTEREST);
+    dailySupplySideRevenue.addCGToken(cgId, flashloanFees - flashloanProtocolFees, METRIC.FLASHLOAN_FEES);
+  }
+
+  return { dailyFees, dailyRevenue, dailyProtocolRevenue: dailyRevenue, dailySupplySideRevenue };
+};
+
+const methodology = {
+  Fees: "Interest paid by borrowers, plus any flashloan fees.",
+  Revenue: "The share of borrower interest and flashloan fees kept by Zest.",
+  ProtocolRevenue: "The share of borrower interest and flashloan fees kept by Zest.",
+  SupplySideRevenue: "The remaining borrower interest and flashloan fees paid to lenders.",
+};
+
+const breakdownMethodology = {
+  Fees: {
+    [METRIC.BORROW_INTEREST]: "Interest paid on Zest v1 loans.",
+    [METRIC.FLASHLOAN_FEES]: "Fees paid for Zest v1 flashloans.",
+  },
+  Revenue: {
+    [METRIC.PROTOCOL_FEES]: "Zest's share of borrower interest.",
+    [METRIC.FLASHLOAN_FEES]: "Zest's share of flashloan fees.",
+  },
+  ProtocolRevenue: {
+    [METRIC.PROTOCOL_FEES]: "Zest's share of borrower interest.",
+    [METRIC.FLASHLOAN_FEES]: "Zest's share of flashloan fees.",
+  },
+  SupplySideRevenue: {
+    [METRIC.BORROW_INTEREST]: "Borrower interest paid to lenders.",
+    [METRIC.FLASHLOAN_FEES]: "Flashloan fees paid to lenders.",
+  },
+};
+
+const adapter: Adapter = {
+  version: 1,
+  fetch,
+  adapter: chainConfig,
+  isExpensiveAdapter: true,
+  dependencies: [Dependencies.ALLIUM],
+  methodology,
+  breakdownMethodology,
+};
+
+export default adapter;

--- a/fees/zest/index.ts
+++ b/fees/zest/index.ts
@@ -6,6 +6,13 @@ import { METRIC } from "../../helpers/metrics";
 const FIXED_ONE = 100_000_000;
 const ZEST_V1_DEPLOYER = "SP2VCQJGH7PHP2DJK7Z0V48AGBHQAW3R3ZW1QF4N";
 
+const LABEL = {
+  BORROW_TO_TREASURY: "Borrow Interest To Treasury",
+  BORROW_TO_LENDERS: "Borrow Interest To Lenders",
+  FLASHLOAN_TO_TREASURY: "Flashloan Fees To Treasury",
+  FLASHLOAN_TO_LENDERS: "Flashloan Fees To Lenders",
+};
+
 interface AssetData {
   contract: string;
   cgId: string;
@@ -58,16 +65,49 @@ const fetch = async (options: FetchOptions) => {
     ),
     reserve_events AS (
       SELECT * FROM reserve_events_raw
-      WHERE burn_block_time >= TO_TIMESTAMP_NTZ(${options.startOfDay}) AND asset IN (${ASSET_FILTER})
+      WHERE burn_block_time >= TO_TIMESTAMP_NTZ(${options.startTimestamp}) AND asset IN (${ASSET_FILTER})
       UNION ALL
       SELECT * FROM (
         SELECT * FROM reserve_events_raw
-        WHERE burn_block_time < TO_TIMESTAMP_NTZ(${options.startOfDay}) AND asset IN (${ASSET_FILTER})
+        WHERE burn_block_time < TO_TIMESTAMP_NTZ(${options.startTimestamp}) AND asset IN (${ASSET_FILTER})
         QUALIFY ROW_NUMBER() OVER (PARTITION BY asset ORDER BY burn_block_time DESC, tx_id DESC, event_index DESC) = 1
       )
     ),
+    factor_logs AS (
+      SELECT
+        e.burn_block_time,
+        e.event_contents:contract_log:value:repr::string AS repr
+      FROM stacks.raw.events e
+      JOIN stacks.raw.transactions t ON e.tx_id = t.tx_id
+      WHERE e.burn_block_time < TO_TIMESTAMP_NTZ(${options.endTimestamp})
+        AND t.tx_status = 'success'
+        AND t.canonical
+        AND t.microblock_canonical
+        AND e.event_type = 'smart_contract_log'
+        AND e.event_contents:contract_log:contract_id::string LIKE '${ZEST_V1_DEPLOYER}.%'
+        AND e.event_contents:contract_log:value:repr::string LIKE '%reserve-factor%'
+    ),
+    factor_updates AS (
+      SELECT * FROM (
+        SELECT
+          burn_block_time,
+          COALESCE(
+            REGEXP_SUBSTR(repr, '\\(key ''([^'']+)''\\)', 1, 1, 'e', 1),
+            REGEXP_SUBSTR(repr, '\\(asset ''([^'']+)''\\)', 1, 1, 'e', 1)
+          ) AS asset,
+          TRY_TO_NUMBER(COALESCE(
+            REGEXP_SUBSTR(repr, '\\(data u([0-9]+)\\)', 1, 1, 'e', 1),
+            REGEXP_SUBSTR(repr, '\\(new-reserve-factor u([0-9]+)\\)', 1, 1, 'e', 1)
+          )) AS reserve_factor
+        FROM factor_logs
+        WHERE repr LIKE '%set-reserve-factor%' OR repr LIKE '%pre-update-reserve-factor%'
+      )
+      WHERE asset IN (${ASSET_FILTER}) AND reserve_factor > 0
+    ),
     treasury_deltas AS (
       SELECT
+        tx_id,
+        event_index,
         burn_block_time,
         asset,
         GREATEST(accrued - LAG(accrued) OVER (PARTITION BY asset ORDER BY burn_block_time, tx_id, event_index), 0) AS protocol_interest
@@ -76,16 +116,13 @@ const fetch = async (options: FetchOptions) => {
     borrow_interest AS (
       SELECT
         d.asset,
-        protocol_interest * ${FIXED_ONE} / CASE
-          WHEN burn_block_time >= TO_TIMESTAMP_NTZ('2026-04-28 13:43:29') THEN 95000000
-          WHEN burn_block_time >= TO_TIMESTAMP_NTZ('2026-03-02 14:17:00') THEN 50000000
-          WHEN burn_block_time >= TO_TIMESTAMP_NTZ('2026-02-17 18:31:03') THEN 20000000
-          ELSE 10000000
-        END AS borrow_interest,
+        d.protocol_interest * ${FIXED_ONE} / f.reserve_factor AS borrow_interest,
         d.protocol_interest
       FROM treasury_deltas d
-      WHERE d.burn_block_time >= TO_TIMESTAMP_NTZ(${options.startOfDay})
+      JOIN factor_updates f ON f.asset = d.asset AND f.burn_block_time <= d.burn_block_time
+      WHERE d.burn_block_time >= TO_TIMESTAMP_NTZ(${options.startTimestamp})
         AND d.protocol_interest > 0
+      QUALIFY ROW_NUMBER() OVER (PARTITION BY d.tx_id, d.event_index ORDER BY f.burn_block_time DESC) = 1
     ),
     flashloans AS (
       SELECT * FROM (
@@ -95,7 +132,7 @@ const fetch = async (options: FetchOptions) => {
           TRY_TO_NUMBER(REGEXP_SUBSTR(e.event_contents:contract_log:value:repr::string, '\\(protocol-fee u([0-9]+)\\)', 1, 1, 'e', 1)) AS flashloan_protocol_fees
         FROM stacks.raw.events e
         JOIN stacks.raw.transactions t ON e.tx_id = t.tx_id
-        WHERE e.burn_block_time >= TO_TIMESTAMP_NTZ(${options.startOfDay})
+        WHERE e.burn_block_time >= TO_TIMESTAMP_NTZ(${options.startTimestamp})
           AND e.burn_block_time < TO_TIMESTAMP_NTZ(${options.endTimestamp})
           AND t.tx_status = 'success'
           AND t.canonical
@@ -130,10 +167,10 @@ const fetch = async (options: FetchOptions) => {
 
     dailyFees.addCGToken(cgId, borrowInterest, METRIC.BORROW_INTEREST);
     dailyFees.addCGToken(cgId, flashloanFees, METRIC.FLASHLOAN_FEES);
-    dailyRevenue.addCGToken(cgId, protocolInterest, METRIC.PROTOCOL_FEES);
-    dailyRevenue.addCGToken(cgId, flashloanProtocolFees, METRIC.FLASHLOAN_FEES);
-    dailySupplySideRevenue.addCGToken(cgId, borrowInterest - protocolInterest, METRIC.BORROW_INTEREST);
-    dailySupplySideRevenue.addCGToken(cgId, flashloanFees - flashloanProtocolFees, METRIC.FLASHLOAN_FEES);
+    dailyRevenue.addCGToken(cgId, protocolInterest, LABEL.BORROW_TO_TREASURY);
+    dailyRevenue.addCGToken(cgId, flashloanProtocolFees, LABEL.FLASHLOAN_TO_TREASURY);
+    dailySupplySideRevenue.addCGToken(cgId, borrowInterest - protocolInterest, LABEL.BORROW_TO_LENDERS);
+    dailySupplySideRevenue.addCGToken(cgId, flashloanFees - flashloanProtocolFees, LABEL.FLASHLOAN_TO_LENDERS);
   }
 
   return { dailyFees, dailyRevenue, dailyProtocolRevenue: dailyRevenue, dailySupplySideRevenue };
@@ -152,16 +189,16 @@ const breakdownMethodology = {
     [METRIC.FLASHLOAN_FEES]: "Fees paid for Zest v1 flashloans.",
   },
   Revenue: {
-    [METRIC.PROTOCOL_FEES]: "Zest's share of borrower interest.",
-    [METRIC.FLASHLOAN_FEES]: "Zest's share of flashloan fees.",
+    [LABEL.BORROW_TO_TREASURY]: "Zest's share of borrower interest.",
+    [LABEL.FLASHLOAN_TO_TREASURY]: "Zest's share of flashloan fees.",
   },
   ProtocolRevenue: {
-    [METRIC.PROTOCOL_FEES]: "Zest's share of borrower interest.",
-    [METRIC.FLASHLOAN_FEES]: "Zest's share of flashloan fees.",
+    [LABEL.BORROW_TO_TREASURY]: "Zest's share of borrower interest.",
+    [LABEL.FLASHLOAN_TO_TREASURY]: "Zest's share of flashloan fees.",
   },
   SupplySideRevenue: {
-    [METRIC.BORROW_INTEREST]: "Borrower interest paid to lenders.",
-    [METRIC.FLASHLOAN_FEES]: "Flashloan fees paid to lenders.",
+    [LABEL.BORROW_TO_LENDERS]: "Borrower interest paid to lenders.",
+    [LABEL.FLASHLOAN_TO_LENDERS]: "Flashloan fees paid to lenders.",
   },
 };
 


### PR DESCRIPTION
> Maintainer note: please run the Zest adapter with an Allium API key to validate the Stacks `event_contents:contract_log:value:repr` paths and reserve-state delta query.

Tracks Zest V1 https://defillama.com/protocol/zest-v1

## Summary
- Adds the Zest v1 fees adapter for Stacks under `fees/zest`.
- Tracks borrower interest, flashloan fees, protocol revenue, and supply-side revenue for the active Zest v1 markets.
- Uses Allium raw Stacks events for historical daily aggregation.

## Changes
- Added `fees/zest/index.ts` with a Stacks chain config for the Zest v1 deployer.
- Scoped the adapter to the listed Zest v1 assets: STX, sBTC, stSTX, stSTXbtc, aeUSDC, and USDh.
- Uses `pool-reserve-data` reserve-state logs to calculate protocol interest from `accrued-to-treasury` deltas.
- Applies historical reserve-factor periods to estimate total borrower interest from protocol interest.
- Parses Zest v1 flashloan logs for total flashloan fees and protocol flashloan fees.
- Reports fees, revenue, protocol revenue, and supply-side revenue with metric breakdown methodology.

## Methodology
- Fees include borrower interest and flashloan fees.
- Revenue and protocol revenue include Zest's share of borrower interest and flashloan fees.
- Supply-side revenue includes the remaining borrower interest and flashloan fees paid to lenders.
- The adapter starts on `2024-02-23`, the launch day for the scoped Zest v1 market deployment.

## Data Quality / Risk
- The query depends on Allium's Stacks raw event JSON shape for contract logs.
- Borrow interest is reconstructed from reserve-state deltas and reserve-factor periods rather than a direct borrower-interest event.
- Flashloan fees are read directly from Zest v1 flashloan log fields.
