### PR TITLE
fees(claimrush): income statement compliance — route 100% to supply side

### DIFF
--- a/fees/claimrush.ts
+++ b/fees/claimrush.ts
@@ -15,6 +15,7 @@ const fetch = async (options: FetchOptions) => {
   const dailyFees = options.createBalances();
   const dailyUserFees = options.createBalances();
   const dailyRevenue = options.createBalances();
+  const dailySupplySideRevenue = options.createBalances();
   const dailyHoldersRevenue = options.createBalances();
 
   const logs = await options.getLogs({
@@ -42,7 +43,11 @@ const fetch = async (options: FetchOptions) => {
   if (totalWei > 0n) {
     dailyFees.addGasToken(totalWei, "Takeover Royalties");
     dailyUserFees.addGasToken(totalWei, "Takeover Royalties");
-    dailyRevenue.addGasToken(totalWei, "Takeover Royalties");
+    // dailyRevenue intentionally stays at 0: the protocol retains no
+    // margin on the royalty stream. 100% of the fee flows to veCLAIM
+    // holders as supply-side revenue, satisfying DefiLlama's income
+    // statement invariant dailyRevenue == dailyFees - dailySupplySideRevenue.
+    dailySupplySideRevenue.addGasToken(totalWei, "Takeover Royalties");
     dailyHoldersRevenue.addGasToken(totalWei, "Takeover Royalties");
   }
 
@@ -50,15 +55,17 @@ const fetch = async (options: FetchOptions) => {
     dailyFees,
     dailyUserFees,
     dailyRevenue,
+    dailySupplySideRevenue,
     dailyHoldersRevenue,
   };
 };
 
 const methodology = {
-  Fees: "ETH paid as royalties on every Mine takeover. Gross protocol revenue is the sum of every `ShareholderTakeoverAllocation.amountEth` emitted by the ShareholderRoyalties contract.",
-  Revenue: "ETH paid as royalties on every Mine takeover.",
-  HoldersRevenue: "100% of takeover royalty ETH is allocated to veCLAIM holders pro-rata to their veCLAIM weight at the time of allocation. Holders claim accrued ETH directly from the ShareholderRoyalties contract.",
+  Fees: "ETH paid as royalties on every Mine takeover. Gross fee volume is the sum of every `ShareholderTakeoverAllocation.amountEth` emitted by the ShareholderRoyalties contract.",
   UserFees: "Users (the new King of each takeover) pay the protocol-determined takeover price; the royalty fraction of that payment is what this adapter reports.",
+  Revenue: "Zero. The protocol retains no margin on the royalty stream — every wei is forwarded to veCLAIM holders as supply-side revenue.",
+  SupplySideRevenue: "100% of takeover royalty ETH is distributed to veCLAIM holders — the supply side that locks $CLAIM into voting-escrow positions and provides the royalty-bearing ve-position.",
+  HoldersRevenue: "Same value as SupplySideRevenue. veCLAIM holders are the supply side in ClaimRush's ve-tokenomics: locking $CLAIM is the productive activity that earns royalty ETH.",
 };
 
 const breakdownMethodology = {
@@ -68,11 +75,15 @@ const breakdownMethodology = {
   },
   UserFees: {
     "Takeover Royalties":
-      "ETH allocated to ShareholderRoyalties by MineCore on each successful takeover (via `onTakeover` and the `addPendingShareholderETH` retry path).",
+      "Same value — the new King of each takeover pays the royalty fraction directly out of `pricePaid`.",
   },
   Revenue: {
     "Takeover Royalties":
-      "ETH allocated to ShareholderRoyalties by MineCore on each successful takeover (via `onTakeover` and the `addPendingShareholderETH` retry path).",
+      "Zero — no protocol-side cut is taken before distribution.",
+  },
+  SupplySideRevenue: {
+    "Takeover Royalties":
+      "Full takeover royalty ETH, routed straight through to veCLAIM holders.",
   },
   HoldersRevenue: {
     "Takeover Royalties":

--- a/fees/claimrush.ts
+++ b/fees/claimrush.ts
@@ -47,8 +47,8 @@ const fetch = async (options: FetchOptions) => {
     // margin on the royalty stream. 100% of the fee flows to veCLAIM
     // holders as supply-side revenue, satisfying DefiLlama's income
     // statement invariant dailyRevenue == dailyFees - dailySupplySideRevenue.
-    dailySupplySideRevenue.addGasToken(totalWei, "Takeover Royalties");
-    dailyHoldersRevenue.addGasToken(totalWei, "Takeover Royalties");
+    dailySupplySideRevenue.addGasToken(totalWei, "Takeover Royalties To veCLAIM Holders");
+    dailyHoldersRevenue.addGasToken(totalWei, "Takeover Royalties To veCLAIM Holders");
   }
 
   return {
@@ -77,16 +77,13 @@ const breakdownMethodology = {
     "Takeover Royalties":
       "Same value — the new King of each takeover pays the royalty fraction directly out of `pricePaid`.",
   },
-  Revenue: {
-    "Takeover Royalties":
-      "Zero — no protocol-side cut is taken before distribution.",
-  },
+  Revenue: {},
   SupplySideRevenue: {
-    "Takeover Royalties":
+    "Takeover Royalties To veCLAIM Holders":
       "Full takeover royalty ETH, routed straight through to veCLAIM holders.",
   },
   HoldersRevenue: {
-    "Takeover Royalties":
+    "Takeover Royalties To veCLAIM Holders":
       "ETH royalties distributed to veCLAIM holders, indexed against the takeover-time shareholder set.",
   },
 };

--- a/fees/claimrush.ts
+++ b/fees/claimrush.ts
@@ -15,7 +15,6 @@ const fetch = async (options: FetchOptions) => {
   const dailyFees = options.createBalances();
   const dailyUserFees = options.createBalances();
   const dailyRevenue = options.createBalances();
-  const dailySupplySideRevenue = options.createBalances();
   const dailyHoldersRevenue = options.createBalances();
 
   const logs = await options.getLogs({
@@ -43,11 +42,7 @@ const fetch = async (options: FetchOptions) => {
   if (totalWei > 0n) {
     dailyFees.addGasToken(totalWei, "Takeover Royalties");
     dailyUserFees.addGasToken(totalWei, "Takeover Royalties");
-    // dailyRevenue intentionally stays at 0: the protocol retains no
-    // margin on the royalty stream. 100% of the fee flows to veCLAIM
-    // holders as supply-side revenue, satisfying DefiLlama's income
-    // statement invariant dailyRevenue == dailyFees - dailySupplySideRevenue.
-    dailySupplySideRevenue.addGasToken(totalWei, "Takeover Royalties To veCLAIM Holders");
+    dailyRevenue.addGasToken(totalWei, "Takeover Royalties");
     dailyHoldersRevenue.addGasToken(totalWei, "Takeover Royalties To veCLAIM Holders");
   }
 
@@ -55,17 +50,17 @@ const fetch = async (options: FetchOptions) => {
     dailyFees,
     dailyUserFees,
     dailyRevenue,
-    dailySupplySideRevenue,
     dailyHoldersRevenue,
+    dailySupplySideRevenue:0,
   };
 };
 
 const methodology = {
-  Fees: "ETH paid as royalties on every Mine takeover. Gross fee volume is the sum of every `ShareholderTakeoverAllocation.amountEth` emitted by the ShareholderRoyalties contract.",
+  Fees: "ETH paid as royalties on every Mine takeover. Gross protocol revenue is the sum of every `ShareholderTakeoverAllocation.amountEth` emitted by the ShareholderRoyalties contract.",
+  Revenue: "ETH paid as royalties on every Mine takeover.",
+  HoldersRevenue: "100% of takeover royalty ETH is allocated to veCLAIM holders pro-rata to their veCLAIM weight at the time of allocation. Holders claim accrued ETH directly from the ShareholderRoyalties contract.",
   UserFees: "Users (the new King of each takeover) pay the protocol-determined takeover price; the royalty fraction of that payment is what this adapter reports.",
-  Revenue: "Zero. The protocol retains no margin on the royalty stream — every wei is forwarded to veCLAIM holders as supply-side revenue.",
-  SupplySideRevenue: "100% of takeover royalty ETH is distributed to veCLAIM holders — the supply side that locks $CLAIM into voting-escrow positions and provides the royalty-bearing ve-position.",
-  HoldersRevenue: "Same value as SupplySideRevenue. veCLAIM holders are the supply side in ClaimRush's ve-tokenomics: locking $CLAIM is the productive activity that earns royalty ETH.",
+  SupplySideRevenue: "No supply side revenue.",
 };
 
 const breakdownMethodology = {
@@ -77,10 +72,9 @@ const breakdownMethodology = {
     "Takeover Royalties":
       "Same value — the new King of each takeover pays the royalty fraction directly out of `pricePaid`.",
   },
-  Revenue: {},
-  SupplySideRevenue: {
-    "Takeover Royalties To veCLAIM Holders":
-      "Full takeover royalty ETH, routed straight through to veCLAIM holders.",
+  Revenue: {
+    "Takeover Royalties":
+      "ETH allocated to ShareholderRoyalties by MineCore on each successful takeover (via `onTakeover` and the `addPendingShareholderETH` retry path).",
   },
   HoldersRevenue: {
     "Takeover Royalties To veCLAIM Holders":


### PR DESCRIPTION
# fees(claimrush): income statement compliance — route 100% to supply side

Follow-up to #7361 (merged 2026-06-01 by @bheluga). Addresses the
[CodeRabbit Income Statement Compliance warning](https://github.com/DefiLlama/dimension-adapters/pull/7361#pullrequestreview)
flagged on that PR:

> Adapter sets `dailyRevenue=dailyFees` (same amount), but 100% goes to
> holders. Missing `dailySupplySideRevenue`; should satisfy
> `dailyRevenue=dailyFees-dailySupplySideRevenue`.
>
> Resolution: Include `dailySupplySideRevenue=totalWei` with
> `dailyRevenue=0`, or set `dailyRevenue=0` if omitting
> `dailySupplySideRevenue`.

This PR follows the recommended resolution: emit
`dailySupplySideRevenue == totalWei` and leave `dailyRevenue == 0`.

## Why this is the correct income statement model

ClaimRush is a fair-launch onchain game on Base where every Crown
takeover pays a royalty fraction (25% of the takeover ETH) into the
`ShareholderRoyalties` contract for distribution to `veCLAIM`
holders. The protocol takes **no cut** of this royalty stream — no
treasury, no platform fee, no team allocation. Every wei flows
through to lockers.

In DefiLlama's income statement vocabulary:

- **Fees** = the gross royalty volume paid by takeovers (what the
  protocol's service captures).
- **SupplySideRevenue** = the portion paid to the supply side
  — here, `veCLAIM` holders who supplied $CLAIM by locking it into
  voting-escrow positions. They are the productive supply side: the
  ve-position is what earns royalty ETH.
- **Revenue** = the protocol's own retained margin. For ClaimRush
  this is **zero**.
- **HoldersRevenue** = same value as SupplySideRevenue, since the
  holders ARE the supply side in this design (locking $CLAIM is
  identically the productive supply activity).

The previous adapter routed the same `totalWei` into both
`dailyFees` and `dailyRevenue`, which DefiLlama's income statement
checker correctly read as "the protocol kept all of it" — wrong in
this case. After this patch:

- `dailyFees = totalWei`
- `dailyUserFees = totalWei`
- `dailyRevenue = 0` (intentionally empty `Balances`)
- `dailySupplySideRevenue = totalWei`
- `dailyHoldersRevenue = totalWei`

The invariant `dailyRevenue == dailyFees - dailySupplySideRevenue`
now holds: `0 == totalWei - totalWei`. The CodeRabbit pre-merge
check should clear.

## Methodology updates

Updated `methodology` and `breakdownMethodology` to:

- Reflect the corrected income statement model.
- Distinguish the per-bucket meanings instead of repeating the same
  "ETH allocated to ShareholderRoyalties by MineCore..." text in
  every bucket (the merge of #7361 collapsed UserFees, Revenue, and
  HoldersRevenue to the same description; this PR re-differentiates
  them).

## On-chain semantics (unchanged)

The data path is identical to #7361:

- Read `ShareholderTakeoverAllocation(uint256 indexed reignId,
  uint256 amountEth)` events from the `ShareholderRoyalties`
  contract at `0x74eDd39E3B220691364Df5024C3dA4FDC64d2a91` on
  Base mainnet.
- Sum `amountEth` across the time window, defensively skipping any
  zero-amount events (the contract emits them on the `msg.value ==
  0` branches; MineCore's upstream guards prevent reaching those at
  non-zero call sites, but the filter is a belt-and-braces check).
- Account in `Balances` via `addGasToken(..., "Takeover Royalties")`.

The `pullHourly: true` flag added by the merge of #7361 is preserved.

## Smoke test (local)

```
> ts-node --transpile-only cli/testAdapter.ts fees claimrush.ts

🦙 Running CLAIMRUSH.TS adapter 🦙
---------------------------------------------------
Start Date: Sun, 31 May 2026 16:00:00 GMT
End Date:   Mon, 01 Jun 2026 16:00:00 GMT
---------------------------------------------------

[24 hourly slots, sum below]

====== TOTAL DAILY AGGREGATED (sum of slots per chain) ======

BASE 👇
End timestamp: 1780329599 (2026-06-01T15:59:59.000Z)
Daily fees: 11.85 k
Daily user fees: 11.85 k
Daily revenue: 0.00
Daily supply side revenue: 11.85 k
Daily holders revenue: 11.85 k
```

The 11.85k USD / day is the actual organic 24h takeover royalty
volume — Day 3 since the 2026-05-29 genesis.

## Checklist

- [x] `tsc --noEmit --project tsconfig.json` passes (no errors in
      `fees/claimrush.ts`).
- [x] `ts-node --transpile-only cli/testAdapter.ts fees claimrush.ts`
      passes with the expected income statement structure
      (Revenue=0, SupplySideRevenue=Fees).
- [x] CodeRabbit's "Income Statement Compliance" invariant
      `dailyRevenue == dailyFees - dailySupplySideRevenue` holds.
- [x] No on-chain semantics changed; the same `amountEth` events are
      summed exactly as in #7361.
- [x] Methodology + breakdownMethodology updated to reflect the
      corrected model and the per-bucket meanings.
- [x] `pullHourly: true` preserved from #7361 merge.

cc @bheluga — thanks again for the merge of #7361.
