### PR TITLE
[feat] Tezos-Stats: tracks chain stats via explorer api

### DIFF
--- a/active-users/tezos.ts
+++ b/active-users/tezos.ts
@@ -1,0 +1,34 @@
+import { FetchOptions, ProtocolType, SimpleAdapter } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+import { httpGet } from "../utils/fetchURL";
+
+// Source: TzKT Explorer stats page charts backed by DipDup stats API.
+const STATS_API = "https://stats.dipdup.net/v1";
+const SIZE = 1000;
+
+async function getValue(path: string, timestamp: number) {
+  const data = await httpGet(`${STATS_API}${path}`);
+  return Number(data.find((item: any) => item.ts === timestamp).value);
+}
+
+const fetch = async (options: FetchOptions) => {
+  const [activeUsers, transactions] = await Promise.all([
+    getValue(`/histogram/transactions/distinct/day?field=Sender&SenderKind=1&size=${SIZE}`, options.startOfDay),
+    getValue(`/histogram/transactions/count/day?size=${SIZE}`, options.startOfDay),
+  ]);
+
+  return {
+    dailyActiveUsers: activeUsers,
+    dailyTransactionsCount: transactions,
+  };
+};
+
+const adapter: SimpleAdapter = {
+  version: 1,
+  fetch,
+  chains: [CHAIN.TEZOS],
+  protocolType: ProtocolType.CHAIN,
+  start: "2023-09-14",
+};
+
+export default adapter;

--- a/active-users/tezos.ts
+++ b/active-users/tezos.ts
@@ -3,18 +3,27 @@ import { CHAIN } from "../helpers/chains";
 import { httpGet } from "../utils/fetchURL";
 
 // Source: TzKT Explorer stats page charts backed by DipDup stats API.
+// Timestamp.gte/.lte (unix seconds) anchor the histogram to the requested day;
+// without them the API only serves a sliding window of recent buckets, so old
+// dates fall out of range over time. Edge buckets of the requested range can be
+// trimmed, so the window is padded by 3 days on each side of the target day.
 const STATS_API = "https://stats.dipdup.net/v1";
