### PR TITLE
[feat] New-Users: add coverage for sui and aptos via allium query

### DIFF
--- a/new-users/aptos.ts
+++ b/new-users/aptos.ts
@@ -1,0 +1,39 @@
+import { Dependencies, FetchOptions, ProtocolType, SimpleAdapter } from "../adapters/types";
+import { queryAllium } from "../helpers/allium";
+import { CHAIN } from "../helpers/chains";
+
+const fetch = async (_a: any, _b: any, options: FetchOptions) => {
+    const alliumQuery = `
+    WITH first_seen AS (
+        SELECT
+            sender,
+            MIN(block_timestamp) AS first_seen_timestamp
+        FROM aptos.raw.transactions
+        WHERE block_timestamp < TO_TIMESTAMP_NTZ(${options.endTimestamp})
+          AND sender IS NOT NULL
+        GROUP BY 1
+    )
+    SELECT COALESCE(count(*), 0) AS new_users
+    FROM first_seen
+    WHERE first_seen_timestamp >= TO_TIMESTAMP_NTZ(${options.startTimestamp})
+      AND first_seen_timestamp < TO_TIMESTAMP_NTZ(${options.endTimestamp})
+  `;
+
+    const alliumResult = await queryAllium(alliumQuery);
+
+    return {
+        dailyNewUsers: alliumResult[0].new_users,
+    }
+}
+
+const adapter: SimpleAdapter = {
+    version: 1,
+    fetch,
+    chains: [CHAIN.APTOS],
+    dependencies: [Dependencies.ALLIUM],
+    isExpensiveAdapter: true,
+    protocolType: ProtocolType.CHAIN,
+    start: "2022-10-20",
+};
+
+export default adapter;

--- a/new-users/sui.ts
+++ b/new-users/sui.ts
@@ -3,20 +3,24 @@ import { queryAllium } from "../helpers/allium";
 import { CHAIN } from "../helpers/chains";
 
 const fetch = async (_a: any, _b: any, options: FetchOptions) => {
+
+  const from = new Date(options.fromTimestamp * 1000).toISOString();
+  const to = new Date(options.toTimestamp * 1000).toISOString();
+
     const alliumQuery = `
     WITH first_seen AS (
         SELECT
             sender,
-            MIN(timestamp_ms) AS first_seen_timestamp
+            MIN(checkpoint_timestamp) AS first_seen_timestamp
         FROM sui.raw.transaction_blocks
-        WHERE timestamp_ms < ${options.endTimestamp * 1000}
+        WHERE checkpoint_timestamp < '${to}'
           AND sender IS NOT NULL
         GROUP BY 1
     )
     SELECT COALESCE(count(*), 0) AS new_users
     FROM first_seen
-    WHERE first_seen_timestamp >= ${options.startTimestamp * 1000}
-      AND first_seen_timestamp < ${options.endTimestamp * 1000}
+    WHERE first_seen_timestamp >= '${from}'
+      AND first_seen_timestamp < '${to}'
   `;
 
     const alliumResult = await queryAllium(alliumQuery);

--- a/new-users/sui.ts
+++ b/new-users/sui.ts
@@ -1,0 +1,39 @@
+import { Dependencies, FetchOptions, ProtocolType, SimpleAdapter } from "../adapters/types";
+import { queryAllium } from "../helpers/allium";
+import { CHAIN } from "../helpers/chains";
+
+const fetch = async (_a: any, _b: any, options: FetchOptions) => {
+    const alliumQuery = `
+    WITH first_seen AS (
+        SELECT
+            sender,
+            MIN(timestamp_ms) AS first_seen_timestamp
+        FROM sui.raw.transaction_blocks
+        WHERE timestamp_ms < ${options.endTimestamp * 1000}
+          AND sender IS NOT NULL
+        GROUP BY 1
+    )
+    SELECT COALESCE(count(*), 0) AS new_users
+    FROM first_seen
+    WHERE first_seen_timestamp >= ${options.startTimestamp * 1000}
+      AND first_seen_timestamp < ${options.endTimestamp * 1000}
+  `;
+
+    const alliumResult = await queryAllium(alliumQuery);
+
+    return {
+        dailyNewUsers: alliumResult[0].new_users,
+    }
+}
+
+const adapter: SimpleAdapter = {
+    version: 1,
+    fetch,
+    chains: [CHAIN.SUI],
+    dependencies: [Dependencies.ALLIUM],
+    isExpensiveAdapter: true,
+    protocolType: ProtocolType.CHAIN,
+    start: "2023-04-12",
+};
+
+export default adapter;


### PR DESCRIPTION
Extension to https://github.com/DefiLlama/dimension-adapters/pull/6876

## Summary
- Adds new-users adapters for Aptos and Sui chain-level user metrics.
- Uses Allium raw transaction data to count addresses whose first observed transaction falls within the daily window.

## Changes
- Added `new-users/aptos.ts` using `aptos.raw.transactions`, `sender`, and `block_timestamp`.
- Added `new-users/sui.ts` using `sui.raw.transaction_blocks`, `sender`, and `timestamp_ms`.
- Marked both adapters as Allium-backed chain adapters with the existing Aptos and Sui start dates.
