### PR TITLE
Add Piteas aggregator volume and fees adapters for Pulsechain

### DIFF
--- a/aggregators/piteas/index.ts
+++ b/aggregators/piteas/index.ts
@@ -1,0 +1,59 @@
+import { FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import { formatAddress } from "../../utils/utils";
+
+// PiteasRouter — deployed 2023-07-07 21:35:45 UTC
+// https://otter-pulsechain.g4mm4.io/tx/0xd48a2cf58b231ea285e05a365ab71c9fd6f539d30033513a34e512b56790d02c
+const PITEAS_ROUTER = "0x6BF228eb7F8ad948d37deD07E595EfddfaAF88A6";
+
+// Wrapped PLS — used to price native PLS swaps (srcToken/destToken may be zero address)
+const WPLS = "0xA1077a294dDE1B09bB078844df40758a5D0f9a27";
+const NATIVE_TOKEN = "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE";
+
+const SWAP_EVENT =
+  "event SwapEvent(address swapManager, address srcToken, address destToken, address indexed sender, address destReceiver, uint256 srcAmount, uint256 destAmount)";
+
+const normalizeToken = (token: string): string => {
+  const address = formatAddress(token);
+  if (
+    address === "0x0000000000000000000000000000000000000000" ||
+    address === formatAddress(NATIVE_TOKEN)
+  ) {
+    return WPLS;
+  }
+  return address;
+};
+
+const fetch = async (options: FetchOptions) => {
+  const dailyVolume = options.createBalances();
+
+  const logs = await options.getLogs({
+    target: PITEAS_ROUTER,
+    eventAbi: SWAP_EVENT,
+  });
+
+  logs.forEach((log: any) => {
+    dailyVolume.add(normalizeToken(log.destToken), log.destAmount);
+  });
+
+  return { dailyVolume };
+};
+
+const methodology = {
+  Volume:
+    "Swap volume routed through PiteasRouter on PulseChain. Measured as the output token amount (destAmount) emitted in each SwapEvent.",
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  pullHourly: true,
+  fetch,
+  adapter: {
+    [CHAIN.PULSECHAIN]: {
+      start: "2023-07-07",
+    },
+  },
+  methodology,
+};
+
+export default adapter;

--- a/aggregators/piteas/index.ts
+++ b/aggregators/piteas/index.ts
@@ -3,7 +3,9 @@ import { CHAIN } from "../../helpers/chains";
 import { formatAddress } from "../../utils/utils";
 
 const PITEAS_ROUTER = "0x6BF228eb7F8ad948d37deD07E595EfddfaAF88A6";
-const WPLS = "0xA1077a294dDE1B09bB078844df40758a5D0f9a27";
+
+// Wrapped PLS — used to price native PLS swaps (srcToken/destToken may be zero address)
+const WPLS = "0xa1077a294dde1b09bb078844df40758a5d0f9a27";
 const NATIVE_TOKEN = "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE";
 
 const SWAP_EVENT =
@@ -15,7 +17,7 @@ const normalizeToken = (token: string): string => {
     address === "0x0000000000000000000000000000000000000000" ||
     address === formatAddress(NATIVE_TOKEN)
   ) {
-    return WPLS;
+    return formatAddress(WPLS);
   }
   return address;
 };
@@ -44,11 +46,8 @@ const adapter: SimpleAdapter = {
   version: 2,
   pullHourly: true,
   fetch,
-  adapter: {
-    [CHAIN.PULSECHAIN]: {
-      start: "2023-07-07",
-    },
-  },
+  start: "2023-07-07",
+  chains: [CHAIN.PULSECHAIN],
   methodology,
 };
 

