### PR TITLE
aerodrome: readable pre-launch cutoff dates and Ignition docs

### DIFF
--- a/dexs/aerodrome/utils.ts
+++ b/dexs/aerodrome/utils.ts
@@ -1,41 +1,73 @@
 import * as sdk from '@defillama/sdk';
 
+// ---------------------------------------------------------------------------
+// Aero Ignition pre-launch token pricing
+// ---------------------------------------------------------------------------
+// Aerodrome's "Ignition" launchpad lets a project deposit bribes/incentives
+// denominated in its own token *before* that token trades. Those bribes show up
+// as NotifyReward events and feed BribesRevenue, but DefiLlama has no market
+// price for the token until it launches - so for the pre-launch window we value
+// the bribes with a manually supplied price instead.
+//
+// Each Ignition launch is announced on-chain by the IgnitionRegistry
+// (0xb92ad5cd5a94242aea076918f6fd4394867ccbbb) via:
+//   IgnitionEvent(address token, address pool, address incentive, uint256 initial_incentive_epoch_timestamp)
+// `token` is the entry key below. Note the event's timestamp is when the
+// incentive epoch *starts* (pre-launch bribes begin), NOT when the token starts
+// trading - those can be days to weeks apart - so the event cannot give us the
+// `tradesFrom` date or the price. Both are set by hand here. Not every
+// pre-launch token comes through this registry (e.g. 0x8e4c... did not), so this
+// map is the source of truth, maintained manually.
+//
+// To add a new launch:
+//   1. token       - the IgnitionEvent `token` address, lowercased, as the key.
+//   2. decimals     - the token's ERC20 decimals (almost always 18).
+//   3. conversionRate - the token's USD price during the pre-launch window
+//                       (use the launch-day VWAP; the event carries no price).
+//   4. tradesFrom   - 'YYYY-MM-DD' (UTC) of the first day DefiLlama prices the
+//                     token reliably, i.e. the day after launch. Before this date
+//                     bribes use `conversionRate`; on/after it they use spot.
 export const PRE_LAUNCH_TOKEN_PRICING = {
   '0x11dc28d01984079b7efe7763b533e6ed9e3722b9': {
     decimals: 18,
     conversionRate: 1.5887,
-    cutoffTimestamp: 1758240000
+    tradesFrom: '2025-09-19'
   },
   '0xf732a566121fa6362e9e0fbdd6d66e5c8c925e49': {
     decimals: 18,
     conversionRate: 0.15,
-    cutoffTimestamp: 1761782400
+    tradesFrom: '2025-10-30'
   },
   '0x9126236476efba9ad8ab77855c60eb5bf37586eb': {
     decimals: 18,
     conversionRate: 0.025,
-    cutoffTimestamp: 1766188800
+    tradesFrom: '2025-12-20'
   },
   '0x194f360d130f2393a5e9f3117a6a1b78abea1624': {
     decimals: 18,
     conversionRate: 0.01208,
-    cutoffTimestamp: 1769126400
+    tradesFrom: '2026-01-23'
   },
   '0x8e4cbbcc33db6c0a18561fde1f6ba35906d4848b': {
     decimals: 18,
     conversionRate: 0.07245,
-    cutoffTimestamp: 1775088000
+    tradesFrom: '2026-04-02'
   },
-  '0x6E84030FA86EBf585E3E18fe557e5612f7e93Bff': {
+  '0x6e84030fa86ebf585e3e18fe557e5612f7e93bff': {
     decimals: 18,
     conversionRate: 0.06,
-    cutoffTimestamp: 1778716800
+    tradesFrom: '2026-05-14'
+  },
+  '0xa1a0b2e02b0e6830ad5a4a7211691200945d8919': {
+    decimals: 18,
+    conversionRate: 0.00015,
+    tradesFrom: '2026-06-05'
   }
 }
 
 // Pricing rule for tokens in PRE_LAUNCH_TOKEN_PRICING:
-//   currentTimestamp <  cutoffTimestamp  → hardcoded conversionRate (token has no market price yet)
-//   currentTimestamp >= cutoffTimestamp  → DefiLlama spot price via balances.add (token is live)
+//   currentTimestamp <  tradesFrom  -> hardcoded conversionRate (token has no market price yet)
+//   currentTimestamp >= tradesFrom  -> DefiLlama spot price via balances.add (token is live)
 // Tokens not in the map always use balances.add.
 export const handleBribeToken = (
   token: string,
@@ -44,8 +76,9 @@ export const handleBribeToken = (
   dailyBribesRevenue: sdk.Balances
 ): void => {
   const tokenConfig = PRE_LAUNCH_TOKEN_PRICING[token.toLowerCase()]
+  const tradesFromTimestamp = tokenConfig && Date.parse(tokenConfig.tradesFrom) / 1000
 
-  if (!tokenConfig || currentTimestamp >= tokenConfig.cutoffTimestamp) {
+  if (!tokenConfig || currentTimestamp >= tradesFromTimestamp) {
     dailyBribesRevenue.add(token, amount)
     return
   }


### PR DESCRIPTION
## What

Aerodrome adapter maintenance for the Aero Ignition pre-launch token pricing in `dexs/aerodrome/utils.ts`:

- Replace the `cutoffTimestamp` unix timestamps with `tradesFrom` date strings (`YYYY-MM-DD`) so entries are readable and easy to add. All six existing dates parse to the exact same timestamps, so no values change.
- Add documentation explaining what these tokens are (Ignition pre-launch bribe tokens with no market price yet), where the addresses come from (the IgnitionRegistry `IgnitionEvent`), why the event cannot supply the cutoff or price (its timestamp is the incentive-epoch start, not the launch), and a checklist for adding a new launch.
- Add the new Ignition token `0xa1A0B2E02B0E6830aD5A4A7211691200945d8919` (launched Thu 4 Jun 2026): decimals 18, VWAP price 0.00015, trades from 2026-06-05.

## Why

Pre-launch bribes are paid in the launching token before it trades, so DefiLlama has no price for that window and the adapter values them with a manual rate. The new token was missing, so its pre-launch bribe revenue was counted as 0.
@