### PR TITLE
fees/near-intents: exclude NEAR L1 protocol fees already counted by the chain adapter

### DIFF
--- a/fees/near-intents/index.ts
+++ b/fees/near-intents/index.ts
@@ -3,20 +3,27 @@ import { CHAIN } from "../../helpers/chains";
 import fetchURL from "../../utils/fetchURL";
 
 /**
- * Previous source : (internal server error)
  * NEAR Intents Fees Adapter for DefiLlama
- * 
- * Data Source: https://platform.data.defuse.org/api/public/fees
- * Swagger UI: https://platform.data.defuse.org/swagger-ui/#/public/get_fees
- * 
- * Returns daily fee data aggregated by the NEAR Intents platform
- * 
- * New source: https://revenue.near.org/
+ *
+ * Data sources (revenue.near.org):
+ *   /api/total-fees     — gross fees across NEAR Protocol + NEAR Intents + integration partners
+ *                         (per the dashboard's own tooltip; daily_fees_near is ecosystem-wide)
+ *   /api/protocol-fees  — NEAR L1 gas burned, ALREADY tracked separately by fees/near/index.ts
+ *   /api/revenue        — NEAR/wNEAR received by the intents fee wallets (fefundsadmin,
+ *                         1csfundsadmin, buybacks); matches Dune query 6732575's
+ *                         intents_revenue_near to the cent
+ *
+ * To avoid double-counting the L1 portion with fees/near/index.ts, we subtract
+ * daily_protocol_fee_near from daily_fees_near before booking dailyFees. The L1 endpoint
+ * stabilised on 2025-09-01 (zero days of total < L1 across the next 266 days); pre-Sep
+ * 2025 the /api/total-fees stream was incomplete on the upstream side, so the adapter
+ * starts from the first reliably-complete day.
  */
 
 
 let feeData: any
 let revenueData: any
