### PR TITLE
fix(txflow-perps-oi): query end-of-day OI instead of start-of-day

### DIFF
--- a/open-interest/txflow-perps-oi.ts
+++ b/open-interest/txflow-perps-oi.ts
@@ -9,7 +9,9 @@ async function fetch(_a: any, _b: any, options: FetchOptions) {
         FROM
             dune.txflow_mainnet.platform_hourly_oi
         WHERE
-            hour_ts = ${options.startOfDay}
+            hour_ts <= ${options.endTimestamp}
+        ORDER BY hour_ts DESC
+        LIMIT 1
     `;
 
     const result = await queryDuneSql(options, duneQuery);


### PR DESCRIPTION
The WHERE clause used `options.startOfDay` (midnight UTC), so `openInterestAtEnd` was reporting the prior day's closing value. Changed to `hour_ts <= options.endTimestamp ORDER BY hour_ts DESC LIMIT 1` to pick the last hourly record within the reporting period.