### PR TITLE
[fix] Helpers-getETHReceived: exclude single-target self-transfers

### DIFF
--- a/helpers/token.ts
+++ b/helpers/token.ts
@@ -704,7 +704,7 @@ export async function getETHReceived({ options, balances, target, targets = [], 
       SELECT SUM(raw_amount) as value
       FROM ${chainKey}${tableMap[options.chain] ? '.assets.${tableMap[options.chain]}' : '.assets.native_token_transfers'}
       WHERE to_address in ${targetList} 
-      ${excludeSenders.length > 1 ? `AND from_address not in ${excludeSenderList} ` : ' '}
+      ${excludeSenders.length > 0 ? `AND from_address not in ${excludeSenderList} ` : ' '}
       AND transfer_type = 'value_transfer'
       AND block_timestamp BETWEEN TO_TIMESTAMP_NTZ(${options.startTimestamp}) AND TO_TIMESTAMP_NTZ(${options.endTimestamp})
       `
@@ -717,7 +717,7 @@ export async function getETHReceived({ options, balances, target, targets = [], 
       FROM ${getAlliumChain(options.chain)}.raw.traces
       WHERE to_address in ${targetList} 
       AND status = 1
-      ${excludeSenders.length > 1 ? `AND from_address not in ${excludeSenderList} ` : ' '}
+      ${excludeSenders.length > 0 ? `AND from_address not in ${excludeSenderList} ` : ' '}
       AND block_timestamp BETWEEN TO_TIMESTAMP_NTZ(${options.startTimestamp}) AND TO_TIMESTAMP_NTZ(${options.endTimestamp})
       `
   }


### PR DESCRIPTION

## Summary
- Fixes `getETHReceived` so single-target native token self-transfers are excluded as documented.
- Prevents fee/revenue adapters using one receiver wallet from overcounting native-token inflows sent by the same wallet.

## Changes
- Updated `helpers/token.ts` to apply `from_address NOT IN (...)` whenever the exclude sender list has at least one address.
- Applied the same condition to both Allium native transfer and raw traces query paths.
- Preserved existing multi-target behavior and `notFromSenders` filtering.
