### PR TITLE
fees/mayan: add Monad, HyperEVM and Sui chains

### DIFF
--- a/fees/mayan.ts
+++ b/fees/mayan.ts
@@ -32,6 +32,12 @@ const getChainKey = (chain: string) => {
       return 'base';
     case CHAIN.OPTIMISM:
       return 'optimism';
+    case CHAIN.MONAD:
+      return 'monad';
+    case CHAIN.HYPERLIQUID:
+      return 'hyperevm';
+    case CHAIN.SUI:
+      return 'sui';
     default:
       return '';
   }
@@ -109,6 +115,15 @@ const adapter: SimpleAdapter = {
     },
     [CHAIN.OPTIMISM]: {
       fetch: fetch(CHAIN.OPTIMISM),
+    },
+    [CHAIN.MONAD]: {
+      fetch: fetch(CHAIN.MONAD),
+    },
+    [CHAIN.HYPERLIQUID]: {
+      fetch: fetch(CHAIN.HYPERLIQUID),
+    },
+    [CHAIN.SUI]: {
+      fetch: fetch(CHAIN.SUI),
     },
   },
 };


### PR DESCRIPTION
## Summary

Mayan's public explorer-api `chains-overview` endpoint exposes outflow volume for 14 chains today, but the adapter's `getChainKey()` switch only mapped 8. Unmapped chains silently returned 0 via `fetchChainVolume()`, so material Mayan activity on Monad, HyperEVM and Sui was being dropped on the floor.

This PR adds those three chains, keeping the existing methodology (0.1% of outflow volume per chain) unchanged.

## What the API actually reports

Pulling `https://explorer-api.mayan.finance/v3/stats/chains-overview?timeRange=30d` and summing outflow:

| chain | 30d outflow | in adapter today? |
| --- | ---: | --- |
| ethereum | $107.1M | yes |
| solana | $80.5M | yes |
| arbitrum | $39.0M | yes |
| **monad** | **$38.2M** | **no — added in this PR** |
| base | $34.3M | yes |
| bsc | $28.4M | yes |
| polygon | $12.6M | yes |
| **sui** | **$10.6M** | **no — added in this PR** |
| avalanche | $9.7M | yes |
| **hyperevm** | **$9.7M** | **no — added in this PR** (mapped via `CHAIN.HYPERLIQUID`) |
| optimism | $1.8M | yes |
| unichain | $0.3M | skipped (too small) |
| linea | $75k | skipped (too small) |
| hypercore | $0 | skipped (no activity) |

## Sanity check the API is the same source the adapter already uses

24h outflow summed across all chains in `chains-overview`: \$9,236,898
Mayan's own `v3/stats/overview` `last24h.volume`: \$8,834,454
Ratio: 104.6% — same number to within ~5%.

So `chains-overview.outFlow` already is the volume figure the adapter has always multiplied by 0.1%. The 8-chain switch is the only thing constraining coverage.

## Local test

```
$ pnpm run test fees mayan

🦙 Running MAYAN adapter 🦙
---------------------------------------------------
Start Date:	Sat, 23 May 2026 00:00:00 GMT
End Date:	Sun, 24 May 2026 00:00:00 GMT
---------------------------------------------------

chain       | Daily fees | Daily revenue
---         | ---        | ---
ethereum    | 2.69 k     | 2.69 k
arbitrum    | 949.00     | 949.00
avax        | 138.00     | 138.00
bsc         | 933.00     | 933.00
polygon     | 312.00     | 312.00
solana      | 2.32 k     | 2.32 k
base        | 614.00     | 614.00
optimism    | 20.00      | 20.00
monad       | 523.00     | 523.00
hyperliquid | 394.00     | 394.00
sui         | 115.00     | 115.00
Aggregate   | 9.01 k     | 9.01 k
```

The three added chains contribute \$1,032/day today, ~11% of the day's aggregate.

## Why these three chains specifically (and not unichain / linea / hypercore)

`v3/stats/chains-overview?timeRange=30d` is the volume floor I used. monad/sui/hyperevm each have ≥ \$9M/30d (clearly material, with monad currently the 4th-largest Mayan chain by volume). unichain at \$306k/30d and linea at \$75k/30d are below the threshold where a missing fee adapter entry meaningfully moves the number — happy to add them in a follow-up if the team prefers full chain coverage.

## Notes

- "Allow edits by maintainers" is on.
- `runAtCurrTime: true` + the API's hard-coded `timeRange=24h` means there's no historical backfill — production will just start picking up the three new chains' fees going forward, no risk of distorting old days.
- The adapter methodology text says \"Mayan WH Swap\" specifically, but `chains-overview.outFlow` covers all Mayan products (Swift + WH Swap + MCTP) — the 104.6% match against `v3/stats/overview` total volume above shows that. The text predates Swift/MCTP and could be tightened separately; this PR doesn't change behavior on the 8 existing chains, only fills the chain gap with the same methodology.