### PR TITLE
factory/curators: add Arbitrum and Katana to Steakhouse Financial

### DIFF
--- a/factory/curators.ts
+++ b/factory/curators.ts
@@ -361,6 +361,14 @@ const configs: Record<string, CuratorConfig> = {
         morphoVaultOwners: ['0x84ae7f8eb667b391a5ae2f69bd5a0e4b5b77c999'],
         start: '2025-04-30',
       },
+      [CHAIN.ARBITRUM]: {
+        morphoVaultOwners: ['0x0000aeB716a0DF7A9A1AAd119b772644Bc089dA8'],
+        start: '2025-07-17',
+      },
+      [CHAIN.KATANA]: {
+        morphoVaultOwners: ['0xe6FC2a011153DD5a230725a9F0c89a9c81aB4887'],
+        start: '2025-06-23',
+      },
       [CHAIN.MONAD]: {
         morphoVaultOwners: ['0x0000aeB716a0DF7A9A1AAd119b772644Bc089dA8'],
         morphoVaultV2Owners: ['0xD546Dc0dB55c28860176147b2D0FEFcc533eCf08'],

--- a/factory/curators.ts
+++ b/factory/curators.ts
@@ -363,6 +363,7 @@ const configs: Record<string, CuratorConfig> = {
       },
       [CHAIN.ARBITRUM]: {
         morphoVaultOwners: ['0x0000aeB716a0DF7A9A1AAd119b772644Bc089dA8'],
+        morphoVaultV2Owners: ['0x0b1aA22117E38f260e0F3aB3b0F12a22c2691ffC'],
         start: '2025-07-17',
       },
       [CHAIN.KATANA]: {


### PR DESCRIPTION
## Summary

Steakhouse Financial's TVL adapter (`DefiLlama-Adapters/projects/steakhouse/index.js`) lists Arbitrum and Katana as live chains. The fees adapter here was only configured for Ethereum, Base, Corn and Monad, so deposits on those two chains were not contributing dailyFees / dailyRevenue / dailySupplySideRevenue.

## On-chain verification

Rate growth on `convertToAssets(1e18)` over a 7-day window, on every vault auto-discovered for these chains:

### Arbitrum

Morpho factory `0x878988f5f561081deEa117717052164ea1Ef0c82`, initial-owner `0x0000aeB716a0DF7A9A1AAd119b772644Bc089dA8`:

| Vault | Asset | TVL | 7d annualised |
| --- | --- | ---: | ---: |
| `0x5C0C306A...` Steakhouse High Yield USDC | USDC | $2.46M | 4.01% |
| `0x4739E2C2...` Steakhouse High Yield USDT0 | USDT0 | $133k | 3.25% |
| `0x250CF7C8...` Steakhouse Prime USDC | USDC | $148k | 4.44% |
| `0x22819614...` Steakhouse Prime USDT0 | USDT0 | $18 | 3.17% |
| `0x0623A67D...` Steakhouse Prime ETH | WETH | $15 | 0.00% (dormant) |

Approx ~$9.5k/month of total fees + supply-side accrual today.

### Katana

Morpho factory `0x1c8De6889acee12257899BFeAa2b7e534de32E16`, initial-owner `0xe6FC2a011153DD5a230725a9F0c89a9c81aB4887`:

| Vault | Asset | TVL | 7d annualised |
| --- | --- | ---: | ---: |
| `0x61D4F9D3...` Steakhouse Prime USDC | USDC | $32.7M | 1.34% |
| `0x82C4C641...` Steakhouse Prime AUSD | AUSD | $649k | 1.25% |
| `0x1445A01A...` Steakhouse High Yield USDC | USDC | $1.8k | 2.00% |
| `0xDE6A4F28...` Steakhouse High Yield AUSD | AUSD | $62 | 1.25% |

Approx ~$36.6k/month of total fees + supply-side accrual today.

## What is intentionally NOT added

- **Polygon**: the TVL adapter lists it, but on-chain the Morpho vaults under Steakhouse's known owners (`Steakhouse High Yield USDC` $54k, `Steakhouse High Yield USDT0` $194k, plus 10 `Safe x Steakhouse` vaults with <$2 each) show 0% rate growth over the last 7 days. Per the curator helper math (rate-delta × balance), adding Polygon would report $0 in fees indefinitely until those markets get borrowers.
- **Solana / Kamino**: $39M of curated TVL exists there, but the curator framework in `helpers/curators` only supports Morpho and Euler. Would need a separate Kamino integration.
- **Unichain**: TVL adapter lists it but DL currently reports $0 TVL on that chain for Steakhouse.

## Local test

The Steakhouse cluster is exercised through the per-curator factory export in `factory/curators.ts`. I verified the change locally by reading the new vaults' `convertToAssets(1e18)` at `latest` and at `latest - ~7d` via public RPC on Arbitrum (publicnode) and Katana (rpc.katana.network), confirming positive rate growth on every vault listed above except `Steakhouse Prime ETH` (which is sub-cent TVL and dormant on both reads).

"Allow edits by maintainers" is on.