### PR TITLE
Add Blink (blink.lat) Hyperliquid builder

### DIFF
--- a/factory/hyperliquid.ts
+++ b/factory/hyperliquid.ts
@@ -261,17 +261,6 @@ const builderFeesConfigs: Record<string, BuilderConfig> = {
       ProtocolRevenue: "builder code revenue from Hyperliquid Perps Trades.",
     },
   },
-  "blink-perps": {
-    addresses: ["0xc7bcb2eee9bbfbf875499960746bc52b2e1a75c6"],
-    start: "2026-05-23",
-    methodology: {
-      Fees: "Builder code fees paid by users on Hyperliquid perps via Blink (blink.lat).",
-      Revenue: "Builder code fees collected by Blink from Hyperliquid perps.",
-      ProtocolRevenue: "Builder code fees collected by Blink from Hyperliquid perps.",
-      HoldersRevenue: "No fees distributed to token holders",
-    },
-    extraReturnFields: { dailyHoldersRevenue: "0" },
-  },
   "dexari": {
     addresses: ["0x7975cafdff839ed5047244ed3a0dd82a89866081"],
     start: "2025-01-28",

--- a/factory/hyperliquid.ts
+++ b/factory/hyperliquid.ts
@@ -74,6 +74,17 @@ const builderConfigs: Record<string, BuilderConfig> = {
     },
     breakdownFees: true,
   },
+  "blink-perps": {
+    addresses: ["0xc7bcb2eee9bbfbf875499960746bc52b2e1a75c6"],
+    start: "2026-05-23",
+    methodology: {
+      Fees: "Builder code fees paid by users on Hyperliquid perps via Blink (blink.lat).",
+      Revenue: "Builder code fees collected by Blink from Hyperliquid perps.",
+      ProtocolRevenue: "Builder code fees collected by Blink from Hyperliquid perps.",
+      HoldersRevenue: "No fees distributed to token holders",
+    },
+    extraReturnFields: { dailyHoldersRevenue: "0" },
+  },
   "phantom-perps": {
     addresses: ["0xb84168cf3be63c6b8dad05ff5d755e97432ff80b"],
     start: "2025-07-08",
@@ -249,6 +260,17 @@ const builderFeesConfigs: Record<string, BuilderConfig> = {
       Revenue: "builder code revenue from Hyperliquid Perps Trades.",
       ProtocolRevenue: "builder code revenue from Hyperliquid Perps Trades.",
     },
+  },
+  "blink-perps": {
+    addresses: ["0xc7bcb2eee9bbfbf875499960746bc52b2e1a75c6"],
+    start: "2026-05-23",
+    methodology: {
+      Fees: "Builder code fees paid by users on Hyperliquid perps via Blink (blink.lat).",
+      Revenue: "Builder code fees collected by Blink from Hyperliquid perps.",
+      ProtocolRevenue: "Builder code fees collected by Blink from Hyperliquid perps.",
+      HoldersRevenue: "No fees distributed to token holders",
+    },
+    extraReturnFields: { dailyHoldersRevenue: "0" },
   },
   "dexari": {
     addresses: ["0x7975cafdff839ed5047244ed3a0dd82a89866081"],


### PR DESCRIPTION
## Summary

Adds **Blink** (`blink-perps`) to the Hyperliquid builder factory for **DEX volume** and **fees/revenue** tracking.

- **Website:** https://blink.lat
- **Product:** Social-first Hyperliquid perps frontend using builder codes
- **Builder address:** `0xc7BcB2EeE9BbFbf875499960746Bc52B2E1A75C6`
- **Start date:** `2026-05-23` (production builder integration)

## Changes

- `factory/hyperliquid.ts`: register `blink-perps` in `builderConfigs` (dexs) and `builderFeesConfigs` (fees)

## Methodology

Builder code fees from Hyperliquid perp trades routed through Blink. Revenue = protocol revenue (no token holder distribution).

## Notes

- Blink does not hold on-chain TVL; this is a builder-frontend listing only (same pattern as `phantom-perps`, `metamask-perps`, etc.).
- Happy to adjust `start` date if you prefer first on-chain fill timestamp from Hyperliquid explorer.

## Test plan

- [ ] `pnpm test dexs blink-perps` (CI / indexer)
- [ ] `pnpm test fees blink-perps`


Made with [Cursor](https://cursor.com)