### PR TITLE
Arrakis V2: fee attribution from onchain verification

### DIFF
--- a/fees/arrakis-v2/index.ts
+++ b/fees/arrakis-v2/index.ts
@@ -1,6 +1,7 @@
 import { Chain } from "../../adapters/types";
 import { Adapter, FetchOptions } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
+import { METRIC } from "../../helpers/metrics";
 
 type IVault = {
   helper: string;
@@ -81,9 +82,9 @@ async function fetch({ chain, api, fromApi, toApi, createBalances }: FetchOption
       const delta0 = BigInt(currFee0) - BigInt(prevFee0);
       if (delta0 > 0n) {
         const managerCut0 = (delta0 * mgrBPS) / 10000n;
-        dailyFees.add(token0, delta0);
-        dailySupplySideRevenue.add(token0, delta0 - managerCut0);
-        dailyRevenue.add(token0, managerCut0);
+        dailyFees.add(token0, delta0, METRIC.LP_FEES);
+        dailySupplySideRevenue.add(token0, delta0 - managerCut0, 'LP Fees To Depositors');
+        dailyRevenue.add(token0, managerCut0, 'LP Fees To Manager');
       }
     }
 
@@ -91,9 +92,9 @@ async function fetch({ chain, api, fromApi, toApi, createBalances }: FetchOption
       const delta1 = BigInt(currFee1) - BigInt(prevFee1);
       if (delta1 > 0n) {
         const managerCut1 = (delta1 * mgrBPS) / 10000n;
-        dailyFees.add(token1, delta1);
-        dailySupplySideRevenue.add(token1, delta1 - managerCut1);
-        dailyRevenue.add(token1, managerCut1);
+        dailyFees.add(token1, delta1, METRIC.LP_FEES);
+        dailySupplySideRevenue.add(token1, delta1 - managerCut1, 'LP Fees To Depositors');
+        dailyRevenue.add(token1, managerCut1, 'LP Fees To Manager');
       }
     }
   });
@@ -107,12 +108,25 @@ const methodology = {
   Revenue: 'Manager fee portion of accrued fees. Manager address is freely set per vault and is not necessarily Arrakis Finance, no Arrakis protocol-level fee exists in V2 core.',
 };
 
+const breakdownMethodology = {
+  Fees: {
+    [METRIC.LP_FEES]: 'Uniswap V3 trading fees accrued to vault LP positions',
+  },
+  SupplySideRevenue: {
+    'LP Fees To Depositors': 'Uniswap V3 fees remaining in vault after manager fee is subtracted',
+  },
+  Revenue: {
+    'LP Fees To Manager': 'Uniswap V3 fees allocated to vault manager (managerFeeBPS)',
+  },
+};
+
 const adapter: Adapter = {
   version: 2,
   fetch,
   chains: [CHAIN.ETHEREUM],
   start: '2023-08-26',
   methodology,
+  breakdownMethodology,
 };
 
 export default adapter;

--- a/fees/arrakis-v2/index.ts
+++ b/fees/arrakis-v2/index.ts
@@ -1,7 +1,6 @@
 import { Chain } from "../../adapters/types";
 import { Adapter, FetchOptions } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