--- a/aggregators/piteas/index.ts
+++ b/aggregators/piteas/index.ts
@@ -2,11 +2,7 @@ import { FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 import { formatAddress } from "../../utils/utils";
 
-// PiteasRouter — deployed 2023-07-07 21:35:45 UTC
-// https://otter-pulsechain.g4mm4.io/tx/0xd48a2cf58b231ea285e05a365ab71c9fd6f539d30033513a34e512b56790d02c
 const PITEAS_ROUTER = "0x6BF228eb7F8ad948d37deD07E595EfddfaAF88A6";
-
-// Wrapped PLS — used to price native PLS swaps (srcToken/destToken may be zero address)
 const WPLS = "0xA1077a294dDE1B09bB078844df40758a5D0f9a27";
 const NATIVE_TOKEN = "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE";
 

--- a/fees/piteas/index.ts
+++ b/fees/piteas/index.ts
@@ -3,53 +3,25 @@ import { CHAIN } from "../../helpers/chains";
 import { METRIC } from "../../helpers/metrics";
 import { addTokensReceived } from "../../helpers/token";
 
+// https://docs.piteas.io/contracts
 const FEE_TREASURY = "0x31415995b2ffaDf05FE929fDB6a87FD18A2817dD";
-const REVENUE_TO_HOLDERS_RATIO = 0.5;
-const REVENUE_TO_PROTOCOL_RATIO = 0.5;
-
-const PITEAS_METRICS = {
-  SwapFees: METRIC.SWAP_FEES,
-  SwapFeesToProtocolDevelopment: "Swap Fees To Protocol Development",
-  PTSBuyBack: METRIC.TOKEN_BUY_BACK,
-};
 
 const fetch = async (options: FetchOptions): Promise<FetchResult> => {
   const dailyFees = options.createBalances();
-  const dailyUserFees = options.createBalances();
-  const dailyRevenue = options.createBalances();
-  const dailyProtocolRevenue = options.createBalances();
-  const dailyHoldersRevenue = options.createBalances();
-  const dailySupplySideRevenue = options.createBalances();
-
-  const treasuryInflows = options.createBalances();
 
   await addTokensReceived({
     options,
     target: FEE_TREASURY,
-    balances: treasuryInflows,
+    balances: dailyFees,
     skipIndexer: true,
   });
 
-  dailyFees.add(treasuryInflows, PITEAS_METRICS.SwapFees);
-  dailyUserFees.add(treasuryInflows, PITEAS_METRICS.SwapFees);
-  dailyRevenue.add(treasuryInflows, PITEAS_METRICS.SwapFees);
-
-  dailyHoldersRevenue.add(
-    dailyRevenue.clone(REVENUE_TO_HOLDERS_RATIO),
-    PITEAS_METRICS.PTSBuyBack,
-  );
-  dailyProtocolRevenue.add(
-    dailyRevenue.clone(REVENUE_TO_PROTOCOL_RATIO),
-    PITEAS_METRICS.SwapFeesToProtocolDevelopment,
-  );
-
   return {
     dailyFees,
-    dailyUserFees,
-    dailyRevenue,
-    dailyProtocolRevenue,
-    dailyHoldersRevenue,
-    dailySupplySideRevenue,
+    dailyUserFees: dailyFees,
+    dailyRevenue: dailyFees,
+    dailyProtocolRevenue: dailyFees,
+    dailySupplySideRevenue: options.createBalances(),
   };
 };
 
@@ -57,31 +29,18 @@ const methodology = {
   Fees: "ERC20 token transfers received by the Piteas fee treasury on PulseChain. Native PLS internal transfers are excluded because PulseChain is not supported by Allium or Dune.",
   UserFees: "Swap fees paid by users routing trades through the Piteas aggregator, tracked as ERC20 inflows to the fee treasury.",
   Revenue: "All ERC20 swap fees received by the fee treasury are kept by the protocol.",
-  ProtocolRevenue: "50% of protocol revenue allocated to protocol development and operations per protocol policy.",
-  HoldersRevenue: "50% of protocol revenue allocated to PTS market buybacks per protocol policy.",
+  ProtocolRevenue: "All swap fees received by the fee treasury.",
   SupplySideRevenue: "No supply-side revenue; Piteas does not share fees with liquidity providers.",
 };
 
 const breakdownMethodology = {
   Fees: {
-    [PITEAS_METRICS.SwapFees]:
+    [METRIC.SWAP_FEES]:
       "ERC20 swap fees routed to the Piteas fee treasury from aggregator trades on PulseChain.",
   },
-  UserFees: {
-    [PITEAS_METRICS.SwapFees]:
-      "ERC20 swap fees paid by users routing trades through the Piteas aggregator.",
-  },
   Revenue: {
-    [PITEAS_METRICS.SwapFees]:
+    [METRIC.SWAP_FEES]:
       "All ERC20 swap fees received by the Piteas fee treasury.",
-  },
-  ProtocolRevenue: {
-    [PITEAS_METRICS.SwapFeesToProtocolDevelopment]:
-      "Half of treasury inflows allocated to protocol development and operations.",
-  },
-  HoldersRevenue: {
-    [PITEAS_METRICS.PTSBuyBack]:
-      "Half of treasury inflows allocated to PTS market buybacks per protocol policy.",
   },
 };
 

--- a/fees/piteas/index.ts
+++ b/fees/piteas/index.ts
@@ -1,0 +1,106 @@
+import { Dependencies, FetchOptions, FetchResult, SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import { METRIC } from "../../helpers/metrics";
+import { addTokensReceived, getETHReceived } from "../../helpers/token";
+
+const FEE_TREASURY = "0x31415995b2ffaDf05FE929fDB6a87FD18A2817dD";
+
+const REVENUE_TO_HOLDERS_RATIO = 0.5;
+const REVENUE_TO_PROTOCOL_RATIO = 0.5;
+
+const PITEAS_METRICS = {
+  SwapFees: METRIC.SWAP_FEES,
+  SwapFeesToProtocolDevelopment: "Swap Fees To Protocol Development",
+  PTSBuyBack: METRIC.TOKEN_BUY_BACK,
+};
+
+const fetch = async (options: FetchOptions): Promise<FetchResult> => {
+  const dailyFees = options.createBalances();
+  const dailyUserFees = options.createBalances();
+  const dailyRevenue = options.createBalances();
+  const dailyProtocolRevenue = options.createBalances();
+  const dailyHoldersRevenue = options.createBalances();
+
+  const treasuryInflows = options.createBalances();
+
+  await addTokensReceived({
+    options,
+    target: FEE_TREASURY,
+    balances: treasuryInflows,
+    skipIndexer: true,
+  });
+
+  await getETHReceived({
+    options,
+    target: FEE_TREASURY,
+    balances: treasuryInflows,
+  });
+
+  dailyFees.add(treasuryInflows, PITEAS_METRICS.SwapFees);
+  dailyUserFees.add(treasuryInflows, PITEAS_METRICS.SwapFees);
+  dailyRevenue.add(treasuryInflows, PITEAS_METRICS.SwapFees);
+
+  dailyHoldersRevenue.add(
+    dailyRevenue.clone(REVENUE_TO_HOLDERS_RATIO),
+    PITEAS_METRICS.PTSBuyBack,
+  );
+  dailyProtocolRevenue.add(
+    dailyRevenue.clone(REVENUE_TO_PROTOCOL_RATIO),
+    PITEAS_METRICS.SwapFeesToProtocolDevelopment,
+  );
+
+  return {
+    dailyFees,
+    dailyUserFees,
+    dailyRevenue,
+    dailyProtocolRevenue,
+    dailyHoldersRevenue,
+  };
+};
+
+const methodology = {
+  Fees: "Protocol swap fees received by the dedicated Piteas fee treasury, including native PLS (internal transfers) and ERC20 token transfers.",
+  UserFees: "Swap fees paid by users routing trades through the Piteas aggregator.",
+  Revenue: "All protocol swap fees received by the fee treasury are kept by the protocol.",
+  ProtocolRevenue: "50% of protocol revenue allocated to protocol development and operations.",
+  HoldersRevenue: "50% of protocol revenue used for PTS market buybacks.",
+};
+
+const breakdownMethodology = {
+  Fees: {
+    [PITEAS_METRICS.SwapFees]:
+      "Swap fees routed to the Piteas fee treasury from aggregator trades on PulseChain, in native PLS or ERC20.",
+  },
+  UserFees: {
+    [PITEAS_METRICS.SwapFees]:
+      "Swap fees paid by users routing trades through the Piteas aggregator.",
+  },
+  Revenue: {
+    [PITEAS_METRICS.SwapFees]:
+      "All swap fees received by the Piteas fee treasury.",
+  },
+  ProtocolRevenue: {
+    [PITEAS_METRICS.SwapFeesToProtocolDevelopment]:
+      "Half of treasury inflows allocated to protocol development and operations.",
+  },
+  HoldersRevenue: {
+    [PITEAS_METRICS.PTSBuyBack]:
+      "Half of treasury inflows used to buy PTS from the market.",
+  },
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  pullHourly: true,
+  fetch,
+  dependencies: [Dependencies.ALLIUM],
+  adapter: {
+    [CHAIN.PULSECHAIN]: {
+      start: "2023-07-07",
+    },
+  },
+  methodology,
+  breakdownMethodology,
+};
+
+export default adapter;

--- a/fees/piteas/index.ts
+++ b/fees/piteas/index.ts
@@ -7,21 +7,19 @@ import { addTokensReceived } from "../../helpers/token";
 const FEE_TREASURY = "0x31415995b2ffaDf05FE929fDB6a87FD18A2817dD";
 
 const fetch = async (options: FetchOptions): Promise<FetchResult> => {
-  const dailyFees = options.createBalances();
-
-  await addTokensReceived({
+  const fees = await addTokensReceived({
     options,
     target: FEE_TREASURY,
-    balances: dailyFees,
-    skipIndexer: true,
   });
+
+  const dailyFees = fees.clone(1, METRIC.SWAP_FEES)
 
   return {
     dailyFees,
     dailyUserFees: dailyFees,
     dailyRevenue: dailyFees,
     dailyProtocolRevenue: dailyFees,
-    dailySupplySideRevenue: options.createBalances(),
+    dailySupplySideRevenue: 0
   };
 };
 

--- a/fees/piteas/index.ts
+++ b/fees/piteas/index.ts
@@ -1,10 +1,9 @@
-import { Dependencies, FetchOptions, FetchResult, SimpleAdapter } from "../../adapters/types";
+import { FetchOptions, FetchResult, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 import { METRIC } from "../../helpers/metrics";
-import { addTokensReceived, getETHReceived } from "../../helpers/token";
+import { addTokensReceived } from "../../helpers/token";
 
 const FEE_TREASURY = "0x31415995b2ffaDf05FE929fDB6a87FD18A2817dD";
-
 const REVENUE_TO_HOLDERS_RATIO = 0.5;
 const REVENUE_TO_PROTOCOL_RATIO = 0.5;
 
@@ -20,6 +19,7 @@ const fetch = async (options: FetchOptions): Promise<FetchResult> => {
   const dailyRevenue = options.createBalances();
   const dailyProtocolRevenue = options.createBalances();
   const dailyHoldersRevenue = options.createBalances();
+  const dailySupplySideRevenue = options.createBalances();
 
   const treasuryInflows = options.createBalances();
 
@@ -28,12 +28,6 @@ const fetch = async (options: FetchOptions): Promise<FetchResult> => {
     target: FEE_TREASURY,
     balances: treasuryInflows,
     skipIndexer: true,
-  });
-
-  await getETHReceived({
-    options,
-    target: FEE_TREASURY,
-    balances: treasuryInflows,
   });
 
   dailyFees.add(treasuryInflows, PITEAS_METRICS.SwapFees);
@@ -55,29 +49,31 @@ const fetch = async (options: FetchOptions): Promise<FetchResult> => {
     dailyRevenue,
     dailyProtocolRevenue,
     dailyHoldersRevenue,
+    dailySupplySideRevenue,
   };
 };
 
 const methodology = {
-  Fees: "Protocol swap fees received by the dedicated Piteas fee treasury, including native PLS (internal transfers) and ERC20 token transfers.",
-  UserFees: "Swap fees paid by users routing trades through the Piteas aggregator.",
-  Revenue: "All protocol swap fees received by the fee treasury are kept by the protocol.",
-  ProtocolRevenue: "50% of protocol revenue allocated to protocol development and operations.",
-  HoldersRevenue: "50% of protocol revenue used for PTS market buybacks.",
+  Fees: "ERC20 token transfers received by the Piteas fee treasury on PulseChain. Native PLS internal transfers are excluded because PulseChain is not supported by Allium or Dune.",
+  UserFees: "Swap fees paid by users routing trades through the Piteas aggregator, tracked as ERC20 inflows to the fee treasury.",
+  Revenue: "All ERC20 swap fees received by the fee treasury are kept by the protocol.",
+  ProtocolRevenue: "50% of protocol revenue allocated to protocol development and operations per protocol policy.",
+  HoldersRevenue: "50% of protocol revenue allocated to PTS market buybacks per protocol policy.",
+  SupplySideRevenue: "No supply-side revenue; Piteas does not share fees with liquidity providers.",
 };
 
 const breakdownMethodology = {
   Fees: {
     [PITEAS_METRICS.SwapFees]:
-      "Swap fees routed to the Piteas fee treasury from aggregator trades on PulseChain, in native PLS or ERC20.",
+      "ERC20 swap fees routed to the Piteas fee treasury from aggregator trades on PulseChain.",
   },
   UserFees: {
     [PITEAS_METRICS.SwapFees]:
-      "Swap fees paid by users routing trades through the Piteas aggregator.",
+      "ERC20 swap fees paid by users routing trades through the Piteas aggregator.",
   },
   Revenue: {
     [PITEAS_METRICS.SwapFees]:
-      "All swap fees received by the Piteas fee treasury.",
+      "All ERC20 swap fees received by the Piteas fee treasury.",
   },
   ProtocolRevenue: {
     [PITEAS_METRICS.SwapFeesToProtocolDevelopment]:
@@ -85,7 +81,7 @@ const breakdownMethodology = {
   },
   HoldersRevenue: {
     [PITEAS_METRICS.PTSBuyBack]:
-      "Half of treasury inflows used to buy PTS from the market.",
+      "Half of treasury inflows allocated to PTS market buybacks per protocol policy.",
   },
 };
 
@@ -93,12 +89,8 @@ const adapter: SimpleAdapter = {
   version: 2,
   pullHourly: true,
   fetch,
-  dependencies: [Dependencies.ALLIUM],
-  adapter: {
-    [CHAIN.PULSECHAIN]: {
-      start: "2023-07-07",
-    },
-  },
+  start: "2023-07-07",
+  chains: [CHAIN.PULSECHAIN],
   methodology,
   breakdownMethodology,
 };


### PR DESCRIPTION
```Hi team,

defillama-server blocks both PRs and issues for my account (contribution restriction).

Metadata is ready on my fork:
https://github.com/piteasio/defillama-server/tree/add-piteas-metadata

Compare:
https://github.com/DefiLlama/defillama-server/compare/master...piteasio:defillama-server:add-piteas-metadata

Icons PR: https://github.com/DefiLlama/icons/pull/2403

Could a maintainer merge the metadata from my branch when the adapter PR is reviewed? Thanks!
```

## Listing Information

**Name (to be shown on DefiLlama):**  
Piteas

**Twitter Link:**  
https://x.com/piteasio

**List of audit links if any:**  
https://docs.piteas.io/audit

**Website Link:**  
https://piteas.io

**Logo (High resolution, will be shown with rounded borders):**  
https://app.piteas.io/logo.png

**Current TVL:**  
$0 — Piteas is a DEX aggregator and does not lock user funds. This PR adds volume and fees adapters only (no TVL adapter).

**Treasury Addresses (if the protocol has treasury):**  
- Revenue & Buyback Wallet: `0x31415995b2ffaDf05FE929fDB6a87FD18A2817dD`  
- PTS Treasury Wallet: `0x0101838F92c2e6cbE6C2Be716056A0a291f6824a`

**Chain:**  
Pulsechain

**Coingecko ID:**  
piteas

**Coinmarketcap ID:**  
28120

**Short Description (to be shown on DefiLlama):**  
Piteas is the first DEX aggregator on PulseChain, routing swaps across PulseX, Liberty Swap, Phux, 9mm, Tide, 9inch, and other liquidity sources to deliver optimal swap execution.

**Token address and ticker if any:**  
PTS — `0x2A06a971fE6ffa002fd242d437E3db2b5cC5B433` (Pulsechain)

**Category:**  
Dex Aggregator

**Oracle Provider(s):**  
N/A — not applicable (off-chain pathfinding; no on-chain price oracle dependency for swaps)

**Implementation Details:**  
N/A

**Documentation/Proof:**  
N/A

**forkedFrom:**  
None

**methodology (what is being counted as tvl, how is tvl being calculated):**  
No TVL — funds are not locked in Piteas contracts.

**Aggregators volume methodology:**  
Swap volume is measured as the output-side amount (`destAmount` / `destToken`) from `SwapEvent` logs emitted by PiteasRouter (`0x6BF228eb7F8ad948d37deD07E595EfddfaAF88A6`). Native PLS (zero address) is normalized to WPLS for pricing. Start date: 2023-07-07.

**Fees & revenue methodology:**  
Protocol fees are tracked as all inflows to the Revenue & Buyback Wallet (`0x31415995b2ffaDf05FE929fDB6a87FD18A2817dD`), including ERC20 token transfers (on-chain logs) and native PLS internal transfers (Allium traces). Revenue is split ~50% to protocol development and ~50% to PTS market buybacks. Start date: 2023-07-07.

**Github org/user:**  
https://github.com/piteasio

**Does this project have a referral program?**  
No on-chain user referral program. Partner/widget API and SDK integrations exist for third-party apps.

---

## Additional Links

- App: https://app.piteas.io  
- Docs: https://docs.piteas.io  
- Contracts: https://docs.piteas.io/contracts

## Contracts

| Role | Address |
|------|---------|
| PiteasRouter | `0x6BF228eb7F8ad948d37deD07E595EfddfaAF88A6` |
| PTS Token | `0x2A06a971fE6ffa002fd242d437E3db2b5cC5B433` |
| Revenue & Buyback Wallet | `0x31415995b2ffaDf05FE929fDB6a87FD18A2817dD` |

## Files Added

- `aggregators/piteas/index.ts` — aggregator volume adapter  
- `fees/piteas/index.ts` — fees and revenue adapter  

## Test Plan

- [x] `npm test aggregators piteas`
- [x] `npm test aggregators piteas 2024-06-01`
- [x] `npm test aggregators piteas 2023-07-10`
- [ ] `npm test fees piteas` — requires Allium API key for native PLS fee tracking (runs on DefiLlama infra)