### PR TITLE
fix(pool-party): handle new bridged tokens (CBTC, USDC.B, FRXUSD.B), prevent crash

### DIFF
--- a/dexs/pool-party/index.ts
+++ b/dexs/pool-party/index.ts
@@ -19,14 +19,24 @@ import fetchURL from "../../utils/fetchURL";
 
 const VOLUME_URL = "https://api-mainnet.cantonwallet.com/canton/pool-party/public/v1/volume?period=24h";
 
-// Pool Party SDK instrument IDs (stable per Send Foundation):
-//   "Amulet"  : Canton Coin (CC) — priced via coingecko:canton-network
-//   "USDCx"   : bridged USDC on Canton — priced as USDC ($1 stable proxy)
-//   CUSD UUID : Send's privacy stablecoin — priced as USDC ($1 stable proxy)
-//
-// Brale issues multiple instruments (CUSD + SBC) from the same issuer party;
-// only the CUSD UUID below is in scope. Unknown instrument IDs throw.
+// Brale issues multiple instruments from the same issuer party; CUSD is
+// reported with this UUID instrument ID on the volume API.
 const CUSD_INSTRUMENT_ID = "481871d4-ca56-42a8-b2d3-4b7d28742946";
+
+// Token IDs that have a direct CoinGecko listing — priced via slug.
+const TOKEN_TO_CG: Record<string, string> = {
+    "Amulet": "canton-network",         // Canton Coin (CC)
+    "CBTC": "coinbase-wrapped-btc",     // cbBTC (Pool Party API uses "CBTC"; on-ledger instrumentId is CBBTC.B)
+};
+
+// Token IDs that are USD stablecoins without their own CoinGecko listing —
+// priced as USDC ($1 stable proxy).
+const STABLE_TOKENS = new Set([
+    "USDCx",            // bridged USDC on Canton (original)
+    "USDC.B",           // bridged USDC (new variant)
+    "FRXUSD.B",         // Frax USD stablecoin (bridged)
+    CUSD_INSTRUMENT_ID, // Send's privacy stablecoin (CUSD)
+]);
 
 
 const fetch = async (options: FetchOptions) => {
@@ -37,16 +47,15 @@ const fetch = async (options: FetchOptions) => {
 
     const addTokenAmounts = (balances: ReturnType<FetchOptions["createBalances"]>, data: Record<string, string>) => {
         for (const [token, amount] of Object.entries(data)) {
-            if (token === "Amulet") {
-                // CoinGecko slug — same approach as the merged TVL adapter
-                // (projects/pool-party). addGasToken does not resolve CC
-                // pricing on the canton chain, so we route via the slug.
-                balances.addCGToken("canton-network", +amount);
-            } else if (token === "USDCx" || token === CUSD_INSTRUMENT_ID) {
+            const cgId = TOKEN_TO_CG[token];
+            if (cgId) {
+                balances.addCGToken(cgId, +amount);
+            } else if (STABLE_TOKENS.has(token)) {
                 balances.addUSDValue(+amount);
-            } else {
-                throw new Error(`Unknown token: ${token}`);
             }
+            // Unknown tokens are silently skipped rather than thrown — Pool
+            // Party's pool composition can change without an adapter update,
+            // and we prefer an undercount to a crashed adapter.
         }
     };
 
@@ -58,18 +67,19 @@ const fetch = async (options: FetchOptions) => {
 
 const methodology = {
     Volume:
-        "24h spot/swap volume across CC, CUSD, and USDCx pools, fetched from " +
+        "24h spot/swap volume across all live Pool Party pools, fetched from " +
         "Pool Party's public API on Send Foundation's validator " +
         "(api-mainnet.cantonwallet.com). Raw per-token volume across all swap " +
         "legs — matches the headline 24h volume displayed on Pool Party's " +
-        "primary UI at cantonwallet.com/pools/. CC priced via canton-network " +
-        "on CoinGecko; CUSD and USDCx priced as USDC ($1 stable proxy) since " +
-        "neither has a direct CoinGecko listing.",
+        "primary UI at cantonwallet.com/pools/. CC (Amulet) priced via " +
+        "canton-network on CoinGecko; cbBTC (CBTC) priced via " +
+        "coinbase-wrapped-btc on CoinGecko; USDCx, USDC.B, FRXUSD.B, and CUSD " +
+        "priced as USDC ($1 stable proxy) since none have a direct CoinGecko " +
+        "listing.",
     Fees:
         "All swap fees collected by Pool Party (24h), fetched from Pool Party's " +
         "public API on Send Foundation's validator (api-mainnet.cantonwallet.com). " +
-        "CC fees priced via canton-network on CoinGecko; CUSD and USDCx fees " +
-        "priced as USDC ($1 stable proxy). Phase 2 will populate " +
+        "Tokens priced the same way as Volume. Phase 2 will populate " +
         "supplySideRevenue, protocolRevenue, and holdersRevenue once Send's " +
         "per-swap fee attribution views are available.",
     UserFees: "All fees paid by users on swaps.",

--- a/dexs/pool-party/index.ts
+++ b/dexs/pool-party/index.ts
@@ -19,23 +19,45 @@ import fetchURL from "../../utils/fetchURL";
 
 const VOLUME_URL = "https://api-mainnet.cantonwallet.com/canton/pool-party/public/v1/volume?period=24h";
 
-// Brale issues multiple instruments from the same issuer party; CUSD is
-// reported with this UUID instrument ID on the volume API.
+// CUSD UUID — Send's privacy stablecoin (Brale-issued). Authoritative source:
+// apps/api-gateway/spec/350-pool-party-public-v1.spec.md in
+// 0xsend/canton-monorepo, and live config in
+// infrastructure/apps/pool-party/values-mainnet.yaml.
 const CUSD_INSTRUMENT_ID = "481871d4-ca56-42a8-b2d3-4b7d28742946";
 
-// Token IDs that have a direct CoinGecko listing — priced via slug.
+// Token IDs with a direct CoinGecko listing — priced via slug.
 const TOKEN_TO_CG: Record<string, string> = {
-    "Amulet": "canton-network",         // Canton Coin (CC)
-    "CBTC": "coinbase-wrapped-btc",     // cbBTC (Pool Party API uses "CBTC"; on-ledger instrumentId is CBBTC.B)
+    // Canton Coin (CC). Canonical Canton instrument key per the Pool Party SDK
+    // spec referenced above.
+    "Amulet": "canton-network",
+
+    // cbBTC — Pool Party's volume API exposes Coinbase Wrapped BTC as "CBTC"
+    // (no .B suffix); the on-ledger instrumentId.id is "CBBTC.B" per
+    // packages/app/src/config/tokens.ts in 0xsend/canton-monorepo. Treated
+    // here as the same Coinbase Wrapped BTC token, priced via the
+    // `coinbase-wrapped-btc` CoinGecko slug.
+    "CBTC": "coinbase-wrapped-btc",
 };
 
 // Token IDs that are USD stablecoins without their own CoinGecko listing —
 // priced as USDC ($1 stable proxy).
 const STABLE_TOKENS = new Set([
-    "USDCx",            // bridged USDC on Canton (original)
-    "USDC.B",           // bridged USDC (new variant)
-    "FRXUSD.B",         // Frax USD stablecoin (bridged)
-    CUSD_INSTRUMENT_ID, // Send's privacy stablecoin (CUSD)
+    // Bridged USDC on Canton (original; pre-dates the `.B` family). Source:
+    // 0xsend/canton-monorepo apps/web/src/config/bridge-assets.ts.
+    "USDCx",
+
+    // Bridged USDC (new `.B` variant launched alongside the new pools).
+    // Source: 0xsend/canton-monorepo packages/app/src/config/tokens.ts —
+    // BASE_USDC_CONTRACTS and the SupportedToken enum.
+    "USDC.B",
+
+    // Bridged Frax USD stablecoin. Source: 0xsend/canton-monorepo
+    // apps/web/src/config/bridge-assets.ts — FRXUSD_TOKEN_CONTRACTS.
+    "FRXUSD.B",
+
+    // CUSD (Send privacy stable). Same authoritative sources as
+    // CUSD_INSTRUMENT_ID above.
+    CUSD_INSTRUMENT_ID,
 ]);
 
 
@@ -52,10 +74,16 @@ const fetch = async (options: FetchOptions) => {
                 balances.addCGToken(cgId, +amount);
             } else if (STABLE_TOKENS.has(token)) {
                 balances.addUSDValue(+amount);
+            } else {
+                // Pool Party's pool composition can change without an adapter
+                // update. We log instead of throw so a brand-new token doesn't
+                // take the daily run offline — the chart keeps publishing
+                // (slightly under-counted) until the mapping is extended in a
+                // follow-up PR. Long-term plan is to have Pool Party's API
+                // return cgId per token, removing the hardcoded mapping
+                // entirely (see PR discussion).
+                console.warn(`[pool-party] unknown token in volume/fees response: ${token} (skipping)`);
             }
-            // Unknown tokens are silently skipped rather than thrown — Pool
-            // Party's pool composition can change without an adapter update,
-            // and we prefer an undercount to a crashed adapter.
         }
     };
 


### PR DESCRIPTION
Follow-up to #7546.

Pool Party launched new pools with new tokens (`CBTC`, `USDC.B`, `FRXUSD.B`) that the volume adapter's `addTokenAmounts` was throwing on, so every fetch failed and DefiLlama recorded null daily volume for the past several days (missing bars on the chart).

Changes:

1. Maps the new tokens: `CBTC` → `coinbase-wrapped-btc` (CoinGecko), `USDC.B` and `FRXUSD.B` → `$1` stable proxy via `addUSDValue`.
2. Replaces the `throw` on unknown tokens with a silent skip — Pool Party's pool composition can change without an adapter update, and we prefer an undercount to a crashed adapter.
3. Methodology updated to list all four stables and CBTC pricing explicitly.

Note: cbBTC's canonical on-ledger `instrumentId.id` is `CBBTC.B`, but Send's public volume API exposes it as `CBTC` — that's what we map. Treating both as the same Coinbase Wrapped BTC token.

Long-term plan: migrate this adapter to CCTools (mirroring the TVL adapter in DefiLlama/DefiLlama-Adapters#19355) once CCTools' `/markets/send/pools` endpoint exposes `volume24hUsd` and `fees24hUsd` per pool. This PR is an interim fix to restore the displayed volume.