### PR TITLE
feat: add Anchored dimensions adapter for fetching trading metrics

### DIFF
--- a/dexs/anchored/index.ts
+++ b/dexs/anchored/index.ts
@@ -1,0 +1,26 @@
+import { FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import { fetchAnchoredDimensions, toNumber } from "../../helpers/anchored";
+
+const fetch = async (options: FetchOptions) => {
+  const data = await fetchAnchoredDimensions(options);
+  const dailyVolume = options.createBalances();
+
+  dailyVolume.addUSDValue(toNumber(data.dailyVolume));
+
+  return {
+    dailyVolume,
+  };
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  chains: [CHAIN.ETHEREUM, CHAIN.MONAD],
+  fetch,
+  start: "2026-02-01",
+  methodology: {
+    Volume: "Trading volume in USD from settled filled tokenized stock trades on Anchored.",
+  },
+};
+
+export default adapter;

--- a/fees/anchored/index.ts
+++ b/fees/anchored/index.ts
@@ -1,0 +1,54 @@
+import { FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import { METRIC } from "../../helpers/metrics";
+import { fetchAnchoredDimensions, toNumber } from "../../helpers/anchored";
+
+const fetch = async (options: FetchOptions) => {
+  const data = await fetchAnchoredDimensions(options);
+
+  const dailyFees = options.createBalances();
+  const dailyRevenue = options.createBalances();
+
+  dailyFees.addUSDValue(toNumber(data.dailyFees), METRIC.TRADING_FEES);
+  dailyRevenue.addUSDValue(toNumber(data.dailyRevenue), METRIC.TRADING_FEES);
+
+  return {
+    dailyFees,
+    dailyUserFees: dailyFees,
+    dailyRevenue,
+    dailyProtocolRevenue: dailyRevenue,
+  };
+};
+
+const methodology = {
+  Fees: "Trading fees paid by users on settled filled tokenized stock trades, including mint fees and protocol fees.",
+  UserFees: "All tracked fees are paid directly by users when trades settle.",
+  Revenue: "Protocol revenue is the protocol fee portion kept by Anchored.",
+  ProtocolRevenue: "Protocol revenue is allocated to the protocol treasury.",
+};
+
+const breakdownMethodology = {
+  Fees: {
+    [METRIC.TRADING_FEES]: "Mint fees plus protocol fees paid by users on settled filled tokenized stock trades.",
+  },
+  UserFees: {
+    [METRIC.TRADING_FEES]: "Mint fees plus protocol fees paid by users on settled filled tokenized stock trades.",
+  },
+  Revenue: {
+    [METRIC.TRADING_FEES]: "Protocol fee portion kept by Anchored.",
+  },
+  ProtocolRevenue: {
+    [METRIC.TRADING_FEES]: "Protocol fee portion allocated to the protocol treasury.",
+  },
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  chains: [CHAIN.ETHEREUM, CHAIN.MONAD],
+  fetch,
+  start: "2026-02-01",
+  methodology,
+  breakdownMethodology,
+};
+
+export default adapter;

--- a/helpers/anchored.ts
+++ b/helpers/anchored.ts
@@ -1,0 +1,35 @@
+import { FetchOptions } from "../adapters/types";
+import { httpGet } from "../utils/fetchURL";
+
+const API_BASE = process.env.ANCHORED_API_BASE || "https://rwa-api.anchored.finance/rwa/api/v2/defillama";
+
+export type AnchoredDimensions = {
+  dailyVolume: string;
+  dailyFees: string;
+  dailyUserFees: string;
+  dailyRevenue: string;
+  dailyProtocolRevenue: string;
+};
+
+type BaseResponse<T> = {
+  code: number;
+  errMsg?: string;
+  data?: T;
+};
+
+export async function fetchAnchoredDimensions(options: FetchOptions): Promise<AnchoredDimensions> {
+  const params = new URLSearchParams({
+    chain: options.chain,
+    startTimestamp: String(options.startTimestamp),
+    endTimestamp: String(options.endTimestamp),
+  });
+  const response: BaseResponse<AnchoredDimensions> = await httpGet(`${API_BASE}/dimensions?${params}`);
+  if (!response || response.code !== 200 || !response.data) {
+    throw new Error(response?.errMsg || `Anchored dimensions endpoint failed for ${options.chain}`);
+  }
+  return response.data;
+}
+
+export function toNumber(value?: string): number {
+  return Number(value || 0);
+}


### PR DESCRIPTION
Adds Anchored Finance dimension adapters for:

  - DEX volume: `dexs/anchored`
  - Fees/revenue: `fees/anchored`

  The adapters track settled filled tokenized stock trades on Ethereum and Monad using Anchored's DefiLlama dimensions endpoint.

  ##### Name (to be shown on DefiLlama):

  Anchored Finance

  ##### Twitter Link:

  https://x.com/AnchoredFi

  ##### List of audit links if any:

  Sherlock audit report:
  https://sherlock-files.ams3.digitaloceanspaces.com/reports/2026.04.02%20-%20Final%20-%20Anchored%20Collaborative%20Audit%20Report%201775117748.pdf

  ##### Website Link:

  https://anchored.finance/

  ##### Logo (High resolution, will be shown with rounded borders):

  https://anchored.finance/favicon.svg

  ##### Current TVL:

  N/A - this PR adds volume and fee/revenue dimension adapters, not a TVL adapter.

  Existing RWA listing: https://defillama.com/rwa/platform/anchored-finance

  ##### Treasury Addresses (if the protocol has treasury)

  N/A / not publicly documented

  ##### Chain:

  Ethereum, Monad

  ##### Short Description (to be shown on DefiLlama):

  Anchored Finance provides infrastructure for the compliant issuance, redemption, and distribution of tokenized real-world assets,
  starting with 1:1 backed tokenized stocks and fund products.

  ##### Token address and ticker if any:

  No native protocol token.

  Anchored tokenized stocks use the `a` + ticker format, e.g. `aAAPL`, `aNVDA`, `aTSLA`. Full token list and contract addresses are
  documented here:

  https://docs.anchored.finance/getting-started/anchored-tokens

  ##### Category (full list at https://defillama.com/categories) *Please choose only one:

  RWA

  ##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.):

  N/A for this dimension adapter. The adapter does not use an on-chain oracle.

  ##### Implementation Details: Briefly describe how the oracle is integrated into your project:

  The DefiLlama adapters query Anchored's time-bounded dimensions endpoint by chain and return:

  - `dailyVolume` for settled filled tokenized stock trades
  - `dailyFees` / `dailyUserFees` for user-paid trading fees
  - `dailyRevenue` / `dailyProtocolRevenue` for the protocol fee portion kept by Anchored

  No additional package dependencies are added.

  ##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage:

  Anchored docs: https://docs.anchored.finance/
  Overview: https://docs.anchored.finance/getting-started/quickstart
  Token list: https://docs.anchored.finance/getting-started/anchored-tokens
  Proof of Reserves: https://docs.anchored.finance/general/trust-and-transparency
  Accountable PoR dashboard: https://accountable.anchored.finance/
  Smart contract audit: https://docs.anchored.finance/general/smart-contract-audits

  ##### forkedFrom (Does your project originate from another project):

  No

  ##### methodology (what is being counted as tvl, how is tvl being calculated):

  This PR does not add a TVL adapter.

  Volume counts USD trading volume from settled filled tokenized stock trades on Anchored.

  Fees count trading fees paid by users on settled filled tokenized stock trades, including mint fees and protocol fees.

  Revenue counts the protocol fee portion kept by Anchored and allocated to protocol revenue.

  ##### Github org/user (Optional, if your code is open source, we can track activity):

  N/A

  ##### Does this project have a referral program?

  N/A / not publicly documented