### PR TITLE
fix: compute 3F fees from FeesAccrued events

### DIFF
--- a/fees/3f.ts
+++ b/fees/3f.ts
@@ -1,25 +1,22 @@
 import { FetchOptions, SimpleAdapter } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
-import { METRIC } from "../helpers/metrics";
 
 const POSITION_MANAGER_FACTORY = "0x8e0667429d1717b3e5fe783a6c472d6d901fe5fa";
 const FACTORY_DEPLOY_BLOCK = 24844184;
 
 const Abis = {
   PositionManagerCreated: "event PositionManagerCreated(address indexed positionManager, address indexed owner, address indexed collateralAsset, address debtAsset, uint256 ltv, address transferGuard)",
+  // Emitted when fees are accrued and minted (as shares) to the fee recipient.
+  FeesAccrued: "event FeesAccrued(address indexed feeRecipient, uint256 shares)",
   totalAssets: "uint256:totalAssets",
+  totalSupply: "uint256:totalSupply",
   assets: "function assets() view returns (address collateralAsset, address debtAsset)",
-  feeData: "function feeData() view returns (address feeRecipient, uint24 managementFee, uint24 performanceFee, uint256 lastTotalAssets, uint40 lastFeeAccrualTimestamp)",
 };
-
-const BPS = BigInt(10000);
-const SECONDS_PER_YEAR = BigInt(365 * 24 * 60 * 60);
 
 const fetch = async (options: FetchOptions) => {
   const dailyFees = options.createBalances();
-  const dailyRevenue = options.createBalances();
-  const dailySupplySideRevenue = options.createBalances();
 
+  // Discover all Position Managers ever created by the factory.
   const factoryLogs = await options.getLogs({
     target: POSITION_MANAGER_FACTORY,
     eventAbi: Abis.PositionManagerCreated,
@@ -30,81 +27,47 @@ const fetch = async (options: FetchOptions) => {
   const positionManagers = factoryLogs.map((log: any) => log.positionManager);
   if (positionManagers.length === 0) return { dailyFees, dailyRevenue: dailyFees };
 
-  const [assetsResults, assetsBefore, assetsAfter, feeDataResults] = await Promise.all([
-    options.api.multiCall({
-      abi: Abis.assets,
-      calls: positionManagers,
-      permitFailure: true,
-    }),
-    options.fromApi.multiCall({
-      abi: Abis.totalAssets,
-      calls: positionManagers,
-      permitFailure: true,
-    }),
-    options.toApi.multiCall({
-      abi: Abis.totalAssets,
-      calls: positionManagers,
-      permitFailure: true,
-    }),
-    options.api.multiCall({
-      abi: Abis.feeData,
-      calls: positionManagers,
-      permitFailure: true,
-    }),
+  // For each Position Manager:
+  //  - read its debt asset (fees are denominated in shares -> converted to debt asset)
+  //  - read totalAssets/totalSupply at the end of the window to price the fee shares
+  //  - collect FeesAccrued events emitted during the window
+  const [assetsResults, totalAssetsResults, totalSupplyResults, feesLogs] = await Promise.all([
+    options.api.multiCall({ abi: Abis.assets, calls: positionManagers, permitFailure: true }),
+    options.toApi.multiCall({ abi: Abis.totalAssets, calls: positionManagers, permitFailure: true }),
+    options.toApi.multiCall({ abi: Abis.totalSupply, calls: positionManagers, permitFailure: true }),
+    options.getLogs({ targets: positionManagers, eventAbi: Abis.FeesAccrued, flatten: false }),
   ]);
-  const elapsed = BigInt(options.toTimestamp - options.fromTimestamp);
 
   for (let i = 0; i < positionManagers.length; i++) {
     const assets = assetsResults[i];
-    const totalAssetsBefore = assetsBefore[i];
-    const totalAssetsAfter = assetsAfter[i];
-    const feeData = feeDataResults[i];
-    if (!assets || !totalAssetsAfter || !feeData) continue;
+    const totalAssets = totalAssetsResults[i];
+    const totalSupply = totalSupplyResults[i];
+    const logs = feesLogs[i] || [];
+    if (!assets || !totalAssets || !totalSupply || BigInt(totalSupply) === BigInt(0)) continue;
 
-    if (BigInt(totalAssetsAfter) <= BigInt(0)) continue;
-
-    const debtAsset = assets.debtAsset;
-    const managementFee = BigInt(feeData.managementFee);
-    const performanceFee = BigInt(feeData.performanceFee);
-
-    // management fee
-    const managementFeeAmount = BigInt(totalAssetsAfter) * managementFee * elapsed / (BPS * SECONDS_PER_YEAR);
-
-    if (managementFeeAmount > BigInt(0)) {
-      dailyFees.add(debtAsset, managementFeeAmount, METRIC.MANAGEMENT_FEES);
-      dailyRevenue.add(debtAsset, managementFeeAmount, METRIC.MANAGEMENT_FEES);
+    // Sum all fee shares minted to the fee recipient during the window.
+    let feeShares = BigInt(0);
+    for (const log of logs) {
+      feeShares += BigInt(log.shares);
     }
+    if (feeShares === BigInt(0)) continue;
 
-    // performance fee and supply side from gains within this period
-    let performanceFeeAmount = BigInt(0);
-    if (totalAssetsBefore) {
-      const gains = BigInt(totalAssetsAfter) - BigInt(totalAssetsBefore);
-
-      if (performanceFee > BigInt(0) && gains > managementFeeAmount) {
-        performanceFeeAmount = (gains - managementFeeAmount) * performanceFee / BPS;
-        dailyFees.add(debtAsset, performanceFeeAmount, METRIC.PERFORMANCE_FEES);
-        dailyRevenue.add(debtAsset, performanceFeeAmount, METRIC.PERFORMANCE_FEES);
-      }
-
-      // supply side
-      const supplySide = gains - performanceFeeAmount;
-      dailyFees.add(debtAsset, supplySide, METRIC.ASSETS_YIELDS);
-      dailySupplySideRevenue.add(debtAsset, supplySide, METRIC.ASSETS_YIELDS);
-    }
+    // Convert fee shares to the debt asset: shares * totalAssets / totalSupply.
+    const feeAssets = feeShares * BigInt(totalAssets) / BigInt(totalSupply);
+    dailyFees.add(assets.debtAsset, feeAssets);
   }
 
+  // All accrued fees are minted to the protocol fee recipient, so fees == revenue.
   return {
     dailyFees,
-    dailyRevenue,
-    dailyProtocolRevenue: dailyRevenue,
-    dailySupplySideRevenue,
+    dailyRevenue: dailyFees,
+    dailyProtocolRevenue: dailyFees,
   };
 };
 
 const adapter: SimpleAdapter = {
   version: 2,
   pullHourly: true,
-  allowNegativeValue: true,
   adapter: {
     [CHAIN.ETHEREUM]: {
       fetch,
@@ -112,28 +75,9 @@ const adapter: SimpleAdapter = {
     },
   },
   methodology: {
-    Fees: "Total yield generated from Position Manager leveraged exposure to tokenized RWAs, including management fees, performance fees, and net yield distributed to share holders.",
-    Revenue: "Protocol revenue from management and performance fees collected by the facility fee recipient.",
-    ProtocolRevenue: "Protocol revenue from management and performance fees collected by the facility fee recipient.",
-    SupplySideRevenue: "Net yield from leveraged RWA exposure distributed to Position Manager share holders after fees.",
-  },
-  breakdownMethodology: {
-    Fees: {
-      [METRIC.ASSETS_YIELDS]: "Net yield from leveraged RWA exposure distributed to Position Manager share holders.",
-      [METRIC.MANAGEMENT_FEES]: "Time-based management fees on total assets held in Position Manager leveraged RWA positions.",
-      [METRIC.PERFORMANCE_FEES]: "Performance fees on net gains from leveraged RWA exposure, charged after management fee deduction.",
-    },
-    Revenue: {
-      [METRIC.MANAGEMENT_FEES]: "Management fees collected by the protocol fee recipient.",
-      [METRIC.PERFORMANCE_FEES]: "Performance fees collected by the protocol fee recipient.",
-    },
-    ProtocolRevenue: {
-      [METRIC.MANAGEMENT_FEES]: "Management fees directed to the protocol fee recipient.",
-      [METRIC.PERFORMANCE_FEES]: "Performance fees directed to the protocol fee recipient.",
-    },
-    SupplySideRevenue: {
-      [METRIC.ASSETS_YIELDS]: "Net yield from leveraged RWA exposure distributed to Position Manager share holders.",
-    },
+    Fees: "3F charges two fees on its leveraged RWA positions. The performance fee is taken on the return of the leveraged collateral after subtracting the cost of the borrowed debt (for example, on a 10x position it applies to the RWA yield on the full leveraged exposure minus what is paid to service the debt). The management fee is taken on the entire value of the RWA collateral, including the leveraged portion (for example, on a 10x position it is charged on ten times the deposited amount, not just the user's own capital). Fees are accrued and collected when positions are updated, so a single day can include fees that built up over the previous days or weeks.",
+    Revenue: "Both the management and performance fees are paid to the protocol, so revenue equals the total fees collected.",
+    ProtocolRevenue: "Both the management and performance fees are paid to the protocol, so protocol revenue equals the total fees collected.",
   },
 };
 

--- a/fees/3f.ts
+++ b/fees/3f.ts
@@ -1,4 +1,6 @@
 import { ChainApi } from "@defillama/sdk";
+import PromisePool from "@supercharge/promise-pool";
+import pLimit from "p-limit";
 import { FetchOptions, SimpleAdapter } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
 import { METRIC } from "../helpers/metrics";
@@ -42,7 +44,7 @@ const fetch = async (options: FetchOptions) => {
 
   const [assetsResults, feesLogs] = await Promise.all([
     options.api.multiCall({ abi: Abis.assets, calls: positionManagers, permitFailure: true }),
-    options.getLogs({ targets: positionManagers, eventAbi: Abis.FeesAccrued, entireLog: true }),
+    options.getLogs({ targets: positionManagers, eventAbi: Abis.FeesAccrued, entireLog: true, parseLog: true }),
   ]);
 
   const debtAssetByManager: Record<string, string> = {};
@@ -60,7 +62,7 @@ const fetch = async (options: FetchOptions) => {
     eventsByBlock[block].push({
       manager: log.address.toLowerCase(),
       shares,
-      logIndex: Number(log.logIndex ?? log.index ?? 0),
+      logIndex: log.logIndex,
     });
   }
 
@@ -72,83 +74,87 @@ const fetch = async (options: FetchOptions) => {
   // `performanceFeeAssets = max(0, basis - managementFeeAssets) * performanceFee / BPS`.
   // Inverting `convertToShares` recovers `feeAssets` (denominated in the debt asset),
   // and with the basis known the management/performance split solves algebraically.
-  await Promise.all(Object.entries(eventsByBlock).map(async ([blockStr, events]) => {
-    const api = new ChainApi({ chain: options.chain, block: Number(blockStr) - 1 });
-    const managers = Array.from(new Set(events.map((event) => event.manager)));
-    const managerIndexes: Record<string, number> = {};
-    managers.forEach((manager, i) => { managerIndexes[manager] = i; });
+  const { errors } = await PromisePool.withConcurrency(1)
+    .for(Object.entries(eventsByBlock))
+    .process(async ([blockStr, events]) => {
+      const api = new ChainApi({ chain: options.chain, block: Number(blockStr) - 1 });
+      const managers = Array.from(new Set(events.map((event) => event.manager)));
+      const managerIndexes: Record<string, number> = {};
+      managers.forEach((manager, i) => { managerIndexes[manager] = i; });
 
-    const [feeDatas, totalAssetsResults, totalSupplyResults, offsets, lastDebts, collaterals, debts] = await Promise.all([
-      api.multiCall({ abi: Abis.feeData, calls: managers, permitFailure: true }),
-      api.multiCall({ abi: Abis.totalAssets, calls: managers, permitFailure: true }),
-      api.multiCall({ abi: Abis.totalSupply, calls: managers, permitFailure: true }),
-      api.multiCall({ abi: Abis.virtualShareOffset, calls: managers, permitFailure: true }),
-      api.multiCall({ abi: Abis.lastDebt, calls: managers, permitFailure: true }),
-      api.multiCall({ abi: Abis.collateralAmountQuoted, calls: managers, permitFailure: true }),
-      api.multiCall({ abi: Abis.debtAmount, calls: managers, permitFailure: true }),
-    ]);
+      const limit = pLimit(4);
+      const [feeDatas, totalAssetsResults, totalSupplyResults, offsets, lastDebts, collaterals, debts] = await Promise.all([
+        limit(() => api.multiCall({ abi: Abis.feeData, calls: managers, permitFailure: true })),
+        limit(() => api.multiCall({ abi: Abis.totalAssets, calls: managers, permitFailure: true })),
+        limit(() => api.multiCall({ abi: Abis.totalSupply, calls: managers, permitFailure: true })),
+        limit(() => api.multiCall({ abi: Abis.virtualShareOffset, calls: managers, permitFailure: true })),
+        limit(() => api.multiCall({ abi: Abis.lastDebt, calls: managers, permitFailure: true })),
+        limit(() => api.multiCall({ abi: Abis.collateralAmountQuoted, calls: managers, permitFailure: true })),
+        limit(() => api.multiCall({ abi: Abis.debtAmount, calls: managers, permitFailure: true })),
+      ]);
 
-    // A manager can accrue more than once in a block. The first accrual resets the
-    // fee snapshot, so later accruals in the same block have a zero performance basis,
-    // and their shares must be valued against the supply inflated by the earlier mints.
-    const mintedSharesByManager: Record<string, bigint> = {};
-    events.sort((a, b) => a.logIndex - b.logIndex);
+      // A manager can accrue more than once in a block. The first accrual resets the
+      // fee snapshot, so later accruals in the same block have a zero performance basis,
+      // and their shares must be valued against the supply inflated by the earlier mints.
+      const mintedSharesByManager: Record<string, bigint> = {};
+      events.sort((a, b) => a.logIndex - b.logIndex);
 
-    for (const event of events) {
-      const i = managerIndexes[event.manager];
-      const debtAsset = debtAssetByManager[event.manager];
-      const feeData = feeDatas[i];
-      if (!debtAsset || !feeData || totalAssetsResults[i] == null || totalSupplyResults[i] == null) continue;
+      for (const event of events) {
+        const i = managerIndexes[event.manager];
+        const debtAsset = debtAssetByManager[event.manager];
+        const feeData = feeDatas[i];
+        if (!debtAsset || !feeData || totalAssetsResults[i] == null || totalSupplyResults[i] == null) continue;
 
-      const alreadyMintedShares = mintedSharesByManager[event.manager] ?? ZERO;
-      mintedSharesByManager[event.manager] = alreadyMintedShares + event.shares;
+        const alreadyMintedShares = mintedSharesByManager[event.manager] ?? ZERO;
+        mintedSharesByManager[event.manager] = alreadyMintedShares + event.shares;
 
-      const totalAssets = BigInt(totalAssetsResults[i]);
-      const totalSupply = BigInt(totalSupplyResults[i]) + alreadyMintedShares;
-      const offset = offsets[i] != null ? BigInt(offsets[i]) : ZERO;
-      const lastTotalAssets = BigInt(feeData.lastTotalAssets);
-      const performanceFee = BigInt(feeData.performanceFee);
+        const totalAssets = BigInt(totalAssetsResults[i]);
+        const totalSupply = BigInt(totalSupplyResults[i]) + alreadyMintedShares;
+        const offset = offsets[i] != null ? BigInt(offsets[i]) : ZERO;
+        const lastTotalAssets = BigInt(feeData.lastTotalAssets);
+        const performanceFee = BigInt(feeData.performanceFee);
 
-      // Invert convertToShares: shares = feeAssets * (supply + offset) / (totalAssets - feeAssets + 1)
-      // => feeAssets = shares * (totalAssets + 1) / (supply + offset + shares)
-      const feeAssets = event.shares * (totalAssets + ONE) / (totalSupply + offset + event.shares);
-      if (feeAssets === ZERO) continue;
+        // Invert convertToShares: shares = feeAssets * (supply + offset) / (totalAssets - feeAssets + 1)
+        // => feeAssets = shares * (totalAssets + 1) / (supply + offset + shares)
+        const feeAssets = event.shares * (totalAssets + ONE) / (totalSupply + offset + event.shares);
+        if (feeAssets === ZERO) continue;
 
-      // Performance fee basis at the accrual snapshot. An earlier accrual in the same
-      // block already reset the snapshot, leaving no basis for this event.
-      let basis = ZERO;
-      if (alreadyMintedShares === ZERO) {
-        if (lastDebts[i] != null && collaterals[i] != null && debts[i] != null) {
-          // Levered-slice basis: LTV_prev * currentCollat - currentDebt
-          // (lastDebt == 0 is the bootstrap sentinel: no performance fee that period).
-          const lastDebt = BigInt(lastDebts[i]);
-          if (lastDebt > ZERO) {
-            const lastCollateral = lastTotalAssets + lastDebt;
-            const scaledLastDebt = (lastDebt * BigInt(collaterals[i]) + lastCollateral - ONE) / lastCollateral;
-            const currentDebt = BigInt(debts[i]);
-            if (scaledLastDebt > currentDebt) basis = scaledLastDebt - currentDebt;
+        // Performance fee basis at the accrual snapshot. An earlier accrual in the same
+        // block already reset the snapshot, leaving no basis for this event.
+        let basis = ZERO;
+        if (alreadyMintedShares === ZERO) {
+          if (lastDebts[i] != null && collaterals[i] != null && debts[i] != null) {
+            // Levered-slice basis: LTV_prev * currentCollat - currentDebt
+            // (lastDebt == 0 is the bootstrap sentinel: no performance fee that period).
+            const lastDebt = BigInt(lastDebts[i]);
+            if (lastDebt > ZERO) {
+              const lastCollateral = lastTotalAssets + lastDebt;
+              const scaledLastDebt = (lastDebt * BigInt(collaterals[i]) + lastCollateral - ONE) / lastCollateral;
+              const currentDebt = BigInt(debts[i]);
+              if (scaledLastDebt > currentDebt) basis = scaledLastDebt - currentDebt;
+            }
+          } else if (totalAssets > lastTotalAssets) {
+            // Pre-upgrade NAV-variation basis: totalAssets - lastTotalAssets.
+            basis = totalAssets - lastTotalAssets;
           }
-        } else if (totalAssets > lastTotalAssets) {
-          // Pre-upgrade NAV-variation basis: totalAssets - lastTotalAssets.
-          basis = totalAssets - lastTotalAssets;
         }
+
+        // feeAssets = mgmt + max(0, basis - mgmt) * performanceFee / BPS
+        // If feeAssets < basis the performance branch was active: solve for mgmt.
+        // Otherwise the whole accrual is management fees.
+        let managementFeeAssets = feeAssets;
+        if (performanceFee > ZERO && feeAssets < basis) {
+          managementFeeAssets = (feeAssets * BPS - basis * performanceFee) / (BPS - performanceFee);
+          if (managementFeeAssets < ZERO) managementFeeAssets = ZERO;
+        }
+        const performanceFeeAssets = feeAssets - managementFeeAssets;
+
+        if (managementFeeAssets > ZERO) dailyFees.add(debtAsset, managementFeeAssets, METRIC.MANAGEMENT_FEES);
+        if (performanceFeeAssets > ZERO) dailyFees.add(debtAsset, performanceFeeAssets, METRIC.PERFORMANCE_FEES);
       }
+    });
 
-      // feeAssets = mgmt + max(0, basis - mgmt) * performanceFee / BPS
-      // If feeAssets < basis the performance branch was active: solve for mgmt.
-      // Otherwise the whole accrual is management fees.
-      let managementFeeAssets = feeAssets;
-      if (performanceFee > ZERO && feeAssets < basis) {
-        managementFeeAssets = (feeAssets * BPS - basis * performanceFee) / (BPS - performanceFee);
-        if (managementFeeAssets < ZERO) managementFeeAssets = ZERO;
-      }
-      const performanceFeeAssets = feeAssets - managementFeeAssets;
-
-      if (managementFeeAssets > ZERO) dailyFees.add(debtAsset, managementFeeAssets, METRIC.MANAGEMENT_FEES);
-      if (performanceFeeAssets > ZERO) dailyFees.add(debtAsset, performanceFeeAssets, METRIC.PERFORMANCE_FEES);
-    }
-  }));
-
+  if (errors.length > 0) throw errors[0];
   // All accrued fees are minted to the protocol fee recipient, so fees == revenue.
   return {
     dailyFees,

--- a/fees/3f.ts
+++ b/fees/3f.ts
@@ -75,7 +75,7 @@ const adapter: SimpleAdapter = {
     },
   },
   methodology: {
-    Fees: "3F charges two fees on its leveraged RWA positions. The performance fee is taken on the return of the leveraged collateral after subtracting the cost of the borrowed debt (for example, on a 10x position it applies to the RWA yield on the full leveraged exposure minus what is paid to service the debt). The management fee is taken on the entire value of the RWA collateral, including the leveraged portion (for example, on a 10x position it is charged on ten times the deposited amount, not just the user's own capital). Fees are accrued and collected when positions are updated, so a single day can include fees that built up over the previous days or weeks.",
+    Fees: "3F charges two fees on its leveraged RWA positions. The performance fee is taken on the return of the leveraged collateral, after subtracting the cost of the borrowed debt. The management fee is taken on the full value of the RWA collateral, including the leveraged portion, rather than only the user's deposited capital. Fees are accrued and collected when positions are updated, so a single day can include fees that built up over the preceding days or weeks.",
     Revenue: "Both the management and performance fees are paid to the protocol, so revenue equals the total fees collected.",
     ProtocolRevenue: "Both the management and performance fees are paid to the protocol, so protocol revenue equals the total fees collected.",
   },

--- a/fees/3f.ts
+++ b/fees/3f.ts
@@ -1,5 +1,7 @@
+import { ChainApi } from "@defillama/sdk";
 import { FetchOptions, SimpleAdapter } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
+import { METRIC } from "../helpers/metrics";
 
 const POSITION_MANAGER_FACTORY = "0x8e0667429d1717b3e5fe783a6c472d6d901fe5fa";
 const FACTORY_DEPLOY_BLOCK = 24844184;
@@ -8,13 +10,24 @@ const Abis = {
   PositionManagerCreated: "event PositionManagerCreated(address indexed positionManager, address indexed owner, address indexed collateralAsset, address debtAsset, uint256 ltv, address transferGuard)",
   // Emitted when fees are accrued and minted (as shares) to the fee recipient.
   FeesAccrued: "event FeesAccrued(address indexed feeRecipient, uint256 shares)",
+  assets: "function assets() view returns (address collateralAsset, address debtAsset)",
+  feeData: "function feeData() view returns (address feeRecipient, uint24 managementFee, uint24 performanceFee, uint256 lastTotalAssets, uint256 lastFeeAccrualTimestamp)",
   totalAssets: "uint256:totalAssets",
   totalSupply: "uint256:totalSupply",
-  assets: "function assets() view returns (address collateralAsset, address debtAsset)",
+  virtualShareOffset: "uint256:virtualShareOffset",
+  // Only available since the levered-slice performance fee upgrade; revert before it.
+  lastDebt: "uint256:lastDebt",
+  collateralAmountQuoted: "uint256:collateralAmountQuoted",
+  debtAmount: "uint256:debtAmount",
 };
+
+const BPS = BigInt(10000);
+const ZERO = BigInt(0);
+const ONE = BigInt(1);
 
 const fetch = async (options: FetchOptions) => {
   const dailyFees = options.createBalances();
+  const emptyResult = { dailyFees, dailyRevenue: dailyFees, dailyProtocolRevenue: dailyFees };
 
   // Discover all Position Managers ever created by the factory.
   const factoryLogs = await options.getLogs({
@@ -25,37 +38,116 @@ const fetch = async (options: FetchOptions) => {
   });
 
   const positionManagers = factoryLogs.map((log: any) => log.positionManager);
-  if (positionManagers.length === 0) return { dailyFees, dailyRevenue: dailyFees };
+  if (positionManagers.length === 0) return emptyResult;
 
-  // For each Position Manager:
-  //  - read its debt asset (fees are denominated in shares -> converted to debt asset)
-  //  - read totalAssets/totalSupply at the end of the window to price the fee shares
-  //  - collect FeesAccrued events emitted during the window
-  const [assetsResults, totalAssetsResults, totalSupplyResults, feesLogs] = await Promise.all([
+  const [assetsResults, feesLogs] = await Promise.all([
     options.api.multiCall({ abi: Abis.assets, calls: positionManagers, permitFailure: true }),
-    options.toApi.multiCall({ abi: Abis.totalAssets, calls: positionManagers, permitFailure: true }),
-    options.toApi.multiCall({ abi: Abis.totalSupply, calls: positionManagers, permitFailure: true }),
-    options.getLogs({ targets: positionManagers, eventAbi: Abis.FeesAccrued, flatten: false }),
+    options.getLogs({ targets: positionManagers, eventAbi: Abis.FeesAccrued, entireLog: true }),
   ]);
 
-  for (let i = 0; i < positionManagers.length; i++) {
-    const assets = assetsResults[i];
-    const totalAssets = totalAssetsResults[i];
-    const totalSupply = totalSupplyResults[i];
-    const logs = feesLogs[i] || [];
-    if (!assets || !totalAssets || !totalSupply || BigInt(totalSupply) === BigInt(0)) continue;
+  const debtAssetByManager: Record<string, string> = {};
+  positionManagers.forEach((manager: string, i: number) => {
+    if (assetsResults[i]) debtAssetByManager[manager.toLowerCase()] = assetsResults[i].debtAsset;
+  });
 
-    // Sum all fee shares minted to the fee recipient during the window.
-    let feeShares = BigInt(0);
-    for (const log of logs) {
-      feeShares += BigInt(log.shares);
-    }
-    if (feeShares === BigInt(0)) continue;
-
-    // Convert fee shares to the debt asset: shares * totalAssets / totalSupply.
-    const feeAssets = feeShares * BigInt(totalAssets) / BigInt(totalSupply);
-    dailyFees.add(assets.debtAsset, feeAssets);
+  // Group FeesAccrued events by block so pre-accrual state is read once per block.
+  const eventsByBlock: Record<number, Array<{ manager: string; shares: bigint; logIndex: number }>> = {};
+  for (const log of feesLogs) {
+    const shares = BigInt(log.args.shares);
+    if (shares === ZERO) continue;
+    const block = Number(log.blockNumber);
+    if (!eventsByBlock[block]) eventsByBlock[block] = [];
+    eventsByBlock[block].push({
+      manager: log.address.toLowerCase(),
+      shares,
+      logIndex: Number(log.logIndex ?? log.index ?? 0),
+    });
   }
+
+  // For each accrual event, recompute the management/performance split from the state
+  // one block before the accrual (the snapshot the contract itself accrued against).
+  //
+  // The contract mints `feeShares = convertToShares(feeAssets)` where
+  // `feeAssets = managementFeeAssets + performanceFeeAssets` and
+  // `performanceFeeAssets = max(0, basis - managementFeeAssets) * performanceFee / BPS`.
+  // Inverting `convertToShares` recovers `feeAssets` (denominated in the debt asset),
+  // and with the basis known the management/performance split solves algebraically.
+  await Promise.all(Object.entries(eventsByBlock).map(async ([blockStr, events]) => {
+    const api = new ChainApi({ chain: options.chain, block: Number(blockStr) - 1 });
+    const managers = Array.from(new Set(events.map((event) => event.manager)));
+    const managerIndexes: Record<string, number> = {};
+    managers.forEach((manager, i) => { managerIndexes[manager] = i; });
+
+    const [feeDatas, totalAssetsResults, totalSupplyResults, offsets, lastDebts, collaterals, debts] = await Promise.all([
+      api.multiCall({ abi: Abis.feeData, calls: managers, permitFailure: true }),
+      api.multiCall({ abi: Abis.totalAssets, calls: managers, permitFailure: true }),
+      api.multiCall({ abi: Abis.totalSupply, calls: managers, permitFailure: true }),
+      api.multiCall({ abi: Abis.virtualShareOffset, calls: managers, permitFailure: true }),
+      api.multiCall({ abi: Abis.lastDebt, calls: managers, permitFailure: true }),
+      api.multiCall({ abi: Abis.collateralAmountQuoted, calls: managers, permitFailure: true }),
+      api.multiCall({ abi: Abis.debtAmount, calls: managers, permitFailure: true }),
+    ]);
+
+    // A manager can accrue more than once in a block. The first accrual resets the
+    // fee snapshot, so later accruals in the same block have a zero performance basis,
+    // and their shares must be valued against the supply inflated by the earlier mints.
+    const mintedSharesByManager: Record<string, bigint> = {};
+    events.sort((a, b) => a.logIndex - b.logIndex);
+
+    for (const event of events) {
+      const i = managerIndexes[event.manager];
+      const debtAsset = debtAssetByManager[event.manager];
+      const feeData = feeDatas[i];
+      if (!debtAsset || !feeData || totalAssetsResults[i] == null || totalSupplyResults[i] == null) continue;
+
+      const alreadyMintedShares = mintedSharesByManager[event.manager] ?? ZERO;
+      mintedSharesByManager[event.manager] = alreadyMintedShares + event.shares;
+
+      const totalAssets = BigInt(totalAssetsResults[i]);
+      const totalSupply = BigInt(totalSupplyResults[i]) + alreadyMintedShares;
+      const offset = offsets[i] != null ? BigInt(offsets[i]) : ZERO;
+      const lastTotalAssets = BigInt(feeData.lastTotalAssets);
+      const performanceFee = BigInt(feeData.performanceFee);
+
+      // Invert convertToShares: shares = feeAssets * (supply + offset) / (totalAssets - feeAssets + 1)
+      // => feeAssets = shares * (totalAssets + 1) / (supply + offset + shares)
+      const feeAssets = event.shares * (totalAssets + ONE) / (totalSupply + offset + event.shares);
+      if (feeAssets === ZERO) continue;
+
+      // Performance fee basis at the accrual snapshot. An earlier accrual in the same
+      // block already reset the snapshot, leaving no basis for this event.
+      let basis = ZERO;
+      if (alreadyMintedShares === ZERO) {
+        if (lastDebts[i] != null && collaterals[i] != null && debts[i] != null) {
+          // Levered-slice basis: LTV_prev * currentCollat - currentDebt
+          // (lastDebt == 0 is the bootstrap sentinel: no performance fee that period).
+          const lastDebt = BigInt(lastDebts[i]);
+          if (lastDebt > ZERO) {
+            const lastCollateral = lastTotalAssets + lastDebt;
+            const scaledLastDebt = (lastDebt * BigInt(collaterals[i]) + lastCollateral - ONE) / lastCollateral;
+            const currentDebt = BigInt(debts[i]);
+            if (scaledLastDebt > currentDebt) basis = scaledLastDebt - currentDebt;
+          }
+        } else if (totalAssets > lastTotalAssets) {
+          // Pre-upgrade NAV-variation basis: totalAssets - lastTotalAssets.
+          basis = totalAssets - lastTotalAssets;
+        }
+      }
+
+      // feeAssets = mgmt + max(0, basis - mgmt) * performanceFee / BPS
+      // If feeAssets < basis the performance branch was active: solve for mgmt.
+      // Otherwise the whole accrual is management fees.
+      let managementFeeAssets = feeAssets;
+      if (performanceFee > ZERO && feeAssets < basis) {
+        managementFeeAssets = (feeAssets * BPS - basis * performanceFee) / (BPS - performanceFee);
+        if (managementFeeAssets < ZERO) managementFeeAssets = ZERO;
+      }
+      const performanceFeeAssets = feeAssets - managementFeeAssets;
+
+      if (managementFeeAssets > ZERO) dailyFees.add(debtAsset, managementFeeAssets, METRIC.MANAGEMENT_FEES);
+      if (performanceFeeAssets > ZERO) dailyFees.add(debtAsset, performanceFeeAssets, METRIC.PERFORMANCE_FEES);
+    }
+  }));
 
   // All accrued fees are minted to the protocol fee recipient, so fees == revenue.
   return {
@@ -78,6 +170,20 @@ const adapter: SimpleAdapter = {
     Fees: "3F charges two fees on its leveraged RWA positions. The performance fee is taken on the return of the leveraged collateral, after subtracting the cost of the borrowed debt. The management fee is taken on the full value of the RWA collateral, including the leveraged portion, rather than only the user's deposited capital. Fees are accrued and collected when positions are updated, so a single day can include fees that built up over the preceding days or weeks.",
     Revenue: "Both the management and performance fees are paid to the protocol, so revenue equals the total fees collected.",
     ProtocolRevenue: "Both the management and performance fees are paid to the protocol, so protocol revenue equals the total fees collected.",
+  },
+  breakdownMethodology: {
+    Fees: {
+      [METRIC.MANAGEMENT_FEES]: "Time-based management fees charged on the full value of the RWA collateral held by Position Managers, including the leveraged portion.",
+      [METRIC.PERFORMANCE_FEES]: "Performance fees charged on the return of the leveraged collateral after subtracting the cost of the borrowed debt, net of management fees.",
+    },
+    Revenue: {
+      [METRIC.MANAGEMENT_FEES]: "Management fees collected by the protocol fee recipient.",
+      [METRIC.PERFORMANCE_FEES]: "Performance fees collected by the protocol fee recipient.",
+    },
+    ProtocolRevenue: {
+      [METRIC.MANAGEMENT_FEES]: "Management fees directed to the protocol fee recipient.",
+      [METRIC.PERFORMANCE_FEES]: "Performance fees directed to the protocol fee recipient.",
+    },
   },
 };
 


### PR DESCRIPTION
## Summary

This is a fix for the 3F fees/revenue adapter (`fees/3f.ts`) added in #7142.

The computation introduced in #7142 does not match how fees are actually charged on our leveraged RWA positions, so the reported fees and revenue are incorrect. The previous version tried to estimate management and performance fees from `totalAssets` deltas over each window, which neither reflects the protocol's fee logic nor the timing of fee collection.

This PR sources the fees directly from the on-chain `FeesAccrued` events (the single source of truth that stays correct across our upcoming fee-mechanism upgrade), and recomputes the management/performance breakdown for each event from the contract state it accrued against.

## What this fix does

3F mints fee shares to the protocol fee recipient and emits a single event whenever fees are accrued on a Position Manager:

```solidity
/// @notice Emitted when fees are accrued and minted to the fee recipient.
event FeesAccrued(address indexed feeRecipient, uint256 shares);
```

The adapter now:

1. Discovers every Position Manager from the factory's `PositionManagerCreated` events.
2. Reads each Position Manager's `FeesAccrued` events within the window — this captures fees directly at the source instead of estimating them.
3. For each event, reads the Position Manager state at the block before the accrual (the same snapshot the contract accrued against), recovers the total fee value in the debt asset by inverting the share conversion (`feeAssets = shares * (totalAssets + 1) / (totalSupply + virtualShareOffset + shares)`), and solves the management/performance split algebraically from the performance-fee basis.

The split handles both fee mechanisms: the current NAV-variation performance basis and the upcoming levered-slice basis (`LTV_prev * currentCollat - currentDebt`, detected via the new `lastDebt()` getter). It also handles a manager accruing more than once in a single block: the first accrual resets the fee snapshot, so subsequent same-block events carry no performance basis and are valued against the supply inflated by the earlier mints.

Since every accrued fee is paid to the protocol, `dailyFees == dailyRevenue == dailyProtocolRevenue`.

## How the fees work

- The **performance fee** is taken on the return of the leveraged collateral, after subtracting the cost of the borrowed debt.
- The **management fee** is taken on the full value of the RWA collateral, including the leveraged portion, rather than only the user's deposited capital.
- Fees are accrued and collected when positions are updated, so a single day can include fees that built up over the preceding days or weeks. Listening to the events captures this correctly, whereas the per-window delta approach did not.

## Accuracy

- **Total fees are exact**: they are derived directly from the shares minted in the `FeesAccrued` events.
- **The management/performance split is a very close approximation**: it is recomputed from state at the block boundary rather than mid-transaction. Validated against the contract's own `pendingFees()` view on historical accruals for both fee mechanisms — discrepancies are only a couple of wei.

## Notes

- Tested locally: 2026-06-03 reports ~$283 in fees/revenue (Management Fees ~$66, Performance Fees ~$217), sourced entirely from `FeesAccrued` events, with the breakdown surfaced via `breakdownMethodology`.
- The failing `ts-check` job is unrelated to this PR: it fails on current master after the recent adapter-type refactor (errors are in files this PR does not touch).