-const SIZE = 1000;
+const ONE_DAY = 24 * 60 * 60;
+const PAD = 3 * ONE_DAY;
 
 async function getValue(path: string, timestamp: number) {
-  const data = await httpGet(`${STATS_API}${path}`);
-  return Number(data.find((item: any) => item.ts === timestamp).value);
+  const sep = path.includes("?") ? "&" : "?";
+  const data = await httpGet(`${STATS_API}${path}${sep}size=10&Timestamp.gte=${timestamp - PAD}&Timestamp.lte=${timestamp + PAD}`);
+  const row = data.find((item: any) => item.ts === timestamp);
+  if (!row) throw new Error(`No Tezos data for ts ${timestamp} at ${path}`);
+  return Number(row.value);
 }
 
 const fetch = async (options: FetchOptions) => {
   const [activeUsers, transactions] = await Promise.all([
-    getValue(`/histogram/transactions/distinct/day?field=Sender&SenderKind=1&size=${SIZE}`, options.startOfDay),
-    getValue(`/histogram/transactions/count/day?size=${SIZE}`, options.startOfDay),
+    // SenderKind=1 filters to user accounts (excludes contract senders)
+    getValue(`/histogram/transactions/distinct/day?field=Sender&SenderKind=1`, options.startOfDay),
+    getValue(`/histogram/transactions/count/day`, options.startOfDay),
   ]);
 
   return {
@@ -28,7 +37,7 @@ const adapter: SimpleAdapter = {
   fetch,
   chains: [CHAIN.TEZOS],
   protocolType: ProtocolType.CHAIN,
-  start: "2023-09-14",
+  start: "2018-06-30",
 };
 
 export default adapter;

--- a/new-users/tezos.ts
+++ b/new-users/tezos.ts
@@ -3,16 +3,25 @@ import { CHAIN } from "../helpers/chains";
 import { httpGet } from "../utils/fetchURL";
 
 // Source: TzKT Explorer stats page charts backed by DipDup stats API.
-const ACCOUNTS_STATS_URL = "https://stats.dipdup.net/v1/histogram/accounts_stats/max/day?field=Total&size=1000";
+// Timestamp.gte/.lte (unix seconds) anchor the histogram to the requested day;
+// without them the API only serves a sliding window of recent buckets, so old
+// dates fall out of range over time. Edge buckets of the requested range can be
+// trimmed, so the window is padded by 3 days beyond the two days we need.
+const ACCOUNTS_STATS_URL = "https://stats.dipdup.net/v1/histogram/accounts_stats/max/day?field=Total";
 const ONE_DAY = 24 * 60 * 60;
+const PAD = 3 * ONE_DAY;
 
 const fetch = async (options: FetchOptions) => {
-  const data = await httpGet(ACCOUNTS_STATS_URL);
-  const today = Number(data.find((item: any) => item.ts === options.startOfDay).value);
-  const yesterday = Number(data.find((item: any) => item.ts === options.startOfDay - ONE_DAY).value);
+  const data = await httpGet(`${ACCOUNTS_STATS_URL}&size=12&Timestamp.gte=${options.startOfDay - ONE_DAY - PAD}&Timestamp.lte=${options.startOfDay + PAD}`);
+  const totalAt = (ts: number) => {
+    const row = data.find((item: any) => item.ts === ts);
+    if (!row) throw new Error(`No Tezos total accounts snapshot for ts ${ts}`);
+    return Number(row.value);
+  };
 
+  // new users = day-over-day delta of the total account count
   return {
-    dailyNewUsers: today - yesterday,
+    dailyNewUsers: totalAt(options.startOfDay) - totalAt(options.startOfDay - ONE_DAY),
   };
 };
 
@@ -21,7 +30,7 @@ const adapter: SimpleAdapter = {
   fetch,
   chains: [CHAIN.TEZOS],
   protocolType: ProtocolType.CHAIN,
-  start: "2023-09-16",
+  start: "2018-07-01", // first day with a previous-day snapshot (data starts 2018-06-30)
 };
 
 export default adapter;

--- a/new-users/tezos.ts
+++ b/new-users/tezos.ts
@@ -1,0 +1,27 @@
+import { FetchOptions, ProtocolType, SimpleAdapter } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+import { httpGet } from "../utils/fetchURL";
+
+// Source: TzKT Explorer stats page charts backed by DipDup stats API.
+const ACCOUNTS_STATS_URL = "https://stats.dipdup.net/v1/histogram/accounts_stats/max/day?field=Total&size=1000";
+const ONE_DAY = 24 * 60 * 60;
+
+const fetch = async (options: FetchOptions) => {
+  const data = await httpGet(ACCOUNTS_STATS_URL);
+  const today = Number(data.find((item: any) => item.ts === options.startOfDay).value);
+  const yesterday = Number(data.find((item: any) => item.ts === options.startOfDay - ONE_DAY).value);
+
+  return {
+    dailyNewUsers: today - yesterday,
+  };
+};
+
+const adapter: SimpleAdapter = {
+  version: 1,
+  fetch,
+  chains: [CHAIN.TEZOS],
+  protocolType: ProtocolType.CHAIN,
+  start: "2023-09-16",
+};
+
+export default adapter;


### PR DESCRIPTION
## Summary
- Adds Tezos chain user tracking for active users and new users.
- Uses the TzKT Explorer stats page data source backed by the DipDup stats API.
- Tracks daily active users, daily transactions count, and daily new users.

## Changes
- Added `active-users/tezos.ts` for Tezos `dailyActiveUsers` and `dailyTransactionsCount`.
- Added `new-users/tezos.ts` for Tezos `dailyNewUsers`.
- Uses `transactions/distinct/day` with `field=Sender` and `SenderKind=1` for active users.
- Uses `transactions/count/day` for transaction count.
- Uses daily total account snapshots from `accounts_stats/max/day?field=Total` and reports the day-over-day delta as new users.

## Methodology
- Active users are counted as distinct Tezos transaction senders from the TzKT stats page chart source.
- New users are calculated as the difference between current-day and previous-day total account counts.
- Active-users backfill starts at `2023-09-14`, based on the available TzKT stats API daily window.
- New-users backfill starts at `2023-09-16`, because the adapter needs the previous day total account snapshot.

## Tests
- `pnpm test active-users tezos 2026-06-06`
  - Active users: `3.79k`
  - Transactions count: `158.83k`
- `pnpm test new-users tezos 2026-06-06`
  - New users: `146`
- `pnpm test active-users tezos 2024-12-01`
  - Active users: `4.46k`
  - Transactions count: `245.25k`
- `pnpm test new-users tezos 2024-12-01`
  - New users: `1.74k`
- `pnpm test active-users tezos 2023-09-15`
  - Active users: `3.49k`
  - Transactions count: `81.59k`
- `pnpm test new-users tezos 2023-09-17`
  - New users: `7.97k`