### PR TITLE
feat(fees): add Mycelia Signal adapter

### DIFF
--- a/fees/mycelia-signal.ts
+++ b/fees/mycelia-signal.ts
@@ -1,11 +1,7 @@
 import { FetchOptions, SimpleAdapter } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
-
-// USDC on Base (Mycelia settles in USDC only)
-const USDC_BASE = '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913';
-
-// Standard ERC-20 Transfer event topic
-const TRANSFER_TOPIC = '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef';
+import { addTokensReceived } from "../helpers/token";
+import coreAssets from "../helpers/coreAssets.json"
 
 // Mycelia's two revenue wallets:
 //  1. Direct settlement — full gross USDC from the TypeScript x402 proxy
@@ -22,39 +18,29 @@ const RECEIVERS: Record<string, { address: string; label: string }> = {
   },
 };
 
-// Pad a 20-byte address into a 32-byte topic value
-const padTopic = (addr: string) =>
-  '0x' + addr.toLowerCase().slice(2).padStart(64, '0');
-
-// Extract raw 20-byte address from a 32-byte topic value
-const topicToAddress = (topic: string) =>
-  '0x' + topic.slice(-40).toLowerCase();
-
 // Mycelia-controlled wallets — used to exclude internal transfers
 // (self-sends and cross-wallet transfers) from fee aggregation
 const INTERNAL_ADDRESSES = new Set(
   Object.values(RECEIVERS).map(r => r.address.toLowerCase())
 );
 
