### PR TITLE
feat: Add Sophon chain new-users and active-users adapters

### DIFF
--- a/active-users/sophon.ts
+++ b/active-users/sophon.ts
@@ -1,0 +1,32 @@
+import { Dependencies, FetchOptions, ProtocolType, SimpleAdapter } from "../adapters/types";
+import { queryDuneSql } from "../helpers/dune";
+import { CHAIN } from "../helpers/chains";
+
+const fetch = async (options: FetchOptions) => {
+  const query = `
+    SELECT
+      COALESCE(COUNT(DISTINCT "from"), 0) AS user_count,
+      COALESCE(COUNT(*), 0) AS transaction_count
+    FROM sophon.transactions
+    WHERE TIME_RANGE
+  `;
+
+  const result = await queryDuneSql(options, query);
+
+  return {
+    dailyActiveUsers: result[0].user_count,
+    dailyTransactionsCount: result[0].transaction_count,
+  };
+};
+
+const adapter: SimpleAdapter = {
+  version: 1,
+  fetch,
+  chains: [CHAIN.SOPHON],
+  dependencies: [Dependencies.DUNE],
+  isExpensiveAdapter: true,
+  protocolType: ProtocolType.CHAIN,
+  start: "2024-12-18",
+};
+
+export default adapter;

--- a/new-users/sophon.ts
+++ b/new-users/sophon.ts
@@ -1,0 +1,31 @@
+import { Dependencies, FetchOptions, ProtocolType, SimpleAdapter } from "../adapters/types";
+import { queryDuneSql } from "../helpers/dune";
+import { CHAIN } from "../helpers/chains";
+
+const fetch = async (options: FetchOptions) => {
+  const query = `
+    SELECT
+      COALESCE(COUNT(DISTINCT "from"), 0) AS new_users
+    FROM sophon.transactions
+    WHERE TIME_RANGE
+      AND nonce = 0
+  `;
+
+  const result = await queryDuneSql(options, query);
+
+  return {
+    dailyNewUsers: result[0].new_users,
+  };
+};
+
+const adapter: SimpleAdapter = {
+  version: 1,
+  fetch,
+  chains: [CHAIN.SOPHON],
+  dependencies: [Dependencies.DUNE],
+  isExpensiveAdapter: true,
+  protocolType: ProtocolType.CHAIN,
+  start: "2024-12-18",
+};
+
+export default adapter;


### PR DESCRIPTION
 ### Summary                                                                                                      
                                                                                                                 
  - Add Sophon chain active-users adapter tracking daily unique addresses and transaction count                  
  - Add Sophon chain new-users adapter tracking first-time transactors (nonce = 0)
  - Both adapters query Dune's sophon.transactions table                                                         
                                                                                                                 
  Test plan                               
    
```                                                                                                             
    pnpm test active-users sophon                                                                                
    pnpm test new-users sophon
```