### PR TITLE
Add ClawPump fees adapter (Solana)

### DIFF
--- a/fees/clawpump.ts
+++ b/fees/clawpump.ts
@@ -1,0 +1,52 @@
+import fetchURL from "../utils/fetchURL";
+import { FetchOptions, FetchResult, SimpleAdapter } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+
+const statsURL = "https://agents.clawpump.tech/api/platform-stats";
+
+const FEE_RATE = 0.01; // 1% fee on all trading volume
+const AGENT_FEE_SHARE = 0.65; // agents earn 65% of trading fees, protocol keeps 35%
+
+const fetch = async ({ createBalances }: FetchOptions): Promise<FetchResult> => {
+  const stats = await fetchURL(statsURL);
+
+  const dailyVolume = createBalances();
+  const dailyFees = createBalances();
+  const dailyRevenue = createBalances();
+  const dailySupplySideRevenue = createBalances();
+
+  const volume24h = Number(stats.volume24hUsd);
+  const fees = volume24h * FEE_RATE;
+
+  dailyVolume.addUSDValue(volume24h);
+  dailyFees.addUSDValue(fees);
+  dailyRevenue.addUSDValue(fees * (1 - AGENT_FEE_SHARE));
+  dailySupplySideRevenue.addUSDValue(fees * AGENT_FEE_SHARE);
+
+  return {
+    dailyVolume,
+    dailyFees,
+    dailyUserFees: dailyFees,
+    dailyRevenue,
+    dailyProtocolRevenue: dailyRevenue,
+    dailySupplySideRevenue,
+  };
+};
+
+const methodology = {
+  Fees: "1% fee charged on all trading volume on ClawPump.",
+  UserFees: "Trading fees paid by traders, 1% of trading volume.",
+  Revenue: "35% of trading fees kept by the protocol.",
+  ProtocolRevenue: "35% of trading fees kept by the protocol.",
+  SupplySideRevenue: "65% of trading fees distributed to the AI agents whose tokens generated them.",
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  chains: [CHAIN.SOLANA],
+  fetch,
+  runAtCurrTime: true,
+  methodology,
+};
+
+export default adapter;


### PR DESCRIPTION
## ClawPump — fees, revenue and volume (Solana)

**Name:** ClawPump
**Category:** Launchpad
**Chain:** Solana
**Website:** https://clawpump.tech (app: https://agents.clawpump.tech)
**Twitter:** https://twitter.com/clawpumptech
**Token:** `739dnZEG4yaBWFsY8L8ZwrfhGG6dhtCSercW8Umspump` (CLAW)

ClawPump is an AI agent token launchpad on Solana (gasless launches on pump.fun; agents earn 65% of trading fees and self-fund their compute).

## Methodology
- Source: `https://agents.clawpump.tech/api/platform-stats` (`volume24hUsd`)
- Fees: 1% fee on all trading volume
- Revenue / ProtocolRevenue: 35% of fees kept by the protocol
- SupplySideRevenue: 65% of fees paid to the AI agents whose tokens generated them
- `runAtCurrTime: true` — the API only exposes a live 24h snapshot, no history

## Test output
```
SOLANA
Daily volume: 1.06 M
Daily fees: 10.58 k
Daily user fees: 10.58 k
Daily revenue: 3.70 k
Daily protocol revenue: 3.70 k
Daily supply side revenue: 6.88 k
```

Companion TVL adapter: DefiLlama/DefiLlama-Adapters#19615

🤖 Generated with [Claude Code](https://claude.com/claude-code)