### PR TITLE
[feat] minebtc-fun - add current fees adapter

### DIFF
--- a/fees/minebtc-fun.ts
+++ b/fees/minebtc-fun.ts
@@ -1,0 +1,95 @@
+import { Dependencies, FetchOptions, SimpleAdapter } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+import { METRIC } from "../helpers/metrics";
+import { getSolanaReceived } from "../helpers/token";
+
+// MineBTC Program: 1eotiTH2UxCpPMmtzUDGqf1b8dwM7AMKb8a2Tio51an
+// SOL Casino roll fees are charged on gross bet size. Referral cuts, when
+// present, are paid to per-user referral PDAs before the canonical vault split.
+const SOL_TREASURY = "2TU3jP7vnhPD1ksVmSMQhuAauuFCuj9magtMWDW65jEx";
+const STAKER_SOL_REWARD_VAULT = "FYnbbqMPUetvN22CDeDxAJb4SSXmqZcGEbrwVvoJREvK";
+
+const TREASURY_BUYBACK_SHARE = 0.7;
+const TREASURY_PROTOCOL_SHARE = 0.3;
+
+const fetchFees = async (options: FetchOptions) => {
+  if (!process.env.ALLIUM_API_KEY) {
+    const empty = options.createBalances();
+
+    return {
+      dailyFees: empty,
+      dailyUserFees: empty,
+      dailyRevenue: empty,
+      dailyProtocolRevenue: empty,
+      dailyHoldersRevenue: empty,
+      dailySupplySideRevenue: empty,
+    };
+  }
+
+  const [treasuryReceipts, stakingRewardReceipts] = await Promise.all([
+    getSolanaReceived({ options, target: SOL_TREASURY }),
+    getSolanaReceived({ options, target: STAKER_SOL_REWARD_VAULT }),
+  ]);
+
+  const dailyHoldersRevenue = treasuryReceipts.clone(TREASURY_BUYBACK_SHARE, METRIC.TOKEN_BUY_BACK);
+  const dailyProtocolRevenue = treasuryReceipts.clone(TREASURY_PROTOCOL_SHARE, METRIC.PROTOCOL_FEES);
+  const dailySupplySideRevenue = stakingRewardReceipts.clone(1, METRIC.STAKING_REWARDS);
+
+  const dailyRevenue = options.createBalances();
+  dailyRevenue.addBalances(dailyHoldersRevenue, METRIC.TOKEN_BUY_BACK);
+  dailyRevenue.addBalances(dailyProtocolRevenue, METRIC.PROTOCOL_FEES);
+
+  const dailyFees = options.createBalances();
+  dailyFees.addBalances(dailyHoldersRevenue, "Casino Roll Fees");
+  dailyFees.addBalances(dailyProtocolRevenue, "Casino Roll Fees");
+  dailyFees.addBalances(dailySupplySideRevenue, "Casino Roll Fees");
+
+  return {
+    dailyFees,
+    dailyUserFees: dailyFees,
+    dailyRevenue,
+    dailyProtocolRevenue,
+    dailyHoldersRevenue,
+    dailySupplySideRevenue,
+  };
+};
+
+const methodology = {
+  Fees: "SOL fees paid by users for MineBTC Casino rolls.",
+  Revenue: "SOL received by the MineBTC treasury. The economy crank allocates this treasury flow between dBTC buybacks and protocol-side treasury / market-making flows.",
+  ProtocolRevenue: "30% of treasury receipts retained for protocol-side treasury and market-making flows.",
+  HoldersRevenue: "70% of treasury receipts allocated to dBTC buybacks, benefiting holders.",
+  SupplySideRevenue: "SOL fees routed to the staking reward vault for dBTC and LP stakers.",
+};
+
+const breakdownMethodology = {
+  Fees: {
+    "Casino Roll Fees": "SOL fees paid by users for MineBTC Casino rolls.",
+  },
+  Revenue: {
+    [METRIC.TOKEN_BUY_BACK]: "70% of treasury receipts allocated to dBTC buybacks.",
+    [METRIC.PROTOCOL_FEES]: "30% of treasury receipts retained for protocol-side treasury and market-making flows.",
+  },
+  ProtocolRevenue: {
+    [METRIC.PROTOCOL_FEES]: "30% of treasury receipts retained for protocol-side treasury and market-making flows.",
+  },
+  HoldersRevenue: {
+    [METRIC.TOKEN_BUY_BACK]: "70% of treasury receipts allocated to dBTC buybacks.",
+  },
+  SupplySideRevenue: {
+    [METRIC.STAKING_REWARDS]: "SOL fees routed to the staking reward vault for dBTC and LP stakers.",
+  },
+}
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  pullHourly: true,
+  fetch: fetchFees,
+  chains: [CHAIN.SOLANA],
+  start: "2026-05-21",
+  methodology,
+  breakdownMethodology,
+  dependencies: [Dependencies.ALLIUM],
+};
+
+export default adapter;

