### PR TITLE
[feat] SparkDex-Perps: track oi for sparkdex-perps via api

### DIFF
--- a/open-interest/sparkdex-perps-oi.ts
+++ b/open-interest/sparkdex-perps-oi.ts
@@ -1,0 +1,30 @@
+import { FetchOptions, SimpleAdapter } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+import fetchURL from "../utils/fetchURL";
+
+const API = "https://api.sparkdex.ai/perps/v2/trading-stats/daily";
+const DAY = 86400;
+
+const fetch = async (_: number, _1: any, options: FetchOptions) => {
+  const res = await fetchURL(
+    `${API}?from=${options.startOfDay}&to=${options.endTimestamp + DAY}&format=open_interest&chainId=14&dex=SparkDEX`
+  );
+
+  const item = res.data.find((stat: any) => stat.timestamp === options.endTimestamp);
+  if (!item) throw new Error(`No SparkDEX OI data for ${options.endTimestamp}`);
+
+  return {
+    openInterestAtEnd: item.openInterest,
+    longOpenInterestAtEnd: item.longOpenInterest,
+    shortOpenInterestAtEnd: item.shortOpenInterest,
+  };
+};
+
+const adapter: SimpleAdapter = {
+  version: 1,
+  fetch,
+  chains: [CHAIN.FLARE],
+  start: "2025-10-16",
+};
+
+export default adapter;


### PR DESCRIPTION

https://defillama.com/protocol/sparkdex-perps
## Summary
- Adds SparkDEX perps open interest tracking on Flare.
- Uses SparkDEX daily trading stats API to report total, long, and short OI.

## Changes
- Added `open-interest/sparkdex-perps-oi.ts`.
- Fetches `open_interest` data from `api.sparkdex.ai` for SparkDEX on `chainId=14`.
- Selects the `endTimestamp` bucket and queries one extra day to avoid the API's unstable final/live bucket behavior.
- Sets the backfill start to `2025-10-16`, the first observed day with OI data.

## Tests
- `pnpm test open-interest sparkdex-perps-oi 2026-04-23`
- `pnpm test open-interest sparkdex-perps-oi 2026-04-26`
- `pnpm test open-interest sparkdex-perps-oi 2026-05-24`
- `pnpm test open-interest sparkdex-perps-oi`
- `pnpm test open-interest sparkdex-perps-oi 2025-05-23`