### PR TITLE
feat: Add Conflux chain fees and new-users adapters

### DIFF
--- a/fees/conflux.ts
+++ b/fees/conflux.ts
@@ -1,0 +1,32 @@
+import { Adapter, FetchOptions, ProtocolType } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+import fetchURL from "../utils/fetchURL";
+
+const API_BASE = "https://evmapi.confluxscan.io/api";
+
+async function fetch(options: FetchOptions) {
+    const dailyFees = options.createBalances();
+    const dateString = options.dateString;
+    const prevDay = new Date(new Date(dateString).getTime() - 86400000).toISOString().slice(0, 10);
+    const feeData = await fetchURL(`${API_BASE}?module=stats&action=dailytxnfee&startdate=${prevDay}&enddate=${dateString}`);
+    if (!Array.isArray(feeData?.result))
+        throw new Error(`Conflux: API error for ${dateString}`);
+    const feeToday = feeData.result.find((fee: any) => fee.UTCDate === dateString);
+    if (feeToday) {
+        dailyFees.addCGToken("conflux-token", Number(feeToday.transactionFee_CFX));
+    }
+    return { dailyFees };
+}
+
+const adapter: Adapter = {
+    version: 1,
+    fetch,
+    chains: [CHAIN.CONFLUX],
+    start: "2022-02-20",
+    protocolType: ProtocolType.CHAIN,
+    methodology: {
+        Fees: "Transaction fees paid by users on Conflux eSpace",
+    },
+};
+
+export default adapter;

--- a/fees/conflux.ts
+++ b/fees/conflux.ts
@@ -2,20 +2,44 @@ import { Adapter, FetchOptions, ProtocolType } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
 import fetchURL from "../utils/fetchURL";
 
