### PR TITLE
[Fees] Rainbow Wallet - Improve swap volumes & fees accuracy from April 2026

### DIFF
--- a/fees/rainbow-wallet.ts
+++ b/fees/rainbow-wallet.ts
@@ -26,7 +26,7 @@ const RainBowRouter = {
 // April 1 2026 00:00 UTC — Rainbow switched to sponsor transactions, causing
 // many trades to have tx_to = multicall contract instead of the Rainbow Router.
 // From this date, dex.trades under-reports volume; use the internal swap table instead.
-const APRIL_2026 = 1743465600
+const APRIL_1_2026 = '2026-04-01'
 
 // Pre-April 2026: detect trades via Rainbow Router address in dex.trades
 const PRE_APRIL_SQL = (options: FetchOptions) => `
@@ -161,7 +161,7 @@ const POST_APRIL_SQL = (options: FetchOptions) => `
 `
 
 const prefetch = async (options: FetchOptions) => {
-  const sql = options.startTimestamp < APRIL_2026
+  const sql = options.dateString < APRIL_1_2026
     ? PRE_APRIL_SQL(options)
     : POST_APRIL_SQL(options)
   return queryDuneSql(options, sql)

--- a/fees/rainbow-wallet.ts
+++ b/fees/rainbow-wallet.ts
@@ -23,95 +23,149 @@ const RainBowRouter = {
   [CHAIN.MONAD]: rainbowRouter,
 }
 
-// Prefetch function that will run once before any fetch calls
-// don't do console.log(options) as there is circular dependency in ChainApi
-const prefetch = async (options: FetchOptions) => {
-  return queryDuneSql(options, `
-    WITH eoa_router_trades AS (
-        SELECT blockchain, tx_hash, SUM(amount_usd) AS amount_usd
-        FROM dex.trades
-        WHERE (
-            (tx_to = 0x00000000009726632680fb29d3f7a9734e3010e2 AND blockchain NOT IN ('unichain', 'zora'))
-            OR (tx_to = 0x2a0332E28913A06Fa924d40A3E2160f763010417 AND blockchain = 'unichain')
-            OR (tx_to = 0xA61550E9ddD2797E16489db09343162BE98d9483 AND blockchain = 'zora')
+// April 1 2026 00:00 UTC — Rainbow switched to sponsor transactions, causing
+// many trades to have tx_to = multicall contract instead of the Rainbow Router.
+// From this date, dex.trades under-reports volume; use the internal swap table instead.
+const APRIL_2026 = 1743465600
+
+// Pre-April 2026: detect trades via Rainbow Router address in dex.trades
+const PRE_APRIL_SQL = (options: FetchOptions) => `
+  WITH eoa_router_trades AS (
+      SELECT blockchain, tx_hash, SUM(amount_usd) AS amount_usd
+      FROM dex.trades
+      WHERE (
+          (tx_to = 0x00000000009726632680fb29d3f7a9734e3010e2 AND blockchain NOT IN ('unichain', 'zora'))
+          OR (tx_to = 0x2a0332E28913A06Fa924d40A3E2160f763010417 AND blockchain = 'unichain')
+          OR (tx_to = 0xA61550E9ddD2797E16489db09343162BE98d9483 AND blockchain = 'zora')
+      )
+      AND block_time >= from_unixtime(${options.startTimestamp})
+      AND block_time <= from_unixtime(${options.endTimestamp})
+      GROUP BY 1, 2
+  ),
+
+  smart_wallet_validated AS (
+      SELECT DISTINCT blockchain, tx_hash
+      FROM tokens.transfers
+      WHERE tx_from    = tx_to
+        AND (
+            ("to" = 0x00000000009726632680fb29d3f7a9734e3010e2 AND blockchain NOT IN ('unichain', 'zora'))
+            OR ("to" = 0x2a0332E28913A06Fa924d40A3E2160f763010417 AND blockchain = 'unichain')
+            OR ("to" = 0xA61550E9ddD2797E16489db09343162BE98d9483 AND blockchain = 'zora')
         )
+        AND block_date >= DATE '2026-02-25'
         AND block_time >= from_unixtime(${options.startTimestamp})
         AND block_time <= from_unixtime(${options.endTimestamp})
-        GROUP BY 1, 2
-    ),
+  ),
 
-    smart_wallet_validated AS (
-        SELECT DISTINCT blockchain, tx_hash
-        FROM tokens.transfers
-        WHERE tx_from    = tx_to
-          AND (
-              ("to" = 0x00000000009726632680fb29d3f7a9734e3010e2 AND blockchain NOT IN ('unichain', 'zora'))
-              OR ("to" = 0x2a0332E28913A06Fa924d40A3E2160f763010417 AND blockchain = 'unichain')
-              OR ("to" = 0xA61550E9ddD2797E16489db09343162BE98d9483 AND blockchain = 'zora')
-          )
-          AND block_date >= DATE '2026-02-25'
-          AND block_time >= from_unixtime(${options.startTimestamp})
-          AND block_time <= from_unixtime(${options.endTimestamp})
-    ),
+  smart_wallet_trades AS (
+      SELECT t.blockchain, t.tx_hash, SUM(t.amount_usd) AS amount_usd
+      FROM dex.trades t
+      INNER JOIN smart_wallet_validated s
+          ON t.blockchain = s.blockchain
+         AND t.tx_hash    = s.tx_hash
+      WHERE t.block_date >= DATE '2026-02-25'
+        AND t.block_time >= from_unixtime(${options.startTimestamp})
+        AND t.block_time <= from_unixtime(${options.endTimestamp})
+      GROUP BY 1, 2
+  ),
 
-    smart_wallet_trades AS (
-        SELECT t.blockchain, t.tx_hash, SUM(t.amount_usd) AS amount_usd
-        FROM dex.trades t
-        INNER JOIN smart_wallet_validated s
-            ON t.blockchain = s.blockchain
-           AND t.tx_hash    = s.tx_hash
-        WHERE t.block_date >= DATE '2026-02-25'
-          AND t.block_time >= from_unixtime(${options.startTimestamp})
-          AND t.block_time <= from_unixtime(${options.endTimestamp})
-        GROUP BY 1, 2
-    ),
+  combined AS (
+      SELECT blockchain, tx_hash, amount_usd FROM eoa_router_trades
+      UNION ALL
+      SELECT blockchain, tx_hash, amount_usd FROM smart_wallet_trades
+  ),
 
-    combined AS (
-        SELECT blockchain, tx_hash, amount_usd FROM eoa_router_trades
-        UNION ALL
-        SELECT blockchain, tx_hash, amount_usd FROM smart_wallet_trades
-    ),
+  relay_bridge AS (
+      SELECT
+          CASE
+              WHEN origin = 'bnb'         THEN 'bsc'
+              WHEN origin = 'avalanche_c' THEN 'avax'
+              ELSE origin
+          END AS chain,
+          SUM(usd_vol)          AS volume,
+          SUM(usd_vol) * 0.0025 AS fees
+      FROM dune.rainbowdotme.result_rainbow_relay_tx
+      WHERE block_time >= from_unixtime(${options.startTimestamp})
+        AND block_time <  from_unixtime(${options.endTimestamp})
+      GROUP BY 1
+  ),
 
-    relay_bridge AS (
-        SELECT
-            CASE
-                WHEN origin = 'bnb'         THEN 'bsc'
-                WHEN origin = 'avalanche_c' THEN 'avax'
-                ELSE origin
-            END AS chain,
-            SUM(usd_vol)          AS volume,
-            SUM(usd_vol) * 0.0025 AS fees
-        FROM dune.rainbowdotme.result_rainbow_relay_tx
-        WHERE block_time >= from_unixtime(${options.startTimestamp})
-          AND block_time <  from_unixtime(${options.endTimestamp})
-        GROUP BY 1
-    ),
+  swap_fees AS (
+      SELECT
+          CASE
+              WHEN blockchain = 'bnb'         THEN 'bsc'
+              WHEN blockchain = 'avalanche_c' THEN 'avax'
+              ELSE blockchain
+          END AS chain,
+          SUM(amount_usd)          AS volume,
+          SUM(amount_usd * 0.0085) AS fees
+      FROM combined
+      GROUP BY 1
+  ),
 
-    swap_fees AS (
-        SELECT
-            CASE
-                WHEN blockchain = 'bnb'         THEN 'bsc'
-                WHEN blockchain = 'avalanche_c' THEN 'avax'
-                ELSE blockchain
-            END AS chain,
-            SUM(amount_usd)          AS volume,
-            SUM(amount_usd * 0.0085) AS fees
-        FROM combined
-        GROUP BY 1
-    ),
+  total_fees AS (
+      SELECT chain, fee_type, SUM(volume) AS volume, SUM(fees) AS fees
+      FROM (
+          SELECT chain, '${METRIC.SWAP_FEES}' AS fee_type, volume, fees FROM swap_fees
+          UNION ALL
+          SELECT chain, 'Bridge Fees' AS fee_type, volume, fees FROM relay_bridge
+      ) AS all_fees
+      GROUP BY chain, fee_type
+  )
+  SELECT chain, fee_type, volume, fees FROM total_fees
+`
 
-    total_fees AS (
-        SELECT chain, fee_type, SUM(volume) AS volume, SUM(fees) AS fees
-        FROM (
-            SELECT chain, '${METRIC.SWAP_FEES}' AS fee_type, volume, fees FROM swap_fees
-            UNION ALL
-            SELECT chain, 'Bridge Fees' AS fee_type, volume, fees FROM relay_bridge
-        ) AS all_fees
-        GROUP BY chain, fee_type
-    )
-    SELECT chain, fee_type, volume, fees FROM total_fees
-  `);
-  }
+// April 2026+: use Rainbow's internal swap table which captures all trades
+// including those routed via sponsor/multicall transactions
+const POST_APRIL_SQL = (options: FetchOptions) => `
+  WITH swap_fees AS (
+      SELECT
+          CASE
+              WHEN network = 'bnb'         THEN 'bsc'
+              WHEN network = 'avalanche_c' THEN 'avax'
+              ELSE network
+          END AS chain,
+          SUM(usd_vol) AS volume,
+          SUM(usd_fee) AS fees
+      FROM dune.rainbowdotme.result_rainbow_swaps_core_aggregated_with_prices_since_april
+      WHERE time >= from_unixtime(${options.startTimestamp})
+        AND time <  from_unixtime(${options.endTimestamp})
+      GROUP BY 1
+  ),
+
+  relay_bridge AS (
+      SELECT
+          CASE
+              WHEN origin = 'bnb'         THEN 'bsc'
+              WHEN origin = 'avalanche_c' THEN 'avax'
+              ELSE origin
+          END AS chain,
+          SUM(usd_vol)          AS volume,
+          SUM(usd_vol) * 0.0025 AS fees
+      FROM dune.rainbowdotme.result_rainbow_relay_tx
+      WHERE block_time >= from_unixtime(${options.startTimestamp})
+        AND block_time <  from_unixtime(${options.endTimestamp})
+      GROUP BY 1
+  ),
+
+  total_fees AS (
+      SELECT chain, fee_type, SUM(volume) AS volume, SUM(fees) AS fees
+      FROM (
+          SELECT chain, '${METRIC.SWAP_FEES}' AS fee_type, volume, fees FROM swap_fees
+          UNION ALL
+          SELECT chain, 'Bridge Fees' AS fee_type, volume, fees FROM relay_bridge
+      ) AS all_fees
+      GROUP BY chain, fee_type
+  )
+  SELECT chain, fee_type, volume, fees FROM total_fees
+`
+
+const prefetch = async (options: FetchOptions) => {
+  const sql = options.startTimestamp < APRIL_2026
+    ? PRE_APRIL_SQL(options)
+    : POST_APRIL_SQL(options)
+  return queryDuneSql(options, sql)
+}
 
 const fetch: any = async (timestamp: number, _: any, options: FetchOptions) => {
   const results = options.preFetchedResults || [];


### PR DESCRIPTION
Name (as shown on DefiLlama): Rainbow Wallet
Twitter link: https://x.com/rainbowdotme
Website link: https://rainbow.me

## Summary

Improves swap volume accuracy from April 2026 onward.

Rainbow switched to sponsor transactions in April 2026, which caused two compounding issues with the `dex.trades` approach:

1. **Missing trades** — many transactions now have `tx_to = multicall contract` instead of the Rainbow Router address, so they are not captured by the router filter at all
2. **Underreported volume** — even trades that do appear in `dex.trades` via the router filter may have incomplete volume figures, as the decoded trade data does not always reflect the full swap amount for sponsor-style transactions

The adapter now branches on the query timestamp:

- **Pre-April 2026** — unchanged: existing `dex.trades` + smart wallet logic (historical data fully preserved)
- **April 2026+** — uses `dune.rainbowdotme.result_rainbow_swaps_core_aggregated_with_prices_since_april`, Rainbow's internal swap table that captures all trades with accurate volume regardless of transaction type, combined with the existing relay bridge CTE

The branching happens in TypeScript before the Dune query is built, so each call sends exactly one clean SQL with no dead branches.

## Methodology

No change — fee rates remain 0.85% on swap volume and 0.25% on relay bridge volume.

## Verification

Tested for May 2026 (29 days). Total: ~\$104,800 with new logic vs ~\$22k with old router-only logic — uplift from both fully missing trades and previously underreported volumes.

Pre-April historical data verified unchanged: Feb 23 window returns identical values to the previous adapter.