### PR TITLE
fees/justlend: paginate AccrueInterest logs (stop truncating busy-day interest)

### DIFF
--- a/fees/justlend.ts
+++ b/fees/justlend.ts
@@ -122,14 +122,34 @@ const getContext = async (timestamp: number, _: ChainBlocks, { fromTimestamp, to
 };
 
 const endpoint = `https://api.trongrid.io`
-// TODO: check and replace code to fetch logs more than 200
-const getLogs = async (address: string, min_block_timestamp: number, max_block_timestamp: number) => {
-  const url = `${endpoint}/v1/contracts/${fromHex(address)}/events?event_name=AccrueInterest&min_block_timestamp=${min_block_timestamp}&max_block_timestamp=${max_block_timestamp}&limit=200`;
-  const res = await httpGet(url);
-  return res.data;
-}
-
 const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+// TronGrid caps each events response at 200. On busy days a single market emits more than
+// 200 AccrueInterest events in a day (e.g. 398 on the USDT market on 2024-12-03), so a single
+// capped request silently drops the remainder and undercounts borrow interest. Paginate with
+// the fingerprint cursor, mirroring getDailyEnergyRentalFees below.
+const getLogs = async (address: string, min_block_timestamp: number, max_block_timestamp: number) => {
+  let logs: any[] = [];
+  let fingerprint: string | undefined = undefined;
+  for (let page = 0; page < 200; page++) {
+    const params = [
+      'event_name=AccrueInterest',
+      `min_block_timestamp=${min_block_timestamp}`,
+      `max_block_timestamp=${max_block_timestamp}`,
+      'order_by=block_timestamp,asc',
+      'limit=200',
+    ];
+    if (fingerprint) params.push(`fingerprint=${fingerprint}`);
+    const url = `${endpoint}/v1/contracts/${fromHex(address)}/events?${params.join('&')}`;
+    const res = await httpGet(url);
+    const events = res.data ?? [];
+    logs = logs.concat(events);
+    fingerprint = res.meta?.fingerprint;
+    if (!fingerprint || !events.length) break;
+    await delay(2500);
+  }
+  return logs;
+}
 const getDailyProtocolFees = async ({
   markets,
   underlyings,


### PR DESCRIPTION
## Summary

The JustLend fee adapter sums `interestAccumulated` from `AccrueInterest` events to compute borrow-interest fees, but the fetch caps each market at a single 200-event response with no pagination (the code even carried a `// TODO: check and replace code to fetch logs more than 200`). On busy days a market emits well over 200 `AccrueInterest` events, so the surplus is silently dropped and fees are undercounted.

This wires the same `fingerprint` pagination already used by the Energy Rental path (`getDailyEnergyRentalFees`) into `getLogs`.

## On-chain proof (TronGrid, the same endpoint the adapter calls)

Event counts per market per day (limit=200 response, `+more` = a fingerprint cursor indicates additional uncfetched events):

| Date | WTRX | USDT | USDD |
|---|---|---|---|
| 2024-03-15 | 84 | 128 | 55 |
| 2024-12-03 | 200 **+more** | 200 **+more** | 200 **+more** |
| 2025-11-10 | 46 | 200 **+more** | 3 |

Quantifying the dropped interest on 2024-12-03 by paginating fully and summing `interestAccumulated`:

| Market | Total events | Captured (cap 200) | Dropped | Interest missed |
|---|---|---|---|---|
| WTRX | 690 | 200 | 490 | 2,695 TRX (28.4%) |
| USDT | 398 | 200 | 198 | 1,927 USDT (13.3%) |

Both major markets (and USDD, which also exceeded 200 that day) were truncated, so the day's total borrow-interest fee was undercounted by a material amount.

## Scope

This is distinct from #7106 (which added the Energy Rental Market path and already paginates `ReturnResource`). The `AccrueInterest` borrow-interest fetcher was still single-request capped; this PR fixes that path only.

It does not change current days (today the busiest market emits ~40 events/day, under the cap) — it corrects historical busy-day undercounting and prevents future truncation.

## Test

- `pnpm run ts-check` passes.
- `cli/testAdapter.ts fees justlend 2024-12-04` (the 2024-12-03 window) runs end-to-end with pagination and returns daily fees without error.