### PR TITLE
feat: add lulo fees adapter

### DIFF
--- a/fees/lulo.ts
+++ b/fees/lulo.ts
@@ -1,0 +1,65 @@
+import { Dependencies, FetchOptions, SimpleAdapter } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+import ADDRESSES from "../helpers/coreAssets.json";
+import { METRIC } from "../helpers/metrics";
+import { queryDuneSql } from "../helpers/dune";
+
+const USDC = ADDRESSES.solana.USDC;
+const LULO_PROGRAM = "FL3X2pRsQ9zHENpZSKDRREtccwJuei8yg9fwDu9UN69Q";
+
+const fetch = async (options: FetchOptions) => {
+  const dailyFees = options.createBalances();
+  const dailySupplySideRevenue = options.createBalances();
+
+  const query = `
+    SELECT
+      sum(CASE WHEN lm LIKE '%accrued_interest=%' AND lm LIKE '%protected_accumulated=%'
+               THEN cast(regexp_extract(lm, 'accrued_interest=([0-9]+)', 1) AS double) ELSE 0 END) AS gross_yield,
+      sum(CASE WHEN lm LIKE '%protected_referral_fee=%' OR lm LIKE '%regular_referral_fee=%'
+               THEN cast(regexp_extract(lm, 'referral_fee=([0-9]+)', 1) AS double) ELSE 0 END) AS performance_fee
+    FROM solana.transactions
+    CROSS JOIN UNNEST(log_messages) AS u(lm)
+    WHERE TIME_RANGE
+      AND contains(account_keys, '${LULO_PROGRAM}')
+      AND (lm LIKE '%accrued_interest=%' OR lm LIKE '%referral_fee=%')`;
+
+  const [row] = await queryDuneSql(options, query);
+
+  const grossYield = Number(row?.gross_yield ?? 0);
+  const performanceFee = Number(row?.performance_fee ?? 0);
+
+  dailyFees.add(USDC, grossYield, METRIC.ASSETS_YIELDS);
+  dailySupplySideRevenue.add(USDC, grossYield - performanceFee, METRIC.ASSETS_YIELDS);
+
+  return {
+    dailyFees,
+    dailySupplySideRevenue,
+  };
+};
+
+const methodology = {
+  Fees: "Gross yield accrued on stablecoin deposits across Lulo's underlying lending integrations.",
+  SupplySideRevenue: "Gross yield minus Lulo's  performance fee (charged at withdrawal, routed through the referral system).",
+};
+
+const breakdownMethodology = {
+  Fees: {
+    [METRIC.ASSETS_YIELDS]: "Gross yield on deposited assets.",
+  },
+  SupplySideRevenue: {
+    [METRIC.ASSETS_YIELDS]: "Depositor retained yield after performance fee.",
+  },
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  fetch,
+  chains: [CHAIN.SOLANA],
+  start: "2025-01-01",
+  isExpensiveAdapter: true,
+  dependencies: [Dependencies.DUNE],
+  methodology,
+  breakdownMethodology,
+};
+
+export default adapter;

