### PR TITLE
feat(morpho): add Citrea chain support

### DIFF
--- a/fees/morpho/index.ts
+++ b/fees/morpho/index.ts
@@ -133,6 +133,11 @@ const MorphoBlues: Record<string, MorphoBlueConfig> = {
     blue: "0xF4346F5132e810f80a28487a79c7559d9797E8B0",
     start: "2025-12-16",
   },
+  [CHAIN.CITREA]: {
+    fromBlock: 2528230,
+    blue: "0x99D31FEcc885204b4136ea5D2ef2a37F36E3AeB8",
+    start: "2026-01-23",
+  },
   // [CHAIN.STABLE]: {
   //   fromBlock: 4342501,
   //   blue: "0xa40103088A899514E3fe474cD3cc5bf811b1102e",


### PR DESCRIPTION
## Summary

Adds Citrea support to the Morpho Blue fees adapter.

Morpho Blue is deployed on Citrea but was not tracked in `fees/morpho/index.ts`. This PR adds the Citrea deployment using the existing `fromBlock` log-discovery path used by non-API Morpho chains.

## Changes

Adds one `MorphoBlues` entry:

```ts
[CHAIN.CITREA]: {
  fromBlock: 2528230,
  blue: "0x99D31FEcc885204b4136ea5D2ef2a37F36E3AeB8",
  start: "2026-01-23",
},
```

## Verification

- `CHAIN.CITREA` exists in `helpers/chains.ts`
- Deployment block confirmed: `2528230`
- `CreateMarket` event confirmed at block `2528296`
- `AccrueInterest` event confirmed at block `7686854`
- Existing `namoshi.ts` adapter already uses `getLogs` on `CHAIN.CITREA`, so Citrea log fetching is already used in this repo

## Out of scope

Etherlink was checked but intentionally excluded for now. Its public RPC has a tight block-range limit, and the Morpho adapter does not currently set chain-specific `maxBlockRange` for daily log queries.