### PR TITLE
[fix] Rocksolid: track usdm and reth looping vault fees and revenue

### DIFF
--- a/fees/rocksolid-network/index.ts
+++ b/fees/rocksolid-network/index.ts
@@ -2,8 +2,26 @@ import { FetchOptions, FetchResultV2, SimpleAdapter } from "../../adapters/types
 import { CHAIN } from "../../helpers/chains";
 import { METRIC } from "../../helpers/metrics";
 
-const rEthVault = "0x936faCdf10c8c36294e7b9d28345255539d81bc7";
-const rEthToken = "0xae78736Cd615f374D3085123A210448E74Fc6393";
+const chainConfig: any = {
+  [CHAIN.ETHEREUM]: {
+    start: '2025-08-28',
+    vaults: [
+      {
+        address: '0x936faCdf10c8c36294e7b9d28345255539d81bc7', // rock.rETH
+        asset: '0xae78736Cd615f374D3085123A210448E74Fc6393',
+      },
+      {
+        address: '0x7a12D4B719F5aA479eCD60dEfED909fb2A37e428', // rock.rLETH
+        asset: '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2',
+      },
+      {
+        address: '0xba71097e426983d840569edfa1a01396b56d86ad', // rock.rUSDM
+        asset: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+      },
+    ],
+  },
+}
+
 const feeRegistry = "0x6dA4D1859bA1d02D095D2246142CdAd52233e27C";
 
 const Abis = {
@@ -13,49 +31,62 @@ const Abis = {
 }
 
 const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
+    const { vaults } = chainConfig[options.chain];
+    const vaultAddresses = vaults.map((vault: { address: string }) => vault.address);
     const dailyFees = options.createBalances();
     const dailyRevenue = options.createBalances();
     const dailySupplySideRevenue = options.createBalances();
 
-    const [balance, feeRates, protocolRate] = await Promise.all([
-        options.api.call({ target: rEthVault, abi: 'uint256:totalAssets' }),
-        options.api.call({ target: rEthVault, abi: Abis.feeRates }),
-        options.api.call({ target: feeRegistry, abi: Abis.protocolRate, params: [rEthVault] })
+    const [balances, feeRates, protocolRates] = await Promise.all([
+        options.api.multiCall({ calls: vaultAddresses, abi: 'uint256:totalAssets', permitFailure: true }),
+        options.api.multiCall({ calls: vaultAddresses, abi: Abis.feeRates, permitFailure: true }),
+        options.api.multiCall({ calls: vaultAddresses.map((vault: string) => ({ target: feeRegistry, params: [vault] })), abi: Abis.protocolRate, permitFailure: true })
     ]);
 
-    const [indexBefore, indexAfter] = await Promise.all([
-        options.fromApi.call({ target: rEthVault, abi: Abis.convertToAssets, params: [String(1e18)] }),
-        options.toApi.call({ target: rEthVault, abi: Abis.convertToAssets, params: [String(1e18)] })
+    const convertCalls = vaultAddresses.map((vault: string) => ({ target: vault, params: [String(1e18)] }));
+    const [indexesBefore, indexesAfter] = await Promise.all([
+        options.fromApi.multiCall({ calls: convertCalls, abi: Abis.convertToAssets, permitFailure: true }),
+        options.toApi.multiCall({ calls: convertCalls, abi: Abis.convertToAssets, permitFailure: true })
     ]);
 
-    const cumulativeYield = (BigInt(indexAfter) - BigInt(indexBefore)) * BigInt(balance) / BigInt(1e18);
+    vaults.forEach(({ asset }: { asset: string }, i: number) => {
+        const balance = balances[i];
+        const feeRate = feeRates[i];
+        const protocolRate = protocolRates[i];
+        const indexBefore = indexesBefore[i];
+        const indexAfter = indexesAfter[i];
 
-    const managementFeeRate = Number(feeRates.managementRate) / 1e4;
-    const performanceFeeRate = Number(feeRates.performanceRate) / 1e4;
-    const protocolFeeRate = Number(protocolRate) / 1e4;
+        if (!balance || !feeRate || !protocolRate || !indexBefore || !indexAfter) return;
 
-    const performanceFees = Number(cumulativeYield) * performanceFeeRate;
+        const cumulativeYield = (BigInt(indexAfter) - BigInt(indexBefore)) * BigInt(balance) / BigInt(1e18);
 
-    const oneYear = 365 * 24 * 3600;
-    const timeframe = options.toTimestamp - options.fromTimestamp;
-    const managementFees = Number(balance) * managementFeeRate * timeframe / oneYear;
+        const managementFeeRate = Number(feeRate.managementRate) / 1e4;
+        const performanceFeeRate = Number(feeRate.performanceRate) / 1e4;
+        const protocolFeeRate = Number(protocolRate) / 1e4;
 
-    const supplySideYield = Number(cumulativeYield) - performanceFees;
-    
-    const protocolPerformanceFees = performanceFees * protocolFeeRate
-    const protocolManagementFees = managementFees * protocolFeeRate
-    const curatorsFees = (performanceFees * (1- protocolFeeRate)) + (managementFees * (1- protocolFeeRate))
+        const performanceFees = Number(cumulativeYield) * performanceFeeRate;
 
-    dailyFees.add(rEthToken, supplySideYield, METRIC.ASSETS_YIELDS);
-    dailyFees.add(rEthToken, protocolPerformanceFees, METRIC.PERFORMANCE_FEES);
-    dailyFees.add(rEthToken, protocolManagementFees, METRIC.MANAGEMENT_FEES);
-    dailyFees.add(rEthToken, curatorsFees, METRIC.CURATORS_FEES);
+        const oneYear = 365 * 24 * 3600;
+        const timeframe = options.toTimestamp - options.fromTimestamp;
+        const managementFees = Number(balance) * managementFeeRate * timeframe / oneYear;
 
-    dailySupplySideRevenue.add(rEthToken, supplySideYield, METRIC.ASSETS_YIELDS);
-    dailySupplySideRevenue.add(rEthToken, curatorsFees, METRIC.CURATORS_FEES);
+        const supplySideYield = Number(cumulativeYield) - performanceFees;
+        
+        const protocolPerformanceFees = performanceFees * protocolFeeRate
+        const protocolManagementFees = managementFees * protocolFeeRate
+        const curatorsFees = (performanceFees * (1- protocolFeeRate)) + (managementFees * (1- protocolFeeRate))
 
-    dailyRevenue.add(rEthToken, protocolPerformanceFees, METRIC.PERFORMANCE_FEES);
-    dailyRevenue.add(rEthToken, protocolManagementFees, METRIC.MANAGEMENT_FEES);
+        dailyFees.add(asset, supplySideYield, METRIC.ASSETS_YIELDS);
+        dailyFees.add(asset, protocolPerformanceFees, METRIC.PERFORMANCE_FEES);
+        dailyFees.add(asset, protocolManagementFees, METRIC.MANAGEMENT_FEES);
+        dailyFees.add(asset, curatorsFees, METRIC.CURATORS_FEES);
+
+        dailySupplySideRevenue.add(asset, supplySideYield, METRIC.ASSETS_YIELDS);
+        dailySupplySideRevenue.add(asset, curatorsFees, METRIC.CURATORS_FEES);
+
+        dailyRevenue.add(asset, protocolPerformanceFees, METRIC.PERFORMANCE_FEES);
+        dailyRevenue.add(asset, protocolManagementFees, METRIC.MANAGEMENT_FEES);
+    });
 
     return {
         dailyFees,
@@ -65,40 +96,41 @@ const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
     };
 }
 
+const methodology = {
+    Fees: "Total yield generated from Rocksolid vaults.",
+    Revenue: "Portion of 10% performance fee and 1% annual management fee to Rocksolid protocol.",
+    ProtocolRevenue: "Portion of 10% performance fee and 1% annual management fee to Rocksolid protocol.",
+    SupplySideRevenue: "Vault yield distributed to suppliers + curators.",
+};
+
+const breakdownMethodology = {
+    Fees: {
+        [METRIC.ASSETS_YIELDS]: "Yield generated from supplied assets in Rocksolid vaults.",
+        [METRIC.PERFORMANCE_FEES]: "Portion of collected from performance fees to Rocksolid protocol.",
+        [METRIC.MANAGEMENT_FEES]: "Portion of collected from management fees to Rocksolid protocol.",
+        [METRIC.CURATORS_FEES]: "Share of performance and management fees to vault deployers/curators.",
+    },
+    Revenue: {
+        [METRIC.PERFORMANCE_FEES]: "Portion of collected from performance fees to Rocksolid protocol.",
+        [METRIC.MANAGEMENT_FEES]: "Portion of collected from management fees to Rocksolid protocol.",
+    },
+    ProtocolRevenue: {
+        [METRIC.PERFORMANCE_FEES]: "Portion of collected from performance fees to Rocksolid protocol.",
+        [METRIC.MANAGEMENT_FEES]: "Portion of collected from management fees to Rocksolid protocol.",
+    },
+    SupplySideRevenue: {
+        [METRIC.ASSETS_YIELDS]: "Vault yield distributed to suppliers.",
+        [METRIC.CURATORS_FEES]: "Share of performance and management fees to vault deployers/curators.",
+    }
+}
+
 const adapter: SimpleAdapter = {
     version: 2,
-    adapter: {
-        [CHAIN.ETHEREUM]: {
-            fetch,
-            start: "2025-08-28",
-        }
-    },
-    methodology: {
-        Fees: "Total yield generated from rock.rETH vault.",
-        Revenue: "Portion of 10% performance fee and 1% annual management fee to Rocksolid protocol.",
-        ProtocolRevenue: "Portion of 10% performance fee and 1% annual management fee to Rocksolid protocol.",
-        SupplySideRevenue: "Vault yield distributed to suppliers + curators.",
-    },
-    breakdownMethodology: {
-        Fees: {
-            [METRIC.ASSETS_YIELDS]: "Yield generated from supplied assets in the rock.rETH vault.",
-            [METRIC.PERFORMANCE_FEES]: "Portion of collected from performance fees to Rocksolid protocol.",
-            [METRIC.MANAGEMENT_FEES]: "Portion of collected from management fees to Rocksolid protocol.",
-            [METRIC.CURATORS_FEES]: 'Share of performance and management fees to vault deployers/curators.',
-        },
-        Revenue: {
-          [METRIC.PERFORMANCE_FEES]: "Portion of collected from performance fees to Rocksolid protocol.",
-          [METRIC.MANAGEMENT_FEES]: "Portion of collected from management fees to Rocksolid protocol.",
-        },
-        ProtocolRevenue: {
-          [METRIC.PERFORMANCE_FEES]: "Portion of collected from performance fees to Rocksolid protocol.",
-          [METRIC.MANAGEMENT_FEES]: "Portion of collected from management fees to Rocksolid protocol.",
-        },
-        SupplySideRevenue: {
-            [METRIC.ASSETS_YIELDS]: "Vault yield distributed to suppliers.",
-            [METRIC.CURATORS_FEES]: 'Share of performance and management fees to vault deployers/curators.',
-        }
-    }
+    fetch,
+    pullHourly: true,
+    adapter: chainConfig,
+    methodology,
+    breakdownMethodology,
 }
 
 export default adapter;

--- a/fees/rocksolid-network/index.ts
+++ b/fees/rocksolid-network/index.ts
@@ -127,7 +127,6 @@ const breakdownMethodology = {
 const adapter: SimpleAdapter = {
     version: 2,
     fetch,
-    pullHourly: true,
     adapter: chainConfig,
     methodology,
     breakdownMethodology,

--- a/fees/rocksolid-network/index.ts
+++ b/fees/rocksolid-network/index.ts
@@ -130,6 +130,7 @@ const adapter: SimpleAdapter = {
     adapter: chainConfig,
     methodology,
     breakdownMethodology,
+    pullHourly: true,
 }
 
 export default adapter;


### PR DESCRIPTION
## Summary
- Expands the Rocksolid Network fees adapter to include the rLETH and rUSDM vaults on Ethereum.
- Reports vault yield, management fees, performance fees, curator fees, revenue, protocol revenue, and supply-side revenue across all configured Rocksolid vaults.

## Changes
- Updated `fees/rocksolid-network/index.ts` to use a chain-level config for Ethereum vaults and their hardcoded asset addresses.
- Added rLETH vault `0x7a12D4B719F5aA479eCD60dEfED909fb2A37e428` with WETH as the asset.
- Added rUSDM vault `0xba71097e426983d840569edfa1a01396b56d86ad` with USDC as the asset.
- Kept the existing fee methodology and applied the same vault accounting logic across all configured vaults.

## Methodology
- Uses each vault's `totalAssets`, `feeRates`, and registry `protocolRate` to calculate management fees, performance fees, protocol revenue, curator fees, and supply-side yield.
- Uses historical `convertToAssets(1e18)` values from the start and end blocks to calculate vault yield over the fetch window.
- Uses hardcoded asset addresses for each vault to avoid relying on vault `asset()` calls.
