### PR TITLE
[feat] StandX: add fees/revenue adapter for standx-perps from volume

### DIFF
--- a/fees/standx/index.ts
+++ b/fees/standx/index.ts
@@ -1,0 +1,61 @@
+import { FetchOptions, FetchResult, SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import { METRIC } from "../../helpers/metrics";
+import { fetchURLAutoHandleRateLimit } from "../../utils/fetchURL";
+
+const API_ENDPOINT = "https://perps.standx.com/api";
+
+const fetch = async (_a: any, _b: any, options: FetchOptions): Promise<FetchResult> => {
+  const dailyFees = options.createBalances();
+  const dailyRevenue = options.createBalances();
+
+  const symbolsResponse: any[] = await fetchURLAutoHandleRateLimit(`${API_ENDPOINT}/query_symbol_info`);
+  const symbols = symbolsResponse.filter((item: any) => item.status === "trading" || item.status === "reduce_only");
+
+  for (const { symbol, maker_fee, taker_fee } of symbols as any[]) {
+    const marketInfo: any = await fetchURLAutoHandleRateLimit(
+      `${API_ENDPOINT}/kline/history?symbol=${symbol}&from=${options.startOfDay}&to=${options.endTimestamp}&resolution=60&countback=50`,
+    );
+    if (!marketInfo.t) continue;
+
+    const volume = marketInfo.t.reduce((sum: number, time: number, i: number) => {
+      if (time < options.startOfDay || time >= options.endTimestamp) return sum;
+      return sum + marketInfo.v[i] * marketInfo.c[i];
+    }, 0);
+    const fees = volume * (Number(maker_fee) + Number(taker_fee));
+
+    dailyFees.addUSDValue(fees, METRIC.TRADING_FEES);
+    dailyRevenue.addUSDValue(fees, "Trading Fees To Protocol");
+  }
+
+  return {
+    dailyFees,
+    dailyRevenue,
+    dailyProtocolRevenue: dailyRevenue,
+  };
+};
+
+const methodology = {
+  Fees: "All trading fees collected from perpetual futures trades on StandX",
+  Revenue: "All trading fees collected by StandX",
+};
+
+const breakdownMethodology = {
+  Fees: {
+    [METRIC.TRADING_FEES]: "Fees paid by traders on perpetual futures trades",
+  },
+  Revenue: {
+    "Trading Fees To Protocol": "Trading fees collected by StandX",
+  },
+};
+
+const adapter: SimpleAdapter = {
+  version: 1,
+  fetch,
+  chains: [CHAIN.STANDX],
+  start: "2025-11-24",
+  methodology,
+  breakdownMethodology,
+};
+
+export default adapter;


### PR DESCRIPTION

> Maintainer note: We do not have a direct StandX fees API endpoint, and I could not find verified contract sources/events that expose perps fees cleanly. StandX also offers rebates for active traders that we cannot infer, and public fee tier data is not available, so its flat fees charged per trade. Using hourly perps chart volume multiplied by the public maker/taker fee rates is the cleanest approach I found. Please guide if there is a better source or methodology.

## Summary
- Adds a StandX perps fees adapter under `fees/standx`.
- Estimates trading fees and protocol revenue from StandX public perps market data.

## Changes
- Fetches active/reduce-only perps symbols from `https://perps.standx.com/api/query_symbol_info`.
- Fetches hourly market chart data from `kline/history` using the adapter day window.
- Calculates estimated fees as hourly volume multiplied by `maker_fee + taker_fee`.
- Reports `dailyFees`, `dailyRevenue`, and `dailyProtocolRevenue` for StandX perps.

## Methodology
- Perps volume is derived from hourly kline data as `base volume * close price`.
- Fees are estimated from the public maker/taker fee rates returned by StandX symbol info.
- Revenue is treated as equal to fees because no supply-side split or rebate-adjusted fee endpoint is available.

## Tests
- `pnpm test fees standx 2026-05-01`