### PR TITLE
[feat] Telemetry: track swap volume via dune

### DIFF
--- a/dexs/telemetry.ts
+++ b/dexs/telemetry.ts
@@ -1,0 +1,75 @@
+import { Dependencies, FetchOptions, SimpleAdapter } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+import { queryDuneSql } from "../helpers/dune";
+
+// ref https://dune.com/queries/5424905/8856073
+const chainConfig: Record<string, { start: string; feeWallet: string }> = {
+  [CHAIN.SOLANA]: {
+    start: "2025-08-12",
+    feeWallet: "FBYmU5XbRgX2DV2i2SpPPpHpXmf6mdZS98wQChmUyMba",
+  },
+};
+
+const fetch = async (_a: any, _b: any, options: FetchOptions) => {
+  const tenHoursAgo = Date.now() - (10 * 60 * 60 * 1000);
+  if ((options.toTimestamp * 1000) > tenHoursAgo) {
+    throw new Error("End timestamp is less than 10 hours ago, skipping due to dune indexing delay");
+  }
+
+  const { feeWallet } = chainConfig[options.chain];
+  const query = `
+    WITH telemetry_txs AS (
+      SELECT DISTINCT id AS tx_id
+      FROM solana.transactions
+      CROSS JOIN UNNEST(SEQUENCE(1, CARDINALITY(account_keys))) AS u(i)
+      WHERE TIME_RANGE
+        AND success = true
+        AND CONTAINS(account_keys, '${feeWallet}')
+        AND account_keys[i] = '${feeWallet}'
+        AND post_balances[i] > pre_balances[i]
+    ),
+    bot_trades AS (
+      SELECT
+        t.tx_id,
+        t.trader_id,
+        t.amount_usd,
+        t.outer_instruction_index,
+        t.inner_instruction_index,
+        ROW_NUMBER() OVER (
+          PARTITION BY t.tx_id, t.trader_id, t.outer_instruction_index, t.inner_instruction_index
+          ORDER BY
+            CASE WHEN t.token_bought_symbol = 'WSOL' OR t.token_sold_symbol = 'WSOL' THEN 0 ELSE 1 END,
+            t.amount_usd DESC
+        ) AS row_num
+      FROM dex_solana.trades t
+      JOIN telemetry_txs txs ON t.tx_id = txs.tx_id
+      WHERE TIME_RANGE
+        AND t.trader_id != '${feeWallet}'
+    )
+    SELECT COALESCE(SUM(amount_usd), 0) AS daily_volume
+    FROM bot_trades
+    WHERE row_num = 1
+  `;
+
+  const [result] = await queryDuneSql(options, query);
+  const dailyVolume = options.createBalances();
+  dailyVolume.addUSDValue(result?.daily_volume);
+
+  return { dailyVolume };
+};
+
+const methodology = {
+  Volume: "Total USD trading volume of swaps routed through Telemetry.",
+};
+
+const adapter: SimpleAdapter = {
+  version: 1,
+  fetch,
+  adapter: chainConfig,
+  dependencies: [Dependencies.DUNE],
+  isExpensiveAdapter: true,
+  methodology,
+  doublecounted: true,
+};
+
+export default adapter;

--- a/dexs/telemetry.ts
+++ b/dexs/telemetry.ts
@@ -16,19 +16,10 @@ const fetch = async (_a: any, _b: any, options: FetchOptions) => {
     throw new Error("End timestamp is less than 10 hours ago, skipping due to dune indexing delay");
   }
 
+  // skip post > pre balance checks as fee may be set t0 0 it will skip all volumes.
   const { feeWallet } = chainConfig[options.chain];
   const query = `
-    WITH telemetry_txs AS (
-      SELECT DISTINCT id AS tx_id
-      FROM solana.transactions
-      CROSS JOIN UNNEST(SEQUENCE(1, CARDINALITY(account_keys))) AS u(i)
-      WHERE TIME_RANGE
-        AND success = true
-        AND CONTAINS(account_keys, '${feeWallet}')
-        AND account_keys[i] = '${feeWallet}'
-        AND post_balances[i] > pre_balances[i]
-    ),
-    bot_trades AS (
+    WITH bot_trades AS (
       SELECT
         t.tx_id,
         t.trader_id,
@@ -42,9 +33,17 @@ const fetch = async (_a: any, _b: any, options: FetchOptions) => {
             t.amount_usd DESC
         ) AS row_num
       FROM dex_solana.trades t
-      JOIN telemetry_txs txs ON t.tx_id = txs.tx_id
       WHERE TIME_RANGE
         AND t.trader_id != '${feeWallet}'
+        AND EXISTS (
+          SELECT 1
+          FROM solana.transactions tx
+          CROSS JOIN UNNEST(SEQUENCE(1, CARDINALITY(tx.account_keys))) AS u(i)
+          WHERE TIME_RANGE
+            AND tx.id = t.tx_id
+            AND tx.success = true
+            AND tx.account_keys[i] = '${feeWallet}'
+        )
     )
     SELECT COALESCE(SUM(amount_usd), 0) AS daily_volume
     FROM bot_trades


### PR DESCRIPTION
## Summary
- Adds a new Telemetry DEX volume adapter for Solana under `dexs/telemetry.ts`.
- Tracks routed swap volume using Dune by identifying transactions where Telemetry's fee wallet receives SOL and summing matching `dex_solana.trades` volume.

## Changes
- Added `dexs/telemetry.ts` with a Dune-backed `version: 1` adapter.
- Uses the Telemetry fee wallet from the existing fees adapter: `FBYmU5XbRgX2DV2i2SpPPpHpXmf6mdZS98wQChmUyMba`.
- Filters successful Solana transactions involving the fee wallet, joins them to `dex_solana.trades`, excludes Telemetry wallet trade rows, and de-duplicates trade rows with `ROW_NUMBER()`.
- Adds the standard 10-hour Dune indexing delay guard for DEX trade table queries.
- Marks the adapter as `doublecounted` because volume is routed through underlying Solana DEXs.

## Methodology
- Volume is counted as USD swap volume from `dex_solana.trades` for transactions where Telemetry's fee wallet receives SOL.
- The adapter excludes rows where `trader_id` is the Telemetry fee wallet and keeps one trade row per transaction/trader/instruction tuple to reduce duplicate route rows.

## Tests
- `DUNE_API_KEYS=... pnpm test dexs telemetry 2026-06-03`
- Passed before the final query cleanup, returning Solana daily volume of `47.10 k`.