### PR TITLE
feat(blocxroute): add revenue split

### DIFF
--- a/fees/blocxroute.ts
+++ b/fees/blocxroute.ts
@@ -69,7 +69,7 @@ const fetch: any = async (_a: any, _b: any, options: FetchOptions) => {
   const data = await queryDuneSql(options, query);
   const dailyFees = options.createBalances();
   dailyFees.addCGToken('solana', data[0].revenue);
-  return { dailyFees: dailyFees }
+  return { dailyFees, dailyRevenue: dailyFees, dailyProtocolRevenue: dailyFees }
 }
 
 // https://docs.bloxroute.com/bsc-and-eth/apis/transaction-bundles/bundle-submission/bsc-bundle-submission
@@ -78,7 +78,7 @@ const fetchBSC: any = async (_a: any, _b: any, options: FetchOptions) => {
     options,
     target: '0x74c5F8C6ffe41AD4789602BDB9a48E6Cad623520',
   })
-  return { dailyFees }
+  return { dailyFees, dailyRevenue: dailyFees, dailyProtocolRevenue: dailyFees }
 }
 
 const adapter: SimpleAdapter = {
@@ -96,6 +96,8 @@ const adapter: SimpleAdapter = {
   dependencies: [Dependencies.DUNE, Dependencies.ALLIUM],
   methodology: {
     Fees: "mev fees to blocXroute, subtracted routed jito mev fees to prevent double counting",
+    Revenue: "All MEV fees are kept by bloXroute as protocol revenue.",
+    ProtocolRevenue: "All MEV fees are kept by bloXroute as protocol revenue.",
   }
 };
 


### PR DESCRIPTION
- add `dailyRevenue` and `dailyProtocolRevenue` to both Solana and BSC fetch returns (both equal to `dailyFees`)
- add `Revenue` and `ProtocolRevenue` entries to `methodology`
- bloxroute is an MEV relay with no supply-side participants. All collected fees flow directly to the protocol treasury, so `dailyFees = dailyRevenue = dailyProtocolRevenue`. 