### PR TITLE
rework thorchain-dex fee/revenue accounting and add breakdown labels

### DIFF
--- a/dexs/thorchain-dex.ts
+++ b/dexs/thorchain-dex.ts
@@ -30,11 +30,16 @@ const fetch = async (options: FetchOptions) => {
   return { dailyVolume };
 };
 
+const methodology = {
+  Volume: "Total USD value of swaps executed through THORChain's liquidity pools, sourced from THORChain Midgard. Every swap routes through native RUNE and settles on the THORChain L1, so volume is reported on the THORChain chain. Daily RUNE-denominated swap volume is converted to USD using that day's RUNE price.",
+};
+
 const adapter: SimpleAdapter = {
   version: 1,
   fetch,
   chains: [CHAIN.THORCHAIN],
   start: '2022-09-07',
+  methodology,
 };
 
 export default adapter;

--- a/fees/thorchain-dex/index.ts
+++ b/fees/thorchain-dex/index.ts
@@ -2,23 +2,23 @@ import BigNumber from "bignumber.js";
 import { FetchOptions, SimpleAdapter } from "../../adapters/types"
 import { CHAIN } from "../../helpers/chains"
 import { httpGet } from "../../utils/fetchURL";
-import { getTimestampAtStartOfDayUTC } from "../../utils/date";
 
-const chainMapping: any = {
-  ETH: CHAIN.ETHEREUM,
-  BTC: CHAIN.BITCOIN,
-  AVAX: CHAIN.AVAX,
-  BSC: CHAIN.BSC,
-  LTC: CHAIN.LITECOIN,
-  BCH: CHAIN.BITCOIN_CASH,
-  DOGE: CHAIN.DOGECHAIN,
-  GAIA: CHAIN.COSMOS,
-  BASE: CHAIN.BASE,
-  THOR: CHAIN.THORCHAIN,
-  XRP: CHAIN.RIPPLE,
+
+const chainConfig = {
+  [CHAIN.ETHEREUM]: { start: '2022-09-07', symbol: 'ETH' },
+  [CHAIN.BITCOIN]: { start: '2022-09-07', symbol: 'BTC' },
+  [CHAIN.LITECOIN]: { start: '2022-09-07', symbol: 'LTC' },
+  [CHAIN.DOGECHAIN]: { start: '2022-09-07', symbol: 'DOGE' },
+  [CHAIN.COSMOS]: { start: '2022-09-07', symbol: 'GAIA' },
+  [CHAIN.AVAX]: { start: '2022-09-07', symbol: 'AVAX' },
+  [CHAIN.BSC]: { start: '2022-09-07', symbol: 'BSC' },
+  [CHAIN.BITCOIN_CASH]: { start: '2022-09-07', symbol: 'BCH' },
+  [CHAIN.BASE]: { start: '2022-09-07', symbol: 'BASE' },
+  [CHAIN.THORCHAIN]: { start: '2022-09-07', symbol: 'THOR' },
+  [CHAIN.RIPPLE]: { start: '2022-09-07', symbol: 'XRP' },
+  [CHAIN.SOLANA]: { start: '2022-09-07', symbol: 'SOL' },
+  [CHAIN.TRON]: { start: '2022-09-07', symbol: 'TRON' },
 }
-
-const THORCHAIN_SUPPORTED_CHAINS = ['BTC', 'ETH', 'LTC', 'DOGE', 'GAIA', 'AVAX', 'BSC', 'BCH', 'BASE', 'THOR', 'XRP']
 
 interface Pool {
   assetLiquidityFees: string
@@ -69,7 +69,7 @@ const requests: IRequest = {}
 export async function fetchCacheURL(url: string) {
   const key = url;
   if (!requests[key])
-    requests[key] = httpGet(url, { headers: {"x-client-id": "defillama"}});
+    requests[key] = httpGet(url, { headers: { "x-client-id": "defillama" } });
   return requests[key]
 }
 
@@ -77,91 +77,183 @@ const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms))
 
 
 // New function to generate fetch logic for a single chain
