### PR TITLE
fix(fees/nile-exchange): remove dead bribes subgraph

### DIFF
--- a/fees/nile-exchange/index.ts
+++ b/fees/nile-exchange/index.ts
@@ -1,72 +1,29 @@
-import { Adapter, FetchOptions } from "../../adapters/types";
+import { Adapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
-import { fees_bribes } from './bribes';
 import { getUniV3LogAdapter } from "../../helpers/uniswap";
-
-type TStartTime = {
-  [key: string]: number;
-}
-const startTimeV2: TStartTime = {
-  [CHAIN.LINEA]: 1705968000,
-}
-
-const getBribes = async ({ fromTimestamp, toTimestamp, createBalances, getFromBlock, }: FetchOptions): Promise<any> => {
-  const fromBlock = await getFromBlock()
-  const bribes = createBalances();
-  const bribes_delta = createBalances();
-  await fees_bribes(fromBlock, toTimestamp, bribes_delta);
-  await fees_bribes(fromBlock, fromTimestamp, bribes);
-  bribes.subtract(bribes_delta);
-  return {
-    timestamp: toTimestamp,
-    dailyBribesRevenue: bribes,
-  };
-};
-
-// const v2Endpoints = {
-//   [CHAIN.LINEA]: "https://api.studio.thegraph.com/query/66247/nile-cl/version/latest/",
-// };
-
-// const v2Graphs = getGraphDimensions2({
-//   graphUrls: v2Endpoints,
-//   totalVolume: {
-//     factory: "factories",
-//     field: DEFAULT_TOTAL_VOLUME_FIELD,
-//   },
-//   feesPercent: {
-//     type: "fees",
-//     HoldersRevenue: 92,
-//     ProtocolRevenue: 8,
-//     SupplySideRevenue: 0,
-//     UserFees: 100, // User fees are 100% of collected fees
-//     Revenue: 100 // Revenue is 100% of collected fees
-//   }
-// });
 
 // https://docs.ramses.exchange/ramses-cl-v2/concentrated-liquidity/fee-distribution
 const methodology = {
-  Fees: "User pays 0.3% fees on each swap.",
-  UserFees: "User pays 0.3% fees on each swap.",
-  Revenue: "100% fees are revenue",
-  ProtocolRevenue: "Revenue going to the protocol. 8% of collected fees. (is probably right because the distribution is dynamic.)",
-  HoldersRevenue: "User fees are distributed among holders. 92% of collected fees. (is probably right because the distribution is dynamic.)",
-  SupplySideRevenue: "0% of collected fees are distributed among LPs. (is probably right because the distribution is dynamic.)"
+  Fees: "Swap fees charged on each trade.",
+  UserFees: "100% of swap fees paid by users.",
+  Revenue: "100% of collected fees.",
+  ProtocolRevenue: "8% of collected fees go to the protocol treasury.",
+  HoldersRevenue: "92% of collected fees distributed to xNILE stakers.",
+  SupplySideRevenue: "0% of collected fees go to LPs.",
 }
 
 const adapter: Adapter = {
   version: 2,
   adapter: {
     [CHAIN.LINEA]: {
-      fetch: async (options: FetchOptions) => {
-        const adapter = getUniV3LogAdapter({ factory: "0xAAA32926fcE6bE95ea2c51cB4Fcb60836D320C42", revenueRatio: 1, userFeesRatio: 1, protocolRevenueRatio: 0.08, holdersRevenueRatio: 0.92 })
-        const response = await adapter(options)
-
-        const bribesResult = await getBribes(options);
-        response.dailyBribesRevenue = bribesResult.dailyBribesRevenue;
-
-        return response;
-      },
-      start: startTimeV2[CHAIN.LINEA],
+      fetch: getUniV3LogAdapter({
+        factory: "0xAAA32926fcE6bE95ea2c51cB4Fcb60836D320C42",
+        revenueRatio: 1,
+        userFeesRatio: 1,
+        protocolRevenueRatio: 0.08,
+        holdersRevenueRatio: 0.92,
+      }),
+      start: 1705968000,
     },
   },
   methodology,

--- a/fees/nile-exchange/index.ts
+++ b/fees/nile-exchange/index.ts
@@ -14,6 +14,7 @@ const methodology = {
 
 const adapter: Adapter = {
   version: 2,
+  pullHourly: true,
   adapter: {
     [CHAIN.LINEA]: {
       fetch: getUniV3LogAdapter({


### PR DESCRIPTION
- The bribes subgraph, every run was crashing with a 404 deployment error.
- Removed `getBribes` and `bribes.ts` import entirely; no working replacement endpoint exists.

## Verification

Fee split confirmed against the deployed contracts on Linea:

- `feeProtocol() = 100` (max) on factory → 100% of swap fees flow to `feeCollector`, nothing stays for LPs → `supplySideRevenue = 0` ✓
- Traced 6 pools across a real `collectProtocolFees` transaction: `FeeLiquidator` (`0x3add...`) receives exactly **8.000%** and pool-specific gauge fee distributors receive **92.000%** in every case ✓
- Factory `0xAAA32926...` confirmed as Nile CL factory, deployed Jan 22 2024; start timestamp Jan 23 2024 ✓


fix #6498 