### PR TITLE
feat(rlusd): add stablecoin issuer yield fees

### DIFF
--- a/fees/ripple-usd.ts
+++ b/fees/ripple-usd.ts
@@ -5,29 +5,51 @@ import { buildStablecoinAdapter } from "../helpers/attestations-stablecoins";
 // { time, circulation (in billions), allocated (in billions), tbillRate? (in %) }
 // allocated = U.S. Treasury bills + government money-market funds; cash deposits
 // at U.S. regulated financial institutions are excluded per the helper convention.
-// Figures are month-end values from the monthly RLUSD attestation reports issued
-// by Standard Custody & Trust Company, LLC (Ripple) and examined by Deloitte:
+// Each monthly RLUSD attestation report (Standard Custody & Trust Company, LLC /
+// Ripple, examined by Deloitte) states reserves as of TWO explicit report dates
+// (mid-month and month-end); all are included below with their exact dates so
+// nearest-attestation selection never reaches far forward in time:
 // https://ripple.com/solutions/stablecoin/transparency/
 const adapter = buildStablecoinAdapter(CHAIN.OFF_CHAIN, '250', 30, [
   {
-    time: '2026-04',
+    time: '2026-04-30',
     circulation: 1.44,
     allocated: 1.30, // 1,033.3m tbills + 263.4m money-market funds
   },
   {
-    time: '2026-03',
+    time: '2026-04-24',
+    circulation: 1.54,
+    allocated: 1.37, // 999.6m tbills + 367.5m money-market funds
+  },
+  {
+    time: '2026-03-31',
     circulation: 1.24,
     allocated: 1.08, // 931.5m tbills + 146.6m money-market funds
   },
   {
-    time: '2026-02',
+    time: '2026-03-13',
+    circulation: 1.55,
+    allocated: 1.38, // 914.8m tbills + 464.8m money-market funds
+  },
+  {
+    time: '2026-02-27',
     circulation: 1.50,
     allocated: 1.31, // 890.8m tbills + 423.3m money-market funds
   },
   {
-    time: '2026-01',
+    time: '2026-02-19',
+    circulation: 1.54,
+    allocated: 1.33, // 863.4m tbills + 464.9m money-market funds
+  },
+  {
+    time: '2026-01-30',
     circulation: 1.36,
     allocated: 1.24, // 838.8m tbills + 403.1m money-market funds
+  },
+  {
+    time: '2026-01-14',
+    circulation: 1.39,
+    allocated: 1.23, // 696.4m tbills + 533.8m money-market funds
   },
 ]);
 
@@ -49,6 +71,6 @@ adapter.breakdownMethodology = {
   },
 }
 
-adapter.start = '2026-01-01';
+adapter.start = '2026-01-14'; // first attestation report date — no earlier sourced data
 
 export default adapter;

--- a/fees/ripple-usd.ts
+++ b/fees/ripple-usd.ts
@@ -12,45 +12,90 @@ import { buildStablecoinAdapter } from "../helpers/attestations-stablecoins";
 // https://ripple.com/solutions/stablecoin/transparency/
 const adapter = buildStablecoinAdapter(CHAIN.OFF_CHAIN, '250', 30, [
   {
-    time: '2026-04-30',
+    time: '2026-04',
     circulation: 1.44,
-    allocated: 1.30, // 1,033.3m tbills + 263.4m money-market funds
+    allocated: 1.03 + 0.263,
   },
   {
-    time: '2026-04-24',
-    circulation: 1.54,
-    allocated: 1.37, // 999.6m tbills + 367.5m money-market funds
-  },
-  {
-    time: '2026-03-31',
+    time: '2026-03',
     circulation: 1.24,
-    allocated: 1.08, // 931.5m tbills + 146.6m money-market funds
+    allocated: 0.93 + 0.146,
   },
   {
-    time: '2026-03-13',
-    circulation: 1.55,
-    allocated: 1.38, // 914.8m tbills + 464.8m money-market funds
+    time: '2026-02',
+    circulation: 1.5,
+    allocated: 0.89 + 0.423,
   },
   {
-    time: '2026-02-27',
-    circulation: 1.50,
-    allocated: 1.31, // 890.8m tbills + 423.3m money-market funds
+    time: '2026-01',
+    circulation: 1.358,
+    allocated: 0.839 + 0.403
   },
   {
-    time: '2026-02-19',
-    circulation: 1.54,
-    allocated: 1.33, // 863.4m tbills + 464.9m money-market funds
+    time: '2025-12',
+    circulation: 1.28,
+    allocated: 0.338 + 0.867,
   },
   {
-    time: '2026-01-30',
-    circulation: 1.36,
-    allocated: 1.24, // 838.8m tbills + 403.1m money-market funds
+    time: '2025-11',
+    circulation: 1.26,
+    allocated: 0.712 + 0.382,
   },
   {
-    time: '2026-01-14',
-    circulation: 1.39,
-    allocated: 1.23, // 696.4m tbills + 533.8m money-market funds
+    time: '2025-10',
+    circulation: 0.963,
+    allocated: 0.526 + 0.282,
   },
+  {
+    time: '2025-09',
+    circulation: 0.789,
+    allocated: 0.451 + 0.249,
+  },
+  {
+    time: '2025-08',
+    circulation: 0.701,
+    allocated: 0.394 + 0.225,
+  },
+  {
+    time: '2025-07',
+    circulation: 0.602,
+    allocated: 0.33 + 0.177
+  },
+  {
+    time: '2025-06',
+    circulation: 0.456,
+    allocated: 0.401
+  },
+  {
+    time: '2025-05',
+    circulation: 0.301,
+    allocated: 0.181 + 0.098,
+  },
+  {
+    time: '2025-04',
+    circulation: 0.317,
+    allocated: 0.14 + 0.141,
+  },
+  {
+    time: '2025-03',
+    circulation: 0.193,
+    allocated: 0.07 + 0.082,
+  },
+  {
+    time: '2025-02',
+    circulation: 0.13,
+    allocated: 0.052 + 0.046,
+  },
+  {
+    time: '2025-01',
+    circulation: 0.1067,
+    allocated: 0.042 + 0.042,
+  },
+  {
+    time: '2024-12',
+    circulation: 0.077,
+    allocated: 0.030 + 0.020,
+  }
 ]);
 
 adapter.methodology = {
@@ -71,6 +116,6 @@ adapter.breakdownMethodology = {
   },
 }
 
