### PR TITLE
Add tizi fee adapter

### DIFF
--- a/fees/tizi/index.ts
+++ b/fees/tizi/index.ts
@@ -33,12 +33,12 @@ const fetch = async (options: FetchOptions) => {
       permitFailure: true,
     });
 
-    const feeNum = (profitNumerator != null && BigInt(profitNumerator as string) > 0n)
-      ? BigInt(profitNumerator as string)
-      : 100n;
-    const feeDen = (profitDenominator != null && BigInt(profitDenominator as string) > 0n)
-      ? BigInt(profitDenominator as string)
-      : 1000n;
+    const rawNum = profitNumerator != null ? BigInt(profitNumerator as string) : 0n;
+    const rawDen = profitDenominator != null ? BigInt(profitDenominator as string) : 0n;
+
+    const bothValid = rawNum > 0n && rawDen > 0n;
+    const feeNum = bothValid ? rawNum : 100n;
+    const feeDen = bothValid ? rawDen : 1000n;
 
     const totalYield = profitDelta * feeDen / feeNum;
 

--- a/fees/tizi/index.ts
+++ b/fees/tizi/index.ts
@@ -22,19 +22,24 @@ const fetch = async (options: FetchOptions) => {
     abi: "uint256:totalProfit",
   });
 
-  const profitNumerator = await options.api.call({
-    target: STAKED_TD,
-    abi: "uint256:profitNumerator",
-  });
-  const profitDenominator = await options.api.call({
-    target: STAKED_TD,
-    abi: "uint256:profitDenominator",
-  });
-
   const profitDelta = Number(totalProfitAfter) - Number(totalProfitBefore);
 
   if (profitDelta > 0) {
-    const feeRate = Number(profitNumerator) / Number(profitDenominator);
+    const profitNumerator = await options.toApi.call({
+      target: STAKED_TD,
+      abi: "uint256:profitNumerator",
+      permitFailure: true,
+    });
+    const profitDenominator = await options.toApi.call({
+      target: STAKED_TD,
+      abi: "uint256:profitDenominator",
+      permitFailure: true,
+    });
+
+    const feeRate = (profitNumerator && profitDenominator)
+      ? Number(profitNumerator) / Number(profitDenominator)
+      : 0.1;
+
     const totalYield = profitDelta / feeRate;
 
     dailyFees.add(USDC, totalYield / TD_TO_USDC);

--- a/fees/tizi/index.ts
+++ b/fees/tizi/index.ts
@@ -33,8 +33,12 @@ const fetch = async (options: FetchOptions) => {
       permitFailure: true,
     });
 
-    const feeNum = profitNumerator ? BigInt(profitNumerator as string) : 100n;
-    const feeDen = profitDenominator ? BigInt(profitDenominator as string) : 1000n;
+    const feeNum = (profitNumerator != null)
+      ? BigInt(profitNumerator as string)
+      : 100n;
+    const feeDen = (profitDenominator != null && BigInt(profitDenominator as string) > 0n)
+      ? BigInt(profitDenominator as string)
+      : 1000n;
 
     const totalYield = profitDelta * feeDen / feeNum;
 

--- a/fees/tizi/index.ts
+++ b/fees/tizi/index.ts
@@ -33,7 +33,7 @@ const fetch = async (options: FetchOptions) => {
       permitFailure: true,
     });
 
-    const feeNum = (profitNumerator != null)
+    const feeNum = (profitNumerator != null && BigInt(profitNumerator as string) > 0n)
       ? BigInt(profitNumerator as string)
       : 100n;
     const feeDen = (profitDenominator != null && BigInt(profitDenominator as string) > 0n)

