### PR TITLE
fix(hyperliquid-hlp): subtract HIP-3 deployer fees from HLP dailyFees

### DIFF
--- a/fees/hyperliquid-hlp.ts
+++ b/fees/hyperliquid-hlp.ts
@@ -15,7 +15,12 @@ async function fetch(_1: number, _: any,  options: FetchOptions) {
     spotFees = result.dailySpotFees.clone(hlpShare)
   } else {
     const result = await queryHyperliquidIndexer(options);
-    perpFees = result.dailyPerpRevenue.clone(hlpShare)
+
+    const adjustedPerpRevenue = result.dailyPerpRevenue.clone()
+    for (const deployer of Object.values(result.hip3Deployers)) {
+      adjustedPerpRevenue.subtract(deployer.dailyPerpFee)
+    }
+    perpFees = adjustedPerpRevenue.clone(hlpShare)
     spotFees = result.dailySpotRevenue.clone(hlpShare)
   }
 


### PR DESCRIPTION
# Summary
> closes #7075 

HLP fees overstated by 3-17% due to HIP-3 Growth Mode markets being counted at full weight.
HIP-3 Growth Mode markets have ~90% reduced taker fees.

## Fix
- Subtract each HIP-3 deployer's `dailyPerpFee` from `dailyPerpRevenue` before applying `hlpShare`

## Tests
- Tests (`pnpm test fees hyperliquid-hlp`) require `LLAMA_HL_INDEXER` env which I dont have; but the fix seem trivial.
