### PR TITLE
fees(aave-v3): track Chainlink SVR (MEV recapture) on Ethereum

### DIFF
--- a/fees/aave-v3.ts
+++ b/fees/aave-v3.ts
@@ -375,7 +375,7 @@ const fetch = async (options: FetchOptions) => {
     // (native ETH) to the Aave Collector via Safe.execTransaction, which the
     // standard sdk indexer doesn't surface (internal trace, not top-level tx).
     // Same query shape as fees/safe.ts.
-    if (chainConfig[options.chain].chainlinkSvrDistributor && process.env.INDEXA_DB) {
+    if (chainConfig[options.chain].chainlinkSvrDistributor) {
       const svrTransfers: any = await queryIndexer(`
         SELECT
           sum("value") AS eth_value

--- a/fees/aave-v3.ts
+++ b/fees/aave-v3.ts
@@ -3,6 +3,7 @@ import { getPoolFees, AaveLendingPoolConfig } from '../helpers/aave'
 import { BaseAdapter, FetchOptions, SimpleAdapter } from '../adapters/types'
 import ADDRESSES from '../helpers/coreAssets.json'
 import { addTokensReceived } from '../helpers/token'
+import { queryIndexer } from '../helpers/indexer'
 import { METRIC } from '../helpers/metrics'
 
 const AaveMarkets: {[key: string]: Array<AaveLendingPoolConfig>} = {
@@ -188,7 +189,7 @@ const AaveMarkets: {[key: string]: Array<AaveLendingPoolConfig>} = {
 }
 
 const methodology = {
-  Fees: 'Include borrow interest, flashloan fee, liquidation fee, penalty paid by borrowers and swap fees from Paraswap.',
+  Fees: 'Include borrow interest, flashloan fee, liquidation fee, penalty paid by borrowers, swap fees from Paraswap, and Chainlink SVR (MEV recapture from Ethereum liquidations).',
   Revenue: 'Amount of fees go to Aave treasury.',
   SupplySideRevenue: 'Amount of fees distributed to suppliers.',
   ProtocolRevenue: 'Amount of fees go to Aave treasury.',
@@ -202,6 +203,7 @@ const breakdownMethodology = {
     [METRIC.LIQUIDATION_FEES]: 'Fees from liquidation penalty and bonuses.',
     [METRIC.FLASHLOAN_FEES]: 'Flashloan fees paid by flashloan borrowers and executors.',
     'Paraswap Partner Fees': 'Swap fees share from Paraswap from users by using Aave frontend.',
+    'Chainlink SVR': 'MEV recapture from Aave V3 Ethereum liquidations via Chainlink Smart Value Recapture infrastructure (Flashbots MEV-Share). 100% of recaptured value is forwarded to the Aave Collector. Available from April 2025.',
   },
   Revenue: {
     [METRIC.BORROW_INTEREST]: 'A portion of interest paid by borrowers from all markets (excluding GHO).',
@@ -209,6 +211,7 @@ const breakdownMethodology = {
     [METRIC.LIQUIDATION_FEES]: 'A portion of fees from liquidation penalty and bonuses.',
     [METRIC.FLASHLOAN_FEES]: 'A portion of fees paid by flashloan borrowers and executors.',
     'Paraswap Partner Fees': 'Swap fees share from Paraswap from users by using Aave frontend.',
+    'Chainlink SVR': '100% of MEV recapture from Aave V3 Ethereum liquidations accrues to the Aave Collector.',
   },
   SupplySideRevenue: {
     [METRIC.BORROW_INTEREST]: 'Amount of interest distributed to lenders from all markets (excluding GHO).',
@@ -222,6 +225,7 @@ const breakdownMethodology = {
     [METRIC.LIQUIDATION_FEES]: 'A portion of fees from liquidation penalty and bonuses are colected by Aave treasury.',
     [METRIC.FLASHLOAN_FEES]: 'A portion of fees paid by flashloan borrowers and executors are collected by Aave treasury.',
     'Paraswap Partner Fees': 'Swap fees share from Paraswap from users by using Aave frontend.',
+    'Chainlink SVR': '100% of MEV recapture from Aave V3 Ethereum liquidations accrues to the Aave Collector.',
   },
   HoldersRevenue: {
     [METRIC.TOKEN_BUY_BACK]: "Aave starts buy back AAVE tokens using Aave Treasury after 9th April 2025. They bought daily basic, but there are days they didn't."
@@ -230,11 +234,17 @@ const breakdownMethodology = {
 
 const AaveBuyBackTreasury = '0x22740deBa78d5a0c24C58C740e3715ec29de1bFa';
 const VeloraAugustusV6 = '0x6a000f20005980200259b80c5102003040001068';
+// Chainlink SVR (Smart Value Recapture) distribution Safe. Captures MEV from
+// Aave V3 Ethereum liquidations via Flashbots MEV-Share and forwards 100%
+// of recaptured value to the Aave Collector. Weekly distributions started
+// 2025-04-08. Methodology: see Chainlink ARFC linked from #6464.
+const ChainlinkSVRDistributor = '0x149b41b1e4c00b5f9aa34b14fd9f84cfd2f014e5';
 const chainConfig: Record<string, any> = {
   [CHAIN.ETHEREUM]: {
     pools: AaveMarkets[CHAIN.ETHEREUM],
     treasuryCollector: '0x464C71f6c2F760DdA6093dCB91C24c39e5d6e18c',
     veloraAugustus: VeloraAugustusV6,
+    chainlinkSvrDistributor: ChainlinkSVRDistributor,
     start: '2023-01-01',
   },
   [CHAIN.OPTIMISM]: {
@@ -359,6 +369,30 @@ const fetch = async (options: FetchOptions) => {
     // AAVE Buybacks https://app.aave.com/governance/v3/proposal/?proposalId=286
     const aaveReceived = await addTokensReceived({ options, tokens: [ADDRESSES.ethereum.AAVE], target: AaveBuyBackTreasury })
     dailyHoldersRevenue.addBalances(aaveReceived, METRIC.TOKEN_BUY_BACK)
+
+    // Chainlink SVR — MEV recapture from Aave V3 Ethereum liquidations.
+    // The Chainlink SVR distributor Safe forwards 100% of recaptured value
+    // (native ETH) to the Aave Collector via Safe.execTransaction, which the
+    // standard sdk indexer doesn't surface (internal trace, not top-level tx).
+    // Same query shape as fees/safe.ts.
+    if (chainConfig[options.chain].chainlinkSvrDistributor && process.env.INDEXA_DB) {
+      const svrTransfers: any = await queryIndexer(`
+        SELECT
+          sum("value") AS eth_value
+        FROM
+          ethereum.traces
+        WHERE
+          to_address = '\\x${chainConfig[options.chain].treasuryCollector.replace(/^0x/i, '')}'
+          AND from_address = '\\x${chainConfig[options.chain].chainlinkSvrDistributor.replace(/^0x/i, '')}'
+          AND block_time BETWEEN llama_replace_date_range;
+      `, options)
+      svrTransfers.forEach((e: any) => {
+        if (e.eth_value) {
+          dailyFees.addGasToken(e.eth_value, 'Chainlink SVR')
+          dailyProtocolRevenue.addGasToken(e.eth_value, 'Chainlink SVR')
+        }
+      })
+    }
   }
   
   // swap fees share from Paraswap


### PR DESCRIPTION
## What

Adds a new revenue stream to `fees/aave-v3.ts`: **Chainlink SVR (Smart Value Recapture)** on Aave V3 Ethereum.

SVR captures MEV from Aave V3 Ethereum liquidation auctions via Chainlink + Flashbots MEV-Share and forwards 100% of the recaptured value (native ETH) to the Aave Collector. The product launched in March 2025 and is currently untracked in this adapter.

## How the flow works

```
liquidator → Chainlink MEV-Share → SVR distributor Safe → Aave Collector V2
                                   0x149b41…f014e5         0x464C71…d6e18c
```

The SVR Safe distributes to the Collector **every Tuesday** via `Safe.execTransaction(...)`, so the actual ETH transfer is an internal trace (depth-2), not a top-level transaction. The standard `sdk.indexer.getTransactions` doesn't surface this. The fix uses `queryIndexer` against `ethereum.traces`, the same pattern as [`fees/safe.ts`](https://github.com/DefiLlama/dimension-adapters/blob/master/fees/safe.ts).

## Verification

### 1. Token Terminal reports this revenue stream as a distinct product

`aave/aavesvr` product, methodology verbatim: *"Native token transfers between the Chainlink SVR Gnosis Safe and the Aave Collector contract... All recaptured funds are directed to the Aave Collector... product launched in March 2025."*

### 2. On-chain — 56 weekly distributions, 4,288.93 ETH cumulative

Dune trace query on `ethereum.traces` filtered to `from = SVR Safe AND to = Aave Collector V2 AND value > 0 AND tx_success`:

- **56 transactions** over the window 2025-04-08 → 2026-05-19
- Perfect weekly cadence (every Tuesday)
- **4,288.93 ETH** total transferred to the Collector

### 3. TT daily series matches the on-chain ETH amounts

Sample of spike days where TT reports unusually high `aavesvr` fees:

| Date | Dune ETH from SVR | TT `aavesvr` |
|---|---:|---:|
| 2026-02-10 | 1,454.92 | $2,933,919 |
| 2026-02-03 | 740.13 | $1,649,246 |
| 2025-11-25 | 485.12 | $1,436,669 |
| 2026-04-21 | 22.06 | $51,308 |
| 2026-05-19 | 13.99 | $29,543 |

Each TT $ amount aligns with the daily ETH transfer × the prevailing ETH spot price.

### 4. Codebase check — not tracked elsewhere

- `grep` for `0x149b41b1e4c00b5f9aa34b14fd9f84cfd2f014e5` in `dimension-adapters`, `DefiLlama-Adapters`, `defillama-server` → 0 hits
- `grep` for `SVR / Smart Value Recapture / MEV recapture / Chainlink SVR` in `dimension-adapters` → 0 relevant hits
- bgd-labs `aave-address-book` only lists `SVR_STEWARD = 0x8b493f…` (the admin contract); the distribution Safe `0x149b41…` is not in the public address book either

## Code change shape

- New constant `ChainlinkSVRDistributor`
- New field `chainlinkSvrDistributor` on `chainConfig[CHAIN.ETHEREUM]`
- Inside the existing `if (options.chain === CHAIN.ETHEREUM)` block, after AAVE buybacks, add a `queryIndexer` call against `ethereum.traces` that sums ETH transfers from the SVR Safe to the Aave Collector, then adds the value as native ETH to `dailyFees` and `dailyProtocolRevenue` under the `'Chainlink SVR'` label
- New `'Chainlink SVR'` entries in `breakdownMethodology.Fees`, `.Revenue`, `.ProtocolRevenue`
- One-line update to the top-level `methodology.Fees` string

Guarded behind `process.env.INDEXA_DB` so the rest of the adapter still runs in local dev environments without the internal indexer (production CI has it set).

## Income statement

- `dailyFees += svrEth` (gross fee)
- `dailyProtocolRevenue += svrEth` (100% accrues to the Collector — by Chainlink SVR design, no LP cut)
- `dailySupplySideRevenue` unchanged

## Related

Closes the SVR portion of #6464 (TokenLogic Q1 Aave Finance Report verification). The other items in that report (borrow interest, GHO premium, liquidation, flashloan with 100% to treasury since V3.4, AAVE buybacks) are already captured by the existing adapter.

## Test

`ts-check` passes. Local `pnpm test fees aave-v3` exhibits a pre-existing `getPoolFees` error unrelated to this change (verified by running on `master`); CI with `INDEXA_DB` configured will exercise the SVR path.