### PR TITLE
feat: add huma finance v2 fees adapter

### DIFF
--- a/fees/huma-finance-v2/index.ts
+++ b/fees/huma-finance-v2/index.ts
@@ -1,0 +1,80 @@
+import { Dependencies, FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import { queryDuneSql } from "../../helpers/dune";
+
+// Huma V2 (PayFi lending) on Solana. Borrower payments realize profit
+// (interest yield + late fees) distributed via IncomeDistributedEvent:
+//   profit = protocol_income + pool_owner_income + ea_income + remaining
+// protocol_fee_bps = 5% -> treasury; remaining -> tranches + first-loss covers.
+
+const PROGRAM = "EVQ4s1b6N1vmWFDv8PRNc77kufBP8HcrSNWXQAhRsJq9"; // institutional credit engine
+const USDC = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
+const INCOME_DISTRIBUTED_DISC = "0x4e4f7b1264f45a73"; // anchor event discriminator
+
+const fetch = async (options: FetchOptions) => {
+  const dailyFees = options.createBalances();
+  const dailyProtocolRevenue = options.createBalances();
+  const dailySupplySideRevenue = options.createBalances();
+
+  // Event bytes: disc(8) pool(32) protocol(u128) owner(u128) ea(u128) remaining(u128)
+  const query = `
+    WITH income_logs AS (
+      SELECT from_base64(split(l.logs, ' ')[3]) AS data
+      FROM solana.transactions tx
+      CROSS JOIN UNNEST(tx.log_messages) AS l(logs)
+      WHERE tx.success = true
+        AND contains(tx.account_keys, '${PROGRAM}')
+        AND TIME_RANGE
+        AND l.logs LIKE 'Program data:%'
+        AND cardinality(split(l.logs, ' ')) = 3
+        AND try(from_base64(split(l.logs, ' ')[3])) IS NOT NULL
+    )
+    SELECT
+      SUM(bytearray_to_bigint(bytearray_reverse(bytearray_substring(data, 41, 8)))) AS protocol_income,
+      SUM(bytearray_to_bigint(bytearray_reverse(bytearray_substring(data, 57, 8)))) AS pool_owner_income,
+      SUM(bytearray_to_bigint(bytearray_reverse(bytearray_substring(data, 73, 8)))) AS ea_income,
+      SUM(bytearray_to_bigint(bytearray_reverse(bytearray_substring(data, 89, 8)))) AS remaining
+    FROM income_logs
+    WHERE bytearray_substring(data, 1, 8) = ${INCOME_DISTRIBUTED_DISC}
+  `;
+
+  const rows = await queryDuneSql(options, query);
+  const r = rows?.[0] ?? {};
+
+  const protocolSide =
+    Number(r.protocol_income ?? 0) +
+    Number(r.pool_owner_income ?? 0) +
+    Number(r.ea_income ?? 0);
+  const supplySide = Number(r.remaining ?? 0);
+
+  dailyProtocolRevenue.add(USDC, protocolSide);
+  dailySupplySideRevenue.add(USDC, supplySide);
+  dailyFees.add(USDC, protocolSide);
+  dailyFees.add(USDC, supplySide);
+
+  return {
+    dailyFees,
+    dailyRevenue: dailyProtocolRevenue,
+    dailyProtocolRevenue,
+    dailySupplySideRevenue,
+  };
+};
+
+const methodology = {
+  Fees: "Pool profit realized from borrower payments (interest yield + late fees), distributed by the Huma credit engine on each IncomeDistributedEvent.",
+  Revenue: "Protocol-side cut of pool profit: Huma treasury protocol fee plus pool owner and evaluation agent rewards.",
+  ProtocolRevenue: "Huma treasury protocol fee (protocol_fee_bps, currently 5%) plus pool owner and evaluation agent rewards (currently 0 on live pools).",
+  SupplySideRevenue: "Profit paid to liquidity providers — senior and junior tranche lenders and first-loss cover providers.",
+};
+
+const adapter: SimpleAdapter = {
+  version: 1,
+  fetch,
+  chains: [CHAIN.SOLANA],
+  start: '2024-10-10',
+  dependencies: [Dependencies.DUNE],
+  isExpensiveAdapter: true,
+  methodology,
+};
+
+export default adapter;


### PR DESCRIPTION
### What this PR does

Adds a **fees & revenue** adapter (`fees/huma-finance-v2`) for the **already-listed** Huma Finance V2 protocol (Solana). This is **not a new protocol listing** — TVL is already tracked via `projects/huma-v2`. No metadata changes; the form below is filled from the existing listing + on-chain verification for reviewer convenience.

**Source & methodology (fees):** Huma is a PayFi lending network — LPs deposit USDC that is lent to payment businesses. Borrower payments realize profit (interest yield + late fees) which the Solana credit engine (program `EVQ4s1b6N1vmWFDv8PRNc77kufBP8HcrSNWXQAhRsJq9`) distributes via the `IncomeDistributedEvent` anchor event, where:

```
profit = protocol_income + pool_owner_income + ea_income + remaining
```

The adapter sums this event (via Dune `solana.transactions` logs) and maps:
- `dailyFees` = full realized profit (interest yield + late fees)
- `dailyProtocolRevenue` / `dailyRevenue` = `protocol_income + pool_owner_income + ea_income` — the Huma treasury protocol fee (`protocol_fee_bps = 5%`) plus pool-owner/EA rewards (currently **0** on all live pools)
- `dailySupplySideRevenue` = `remaining` — paid to senior + junior tranche LPs and first-loss covers
- No `dailyHoldersRevenue` — there is **no HUMA buyback/burn in the profit path**

**Verified on-chain (contract = source of truth):** pulled the deployed program's on-chain Anchor IDL + live account reads (`HumaConfig.protocol_fee_bps = 500`); byte-validated `IncomeDistributedEvent` against a real payment tx (`protocol = exactly 5.00%` of total, `profit = protocol + remaining`). Live run on a payment day: fees $1.10M, protocol $54.9k (4.99%), supply-side $1.04M (≈8.6% APY on ~$153M, consistent with documented 8–10.5% Classic-mode APY). Activity is sparse/lumpy — most days are correctly $0 and payment days spike.

---

##### Name (to be shown on DefiLlama):
Huma Finance V2 *(existing listing — unchanged)*

##### Twitter Link:
https://x.com/humafinance

##### List of audit links if any:
https://docs.huma.finance/ecosystem-resources/security-audits (Halborn — incl. `huma-solana-programs`)

##### Website Link:
https://huma.finance/

##### Logo (High resolution, will be shown with rounded borders):
N/A — existing listing, unchanged

##### Current TVL:
~$153.2M (Solana) — existing `huma-v2` TVL adapter

##### Treasury Addresses (if the protocol has treasury)
Solana protocol-fee treasury: `HGLTeA6ZyGCU2Tbc5Vjk3E4r1YE27uhWr5cgQt25KitG` (on-chain `HumaConfig.treasury`)

##### Chain:
Solana

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed):
N/A — not set on the existing listing

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed):
N/A — not set on the existing listing

