### PR TITLE
feat: add Perpl volume + fees adapters (Monad)

### DIFF
--- a/dexs/perpl.ts
+++ b/dexs/perpl.ts
@@ -1,0 +1,59 @@
+import { Adapter, FetchOptions } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+
+// Perpl Exchange (UUPS proxy) on Monad mainnet
+const EXCHANGE = "0x34B6552d57a35a1D042CcAe1951BD1C370112a6F";
+
+// Per-market PNS / LNS decimal scales (from on-chain Perpetual config).
+// Notional USD per fill = (pricePNS / PRICE_SCALE) * (lotLNS / SIZE_SCALE).
+const PRICE_SCALE: Record<number, number> = {
+  1: 10,           // BTC
+  10: 1_000_000,   // MON
+  20: 100,         // ETH
+  30: 100,         // SOL
+  40: 10_000,      // HYPE
+};
+const SIZE_SCALE: Record<number, number> = {
+  1: 100_000,      // BTC
+  10: 1,           // MON
+  20: 1_000,       // ETH
+  30: 1_000,       // SOL
+  40: 100,         // HYPE
+};
+
+const fetch = async ({ getLogs }: FetchOptions) => {
+  // MakerOrderFilled fires once per fill on the maker side and carries perpId
+  // for per-market scaling. Each match emits exactly one MakerOrderFilled and
+  // one TakerOrderFilled with identical notional, so summing the maker side
+  // gives one-sided exchange volume (the convention DefiLlama uses).
+  const logs = await getLogs({
+    target: EXCHANGE,
+    eventAbi:
+      "event MakerOrderFilled(uint256 perpId, uint256 accountId, uint256 orderId, uint256 pricePNS, uint256 lotLNS, uint256 feeCNS, uint256 lockedBalanceCNS, int256 amountCNS, uint256 balanceCNS)",
+  });
+
+  let dailyVolume = 0;
+  for (const log of logs) {
+    const perpId = Number(log.perpId);
+    const ps = PRICE_SCALE[perpId];
+    const ss = SIZE_SCALE[perpId];
+    if (!ps || !ss) continue; // unknown market — skip rather than mis-scale
+    const notional = (Number(log.pricePNS) / ps) * (Number(log.lotLNS) / ss);
+    dailyVolume += notional;
+  }
+
+  return { dailyVolume };
+};
+
+const adapter: Adapter = {
+  version: 2,
+  chains: [CHAIN.MONAD],
+  fetch,
+  start: "2026-02-15",
+  methodology: {
+    Volume:
+      "Sum of notional traded on Perpl perpetual futures across BTC, MON, ETH, SOL, HYPE markets. Computed from MakerOrderFilled events emitted by the Exchange contract (0x34B6...12a6F), decoded with each market's pricePNS / lotLNS decimal scales. One-sided (per DefiLlama convention).",
+  },
+};
+
+export default adapter;

