### PR TITLE
fees/dexscreener: count SOL payments, not just USDC

### DIFF
--- a/fees/dexscreener.ts
+++ b/fees/dexscreener.ts
@@ -8,8 +8,11 @@ import CoreAssets from "../helpers/coreAssets.json";
 const sol = async (options: FetchOptions) => {
     const dailyFees = await getSolanaReceived({
         options,
+        // Listings/boosts are paid in both USDC and native SOL into the same wallets;
+        // SOL payments are the larger share, so track both mints.
         mints: [
-            CoreAssets.solana.USDC, // track USDC only
+            CoreAssets.solana.USDC,
+            CoreAssets.solana.SOL,
         ],
         targets: [
             '23vEM5NAmK68uBHFM52nfNtZn7CgpHDSmAGWebsjg5ft',


### PR DESCRIPTION
## Summary

The Dexscreener Solana adapter filters `getSolanaReceived` to `mints: [USDC]` ("track USDC only"). But Dexscreener listings / token profiles / boosts are paid in **both USDC and native SOL** into the same three collector wallets, and SOL is the larger share — so the adapter currently undercounts fees by roughly 4x. This adds the SOL mint to the existing filter.

## On-chain evidence (Dune `tokens_solana.transfers`, last 30 days)

On top of the USDC the adapter already counts, the three tracked wallets received in native SOL:

| Wallet | SOL received (30d) | distinct signers |
|---|---|---|
| 21wG4F3ZR8gwGC47CkpD6ySBUgH9AABtYMBWFiYdTTgv | 29,465 SOL | 3,024 |
| 23vEM5NAmK68uBHFM52nfNtZn7CgpHDSmAGWebsjg5ft | 4,832 SOL | 775 |
| AJENSD55ZJBwipZnEf7UzW2pjxex1cV2jSKPz7aMwJo5 | 4,414 SOL | 639 |
| **Total** | **38,712 SOL** | — |

At the current SOL price (~$83.8) that is ≈ $3.2M / 30d in SOL payments, versus ~$1M / 30d in USDC currently reported. The token mix to these wallets is clean — only USDC and SOL, no spam tokens.

## These SOL inflows are user payments, not treasury movement

Comparing the SOL stream against the known-good USDC stream on the largest wallet (30d), by transaction signer (the EOA that originated each payment):

| | SOL | USDC |
|---|---|---|
| transfers | 6,472 | 1,997 |
| distinct signers | 3,024 | 1,013 |
| transactions signed by the collector wallet itself | 0 | 0 |
| median payment | 3.32 SOL (≈ $278) | $296 |
| avg payment | 4.55 SOL (≈ $381) | $352 |

The SOL stream has more distinct originators than USDC (3,024 vs 1,013), none of them the collector wallet itself, and the median payment (~$278) matches the USDC median (~$296) and Dexscreener's ~$299 listing fee. Same product, same price point, paid in SOL instead of USDC.

Payment-size distribution of the SOL stream confirms the listing pattern:

| SOL per payment | transfers | distinct signers | total SOL |
|---|---|---|---|
| <0.5 (dust) | 32 | 13 | 0.1 |
| 0.5–2 | 1,679 | 902 | 1,879 |
| 2–5 (≈ $300 listing band) | 4,166 | 2,228 | 13,904 |
| 5–10 | 248 | 193 | 1,672 |
| 10–50 | 342 | 226 | 6,231 |
| 50–500 | 4 | 4 | 305 |
| 500+ | 1 | 1 | 5,456 |

The bulk sits in the 2–5 SOL band (4,166 payments from 2,228 distinct signers), right on the listing fee. For full transparency: one payer (`GKFwoagcyRMbgTurc11uSkzrh79AgrL72bF6M7JJaMvu`) sent a single 5,456 SOL payment (~18% of the largest wallet's SOL); it is an external signer, not the collector wallet. Even excluding it, ~33,000 SOL / 30d (~$2.8M) is still uncounted small-creator listing/boost revenue.

## Why the SOL mint is `So11...112`

`getSolanaReceived` reads Allium's `solana.assets.transfers`, where native SOL is keyed by the canonical `So11111111111111111111111111111111111111112` mint — the same id DefiLlama prices. `graveyard-protocol` already tracks SOL fees via this exact mint filter through the same helper, confirming the path resolves and prices correctly. (The Dune table above labels native SOL as `...111`; that is Dune's representation of the same native SOL, cross-checked here as the independent data source.)

## Change

```diff
     mints: [
-        CoreAssets.solana.USDC, // track USDC only
+        CoreAssets.solana.USDC,
+        CoreAssets.solana.SOL,
     ],
```

`pnpm run ts-check` passes. The adapter runs on Allium in production (it already does so for the USDC path); the SOL inflows above were cross-checked independently on Dune.