### PR TITLE
feat(silentswap): add SilentSwap volume adapter (BNB Chain)

### DIFF
--- a/dexs/silentswap/index.ts
+++ b/dexs/silentswap/index.ts
@@ -1,0 +1,97 @@
+import { CHAIN } from "../../helpers/chains";
+import type { FetchOptions, FetchV2, SimpleAdapter } from "../../adapters/types";
+
+/**
+ * SilentSwap volume adapter.
+ *
+ * SilentSwap is a privacy-preserving cross-chain swap protocol. The on-chain
+ * gateway contracts route per-order funds and intentionally are not exposed
+ * to indexers — surfacing them would leak the user-level activity that the
+ * protocol is designed to keep private.
+ *
+ * Instead, the SilentSwap operator publishes anonymized aggregate USD totals
+ * to an upgradeable reporter contract on BNB Chain (`SilentSwapStats`,
+ * deployed behind an ERC-1967 UUPS proxy). The contract holds only
+ * aggregates (no addresses, no per-order data) and every update is recorded
+ * as on-chain history.
+ *
+ * Source repo for the reporter contract:
+ *   https://github.com/SilentSwapV2/silentswap-dashboard/tree/main/contracts
+ */
+
+const STATS_CONTRACT = "0x5894a9B8B342BDb1AD7570C3656eE406eE26f676"; // BNB mainnet, deployed 2026-05-25
+
+const ONE_DAY_SECONDS = 24 * 60 * 60;
+
+const inflowUsdAbi = "function inflowUsd() view returns (uint256)";
+const volumeByDateAbi =
+    "function volumeByDate(uint64) view returns (" +
+    "uint128 cumulativeUsd, uint128 inflowUsd, uint128 outflowUsd, " +
+    "uint128 dailyUsd, uint64 transferCount, uint32 tokenCount, " +
+    "uint64 bnbBlock, uint64 publishedAt)";
+
+function yyyymmdd(ts: number): bigint {
+    const d = new Date(ts * 1000);
+    return BigInt(
+        d.getUTCFullYear() * 10_000 + (d.getUTCMonth() + 1) * 100 + d.getUTCDate(),
+    );
+}
+
+async function readInflowAtDate(api: FetchOptions["api"], date: bigint): Promise<bigint> {
+    const snap = await api.call({
+        target: STATS_CONTRACT,
+        abi: volumeByDateAbi,
+        params: [date.toString()],
+    });
+    // The decoded named tuple has `inflowUsd` at index 1.
+    const inflow =
+        (snap as { inflowUsd?: string | bigint })?.inflowUsd ??
+        (snap as Array<string | bigint>)[1] ??
+        0n;
+    return BigInt(inflow);
+}
+
+const fetch: FetchV2 = async ({ api, startTimestamp }) => {
+    const date = yyyymmdd(startTimestamp);
+    const prevDate = yyyymmdd(startTimestamp - ONE_DAY_SECONDS);
+
+    const [todayInflow6, prevInflow6, cumulativeInflow6] = await Promise.all([
+        readInflowAtDate(api, date),
+        readInflowAtDate(api, prevDate),
+        api.call({ target: STATS_CONTRACT, abi: inflowUsdAbi }) as Promise<bigint | string>,
+    ]);
+
+    const dailyInflow6 =
+        todayInflow6 > prevInflow6 ? todayInflow6 - prevInflow6 : todayInflow6;
+
+    return {
+        dailyVolume: Number(dailyInflow6) / 1e6,
+        totalVolume: Number(BigInt(cumulativeInflow6)) / 1e6,
+    };
+};
+
+const adapter: SimpleAdapter = {
+    version: 2,
+    methodology: {
+        Volume:
+            "Anonymized inflow series read from the SilentSwapStats reporter " +
+            "contract on BNB Chain (" + STATS_CONTRACT + "). " +
+            "dailyVolume = volumeByDate(date).inflowUsd - " +
+            "volumeByDate(date-1).inflowUsd; totalVolume = inflowUsd(). " +
+            "Per-order gateway addresses are intentionally not exposed to " +
+            "preserve user privacy.",
+    },
+    adapter: {
+        [CHAIN.BSC]: {
+            fetch,
+            start: "2026-05-25",
+            // The reporter contract stores per-date snapshots as current state
+            // (`volumeByDate[date]` is monotonic and never overwritten), so
+            // current-block reads return the correct historical day values
+            // without needing an archive node.
+            runAtCurrTime: true,
+        },
+    },
+};
+
+export default adapter;


### PR DESCRIPTION
## Summary

Adds a privacy-preserving volume adapter for **SilentSwap**, a cross-chain
swap protocol that publishes anonymized aggregate inflow totals to an
upgradeable on-chain reporter contract on BNB Chain (`SilentSwapStats`,
ERC-1967 UUPS proxy at [`0x5894a9B8B342BDb1AD7570C3656eE406eE26f676`](https://bscscan.com/address/0x5894a9B8B342BDb1AD7570C3656eE406eE26f676)).

Per-order gateway addresses are intentionally **not** exposed to indexers —
that's a design invariant of the protocol, so volume is read from the
operator-published aggregates instead.

## Methodology

- `totalVolume` ← `inflowUsd()` (cumulative, 6dp USD).
- `dailyVolume` ← `volumeByDate(date).inflowUsd − volumeByDate(date−1).inflowUsd`
  (clamped to ≥0). The reporter stores end-of-day cumulative inflow per UTC
  date; daily volume is the delta between consecutive snapshots.

These are the same reads driving the SilentSwap operator dashboard's
"Contracts" page (`frontend/src/app/contracts/page.tsx` in the source repo),
so on-chain state, the dashboard, and the DefiLlama listing always agree.

`runAtCurrTime: true` is set because the reporter stores per-date snapshots
as current state (`volumeByDate[date]` is monotonic and never overwritten),
so current-block reads return the correct historical day values without
needing an archive node.

## Reporter contract

- **Source**: <https://github.com/SilentSwapV2/silentswap-dashboard/tree/main/contracts>
- **Proxy**: [`0x5894a9B8B342BDb1AD7570C3656eE406eE26f676`](https://bscscan.com/address/0x5894a9B8B342BDb1AD7570C3656eE406eE26f676)
- **Implementation**: [`0xb83caad486A2dFe502bB474A7BceF89c6404F2e8`](https://bscscan.com/address/0xb83caad486A2dFe502bB474A7BceF89c6404F2e8)
- **Deployed**: 2026-05-25
- Publisher service: <https://github.com/SilentSwapV2/silentswap-dashboard/tree/main/backend/src/modules/stats-publisher>

## Sanity check (2026-05-28, BSC mainnet, direct adapter call)

```
RESULT: { dailyVolume: 2194845016.43, totalVolume: 2201391048.85 }
```

(Day-1 reads as `todayInflow` when no prior snapshot exists yet; the daily
series normalizes once a second day's snapshot is published.)

## Privacy note

Omitted fields — `outflowUsd`, per-user metrics, per-order data — are
intentionally excluded by the reporter's anonymization design. Inflow is
the privacy-preserving headline metric. No PII leakage in any read.
