### PR TITLE
[fix] PumpFun-Spikes: count graduation fees from migrator wallet

### DIFF
--- a/fees/pumpdotfun.ts
+++ b/fees/pumpdotfun.ts
@@ -103,6 +103,7 @@ const PUMP_FEE_EXCLUDE_TX_ADDRESSES = [
   'FGptqdxjahafaCzpZ1T6EDtCzYMv7Dyn5MgBLyB3VUFW',
   'X5QPJcpph4mBAJDzc4hRziFftSbcygV59kRb2Fu6Je1',
   '7GFUN3bWzJMKMRZ34JLsvcqdssDbXnp589SiE33KVwcC',
+  '39azUYFWPz3VHgKCf3VChUwbpURdCHRxjWVowf5jUJjg', // Pump.fun migration address, internal wallet.
 ]
 
 // Mayhem fees: SOL + WSOL inflows to the program fee wallet, counted as 100% protocol.

--- a/fees/pumpdotfun.ts
+++ b/fees/pumpdotfun.ts
@@ -70,12 +70,15 @@ function getProtocolRevenueRatio(timestamp: number): number {
 
 // Mayhem-mode program fee wallet (receives both native SOL and WSOL).
 const MAYHEM_FEE_WALLET = 'GesfTA3X2arioaHp8bbKdjG9vJtskViWACZoYvxp4twS'
+// Pump.fun migrator wallet: moves graduated bonding-curve liquidity to Raydium.
+const PUMP_FUN_MIGRATOR = '39azUYFWPz3VHgKCf3VChUwbpURdCHRxjWVowf5jUJjg'
 
 const LABEL = {
   PumpFunProtocolFee: 'Pump Fun Protocol Fees',
   PumpFunMayhemFee:   'Pump Fun Mayhem Fees',
   PumpFunCreatorFee:  'Pump Fun Creator Fees',
   PumpFunCashback:    'Pump Fun Cashback',
+  PumpFunGraduationFee: 'Pump Fun Graduation Fees',
 } as const
 
 // Wallets used by the pre-cutoff fallback. https://dune.com/queries/4313339
@@ -103,7 +106,6 @@ const PUMP_FEE_EXCLUDE_TX_ADDRESSES = [
   'FGptqdxjahafaCzpZ1T6EDtCzYMv7Dyn5MgBLyB3VUFW',
   'X5QPJcpph4mBAJDzc4hRziFftSbcygV59kRb2Fu6Je1',
   '7GFUN3bWzJMKMRZ34JLsvcqdssDbXnp589SiE33KVwcC',
-  '39azUYFWPz3VHgKCf3VChUwbpURdCHRxjWVowf5jUJjg', // Pump.fun migration address, internal wallet.
 ]
 
 // Mayhem fees: SOL + WSOL inflows to the program fee wallet, counted as 100% protocol.
@@ -166,42 +168,50 @@ async function fetchFromTradeEvents(options: FetchOptions) {
 // Fallback path (< 2025-11-05): pump_evt_tradeevent isn't populated, so we read pump's
 // slice from wallet inflows and reconstruct the creator slice with the era ratio.
 // (Cashback didn't exist in this era, so we pass 0.)
+// The Dune query scans only relevant wallet balance changes once, then splits fee-recipient
+// inflows into normal bonding-curve fees and migrator-funded graduation fees. Txns with
+// fee-recipient/internal outflows are excluded from the normal-fee bucket to avoid counting
+// wallet-to-wallet movements as user-paid fees.
 async function fetchFromDune(options: FetchOptions) {
+  const feeRecipients = PUMP_FEE_RECIPIENTS.map(a => `'${a}'`).join(',')
+  const excludeAddresses = [...PUMP_FEE_EXCLUDE_TX_ADDRESSES, ...PUMP_FEE_RECIPIENTS, PUMP_FUN_MIGRATOR].map(a => `'${a}'`).join(',')
+  const relevantAddresses = [...new Set([...PUMP_FEE_EXCLUDE_TX_ADDRESSES, ...PUMP_FEE_RECIPIENTS, PUMP_FUN_MIGRATOR])].map(a => `'${a}'`).join(',')
+
   const [pumpFeeRows, apiData] = await Promise.all([
     queryDuneSql(options, `
-      WITH excluded_transactions AS (
-        SELECT DISTINCT tx_id
+      WITH fee_transactions AS (
+        SELECT
+          tx_id,
+          SUM(CASE WHEN address IN (${feeRecipients}) AND balance_change > 0 THEN balance_change ELSE 0 END) AS fee_inflow,
+          MAX(CASE WHEN address = '${PUMP_FUN_MIGRATOR}' AND balance_change < 0 THEN 1 ELSE 0 END) AS has_graduation,
+          MAX(CASE WHEN address IN (${excludeAddresses}) AND balance_change < 0 THEN 1 ELSE 0 END) AS has_exclusion
         FROM solana.account_activity
         WHERE tx_success = TRUE
-          AND block_time >= from_unixtime(${options.startTimestamp})
-          AND block_time <= from_unixtime(${options.endTimestamp})
-          AND address IN (${PUMP_FEE_EXCLUDE_TX_ADDRESSES.map(a => `'${a}'`).join(',')})
-          AND balance_change < 0
+          AND TIME_RANGE
+          AND address IN (${relevantAddresses})
+        GROUP BY tx_id
       )
-      SELECT SUM(sa.balance_change) / 1e9 AS total_sol_revenue
-      FROM solana.account_activity sa
-      LEFT JOIN excluded_transactions et ON sa.tx_id = et.tx_id
-      WHERE sa.tx_success = TRUE
-        AND sa.block_time >= from_unixtime(${options.startTimestamp})
-        AND sa.block_time <= from_unixtime(${options.endTimestamp})
-        AND sa.address IN (${PUMP_FEE_RECIPIENTS.map(a => `'${a}'`).join(',')})
-        AND sa.balance_change > 0
-        AND et.tx_id IS NULL
+      SELECT
+        SUM(CASE WHEN has_exclusion = 0 THEN fee_inflow ELSE 0 END) / 1e9 AS total_sol_revenue,
+        SUM(CASE WHEN has_graduation = 1 THEN fee_inflow ELSE 0 END) / 1e9 AS graduation_sol_revenue
+      FROM fee_transactions
+      WHERE fee_inflow > 0
     `, { extraUIDKey: 'pump-fees' }),
     getDailyApiData(options.dateString).catch(() => undefined),
   ])
 
-  const pumpFee    = (pumpFeeRows?.[0]?.total_sol_revenue ?? 0) * 1e9
+  const pumpFee       = (pumpFeeRows?.[0]?.total_sol_revenue ?? 0) * 1e9
+  const graduationFee = (pumpFeeRows?.[0]?.graduation_sol_revenue ?? 0) * 1e9
   const creatorFee = pumpFee * getCreatorFeeRatio(options.startTimestamp)
 
   return buildBalances(
     options,
-    [{ mint: ADDRESSES.solana.SOL, pumpFee, creatorFee, cashback: 0 }],
+    [{ mint: ADDRESSES.solana.SOL, pumpFee, creatorFee, cashback: 0, graduationFee }],
     apiData?.buybackUsd ?? 0,
   )
 }
 
-type FeeRow = { mint: string, pumpFee: number, creatorFee: number, cashback: number }
+type FeeRow = { mint: string, pumpFee: number, creatorFee: number, cashback: number, graduationFee?: number }
 
 // Pump's tradeevent reports the quote as the System Program id ('11...11') for SOL-quoted
 // pairs (and may emit null/empty pre-IDL-update). Everything else (e.g. USDC mint) is the
@@ -234,7 +244,7 @@ async function buildBalances(
   const dailySupplySideRevenue = options.createBalances()
 
   const protocolRatio = getProtocolRevenueRatio(options.startTimestamp)
-  for (const { mint, pumpFee, creatorFee, cashback } of feeRows) {
+  for (const { mint, pumpFee, creatorFee, cashback, graduationFee = 0 } of feeRows) {
     // Pump's slice: gross fee, also revenue. ProtocolRevenue is the era-ratio share.
     if (pumpFee > 0) {
       dailyFees.add(mint, pumpFee, LABEL.PumpFunProtocolFee)
@@ -250,6 +260,11 @@ async function buildBalances(
     if (cashback > 0) {
       dailyFees.add(mint, cashback, LABEL.PumpFunCashback)
       dailySupplySideRevenue.add(mint, cashback, LABEL.PumpFunCashback)
+    }
+    if (graduationFee > 0) {
+      dailyFees.add(mint, graduationFee, LABEL.PumpFunGraduationFee)
+      dailyRevenue.add(mint, graduationFee, LABEL.PumpFunGraduationFee)
+      dailyProtocolRevenue.add(mint, graduationFee, LABEL.PumpFunGraduationFee)
     }
   }
 
@@ -276,14 +291,17 @@ const breakdownMethodology = {
     [LABEL.PumpFunCreatorFee]: 'Creator slice of the bonding-curve trade fee (0.05% from 2025-05-13, 0.30% from Project Ascend / Sept 2025).',
     [LABEL.PumpFunCashback]: 'Cashback Coins slice — paid by traders; same 0.30% slot as the creator fee, mutually exclusive per coin (Cashback Coins from Feb 2026).',
     [LABEL.PumpFunMayhemFee]: 'Mayhem-mode fees collected at the Mayhem program fee wallet.',
+    [LABEL.PumpFunGraduationFee]: 'Fees received by Pump.fun fee wallets from the token graduation during bonding-curve to Raydium migrations.',
   },
   Revenue: {
     [LABEL.PumpFunProtocolFee]: "Pump's slice of the bonding-curve trade fee — kept by the protocol.",
     [LABEL.PumpFunMayhemFee]: 'Mayhem-mode fees (no creator/buyback split — 100% protocol).',
+    [LABEL.PumpFunGraduationFee]: 'Graduation fees kept by the protocol when tokens migrate from Pump.fun bonding curves to Raydium.',
   },
   ProtocolRevenue: {
     [LABEL.PumpFunProtocolFee]: "Pump's slice kept by the protocol after the buyback share (100% pre-2025-07-14, 0% from 2025-07-14, 50% from 2026-04-28).",
     [LABEL.PumpFunMayhemFee]: 'Mayhem-mode fees.',
+    [LABEL.PumpFunGraduationFee]: 'Graduation fees kept by the protocol.',
   },
   HoldersRevenue: {
     [METRIC.TOKEN_BUY_BACK]: 'PUMP token buyback (sourced from the fees.pump.fun API; aggregates buybacks across all pump products).',
@@ -304,9 +322,9 @@ const adapter: SimpleAdapter = {
   allowNegativeValue: true,
   breakdownMethodology,
   methodology: {
-    Fees: "Bonding-curve trade fees paid by users (pump's slice + creator/cashback slice) plus Mayhem-mode fees.",
-    Revenue: "Pump's slice of the bonding-curve trade fee plus Mayhem-mode fees.",
-    ProtocolRevenue: "Pump's slice kept by the protocol after the buyback share, plus 100% of Mayhem fees. Era-based split: 100% pre-2025-07-14, 0% from 2025-07-14, 50% from 2026-04-28.",
+    Fees: "Bonding-curve trade fees paid by users (pump's slice + creator/cashback slice), graduation fees, and Mayhem-mode fees.",
+    Revenue: "Pump's slice of the bonding-curve trade fee plus graduation fees and Mayhem-mode fees.",
+    ProtocolRevenue: "Pump's slice kept by the protocol after the buyback share, plus 100% of graduation and Mayhem fees. Era-based split: 100% pre-2025-07-14, 0% from 2025-07-14, 50% from 2026-04-28.",
     HoldersRevenue: "PUMP token buyback (sourced from the fees.pump.fun API; aggregates buybacks across all pump products, so it won't sum exactly with ProtocolRevenue here).",
     SupplySideRevenue: "Creator fees paid out to coin creators and cashback returned to traders/holders of the coin.",
   },


### PR DESCRIPTION
Fixes #7552

## Summary
- Updates the Pump.fun historical fee fallback to separate normal bonding-curve fee-wallet inflows from token graduation fees.
- Adds a dedicated `Pump Fun Graduation Fees` breakdown label for SOL received by Pump.fun fee wallets from the migrator wallet during bonding-curve to Raydium migrations.
- Optimizes the fallback Dune query to scan relevant `solana.account_activity` rows once and derive normal fees, graduation fees, and exclusion flags from the same grouped tx set.

## Changes
- Added `PUMP_FUN_MIGRATOR` for `39azUYFWPz3VHgKCf3VChUwbpURdCHRxjWVowf5jUJjg`, the Pump.fun migrator wallet that moves graduated bonding-curve liquidity to Raydium.
- Updated the pre-`2025-11-05` fallback Dune query in `fees/pumpdotfun.ts` to return two buckets:
  - `total_sol_revenue`: normal fee-recipient inflows, excluding transactions with internal fee-recipient or excluded-wallet outflows.
  - `graduation_sol_revenue`: fee-recipient inflows in transactions where the migrator wallet has an outgoing balance change.
- Added `Pump Fun Graduation Fees` to `dailyFees`, `dailyRevenue`, and `dailyProtocolRevenue`.
- Added `Pump Fun Graduation Fees` entries to `breakdownMethodology`.
- Updated the top-level methodology strings to mention graduation fees alongside bonding-curve and Mayhem-mode fees.
- Kept the decoded `pumpdotfun_solana.pump_evt_tradeevent` path unchanged for dates from `2025-11-05` onward.

## Methodology
- Before `pumpdotfun_solana.pump_evt_tradeevent` is populated, Pump.fun fee accounting uses wallet-level SOL inflows from `solana.account_activity`.
- Normal bonding-curve fees are counted from positive SOL inflows to known Pump.fun fee recipient wallets, excluding transactions that also contain outgoing SOL movement from known internal, excluded, migrator, or fee-recipient wallets.
- Graduation fees are tracked separately by counting SOL received by Pump.fun fee recipient wallets in transactions where the migrator wallet has an outgoing SOL balance change.
- This avoids treating gross migration liquidity as normal bonding-curve trading fees while still accounting for protocol revenue collected during token graduation.
- Creator fee reconstruction remains unchanged for the historical fallback path, and cashback remains zero before the cashback era.

## Data Quality / Risk
- The new graduation bucket is intentionally separated from normal Pump.fun bonding-curve fees so historical migration activity does not inflate trading-fee revenue.
- The fallback query remains Dune-based and historical Solana `account_activity` windows can still be expensive, but the query now performs one grouped scan over the relevant address set instead of multiple broad scans/joins.
- Full adapter tests also call the Mayhem-mode helper, which requires `ALLIUM_API_KEY`; standalone Dune validation was used to verify the updated fallback query where Allium was unavailable locally.

## Tests
- `DUNE_API_KEYS=<set> DEBUG_BREAKDOWN_FEES=1 pnpm test fees pumpdotfun 2025-01-02`
  - Dune query completed, then the full adapter run failed on missing `ALLIUM_API_KEY` from the Mayhem-mode helper.
- Standalone Dune-only fallback query for `2025-01-01`:
  - `total_sol_revenue`: `11,506.036665505 SOL`
  - `graduation_sol_revenue`: `61,000 SOL`
  - Execution ID: `01KTXKA1A2PFS2W20C3S6MQWWG`
- Standalone Dune-only fallback query for `2025-01-24`:
  - `total_sol_revenue`: `20,017.815068249 SOL`
  - `graduation_sol_revenue`: `41,000 SOL`
  - Execution ID: `01KTXKEKH04TNXVYE4FQR60PEQ`
- Standalone Dune-only fallback query for `2025-01-28`:
  - `total_sol_revenue`: `18,596.511251969 SOL`
  - `graduation_sol_revenue`: `22,000 SOL`
  - Execution ID: `01KTXKJ4J66CDD4D2MYX00PF3S`
- Standalone Dune-only fallback query for `2025-02-04`:
  - `total_sol_revenue`: `14,382.216593376 SOL`
  - `graduation_sol_revenue`: `0 SOL`
  - Execution ID: `01KTXKPCD45R974ENVA4M285RE`