### PR TITLE
[feat] sablier - add volume adapters for lockup and flow

### DIFF
--- a/dexs/sablier-flow.ts
+++ b/dexs/sablier-flow.ts
@@ -1,0 +1,103 @@
+import type { FetchOptions, SimpleAdapter } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+import { postURL } from "../utils/fetchURL";
+
+// Sablier Flow: rate-based recurring payment streams (payroll, grants,
+// subscriptions). Funded by deposits and topups. Volume is the value paid out to
+// recipients on chain. We sum two action categories: Withdraw (recipient pulls
+// accrued funds, recorded in `amountA` for Flow's single-party shape) and Void
+// (auto-settles the accrued-but-unwithdrawn portion to the recipient on stream
+// termination, recorded in `amountB` for the two-party shape). Refund is the
+// sender pulling back uncommitted deposits and is excluded. Data comes from
+// Sablier's public Envio HyperIndex; per-chain queries filter by chainId. Daily
+// figures are lumpy (claim/void timing) but cumulative equals true streamed value.
+
+const INDEXER = "https://indexer.hyperindex.xyz/53b7e25/v1/graphql";
+const PAGE_SIZE = 1000;
+
+const CONFIG: Record<string, { chainId: number; start: string }> = {
+  [CHAIN.ETHEREUM]: { chainId: 1, start: "2024-12-01" },
+  [CHAIN.ARBITRUM]: { chainId: 42161, start: "2024-12-01" },
+  [CHAIN.OPTIMISM]: { chainId: 10, start: "2024-12-01" },
+  [CHAIN.BASE]: { chainId: 8453, start: "2024-12-01" },
+  [CHAIN.POLYGON]: { chainId: 137, start: "2024-12-01" },
+  [CHAIN.BSC]: { chainId: 56, start: "2024-12-01" },
+  [CHAIN.XDAI]: { chainId: 100, start: "2024-12-01" },
+  [CHAIN.AVAX]: { chainId: 43114, start: "2024-12-01" },
+  [CHAIN.SCROLL]: { chainId: 534352, start: "2024-12-01" },
+  [CHAIN.LINEA]: { chainId: 59144, start: "2024-12-01" },
+  [CHAIN.BLAST]: { chainId: 81457, start: "2024-12-01" },
+  [CHAIN.ERA]: { chainId: 324, start: "2024-12-01" },
+  [CHAIN.SONIC]: { chainId: 146, start: "2024-12-01" },
+  [CHAIN.MODE]: { chainId: 34443, start: "2024-12-01" },
+  [CHAIN.ABSTRACT]: { chainId: 2741, start: "2025-01-01" },
+  [CHAIN.UNICHAIN]: { chainId: 130, start: "2025-02-01" },
+  [CHAIN.SEI]: { chainId: 1329, start: "2024-12-01" },
+  [CHAIN.BERACHAIN]: { chainId: 80094, start: "2025-02-01" },
+  [CHAIN.HYPERLIQUID]: { chainId: 999, start: "2025-02-01" },
+};
+
+interface Row {
+  id: string;
+  category: "Withdraw" | "Void";
+  amountA: string | null;
+  amountB: string | null;
+  stream: { asset_id: string } | null;
+}
+
+const buildQuery = (chainId: number, from: number, to: number, cursor: string) => `{
+  FlowAction(
+    where: {
+      category: {_in: [Withdraw, Void]}
+      chainId: {_eq: ${chainId}}
+      timestamp: {_gte: "${from}", _lt: "${to}"}
+      id: {_gt: "${cursor}"}
+    }
+    order_by: {id: asc}
+    limit: ${PAGE_SIZE}
+  ) {
+    id
+    category
+    amountA
+    amountB
+    stream { asset_id }
+  }
+}`;
+
+const fetch = async (options: FetchOptions) => {
+  const dailyVolume = options.createBalances();
+  const cfg = CONFIG[options.chain];
+  let cursor = "";
+  while (true) {
+    const query = buildQuery(cfg.chainId, options.fromTimestamp, options.toTimestamp, cursor);
+    const res: { data: { FlowAction: Row[] } } = await postURL(INDEXER, { query });
+    const rows = res.data.FlowAction;
+    if (!rows.length) break;
+    for (const r of rows) {
+      // Flow's single-party Withdraw puts the recipient amount in amountA; the
+      // two-party Void puts the recipient settlement in amountB.
+      const amount = r.category === "Withdraw" ? r.amountA : r.amountB;
+      if (!amount || amount === "0" || !r.stream?.asset_id) continue;
+      // asset_id format: `asset-<chainId>-<tokenAddress>`; take the address suffix.
+      const parts = r.stream.asset_id.split("-");
+      const token = parts[parts.length - 1];
+      dailyVolume.add(token, amount);
+    }
+    if (rows.length < PAGE_SIZE) break;
+    cursor = rows[rows.length - 1].id;
+  }
+  return { dailyVolume };
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  pullHourly: true,
+  methodology: {
+    Volume:
+      "Value paid out to Sablier Flow stream recipients per chain. Sum of recipient amounts on `FlowAction` rows where category is Withdraw (recipient pulls accrued funds, recorded in `amountA`) or Void (auto-settles the accrued-but-unwithdrawn portion to the recipient on stream termination, recorded in `amountB`). Refund actions are the sender pulling back uncommitted deposits and are excluded. Streams are pre-funded via deposits and topups. Data is sourced from Sablier's public Envio HyperIndex. Flow is the rate-based recurring-payment product used for payroll, grants, and subscriptions.",
+  },
+  adapter: CONFIG,
+  fetch,
+};
+
+export default adapter;

