### PR TITLE
Add Turbo (HyperEVM DEX) volume + fees adapter

### DIFF
--- a/dexs/turbo/index.ts
+++ b/dexs/turbo/index.ts
@@ -1,0 +1,29 @@
+import { uniV3Exports } from "../../helpers/uniswap";
+import { CHAIN } from "../../helpers/chains";
+
+// Turbo is a Uniswap V3 fork DEX on HyperEVM (chain 999).
+// Volume is the USD value of all swaps across Turbo's pools, discovered from
+// the same factory's PoolCreated events as the TVL adapter and summed from
+// on-chain Swap events. (This is the DEX's own pool volume, the same number
+// the app surfaces, not the smaller router-routed subset.)
+export default uniV3Exports(
+  {
+    [CHAIN.HYPERLIQUID]: {
+      factory: "0xc72d2695A203696243Aa3EdD6CC98E43262E007E",
+      start: "2026-05-30",
+      userFeesRatio: 1,       // traders pay 100% of the swap fee
+      revenueRatio: 0,        // Turbo takes no protocol cut; all fees go to LPs
+      protocolRevenueRatio: 0,
+    },
+  },
+  {
+    methodology: {
+      Volume: "USD value of all swaps across Turbo's Uniswap V3 pools on HyperEVM, summed from on-chain Swap events.",
+      Fees: "Swap fees paid by traders (each pool's fee tier applied to its swap volume).",
+      UserFees: "Swap fees paid by traders.",
+      Revenue: "Turbo charges no protocol fee, so protocol revenue is zero.",
+      ProtocolRevenue: "Turbo charges no protocol fee, so protocol revenue is zero.",
+      SupplySideRevenue: "All swap fees accrue to liquidity providers.",
+    },
+  }
+);


### PR DESCRIPTION
Adds a **volume + fees** adapter for **Turbo**, a Uniswap V3 DEX on HyperEVM (chain 999).

The TVL adapter was just merged into DefiLlama-Adapters (`registries/uniswapV3`, #19511), so the pool log-cache is populated. This reads it via `uniV3Exports` off the same factory `0xc72d2695A203696243Aa3EdD6CC98E43262E007E`.

`npx ts-node --transpile-only cli/testAdapter.ts dexs turbo` passes: ~$14k-26k/day volume (varies by day), and fees accrue entirely to LPs (Turbo charges no protocol fee, so revenue is 0).

methodology:
- Volume: USD value of all swaps across Turbo's Uniswap V3 pools, from on-chain Swap events.
- Fees: each pool's fee tier applied to its swap volume; 100% to LPs (SupplySideRevenue), 0 protocol revenue.
