### PR TITLE
Add Pokeliquid volume/fees (Solana perps)

### DIFF
--- a/dexs/pokeliquid/index.ts
+++ b/dexs/pokeliquid/index.ts
@@ -1,5 +1,6 @@
 import { SimpleAdapter, FetchOptions } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
+import { METRIC } from "../../helpers/metrics";
 import fetchURL from "../../utils/fetchURL";
 
 const API = "https://pokeliquid.xyz/api/keeper";
@@ -12,46 +13,89 @@ const API = "https://pokeliquid.xyz/api/keeper";
 const fetch = async (options: FetchOptions) => {
   const res = await fetchURL(`${API}/daily-volume?date=${options.dateString}`);
 
-  const tradingFees = res.tradingFees ?? 0;
-  const fundingFees = res.fundingFees ?? 0;
-  const liquidationFees = res.liquidationFees ?? 0;
-  const totalFees = tradingFees + fundingFees + liquidationFees;
+  if(!res || res.dailyVolume == undefined || res.tradingFees == undefined || res.fundingFees == undefined || res.liquidationFees == undefined)
+    throw new Error(`No data found for ${options.dateString}`);
 
-  // Supply side: LPs + liquidator rewards + insurance fund
-  const tradingToLPs = tradingFees * 0.50;
-  const tradingToInsurance = tradingFees * 0.25;
-  const fundingToLPs = fundingFees * 0.70;
-  const fundingToInsurance = fundingFees * 0.20;
-  const liqToLPs = liquidationFees * 0.44;
-  const liqToInsurance = liquidationFees * 0.44;
-  const liqToLiquidator = liquidationFees * 0.02;
-  const supplySide = tradingToLPs + tradingToInsurance + fundingToLPs + fundingToInsurance + liqToLPs + liqToInsurance + liqToLiquidator;
+  const tradingFees = res.tradingFees;
+  const fundingFees = res.fundingFees;
+  const liquidationFees = res.liquidationFees;
 
-  // Protocol revenue: platform's share
-  const revenue = totalFees - supplySide;
+  const dailyVolume = options.createBalances();
+  const dailyFees = options.createBalances();
+  const dailySupplySideRevenue = options.createBalances();
+  const dailyRevenue = options.createBalances();
+
+  dailyVolume.addUSDValue(res.dailyVolume);
+
+  dailyFees.addUSDValue(tradingFees, METRIC.TRADING_FEES);
+  dailyFees.addUSDValue(fundingFees, 'Funding Fees');
+  dailyFees.addUSDValue(liquidationFees, METRIC.LIQUIDATION_FEES);
+
+  dailySupplySideRevenue.addUSDValue(tradingFees * 0.5, 'Trading Fees to LPs');
+  dailySupplySideRevenue.addUSDValue(tradingFees * 0.25, 'Trading Fees to Insurance Fund');
+  dailySupplySideRevenue.addUSDValue(fundingFees * 0.70, 'Funding Fees to LPs');
+  dailySupplySideRevenue.addUSDValue(fundingFees * 0.20, 'Funding Fees to Insurance Fund');
+  dailySupplySideRevenue.addUSDValue(liquidationFees * 0.44, 'Liquidation Fees to LPs');
+  dailySupplySideRevenue.addUSDValue(liquidationFees * 0.44, 'Liquidation Fees to Insurance Fund');
+  dailySupplySideRevenue.addUSDValue(liquidationFees * 0.02, 'Liquidation Fees to Liquidator');
+
+  dailyRevenue.addUSDValue(tradingFees * 0.25, 'Trading Fees to Platform');
+  dailyRevenue.addUSDValue(fundingFees * 0.10, 'Funding Fees to Platform');
+  dailyRevenue.addUSDValue(liquidationFees * 0.10, 'Liquidation Fees to Platform');
 
   return {
-    dailyVolume: res.dailyVolume,
-    dailyFees: totalFees,
-    dailySupplySideRevenue: supplySide,
-    dailyRevenue: revenue,
-    dailyProtocolRevenue: revenue,
+    dailyVolume,
+    dailyFees,
+    dailyUserFees: dailyFees,
+    dailySupplySideRevenue,
+    dailyRevenue,
+    dailyProtocolRevenue: dailyRevenue,
   };
 };
 
 const methodology = {
   Volume: "Notional value of all perpetual positions opened",
   Fees: "Trading fees (2% open + 2% close), hourly funding fees, and liquidation fees",
+  UserFees: "Trading fees (2% open + 2% close), hourly funding fees, and liquidation fees",
   SupplySideRevenue: "Fees distributed to LPs, insurance fund, and liquidators",
   Revenue: "Fees retained by the protocol (platform share)",
+  ProtocolRevenue: "Fees retained by the protocol (platform share)",
+};
+
+const breakdownMethodology = {
+  Fees: {
+    [METRIC.TRADING_FEES]: "Trading fees charged on position open (2%) and close (2%)",
+    'Funding Fees': "Hourly funding fees settled between long and short positions",
+    [METRIC.LIQUIDATION_FEES]: "Fees charged when positions are liquidated",
+  },
+  Revenue: {
+    'Trading Fees to Platform': "25% of trading fees retained by the platform",
+    'Funding Fees to Platform': "10% of funding fees retained by the platform",
+    'Liquidation Fees to Platform': "10% of liquidation fees retained by the platform",
+  },
+  ProtocolRevenue: {
+    'Trading Fees to Platform': "25% of trading fees retained by the platform",
+    'Funding Fees to Platform': "10% of funding fees retained by the platform",
+    'Liquidation Fees to Platform': "10% of liquidation fees retained by the platform",
+  },
+  SupplySideRevenue: {
+    'Trading Fees to LPs': "50% of trading fees to liquidity providers",
+    'Trading Fees to Insurance Fund': "25% of trading fees to insurance fund",
+    'Funding Fees to LPs': "70% of funding fees to liquidity providers",
+    'Funding Fees to Insurance Fund': "20% of funding fees to insurance fund",
+    'Liquidation Fees to LPs': "44% of liquidation fees to liquidity providers",
+    'Liquidation Fees to Insurance Fund': "44% of liquidation fees to insurance fund",
+    'Liquidation Fees to Liquidator': "2% of liquidation fees to liquidator",
+  },
 };
 
 const adapter: SimpleAdapter = {
   version: 1,
   fetch,
   chains: [CHAIN.SOLANA],
-  start: "2026-04-01",
+  start: "2026-06-06",
   methodology,
+  breakdownMethodology,
 };
 
 export default adapter;

