### PR TITLE
feat: Add AFX perp volume adapter

### DIFF
--- a/dexs/afx-perp.ts
+++ b/dexs/afx-perp.ts
@@ -1,0 +1,61 @@
+import { SimpleAdapter, FetchOptions, FetchResultV2 } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+import { httpGet } from "../utils/fetchURL";
+import { PromisePool } from "@supercharge/promise-pool";
+
+const API_BASE = "https://api.afx.xyz";
+const DAILY_INTERVAL = 86400;
+
+interface KlineCandle {
+  timestamp: number;
+  turnover: string;
+}
+
+interface ProductMeta {
+  perpProducts: { symbol: string }[];
+}
+
+const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
+  const dailyVolume = options.createBalances();
+
+  const { data: productMeta }: { data: ProductMeta } = await httpGet(`${API_BASE}/info/public/product-meta`);
+  const symbols = productMeta.perpProducts.map((p) => p.symbol);
+
+  const startTime = options.startOfDay;
+  const endTime = startTime + DAILY_INTERVAL;
+
+  const { results } = await PromisePool
+    .withConcurrency(5)
+    .for(symbols)
+    .process(async (symbol) => {
+      const res: { data: KlineCandle[] } = await httpGet(`${API_BASE}/info/kline/list?symbol_name=${symbol}&interval=${DAILY_INTERVAL}&startTime=${startTime}&endTime=${endTime}`);
+      return res.data;
+    });
+
+  let totalTurnover = 0;
+  for (const candles of results) {
+    const match = candles.find((c) => c.timestamp === startTime);
+    if (match) {
+      totalTurnover += Number(match.turnover);
+    }
+  }
+
+  dailyVolume.addUSDValue(totalTurnover);
+
+  return { dailyVolume };
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  adapter: {
+    [CHAIN.AFX]: {
+      fetch,
+      start: "2026-05-12",
+    },
+  },
+  methodology: {
+    Volume: "Sum of daily turnover (notional volume in USD) across all perpetual trading pairs, sourced from AFX kline data.",
+  },
+};
+
+export default adapter;

--- a/dexs/afx-perp.ts
+++ b/dexs/afx-perp.ts
@@ -1,53 +1,48 @@
-import { SimpleAdapter, FetchOptions, FetchResultV2 } from "../adapters/types";
+import { Dependencies, FetchOptions, SimpleAdapter } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
-import { fetchURLAutoHandleRateLimit } from "../utils/fetchURL";
+import { queryDuneSql } from "../helpers/dune";
 
