### PR TITLE
[feat] EdgeX-V2: tracks edgeX v2 perps volume

### DIFF
--- a/dexs/edgeX-v2/index.ts
+++ b/dexs/edgeX-v2/index.ts
@@ -1,7 +1,8 @@
 import { PromisePool } from "@supercharge/promise-pool";
 import { FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
-import fetchURL from "../../utils/fetchURL";
+import fetchURL, { fetchURLAutoHandleRateLimit } from "../../utils/fetchURL";
+import { sleep } from "../../utils/utils";
 
 const META_ENDPOINT = "https://edgex-prod-v2.edgex.exchange/api/v2/public/meta/getMetaData";
 const klineEndpoint = (contractId: string, startTime: number, endTime: number) =>
@@ -16,7 +17,8 @@ const fetch = async (_timestamp: number, _chainBlocks: any, options: FetchOption
   const { results } = await PromisePool.withConcurrency(2)
     .for(contracts)
     .process(async (contract: { contractId: string }) => {
-      const response = await fetchURL(klineEndpoint(contract.contractId, startTime, endTime));
+      const response = await fetchURLAutoHandleRateLimit(klineEndpoint(contract.contractId, startTime, endTime));
+      await sleep(500);
       if (!response.data.dataList.length) return 0;
       return response.data.dataList.map((kline: { value: string }) => Number(kline.value)).reduce((total: number, volume: number) => total + volume);
     });

--- a/dexs/edgeX-v2/index.ts
+++ b/dexs/edgeX-v2/index.ts
@@ -1,0 +1,34 @@
+import { PromisePool } from "@supercharge/promise-pool";
+import { FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import fetchURL from "../../utils/fetchURL";
+
+const META_ENDPOINT = "https://edgex-prod-v2.edgex.exchange/api/v2/public/meta/getMetaData";
+const klineEndpoint = (contractId: string, startTime: number, endTime: number) =>
+  `https://edgex-prod-v2.edgex.exchange/api/v2/public/quote/getKline?contractId=${contractId}&klineType=DAY_1&filterBeginKlineTimeInclusive=${startTime}&filterEndKlineTimeExclusive=${endTime}&priceType=LAST_PRICE`;
+
+const fetch = async (_timestamp: number, _chainBlocks: any, options: FetchOptions) => {
+  const metadata = await fetchURL(META_ENDPOINT);
+  const contracts: { contractId: string }[] = metadata.data.contractList.filter((contract: { enableTrade: boolean; enableDisplay: boolean }) => contract.enableTrade && contract.enableDisplay);
+  const startTime = options.startOfDay * 1000;
+  const endTime = options.endTimestamp * 1000;
+
+  const { results } = await PromisePool.withConcurrency(2)
+    .for(contracts)
+    .process(async (contract: { contractId: string }) => {
+      const response = await fetchURL(klineEndpoint(contract.contractId, startTime, endTime));
+      if (!response.data.dataList.length) return 0;
+      return response.data.dataList.map((kline: { value: string }) => Number(kline.value)).reduce((total: number, volume: number) => total + volume);
+    });
+
+  return { dailyVolume: results.reduce((total: number, volume: number) => total + volume) };
+};
+
+const adapter: SimpleAdapter = {
+  version: 1,
+  fetch,
+  chains: [CHAIN.EDGEX],
+  start: "2026-05-12",
+};
+
+export default adapter;


### PR DESCRIPTION
## Summary
- Adds a new `edgeX-v2` DEX volume adapter for edgeX V2 perpetual markets.
- Tracks daily perp trading volume on `CHAIN.EDGEX` from edgeX's public V2 API.

## Changes
- Added `dexs/edgeX-v2/index.ts`.
- Fetches enabled V2 perp contracts from `https://edgex-prod-v2.edgex.exchange/api/v2/public/meta/getMetaData`.
- Aggregates `value` from `DAY_1` klines via `contractId`.
- Uses `PromisePool.withConcurrency(2)` for contract kline requests.
- Sets the adapter start date to `2026-05-12`.

## Methodology
- Sums daily notional volume from edgeX V2 `DAY_1` kline records across enabled and displayed perp contracts.
- Uses completed daily API windows through adapter `version: 1`.

## Notes
- Website: https://pro.edgex.exchange/en-US/perpetuals/BTCUSDC
- Twitter/X: https://x.com/edgeX_exchange

## Tests
- `pnpm test dexs edgeX-v2`
- `pnpm test dexs edgeX-v2 2026-05-13`