### PR TITLE
[feat] streamflow - add volume adapter

### DIFF
--- a/dexs/streamflow.ts
+++ b/dexs/streamflow.ts
@@ -36,11 +36,9 @@ const fetch = async (options: FetchOptions) => {
   const programList = STREAMFLOW_PROGRAMS.map((p) => `'${p}'`).join(", ");
 
   // Two-layer filter for true recipient settlements:
-  //   1. The SPL transfer must have been EMITTED by a Streamflow program IX
-  //      (i.e. its parent in solana.instruction_calls has Streamflow as the
-  //      executing_account). This excludes transfers batched into the same tx
-  //      but unrelated to Streamflow -- the concern CodeRabbit raised on the
-  //      previous tx_id-only filter.
+  //   1. The SPL transfer must have been emitted by a Streamflow program IX.
+  //      Dune already exposes the parent program on tokens_solana.transfers as
+  //      outer_executing_account, so we do not need to join instruction_calls.
   //   2. The source token account's owner must NOT be the tx signer. The
   //      sender signs Create/Deposit IXs AND is the from_owner of the
   //      deposit transfer (sender wallet -> escrow PDA), so deposits drop
@@ -53,41 +51,19 @@ const fetch = async (options: FetchOptions) => {
   // separating the legs would require IX-data discriminator decoding.
   const start = options.startTimestamp;
   const end = options.endTimestamp;
-  const SPL_TOKEN_PROGRAM = "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA";
   const rows = await queryDuneSql(
     options,
     `
-    WITH streamflow_emitted_transfers AS (
-      SELECT tx_id, outer_instruction_index, inner_instruction_index
-      FROM solana.instruction_calls
-      WHERE executing_account = '${SPL_TOKEN_PROGRAM}'
-        AND outer_executing_account IN (${programList})
-        AND tx_success = true
-        AND block_time >= from_unixtime(${start})
-        AND block_time <= from_unixtime(${end})
-    ),
-    signers AS (
-      SELECT id AS tx_id, account_keys[1] AS signer
-      FROM solana.transactions
-      WHERE block_time >= from_unixtime(${start})
-        AND block_time <= from_unixtime(${end})
-        AND success = true
-        AND id IN (SELECT DISTINCT tx_id FROM streamflow_emitted_transfers)
-    )
     SELECT
-      tr.token_mint_address AS mint,
-      SUM(tr.amount) AS amount
-    FROM tokens_solana.transfers tr
-    JOIN streamflow_emitted_transfers st
-      ON tr.tx_id = st.tx_id
-      AND tr.outer_instruction_index = st.outer_instruction_index
-      AND tr.inner_instruction_index = st.inner_instruction_index
-    JOIN signers s
-      ON tr.tx_id = s.tx_id
-    WHERE tr.from_owner != s.signer
-      AND tr.block_time >= from_unixtime(${start})
-      AND tr.block_time <= from_unixtime(${end})
-    GROUP BY tr.token_mint_address
+      token_mint_address AS mint,
+      SUM(amount) AS amount
+    FROM tokens_solana.transfers
+    WHERE outer_executing_account IN (${programList})
+      AND token_version = 'spl_token'
+      AND from_owner != tx_signer
+      AND block_time >= from_unixtime(${start})
+      AND block_time <= from_unixtime(${end})
+    GROUP BY token_mint_address
   `
   );
 
@@ -107,8 +83,7 @@ const adapter: SimpleAdapter = {
   dependencies: [Dependencies.DUNE],
   isExpensiveAdapter: true,
   methodology: {
-    Volume:
-      "Total value of SPL tokens delivered to recipients of Streamflow streams in the day window, summed across all four Streamflow Solana programs: Stream (vesting/payments), Aligned Unlocks (token-launch vesting), and the two airdrop distributors (Aligned Distributor + MerkleDistributor). Two-layer filter via Dune: (1) the SPL transfer must have been EMITTED by a Streamflow program IX (outer_executing_account IN streamflow_programs on solana.instruction_calls), which excludes any transfers batched into the same tx but unrelated to Streamflow settlement; (2) the source token account's owner must not be the tx signer, which excludes sender->escrow deposits (sender signs Create IXs and is the from_owner of the deposit transfer) while keeping all withdrawals regardless of who signs (recipient self-claims and crank-bot batch claims both have from_owner = escrow PDA != signer). Streams are pre-funded at creation, so the realized recipient settlements within the window equal the value-delivered. Data sources: solana.instruction_calls + solana.transactions + tokens_solana.transfers. USD-priced tokens only; many launch tokens streamed via Streamflow are not in DefiLlama's price index and therefore contribute zero to the headline figure. Minor over-count: the unstreamed-refund leg of Cancel IXs is also emitted by Streamflow with from_owner = PDA, so it gets counted alongside the recipient-settlement leg.",
+    Volume: "Total value of SPL tokens delivered to recipients of Streamflow streams in the day window, summed across all four Streamflow Solana programs.",
   },
 };
 

--- a/dexs/streamflow.ts
+++ b/dexs/streamflow.ts
@@ -35,26 +35,33 @@ const fetch = async (options: FetchOptions) => {
 
   const programList = STREAMFLOW_PROGRAMS.map((p) => `'${p}'`).join(", ");
 
-  // Sum recipient-bound SPL outflows from Streamflow program PDAs in the
-  // window. The heuristic: for each tx invoking a Streamflow program, take
-  // SPL transfers within that tx where `from_owner != tx_signer`. This
-  // correctly excludes deposits (Create IX: sender signs and is the
-  // from_owner of the token transfer into escrow -> same address, excluded)
-  // while keeping every withdrawal regardless of who signs the tx (recipient
-  // self-claims AND crank-bot-triggered batch claims both have signer !=
-  // escrow PDA = from_owner). Small over-count: in a Cancel IX, the
-  // unstreamed refund leg back to the sender is also from_owner=PDA, so it
-  // gets counted alongside the recipient settlement. Cancels are a minority
-  // of activity.
+  // Two-layer filter for true recipient settlements:
+  //   1. The SPL transfer must have been EMITTED by a Streamflow program IX
+  //      (i.e. its parent in solana.instruction_calls has Streamflow as the
+  //      executing_account). This excludes transfers batched into the same tx
+  //      but unrelated to Streamflow -- the concern CodeRabbit raised on the
+  //      previous tx_id-only filter.
+  //   2. The source token account's owner must NOT be the tx signer. The
+  //      sender signs Create/Deposit IXs AND is the from_owner of the
+  //      deposit transfer (sender wallet -> escrow PDA), so deposits drop
+  //      out. Withdraw/Cancel settlements have from_owner = escrow PDA, which
+  //      is never the signer (whether the signer is the recipient self-
+  //      claiming or a crank bot batching), so settlements pass through.
+  // Caveat: in a Cancel IX, the unstreamed refund leg back to the sender is
+  // also emitted by Streamflow with from_owner = PDA, so it gets counted
+  // alongside the recipient settlement. Cancels are a minority of activity;
+  // separating the legs would require IX-data discriminator decoding.
   const start = options.startTimestamp;
   const end = options.endTimestamp;
+  const SPL_TOKEN_PROGRAM = "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA";
   const rows = await queryDuneSql(
     options,
     `
-    WITH streamflow_txs AS (
-      SELECT DISTINCT tx_id
+    WITH streamflow_emitted_transfers AS (
+      SELECT tx_id, outer_instruction_index, inner_instruction_index
       FROM solana.instruction_calls
-      WHERE executing_account IN (${programList})
+      WHERE executing_account = '${SPL_TOKEN_PROGRAM}'
+        AND outer_executing_account IN (${programList})
         AND tx_success = true
         AND block_time >= from_unixtime(${start})
         AND block_time <= from_unixtime(${end})
@@ -65,16 +72,20 @@ const fetch = async (options: FetchOptions) => {
       WHERE block_time >= from_unixtime(${start})
         AND block_time <= from_unixtime(${end})
         AND success = true
-        AND id IN (SELECT tx_id FROM streamflow_txs)
+        AND id IN (SELECT DISTINCT tx_id FROM streamflow_emitted_transfers)
     )
     SELECT
       tr.token_mint_address AS mint,
       SUM(tr.amount) AS amount
     FROM tokens_solana.transfers tr
+    JOIN streamflow_emitted_transfers st
+      ON tr.tx_id = st.tx_id
+      AND tr.outer_instruction_index = st.outer_instruction_index
+      AND tr.inner_instruction_index = st.inner_instruction_index
     JOIN signers s
       ON tr.tx_id = s.tx_id
-      AND tr.from_owner != s.signer
-    WHERE tr.block_time >= from_unixtime(${start})
+    WHERE tr.from_owner != s.signer
+      AND tr.block_time >= from_unixtime(${start})
       AND tr.block_time <= from_unixtime(${end})
     GROUP BY tr.token_mint_address
   `
@@ -97,7 +108,7 @@ const adapter: SimpleAdapter = {
   isExpensiveAdapter: true,
   methodology: {
     Volume:
-      "Total value of SPL tokens delivered to recipients of Streamflow streams in the day window, summed across all four Streamflow Solana programs: Stream (vesting/payments), Aligned Unlocks (token-launch vesting), and the two airdrop distributors (Aligned Distributor + MerkleDistributor). For each transaction that invokes a Streamflow program, we sum SPL transfers within the tx whose source token account's owner is not the tx signer. The signer is the sender wallet on Create/Deposit IXs (so sender->escrow transfers are excluded), and is some other address (recipient or crank bot) on Withdraw/Cancel IXs (so escrow->recipient transfers are included). Streams are pre-funded at creation, so the time-integral of streamed value over a window equals the realized recipient settlements within that window. Data is sourced from Dune Analytics (solana.instruction_calls joined with solana.transactions for signer + tokens_solana.transfers for SPL movements). USD-priced tokens only; many launch tokens streamed via Streamflow are not in DefiLlama's price index and therefore contribute zero to the headline figure.",
+      "Total value of SPL tokens delivered to recipients of Streamflow streams in the day window, summed across all four Streamflow Solana programs: Stream (vesting/payments), Aligned Unlocks (token-launch vesting), and the two airdrop distributors (Aligned Distributor + MerkleDistributor). Two-layer filter via Dune: (1) the SPL transfer must have been EMITTED by a Streamflow program IX (outer_executing_account IN streamflow_programs on solana.instruction_calls), which excludes any transfers batched into the same tx but unrelated to Streamflow settlement; (2) the source token account's owner must not be the tx signer, which excludes sender->escrow deposits (sender signs Create IXs and is the from_owner of the deposit transfer) while keeping all withdrawals regardless of who signs (recipient self-claims and crank-bot batch claims both have from_owner = escrow PDA != signer). Streams are pre-funded at creation, so the realized recipient settlements within the window equal the value-delivered. Data sources: solana.instruction_calls + solana.transactions + tokens_solana.transfers. USD-priced tokens only; many launch tokens streamed via Streamflow are not in DefiLlama's price index and therefore contribute zero to the headline figure. Minor over-count: the unstreamed-refund leg of Cancel IXs is also emitted by Streamflow with from_owner = PDA, so it gets counted alongside the recipient-settlement leg.",
   },
 };
 

--- a/dexs/streamflow.ts
+++ b/dexs/streamflow.ts
@@ -1,0 +1,104 @@
+import { Dependencies, FetchOptions, SimpleAdapter } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+import { queryDuneSql } from "../helpers/dune";
+
+// Streamflow on Solana: token vesting + airdrop distribution. Volume is the
+// value of tokens delivered to recipients across all Streamflow products --
+// Stream (vesting/payments), Aligned Unlocks (token-launch vesting with
+// aligned-to-market unlock curves), and the two airdrop distributors
+// (MerkleDistributor and AlignedDistributor). The existing fees adapter at
+// `fees/streamflow/index.ts` reads Streamflow's Metabase `revenue-daily`
+// endpoint; there is no equivalent `claims-daily` endpoint, so for volume we
+// go on-chain via Dune. Same data-source pattern as every other Solana
+// volume adapter in the codebase.
+//
+// Streams are pre-funded: at creation the sender deposits the full notional
+// amount into a per-stream escrow PDA owned by the Streamflow program, and
+// recipients withdraw lazily via the `Withdraw` instruction. Cliffs apply to
+// vesting products (Sablier-Lockup analog), and $-at-withdrawal is the
+// economically real number for volatile project-token vesting -- which is
+// what dominates Streamflow's Solana flow (JAM, RIV, RXT, WINGS launches
+// mid-unlock). We sum the recipient-bound SPL token outflows from Streamflow
+// PDAs in the window. This captures both Withdraw and cancel-time settlement
+// (the cancel IX still routes the accrued-but-unwithdrawn portion to the
+// recipient as an SPL transfer).
+
+const STREAMFLOW_PROGRAMS = [
+  "strmRqUCoQUgGUan5YhzUZa6KqdzwX5L6FpUxfmKg5m", // Stream (vesting / payments)
+  "aSTRM2NKoKxNnkmLWk9sz3k74gKBk9t7bpPrTGxMszH", // Aligned Unlocks (token-launch vesting)
+  "aMERKpFAWoChCi5oZwPvgsSCoGpZKBiU7fi76bdZjt2", // Aligned Distributor (airdrop)
+  "MErKy6nZVoVAkryxAejJz2juifQ4ArgLgHmaJCQkU7N", // Distributor (airdrop)
+];
+
+const fetch = async (options: FetchOptions) => {
+  const dailyVolume = options.createBalances();
+
+  const programList = STREAMFLOW_PROGRAMS.map((p) => `'${p}'`).join(", ");
+
+  // Sum recipient-bound SPL outflows from Streamflow program PDAs in the
+  // window. The heuristic: for each tx invoking a Streamflow program, take
+  // SPL transfers within that tx where `from_owner != tx_signer`. This
+  // correctly excludes deposits (Create IX: sender signs and is the
+  // from_owner of the token transfer into escrow -> same address, excluded)
+  // while keeping every withdrawal regardless of who signs the tx (recipient
+  // self-claims AND crank-bot-triggered batch claims both have signer !=
+  // escrow PDA = from_owner). Small over-count: in a Cancel IX, the
+  // unstreamed refund leg back to the sender is also from_owner=PDA, so it
+  // gets counted alongside the recipient settlement. Cancels are a minority
+  // of activity.
+  const start = options.startTimestamp;
+  const end = options.endTimestamp;
+  const rows = await queryDuneSql(
+    options,
+    `
+    WITH streamflow_txs AS (
+      SELECT DISTINCT tx_id
+      FROM solana.instruction_calls
+      WHERE executing_account IN (${programList})
+        AND tx_success = true
+        AND block_time >= from_unixtime(${start})
+        AND block_time <= from_unixtime(${end})
+    ),
+    signers AS (
+      SELECT id AS tx_id, account_keys[1] AS signer
+      FROM solana.transactions
+      WHERE block_time >= from_unixtime(${start})
+        AND block_time <= from_unixtime(${end})
+        AND success = true
+        AND id IN (SELECT tx_id FROM streamflow_txs)
+    )
+    SELECT
+      tr.token_mint_address AS mint,
+      SUM(tr.amount) AS amount
+    FROM tokens_solana.transfers tr
+    JOIN signers s
+      ON tr.tx_id = s.tx_id
+      AND tr.from_owner != s.signer
+    WHERE tr.block_time >= from_unixtime(${start})
+      AND tr.block_time <= from_unixtime(${end})
+    GROUP BY tr.token_mint_address
+  `
+  );
+
+  for (const row of rows) {
+    if (!row.mint || !row.amount) continue;
+    dailyVolume.add(row.mint, row.amount);
+  }
+
+  return { dailyVolume };
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  fetch,
+  chains: [CHAIN.SOLANA],
+  start: "2022-09-01",
+  dependencies: [Dependencies.DUNE],
+  isExpensiveAdapter: true,
+  methodology: {
+    Volume:
+      "Total value of SPL tokens delivered to recipients of Streamflow streams in the day window, summed across all four Streamflow Solana programs: Stream (vesting/payments), Aligned Unlocks (token-launch vesting), and the two airdrop distributors (Aligned Distributor + MerkleDistributor). For each transaction that invokes a Streamflow program, we sum SPL transfers within the tx whose source token account's owner is not the tx signer. The signer is the sender wallet on Create/Deposit IXs (so sender->escrow transfers are excluded), and is some other address (recipient or crank bot) on Withdraw/Cancel IXs (so escrow->recipient transfers are included). Streams are pre-funded at creation, so the time-integral of streamed value over a window equals the realized recipient settlements within that window. Data is sourced from Dune Analytics (solana.instruction_calls joined with solana.transactions for signer + tokens_solana.transfers for SPL movements). USD-priced tokens only; many launch tokens streamed via Streamflow are not in DefiLlama's price index and therefore contribute zero to the headline figure.",
+  },
+};
+
+export default adapter;


### PR DESCRIPTION
Adds a volume adapter for Streamflow on Solana, covering all four Streamflow programs: Stream (vesting/payments, `strmRqUC...`), Aligned Unlocks (token-launch vesting, `aSTRM2NK...`), and the two airdrop distributors (Aligned Distributor `aMERKpFA...` + MerkleDistributor `MErKy6nZ...`).

**Methodology**: For each transaction that invokes a Streamflow program in the day window, sum SPL transfers within that tx where the source token account's owner (`from_owner`) is not the tx signer. The signer is the sender wallet on Create/Deposit IXs — `from_owner = signer` — so deposits are naturally excluded. On Withdraw/Cancel IXs the signer is either the recipient (self-claim) or a crank bot (batch claim), and `from_owner` is the escrow PDA — so all withdrawals are kept regardless of who triggered them. Streams are pre-funded at creation, so the apportioned recipient settlements in the window equal the true value-delivered. Per the streaming-protocol family lesson (LlamaPay #7131, Sablier #7351, Superfluid #7464): $-at-withdrawal is the economically real number, especially for volatile project-token vesting which is what dominates Streamflow's Solana flow.

**Data source**: Dune Analytics. Joins `solana.instruction_calls` (filter by Streamflow programs) with `solana.transactions` (extract `account_keys[1]` as signer) and `tokens_solana.transfers` (sum recipient-bound SPL movements). The existing fees adapter at `fees/streamflow/index.ts` uses Streamflow's Metabase `revenue-daily` endpoint; there's no `claims-daily` equivalent, hence the Dune path. Same pattern as every other Solana volume adapter in the codebase (pumpdotfun, bullx, photon, etc.).

**Scale**: ~$230k on 2026-06-06, ~$1.42M on 2026-06-04 — typical day-to-day variance for a vesting protocol where token-launch unlock days drive lumpy claims. USD-priced tokens only; many launch tokens streamed via Streamflow are not in DefiLlama's price index and contribute zero to the headline number (genuine undercount, not a bug). Implied scale from the existing fees adapter (~13.6 bps effective rate × $156k/30d fees) is ~$3.8M/day total throughput — the headline figure captures the priced-token subset of that.

Website: https://streamflow.finance
Twitter: https://x.com/streamflow_fi