### PR TITLE
Add new DEX Volume adapter for Showdown

### DIFF
--- a/dexs/showdown/index.ts
+++ b/dexs/showdown/index.ts
@@ -1,66 +1,56 @@
 import { FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
+import ADDRESSES from "../../helpers/coreAssets.json"
 
 const SHOWDOWN_CONTRACTS = {
-  MONEYGAMES: { address: "0x7B8DF4195eda5b193304eeCB5107DE18b6557D24", fromBlock: 6238852, },
-  TOURNAMENTS: { address: "0x130A8Da14C998C0fC23c5F5aDa64a318dFD6A805", fromBlock: 11578822, },
+    MONEYGAMES: "0x7B8DF4195eda5b193304eeCB5107DE18b6557D24",
+    TOURNAMENTS: "0x130A8Da14C998C0fC23c5F5aDa64a318dFD6A805",
 };
 
-const USDM = "0xFAfDdbb3FC7688494971a79cc65DCa3EF82079E7";
-const LOG_CHUNK_SIZE = 100_000;
+const USDM = ADDRESSES.megaeth.USDm;
 
 const MATCHFUNDED_EVENT_ABI = "event MatchFunded(bytes16 indexed matchId, address indexed player1, address indexed player2, uint128 amount)";
 const REGISTERED_EVENT_ABI = "event Registered(bytes16 indexed tournamentId, address indexed wallet, uint256 amount)";
 const UNREGISTERED_EVENT_ABI = "event Unregistered(bytes16 indexed tournamentId, address indexed wallet, uint256 amount)";
 
 const fetch = async (options: FetchOptions) => {
-  const dailyVolume = options.createBalances();
-  const fromBlockWindow = await options.getFromBlock();
-  const toBlock = await options.getToBlock();
-  const showdownStartBlock = Math.min(SHOWDOWN_CONTRACTS.MONEYGAMES.fromBlock, SHOWDOWN_CONTRACTS.TOURNAMENTS.fromBlock);
-  const effectiveFromBlock = Math.max(showdownStartBlock, fromBlockWindow);
-  if (toBlock - effectiveFromBlock > LOG_CHUNK_SIZE) {
-    throw new Error(`Showdown DEX fetch window too large: ${toBlock - effectiveFromBlock} blocks (max ${LOG_CHUNK_SIZE})`);
-  }
+    const dailyVolume = options.createBalances();
 
-  const matchFundedLogs = await options.getLogs({
-    target: SHOWDOWN_CONTRACTS.MONEYGAMES.address,
-    eventAbi: MATCHFUNDED_EVENT_ABI,
-    fromBlock: Math.max(SHOWDOWN_CONTRACTS.MONEYGAMES.fromBlock, fromBlockWindow),
-    toBlock,
-  });
-  const registeredLogs = await options.getLogs({
-    target: SHOWDOWN_CONTRACTS.TOURNAMENTS.address,
-    eventAbi: REGISTERED_EVENT_ABI,
-    fromBlock: Math.max(SHOWDOWN_CONTRACTS.TOURNAMENTS.fromBlock, fromBlockWindow),
-    toBlock,
-  });
-  const unregisteredLogs = await options.getLogs({
-    target: SHOWDOWN_CONTRACTS.TOURNAMENTS.address,
-    eventAbi: UNREGISTERED_EVENT_ABI,
-    fromBlock: Math.max(SHOWDOWN_CONTRACTS.TOURNAMENTS.fromBlock, fromBlockWindow),
-    toBlock,
-  });
+    const matchFundedLogs = await options.getLogs({
+        target: SHOWDOWN_CONTRACTS.MONEYGAMES,
+        eventAbi: MATCHFUNDED_EVENT_ABI,
+    });
 
-  matchFundedLogs.forEach((log: any) => {
-    // MatchFunded amount applies to both players in the match.
-    dailyVolume.add(USDM, BigInt(log.amount) * 2n);
-  });
-  registeredLogs.forEach((log: any) => dailyVolume.add(USDM, log.amount));
-  unregisteredLogs.forEach((log: any) => dailyVolume.add(USDM, -log.amount));
+    const registeredLogs = await options.getLogs({
+        target: SHOWDOWN_CONTRACTS.TOURNAMENTS,
+        eventAbi: REGISTERED_EVENT_ABI,
+    });
 
-  return { dailyVolume };
+    const unregisteredLogs = await options.getLogs({
+        target: SHOWDOWN_CONTRACTS.TOURNAMENTS,
+        eventAbi: UNREGISTERED_EVENT_ABI,
+    });
+
+    matchFundedLogs.forEach((log: any) => {
+        // MatchFunded amount applies to both players in the match.
+        dailyVolume.add(USDM, BigInt(log.amount) * 2n);
+    });
+
+    registeredLogs.forEach((log: any) => dailyVolume.add(USDM, log.amount));
+    unregisteredLogs.forEach((log: any) => dailyVolume.add(USDM, -log.amount));
+
+    return { dailyVolume };
 };
 
 const adapter: SimpleAdapter = {
-  version: 2,
-  pullHourly: false,
-  chains: [CHAIN.MEGAETH],
-  start: "2026-02-03",
-  methodology: {
-    Volume: "Includes all Showdown money game deposits and net tournament registrations.",
-  },
-  fetch,
+    version: 2,
+    fetch,
+    pullHourly: true,
+    chains: [CHAIN.MEGAETH],
+    start: "2026-02-03",
+    methodology: {
+        Volume: "Includes all Showdown money game deposits and net tournament registrations.",
+    },
 };
 
 export default adapter;

--- a/dexs/showdown/index.ts
+++ b/dexs/showdown/index.ts
@@ -1,0 +1,66 @@
+import { FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+
+const SHOWDOWN_CONTRACTS = {
+  MONEYGAMES: { address: "0x7B8DF4195eda5b193304eeCB5107DE18b6557D24", fromBlock: 6238852, },
+  TOURNAMENTS: { address: "0x130A8Da14C998C0fC23c5F5aDa64a318dFD6A805", fromBlock: 11578822, },
+};
+
+const USDM = "0xFAfDdbb3FC7688494971a79cc65DCa3EF82079E7";
+const LOG_CHUNK_SIZE = 100_000;
+
+const MATCHFUNDED_EVENT_ABI = "event MatchFunded(bytes16 indexed matchId, address indexed player1, address indexed player2, uint128 amount)";
+const REGISTERED_EVENT_ABI = "event Registered(bytes16 indexed tournamentId, address indexed wallet, uint256 amount)";
+const UNREGISTERED_EVENT_ABI = "event Unregistered(bytes16 indexed tournamentId, address indexed wallet, uint256 amount)";
+
+const fetch = async (options: FetchOptions) => {
+  const dailyVolume = options.createBalances();
+  const fromBlockWindow = await options.getFromBlock();
+  const toBlock = await options.getToBlock();
+  const showdownStartBlock = Math.min(SHOWDOWN_CONTRACTS.MONEYGAMES.fromBlock, SHOWDOWN_CONTRACTS.TOURNAMENTS.fromBlock);
+  const effectiveFromBlock = Math.max(showdownStartBlock, fromBlockWindow);
+  if (toBlock - effectiveFromBlock > LOG_CHUNK_SIZE) {
+    throw new Error(`Showdown DEX fetch window too large: ${toBlock - effectiveFromBlock} blocks (max ${LOG_CHUNK_SIZE})`);
+  }
+
+  const matchFundedLogs = await options.getLogs({
+    target: SHOWDOWN_CONTRACTS.MONEYGAMES.address,
+    eventAbi: MATCHFUNDED_EVENT_ABI,
+    fromBlock: Math.max(SHOWDOWN_CONTRACTS.MONEYGAMES.fromBlock, fromBlockWindow),
+    toBlock,
+  });
+  const registeredLogs = await options.getLogs({
+    target: SHOWDOWN_CONTRACTS.TOURNAMENTS.address,
+    eventAbi: REGISTERED_EVENT_ABI,
+    fromBlock: Math.max(SHOWDOWN_CONTRACTS.TOURNAMENTS.fromBlock, fromBlockWindow),
+    toBlock,
+  });
+  const unregisteredLogs = await options.getLogs({
+    target: SHOWDOWN_CONTRACTS.TOURNAMENTS.address,
+    eventAbi: UNREGISTERED_EVENT_ABI,
+    fromBlock: Math.max(SHOWDOWN_CONTRACTS.TOURNAMENTS.fromBlock, fromBlockWindow),
+    toBlock,
+  });
+
+  matchFundedLogs.forEach((log: any) => {
+    // MatchFunded amount applies to both players in the match.
+    dailyVolume.add(USDM, BigInt(log.amount) * 2n);
+  });
+  registeredLogs.forEach((log: any) => dailyVolume.add(USDM, log.amount));
+  unregisteredLogs.forEach((log: any) => dailyVolume.add(USDM, -log.amount));
+
+  return { dailyVolume };
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  pullHourly: false,
+  chains: [CHAIN.MEGAETH],
+  start: "2026-02-03",
+  methodology: {
+    Volume: "Includes all Showdown money game deposits and net tournament registrations.",
+  },
+  fetch,
+};
+
+export default adapter;


### PR DESCRIPTION
Add new DEX Volume adapter for Showdown


##### Name (to be shown on DefiLlama): Showdown

##### Twitter Link: https://x.com/Showdown_TCG

##### List of audit links if any: N/A

##### Website Link: https://www.showdown.game/

##### Logo (High resolution, will be shown with rounded borders): https://avatars.githubusercontent.com/u/286766370

##### Treasury Addresses (if the protocol has treasury): N/A

##### Chain: MegaETH

##### Coingecko ID: N/A

##### Coinmarketcap ID: N/A

##### Short Description (to be shown on DefiLlama): Showdown is a Web3 competitive card game on MegaETH that reinvents poker with strategic deckbuilding and real-stakes gameplay, letting players compete in money games and tournaments using USDm.

##### Token address and ticker if any: N/A

##### Category: Gaming

##### Methodology: Includes all Showdown money game deposits and net tournament registrations.




Test results:

npm test -- dexs showdown 2026-05-21

> adapters@1.0.0 test
> ts-node --transpile-only cli/testAdapter.ts dexs showdown 2026-05-21

🦙 Running SHOWDOWN adapter 🦙
---------------------------------------------------
Start Date:     Wed, 20 May 2026 00:00:00 GMT
End Date:       Thu, 21 May 2026 00:00:00 GMT
---------------------------------------------------

MEGAETH 👇
Backfill start time: 3/2/2026
Daily volume: 4.89 k
End timestamp: 1779321599 (2026-05-20T23:59:59.000Z)


npm test -- dexs showdown 2026-05-20

> adapters@1.0.0 test
> ts-node --transpile-only cli/testAdapter.ts dexs showdown 2026-05-20

🦙 Running SHOWDOWN adapter 🦙
---------------------------------------------------
Start Date:     Tue, 19 May 2026 00:00:00 GMT
End Date:       Wed, 20 May 2026 00:00:00 GMT
---------------------------------------------------

MEGAETH 👇
Backfill start time: 3/2/2026
Daily volume: 11.30 k
End timestamp: 1779235199 (2026-05-19T23:59:59.000Z)


npm test -- dexs showdown 2026-05-19

> adapters@1.0.0 test
> ts-node --transpile-only cli/testAdapter.ts dexs showdown 2026-05-19

🦙 Running SHOWDOWN adapter 🦙
---------------------------------------------------
Start Date:     Mon, 18 May 2026 00:00:00 GMT
End Date:       Tue, 19 May 2026 00:00:00 GMT
---------------------------------------------------

MEGAETH 👇
Backfill start time: 3/2/2026
Daily volume: 4.49 k
End timestamp: 1779148799 (2026-05-18T23:59:59.000Z)
