### PR TITLE
factory/curators: fill missing Morpho V1.1 chain coverage for Hyperithm, MEV-Capital, Yearn-Curating

### DIFF
--- a/factory/curators.ts
+++ b/factory/curators.ts
@@ -141,6 +141,10 @@ const configs: Record<string, CuratorConfig> = {
         morphoVaultOwners: ['0x16fa314141C76D4a0675f5e8e3CCBE4E0fA22C7c'],
         morphoVaultV2Owners: ['0xC56EA16EA06B0a6A7b3B03B2f48751e549bE40fD'],
       },
+      [CHAIN.ARBITRUM]: {
+        morphoVaultOwners: ['0xC56EA16EA06B0a6A7b3B03B2f48751e549bE40fD'],
+        start: '2025-09-04',
+      },
       [CHAIN.KATANA]: {
         morphoVaultV2Owners: ['0xC56EA16EA06B0a6A7b3B03B2f48751e549bE40fD'],
         start: '2025-12-22'
@@ -171,8 +175,17 @@ const configs: Record<string, CuratorConfig> = {
   "mev-capital": {
     vaults: {
       [CHAIN.ETHEREUM]: {
-        morphoVaultOwners: ['0x06590Fef209Ebc1f8eEF83dA05984cD4eFf0d0E3', '0x650741eB4f6AB0776B9bF98A3280E3Cd6A2F1BF1', '0x6fA5d361Ab8165347F636217001E22a7cEF09B48'],
+        morphoVaultOwners: ['0x06590Fef209Ebc1f8eEF83dA05984cD4eFf0d0E3', '0x650741eB4f6AB0776B9bF98A3280E3Cd6A2F1BF1', '0x6fA5d361Ab8165347F636217001E22a7cEF09B48', '0x0f2dc4f7d060e5cee687b3acabd85d5c94efb756'],
         eulerVaultOwners: ['0xF1B4Ad34B4DbBAab120e4A04Eb3D3707Ea41b6eb', '0x6293e97900aA987Cf3Cbd419e0D5Ba43ebfA91c1'],
+      },
+      [CHAIN.HYPERLIQUID]: {
+        morphoVaultOwners: [
+          '0x444543b439b1169cefc50be42caa628b0ea35d85',
+          '0x6293e97900aA987Cf3Cbd419e0D5Ba43ebfA91c1',
+          '0x6fA5d361Ab8165347F636217001E22a7cEF09B48',
+          '0x0f2dc4f7d060e5cee687b3acabd85d5c94efb756',
+        ],
+        start: '2025-04-24',
       },
       [CHAIN.SONIC]: {
         eulerVaultOwners: ['0xb1a084b03a75f4bBb895b91BF1f5E9615A28F17D', '0xB672Ea44A1EC692A9Baf851dC90a1Ee3DB25F1C4', '0x6293e97900aA987Cf3Cbd419e0D5Ba43ebfA91c1', '0x3fEcc0d59BF024De157996914e548047ec0ccCE5'],
@@ -442,6 +455,10 @@ const configs: Record<string, CuratorConfig> = {
       },
       [CHAIN.BASE]: {
         morphoVaultOwners: ['0xFc5F89d29CCaa86e5410a7ad9D9d280d4455C12B', '0x50b75d586929ab2f75dc15f07e1b921b7c4ba8fa'],
+      },
+      [CHAIN.ARBITRUM]: {
+        morphoVaultOwners: ['0xFc5F89d29CCaa86e5410a7ad9D9d280d4455C12B'],
+        start: '2025-07-22',
       },
       [CHAIN.KATANA]: {
         start: '2025-06-30',


### PR DESCRIPTION
## Summary

Three top Morpho curators have meaningful Morpho V1.1 vault deployments on chains absent from \`factory/curators.ts\`, plus MEV-Capital has a deployer address missing on Ethereum so two real-fee vaults are unattributed. This PR adds those owners/chains based on on-chain CreateMetaMorpho event data cross-checked with Morpho's curator registry.

## Verified gaps closed

| Curator | Chain | Vaults added | Total TVL | Top vault | APY | Fee |
|---|---|---:|---:|---|---:|---:|
| Hyperithm | Arbitrum (new) | 1 | $780k | hyperUSDCa | 4.45% | 10% |
| MEV-Capital | Ethereum (initialOwner gap) | 2 | $570k | sgfEURCV | 8.33% | 8% |
| MEV-Capital | Hyperliquid (new) | 4 | $773k | mcHYPE | 7.89% | 0% (supply-only) |
| Yearn-Curating | Arbitrum (new) | 3 | $54k | yDG-USDC | 1.97% | 10% |

Aggregate: ~$2.18M TVL coverage added, ~$3.6k+/year in protocol revenue currently unbooked plus ~$95k+/year supply-side yield.

## How the addresses were sourced

For each curator the missing-chain vault addresses come from Morpho's blue-api curator registry filtered by \`ownerAddress_in\` for that curator's known operator addresses. The \`initialOwner\` (the constructor arg in CreateMetaMorpho, which is what the curator framework filters on) was then read from \`metamorpho_factory_multichain.metamorphov1_1factory_evt_createmetamorpho\` decoded events on Dune. Examples:

- Hyperithm Arbitrum hyperUSDC (\`0x4b6f1c9e5d470b97181786b26da0d0945a7cf027\`) — initialOwner \`0xc56ea16e...\` (already in Hyperithm Ethereum \`morphoVaultV2Owners\`; same address used as V1.1 owner on Arbitrum).
- MEV-Capital Ethereum sgfEURCV (\`0x34ece536d2ae03192b06c0a67030d1faf4c0ba43\`) — initialOwner \`0x0f2dc4f7...\` (not currently in any MEV-Capital config entry).
- MEV-Capital Hyperliquid mcHYPE (\`0xd19e3d00f8547f7d108abfd4bbb015486437b487\`) — initialOwner \`0x444543b4...\`.
- Yearn-Curating Arbitrum yDG-USDC, yOG-USDC, yOG-WETH — all initialOwner \`0xFc5F89...\` (already the Yearn-Curating address on Ethereum/Base/Katana).

## Skipped (dormant per the existing framework convention)

- MEV-Capital Arbitrum MCUSDC ($651k but 0% APY), Base mevfUSDC ($51k but 0% APY), Polygon mevUSDC ($9 dust), Unichain MC_USDC ($335 dust), Katana MC_USDC ($0).
- Hyperithm HyperEVM (top vault hyperUSDT0 only 0.07% APY), Katana ($1), Monad ($25).
- Yearn-Curating HyperEVM + Optimism (deposits but 0% APY on the only sized vault).

These can be re-added later once the deployments materialise; adding them now would write \$0 into production indefinitely.

## Test plan

- [x] Verified each added \`initialOwner\` actually deployed the claimed vaults via decoded \`CreateMetaMorpho\` events on Dune
- [x] Verified TVL / APY / fee for every vault added via Morpho's blue-api at production-current state
- [x] Confirmed every added chain is in \`helpers/curators/configs.ts\` \`MorphoConfigs\` (factory addresses present)
- [x] Branch cut fresh from upstream master, single-file diff (factory/curators.ts only), 1 file changed, +18/-1