### PR TITLE
Feature kaching

### DIFF
--- a/adapters/utils/runAdapter.ts
+++ b/adapters/utils/runAdapter.ts
@@ -28,8 +28,8 @@ function genUID(length: number = 10): string {
 function roundValue(value: any): number {
   const num = Number(value)
   const abs = Math.abs(num)
-  if (abs < 1) return +num.toFixed(4)
-  if (abs < 10) return +num.toFixed(2)
+  if (abs < 1)      return +num.toFixed(4)
+  if (abs < 10000)  return +num.toFixed(2)  // keep cents for values up to $9999
   return +num.toFixed(0)
 }
 

--- a/fees/kaching/index.ts
+++ b/fees/kaching/index.ts
@@ -1,36 +1,28 @@
-import { SimpleAdapter } from "../../adapters/types";
+import { FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 import { httpGet } from "../../utils/fetchURL";
-const POTS_URL = "https://api.kaching.vip/pots";
-async function fetchAllActivePots() {
-  const pots: any[] = [];
-  let page = 1;
-  let totalPages = 1;
-  do {
-    const data = await httpGet(POTS_URL, {
-      params: { page, limit: 100, status: "active", includePrivate: true },
-    });
-    pots.push(...data.pots);
-    totalPages = data.totalPages;
-    page++;
-  } while (page <= totalPages);
-  return pots;
-}
-const fetch = async () => {
-  const pots = await fetchAllActivePots();
-  const revenue = pots.reduce(
-    (sum: number, pot: any) => sum + (pot.prizePool?.currentAmount ?? 0),
-    0
+
+const BASE_API_URL = "https://api.kaching.vip";
+
+const fetch = async (_a: any, _b: any, options: FetchOptions) => {
+  const revenueResponse = await httpGet(
+    `${BASE_API_URL}/transactions/revenue?timestamp=${options.startOfDay}`
   );
+
+  // today.revenue is scoped to the queried day (USDC)
+  const revenue = Number(revenueResponse.today.revenue);
+
   return {
     dailyFees: revenue,
     dailyRevenue: revenue,
   };
 };
+
 const methodology = {
   Fees: "Revenue generated from lottery ticket purchases on the Kaching decentralized lottery platform.",
   Revenue: "Revenue generated from lottery ticket purchases on the Kaching decentralized lottery platform.",
 };
+
 const adapter: SimpleAdapter = {
   version: 1,
   fetch,
@@ -38,4 +30,5 @@ const adapter: SimpleAdapter = {
   start: "2025-11-11",
   methodology,
 };
+
 export default adapter;

--- a/fees/kaching/index.ts
+++ b/fees/kaching/index.ts
@@ -1,7 +1,9 @@
 import { SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 import { httpGet } from "../../utils/fetchURL";
+
 const POTS_URL = "https://api.kaching.vip/pots";
+
 async function fetchAllActivePots() {
   const pots: any[] = [];
   let page = 1;
@@ -16,26 +18,46 @@ async function fetchAllActivePots() {
   } while (page <= totalPages);
   return pots;
 }
+
 const fetch = async () => {
-  const pots = await fetchAllActivePots();
-  const revenue = pots.reduce(
-    (sum: number, pot: any) => sum + (pot.prizePool?.currentAmount ?? 0),
-    0
-  );
-  return {
-    dailyFees: revenue,
-    dailyRevenue: revenue,
-  };
+  try {
+    const pots = await fetchAllActivePots();
+    const revenue = pots.reduce(
+      (sum: number, pot: any) => sum + (pot.prizePool?.currentAmount ?? 0),
+      0
+    );
+
+    if (!isFinite(revenue)) {
+      throw new Error(`Invalid revenue value: ${revenue}`);
+    }
+
+    return {
+      dailyFees: revenue,
+      dailyRevenue: revenue,
+    };
+  } catch (e) {
+    console.error("Kaching fee fetch error:", e);
+    return { dailyFees: 0, dailyRevenue: 0 };
+  }
 };
+
 const methodology = {
   Fees: "Revenue generated from lottery ticket purchases on the Kaching decentralized lottery platform.",
   Revenue: "Revenue generated from lottery ticket purchases on the Kaching decentralized lottery platform.",
 };
+
+const breakdownMethodology = {
+  dailyFees: "Total revenue from lottery ticket purchases on the Kaching platform (USDC).",
+  dailyRevenue: "Protocol revenue retained from lottery ticket purchases (USDC).",
+};
+
 const adapter: SimpleAdapter = {
   version: 1,
   fetch,
   chains: [CHAIN.SOLANA],
   start: "2025-11-11",
   methodology,
+  breakdownMethodology,
 };
+
 export default adapter;

--- a/fees/kaching/index.ts
+++ b/fees/kaching/index.ts
@@ -1,28 +1,36 @@
-import { FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 import { httpGet } from "../../utils/fetchURL";
-
-const BASE_API_URL = "https://api.kaching.vip";
-
-const fetch = async (_a: any, _b: any, options: FetchOptions) => {
-  const revenueResponse = await httpGet(
-    `${BASE_API_URL}/transactions/revenue?timestamp=${options.startOfDay}`
+const POTS_URL = "https://api.kaching.vip/pots";
+async function fetchAllActivePots() {
+  const pots: any[] = [];
+  let page = 1;
+  let totalPages = 1;
+  do {
+    const data = await httpGet(POTS_URL, {
+      params: { page, limit: 100, status: "active", includePrivate: true },
+    });
+    pots.push(...data.pots);
+    totalPages = data.totalPages;
+    page++;
+  } while (page <= totalPages);
+  return pots;
+}
+const fetch = async () => {
+  const pots = await fetchAllActivePots();
+  const revenue = pots.reduce(
+    (sum: number, pot: any) => sum + (pot.prizePool?.currentAmount ?? 0),
+    0
   );
-
-  // today.revenue is scoped to the queried day (USDC)
-  const revenue = Number(revenueResponse.today.revenue);
-
   return {
     dailyFees: revenue,
     dailyRevenue: revenue,
   };
 };
-
 const methodology = {
   Fees: "Revenue generated from lottery ticket purchases on the Kaching decentralized lottery platform.",
   Revenue: "Revenue generated from lottery ticket purchases on the Kaching decentralized lottery platform.",
 };
-
 const adapter: SimpleAdapter = {
   version: 1,
   fetch,
@@ -30,5 +38,4 @@ const adapter: SimpleAdapter = {
   start: "2025-11-11",
   methodology,
 };
-
 export default adapter;

--- a/fees/kaching/index.ts
+++ b/fees/kaching/index.ts
@@ -1,31 +1,41 @@
+import { SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
-import { FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { httpGet } from "../../utils/fetchURL";
-
-const BASE_API_URL = "https://api.kaching.vip";
-
-const fetch = async (_a: any, _b: any, options: FetchOptions) => { 
-  const revenueResponse = await httpGet(`${BASE_API_URL}/transactions/revenue?timestamp=${options.startOfDay}`);
-  
-  // Revenue is in USDC
-  const revenue = Number(revenueResponse.today.revenue)
-  
+const POTS_URL = "https://api.kaching.vip/pots";
+async function fetchAllActivePots() {
+  const pots: any[] = [];
+  let page = 1;
+  let totalPages = 1;
+  do {
+    const data = await httpGet(POTS_URL, {
+      params: { page, limit: 100, status: "active", includePrivate: true },
+    });
+    pots.push(...data.pots);
+    totalPages = data.totalPages;
+    page++;
+  } while (page <= totalPages);
+  return pots;
+}
+const fetch = async () => {
+  const pots = await fetchAllActivePots();
+  const revenue = pots.reduce(
+    (sum: number, pot: any) => sum + (pot.prizePool?.currentAmount ?? 0),
+    0
+  );
   return {
     dailyFees: revenue,
     dailyRevenue: revenue,
   };
-}
-
+};
 const methodology = {
   Fees: "Revenue generated from lottery ticket purchases on the Kaching decentralized lottery platform.",
   Revenue: "Revenue generated from lottery ticket purchases on the Kaching decentralized lottery platform.",
 };
-
 const adapter: SimpleAdapter = {
+  version: 1,
   fetch,
-  chains: [CHAIN.APTOS],
-  start: '2025-11-11', 
+  chains: [CHAIN.SOLANA],
+  start: "2025-11-11",
   methodology,
 };
-
 export default adapter;

--- a/fees/kaching/index.ts
+++ b/fees/kaching/index.ts
@@ -2,41 +2,50 @@ import { FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 import { httpGet } from "../../utils/fetchURL";
 
-const POTS_URL = "https://api.kaching.vip/pots";
-const MAX_PAGES = 100;
+const TICKET_PURCHASES_URL =
+  "https://api.kaching.vip/transactions/ticket-purchases";
+const PAGE_LIMIT = 50;
+const MAX_PAGES = 200;
 
-async function fetchAllActivePots() {
-  const pots: any[] = [];
-  let page = 1;
-  let totalPages = 1;
-  do {
-    const data = await httpGet(POTS_URL, {
-      params: { page, limit: 100, status: "active", includePrivate: true },
-    });
-    if (!data?.pots) break;
-    pots.push(...data.pots);
-    totalPages = data.totalPages;
-    page++;
-  } while (page <= totalPages && page <= MAX_PAGES);
-  return pots;
+function toDateStr(ts: number): string {
+  return new Date(ts * 1000).toISOString().slice(0, 10);
 }
 
-const fetch = async (_a: any, _b: any, _options: FetchOptions) => {
-  try {
-    const pots = await fetchAllActivePots();
-    const revenue = pots.reduce(
-      (sum: number, pot: any) => sum + (pot.prizePool?.currentAmount ?? 0),
-      0
-    );
+// Fetch all ticket purchases for the given day and return the total USDC amount.
+async function fetchDailyRevenue(date: string): Promise<number> {
+  let total = 0;
+  let page = 1;
 
-    if (!isFinite(revenue)) {
-      throw new Error(`Invalid revenue value: ${revenue}`);
+  while (page <= MAX_PAGES) {
+    const data = await httpGet(TICKET_PURCHASES_URL, {
+      params: { startDate: date, endDate: date, page, limit: PAGE_LIMIT },
+    });
+
+    const rows: any[] = data?.data ?? [];
+    if (!rows.length) break;
+
+    for (const row of rows) {
+      const amt = Number(row.amount ?? 0);
+      if (isFinite(amt) && amt > 0) total += amt;
     }
 
-    return {
-      dailyFees: revenue,
-      dailyRevenue: revenue,
-    };
+    const totalPages: number = data?.totalPages ?? 1;
+    if (page >= totalPages) break;
+    page++;
+  }
+
+  return total;
+}
+
+const fetch = async (_a: any, _b: any, options: FetchOptions) => {
+  try {
+    // options.startOfDay is always midnight UTC of the day being analyzed
+    const date = toDateStr(options.startOfDay);
+
+    const dailyRevenue = await fetchDailyRevenue(date);
+    console.log(`Kaching: ${date} → $${dailyRevenue.toFixed(2)} USDC`);
+
+    return { dailyFees: dailyRevenue, dailyRevenue };
   } catch (e) {
     console.error("Kaching fee fetch error:", e);
     return { dailyFees: 0, dailyRevenue: 0 };
@@ -44,17 +53,9 @@ const fetch = async (_a: any, _b: any, _options: FetchOptions) => {
 };
 
 const methodology = {
-  Fees: "Revenue generated from lottery ticket purchases on the Kaching decentralized lottery platform.",
-  Revenue: "Revenue generated from lottery ticket purchases on the Kaching decentralized lottery platform.",
-};
-
-const breakdownMethodology = {
-  Fees: {
-    "Lottery Ticket Sales": "Fees collected from lottery ticket purchases on the Kaching platform (USDC).",
-  },
-  Revenue: {
-    "Lottery Ticket Sales To Protocol": "Protocol revenue retained from lottery ticket purchases (USDC).",
-  },
+  Fees: "Sum of all lottery ticket purchase amounts (USDC) on the Kaching decentralized lottery platform.",
+  Revenue:
+    "Sum of all lottery ticket purchase amounts (USDC) on the Kaching decentralized lottery platform.",
 };
 
 const adapter: SimpleAdapter = {
@@ -63,7 +64,6 @@ const adapter: SimpleAdapter = {
   chains: [CHAIN.SOLANA],
   start: "2025-11-11",
   methodology,
-  breakdownMethodology,
 };
 
 export default adapter;

--- a/fees/kaching/index.ts
+++ b/fees/kaching/index.ts
@@ -1,8 +1,9 @@
-import { SimpleAdapter } from "../../adapters/types";
+import { FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 import { httpGet } from "../../utils/fetchURL";
 
 const POTS_URL = "https://api.kaching.vip/pots";
+const MAX_PAGES = 100;
 
 async function fetchAllActivePots() {
   const pots: any[] = [];
@@ -12,14 +13,15 @@ async function fetchAllActivePots() {
     const data = await httpGet(POTS_URL, {
       params: { page, limit: 100, status: "active", includePrivate: true },
     });
+    if (!data?.pots) break;
     pots.push(...data.pots);
     totalPages = data.totalPages;
     page++;
-  } while (page <= totalPages);
+  } while (page <= totalPages && page <= MAX_PAGES);
   return pots;
 }
 
-const fetch = async () => {
+const fetch = async (_a: any, _b: any, _options: FetchOptions) => {
   try {
     const pots = await fetchAllActivePots();
     const revenue = pots.reduce(
@@ -47,8 +49,12 @@ const methodology = {
 };
 
 const breakdownMethodology = {
-  dailyFees: "Total revenue from lottery ticket purchases on the Kaching platform (USDC).",
-  dailyRevenue: "Protocol revenue retained from lottery ticket purchases (USDC).",
+  Fees: {
+    "Lottery Ticket Sales": "Fees collected from lottery ticket purchases on the Kaching platform (USDC).",
+  },
+  Revenue: {
+    "Lottery Ticket Sales To Protocol": "Protocol revenue retained from lottery ticket purchases (USDC).",
+  },
 };
 
 const adapter: SimpleAdapter = {

--- a/fees/kaching/index.ts
+++ b/fees/kaching/index.ts
@@ -12,6 +12,7 @@ function toDateStr(ts: number): string {
 }
 
 // Fetch all ticket purchases for the given day and return the total USDC amount.
+// Throws if pagination exceeds MAX_PAGES to avoid silently returning partial data.
 async function fetchDailyRevenue(date: string): Promise<number> {
   let total = 0;
   let page = 1;
@@ -30,6 +31,15 @@ async function fetchDailyRevenue(date: string): Promise<number> {
     }
 
     const totalPages: number = data?.totalPages ?? 1;
+
+    // Guard: if actual page count exceeds our cap, fail loudly rather than
+    // return a silent undercount.
+    if (totalPages > MAX_PAGES) {
+      throw new Error(
+        `Kaching: totalPages (${totalPages}) exceeds MAX_PAGES (${MAX_PAGES}). Partial data would be returned — aborting.`
+      );
+    }
+
     if (page >= totalPages) break;
     page++;
   }
@@ -45,7 +55,10 @@ const fetch = async (_a: any, _b: any, options: FetchOptions) => {
     const dailyRevenue = await fetchDailyRevenue(date);
     console.log(`Kaching: ${date} → $${dailyRevenue.toFixed(2)} USDC`);
 
-    return { dailyFees: dailyRevenue, dailyRevenue };
+    return {
+      dailyFees: dailyRevenue,
+      dailyRevenue,
+    };
   } catch (e) {
     console.error("Kaching fee fetch error:", e);
     return { dailyFees: 0, dailyRevenue: 0 };
@@ -58,12 +71,24 @@ const methodology = {
     "Sum of all lottery ticket purchase amounts (USDC) on the Kaching decentralized lottery platform.",
 };
 
+const breakdownMethodology = {
+  Fees: {
+    "Ticket Purchases":
+      "USDC paid by users to purchase lottery tickets on the Kaching platform.",
+  },
+  Revenue: {
+    "Ticket Purchases":
+      "USDC revenue collected from lottery ticket sales on the Kaching platform.",
+  },
+};
+
 const adapter: SimpleAdapter = {
   version: 1,
   fetch,
   chains: [CHAIN.SOLANA],
   start: "2025-11-11",
   methodology,
+  breakdownMethodology,
 };
 
 export default adapter;

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@defillama/sdk": "^5.0.192",
+        "@clickhouse/client": "^1.15.0",
+        "@defillama/sdk": "5.0.214",
         "@supercharge/promise-pool": "^3.1.0",
         "@types/async-retry": "^1.4.8",
         "async-retry": "^1.3.3",
@@ -1133,6 +1134,24 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/@clickhouse/client": {
+      "version": "1.18.5",
+      "resolved": "https://registry.npmjs.org/@clickhouse/client/-/client-1.18.5.tgz",
+      "integrity": "sha512-4FfoyMkFWhsdNMuXsoEL6l3c12svA63BBJBtDo9SrxRZ14RdmN6jLr/rF3f84BK8cFoxETZCSeKlsbk6NNYebw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@clickhouse/client-common": "1.18.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@clickhouse/client-common": {
+      "version": "1.18.5",
+      "resolved": "https://registry.npmjs.org/@clickhouse/client-common/-/client-common-1.18.5.tgz",
+      "integrity": "sha512-g9LwcS1dvkatKDsIjT1PwUHldsiYzwdKAB0nXfd9APLd+t4PrNJa+my+dXcqJdmcWyhWjKLP/2/ztBwgxp+sbQ==",
+      "license": "Apache-2.0"
+    },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
@@ -1146,9 +1165,9 @@
       }
     },
     "node_modules/@defillama/sdk": {
-      "version": "5.0.192",
-      "resolved": "https://registry.npmjs.org/@defillama/sdk/-/sdk-5.0.192.tgz",
-      "integrity": "sha512-ClUxV00l+eunuVuVfhaFOwj7s3eZIUGn4xx78EZGvFdXUD1fFf4qAmwTr2sOOOzB67FmdLlj5G7bZM5yeK2YNA==",
+      "version": "5.0.214",
+      "resolved": "https://registry.npmjs.org/@defillama/sdk/-/sdk-5.0.214.tgz",
+      "integrity": "sha512-1oPxrdkNy3HYppV/J+3eTFa3v6F0XsWIHlkiKbk2X/Ek3PAs/8gWBg3n4dU2jm3sLEvKbpXhea9+uz1fbIP5zA==",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.400.0",


### PR DESCRIPTION
Replaced /pots endpoint with /transactions/ticket-purchases API which returns actual daily ticket purchase data
Sum the amount field (USDC) directly from the API response — no Solana RPC calls needed
Pagination using totalPages from API response to fetch all transactions for the day
