### PR TITLE
Pareto credit

### DIFF
--- a/fees/idle/index.ts
+++ b/fees/idle/index.ts
@@ -22,7 +22,6 @@ const chainConfig: Record<string, Record<string, any>> = {
             "0xDcE26B2c78609b983cF91cCcD43E238353653b0E", // IdleCDO_clearpool_DAI
             "0xd0DbcD556cA22d3f3c142e9a3220053FD7a247BC", //Idle DAI
             "0x1f5A97fB665e295303D2F7215bA2160cc5313c8E",
-            "0xf6223C567F21E33e859ED7A045773526E9E3c2D5",
         ],
         BEST_YIELD_VAULTS: [
             "0x3fE7940616e5Bc47b0775a0dccf6237893353bB4", //DAI
@@ -59,14 +58,11 @@ const chainConfig: Record<string, Record<string, any>> = {
             "0x94e399Af25b676e7783fDcd62854221e67566b7f", // fasanara USDT
             "0x8771128e9E386DC8E4663118BB11EA3DE910e528", //portofino USDT
             "0x67D07aA415c8eC78cbF0074bE12254E55Ad43f3f", //Bastion USDT
-            "0xD2c0D848aA5AD1a4C12bE89e713E70B73211989B", //Falconx USDC
         ]
     },
     [CHAIN.POLYGON]: {
         start: '2021-05-31',
-        YIELD_TRANCHES: [
-            "0xF9E2AE779a7d25cDe46FccC41a27B8A4381d4e52", //Bastion CV
-        ],
+        YIELD_TRANCHES: [],
         BEST_YIELD_VAULTS: [
             "0x8a999F5A3546F8243205b2c0eCb0627cC10003ab", // idleDAIYield
             "0x1ee6470CD75D5686d0b2b90C0305Fa46fb0C89A1", // idleUSDCYield
@@ -81,9 +77,7 @@ const chainConfig: Record<string, Record<string, any>> = {
     },
     [CHAIN.ARBITRUM]: {
         start: "2024-11-29",
-        YIELD_TRANCHES: [
-            "0x3919396Cd445b03E6Bb62995A7a4CB2AC544245D", //bastion CV
-        ]
+        YIELD_TRANCHES: []
     }
 }
 

--- a/fees/pareto-credit.ts
+++ b/fees/pareto-credit.ts
@@ -4,8 +4,12 @@ import { METRIC } from '../helpers/metrics';
 
 // Performance fee on borrower interest only (per-vault rate, read from AccrueInterest on stopEpoch) -> treasury; rest -> depositors. No buyback => no holders revenue. Owns every credit vault.
 // the legacy tranches/best-yield stay in fees/idle (same parent: parent#pareto).
+// Vaults are IdleCDOEpochVariant proxies, listed in the Pareto API (https://docs.pareto.credit/developers/api)
+// and labeled "Pareto: Credit Vault ..." on the explorers.
 const config: any = {
   [CHAIN.ETHEREUM]: {
+    // IdleCreditVaultFactory, verified on etherscan, deployed at block 22938055.
+    // Emits CreditVaultDeployed for every vault created after the four pre-factory vaults below.
     factory: { address: '0x59aabdad8fdabd227cc71543b128765f93906626', fromBlock: 22938055 },
     credits: [
       '0xf6223C567F21E33e859ED7A045773526E9E3c2D5', // Fasanara Yield
@@ -56,16 +60,15 @@ const fetch = async (options: FetchOptions) => {
     });
   }
 
-  // per-vault underlying (AccrueInterest amounts use its decimals)
-  const tokens = await api.multiCall({ abi: abis.token, calls: vaults, permitFailure: true });
+  // per-vault underlying (AccrueInterest amounts use its decimals); no permitFailure,
+  // a vault that cannot resolve token() should fail the run, not silently drop its fees
+  const tokens = await api.multiCall({ abi: abis.token, calls: vaults });
 
-  const logsPerVault = await Promise.all(
-    vaults.map((vault) => getLogs({ target: vault, eventAbi: abis.accrueInterest }))
-  );
+  // flatten: false keeps one log array per vault, aligned with tokens[i]
+  const logsPerVault = await getLogs({ targets: vaults, eventAbi: abis.accrueInterest, flatten: false });
 
   logsPerVault.forEach((logs: any[], i) => {
     const token = tokens[i];
-    if (!token) return;
     logs.forEach((log) => {
       const interest = BigInt(log.interest.toString());
       const fees = BigInt(log.fees.toString());

--- a/fees/pareto-credit.ts
+++ b/fees/pareto-credit.ts
@@ -1,0 +1,118 @@
+import { FetchOptions, SimpleAdapter } from '../adapters/types';
+import { CHAIN } from '../helpers/chains';
+import { METRIC } from '../helpers/metrics';
+
+// Performance fee on borrower interest only (per-vault rate, read from AccrueInterest on stopEpoch) -> treasury; rest -> depositors. No buyback => no holders revenue. Owns every credit vault.
+// the legacy tranches/best-yield stay in fees/idle (same parent: parent#pareto).
+const config: any = {
+  [CHAIN.ETHEREUM]: {
+    factory: { address: '0x59aabdad8fdabd227cc71543b128765f93906626', fromBlock: 22938055 },
+    credits: [
+      '0xf6223C567F21E33e859ED7A045773526E9E3c2D5', // Fasanara Yield
+      '0x4462eD748B8F7985A4aC6b538Dfc105Fce2dD165', // Bastion
+      '0x14B8E918848349D1e71e806a52c13D4e0d3246E0', // Adaptive Frontier
+      '0x433D5B175148dA32Ffe1e1A37a939E1b7e79be4d', // FalconX
+    ],
+  },
+  [CHAIN.POLYGON]: {
+    credits: ['0xF9E2AE779a7d25cDe46FccC41a27B8A4381d4e52'], // Bastion
+  },
+  [CHAIN.OPTIMISM]: {
+    credits: ['0xD2c0D848aA5AD1a4C12bE89e713E70B73211989B'], // FalconX
+  },
+  [CHAIN.ARBITRUM]: {
+    credits: ['0x3919396Cd445b03E6Bb62995A7a4CB2AC544245D'], // Bastion
+  },
+};
+
+const abis = {
+  creditVaultDeployed: 'event CreditVaultDeployed(address proxy)',
+  accrueInterest: 'event AccrueInterest(uint256 interest, uint256 fees)',
+  token: 'function token() view returns (address)',
+};
+
+const fetch = async (options: FetchOptions) => {
+  const { chain, createBalances, getLogs, api } = options;
+  const dailyFees = createBalances();
+  const dailyRevenue = createBalances();
+  const dailyProtocolRevenue = createBalances();
+  const dailySupplySideRevenue = createBalances();
+
+  const { factory, credits = [] } = config[chain];
+  const vaults: string[] = [...credits];
+
+  // pick up factory-deployed vaults
+  if (factory) {
+    const deployed = await getLogs({
+      target: factory.address,
+      eventAbi: abis.creditVaultDeployed,
+      fromBlock: factory.fromBlock,
+      cacheInCloud: true,
+    });
+    deployed.forEach((log: any) => {
+      if (!vaults.find((v) => v.toLowerCase() === log.proxy.toLowerCase())) {
+        vaults.push(log.proxy);
+      }
+    });
+  }
+
+  // per-vault underlying (AccrueInterest amounts use its decimals)
+  const tokens = await api.multiCall({ abi: abis.token, calls: vaults, permitFailure: true });
+
+  const logsPerVault = await Promise.all(
+    vaults.map((vault) => getLogs({ target: vault, eventAbi: abis.accrueInterest }))
+  );
+
+  logsPerVault.forEach((logs: any[], i) => {
+    const token = tokens[i];
+    if (!token) return;
+    logs.forEach((log) => {
+      const interest = BigInt(log.interest.toString());
+      const fees = BigInt(log.fees.toString());
+      dailyFees.add(token, interest, METRIC.BORROW_INTEREST);
+      dailyRevenue.add(token, fees, METRIC.PERFORMANCE_FEES);
+      dailyProtocolRevenue.add(token, fees, METRIC.PERFORMANCE_FEES);
+      dailySupplySideRevenue.add(token, interest - fees, METRIC.BORROW_INTEREST);
+    });
+  });
+
+  return { dailyFees, dailyRevenue, dailyProtocolRevenue, dailySupplySideRevenue };
+};
+
+const methodology = {
+  Fees: 'Interest paid by borrowers across all Pareto credit vaults.',
+  Revenue: 'Performance fee charged by the protocol on borrower interest (per-vault rate).',
+  ProtocolRevenue: 'Performance fee collected to the Pareto treasury multisig.',
+  SupplySideRevenue: 'Borrower interest distributed to credit vault depositors (lenders) after the performance fee.',
+};
+
+const breakdownMethodology = {
+  Fees: {
+    [METRIC.BORROW_INTEREST]: 'Interest paid by borrowers on funds drawn from each credit vault.',
+  },
+  Revenue: {
+    [METRIC.PERFORMANCE_FEES]: 'Protocol performance fee on borrower interest.',
+  },
+  ProtocolRevenue: {
+    [METRIC.PERFORMANCE_FEES]: 'Performance fee sent to the Pareto treasury multisig.',
+  },
+  SupplySideRevenue: {
+    [METRIC.BORROW_INTEREST]: 'Net borrower interest distributed to vault depositors after the performance fee.',
+  },
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  pullHourly: true,
+  fetch,
+  adapter: {
+    [CHAIN.ETHEREUM]: { start: '2024-10-14' },
+    [CHAIN.POLYGON]: { start: '2025-03-31' },
+    [CHAIN.OPTIMISM]: { start: '2025-01-31' },
+    [CHAIN.ARBITRUM]: { start: '2024-12-31' },
+  },
+  methodology,
+  breakdownMethodology,
+};
+
+export default adapter;


### PR DESCRIPTION
Adds a dedicated `pareto-credit` fees adapter for Pareto Credit's epoch-based credit vaults and removes those vaults from the Idle adapter to prevent double counting.

### Changes

#### New adapter

Adds `fees/pareto-credit.ts`, which tracks Pareto Credit `IdleCDOEpochVariant` vaults across:

- Ethereum
- Polygon
- Optimism
- Arbitrum

Ethereum vaults are discovered from the credit-vault factory, with the four pre-factory vaults included manually. New factory-created vaults will be picked up automatically.

#### Idle cleanup

Removes the four Pareto Credit vaults that were previously counted by `fees/idle/index.ts`:

- Fasanara (Ethereum)
- FalconX (Optimism)
- Bastion (Polygon)
- Bastion (Arbitrum)

This ensures each vault's fees are attributed exactly once.

### Fee methodology

Fees are realized via `AccrueInterest(uint256 interest, uint256 fees)`, emitted during `stopEpoch`.

Performance fees are read directly from emitted events rather than hardcoded values. On-chain verification shows a standard fee of 10%, with the Fasanara vault configured at 20%.

The fee recipient is the Pareto treasury multisig (`0xFb3bD0…3814` on Ethereum), so performance fees are classified as protocol revenue rather than holder revenue.

| Field | Calculation |
| --- | --- |
| `dailyFees` | `interest` (gross borrower interest) |
| `dailyRevenue` | `fees` (performance fee paid to treasury) |
| `dailyProtocolRevenue` | `fees` |
| `dailySupplySideRevenue` | `interest - fees` (lender share) |
| `dailyHoldersRevenue` | `0` (no buyback mechanism active) |

### Attribution fix

Idle and Pareto Credit are separate DefiLlama protocols under the same `parent#pareto`.

The Idle adapter was previously attributing fees from several epoch-based credit vaults that belong to the Pareto Credit product. These vaults are now tracked exclusively by the new `pareto-credit` adapter, while Idle continues to cover:

- Legacy continuous tranches
- Best Yield products
- Non-epoch credit vaults and PYTs that do not emit `AccrueInterest`

Epoch vaults are identified via `epochDuration()`, which is specific to `IdleCDOEpochVariant`.

Because both adapters roll up to the same parent protocol, parent-level totals remain unchanged. This PR only reattributes revenue from the Idle child page to the Pareto Credit child page.

### Verification

- Reconciled adapter output against raw on-chain `AccrueInterest` event totals across multiple dates.
- Example: Ethereum on 2025-11-24 matched exactly at **$34,198.82 fees** and **$6,237.38 revenue**.
- Verified the accounting identity: `dailyFees = dailyRevenue + dailySupplySideRevenue`.
- Confirmed the Idle adapter runs cleanly after removing epoch vaults, including handling empty L2 tranche lists.
- Set chain-specific `start` timestamps to each chain's first observed `AccrueInterest` event.