### PR TITLE
[feat] Lighter-Stats: track user stats for lighter perps

### DIFF
--- a/active-users/lighter.ts
+++ b/active-users/lighter.ts
@@ -1,0 +1,72 @@
+import { PromisePool } from "@supercharge/promise-pool";
+import { FetchOptions, SimpleAdapter } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+import { httpGet, postURL } from "../utils/fetchURL";
+
+const API_URL = "https://blockworks.com/api/studio/dashboard/626/visualization/5670/execution?limit=50000&page=1";
+const TOKEN_TERMINAL_API = "https://api.tokenterminal.com/trpc/metrics.postTimeseries";
+const TOKEN_TERMINAL_PUBLIC_TOKEN = "c0e5035a-64f6-4d2c-b5f6-ac1d1cb3da2f";
+
+type LighterUserStats = {
+  dt: string;
+  new_users: number;
+  daus: number;
+};
+
+type TokenTerminalPoint = {
+  timestamp: string;
+  value: number | null;
+};
+
+const fetch = async (_a: any, _b: any, options: FetchOptions) => {
+  const date = new Date(options.startOfDay * 1000).toISOString().slice(0, 10);
+  const { results } = await PromisePool.withConcurrency(2)
+    .for(["userStats", "tradeStats"])
+    .process(async (task) => ({
+      task,
+      data: task === "userStats"
+        ? await httpGet(API_URL)
+        : await postURL(
+          TOKEN_TERMINAL_API,
+          {
+            data_ids: ["lighter"],
+            metric_ids: ["trade_count"],
+            interval: "365d",
+            groupBy: "none",
+            start: date,
+            end: date,
+            bridged: true,
+          },
+          3,
+          {
+            headers: {
+              Authorization: `Bearer ${TOKEN_TERMINAL_PUBLIC_TOKEN}`,
+              "x-app-path": "/explorer/projects/lighter/metrics/trade-count",
+            },
+          },
+        ),
+    }));
+
+  const userRows = results.find(({ task }) => task === "userStats")?.data?.data as LighterUserStats[] | undefined;
+  const userRow = Array.isArray(userRows) ? userRows.find(({ dt }) => dt.startsWith(date)) : undefined;
+  if (!userRow) throw new Error(`No Lighter user stats for ${date}`);
+
+  const tradeRows = results.find(({ task }) => task === "tradeStats")?.data?.result?.data?.data as TokenTerminalPoint[] | undefined;
+  const tradeRow = Array.isArray(tradeRows) ? tradeRows.find(({ timestamp }) => timestamp.startsWith(date)) : undefined;
+  if (!tradeRow || tradeRow.value === null) throw new Error(`No Lighter trade count for ${date}`);
+
+  return {
+    dailyActiveUsers: userRow.daus,
+    dailyNewUsers: userRow.new_users,
+    dailyTransactionsCount: tradeRow.value,
+  };
+};
+
+const adapter: SimpleAdapter = {
+  version: 1,
+  fetch,
+  chains: [CHAIN.ZK_LIGHTER],
+  start: "2025-01-17",
+};
+
+export default adapter;

--- a/active-users/lighter.ts
+++ b/active-users/lighter.ts
@@ -21,7 +21,7 @@ const fetch = async (_a: any, _b: any, options: FetchOptions) => {
       return { task, data: row.data };
     });
 
-  if (errors.length) throw errors;
+  if (errors.length) throw errors[0];
 
   const metrics = Object.fromEntries(results.map(({ task, data }) => [task, data]));
 

--- a/active-users/lighter.ts
+++ b/active-users/lighter.ts
@@ -1,64 +1,33 @@
 import { PromisePool } from "@supercharge/promise-pool";
 import { FetchOptions, SimpleAdapter } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
-import { httpGet, postURL } from "../utils/fetchURL";
+import fetchURL from "../utils/fetchURL";
 
-const API_URL = "https://blockworks.com/api/studio/dashboard/626/visualization/5670/execution?limit=50000&page=1";
-const TOKEN_TERMINAL_API = "https://api.tokenterminal.com/trpc/metrics.postTimeseries";
-const TOKEN_TERMINAL_PUBLIC_TOKEN = "c0e5035a-64f6-4d2c-b5f6-ac1d1cb3da2f";
+const LIGHTER_METRICS_API = "https://mainnet.zklighter.elliot.ai/api/v1/exchangeMetrics";
 
