### PR TITLE
[fix] Velodrome-V2: refine methodology and optimize adapter

### DIFF
--- a/fees/velodrome-v2/index.ts
+++ b/fees/velodrome-v2/index.ts
@@ -1,116 +1,149 @@
 import ADDRESSES from '../../helpers/coreAssets.json'
+import { SimpleAdapter } from "../../adapters/types"
 import { CHAIN } from "../../helpers/chains"
-import { uniV2Exports } from "../../helpers/uniswap";
+import { METRIC } from "../../helpers/metrics";
+import { getUniV2LogAdapter } from "../../helpers/uniswap";
 
-const swapEvent = 'event Swap(address indexed sender, address indexed to, uint256 amount0In, uint256 amount1In, uint256 amount0Out, uint256 amount1Out)'
-const notifyRewardEvent = 'event NotifyReward(address indexed from,uint256 amount)';
+const ABI = {
+  swap: 'event Swap(address indexed sender, address indexed to, uint256 amount0In, uint256 amount1In, uint256 amount0Out, uint256 amount1Out)',
+  notifyReward: 'event NotifyReward(address indexed from,uint256 amount)',
+  notifyRewardWithToken: 'event NotifyReward(address indexed from,address indexed reward,uint256 indexed epoch,uint256 amount)',
+  gaugeCreated: 'event GaugeCreated(address indexed poolFactory,address indexed votingRewardsFactory,address indexed gaugeFactory,address pool,address bribeVotingReward,address feeVotingReward,address gauge,address creator)',
+  leafGaugeCreated: 'event GaugeCreated(address indexed poolFactory,address indexed votingRewardsFactory,address indexed gaugeFactory,address pool,address incentiveVotingReward,address feeVotingReward,address gauge)',
+  gauges: 'function gauges(address) view returns (address)',
+}
 
-const event_notify_reward_op = 'event NotifyReward(address indexed from,address indexed reward,uint256 indexed epoch,uint256 amount)';
-const event_gauge_created = 'event GaugeCreated(address indexed poolFactory,address indexed votingRewardsFactory,address indexed gaugeFactory,address pool,address bribeVotingReward,address feeVotingReward,address gauge,address creator)'
-const leaf_gauge_created = 'event GaugeCreated(address indexed poolFactory,address indexed votingRewardsFactory,address indexed gaugeFactory,address pool,address incentiveVotingReward,address feeVotingReward,address gauge)'
 const leaf_voter = '0x97cDBCe21B6fd0585d29E539B1B99dAd328a1123'
 const leaf_pool_factory = '0x31832f2a97Fd20664D76Cc421207669b55CE4BC0'
 
-const config: Record<string, any> = {
+type ChainConfig = {
+  start?: string
+  factory?: string
+  voter?: string
+  maxPairSize?: number
+  bribeFromBlock?: number
+  stakingRewards?: string
+  rewardToken?: string
+  leafFromBlock?: number
+}
+const chainConfig: Record<string, ChainConfig> = {
+  [CHAIN.OPTIMISM]: {
+    factory: '0xF1046053aa5682b4F9a81b5481394DA16BE5FF5a',
+    voter: '0x41c914ee0c7e1a5edcd0295623e6dc557b5abf3c',
+    maxPairSize: 500,
+    bribeFromBlock: 105896852,
+  },
   [CHAIN.MODE]: {
     stakingRewards: '0xD2F998a46e4d9Dd57aF1a28EBa8C34E7dD3851D7',
     rewardToken: '0xDfc7C877a950e49D2610114102175A06C2e3167a',
+    leafFromBlock: 15405187,
   },
   [CHAIN.BOB]: {
     stakingRewards: "0x8Eb6838B4e998DA08aab851F3d42076f21530389",
     rewardToken: ADDRESSES.optimism.WETH_1,
-  }
+  },
+  [CHAIN.LISK]: { leafFromBlock: 8339180 },
+  [CHAIN.FRAXTAL]: { leafFromBlock: 12603117 },
+  [CHAIN.INK]: { leafFromBlock: 3448692 },
+  [CHAIN.SONEIUM]: { leafFromBlock: 1906595 },
+  [CHAIN.UNICHAIN]: { leafFromBlock: 9387000 },
+  [CHAIN.SWELLCHAIN]: { voter: leaf_voter },
 }
