### PR TITLE
Consolidate Ramses metrics

### DIFF
--- a/dexs/ramses-hl-cl.ts
+++ b/dexs/ramses-hl-cl.ts
@@ -371,33 +371,33 @@ export function createPoolFetchHandler(poolType: PoolType) {
 const fetch = createPoolFetchHandler('cl');
 
 export const methodology = {
-  Fees: "Swap fees paid by traders and external vote incentives paid by protocols.",
-  Revenue: "Swap fees directed to the protocol treasury plus swap fees and vote incentives distributed to veRAM voters.",
+  Fees: "Swap fees paid by traders and incentives paid by protocols.",
+  Revenue: "Protocol swap fees plus fees and incentives distributed to veRAM voters.",
   UserFees: "Swap fees paid by traders.",
-  ProtocolRevenue: "Share of swap fees directed to the protocol treasury.",
-  HoldersRevenue: "Swap fees and external vote incentives distributed through Ramses fee distributors to veRAM voters for the pools they vote on.",
-  SupplySideRevenue: "Share of swap fees retained by liquidity providers.",
+  ProtocolRevenue: "Protocol share of swap fees.",
+  HoldersRevenue: "Swap fees and incentives distributed to veRAM voters.",
+  SupplySideRevenue: "Swap fees retained by liquidity providers.",
 };
 
 export const breakdownMethodology = {
   Fees: {
     [METRIC.SWAP_FEES]: "Swap fees paid by traders.",
-    ["Bribes"]: "External vote incentives paid by protocols.",
+    ["Bribes"]: "Incentives paid by protocols.",
   },
   Revenue: {
-    ["Swap Fees to protocol"]: "Share of swap fees directed to the protocol treasury.",
-    ["Swap Fees to holders"]: "Swap fees distributed through fee distributors to veRAM voters for the corresponding pool.",
-    ["Bribes to holders"]: "External vote incentives distributed through fee distributors to veRAM voters for the corresponding pool.",
+    ["Swap Fees to protocol"]: "Protocol share of swap fees.",
+    ["Swap Fees to holders"]: "Swap fees distributed to veRAM voters for the corresponding pool.",
+    ["Bribes to holders"]: "Incentives distributed to veRAM voters for the corresponding pool.",
   },
   ProtocolRevenue: {
-    ["Swap Fees to protocol"]: "Share of swap fees directed to the protocol treasury.",
+    ["Swap Fees to protocol"]: "Protocol share of swap fees.",
   },
   SupplySideRevenue: {
-    ["Swap Fees to LPs"]: "Share of swap fees retained by liquidity providers.",
+    ["Swap Fees to LPs"]: "Swap fees retained by liquidity providers.",
   },
   HoldersRevenue: {
-    ["Swap Fees to holders"]: "Swap fees distributed through fee distributors to veRAM voters for the corresponding pool.",
-    ["Bribes to holders"]: "External vote incentives distributed through fee distributors to veRAM voters for the corresponding pool.",
+    ["Swap Fees to holders"]: "Swap fees distributed to veRAM voters for the corresponding pool.",
+    ["Bribes to holders"]: "Incentives distributed to veRAM voters for the corresponding pool.",
   },
 };
 

--- a/dexs/ramses-hl-cl.ts
+++ b/dexs/ramses-hl-cl.ts
@@ -1,7 +1,8 @@
-import { FetchOptions, SimpleAdapter } from "../adapters/types";
+import { BaseAdapter, FetchOptions, SimpleAdapter } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
 import request, { gql } from "graphql-request";
 import { METRIC } from "../helpers/metrics";
+import { getAdapter } from "../factory/uniV2";
 
 const RAM_TOKEN_CONTRACT = "0x555570a286F15EbDFE42B66eDE2f724Aa1AB5555";
 const XRAM_TOKEN_CONTRACT = "	0xAE6D5FcE541216BDA471D311425B5412D9f1DEb9";
@@ -13,6 +14,8 @@ export const subgraphEndpoints: any = {
 };
 
 const subgraphQueryLimit = 1000;
+const clArbitrumCutover = Date.UTC(2026, 0, 13) / 1000;
+const legacyArbitrumCutover = Date.UTC(2026, 0, 28) / 1000;
 
 interface IGraphRes {
   clVolumeUSD: number;
@@ -40,6 +43,18 @@ interface IVoteBribe {
 interface IToken {
   id: string;
   priceUSD: string;
+}
+
+interface IPoolHourData {
+  startOfHour: string;
+  volumeUSD: string;
+  feesUSD: string;
+  voterFeesUSD: string;
+  treasuryFeesUSD: string;
+}
+
+interface IPoolWithHourData {
+  poolHourData: IPoolHourData[];
 }
 
 async function paginate<T>(
@@ -92,7 +107,7 @@ async function getBribes(options: FetchOptions) {
       to: options.startOfDay + 24 * 60 * 60,
       first,
       skip,
-    }).then((data) => data.voteBribes);
+    }).then((data: any) => data.voteBribes);
 
   return paginate<IVoteBribe>(getData, subgraphQueryLimit);
 }
