### PR TITLE
Update Zinc fees adapter to use official volume API

### DIFF
--- a/fees/zinc/index.ts
+++ b/fees/zinc/index.ts
@@ -1,83 +1,100 @@
-import { Dependencies, FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
-import { queryAllium } from "../../helpers/allium";
 import ADDRESSES from "../../helpers/coreAssets.json";
+import fetchURL from "../../utils/fetchURL";
 
-const TREASURY = "4Ucw8BNkLWBu6gxkQsw3BRG2qRtw5WrG1UxiKpQjScH5";
-const BUYBACK_SOL_VAULT = "8nEo7GArDc3aVDuHoiDYJoVUNLtzgYaVmGGNvxELCZJc";
-const STOCKPILE_SOL_VAULT = "8RxMJD7BtdzxuZkmDqcxhR6gWvegLJ1GNf9NFrPkCmwf";
-const MeteoraPoolAuthority = "HLnpSz9h2S4hiLQ43rnSD9XkcUThA7B8hQMKmDaiTLcC";
+const VOLUME_ENDPOINT = "https://zinc.cash/api/volume/daily";
+const CONFIG_ENDPOINT = "https://zinc.cash/api/config";
 
-const BURN_SPLIT_FROM_BUYBACKS = 0.9;
-const STAKING_SPLIT_FROM_BUYBACKS = 0.1;
+const BPS_DENOMINATOR = 10_000n;
+const BURN_SPLIT_BPS = 9_000;
+const STAKING_SPLIT_BPS = 1_000;
+
+type DailyVolume = {
+  day: string;
+  gross_lamports: number | string;
+};
+
+type VolumeResponse = {
+  daily: DailyVolume[];
+};
+
+type ConfigResponse = {
+  deploy_total_fee_bps: number;
+  deploy_admin_fee_bps?: number;
+  deploy_stockpile_fee_bps?: number;
+  deploy_bonanza_fee_bps?: number;
+  deploy_affiliate_fee_bps?: number;
+};
+
+function toBigIntLamports(value: number | string) {
+  return BigInt(Math.trunc(Number(value)));
+}
+
+function bpsAmount(amount: bigint, bps: number) {
+  return ((amount * BigInt(Math.max(bps, 0))) / BPS_DENOMINATOR).toString();
+}
+
+function addIfPositive(
+  balances: ReturnType<FetchOptions["createBalances"]>,
+  amount: string,
+  label: string,
+) {
+  if (BigInt(amount) > 0n) balances.add(ADDRESSES.solana.SOL, amount, label);
+}
 
 const fetch = async (options: FetchOptions) => {
-  const vaults = [TREASURY, STOCKPILE_SOL_VAULT];
-  const rows = await queryAllium(`
-    SELECT
-      to_address,
-      SUM(
-        CASE
-          WHEN to_address = '${TREASURY}' THEN raw_amount
-          WHEN from_address != '${TREASURY}' THEN raw_amount
-          ELSE 0
-        END
-      ) AS amount
-    FROM solana.assets.transfers
-    WHERE to_address IN (${vaults.map((a) => `'${a}'`).join(", ")})
-      AND mint = '${ADDRESSES.solana.SOL}'
-      AND block_timestamp BETWEEN TO_TIMESTAMP_NTZ(${options.startTimestamp}) AND TO_TIMESTAMP_NTZ(${options.endTimestamp})
-    GROUP BY to_address
-  `);
-  
-  // count buy back buy SOL were sent to MeteoraPoolAuthority from TREASURY
-  const buybacks = await queryAllium(`
-    SELECT
-      SUM(raw_amount) AS amount
-    FROM solana.assets.transfers
-    WHERE
-      to_address = '${MeteoraPoolAuthority}'
-      AND from_address = '${TREASURY}'
-      AND mint = '${ADDRESSES.solana.SOL}'
-      AND block_timestamp BETWEEN TO_TIMESTAMP_NTZ(${options.startTimestamp}) AND TO_TIMESTAMP_NTZ(${options.endTimestamp})
-  `);
+  const [volume, config]: [VolumeResponse, ConfigResponse] = await Promise.all([
+    fetchURL(VOLUME_ENDPOINT),
+    fetchURL(CONFIG_ENDPOINT),
+  ]);
 
-  const treasuryFlows = options.createBalances();
-  const buybackFlows = options.createBalances();
-  const stockpileFlows = options.createBalances();
-  const flowsByVault: Record<string, typeof treasuryFlows> = {
-    [TREASURY]: treasuryFlows,
-    [BUYBACK_SOL_VAULT]: buybackFlows,
-    [STOCKPILE_SOL_VAULT]: stockpileFlows,
-  };
-  rows.forEach((row: { to_address: string; amount: number }) => {
-    flowsByVault[row.to_address]?.add(ADDRESSES.solana.SOL, row.amount);
-  });
-  flowsByVault[BUYBACK_SOL_VAULT].add(ADDRESSES.solana.SOL, buybacks[0].amount)
+  const dailyVolume = volume.daily.find(({ day }) => day === options.dateString);
+  if (!dailyVolume) throw new Error(`No Zinc volume data found for ${options.dateString}`);
+  const grossLamports = toBigIntLamports(dailyVolume.gross_lamports);
+
+  const protocolBps = config.deploy_admin_fee_bps ?? 0;
+  const stockpileBps = config.deploy_stockpile_fee_bps ?? 0;
+  const bonanzaBps = config.deploy_bonanza_fee_bps ?? 0;
+  const affiliateBps = config.deploy_affiliate_fee_bps ?? 0;
+  const prizePoolBps = stockpileBps + bonanzaBps;
+  const holdersBps =
+    config.deploy_total_fee_bps - protocolBps - prizePoolBps - affiliateBps;
+
+  const totalFees = bpsAmount(grossLamports, config.deploy_total_fee_bps);
+  const protocolFees = bpsAmount(grossLamports, protocolBps);
+  const prizePoolFees = bpsAmount(grossLamports, prizePoolBps);
+  const affiliateFees = bpsAmount(grossLamports, affiliateBps);
+  const holdersFees = bpsAmount(grossLamports, holdersBps);
+  const burnFees = bpsAmount(BigInt(holdersFees), BURN_SPLIT_BPS);
+  const stakingFees = bpsAmount(BigInt(holdersFees), STAKING_SPLIT_BPS);
 
   const dailyFees = options.createBalances();
-  dailyFees.addBalances(treasuryFlows, "Mining Fees");
-  dailyFees.addBalances(buybackFlows, "Mining Fees");
-  dailyFees.addBalances(stockpileFlows, "Mining Fees");
+  addIfPositive(dailyFees, protocolFees, "Mining Fees to Protocol");
+  addIfPositive(dailyFees, holdersFees, "Mining Fees to Buybacks");
+  addIfPositive(dailyFees, prizePoolFees, "Mining Fees to Prize Pools");
+  addIfPositive(dailyFees, affiliateFees, "Mining Fees to Affiliates");
 
-  const dailyRevenue = options.createBalances();
-  dailyRevenue.addBalances(treasuryFlows, "Mining Fees to Protocol");
-  dailyRevenue.addBalances(buybackFlows.clone(BURN_SPLIT_FROM_BUYBACKS), "Mining Fees to $ZINC Burn");
-  dailyRevenue.addBalances(buybackFlows.clone(STAKING_SPLIT_FROM_BUYBACKS), "Mining Fees to $ZINC Stakers");
+  const dailyUserFees = options.createBalances();
+  addIfPositive(dailyUserFees, totalFees, "Mining Fees");
 
   const dailyProtocolRevenue = options.createBalances();
-  dailyProtocolRevenue.addBalances(treasuryFlows, "Mining Fees to Protocol");
+  addIfPositive(dailyProtocolRevenue, protocolFees, "Mining Fees to Protocol");
 
   const dailyHoldersRevenue = options.createBalances();
-  dailyHoldersRevenue.addBalances(buybackFlows.clone(BURN_SPLIT_FROM_BUYBACKS), "Mining Fees to $ZINC Burn");
-  dailyHoldersRevenue.addBalances(buybackFlows.clone(STAKING_SPLIT_FROM_BUYBACKS), "Mining Fees to $ZINC Stakers");
+  addIfPositive(dailyHoldersRevenue, burnFees, "Mining Fees to $ZINC Burn");
+  addIfPositive(dailyHoldersRevenue, stakingFees, "Mining Fees to $ZINC Stakers");
 
   const dailySupplySideRevenue = options.createBalances();
-  dailySupplySideRevenue.addBalances(stockpileFlows, "Mining Fees to Stockpile Prize Pool");
+  addIfPositive(dailySupplySideRevenue, prizePoolFees, "Mining Fees to Prize Pools");
+
+  const dailyRevenue = options.createBalances();
+  dailyRevenue.addBalances(dailyProtocolRevenue, "Mining Fees to Protocol");
+  dailyRevenue.addBalances(dailyHoldersRevenue, "Mining Fees to $ZINC Holders");
 
   return {
     dailyFees,
-    dailyUserFees: dailyFees,
+    dailyUserFees,
     dailyRevenue,
     dailyProtocolRevenue,
     dailyHoldersRevenue,
@@ -86,35 +103,52 @@ const fetch = async (options: FetchOptions) => {
 };
 
 const methodology = {
-  Fees: "SOL paid by players when participating in ZINC rounds.",
-  UserFees: "SOL paid by players when participating in ZINC rounds.",
-  Revenue: "SOL retained by the ZINC treasury and buyback vault.",
-  ProtocolRevenue: "SOL retained by the ZINC treasury.",
-  HoldersRevenue: "SOL accumulated in the buyback vault, later converted to ZINC and distributed to stakers/burned, on a 10/90 ratio.",
-  SupplySideRevenue: "SOL accumulated in the stockpile vault and paid out to stockpile winners.",
+  Fees:
+    "Total deploy fees paid by players when participating in ZINC mining rounds. Gross round volume is pulled from zinc.cash/api/volume/daily and multiplied by deploy_total_fee_bps from zinc.cash/api/config.",
+  UserFees:
+    "Total deploy fees paid by players when participating in ZINC mining rounds.",
+  Revenue:
+    "Protocol admin fees plus buyback fees that accrue to ZINC holders through burns and staking distributions.",
+  ProtocolRevenue:
+    "The admin portion of deploy fees retained by the ZINC treasury, using deploy_admin_fee_bps from zinc.cash/api/config.",
+  HoldersRevenue:
+    "The buyback portion of deploy fees, split 90% to ZINC burns and 10% to ZINC stakers.",
+  SupplySideRevenue:
+    "Deploy fees allocated to stockpile and bonanza prize pools.",
 };
 
 const breakdownMethodology = {
   Fees: {
-    "Mining Fees": "Mining fees paid by players when participating in ZINC rounds.",
+    "Mining Fees to Protocol":
+      "Admin portion of deploy fees retained by the ZINC treasury.",
+    "Mining Fees to Buybacks":
+      "Deploy fees allocated to ZINC buybacks, burns, and staking distributions.",
+    "Mining Fees to Prize Pools":
+      "Deploy fees allocated to stockpile and bonanza prize pools.",
+    "Mining Fees to Affiliates":
+      "Affiliate portion of deploy fees paid to referrers when applicable.",
   },
   UserFees: {
-    "Mining Fees": "Mining fees paid by players when participating in ZINC rounds.",
+    "Mining Fees":
+      "Total deploy fees paid by players when participating in ZINC mining rounds.",
   },
   Revenue: {
     "Mining Fees to Protocol": "Mining fees retained by the ZINC treasury.",
-    "Mining Fees to $ZINC Burn": "Mining fees converted to $ZINC and burned.",
-    "Mining Fees to $ZINC Stakers": "Mining fees converted to $ZINC and distributed to stakers.",
+    "Mining Fees to $ZINC Holders":
+      "Mining fees used for ZINC buybacks, burns, and staking distributions.",
   },
   ProtocolRevenue: {
     "Mining Fees to Protocol": "Mining fees retained by the ZINC treasury.",
   },
   HoldersRevenue: {
-    "Mining Fees to $ZINC Burn": "Mining fees converted to $ZINC and burned (90% of buyback fees).",
-    "Mining Fees to $ZINC Stakers": "Mining fees converted to $ZINC and distributed to stakers (10% of buyback fees).",
+    "Mining Fees to $ZINC Burn":
+      "Buyback fees converted to ZINC and burned (90% of buyback fees).",
+    "Mining Fees to $ZINC Stakers":
+      "Buyback fees converted to ZINC and distributed to stakers (10% of buyback fees).",
   },
   SupplySideRevenue: {
-    "Mining Fees to Stockpile Prize Pool": "Mining fees paid to the stockpile prize pool.",
+    "Mining Fees to Prize Pools":
+      "Mining fees allocated to stockpile and bonanza prize pools.",
   },
 };
 
@@ -122,11 +156,9 @@ const adapter: SimpleAdapter = {
   version: 2,
   fetch,
   chains: [CHAIN.SOLANA],
-  dependencies: [Dependencies.ALLIUM],
   start: "2026-05-26",
   methodology,
   breakdownMethodology,
-  pullHourly: true,
 };
 
 export default adapter;


### PR DESCRIPTION
Updates the Zinc fees adapter to use the protocol official daily volume and config endpoints instead of reconstructing SOL transfer flows.

Sources:
- https://zinc.cash/api/volume/daily
- https://zinc.cash/api/config

The adapter now calculates deploy fees from gross mining round volume and live config bps, then reports:
- dailyFees / dailyUserFees from deploy_total_fee_bps
- dailyProtocolRevenue from deploy_admin_fee_bps
- dailyHoldersRevenue from the remaining buyback allocation, split 90% burn / 10% stakers
- dailySupplySideRevenue from stockpile + bonanza prize-pool bps

This better reflects Zinc gross mining activity because recycled auto-miner round volume is not fully visible in simple SOL transfer flows. The adapter is daily, so pullHourly was removed.

Tests run:
```
pnpm test fees zinc 2026-05-27
pnpm test fees zinc 2026-06-11
pnpm ts-check
```