### PR TITLE
[feat] EdgeX-V2-Fees: track fee and revenue via api

### DIFF
--- a/fees/edgeX-v2/index.ts
+++ b/fees/edgeX-v2/index.ts
@@ -32,7 +32,7 @@ const fetch = async (_: any, _1: any, options: FetchOptions) => {
 
   dailyFees.addUSDValue(fees, METRIC.TRADING_FEES);
   dailyRevenue.addUSDValue(revenue, METRIC.PROTOCOL_FEES);
-  dailySupplySideRevenue.addUSDValue(fees - revenue, "Trading Fees To Buyback");
+  dailySupplySideRevenue.addUSDValue(fees - revenue, 'Referral Rewards');
 
   return {
     dailyFees,
@@ -44,7 +44,7 @@ const fetch = async (_: any, _1: any, options: FetchOptions) => {
 const methodology = {
   Fees: "Total trading fees paid by users on edgeX v2.",
   Revenue: "The portion of trading fees kept by the protocol.",
-  SupplySideRevenue: "The portion of trading fees used to buyback EDGE token.",
+  SupplySideRevenue: "The portion of trading fees distributed as referral rewards.",
 };
 
 const breakdownMethodology = {
@@ -55,7 +55,7 @@ const breakdownMethodology = {
     [METRIC.PROTOCOL_FEES]: "Trading fees kept by the edgeX protocol.",
   },
   SupplySideRevenue: {
-    ["Trading Fees To Buyback"]: "The portion of trading fees used to buyback EDGE token.",
+    'Referral Rewards': "The portion of trading fees distributed as referral rewards.",
   },
 };
 

--- a/fees/edgeX-v2/index.ts
+++ b/fees/edgeX-v2/index.ts
@@ -1,0 +1,43 @@
+import { FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import fetchURL from "../../utils/fetchURL";
+
+const API_ENDPOINT = "https://edgex-prod-v2.edgex.exchange/api/v2/public/quote/fee";
+
+interface EdgeXFeeResponse {
+  data: {
+    dayTimestamp: number;
+    fee: string;
+    revenue: string;
+  }[];
+}
+
+const fetch = async (_: any, _1: any, options: FetchOptions) => {
+  const apiUrl = `${API_ENDPOINT}?filterBeginKlineTimeInclusive=${(options.fromTimestamp - 800) * 1000}&filterEndKlineTimeExclusive=${options.toTimestamp * 1000}`;
+  const { data }: EdgeXFeeResponse = await fetchURL(apiUrl);
+  const startOfDayUTC = options.startOfDay * 1000;
+  const dayData = data.find((item) => item.dayTimestamp === startOfDayUTC);
+
+  if (!dayData) {
+    throw new Error(`No fee data found for timestamp ${options.dateString} (ms: ${startOfDayUTC}) in edgeX v2 response`);
+  }
+
+  const dailyFees = dayData.fee;
+  const dailyRevenue = dayData.revenue;
+  const dailySupplySideRevenue = Number(dailyFees) - Number(dailyRevenue);
+
+  return {
+    dailyFees,
+    dailyRevenue,
+    dailySupplySideRevenue,
+  };
+};
+
+const adapter: SimpleAdapter = {
+  version: 1,
+  fetch,
+  chains: [CHAIN.EDGEX],
+  start: "2026-05-12",
+};
+
+export default adapter;

--- a/fees/edgeX-v2/index.ts
+++ b/fees/edgeX-v2/index.ts
@@ -1,7 +1,9 @@
 import { FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
+import { METRIC } from "../../helpers/metrics";
 import fetchURL from "../../utils/fetchURL";
 
+// Holders revenue is calculated in edgex-v1 and resembles all products buyback
 const API_ENDPOINT = "https://edgex-prod-v2.edgex.exchange/api/v2/public/quote/fee";
 
 interface EdgeXFeeResponse {
@@ -22,9 +24,15 @@ const fetch = async (_: any, _1: any, options: FetchOptions) => {
     throw new Error(`No fee data found for timestamp ${options.dateString} (ms: ${startOfDayUTC}) in edgeX v2 response`);
   }
 
-  const dailyFees = dayData.fee;
-  const dailyRevenue = dayData.revenue;
-  const dailySupplySideRevenue = Number(dailyFees) - Number(dailyRevenue);
+  const fees = Number(dayData.fee);
+  const revenue = Number(dayData.revenue);
+  const dailyFees = options.createBalances();
+  const dailyRevenue = options.createBalances();
+  const dailySupplySideRevenue = options.createBalances();
+
+  dailyFees.addUSDValue(fees, METRIC.TRADING_FEES);
+  dailyRevenue.addUSDValue(revenue, METRIC.PROTOCOL_FEES);
+  dailySupplySideRevenue.addUSDValue(fees - revenue, "Trading Fees To Buyback");
 
   return {
     dailyFees,
@@ -33,11 +41,31 @@ const fetch = async (_: any, _1: any, options: FetchOptions) => {
   };
 };
 
+const methodology = {
+  Fees: "Total trading fees paid by users on edgeX v2.",
+  Revenue: "The portion of trading fees kept by the protocol.",
+  SupplySideRevenue: "The portion of trading fees used to buyback EDGE token.",
+};
+
+const breakdownMethodology = {
+  Fees: {
+    [METRIC.TRADING_FEES]: "All trading fees paid by users on edgeX v2.",
+  },
+  Revenue: {
+    [METRIC.PROTOCOL_FEES]: "Trading fees kept by the edgeX protocol.",
+  },
+  SupplySideRevenue: {
+    ["Trading Fees To Buyback"]: "The portion of trading fees used to buyback EDGE token.",
+  },
+};
+
 const adapter: SimpleAdapter = {
   version: 1,
   fetch,
   chains: [CHAIN.EDGEX],
   start: "2026-05-12",
+  methodology,
+  breakdownMethodology,
 };
 
 export default adapter;


### PR DESCRIPTION
## Summary
- Adds edgeX v2 perps volume and fees/revenue adapters.
- Uses edgeX v2 public API endpoints for daily volume, fees, and revenue on `CHAIN.EDGEX`.

## Changes
- Added `dexs/edgeX-v2` for daily perps volume using v2 metadata and `DAY_1` klines.
- Added `fees/edgeX-v2` for daily fees, revenue, and supply-side revenue from the v2 fee endpoint.
- Start date set to `2026-05-12`.

## Tests
- `pnpm test dexs edgeX-v2`
- `pnpm test dexs edgeX-v2 2026-05-13`
- `pnpm test fees edgeX-v2`
- `pnpm test fees edgeX-v2 2026-05-13`