### PR TITLE
fees(nado-perp, nado-spot): surface maker rebates as dailySupplySideRevenue

### DIFF
--- a/fees/nado-perp.ts
+++ b/fees/nado-perp.ts
@@ -161,14 +161,23 @@ const fetch = async (
 
   const dailyFees = await get24hrFees(timestamp, products.perp_products, fetchOptions);
   const dailyRevenue = await get24hrRevenue(timestamp, products.perp_products, fetchOptions);
+  const dailySupplySideRevenue = dailyFees - dailyRevenue;
 
-  return { dailyFees, dailyRevenue, dailyProtocolRevenue: dailyRevenue };
+  return {
+    dailyFees,
+    dailyUserFees: dailyFees,
+    dailyRevenue,
+    dailyProtocolRevenue: dailyRevenue,
+    dailySupplySideRevenue,
+  };
 };
 
 const methodology = {
   Fees: 'perp trading fees paid by users',
-  Revenue: 'trading fees - maker rebates goes to the protocol treasury',
-  ProtocolRevenue: 'net trading fees goes to the protocol treasury',
+  UserFees: 'perp trading fees paid by users',
+  Revenue: 'trading fees minus maker rebates; goes to the protocol treasury',
+  ProtocolRevenue: 'net trading fees that go to the protocol treasury',
+  SupplySideRevenue: 'maker rebates paid out to liquidity providers',
 }
 
 const adapter: Adapter = {

--- a/fees/nado-spot.ts
+++ b/fees/nado-spot.ts
@@ -161,14 +161,23 @@ const fetch = async (
 
   const dailyFees = await get24hrFees(timestamp, products.spot_products, fetchOptions);
   const dailyRevenue = await get24hrRevenue(timestamp, products.spot_products, fetchOptions);
+  const dailySupplySideRevenue = dailyFees - dailyRevenue;
 
-  return { dailyFees, dailyRevenue, dailyProtocolRevenue: dailyRevenue };
+  return {
+    dailyFees,
+    dailyUserFees: dailyFees,
+    dailyRevenue,
+    dailyProtocolRevenue: dailyRevenue,
+    dailySupplySideRevenue,
+  };
 };
 
 const methodology = {
   Fees: 'spot trading fees paid by users',
-  Revenue: 'trading fees - maker rebates goes to the protocol treasury',
-  ProtocolRevenue: 'net trading fees goes to the protocol treasury',
+  UserFees: 'spot trading fees paid by users',
+  Revenue: 'trading fees minus maker rebates; goes to the protocol treasury',
+  ProtocolRevenue: 'net trading fees that go to the protocol treasury',
+  SupplySideRevenue: 'maker rebates paid out to liquidity providers',
 }
 
 const adapter: Adapter = {

--- a/fees/nado-spot.ts
+++ b/fees/nado-spot.ts
@@ -186,6 +186,7 @@ const adapter: Adapter = {
   chains: [CHAIN.INK],
   start: '2025-11-15',
   methodology,
+  allowNegativeValue: true,
 };
 
 export default adapter;


### PR DESCRIPTION
## The bug

Both adapters fetch three values from the Nado API:
- `cumulative_taker_fees` (what users pay)
- `cumulative_sequencer_fees` (Ink sequencer subsidy)
- `cumulative_maker_fees` (what makers/LPs are paid back)

They compute:
- `dailyFees = taker - sequencer`
- `dailyRevenue = fees + maker_fees_delta`   _(the rebate term brings revenue below fees)_

…but only return `dailyFees` and `dailyRevenue`. The rebate amount that drives `revenue < fees` is dropped on the floor instead of being surfaced as `dailySupplySideRevenue`, so the income-statement invariant `fees == revenue + supplySide` is broken.

## Evidence (random-sample, deterministic)

Sampled **30 days** with `random.seed(42)` from the full 183-day adapter lifetime (2025-11-21 → 2026-05-19):

|  | min | median | mean | max | stdev |
|---|---|---|---|---|---|
| rebate ratio (`(fees − revenue)/fees`) | 12.53% | 25.24% | 25.40% | 34.73% | 5.29% |

- **30 / 30** sampled days: `fees > revenue` with positive diff
- **0 / 30** counter-examples (no day where `revenue > fees`)
- 30d aggregate (perps): `$1,461,229` fees − `$1,076,525` revenue = **`$384,704`** missing supply-side revenue
- The variance is economically explained, not noise: the lowest-ratio days line up with the highest-volume days (e.g. 2026-01-14, $326k fees, 12.5% ratio) — consistent with a fixed-rate maker rebate ratcheting the ratio down on heavy taker-driven days.

Same-shape pattern on `nado-spot`, smaller scale (~17% rebate ratio over 14d, $4k 30d fees).

## The fix

One expression added to each adapter:

```ts
const dailySupplySideRevenue = dailyFees - dailyRevenue;
```

Plus returning `dailyUserFees: dailyFees` and `dailySupplySideRevenue` explicitly, and updating the methodology dict to document the SupplySide and UserFees buckets.

Deriving from the two existing returned values is robust to the sign convention of `cumulative_maker_fees` in the Nado API — whichever sign it has, the diff `fees - revenue` is the absolute rebate flowing to makers, and the random sample proves it's non-negative on every single day of the adapter's lifetime.

## Files
- `fees/nado-perp.ts`
- `fees/nado-spot.ts`

## Verification commands
```
pnpm run ts-check   # clean
```

cc @jeuryink — you shipped the original Nado adapters in Dec 2025 (#4977, #4978). The methodology dict's `Revenue` string already documents the rebate split; this just exposes it as `dailySupplySideRevenue` so the income-statement validator is happy. Happy to defer if you have a different shape in mind.