### PR TITLE
fix getLatestBlockRetry never actually retrying on failure

### DIFF
--- a/cli/utils.ts
+++ b/cli/utils.ts
@@ -16,15 +16,16 @@ export function checkArguments(argv: string[]) {
 
 export async function getLatestBlockRetry(chain: string) {
   let lastError: any;
-  for (let i = 0; i < 5; i++) {
+  const maxRetries = 5;
+  for (let i = 0; i < maxRetries; i++) {
     try {
       return await getLatestBlock(chain);
     } catch (e) {
       lastError = e;
-      await new Promise((r) => setTimeout(r, 200 * 2 ** i));
+      if (i < maxRetries - 1) await new Promise((r) => setTimeout(r, 200 * 2 ** i));
     }
   }
-  throw new Error(`Couln't get block heights for chain "${chain}"\n${lastError}`);
+  throw new Error(`Couln't get block heights for chain "${chain}"\n${lastError?.message ?? String(lastError)}`);
 }
 
 export function printVolumes(volumes: any[], _?: SimpleAdapter) {

--- a/cli/utils.ts
+++ b/cli/utils.ts
@@ -15,13 +15,16 @@ export function checkArguments(argv: string[]) {
 }
 
 export async function getLatestBlockRetry(chain: string) {
+  let lastError: any;
   for (let i = 0; i < 5; i++) {
     try {
       return await getLatestBlock(chain);
     } catch (e) {
-      throw new Error(`Couln't get block heights for chain "${chain}"\n${e}`);
+      lastError = e;
+      await new Promise((r) => setTimeout(r, 200 * 2 ** i));
     }
   }
+  throw new Error(`Couln't get block heights for chain "${chain}"\n${lastError}`);
 }
 
 export function printVolumes(volumes: any[], _?: SimpleAdapter) {

--- a/cli/utils.ts
+++ b/cli/utils.ts
@@ -25,7 +25,7 @@ export async function getLatestBlockRetry(chain: string) {
       if (i < maxRetries - 1) await new Promise((r) => setTimeout(r, 200 * 2 ** i));
     }
   }
-  throw new Error(`Couln't get block heights for chain "${chain}"\n${lastError?.message ?? String(lastError)}`);
+  throw new Error(`Couldn't get block heights for chain "${chain}"\n${lastError?.message ?? String(lastError)}`);
 }
 
 export function printVolumes(volumes: any[], _?: SimpleAdapter) {


### PR DESCRIPTION
the retry loop called throw inside the catch block, which then rethrew the error immediately on the first failure making the loop exit after one attempt. retries 2 through 5 were unreachable. fixed it by storing the last error and only throwing after all attempts are exhausted. also added exponential backoff between retries.