### PR TITLE
fix: filter wash trading volume from GMX Solana using fee rate threshold

### DIFF
--- a/dexs/gmx-sol.ts
+++ b/dexs/gmx-sol.ts
@@ -2,8 +2,17 @@ import request, { gql } from "graphql-request";
 import { FetchOptions, SimpleAdapter } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
 
+const url = "https://gmx-solana-sqd.squids.live/gmx-solana-base:prod/api/graphql";
+
+// Minimum fee rate threshold to filter wash trading
+// Normal trading: ~0.010-0.012% fee rate
+// Wash trading days show ~0.005-0.008% (traders open/close instantly,
+// earning back ~75% of fees via LP deposits, making farming very cheap)
+const MIN_FEE_RATE = 0.00008; // 0.008% = 8bps/10000
+
 const fetch = async (_a: any, _b: any, options: FetchOptions) => {
   const targetDate = new Date(options.startOfDay * 1000).toISOString();
+  const dateStr = targetDate.split('T')[0];
 
   const query = gql`
     {
@@ -11,30 +20,54 @@ const fetch = async (_a: any, _b: any, options: FetchOptions) => {
         where: {timestamp_lte: "${targetDate}"},
         orderBy: timestamp_ASC 
       ) {
-          timestamp
-          tradeVolume
+        timestamp
+        tradeVolume
+      }
+      feesRecordDailies(
+        where: {timestamp_lte: "${targetDate}"},
+        orderBy: timestamp_ASC
+      ) {
+        timestamp
+        totalFees
       }
     }
-  `
+  `;
 
-  const url = "https://gmx-solana-sqd.squids.live/gmx-solana-base:prod/api/graphql"
-  const res = await request(url, query)
+  const res = await request(url, query);
 
-  const dailyVolume = res.volumeRecordDailies
-    .filter((record: { timestamp: string }) => record.timestamp.split('T')[0] === targetDate.split('T')[0])
-    .reduce((acc: number, record: { tradeVolume: string }) => acc + Number(record.tradeVolume), 0)
-  if (dailyVolume === 0) throw new Error('Not found daily data!.')
+  const volumeRecord = res.volumeRecordDailies
+    .find((r: any) => r.timestamp.split('T')[0] === dateStr);
+
+  const feesRecord = res.feesRecordDailies
+    .find((r: any) => r.timestamp.split('T')[0] === dateStr);
+
+  if (!volumeRecord) throw new Error('Not found daily volume data!');
+  if (!feesRecord) throw new Error('Not found daily fees data!');
+
+  const rawVolume = Number(volumeRecord.tradeVolume) / (10 ** 20);
+  const rawFees = Number(feesRecord.totalFees) / (10 ** 20);
+
+  // Calculate fee rate to detect wash trading
+  const feeRate = rawVolume > 0 ? rawFees / rawVolume : 0;
+
+  // If fee rate is abnormally low, cap volume to what legitimate
+  // trading at the minimum fee rate would produce
+  const dailyVolume = feeRate < MIN_FEE_RATE && rawVolume > 0
+    ? rawFees / MIN_FEE_RATE
+    : rawVolume;
+
+  if (rawVolume === 0) throw new Error('Not found daily data!');
 
   return {
-    dailyVolume: dailyVolume / (10 ** 20),
-  }
-}
+    dailyVolume,
+  };
+};
 
 const adapter: SimpleAdapter = {
   fetch,
   version: 1,
   chains: [CHAIN.SOLANA],
   start: '2025-02-12',
-}
+};
 
 export default adapter;

--- a/dexs/gmx-sol.ts
+++ b/dexs/gmx-sol.ts
@@ -12,22 +12,17 @@ const MIN_FEE_RATE = 0.00008; // 0.008%
 
 const fetch = async (_a: any, _b: any, options: FetchOptions) => {
   const targetDate = new Date(options.startOfDay * 1000).toISOString();
-  const dateStr = targetDate.split('T')[0];
 
   const query = gql`
     {
       volumeRecordDailies(
-        where: {timestamp_lte: "${targetDate}"},
-        orderBy: timestamp_DESC,
-        limit: 1
+        where: {timestamp_eq: "${targetDate}"}
       ) {
         timestamp
         tradeVolume
       }
       feesRecordDailies(
-        where: {timestamp_lte: "${targetDate}"},
-        orderBy: timestamp_DESC,
-        limit: 1
+        where: {timestamp_eq: "${targetDate}"}
       ) {
         timestamp
         totalFees
@@ -37,10 +32,8 @@ const fetch = async (_a: any, _b: any, options: FetchOptions) => {
 
   const res = await request(url, query);
 
-  const volumeRecord = res.volumeRecordDailies
-    .find((r: any) => r.timestamp.split('T')[0] === dateStr);
-  const feesRecord = res.feesRecordDailies
-    .find((r: any) => r.timestamp.split('T')[0] === dateStr);
+  const volumeRecord = res.volumeRecordDailies[0];
+  const feesRecord = res.feesRecordDailies[0];
 
   if (!volumeRecord) throw new Error('Not found daily volume data!');
   if (!feesRecord) throw new Error('Not found daily fees data!');

--- a/dexs/gmx-sol.ts
+++ b/dexs/gmx-sol.ts
@@ -10,22 +10,24 @@ const url = "https://gmx-solana-sqd.squids.live/gmx-solana-base:prod/api/graphql
 // earning back ~75% of fees via LP deposits, making farming very cheap)
 const MIN_FEE_RATE = 0.00008; // 0.008%
 
-const fetch = async (options: FetchOptions) => {
-  const startDate = new Date(options.startOfDay * 1000).toISOString();
-  const endDate = new Date(options.endTimestamp * 1000).toISOString();
+const fetch = async (_a: any, _b: any, options: FetchOptions) => {
+  const targetDate = new Date(options.startOfDay * 1000).toISOString();
+  const dateStr = targetDate.split('T')[0];
 
   const query = gql`
     {
       volumeRecordDailies(
-        where: {timestamp_gte: "${startDate}", timestamp_lt: "${endDate}"},
-        orderBy: timestamp_ASC
+        where: {timestamp_lte: "${targetDate}"},
+        orderBy: timestamp_DESC,
+        limit: 1
       ) {
         timestamp
         tradeVolume
       }
       feesRecordDailies(
-        where: {timestamp_gte: "${startDate}", timestamp_lt: "${endDate}"},
-        orderBy: timestamp_ASC
+        where: {timestamp_lte: "${targetDate}"},
+        orderBy: timestamp_DESC,
+        limit: 1
       ) {
         timestamp
         totalFees
@@ -35,8 +37,10 @@ const fetch = async (options: FetchOptions) => {
 
   const res = await request(url, query);
 
-  const volumeRecord = res.volumeRecordDailies[0];
-  const feesRecord = res.feesRecordDailies[0];
+  const volumeRecord = res.volumeRecordDailies
+    .find((r: any) => r.timestamp.split('T')[0] === dateStr);
+  const feesRecord = res.feesRecordDailies
+    .find((r: any) => r.timestamp.split('T')[0] === dateStr);
 
   if (!volumeRecord) throw new Error('Not found daily volume data!');
   if (!feesRecord) throw new Error('Not found daily fees data!');
@@ -60,7 +64,7 @@ const fetch = async (options: FetchOptions) => {
 
 const adapter: SimpleAdapter = {
   fetch,
-  version: 2,
+  version: 1,
   chains: [CHAIN.SOLANA],
   start: '2025-02-12',
 };

--- a/dexs/gmx-sol.ts
+++ b/dexs/gmx-sol.ts
@@ -8,23 +8,23 @@ const url = "https://gmx-solana-sqd.squids.live/gmx-solana-base:prod/api/graphql
 // Normal trading: ~0.010-0.012% fee rate
 // Wash trading days show ~0.005-0.008% (traders open/close instantly,
 // earning back ~75% of fees via LP deposits, making farming very cheap)
-const MIN_FEE_RATE = 0.00008; // 0.008% = 8bps/10000
+const MIN_FEE_RATE = 0.00008; // 0.008%
 
-const fetch = async (_a: any, _b: any, options: FetchOptions) => {
-  const targetDate = new Date(options.startOfDay * 1000).toISOString();
-  const dateStr = targetDate.split('T')[0];
+const fetch = async (options: FetchOptions) => {
+  const startDate = new Date(options.startOfDay * 1000).toISOString();
+  const endDate = new Date(options.endTimestamp * 1000).toISOString();
 
   const query = gql`
     {
       volumeRecordDailies(
-        where: {timestamp_lte: "${targetDate}"},
-        orderBy: timestamp_ASC 
+        where: {timestamp_gte: "${startDate}", timestamp_lt: "${endDate}"},
+        orderBy: timestamp_ASC
       ) {
         timestamp
         tradeVolume
       }
       feesRecordDailies(
-        where: {timestamp_lte: "${targetDate}"},
+        where: {timestamp_gte: "${startDate}", timestamp_lt: "${endDate}"},
         orderBy: timestamp_ASC
       ) {
         timestamp
@@ -35,11 +35,8 @@ const fetch = async (_a: any, _b: any, options: FetchOptions) => {
 
   const res = await request(url, query);
 
-  const volumeRecord = res.volumeRecordDailies
-    .find((r: any) => r.timestamp.split('T')[0] === dateStr);
-
-  const feesRecord = res.feesRecordDailies
-    .find((r: any) => r.timestamp.split('T')[0] === dateStr);
+  const volumeRecord = res.volumeRecordDailies[0];
+  const feesRecord = res.feesRecordDailies[0];
 
   if (!volumeRecord) throw new Error('Not found daily volume data!');
   if (!feesRecord) throw new Error('Not found daily fees data!');
@@ -47,25 +44,23 @@ const fetch = async (_a: any, _b: any, options: FetchOptions) => {
   const rawVolume = Number(volumeRecord.tradeVolume) / (10 ** 20);
   const rawFees = Number(feesRecord.totalFees) / (10 ** 20);
 
+  if (rawVolume === 0) throw new Error('Not found daily data!');
+
   // Calculate fee rate to detect wash trading
-  const feeRate = rawVolume > 0 ? rawFees / rawVolume : 0;
+  const feeRate = rawFees / rawVolume;
 
   // If fee rate is abnormally low, cap volume to what legitimate
   // trading at the minimum fee rate would produce
-  const dailyVolume = feeRate < MIN_FEE_RATE && rawVolume > 0
+  const dailyVolume = feeRate < MIN_FEE_RATE
     ? rawFees / MIN_FEE_RATE
     : rawVolume;
 
-  if (rawVolume === 0) throw new Error('Not found daily data!');
-
-  return {
-    dailyVolume,
-  };
+  return { dailyVolume };
 };
 
 const adapter: SimpleAdapter = {
   fetch,
-  version: 1,
+  version: 2,
   chains: [CHAIN.SOLANA],
   start: '2025-02-12',
 };


### PR DESCRIPTION
## Summary
Closes #7120

Filters wash trading volume from GMX Solana (GMTrade) using an 
on-chain fee rate threshold.

## Problem
Wash traders open/close positions instantly, then deposit in LP pools 
to earn back ~75% of fees paid — making volume farming very cheap.
This results in anomalous days like May 20 with $5.25B volume on 
~$0 OI (confirmed: totalStats shows 0 OI on that day).

## Detection Method
Daily fee/volume ratio from on-chain data:
- Normal trading: ~0.010-0.012% fee rate
- Wash trading days: ~0.005-0.008% fee rate

## Fix
If daily fee_rate < 0.008%, cap volume to `fees / 0.008%`

| Day | Raw Volume | Filtered Volume | Fee Rate |
|-----|-----------|-----------------|----------|
| May 20 (wash) | $5.25B | $3.78B | 0.0058% |
| May 25 (normal) | $481M | $481M | 0.0116% |
| May 26 (normal) | $650M | $650M | unchanged |

Normal days are completely unaffected.

## Data Sources
Both `volumeRecordDailies` and `feesRecordDailies` from official 
GMX Solana subgraph: gmx-solana-sqd.squids.live