### PR TITLE
fix: include JustLend Energy Rental Market fees in adapter

### DIFF
--- a/fees/justlend.ts
+++ b/fees/justlend.ts
@@ -33,6 +33,12 @@ const fetch = async (timestamp: number, _: ChainBlocks, { createBalances, fromTi
   const tempBalance = dailyProtocolFees.clone();
   tempBalance.subtract(dailyProtocolRevenue);
   dailySupplySideRevenue.addBalances(tempBalance, 'Borrow Interest');
+
+  // Energy Rental Market — JustLend's separate product where users rent
+  // Energy from staked TRX. Fees flow to sTRX stakers; we count them on the
+  // supply side and don't claim a protocol cut (split not published).
+  await getDailyEnergyRentalFees(context, { dailyProtocolFees, dailySupplySideRevenue });
+
   return {
     timestamp,
     dailyFees: dailyProtocolFees,
@@ -161,6 +167,43 @@ const getDailyProtocolFees = async ({
   });
 };
 
+// Tagged on TronScan as `JustLend DAO: Energy Rental`. Each rental closes with
+// a `ReturnResource` event whose `usageRental` field is the fee retained from
+// the renter's security deposit (verified by tracing internal transfers — the
+// deposit refund equals `subedSecurityDeposit - usageRental`).
+const ENERGY_RENTAL_CONTRACT = 'TU2MJ5Veik1LRAgjeSzEdvmDYx7mefJZvd';
+
+const getDailyEnergyRentalFees = async (
+  { startBlock, endBlock }: IContext,
+  { dailyProtocolFees, dailySupplySideRevenue }: { dailyProtocolFees: sdk.Balances, dailySupplySideRevenue: sdk.Balances },
+) => {
+  const trxToken = ADDRESSES.tron.WTRX.toLowerCase();
+  let fingerprint: string | undefined = undefined;
+  for (let page = 0; page < 200; page++) {
+    const params = [
+      'event_name=ReturnResource',
+      `min_block_timestamp=${startBlock}`,
+      `max_block_timestamp=${endBlock}`,
+      'order_by=block_timestamp,asc',
+      'limit=200',
+    ];
+    if (fingerprint) params.push(`fingerprint=${fingerprint}`);
+    const url = `${endpoint}/v1/contracts/${ENERGY_RENTAL_CONTRACT}/events?${params.join('&')}`;
+    const res = await httpGet(url);
+    const events = res.data ?? [];
+    for (const ev of events) {
+      const usageRental = ev.result?.usageRental;
+      if (!usageRental) continue;
+      const sun = Number(usageRental);
+      dailyProtocolFees.add(trxToken, sun, 'Energy Rental Fee');
+      dailySupplySideRevenue.add(trxToken, sun, 'Energy Rental Fee');
+    }
+    fingerprint = res.meta?.fingerprint;
+    if (!fingerprint) break;
+    await delay(2500);
+  }
+};
+
 
 const adapter: Adapter = {
   adapter: {
@@ -171,15 +214,16 @@ const adapter: Adapter = {
     },
   },
   methodology: {
-    Fees: "Total interest paid by borrowers across all lending markets",
+    Fees: "Total interest paid by borrowers across all lending markets, plus usage fees paid by renters on the Energy Rental Market",
     Revenue: "Protocol's share of interest based on each market's reserve factor",
     ProtocolRevenue: "Protocol's share of interest based on each market's reserve factor",
     HoldersRevenue: "No revenue distributed to JST holders",
-    SupplySideRevenue: "Interest paid to lenders in liquidity pools (total interest minus protocol reserve)",
+    SupplySideRevenue: "Interest paid to lenders in liquidity pools plus Energy Rental usage fees paid to sTRX stakers",
   },
   breakdownMethodology: {
     Fees: {
       'Borrow Interest': 'Interest accrued from borrowers across all lending markets, calculated from AccrueInterest events',
+      'Energy Rental Fee': 'Usage fees paid by renters on the JustLend Energy Rental Market, from the usageRental field of ReturnResource events',
     },
     Revenue: {
       'Protocol Reserve Share': 'Portion of borrow interest kept by the protocol based on each market\'s reserve factor',
@@ -189,6 +233,7 @@ const adapter: Adapter = {
     },
     SupplySideRevenue: {
       'Borrow Interest': 'Borrow interest distributed to lenders (total interest minus protocol reserve share)',
+      'Energy Rental Fee': 'Energy Rental usage fees distributed to sTRX stakers who provide the delegated TRX',
     },
   }
 };


### PR DESCRIPTION
## Summary

`fees/justlend.ts` currently only tracks `AccrueInterest` events on 19 cToken lending markets and misses JustLend's separate **Energy Rental Market** ([`TU2MJ5Veik1LRAgjeSzEdvmDYx7mefJZvd`](https://tronscan.org/#/contract/TU2MJ5Veik1LRAgjeSzEdvmDYx7mefJZvd), tagged *"JustLend DAO: Energy Rental"* on TronScan). This PR adds it.

## Bug evidence

The rental contract emits a `ReturnResource` event on each close. The `usageRental` field is the fee actually charged to the renter (deducted from the security deposit). 24h scan of the contract for **2026-05-19 21:00 → 2026-05-20 21:00 UTC**:

- 868 `ReturnResource` events
- Σ `usageRental` = **201,553.94 TRX ≈ \$72,800** (TRX = \$0.36 / CoinGecko spot)

Production today reports \$16,849 for that window — the methodology field on the API confirms the existing adapter is *"Total interest paid by borrowers across all lending markets"*, i.e. lending only.

### On-chain proof that `usageRental` is retained, not refunded

Traced internal transfers of `ReturnResource` tx `aee8caa814651d87dd51b324d4687b14956300410cd19928b0a6336301b69998`:
- Renter posted 80 TRX security deposit at rent open
- On close: 12,000 TRX delegation returned to receiver, **75.025 TRX refunded to renter**, **4.972868 TRX retained by the rental contract**
- 4.972868 == `usageRental` from the event — confirmed.

## Local test (after the fix)

The adapter adds raw `usageRental` lamports to the Balances object; the framework converts to USD at run-time via CoinGecko historical prices.

| Date | Production fee chart | Local test result | Δ (energy rental) |
|---|---|---|---|
| 2026-05-18 | \$16,603 | \$119,370 | \$102,767 |
| 2026-05-20 | \$16,849 | \$88,530 | \$71,681 |

Income statement invariant holds: `dailyFees = dailyRevenue + dailySupplySideRevenue` (both days).

## Methodology choice

Energy rental fees are added to:
- `dailyFees` (unambiguous — fee paid by user, retained by protocol)
- `dailySupplySideRevenue` (per JustLend docs, *"energy rental rewards are distributed to stakers according to the amount and percentage of TRX they have staked"*)

**No protocol cut is claimed from this stream** because the LP/treasury split is not publicly documented for the energy rental product. If the team has internal numbers, the reserve factor for this stream can be tightened in a follow-up — the conservative default here avoids overclaiming `dailyRevenue`.

## Test plan

- [x] `pnpm run ts-check` clean
- [x] `pnpm run test fees justlend 2026-05-19` — returns non-zero fee value, supply-side matches `dailyFees - dailyRevenue`
- [x] `pnpm run test fees justlend 2026-05-21` — same shape, different magnitude (energy rental volume varies day-to-day)
- [x] Verified `usageRental` semantics by tracing internal transfers in a real `ReturnResource` tx
- [x] Confirmed no closed/open PRs target the energy rental contract

Allow edits by maintainers: ON.