### PR TITLE
fix(jpg-store): replace with onchain tracking

### DIFF
--- a/fees/jpg-store/index.ts
+++ b/fees/jpg-store/index.ts
@@ -1,21 +1,66 @@
 import { Adapter, FetchOptions, FetchResult } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
-import fetchURL from "../../utils/fetchURL";
+import { blockfrost } from "../../helpers/cardano";
+
+// jpg.store v3 marketplace address: receives 2% fee outputs (ADA-only) from
+// every NFT sale settled by the ask.spend validator.
+// Payment script:   84cc25ea4c29951d40b443b95bbc5676bc425470f96376d1984af9ab
+// Stake script:     2c967f4bd28944b06462e13c5e3f5d5fa6e03f8567569438cd833e6d
+const MARKETPLACE_ADDR =
+  "addr1xxzvcf02fs5e282qk3pmjkau2emtcsj5wrukxak3np90n2evjel5h55fgjcxgchp830r7h2l5msrlpt8262r3nvr8eksg6pw3p";
+
+async function getMarketplaceFees(start: number, end: number): Promise<number> {
+  let page = 1;
+  let totalLovelace = 0;
+
+  while (true) {
+    const txs = await blockfrost(
+      `/addresses/${MARKETPLACE_ADDR}/transactions?page=${page}&order=desc`
+    );
+
+    if (!txs || txs.length === 0) break;
+
+    const txsInWindow = txs.filter(
+      (tx: any) => tx.block_time >= start && tx.block_time <= end
+    );
+    const pastWindow = txs.some((tx: any) => tx.block_time < start);
+
+    const utxoResults = await Promise.all(
+      txsInWindow.map((tx: any) => blockfrost(`/txs/${tx.tx_hash}/utxos`))
+    );
+
+    for (const utxos of utxoResults) {
+      for (const output of utxos.outputs) {
+        if (output.address !== MARKETPLACE_ADDR) continue;
+        // Fee outputs are pure ADA. Listings always carry the NFT token,
+        // so any output with >1 asset is a listing/migration, not a fee.
+        if (output.amount.length !== 1) continue;
+        const lovelaceOut = output.amount[0];
+        if (lovelaceOut.unit !== "lovelace") continue;
+        totalLovelace += Number(lovelaceOut.quantity);
+      }
+    }
+
+    if (pastWindow) break;
+    page++;
+  }
+
+  return totalLovelace / 1_000_000;
+}
 
 const fetch = async (options: FetchOptions): Promise<FetchResult> => {
-  const data = await fetchURL(`https://tidelabs.io/api/defillama/jpg-store/fees?from=${options.startTimestamp}&to=${options.endTimestamp}`);
-
-  const dailyFeesUSD = options.createBalances();
-  const dailyRevenueUSD = options.createBalances();
-
-  dailyFeesUSD.addCGToken("cardano", Number(data.dailyFees));
-  dailyRevenueUSD.addCGToken("cardano", Number(data.dailyRevenue));
+  const dailyFees = options.createBalances();
+  const ada = await getMarketplaceFees(
+    options.startTimestamp,
+    options.endTimestamp
+  );
+  dailyFees.addCGToken("cardano", ada);
 
   return {
-    dailyFees: dailyFeesUSD,
-    dailyUserFees: dailyFeesUSD,
-    dailyRevenue: dailyRevenueUSD,
-    dailyProtocolRevenue: dailyRevenueUSD,
+    dailyFees,
+    dailyUserFees: dailyFees,
+    dailyRevenue: dailyFees,
+    dailyProtocolRevenue: dailyFees,
   };
 };
 
@@ -28,10 +73,10 @@ const adapter: Adapter = {
     },
   },
   methodology: {
-    Fees: "All service fees collected from NFT sales",
-    UserFees: "All service fees collected from NFT sales",
-    Revenue: " service fees collected from NFT sales to protocol",
-    ProtocolRevenue: "service fees collected from NFT sales to protocol",
+    Fees: "2% marketplace fee collected at the jpg.store v3 marketplace contract on each NFT sale.",
+    UserFees: "2% marketplace fee paid by sellers on each NFT sale.",
+    Revenue: "All marketplace fees collected by the jpg.store protocol.",
+    ProtocolRevenue: "All marketplace fees collected by the jpg.store protocol.",
   },
 };
 

--- a/helpers/cardano.ts
+++ b/helpers/cardano.ts
@@ -1,7 +1,7 @@
 import { httpGet } from "../utils/fetchURL";
 import { getEnv } from "./env";
 
-async function blockfrost(path: string) {
+export async function blockfrost(path: string) {
     return httpGet(`https://cardano-mainnet.blockfrost.io/api/v0${path}`, {
         headers: {
             project_id: getEnv("BLOCKFROST_PROJECT_ID"),


### PR DESCRIPTION
fix #6513 

* Replaces the unreachable API with on-chain tracking via Blockfrost.
* Tracks fees from the jpg.store v3 marketplace contract address derived from `marketplace_sh` and `marketplace_stake_sh` in `contracts-v3/lib/jpg/constants.ak`.
* Filters fee outputs as ADA-only UTXOs (`amount.length === 1 && unit === "lovelace"`); listing UTXOs always include the NFT token. UTXO fetches per page are batched with `Promise.all`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * JPG.store fee calculations now derive from on-chain Cardano transaction data for improved accuracy in daily fees and revenue tracking, with explicit documentation of the 2% marketplace fee model.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DefiLlama/dimension-adapters/pull/7264?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->