### PR TITLE
[feat] dotMega-Domains: track fees/revenue for dotmega domains.

### DIFF
--- a/fees/dotmega-domains/index.ts
+++ b/fees/dotmega-domains/index.ts
@@ -3,6 +3,7 @@ import { CHAIN } from "../../helpers/chains";
 import ADDRESSES from "../../helpers/coreAssets.json";
 import { addTokensReceived } from "../../helpers/token";
 
+// https://github.com/0xBreadguy/mega-names#contracts
 const MEGA_NAMES = "0x5B424C6CCba77b32b9625a6fd5A30D409d20d997";
 
 const fetch = async (options: FetchOptions) => {

--- a/fees/dotmega-domains/index.ts
+++ b/fees/dotmega-domains/index.ts
@@ -1,0 +1,63 @@
+import { FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import ADDRESSES from "../../helpers/coreAssets.json";
+import { addTokensReceived } from "../../helpers/token";
+
+const MEGA_NAMES = "0x5B424C6CCba77b32b9625a6fd5A30D409d20d997";
+
+const fetch = async (options: FetchOptions) => {
+  const feeRecipient = await options.api.call({
+    target: MEGA_NAMES,
+    abi: "function feeRecipient() view returns (address)",
+  });
+
+  const received = await addTokensReceived({
+    options,
+    token: ADDRESSES.megaeth.USDm,
+    target: feeRecipient,
+  });
+
+  const dailyFees = options.createBalances();
+  const dailyRevenue = options.createBalances();
+  const dailyProtocolRevenue = options.createBalances();
+
+  dailyFees.addBalances(received, "Domain Registration Fees");
+  dailyRevenue.addBalances(received, "Domain Registration Fees To Protocol");
+  dailyProtocolRevenue.addBalances(received, "Domain Registration Fees To Protocol");
+
+  return {
+    dailyFees,
+    dailyRevenue,
+    dailyProtocolRevenue,
+  };
+};
+
+const methodology = {
+  Fees: "Includes all domain registration fees paid by Dotmega Domains users.",
+  Revenue: "Revenue is domain registration fees retained by Dotmega Domains.",
+  ProtocolRevenue: "Protocol revenue is domain registration fees retained by Dotmega Domains.",
+};
+
+const breakdownMethodology = {
+  Fees: {
+    "Domain Registration Fees": "Domain registration fees paid by Dotmega Domains users in USDm.",
+  },
+  Revenue: {
+    "Domain Registration Fees To Protocol": "Domain registration fees retained by protocol.",
+  },
+  ProtocolRevenue: {
+    "Domain Registration Fees To Protocol": "Domain registration fees retained by protocol.",
+  },
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  pullHourly: true,
+  fetch,
+  chains: [CHAIN.MEGAETH],
+  start: "2026-02-14",
+  methodology,
+  breakdownMethodology,
+};
+
+export default adapter;


### PR DESCRIPTION
## Summary
- Adds a new fees adapter for Dotmega Domains (`.mega`) on MegaETH.
- Tracks USDm domain registration fee inflows as fees, revenue, and protocol revenue.
- Uses the MegaNames contract's live `feeRecipient()` value instead of hardcoding the recipient wallet.

## Protocol Info
- Website: https://dotmega.domains/
- GitHub: https://github.com/0xBreadguy/mega-names
- X: https://x.com/dotmegadomains
- Builder X: https://x.com/bread_
- Chain: MegaETH
- MegaNames contract: `0x5B424C6CCba77b32b9625a6fd5A30D409d20d997`
- USDm token: `0xFAfDdbb3FC7688494971a79cc65DCa3EF82079E7`

## Changes
- Added `fees/dotmega-domains/index.ts`.
- Uses `ADDRESSES.megaeth.USDm` from `helpers/coreAssets.json` for the tracked token.
- Calls `feeRecipient()` on the MegaNames contract at fetch time and tracks USDm transfers received by that address.
- Reports:
  - `dailyFees`
  - `dailyRevenue`
  - `dailyProtocolRevenue`
- Adds methodology and breakdown labels for `Domain Registration Fees` and `Domain Registration Fees To Protocol`.
- Sets adapter start date to `2026-02-14`, based on observed historical USDm fee inflows.

## Methodology
- Counts incoming USDm transfers to the current MegaNames `feeRecipient()` address as Dotmega Domains registration fees.
- Treats all tracked registration fees as protocol-retained revenue.
- Uses on-chain token transfer data with hourly pulls for MegaETH.

## Tests
- `pnpm test fees dotmega-domains`
- `pnpm test fees dotmega-domains 2026-02-15`
- `pnpm test fees dotmega-domains 2026-05-20`