### PR TITLE
feat: Track Dash chain active users

### DIFF
--- a/users/chains.ts
+++ b/users/chains.ts
@@ -153,6 +153,12 @@ export default [
         getUsers: coinmetricsData("bch"),
         id: "bch"
     },
+    {
+        name: "dash",
+        chain: CHAIN.DASH,
+        getUsers: coinmetricsData("dash"),
+        id: "dash"
+    },
     // {
     //     name: "bsv",
     //     chain: CHAIN.BITCOIN_SV,


### PR DESCRIPTION
### Summary                                                                                                     
  - Add Dash chain active users and transaction count tracking via CoinMetrics API in `users/chains.ts`