### PR TITLE
[feat] Unibot: track volume via onchain WETH logs

### DIFF
--- a/dexs/unibot.ts
+++ b/dexs/unibot.ts
@@ -1,0 +1,61 @@
+import { FetchOptions, SimpleAdapter } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+import ADDRESSES from "../helpers/coreAssets.json";
+
+const chainConfig: Record<string, { start: string; router: string; weth: string }> = {
+  [CHAIN.ETHEREUM]: {
+    start: "2024-01-11",
+    router: "0x5c9321e92Ba4eb43f2901c4952358e132163a85A",
+    weth: ADDRESSES.ethereum.WETH,
+  },
+};
+
+const depositEvent = "event Deposit(address indexed dst, uint256 wad)";
+const withdrawalEvent = "event Withdrawal(address indexed src, uint256 wad)";
+
+const fetchEvm = async (options: FetchOptions) => {
+  const dailyVolume = options.createBalances();
+  const { router, weth } = chainConfig[options.chain];
+  const routerAddress = router.toLowerCase();
+
+  // Unibot performs all transactions via WETH, so we just count deposit/withdrawal of weth
+  // Skips dune query via WETH logs
+  const [deposits, withdrawals] = await Promise.all([
+    options.getLogs({
+      target: weth,
+      eventAbi: depositEvent,
+    }),
+    options.getLogs({
+      target: weth,
+      eventAbi: withdrawalEvent,
+    }),
+  ]);
+
+  deposits
+    .filter((log: any) => log.dst.toLowerCase() === routerAddress)
+    .forEach((log: any) => dailyVolume.add(weth, log.wad));
+
+  withdrawals
+    .filter((log: any) => log.src.toLowerCase() === routerAddress)
+    .forEach((log: any) => dailyVolume.add(weth, log.wad));
+
+  return { dailyVolume };
+};
+
+const fetch = (options: FetchOptions) => fetchEvm(options);
+
+const methodology = {
+  Volume:
+    "Unibot swap volume routed through unibot router.",
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  pullHourly: true,
+  fetch,
+  adapter: chainConfig,
+  doublecounted: true,
+  methodology,
+};
+
+export default adapter;


### PR DESCRIPTION
## Summary
- Adds a `dexs/unibot.ts` volume adapter for Unibot on Ethereum.
- Tracks routed Telegram bot swap volume through WETH wrap/unwrap activity on the Unibot router.

## Changes
- Added a v2 hourly DEX adapter for Unibot with Ethereum start date `2024-01-11`.
- Counts WETH `Deposit` events where `dst` is the Unibot router and WETH `Withdrawal` events where `src` is the Unibot router.
- Marks the adapter as `doublecounted: true` because the routed swaps are also counted by the underlying DEX pools.

## Methodology
- Unibot executes trades through WETH, so buy volume is counted from WETH deposited into the router and sell volume is counted from WETH withdrawn by the router.
- Uses on-chain WETH event logs via `options.getLogs` with event ABIs, then filters parsed event args to the Unibot router.
