### PR TITLE
fix(renzo): remove pullHourly to restore daily fee reporting

### DIFF
--- a/fees/renzo/index.ts
+++ b/fees/renzo/index.ts
@@ -87,7 +87,6 @@ const fetch = async (options: FetchOptions) => {
 
 const adapter: SimpleAdapter = {
   version: 2,
-  pullHourly: true,
   adapter: {
     [CHAIN.ETHEREUM]: {
       fetch,


### PR DESCRIPTION
## Summary

Renzo has reported $0 fees since 2026-03-07. This PR identifies and fixes the root cause.

## Root Cause

The Renzo Goldsky subgraph uses `interval: day` aggregations. Each daily record has its timestamp set to **midnight UTC** for that day.

On 2026-03-07, commit `9b76088` added `pullHourly: true` to the adapter. With `pullHourly: true`, the system calls the adapter with **1-hour windows** rather than 24-hour windows.

With a 1-hour window (e.g., 14:00–15:00 UTC), the query filter is:
```
timestamp_gte: 14:00_in_microseconds
timestamp_lt: 15:00_in_microseconds
```

The daily aggregate record has `timestamp = midnight`, which is **less than** `timestamp_gte = 14:00`. It is excluded. The subgraph returns empty arrays. All fee amounts are 0.

This only works for the **midnight-to-01:00 UTC** window, where the daily aggregate timestamp falls in range. All other 23 hourly calls return $0.

**Timeline correlation:** Last non-zero Renzo fees on DeFiLlama: 2026-03-06. `pullHourly` commit date: 2026-03-07. Exact match.

## Fix

Remove `pullHourly: true`. The Goldsky subgraph does not support `interval: hour` (confirmed via schema introspection — the query panics with "we only collect fields that are objects or interfaces"). Daily 24-hour windows work correctly with `interval: day` aggregations.

## Verification

Confirmed via direct Goldsky subgraph queries:
- With 24-hour window (midnight to midnight): returns `[{totalFeeAmountWei: "1999971841198812252"}, ...]` ✓
- With 1-hour window at 14:00: returns `[]` ✗

## Test plan

- [ ] After merge, confirm Renzo daily fees reappear on DeFiLlama (typically within a few hours)
- [ ] Verify Goldsky subgraph still live: `https://api.goldsky.com/api/public/project_clsxzkxi8dh7o01zx5kyxdga4/subgraphs/historical-data/stable/gn`