### PR TITLE
fix: shift-protocol fee spikes from zero share price

### DIFF
--- a/fees/shift-protocol/index.ts
+++ b/fees/shift-protocol/index.ts
@@ -58,20 +58,22 @@ const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
 
     if (!baseToken || !totalSupply || !priceBefore || !priceAfter) continue;
 
-    const priceChange = BigInt(priceAfter) - BigInt(priceBefore);
-    const feeYield = BigInt(totalSupply) * priceChange / BigInt(1e18);
+    if (BigInt(priceBefore) === 0n || BigInt(priceAfter) === 0n) continue;
 
-    if (priceChange > 0n) {
+    const priceChange = BigInt(priceAfter) - BigInt(priceBefore);
+    const netYield = BigInt(totalSupply) * priceChange / BigInt(1e18);
+
+    if (vault.performanceFee > 0) {
       const perfFee = BigInt(vault.performanceFee);
-      const grossYield = feeYield * 100n / (100n - perfFee);
-      const perfFeeAmount = grossYield - feeYield;
+      const grossYield = netYield * 100n / (100n - perfFee);
+      const perfFeeAmount = grossYield - netYield;
 
       dailyFees.add(baseToken, grossYield, METRIC.ASSETS_YIELDS);
       dailyRevenue.add(baseToken, perfFeeAmount, METRIC.PERFORMANCE_FEES);
-      dailySupplySideRevenue.add(baseToken, feeYield, METRIC.ASSETS_YIELDS);
+      dailySupplySideRevenue.add(baseToken, netYield, METRIC.ASSETS_YIELDS);
     } else {
-      dailyFees.add(baseToken, feeYield, METRIC.ASSETS_YIELDS);
-      dailySupplySideRevenue.add(baseToken, feeYield, METRIC.ASSETS_YIELDS);
+      dailyFees.add(baseToken, netYield, METRIC.ASSETS_YIELDS);
+      dailySupplySideRevenue.add(baseToken, netYield, METRIC.ASSETS_YIELDS);
     }
 
     if (vault.managementFee > 0) {


### PR DESCRIPTION
### Summary   
                                                                                                            
  - Skip vaults when getSharePrice returns 0 (invalid RPC data) to prevent massive fee swings 
  On certain hours, Base vault share prices return 0 from RPC:

```
  priceBefore  priceAfter
  0            0           ← invalid, skipped
  1011715      1011661     ← valid                                                                               
  1006779      1006783     ← valid
  1020026      1019987     ← valid                                                                                                                                                           
  1067976      0           ← ltPARA price drops to 0 (bad RPC data)                                              
  1014358      0           ← extUSD price drops to 0 (bad RPC data)                                            
  0            1019987     ← invalid, skipped                                                                    
  ```
  Without the guard, priceChange = 0 - 1067976 produces spikes.  