### PR TITLE
[fix] Core-Markets: mark as dead

### DIFF
--- a/dexs/core-markets/index.ts
+++ b/dexs/core-markets/index.ts
@@ -59,7 +59,7 @@ const adapter: SimpleAdapter = {
     [CHAIN.BLAST]: {
       fetch,
       start: "2024-03-01", // Dimension adapter is not mapped in defillama-server.
-      deadFrom : "2026-06-10" // No point mapping now, as the data source is not present.
+      deadFrom : "2026-06-01" // No point mapping now, as the data source is not present.
     },
   },
 };

--- a/dexs/core-markets/index.ts
+++ b/dexs/core-markets/index.ts
@@ -5,6 +5,7 @@ import { CHAIN } from "../../helpers/chains";
 
 const ONE_DAY_IN_SECONDS = 60 * 60 * 24;
 
+// Subgraph endpoint is dead, also the projects official website is dead.
 const endpoint = "https://api.studio.thegraph.com/query/62472/core-analytics-082/version/latest";
 
 const query = gql`
@@ -57,7 +58,8 @@ const adapter: SimpleAdapter = {
   adapter: {
     [CHAIN.BLAST]: {
       fetch,
-      start: async () => 236678,
+      start: "2024-03-01", // Dimension adapter is not mapped in defillama-server.
+      deadFrom : "2026-06-10" // No point mapping now, as the data source is not present.
     },
   },
 };


### PR DESCRIPTION
- Mark the adapter as dead from `2026-06-10`
- Official endpoint is unreachable
- Twitter dead, Subgraph dead
- Markets were symm.io deployed but symm.io dont have traces about blast subgraph to trac via factory
- Wasnt mapped in `defillama-server`