### PR TITLE
draft: add americafun fees adapter

### DIFF
--- a/fees/americafun.ts
+++ b/fees/americafun.ts
@@ -25,12 +25,12 @@ const fetch = async (options: FetchOptions) => {
   const dailyHoldersRevenue = options.createBalances()
   const dailySupplySideRevenue = options.createBalances()
 
-  const feesUsd = parseFloat(data.dailyFees) || 0
-  const revenueUsd = parseFloat(data.dailyRevenue) || 0
-  const protocolRevenueUsd = parseFloat(data.dailyProtocolRevenue) || 0
-  const holdersRevenueUsd = parseFloat(data.dailyHoldersRevenue) || 0
-  const meteoraFeeUsd = parseFloat(data.meteoraFee) || 0
-  const lpFeeUsd = (parseFloat(data.dailySupplySideRevenue) || 0) - meteoraFeeUsd
+  const feesUsd = Number(data.dailyFees)
+  const revenueUsd = Number(data.dailyRevenue)
+  const protocolRevenueUsd = Number(data.dailyProtocolRevenue)
+  const holdersRevenueUsd = Number(data.dailyHoldersRevenue)
+  const meteoraFeeUsd = Number(data.meteoraFee)
+  const lpFeeUsd = Number(data.dailySupplySideRevenue) - meteoraFeeUsd
 
   if (feesUsd > 0) dailyFees.addUSDValue(feesUsd, "Swap Fees")
   if (revenueUsd > 0) dailyRevenue.addUSDValue(revenueUsd, "Swap Fees To Protocol")

--- a/fees/americafun.ts
+++ b/fees/americafun.ts
@@ -8,6 +8,7 @@ interface DailyFeesResponse {
   dailyFees: string
   dailyRevenue: string
   dailySupplySideRevenue: string
+  meteoraFee: string
   timestamp: number
 }
 
@@ -22,23 +23,26 @@ const fetch = async (options: FetchOptions) => {
 
   const feesUsd = parseFloat(data.dailyFees) || 0
   const revenueUsd = parseFloat(data.dailyRevenue) || 0
-  const supplySideUsd = parseFloat(data.dailySupplySideRevenue) || 0
+  const meteoraFeeUsd = parseFloat(data.meteoraFee) || 0
+  const lpAndCreatorFeeUsd = (parseFloat(data.dailySupplySideRevenue) || 0) - meteoraFeeUsd
 
   if (feesUsd > 0) dailyFees.addUSDValue(feesUsd, "Swap Fees")
   if (revenueUsd > 0) dailyRevenue.addUSDValue(revenueUsd, "Swap Fees To Protocol")
-  if (supplySideUsd > 0) dailySupplySideRevenue.addUSDValue(supplySideUsd, "Swap Fees To Liquidity Providers")
+  if (meteoraFeeUsd > 0) dailySupplySideRevenue.addUSDValue(meteoraFeeUsd, "Swap Fees To Meteora")
+  if (lpAndCreatorFeeUsd > 0) dailySupplySideRevenue.addUSDValue(lpAndCreatorFeeUsd, "Swap Fees To Liquidity Providers")
 
   return { dailyFees, dailyRevenue, dailySupplySideRevenue }
 }
 
 const breakdownMethodology = {
   Fees: {
-    "Swap Fees": "Trading fees collected from DBC (Dynamic Bonding Curve) and DAMM v2 liquidity pools.",
+    "Swap Fees": "Gross trading fees collected from DBC (Dynamic Bonding Curve) and DAMM v2 liquidity pools, including Meteora's protocol cut.",
   },
   Revenue: {
-    "Swap Fees To Protocol": "Protocol share of trading fees allocated to the treasury and stakers.",
+    "Swap Fees To Protocol": "Protocol share of trading fees allocated to the americafun treasury and stakers.",
   },
   SupplySideRevenue: {
+    "Swap Fees To Meteora": "Meteora protocol fee: 20% of gross trading fees (applies to both DBC and DAMM v2 pools).",
     "Swap Fees To Liquidity Providers": "Share of trading fees paid to liquidity providers and pool creators.",
   },
 }
@@ -49,9 +53,9 @@ const adapter: SimpleAdapter = {
   chains: [CHAIN.SOLANA],
   start: "2026-04-20",
   methodology: {
-    Fees: "Total trading fees collected from DBC (Dynamic Bonding Curve) and DAMM v2 liquidity pools.",
-    Revenue: "Protocol share of trading fees allocated to the treasury and stakers.",
-    SupplySideRevenue: "Share of trading fees paid to liquidity providers and pool creators.",
+    Fees: "Gross trading fees from DBC and DAMM v2 pools, including Meteora's 20% protocol cut.",
+    Revenue: "americafun protocol share allocated to the treasury and stakers.",
+    SupplySideRevenue: "Meteora protocol fees plus fees distributed to liquidity providers and pool creators.",
   },
   breakdownMethodology,
 }

--- a/fees/americafun.ts
+++ b/fees/americafun.ts
@@ -12,7 +12,7 @@ interface DailyFeesResponse {
   timestamp: number
 }
 
-const fetch = async (options: FetchOptions) => {
+const fetch = async (_a: any, _b: any, options: FetchOptions) => {
   const data: DailyFeesResponse = await httpGet(
     `${API_BASE}/fees?from=${options.startTimestamp}&to=${options.endTimestamp}`
   )
@@ -34,6 +34,12 @@ const fetch = async (options: FetchOptions) => {
   return { dailyFees, dailyRevenue, dailySupplySideRevenue }
 }
 
+const methodology = {
+  Fees: "Gross trading fees from DBC and DAMM v2 pools, including Meteora's 20% protocol cut.",
+  Revenue: "americafun protocol share allocated to the treasury and stakers.",
+  SupplySideRevenue: "Meteora protocol fees plus fees distributed to liquidity providers and pool creators.",
+};
+
 const breakdownMethodology = {
   Fees: {
     "Swap Fees": "Gross trading fees collected from DBC (Dynamic Bonding Curve) and DAMM v2 liquidity pools, including Meteora's protocol cut.",
@@ -48,15 +54,11 @@ const breakdownMethodology = {
 }
 
 const adapter: SimpleAdapter = {
-  version: 2,
+  version: 1, //api updates once a day
   fetch,
   chains: [CHAIN.SOLANA],
   start: "2026-04-20",
-  methodology: {
-    Fees: "Gross trading fees from DBC and DAMM v2 pools, including Meteora's 20% protocol cut.",
-    Revenue: "americafun protocol share allocated to the treasury and stakers.",
-    SupplySideRevenue: "Meteora protocol fees plus fees distributed to liquidity providers and pool creators.",
-  },
+  methodology,
   breakdownMethodology,
 }
 

--- a/fees/americafun.ts
+++ b/fees/americafun.ts
@@ -7,58 +7,72 @@ const API_BASE = "https://defillama.america.fun/api/v1"
 interface DailyFeesResponse {
   dailyFees: string
   dailyRevenue: string
+  dailyProtocolRevenue: string
+  dailyHoldersRevenue: string
   dailySupplySideRevenue: string
   meteoraFee: string
   timestamp: number
 }
 
-const fetch = async (_a: any, _b: any, options: FetchOptions) => {
+const fetch = async (options: FetchOptions) => {
   const data: DailyFeesResponse = await httpGet(
     `${API_BASE}/fees?from=${options.startTimestamp}&to=${options.endTimestamp}`
   )
 
   const dailyFees = options.createBalances()
   const dailyRevenue = options.createBalances()
+  const dailyProtocolRevenue = options.createBalances()
+  const dailyHoldersRevenue = options.createBalances()
   const dailySupplySideRevenue = options.createBalances()
 
   const feesUsd = parseFloat(data.dailyFees) || 0
   const revenueUsd = parseFloat(data.dailyRevenue) || 0
+  const protocolRevenueUsd = parseFloat(data.dailyProtocolRevenue) || 0
+  const holdersRevenueUsd = parseFloat(data.dailyHoldersRevenue) || 0
   const meteoraFeeUsd = parseFloat(data.meteoraFee) || 0
-  const lpAndCreatorFeeUsd = (parseFloat(data.dailySupplySideRevenue) || 0) - meteoraFeeUsd
+  const lpFeeUsd = (parseFloat(data.dailySupplySideRevenue) || 0) - meteoraFeeUsd
 
   if (feesUsd > 0) dailyFees.addUSDValue(feesUsd, "Swap Fees")
   if (revenueUsd > 0) dailyRevenue.addUSDValue(revenueUsd, "Swap Fees To Protocol")
+  if (protocolRevenueUsd > 0) dailyProtocolRevenue.addUSDValue(protocolRevenueUsd, "Swap Fees To Treasury")
+  if (holdersRevenueUsd > 0) dailyHoldersRevenue.addUSDValue(holdersRevenueUsd, "Swap Fees To Stakers")
   if (meteoraFeeUsd > 0) dailySupplySideRevenue.addUSDValue(meteoraFeeUsd, "Swap Fees To Meteora")
-  if (lpAndCreatorFeeUsd > 0) dailySupplySideRevenue.addUSDValue(lpAndCreatorFeeUsd, "Swap Fees To Liquidity Providers")
+  if (lpFeeUsd > 0) dailySupplySideRevenue.addUSDValue(lpFeeUsd, "Swap Fees To Liquidity Providers")
 
-  return { dailyFees, dailyRevenue, dailySupplySideRevenue }
+  return { dailyFees, dailyRevenue, dailyProtocolRevenue, dailyHoldersRevenue, dailySupplySideRevenue }
 }
-
-const methodology = {
-  Fees: "Gross trading fees from DBC and DAMM v2 pools, including Meteora's 20% protocol cut.",
-  Revenue: "americafun protocol share allocated to the treasury and stakers.",
-  SupplySideRevenue: "Meteora protocol fees plus fees distributed to liquidity providers and pool creators.",
-};
 
 const breakdownMethodology = {
   Fees: {
     "Swap Fees": "Gross trading fees collected from DBC (Dynamic Bonding Curve) and DAMM v2 liquidity pools, including Meteora's protocol cut.",
   },
   Revenue: {
-    "Swap Fees To Protocol": "Protocol share of trading fees allocated to the americafun treasury and stakers.",
+    "Swap Fees To Protocol": "americafun protocol share: treasury, creator, and staker portions of trading fees.",
+  },
+  ProtocolRevenue: {
+    "Swap Fees To Treasury": "Fees allocated to the americafun treasury and pool creators.",
+  },
+  HoldersRevenue: {
+    "Swap Fees To Stakers": "Fees distributed to americafun governance token stakers.",
   },
   SupplySideRevenue: {
     "Swap Fees To Meteora": "Meteora protocol fee: 20% of gross trading fees (applies to both DBC and DAMM v2 pools).",
-    "Swap Fees To Liquidity Providers": "Share of trading fees paid to liquidity providers and pool creators.",
+    "Swap Fees To Liquidity Providers": "Share of trading fees paid to liquidity providers.",
   },
 }
 
 const adapter: SimpleAdapter = {
-  version: 1, //api updates once a day
+  version: 2,
   fetch,
   chains: [CHAIN.SOLANA],
   start: "2026-04-20",
-  methodology,
+  methodology: {
+    Fees: "Gross trading fees from DBC and DAMM v2 pools, including Meteora's 20% protocol cut.",
+    Revenue: "americafun protocol share: treasury, creator, and staker portions of trading fees.",
+    ProtocolRevenue: "Fees allocated to the americafun treasury and pool creators.",
+    HoldersRevenue: "Fees distributed to americafun governance token stakers.",
+    SupplySideRevenue: "Meteora protocol fees plus fees distributed to liquidity providers.",
+  },
   breakdownMethodology,
 }
 

--- a/fees/americafun.ts
+++ b/fees/americafun.ts
@@ -14,30 +14,30 @@ interface DailyFeesResponse {
   timestamp: number
 }
 
-const fetch = async (options: FetchOptions) => {
+const fetch = async (_a: any, _b: any, options: FetchOptions) => {
   const data: DailyFeesResponse = await httpGet(
     `${API_BASE}/fees?from=${options.startTimestamp}&to=${options.endTimestamp}`
   )
 
   const dailyFees = options.createBalances()
-  const dailyRevenue = options.createBalances()
   const dailyProtocolRevenue = options.createBalances()
   const dailyHoldersRevenue = options.createBalances()
   const dailySupplySideRevenue = options.createBalances()
 
-  const feesUsd = Number(data.dailyFees)
-  const revenueUsd = Number(data.dailyRevenue)
-  const protocolRevenueUsd = Number(data.dailyProtocolRevenue)
-  const holdersRevenueUsd = Number(data.dailyHoldersRevenue)
-  const meteoraFeeUsd = Number(data.meteoraFee)
-  const lpFeeUsd = Number(data.dailySupplySideRevenue) - meteoraFeeUsd
+  const feesUsd = parseFloat(data.dailyFees) || 0
+  const protocolRevenueUsd = parseFloat(data.dailyProtocolRevenue) || 0
+  const holdersRevenueUsd = parseFloat(data.dailyHoldersRevenue) || 0
+  const meteoraFeeUsd = parseFloat(data.meteoraFee) || 0
+  const lpFeeUsd = (parseFloat(data.dailySupplySideRevenue) || 0) - meteoraFeeUsd
 
   if (feesUsd > 0) dailyFees.addUSDValue(feesUsd, "Swap Fees")
-  if (revenueUsd > 0) dailyRevenue.addUSDValue(revenueUsd, "Swap Fees To Protocol")
   if (protocolRevenueUsd > 0) dailyProtocolRevenue.addUSDValue(protocolRevenueUsd, "Swap Fees To Treasury")
   if (holdersRevenueUsd > 0) dailyHoldersRevenue.addUSDValue(holdersRevenueUsd, "Swap Fees To Stakers")
   if (meteoraFeeUsd > 0) dailySupplySideRevenue.addUSDValue(meteoraFeeUsd, "Swap Fees To Meteora")
   if (lpFeeUsd > 0) dailySupplySideRevenue.addUSDValue(lpFeeUsd, "Swap Fees To Liquidity Providers")
+
+  const dailyRevenue = dailyProtocolRevenue.clone()
+  dailyRevenue.addBalances(dailyHoldersRevenue)
 
   return { dailyFees, dailyRevenue, dailyProtocolRevenue, dailyHoldersRevenue, dailySupplySideRevenue }
 }
@@ -47,7 +47,8 @@ const breakdownMethodology = {
     "Swap Fees": "Gross trading fees collected from DBC (Dynamic Bonding Curve) and DAMM v2 liquidity pools, including Meteora's protocol cut.",
   },
   Revenue: {
-    "Swap Fees To Protocol": "americafun protocol share: treasury and staker portions of trading fees.",
+    "Swap Fees To Treasury": "Fees allocated to the americafun treasury.",
+    "Swap Fees To Stakers": "Fees distributed to americafun governance token stakers.",
   },
   ProtocolRevenue: {
     "Swap Fees To Treasury": "Fees allocated to the americafun treasury.",
@@ -62,7 +63,7 @@ const breakdownMethodology = {
 }
 
 const adapter: SimpleAdapter = {
-  version: 2,
+  version: 1,
   fetch,
   chains: [CHAIN.SOLANA],
   start: "2026-04-20",

--- a/fees/americafun.ts
+++ b/fees/americafun.ts
@@ -47,10 +47,10 @@ const breakdownMethodology = {
     "Swap Fees": "Gross trading fees collected from DBC (Dynamic Bonding Curve) and DAMM v2 liquidity pools, including Meteora's protocol cut.",
   },
   Revenue: {
-    "Swap Fees To Protocol": "americafun protocol share: treasury, creator, and staker portions of trading fees.",
+    "Swap Fees To Protocol": "americafun protocol share: treasury and staker portions of trading fees.",
   },
   ProtocolRevenue: {
-    "Swap Fees To Treasury": "Fees allocated to the americafun treasury and pool creators.",
+    "Swap Fees To Treasury": "Fees allocated to the americafun treasury.",
   },
   HoldersRevenue: {
     "Swap Fees To Stakers": "Fees distributed to americafun governance token stakers.",
@@ -68,8 +68,8 @@ const adapter: SimpleAdapter = {
   start: "2026-04-20",
   methodology: {
     Fees: "Gross trading fees from DBC and DAMM v2 pools, including Meteora's 20% protocol cut.",
-    Revenue: "americafun protocol share: treasury, creator, and staker portions of trading fees.",
-    ProtocolRevenue: "Fees allocated to the americafun treasury and pool creators.",
+    Revenue: "americafun protocol share: treasury and staker portions of trading fees.",
+    ProtocolRevenue: "Fees allocated to the americafun treasury.",
     HoldersRevenue: "Fees distributed to americafun governance token stakers.",
     SupplySideRevenue: "Meteora protocol fees plus fees distributed to liquidity providers.",
   },

--- a/fees/americafun.ts
+++ b/fees/americafun.ts
@@ -1,0 +1,59 @@
+import { FetchOptions, SimpleAdapter } from "../adapters/types"
+import { CHAIN } from "../helpers/chains"
+import { httpGet } from "../utils/fetchURL"
+
+const API_BASE = "https://americafun-api.up.railway.app/api/v1"
+
+interface DailyFeesResponse {
+  dailyFees: string
+  dailyRevenue: string
+  dailySupplySideRevenue: string
+  timestamp: number
+}
+
+const fetch = async (_a: any, _b: any, options: FetchOptions) => {
+  const data: DailyFeesResponse = await httpGet(
+    `${API_BASE}/fees?from=${options.startTimestamp}&to=${options.endTimestamp}`
+  )
+
+  const dailyFees = options.createBalances()
+  const dailyRevenue = options.createBalances()
+  const dailySupplySideRevenue = options.createBalances()
+
+  const feesUsd = parseFloat(data.dailyFees)
+  const revenueUsd = parseFloat(data.dailyRevenue)
+  const supplySideUsd = parseFloat(data.dailySupplySideRevenue)
+
+  if (feesUsd > 0) dailyFees.addUSDValue(feesUsd, "Swap Fees")
+  if (revenueUsd > 0) dailyRevenue.addUSDValue(revenueUsd, "Swap Fees To Protocol")
+  if (supplySideUsd > 0) dailySupplySideRevenue.addUSDValue(supplySideUsd, "Swap Fees To Liquidity Providers")
+
+  return { dailyFees, dailyRevenue, dailySupplySideRevenue }
+}
+
+const breakdownMethodology = {
+  Fees: {
+    "Swap Fees": "Trading fees collected from DBC (Dynamic Bonding Curve) and DAMM v2 liquidity pools.",
+  },
+  Revenue: {
+    "Swap Fees To Protocol": "Protocol share of trading fees allocated to the treasury and stakers.",
+  },
+  SupplySideRevenue: {
+    "Swap Fees To Liquidity Providers": "Share of trading fees paid to liquidity providers and pool creators.",
+  },
+}
+
+const adapter: SimpleAdapter = {
+  version: 1,
+  fetch,
+  chains: [CHAIN.SOLANA],
+  start: "2026-04-20",
+  methodology: {
+    Fees: "Total trading fees collected from DBC (Dynamic Bonding Curve) and DAMM v2 liquidity pools.",
+    Revenue: "Protocol share of trading fees allocated to the treasury and stakers.",
+    SupplySideRevenue: "Share of trading fees paid to liquidity providers and pool creators.",
+  },
+  breakdownMethodology,
+}
+
+export default adapter

--- a/fees/americafun.ts
+++ b/fees/americafun.ts
@@ -2,7 +2,7 @@ import { FetchOptions, SimpleAdapter } from "../adapters/types"
 import { CHAIN } from "../helpers/chains"
 import { httpGet } from "../utils/fetchURL"
 
-const API_BASE = "https://americafun-api.up.railway.app/api/v1"
+const API_BASE = "https://defillama.america.fun/api/v1"
 
 interface DailyFeesResponse {
   dailyFees: string

--- a/fees/americafun.ts
+++ b/fees/americafun.ts
@@ -11,7 +11,7 @@ interface DailyFeesResponse {
   timestamp: number
 }
 
-const fetch = async (_a: any, _b: any, options: FetchOptions) => {
+const fetch = async (options: FetchOptions) => {
   const data: DailyFeesResponse = await httpGet(
     `${API_BASE}/fees?from=${options.startTimestamp}&to=${options.endTimestamp}`
   )
@@ -20,9 +20,9 @@ const fetch = async (_a: any, _b: any, options: FetchOptions) => {
   const dailyRevenue = options.createBalances()
   const dailySupplySideRevenue = options.createBalances()
 
-  const feesUsd = parseFloat(data.dailyFees)
-  const revenueUsd = parseFloat(data.dailyRevenue)
-  const supplySideUsd = parseFloat(data.dailySupplySideRevenue)
+  const feesUsd = parseFloat(data.dailyFees) || 0
+  const revenueUsd = parseFloat(data.dailyRevenue) || 0
+  const supplySideUsd = parseFloat(data.dailySupplySideRevenue) || 0
 
   if (feesUsd > 0) dailyFees.addUSDValue(feesUsd, "Swap Fees")
   if (revenueUsd > 0) dailyRevenue.addUSDValue(revenueUsd, "Swap Fees To Protocol")
@@ -44,7 +44,7 @@ const breakdownMethodology = {
 }
 
 const adapter: SimpleAdapter = {
-  version: 1,
+  version: 2,
   fetch,
   chains: [CHAIN.SOLANA],
   start: "2026-04-20",


### PR DESCRIPTION
## Summary

- **Protocol**: americafun.fun — Solana DEX using Meteora DBC (Dynamic Bonding Curve) and DAMM v2 liquidity pools
- **Website**: https://america.fun/
- **Chain**: Solana
- **Category**: Fees
- **Twitter**: https://x.com/americadotfun

## Adapter

Fetches daily fees and revenue from americafun's public REST API:

```
GET https://defillama.america.fun/api/v1/fees?from=<unix>&to=<unix>
```

Returns pre-aggregated USD values from on-chain DFS fee vault claim events:
- `dailyFees` — gross trading fees including Meteora's 20% protocol cut
- `dailyRevenue` — americafun protocol share (treasury + stakers + creators)
- `dailySupplySideRevenue` — Meteora fees + fees to LPs
- `meteoraFee` — Meteora's 20% cut, attributed separately in supply side

## Test

```
pnpm test fees americafun 2026-05-25
```

Output:
```
SOLANA 👇
Backfill start time: 20/4/2026
Daily fees: 3.46 k
Daily revenue: 2.40 k
Daily supply side revenue: 1.06 k
```

## Checklist

- [x] `pnpm test fees americafun 2026-05-25` passes locally
- [x] No new npm packages added
- [x] `package.json` / `package-lock.json` not modified
- [x] Start date verified against production data (`2026-04-20`)
- [x] Labels in `.add()` calls all documented in `breakdownMethodology`
- [x] Meteora protocol fee (20%) included in `dailyFees` and attributed as `"Swap Fees To Meteora"` in supply side