### PR TITLE
fees/azuro: add Arbitrum and Linea fee coverage + mark Gnosis as dead

### DIFF
--- a/fees/azuro/index.ts
+++ b/fees/azuro/index.ts
@@ -24,6 +24,13 @@ const prefetch = async (options: FetchOptions) => {
           usd_ggr
       FROM dune.azuro.result_v_3_stacked_resolved_bets
       WHERE bet_status != 'accepted'
+      UNION ALL
+      SELECT
+          call_block_time AS resolve_time,
+          'linea' AS chain,
+          (CAST(finalReserve AS DOUBLE) - CAST(lockedReserve AS DOUBLE)) / 1e6 AS usd_ggr
+      FROM azuro_linea.lpv2_call_addreserve
+      WHERE call_success = true
     ),
     normalized AS (
       SELECT
@@ -88,9 +95,18 @@ const adapter: Adapter = {
     },
     [CHAIN.XDAI]: {
       start: '2022-01-01',
+      deadFrom: '2025-12-01',
     },
     [CHAIN.BASE]: {
       start: '2024-02-01',
+    },
+    [CHAIN.ARBITRUM]: {
+      start: '2023-06-01',
+      deadFrom: '2023-12-23',
+    },
+    [CHAIN.LINEA]: {
+      start: '2023-08-01',
+      deadFrom: '2024-03-30',
     },
     [CHAIN.CHILIZ]: {
       start: '2024-07-09',


### PR DESCRIPTION
Update to the existing **Azuro** fees adapter