### PR TITLE
[feat] Fluent-Stats: track chain stats via blockscoutStats

### DIFF
--- a/users/utils/blockscoutStats.ts
+++ b/users/utils/blockscoutStats.ts
@@ -72,6 +72,7 @@ const blockscoutStatsChains: Record<string, ChainConfig> = {
   zilliqa: { chain: CHAIN.ZILLIQA, baseUrl: "https://zilliqa.blockscout.com", version: 2 },
   zora: { chain: CHAIN.ZORA, baseUrl: "https://explorer.zora.co", version: 1 },
   "zksync-era": { chain: CHAIN.ZKSYNC, baseUrl: "https://zksync.blockscout.com", version: 2 },
+  fluent: { chain: CHAIN.FLUENT, baseUrl: "https://fluentscan.xyz", statsUrl: "https://fluentscan.xyz/node-api/proxy", version: 1 },
 };
 
 async function fetchLine(config: ChainConfig, line: string, date: string) {


### PR DESCRIPTION
## Summary
- Adds Fluent chain user-stat tracking through the shared Blockscout stats helper.
- Uses FluentScan's Blockscout stats proxy to report daily active users, transaction count, and new users.

## Changes
- Added `CHAIN.FLUENT` to `users/utils/blockscoutStats.ts`.
- Configured Fluent with `baseUrl: "https://fluentscan.xyz"` and `statsUrl: "https://fluentscan.xyz/node-api/proxy"`.
- Uses the existing Blockscout stats lines:
  - `activeAccounts` for active users.
  - `newTxns` for transaction count.
  - `newAccounts` for new users.

## Methodology
- Active users and new users are sourced from FluentScan's Blockscout stats API.
- The adapter uses the existing users factory via `blockscoutStatsExports`, so Fluent is exposed under both `active-users` and `new-users`.

## Tests
| Command | UTC day tested | Active users | Transactions | New users | Result |
|---|---:|---:|---:|---:|---|
| `pnpm test active-users fluent 2026-04-10` | 2026-04-09 | 1 | 10 | n/a | Pass |
| `pnpm test new-users fluent 2026-04-10` | 2026-04-09 | n/a | n/a | 0 | Pass |
| `pnpm test active-users fluent 2026-04-11` | 2026-04-10 | 6 | 77 | n/a | Pass |
| `pnpm test new-users fluent 2026-04-11` | 2026-04-10 | n/a | n/a | 3 | Pass |
| `pnpm test active-users fluent 2026-04-12` | 2026-04-11 | 3 | 4 | n/a | Pass |
| `pnpm test new-users fluent 2026-04-12` | 2026-04-11 | n/a | n/a | 1 | Pass |
| `pnpm test active-users fluent 2026-04-13` | 2026-04-12 | 2 | 21 | n/a | Pass |
| `pnpm test new-users fluent 2026-04-13` | 2026-04-12 | n/a | n/a | 2 | Pass |
| `pnpm test active-users fluent 2026-04-14` | 2026-04-13 | 8 | 120 | n/a | Pass |
| `pnpm test new-users fluent 2026-04-14` | 2026-04-13 | n/a | n/a | 7 | Pass |
| `pnpm test active-users fluent 2026-04-15` | 2026-04-14 | 15 | 86 | n/a | Pass |
| `pnpm test new-users fluent 2026-04-15` | 2026-04-14 | n/a | n/a | 4 | Pass |
| `pnpm test active-users fluent 2026-06-10` | 2026-06-09 | 89 | 3.19k | n/a | Pass |
| `pnpm test new-users fluent 2026-06-10` | 2026-06-09 | n/a | n/a | 1 | Pass |
| `pnpm test active-users fluent 2026-06-11` | 2026-06-10 | 86 | 3.17k | n/a | Pass |
| `pnpm test new-users fluent 2026-06-11` | 2026-06-10 | n/a | n/a | 3 | Pass |
| `pnpm test active-users fluent 2026-06-12` | 2026-06-11 | 118 | 3.87k | n/a | Pass |
| `pnpm test new-users fluent 2026-06-12` | 2026-06-11 | n/a | n/a | 6 | Pass |