--- a/fees/tizi/index.ts
+++ b/fees/tizi/index.ts
@@ -1,0 +1,68 @@
+import { FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import ADDRESSES from "../../helpers/coreAssets.json";
+
+const STAKED_TD = "0x0CB091e6D9fd696b4CC8571E19e042F456c182Ad";
+const USDC = ADDRESSES.base.USDC;
+
+// TD (18 decimals) → USDC (6 decimals): divide by 1e12
+const TD_TO_USDC = 1e12;
+
+const fetch = async (options: FetchOptions) => {
+  const dailyFees = options.createBalances();
+  const dailyRevenue = options.createBalances();
+  const dailySupplySideRevenue = options.createBalances();
+
+  const totalProfitBefore = await options.fromApi.call({
+    target: STAKED_TD,
+    abi: "uint256:totalProfit",
+  });
+  const totalProfitAfter = await options.toApi.call({
+    target: STAKED_TD,
+    abi: "uint256:totalProfit",
+  });
+
+  const profitNumerator = await options.api.call({
+    target: STAKED_TD,
+    abi: "uint256:profitNumerator",
+  });
+  const profitDenominator = await options.api.call({
+    target: STAKED_TD,
+    abi: "uint256:profitDenominator",
+  });
+
+  const profitDelta = Number(totalProfitAfter) - Number(totalProfitBefore);
+
+  if (profitDelta > 0) {
+    const feeRate = Number(profitNumerator) / Number(profitDenominator);
+    const totalYield = profitDelta / feeRate;
+
+    dailyFees.add(USDC, totalYield / TD_TO_USDC);
+    dailyRevenue.add(USDC, profitDelta / TD_TO_USDC);
+    dailySupplySideRevenue.add(USDC, (totalYield - profitDelta) / TD_TO_USDC);
+  }
+
+  return {
+    dailyFees,
+    dailyRevenue,
+    dailyProtocolRevenue: dailyRevenue,
+    dailySupplySideRevenue,
+  };
+};
+
+const methodology = {
+  Fees: "Total staking yield generated from TD staking rewards.",
+  Revenue: "Portion of yield claimed by the protocol (profitNumerator / profitDenominator, default 10%).",
+  ProtocolRevenue: "All protocol profit is directed to the protocol's profitRecipient.",
+  SupplySideRevenue: "Portion of yield distributed to stTD stakers (total yield minus protocol profit).",
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  fetch,
+  chains: [CHAIN.BASE],
+  start: "2026-03-20",
+  methodology,
+};
+
+export default adapter;

--- a/fees/tizi/index.ts
+++ b/fees/tizi/index.ts
@@ -41,11 +41,10 @@ const fetch = async (options: FetchOptions) => {
   const feeDen = bothValid ? rawDen : 1000n;
 
   const totalYield = profitDelta * feeDen / feeNum;
-  const protocolShare = totalYield > 0n ? profitDelta : 0n;
   
   dailyFees.add(USDC, totalYield / BigInt(1e12), 'Staking Yield');
-  dailyRevenue.add(USDC, protocolShare / BigInt(1e12), 'Staking Yield To Protocol');
-  dailySupplySideRevenue.add(USDC, (totalYield - protocolShare) / BigInt(1e12), 'Staking Yield To Stakers');
+  dailyRevenue.add(USDC, profitDelta / BigInt(1e12), 'Staking Yield To Protocol');
+  dailySupplySideRevenue.add(USDC, (totalYield - profitDelta) / BigInt(1e12), 'Staking Yield To Stakers');
 
   return {
     dailyFees,

--- a/fees/tizi/index.ts
+++ b/fees/tizi/index.ts
@@ -19,33 +19,33 @@ const fetch = async (options: FetchOptions) => {
     abi: "uint256:totalProfit",
   });
 
-  const profitDelta = BigInt(totalProfitAfter as string) - BigInt(totalProfitBefore as string);
+  const profitDelta = BigInt(totalProfitAfter) - BigInt(totalProfitBefore);
 
-  if (profitDelta > 0n) {
-    const profitNumerator = await options.toApi.call({
-      target: STAKED_TD,
-      abi: "uint256:profitNumerator",
-      permitFailure: true,
-    });
-    const profitDenominator = await options.toApi.call({
-      target: STAKED_TD,
-      abi: "uint256:profitDenominator",
-      permitFailure: true,
-    });
+  const profitNumerator = await options.toApi.call({
+    target: STAKED_TD,
+    abi: "uint256:profitNumerator",
+    permitFailure: true,
+  });
 
-    const rawNum = profitNumerator != null ? BigInt(profitNumerator as string) : 0n;
-    const rawDen = profitDenominator != null ? BigInt(profitDenominator as string) : 0n;
+  const profitDenominator = await options.toApi.call({
+    target: STAKED_TD,
+    abi: "uint256:profitDenominator",
+    permitFailure: true,
+  });
 
-    const bothValid = rawNum > 0n && rawDen > 0n;
-    const feeNum = bothValid ? rawNum : 100n;
-    const feeDen = bothValid ? rawDen : 1000n;
+  const rawNum = profitNumerator != null ? BigInt(profitNumerator) : 0n;
+  const rawDen = profitDenominator != null ? BigInt(profitDenominator) : 0n;
 
-    const totalYield = profitDelta * feeDen / feeNum;
+  const bothValid = rawNum > 0n && rawDen > 0n;
+  const feeNum = bothValid ? rawNum : 100n;
+  const feeDen = bothValid ? rawDen : 1000n;
 
-    dailyFees.add(USDC, totalYield / BigInt(1e12), 'Staking Yield');
-    dailyRevenue.add(USDC, profitDelta / BigInt(1e12), 'Staking Yield To Protocol');
-    dailySupplySideRevenue.add(USDC, (totalYield - profitDelta) / BigInt(1e12), 'Staking Yield To Stakers');
-  }
+  const totalYield = profitDelta * feeDen / feeNum;
+  const protocolShare = totalYield > 0n ? profitDelta : 0n;
+  
+  dailyFees.add(USDC, totalYield / BigInt(1e12), 'Staking Yield');
+  dailyRevenue.add(USDC, protocolShare / BigInt(1e12), 'Staking Yield To Protocol');
+  dailySupplySideRevenue.add(USDC, (totalYield - protocolShare) / BigInt(1e12), 'Staking Yield To Stakers');
 
   return {
     dailyFees,
@@ -81,6 +81,8 @@ const adapter: SimpleAdapter = {
   start: "2026-03-20",
   methodology,
   breakdownMethodology,
+  allowNegativeValue: true,
+  pullHourly: true,
 };
 
 export default adapter;

--- a/fees/tizi/index.ts
+++ b/fees/tizi/index.ts
@@ -42,9 +42,9 @@ const fetch = async (options: FetchOptions) => {
 
     const totalYield = profitDelta * feeDen / feeNum;
 
-    dailyFees.add(USDC, totalYield / BigInt(1e12));
-    dailyRevenue.add(USDC, profitDelta / BigInt(1e12));
-    dailySupplySideRevenue.add(USDC, (totalYield - profitDelta) / BigInt(1e12));
+    dailyFees.add(USDC, totalYield / BigInt(1e12), 'Staking Yield');
+    dailyRevenue.add(USDC, profitDelta / BigInt(1e12), 'Staking Yield To Protocol');
+    dailySupplySideRevenue.add(USDC, (totalYield - profitDelta) / BigInt(1e12), 'Staking Yield To Stakers');
   }
 
   return {
@@ -62,12 +62,25 @@ const methodology = {
   SupplySideRevenue: "Portion of yield distributed to stTD stakers (total yield minus protocol profit).",
 };
 
+const breakdownMethodology = {
+  Fees: {
+    'Staking Yield': "Total yield from TD staking rewards distributed via addYield().",
+  },
+  Revenue: {
+    'Staking Yield To Protocol': "Protocol's profit cut (profitNumerator / profitDenominator of yield), sent to profitRecipient.",
+  },
+  SupplySideRevenue: {
+    'Staking Yield To Stakers': "Yield distributed to stTD stakers after deducting protocol profit.",
+  },
+};
+
 const adapter: SimpleAdapter = {
   version: 2,
   fetch,
   chains: [CHAIN.BASE],
   start: "2026-03-20",
   methodology,
+  breakdownMethodology,
 };
 
 export default adapter;

--- a/fees/tizi/index.ts
+++ b/fees/tizi/index.ts
@@ -5,9 +5,6 @@ import ADDRESSES from "../../helpers/coreAssets.json";
 const STAKED_TD = "0x0CB091e6D9fd696b4CC8571E19e042F456c182Ad";
 const USDC = ADDRESSES.base.USDC;
 
-// TD (18 decimals) → USDC (6 decimals): divide by 1e12
-const TD_TO_USDC = 1e12;
-
 const fetch = async (options: FetchOptions) => {
   const dailyFees = options.createBalances();
   const dailyRevenue = options.createBalances();
@@ -22,9 +19,9 @@ const fetch = async (options: FetchOptions) => {
     abi: "uint256:totalProfit",
   });
 
-  const profitDelta = Number(totalProfitAfter) - Number(totalProfitBefore);
+  const profitDelta = BigInt(totalProfitAfter as string) - BigInt(totalProfitBefore as string);
 
-  if (profitDelta > 0) {
+  if (profitDelta > 0n) {
     const profitNumerator = await options.toApi.call({
       target: STAKED_TD,
       abi: "uint256:profitNumerator",
@@ -36,15 +33,14 @@ const fetch = async (options: FetchOptions) => {
       permitFailure: true,
     });
 
-    const feeRate = (profitNumerator && profitDenominator)
-      ? Number(profitNumerator) / Number(profitDenominator)
-      : 0.1;
+    const feeNum = profitNumerator ? BigInt(profitNumerator as string) : 100n;
+    const feeDen = profitDenominator ? BigInt(profitDenominator as string) : 1000n;
 
-    const totalYield = profitDelta / feeRate;
+    const totalYield = profitDelta * feeDen / feeNum;
 
-    dailyFees.add(USDC, totalYield / TD_TO_USDC);
-    dailyRevenue.add(USDC, profitDelta / TD_TO_USDC);
-    dailySupplySideRevenue.add(USDC, (totalYield - profitDelta) / TD_TO_USDC);
+    dailyFees.add(USDC, totalYield / BigInt(1e12));
+    dailyRevenue.add(USDC, profitDelta / BigInt(1e12));
+    dailySupplySideRevenue.add(USDC, (totalYield - profitDelta) / BigInt(1e12));
   }
 
   return {


### PR DESCRIPTION
https://defillama.com/protocol/tizi

- Tracks staking yield profit via cumulative totalProfit variable on StakedTD contract (Base)
- Fees = total staking yield, Revenue = protocol profit cut (~10%), SupplySideRevenue = staker share
- Tested: npm test fees tizi 2026-05-27 → dailyFees: $143, dailyRevenue: $14
