### PR TITLE
aggregators/jupiter-aggregator: source from dex_solana.trades from 2025-09

### DIFF
--- a/aggregators/jupiter-aggregator/index.ts
+++ b/aggregators/jupiter-aggregator/index.ts
@@ -1,10 +1,11 @@
 import { CHAIN } from "../../helpers/chains";
 import { Dependencies, FetchOptions } from "../../adapters/types";
 import { queryDuneSql } from "../../helpers/dune";
-const DEX_TRADES_START = 1756684800; // 2025-09-01, aggregator_swaps coverage incomplete from here
+
+const DEX_TRADES_START = '2025-09-01'; //aggregator_swaps coverage incomplete from here
 
 const newQuery = (options: FetchOptions) => `
-  SELECT SUM(amount_usd) AS volume_24
+  SELECT COALESCE(SUM(amount_usd), 0) AS volume_24
   FROM dex_solana.trades
   WHERE block_time >= from_unixtime(${options.startTimestamp})
     AND block_time <  from_unixtime(${options.endTimestamp})
@@ -17,8 +18,16 @@ const legacyQuery = (options: FetchOptions) => `
   WHERE block_time >= from_unixtime(${options.startTimestamp}) AND block_time < from_unixtime(${options.endTimestamp})
 `;
 
-const fetch = async (options: FetchOptions) => {
-  const sql = options.startOfDay >= DEX_TRADES_START ? newQuery(options) : legacyQuery(options);
+const fetch = async (_a: any, _b: any, options: FetchOptions) => {
+  const useDexTrades = options.dateString >= DEX_TRADES_START;
+  if (useDexTrades) {
+    const now = Date.now();
+    const tenHoursAgo = now - 10 * 60 * 60 * 1000;
+    if (options.toTimestamp * 1000 > tenHoursAgo) {
+      throw new Error("End timestamp is less than 10 hours ago, skipping due to dune indexing delay");
+    }
+  }
+  const sql = useDexTrades ? newQuery(options) : legacyQuery(options);
   const data = await queryDuneSql(options, sql);
 
   const chainData = data[0];
@@ -29,7 +38,7 @@ const fetch = async (options: FetchOptions) => {
 };
 
 const adapter: any = {
-  version: 2,
+  version: 1,
   dependencies: [Dependencies.DUNE],
   fetch,
   start: '2023-04-16',

--- a/aggregators/jupiter-aggregator/index.ts
+++ b/aggregators/jupiter-aggregator/index.ts
@@ -1,16 +1,25 @@
 import { CHAIN } from "../../helpers/chains";
 import { Dependencies, FetchOptions } from "../../adapters/types";
 import { queryDuneSql } from "../../helpers/dune";
-// 1800 1022 777
-const fetch = async (_a: any, _b: any, options: FetchOptions) => {
+const DEX_TRADES_START = 1756684800; // 2025-09-01, aggregator_swaps coverage incomplete from here
 
-  // https://dune.com/queries/4187430
-  const data = await queryDuneSql(options, `
-    SELECT 
-      sum(COALESCE(input_usd,output_usd)) as volume_24
-    FROM jupiter_solana.aggregator_swaps
-    WHERE block_time >= from_unixtime(${options.startTimestamp}) AND block_time < from_unixtime(${options.endTimestamp})
-  `);
+const newQuery = (options: FetchOptions) => `
+  SELECT SUM(amount_usd) AS volume_24
+  FROM dex_solana.trades
+  WHERE block_time >= from_unixtime(${options.startTimestamp})
+    AND block_time <  from_unixtime(${options.endTimestamp})
+    AND trade_source = 'JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4'
+`;
+
+const legacyQuery = (options: FetchOptions) => `
+  SELECT sum(COALESCE(input_usd, output_usd)) as volume_24
+  FROM jupiter_solana.aggregator_swaps
+  WHERE block_time >= from_unixtime(${options.startTimestamp}) AND block_time < from_unixtime(${options.endTimestamp})
+`;
+
+const fetch = async (_a: any, _b: any, options: FetchOptions) => {
+  const sql = options.startOfDay >= DEX_TRADES_START ? newQuery(options) : legacyQuery(options);
+  const data = await queryDuneSql(options, sql);
 
   const chainData = data[0];
   if (!chainData) throw new Error(`Dune query failed: ${JSON.stringify(data)}`);
@@ -26,7 +35,7 @@ const adapter: any = {
   start: '2023-04-16',
   methodology: {
     Volume:
-      "Volume is calculated by summing the token volume of all trades settled on the protocol that day.",
+      "Volume routed through the Jupiter aggregator on Solana. From 2025-09 sourced from dex_solana.trades (Jupiter v6 program), as jupiter_solana.aggregator_swaps has incomplete coverage from that point; earlier dates use jupiter_solana.aggregator_swaps.",
   },
   chains: [CHAIN.SOLANA],
 };

--- a/aggregators/jupiter-aggregator/index.ts
+++ b/aggregators/jupiter-aggregator/index.ts
@@ -17,7 +17,7 @@ const legacyQuery = (options: FetchOptions) => `
   WHERE block_time >= from_unixtime(${options.startTimestamp}) AND block_time < from_unixtime(${options.endTimestamp})
 `;
 
-const fetch = async (_a: any, _b: any, options: FetchOptions) => {
+const fetch = async (options: FetchOptions) => {
   const sql = options.startOfDay >= DEX_TRADES_START ? newQuery(options) : legacyQuery(options);
   const data = await queryDuneSql(options, sql);
 
@@ -29,7 +29,7 @@ const fetch = async (_a: any, _b: any, options: FetchOptions) => {
 };
 
 const adapter: any = {
-  version: 1,
+  version: 2,
   dependencies: [Dependencies.DUNE],
   fetch,
   start: '2023-04-16',


### PR DESCRIPTION
jupiter_solana.aggregator_swaps has incomplete coverage from 2025-09. This switches the source to dex_solana.trades (Jupiter v6 program) from that date; earlier dates keep aggregator_swaps so history is preserved.

Volume from 2025-09 onward is restated to the dex_solana.trades values.