### PR TITLE
Add Igra chain fees and active users tracking

### DIFF
--- a/factory/blockscout.ts
+++ b/factory/blockscout.ts
@@ -125,6 +125,7 @@ const protocolChainMap: Record<string, string> = {
   "lukso": CHAIN.LUKSO,
   "kasplex": CHAIN.KASPLEX,
   "gatelayer": CHAIN.GATE_LAYER,
+  "igra": CHAIN.IGRA,
 }
 
 const deadFromMap: Record<string, string> = {

--- a/helpers/blockscoutFees.ts
+++ b/helpers/blockscoutFees.ts
@@ -144,6 +144,7 @@ export const chainConfigMap: any = {
   [CHAIN.LUKSO]: { CGToken: 'lukso-token-2', explorer: 'https://explorer.execution.mainnet.lukso.network', allStatsApi: 'https://stats-explorer.execution.mainnet.lukso.network' },
   [CHAIN.KASPLEX]: { CGToken: 'kaspa', explorer: 'https://explorer.kasplex.org/node-api/proxy', start: '2026-03-28' },
   [CHAIN.GATE_LAYER]: { CGToken: 'gatechain-token', explorer: 'https://www.gatescan.org/gatelayer' },
+  [CHAIN.IGRA]: { CGToken: 'kaspa', explorer: 'https://explorer.igralabs.com', start: '2026-03-03' },
 }
 
 function getTimeString(timestamp: number) {

--- a/users/utils/blockscoutStats.ts
+++ b/users/utils/blockscoutStats.ts
@@ -35,6 +35,7 @@ const blockscoutStatsChains: Record<string, ChainConfig> = {
   hemi: { chain: CHAIN.HEMI, baseUrl: "https://explorer.hemi.xyz", version: 1 },
   "hashkey": { chain: CHAIN.HASHKEY, baseUrl: "https://hashkey.blockscout.com", version: 2 },
   hpp: { chain: CHAIN.HPP, baseUrl: "https://explorer.hpp.io", version: 1 },
+  igra: { chain: CHAIN.IGRA, baseUrl: "https://explorer.igralabs.com", statsUrl: "https://stats.explorer.igralabs.com", version: 1 },
   "immutablex": { chain: CHAIN.IMX, baseUrl: "https://explorer.immutable.com", version: 2 },
   ink: { chain: CHAIN.INK, baseUrl: "https://explorer.inkonchain.com", version: 2 },
   "iota_evm": { chain: CHAIN.IOTAEVM, baseUrl: "https://explorer.evm.iota.org", version: 2 },


### PR DESCRIPTION
Adds Igra Network (Chain ID 38833) to the blockscout fee and active users adapters.

**Fees** (`factory/blockscout.ts` + `helpers/blockscoutFees.ts`):
- Native token iKAS is 1:1 wrapped KAS, priced via `kaspa` CoinGecko ID (same as Kasplex)
- Explorer API verified: `https://explorer.igralabs.com/api?module=stats&action=totalfees&date=2026-05-30` returns correct wei values
(~7,700 iKAS/day)
- Data available since 2026-03-03

**Active users/transactions** (`users/utils/blockscoutStats.ts`):
- Blockscout stats service at `stats.explorer.igralabs.com` (separate subdomain, hence `statsUrl`)
- All three endpoints verified: `activeAccounts` (~484/day), `newAccounts` (~312/day), `newTxns` (~41K/day)