### PR TITLE
[feat] llamapay - add volume adapter

### DIFF
--- a/dexs/llamapay.ts
+++ b/dexs/llamapay.ts
@@ -1,0 +1,91 @@
+import * as sdk from "@defillama/sdk";
+import { FetchOptions, SimpleAdapter } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+
+// LlamaPay streams ERC-20s by the second. A factory per chain deploys one
+// streaming contract per token; recipients withdraw accrued funds whenever they
+// like. We treat the value WITHDRAWN by recipients as the protocol's payment
+// volume (the money actually settled to people), read on-chain from Withdraw
+// events. LlamaPay charges no protocol fee, so there is no fees/revenue to report.
+//
+// Withdraw(from, to, amountPerSec, streamId, amount): in LlamaPay.sol `amount` is
+// `amountToTransfer = (delta * amountPerSec) / DECIMALS_DIVISOR` (the exact token
+// amount transferred to the recipient in NATIVE token decimals), so it can be
+// summed directly via Balances.add(token, amount).
+
+// Original CREATE2 salary-streaming factory (same address across the early chains).
+const OLD_FACTORY = "0xde1C04855c2828431ba637675B6929A684f84C7F";
+// Second deterministic factory used on the newer chains (Base, Scroll, Sonic, ...).
+const NEW_FACTORY = "0x09c39B8311e4B7c678cBDAD76556877ecD3aEa07";
+
+const CONFIG: Record<string, { factory: string; start: string }> = {
+  [CHAIN.ETHEREUM]: { factory: OLD_FACTORY, start: "2022-06-01" },
+  [CHAIN.ARBITRUM]: { factory: OLD_FACTORY, start: "2022-06-01" },
+  [CHAIN.OPTIMISM]: { factory: OLD_FACTORY, start: "2022-06-01" },
+  [CHAIN.POLYGON]: { factory: OLD_FACTORY, start: "2022-06-01" },
+  [CHAIN.BSC]: { factory: OLD_FACTORY, start: "2022-06-01" },
+  [CHAIN.XDAI]: { factory: OLD_FACTORY, start: "2022-06-01" },
+  [CHAIN.AVAX]: { factory: "0x7d507b4c2d7e54da5731f643506996da8525f4a3", start: "2022-06-01" },
+  [CHAIN.BASE]: { factory: NEW_FACTORY, start: "2023-08-01" },
+  [CHAIN.SCROLL]: { factory: NEW_FACTORY, start: "2023-10-01" },
+  [CHAIN.SONIC]: { factory: NEW_FACTORY, start: "2024-12-01" },
+  [CHAIN.BERACHAIN]: { factory: NEW_FACTORY, start: "2025-02-01" },
+  [CHAIN.METIS]: { factory: "0x43634d1C608f16Fb0f4926c12b54124C93030600", start: "2022-06-01" },
+};
+
+const abi = {
+  count: "uint256:getLlamaPayContractCount",
+  byIndex: "function getLlamaPayContractByIndex(uint256) view returns (address)",
+  token: "address:token",
+  withdraw:
+    "event Withdraw(address indexed from, address indexed to, uint216 amountPerSec, bytes32 streamId, uint amount)",
+};
+
+const fetch = async (options: FetchOptions) => {
+  const dailyVolume = options.createBalances();
+
+  // Enumerate contracts + token mapping at the LATEST block, not the historical
+  // window block. Both are window-independent (the contract set only grows; each
+  // contract's token is immutable). Reading them at a past block needs archive
+  // state that public RPCs prune. Logs below stay window-bound; contracts created
+  // after the window simply have no logs in it.
+  const api = new sdk.ChainApi({ chain: options.chain });
+  const contracts: string[] = await api.fetchList({
+    lengthAbi: abi.count,
+    itemAbi: abi.byIndex,
+    target: CONFIG[options.chain].factory,
+  });
+  if (!contracts.length) return { dailyVolume };
+
+  // Each contract streams exactly one token; map contract -> token.
+  const tokens: string[] = await api.multiCall({ abi: abi.token, calls: contracts });
+  const tokenByContract: Record<string, string> = {};
+  contracts.forEach((c, i) => {
+    tokenByContract[c.toLowerCase()] = tokens[i];
+  });
+
+  // Withdraw events = value paid out to recipients in the window (native units).
+  // onlyArgs:false keeps the emitting contract address (each contract = one token)
+  // alongside the decoded args, so we can attribute each withdrawal to its token.
+  const logs = await options.getLogs({ targets: contracts, eventAbi: abi.withdraw, onlyArgs: false });
+  for (const log of logs) {
+    const token = tokenByContract[(log.address || log.source || "").toLowerCase()];
+    if (token) dailyVolume.add(token, log.args.amount);
+  }
+
+  return { dailyVolume };
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  pullHourly: true,
+  methodology: {
+    Volume:
+      "Total value withdrawn by stream recipients across all per-token LlamaPay contracts, summed on-chain from Withdraw events (contracts enumerated via the LlamaPay factory). Amounts are in native token decimals. LlamaPay charges no protocol fee, so no fees/revenue is reported.",
+  },
+  adapter: Object.fromEntries(
+    Object.entries(CONFIG).map(([chain, c]) => [chain, { fetch, start: c.start }]),
+  ),
+};
+
+export default adapter;

