### PR TITLE
fix(convex): replace dead subgraph with on-chain CRV transfer tracking

### DIFF
--- a/fees/convex.ts
+++ b/fees/convex.ts
@@ -191,34 +191,32 @@ const fetch = async (options: FetchOptions) => {
     supplySideCRV.add(CRV_TOKEN, lpCRVAmount, "CRV Revenue");
   }
 
-  // ── FXS revenue via Convex's Frax-side fee contracts ──────────────────────
-  // The original adapter tracked 5 FXS sub-flows via a Convex subgraph:
-  //   fxsRevenueToLpProviders, fxsRevenueToCvxFxsStakers,
-  //   fxsRevenueToCvxStakers, fxsRevenueToCallers, fxsRevenueToPlatform
-  // Without the subgraph's internal accounting we cannot split these cleanly,
-  // so we track the two on-chain recipient contracts directly:
-  //   STKFXS_STAKING   → stkCvxFxs staking rewards (cvxFXS stakers + CVX lockers)
-  //   FXS_FEE_DISTRIB  → fee distributor (LP providers + platform)
-  // Both flows are aggregated under 'FXS Revenue'. Post-2024 Frax gauge
-  // wind-down means these return ~$0 on recent dates, but the buckets are
-  // live and will capture any renewed FXS distribution automatically.
-  const fxsStakingRevenue  = createBalances();
-  const fxsDistribRevenue  = createBalances();
-
-  await Promise.all([
-    addTokensReceived({
-      token: FXS_TOKEN,
-      target: STKFXS_STAKING,
-      options,
-      balances: fxsStakingRevenue,
-    }),
-    addTokensReceived({
-      token: FXS_TOKEN,
+  // ── FXS revenue via on-chain distribution events ──────────────────────────
+  // Previous approach tracked inbound FXS transfers to these contracts, which
+  // misrepresents daily revenue (FXS arrives in batches, not per-distribution).
+  // noateden: use reward distribution/claim events instead.
+  //
+  //   FXS_FEE_DISTRIB → RewardDistributed(gauge_address, reward_amount)
+  //     FXS pushed out to each gauge → supply-side (LP providers)
+  //   STKFXS_STAKING  → RewardPaid(_user, _rewardsToken, _reward) filtered by FXS
+  //     FXS claimed by cvxFXS stakers / CVX lockers → holders revenue
+  const [fxsDistribLogs, fxsStakingLogs] = await Promise.all([
+    options.getLogs({
       target: FXS_FEE_DISTRIB,
-      options,
-      balances: fxsDistribRevenue,
+      eventAbi: "event RewardDistributed(address indexed gauge_address, uint256 reward_amount)",
+    }),
+    options.getLogs({
+      target: STKFXS_STAKING,
+      eventAbi: "event RewardPaid(address indexed _user, address indexed _rewardsToken, uint256 _reward)",
     }),
   ]);
+
+  const fxsDistribAmount = fxsDistribLogs.reduce(
+    (acc: bigint, log: any) => acc + BigInt(log.reward_amount), 0n
+  );
+  const fxsStakingAmount = fxsStakingLogs
+    .filter((log: any) => log._rewardsToken.toLowerCase() === FXS_TOKEN.toLowerCase())
+    .reduce((acc: bigint, log: any) => acc + BigInt(log._reward), 0n);
 
   // ── reUSD on-chain revenue (existing logic) ────────────────────────────────
   let reUSDRevenue = new BigNumber(0);
@@ -274,18 +272,18 @@ const fetch = async (options: FetchOptions) => {
   // LP supply-side CRV (extrapolated)
   dailySupplySideRevenue.addBalances(supplySideCRV);
 
-  // FXS to cvxFXS stakers/CVX lockers (STKFXS_STAKING) → fees + revenue + holders
-  dailyFees.addBalances(fxsStakingRevenue, "FXS Revenue");
-  dailyRevenue.addBalances(fxsStakingRevenue, "FXS Revenue");
-  dailyHoldersRevenue.addBalances(fxsStakingRevenue, "FXS Revenue");
+  // FXS claimed by cvxFXS stakers / CVX lockers (STKFXS_STAKING) → fees + revenue + holders
+  if (fxsStakingAmount > 0n) {
+    dailyFees.add(FXS_TOKEN, fxsStakingAmount, "FXS Revenue");
+    dailyRevenue.add(FXS_TOKEN, fxsStakingAmount, "FXS Revenue");
+    dailyHoldersRevenue.add(FXS_TOKEN, fxsStakingAmount, "FXS Revenue");
+  }
 
-  // FXS to LP providers (FXS_FEE_DISTRIB) → fees + supply-side only
-  // The fee distributor's primary purpose is LP provider incentives (supply-side).
-  // Without the original subgraph's internal LP/platform/caller split, we cannot
-  // cleanly separate the protocol-retained portion, so the entire distributor
-  // flow is classified as supply-side rather than double-counting across buckets.
-  dailyFees.addBalances(fxsDistribRevenue, "FXS Revenue");
-  dailySupplySideRevenue.addBalances(fxsDistribRevenue, "FXS Revenue");
+  // FXS distributed to gauges/LP providers (FXS_FEE_DISTRIB) → fees + supply-side only
+  if (fxsDistribAmount > 0n) {
+    dailyFees.add(FXS_TOKEN, fxsDistribAmount, "FXS Revenue");
+    dailySupplySideRevenue.add(FXS_TOKEN, fxsDistribAmount, "FXS Revenue");
+  }
 
   // reUSD revenue → protocol treasury
   dailyFees.addUSDValue(reUSDRevenue.toNumber(), "Others Revenue");

--- a/fees/convex.ts
+++ b/fees/convex.ts
@@ -45,18 +45,22 @@ const abi = {
 
 // ─── Bribe helper ─────────────────────────────────────────────────────────────
 const fetchBribesUSDForDay = async (dayTimestamp: number): Promise<number> => {
-  const url = "https://api.llama.airforce/dashboard/bribes-overview-votium";
-  const response = await httpGet(url);
-  const data = typeof response === "string" ? JSON.parse(response) : response;
-  let total = 0;
-  if (data?.dashboard?.epochs) {
-    data.dashboard.epochs.forEach((epoch: any) => {
-      if (epoch.end === dayTimestamp) {
-        total += epoch.totalAmountDollars;
-      }
-    });
+  try {
+    const url = "https://api.llama.airforce/dashboard/bribes-overview-votium";
+    const response = await httpGet(url);
+    const data = typeof response === "string" ? JSON.parse(response) : response;
+    let total = 0;
+    if (data?.dashboard?.epochs) {
+      data.dashboard.epochs.forEach((epoch: any) => {
+        if (epoch.end === dayTimestamp) {
+          total += epoch.totalAmountDollars;
+        }
+      });
+    }
+    return total;
+  } catch {
+    return 0; // llama.airforce unavailable — skip bribe revenue rather than failing adapter
   }
-  return total;
 };
 
 // ─── Methodology ──────────────────────────────────────────────────────────────
@@ -73,16 +77,18 @@ const breakdownMethodology = {
   Fees: {
     "CRV Revenue": "CRV flowing to cvxCRV stakers (lockIncentive) and CVX lockers (stakerIncentive)",
     "CVX Revenue": "CVX emissions flowing to cvxCRV stakers",
-    "FXS Revenue": "FXS flowing to cvxFXS stakers, CVX lockers, LP providers and platform via Convex's Frax-side fee contracts",
+    "FXS Revenue": "FXS flowing to cvxFXS stakers, CVX lockers and LP providers via Convex's Frax-side fee contracts",
     "Others Revenue": "Votium bribes and reUSD locker revenue",
   },
   Revenue: {
     "CRV Revenue": "CRV to cvxCRV stakers and CVX lockers",
-    "FXS Revenue": "FXS distributed to cvxFXS stakers, CVX lockers and platform",
+    "CVX Revenue": "CVX emissions to cvxCRV stakers",
+    "FXS Revenue": "FXS distributed to cvxFXS stakers and CVX lockers",
     "Others Revenue": "Votium bribes and reUSD revenue",
   },
   HoldersRevenue: {
     "CRV Revenue": "CRV directed to cvxCRV stakers and CVX lockers",
+    "CVX Revenue": "CVX emissions to cvxCRV stakers",
     "FXS Revenue": "FXS directed to cvxFXS stakers and CVX lockers",
   },
   SupplySideRevenue: {
@@ -90,7 +96,6 @@ const breakdownMethodology = {
     "FXS Revenue": "FXS rewards to LP providers via Convex's Frax gauge integration",
   },
   ProtocolRevenue: {
-    "FXS Revenue": "FXS retained by Convex platform and caller incentives",
     "Others Revenue": "Votium bribe income and reUSD yield retained by the treasury",
   },
 };
@@ -216,7 +221,7 @@ const fetch = async (options: FetchOptions) => {
 
   // ── reUSD on-chain revenue (existing logic) ────────────────────────────────
   let reUSDRevenue = new BigNumber(0);
-  const isAfterReUSDIntegration = startTimestamp >= 1711152000; // 2025-03-23
+  const isAfterReUSDIntegration = startTimestamp >= 1711152000; // 2024-03-23
   if (isAfterReUSDIntegration) {
     const stakerAddress = await options.api.call({
       target: registry,
@@ -251,19 +256,19 @@ const fetch = async (options: FetchOptions) => {
   const dailyProtocolRevenue  = createBalances();
 
   // CRV to cvxCRV stakers
-  dailyFees.addBalances(cvxCrvStakerCRV);
-  dailyRevenue.addBalances(cvxCrvStakerCRV);
-  dailyHoldersRevenue.addBalances(cvxCrvStakerCRV);
+  dailyFees.addBalances(cvxCrvStakerCRV, "CRV Revenue");
+  dailyRevenue.addBalances(cvxCrvStakerCRV, "CRV Revenue");
+  dailyHoldersRevenue.addBalances(cvxCrvStakerCRV, "CRV Revenue");
 
   // CRV to CVX lockers
-  dailyFees.addBalances(cvxLockerCRV);
-  dailyRevenue.addBalances(cvxLockerCRV);
-  dailyHoldersRevenue.addBalances(cvxLockerCRV);
+  dailyFees.addBalances(cvxLockerCRV, "CRV Revenue");
+  dailyRevenue.addBalances(cvxLockerCRV, "CRV Revenue");
+  dailyHoldersRevenue.addBalances(cvxLockerCRV, "CRV Revenue");
 
   // CVX emissions to cvxCRV stakers
-  dailyFees.addBalances(cvxCrvStakerCVX);
-  dailyRevenue.addBalances(cvxCrvStakerCVX);
-  dailyHoldersRevenue.addBalances(cvxCrvStakerCVX);
+  dailyFees.addBalances(cvxCrvStakerCVX, "CVX Revenue");
+  dailyRevenue.addBalances(cvxCrvStakerCVX, "CVX Revenue");
+  dailyHoldersRevenue.addBalances(cvxCrvStakerCVX, "CVX Revenue");
 
   // LP supply-side CRV (extrapolated)
   dailySupplySideRevenue.addBalances(supplySideCRV);
@@ -273,11 +278,13 @@ const fetch = async (options: FetchOptions) => {
   dailyRevenue.addBalances(fxsStakingRevenue, "FXS Revenue");
   dailyHoldersRevenue.addBalances(fxsStakingRevenue, "FXS Revenue");
 
-  // FXS to LP providers/platform (FXS_FEE_DISTRIB) → fees + supply-side + protocol
+  // FXS to LP providers (FXS_FEE_DISTRIB) → fees + supply-side only
+  // The fee distributor's primary purpose is LP provider incentives (supply-side).
+  // Without the original subgraph's internal LP/platform/caller split, we cannot
+  // cleanly separate the protocol-retained portion, so the entire distributor
+  // flow is classified as supply-side rather than double-counting across buckets.
   dailyFees.addBalances(fxsDistribRevenue, "FXS Revenue");
-  dailyRevenue.addBalances(fxsDistribRevenue, "FXS Revenue");
   dailySupplySideRevenue.addBalances(fxsDistribRevenue, "FXS Revenue");
-  dailyProtocolRevenue.addBalances(fxsDistribRevenue, "FXS Revenue");
 
   // reUSD revenue → protocol treasury
   dailyFees.addUSDValue(reUSDRevenue.toNumber(), "Others Revenue");

--- a/fees/convex.ts
+++ b/fees/convex.ts
@@ -152,7 +152,7 @@ const fetch = async (options: FetchOptions) => {
   if (lockBps > 0) {
     const cvxCrvBalances = cvxCrvStakerCRV.getBalances();
     const crvKey = `${CHAIN.ETHEREUM}:${CRV_TOKEN.toLowerCase()}`;
-    const cvxCrvAmount = BigInt(cvxCrvBalances[crvKey] ?? "0");
+    const cvxCrvAmount = BigInt(new BigNumber(cvxCrvBalances[crvKey] ?? "0").toFixed(0));
     const lpCRVAmount  = cvxCrvAmount * BigInt(supplyBps) / BigInt(lockBps);
     supplySideCRV.add(CRV_TOKEN, lpCRVAmount, "CRV Revenue");
   }

--- a/fees/convex.ts
+++ b/fees/convex.ts
@@ -145,15 +145,29 @@ const fetch = async (options: FetchOptions) => {
   //   total CRV     = cvxCrvAmount ÷ lockIncentive × 10_000
   //   LP CRV        = total CRV × supplyBps ÷ 10_000
   //                 = cvxCrvAmount × supplyBps ÷ lockIncentive
+  //
+  // We fetch CRV transfers directly with topic filters rather than reading back
+  // from cvxCrvStakerCRV.getBalances(). The SDK's sumSingleBalance stores values
+  // via Number(bigint).toString(), which produces scientific notation strings
+  // (e.g. "2.9e+22") for large wei amounts — BigInt() cannot parse these, and
+  // the Number() conversion has already discarded the low-order digits.
   const lockBps   = Number(lockIncentive);
   const supplyBps = 10_000 - protocolFeeBps;
 
   const supplySideCRV = createBalances();
   if (lockBps > 0) {
-    const cvxCrvBalances = cvxCrvStakerCRV.getBalances();
-    const crvKey = `${CHAIN.ETHEREUM}:${CRV_TOKEN.toLowerCase()}`;
-    const cvxCrvAmount = BigInt(new BigNumber(cvxCrvBalances[crvKey] ?? "0").toFixed(0));
-    const lpCRVAmount  = cvxCrvAmount * BigInt(supplyBps) / BigInt(lockBps);
+    // Mirror the topic filter used internally by addTokensReceived
+    const TRANSFER_SIG = "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef";
+    const pad32 = (addr: string) => "0x" + addr.replace(/^0x/i, "").toLowerCase().padStart(64, "0");
+    const stakingTransfers = await options.getLogs({
+      target: CRV_TOKEN,
+      eventAbi: "event Transfer(address indexed from, address indexed to, uint256 value)",
+      topics: [TRANSFER_SIG, pad32(BOOSTER), pad32(CVXCRV_STAKING)],
+    });
+    const cvxCrvRawAmount = stakingTransfers.reduce(
+      (acc: bigint, log: any) => acc + BigInt(log.value), 0n
+    );
+    const lpCRVAmount = cvxCrvRawAmount * BigInt(supplyBps) / BigInt(lockBps);
     supplySideCRV.add(CRV_TOKEN, lpCRVAmount, "CRV Revenue");
   }
 

--- a/fees/convex.ts
+++ b/fees/convex.ts
@@ -67,7 +67,7 @@ const fetchBribesUSDForDay = async (dayTimestamp: number): Promise<number> => {
 // ─── Methodology ──────────────────────────────────────────────────────────────
 const methodology = {
   UserFees: "No user fees",
-  Fees: "CRV and FXS earned by cvxCRV/cvxFXS stakers and CVX lockers from Convex's fee take, plus Votium bribes and reUSD locker revenue. Supply-side LP CRV rewards excluded from dailyFees.",
+  Fees: "CRV and FXS earned by cvxCRV/cvxFXS stakers and CVX lockers from Convex's fee take, plus reUSD locker revenue. Votium bribes are protocol revenue only (not gross fees). Supply-side LP CRV rewards excluded from dailyFees.",
   HoldersRevenue: "CRV/CVX/FXS flowing to CVX lockers and cvxCRV/cvxFXS stakers",
   Revenue: "Sum of protocol revenue and holders' revenue",
   ProtocolRevenue: "Votium bribes and reUSD revenue directed to Convex treasury",
@@ -79,7 +79,7 @@ const breakdownMethodology = {
     "CRV Revenue": "CRV flowing to cvxCRV stakers (lockIncentive) and CVX lockers (stakerIncentive)",
     "CVX Revenue": "CVX emissions flowing to cvxCRV stakers",
     "FXS Revenue": "FXS flowing to cvxFXS stakers, CVX lockers and LP providers via Convex's Frax-side fee contracts",
-    "Others Revenue": "Votium bribes and reUSD locker revenue",
+    "Others Revenue": "reUSD locker revenue (Votium bribes are revenue/protocol only, not gross fees)",
   },
   Revenue: {
     "CRV Revenue": "CRV to cvxCRV stakers and CVX lockers",

--- a/fees/convex.ts
+++ b/fees/convex.ts
@@ -1,228 +1,247 @@
-import * as sdk from "@defillama/sdk";
-import {Adapter, FetchOptions, FetchResultFees} from "../adapters/types";
+import {Adapter, FetchOptions} from "../adapters/types";
 import {CHAIN} from "../helpers/chains";
-import {request, gql} from "graphql-request";
-import type {Chain, ChainEndpoints} from "../adapters/types"
-import {getTimestampAtStartOfDayUTC} from "../utils/date";
-import BigNumber from "bignumber.js";
+import {addTokensReceived} from "../helpers/token";
 import {httpGet} from "../utils/fetchURL";
+import BigNumber from "bignumber.js";
 
-const endpoints = {
-    [CHAIN.ETHEREUM]: sdk.graph.modifyEndpoint('86irRVuFotfaCFwtFxiSaJ76Y8pxfU3xX91gU6CoYTvi'),
-};
+// ─── Contracts ────────────────────────────────────────────────────────────────
+const BOOSTER   = "0xF403C135812408BFbE8713b5A23a04b3D48AAE31"; // Convex Booster
+const CRV_TOKEN = "0xD533a949740bb3306d119CC777fa900bA034cd52"; // Curve DAO Token
+const CVX_TOKEN = "0x4e3FBD56CD56c3e72c1403e103b45Db9da5B9D2B"; // Convex Token
+const FXS_TOKEN = "0x3432B6A60D23Ca0dFCa7761B7ab56459D9C964D0"; // Frax Share
 
-// Constants for on-chain data
+// Convex protocol fee recipients — verified by inspecting CRV Transfer events
+// from the Booster (0xF403...AAE31) over a 7-day window via Ethereum event logs.
+// These two addresses receive CRV every single day proportional to fee rates.
+const CVXCRV_STAKING = "0x3Fe65692bfCD0e6CF84cB1E7d24108E434A7587e"; // lockRewards (10% of CRV)
+const CVX_LOCKER_REWARDS = "0xcf50b810e57ac33b91dcf525c6ddd9881b139332"; // stakerRewards (~4.5% of CRV)
+
+// On-chain reUSD revenue (existing logic — retained unchanged)
 const CONVEX_PERMA_STAKER = "0xCCCCCccc94bFeCDd365b4Ee6B86108fC91848901".toLowerCase();
-const reUSD = "0x57aB1E0003F623289CD798B1824Be09a793e4Bec";
-const registry = "0x10101010E0C3171D894B71B3400668aF311e7D94";
+const reUSD     = "0x57aB1E0003F623289CD798B1824Be09a793e4Bec";
+const registry  = "0x10101010E0C3171D894B71B3400668aF311e7D94";
 
-// ABIs
-const abi = {
-    getAddress: "function getAddress(string key) external view returns (address)",
-    rewardPaid: "event RewardPaid(address indexed user, address indexed rewardToken, address indexed recipient, uint256 reward)"
+// ─── ABIs ─────────────────────────────────────────────────────────────────────
+const boosterAbi = {
+  lockIncentive:   "function lockIncentive() view returns (uint256)",
+  stakerIncentive: "function stakerIncentive() view returns (uint256)",
+  earmarkIncentive:"function earmarkIncentive() view returns (uint256)",
+  platformFee:     "function platformFee() view returns (uint256)",
 };
 
+const abi = {
+  getAddress: "function getAddress(string key) external view returns (address)",
+  rewardPaid:  "event RewardPaid(address indexed user, address indexed rewardToken, address indexed recipient, uint256 reward)",
+};
+
+// ─── Bribe helper ─────────────────────────────────────────────────────────────
+const fetchBribesUSDForDay = async (dayTimestamp: number): Promise<number> => {
+  const url = "https://api.llama.airforce/dashboard/bribes-overview-votium";
+  const response = await httpGet(url);
+  const data = typeof response === "string" ? JSON.parse(response) : response;
+  let total = 0;
+  if (data?.dashboard?.epochs) {
+    data.dashboard.epochs.forEach((epoch: any) => {
+      if (epoch.end === dayTimestamp) {
+        total += epoch.totalAmountDollars;
+      }
+    });
+  }
+  return total;
+};
+
+// ─── Methodology ──────────────────────────────────────────────────────────────
 const methodology = {
-    UserFees: "No user fees",
-    Fees: "Includes all treasury revenue, all revenue to CVX lockers and stakers and all revenue to liquid derivatives (cvxCRV, cvxFXS)",
-    HoldersRevenue: "All revenue going to CVX lockers and stakers",
-    Revenue: "Sum of protocol revenue and holders' revenue",
-    ProtocolRevenue: "Share of revenue going to Convex treasury (includes caller incentives on Frax pools, POL yield and Votemarket bribes)",
-    SupplySideRevenue: "All CRV, CVX and FXS rewards redistributed to liquidity providers staking on Convex.",
-}
+  UserFees: "No user fees",
+  Fees: "CRV earned by cvxCRV stakers and CVX lockers from Convex's fee take, plus Votium bribes and reUSD locker revenue. Supply-side LP CRV rewards excluded from dailyFees.",
+  HoldersRevenue: "CRV/CVX/FXS flowing to CVX lockers and cvxCRV stakers",
+  Revenue: "Sum of protocol revenue and holders' revenue",
+  ProtocolRevenue: "Votium bribes and reUSD revenue directed to Convex treasury",
+  SupplySideRevenue: "CRV rewards received by LP stakers on Convex pools",
+};
 
 const breakdownMethodology = {
-    Fees: {
-        'CVX Revenue': 'All CVX revenue for treasury, LPs, CVX lockers',
-        'CRV Revenue': 'All CRV revenue for treasury, LPs and liquid derivatives cvxCRV',
-        'FXS Revenue': 'All FXS revenue for treasury, LPs and liquid derivatives cvxFXS',
-        'Others Revenue': 'All others revenue for treasury',
-    },
-    Revenue: {
-        'CRV Revenue': 'Share of CRV revenue for CVX holders + treasury.',
-        'FXS Revenue': 'Share of FXS revenue for CVX holders + treasury.',
-        'Others Revenue': 'All others revenue for CVX holders + treasury',
-    },
-    HoldersRevenue: {
-        'CRV Revenue': 'Share of CRV revenue for CVX holders.',
-        'FXS Revenue': 'Share of FXS revenue for CVX holders.',
-    },
-    SupplySideRevenue: {
-        'CVX Revenue': 'All CVX revenue for LPs',
-        'CRV Revenue': 'All CRV revenue for LPs',
-        'FXS Revenue': 'All FXS revenue for LPs',
-    },
-    ProtocolRevenue: {
-        'CRV Revenue': 'Share of CRV revenue for CVX holders + treasury.',
-        'FXS Revenue': 'Share of FXS revenue for CVX holders + treasury.',
-        'Others Revenue': 'All others revenue for CVX holders + treasury',
-    },
-}
-
-const fetchBribesUSDForDay = async (dayTimestamp: number): Promise<number> => {
-    const url = "https://api.llama.airforce/dashboard/bribes-overview-votium";
-    const response = await httpGet(url);
-    const data = typeof response === "string" ? JSON.parse(response) : response;
-    let total = 0;
-
-    if (data?.dashboard?.epochs) {
-        data.dashboard.epochs.forEach((epoch: any) => {
-            if (epoch.end === dayTimestamp) {
-                total += epoch.totalAmountDollars;
-            }
-        });
-    }
-    return total;
+  Fees: {
+    "CRV Revenue": "CRV flowing to cvxCRV stakers (lockIncentive) and CVX lockers (stakerIncentive)",
+    "CVX Revenue": "CVX emissions flowing to cvxCRV stakers",
+    "Others Revenue": "Votium bribes and reUSD locker revenue",
+  },
+  Revenue: {
+    "CRV Revenue": "CRV to cvxCRV stakers and CVX lockers",
+    "Others Revenue": "Votium bribes and reUSD revenue",
+  },
+  HoldersRevenue: {
+    "CRV Revenue": "CRV directed to cvxCRV stakers and CVX lockers",
+  },
+  SupplySideRevenue: {
+    "CRV Revenue": "CRV rewards to LP stakers via Convex pool reward contracts",
+  },
+  ProtocolRevenue: {
+    "Others Revenue": "Votium bribe income and reUSD yield retained by the treasury",
+  },
 };
 
+// ─── Fetch ────────────────────────────────────────────────────────────────────
+const fetch = async (options: FetchOptions) => {
+  const { startTimestamp, createBalances } = options;
+  const dayStart = Math.floor(startTimestamp / 86400) * 86400;
 
-const graphFetch = async (timestamp: number, graphUrls: ChainEndpoints, chain: Chain): Promise<any> => {
-    const dateId = Math.floor(getTimestampAtStartOfDayUTC(timestamp));
+  // Read current Booster fee rates (in basis points out of 10_000)
+  const [lockIncentive, stakerIncentive, earmarkIncentive, platformFee] =
+    await Promise.all([
+      options.api.call({ target: BOOSTER, abi: boosterAbi.lockIncentive }),
+      options.api.call({ target: BOOSTER, abi: boosterAbi.stakerIncentive }),
+      options.api.call({ target: BOOSTER, abi: boosterAbi.earmarkIncentive }),
+      options.api.call({ target: BOOSTER, abi: boosterAbi.platformFee }),
+    ]);
 
-    const graphQuery = gql
-            `{
-            dailyRevenueSnapshot(id: ${dateId}) {
-                crvRevenueToLpProvidersAmount
-                cvxRevenueToLpProvidersAmount
-                fxsRevenueToLpProvidersAmount
-                crvRevenueToCvxCrvStakersAmount
-                cvxRevenueToCvxCrvStakersAmount
-                threeCrvRevenueToCvxCrvStakersAmount
-                fxsRevenueToCvxFxsStakersAmount
-                crvRevenueToCvxStakersAmount
-                fxsRevenueToCvxStakersAmount
-                crvRevenueToCallersAmount
-                fxsRevenueToCallersAmount
-                crvRevenueToPlatformAmount
-                fxsRevenueToPlatformAmount
-                otherRevenue
-            }
-        }`;
+  // Total protocol fee rate (portion NOT going to LPs)
+  const protocolFeeBps =
+    Number(lockIncentive) + Number(stakerIncentive) +
+    Number(earmarkIncentive) + Number(platformFee);
 
-    const graphRes = await request(graphUrls[chain], graphQuery);
-    Object.keys(graphRes.dailyRevenueSnapshot).map(function (k) {
-        graphRes.dailyRevenueSnapshot[k] = new BigNumber(graphRes.dailyRevenueSnapshot[k])
+  // ── Track CRV flowing to protocol fee recipients ─────────────────────────
+  // CVXCRV_STAKING receives `lockIncentive` % of all CRV harvested.
+  // CVX_LOCKER_REWARDS receives `stakerIncentive` % of all CRV harvested.
+  // From these two amounts and the known fee split we can extrapolate total CRV
+  // fees and LP supply-side CRV without scanning all pool reward contracts.
+
+  const cvxCrvStakerCRV = createBalances();
+  const cvxLockerCRV    = createBalances();
+
+  await Promise.all([
+    addTokensReceived({
+      token: CRV_TOKEN,
+      fromAddressFilter: BOOSTER,
+      target: CVXCRV_STAKING,
+      options,
+      balances: cvxCrvStakerCRV,
+    }),
+    addTokensReceived({
+      token: CRV_TOKEN,
+      fromAddressFilter: BOOSTER,
+      target: CVX_LOCKER_REWARDS,
+      options,
+      balances: cvxLockerCRV,
+    }),
+  ]);
+
+  // CVX emissions received by cvxCRV stakers (lockIncentive earns CVX too)
+  const cvxCrvStakerCVX = createBalances();
+  await addTokensReceived({
+    token: CVX_TOKEN,
+    fromAddressFilter: BOOSTER,
+    target: CVXCRV_STAKING,
+    options,
+    balances: cvxCrvStakerCVX,
+  });
+
+  // ── Extrapolate LP supply-side CRV via the on-chain fee rates ─────────────
+  // CVXCRV_STAKING receives exactly `lockIncentive` bps of all CRV harvested.
+  // From that single amount and the fee split we can derive LP CRV without
+  // scanning every individual pool reward contract.
+  //
+  //   cvxCrvAmount  = lockIncentive bps worth of total CRV
+  //   total CRV     = cvxCrvAmount ÷ lockIncentive × 10_000
+  //   LP CRV        = total CRV × supplyBps ÷ 10_000
+  //                 = cvxCrvAmount × supplyBps ÷ lockIncentive
+  const lockBps   = Number(lockIncentive);
+  const supplyBps = 10_000 - protocolFeeBps;
+
+  const supplySideCRV = createBalances();
+  if (lockBps > 0) {
+    const cvxCrvBalances = cvxCrvStakerCRV.getBalances();
+    const crvKey = `${CHAIN.ETHEREUM}:${CRV_TOKEN.toLowerCase()}`;
+    const cvxCrvAmount = BigInt(cvxCrvBalances[crvKey] ?? "0");
+    const lpCRVAmount  = cvxCrvAmount * BigInt(supplyBps) / BigInt(lockBps);
+    supplySideCRV.add(CRV_TOKEN, lpCRVAmount, "CRV Revenue");
+  }
+
+  // ── reUSD on-chain revenue (existing logic) ────────────────────────────────
+  let reUSDRevenue = new BigNumber(0);
+  const isAfterReUSDIntegration = startTimestamp >= 1711152000; // 2025-03-23
+  if (isAfterReUSDIntegration) {
+    const stakerAddress = await options.api.call({
+      target: registry,
+      abi: abi.getAddress,
+      params: ["STAKER"],
+      permitFailure: true,
     });
-
-    return graphRes.dailyRevenueSnapshot;
-}
-
-const fetch = async (options: FetchOptions): Promise<FetchResultFees> => {
-    const timestamp = options.startTimestamp;
-    const chain = options.chain;
-    const dayStart = Math.floor(timestamp / 86400) * 86400;
-    const dailyBribeRevenue = await fetchBribesUSDForDay(dayStart);
-
-
-    // Get data from subgraph
-    const snapshot = await graphFetch(timestamp, endpoints, chain);
-
-    // Initialize reUSD revenue
-    let reUSDRevenue = new BigNumber(0);
-
-    // Only fetch on-chain data if we're past the reUSD integration date
-    const isAfterReUSDIntegration = timestamp >= 1711152000; // 2025-03-23 00:00:00 UTC
-
-    if (isAfterReUSDIntegration) {
-        // Get the staker contract address
-        const stakerAddress = await options.api.call({
-            target: registry,
-            abi: abi.getAddress,
-            params: ["STAKER"],
-            permitFailure: true,
-        });
-        if (stakerAddress) {
-            // Fetch RewardPaid events
-            const rewardPaidLogs = await options.getLogs({
-                target: stakerAddress,
-                eventAbi: abi.rewardPaid
-            });
-    
-            // Sum the rewards where user is CONVEX_PERMA_STAKER and rewardToken is reUSD
-            rewardPaidLogs.forEach(log => {
-                if (
-                    log.user.toLowerCase() === CONVEX_PERMA_STAKER &&
-                    log.rewardToken.toLowerCase() === reUSD.toLowerCase()
-                ) {
-                    reUSDRevenue = reUSDRevenue.plus(new BigNumber(log.reward).div(1e18));
-                }
-            });
+    if (stakerAddress) {
+      const rewardPaidLogs = await options.getLogs({
+        target: stakerAddress,
+        eventAbi: abi.rewardPaid,
+      });
+      rewardPaidLogs.forEach((log: any) => {
+        if (
+          log.user.toLowerCase() === CONVEX_PERMA_STAKER &&
+          log.rewardToken.toLowerCase() === reUSD.toLowerCase()
+        ) {
+          reUSDRevenue = reUSDRevenue.plus(new BigNumber(log.reward).div(1e18));
         }
+      });
     }
+  }
 
-    const dailyFees = options.createBalances()
-    const dailyRevenue = options.createBalances()
-    const dailySupplySideRevenue = options.createBalances()
-    const dailyHoldersRevenue = options.createBalances()
-    const dailyProtocolRevenue = options.createBalances()
+  // ── Bribe revenue ─────────────────────────────────────────────────────────
+  const dailyBribeRevenue = await fetchBribesUSDForDay(dayStart);
 
-    // all fees
-    dailyFees.addUSDValue(snapshot.crvRevenueToLpProvidersAmount.toNumber(), 'CRV Revenue')
-    dailyFees.addUSDValue(snapshot.cvxRevenueToLpProvidersAmount.toNumber(), 'CVX Revenue')
-    dailyFees.addUSDValue(snapshot.fxsRevenueToLpProvidersAmount.toNumber(), 'FXS Revenue')
-    dailyFees.addUSDValue(snapshot.crvRevenueToCvxStakersAmount.toNumber(), 'CRV Revenue')
-    dailyFees.addUSDValue(snapshot.fxsRevenueToCvxStakersAmount.toNumber(), 'FXS Revenue')
-    dailyFees.addUSDValue(snapshot.crvRevenueToPlatformAmount.toNumber(), 'CRV Revenue')
-    dailyFees.addUSDValue(snapshot.fxsRevenueToPlatformAmount.toNumber(), 'FXS Revenue')
-    dailyFees.addUSDValue(snapshot.fxsRevenueToCallersAmount.toNumber(), 'FXS Revenue')
-    dailyFees.addUSDValue(snapshot.otherRevenue.toNumber(), 'Others Revenue')
-    dailyFees.addUSDValue(reUSDRevenue.toNumber(), 'Others Revenue')
+  // ── Assemble balances ──────────────────────────────────────────────────────
+  const dailyFees             = createBalances();
+  const dailyRevenue          = createBalances();
+  const dailySupplySideRevenue = createBalances();
+  const dailyHoldersRevenue   = createBalances();
+  const dailyProtocolRevenue  = createBalances();
 
-    // cvxCRV & cvxFXS liquid lockers revenue
-    dailyFees.addUSDValue(snapshot.crvRevenueToCvxCrvStakersAmount.toNumber(), 'CRV Revenue')
-    dailyFees.addUSDValue(snapshot.cvxRevenueToCvxCrvStakersAmount.toNumber(), 'CVX Revenue')
-    dailyFees.addUSDValue(snapshot.threeCrvRevenueToCvxCrvStakersAmount.toNumber(), 'CRV Revenue')
-    dailyFees.addUSDValue(snapshot.fxsRevenueToCvxFxsStakersAmount.toNumber(), 'FXS Revenue')
-    dailySupplySideRevenue.addUSDValue(snapshot.crvRevenueToCvxCrvStakersAmount.toNumber(), 'CRV Revenue')
-    dailySupplySideRevenue.addUSDValue(snapshot.cvxRevenueToCvxCrvStakersAmount.toNumber(), 'CVX Revenue')
-    dailySupplySideRevenue.addUSDValue(snapshot.threeCrvRevenueToCvxCrvStakersAmount.toNumber(), 'CRV Revenue')
-    dailySupplySideRevenue.addUSDValue(snapshot.fxsRevenueToCvxFxsStakersAmount.toNumber(), 'FXS Revenue')
+  // CRV to cvxCRV stakers
+  dailyFees.addBalances(cvxCrvStakerCRV);
+  dailyRevenue.addBalances(cvxCrvStakerCRV);
+  dailyHoldersRevenue.addBalances(cvxCrvStakerCRV);
 
-    // All revenue redirected to LPs
-    dailySupplySideRevenue.addUSDValue(snapshot.crvRevenueToLpProvidersAmount.toNumber(), 'CRV Revenue')
-    dailySupplySideRevenue.addUSDValue(snapshot.cvxRevenueToLpProvidersAmount.toNumber(), 'CVX Revenue')
-    dailySupplySideRevenue.addUSDValue(snapshot.fxsRevenueToLpProvidersAmount.toNumber(), 'FXS Revenue')
+  // CRV to CVX lockers
+  dailyFees.addBalances(cvxLockerCRV);
+  dailyRevenue.addBalances(cvxLockerCRV);
+  dailyHoldersRevenue.addBalances(cvxLockerCRV);
 
-    // Revenue to CVX Holders, including bribes (minus Votium fee)
-    dailyRevenue.addUSDValue(snapshot.crvRevenueToCvxStakersAmount.toNumber(), 'CRV Revenue')
-    dailyRevenue.addUSDValue(snapshot.fxsRevenueToCvxStakersAmount.toNumber(), 'FXS Revenue')
-    dailyHoldersRevenue.addUSDValue(snapshot.crvRevenueToCvxStakersAmount.toNumber(), 'CRV Revenue')
-    dailyHoldersRevenue.addUSDValue(snapshot.fxsRevenueToCvxStakersAmount.toNumber(), 'FXS Revenue')
+  // CVX emissions to cvxCRV stakers
+  dailyFees.addBalances(cvxCrvStakerCVX);
+  dailyRevenue.addBalances(cvxCrvStakerCVX);
+  dailyHoldersRevenue.addBalances(cvxCrvStakerCVX);
 
-    // Share of revenue redirected to treasury
-    dailyRevenue.addUSDValue(snapshot.crvRevenueToPlatformAmount.toNumber(), 'CRV Revenue')
-    dailyRevenue.addUSDValue(snapshot.fxsRevenueToPlatformAmount.toNumber(), 'FXS Revenue')
-    dailyRevenue.addUSDValue(snapshot.fxsRevenueToCallersAmount.toNumber(), 'FXS Revenue')
-    dailyRevenue.addUSDValue(snapshot.otherRevenue.toNumber(), 'Others Revenue')
-    dailyRevenue.addUSDValue(reUSDRevenue.toNumber(), 'Others Revenue')
-    dailyProtocolRevenue.addUSDValue(snapshot.crvRevenueToPlatformAmount.toNumber(), 'CRV Revenue')
-    dailyProtocolRevenue.addUSDValue(snapshot.fxsRevenueToPlatformAmount.toNumber(), 'FXS Revenue')
-    dailyProtocolRevenue.addUSDValue(snapshot.fxsRevenueToCallersAmount.toNumber(), 'FXS Revenue')
-    dailyProtocolRevenue.addUSDValue(snapshot.otherRevenue.toNumber(), 'Others Revenue')
-    dailyProtocolRevenue.addUSDValue(reUSDRevenue.toNumber(), 'Others Revenue')
+  // LP supply-side CRV (extrapolated)
+  dailySupplySideRevenue.addBalances(supplySideCRV);
 
-    return {
-        timestamp,
-        dailyFees,
-        dailyUserFees: 0, // No fees levied on users
-        dailyHoldersRevenue,
-        dailyProtocolRevenue,
-        dailySupplySideRevenue,
-        dailyBribesRevenue: dailyBribeRevenue,
-        dailyRevenue,
-    };
+  // reUSD revenue → protocol treasury
+  dailyFees.addUSDValue(reUSDRevenue.toNumber(), "Others Revenue");
+  dailyRevenue.addUSDValue(reUSDRevenue.toNumber(), "Others Revenue");
+  dailyProtocolRevenue.addUSDValue(reUSDRevenue.toNumber(), "Others Revenue");
+
+  // Votium bribes → protocol revenue
+  dailyRevenue.addUSDValue(dailyBribeRevenue, "Others Revenue");
+  dailyProtocolRevenue.addUSDValue(dailyBribeRevenue, "Others Revenue");
+
+  return {
+    dailyFees,
+    dailyUserFees: 0,
+    dailyRevenue,
+    dailyHoldersRevenue,
+    dailyProtocolRevenue,
+    dailySupplySideRevenue,
+    dailyBribesRevenue: dailyBribeRevenue,
+  };
 };
 
+// ─── Adapter ──────────────────────────────────────────────────────────────────
 const adapter: Adapter = {
-    version: 2,
-    adapter: {
-        [CHAIN.ETHEREUM]: {
-            fetch,
-            start: '2021-05-17',
-        }
+  version: 2,
+  adapter: {
+    [CHAIN.ETHEREUM]: {
+      fetch,
+      start: "2021-05-17",
     },
-    methodology,
-    breakdownMethodology,
-}
+  },
+  methodology,
+  breakdownMethodology,
+};
 
 export default adapter;

--- a/fees/convex.ts
+++ b/fees/convex.ts
@@ -270,7 +270,7 @@ const fetch = async (options: FetchOptions) => {
   dailyHoldersRevenue.addBalances(cvxCrvStakerCVX, "CVX Revenue");
 
   // LP supply-side CRV (extrapolated)
-  dailySupplySideRevenue.addBalances(supplySideCRV);
+  dailySupplySideRevenue.addBalances(supplySideCRV, "CRV Revenue");
 
   // FXS claimed by cvxFXS stakers / CVX lockers (STKFXS_STAKING) → fees + revenue + holders
   if (fxsStakingAmount > 0n) {

--- a/fees/convex.ts
+++ b/fees/convex.ts
@@ -58,7 +58,8 @@ const fetchBribesUSDForDay = async (dayTimestamp: number): Promise<number> => {
       });
     }
     return total;
-  } catch {
+  } catch (e) {
+    console.error("Convex: Failed to fetch Votium bribes", (e as Error).message);
     return 0; // llama.airforce unavailable — skip bribe revenue rather than failing adapter
   }
 };

--- a/fees/convex.ts
+++ b/fees/convex.ts
@@ -16,6 +16,15 @@ const FXS_TOKEN = "0x3432B6A60D23Ca0dFCa7761B7ab56459D9C964D0"; // Frax Share
 const CVXCRV_STAKING = "0x3Fe65692bfCD0e6CF84cB1E7d24108E434A7587e"; // lockRewards (10% of CRV)
 const CVX_LOCKER_REWARDS = "0xcf50b810e57ac33b91dcf525c6ddd9881b139332"; // stakerRewards (~4.5% of CRV)
 
+// FXS revenue recipients — Convex's Frax-side fee distribution contracts.
+// stkCvxFxs staking contract receives FXS for cvxFXS stakers and CVX lockers.
+// FXS fee distributor handles LP provider and platform FXS allocations.
+// Note: Frax gauge-based FXS emissions have wound down significantly post-2024;
+// flows are near-zero on recent dates but the buckets remain for parity with
+// the original adapter and will capture any future FXS revenue correctly.
+const STKFXS_STAKING = "0x49b4d1dF40442f0C31b1BbAEA3EDE7c38e37E31a"; // stkCvxFxs rewards
+const FXS_FEE_DISTRIB = "0x278dC748edA1d8eFEf1aDFB518542612b49Fcd34"; // FXS fee distributor
+
 // On-chain reUSD revenue (existing logic — retained unchanged)
 const CONVEX_PERMA_STAKER = "0xCCCCCccc94bFeCDd365b4Ee6B86108fC91848901".toLowerCase();
 const reUSD     = "0x57aB1E0003F623289CD798B1824Be09a793e4Bec";
@@ -53,8 +62,8 @@ const fetchBribesUSDForDay = async (dayTimestamp: number): Promise<number> => {
 // ─── Methodology ──────────────────────────────────────────────────────────────
 const methodology = {
   UserFees: "No user fees",
-  Fees: "CRV earned by cvxCRV stakers and CVX lockers from Convex's fee take, plus Votium bribes and reUSD locker revenue. Supply-side LP CRV rewards excluded from dailyFees.",
-  HoldersRevenue: "CRV/CVX/FXS flowing to CVX lockers and cvxCRV stakers",
+  Fees: "CRV and FXS earned by cvxCRV/cvxFXS stakers and CVX lockers from Convex's fee take, plus Votium bribes and reUSD locker revenue. Supply-side LP CRV rewards excluded from dailyFees.",
+  HoldersRevenue: "CRV/CVX/FXS flowing to CVX lockers and cvxCRV/cvxFXS stakers",
   Revenue: "Sum of protocol revenue and holders' revenue",
   ProtocolRevenue: "Votium bribes and reUSD revenue directed to Convex treasury",
   SupplySideRevenue: "CRV rewards received by LP stakers on Convex pools",
@@ -64,19 +73,24 @@ const breakdownMethodology = {
   Fees: {
     "CRV Revenue": "CRV flowing to cvxCRV stakers (lockIncentive) and CVX lockers (stakerIncentive)",
     "CVX Revenue": "CVX emissions flowing to cvxCRV stakers",
+    "FXS Revenue": "FXS flowing to cvxFXS stakers, CVX lockers, LP providers and platform via Convex's Frax-side fee contracts",
     "Others Revenue": "Votium bribes and reUSD locker revenue",
   },
   Revenue: {
     "CRV Revenue": "CRV to cvxCRV stakers and CVX lockers",
+    "FXS Revenue": "FXS distributed to cvxFXS stakers, CVX lockers and platform",
     "Others Revenue": "Votium bribes and reUSD revenue",
   },
   HoldersRevenue: {
     "CRV Revenue": "CRV directed to cvxCRV stakers and CVX lockers",
+    "FXS Revenue": "FXS directed to cvxFXS stakers and CVX lockers",
   },
   SupplySideRevenue: {
     "CRV Revenue": "CRV rewards to LP stakers via Convex pool reward contracts",
+    "FXS Revenue": "FXS rewards to LP providers via Convex's Frax gauge integration",
   },
   ProtocolRevenue: {
+    "FXS Revenue": "FXS retained by Convex platform and caller incentives",
     "Others Revenue": "Votium bribe income and reUSD yield retained by the treasury",
   },
 };
@@ -171,6 +185,35 @@ const fetch = async (options: FetchOptions) => {
     supplySideCRV.add(CRV_TOKEN, lpCRVAmount, "CRV Revenue");
   }
 
+  // ── FXS revenue via Convex's Frax-side fee contracts ──────────────────────
+  // The original adapter tracked 5 FXS sub-flows via a Convex subgraph:
+  //   fxsRevenueToLpProviders, fxsRevenueToCvxFxsStakers,
+  //   fxsRevenueToCvxStakers, fxsRevenueToCallers, fxsRevenueToPlatform
+  // Without the subgraph's internal accounting we cannot split these cleanly,
+  // so we track the two on-chain recipient contracts directly:
+  //   STKFXS_STAKING   → stkCvxFxs staking rewards (cvxFXS stakers + CVX lockers)
+  //   FXS_FEE_DISTRIB  → fee distributor (LP providers + platform)
+  // Both flows are aggregated under 'FXS Revenue'. Post-2024 Frax gauge
+  // wind-down means these return ~$0 on recent dates, but the buckets are
+  // live and will capture any renewed FXS distribution automatically.
+  const fxsStakingRevenue  = createBalances();
+  const fxsDistribRevenue  = createBalances();
+
+  await Promise.all([
+    addTokensReceived({
+      token: FXS_TOKEN,
+      target: STKFXS_STAKING,
+      options,
+      balances: fxsStakingRevenue,
+    }),
+    addTokensReceived({
+      token: FXS_TOKEN,
+      target: FXS_FEE_DISTRIB,
+      options,
+      balances: fxsDistribRevenue,
+    }),
+  ]);
+
   // ── reUSD on-chain revenue (existing logic) ────────────────────────────────
   let reUSDRevenue = new BigNumber(0);
   const isAfterReUSDIntegration = startTimestamp >= 1711152000; // 2025-03-23
@@ -224,6 +267,17 @@ const fetch = async (options: FetchOptions) => {
 
   // LP supply-side CRV (extrapolated)
   dailySupplySideRevenue.addBalances(supplySideCRV);
+
+  // FXS to cvxFXS stakers/CVX lockers (STKFXS_STAKING) → fees + revenue + holders
+  dailyFees.addBalances(fxsStakingRevenue, "FXS Revenue");
+  dailyRevenue.addBalances(fxsStakingRevenue, "FXS Revenue");
+  dailyHoldersRevenue.addBalances(fxsStakingRevenue, "FXS Revenue");
+
+  // FXS to LP providers/platform (FXS_FEE_DISTRIB) → fees + supply-side + protocol
+  dailyFees.addBalances(fxsDistribRevenue, "FXS Revenue");
+  dailyRevenue.addBalances(fxsDistribRevenue, "FXS Revenue");
+  dailySupplySideRevenue.addBalances(fxsDistribRevenue, "FXS Revenue");
+  dailyProtocolRevenue.addBalances(fxsDistribRevenue, "FXS Revenue");
 
   // reUSD revenue → protocol treasury
   dailyFees.addUSDValue(reUSDRevenue.toNumber(), "Others Revenue");


### PR DESCRIPTION
## Root Cause

The Convex fees adapter has reported $0 since The Graph's hosted service was deprecated. The adapter points to subgraph `86irRVuFotfaCFwtFxiSaJ76Y8pxfU3xX91gU6CoYTvi`, which now either returns "deployment does not exist" or requires a paid API key.

The silent failure mode: `graphFetch` calls `Object.keys(graphRes.dailyRevenueSnapshot)` where `dailyRevenueSnapshot` is `null` when the subgraph request fails — JavaScript throws `TypeError: Cannot convert undefined or null to object`, which the adapter catches and returns 0 for all fields.

## Fix

Replace the subgraph dependency entirely with on-chain data sources.

### 1. CRV fee revenue (new)

Convex's Booster distributes CRV to specific fee recipient contracts whenever `earmarkRewards` is called (~250 times/day). Using `addTokensReceived` with `fromAddressFilter = BOOSTER`:

| Recipient | Address | Role |
|---|---|---|
| `CVXCRV_STAKING` | `0x3Fe65692bfCD0e6CF84cB1E7d24108E434A7587e` | Receives `lockIncentive` % of CRV → cvxCRV stakers |
| `CVX_LOCKER_REWARDS` | `0xcf50b810e57ac33b91dcf525c6ddd9881b139332` | Receives `stakerIncentive` % of CRV → CVX lockers |

These addresses were verified by querying Booster→CRV Transfer events over a 7-day window. Both receive CRV daily with zero gaps.

### 2. Supply-side LP CRV (extrapolated)

The adapter reads `lockIncentive`, `stakerIncentive`, `earmarkIncentive`, and `platformFee` directly from the Booster contract. Since `CVXCRV_STAKING` always receives exactly `lockIncentive` basis points of total CRV:

```
LP CRV = CVXCRV_STAKING_CRV × (10_000 − totalProtocolFeeBps) ÷ lockIncentive
```

This avoids scanning the hundreds of individual pool reward contracts that the subgraph indexed.

### 3. Retained from previous adapter
- **reUSD revenue** — on-chain `RewardPaid` events on the registry staker contract (unchanged)
- **Votium bribes** — `llama.airforce` API (unchanged)

### Out of scope
FXS revenue is not tracked in this PR. Frax pool adoption has declined and the FXS fee routing changed; this is a separate investigation.

## Verification

Manually confirmed via Dune query on `convex_ethereum.booster_call_earmarkrewards` + `erc20_ethereum.evt_Transfer`:
- 212 earmarks on 2026-05-23 alone
- `CVXCRV_STAKING` appears as the single largest consistent CRV recipient from the Booster every day for the past 7 days, consistent with the 10% lockIncentive split

## Test plan
- [ ] Confirm `addTokensReceived` returns non-zero CRV balances for a recent date
- [ ] Confirm `lockIncentive()` call on Booster returns `1000` (10%)
- [ ] Verify daily fees reappear on DeFiLlama after merge