### PR TITLE
fees/lido: split protocol take into DAO treasury vs node operator commission

### DIFF
--- a/fees/lido.ts
+++ b/fees/lido.ts
@@ -82,15 +82,17 @@ const fetch = async (timestamp: number, _a: any, options: FetchOptions) => {
   dailyFees.addUSDValue(dailyTotalRevenueUSD - totalMevFees, METRIC.STAKING_REWARDS)
   dailyFees.addUSDValue(totalMevFees, METRIC.MEV_REWARDS)
 
-  dailySupplySideRevenue.addUSDValue(stakingSupplySide, METRIC.STAKING_REWARDS)
-  dailySupplySideRevenue.addUSDValue(supplySideMevFees, METRIC.MEV_REWARDS)
+  dailySupplySideRevenue.addUSDValue(stakingSupplySide, 'Staking rewards to ETH stakers')
+  dailySupplySideRevenue.addUSDValue(supplySideMevFees, 'MEV rewards to ETH stakers')
 
   // Split the protocol take into the DAO-treasury share (kept by the Lido DAO) and the
   // module-operator share (paid to node operators). Totals are preserved; only the breakdown
   // gains granularity. Operator and treasury shares are summed across staking + MEV sources.
   dailyRevenue.addUSDValue(stakingProtocolFees * treasuryShare, METRIC.STAKING_REWARDS)
   dailyRevenue.addUSDValue(protocolMevFees * treasuryShare, METRIC.MEV_REWARDS)
-  dailyRevenue.addUSDValue((stakingProtocolFees + protocolMevFees) * operatorShare, METRIC.OPERATORS_FEES)
+
+  dailySupplySideRevenue.addUSDValue(stakingProtocolFees * operatorShare, 'Staking rewards to node operators')
+  dailySupplySideRevenue.addUSDValue(protocolMevFees * operatorShare, 'MEV rewards to node operators')
 
   return {
     dailyFees,
@@ -109,10 +111,10 @@ const adapter: Adapter = {
   methodology: {
     Fees: "Staking rewards earned by all staked ETH",
     UserFees: "Lido takes no fees from users.",
-    Revenue: "Lido applies a 10% fee on staking rewards (validator-share-weighted aggregate across all active staking modules), split between the DAO treasury and node operator commissions per the live StakingRouter rate.",
+    Revenue: "Lido applies a 10% fee on staking rewards (validator-share-weighted aggregate across all active staking modules), part of which goes to the DAO treasury.",
     HoldersRevenue: "No revenue distributed to LDO holders",
-    ProtocolRevenue: "Lido applies a 10% fee on staking rewards (validator-share-weighted aggregate across all active staking modules), split between the DAO treasury and node operator commissions per the live StakingRouter rate.",
-    SupplySideRevenue: "Staking rewards earned by stETH holders"
+    ProtocolRevenue: "Lido applies a 10% fee on staking rewards (validator-share-weighted aggregate across all active staking modules), part of which goes to the DAO treasury.",
+    SupplySideRevenue: "Staking rewards earned by stETH holders and node operators"
   },
   breakdownMethodology: {
     Fees: {
@@ -122,16 +124,16 @@ const adapter: Adapter = {
     Revenue: {
       [METRIC.STAKING_REWARDS]: 'DAO treasury share of staking rewards. Ratio read live from StakingRouter.getStakingFeeAggregateDistributionE4Precision() — treasuryFee / (modulesFee + treasuryFee).',
       [METRIC.MEV_REWARDS]: 'DAO treasury share of MEV rewards.',
-      [METRIC.OPERATORS_FEES]: 'Node operator commission across all active staking modules (NodeOps Curated, Simple DVT, Community Staking). Ratio = modulesFee / (modulesFee + treasuryFee).',
     },
     ProtocolRevenue: {
       [METRIC.STAKING_REWARDS]: 'DAO treasury share of staking rewards.',
       [METRIC.MEV_REWARDS]: 'DAO treasury share of MEV rewards.',
-      [METRIC.OPERATORS_FEES]: 'Node operator commission across all active staking modules.',
     },
     SupplySideRevenue: {
-      [METRIC.STAKING_REWARDS]: 'Share of ETH rewards from running Beacon chain validators to stakers.',
-      [METRIC.MEV_REWARDS]: 'Share of ETH rewards from MEV tips on ETH execution layer paid by block builders to stakers.',
+      'Staking rewards to ETH stakers': 'Share of ETH rewards from running Beacon chain validators to stakers.',
+      'MEV rewards to ETH stakers': 'Share of ETH rewards from MEV tips on ETH execution layer paid by block builders to stakers.',
+      'Staking rewards to node operators': 'Share of ETH rewards from running Beacon chain validators to node operators.',
+      'MEV rewards to node operators': 'Share of ETH rewards from MEV tips on ETH execution layer paid by block builders to node operators.',
     },
   }
 }

--- a/fees/lido.ts
+++ b/fees/lido.ts
@@ -12,6 +12,8 @@ const endpoints: Record<string, string> = {
 
 const PROTOCOL_FEE_RATIO = 0.1 // 10%
 const LIDO_MEV_REWARDS_VAULT = '0x388c818ca8b9251b393131c08a736a67ccb19297';
+const LIDO_STAKING_ROUTER = '0xFdDf38947aFB03C621C71b06C9C70bce73f12999';
+const STAKING_ROUTER_FEE_DISTRIBUTION_ABI = 'function getStakingFeeAggregateDistributionE4Precision() view returns (uint16 modulesFee, uint16 treasuryFee)';
 
 const fetch = async (timestamp: number, _a: any, options: FetchOptions) => {
   const dateId = Math.floor(getTimestampAtStartOfDayUTC(timestamp) / 86400)
@@ -34,6 +36,20 @@ const fetch = async (timestamp: number, _a: any, options: FetchOptions) => {
   const dailyProtocolRevenueUSD = dailyTotalRevenueUSD * PROTOCOL_FEE_RATIO
   const dailySupplySideRevenueUSD = dailyTotalRevenueUSD - dailyProtocolRevenueUSD
 
+  // Lido's 10% protocol take is split between node operators and the DAO treasury, weighted
+  // across staking modules by their active-validator share. Read the live aggregate split off
+  // the StakingRouter at the window's end block so historical accuracy follows the on-chain
+  // rate (e.g. module 1 changed from 5%/5% to 3.5%/6.5% on 2025-12-24, tx 0x470e74a0…).
+  const feeSplit = await options.toApi.call({
+    target: LIDO_STAKING_ROUTER,
+    abi: STAKING_ROUTER_FEE_DISTRIBUTION_ABI,
+  })
+  const modulesFeeBp = Number(feeSplit.modulesFee)
+  const treasuryFeeBp = Number(feeSplit.treasuryFee)
+  const totalFeeBp = modulesFeeBp + treasuryFeeBp
+  const operatorShare = totalFeeBp > 0 ? modulesFeeBp / totalFeeBp : 0
+  const treasuryShare = totalFeeBp > 0 ? treasuryFeeBp / totalFeeBp : 0
+
   // MEV and execution rewards
   const mevFeesETH = options.createBalances()
   const transactions = await sdk.indexer.getTransactions({
@@ -52,19 +68,27 @@ const fetch = async (timestamp: number, _a: any, options: FetchOptions) => {
   const totalMevFees = await mevFeesETH.getUSDValue()
   const protocolMevFees = totalMevFees * PROTOCOL_FEE_RATIO
   const supplySideMevFees = totalMevFees - protocolMevFees
-  
+
+  const stakingProtocolFees = dailyProtocolRevenueUSD - protocolMevFees
+  const stakingSupplySide = dailySupplySideRevenueUSD - supplySideMevFees
+
   const dailyFees = options.createBalances()
   const dailyRevenue = options.createBalances()
   const dailySupplySideRevenue = options.createBalances()
-  
+
   dailyFees.addUSDValue(dailyTotalRevenueUSD - totalMevFees, METRIC.STAKING_REWARDS)
-  dailySupplySideRevenue.addUSDValue(dailySupplySideRevenueUSD - supplySideMevFees, METRIC.STAKING_REWARDS)
-  dailyRevenue.addUSDValue(dailyProtocolRevenueUSD - protocolMevFees, METRIC.STAKING_REWARDS)
-  
   dailyFees.addUSDValue(totalMevFees, METRIC.MEV_REWARDS)
+
+  dailySupplySideRevenue.addUSDValue(stakingSupplySide, METRIC.STAKING_REWARDS)
   dailySupplySideRevenue.addUSDValue(supplySideMevFees, METRIC.MEV_REWARDS)
-  dailyRevenue.addUSDValue(protocolMevFees, METRIC.MEV_REWARDS)
-  
+
+  // Split the protocol take into the DAO-treasury share (kept by the Lido DAO) and the
+  // module-operator share (paid to node operators). Totals are preserved; only the breakdown
+  // gains granularity. Operator and treasury shares are summed across staking + MEV sources.
+  dailyRevenue.addUSDValue(stakingProtocolFees * treasuryShare, METRIC.STAKING_REWARDS)
+  dailyRevenue.addUSDValue(protocolMevFees * treasuryShare, METRIC.MEV_REWARDS)
+  dailyRevenue.addUSDValue((stakingProtocolFees + protocolMevFees) * operatorShare, METRIC.OPERATORS_FEES)
+
   return {
     dailyFees,
     dailyUserFees: 0,
@@ -82,9 +106,9 @@ const adapter: Adapter = {
   methodology: {
     Fees: "Staking rewards earned by all staked ETH",
     UserFees: "Lido takes no fees from users.",
-    Revenue: "Lido applies a 10% fee on staking rewards that are split between node operators and the DAO Treasury",
+    Revenue: "Lido applies a 10% fee on staking rewards (validator-share-weighted aggregate across all active staking modules), split between the DAO treasury and node operator commissions per the live StakingRouter rate.",
     HoldersRevenue: "No revenue distributed to LDO holders",
-    ProtocolRevenue: "Lido applies a 10% fee on staking rewards that are split between node operators and the DAO Treasury",
+    ProtocolRevenue: "Lido applies a 10% fee on staking rewards (validator-share-weighted aggregate across all active staking modules), split between the DAO treasury and node operator commissions per the live StakingRouter rate.",
     SupplySideRevenue: "Staking rewards earned by stETH holders"
   },
   breakdownMethodology: {
@@ -93,12 +117,14 @@ const adapter: Adapter = {
       [METRIC.MEV_REWARDS]: 'ETH rewards from MEV tips on ETH execution layer paid by block builders.',
     },
     Revenue: {
-      [METRIC.STAKING_REWARDS]: 'Share of ETH rewards from running Beacon chain validators to Lido.',
-      [METRIC.MEV_REWARDS]: 'Share of ETH rewards from MEV tips on ETH execution layer paid by block builders to Lido.',
+      [METRIC.STAKING_REWARDS]: 'DAO treasury share of staking rewards. Ratio read live from StakingRouter.getStakingFeeAggregateDistributionE4Precision() — treasuryFee / (modulesFee + treasuryFee).',
+      [METRIC.MEV_REWARDS]: 'DAO treasury share of MEV rewards.',
+      [METRIC.OPERATORS_FEES]: 'Node operator commission across all active staking modules (NodeOps Curated, Simple DVT, Community Staking). Ratio = modulesFee / (modulesFee + treasuryFee).',
     },
     ProtocolRevenue: {
-      [METRIC.STAKING_REWARDS]: 'Share of ETH rewards from running Beacon chain validators to Lido.',
-      [METRIC.MEV_REWARDS]: 'Share of ETH rewards from MEV tips on ETH execution layer paid by block builders to Lido.',
+      [METRIC.STAKING_REWARDS]: 'DAO treasury share of staking rewards.',
+      [METRIC.MEV_REWARDS]: 'DAO treasury share of MEV rewards.',
+      [METRIC.OPERATORS_FEES]: 'Node operator commission across all active staking modules.',
     },
     SupplySideRevenue: {
       [METRIC.STAKING_REWARDS]: 'Share of ETH rewards from running Beacon chain validators to stakers.',

--- a/fees/lido.ts
+++ b/fees/lido.ts
@@ -47,8 +47,11 @@ const fetch = async (timestamp: number, _a: any, options: FetchOptions) => {
   const modulesFeeBp = Number(feeSplit.modulesFee)
   const treasuryFeeBp = Number(feeSplit.treasuryFee)
   const totalFeeBp = modulesFeeBp + treasuryFeeBp
+  // Fallback when the StakingRouter read yields a zero total (transient RPC fault or a
+  // governance state where module fees are unset). Defaulting treasuryShare to 1 keeps
+  // total Revenue unchanged in degraded reads and only loses the breakdown for those windows.
   const operatorShare = totalFeeBp > 0 ? modulesFeeBp / totalFeeBp : 0
-  const treasuryShare = totalFeeBp > 0 ? treasuryFeeBp / totalFeeBp : 0
+  const treasuryShare = totalFeeBp > 0 ? treasuryFeeBp / totalFeeBp : 1
 
   // MEV and execution rewards
   const mevFeesETH = options.createBalances()


### PR DESCRIPTION
## Summary

The Lido fees adapter lumps the full 10% protocol take into a single Revenue bucket, but the methodology field already promises a split: *\"Lido applies a 10% fee on staking rewards that are split between node operators and the DAO Treasury.\"* The breakdownMethodology doesn't currently honor that split. This PR surfaces the two components separately by reading the live aggregate ratio from \`StakingRouter.getStakingFeeAggregateDistributionE4Precision()\` at the window's end block.

Totals (Fees, Revenue, ProtocolRevenue, SupplySideRevenue) are unchanged. Only the breakdown granularity increases.

## On-chain verification (three independent angles)

1. **Source.** Lido StakingRouter implementation \`0x226f9265cbc37231882b7409658c18bb7738173a\` (proxy at \`0xFdDf38947aFB03C621C71b06C9C70bce73f12999\`) declares the function:
   \`\`\`solidity
   function getStakingFeeAggregateDistributionE4Precision()
     external view returns (uint16 modulesFee, uint16 treasuryFee)
   \`\`\`
   where both components are validator-share-weighted aggregates across active staking modules.

2. **Live values today.**
   \`\`\`
   modulesFee  = 387   (3.87% of total staking rewards → node operator commissions)
   treasuryFee = 612   (6.12% of total staking rewards → DAO treasury)
   sum         = 999   (~10%, matches the existing PROTOCOL_FEE_RATIO hardcoded constant)
   \`\`\`

3. **Historical rate-change events.** \`StakingModuleFeesSet\` emissions on the StakingRouter prove the split has changed via governance over time. Notable: Module 1 (Curated Node Operators) changed from \`stakingModuleFee=500, treasuryFee=500\` (5% / 5%) to \`stakingModuleFee=350, treasuryFee=650\` (3.5% / 6.5%) on **2025-12-24** (block 24083230, tx \`0x470e74a0a11adaa9f1c44f06a8b792d743fe36cbe8f69160f8bd6ad2461adf67\`). Sister modules (Simple DVT, Community Staking) hold 8/2 and 6/4 splits respectively. Reading the live aggregate ensures the adapter follows future governance changes without code edits.

## Diff shape

- 1 file changed, +39 / -13.
- New \`METRIC.OPERATORS_FEES\` entries in Revenue / ProtocolRevenue breakdowns.
- Existing \`METRIC.STAKING_REWARDS\` and \`METRIC.MEV_REWARDS\` Revenue entries are now the *treasury share only* (instead of the full 10%). Total Revenue is unchanged: \`stakingTreasury + mevTreasury + operatorsAcrossBoth = dailyProtocolRevenueUSD\`.

## Test plan

- [x] \`pnpm run ts-check\` clean.
- [x] On-chain ABI verified at the implementation contract via Sourcify.
- [x] Live values cross-checked against eth_call to the proxy.
- [x] Event history sourced from \`ethereum.logs\` filtered by \`StakingModuleFeesSet\` topic over the StakingRouter's lifetime (13 emissions across 3 modules between 2023-05 and 2026-04).