### PR TITLE
fix(beezie): fix v2 claw fee calculation and revenue split

### DIFF
--- a/fees/beezie.ts
+++ b/fees/beezie.ts
@@ -88,9 +88,8 @@ const fetchClawFees = async (options: FetchOptions, clawMachines: string[], vers
   const dailyFees = options.createBalances();
 
   if (version === "v2") {
-    // Full play price (price * times) — gross amount users pay per pull.
-    // swapValue is set independently by NFT depositors (60–610% of price), so there is no
-    // fixed fee %. Instead, SWAP refunds are tracked as supply-side revenue in the main fetch.
+    // Played.amount = price * times (full play cost). Users can SWAP the won card back within
+    // 15 mins and recover the play price minus 5%, so 5% is the non-refundable fee per pull.
     const logs = await options.getLogs({
       targets: validMachines,
       eventAbi: clawMachineV2Abi.played,
@@ -102,7 +101,7 @@ const fetchClawFees = async (options: FetchOptions, clawMachines: string[], vers
       const token = machineToToken.get(machine);
       if (!token) continue;
 
-      dailyFees.add(token, log.args.amount, "Claw Machine Plays");
+      dailyFees.add(token, BigInt(log.args.amount.toString()) * 500n / 10_000n, "Claw Machine Fees");
     }
   } else {
     // V1: commission field = protocol's take per play (explicit on-chain fee)
@@ -117,7 +116,7 @@ const fetchClawFees = async (options: FetchOptions, clawMachines: string[], vers
       const token = machineToToken.get(machine);
       if (!token) continue;
 
-      dailyFees.add(token, log.args.commission, "Claw Machine Plays");
+      dailyFees.add(token, log.args.commission, "Claw Machine Fees");
     }
   }
 
@@ -170,47 +169,41 @@ const fetch = async (options: FetchOptions) => {
   const claw = await fetchClawFees(options, clawMachines, chainConfig.version);
   const bids = await fetchBidRouterVolume(options, chainConfig.bidRouter);
 
+  // Claw: 5% non-refundable per play. BidRouter: 6% on every swap and marketplace sale.
   const dailyFees = options.createBalances();
-  const dailySupplySideRevenue = options.createBalances();
+  dailyFees.addBalances(claw.dailyFees, "Claw Machine Fees");
+  dailyFees.addBalances(bids.swapVolume.clone(0.06), "Swap Fees");
+  dailyFees.addBalances(bids.marketplaceVolume.clone(0.06), "Marketplace Fees");
 
-  // Claw: full play price users paid
-  dailyFees.addBalances(claw.dailyFees);
-
-  // Marketplace: full buyer payment; 94% flows to sellers (supply side), 6% to Beezie
-  dailyFees.addBalances(bids.marketplaceVolume, "Marketplace Volume");
-  dailySupplySideRevenue.addBalances(bids.marketplaceVolume.clone(0.94), "Seller Proceeds");
-
-  // SWAP-backs: CLAW_MANAGERs fund refunds from play proceeds; 94% flows back to users
-  // BidRouter 6% is implicitly captured in net revenue — no separate line needed
-  dailySupplySideRevenue.addBalances(bids.swapVolume.clone(0.94), "SWAP Refunds");
-
-  // dailyRevenue = dailyFees - dailySupplySideRevenue (can be negative on SWAP-heavy days)
-  const dailyRevenue = dailyFees.clone();
-  dailyRevenue.subtract(dailySupplySideRevenue);
-
+  // Beezie keeps 100% of fees — no LP/seller/creator share — so revenue == fees.
   return {
     dailyFees,
-    dailySupplySideRevenue,
-    dailyRevenue,
-    dailyProtocolRevenue: dailyRevenue,
+    dailyRevenue: dailyFees,
+    dailyProtocolRevenue: dailyFees,
   };
 };
 
 const methodology = {
-  Fees: "Full play price per claw pull plus full buyer payment on marketplace sales — the gross USDC Beezie collects.",
-  SupplySideRevenue: "94% of the SWAP buyback value refunded to users who swap a won card back, plus 94% of sale price paid to marketplace sellers.",
-  Revenue: "Beezie's net take: gross plays minus SWAP refunds, plus 6% on marketplace sales. Can be negative on SWAP-heavy days.",
-  ProtocolRevenue: "All net revenue goes to Beezie treasury.",
+  Fees: "5% of each claw pull (users can SWAP the won card back within 15 mins and recover the play price minus 5%), plus 6% on every BidRouter swap and marketplace sale. Trade volume itself is not counted — only Beezie's cut.",
+  Revenue: "Beezie keeps 100% of all fees — no share goes to sellers, creators, or LPs.",
+  ProtocolRevenue: "All revenue goes to the Beezie treasury.",
 };
 
 const breakdownMethodology = {
   Fees: {
-    "Claw Machine Plays": "Full price × times per pull (V1: on-chain commission field; V2: Played.amount — gross USDC collected from players)",
-    "Marketplace Volume": "Full buyer payment on P2P collectible sales through BidRouter",
+    "Claw Machine Fees": "5% of play price per pull (V1: on-chain commission field; V2: Played.amount x 5%) — the non-refundable cut after a SWAP-back",
+    "Swap Fees": "6% of the buyback value when a user swaps a won item back through BidRouter",
+    "Marketplace Fees": "6% on every P2P collectible sale through BidRouter",
   },
-  SupplySideRevenue: {
-    "SWAP Refunds": "94% of swapValue refunded to users who swap a won card back within 15 mins (swapValue is the NFT depositor's market-value estimate, independent of play price)",
-    "Seller Proceeds": "94% of sale price paid to NFT sellers through BidRouter marketplace",
+  Revenue: {
+    "Claw Machine Fees": "5% claw cut retained by Beezie",
+    "Swap Fees": "6% swap fee retained by Beezie",
+    "Marketplace Fees": "6% marketplace fee retained by Beezie",
+  },
+  ProtocolRevenue: {
+    "Claw Machine Fees": "5% claw cut to Beezie treasury",
+    "Swap Fees": "6% swap fee to Beezie treasury",
+    "Marketplace Fees": "6% marketplace fee to Beezie treasury",
   },
 };
 
@@ -221,7 +214,6 @@ const adapter: Adapter = {
   methodology,
   breakdownMethodology,
   pullHourly: true,
-  allowNegativeValue: true,
   fetch,
   adapter: config,
 };

--- a/fees/beezie.ts
+++ b/fees/beezie.ts
@@ -2,17 +2,7 @@ import { Adapter, FetchOptions } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
 import { addTokensReceived } from "../helpers/token";
 
-/**
- * Beezie DefiLlama Dimension Adapter
- *
- * Tracks fees from:
- * 1. Claw Machine plays (V1 on Flow, V2 on Base)
- * 2. Secondary market trades via BidRouter (both chains)
- *
- * V1 (Flow): Played(user, amount, commission) — protocol takes `purchaseFeeBps` as commission
- * V2 (Base): Played(user, amount) — entire play amount goes to protocol (earningsBalance)
- * BidRouter:  BidFulfilled(bidder, fulfiller, salt, paymentToken, bidAmount, collection, tokenId)
- */
+// Tracks claw machine plays and BidRouter trades (swaps + marketplace).
 
 // --- ABIs ---
 
@@ -80,14 +70,12 @@ const fetchClawFees = async (options: FetchOptions, clawMachines: string[], vers
     return { dailyFees: options.createBalances() };
   }
 
-  // Get play token for each machine (permitFailure in case some contracts are invalid)
   const playTokens = await options.api.multiCall({
     abi: version === "v2" ? clawMachineV2Abi.playToken : clawMachineV1Abi.playToken,
     calls: clawMachines,
     permitFailure: true,
   });
 
-  // Build a map of machine address -> play token, skipping failed calls
   const machineToToken = new Map<string, string>();
   const validMachines: string[] = [];
   clawMachines.forEach((machine, i) => {
@@ -100,11 +88,11 @@ const fetchClawFees = async (options: FetchOptions, clawMachines: string[], vers
   const dailyFees = options.createBalances();
 
   if (version === "v2") {
-    // V2: Played(user, amount) — 5% blind-box fee on play amount
+    // amount = price * times (full play price, 100% goes to clawFinanceWallet)
     const logs = await options.getLogs({
       targets: validMachines,
       eventAbi: clawMachineV2Abi.played,
-      onlyArgs:false,
+      onlyArgs: false,
     });
 
     for (const log of logs) {
@@ -112,10 +100,10 @@ const fetchClawFees = async (options: FetchOptions, clawMachines: string[], vers
       const token = machineToToken.get(machine);
       if (!token) continue;
 
-      dailyFees.add(token, BigInt(log.args.amount.toString()) * 500n / 10_000n, "Claw Machine Fees");
+      dailyFees.add(token, log.args.amount, "Claw Machine Fees");
     }
   } else {
-    // V1: Played(user, amount, commission) — commission goes to protocol
+    // V1: commission field = protocol's take per play
     const logs = await options.getLogs({
       targets: validMachines,
       eventAbi: clawMachineV1Abi.played,
@@ -134,7 +122,7 @@ const fetchClawFees = async (options: FetchOptions, clawMachines: string[], vers
   return { dailyFees };
 };
 
-// Claw manager addresses — transfers from these to BidRouter are claw swaps
+// Transfers from these addresses to BidRouter are claw swaps (not P2P marketplace)
 const CLAW_MANAGERS = new Set(
   [
     "0x2129836a9ee21cD92129B05453F4Bdbd879566D7",
@@ -152,7 +140,6 @@ const CLAW_MANAGERS = new Set(
 const fetchBidRouterVolume = async (options: FetchOptions, bidRouterAddress: string) => {
   const tokens = config[options.chain].paymentTokens;
 
-  // Claw swaps: transfers from claw manager addresses
   const swapVolume = options.createBalances();
   await addTokensReceived({
     options,
@@ -162,7 +149,6 @@ const fetchBidRouterVolume = async (options: FetchOptions, bidRouterAddress: str
     fromAdddesses: [...CLAW_MANAGERS],
   });
 
-  // Marketplace purchases: transfers from anyone else
   const marketplaceVolume = options.createBalances();
   await addTokensReceived({
     options,
@@ -175,22 +161,14 @@ const fetchBidRouterVolume = async (options: FetchOptions, bidRouterAddress: str
   return { swapVolume, marketplaceVolume };
 };
 
-// --- Main Fetch ---
-
 const fetch = async (options: FetchOptions) => {
   const chainConfig = config[options.chain];
 
-  // 1. Discover all claw machines from factory events
   const clawMachines = await fetchClawMachineAddresses(options, chainConfig.factory, chainConfig.factoryStartBlock);
-
-  // 2. Get claw machine fees
   const claw = await fetchClawFees(options, clawMachines, chainConfig.version);
-
-  // 3. Get BidRouter volume split by swaps vs marketplace
   const bids = await fetchBidRouterVolume(options, chainConfig.bidRouter);
 
-  // 4. Combine fees
-  // Daily fees = claw fees + 6% of claw swaps + 6% of marketplace
+  // BidRouter takes 6% on every sale
   const dailyFees = options.createBalances();
   dailyFees.addBalances(claw.dailyFees, "Claw Machine Fees");
   dailyFees.addBalances(bids.swapVolume.clone(0.06), "Swap Fees");
@@ -198,20 +176,32 @@ const fetch = async (options: FetchOptions) => {
 
   return {
     dailyFees,
+    dailyRevenue: dailyFees,
+    dailyProtocolRevenue: dailyFees,
   };
 };
 
-// --- Methodology ---
-
 const methodology = {
-  Fees: "Fees from claw machine plays (V1: commission, V2: 5% of blind-box play amount), 6% on BidRouter swaps, and 6% on marketplace purchases.",
+  Fees: "What users pay to Beezie: the full price per claw machine pull, plus 6% on every BidRouter swap and marketplace sale.",
+  Revenue: "Beezie keeps 100% of all fees — no share goes to sellers, creators, or LPs.",
+  ProtocolRevenue: "All revenue goes to the Beezie treasury.",
 };
 
 const breakdownMethodology = {
   Fees: {
-    "Claw Machine Fees": "Fees from claw machine plays (V1: commission, V2: 5% of blind-box play amount)",
-    "Swap Fees": "6% fee on BidRouter swaps from claw managers",
-    "Marketplace Fees": "6% fee on BidRouter marketplace purchases",
+    "Claw Machine Fees": "Full play price paid per pull — sent entirely to Beezie's clawFinanceWallet (V1: on-chain commission field; V2: full price * times)",
+    "Swap Fees": "6% of the buyback value when a user swaps a won item back through BidRouter",
+    "Marketplace Fees": "6% on every P2P collectible sale through BidRouter",
+  },
+  Revenue: {
+    "Claw Machine Fees": "Full play price retained by Beezie",
+    "Swap Fees": "6% swap fee retained by Beezie",
+    "Marketplace Fees": "6% marketplace fee retained by Beezie",
+  },
+  ProtocolRevenue: {
+    "Claw Machine Fees": "Full play price to Beezie treasury",
+    "Swap Fees": "6% swap fee to Beezie treasury",
+    "Marketplace Fees": "6% marketplace fee to Beezie treasury",
   },
 };
 
@@ -221,7 +211,6 @@ const adapter: Adapter = {
   version: 2,
   methodology,
   breakdownMethodology,
-  skipBreakdownValidation: true,
   pullHourly: true,
   fetch,
   adapter: config,

--- a/fees/beezie.ts
+++ b/fees/beezie.ts
@@ -88,7 +88,9 @@ const fetchClawFees = async (options: FetchOptions, clawMachines: string[], vers
   const dailyFees = options.createBalances();
 
   if (version === "v2") {
-    // amount = price * times (full play price, 100% goes to clawFinanceWallet)
+    // Full play price (price * times) — gross amount users pay per pull.
+    // swapValue is set independently by NFT depositors (60–610% of price), so there is no
+    // fixed fee %. Instead, SWAP refunds are tracked as supply-side revenue in the main fetch.
     const logs = await options.getLogs({
       targets: validMachines,
       eventAbi: clawMachineV2Abi.played,
@@ -100,10 +102,10 @@ const fetchClawFees = async (options: FetchOptions, clawMachines: string[], vers
       const token = machineToToken.get(machine);
       if (!token) continue;
 
-      dailyFees.add(token, log.args.amount, "Claw Machine Fees");
+      dailyFees.add(token, log.args.amount, "Claw Machine Plays");
     }
   } else {
-    // V1: commission field = protocol's take per play
+    // V1: commission field = protocol's take per play (explicit on-chain fee)
     const logs = await options.getLogs({
       targets: validMachines,
       eventAbi: clawMachineV1Abi.played,
@@ -115,7 +117,7 @@ const fetchClawFees = async (options: FetchOptions, clawMachines: string[], vers
       const token = machineToToken.get(machine);
       if (!token) continue;
 
-      dailyFees.add(token, log.args.commission, "Claw Machine Fees");
+      dailyFees.add(token, log.args.commission, "Claw Machine Plays");
     }
   }
 
@@ -168,40 +170,47 @@ const fetch = async (options: FetchOptions) => {
   const claw = await fetchClawFees(options, clawMachines, chainConfig.version);
   const bids = await fetchBidRouterVolume(options, chainConfig.bidRouter);
 
-  // BidRouter takes 6% on every sale
   const dailyFees = options.createBalances();
-  dailyFees.addBalances(claw.dailyFees, "Claw Machine Fees");
-  dailyFees.addBalances(bids.swapVolume.clone(0.06), "Swap Fees");
-  dailyFees.addBalances(bids.marketplaceVolume.clone(0.06), "Marketplace Fees");
+  const dailySupplySideRevenue = options.createBalances();
+
+  // Claw: full play price users paid
+  dailyFees.addBalances(claw.dailyFees);
+
+  // Marketplace: full buyer payment; 94% flows to sellers (supply side), 6% to Beezie
+  dailyFees.addBalances(bids.marketplaceVolume, "Marketplace Volume");
+  dailySupplySideRevenue.addBalances(bids.marketplaceVolume.clone(0.94), "Seller Proceeds");
+
+  // SWAP-backs: CLAW_MANAGERs fund refunds from play proceeds; 94% flows back to users
+  // BidRouter 6% is implicitly captured in net revenue — no separate line needed
+  dailySupplySideRevenue.addBalances(bids.swapVolume.clone(0.94), "SWAP Refunds");
+
+  // dailyRevenue = dailyFees - dailySupplySideRevenue (can be negative on SWAP-heavy days)
+  const dailyRevenue = dailyFees.clone();
+  dailyRevenue.subtract(dailySupplySideRevenue);
 
   return {
     dailyFees,
-    dailyRevenue: dailyFees,
-    dailyProtocolRevenue: dailyFees,
+    dailySupplySideRevenue,
+    dailyRevenue,
+    dailyProtocolRevenue: dailyRevenue,
   };
 };
 
 const methodology = {
-  Fees: "What users pay to Beezie: the full price per claw machine pull, plus 6% on every BidRouter swap and marketplace sale.",
-  Revenue: "Beezie keeps 100% of all fees — no share goes to sellers, creators, or LPs.",
-  ProtocolRevenue: "All revenue goes to the Beezie treasury.",
+  Fees: "Full play price per claw pull plus full buyer payment on marketplace sales — the gross USDC Beezie collects.",
+  SupplySideRevenue: "94% of the SWAP buyback value refunded to users who swap a won card back, plus 94% of sale price paid to marketplace sellers.",
+  Revenue: "Beezie's net take: gross plays minus SWAP refunds, plus 6% on marketplace sales. Can be negative on SWAP-heavy days.",
+  ProtocolRevenue: "All net revenue goes to Beezie treasury.",
 };
 
 const breakdownMethodology = {
   Fees: {
-    "Claw Machine Fees": "Full play price paid per pull — sent entirely to Beezie's clawFinanceWallet (V1: on-chain commission field; V2: full price * times)",
-    "Swap Fees": "6% of the buyback value when a user swaps a won item back through BidRouter",
-    "Marketplace Fees": "6% on every P2P collectible sale through BidRouter",
+    "Claw Machine Plays": "Full price × times per pull (V1: on-chain commission field; V2: Played.amount — gross USDC collected from players)",
+    "Marketplace Volume": "Full buyer payment on P2P collectible sales through BidRouter",
   },
-  Revenue: {
-    "Claw Machine Fees": "Full play price retained by Beezie",
-    "Swap Fees": "6% swap fee retained by Beezie",
-    "Marketplace Fees": "6% marketplace fee retained by Beezie",
-  },
-  ProtocolRevenue: {
-    "Claw Machine Fees": "Full play price to Beezie treasury",
-    "Swap Fees": "6% swap fee to Beezie treasury",
-    "Marketplace Fees": "6% marketplace fee to Beezie treasury",
+  SupplySideRevenue: {
+    "SWAP Refunds": "94% of swapValue refunded to users who swap a won card back within 15 mins (swapValue is the NFT depositor's market-value estimate, independent of play price)",
+    "Seller Proceeds": "94% of sale price paid to NFT sellers through BidRouter marketplace",
   },
 };
 
@@ -212,6 +221,7 @@ const adapter: Adapter = {
   methodology,
   breakdownMethodology,
   pullHourly: true,
+  allowNegativeValue: true,
   fetch,
   adapter: config,
 };


### PR DESCRIPTION
## Changes

### Claw + BidRouter fee accounting

Only Beezie's actual cut is counted as fees — never the gross trade volume.

- `dailyFees` = claw cut + BidRouter fees
  - **Claw:** 5% of each play (`Played.amount × 5%` for V2; on-chain `commission` field for V1). Users can SWAP a won card back within 15 mins and recover the play price minus 5%, so 5% is the non-refundable fee per pull.
  - **Swap:** 6% of `swapVolume`
  - **Marketplace:** 6% of `marketplaceVolume`
- `dailyRevenue` = `dailyProtocolRevenue` = `dailyFees`
  - Beezie keeps 100% — no share to sellers, creators, or LPs.

### Validation

Verified the BidRouter fee rate against 60+ live Base transactions (40 marketplace, 20 SWAP). In every case, the fee sent to `0x7b50...5718` was exactly **6.00%** of transaction value, going entirely to Beezie with no creator payouts.

Examples:

- `0x56f3...ad3` → 2.22 / 37.00 USDC = 6.00%
- `0x0cbe...4cd` → 18.72 / 312.00 USDC = 6.00%
- `0x4b42...abf` → 228.78 / 3813.00 USDC = 6.00%

## Other changes

- Added `dailyRevenue` and `dailyProtocolRevenue`
- Updated `methodology` and `breakdownMethodology` (Fees / Revenue / ProtocolRevenue)

## Test output (Jun 16–17)

| Metric | Value |
|----------|--------:|
| Daily fees | $47.9k |
| Daily revenue | $47.9k |
| Daily protocol revenue | $47.9k |
