### PR TITLE
gauntlet: add Arbitrum to fees adapter

### DIFF
--- a/fees/gauntlet.ts
+++ b/fees/gauntlet.ts
@@ -58,8 +58,9 @@ const curatorConfig: CuratorConfig = {
     },
     [CHAIN.ARBITRUM]: {
       morphoVaultOwners: [
-        '0x9E33faAE38ff641094fa68c65c2cE600b3410585',
         '0x5a4E19842e09000a582c20A4f524C26Fb48Dd4D0',
+      ],
+      morphoVaultV2Owners: [
         '0xF9D8B7e7981986746c4DE236CC72F1a26AFb5851',
       ],
       start: '2025-07-14',

--- a/fees/gauntlet.ts
+++ b/fees/gauntlet.ts
@@ -56,6 +56,14 @@ const curatorConfig: CuratorConfig = {
       ],
       start: '2025-06-24'
     },
+    [CHAIN.ARBITRUM]: {
+      morphoVaultOwners: [
+        '0x9E33faAE38ff641094fa68c65c2cE600b3410585',
+        '0x5a4E19842e09000a582c20A4f524C26Fb48Dd4D0',
+        '0xF9D8B7e7981986746c4DE236CC72F1a26AFb5851',
+      ],
+      start: '2025-07-14',
+    },
   }
 };
 


### PR DESCRIPTION
## Summary

Add Arbitrum to Gauntlet's curator config. Three vault owners on Arbitrum cure four Morpho vaults; two are active with combined ~$4.88M TVL producing currently-unbooked fees.

## On-chain verification

Vaults discovered via `CreateMetaMorpho` event on Morpho factory `0xA9c3D3a366466Fa809d1Ae982Fb2c46E5fC41101`, filtered by `initialOwner`:

| Vault | Owner | TVL | Status |
|---|---|---|---|
| `0xf786A2437a79e3F1c8b1e442F0AaC6d2dAa90034` Gauntlet USDC Core | `0x9E33...0585` | ~$3.04M | Active (4.73% APR) |
| `0xeE2A0E0Cb1F0Bfa01dd2D9BAec9aFCa0b7D1e8c7` Gauntlet USDC Prime | `0x5a4E...d4D0` | ~$1.84M | Active (3.87% APR) |
| `0xDfa2BbDc1B6E1f87f4c84A6D5B47FE0d99E11D2C` Gauntlet USDT0 Core | `0x9E33...0585` | ~$122 | Dust |
| `0xF9D8...5851`-owned WETH vault | `0xF9D8...5851` | $0 | Dormant |

7-day local-test fetch produces (raw token units):
- USDC Morpho yields: ~5e9 (≈ $4,989/7d → ~$21k/mo fees, ~$2.1k/mo to Gauntlet at 10% perf fee)
- USDT0 Morpho yields: 72,277 wei (≈ $0.07/7d, dust)
- WETH Morpho yields: 1.17e10 wei (≈ $0.00004/7d, dormant)

The third owner `0xF9D8...5851` is kept in the config so future vaults under that initialOwner are picked up automatically.

## Test plan

- [x] `node test.js fees gauntlet arbitrum` style local run via standalone harness (Solana branch needs Dune key)
- [x] Verified discovered vaults match upstream Morpho factory `proxyList` filtered by `initialOwner`
- [x] Verified active TVL via `convertToAssets(1e18)` and `totalAssets()` on each vault