-type LighterUserStats = {
-  dt: string;
-  new_users: number;
-  daus: number;
-};
-
-type TokenTerminalPoint = {
-  timestamp: string;
-  value: number | null;
+type LighterMetricPoint = {
+  timestamp: number;
+  data: number;
 };
 
 const fetch = async (_a: any, _b: any, options: FetchOptions) => {
   const date = new Date(options.startOfDay * 1000).toISOString().slice(0, 10);
-  const { results } = await PromisePool.withConcurrency(2)
-    .for(["userStats", "tradeStats"])
-    .process(async (task) => ({
-      task,
-      data: task === "userStats"
-        ? await httpGet(API_URL)
-        : await postURL(
-          TOKEN_TERMINAL_API,
-          {
-            data_ids: ["lighter"],
-            metric_ids: ["trade_count"],
-            interval: "365d",
-            groupBy: "none",
-            start: date,
-            end: date,
-            bridged: true,
-          },
-          3,
-          {
-            headers: {
-              Authorization: `Bearer ${TOKEN_TERMINAL_PUBLIC_TOKEN}`,
-              "x-app-path": "/explorer/projects/lighter/metrics/trade-count",
-            },
-          },
-        ),
-    }));
+  const { results, errors } = await PromisePool.withConcurrency(2)
+    .for(["active_account_count", "trade_count"])
+    .process(async (task) => {
+      const response = await fetchURL(`${LIGHTER_METRICS_API}?period=all&kind=${task}`);
+      const row = (response.metrics as LighterMetricPoint[]).find(({ timestamp }) => timestamp === options.startOfDay);
+      if (!row) throw new Error(`No Lighter ${task} for ${date}`);
+      return { task, data: row.data };
+    });
 
-  const userRows = results.find(({ task }) => task === "userStats")?.data?.data as LighterUserStats[] | undefined;
-  const userRow = Array.isArray(userRows) ? userRows.find(({ dt }) => dt.startsWith(date)) : undefined;
-  if (!userRow) throw new Error(`No Lighter user stats for ${date}`);
+  if (errors.length) throw errors;
 
-  const tradeRows = results.find(({ task }) => task === "tradeStats")?.data?.result?.data?.data as TokenTerminalPoint[] | undefined;
-  const tradeRow = Array.isArray(tradeRows) ? tradeRows.find(({ timestamp }) => timestamp.startsWith(date)) : undefined;
-  if (!tradeRow || tradeRow.value === null) throw new Error(`No Lighter trade count for ${date}`);
+  const metrics = Object.fromEntries(results.map(({ task, data }) => [task, data]));
 
   return {
-    dailyActiveUsers: userRow.daus,
-    dailyNewUsers: userRow.new_users,
-    dailyTransactionsCount: tradeRow.value,
+    dailyActiveUsers: metrics.active_account_count,
+    dailyTransactionsCount: metrics.trade_count,
   };
 };
 

--- a/new-users/lighter.ts
+++ b/new-users/lighter.ts
@@ -1,0 +1,26 @@
+import { FetchOptions, SimpleAdapter } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+import fetchURL from "../utils/fetchURL";
+
+const LIGHTER_METRICS_API = "https://mainnet.zklighter.elliot.ai/api/v1/exchangeMetrics";
+
+const fetch = async (_a: any, _b: any, options: FetchOptions) => {
+  const date = new Date(options.startOfDay * 1000).toISOString().slice(0, 10);
+  const response = await fetchURL(`${LIGHTER_METRICS_API}?period=all&kind=account_count`);
+  const row = response.metrics.find(({ timestamp }: any) => timestamp === options.startOfDay);
+
+  if (!row) throw new Error(`No Lighter account count for ${date}`);
+
+  return {
+    dailyNewUsers: row.data,
+  };
+};
+
+const adapter: SimpleAdapter = {
+  version: 1,
+  fetch,
+  chains: [CHAIN.ZK_LIGHTER],
+  start: "2025-01-17",
+};
+
+export default adapter;


### PR DESCRIPTION
## Summary
- Adds an `active-users` adapter for Lighter on `zklighter`.
- Reports daily active users, daily new users, and daily transaction count from external daily stats sources.

## Changes
- Added `active-users/lighter.ts`.
- Uses Blockworks Lighter stats for `dailyActiveUsers` and `dailyNewUsers`.
- Uses Token Terminal `trade_count` for `dailyTransactionsCount`.
- Sets adapter start date to `2025-01-17`, where both sources have data.
