### PR TITLE
fees(claimrush): add Mine takeover royalty stream

### DIFF
--- a/fees/claimrush.ts
+++ b/fees/claimrush.ts
@@ -1,0 +1,92 @@
+import { FetchOptions, SimpleAdapter } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+
+// ClaimRush — ShareholderRoyalties (Base mainnet)
+// Every Mine takeover routes ETH to this contract, which then crystallises
+// each veCLAIM locker's pro-rata share. The on-chain emission of
+// `ShareholderTakeoverAllocation(reignId, amountEth)` represents the gross
+// ETH allocated to veCLAIM holders for that takeover.
+const SHAREHOLDER_ROYALTIES = "0x74eDd39E3B220691364Df5024C3dA4FDC64d2a91";
+
+const SHAREHOLDER_TAKEOVER_ALLOCATION =
+  "event ShareholderTakeoverAllocation(uint256 indexed reignId, uint256 amountEth)";
+
+const fetch = async (options: FetchOptions) => {
+  const dailyFees = options.createBalances();
+  const dailyUserFees = options.createBalances();
+  const dailyRevenue = options.createBalances();
+  const dailyHoldersRevenue = options.createBalances();
+
+  const logs = await options.getLogs({
+    target: SHAREHOLDER_ROYALTIES,
+    eventAbi: SHAREHOLDER_TAKEOVER_ALLOCATION,
+  });
+
+  // Sum the amountEth field across every takeover in the window.
+  // `onTakeover` and the retry path `addPendingShareholderETH` each emit
+  // exactly once per ETH allocation: a failed onTakeover reverts the event
+  // along with its state changes, MineCore buffers the unsent wei in its
+  // own `shareholderEthPending` accumulator, and the same wei resurfaces
+  // in a later `addPendingShareholderETH` emission (with reignId=0).
+  // Both functions are `onlyMineCore`, and MineCore guards both call sites
+  // against zero-value calls (`if (amountEth == 0) return;` for the happy
+  // path; `if (pending == 0) return;` for the retry). The contract's
+  // `msg.value == 0` branches still exist for completeness and emit a
+  // zero-amount event; the `> 0n` filter below skips those defensively.
+  let totalWei = 0n;
+  for (const log of logs) {
+    const amount = BigInt(log.amountEth ?? 0);
+    if (amount > 0n) totalWei += amount;
+  }
+
+  if (totalWei > 0n) {
+    dailyFees.addGasToken(totalWei, "Takeover Royalties");
+    dailyUserFees.addGasToken(totalWei, "Takeover Royalties");
+    dailyRevenue.addGasToken(totalWei, "Takeover Royalties");
+    dailyHoldersRevenue.addGasToken(totalWei, "Takeover Royalties");
+  }
+
+  return {
+    dailyFees,
+    dailyUserFees,
+    dailyRevenue,
+    dailyHoldersRevenue,
+  };
+};
+
+const methodology = {
+  Fees: "ETH paid as royalties on every Mine takeover. Gross protocol revenue is the sum of every `ShareholderTakeoverAllocation.amountEth` emitted by the ShareholderRoyalties contract.",
+  Revenue: "Same as Fees. The protocol retains no margin on the royalty stream — every wei is forwarded to veCLAIM holders pro-rata to their veCLAIM weight.",
+  HoldersRevenue: "100% of takeover royalty ETH is allocated to veCLAIM holders pro-rata to their veCLAIM weight at the time of allocation. Holders claim accrued ETH directly from the ShareholderRoyalties contract.",
+  UserFees: "Users (the new King of each takeover) pay the protocol-determined takeover price; the royalty fraction of that payment is what this adapter reports.",
+};
+
+const breakdownMethodology = {
+  Fees: {
+    "Takeover Royalties":
+      "ETH allocated to ShareholderRoyalties by MineCore on each successful takeover (via `onTakeover` and the `addPendingShareholderETH` retry path).",
+  },
+  UserFees: {
+    "Takeover Royalties":
+      "Same value — the new King of each takeover pays the royalty fraction directly out of `pricePaid`.",
+  },
+  Revenue: {
+    "Takeover Royalties":
+      "Identical to Fees — no protocol-side cut is taken before distribution.",
+  },
+  HoldersRevenue: {
+    "Takeover Royalties":
+      "ETH distributed to veCLAIM holders, indexed against the takeover-time shareholder set.",
+  },
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  fetch,
+  start: "2026-05-19",
+  chains: [CHAIN.BASE],
+  methodology,
+  breakdownMethodology,
+};
+
+export default adapter;

