### PR TITLE
update USTB and USCC fee methodology text (Invesco / Bitwise)

### DIFF
--- a/fees/superstate-uscc/index.ts
+++ b/fees/superstate-uscc/index.ts
@@ -52,8 +52,8 @@ const fetch = async (options: FetchOptions) => {
 };
 
 const methodology = {
-    Fees: "Total Yields from Superstate USCC basis trading",
-    Revenue: "0.75% Annual Management fee collected by superstate",
+    Fees: "Total Yields from Bitwise USCC basis trading",
+    Revenue: "0.75% Annual Management fee collected by Bitwise",
 };
 
 const adapter: SimpleAdapter = {

--- a/fees/superstate/index.ts
+++ b/fees/superstate/index.ts
@@ -50,7 +50,7 @@ const fetch = async (options: FetchOptions) => {
 
 const methodology = {
   Fees: "Total Yields from RWA Yields",
-  Revenue: "0.15% Annual Management fee collected by superstate",
+  Revenue: "0.15% Annual Management fee collected by Invesco",
 };
 
 const adapter: SimpleAdapter = {


### PR DESCRIPTION
Updates the displayed fee/revenue methodology text for the two Superstate funds following their sponsor rebrand:
  
- fees/superstate-uscc: "Superstate" → "Bitwise" (Fees + Revenue)
- fees/superstate: Revenue "superstate" → "Invesco"

Methodology text only — no change to the fee/revenue calculation logic, rates, or adapter behavior.