### PR TITLE
parallelize sequential fetches in steamm, woofi, delphi and lexer adapters

### DIFF
--- a/dexs/delphi/index.ts
+++ b/dexs/delphi/index.ts
@@ -32,15 +32,19 @@ const fetch: FetchV2 = async (options) => {
 
     const configs: Record<string, { tradingFee: bigint, recipientPct: bigint }> = {};
 
-    for (const marketProxy of marketProxies) {
-        const market = await options.api.call({ target: marketProxy, abi: abi.getMarket });
-        const recipientPct = await options.api.call({ target: marketProxy, abi: abi.tradingFeesRecipientPct });
+    const [markets, recipientPcts] = await Promise.all([
+        options.api.multiCall({ calls: marketProxies, abi: abi.getMarket }),
+        options.api.multiCall({ calls: marketProxies, abi: abi.tradingFeesRecipientPct }),
+    ]);
+
+    marketProxies.forEach((marketProxy, i) => {
+        const market = markets[i];
         const config = market.config ?? market[0];
         configs[marketProxy] = {
             tradingFee: BigInt(config.tradingFee ?? config[2]),
-            recipientPct: BigInt(recipientPct),
+            recipientPct: BigInt(recipientPcts[i]),
         };
-    }
+    });
 
     buyLogs.forEach((buy) => {
         const config = configs[buy.marketProxy.toLowerCase()];

--- a/dexs/lexer-derivatives.ts
+++ b/dexs/lexer-derivatives.ts
@@ -28,13 +28,13 @@ const historicalDataDerivatives = gql`
 const fetchDerivativesValue = async (timestamp: number): Promise<FetchResultVolume> => {
   let dailyVolume = 0;
   const t = getUniqStartOfTodayTimestamp(new Date(timestamp * 1000))
-  for (const api of apiEndPoints) {
-    const derivatives: VolumeStatsQuery[] = (
-      await request(api, historicalDataDerivatives, {
-        id: String(t),
-        period: "daily",
-      })
-    ).volumeStats as VolumeStatsQuery[];
+  const results = await Promise.all(
+    apiEndPoints.map((api) =>
+      request(api, historicalDataDerivatives, { id: String(t), period: "daily" })
+    )
+  );
+  for (const result of results) {
+    const derivatives = result.volumeStats as VolumeStatsQuery[];
     dailyVolume += derivatives.length ? Number(
       Object.values(derivatives[0] || {}).reduce((sum, element) =>
         String(Number(sum) + Number(element))

--- a/dexs/lexer-swap.ts
+++ b/dexs/lexer-swap.ts
@@ -27,13 +27,13 @@ const historicalDataSwap = gql`
 const fetchSwapValue = async (timestamp: number): Promise<FetchResultVolume> => {
   let dailyVolume = 0;
   const t = getUniqStartOfTodayTimestamp(new Date(timestamp * 1000))
-  for (const api of apiEndPoints) {
-    const swap: VolumeStatsQuery[] = (
-      await request(api, historicalDataSwap, {
-        id: String(t),
-        period: "daily",
-      })
-    ).volumeStats as VolumeStatsQuery[];
+  const results = await Promise.all(
+    apiEndPoints.map((api) =>
+      request(api, historicalDataSwap, { id: String(t), period: "daily" })
+    )
+  );
+  for (const result of results) {
+    const swap = result.volumeStats as VolumeStatsQuery[];
     dailyVolume += Number(swap.reduce((acc, cur) => acc + Number(cur.swap), 0));
   }
   dailyVolume /= 1e30;

--- a/dexs/steamm.ts
+++ b/dexs/steamm.ts
@@ -28,11 +28,15 @@ async function fetchPoolsStats(startTimestamp: number, endTimestamp: number): Pr
   const poolInfos: Array<PoolInfo> = [];
 
   const poolConfigs = await fetchURL(suilendPoolsURL());
-  const { results: allHistorical } = await PromisePool.withConcurrency(5)
+  const { results: allHistorical , errors } = await PromisePool.withConcurrency(5)
     .for(poolConfigs)
     .process((poolConfig: any) =>
       fetchURL(suilendPoolHistoricalURL(poolConfig.pool.id, startTimestamp, endTimestamp - 1))
     );
+
+  if (errors?.length)
+    throw errors[0];
+  
   poolConfigs.forEach((poolConfig: any, idx: number) => {
     const dayItem = allHistorical[idx]?.find((item: Volume) => Number(item.start) === startTimestamp);
     if (dayItem) {

--- a/dexs/steamm.ts
+++ b/dexs/steamm.ts
@@ -1,6 +1,7 @@
 import { Adapter, FetchOptions } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
 import fetchURL from "../utils/fetchURL";
+import PromisePool from "@supercharge/promise-pool";
 
 const suilendPoolsURL = () => `https://global.suilend.fi/steamm/pools/all`;
 
@@ -27,22 +28,20 @@ async function fetchPoolsStats(startTimestamp: number, endTimestamp: number): Pr
   const poolInfos: Array<PoolInfo> = [];
 
   const poolConfigs = await fetchURL(suilendPoolsURL());
-  for (const poolConfig of poolConfigs) {
-    const historicalItems: Array<Volume> = await fetchURL(
-      suilendPoolHistoricalURL(
-        poolConfig.pool.id,
-        startTimestamp,
-        endTimestamp - 1,
-      )
+  const { results: allHistorical } = await PromisePool.withConcurrency(5)
+    .for(poolConfigs)
+    .process((poolConfig: any) =>
+      fetchURL(suilendPoolHistoricalURL(poolConfig.pool.id, startTimestamp, endTimestamp - 1))
     );
-    const dayItem = historicalItems.find(item => Number(item.start) === startTimestamp)
+  poolConfigs.forEach((poolConfig: any, idx: number) => {
+    const dayItem = allHistorical[idx]?.find((item: Volume) => Number(item.start) === startTimestamp);
     if (dayItem) {
       poolInfos.push({
         id: poolConfig.pool.id,
         volumeUsd: Number(dayItem.usdValue),
       });
     }
-  }
+  });
 
   return poolInfos;
 }

--- a/fees/woofi.ts
+++ b/fees/woofi.ts
@@ -20,10 +20,12 @@ const CONFIG: Record<string, string> = {
 const fetch = async (options: FetchOptions) => {
   const { api, chain } = options;
   const from = CONFIG[chain];
-  const token = await api.call({ abi: 'address:quoteToken', target: from })
-  const rebateManager = await api.call({ abi: 'address:rebateManager', target: from })
-  const treasury = await api.call({ abi: 'address:treasury', target: from })
-  const vaultManager = await api.call({ abi: 'address:vaultManager', target: from })
+  const [token, rebateManager, treasury, vaultManager] = await Promise.all([
+    api.call({ abi: 'address:quoteToken', target: from }),
+    api.call({ abi: 'address:rebateManager', target: from }),
+    api.call({ abi: 'address:treasury', target: from }),
+    api.call({ abi: 'address:vaultManager', target: from }),
+  ])
   const valutManagerFees = await addTokensReceived({ fromAddressFilter: from, options, tokens: [token], targets: [vaultManager] })
   const rebateManagerFees = await addTokensReceived({ fromAddressFilter: from, options, tokens: [token], targets: [rebateManager] })
   const treasuryFees = await addTokensReceived({ fromAddressFilter: from, options, tokens: [token], targets: [treasury] })


### PR DESCRIPTION
four adapters had sequential awaits inside loops or consecutive independent calls that blocked on each other unnecessarily.

steamm: fetched historical volume for each pool one at a time inside a for loop. replaced with PromisePool with concurrency of 5 to fetch all pools concurrently without overwhelming the API.

woofi: four consecutive api.call to the same contract (quoteToken, rebateManager, treasury, vaultManager) each awaited separately. replaced with a single Promise.all.

delphi: two api.call per market proxy inside a for loop (getMarket and tradingFeesRecipientPct). replaced with two multiCall batches covering all proxies at once.

lexer-swap and lexer-derivatives: two sequential subgraph requests to independent endpoints. replaced with Promise.all.