### PR TITLE
fees(claimrush): unify breakdown label across all four buckets

### DIFF
--- a/fees/claimrush.ts
+++ b/fees/claimrush.ts
@@ -40,9 +40,9 @@ const fetch = async (options: FetchOptions) => {
   }
 
   if (totalWei > 0n) {
-    dailyFees.addGasToken(totalWei, "Takeover Royalties");
-    dailyUserFees.addGasToken(totalWei, "Takeover Royalties");
-    dailyRevenue.addGasToken(totalWei, "Takeover Royalties");
+    dailyFees.addGasToken(totalWei, "Takeover Royalties To veCLAIM Holders");
+    dailyUserFees.addGasToken(totalWei, "Takeover Royalties To veCLAIM Holders");
+    dailyRevenue.addGasToken(totalWei, "Takeover Royalties To veCLAIM Holders");
     dailyHoldersRevenue.addGasToken(totalWei, "Takeover Royalties To veCLAIM Holders");
   }
 
@@ -65,15 +65,15 @@ const methodology = {
 
 const breakdownMethodology = {
   Fees: {
-    "Takeover Royalties":
+    "Takeover Royalties To veCLAIM Holders":
       "ETH allocated to ShareholderRoyalties by MineCore on each successful takeover (via `onTakeover` and the `addPendingShareholderETH` retry path).",
   },
   UserFees: {
-    "Takeover Royalties":
+    "Takeover Royalties To veCLAIM Holders":
       "Same value — the new King of each takeover pays the royalty fraction directly out of `pricePaid`.",
   },
   Revenue: {
-    "Takeover Royalties":
+    "Takeover Royalties To veCLAIM Holders":
       "ETH allocated to ShareholderRoyalties by MineCore on each successful takeover (via `onTakeover` and the `addPendingShareholderETH` retry path).",
   },
   HoldersRevenue: {


### PR DESCRIPTION
## Summary

Apply the descriptive `"Takeover Royalties To veCLAIM Holders"` label to `dailyFees`, `dailyUserFees`, and `dailyRevenue` (it was already in use on `dailyHoldersRevenue` since #7368). All four buckets now share one label string, so the per-protocol **Token Holder Net Income** card stops splitting a single income stream into two artificial sub-buckets.

## The bug on the protocol page

On `defillama.com/protocol/ClaimRush`, the **Token Holder Net Income** breakdown currently looks like this:

| Label | Amount | Reality |
|---|---|---|
| Takeover Royalties | **$14.37K** | Pre-#7368 data (May 30 – Jun 2) |
| Takeover Royalties To veCLAIM Holders | **$63.02K** | Post-#7368 data (Jun 2 onward) |
| **Sum** | **$77.39K** | = `total30d` ✓ |

Two label strings, one stream. The split is a pure label-history artifact — there is no second source of takeover royalties to veCLAIM holders.

## Root cause

`#7368` (merged 2026-06-02 06:34 UTC) renamed only the `dailyHoldersRevenue` label to `"Takeover Royalties To veCLAIM Holders"`:

```typescript
// fees/claimrush.ts on master (today):
dailyFees.addGasToken(totalWei, "Takeover Royalties");
dailyUserFees.addGasToken(totalWei, "Takeover Royalties");
dailyRevenue.addGasToken(totalWei, "Takeover Royalties");
dailyHoldersRevenue.addGasToken(totalWei, "Takeover Royalties To veCLAIM Holders");
//                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
//                                       the odd one out
```

Because the dimension store keys labels per data-point, pre-merge HoldersRevenue entries kept the original `"Takeover Royalties"` string while post-merge entries got the new one. The UI groups by string → two buckets.

## Fix

Make all four `addGasToken` calls use the same label, and update `breakdownMethodology` to match. The "Takeover Royalties To veCLAIM Holders" wording is more descriptive (source + destination in one phrase) and matches what was approved on HoldersRevenue.

```diff
- dailyFees.addGasToken(totalWei, "Takeover Royalties");
- dailyUserFees.addGasToken(totalWei, "Takeover Royalties");
- dailyRevenue.addGasToken(totalWei, "Takeover Royalties");
+ dailyFees.addGasToken(totalWei, "Takeover Royalties To veCLAIM Holders");
+ dailyUserFees.addGasToken(totalWei, "Takeover Royalties To veCLAIM Holders");
+ dailyRevenue.addGasToken(totalWei, "Takeover Royalties To veCLAIM Holders");
  dailyHoldersRevenue.addGasToken(totalWei, "Takeover Royalties To veCLAIM Holders");
```

No functional change to fees / revenue accounting — the same `totalWei` is attributed to the same dimensions. Only the displayed bucket label changes.

## Re-index ask

@bheluga — once merged, could we get a backfill re-index of `claimrush` so the historical pre-#7368 data points get re-labeled to the unified string? Otherwise the **Token Holder Net Income** card will continue showing two buckets until the old entries age out of the 30d window (and forever in the all-time / 1y views).

If a manual re-index isn't easy, I'm happy with the eventual aging-out path; flagging it because the bug is currently visible to anyone landing on the protocol page.

Thanks!
