### PR TITLE
[feat] Alex-Stacks: track fees, revenue and lp share for alex via subgraph

### DIFF
--- a/fees/alex/index.ts
+++ b/fees/alex/index.ts
@@ -9,8 +9,19 @@ const FEE_PRECISION = 1e18;
 
 type FeeStats = { fees: number; supplySide: number };
 type PoolVolumeRow = { pool_id: number; volume: string };
-type PoolRateRow = { pool_id: number; fee_rate_x: string; fee_rate_y: string; fee_rebate: string };
-type SnapshotFeeRow = { burn_block_time: number; pool_id: number; fee_24h: string; fee_rebate_24h: string };
+type SnapshotFeeRow = {
+  burn_block_time: number;
+  pool_id: number;
+  fee_24h: string;
+  fee_rebate_24h: string;
+};
+type SnapshotRateRow = {
+  burn_block_time: number;
+  pool_id: number;
+  fee_rate_x: string;
+  fee_rate_y: string;
+  fee_rebate: string;
+};
 
 const emptyStats = (): FeeStats => ({ fees: 0, supplySide: 0 });
 const gql = async <T>(url: string, query: string): Promise<T> => (await postURL(url, { query })).data;
@@ -23,23 +34,41 @@ async function v2Fees(start: number, end: number): Promise<FeeStats> {
   }`);
   const volumeRows = data.sink_mart_amm_pool_v2_1_volume_by_pool_1d;
   if (!volumeRows.length) return emptyStats();
+  const poolIds = [...new Set(volumeRows.map((row) => row.pool_id))];
 
-  const rateData = await gql<{ latest_amm_swap_pool_stats_v2_1: PoolRateRow[] }>(V2_GQL, `{
-    latest_amm_swap_pool_stats_v2_1(
-      where: { pool_id: { _in: ${JSON.stringify(volumeRows.map((row) => row.pool_id))} } }
-    ) { pool_id fee_rate_x fee_rate_y fee_rebate }
+  const blockData = await gql<{ synced_blocks: Array<{ block_height: number }> }>(V2_GQL, `{
+    synced_blocks(
+      where: { burn_block_time: { _lte: ${end} } }
+      order_by: { burn_block_time: desc }
+      limit: 1
+    ) { block_height }
   }`);
-  const ratesByPool: Record<number, { feeRate: number; lpShare: number }> = Object.fromEntries(rateData.latest_amm_swap_pool_stats_v2_1.map((row) => [
-    row.pool_id,
-    {
+  const endBlock = blockData.synced_blocks[0]?.block_height;
+  if (!endBlock) throw new Error(`ALEX block missing for timestamp ${end}`);
+
+  const snapshotQueries = poolIds.map((poolId) => `
+    pool_${poolId}: amm_swap_pool_stats_v2_1(
+      where: { pool_id: { _eq: ${poolId} }, block_height: { _lte: ${endBlock} } }
+      order_by: { block_height: desc }
+      limit: 1
+    ) { pool_id burn_block_time fee_rate_x fee_rate_y fee_rebate }
+  `).join("\n");
+  const snapshotsByPool = await gql<Record<string, SnapshotRateRow[]>>(V2_GQL, `{ ${snapshotQueries} }`);
+
+  const ratesByPool: Record<number, { feeRate: number; lpShare: number }> = {};
+  Object.values(snapshotsByPool).forEach((rows) => {
+    const row = rows[0];
+    if (!row) throw new Error(`ALEX v2 fee snapshot missing for block ${endBlock}`);
+    ratesByPool[row.pool_id] = {
+      // The daily volume table is not directional, so use the average of token-x and token-y fee rates.
       feeRate: (Number(row.fee_rate_x) + Number(row.fee_rate_y)) / 2 / FEE_PRECISION,
       lpShare: Number(row.fee_rebate) / FEE_PRECISION,
-    },
-  ]));
+    };
+  });
 
   const stats = volumeRows.reduce<FeeStats>((acc, row) => {
     const rate = ratesByPool[row.pool_id];
-    if (!rate) throw new Error(`ALEX fee rate missing for pool ${row.pool_id}`);
+    if (!rate) throw new Error(`ALEX v2 fee rate missing for pool ${row.pool_id}`);
     const fees = Number(row.volume) / FEE_PRECISION * rate.feeRate;
     acc.fees += fees;
     acc.supplySide += fees * rate.lpShare;

--- a/fees/alex/index.ts
+++ b/fees/alex/index.ts
@@ -1,0 +1,112 @@
+import { FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import { METRIC } from "../../helpers/metrics";
+import { postURL } from "../../utils/fetchURL";
+
+const V2_GQL = "https://gql-v2.alexlab.co/v1/graphql";
+const AMM_V2_START = 1720224000; // 2024-07-06
+const FEE_PRECISION = 1e18;
+
+type FeeStats = { fees: number; supplySide: number };
+type PoolVolumeRow = { pool_id: number; volume: string };
+type PoolRateRow = { pool_id: number; fee_rate_x: string; fee_rate_y: string; fee_rebate: string };
+type SnapshotFeeRow = { burn_block_time: number; pool_id: number; fee_24h: string; fee_rebate_24h: string };
+
+const emptyStats = (): FeeStats => ({ fees: 0, supplySide: 0 });
+const gql = async <T>(url: string, query: string): Promise<T> => (await postURL(url, { query })).data;
+
+async function v2Fees(start: number, end: number): Promise<FeeStats> {
+  const data = await gql<{ sink_mart_amm_pool_v2_1_volume_by_pool_1d: PoolVolumeRow[] }>(V2_GQL, `{
+    sink_mart_amm_pool_v2_1_volume_by_pool_1d(
+      where: { date: { _gte: "${new Date(start * 1000).toISOString()}", _lt: "${new Date(end * 1000).toISOString()}" } }
+    ) { pool_id volume }
+  }`);
+  const volumeRows = data.sink_mart_amm_pool_v2_1_volume_by_pool_1d;
+  if (!volumeRows.length) return emptyStats();
+
+  const rateData = await gql<{ latest_amm_swap_pool_stats_v2_1: PoolRateRow[] }>(V2_GQL, `{
+    latest_amm_swap_pool_stats_v2_1(
+      where: { pool_id: { _in: ${JSON.stringify(volumeRows.map((row) => row.pool_id))} } }
+    ) { pool_id fee_rate_x fee_rate_y fee_rebate }
+  }`);
+  const ratesByPool: Record<number, { feeRate: number; lpShare: number }> = Object.fromEntries(rateData.latest_amm_swap_pool_stats_v2_1.map((row) => [
+    row.pool_id,
+    {
+      feeRate: (Number(row.fee_rate_x) + Number(row.fee_rate_y)) / 2 / FEE_PRECISION,
+      lpShare: Number(row.fee_rebate) / FEE_PRECISION,
+    },
+  ]));
+
+  const stats = volumeRows.reduce<FeeStats>((acc, row) => {
+    const rate = ratesByPool[row.pool_id];
+    if (!rate) throw new Error(`ALEX fee rate missing for pool ${row.pool_id}`);
+    const fees = Number(row.volume) / FEE_PRECISION * rate.feeRate;
+    acc.fees += fees;
+    acc.supplySide += fees * rate.lpShare;
+    return acc;
+  }, emptyStats());
+
+  return stats;
+}
+
+async function v1_1Fees(start: number, end: number): Promise<FeeStats> {
+  const data = await gql<{ amm_swap_pool_stats_v1_1: SnapshotFeeRow[] }>(V2_GQL, `{
+    amm_swap_pool_stats_v1_1(
+      where: { burn_block_time: { _gte: ${start}, _lt: ${end} } }
+    ) { burn_block_time pool_id fee_24h fee_rebate_24h }
+  }`);
+  const latestByPool: Record<number, SnapshotFeeRow> = {};
+  data.amm_swap_pool_stats_v1_1.forEach((row) => {
+    const current = latestByPool[row.pool_id];
+    if (!current || row.burn_block_time > current.burn_block_time) latestByPool[row.pool_id] = row;
+  });
+
+  const stats = Object.values(latestByPool).reduce<FeeStats>((acc, row) => {
+    acc.fees += Number(row.fee_24h) / FEE_PRECISION;
+    acc.supplySide += Number(row.fee_rebate_24h) / FEE_PRECISION;
+    return acc;
+  }, emptyStats());
+
+  return stats;
+}
+
+const fetch = async (_timestamp: number, _chainBlocks: any, options: FetchOptions) => {
+  const stats = options.startOfDay >= AMM_V2_START
+    ? await v2Fees(options.startOfDay, options.endTimestamp)
+    : await v1_1Fees(options.startOfDay, options.endTimestamp);
+
+  const dailyFees = options.createBalances();
+  const dailySupplySideRevenue = options.createBalances();
+  const dailyRevenue = options.createBalances();
+
+  dailyFees.addUSDValue(stats.fees, METRIC.SWAP_FEES);
+  dailySupplySideRevenue.addUSDValue(stats.supplySide, "Swap Fees To LPs");
+  dailyRevenue.addUSDValue(stats.fees - stats.supplySide, "Swap Fees To Protocol");
+
+  return { dailyFees, dailySupplySideRevenue, dailyRevenue, dailyProtocolRevenue: dailyRevenue };
+};
+
+const methodology = {
+  Fees: "Total swap fees paid by ALEX AMM traders.",
+  SupplySideRevenue: "The LP rebate portion of ALEX AMM swap fees.",
+  Revenue: "ALEX AMM swap fees retained by ALEX Lab Foundation after LP rebates.",
+  ProtocolRevenue: "ALEX AMM swap fees retained by ALEX Lab Foundation after LP rebates.",
+};
+
+const breakdownMethodology = {
+  Fees: { [METRIC.SWAP_FEES]: "Total swap fees paid by ALEX AMM traders." },
+  SupplySideRevenue: { "Swap Fees To LPs": "Swap fee rebates paid to liquidity providers." },
+  Revenue: { "Swap Fees To Protocol": "Swap fees retained by ALEX Lab Foundation after LP rebates." },
+  ProtocolRevenue: { "Swap Fees To Protocol": "Swap fees retained by ALEX Lab Foundation after LP rebates." },
+};
+
+const adapter: SimpleAdapter = {
+  version: 1,
+  fetch,
+  chains: [CHAIN.STACKS],
+  start: "2023-05-03",
+  methodology,
+  breakdownMethodology,
+};
+
+export default adapter;


### PR DESCRIPTION
Tracks fees for https://defillama.com/protocol/alex

## Summary
- Adds a dedicated ALEX fees adapter for Stacks under `fees/alex`.
- Tracks ALEX AMM swap fees, LP fee rebates, and protocol-retained revenue separately from the existing DEX volume adapter.
- Starts fee backfill at `2023-05-03`, the first supported historical fee snapshot source, avoiding the unavailable legacy GraphQL fee path.

## Changes
- Added `fees/alex/index.ts` for ALEX AMM fee accounting on `CHAIN.STACKS`.
- Uses ALEX GraphQL `amm_swap_pool_stats_v1_1` snapshots for the 2023-05-03 to 2024-07-06 range.
- Uses `sink_mart_amm_pool_v2_1_volume_by_pool_1d` plus `latest_amm_swap_pool_stats_v2_1` fee/rebate rates for the v2 AMM range.
- Reports:
  - `dailyFees` as total swap fees paid by traders.
  - `dailySupplySideRevenue` as swap fee rebates to LPs.
  - `dailyRevenue` and `dailyProtocolRevenue` as fees retained by ALEX Lab Foundation after LP rebates.
- Keeps the existing `dexs/alex` adapter volume-only.

## Methodology
- V1.1 fee snapshots take the latest pool snapshot in the requested UTC day and sum `fee_24h` and `fee_rebate_24h`.
- V2 fees are derived from daily pool volume multiplied by pool fee rates; LP supply-side revenue uses the pool rebate rate.
- Revenue is calculated as `dailyFees - dailySupplySideRevenue`.
- Legacy pre-2023-05-03 fees are excluded because the required legacy ALEX GraphQL endpoint currently returns `503`.

## Tests
- `pnpm test fees alex` — passed; daily fees `72.00`, supply-side revenue `38.00`, revenue `34.00`.
- `pnpm test fees alex 2023-06-01` — passed; daily fees `1.83k`, supply-side revenue `906.00`, revenue `923.00`.
- `pnpm test fees alex 2026-05-14` — passed; daily fees `120.00`, supply-side revenue `62.00`, revenue `58.00`.
- `pnpm test fees alex 2024-07-10` — passed; zero-fee quiet day.