### PR TITLE
[fix] EdgeX-V1: refine methodology labels

### DIFF
--- a/fees/edgex/index.ts
+++ b/fees/edgex/index.ts
@@ -1,6 +1,7 @@
 import { CHAIN } from "../../helpers/chains";
 import { FetchResultFees, FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { addTokensReceived } from "../../helpers/token";
+import { METRIC } from "../../helpers/metrics";
 import { httpGet } from "../../utils/fetchURL";
 
 const API_ENDPOINT = "https://pro.edgex.exchange/api/v1/public/quote/fee";
@@ -31,10 +32,16 @@ const fetch = async (_: any, _1: any, options: FetchOptions): Promise<FetchResul
     throw new Error(`No fee data found for timestamp ${options.dateString} (ms: ${startOfDayUTC}) in edgeX response`);
   }
 
-  const dailyFees = dayData.fee;
-  const dailyRevenue = dayData.revenue;
+  const fees = Number(dayData.fee);
+  const revenue = Number(dayData.revenue);
+  const dailyFees = options.createBalances();
+  const dailyRevenue = options.createBalances();
+  const dailySupplySideRevenue = options.createBalances();
   const dailyHoldersRevenue = options.createBalances();
-  const dailySupplySideRevenue = Number(dailyFees) - Number(dailyRevenue)
+
+  dailyFees.addUSDValue(fees, METRIC.TRADING_FEES);
+  dailyRevenue.addUSDValue(revenue, METRIC.PROTOCOL_FEES);
+  dailySupplySideRevenue.addUSDValue(fees - revenue, "Referral Rewards");
 
   return {
     dailyFees,
@@ -45,13 +52,39 @@ const fetch = async (_: any, _1: any, options: FetchOptions): Promise<FetchResul
 };
 
 const fetchBB = async (_a:any, _b:any, options: FetchOptions) => {
-  const dailyHoldersRevenue = await addTokensReceived({
+  const buybacks = await addTokensReceived({
     options,
     target: '0x221e7fca09589ab2d7dc552ee72acf1a2ff10048',
     token: '0xb0076de78dc50581770bba1d211ddc0ad4f2a241',
   });
   const dailyFees = options.createBalances();
+  const dailyHoldersRevenue = options.createBalances();
+
+  dailyHoldersRevenue.addBalances(buybacks, METRIC.TOKEN_BUY_BACK);
+
   return { dailyFees, dailyRevenue: dailyFees, dailySupplySideRevenue: dailyFees, dailyHoldersRevenue };
+};
+
+const methodology = {
+  Fees: "Total trading fees paid by users on edgeX v1.",
+  Revenue: "The portion of trading fees kept by the protocol.",
+  SupplySideRevenue: "The portion of trading fees distributed as referral rewards.",
+  HoldersRevenue: "EDGE token buybacks funded by edgeX protocol revenue.",
+};
+
+const breakdownMethodology = {
+  Fees: {
+    [METRIC.TRADING_FEES]: "All trading fees paid by users on edgeX v1.",
+  },
+  Revenue: {
+    [METRIC.PROTOCOL_FEES]: "Trading fees kept by the edgeX protocol.",
+  },
+  SupplySideRevenue: {
+    "Referral Rewards": "The portion of trading fees distributed as referral rewards.",
+  },
+  HoldersRevenue: {
+    [METRIC.TOKEN_BUY_BACK]: "EDGE token buybacks funded by edgeX protocol revenue.",
+  },
 };
 
 const adapter: SimpleAdapter = {
@@ -60,6 +93,8 @@ const adapter: SimpleAdapter = {
     [CHAIN.EDGEX]: { fetch, start: '2025-02-25'},
     [CHAIN.ETHEREUM]: { fetch: fetchBB, start: '2026-04-01'},
   },
+  methodology,
+  breakdownMethodology,
 };
 
 export default adapter; 


### PR DESCRIPTION
## Summary
- Refines the edgeX fees adapter methodology and breakdown labels for clearer fee classification.

## Changes
- Updated `fees/edgex` to label trading fees, protocol revenue, referral rewards, and token buyback holder revenue.
- Added methodology and breakdown methodology aligned with the edgeX v2 fees adapter.

## Tests
- `pnpm test fees edgex 2026-05-14`