### PR TITLE
[fix] Carbon: seggregate and fix oi adadpter from dex/carbon

### DIFF
--- a/dexs/carbon/index.ts
+++ b/dexs/carbon/index.ts
@@ -11,7 +11,6 @@ async function fetch(_a: any, _b: any, options: FetchOptions): Promise<FetchResu
 
   const dailyFees = options.createBalances();
   const dailyVolume = options.createBalances();
-  const openInterestAtEnd = options.createBalances();
 
   const response = await fetchURL("https://app.carbon.inc/analytics");
 
@@ -20,7 +19,7 @@ async function fetch(_a: any, _b: any, options: FetchOptions): Promise<FetchResu
   );
 
   const analyticsJson = JSON.parse(analyticsData[1]);
-  const { platformChartsData, intentXFEOIAnalytics } = analyticsJson.props.pageProps;
+  const { platformChartsData } = analyticsJson.props.pageProps;
   const {volumeChart, revenueChart} = platformChartsData;
 
   const today = formatDate();
@@ -35,17 +34,11 @@ async function fetch(_a: any, _b: any, options: FetchOptions): Promise<FetchResu
     dailyFees.addUSDValue(todaysRevenueData);
   });
 
-  Object.values(intentXFEOIAnalytics).forEach((value: any) => {
-    const todaysOIData = +value.find((data: any) => data.date === options.dateString).totalOI;
-    openInterestAtEnd.addUSDValue(todaysOIData);
-  });
-
   return {
     dailyVolume,
     dailyFees,
     dailyRevenue: dailyFees,
     dailyProtocolRevenue: dailyFees,
-    openInterestAtEnd,
   };
 };
 

--- a/open-interest/carbon.ts
+++ b/open-interest/carbon.ts
@@ -1,0 +1,22 @@
+import { FetchOptions, SimpleAdapter } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+import fetchURL from "../utils/fetchURL";
+
+const fetch = async (_a: any, _b: any, options: FetchOptions) => {
+  const date = new Date(options.startOfDay * 1000).toISOString().slice(0, 10);
+  const payload = String(await fetchURL("https://app.carbon.inc/analytics")).match(/<script id="__NEXT_DATA__" type="application\/json">([\s\S]*?)<\/script>/)?.[1];
+  if (!payload) throw new Error("Carbon analytics page missing __NEXT_DATA__ payload");
+
+  const oi = JSON.parse(payload).props.pageProps.intentXFEOIAnalytics["8453"]
+    .find((i: any) => i.date === date)?.totalOI;
+  if (oi == null) throw new Error(`Carbon OI missing for ${date}`);
+
+  return { openInterestAtEnd: Number(oi) };
+};
+
+export default {
+  version: 1,
+  chains: [CHAIN.BASE],
+  fetch,
+  start: "2025-07-09",
+} as SimpleAdapter;


### PR DESCRIPTION
## Maintainer Note
- OI is missing in the `defillama-server`
- Fees are still present in `dexs/carbon` for now. They should be moved to a dedicated `fees/carbon` adapter in a follow-up for cleaner separation between volume, fees, and open interest.

## Summary
- Adds a dedicated Carbon open interest adapter for Base under `open-interest/carbon`.
- Removes `openInterestAtEnd` from `dexs/carbon`.

## Changes
- Added `open-interest/carbon.ts` to fetch Carbon OI from the Carbon analytics page `__NEXT_DATA__` payload.
- Uses `options.startOfDay` to derive the daily `YYYY-MM-DD` key used by Carbon’s `intentXFEOIAnalytics[8453]` data.
- Keeps `dexs/carbon/index.ts` focused on its existing volume and fee/revenue fields.

## Methodology
- Carbon OI is sourced from the official analytics payload at `https://app.carbon.inc/analytics`.
- The adapter reads Base chain analytics from `intentXFEOIAnalytics["8453"]`.
- Start date is `2025-07-09`, matching the first available OI row in the analytics payload.

## Data Quality / Risk
- The OI adapter depends on Carbon’s Next.js analytics payload shape remaining available server-side.

## Tests
- `pnpm test dexs carbon`
- `pnpm test open-interest carbon`