### PR TITLE
[feat] Movement-Stats: tracks chain stats using explorer

### DIFF
--- a/active-users/move.ts
+++ b/active-users/move.ts
@@ -1,0 +1,31 @@
+import { FetchOptions, ProtocolType, SimpleAdapter } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+import fetchURL from "../utils/fetchURL";
+
+// Source: intercepted request from https://explorer.movementnetwork.xyz/analytics.
+const STATS_URL = "https://storage.googleapis.com/explorer_stats/chain_stats_mainnet_v2.json";
+
+const fetch = async (options: FetchOptions) => {
+  const data = await fetchURL(STATS_URL);
+  const users = data.daily_active_users.find((row: any) => row.date === options.dateString);
+  const txs = data.daily_user_transactions.find((row: any) => row.date === options.dateString);
+  const gas = data.daily_gas_from_user_transactions.find((row: any) => row.date === options.dateString);
+
+  if (!users || !txs || !gas) throw new Error(`No Movement stats found for ${options.dateString}`);
+
+  return {
+    dailyActiveUsers: users.daily_active_user_count,
+    dailyTransactionsCount: txs.num_user_transactions,
+    dailyGasUsed: gas.gas_cost,
+  };
+};
+
+const adapter: SimpleAdapter = {
+  version: 1,
+  fetch,
+  chains: [CHAIN.MOVE],
+  protocolType: ProtocolType.CHAIN,
+  start: "2026-05-10",
+};
+
+export default adapter;

--- a/new-users/move.ts
+++ b/new-users/move.ts
@@ -1,0 +1,27 @@
+import { FetchOptions, ProtocolType, SimpleAdapter } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+import fetchURL from "../utils/fetchURL";
+
+// Source: intercepted request from https://explorer.movementnetwork.xyz/analytics.
+const STATS_URL = "https://storage.googleapis.com/explorer_stats/chain_stats_mainnet_v2.json";
+
+const fetch = async (options: FetchOptions) => {
+  const data = await fetchURL(STATS_URL);
+  const users = data.daily_new_accounts_created.find((row: any) => row.date === options.dateString);
+
+  if (!users) throw new Error(`No Movement new account stats found for ${options.dateString}`);
+
+  return {
+    dailyNewUsers: users.new_account_count,
+  };
+};
+
+const adapter: SimpleAdapter = {
+  version: 1,
+  fetch,
+  chains: [CHAIN.MOVE],
+  protocolType: ProtocolType.CHAIN,
+  start: "2026-05-10",
+};
+
+export default adapter;


### PR DESCRIPTION
## Summary
- Adds Movement chain user-stat adapters for active users and new users.
- Uses the Movement explorer analytics stats feed to report daily active users, transactions, gas cost, and new accounts.

## Changes
- Added `active-users/move.ts` for `CHAIN.MOVE`.
- Added `new-users/move.ts` for `CHAIN.MOVE`.
- Reads stats from `https://storage.googleapis.com/explorer_stats/chain_stats_mainnet_v2.json`, sourced from an intercepted request on `https://explorer.movementnetwork.xyz/analytics`.
- Reports `dailyActiveUsers`, `dailyTransactionsCount`, and `dailyGasUsed` from the active-users adapter.
- Reports `dailyNewUsers` from the new-users adapter.

## Methodology
- `dailyActiveUsers` uses `daily_active_users[].daily_active_user_count`.
- `dailyTransactionsCount` uses `daily_user_transactions[].num_user_transactions`.
- `dailyGasUsed` uses `daily_gas_from_user_transactions[].gas_cost`, which is denominated in MOVE tokens.
- `dailyNewUsers` uses `daily_new_accounts_created[].new_account_count`.

## Tests
- `pnpm test active-users move 2026-06-08`
- `pnpm test new-users move 2026-06-08`