### PR TITLE
fees/sushiswap-agg: track RP9, RP9_1, RP9_2, RP10, RP11

### DIFF
--- a/fees/sushiswap-agg.ts
+++ b/fees/sushiswap-agg.ts
@@ -14,15 +14,80 @@ const RP8_ADDRESS: any = {
   [CHAIN.KATANA]: '0x2905d7e4D048d29954F81b02171DD313F457a4a4',
 }
 
+const RP9_ADDRESS: any = {
+  [CHAIN.ETHEREUM]: '0x81602EF321C46d73f5Ba7f476947AE1a862957dc',
+  [CHAIN.ARBITRUM]: '0x81602EF321C46d73f5Ba7f476947AE1a862957dc',
+  [CHAIN.OPTIMISM]: '0x81602EF321C46d73f5Ba7f476947AE1a862957dc',
+  [CHAIN.BASE]: '0x81602EF321C46d73f5Ba7f476947AE1a862957dc',
+  [CHAIN.POLYGON]: '0x81602EF321C46d73f5Ba7f476947AE1a862957dc',
+  [CHAIN.MOONBEAM]: '0x81602EF321C46d73f5Ba7f476947AE1a862957dc',
+  [CHAIN.POLYGON_ZKEVM]: '0x81602EF321C46d73f5Ba7f476947AE1a862957dc',
+  [CHAIN.MANTLE]: '0x81602EF321C46d73f5Ba7f476947AE1a862957dc',
+  [CHAIN.KATANA]: '0x81602EF321C46d73f5Ba7f476947AE1a862957dc',
+}
+
+const RP9_1_ADDRESS: any = {
+  [CHAIN.ETHEREUM]: '0x3b0aa7d38bf3c103bf02d1de2e37568cbed3d6e8',
+  [CHAIN.ARBITRUM]: '0x3b0aa7d38bf3c103bf02d1de2e37568cbed3d6e8',
+  [CHAIN.OPTIMISM]: '0x3b0aa7d38bf3c103bf02d1de2e37568cbed3d6e8',
+  [CHAIN.BASE]: '0x3b0aa7d38bf3c103bf02d1de2e37568cbed3d6e8',
+  [CHAIN.POLYGON]: '0x3b0aa7d38bf3c103bf02d1de2e37568cbed3d6e8',
+  [CHAIN.POLYGON_ZKEVM]: '0x3b0aa7d38bf3c103bf02d1de2e37568cbed3d6e8',
+  [CHAIN.MANTLE]: '0x3b0aa7d38bf3c103bf02d1de2e37568cbed3d6e8',
+  [CHAIN.KATANA]: '0x3b0aa7d38bf3c103bf02d1de2e37568cbed3d6e8',
+}
+
+const RP9_2_ADDRESS: any = {
+  [CHAIN.ETHEREUM]: '0xd2b37ade14708bf18904047b1e31f8166d39612b',
+  [CHAIN.ARBITRUM]: '0xd2b37ade14708bf18904047b1e31f8166d39612b',
+  [CHAIN.OPTIMISM]: '0xd2b37ade14708bf18904047b1e31f8166d39612b',
+  [CHAIN.BASE]: '0xd2b37ade14708bf18904047b1e31f8166d39612b',
+  [CHAIN.POLYGON]: '0xd2b37ade14708bf18904047b1e31f8166d39612b',
+  [CHAIN.POLYGON_ZKEVM]: '0xd2b37ade14708bf18904047b1e31f8166d39612b',
+  [CHAIN.MANTLE]: '0xd2b37ade14708bf18904047b1e31f8166d39612b',
+  [CHAIN.KATANA]: '0xd2b37ade14708bf18904047b1e31f8166d39612b',
+}
+
+const RP10_ADDRESS: any = {
+  [CHAIN.ETHEREUM]: '0xe89aab725a2b2c0656248dcccc894a04661be55a',
+  [CHAIN.ARBITRUM]: '0xe89aab725a2b2c0656248dcccc894a04661be55a',
+  [CHAIN.OPTIMISM]: '0xe89aab725a2b2c0656248dcccc894a04661be55a',
+  [CHAIN.BASE]: '0xe89aab725a2b2c0656248dcccc894a04661be55a',
+  [CHAIN.POLYGON]: '0xe89aab725a2b2c0656248dcccc894a04661be55a',
+  [CHAIN.POLYGON_ZKEVM]: '0xe89aab725a2b2c0656248dcccc894a04661be55a',
+  [CHAIN.MANTLE]: '0xe89aab725a2b2c0656248dcccc894a04661be55a',
+  [CHAIN.KATANA]: '0xe89aab725a2b2c0656248dcccc894a04661be55a',
+}
+
+const RP11_ADDRESS: any = {
+  [CHAIN.ETHEREUM]: '0xc10ee9031f2a0b84766a86b55a8d90f357910fb4',
+  [CHAIN.ARBITRUM]: '0xc10ee9031f2a0b84766a86b55a8d90f357910fb4',
+  [CHAIN.OPTIMISM]: '0xc10ee9031f2a0b84766a86b55a8d90f357910fb4',
+  [CHAIN.BASE]: '0xc10ee9031f2a0b84766a86b55a8d90f357910fb4',
+  [CHAIN.POLYGON]: '0xc10ee9031f2a0b84766a86b55a8d90f357910fb4',
+  [CHAIN.POLYGON_ZKEVM]: '0xc10ee9031f2a0b84766a86b55a8d90f357910fb4',
+  [CHAIN.MANTLE]: '0xc10ee9031f2a0b84766a86b55a8d90f357910fb4',
+  [CHAIN.KATANA]: '0xc10ee9031f2a0b84766a86b55a8d90f357910fb4',
+}
+
 const ROUTE_RP7_EVENT = 'event Route(address indexed from, address to, address indexed tokenIn, address tokenOut, uint256 amountIn, uint256 amountOut, int256 slippage, uint32 indexed referralCode)'
