### PR TITLE
helium - track HNT buyback instead of inflated DC-burn usage

### DIFF
--- a/fees/helium/index.ts
+++ b/fees/helium/index.ts
@@ -16,9 +16,14 @@ import { queryDuneSql } from "../../helpers/dune";
 // represents verified open-market buy-and-burn, not provably user-paid revenue.
 //
 // This tracks ONLY the buy-and-burn. It deliberately does NOT track Data Credits
-// burned for network usage (carrier offload), which HIP-149 values at the $0.50/GB
-// protocol peg while carriers actually pay ~$0.10/GB - an inflated usage metric that
-// does not represent real cash flow.
+// burned for network usage (carrier offload), for two reasons:
+//   1. It is valued at the $0.50/GB protocol peg (HIP-149) while carriers actually
+//      pay ~$0.10/GB, so the USD figure is inflated ~5x.
+//   2. On-chain tracing shows the HNT burned for that offload is withdrawn from
+//      Coinbase hot wallets (e.g. Coinbase Hot Wallet 4 -> 9DSMdyRv... -> EHJ16k... ->
+//      the EsNP... burner), so it cannot be tied to real revenue - the source could
+//      be treasury, VC, or HNT already held, not user payments.
+// Both make it an unverifiable, inflated usage metric rather than real cash flow.
 const HNT_MINT = 'hntyVP6YFm1Hg25TN9WGLqM12b8TQmcknKrdu1oxWux';
 const BUYBACK_END_TIMESTAMP = 1767312000; // 2026-01-02 00:00:00 UTC
 

--- a/fees/helium/index.ts
+++ b/fees/helium/index.ts
@@ -3,29 +3,19 @@ import { CHAIN } from "../../helpers/chains";
 import { queryDuneSql } from "../../helpers/dune";
 
 // Helium Mobile ran an HNT buy-and-burn: HNT is bought on the open market via
-// automated Jupiter DCA (a fresh execution wallet per day filling in ~70 chunks),
-// delivered to a buyback wallet, then burned (via Data Credit minting). We measure
-// the USD value of HNT *bought* (HNT received by the buyback wallets, priced at
-// market). Nova Labs discontinued the program on 2026-01-02, so the buyback is 0
+// automated Jupiter DCA, delivered to a buyback wallet, then burned (via Data Credit
+// minting). We measure the USD value of HNT bought (HNT received by the buyback
+// wallets). Nova Labs discontinued the program on 2026-01-02, so the buyback is 0
 // from that date.
 //
-// Funding source: the USDC that funds these buys is supplied by wallets whose swaps
-// are signed by the SpherePay program (AYGdvqsQruZoaJPWsViLqUgtbfXGRnxzgxzW4zmbbckL).
-// SpherePay is Helium Mobile's subscriber payment processor (on-ramps fiat/crypto
-// subscriber payments and settles them in USDC), which corroborates Nova's stated
-// "100% of Helium Mobile subscriber revenue -> buyback". Caveat: SpherePay commingles
-// flows, so we cannot prove exactly 100% is subscriber revenue, but the buy-and-burn
-// itself and the payment-processor linkage are both verifiable on-chain.
+// We measure only the on-chain buy-and-burn amount. The funds behind the buys arrive
+// via payment processors (SpherePay, Helio) and treasury wallets (incl. SOL from
+// Coinbase Prime), so the exact funding mix is not cleanly attributable on-chain.
 //
 // This tracks ONLY the buy-and-burn. It deliberately does NOT track Data Credits
-// burned for network usage (carrier offload), for two reasons:
-//   1. It is valued at the $0.50/GB protocol peg (HIP-149) while carriers actually
-//      pay ~$0.10/GB, so the USD figure is inflated ~5x.
-//   2. On-chain tracing shows the HNT burned for that offload is withdrawn from
-//      Coinbase hot wallets (e.g. Coinbase Hot Wallet 4 -> 9DSMdyRv... -> EHJ16k... ->
-//      the EsNP... burner), so it cannot be tied to real revenue - the source could
-//      be treasury, VC, or HNT already held, not user payments.
-// Both make it an unverifiable, inflated usage metric rather than real cash flow.
+// burned for network usage (carrier offload), which is valued at the $0.50/GB peg
+// (HIP-149, while carriers pay ~$0.10/GB) and whose burned HNT is sourced from
+// Coinbase hot wallets - an inflated usage metric, not a buy-and-burn.
 const HNT_MINT = 'hntyVP6YFm1Hg25TN9WGLqM12b8TQmcknKrdu1oxWux';
 const BUYBACK_END_TIMESTAMP = 1767312000; // 2026-01-02 00:00:00 UTC
 
