### PR TITLE
[feat] BullX-Bot: track volume via dune

### DIFF
--- a/dexs/bullx.ts
+++ b/dexs/bullx.ts
@@ -1,0 +1,81 @@
+import ADDRESSES from '../helpers/coreAssets.json';
+import { Dependencies, FetchOptions, SimpleAdapter } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+import { queryDuneSql } from "../helpers/dune";
+
+const chainConfig = {
+  [CHAIN.SOLANA]: {
+    start: '2024-04-03',
+    feeWallets: {
+      old: 'F4hJ3Ee3c5UuaorKAMfELBjYCjiiLH75haZTKqTywRP3',
+      current: '9RYJ3qr5eU5xAooqVcbmdeusjcViL5Nkiq7Gske3tiKq',
+    },
+    cutoffTimestamp: 1731715200,
+  },
+} as const;
+
+const fetch: any = async (_a: any, _b: any, options: FetchOptions) => {
+  const tenHoursAgo = Date.now() - (10 * 60 * 60 * 1000);
+  if ((options.toTimestamp * 1000) > tenHoursAgo) {
+    throw new Error("End timestamp is less than 10 hours ago, skipping due to dune indexing delay");
+  }
+
+  const { feeWallets, cutoffTimestamp } = chainConfig[CHAIN.SOLANA];
+  const feeWallet = options.startOfDay >= cutoffTimestamp ? feeWallets.current : feeWallets.old;
+
+  const data = await queryDuneSql(options, `
+    WITH bullx_txs AS (
+      SELECT DISTINCT id AS tx_id
+      FROM solana.transactions
+      CROSS JOIN UNNEST(SEQUENCE(1, CARDINALITY(account_keys))) AS u(i)
+      WHERE TIME_RANGE
+        AND success = true
+        AND CONTAINS(account_keys, '${feeWallet}')
+        AND account_keys[i] = '${feeWallet}'
+        AND post_balances[i] > pre_balances[i]
+    ),
+    bot_trades AS (
+      SELECT
+        t.tx_id,
+        t.trader_id,
+        t.amount_usd,
+        ROW_NUMBER() OVER (
+          PARTITION BY t.tx_id, t.trader_id
+          ORDER BY
+            CASE WHEN t.token_bought_symbol = 'WSOL' OR t.token_sold_symbol = 'WSOL' THEN 0 ELSE 1 END,
+            t.amount_usd DESC
+        ) AS row_num
+      FROM dex_solana.trades t
+      JOIN bullx_txs b ON t.tx_id = b.tx_id
+      WHERE TIME_RANGE
+        AND t.trader_id != '${feeWallet}'
+        AND (
+          t.token_bought_symbol = 'WSOL'
+          OR t.token_sold_symbol = 'WSOL'
+          OR t.token_bought_mint_address = '${ADDRESSES.solana.SOL}'
+          OR t.token_sold_mint_address = '${ADDRESSES.solana.SOL}'
+        )
+    )
+    SELECT COALESCE(SUM(amount_usd), 0) AS daily_volume
+    FROM bot_trades
+    WHERE row_num = 1
+  `);
+
+  const dailyVolume = options.createBalances();
+  dailyVolume.addUSDValue(data[0].daily_volume);
+  return { dailyVolume };
+};
+
+const adapter: SimpleAdapter = {
+  version: 1,
+  fetch,
+  adapter: chainConfig,
+  dependencies: [Dependencies.DUNE],
+  isExpensiveAdapter: true,
+  methodology: {
+    Volume: "Total swap volume traded on BullX.",
+  },
+  doublecounted: true,
+};
+
+export default adapter;

--- a/dexs/bullx.ts
+++ b/dexs/bullx.ts
@@ -10,9 +10,9 @@ const chainConfig = {
       old: 'F4hJ3Ee3c5UuaorKAMfELBjYCjiiLH75haZTKqTywRP3',
       current: '9RYJ3qr5eU5xAooqVcbmdeusjcViL5Nkiq7Gske3tiKq',
     },
-    cutoffTimestamp: 1731715200,
+    cutoffDate: '2024-11-16',
   },
-} as const;
+};
 
 const fetch: any = async (_a: any, _b: any, options: FetchOptions) => {
   const tenHoursAgo = Date.now() - (10 * 60 * 60 * 1000);
@@ -20,8 +20,8 @@ const fetch: any = async (_a: any, _b: any, options: FetchOptions) => {
     throw new Error("End timestamp is less than 10 hours ago, skipping due to dune indexing delay");
   }
 
-  const { feeWallets, cutoffTimestamp } = chainConfig[CHAIN.SOLANA];
-  const feeWallet = options.startOfDay >= cutoffTimestamp ? feeWallets.current : feeWallets.old;
+  const { feeWallets, cutoffDate } = chainConfig[CHAIN.SOLANA];
+  const feeWallet = options.dateString >= cutoffDate ? feeWallets.current : feeWallets.old;
 
   const data = await queryDuneSql(options, `
     WITH bullx_txs AS (

--- a/dexs/bullx.ts
+++ b/dexs/bullx.ts
@@ -39,8 +39,10 @@ const fetch: any = async (_a: any, _b: any, options: FetchOptions) => {
         t.tx_id,
         t.trader_id,
         t.amount_usd,
+        t.outer_instruction_index,
+        t.inner_instruction_index,
         ROW_NUMBER() OVER (
-          PARTITION BY t.tx_id, t.trader_id
+          PARTITION BY t.tx_id, t.trader_id, t.outer_instruction_index, t.inner_instruction_index
           ORDER BY
             CASE WHEN t.token_bought_symbol = 'WSOL' OR t.token_sold_symbol = 'WSOL' THEN 0 ELSE 1 END,
             t.amount_usd DESC


### PR DESCRIPTION
https://defillama.com/protocol/bullx

## Summary
- Adds a BullX DEX volume adapter for Solana under `dexs/bullx.ts`.
- Uses Dune to calculate routed swap volume from BullX fee-paying transactions joined to `dex_solana.trades`.

## Changes
- Added `dexs/bullx.ts` with a Solana-only `dailyVolume` adapter.
- Identifies BullX transactions from `solana.transactions` using the active fee wallet balance increase, with the fee wallet selected by the existing BullX cutoff date.
- Joins matched transactions to `dex_solana.trades` and sums deduplicated USD trade volume.
- Adds a 10-hour Dune indexing-delay guard for `dex_solana.trades`.

## Methodology
- Counts spot swap volume routed through BullX on Solana.
- Uses `TIME_RANGE` for both `solana.transactions` and `dex_solana.trades`.
- Deduplicates per transaction and trader with `ROW_NUMBER()` to reduce multi-hop overcounting.
- Marks the adapter as `doublecounted` because routed volume is also counted by the underlying DEX venues.