### PR TITLE
[fees] minebtc - Update adapter for mainnet deployment

### DIFF
--- a/fees/minebtc.ts
+++ b/fees/minebtc.ts
@@ -13,72 +13,70 @@ const TREASURY_BUYBACK_SHARE = 0.7;
 const TREASURY_PROTOCOL_SHARE = 0.3;
 
 const fetch = async (options: FetchOptions) => {
-    const [treasuryReceipts, stakingRewardReceipts] = await Promise.all([
-        getSolanaReceived({ options, target: SOL_TREASURY }),
-        getSolanaReceived({ options, target: STAKER_SOL_REWARD_VAULT }),
-    ]);
+  const [treasuryReceipts, stakingRewardReceipts] = await Promise.all([
+    getSolanaReceived({ options, target: SOL_TREASURY }),
+    getSolanaReceived({ options, target: STAKER_SOL_REWARD_VAULT }),
+  ]);
 
-    const dailyHoldersRevenue = treasuryReceipts.clone(TREASURY_BUYBACK_SHARE, METRIC.TOKEN_BUY_BACK);
-    const dailyProtocolRevenue = treasuryReceipts.clone(TREASURY_PROTOCOL_SHARE, METRIC.PROTOCOL_FEES);
-    const dailySupplySideRevenue = stakingRewardReceipts.clone(1, METRIC.STAKING_REWARDS);
+  const dailyHoldersRevenue = treasuryReceipts.clone(TREASURY_BUYBACK_SHARE, METRIC.TOKEN_BUY_BACK);
+  const dailyProtocolRevenue = treasuryReceipts.clone(TREASURY_PROTOCOL_SHARE, METRIC.PROTOCOL_FEES);
+  const dailySupplySideRevenue = stakingRewardReceipts.clone(1, METRIC.STAKING_REWARDS);
 
-    const dailyRevenue = options.createBalances();
-    dailyRevenue.addBalances(dailyHoldersRevenue, METRIC.TOKEN_BUY_BACK);
-    dailyRevenue.addBalances(dailyProtocolRevenue, METRIC.PROTOCOL_FEES);
+  const dailyRevenue = options.createBalances();
+  dailyRevenue.addBalances(dailyHoldersRevenue, METRIC.TOKEN_BUY_BACK);
+  dailyRevenue.addBalances(dailyProtocolRevenue, METRIC.PROTOCOL_FEES);
 
-    const dailyFees = options.createBalances();
-    dailyFees.addBalances(dailyHoldersRevenue, METRIC.TOKEN_BUY_BACK);
-    dailyFees.addBalances(dailyProtocolRevenue, METRIC.PROTOCOL_FEES);
-    dailyFees.addBalances(dailySupplySideRevenue, METRIC.STAKING_REWARDS);
+  const dailyFees = options.createBalances();
+  dailyFees.addBalances(dailyHoldersRevenue, 'Canonical Roll Fees');
+  dailyFees.addBalances(dailyProtocolRevenue, 'Canonical Roll Fees');
+  dailyFees.addBalances(dailySupplySideRevenue, 'Canonical Roll Fees');
 
-    return {
-        dailyFees,
-        dailyUserFees: dailyFees,
-        dailyRevenue,
-        dailyProtocolRevenue,
-        dailyHoldersRevenue,
-        dailySupplySideRevenue,
-    };
+  return {
+    dailyFees,
+    dailyUserFees: dailyFees,
+    dailyRevenue,
+    dailyProtocolRevenue,
+    dailyHoldersRevenue,
+    dailySupplySideRevenue,
+  };
 };
 
 const methodology = {
-    Fees: "Canonical SOL fees received by the MineBTC treasury and staking reward vault from Casino rolls.",
-    Revenue: "SOL received by the MineBTC treasury. The economy crank allocates this treasury flow between dBTC buybacks and protocol-side treasury / market-making flows.",
-    ProtocolRevenue: "30% of treasury receipts retained for protocol-side treasury and market-making flows.",
-    HoldersRevenue: "70% of treasury receipts allocated to dBTC buybacks, benefiting holders.",
-    SupplySideRevenue: "SOL staking rewards distributed to dBTC and LP stakers through the staking reward vault.",
+  Fees: "Total fees paid by users for canonical roll bets.",
+  Revenue: "SOL received by the MineBTC treasury. The economy crank allocates this treasury flow between dBTC buybacks and protocol-side treasury / market-making flows.",
+  ProtocolRevenue: "30% of treasury receipts retained for protocol-side treasury and market-making flows.",
+  HoldersRevenue: "70% of treasury receipts allocated to dBTC buybacks, benefiting holders.",
+  SupplySideRevenue: "SOL staking rewards distributed to dBTC and LP stakers through the staking reward vault.",
 };
 
 const breakdownMethodology = {
-    Fees: {
-        [METRIC.TOKEN_BUY_BACK]: "Treasury receipts allocated to dBTC buybacks.",
-        [METRIC.PROTOCOL_FEES]: "Treasury receipts retained for protocol-side treasury and market-making flows.",
-        [METRIC.STAKING_REWARDS]: "SOL fees routed to the staking reward vault for dBTC and LP stakers.",
-    },
-    Revenue: {
-        [METRIC.TOKEN_BUY_BACK]: "70% of treasury receipts allocated to dBTC buybacks.",
-        [METRIC.PROTOCOL_FEES]: "30% of treasury receipts retained for protocol-side treasury and market-making flows.",
-    },
-    ProtocolRevenue: {
-        [METRIC.PROTOCOL_FEES]: "30% of treasury receipts retained for protocol-side treasury and market-making flows.",
-    },
-    HoldersRevenue: {
-        [METRIC.TOKEN_BUY_BACK]: "70% of treasury receipts allocated to dBTC buybacks.",
-    },
-    SupplySideRevenue: {
-        [METRIC.STAKING_REWARDS]: "SOL fees routed to the staking reward vault for dBTC and LP stakers.",
-    },
+  Fees: {
+    'Canonical Roll Fees': "Fees paid by users for canonical roll bets.",
+  },
+  Revenue: {
+    [METRIC.TOKEN_BUY_BACK]: "70% of treasury receipts allocated to dBTC buybacks.",
+    [METRIC.PROTOCOL_FEES]: "30% of treasury receipts retained for protocol-side treasury and market-making flows.",
+  },
+  ProtocolRevenue: {
+    [METRIC.PROTOCOL_FEES]: "30% of treasury receipts retained for protocol-side treasury and market-making flows.",
+  },
+  HoldersRevenue: {
+    [METRIC.TOKEN_BUY_BACK]: "70% of treasury receipts allocated to dBTC buybacks.",
+  },
+  SupplySideRevenue: {
+    [METRIC.STAKING_REWARDS]: "SOL fees routed to the staking reward vault for dBTC and LP stakers.",
+  },
 }
 
 const adapter: SimpleAdapter = {
-    version: 2,
-    pullHourly: true,
-    fetch,
-    chains: [CHAIN.SOLANA],
-    start: "2026-05-21",
-    methodology,
-    breakdownMethodology,
-    dependencies: [Dependencies.ALLIUM],
+  version: 2,
+  pullHourly: true,
+  fetch,
+  chains: [CHAIN.SOLANA],
+  start: "2026-05-21",
+  methodology,
+  breakdownMethodology,
+  dependencies: [Dependencies.ALLIUM],
 };
 
 export default adapter;

