### PR TITLE
[feat] Dipcoin-Perps: track open interest via api

### DIFF
--- a/open-interest/dipcoin-perps.ts
+++ b/open-interest/dipcoin-perps.ts
@@ -6,7 +6,7 @@ const API = "https://gray-api.dipcoin.io";
 
 const fetch = async () => {
   const marketsRes = await fetchURLAutoHandleRateLimit(`${API}/api/perp-market-api/list`);
-  const markets = (marketsRes.data || []).filter((market: any) => market.status === 1 && market.visible !== false);
+  const markets = marketsRes.data.filter((market: any) => market.status === 1 && market.visible !== false);
   let openInterest = 0;
 
   for (const market of markets) {

--- a/open-interest/dipcoin-perps.ts
+++ b/open-interest/dipcoin-perps.ts
@@ -21,7 +21,6 @@ const adapter: SimpleAdapter = {
   version: 2,
   fetch,
   chains: [CHAIN.SUI],
-  start: "2025-10-15",
   runAtCurrTime: true,
 };
 

--- a/open-interest/dipcoin-perps.ts
+++ b/open-interest/dipcoin-perps.ts
@@ -11,7 +11,7 @@ const fetch = async () => {
 
   for (const market of markets) {
     const ticker = await fetchURLAutoHandleRateLimit(`${API}/api/perp-market-api/ticker?symbol=${encodeURIComponent(market.symbol)}`);
-    openInterest += Number(ticker.data?.openInterest || 0) / 1e18;
+    openInterest += Number(ticker.data.openInterest) / 1e18;
   }
 
   return { openInterestAtEnd: openInterest };

--- a/open-interest/dipcoin-perps.ts
+++ b/open-interest/dipcoin-perps.ts
@@ -1,0 +1,28 @@
+import { SimpleAdapter } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+import { fetchURLAutoHandleRateLimit } from "../utils/fetchURL";
+
+const API = "https://gray-api.dipcoin.io";
+
+const fetch = async () => {
+  const marketsRes = await fetchURLAutoHandleRateLimit(`${API}/api/perp-market-api/list`);
+  const markets = (marketsRes.data || []).filter((market: any) => market.status === 1 && market.visible !== false);
+  let openInterest = 0;
+
+  for (const market of markets) {
+    const ticker = await fetchURLAutoHandleRateLimit(`${API}/api/perp-market-api/ticker?symbol=${encodeURIComponent(market.symbol)}`);
+    openInterest += Number(ticker.data?.openInterest || 0) / 1e18;
+  }
+
+  return { openInterestAtEnd: openInterest };
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  fetch,
+  chains: [CHAIN.SUI],
+  start: "2025-10-15",
+  runAtCurrTime: true,
+};
+
+export default adapter;


### PR DESCRIPTION
https://defillama.com/protocol/dipcoin-perps
## Summary
- Adds a Dipcoin Perps open interest adapter for Sui.

## Changes
- Added `open-interest/dipcoin-perps.ts`.
- Fetches active visible markets from Dipcoin’s public API and sums per-market `openInterest` from ticker responses.
- Uses `fetchURLAutoHandleRateLimit` for API requests.

## Tests
- `pnpm test open-interest dipcoin-perps`