-const API_BASE = "https://api10.afx.xyz";
-const DAILY_INTERVAL = 86400;
-
-interface KlineCandle {
-  timestamp: number;
-  turnover: string;
-}
-
-interface ProductMeta {
-  perpProducts: { symbol: string }[];
-}
-
-const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
+const fetch = async (options: FetchOptions) => {
   const dailyVolume = options.createBalances();
 
-  const { data: productMeta }: { data: ProductMeta } = await fetchURLAutoHandleRateLimit(`${API_BASE}/info/public/product-meta`);
-  if (!productMeta?.perpProducts) throw new Error("AFX: failed to fetch product meta");
-  const symbols = productMeta.perpProducts.map((p) => p.symbol);
+  const rows = await queryDuneSql(options, `
+    with meta as (
+      select json_parse(http_get('https://api10.afx.xyz/info/public/product-meta', ARRAY['Accept: application/json','User-Agent: Mozilla/5.0'])) as j
+    ),
+    markets as (
+      select json_extract_scalar(p,'$.symbol') as symbol
+      from meta cross join unnest(cast(json_extract(j,'$.data.perpProducts') as array(json))) as t(p)
+    ),
+    k as (
+      select symbol,
+        json_parse(http_get(concat('https://api10.afx.xyz/info/kline/last?symbol_name=', symbol, '&interval=86400&limit=30'), ARRAY['Accept: application/json','User-Agent: Mozilla/5.0'])) as j
+      from markets
+    ),
+    candles as (
+      select
+        cast(json_extract_scalar(c,'$.timestamp') as bigint) as ts,
+        cast(json_extract_scalar(c,'$.turnover') as double) as turnover_usd
+      from k cross join unnest(cast(json_extract(j,'$.data') as array(json))) as t(c)
+    )
+    select coalesce(sum(turnover_usd), 0) as daily_volume
+    from candles
+    where ts = ${options.startOfDay}
+  `);
 
-  const startTime = options.startOfDay;
-  const endTime = startTime + DAILY_INTERVAL;
-
-  let totalTurnover = 0;
-  for (let i = 0; i < symbols.length; i++) {
-    const symbol = symbols[i];
-    const res: { data: KlineCandle[] } = await fetchURLAutoHandleRateLimit(`${API_BASE}/info/kline/list?symbol_name=${symbol}&interval=${DAILY_INTERVAL}&startTime=${startTime}&endTime=${endTime}`);
-    if (!Array.isArray(res?.data)) throw new Error(`AFX: invalid kline response for ${symbol}`);
-    const match = res.data.find((c) => c.timestamp === startTime);
-    if (match) {
-      totalTurnover += Number(match.turnover);
-    }
-  }
-
-  dailyVolume.addUSDValue(totalTurnover);
+  dailyVolume.addUSDValue(rows[0].daily_volume);
 
   return { dailyVolume };
 };
 
 const adapter: SimpleAdapter = {
-  // version 1: the kline API only serves daily aggregates (interval=86400, keyed off startOfDay)
   version: 1,
   fetch,
   chains: [CHAIN.AFX],
   start: "2026-05-12",
+  dependencies: [Dependencies.DUNE],
+  isExpensiveAdapter: true,
   methodology: {
-    Volume: "Sum of daily turnover (notional volume in USD) across all perpetual trading pairs, sourced from AFX kline data.",
+    Volume: "Sum of daily turnover (notional volume in USD) across all AFX perpetual trading pairs.",
   },
 };
 

--- a/dexs/afx-perp.ts
+++ b/dexs/afx-perp.ts
@@ -1,7 +1,6 @@
 import { SimpleAdapter, FetchOptions, FetchResultV2 } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
-import fetchURL from "../utils/fetchURL";
-import { sleep } from "../utils/utils";
+import { fetchURLAutoHandleRateLimit } from "../utils/fetchURL";
 
 const API_BASE = "https://api.afx.xyz";
 const DAILY_INTERVAL = 86400;