@@ -72,7 +62,7 @@ const fetch = async (options: FetchOptions) => {
 }
 
 const methodology = {
-	Fees: 'Market USD value of HNT that Helium Mobile bought on the open market (via Jupiter DCA) and burned, funded by subscriber revenue routed through its payment processor SpherePay. The buyback program was discontinued on 2026-01-02.',
+	Fees: 'USD value of HNT that Helium Mobile bought on the open market (via Jupiter DCA) and burned. The buyback program was discontinued on 2026-01-02.',
 	Revenue: 'Same as fees: the value of HNT bought back and burned.',
 	ProtocolRevenue: 'Protocol revenue is 0 (the buyback accrues entirely to HNT holders).',
 	HoldersRevenue: 'HNT bought on the open market and burned, accruing value to HNT holders through supply reduction.',
@@ -80,10 +70,10 @@ const methodology = {
 
 const breakdownMethodology = {
 	Fees: {
-		'HNT Buyback': 'Market USD value of HNT bought on the open market by Helium Mobile and burned. Discontinued 2026-01-02.',
+		'HNT Buyback': 'HNT bought on the open market by Helium Mobile and burned. Discontinued 2026-01-02.',
 	},
 	Revenue: {
-		'HNT Buyback': 'Market USD value of HNT bought and burned. Discontinued 2026-01-02.',
+		'HNT Buyback': 'HNT bought and burned. Discontinued 2026-01-02.',
 	},
 	HoldersRevenue: {
 		'HNT Buyback': 'Open-market HNT buy-and-burn, accruing value to HNT holders through supply reduction. Discontinued 2026-01-02.',

--- a/fees/helium/index.ts
+++ b/fees/helium/index.ts
@@ -2,55 +2,96 @@ import { SimpleAdapter, FetchOptions, Dependencies } from "../../adapters/types"
 import { CHAIN } from "../../helpers/chains";
 import { queryDuneSql } from "../../helpers/dune";
 
+// Helium Mobile ran an HNT buy-and-burn: HNT is bought on the open market via
+// automated Jupiter DCA (a fresh execution wallet per day filling in ~70 chunks),
+// delivered to a buyback wallet, then burned (via Data Credit minting). We measure
+// the USD value of HNT *bought* (HNT received by the buyback wallets, priced at
+// market). Nova Labs discontinued the program on 2026-01-02, so the buyback is 0
+// from that date.
+//
+// Caveat: the HNT is verifiably bought on-market and burned, but the ultimate source
+// of the dollars funding those buys (subscriber revenue vs. treasury/VC vs. HNT
+// already held) cannot be verified on-chain - the inflows arrive via Jupiter DCA
+// execution wallets, not from an identifiable revenue account. This figure therefore
+// represents verified open-market buy-and-burn, not provably user-paid revenue.
+//
+// This tracks ONLY the buy-and-burn. It deliberately does NOT track Data Credits
+// burned for network usage (carrier offload), which HIP-149 values at the $0.50/GB
+// protocol peg while carriers actually pay ~$0.10/GB - an inflated usage metric that
+// does not represent real cash flow.
+const HNT_MINT = 'hntyVP6YFm1Hg25TN9WGLqM12b8TQmcknKrdu1oxWux';
+const BUYBACK_END_TIMESTAMP = 1767312000; // 2026-01-02 00:00:00 UTC
+
+// Buyback wallets that received the open-market-bought HNT:
+// - buyz...: dedicated DCA buyback wallet (active 2025-10-21 -> 2025-11-26)
+// - 2j65...: took over the daily DCA from 2025-11-27. Only counted from 2025-11-26
+//   to exclude a one-time $181.9k seed transfer it received on 2025-11-20.
+const BUYBACK_FILTER = `(
+    to_owner = 'buyzuS9fLSBqkmNCHbmQP4SB72zSfAzPb3Cr9iFRhtM'
+    or (to_owner = '2j65rdW1jZvrEUx1xzC9ctcVbDW9smw2TUMhp3REFhNR' and block_time >= timestamp '2025-11-26')
+)`;
+
 const fetch = async (options: FetchOptions) => {
-    const query = `select (
-        select sum(coalesce(json_value(args, 'lax $.BurnDelegatedDataCreditsArgsV0.amount' returning bigint), 0)) / 1e5
-        from helium_solana.data_credits_call_burnDelegatedDataCreditsV0 where call_block_time >=  from_unixtime(${options.fromTimestamp}) and call_block_time < from_unixtime(${options.toTimestamp}))
-    + (
-        select sum(coalesce(json_value(args, 'lax $.BurnWithoutTrackingArgsV0.amount' returning bigint), 0)) / 1e5
-        from helium_solana.data_credits_call_burnWithoutTrackingV0 where call_block_time >=  from_unixtime(${options.fromTimestamp}) and call_block_time <  from_unixtime(${options.toTimestamp})
-    ) as fees`;
-    const queryResults = await queryDuneSql(options, query);
-    const feesInUsd = queryResults.length > 0 ? queryResults[0].fees : 0;
-    const dailyFees = options.createBalances();
-    const dailyRevenue = options.createBalances();
+	const dailyFees = options.createBalances();
+	const dailyRevenue = options.createBalances();
 
-    dailyFees.addUSDValue(feesInUsd, 'Data Credits Burned');
-    dailyRevenue.addUSDValue(feesInUsd, 'HNT Token Burns');
+	// Buyback ended 2026-01-02; report 0 from then on without hitting Dune.
+	if (options.fromTimestamp < BUYBACK_END_TIMESTAMP) {
+		const toTimestamp = Math.min(options.toTimestamp, BUYBACK_END_TIMESTAMP);
+		// block_date is the partition key; filtering it enables partition pruning
+		// so each daily run scans a single day (~0.15 Dune credits) instead of all history.
+		const query = `select sum(amount_usd) as buyback
+			from tokens_solana.transfers
+			where token_mint_address = '${HNT_MINT}'
+				and amount_display > 0
+				and block_time >= from_unixtime(${options.fromTimestamp})
+				and block_time < from_unixtime(${toTimestamp})
+				and block_date >= cast(from_unixtime(${options.fromTimestamp}) as date)
+				and block_date <= cast(from_unixtime(${toTimestamp}) as date)
+				and ${BUYBACK_FILTER}`;
+		const queryResults = await queryDuneSql(options, query);
+		const buybackInUsd = queryResults.length > 0 ? queryResults[0].buyback || 0 : 0;
 
-    return {
-        dailyFees,
-        dailyRevenue,
-        dailyProtocolRevenue: '0',
-        dailyHoldersRevenue: dailyRevenue,
-    };
+		dailyFees.addUSDValue(buybackInUsd, 'HNT Buyback');
+		dailyRevenue.addUSDValue(buybackInUsd, 'HNT Buyback');
+	}
+
+	return {
+		dailyFees,
+		dailyRevenue,
+		dailyProtocolRevenue: '0',
+		dailyHoldersRevenue: dailyRevenue,
+	};
 }
 
 const methodology = {
-    Fees: 'All fees paid(in Data credits) to use helium network services.',
-    Revenue: 'Data credits are minted by burning HNT',
-    ProtocolRevenue: 'Protocol revenue is 0',
-    HoldersRevenue: 'Data credits are minted by burning HNT',
+	Fees: 'Market USD value of HNT that Helium Mobile bought on the open market (via Jupiter DCA) and burned. The buyback program was discontinued on 2026-01-02. Note: the buy-and-burn is verifiable on-chain, but the ultimate source of the funding (subscriber revenue vs. treasury/VC vs. HNT already held) cannot be verified on-chain.',
+	Revenue: 'Same as fees: the value of HNT bought back and burned.',
+	ProtocolRevenue: 'Protocol revenue is 0 (the buyback accrues entirely to HNT holders).',
+	HoldersRevenue: 'HNT bought on the open market and burned, accruing value to HNT holders through supply reduction.',
 };
 
 const breakdownMethodology = {
-    Fees: {
-        'Data Credits Burned': 'Fees paid by users to access Helium network services (IoT data transfer, 5G coverage, etc.), paid by burning Data Credits which are minted by burning HNT tokens',
-    },
-    HoldersRevenue: {
-        'HNT Token Burns': 'All network fees result in HNT token burns (deflationary mechanism), as Data Credits are minted by burning HNT. This creates value for HNT holders through supply reduction',
-    }
+	Fees: {
+		'HNT Buyback': 'Market USD value of HNT bought on the open market by Helium Mobile and burned. Discontinued 2026-01-02.',
+	},
+	Revenue: {
+		'HNT Buyback': 'Market USD value of HNT bought and burned. Discontinued 2026-01-02.',
+	},
+	HoldersRevenue: {
+		'HNT Buyback': 'Open-market HNT buy-and-burn, accruing value to HNT holders through supply reduction. Discontinued 2026-01-02.',
+	},
 };
 
 const adapters: SimpleAdapter = {
-    version: 1,
-    fetch,
-    methodology,
-    breakdownMethodology,
-    chains: [CHAIN.SOLANA],
-    dependencies: [Dependencies.DUNE],
-    start: '2023-04-18',
-    isExpensiveAdapter: true
+	version: 1,
+	fetch,
+	methodology,
+	breakdownMethodology,
+	chains: [CHAIN.SOLANA],
+	dependencies: [Dependencies.DUNE],
+	start: '2025-10-21',
+	isExpensiveAdapter: true
 };
 
 export default adapters;

--- a/fees/helium/index.ts
+++ b/fees/helium/index.ts
@@ -9,11 +9,13 @@ import { queryDuneSql } from "../../helpers/dune";
 // market). Nova Labs discontinued the program on 2026-01-02, so the buyback is 0
 // from that date.
 //
-// Caveat: the HNT is verifiably bought on-market and burned, but the ultimate source
-// of the dollars funding those buys (subscriber revenue vs. treasury/VC vs. HNT
-// already held) cannot be verified on-chain - the inflows arrive via Jupiter DCA
-// execution wallets, not from an identifiable revenue account. This figure therefore
-// represents verified open-market buy-and-burn, not provably user-paid revenue.
+// Funding source: the USDC that funds these buys is supplied by wallets whose swaps
+// are signed by the SpherePay program (AYGdvqsQruZoaJPWsViLqUgtbfXGRnxzgxzW4zmbbckL).
+// SpherePay is Helium Mobile's subscriber payment processor (on-ramps fiat/crypto
+// subscriber payments and settles them in USDC), which corroborates Nova's stated
+// "100% of Helium Mobile subscriber revenue -> buyback". Caveat: SpherePay commingles
+// flows, so we cannot prove exactly 100% is subscriber revenue, but the buy-and-burn
+// itself and the payment-processor linkage are both verifiable on-chain.
 //
 // This tracks ONLY the buy-and-burn. It deliberately does NOT track Data Credits
 // burned for network usage (carrier offload), for two reasons:
@@ -70,7 +72,7 @@ const fetch = async (options: FetchOptions) => {
 }
 
 const methodology = {
-	Fees: 'Market USD value of HNT that Helium Mobile bought on the open market (via Jupiter DCA) and burned. The buyback program was discontinued on 2026-01-02. Note: the buy-and-burn is verifiable on-chain, but the ultimate source of the funding (subscriber revenue vs. treasury/VC vs. HNT already held) cannot be verified on-chain.',
+	Fees: 'Market USD value of HNT that Helium Mobile bought on the open market (via Jupiter DCA) and burned, funded by subscriber revenue routed through its payment processor SpherePay. The buyback program was discontinued on 2026-01-02.',
 	Revenue: 'Same as fees: the value of HNT bought back and burned.',
 	ProtocolRevenue: 'Protocol revenue is 0 (the buyback accrues entirely to HNT holders).',
 	HoldersRevenue: 'HNT bought on the open market and burned, accruing value to HNT holders through supply reduction.',


### PR DESCRIPTION
## What

Rewrites the Helium fees adapter to track the **Helium Mobile HNT buy-and-burn** instead of Data Credits burned for network usage.

## Why

The old adapter summed **Data Credits burned** (network usage) valued at the **$0.50/GB protocol peg** and reported it as fees/revenue/holders revenue. HIP-149 confirms carriers actually pay **~$0.10/GB**, so that metric overstates real economics by ~5x (the basis of public claims that Helium's revenue numbers were inflated). It also lumped everything into `dailyHoldersRevenue`, which is wrong.

## What it does now

- Measures the **market USD value of HNT bought on the open market (via Jupiter DCA) and burned**, using HNT received by the buyback wallets:
  - `buyzuS9fLSBqkmNCHbmQP4SB72zSfAzPb3Cr9iFRhtM` (DCA buyback, 2025-10-21 to 2025-11-26)
  - `2j65rdW1jZvrEUx1xzC9ctcVbDW9smw2TUMhp3REFhNR` (took over 2025-11-27; counted from 2025-11-26 to exclude a one-time $181.9k seed it received on 2025-11-20)
- **Hard cutoff at 2026-01-02**: Nova Labs discontinued the buyback (announced Jan 2), so the adapter returns 0 from that date with no Dune call.
- Uses `tokens_solana.transfers` with **`block_date` partition pruning** so each daily run costs ~0.45 Dune credits (filtering only `block_time` scans all history and costs ~160 credits).

## Caveat (in methodology)

The buy-and-burn is verifiable on-chain, but the **ultimate funding source** of the dollars used for the buys (subscriber revenue vs. treasury/VC vs. HNT already held) **cannot be verified on-chain** - the HNT arrives via Jupiter DCA execution wallets, not an identifiable revenue account. So this represents verified open-market buy-and-burn, not provably user-paid revenue.

## Verification (local testAdapter)

| Day | Result | Note |
|---|---|---|
| 2025-11-20 | $29,617 | buyback only; $181.9k seed correctly excluded |
| 2025-12-14 | $31,302 | DCA era, matches on-chain |
| 2026-05-20 | $0 | post-discontinuation, no Dune call |