--- a/dexs/sablier-lockup.ts
+++ b/dexs/sablier-lockup.ts
@@ -1,0 +1,96 @@
+import type { FetchOptions, SimpleAdapter } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+import { postURL } from "../utils/fetchURL";
+
+// Sablier Lockup: pre-funded token streams with optional cliff, used predominantly
+// for project-token vesting (team / investor / airdrop allocations). Volume is the
+// value paid out to recipients on chain. We sum `amountB` across two action
+// categories: Withdraw (recipient pulls accrued funds) and Cancel (auto-settles
+// the accrued-but-unwithdrawn portion to the recipient on cancellation). Both
+// record the recipient amount in `amountB`. Data comes from Sablier's public
+// Envio HyperIndex; per-chain queries filter by chainId. Streams are pre-funded
+// at creation so every settlement is funded value. Daily figures are lumpy
+// (claim/cancel timing) but cumulative equals true streamed value over time.
+
+const INDEXER = "https://indexer.hyperindex.xyz/53b7e25/v1/graphql";
+const PAGE_SIZE = 1000;
+
+const CONFIG: Record<string, { chainId: number; start: string }> = {
+  [CHAIN.ETHEREUM]: { chainId: 1, start: "2023-07-01" },
+  [CHAIN.ARBITRUM]: { chainId: 42161, start: "2023-07-01" },
+  [CHAIN.OPTIMISM]: { chainId: 10, start: "2023-07-01" },
+  [CHAIN.BASE]: { chainId: 8453, start: "2023-08-01" },
+  [CHAIN.POLYGON]: { chainId: 137, start: "2023-07-01" },
+  [CHAIN.BSC]: { chainId: 56, start: "2023-07-01" },
+  [CHAIN.XDAI]: { chainId: 100, start: "2023-07-01" },
+  [CHAIN.AVAX]: { chainId: 43114, start: "2023-07-01" },
+  [CHAIN.SCROLL]: { chainId: 534352, start: "2023-10-01" },
+  [CHAIN.LINEA]: { chainId: 59144, start: "2023-07-01" },
+  [CHAIN.BLAST]: { chainId: 81457, start: "2024-02-01" },
+  [CHAIN.ERA]: { chainId: 324, start: "2023-07-01" },
+  [CHAIN.SONIC]: { chainId: 146, start: "2024-12-01" },
+  [CHAIN.MODE]: { chainId: 34443, start: "2024-01-01" },
+  [CHAIN.ABSTRACT]: { chainId: 2741, start: "2025-01-01" },
+  [CHAIN.UNICHAIN]: { chainId: 130, start: "2025-02-01" },
+  [CHAIN.SEI]: { chainId: 1329, start: "2024-12-01" },
+  [CHAIN.BERACHAIN]: { chainId: 80094, start: "2025-02-01" },
+  [CHAIN.HYPERLIQUID]: { chainId: 999, start: "2025-02-01" },
+};
+
+interface Row {
+  id: string;
+  amountB: string | null;
+  stream: { asset_id: string } | null;
+}
+
+const buildQuery = (chainId: number, from: number, to: number, cursor: string) => `{
+  LockupAction(
+    where: {
+      category: {_in: [Withdraw, Cancel]}
+      chainId: {_eq: ${chainId}}
+      timestamp: {_gte: "${from}", _lt: "${to}"}
+      id: {_gt: "${cursor}"}
+    }
+    order_by: {id: asc}
+    limit: ${PAGE_SIZE}
+  ) {
+    id
+    amountB
+    stream { asset_id }
+  }
+}`;
+
+const fetch = async (options: FetchOptions) => {
+  const dailyVolume = options.createBalances();
+  const cfg = CONFIG[options.chain];
+  let cursor = "";
+  while (true) {
+    const query = buildQuery(cfg.chainId, options.fromTimestamp, options.toTimestamp, cursor);
+    const res: { data: { LockupAction: Row[] } } = await postURL(INDEXER, { query });
+    const rows = res.data.LockupAction;
+    if (!rows.length) break;
+    for (const r of rows) {
+      if (!r.amountB || r.amountB === "0" || !r.stream?.asset_id) continue;
+      // asset_id format: `asset-<chainId>-<tokenAddress>`; take the address suffix.
+      const parts = r.stream.asset_id.split("-");
+      const token = parts[parts.length - 1];
+      dailyVolume.add(token, r.amountB);
+    }
+    if (rows.length < PAGE_SIZE) break;
+    cursor = rows[rows.length - 1].id;
+  }
+  return { dailyVolume };
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  pullHourly: true,
+  methodology: {
+    Volume:
+      "Value paid out to Sablier Lockup stream recipients per chain. Sum of `amountB` on `LockupAction` rows where category is Withdraw (recipient pulls accrued funds) or Cancel (auto-settles the accrued-but-unwithdrawn portion to the recipient on cancellation). Streams are pre-funded at creation so every settlement is funded value. Data is sourced from Sablier's public Envio HyperIndex. Lockup is overwhelmingly used for project-token vesting, so daily volume is dominated by vesting unlocks.",
+  },
+  adapter: CONFIG,
+  fetch,
+};
+
+export default adapter;


