### PR TITLE
[feat] Allium-Users: add chain coverage for dau/txs via allium

### DIFF
--- a/users/chains.ts
+++ b/users/chains.ts
@@ -96,6 +96,15 @@ const alliumChainMap: Record<string, string> = {
     linea: CHAIN.LINEA,
     ronin: CHAIN.RONIN,
     sonic: CHAIN.SONIC,
+    mantle: CHAIN.MANTLE,
+    berachain: CHAIN.BERACHAIN,
+    blast: CHAIN.BLAST,
+    monad: CHAIN.MONAD,
+    plasma: CHAIN.PLASMA,
+    sei: CHAIN.SEI,
+    core: CHAIN.CORE,
+    tempo: CHAIN.TEMPO,
+    stable: CHAIN.STABLE,
 }
 
 const alliumExports = Object.keys(alliumChainMap).map(c => ({ name: c, id: c, getUsers: getAlliumUsersChain(c), getNewUsers: getAlliumNewUsersChain(c), chain: alliumChainMap[c], type: 'chain' }))


### PR DESCRIPTION
## Summary
- Adds additional Allium-backed mainnet chain user exports.

## Changes
- Added Mantle, Berachain, Blast, Monad, Plasma, Sei, Core, Tempo, and Stable to `users/chains.ts`.
- Reuses the existing Allium `raw.transactions` logic for active users, new users, and daily transaction counts.
