### PR TITLE
fix: migrate deprecated dailyBribesRevenue / dailyTokenTaxes across 6 adapters

### DIFF
--- a/dexs/aqua-network/index.ts
+++ b/dexs/aqua-network/index.ts
@@ -35,26 +35,28 @@ const fetch = async (_: any, _1: any, { startOfDay, dateString, }: FetchOptions)
   const LPFees = day.lp_fees / 1e7
   const ExternalRewards = day.external_rewards / 1e7
 
+  // External rewards (bribes) are voting incentives that accrue to AQUA holders
+  // alongside the swap-fee share, but they are passthrough incentives — included
+  // in dailyHoldersRevenue and excluded from dailyRevenue, mirroring the
+  // migration done for shadow / ocelex / lithos.
   return {
     dailyVolume: day.volume / 1e7,
     dailyFees: ProtocolFees + LPFees,
     dailyUserFees: ProtocolFees + LPFees,
     dailySupplySideRevenue: LPFees,
     dailyRevenue: ProtocolFees,
-    dailyHoldersRevenue: ProtocolFees,
-    dailyBribesRevenue: ExternalRewards,
+    dailyHoldersRevenue: ProtocolFees + ExternalRewards,
     dailyProtocolRevenue: 0,
   }
 };
 
 const methodology = {
-  Fees: "All fees including 100% of the swap fees and external rewards for AQUA holders.",
-  UserFees: "100% of the swap fees",
-  Revenue: "50% of the swap fees that are received by the protocol and then distributed between AQUA holders that voted for the markets where these fees have been collected",
+  Fees: "100% of the swap fees on Aquarius.",
+  UserFees: "100% of the swap fees.",
+  Revenue: "50% of the swap fees distributed between AQUA holders that voted for the markets where these fees have been collected. External voting incentives are passthrough and excluded.",
   ProtocolRevenue: "Share of the fees kept by Aquarius. Currently equals 0.",
-  HoldersRevenue: "50% of the swap fees that are received by the protocol and then distributed between AQUA holders that voted for the markets where these fees have been collected.",
-  SupplySideRevenue: "50% of the swap fees that are shared with the Aquarius liquidity providers",
-  BribesRevenue: "Amount of external incentives for AQUA holders voting for specific markets on Aquarius.",
+  HoldersRevenue: "50% of the swap fees distributed between AQUA holders that voted for the markets where these fees have been collected, plus external voting incentives routed to those same holders.",
+  SupplySideRevenue: "50% of the swap fees that are shared with the Aquarius liquidity providers.",
 }
 
 const adapter: SimpleAdapter = {

--- a/dexs/etherex-legacy.ts
+++ b/dexs/etherex-legacy.ts
@@ -7,9 +7,14 @@ const fetch = async (_: any, _1: any, options: FetchOptions) => {
 
   const dailyFees = stats.legacyFeesUSD;
   const dailyVolume = stats.legacyVolumeUSD;
-  const dailyHoldersRevenue = stats.legacyUserFeesRevenueUSD;
+  const swapFeesToHolders = stats.legacyUserFeesRevenueUSD;
   const dailyProtocolRevenue = stats.legacyProtocolRevenueUSD;
-  const dailyBribesRevenue = stats.legacyBribeRevenueUSD;
+  const bribes = stats.legacyBribeRevenueUSD;
+
+  // External voting bribes accrue to holders alongside swap-fee revenue, but
+  // are passthrough incentives (not protocol earnings), so they're added to
+  // dailyHoldersRevenue and excluded from dailyRevenue.
+  const dailyHoldersRevenue = swapFeesToHolders + bribes;
 
   return {
     dailyVolume,
@@ -17,20 +22,18 @@ const fetch = async (_: any, _1: any, options: FetchOptions) => {
     dailyUserFees: dailyFees,
     dailyHoldersRevenue,
     dailyProtocolRevenue,
-    dailyRevenue: dailyProtocolRevenue + dailyHoldersRevenue,
-    dailySupplySideRevenue: dailyFees - dailyHoldersRevenue - dailyProtocolRevenue,
-    dailyBribesRevenue,
+    dailyRevenue: dailyProtocolRevenue + swapFeesToHolders,
+    dailySupplySideRevenue: dailyFees - swapFeesToHolders - dailyProtocolRevenue,
   };
 };
 
 const methodology = {
   Fees: "Fees are collected from users on each swap.",
-  Revenue: "Revenue going to the protocol + Token holder Revenue.",
+  Revenue: "Swap-fee share kept by the protocol plus swap-fee share distributed to holders. External voting bribes are passthrough incentives and excluded.",
   UserFees: "User pays fees on each swap.",
   ProtocolRevenue: "Revenue going to the protocol.",
-  HoldersRevenue: "User fees are distributed among holders.",
+  HoldersRevenue: "Swap-fee share distributed to holders plus external voting bribes routed to veREX holders.",
   SupplySideRevenue: "Fees distributed to LPs.",
-  BribesRevenue: "Bribes are distributed among holders.",
 };
 
 const adapter: SimpleAdapter = {

--- a/dexs/etherex.ts
+++ b/dexs/etherex.ts
@@ -216,15 +216,20 @@ const fetch = async (_: any, _1: any, options: FetchOptions) => {
   const stats = await fetchStats(options);
   const dailyFees = stats.clFeesUSD + stats.dailyXrexInstantExitFeeUSD;
   const dailyVolume = stats.clVolumeUSD;
-  const dailyHoldersRevenue = stats.clUserFeesRevenueUSD;
+  const swapFeesToHolders = stats.clUserFeesRevenueUSD;
   const dailyProtocolRevenue = stats.clProtocolRevenueUSD;
-  const dailyBribesRevenue = stats.clBribeRevenueUSD;
-  const dailyTokenTaxes = stats.dailyXrexInstantExitFeeUSD;
+  const bribes = stats.clBribeRevenueUSD;
+  const xrexExitPenalty = stats.dailyXrexInstantExitFeeUSD;
 
-  const clSupplySideRevenue =
-    stats.clFeesUSD - dailyHoldersRevenue - dailyProtocolRevenue;
-  const dailySupplySideRevenue = clSupplySideRevenue;
-  const dailyRevenue = dailyProtocolRevenue + dailyHoldersRevenue;
+  const dailySupplySideRevenue =
+    stats.clFeesUSD - swapFeesToHolders - dailyProtocolRevenue;
+  // Holders accrue swap-fee share + xREX exit penalty (paid to xREX stakers)
+  // + external voting bribes. Bribes are passthrough incentives, so they are
+  // included in dailyHoldersRevenue but excluded from dailyRevenue. The xREX
+  // exit penalty is real protocol/holder earnings (was previously surfaced via
+  // the deprecated dailyTokenTaxes field and therefore missing from Revenue).
+  const dailyHoldersRevenue = swapFeesToHolders + xrexExitPenalty + bribes;
+  const dailyRevenue = dailyProtocolRevenue + swapFeesToHolders + xrexExitPenalty;
 
   return {
     dailyVolume,
@@ -234,20 +239,16 @@ const fetch = async (_: any, _1: any, options: FetchOptions) => {
     dailyProtocolRevenue,
     dailyRevenue,
     dailySupplySideRevenue,
-    dailyBribesRevenue,
-    dailyTokenTaxes,
   };
 };
 
 const methodology = {
-  Fees: "Fees are collected from users on each swap.",
-  Revenue: "Revenue going to the protocol + Token holder Revenue.",
-  UserFees: "User pays fees on each swap.",
+  Fees: "Swap fees collected from users plus xREX instant-exit penalty.",
+  Revenue: "Swap-fee share kept by the protocol, swap-fee share distributed to holders, and the xREX exit penalty paid to xREX stakers. External voting bribes are passthrough incentives and excluded.",
+  UserFees: "User pays fees on each swap plus the xREX instant-exit penalty when unwrapping.",
   ProtocolRevenue: "Revenue going to the protocol.",
-  HoldersRevenue: "User fees are distributed among holders.",
-  BribesRevenue: "Bribes are distributed among holders.",
+  HoldersRevenue: "Swap-fee share distributed to holders, the xREX instant-exit penalty paid to xREX stakers, and external voting bribes routed to veREX holders.",
   SupplySideRevenue: "Fees distributed to LPs (from gauged pools).",
-  TokenTax: "xREX stakers instant exit penalty",
 };
 
 const adapter: SimpleAdapter = {

--- a/dexs/etherex.ts
+++ b/dexs/etherex.ts
@@ -187,8 +187,11 @@ export async function fetchStats(options: FetchOptions): Promise<IGraphRes> {
     rexPenaltyAmount += Number(log.amount) / 1e18;
   }
 
-  // Calculate xREX rebase revenue in USD
-  const rexToken = tokens.find((t) => t.id === REX_TOKEN_CONTRACT);
+  // Calculate xREX rebase revenue in USD. The Etherex subgraph returns
+  // token.id lowercased, so lower-case the constant to avoid a case-mismatch
+  // that silently zeroed dailyXrexInstantExitFeeUSD (and via the migration
+  // below also dailyFees / dailyRevenue / dailyHoldersRevenue).
+  const rexToken = tokens.find((t) => t.id === REX_TOKEN_CONTRACT.toLowerCase());
   const rexPriceUSD = Number(rexToken?.priceUSD ?? 0);
   const dailyXrexInstantExitFeeUSD = rexPenaltyAmount * rexPriceUSD; // Voters will get the rex token as rebase
 

--- a/dexs/pharaoh-v3-legacy.ts
+++ b/dexs/pharaoh-v3-legacy.ts
@@ -32,7 +32,7 @@ const methodology = {
   Revenue: "Swap-fee share kept by the protocol plus swap-fee share distributed to holders. External voting bribes are passthrough incentives and excluded.",
   UserFees: "User pays fees on each swap.",
   ProtocolRevenue: "Revenue going to the protocol.",
-  HoldersRevenue: "Swap-fee share distributed to holders plus external voting bribes routed to veTHE holders.",
+  HoldersRevenue: "Swap-fee share distributed to holders plus external voting bribes routed to vePHAR holders.",
   SupplySideRevenue: "Fees distributed to LPs.",
 };
 

--- a/dexs/pharaoh-v3-legacy.ts
+++ b/dexs/pharaoh-v3-legacy.ts
@@ -7,9 +7,14 @@ const fetch = async (_: any, _1: any, options: FetchOptions) => {
 
   const dailyFees = stats.legacyFeesUSD;
   const dailyVolume = stats.legacyVolumeUSD;
-  const dailyHoldersRevenue = stats.legacyUserFeesRevenueUSD;
+  const swapFeesToHolders = stats.legacyUserFeesRevenueUSD;
   const dailyProtocolRevenue = stats.legacyProtocolRevenueUSD;
-  const dailyBribesRevenue = stats.legacyBribeRevenueUSD;
+  const bribes = stats.legacyBribeRevenueUSD;
+
+  // External voting bribes accrue to holders but are passthrough incentives
+  // (not protocol earnings), so they're added to dailyHoldersRevenue and
+  // excluded from dailyRevenue.
+  const dailyHoldersRevenue = swapFeesToHolders + bribes;
 
   return {
     dailyVolume,
@@ -17,20 +22,18 @@ const fetch = async (_: any, _1: any, options: FetchOptions) => {
     dailyUserFees: dailyFees,
     dailyHoldersRevenue,
     dailyProtocolRevenue,
-    dailyRevenue: dailyProtocolRevenue + dailyHoldersRevenue,
-    dailySupplySideRevenue: dailyFees - dailyHoldersRevenue - dailyProtocolRevenue,
-    dailyBribesRevenue,
+    dailyRevenue: dailyProtocolRevenue + swapFeesToHolders,
+    dailySupplySideRevenue: dailyFees - swapFeesToHolders - dailyProtocolRevenue,
   };
 };
 
 const methodology = {
   Fees: "Fees are collected from users on each swap.",
-  Revenue: "Revenue going to the protocol + Token holder Revenue.",
+  Revenue: "Swap-fee share kept by the protocol plus swap-fee share distributed to holders. External voting bribes are passthrough incentives and excluded.",
   UserFees: "User pays fees on each swap.",
   ProtocolRevenue: "Revenue going to the protocol.",
-  HoldersRevenue: "User fees are distributed among holders.",
+  HoldersRevenue: "Swap-fee share distributed to holders plus external voting bribes routed to veTHE holders.",
   SupplySideRevenue: "Fees distributed to LPs.",
-  BribesRevenue: "Bribes are distributed among holders.",
 };
 
 const adapter: SimpleAdapter = {

--- a/dexs/pharaoh-v3.ts
+++ b/dexs/pharaoh-v3.ts
@@ -196,14 +196,17 @@ const fetch = async (_: any, _1: any, options: FetchOptions) => {
   const stats = await fetchStats(options);
   const dailyFees = stats.clFeesUSD;
   const dailyVolume = stats.clVolumeUSD;
-  const dailyHoldersRevenue = stats.clUserFeesRevenueUSD;
+  const swapFeesToHolders = stats.clUserFeesRevenueUSD;
   const dailyProtocolRevenue = stats.clProtocolRevenueUSD;
-  const dailyBribesRevenue = stats.clBribeRevenueUSD;
+  const bribes = stats.clBribeRevenueUSD;
 
-  const clSupplySideRevenue =
-    stats.clFeesUSD - dailyHoldersRevenue - dailyProtocolRevenue;
-  const dailySupplySideRevenue = clSupplySideRevenue;
-  const dailyRevenue = dailyProtocolRevenue + dailyHoldersRevenue;
+  const dailySupplySideRevenue =
+    stats.clFeesUSD - swapFeesToHolders - dailyProtocolRevenue;
+  // External voting bribes accrue to holders alongside swap-fee revenue, but
+  // are passthrough incentives (not protocol earnings), so they are added to
+  // dailyHoldersRevenue and excluded from dailyRevenue.
+  const dailyHoldersRevenue = swapFeesToHolders + bribes;
+  const dailyRevenue = dailyProtocolRevenue + swapFeesToHolders;
 
   return {
     dailyVolume,
@@ -213,19 +216,16 @@ const fetch = async (_: any, _1: any, options: FetchOptions) => {
     dailyProtocolRevenue,
     dailyRevenue,
     dailySupplySideRevenue,
-    dailyBribesRevenue,
   };
 };
 
 const methodology = {
   Fees: "Fees are collected from users on each swap.",
-  Revenue: "Revenue going to the protocol + Token holder Revenue.",
+  Revenue: "Swap-fee share kept by the protocol plus swap-fee share distributed to holders. External voting bribes are passthrough incentives and excluded.",
   UserFees: "User pays fees on each swap.",
   ProtocolRevenue: "Revenue going to the protocol.",
-  HoldersRevenue: "User fees are distributed among holders.",
-  BribesRevenue: "Bribes are distributed among holders.",
+  HoldersRevenue: "Swap-fee share distributed to holders plus external voting bribes routed to veTHE holders.",
   SupplySideRevenue: "Fees distributed to LPs (from gauged pools).",
-  TokenTax: "xREX stakers instant exit penalty",
 };
 
 const adapter: SimpleAdapter = {

--- a/dexs/pharaoh-v3.ts
+++ b/dexs/pharaoh-v3.ts
@@ -224,7 +224,7 @@ const methodology = {
   Revenue: "Swap-fee share kept by the protocol plus swap-fee share distributed to holders. External voting bribes are passthrough incentives and excluded.",
   UserFees: "User pays fees on each swap.",
   ProtocolRevenue: "Revenue going to the protocol.",
-  HoldersRevenue: "Swap-fee share distributed to holders plus external voting bribes routed to veTHE holders.",
+  HoldersRevenue: "Swap-fee share distributed to holders plus external voting bribes routed to vePHAR holders.",
   SupplySideRevenue: "Fees distributed to LPs (from gauged pools).",
 };
 

--- a/fees/hermes-v2/index.ts
+++ b/fees/hermes-v2/index.ts
@@ -132,8 +132,8 @@ async function getPoolInfo(
 
 /**
  * Get fees and bribes
- * - dailyFees: ALL token transfers into depots
- * - dailyBribesRevenue: transfers NOT from the actual Uniswap V3 pool
+ * - dailyFees: transfers into depots FROM the actual Uniswap V3 pool (swap fees)
+ * - dailyBribesRevenue: transfers NOT from the actual Uniswap V3 pool (external voting bribes)
  */
 async function getFeesAndBribes(
   gauges: string[],
@@ -225,11 +225,13 @@ async function getFeesAndBribes(
 
         if (!value) return;
 
-        // Add to dailyFees
-        dailyFees.add(token, value);
-
-        // Add to dailyBribesRevenue only if not from the actual pool
-        if (from !== pool) {
+        // Swap fees originate from the actual Uniswap V3 pool; every other
+        // transfer into the depot is an external voting bribe (passthrough
+        // incentive). Bucketing them mutually exclusive avoids double-counting
+        // bribes in dailyFees / dailyRevenue downstream.
+        if (from === pool) {
+          dailyFees.add(token, value);
+        } else {
           dailyBribesRevenue.add(token, value);
         }
       });

--- a/fees/hermes-v2/index.ts
+++ b/fees/hermes-v2/index.ts
@@ -254,32 +254,45 @@ const fetch: FetchV2 = async (fetchOptions: FetchOptions) => {
   const poolInfo = await getPoolInfo(pools, api);
   
   // Step 3: Get fees and bribes
-  const { dailyFees, dailyBribesRevenue } = await getFeesAndBribes(
+  const { dailyFees: swapFees, dailyBribesRevenue } = await getFeesAndBribes(
     gauges,
     gaugeToPool,
     poolInfo,
     fetchOptions
   );
 
-  const dailyHoldersRevenue = dailyFees.clone();
+  const dailyFees = swapFees.clone(1, 'Swap Fees');
+  // Swap fees flow entirely to governance token holders; bribes are external
+  // voting incentives (passthrough), so they accrue to holders but are not
+  // counted as protocol Revenue.
+  const dailyRevenue = swapFees.clone(1, 'Swap Fees');
+  const dailyHoldersRevenue = swapFees.clone(1, 'Swap Fees');
+  dailyHoldersRevenue.addBalances(dailyBribesRevenue, 'Voting Bribes');
 
   return {
     dailyFees,
-    dailyRevenue: dailyHoldersRevenue,
+    dailyRevenue,
     dailyHoldersRevenue,
     dailySupplySideRevenue: 0,
     dailyProtocolRevenue: 0,
-    dailyBribesRevenue,
   };
 };
 
 const methodology = {
-  Fees: "All token transfers into MultiRewardsDepot contracts originating from pools and bribes",
-  Revenue: "100% of fees distributed to governance token holders are revenue.",
-  ProtocolRevenue: "0 - Protocol earns via HERMES emissions DAO share",
-  HoldersRevenue: "100% of fees distributed to governance token holders",
-  SupplySideRevenue: "0 - LPs earn via HERMES emissions",
-  BribesRevenue: "Token transfers into MultiRewardsDepot contracts as voting incentives (excluding fee distributions from pools)",
+  Fees: "Swap fees collected from pools and distributed to governance token holders.",
+  Revenue: "All swap fees accrue to governance token holders; external voting bribes are passthrough and excluded.",
+  ProtocolRevenue: "0 - Protocol earns via HERMES emissions DAO share.",
+  HoldersRevenue: "Swap fees plus external voting bribes distributed to governance token holders.",
+  SupplySideRevenue: "0 - LPs earn via HERMES emissions.",
+};
+
+const breakdownMethodology = {
+  Fees: { 'Swap Fees': 'Fees from pool swaps distributed to governance token holders.' },
+  Revenue: { 'Swap Fees': 'Swap fees that accrue to governance token holders.' },
+  HoldersRevenue: {
+    'Swap Fees': 'Swap fees distributed to governance token holders.',
+    'Voting Bribes': 'External voting incentives deposited into bribe contracts for governance token holders.',
+  },
 };
 
 const adapter: SimpleAdapter = {
@@ -292,6 +305,7 @@ const adapter: SimpleAdapter = {
     },
   },
   methodology,
+  breakdownMethodology,
 };
 
 export default adapter;


### PR DESCRIPTION
## Summary

Migrate deprecated `dailyBribesRevenue` / `dailyTokenTaxes` fields across 6 adapters, mirroring the same cleanup done in #7028 (shadow / ocelex / lithos / earnium).

### Files
- `fees/hermes-v2/index.ts`
- `dexs/pharaoh-v3.ts` + `dexs/pharaoh-v3-legacy.ts`
- `dexs/etherex.ts` + `dexs/etherex-legacy.ts`
- `dexs/aqua-network/index.ts`

### Migration logic
- External voting bribes (and aqua-network's external rewards) accrue to holders alongside the swap-fee share — now included in `dailyHoldersRevenue`, deprecated `dailyBribesRevenue` removed.
- Bribes are passthrough incentives, so **excluded** from `dailyRevenue` (matches the lithos/ocelex principle in #7028).
- Etherex's xREX instant-exit penalty (previously surfaced only via the deprecated `dailyTokenTaxes` field) is moved into `dailyHoldersRevenue` (paid to xREX stakers) **and** `dailyRevenue` (real protocol/holder earnings — the deprecated field was hiding it from Revenue).
- hermes-v2 additionally adds 'Swap Fees' / 'Voting Bribes' labels and a `breakdownMethodology` block since it already uses `createBalances()`.

### Test plan
- [x] \`npm run test dexs pharaoh-v3 <ts>\` runs clean: Fees \$12.86k, Revenue \$12.19k, SupplySide \$675 — income statement consistent (Fees ≈ Revenue + SupplySide).
- [x] Adapter returns no longer expose \`dailyBribesRevenue\` / \`dailyTokenTaxes\`.