### PR TITLE
[feat] Moonshot: track volume  via dune

### DIFF
--- a/dexs/moonshot-money.ts
+++ b/dexs/moonshot-money.ts
@@ -19,37 +19,32 @@ const fetch = async (_a: any, _b: any, options: FetchOptions): Promise<FetchResu
   const { feeAddress } = chainConfig[options.chain];
 
   const rows = await (queryDuneSql(options, `
-    WITH moonshot_txs AS (
-      SELECT DISTINCT
-        tx_id
-      FROM
-        tokens_solana.transfers
-      WHERE
-        TIME_RANGE
-        AND to_owner = '${feeAddress}'
-        AND token_mint_address = '${ADDRESSES.solana.USDC}'
-
-      UNION
-
-      SELECT DISTINCT
-        id AS tx_id
-      FROM
-        solana.transactions
-        CROSS JOIN UNNEST(SEQUENCE(1, CARDINALITY(account_keys))) AS u(i)
-      WHERE
-        TIME_RANGE
-        AND success = true
-        AND account_keys[i] = '${feeAddress}'
-        AND post_balances[i] > pre_balances[i]
-    )
     SELECT
       COALESCE(SUM(amount_usd), 0) AS daily_volume
     FROM
-      dex_solana.trades
+      dex_solana.trades t
     WHERE
       TIME_RANGE
-      AND trader_id != '${feeAddress}'
-      AND tx_id IN (SELECT tx_id FROM moonshot_txs)
+      AND t.trader_id != '${feeAddress}'
+      AND (
+        EXISTS (
+          SELECT 1
+          FROM tokens_solana.transfers tr
+          WHERE TIME_RANGE
+            AND tr.tx_id = t.tx_id
+            AND tr.to_owner = '${feeAddress}'
+            AND tr.token_mint_address = '${ADDRESSES.solana.USDC}'
+        )
+        OR EXISTS (
+          SELECT 1
+          FROM solana.transactions tx
+          CROSS JOIN UNNEST(SEQUENCE(1, CARDINALITY(tx.account_keys))) AS u(i)
+          WHERE TIME_RANGE
+            AND tx.id = t.tx_id
+            AND tx.success = true
+            AND tx.account_keys[i] = '${feeAddress}'
+        )
+      )
   `) as any);
 
   return { dailyVolume: Number(rows[0].daily_volume) };

--- a/dexs/moonshot-money.ts
+++ b/dexs/moonshot-money.ts
@@ -1,0 +1,72 @@
+import { Dependencies, FetchOptions, FetchResult, SimpleAdapter } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+import ADDRESSES from "../helpers/coreAssets.json";
+import { queryDuneSql } from "../helpers/dune";
+
+const chainConfig: Record<string, { start: string; feeAddress: string }> = {
+  [CHAIN.SOLANA]: {
+    start: "2024-05-14",
+    feeAddress: "5wkyL2FLEcyUUgc3UeGntHTAfWfzDrVuxMnaMm7792Gk",
+  },
+};
+
+const fetch = async (_a: any, _b: any, options: FetchOptions): Promise<FetchResult> => {
+  const tenHoursAgo = Date.now() - (10 * 60 * 60 * 1000);
+  if ((options.toTimestamp * 1000) > tenHoursAgo) {
+    throw new Error("End timestamp is less than 10 hours ago, skipping due to dune indexing delay");
+  }
+
+  const { feeAddress } = chainConfig[options.chain];
+
+  const rows = await (queryDuneSql(options, `
+    WITH moonshot_txs AS (
+      SELECT DISTINCT
+        tx_id
+      FROM
+        tokens_solana.transfers
+      WHERE
+        TIME_RANGE
+        AND to_owner = '${feeAddress}'
+        AND token_mint_address = '${ADDRESSES.solana.USDC}'
+
+      UNION
+
+      SELECT DISTINCT
+        id AS tx_id
+      FROM
+        solana.transactions
+        CROSS JOIN UNNEST(SEQUENCE(1, CARDINALITY(account_keys))) AS u(i)
+      WHERE
+        TIME_RANGE
+        AND success = true
+        AND account_keys[i] = '${feeAddress}'
+        AND post_balances[i] > pre_balances[i]
+    )
+    SELECT
+      COALESCE(SUM(amount_usd), 0) AS daily_volume
+    FROM
+      dex_solana.trades
+    WHERE
+      TIME_RANGE
+      AND trader_id != '${feeAddress}'
+      AND tx_id IN (SELECT tx_id FROM moonshot_txs)
+  `) as any);
+
+  return { dailyVolume: Number(rows[0].daily_volume) };
+};
+
+const methodology = {
+  Volume: "Total USD swap volume traded through Moonshot.money.",
+};
+
+const adapter: SimpleAdapter = {
+  version: 1,
+  fetch,
+  adapter: chainConfig,
+  dependencies: [Dependencies.DUNE],
+  isExpensiveAdapter: true,
+  methodology,
+  doublecounted: true,
+};
+
+export default adapter;


### PR DESCRIPTION
https://defillama.com/protocol/moonshot.money

## Summary
- Adds a Moonshot Money DEX volume adapter for Solana.
- Tracks routed swap volume from Moonshot fee-paying transactions using Dune Solana tables.

## Changes
- Added `dexs/moonshot-money.ts` with a Dune-backed `version: 1` adapter.
- Uses the Moonshot fee wallet to identify transactions from USDC fee transfers and SOL balance-increase fee payments.
- Aggregates matching `dex_solana.trades.amount_usd` as `dailyVolume`.
- Marks the adapter as `doublecounted: true` because volume is routed through underlying Solana DEX venues.

## Methodology
- Identifies Moonshot transactions from:
  - `tokens_solana.transfers` where USDC is sent to the Moonshot fee wallet.
  - `solana.transactions` where the Moonshot fee wallet receives native SOL.
- Sums USD trade volume from `dex_solana.trades` for those transaction IDs.
- Excludes trades where the Moonshot fee wallet is the trader.
- Uses the adapter start date `2024-05-14`.

## Tests
- `DUNE_API_KEYS=<redacted> pnpm test dexs moonshot.money 2026-04-05`
  - `SOLANA Daily volume: 1.65 M`