-
-const superchainConfig: Record<string, any> = {
-  [CHAIN.MODE]: {
-    start_block: 15405187,
-  },
-  [CHAIN.LISK]: {
-    start_block: 8339180,
-  },
-  [CHAIN.INK]: {
-    start_block: 3448692,
-  },
-  [CHAIN.SONEIUM]: {
-    start_block: 1906595,
-  },
-  [CHAIN.FRAXTAL]: {
-    start_block: 12603117,
-  },
-  [CHAIN.UNICHAIN]: {
-    start_block: 9387000,
-  }
-}
-
-
-const customLogic = async ({ dailyFees, fetchOptions, filteredPairs, }: any) => {
-  const { createBalances, getLogs, chain, api, getToBlock, } = fetchOptions
+const customLogic = async ({ dailyFees, fetchOptions, filteredPairs, }: any, config: ChainConfig) => {
+  const { createBalances, getLogs, api, getToBlock, } = fetchOptions
   const dailyBribes = createBalances()
 
-  // handle native OP Mainnet bribes
-  if (chain === CHAIN.OPTIMISM) {
-    let voter = '0x41C914ee0c7E1A5edCD0295623e6dC557B5aBf3C'
-    const logs_gauge_created = (await getLogs({
-      target: voter,
-      fromBlock: 105896852,
+  if (config.bribeFromBlock && config.voter) {
+    const gaugeCreatedLogs = await getLogs({
+      target: config.voter,
+      fromBlock: config.bribeFromBlock,
       toBlock: await getToBlock(),
-      eventAbi: event_gauge_created,
+      eventAbi: ABI.gaugeCreated,
       cacheInCloud: true,
-    }))
-    const bribes_contract: string[] = logs_gauge_created.map((e: any) => e.bribeVotingReward.toLowerCase());
-
-    let logs = await getLogs({
-      targets: bribes_contract,
-      eventAbi: event_notify_reward_op,
     })
-    logs.map((e: any) => {
-      dailyBribes.add(e.reward, e.amount)
-    })
+    const targets = gaugeCreatedLogs.map((log: any) => log.bribeVotingReward.toLowerCase());
+    const logs = await getLogs({ targets, eventAbi: ABI.notifyRewardWithToken })
+    logs.forEach((log: any) => dailyBribes.add(log.reward, log.amount, 'Voting Incentives'))
   }
-  // handle Superchain beta "staking rewards" bribes on Mode and Bob
-  if (chain in config) {
-    const { stakingRewards, rewardToken, } = config[chain]
+
+  if (config.stakingRewards && config.rewardToken) {
     const pairs = Object.keys(filteredPairs)
-    const gauges = await api.multiCall({ target: stakingRewards, abi: 'function gauges(address) view returns (address)', calls: pairs })
-    let logs = await getLogs({ targets: gauges, eventAbi: notifyRewardEvent })
-
-    logs.forEach((log: any) => {
-      dailyBribes.add(rewardToken, log.amount)
-    })
+    const gauges = await api.multiCall({ target: config.stakingRewards, abi: ABI.gauges, calls: pairs })
+    const logs = await getLogs({ targets: gauges, eventAbi: ABI.notifyReward });
+    logs.forEach((log: any) => dailyBribes.add(config.rewardToken!, log.amount, 'Voting Incentives'))
   }
 
-  // handle Superchain 1.0 L2 bribes
-  if (chain in superchainConfig) {
-    const leaf_gauge_logs = (await getLogs({
+  if (config.leafFromBlock) {
+    const leafGaugeLogs = await getLogs({
       target: leaf_voter,
-      fromBlock: superchainConfig[chain]['start_block'],
+      fromBlock: config.leafFromBlock,
       toBlock: await getToBlock(),
-      eventAbi: leaf_gauge_created,
+      eventAbi: ABI.leafGaugeCreated,
       cacheInCloud: true,
-    }))
-    const incentive_contracts: string[] = leaf_gauge_logs.map((e: any) => e.incentiveVotingReward.toLowerCase());
-
-    let logs = await getLogs({
-      targets: incentive_contracts,
-      eventAbi: event_notify_reward_op,
     })
-    logs.map((e: any) => {
-      dailyBribes.add(e.reward, e.amount)
-    })
+    const targets = leafGaugeLogs.map((log: any) => log.incentiveVotingReward.toLowerCase());
+    const logs = await getLogs({ targets, eventAbi: ABI.notifyRewardWithToken })
+    logs.forEach((log: any) => dailyBribes.add(log.reward, log.amount, 'Voting Incentives'))
   }
 
-  return { dailyFees, dailyRevenue: dailyFees, dailyHoldersRevenue: dailyFees, dailyBribesRevenue: dailyBribes } as any
+  dailyFees = dailyFees.clone(1, METRIC.SWAP_FEES)
+
+  return {
+    dailyFees,
+    dailyUserFees: dailyFees.clone(1, METRIC.SWAP_FEES),
+    dailyRevenue: dailyFees.clone(1, 'Swap Fees To Voters'),
+    dailyHoldersRevenue: dailyFees.clone(1, 'Swap Fees To Voters'),
+    dailyBribesRevenue: dailyBribes,
+  } as any
 }
 
-export default uniV2Exports({
-  [CHAIN.OPTIMISM]: { factory: '0xF1046053aa5682b4F9a81b5481394DA16BE5FF5a', swapEvent, voter: '0x41c914ee0c7e1a5edcd0295623e6dc557b5abf3c', maxPairSize: 500, customLogic, },
-  [CHAIN.MODE]: { factory: '0x31832f2a97Fd20664D76Cc421207669b55CE4BC0', customLogic },
-  [CHAIN.BOB]: { factory: '0x31832f2a97Fd20664D76Cc421207669b55CE4BC0', swapEvent, customLogic, },
-  [CHAIN.LISK]: {factory: leaf_pool_factory, customLogic},
-  [CHAIN.FRAXTAL]: {factory: leaf_pool_factory, customLogic},
-  [CHAIN.INK]: {factory: leaf_pool_factory, customLogic},
-  [CHAIN.SONEIUM]: {factory: leaf_pool_factory, customLogic},
-  [CHAIN.UNICHAIN]: {factory: leaf_pool_factory, customLogic},
-  [CHAIN.SWELLCHAIN]: {factory: '0x31832f2a97Fd20664D76Cc421207669b55CE4BC0', swapEvent, voter: '0x97cDBCe21B6fd0585d29E539B1B99dAd328a1123', customLogic,}
-})
+const methodology = {
+  Fees: "Swap fees paid by users on Velodrome V2 trades.",
+  UserFees: "Users pay swap fees on each Velodrome V2 trade.",
+  Revenue: "Swap fees are distributed to veVELO voters.",
+  HoldersRevenue: "Swap fees are distributed to veVELO voters.",
+  SupplySideRevenue: "LPs receive VELO gauge emissions, not swap fees.",
+  BribesRevenue: "External voting incentives paid to veVELO voters.",
+}
+
+const breakdownMethodology = {
+  Fees: {
+    [METRIC.SWAP_FEES]: "Swap fees paid by users on Velodrome V2 trades.",
+  },
+  UserFees: {
+    [METRIC.SWAP_FEES]: "Swap fees paid by users on Velodrome V2 trades.",
+  },
+  Revenue: {
+    'Swap Fees To Voters': "Swap fees distributed to veVELO voters.",
+  },
+  HoldersRevenue: {
+    'Swap Fees To Voters': "Swap fees distributed to veVELO voters.",
+  },
+  BribesRevenue: {
+    'Voting Incentives': "External incentives paid to veVELO voters for directing liquidity emissions.",
+  },
+}
+
+const fetch = async (options: any) => {
+  const config = chainConfig[options.chain]
+  const adapterFetch = getUniV2LogAdapter({
+    factory: config.factory ?? leaf_pool_factory,
+    swapEvent: ABI.swap,
+    voter: config.voter,
+    maxPairSize: config.maxPairSize,
+    customLogic: (props: any) => customLogic(props, config),
+  })
+
+  return adapterFetch(options)
+}
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  pullHourly: true,
+  fetch,
+  methodology,
+  breakdownMethodology,
+  adapter: chainConfig,
+}
+
+export default adapter


### PR DESCRIPTION
## Summary
- Updates the Velodrome V2 fees adapter metadata and breakdown labels.
- Clarifies swap-fee accounting for veVELO voters and separates external voting incentives from protocol-generated swap fees.

## Changes
- Refactored `fees/velodrome-v2/index.ts` to use a compact `chainConfig` with a shared root `fetch`.
- Added `methodology` and `breakdownMethodology` for `dailyFees`, `dailyUserFees`, `dailyRevenue`, `dailyHoldersRevenue`, and `dailyBribesRevenue`.
- Labels swap fees as `Token Swap Fees` and voter distributions as `Swap Fees To Voters`.
- Labels external bribes/incentives as `Voting Incentives`.
- Clarifies that LPs receive VELO gauge emissions, not swap-fee supply-side revenue.

## Methodology
- Counts swap fees paid by users on Velodrome V2 trades.
- Reports swap fees as revenue and holders revenue because fees are distributed to veVELO voters.
- Tracks external voting incentives separately as `dailyBribesRevenue`.
- Does not report LP gauge emissions as fee revenue or supply-side revenue.