-const getFetchForChain = (chainShortName: string) => {
-  return async (options: FetchOptions) => {
-    const startOfDay = getTimestampAtStartOfDayUTC(options.startOfDay);
-    const earningsUrl = `https://gateway.liquify.com/chain/thorchain_midgard/v2/history/earnings?interval=day&from=${options.startTimestamp}&to=${options.endTimestamp}`;
-    const reserveUrl = `https://vanaheimex.com/api/reserve?interval=day&from=${options.startTimestamp}&to=${options.endTimestamp}`;
-    const poolsUrl = `https://gateway.liquify.com/chain/thorchain_midgard/v2/pools?period=24h`;
+const fetch: any = async (options: FetchOptions) => {
+  const startOfDay = options.startOfDay;
+  const chainShortName = chainConfig[options.chain].symbol;
+  const earningsUrl = `https://gateway.liquify.com/chain/thorchain_midgard/v2/history/earnings?interval=day&from=${options.startTimestamp}&to=${options.endTimestamp}`;
+  const reserveUrl = `https://vanaheimex.com/api/reserve?interval=day&from=${options.startTimestamp}&to=${options.endTimestamp}`;
+  const poolsUrl = `https://gateway.liquify.com/chain/thorchain_midgard/v2/pools?period=24h`;
 
-    const earnings = await fetchCacheURL(earningsUrl);
-    await sleep(3000);
-    const revenue = await fetchCacheURL(reserveUrl);
+  const earnings = await fetchCacheURL(earningsUrl);
+  await sleep(3000);
+  const revenue = await fetchCacheURL(reserveUrl);
+  await sleep(2000);
+  const pools = await fetchCacheURL(poolsUrl);
+  await sleep(2000);
+
+  // Only fetch affiliate earnings for THOR chain
+  let affiliateEarnings: any | null = null;
+  if (chainShortName === 'THOR') {
+    const affiliateUrl = `https://gateway.liquify.com/chain/thorchain_midgard/v2/history/affiliate?from=${options.startTimestamp}&to=${options.endTimestamp}`;
+    affiliateEarnings = await fetchCacheURL(affiliateUrl);
     await sleep(2000);
-    const pools = await fetchCacheURL(poolsUrl);
-    await sleep(2000);
-    
-    // Only fetch affiliate earnings for THOR chain
-    let affiliateEarnings: any | null = null;
-    if (chainShortName === 'THOR') {
-      const affiliateUrl = `https://gateway.liquify.com/chain/thorchain_midgard/v2/history/affiliate?from=${options.startTimestamp}&to=${options.endTimestamp}`;
-      affiliateEarnings = await fetchCacheURL(affiliateUrl);
-      await sleep(2000);
-    }
+  }
 
-    const selectedEarningInterval = findInterval(startOfDay, earnings.intervals);
-    const selectedRevenueInterval = findInterval(startOfDay, revenue.intervals);
+  const selectedEarningInterval = findInterval(startOfDay, earnings.intervals);
+  const selectedRevenueInterval = findInterval(startOfDay, revenue.intervals);
 
 
-    const poolsByChainEarnings: Pool[] = selectedEarningInterval.pools.filter((pool: any) => assetFromString(pool.pool)?.chain === chainShortName);
+  const poolsByChainEarnings: Pool[] = selectedEarningInterval.pools.filter((pool: any) => assetFromString(pool.pool)?.chain === chainShortName);
 
-    const totalRuneDepth = pools.reduce((acum: BigNumber, pool: any) => acum.plus(pool.runeDepth), BigNumber(0));
-    const poolsByChainData = pools.filter((pool: any) => assetFromString(pool.asset)?.chain === chainShortName);
-    const runeDepthPerChain = poolsByChainData.reduce((acum: BigNumber, pool: any) => acum.plus(pool.runeDepth), BigNumber(0));
+  const totalRuneDepth = pools.reduce((acum: BigNumber, pool: any) => acum.plus(pool.runeDepth), BigNumber(0));
+  const poolsByChainData = pools.filter((pool: any) => assetFromString(pool.asset)?.chain === chainShortName);
+  const runeDepthPerChain = poolsByChainData.reduce((acum: BigNumber, pool: any) => acum.plus(pool.runeDepth), BigNumber(0));
 
-    const protocolRevenue = BigNumber(selectedRevenueInterval.gasFeeOutbound || 0).minus(BigNumber(selectedRevenueInterval.gasReimbursement || 0));
+  const runePriceUSD = BigNumber(selectedEarningInterval.runePriceUSD || 0);
 
-    const runePercentagePerChain = totalRuneDepth.isZero() ? BigNumber(0) : runeDepthPerChain.div(totalRuneDepth);
-    const bondingEarnings = selectedEarningInterval.bondingEarnings ? BigNumber(selectedEarningInterval.bondingEarnings) : BigNumber(0);
-    const bondingRewardPerChainBasedOnRuneDepth = bondingEarnings.times(runePercentagePerChain); // TODO: Artificial distribution according to the liquidity of the pools. But it is a protocol level data
-    const protocolRevenuePerChainBasedOnRuneDepth = protocolRevenue.times(runePercentagePerChain);
+  // Net outbound (network) fee kept by the protocol, in RUNE: outbound gas charged minus gas reimbursed.
+  // Protocol-level value, attributed per chain by the chain's share of total RUNE pool depth.
+  const netOutboundRune = BigNumber(selectedRevenueInterval?.gasFeeOutbound || 0).minus(BigNumber(selectedRevenueInterval?.gasReimbursement || 0));
+  const runeDepthShare = totalRuneDepth.isZero() ? BigNumber(0) : runeDepthPerChain.div(totalRuneDepth);
+  const rawOutboundFeeUSD = netOutboundRune.times(runeDepthShare).div(1e8).times(runePriceUSD);
+  const chainOutboundFeeUSD = rawOutboundFeeUSD.gt(0) ? rawOutboundFeeUSD : BigNumber(0);
 
-    const dailyFees = poolsByChainEarnings.reduce((acum, pool) => {
-      const liquidityFeesPerPoolInDollars = BigNumber(pool.totalLiquidityFeesRune).div(1e8).times(BigNumber(selectedEarningInterval.runePriceUSD));
-      const saverLiquidityFeesPerPoolInDollars = BigNumber(pool.saverEarning).div(1e8).times(BigNumber(selectedEarningInterval.runePriceUSD));
-      const totalLiquidityFees = liquidityFeesPerPoolInDollars.plus(saverLiquidityFeesPerPoolInDollars);
-      return acum.plus(totalLiquidityFees);
-    }, BigNumber(0));
+  // Network-wide Incentive Pendulum split of system income between nodes (RUNE bonders) and pools (LPs).
+  // We apply this ratio to the chain's actual swap fees, so RUNE block-reward emissions are excluded from fees/revenue.
+  const systemIncome = BigNumber(selectedEarningInterval.earnings || 0);
+  const bondingEarnings = BigNumber(selectedEarningInterval.bondingEarnings || 0);
+  const nodeShareRatio = systemIncome.isZero() ? BigNumber(0) : bondingEarnings.div(systemIncome);
 
-    // Add affiliate earnings to dailyFees only for THOR chain
-    const affiliateTotalEarningsUSD = (chainShortName === 'THOR' && affiliateEarnings && affiliateEarnings.intervals && affiliateEarnings.intervals.length > 0) 
-      ? BigNumber(affiliateEarnings.intervals[0].volumeUSD).div(1e2) 
-      : BigNumber(0);
-    const dailyFeesWithAffiliates = dailyFees.plus(affiliateTotalEarningsUSD);
+  // Slip-based liquidity (swap) fees and saver-vault earnings paid by users on this chain's pools, in USD.
+  const chainSwapFeesUSD = poolsByChainEarnings.reduce((acum, pool) => {
+    const liquidityFees = BigNumber(pool.totalLiquidityFeesRune).div(1e8).times(runePriceUSD);
+    const saverFees = BigNumber(pool.saverEarning).div(1e8).times(runePriceUSD);
+    return acum.plus(liquidityFees).plus(saverFees);
+  }, BigNumber(0));
 
-    const dailySupplysideRevenue = poolsByChainEarnings.reduce((acum, pool) => {
-      const liquidityFeesPerPoolInDollars = BigNumber(pool.totalLiquidityFeesRune).div(1e8).times(BigNumber(selectedEarningInterval.runePriceUSD));
-      const saverLiquidityFeesPerPoolInDollars = BigNumber(pool.saverEarning).div(1e8).times(BigNumber(selectedEarningInterval.runePriceUSD));
-      const rewardsInDollars = BigNumber(pool.rewards).div(1e8).times(BigNumber(selectedEarningInterval.runePriceUSD));
-      const totalLiquidityFees = liquidityFeesPerPoolInDollars.plus(saverLiquidityFeesPerPoolInDollars).plus(rewardsInDollars);
-      return acum.plus(totalLiquidityFees);
-    }, BigNumber(0));
+  // Affiliate fees charged by interfaces/wallets (pass-through to integrators, so they are also supply-side).
+  // Only exposed at the network level, attributed to the THORChain native chain.
+  const affiliateFeesUSD = (chainShortName === 'THOR' && affiliateEarnings?.intervals?.length > 0)
+    ? BigNumber(affiliateEarnings.intervals[0].volumeUSD).div(1e2)
+    : BigNumber(0);
 
-    const runePriceUSDNum = selectedEarningInterval.runePriceUSD ? Number(selectedEarningInterval.runePriceUSD) : 0;
-    const protocolRevenueByChainInDollars = protocolRevenuePerChainBasedOnRuneDepth.div(1e8).times(runePriceUSDNum);
-    const dailyHoldersRevenue = bondingRewardPerChainBasedOnRuneDepth.div(1e8).times(runePriceUSDNum);
-    // if (dailyFees.isZero()) throw new Error("No fees found for this day");
+  // Documented THORChain governance carve-outs from system income (= swap fees here; RUNE block-reward
+  // emissions are ~0 and excluded). Percentages are fixed protocol constants; activation dates are
+  // best-effort from public sources (on-chain mimir history is the source of truth - verify before relying).
+  //   5% RUNE burn: from the V3 launch ~2024-12-21 (ADR-017; a negligible 0.01% ran from ~2024-09-28, treated as 0).
+  //   10% to TCY stakers: from the TCY launch ~2025-05-05.
+  //   5% developer fund + 5% marketing fund: from ~2025-09-01 (ADR-021; APPROXIMATE date - verify).
+  const dateStr = new Date(options.startOfDay * 1000).toISOString().slice(0, 10);
+  const burnPct = dateStr >= '2024-12-21' ? 0.05 : 0;
+  const tcyPct = dateStr >= '2025-05-05' ? 0.10 : 0;
+  const devPct = dateStr >= '2025-09-01' ? 0.05 : 0;
+  const marketingPct = dateStr >= '2025-09-01' ? 0.05 : 0;
 
-      return {
-        dailyFees: dailyFeesWithAffiliates,
-        dailyUserFees: dailyFeesWithAffiliates,
-        dailyRevenue: `${dailyHoldersRevenue.plus(protocolRevenueByChainInDollars)}`,
-        dailyProtocolRevenue: protocolRevenueByChainInDollars.gt(0) ? protocolRevenueByChainInDollars : 0,
-        dailyHoldersRevenue: dailyHoldersRevenue,
-        dailySupplySideRevenue: dailySupplysideRevenue,
-        timestamp: startOfDay
-      };
+  const burnUSD = chainSwapFeesUSD.times(burnPct);
+  const tcyUSD = chainSwapFeesUSD.times(tcyPct);
+  const devUSD = chainSwapFeesUSD.times(devPct);
+  const marketingUSD = chainSwapFeesUSD.times(marketingPct);
+
+  // The rest of system income is split between nodes (RUNE bonders) and pools (LPs) by the Incentive
+  // Pendulum ratio. node + LP + every carve-out sum to the swap fees exactly, so the income-statement
+  // identity (Fees = Revenue + SupplySideRevenue) holds.
+  const nodePoolUSD = chainSwapFeesUSD.minus(burnUSD).minus(tcyUSD).minus(devUSD).minus(marketingUSD);
+  const nodeRevenueUSD = nodePoolUSD.times(nodeShareRatio);
+  const lpRevenueUSD = nodePoolUSD.minus(nodeRevenueUSD);
+
+  // Emit each component under its own label so the breakdown is itemized in the UI.
+  // RUNE-holder value (bonder rewards + RUNE burn) -> holders; LP, affiliate (integrator) and TCY -> supply;
+  // outbound fee and developer/marketing funds -> protocol.
+  const dailyFees = options.createBalances();
+  dailyFees.addUSDValue(chainSwapFeesUSD.toNumber(), 'Swap Fees');
+  dailyFees.addUSDValue(chainOutboundFeeUSD.toNumber(), 'Outbound Fees');
+  dailyFees.addUSDValue(affiliateFeesUSD.toNumber(), 'Affiliate Fees');
+
+  const dailyUserFees = options.createBalances();
+  dailyUserFees.addUSDValue(chainSwapFeesUSD.toNumber(), 'Swap Fees');
+  dailyUserFees.addUSDValue(chainOutboundFeeUSD.toNumber(), 'Outbound Fees');
+  dailyUserFees.addUSDValue(affiliateFeesUSD.toNumber(), 'Affiliate Fees');
+
+  const dailyHoldersRevenue = options.createBalances();
+  dailyHoldersRevenue.addUSDValue(nodeRevenueUSD.toNumber(), 'Swap Fees To RUNE Bonders');
+  dailyHoldersRevenue.addUSDValue(burnUSD.toNumber(), 'RUNE Burn');
+
+  const dailySupplySideRevenue = options.createBalances();
+  dailySupplySideRevenue.addUSDValue(lpRevenueUSD.toNumber(), 'Swap Fees To LPs');
+  dailySupplySideRevenue.addUSDValue(affiliateFeesUSD.toNumber(), 'Affiliate Fees To Integrators');
+  dailySupplySideRevenue.addUSDValue(tcyUSD.toNumber(), 'TCY Staker Rewards');
+
+  const dailyProtocolRevenue = options.createBalances();
+  dailyProtocolRevenue.addUSDValue(chainOutboundFeeUSD.toNumber(), 'Outbound Fees To Protocol');
+  dailyProtocolRevenue.addUSDValue(devUSD.toNumber(), 'Developer Fund');
+  dailyProtocolRevenue.addUSDValue(marketingUSD.toNumber(), 'Marketing Fund');
+
+  const dailyRevenue = options.createBalances();
+  dailyRevenue.addUSDValue(nodeRevenueUSD.toNumber(), 'Swap Fees To RUNE Bonders');
+  dailyRevenue.addUSDValue(burnUSD.toNumber(), 'RUNE Burn');
+  dailyRevenue.addUSDValue(chainOutboundFeeUSD.toNumber(), 'Outbound Fees To Protocol');
+  dailyRevenue.addUSDValue(devUSD.toNumber(), 'Developer Fund');
+  dailyRevenue.addUSDValue(marketingUSD.toNumber(), 'Marketing Fund');
+
+  return {
+    dailyFees,
+    dailyUserFees,
+    dailyRevenue,
+    dailyProtocolRevenue,
+    dailyHoldersRevenue,
+    dailySupplySideRevenue,
   };
 };
 
+const methodology = {
+  Fees: "Slip-based liquidity (swap) fees and saver-vault earnings paid by users on each chain's THORChain pools, the protocol's net outbound (network) fee, and affiliate fees charged by interfaces/wallets (affiliate fees are attributed to the THORChain native chain). RUNE block-reward emissions are excluded.",
+  UserFees: "All swap, saver, outbound and affiliate fees paid by users when swapping through THORChain.",
+  Revenue: "RUNE-holder value (the node-bonder share of swap fees plus the RUNE burn) and protocol-kept income (net outbound network fee, developer fund and marketing fund).",
+  ProtocolRevenue: "Income kept by the protocol: net outbound network fee plus the 5% developer fund and 5% marketing fund taken from system income.",
+  HoldersRevenue: "Value to RUNE holders: the node-operator (RUNE bonder) share of swap fees set by the Incentive Pendulum, plus the 5% of system income burned (RUNE permanently removed from supply).",
+  SupplySideRevenue: "Value paid to suppliers: the liquidity-provider share of swap fees (LP side of the Incentive Pendulum), affiliate fees passed through to integrators, and the 10% of system income paid to TCY stakers.",
+};
+
+const breakdownMethodology = {
+  Fees: {
+    'Swap Fees': "Slip-based liquidity (swap) fees and saver-vault earnings paid by users on each chain's THORChain pools.",
+    'Outbound Fees': "Net outbound network fee (outbound gas charged minus gas reimbursed) paid by users.",
+    'Affiliate Fees': "Fees charged by the interface or wallet that built the swap (attributed to the THORChain native chain).",
+  },
+  UserFees: {
+    'Swap Fees': "Slip-based liquidity (swap) fees and saver-vault earnings paid by users on each chain's THORChain pools.",
+    'Outbound Fees': "Net outbound network fee (outbound gas charged minus gas reimbursed) paid by users.",
+    'Affiliate Fees': "Fees charged by the interface or wallet that built the swap (attributed to the THORChain native chain).",
+  },
+  Revenue: {
+    'Swap Fees To RUNE Bonders': "Node operators' (RUNE bonders') share of swap fees, set network-wide by the Incentive Pendulum.",
+    'RUNE Burn': "5% of system income burned, permanently removing RUNE from supply (since the V3 launch, ~2024-12-21).",
+    'Outbound Fees To Protocol': "Net outbound network fee kept by the protocol.",
+    'Developer Fund': "5% of system income allocated to the developer fund (approx. since 2025-09-01).",
+    'Marketing Fund': "5% of system income allocated to the marketing fund (approx. since 2025-09-01).",
+  },
+  ProtocolRevenue: {
+    'Outbound Fees To Protocol': "Net outbound network fee kept by the protocol, attributed per chain by RUNE pool-depth share.",
+    'Developer Fund': "5% of system income allocated to the developer fund (approx. since 2025-09-01).",
+    'Marketing Fund': "5% of system income allocated to the marketing fund (approx. since 2025-09-01).",
+  },
+  HoldersRevenue: {
+    'Swap Fees To RUNE Bonders': "Node operators' (RUNE bonders') share of swap fees in RUNE, set network-wide by the Incentive Pendulum.",
+    'RUNE Burn': "5% of system income burned, permanently removing RUNE from supply and accruing value to RUNE holders (since the V3 launch, ~2024-12-21).",
+  },
+  SupplySideRevenue: {
+    'Swap Fees To LPs': "Liquidity providers' share of swap fees (the LP side of the Incentive Pendulum).",
+    'Affiliate Fees To Integrators': "Affiliate fees passed through to the integrator that built the swap.",
+    'TCY Staker Rewards': "10% of system income paid in RUNE to TCY stakers (since the TCY launch, ~2025-05-05).",
+  },
+};
+
 const adapters: SimpleAdapter = {
-  adapter: THORCHAIN_SUPPORTED_CHAINS.reduce((acc, chainKey) => {
-    (acc as any)[chainMapping[chainKey]] = {
-      fetch: getFetchForChain(chainKey) as any,
-      // runAtCurrTime: true,
-    };
-    return acc;
-  }, {}),
+  version: 1,
+  fetch,
+  adapter: chainConfig,
+  methodology,
+  breakdownMethodology,
 };
 
 export default adapters


### PR DESCRIPTION
Rework the THORChain DEX fees adapter into a clean income statement and document the methodology.

System income (swap fees plus saver earnings; RUNE block-reward emissions excluded) is split per THORChain's governance levers, date-gated to each lever's activation: 75% to nodes and LPs via the Incentive Pendulum, 10% to TCY stakers, 5% burned, 5% developer fund, 5% marketing fund. Holders revenue is the node-bonder share plus the RUNE burn; supply-side is the LP share plus affiliate (integrator pass-through) plus TCY; protocol revenue is the net outbound fee plus the developer and marketing funds. Fees equals Revenue plus SupplySideRevenue in every period, with itemized breakdown labels. Also adds the SOL and TRON pools, and gives the volume adapter a methodology field (volume stays attributed to the THORChain chain).

The developer/marketing activation date (2025-09-01) is approximate, pending confirmation of the on-chain mimir dates.
