### PR TITLE
optimised pump-swap query

### DIFF
--- a/fees/pump-swap/index.ts
+++ b/fees/pump-swap/index.ts
@@ -22,6 +22,15 @@ const fetch = async (options: FetchOptions) => {
                 quote_mint AS quoteMint
             FROM
                 pumpdotfun_solana.pump_amm_evt_createpoolevent
+            WHERE
+                quote_mint IN (
+                    '${ADDRESSES.solana.SOL}',
+                    'mSoLzYCxHdYgdzU16g5QSh3i5K3z3KZK7ytfqcJm7So',
+                    '${ADDRESSES.solana.USDC}',
+                    '${ADDRESSES.solana.USDT}',
+                    '${ADDRESSES.solana.PUMP}',
+                    'DEkqHyPN7GMRJ5cArtQFAWefqbZb33Hyf6s5iCwjEonT'
+                )
         ),
         sells AS (
             SELECT
@@ -58,14 +67,7 @@ const fetch = async (options: FetchOptions) => {
                 (SELECT * FROM buys UNION ALL SELECT * FROM sells) s
                 JOIN pools p ON s.pool = p.pool
             WHERE
-                p.quoteMint IN (
-                    '${ADDRESSES.solana.SOL}',
-                    'mSoLzYCxHdYgdzU16g5QSh3i5K3z3KZK7ytfqcJm7So',
-                    '${ADDRESSES.solana.USDC}',
-                    '${ADDRESSES.solana.USDT}',
-                    '${ADDRESSES.solana.PUMP}',
-                    'DEkqHyPN7GMRJ5cArtQFAWefqbZb33Hyf6s5iCwjEonT'
-                )
+                s.amount IS NOT NULL
         )
         SELECT
             quoteMint,
@@ -75,8 +77,6 @@ const fetch = async (options: FetchOptions) => {
             SUM(coinCreatorFee) AS coinCreatorFee
         FROM
             pumpswap_trades
-        WHERE
-            amount IS NOT NULL
         GROUP BY
             quoteMint
     `)


### PR DESCRIPTION
Part of https://github.com/DefiLlama/dimension-adapters/issues/6265

- the problem was that the `pools` CTE scanned all `pumpdotfun_solana.pump_amm_evt_createpoolevent` rows and most are filtered out later anyway.