### PR TITLE
fix(basenames): wire breakdown methodology

### DIFF
--- a/fees/basenames.ts
+++ b/fees/basenames.ts
@@ -68,6 +68,7 @@ const adapter: SimpleAdapter = {
   chains: [CHAIN.BASE],
   start: "2024-07-25", // first ETHPaymentProcessed emission
   methodology,
+  breakdownMethodology,
   pullHourly: true,
 };
 


### PR DESCRIPTION
Wires the existing `breakdownMethodology` object into the Basenames adapter export.

The labels are already applied to the balances and the breakdown text is already defined in the file; this just exposes it through the adapter object so the methodology can surface correctly.