### PR TITLE
[feat] Katana-Perps: track open-interest for katana-perps via api

### DIFF
--- a/open-interest/katana-perps-oi.ts
+++ b/open-interest/katana-perps-oi.ts
@@ -1,11 +1,11 @@
 import type { FetchOptions, SimpleAdapter } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
-import { fetchURLAutoHandleRateLimit } from "../utils/fetchURL";
+import fetchURL from "../utils/fetchURL";
 
 const MARKETS_API_URL = "https://api-perps.katana.network/v1/markets";
 
 const fetch = async (_: FetchOptions) => {
-  const markets = await fetchURLAutoHandleRateLimit(MARKETS_API_URL);
+  const markets = await fetchURL(MARKETS_API_URL);
   const openInterestAtEnd = markets.reduce(
     (sum: number, market: any) => sum + Number(market.openInterest) * Number(market.indexPrice),
     0
@@ -21,7 +21,6 @@ const adapter: SimpleAdapter = {
   fetch,
   chains: [CHAIN.KATANA],
   runAtCurrTime: true,
-  start: "2026-01-12",
 };
 
 export default adapter;

--- a/open-interest/katana-perps.ts
+++ b/open-interest/katana-perps.ts
@@ -1,0 +1,27 @@
+import type { FetchOptions, SimpleAdapter } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+import { fetchURLAutoHandleRateLimit } from "../utils/fetchURL";
+
+const MARKETS_API_URL = "https://api-perps.katana.network/v1/markets";
+
+const fetch = async (_: FetchOptions) => {
+  const markets = await fetchURLAutoHandleRateLimit(MARKETS_API_URL);
+  const openInterestAtEnd = markets.reduce(
+    (sum: number, market: any) => sum + Number(market.openInterest) * Number(market.indexPrice),
+    0
+  );
+
+  return {
+    openInterestAtEnd,
+  };
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  fetch,
+  chains: [CHAIN.KATANA],
+  runAtCurrTime: true,
+  start: "2026-01-12",
+};
+
+export default adapter;


### PR DESCRIPTION
> Maintainer
> Katana Perps does not expose aggregate market OI through the exchange contract; on-chain reconstruction would require indexing wallet-level positions from trade/liquidation/deleverage events. The public markets API exposes per-market base OI and index price directly, so this adapter uses that source and sums `openInterest * indexPrice` across markets.

## Summary
- Adds a Katana Perps open interest adapter on Katana.
- Reports `openInterestAtEnd` from the summed per-market notional OI.

## Changes
- Added `open-interest/katana-perps.ts`.
- Fetches `https://api-perps.katana.network/v1/markets` with `fetchURLAutoHandleRateLimit`.
- Calculates OI as `sum(openInterest * indexPrice)` across all returned markets.
- Uses `chains: [CHAIN.KATANA]`, `runAtCurrTime: true`, and start date `2026-01-12`.

## Methodology
- Katana Perps market `openInterest` is base-denominated.
- Adapter converts each market to USD using the market `indexPrice`, then sums all market notionals.

## Tests
- `pnpm test open-interest katana-perps`