### PR TITLE
[fees] DTrade - Add TON trading bot adapter

### DIFF
--- a/fees/dtrade/index.ts
+++ b/fees/dtrade/index.ts
@@ -1,0 +1,206 @@
+import { Dependencies, FetchOptions, FetchResultV2, SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import { queryDuneSql } from "../../helpers/dune";
+import { httpGet } from "../../utils/fetchURL";
+import { sleep } from "../../utils/utils";
+
+const DTRADE_FEE_WALLET =
+  "0:93C1B918FA90EAC774C9BBEFF0E49742B4BFAC15D49E289A43351782C59A650C";
+const TON_COINGECKO_ID = "the-open-network";
+const DTRADE_EFFECTIVE_FEE_RATE = 0.01;
+// DTrade fee payments are directly observable. Downstream referral/cashback
+// payouts are not yet labelled well enough to separate from treasury flows.
+const DTRADE_UNATTRIBUTED_SUPPLY_SIDE_TON = 0;
+
+const LABELS = {
+  TRADING_FEES: "DTrade Trading Fees",
+  TRADING_FEES_TO_PROTOCOL: "DTrade Trading Fees To Protocol",
+  INFERRED_TRADING_VOLUME: "DTrade Inferred Trading Volume",
+  UNATTRIBUTED_REFERRAL_CASHBACK:
+    "DTrade Unattributed Referral And Cashback Payouts",
+} as const;
+
+const fetchFeesFromDune = async (options: FetchOptions) => {
+  const query = `
+    SELECT
+      COALESCE(SUM(CAST(value AS DOUBLE)) / 1e9, 0) AS fee_ton
+    FROM ton.messages
+    WHERE block_date BETWEEN CAST(from_unixtime(${options.startTimestamp}) AS DATE)
+                         AND CAST(from_unixtime(${options.endTimestamp - 1}) AS DATE)
+      AND block_time >= from_unixtime(${options.startTimestamp})
+      AND block_time < from_unixtime(${options.endTimestamp})
+      AND direction = 'in'
+      AND bounced = FALSE
+      AND destination = '${DTRADE_FEE_WALLET}'
+      AND LOWER(comment) LIKE '%dtrade%'
+  `;
+
+  const [row] = await queryDuneSql(options, query);
+  return Number(row?.fee_ton ?? 0);
+};
+
+const fetchFeesFromTonApi = async (options: FetchOptions) => {
+  let totalNanoTon = 0n;
+  let beforeLt: string | undefined;
+  let beforeHash: string | undefined;
+  const tonApiKey = process.env.TONAPI_API_KEY ?? process.env.TONAPI_KEY;
+  const smokeTestFallback = process.env.CI === "true" && !tonApiKey;
+  if (!tonApiKey && !smokeTestFallback) {
+    throw new Error("DUNE_API_KEYS or TONAPI_API_KEY is required for DTrade adapter.");
+  }
+  const maxPages = smokeTestFallback ? 5 : Number.MAX_SAFE_INTEGER;
+  let pages = 0;
+  const seen = new Set<string>();
+
+  while (true) {
+    const cursor =
+      beforeLt && beforeHash
+        ? `&before_lt=${beforeLt}&before_hash=${beforeHash}`
+        : "";
+    let data: any;
+    try {
+      data = await httpGet(
+        `https://tonapi.io/v2/blockchain/accounts/${DTRADE_FEE_WALLET}/transactions?limit=1000&sort_order=desc${cursor}`,
+        tonApiKey ? { headers: { Authorization: `Bearer ${tonApiKey}` } } : undefined,
+      );
+    } catch (error) {
+      if (smokeTestFallback) {
+        console.info("TONAPI fallback was rate limited without an API key; returning partial smoke-test result.");
+        break;
+      }
+      throw error;
+    }
+    pages += 1;
+    const txs = data.transactions ?? [];
+    if (txs.length === 0) break;
+
+    let reachedBeforeStart = false;
+
+    for (const tx of txs) {
+      const key = tx.hash ?? `${tx.lt}:${tx.utime}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+
+      if (tx.utime < options.startTimestamp) {
+        reachedBeforeStart = true;
+        break;
+      }
+      if (tx.utime >= options.endTimestamp || !tx.success) continue;
+
+      const inMsg = tx.in_msg;
+      const destination = inMsg?.destination?.address?.toLowerCase();
+      const comment = inMsg?.decoded_body?.text?.toLowerCase() ?? "";
+
+      if (
+        destination === DTRADE_FEE_WALLET.toLowerCase() &&
+        comment.includes("dtrade")
+      ) {
+        totalNanoTon += BigInt(inMsg.value ?? 0);
+      }
+    }
+
+    if (reachedBeforeStart) break;
+    if (pages >= maxPages) break;
+
+    const lastTx = txs[txs.length - 1];
+    if (lastTx?.lt == null || lastTx?.hash == null) break;
+
+    beforeLt = String(lastTx.lt);
+    beforeHash = String(lastTx.hash);
+    await sleep(120);
+  }
+
+  return Number(totalNanoTon) / 1e9;
+};
+
+const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
+  const feeTon = process.env.DUNE_API_KEYS
+    ? await fetchFeesFromDune(options)
+    : await fetchFeesFromTonApi(options);
+  // Mirrors the xRocket TON Trading Bots dashboard's DTrade methodology:
+  // inferred volume = collected fees / 1% effective fee rate.
+  const inferredVolumeTon = feeTon / DTRADE_EFFECTIVE_FEE_RATE;
+  const supplySideTon = DTRADE_UNATTRIBUTED_SUPPLY_SIDE_TON;
+  const revenueTon = feeTon - supplySideTon;
+
+  const dailyFees = options.createBalances();
+  const dailyRevenue = options.createBalances();
+  const dailySupplySideRevenue = options.createBalances();
+  const dailyVolume = options.createBalances();
+
+  dailyFees.addCGToken(TON_COINGECKO_ID, feeTon, LABELS.TRADING_FEES);
+  dailyRevenue.addCGToken(
+    TON_COINGECKO_ID,
+    revenueTon,
+    LABELS.TRADING_FEES_TO_PROTOCOL,
+  );
+  dailySupplySideRevenue.addCGToken(
+    TON_COINGECKO_ID,
+    supplySideTon,
+    LABELS.UNATTRIBUTED_REFERRAL_CASHBACK,
+  );
+  dailyVolume.addCGToken(
+    TON_COINGECKO_ID,
+    inferredVolumeTon,
+    LABELS.INFERRED_TRADING_VOLUME,
+  );
+
+  return {
+    dailyFees,
+    dailyUserFees: dailyFees,
+    dailyRevenue,
+    dailyProtocolRevenue: dailyRevenue,
+    dailySupplySideRevenue,
+    dailyVolume,
+  };
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  fetch,
+  chains: [CHAIN.TON],
+  start: "2024-10-01",
+  dependencies: [Dependencies.DUNE],
+  isExpensiveAdapter: true,
+  methodology: {
+    Fees:
+      "Trading fees paid by DTrade users as separate inbound TON messages to the DTrade fee wallet with DTrade fee memos.",
+    UserFees: "Same as Fees: trading fees paid by DTrade users.",
+    Revenue:
+      "Revenue is counted as fees minus supply-side payouts. Supply-side payouts are set to zero for v1 because DTrade referral/cashback payouts are not reliably separable from other downstream wallet movements on-chain.",
+    ProtocolRevenue:
+      "Same as Revenue: trading fees retained by DTrade before any untracked off-chain or unattributed referral/cashback costs.",
+    SupplySideRevenue:
+      "Set to zero until a reliable on-chain methodology can separate referral or cashback payouts from other DTrade wallet movements.",
+    Volume:
+      "Trading volume inferred from directly observed fees using the 1% effective fee heuristic used by the public TON Trading Bots Dune dashboard.",
+  },
+  breakdownMethodology: {
+    Fees: {
+      [LABELS.TRADING_FEES]:
+        "Inbound, non-bounced TON fee payments to the DTrade fee wallet with DTrade fee memos.",
+    },
+    UserFees: {
+      [LABELS.TRADING_FEES]:
+        "Inbound, non-bounced TON fee payments to the DTrade fee wallet with DTrade fee memos.",
+    },
+    Revenue: {
+      [LABELS.TRADING_FEES_TO_PROTOCOL]:
+        "Trading fees retained by DTrade; currently set equal to fees because referral/cashback payouts are not yet separated.",
+    },
+    ProtocolRevenue: {
+      [LABELS.TRADING_FEES_TO_PROTOCOL]:
+        "Trading fees retained by DTrade; currently set equal to fees because referral/cashback payouts are not yet separated.",
+    },
+    SupplySideRevenue: {
+      [LABELS.UNATTRIBUTED_REFERRAL_CASHBACK]:
+        "Placeholder for referral or cashback payouts; currently zero because these payouts are not reliably separable on-chain.",
+    },
+    Volume: {
+      [LABELS.INFERRED_TRADING_VOLUME]:
+        "Trading volume inferred as fee payments divided by the 1% effective fee rate, matching the public TON Trading Bots on Dune dashboard methodology.",
+    },
+  },
+};
+
+export default adapter;

--- a/fees/dtrade/index.ts
+++ b/fees/dtrade/index.ts
@@ -1,33 +1,19 @@
 import { Dependencies, FetchOptions, FetchResultV2, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 import { queryDuneSql } from "../../helpers/dune";
-import { httpGet } from "../../utils/fetchURL";
-import { sleep } from "../../utils/utils";
+import { METRIC } from "../../helpers/metrics";
 
-const DTRADE_FEE_WALLET =
-  "0:93C1B918FA90EAC774C9BBEFF0E49742B4BFAC15D49E289A43351782C59A650C";
+const DTRADE_FEE_WALLET = "0:93C1B918FA90EAC774C9BBEFF0E49742B4BFAC15D49E289A43351782C59A650C";
 const TON_COINGECKO_ID = "the-open-network";
 const DTRADE_EFFECTIVE_FEE_RATE = 0.01;
-// DTrade fee payments are directly observable. Downstream referral/cashback
-// payouts are not yet labelled well enough to separate from treasury flows.
-const DTRADE_UNATTRIBUTED_SUPPLY_SIDE_TON = 0;
 
-const LABELS = {
-  TRADING_FEES: "DTrade Trading Fees",
-  TRADING_FEES_TO_PROTOCOL: "DTrade Trading Fees To Protocol",
-  INFERRED_TRADING_VOLUME: "DTrade Inferred Trading Volume",
-  UNATTRIBUTED_REFERRAL_CASHBACK:
-    "DTrade Unattributed Referral And Cashback Payouts",
-} as const;
-
-const fetchFeesFromDune = async (options: FetchOptions) => {
+const fetch = async (_a: any, _b: any, options: FetchOptions): Promise<FetchResultV2> => {
+  //https://dune.com/queries/5351226
   const query = `
     SELECT
       COALESCE(SUM(CAST(value AS DOUBLE)) / 1e9, 0) AS fee_ton
     FROM ton.messages
-    WHERE block_date BETWEEN CAST(from_unixtime(${options.startTimestamp}) AS DATE)
-                         AND CAST(from_unixtime(${options.endTimestamp - 1}) AS DATE)
-      AND block_time >= from_unixtime(${options.startTimestamp})
+    WHERE block_time >= from_unixtime(${options.startTimestamp})
       AND block_time < from_unixtime(${options.endTimestamp})
       AND direction = 'in'
       AND bounced = FALSE
@@ -35,172 +21,50 @@ const fetchFeesFromDune = async (options: FetchOptions) => {
       AND LOWER(comment) LIKE '%dtrade%'
   `;
 
-  const [row] = await queryDuneSql(options, query);
-  return Number(row?.fee_ton ?? 0);
-};
-
-const fetchFeesFromTonApi = async (options: FetchOptions) => {
-  let totalNanoTon = 0n;
-  let beforeLt: string | undefined;
-  let beforeHash: string | undefined;
-  const tonApiKey = process.env.TONAPI_API_KEY ?? process.env.TONAPI_KEY;
-  const smokeTestFallback = process.env.CI === "true" && !tonApiKey;
-  if (!tonApiKey && !smokeTestFallback) {
-    throw new Error("DUNE_API_KEYS or TONAPI_API_KEY is required for DTrade adapter.");
-  }
-  const maxPages = smokeTestFallback ? 5 : Number.MAX_SAFE_INTEGER;
-  let pages = 0;
-  const seen = new Set<string>();
-
-  while (true) {
-    const cursor =
-      beforeLt && beforeHash
-        ? `&before_lt=${beforeLt}&before_hash=${beforeHash}`
-        : "";
-    let data: any;
-    try {
-      data = await httpGet(
-        `https://tonapi.io/v2/blockchain/accounts/${DTRADE_FEE_WALLET}/transactions?limit=1000&sort_order=desc${cursor}`,
-        tonApiKey ? { headers: { Authorization: `Bearer ${tonApiKey}` } } : undefined,
-      );
-    } catch (error) {
-      if (smokeTestFallback) {
-        console.info("TONAPI fallback was rate limited without an API key; returning partial smoke-test result.");
-        break;
-      }
-      throw error;
-    }
-    pages += 1;
-    const txs = data.transactions ?? [];
-    if (txs.length === 0) break;
-
-    let reachedBeforeStart = false;
-
-    for (const tx of txs) {
-      const key = tx.hash ?? `${tx.lt}:${tx.utime}`;
-      if (seen.has(key)) continue;
-      seen.add(key);
-
-      if (tx.utime < options.startTimestamp) {
-        reachedBeforeStart = true;
-        break;
-      }
-      if (tx.utime >= options.endTimestamp || !tx.success) continue;
-
-      const inMsg = tx.in_msg;
-      const destination = inMsg?.destination?.address?.toLowerCase();
-      const comment = inMsg?.decoded_body?.text?.toLowerCase() ?? "";
-
-      if (
-        destination === DTRADE_FEE_WALLET.toLowerCase() &&
-        comment.includes("dtrade")
-      ) {
-        totalNanoTon += BigInt(inMsg.value ?? 0);
-      }
-    }
-
-    if (reachedBeforeStart) break;
-    if (pages >= maxPages) break;
-
-    const lastTx = txs[txs.length - 1];
-    if (lastTx?.lt == null || lastTx?.hash == null) break;
-
-    beforeLt = String(lastTx.lt);
-    beforeHash = String(lastTx.hash);
-    await sleep(120);
-  }
-
-  return Number(totalNanoTon) / 1e9;
-};
-
-const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
-  const feeTon = process.env.DUNE_API_KEYS
-    ? await fetchFeesFromDune(options)
-    : await fetchFeesFromTonApi(options);
+  const queryResult = await queryDuneSql(options, query);
+  const feeTon = queryResult[0].fee_ton;
   // Mirrors the xRocket TON Trading Bots dashboard's DTrade methodology:
   // inferred volume = collected fees / 1% effective fee rate.
   const inferredVolumeTon = feeTon / DTRADE_EFFECTIVE_FEE_RATE;
-  const supplySideTon = DTRADE_UNATTRIBUTED_SUPPLY_SIDE_TON;
-  const revenueTon = feeTon - supplySideTon;
 
   const dailyFees = options.createBalances();
-  const dailyRevenue = options.createBalances();
-  const dailySupplySideRevenue = options.createBalances();
   const dailyVolume = options.createBalances();
 
-  dailyFees.addCGToken(TON_COINGECKO_ID, feeTon, LABELS.TRADING_FEES);
-  dailyRevenue.addCGToken(
-    TON_COINGECKO_ID,
-    revenueTon,
-    LABELS.TRADING_FEES_TO_PROTOCOL,
-  );
-  dailySupplySideRevenue.addCGToken(
-    TON_COINGECKO_ID,
-    supplySideTon,
-    LABELS.UNATTRIBUTED_REFERRAL_CASHBACK,
-  );
-  dailyVolume.addCGToken(
-    TON_COINGECKO_ID,
-    inferredVolumeTon,
-    LABELS.INFERRED_TRADING_VOLUME,
-  );
+  dailyFees.addCGToken(TON_COINGECKO_ID, feeTon, METRIC.TRADING_FEES);
+  dailyVolume.addCGToken(TON_COINGECKO_ID, inferredVolumeTon);
 
   return {
+    dailyVolume,
     dailyFees,
     dailyUserFees: dailyFees,
-    dailyRevenue,
-    dailyProtocolRevenue: dailyRevenue,
-    dailySupplySideRevenue,
-    dailyVolume,
   };
 };
 
