### PR TITLE
fix: chainlink requests

### DIFF
--- a/fees/chainlink-requests.ts
+++ b/fees/chainlink-requests.ts
@@ -33,7 +33,7 @@ const fetch = async (_: any, _1: any, { getFromBlock, getToBlock, createBalances
   const amount = await getTotalPaymentFromLogs(fromBlock, toBlock, getLogs)
 
   dailyFees.addCGToken('chainlink', amount / 10n ** 18n)
-  return { dailyFees }
+  return { dailyFees, dailyRevenue: dailyFees, dailyProtocolRevenue: dailyFees }
 }
 
 const methodology = {

--- a/fees/chainlink-requests.ts
+++ b/fees/chainlink-requests.ts
@@ -33,13 +33,12 @@ const fetch = async (_: any, _1: any, { getFromBlock, getToBlock, createBalances
   const amount = await getTotalPaymentFromLogs(fromBlock, toBlock, getLogs)
 
   dailyFees.addCGToken('chainlink', amount / 10n ** 18n)
-  return { dailyFees, dailyRevenue: dailyFees, dailyProtocolRevenue: dailyFees }
+  return { dailyFees, dailySupplySideRevenue: dailyFees }
 }
 
 const methodology = {
-    Fees: "Sum of all fees from Chainlink Requests,Chainlink Keepers,Chainlink VRF V1,Chainlink VRF V2,Chainlink CCIP",
-    Revenue: "Sum of all revenue from Chainlink Requests,Chainlink Keepers,Chainlink VRF V1,Chainlink VRF V2,Chainlink CCIP",
-    ProtocolRevenue: "Sum of all revenue from Chainlink Requests,Chainlink Keepers,Chainlink VRF V1,Chainlink VRF V2,Chainlink CCIP",
+  Fees: "Sum of all fees from Chainlink Requests,Chainlink Keepers,Chainlink VRF V1,Chainlink VRF V2,Chainlink CCIP.",
+  SupplySideRevenue: "All LINK payments go directly to the oracle node operators who fulfill the requests.",
 }
 
 const adapter: SimpleAdapter = {


### PR DESCRIPTION
Chainlink keeps all request fees there's no supply side split. This wires up the missing dailyRevenue and dailyProtocolRevenue fields so the dashboard reflects that correctly.