### PR TITLE
fix: yaka v3 fees

### DIFF
--- a/dexs/yakafinance-v3/index.ts
+++ b/dexs/yakafinance-v3/index.ts
@@ -10,13 +10,13 @@ import { sleep } from "../../utils/utils";
 
 const GECKOTERMINAL_POOLS_URL =
   "https://api.geckoterminal.com/api/v2/networks/sei-evm/dexes/yaka-finance-v3/pools";
-const DEFAULT_FEE_RATE = 0.003;
 const COMMUNITY_FEE_SHARE = 0.015;
 const MAX_PAGES = 20;
 
 const getFeeRateFromPoolName = (name = "") => {
   const feeMatch = name.match(/([0-9.]+)%\s*$/);
-  return feeMatch ? Number(feeMatch[1]) / 100 : DEFAULT_FEE_RATE;
+  if (!feeMatch) throw new Error(`Yaka V3: could not parse fee tier from pool name "${name}" — GeckoTerminal naming may have changed`);
+  return Number(feeMatch[1]) / 100;
 };
 
 const fetchPools = async () => {

--- a/dexs/yakafinance-v3/index.ts
+++ b/dexs/yakafinance-v3/index.ts
@@ -1,34 +1,71 @@
-import request from "graphql-request";
-import { FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { FetchOptions } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
+import { fetchURLAutoHandleRateLimit } from "../../utils/fetchURL";
+import { sleep } from "../../utils/utils";
 
-const fetch = async (_timestamp: number, _: any, options: FetchOptions): Promise<any> => {
-  const dayID = Math.floor(options.startOfDay / 86400);
-  const query = `
-    {
-        algebraDayData(id:${dayID}) {
-            id
-            volumeUSD
-            feesUSD
-        }
-    }`;
-  const url = "https://api.studio.thegraph.com/query/105503/yaka-data-new/version/latest";
-  const req = await request(url, query);
+// Yaka V3 is an Algebra Integral 1.2 fork on Sei.
+// Factory: 0xEdbBc263C74865e67C6b16F47740Fa3901b95Ae1
+// On-chain defaultCommunityFee = 15 / 1000 = 1.5% (verified across pools).
+// The community fee routes to veYAKA holders via the gauge/bribe system.
+
+const GECKOTERMINAL_POOLS_URL =
+  "https://api.geckoterminal.com/api/v2/networks/sei-evm/dexes/yaka-finance-v3/pools";
+const DEFAULT_FEE_RATE = 0.003;
+const COMMUNITY_FEE_SHARE = 0.015;
+const MAX_PAGES = 20;
+
+const getFeeRateFromPoolName = (name = "") => {
+  const feeMatch = name.match(/([0-9.]+)%\s*$/);
+  return feeMatch ? Number(feeMatch[1]) / 100 : DEFAULT_FEE_RATE;
+};
+
+const fetchPools = async () => {
+  const pools: any[] = [];
+  for (let page = 1; page <= MAX_PAGES; page++) {
+    const response = await fetchURLAutoHandleRateLimit(`${GECKOTERMINAL_POOLS_URL}?page=${page}`);
+    const pagePools = response?.data ?? [];
+    if (!pagePools.length) break;
+    pools.push(...pagePools);
+    await sleep(1000);
+  }
+  return pools;
+};
+
+const fetch = async (_a: any, _b: any, _: FetchOptions) => {
+  const pools = await fetchPools();
+  let dailyVolume = 0;
+  let dailyFees = 0;
+
+  for (const { attributes } of pools) {
+    const volume = Number(attributes.volume_usd.h24);
+    if (!Number.isFinite(volume) || volume <= 0) continue;
+    dailyVolume += volume;
+    dailyFees += volume * getFeeRateFromPoolName(attributes.name);
+  }
+
+  const dailyRevenue = dailyFees * COMMUNITY_FEE_SHARE;
   return {
-    dailyVolume: req.algebraDayData.volumeUSD,
-    dailyFees: req.algebraDayData.feesUSD,
-    dailySupplySideRevenue: req.algebraDayData.feesUSD * 0.88,
-    dailyRevenue: req.algebraDayData.feesUSD * 0.12,
-  }
-}
+    dailyVolume,
+    dailyFees,
+    dailyUserFees: dailyFees,
+    dailyRevenue,
+    dailyHoldersRevenue: dailyRevenue,
+    dailySupplySideRevenue: dailyFees - dailyRevenue,
+  };
+};
 
-const adapter: SimpleAdapter = {
-  adapter: {
-    [CHAIN.SEI]: {
-      fetch,
-      start: '2025-04-10',
-    },
-  }
-}
+const methodology = {
+  Fees: "Swap fees calculated from each pool's 24h volume and advertised fee tier.",
+  UserFees: "Swap fees paid by users on each trade.",
+  Revenue: "1.5% community fee on swaps.",
+  HoldersRevenue: "1.5% community fee routed to veYAKA holders via gauges.",
+  SupplySideRevenue: "98.5% of swap fees distributed to liquidity providers.",
+};
 
-export default adapter;
+export default {
+  version: 1,
+  runAtCurrTime: true,
+  methodology,
+  fetch,
+  chains: [CHAIN.SEI],
+};


### PR DESCRIPTION
fix #6512 

## Summary

* The Yaka V3 subgraph (`yaka-data-new`) is no longer working and just returns `Not found`.
* also found the fee split assumption was wrong. Instead of 12% protocol / 88% LPs, the on-chain `defaultCommunityFee()` on the Algebra factory (`0xEdbBc263C74865e67C6b16F47740Fa3901b95Ae1`) returns `15`, which means the actual split is 1.5% protocol fees and 98.5% to LPs (per the Algebra Integral 1.2 spec). We confirmed this across all 15 live pools via `globalState().communityFee = 15`.
* Because of the dead subgraph, the adapter was switched to the GeckoTerminal pools API, following the same approach already used in the `sailor-finance` Sei Algebra integration.
* `runAtCurrTime: true` is now enabled since GeckoTerminal only exposes rolling 24h data. This means historical backfills are no longer available, but the old setup wasn’t returning usable historical data anyway.