### PR TITLE
feat: Add WaterX perp volume adapter (Sui)

### DIFF
--- a/dexs/waterx/index.ts
+++ b/dexs/waterx/index.ts
@@ -1,0 +1,41 @@
+import { FetchOptions, FetchResultV2, SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import { queryEvents } from "../../helpers/sui";
+
+const waterxPerp = "0x44dad8a2899167fe2806c2c298366c0824180fc382aa66cb8bd034b2e9aef96f";
+
+const eventTypes = [
+  `${waterxPerp}::events::PositionOpened`,
+  `${waterxPerp}::events::PositionClosed`,
+  `${waterxPerp}::events::PositionModified`,
+  `${waterxPerp}::events::PositionLiquidated`,
+];
+
+async function fetch(options: FetchOptions): Promise<FetchResultV2> {
+  const dailyVolume = options.createBalances();
+
+  const results = await Promise.all(
+    eventTypes.map((eventType) => queryEvents({ eventType, options }))
+  );
+
+  for (const events of results) {
+    for (const event of events) {
+      dailyVolume.addUSDValue(Number(event.volume_usd.value) / 1e9);
+    }
+  }
+
+  return { dailyVolume };
+}
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  pullHourly: true,
+  adapter: {
+    [CHAIN.SUI]: {
+      fetch,
+      start: "2026-06-03",
+    },
+  },
+};
+
+export default adapter;


### PR DESCRIPTION
## Summary                                                                
  - Add WaterX perpetual DEX volume adapter on Sui                          
  - Tracks volume from on-chain events (PositionOpened, PositionClosed,     
  PositionModified, PositionLiquidated)                                     
  - Uses `volume_usd` field from events emitted by the waterx_perp package 
  - docs: https://docs.waterx.app/
  - x: https://x.com/WaterX_app