@@ -18,7 +17,7 @@ interface ProductMeta {
 const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
   const dailyVolume = options.createBalances();
 
-  const { data: productMeta }: { data: ProductMeta } = await fetchURL(`${API_BASE}/info/public/product-meta`);
+  const { data: productMeta }: { data: ProductMeta } = await fetchURLAutoHandleRateLimit(`${API_BASE}/info/public/product-meta`);
   if (!productMeta?.perpProducts) throw new Error("AFX: failed to fetch product meta");
   const symbols = productMeta.perpProducts.map((p) => p.symbol);
 
@@ -27,9 +26,8 @@ const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
 
   let totalTurnover = 0;
   for (let i = 0; i < symbols.length; i++) {
-    if (i > 0) await sleep(1000);
     const symbol = symbols[i];
-    const res: { data: KlineCandle[] } = await fetchURL(`${API_BASE}/info/kline/list?symbol_name=${symbol}&interval=${DAILY_INTERVAL}&startTime=${startTime}&endTime=${endTime}`);
+    const res: { data: KlineCandle[] } = await fetchURLAutoHandleRateLimit(`${API_BASE}/info/kline/list?symbol_name=${symbol}&interval=${DAILY_INTERVAL}&startTime=${startTime}&endTime=${endTime}`);
     if (!Array.isArray(res?.data)) throw new Error(`AFX: invalid kline response for ${symbol}`);
     const match = res.data.find((c) => c.timestamp === startTime);
     if (match) {

--- a/dexs/afx-perp.ts
+++ b/dexs/afx-perp.ts
@@ -1,7 +1,6 @@
 import { SimpleAdapter, FetchOptions, FetchResultV2 } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
-import { fetchURLAutoHandleRateLimit } from "../utils/fetchURL";
-import { PromisePool } from "@supercharge/promise-pool";
+import fetchURL from "../utils/fetchURL";
 
 const API_BASE = "https://api.afx.xyz";
 const DAILY_INTERVAL = 86400;
@@ -18,26 +17,18 @@ interface ProductMeta {
 const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
   const dailyVolume = options.createBalances();
 
-  const { data: productMeta }: { data: ProductMeta } = await fetchURLAutoHandleRateLimit(`${API_BASE}/info/public/product-meta`);
+  const { data: productMeta }: { data: ProductMeta } = await fetchURL(`${API_BASE}/info/public/product-meta`);
+  if (!productMeta?.perpProducts) throw new Error("AFX: failed to fetch product meta");
   const symbols = productMeta.perpProducts.map((p) => p.symbol);
 
   const startTime = options.startOfDay;
   const endTime = startTime + DAILY_INTERVAL;
 
-  const { results, errors } = await PromisePool
-    .withConcurrency(5)
-    .for(symbols)
-    .process(async (symbol) => {
-      const res: { data: KlineCandle[] } = await fetchURLAutoHandleRateLimit(`${API_BASE}/info/kline/list?symbol_name=${symbol}&interval=${DAILY_INTERVAL}&startTime=${startTime}&endTime=${endTime}`);
-      return res.data;
-    });
-
-  // a failed symbol fetch (e.g. rate limit) must fail the run, not silently undercount volume
-  if (errors.length) throw errors[0];
-
   let totalTurnover = 0;
-  for (const candles of results) {
-    const match = candles.find((c) => c.timestamp === startTime);
+  for (const symbol of symbols) {
+    const res: { data: KlineCandle[] } = await fetchURL(`${API_BASE}/info/kline/list?symbol_name=${symbol}&interval=${DAILY_INTERVAL}&startTime=${startTime}&endTime=${endTime}`);
+    if (!Array.isArray(res?.data)) throw new Error(`AFX: invalid kline response for ${symbol}`);
+    const match = res.data.find((c) => c.timestamp === startTime);
     if (match) {
       totalTurnover += Number(match.turnover);
     }

--- a/dexs/afx-perp.ts
+++ b/dexs/afx-perp.ts
@@ -24,13 +24,16 @@ const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
   const startTime = options.startOfDay;
   const endTime = startTime + DAILY_INTERVAL;
 
-  const { results } = await PromisePool
+  const { results, errors } = await PromisePool
     .withConcurrency(5)
     .for(symbols)
     .process(async (symbol) => {
       const res: { data: KlineCandle[] } = await httpGet(`${API_BASE}/info/kline/list?symbol_name=${symbol}&interval=${DAILY_INTERVAL}&startTime=${startTime}&endTime=${endTime}`);
       return res.data;
     });
+
+  // a failed symbol fetch (e.g. rate limit) must fail the run, not silently undercount volume
+  if (errors.length) throw errors[0];
 
   let totalTurnover = 0;
   for (const candles of results) {
@@ -46,13 +49,11 @@ const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
 };
 
 const adapter: SimpleAdapter = {
-  version: 2,
-  adapter: {
-    [CHAIN.AFX]: {
-      fetch,
-      start: "2026-05-12",
-    },
-  },
+  // version 1: the kline API only serves daily aggregates (interval=86400, keyed off startOfDay)
+  version: 1,
+  fetch,
+  chains: [CHAIN.AFX],
+  start: "2026-05-12",
   methodology: {
     Volume: "Sum of daily turnover (notional volume in USD) across all perpetual trading pairs, sourced from AFX kline data.",
   },

--- a/dexs/afx-perp.ts
+++ b/dexs/afx-perp.ts
@@ -1,6 +1,6 @@
 import { SimpleAdapter, FetchOptions, FetchResultV2 } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
-import { httpGet } from "../utils/fetchURL";
+import { fetchURLAutoHandleRateLimit } from "../utils/fetchURL";
 import { PromisePool } from "@supercharge/promise-pool";
 
 const API_BASE = "https://api.afx.xyz";
@@ -18,7 +18,7 @@ interface ProductMeta {
 const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
   const dailyVolume = options.createBalances();
 
-  const { data: productMeta }: { data: ProductMeta } = await httpGet(`${API_BASE}/info/public/product-meta`);
+  const { data: productMeta }: { data: ProductMeta } = await fetchURLAutoHandleRateLimit(`${API_BASE}/info/public/product-meta`);
   const symbols = productMeta.perpProducts.map((p) => p.symbol);
 
   const startTime = options.startOfDay;
@@ -28,7 +28,7 @@ const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
     .withConcurrency(5)
     .for(symbols)
     .process(async (symbol) => {
-      const res: { data: KlineCandle[] } = await httpGet(`${API_BASE}/info/kline/list?symbol_name=${symbol}&interval=${DAILY_INTERVAL}&startTime=${startTime}&endTime=${endTime}`);
+      const res: { data: KlineCandle[] } = await fetchURLAutoHandleRateLimit(`${API_BASE}/info/kline/list?symbol_name=${symbol}&interval=${DAILY_INTERVAL}&startTime=${startTime}&endTime=${endTime}`);
       return res.data;
     });
 

--- a/dexs/afx-perp.ts
+++ b/dexs/afx-perp.ts
@@ -1,6 +1,7 @@
 import { SimpleAdapter, FetchOptions, FetchResultV2 } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
 import fetchURL from "../utils/fetchURL";
+import { sleep } from "../utils/utils";
 
 const API_BASE = "https://api.afx.xyz";
 const DAILY_INTERVAL = 86400;
@@ -25,7 +26,9 @@ const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
   const endTime = startTime + DAILY_INTERVAL;
 
   let totalTurnover = 0;
-  for (const symbol of symbols) {
+  for (let i = 0; i < symbols.length; i++) {
+    if (i > 0) await sleep(1000);
+    const symbol = symbols[i];
     const res: { data: KlineCandle[] } = await fetchURL(`${API_BASE}/info/kline/list?symbol_name=${symbol}&interval=${DAILY_INTERVAL}&startTime=${startTime}&endTime=${endTime}`);
     if (!Array.isArray(res?.data)) throw new Error(`AFX: invalid kline response for ${symbol}`);
     const match = res.data.find((c) => c.timestamp === startTime);

--- a/dexs/afx-perp.ts
+++ b/dexs/afx-perp.ts
@@ -2,7 +2,7 @@ import { SimpleAdapter, FetchOptions, FetchResultV2 } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
 import { fetchURLAutoHandleRateLimit } from "../utils/fetchURL";
 
-const API_BASE = "https://api.afx.xyz";
+const API_BASE = "https://api10.afx.xyz";
 const DAILY_INTERVAL = 86400;
 
 interface KlineCandle {

--- a/helpers/chains.ts
+++ b/helpers/chains.ts
@@ -13,6 +13,7 @@ export enum CHAIN {
   GALA = "gala",
   TARA = "tara",
   PROTON = "proton",
+  AFX = "afx",
   ARBITRUM = "arbitrum",
   ASSETCHAIN = "assetchain",
   AVAX = "avax",


### PR DESCRIPTION
### Summary
                                                                                                                 
  - Add AFX perpetual derivatives volume adapter                                                                 
  - AFX is a sovereign L1 purpose-built for decentralized derivatives with sub-100ms finality                    
  - Volume is fetched from AFX's REST API (/info/kline/list) by summing daily turnover (USD notional volume)     
  across all 34 perpetual trading pairs                                                                          
  - Added AFX chain to the chains helper enum       
  - https://defillama.com/protocol/afx                                                             
                                                                                                                 
  Test plan                                                                                                    
                                                                                                                 
  - pnpm test dexs afx-perp 2026-05-13 — $2.24M                                                                  
  - pnpm test dexs afx-perp 2026-06-01 — $14.42M
  - pnpm test dexs afx-perp 2026-06-10 — $28.17M                                                                 
  - pnpm test dexs afx-perp 2026-06-11 — $32.28M   