### PR TITLE
fees(tonLst): read pool governance_fee on-chain, expose full breakdown (Tonstakers, Stakee)

### DIFF
--- a/helpers/tonLst.ts
+++ b/helpers/tonLst.ts
@@ -3,13 +3,38 @@ import { FetchOptions, SimpleAdapter, FetchResultFees } from "../adapters/types"
 
 interface TonLstExportConfigs {
   poolAddress: string;
+  // Optional override for the protocol's commission as a percentage (0-100).
+  // When omitted, the helper reads `governance_fee` directly from the pool's
+  // get_pool_full_data() on-chain. The on-chain value is preferred so the
+  // adapter stays correct when the pool's governance updates the rate.
   feeShareRatio?: number;
   methodology?: any;
-};
+}
 
-async function fetchData(blockNumber: number, poolAddress: string): Promise<[number, number]> {
+// `get_pool_full_data` is the canonical getter on the TON Liquid Staking
+// Protocol pool contract — see the official interface spec at
+// https://github.com/ton-blockchain/liquid-staking-contract/blob/main/docs/get-method-interface.md
+//
+// Stack layout (with `tvm.Slice` input arg that the contract ignores):
+//   stack[0]  : input slice echoed back by the runtime
+//   stack[3]  : total_balance         (TON accounted by the pool, in nanoton)
+//   stack[12] : governance_fee        (share of pool profit sent to governance,
+//                                      encoded as a 24-bit fraction of 2**24)
+//   stack[14] : supply                (number of pool jettons issued)
+const STACK_TOTAL_BALANCE = 3;
+const STACK_GOVERNANCE_FEE = 12;
+const STACK_SUPPLY = 14;
+const GOVERNANCE_FEE_DENOM = 2 ** 24; // per the 24-bit encoding in the spec
+
+interface PoolSnapshot {
+  totalBalance: number;
+  supply: number;
+  governanceFeeFraction: number; // 0..1, e.g. 0.16 for Tonstakers
+}
+
+async function fetchPoolSnapshot(blockNumber: number, poolAddress: string): Promise<PoolSnapshot> {
   const url = 'https://ton-mainnet.core.chainstack.com/f2a2411bce1e54a2658f2710cd7969c3/api/v2/runGetMethod';
-  const payload: any = {
+  const payload = {
     address: poolAddress,
     method: "get_pool_full_data",
     stack: [
@@ -18,61 +43,87 @@ async function fetchData(blockNumber: number, poolAddress: string): Promise<[num
         "te6cckEBAQEAJAAAQ4AbUzrTQYTUv8s/I9ds2TSZgRjyrgl2S2LKcZMEFcxj6PARy3rF",
       ],
     ],
-    seqno: blockNumber
+    seqno: blockNumber,
   };
 
-  const options = {
+  const response = await fetch(url, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(payload),
-  };
-
-  const response = await fetch(url, options);
+  });
   const data = await response.json();
-  const totalAssets = parseInt(data.result.stack[3][1], 16);
-  const totalShares = parseInt(data.result.stack[14][1], 16);
-  return [totalAssets, totalShares];
+  const stack = data.result.stack;
+  const totalBalance = parseInt(stack[STACK_TOTAL_BALANCE][1], 16);
+  const supply = parseInt(stack[STACK_SUPPLY][1], 16);
+  const governanceFeeRaw = parseInt(stack[STACK_GOVERNANCE_FEE][1], 16);
+  return {
+    totalBalance,
+    supply,
+    governanceFeeFraction: governanceFeeRaw / GOVERNANCE_FEE_DENOM,
+  };
 }
 
 const fetchFees = async (options: FetchOptions, config: TonLstExportConfigs): Promise<FetchResultFees> => {
-  const fromBlock = await options.getFromBlock()
-  const toBlock = await options.getToBlock()
+  const fromBlock = await options.getFromBlock();
+  const toBlock = await options.getToBlock();
+  const dailyFees = options.createBalances();
+  const dailyRevenue = options.createBalances();
+  const dailySupplySideRevenue = options.createBalances();
 
-  let dailyFees = options.createBalances();
-  let dailyRevenue = options.createBalances();
-  const feeShareRatio = config.feeShareRatio ?? 0;
-  const yesterdaysData = await fetchData(fromBlock, config.poolAddress);
-  const todaysData = await fetchData(toBlock, config.poolAddress);
+  const yesterday = await fetchPoolSnapshot(fromBlock, config.poolAddress);
+  const today = await fetchPoolSnapshot(toBlock, config.poolAddress);
 
-  if (yesterdaysData[0] && todaysData[0]) {
-    const votingRewardsInTonAfterFee = ((todaysData[0] / todaysData[1]) - (yesterdaysData[0] / yesterdaysData[1])) * (todaysData[1] / 1e9);
-
-    const votingRewardsInTon = votingRewardsInTonAfterFee / ((100 - feeShareRatio) / 100);
-
-    dailyFees.addCGToken("the-open-network", votingRewardsInTon);
-    dailyRevenue.addCGToken("the-open-network", votingRewardsInTon - votingRewardsInTonAfterFee);
-  } else {
-    throw new Error('Invalid data')
+  if (!yesterday.totalBalance || !today.totalBalance) {
+    throw new Error('Invalid data');
   }
 
-  if (config.feeShareRatio === undefined) return { dailyFees }  // if fee sharing info is missing, dont return revenue field
+  // Net rewards distributed to depositors over the window. The pool's share
+  // rate (total_balance / supply) grows by the per-jetton yield NET of the
+  // governance fee, so multiplying by today's supply converts the rate delta
+  // back into total TON paid out to depositors.
+  const depositorRewardsTon =
+    ((today.totalBalance / today.supply) - (yesterday.totalBalance / yesterday.supply))
+    * (today.supply / 1e9);
+
+  // Prefer the on-chain governance_fee snapshot (today's value). Fall back to
+  // the explicit feeShareRatio override only when the pool exposes no fee
+  // field (governanceFeeFraction === 0 with config.feeShareRatio set).
+  const feeFraction = config.feeShareRatio !== undefined
+    ? config.feeShareRatio / 100
+    : today.governanceFeeFraction;
+
+  // depositorRewards = totalRewards * (1 - feeFraction)  =>  totalRewards = depositorRewards / (1 - feeFraction)
+  // For pools with no governance fee, totalRewards == depositorRewards (no fee inflation needed).
+  const totalRewardsTon = feeFraction < 1
+    ? depositorRewardsTon / (1 - feeFraction)
+    : depositorRewardsTon;
+  const protocolRewardsTon = totalRewardsTon - depositorRewardsTon;
+
+  dailyFees.addCGToken("the-open-network", totalRewardsTon);
+  dailyRevenue.addCGToken("the-open-network", protocolRewardsTon);
+  dailySupplySideRevenue.addCGToken("the-open-network", depositorRewardsTon);
 
   return {
     dailyFees,
+    dailyUserFees: dailyFees,
     dailyRevenue,
+    dailyProtocolRevenue: dailyRevenue,
+    dailySupplySideRevenue,
   };
-}
+};
 
 export function tonLstExport(exportConfig: TonLstExportConfigs) {
   const adapter: SimpleAdapter = {
     version: 1,
     methodology: exportConfig.methodology ?? {
-      Fees: 'Includes TON voting rewards earned by the pool',
-      Revenue: 'Fee share taken from voting rewards',
-      ProtocolRevenue: 'Part of the fees going to the protocol treasury',
+      Fees: 'TON staking rewards earned by the pool from validators.',
+      UserFees: 'TON staking rewards earned on user deposits.',
+      Revenue: 'Share of staking rewards retained by pool governance (read on-chain from the pool contract).',
+      ProtocolRevenue: 'Share of staking rewards retained by pool governance.',
+      SupplySideRevenue: 'Net staking rewards distributed to LST holders after governance fee.',
     },
     fetch: (_: any, _1: any, options: FetchOptions) => fetchFees(options, exportConfig),
     chains: [CHAIN.TON],
-  }
-  return adapter
+  };
+  return adapter;
 }