@@ -125,7 +140,7 @@ async function getTokens(options: FetchOptions, tokens: string[]) {
       first,
       skip,
       startOfDay: options.startOfDay,
-    }).then((data) =>
+    }).then((data: any) =>
       // Transform tokenDayDatas to match expected token format
       data.tokenDayDatas.map((td: any) => ({
         id: td.token.id,
@@ -137,7 +152,7 @@ async function getTokens(options: FetchOptions, tokens: string[]) {
 }
 
 export async function fetchStats(options: FetchOptions): Promise<IGraphRes> {
-  const protocolDayStats = await fetchProtocolDayStats(options);
+  const protocolDayStats = await fetchRecentProtocolStats(options) ?? await fetchProtocolDayStats(options);
 
   const voteBribes = await getBribes(options);
   const tokenIds = new Set(voteBribes.map((e) => e.token.id));
@@ -209,7 +224,83 @@ export async function fetchProtocolDayStats(
   };
 }
 
-type PoolType = 'cl' | 'legacy';
+function emptyPoolStats() {
+  return {
+    volumeUSD: 0,
+    feesUSD: 0,
+    userFeesRevenueUSD: 0,
+    protocolRevenueUSD: 0,
+  };
+}
+
+function addPoolHours(stats: ReturnType<typeof emptyPoolStats>, poolHourData: IPoolHourData[], fromTimestamp: number, toTimestamp: number) {
+  poolHourData
+    .filter((hour) => Number(hour.startOfHour) >= fromTimestamp && Number(hour.startOfHour) < toTimestamp)
+    .forEach((hour) => {
+      stats.volumeUSD += Number(hour.volumeUSD ?? 0);
+      stats.feesUSD += Number(hour.feesUSD ?? 0);
+      stats.userFeesRevenueUSD += Number(hour.voterFeesUSD ?? 0);
+      stats.protocolRevenueUSD += Number(hour.treasuryFeesUSD ?? 0);
+    });
+}
+
+async function fetchPoolHourStats(options: FetchOptions, poolType: PoolType) {
+  const poolField = poolType === 'cl' ? 'clPools' : 'legacyPools';
+  const query = gql`
+    query poolHourStats($first: Int!, $skip: Int!) {
+      ${poolField}(first: $first, skip: $skip) {
+        poolHourData(first: 48, orderBy: startOfHour, orderDirection: desc) {
+          startOfHour
+          volumeUSD
+          feesUSD
+          voterFeesUSD
+          treasuryFeesUSD
+        }
+      }
+    }
+  `;
+
+  const pools = await paginate<IPoolWithHourData>(
+    async (first, skip) => request<any>(subgraphEndpoints[options.chain], query, { first, skip }).then((data: any) => data[poolField]),
+    subgraphQueryLimit,
+  );
+
+  const stats = emptyPoolStats();
+  pools.forEach((pool) => addPoolHours(stats, pool.poolHourData ?? [], options.fromTimestamp, options.toTimestamp));
+
+  return stats;
+}
+
+async function fetchRecentProtocolStats(options: FetchOptions): Promise<IProtocolDayStats | null> {
+  if (options.toTimestamp < Math.floor(Date.now() / 1000) - 48 * 60 * 60) return null;
+
+  const [clStats, legacyStats] = await Promise.all([
+    fetchPoolHourStats(options, 'cl'),
+    fetchPoolHourStats(options, 'legacy'),
+  ]);
+
+  const totalVolume = clStats.volumeUSD + legacyStats.volumeUSD;
+  const totalFees = clStats.feesUSD + legacyStats.feesUSD;
+  if (totalVolume === 0 && totalFees === 0) return null;
+
+  return {
+    clVolumeUSD: clStats.volumeUSD,
+    clFeesUSD: clStats.feesUSD,
+    legacyVolumeUSD: legacyStats.volumeUSD,
+    legacyFeesUSD: legacyStats.feesUSD,
+    clUserFeesRevenueUSD: clStats.userFeesRevenueUSD,
+    legacyUserFeesRevenueUSD: legacyStats.userFeesRevenueUSD,
+    clProtocolRevenueUSD: clStats.protocolRevenueUSD,
+    legacyProtocolRevenueUSD: legacyStats.protocolRevenueUSD,
+  };
+}
+
+export type PoolType = 'cl' | 'legacy';
+
+type ChainConfig = {
+  chain: string;
+  start: string;
+};
 
 interface PoolStats {
   volumeUSD: number;
@@ -238,7 +329,7 @@ function getPoolStats(stats: IGraphRes, poolType: PoolType): PoolStats {
   };
 }
 
-function createFetchHandler(poolType: PoolType) {
+export function createPoolFetchHandler(poolType: PoolType) {
   return async (_: any, _1: any, options: FetchOptions) => {
     const stats = await fetchStats(options);
     const poolStats = getPoolStats(stats, poolType);
@@ -277,36 +368,36 @@ function createFetchHandler(poolType: PoolType) {
   };
 }
 
-const fetch = createFetchHandler('cl');
+const fetch = createPoolFetchHandler('cl');
 
 export const methodology = {
-  Fees: "Includes swap fees and bribes paid by protocols",
-  Revenue: "Revenue going to the protocol + Token holder Revenue.",
-  UserFees: "User pays fees on each swap.",
-  ProtocolRevenue: "Swap fees going to the protocol",
-  HoldersRevenue: "Swap fees distributed to holders and all the bribes go to holders",
-  SupplySideRevenue: "Swap fees distributed to LPs (from gauged pools).",
+  Fees: "Swap fees paid by traders and external vote incentives paid by protocols.",
+  Revenue: "Swap fees directed to the protocol treasury plus swap fees and vote incentives distributed to veRAM voters.",
+  UserFees: "Swap fees paid by traders.",
+  ProtocolRevenue: "Share of swap fees directed to the protocol treasury.",
+  HoldersRevenue: "Swap fees and external vote incentives distributed through Ramses fee distributors to veRAM voters for the pools they vote on.",
+  SupplySideRevenue: "Share of swap fees retained by liquidity providers.",
 };
 
 export const breakdownMethodology = {
   Fees: {
-    [METRIC.SWAP_FEES]: "Fees are collected from users on each swap.",
-    ["Bribes"]: "Bribes paid by protocols",
+    [METRIC.SWAP_FEES]: "Swap fees paid by traders.",
+    ["Bribes"]: "External vote incentives paid by protocols.",
   },
   Revenue: {
-    ["Swap Fees to protocol"]: "Revenue going to the protocol.",
-    ["Swap Fees to holders"]: "User fees are distributed among holders.",
-    ["Bribes to holders"]: "Bribes paid by protocols to holders",
+    ["Swap Fees to protocol"]: "Share of swap fees directed to the protocol treasury.",
+    ["Swap Fees to holders"]: "Swap fees distributed through fee distributors to veRAM voters for the corresponding pool.",
+    ["Bribes to holders"]: "External vote incentives distributed through fee distributors to veRAM voters for the corresponding pool.",
   },
   ProtocolRevenue: {
-    ["Swap Fees to protocol"]: "Revenue going to the protocol.",
+    ["Swap Fees to protocol"]: "Share of swap fees directed to the protocol treasury.",
   },
   SupplySideRevenue: {
-    ["Swap Fees to LPs"]: "Fees distributed to LPs (from gauged pools).",
+    ["Swap Fees to LPs"]: "Share of swap fees retained by liquidity providers.",
   },
   HoldersRevenue: {
-    ["Swap Fees to holders"]: "User fees are distributed among holders.",
-    ["Bribes to holders"]: "Bribes paid by protocols to holders",
+    ["Swap Fees to holders"]: "Swap fees distributed through fee distributors to veRAM voters for the corresponding pool.",
+    ["Bribes to holders"]: "External vote incentives distributed through fee distributors to veRAM voters for the corresponding pool.",
   },
 };
 
@@ -320,7 +411,7 @@ export function createClAdapter(chain: string, start: string): SimpleAdapter {
   };
 }
 
-const legacyFetch = createFetchHandler('legacy');
+const legacyFetch = createPoolFetchHandler('legacy');
 
 export function createLegacyAdapter(chain: string, start: string): SimpleAdapter {
   return {
@@ -332,6 +423,72 @@ export function createLegacyAdapter(chain: string, start: string): SimpleAdapter
   };
 }
 
-const adapter: SimpleAdapter = createClAdapter(CHAIN.HYPERLIQUID, '2025-11-08');
+export function createPoolAdapter(poolType: PoolType, chainConfigs: ChainConfig[]): SimpleAdapter {
+  const fetch = createPoolFetchHandler(poolType);
+
+  return {
+    version: 1,
+    adapter: chainConfigs.reduce((adapter, { chain, start }) => {
+      adapter[chain] = { fetch, start };
+      return adapter;
+    }, {} as BaseAdapter),
+    methodology,
+    breakdownMethodology,
+  };
+}
+
+function createConsolidatedPoolAdapter(
+  poolType: PoolType,
+  oldArbitrumFetch: any,
+  arbitrumStart: number,
+  arbitrumCutover: number,
+): SimpleAdapter {
+  const currentFetch = createPoolFetchHandler(poolType);
+  const fetchCurrent = (timestamp: any, chainBlocks: any, options: FetchOptions) => currentFetch(timestamp, chainBlocks, options);
+
+  return {
+    version: 1,
+    skipBreakdownValidation: true,
+    methodology,
+    breakdownMethodology,
+    adapter: {
+      [CHAIN.ARBITRUM]: {
+        fetch: async (timestamp: any, chainBlocks: any, options: FetchOptions) => {
+          if (options.startOfDay < arbitrumCutover) return oldArbitrumFetch(options as any, {} as any, options);
+          return fetchCurrent(timestamp, chainBlocks, options);
+        },
+        start: arbitrumStart,
+      },
+      [CHAIN.HYPERLIQUID]: {
+        fetch: fetchCurrent,
+        start: '2025-11-08',
+      },
+      [CHAIN.POLYGON]: {
+        fetch: fetchCurrent,
+        start: '2026-01-28',
+      },
+    },
+  };
+}
+
+export function createConsolidatedClAdapter(): SimpleAdapter {
+  return createConsolidatedPoolAdapter(
+    'cl',
+    getAdapter("ramses-exchange-v2")!.fetch!,
+    1685574000,
+    clArbitrumCutover,
+  );
+}
+
+export function createConsolidatedLegacyAdapter(): SimpleAdapter {
+  return createConsolidatedPoolAdapter(
+    'legacy',
+    getAdapter("ramses-exchange")!.adapter![CHAIN.ARBITRUM].fetch!,
+    1678838400,
+    legacyArbitrumCutover,
+  );
+}
+
+const adapter: SimpleAdapter = createConsolidatedClAdapter();
 
 export default adapter;

--- a/dexs/ramses-hl-cl.ts
+++ b/dexs/ramses-hl-cl.ts
@@ -1,11 +1,10 @@
-import { BaseAdapter, FetchOptions, SimpleAdapter } from "../adapters/types";
+import { FetchOptions, SimpleAdapter } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
 import request, { gql } from "graphql-request";
 import { METRIC } from "../helpers/metrics";
 import { getAdapter } from "../factory/uniV2";
 
 const RAM_TOKEN_CONTRACT = "0x555570a286F15EbDFE42B66eDE2f724Aa1AB5555";
-const XRAM_TOKEN_CONTRACT = "	0xAE6D5FcE541216BDA471D311425B5412D9f1DEb9";
 
 export const subgraphEndpoints: any = {
   [CHAIN.ARBITRUM]: "https://arbitrumv2.kingdomsubgraph.com/subgraphs/name/ramses-pruned",
@@ -297,11 +296,6 @@ async function fetchRecentProtocolStats(options: FetchOptions): Promise<IProtoco
 
 export type PoolType = 'cl' | 'legacy';
 
-type ChainConfig = {
-  chain: string;
-  start: string;
-};
-
 interface PoolStats {
   volumeUSD: number;
   feesUSD: number;
@@ -337,11 +331,13 @@ export function createPoolFetchHandler(poolType: PoolType) {
     const dailyVolume = poolStats.volumeUSD;
 
     const dailyFees = options.createBalances();
+    const dailyUserFees = options.createBalances();
     const dailyHoldersRevenue = options.createBalances();
     const dailyProtocolRevenue = options.createBalances();
     const dailySupplySideRevenue = options.createBalances();
 
     dailyFees.addUSDValue(poolStats.feesUSD, METRIC.SWAP_FEES);
+    dailyUserFees.addUSDValue(poolStats.feesUSD, METRIC.SWAP_FEES);
     dailyHoldersRevenue.addUSDValue(poolStats.userFeesRevenueUSD, 'Swap Fees to holders');
     dailyProtocolRevenue.addUSDValue(poolStats.protocolRevenueUSD, 'Swap Fees to protocol');
 
@@ -359,7 +355,7 @@ export function createPoolFetchHandler(poolType: PoolType) {
     return {
       dailyVolume,
       dailyFees,
-      dailyUserFees: dailyFees,
+      dailyUserFees,
       dailyHoldersRevenue,
       dailyProtocolRevenue,
       dailyRevenue,
@@ -418,20 +414,6 @@ export function createLegacyAdapter(chain: string, start: string): SimpleAdapter
     fetch: legacyFetch,
     chains: [chain],
     start,
-    methodology,
-    breakdownMethodology,
-  };
-}
-
-export function createPoolAdapter(poolType: PoolType, chainConfigs: ChainConfig[]): SimpleAdapter {
-  const fetch = createPoolFetchHandler(poolType);
-
-  return {
-    version: 1,
-    adapter: chainConfigs.reduce((adapter, { chain, start }) => {
-      adapter[chain] = { fetch, start };
-      return adapter;
-    }, {} as BaseAdapter),
     methodology,
     breakdownMethodology,
   };

--- a/dexs/ramses-hl-legacy.ts
+++ b/dexs/ramses-hl-legacy.ts
@@ -1,4 +1,3 @@
-import { CHAIN } from "../helpers/chains";
-import { createLegacyAdapter } from "./ramses-hl-cl";
+import { createConsolidatedLegacyAdapter } from "./ramses-hl-cl";
 
-export default createLegacyAdapter(CHAIN.HYPERLIQUID, '2025-11-08');
+export default createConsolidatedLegacyAdapter();

--- a/fees/ramses-exchange-v1/index.ts
+++ b/fees/ramses-exchange-v1/index.ts
@@ -47,9 +47,8 @@ const adapter: Adapter = {
 
         const v1Results: any = await feeAdapter!(options as any, {}, options)
         const bribesResult = await getBribes(options);
-        v1Results.dailyBribesRevenue = bribesResult.dailyBribesRevenue;
-
         const dailyFees = options.createBalances();
+        const dailyUserFees = options.createBalances();
         const dailyProtocolRevenue = options.createBalances();
         const dailySupplySideRevenue = options.createBalances();
         const dailyHoldersRevenue = options.createBalances();
@@ -58,6 +57,7 @@ const adapter: Adapter = {
         const swapFees = Number(await v1Results.dailyFees.getUSDValue());
 
         dailyFees.addUSDValue(swapFees, METRIC.SWAP_FEES);
+        dailyUserFees.addUSDValue(swapFees, METRIC.SWAP_FEES);
         dailyFees.addUSDValue(bribeRevenue, 'Bribes');
 
         dailyHoldersRevenue.addUSDValue(swapFees * 0.75, 'Swap Fees to holders');
@@ -72,7 +72,7 @@ const adapter: Adapter = {
         return {
           dailyVolume: v1Results.dailyVolume,
           dailyFees,
-          dailyUserFees: dailyFees,
+          dailyUserFees,
           dailyRevenue,
           dailyProtocolRevenue,
           dailySupplySideRevenue,

--- a/fees/ramses-exchange-v1/index.ts
+++ b/fees/ramses-exchange-v1/index.ts
@@ -3,6 +3,7 @@ import { CHAIN } from "../../helpers/chains";
 import { uniV2Exports } from "../../helpers/uniswap";
 import { fees_bribes } from './bribes';
 import { METRIC } from "../../helpers/metrics";
+import { breakdownMethodology, createPoolFetchHandler, methodology } from "../../dexs/ramses-hl-cl";
 
 
 const FACTORY_ADDRESS = '0xaaa20d08e59f6561f242b08513d36266c5a29415';
@@ -13,6 +14,9 @@ type TStartTime = {
 const startTimeV2: TStartTime = {
   [CHAIN.ARBITRUM]: 1678838400,
 }
+const arbitrumCutover = Date.UTC(2026, 0, 28) / 1000;
+const currentFetch = createPoolFetchHandler('legacy');
+const fetchCurrent = (options: FetchOptions) => currentFetch(undefined, undefined, options);
 
 const getBribes = async ({ fromTimestamp, toTimestamp, createBalances, getFromBlock, }: FetchOptions): Promise<any> => {
   const fromBlock = await getFromBlock()
@@ -27,36 +31,6 @@ const getBribes = async ({ fromTimestamp, toTimestamp, createBalances, getFromBl
   };
 };
 
-const methodology = {
-  UserFees: "User pays 0.05%, 0.30%, or 1% on each swap.",
-  ProtocolRevenue: "Revenue going to the protocol. 5% of collected fees. (is probably right because the distribution is dynamic.)",
-  HoldersRevenue: "User fees are distributed among holders. 75% of collected fees. (is probably right because the distribution is dynamic.)",
-  SupplySideRevenue: "20% of collected fees are distributed among LPs. (is probably right because the distribution is dynamic.)"
-}
-
-const breakdownMethodology = {
-  Fees: {
-    [METRIC.SWAP_FEES]: "Swap fees paid by users",
-    ['Bribes']: "Bribes paid by protocols"
-  },
-  Revenue: {
-    ['Swap Fees to protocol']: "5% of swap fees go to the protocol treasury",
-    ['Swap Fees to holders']: "75% of swap fees go to the holders",
-    ['Bribes to holders']: "All the bribes go to the holders",
-  },
-  ProtocolRevenue: {
-    ['Swap Fees to protocol']: "5% of swap fees go to the protocol treasury",
-  },
-  SupplySideRevenue: {
-    ['Swap Fees to LPs']: "20% of swap fees go to the LPs",
-  },
-  HoldersRevenue: {
-    ['Swap Fees to holders']: "75% of swap fees go to the holders",
-    ['Bribes to holders']: "All the bribes go to the holders",
-  },
-}
-
-
 const feeAdapter = uniV2Exports({
   [CHAIN.ARBITRUM]: { factory: FACTORY_ADDRESS, },
 }).adapter![CHAIN.ARBITRUM].fetch
@@ -69,6 +43,8 @@ const adapter: Adapter = {
   adapter: {
     [CHAIN.ARBITRUM]: {
       fetch: async (options: FetchOptions) => {
+        if (options.startOfDay >= arbitrumCutover) return fetchCurrent(options);
+
         const v1Results: any = await feeAdapter!(options as any, {}, options)
         const bribesResult = await getBribes(options);
         v1Results.dailyBribesRevenue = bribesResult.dailyBribesRevenue;
@@ -104,6 +80,14 @@ const adapter: Adapter = {
         };
       },
       start: startTimeV2[CHAIN.ARBITRUM],
+    },
+    [CHAIN.HYPERLIQUID]: {
+      fetch: fetchCurrent,
+      start: '2025-11-08',
+    },
+    [CHAIN.POLYGON]: {
+      fetch: fetchCurrent,
+      start: '2026-01-28',
     },
   },
 };

--- a/fees/ramses-exchange-v2/index.ts
+++ b/fees/ramses-exchange-v2/index.ts
@@ -7,6 +7,7 @@ import {
   getGraphDimensions2,
 } from "../../helpers/getUniSubgraph"
 import { METRIC } from "../../helpers/metrics";
+import { breakdownMethodology, createPoolFetchHandler, methodology } from "../../dexs/ramses-hl-cl";
 
 type TStartTime = {
   [key: string]: number;
@@ -14,6 +15,9 @@ type TStartTime = {
 const startTimeV2: TStartTime = {
   [CHAIN.ARBITRUM]: 1685574000,
 }
+const arbitrumCutover = Date.UTC(2026, 0, 13) / 1000;
+const currentFetch = createPoolFetchHandler('cl');
+const fetchCurrent = (options: FetchOptions) => currentFetch(undefined, undefined, options);
 
 const getBribes = async ({ fromTimestamp, toTimestamp, createBalances, getFromBlock, }: FetchOptions): Promise<any> => {
   const fromBlock = await getFromBlock()
@@ -47,36 +51,6 @@ const v2Graphs = getGraphDimensions2({
     Revenue: 80 // Revenue is 100% of collected fees
   }
 });
-// https://docs.ramses.exchange/ramses-cl-v2/concentrated-liquidity/fee-distribution
-const methodology = {
-  UserFees: "User pays 0.05%, 0.30%, or 1% on each swap.",
-  ProtocolRevenue: "Revenue going to the protocol. 5% of collected fees. (is probably right because the distribution is dynamic.)",
-  HoldersRevenue: "User fees are distributed among holders. 75% of collected fees. (is probably right because the distribution is dynamic.)",
-  SupplySideRevenue: "20% of collected fees are distributed among LPs. (is probably right because the distribution is dynamic.)"
-}
-
-const breakdownMethodology = {
-  Fees: {
-    [METRIC.SWAP_FEES]: "Swap fees paid by users",
-    ['Bribes']: "Bribes paid by protocols"
-  },
-  Revenue: {
-    ['Swap Fees to protocol']: "5% of swap fees go to the protocol treasury",
-    ['Swap Fees to holders']: "75% of swap fees go to the holders",
-    ['Bribes to holders']: "All the bribes go to the holders",
-  },
-  ProtocolRevenue: {
-    ['Swap Fees to protocol']: "5% of swap fees go to the protocol treasury",
-  },
-  SupplySideRevenue: {
-    ['Swap Fees to LPs']: "20% of swap fees go to the LPs",
-  },
-  HoldersRevenue: {
-    ['Swap Fees to holders']: "75% of swap fees go to the holders",
-    ['Bribes to holders']: "All the bribes go to the holders",
-  },
-}
-
 const adapter: Adapter = {
   version: 2,
   methodology,
@@ -84,6 +58,8 @@ const adapter: Adapter = {
   adapter: {
     [CHAIN.ARBITRUM]: {
       fetch: async (options: FetchOptions) => {
+        if (options.startOfDay >= arbitrumCutover) return fetchCurrent(options);
+
         const v2Result = await v2Graphs(options)
         const bribesResult = await getBribes(options);
         v2Result.dailyBribesRevenue = bribesResult.dailyBribesRevenue;
@@ -118,6 +94,14 @@ const adapter: Adapter = {
         };
       },
       start: startTimeV2[CHAIN.ARBITRUM],
+    },
+    [CHAIN.HYPERLIQUID]: {
+      fetch: fetchCurrent,
+      start: '2025-11-08',
+    },
+    [CHAIN.POLYGON]: {
+      fetch: fetchCurrent,
+      start: '2026-01-28',
     },
   },
 };

--- a/fees/ramses-exchange-v2/index.ts
+++ b/fees/ramses-exchange-v2/index.ts
@@ -47,8 +47,8 @@ const v2Graphs = getGraphDimensions2({
     HoldersRevenue: 72,
     ProtocolRevenue: 8,
     SupplySideRevenue: 20,
-    UserFees: 100, // User fees are 100% of collected fees
-    Revenue: 80 // Revenue is 100% of collected fees
+    UserFees: 100,
+    Revenue: 80,
   }
 });
 const adapter: Adapter = {
@@ -62,9 +62,8 @@ const adapter: Adapter = {
 
         const v2Result = await v2Graphs(options)
         const bribesResult = await getBribes(options);
-        v2Result.dailyBribesRevenue = bribesResult.dailyBribesRevenue;
-
         const dailyFees = options.createBalances();
+        const dailyUserFees = options.createBalances();
         const dailyProtocolRevenue = options.createBalances();
         const dailySupplySideRevenue = options.createBalances();
         const dailyHoldersRevenue = options.createBalances();
@@ -72,6 +71,7 @@ const adapter: Adapter = {
         const bribeRevenue = Number(await bribesResult.dailyBribesRevenue.getUSDValue());
 
         dailyFees.addUSDValue(v2Result.dailyFees, METRIC.SWAP_FEES);
+        dailyUserFees.addUSDValue(v2Result.dailyFees, METRIC.SWAP_FEES);
         dailyFees.addUSDValue(bribeRevenue, 'Bribes');
 
         dailyHoldersRevenue.addUSDValue(Number(v2Result.dailyHoldersRevenue), 'Swap Fees to holders');
@@ -86,7 +86,7 @@ const adapter: Adapter = {
         return {
           dailyVolume: v2Result.dailyVolume,
           dailyFees,
-          dailyUserFees: dailyFees,
+          dailyUserFees,
           dailyRevenue,
           dailyProtocolRevenue,
           dailySupplySideRevenue,


### PR DESCRIPTION
Reason/details:

Consolidates Ramses CL and Ramses Legacy fee/volume adapters while keeping the existing historical keys. Current Ramses stats now use public Kingdom subgraph pool-hour data for fresher rolling windows, with daily protocol rows retained for historical backfill.

Goals:
- clean up Ramses metric routing into CL and Legacy
- improve current stats cadence beyond daily rows
- preserve historical adapter continuity

Verification:
- npm run ts-check
- npm run ts-check-cli
- git diff --check
- Ramses CL/Legacy fees and DEX adapter probes
- sampled parity against Ramses /stats daily rows

Companion PRs:
- defillama-server: https://github.com/DefiLlama/defillama-server/pull/12189
- DefiLlama-Adapters: https://github.com/DefiLlama/DefiLlama-Adapters/pull/19575
- Proposed DefiLlama-Adapters: https://github.com/DefiLlama/DefiLlama-Adapters/pull/19597