### PR TITLE
feat: add Solana support to 0x aggregator via dune

### DIFF
--- a/aggregators/zrx/index.ts
+++ b/aggregators/zrx/index.ts
@@ -1,7 +1,8 @@
 import { CHAIN } from "../../helpers/chains";
-import { FetchOptions } from "../../adapters/types";
+import { Dependencies, FetchOptions } from "../../adapters/types";
 import { getEnv } from "../../helpers/env";
 import { httpGet } from "../../utils/fetchURL";
+import { queryDuneSql } from "../../helpers/dune";
 
 type TChain = {
   [key: string]: number;
@@ -34,36 +35,73 @@ const CHAINS: TChain = {
 const inflatedVolume: Record<string, Array<string>> = {
   [CHAIN.ETHEREUM]: ["2026-03-02", "2026-03-22"],
   [CHAIN.BASE]: ["2026-05-02"],
-}
+};
 
 const fetch = async (_a: any, _b: any, options: FetchOptions) => {
-  const response= await httpGet(`https://api.0x.org/stats/volume/daily?timestamp=${options.startOfDay}&chainId=${CHAINS[options.chain]}`, {
-    headers: {
-      "0x-api-key": getEnv("AGGREGATOR_0X_API_KEY")
-    }
-  })
+  const response = await httpGet(
+    `https://api.0x.org/stats/volume/daily?timestamp=${options.startOfDay}&chainId=${CHAINS[options.chain]}`,
+    {
+      headers: {
+        "0x-api-key": getEnv("AGGREGATOR_0X_API_KEY"),
+      },
+    },
+  );
 
   let dailyVolume = 0;
 
-  if (!inflatedVolume[options.chain] || !inflatedVolume[options.chain].includes(options.dateString))
+  if (
+    !inflatedVolume[options.chain] ||
+    !inflatedVolume[options.chain].includes(options.dateString)
+  )
     dailyVolume = response.data.volume;
 
   return {
     dailyVolume,
+  };
+};
+
+const SOLANA_PROGRAM = "Sett1erwx2eqT5A8uvu8GBxDFT2W5TNnhirL7hLmb8m";
+
+const fetchSolana = async (_a: any, _b: any, options: FetchOptions) => {
+  const tenHoursAgo = Date.now() - 10 * 60 * 60 * 1000;
+  if (options.toTimestamp * 1000 > tenHoursAgo) {
+    throw new Error(
+      "End timestamp is less than 10 hours ago, skipping due to dune indexing delay",
+    );
   }
+  const data = await queryDuneSql(
+    options,
+    `
+    SELECT COALESCE(SUM(amount_usd), 0) AS volume_24
+    FROM dex_solana.trades
+    WHERE block_time >= from_unixtime(${options.startTimestamp})
+      AND block_time <  from_unixtime(${options.endTimestamp})
+      AND trade_source = '${SOLANA_PROGRAM}'
+  `,
+  );
+  const row = data[0];
+  if (!row) throw new Error(`Dune query failed: ${JSON.stringify(data)}`);
+  return { dailyVolume: row.volume_24 };
 };
 
 const adapter: any = {
   version: 1,
-  adapter: Object.keys(CHAINS).reduce((acc, chain) => {
-    return {
-      ...acc,
-      [chain]: {
-        fetch: fetch,
-        start: '2022-05-17',
-      },
-    };
-  }, {}),
+  dependencies: [Dependencies.DUNE],
+  adapter: {
+    ...Object.keys(CHAINS).reduce((acc, chain) => {
+      return {
+        ...acc,
+        [chain]: {
+          fetch: fetch,
+          start: "2022-05-17",
+        },
+      };
+    }, {}),
+    [CHAIN.SOLANA]: {
+      fetch: fetchSolana,
+      start: "2026-01-01",
+    },
+  },
 };
 
 export default adapter;

--- a/aggregators/zrx/index.ts
+++ b/aggregators/zrx/index.ts
@@ -87,6 +87,7 @@ const fetchSolana = async (_a: any, _b: any, options: FetchOptions) => {
 const adapter: any = {
   version: 1,
   dependencies: [Dependencies.DUNE],
+  isExpensiveAdapter: true,
   adapter: {
     ...Object.keys(CHAINS).reduce((acc, chain) => {
       return {


### PR DESCRIPTION
Add Solana chain support to the 0x aggregator adapter, sourcing volume
from dex_solana.trades via Dune using the 0x settler program address
(Sett1erwx2eqT5A8uvu8GBxDFT2W5TNnhirL7hLmb8m). Mirrors the approach
used by the Jupiter aggregator adapter.

Website: https://0x.org
Twitter: https://twitter.com/0xProject

Example for 1st June
<img width="666" height="238" alt="image" src="https://github.com/user-attachments/assets/ad88197d-9659-4ac3-a63f-c9682b869dc5" />


