### PR TITLE
[feat] Ripple-Stats: track users and txcount for ripple via allium

### DIFF
--- a/active-users/ripple.ts
+++ b/active-users/ripple.ts
@@ -1,0 +1,34 @@
+import { Dependencies, FetchOptions, ProtocolType, SimpleAdapter } from "../adapters/types";
+import { queryAllium } from "../helpers/allium";
+import { CHAIN } from "../helpers/chains";
+
+const fetch = async (_a: any, _b: any, options: FetchOptions) => {
+  const alliumQuery = `
+    SELECT
+      COALESCE(COUNT(DISTINCT account), 0) AS user_count,
+      COALESCE(COUNT(hash), 0) AS transaction_count
+    FROM xrp_ledger.raw.transactions
+    WHERE ledger_close_time >= TO_TIMESTAMP_NTZ(${options.startTimestamp})
+      AND ledger_close_time < TO_TIMESTAMP_NTZ(${options.endTimestamp})
+      AND transaction_result = 'tesSUCCESS'
+  `;
+
+  const alliumResult = await queryAllium(alliumQuery);
+
+  return {
+    dailyActiveUsers: alliumResult[0].user_count,
+    dailyTransactionsCount: alliumResult[0].transaction_count,
+  };
+};
+
+const adapter: SimpleAdapter = {
+  version: 1,
+  fetch,
+  chains: [CHAIN.RIPPLE],
+  dependencies: [Dependencies.ALLIUM],
+  isExpensiveAdapter: true,
+  protocolType: ProtocolType.CHAIN,
+  start: "2013-01-01",
+};
+
+export default adapter;

--- a/active-users/ripple.ts
+++ b/active-users/ripple.ts
@@ -6,7 +6,7 @@ const fetch = async (_a: any, _b: any, options: FetchOptions) => {
   const alliumQuery = `
     SELECT
       COALESCE(COUNT(DISTINCT account), 0) AS user_count,
-      COALESCE(COUNT(hash), 0) AS transaction_count
+      COALESCE(COUNT(DISTINCT hash), 0) AS transaction_count
     FROM xrp_ledger.raw.transactions
     WHERE ledger_close_time >= TO_TIMESTAMP_NTZ(${options.startTimestamp})
       AND ledger_close_time < TO_TIMESTAMP_NTZ(${options.endTimestamp})

--- a/new-users/ripple.ts
+++ b/new-users/ripple.ts
@@ -1,0 +1,40 @@
+import { Dependencies, FetchOptions, ProtocolType, SimpleAdapter } from "../adapters/types";
+import { queryAllium } from "../helpers/allium";
+import { CHAIN } from "../helpers/chains";
+
+const fetch = async (_a: any, _b: any, options: FetchOptions) => {
+  const alliumQuery = `
+    WITH first_seen AS (
+      SELECT
+        account,
+        MIN(ledger_close_time) AS first_seen_timestamp
+      FROM xrp_ledger.raw.transactions
+      WHERE ledger_close_time < TO_TIMESTAMP_NTZ(${options.endTimestamp})
+        AND account IS NOT NULL
+        AND transaction_result = 'tesSUCCESS'
+      GROUP BY 1
+    )
+    SELECT COALESCE(COUNT(*), 0) AS new_users
+    FROM first_seen
+    WHERE first_seen_timestamp >= TO_TIMESTAMP_NTZ(${options.startTimestamp})
+      AND first_seen_timestamp < TO_TIMESTAMP_NTZ(${options.endTimestamp})
+  `;
+
+  const alliumResult = await queryAllium(alliumQuery);
+
+  return {
+    dailyNewUsers: alliumResult[0].new_users,
+  };
+};
+
+const adapter: SimpleAdapter = {
+  version: 1,
+  fetch,
+  chains: [CHAIN.RIPPLE],
+  dependencies: [Dependencies.ALLIUM],
+  isExpensiveAdapter: true,
+  protocolType: ProtocolType.CHAIN,
+  start: "2013-01-01",
+};
+
+export default adapter;


### PR DESCRIPTION
## Summary
- Adds Ripple/XRP Ledger chain active-users and new-users adapters.
- Uses Allium `xrp_ledger.raw.transactions` to report successful submitting accounts and first-seen accounts.

## Changes
- Added `active-users/ripple.ts` for `dailyActiveUsers` and `dailyTransactionsCount`.
- Added `new-users/ripple.ts` for `dailyNewUsers`.
- Exports metrics under `CHAIN.RIPPLE` while querying Allium’s `xrp_ledger.raw.transactions` table.
- Set start date to `2013-01-01`, the date of the earliest available XRPL ledger history.

## Methodology
- Active users are counted as distinct `account`s from transactions with `transaction_result = 'tesSUCCESS'`.
- Transaction count is counted from successful transaction `hash` values.
- New users are counted from each `account`'s first successful transaction.
- Start date follows the earliest available XRPL transaction history rather than the June 2012 network launch, since early ledgers before `32570` are not available.