--- a/fees/claimrush.ts
+++ b/fees/claimrush.ts
@@ -82,6 +82,7 @@ const breakdownMethodology = {
 
 const adapter: SimpleAdapter = {
   version: 2,
+  pullHourly: true,
   fetch,
   start: "2026-05-19",
   chains: [CHAIN.BASE],

--- a/fees/claimrush.ts
+++ b/fees/claimrush.ts
@@ -56,7 +56,7 @@ const fetch = async (options: FetchOptions) => {
 
 const methodology = {
   Fees: "ETH paid as royalties on every Mine takeover. Gross protocol revenue is the sum of every `ShareholderTakeoverAllocation.amountEth` emitted by the ShareholderRoyalties contract.",
-  Revenue: "Same as Fees. The protocol retains no margin on the royalty stream — every wei is forwarded to veCLAIM holders pro-rata to their veCLAIM weight.",
+  Revenue: "ETH paid as royalties on every Mine takeover.",
   HoldersRevenue: "100% of takeover royalty ETH is allocated to veCLAIM holders pro-rata to their veCLAIM weight at the time of allocation. Holders claim accrued ETH directly from the ShareholderRoyalties contract.",
   UserFees: "Users (the new King of each takeover) pay the protocol-determined takeover price; the royalty fraction of that payment is what this adapter reports.",
 };
@@ -68,15 +68,15 @@ const breakdownMethodology = {
   },
   UserFees: {
     "Takeover Royalties":
-      "Same value — the new King of each takeover pays the royalty fraction directly out of `pricePaid`.",
+      "ETH allocated to ShareholderRoyalties by MineCore on each successful takeover (via `onTakeover` and the `addPendingShareholderETH` retry path).",
   },
   Revenue: {
     "Takeover Royalties":
-      "Identical to Fees — no protocol-side cut is taken before distribution.",
+      "ETH allocated to ShareholderRoyalties by MineCore on each successful takeover (via `onTakeover` and the `addPendingShareholderETH` retry path).",
   },
   HoldersRevenue: {
     "Takeover Royalties":
-      "ETH distributed to veCLAIM holders, indexed against the takeover-time shareholder set.",
+      "ETH royalties distributed to veCLAIM holders, indexed against the takeover-time shareholder set.",
   },
 };
 


### PR DESCRIPTION
## Adapter summary

Adds a `fees` adapter for **ClaimRush** on **Base** (`fees/claimrush.ts`).

ClaimRush is a competitive on-chain "King of the Hill" yield protocol on Base. Every Mine takeover routes ETH to the `ShareholderRoyalties` contract (`0x74eDd39E3B220691364Df5024C3dA4FDC64d2a91`), which crystallises each veCLAIM holder's pro-rata share. The adapter sums the ETH allocated to that contract across each day window and reports it under `dailyFees`, `dailyUserFees`, `dailyRevenue`, and `dailyHoldersRevenue`.

This is the fee surface that complements the TVL adapter merged in #19495. With both surfaces live, the protocol page can render the veCLAIM APR (ETH royalty stream / locked CLAIM in `staking`) on the yields page — the metric users actually care about for a yield-bearing ve-position.

## Income statement model

| dimension | value | reasoning |
|---|---|---|
| `dailyFees` | sum of `ShareholderTakeoverAllocation.amountEth` | Gross protocol revenue — total ETH allocated to the royalty contract in the window |
| `dailyUserFees` | same value | The new King of each takeover pays the royalty fraction directly out of `pricePaid` |
| `dailyRevenue` | same value | Protocol retains no margin; `dailyRevenue = dailyFees − dailySupplySideRevenue` and supplySideRevenue is `0` (no separate LP/lender supply side — the lockers themselves are both the supply side and the holders) |
| `dailyHoldersRevenue` | same value | 100% of the royalty stream is forwarded to veCLAIM holders pro-rata to their veCLAIM weight at allocation time |

`dailyProtocolRevenue` and `dailySupplySideRevenue` are omitted (both zero — no treasury cut, no separate supply-side stream).

## Data source

Single event emitted by `ShareholderRoyalties` on Base:

```solidity
event ShareholderTakeoverAllocation(uint256 indexed reignId, uint256 amountEth);
```

Emitted from two `onlyMineCore` call sites in the contract:
- `onTakeover(reignId)` — happy path on each successful takeover
- `addPendingShareholderETH(reignId)` — retry path when the initial allocation reverted (e.g., ve checkpoint stale); accumulates failed pendings on MineCore side, then re-pushes via `retryPushShareholderEth()` with `reignId=0`

Each ETH allocation is emitted **exactly once** across the pair — a failed `onTakeover` reverts both the event and the `pendingShareholderETH += msg.value` write atomically (the failed path is caught by `_tryRoyaltiesTakeover`'s try/catch in MineCore, no event emitted), and the same wei resurfaces in a later `addPendingShareholderETH` emission. No deduplication required.

There is no `receive()` or `fallback()` on `ShareholderRoyalties`, so these two `onlyMineCore` functions are the only ETH entry paths. Adapter therefore captures 100% of distributed ETH.

Implementation:

```ts
const logs = await options.getLogs({
  target: SHAREHOLDER_ROYALTIES,
  eventAbi: "event ShareholderTakeoverAllocation(uint256 indexed reignId, uint256 amountEth)",
});
let totalWei = 0n;
for (const log of logs) {
  const amount = BigInt(log.amountEth ?? 0);
  if (amount > 0n) totalWei += amount;
}
dailyFees.addGasToken(totalWei, "Takeover Royalties");  // + 3 more buckets
```

Wei → USD conversion via DefiLlama's native-gas-token pricer (`addGasToken` resolves to ETH on Base).

## Local smoke test

```
$ pnpm test fees claimrush
🦙 Running CLAIMRUSH adapter 🦙
---------------------------------------------------
Start Date: Sun, 31 May 2026 10:52:27 GMT
End Date:   Mon, 01 Jun 2026 10:52:27 GMT
---------------------------------------------------

BASE 👇
Backfill start time: 19/5/2026
Daily fees:           11.01 k
Daily user fees:      11.01 k
Daily revenue:        11.01 k
Daily holders revenue: 11.01 k
End timestamp: 1780311146 (2026-06-01T10:52:26.000Z)
```

## On-chain cross-check

Manual `cast logs` sum across the identical 24 h window the adapter just ran (block range `46717700` → `46760900` on Base mainnet):

| metric | value |
|---|---|
| `ShareholderTakeoverAllocation` events in window | 48 |
| Zero-amount events (would be filtered by adapter) | 0 |
| ETH summed via raw event `data` field | 5.570424 ETH |
| Adapter `dailyFees` for same window | $11.01 k |
| Implied ETH price | ~$1,977/ETH (matches the DefiLlama price oracle) |

The adapter is a pure sum-of-event-amounts — no off-chain inputs, no API dependencies, no math beyond `BigInt` addition — so the on-chain sum and the adapter output are identical by construction. The cross-check additionally confirms (a) the `amountEth` field parses correctly out of the ABI and (b) the `msg.value == 0` defensive filter is never triggered in practice (the upstream MineCore guard `if (amountEth == 0) return;` runs before the call, and `addPendingShareholderETH` is guarded by `if (pending == 0) return;` on the retry path).

## Methodology fields

```ts
methodology = {
  Fees:           "ETH paid as royalties on every Mine takeover. Gross protocol revenue is the sum of every `ShareholderTakeoverAllocation.amountEth` emitted by the ShareholderRoyalties contract.",
  UserFees:       "Users (the new King of each takeover) pay the protocol-determined takeover price; the royalty fraction of that payment is what this adapter reports.",
  Revenue:        "Same as Fees. The protocol retains no margin on the royalty stream — every wei is forwarded to veCLAIM holders pro-rata to their veCLAIM weight.",
  HoldersRevenue: "100% of takeover royalty ETH is allocated to veCLAIM holders pro-rata to their veCLAIM weight at the time of allocation. Holders claim accrued ETH directly from the ShareholderRoyalties contract.",
};

breakdownMethodology = {
  Fees:           { "Takeover Royalties": "ETH allocated to ShareholderRoyalties by MineCore on each successful takeover (via `onTakeover` and the `addPendingShareholderETH` retry path)." },
  UserFees:       { "Takeover Royalties": "Same value — the new King of each takeover pays the royalty fraction directly out of `pricePaid`." },
  Revenue:        { "Takeover Royalties": "Identical to Fees — no protocol-side cut is taken before distribution." },
  HoldersRevenue: { "Takeover Royalties": "ETH distributed to veCLAIM holders, indexed against the takeover-time shareholder set." },
};
```

## References

- TVL adapter (merged): #19495
- Protocol page: https://claimru.sh
- Public source: https://github.com/claimrush/claimrush
- Security policy: https://github.com/claimrush/claimrush/blob/main/SECURITY.md

## Checklist

- [x] Adapter compiles and runs cleanly under `pnpm test fees claimrush` and `tsc --noEmit -p tsconfig.json` (no `fees/claimrush.ts` diagnostics)
- [x] Single-event sum confirmed against on-chain `cast logs` (48 events, 5.5704 ETH, $11.01k @ ~$1,977/ETH; cross-check at HEAD)
- [x] Every `.add()` label appears in `breakdownMethodology` (single label: `"Takeover Royalties"`)
- [x] Every `breakdownMethodology` label corresponds to a `.add()` call
- [x] Every `methodology` key has a matching return-value bucket
- [x] `dailyRevenue ≤ dailyFees` (equal)
- [x] `dailyHoldersRevenue ≤ dailyFees` (equal)
- [x] `dailyUserFees ≤ dailyFees` (equal)
- [x] Adapter has `start: "2026-05-19"` (UTC day of the `ShareholderRoyalties` deploy block at `46183959` / `2026-05-19T02:21:05Z`)
- [x] No `receive()` / `fallback()` on the source contract — `getLogs` captures 100% of ETH inflows
- [x] Retry path (`addPendingShareholderETH`) verified to emit exactly once per allocation, no double-counting
- [x] `maintainer_can_modify: true` (set at PR creation time)

cc @FelixBruguera — follow-up to the merged TVL adapter #19495.
