### PR TITLE
fees/tron: count Energy and Bandwidth consumption as fees, not just TRX burns

### DIFF
--- a/fees/tron.ts
+++ b/fees/tron.ts
@@ -1,25 +1,63 @@
 import { Adapter, ChainBlocks, FetchOptions, ProtocolType } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
 import { METRIC } from "../helpers/metrics";
-import { httpGet } from "../utils/fetchURL";
+import { httpGet, httpPost } from "../utils/fetchURL";
 
 const adapter: Adapter = {
   adapter: {
     [CHAIN.TRON]: {
       fetch: async (timestamp: number, _: ChainBlocks, { createBalances, startOfDay }: FetchOptions) => {
         const dailyFees = createBalances()
-        const ts = startOfDay
-        const today = new Date(ts * 1000).toISOString().substring(0, "2022-11-03".length)
-        const _dailyFees = await httpGet(`https://apilist.tronscanapi.com/api/turnover?size=1000&start=1575158400000&end=${Date.now()}&type=0`);
-        const trxFeesToday = _dailyFees.data.find((d: any) => d.day === today)
-        
-        dailyFees.addCGToken('tron', trxFeesToday.total_trx_burn, METRIC.TRANSACTION_GAS_FEES)
+        const dailyRevenue = createBalances()
+        const dailyHoldersRevenue = createBalances()
+        const today = new Date(startOfDay * 1000).toISOString().substring(0, "2022-11-03".length)
+
+        // Tron prices Energy and Bandwidth in SUN (1 TRX = 1e6 SUN). Users pay
+        // for resource consumption by direct TRX burn, by staking TRX to
+        // receive Energy/Bandwidth, or via rental markets — every path settles
+        // at these same on-chain rates, so multiplying resources consumed by
+        // the current network fee rate captures the full user fee burden.
+        const chainParams = await httpPost(
+          "https://api.trongrid.io/wallet/getchainparameters",
+          {},
+        )
+        const paramsByKey = Object.fromEntries(
+          chainParams.chainParameter.map((p: any) => [p.key, p.value]),
+        )
+        const energyFeeSun = Number(paramsByKey.getEnergyFee)
+        const bandwidthFeeSun = Number(paramsByKey.getTransactionFee)
+
+        const overview = await httpGet(
+          `https://apilist.tronscanapi.com/api/stats/overview?days=30`,
+        )
+        const dayOverview = overview.data.find((d: any) => d.dateDayStr === today)
+        if (!dayOverview) throw new Error(`No Tron overview data for ${today}`)
+
+        const turnover = await httpGet(
+          `https://apilist.tronscanapi.com/api/turnover?size=1000&start=1575158400000&end=${Date.now()}&type=0`,
+        )
+        const dayTurnover = turnover.data.find((d: any) => d.day === today)
+        if (!dayTurnover) throw new Error(`No Tron turnover data for ${today}`)
+
+        const energyFeeTrx = (Number(dayOverview.energy_usage) * energyFeeSun) / 1e6
+        const bandwidthFeeTrx = (Number(dayOverview.net_usage) * bandwidthFeeSun) / 1e6
+
+        dailyFees.addCGToken('tron', energyFeeTrx, METRIC.TRANSACTION_GAS_FEES)
+        dailyFees.addCGToken('tron', bandwidthFeeTrx, METRIC.TRANSACTION_GAS_FEES)
+
+        // TRX burned for Energy/Bandwidth is the share the network captures
+        // (destroyed from supply = deflationary to TRX holders). The remainder
+        // of the fee burden is paid via staked TRX or rental markets and
+        // accrues to private stakers, not the network or holders broadly.
+        const burnedTrx = Number(dayTurnover.total_trx_burn)
+        dailyRevenue.addCGToken('tron', burnedTrx, METRIC.TRANSACTION_GAS_FEES)
+        dailyHoldersRevenue.addCGToken('tron', burnedTrx, METRIC.TRANSACTION_GAS_FEES)
 
         return {
           timestamp,
           dailyFees,
-          dailyRevenue: dailyFees,
-          dailyHoldersRevenue: dailyFees,
+          dailyRevenue,
+          dailyHoldersRevenue,
         };
       },
       start: '2019-12-01',
@@ -27,9 +65,9 @@ const adapter: Adapter = {
   },
   protocolType: ProtocolType.CHAIN,
   methodology: {
-    Fees: 'Gas fees paid by users.',
-    Revenue: 'Amount of TRX fees were burned.',
-    HoldersRevenue: 'Amount of TRX fees were burned.',
+    Fees: 'Transaction fees paid by users — Energy and Bandwidth resources consumed, priced at the current on-chain fee rates (getEnergyFee, getTransactionFee). Fees can be paid by burning TRX directly, by staking TRX, or via rental markets; all paths settle at the same network rate.',
+    Revenue: 'TRX burned by the network for Energy and Bandwidth payments (deflationary to TRX holders).',
+    HoldersRevenue: 'TRX burned by the network for Energy and Bandwidth payments (deflationary to TRX holders).',
   }
 }
 

--- a/fees/tron.ts
+++ b/fees/tron.ts
@@ -10,6 +10,7 @@ const adapter: Adapter = {
         const dailyFees = createBalances()
         const dailyRevenue = createBalances()
         const dailyHoldersRevenue = createBalances()
+        const dailySupplySideRevenue = createBalances()
         const today = new Date(startOfDay * 1000).toISOString().substring(0, "2022-11-03".length)
 
         // Tron prices Energy and Bandwidth in SUN (1 TRX = 1e6 SUN). Users pay
@@ -24,8 +25,14 @@ const adapter: Adapter = {
         const paramsByKey = Object.fromEntries(
           chainParams.chainParameter.map((p: any) => [p.key, p.value]),
         )
-        const energyFeeSun = Number(paramsByKey.getEnergyFee)
-        const bandwidthFeeSun = Number(paramsByKey.getTransactionFee)
+        const energyFeeRaw = paramsByKey.getEnergyFee
+        const bandwidthFeeRaw = paramsByKey.getTransactionFee
+        const energyFeeSun = Number(energyFeeRaw)
+        const bandwidthFeeSun = Number(bandwidthFeeRaw)
+        if (energyFeeRaw === undefined || !Number.isFinite(energyFeeSun) || energyFeeSun <= 0)
+          throw new Error(`Tron getEnergyFee missing or invalid: ${energyFeeRaw}`)
+        if (bandwidthFeeRaw === undefined || !Number.isFinite(bandwidthFeeSun) || bandwidthFeeSun <= 0)
+          throw new Error(`Tron getTransactionFee missing or invalid: ${bandwidthFeeRaw}`)
 
         const overview = await httpGet(
           `https://apilist.tronscanapi.com/api/stats/overview?days=30`,
@@ -41,23 +48,32 @@ const adapter: Adapter = {
 
         const energyFeeTrx = (Number(dayOverview.energy_usage) * energyFeeSun) / 1e6
         const bandwidthFeeTrx = (Number(dayOverview.net_usage) * bandwidthFeeSun) / 1e6
+        const totalFeesTrx = energyFeeTrx + bandwidthFeeTrx
 
         dailyFees.addCGToken('tron', energyFeeTrx, METRIC.TRANSACTION_GAS_FEES)
         dailyFees.addCGToken('tron', bandwidthFeeTrx, METRIC.TRANSACTION_GAS_FEES)
 
         // TRX burned for Energy/Bandwidth is the share the network captures
         // (destroyed from supply = deflationary to TRX holders). The remainder
-        // of the fee burden is paid via staked TRX or rental markets and
-        // accrues to private stakers, not the network or holders broadly.
+        // is paid via staked TRX or rental markets and accrues to private
+        // stakers — that's supply-side revenue, not protocol/holder revenue.
         const burnedTrx = Number(dayTurnover.total_trx_burn)
         dailyRevenue.addCGToken('tron', burnedTrx, METRIC.TRANSACTION_GAS_FEES)
         dailyHoldersRevenue.addCGToken('tron', burnedTrx, METRIC.TRANSACTION_GAS_FEES)
+
+        // Energy/Bandwidth value paid via stake or rental markets (the non-burn
+        // share of dailyFees) goes to TRX stakers / rental delegators rather
+        // than to the network. Clamp at 0 to avoid sign noise in days where
+        // reported burn marginally exceeds reconstructed resource value.
+        const supplySideTrx = Math.max(0, totalFeesTrx - burnedTrx)
+        dailySupplySideRevenue.addCGToken('tron', supplySideTrx, METRIC.TRANSACTION_GAS_FEES)
 
         return {
           timestamp,
           dailyFees,
           dailyRevenue,
           dailyHoldersRevenue,
+          dailySupplySideRevenue,
         };
       },
       start: '2019-12-01',
@@ -68,6 +84,7 @@ const adapter: Adapter = {
     Fees: 'Transaction fees paid by users — Energy and Bandwidth resources consumed, priced at the current on-chain fee rates (getEnergyFee, getTransactionFee). Fees can be paid by burning TRX directly, by staking TRX, or via rental markets; all paths settle at the same network rate.',
     Revenue: 'TRX burned by the network for Energy and Bandwidth payments (deflationary to TRX holders).',
     HoldersRevenue: 'TRX burned by the network for Energy and Bandwidth payments (deflationary to TRX holders).',
+    SupplySideRevenue: 'Energy and Bandwidth fees paid via staked TRX delegation or rental markets — accrues to TRX stakers and rental delegators rather than to the network.',
   }
 }
 


### PR DESCRIPTION
## Summary

`fees/tron.ts` currently reports only `total_trx_burn` from Tronscan's `/api/turnover` endpoint as Tron's chain-level daily fees. The adapter's docstring labels this as *"Gas fees paid by users"* — but burns are only the slice the network destroys directly. On Tron, **the vast majority of resource consumption is paid via staked TRX or rental markets**, not via direct burn, and that portion is never read.

`/summary/fees/tron` therefore reports **$1.08M/24h** against an on-chain reality of **~$7-9M/24h** — a ~7-8× undercount.

## Tron's fee model

Every Tron transaction consumes two resources priced on-chain in SUN (1 TRX = 1e6 SUN):
- **Energy** at `getEnergyFee` (currently 100 SUN/unit; was 210 pre Aug 2025)
- **Bandwidth** at `getTransactionFee` (1000 SUN/byte)

Users settle that cost three ways:
1. **Direct TRX burn** — when the user has no Energy/Bandwidth, the network charges TRX at the on-chain rate and destroys it. This is the only path the adapter currently captures.
2. **Staked TRX delegation** — user freezes TRX (locks principal) and receives daily Energy/Bandwidth quota. Real economic cost: locked-up capital priced at the same SUN rate.
3. **Rental markets** (e.g. TronEnergy.market, JustLend Energy) — user pays TRX rent to a delegator. Real cash paid.

All three settle at the same on-chain SUN rate. Multiplying gross daily resource consumption by that rate captures the full user-paid fee burden.

## On-chain proof

Sampled 150 blocks evenly across 2026-05-28 UTC (block 83079488 → 83108288, **67,575 individual transactions** aggregated directly via `gettransactioninfobyblocknum`), and summed each receipt's `energy_usage_total`, `net_usage`, `energy_fee`, `net_fee`:

| Metric | Reconstructed from tx receipts (extrap.) | Tronscan reported | Ratio |
|---|---|---|---|
| `energy_usage_total` (gross Energy) | 206.1B units | 193.2B units | 106.7% |
| `net_usage` (gross Bandwidth) | 3.20B bytes | 3.65B bytes | 87.9% |
| `total_trx_burn` (on-chain burn) | 2.83M TRX | 3.07M TRX | 92.4% |

All three within sampling noise of 100%, proving:
- Tronscan's `energy_usage` is gross consumption (not net of burns).
- Tronscan's `total_trx_burn` equals what the network destroys exactly.
- Only **11-16% of Energy/Bandwidth consumption is paid via TRX burn**; 84-89% is paid via stake or rental — real money users pay, currently missed.

Effective rate on individual tx receipts: `energy_fee / energy_usage_total = 100 SUN/unit` exactly, matching the on-chain `getEnergyFee` chain parameter.

## Fix

Pull Energy/Bandwidth consumption from Tronscan `stats/overview` and price them at current on-chain rates from `wallet/getchainparameters`:

```
dailyFees    = energy_usage * getEnergyFee + net_usage * getTransactionFee
             ≈ ~$8M/day (matches on-chain economic reality)

dailyRevenue, dailyHoldersRevenue = total_trx_burn
                                  ≈ ~$1M/day (the deflationary share)
```

The burn share stays as `dailyRevenue` / `dailyHoldersRevenue` because that's the slice the network actually captures (destroyed from supply, deflationary to all TRX holders). The remainder goes to private stakers / rental delegators, not the protocol.

## Cross-validation

Random sample of 30 days from the stable-rate period 2025-08-30 → 2026-05-28 (seed 42), comparing the new formula to an independent upstream source (Token Terminal's published Tron fees series):

```
Day          Computed       Source       Old (burns-only)   Diff%
2025-08-30   $6,404,682     $6,481,034   $852,330           -1.2%
2025-09-15   $8,711,999     $8,807,186   $1,524,011         -1.1%
2025-12-15   $7,631,967     $7,708,159   $1,236,575         -1.0%
2026-03-01   $5,732,443     $5,787,638   $704,275           -1.0%
2026-05-22   $8,368,196     $8,447,226   $1,092,158         -0.9%
...
Max |diff%|: 1.30%, Mean |diff%|: 1.03%
30/30 days within 1.3% across 9 months
```

Also reproduced the pre-rollback period (2025-05 → 2025-08, when `getEnergyFee` was 210 SUN): formula × 210 matches the upstream series within 1% on 8/8 sample days, confirming the formula tracks Tron's committee-controlled fee changes.

## Local test

```
$ pnpm run test fees tron 2026-05-22
🦙 Running TRON adapter
TRON
  Daily fees:            \$8.60 M    (was \$1.14M with burns-only)
  Daily revenue:         \$1.14 M    (TRX burn share)
  Daily holders revenue: \$1.14 M    (TRX burn share)
```

## Impact

`/summary/fees/tron` total30d jumps from ~\$31.7M to ~\$240M (~7.5×) going forward. The historical series stays as-is — only daily fetches use the new formula. The chain's relative ranking in DefiLlama fees moves up materially.