### PR TITLE
[feat] HBANK-Perps: track Hyperliquid builder code fees

### DIFF
--- a/factory/hyperliquid.ts
+++ b/factory/hyperliquid.ts
@@ -92,6 +92,16 @@ const builderConfigs: Record<string, BuilderConfig> = {
     },
     breakdownFees: true,
   },
+  "hbank-perps": {
+    addresses: ["0x0ca900e83d99a55206873fbf5b872453b032d970"],
+    start: "2026-04-14",
+    methodology: {
+      Fees: "Trading fees paid by users for perps via HBANK.",
+      Revenue: "Builder code fees collected by HBANK from Hyperliquid Perps.",
+      ProtocolRevenue: "Builder code fees collected by HBANK from Hyperliquid Perps.",
+    },
+    breakdownFees: true,
+  },
   "based-app": {
     addresses: ["0x1924b8561eef20e70ede628a296175d358be80e5"],
     start: "2025-07-08",


### PR DESCRIPTION
Adds **HBANK** as a Hyperliquid builder-code app in the Hyperliquid factory (`factory/hyperliquid.ts`), registering the `hbank-perps` builder config.

HBANK (https://app.hbank.cash) offers perpetual futures powered by Hyperliquid builder codes. This tracks the builder-code fees / revenue / volume HBANK generates from Hyperliquid Perps, following the same pattern as the other builder entries in this file.

**Adapter config**
- Builder address: `0x0ca900e83d99a55206873fbf5b872453b032d970`
- Start: `2026-04-14`
- `breakdownFees: true` (reported under "Hyperliquid Builder Code Fees")
- Methodology:
  - Fees: Trading fees paid by users for perps via HBANK.
  - Revenue / ProtocolRevenue: Builder code fees collected by HBANK from Hyperliquid Perps.

**Listing metadata** (for the protocol page — please create the entry, since `defillama-server` interactions are restricted to prior contributors):
- name: `HBANK`
- id / slug: `hbank-perps`
- url: `https://app.hbank.cash`
- logo: `https://app.hbank.cash/hbank-icon.png`
- twitter: `HbankCash`
- description: HBANK perpetual futures, powered by Hyperliquid builder codes.
- category: Derivatives
- fees / derivatives → `hbank-perps`
- parent / double-counted to: Hyperliquid

Happy to provide anything else needed to get the listing created. Thanks!