### PR TITLE
feat(morpho): add Flare chain support to fees adapter

### DIFF
--- a/fees/morpho/index.ts
+++ b/fees/morpho/index.ts
@@ -128,6 +128,16 @@ const MorphoBlues: Record<string, MorphoBlueConfig> = {
     blue: "0xc85CE8ffdA27b646D269516B8d0Fa6ec2E958B55",
     start: "2025-07-10",
   },
+  [CHAIN.FLARE]: {
+    fromBlock: 52378788,
+    blue: "0xF4346F5132e810f80a28487a79c7559d9797E8B0",
+    start: "2025-12-16",
+  },
+  [CHAIN.SEI]: {
+    fromBlock: 166036723,
+    blue: "0xc9cDAc20FCeAAF616f7EB0bb6Cd2c69dcfa9094c",
+    start: "2025-09-02",
+  },
   // [CHAIN.STABLE]: {
   //   fromBlock: 4342501,
   //   blue: "0xa40103088A899514E3fe474cD3cc5bf811b1102e",

--- a/fees/morpho/index.ts
+++ b/fees/morpho/index.ts
@@ -133,11 +133,6 @@ const MorphoBlues: Record<string, MorphoBlueConfig> = {
     blue: "0xF4346F5132e810f80a28487a79c7559d9797E8B0",
     start: "2025-12-16",
   },
-  [CHAIN.SEI]: {
-    fromBlock: 166036723,
-    blue: "0xc9cDAc20FCeAAF616f7EB0bb6Cd2c69dcfa9094c",
-    start: "2025-09-02",
-  },
   // [CHAIN.STABLE]: {
   //   fromBlock: 4342501,
   //   blue: "0xa40103088A899514E3fe474cD3cc5bf811b1102e",


### PR DESCRIPTION
## Summary

Morpho Blue is live on Flare (\$46.7M TVL) but is not currently tracked by the fees adapter. This PR adds Flare using the same \`fromBlock\` (RPC event log) path as Fraxtal, Ink, Optimism, and the other non-API chains already in the adapter. Flare is not supported by the Morpho Blue GraphQL API, so no \`chainId\` field is added.

**Contract address** verified from \`DefiLlama-Adapters/projects/morpho-blue/index.js\`.

> **Note on Sei:** Sei was explored but excluded — \`getLogs\` is disabled for the Sei chain in the DeFiLlama infrastructure due to frequent timeouts, so the \`fromBlock\` path cannot be used there.

## Changes

\`fees/morpho/index.ts\` — one entry added to \`MorphoBlues\`:
\`\`\`ts
[CHAIN.FLARE]: {
  fromBlock: 52378788,
  blue: "0xF4346F5132e810f80a28487a79c7559d9797E8B0",
  start: "2025-12-16",
},
\`\`\`

The existing loop at the bottom of the file auto-generates the adapter chain entries — no further changes required.

## Test plan

- [x] \`CHAIN.FLARE\` defined in \`helpers/chains.ts\`
- [x] Start date (2025-12-16) confirmed from block 52378788 timestamp via RPC
- [x] Contract address cross-referenced against \`DefiLlama-Adapters/projects/morpho-blue/index.js\`
- [x] No competing open PRs for Flare on this adapter