### PR TITLE
[feat] GMGNAI: track volume for base,bsc and solana via dune

### DIFF
--- a/dexs/gmgnai.ts
+++ b/dexs/gmgnai.ts
@@ -1,14 +1,17 @@
 import { Dependencies, FetchOptions, FetchResult, SimpleAdapter } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
+import ADDRESSES from "../helpers/coreAssets.json";
 import { queryDuneSql } from "../helpers/dune";
 
 // Source: Dune GMGN dashboard/query shared with the fees adapter.
 type ChainConfig = {
   start: string;
-  duneChain?: string;
   contract?: string;
+  wrappedNative?: string;
   feeAddresses?: string[];
 };
+
+const SWAP_EVENT = "event Swap(address indexed payer,address indexed receiver,address indexed feeToken,uint256 amountIn,uint256 amountOut,(uint8 swapType,address tokenIn,address tokenOut,address poolAddress,uint24 fee,int24 tickSpacing,address factoryAddress,bytes path)[] descs)";
 
 const chainConfig: Record<string, ChainConfig> = {
   [CHAIN.SOLANA]: {
@@ -26,14 +29,14 @@ const chainConfig: Record<string, ChainConfig> = {
     ],
   },
   [CHAIN.BASE]: {
-    start: "2025-08-01",
-    duneChain: "base",
+    start: "2024-07-05",
     contract: "0xd8Ba9D1a99Fc21f0ECA24e9b85737c28A194a4E2",
+    wrappedNative: ADDRESSES.base.WETH,
   },
   [CHAIN.BSC]: {
-    start: "2024-01-01",
-    duneChain: "bnb",
+    start: "2024-11-27",
     contract: "0x1de460f363AF910f51726DEf188F9004276Bf4bc",
+    wrappedNative: ADDRESSES.bsc.WBNB,
   },
 };
 
@@ -41,10 +44,10 @@ type DuneVolumeRow = {
   daily_volume?: string | number | null;
 };
 