+const isExternalTransfer = (log: any) => {
+  const sender = log.from.toLowerCase();
+  return !INTERNAL_ADDRESSES.has(sender);
+};
+
 const fetch = async (options: FetchOptions) => {
   const dailyFees = options.createBalances();
 
   for (const receiver of Object.values(RECEIVERS)) {
-    const logs = await options.getLogs({
-      target: USDC_BASE,
-      topics: [TRANSFER_TOPIC, null, padTopic(receiver.address)] as any,
+    const received = await addTokensReceived({
+      options,
+      token: coreAssets.base.USDC,
+      target: receiver.address,
+      logFilter: isExternalTransfer,
     });
 
-    for (const log of logs) {
-      // Exclude internal transfers between Mycelia-controlled wallets
-      // (self-sends or cross-wallet rebalancing) to prevent overstating fees
-      const sender = topicToAddress(log.topics[1] as string);
-      if (INTERNAL_ADDRESSES.has(sender)) continue;
-
-      // ERC-20 Transfer 'value' lives in the data field as a 32-byte uint
-      const amount = BigInt(log.data);
-      dailyFees.add(USDC_BASE, amount, receiver.label);
-    }
+    dailyFees.addBalances(received, receiver.label);
   }
 
   // No supply-side or holder splits — protocol keeps 100% of fees.
@@ -75,6 +61,10 @@ const methodology = {
 
 const breakdownMethodology = {
   Fees: {
+    'Direct settlement': 'USDC received via the Mycelia-operated TypeScript x402 proxy (myceliasignal-x402-proxy.service), settling directly to 0xD593832Ce9C2B13B192ba50B55dd9AF44e96700d. Represents full gross fees for direct path traffic.',
+    'Orbis marketplace payouts (80% net)': 'USDC received from the Orbis x402 marketplace facilitator at the configured payout address 0xfF51E0339A17f5fcBa6eAf0E06518d0042ac84bf. Represents 80% of customer payments routed through Orbis (the remaining 20% is retained by Orbis as a facilitator fee). Payouts are batched weekly.',
+  },
+  Revenue: {
     'Direct settlement': 'USDC received via the Mycelia-operated TypeScript x402 proxy (myceliasignal-x402-proxy.service), settling directly to 0xD593832Ce9C2B13B192ba50B55dd9AF44e96700d. Represents full gross fees for direct path traffic.',
     'Orbis marketplace payouts (80% net)': 'USDC received from the Orbis x402 marketplace facilitator at the configured payout address 0xfF51E0339A17f5fcBa6eAf0E06518d0042ac84bf. Represents 80% of customer payments routed through Orbis (the remaining 20% is retained by Orbis as a facilitator fee). Payouts are batched weekly.',
   },

--- a/fees/mycelia-signal.ts
+++ b/fees/mycelia-signal.ts
@@ -7,15 +7,18 @@ const USDC_BASE = '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913';
 // Standard ERC-20 Transfer event topic
 const TRANSFER_TOPIC = '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef';
 
-// Mycelia's two settlement wallets. Both are actively receiving payments.
+// Mycelia's two revenue wallets:
+//  1. Direct settlement — full gross USDC from the TypeScript x402 proxy
+//  2. Orbis marketplace payouts — 80% net of Orbis-mediated revenue (Orbis
+//     facilitator retains 20%); paid weekly to the configured payout address.
 const RECEIVERS: Record<string, { address: string; label: string }> = {
   direct: {
     address: '0xD593832Ce9C2B13B192ba50B55dd9AF44e96700d',
     label: 'Direct settlement',
   },
-  legacy: {
-    address: '0x2bB72231Eed303Cc91a462a1fa738B42B6a9aC6D',
-    label: 'Legacy SDK settlement',
+  orbis_payouts: {
+    address: '0xfF51E0339A17f5fcBa6eAf0E06518d0042ac84bf',
+    label: 'Orbis marketplace payouts (80% net)',
   },
 };
 
@@ -64,7 +67,7 @@ const fetch = async (options: FetchOptions) => {
 };
 
 const methodology = {
-  Fees: "USDC payments received via the x402 protocol for Mycelia oracle endpoint calls. Each Mycelia API request requires a per-call USDC payment on Base. The adapter tracks USDC Transfer events on Base to both settlement wallets and sums the values, excluding transfers where the sender is one of the two Mycelia-controlled wallets (self-sends and cross-wallet internal transfers).",
+  Fees: "USDC payments received for Mycelia oracle API calls. Each Mycelia API request requires a per-call USDC payment on Base. The adapter tracks USDC Transfer events on Base to two protocol-controlled wallets: (1) the direct settlement wallet for payments via the Mycelia-operated x402 proxy (full gross), and (2) the Orbis marketplace payout wallet, which receives weekly payouts representing 80% of revenue from Orbis-mediated traffic (Orbis retains 20% as a facilitator fee). Transfers where the sender is one of the two Mycelia-controlled wallets are excluded (self-sends and cross-wallet internal transfers).",
   Revenue: "100% of fees accrue to the protocol treasury. There is no supply-side, LP, integrator, or token-holder revenue split.",
   ProtocolRevenue: "Same as Revenue — all USDC payments accumulate in the protocol-operated receiver wallets.",
   UserFees: "Same as Fees — every payment is made directly by an end user (human or autonomous agent) per API call.",
@@ -72,8 +75,8 @@ const methodology = {
 
 const breakdownMethodology = {
   Fees: {
-    'Direct settlement': 'USDC received via the current TypeScript x402 proxy (myceliasignal-x402-proxy.service), settling to 0xD593832Ce9C2B13B192ba50B55dd9AF44e96700d.',
-    'Legacy SDK settlement': 'USDC received via the original Python SDK proxy path (myceliasignal-x402-sdk.service), settling to 0x2bB72231Eed303Cc91a462a1fa738B42B6a9aC6D. Still actively receiving payments from existing SDK integrations.',
+    'Direct settlement': 'USDC received via the Mycelia-operated TypeScript x402 proxy (myceliasignal-x402-proxy.service), settling directly to 0xD593832Ce9C2B13B192ba50B55dd9AF44e96700d. Represents full gross fees for direct path traffic.',
+    'Orbis marketplace payouts (80% net)': 'USDC received from the Orbis x402 marketplace facilitator at the configured payout address 0xfF51E0339A17f5fcBa6eAf0E06518d0042ac84bf. Represents 80% of customer payments routed through Orbis (the remaining 20% is retained by Orbis as a facilitator fee). Payouts are batched weekly.',
   },
 };
 

--- a/fees/mycelia-signal.ts
+++ b/fees/mycelia-signal.ts
@@ -29,7 +29,7 @@ const fetch = async (options: FetchOptions) => {
   for (const receiver of Object.values(RECEIVERS)) {
     const logs = await options.getLogs({
       target: USDC_BASE,
-      topics: [TRANSFER_TOPIC, null, padTopic(receiver.address)],
+      topics: [TRANSFER_TOPIC, null, padTopic(receiver.address)] as any,
     });
 
     for (const log of logs) {
@@ -70,7 +70,6 @@ const adapter: SimpleAdapter = {
     [CHAIN.BASE]: {
       fetch,
       start: '2026-04-12',
-      pullHourly: true,
     },
   },
 };

--- a/fees/mycelia-signal.ts
+++ b/fees/mycelia-signal.ts
@@ -23,6 +23,16 @@ const RECEIVERS: Record<string, { address: string; label: string }> = {
 const padTopic = (addr: string) =>
   '0x' + addr.toLowerCase().slice(2).padStart(64, '0');
 
+// Extract raw 20-byte address from a 32-byte topic value
+const topicToAddress = (topic: string) =>
+  '0x' + topic.slice(-40).toLowerCase();
+
+// Mycelia-controlled wallets — used to exclude internal transfers
+// (self-sends and cross-wallet transfers) from fee aggregation
+const INTERNAL_ADDRESSES = new Set(
+  Object.values(RECEIVERS).map(r => r.address.toLowerCase())
+);
+
 const fetch = async (options: FetchOptions) => {
   const dailyFees = options.createBalances();
 
@@ -33,6 +43,11 @@ const fetch = async (options: FetchOptions) => {
     });
 
     for (const log of logs) {
+      // Exclude internal transfers between Mycelia-controlled wallets
+      // (self-sends or cross-wallet rebalancing) to prevent overstating fees
+      const sender = topicToAddress(log.topics[1] as string);
+      if (INTERNAL_ADDRESSES.has(sender)) continue;
+
       // ERC-20 Transfer 'value' lives in the data field as a 32-byte uint
       const amount = BigInt(log.data);
       dailyFees.add(USDC_BASE, amount, receiver.label);
@@ -49,7 +64,7 @@ const fetch = async (options: FetchOptions) => {
 };
 
 const methodology = {
-  Fees: "USDC payments received via the x402 protocol for Mycelia oracle endpoint calls. Each Mycelia API request requires a per-call USDC payment on Base. The adapter tracks USDC Transfer events on Base to both settlement wallets and sums the values.",
+  Fees: "USDC payments received via the x402 protocol for Mycelia oracle endpoint calls. Each Mycelia API request requires a per-call USDC payment on Base. The adapter tracks USDC Transfer events on Base to both settlement wallets and sums the values, excluding transfers where the sender is one of the two Mycelia-controlled wallets (self-sends and cross-wallet internal transfers).",
   Revenue: "100% of fees accrue to the protocol treasury. There is no supply-side, LP, integrator, or token-holder revenue split.",
   ProtocolRevenue: "Same as Revenue — all USDC payments accumulate in the protocol-operated receiver wallets.",
   UserFees: "Same as Fees — every payment is made directly by an end user (human or autonomous agent) per API call.",

--- a/fees/mycelia-signal.ts
+++ b/fees/mycelia-signal.ts
@@ -1,0 +1,78 @@
+import { FetchOptions, SimpleAdapter } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+
+// USDC on Base (Mycelia settles in USDC only)
+const USDC_BASE = '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913';
+
+// Standard ERC-20 Transfer event topic
+const TRANSFER_TOPIC = '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef';
+
+// Mycelia's two settlement wallets. Both are actively receiving payments.
+const RECEIVERS: Record<string, { address: string; label: string }> = {
+  direct: {
+    address: '0xD593832Ce9C2B13B192ba50B55dd9AF44e96700d',
+    label: 'Direct settlement',
+  },
+  legacy: {
+    address: '0x2bB72231Eed303Cc91a462a1fa738B42B6a9aC6D',
+    label: 'Legacy SDK settlement',
+  },
+};
+
+// Pad a 20-byte address into a 32-byte topic value
+const padTopic = (addr: string) =>
+  '0x' + addr.toLowerCase().slice(2).padStart(64, '0');
+
+const fetch = async (options: FetchOptions) => {
+  const dailyFees = options.createBalances();
+
+  for (const receiver of Object.values(RECEIVERS)) {
+    const logs = await options.getLogs({
+      target: USDC_BASE,
+      topics: [TRANSFER_TOPIC, null, padTopic(receiver.address)],
+    });
+
+    for (const log of logs) {
+      // ERC-20 Transfer 'value' lives in the data field as a 32-byte uint
+      const amount = BigInt(log.data);
+      dailyFees.add(USDC_BASE, amount, receiver.label);
+    }
+  }
+
+  // No supply-side or holder splits — protocol keeps 100% of fees.
+  return {
+    dailyFees,
+    dailyRevenue: dailyFees,
+    dailyProtocolRevenue: dailyFees,
+    dailyUserFees: dailyFees,
+  };
+};
+
+const methodology = {
+  Fees: "USDC payments received via the x402 protocol for Mycelia oracle endpoint calls. Each Mycelia API request requires a per-call USDC payment on Base. The adapter tracks USDC Transfer events on Base to both settlement wallets and sums the values.",
+  Revenue: "100% of fees accrue to the protocol treasury. There is no supply-side, LP, integrator, or token-holder revenue split.",
+  ProtocolRevenue: "Same as Revenue — all USDC payments accumulate in the protocol-operated receiver wallets.",
+  UserFees: "Same as Fees — every payment is made directly by an end user (human or autonomous agent) per API call.",
+};
+
+const breakdownMethodology = {
+  Fees: {
+    'Direct settlement': 'USDC received via the current TypeScript x402 proxy (myceliasignal-x402-proxy.service), settling to 0xD593832Ce9C2B13B192ba50B55dd9AF44e96700d.',
+    'Legacy SDK settlement': 'USDC received via the original Python SDK proxy path (myceliasignal-x402-sdk.service), settling to 0x2bB72231Eed303Cc91a462a1fa738B42B6a9aC6D. Still actively receiving payments from existing SDK integrations.',
+  },
+};
+
+const adapter: SimpleAdapter = {
+  methodology,
+  breakdownMethodology,
+  version: 2,
+  adapter: {
+    [CHAIN.BASE]: {
+      fetch,
+      start: '2026-04-12',
+      pullHourly: true,
+    },
+  },
+};
+
+export default adapter;

--- a/fees/mycelia-signal.ts
+++ b/fees/mycelia-signal.ts
@@ -81,6 +81,7 @@ const adapter: SimpleAdapter = {
   methodology,
   breakdownMethodology,
   version: 2,
+  pullHourly: true,
   adapter: {
     [CHAIN.BASE]: {
       fetch,


### PR DESCRIPTION
This PR adds a fees adapter for Mycelia Signal, following @FelixBruguera's guidance on the closed listing PR (https://github.com/DefiLlama/defillama-server/pull/11710): the protocol has on-chain settlement on Base, so a fees adapter is the right path to surface revenue/fees metrics.

The adapter reads ERC-20 Transfer events on Base to two protocol-operated receiver wallets and sums daily fees. Tested locally across four dates with results consistent with on-chain ledger data:

| Date | Daily Fees |
|---|---:|
| 2026-04-14 | $0.47 (early ramp) |
| 2026-05-14 | $24.00 |
| 2026-06-03 | $33.00 |
| 2026-06-04 | $41.00 |

---

##### Name (to be shown on DefiLlama):
Mycelia Signal

##### Twitter Link:
https://twitter.com/jbulkeley

##### List of audit links if any:
None

##### Website Link:
https://myceliasignal.com

##### Logo (High resolution, will be shown with rounded borders):
https://myceliasignal.com/logo.png

##### Current TVL:
N/A — Mycelia is a pay-per-call oracle service. There is no TVL. The protocol earns fees via per-request USDC payments on Base.

##### Treasury Addresses:
- `0xD593832Ce9C2B13B192ba50B55dd9AF44e96700d` (direct settlement, current TS proxy path)
- `0x2bB72231Eed303Cc91a462a1fa738B42B6a9aC6D` (legacy SDK settlement, still active)

##### Chain:
Base

##### Coingecko ID:
(none — no token)

##### Coinmarketcap ID:
(none — no token)

##### Short Description (to be shown on DefiLlama):
Sovereign HTTP oracle serving Ed25519-signed market data via x402 (USDC on Base, pay-per-call). 131 endpoints covering crypto prices, FX, commodities, US/EU macro indicators, volatility surfaces, and structured products. No API keys, no token, no subscriptions — every response is independently verifiable against a published public key.

##### Token address and ticker if any:
None — Mycelia has no token.

##### Category:
Oracle

##### Oracle Provider(s):
N/A — Mycelia IS the oracle (no upstream oracle dependency).

##### Implementation Details:
N/A — Mycelia is the data source, not a consumer of external oracles.

##### Documentation/Proof:
- Docs: https://myceliasignal.com/docs
- OpenAPI spec: https://myceliasignal.com/openapi.json
- Verification & test vectors: https://myceliasignal.com/docs/verification

##### forkedFrom:
None — original project.

##### methodology:
The adapter reads ERC-20 Transfer events on Base for USDC payments to the two protocol-operated receiver wallets and sums them as daily fees. 100% of fees accrue to the protocol treasury (no supply-side, LP, integrator, or holder revenue split), so `dailyFees` = `dailyRevenue` = `dailyProtocolRevenue` = `dailyUserFees`. Two breakdown labels distinguish the two active settlement paths:

- **Direct settlement** — current TypeScript x402 proxy (`myceliasignal-x402-proxy.service`)
- **Legacy SDK settlement** — original Python SDK proxy (`myceliasignal-x402-sdk.service`), still receiving payments from existing SDK integrations

Notes:
- The adapter reports gross on-chain USDC inflows. A non-trivial fraction of gross transfers on low-fee chains is wash/relay traffic; if DefiLlama would prefer adapter-level wash filtering rather than platform-level, I'm happy to add a self-payment filter (`topic[1] == topic[2]`) or implement a more involved heuristic.
- The legacy SDK wallet is still active despite being non-default — existing SDK integrations continue to settle to it (~11× more clean transactions than the direct wallet over the observation window).

##### Github org/user:
jonathanbulkeley

##### Does this project have a referral program?
No.