--- a/fees/minebtc.ts
+++ b/fees/minebtc.ts
@@ -1,30 +1,35 @@
 import { Dependencies, FetchOptions, SimpleAdapter } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
+import { METRIC } from "../helpers/metrics";
 import { getSolanaReceived } from "../helpers/token";
 
-// MineBTC Program: Hw9uxvtmQdS57N6aNwJA5iqjSqzhRDdopCHgm8EPwkqx
-// Fee structure: 10% protocol fee on all SOL bets
-//   - 1% -> staker SOL rewards vault (supply-side)
-//   - 9% -> SOL treasury, further split:
-//       - 80% (7.2% of bets) -> dogeBTC buybacks (holders)
-//       - 20% (1.8% of bets) -> team multisig (protocol)
-const SOL_TREASURY = "6rBKBaVK2m8rGjHXa65ohjWjD3B3VGDSKUpJrxraPmX1";
+// MineBTC Program: 1eotiTH2UxCpPMmtzUDGqf1b8dwM7AMKb8a2Tio51an
+// SOL Casino roll fees are charged on gross bet size. Referral cuts, when
+// present, are paid to per-user referral PDAs before the canonical vault split.
+const SOL_TREASURY = "2TU3jP7vnhPD1ksVmSMQhuAauuFCuj9magtMWDW65jEx";
+const STAKER_SOL_REWARD_VAULT = "FYnbbqMPUetvN22CDeDxAJb4SSXmqZcGEbrwVvoJREvK";
+
+const TREASURY_BUYBACK_SHARE = 0.7;
+const TREASURY_PROTOCOL_SHARE = 0.3;
 
 const fetch = async (options: FetchOptions) => {
-    // SOL treasury receives 9% of all bets placed (the other 1% goes to staker vault)
-    const dailyRevenue = await getSolanaReceived({ options, target: SOL_TREASURY });
+    const [treasuryReceipts, stakingRewardReceipts] = await Promise.all([
+        getSolanaReceived({ options, target: SOL_TREASURY }),
+        getSolanaReceived({ options, target: STAKER_SOL_REWARD_VAULT }),
+    ]);
 
-    // Total protocol fees = 10% of bets; treasury = 9/10 of that
-    const dailyFees = dailyRevenue.clone(10 / 9);
+    const dailyHoldersRevenue = treasuryReceipts.clone(TREASURY_BUYBACK_SHARE, METRIC.TOKEN_BUY_BACK);
+    const dailyProtocolRevenue = treasuryReceipts.clone(TREASURY_PROTOCOL_SHARE, METRIC.PROTOCOL_FEES);
+    const dailySupplySideRevenue = stakingRewardReceipts.clone(1, METRIC.STAKING_REWARDS);
 
-    // Supply-side: staker SOL rewards = 1% of bets = 1/9 of treasury inflow
-    const dailySupplySideRevenue = dailyRevenue.clone(1 / 9);
+    const dailyRevenue = options.createBalances();
+    dailyRevenue.addBalances(dailyHoldersRevenue, METRIC.TOKEN_BUY_BACK);
+    dailyRevenue.addBalances(dailyProtocolRevenue, METRIC.PROTOCOL_FEES);
 
-    // Protocol revenue: 20% of treasury -> team multisig
-    const dailyProtocolRevenue = dailyRevenue.clone(0.2);
-
-    // Holders revenue: 80% of treasury -> dogeBTC buybacks
-    const dailyHoldersRevenue = dailyRevenue.clone(0.8);
+    const dailyFees = options.createBalances();
+    dailyFees.addBalances(dailyHoldersRevenue, METRIC.TOKEN_BUY_BACK);
+    dailyFees.addBalances(dailyProtocolRevenue, METRIC.PROTOCOL_FEES);
+    dailyFees.addBalances(dailySupplySideRevenue, METRIC.STAKING_REWARDS);
 
     return {
         dailyFees,
@@ -37,11 +42,32 @@ const fetch = async (options: FetchOptions) => {
 };
 
 const methodology = {
-    Fees: "10% protocol fee on all SOL bets placed in MineBTC faction warfare rounds.",
-    Revenue: "9% of bets flow to the protocol treasury for buybacks and team earnings.",
-    ProtocolRevenue: "20% of treasury (1.8% of total bets) distributed to team multisig as dev earnings.",
-    HoldersRevenue: "80% of treasury (7.2% of total bets) used for dogeBTC token buybacks, benefiting holders.",
-    SupplySideRevenue: "1% of bets distributed as SOL staking rewards to dogeBTC and LP stakers of the winning faction.",
+    Fees: "Canonical SOL fees received by the MineBTC treasury and staking reward vault from Casino rolls.",
+    Revenue: "SOL received by the MineBTC treasury. The economy crank allocates this treasury flow between dBTC buybacks and protocol-side treasury / market-making flows.",
+    ProtocolRevenue: "30% of treasury receipts retained for protocol-side treasury and market-making flows.",
+    HoldersRevenue: "70% of treasury receipts allocated to dBTC buybacks, benefiting holders.",
+    SupplySideRevenue: "SOL staking rewards distributed to dBTC and LP stakers through the staking reward vault.",
+};
+
+const breakdownMethodology = {
+    Fees: {
+        [METRIC.TOKEN_BUY_BACK]: "Treasury receipts allocated to dBTC buybacks.",
+        [METRIC.PROTOCOL_FEES]: "Treasury receipts retained for protocol-side treasury and market-making flows.",
+        [METRIC.STAKING_REWARDS]: "SOL fees routed to the staking reward vault for dBTC and LP stakers.",
+    },
+    Revenue: {
+        [METRIC.TOKEN_BUY_BACK]: "70% of treasury receipts allocated to dBTC buybacks.",
+        [METRIC.PROTOCOL_FEES]: "30% of treasury receipts retained for protocol-side treasury and market-making flows.",
+    },
+    ProtocolRevenue: {
+        [METRIC.PROTOCOL_FEES]: "30% of treasury receipts retained for protocol-side treasury and market-making flows.",
+    },
+    HoldersRevenue: {
+        [METRIC.TOKEN_BUY_BACK]: "70% of treasury receipts allocated to dBTC buybacks.",
+    },
+    SupplySideRevenue: {
+        [METRIC.STAKING_REWARDS]: "SOL fees routed to the staking reward vault for dBTC and LP stakers.",
+    },
 }
 
 const adapter: SimpleAdapter = {
@@ -49,8 +75,9 @@ const adapter: SimpleAdapter = {
     pullHourly: true,
     fetch,
     chains: [CHAIN.SOLANA],
-    start: "2025-12-16",
+    start: "2026-05-21",
     methodology,
+    breakdownMethodology,
     dependencies: [Dependencies.ALLIUM],
 };
 


### PR DESCRIPTION
Updates the MineBTC fees adapter to the current mainnet deployment and fee model.\n\nChanges:\n- Rebuilds the branch cleanly from upstream master so this PR only touches fees/minebtc.ts.\n- Replaces stale SOL treasury with the current mainnet treasury.\n- Tracks the current staking rewards vault as supply-side revenue.\n- Labels MineBTC fee components with breakdownMethodology.\n- Updates methodology for treasury receipts, 70% dBTC buyback allocation, and staking reward distribution.\n- Sets the adapter start date to the current mainnet launch.\n\nAudit notes:\n- dBTC and LP staking custody is global; per-country staking lives in FactionState reward indexes/hashpower, not separate token vaults.\n- 0.1% dBTC transfer tax is harvested separately into the faction treasury flow and distributed by Country Race rank; it is not counted as SOL fee revenue in this adapter.\n- Referral cuts are paid to per-user referral PDAs before the canonical treasury/staking vault split, so this adapter tracks canonical vault receipts.\n\nValidation:\n- pnpm test fees minebtc: blocked locally because ALLIUM_API_KEY is not configured; this is expected for local runs without Allium credentials.

Note: Allowing start date change , as no fees was recorded previously