### PR TITLE
[feat] archer-exchange - Add DAUs and volume data on Solana

### DIFF
--- a/active-users/archer-exchange.ts
+++ b/active-users/archer-exchange.ts
@@ -1,0 +1,26 @@
+import { FetchOptions, SimpleAdapter } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+import { httpGet } from "../utils/fetchURL";
+
+const STATS_URL = "https://api.archer.exchange/v1/stats/dimensions";
+
+const fetch = async (_a: any, _b: any, options: FetchOptions) => {
+  const { activeUsers, newUsers, transactions } = await httpGet(
+    `${STATS_URL}?start=${options.startTimestamp}&end=${options.endTimestamp}`
+  );
+
+  return {
+    dailyActiveUsers: Number(activeUsers),
+    dailyNewUsers: Number(newUsers),
+    dailyTransactionsCount: Number(transactions),
+  };
+};
+
+const adapter: SimpleAdapter = {
+  version: 1,
+  fetch,
+  chains: [CHAIN.SOLANA],
+  start: "2026-02-23",
+};
+
+export default adapter;

--- a/active-users/archer-exchange.ts
+++ b/active-users/archer-exchange.ts
@@ -9,11 +9,14 @@ const fetch = async (options: FetchOptions) => {
     `${STATS_URL}?start=${options.startTimestamp}&end=${options.endTimestamp}`
   );
 
-  return {
-    dailyActiveUsers: Number(activeUsers),
-    dailyNewUsers: Number(newUsers),
-    dailyTransactionsCount: Number(transactions),
-  };
+  const dailyActiveUsers = Number(activeUsers);
+  const dailyNewUsers = Number(newUsers);
+  const dailyTransactionsCount = Number(transactions);
+  if (![dailyActiveUsers, dailyNewUsers, dailyTransactionsCount].every(Number.isFinite)) {
+    throw new Error("archer-exchange: invalid user metrics from stats endpoint");
+  }
+
+  return { dailyActiveUsers, dailyNewUsers, dailyTransactionsCount };
 };
 
 const adapter: SimpleAdapter = {

--- a/active-users/archer-exchange.ts
+++ b/active-users/archer-exchange.ts
@@ -4,7 +4,7 @@ import { httpGet } from "../utils/fetchURL";
 
 const STATS_URL = "https://api.archer.exchange/v1/stats/dimensions";
 
-const fetch = async (_a: any, _b: any, options: FetchOptions) => {
+const fetch = async (options: FetchOptions) => {
   const { activeUsers, newUsers, transactions } = await httpGet(
     `${STATS_URL}?start=${options.startTimestamp}&end=${options.endTimestamp}`
   );
@@ -17,7 +17,7 @@ const fetch = async (_a: any, _b: any, options: FetchOptions) => {
 };
 
 const adapter: SimpleAdapter = {
-  version: 1,
+  version: 2,
   fetch,
   chains: [CHAIN.SOLANA],
   start: "2026-02-23",

--- a/dexs/archer-exchange.ts
+++ b/dexs/archer-exchange.ts
@@ -1,0 +1,27 @@
+import { FetchOptions, SimpleAdapter } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+import { httpGet } from "../utils/fetchURL";
+
+const STATS_URL = "https://api.archer.exchange/v1/stats/dimensions";
+
+const fetch = async (_a: any, _b: any, options: FetchOptions) => {
+  const { volumeUsd } = await httpGet(
+    `${STATS_URL}?start=${options.startTimestamp}&end=${options.endTimestamp}`
+  );
+
+  const dailyVolume = options.createBalances();
+  dailyVolume.addUSDValue(Number(volumeUsd));
+  return { dailyVolume };
+};
+
+const adapter: SimpleAdapter = {
+  version: 1,
+  adapter: {
+    [CHAIN.SOLANA]: {
+      fetch,
+      start: "2026-02-23",
+    },
+  },
+};
+
+export default adapter;

--- a/dexs/archer-exchange.ts
+++ b/dexs/archer-exchange.ts
@@ -9,8 +9,13 @@ const fetch = async (options: FetchOptions) => {
     `${STATS_URL}?start=${options.startTimestamp}&end=${options.endTimestamp}`
   );
 
+  const volume = Number(volumeUsd);
+  if (!Number.isFinite(volume)) {
+    throw new Error(`archer-exchange: invalid volumeUsd from stats endpoint: ${volumeUsd}`);
+  }
+
   const dailyVolume = options.createBalances();
-  dailyVolume.addUSDValue(Number(volumeUsd));
+  dailyVolume.addUSDValue(volume);
   return { dailyVolume };
 };
 

--- a/dexs/archer-exchange.ts
+++ b/dexs/archer-exchange.ts
@@ -4,7 +4,7 @@ import { httpGet } from "../utils/fetchURL";
 
 const STATS_URL = "https://api.archer.exchange/v1/stats/dimensions";
 
-const fetch = async (_a: any, _b: any, options: FetchOptions) => {
+const fetch = async (options: FetchOptions) => {
   const { volumeUsd } = await httpGet(
     `${STATS_URL}?start=${options.startTimestamp}&end=${options.endTimestamp}`
   );
@@ -15,7 +15,7 @@ const fetch = async (_a: any, _b: any, options: FetchOptions) => {
 };
 
 const adapter: SimpleAdapter = {
-  version: 1,
+  version: 2,
   adapter: {
     [CHAIN.SOLANA]: {
       fetch,


### PR DESCRIPTION
**Not a new protocol listing.** Archer Exchange is already listed for TVL; this PR adds two dimension adapters for the existing protocol:

- `dexs/archer-exchange.ts` — daily DEX volume (USD)
- `active-users/archer-exchange.ts` — daily active users, new users, and transaction counts

Both source per-UTC-day metrics from Archer's public stats endpoint (`https://api.archer.exchange/v1/stats/dimensions?start=<unixSec>&end=<unixSec>`), computed server-side from on-chain trade data (deduped). Slug `archer-exchange` matches the existing TVL adapter so all metrics roll up under one protocol page. Start date `2026-02-23` is the protocol's launch day.

DefiLlama's generic (Allium-based) active-users router is EVM-only, so the Solana DAU/new-user/transaction metrics are served via this custom adapter against the backend endpoint.

"Allow edits by maintainers" is enabled.