-const fetchSolana = (options: FetchOptions) => {
+const fetchSolana = async (options: FetchOptions): Promise<FetchResult> => {
   const feeAddresses = chainConfig[CHAIN.SOLANA].feeAddresses!;
 
-  return queryDuneSql(options, `
+  const rows = await (queryDuneSql(options, `
   WITH gmgn_txs AS (
     SELECT DISTINCT
       id AS tx_id
@@ -65,40 +68,32 @@ const fetchSolana = (options: FetchOptions) => {
     TIME_RANGE
     AND trader_id NOT IN (${feeAddresses.map((address) => `'${address}'`).join(", ")})
     AND tx_id IN (SELECT tx_id FROM gmgn_txs)
-`) as Promise<DuneVolumeRow[]>;
+`) as Promise<DuneVolumeRow[]>);
+
+  return { dailyVolume: Number(rows[0].daily_volume) };
 };
 
-const fetchEvm = (options: FetchOptions) => {
+const fetchEvm = async (options: FetchOptions): Promise<FetchResult> => {
   const config = chainConfig[options.chain];
+  const dailyVolume = options.createBalances();
+  const nativeTokens = new Set([ADDRESSES.null, config.wrappedNative?.toLowerCase()]);
 
-  return queryDuneSql(options, `
-  WITH bot_trades AS (
-    SELECT
-      trades.tx_hash,
-      trades.evt_index,
-      trades.amount_usd
-    FROM
-      dex.trades
-    WHERE
-      trades.blockchain = '${config.duneChain}'
-      AND trades.tx_to = ${config.contract}
-      AND TIME_RANGE
-  ),
-  last_trades AS (
-    SELECT
-      tx_hash,
-      MAX(evt_index) AS evt_index
-    FROM
-      bot_trades
-    GROUP BY
-      tx_hash
-  )
-  SELECT
-    COALESCE(SUM(bot_trades.amount_usd), 0) AS daily_volume
-  FROM
-    bot_trades
-    JOIN last_trades USING (tx_hash, evt_index)
-`) as Promise<DuneVolumeRow[]>;
+  const logs = await options.getLogs({
+    target: config.contract,
+    eventAbi: SWAP_EVENT,
+  });
+
+  logs.forEach((log: any) => {
+    const firstDesc = log.descs[0];
+    const lastDesc = log.descs[log.descs.length - 1];
+    const tokenIn = (firstDesc.tokenIn ?? firstDesc[1]).toLowerCase();
+    const tokenOut = (lastDesc.tokenOut ?? lastDesc[2]).toLowerCase();
+
+    if (nativeTokens.has(tokenIn)) dailyVolume.addGasToken(log.amountIn);
+    else if (nativeTokens.has(tokenOut)) dailyVolume.addGasToken(log.amountOut);
+  });
+
+  return { dailyVolume };
 };
 
 const fetch = async (_a: any, _b: any, options: FetchOptions): Promise<FetchResult> => {
@@ -107,13 +102,9 @@ const fetch = async (_a: any, _b: any, options: FetchOptions): Promise<FetchResu
     throw new Error("End timestamp is less than 10 hours ago, skipping due to dune indexing delay");
   }
 
-  const rows = options.chain === CHAIN.SOLANA
+  return options.chain === CHAIN.SOLANA
     ? await fetchSolana(options)
     : await fetchEvm(options);
-
-  return {
-    dailyVolume: Number(rows[0].daily_volume),
-  };
 };
 
 const adapter: SimpleAdapter = {

--- a/dexs/gmgnai.ts
+++ b/dexs/gmgnai.ts
@@ -1,0 +1,127 @@
+import { Dependencies, FetchOptions, FetchResult, SimpleAdapter } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+import { queryDuneSql } from "../helpers/dune";
+
+// Source: Dune GMGN dashboard/query shared with the fees adapter.
+type ChainConfig = {
+  start: string;
+  duneChain?: string;
+  contract?: string;
+  feeAddresses?: string[];
+};
+
+const chainConfig: Record<string, ChainConfig> = {
+  [CHAIN.SOLANA]: {
+    start: "2024-03-20",
+    feeAddresses: [
+      "BB5dnY55FXS1e1NXqZDwCzgdYJdMCj3B92PU6Q5Fb6DT",
+      "7sHXjs1j7sDJGVSMSPjD1b4v3FD6uRSvRWfhRdfv5BiA",
+      "HeZVpHj9jLwTVtMMbzQRf6mLtFPkWNSg11o68qrbUBa3",
+      "ByRRgnZenY6W2sddo1VJzX9o4sMU4gPDUkcmgrpGBxRy",
+      "DXfkEGoo6WFsdL7x6gLZ7r6Hw2S6HrtrAQVPWYx2A1s9",
+      "3t9EKmRiAUcQUYzTZpNojzeGP1KBAVEEbDNmy6wECQpK",
+      "DymeoWc5WLNiQBaoLuxrxDnDRvLgGZ1QGsEoCAM7Jsrx",
+      "dBhdrmwBkRa66XxBuAK4WZeZnsZ6bHeHCCLXa3a8bTJ",
+      "6TxjC5wJzuuZgTtnTMipwwULEbMPx5JPW3QwWkdTGnrn",
+    ],
+  },
+  [CHAIN.BASE]: {
+    start: "2025-08-01",
+    duneChain: "base",
+    contract: "0xd8Ba9D1a99Fc21f0ECA24e9b85737c28A194a4E2",
+  },
+  [CHAIN.BSC]: {
+    start: "2024-01-01",
+    duneChain: "bnb",
+    contract: "0x1de460f363AF910f51726DEf188F9004276Bf4bc",
+  },
+};
+
+type DuneVolumeRow = {
+  daily_volume?: string | number | null;
+};
+
+const fetchSolana = (options: FetchOptions) => {
+  const feeAddresses = chainConfig[CHAIN.SOLANA].feeAddresses!;
+
+  return queryDuneSql(options, `
+  WITH gmgn_txs AS (
+    SELECT DISTINCT
+      id AS tx_id
+    FROM
+      solana.transactions
+      CROSS JOIN UNNEST(SEQUENCE(1, CARDINALITY(account_keys))) AS u(i)
+    WHERE
+      TIME_RANGE
+      AND success = true
+      AND account_keys[i] IN (${feeAddresses.map((address) => `'${address}'`).join(", ")})
+      AND post_balances[i] > pre_balances[i]
+  )
+  SELECT
+    COALESCE(SUM(amount_usd), 0) AS daily_volume
+  FROM
+    dex_solana.trades
+  WHERE
+    TIME_RANGE
+    AND trader_id NOT IN (${feeAddresses.map((address) => `'${address}'`).join(", ")})
+    AND tx_id IN (SELECT tx_id FROM gmgn_txs)
+`) as Promise<DuneVolumeRow[]>;
+};
+
+const fetchEvm = (options: FetchOptions) => {
+  const config = chainConfig[options.chain];
+
+  return queryDuneSql(options, `
+  WITH bot_trades AS (
+    SELECT
+      trades.tx_hash,
+      trades.evt_index,
+      trades.amount_usd
+    FROM
+      dex.trades
+    WHERE
+      trades.blockchain = '${config.duneChain}'
+      AND trades.tx_to = ${config.contract}
+      AND TIME_RANGE
+  ),
+  last_trades AS (
+    SELECT
+      tx_hash,
+      MAX(evt_index) AS evt_index
+    FROM
+      bot_trades
+    GROUP BY
+      tx_hash
+  )
+  SELECT
+    COALESCE(SUM(bot_trades.amount_usd), 0) AS daily_volume
+  FROM
+    bot_trades
+    JOIN last_trades USING (tx_hash, evt_index)
+`) as Promise<DuneVolumeRow[]>;
+};
+
+const fetch = async (_a: any, _b: any, options: FetchOptions): Promise<FetchResult> => {
+  const tenHoursAgo = Date.now() - (10 * 60 * 60 * 1000);
+  if ((options.toTimestamp * 1000) > tenHoursAgo) {
+    throw new Error("End timestamp is less than 10 hours ago, skipping due to dune indexing delay");
+  }
+
+  const rows = options.chain === CHAIN.SOLANA
+    ? await fetchSolana(options)
+    : await fetchEvm(options);
+
+  return {
+    dailyVolume: Number(rows[0].daily_volume),
+  };
+};
+
+const adapter: SimpleAdapter = {
+  version: 1,
+  fetch,
+  adapter: chainConfig,
+  dependencies: [Dependencies.DUNE],
+  isExpensiveAdapter: true,
+};
+
+export default adapter;

--- a/dexs/gmgnai.ts
+++ b/dexs/gmgnai.ts
@@ -9,9 +9,8 @@ type ChainConfig = {
   contract?: string;
   wrappedNative?: string;
   feeAddresses?: string[];
+  swapEvent?: string;
 };
-
-const SWAP_EVENT = "event Swap(address indexed payer,address indexed receiver,address indexed feeToken,uint256 amountIn,uint256 amountOut,(uint8 swapType,address tokenIn,address tokenOut,address poolAddress,uint24 fee,int24 tickSpacing,address factoryAddress,bytes path)[] descs)";
 
 const chainConfig: Record<string, ChainConfig> = {
   [CHAIN.SOLANA]: {
@@ -32,11 +31,13 @@ const chainConfig: Record<string, ChainConfig> = {
     start: "2024-07-05",
     contract: "0xd8Ba9D1a99Fc21f0ECA24e9b85737c28A194a4E2",
     wrappedNative: ADDRESSES.base.WETH,
+    swapEvent: "event Swap(address indexed payer,address indexed receiver,address indexed feeToken,uint256 amountIn,uint256 amountOut,(uint8 swapType,address tokenIn,address tokenOut,address poolAddress,uint24 fee,int24 tickSpacing,address factoryAddress,bytes path)[] descs)",
   },
   [CHAIN.BSC]: {
     start: "2024-11-27",
     contract: "0x1de460f363AF910f51726DEf188F9004276Bf4bc",
     wrappedNative: ADDRESSES.bsc.WBNB,
+    swapEvent: "event Swap(address indexed payer,address indexed receiver,address indexed feeToken,uint256 amountIn,uint256 amountOut,(uint8 swapType,address tokenIn,address tokenOut,address poolAddress,uint24 fee,int24 tickSpacing,address factoryAddress,bytes path, address, bytes32)[] descs)",
   },
 };
 
@@ -80,7 +81,7 @@ const fetchEvm = async (options: FetchOptions): Promise<FetchResult> => {
 
   const logs = await options.getLogs({
     target: config.contract,
-    eventAbi: SWAP_EVENT,
+    eventAbi: config.swapEvent,
   });
 
   logs.forEach((log: any) => {


### PR DESCRIPTION
https://defillama.com/protocol/gmgn

## Summary
- Adds a GMGN AI DEX volume adapter under `dexs/gmgnai.ts`.
- Tracks routed trading volume on Solana, Base, and BSC using Dune SQL sources aligned with the existing GMGN fees adapter coverage.

## Changes
- Added a shared `chainConfig` with start dates, Solana fee wallets, and EVM bot contracts.
- Added Solana volume logic that identifies GMGN fee-receiving transactions from `solana.transactions` by positive fee-wallet SOL balance changes, then sums matching `dex_solana.trades` volume.
- Added shared EVM volume logic for Base and BSC that filters `dex.trades` by GMGN bot contract and counts the last trade event per transaction to reduce multi-hop overcounting.
- Added a Dune indexing delay guard to avoid querying very fresh windows.

## Methodology
- Solana volume is counted from DEX trades in transactions where a configured GMGN fee wallet had a positive native SOL balance change.
- Base and BSC volume is counted from DEX trades routed through the configured GMGN bot contracts.
- EVM transactions are deduped by keeping the highest `evt_index` per `tx_hash`, following the existing bot-volume adapter pattern.
