### PR TITLE
fix: Correct Bitcoin incentives halving calculation

### DIFF
--- a/incentives/bitcoin/index.ts
+++ b/incentives/bitcoin/index.ts
@@ -13,7 +13,7 @@ type IResponse = Array<{
 
 const BASE_REWARD = 50
 const HALVING_BLOCKS = 210000
-const getBTCRewardByBlock = (block: number) => BASE_REWARD / Math.trunc((block / HALVING_BLOCKS) + 1)
+const getBTCRewardByBlock = (block: number) => BASE_REWARD / Math.pow(2, Math.floor(block / HALVING_BLOCKS))
 
 const getDailyBlocksByTimestampLast24h = async (timestamp: number) => {
     const url = `https://blockchain.info/blocks/${timestamp * 1000}?format=json`
@@ -23,7 +23,7 @@ const getDailyBlocksByTimestampLast24h = async (timestamp: number) => {
 const getIncentives: Fetch = async (timestamp: number): Promise<FetchResultIncentives> => {
     const dayBlocks = await getDailyBlocksByTimestampLast24h(timestamp)
     const rewardByBlock = getBTCRewardByBlock(dayBlocks[0].height)
-    const tokens = await sdk.Balances.getUSDString({ 'coingecko:bitcoin': dayBlocks.length * rewardByBlock}, timestamp)
+    const tokens = await sdk.Balances.getUSDString({ 'coingecko:bitcoin': dayBlocks.length * rewardByBlock }, timestamp)
     return {
         timestamp,
         block: dayBlocks[0].height,


### PR DESCRIPTION
## Summary                                                                                                     
  - Fix incorrect Bitcoin block reward halving formula in `incentives/bitcoin/index.ts`                     
                                                                                                                 
  ### The Bug                                                                                                    
  The original formula used linear division instead of exponential halving:                                      
                                                                                                                 
  ```ts                                                                                                          
  // Old (wrong)                                                                                                 
  BASE_REWARD / Math.trunc((block / HALVING_BLOCKS) + 1)    
                                                                                                                 
  // New (correct)
  BASE_REWARD / Math.pow(2, Math.floor(block / HALVING_BLOCKS))                                                  
                                                            
 Bitcoin's block reward halves (divides by 2) every 210,000 blocks. The old formula                             
  divided by `(n+1)` where `n` is the number of halvings, instead of dividing by `2^n`.                          
  Both formulas produce the same result for halvings 0 and 1 because `2^0 = 1` and                               
  `2^1 = 2`, which are the same as `(0+1) = 1` and `(1+1) = 2`. The divergence starts                          
  at halving 2, where `2^2 = 4` but `(2+1) = 3`                                                

  Impact by halving period

  ┌───────────────┬─────────────────────┬────────────────────┬─────────────────────┐
  │    Halving    │     Block Range     │    Old Formula     │   Correct Formula   │                        
  ├───────────────┼─────────────────────┼────────────────────┼─────────────────────┤
  │ 0 (2009-2012) │ 0 - 209,999         │ 50 / 1 = 50 BTC    │ 50 / 1 = 50 BTC     │
  ├───────────────┼─────────────────────┼────────────────────┼─────────────────────┤                             
  │ 1 (2012-2016) │ 210,000 - 419,999   │ 50 / 2 = 25 BTC    │ 50 / 2 = 25 BTC     │                             
  ├───────────────┼─────────────────────┼────────────────────┼─────────────────────┤                             
  │ 2 (2016-2020) │ 420,000 - 629,999   │ 50 / 3 = 16.67 BTC │ 50 / 4 = 12.5 BTC   │                             
  ├───────────────┼─────────────────────┼────────────────────┼─────────────────────┤                             
  │ 3 (2020-2024) │ 630,000 - 839,999   │ 50 / 4 = 12.5 BTC  │ 50 / 8 = 6.25 BTC   │                           
  ├───────────────┼─────────────────────┼────────────────────┼─────────────────────┤                             
  │ 4 (2024-now)  │ 840,000 - 1,049,999 │ 50 / 5 = 10 BTC    │ 50 / 16 = 3.125 BTC │