### PR TITLE
templarfi: add near fees adapter

### DIFF
--- a/fees/templarfi/index.ts
+++ b/fees/templarfi/index.ts
@@ -1,7 +1,7 @@
 import { FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 import { METRIC } from "../../helpers/metrics";
-import { nearViewCall } from "../../helpers/near";
+import { nearView } from "../../helpers/near";
 
 const REGISTRY = "v1.tmplr.near";
 const MS_PER_YEAR = 365 * 24 * 3600 * 1000;
@@ -12,7 +12,7 @@ async function listMarkets(): Promise<string[]> {
   let offset = 0;
   const count = 100;
   while (true) {
-    const batch: string[] = await nearViewCall(REGISTRY, "list_deployments", { offset, count });
+    const batch: string[] = await nearView(REGISTRY, "list_deployments", { offset, count });
     if (!Array.isArray(batch) || batch.length === 0) break;
     deployments.push(...batch);
     if (batch.length < count) break;
@@ -24,10 +24,10 @@ async function listMarkets(): Promise<string[]> {
 }
 
 async function marketInterest(market: string, fromMs: number, toMs: number): Promise<number> {
-  const len: number = await nearViewCall(market, "get_finalized_snapshots_len");
+  const len: number = await nearView(market, "get_finalized_snapshots_len");
   if (!len) return 0;
 
-  const snaps: any[] = await nearViewCall(market, "list_finalized_snapshots", {
+  const snaps: any[] = await nearView(market, "list_finalized_snapshots", {
     offset: Math.max(0, len - SNAPSHOT_PAGE),
     count: Math.min(SNAPSHOT_PAGE, len),
   });
@@ -60,7 +60,7 @@ const fetch = async (options: FetchOptions) => {
 
   await Promise.all(
     markets.map(async (market) => {
-      const config = await nearViewCall(market, "get_configuration");
+      const config = await nearView(market, "get_configuration");
       const yieldWeights = config?.yield_weights;
       const decimals = config?.price_oracle_configuration?.borrow_asset_decimals;
       if (!yieldWeights || decimals === undefined) return;

--- a/fees/templarfi/index.ts
+++ b/fees/templarfi/index.ts
@@ -1,21 +1,16 @@
-import BigNumber from "bignumber.js";
 import { FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 import { METRIC } from "../../helpers/metrics";
 import { nearViewCall } from "../../helpers/near";
 
 const REGISTRY = "v1.tmplr.near";
-
-// Fraction of a year per millisecond
-const YEAR_PER_MS = new BigNumber("0.00000000003168873850681143096456210346");
-
+const MS_PER_YEAR = 365 * 24 * 3600 * 1000;
 const SNAPSHOT_PAGE = 200;
 
 async function listMarkets(): Promise<string[]> {
   const deployments: string[] = [];
   let offset = 0;
   const count = 100;
-  // eslint-disable-next-line no-constant-condition
   while (true) {
     const batch: string[] = await nearViewCall(REGISTRY, "list_deployments", { offset, count });
     if (!Array.isArray(batch) || batch.length === 0) break;
@@ -23,44 +18,32 @@ async function listMarkets(): Promise<string[]> {
     if (batch.length < count) break;
     offset += count;
   }
-  // Skip known non-market deployments
   return deployments.filter(
     (d) => !d.startsWith("proxy-oracle-") && !d.startsWith("liqtest-") && d !== "redstone-adapter." + REGISTRY,
   );
 }
 
-// Gross borrower interest (raw borrow-asset units) accrued in [fromMs, toMs].
-// Each snapshot holds (borrowed, interest_rate) over (prev end, this end], we
-// attribute each interval's interest to its overlap with the query window.
-async function marketInterest(market: string, fromMs: number, toMs: number): Promise<BigNumber> {
+async function marketInterest(market: string, fromMs: number, toMs: number): Promise<number> {
   const len: number = await nearViewCall(market, "get_finalized_snapshots_len");
-  if (!len || len === 0) return new BigNumber(0);
+  if (!len) return 0;
 
-  let snaps: any[] = [];
-  let offset = Math.max(0, len - SNAPSHOT_PAGE);
-  while (true) {
-    const page = await nearViewCall(market, "list_finalized_snapshots", { offset, count: Math.min(SNAPSHOT_PAGE, len - offset) });
-    if (!Array.isArray(page) || page.length === 0) break;
-    snaps = page.concat(snaps);
-    if (offset === 0 || Number(page[0].end_timestamp_ms) <= fromMs) break;
-    offset = Math.max(0, offset - SNAPSHOT_PAGE);
-  }
+  const snaps: any[] = await nearViewCall(market, "list_finalized_snapshots", {
+    offset: Math.max(0, len - SNAPSHOT_PAGE),
+    count: Math.min(SNAPSHOT_PAGE, len),
+  });
+  if (!snaps?.length) return 0;
 
-  let total = new BigNumber(0);
+  let total = 0;
   let prevEnd: number | null = null;
   for (const s of snaps) {
     const end = Number(s.end_timestamp_ms);
     if (prevEnd !== null) {
-      const overlapMs = Math.min(end, toMs) - Math.max(prevEnd, fromMs);
-      if (overlapMs > 0) {
-        total = total.plus(
-          new BigNumber(s.borrow_asset_borrowed).times(s.interest_rate).times(overlapMs).times(YEAR_PER_MS),
-        );
-      }
+      const overlap = Math.min(end, toMs) - Math.max(prevEnd, fromMs);
+      if (overlap > 0)
+        total += Number(s.borrow_asset_borrowed) * Number(s.interest_rate) * overlap / MS_PER_YEAR;
     }
     prevEnd = end;
   }
-
   return total;
 }
 
@@ -77,32 +60,24 @@ const fetch = async (options: FetchOptions) => {
 
   await Promise.all(
     markets.map(async (market) => {
-      let config: any;
-      try {
-        config = await nearViewCall(market, "get_configuration");
-      } catch {
-        return; // not a market
-      }
+      const config = await nearViewCall(market, "get_configuration");
       const yieldWeights = config?.yield_weights;
       const decimals = config?.price_oracle_configuration?.borrow_asset_decimals;
       if (!yieldWeights || decimals === undefined) return;
 
-      const supplyWeight = new BigNumber(yieldWeights.supply);
-      const staticWeight = Object.values(yieldWeights.static || {}).reduce(
-        (acc: BigNumber, w: any) => acc.plus(w),
-        new BigNumber(0),
-      );
-      const totalWeight = supplyWeight.plus(staticWeight);
-      if (totalWeight.isZero()) return;
+      const supplyWeight = Number(yieldWeights.supply);
+      const staticWeight = (Object.values(yieldWeights.static ?? {}) as number[])
+        .reduce((acc, w) => acc + Number(w), 0);
+      const totalWeight = supplyWeight + staticWeight;
+      if (!totalWeight) return;
 
       const interestRaw = await marketInterest(market, fromMs, toMs);
-      if (interestRaw.isZero()) return;
+      if (!interestRaw) return;
 
-      const scale = new BigNumber(10).pow(decimals);
-      const feesUsd = interestRaw.div(scale);
-      dailyFees.addUSDValue(feesUsd.toNumber(), METRIC.BORROW_INTEREST);
-      dailySupplySideRevenue.addUSDValue(feesUsd.times(supplyWeight).div(totalWeight).toNumber(), METRIC.BORROW_INTEREST);
-      dailyProtocolRevenue.addUSDValue(feesUsd.times(staticWeight).div(totalWeight).toNumber(), METRIC.BORROW_INTEREST);
+      const feesUsd = interestRaw / 10 ** decimals;
+      dailyFees.addUSDValue(feesUsd, METRIC.BORROW_INTEREST);
+      dailySupplySideRevenue.addUSDValue(feesUsd * supplyWeight / totalWeight, METRIC.BORROW_INTEREST);
+      dailyProtocolRevenue.addUSDValue(feesUsd * staticWeight / totalWeight, METRIC.BORROW_INTEREST);
     }),
   );
 
@@ -117,11 +92,8 @@ const fetch = async (options: FetchOptions) => {
 const adapter: SimpleAdapter = {
   version: 2,
   start: "2025-08-11",
-  adapter: {
-    [CHAIN.NEAR]: {
-      fetch,
-    },
-  },
+  chains: [CHAIN.NEAR],
+  fetch,
   methodology: {
     Fees: "Gross interest accrued by borrowers across all Templar lending markets, derived from on-chain market snapshots (borrowed amount x interest rate x time).",
     Revenue: "Protocol's share of borrower interest (the static yield weight), sent to the Templar treasury (revenue.tmplr.near).",
@@ -133,6 +105,9 @@ const adapter: SimpleAdapter = {
       [METRIC.BORROW_INTEREST]: "Gross interest accrued by borrowers across all Templar lending markets.",
     },
     Revenue: {
+      [METRIC.BORROW_INTEREST]: "Protocol's share of borrower interest (the static yield weight), sent to the Templar treasury (revenue.tmplr.near).",
+    },
+    ProtocolRevenue: {
       [METRIC.BORROW_INTEREST]: "Protocol's share of borrower interest (the static yield weight), sent to the Templar treasury (revenue.tmplr.near).",
     },
     SupplySideRevenue: {

--- a/fees/templarfi/index.ts
+++ b/fees/templarfi/index.ts
@@ -1,0 +1,132 @@
+import BigNumber from "bignumber.js";
+import { FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import { nearViewCall } from "../../helpers/near";
+
+const REGISTRY = "v1.tmplr.near";
+
+// Fraction of a year per millisecond
+const YEAR_PER_MS = new BigNumber("0.00000000003168873850681143096456210346");
+
+const SNAPSHOT_PAGE = 200;
+
+async function listMarkets(): Promise<string[]> {
+  const deployments: string[] = [];
+  let offset = 0;
+  const count = 100;
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const batch: string[] = await nearViewCall(REGISTRY, "list_deployments", { offset, count });
+    if (!Array.isArray(batch) || batch.length === 0) break;
+    deployments.push(...batch);
+    if (batch.length < count) break;
+    offset += count;
+  }
+  // Skip known non-market deployments
+  return deployments.filter(
+    (d) => !d.startsWith("proxy-oracle-") && !d.startsWith("liqtest-") && d !== "redstone-adapter." + REGISTRY,
+  );
+}
+
+// Gross borrower interest (raw borrow-asset units) accrued in [fromMs, toMs].
+// Each snapshot holds (borrowed, interest_rate) over (prev end, this end], we
+// attribute each interval's interest to its overlap with the query window.
+async function marketInterest(market: string, fromMs: number, toMs: number): Promise<BigNumber> {
+  const len: number = await nearViewCall(market, "get_finalized_snapshots_len");
+  if (!len || len === 0) return new BigNumber(0);
+
+  let snaps: any[] = [];
+  let offset = Math.max(0, len - SNAPSHOT_PAGE);
+  while (true) {
+    const page = await nearViewCall(market, "list_finalized_snapshots", { offset, count: Math.min(SNAPSHOT_PAGE, len - offset) });
+    if (!Array.isArray(page) || page.length === 0) break;
+    snaps = page.concat(snaps);
+    if (offset === 0 || Number(page[0].end_timestamp_ms) <= fromMs) break;
+    offset = Math.max(0, offset - SNAPSHOT_PAGE);
+  }
+
+  let total = new BigNumber(0);
+  let prevEnd: number | null = null;
+  for (const s of snaps) {
+    const end = Number(s.end_timestamp_ms);
+    if (prevEnd !== null) {
+      const overlapMs = Math.min(end, toMs) - Math.max(prevEnd, fromMs);
+      if (overlapMs > 0) {
+        total = total.plus(
+          new BigNumber(s.borrow_asset_borrowed).times(s.interest_rate).times(overlapMs).times(YEAR_PER_MS),
+        );
+      }
+    }
+    prevEnd = end;
+  }
+
+  return total;
+}
+
+const fetch = async (options: FetchOptions) => {
+  const { fromTimestamp, toTimestamp, createBalances } = options;
+  const fromMs = fromTimestamp * 1000;
+  const toMs = toTimestamp * 1000;
+
+  const dailyFees = createBalances();
+  const dailySupplySideRevenue = createBalances();
+  const dailyProtocolRevenue = createBalances();
+
+  const markets = await listMarkets();
+
+  await Promise.all(
+    markets.map(async (market) => {
+      let config: any;
+      try {
+        config = await nearViewCall(market, "get_configuration");
+      } catch {
+        return; // not a market
+      }
+      const yieldWeights = config?.yield_weights;
+      const decimals = config?.price_oracle_configuration?.borrow_asset_decimals;
+      if (!yieldWeights || decimals === undefined) return;
+
+      const supplyWeight = new BigNumber(yieldWeights.supply);
+      const staticWeight = Object.values(yieldWeights.static || {}).reduce(
+        (acc: BigNumber, w: any) => acc.plus(w),
+        new BigNumber(0),
+      );
+      const totalWeight = supplyWeight.plus(staticWeight);
+      if (totalWeight.isZero()) return;
+
+      const interestRaw = await marketInterest(market, fromMs, toMs);
+      if (interestRaw.isZero()) return;
+
+      const scale = new BigNumber(10).pow(decimals);
+      const feesUsd = interestRaw.div(scale);
+      dailyFees.addUSDValue(feesUsd.toNumber());
+      dailySupplySideRevenue.addUSDValue(feesUsd.times(supplyWeight).div(totalWeight).toNumber());
+      dailyProtocolRevenue.addUSDValue(feesUsd.times(staticWeight).div(totalWeight).toNumber());
+    }),
+  );
+
+  return {
+    dailyFees,
+    dailyRevenue: dailyProtocolRevenue,
+    dailyProtocolRevenue,
+    dailySupplySideRevenue,
+  };
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  start: "2025-08-11",
+  adapter: {
+    [CHAIN.NEAR]: {
+      fetch,
+    },
+  },
+  methodology: {
+    Fees: "Gross interest accrued by borrowers across all Templar lending markets, derived from on-chain market snapshots (borrowed amount x interest rate x time).",
+    Revenue: "Protocol's share of borrower interest (the static yield weight), sent to the Templar treasury (revenue.tmplr.near).",
+    ProtocolRevenue: "Protocol's share of borrower interest (the static yield weight), sent to the Templar treasury (revenue.tmplr.near).",
+    SupplySideRevenue: "Borrower interest distributed to suppliers/lenders (the supply yield weight).",
+  },
+};
+
+export default adapter;

--- a/fees/templarfi/index.ts
+++ b/fees/templarfi/index.ts
@@ -1,6 +1,7 @@
 import BigNumber from "bignumber.js";
 import { FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
+import { METRIC } from "../../helpers/metrics";
 import { nearViewCall } from "../../helpers/near";
 
 const REGISTRY = "v1.tmplr.near";
@@ -99,9 +100,9 @@ const fetch = async (options: FetchOptions) => {
 
       const scale = new BigNumber(10).pow(decimals);
       const feesUsd = interestRaw.div(scale);
-      dailyFees.addUSDValue(feesUsd.toNumber());
-      dailySupplySideRevenue.addUSDValue(feesUsd.times(supplyWeight).div(totalWeight).toNumber());
-      dailyProtocolRevenue.addUSDValue(feesUsd.times(staticWeight).div(totalWeight).toNumber());
+      dailyFees.addUSDValue(feesUsd.toNumber(), METRIC.BORROW_INTEREST);
+      dailySupplySideRevenue.addUSDValue(feesUsd.times(supplyWeight).div(totalWeight).toNumber(), METRIC.BORROW_INTEREST);
+      dailyProtocolRevenue.addUSDValue(feesUsd.times(staticWeight).div(totalWeight).toNumber(), METRIC.BORROW_INTEREST);
     }),
   );
 
@@ -126,6 +127,17 @@ const adapter: SimpleAdapter = {
     Revenue: "Protocol's share of borrower interest (the static yield weight), sent to the Templar treasury (revenue.tmplr.near).",
     ProtocolRevenue: "Protocol's share of borrower interest (the static yield weight), sent to the Templar treasury (revenue.tmplr.near).",
     SupplySideRevenue: "Borrower interest distributed to suppliers/lenders (the supply yield weight).",
+  },
+  breakdownMethodology: {
+    Fees: {
+      [METRIC.BORROW_INTEREST]: "Gross interest accrued by borrowers across all Templar lending markets.",
+    },
+    Revenue: {
+      [METRIC.BORROW_INTEREST]: "Protocol's share of borrower interest (the static yield weight), sent to the Templar treasury (revenue.tmplr.near).",
+    },
+    SupplySideRevenue: {
+      [METRIC.BORROW_INTEREST]: "Borrower interest distributed to suppliers/lenders (the supply yield weight).",
+    },
   },
 };
 

--- a/helpers/env.ts
+++ b/helpers/env.ts
@@ -28,6 +28,7 @@ const DEFAULTS: any = {
   CANTO_RPC: 'https://tuber.build/api/eth-rpc',
   APTOS_RPC: 'https://aptos-mainnet.pontem.network',
   SOLANA_RPC: "https://api.mainnet-beta.solana.com",
+  NEAR_RPC: "https://free.rpc.fastnear.com,https://near.lava.build,https://rpc.mainnet.near.org",
   VIRTUS_BACKEND_BASE: 'https://back.virtus-protocol.com/api',
   BLOCKFROST_PROJECT_ID: 'mai'+'nnetBfkdsCOvb4BS'+'VA6pb1D43ptQ7t3cLt06',
   SAUCERSWAP_API_KEY: 'api262369f52fef0cf082bc1a24d89c5',

--- a/helpers/near.ts
+++ b/helpers/near.ts
@@ -18,7 +18,7 @@ let rpcCursor = 0;
  * @param args - Optional JSON-serializable arguments (default: {}).
  * @returns Parsed JSON result returned by the contract method.
  */
-export async function nearViewCall(account: string, method: string, args: any = {}): Promise<any> {
+export async function nearView(account: string, method: string, args: any = {}): Promise<any> {
   const payload = {
     jsonrpc: "2.0",
     id: "dimension-adapters",

--- a/helpers/near.ts
+++ b/helpers/near.ts
@@ -1,0 +1,47 @@
+import plimit from "p-limit";
+import { postURL } from "../utils/fetchURL";
+import { sleep } from "../utils/utils";
+import { getEnv } from "./env";
+
+// NEAR JSON-RPC view call with retry, endpoint failover, and concurrency cap.
+
+const RPCS = getEnv("NEAR_RPC").split(",");
+
+// Cap concurrent calls to stay under rate limits.
+const limit = plimit(3);
+let rpcCursor = 0;
+
+export async function nearViewCall(account: string, method: string, args: any = {}): Promise<any> {
+  const payload = {
+    jsonrpc: "2.0",
+    id: "dimension-adapters",
+    method: "query",
+    params: {
+      request_type: "call_function",
+      finality: "final",
+      account_id: account,
+      method_name: method,
+      args_base64: Buffer.from(JSON.stringify(args)).toString("base64"),
+    },
+  };
+  return limit(async () => {
+    let lastErr: any;
+    for (let attempt = 0; attempt < 8; attempt++) {
+      // Round-robin across endpoints.
+      const rpc = RPCS[rpcCursor++ % RPCS.length];
+      try {
+        const body = await postURL(rpc, payload, 0);
+        if (body?.error) throw new Error(`${account}.${method}: ${JSON.stringify(body.error)}`);
+        if (body?.result?.error) throw new Error(`${account}.${method}: ${body.result.error}`);
+        return JSON.parse(Buffer.from(body.result.result).toString());
+      } catch (e: any) {
+        lastErr = e;
+        const status = e?.statusCode || e?.response?.status;
+        const retryable = status === 429 || status === 503 || /429|503|timeout|socket|ECONN|ETIMEDOUT/i.test(e?.message ?? "");
+        if (!retryable) throw e;
+        await sleep(400 * 2 ** attempt + Math.floor(Math.random() * 300));
+      }
+    }
+    throw lastErr;
+  });
+}

--- a/helpers/near.ts
+++ b/helpers/near.ts
@@ -11,6 +11,13 @@ const RPCS = getEnv("NEAR_RPC").split(",");
 const limit = plimit(3);
 let rpcCursor = 0;
 
+/**
+ * Perform a NEAR JSON-RPC view (`call_function`) call with retry, endpoint failover, and concurrency limiting.
+ * @param account - The NEAR account ID (contract) to call.
+ * @param method - The view method name.
+ * @param args - Optional JSON-serializable arguments (default: {}).
+ * @returns Parsed JSON result returned by the contract method.
+ */
 export async function nearViewCall(account: string, method: string, args: any = {}): Promise<any> {
   const payload = {
     jsonrpc: "2.0",
@@ -33,6 +40,7 @@ export async function nearViewCall(account: string, method: string, args: any = 
         const body = await postURL(rpc, payload, 0);
         if (body?.error) throw new Error(`${account}.${method}: ${JSON.stringify(body.error)}`);
         if (body?.result?.error) throw new Error(`${account}.${method}: ${body.result.error}`);
+        if (!Array.isArray(body?.result?.result)) throw new Error(`${account}.${method}: unexpected response shape`);
         return JSON.parse(Buffer.from(body.result.result).toString());
       } catch (e: any) {
         lastErr = e;


### PR DESCRIPTION
### Methodology

* **Fees:** Total borrower interest accrued across all Templar markets, calculated from finalized on-chain snapshots.
* **SupplySideRevenue:** Interest paid to suppliers/lenders.
* **ProtocolRevenue / Revenue:** Protocol's share of interest, sent to the treasury (`revenue.tmplr.near`).

Markets are discovered through the registry (`v1.tmplr.near`), excluding non-market deployments such as oracles and test markets.

### Supporting changes

* Adds `helpers/near.ts` with `nearViewCall` for NEAR JSON-RPC view calls, including retries, backoff, endpoint failover, and concurrency limits.
* Adds default `NEAR_RPC` endpoints in `helpers/env.ts`.

https://defillama.com/protocol/templar-protocol