### PR TITLE
[fix] Native-Transfers: resolve native transfer table bug in token helper

### DIFF
--- a/helpers/token.ts
+++ b/helpers/token.ts
@@ -702,7 +702,7 @@ export async function getETHReceived({ options, balances, target, targets = [], 
   if (chainKey) {
     query = `
       SELECT SUM(raw_amount) as value
-      FROM ${chainKey}${tableMap[options.chain] ? '.assets.${tableMap[options.chain]}' : '.assets.native_token_transfers'}
+      FROM ${chainKey}${tableMap[options.chain] ? `.assets.${tableMap[options.chain]}` : '.assets.native_token_transfers'}
       WHERE to_address in ${targetList} 
       ${excludeSenders.length > 0 ? `AND from_address not in ${excludeSenderList} ` : ' '}
       AND transfer_type = 'value_transfer'


### PR DESCRIPTION
Fixes native transfer table interpolation in `helpers/token.ts` so mapped Allium tables like Tron and Near resolve correctly.