### PR TITLE
[feat] Hedera-Stats: track stats using subgraph

### DIFF
--- a/active-users/hedera.ts
+++ b/active-users/hedera.ts
@@ -1,0 +1,46 @@
+import { FetchOptions, ProtocolType, SimpleAdapter } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+import { postURL } from "../utils/fetchURL";
+
+// HashScan's mainnet metrics page reads Hedera stats from Hgraph GraphQL.
+const HGRAPH_GRAPHQL_URL = "https://mainnet.hedera.api.hgraph.io/v1/graphql";
+
+const fetch = async (options: FetchOptions) => {
+  const startDate = `${options.dateString}T00:00:00`;
+  const endDate = new Date(options.toTimestamp * 1e3).toISOString();
+  const query = `{
+    activeAccounts: ecosystem_metric(
+      where: { name: { _eq: "active_accounts" }, period: { _eq: "day" }, start_date: { _eq: "${startDate}" } }
+      limit: 1
+    ) { total }
+    transactions: ecosystem_metric(
+      where: { name: { _eq: "new_transactions" }, period: { _eq: "day" }, start_date: { _eq: "${startDate}" } }
+      limit: 1
+    ) { total }
+    networkFees: ecosystem_metric(
+      where: { name: { _eq: "network_fee" }, period: { _eq: "hour" }, start_date: { _gte: "${startDate}" }, end_date: { _lte: "${endDate}" } }
+      order_by: { end_date: asc }
+    ) { total }
+  }`;
+  const response = await postURL(HGRAPH_GRAPHQL_URL, { query });
+
+  const activeAccounts = response.data.activeAccounts[0].total;
+  const transactions = response.data.transactions[0].total;
+  const networkFees = response.data.networkFees;
+
+  return {
+    dailyActiveUsers: Number(activeAccounts),
+    dailyTransactionsCount: Number(transactions),
+    dailyGasUsed: networkFees.reduce((sum: number, metric: any) => sum + Number(metric.total), 0) / 1e8,
+  };
+};
+
+const adapter: SimpleAdapter = {
+  version: 1,
+  fetch,
+  chains: [CHAIN.HEDERA],
+  protocolType: ProtocolType.CHAIN,
+  start: "2019-09-13",
+};
+
+export default adapter;

--- a/new-users/hedera.ts
+++ b/new-users/hedera.ts
@@ -1,0 +1,33 @@
+import { FetchOptions, ProtocolType, SimpleAdapter } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+import { postURL } from "../utils/fetchURL";
+
+// HashScan's mainnet metrics page reads Hedera stats from Hgraph GraphQL.
+const HGRAPH_GRAPHQL_URL = "https://mainnet.hedera.api.hgraph.io/v1/graphql";
+
+const fetch = async (options: FetchOptions) => {
+  const startDate = `${options.dateString}T00:00:00`;
+  const query = `{
+    newAccounts: ecosystem_metric(
+      where: { name: { _eq: "new_accounts" }, period: { _eq: "day" }, start_date: { _eq: "${startDate}" } }
+      limit: 1
+    ) { total }
+  }`;
+  const response = await postURL(HGRAPH_GRAPHQL_URL, { query });
+
+  const newAccounts = response.data.newAccounts[0].total;
+
+  return {
+    dailyNewUsers: Number(newAccounts),
+  };
+};
+
+const adapter: SimpleAdapter = {
+  version: 1,
+  fetch,
+  chains: [CHAIN.HEDERA],
+  protocolType: ProtocolType.CHAIN,
+  start: "2019-09-13",
+};
+
+export default adapter;


### PR DESCRIPTION
## Summary
- Adds Hedera chain user tracking for active users and new users.
- Uses HashScan's mainnet metrics source via Hgraph GraphQL daily Hedera stats.
- Tracks active accounts, new accounts, transaction count, and network fee-derived gas usage from `2019-09-13`.

## Changes
- Added `active-users/hedera.ts` for Hedera `dailyActiveUsers`, `dailyTransactionsCount`, and `dailyGasUsed`.
- Added `new-users/hedera.ts` for Hedera `dailyNewUsers`.
- Reads Hgraph `ecosystem_metric` rows for:
  - `active_accounts`
  - `new_transactions`
  - `network_fee`
  - `new_accounts`

## Methodology
- Daily user metrics are matched by Hgraph `start_date` using the DefiLlama test window date.
- `dailyActiveUsers` uses the daily `active_accounts` metric.
- `dailyTransactionsCount` uses the daily `new_transactions` metric.
- `dailyGasUsed` sums hourly `network_fee` rows over the day and divides by `1e8` to convert tinybar-denominated totals to HBAR units.
- `dailyNewUsers` uses the daily `new_accounts` metric.

## Tests
- `pnpm test active-users hedera 2019-09-14`
  - Active users: `32`
  - Transactions: `12.94k`
  - Gas used: `13`
- `pnpm test new-users hedera 2019-09-14`
  - New users: `2`
- `pnpm test active-users hedera 2020-01-01`
  - Active users: `61`
  - Transactions: `335.16k`
  - Gas used: `682`
- `pnpm test new-users hedera 2020-01-01`
  - New users: `11`
- `pnpm test active-users hedera 2022-06-15`
  - Active users: `1.88k`
  - Transactions: `587.78k`
  - Gas used: `3.17k`
- `pnpm test new-users hedera 2022-06-15`
  - New users: `1.91k`
- `pnpm test active-users hedera 2024-12-01`
  - Active users: `10.15k`
  - Transactions: `324.97k`
  - Gas used: `11.64k`
- `pnpm test new-users hedera 2024-12-01`
  - New users: `7.28k`
- `pnpm test active-users hedera 2026-06-06`
  - Active users: `3.62k`
  - Transactions: `486.98k`
  - Gas used: `13.54k`
- `pnpm test new-users hedera 2026-06-06`
  - New users: `7.31k`
