### PR TITLE
block v2 dune adapters and gate store-all dune runs

### DIFF
--- a/adapters/types.ts
+++ b/adapters/types.ts
@@ -47,6 +47,8 @@ export type FetchOptions = {
   preFetchedResults?: any,
   moduleUID: string,  // randomly generated unique identifier for the module, useful for caching (used only for batch processing dune queries for now)
   startOfDayId?: string, // id used in some subgraphs to identify daily data, usually it's the startOfDay timestamp divided by 86400
+  runType?: 'store-all' | 'refill-all' | 'default' | 'refill-yesterday', // run mode injected by the server, used to gate indexer-dependent helpers (e.g. dune)
+  version?: number, // adapter version (1 or 2), used to gate indexer-dependent helpers (e.g. dune)
   metadata?: {
     [key: string]: any
     adapterType?: string

--- a/adapters/utils/runAdapter.ts
+++ b/adapters/utils/runAdapter.ts
@@ -101,6 +101,7 @@ type AdapterRunOptions = {
   withMetadata?: boolean, // if true, returns metadata with the response
   cacheResults?: boolean, // deprecated, if true, caches the results in adapterRunResponseCache
   runWindowInSeconds?: number, // time window for which the adapter should run, default is 1 day
+  runType?: 'store-all' | 'refill-all' | 'default' | 'refill-yesterday', // run mode injected by the server, used to gate indexer-dependent helpers
   metadata?: {
     [key: string]: any
     adapterType?: string
@@ -137,6 +138,7 @@ async function _runAdapter({
   withMetadata = false,
   deadChains = new Set(),
   runWindowInSeconds = ONE_DAY_IN_SECONDS,
+  runType,
   metadata = {},
 }: AdapterRunOptions) {
   const cleanCurrentDayTimestamp = endTimestamp
@@ -445,6 +447,8 @@ async function _runAdapter({
       moduleUID,
       startOfDayId: getStartOfDayId(startOfDay),
       streamLogs,
+      runType,
+      version: adapterVersion,
       metadata,
     }
   }

--- a/helpers/dune.ts
+++ b/helpers/dune.ts
@@ -8,6 +8,24 @@ import { CHAIN } from "./chains";
 
 let _axiosDune: any = null;
 
+// Dune indexers lag behind the chain head, so dune-backed adapters can't be trusted for
+// the hourly/near-real-time path:
+//  - v2 adapters are not supported at all (they run too close to head); they must be v1.
+//  - for the daily store-all run, the 00:00-02:00 UTC window has incomplete data for the
+//    previous day, so we skip it and let the refill-yesterday job backfill it once the
+//    indexer has caught up.
+const INDEXER_DELAY_WINDOW_END_HOUR_UTC = 2;
+
+function assertDuneRunAllowed(options?: FetchOptions) {
+  if (options?.version === 2) {
+    throw new Error("Dune queries are not supported in v2 adapters; please implement this as a v1 adapter")
+  }
+
+  if (options?.runType === "store-all" && new Date().getUTCHours() < INDEXER_DELAY_WINDOW_END_HOUR_UTC) {
+    throw new Error(`[dune] skipped during store-all in the 00:00-0${INDEXER_DELAY_WINDOW_END_HOUR_UTC}:00 UTC indexer-delay window; will be backfilled by the refill-yesterday job`)
+  }
+}
+
 // this wrapper is to ensure that secret is set before we try to use it
 function getAxiosDune() {
   if (_axiosDune) return _axiosDune;
@@ -99,6 +117,7 @@ const batchedQueries = new Map<string, {
 
 
 export function queryDune(queryId: string, query_parameters: any, options: FetchOptions, { extraUIDKey = '' }: { extraUIDKey?: string } = {}) {
+  assertDuneRunAllowed(options)
   const isBulkMode = getEnv('DUNE_BULK_MODE') === 'true'
   const batchTime = Number(getEnv('DUNE_BULK_MODE_BATCH_TIME') ?? 3_000)
 

--- a/helpers/dune.ts
+++ b/helpers/dune.ts
@@ -10,18 +10,25 @@ let _axiosDune: any = null;
 
 // Dune indexers lag behind the chain head, so dune-backed adapters can't be trusted for
 // the hourly/near-real-time path:
-//  - v2 adapters are not supported at all (they run too close to head); they must be v1.
-//  - for the daily store-all run, the 00:00-02:00 UTC window has incomplete data for the
-//    previous day, so we skip it and let the refill-yesterday job backfill it once the
-//    indexer has caught up.
+//  - v2 adapters run too close to head, so dune in v2 is discouraged. We don't hard-fail
+//    (tests/backfills still run), but we warn and skip it during the store-all run so
+//    incomplete data isn't persisted; the refill-yesterday job backfills it later.
+//  - for v1 adapters, the daily store-all run in the 00:00-02:00 UTC window has incomplete
+//    data for the previous day, so we skip just that window and let refill-yesterday backfill.
 const INDEXER_DELAY_WINDOW_END_HOUR_UTC = 2;
 
 function assertDuneRunAllowed(options?: FetchOptions) {
+  const isStoreAll = options?.runType === "store-all"
+
   if (options?.version === 2) {
-    throw new Error("Dune queries are not supported in v2 adapters; please implement this as a v1 adapter")
+    console.warn("[dune] dune queries in v2 adapters are unreliable due to indexer lag; prefer migrating this to a v1 adapter")
+    if (isStoreAll) {
+      throw new Error("[dune] v2 dune adapter skipped during store-all; will be backfilled by the refill-yesterday job")
+    }
+    return
   }
 
-  if (options?.runType === "store-all" && new Date().getUTCHours() < INDEXER_DELAY_WINDOW_END_HOUR_UTC) {
+  if (isStoreAll && new Date().getUTCHours() < INDEXER_DELAY_WINDOW_END_HOUR_UTC) {
     throw new Error(`[dune] skipped during store-all in the 00:00-0${INDEXER_DELAY_WINDOW_END_HOUR_UTC}:00 UTC indexer-delay window; will be backfilled by the refill-yesterday job`)
   }
 }


### PR DESCRIPTION
## What

Dune's indexers lag behind chain head, so dune-backed adapters are unreliable on the near-real-time path. This adds a guard in the dune helper (`helpers/dune.ts`) with two independent rules:

1. **v2 + dune is a hard block** — any v2 adapter calling `queryDune`/`queryDuneSql` throws and is directed to implement as v1.
2. **store-all run, 00:00-02:00 UTC is skipped** — the previous UTC day is not fully indexed yet during that window, so the daily store-all run throws instead of persisting incomplete numbers. The `refill-yesterday` job backfills it once the indexer catches up. Other run types (`refill-all`, `default`, `refill-yesterday`) and all other hours pass through.

To support this, `runType` (passed by the server) and the adapter `version` (`module.version`) are threaded onto the fetch options object via the `getOptionsObject` closure in `adapters/utils/runAdapter.ts`.

Pairs with the server change in DefiLlama/defillama-server#12171, which forwards `runType` into `runAdapter`.

## Blast radius

Rule 1 means existing v2 adapters that use dune will start failing until migrated to v1. Current v2 dune adapters (heuristic scan for `version: 2` + `queryDune*`):

- `fees/ethereum/index.ts`

Note: adapters that get v2 via a shared helper export (rather than a literal `version: 2`) won't show up in this scan, so the real list may be slightly larger.

## Test

`npm run ts-check` passes with 0 errors.
