### PR TITLE
[fix] Fulcrom-Perps: track oi via subgraph and simplify code

### DIFF
--- a/dexs/fulcrom-finance-derivatives.ts
+++ b/dexs/fulcrom-finance-derivatives.ts
@@ -1,91 +1,67 @@
 import request, { gql } from "graphql-request";
-import { Fetch, SimpleAdapter } from "../adapters/types";
+import { FetchOptions, SimpleAdapter } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
-import { getUniqStartOfTodayTimestamp } from "../helpers/getUniSubgraphVolume";
 
-const endpoints: { [key: string]: string } = {
-  [CHAIN.CRONOS]: "https://graph.cronoslabs.com/subgraphs/name/fulcrom/stats-prod",
-  // [CHAIN.ERA]: "https://api.studio.thegraph.com/query/52869/stats-prod/version/latest",
-  [CHAIN.CRONOS_ZKEVM]: "https://api.goldsky.com/api/public/project_clwrfupe2elf301wlhnd7bvva/subgraphs/fulcrom-stats-mainnet/prod/gn"
+const chainConfig: Record<string, { endpoint: string; start: number }> = {
+  [CHAIN.CRONOS]: {
+    endpoint: "https://graph.cronoslabs.com/subgraphs/name/fulcrom/stats-prod",
+    start: 1677470400,
+  },
+  [CHAIN.CRONOS_ZKEVM]: {
+    endpoint: "https://api.goldsky.com/api/public/project_clwrfupe2elf301wlhnd7bvva/subgraphs/fulcrom-stats-mainnet/prod/gn",
+    start: 1723698700,
+  },
 };
+const toUSD = (value: string | bigint) => Number(BigInt(value) / 10n ** 24n) / 1e6;
 
-const historicalDataDerivatives = gql`
-  query get_volume($period: String!, $id: String!) {
-    volumeStats(where: { period: $period, id: $id }) {
+const query = gql`
+  query get_volume($id: String!, $timestamp: Int!) {
+    volumeStats(where: { period: "daily", id: $id }) {
       liquidation
       margin
+    }
+    tradingStats(first: 1, where: { period: daily, timestamp_lte: $timestamp }, orderBy: timestamp, orderDirection: desc) {
+      longOpenInterest
+      shortOpenInterest
     }
   }
 `;
 
 interface IGraphResponse {
   volumeStats: Array<{
-    burn: string;
     liquidation: string;
     margin: string;
-    mint: string;
-    swap: string;
+  }>;
+  tradingStats: Array<{
+    longOpenInterest: string;
+    shortOpenInterest: string;
   }>;
 }
 
-const getFetch =
-  (chain: string): Fetch =>
-    async (timestamp: number) => {
-      const dayTimestamp = getUniqStartOfTodayTimestamp(
-        new Date(timestamp * 1000)
-      );
-      const dailyData: IGraphResponse = await request(endpoints[chain], historicalDataDerivatives, {
-        id: "daily:" + String(dayTimestamp),
-        period: "daily",
-      });
-      const totalData: IGraphResponse = await request(endpoints[chain], historicalDataDerivatives, {
-        id: "total",
-        period: "total",
-      });
+const fetch = async (_timestamp: number, _a: any, options: FetchOptions) => {
+  const dailyData: IGraphResponse = await request(chainConfig[options.chain].endpoint, query, {
+    id: "daily:" + String(options.startOfDay),
+    timestamp: options.startOfDay,
+  });
+  const volume = dailyData.volumeStats[0];
+  const oi = dailyData.tradingStats[0];
 
-      return {
-        timestamp: dayTimestamp,
-        dailyVolume:
-          dailyData.volumeStats.length == 1
-            ? String(
-              Number(
-                Object.values(dailyData.volumeStats[0]).reduce((sum, element) =>
-                  String(Number(sum) + Number(element))
-                )
-              ) *
-              10 ** -30
-            )
-            : undefined,
-        totalVolume:
-          totalData.volumeStats.length == 1
-            ? String(
-              Number(
-                Object.values(totalData.volumeStats[0]).reduce((sum, element) =>
-                  String(Number(sum) + Number(element))
-                )
-              ) *
-              10 ** -30
-            )
-            : undefined,
-      };
-    };
+  const dailyVolume = toUSD(BigInt(volume.margin) + BigInt(volume.liquidation));
+  const longOpenInterestAtEnd = toUSD(oi.longOpenInterest);
+  const shortOpenInterestAtEnd = toUSD(oi.shortOpenInterest);
+  const openInterestAtEnd = longOpenInterestAtEnd + shortOpenInterestAtEnd;
 
-const startTimestamps: { [chain: string]: number } = {
-  [CHAIN.CRONOS]: 1677470400,
-  [CHAIN.ERA]: 1696496400,
-  [CHAIN.CRONOS_ZKEVM]: 1723698700,
+  return {
+    dailyVolume,
+    openInterestAtEnd,
+    longOpenInterestAtEnd,
+    shortOpenInterestAtEnd,
+  };
 };
 
 const adapter: SimpleAdapter = {
-  adapter: Object.keys(endpoints).reduce((acc, chain) => {
-    return {
-      ...acc,
-      [chain]: {
-        fetch: getFetch(chain),
-        start: startTimestamps[chain],
-      },
-    };
-  }, {}),
+  fetch,
+  adapter: chainConfig,
 };
 
 export default adapter;

--- a/dexs/fulcrom-finance-derivatives.ts
+++ b/dexs/fulcrom-finance-derivatives.ts
@@ -2,14 +2,14 @@ import request, { gql } from "graphql-request";
 import { FetchOptions, SimpleAdapter } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
 
-const chainConfig: Record<string, { endpoint: string; start: number }> = {
+const chainConfig: Record<string, { endpoint: string; start: string }> = {
   [CHAIN.CRONOS]: {
     endpoint: "https://graph.cronoslabs.com/subgraphs/name/fulcrom/stats-prod",
-    start: 1677470400,
+    start: '2023-02-27',
   },
   [CHAIN.CRONOS_ZKEVM]: {
     endpoint: "https://api.goldsky.com/api/public/project_clwrfupe2elf301wlhnd7bvva/subgraphs/fulcrom-stats-mainnet/prod/gn",
-    start: 1723698700,
+    start: '2024-08-15',
   },
 };
 const toUSD = (value: string | bigint) => Number(BigInt(value) / 10n ** 24n) / 1e6;


### PR DESCRIPTION
> Maintainer Note
> I have removed swap, mint, burn from the volume stats as they are amm related queries and will overcount the volume here the fulcrom AMM already covers swap query thats a 400k + overcounting for today 
## Summary
- Adds open interest reporting to the Fulcrom derivatives adapter.
- Simplifies the Fulcrom adapter structure by using a shared `chainConfig` and root-level `fetch`.
- Keeps daily volume behavior while adding long, short, and total open interest metrics.

## Changes
- Updated `dexs/fulcrom-finance-derivatives.ts`.
- Added `tradingStats` subgraph query fields for `longOpenInterest` and `shortOpenInterest`.
- Reports `openInterestAtEnd`, `longOpenInterestAtEnd`, and `shortOpenInterestAtEnd` for Cronos and Cronos zkEVM.
- Consolidated endpoints and start timestamps into `chainConfig`.
- Removed extra total volume logic and unused daily volume fields, keeping only margin and liquidation volume.
- Uses `options.startOfDay` directly for daily queries.
- Handles `1e30` graph values with `BigInt` scaling before converting to USD numbers.

## Methodology
- Daily volume is calculated as `margin + liquidation` from Fulcrom `volumeStats`.
- Open interest is calculated from Fulcrom `tradingStats` as long OI plus short OI.
- Uses the latest daily `tradingStats` record at or before the requested day timestamp.

## Tests
- `pnpm test dexs fulcrom-finance-derivatives`
- `pnpm test dexs fulcrom-finance-derivatives 2026-05-23`