### PR TITLE
fees/trust-wallet: capture native gas-token fees forwarded by 0x Settler

### DIFF
--- a/fees/trust-wallet.ts
+++ b/fees/trust-wallet.ts
@@ -1,7 +1,7 @@
 import ADDRESSES from '../helpers/coreAssets.json'
 import { FetchOptions, SimpleAdapter } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
-import { addTokensReceived } from "../helpers/token";
+import { addTokensReceived, getETHReceived } from "../helpers/token";
 
 const chains = [
   CHAIN.ETHEREUM,
@@ -178,6 +178,20 @@ const fetchFees = async (options: FetchOptions) => {
   }
   fees_percet.resizeBy(0.01)
   dailyFees.addBalances(fees_percet)
+
+  // Native gas-token fees. When a user swap is paid in the chain's native token
+  // (ETH / BNB / POL / AVAX / etc.), 0x Settler (Trust Wallet's documented swap router
+  // partner — verified Sourcify source at 0x7f54f05635d15cde17a49502fedb9d1803a3be8a /
+  // contract MainnetSettler @custom:security-contact security@0x.org) forwards the
+  // Trust Wallet integrator fee to the same fee collectors as plain internal value
+  // calls. Those calls do not emit ERC20 Transfer events and so are invisible to the
+  // addTokensReceived path above. Pulled via Allium native_token_transfers / traces.
+  await getETHReceived({
+    options,
+    targets: targets[options.chain],
+    balances: dailyFees,
+  });
+
   return {
     dailyFees,
     dailyRevenue: dailyFees,
@@ -197,7 +211,7 @@ const adapter: SimpleAdapter = {
     };
   }, {}),
   methodology: {
-    Fees: 'All fees paid by users for swapping, bridging in Trust wallet.',
+    Fees: 'All fees paid by users for swapping, bridging in Trust Wallet. Captured both from ERC20 Transfer events into the fee collectors (USDC and 1%-scaled USDT) and from native gas-token internal transfers forwarded by the 0x Settler integrator.',
     Revenue: 'Fees collected by Trust Wallet.',
     ProtocolRevenue: 'Fees collected by Trust Wallet.',
   }


### PR DESCRIPTION
## Summary

The adapter credited Trust Wallet's fee collectors only via \`addTokensReceived\` (ERC20 Transfer events). Trust Wallet routes user swaps through 0x Protocol's AllowanceHolder + Settler pair. When a user pays in the chain's native gas token (ETH / BNB / POL / AVAX / etc.) the Settler forwards Trust Wallet's integrator fee as a plain internal value call — no Transfer event, invisible to \`addTokensReceived\`.

## Path verified on a sample tx

Tx \`0xc541a7e02bbbe92a9621374e9ab7b885e51ff1c349a02979fd1b16ac9941bdc3\`:

1. User \`0x3f588f46…\` sends 3 ETH to \`0x0000000000001ff3684f28c67538d4d072c22734\`. Sourcify partial-match source declares contract \`AllowanceHolder\` (files \`AllowanceHolder.sol\`, \`IAllowanceHolder.sol\`, \`AllowanceHolderBase.sol\`). Selector \`0x2213bc0b\` decodes to \`exec(address,address,uint256,address,bytes)\` per 4byte.directory — that is \`AllowanceHolder.exec()\`, 0x's canonical user entrypoint.
2. AllowanceHolder delegates to 0x Settler \`0x7f54f05635d15cde17a49502fedb9d1803a3be8a\`. Sourcify-verified source declares \`contract MainnetSettler\` with \`@custom:security-contact security@0x.org\`.
3. Settler executes the swap and forwards \`0.021 ETH\` to Trust Wallet fee collector \`0xaD01C20d5886137e056775af56915de824c8fCe5\`.

The 0.7% ratio matches Trust Wallet's documented swap fee and is consistent across three sampled txs where user-input ETH is visible at the top-level call:

\`\`\`
3.000 ETH input  ->  0.0210 ETH fee   (0.700%)
2.186 ETH input  ->  0.0153 ETH fee   (0.700%)
2.167 ETH input  ->  0.0152 ETH fee   (0.700%)
\`\`\`

## Originator-diversity check across all 7 chains

7-day window ending 2026-05-26 ([Dune query 7580200](https://dune.com/queries/7580200)):

| Chain | Traces | Distinct originators | Native received | Self-originated |
|---|---:|---:|---:|---:|
| Ethereum | 13,670 | 4,307 | 3.91 ETH | 0 |
| Base | 70,474 | 6,115 | 3.59 ETH | 0 |
| BSC | 24,627 | 11,177 | 17.12 BNB | 0 |
| Polygon | 764 | 385 | 5,751 POL | 0 |
| Avalanche | 117 | 77 | 5.40 AVAX | 0 |
| Arbitrum | 305 | 180 | 0.019 ETH | 0 |
| Optimism | 63 | 44 | 0.0013 ETH | 0 |

Many distinct EOA originators per chain, none originating from the fee collector itself — confirms user-paid pattern, not the fee wallet rebalancing its own ERC20 balance into ETH.

## Effect on accounting

Native flows over the 7d sample total roughly \$45k. At 30d horizon that is on the order of \$200k of fees becoming visible on top of the current \$300k/30d adapter total.

## Diff shape

Adds \`getETHReceived\` after the existing \`addTokensReceived\` calls, into the same balances object. No \`fromAddressFilter\` because the integrator forwarder is 0x Settler (and other aggregators), distinct from the Trust Wallet routers in the existing ERC20 \`fromAdddesses\` whitelist. All seven supported chains are present in \`helpers/allium.ts\` \`ALLIUM_CHAIN_MAP\` so the helper resolves to a real Allium schema on each.

## Test plan

- [x] \`pnpm run ts-check\` clean
- [x] Branch cut fresh from upstream master at \`d33debbd9\`
- [x] \`git diff --stat upstream/master..HEAD\` = \`1 file changed, +16/-2\`
- [x] Sample-tx walkthrough confirms user → AllowanceHolder.exec → Settler → fee collector path
- [x] Fee rate (0.7%) verified on three independent sample txs and matches Trust Wallet docs
- [x] Originator-diversity check passes on every chain