### PR TITLE
[fix] Reya: migrate reya oi from api to onchain functions

### DIFF
--- a/open-interest/reya-dex-oi.ts
+++ b/open-interest/reya-dex-oi.ts
@@ -7,50 +7,58 @@ const PASSIVE_PERP_PROXY = "0x27E5cb712334e101B3c232eB0Be198baaa595F5F";
 const MARKET_DEFINITIONS_ENDPOINT = "https://api.reya.xyz/v2/marketDefinitions";
 const WAD = 1e18;
 
+type MarketDefinition = {
+  marketId: number;
+};
+
 const abis = {
   // Source: Reya docs + Reya-Labs/reya-deployments IPassivePerpProxy.
-  getOpenBaseInterest: "function getOpenBaseInterest(uint128 marketId) view returns (uint256)",
-  getLatestMTMData: "function getLatestMTMData(uint128 marketId) view returns (tuple(uint256 price, uint256 timestamp))",
+  getMarketData: "function getMarketData(uint128 marketId) view returns (tuple(tuple(uint128 id, uint128 passivePoolId, uint128 poolAccountId, address quoteToken, uint8 quoteTokenDecimals, int256 lastFundingVelocity, int256 lastFundingRate, uint256 lastFundingTimestamp, tuple(uint256 price, uint256 timestamp) lastMTM, tuple(int256 fundingValue, uint256 baseMultiplier, uint256 adlUnwindPrice) longTrackers, tuple(int256 fundingValue, uint256 baseMultiplier, uint256 adlUnwindPrice) shortTrackers, uint256 openInterest, int256 logPriceMultiplier, uint256 depthFactor, uint256 priceSpread, uint256 velocityMultiplier) marketData, uint256 blockTimestamp, uint256 blockNumber))",
+  getInstantaneousPoolPrice: "function getInstantaneousPoolPrice(uint128 marketId) view returns (uint256)",
 };
 
 const fetch = async (options: FetchOptions) => {
-  const calls = (await fetchURL(MARKET_DEFINITIONS_ENDPOINT)).map(({ marketId }: any) => ({ params: [marketId] }));
+  const markets: MarketDefinition[] = await fetchURL(MARKET_DEFINITIONS_ENDPOINT);
+  const calls = markets.map(({ marketId }) => ({ params: [marketId] }));
 
-  const [openInterests, prices] = await Promise.all([
+  const [marketData, poolPrices] = await Promise.all([
     options.toApi.multiCall({
       target: PASSIVE_PERP_PROXY,
-      abi: abis.getOpenBaseInterest,
+      abi: abis.getMarketData,
       calls,
       permitFailure: true,
     }),
     options.toApi.multiCall({
       target: PASSIVE_PERP_PROXY,
-      abi: abis.getLatestMTMData,
+      abi: abis.getInstantaneousPoolPrice,
       calls,
       permitFailure: true,
     }),
   ]);
 
-  const openInterestAtEnd = openInterests.reduce((sum: number, oi: any, i: number) => {
-    const price = prices[i]?.price;
-    if (oi == null || price == null) return sum;
-    return sum + (Number(oi) / WAD) * (Number(price) / WAD);
+  const oneSidedOpenInterest = marketData.reduce((sum: number, market: any, i: number) => {
+    if (!market || poolPrices[i] == null) return sum;
+    // Reya team confirmed marketData.openInterest is one-sided long OI.
+    const oi = Number(market.marketData.openInterest) / WAD;
+    const price = Number(poolPrices[i]) / WAD;
+    return sum + oi * price;
   }, 0);
 
-  return { openInterestAtEnd };
+  const longOpenInterestAtEnd = oneSidedOpenInterest;
+  const shortOpenInterestAtEnd = oneSidedOpenInterest;
+
+  return {
+    openInterestAtEnd: longOpenInterestAtEnd + shortOpenInterestAtEnd,
+    longOpenInterestAtEnd,
+    shortOpenInterestAtEnd,
+  };
 };
 
 const adapter: SimpleAdapter = {
   version: 2,
-  methodology: {
-    openInterestAtEnd: "Active market IDs are discovered from Reya's official market definitions API. Open interest is fetched onchain from getOpenBaseInterest and valued with getLatestMTMData mark prices.",
-  },
-  adapter: {
-    [CHAIN.REYA]: {
-      fetch,
-      start: "2024-08-11",
-    },
-  },
+  chains: [CHAIN.REYA],
+  fetch,
+  start: "2026-03-11", // Latest proxy implementation deployment, return 0 data befor this date
 };
 
 export default adapter;

--- a/open-interest/reya-dex-oi.ts
+++ b/open-interest/reya-dex-oi.ts
@@ -1,37 +1,56 @@
-import fetchURL from "../utils/fetchURL"
-import { SimpleAdapter } from "../adapters/types";
+import fetchURL from "../utils/fetchURL";
+import { FetchOptions, SimpleAdapter } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
 
-const marketsEndpoint = "https://api.reya.xyz/api/markets"
+// Source: Reya-Labs/reya-deployments packages/tomls/src/omnibus/reya_network.toml.
+const PASSIVE_PERP_PROXY = "0x27E5cb712334e101B3c232eB0Be198baaa595F5F";
+const MARKET_DEFINITIONS_ENDPOINT = "https://api.reya.xyz/v2/marketDefinitions";
+const WAD = 1e18;
 
-const fetch = async (_a: any) => {
-  const markets = (await fetchURL(marketsEndpoint))
+const abis = {
+  // Source: Reya docs + Reya-Labs/reya-deployments IPassivePerpProxy.
+  getOpenBaseInterest: "function getOpenBaseInterest(uint128 marketId) view returns (uint256)",
+  getLatestMTMData: "function getLatestMTMData(uint128 marketId) view returns (tuple(uint256 price, uint256 timestamp))",
+};
 
-  let longOpenInterestAtEnd = 0
-  let shortOpenInterestAtEnd = 0
+const fetch = async (options: FetchOptions) => {
+  const calls = (await fetchURL(MARKET_DEFINITIONS_ENDPOINT)).map(({ marketId }: any) => ({ params: [marketId] }));
 
-  for (const market of markets) {
-    if (market.isActive !== true) continue
-    longOpenInterestAtEnd += Number(market.longOI) * Number(market.markPrice)
-    shortOpenInterestAtEnd += Number(market.shortOI) * Number(market.markPrice)
-  }
+  const [openInterests, prices] = await Promise.all([
+    options.toApi.multiCall({
+      target: PASSIVE_PERP_PROXY,
+      abi: abis.getOpenBaseInterest,
+      calls,
+      permitFailure: true,
+    }),
+    options.toApi.multiCall({
+      target: PASSIVE_PERP_PROXY,
+      abi: abis.getLatestMTMData,
+      calls,
+      permitFailure: true,
+    }),
+  ]);
 
-  return { 
-    openInterestAtEnd: longOpenInterestAtEnd + shortOpenInterestAtEnd,
-    longOpenInterestAtEnd,
-    shortOpenInterestAtEnd
-  }
+  const openInterestAtEnd = openInterests.reduce((sum: number, oi: any, i: number) => {
+    const price = prices[i]?.price;
+    if (oi == null || price == null) return sum;
+    return sum + (Number(oi) / WAD) * (Number(price) / WAD);
+  }, 0);
+
+  return { openInterestAtEnd };
 };
 
 const adapter: SimpleAdapter = {
   version: 2,
+  methodology: {
+    openInterestAtEnd: "Active market IDs are discovered from Reya's official market definitions API. Open interest is fetched onchain from getOpenBaseInterest and valued with getLatestMTMData mark prices.",
+  },
   adapter: {
     [CHAIN.REYA]: {
       fetch,
-      runAtCurrTime: true,
-      start: "2024-03-20",
+      start: "2024-08-11",
     },
   },
 };
 
-export default adapter; 
+export default adapter;


### PR DESCRIPTION
## Summary
- Updates the Reya open interest adapter to fetch OI from onchain contract state instead of relying on the legacy markets API.
- Uses Reya's active market definitions API to discover current market IDs, then values each market's onchain OI with onchain MTM prices.
- Website: https://reya.network/
- Twitter/X: https://x.com/reya_xyz

## Changes
- Updated `open-interest/reya-dex-oi.ts` for Reya on `CHAIN.REYA`.
- Replaced the previous `https://api.reya.xyz/api/markets` OI calculation with onchain calls to `PassivePerpProxy`.
- Added `getOpenBaseInterest(marketId)` and `getLatestMTMData(marketId)` calls for active markets from `https://api.reya.xyz/v2/marketDefinitions`.
- Added a guard to skip markets that are returned by the current API but do not exist at the requested historical block.

## Methodology
- Market IDs are discovered from Reya's official market definitions API.
- Open interest is fetched onchain from Reya's `PassivePerpProxy` using `getOpenBaseInterest`.
- OI is valued in USD using the onchain MTM price returned by `getLatestMTMData`.
- Long/short OI is not reported because the public onchain interface exposes aggregate OI but not side-specific OI.

## Tests
- `pnpm test open-interest reya-dex-oi`
- `pnpm test open-interest reya-dex-oi 2025-01-15`