### PR TITLE
[feat] Strike-FInance: track oi for strike finance via api

### DIFF
--- a/open-interest/strike-finance-oi.ts
+++ b/open-interest/strike-finance-oi.ts
@@ -1,0 +1,32 @@
+import { FetchOptions, SimpleAdapter } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+import fetchURL from "../utils/fetchURL";
+
+const HISTORICAL_OPEN_INTEREST_ENDPOINT = "https://api.strikefinance.org/stat/v1/dashboard/open-interest";
+
+const fetch = async (_a: any, _b: any, options: FetchOptions) => {
+  const { open_interest }: { open_interest: [number, string, number | string][] } = await fetchURL(HISTORICAL_OPEN_INTEREST_ENDPOINT);
+  const startTimestamp = options.startTimestamp * 1000;
+  const targetTimestamp = options.endTimestamp * 1000;
+  const timestamps = open_interest
+    .map(([timestamp]) => Number(timestamp))
+    .filter((timestamp) => timestamp >= startTimestamp && timestamp <= targetTimestamp);
+
+  if (!timestamps.length) throw new Error(`No Strike Finance open interest data found for ${options.dateString}`);
+
+  const endOfPeriodTimestamp = Math.max(...timestamps);
+  const openInterestAtEnd = open_interest
+    .filter(([timestamp]) => Number(timestamp) === endOfPeriodTimestamp)
+    .reduce((sum, [, , openInterest]) => sum + Number(openInterest), 0);
+
+  return { openInterestAtEnd };
+};
+
+const adapter: SimpleAdapter = {
+  version: 1,
+  fetch,
+  chains: [CHAIN.CARDANO],
+  start: "2026-03-19",
+};
+
+export default adapter;


### PR DESCRIPTION
https://defillama.com/protocol/strike-finance-perpetuals

## Summary
- Adds a historical Strike Finance open interest adapter for Cardano.

## Changes
- Added `open-interest/strike-finance-oi.ts`.
- Uses Strike Finance protocol statistics OI data from `2026-03-19`.
- Sums market OI snapshots within the requested start/end window.

## Tests
- `pnpm test open-interest strike-finance-oi`
- `pnpm test open-interest strike-finance-oi 2026-05-23`