### PR TITLE
parallelize chain fee fetches in across prefetch

### DIFF
--- a/fees/across.ts
+++ b/fees/across.ts
@@ -121,7 +121,7 @@ const prefetch = async (options: FetchOptions): Promise<any> => {
       } catch (error) {
         console.error(`[across][prefetch] failed chain=${dst_chain} chainId=${destinationChainId}`, error);
       }
-      await sleep(1000);
+      await sleep(2500);
       return { dst_chain, relay_fees, lp_fees: 0 };
     });
 

--- a/fees/across.ts
+++ b/fees/across.ts
@@ -121,7 +121,7 @@ const prefetch = async (options: FetchOptions): Promise<any> => {
       } catch (error) {
         console.error(`[across][prefetch] failed chain=${dst_chain} chainId=${destinationChainId}`, error);
       }
-      await sleep(2500);
+      await sleep(5000);
       return { dst_chain, relay_fees, lp_fees: 0 };
     });
 

--- a/fees/across.ts
+++ b/fees/across.ts
@@ -8,7 +8,7 @@
 import PromisePool from "@supercharge/promise-pool";
 import { Adapter, FetchOptions } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
-import fetchURL from "../utils/fetchURL";
+import fetchURL, { fetchURLAutoHandleRateLimit } from "../utils/fetchURL";
 import { sleep } from "../utils/utils";
 
 interface IResponse {
@@ -83,7 +83,7 @@ const fetchBridgeFeesForChain = async (destinationChainId: number, startTimestam
       limit: String(PAGE_LIMIT),
       skip: String(skip),
     });
-    const deposits: IAcrossDeposit[] = await fetchURL(`${ACROSS_DEPOSITS_API}?${queryParams.toString()}`);
+    const deposits: IAcrossDeposit[] = await fetchURLAutoHandleRateLimit(`${ACROSS_DEPOSITS_API}?${queryParams.toString()}`);
     if (!Array.isArray(deposits) || !deposits.length) break;
 
     let reachedOlderData = false;
@@ -121,7 +121,7 @@ const prefetch = async (options: FetchOptions): Promise<any> => {
       } catch (error) {
         console.error(`[across][prefetch] failed chain=${dst_chain} chainId=${destinationChainId}`, error);
       }
-      await sleep(5000);
+      await sleep(1000);
       return { dst_chain, relay_fees, lp_fees: 0 };
     });
 

--- a/fees/across.ts
+++ b/fees/across.ts
@@ -108,21 +108,18 @@ const fetchBridgeFeesForChain = async (destinationChainId: number, startTimestam
 
 // Prefetch function that will run once before any fetch calls
 const prefetch = async (options: FetchOptions): Promise<any> => {
-  const results: IResponse[] = [];
-
-  for (const [dst_chain, destinationChainId] of Object.entries(chainIdConfig)) {
-    let relay_fees = 0;
-    try {
-      relay_fees = await fetchBridgeFeesForChain(destinationChainId, options.startTimestamp, options.endTimestamp);
-    } catch (error) {
-      console.error(`[across][prefetch] failed chain=${dst_chain} chainId=${destinationChainId}`, error);
-    }
-    results.push({
-      dst_chain,
-      relay_fees,
-      lp_fees: 0,
-    });
-  }
+  const entries = Object.entries(chainIdConfig);
+  const results = await Promise.all(
+    entries.map(async ([dst_chain, destinationChainId]) => {
+      let relay_fees = 0;
+      try {
+        relay_fees = await fetchBridgeFeesForChain(destinationChainId, options.startTimestamp, options.endTimestamp);
+      } catch (error) {
+        console.error(`[across][prefetch] failed chain=${dst_chain} chainId=${destinationChainId}`, error);
+      }
+      return { dst_chain, relay_fees, lp_fees: 0 };
+    })
+  );
 
   return results as any;
 };

--- a/fees/across.ts
+++ b/fees/across.ts
@@ -5,9 +5,11 @@
  * uses `bridgeFeeUsd` as the relayer fee source of truth.
  */
 
+import PromisePool from "@supercharge/promise-pool";
 import { Adapter, FetchOptions } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
 import fetchURL from "../utils/fetchURL";
+import { sleep } from "../utils/utils";
 
 interface IResponse {
   dst_chain: string;
@@ -101,6 +103,7 @@ const fetchBridgeFeesForChain = async (destinationChainId: number, startTimestam
 
     skip += PAGE_LIMIT;
     pagesFetched += 1;
+    await sleep(200);
   }
 
   return totalBridgeFeesUsd;
@@ -109,17 +112,18 @@ const fetchBridgeFeesForChain = async (destinationChainId: number, startTimestam
 // Prefetch function that will run once before any fetch calls
 const prefetch = async (options: FetchOptions): Promise<any> => {
   const entries = Object.entries(chainIdConfig);
-  const results = await Promise.all(
-    entries.map(async ([dst_chain, destinationChainId]) => {
+  const { results } = await PromisePool.withConcurrency(3)
+    .for(entries)
+    .process(async ([dst_chain, destinationChainId]) => {
       let relay_fees = 0;
       try {
         relay_fees = await fetchBridgeFeesForChain(destinationChainId, options.startTimestamp, options.endTimestamp);
       } catch (error) {
         console.error(`[across][prefetch] failed chain=${dst_chain} chainId=${destinationChainId}`, error);
       }
+      await sleep(1000);
       return { dst_chain, relay_fees, lp_fees: 0 };
-    })
-  );
+    });
 
   return results as any;
 };


### PR DESCRIPTION
prefetch was fetching bridge fees for each destination chain one at a time inside a for-of loop, so each chain waited for the previous one to finish. but since all chain fetches are fully independent, replaced the loop with Promise.all so all chains are fetched concurrently. error handling per chain is unchanged.