### PR TITLE
perf: dune queries

### DIFF
--- a/fees/bob.ts
+++ b/fees/bob.ts
@@ -7,17 +7,15 @@ const fetch = async (options: FetchOptions) => {
   const dailyFees = options.createBalances();
   const dailyRevenue = options.createBalances();
 
-  // Query Dune for daily ETH revenue by day
-  const sql_query = getSqlFromFile('helpers/queries/bob-blockchain.sql', {})
+  const sql_query = getSqlFromFile('helpers/queries/bob-blockchain.sql', {
+    start: options.startTimestamp,
+    end: options.endTimestamp,
+  })
   const results = await queryDuneSql(options, sql_query);
 
-  // Find the row matching our date
   const dateString = new Date(options.startOfDay * 1000).toISOString().split('T')[0];
-
   if (results && results.length > 0) {
-    const dayData = results.find((row: any) =>
-      row.day && row.day.startsWith(dateString)
-    );
+    const dayData = results.find((row: any) => row.day && row.day.startsWith(dateString));
 
     if (dayData) {
       // Use revenue_value (in wei) instead of revenue_eth

--- a/helpers/dune.ts
+++ b/helpers/dune.ts
@@ -264,8 +264,11 @@ export const queryDuneSql = (options: any, query: string, { extraUIDKey }: { ext
   }, options, { extraUIDKey })
 }
 
-export const queryDuneResult = async (_: any, queryId: string) => {
-  const { data: latest_result } = await getAxiosDune().get(`/query/${queryId}/results`)
+export const queryDuneResult = async (_: any, queryId: string, filters?: string) => {
+  const params: Record<string, string> = { limit: '100000' }
+  if (filters) params.filters = filters
+  const urlParams = new URLSearchParams(params).toString()
+  const { data: latest_result } = await getAxiosDune().get(`/query/${queryId}/results?${urlParams}`)
   return latest_result.result.rows
 }
 

--- a/helpers/queries/bob-blockchain.sql
+++ b/helpers/queries/bob-blockchain.sql
@@ -5,6 +5,8 @@ WITH daily_prices AS (
       FROM prices.day
       WHERE blockchain = 'ethereum'
       AND contract_address = 0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2
+      AND timestamp >= from_unixtime({{start}})
+      AND timestamp <= from_unixtime({{end}})
   ), realised_revenues AS (
       SELECT
           date_trunc('day', t.block_time) day,
@@ -12,6 +14,8 @@ WITH daily_prices AS (
       FROM ethereum.traces t
       WHERE t.to = 0xC91482A96e9c2A104d9298D1980eCCf8C4dc764E
       AND t.value <> 0
+      AND t.block_time >= from_unixtime({{start}})
+      AND t.block_time <= from_unixtime({{end}})
       GROUP BY date_trunc('day', t.block_time)
   ), fee_vaults_balances_diff AS (
       SELECT
@@ -77,5 +81,7 @@ WITH daily_prices AS (
   FROM daily_prices p
   LEFT JOIN realised_revenues rr ON rr.day = p.day
   LEFT JOIN revenues r ON r.day = p.day
-  WHERE p.day >= DATE('2024-04-11')
+  WHERE p.day >= from_unixtime({{start}})
+  AND p.day <= from_unixtime({{end}})
+
   GROUP BY p.day

--- a/helpers/queries/jupiter-perpetual-oi.sql
+++ b/helpers/queries/jupiter-perpetual-oi.sql
@@ -13,6 +13,7 @@ WITH position_changes AS (
     WHERE executing_account = 'PERPHjGBqRHArX4DySjwM6UJHiR3sWAatqfdBS2qQJu'
     AND bytearray_substring(data, 1+8, 8) = 0xf5715534d6bb9984
     AND tx_success = true
+    AND block_time <= from_unixtime({{end}})
 
     UNION ALL
 
@@ -30,6 +31,7 @@ WITH position_changes AS (
     WHERE executing_account = 'PERPHjGBqRHArX4DySjwM6UJHiR3sWAatqfdBS2qQJu'
     AND bytearray_substring(data, 1+8, 8) = 0xcdec3904d16a5745
     AND tx_success = true
+    AND block_time <= from_unixtime({{end}})
 
     UNION ALL
 
@@ -51,6 +53,7 @@ WITH position_changes AS (
     WHERE executing_account = 'PERPHjGBqRHArX4DySjwM6UJHiR3sWAatqfdBS2qQJu'
     AND bytearray_substring(data, 1+8, 8) = 0x409c2b4a6d83107f
     AND tx_success = true
+    AND block_time <= from_unixtime({{end}})
 
     UNION ALL
 
@@ -69,6 +72,7 @@ WITH position_changes AS (
     WHERE executing_account = 'PERPHjGBqRHArX4DySjwM6UJHiR3sWAatqfdBS2qQJu'
     AND bytearray_substring(data, 1+8, 8) = 0xabad6a19efbe3a3b
     AND tx_success = true
+    AND block_time <= from_unixtime({{end}})
 
     UNION ALL
 
@@ -87,6 +91,7 @@ WITH position_changes AS (
     WHERE executing_account = 'PERPHjGBqRHArX4DySjwM6UJHiR3sWAatqfdBS2qQJu'
     AND bytearray_substring(data, 1+8, 8) IN (0x68452084d423bf2f, 0x806547a880485654)
     AND tx_success = true
+    AND block_time <= from_unixtime({{end}})
 ),
 native_deltas AS (
     SELECT
@@ -137,4 +142,6 @@ SELECT
     position_side,
     cumulative_native_oi
 FROM cumulative_oi
+WHERE day >= date(from_unixtime({{start}}))
+AND day <= date(from_unixtime({{end}}))
 ORDER BY day, position_mint;

--- a/open-interest/jupiter-perpetual-oi.ts
+++ b/open-interest/jupiter-perpetual-oi.ts
@@ -13,7 +13,10 @@ const fetch = async (_a: any, _b: any, options: FetchOptions) => {
   let data: any[] = []
 
   if (options.startOfDay >= 1775260800) {
-    data = await queryDuneSql(options, getSqlFromFile('helpers/queries/jupiter-perpetual-oi.sql'));
+    data = await queryDuneSql(options, getSqlFromFile('helpers/queries/jupiter-perpetual-oi.sql', {
+      start: options.startTimestamp,
+      end: options.endTimestamp,
+    }));
   }
   else {
     data = await queryDuneResult(options, queryId);


### PR DESCRIPTION
* **bob-blockchain.sql + fees/bob.ts**: `realised_revenues` and `daily_prices` were scanning and returning full historical datasets even though only one day was needed. Both queries are now restricted to `{{start}}`–`{{end}}`, reducing each run to a single day.

* **jupiter-perpetual-oi.sql + open-interest/jupiter-perpetual-oi.ts**: All `position_changes` branches scanned `solana.instruction_calls` from genesis. An upper time bound (`{{end}}`) is now applied to each branch, and the final query is restricted to the target day, avoiding full-history result transfers.

* **helpers/dune.ts — `queryDuneResult`**: Added `limit=100000` to prevent silent truncation from Dune's 1,000-row default. Also added optional `filters` support for API-level date filtering.