### PR TITLE
Add Tristero v3 adapter coverage

### DIFF
--- a/dexs/tristero/index.ts
+++ b/dexs/tristero/index.ts
@@ -1,8 +1,17 @@
+import { Balances } from "@defillama/sdk";
+import { AbiCoder, Interface } from "ethers";
 import { FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 import ADDRESSES from "../../helpers/coreAssets.json";
+import getTxReceipts, { getTransactions } from "../../helpers/getTxReceipts";
+import {
+  getActiveTristeroV3MarginEscrows,
+  getTristeroV3MarginPositions,
+  type TristeroV3MarginPosition,
+} from "../../helpers/tristeroMargin";
 
 const event_order_filled = 'event OrderFilled(bytes32 indexed orderUUID,string orderType,address target,address filler,address srcAsset,address dstAsset,uint256 srcQuantity,uint256 dstQuantity)';
+const ERC20_TRANSFER_TOPIC = "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef";
 
 type RouterConfig = {
   address: string;
@@ -54,6 +63,462 @@ const WRAPPED_NATIVE_TOKENS: Record<string, string | undefined> = {
   [CHAIN.XDAI]: ADDRESSES[CHAIN.XDAI]?.WXDAI,
 };
 
+function normalizeVolumeToken(chain: string, tokenAddress?: string | null): string | null {
+  const normalized = tokenAddress?.toLowerCase();
+  if (!normalized) return null;
+
+  if (normalized === '0x0000000000000000000000000000000000000000' || normalized === 'native') {
+    const wrappedToken = WRAPPED_NATIVE_TOKENS[chain] ?? ADDRESSES[chain]?.WETH;
+    return wrappedToken?.toLowerCase() ?? null;
+  }
+
+  return normalized;
+}
+
+type TristeroV3ChainConfig = {
+  start: string;
+  router: string;
+  escrow: string;
+  includedOrderTypes: string[];
+};
+
+type TristeroV3TransferLog = {
+  address: string;
+  data: string;
+  topics?: string[];
+  transactionHash?: string;
+  transaction_hash?: string;
+  txHash?: string;
+  logIndex?: string | number;
+  log_index?: string | number;
+  index?: string | number;
+};
+
+type TristeroV3DecodedOrder = {
+  orderType: string;
+  srcToken: string;
+  srcQuantity: bigint;
+  customData: string;
+};
+
+type TristeroV3Transaction = {
+  hash?: string | null;
+  from?: string | null;
+  to?: string | null;
+  data?: string;
+  input?: string;
+};
+
+type TristeroV3Receipt = {
+  hash?: string;
+  transactionHash?: string;
+  logs?: readonly TristeroV3TransferLog[];
+};
+
+const TRISTERO_V3_VOLUME_CONFIGS: Record<string, TristeroV3ChainConfig> = {
+  [CHAIN.ARBITRUM]: {
+    start: "2026-05-21",
+    router: "0x739DfF607F5303a2EB4D2271d11AEC6f642f6480",
+    escrow: "0x969D1eAb4C39706692d14894924245ca1Fe7cBCe",
+    includedOrderTypes: ["TAKER", "CROSS", "MARGIN"],
+  },
+  [CHAIN.BASE]: {
+    start: "2026-05-21",
+    router: "0x739DfF607F5303a2EB4D2271d11AEC6f642f6480",
+    escrow: "0x969D1eAb4C39706692d14894924245ca1Fe7cBCe",
+    includedOrderTypes: ["TAKER", "CROSS", "MARGIN"],
+  },
+} as const;
+
+const ORDER_ROUTER_ABI = [
+  {
+    type: "function",
+    name: "send",
+    stateMutability: "nonpayable",
+    inputs: [
+      {
+        name: "order",
+        type: "tuple",
+        components: [
+          { name: "sender", type: "address" },
+          {
+            name: "parameters",
+            type: "tuple",
+            components: [
+              { name: "srcAsset", type: "address" },
+              { name: "dstAsset", type: "address" },
+              { name: "srcQuantity", type: "uint256" },
+              { name: "dstQuantity", type: "uint256" },
+              { name: "minQuantity", type: "uint256" },
+              { name: "darkSalt", type: "uint128" },
+            ],
+          },
+          { name: "deadline", type: "uint256" },
+          { name: "target", type: "address" },
+          { name: "filler", type: "address" },
+          { name: "orderType", type: "string" },
+          { name: "customData", type: "bytes" },
+        ],
+      },
+      {
+        name: "payload",
+        type: "tuple",
+        components: [
+          { name: "nonce", type: "uint256" },
+          { name: "signature", type: "bytes" },
+        ],
+      },
+      {
+        name: "arb",
+        type: "tuple",
+        components: [
+          { name: "multicallTarget", type: "address" },
+          {
+            name: "calls",
+            type: "tuple[]",
+            components: [
+              { name: "target", type: "address" },
+              { name: "allowFailure", type: "bool" },
+              { name: "value", type: "uint256" },
+              { name: "callData", type: "bytes" },
+            ],
+          },
+          { name: "refundTo", type: "address" },
+          { name: "nftRecipient", type: "address" },
+        ],
+      },
+      { name: "minOut", type: "uint256" },
+      {
+        name: "v",
+        type: "tuple",
+        components: [
+          { name: "vault", type: "address" },
+          {
+            name: "permit",
+            type: "tuple",
+            components: [
+              {
+                name: "permitted",
+                type: "tuple",
+                components: [
+                  { name: "token", type: "address" },
+                  { name: "amount", type: "uint256" },
+                ],
+              },
+              { name: "nonce", type: "uint256" },
+              { name: "deadline", type: "uint256" },
+            ],
+          },
+          { name: "signature", type: "bytes" },
+        ],
+      },
+    ],
+  },
+] as const;
+
+const ESCROW_ABI = [
+  {
+    type: "function",
+    name: "close",
+    stateMutability: "nonpayable",
+    inputs: [
+      {
+        name: "order",
+        type: "tuple",
+        components: [
+          { name: "positionId", type: "uint128" },
+          { name: "sharesToClose", type: "uint256" },
+          { name: "minOut", type: "uint256" },
+          { name: "deadline", type: "uint256" },
+          { name: "permit2Nonce", type: "uint256" },
+        ],
+      },
+      { name: "signature", type: "bytes" },
+      {
+        name: "arb",
+        type: "tuple",
+        components: [
+          { name: "multicallTarget", type: "address" },
+          {
+            name: "calls",
+            type: "tuple[]",
+            components: [
+              { name: "target", type: "address" },
+              { name: "allowFailure", type: "bool" },
+              { name: "value", type: "uint256" },
+              { name: "callData", type: "bytes" },
+            ],
+          },
+          { name: "refundTo", type: "address" },
+          { name: "nftRecipient", type: "address" },
+        ],
+      },
+    ],
+  },
+] as const;
+
+const ORDER_ROUTER_INTERFACE = new Interface(ORDER_ROUTER_ABI);
+const ESCROW_INTERFACE = new Interface(ESCROW_ABI);
+const ABI_CODER = AbiCoder.defaultAbiCoder();
+
+function topicAddress(address: string): string {
+  return `0x${address.toLowerCase().replace(/^0x/, "").padStart(64, "0")}`;
+}
+
+function normalize(value?: string | null): string {
+  return value?.toLowerCase() ?? "";
+}
+
+function getTxHash(log?: TristeroV3TransferLog | null): string | undefined {
+  return log?.transactionHash ?? log?.transaction_hash ?? log?.txHash;
+}
+
+function getReceiptTxHash(receipt: TristeroV3Receipt): string | undefined {
+  return receipt.transactionHash ?? receipt.hash ?? (receipt.logs?.length ? getTxHash(receipt.logs[0] as TristeroV3TransferLog) : undefined);
+}
+
+function isNonZeroBytes32(value: string): boolean {
+  if (!/^0x[0-9a-fA-F]{64}$/.test(value)) return false;
+  return BigInt(value) > 0n;
+}
+
+function isIncludedOrderType(orderType: string, includedOrderTypes: string[]): boolean {
+  return includedOrderTypes.includes(orderType.toUpperCase());
+}
+
+function isRouterTransaction(tx: TristeroV3Transaction | null, router: string): boolean {
+  return normalize(tx?.to) === normalize(router);
+}
+
+function decodeTristeroV3SendOrder(data?: string): TristeroV3DecodedOrder | null {
+  if (!data) return null;
+
+  try {
+    const parsed = ORDER_ROUTER_INTERFACE.parseTransaction({ data });
+    if (!parsed || parsed.name !== "send") return null;
+
+    const order = parsed.args.order;
+    return {
+      orderType: order.orderType,
+      srcToken: order.parameters.srcAsset,
+      srcQuantity: BigInt(order.parameters.srcQuantity),
+      customData: order.customData,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function decodeTristeroV3CloseOrder(data?: string): boolean {
+  if (!data) return false;
+
+  try {
+    const parsed = ESCROW_INTERFACE.parseTransaction({ data });
+    return parsed?.name === "close";
+  } catch {
+    return false;
+  }
+}
+
+function getMarginLoanQuantity(order: TristeroV3DecodedOrder): bigint {
+  if (order.orderType.toUpperCase() !== "MARGIN" || !order.customData || order.customData === "0x") {
+    return 0n;
+  }
+
+  try {
+    const [loanAsset, loanQuantity] = ABI_CODER.decode(["address", "uint256", "uint256"], order.customData);
+    if (normalize(loanAsset) !== normalize(order.srcToken)) return 0n;
+    return BigInt(loanQuantity);
+  } catch {
+    return 0n;
+  }
+}
+
+function getOrderVolumeQuantity(order: TristeroV3DecodedOrder): bigint {
+  return order.srcQuantity + getMarginLoanQuantity(order);
+}
+
+function isTristeroV3RouterTransferLog(log: TristeroV3TransferLog, router: string): boolean {
+  const topics = log.topics ?? [];
+
+  return topics.length === 3
+    && normalize(topics[0]) === ERC20_TRANSFER_TOPIC
+    && normalize(topics[2]) === topicAddress(router)
+    && isNonZeroBytes32(log.data);
+}
+
+function addTristeroV3OrdersToBalances(
+  logs: TristeroV3TransferLog[],
+  transactions: (TristeroV3Transaction | null)[],
+  dailyVolume: Balances,
+  config: TristeroV3ChainConfig,
+  chain: string,
+) {
+  const seenTxs = new Set<string>();
+  const transactionByHash = new Map<string, TristeroV3Transaction>();
+
+  transactions.forEach((tx) => {
+    if (!tx?.hash) return;
+    transactionByHash.set(normalize(tx.hash), tx);
+  });
+
+  logs.forEach((log) => {
+    if (!isTristeroV3RouterTransferLog(log, config.router)) return;
+    const txHash = getTxHash(log);
+    if (!txHash) return;
+
+    const normalizedTxHash = normalize(txHash);
+    if (seenTxs.has(normalizedTxHash)) return;
+
+    const tx = transactionByHash.get(normalizedTxHash);
+    if (!isRouterTransaction(tx ?? null, config.router)) return;
+
+    const decodedOrder = decodeTristeroV3SendOrder(tx?.data ?? tx?.input);
+    if (!decodedOrder || !isIncludedOrderType(decodedOrder.orderType, config.includedOrderTypes)) return;
+
+    const tokenAddress = normalizeVolumeToken(chain, decodedOrder.srcToken);
+    if (!tokenAddress) return;
+
+    seenTxs.add(normalizedTxHash);
+    dailyVolume.add(tokenAddress, getOrderVolumeQuantity(decodedOrder));
+  });
+}
+
+function topicToAddress(topic?: string): string {
+  return topic ? `0x${topic.slice(-40)}`.toLowerCase() : "";
+}
+
+function addTristeroV3CloseReceiptsToBalances(
+  receipts: (TristeroV3Receipt | null)[],
+  transactions: (TristeroV3Transaction | null)[],
+  dailyVolume: Balances,
+  config: TristeroV3ChainConfig,
+  closePositionsByTxHash: Map<string, TristeroV3MarginPosition[]>,
+  closeTxHashes: string[],
+) {
+  const txByHash = new Map<string, TristeroV3Transaction>();
+
+  transactions.forEach((tx) => {
+    if (!tx?.hash) return;
+    txByHash.set(normalize(tx.hash), tx);
+  });
+
+  receipts.forEach((receipt, index) => {
+    if (!receipt) {
+      throw new Error(`Missing Tristero v3 close receipt for ${config.escrow} tx ${normalize(closeTxHashes[index])}`);
+    }
+
+    const receiptTxHash = getReceiptTxHash(receipt);
+    if (!receiptTxHash) {
+      throw new Error(`Missing Tristero v3 close receipt transaction hash for ${config.escrow} tx ${normalize(closeTxHashes[index])}`);
+    }
+    const normalizedReceiptTxHash = normalize(receiptTxHash);
+
+    const tx = txByHash.get(normalizedReceiptTxHash);
+    if (!tx || !isRouterTransaction(tx, config.escrow) || !decodeTristeroV3CloseOrder(tx.data ?? tx.input)) {
+      throw new Error(`Missing Tristero v3 close transaction data for ${config.escrow} tx ${normalizedReceiptTxHash}`);
+    }
+
+    const closePositions = closePositionsByTxHash.get(normalizedReceiptTxHash);
+    if (!closePositions?.length) {
+      throw new Error(`Missing Tristero v3 close position state for ${config.escrow} tx ${normalizedReceiptTxHash}`);
+    }
+
+    const loanAssets = [...new Set(closePositions.map((position) => normalize(position.loanAsset)))];
+    loanAssets.forEach((loanAsset) => {
+      let grossCloseAmount = 0n;
+
+      (receipt.logs ?? []).forEach((log) => {
+        const topics = log.topics ?? [];
+        if (
+          normalize(log.address) !== loanAsset
+          || topics.length !== 3
+          || normalize(topics[0]) !== ERC20_TRANSFER_TOPIC
+          || normalize(topics[1]) !== topicAddress(config.escrow)
+          || topicToAddress(topics[2]) === "0x0000000000000000000000000000000000000000"
+          || !isNonZeroBytes32(log.data)
+        ) {
+          return;
+        }
+
+        grossCloseAmount += BigInt(log.data);
+      });
+
+      if (grossCloseAmount > 0n) {
+        dailyVolume.add(loanAsset, grossCloseAmount);
+      }
+    });
+  });
+}
+
+function groupClosePositionsByTxHash(positions: TristeroV3MarginPosition[], closeTxHashes: Set<string>): Map<string, TristeroV3MarginPosition[]> {
+  const positionsByTxHash = new Map<string, TristeroV3MarginPosition[]>();
+
+  positions.forEach((position) => {
+    const txHash = normalize(position.closeTxHash);
+    if (!txHash || !closeTxHashes.has(txHash)) return;
+
+    const positionsForTx = positionsByTxHash.get(txHash) ?? [];
+    positionsForTx.push(position);
+    positionsByTxHash.set(txHash, positionsForTx);
+  });
+
+  return positionsByTxHash;
+}
+
+async function addTristeroV3ChainVolume(options: FetchOptions, dailyVolume: Balances) {
+  const config = TRISTERO_V3_VOLUME_CONFIGS[options.chain];
+  if (!config || options.dateString < config.start) return;
+
+  // Current v3 router.send is nonpayable and backend submits it with value=0,
+  // so router funding is discoverable through ERC20 Transfer logs. If a future
+  // router.send becomes payable, also decode tx.value-backed native funding.
+  const logs: TristeroV3TransferLog[] = await options.getLogs({
+    topics: [
+      ERC20_TRANSFER_TOPIC,
+      null as any,
+      topicAddress(config.router),
+    ],
+    noTarget: true,
+    eventAbi: "event Transfer(address indexed from, address indexed to, uint256 value)",
+    entireLog: true,
+  });
+
+  const txHashes = [...new Set(logs.map(getTxHash).filter((txHash): txHash is string => !!txHash))];
+  if (txHashes.length) {
+    const transactions = await getTransactions(options.chain, txHashes, {
+      cacheKey: "tristero-v3-router-send",
+    });
+    addTristeroV3OrdersToBalances(logs, transactions, dailyVolume, config, options.chain);
+  }
+
+  const closeLogs: TristeroV3TransferLog[] = await options.getLogs({
+    target: config.escrow,
+    eventAbi: "event PositionClosed(uint128 indexed positionId, address indexed filler)",
+    entireLog: true,
+  });
+  const closeTxHashes = [...new Set(closeLogs.map(getTxHash).filter((txHash): txHash is string => !!txHash))];
+  if (closeTxHashes.length) {
+    const normalizedCloseTxHashes = new Set(closeTxHashes.map(normalize));
+    const v3MarginPositions = await getTristeroV3MarginPositions(
+      options,
+      getActiveTristeroV3MarginEscrows(options.chain, options.dateString),
+      await options.getToBlock(),
+    );
+    const closePositionsByTxHash = groupClosePositionsByTxHash(v3MarginPositions, normalizedCloseTxHashes);
+
+    const [closeTransactions, closeReceipts] = await Promise.all([
+      getTransactions(options.chain, closeTxHashes, {
+        cacheKey: "tristero-v3-escrow-close",
+      }),
+      getTxReceipts(options.chain, closeTxHashes, {
+        cacheKey: "tristero-v3-escrow-close",
+      }),
+    ]);
+    addTristeroV3CloseReceiptsToBalances(closeReceipts as unknown as TristeroV3Receipt[], closeTransactions, dailyVolume, config, closePositionsByTxHash, closeTxHashes);
+  }
+}
+
 const fetch = async (options: FetchOptions) => {
   const dailyVolume = options.createBalances();
   const chain = options.chain;
@@ -76,15 +541,13 @@ const fetch = async (options: FetchOptions) => {
 
   allLogs.forEach((log: any) => {
     if (log.srcAsset && log.srcQuantity) {
-      let tokenAddress = log.srcAsset.toLowerCase();
-      if (tokenAddress === '0x0000000000000000000000000000000000000000' || tokenAddress === 'native') {
-        const wrappedToken = WRAPPED_NATIVE_TOKENS[chain] ?? ADDRESSES[chain]?.WETH;
-        if (!wrappedToken) return;
-        tokenAddress = wrappedToken.toLowerCase();
-      }
+      const tokenAddress = normalizeVolumeToken(chain, log.srcAsset);
+      if (!tokenAddress) return;
       dailyVolume.add(tokenAddress, log.srcQuantity);
     }
   });
+
+  await addTristeroV3ChainVolume(options, dailyVolume);
 
   return { dailyVolume };
 };
@@ -98,6 +561,9 @@ const adapter: SimpleAdapter = {
       { fetch, start: config.start }
     ])
   ),
+  methodology: {
+    Volume: "Legacy Tristero volume is counted from OrderFilled source token amounts. V3 volume is counted from on-chain router.send transactions for TAKER, CROSS, and MARGIN orders plus escrow.close settlement transfers; margin opens include collateral plus decoded loan quantity.",
+  },
 };
 
 export default adapter;

--- a/fees/tristero-margin.ts
+++ b/fees/tristero-margin.ts
@@ -1,7 +1,13 @@
 import { FetchOptions, FetchResultV2, SimpleAdapter } from "../adapters/types";
+import getTxReceipts from "../helpers/getTxReceipts";
 import { METRIC } from "../helpers/metrics";
 import {
     getActiveTristeroMarginEscrows,
+    getActiveTristeroV3MarginEscrows,
+    getTristeroMarginChainStart,
+    getTristeroMarginChains,
+    getTristeroV3MarginPositions,
+    getV3PositionKey,
     getPositionIds,
     mulDivCeil,
     normalizePosition,
@@ -9,9 +15,12 @@ import {
     toBigIntSafe,
     toPositionId,
     TRISTERO_MARGIN_ABI,
+    TRISTERO_V3_MARGIN_ABI,
     type TristeroMarginPosition,
-    TRISTERO_MARGIN_CONFIGS,
+    type TristeroV3MarginPosition,
 } from "../helpers/tristeroMargin";
+
+const ERC20_TRANSFER_TOPIC = "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef";
 
 const MARGIN_METRICS = {
     BORROW_INTEREST_TO_PROTOCOL: 'Borrow Interest To Protocol',
@@ -64,6 +73,140 @@ function addToPositionMap(map: Map<string, bigint>, positionRef: PositionRef, am
 function addToTokenMap(map: Map<string, bigint>, token: string, amount: bigint) {
     const key = token.toLowerCase();
     map.set(key, (map.get(key) ?? 0n) + amount);
+}
+
+function normalizeAddress(value?: string | null): string {
+    return value?.toLowerCase() ?? "";
+}
+
+function topicAddress(address: string): string {
+    return `0x${address.toLowerCase().replace(/^0x/, "").padStart(64, "0")}`;
+}
+
+function topicToAddress(topic?: string): string {
+    return topic ? `0x${topic.slice(-40)}`.toLowerCase() : "";
+}
+
+function isNonZeroBytes32(value?: string): boolean {
+    if (!value || !/^0x[0-9a-fA-F]{64}$/.test(value)) return false;
+    return BigInt(value) > 0n;
+}
+
+async function readV3LoanValuesAtBlock(
+    options: FetchOptions,
+    positions: TristeroV3MarginPosition[],
+    block: number,
+): Promise<Map<string, bigint>> {
+    const values = positions.length
+        ? await options.api.multiCall({
+            abi: TRISTERO_V3_MARGIN_ABI.readValue,
+            calls: positions.map((position) => ({
+                target: position.vault,
+                params: [position.loanAsset, position.loanShares.toString()],
+            })),
+            block,
+            permitFailure: true,
+        })
+        : [];
+
+    const valuesByPosition = new Map<string, bigint>();
+    positions.forEach((position, index) => {
+        const value = toBigIntOrNull(values[index]);
+        if (value === null) {
+            throw new Error(`Unable to read Tristero v3 loan value for ${options.chain} position ${position.positionId} at ${position.escrow} block ${block}`);
+        }
+
+        valuesByPosition.set(getV3PositionKey(position), value);
+    });
+
+    return valuesByPosition;
+}
+
+async function readV3LoanValuesByPositionBlock(
+    options: FetchOptions,
+    positionBlocks: { position: TristeroV3MarginPosition; block: number }[],
+): Promise<Map<string, bigint>> {
+    const positionsByBlock = new Map<number, TristeroV3MarginPosition[]>();
+
+    positionBlocks.forEach(({ position, block }) => {
+        const positions = positionsByBlock.get(block) ?? [];
+        positions.push(position);
+        positionsByBlock.set(block, positions);
+    });
+
+    const valuesByPosition = new Map<string, bigint>();
+    for (const [block, positions] of positionsByBlock.entries()) {
+        const valuesAtBlock = await readV3LoanValuesAtBlock(options, positions, block);
+        valuesAtBlock.forEach((value, key) => valuesByPosition.set(`${key}-${block}`, value));
+    }
+
+    return valuesByPosition;
+}
+
+function getV3HistoricalValueKey(position: TristeroV3MarginPosition, block: number): string {
+    return `${getV3PositionKey(position)}-${block}`;
+}
+
+async function getV3CloseRepayments(
+    options: FetchOptions,
+    closedPositions: TristeroV3MarginPosition[],
+): Promise<Map<string, bigint>> {
+    const txHashes = [...new Set(closedPositions.map((position) => position.closeTxHash).filter((txHash): txHash is string => !!txHash))];
+    const repaymentByPosition = new Map<string, bigint>();
+    if (!txHashes.length) return repaymentByPosition;
+
+    const receipts = await getTxReceipts(options.chain, txHashes, {
+        cacheKey: "tristero-v3-margin-close-fees",
+    });
+    const positionsByTxHash = new Map<string, TristeroV3MarginPosition[]>();
+    closedPositions.forEach((position) => {
+        if (!position.closeTxHash) return;
+        const txHash = position.closeTxHash.toLowerCase();
+        const positions = positionsByTxHash.get(txHash) ?? [];
+        positions.push(position);
+        positionsByTxHash.set(txHash, positions);
+    });
+
+    receipts.forEach((receipt: any, index) => {
+        if (!receipt) {
+            throw new Error(`Missing Tristero v3 close receipt for ${options.chain} tx ${normalizeAddress(txHashes[index])}`);
+        }
+
+        const txHash = normalizeAddress(receipt.transactionHash ?? receipt.hash);
+        if (!txHash) {
+            throw new Error(`Missing Tristero v3 close receipt transaction hash for ${options.chain} tx ${normalizeAddress(txHashes[index])}`);
+        }
+
+        const positions = positionsByTxHash.get(txHash);
+        if (!positions?.length) return;
+        if (positions.length !== 1) {
+            throw new Error(`Ambiguous Tristero v3 close repayment attribution for ${options.chain} tx ${txHash}: ${positions.length} positions share one receipt`);
+        }
+
+        const position = positions[0];
+        let repayment = 0n;
+        (receipt.logs ?? []).forEach((log: any) => {
+            const topics = log.topics ?? [];
+            if (
+                normalizeAddress(log.address) !== position.loanAsset
+                || topics.length !== 3
+                || normalizeAddress(topics[0]) !== ERC20_TRANSFER_TOPIC
+                || normalizeAddress(topics[1]) !== topicAddress(position.escrow)
+                || topicToAddress(topics[2]) !== normalizeAddress(position.closeFiller)
+                || !isNonZeroBytes32(log.data)
+            ) {
+                return;
+            }
+
+            repayment += BigInt(log.data);
+        });
+
+        if (repayment > 0n) {
+            repaymentByPosition.set(getV3PositionKey(position), repayment);
+        }
+    });
+
+    return repaymentByPosition;
 }
 
 function flattenGroupedLogs(logGroups: any[][], escrows: string[]): any[] {
@@ -172,8 +315,9 @@ const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
     const liquidationFees = options.createBalances();
     const liquidationProtocolRevenue = options.createBalances();
     const escrows = getActiveTristeroMarginEscrows(options.chain, options.dateString);
+    const v3Escrows = getActiveTristeroV3MarginEscrows(options.chain, options.dateString);
 
-    if (!escrows.length) {
+    if (!escrows.length && !v3Escrows.length) {
         const dailyFees = borrowInterestFees.clone();
         const dailyProtocolRevenue = borrowInterestProtocolRevenue.clone();
 
@@ -182,7 +326,7 @@ const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
             dailyUserFees: dailyFees.clone(),
             dailyRevenue: dailyProtocolRevenue.clone(),
             dailyProtocolRevenue,
-            dailySupplySideRevenue: borrowInterestFees.clone(),
+            dailySupplySideRevenue: borrowInterestSupplySideRevenue.clone(),
         };
     }
 
@@ -375,6 +519,77 @@ const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
         borrowInterestFees.add(position.loanToken, accruedDuringPeriod.toString(), METRIC.BORROW_INTEREST);
     });
 
+    if (v3Escrows.length) {
+        const fromBlock = await options.getFromBlock();
+        const toBlock = await options.getToBlock();
+        const v3Positions = await getTristeroV3MarginPositions(options, v3Escrows, toBlock);
+        const relevantV3Positions = v3Positions.filter((position) =>
+            position.openBlock <= toBlock
+            && (position.closeBlock === undefined || position.closeBlock >= fromBlock)
+        );
+
+        const startBlockByPosition = new Map<string, number>();
+        relevantV3Positions.forEach((position) => {
+            startBlockByPosition.set(
+                getV3PositionKey(position),
+                position.openBlock > fromBlock ? position.openBlock : fromBlock,
+            );
+        });
+        const startBlocks = relevantV3Positions.map((position) => ({
+            position,
+            block: startBlockByPosition.get(getV3PositionKey(position))!,
+        }));
+        const closedV3Positions = relevantV3Positions.filter((position) =>
+            position.closeBlock !== undefined
+            && position.closeBlock >= fromBlock
+            && position.closeBlock <= toBlock
+        );
+        const openV3Positions = relevantV3Positions.filter((position) =>
+            position.closeBlock === undefined || position.closeBlock > toBlock
+        );
+
+        const [startLoanValues, endLoanValues, closeRepayments] = await Promise.all([
+            readV3LoanValuesByPositionBlock(options, startBlocks),
+            readV3LoanValuesAtBlock(options, openV3Positions, toBlock),
+            getV3CloseRepayments(options, closedV3Positions),
+        ]);
+
+        relevantV3Positions.forEach((position) => {
+            const startBlock = startBlockByPosition.get(getV3PositionKey(position));
+            if (startBlock === undefined) {
+                throw new Error(`Missing Tristero v3 start block for ${options.chain} position ${position.positionId} at ${position.escrow}`);
+            }
+
+            const startValue = startLoanValues.get(getV3HistoricalValueKey(position, startBlock));
+            if (startValue === undefined) {
+                throw new Error(`Missing Tristero v3 start loan value for ${options.chain} position ${position.positionId} at ${position.escrow}`);
+            }
+
+            const closedInPeriod = position.closeBlock !== undefined
+                && position.closeBlock >= fromBlock
+                && position.closeBlock <= toBlock;
+            const positionKey = getV3PositionKey(position);
+            let endValue: bigint | undefined;
+            if (closedInPeriod) {
+                endValue = closeRepayments.get(positionKey);
+                if (endValue === undefined) {
+                    throw new Error(`Missing Tristero v3 close repayment for ${options.chain} position ${position.positionId} at ${position.escrow}`);
+                }
+            } else {
+                endValue = endLoanValues.get(positionKey);
+            }
+            if (endValue === undefined) {
+                throw new Error(`Missing Tristero v3 end loan value for ${options.chain} position ${position.positionId} at ${position.escrow}`);
+            }
+
+            const accruedDuringPeriod = endValue - startValue;
+            if (accruedDuringPeriod <= 0n) return;
+
+            addToTokenMap(grossBorrowInterestByToken, position.loanAsset, accruedDuringPeriod);
+            borrowInterestFees.add(position.loanAsset, accruedDuringPeriod.toString(), METRIC.BORROW_INTEREST);
+        });
+    }
+
     protocolBorrowInterestByToken.forEach((amount, token) => {
         borrowInterestProtocolRevenue.add(token, amount.toString(), MARGIN_METRICS.BORROW_INTEREST_TO_PROTOCOL);
     });
@@ -409,16 +624,16 @@ const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
 };
 
 const methodology = {
-    Fees: 'Daily borrow interest accrued on open margin positions, plus any protocol-collected liquidation fees.',
-    Revenue: 'Protocol share of margin borrow interest and liquidation fees. The current live staging escrow has protocol borrow fees disabled, so this is usually zero until that parameter changes.',
-    ProtocolRevenue: 'Protocol share of margin borrow interest and liquidation fees. The current live staging escrow has protocol borrow fees disabled, so this is usually zero until that parameter changes.',
+    Fees: 'Daily borrow interest accrued on legacy and v3 margin positions, plus any legacy protocol-collected liquidation fees.',
+    Revenue: 'Protocol share of legacy margin borrow interest and liquidation fees. V3 borrow interest is attributed to lenders unless a protocol fee event is introduced.',
+    ProtocolRevenue: 'Protocol share of legacy margin borrow interest and liquidation fees. V3 borrow interest is attributed to lenders unless a protocol fee event is introduced.',
     SupplySideRevenue: 'Borrow interest attributable to the filler lenders that funded margin positions.',
 };
 
 const breakdownMethodology = {
     Fees: {
-        [METRIC.BORROW_INTEREST]: 'Borrow interest accrued during the day across active, closed, and liquidated margin positions.',
-        [METRIC.LIQUIDATION_FEES]: 'Protocol-collected liquidation fees.',
+        [METRIC.BORROW_INTEREST]: 'Borrow interest accrued during the day across active, closed, and liquidated legacy positions, plus v3 vault loan-value growth and close repayments.',
+        [METRIC.LIQUIDATION_FEES]: 'Legacy protocol-collected liquidation fees.',
     },
     Revenue: {
         [MARGIN_METRICS.BORROW_INTEREST_TO_PROTOCOL]: 'Protocol share of borrow interest.',
@@ -435,7 +650,12 @@ const breakdownMethodology = {
 };
 const adapter: SimpleAdapter = {
     version: 2,
-    adapter: TRISTERO_MARGIN_CONFIGS,
+    adapter: Object.fromEntries(
+        getTristeroMarginChains().map((chain) => [
+            chain,
+            { start: getTristeroMarginChainStart(chain) },
+        ])
+    ),
     fetch,
     pullHourly: true,
     methodology,

--- a/helpers/tristeroMargin.ts
+++ b/helpers/tristeroMargin.ts
@@ -1,5 +1,6 @@
 import { FetchOptions } from "../adapters/types";
 import { CHAIN } from "./chains";
+import { getBlock } from "./getBlock";
 
 type TristeroMarginEscrowConfig = {
   address: string;
@@ -10,6 +11,18 @@ type TristeroMarginEscrowConfig = {
 type TristeroMarginChainConfig = {
   start: string;
   escrows: TristeroMarginEscrowConfig[];
+};
+
+export type TristeroV3MarginEscrowConfig = {
+  address: string;
+  vault: string;
+  start: string;
+  end?: string;
+};
+
+type TristeroV3MarginChainConfig = {
+  start: string;
+  escrows: TristeroV3MarginEscrowConfig[];
 };
 
 export const TRISTERO_MARGIN_CONFIGS: Record<string, TristeroMarginChainConfig> = {
@@ -36,18 +49,57 @@ export const TRISTERO_MARGIN_CONFIGS: Record<string, TristeroMarginChainConfig> 
   },
 } as const;
 
+export const TRISTERO_V3_MARGIN_CONFIGS: Record<string, TristeroV3MarginChainConfig> = {
+  [CHAIN.ARBITRUM]: {
+    start: '2026-05-21',
+    escrows: [
+      {
+        address: '0x969D1eAb4C39706692d14894924245ca1Fe7cBCe',
+        vault: '0xd329330475126E0Fd0b955C385eaf5de4B684802',
+        start: '2026-05-21',
+      },
+    ],
+  },
+  [CHAIN.BASE]: {
+    start: '2026-05-21',
+    escrows: [
+      {
+        address: '0x969D1eAb4C39706692d14894924245ca1Fe7cBCe',
+        vault: '0xd329330475126E0Fd0b955C385eaf5de4B684802',
+        start: '2026-05-21',
+      },
+    ],
+  },
+} as const;
+
 export function getTristeroMarginChains(): string[] {
-  return Object.keys(TRISTERO_MARGIN_CONFIGS);
+  return Array.from(new Set([
+    ...Object.keys(TRISTERO_MARGIN_CONFIGS),
+    ...Object.keys(TRISTERO_V3_MARGIN_CONFIGS),
+  ]));
 }
 
 export function getTristeroMarginChainStart(chain: string): string | undefined {
-  return TRISTERO_MARGIN_CONFIGS[chain]?.start;
+  const starts = [TRISTERO_MARGIN_CONFIGS[chain]?.start, TRISTERO_V3_MARGIN_CONFIGS[chain]?.start].filter(Boolean) as string[];
+  return starts.sort()[0];
 }
 
 export function getActiveTristeroMarginEscrows(chain: string, date: string): string[] {
   return (TRISTERO_MARGIN_CONFIGS[chain]?.escrows ?? [])
     .filter(({ start, end }) => date >= start && (!end || date <= end))
     .map(({ address }) => address);
+}
+
+/**
+ * Returns v3 margin escrows that should be included for a chain/date window.
+ *
+ * @param chain DefiLlama chain slug used by the adapter runner.
+ * @param date Adapter date string in YYYY-MM-DD format.
+ * @returns V3 margin escrow/vault configs whose start/end range includes date.
+ */
+export function getActiveTristeroV3MarginEscrows(chain: string, date: string): TristeroV3MarginEscrowConfig[] {
+  return (TRISTERO_V3_MARGIN_CONFIGS[chain]?.escrows ?? [])
+    .filter(({ start, end }) => date >= start && (!end || date <= end));
 }
 
 export const TRISTERO_MARGIN_ABI = {
@@ -60,6 +112,14 @@ export const TRISTERO_MARGIN_ABI = {
   protocolFeeCollected: 'event ProtocolFeeCollected(uint128 indexed positionId, address indexed token, uint256 amount)',
 } as const;
 
+export const TRISTERO_V3_MARGIN_ABI = {
+  ownerOf: 'function ownerOf(uint256 tokenId) view returns (address)',
+  readValue: 'function readValue(address token, uint256 shares) view returns (uint256)',
+  positionOpened: 'event PositionOpened(uint128 indexed positionId, address indexed taker, address indexed filler, (address underlyingAsset, address loanAsset, uint256 notionalShares, uint256 loanShares, uint256 RPS, uint256 lastUpdate) position)',
+  positionReduced: 'event PositionReduced(uint128 indexed positionId, address indexed taker, uint256 repayAmount, uint256 collateralOut, (address underlyingAsset, address loanAsset, uint256 notionalShares, uint256 loanShares, uint256 RPS, uint256 lastUpdate) position)',
+  positionClosed: 'event PositionClosed(uint128 indexed positionId, address indexed filler)',
+} as const;
+
 export interface TristeroMarginPosition {
   taker: string;
   filler: string;
@@ -69,6 +129,51 @@ export interface TristeroMarginPosition {
   loanAmount: bigint;
   liqPrice: bigint;
 }
+
+export interface TristeroV3MarginPosition {
+  escrow: string;
+  vault: string;
+  positionId: number;
+  taker: string;
+  filler: string;
+  underlyingAsset: string;
+  loanAsset: string;
+  notionalShares: bigint;
+  loanShares: bigint;
+  rps: bigint;
+  lastUpdate: bigint;
+  openBlock: number;
+  // PositionClosed is terminal in current v3. Partial changes emit PositionReduced
+  // and update the remaining share fields without setting these close fields.
+  closeBlock?: number;
+  closeTxHash?: string;
+  closeFiller?: string;
+}
+
+type TristeroV3PositionStruct = {
+  underlyingAsset: string;
+  loanAsset: string;
+  notionalShares: bigint;
+  loanShares: bigint;
+  rps: bigint;
+  lastUpdate: bigint;
+};
+
+type TristeroV3ReducedPositionLog = {
+  positionId: number;
+  taker: string;
+  position: TristeroV3PositionStruct;
+  blockNumber: number;
+  logIndex: number;
+};
+
+type TristeroV3ClosedPositionLog = {
+  positionId: number;
+  filler: string;
+  blockNumber: number;
+  logIndex: number;
+  txHash?: string;
+};
 
 export function toBigIntSafe(value: any): bigint {
   if (value === null || value === undefined) {
@@ -94,6 +199,16 @@ export function getPositionIds(totalPositions: any): number[] {
   if (totalPositions === null || totalPositions === undefined) return [];
   const total = Number(toBigIntSafe(totalPositions));
   return Array.from({ length: total }, (_, index) => index + 1);
+}
+
+/**
+ * Builds the stable map key used to join v3 position event state across helpers.
+ *
+ * @param positionRef Escrow address and numeric v3 position id.
+ * @returns Lowercase escrow and position id joined into a unique key.
+ */
+export function getV3PositionKey({ escrow, positionId }: { escrow: string; positionId: number }): string {
+  return `${escrow.toLowerCase()}-${positionId}`;
 }
 
 export function mulDivCeil(a: bigint, b: bigint, denominator: bigint): bigint {
@@ -162,4 +277,230 @@ export async function getAccumulatedInterestAtBlock(options: FetchOptions, escro
   });
 
   return toBigIntOrNull(interest) ?? 0n;
+}
+
+function normalizeAddress(value?: string | null): string {
+  return value?.toLowerCase() ?? "";
+}
+
+function getLogTxHash(log: any): string | undefined {
+  return log?.transactionHash ?? log?.transaction_hash ?? log?.txHash;
+}
+
+function getLogIndex(log: any): number {
+  const value = log?.logIndex ?? log?.log_index ?? log?.index ?? 0;
+  return Number(value);
+}
+
+function normalizeV3PositionStruct(position: any): TristeroV3PositionStruct | null {
+  const underlyingAsset = position.underlyingAsset ?? position[0];
+  const loanAsset = position.loanAsset ?? position[1];
+  const notionalShares = toBigIntOrNull(position.notionalShares ?? position[2]);
+  const loanShares = toBigIntOrNull(position.loanShares ?? position[3]);
+  const rps = toBigIntOrNull(position.RPS ?? position.rps ?? position[4]);
+  const lastUpdate = toBigIntOrNull(position.lastUpdate ?? position[5]);
+
+  if (!underlyingAsset || !loanAsset || notionalShares === null || loanShares === null || rps === null || lastUpdate === null) {
+    return null;
+  }
+
+  return {
+    underlyingAsset: normalizeAddress(underlyingAsset),
+    loanAsset: normalizeAddress(loanAsset),
+    notionalShares,
+    loanShares,
+    rps,
+    lastUpdate,
+  };
+}
+
+function normalizeV3PositionOpenedLog(log: any, config: TristeroV3MarginEscrowConfig): TristeroV3MarginPosition | null {
+  const args = log?.args ?? log;
+  const positionId = args?.positionId ?? args?.[0];
+  const blockNumber = log?.blockNumber;
+  const position = normalizeV3PositionStruct(args?.position ?? args?.[3]);
+
+  if (positionId === null || positionId === undefined || !position || blockNumber === null || blockNumber === undefined) return null;
+
+  return {
+    escrow: config.address.toLowerCase(),
+    vault: config.vault.toLowerCase(),
+    positionId: toPositionId(positionId),
+    taker: normalizeAddress(args?.taker ?? args?.[1]),
+    filler: normalizeAddress(args?.filler ?? args?.[2]),
+    ...position,
+    openBlock: Number(blockNumber),
+  };
+}
+
+function normalizeV3PositionReducedLog(log: any): TristeroV3ReducedPositionLog | null {
+  const args = log?.args ?? log;
+  const positionId = args?.positionId ?? args?.[0];
+  const blockNumber = log?.blockNumber;
+  const position = normalizeV3PositionStruct(args?.position ?? args?.[4]);
+
+  if (positionId === null || positionId === undefined || !position || blockNumber === null || blockNumber === undefined) return null;
+
+  return {
+    positionId: toPositionId(positionId),
+    taker: normalizeAddress(args?.taker ?? args?.[1]),
+    position,
+    blockNumber: Number(blockNumber),
+    logIndex: getLogIndex(log),
+  };
+}
+
+function normalizeV3PositionClosedLog(log: any): TristeroV3ClosedPositionLog | null {
+  const args = log?.args ?? log;
+  const positionId = args?.positionId ?? args?.[0];
+  const blockNumber = log?.blockNumber;
+
+  if (positionId === null || positionId === undefined || blockNumber === null || blockNumber === undefined) return null;
+
+  return {
+    positionId: toPositionId(positionId),
+    filler: normalizeAddress(args?.filler ?? args?.[1]),
+    blockNumber: Number(blockNumber),
+    logIndex: getLogIndex(log),
+    txHash: getLogTxHash(log),
+  };
+}
+
+async function getV3EscrowStartBlock(chain: string, start: string): Promise<number> {
+  const timestamp = Math.floor(new Date(`${start}T00:00:00Z`).getTime() / 1000);
+  const block = await getBlock(timestamp, chain);
+  if (block === null || block === undefined) {
+    throw new Error(`Unable to resolve Tristero v3 margin escrow start block for ${chain} at ${start}`);
+  }
+
+  return Number(block);
+}
+
+/**
+ * Reconstructs v3 margin positions from PositionOpened and PositionClosed logs.
+ * PositionReduced logs mutate the remaining share state; PositionClosed is terminal.
+ *
+ * @param options DefiLlama fetch options for the current chain/window.
+ * @param configs Active v3 escrow/vault configs to scan.
+ * @param toBlock Last block to include when reconstructing position state.
+ * @returns V3 positions opened up to toBlock, annotated with close data when closed.
+ */
+export async function getTristeroV3MarginPositions(
+  options: FetchOptions,
+  configs: TristeroV3MarginEscrowConfig[],
+  toBlock: number,
+): Promise<TristeroV3MarginPosition[]> {
+  const positionsByKey = new Map<string, TristeroV3MarginPosition>();
+
+  for (const config of configs) {
+    const startBlock = await getV3EscrowStartBlock(options.chain, config.start);
+    if (startBlock > toBlock) continue;
+
+    const [openedLogs, reducedLogs, closedLogs] = await Promise.all([
+      options.getLogs({
+        target: config.address,
+        eventAbi: TRISTERO_V3_MARGIN_ABI.positionOpened,
+        fromBlock: startBlock,
+        toBlock,
+        entireLog: true,
+        parseLog: true,
+        cacheInCloud: true,
+      }),
+      options.getLogs({
+        target: config.address,
+        eventAbi: TRISTERO_V3_MARGIN_ABI.positionReduced,
+        fromBlock: startBlock,
+        toBlock,
+        entireLog: true,
+        parseLog: true,
+        cacheInCloud: true,
+      }),
+      options.getLogs({
+        target: config.address,
+        eventAbi: TRISTERO_V3_MARGIN_ABI.positionClosed,
+        fromBlock: startBlock,
+        toBlock,
+        entireLog: true,
+        parseLog: true,
+        cacheInCloud: true,
+      }),
+    ]);
+
+    (openedLogs as any[]).forEach((log) => {
+      const position = normalizeV3PositionOpenedLog(log, config);
+      if (!position) return;
+      positionsByKey.set(getV3PositionKey(position), position);
+    });
+
+    const positionStateLogs = [
+      ...(reducedLogs as any[]).flatMap((log) => {
+        const reducedLog = normalizeV3PositionReducedLog(log);
+        return reducedLog ? [{ type: 'reduced' as const, ...reducedLog }] : [];
+      }),
+      ...(closedLogs as any[]).flatMap((log) => {
+        const closedLog = normalizeV3PositionClosedLog(log);
+        return closedLog ? [{ type: 'closed' as const, ...closedLog }] : [];
+      }),
+    ].sort((a, b) => a.blockNumber - b.blockNumber || a.logIndex - b.logIndex);
+
+    positionStateLogs.forEach((log) => {
+      const key = getV3PositionKey({ escrow: config.address, positionId: log.positionId });
+      const position = positionsByKey.get(key);
+      if (!position) return;
+
+      if (log.type === 'reduced') {
+        position.taker = log.taker;
+        position.underlyingAsset = log.position.underlyingAsset;
+        position.loanAsset = log.position.loanAsset;
+        position.notionalShares = log.position.notionalShares;
+        position.loanShares = log.position.loanShares;
+        position.rps = log.position.rps;
+        position.lastUpdate = log.position.lastUpdate;
+        return;
+      }
+
+      position.closeBlock = log.blockNumber;
+      position.closeTxHash = log.txHash;
+      position.closeFiller = log.filler;
+    });
+  }
+
+  return Array.from(positionsByKey.values());
+}
+
+/**
+ * Reconstructs currently open v3 margin positions and verifies each NFT owner.
+ *
+ * @param options DefiLlama fetch options for the current chain/window.
+ * @param configs Active v3 escrow/vault configs to scan.
+ * @returns V3 positions that have not emitted PositionClosed by the end block.
+ */
+export async function getOpenTristeroV3MarginPositions(
+  options: FetchOptions,
+  configs: TristeroV3MarginEscrowConfig[],
+): Promise<TristeroV3MarginPosition[]> {
+  if (!configs.length) return [];
+
+  const toBlock = await options.getToBlock();
+  const positions = await getTristeroV3MarginPositions(options, configs, toBlock);
+  const candidates = positions.filter((position) => position.closeBlock === undefined || position.closeBlock > toBlock);
+  if (!candidates.length) return [];
+
+  const owners = await options.toApi.multiCall({
+    abi: TRISTERO_V3_MARGIN_ABI.ownerOf,
+    calls: candidates.map((position) => ({
+      target: position.escrow,
+      params: [position.positionId],
+    })),
+    permitFailure: true,
+  });
+
+  owners.forEach((owner, index) => {
+    if (!normalizeAddress(owner)) {
+      const position = candidates[index];
+      throw new Error(`Unable to read Tristero v3 ownerOf for ${options.chain} position ${position.positionId} at ${position.escrow}`);
+    }
+  });
+
+  return candidates;
 }

--- a/open-interest/tristero-margin.ts
+++ b/open-interest/tristero-margin.ts
@@ -1,45 +1,75 @@
 import { FetchOptions, FetchResultV2, SimpleAdapter } from "../adapters/types";
 import {
     getActiveTristeroMarginEscrows,
+    getActiveTristeroV3MarginEscrows,
+    getOpenTristeroV3MarginPositions,
     getPositionIds,
+    getTristeroMarginChainStart,
+    getTristeroMarginChains,
     normalizePosition,
+    toBigIntOrNull,
     TRISTERO_MARGIN_ABI,
-    TRISTERO_MARGIN_CONFIGS,
+    TRISTERO_V3_MARGIN_ABI,
 } from "../helpers/tristeroMargin";
 
 const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
     const openInterestAtEnd = options.createBalances();
     const escrows = getActiveTristeroMarginEscrows(options.chain, options.dateString);
+    const v3Escrows = getActiveTristeroV3MarginEscrows(options.chain, options.dateString);
 
-    if (!escrows.length) {
+    if (!escrows.length && !v3Escrows.length) {
         return { openInterestAtEnd };
     }
 
-    const totalPositionsPerEscrow = await options.toApi.multiCall({
-        abi: TRISTERO_MARGIN_ABI.totalPositions,
-        calls: escrows.map((escrow) => ({ target: escrow })),
-        permitFailure: true,
-    });
+    if (escrows.length) {
+        const totalPositionsPerEscrow = await options.toApi.multiCall({
+            abi: TRISTERO_MARGIN_ABI.totalPositions,
+            calls: escrows.map((escrow) => ({ target: escrow })),
+        });
 
-    const escrowToPositionIds = totalPositionsPerEscrow.map((totalPositions, index) => ({
-        escrow: escrows[index],
-        positionIds: getPositionIds(totalPositions),
-    }));
+        const escrowToPositionIds = totalPositionsPerEscrow.map((totalPositions, index) => ({
+            escrow: escrows[index],
+            positionIds: getPositionIds(totalPositions),
+        }));
 
-    const positions = await options.toApi.multiCall({
-        abi: TRISTERO_MARGIN_ABI.positions,
-        calls: escrowToPositionIds.flatMap(({ escrow, positionIds }) => positionIds.map((positionId) => ({
-            target: escrow,
-            params: [positionId],
-        }))),
-        permitFailure: true,
-    });
+        const positions = await options.toApi.multiCall({
+            abi: TRISTERO_MARGIN_ABI.positions,
+            calls: escrowToPositionIds.flatMap(({ escrow, positionIds }) => positionIds.map((positionId) => ({
+                target: escrow,
+                params: [positionId],
+            }))),
+        });
 
-    positions.forEach((position: any) => {
-        const normalized = normalizePosition(position);
-        if (!normalized || normalized.size === 0n) return;
-        openInterestAtEnd.add(normalized.token, normalized.size);
-    });
+        positions.forEach((position: any) => {
+            const normalized = normalizePosition(position);
+            if (!normalized || normalized.size === 0n) return;
+            openInterestAtEnd.add(normalized.token, normalized.size);
+        });
+    }
+
+    if (v3Escrows.length) {
+        const v3Positions = await getOpenTristeroV3MarginPositions(options, v3Escrows);
+        const notionals = v3Positions.length
+            ? await options.toApi.multiCall({
+                abi: TRISTERO_V3_MARGIN_ABI.readValue,
+                calls: v3Positions.map((position) => ({
+                    target: position.vault,
+                    params: [position.underlyingAsset, position.notionalShares.toString()],
+                })),
+                permitFailure: true,
+            })
+            : [];
+
+        v3Positions.forEach((position, index) => {
+            const notional = toBigIntOrNull(notionals[index]);
+            if (notional === null) {
+                throw new Error(`Unable to read Tristero v3 notional value for ${options.chain} position ${position.positionId} at ${position.escrow}`);
+            }
+
+            if (notional === 0n) return;
+            openInterestAtEnd.add(position.underlyingAsset, notional);
+        });
+    }
 
     return {
         openInterestAtEnd,
@@ -48,7 +78,12 @@ const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
 
 const adapter: SimpleAdapter = {
     version: 2,
-    adapter: TRISTERO_MARGIN_CONFIGS,
+    adapter: Object.fromEntries(
+        getTristeroMarginChains().map((chain) => [
+            chain,
+            { start: getTristeroMarginChainStart(chain) },
+        ])
+    ),
     fetch,
 };
 


### PR DESCRIPTION
## Summary
- fold Tristero v3 DEX volume into the existing `dexs/tristero` adapter instead of adding a separate adapter
- add v3 margin escrow/vault config and position reconstruction to the existing Tristero margin helper
- extend existing Tristero margin fees and open-interest adapters for v3 margin positions

## Details
- v3 spot volume counts decoded `router.send` transactions for TAKER and CROSS orders
- v3 margin volume counts MARGIN opens, including decoded loan quantity, and escrow close settlement transfers
- v3 margin open interest uses `PositionOpened`/`PositionClosed`, `ownerOf`, and `vault.readValue(underlying, notionalShares)`
- v3 margin fees track lender borrow interest from vault loan-value growth and close repayments

## Validation
- `node node_modules/typescript/bin/tsc --project tsconfig.json --pretty false`
- `node node_modules/.bin/ts-node --transpile-only cli/testAdapter.ts dexs tristero`
- `node node_modules/.bin/ts-node --transpile-only cli/testAdapter.ts fees tristero-margin`
- `node node_modules/.bin/ts-node --transpile-only cli/testAdapter.ts open-interest tristero-margin`