### PR TITLE
fix(ekubo-evm): migrate endpoint and support historical date queries

### DIFF
--- a/dexs/ekubo-evm.ts
+++ b/dexs/ekubo-evm.ts
@@ -1,7 +1,7 @@
 import { FetchOptions, SimpleAdapter } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
 import { nullAddress } from "../helpers/token";
-import { httpGet } from "../utils/fetchURL";
+import fetchURL from "../utils/fetchURL";
 
 const BASE = 'https://prod-api.ekubo.org/overview';
 const CHAIN_ID = 1; // Ethereum mainnet
@@ -18,23 +18,29 @@ async function fetch(_ts: number, _blocks: any, options: FetchOptions) {
   const dailyFees = options.createBalances();
   const dailyRevenue = options.createBalances();
 
-  const dateStr = new Date(options.startOfDay * 1000).toISOString().split('T')[0];
+  const dateStr = options.dateString;
 
-  const volumeData: any[] = (await httpGet(`${BASE}/volume?chainId=${CHAIN_ID}`)).volumeByTokenByDate ?? [];
-  const revenueData: any[] = (await httpGet(`${BASE}/revenue?chainId=${CHAIN_ID}`)).revenueByTokenByDate ?? [];
+  const volumeData: any[] = (await fetchURL(`${BASE}/volume?chainId=${CHAIN_ID}`)).volumeByTokenByDate;
+  const revenueData: any[] = (await fetchURL(`${BASE}/revenue?chainId=${CHAIN_ID}`)).revenueByTokenByDate;
 
-  for (const t of volumeData.filter((e: any) => e.date.split('T')[0] === dateStr)) {
+  const todaysVolumeData = volumeData.filter((e: any) => e.date.split('T')[0] === dateStr);
+  const todaysRevenueData = revenueData.filter((e: any) => e.date.split('T')[0] === dateStr);
+
+  if(!todaysVolumeData || !todaysRevenueData) {
+    throw new Error(`No data found for date ${dateStr}`);
+  }
+
+  for (const t of todaysVolumeData) {
     const token = toEvmAddress(t.token);
     dailyVolume.add(token, t.volume);
     dailyFees.add(token, t.fees);
   }
 
-  for (const t of revenueData.filter((e: any) => e.date.split('T')[0] === dateStr)) {
+  for (const t of todaysRevenueData) {
     const token = toEvmAddress(t.token);
     dailyFees.add(token, t.revenue);
     dailyRevenue.add(token, t.revenue);
   }
-
   const dailySupplySideRevenue = dailyFees.clone();
   dailySupplySideRevenue.subtract(dailyRevenue);
 

--- a/dexs/ekubo-evm.ts
+++ b/dexs/ekubo-evm.ts
@@ -3,31 +3,65 @@ import { CHAIN } from "../helpers/chains";
 import { nullAddress } from "../helpers/token";
 import { httpGet } from "../utils/fetchURL";
 
-const adapters: SimpleAdapter = {
-  adapter: {
-    [CHAIN.ETHEREUM]: { fetch, runAtCurrTime: true },
-  },
-  version: 2,
-};
-export default adapters;
+const BASE = 'https://prod-api.ekubo.org/overview';
+const CHAIN_ID = 1; // Ethereum mainnet
 
-const routes: any = {
-  [CHAIN.ETHEREUM]: 'https://eth-mainnet-api.ekubo.org/overview/volume',
+function toEvmAddress(raw: string): string {
+  const s = (raw ?? '').toLowerCase();
+  return !s || s === '0x0' || s === '0x0000000000000000000000000000000000000000'
+    ? nullAddress
+    : s;
 }
 
-async function fetch(options: FetchOptions) {
-  const { chain } = options;
-  const dailyFees = options.createBalances();
+async function fetch(_ts: number, _blocks: any, options: FetchOptions) {
   const dailyVolume = options.createBalances();
-  const { volumeByToken_24h } = await httpGet(routes[chain]);
-  volumeByToken_24h.map((t: any) => {
-    let token = BigInt(t.token).toString(16);
-    if (t.token === '0') token = nullAddress
-    else token = '0x' + token
-    dailyFees.add(token, t.fees);
+  const dailyFees = options.createBalances();
+  const dailyRevenue = options.createBalances();
+
+  const dateStr = new Date(options.startOfDay * 1000).toISOString().split('T')[0];
+
+  const volumeData: any[] = (await httpGet(`${BASE}/volume?chainId=${CHAIN_ID}`)).volumeByTokenByDate ?? [];
+  const revenueData: any[] = (await httpGet(`${BASE}/revenue?chainId=${CHAIN_ID}`)).revenueByTokenByDate ?? [];
+
+  for (const t of volumeData.filter((e: any) => e.date.split('T')[0] === dateStr)) {
+    const token = toEvmAddress(t.token);
     dailyVolume.add(token, t.volume);
-  })
+    dailyFees.add(token, t.fees);
+  }
 
-  return { dailyFees, dailyVolume };
+  for (const t of revenueData.filter((e: any) => e.date.split('T')[0] === dateStr)) {
+    const token = toEvmAddress(t.token);
+    dailyFees.add(token, t.revenue);
+    dailyRevenue.add(token, t.revenue);
+  }
 
+  const dailySupplySideRevenue = dailyFees.clone();
+  dailySupplySideRevenue.subtract(dailyRevenue);
+
+  return {
+    dailyVolume,
+    dailyFees,
+    dailyRevenue,
+    dailyProtocolRevenue: dailyRevenue,
+    dailySupplySideRevenue,
+  };
 }
+
+const adapter: SimpleAdapter = {
+  version: 1,
+  adapter: {
+    [CHAIN.ETHEREUM]: {
+      fetch,
+      start: '2025-01-31',
+    },
+  },
+  methodology: {
+    Volume: 'Per-token daily swap volume.',
+    Fees: 'Total swap fees paid by traders plus protocol-owned LP position earnings.',
+    Revenue: 'Fees earned by protocol-owned LP positions (DAO-controlled).',
+    SupplySideRevenue: 'Swap fees distributed to non-protocol liquidity providers.',
+    ProtocolRevenue: 'Fees earned by protocol-owned LP positions (DAO-controlled).',
+  },
+};
+
+export default adapter;


### PR DESCRIPTION
- Migrates from the deprecated eth-mainnet-api.ekubo.org endpoint  to prod-api.ekubo.org/overview/volume
- Switches from volumeByToken_24h (always-current snapshot) to volumeByTokenByDate filtered by options.dateString, enabling proper historical backfill
- Adds methodology fields