--- a/fees/minebtc-fun.ts
+++ b/fees/minebtc-fun.ts
@@ -16,24 +16,9 @@ const CASINO_ROLL_FEES_TO_BUYBACKS = "Casino Roll Fees To Buybacks";
 const CASINO_ROLL_FEES_TO_TREASURY = "Casino Roll Fees To Treasury";
 const CASINO_ROLL_FEES_TO_STAKERS = "Casino Roll Fees To Stakers";
 
-const fetchFees = async (options: FetchOptions) => {
-  if (!process.env.ALLIUM_API_KEY) {
-    const empty = options.createBalances();
-
-    return {
-      dailyFees: empty,
-      dailyUserFees: empty,
-      dailyRevenue: empty,
-      dailyProtocolRevenue: empty,
-      dailyHoldersRevenue: empty,
-      dailySupplySideRevenue: empty,
-    };
-  }
-
-  const [treasuryReceipts, stakingRewardReceipts] = await Promise.all([
-    getSolanaReceived({ options, target: SOL_TREASURY, mints: [ADDRESSES.solana.SOL] }),
-    getSolanaReceived({ options, target: STAKER_SOL_REWARD_VAULT, mints: [ADDRESSES.solana.SOL] }),
-  ]);
+const fetch = async (options: FetchOptions) => {
+  const treasuryReceipts = await getSolanaReceived({ options, target: SOL_TREASURY, mints: [ADDRESSES.solana.SOL] });
+  const stakingRewardReceipts = await getSolanaReceived({ options, target: STAKER_SOL_REWARD_VAULT, mints: [ADDRESSES.solana.SOL] });
 
   const dailyHoldersRevenue = treasuryReceipts.clone(TREASURY_BUYBACK_SHARE, CASINO_ROLL_FEES_TO_BUYBACKS);
   const dailyProtocolRevenue = treasuryReceipts.clone(TREASURY_PROTOCOL_SHARE, CASINO_ROLL_FEES_TO_TREASURY);
@@ -88,7 +73,7 @@ const breakdownMethodology = {
 const adapter: SimpleAdapter = {
   version: 2,
   pullHourly: true,
-  fetch: fetchFees,
+  fetch,
   chains: [CHAIN.SOLANA],
   start: "2026-05-21",
   methodology,

--- a/fees/minebtc-fun.ts
+++ b/fees/minebtc-fun.ts
@@ -1,6 +1,6 @@
 import { Dependencies, FetchOptions, SimpleAdapter } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
-import { METRIC } from "../helpers/metrics";
+import ADDRESSES from "../helpers/coreAssets.json";
 import { getSolanaReceived } from "../helpers/token";
 
 // MineBTC Program: 1eotiTH2UxCpPMmtzUDGqf1b8dwM7AMKb8a2Tio51an
@@ -11,6 +11,10 @@ const STAKER_SOL_REWARD_VAULT = "FYnbbqMPUetvN22CDeDxAJb4SSXmqZcGEbrwVvoJREvK";
 
 const TREASURY_BUYBACK_SHARE = 0.7;
 const TREASURY_PROTOCOL_SHARE = 0.3;
+const CASINO_ROLL_FEES = "Casino Roll Fees";
+const CASINO_ROLL_FEES_TO_BUYBACKS = "Casino Roll Fees To Buybacks";
+const CASINO_ROLL_FEES_TO_TREASURY = "Casino Roll Fees To Treasury";
+const CASINO_ROLL_FEES_TO_STAKERS = "Casino Roll Fees To Stakers";
 
 const fetchFees = async (options: FetchOptions) => {
   if (!process.env.ALLIUM_API_KEY) {
@@ -27,22 +31,22 @@ const fetchFees = async (options: FetchOptions) => {
   }
 
   const [treasuryReceipts, stakingRewardReceipts] = await Promise.all([
-    getSolanaReceived({ options, target: SOL_TREASURY }),
-    getSolanaReceived({ options, target: STAKER_SOL_REWARD_VAULT }),
+    getSolanaReceived({ options, target: SOL_TREASURY, mints: [ADDRESSES.solana.SOL] }),
+    getSolanaReceived({ options, target: STAKER_SOL_REWARD_VAULT, mints: [ADDRESSES.solana.SOL] }),
   ]);
 
-  const dailyHoldersRevenue = treasuryReceipts.clone(TREASURY_BUYBACK_SHARE, METRIC.TOKEN_BUY_BACK);
-  const dailyProtocolRevenue = treasuryReceipts.clone(TREASURY_PROTOCOL_SHARE, METRIC.PROTOCOL_FEES);
-  const dailySupplySideRevenue = stakingRewardReceipts.clone(1, METRIC.STAKING_REWARDS);
+  const dailyHoldersRevenue = treasuryReceipts.clone(TREASURY_BUYBACK_SHARE, CASINO_ROLL_FEES_TO_BUYBACKS);
+  const dailyProtocolRevenue = treasuryReceipts.clone(TREASURY_PROTOCOL_SHARE, CASINO_ROLL_FEES_TO_TREASURY);
+  const dailySupplySideRevenue = stakingRewardReceipts.clone(1, CASINO_ROLL_FEES_TO_STAKERS);
 
   const dailyRevenue = options.createBalances();
-  dailyRevenue.addBalances(dailyHoldersRevenue, METRIC.TOKEN_BUY_BACK);
-  dailyRevenue.addBalances(dailyProtocolRevenue, METRIC.PROTOCOL_FEES);
+  dailyRevenue.addBalances(dailyHoldersRevenue, CASINO_ROLL_FEES_TO_BUYBACKS);
+  dailyRevenue.addBalances(dailyProtocolRevenue, CASINO_ROLL_FEES_TO_TREASURY);
 
   const dailyFees = options.createBalances();
-  dailyFees.addBalances(dailyHoldersRevenue, "Casino Roll Fees");
-  dailyFees.addBalances(dailyProtocolRevenue, "Casino Roll Fees");
-  dailyFees.addBalances(dailySupplySideRevenue, "Casino Roll Fees");
+  dailyFees.addBalances(dailyHoldersRevenue, CASINO_ROLL_FEES);
+  dailyFees.addBalances(dailyProtocolRevenue, CASINO_ROLL_FEES);
+  dailyFees.addBalances(dailySupplySideRevenue, CASINO_ROLL_FEES);
 
   return {
     dailyFees,
@@ -64,20 +68,20 @@ const methodology = {
 
 const breakdownMethodology = {
   Fees: {
-    "Casino Roll Fees": "SOL fees paid by users for MineBTC Casino rolls.",
+    [CASINO_ROLL_FEES]: "SOL fees paid by users for MineBTC Casino rolls.",
   },
   Revenue: {
-    [METRIC.TOKEN_BUY_BACK]: "70% of treasury receipts allocated to dBTC buybacks.",
-    [METRIC.PROTOCOL_FEES]: "30% of treasury receipts retained for protocol-side treasury and market-making flows.",
+    [CASINO_ROLL_FEES_TO_BUYBACKS]: "70% of treasury receipts allocated to dBTC buybacks.",
+    [CASINO_ROLL_FEES_TO_TREASURY]: "30% of treasury receipts retained for protocol-side treasury and market-making flows.",
   },
   ProtocolRevenue: {
-    [METRIC.PROTOCOL_FEES]: "30% of treasury receipts retained for protocol-side treasury and market-making flows.",
+    [CASINO_ROLL_FEES_TO_TREASURY]: "30% of treasury receipts retained for protocol-side treasury and market-making flows.",
   },
   HoldersRevenue: {
-    [METRIC.TOKEN_BUY_BACK]: "70% of treasury receipts allocated to dBTC buybacks.",
+    [CASINO_ROLL_FEES_TO_BUYBACKS]: "70% of treasury receipts allocated to dBTC buybacks.",
   },
   SupplySideRevenue: {
-    [METRIC.STAKING_REWARDS]: "SOL fees routed to the staking reward vault for dBTC and LP stakers.",
+    [CASINO_ROLL_FEES_TO_STAKERS]: "SOL fees routed to the staking reward vault for dBTC and LP stakers.",
   },
 }
 


### PR DESCRIPTION
## Summary
- add a `minebtc-fun` fees adapter for the current MineBTC/dBTC mainnet deployment
- track SOL receipts to the treasury and staking reward vault from MineBTC Casino rolls

## Methodology
Fees are SOL fees paid by users for MineBTC Casino rolls. Treasury receipts are split as 70% holders revenue for dBTC buybacks and 30% protocol revenue for treasury / market-making flows. Supply-side revenue is SOL routed to the staking reward vault for dBTC and LP stakers.

## Metadata / Links
- Website: https://minebtc.fun
- Twitter: https://x.com/minebtcdotfun
- Program: https://solscan.io/account/1eotiTH2UxCpPMmtzUDGqf1b8dwM7AMKb8a2Tio51an
- dBTC mint: https://solscan.io/token/CtAu3kc8cQ1jcDMmRTBsDHoPuE3sswCagQ3BuqFDC6dt
- SOL treasury: https://solscan.io/account/2TU3jP7vnhPD1ksVmSMQhuAauuFCuj9magtMWDW65jEx
- Staking SOL reward vault: https://solscan.io/account/FYnbbqMPUetvN22CDeDxAJb4SSXmqZcGEbrwVvoJREvK

## Context
This PR adds the current MineBTC deployment under the `minebtc-fun` dimensions key so it can be listed with current contracts and metadata.

## Validation
- `npm run ts-check -- --pretty false`
- `npm run test -- fees minebtc-fun`

Note: local/fork test environments without `ALLIUM_API_KEY` return empty balances so the adapter can load. DefiLlama production environments with Allium configured will query actual Solana transfers.