+// Conflux eSpace uses CIP-1559: base fee is burned, priority fee goes to validators.
+// Revenue = gasUsed × baseFeePerGas (burned portion).
+// SupplySideRevenue = total fees - burned (validator tips).
+// baseFeePerGas ≈ minGasPrice observed that day (confirmed equal at low utilisation via RPC).
 const API_BASE = "https://evmapi.confluxscan.io/api";
 
 async function fetch(options: FetchOptions) {
     const dailyFees = options.createBalances();
+    const dailyRevenue = options.createBalances();
+    const dailySupplySideRevenue = options.createBalances();
     const dateString = options.dateString;
     const prevDay = new Date(new Date(dateString).getTime() - 86400000).toISOString().slice(0, 10);
-    const feeData = await fetchURL(`${API_BASE}?module=stats&action=dailytxnfee&startdate=${prevDay}&enddate=${dateString}`);
-    if (!Array.isArray(feeData?.result))
+
+    const [feeData, gasUsedData, gasPriceData] = await Promise.all([
+        fetchURL(`${API_BASE}?module=stats&action=dailytxnfee&startdate=${prevDay}&enddate=${dateString}`),
+        fetchURL(`${API_BASE}?module=stats&action=dailygasused&startdate=${prevDay}&enddate=${dateString}`),
+        fetchURL(`${API_BASE}?module=stats&action=dailyavggasprice&startdate=${prevDay}&enddate=${dateString}`),
+    ]);
+
+    if (!Array.isArray(feeData?.result) || !Array.isArray(gasUsedData?.result) || !Array.isArray(gasPriceData?.result))
         throw new Error(`Conflux: API error for ${dateString}`);
-    const feeToday = feeData.result.find((fee: any) => fee.UTCDate === dateString);
-    if (feeToday) {
-        dailyFees.addCGToken("conflux-token", Number(feeToday.transactionFee_CFX));
-    }
-    return { dailyFees };
+
+    const feeToday = feeData.result.find((e: any) => e.UTCDate === dateString);
+    const gasUsedToday = gasUsedData.result.find((e: any) => e.UTCDate === dateString);
+    const gasPriceToday = gasPriceData.result.find((e: any) => e.UTCDate === dateString);
+
+    if (!feeToday || !gasUsedToday || !gasPriceToday) return { dailyFees, dailyRevenue, dailySupplySideRevenue };
+
+    const totalFeesCFX = Number(feeToday.transactionFee_CFX);
+    // Base fee equals the minimum observed gas price (Drip). Burned = gasUsed × baseFee / 1e18.
+    const burnedCFX = (Number(gasUsedToday.gasUsed) * Number(gasPriceToday.minGasPrice_Drip)) / 1e18;
+    const validatorCFX = Math.max(0, totalFeesCFX - burnedCFX);
+
+    dailyFees.addCGToken("conflux-token", totalFeesCFX, "Transaction Fees");
+    dailyRevenue.addCGToken("conflux-token", burnedCFX, "Burned Base Fees");
+    dailySupplySideRevenue.addCGToken("conflux-token", validatorCFX, "Validator Tips");
+
+    return { dailyFees, dailyRevenue, dailySupplySideRevenue };
 }
 
 const adapter: Adapter = {
@@ -26,6 +50,19 @@ const adapter: Adapter = {
     protocolType: ProtocolType.CHAIN,
     methodology: {
         Fees: "Transaction fees paid by users on Conflux eSpace",
+        Revenue: "Base fees burned via CIP-1559 (gasUsed × baseFeePerGas)",
+        SupplySideRevenue: "Priority fees (tips) paid to validators",
+    },
+    breakdownMethodology: {
+        Fees: {
+            "Transaction Fees": "Total gas fees paid by users on Conflux eSpace",
+        },
+        Revenue: {
+            "Burned Base Fees": "Base fee portion of gas fees burned by the protocol (CIP-1559)",
+        },
+        SupplySideRevenue: {
+            "Validator Tips": "Priority fee portion of gas fees paid to block validators",
+        },
     },
 };
 

--- a/fees/conflux.ts
+++ b/fees/conflux.ts
@@ -4,14 +4,12 @@ import fetchURL from "../utils/fetchURL";
 
 // Conflux eSpace uses CIP-1559: base fee is burned, priority fee goes to validators.
 // Revenue = gasUsed × baseFeePerGas (burned portion).
-// SupplySideRevenue = total fees - burned (validator tips).
 // baseFeePerGas ≈ minGasPrice observed that day (confirmed equal at low utilisation via RPC).
 const API_BASE = "https://evmapi.confluxscan.io/api";
 
 async function fetch(options: FetchOptions) {
     const dailyFees = options.createBalances();
     const dailyRevenue = options.createBalances();
-    const dailySupplySideRevenue = options.createBalances();
     const dateString = options.dateString;
     const prevDay = new Date(new Date(dateString).getTime() - 86400000).toISOString().slice(0, 10);
 
@@ -28,18 +26,16 @@ async function fetch(options: FetchOptions) {
     const gasUsedToday = gasUsedData.result.find((e: any) => e.UTCDate === dateString);
     const gasPriceToday = gasPriceData.result.find((e: any) => e.UTCDate === dateString);
 
-    if (!feeToday || !gasUsedToday || !gasPriceToday) return { dailyFees, dailyRevenue, dailySupplySideRevenue };
+    if (!feeToday || !gasUsedToday || !gasPriceToday) return { dailyFees, dailyRevenue };
 
     const totalFeesCFX = Number(feeToday.transactionFee_CFX);
     // Base fee equals the minimum observed gas price (Drip). Burned = gasUsed × baseFee / 1e18.
     const burnedCFX = (Number(gasUsedToday.gasUsed) * Number(gasPriceToday.minGasPrice_Drip)) / 1e18;
-    const validatorCFX = Math.max(0, totalFeesCFX - burnedCFX);
 
     dailyFees.addCGToken("conflux-token", totalFeesCFX, "Transaction Fees");
     dailyRevenue.addCGToken("conflux-token", burnedCFX, "Burned Base Fees");
-    dailySupplySideRevenue.addCGToken("conflux-token", validatorCFX, "Validator Tips");
 
-    return { dailyFees, dailyRevenue, dailySupplySideRevenue };
+    return { dailyFees, dailyRevenue };
 }
 
 const adapter: Adapter = {
@@ -51,7 +47,6 @@ const adapter: Adapter = {
     methodology: {
         Fees: "Transaction fees paid by users on Conflux eSpace",
         Revenue: "Base fees burned via CIP-1559 (gasUsed × baseFeePerGas)",
-        SupplySideRevenue: "Priority fees (tips) paid to validators",
     },
     breakdownMethodology: {
         Fees: {
@@ -59,9 +54,6 @@ const adapter: Adapter = {
         },
         Revenue: {
             "Burned Base Fees": "Base fee portion of gas fees burned by the protocol (CIP-1559)",
-        },
-        SupplySideRevenue: {
-            "Validator Tips": "Priority fee portion of gas fees paid to block validators",
         },
     },
 };

--- a/fees/conflux.ts
+++ b/fees/conflux.ts
@@ -26,7 +26,7 @@ async function fetch(options: FetchOptions) {
     const gasUsedToday = gasUsedData.result.find((e: any) => e.UTCDate === dateString);
     const gasPriceToday = gasPriceData.result.find((e: any) => e.UTCDate === dateString);
 
-    if (!feeToday || !gasUsedToday || !gasPriceToday) return { dailyFees, dailyRevenue };
+    if (!feeToday || !gasUsedToday || !gasPriceToday) throw new Error(`Conflux: no data for ${dateString}`);
 
     const totalFeesCFX = Number(feeToday.transactionFee_CFX);
     // Base fee equals the minimum observed gas price (Drip). Burned = gasUsed × baseFee / 1e18.

--- a/new-users/conflux.ts
+++ b/new-users/conflux.ts
@@ -11,6 +11,7 @@ const fetch = async (options: FetchOptions) => {
     if (!Array.isArray(data?.result))
         throw new Error(`Conflux: API error for ${dateString}`);
     const entry = data.result.find((e: any) => e.UTCDate === dateString);
+    if (!entry) throw new Error(`Conflux: no new-address entry for ${dateString}`);
     return {
         dailyNewUsers: entry.newAddressCount,
     };

--- a/new-users/conflux.ts
+++ b/new-users/conflux.ts
@@ -1,0 +1,27 @@
+import { FetchOptions, ProtocolType, SimpleAdapter } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+import fetchURL from "../utils/fetchURL";
+
+const API_BASE = "https://evmapi.confluxscan.io/api";
+
+const fetch = async (options: FetchOptions) => {
+    const dateString = options.dateString;
+    const prevDay = new Date(new Date(dateString).getTime() - 86400000).toISOString().slice(0, 10);
+    const data = await fetchURL(`${API_BASE}?module=stats&action=dailynewaddress&startdate=${prevDay}&enddate=${dateString}`);
+    if (!Array.isArray(data?.result))
+        throw new Error(`Conflux: API error for ${dateString}`);
+    const entry = data.result.find((e: any) => e.UTCDate === dateString);
+    return {
+        dailyNewUsers: entry.newAddressCount,
+    };
+};
+
+const adapter: SimpleAdapter = {
+    version: 1,
+    fetch,
+    chains: [CHAIN.CONFLUX],
+    start: "2022-02-20",
+    protocolType: ProtocolType.CHAIN,
+};
+
+export default adapter;


### PR DESCRIPTION
### Summary                                                                                                        
                                                                                                                 
  - Add Conflux eSpace chain fees adapter using ConfluxScan etherscan-compatible API (dailytxnfee)               
  - Add Conflux new-users adapter using ConfluxScan API (dailynewaddress)                                                                            
  - https://defillama.com/chain/conflux                                                                            
                                                                                                                 
  Test plan                                                                                                      
                                                                                                                 
  - pnpm test fees conflux 2026-06-05 — $12.00                                                                   
  - pnpm test fees conflux 2023-03-30 — $486.00                                                               
  - pnpm test fees conflux 2025-06-01 — $4.75                                                                    
  - pnpm test new-users conflux 2026-06-05 — 127 new users  