--- a/fees/perpl.ts
+++ b/fees/perpl.ts
@@ -1,0 +1,75 @@
+import { Adapter, FetchOptions } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+import { METRIC } from "../helpers/metrics";
+
+// Perpl Exchange (UUPS proxy) on Monad mainnet
+const EXCHANGE = "0x34B6552d57a35a1D042CcAe1951BD1C370112a6F";
+
+// AUSD is 6-decimal; feeCNS values are AUSD in CNS units.
+
+const fetch = async ({ getLogs, createBalances }: FetchOptions) => {
+  const dailyFees = createBalances();
+
+  // Each match emits one MakerOrderFilled (maker-side fee) and one
+  // TakerOrderFilled (taker-side fee). Summing feeCNS across both gives
+  // total fees paid by users on Perpl.
+  const makerLogs = await getLogs({
+    target: EXCHANGE,
+    eventAbi:
+      "event MakerOrderFilled(uint256 perpId, uint256 accountId, uint256 orderId, uint256 pricePNS, uint256 lotLNS, uint256 feeCNS, uint256 lockedBalanceCNS, int256 amountCNS, uint256 balanceCNS)",
+  });
+  const takerLogs = await getLogs({
+    target: EXCHANGE,
+    eventAbi:
+      "event TakerOrderFilled(uint256 entryPricePNS, uint256 collatPricePNS, uint256 pnlPricePNS, uint256 lotLNS, uint256 feeCNS, int256 amountCNS, uint256 balanceCNS)",
+  });
+
+  for (const log of makerLogs) {
+    dailyFees.addUSDValue(Number(log.feeCNS) / 1e6, METRIC.TRADING_FEES);
+  }
+  for (const log of takerLogs) {
+    dailyFees.addUSDValue(Number(log.feeCNS) / 1e6, METRIC.TRADING_FEES);
+  }
+
+  // The Exchange routes fees 50/50 between (a) the per-perp insurance fund and
+  // (b) the protocol balance — both are protocol-owned reserves. There are no
+  // external LP fee shares to net out, so Revenue = Fees.
+  return {
+    dailyFees,
+    dailyRevenue: dailyFees,
+    dailyProtocolRevenue: dailyFees,
+    dailySupplySideRevenue: 0,
+  };
+};
+
+const breakdownMethodology = {
+  Fees: {
+    [METRIC.TRADING_FEES]:
+      "Maker fee (~1.6 bps) and taker fee (~2.8 bps) on filled volume across BTC, MON, ETH, SOL, HYPE perpetual futures.",
+  },
+  Revenue: {
+    [METRIC.TRADING_FEES]:
+      "100% of trading fees accrue to the protocol; the Exchange splits each fee 50/50 between the per-perp insurance fund and the protocol balance.",
+  },
+  ProtocolRevenue: {
+    [METRIC.TRADING_FEES]:
+      "All trading fees end up in protocol-controlled balances (insurance fund + protocol balance). No external LPs.",
+  },
+};
+
+const adapter: Adapter = {
+  version: 2,
+  chains: [CHAIN.MONAD],
+  fetch,
+  start: "2026-02-15",
+  methodology: {
+    Fees: "Trading fees paid by users (maker + taker) on Perpl perpetual futures, summed from MakerOrderFilled.feeCNS and TakerOrderFilled.feeCNS emitted by the Exchange contract (0x34B6...12a6F). AUSD is the 6-decimal collateral token.",
+    Revenue:
+      "100% of trading fees go to the protocol. The Exchange routes each fee 50/50 between the per-perp insurance fund and the protocol balance, both of which are protocol-owned reserves. No external liquidity providers.",
+    ProtocolRevenue:
+      "Same as Revenue. Internal split (50% insurance / 50% protocol balance) is accounting only — both are protocol reserves.",
+  },
+  breakdownMethodology,
+};
+
+export default adapter;


### PR DESCRIPTION
## Summary

Adds dimension adapters for [Perpl](https://perpl.xyz/), a perpetual futures DEX on Monad mainnet. Companion to the TVL adapter at `DefiLlama-Adapters/projects/perpl/index.js` (merged in PR #18382).

### `dexs/perpl.ts` — Volume adapter

Sums one-sided notional traded across BTC, MON, ETH, SOL, HYPE perpetual markets from the Exchange contract's `MakerOrderFilled` event log, decoded with each market's `pricePNS` / `lotLNS` decimal scales.

### `fees/perpl.ts` — Fees + Revenue adapter

Sums `feeCNS` paid by users from both `MakerOrderFilled` (maker side) and `TakerOrderFilled` (taker side) events. AUSD is 6-decimal.

Trading fees are routed by the Exchange contract 50/50 between (a) per-perp insurance fund and (b) the protocol balance. Both are protocol-owned reserves — there are no external LP fee shares to net out, so:

- `dailyFees` = maker fees + taker fees
- `dailyRevenue` = `dailyFees` (100% to protocol)
- `dailyProtocolRevenue` = `dailyFees`
- `dailySupplySideRevenue` = 0

## Source references

- Exchange contract (UUPS proxy): `0x34B6552d57a35a1D042CcAe1951BD1C370112a6F` (monadscan: https://monadscan.com/address/0x34B6552d57a35a1D042CcAe1951BD1C370112a6F)
- AUSD collateral: `0x00000000eFE302BEAA2b3e6e1b18d08D69a9012a` (Agora canonical deploy)
- Event signatures decoded inline; verified against on-chain bytecode

## Test plan

- [x] `pnpm test dexs perpl 2026-05-14` — peak BTC-volume day, expect ~$4.4M from ClickHouse cross-check
- [x] `pnpm test fees perpl 2026-05-14` — peak fees day, expect ~$1.5–2k
- [x] Cumulative fee total reproduces the reference figure of ~$54,957 (verified via independent ClickHouse aggregation)
- [x] `pnpm ts-check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
