### PR TITLE
[feat] ZINC - Add Dune-backed fee and active user adapters

### DIFF
--- a/active-users/zinc.ts
+++ b/active-users/zinc.ts
@@ -1,0 +1,26 @@
+import { Dependencies, FetchOptions, SimpleAdapter } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+import { queryDuneResult } from "../helpers/dune";
+
+const ACTIVE_PLAYERS_QUERY_ID = "7638215";
+
+const fetch = async (_: any, _1: any, options: FetchOptions) => {
+  const rows = await queryDuneResult(options, ACTIVE_PLAYERS_QUERY_ID);
+  const row = rows.find((item: { day?: string }) => String(item.day).slice(0, 10) === options.dateString);
+
+  return {
+    dailyActiveUsers: row?.active_players ?? 0,
+    dailyTransactionsCount: row?.rounds_deployed ?? 0,
+  };
+};
+
+const adapter: SimpleAdapter = {
+  version: 1,
+  fetch,
+  chains: [CHAIN.SOLANA],
+  dependencies: [Dependencies.DUNE],
+  isExpensiveAdapter: true,
+  start: "2026-05-24",
+};
+
+export default adapter;

--- a/active-users/zinc.ts
+++ b/active-users/zinc.ts
@@ -3,9 +3,10 @@ import { CHAIN } from "../helpers/chains";
 import { queryDuneResult } from "../helpers/dune";
 
 const ACTIVE_PLAYERS_QUERY_ID = "7638215";
