### PR TITLE
[fix] Perpl-Perps: account insurance, protocol fees and refine methodology 

### DIFF
--- a/dexs/perpl/index.ts
+++ b/dexs/perpl/index.ts
@@ -1,59 +1,56 @@
 import { SimpleAdapter, FetchOptions } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 
+// Dune query for fees and abi https://dune.com/queries/6960061/10872718
 const EXCHANGE = "0x34B6552d57a35a1D042CcAe1951BD1C370112a6F";
+const CNS_DECIMALS = 1e6;
 
-// Market config: perpId → { priceDecimals, lotDecimals }
-const MARKETS: Record<number, { priceDecimals: number; lotDecimals: number }> = {
-    1: { priceDecimals: 1, lotDecimals: 5 },   // BTC
-    10: { priceDecimals: 6, lotDecimals: 0 },   // MON
-    20: { priceDecimals: 2, lotDecimals: 3 },   // ETH
+const abi = {
+    positionOpenedTopic: "0xc0150ebb43a9c2478aa9c69d27078da071ceafb70e2d822d7d39a533e0418728",
+    positionIncreasedTopic: "0x2a077a58d72570ce2b985a210c9ad672373eb9bcc337d1dc62b8b75dd644cf27",
+    makerOrderFilled: "event MakerOrderFilled(uint256 perpId, uint256 accountId, uint256 orderId, uint256 pricePNS, uint256 lotLNS, uint256 feeCNS, uint256 lockedBalanceCNS, int256 amountCNS, uint256 balanceCNS)",
+    takerOrderFilled: "event TakerOrderFilled(uint256 entryPricePNS, uint256 perpId, uint256 accountId, uint256 lotLNS, uint256 feeCNS, int256 amountCNS, uint256 balanceCNS)",
+    getPerpetualInfo: "function getPerpetualInfo(uint256 perpId) view returns ((string name, string symbol, uint256 priceDecimals, uint256 lotDecimals, bytes32 linkFeedId, uint256 priceTolPer100K, uint256 marginTol, uint256 marginTolDecimals, uint256 refPriceMaxAgeSec, uint256 positionBalanceCNS, uint256 insuranceBalanceCNS, uint256 markPNS, uint256 markTimestamp, uint256 lastPNS, uint256 lastTimestamp, uint256 oraclePNS, uint256 oracleTimestampSec, uint256 longOpenInterestLNS, uint256 shortOpenInterestLNS))",
 };
 
-const MakerOrderFilledEvent =
-    "event MakerOrderFilled(uint256 perpId, uint256 accountId, uint256 orderId, uint256 pricePNS, uint256 lotLNS, uint256 feeCNS, uint256 lockedBalanceCNS, int256 amountCNS, uint256 balanceCNS)";
-
-const TakerOrderFilledEvent =
-    "event TakerOrderFilled(uint256 entryPricePNS, uint256 perpId, uint256 accountId, uint256 lotLNS, uint256 feeCNS, uint256 lockedBalanceCNS, int256 amountCNS, uint256 balanceCNS)";
-
-const getPerpetualInfoAbi =
-    "function getPerpetualInfo(uint256 perpId) view returns ((string name, string symbol, uint256 priceDecimals, uint256 lotDecimals, bytes32 linkFeedId, uint256 priceTolPer100K, uint256 marginTol, uint256 marginTolDecimals, uint256 refPriceMaxAgeSec, uint256 positionBalanceCNS, uint256 insuranceBalanceCNS, uint256 markPNS, uint256 markTimestamp, uint256 lastPNS, uint256 lastTimestamp, uint256 oraclePNS, uint256 oracleTimestampSec, uint256 longOpenInterestLNS, uint256 shortOpenInterestLNS))";
-
 const fetch = async (options: FetchOptions) => {
-    const [makerLogs, takerLogs] = await Promise.all([
-        options.getLogs({ target: EXCHANGE, eventAbi: MakerOrderFilledEvent }),
-        options.getLogs({ target: EXCHANGE, eventAbi: TakerOrderFilledEvent }),
+    const [makerLogs, takerLogs, positionOpenedLogs, positionIncreasedLogs] = await Promise.all([
+        options.getLogs({ target: EXCHANGE, eventAbi: abi.makerOrderFilled }),
+        options.getLogs({ target: EXCHANGE, eventAbi: abi.takerOrderFilled }),
+        options.getLogs({ target: EXCHANGE, topics: [abi.positionOpenedTopic], entireLog: true }),
+        options.getLogs({ target: EXCHANGE, topics: [abi.positionIncreasedTopic], entireLog: true }),
     ]);
 
-    // Discover market config for any new perpIds
-    const allPerpIds = new Set([
-        ...makerLogs.map((log: any) => Number(log.perpId)),
-        ...takerLogs.map((log: any) => Number(log.perpId)),
-    ]);
-    const missingPerpIds = Array.from(allPerpIds).filter((id: number) => !MARKETS[id]);
+    const markets: Record<number, { priceDecimals: number; lotDecimals: number }> = {};
 
-    if (missingPerpIds.length > 0) {
+    // Use the live market config for traded perpIds instead of stale hardcoded decimals.
+    const perpIds = Array.from(new Set(makerLogs.map((log: any) => Number(log.perpId))));
+    if (perpIds.length > 0) {
         const perpetualInfos = await options.api.multiCall({
-            abi: getPerpetualInfoAbi,
+            abi: abi.getPerpetualInfo,
             target: EXCHANGE,
-            calls: missingPerpIds.map((id: number) => ({ params: [id] })),
+            calls: perpIds.map((id) => ({ params: [id] })),
         });
 
-        for (let i = 0; i < perpetualInfos.length; i++) {
-            MARKETS[missingPerpIds[i]] = {
-                priceDecimals: Number(perpetualInfos[i].priceDecimals),
-                lotDecimals: Number(perpetualInfos[i].lotDecimals),
+        perpetualInfos.forEach((info: any, i: number) => {
+            markets[perpIds[i]] = {
+                priceDecimals: Number(info.priceDecimals),
+                lotDecimals: Number(info.lotDecimals),
             };
-        }
+        });
     }
 
     const dailyVolume = options.createBalances();
     const dailyFees = options.createBalances();
+    const dailyUserFees = options.createBalances();
+    const dailyRevenue = options.createBalances();
+    const dailyProtocolRevenue = options.createBalances();
+    const dailySupplySideRevenue = options.createBalances();
 
     // Volume from maker fills only (one per trade, avoids double-counting)
     for (const log of makerLogs) {
         const perpId = Number(log.perpId);
-        const market = MARKETS[perpId];
+        const market = markets[perpId];
         if (!market) {
             throw new Error(`Perpl: unknown perpId ${perpId}`);
         }
@@ -63,47 +60,94 @@ const fetch = async (options: FetchOptions) => {
         dailyVolume.addUSDValue(price * lots);
 
         // Maker fees in AUSD (6 decimals, 1:1 USD)
-        dailyFees.addUSDValue(Number(log.feeCNS) / 1e6, "Maker Fees");
+        const fee = Number(log.feeCNS) / CNS_DECIMALS;
+        dailyFees.addUSDValue(fee, "Maker Fees");
+        dailyUserFees.addUSDValue(fee, "Maker Fees");
+        dailyRevenue.addUSDValue(fee, "Maker Fees");
+        dailyProtocolRevenue.addUSDValue(fee, "Maker Fees");
     }
 
     // Taker fees (separate fee charged to taker side)
     for (const log of takerLogs) {
-        dailyFees.addUSDValue(Number(log.feeCNS) / 1e6, "Taker Fees");
+        const fee = Number(log.feeCNS) / CNS_DECIMALS;
+        dailyFees.addUSDValue(fee, "Taker Fees");
+        dailyUserFees.addUSDValue(fee, "Taker Fees");
+        dailyRevenue.addUSDValue(fee, "Taker Fees");
+        dailyProtocolRevenue.addUSDValue(fee, "Taker Fees");
     }
 
-    // All fees go to protocol (insurance fund + protocol balance)
+    // The position fee topics are not publicly ABI-matched; these word indexes mirror the Dune query.
+    positionOpenedLogs.forEach((log: any) => {
+        const data = log.data.slice(2);
+        const insuranceFee = Number(BigInt(`0x${data.slice(8 * 64, 9 * 64)}`)) / CNS_DECIMALS;
+        const protocolFee = Number(BigInt(`0x${data.slice(9 * 64, 10 * 64)}`)) / CNS_DECIMALS;
+        dailyFees.addUSDValue(insuranceFee, "Position Insurance Fees");
+        dailyUserFees.addUSDValue(insuranceFee, "Position Insurance Fees");
+        dailySupplySideRevenue.addUSDValue(insuranceFee, "Position Insurance Fees");
+        dailyFees.addUSDValue(protocolFee, "Position Protocol Fees");
+        dailyUserFees.addUSDValue(protocolFee, "Position Protocol Fees");
+        dailyRevenue.addUSDValue(protocolFee, "Position Protocol Fees");
+        dailyProtocolRevenue.addUSDValue(protocolFee, "Position Protocol Fees");
+    });
+
+    positionIncreasedLogs.forEach((log: any) => {
+        const data = log.data.slice(2);
+        const insuranceFee = Number(BigInt(`0x${data.slice(12 * 64, 13 * 64)}`)) / CNS_DECIMALS;
+        const protocolFee = Number(BigInt(`0x${data.slice(13 * 64, 14 * 64)}`)) / CNS_DECIMALS;
+        dailyFees.addUSDValue(insuranceFee, "Position Insurance Fees");
+        dailyUserFees.addUSDValue(insuranceFee, "Position Insurance Fees");
+        dailySupplySideRevenue.addUSDValue(insuranceFee, "Position Insurance Fees");
+        dailyFees.addUSDValue(protocolFee, "Position Protocol Fees");
+        dailyUserFees.addUSDValue(protocolFee, "Position Protocol Fees");
+        dailyRevenue.addUSDValue(protocolFee, "Position Protocol Fees");
+        dailyProtocolRevenue.addUSDValue(protocolFee, "Position Protocol Fees");
+    });
+
+    // Insurance fees go to supply side; all other tracked fees go to protocol revenue.
     // No LP rewards, referrals, or token holder distributions
     return {
         dailyVolume,
         dailyFees,
-        dailyUserFees: dailyFees,
-        dailyRevenue: dailyFees,
-        dailyProtocolRevenue: dailyFees,
-        dailySupplySideRevenue: 0,
-        dailyHoldersRevenue: 0,
+        dailyUserFees,
+        dailyRevenue,
+        dailyProtocolRevenue,
+        dailySupplySideRevenue,
     };
 };
 
 const methodology = {
-    Fees: "Trading fees paid by makers and takers on each fill.",
-    Revenue: "All fees are retained by the protocol (insurance fund + protocol balance).",
-    ProtocolRevenue: "100% of trading fees go to the protocol.",
-    SupplySideRevenue: "Perpl is an order-book DEX with no LP fee sharing.",
-    HoldersRevenue: "No token holder fee distribution.",
+    Fees: "All fees paid by traders on Perpl: maker fees, taker fees, protocol fees, and insurance fund fees.",
+    UserFees: "All fees paid by traders on Perpl.",
+    Revenue: "Fees kept by the protocol, excluding the portion sent to the insurance fund.",
+    ProtocolRevenue: "Fees kept by the protocol.",
+    SupplySideRevenue: "Fees sent to the insurance fund.",
 };
 
 const breakdownMethodology = {
     Fees: {
-        "Maker Fees": "Fees paid by makers on each fill.",
-        "Taker Fees": "Fees paid by takers on each fill.",
+        "Maker Fees": "Fees paid by maker orders when trades are filled.",
+        "Taker Fees": "Fees paid by taker orders when trades are filled.",
+        "Position Insurance Fees": "Fees paid into the insurance fund when positions are opened or increased.",
+        "Position Protocol Fees": "Protocol fees paid when positions are opened or increased.",
+    },
+    UserFees: {
+        "Maker Fees": "Fees paid by maker orders when trades are filled.",
+        "Taker Fees": "Fees paid by taker orders when trades are filled.",
+        "Position Insurance Fees": "Fees paid into the insurance fund when positions are opened or increased.",
+        "Position Protocol Fees": "Protocol fees paid when positions are opened or increased.",
     },
     Revenue: {
-        "Maker Fees": "Fees paid by makers on each fill.",
-        "Taker Fees": "Fees paid by takers on each fill.",
+        "Maker Fees": "Maker fees kept by the protocol.",
+        "Taker Fees": "Taker fees kept by the protocol.",
+        "Position Protocol Fees": "Position protocol fees kept by the protocol.",
     },
     ProtocolRevenue: {
-        "Maker Fees": "Fees paid by makers on each fill.",
-        "Taker Fees": "Fees paid by takers on each fill.",
+        "Maker Fees": "Maker fees kept by the protocol.",
+        "Taker Fees": "Taker fees kept by the protocol.",
+        "Position Protocol Fees": "Position protocol fees kept by the protocol.",
+    },
+    SupplySideRevenue: {
+        "Position Insurance Fees": "Insurance fees sent to the insurance fund.",
     },
 };
 


### PR DESCRIPTION
> Maintainer Note
> This adapter is correctly wired in `defillama-server` for fees volume and oi but still the fees on UI isnt populated correctly

## Summary
- Updates the Perpl DEX adapter on Monad to report complete fees, revenue, supply-side revenue, and volume.
- Adds position protocol and insurance fee handling using Perpl exchange event logs, with insurance fees reported as supply-side revenue.

## Changes
- Updated `dexs/perpl/index.ts`.
- Fixed the `TakerOrderFilled` event ABI so taker fees are decoded from the correct event topic.
- Added decoding for position opened and position increased fee events:
  - position protocol fees are counted as protocol revenue
  - position insurance fees are counted as supply-side revenue
- Uses `getPerpetualInfo` for traded `perpId`s to fetch live `priceDecimals` and `lotDecimals` for maker-fill volume calculation.
- Added methodology and breakdown labels for maker fees, taker fees, position protocol fees, and position insurance fees.
- Added Dune reference for event topics and fee decoding: https://dune.com/queries/6960061/10872718

## Methodology
- Volume is calculated from maker fills only to avoid double-counting both sides of the same trade.
- Fees are paid in AUSD/CNS with 6 decimals and counted as USD.
- `dailyFees` and `dailyUserFees` include maker fees, taker fees, position protocol fees, and position insurance fees.
- `dailyRevenue` and `dailyProtocolRevenue` include maker fees, taker fees, and position protocol fees.
- `dailySupplySideRevenue` includes position insurance fees sent to the insurance fund.

## Tests
- `pnpm test dexs perpl`