### PR TITLE
[fix] Vapordex-V1: expand coverage via contracts & deprecate apechain

### DIFF
--- a/dexs/vapordex-v1.ts
+++ b/dexs/vapordex-v1.ts
@@ -1,32 +1,41 @@
-import * as sdk from "@defillama/sdk";
-import { SimpleAdapter } from "../adapters/types";
+import { FetchOptions, SimpleAdapter } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
-import { univ2Adapter2 } from "../helpers/getUniSubgraphVolume";
+import { uniV2Exports } from "../helpers/uniswap";
 
-const avaxAdapter = univ2Adapter2({
-  endpoints: {
-    [CHAIN.AVAX]: sdk.graph.modifyEndpoint(
-      "B6Tur5gXGCcswG8rEtmwfjBqeyDXCDUQSwM9wUXHoui5"
-    ),
-  },
-  factoriesName: "dexAmmProtocols",
-  totalVolume: "cumulativeVolumeUSD",
-})
+// Fees are hardcoded in Pair.swap function in pair contract.
+const feeConfig = {
+  fees: 0.0029,
+  userFeesRatio: 1,
+  revenueRatio: 0,
+  protocolRevenueRatio: 0,
+  holdersRevenueRatio: 0,
+}
 
-const apechainAdapter = univ2Adapter2({
-  endpoints: {
-    [CHAIN.APECHAIN]: "https://api.goldsky.com/api/public/project_cloh4i8580dwo2nz7brhf4r6p/subgraphs/vapordex-v1-apechain/1.0.0/gn",
+const chainConfig: Record<string, { start: string; factory: string; allowReadPairs: true }> = {
+  [CHAIN.AVAX]: {
+    start: "2023-09-19",
+    factory: "0xc009a670e2b02e21e7e75ae98e254f467f7ae257",
+    allowReadPairs: true,
   },
-  factoriesName: "uniswapFactories",
-  totalVolume: "totalVolumeUSD",
-})
+  [CHAIN.TELOS]: {
+    start: "2024-01-17",
+    factory: "0xDef9ee39FD82ee57a1b789Bc877E2Cbd88fd5caE",
+    allowReadPairs: true,
+  }, // No Pair created till date, expect 0 values.
+  // [CHAIN.APECHAIN]: no active contract, no pools to track // subgraph inactive
+}
+
+const uniV2Adapter = uniV2Exports(Object.fromEntries(
+  Object.entries(chainConfig).map(([chain, config]) => [chain, { ...config, ...feeConfig }])
+))
+
+const fetch = (options: FetchOptions) =>
+  (uniV2Adapter.adapter![options.chain].fetch as (options: FetchOptions) => any)(options)
 
 const adapter: SimpleAdapter = {
   version: 2,
-  adapter: {
-    [CHAIN.AVAX]: { fetch: avaxAdapter, start: '2023-09-19' },
-    [CHAIN.APECHAIN]: { fetch: apechainAdapter, start: '2023-09-19' },
-  },
+  fetch,
+  adapter: chainConfig,
 };
 
 export default adapter;

--- a/dexs/vapordex-v1.ts
+++ b/dexs/vapordex-v1.ts
@@ -34,6 +34,7 @@ const fetch = (options: FetchOptions) =>
 
 const adapter: SimpleAdapter = {
   version: 2,
+  pullHourly: true,
   fetch,
   adapter: chainConfig,
 };


### PR DESCRIPTION
## Summary
- Migrates `dexs/vapordex-v1.ts` from subgraph volume reads to the Uniswap V2 log helper.
- Adds active VaporDEX V1 coverage for Avalanche and Telos.

## Changes
- Uses `uniV2Exports` with a shared `chainConfig` and one root `fetch`.
- Counts 0.29% swap fees as LP supply-side revenue, with no protocol revenue counted.
- Removes ApeChain from active coverage because no active V1 factory contract was available.

## Methodology
- Volume and fees are derived from VaporDEX V1 pair swap events.
- Swap fees use the pair contract's hardcoded `29 / 10000` fee.