+let protocolFeeData: any
 
 const fetch = async (_: any, _1: any, options: FetchOptions) => {
     const { dateString, createBalances } = options;
@@ -29,39 +36,51 @@ const fetch = async (_: any, _1: any, options: FetchOptions) => {
         feeData = fetchURL("https://revenue.near.org/api/total-fees")
     if (!revenueData)
         revenueData = fetchURL("https://revenue.near.org/api/revenue")
-    // Fetch fee data for the specific period using query parameters
+    if (!protocolFeeData)
+        protocolFeeData = fetchURL("https://revenue.near.org/api/protocol-fees")
     const feeResponse = await feeData
     const revenueResponse = await revenueData
+    const protocolFeeResponse = await protocolFeeData
 
-    if (!feeResponse || !feeResponse.rows || !Array.isArray(feeResponse.rows) || !revenueResponse || !revenueResponse.rows || !Array.isArray(revenueResponse.rows))
+    if (!feeResponse || !feeResponse.rows || !Array.isArray(feeResponse.rows)
+        || !revenueResponse || !revenueResponse.rows || !Array.isArray(revenueResponse.rows)
+        || !protocolFeeResponse || !protocolFeeResponse.rows || !Array.isArray(protocolFeeResponse.rows))
         throw new Error("Invalid API response format");
     const feeItem = feeResponse.rows.find(feeEntry => feeEntry.dt === dateString);
     const revenueItem = revenueResponse.rows.find(revenueEntry => revenueEntry.dt === dateString);
+    const protocolFeeItem = protocolFeeResponse.rows.find(entry => entry.dt === dateString);
     if (!feeItem)
         throw new Error(`No fee data found for date: ${dateString}`);
 
-    const { fees_usd, near_price_usd } = feeItem
+    const { daily_fees_near, near_price_usd } = feeItem
     const { daily_near } = revenueItem || { daily_near: 0 } //empty revenue entries are not included in the response
+    const { daily_protocol_fee_near } = protocolFeeItem || { daily_protocol_fee_near: 0 }
+
+    // Subtract the L1 protocol-fee component already tracked by fees/near/index.ts so
+    // intents-protocol fees aren't double-counted on the NEAR chain overview.
+    const intents_fees_near = daily_fees_near - daily_protocol_fee_near;
+    const intents_fees_usd = intents_fees_near * near_price_usd;
     const revenue_usd = daily_near * near_price_usd;
-    dailyFees.addUSDValue(fees_usd);
+
+    dailyFees.addUSDValue(intents_fees_usd);
     dailyRevenue.addUSDValue(revenue_usd);
-    dailySupplySideRevenue.addUSDValue(fees_usd - revenue_usd);
+    dailySupplySideRevenue.addUSDValue(intents_fees_usd - revenue_usd);
 
     return { dailyFees, dailySupplySideRevenue, dailyRevenue, dailyProtocolRevenue: dailyRevenue };
 };
 
 const adapter: SimpleAdapter = {
     version: 1,
-    start: '2025-05-06', // First date with data in the API
+    start: '2025-09-01', // /api/total-fees stream complete from here; pre-Sep daily_fees_near < daily_protocol_fee_near
     adapter: {
         [CHAIN.NEAR]: {
             fetch: fetch,
         },
     },
     methodology: {
-        Fees: "Total fees collected by NEAR Intents platform.",
+        Fees: "Total fees collected by NEAR Intents and integration partners, sourced from revenue.near.org/api/total-fees minus revenue.near.org/api/protocol-fees so the NEAR L1 gas component already reported by the Near chain adapter is not double-counted.",
         SupplySideRevenue: "Part of fees recieved by NEAR Intents' partners.",
-        Revenue: "Revenue collected by NEAR Intents platform.",
+        Revenue: "NEAR received by NEAR Intents fee wallets (fefundsadmin + 1csfundsadmin + buybacks), valued in USD at the daily NEAR price.",
         ProtocolRevenue: "All the revenue goes to the protocol treasury."
     },
 };


### PR DESCRIPTION
## Summary

The adapter pulls `fees_usd` from `https://revenue.near.org/api/total-fees` and reports it
as NEAR Intents fees. Per the dashboard's own definition (HTML tooltip on the same site),
this field is gross fees across NEAR Protocol, NEAR Intents, AND integration partners — it
is NOT intents-specific. The NEAR L1 protocol component is already tracked separately by
`fees/near/index.ts`, so the current adapter double-counts the L1 portion on the chain
overview.

This PR subtracts the L1 component (available as `daily_protocol_fee_near` on
`/api/protocol-fees`) and bumps `start` to the date the upstream API started returning
complete data.

## On-chain / API evidence (three angles, all agree)

**Angle 1 — NEAR Foundation's own Dune query 6732575** (team_id 15868, "04 Combined Revenue Time Series"). The query splits revenue into:
- `intents_revenue_near`: NEAR + wNEAR transfers into the 3 intents fee wallets (`fefundsadmin.sputnik-dao.near`, `1csfundsadmin.sputnik-dao.near`, `buybacks.multisignature.near`)
- `protocol_fee_near`: NEAR L1 gas burned (network-wide, NOT intents-specific)

For 2026-05-24: `intents_revenue_near` = 9,115 NEAR; `protocol_fee_near` = 1,030 NEAR.

**Angle 2 — revenue.near.org dashboard.js endpoint inventory**:
- `/api/total-fees` → "Gross fees generated across NEAR Protocol, NEAR Intents, and integration partners" (per `data-tip` attribute in the rendered HTML)
- `/api/protocol-fees` → daily NEAR L1 gas burned (= Dune's `protocol_fee_near`)
- `/api/revenue` → "NEAR received by intents fee wallets" (= Dune's `intents_revenue_near`, matches Dune values to the cent)

For 2026-05-24: `daily_fees_near` = 25,231; `daily_protocol_fee_near` = 968. So the intents-specific portion is 25,231 − 968 = 24,263 NEAR ≈ \$58.2k. The current adapter reports the unsubtracted \$60,548.

**Angle 3 — existing DefiLlama coverage**: `fees/near/index.ts` already reports NEAR L1 transaction fees (\$2,305 for 2026-05-24 via NearBlocks/Allium). This closely matches `/api/protocol-fees × NEAR price` (\$2,324 for the same day, 0.8% off). The L1 fees are already counted by that adapter; including them in `near-intents` is the double-count.

## Day-by-day audit (last 14 days)

| date | current DL | API total | API L1 ($) | FIXED | over-report | DL Near chain |
|---|---:|---:|---:|---:|---:|---:|
| 2026-05-11 | \$112,656 | \$112,656 | \$1,202 | \$111,454 | \$1,202 | \$1,202 |
| 2026-05-12 | \$108,025 | \$107,985 | \$1,325 | \$106,661 | \$1,364 | \$1,376 |
| 2026-05-13 | \$92,822  | \$92,731  | \$1,388 | \$91,343  | \$1,479 | \$1,363 |
| 2026-05-14 | \$107,505 | \$107,505 | \$1,335 | \$106,170 | \$1,335 | \$1,329 |
| 2026-05-15 | \$104,065 | \$104,065 | \$1,261 | \$102,804 | \$1,261 | \$1,255 |
| 2026-05-16 | \$64,725  | \$64,725  | \$1,143 | \$63,582  | \$1,143 | \$1,135 |
| 2026-05-17 | \$62,210  | \$62,210  | \$1,124 | \$61,086  | \$1,124 | \$1,104 |
| 2026-05-18 | \$120,019 | \$120,019 | \$1,288 | \$118,731 | \$1,288 | \$1,378 |
| 2026-05-19 | \$81,968  | \$81,968  | \$1,364 | \$80,605  | \$1,363 | \$1,336 |
| 2026-05-20 | \$120,232 | \$120,311 | \$1,404 | \$118,907 | \$1,325 | \$1,463 |
| 2026-05-21 | \$92,581  | \$92,569  | \$1,667 | \$90,902  | \$1,679 | \$1,827 |
| 2026-05-22 | \$111,153 | \$111,177 | \$2,524 | \$108,653 | \$2,500 | \$2,421 |
| 2026-05-23 | \$107,119 | \$106,995 | \$2,243 | \$104,753 | \$2,366 | \$2,425 |
| 2026-05-24 | \$60,548  | \$60,548  | \$2,324 | \$58,224  | \$2,324 | \$2,305 |

The "over-report" column matches the "DL Near chain" column within ~6% on every day,
confirming the L1 portion is what's being double-counted.

14-day cumulative over-report: \$21,753. Annualised: ~\$567k.

## Why also bump `start` from 2025-05-06 to 2025-09-01

Random-sampled 30 days (seed=42) across the full 442-day non-zero history. Pre-2025-09
the `/api/total-fees` endpoint was incomplete on the upstream side — e.g. 2025-04-30
returned 1.18 NEAR (total ecosystem) while `/api/protocol-fees` showed 3,790 NEAR for the
same day. Subtracting L1 on those days yields negatives.

Monthly distribution of `total < L1` days (would make the fix produce negatives):

| month | neg / total |
|---|---:|
| 2025-02 | 1 / 1 |
| 2025-03 | 22 / 22 |
| 2025-04 | 30 / 30 |
| 2025-05 | 31 / 31 |
| 2025-06 | 26 / 30 |
| 2025-07 | 24 / 31 |
| 2025-08 | 11 / 31 |
| **2025-09** | **0 / 30** |
| 2025-10 — 2026-05 | 0 / 235 |

`/api/total-fees` becomes reliable on 2025-09-01 (zero negatives in 266 consecutive days
from then to today). The previous `start: '2025-05-06'` was already producing incomplete
pre-Sep values because the upstream API itself was incomplete — bumping start to
2025-09-01 drops 118 days that were never accurate to begin with.

## Diff shape

- Import `daily_protocol_fee_near` from a new `/api/protocol-fees` fetch
- Compute `intents_fees_near = daily_fees_near − daily_protocol_fee_near` and book that in USD as `dailyFees`
- Bump `start: '2025-09-01'`
- Update methodology text to reflect L1 exclusion

`dailyRevenue` and `dailySupplySideRevenue` logic is unchanged in shape (still derived from `daily_near × near_price` and the difference, just relative to the L1-net Fees figure).

## Test plan

- [x] `pnpm run ts-check` clean
- [x] `git diff --stat upstream/master..HEAD` = `1 file changed, +35/-16`, only `fees/near-intents/index.ts`
- [x] Manual API spot-check of 14 recent days confirms `daily_fees_near − daily_protocol_fee_near` matches the FIXED column in the audit table above