### PR TITLE
[fix] Ondo-Perps: track volume via klines and fix start date

### DIFF
--- a/dexs/ondo-perps/index.ts
+++ b/dexs/ondo-perps/index.ts
@@ -1,34 +1,39 @@
+import { PromisePool } from "@supercharge/promise-pool";
 import { FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
-import { httpGet } from "../../utils/fetchURL";
+import fetchURL, { fetchURLAutoHandleRateLimit } from "../../utils/fetchURL";
 
-
-const API = "https://api.ondoperps.xyz/v1/perps/volume";
-
-type VolumeItem = {
-  market: string;
-  volume: string;
-  quoteVolume: string;
-};
+const API_BASE = "https://api.ondoperps.xyz/v1";
 
 const fetch = async (options: FetchOptions) => {
-  const response = await httpGet(API);
-  const dailyVolume = response.result.reduce((acc: number, market: VolumeItem) => acc + Number(market.quoteVolume), 0)
-  return { dailyVolume }
-}
+  const markets = (await fetchURL(`${API_BASE}/markets`)).result.perps.tradingPairs;
+
+  // No error handling as current markets may not have historical candles.
+  const { results } = await PromisePool.withConcurrency(3)
+    .for(markets)
+    .process(async ({ displayName }: any) => {
+      const { t, c, v } = await fetchURLAutoHandleRateLimit(
+        `${API_BASE}/perps/history?symbol=${encodeURIComponent(`${displayName}.P`)}&resolution=1D&from=${options.startOfDay}&to=${options.endTimestamp}`
+      );
+      const i = t.indexOf(options.startOfDay);
+      return i >= 0 ? Number(c[i]) * Number(v[i]) : 0;
+    });
+
+  const dailyVolume = results.reduce((sum: number, volume: number) => sum + volume, 0);
+
+  return { dailyVolume };
+};
 
 const methodology = {
-  Volume:
-    "Daily trading volume from Ondo Perps's API.",
+  Volume: "Total USD trading volume on Ondo Perps.",
 };
 
 const adapter: SimpleAdapter = {
-    version: 1,
-    fetch,
-    chains: [CHAIN.OFF_CHAIN],
-    start: "2025-06-08",
-    runAtCurrTime: true,
-    methodology,
+  version: 1,
+  fetch,
+  chains: [CHAIN.OFF_CHAIN],
+  start: "2026-03-17", // First OHLCV Candle
+  methodology,
 };
 
 export default adapter;

--- a/open-interest/ondo-perps.ts
+++ b/open-interest/ondo-perps.ts
@@ -1,6 +1,6 @@
 import { FetchOptions, SimpleAdapter } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
-import { httpGet } from "../utils/fetchURL";
+import fetchURL from "../utils/fetchURL";
 
 
 const API = "https://api.ondoperps.xyz/v1/perps/open_interest";
@@ -12,7 +12,7 @@ type OpenInterestItem = {
 };
 
 const fetch = async (_options: FetchOptions) => {
-  const response = await httpGet(API);
+  const response = await fetchURL(API);
   const openInterestAtEnd = response.result.reduce((acc: number, market: OpenInterestItem) => acc + Number(market.notionalValue), 0)
   return { openInterestAtEnd }
 }
@@ -26,7 +26,7 @@ const adapter: SimpleAdapter = {
     version: 1,
     fetch,
     chains: [CHAIN.OFF_CHAIN],
-    start: "2025-06-08",
+    start: "2026-03-17", // Matched with OHLCV first candle
     runAtCurrTime: true,
     methodology,
 };


### PR DESCRIPTION
## Summary
- Updates Ondo Perps volume to use 1D candlestick data instead of the rolling volume endpoint.
- Keeps historical missing markets as zero-volume entries when no matching candle exists.

## Changes
- Updated `dexs/ondo-perps` to fetch markets from `/v1/markets` and aggregate `c * v` from `/v1/perps/history`.
- Added PromisePool fanout for per-market candle requests.
- Updated `open-interest/ondo-perps.ts` to use `fetchURL`.

## Tests
- `pnpm test dexs ondo-perps 2026-05-11`