### PR TITLE
fix(fees/ajna): fix reserve accounting and fee destination

### DIFF
--- a/fees/ajna-v1/index.ts
+++ b/fees/ajna-v1/index.ts
@@ -15,6 +15,7 @@ export const fetchAjna = async (options: FetchOptions, factoryAddress: string, p
   const dailyFees = options.createBalances();
   const dailySupplySideRevenue = options.createBalances();
   const dailyHoldersRevenue = options.createBalances();
+  const dailyProtocolRevenue = options.createBalances();
 
   const pools: string[] = await options.api.call({ abi: 'address[]:getDeployedPoolsList', target: factoryAddress })
 
@@ -40,7 +41,8 @@ export const fetchAjna = async (options: FetchOptions, factoryAddress: string, p
 
       const poolReserves = poolReserveInfoEnd[i][0] - poolReserveInfoStart[i][0];
       if (poolReserves > 0) {
-        dailyFees.add(quoteToken[i], poolReserves / quoteTokenScale[i], "Reserve accumulation")
+        dailyFees.add(quoteToken[i], poolReserves / quoteTokenScale[i], "Reserve Accumulation")
+        dailyProtocolRevenue.add(quoteToken[i], poolReserves / quoteTokenScale[i], "Reserve Accumulation To Protocol")
       }
       const hasBurn = currentBurnEpochEnd[i][0] - currentBurnEpochStart[i][0];
       if (hasBurn) {
@@ -72,12 +74,14 @@ export const fetchAjna = async (options: FetchOptions, factoryAddress: string, p
   }
 
   dailyFees.addBalances(dailySupplySideRevenue)
-  dailyFees.addBalances(dailyHoldersRevenue)
+
+  const dailyRevenue = options.createBalances();
+  dailyRevenue.addBalances(dailyProtocolRevenue);
 
   return {
     dailyFees,
-    dailyRevenue: dailyHoldersRevenue,
-    dailyProtocolRevenue: 0,
+    dailyRevenue,
+    dailyProtocolRevenue,
     dailyHoldersRevenue,
     dailySupplySideRevenue,
   };
@@ -92,14 +96,16 @@ const fetch = async (options: FetchOptions) => {
 const breakdownMethodology = {
   Fees: {
     [METRIC.BORROW_INTEREST]: "Interest paid by borrowers for loans, with approximately 85-90% distributed to lenders",
-    "Reserve accumulation": "Portion of borrow interest accumulated in pool reserves, approximately 10-15% of total interest, held for future token burns",
-    [METRIC.TOKEN_BUY_BACK]: "AJNA token burns executed through reserve auctions, reducing circulating supply"
+    "Reserve Accumulation": "Portion of borrow interest accumulated in pool reserves, approximately 10-15% of total interest, held for future token burns",
   },
   Revenue: {
-    [METRIC.TOKEN_BUY_BACK]: "AJNA token burns funded by accumulated reserves through periodic auctions"
+    "Reserve Accumulation To Protocol": "Protocol-held reserves pending auction, eventually used to buy back and burn AJNA tokens"
   },
   SupplySideRevenue: {
     [METRIC.BORROW_INTEREST]: "Interest distributed to lenders who supply liquidity to lending pools"
+  },
+  ProtocolRevenue: {
+    "Reserve Accumulation To Protocol": "Protocol-held reserves pending auction, eventually used to buy back and burn AJNA tokens"
   },
   HoldersRevenue: {
     [METRIC.TOKEN_BUY_BACK]: "AJNA token burns that reduce circulating supply, benefiting all token holders"
@@ -112,11 +118,11 @@ const adapter: SimpleAdapter = {
   chains: [CHAIN.ETHEREUM],
   start: '2023-07-04',
   methodology: {
-    Fees: "Fees collected from borrowers, lenders, and penalties",
-    Revenue: "~10-15% net interest margin + origination fees and penalties are used to burn AJNA token",
-    ProtocolRevenue: "Protocol takes no direct fees",
-    HoldersRevenue: "Accumulated fees in reserves are used for token burns by utilizing auctions",
-    SupplySideRevenue: "~85-90% interest rate goes to lenders from borrowers"
+    Fees: "Total interest paid by borrowers: ~85-90% to lenders and ~10-15% to protocol reserves",
+    Revenue: "~10-15% of borrower interest accumulated in pool reserves, held by the protocol pending reserve auctions",
+    ProtocolRevenue: "~10-15% of borrower interest accumulated in pool reserves, held pending reserve auctions",
+    HoldersRevenue: "Accumulated reserves auctioned periodically to buy back and burn AJNA tokens (off-statement; funded by prior periods' reserves)",
+    SupplySideRevenue: "~85-90% of borrower interest distributed to lenders"
   },
   breakdownMethodology,
 };

--- a/fees/ajna-v1/index.ts
+++ b/fees/ajna-v1/index.ts
@@ -15,7 +15,7 @@ export const fetchAjna = async (options: FetchOptions, factoryAddress: string, p
   const dailyFees = options.createBalances();
   const dailySupplySideRevenue = options.createBalances();
   const dailyHoldersRevenue = options.createBalances();
-  const dailyProtocolRevenue = options.createBalances();
+  const dailyRevenue = options.createBalances();
 
   const pools: string[] = await options.api.call({ abi: 'address[]:getDeployedPoolsList', target: factoryAddress })
 
@@ -36,13 +36,14 @@ export const fetchAjna = async (options: FetchOptions, factoryAddress: string, p
 
       const totalInterestEarnedByLenders = reserveInfoEnd[i][reserveInfoIndex] - reserveInfoStart[i][reserveInfoIndex]
       if (totalInterestEarnedByLenders > 0) {
+        dailyFees.add(quoteToken[i], totalInterestEarnedByLenders / quoteTokenScale[i], METRIC.BORROW_INTEREST)
         dailySupplySideRevenue.add(quoteToken[i], totalInterestEarnedByLenders / quoteTokenScale[i], METRIC.BORROW_INTEREST)
       }
 
       const poolReserves = poolReserveInfoEnd[i][0] - poolReserveInfoStart[i][0];
       if (poolReserves > 0) {
-        dailyFees.add(quoteToken[i], poolReserves / quoteTokenScale[i], "Reserve Accumulation")
-        dailyProtocolRevenue.add(quoteToken[i], poolReserves / quoteTokenScale[i], "Reserve Accumulation To Protocol")
+        dailyFees.add(quoteToken[i], poolReserves / quoteTokenScale[i], METRIC.BORROW_INTEREST)
+        dailyRevenue.add(quoteToken[i], poolReserves / quoteTokenScale[i], "Reserve Accumulation")
       }
       const hasBurn = currentBurnEpochEnd[i][0] - currentBurnEpochStart[i][0];
       if (hasBurn) {
@@ -73,15 +74,10 @@ export const fetchAjna = async (options: FetchOptions, factoryAddress: string, p
     })
   }
 
-  dailyFees.addBalances(dailySupplySideRevenue)
-
-  const dailyRevenue = options.createBalances();
-  dailyRevenue.addBalances(dailyProtocolRevenue);
-
   return {
     dailyFees,
     dailyRevenue,
-    dailyProtocolRevenue,
+    dailyProtocolRevenue: 0, // revenue are used to buy back and burn AJNA token 
     dailyHoldersRevenue,
     dailySupplySideRevenue,
   };
@@ -96,16 +92,12 @@ const fetch = async (options: FetchOptions) => {
 const breakdownMethodology = {
   Fees: {
     [METRIC.BORROW_INTEREST]: "Interest paid by borrowers for loans, with approximately 85-90% distributed to lenders",
-    "Reserve Accumulation": "Portion of borrow interest accumulated in pool reserves, approximately 10-15% of total interest, held for future token burns",
   },
   Revenue: {
-    "Reserve Accumulation To Protocol": "Protocol-held reserves pending auction, eventually used to buy back and burn AJNA tokens"
+    "Reserve Accumulation": "Portion of borrow interest accumulated in pool reserves, approximately 10-15% of total interest, held for future token burns"
   },
   SupplySideRevenue: {
     [METRIC.BORROW_INTEREST]: "Interest distributed to lenders who supply liquidity to lending pools"
-  },
-  ProtocolRevenue: {
-    "Reserve Accumulation To Protocol": "Protocol-held reserves pending auction, eventually used to buy back and burn AJNA tokens"
   },
   HoldersRevenue: {
     [METRIC.TOKEN_BUY_BACK]: "AJNA token burns that reduce circulating supply, benefiting all token holders"
@@ -120,7 +112,7 @@ const adapter: SimpleAdapter = {
   methodology: {
     Fees: "Total interest paid by borrowers: ~85-90% to lenders and ~10-15% to protocol reserves",
     Revenue: "~10-15% of borrower interest accumulated in pool reserves, held by the protocol pending reserve auctions",
-    ProtocolRevenue: "~10-15% of borrower interest accumulated in pool reserves, held pending reserve auctions",
+    ProtocolRevenue: "No revenue were collected by Ajna protocol.",
     HoldersRevenue: "Accumulated reserves auctioned periodically to buy back and burn AJNA tokens (off-statement; funded by prior periods' reserves)",
     SupplySideRevenue: "~85-90% of borrower interest distributed to lenders"
   },

--- a/fees/ajna-v2/index.ts
+++ b/fees/ajna-v2/index.ts
@@ -85,16 +85,12 @@ const fetch = async (options: FetchOptions) => {
 const breakdownMethodology = {
   Fees: {
     [METRIC.BORROW_INTEREST]: "Interest paid by borrowers for loans, with approximately 85-90% distributed to lenders",
-    "Reserve Accumulation": "Portion of borrow interest accumulated in pool reserves, approximately 10-15% of total interest, held for future token burns",
   },
   Revenue: {
-    "Reserve Accumulation To Protocol": "Protocol-held reserves pending auction, eventually used to buy back and burn AJNA tokens"
+    "Reserve Accumulation": "Portion of borrow interest accumulated in pool reserves, approximately 10-15% of total interest, held for future token burns"
   },
   SupplySideRevenue: {
     [METRIC.BORROW_INTEREST]: "Interest distributed to lenders who supply liquidity to lending pools"
-  },
-  ProtocolRevenue: {
-    "Reserve Accumulation To Protocol": "Protocol-held reserves pending auction, eventually used to buy back and burn AJNA tokens"
   },
   HoldersRevenue: {
     [METRIC.TOKEN_BUY_BACK]: "AJNA token burns that reduce circulating supply, benefiting all token holders"
@@ -108,7 +104,7 @@ const adapter: SimpleAdapter = {
   methodology: {
     Fees: "Total interest paid by borrowers: ~85-90% to lenders and ~10-15% to protocol reserves",
     Revenue: "~10-15% of borrower interest accumulated in pool reserves, held by the protocol pending reserve auctions",
-    ProtocolRevenue: "~10-15% of borrower interest accumulated in pool reserves, held pending reserve auctions",
+    ProtocolRevenue: "No revenue were collected by Ajna protocol.",
     HoldersRevenue: "Accumulated reserves auctioned periodically to buy back and burn AJNA tokens",
     SupplySideRevenue: "~85-90% of borrower interest distributed to lenders"
   },

--- a/fees/ajna-v2/index.ts
+++ b/fees/ajna-v2/index.ts
@@ -85,14 +85,16 @@ const fetch = async (options: FetchOptions) => {
 const breakdownMethodology = {
   Fees: {
     [METRIC.BORROW_INTEREST]: "Interest paid by borrowers for loans, with approximately 85-90% distributed to lenders",
-    "Reserve accumulation": "Portion of borrow interest accumulated in pool reserves, approximately 10-15% of total interest, held for future token burns",
-    [METRIC.TOKEN_BUY_BACK]: "AJNA token burns executed through reserve auctions, reducing circulating supply"
+    "Reserve Accumulation": "Portion of borrow interest accumulated in pool reserves, approximately 10-15% of total interest, held for future token burns",
   },
   Revenue: {
-    [METRIC.TOKEN_BUY_BACK]: "AJNA token burns funded by accumulated reserves through periodic auctions"
+    "Reserve Accumulation To Protocol": "Protocol-held reserves pending auction, eventually used to buy back and burn AJNA tokens"
   },
   SupplySideRevenue: {
     [METRIC.BORROW_INTEREST]: "Interest distributed to lenders who supply liquidity to lending pools"
+  },
+  ProtocolRevenue: {
+    "Reserve Accumulation To Protocol": "Protocol-held reserves pending auction, eventually used to buy back and burn AJNA tokens"
   },
   HoldersRevenue: {
     [METRIC.TOKEN_BUY_BACK]: "AJNA token burns that reduce circulating supply, benefiting all token holders"
@@ -104,11 +106,11 @@ const adapter: SimpleAdapter = {
   fetch,
   adapter: chainConfig,
   methodology: {
-    Fees: "Fees collected from borrowers, lenders, and penalties",
-    Revenue: "~10-15% net interest margin + origination fees and penalties are used to burn AJNA token",
-    ProtocolRevenue: "Protocol takes no direct fees",
-    HoldersRevenue: "Accumulated fees in reserves are used for token burns by utilizing auctions",
-    SupplySideRevenue: "~85-90% interest rate goes to lenders from borrowers"
+    Fees: "Total interest paid by borrowers: ~85-90% to lenders and ~10-15% to protocol reserves",
+    Revenue: "~10-15% of borrower interest accumulated in pool reserves, held by the protocol pending reserve auctions",
+    ProtocolRevenue: "~10-15% of borrower interest accumulated in pool reserves, held pending reserve auctions",
+    HoldersRevenue: "Accumulated reserves auctioned periodically to buy back and burn AJNA tokens",
+    SupplySideRevenue: "~85-90% of borrower interest distributed to lenders"
   },
   breakdownMethodology,
 };


### PR DESCRIPTION
Fixes two accounting issues in the Ajna adapters:

* Reserve accumulation (~10–15% of borrower interest) was included in `dailyFees` but not assigned to any revenue destination, breaking:

  ```
  dailyFees = dailySupplySideRevenue + dailyRevenue
  ```

* AJNA burns were incorrectly added into `dailyFees` via:

  ```
  dailyFees.addBalances(dailyHoldersRevenue)
  ```

causing double-counting. Burns are redistribution of existing reserves, not new user-paid fees.

## Changes

* Added `dailyProtocolRevenue` for reserve accumulation
* `dailyRevenue` now equals protocol revenue only
* Removed AJNA burns from `dailyFees`
* Updated methodology + labels to match GUIDELINES