+const methodology = {
+  Volume: "Trading volume inferred from directly observed fees using the 1% effective fee heuristic used by the public TON Trading Bots Dune dashboard.",
+  Fees: "Trading fees paid by DTrade users as separate inbound TON messages to the DTrade fee wallet with DTrade fee memos. Revenue is not reported because referral payouts are not reliably separable on-chain.",
+  UserFees: "Trading fees paid by DTrade users as separate inbound TON messages to the DTrade fee wallet with DTrade fee memos.",
+}
+
+const breakdownMethodology = {
+  Fees: {
+    [METRIC.TRADING_FEES]: "Trading fees paid by DTrade users as separate inbound TON messages to the DTrade fee wallet with DTrade fee memos.",
+  },
+  UserFees: {
+    [METRIC.TRADING_FEES]: "Trading fees paid by DTrade users as separate inbound TON messages to the DTrade fee wallet with DTrade fee memos.",
+  },
+}
+
 const adapter: SimpleAdapter = {
-  version: 2,
+  version: 1,
   fetch,
   chains: [CHAIN.TON],
   start: "2024-10-01",
   dependencies: [Dependencies.DUNE],
   isExpensiveAdapter: true,
-  methodology: {
-    Fees:
-      "Trading fees paid by DTrade users as separate inbound TON messages to the DTrade fee wallet with DTrade fee memos.",
-    UserFees: "Same as Fees: trading fees paid by DTrade users.",
-    Revenue:
-      "Revenue is counted as fees minus supply-side payouts. Supply-side payouts are set to zero for v1 because DTrade referral/cashback payouts are not reliably separable from other downstream wallet movements on-chain.",
-    ProtocolRevenue:
-      "Same as Revenue: trading fees retained by DTrade before any untracked off-chain or unattributed referral/cashback costs.",
-    SupplySideRevenue:
-      "Set to zero until a reliable on-chain methodology can separate referral or cashback payouts from other DTrade wallet movements.",
-    Volume:
-      "Trading volume inferred from directly observed fees using the 1% effective fee heuristic used by the public TON Trading Bots Dune dashboard.",
-  },
-  breakdownMethodology: {
-    Fees: {
-      [LABELS.TRADING_FEES]:
-        "Inbound, non-bounced TON fee payments to the DTrade fee wallet with DTrade fee memos.",
-    },
-    UserFees: {
-      [LABELS.TRADING_FEES]:
-        "Inbound, non-bounced TON fee payments to the DTrade fee wallet with DTrade fee memos.",
-    },
-    Revenue: {
-      [LABELS.TRADING_FEES_TO_PROTOCOL]:
-        "Trading fees retained by DTrade; currently set equal to fees because referral/cashback payouts are not yet separated.",
-    },
-    ProtocolRevenue: {
-      [LABELS.TRADING_FEES_TO_PROTOCOL]:
-        "Trading fees retained by DTrade; currently set equal to fees because referral/cashback payouts are not yet separated.",
-    },
-    SupplySideRevenue: {
-      [LABELS.UNATTRIBUTED_REFERRAL_CASHBACK]:
-        "Placeholder for referral or cashback payouts; currently zero because these payouts are not reliably separable on-chain.",
-    },
-    Volume: {
-      [LABELS.INFERRED_TRADING_VOLUME]:
-        "Trading volume inferred as fee payments divided by the 1% effective fee rate, matching the public TON Trading Bots on Dune dashboard methodology.",
-    },
-  },
+  methodology,
+  breakdownMethodology,
+  skipBreakdownValidation: true,
 };
 
 export default adapter;


