### PR TITLE
[codex] Add Omni Terminal Hyperliquid builder

### DIFF
--- a/factory/hyperliquid.ts
+++ b/factory/hyperliquid.ts
@@ -233,6 +233,16 @@ const builderConfigs: Record<string, BuilderConfig> = {
       ProtocolRevenue: "Fees collected by OneKey from Hyperliquid Perps as Builder Revenue.",
     },
   },
+  "omni-terminal": {
+    addresses: ["0x733f40a4fa0cd13d59abade04b9ed2e9acac6457"],
+    start: "2026-02-26",
+    methodology: {
+      Volume: "Total volume from users trading Hyperliquid perps through Omni Terminal.",
+      Fees: "Builder code fees paid by users on Hyperliquid perps trades routed through Omni Terminal.",
+      Revenue: "Builder code fees collected by Omni Terminal from Hyperliquid perps trades.",
+      ProtocolRevenue: "Builder code fees collected by Omni Terminal from Hyperliquid perps trades.",
+    },
+  },
   "pear-interface": {
     addresses: ["0xa47d4d99191db54a4829cdf3de2417e527c3b042"],
     start: "2025-07-08",


### PR DESCRIPTION
Adds Omni Terminal to the Hyperliquid builder factory so DefiLlama can surface Omni Terminal on the Interface protocols dashboard with daily volume, fees, revenue, and protocol revenue from Hyperliquid builder-fill stats.

##### Name (to be shown on DefiLlama):
Omni Terminal

##### Twitter Link:
Not confirmed

##### Website Link:
https://omniterminal.app

##### Chain:
Hyperliquid

##### Short Description (to be shown on DefiLlama):
Hyperliquid-focused trading terminal for execution context, liquidation risk, wallet and trader investigation, funding/basis review, and AI-assisted market analysis.

##### Category (full list at https://defillama.com/categories) *Please choose only one:
Interface

##### methodology (what is being counted as tvl, how is tvl being calculated):
No TVL adapter is added. This dimension adapter counts Hyperliquid builder-code taker volume and builder-code fees/revenue for Omni Terminal builder address 0x733f40a4fa0cd13d59abade04b9ed2e9acac6457 using the existing Hyperliquid builder factory and Hyperliquid stats-data builder_fills exports.

### Validation
- `corepack pnpm test dexs omni-terminal 2026-02-27`
- `corepack pnpm test fees omni-terminal 2026-02-27`
- `corepack pnpm run build` completed but reported existing unrelated module-generation errors in `fees/glif`, `dexs/delphi`, and `dexs/sweep-n-flip`.

### Notes
- Start date is 2026-02-26, verified as the first public builder_fills date for the Omni Terminal builder address.
- Public website: https://omniterminal.app
