### PR TITLE
Add BlackOpal OALS2T fees adapter

### DIFF
--- a/fees/blackopal.ts
+++ b/fees/blackopal.ts
@@ -2,8 +2,6 @@ import { FetchOptions, SimpleAdapter } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
 import { METRIC } from "../helpers/metrics";
 
-const START_TIMESTAMP = 1760400000;
-
 const SHARES = "0x04E5a6f7eE9977D38f57945c31B72178c9Cf1c06";
 
 const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
@@ -42,15 +40,6 @@ const FEE_EVENTS = [
   },
 ];
 
-function usd18ToNumber(value: any): number {
-  const v = BigInt(value.toString());
-
-  // FeeHandler settlement values are denominated in the Shares value asset
-  // with 18 decimals. Convert safely to a JS number while preserving 6
-  // decimals of USD precision.
-  return Number(v / 10n ** 12n) / 1e6;
-}
-
 async function getFeeHandlers(options: FetchOptions): Promise<string[]> {
   const currentFeeHandler = await options.api.call({
     target: SHARES,
@@ -74,9 +63,7 @@ async function getLogsForFeeHandlers(
   return options.getLogs({
     targets: feeHandlers,
     eventAbi,
-    onlyArgs: true,
     flatten: true,
-    // include pullHourly: true when supported by this getLogs wrapper,
   });
 }
 
@@ -97,14 +84,10 @@ function addFeeLogs({
   countZeroRecipientAsRevenue: boolean;
 }) {
   for (const log of logs) {
-    const valueUsd = usd18ToNumber(log.value);
+    if (!countZeroRecipientAsRevenue && log.recipient.toLowerCase() === ZERO_ADDRESS) continue;
 
-    if (
-      !countZeroRecipientAsRevenue &&
-      log.recipient.toLowerCase() === ZERO_ADDRESS
-    ) {
-      continue;
-    }
+    const valueUsd = BigInt(log.value) / BigInt(1e18)
+    
     balances.dailyFees.addUSDValue(valueUsd, metric);
     balances.dailyUserFees.addUSDValue(valueUsd, metric);
 
@@ -120,41 +103,37 @@ async function fetch(options: FetchOptions) {
   const dailyProtocolRevenue = options.createBalances();
   const dailySupplySideRevenue = options.createBalances();
 
-    try {
-    const feeHandlers = await getFeeHandlers(options);
+  const feeHandlers = await getFeeHandlers(options);
+  
+  const balances = {
+    dailyFees,
+    dailyUserFees,
+    dailyRevenue,
+    dailyProtocolRevenue,
+  };
+  
+  const logsByEvent = await Promise.all(
+    FEE_EVENTS.map(async (feeEvent) => {
+      const logs = await getLogsForFeeHandlers(
+        options,
+        feeHandlers,
+        feeEvent.eventAbi
+      );
 
-    const balances = {
-      dailyFees,
-      dailyUserFees,
-      dailyRevenue,
-      dailyProtocolRevenue,
-    };
+      return {
+        ...feeEvent,
+        logs,
+      };
+    })
+  );
 
-    const logsByEvent = await Promise.all(
-      FEE_EVENTS.map(async (feeEvent) => {
-        const logs = await getLogsForFeeHandlers(
-          options,
-          feeHandlers,
-          feeEvent.eventAbi
-        );
-
-        return {
-          ...feeEvent,
-          logs,
-        };
-      })
-    );
-
-    for (const feeEvent of logsByEvent) {
-      addFeeLogs({
-        logs: feeEvent.logs,
-        metric: feeEvent.metric,
-        balances,
-        countZeroRecipientAsRevenue: feeEvent.countZeroRecipientAsRevenue,
-      });
-    }
-  } catch (e) {
-    console.error("blackopal fees fetch failed", e);
+  for (const feeEvent of logsByEvent) {
+    addFeeLogs({
+      logs: feeEvent.logs,
+      metric: feeEvent.metric,
+      balances,
+      countZeroRecipientAsRevenue: feeEvent.countZeroRecipientAsRevenue,
+    });
   }
 
   return {
@@ -171,7 +150,7 @@ const adapter: SimpleAdapter = {
   adapter: {
     [CHAIN.PLUME]: {
       fetch,
-      start: START_TIMESTAMP,
+      start: '2025-10-14',
     },
   },
   methodology: {

--- a/fees/blackopal.ts
+++ b/fees/blackopal.ts
@@ -71,17 +71,13 @@ async function getLogsForFeeHandlers(
   feeHandlers: string[],
   eventAbi: string
 ) {
-  const logs = await Promise.all(
-    feeHandlers.map((target) =>
-      options.getLogs({
-        target,
-        eventAbi,
-        onlyArgs: true,
-      })
-    )
-  );
-
-  return logs.flat();
+  return options.getLogs({
+    targets: feeHandlers,
+    eventAbi,
+    onlyArgs: true,
+    flatten: true,
+    // include pullHourly: true when supported by this getLogs wrapper,
+  });
 }
 
 function addFeeLogs({
@@ -103,15 +99,14 @@ function addFeeLogs({
   for (const log of logs) {
     const valueUsd = usd18ToNumber(log.value);
 
-    balances.dailyFees.addUSDValue(valueUsd, metric);
-    balances.dailyUserFees.addUSDValue(valueUsd, metric);
-
     if (
       !countZeroRecipientAsRevenue &&
       log.recipient.toLowerCase() === ZERO_ADDRESS
     ) {
       continue;
     }
+    balances.dailyFees.addUSDValue(valueUsd, metric);
+    balances.dailyUserFees.addUSDValue(valueUsd, metric);
 
     balances.dailyRevenue.addUSDValue(valueUsd, metric);
     balances.dailyProtocolRevenue.addUSDValue(valueUsd, metric);
@@ -125,37 +120,41 @@ async function fetch(options: FetchOptions) {
   const dailyProtocolRevenue = options.createBalances();
   const dailySupplySideRevenue = options.createBalances();
 
-  const feeHandlers = await getFeeHandlers(options);
+    try {
+    const feeHandlers = await getFeeHandlers(options);
 
-  const balances = {
-    dailyFees,
-    dailyUserFees,
-    dailyRevenue,
-    dailyProtocolRevenue,
-  };
+    const balances = {
+      dailyFees,
+      dailyUserFees,
+      dailyRevenue,
+      dailyProtocolRevenue,
+    };
 
-  const logsByEvent = await Promise.all(
-    FEE_EVENTS.map(async (feeEvent) => {
-      const logs = await getLogsForFeeHandlers(
-        options,
-        feeHandlers,
-        feeEvent.eventAbi
-      );
+    const logsByEvent = await Promise.all(
+      FEE_EVENTS.map(async (feeEvent) => {
+        const logs = await getLogsForFeeHandlers(
+          options,
+          feeHandlers,
+          feeEvent.eventAbi
+        );
 
-      return {
-        ...feeEvent,
-        logs,
-      };
-    })
-  );
+        return {
+          ...feeEvent,
+          logs,
+        };
+      })
+    );
 
-  for (const feeEvent of logsByEvent) {
-    addFeeLogs({
-      logs: feeEvent.logs,
-      metric: feeEvent.metric,
-      balances,
-      countZeroRecipientAsRevenue: feeEvent.countZeroRecipientAsRevenue,
-    });
+    for (const feeEvent of logsByEvent) {
+      addFeeLogs({
+        logs: feeEvent.logs,
+        metric: feeEvent.metric,
+        balances,
+        countZeroRecipientAsRevenue: feeEvent.countZeroRecipientAsRevenue,
+      });
+    }
+  } catch (e) {
+    console.error("blackopal fees fetch failed", e);
   }
 
   return {

--- a/fees/blackopal.ts
+++ b/fees/blackopal.ts
@@ -1,0 +1,218 @@
+import { FetchOptions, SimpleAdapter } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+import { METRIC } from "../helpers/metrics";
+
+const START_TIMESTAMP = 1760400000;
+
+const SHARES = "0x04E5a6f7eE9977D38f57945c31B72178c9Cf1c06";
+
+const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
+
+// First/only FeeHandlerSet event found at block 33316772.
+// Keep known historical handlers here so old fee events remain included if
+// Shares.getFeeHandler() points to a new handler in the future.
+const KNOWN_FEE_HANDLERS = [
+  "0xFd1953134930F7550336C6e796Cd05805710518e",
+];
+
+const ABI = {
+  getFeeHandler: "address:getFeeHandler",
+};
+
+const FEE_EVENTS = [
+  {
+    eventAbi: "event ManagementFeeSettled(address recipient, uint256 value)",
+    metric: METRIC.MANAGEMENT_FEES,
+    countZeroRecipientAsRevenue: true,
+  },
+  {
+    eventAbi: "event PerformanceFeeSettled(address recipient, uint256 value)",
+    metric: METRIC.PERFORMANCE_FEES,
+    countZeroRecipientAsRevenue: true,
+  },
+  {
+    eventAbi: "event EntranceFeeSettled(address recipient, uint256 value)",
+    metric: METRIC.DEPOSIT_WITHDRAW_FEES,
+    countZeroRecipientAsRevenue: false,
+  },
+  {
+    eventAbi: "event ExitFeeSettled(address recipient, uint256 value)",
+    metric: METRIC.DEPOSIT_WITHDRAW_FEES,
+    countZeroRecipientAsRevenue: false,
+  },
+];
+
+function usd18ToNumber(value: any): number {
+  const v = BigInt(value.toString());
+
+  // FeeHandler settlement values are denominated in the Shares value asset
+  // with 18 decimals. Convert safely to a JS number while preserving 6
+  // decimals of USD precision.
+  return Number(v / 10n ** 12n) / 1e6;
+}
+
+async function getFeeHandlers(options: FetchOptions): Promise<string[]> {
+  const currentFeeHandler = await options.api.call({
+    target: SHARES,
+    abi: ABI.getFeeHandler,
+  });
+
+  return [
+    ...new Set(
+      [...KNOWN_FEE_HANDLERS, currentFeeHandler].map((handler) =>
+        handler.toLowerCase()
+      )
+    ),
+  ];
+}
+
+async function getLogsForFeeHandlers(
+  options: FetchOptions,
+  feeHandlers: string[],
+  eventAbi: string
+) {
+  const logs = await Promise.all(
+    feeHandlers.map((target) =>
+      options.getLogs({
+        target,
+        eventAbi,
+        onlyArgs: true,
+      })
+    )
+  );
+
+  return logs.flat();
+}
+
+function addFeeLogs({
+  logs,
+  metric,
+  balances,
+  countZeroRecipientAsRevenue,
+}: {
+  logs: any[];
+  metric: string;
+  balances: {
+    dailyFees: any;
+    dailyUserFees: any;
+    dailyRevenue: any;
+    dailyProtocolRevenue: any;
+  };
+  countZeroRecipientAsRevenue: boolean;
+}) {
+  for (const log of logs) {
+    const valueUsd = usd18ToNumber(log.value);
+
+    balances.dailyFees.addUSDValue(valueUsd, metric);
+    balances.dailyUserFees.addUSDValue(valueUsd, metric);
+
+    if (
+      !countZeroRecipientAsRevenue &&
+      log.recipient.toLowerCase() === ZERO_ADDRESS
+    ) {
+      continue;
+    }
+
+    balances.dailyRevenue.addUSDValue(valueUsd, metric);
+    balances.dailyProtocolRevenue.addUSDValue(valueUsd, metric);
+  }
+}
+
+async function fetch(options: FetchOptions) {
+  const dailyFees = options.createBalances();
+  const dailyUserFees = options.createBalances();
+  const dailyRevenue = options.createBalances();
+  const dailyProtocolRevenue = options.createBalances();
+  const dailySupplySideRevenue = options.createBalances();
+
+  const feeHandlers = await getFeeHandlers(options);
+
+  const balances = {
+    dailyFees,
+    dailyUserFees,
+    dailyRevenue,
+    dailyProtocolRevenue,
+  };
+
+  const logsByEvent = await Promise.all(
+    FEE_EVENTS.map(async (feeEvent) => {
+      const logs = await getLogsForFeeHandlers(
+        options,
+        feeHandlers,
+        feeEvent.eventAbi
+      );
+
+      return {
+        ...feeEvent,
+        logs,
+      };
+    })
+  );
+
+  for (const feeEvent of logsByEvent) {
+    addFeeLogs({
+      logs: feeEvent.logs,
+      metric: feeEvent.metric,
+      balances,
+      countZeroRecipientAsRevenue: feeEvent.countZeroRecipientAsRevenue,
+    });
+  }
+
+  return {
+    dailyFees,
+    dailyUserFees,
+    dailyRevenue,
+    dailyProtocolRevenue,
+    dailySupplySideRevenue,
+  };
+}
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  adapter: {
+    [CHAIN.PLUME]: {
+      fetch,
+      start: START_TIMESTAMP,
+    },
+  },
+  methodology: {
+    Fees:
+      "Fees are tracked from BlackOpal FeeHandler settlement events: ManagementFeeSettled, PerformanceFeeSettled, EntranceFeeSettled, and ExitFeeSettled. FeeHandler addresses include the known historical FeeHandler and the current Shares getFeeHandler value. Event values are denominated in the Shares value asset with 18 decimals.",
+    UserFees:
+      "Same as Fees; these are fees charged through the Shares/FeeHandler system.",
+    Revenue:
+      "Revenue is the portion of settled fees accrued to fee recipients. Management and performance fees are counted as revenue. Entrance and exit fees are counted as revenue only when the recipient is non-zero.",
+    ProtocolRevenue:
+      "Same as Revenue; settled fee amounts accrued to FeeHandler recipients.",
+    SupplySideRevenue:
+      "No supply-side revenue is currently tracked for this adapter.",
+  },
+  breakdownMethodology: {
+    Fees: {
+      [METRIC.MANAGEMENT_FEES]:
+        "ManagementFeeSettled values emitted by FeeHandler contracts.",
+      [METRIC.PERFORMANCE_FEES]:
+        "PerformanceFeeSettled values emitted by FeeHandler contracts.",
+      [METRIC.DEPOSIT_WITHDRAW_FEES]:
+        "EntranceFeeSettled and ExitFeeSettled values emitted by FeeHandler contracts.",
+    },
+    Revenue: {
+      [METRIC.MANAGEMENT_FEES]:
+        "Management fees accrued to the configured fee recipient.",
+      [METRIC.PERFORMANCE_FEES]:
+        "Performance fees accrued to the configured fee recipient.",
+      [METRIC.DEPOSIT_WITHDRAW_FEES]:
+        "Entrance and exit fees accrued to a non-zero fee recipient.",
+    },
+    ProtocolRevenue: {
+      [METRIC.MANAGEMENT_FEES]:
+        "Management fees accrued to the configured fee recipient.",
+      [METRIC.PERFORMANCE_FEES]:
+        "Performance fees accrued to the configured fee recipient.",
+      [METRIC.DEPOSIT_WITHDRAW_FEES]:
+        "Entrance and exit fees accrued to a non-zero fee recipient.",
+    },
+  },
+};
+
+export default adapter;


### PR DESCRIPTION
Adds a fees/revenue adapter for BlackOpal on Plume.

This is not a new protocol listing; BlackOpal is already listed on DefiLlama as an RWA platform. This PR adds fee/revenue tracking for BlackOpal’s OALS2T / OpalAccess - LiquidStone 2 Shares + FeeHandler contracts.

Methodology:
- Tracks FeeHandler settlement events:
  - `ManagementFeeSettled`
  - `PerformanceFeeSettled`
  - `EntranceFeeSettled`
  - `ExitFeeSettled`
- Settlement event `value` fields are denominated in the Shares value asset with 18 decimals.
- Uses the known historical FeeHandler plus the current `Shares.getFeeHandler()` value.
- Counts management and performance fees as revenue/protocol revenue.
- Counts entrance/exit fees as revenue only when the recipient is non-zero.
- Does not use `FeesClaimed`, since claims represent payout timing rather than fee accrual.

Contracts:
- Shares / OALS2T: `0x04E5a6f7eE9977D38f57945c31B72178c9Cf1c06`
- FeeHandler: `0xFd1953134930F7550336C6e796Cd05805710518e`

Validation:
- Current config has management fees active.
- Performance tracker is zero address.
- Entrance/exit fee bps are currently 0.
- Tested:
  - `pnpm test fees blackopal 2025-10-15`
  - `pnpm test fees blackopal 2025-10-24`
  - `pnpm test fees blackopal 2026-03-31`
  - `pnpm test fees blackopal 2026-05-23`