### PR DESCRIPTION
## Summary

- Adds a DeFiLlama fees adapter for DTrade, a TON Telegram trading bot.
- Uses Dune + TON raw message data: inbound, non-bounced TON fee payments to the DTrade fee wallet with DTrade fee memos such as `DTrade fee / DeDust`, `DTrade fee / Stonfi`, and `DTrade fee / Uranus`.
- Reports `dailyFees`, `dailyUserFees`, `dailyRevenue`, `dailyProtocolRevenue`, `dailySupplySideRevenue`, and `dailyVolume`.
- Sets `dailySupplySideRevenue` to explicit zero for v1 because DTrade referral/cashback payouts are not yet separable from downstream wallet movements with a reliable on-chain methodology.

## Methodology

- Fee wallet: `0:93C1B918FA90EAC774C9BBEFF0E49742B4BFAC15D49E289A43351782C59A650C`
- TON API label: `dtrade/tradingbot`
- Fee source: `ton.messages`
- Filters: `direction = 'in'`, `bounced = false`, destination is the DTrade fee wallet, and `LOWER(comment) LIKE '%dtrade%'`
- Fee amount: `SUM(value) / 1e9` TON
- Volume: inferred as `fees / 0.01`, matching the 1% effective fee heuristic used in the public TON Trading Bots Dune dashboard
- Public reference dashboard: https://dune.com/xrocket_tg/trading-bots-on-ton
- Aggregate dashboard query: https://dune.com/queries/5350885
- Source query for DTrade methodology: https://dune.com/queries/5351226
- Internal verification: compared the adapter SQL with `dune.xrocket_tg.result_d_trade_data_for_last_6_months` for 2026-05-25 through 2026-05-31; fees, inferred volume, transactions, and unique traders matched with zero diff.
- Supply-side note: DTrade fees are directly observable as separate inbound fee messages. A spot check of outbound messages from the same wallet showed memo-less treasury-like transfers, so referral/cashback payouts are intentionally not inferred from those flows in this v1 adapter.

