### PR TITLE
fix(silentswap): clamp daily bridge volume to >=0

### DIFF
--- a/bridge-aggregators/silentswap/index.ts
+++ b/bridge-aggregators/silentswap/index.ts
@@ -47,7 +47,10 @@ const fetch = async (options: FetchOptions) => {
   const inflowsTillToday = inflowData[0].inflowUsd;
   const inflowsTillYesterday = inflowData[1].inflowUsd;
 
-  const dailyInflows = inflowsTillToday - inflowsTillYesterday;
+  // Clamp to >=0 (as documented in the methodology): a missing or reset
+  // snapshot on either date must never produce a negative daily volume.
+  const delta = inflowsTillToday - inflowsTillYesterday;
+  const dailyInflows = delta > 0 ? delta : 0;
 
   return {
     dailyBridgeVolume: Number(dailyInflows) / 1e6,


### PR DESCRIPTION
## What

Clamp the SilentSwap daily bridge volume to `>=0`.

The adapter's methodology documents the daily series as *"clamped to ≥0"*, but `fetch` returned the raw inflow delta (`inflowsTillToday - inflowsTillYesterday`). A missing or reset reporter snapshot on either date could produce a **negative** `dailyBridgeVolume`. This change clamps the delta so the code matches the documented behaviour.

```diff
-  const dailyInflows = inflowsTillToday - inflowsTillYesterday;
+  const delta = inflowsTillToday - inflowsTillYesterday;
+  const dailyInflows = delta > 0 ? delta : 0;
```

## Context — protocol page shows no volume

The SilentSwap adapter (merged in #7355) runs correctly — a local test reports ~24M daily volume, and the `SilentSwapStats` reporter contract on BNB Chain (`0x5894a9B8B342BDb1AD7570C3656eE406eE26f676`) has published nightly snapshots since `2026-05-29`.

However, https://defillama.com/protocol/silentswap still shows **empty volume**. Root cause is on the server side: the SilentSwap protocol entry (id `7964`) in `defillama-server` (`defi/src/protocols/data6.ts`) is missing the `dimensions` mapping, so `generateProtocolAdaptorsList2` skips it (`configObj` is undefined → `if (!configObj) return`).

The one-line server fix mirrors the WheelX entry:

```ts
dimensions: {
  "bridge-aggregators": "silentswap",
},
```

We couldn't open that PR directly — `defillama-server` restricts interactions to prior contributors. If a maintainer can add the `dimensions` field (or point us at the right path), the adapter will start backfilling from its `2026-05-29` start date. 🙏
