### PR TITLE
fees/kyberswap-aggregator: capture native gas-token fees alongside ERC20

### DIFF
--- a/fees/kyberswap-aggregator.ts
+++ b/fees/kyberswap-aggregator.ts
@@ -1,5 +1,5 @@
 import { CHAIN } from "../helpers/chains"
-import { FetchOptions, SimpleAdapter } from "../adapters/types";
+import { Dependencies, FetchOptions, SimpleAdapter } from "../adapters/types";
 import { addTokensReceived, getETHReceived } from "../helpers/token";
 import { getDefaultDexTokensBlacklisted } from "../helpers/lists";
 
@@ -95,6 +95,7 @@ const methodology = {
 const adapter: SimpleAdapter = {
   version: 2,
   pullHourly: true,
+  dependencies: [Dependencies.ALLIUM],
   fetch,
   adapter: chainConfig,
   methodology,

--- a/fees/kyberswap-aggregator.ts
+++ b/fees/kyberswap-aggregator.ts
@@ -1,6 +1,6 @@
 import { CHAIN } from "../helpers/chains"
 import { FetchOptions, SimpleAdapter } from "../adapters/types";
-import { addTokensReceived } from "../helpers/token";
+import { addTokensReceived, getETHReceived } from "../helpers/token";
 import { getDefaultDexTokensBlacklisted } from "../helpers/lists";
 
 const chainConfig: Record<string, { id: number, start: string }> = {
@@ -30,6 +30,15 @@ const chainConfig: Record<string, { id: number, start: string }> = {
   // [CHAIN.BITTORRENT]: {id: 199, start: '2021-06-01'},
 };
 
+// Chains where the helper's Allium native-trace fallback is wired (ALLIUM_CHAIN_MAP).
+// Outside this set getETHReceived would resolve to a non-existent schema and throw, so
+// the existing addTokensReceived (ERC20-only) path stays in effect on those chains.
+const nativeFeeChains = new Set<string>([
+  CHAIN.ETHEREUM, CHAIN.ARBITRUM, CHAIN.AVAX, CHAIN.BSC, CHAIN.OPTIMISM,
+  CHAIN.POLYGON, CHAIN.SCROLL, CHAIN.BASE, CHAIN.PLASMA, CHAIN.BERACHAIN,
+  CHAIN.UNICHAIN, CHAIN.MONAD, CHAIN.ERA, CHAIN.HYPERLIQUID,
+])
+
 const blacklistedTokens = [
   // UXLINK is hacked
   '0x1a6b3a62391eccaaa992ade44cd4afe6bec8cff1',
@@ -43,7 +52,7 @@ const blacklistedTokens = [
 
   // MAGA
   '0xda2e903b0b67f30bf26bd3464f9ee1a383bbbe5f',
-  
+
   // TARA
   '0x2F42b7d686ca3EffC69778B6ED8493A7787b4d6E',
 
@@ -54,23 +63,33 @@ const blacklistedTokens = [
 const feeCollector = "0x4f82e73edb06d29ff62c91ec8f5ff06571bdeb29"
 
 async function fetch(options: FetchOptions) {
-  // MISSING INTERNAL ETH TRANSFERS!
+  // ERC20 fees: KyberSwap's MetaAggregationRouterV2 sends the protocol cut to the
+  // feeCollector as an ERC20 Transfer for non-native trades.
   const dailyFees = await addTokensReceived({ target: feeCollector, options })
+
+  // Native gas-token fees: the same router forwards native ETH / BNB / etc. via an
+  // internal call when the trade pays in the chain's native token. These do not emit
+  // Transfer events and are invisible to addTokensReceived. Pull them from Allium's
+  // native_token_transfers / traces table. Sender on every chain is the router
+  // 0x8f10b468b06c6fd214b65f87778827f7d113f996 (CREATE2-deployed at the same address
+  // on every supported chain) — verified across Ethereum / Base / BSC / Arbitrum.
+  if (nativeFeeChains.has(options.chain)) {
+    await getETHReceived({ target: feeCollector, options, balances: dailyFees })
+  }
+
   const defaultBlacklistedTokens = getDefaultDexTokensBlacklisted(options.chain)
   blacklistedTokens.forEach(t => dailyFees.removeTokenBalance(t))
   defaultBlacklistedTokens.forEach(t => dailyFees.removeTokenBalance(t))
-  /*     const { usdTokenBalances, usdTvl, rawTokenBalances, } = await dailyFees.getUSDJSONs()
-    console.log({ chain: options.chain, usdTvl })
-    const tokens = Object.keys(rawTokenBalances).map(t => t.split(':')[1])
-    const symbols = await options.api.multiCall({  abi: 'string:symbol', calls: tokens, permitFailure: true })
-    console.table(symbols.map((s, i) => ({ token: tokens[i], symbol: s })))
 
-    let debugTable: any = []
-    Object.entries(usdTokenBalances).filter(([, v]) => v > 1000).forEach(([t, v]) => {
-        debugTable.push({ token: t, value: v })
-    })
-    console.table(debugTable) */
   return { dailyFees, dailyRevenue: dailyFees, dailyProtocolRevenue: dailyFees, dailyHoldersRevenue: 0 }
+}
+
+const methodology = {
+  Fees: 'Aggregator fees retained by KyberSwap on routed swaps. Pulled from both ERC20 Transfer events into the fee collector and from native gas-token internal transfers on chains where the indexer covers them.',
+  UserFees: 'Aggregator fees paid by users on KyberSwap-routed swaps.',
+  Revenue: 'All collected aggregator fees retained by KyberSwap.',
+  ProtocolRevenue: 'All collected aggregator fees retained by KyberSwap.',
+  HoldersRevenue: 'No revenue share to KNC token holders from aggregator fees.',
 }
 
 const adapter: SimpleAdapter = {
@@ -78,6 +97,7 @@ const adapter: SimpleAdapter = {
   pullHourly: true,
   fetch,
   adapter: chainConfig,
+  methodology,
 }
 
 export default adapter;


### PR DESCRIPTION
## Summary

The adapter at \`fees/kyberswap-aggregator.ts\` only credited the protocol fee collector \`0x4f82e73edb06d29ff62c91ec8f5ff06571bdeb29\` via \`addTokensReceived\`, which reads ERC20 \`Transfer\` events. KyberSwap's MetaAggregationRouterV2 also forwards the protocol fee as the chain's native gas token whenever the trade pays in ETH / BNB / etc., and those inflows arrive as internal value calls with no \`Transfer\` event. The previous version of the file carried a \`// MISSING INTERNAL ETH TRANSFERS!\` self-note (added in commit \`d2fbde5fd1\`) acknowledging the gap; this PR closes it.

## On-chain verification

Internal native-token traces landing on \`0x4f82e7…\` over the 7-day window ending 2026-05-26 ([Dune query 7579643](https://dune.com/queries/7579643)):

| Chain | Internal traces | Native received | Dominant sender |
|---|---:|---:|---|
| Ethereum | 786 | 1.06 ETH | \`0x8f10b468…\` (784 traces, 0.97 ETH) |
| Base | 3,586 | 2.29 ETH | \`0x8f10b468…\` (3,586 traces, 2.29 ETH) |
| BSC | 786 | 0.29 BNB | \`0x8f10b468…\` (784 traces, 0.29 BNB) |
| Arbitrum | 161 | 0.0051 ETH | \`0x8f10b468…\` |

Total ≈ \$12k of native fees in seven days, or roughly \$50k/30d that the current adapter would silently drop. The dominant sender on every chain is the router \`0x8f10b468b06c6fd214b65f87778827f7d113f996\`, which is the CREATE2-deployed MetaAggregationRouterV2 (verified by reading \`owner()\` on Ethereum: \`0x697161a9ece8afd6ae30946d790077050f993cbc\`, a known KyberSwap multisig). The same router address is used on every supported chain.

## Diff shape

- \`getETHReceived\` is called after the existing \`addTokensReceived\`, accumulating native inflows into the same \`dailyFees\` balances object.
- Call is gated on a small whitelist of chains whose entries exist in \`helpers/allium.ts\` \`ALLIUM_CHAIN_MAP\` (Ethereum, Arbitrum, Avax, BSC, Optimism, Polygon, Scroll, Base, Plasma, Berachain, Unichain, Monad, ERA, Hyperliquid). Outside this set the helper would resolve to a non-existent schema and throw, so the existing ERC20-only path stays in effect there. No try/catch — failures continue to propagate.
- Stale commented-out debug print block removed.
- \`methodology\` block added. Production \`/summary/fees/kyberswap-aggregator\` currently returns \`Fees=?, Revenue=?\` because the adapter never declared a methodology; this fills that.

## Test plan

- [x] \`pnpm run ts-check\` clean
- [x] Branch cut fresh from upstream master at \`409ca6d04\`
- [x] \`git diff --stat upstream/master..HEAD\` = \`1 file changed, +33/-13\`
- [x] Sender identity verified by reading \`owner()\` on \`0x8f10b468…\` via 1rpc.io eth_call
- [x] Fee collector code length confirmed \`0x\` (EOA) so the helper choice (Allium traces, not SafeReceived) is correct