--- a/fees/lulo.ts
+++ b/fees/lulo.ts
@@ -14,22 +14,19 @@ const fetch = async (options: FetchOptions) => {
   const query = `
     SELECT
       sum(CASE WHEN lm LIKE '%accrued_interest=%' AND lm LIKE '%protected_accumulated=%'
-               THEN cast(regexp_extract(lm, 'accrued_interest=([0-9]+)', 1) AS double) ELSE 0 END) AS gross_yield,
-      sum(CASE WHEN lm LIKE '%protected_referral_fee=%' OR lm LIKE '%regular_referral_fee=%'
-               THEN cast(regexp_extract(lm, 'referral_fee=([0-9]+)', 1) AS double) ELSE 0 END) AS performance_fee
+               THEN cast(regexp_extract(lm, 'accrued_interest=([0-9]+)', 1) AS double) ELSE 0 END) AS gross_yield
     FROM solana.transactions
     CROSS JOIN UNNEST(log_messages) AS u(lm)
     WHERE TIME_RANGE
       AND contains(account_keys, '${LULO_PROGRAM}')
-      AND (lm LIKE '%accrued_interest=%' OR lm LIKE '%referral_fee=%')`;
+      AND lm LIKE '%accrued_interest=%'`;
 
   const [row] = await queryDuneSql(options, query);
 
   const grossYield = Number(row?.gross_yield ?? 0);
-  const performanceFee = Number(row?.performance_fee ?? 0);
 
   dailyFees.add(USDC, grossYield, METRIC.ASSETS_YIELDS);
-  dailySupplySideRevenue.add(USDC, grossYield - performanceFee, METRIC.ASSETS_YIELDS);
+  dailySupplySideRevenue.add(USDC, grossYield, METRIC.ASSETS_YIELDS);
 
   return {
     dailyFees,
@@ -38,8 +35,8 @@ const fetch = async (options: FetchOptions) => {
 };
 
 const methodology = {
-  Fees: "Gross yield accrued on stablecoin deposits across Lulo's underlying lending integrations.",
-  SupplySideRevenue: "Gross yield minus Lulo's  performance fee (charged at withdrawal, routed through the referral system).",
+  Fees: "Gross yield accrued on stablecoin deposits via Lulo's underlying lending integrations.",
+  SupplySideRevenue: "Gross yield paid to depositors and referrers.",
 };
 
 const breakdownMethodology = {
@@ -47,7 +44,7 @@ const breakdownMethodology = {
     [METRIC.ASSETS_YIELDS]: "Gross yield on deposited assets.",
   },
   SupplySideRevenue: {
-    [METRIC.ASSETS_YIELDS]: "Depositor retained yield after performance fee.",
+    [METRIC.ASSETS_YIELDS]: "Yield to depositors and referrers.",
   },
 };
 

--- a/fees/lulo.ts
+++ b/fees/lulo.ts
@@ -49,7 +49,7 @@ const breakdownMethodology = {
 };
 
 const adapter: SimpleAdapter = {
-  version: 2,
+  version: 1,
   fetch,
   chains: [CHAIN.SOLANA],
   start: "2025-01-01",


### PR DESCRIPTION
##### Name (to be shown on DefiLlama):

Lulo

##### Twitter Link:

https://x.com/uselulo

##### List of audit links if any:

##### Website Link:

https://www.lulo.fi/

##### Logo (High resolution, will be shown with rounded borders):


##### Current TVL:

https://defillama.com/protocol/lulo

##### Treasury Addresses (if the protocol has treasury)

N/A — performance fees are routed through Lulo's referral system; no fixed treasury address is publicly designated.

##### Chain:

Solana

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed): (https://api.coingecko.com/api/v3/coins/list)

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)

##### Short Description (to be shown on DefiLlama):

Stablecoin yield optimizer on Solana that routes USDC deposits across lending protocols including Kamino, Save, Maple, and Jupiter Lend to maximize yield across Protected and Boosted tranches.

##### Token address and ticker if any:

None

##### Category (full list at https://defillama.com/categories) *Please choose only one:

Yield Aggregator

##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.):

None — yield is sourced directly from underlying lending protocol rates and does not require a price oracle.

##### Implementation Details: Briefly describe how the oracle is integrated into your project:

N/A

##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage:

N/A

##### forkedFrom (Does your project originate from another project):

None

##### methodology (what is being counted as tvl, how is tvl being calculated):

TVL represents user-deposited USDC allocated across underlying lending venues managed by Lulo, including Kamino, Save, Maple, and Jupiter Lend.

For fees methodology:

* dailyFees: Gross yield accrued on stablecoin deposits, parsed from `accrued_interest` logs emitted by the `RefreshPoolTvl` instruction of the deployed Solana program (`FL3X2pRsQ9zHENpZSKDRREtccwJuei8yg9fwDu9UN69Q`) using Dune data.
* dailySupplySideRevenue: Gross yield minus the performance fee, which is recorded as `*_referral_fee` upon withdrawal.
* Performance fees are distributed through Lulo's referral system to either Lulo-controlled house accounts or external integrators, depending on referral attribution.

##### Github org/user (Optional, if your code is open source, we can track activity):

##### Does this project have a referral program?

Yes. Approximately 12% of generated yield is collected as a performance fee and distributed through Lulo's referral system. Direct users contribute fees to Lulo's house account, while referred users generate fees for the referring integrator.