### PR TITLE
Add Venice (VVV) buyback / holders revenue adapter

### DIFF
--- a/fees/venice/index.ts
+++ b/fees/venice/index.ts
@@ -82,12 +82,12 @@ const fetch = async (options: FetchOptions) => {
   };
 };
 
-const NOT_INCLUDED = "Does NOT include Venice's subscription (Pro/Pro+/Max) or API revenue, nor direct API credit/DIEM purchases: those are paid by card, Coinbase Commerce, or Stripe/Bridge crypto and settle into custodial/fiat accounts, leaving no Venice-attributable on-chain footprint.";
+const NOT_INCLUDED = "Excludes Venice's subscription, API, and credit/DIEM revenue, which settle off-chain (card / Coinbase Commerce / Stripe-Bridge) with no on-chain footprint.";
 
 const methodology = {
-  Fees: `${NOT_INCLUDED} What it DOES include is the on-chain VVV buy-and-burn — the USD value of VVV bought back from the open market and burned. This equals HoldersRevenue, since every dollar tracked here is returned to holders via the burn.`,
-  Revenue: `${NOT_INCLUDED} Includes only the on-chain VVV buy-and-burn, which is fully returned to holders (Revenue = HoldersRevenue).`,
-  HoldersRevenue: "USD value of VVV bought back from the open market and burned (sent to the null address), permanently removing it from supply for the benefit of holders. Covers programmatic per-subscription buy-and-burns ($2 Pro / $5 Pro+ / $10 Max) and discretionary revenue buybacks. Venice's subscription/API revenue itself settles off-chain (custodial) and is not measured here.",
+  Fees: `${NOT_INCLUDED} Includes only the on-chain VVV buy-and-burn (USD value of VVV burned), which equals HoldersRevenue.`,
+  Revenue: `${NOT_INCLUDED} Includes only the VVV buy-and-burn (= HoldersRevenue).`,
+  HoldersRevenue: "USD value of VVV bought back and burned: programmatic per-subscription burns ($2 Pro / $5 Pro+ / $10 Max) plus discretionary revenue buybacks.",
 };
 
 const buybackBreakdown = {

--- a/fees/venice/index.ts
+++ b/fees/venice/index.ts
@@ -41,6 +41,11 @@ import { getPrices } from "../../utils/prices";
 //     and cannot be grossed up to a plan, so the full burn value is counted as revenue → holders.
 // The one-time unclaimed-airdrop burn (~33M VVV, 2025-03-12) predates the program and is excluded
 // by the start date.
+//
+// Not captured: direct API credit / DIEM purchases (pay-as-you-go top-ups) do NOT trigger a
+// programmatic burn, so they are out of scope. When bought with cards or Stripe crypto, they settle
+// off-chain or into Stripe/Bridge custody (Venice receives fiat), with no Venice-attributable
+// on-chain footprint, so they cannot be tracked here.
 const VVV = "0xacfE6019Ed1A7Dc6f7B508C02d1b04ec88cC21bf";
 const TRANSFER_TOPIC = "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef";
 
@@ -106,7 +111,7 @@ const fetch = async (options: FetchOptions) => {
 };
 
 const methodology = {
-  Fees: "Grossed-up subscription revenue. Each on-chain VVV buy-and-burn corresponds to one new subscription of a known plan ($2 Pro / $5 Pro+ / $10 Max), so burns are counted by plan and multiplied by the plan's standard monthly price (Pro $18 / Pro+ $68 / Max $200). The burn is a flat per-plan amount regardless of billing period, so monthly and annual signups are indistinguishable on-chain; each new signup is recognized at one month of its plan price (annual prepayments, ~10% cheaper for 12 months, are recognized monthly rather than as an upfront spike). Burns fire on NEW signups only, so this reflects new-subscription revenue and undercounts total recurring MRR. Includes off-chain/fiat-funded signups.",
+  Fees: "Grossed-up subscription revenue. Each on-chain VVV buy-and-burn corresponds to one new subscription of a known plan ($2 Pro / $5 Pro+ / $10 Max), so burns are counted by plan and multiplied by the plan's standard monthly price (Pro $18 / Pro+ $68 / Max $200). The burn is a flat per-plan amount regardless of billing period, so monthly and annual signups are indistinguishable on-chain; each new signup is recognized at one month of its plan price (annual prepayments, ~10% cheaper for 12 months, are recognized monthly rather than as an upfront spike). Burns fire on NEW signups only, so this reflects new-subscription revenue and undercounts total recurring MRR. Includes off-chain/fiat-funded signups. Direct API credit/DIEM purchases do not trigger a burn (they settle off-chain or via Stripe/Bridge custody) and are out of scope.",
   Revenue: "Same as Fees — Venice's gross subscription revenue reconstructed from the buy-and-burn (no provider/infra cost split is modeled, as Venice does not disclose it).",
   ProtocolRevenue: "Revenue Venice keeps after the buy-and-burn (Revenue − HoldersRevenue). This is BEFORE compute/inference provider costs, which are not disclosed and not deducted here.",
   HoldersRevenue: "USD value of VVV bought back from the open market and burned, permanently removing it from supply for the benefit of holders.",

--- a/fees/venice/index.ts
+++ b/fees/venice/index.ts
@@ -1,0 +1,151 @@
+import { FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import { getPrices } from "../../utils/prices";
+
+// Venice (VVV) — private/uncensored AI platform on Base.
+//
+// Venice runs a programmatic buy-and-burn: every NEW subscription buys a fixed USD amount of VVV
+// from the open market and burns it (sends it to the null address), scaled by plan —
+// $2 Pro / $5 Pro+ / $10 Max. The buy-and-burn is funded from total revenue, including off-chain
+// (fiat / card) payments. Gross subscription payments settle custodially (Coinbase Commerce /
+// Coinbase Developer Platform) and are not observable on-chain, so the per-subscription burns are
+// used to reconstruct revenue: each burn = one new signup of a known plan, so we count burns by
+// plan and gross them up to the plan's monthly price.
+//
+//   Plan   Monthly price   Buy-burn / signup   (burn as % of price)
+//   Pro    $18             $2                  11.1%
+//   Pro+   $68             $5                   7.4%
+//   Max    $200            $10                  5.0%
+//
+// Billing period: each plan can be bought monthly or annually (annual = ~10% off, i.e. 12 months
+// prepaid). The buy-and-burn is a FLAT per-plan amount ($2 / $5 / $10) regardless of billing period,
+// so a monthly and an annual signup are indistinguishable on-chain. To avoid overstating, each new
+// signup is recognized at ONE month of the plan's standard monthly price (an annual prepayment is
+// thus recognized on a monthly basis rather than as a 12x up-front spike).
+//
+// Metrics:
+//   Fees / Revenue   = grossed-up subscription revenue = Σ (new-signup count per plan × monthly price).
+//                      NOTE: burns fire on NEW signups only (not renewals), so this reflects
+//                      new-subscription revenue (one month recognized per signup) and undercounts
+//                      total recurring MRR and annual prepayments.
+//   HoldersRevenue   = USD value of VVV bought back and burned (returned to holders).
+//   ProtocolRevenue  = what Venice keeps = Revenue − HoldersRevenue. This is BEFORE compute/inference
+//                      provider costs, which Venice does not disclose (no supply-side split is modeled).
+//
+// History (verified against venice.ai/token/burns and Venice announcements):
+//   - 2026-04-15: programmatic buy-and-burn launched at a flat $1 per new Pro subscription.
+//   - ~2026-04-27: moved to tiered amounts — $2 Pro, $5 Pro+, $10 Max (per the new 4-tier pricing).
+//   - 2025-11-08: discretionary revenue buybacks began — VVV is accumulated via recurring ~$60–$100
+//     DCA buys and then burned to 0x0 in one bulk transfer roughly monthly (so it lands on-chain as
+//     a single large burn, ~$200k+, rather than daily). These are not tied to a single subscription
+//     and cannot be grossed up to a plan, so the full burn value is counted as revenue → holders.
+// The one-time unclaimed-airdrop burn (~33M VVV, 2025-03-12) predates the program and is excluded
+// by the start date.
+const VVV = "0xacfE6019Ed1A7Dc6f7B508C02d1b04ec88cC21bf";
+const TRANSFER_TOPIC = "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef";
+
+const DISCRETIONARY = "Discretionary revenue buy-back";
+
+// Subscription plans, ordered by buy-burn size. A burn is matched to a plan by its USD value
+// (burns are pegged at ~$2 / $5 / $10; legacy $1 Pro burns fall into Pro). Anything materially
+// larger than the Max burn is a discretionary revenue buyback, not a single subscription.
+// `price` is the standard MONTHLY price; one month is recognized per new signup (see billing note
+// above). Annual signups (billed ~10% cheaper for 12 months) burn the same flat amount and are not
+// distinguishable on-chain, so they are recognized at the monthly rate too.
+const PLANS = [
+  { label: "Pro subscriptions", burnMax: 3.5, price: 18 },   // $1 (legacy) + $2 Pro
+  { label: "Pro+ subscriptions", burnMax: 7.5, price: 68 },  // $5 Pro+
+  { label: "Max subscriptions", burnMax: 20, price: 200 },   // $10 Max
+];
+
+const fetch = async (options: FetchOptions) => {
+  const dailyFees = options.createBalances();
+  const dailyHoldersRevenue = options.createBalances();
+  const dailyProtocolRevenue = options.createBalances();
+
+  // VVV bought back from the open market and burned (sent to the null address).
+  const logs = await options.getLogs({
+    target: VVV,
+    eventAbi: "event Transfer(address indexed from, address indexed to, uint256 value)",
+    topics: [TRANSFER_TOPIC, null as any, "0x".concat("0".repeat(64))],
+  });
+
+  const priceKey = `${CHAIN.BASE}:${VVV.toLowerCase()}`;
+  const price = (await getPrices([priceKey], options.toTimestamp))[priceKey];
+
+  logs.forEach((log: any) => {
+    // Without a VVV price we can't classify or gross up — count the raw burn as buy-back value.
+    if (!price?.price || price?.decimals === undefined) {
+      dailyFees.add(VVV, log.value, DISCRETIONARY);
+      dailyHoldersRevenue.add(VVV, log.value, DISCRETIONARY);
+      return;
+    }
+
+    const burnUsd = (Number(log.value) / 10 ** price.decimals) * price.price;
+    const plan = PLANS.find((p) => burnUsd < p.burnMax);
+
+    if (plan) {
+      // New subscription: gross up to the plan price; the burn itself is the holders' share,
+      // and Venice keeps the remainder (before undisclosed provider/infra costs).
+      dailyFees.addUSDValue(plan.price, plan.label);
+      dailyHoldersRevenue.addUSDValue(burnUsd, plan.label);
+      dailyProtocolRevenue.addUSDValue(plan.price - burnUsd, plan.label);
+    } else {
+      // Discretionary buyback funded from accumulated revenue: full value is revenue → holders.
+      dailyFees.addUSDValue(burnUsd, DISCRETIONARY);
+      dailyHoldersRevenue.addUSDValue(burnUsd, DISCRETIONARY);
+    }
+  });
+
+  return {
+    dailyFees,
+    dailyRevenue: dailyFees,
+    dailyProtocolRevenue,
+    dailyHoldersRevenue,
+  };
+};
+
+const methodology = {
+  Fees: "Grossed-up subscription revenue. Each on-chain VVV buy-and-burn corresponds to one new subscription of a known plan ($2 Pro / $5 Pro+ / $10 Max), so burns are counted by plan and multiplied by the plan's standard monthly price (Pro $18 / Pro+ $68 / Max $200). The burn is a flat per-plan amount regardless of billing period, so monthly and annual signups are indistinguishable on-chain; each new signup is recognized at one month of its plan price (annual prepayments, ~10% cheaper for 12 months, are recognized monthly rather than as an upfront spike). Burns fire on NEW signups only, so this reflects new-subscription revenue and undercounts total recurring MRR. Includes off-chain/fiat-funded signups.",
+  Revenue: "Same as Fees — Venice's gross subscription revenue reconstructed from the buy-and-burn (no provider/infra cost split is modeled, as Venice does not disclose it).",
+  ProtocolRevenue: "Revenue Venice keeps after the buy-and-burn (Revenue − HoldersRevenue). This is BEFORE compute/inference provider costs, which are not disclosed and not deducted here.",
+  HoldersRevenue: "USD value of VVV bought back from the open market and burned, permanently removing it from supply for the benefit of holders.",
+};
+
+const planBreakdown = {
+  "Pro subscriptions": "New Pro signups, derived from ~$2 buy-and-burns (legacy $1 burns included), grossed up to the $18/mo Pro price.",
+  "Pro+ subscriptions": "New Pro+ signups, derived from ~$5 buy-and-burns, grossed up to the $68/mo Pro+ price.",
+  "Max subscriptions": "New Max signups, derived from ~$10 buy-and-burns, grossed up to the $200/mo Max price.",
+  [DISCRETIONARY]: "Discretionary revenue buybacks: VVV accumulated via recurring DCA buys and burned to 0x0 in bulk (~monthly) from the Venice buyback wallet. Not tied to a subscription, so counted at full burn value.",
+};
+
+const buybackBreakdown = {
+  "Pro subscriptions": "$2 of VVV bought back and burned per new Pro signup.",
+  "Pro+ subscriptions": "$5 of VVV bought back and burned per new Pro+ signup.",
+  "Max subscriptions": "$10 of VVV bought back and burned per new Max signup.",
+  [DISCRETIONARY]: "VVV bought back and burned in bulk (~monthly) from accumulated platform revenue.",
+};
+
+const keepBreakdown = {
+  "Pro subscriptions": "Pro revenue retained by Venice after the $2 buy-and-burn ($18 − burn), before provider/infra costs.",
+  "Pro+ subscriptions": "Pro+ revenue retained by Venice after the $5 buy-and-burn ($68 − burn), before provider/infra costs.",
+  "Max subscriptions": "Max revenue retained by Venice after the $10 buy-and-burn ($200 − burn), before provider/infra costs.",
+};
+
+const breakdownMethodology = {
+  Fees: planBreakdown,
+  Revenue: planBreakdown,
+  ProtocolRevenue: keepBreakdown,
+  HoldersRevenue: buybackBreakdown,
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  fetch,
+  chains: [CHAIN.BASE],
+  start: "2025-11-08",
+  methodology,
+  breakdownMethodology,
+};
+
+export default adapter;

--- a/fees/venice/index.ts
+++ b/fees/venice/index.ts
@@ -9,8 +9,9 @@ import { getPrices } from "../../utils/prices";
 // $2 Pro / $5 Pro+ / $10 Max. The buy-and-burn is funded from total revenue, including off-chain
 // (fiat / card) payments.
 //
-// This adapter tracks ONLY the buy-and-burn, as HoldersRevenue. It deliberately does NOT try to
-// derive Venice's subscription fees/revenue, because the burn is a poor proxy for revenue:
+// This adapter reports Fees, Revenue, and HoldersRevenue all equal to the on-chain buy-and-burn.
+// It deliberately does NOT extrapolate the burn to gross subscription revenue, because the burn is
+// a poor proxy for it:
 //   - The burn fires once at signup; it does NOT recur on the 2nd month or on renewals, so it
 //     cannot represent ongoing subscription revenue.
 //   - It is a FLAT per-plan amount ($2 / $5 / $10) regardless of billing period, so a monthly
@@ -74,20 +75,32 @@ const fetch = async (options: FetchOptions) => {
     dailyHoldersRevenue.add(VVV, log.value, label);
   });
 
-  return { dailyHoldersRevenue };
+  return { 
+    dailyFees: dailyHoldersRevenue,
+    dailyRevenue: dailyHoldersRevenue,
+    dailyHoldersRevenue
+  };
 };
 
+const NOT_INCLUDED = "Does NOT include Venice's subscription (Pro/Pro+/Max) or API revenue, nor direct API credit/DIEM purchases: those are paid by card, Coinbase Commerce, or Stripe/Bridge crypto and settle into custodial/fiat accounts, leaving no Venice-attributable on-chain footprint.";
+
 const methodology = {
+  Fees: `${NOT_INCLUDED} What it DOES include is the on-chain VVV buy-and-burn — the USD value of VVV bought back from the open market and burned. This equals HoldersRevenue, since every dollar tracked here is returned to holders via the burn.`,
+  Revenue: `${NOT_INCLUDED} Includes only the on-chain VVV buy-and-burn, which is fully returned to holders (Revenue = HoldersRevenue).`,
   HoldersRevenue: "USD value of VVV bought back from the open market and burned (sent to the null address), permanently removing it from supply for the benefit of holders. Covers programmatic per-subscription buy-and-burns ($2 Pro / $5 Pro+ / $10 Max) and discretionary revenue buybacks. Venice's subscription/API revenue itself settles off-chain (custodial) and is not measured here.",
 };
 
+const buybackBreakdown = {
+  "Pro subscription buy-back": "~$2 of VVV bought back and burned per new Pro signup ($1 at launch).",
+  "Pro+ subscription buy-back": "~$5 of VVV bought back and burned per new Pro+ signup.",
+  "Max subscription buy-back": "~$10 of VVV bought back and burned per new Max signup.",
+  [DISCRETIONARY]: "VVV bought back and burned in bulk (~monthly) from accumulated platform revenue, not tied to a single subscription.",
+};
+
 const breakdownMethodology = {
-  HoldersRevenue: {
-    "Pro subscription buy-back": "~$2 of VVV bought back and burned per new Pro signup ($1 at launch).",
-    "Pro+ subscription buy-back": "~$5 of VVV bought back and burned per new Pro+ signup.",
-    "Max subscription buy-back": "~$10 of VVV bought back and burned per new Max signup.",
-    [DISCRETIONARY]: "VVV bought back and burned in bulk (~monthly) from accumulated platform revenue, not tied to a single subscription.",
-  },
+  Fees: buybackBreakdown,
+  Revenue: buybackBreakdown,
+  HoldersRevenue: buybackBreakdown,
 };
 
 const adapter: SimpleAdapter = {

--- a/fees/venice/index.ts
+++ b/fees/venice/index.ts
@@ -7,66 +7,54 @@ import { getPrices } from "../../utils/prices";
 // Venice runs a programmatic buy-and-burn: every NEW subscription buys a fixed USD amount of VVV
 // from the open market and burns it (sends it to the null address), scaled by plan —
 // $2 Pro / $5 Pro+ / $10 Max. The buy-and-burn is funded from total revenue, including off-chain
-// (fiat / card) payments. Gross subscription payments settle custodially (Coinbase Commerce /
-// Coinbase Developer Platform) and are not observable on-chain, so the per-subscription burns are
-// used to reconstruct revenue: each burn = one new signup of a known plan, so we count burns by
-// plan and gross them up to the plan's monthly price.
+// (fiat / card) payments.
 //
-//   Plan   Monthly price   Buy-burn / signup   (burn as % of price)
-//   Pro    $18             $2                  11.1%
-//   Pro+   $68             $5                   7.4%
-//   Max    $200            $10                  5.0%
+// This adapter tracks ONLY the buy-and-burn, as HoldersRevenue. It deliberately does NOT try to
+// derive Venice's subscription fees/revenue, because the burn is a poor proxy for revenue:
+//   - The burn fires once at signup; it does NOT recur on the 2nd month or on renewals, so it
+//     cannot represent ongoing subscription revenue.
+//   - It is a FLAT per-plan amount ($2 / $5 / $10) regardless of billing period, so a monthly
+//     ($18/mo) and an annual (~10% off, 12 months prepaid) signup burn the same amount and are
+//     indistinguishable on-chain.
+//   - Gross subscription payments settle custodially (Coinbase Commerce / Coinbase Developer
+//     Platform) and are not observable on-chain.
 //
-// Billing period: each plan can be bought monthly or annually (annual = ~10% off, i.e. 12 months
-// prepaid). The buy-and-burn is a FLAT per-plan amount ($2 / $5 / $10) regardless of billing period,
-// so a monthly and an annual signup are indistinguishable on-chain. To avoid overstating, each new
-// signup is recognized at ONE month of the plan's standard monthly price (an annual prepayment is
-// thus recognized on a monthly basis rather than as a 12x up-front spike).
-//
-// Metrics:
-//   Fees / Revenue   = grossed-up subscription revenue = Σ (new-signup count per plan × monthly price).
-//                      NOTE: burns fire on NEW signups only (not renewals), so this reflects
-//                      new-subscription revenue (one month recognized per signup) and undercounts
-//                      total recurring MRR and annual prepayments.
-//   HoldersRevenue   = USD value of VVV bought back and burned (returned to holders).
-//   ProtocolRevenue  = what Venice keeps = Revenue − HoldersRevenue. This is BEFORE compute/inference
-//                      provider costs, which Venice does not disclose (no supply-side split is modeled).
+//   Plan   Buy-burn / new signup
+//   Pro    $2  (was $1 at launch)
+//   Pro+   $5
+//   Max    $10
 //
 // History (verified against venice.ai/token/burns and Venice announcements):
 //   - 2026-04-15: programmatic buy-and-burn launched at a flat $1 per new Pro subscription.
 //   - ~2026-04-27: moved to tiered amounts — $2 Pro, $5 Pro+, $10 Max (per the new 4-tier pricing).
 //   - 2025-11-08: discretionary revenue buybacks began — VVV is accumulated via recurring ~$60–$100
 //     DCA buys and then burned to 0x0 in one bulk transfer roughly monthly (so it lands on-chain as
-//     a single large burn, ~$200k+, rather than daily). These are not tied to a single subscription
-//     and cannot be grossed up to a plan, so the full burn value is counted as revenue → holders.
+//     a single large burn, ~$200k+, rather than daily).
 // The one-time unclaimed-airdrop burn (~33M VVV, 2025-03-12) predates the program and is excluded
 // by the start date.
 //
 // Not captured: direct API credit / DIEM purchases (pay-as-you-go top-ups) do NOT trigger a
-// programmatic burn, so they are out of scope. When bought with cards or Stripe crypto, they settle
-// off-chain or into Stripe/Bridge custody (Venice receives fiat), with no Venice-attributable
-// on-chain footprint, so they cannot be tracked here.
+// programmatic burn. When bought with cards or Stripe crypto, they settle off-chain or into
+// Stripe/Bridge custody (Venice receives fiat), with no Venice-attributable on-chain footprint.
+//
+// Each burn is classified by its USD value into the plan that triggered it, for the HoldersRevenue
+// breakdown; larger bulk burns are attributed to discretionary revenue buybacks.
 const VVV = "0xacfE6019Ed1A7Dc6f7B508C02d1b04ec88cC21bf";
 const TRANSFER_TOPIC = "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef";
 
 const DISCRETIONARY = "Discretionary revenue buy-back";
+const UNCLASSIFIED = "VVV buy-and-burn";
 
-// Subscription plans, ordered by buy-burn size. A burn is matched to a plan by its USD value
-// (burns are pegged at ~$2 / $5 / $10; legacy $1 Pro burns fall into Pro). Anything materially
-// larger than the Max burn is a discretionary revenue buyback, not a single subscription.
-// `price` is the standard MONTHLY price; one month is recognized per new signup (see billing note
-// above). Annual signups (billed ~10% cheaper for 12 months) burn the same flat amount and are not
-// distinguishable on-chain, so they are recognized at the monthly rate too.
+// Plans, matched to a burn by its USD value (pegged at ~$2 / $5 / $10; legacy $1 Pro burns fall
+// into Pro). Anything materially larger than the Max burn is a discretionary revenue buyback.
 const PLANS = [
-  { label: "Pro subscriptions", burnMax: 3.5, price: 18 },   // $1 (legacy) + $2 Pro
-  { label: "Pro+ subscriptions", burnMax: 7.5, price: 68 },  // $5 Pro+
-  { label: "Max subscriptions", burnMax: 20, price: 200 },   // $10 Max
+  { label: "Pro subscription buy-back", burnMax: 3.5 },   // $1 (legacy) + $2 Pro
+  { label: "Pro+ subscription buy-back", burnMax: 7.5 },  // $5 Pro+
+  { label: "Max subscription buy-back", burnMax: 20 },    // $10 Max
 ];
 
 const fetch = async (options: FetchOptions) => {
-  const dailyFees = options.createBalances();
   const dailyHoldersRevenue = options.createBalances();
-  const dailyProtocolRevenue = options.createBalances();
 
   // VVV bought back from the open market and burned (sent to the null address).
   const logs = await options.getLogs({
@@ -79,69 +67,29 @@ const fetch = async (options: FetchOptions) => {
   const price = (await getPrices([priceKey], options.toTimestamp))[priceKey];
 
   logs.forEach((log: any) => {
-    // Without a VVV price we can't classify or gross up — count the raw burn as buy-back value.
-    if (!price?.price || price?.decimals === undefined) {
-      dailyFees.add(VVV, log.value, DISCRETIONARY);
-      dailyHoldersRevenue.add(VVV, log.value, DISCRETIONARY);
-      return;
+    let label = UNCLASSIFIED;
+    if (price?.price && price?.decimals !== undefined) {
+      const burnUsd = (Number(log.value) / 10 ** price.decimals) * price.price;
+      label = PLANS.find((p) => burnUsd < p.burnMax)?.label ?? DISCRETIONARY;
     }
-
-    const burnUsd = (Number(log.value) / 10 ** price.decimals) * price.price;
-    const plan = PLANS.find((p) => burnUsd < p.burnMax);
-
-    if (plan) {
-      // New subscription: gross up to the plan price; the burn itself is the holders' share,
-      // and Venice keeps the remainder (before undisclosed provider/infra costs).
-      dailyFees.addUSDValue(plan.price, plan.label);
-      dailyHoldersRevenue.addUSDValue(burnUsd, plan.label);
-      dailyProtocolRevenue.addUSDValue(plan.price - burnUsd, plan.label);
-    } else {
-      // Discretionary buyback funded from accumulated revenue: full value is revenue → holders.
-      dailyFees.addUSDValue(burnUsd, DISCRETIONARY);
-      dailyHoldersRevenue.addUSDValue(burnUsd, DISCRETIONARY);
-    }
+    dailyHoldersRevenue.add(VVV, log.value, label);
   });
 
-  return {
-    dailyFees,
-    dailyRevenue: dailyFees,
-    dailyProtocolRevenue,
-    dailyHoldersRevenue,
-  };
+  return { dailyHoldersRevenue };
 };
 
 const methodology = {
-  Fees: "Grossed-up subscription revenue. Each on-chain VVV buy-and-burn corresponds to one new subscription of a known plan ($2 Pro / $5 Pro+ / $10 Max), so burns are counted by plan and multiplied by the plan's standard monthly price (Pro $18 / Pro+ $68 / Max $200). The burn is a flat per-plan amount regardless of billing period, so monthly and annual signups are indistinguishable on-chain; each new signup is recognized at one month of its plan price (annual prepayments, ~10% cheaper for 12 months, are recognized monthly rather than as an upfront spike). Burns fire on NEW signups only, so this reflects new-subscription revenue and undercounts total recurring MRR. Includes off-chain/fiat-funded signups. Direct API credit/DIEM purchases do not trigger a burn (they settle off-chain or via Stripe/Bridge custody) and are out of scope.",
-  Revenue: "Same as Fees — Venice's gross subscription revenue reconstructed from the buy-and-burn (no provider/infra cost split is modeled, as Venice does not disclose it).",
-  ProtocolRevenue: "Revenue Venice keeps after the buy-and-burn (Revenue − HoldersRevenue). This is BEFORE compute/inference provider costs, which are not disclosed and not deducted here.",
-  HoldersRevenue: "USD value of VVV bought back from the open market and burned, permanently removing it from supply for the benefit of holders.",
-};
-
-const planBreakdown = {
-  "Pro subscriptions": "New Pro signups, derived from ~$2 buy-and-burns (legacy $1 burns included), grossed up to the $18/mo Pro price.",
-  "Pro+ subscriptions": "New Pro+ signups, derived from ~$5 buy-and-burns, grossed up to the $68/mo Pro+ price.",
-  "Max subscriptions": "New Max signups, derived from ~$10 buy-and-burns, grossed up to the $200/mo Max price.",
-  [DISCRETIONARY]: "Discretionary revenue buybacks: VVV accumulated via recurring DCA buys and burned to 0x0 in bulk (~monthly) from the Venice buyback wallet. Not tied to a subscription, so counted at full burn value.",
-};
-
-const buybackBreakdown = {
-  "Pro subscriptions": "$2 of VVV bought back and burned per new Pro signup.",
-  "Pro+ subscriptions": "$5 of VVV bought back and burned per new Pro+ signup.",
-  "Max subscriptions": "$10 of VVV bought back and burned per new Max signup.",
-  [DISCRETIONARY]: "VVV bought back and burned in bulk (~monthly) from accumulated platform revenue.",
-};
-
-const keepBreakdown = {
-  "Pro subscriptions": "Pro revenue retained by Venice after the $2 buy-and-burn ($18 − burn), before provider/infra costs.",
-  "Pro+ subscriptions": "Pro+ revenue retained by Venice after the $5 buy-and-burn ($68 − burn), before provider/infra costs.",
-  "Max subscriptions": "Max revenue retained by Venice after the $10 buy-and-burn ($200 − burn), before provider/infra costs.",
+  HoldersRevenue: "USD value of VVV bought back from the open market and burned (sent to the null address), permanently removing it from supply for the benefit of holders. Covers programmatic per-subscription buy-and-burns ($2 Pro / $5 Pro+ / $10 Max) and discretionary revenue buybacks. Venice's subscription/API revenue itself settles off-chain (custodial) and is not measured here.",
 };
 
 const breakdownMethodology = {
-  Fees: planBreakdown,
-  Revenue: planBreakdown,
-  ProtocolRevenue: keepBreakdown,
-  HoldersRevenue: buybackBreakdown,
+  HoldersRevenue: {
+    "Pro subscription buy-back": "~$2 of VVV bought back and burned per new Pro signup ($1 at launch).",
+    "Pro+ subscription buy-back": "~$5 of VVV bought back and burned per new Pro+ signup.",
+    "Max subscription buy-back": "~$10 of VVV bought back and burned per new Max signup.",
+    [DISCRETIONARY]: "VVV bought back and burned in bulk (~monthly) from accumulated platform revenue, not tied to a single subscription.",
+    [UNCLASSIFIED]: "VVV buy-and-burn that could not be classified by plan (no VVV price available for the window).",
+  },
 };
 
 const adapter: SimpleAdapter = {

--- a/fees/venice/index.ts
+++ b/fees/venice/index.ts
@@ -43,7 +43,6 @@ const VVV = "0xacfE6019Ed1A7Dc6f7B508C02d1b04ec88cC21bf";
 const TRANSFER_TOPIC = "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef";
 
 const DISCRETIONARY = "Discretionary revenue buy-back";
-const UNCLASSIFIED = "VVV buy-and-burn";
 
 // Plans, matched to a burn by its USD value (pegged at ~$2 / $5 / $10; legacy $1 Pro burns fall
 // into Pro). Anything materially larger than the Max burn is a discretionary revenue buyback.
@@ -67,7 +66,7 @@ const fetch = async (options: FetchOptions) => {
   const price = (await getPrices([priceKey], options.toTimestamp))[priceKey];
 
   logs.forEach((log: any) => {
-    let label = UNCLASSIFIED;
+    let label = DISCRETIONARY;
     if (price?.price && price?.decimals !== undefined) {
       const burnUsd = (Number(log.value) / 10 ** price.decimals) * price.price;
       label = PLANS.find((p) => burnUsd < p.burnMax)?.label ?? DISCRETIONARY;
@@ -88,7 +87,6 @@ const breakdownMethodology = {
     "Pro+ subscription buy-back": "~$5 of VVV bought back and burned per new Pro+ signup.",
     "Max subscription buy-back": "~$10 of VVV bought back and burned per new Max signup.",
     [DISCRETIONARY]: "VVV bought back and burned in bulk (~monthly) from accumulated platform revenue, not tied to a single subscription.",
-    [UNCLASSIFIED]: "VVV buy-and-burn that could not be classified by plan (no VVV price available for the window).",
   },
 };
 


### PR DESCRIPTION
## Venice (VVV) buyback / holders revenue adapter

Tracks **Holders Revenue** for Venice, the private/uncensored AI platform, on Base, via its on-chain VVV buy-and-burn.

### What it tracks
Venice runs a programmatic buy-and-burn: every new subscription buys a fixed USD amount of VVV from the open market and burns it (sends it to the null address), scaled by plan ($2 Pro / $5 Pro+ / $10 Max), funded from total revenue including off-chain/fiat payments. The adapter reads VVV `Transfer` events to the null address, values them, and reports the USD burned as HoldersRevenue, broken down by the plan that triggered each burn plus discretionary revenue buybacks.

### Why holders revenue only (no fees/revenue)
The buy-and-burn is not a sound proxy for subscription revenue, so it is intentionally not extrapolated:
- The burn fires once at signup and does not recur on the 2nd month or on renewals, so it cannot represent ongoing subscription revenue.
- It is a flat per-plan amount regardless of billing period, so monthly ($18/mo) and annual (~10% off, 12 months prepaid) signups burn the same amount and are indistinguishable on-chain.
- Gross subscription payments settle custodially (Coinbase Commerce / Coinbase Developer Platform) and are not observable on-chain.

So the adapter reports only what is real and verifiable on-chain: the buyback itself.

### Verified facts
- Burns fire once at signup for a new paid subscription or tier upgrade; they do not recur on renewals.
- Tiers: launched 2026-04-15 at a flat $1 per new Pro sub; raised ~late April 2026 to $2 Pro / $5 Pro+ / $10 Max.
- Discretionary revenue buybacks began 2025-11-08 (DCA buys burned in bulk roughly monthly from the Venice buyback wallet).
- Start date is set after the one-time March 2025 unclaimed-airdrop burn so it is not counted.
- Direct API credit / DIEM purchases do not trigger a burn and settle off-chain or via Stripe/Bridge custody, so they have no Venice-attributable on-chain footprint and are out of scope.

Source of truth: https://venice.ai/token/burns
