### PR TITLE
[fix] Bluefin-Perps: track bluefin-pro oi via api

### DIFF
--- a/dexs/bluefin-pro/index.ts
+++ b/dexs/bluefin-pro/index.ts
@@ -5,14 +5,17 @@ import { httpGet } from "../../utils/fetchURL";
 const fetch = async () => {
   const exchangeInfo = (await httpGet(`https://api.sui-prod.bluefin.io/v1/exchange/info`))
   let volume = 0;
+  let openInterest = 0;
   for(const market of exchangeInfo.markets){
     if(market.status !== "ACTIVE") continue;
-    const {quoteVolume24hrE9} = (await httpGet(`https://api.sui-prod.bluefin.io/v1/exchange/ticker?symbol=${market.symbol}`))
+    const {quoteVolume24hrE9, openInterestE9} = (await httpGet(`https://api.sui-prod.bluefin.io/v1/exchange/ticker?symbol=${market.symbol}`))
     volume += Number(quoteVolume24hrE9)
+    openInterest += Number(openInterestE9)
   }
 
   return {
     dailyVolume: volume/1e9,
+    openInterestAtEnd: openInterest / 1e9,
   };
 };
 

--- a/dexs/bluefin-pro/index.ts
+++ b/dexs/bluefin-pro/index.ts
@@ -1,14 +1,15 @@
 import { SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
-import { httpGet } from "../../utils/fetchURL";
+import { fetchURLAutoHandleRateLimit } from "../../utils/fetchURL";
 
 const fetch = async () => {
-  const exchangeInfo = (await httpGet(`https://api.sui-prod.bluefin.io/v1/exchange/info`))
+  const exchangeInfo = (await fetchURLAutoHandleRateLimit(`https://api.sui-prod.bluefin.io/v1/exchange/info`))
+  const tickers = (await fetchURLAutoHandleRateLimit(`https://api.sui-prod.bluefin.io/v1/exchange/tickers`))
+  const activeMarkets = new Set(exchangeInfo.markets.filter((market: any) => market.status === "ACTIVE").map((market: any) => market.symbol));
   let volume = 0;
   let openInterest = 0;
-  for(const market of exchangeInfo.markets){
-    if(market.status !== "ACTIVE") continue;
-    const {quoteVolume24hrE9, openInterestE9} = (await httpGet(`https://api.sui-prod.bluefin.io/v1/exchange/ticker?symbol=${market.symbol}`))
+  for(const { symbol, quoteVolume24hrE9, openInterestE9 } of tickers){
+    if(!activeMarkets.has(symbol)) continue;
     volume += Number(quoteVolume24hrE9)
     openInterest += Number(openInterestE9)
   }


### PR DESCRIPTION
## Summary
- Adds Bluefin Pro open interest to the existing Sui DEX adapter.
- Uses Bluefin Pro’s public ticker API alongside the existing volume fetch.

## Changes
- Updated `dexs/bluefin-pro/index.ts` to sum `openInterestE9` across active markets.
- Reports `openInterestAtEnd` in addition to `dailyVolume`.

## Tests
- `pnpm test dexs bluefin-pro`