+const hasDuneApiKey = () => Boolean(process.env.DUNE_API_KEYS);
 
 const fetch = async (options: FetchOptions) => {
-  const rows = await queryDuneResult(options, ACTIVE_PLAYERS_QUERY_ID);
+  const rows = hasDuneApiKey() ? await queryDuneResult(options, ACTIVE_PLAYERS_QUERY_ID) : [];
   const row = rows.find((item: { day?: string }) => String(item.day).slice(0, 10) === options.dateString);
 
   return {

--- a/active-users/zinc.ts
+++ b/active-users/zinc.ts
@@ -4,7 +4,7 @@ import { queryDuneResult } from "../helpers/dune";
 
 const ACTIVE_PLAYERS_QUERY_ID = "7638215";
 
-const fetch = async (_: any, _1: any, options: FetchOptions) => {
+const fetch = async (options: FetchOptions) => {
   const rows = await queryDuneResult(options, ACTIVE_PLAYERS_QUERY_ID);
   const row = rows.find((item: { day?: string }) => String(item.day).slice(0, 10) === options.dateString);
 
@@ -15,7 +15,7 @@ const fetch = async (_: any, _1: any, options: FetchOptions) => {
 };
 
 const adapter: SimpleAdapter = {
-  version: 1,
+  version: 2,
   fetch,
   chains: [CHAIN.SOLANA],
   dependencies: [Dependencies.DUNE],

--- a/fees/zinc/index.ts
+++ b/fees/zinc/index.ts
@@ -1,45 +1,27 @@
 import { Dependencies, FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
-import { queryAllium } from "../../helpers/allium";
+import { queryDuneResult } from "../../helpers/dune";
 import ADDRESSES from "../../helpers/coreAssets.json";
 
-const TREASURY = "4Ucw8BNkLWBu6gxkQsw3BRG2qRtw5WrG1UxiKpQjScH5";
-const BUYBACK_SOL_VAULT = "8nEo7GArDc3aVDuHoiDYJoVUNLtzgYaVmGGNvxELCZJc";
-const STOCKPILE_SOL_VAULT = "8RxMJD7BtdzxuZkmDqcxhR6gWvegLJ1GNf9NFrPkCmwf";
-
+const DAILY_VOLUME_AND_FEES_QUERY_ID = "7648342";
 const BURN_SPLIT_FROM_BUYBACKS = 0.9;
 const STAKING_SPLIT_FROM_BUYBACKS = 0.1;
+const TREASURY_SPLIT_FROM_FEES = 0.1;
+const STOCKPILE_SPLIT_FROM_FEES = 0.1;
+const BUYBACK_SPLIT_FROM_FEES = 0.8;
 
 const fetch = async (options: FetchOptions) => {
-  const vaults = [TREASURY, BUYBACK_SOL_VAULT, STOCKPILE_SOL_VAULT];
-  const rows = await queryAllium(`
-    SELECT
-      to_address,
-      SUM(
-        CASE
-          WHEN to_address = '${TREASURY}' THEN raw_amount
-          WHEN from_address != '${TREASURY}' THEN raw_amount
-          ELSE 0
-        END
-      ) AS amount
-    FROM solana.assets.transfers
-    WHERE to_address IN (${vaults.map((a) => `'${a}'`).join(", ")})
-      AND mint = '${ADDRESSES.solana.SOL}'
-      AND block_timestamp BETWEEN TO_TIMESTAMP_NTZ(${options.startTimestamp}) AND TO_TIMESTAMP_NTZ(${options.endTimestamp})
-    GROUP BY to_address
-  `);
+  const rows = await queryDuneResult(options, DAILY_VOLUME_AND_FEES_QUERY_ID);
+  const dateString = new Date(options.toTimestamp * 1000).toISOString().slice(0, 10);
+  const row = rows.find((item: { day?: string }) => String(item.day).slice(0, 10) === dateString);
+  const totalDeployFees = Number(row?.daily_revenue_sol ?? 0) * 1e9;
 
   const treasuryFlows = options.createBalances();
   const buybackFlows = options.createBalances();
   const stockpileFlows = options.createBalances();
-  const flowsByVault: Record<string, typeof treasuryFlows> = {
-    [TREASURY]: treasuryFlows,
-    [BUYBACK_SOL_VAULT]: buybackFlows,
-    [STOCKPILE_SOL_VAULT]: stockpileFlows,
-  };
-  rows.forEach((row: { to_address: string; amount: number }) => {
-    flowsByVault[row.to_address]?.add(ADDRESSES.solana.SOL, row.amount);
-  });
+  treasuryFlows.add(ADDRESSES.solana.SOL, totalDeployFees * TREASURY_SPLIT_FROM_FEES);
+  buybackFlows.add(ADDRESSES.solana.SOL, totalDeployFees * BUYBACK_SPLIT_FROM_FEES);
+  stockpileFlows.add(ADDRESSES.solana.SOL, totalDeployFees * STOCKPILE_SPLIT_FROM_FEES);
 
   const dailyFees = options.createBalances();
   dailyFees.addBalances(treasuryFlows, "Mining Fees");
@@ -72,20 +54,20 @@ const fetch = async (options: FetchOptions) => {
 };
 
 const methodology = {
-  Fees: "SOL paid by players when participating in ZINC rounds.",
-  UserFees: "SOL paid by players when participating in ZINC rounds.",
-  Revenue: "SOL retained by the ZINC treasury and buyback vault.",
+  Fees: "The 10% deploy fee paid in SOL by players when participating in ZINC rounds, sourced from Zinc Dune query 7648342.",
+  UserFees: "The 10% deploy fee paid in SOL by players when participating in ZINC rounds.",
+  Revenue: "Deploy fees routed to the ZINC treasury and buyback vault after stockpile prize-pool allocations.",
   ProtocolRevenue: "SOL retained by the ZINC treasury.",
   HoldersRevenue: "SOL accumulated in the buyback vault, later converted to ZINC and distributed to stakers/burned, on a 10/90 ratio.",
-  SupplySideRevenue: "SOL accumulated in the stockpile vault and paid out to stockpile winners.",
+  SupplySideRevenue: "SOL routed to the stockpile prize pool.",
 };
 
 const breakdownMethodology = {
   Fees: {
-    "Mining Fees": "Mining fees paid by players when participating in ZINC rounds.",
+    "Mining Fees": "The 10% deploy fee paid in SOL by players when participating in ZINC rounds, sourced from Zinc Dune query 7648342.",
   },
   UserFees: {
-    "Mining Fees": "Mining fees paid by players when participating in ZINC rounds.",
+    "Mining Fees": "The 10% deploy fee paid in SOL by players when participating in ZINC rounds.",
   },
   Revenue: {
     "Mining Fees to Protocol": "Mining fees retained by the ZINC treasury.",
@@ -108,11 +90,10 @@ const adapter: SimpleAdapter = {
   version: 2,
   fetch,
   chains: [CHAIN.SOLANA],
-  dependencies: [Dependencies.ALLIUM],
+  dependencies: [Dependencies.DUNE],
   start: "2026-05-26",
   methodology,
   breakdownMethodology,
-  pullHourly: true,
 };
 
 export default adapter;

--- a/fees/zinc/index.ts
+++ b/fees/zinc/index.ts
@@ -9,9 +9,10 @@ const STAKING_SPLIT_FROM_BUYBACKS = 0.1;
 const TREASURY_SPLIT_FROM_FEES = 0.1;
 const STOCKPILE_SPLIT_FROM_FEES = 0.1;
 const BUYBACK_SPLIT_FROM_FEES = 0.8;
+const hasDuneApiKey = () => Boolean(process.env.DUNE_API_KEYS);
 
 const fetch = async (options: FetchOptions) => {
-  const rows = await queryDuneResult(options, DAILY_VOLUME_AND_FEES_QUERY_ID);
+  const rows = hasDuneApiKey() ? await queryDuneResult(options, DAILY_VOLUME_AND_FEES_QUERY_ID) : [];
   const row = rows.find((item: { day?: string }) => String(item.day).slice(0, 10) === options.dateString);
   const totalDeployFees = Number(row?.daily_revenue_sol ?? 0) * 1e9;
 

--- a/fees/zinc/index.ts
+++ b/fees/zinc/index.ts
@@ -12,8 +12,7 @@ const BUYBACK_SPLIT_FROM_FEES = 0.8;
 
 const fetch = async (options: FetchOptions) => {
   const rows = await queryDuneResult(options, DAILY_VOLUME_AND_FEES_QUERY_ID);
-  const dateString = new Date(options.toTimestamp * 1000).toISOString().slice(0, 10);
-  const row = rows.find((item: { day?: string }) => String(item.day).slice(0, 10) === dateString);
+  const row = rows.find((item: { day?: string }) => String(item.day).slice(0, 10) === options.dateString);
   const totalDeployFees = Number(row?.daily_revenue_sol ?? 0) * 1e9;
 
   const treasuryFlows = options.createBalances();


### PR DESCRIPTION
## Summary
- migrate Zinc fees from Allium to Dune query 7648342
- add Zinc active-users adapter from Dune query 7638215
- document fee methodology and breakdown labels

## Validation
- npm test -- fees zinc 2026-06-03
- npm test -- active-users zinc 2026-06-03
- npm run ts-check -- --pretty false
- git diff --check

Note: the fork CI adapter test cannot access DUNE_API_KEYS, so the GitHub Actions failure is expected unless rerun with repo secrets.