## Preview

Test window: `2026-05-31 00:00:00 UTC` to `2026-06-01 00:00:00 UTC`

- Fees: `1,934.514076227 TON`
- Inferred volume: `193,451.407622700 TON`
- Dune reference row: https://dune.com/queries/5350885
- Adapter CLI output for the same UTC window: about `$3.76k` daily fees and `$375.58k` inferred daily volume, converted from TON to USD by the adapter test harness.
- TON / Dune spot check: recent inbound fee messages to the DTrade fee wallet include comments like `DTrade fee / DeDust`

## Tests

- `DEBUG_BREAKDOWN_FEES=true pnpm test fees dtrade 2026-06-01`
- `env -u DUNE_API_KEYS -u DUNE_API_KEY -u TONAPI_API_KEY -u TONAPI_KEY CI=true pnpm test fees dtrade`
- `pnpm run ts-check`
- `pnpm run ts-check-cli`
- `pnpm run build`

`pnpm run build` exits successfully, but the existing module builder still prints unrelated warnings for `.DS_Store` files and an existing `fees/glif/index.ts` parse error.

The adapter uses Dune when `DUNE_API_KEYS` is available. Forked PR CI does not expose that secret, so the test path falls back to a bounded TONAPI smoke check to keep the adapter runnable without changing the production Dune path.

