### PR TITLE
feat(sushiswap-agg): add ERA and Linea fee coverage

### DIFF
--- a/fees/morpho/index.ts
+++ b/fees/morpho/index.ts
@@ -133,6 +133,11 @@ const MorphoBlues: Record<string, MorphoBlueConfig> = {
     blue: "0xF4346F5132e810f80a28487a79c7559d9797E8B0",
     start: "2025-12-16",
   },
+  [CHAIN.CITREA]: {
+    fromBlock: 2528230,
+    blue: "0x99D31FEcc885204b4136ea5D2ef2a37F36E3AeB8",
+    start: "2026-01-23",
+  },
   // [CHAIN.STABLE]: {
   //   fromBlock: 4342501,
   //   blue: "0xa40103088A899514E3fe474cD3cc5bf811b1102e",

--- a/fees/sushiswap-agg.ts
+++ b/fees/sushiswap-agg.ts
@@ -68,6 +68,8 @@ const RP11_ADDRESS: any = {
   [CHAIN.POLYGON_ZKEVM]: '0xc10ee9031f2a0b84766a86b55a8d90f357910fb4',
   [CHAIN.MANTLE]: '0xc10ee9031f2a0b84766a86b55a8d90f357910fb4',
   [CHAIN.KATANA]: '0xc10ee9031f2a0b84766a86b55a8d90f357910fb4',
+  [CHAIN.ERA]: '0xc10ee9031f2a0b84766a86b55a8d90f357910fb4',
+  [CHAIN.LINEA]: '0xc10ee9031f2a0b84766a86b55a8d90f357910fb4',
 }
 
 const ROUTE_RP7_EVENT = 'event Route(address indexed from, address to, address indexed tokenIn, address tokenOut, uint256 amountIn, uint256 amountOut, int256 slippage, uint32 indexed referralCode)'
@@ -123,5 +125,7 @@ export default {
     [CHAIN.POLYGON_ZKEVM]: { start: '2025-07-04', },
     [CHAIN.MANTLE]: { start: '2025-07-04', },
     [CHAIN.KATANA]: { start: '2025-07-04', },
+    [CHAIN.ERA]: { start: '2026-02-08', },
+    [CHAIN.LINEA]: { start: '2026-02-08', },
   }
 }


### PR DESCRIPTION
## Summary

Adds ERA and Linea to the SushiSwap aggregator fees adapter.

The fees adapter already tracks RP11 and is working on existing chains. This PR extends the same RP11 fee tracking to ERA and Linea, which are already covered by the volume adapter and have active RP11 route events.

## Changes

- Add `CHAIN.ERA` and `CHAIN.LINEA` to `RP11_ADDRESS`
- Add ERA and Linea adapter entries with start date `2026-02-08`

## Verification

- RP11 address matches the existing SushiSwap aggregator volume adapter:
  `0xc10ee9031f2a0b84766a86b55a8d90f357910fb4`
- Route event topic matches existing fee adapter ABI:
  `0x84b514c5b926879bf66a04e4becdc6f521e94a4411e7dfa3dd255f214478f558`
- Recent RP11 route events confirmed:
  - ERA: 2 events in latest 1000 blocks
  - Linea: 4 events in latest 1000 blocks
- RP9/RP10 checked and inactive on both chains, so RP11-only coverage is sufficient
- Tested with `npm test -- fees sushiswap-agg 2026-05-25`:
  - ERA: $1.20 daily fees ✓
  - Linea: $1.99 daily fees ✓
  - No errors on any chain ✓