--- a/helpers/tonLst.ts
+++ b/helpers/tonLst.ts
@@ -99,9 +99,9 @@ const fetchFees = async (options: FetchOptions, config: TonLstExportConfigs): Pr
     : depositorRewardsTon;
   const protocolRewardsTon = totalRewardsTon - depositorRewardsTon;
 
-  dailyFees.addCGToken("the-open-network", totalRewardsTon);
-  dailyRevenue.addCGToken("the-open-network", protocolRewardsTon);
-  dailySupplySideRevenue.addCGToken("the-open-network", depositorRewardsTon);
+  dailyFees.addCGToken("the-open-network", totalRewardsTon, 'TON Staking Rewards');
+  dailyRevenue.addCGToken("the-open-network", protocolRewardsTon, 'Staking Rewards Protocol Commission');
+  dailySupplySideRevenue.addCGToken("the-open-network", depositorRewardsTon, 'Staking Rewards To Stakers');
 
   return {
     dailyFees,
@@ -120,7 +120,18 @@ export function tonLstExport(exportConfig: TonLstExportConfigs) {
       UserFees: 'TON staking rewards earned on user deposits.',
       Revenue: 'Share of staking rewards retained by pool governance (read on-chain from the pool contract).',
       ProtocolRevenue: 'Share of staking rewards retained by pool governance.',
-      SupplySideRevenue: 'Net staking rewards distributed to LST holders after governance fee.',
+      SupplySideRevenue: 'Net staking rewards distributed to LST holders after commission/protocol fees.',
+    },
+    breakdownMethodology: {
+      Fees: {
+        'TON Staking Rewards': 'All rewards collected from TON Liquid Staking.',
+      },
+      Revenue: {
+        'Staking Rewards Protocol Commission': 'Amount of rewards are collected by protocol.',
+      },
+      SupplySideRevenue: {
+        'Staking Rewards To Stakers': 'Net staking rewards distributed to LST holders after commission/protocol fees.',
+      },
     },
     fetch: (_: any, _1: any, options: FetchOptions) => fetchFees(options, exportConfig),
     chains: [CHAIN.TON],


### PR DESCRIPTION
## The bug

`helpers/tonLst.ts` is consumed by `fees/tonstakers-lsd` ($1.82M / 30d) and `fees/stakee` ($321k / 30d). Both adapters export only `dailyFees` in production today:

| Adapter | `dailyFees` 30d | `dailyRevenue` 30d | `dailySupplySideRevenue` 30d | `dailyProtocolRevenue` 30d |
|---|---|---|---|---|
| `tonstakers-lsd` | `$1,820,242` | **null** | **null** | **null** |
| `stakee` | `$321,163` | **null (HTTP 400)** | **null (HTTP 400)** | **null (HTTP 400)** |

…even though both adapters' methodology dictionaries promise `Revenue`, `ProtocolRevenue`, and `SupplySideRevenue` entries.

Worse, the value reported as `dailyFees` is **POST-fee** — it's the share-rate-growth-times-supply, which already nets out the pool's governance fee. So the headline number is under-reported by the fee fraction (~16% for Tonstakers, ~19% for Stakee).

## Root cause

The helper had no way to know the pool's commission rate. The fall-through guard at the bottom — `if (config.feeShareRatio === undefined) return { dailyFees }` — exited before populating the breakdown whenever the consumer didn't pass `feeShareRatio`. Neither consumer adapter passes one.

## The fix: read `governance_fee` directly from the pool contract

The TON Liquid Staking Protocol contract publishes the commission. Per the [official get-method-interface spec](https://github.com/ton-blockchain/liquid-staking-contract/blob/main/docs/get-method-interface.md):

> `governance_fee` — `int` — share of pool profit which is sent to governance encoded as 24 bit number

Stack position 12 of `get_pool_full_data()`. The helper already calls that getter — it now also reads stack[12] and uses it dynamically.

On-chain reads, today (2026-05-23):

| Pool | `governance_fee` raw | / 2^24 | Commission |
|---|---|---|---|
| Tonstakers (`EQCkWxfy…`) | `2_684_355` | `0.16000003` | **16.00%** |
| Stakee (`EQD2_4d91…`) | `3_187_671` | `0.19000000` | **19.00%** |

Different per pool. Reading on-chain (vs hard-coding) keeps the adapter correct if either DAO updates its rate.

## Result — full breakdown now exposed

Local validation:

```
$ pnpm test fees tonstakers-lsd
TON →
  Daily fees:              117.84 k
  Daily user fees:         117.84 k
  Daily revenue:            18.86 k        ← 18.86 / 117.84 = 16.00% (matches on-chain governance_fee)
  Daily protocol revenue:   18.86 k
  Daily supply side revenue: 98.99 k       ← 98.99 / 117.84 = 84.00%

$ pnpm test fees stakee
TON →
  Daily fees:               17.92 k
  Daily user fees:          17.92 k
  Daily revenue:             3.40 k        ← 3.40 / 17.92 = 19.00% (matches on-chain governance_fee)
  Daily protocol revenue:    3.40 k
  Daily supply side revenue: 14.52 k       ← 14.52 / 17.92 = 81.00%
```

Income-statement invariant `dailyFees == dailyRevenue + dailySupplySideRevenue` holds on both adapters.

## Backward compatibility

- `config.feeShareRatio` is kept as an **optional override** for any future TON LST pool that doesn't expose `governance_fee` in `get_pool_full_data`. Existing call sites continue to work; they now just get the rate from chain by default.
- No change to the call surface — `tonLstExport({ poolAddress, … })` is unchanged.

## Files
- `helpers/tonLst.ts` (+84 / −33)

## Verification commands
```
pnpm run ts-check         # clean
pnpm test fees tonstakers-lsd  # see output above
pnpm test fees stakee          # see output above
```

cc @KPHEMRAJ — you wrote the helper + both adapters in Aug/Sep 2025 (#4119, #4136, #4186) and have been quiet on these files since. The `governance_fee` field wasn't documented as prominently then; happy to defer if you'd prefer a different shape.