### PR TITLE
feat(yologames): add revenue and protocol revenue fields

### DIFF
--- a/fees/yologames/index.ts
+++ b/fees/yologames/index.ts
@@ -14,13 +14,15 @@ const fetch: any = async ({ createBalances, fromTimestamp, toTimestamp }: FetchO
   const dailyFees = createBalances();
   const statsApiResponse = await fetchDailyStats(fromTimestamp, toTimestamp);
   dailyFees.addGasToken(statsApiResponse.feesETH * 1e18);
-  return { dailyFees };
+  return { dailyFees, dailyRevenue: dailyFees, dailyProtocolRevenue: dailyFees };
 };
 
 const adapter: Adapter = {
   version: 2,
   methodology: {
     Fees: "YOLO Games collects a 1% fee for Moon Or Doom and YOLO winnings, and a 3% fee on Poke The Bear winnings.",
+    Revenue: "All game fees are kept by YOLO Games as protocol revenue.",
+    ProtocolRevenue: "All game fees are kept by YOLO Games as protocol revenue.",
   },
   adapter: {
     [CHAIN.BLAST]: {

--- a/fees/yologames/index.ts
+++ b/fees/yologames/index.ts
@@ -1,6 +1,7 @@
 import { Adapter, FetchOptions } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 import fetchURL from "../../utils/fetchURL";
+import { METRIC } from "../../helpers/metrics";
 
 const fetchDailyStats = async (
   from: number, to: number
@@ -10,26 +11,72 @@ const fetchDailyStats = async (
   return { feesETH: response.feesETH };
 };
 
+const FEE_SHARES = {
+  RAKE_BACK: 0.45,
+  LOTTERY: 0.05,
+  BUYBACK: 0.2,
+  TREASURY: 0.3,
+}
+
 const fetch: any = async ({ createBalances, fromTimestamp, toTimestamp }: FetchOptions) => {
   const dailyFees = createBalances();
+  const dailyRevenue = createBalances();
+  const dailyProtocolRevenue = createBalances();
+  const dailySupplySideRevenue = createBalances();
+  const dailyHoldersRevenue = createBalances();
+
   const statsApiResponse = await fetchDailyStats(fromTimestamp, toTimestamp);
-  dailyFees.addGasToken(statsApiResponse.feesETH * 1e18);
-  return { dailyFees, dailyRevenue: dailyFees, dailyProtocolRevenue: dailyFees };
+
+  dailyFees.addGasToken(statsApiResponse.feesETH * 1e18, METRIC.PROTOCOL_FEES);
+
+  dailyHoldersRevenue.addGasToken(statsApiResponse.feesETH * 1e18 * FEE_SHARES.BUYBACK, METRIC.TOKEN_BUY_BACK);
+  dailyRevenue.addGasToken(statsApiResponse.feesETH * 1e18 * FEE_SHARES.BUYBACK, METRIC.TOKEN_BUY_BACK);
+
+  dailyProtocolRevenue.addGasToken(statsApiResponse.feesETH * 1e18 * FEE_SHARES.TREASURY, 'Protocol Fees to Treasury');
+  dailyRevenue.addGasToken(statsApiResponse.feesETH * 1e18 * FEE_SHARES.TREASURY, 'Protocol Fees to Treasury');
+
+  dailySupplySideRevenue.addGasToken(statsApiResponse.feesETH * 1e18 * FEE_SHARES.RAKE_BACK, 'Rake Back to Players');
+  dailySupplySideRevenue.addGasToken(statsApiResponse.feesETH * 1e18 * FEE_SHARES.LOTTERY, 'Protocol Fees to Lottery');
+
+  return { dailyFees, dailyRevenue, dailyProtocolRevenue, dailySupplySideRevenue, dailyHoldersRevenue };
 };
+
+const methodology = {
+  Fees: "YOLO Games collects a 1% fee for Moon Or Doom and YOLO winnings, and a 3% fee on Poke The Bear winnings.",
+  Revenue: "Includes 20% of the fees for token buybacks and 30% of the fees for the protocol treasury.",
+  ProtocolRevenue: "Includes 30% of the fees for the protocol treasury.",
+  SupplySideRevenue: "Includes 45% of the fees for the rake back to players and 5% of the fees for the protocol fees to the lottery.",
+  HoldersRevenue: "Includes 20% of the fees for the token buybacks.",
+}
+
+const breakdownMethodology = {
+  Fees: {
+    [METRIC.PROTOCOL_FEES]: "Includes 1% of the fees for Moon Or Doom and YOLO winnings, and a 3% fee on Poke The Bear winnings.",
+  },
+  Revenue: {
+    [METRIC.TOKEN_BUY_BACK]: "Includes 20% of the fees going to token buybacks.",
+    'Protocol Fees to Treasury': "Includes 30% of the fees going to the protocol treasury.",
+  },
+  ProtocolRevenue: {
+    'Protocol Fees to Treasury': "Includes 30% of the fees going to the protocol treasury.",
+  },
+  SupplySideRevenue: {
+    'Rake Back to Players': "Includes 45% of the fees going to the rake back to players.",
+    'Protocol Fees to Lottery': "Includes 5% of the fees going to the protocol fees to the lottery.",
+  },
+  HoldersRevenue: {
+    [METRIC.TOKEN_BUY_BACK]: "Includes 20% of the fees going to token buybacks.",
+  },
+}
 
 const adapter: Adapter = {
   version: 2,
-  methodology: {
-    Fees: "YOLO Games collects a 1% fee for Moon Or Doom and YOLO winnings, and a 3% fee on Poke The Bear winnings.",
-    Revenue: "All game fees are kept by YOLO Games as protocol revenue.",
-    ProtocolRevenue: "All game fees are kept by YOLO Games as protocol revenue.",
-  },
-  adapter: {
-    [CHAIN.BLAST]: {
-      fetch,
-      start: '2024-03-01',
-    },
-  },
+  methodology,
+  breakdownMethodology,
+  chains: [CHAIN.BLAST],
+  start: '2024-03-01',
+  fetch,
+  pullHourly: true,
 };
 
 export default adapter;

--- a/fees/yologames/index.ts
+++ b/fees/yologames/index.ts
@@ -11,6 +11,7 @@ const fetchDailyStats = async (
   return { feesETH: response.feesETH };
 };
 
+//https://docs.yologames.io/games/game-fees
 const FEE_SHARES = {
   RAKE_BACK: 0.45,
   LOTTERY: 0.05,


### PR DESCRIPTION
- Adds `dailyRevenue` and `dailyProtocolRevenue` equal to `dailyFees`
- Adds `Revenue` and `ProtocolRevenue` methodology entries

YOLO Games has no LPs, lenders, or external fee recipients, all fees from Moon or Doom (1%), YOLO (1%), and Poke the Bear (3%) are kept by the protocol, so `dailySupplySideRevenue` is zero and the full fee is protocol revenue.

Effective fee rate confirmed ~1.07% from live API (`feesETH/volumeETH`), consistent with the stated 1% primary game fee.