--- a/dexs/pokeliquid/index.ts
+++ b/dexs/pokeliquid/index.ts
@@ -4,13 +4,46 @@ import fetchURL from "../../utils/fetchURL";
 
 const API = "https://pokeliquid.xyz/api/keeper";
 
+// Fee distribution rates (from on-chain program):
+// Trading fees (2% open + 2% close): 50% LP, 25% insurance, 25% platform
+// Funding fees (hourly settlement):  70% LP, 20% insurance, 10% platform
+// Liquidation fees:                  44% LP, 44% insurance, 2% liquidator, 10% platform
+
 const fetch = async (options: FetchOptions) => {
   const res = await fetchURL(`${API}/daily-volume?date=${options.dateString}`);
+
+  const tradingFees = res.tradingFees ?? 0;
+  const fundingFees = res.fundingFees ?? 0;
+  const liquidationFees = res.liquidationFees ?? 0;
+  const totalFees = tradingFees + fundingFees + liquidationFees;
+
+  // Supply side: LPs + liquidator rewards + insurance fund
+  const tradingToLPs = tradingFees * 0.50;
+  const tradingToInsurance = tradingFees * 0.25;
+  const fundingToLPs = fundingFees * 0.70;
+  const fundingToInsurance = fundingFees * 0.20;
+  const liqToLPs = liquidationFees * 0.44;
+  const liqToInsurance = liquidationFees * 0.44;
+  const liqToLiquidator = liquidationFees * 0.02;
+  const supplySide = tradingToLPs + tradingToInsurance + fundingToLPs + fundingToInsurance + liqToLPs + liqToInsurance + liqToLiquidator;
+
+  // Protocol revenue: platform's share
+  const revenue = totalFees - supplySide;
+
   return {
     dailyVolume: res.dailyVolume,
-    dailyFees: res.dailyFees,
-    dailyRevenue: res.dailyFees,
+    dailyFees: totalFees,
+    dailySupplySideRevenue: supplySide,
+    dailyRevenue: revenue,
+    dailyProtocolRevenue: revenue,
   };
+};
+
+const methodology = {
+  Volume: "Notional value of all perpetual positions opened",
+  Fees: "Trading fees (2% open + 2% close), hourly funding fees, and liquidation fees",
+  SupplySideRevenue: "Fees distributed to LPs, insurance fund, and liquidators",
+  Revenue: "Fees retained by the protocol (platform share)",
 };
 
 const adapter: SimpleAdapter = {
@@ -18,6 +51,7 @@ const adapter: SimpleAdapter = {
   fetch,
   chains: [CHAIN.SOLANA],
   start: "2026-04-01",
+  methodology,
 };
 
 export default adapter;

--- a/dexs/pokeliquid/index.ts
+++ b/dexs/pokeliquid/index.ts
@@ -1,0 +1,23 @@
+import { SimpleAdapter, FetchOptions } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import fetchURL from "../../utils/fetchURL";
+
+const API = "https://pokeliquid.xyz/api/keeper";
+
+const fetch = async (options: FetchOptions) => {
+  const res = await fetchURL(`${API}/daily-volume?date=${options.dateString}`);
+  return {
+    dailyVolume: res.dailyVolume,
+    dailyFees: res.dailyFees,
+    dailyRevenue: res.dailyFees,
+  };
+};
+
+const adapter: SimpleAdapter = {
+  version: 1,
+  fetch,
+  chains: [CHAIN.SOLANA],
+  start: "2026-04-01",
+};
+
+export default adapter;

--- a/dexs/pokeliquid/index.ts
+++ b/dexs/pokeliquid/index.ts
@@ -5,6 +5,7 @@ import fetchURL from "../../utils/fetchURL";
 
 const API = "https://pokeliquid.xyz/api/keeper";
 
+// https://www.pokeliquid.xyz/docs#fees
 // Fee distribution rates (from on-chain program):
 // Trading fees (2% open + 2% close): 50% LP, 25% insurance, 25% platform
 // Funding fees (hourly settlement):  70% LP, 20% insurance, 10% platform


### PR DESCRIPTION
## Protocol Information
- **Name:** Pokeliquid
- **Website:** https://pokeliquid.xyz
- **Category:** Derivatives (Perpetuals)
- **Chain:** Solana
- **Program ID:** `5C1cz4kCA8DcD2zjhBphuK86vAjdoCnichK1kdLHPMt6`

## Methodology
- **Volume:** Sum of all trade notional values per day
- **Fees:** Sum of all trading fees collected per day (2% of collateral)
- **Revenue:** Same as fees (all fees go to protocol/LPs)

## API Endpoint
`https://pokeliquid.xyz/api/keeper/daily-volume?date=YYYY-MM-DD`

Example response:
```json
{"date":"2026-06-09","dailyVolume":216122.41,"dailyFees":430.01}
```

## Notes
- TVL adapter submitted separately to DefiLlama-Adapters (#19616)
- Data available from 2026-04-01 onward