### PR TITLE
[fix] Citrex-Perps: track open interest from api 

### DIFF
--- a/dexs/citrex-markets/index.ts
+++ b/dexs/citrex-markets/index.ts
@@ -26,14 +26,17 @@ const fetch = async (timestamp: number) => {
   const dayTimestamp = getUniqStartOfTodayTimestamp(new Date(timestamp * 1000));
 
   // Divide by 10^18 to convert from min units to USDC human-readable as per the contract
-  let dailyVolume = response.reduce((acc, item) => {
+  const dailyVolume = response.reduce((acc, item) => {
     return acc + Number(item.volume);
   }, 0);
 
-  dailyVolume = dailyVolume / 10 ** 18;
+  const openInterestAtEnd = response.reduce((acc, item) => {
+    return acc + Number(item.openInterest);
+  }, 0);
 
   return {
-    dailyVolume: dailyVolume?.toString(),
+    dailyVolume: (dailyVolume / 10 ** 18)?.toString(),
+    openInterestAtEnd: (openInterestAtEnd / 10 ** 18).toString(),
     timestamp: dayTimestamp,
   };
 };

--- a/dexs/citrex-markets/index.ts
+++ b/dexs/citrex-markets/index.ts
@@ -30,16 +30,16 @@ const fetch = async (timestamp: number) => {
   const baseUnit = new BigNumber(10).pow(18);
 
   const dailyVolume = response.reduce((acc, item) => {
-    return acc.plus(item.volume || "0");
+    return acc.plus(item.volume);
   }, new BigNumber(0));
 
   const openInterestAtEnd = response.reduce((acc, item) => {
-    return acc.plus(item.openInterest || "0");
+    return acc.plus(item.openInterest);
   }, new BigNumber(0));
 
   return {
-    dailyVolume: dailyVolume.div(baseUnit).toString(),
-    openInterestAtEnd: openInterestAtEnd.div(baseUnit).toString(),
+    dailyVolume: dailyVolume.div(baseUnit),
+    openInterestAtEnd: openInterestAtEnd.div(baseUnit),
     timestamp: dayTimestamp,
   };
 };

--- a/dexs/citrex-markets/index.ts
+++ b/dexs/citrex-markets/index.ts
@@ -1,3 +1,4 @@
+import BigNumber from "bignumber.js";
 import { getUniqStartOfTodayTimestamp } from "../../helpers/getUniSubgraphVolume";
 import { httpGet } from "../../utils/fetchURL";
 import { CHAIN } from "../../helpers/chains";
@@ -26,17 +27,19 @@ const fetch = async (timestamp: number) => {
   const dayTimestamp = getUniqStartOfTodayTimestamp(new Date(timestamp * 1000));
 
   // Divide by 10^18 to convert from min units to USDC human-readable as per the contract
+  const baseUnit = new BigNumber(10).pow(18);
+
   const dailyVolume = response.reduce((acc, item) => {
-    return acc + Number(item.volume);
-  }, 0);
+    return acc.plus(item.volume || "0");
+  }, new BigNumber(0));
 
   const openInterestAtEnd = response.reduce((acc, item) => {
-    return acc + Number(item.openInterest);
-  }, 0);
+    return acc.plus(item.openInterest || "0");
+  }, new BigNumber(0));
 
   return {
-    dailyVolume: (dailyVolume / 10 ** 18)?.toString(),
-    openInterestAtEnd: (openInterestAtEnd / 10 ** 18).toString(),
+    dailyVolume: dailyVolume.div(baseUnit).toString(),
+    openInterestAtEnd: openInterestAtEnd.div(baseUnit).toString(),
     timestamp: dayTimestamp,
   };
 };


### PR DESCRIPTION
## Summary
- Adds open interest reporting for the Citrex Markets DEX adapter on Sei.
- Uses the existing Citrex 24h ticker API response to include `openInterestAtEnd` alongside daily volume.

## Changes
- Updated `dexs/citrex-markets/index.ts` to sum `openInterest` across all returned USDC perpetual markets.
- Scales the aggregated open interest by `10 ** 18`, matching the existing volume unit conversion.
- Preserves the existing adapter methodology text and current 24h ticker data source.

## Methodology
- `dailyVolume` continues to use `https://api.citrex.markets/v1/ticker/24hr`.
- `openInterestAtEnd` is calculated from the same endpoint by summing each market's `openInterest` field and converting from base units to human-readable USDC.

## Tests
- `pnpm test dexs citrex-markets`