### PR TITLE
feat: add perpflow builder code to hyperliquid

### DIFF
--- a/factory/hyperliquid.ts
+++ b/factory/hyperliquid.ts
@@ -132,6 +132,15 @@ const builderConfigs: Record<string, BuilderConfig> = {
       ProtocolRevenue: "Builder Code Fees collected by Phantom from Hyperliquid Perps.",
     },
   },
+  "perpflow": {
+    addresses: ["0x113f059d7a863fbca1ff60df5b1954dbec9f91dd"],
+    start: "2025-07-26",
+    methodology: {
+      Fees: "Builder code fees paid by users on Hyperliquid perps trades routed through Perpflow's delta-neutral position creator.",
+      Revenue: "Builder code revenue collected by Perpflow from Hyperliquid Perps Trades.",
+      ProtocolRevenue: "Builder code revenue collected by Perpflow from Hyperliquid Perps Trades.",
+    },
+  },
   "perpmate": {
     addresses: ["0xE4FEa748ECa48F44b1e042775F0C2363be1A2d80"],
     start: "2025-09-04",


### PR DESCRIPTION
Adds Perpflow as a Hyperliquid builder-code adapter (via the `factory/hyperliquid.ts` builder config).

##### Name (to be shown on DefiLlama):
Perpflow

##### Website Link:
https://perpflow.xyz/

##### Chain:
Hyperliquid

##### Token address and ticker if any:
None

##### Category:
Derivatives (Hyperliquid perps builder code)

##### methodology:
Tracks builder-code revenue for Perpflow's builder address `0x113f059d7a863fbca1ff60df5b1954dbec9f91dd` from Hyperliquid perps trades, read from Hyperliquid's `builder_fills` data. 

Perpflow is an automated delta-neutral yield platform on Hyperliquid. It appends its builder code (up to 0.1% on perps) to fills it routes.

##### Verification:
- Builder address confirmed against Hyperliquid `builder_fills` (real perps fills with populated `builder_fee` column).
- Start date `2025-07-26` = first day the builder code had fills.