### PR TITLE
[fix] EasyA Kickstart - add DBC config and volume tracking

### DIFF
--- a/fees/easya-kickstart/index.ts
+++ b/fees/easya-kickstart/index.ts
@@ -14,6 +14,7 @@ const EASYA_PARTNER_CONFIGS = [
     'FctVFHQvVaj3hTDHCSXZjTmmsRs5bX5ogUPGHFSgrJpU',
     'NHT6MNushFNWpaFgQs5k49HHzsas9jQAVoRvqyXc5Qx',
     '6iEekXhre85eDB1mxRuXbRDHbSG8HeSPYopp9e7fp4BJ',
+    '5WP4ZKstxzM6vUxE4xCahuXowaJeEXgLUhCXCKm7yqRy',
 ];
 
 interface IData {

--- a/fees/easya-kickstart/index.ts
+++ b/fees/easya-kickstart/index.ts
@@ -18,7 +18,6 @@ const EASYA_PARTNER_CONFIGS = [
 ];
 
 interface IData {
-    total_volume: string;
     total_trading_fees: string;
     total_protocol_fees: string;
     total_referral_fees: string;
@@ -52,7 +51,6 @@ const fetch = async (_a: any, _b: any, options: FetchOptions) => {
           AND s.evt_block_time <  from_unixtime(${options.endTimestamp})
       )
     SELECT
-      SUM(CASE WHEN trade_direction = 1 THEN COALESCE(amount_in, 0) ELSE COALESCE(amount_out, 0) END) AS total_volume,
       SUM(CASE WHEN collect_fee_mode = 1 AND trade_direction = 1 THEN 0 ELSE COALESCE(trading_fee,  0) END) AS total_trading_fees,
       SUM(CASE WHEN collect_fee_mode = 1 AND trade_direction = 1 THEN 0 ELSE COALESCE(protocol_fee, 0) END) AS total_protocol_fees,
       SUM(CASE WHEN collect_fee_mode = 1 AND trade_direction = 1 THEN 0 ELSE COALESCE(referral_fee, 0) END) AS total_referral_fees
@@ -60,19 +58,16 @@ const fetch = async (_a: any, _b: any, options: FetchOptions) => {
   `);
 
     const wsol = ADDRESSES.solana.SOL;
-    const dailyVolume = options.createBalances();
     const dailyFees = options.createBalances();
     const dailyProtocolRevenue = options.createBalances();
     const dailySupplySideRevenue = options.createBalances();
 
     const row = data?.[0];
     if (row) {
-        const volume = Number(row.total_volume || 0);
         const trading = Number(row.total_trading_fees || 0);
         const protocol = Number(row.total_protocol_fees || 0);
         const referral = Number(row.total_referral_fees || 0);
 
-        dailyVolume.add(wsol, volume);
         dailyFees.add(wsol, trading, METRIC.TRADING_FEES);
         dailyFees.add(wsol, protocol, "Protocol Fees to Meteora");
         dailyFees.add(wsol, referral, "Referral Fees");
@@ -89,7 +84,6 @@ const fetch = async (_a: any, _b: any, options: FetchOptions) => {
     }
 
     return {
-        dailyVolume,
         dailyFees,
         dailyUserFees: dailyFees,
         dailyRevenue: dailyProtocolRevenue,
@@ -99,8 +93,6 @@ const fetch = async (_a: any, _b: any, options: FetchOptions) => {
 };
 
 const methodology = {
-    Volume:
-        'Total swap volume on EasyA Kickstart bonding curves, measured in WSOL quote asset.',
     Fees:
         'Total swap fees paid by users on EasyA Kickstart bonding curves: trading_fee + protocol_fee + referral_fee from Meteora DBC swap events.',
     Revenue:

--- a/fees/easya-kickstart/index.ts
+++ b/fees/easya-kickstart/index.ts
@@ -6,9 +6,9 @@ import { METRIC } from "../../helpers/metrics";
 
 // EasyA Kickstart is a Solana memecoin launchpad built on top of Meteora's
 // Dynamic Bonding Curve (DBC) program. Every token launched via Kickstart is
-// a DBC VirtualPool whose `config` field points at one of EasyA's three
+// a DBC VirtualPool whose `config` field points at one of EasyA's four
 // PoolConfig accounts (all share the same fee_claimer EfgbywXHbDn...).
-// All three configs use WSOL as the quote asset.
+// All four configs use WSOL as the quote asset.
 const DBC_PROGRAM = 'dbcij3LWUppWqq96dh6gJWwBifmcGfLSB5D4DuSMaqN';
 const EASYA_PARTNER_CONFIGS = [
     'FctVFHQvVaj3hTDHCSXZjTmmsRs5bX5ogUPGHFSgrJpU',
@@ -60,16 +60,19 @@ const fetch = async (_a: any, _b: any, options: FetchOptions) => {
   `);
 
     const wsol = ADDRESSES.solana.SOL;
+    const dailyVolume = options.createBalances();
     const dailyFees = options.createBalances();
     const dailyProtocolRevenue = options.createBalances();
     const dailySupplySideRevenue = options.createBalances();
 
     const row = data?.[0];
     if (row) {
+        const volume = Number(row.total_volume || 0);
         const trading = Number(row.total_trading_fees || 0);
         const protocol = Number(row.total_protocol_fees || 0);
         const referral = Number(row.total_referral_fees || 0);
 
+        dailyVolume.add(wsol, volume);
         dailyFees.add(wsol, trading, METRIC.TRADING_FEES);
         dailyFees.add(wsol, protocol, "Protocol Fees to Meteora");
         dailyFees.add(wsol, referral, "Referral Fees");
@@ -86,6 +89,7 @@ const fetch = async (_a: any, _b: any, options: FetchOptions) => {
     }
 
     return {
+        dailyVolume,
         dailyFees,
         dailyUserFees: dailyFees,
         dailyRevenue: dailyProtocolRevenue,
@@ -95,6 +99,8 @@ const fetch = async (_a: any, _b: any, options: FetchOptions) => {
 };
 
 const methodology = {
+    Volume:
+        'Total swap volume on EasyA Kickstart bonding curves, measured in WSOL quote asset.',
     Fees:
         'Total swap fees paid by users on EasyA Kickstart bonding curves: trading_fee + protocol_fee + referral_fee from Meteora DBC swap events.',
     Revenue:
@@ -112,10 +118,10 @@ const breakdownMethodology = {
         "Referral Fees": "DBC Referral Fees going to referrers",
     },
     Revenue: {
-        [METRIC.TRADING_FEES]: "DBC Trading Fees going to EasyA",
+        "Trading Fees to EasyA": "DBC Trading Fees going to EasyA",
     },
     ProtocolRevenue: {
-        [METRIC.TRADING_FEES]: "DBC Trading Fees going to EasyA",
+        "Trading Fees to EasyA": "DBC Trading Fees going to EasyA",
     },
     SupplySideRevenue: {
         "Protocol Fees to Meteora": "DBC Protocol Fees going to Meteora",


### PR DESCRIPTION
## Summary
- Add the latest EasyA Kickstart Meteora DBC config to the tracked config list.
- Return `dailyVolume` using the adapter's existing WSOL-denominated swap volume query.
- Align revenue/protocol revenue breakdown labels with the balances returned by the adapter.

## Test plan
- Checked IDE lints for `fees/easya-kickstart/index.ts`.