### PR TITLE
[fix] Superswap: account portal to portal volume

### DIFF
--- a/aggregators/superswap/index.ts
+++ b/aggregators/superswap/index.ts
@@ -2,15 +2,19 @@ import { FetchOptions, SimpleAdapter } from "../../adapters/types"
 import { CHAIN } from "../../helpers/chains"
 import ADDRESSES from '../../helpers/coreAssets.json'
 
-const event_route = 'event Route(address indexed from,address to,address indexed tokenIn,address indexed tokenOut,uint256 amountIn,uint256 amountOutMin,uint256 amountOut)'
 
 type ChainConfig = {
   start: string
   v1Routers: string[]
   v2Routers: string[]
   portal: string
+  spokePool?: string
 }
 
+const ABI = {
+  route: 'event Route(address indexed from,address to,address indexed tokenIn,address indexed tokenOut,uint256 amountIn,uint256 amountOutMin,uint256 amountOut)',
+  fundsDeposited: 'event FundsDeposited(bytes32 inputToken,bytes32 outputToken,uint256 inputAmount,uint256 outputAmount,uint256 indexed destinationChainId,uint256 indexed depositId,uint32 quoteTimestamp,uint32 fillDeadline,uint32 exclusivityDeadline,bytes32 indexed depositor,bytes32 recipient,bytes32 exclusiveRelayer,bytes message)',
+}
 const FEES = {
   inchain: 0.25, //0.25%
   crosschain: 0.35, //0.35%
@@ -20,25 +24,25 @@ const SWAP_FEES_TO_PROTOCOL = 'Swap Fees To Protocol'
 
 // V1 routers are included for volume only. V2 routers use the same Route event and are the only routers with inferred fees.
 const chainConfig: Record<string, ChainConfig> = {
-  [CHAIN.ARBITRUM]: { start: '2026-02-10', v1Routers: ['0x8b9Ffff3d567cc578752D455BCb7BE86fa60F5b8'], v2Routers: ['0x5E0DD34FB6C74552A1FFF089090375A508c1ead3'], portal: '0x025f28177dBc77A7134f76C0498467b3ea3aa2A2' },
-  [CHAIN.BASE]: { start: '2026-02-10', v1Routers: ['0x19FD96207f7B5c55403BE736897f7C1109C8314E'], v2Routers: ['0xCb26DE359b51BDd87b8D054F260307b5EEfc0212'], portal: '0xfe76Ad9679932acb2dbB3eD76283F03f7D80006e' },
-  [CHAIN.BLAST]: { start: '2026-02-10', v1Routers: ['0x756d003c2aacFBAB59C29aFC49933B952bd9E600'], v2Routers: ['0xBafbbCe0c1a7e540291225724D35ba00d91370Ef'], portal: '0xDa69f96C1d2DF824a11354d423dc84106AAA411a' },
-  [CHAIN.BSC]: { start: '2026-02-10', v1Routers: ['0x51abC29C7b7611333Ba56cfe6B10dC1ff089786E'], v2Routers: ['0xFa227a80e8358c9794D425E87Fb81F828Eb9A052'], portal: '0xc3fBfe30fBD27774018f2D125FC195f799A375Bf' },
-  [CHAIN.ETHEREUM]: { start: '2026-02-10', v1Routers: ['0x50b1E6ab68E6BeD281C27810dEd0c293C3a20B4D'], v2Routers: ['0x660e5bd52C1Be2b078eC886Ea2463C9b2ba5feB8'], portal: '0x8a6a5990Dd8D8781D3c15Be2E8C36720C9A453D2' },
-  [CHAIN.INK]: { start: '2026-02-10', v1Routers: ['0x5839389261D1F38aac7c8E91DcDa85646bEcB414', '0x9f64D99eA5BA69d2E6a5f19a923A26fbdfB370B9'], v2Routers: ['0x8d3cAe434bA71F195400672A9F4b8838C6A96712'], portal: '0x92E8C76e9058BC0cb68a88eFAB9dB37c9A70Bb9e' },
-  [CHAIN.LINEA]: { start: '2026-02-10', v1Routers: ['0x20b46e8b753093cFf78276832b92DE1A952dcF74'], v2Routers: ['0x7bf555d749895b6f5d70506AD6D62b6E1Cfb8015'], portal: '0x7C085CB54F82F0dcf6Ac66057BB6125c6279a324' },
-  [CHAIN.LISK]: { start: '2026-02-10', v1Routers: ['0x756d003c2aacFBAB59C29aFC49933B952bd9E600'], v2Routers: ['0xBafbbCe0c1a7e540291225724D35ba00d91370Ef'], portal: '0xDa69f96C1d2DF824a11354d423dc84106AAA411a' },
-  [CHAIN.MODE]: { start: '2026-02-10', v1Routers: ['0x919150CC162573d9BdCa1887E557b3208b536C99'], v2Routers: ['0x3216F0aaF5e0d30b6b4B4a79DA2f49e6db68d881'], portal: '0xBafbbCe0c1a7e540291225724D35ba00d91370Ef' },
-  [CHAIN.MONAD]: { start: '2026-02-10', v1Routers: ['0xDa69f96C1d2DF824a11354d423dc84106AAA411a'], v2Routers: ['0xdFE1Fc6738ef169eA175c665A060b4a268B84724'], portal: '0x69f571C93D055CB8096d0D8F591F9e9293a83d31' },
-  [CHAIN.OPTIMISM]: { start: '2026-02-10', v1Routers: ['0x5ECcD3f2eB245d20Db0e26934961576C1D1B0438'], v2Routers: ['0xa49bea83Fc71Cc430Bf95d51039E2464d5A1814a'], portal: '0x514302FCbaC5a65E09fFD7d68cf4F9F490A000CE' },
-  [CHAIN.PLASMA]: { start: '2026-02-10', v1Routers: ['0x2b7279D1227CC4838e15f473b8e1718ACBEc4292'], v2Routers: ['0xBafbbCe0c1a7e540291225724D35ba00d91370Ef'], portal: '0xDa69f96C1d2DF824a11354d423dc84106AAA411a' },
-  [CHAIN.POLYGON]: { start: '2026-02-10', v1Routers: ['0xb511c2CF878e950e5598C1c3e47e546930A1AEa5'], v2Routers: ['0xD001Cec33Ff94B1d41437d9c458c14242787cB24'], portal: '0xDc61B3Be0c2e9709589d0bb7086F28f962dfB959' },
-  [CHAIN.REDSTONE]: { start: '2026-02-10', v1Routers: [], v2Routers: ['0x9dF7c388b90f79855D523E4fd03633Fc6BAB5378'], portal: '0x248B7A18b3E9C4D61fD41B475575DADcaE2BbC29' },
-  [CHAIN.SCROLL]: { start: '2026-02-10', v1Routers: ['0x9326cA5FdDc0B6F758BE54Cfe0Ea39eDa56B1459'], v2Routers: ['0xBafbbCe0c1a7e540291225724D35ba00d91370Ef'], portal: '0xDa69f96C1d2DF824a11354d423dc84106AAA411a' },
-  [CHAIN.SONEIUM]: { start: '2026-02-10', v1Routers: ['0x756d003c2aacFBAB59C29aFC49933B952bd9E600'], v2Routers: ['0xDa69f96C1d2DF824a11354d423dc84106AAA411a'], portal: '0x32c674ACCCF7f98702b276361C2510b5Db349437' },
-  [CHAIN.UNICHAIN]: { start: '2026-02-10', v1Routers: ['0xB4f358117356E63761537316a4Fdbc0bFCFAA070'], v2Routers: ['0xC4fd90f2f2B1D12256A0459C888Ecd1d4d0f9A87'], portal: '0xAE65c7cA6897728cF6d5Fb38Cf6f8Fe53d74f0eE' },
-  [CHAIN.WC]: { start: '2026-02-10', v1Routers: ['0x2b7279D1227CC4838e15f473b8e1718ACBEc4292'], v2Routers: ['0x248B7A18b3E9C4D61fD41B475575DADcaE2BbC29'], portal: '0x049A2ADD1211Aa25F8e9BAeA5F69094ceB1e2A99' },
-  [CHAIN.ZORA]: { start: '2026-02-10', v1Routers: ['0x919150CC162573d9BdCa1887E557b3208b536C99'], v2Routers: ['0xb3eD19a22b6e1Ee92166a0d6BD7033037A32803E'], portal: '0x3216F0aaF5e0d30b6b4B4a79DA2f49e6db68d881' },
+  [CHAIN.ARBITRUM]: { start: '2026-02-10', v1Routers: ['0x8b9Ffff3d567cc578752D455BCb7BE86fa60F5b8'], v2Routers: ['0x5E0DD34FB6C74552A1FFF089090375A508c1ead3'], portal: '0x025f28177dBc77A7134f76C0498467b3ea3aa2A2', spokePool: '0xe35e9842fceaca96570b734083f4a58e8f7c5f2a' },
+  [CHAIN.BASE]: { start: '2026-02-10', v1Routers: ['0x19FD96207f7B5c55403BE736897f7C1109C8314E'], v2Routers: ['0xCb26DE359b51BDd87b8D054F260307b5EEfc0212'], portal: '0xfe76Ad9679932acb2dbB3eD76283F03f7D80006e', spokePool: '0x09aea4b2242abc8bb4bb78d537a67a245a7bec64' },
+  [CHAIN.BLAST]: { start: '2026-02-10', v1Routers: ['0x756d003c2aacFBAB59C29aFC49933B952bd9E600'], v2Routers: ['0xBafbbCe0c1a7e540291225724D35ba00d91370Ef'], portal: '0xDa69f96C1d2DF824a11354d423dc84106AAA411a', spokePool: '0x2d509190ed0172ba588407d4c2df918f955cc6e1' },
+  [CHAIN.BSC]: { start: '2026-02-10', v1Routers: ['0x51abC29C7b7611333Ba56cfe6B10dC1ff089786E'], v2Routers: ['0xFa227a80e8358c9794D425E87Fb81F828Eb9A052'], portal: '0xc3fBfe30fBD27774018f2D125FC195f799A375Bf', spokePool: '0x4e8e101924ede233c13e2d8622dc8aed2872d505' },
+  [CHAIN.ETHEREUM]: { start: '2026-02-10', v1Routers: ['0x50b1E6ab68E6BeD281C27810dEd0c293C3a20B4D'], v2Routers: ['0x660e5bd52C1Be2b078eC886Ea2463C9b2ba5feB8'], portal: '0x8a6a5990Dd8D8781D3c15Be2E8C36720C9A453D2', spokePool: '0x5c7bcd6e7de5423a257d81b442095a1a6ced35c5' },
+  [CHAIN.INK]: { start: '2026-02-10', v1Routers: ['0x5839389261D1F38aac7c8E91DcDa85646bEcB414', '0x9f64D99eA5BA69d2E6a5f19a923A26fbdfB370B9'], v2Routers: ['0x8d3cAe434bA71F195400672A9F4b8838C6A96712'], portal: '0x92E8C76e9058BC0cb68a88eFAB9dB37c9A70Bb9e', spokePool: '0xef684c38f94f48775959ecf2012d7e864ffb9dd4' },
+  [CHAIN.LINEA]: { start: '2026-02-10', v1Routers: ['0x20b46e8b753093cFf78276832b92DE1A952dcF74'], v2Routers: ['0x7bf555d749895b6f5d70506AD6D62b6E1Cfb8015'], portal: '0x7C085CB54F82F0dcf6Ac66057BB6125c6279a324', spokePool: '0x7e63a5f1a8f0b4d0934b2f2327daed3f6bb2ee75' },
+  [CHAIN.LISK]: { start: '2026-02-10', v1Routers: ['0x756d003c2aacFBAB59C29aFC49933B952bd9E600'], v2Routers: ['0xBafbbCe0c1a7e540291225724D35ba00d91370Ef'], portal: '0xDa69f96C1d2DF824a11354d423dc84106AAA411a', spokePool: '0x9552a0a6624a23b848060ae5901659cdda1f83f8' },
+  [CHAIN.MODE]: { start: '2026-02-10', v1Routers: ['0x919150CC162573d9BdCa1887E557b3208b536C99'], v2Routers: ['0x3216F0aaF5e0d30b6b4B4a79DA2f49e6db68d881'], portal: '0xBafbbCe0c1a7e540291225724D35ba00d91370Ef', spokePool: '0x3bad7ad0728f9917d1bf08af5782dcbd516cdd96' },
+  [CHAIN.MONAD]: { start: '2026-02-10', v1Routers: ['0xDa69f96C1d2DF824a11354d423dc84106AAA411a'], v2Routers: ['0xdFE1Fc6738ef169eA175c665A060b4a268B84724'], portal: '0x69f571C93D055CB8096d0D8F591F9e9293a83d31', spokePool: '0xd2ecb3afe598b746f8123cae365a598da831a449' },
+  [CHAIN.OPTIMISM]: { start: '2026-02-10', v1Routers: ['0x5ECcD3f2eB245d20Db0e26934961576C1D1B0438'], v2Routers: ['0xa49bea83Fc71Cc430Bf95d51039E2464d5A1814a'], portal: '0x514302FCbaC5a65E09fFD7d68cf4F9F490A000CE', spokePool: '0x6f26bf09b1c792e3228e5467807a900a503c0281' },
+  [CHAIN.PLASMA]: { start: '2026-02-10', v1Routers: ['0x2b7279D1227CC4838e15f473b8e1718ACBEc4292'], v2Routers: ['0xBafbbCe0c1a7e540291225724D35ba00d91370Ef'], portal: '0xDa69f96C1d2DF824a11354d423dc84106AAA411a', spokePool: '0x50039faefebef707cfd94d6d462fe6d10b39207a' },
+  [CHAIN.POLYGON]: { start: '2026-02-10', v1Routers: ['0xb511c2CF878e950e5598C1c3e47e546930A1AEa5'], v2Routers: ['0xD001Cec33Ff94B1d41437d9c458c14242787cB24'], portal: '0xDc61B3Be0c2e9709589d0bb7086F28f962dfB959', spokePool: '0x9295ee1d8c5b022be115a2ad3c30c72e34e7f096' },
+  // [CHAIN.REDSTONE]: { start: '2026-02-10', v1Routers: [], v2Routers: ['0x9dF7c388b90f79855D523E4fd03633Fc6BAB5378'], portal: '0x248B7A18b3E9C4D61fD41B475575DADcaE2BbC29', spokePool: '0x13fdac9f9b4777705db45291bbff3c972c6d1d97' },
+  [CHAIN.SCROLL]: { start: '2026-02-10', v1Routers: ['0x9326cA5FdDc0B6F758BE54Cfe0Ea39eDa56B1459'], v2Routers: ['0xBafbbCe0c1a7e540291225724D35ba00d91370Ef'], portal: '0xDa69f96C1d2DF824a11354d423dc84106AAA411a', spokePool: '0x3bad7ad0728f9917d1bf08af5782dcbd516cdd96' },
+  [CHAIN.SONEIUM]: { start: '2026-02-10', v1Routers: ['0x756d003c2aacFBAB59C29aFC49933B952bd9E600'], v2Routers: ['0xDa69f96C1d2DF824a11354d423dc84106AAA411a'], portal: '0x32c674ACCCF7f98702b276361C2510b5Db349437', spokePool: '0x3bad7ad0728f9917d1bf08af5782dcbd516cdd96' },
+  [CHAIN.UNICHAIN]: { start: '2026-02-10', v1Routers: ['0xB4f358117356E63761537316a4Fdbc0bFCFAA070'], v2Routers: ['0xC4fd90f2f2B1D12256A0459C888Ecd1d4d0f9A87'], portal: '0xAE65c7cA6897728cF6d5Fb38Cf6f8Fe53d74f0eE', spokePool: '0x09aea4b2242abc8bb4bb78d537a67a245a7bec64' },
+  [CHAIN.WC]: { start: '2026-02-10', v1Routers: ['0x2b7279D1227CC4838e15f473b8e1718ACBEc4292'], v2Routers: ['0x248B7A18b3E9C4D61fD41B475575DADcaE2BbC29'], portal: '0x049A2ADD1211Aa25F8e9BAeA5F69094ceB1e2A99', spokePool: '0x09aea4b2242abc8bb4bb78d537a67a245a7bec64' },
+  [CHAIN.ZORA]: { start: '2026-02-10', v1Routers: ['0x919150CC162573d9BdCa1887E557b3208b536C99'], v2Routers: ['0xb3eD19a22b6e1Ee92166a0d6BD7033037A32803E'], portal: '0x3216F0aaF5e0d30b6b4B4a79DA2f49e6db68d881', spokePool: '0x13fdac9f9b4777705db45291bbff3c972c6d1d97' },
   [CHAIN.ERA]: { start: '2026-02-10', v1Routers: ['0xec598F086899eD1EE56F8666a31ed19e57453725'], v2Routers: [], portal: '' },
   [CHAIN.MEGAETH]: { start: '2026-02-10', v1Routers: ['0x3A735e9A60304A59EB4492A90D6d0C529631b50e'], v2Routers: [], portal: '' },
   [CHAIN.HYPERLIQUID]: { start: '2026-02-10', v1Routers: ['0x2b7279D1227CC4838e15f473b8e1718ACBEc4292'], v2Routers: [], portal: '' },
@@ -46,8 +50,8 @@ const chainConfig: Record<string, ChainConfig> = {
 
 const fetch = async (options: FetchOptions) => {
   const config = chainConfig[options.chain]
-  const v1Logs = config.v1Routers.length ? await options.getLogs({ targets: config.v1Routers, eventAbi: event_route }) : []
-  const v2Logs = config.v2Routers.length ? await options.getLogs({ targets: config.v2Routers, eventAbi: event_route }) : []
+  const v1Logs = config.v1Routers.length ? await options.getLogs({ targets: config.v1Routers, eventAbi: ABI.route }) : []
+  const v2Logs = config.v2Routers.length ? await options.getLogs({ targets: config.v2Routers, eventAbi: ABI.route }) : []
   const dailyVolume = options.createBalances()
   const dailyFees = options.createBalances()
   const dailyUserFees = options.createBalances()
@@ -79,6 +83,19 @@ const fetch = async (options: FetchOptions) => {
     }
   })
 
+  if (config.spokePool && config.portal) {
+    const portals = new Set(Object.values(chainConfig).map(config => config.portal.toLowerCase()).filter(Boolean))
+    const acrossLogs = await options.getLogs({ target: config.spokePool, eventAbi: ABI.fundsDeposited })
+    acrossLogs.forEach(log => {
+      const recipient = `0x${log.recipient.slice(-40)}`.toLowerCase()
+      if (!portals.has(recipient)) return
+      const token = `0x${log.inputToken.slice(-40)}`
+      const amount = log.inputAmount
+      if (token.toLowerCase() === ADDRESSES.GAS_TOKEN_2.toLowerCase()) dailyVolume.addGasToken(amount)
+      else dailyVolume.add(token, amount)
+    })
+  }
+
   return {
     dailyVolume,
     dailyFees,
@@ -89,7 +106,7 @@ const fetch = async (options: FetchOptions) => {
 }
 
 const methodology = {
-  Volume: "Sum of amountIn from Route events on SuperSwap v1 and v2 routers.",
+  Volume: "Volume is counted from SuperSwap swaps and bridge deposits sent to SuperSwap portals.",
   Fees: "V2 swaps charge 0.25% for in-chain swaps and 0.35% for cross-chain portal swaps.",
   UserFees: "V2 swaps charge 0.25% for in-chain swaps and 0.35% for cross-chain portal swaps.",
   Revenue: "All fees are retained by SuperSwap.",
@@ -117,7 +134,6 @@ const adapter: SimpleAdapter = {
   methodology,
   breakdownMethodology,
   adapter: chainConfig,
-  methodology,
 }
 
 export default adapter;


### PR DESCRIPTION
> Maintainer Note
> Redstone chain is commented out as the RPC is throwing unknown errors.

## Summary
- Updates `aggregators/superswap` to include cross-chain volume routed through SuperSwap portals.
- Uses Across `FundsDeposited` logs from configured SpokePool contracts to capture bridge deposit volume.
- Keeps fee and revenue calculations on SuperSwap v2 `Route` logs only.

## Changes
- Added hardcoded Across SpokePool addresses to the SuperSwap chain config.
- Added an `ABI` object for the SuperSwap `Route` event and Across `FundsDeposited` event.
- Counts cross-chain volume from Across deposits where the recipient is a known SuperSwap portal.
- Leaves v1/v2 `Route` volume logic intact.
- Keeps v2 fee logic unchanged: 0.25% for in-chain swaps and 0.35% for cross-chain portal routes.
- Updated methodology text for normal users.

## Methodology
- Volume is counted from SuperSwap swaps and bridge deposits sent to SuperSwap portals.
- Across deposit logs are used only for volume attribution, not for fees or revenue.
- Fees, user fees, revenue, and protocol revenue are calculated from SuperSwap v2 route events.

## Data Quality / Risk
- Cross-chain deposits are attributed by checking whether the Across deposit recipient is a known SuperSwap portal.
- Across SpokePool log queries may be slower on some chains depending on indexer/RPC coverage.