### PR TITLE
Add Tristero v3 adapter coverage

### DIFF
--- a/dexs/tristero/index.ts
+++ b/dexs/tristero/index.ts
@@ -1,8 +1,17 @@
+import { Balances } from "@defillama/sdk";
+import { AbiCoder, Interface } from "ethers";
 import { FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 import ADDRESSES from "../../helpers/coreAssets.json";
+import getTxReceipts, { getTransactions } from "../../helpers/getTxReceipts";
+import {
+  getActiveTristeroV3MarginEscrows,
+  getTristeroV3MarginPositions,
+  type TristeroV3MarginPosition,
+} from "../../helpers/tristeroMargin";
 
 const event_order_filled = 'event OrderFilled(bytes32 indexed orderUUID,string orderType,address target,address filler,address srcAsset,address dstAsset,uint256 srcQuantity,uint256 dstQuantity)';
+const ERC20_TRANSFER_TOPIC = "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef";
 
 type RouterConfig = {
   address: string;
@@ -54,6 +63,469 @@ const WRAPPED_NATIVE_TOKENS: Record<string, string | undefined> = {
   [CHAIN.XDAI]: ADDRESSES[CHAIN.XDAI]?.WXDAI,
 };
 
+function normalizeVolumeToken(chain: string, tokenAddress?: string | null): string | null {
+  const normalized = tokenAddress?.toLowerCase();
+  if (!normalized) return null;
+
+  if (normalized === '0x0000000000000000000000000000000000000000' || normalized === 'native') {
+    const wrappedToken = WRAPPED_NATIVE_TOKENS[chain] ?? ADDRESSES[chain]?.WETH;
+    return wrappedToken?.toLowerCase() ?? null;
+  }
+
+  return normalized;
+}
+
+type TristeroV3ChainConfig = {
+  start: string;
+  router: string;
+  escrow: string;
+  includedOrderTypes: string[];
+};
+
+type TristeroV3TransferLog = {
+  address: string;
+  data: string;
+  topics?: string[];
+  transactionHash?: string;
+  transaction_hash?: string;
+  txHash?: string;
+  logIndex?: string | number;
+  log_index?: string | number;
+  index?: string | number;
+};
+
+type TristeroV3DecodedOrder = {
+  orderType: string;
+  srcToken: string;
+  srcQuantity: bigint;
+  customData: string;
+};
+
+type TristeroV3Transaction = {
+  hash?: string | null;
+  from?: string | null;
+  to?: string | null;
+  data?: string;
+  input?: string;
+};
+
+type TristeroV3Receipt = {
+  hash?: string;
+  transactionHash?: string;
+  logs?: readonly TristeroV3TransferLog[];
+};
+
+const TRISTERO_V3_VOLUME_CONFIGS: Record<string, TristeroV3ChainConfig> = {
+  [CHAIN.ARBITRUM]: {
+    start: "2026-05-21",
+    router: "0x739DfF607F5303a2EB4D2271d11AEC6f642f6480",
+    escrow: "0x969D1eAb4C39706692d14894924245ca1Fe7cBCe",
+    includedOrderTypes: ["TAKER", "CROSS", "MARGIN"],
+  },
+  [CHAIN.BASE]: {
+    start: "2026-05-21",
+    router: "0x739DfF607F5303a2EB4D2271d11AEC6f642f6480",
+    escrow: "0x969D1eAb4C39706692d14894924245ca1Fe7cBCe",
+    includedOrderTypes: ["TAKER", "CROSS", "MARGIN"],
+  },
+} as const;
+
+const ORDER_ROUTER_ABI = [
+  {
+    type: "function",
+    name: "send",
+    stateMutability: "nonpayable",
+    inputs: [
+      {
+        name: "order",
+        type: "tuple",
+        components: [
+          { name: "sender", type: "address" },
+          {
+            name: "parameters",
+            type: "tuple",
+            components: [
+              { name: "srcAsset", type: "address" },
+              { name: "dstAsset", type: "address" },
+              { name: "srcQuantity", type: "uint256" },
+              { name: "dstQuantity", type: "uint256" },
+              { name: "minQuantity", type: "uint256" },
+              { name: "darkSalt", type: "uint128" },
+            ],
+          },
+          { name: "deadline", type: "uint256" },
+          { name: "target", type: "address" },
+          { name: "filler", type: "address" },
+          { name: "orderType", type: "string" },
+          { name: "customData", type: "bytes" },
+        ],
+      },
+      {
+        name: "payload",
+        type: "tuple",
+        components: [
+          { name: "nonce", type: "uint256" },
+          { name: "signature", type: "bytes" },
+        ],
+      },
+      {
+        name: "arb",
+        type: "tuple",
+        components: [
+          { name: "multicallTarget", type: "address" },
+          {
+            name: "calls",
+            type: "tuple[]",
+            components: [
+              { name: "target", type: "address" },
+              { name: "allowFailure", type: "bool" },
+              { name: "value", type: "uint256" },
+              { name: "callData", type: "bytes" },
+            ],
+          },
+          { name: "refundTo", type: "address" },
+          { name: "nftRecipient", type: "address" },
+        ],
+      },
+      { name: "minOut", type: "uint256" },
+      {
+        name: "v",
+        type: "tuple",
+        components: [
+          { name: "vault", type: "address" },
+          {
+            name: "permit",
+            type: "tuple",
+            components: [
+              {
+                name: "permitted",
+                type: "tuple",
+                components: [
+                  { name: "token", type: "address" },
+                  { name: "amount", type: "uint256" },
+                ],
+              },
+              { name: "nonce", type: "uint256" },
+              { name: "deadline", type: "uint256" },
+            ],
+          },
+          { name: "signature", type: "bytes" },
+        ],
+      },
+    ],
+  },
+] as const;
+
+const ESCROW_ABI = [
+  {
+    type: "function",
+    name: "close",
+    stateMutability: "nonpayable",
+    inputs: [
+      {
+        name: "order",
+        type: "tuple",
+        components: [
+          { name: "positionId", type: "uint128" },
+          { name: "sharesToClose", type: "uint256" },
+          { name: "minOut", type: "uint256" },
+          { name: "deadline", type: "uint256" },
+          { name: "permit2Nonce", type: "uint256" },
+        ],
+      },
+      { name: "signature", type: "bytes" },
+      {
+        name: "arb",
+        type: "tuple",
+        components: [
+          { name: "multicallTarget", type: "address" },
+          {
+            name: "calls",
+            type: "tuple[]",
+            components: [
+              { name: "target", type: "address" },
+              { name: "allowFailure", type: "bool" },
+              { name: "value", type: "uint256" },
+              { name: "callData", type: "bytes" },
+            ],
+          },
+          { name: "refundTo", type: "address" },
+          { name: "nftRecipient", type: "address" },
+        ],
+      },
+    ],
+  },
+] as const;
+
+const ORDER_ROUTER_INTERFACE = new Interface(ORDER_ROUTER_ABI);
+const ESCROW_INTERFACE = new Interface(ESCROW_ABI);
+const ABI_CODER = AbiCoder.defaultAbiCoder();
+
+function topicAddress(address: string): string {
+  return `0x${address.toLowerCase().replace(/^0x/, "").padStart(64, "0")}`;
+}
+
+function normalize(value?: string | null): string {
+  return value?.toLowerCase() ?? "";
+}
+
+function getTxHash(log?: TristeroV3TransferLog | null): string | undefined {
+  return log?.transactionHash ?? log?.transaction_hash ?? log?.txHash;
+}
+
+function getReceiptTxHash(receipt: TristeroV3Receipt): string | undefined {
+  return receipt.transactionHash ?? receipt.hash ?? (receipt.logs?.length ? getTxHash(receipt.logs[0] as TristeroV3TransferLog) : undefined);
+}
+
+function isNonZeroBytes32(value: string): boolean {
+  if (!/^0x[0-9a-fA-F]{64}$/.test(value)) return false;
+  return BigInt(value) > 0n;
+}
+
+function isIncludedOrderType(orderType: string, includedOrderTypes: string[]): boolean {
+  return includedOrderTypes.includes(orderType.toUpperCase());
+}
+
+function isRouterTransaction(tx: TristeroV3Transaction | null, router: string): boolean {
+  return normalize(tx?.to) === normalize(router);
+}
+
+function decodeTristeroV3SendOrder(data?: string): TristeroV3DecodedOrder | null {
+  if (!data) return null;
+
+  try {
+    const parsed = ORDER_ROUTER_INTERFACE.parseTransaction({ data });
+    if (!parsed || parsed.name !== "send") return null;
+
+    const order = parsed.args.order;
+    return {
+      orderType: order.orderType,
+      srcToken: order.parameters.srcAsset,
+      srcQuantity: BigInt(order.parameters.srcQuantity),
+      customData: order.customData,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function decodeTristeroV3CloseOrder(data?: string): boolean {
+  if (!data) return false;
+
+  try {
+    const parsed = ESCROW_INTERFACE.parseTransaction({ data });
+    return parsed?.name === "close";
+  } catch {
+    return false;
+  }
+}
+
+function getMarginLoanQuantity(order: TristeroV3DecodedOrder): bigint {
+  if (order.orderType.toUpperCase() !== "MARGIN" || !order.customData || order.customData === "0x") {
+    return 0n;
+  }
+
+  try {
+    const [loanAsset, loanQuantity] = ABI_CODER.decode(["address", "uint256", "uint256"], order.customData);
+    if (normalize(loanAsset) !== normalize(order.srcToken)) return 0n;
+    return BigInt(loanQuantity);
+  } catch (error) {
+    throw new Error(`Unable to decode Tristero v3 MARGIN customData: ${(error as Error).message}`);
+  }
+}
+
+function getOrderVolumeQuantity(order: TristeroV3DecodedOrder): bigint {
+  return order.srcQuantity + getMarginLoanQuantity(order);
+}
+
+function isTristeroV3RouterTransferLog(log: TristeroV3TransferLog, router: string): boolean {
+  const topics = log.topics ?? [];
+
+  return topics.length === 3
+    && normalize(topics[0]) === ERC20_TRANSFER_TOPIC
+    && normalize(topics[2]) === topicAddress(router)
+    && isNonZeroBytes32(log.data);
+}
+
+function addTristeroV3OrdersToBalances(
+  logs: TristeroV3TransferLog[],
+  transactions: (TristeroV3Transaction | null)[],
+  dailyVolume: Balances,
+  config: TristeroV3ChainConfig,
+  chain: string,
+) {
+  const seenTxs = new Set<string>();
+  const transactionByHash = new Map<string, TristeroV3Transaction>();
+
+  transactions.forEach((tx) => {
+    if (!tx?.hash) return;
+    transactionByHash.set(normalize(tx.hash), tx);
+  });
+
+  logs.forEach((log) => {
+    if (!isTristeroV3RouterTransferLog(log, config.router)) return;
+    const txHash = getTxHash(log);
+    if (!txHash) return;
+
+    const normalizedTxHash = normalize(txHash);
+    if (seenTxs.has(normalizedTxHash)) return;
+
+    const tx = transactionByHash.get(normalizedTxHash);
+    if (!isRouterTransaction(tx ?? null, config.router)) return;
+
+    const decodedOrder = decodeTristeroV3SendOrder(tx?.data ?? tx?.input);
+    if (!decodedOrder || !isIncludedOrderType(decodedOrder.orderType, config.includedOrderTypes)) return;
+
+    const tokenAddress = normalizeVolumeToken(chain, decodedOrder.srcToken);
+    if (!tokenAddress) return;
+
+    seenTxs.add(normalizedTxHash);
+    dailyVolume.add(tokenAddress, getOrderVolumeQuantity(decodedOrder));
+  });
+}
+
+function topicToAddress(topic?: string): string {
+  return topic ? `0x${topic.slice(-40)}`.toLowerCase() : "";
+}
+
+function addTristeroV3CloseReceiptsToBalances(
+  receipts: (TristeroV3Receipt | null)[],
+  transactions: (TristeroV3Transaction | null)[],
+  dailyVolume: Balances,
+  config: TristeroV3ChainConfig,
+  closePositionsByTxHash: Map<string, TristeroV3MarginPosition[]>,
+  closeTxHashes: string[],
+) {
+  const txByHash = new Map<string, TristeroV3Transaction>();
+
+  transactions.forEach((tx) => {
+    if (!tx?.hash) return;
+    txByHash.set(normalize(tx.hash), tx);
+  });
+
+  receipts.forEach((receipt, index) => {
+    if (!receipt) {
+      throw new Error(`Missing Tristero v3 close receipt for ${config.escrow} tx ${normalize(closeTxHashes[index])}`);
+    }
+
+    const receiptTxHash = getReceiptTxHash(receipt);
+    if (!receiptTxHash) {
+      throw new Error(`Missing Tristero v3 close receipt transaction hash for ${config.escrow} tx ${normalize(closeTxHashes[index])}`);
+    }
+    const normalizedReceiptTxHash = normalize(receiptTxHash);
+
+    const tx = txByHash.get(normalizedReceiptTxHash);
+    if (!tx || !isRouterTransaction(tx, config.escrow) || !decodeTristeroV3CloseOrder(tx.data ?? tx.input)) {
+      throw new Error(`Missing Tristero v3 close transaction data for ${config.escrow} tx ${normalizedReceiptTxHash}`);
+    }
+
+    const closePositions = closePositionsByTxHash.get(normalizedReceiptTxHash);
+    if (!closePositions?.length) {
+      throw new Error(`Missing Tristero v3 close position state for ${config.escrow} tx ${normalizedReceiptTxHash}`);
+    }
+    if (closePositions.length !== 1) {
+      throw new Error(`Ambiguous Tristero v3 close volume attribution for ${config.escrow} tx ${normalizedReceiptTxHash}: ${closePositions.length} positions share one receipt`);
+    }
+
+    const closePosition = closePositions[0];
+    const loanAsset = normalize(closePosition.loanAsset);
+    const closeFiller = normalize(closePosition.closeFiller);
+    if (!closeFiller) {
+      throw new Error(`Missing Tristero v3 close filler for ${config.escrow} tx ${normalizedReceiptTxHash}`);
+    }
+
+    let grossCloseAmount = 0n;
+
+    (receipt.logs ?? []).forEach((log) => {
+      const topics = log.topics ?? [];
+      if (
+        normalize(log.address) !== loanAsset
+        || topics.length !== 3
+        || normalize(topics[0]) !== ERC20_TRANSFER_TOPIC
+        || normalize(topics[1]) !== topicAddress(config.escrow)
+        || topicToAddress(topics[2]) !== closeFiller
+        || !isNonZeroBytes32(log.data)
+      ) {
+        return;
+      }
+
+      grossCloseAmount += BigInt(log.data);
+    });
+
+    if (grossCloseAmount > 0n) {
+      dailyVolume.add(loanAsset, grossCloseAmount);
+    }
+  });
+}
+
+function groupClosePositionsByTxHash(positions: TristeroV3MarginPosition[], closeTxHashes: Set<string>): Map<string, TristeroV3MarginPosition[]> {
+  const positionsByTxHash = new Map<string, TristeroV3MarginPosition[]>();
+
+  positions.forEach((position) => {
+    const txHash = normalize(position.closeTxHash);
+    if (!txHash || !closeTxHashes.has(txHash)) return;
+
+    const positionsForTx = positionsByTxHash.get(txHash) ?? [];
+    positionsForTx.push(position);
+    positionsByTxHash.set(txHash, positionsForTx);
+  });
+
+  return positionsByTxHash;
+}
+
+async function addTristeroV3ChainVolume(options: FetchOptions, dailyVolume: Balances) {
+  const config = TRISTERO_V3_VOLUME_CONFIGS[options.chain];
+  if (!config || options.dateString < config.start) return;
+
+  // Current v3 router.send is nonpayable and backend submits it with value=0,
+  // so router funding is discoverable through ERC20 Transfer logs. If a future
+  // router.send becomes payable, also decode tx.value-backed native funding.
+  const logs: TristeroV3TransferLog[] = await options.getLogs({
+    topics: [
+      ERC20_TRANSFER_TOPIC,
+      null as any,
+      topicAddress(config.router),
+    ],
+    noTarget: true,
+    eventAbi: "event Transfer(address indexed from, address indexed to, uint256 value)",
+    entireLog: true,
+  });
+
+  const txHashes = [...new Set(logs.map(getTxHash).filter((txHash): txHash is string => !!txHash))];
+  if (txHashes.length) {
+    const transactions = await getTransactions(options.chain, txHashes, {
+      cacheKey: "tristero-v3-router-send",
+    });
+    addTristeroV3OrdersToBalances(logs, transactions, dailyVolume, config, options.chain);
+  }
+
+  const closeLogs: TristeroV3TransferLog[] = await options.getLogs({
+    target: config.escrow,
+    eventAbi: "event PositionClosed(uint128 indexed positionId, address indexed filler)",
+    entireLog: true,
+  });
+  const closeTxHashes = [...new Set(closeLogs.map(getTxHash).filter((txHash): txHash is string => !!txHash))];
+  if (closeTxHashes.length) {
+    const normalizedCloseTxHashes = new Set(closeTxHashes.map(normalize));
+    const v3MarginPositions = await getTristeroV3MarginPositions(
+      options,
+      getActiveTristeroV3MarginEscrows(options.chain, options.dateString),
+      await options.getToBlock(),
+    );
+    const closePositionsByTxHash = groupClosePositionsByTxHash(v3MarginPositions, normalizedCloseTxHashes);
+
+    const [closeTransactions, closeReceipts] = await Promise.all([
+      getTransactions(options.chain, closeTxHashes, {
+        cacheKey: "tristero-v3-escrow-close",
+      }),
+      getTxReceipts(options.chain, closeTxHashes, {
+        cacheKey: "tristero-v3-escrow-close",
+      }),
+    ]);
+    addTristeroV3CloseReceiptsToBalances(closeReceipts as unknown as TristeroV3Receipt[], closeTransactions, dailyVolume, config, closePositionsByTxHash, closeTxHashes);
+  }
+}
+
 const fetch = async (options: FetchOptions) => {
   const dailyVolume = options.createBalances();
   const chain = options.chain;
@@ -76,15 +548,13 @@ const fetch = async (options: FetchOptions) => {
 
   allLogs.forEach((log: any) => {
     if (log.srcAsset && log.srcQuantity) {
-      let tokenAddress = log.srcAsset.toLowerCase();
-      if (tokenAddress === '0x0000000000000000000000000000000000000000' || tokenAddress === 'native') {
-        const wrappedToken = WRAPPED_NATIVE_TOKENS[chain] ?? ADDRESSES[chain]?.WETH;
-        if (!wrappedToken) return;
-        tokenAddress = wrappedToken.toLowerCase();
-      }
+      const tokenAddress = normalizeVolumeToken(chain, log.srcAsset);
+      if (!tokenAddress) return;
       dailyVolume.add(tokenAddress, log.srcQuantity);
     }
   });
+
+  await addTristeroV3ChainVolume(options, dailyVolume);
 
   return { dailyVolume };
 };
@@ -98,6 +568,9 @@ const adapter: SimpleAdapter = {
       { fetch, start: config.start }
     ])
   ),
+  methodology: {
+    Volume: "Legacy Tristero volume is counted from OrderFilled source token amounts. V3 volume is counted from on-chain router.send transactions for TAKER, CROSS, and MARGIN orders plus escrow.close settlement transfers; margin opens include collateral plus decoded loan quantity.",
+  },
 };
 
 export default adapter;

--- a/dexs/tristero/index.ts
+++ b/dexs/tristero/index.ts
@@ -8,6 +8,7 @@ import getTxReceipts, { getTransactions } from "../../helpers/getTxReceipts";
 import {
   getActiveTristeroV3MarginEscrows,
   getTristeroV3MarginPositions,
+  TRISTERO_V3_MARGIN_ABI,
   type TristeroV3MarginPosition,
 } from "../../helpers/tristeroMargin";
 
@@ -506,7 +507,7 @@ async function addTristeroV3ChainVolume(options: FetchOptions, dailyVolume: Bala
   const closeLogs: TristeroV3TransferLog[] = activeV3EscrowAddresses.length
     ? await options.getLogs({
       targets: activeV3EscrowAddresses,
-      eventAbi: "event PositionClosed(uint128 indexed positionId, address indexed filler)",
+      eventAbi: TRISTERO_V3_MARGIN_ABI.positionClosed,
       entireLog: true,
     })
     : [];

--- a/dexs/tristero/index.ts
+++ b/dexs/tristero/index.ts
@@ -1,3 +1,4 @@
+import * as sdk from "@defillama/sdk";
 import { Balances } from "@defillama/sdk";
 import { AbiCoder, Interface } from "ethers";
 import { FetchOptions, SimpleAdapter } from "../../adapters/types";
@@ -78,7 +79,6 @@ function normalizeVolumeToken(chain: string, tokenAddress?: string | null): stri
 type TristeroV3ChainConfig = {
   start: string;
   router: string;
-  escrow: string;
   includedOrderTypes: string[];
 };
 
@@ -119,13 +119,11 @@ const TRISTERO_V3_VOLUME_CONFIGS: Record<string, TristeroV3ChainConfig> = {
   [CHAIN.ARBITRUM]: {
     start: "2026-05-21",
     router: "0x739DfF607F5303a2EB4D2271d11AEC6f642f6480",
-    escrow: "0x969D1eAb4C39706692d14894924245ca1Fe7cBCe",
     includedOrderTypes: ["TAKER", "CROSS", "MARGIN"],
   },
   [CHAIN.BASE]: {
     start: "2026-05-21",
     router: "0x739DfF607F5303a2EB4D2271d11AEC6f642f6480",
-    escrow: "0x969D1eAb4C39706692d14894924245ca1Fe7cBCe",
     includedOrderTypes: ["TAKER", "CROSS", "MARGIN"],
   },
 } as const;
@@ -260,6 +258,7 @@ const ESCROW_ABI = [
 const ORDER_ROUTER_INTERFACE = new Interface(ORDER_ROUTER_ABI);
 const ESCROW_INTERFACE = new Interface(ESCROW_ABI);
 const ABI_CODER = AbiCoder.defaultAbiCoder();
+const ORDER_ROUTER_SEND_SELECTOR = ORDER_ROUTER_INTERFACE.getFunction("send")?.selector.toLowerCase();
 
 function topicAddress(address: string): string {
   return `0x${address.toLowerCase().replace(/^0x/, "").padStart(64, "0")}`;
@@ -292,6 +291,7 @@ function isRouterTransaction(tx: TristeroV3Transaction | null, router: string): 
 
 function decodeTristeroV3SendOrder(data?: string): TristeroV3DecodedOrder | null {
   if (!data) return null;
+  if (!ORDER_ROUTER_SEND_SELECTOR || !data.toLowerCase().startsWith(ORDER_ROUTER_SEND_SELECTOR)) return null;
 
   try {
     const parsed = ORDER_ROUTER_INTERFACE.parseTransaction({ data });
@@ -304,8 +304,10 @@ function decodeTristeroV3SendOrder(data?: string): TristeroV3DecodedOrder | null
       srcQuantity: BigInt(order.parameters.srcQuantity),
       customData: order.customData,
     };
-  } catch {
-    return null;
+  } catch (error) {
+    const calldataContext = `${data.slice(0, 74)}${data.length > 74 ? "..." : ""}`;
+    sdk.log(`Unable to decode Tristero v3 router.send calldata ${calldataContext}: ${(error as Error).message}`);
+    throw error;
   }
 }
 
@@ -392,7 +394,6 @@ function addTristeroV3CloseReceiptsToBalances(
   receipts: (TristeroV3Receipt | null)[],
   transactions: (TristeroV3Transaction | null)[],
   dailyVolume: Balances,
-  config: TristeroV3ChainConfig,
   closePositionsByTxHash: Map<string, TristeroV3MarginPosition[]>,
   closeTxHashes: string[],
 ) {
@@ -405,33 +406,34 @@ function addTristeroV3CloseReceiptsToBalances(
 
   receipts.forEach((receipt, index) => {
     if (!receipt) {
-      throw new Error(`Missing Tristero v3 close receipt for ${config.escrow} tx ${normalize(closeTxHashes[index])}`);
+      throw new Error(`Missing Tristero v3 close receipt for tx ${normalize(closeTxHashes[index])}`);
     }
 
     const receiptTxHash = getReceiptTxHash(receipt);
     if (!receiptTxHash) {
-      throw new Error(`Missing Tristero v3 close receipt transaction hash for ${config.escrow} tx ${normalize(closeTxHashes[index])}`);
+      throw new Error(`Missing Tristero v3 close receipt transaction hash for tx ${normalize(closeTxHashes[index])}`);
     }
     const normalizedReceiptTxHash = normalize(receiptTxHash);
 
-    const tx = txByHash.get(normalizedReceiptTxHash);
-    if (!tx || !isRouterTransaction(tx, config.escrow) || !decodeTristeroV3CloseOrder(tx.data ?? tx.input)) {
-      throw new Error(`Missing Tristero v3 close transaction data for ${config.escrow} tx ${normalizedReceiptTxHash}`);
-    }
-
     const closePositions = closePositionsByTxHash.get(normalizedReceiptTxHash);
     if (!closePositions?.length) {
-      throw new Error(`Missing Tristero v3 close position state for ${config.escrow} tx ${normalizedReceiptTxHash}`);
+      throw new Error(`Missing Tristero v3 close position state for tx ${normalizedReceiptTxHash}`);
     }
     if (closePositions.length !== 1) {
-      throw new Error(`Ambiguous Tristero v3 close volume attribution for ${config.escrow} tx ${normalizedReceiptTxHash}: ${closePositions.length} positions share one receipt`);
+      throw new Error(`Ambiguous Tristero v3 close volume attribution for tx ${normalizedReceiptTxHash}: ${closePositions.length} positions share one receipt`);
     }
 
     const closePosition = closePositions[0];
+    const escrow = normalize(closePosition.escrow);
+    const tx = txByHash.get(normalizedReceiptTxHash);
+    if (!tx || !isRouterTransaction(tx, escrow) || !decodeTristeroV3CloseOrder(tx.data ?? tx.input)) {
+      throw new Error(`Missing Tristero v3 close transaction data for ${escrow} tx ${normalizedReceiptTxHash}`);
+    }
+
     const loanAsset = normalize(closePosition.loanAsset);
     const closeFiller = normalize(closePosition.closeFiller);
     if (!closeFiller) {
-      throw new Error(`Missing Tristero v3 close filler for ${config.escrow} tx ${normalizedReceiptTxHash}`);
+      throw new Error(`Missing Tristero v3 close filler for ${escrow} tx ${normalizedReceiptTxHash}`);
     }
 
     let grossCloseAmount = 0n;
@@ -442,7 +444,7 @@ function addTristeroV3CloseReceiptsToBalances(
         normalize(log.address) !== loanAsset
         || topics.length !== 3
         || normalize(topics[0]) !== ERC20_TRANSFER_TOPIC
-        || normalize(topics[1]) !== topicAddress(config.escrow)
+        || normalize(topics[1]) !== topicAddress(escrow)
         || topicToAddress(topics[2]) !== closeFiller
         || !isNonZeroBytes32(log.data)
       ) {
@@ -476,6 +478,8 @@ function groupClosePositionsByTxHash(positions: TristeroV3MarginPosition[], clos
 async function addTristeroV3ChainVolume(options: FetchOptions, dailyVolume: Balances) {
   const config = TRISTERO_V3_VOLUME_CONFIGS[options.chain];
   if (!config || options.dateString < config.start) return;
+  const activeV3Escrows = getActiveTristeroV3MarginEscrows(options.chain, options.dateString);
+  const activeV3EscrowAddresses = activeV3Escrows.map(({ address }) => address);
 
   // Current v3 router.send is nonpayable and backend submits it with value=0,
   // so router funding is discoverable through ERC20 Transfer logs. If a future
@@ -499,17 +503,19 @@ async function addTristeroV3ChainVolume(options: FetchOptions, dailyVolume: Bala
     addTristeroV3OrdersToBalances(logs, transactions, dailyVolume, config, options.chain);
   }
 
-  const closeLogs: TristeroV3TransferLog[] = await options.getLogs({
-    target: config.escrow,
-    eventAbi: "event PositionClosed(uint128 indexed positionId, address indexed filler)",
-    entireLog: true,
-  });
+  const closeLogs: TristeroV3TransferLog[] = activeV3EscrowAddresses.length
+    ? await options.getLogs({
+      targets: activeV3EscrowAddresses,
+      eventAbi: "event PositionClosed(uint128 indexed positionId, address indexed filler)",
+      entireLog: true,
+    })
+    : [];
   const closeTxHashes = [...new Set(closeLogs.map(getTxHash).filter((txHash): txHash is string => !!txHash))];
   if (closeTxHashes.length) {
     const normalizedCloseTxHashes = new Set(closeTxHashes.map(normalize));
     const v3MarginPositions = await getTristeroV3MarginPositions(
       options,
-      getActiveTristeroV3MarginEscrows(options.chain, options.dateString),
+      activeV3Escrows,
       await options.getToBlock(),
     );
     const closePositionsByTxHash = groupClosePositionsByTxHash(v3MarginPositions, normalizedCloseTxHashes);
@@ -522,7 +528,7 @@ async function addTristeroV3ChainVolume(options: FetchOptions, dailyVolume: Bala
         cacheKey: "tristero-v3-escrow-close",
       }),
     ]);
-    addTristeroV3CloseReceiptsToBalances(closeReceipts as unknown as TristeroV3Receipt[], closeTransactions, dailyVolume, config, closePositionsByTxHash, closeTxHashes);
+    addTristeroV3CloseReceiptsToBalances(closeReceipts as unknown as TristeroV3Receipt[], closeTransactions, dailyVolume, closePositionsByTxHash, closeTxHashes);
   }
 }
 

--- a/fees/tristero-margin.ts
+++ b/fees/tristero-margin.ts
@@ -111,6 +111,49 @@ function formatV3ReadValueContext(positions: TristeroV3MarginPosition[]): string
         .join(", ");
 }
 
+type PermitFailureMultiCallParams = {
+    abi: string;
+    calls: Array<{ target?: string; params?: any }>;
+    target?: string;
+    block?: number;
+};
+
+async function permitFailureMultiCallWithFallback(
+    options: FetchOptions,
+    api: any,
+    params: PermitFailureMultiCallParams,
+    context: string,
+): Promise<any[]> {
+    try {
+        return await api.multiCall({ ...params, permitFailure: true });
+    } catch (error) {
+        sdk.log(`Tristero multicall failed on ${options.chain} ${context}: ${formatErrorMessage(error)}`);
+    }
+
+    const block = params.block ?? api.block;
+    return Promise.all(params.calls.map(async (call, index) => {
+        const target = call.target ?? params.target;
+        if (!target) {
+            sdk.log(`Tristero multicall fallback missing target on ${options.chain} ${context} call ${index}`);
+            return null;
+        }
+
+        try {
+            const output = await api.call({
+                target,
+                abi: params.abi,
+                params: call.params,
+                block,
+                permitFailure: true,
+            });
+            return output && typeof output === "object" && "output" in output ? output.output : output;
+        } catch (error) {
+            sdk.log(`Tristero multicall fallback failed on ${options.chain} ${context} call ${index} target ${target}: ${formatErrorMessage(error)}`);
+            return null;
+        }
+    }));
+}
+
 async function readV3LoanValuesAtBlock(
     options: FetchOptions,
     positions: TristeroV3MarginPosition[],
@@ -119,15 +162,14 @@ async function readV3LoanValuesAtBlock(
     let values: any[] = [];
     if (positions.length) {
         try {
-            values = await options.api.multiCall({
+            values = await permitFailureMultiCallWithFallback(options, options.api, {
                 abi: TRISTERO_V3_MARGIN_ABI.readValue,
                 calls: positions.map((position) => ({
                     target: position.vault,
                     params: [position.loanAsset, position.loanShares.toString()],
                 })),
                 block,
-                permitFailure: true,
-            });
+            }, `readValue block ${block} for ${positions.length} positions (${formatV3ReadValueContext(positions)})`);
         } catch (error) {
             sdk.log(`Tristero v3 multicall readValue failed on ${options.chain} at block ${block} for ${positions.length} positions (${formatV3ReadValueContext(positions)}): ${formatErrorMessage(error)}`);
             values = [];
@@ -356,15 +398,14 @@ async function getHistoricalPositions(
     const positionsByRef = new Map<string, TristeroMarginPosition | null>();
 
     for (const [block, positionRefs] of positionRefsByBlock.entries()) {
-        const positions = await options.api.multiCall({
+        const positions = await permitFailureMultiCallWithFallback(options, options.api, {
             abi: TRISTERO_MARGIN_ABI.positions,
             calls: positionRefs.map(({ escrow, positionId }) => ({
                 target: escrow,
                 params: [positionId],
             })),
             block,
-            permitFailure: true,
-        });
+        }, `legacy positions block ${block} for ${positionRefs.length} refs`);
 
         positionRefs.forEach((positionRef, index) => {
             positionsByRef.set(getHistoricalPositionKey(positionRef), normalizePosition(positions[index]));
@@ -389,15 +430,14 @@ async function getHistoricalAccumulatedInterest(
     const interestByRef = new Map<string, bigint | null>();
 
     for (const [block, positionRefs] of positionRefsByBlock.entries()) {
-        const accumulatedInterest = await options.api.multiCall({
+        const accumulatedInterest = await permitFailureMultiCallWithFallback(options, options.api, {
             abi: TRISTERO_MARGIN_ABI.accumulatedInterest,
             calls: positionRefs.map(({ escrow, positionId }) => ({
                 target: escrow,
                 params: [positionId],
             })),
             block,
-            permitFailure: true,
-        });
+        }, `legacy accumulatedInterest block ${block} for ${positionRefs.length} refs`);
 
         positionRefs.forEach((positionRef, index) => {
             interestByRef.set(getHistoricalPositionKey(positionRef), toBigIntOrNull(accumulatedInterest[index]));
@@ -545,11 +585,10 @@ const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
         }
     });
 
-    const totalPositionsPerEscrow = await options.toApi.multiCall({
+    const totalPositionsPerEscrow = await permitFailureMultiCallWithFallback(options, options.toApi, {
         abi: TRISTERO_MARGIN_ABI.totalPositions,
         calls: escrows.map((escrow) => ({ target: escrow })),
-        permitFailure: true,
-    });
+    }, `legacy totalPositions for ${escrows.length} escrows`);
 
     const endPositionRefs = totalPositionsPerEscrow.flatMap((totalPositions, index) =>
         getPositionIds(totalPositions).map((positionId) => ({
@@ -559,14 +598,13 @@ const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
     );
 
     const endPositionsRaw = endPositionRefs.length
-        ? await options.toApi.multiCall({
+        ? await permitFailureMultiCallWithFallback(options, options.toApi, {
             abi: TRISTERO_MARGIN_ABI.positions,
             calls: endPositionRefs.map(({ escrow, positionId }) => ({
                 target: escrow,
                 params: [positionId],
             })),
-            permitFailure: true,
-        })
+        }, `legacy end positions for ${endPositionRefs.length} refs`)
         : [];
 
     endPositionsRaw.forEach((position: any, index: number) => {
@@ -581,22 +619,20 @@ const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
     const trackedPositions = Array.from(relevantPositions.values());
     const [startAccruedRaw, endAccruedRaw] = trackedPositions.length
         ? await Promise.all([
-            options.fromApi.multiCall({
+            permitFailureMultiCallWithFallback(options, options.fromApi, {
                 abi: TRISTERO_MARGIN_ABI.accumulatedInterest,
                 calls: trackedPositions.map(({ escrow, positionId }) => ({
                     target: escrow,
                     params: [positionId],
                 })),
-                permitFailure: true,
-            }),
-            options.toApi.multiCall({
+            }, `legacy start accumulatedInterest for ${trackedPositions.length} refs`),
+            permitFailureMultiCallWithFallback(options, options.toApi, {
                 abi: TRISTERO_MARGIN_ABI.accumulatedInterest,
                 calls: trackedPositions.map(({ escrow, positionId }) => ({
                     target: escrow,
                     params: [positionId],
                 })),
-                permitFailure: true,
-            }),
+            }, `legacy end accumulatedInterest for ${trackedPositions.length} refs`),
         ])
         : [[], []];
 

--- a/fees/tristero-margin.ts
+++ b/fees/tristero-margin.ts
@@ -1,4 +1,5 @@
 import * as sdk from "@defillama/sdk";
+import retry from "async-retry";
 import { FetchOptions, FetchResultV2, SimpleAdapter } from "../adapters/types";
 import getTxReceipts from "../helpers/getTxReceipts";
 import { METRIC } from "../helpers/metrics";
@@ -155,15 +156,25 @@ async function readV3LoanValueAtBlock(
     block: number,
 ): Promise<bigint | null> {
     try {
-        const { output } = await sdk.api.abi.call({
-            chain: options.chain,
-            block,
-            target: position.vault,
-            abi: TRISTERO_V3_MARGIN_ABI.readValue,
-            params: [position.loanAsset, position.loanShares.toString()],
-        });
+        return await retry(async () => {
+            const { output } = await sdk.api.abi.call({
+                chain: options.chain,
+                block,
+                target: position.vault,
+                abi: TRISTERO_V3_MARGIN_ABI.readValue,
+                params: [position.loanAsset, position.loanShares.toString()],
+            });
 
-        return toBigIntOrNull(output);
+            const value = toBigIntOrNull(output);
+            if (value === null) throw new Error("readValue returned nullish output");
+            return value;
+        }, {
+            retries: 2,
+            minTimeout: 500,
+            onRetry: (error, attempt) => {
+                sdk.log(`Retrying Tristero v3 single readValue on ${options.chain} position ${position.positionId} at ${position.escrow} block ${block} (attempt ${attempt + 1}): ${formatErrorMessage(error)}`);
+            },
+        });
     } catch (error) {
         sdk.log(`Tristero v3 single readValue failed on ${options.chain} position ${position.positionId} at ${position.escrow} block ${block}: ${formatErrorMessage(error)}`);
         return null;
@@ -206,7 +217,7 @@ function getV3ReductionRepayments(
         const positionKey = getV3PositionKey(reduction);
         const startBlock = startBlockByPosition.get(positionKey);
         if (startBlock === undefined) return;
-        if (reduction.blockNumber < startBlock || reduction.blockNumber > toBlock) return;
+        if (reduction.blockNumber <= startBlock || reduction.blockNumber > toBlock) return;
 
         repayments.set(positionKey, (repayments.get(positionKey) ?? 0n) + reduction.repayAmount);
     });

--- a/fees/tristero-margin.ts
+++ b/fees/tristero-margin.ts
@@ -1,7 +1,16 @@
+import * as sdk from "@defillama/sdk";
 import { FetchOptions, FetchResultV2, SimpleAdapter } from "../adapters/types";
+import getTxReceipts from "../helpers/getTxReceipts";
 import { METRIC } from "../helpers/metrics";
+import { httpPost } from "../utils/fetchURL";
 import {
     getActiveTristeroMarginEscrows,
+    getActiveTristeroV3MarginEscrows,
+    getTristeroMarginChainStart,
+    getTristeroMarginChains,
+    getTristeroV3MarginPositions,
+    getTristeroV3MarginPositionSnapshots,
+    getV3PositionKey,
     getPositionIds,
     mulDivCeil,
     normalizePosition,
@@ -9,9 +18,15 @@ import {
     toBigIntSafe,
     toPositionId,
     TRISTERO_MARGIN_ABI,
+    TRISTERO_V3_MARGIN_ABI,
     type TristeroMarginPosition,
-    TRISTERO_MARGIN_CONFIGS,
+    type TristeroV3MarginPosition,
 } from "../helpers/tristeroMargin";
+
+const ERC20_TRANSFER_TOPIC = "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef";
+const V3_RECEIPT_RPC_FALLBACKS: Record<string, string[]> = {
+    base: ["https://mainnet.base.org"],
+};
 
 const MARGIN_METRICS = {
     BORROW_INTEREST_TO_PROTOCOL: 'Borrow Interest To Protocol',
@@ -64,6 +79,190 @@ function addToPositionMap(map: Map<string, bigint>, positionRef: PositionRef, am
 function addToTokenMap(map: Map<string, bigint>, token: string, amount: bigint) {
     const key = token.toLowerCase();
     map.set(key, (map.get(key) ?? 0n) + amount);
+}
+
+function normalizeAddress(value?: string | null): string {
+    return value?.toLowerCase() ?? "";
+}
+
+function topicAddress(address: string): string {
+    return `0x${address.toLowerCase().replace(/^0x/, "").padStart(64, "0")}`;
+}
+
+function topicToAddress(topic?: string): string {
+    return topic ? `0x${topic.slice(-40)}`.toLowerCase() : "";
+}
+
+function isNonZeroBytes32(value?: string): boolean {
+    if (!value || !/^0x[0-9a-fA-F]{64}$/.test(value)) return false;
+    return BigInt(value) > 0n;
+}
+
+async function readV3LoanValuesAtBlock(
+    options: FetchOptions,
+    positions: TristeroV3MarginPosition[],
+    block: number,
+): Promise<Map<string, bigint>> {
+    let values: any[] = [];
+    if (positions.length) {
+        try {
+            values = await options.api.multiCall({
+                abi: TRISTERO_V3_MARGIN_ABI.readValue,
+                calls: positions.map((position) => ({
+                    target: position.vault,
+                    params: [position.loanAsset, position.loanShares.toString()],
+                })),
+                block,
+                permitFailure: true,
+            });
+        } catch {
+            values = [];
+        }
+    }
+
+    const valuesByPosition = new Map<string, bigint>();
+    for (const [index, position] of positions.entries()) {
+        let value = toBigIntOrNull(values[index]);
+        if (value === null) {
+            value = await readV3LoanValueAtBlock(options, position, block);
+        }
+        if (value === null) {
+            throw new Error(`Unable to read Tristero v3 loan value for ${options.chain} position ${position.positionId} at ${position.escrow} block ${block}`);
+        }
+
+        valuesByPosition.set(getV3PositionKey(position), value);
+    }
+
+    return valuesByPosition;
+}
+
+async function readV3LoanValueAtBlock(
+    options: FetchOptions,
+    position: TristeroV3MarginPosition,
+    block: number,
+): Promise<bigint | null> {
+    try {
+        const { output } = await sdk.api.abi.call({
+            chain: options.chain,
+            block,
+            target: position.vault,
+            abi: TRISTERO_V3_MARGIN_ABI.readValue,
+            params: [position.loanAsset, position.loanShares.toString()],
+        });
+
+        return toBigIntOrNull(output);
+    } catch {
+        return null;
+    }
+}
+
+async function readV3LoanValuesByPositionBlock(
+    options: FetchOptions,
+    positionBlocks: { position: TristeroV3MarginPosition; block: number }[],
+): Promise<Map<string, bigint>> {
+    const positionsByBlock = new Map<number, TristeroV3MarginPosition[]>();
+
+    positionBlocks.forEach(({ position, block }) => {
+        const positions = positionsByBlock.get(block) ?? [];
+        positions.push(position);
+        positionsByBlock.set(block, positions);
+    });
+
+    const valuesByPosition = new Map<string, bigint>();
+    for (const [block, positions] of positionsByBlock.entries()) {
+        const valuesAtBlock = await readV3LoanValuesAtBlock(options, positions, block);
+        valuesAtBlock.forEach((value, key) => valuesByPosition.set(`${key}-${block}`, value));
+    }
+
+    return valuesByPosition;
+}
+
+function getV3HistoricalValueKey(position: { escrow: string; positionId: number }, block: number): string {
+    return `${getV3PositionKey(position)}-${block}`;
+}
+
+async function getV3CloseRepayments(
+    options: FetchOptions,
+    closedPositions: TristeroV3MarginPosition[],
+): Promise<Map<string, bigint>> {
+    const txHashes = [...new Set(closedPositions.map((position) => position.closeTxHash).filter((txHash): txHash is string => !!txHash))];
+    const repaymentByPosition = new Map<string, bigint>();
+    if (!txHashes.length) return repaymentByPosition;
+
+    const receipts = await getTxReceipts(options.chain, txHashes, {
+        cacheKey: "tristero-v3-margin-close-fees",
+    });
+    const positionsByTxHash = new Map<string, TristeroV3MarginPosition[]>();
+    closedPositions.forEach((position) => {
+        if (!position.closeTxHash) return;
+        const txHash = position.closeTxHash.toLowerCase();
+        const positions = positionsByTxHash.get(txHash) ?? [];
+        positions.push(position);
+        positionsByTxHash.set(txHash, positions);
+    });
+
+    for (const [index, cachedReceipt] of receipts.entries()) {
+        const requestedTxHash = normalizeAddress(txHashes[index]);
+        const receipt = cachedReceipt ?? await getV3CloseReceipt(options.chain, requestedTxHash);
+        if (!receipt) {
+            sdk.log(`Missing Tristero v3 close receipt for ${options.chain} tx ${requestedTxHash}; using zero close repayment fallback`);
+            (positionsByTxHash.get(requestedTxHash) ?? []).forEach((position) => {
+                repaymentByPosition.set(getV3PositionKey(position), 0n);
+            });
+            continue;
+        }
+
+        const txHash = normalizeAddress(receipt.transactionHash ?? receipt.hash);
+        if (!txHash) {
+            throw new Error(`Missing Tristero v3 close receipt transaction hash for ${options.chain} tx ${requestedTxHash}`);
+        }
+
+        const positions = positionsByTxHash.get(txHash);
+        if (!positions?.length) continue;
+        if (positions.length !== 1) {
+            throw new Error(`Ambiguous Tristero v3 close repayment attribution for ${options.chain} tx ${txHash}: ${positions.length} positions share one receipt`);
+        }
+
+        const position = positions[0];
+        let repayment = 0n;
+        (receipt.logs ?? []).forEach((log: any) => {
+            const topics = log.topics ?? [];
+            if (
+                normalizeAddress(log.address) !== position.loanAsset
+                || topics.length !== 3
+                || normalizeAddress(topics[0]) !== ERC20_TRANSFER_TOPIC
+                || normalizeAddress(topics[1]) !== topicAddress(position.escrow)
+                || topicToAddress(topics[2]) !== normalizeAddress(position.closeFiller)
+                || !isNonZeroBytes32(log.data)
+            ) {
+                return;
+            }
+
+            repayment += BigInt(log.data);
+        });
+
+        repaymentByPosition.set(getV3PositionKey(position), repayment);
+    }
+
+    return repaymentByPosition;
+}
+
+async function getV3CloseReceipt(chain: string, txHash: string): Promise<any | null> {
+    for (const rpcUrl of V3_RECEIPT_RPC_FALLBACKS[chain] ?? []) {
+        try {
+            const payload = await httpPost(rpcUrl, {
+                jsonrpc: "2.0",
+                id: 1,
+                method: "eth_getTransactionReceipt",
+                params: [txHash],
+            });
+            if (payload?.result) return payload.result;
+        } catch (error) {
+            sdk.log(`Tristero v3 fallback RPC ${rpcUrl} failed for ${txHash}: ${(error as Error).message}`);
+        }
+    }
+
+    return null;
 }
 
 function flattenGroupedLogs(logGroups: any[][], escrows: string[]): any[] {
@@ -172,8 +371,9 @@ const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
     const liquidationFees = options.createBalances();
     const liquidationProtocolRevenue = options.createBalances();
     const escrows = getActiveTristeroMarginEscrows(options.chain, options.dateString);
+    const v3Escrows = getActiveTristeroV3MarginEscrows(options.chain, options.dateString);
 
-    if (!escrows.length) {
+    if (!escrows.length && !v3Escrows.length) {
         const dailyFees = borrowInterestFees.clone();
         const dailyProtocolRevenue = borrowInterestProtocolRevenue.clone();
 
@@ -182,7 +382,7 @@ const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
             dailyUserFees: dailyFees.clone(),
             dailyRevenue: dailyProtocolRevenue.clone(),
             dailyProtocolRevenue,
-            dailySupplySideRevenue: borrowInterestFees.clone(),
+            dailySupplySideRevenue: borrowInterestSupplySideRevenue.clone(),
         };
     }
 
@@ -375,6 +575,98 @@ const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
         borrowInterestFees.add(position.loanToken, accruedDuringPeriod.toString(), METRIC.BORROW_INTEREST);
     });
 
+    if (v3Escrows.length) {
+        const fromBlock = await options.getFromBlock();
+        const toBlock = await options.getToBlock();
+        const v3Positions = await getTristeroV3MarginPositions(options, v3Escrows, toBlock);
+        const relevantV3Positions = v3Positions.filter((position) =>
+            position.openBlock <= toBlock
+            && (position.closeBlock === undefined || position.closeBlock >= fromBlock)
+        );
+
+        const startBlockByPosition = new Map<string, number>();
+        relevantV3Positions.forEach((position) => {
+            startBlockByPosition.set(
+                getV3PositionKey(position),
+                position.openBlock > fromBlock ? position.openBlock : fromBlock,
+            );
+        });
+        const startBlocks = relevantV3Positions.map((position) => ({
+            position,
+            block: startBlockByPosition.get(getV3PositionKey(position))!,
+        }));
+        const startSnapshots = await getTristeroV3MarginPositionSnapshots(
+            options,
+            v3Escrows,
+            startBlocks.map(({ position, block }) => ({
+                escrow: position.escrow,
+                positionId: position.positionId,
+                block,
+            })),
+        );
+        const startSnapshotByPositionBlock = new Map<string, TristeroV3MarginPosition>();
+        startSnapshots.forEach(({ position, block }) => {
+            startSnapshotByPositionBlock.set(getV3HistoricalValueKey(position, block), position);
+        });
+        const startPositionBlocks = startBlocks.map(({ position, block }) => {
+            const snapshot = startSnapshotByPositionBlock.get(getV3HistoricalValueKey(position, block));
+            if (!snapshot) {
+                throw new Error(`Missing Tristero v3 start position snapshot for ${options.chain} position ${position.positionId} at ${position.escrow} block ${block}`);
+            }
+
+            return { position: snapshot, block };
+        });
+        const closedV3Positions = relevantV3Positions.filter((position) =>
+            position.closeBlock !== undefined
+            && position.closeBlock >= fromBlock
+            && position.closeBlock <= toBlock
+        );
+        const openV3Positions = relevantV3Positions.filter((position) =>
+            position.closeBlock === undefined || position.closeBlock > toBlock
+        );
+
+        const [startLoanValues, endLoanValues, closeRepayments] = await Promise.all([
+            readV3LoanValuesByPositionBlock(options, startPositionBlocks),
+            readV3LoanValuesAtBlock(options, openV3Positions, toBlock),
+            getV3CloseRepayments(options, closedV3Positions),
+        ]);
+
+        relevantV3Positions.forEach((position) => {
+            const startBlock = startBlockByPosition.get(getV3PositionKey(position));
+            if (startBlock === undefined) {
+                throw new Error(`Missing Tristero v3 start block for ${options.chain} position ${position.positionId} at ${position.escrow}`);
+            }
+
+            const startValue = startLoanValues.get(getV3HistoricalValueKey(position, startBlock));
+            if (startValue === undefined) {
+                throw new Error(`Missing Tristero v3 start loan value for ${options.chain} position ${position.positionId} at ${position.escrow}`);
+            }
+
+            const closedInPeriod = position.closeBlock !== undefined
+                && position.closeBlock >= fromBlock
+                && position.closeBlock <= toBlock;
+            const positionKey = getV3PositionKey(position);
+            let endValue: bigint | undefined;
+            if (closedInPeriod) {
+                endValue = closeRepayments.get(positionKey);
+                if (endValue === undefined) {
+                    throw new Error(`Missing Tristero v3 close repayment for ${options.chain} position ${position.positionId} at ${position.escrow}`);
+                }
+            } else {
+                endValue = endLoanValues.get(positionKey);
+            }
+            if (endValue === undefined) {
+                throw new Error(`Missing Tristero v3 end loan value for ${options.chain} position ${position.positionId} at ${position.escrow}`);
+            }
+
+            const accruedDuringPeriod = endValue - startValue;
+            if (accruedDuringPeriod <= 0n) return;
+
+            addToTokenMap(grossBorrowInterestByToken, position.loanAsset, accruedDuringPeriod);
+            borrowInterestFees.add(position.loanAsset, accruedDuringPeriod.toString(), METRIC.BORROW_INTEREST);
+        });
+    }
+
     protocolBorrowInterestByToken.forEach((amount, token) => {
         borrowInterestProtocolRevenue.add(token, amount.toString(), MARGIN_METRICS.BORROW_INTEREST_TO_PROTOCOL);
     });
@@ -409,16 +701,16 @@ const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
 };
 
 const methodology = {
-    Fees: 'Daily borrow interest accrued on open margin positions, plus any protocol-collected liquidation fees.',
-    Revenue: 'Protocol share of margin borrow interest and liquidation fees. The current live staging escrow has protocol borrow fees disabled, so this is usually zero until that parameter changes.',
-    ProtocolRevenue: 'Protocol share of margin borrow interest and liquidation fees. The current live staging escrow has protocol borrow fees disabled, so this is usually zero until that parameter changes.',
+    Fees: 'Daily borrow interest accrued on legacy and v3 margin positions, plus any legacy protocol-collected liquidation fees.',
+    Revenue: 'Protocol share of legacy margin borrow interest and liquidation fees. V3 borrow interest is attributed to lenders unless a protocol fee event is introduced.',
+    ProtocolRevenue: 'Protocol share of legacy margin borrow interest and liquidation fees. V3 borrow interest is attributed to lenders unless a protocol fee event is introduced.',
     SupplySideRevenue: 'Borrow interest attributable to the filler lenders that funded margin positions.',
 };
 
 const breakdownMethodology = {
     Fees: {
-        [METRIC.BORROW_INTEREST]: 'Borrow interest accrued during the day across active, closed, and liquidated margin positions.',
-        [METRIC.LIQUIDATION_FEES]: 'Protocol-collected liquidation fees.',
+        [METRIC.BORROW_INTEREST]: 'Borrow interest accrued during the day across active, closed, and liquidated legacy positions, plus v3 vault loan-value growth and close repayments.',
+        [METRIC.LIQUIDATION_FEES]: 'Legacy protocol-collected liquidation fees.',
     },
     Revenue: {
         [MARGIN_METRICS.BORROW_INTEREST_TO_PROTOCOL]: 'Protocol share of borrow interest.',
@@ -435,7 +727,12 @@ const breakdownMethodology = {
 };
 const adapter: SimpleAdapter = {
     version: 2,
-    adapter: TRISTERO_MARGIN_CONFIGS,
+    adapter: Object.fromEntries(
+        getTristeroMarginChains().map((chain) => [
+            chain,
+            { start: getTristeroMarginChainStart(chain) },
+        ])
+    ),
     fetch,
     pullHourly: true,
     methodology,

--- a/fees/tristero-margin.ts
+++ b/fees/tristero-margin.ts
@@ -238,11 +238,10 @@ async function getV3CloseRepayments(
         const requestedTxHash = normalizeAddress(txHashes[index]);
         const receipt = cachedReceipt ?? await getV3CloseReceipt(options.chain, requestedTxHash);
         if (!receipt) {
-            sdk.log(`Missing Tristero v3 close receipt for ${options.chain} tx ${requestedTxHash}; using zero close repayment fallback`);
-            (positionsByTxHash.get(requestedTxHash) ?? []).forEach((position) => {
-                repaymentByPosition.set(getV3PositionKey(position), 0n);
-            });
-            continue;
+            const affectedPositions = (positionsByTxHash.get(requestedTxHash) ?? [])
+                .map(getV3PositionKey)
+                .join(", ") || "none";
+            throw new Error(`Missing Tristero v3 close receipt for ${options.chain} tx ${requestedTxHash}; affected positions: ${affectedPositions}`);
         }
 
         const txHash = normalizeAddress(receipt.transactionHash ?? receipt.hash);
@@ -739,7 +738,7 @@ const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
 };
 
 const methodology = {
-    Fees: 'Daily borrow interest accrued on legacy and v3 margin positions, plus any legacy protocol-collected liquidation fees.',
+    Fees: 'Daily borrow interest accrued on legacy and v3 margin positions, including v3 vault loan-value growth, v3 reduction (PositionReduced) repayments, and close repayments, plus any legacy protocol-collected liquidation fees.',
     Revenue: 'Protocol share of legacy margin borrow interest and liquidation fees. V3 borrow interest is attributed to lenders unless a protocol fee event is introduced.',
     ProtocolRevenue: 'Protocol share of legacy margin borrow interest and liquidation fees. V3 borrow interest is attributed to lenders unless a protocol fee event is introduced.',
     SupplySideRevenue: 'Borrow interest attributable to the filler lenders that funded margin positions.',
@@ -747,7 +746,7 @@ const methodology = {
 
 const breakdownMethodology = {
     Fees: {
-        [METRIC.BORROW_INTEREST]: 'Borrow interest accrued during the day across active, closed, and liquidated legacy positions, plus v3 vault loan-value growth and close repayments.',
+        [METRIC.BORROW_INTEREST]: 'Borrow interest accrued during the day across active, closed, and liquidated legacy positions, plus v3 vault loan-value growth, v3 reduction (PositionReduced) repayments, and close repayments.',
         [METRIC.LIQUIDATION_FEES]: 'Legacy protocol-collected liquidation fees.',
     },
     Revenue: {

--- a/fees/tristero-margin.ts
+++ b/fees/tristero-margin.ts
@@ -35,6 +35,7 @@ const MARGIN_METRICS = {
     BORROW_INTEREST_TO_LENDERS: 'Borrow Interest To Lenders',
     LIQUIDATION_FEES_TO_PROTOCOL: 'Liquidation Fees To Protocol',
 } as const;
+const MULTICALL_FALLBACK_BATCH_SIZE = 5;
 
 type ProtocolFeeLog = {
     token: string;
@@ -131,7 +132,15 @@ async function permitFailureMultiCallWithFallback(
     }
 
     const block = params.block ?? api.block;
-    return Promise.all(params.calls.map(async (call, index) => {
+    const outputs: any[] = [];
+    for (let offset = 0; offset < params.calls.length; offset += MULTICALL_FALLBACK_BATCH_SIZE) {
+        const batch = params.calls.slice(offset, offset + MULTICALL_FALLBACK_BATCH_SIZE);
+        outputs.push(...await Promise.all(batch.map((call, batchIndex) => readFallbackCall(call, offset + batchIndex))));
+    }
+
+    return outputs;
+
+    async function readFallbackCall(call: PermitFailureMultiCallParams["calls"][number], index: number): Promise<any | null> {
         const target = call.target ?? params.target;
         if (!target) {
             sdk.log(`Tristero multicall fallback missing target on ${options.chain} ${context} call ${index}`);
@@ -151,7 +160,7 @@ async function permitFailureMultiCallWithFallback(
             sdk.log(`Tristero multicall fallback failed on ${options.chain} ${context} call ${index} target ${target}: ${formatErrorMessage(error)}`);
             return null;
         }
-    }));
+    }
 }
 
 async function readV3LoanValuesAtBlock(

--- a/fees/tristero-margin.ts
+++ b/fees/tristero-margin.ts
@@ -748,6 +748,9 @@ const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
                     throw new Error(`Missing Tristero v3 close repayment for ${options.chain} position ${position.positionId} at ${position.escrow}`);
                 }
                 totalRepaid += closeRepayment;
+                if (totalRepaid < startValue) {
+                    throw new Error(`Incomplete Tristero v3 repayment attribution for ${options.chain} position ${position.positionId} at ${position.escrow}: repaid ${totalRepaid} < start debt ${startValue}`);
+                }
                 terminalDebt = 0n;
             } else {
                 terminalDebt = endLoanValues.get(positionKey);

--- a/fees/tristero-margin.ts
+++ b/fees/tristero-margin.ts
@@ -10,6 +10,7 @@ import {
     getTristeroMarginChains,
     getTristeroV3MarginPositions,
     getTristeroV3MarginPositionSnapshots,
+    getTristeroV3MarginReductions,
     getV3PositionKey,
     getPositionIds,
     mulDivCeil,
@@ -98,6 +99,17 @@ function isNonZeroBytes32(value?: string): boolean {
     return BigInt(value) > 0n;
 }
 
+function formatErrorMessage(error: unknown): string {
+    return error instanceof Error ? error.message : String(error);
+}
+
+function formatV3ReadValueContext(positions: TristeroV3MarginPosition[]): string {
+    return positions
+        .slice(0, 3)
+        .map((position) => `${position.vault}/${position.loanAsset}/${position.loanShares.toString()}`)
+        .join(", ");
+}
+
 async function readV3LoanValuesAtBlock(
     options: FetchOptions,
     positions: TristeroV3MarginPosition[],
@@ -115,7 +127,8 @@ async function readV3LoanValuesAtBlock(
                 block,
                 permitFailure: true,
             });
-        } catch {
+        } catch (error) {
+            sdk.log(`Tristero v3 multicall readValue failed on ${options.chain} at block ${block} for ${positions.length} positions (${formatV3ReadValueContext(positions)}): ${formatErrorMessage(error)}`);
             values = [];
         }
     }
@@ -151,7 +164,8 @@ async function readV3LoanValueAtBlock(
         });
 
         return toBigIntOrNull(output);
-    } catch {
+    } catch (error) {
+        sdk.log(`Tristero v3 single readValue failed on ${options.chain} position ${position.positionId} at ${position.escrow} block ${block}: ${formatErrorMessage(error)}`);
         return null;
     }
 }
@@ -179,6 +193,25 @@ async function readV3LoanValuesByPositionBlock(
 
 function getV3HistoricalValueKey(position: { escrow: string; positionId: number }, block: number): string {
     return `${getV3PositionKey(position)}-${block}`;
+}
+
+function getV3ReductionRepayments(
+    reductions: Awaited<ReturnType<typeof getTristeroV3MarginReductions>>,
+    startBlockByPosition: Map<string, number>,
+    toBlock: number,
+): Map<string, bigint> {
+    const repayments = new Map<string, bigint>();
+
+    reductions.forEach((reduction) => {
+        const positionKey = getV3PositionKey(reduction);
+        const startBlock = startBlockByPosition.get(positionKey);
+        if (startBlock === undefined) return;
+        if (reduction.blockNumber < startBlock || reduction.blockNumber > toBlock) return;
+
+        repayments.set(positionKey, (repayments.get(positionKey) ?? 0n) + reduction.repayAmount);
+    });
+
+    return repayments;
 }
 
 async function getV3CloseRepayments(
@@ -625,11 +658,13 @@ const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
             position.closeBlock === undefined || position.closeBlock > toBlock
         );
 
-        const [startLoanValues, endLoanValues, closeRepayments] = await Promise.all([
+        const [startLoanValues, endLoanValues, closeRepayments, reductions] = await Promise.all([
             readV3LoanValuesByPositionBlock(options, startPositionBlocks),
             readV3LoanValuesAtBlock(options, openV3Positions, toBlock),
             getV3CloseRepayments(options, closedV3Positions),
+            getTristeroV3MarginReductions(options, v3Escrows, fromBlock, toBlock),
         ]);
+        const reductionRepayments = getV3ReductionRepayments(reductions, startBlockByPosition, toBlock);
 
         relevantV3Positions.forEach((position) => {
             const startBlock = startBlockByPosition.get(getV3PositionKey(position));
@@ -646,20 +681,23 @@ const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
                 && position.closeBlock >= fromBlock
                 && position.closeBlock <= toBlock;
             const positionKey = getV3PositionKey(position);
-            let endValue: bigint | undefined;
+            let terminalDebt: bigint | undefined;
+            let totalRepaid = reductionRepayments.get(positionKey) ?? 0n;
             if (closedInPeriod) {
-                endValue = closeRepayments.get(positionKey);
-                if (endValue === undefined) {
+                const closeRepayment = closeRepayments.get(positionKey);
+                if (closeRepayment === undefined) {
                     throw new Error(`Missing Tristero v3 close repayment for ${options.chain} position ${position.positionId} at ${position.escrow}`);
                 }
+                totalRepaid += closeRepayment;
+                terminalDebt = 0n;
             } else {
-                endValue = endLoanValues.get(positionKey);
+                terminalDebt = endLoanValues.get(positionKey);
             }
-            if (endValue === undefined) {
+            if (terminalDebt === undefined) {
                 throw new Error(`Missing Tristero v3 end loan value for ${options.chain} position ${position.positionId} at ${position.escrow}`);
             }
 
-            const accruedDuringPeriod = endValue - startValue;
+            const accruedDuringPeriod = terminalDebt + totalRepaid - startValue;
             if (accruedDuringPeriod <= 0n) return;
 
             addToTokenMap(grossBorrowInterestByToken, position.loanAsset, accruedDuringPeriod);

--- a/fees/tristero-margin.ts
+++ b/fees/tristero-margin.ts
@@ -309,6 +309,10 @@ async function getV3CloseRepayments(
         }
 
         const position = positions[0];
+        if (!normalizeAddress(position.closeFiller)) {
+            throw new Error(`Missing Tristero v3 close filler for ${options.chain} position ${position.positionId} at ${position.escrow} tx ${txHash}`);
+        }
+
         let repayment = 0n;
         (receipt.logs ?? []).forEach((log: any) => {
             const topics = log.topics ?? [];

--- a/helpers/tristeroMargin.ts
+++ b/helpers/tristeroMargin.ts
@@ -172,14 +172,25 @@ type TristeroV3PositionStruct = {
 type TristeroV3ReducedPositionLog = {
   positionId: number;
   taker: string;
+  repayAmount: bigint;
   position: TristeroV3PositionStruct;
   blockNumber: number;
   logIndex: number;
+  txHash?: string;
 };
 
 type TristeroV3ClosedPositionLog = {
   positionId: number;
   filler: string;
+  blockNumber: number;
+  logIndex: number;
+  txHash?: string;
+};
+
+export type TristeroV3MarginReduction = {
+  escrow: string;
+  positionId: number;
+  repayAmount: bigint;
   blockNumber: number;
   logIndex: number;
   txHash?: string;
@@ -346,17 +357,20 @@ function normalizeV3PositionOpenedLog(log: any, config: TristeroV3MarginEscrowCo
 function normalizeV3PositionReducedLog(log: any): TristeroV3ReducedPositionLog | null {
   const args = log?.args ?? log;
   const positionId = args?.positionId ?? args?.[0];
+  const repayAmount = toBigIntOrNull(args?.repayAmount ?? args?.[2]);
   const blockNumber = log?.blockNumber;
   const position = normalizeV3PositionStruct(args?.position ?? args?.[4]);
 
-  if (positionId === null || positionId === undefined || !position || blockNumber === null || blockNumber === undefined) return null;
+  if (positionId === null || positionId === undefined || repayAmount === null || !position || blockNumber === null || blockNumber === undefined) return null;
 
   return {
     positionId: toPositionId(positionId),
     taker: normalizeAddress(args?.taker ?? args?.[1]),
+    repayAmount,
     position,
     blockNumber: Number(blockNumber),
     logIndex: getLogIndex(log),
+    txHash: getLogTxHash(log),
   };
 }
 
@@ -378,6 +392,38 @@ function normalizeV3PositionClosedLog(log: any): TristeroV3ClosedPositionLog | n
 
 function cloneV3MarginPosition(position: TristeroV3MarginPosition): TristeroV3MarginPosition {
   return { ...position };
+}
+
+function stringifyV3LogContext(log: any): string {
+  try {
+    return JSON.stringify(log, (_key, value) => typeof value === 'bigint' ? value.toString() : value).slice(0, 1000);
+  } catch {
+    return '[unserializable log]';
+  }
+}
+
+function malformedV3LogError(eventName: string, config: TristeroV3MarginEscrowConfig, log: any): Error {
+  return new Error(
+    `Unable to normalize Tristero v3 ${eventName} log for ${config.address.toLowerCase()} at block ${String(log?.blockNumber)} logIndex ${String(getLogIndex(log))}: ${stringifyV3LogContext(log)}`
+  );
+}
+
+function requireV3PositionOpenedLog(log: any, config: TristeroV3MarginEscrowConfig): TristeroV3MarginPosition {
+  const position = normalizeV3PositionOpenedLog(log, config);
+  if (!position) throw malformedV3LogError('PositionOpened', config, log);
+  return position;
+}
+
+function requireV3PositionReducedLog(log: any, config: TristeroV3MarginEscrowConfig): TristeroV3ReducedPositionLog {
+  const reducedLog = normalizeV3PositionReducedLog(log);
+  if (!reducedLog) throw malformedV3LogError('PositionReduced', config, log);
+  return reducedLog;
+}
+
+function requireV3PositionClosedLog(log: any, config: TristeroV3MarginEscrowConfig): TristeroV3ClosedPositionLog {
+  const closedLog = normalizeV3PositionClosedLog(log);
+  if (!closedLog) throw malformedV3LogError('PositionClosed', config, log);
+  return closedLog;
 }
 
 async function getV3EscrowStartBlock(chain: string, start: string): Promise<number> {
@@ -453,16 +499,16 @@ export async function getTristeroV3MarginPositionSnapshots(
 
     const positionEvents = [
       ...(openedLogs as any[]).flatMap((log) => {
-        const position = normalizeV3PositionOpenedLog(log, config);
-        return position ? [{ type: 'opened' as const, blockNumber: position.openBlock, logIndex: getLogIndex(log), position }] : [];
+        const position = requireV3PositionOpenedLog(log, config);
+        return [{ type: 'opened' as const, blockNumber: position.openBlock, logIndex: getLogIndex(log), position }];
       }),
       ...(reducedLogs as any[]).flatMap((log) => {
-        const reducedLog = normalizeV3PositionReducedLog(log);
-        return reducedLog ? [{ type: 'reduced' as const, ...reducedLog }] : [];
+        const reducedLog = requireV3PositionReducedLog(log, config);
+        return [{ type: 'reduced' as const, ...reducedLog }];
       }),
       ...(closedLogs as any[]).flatMap((log) => {
-        const closedLog = normalizeV3PositionClosedLog(log);
-        return closedLog ? [{ type: 'closed' as const, ...closedLog }] : [];
+        const closedLog = requireV3PositionClosedLog(log, config);
+        return [{ type: 'closed' as const, ...closedLog }];
       }),
     ].sort((a, b) => a.blockNumber - b.blockNumber || a.logIndex - b.logIndex);
 
@@ -501,7 +547,7 @@ export async function getTristeroV3MarginPositionSnapshots(
       }
 
       const snapshot = positionsByKey.get(getV3PositionKey(request));
-      if (snapshot) {
+      if (snapshot && (snapshot.closeBlock === undefined || snapshot.closeBlock > request.block)) {
         snapshots.push({
           ...request,
           position: cloneV3MarginPosition(snapshot),
@@ -564,19 +610,18 @@ export async function getTristeroV3MarginPositions(
     ]);
 
     (openedLogs as any[]).forEach((log) => {
-      const position = normalizeV3PositionOpenedLog(log, config);
-      if (!position) return;
+      const position = requireV3PositionOpenedLog(log, config);
       positionsByKey.set(getV3PositionKey(position), position);
     });
 
     const positionStateLogs = [
       ...(reducedLogs as any[]).flatMap((log) => {
-        const reducedLog = normalizeV3PositionReducedLog(log);
-        return reducedLog ? [{ type: 'reduced' as const, ...reducedLog }] : [];
+        const reducedLog = requireV3PositionReducedLog(log, config);
+        return [{ type: 'reduced' as const, ...reducedLog }];
       }),
       ...(closedLogs as any[]).flatMap((log) => {
-        const closedLog = normalizeV3PositionClosedLog(log);
-        return closedLog ? [{ type: 'closed' as const, ...closedLog }] : [];
+        const closedLog = requireV3PositionClosedLog(log, config);
+        return [{ type: 'closed' as const, ...closedLog }];
       }),
     ].sort((a, b) => a.blockNumber - b.blockNumber || a.logIndex - b.logIndex);
 
@@ -603,6 +648,56 @@ export async function getTristeroV3MarginPositions(
   }
 
   return Array.from(positionsByKey.values());
+}
+
+/**
+ * Reads v3 PositionReduced events and returns the loan-asset repayment amount
+ * emitted by the escrow for each reduction.
+ *
+ * @param options DefiLlama fetch options for the current chain/window.
+ * @param configs Active v3 escrow/vault configs to scan.
+ * @param fromBlock First block to include.
+ * @param toBlock Last block to include.
+ * @returns Reduction repayment events keyed by escrow/position id.
+ */
+export async function getTristeroV3MarginReductions(
+  options: FetchOptions,
+  configs: TristeroV3MarginEscrowConfig[],
+  fromBlock: number,
+  toBlock: number,
+): Promise<TristeroV3MarginReduction[]> {
+  const reductions: TristeroV3MarginReduction[] = [];
+  if (!configs.length || fromBlock > toBlock) return reductions;
+
+  for (const config of configs) {
+    const startBlock = await getV3EscrowStartBlock(options.chain, config.start);
+    const queryFromBlock = Math.max(startBlock, fromBlock);
+    if (queryFromBlock > toBlock) continue;
+
+    const reducedLogs = await options.getLogs({
+      target: config.address,
+      eventAbi: TRISTERO_V3_MARGIN_ABI.positionReduced,
+      fromBlock: queryFromBlock,
+      toBlock,
+      entireLog: true,
+      parseLog: true,
+      cacheInCloud: true,
+    });
+
+    (reducedLogs as any[]).forEach((log) => {
+      const reducedLog = requireV3PositionReducedLog(log, config);
+      reductions.push({
+        escrow: config.address.toLowerCase(),
+        positionId: reducedLog.positionId,
+        repayAmount: reducedLog.repayAmount,
+        blockNumber: reducedLog.blockNumber,
+        logIndex: reducedLog.logIndex,
+        txHash: reducedLog.txHash,
+      });
+    });
+  }
+
+  return reductions;
 }
 
 /**

--- a/helpers/tristeroMargin.ts
+++ b/helpers/tristeroMargin.ts
@@ -1,5 +1,6 @@
 import { FetchOptions } from "../adapters/types";
 import { CHAIN } from "./chains";
+import { getBlock } from "./getBlock";
 
 type TristeroMarginEscrowConfig = {
   address: string;
@@ -10,6 +11,18 @@ type TristeroMarginEscrowConfig = {
 type TristeroMarginChainConfig = {
   start: string;
   escrows: TristeroMarginEscrowConfig[];
+};
+
+export type TristeroV3MarginEscrowConfig = {
+  address: string;
+  vault: string;
+  start: string;
+  end?: string;
+};
+
+type TristeroV3MarginChainConfig = {
+  start: string;
+  escrows: TristeroV3MarginEscrowConfig[];
 };
 
 export const TRISTERO_MARGIN_CONFIGS: Record<string, TristeroMarginChainConfig> = {
@@ -36,18 +49,57 @@ export const TRISTERO_MARGIN_CONFIGS: Record<string, TristeroMarginChainConfig> 
   },
 } as const;
 
+export const TRISTERO_V3_MARGIN_CONFIGS: Record<string, TristeroV3MarginChainConfig> = {
+  [CHAIN.ARBITRUM]: {
+    start: '2026-05-21',
+    escrows: [
+      {
+        address: '0x969D1eAb4C39706692d14894924245ca1Fe7cBCe',
+        vault: '0xd329330475126E0Fd0b955C385eaf5de4B684802',
+        start: '2026-05-21',
+      },
+    ],
+  },
+  [CHAIN.BASE]: {
+    start: '2026-05-21',
+    escrows: [
+      {
+        address: '0x969D1eAb4C39706692d14894924245ca1Fe7cBCe',
+        vault: '0xd329330475126E0Fd0b955C385eaf5de4B684802',
+        start: '2026-05-21',
+      },
+    ],
+  },
+} as const;
+
 export function getTristeroMarginChains(): string[] {
-  return Object.keys(TRISTERO_MARGIN_CONFIGS);
+  return Array.from(new Set([
+    ...Object.keys(TRISTERO_MARGIN_CONFIGS),
+    ...Object.keys(TRISTERO_V3_MARGIN_CONFIGS),
+  ]));
 }
 
 export function getTristeroMarginChainStart(chain: string): string | undefined {
-  return TRISTERO_MARGIN_CONFIGS[chain]?.start;
+  const starts = [TRISTERO_MARGIN_CONFIGS[chain]?.start, TRISTERO_V3_MARGIN_CONFIGS[chain]?.start].filter(Boolean) as string[];
+  return starts.sort()[0];
 }
 
 export function getActiveTristeroMarginEscrows(chain: string, date: string): string[] {
   return (TRISTERO_MARGIN_CONFIGS[chain]?.escrows ?? [])
     .filter(({ start, end }) => date >= start && (!end || date <= end))
     .map(({ address }) => address);
+}
+
+/**
+ * Returns v3 margin escrows that should be included for a chain/date window.
+ *
+ * @param chain DefiLlama chain slug used by the adapter runner.
+ * @param date Adapter date string in YYYY-MM-DD format.
+ * @returns V3 margin escrow/vault configs whose start/end range includes date.
+ */
+export function getActiveTristeroV3MarginEscrows(chain: string, date: string): TristeroV3MarginEscrowConfig[] {
+  return (TRISTERO_V3_MARGIN_CONFIGS[chain]?.escrows ?? [])
+    .filter(({ start, end }) => date >= start && (!end || date <= end));
 }
 
 export const TRISTERO_MARGIN_ABI = {
@@ -60,6 +112,14 @@ export const TRISTERO_MARGIN_ABI = {
   protocolFeeCollected: 'event ProtocolFeeCollected(uint128 indexed positionId, address indexed token, uint256 amount)',
 } as const;
 
+export const TRISTERO_V3_MARGIN_ABI = {
+  ownerOf: 'function ownerOf(uint256 tokenId) view returns (address)',
+  readValue: 'function readValue(address token, uint256 shares) view returns (uint256)',
+  positionOpened: 'event PositionOpened(uint128 indexed positionId, address indexed taker, address indexed filler, (address underlyingAsset, address loanAsset, uint256 notionalShares, uint256 loanShares, uint256 RPS, uint256 lastUpdate) position)',
+  positionReduced: 'event PositionReduced(uint128 indexed positionId, address indexed taker, uint256 repayAmount, uint256 collateralOut, (address underlyingAsset, address loanAsset, uint256 notionalShares, uint256 loanShares, uint256 RPS, uint256 lastUpdate) position)',
+  positionClosed: 'event PositionClosed(uint128 indexed positionId, address indexed filler)',
+} as const;
+
 export interface TristeroMarginPosition {
   taker: string;
   filler: string;
@@ -69,6 +129,61 @@ export interface TristeroMarginPosition {
   loanAmount: bigint;
   liqPrice: bigint;
 }
+
+export interface TristeroV3MarginPosition {
+  escrow: string;
+  vault: string;
+  positionId: number;
+  taker: string;
+  filler: string;
+  underlyingAsset: string;
+  loanAsset: string;
+  notionalShares: bigint;
+  loanShares: bigint;
+  rps: bigint;
+  lastUpdate: bigint;
+  openBlock: number;
+  // PositionClosed is terminal in current v3. Partial changes emit PositionReduced
+  // and update the remaining share fields without setting these close fields.
+  closeBlock?: number;
+  closeTxHash?: string;
+  closeFiller?: string;
+}
+
+export type TristeroV3MarginPositionSnapshotRequest = {
+  escrow: string;
+  positionId: number;
+  block: number;
+};
+
+export type TristeroV3MarginPositionSnapshot = TristeroV3MarginPositionSnapshotRequest & {
+  position: TristeroV3MarginPosition;
+};
+
+type TristeroV3PositionStruct = {
+  underlyingAsset: string;
+  loanAsset: string;
+  notionalShares: bigint;
+  loanShares: bigint;
+  rps: bigint;
+  lastUpdate: bigint;
+};
+
+type TristeroV3ReducedPositionLog = {
+  positionId: number;
+  taker: string;
+  position: TristeroV3PositionStruct;
+  blockNumber: number;
+  logIndex: number;
+};
+
+type TristeroV3ClosedPositionLog = {
+  positionId: number;
+  filler: string;
+  blockNumber: number;
+  logIndex: number;
+  txHash?: string;
+};
 
 export function toBigIntSafe(value: any): bigint {
   if (value === null || value === undefined) {
@@ -94,6 +209,16 @@ export function getPositionIds(totalPositions: any): number[] {
   if (totalPositions === null || totalPositions === undefined) return [];
   const total = Number(toBigIntSafe(totalPositions));
   return Array.from({ length: total }, (_, index) => index + 1);
+}
+
+/**
+ * Builds the stable map key used to join v3 position event state across helpers.
+ *
+ * @param positionRef Escrow address and numeric v3 position id.
+ * @returns Lowercase escrow and position id joined into a unique key.
+ */
+export function getV3PositionKey({ escrow, positionId }: { escrow: string; positionId: number }): string {
+  return `${escrow.toLowerCase()}-${positionId}`;
 }
 
 export function mulDivCeil(a: bigint, b: bigint, denominator: bigint): bigint {
@@ -162,4 +287,357 @@ export async function getAccumulatedInterestAtBlock(options: FetchOptions, escro
   });
 
   return toBigIntOrNull(interest) ?? 0n;
+}
+
+function normalizeAddress(value?: string | null): string {
+  return value?.toLowerCase() ?? "";
+}
+
+function getLogTxHash(log: any): string | undefined {
+  return log?.transactionHash ?? log?.transaction_hash ?? log?.txHash;
+}
+
+function getLogIndex(log: any): number {
+  const value = log?.logIndex ?? log?.log_index ?? log?.index ?? 0;
+  return Number(value);
+}
+
+function normalizeV3PositionStruct(position: any): TristeroV3PositionStruct | null {
+  const underlyingAsset = position.underlyingAsset ?? position[0];
+  const loanAsset = position.loanAsset ?? position[1];
+  const notionalShares = toBigIntOrNull(position.notionalShares ?? position[2]);
+  const loanShares = toBigIntOrNull(position.loanShares ?? position[3]);
+  const rps = toBigIntOrNull(position.RPS ?? position.rps ?? position[4]);
+  const lastUpdate = toBigIntOrNull(position.lastUpdate ?? position[5]);
+
+  if (!underlyingAsset || !loanAsset || notionalShares === null || loanShares === null || rps === null || lastUpdate === null) {
+    return null;
+  }
+
+  return {
+    underlyingAsset: normalizeAddress(underlyingAsset),
+    loanAsset: normalizeAddress(loanAsset),
+    notionalShares,
+    loanShares,
+    rps,
+    lastUpdate,
+  };
+}
+
+function normalizeV3PositionOpenedLog(log: any, config: TristeroV3MarginEscrowConfig): TristeroV3MarginPosition | null {
+  const args = log?.args ?? log;
+  const positionId = args?.positionId ?? args?.[0];
+  const blockNumber = log?.blockNumber;
+  const position = normalizeV3PositionStruct(args?.position ?? args?.[3]);
+
+  if (positionId === null || positionId === undefined || !position || blockNumber === null || blockNumber === undefined) return null;
+
+  return {
+    escrow: config.address.toLowerCase(),
+    vault: config.vault.toLowerCase(),
+    positionId: toPositionId(positionId),
+    taker: normalizeAddress(args?.taker ?? args?.[1]),
+    filler: normalizeAddress(args?.filler ?? args?.[2]),
+    ...position,
+    openBlock: Number(blockNumber),
+  };
+}
+
+function normalizeV3PositionReducedLog(log: any): TristeroV3ReducedPositionLog | null {
+  const args = log?.args ?? log;
+  const positionId = args?.positionId ?? args?.[0];
+  const blockNumber = log?.blockNumber;
+  const position = normalizeV3PositionStruct(args?.position ?? args?.[4]);
+
+  if (positionId === null || positionId === undefined || !position || blockNumber === null || blockNumber === undefined) return null;
+
+  return {
+    positionId: toPositionId(positionId),
+    taker: normalizeAddress(args?.taker ?? args?.[1]),
+    position,
+    blockNumber: Number(blockNumber),
+    logIndex: getLogIndex(log),
+  };
+}
+
+function normalizeV3PositionClosedLog(log: any): TristeroV3ClosedPositionLog | null {
+  const args = log?.args ?? log;
+  const positionId = args?.positionId ?? args?.[0];
+  const blockNumber = log?.blockNumber;
+
+  if (positionId === null || positionId === undefined || blockNumber === null || blockNumber === undefined) return null;
+
+  return {
+    positionId: toPositionId(positionId),
+    filler: normalizeAddress(args?.filler ?? args?.[1]),
+    blockNumber: Number(blockNumber),
+    logIndex: getLogIndex(log),
+    txHash: getLogTxHash(log),
+  };
+}
+
+function cloneV3MarginPosition(position: TristeroV3MarginPosition): TristeroV3MarginPosition {
+  return { ...position };
+}
+
+async function getV3EscrowStartBlock(chain: string, start: string): Promise<number> {
+  const timestamp = Math.floor(new Date(`${start}T00:00:00Z`).getTime() / 1000);
+  const block = await getBlock(timestamp, chain);
+  if (block === null || block === undefined) {
+    throw new Error(`Unable to resolve Tristero v3 margin escrow start block for ${chain} at ${start}`);
+  }
+
+  return Number(block);
+}
+
+/**
+ * Reconstructs v3 margin position snapshots at specific historical blocks.
+ *
+ * The returned positions preserve the loan/notional share state as of the
+ * requested block, so fee adapters can value historical boundaries without
+ * reusing the end-of-window mutated position state.
+ *
+ * @param options DefiLlama fetch options for the current chain/window.
+ * @param configs Active v3 escrow/vault configs to scan.
+ * @param requests Escrow, position id, and block tuples to snapshot.
+ * @returns Position snapshots for requests that existed by the requested block.
+ */
+export async function getTristeroV3MarginPositionSnapshots(
+  options: FetchOptions,
+  configs: TristeroV3MarginEscrowConfig[],
+  requests: TristeroV3MarginPositionSnapshotRequest[],
+): Promise<TristeroV3MarginPositionSnapshot[]> {
+  const snapshots: TristeroV3MarginPositionSnapshot[] = [];
+  if (!requests.length) return snapshots;
+
+  for (const config of configs) {
+    const configRequests = requests
+      .filter((request) => request.escrow.toLowerCase() === config.address.toLowerCase())
+      .map((request) => ({ ...request, escrow: request.escrow.toLowerCase() }))
+      .sort((a, b) => a.block - b.block);
+    if (!configRequests.length) continue;
+
+    const maxBlock = Math.max(...configRequests.map((request) => request.block));
+    const startBlock = await getV3EscrowStartBlock(options.chain, config.start);
+    if (startBlock > maxBlock) continue;
+
+    const [openedLogs, reducedLogs, closedLogs] = await Promise.all([
+      options.getLogs({
+        target: config.address,
+        eventAbi: TRISTERO_V3_MARGIN_ABI.positionOpened,
+        fromBlock: startBlock,
+        toBlock: maxBlock,
+        entireLog: true,
+        parseLog: true,
+        cacheInCloud: true,
+      }),
+      options.getLogs({
+        target: config.address,
+        eventAbi: TRISTERO_V3_MARGIN_ABI.positionReduced,
+        fromBlock: startBlock,
+        toBlock: maxBlock,
+        entireLog: true,
+        parseLog: true,
+        cacheInCloud: true,
+      }),
+      options.getLogs({
+        target: config.address,
+        eventAbi: TRISTERO_V3_MARGIN_ABI.positionClosed,
+        fromBlock: startBlock,
+        toBlock: maxBlock,
+        entireLog: true,
+        parseLog: true,
+        cacheInCloud: true,
+      }),
+    ]);
+
+    const positionEvents = [
+      ...(openedLogs as any[]).flatMap((log) => {
+        const position = normalizeV3PositionOpenedLog(log, config);
+        return position ? [{ type: 'opened' as const, blockNumber: position.openBlock, logIndex: getLogIndex(log), position }] : [];
+      }),
+      ...(reducedLogs as any[]).flatMap((log) => {
+        const reducedLog = normalizeV3PositionReducedLog(log);
+        return reducedLog ? [{ type: 'reduced' as const, ...reducedLog }] : [];
+      }),
+      ...(closedLogs as any[]).flatMap((log) => {
+        const closedLog = normalizeV3PositionClosedLog(log);
+        return closedLog ? [{ type: 'closed' as const, ...closedLog }] : [];
+      }),
+    ].sort((a, b) => a.blockNumber - b.blockNumber || a.logIndex - b.logIndex);
+
+    const positionsByKey = new Map<string, TristeroV3MarginPosition>();
+    let eventIndex = 0;
+
+    configRequests.forEach((request) => {
+      while (eventIndex < positionEvents.length && positionEvents[eventIndex].blockNumber <= request.block) {
+        const event = positionEvents[eventIndex];
+
+        if (event.type === 'opened') {
+          positionsByKey.set(getV3PositionKey(event.position), cloneV3MarginPosition(event.position));
+          eventIndex += 1;
+          continue;
+        }
+
+        const key = getV3PositionKey({ escrow: config.address, positionId: event.positionId });
+        const position = positionsByKey.get(key);
+        if (position) {
+          if (event.type === 'reduced') {
+            position.taker = event.taker;
+            position.underlyingAsset = event.position.underlyingAsset;
+            position.loanAsset = event.position.loanAsset;
+            position.notionalShares = event.position.notionalShares;
+            position.loanShares = event.position.loanShares;
+            position.rps = event.position.rps;
+            position.lastUpdate = event.position.lastUpdate;
+          } else {
+            position.closeBlock = event.blockNumber;
+            position.closeTxHash = event.txHash;
+            position.closeFiller = event.filler;
+          }
+        }
+
+        eventIndex += 1;
+      }
+
+      const snapshot = positionsByKey.get(getV3PositionKey(request));
+      if (snapshot) {
+        snapshots.push({
+          ...request,
+          position: cloneV3MarginPosition(snapshot),
+        });
+      }
+    });
+  }
+
+  return snapshots;
+}
+
+/**
+ * Reconstructs v3 margin positions from PositionOpened and PositionClosed logs.
+ * PositionReduced logs mutate the remaining share state; PositionClosed is terminal.
+ *
+ * @param options DefiLlama fetch options for the current chain/window.
+ * @param configs Active v3 escrow/vault configs to scan.
+ * @param toBlock Last block to include when reconstructing position state.
+ * @returns V3 positions opened up to toBlock, annotated with close data when closed.
+ */
+export async function getTristeroV3MarginPositions(
+  options: FetchOptions,
+  configs: TristeroV3MarginEscrowConfig[],
+  toBlock: number,
+): Promise<TristeroV3MarginPosition[]> {
+  const positionsByKey = new Map<string, TristeroV3MarginPosition>();
+
+  for (const config of configs) {
+    const startBlock = await getV3EscrowStartBlock(options.chain, config.start);
+    if (startBlock > toBlock) continue;
+
+    const [openedLogs, reducedLogs, closedLogs] = await Promise.all([
+      options.getLogs({
+        target: config.address,
+        eventAbi: TRISTERO_V3_MARGIN_ABI.positionOpened,
+        fromBlock: startBlock,
+        toBlock,
+        entireLog: true,
+        parseLog: true,
+        cacheInCloud: true,
+      }),
+      options.getLogs({
+        target: config.address,
+        eventAbi: TRISTERO_V3_MARGIN_ABI.positionReduced,
+        fromBlock: startBlock,
+        toBlock,
+        entireLog: true,
+        parseLog: true,
+        cacheInCloud: true,
+      }),
+      options.getLogs({
+        target: config.address,
+        eventAbi: TRISTERO_V3_MARGIN_ABI.positionClosed,
+        fromBlock: startBlock,
+        toBlock,
+        entireLog: true,
+        parseLog: true,
+        cacheInCloud: true,
+      }),
+    ]);
+
+    (openedLogs as any[]).forEach((log) => {
+      const position = normalizeV3PositionOpenedLog(log, config);
+      if (!position) return;
+      positionsByKey.set(getV3PositionKey(position), position);
+    });
+
+    const positionStateLogs = [
+      ...(reducedLogs as any[]).flatMap((log) => {
+        const reducedLog = normalizeV3PositionReducedLog(log);
+        return reducedLog ? [{ type: 'reduced' as const, ...reducedLog }] : [];
+      }),
+      ...(closedLogs as any[]).flatMap((log) => {
+        const closedLog = normalizeV3PositionClosedLog(log);
+        return closedLog ? [{ type: 'closed' as const, ...closedLog }] : [];
+      }),
+    ].sort((a, b) => a.blockNumber - b.blockNumber || a.logIndex - b.logIndex);
+
+    positionStateLogs.forEach((log) => {
+      const key = getV3PositionKey({ escrow: config.address, positionId: log.positionId });
+      const position = positionsByKey.get(key);
+      if (!position) return;
+
+      if (log.type === 'reduced') {
+        position.taker = log.taker;
+        position.underlyingAsset = log.position.underlyingAsset;
+        position.loanAsset = log.position.loanAsset;
+        position.notionalShares = log.position.notionalShares;
+        position.loanShares = log.position.loanShares;
+        position.rps = log.position.rps;
+        position.lastUpdate = log.position.lastUpdate;
+        return;
+      }
+
+      position.closeBlock = log.blockNumber;
+      position.closeTxHash = log.txHash;
+      position.closeFiller = log.filler;
+    });
+  }
+
+  return Array.from(positionsByKey.values());
+}
+
+/**
+ * Reconstructs currently open v3 margin positions and verifies each NFT owner.
+ *
+ * @param options DefiLlama fetch options for the current chain/window.
+ * @param configs Active v3 escrow/vault configs to scan.
+ * @returns V3 positions that have not emitted PositionClosed by the end block.
+ */
+export async function getOpenTristeroV3MarginPositions(
+  options: FetchOptions,
+  configs: TristeroV3MarginEscrowConfig[],
+): Promise<TristeroV3MarginPosition[]> {
+  if (!configs.length) return [];
+
+  const toBlock = await options.getToBlock();
+  const positions = await getTristeroV3MarginPositions(options, configs, toBlock);
+  const candidates = positions.filter((position) => position.closeBlock === undefined || position.closeBlock > toBlock);
+  if (!candidates.length) return [];
+
+  const owners = await options.toApi.multiCall({
+    abi: TRISTERO_V3_MARGIN_ABI.ownerOf,
+    calls: candidates.map((position) => ({
+      target: position.escrow,
+      params: [position.positionId],
+    })),
+    permitFailure: true,
+  });
+
+  owners.forEach((owner, index) => {
+    if (!normalizeAddress(owner)) {
+      const position = candidates[index];
+      throw new Error(`Unable to read Tristero v3 ownerOf for ${options.chain} position ${position.positionId} at ${position.escrow}`);
+    }
+  });
+
+  return candidates;
 }

--- a/open-interest/tristero-margin.ts
+++ b/open-interest/tristero-margin.ts
@@ -1,45 +1,75 @@
 import { FetchOptions, FetchResultV2, SimpleAdapter } from "../adapters/types";
 import {
     getActiveTristeroMarginEscrows,
+    getActiveTristeroV3MarginEscrows,
+    getOpenTristeroV3MarginPositions,
     getPositionIds,
+    getTristeroMarginChainStart,
+    getTristeroMarginChains,
     normalizePosition,
+    toBigIntOrNull,
     TRISTERO_MARGIN_ABI,
-    TRISTERO_MARGIN_CONFIGS,
+    TRISTERO_V3_MARGIN_ABI,
 } from "../helpers/tristeroMargin";
 
 const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
     const openInterestAtEnd = options.createBalances();
     const escrows = getActiveTristeroMarginEscrows(options.chain, options.dateString);
+    const v3Escrows = getActiveTristeroV3MarginEscrows(options.chain, options.dateString);
 
-    if (!escrows.length) {
+    if (!escrows.length && !v3Escrows.length) {
         return { openInterestAtEnd };
     }
 
-    const totalPositionsPerEscrow = await options.toApi.multiCall({
-        abi: TRISTERO_MARGIN_ABI.totalPositions,
-        calls: escrows.map((escrow) => ({ target: escrow })),
-        permitFailure: true,
-    });
+    if (escrows.length) {
+        const totalPositionsPerEscrow = await options.toApi.multiCall({
+            abi: TRISTERO_MARGIN_ABI.totalPositions,
+            calls: escrows.map((escrow) => ({ target: escrow })),
+        });
 
-    const escrowToPositionIds = totalPositionsPerEscrow.map((totalPositions, index) => ({
-        escrow: escrows[index],
-        positionIds: getPositionIds(totalPositions),
-    }));
+        const escrowToPositionIds = totalPositionsPerEscrow.map((totalPositions, index) => ({
+            escrow: escrows[index],
+            positionIds: getPositionIds(totalPositions),
+        }));
 
-    const positions = await options.toApi.multiCall({
-        abi: TRISTERO_MARGIN_ABI.positions,
-        calls: escrowToPositionIds.flatMap(({ escrow, positionIds }) => positionIds.map((positionId) => ({
-            target: escrow,
-            params: [positionId],
-        }))),
-        permitFailure: true,
-    });
+        const positions = await options.toApi.multiCall({
+            abi: TRISTERO_MARGIN_ABI.positions,
+            calls: escrowToPositionIds.flatMap(({ escrow, positionIds }) => positionIds.map((positionId) => ({
+                target: escrow,
+                params: [positionId],
+            }))),
+        });
 
-    positions.forEach((position: any) => {
-        const normalized = normalizePosition(position);
-        if (!normalized || normalized.size === 0n) return;
-        openInterestAtEnd.add(normalized.token, normalized.size);
-    });
+        positions.forEach((position: any) => {
+            const normalized = normalizePosition(position);
+            if (!normalized || normalized.size === 0n) return;
+            openInterestAtEnd.add(normalized.token, normalized.size);
+        });
+    }
+
+    if (v3Escrows.length) {
+        const v3Positions = await getOpenTristeroV3MarginPositions(options, v3Escrows);
+        const notionals = v3Positions.length
+            ? await options.toApi.multiCall({
+                abi: TRISTERO_V3_MARGIN_ABI.readValue,
+                calls: v3Positions.map((position) => ({
+                    target: position.vault,
+                    params: [position.underlyingAsset, position.notionalShares.toString()],
+                })),
+                permitFailure: true,
+            })
+            : [];
+
+        v3Positions.forEach((position, index) => {
+            const notional = toBigIntOrNull(notionals[index]);
+            if (notional === null) {
+                throw new Error(`Unable to read Tristero v3 notional value for ${options.chain} position ${position.positionId} at ${position.escrow}`);
+            }
+
+            if (notional === 0n) return;
+            openInterestAtEnd.add(position.underlyingAsset, notional);
+        });
+    }
 
     return {
         openInterestAtEnd,
@@ -48,7 +78,12 @@ const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
 
 const adapter: SimpleAdapter = {
     version: 2,
-    adapter: TRISTERO_MARGIN_CONFIGS,
+    adapter: Object.fromEntries(
+        getTristeroMarginChains().map((chain) => [
+            chain,
+            { start: getTristeroMarginChainStart(chain) },
+        ])
+    ),
     fetch,
 };
 


### PR DESCRIPTION
## Summary
- fold Tristero v3 DEX volume into the existing `dexs/tristero` adapter instead of adding a separate adapter
- add v3 margin escrow/vault config and position reconstruction to the existing Tristero margin helper
- extend existing Tristero margin fees and open-interest adapters for v3 margin positions

## Details
- v3 spot volume counts decoded `router.send` transactions for TAKER and CROSS orders
- v3 margin volume counts MARGIN opens, including decoded loan quantity, and escrow close settlement transfers
- v3 margin open interest uses `PositionOpened`/`PositionClosed`, `ownerOf`, and `vault.readValue(underlying, notionalShares)`
- v3 margin fees track lender borrow interest from vault loan-value growth and close repayments

## Validation
- `node node_modules/typescript/bin/tsc --project tsconfig.json --pretty false`
- `node node_modules/.bin/ts-node --transpile-only cli/testAdapter.ts dexs tristero`
- `node node_modules/.bin/ts-node --transpile-only cli/testAdapter.ts fees tristero-margin`
- `node node_modules/.bin/ts-node --transpile-only cli/testAdapter.ts open-interest tristero-margin`

Supersedes #7443.