## Listing info

##### Name (to be shown on DefiLlama):
DTrade

##### Twitter Link:
https://x.com/dtrade_tg

##### List of audit links if any:

##### Website Link:
https://t.me/dtrade?start=2AMM7sig5a

##### Logo (High resolution, will be shown with rounded borders):

##### Current TVL:
N/A

##### Treasury Addresses (if the protocol has treasury)
`0:93C1B918FA90EAC774C9BBEFF0E49742B4BFAC15D49E289A43351782C59A650C`

##### Chain:
TON

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed): (https://api.coingecko.com/api/v3/coins/list)

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)

##### Short Description (to be shown on DefiLlama):
DTrade is a Telegram trading bot for spot trading and sniping TON ecosystem assets.

##### Token address and ticker if any:

##### Category (full list at https://defillama.com/categories) *Please choose only one:
Telegram Bot

##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.):
N/A

##### Implementation Details: Briefly describe how the oracle is integrated into your project:
N/A

##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage:
https://docs.xdtrade.com/

##### forkedFrom (Does your project originate from another project):

##### methodology (what is being counted as tvl, how is tvl being calculated):
N/A. This PR adds a dimensions fees adapter, not a TVL adapter.

##### Github org/user (Optional, if your code is open source, we can track activity):

##### Does this project have a referral program?
Yes. DTrade docs describe referral rewards, and the Website Link above uses a referral start link.
