### PR TITLE
fix(dinari): plume processor address

### DIFF
--- a/dexs/dinari/index.ts
+++ b/dexs/dinari/index.ts
@@ -1,14 +1,14 @@
 import { Adapter, FetchOptions } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 import { METRIC } from "../../helpers/metrics";
-// https://github.com/dinaricrypto/sbt-contracts 
-// https://github.com/dinaricrypto/sbt-contracts/blob/50f7cb5f0613c03fad42e7ece78e56d2992d03ba/releases/v0.4.2/order_processor.json#L6
+// https://github.com/dinaricrypto/sbt-contracts
+// https://github.com/dinaricrypto/sbt-contracts/blob/main/releases/v1.0.0/order_processor.json
 // https://github.com/dinaricrypto/sbt-contracts/blob/50f7cb5f0613c03fad42e7ece78e56d2992d03ba/src/orders/OrderProcessor.sol#L652
 const config: Record<string, { processor: string; start: string }> = {
     [CHAIN.ETHEREUM]: { processor: "0xA8a48C202AF4E73ad19513D37158A872A4ac79Cb", start: "2024-05-22" },
     [CHAIN.ARBITRUM]: { processor: "0xFA922457873F750244D93679df0d810881E4131D", start: "2024-05-22" },
     [CHAIN.BASE]: { processor: "0x63FF43009f9ba3584aF2Ddfc3D5FE2cb8AE539c0", start: "2024-06-07" },
-    [CHAIN.PLUME]: { processor: "0xFB0C1fF92C4EDCCC00DABFC2ddaC8338E416786e", start: "2025-10-22" },
+    [CHAIN.PLUME]: { processor: "0xc1571FEbBb6F8b62eDD0E4694714A382885d6bAB", start: "2025-04-22" },
 };
 
 const events = {


### PR DESCRIPTION
Updated Plume integration to use the live v1.0.0 OrderProcessor (`0xc1571FEbBb6F8b62eDD0E4694714A382885d6bAB`) on mainnet (98866) instead of the legacy v0.4.2 contract with no ABI or non-Plume chain changes.