### PR TITLE
fix: correct invalid date string for Aave Mantle start date

### DIFF
--- a/helpers/aave/index.ts
+++ b/helpers/aave/index.ts
@@ -1031,7 +1031,7 @@ const aaveProtocolConfigs: Record<string, { config: {[key: string]: AaveAdapterE
         ],
       },
       [CHAIN.MANTLE]: {
-        start: '2024-05-117',
+        start: '2024-05-17',
         pools: [
           {
             version: 3,


### PR DESCRIPTION
Summary                                                                   
                                                                            
  - Fix typo in Aave Mantle chain start date: '2024-05-117' → '2024-05-17'