### PR TITLE
feat(aave-v3): add X Layer market to fees adapter

### DIFF
--- a/fees/aave-v3.ts
+++ b/fees/aave-v3.ts
@@ -178,6 +178,13 @@ const AaveMarkets: {[key: string]: Array<AaveLendingPoolConfig>} = {
       dataProvider: '0x487c5c669D9eee6057C44973207101276cf73b68',
     },
   ],
+  [CHAIN.XLAYER]: [
+    {
+      version: 3,
+      lendingPoolProxy: '0xE3F3Caefdd7180F884c01E57f65Df979Af84f116',
+      dataProvider: '0x6C505C31714f14e8af2A03633EB2Cdfb4959138F',
+    },
+  ],
 }
 
 const methodology = {
@@ -317,6 +324,10 @@ const chainConfig: Record<string, any> = {
   [CHAIN.MANTLE]: {
     pools: AaveMarkets[CHAIN.MANTLE],
     start: '2026-01-16',
+  },
+  [CHAIN.XLAYER]: {
+    pools: AaveMarkets[CHAIN.XLAYER],
+    start: '2024-10-01',
   },
 }
 

--- a/fees/aave-v3.ts
+++ b/fees/aave-v3.ts
@@ -327,7 +327,7 @@ const chainConfig: Record<string, any> = {
   },
   [CHAIN.XLAYER]: {
     pools: AaveMarkets[CHAIN.XLAYER],
-    start: '2024-10-01',
+    start: '2026-03-30',
   },
 }
 


### PR DESCRIPTION
## Summary

- Adds Aave V3 X Layer market to `fees/aave-v3.ts`
- X Layer is OKX's EVM-compatible chain with ~$65M Aave V3 TVL
- Contract addresses sourced from [bgd-labs/aave-address-book](https://github.com/bgd-labs/aave-address-book/blob/main/src/AaveV3XLayer.sol)

## Changes

| Field | Value |
|---|---|
| Chain | `CHAIN.XLAYER` (`xlayer`) |
| Pool proxy | `0xE3F3Caefdd7180F884c01E57f65Df979Af84f116` |
| ProtocolDataProvider | `0x6C505C31714f14e8af2A03633EB2Cdfb4959138F` |
| Start date | `2024-10-01` |

## Verification

- Aave V3 TVL adapter already tracks X Layer (see `projects/aave-v3/index.js` — `xlayer: ['0x6C505C31714f14e8af2A03633EB2Cdfb4959138F']`)
- `CHAIN.XLAYER = "xlayer"` is defined in `helpers/chains.ts`
- No existing fees coverage for this market

🤖 Generated with [Claude Code](https://claude.com/claude-code)