### PR TITLE
[feat] Ton-Stats: track users and txcount for ton network via allium

### DIFF
--- a/active-users/ton.ts
+++ b/active-users/ton.ts
@@ -1,0 +1,34 @@
+import { Dependencies, FetchOptions, ProtocolType, SimpleAdapter } from "../adapters/types";
+import { queryAllium } from "../helpers/allium";
+import { CHAIN } from "../helpers/chains";
+
+const fetch = async (_a: any, _b: any, options: FetchOptions) => {
+  const alliumQuery = `
+    SELECT
+      COALESCE(COUNT(DISTINCT account), 0) AS user_count,
+      COALESCE(COUNT(hash), 0) AS transaction_count
+    FROM ton.raw.transactions
+    WHERE utime >= ${options.startTimestamp}
+      AND utime < ${options.endTimestamp}
+      AND aborted = FALSE
+  `;
+
+  const alliumResult = await queryAllium(alliumQuery);
+
+  return {
+    dailyActiveUsers: alliumResult[0].user_count,
+    dailyTransactionsCount: alliumResult[0].transaction_count,
+  };
+};
+
+const adapter: SimpleAdapter = {
+  version: 1,
+  fetch,
+  chains: [CHAIN.TON],
+  dependencies: [Dependencies.ALLIUM],
+  isExpensiveAdapter: true,
+  protocolType: ProtocolType.CHAIN,
+  start: "2021-08-03",
+};
+
+export default adapter;

--- a/new-users/ton.ts
+++ b/new-users/ton.ts
@@ -1,0 +1,40 @@
+import { Dependencies, FetchOptions, ProtocolType, SimpleAdapter } from "../adapters/types";
+import { queryAllium } from "../helpers/allium";
+import { CHAIN } from "../helpers/chains";
+
+const fetch = async (_a: any, _b: any, options: FetchOptions) => {
+  const alliumQuery = `
+    WITH first_seen AS (
+      SELECT
+        account,
+        MIN(utime) AS first_seen_timestamp
+      FROM ton.raw.transactions
+      WHERE utime < ${options.endTimestamp}
+        AND account IS NOT NULL
+        AND aborted = FALSE
+      GROUP BY 1
+    )
+    SELECT COALESCE(COUNT(*), 0) AS new_users
+    FROM first_seen
+    WHERE first_seen_timestamp >= ${options.startTimestamp}
+      AND first_seen_timestamp < ${options.endTimestamp}
+  `;
+
+  const alliumResult = await queryAllium(alliumQuery);
+
+  return {
+    dailyNewUsers: alliumResult[0].new_users,
+  };
+};
+
+const adapter: SimpleAdapter = {
+  version: 1,
+  fetch,
+  chains: [CHAIN.TON],
+  dependencies: [Dependencies.ALLIUM],
+  isExpensiveAdapter: true,
+  protocolType: ProtocolType.CHAIN,
+  start: "2021-08-03",
+};
+
+export default adapter;


### PR DESCRIPTION
## Summary
- Adds TON chain active-users and new-users adapters.
- Uses Allium `ton.raw.transactions` to report non-aborted active accounts, transaction count, and first-seen accounts.

## Changes
- Added `active-users/ton.ts` for `dailyActiveUsers` and `dailyTransactionsCount`.
- Added `new-users/ton.ts` for `dailyNewUsers`.
- Set TON start date to `2021-08-03`.

## Methodology
- Active users are counted as distinct non-aborted transaction `account`s during the adapter window.
- Transaction count is counted from non-aborted transaction `hash` values.
- New users are counted from each `account`'s first non-aborted transaction.
- TON’s `raw.transactions` table is account-centric, so `account` is used as the chain-level active account/user identifier.
