### PR TITLE
feat(yuzu-money): add fees adapter — yzPP / syzUSD / yzPrime vault yields

### DIFF
--- a/fees/yuzu-money/index.ts
+++ b/fees/yuzu-money/index.ts
@@ -45,14 +45,14 @@ const chainConfig: Record<string, VaultConfig[]> = {
       underlying: PLASMA_YZUSD,
       underlyingDecimals: 18,
       shareDecimals: 18,
-      label: "syzUSD staking yield",
+      label: "syzUSD Staking Yield To Stakers",
     },
     {
       vault: "0xebfc8c2fe73c431ef2a371aea9132110aab50dca", // yzPP
       underlying: PLASMA_USDT0,
       underlyingDecimals: 6,
       shareDecimals: 18,
-      label: "yzPP first-loss tranche yield",
+      label: "yzPP First-Loss Tranche Yield To Holders",
     },
   ],
   [CHAIN.MONAD]: [
@@ -61,7 +61,7 @@ const chainConfig: Record<string, VaultConfig[]> = {
       underlying: MONAD_USD,
       underlyingDecimals: 6,
       shareDecimals: 18,
-      label: "yzPrime yield",
+      label: "yzPrime Yield To Holders",
     },
   ],
 };
@@ -131,19 +131,20 @@ const methodology = {
 
 const breakdownMethodology = {
   Fees: {
-    "syzUSD staking yield":
+    "syzUSD Staking Yield To Stakers":
       "Daily growth of syzUSD's totalAssets/totalSupply ratio multiplied by today's supply, in yzUSD units.",
-    "yzPP first-loss tranche yield":
+    "yzPP First-Loss Tranche Yield To Holders":
       "Daily growth of yzPP's totalAssets/totalSupply ratio multiplied by today's supply, in USDT0 units. yzPP earns a base yield tracking syzUSD plus a protocol-funded bonus budget from the Reserve Fund.",
-    "yzPrime yield":
+    "yzPrime Yield To Holders":
       "Daily growth of yzPrime's totalAssets/totalSupply ratio multiplied by today's supply. yzPrime is the Yuzu Prime product on Monad with continuous yield distribution.",
   },
   SupplySideRevenue: {
-    "syzUSD staking yield":
+    "syzUSD Staking Yield To Stakers":
       "yzUSD stakers receive 100% of the underlying strategy yield via syzUSD share-rate appreciation.",
-    "yzPP first-loss tranche yield":
+    "yzPP First-Loss Tranche Yield To Holders":
       "yzPP holders receive base yield plus a protocol-funded bonus, in exchange for accepting first-loss risk.",
-    "yzPrime yield": "yzPrime holders receive the full Yuzu Prime yield via share-rate appreciation.",
+    "yzPrime Yield To Holders":
+      "yzPrime holders receive the full Yuzu Prime yield via share-rate appreciation.",
   },
 };
 

--- a/fees/yuzu-money/index.ts
+++ b/fees/yuzu-money/index.ts
@@ -1,0 +1,169 @@
+import { Adapter, FetchOptions, FetchResultV2 } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+
+// Yuzu Money is an over-collateralised yield protocol with two products:
+//
+//   - Yuzu Alpha (Plasma chain): users hold the yzUSD stablecoin and stake it
+//     into syzUSD or supply the yzPP first-loss tranche.
+//   - Yuzu Prime  (Monad chain):  yzPrime token, continuous yield distribution.
+//
+// Per the protocol's own docs (yuzu-money.gitbook.io/yuzu-money/faq/performance-fee):
+// "Does Yuzu Money charge a performance fee on the generated yield? ... Yuzu
+//  Money takes a fixed-fee approach: no performance fee, and dynamically
+//  adjusted APY distribution to depositors..." — i.e. 100% of yield realised
+//  by underlying strategies is distributed back to depositors via the
+//  ERC-4626 share-rate of syzUSD / yzPP / yzPrime; the protocol's economic
+//  accrual is via the Reserve Fund (yzUSD/USDT0 wallet 0xdaef005a...), which
+//  is a *long-horizon* surplus/deficit buffer rather than a per-day fee skim.
+//
+// This adapter reports the on-chain depositor yield (which equals total
+// distributed protocol yield, since no performance fee is taken) by reading
+// each ERC-4626 vault's total_assets / total_supply at the window endpoints
+// and converting the share-rate delta back to underlying units.
+
+interface VaultConfig {
+  /** ERC-4626 vault token address. */
+  vault: string;
+  /** Underlying `asset()` of the vault (yzUSD for syzUSD, USDT0 for yzPP, etc.). */
+  underlying: string;
+  /** Decimals of the underlying asset (matters for USD pricing). */
+  underlyingDecimals: number;
+  /** Decimals of the vault share token (typically 18). */
+  shareDecimals: number;
+  /** Human-readable label used for breakdownMethodology / logging. */
+  label: string;
+}
+
+const PLASMA_USDT0 = "0xb8ce59fc3717ada4c02eadf9682a9e934f625ebb";
+const PLASMA_YZUSD = "0x6695c0f8706c5ace3bdf8995073179cca47926dc";
+const MONAD_USD = "0x754704bc059f8c67012fed69bc8a327a5aafb603"; // yzPrime asset()
+
+const chainConfig: Record<string, VaultConfig[]> = {
+  [CHAIN.PLASMA]: [
+    {
+      vault: "0xc8a8df9b210243c55d31c73090f06787ad0a1bf6", // syzUSD
+      underlying: PLASMA_YZUSD,
+      underlyingDecimals: 18,
+      shareDecimals: 18,
+      label: "syzUSD staking yield",
+    },
+    {
+      vault: "0xebfc8c2fe73c431ef2a371aea9132110aab50dca", // yzPP
+      underlying: PLASMA_USDT0,
+      underlyingDecimals: 6,
+      shareDecimals: 18,
+      label: "yzPP first-loss tranche yield",
+    },
+  ],
+  [CHAIN.MONAD]: [
+    {
+      vault: "0xc9ea90692757831d98ac629f2a0140e02b80a7da", // yzPrime
+      underlying: MONAD_USD,
+      underlyingDecimals: 6,
+      shareDecimals: 18,
+      label: "yzPrime yield",
+    },
+  ],
+};
+
+async function fetch(options: FetchOptions): Promise<FetchResultV2> {
+  const dailyFees = options.createBalances();
+  const dailyRevenue = options.createBalances();
+  const dailySupplySideRevenue = options.createBalances();
+
+  const vaults = chainConfig[options.chain];
+  if (!vaults?.length) {
+    return { dailyFees, dailyRevenue, dailySupplySideRevenue };
+  }
+
+  const vaultAddresses = vaults.map((v) => v.vault);
+  const totalAssetsAbi = "uint256:totalAssets";
+  const totalSupplyAbi = "uint256:totalSupply";
+
+  const [assetsFrom, supplyFrom, assetsTo, supplyTo] = await Promise.all([
+    options.fromApi.multiCall({ abi: totalAssetsAbi, calls: vaultAddresses }),
+    options.fromApi.multiCall({ abi: totalSupplyAbi, calls: vaultAddresses }),
+    options.toApi.multiCall({ abi: totalAssetsAbi, calls: vaultAddresses }),
+    options.toApi.multiCall({ abi: totalSupplyAbi, calls: vaultAddresses }),
+  ]);
+
+  vaults.forEach((v, i) => {
+    const aFrom = Number(assetsFrom[i]);
+    const sFrom = Number(supplyFrom[i]);
+    const aTo = Number(assetsTo[i]);
+    const sTo = Number(supplyTo[i]);
+
+    // Skip days where the vault hadn't deployed / has no shares yet — share-rate
+    // is undefined in that regime and forwarding the delta would emit NaN.
+    if (!sFrom || !sTo) return;
+
+    // Share-rate is (totalAssets / totalSupply); the underlying yield delivered
+    // to depositors over the window is the rate growth scaled by today's share
+    // supply, which gives the result in underlying-asset native units.
+    const rateFrom = aFrom / sFrom;
+    const rateTo = aTo / sTo;
+    const yieldUnderlying = (rateTo - rateFrom) * sTo;
+
+    // No fee skim — all on-chain yield accrues to depositors via vault
+    // appreciation, so dailyFees == dailySupplySideRevenue per the docs.
+    dailyFees.add(v.underlying, yieldUnderlying, v.label);
+    dailySupplySideRevenue.add(v.underlying, yieldUnderlying, v.label);
+  });
+
+  return {
+    dailyFees,
+    dailyUserFees: dailyFees,
+    dailyRevenue,
+    dailyProtocolRevenue: dailyRevenue,
+    dailySupplySideRevenue,
+  };
+}
+
+const methodology = {
+  Fees: "Yield realised by Yuzu Money's underlying strategies and distributed to depositors via syzUSD / yzPP / yzPrime ERC-4626 share-rate appreciation.",
+  UserFees: "Yield earned on user deposits in syzUSD / yzPP / yzPrime.",
+  Revenue:
+    "Zero by policy. Per Yuzu Money's docs the protocol takes no performance fee on yield; its economic accrual is via the off-chain Reserve Fund surplus/deficit buffer, which is not modelled here.",
+  ProtocolRevenue: "Zero by policy (see Revenue).",
+  SupplySideRevenue:
+    "Full vault yield distributed to syzUSD / yzPP / yzPrime depositors via share-rate appreciation.",
+};
+
+const breakdownMethodology = {
+  Fees: {
+    "syzUSD staking yield":
+      "Daily growth of syzUSD's totalAssets/totalSupply ratio multiplied by today's supply, in yzUSD units.",
+    "yzPP first-loss tranche yield":
+      "Daily growth of yzPP's totalAssets/totalSupply ratio multiplied by today's supply, in USDT0 units. yzPP earns a base yield tracking syzUSD plus a protocol-funded bonus budget from the Reserve Fund.",
+    "yzPrime yield":
+      "Daily growth of yzPrime's totalAssets/totalSupply ratio multiplied by today's supply. yzPrime is the Yuzu Prime product on Monad with continuous yield distribution.",
+  },
+  SupplySideRevenue: {
+    "syzUSD staking yield":
+      "yzUSD stakers receive 100% of the underlying strategy yield via syzUSD share-rate appreciation.",
+    "yzPP first-loss tranche yield":
+      "yzPP holders receive base yield plus a protocol-funded bonus, in exchange for accepting first-loss risk.",
+    "yzPrime yield": "yzPrime holders receive the full Yuzu Prime yield via share-rate appreciation.",
+  },
+};
+
+const adapter: Adapter = {
+  version: 2,
+  adapter: {
+    // yzUSD / syzUSD / yzPP on Plasma launched mid-2025, but early days had
+    // ramping TVL and unreliable per-share rate; start the breakdown from the
+    // window where each vault has stable supply.
+    [CHAIN.PLASMA]: { fetch, start: "2025-08-01" },
+    // yzPrime deployed on Monad in April 2026; supply was effectively zero
+    // until early May, so anchor the start there.
+    [CHAIN.MONAD]: { fetch, start: "2026-05-01" },
+  },
+  methodology,
+  breakdownMethodology,
+  // First-loss yzPP can absorb negative NAV days when realised strategy P&L
+  // outruns the Reserve Fund's coverage budget — the docs explicitly call out
+  // this risk. Allow the signed value through rather than masking it.
+  allowNegativeValue: true,
+};
+
+export default adapter;

--- a/fees/yuzu-money/index.ts
+++ b/fees/yuzu-money/index.ts
@@ -38,8 +38,10 @@ const PLASMA_USDT0 = "0xb8ce59fc3717ada4c02eadf9682a9e934f625ebb";
 const PLASMA_YZUSD = "0x6695c0f8706c5ace3bdf8995073179cca47926dc";
 const MONAD_USD = "0x754704bc059f8c67012fed69bc8a327a5aafb603"; // yzPrime asset()
 
-const chainConfig: Record<string, VaultConfig[]> = {
-  [CHAIN.PLASMA]: [
+const chainConfig: Record<string, { start: string, vaults: VaultConfig[] }> = {
+  [CHAIN.PLASMA]: {
+    start: "2025-08-01",
+    vaults: [
     {
       vault: "0xc8a8df9b210243c55d31c73090f06787ad0a1bf6", // syzUSD
       underlying: PLASMA_YZUSD,
@@ -54,8 +56,10 @@ const chainConfig: Record<string, VaultConfig[]> = {
       shareDecimals: 18,
       label: "yzPP First-Loss Tranche Yield To Holders",
     },
-  ],
-  [CHAIN.MONAD]: [
+  ]},
+  [CHAIN.MONAD]: {
+    start: "2026-05-01",
+    vaults: [
     {
       vault: "0xc9ea90692757831d98ac629f2a0140e02b80a7da", // yzPrime
       underlying: MONAD_USD,
@@ -63,7 +67,7 @@ const chainConfig: Record<string, VaultConfig[]> = {
       shareDecimals: 18,
       label: "yzPrime Yield To Holders",
     },
-  ],
+  ]},
 };
 
 async function fetch(options: FetchOptions): Promise<FetchResultV2> {
@@ -71,10 +75,7 @@ async function fetch(options: FetchOptions): Promise<FetchResultV2> {
   const dailyRevenue = options.createBalances();
   const dailySupplySideRevenue = options.createBalances();
 
-  const vaults = chainConfig[options.chain];
-  if (!vaults?.length) {
-    return { dailyFees, dailyRevenue, dailySupplySideRevenue };
-  }
+  const vaults = chainConfig[options.chain].vaults;
 
   const vaultAddresses = vaults.map((v) => v.vault);
   const totalAssetsAbi = "uint256:totalAssets";
@@ -150,15 +151,9 @@ const breakdownMethodology = {
 
 const adapter: Adapter = {
   version: 2,
-  adapter: {
-    // yzUSD / syzUSD / yzPP on Plasma launched mid-2025, but early days had
-    // ramping TVL and unreliable per-share rate; start the breakdown from the
-    // window where each vault has stable supply.
-    [CHAIN.PLASMA]: { fetch, start: "2025-08-01" },
-    // yzPrime deployed on Monad in April 2026; supply was effectively zero
-    // until early May, so anchor the start there.
-    [CHAIN.MONAD]: { fetch, start: "2026-05-01" },
-  },
+  pullHourly: true,
+  fetch,
+  adapter: chainConfig,
   methodology,
   breakdownMethodology,
   // First-loss yzPP can absorb negative NAV days when realised strategy P&L

--- a/fees/yuzu-money/index.ts
+++ b/fees/yuzu-money/index.ts
@@ -26,10 +26,6 @@ interface VaultConfig {
   vault: string;
   /** Underlying `asset()` of the vault (yzUSD for syzUSD, USDT0 for yzPP, etc.). */
   underlying: string;
-  /** Decimals of the underlying asset (matters for USD pricing). */
-  underlyingDecimals: number;
-  /** Decimals of the vault share token (typically 18). */
-  shareDecimals: number;
   /** Human-readable label used for breakdownMethodology / logging. */
   label: string;
 }
@@ -45,15 +41,11 @@ const chainConfig: Record<string, { start: string, vaults: VaultConfig[] }> = {
     {
       vault: "0xc8a8df9b210243c55d31c73090f06787ad0a1bf6", // syzUSD
       underlying: PLASMA_YZUSD,
-      underlyingDecimals: 18,
-      shareDecimals: 18,
       label: "syzUSD Staking Yield To Stakers",
     },
     {
       vault: "0xebfc8c2fe73c431ef2a371aea9132110aab50dca", // yzPP
       underlying: PLASMA_USDT0,
-      underlyingDecimals: 6,
-      shareDecimals: 18,
       label: "yzPP First-Loss Tranche Yield To Holders",
     },
   ]},
@@ -63,8 +55,6 @@ const chainConfig: Record<string, { start: string, vaults: VaultConfig[] }> = {
     {
       vault: "0xc9ea90692757831d98ac629f2a0140e02b80a7da", // yzPrime
       underlying: MONAD_USD,
-      underlyingDecimals: 6,
-      shareDecimals: 18,
       label: "yzPrime Yield To Holders",
     },
   ]},


### PR DESCRIPTION
## What this adds

A new fees adapter for [Yuzu Money](https://defillama.com/protocol/yuzu-money) — an over-collateralised stablecoin / yield protocol that currently has a TVL adapter but no fees adapter on DefiLlama. Two products, combined ~$51M TVL:

| Product | Chain | What it is |
|---|---|---|
| Yuzu Alpha | Plasma | yzUSD stablecoin + staked syzUSD + first-loss yzPP |
| Yuzu Prime | Monad | yzPrime (continuous yield) |

## Why the model isn't the usual "X% of yield" — straight from their docs

I spent a while looking for a performance fee constant. There isn't one. From their own FAQ at [yuzu-money.gitbook.io/yuzu-money/faq/performance-fee](https://yuzu-money.gitbook.io/yuzu-money/faq/performance-fee), verbatim:

> *"Does Yuzu Money charge a performance fee on the generated yield? ... Rather than charging a performance fee on every positive P&L event — which creates unpredictable yield and amplifies payout volatility — Yuzu Money takes a fixed-fee approach: **no performance fee**, and dynamically adjusted APY distribution to depositors based on the following mechanisms:*
> - *When realized P&L exceeds the distributed yield, the excess accrues to the Reserve Fund.*
> - *When realized P&L falls short, the Reserve Fund covers the gap."*

So 100% of the realised strategy yield is passed back to depositors via the ERC-4626 share-rate of syzUSD / yzPP / yzPrime. The protocol's own economic accrual happens through the **Reserve Fund** (`0xdaef005ae017be5b938a2b321db3dec96e684f68`, labelled "Reserve Fund" on the [Yuzu Alpha key-addresses page](https://yuzu-money.gitbook.io/yuzu-money/yuzu-alpha/key-addresses)) as a long-horizon surplus/deficit buffer — not a per-day skim.

## What the adapter does

For each yield-bearing vault:

1. Read `totalAssets()` and `totalSupply()` at the window endpoints via `fromApi` / `toApi`.
2. `yield_in_underlying = (rate_today − rate_yesterday) × supply_today`, with `rate = totalAssets / totalSupply`.
3. Add the result to `dailyFees` and `dailySupplySideRevenue` in the underlying token (yzUSD for syzUSD, USDT0 for yzPP, the Monad USD stable for yzPrime).

Per the docs above, all that yield goes to depositors, so:

```
dailyFees == dailyUserFees == dailySupplySideRevenue
dailyRevenue == dailyProtocolRevenue == 0   (no per-day fee taken)
```

`allowNegativeValue: true` because yzPP is explicitly the first-loss tranche — on days when realised P&L outruns the Reserve Fund's coverage budget, the vault NAV can briefly drop. Same pattern already accepted on `humidifi` and `compound-v3`.

## On-chain verification (read live today, 2026-05-23)

**Plasma — syzUSD** `0xC8A8DF9B210243c55D31c73090F06787aD0A1Bf6`
- `totalAssets()` = 41,605,018,131,804,600,069,361,966 (18 decimals = ~41.6M yzUSD)
- `totalSupply()` = 39,365,968,824,415,265,927,575,134 (18 decimals = ~39.4M syzUSD)
- Share-rate = **1.0568777900** → +5.69% appreciation since launch ✓
- `asset()` = yzUSD

**Plasma — yzPP** `0xEbFC8C2Fe73C431Ef2A371AeA9132110aaB50DCa`
- `asset()` = USDT0 (`0xb8ce59fc3717ada4c02eadf9682a9e934f625ebb`)
- ERC-4626 confirmed; first-loss tranche per [yzPP docs](https://yuzu-money.gitbook.io/yuzu-money/yuzu-alpha/yuzu-protection-pool-yzpp).

**Monad — yzPrime** `0xc9ea90692757831d98ac629f2a0140e02b80a7da`
- ERC-4626 vault, `asset()` = `0x754704bc059f8c67012fed69bc8a327a5aafb603` (Monad USD stable).
- Confirmed deployed and active from early May 2026 (start date set accordingly).

## Local test output

```
$ pnpm run ts-check     # clean

$ pnpm test fees yuzu-money
plasma    $11.27k    monad $888      aggregate $12.16k
```

Historical sample across recent days:

| Date | Plasma | Monad | Aggregate |
|---|---|---|---|
| 2026-05-23 (today) | $11.27k | $888 | $12.16k |
| 2026-05-21 | $10.62k | $851 | $11.47k |
| 2026-05-15 | $9.62k | $496 | $10.12k |
| 2026-05-10 | $9.40k | $80 | $9.48k |
| 2026-04-25 | **−$135.68k** | — | −$135.68k |

That negative day is real — I went on-chain and pulled yzPP's state at the block window: between 2026-04-24 and 2026-04-25 the vault saw a large redemption *and* a ~4% per-share NAV drop, which is exactly what yzPP's first-loss tranche is designed to absorb (per the [yzPP docs](https://yuzu-money.gitbook.io/yuzu-money/yuzu-alpha/yuzu-protection-pool-yzpp): *"yzPP holders remain exposed to first-loss in the event of any loss incurred by Yuzu Money"*). `allowNegativeValue: true` surfaces the signed value instead of masking it.

Income-statement invariant holds on all positive days:
```
dailyFees == dailyRevenue + dailySupplySideRevenue
$12.16k   ==   $0         + $12.16k    ✓
```

## On the `dailyRevenue == 0` design choice

Two paths I considered and rejected:

1. **Track Reserve Fund balance changes as `dailyProtocolRevenue`.** The Reserve Fund's balance also moves when funds rotate to/from the seven "Main Wallet" strategy execution addresses (also on the [key-addresses page](https://yuzu-money.gitbook.io/yuzu-money/yuzu-alpha/key-addresses)), not only on net P&L accrual. Without more granular event tracking I can't cleanly attribute "this delta = pure protocol revenue", so per Rule 10 I'd rather report `0` honestly than a number I can't defend.

2. **Compute a synthetic protocol cut.** The docs are emphatic that there isn't one. Making one up would be wrong.

Happy to revisit the Reserve Fund tracking in a follow-up if you have a preferred attribution method.

## Files

- `fees/yuzu-money/index.ts` (new, 169 lines, +169 / −0)

## Verification commands

```bash
pnpm run ts-check
pnpm test fees yuzu-money
pnpm test fees yuzu-money 2026-05-21
pnpm test fees yuzu-money 2026-05-15
```

cc @tangten — you've been driving Yuzu's DefiLlama integrations (#19178, #2693, #2320). I built this against the public docs + on-chain reads; happy to defer or rework if you have a different fee model in mind for the protocol.