### PR DESCRIPTION
Adds two volume adapters for Sablier at `dexs/sablier-lockup.ts` and `dexs/sablier-flow.ts`. Both protocols are already listed on DefiLlama (category Payments, parent `sablier-finance`) with TVL adapters but no volume tracking. Legacy is intentionally out of scope here (separate older indexer; easy follow-up).

### What it measures
The value paid out to stream recipients per chain, per product. Sablier streams are pre-funded (deposit at creation for Lockup, deposits and topups for Flow), so every recipient transfer is funded value flowing through the protocol.

- **Lockup** is overwhelmingly used for project-token vesting (team / investor / airdrop allocations from major projects). Volume is the daily sum of vesting unlocks claimed by recipients plus cancel-time auto-settlements.
- **Flow** is the rate-based recurring-payment product (payroll, grants, subscriptions). Same idea: sum of recipient withdrawals plus void-time auto-settlements.

### Why this metric and not "value streamed"

- **Cliffs.** Lockup streams typically have cliffs, so "streaming started" does not imply "tokens withdrawable" until the cliff date. Integrating accruals correctly requires per-stream cliff-aware math that's bug-prone for what is fundamentally the same cumulative number as realized settlements.
- **$ value at withdrawal is the economically real number.** Accrued value is a notional ledger entry priced at accrual-day prices; the recipient only realizes that value at withdrawal, at the withdrawal-day price. For vesting protocols carrying volatile project tokens (the dominant Lockup case where tokens can swing materially between accrual and claim), valuing at the withdrawal moment is the truer picture of what was actually paid.
- **Cumulative is identical.** Counting actual recipient transfers (Withdraw + cancel-time settlements) sums to the same true streamed value over any meaningful timescale.

