### PR TITLE
[feat] HyperEVM-Stats: tracks user stats and txcount for hyperevm via dune

### DIFF
--- a/active-users/hyperevm.ts
+++ b/active-users/hyperevm.ts
@@ -8,8 +8,7 @@ const fetch = async (_a: any, _b: any, options: FetchOptions) => {
       COALESCE(COUNT(DISTINCT "from"), 0) AS user_count,
       COALESCE(COUNT(*), 0) AS transaction_count
     FROM hyperevm.transactions
-    WHERE block_time >= from_unixtime(${options.startTimestamp})
-      AND block_time < from_unixtime(${options.endTimestamp})
+    WHERE TIME_RANGE
   `;
 
   const result = await queryDuneSql(options, query);

--- a/active-users/hyperevm.ts
+++ b/active-users/hyperevm.ts
@@ -1,0 +1,33 @@
+import { Dependencies, FetchOptions, ProtocolType, SimpleAdapter } from "../adapters/types";
+import { queryDuneSql } from "../helpers/dune";
+import { CHAIN } from "../helpers/chains";
+
+const fetch = async (_a: any, _b: any, options: FetchOptions) => {
+  const query = `
+    SELECT
+      COALESCE(COUNT(DISTINCT "from"), 0) AS user_count,
+      COALESCE(COUNT(*), 0) AS transaction_count
+    FROM hyperevm.transactions
+    WHERE block_time >= from_unixtime(${options.startTimestamp})
+      AND block_time < from_unixtime(${options.endTimestamp})
+  `;
+
+  const result = await queryDuneSql(options, query);
+
+  return {
+    dailyActiveUsers: result[0].user_count,
+    dailyTransactionsCount: result[0].transaction_count,
+  };
+};
+
+const adapter: SimpleAdapter = {
+  version: 1,
+  fetch,
+  chains: [CHAIN.HYPERLIQUID],
+  dependencies: [Dependencies.DUNE],
+  isExpensiveAdapter: true,
+  protocolType: ProtocolType.CHAIN,
+  start: "2025-02-18",
+};
+
+export default adapter;

--- a/new-users/hyperevm.ts
+++ b/new-users/hyperevm.ts
@@ -1,0 +1,32 @@
+import { Dependencies, FetchOptions, ProtocolType, SimpleAdapter } from "../adapters/types";
+import { queryDuneSql } from "../helpers/dune";
+import { CHAIN } from "../helpers/chains";
+
+const fetch = async (_a: any, _b: any, options: FetchOptions) => {
+  const query = `
+    SELECT
+      COALESCE(COUNT(DISTINCT "from"), 0) AS new_users
+    FROM hyperevm.transactions
+    WHERE block_time >= from_unixtime(${options.startTimestamp})
+      AND block_time < from_unixtime(${options.endTimestamp})
+      AND nonce = 0
+  `;
+
+  const result = await queryDuneSql(options, query);
+
+  return {
+    dailyNewUsers: result[0].new_users,
+  };
+};
+
+const adapter: SimpleAdapter = {
+  version: 1,
+  fetch,
+  chains: [CHAIN.HYPERLIQUID],
+  dependencies: [Dependencies.DUNE],
+  isExpensiveAdapter: true,
+  protocolType: ProtocolType.CHAIN,
+  start: "2025-02-18",
+};
+
+export default adapter;

--- a/new-users/hyperevm.ts
+++ b/new-users/hyperevm.ts
@@ -7,8 +7,7 @@ const fetch = async (_a: any, _b: any, options: FetchOptions) => {
     SELECT
       COALESCE(COUNT(DISTINCT "from"), 0) AS new_users
     FROM hyperevm.transactions
-    WHERE block_time >= from_unixtime(${options.startTimestamp})
-      AND block_time < from_unixtime(${options.endTimestamp})
+    WHERE TIME_RANGE
       AND nonce = 0
   `;
 


### PR DESCRIPTION
## Summary
- Adds HyperEVM chain user adapters for active users and new users.
- Uses Dune `hyperevm.transactions` instead of Allium because Allium data was reported as unreliable for this chain.

## Changes
- Added `active-users/hyperevm.ts` to report daily active users and transaction count for HyperEVM.
- Added `new-users/hyperevm.ts` to report daily new users for HyperEVM.
- Registers both adapters on `CHAIN.HYPERLIQUID` with `ProtocolType.CHAIN`, `Dependencies.DUNE`, and start date `2025-02-18`.

## Methodology
- Active users are counted as distinct transaction senders: `COUNT(DISTINCT "from")`.
- Transaction count is counted from all rows in `hyperevm.transactions` within the requested timestamp window.
- New users are counted as distinct senders with `nonce = 0`, representing first outgoing HyperEVM transactions.
- Both adapters use `options.startTimestamp` to `options.endTimestamp`.

## Tests
- `DUNE_API_KEYS='...' pnpm test active-users hyperevm 2025-02-22`
  - Daily active users: `3.02 k`
  - Daily transactions count: `103.77 k`
- `DUNE_API_KEYS='...' pnpm test new-users hyperevm 2025-02-22`
  - Daily new users: `1.74 k`