--- a/dexs/llamapay.ts
+++ b/dexs/llamapay.ts
@@ -1,4 +1,3 @@
-import * as sdk from "@defillama/sdk";
 import { FetchOptions, SimpleAdapter } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
 
@@ -43,39 +42,27 @@ const abi = {
 const fetch = async (options: FetchOptions) => {
   const dailyVolume = options.createBalances();
 
-  try {
-    // Enumerate contracts + token mapping at the LATEST block, not the historical
-    // window block. Both are window-independent (the contract set only grows; each
-    // contract's token is immutable). Reading them at a past block needs archive
-    // state that public RPCs prune. Logs below stay window-bound; contracts created
-    // after the window simply have no logs in it.
-    const api = new sdk.ChainApi({ chain: options.chain });
-    const contracts: string[] = await api.fetchList({
-      lengthAbi: abi.count,
-      itemAbi: abi.byIndex,
-      target: CONFIG[options.chain].factory,
-    });
-    if (!contracts.length) return { dailyVolume };
+  const contracts: string[] = await options.api.fetchList({
+    lengthAbi: abi.count,
+    itemAbi: abi.byIndex,
+    target: CONFIG[options.chain].factory,
+  });
+  if (!contracts.length) return { dailyVolume };
 
-    // Each contract streams exactly one token; map contract -> token.
-    const tokens: string[] = await api.multiCall({ abi: abi.token, calls: contracts });
-    const tokenByContract: Record<string, string> = {};
-    contracts.forEach((c, i) => {
-      tokenByContract[c.toLowerCase()] = tokens[i];
-    });
+  // Each contract streams exactly one token; map contract -> token.
+  const tokens: string[] = await options.api.multiCall({ abi: abi.token, calls: contracts });
+  const tokenByContract: Record<string, string> = {};
+  contracts.forEach((c, i) => {
+    tokenByContract[c.toLowerCase()] = tokens[i];
+  });
 
-    // Withdraw events = value paid out to recipients in the window (native units).
-    // onlyArgs:false keeps the emitting contract address (each contract = one token)
-    // alongside the decoded args, so we can attribute each withdrawal to its token.
-    const logs = await options.getLogs({ targets: contracts, eventAbi: abi.withdraw, onlyArgs: false });
-    for (const log of logs) {
-      const token = tokenByContract[(log.address || log.source || "").toLowerCase()];
-      if (token) dailyVolume.add(token, log.args.amount);
-    }
-  } catch (e) {
-    // Recoverable chain-specific RPC failure: log and return 0 for this chain so
-    // the rest of this multi-chain adapter still reports.
-    console.error(`[llamapay] ${options.chain} volume fetch failed, returning 0`, e);
+  // Withdraw events = value paid out to recipients in the window (native units).
+  // onlyArgs:false keeps the emitting contract address (each contract = one token)
+  // alongside the decoded args, so we can attribute each withdrawal to its token.
+  const logs = await options.getLogs({ targets: contracts, eventAbi: abi.withdraw, onlyArgs: false });
+  for (const log of logs) {
+    const token = tokenByContract[(log.address || log.source || "").toLowerCase()];
+    if (token) dailyVolume.add(token, log.args.amount);
   }
 
   return { dailyVolume };
@@ -88,9 +75,8 @@ const adapter: SimpleAdapter = {
     Volume:
       "Total value withdrawn by stream recipients across all per-token LlamaPay contracts, summed on-chain from Withdraw events (contracts enumerated via the LlamaPay factory). Amounts are in native token decimals. LlamaPay charges no protocol fee, so no fees/revenue is reported.",
   },
-  adapter: Object.fromEntries(
-    Object.entries(CONFIG).map(([chain, c]) => [chain, { fetch, start: c.start }]),
-  ),
+  adapter: CONFIG,
+  fetch,
 };
 
 export default adapter;

--- a/dexs/llamapay.ts
+++ b/dexs/llamapay.ts
@@ -23,7 +23,6 @@ const CONFIG: Record<string, { factory: string; start: string }> = {
   [CHAIN.ARBITRUM]: { factory: OLD_FACTORY, start: "2022-06-01" },
   [CHAIN.OPTIMISM]: { factory: OLD_FACTORY, start: "2022-06-01" },
   [CHAIN.POLYGON]: { factory: OLD_FACTORY, start: "2022-06-01" },
-  [CHAIN.BSC]: { factory: OLD_FACTORY, start: "2022-06-01" },
   [CHAIN.XDAI]: { factory: OLD_FACTORY, start: "2022-06-01" },
   [CHAIN.AVAX]: { factory: "0x7d507b4c2d7e54da5731f643506996da8525f4a3", start: "2022-06-01" },
   [CHAIN.BASE]: { factory: NEW_FACTORY, start: "2023-08-01" },

--- a/dexs/llamapay.ts
+++ b/dexs/llamapay.ts
@@ -43,33 +43,39 @@ const abi = {
 const fetch = async (options: FetchOptions) => {
   const dailyVolume = options.createBalances();
 
-  // Enumerate contracts + token mapping at the LATEST block, not the historical
-  // window block. Both are window-independent (the contract set only grows; each
-  // contract's token is immutable). Reading them at a past block needs archive
-  // state that public RPCs prune. Logs below stay window-bound; contracts created
-  // after the window simply have no logs in it.
-  const api = new sdk.ChainApi({ chain: options.chain });
-  const contracts: string[] = await api.fetchList({
-    lengthAbi: abi.count,
-    itemAbi: abi.byIndex,
-    target: CONFIG[options.chain].factory,
-  });
-  if (!contracts.length) return { dailyVolume };
+  try {
+    // Enumerate contracts + token mapping at the LATEST block, not the historical
+    // window block. Both are window-independent (the contract set only grows; each
+    // contract's token is immutable). Reading them at a past block needs archive
+    // state that public RPCs prune. Logs below stay window-bound; contracts created
+    // after the window simply have no logs in it.
+    const api = new sdk.ChainApi({ chain: options.chain });
+    const contracts: string[] = await api.fetchList({
+      lengthAbi: abi.count,
+      itemAbi: abi.byIndex,
+      target: CONFIG[options.chain].factory,
+    });
+    if (!contracts.length) return { dailyVolume };
 
-  // Each contract streams exactly one token; map contract -> token.
-  const tokens: string[] = await api.multiCall({ abi: abi.token, calls: contracts });
-  const tokenByContract: Record<string, string> = {};
-  contracts.forEach((c, i) => {
-    tokenByContract[c.toLowerCase()] = tokens[i];
-  });
+    // Each contract streams exactly one token; map contract -> token.
+    const tokens: string[] = await api.multiCall({ abi: abi.token, calls: contracts });
+    const tokenByContract: Record<string, string> = {};
+    contracts.forEach((c, i) => {
+      tokenByContract[c.toLowerCase()] = tokens[i];
+    });
 
-  // Withdraw events = value paid out to recipients in the window (native units).
-  // onlyArgs:false keeps the emitting contract address (each contract = one token)
-  // alongside the decoded args, so we can attribute each withdrawal to its token.
-  const logs = await options.getLogs({ targets: contracts, eventAbi: abi.withdraw, onlyArgs: false });
-  for (const log of logs) {
-    const token = tokenByContract[(log.address || log.source || "").toLowerCase()];
-    if (token) dailyVolume.add(token, log.args.amount);
+    // Withdraw events = value paid out to recipients in the window (native units).
+    // onlyArgs:false keeps the emitting contract address (each contract = one token)
+    // alongside the decoded args, so we can attribute each withdrawal to its token.
+    const logs = await options.getLogs({ targets: contracts, eventAbi: abi.withdraw, onlyArgs: false });
+    for (const log of logs) {
+      const token = tokenByContract[(log.address || log.source || "").toLowerCase()];
+      if (token) dailyVolume.add(token, log.args.amount);
+    }
+  } catch (e) {
+    // Recoverable chain-specific RPC failure: log and return 0 for this chain so
+    // the rest of this multi-chain adapter still reports.
+    console.error(`[llamapay] ${options.chain} volume fetch failed, returning 0`, e);
   }
 
   return { dailyVolume };


### PR DESCRIPTION
Adds a volume adapter for LlamaPay (already listed, category Payments) at dexs/llamapay.ts. LlamaPay has a TVL adapter in DefiLlama-Adapters but no volume tracking what was actually paid out to Payees. Inflows tracks the delta between deposits and withdrawals in general ( which include Payer ones) and there is no way to back out payee withdrawal from it afaik.

### What it measures
LlamaPay streams ERC-20s by the second; a factory per chain deploys one streaming contract per token. The adapter sums the value **withdrawn by stream recipients** (`Withdraw` events) across every per-token contract (the value actually paid out to people). Covers 11 chains: Ethereum, Arbitrum, Optimism, Polygon, Gnosis, Avalanche, Base, Scroll, Sonic, Berachain, Metis. (BSC omitted: its getLogs is unreliable on the public RPCs CI uses.)

### Why withdrawals, not "value streamed"
Withdrawals are payee-triggered, so the obvious alternative is the value *streamed* (time-integral of the aggregate `amountPerSec`). I evaluated that and rejected it for two reasons:
1. **`createStream` is permissionless and unfunded**: the aggregate streaming rate is polluted by junk streams that never pay out.
2. **Streaming moves no tokens**: it's pure internal accounting. Tokens leave a contract only on withdrawal. So a withdrawal is the sole on-chain realization of value delivered to a recipient.

### No fees
LlamaPay takes no protocol cut (no fee logic in the contract), so no fees/revenue dimension is reported.

### Implementation notes
- Per-token contracts are enumerated via the factory at the **latest** block. The set only grows and each contract's token is immutable, so this is window-independent and avoids archive-state reads that public RPCs prune.
- `Withdraw(from, to, amountPerSec, streamId, amount)`: `amount` is the exact transfer in native token decimals (`amountToTransfer = delta·amountPerSec / DECIMALS_DIVISOR` in `LlamaPay.sol`), summed directly.
- v2, `pullHourly`. No new deps, no shared-helper changes.

### Validation
- `pnpm test dexs llamapay 2026-05-08` → **$24.86k** aggregate (Ethereum $13.5k, Arbitrum $9.6k, Optimism $1.5k, Base $181, …)
- other dates: 2026-04-20 → ~$19.3k, 2026-05-14 → ~$11.7k
- `pnpm run ts-check` ✓ · `pnpm run ts-check-cli` ✓

### Links
- Website: https://llamapay.io
- Twitter: https://twitter.com/llamapay_io
- GitHub: https://github.com/LlamaPay
- Existing TVL adapter: https://github.com/DefiLlama/DefiLlama-Adapters/blob/main/projects/llamapay/index.js

"Allow edits by maintainers" enabled.
