### PR TITLE
Add G1Flare fees and volume adapter

### DIFF
--- a/fees/g1flare.ts
+++ b/fees/g1flare.ts
@@ -1,0 +1,44 @@
+import { FetchOptions, SimpleAdapter } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+
+const MODULE1 = "0x9f17a5d7cd90181a34a2011e900b440d71e2c011";
+const USDT0 = "0xe7cd86e13AC4309349F30B3435a9d337750fC82D";
+
+const fetch = async (options: FetchOptions) => {
+  const dailyVolume = options.createBalances();
+  const dailyFees = options.createBalances();
+  
+  const logs = await options.getLogs({
+    target: MODULE1,
+    eventAbi: "event DepositReceived(address indexed sender, uint256 amount, uint256 feeAmount, uint256 netAmount, uint256 newContractBalance)",
+  });
+  
+  for (const log of logs) {
+    dailyVolume.add(USDT0, BigInt(log.amount));
+    dailyFees.add(USDT0, BigInt(log.feeAmount));
+  }
+  
+  return {
+    dailyVolume,
+    dailyFees,
+    dailyRevenue: dailyFees.clone(),
+  };
+};
+
+const adapter: SimpleAdapter = {
+  adapter: {
+    [CHAIN.FLARE]: {
+      fetch,
+      start: 1735689600,
+      meta: {
+        methodology: {
+          Volume: "Total USDT0 deposited through G1Flare Module 1.",
+          Fees: "0.05 percent fee on every deposit.",
+          Revenue: "Same as fees — no supply-side split.",
+        },
+      },
+    },
+  },
+};
+
+export default adapter;

--- a/fees/g1flare.ts
+++ b/fees/g1flare.ts
@@ -5,7 +5,6 @@ const MODULE1 = "0x9f17a5d7cd90181a34a2011e900b440d71e2c011";
 const USDT0 = "0xe7cd86e13AC4309349F30B3435a9d337750fC82D";
 
 const fetch = async (options: FetchOptions) => {
-  const dailyVolume = options.createBalances();
   const dailyFees = options.createBalances();
   
   const logs = await options.getLogs({
@@ -14,29 +13,28 @@ const fetch = async (options: FetchOptions) => {
   });
   
   for (const log of logs) {
-    dailyVolume.add(USDT0, BigInt(log.amount));
     dailyFees.add(USDT0, BigInt(log.feeAmount));
   }
   
   return {
-    dailyVolume,
     dailyFees,
-    dailyRevenue: dailyFees.clone(),
+    dailyRevenue: dailyFees,
+    dailyProtocolRevenue: dailyFees,
   };
 };
 
 const adapter: SimpleAdapter = {
+  version: 2,
+  pullHourly: true,
+  methodology: {
+    Fees: "0.05 percent fee on every deposit.",
+    Revenue: "Same as fees - no supply-side split.",
+    ProtocolRevenue: "Same as fees - no supply-side split.",
+  },
   adapter: {
     [CHAIN.FLARE]: {
       fetch,
-      start: 1781267849,
-      meta: {
-        methodology: {
-          Volume: "Total USDT0 deposited through G1Flare Module 1.",
-          Fees: "0.05 percent fee on every deposit.",
-          Revenue: "Same as fees — no supply-side split.",
-        },
-      },
+      start: '2026-06-12',
     },
   },
 };

--- a/fees/g1flare.ts
+++ b/fees/g1flare.ts
@@ -29,7 +29,7 @@ const adapter: SimpleAdapter = {
   adapter: {
     [CHAIN.FLARE]: {
       fetch,
-      start: 1735689600,
+      start: 1781267849,
       meta: {
         methodology: {
           Volume: "Total USDT0 deposited through G1Flare Module 1.",


### PR DESCRIPTION
Adapter for G1Flare's M1 on Flare mainnet.

- **Volume**: gross USDT0 deposited (pre-fee throughput)
- **Fees**: 0.05% fee taken on each deposit (`feeAmount` from `DepositReceived` event)
- **Revenue**: equal to Fees (no supply-side split; all fees are protocol revenue)

Contract: `0x9f17a5d7cd90181a34a2011e900b440d71e2c011`
Token: `0xe7cd86e13AC4309349F30B3435a9d337750fC82D` (USDT0)
Start: `1781267849`

website: https://g1flare.com/