### Data source
Sablier's public Envio HyperIndex at `https://indexer.hyperindex.xyz/53b7e25/v1/graphql`. The indexer covers Flow + Lockup across all deployed chains, so the adapters need NO per-chain RPC for the data path: one GraphQL query per (chain, window), filtered by `chainId` and `category` + `timestamp` range, summed by token. The framework still needs a block-time lookup per chain (trivial single RPC call), which public RPCs handle reliably.

### One subtlety: the recipient-amount field differs between Lockup and Flow
Lockup actions use `amountB` for the recipient amount on both `Withdraw` (single-party) and `Cancel` (two-party with `amountA` = sender refund). Flow actions split differently: `Withdraw` (single-party) puts the recipient amount in `amountA`, while `Void` (two-party) puts the recipient settlement in `amountB`. The two adapters handle this with a small category-aware selector (see `sablier-flow.ts:fetch`).

### Implementation notes
- v2, `pullHourly: true`. No new deps. No shared-helper changes.
- Adapter shape per the in-repo idiom: top-level `fetch` and `adapter: CONFIG` (per-chain `{ chainId, start }`).
- GraphQL POST via `postURL` from `utils/fetchURL` (preferred over `graphql-request`).
- Cursor pagination by `id`.
- asset address parsed from `stream.asset_id` (format `asset-<chainId>-<address>`).

### Chain coverage
19 chains in CONFIG, intersection of (deployed by Sablier per the listing) ∩ (covered by the indexer) ∩ (DefiLlama `CHAIN` constant exists): Ethereum, Arbitrum, Optimism, Base, Polygon, BSC, Gnosis (xDai), Avalanche, Scroll, Linea, Blast, zkSync Era, Sonic, Mode, Abstract, Unichain, Sei, Berachain, Hyperliquid.

Several chains the indexer also covers (XDC, Morph, Superseed, Sophon, Chiliz) are left out for now pending verification of `CHAIN` constants and DefiLlama support; easy follow-up.

### Validation
Run on PUBLIC RPCs (`.env` disabled, CI-equivalent):
- `pnpm test dexs sablier-lockup 2026-05-08` → **$253.53k** aggregate (Base $180k, Ethereum $66k, BSC $4.75k, Optimism $1.39k, Avax $915, Mode $204, Polygon $91, Era $31; 11 chains $0 that day).
- `pnpm test dexs sablier-flow 2026-05-08` → **$8.40k** aggregate (Arbitrum $7.57k, Ethereum $840). Flow is a smaller product (~$1M TVL vs Lockup's ~$8B) so daily volume is modest.
- `pnpm run ts-check` ✓ · `pnpm run ts-check-cli` ✓

### Links
- Website: https://sablier.com
- Twitter: https://twitter.com/Sablier
- GitHub: https://github.com/sablier-labs
- Indexer (data source): https://indexer.hyperindex.xyz/53b7e25/v1/graphql
- Existing TVL adapters: [lockup](https://github.com/DefiLlama/DefiLlama-Adapters/blob/main/projects/sablier-lockup/index.js) · [flow](https://github.com/DefiLlama/DefiLlama-Adapters/blob/main/projects/sablier-flow/index.js)

"Allow edits by maintainers" enabled.
