### PR TITLE
[feat] Near-Stats: track new users, active users and txcount for near via allium 

### DIFF
--- a/active-users/near.ts
+++ b/active-users/near.ts
@@ -1,0 +1,34 @@
+import { Dependencies, FetchOptions, ProtocolType, SimpleAdapter } from "../adapters/types";
+import { queryAllium } from "../helpers/allium";
+import { CHAIN } from "../helpers/chains";
+
+const fetch = async (_a: any, _b: any, options: FetchOptions) => {
+  const alliumQuery = `
+    SELECT
+      COALESCE(COUNT(DISTINCT signer_id), 0) AS user_count,
+      COALESCE(COUNT(hash), 0) AS transaction_count
+    FROM near.raw.transactions
+    WHERE block_timestamp >= TO_TIMESTAMP_NTZ(${options.startTimestamp})
+      AND block_timestamp < TO_TIMESTAMP_NTZ(${options.endTimestamp})
+      AND success = TRUE
+  `;
+
+  const alliumResult = await queryAllium(alliumQuery);
+
+  return {
+    dailyActiveUsers: alliumResult[0].user_count,
+    dailyTransactionsCount: alliumResult[0].transaction_count,
+  };
+};
+
+const adapter: SimpleAdapter = {
+  version: 1,
+  fetch,
+  chains: [CHAIN.NEAR],
+  dependencies: [Dependencies.ALLIUM],
+  isExpensiveAdapter: true,
+  protocolType: ProtocolType.CHAIN,
+  start: "2020-10-13",
+};
+
+export default adapter;

--- a/new-users/near.ts
+++ b/new-users/near.ts
@@ -1,0 +1,40 @@
+import { Dependencies, FetchOptions, ProtocolType, SimpleAdapter } from "../adapters/types";
+import { queryAllium } from "../helpers/allium";
+import { CHAIN } from "../helpers/chains";
+
+const fetch = async (_a: any, _b: any, options: FetchOptions) => {
+  const alliumQuery = `
+    WITH first_seen AS (
+      SELECT
+        signer_id,
+        MIN(block_timestamp) AS first_seen_timestamp
+      FROM near.raw.transactions
+      WHERE block_timestamp < TO_TIMESTAMP_NTZ(${options.endTimestamp})
+        AND signer_id IS NOT NULL
+        AND success = TRUE
+      GROUP BY 1
+    )
+    SELECT COALESCE(COUNT(*), 0) AS new_users
+    FROM first_seen
+    WHERE first_seen_timestamp >= TO_TIMESTAMP_NTZ(${options.startTimestamp})
+      AND first_seen_timestamp < TO_TIMESTAMP_NTZ(${options.endTimestamp})
+  `;
+
+  const alliumResult = await queryAllium(alliumQuery);
+
+  return {
+    dailyNewUsers: alliumResult[0].new_users,
+  };
+};
+
+const adapter: SimpleAdapter = {
+  version: 1,
+  fetch,
+  chains: [CHAIN.NEAR],
+  dependencies: [Dependencies.ALLIUM],
+  isExpensiveAdapter: true,
+  protocolType: ProtocolType.CHAIN,
+  start: "2020-10-13",
+};
+
+export default adapter;


### PR DESCRIPTION
> Maintainer Note
> The allium query is written with ref to allium docs and hasnt been tested, please test it and lmk if there are any changes to be done.

## Summary
- Adds NEAR chain active-users and new-users adapters.
- Uses Allium `near.raw.transactions` to report active signers, transaction count, and first-seen signer counts.

## Changes
- Added `active-users/near.ts` for `dailyActiveUsers` and `dailyTransactionsCount`.
- Added `new-users/near.ts` for `dailyNewUsers`.
- Set NEAR chain start date to `2020-10-13`.
- Marks both adapters as Allium-backed chain adapters with `ProtocolType.CHAIN`.

## Methodology
- Active users are counted as distinct successful transaction `signer_id`s during the adapter window.
- Transaction count is counted from successful transaction hashes during the adapter window.
- New users are counted from each `signer_id`'s first successful transaction, filtered into the adapter window.
