### PR TITLE
[fix] Aori: gas token mispricing error

### DIFF
--- a/fees/aori/index.ts
+++ b/fees/aori/index.ts
@@ -1,5 +1,6 @@
 import { FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
+import ADDRESSES from "../../helpers/coreAssets.json";
 
 const chainConfig: any = {
     [CHAIN.ETHEREUM]: {
@@ -66,8 +67,11 @@ const FILL_EVENT = `event Fill(
 )`;
 
 const eidToChain = new Map(
-    Object.entries(chainConfig).map(([chainName, config]: [string, any]) => [config.eid, chainName])
+    Object.entries(chainConfig).map(([chainName, config]: [string, any]) => [config.eid.toString(), chainName])
 )
+
+const normalizeToken = (token: string) =>
+    token.toLowerCase() === ADDRESSES.GAS_TOKEN_2 ? ADDRESSES.null : token;
 
 async function fetch(options: FetchOptions) {
     const fillLogs = await options.getLogs({
@@ -80,9 +84,9 @@ async function fetch(options: FetchOptions) {
 
     fillLogs.forEach((log: any) => {
         const { inputToken, inputAmount, outputToken, outputAmount, srcEid } = log.order;
-        const srcChain = eidToChain.get(srcEid);
-        if (srcChain) inputs.add(`${srcChain}:${inputToken}`, inputAmount, { skipChain: true })
-        outputs.add(outputToken, outputAmount)
+        const srcChain = eidToChain.get(srcEid.toString());
+        if (srcChain) inputs.add(`${srcChain}:${normalizeToken(inputToken)}`, inputAmount, { skipChain: true })
+        outputs.add(normalizeToken(outputToken), outputAmount)
     })
 
     const dailyFees = inputs.clone();

--- a/fees/aori/index.ts
+++ b/fees/aori/index.ts
@@ -71,7 +71,7 @@ const eidToChain = new Map(
 )
 
 const normalizeToken = (token: string) =>
-    token.toLowerCase() === ADDRESSES.GAS_TOKEN_2 ? ADDRESSES.null : token.toLowerCase();;
+    token.toLowerCase() === ADDRESSES.GAS_TOKEN_2 ? ADDRESSES.null : token.toLowerCase();
 
 async function fetch(options: FetchOptions) {
     const fillLogs = await options.getLogs({

--- a/fees/aori/index.ts
+++ b/fees/aori/index.ts
@@ -71,7 +71,7 @@ const eidToChain = new Map(
 )
 
 const normalizeToken = (token: string) =>
-    token.toLowerCase() === ADDRESSES.GAS_TOKEN_2 ? ADDRESSES.null : token;
+    token.toLowerCase() === ADDRESSES.GAS_TOKEN_2 ? ADDRESSES.null : token.toLowerCase();;
 
 async function fetch(options: FetchOptions) {
     const fillLogs = await options.getLogs({
@@ -89,8 +89,8 @@ async function fetch(options: FetchOptions) {
         outputs.add(normalizeToken(outputToken), outputAmount)
     })
 
-    const dailyFees = inputs.clone();
-    dailyFees.subtract(outputs);
+    const dailyFees = inputs.clone(1, "Bridge Fees");
+    dailyFees.subtract(outputs, "Bridge Fees");
 
     return {
         dailyFees,
@@ -105,12 +105,25 @@ const methodology = {
     ProtocolRevenue: "All the revenue goes to the protocol.",
 }
 
+const breakdownMethodology = {
+    Fees: {
+        "Bridge Fees": "Bridge fees paid by Aori users, calculated as the difference between input and output amounts.",
+    },
+    Revenue: {
+        "Bridge Fees": "All bridge fees are retained by Aori.",
+    },
+    ProtocolRevenue: {
+        "Bridge Fees": "All bridge fees are retained by Aori.",
+    },
+}
+
 const adapter: SimpleAdapter = {
     version: 2,
     pullHourly: true,
     fetch,
     adapter: chainConfig,
     methodology,
+    breakdownMethodology,
     allowNegativeValue: true,
 }
 


### PR DESCRIPTION
## Summary
- Fixes Aori fee pricing for native gas-token fills that use the `0xeeee...` placeholder.
- Keeps the existing input-minus-output methodology unchanged.

## Changes
- Updated `fees/aori` to normalize `ADDRESSES.GAS_TOKEN_2` to `ADDRESSES.null` before adding token balances.
- Uses the shared `helpers/coreAssets.json` constants instead of local native-token constants.
- Makes LayerZero EID chain lookup tolerant by keying EIDs as strings.