### PR TITLE
fix(hyperliquid-hlp): use public fee source for HLP allocation

### DIFF
--- a/fees/hyperliquid-hlp.ts
+++ b/fees/hyperliquid-hlp.ts
@@ -1,23 +1,14 @@
 import { FetchOptions, SimpleAdapter } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
-import { getRevenueRatioShares, LLAMA_HL_INDEXER_FROM_TIME, queryHyperliquidIndexer, queryHypurrscanApi } from "../helpers/hyperliquid";
+import { getRevenueRatioShares, queryHypurrscanApi } from "../helpers/hyperliquid";
 
 async function fetch(_1: number, _: any,  options: FetchOptions) {
   const dailyFees = options.createBalances()
 
-  let perpFees = options.createBalances()
-  let spotFees = options.createBalances()
   const { hlpShare } = getRevenueRatioShares(options.startOfDay)
-  if (options.startOfDay < LLAMA_HL_INDEXER_FROM_TIME) {
-    // get fees from hypurrscan, no volume
-    const result = await queryHypurrscanApi(options);
-    perpFees = result.dailyPerpFees.clone(hlpShare)
-    spotFees = result.dailySpotFees.clone(hlpShare)
-  } else {
-    const result = await queryHyperliquidIndexer(options);
-    perpFees = result.dailyHyperliquidRevenue.clone(hlpShare)
-    spotFees = result.dailySpotRevenue.clone(hlpShare)
-  }
+  const result = await queryHypurrscanApi(options);
+  const perpFees = result.dailyPerpFees.clone(hlpShare)
+  const spotFees = result.dailySpotFees.clone(hlpShare)
 
   dailyFees.add(perpFees, 'Perp Fees')
   dailyFees.add(spotFees, 'Spot Fees')
@@ -30,19 +21,19 @@ async function fetch(_1: number, _: any,  options: FetchOptions) {
 }
 
 const methodology = {
-  Fees: "1% of perp and spot trading revenue (excluding builders and unit revenue) share for HLP.",
+  Fees: "HLP's share of Hyperliquid perp and spot trading fees, using public cumulative Hypurrscan fee data. HLP received 3% before 30 Aug 2025 and receives 1% after.",
   SupplySideRevenue: 'All fees share of HLP are distributed to vaults suppliers.',
   Revenue: "No revenue.",
 }
 
 const breakdownMethodology = {
   Fees: {
-    'Perp Fees': 'Share of 1% perp trading revenue.',
-    'Spot Fees': 'Share of 1% spot trading revenue',
+    'Perp Fees': 'HLP share of perp trading fees.',
+    'Spot Fees': 'HLP share of spot trading fees',
   },
   SupplySideRevenue: {
-    'Perp Fees': 'Share of 1% perp trading revenue.',
-    'Spot Fees': 'Share of 1% spot trading revenue',
+    'Perp Fees': 'HLP share of perp trading fees.',
+    'Spot Fees': 'HLP share of spot trading fees',
   },
 }
 


### PR DESCRIPTION
## Problem

Fixes https://github.com/DefiLlama/dimension-adapters/issues/7075.

`hyperliquid-hlp` switched from the public Hypurrscan fee source to DefiLlama's Hyperliquid indexer after `LLAMA_HL_INDEXER_FROM_TIME`. Issue #7075 shows that the indexer-based HLP allocation overstates observed parent HLP vault accrual as HIP-3 Growth Mode share grows.

PR #7374 improved Hyperliquid revenue attribution by separating builder and HIP-3 deployer revenue, so this PR does not repeat that change. The remaining HLP-specific issue is that the current public DefiLlama HLP chart still appears high over the original issue window:

| Source | Mar 26 2025 -> May 18 2026 |
|---|---:|
| Issue-stated original DL-indexer prediction | ~$18.45M |
| Current public DefiLlama HLP chart | ~$17.74M |
| Public Hypurrscan prediction, reproduced locally | ~$16.97M |
| Issue-stated observed parent HLP accrual | ~$16.71M |

I also checked recent public daily rows around the #7374 merge. Because #7374 merged late on Jun 1, 2026 UTC, Jun 2-3 are the cleaner post-merge check:

| Date | Current public DefiLlama HLP | Public Hypurrscan HLP formula | Public / Hypurrscan |
|---|---:|---:|---:|
| Jun 1, 2026 | ~$29.25k | ~$26.14k | ~111.9% |
| Jun 2, 2026 | ~$40.31k | ~$37.45k | ~107.6% |
| Jun 3, 2026 | ~$35.40k | ~$31.52k | ~112.3% |

## Change

Use the public Hypurrscan cumulative fee source for `hyperliquid-hlp` across the full supported range.

This keeps the adapter's old public-source path, removes the private-indexer branch for this HLP-specific allocation, and keeps the existing HLP share logic:

- 3% before Aug 30, 2025
- 1% after Aug 30, 2025

## Why this route

Direct parent HLP vault PnL is the best validation source, but the public `vaultDetails` all-time history is sparse around historical UTC boundaries. I do not think closest-point vault PnL deltas should be used as exact daily adapter input unless DefiLlama has indexed vault snapshots.

The public Hypurrscan source is not perfect, but it is much closer to the issue-stated observed HLP accrual than the current published HLP chart for the issue window.

## Tests

```bash
npm test -- fees hyperliquid-hlp.ts 2026-05-18
npm test -- fees hyperliquid-hlp.ts 2025-07-01
npm test -- fees hyperliquid-hlp.ts 2025-09-15
npm run ts-check -- --pretty false
```

I also used a local public reproduction script outside this repo to verify the window-level numbers:

```bash
node pr-prep/hyperliquid-hlp-7075-repro.mjs
```