-import { METRIC } from "../../helpers/metrics";
 
 type IVault = {
   helper: string;
@@ -18,6 +17,7 @@ const abi = {
     "function vaults(uint256 startIndex_, uint256 endIndex_) returns (address[] memory)",
   token0: "address:token0",
   token1: "address:token1",
+  managerFeeBPS: "uint16:managerFeeBPS",
   fees: "function totalUnderlyingWithFees(address vault_) external view returns (uint256 amount0, uint256 amount1, uint256 fee0, uint256 fee1)",
 };
 
@@ -47,6 +47,8 @@ const contracts: IAddress = {
 async function fetch({ chain, api, fromApi, toApi, createBalances }: FetchOptions) {
   const { helper, factory } = contracts[chain];
   const dailyFees = createBalances();
+  const dailySupplySideRevenue = createBalances();
+  const dailyRevenue = createBalances();
 
   const limit = await api.call({ target: factory, abi: abi.numVaults });
   const vaults = await api.call({
@@ -57,48 +59,52 @@ async function fetch({ chain, api, fromApi, toApi, createBalances }: FetchOption
 
   const calls = vaults.map((v: string) => ({ target: helper, params: [v] }));
 
-  const [token0s, token1s, prevBals, currBals] = await Promise.all([
+  const [token0s, token1s, managerFeeBPSs, prevBals, currBals] = await Promise.all([
     api.multiCall({ calls: vaults, abi: abi.token0, permitFailure: true }),
     api.multiCall({ calls: vaults, abi: abi.token1, permitFailure: true }),
+    api.multiCall({ calls: vaults, abi: abi.managerFeeBPS, permitFailure: true }),
     fromApi.multiCall({ calls, abi: abi.fees, permitFailure: true }),
     toApi.multiCall({ calls, abi: abi.fees, permitFailure: true }),
   ]);
 
   vaults.forEach((_: string, index: number) => {
     const token0 = token0s[index];
-    const prevFee0 = prevBals[index]?.fee0 ?? 0;
-    const currFee0 = currBals[index].fee0;
-
     const token1 = token1s[index];
-    const prevFee1 = prevBals[index]?.fee1 ?? 0;
-    const currFee1 = currBals[index].fee1;
+    const mgrBPS = BigInt(managerFeeBPSs[index] ?? 0);
 
-    if (token0 && prevFee0 && currFee0) {
-      const dailyFee0 = BigInt(currFee0) - BigInt(prevFee0);
-      if (dailyFee0 >= 0) {
-        dailyFees.add(token0, dailyFee0, METRIC.MANAGEMENT_FEES);
+    const prevFee0 = prevBals[index]?.fee0 ?? 0;
+    const currFee0 = currBals[index]?.fee0;
+    const prevFee1 = prevBals[index]?.fee1 ?? 0;
+    const currFee1 = currBals[index]?.fee1;
+
+    if (token0 && currFee0 !== undefined) {
+      const delta0 = BigInt(currFee0) - BigInt(prevFee0);
+      if (delta0 > 0n) {
+        const managerCut0 = (delta0 * mgrBPS) / 10000n;
+        dailyFees.add(token0, delta0);
+        dailySupplySideRevenue.add(token0, delta0 - managerCut0);
+        dailyRevenue.add(token0, managerCut0);
       }
     }
 
-    if (token1 && prevFee1 && currFee1) {
-      const dailyFee1 = BigInt(currFee1) - BigInt(prevFee1);
-      if (dailyFee1 >= 0) {
-        dailyFees.add(token1, dailyFee1, METRIC.MANAGEMENT_FEES);
+    if (token1 && currFee1 !== undefined) {
+      const delta1 = BigInt(currFee1) - BigInt(prevFee1);
+      if (delta1 > 0n) {
+        const managerCut1 = (delta1 * mgrBPS) / 10000n;
+        dailyFees.add(token1, delta1);
+        dailySupplySideRevenue.add(token1, delta1 - managerCut1);
+        dailyRevenue.add(token1, managerCut1);
       }
     }
   });
 
-  return { dailyFees };
+  return { dailyFees, dailySupplySideRevenue, dailyRevenue };
 }
 
 const methodology = {
-  Fees: 'All yields are collected from deposited assets by liquidity providers.',
-};
-
-const breakdownMethodology = {
-  Fees: {
-    [METRIC.MANAGEMENT_FEES]: 'Fees collected by Arrakis protocol for managing liquidity vault positions on behalf of depositors',
-  },
+  Fees: 'Gross Uniswap V3 LP fees accrued across all ArrakisV2 vault positions before manager cut.',
+  SupplySideRevenue: 'Depositor share of accrued fees: gross fees minus managerFeeBPS per vault.',
+  Revenue: 'Manager fee portion of accrued fees. Manager address is freely set per vault and is not necessarily Arrakis Finance, no Arrakis protocol-level fee exists in V2 core.',
 };
 
 const adapter: Adapter = {
@@ -107,8 +113,6 @@ const adapter: Adapter = {
   chains: [CHAIN.ETHEREUM],
   start: '2023-08-26',
   methodology,
-  skipBreakdownValidation: true, // because cost are not clear
-  breakdownMethodology,
 };
 
 export default adapter;

--- a/fees/arrakis-v2/index.ts
+++ b/fees/arrakis-v2/index.ts
@@ -84,7 +84,7 @@ async function fetch({ chain, api, fromApi, toApi, createBalances }: FetchOption
         const managerCut0 = (delta0 * mgrBPS) / 10000n;
         dailyFees.add(token0, delta0, METRIC.LP_FEES);
         dailySupplySideRevenue.add(token0, delta0 - managerCut0, 'LP Fees To Depositors');
-        dailyRevenue.add(token0, managerCut0, 'LP Fees To Manager');
+        dailySupplySideRevenue.add(token0, managerCut0, 'LP Fees To Vaults Managers');
       }
     }
 
@@ -94,18 +94,18 @@ async function fetch({ chain, api, fromApi, toApi, createBalances }: FetchOption
         const managerCut1 = (delta1 * mgrBPS) / 10000n;
         dailyFees.add(token1, delta1, METRIC.LP_FEES);
         dailySupplySideRevenue.add(token1, delta1 - managerCut1, 'LP Fees To Depositors');
-        dailyRevenue.add(token1, managerCut1, 'LP Fees To Manager');
+        dailySupplySideRevenue.add(token1, managerCut1, 'LP Fees To Vaults Managers');
       }
     }
   });
 
-  return { dailyFees, dailySupplySideRevenue, dailyRevenue };
+  return { dailyFees, dailySupplySideRevenue, dailyRevenue: 0 };
 }
 
 const methodology = {
-  Fees: 'Gross Uniswap V3 LP fees accrued across all ArrakisV2 vault positions before manager cut.',
-  SupplySideRevenue: 'Depositor share of accrued fees: gross fees minus managerFeeBPS per vault.',
-  Revenue: 'Manager fee portion of accrued fees. Manager address is freely set per vault and is not necessarily Arrakis Finance, no Arrakis protocol-level fee exists in V2 core.',
+  Fees: 'Gross Uniswap V3 LP fees accrued across all ArrakisV2 vault positions before management fees cut.',
+  SupplySideRevenue: 'Depositors share of accrued fees: gross fees minus management fees per vault + fees paid to vaults managers.',
+  Revenue: 'No protocol revenue.',
 };
 
 const breakdownMethodology = {
@@ -114,9 +114,7 @@ const breakdownMethodology = {
   },
   SupplySideRevenue: {
     'LP Fees To Depositors': 'Uniswap V3 fees remaining in vault after manager fee is subtracted',
-  },
-  Revenue: {
-    'LP Fees To Manager': 'Uniswap V3 fees allocated to vault manager (managerFeeBPS)',
+    'LP Fees To Vaults Managers': 'Uniswap V3 fees allocated to vaults managers',
   },
 };
 


### PR DESCRIPTION
The adapter incorrectly assumed all fees belonged to Arrakis and attributed 100% of `fee0`/`fee1` from `totalUnderlyingWithFees()` to `dailyProtocolRevenue`.

This was incorrect because:

1. `fee0`/`fee1` represent gross Uniswap V3 LP fees accrued by the vault, not management fees.
2. Arrakis V2 vaults are permissionless and can be managed by any address; V2 core does not charge a protocol-level fee.

### Fix

Verified the fee model from the V2 core contracts and updated revenue attribution:

* Read `managerFeeBPS` from each vault.
* Split gross LP fees as follows:

  * **dailyFees**: total LP fees accrued.
  * **dailySupplySideRevenue**: LP share (`gross × (1 - managerFeeBPS / 10000)`).
  * **dailyRevenue**: manager share (`gross × managerFeeBPS / 10000`).
* Removed `dailyProtocolRevenue`, as fees cannot be attributed to Arrakis without identifying manager ownership.
* Removed the unnecessary `skipBreakdownValidation: true`.