### PR TITLE
[feat] Stellar-Stats: track users and txcount for stellar chain via allium

### DIFF
--- a/active-users/stellar.ts
+++ b/active-users/stellar.ts
@@ -1,0 +1,34 @@
+import { Dependencies, FetchOptions, ProtocolType, SimpleAdapter } from "../adapters/types";
+import { queryAllium } from "../helpers/allium";
+import { CHAIN } from "../helpers/chains";
+
+const fetch = async (_a: any, _b: any, options: FetchOptions) => {
+  const alliumQuery = `
+    SELECT
+      COALESCE(COUNT(DISTINCT SOURCE_ACCOUNT), 0) AS user_count,
+      COALESCE(COUNT(HASH), 0) AS transaction_count
+    FROM stellar.raw.transactions
+    WHERE LEDGER_CLOSE_TIME >= TO_TIMESTAMP_NTZ(${options.startTimestamp})
+      AND LEDGER_CLOSE_TIME < TO_TIMESTAMP_NTZ(${options.endTimestamp})
+      AND SUCCESSFUL = TRUE
+  `;
+
+  const alliumResult = await queryAllium(alliumQuery);
+
+  return {
+    dailyActiveUsers: alliumResult[0].user_count,
+    dailyTransactionsCount: alliumResult[0].transaction_count,
+  };
+};
+
+const adapter: SimpleAdapter = {
+  version: 1,
+  fetch,
+  chains: [CHAIN.STELLAR],
+  dependencies: [Dependencies.ALLIUM],
+  isExpensiveAdapter: true,
+  protocolType: ProtocolType.CHAIN,
+  start: "2015-09-30",
+};
+
+export default adapter;

--- a/new-users/stellar.ts
+++ b/new-users/stellar.ts
@@ -1,0 +1,40 @@
+import { Dependencies, FetchOptions, ProtocolType, SimpleAdapter } from "../adapters/types";
+import { queryAllium } from "../helpers/allium";
+import { CHAIN } from "../helpers/chains";
+
+const fetch = async (_a: any, _b: any, options: FetchOptions) => {
+  const alliumQuery = `
+    WITH first_seen AS (
+      SELECT
+        SOURCE_ACCOUNT,
+        MIN(LEDGER_CLOSE_TIME) AS first_seen_timestamp
+      FROM stellar.raw.transactions
+      WHERE LEDGER_CLOSE_TIME < TO_TIMESTAMP_NTZ(${options.endTimestamp})
+        AND SOURCE_ACCOUNT IS NOT NULL
+        AND SUCCESSFUL = TRUE
+      GROUP BY 1
+    )
+    SELECT COALESCE(COUNT(*), 0) AS new_users
+    FROM first_seen
+    WHERE first_seen_timestamp >= TO_TIMESTAMP_NTZ(${options.startTimestamp})
+      AND first_seen_timestamp < TO_TIMESTAMP_NTZ(${options.endTimestamp})
+  `;
+
+  const alliumResult = await queryAllium(alliumQuery);
+
+  return {
+    dailyNewUsers: alliumResult[0].new_users,
+  };
+};
+
+const adapter: SimpleAdapter = {
+  version: 1,
+  fetch,
+  chains: [CHAIN.STELLAR],
+  dependencies: [Dependencies.ALLIUM],
+  isExpensiveAdapter: true,
+  protocolType: ProtocolType.CHAIN,
+  start: "2015-09-30",
+};
+
+export default adapter;


### PR DESCRIPTION
## Summary
- Adds Stellar chain active-users and new-users adapters.
- Uses Allium `stellar.raw.transactions` to report successful transaction source accounts and first-seen source accounts.

## Changes
- Added `active-users/stellar.ts` for `dailyActiveUsers` and `dailyTransactionsCount`.
- Added `new-users/stellar.ts` for `dailyNewUsers`.
- Set Stellar start date to `2015-09-30`, matching the existing Stellar chain fees adapter.

## Methodology
- Active users are counted as distinct successful transaction `SOURCE_ACCOUNT`s during the adapter window.
- Transaction count is counted from successful transaction `HASH` values.
- New users are counted from each `SOURCE_ACCOUNT`'s first successful transaction.