##### Short Description (to be shown on DefiLlama):
Permissionless DeFi yield, powered by real-world payment flows. *(existing listing — unchanged)*

##### Token address and ticker if any:
N/A — no token tracked on the existing listing (Huma ticker: HUMA)

##### Category (full list at https://defillama.com/categories) *Please choose only one:
Yield *(existing listing — unchanged)*

##### Oracle Provider(s):
N/A — fees adapter, no oracle used

##### Implementation Details:
N/A

##### Documentation/Proof:
N/A

##### forkedFrom (Does your project originate from another project):
No — Huma's own contracts; the Solana program mirrors Huma's `00labs/huma-contracts-v2` design

##### methodology (what is being counted):
Counts protocol fees & revenue, not TVL. `dailyFees` = realized pool profit (interest yield + late fees) from `IncomeDistributedEvent`; split into `dailyProtocolRevenue`/`dailyRevenue` (5% `protocol_fee_bps` to Huma treasury + pool-owner/EA rewards, 0 on live pools) and `dailySupplySideRevenue` (`remaining`, to tranche LPs + first-loss covers). Sourced from Dune (Solana program logs); origination fee is 0 on live pools, no holders revenue.

##### Github org/user (Optional, if your code is open source, we can track activity):
https://github.com/00labs

##### Does this project have a referral program?
Yes, Huma runs a referral / "Feathers" points program, but it does not affect the protocol-charged fees this adapter counts.