-adapter.start = '2026-01-14'; // first attestation report date — no earlier sourced data
+adapter.start = '2024-11-01';
 
 export default adapter;

--- a/fees/ripple-usd.ts
+++ b/fees/ripple-usd.ts
@@ -1,0 +1,54 @@
+import { CHAIN } from "../helpers/chains";
+import { METRIC } from "../helpers/metrics";
+import { buildStablecoinAdapter } from "../helpers/attestations-stablecoins";
+
+// { time, circulation (in billions), allocated (in billions), tbillRate? (in %) }
+// allocated = U.S. Treasury bills + government money-market funds; cash deposits
+// at U.S. regulated financial institutions are excluded per the helper convention.
+// Figures are month-end values from the monthly RLUSD attestation reports issued
+// by Standard Custody & Trust Company, LLC (Ripple) and examined by Deloitte:
+// https://ripple.com/solutions/stablecoin/transparency/
+const adapter = buildStablecoinAdapter(CHAIN.OFF_CHAIN, '250', 30, [
+  {
+    time: '2026-04',
+    circulation: 1.44,
+    allocated: 1.30, // 1,033.3m tbills + 263.4m money-market funds
+  },
+  {
+    time: '2026-03',
+    circulation: 1.24,
+    allocated: 1.08, // 931.5m tbills + 146.6m money-market funds
+  },
+  {
+    time: '2026-02',
+    circulation: 1.50,
+    allocated: 1.31, // 890.8m tbills + 423.3m money-market funds
+  },
+  {
+    time: '2026-01',
+    circulation: 1.36,
+    allocated: 1.24, // 838.8m tbills + 403.1m money-market funds
+  },
+]);
+
+adapter.methodology = {
+  Fees: 'All yields from RLUSD backing assets (U.S. Treasury bills and government money-market funds).',
+  Revenue: 'All yields from RLUSD backing assets (U.S. Treasury bills and government money-market funds) collected by Standard Custody & Trust Company (Ripple).',
+  ProtocolRevenue: 'All yields from RLUSD backing assets (U.S. Treasury bills and government money-market funds) collected by Standard Custody & Trust Company (Ripple).',
+}
+
+adapter.breakdownMethodology = {
+  Fees: {
+    [METRIC.ASSETS_YIELDS]: 'All yields from RLUSD backing assets (U.S. Treasury bills and government money-market funds).',
+  },
+  Revenue: {
+    [METRIC.ASSETS_YIELDS]: 'All yields from RLUSD backing assets (U.S. Treasury bills and government money-market funds) collected by Standard Custody & Trust Company (Ripple).',
+  },
+  ProtocolRevenue: {
+    [METRIC.ASSETS_YIELDS]: 'All yields from RLUSD backing assets (U.S. Treasury bills and government money-market funds) collected by Standard Custody & Trust Company (Ripple).',
+  },
+}
+
+adapter.start = '2026-01-01';
+
+export default adapter;


### PR DESCRIPTION
Adds Ripple USD (RLUSD) stablecoin issuer yield using the existing stablecoin attestation helper.

Methodology follows the existing Tether/Circle/Paxos/USD1 pattern:
- circulating supply from DefiLlama stablecoins API (stablecoin id 250)
- reserve allocation from Ripple attestations — month-end U.S. Treasury bills + government money-market funds, cash deposits excluded ([transparency page](https://ripple.com/solutions/stablecoin/transparency/), Standard Custody & Trust Company reports examined by Deloitte)
- Treasury yield from FRED DTB3
- issuer-retained asset yield reported as Fees, Revenue, and ProtocolRevenue

Local `testAdapter` runs up to the documented `FRED_API_KEY` requirement (key not available locally); the adapter is otherwise an exact mirror of the merged `fees/world-liberty-financial` shape.