### PR TITLE
factory/curators: register Sentora + Yearn-Curating signer addresses for V1.1 factory

### DIFF
--- a/factory/curators.ts
+++ b/factory/curators.ts
@@ -323,6 +323,7 @@ const configs: Record<string, CuratorConfig> = {
     vaults: {
       [CHAIN.ETHEREUM]: {
         eulerVaultOwners: ['0x5aB5FE7d04CFDeFb9daf61f6f569a58A53D05eE1'],
+        morphoVaultOwners: ['0x13DE0cEE0B83562CBfD46682e10FfA4E3c5090e1'],
         morphoVaultV2Owners: ['0x13DE0cEE0B83562CBfD46682e10FfA4E3c5090e1'],
       },
     },
@@ -438,7 +439,7 @@ const configs: Record<string, CuratorConfig> = {
     breakdownFees: true,
     vaults: {
       [CHAIN.ETHEREUM]: {
-        morphoVaultOwners: ['0xFc5F89d29CCaa86e5410a7ad9D9d280d4455C12B'],
+        morphoVaultOwners: ['0xFc5F89d29CCaa86e5410a7ad9D9d280d4455C12B', '0x75a1253432356f90611546a487b5350CEF08780D'],
       },
       [CHAIN.BASE]: {
         morphoVaultOwners: ['0xFc5F89d29CCaa86e5410a7ad9D9d280d4455C12B', '0x50b75d586929ab2f75dc15f07e1b921b7c4ba8fa'],


### PR DESCRIPTION
## Framework context

\`helpers/curators/index.ts\` walks the Morpho V1.1 factory (\`getMorphoVaults\`) and the V2 factory (\`getMorphoVaultsV2\`) as independent passes. Each pass filters \`CreateMetaMorpho\` / \`CreateVaultV2\` events by a separate config array — \`morphoVaultOwners\` for V1.1 deployments and \`morphoVaultV2Owners\` for V2 deployments. If the same curator signer has deployed vaults through both factories on a chain but is only registered under V2Owners, the V1.1 vaults are silently dropped because their \`initialOwner\` does not appear in the V1.1 owners array. This PR closes that gap for two curators where it produces material missed TVL.

## On-chain verification

Joined every V2-only address in \`factory/curators.ts\` against \`metamorpho_factory_multichain.metamorphov1_1factory_evt_createmetamorpho\` on Dune ([query 7579394](https://dune.com/queries/7579394)), then verified the resulting vault addresses against Morpho's blue-api \`vaults(address_in: [...])\` for live TVL/APY/fee.

### Sentora — Ethereum

\`0x13DE0cEE0B83562CBfD46682e10FfA4E3c5090e1\` is currently in \`morphoVaultV2Owners\` only. On-chain it has also deployed five V1.1 MetaMorpho vaults; two are live:

| Vault | Address | TVL | APY | Fee |
|---|---|---:|---:|---:|
| senPYUSD | \`0x19b3cD7032B8C062E8d44EaCad661a0970DD8c55\` | \$271,955,247 | 2.61% | 0% |
| senRLUSD | \`0x71cb2F8038B2C5D65ddc740B2F3268890CD2A89C\` | \$217,636,417 | 1.59% | 0% |

Three sibling vaults under the same signer have \$0 TVL and were excluded — adding them would write zero in production indefinitely.

### Yearn-Curating — Ethereum

\`0x75a1253432356f90611546a487b5350CEF08780D\` is currently in Yearn-Curating's Katana \`morphoVaultV2Owners\`. On-chain it also deployed two V1.1 MetaMorpho vaults on Ethereum, both live:

| Vault | Address | TVL | APY | Fee |
|---|---|---:|---:|---:|
| ymv-WBTC | \`0x2bB005127069A0F0325Fb7370967E8A2b64FB77E\` | \$3,635,575 | 0.62% | 0% |
| ymv-USDT | \`0x0963232eB842BAF53E8e517691f81745C1F228a0\` | \$2,870,063 | 2.57% | 5% |

## Effect on accounting

For Sentora: current vault fee is 0%, so this adds no \`Revenue\` / \`ProtocolRevenue\` line. It does add a sizeable \`Fees\` total and \`SupplySideRevenue\` distribution (~\$10M/yr in yield at current TVL × APY) that is currently invisible on the protocol page. Historical events from each vault's deployment are picked up automatically because the V1.1 factory walk is event-based from \`fromBlock\`.

For Yearn-Curating: ymv-USDT charges a 5% fee, so a small but real \`Revenue\` line is unlocked alongside the larger \`Fees\` and \`SupplySideRevenue\` deltas.

## Excluded after verification

Same on-chain sweep flagged other V2-only owner addresses that match V1.1 deployments on minor chains for Re7-Labs (\`0xE5EAE3770750…\` on arbitrum / bnb / hyperevm / katana / plume / tac), Rockawayx, API3, Clearstar, and Gauntlet-Base. Every one of those returns either \$0 TVL, dust (<\$50k), or unwhitelisted vaults that Morpho's API does not surface — adding them would write zero values indefinitely.

## Test plan

- [x] \`pnpm run ts-check\` clean
- [x] Branch cut fresh from upstream master at \`ef4a7a6c8\`
- [x] \`git diff --stat upstream/master..HEAD\` = \`1 file changed, +2/-1\`