### PR TITLE
[fix] Pepeboost-tgbot: track referral/cashbacks as supplyside

### DIFF
--- a/fees/pepeboost/index.ts
+++ b/fees/pepeboost/index.ts
@@ -4,9 +4,19 @@ import ADDRESSES from '../../helpers/coreAssets.json'
 import { Dependencies, FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 import { queryDuneSql } from "../../helpers/dune";
+import { METRIC } from "../../helpers/metrics";
+
+// Labelled as "Pepe Boost Fees" on Solscan.
+const FEE_WALLET = 'G9PhF9C9H83mAjjkdJz4MDqkufiTPMJkx7TnKE1kFyCp';
+// Found via on-chain research; this is not an official team-provided address.
+// Rewards are distributed daily at 00:00 UTC according to docs.
+const REWARD_RELAYER = 'BXhkDUR2MCA6wPrnmUN1q2PHLqf973E5L3aqXzouojQE';
 
 const fetch: any = async (_a: any, _b: any, options: FetchOptions) => {
   const dailyFees = options.createBalances();
+  const dailyUserFees = options.createBalances();
+  const dailyRevenue = options.createBalances();
+  const dailySupplySideRevenue = options.createBalances();
 
   const query = `
     WITH
@@ -18,7 +28,7 @@ const fetch: any = async (_a: any, _b: any, options: FetchOptions) => {
         solana.account_activity
       WHERE
         TIME_RANGE
-        AND address = 'G9PhF9C9H83mAjjkdJz4MDqkufiTPMJkx7TnKE1kFyCp'
+        AND address = '${FEE_WALLET}'
         AND tx_success
         AND balance_change > 0 
     ),
@@ -31,19 +41,60 @@ const fetch: any = async (_a: any, _b: any, options: FetchOptions) => {
         JOIN allFeePayments AS feePayments ON trades.tx_id = feePayments.tx_id
       WHERE
         TIME_RANGE
-        AND trades.trader_id != 'G9PhF9C9H83mAjjkdJz4MDqkufiTPMJkx7TnKE1kFyCp'
+        AND trades.trader_id != '${FEE_WALLET}'
       GROUP BY trades.tx_id
+    ),
+    rewardPayouts AS (
+      SELECT
+        COALESCE(SUM(amount), 0) AS rewards
+      FROM
+        tokens_solana.transfers
+      WHERE
+        -- Rewards are distributed daily at 00:00 UTC; use a 15 minute buffer to count outbound SOL payouts from the relayer.
+        block_time >= from_unixtime(${options.startOfDay - 15 * 60})
+        AND block_time < from_unixtime(${options.startOfDay + 15 * 60})
+        AND action = 'transfer'
+        AND token_mint_address = 'So11111111111111111111111111111111111111111'
+        AND from_owner = '${REWARD_RELAYER}'
+        AND to_owner <> '${REWARD_RELAYER}'
+        AND to_owner <> '${FEE_WALLET}'
     )
     SELECT
-      SUM(fee) AS fee
-    FROM
-      botTrades
+      (SELECT SUM(fee) FROM botTrades) AS fee,
+      (SELECT rewards FROM rewardPayouts) AS rewards
   `;
 
   const fees = await queryDuneSql(options, query);
-  dailyFees.add(ADDRESSES.solana.SOL, fees[0].fee);
+  const totalFees = Number(fees[0].fee);
+  const rewards = Number(fees[0].rewards);
+  dailyFees.add(ADDRESSES.solana.SOL, totalFees, METRIC.TRADING_FEES);
+  dailyUserFees.add(ADDRESSES.solana.SOL, totalFees, METRIC.TRADING_FEES);
+  dailyRevenue.add(ADDRESSES.solana.SOL, totalFees - rewards, 'Trading Fees To Protocol');
+  dailySupplySideRevenue.add(ADDRESSES.solana.SOL, rewards, 'Referral/Cashback Payouts');
 
-  return { dailyFees, dailyRevenue: dailyFees, }
+  return { dailyFees, dailyUserFees, dailyRevenue, dailySupplySideRevenue }
+}
+
+const methodology = {
+  Fees: "Trading fees paid by users while using PepeBoost bot.",
+  UserFees: "Trading fees paid by users while using PepeBoost bot.",
+  Revenue: "Trading fees kept by PepeBoost protocol after referral/cashback payouts.",
+  SupplySideRevenue: "Referral/cashback payouts distributed from the PepeBoost reward relayer.",
+}
+
+const breakdownMethodology = {
+  Fees: {
+    [METRIC.TRADING_FEES]: "Trading fees paid by users while using PepeBoost bot.",
+  },
+  UserFees: {
+    [METRIC.TRADING_FEES]: "Trading fees paid by users while using PepeBoost bot.",
+  },
+  Revenue: {
+    'Trading Fees To Protocol': "Trading fees kept by PepeBoost protocol after referral/cashback payouts.",
+  },
+  SupplySideRevenue: {
+    'Referral/Cashback Payouts': "Referral/cashback payouts distributed from the PepeBoost reward relayer.",
+  },
 }
 
 const adapter: SimpleAdapter = {
@@ -53,10 +104,9 @@ const adapter: SimpleAdapter = {
   dependencies: [Dependencies.DUNE],
   start: '2024-01-06',
   isExpensiveAdapter: true,
-  methodology: {
-    Fees: "Trading fees paid by users while using PepeBoost bot.",
-    Revenue: "All fees are collected by PepeBoost protocol.",
-  },
+  allowNegativeValue: true, // Referral/cashback payouts can exceed same-day trading fees.
+  methodology,
+  breakdownMethodology,
 };
 
 export default adapter;


### PR DESCRIPTION
partially fixes #6739 

## Summary
- Updates the PepeBoost fees adapter to split user trading fees, protocol revenue, and referral/cashback payouts.
- Adds supply-side revenue tracking for SOL payouts from the PepeBoost reward relayer on Solana.

## Changes
- Updated `fees/pepeboost/index.ts` to return `dailyFees`, `dailyUserFees`, `dailyRevenue`, and `dailySupplySideRevenue`.
- Counts trading fees from the PepeBoost fee wallet and subtracts referral/cashback payouts from protocol revenue.
- Tracks referral/cashback payouts as outbound native SOL transfers from the reward relayer around the daily `00:00 UTC` distribution window.
- Added methodology and breakdown methodology for trading fees, user fees, protocol revenue, and referral/cashback payouts.
- Enabled negative values because referral/cashback payouts can exceed same-day trading fees.

## Methodology
- Trading fees are counted from positive balance changes to the wallet labelled as Pepe Boost Fees on Solscan.
- Referral/cashback payouts are counted from the reward relayer found through on-chain research; this is not an official team-provided address.
- Rewards are distributed daily around `00:00 UTC`, so the adapter uses a 15-minute buffer around `options.startOfDay` to capture the payout batch.
- Internal transfers back to the fee wallet or reward relayer are excluded from supply-side revenue.