+const ROUTE_RP9_EVENT = 'event Route(address indexed from, address to, address indexed tokenIn, address tokenOut, uint256 amountIn, uint256 amountOut, int256 slippage, uint32 indexed referralCode, bytes32 diagnosticsFirst32)'
 
 // https://etherscan.io/tx/0x2124a56218f4b7b1675fab0ece6c2cd6adee55bcc3e2bfb4dc1fc88db6bc91ee
 const FLAT_FEE = 0.002;
 
 const fetch: FetchV2 = async (options: FetchOptions): Promise<FetchResultV2> => {
   const dailyFees = options.createBalances()
+  const chain = options.chain
+  let logs: any[] = []
 
-  const logs = await options.getLogs({ target: RP8_ADDRESS[options.chain], eventAbi: ROUTE_RP7_EVENT })
+  if (RP8_ADDRESS[chain]) logs = logs.concat(await options.getLogs({ target: RP8_ADDRESS[chain], eventAbi: ROUTE_RP7_EVENT }))
+  if (RP9_ADDRESS[chain]) logs = logs.concat(await options.getLogs({ target: RP9_ADDRESS[chain], eventAbi: ROUTE_RP9_EVENT }))
+  if (RP9_1_ADDRESS[chain]) logs = logs.concat(await options.getLogs({ target: RP9_1_ADDRESS[chain], eventAbi: ROUTE_RP9_EVENT }))
+  if (RP9_2_ADDRESS[chain]) logs = logs.concat(await options.getLogs({ target: RP9_2_ADDRESS[chain], eventAbi: ROUTE_RP9_EVENT }))
+  if (RP10_ADDRESS[chain]) logs = logs.concat(await options.getLogs({ target: RP10_ADDRESS[chain], eventAbi: ROUTE_RP9_EVENT }))
+  if (RP11_ADDRESS[chain]) logs = logs.concat(await options.getLogs({ target: RP11_ADDRESS[chain], eventAbi: ROUTE_RP9_EVENT }))
+
   for (const log of logs) {
     if (Number(log.amountIn) < 0) throw new Error(`Amount cannot be negative. Current value: ${log.amountIn}`)
     if (log.tokenIn.toLowerCase() === ADDRESSES.GAS_TOKEN_2.toLowerCase()) {


### PR DESCRIPTION
## Summary

`fees/sushiswap-agg.ts` only tracks RouteProcessor8. Sushi has rolled out RP9 → RP9_1 → RP9_2 → RP10 → RP11 since this adapter was created, and the volume adapter (`aggregators/sushiswap-agg.ts`, maintained by @0xMasayoshi) was updated for each. The fees side wasn't, so RP8 going dormant in September 2025 silently took the adapter to zero.

## On-chain check

| RouteProcessor | Address | Events / last 10k blocks (Ethereum) |
| --- | --- | --- |
| RP8  | `0x2905d7e4D048d29954F81b02171DD313F457a4a4` | 0 |
| RP9  | `0x81602EF321C46d73f5Ba7f476947AE1a862957dc` | 0 |
| RP10 | `0xe89aab725a2b2c0656248dcccc894a04661be55a` | 0 |
| RP11 | `0xc10ee9031f2a0b84766a86b55a8d90f357910fb4` | 2,675 |

RP11 is also active on Base (1,747 / 5k blocks), BSC (144), Optimism (67) and Linea (15) right now.

## DL state today

- `/summary/fees/sushiswap-agg` → `total24h: 0`, `total30d: 0`. Daily chart last non-zero day = 2025-09-07.
- `/summary/aggregators/sushiswap-agg` → `total30d: $134,724,654`.

At the existing 0.2% rate that's ~$269k/month of fees the slug is missing.

## Change

Adds the RP9 / RP9_1 / RP9_2 / RP10 / RP11 address tables for the 9 chains this adapter is configured on, plus `ROUTE_RP9_EVENT` (the event signature adds a trailing `bytes32 diagnosticsFirst32`). The fetch now aggregates logs from every RP whose address is defined for the current chain, the same pattern `aggregators/sushiswap-agg.ts` uses. `FLAT_FEE = 0.002` is unchanged.

## Local test

```
pnpm run test fees sushiswap-agg
```

Today's 24h run on master returns 0 across all chains. With this change:

```
chain         | Daily fees
ethereum      | 3.83 k
arbitrum      | 1.25 k
optimism      | 27.87
base          | 2.21 k
polygon       | 542.80
moonbeam      | 0.00
polygon_zkevm | 0.00
mantle        | 0.18
katana        | 1.84 k
Aggregate     | 9.70 k
```

cc @0xMasayoshi as the maintainer of the sibling volume adapter — happy to defer or adjust if you'd prefer a single shared source for the RP address tables.

"Allow edits by maintainers" is on.