### PR TITLE
[feat] Stormtrade-Perps: add storm trade oi adapter via api

### DIFF
--- a/open-interest/stormtrade-oi.ts
+++ b/open-interest/stormtrade-oi.ts
@@ -1,11 +1,11 @@
-import { SimpleAdapter } from "../adapters/types";
+import { FetchOptions, SimpleAdapter } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
 import fetchURL from "../utils/fetchURL";
 
 const MARKETS_URL = "https://api.storm.tg/api/markets";
 const USD_SCALE = 1e9;
 
-const fetch = async () => {
+const fetch = async (_options: FetchOptions) => {
   const markets = await fetchURL(MARKETS_URL);
 
   let longOpenInterestAtEnd = 0;

--- a/open-interest/stormtrade-oi.ts
+++ b/open-interest/stormtrade-oi.ts
@@ -11,9 +11,9 @@ const fetch = async (_options: FetchOptions) => {
   let longOpenInterestAtEnd = 0;
   let shortOpenInterestAtEnd = 0;
   for (const market of markets) {
-    if (market.config?.isHidden) continue;
-    longOpenInterestAtEnd += Number(market.amm?.openInterestLong) / USD_SCALE;
-    shortOpenInterestAtEnd += Number(market.amm?.openInterestShort) / USD_SCALE;
+    if (market.settings.status !== "active") continue;
+    longOpenInterestAtEnd += Number(market.amm.openInterestLong) / USD_SCALE;
+    shortOpenInterestAtEnd += Number(market.amm.openInterestShort) / USD_SCALE;
   }
 
   return {

--- a/open-interest/stormtrade-oi.ts
+++ b/open-interest/stormtrade-oi.ts
@@ -1,0 +1,33 @@
+import { SimpleAdapter } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+import fetchURL from "../utils/fetchURL";
+
+const MARKETS_URL = "https://api.storm.tg/api/markets";
+const USD_SCALE = 1e9;
+
+const fetch = async () => {
+  const markets = await fetchURL(MARKETS_URL);
+
+  let longOpenInterestAtEnd = 0;
+  let shortOpenInterestAtEnd = 0;
+  for (const market of markets) {
+    if (market.config?.isHidden) continue;
+    longOpenInterestAtEnd += Number(market.amm?.openInterestLong) / USD_SCALE;
+    shortOpenInterestAtEnd += Number(market.amm?.openInterestShort) / USD_SCALE;
+  }
+
+  return {
+    openInterestAtEnd: longOpenInterestAtEnd + shortOpenInterestAtEnd,
+    longOpenInterestAtEnd,
+    shortOpenInterestAtEnd,
+  };
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  fetch,
+  runAtCurrTime: true,
+  chains: [CHAIN.TON],
+};
+
+export default adapter;


### PR DESCRIPTION
## Summary
- Adds a Storm Trade open interest adapter for TON.
- Uses Storm Trade's live markets API to report current total, long, and short OI.

## Changes
- Added `open-interest/stormtrade-oi.ts`.
- Aggregates `openInterestLong` and `openInterestShort` from `https://api.storm.tg/api/markets`.
- Scales Storm Trade's 1e9-based USD notional values and excludes hidden markets.

## Methodology
- Reports current OI only because the Storm Trade markets API returns live snapshots, not historical OI.
- Calculates total OI as long OI plus short OI to avoid signed notional edge cases.

## Tests
- `pnpm test open-interest stormtrade-oi`