### PR TITLE
[feat] Zo-Perps: add oi adapter via api

### DIFF
--- a/open-interest/zo-perps-oi.ts
+++ b/open-interest/zo-perps-oi.ts
@@ -1,0 +1,38 @@
+import { FetchOptions, SimpleAdapter } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+import fetchURL from "../utils/fetchURL";
+
+const API_URL = "https://api.zofinance.io/analytics/open-interest";
+
+const fetch = async (_: any, _1: any, options: FetchOptions) => {
+  const { data } = await fetchURL(`${API_URL}?range=1y`);
+  const timestamp = data.reduce((latest: string, row: any) => (
+    new Date(row.timestamp).getTime() / 1000 <= options.endTimestamp && row.timestamp > latest ? row.timestamp : latest
+  ), "");
+  const rows = data.filter((row: any) => row.timestamp === timestamp);
+
+  let openInterestAtEnd = 0;
+  let longOpenInterestAtEnd = 0;
+  let shortOpenInterestAtEnd = 0;
+
+  for (const row of rows) {
+    openInterestAtEnd += Number(row.totalOpenInterest);
+    longOpenInterestAtEnd += Number(row.longOpenInterest);
+    shortOpenInterestAtEnd += Number(row.shortOpenInterest);
+  }
+
+  return {
+    openInterestAtEnd,
+    longOpenInterestAtEnd,
+    shortOpenInterestAtEnd,
+  };
+};
+
+const adapter: SimpleAdapter = {
+  fetch,
+  chains: [CHAIN.SUI],
+  start: "2025-09-19",
+  runAtCurrTime: true,
+};
+
+export default adapter;


### PR DESCRIPTION
https://defillama.com/protocol/zo-perps

## Summary
- Adds ZO Perps open interest tracking on Sui.
- Uses ZO's 1-year analytics API to support historical end-of-period OI backfill.

## Changes
- Added `open-interest/zo-perps-oi.ts`.
- Reports `openInterestAtEnd`, `longOpenInterestAtEnd`, and `shortOpenInterestAtEnd`.
- Starts backfill from `2025-09-19`.

## Methodology
- Fetches `https://api.zofinance.io/analytics/open-interest?range=1y`.
- Selects the latest daily snapshot at or before the adapter end timestamp and sums all symbol/pool rows.

## Tests
- `pnpm test open-interest zo-perps-oi`
- `pnpm test open-interest zo-perps-oi 2025-09-19`
- `pnpm test open-interest zo-perps-oi 2025-09-20`
- `pnpm test open-interest zo-perps-oi 2025-12-31`
- `pnpm test open-interest zo-perps-oi 2026-01-01`
- `pnpm test open-interest zo-perps-oi 2026-05-24`
- `pnpm test open-interest zo-perps-oi 2026-05-25`