### PR TITLE
curators: blacklist Clearstar Yield USDC vault with frozen market

### DIFF
--- a/helpers/curators/index.ts
+++ b/helpers/curators/index.ts
@@ -62,6 +62,20 @@ const blacklistedTokens: Record<string, Array<{ token: string, from: string }>> 
   }],
 }
 
+// vaults excluded entirely from a given date onwards. used when a vault's share price is corrupted
+// (e.g. an allocated market frozen at 100% utilization accrues phantom interest, or a pending bad-debt
+// write-off would otherwise show up as a fake large negative day). the adapter only reads vault-level
+// share price, so a single bad market cannot be isolated - the whole vault has to be dropped.
+const blacklistedVaults: Record<string, Array<{ vault: string, from: string }>> = {
+  [CHAIN.ETHEREUM]: [{
+    // Clearstar Yield USDC (CSYUSDC) - allocated RLP/USDC market frozen at 100% utilization, accruing phantom
+    // interest that inflated reported yield from ~$281/day to ~$197k/day. vault now deprecated with unrealized
+    // bad debt; excluding from the freeze onset also keeps the eventual write-off out of the series.
+    vault: '0x9B5E92fd227876b4C07a8c02367E2CB23c639DfA',
+    from: '2026-03-21',
+  }],
+}
+
 function isOwner(owner: string, owners: Array<string>) {
   for (const item of owners) {
     if (String(item).toLowerCase() === String(owner).toLowerCase()) {
@@ -366,13 +380,19 @@ export function getCuratorExport(curatorConfig: CuratorConfig): SimpleAdapter {
         let dailyRevenue = options.createBalances()
         let dailySupplySideRevenue = options.createBalances()
 
+        // vaults blacklisted from this date onwards (corrupted share price / pending write-off)
+        const blacklistedVaultsForChain = new Set(
+          blacklistedVaults[options.chain]?.filter(item => options.dateString >= item.from).map(item => item.vault.toLowerCase())
+        )
+        const isBlacklistedVault = (vault: string) => blacklistedVaultsForChain.has(vault.toLowerCase())
+
         // morpho meta vaults
-        const morphoVaults = await getMorphoVaults(options, vaults.morpho, vaults.morphoVaultOwners);
+        const morphoVaults = (await getMorphoVaults(options, vaults.morpho, vaults.morphoVaultOwners)).filter(vault => !isBlacklistedVault(vault));
 
         // morpho v2 vaults
-        const morphoVaultsV2 = await getMorphoVaultsV2(options, vaults.morphoVaultV2Owners);
+        const morphoVaultsV2 = (await getMorphoVaultsV2(options, vaults.morphoVaultV2Owners)).filter(vault => !isBlacklistedVault(vault));
 
-        const eulerVaults = await getEulerVaults(options, vaults.euler, vaults.eulerVaultOwners);
+        const eulerVaults = (await getEulerVaults(options, vaults.euler, vaults.eulerVaultOwners)).filter(vault => !isBlacklistedVault(vault));
 
         if (morphoVaults.length > 0) {
           await getMorphoVaultFee(options, { dailyFees, dailyRevenue, dailySupplySideRevenue }, morphoVaults, curatorConfig.breakdownFees)


### PR DESCRIPTION
## Problem

The Clearstar fees/revenue numbers are heavily inflated. The CSYUSDC ("Clearstar Yield USDC") Morpho V1 vault on Ethereum (`0x9B5E92fd227876b4C07a8c02367E2CB23c639DfA`) is allocated to an RLP/USDC market that has been frozen at 100% utilization since late March 2026. That market accrues phantom interest, and because the curators adapter only reads vault-level share price growth, it reports this as real yield.

Verified locally (Ethereum only): CSYUSDC alone reported **~\$197k/day** of the adapter's ~\$198k total on 2026-06-08, ramping up from a normal ~\$281/day before the freeze. The vault is now deprecated on Morpho with ~\$5M unrealized bad debt.

## Fix

Add a date-aware per-vault blacklist in `helpers/curators/index.ts` (mirroring the existing `blacklistedTokens` mechanism), and filter blacklisted vaults out of the Morpho v1/v2 and Euler vault lists.

Applied from the freeze onset (`2026-03-21`), so it:
- removes the phantom interest from late March onward (cleaned up on refill),
- preserves the legit pre-freeze yield,
- keeps the eventual on-chain bad-debt write-off from registering as a fake large negative day once the market is force-removed.

## Verification

| date | CSYUSDC included | daily fees |
|---|---|---|
| 2026-03-14 (pre-freeze) | yes | \$1.07k (unchanged) |
| 2026-06-08 (post-freeze) | no (excluded) | \$198.3k → \$1.31k |