### PR TITLE
fix hinkal volume

### DIFF
--- a/aggregators/hinkal/index.ts
+++ b/aggregators/hinkal/index.ts
@@ -8,21 +8,31 @@ const fetchVolume = (chainId: number) => async (options: FetchOptions) => {
   const { startTimestamp, endTimestamp } = options;
   const url = `${VOLUME_URL}/totalVolume/${startTimestamp}/${endTimestamp}/${chainId}`;
   const data = await fetchURL(url);
+  if (data?.dailyVolume === undefined) {
+    console.error(`hinkal: no volume returned for chain ${chainId} (${url})`);
+  }
   return {
     dailyVolume: data?.dailyVolume || 0,
   };
 };
 
+const methodology = {
+  Volume: "Total value transacted through the Hinkal protocol",
+};
+
 const adapter: Adapter = {
   version: 2,
+  pullHourly: false,
+  methodology,
+  // fetchVolume's argument is the Hinkal backend chainId for each network.
   adapter: {
-    [CHAIN.ETHEREUM]: { fetch: fetchVolume(1), start: '2025-12-13' },
-    [CHAIN.BASE]: { fetch: fetchVolume(8453), start: '2025-12-13' },
-    [CHAIN.ARBITRUM]: { fetch: fetchVolume(42161), start: '2025-12-13' },
-    [CHAIN.POLYGON]: { fetch: fetchVolume(137), start: '2025-12-13' },
-    [CHAIN.OPTIMISM]: { fetch: fetchVolume(10), start: '2025-12-13' },
-    [CHAIN.SOLANA]: { fetch: fetchVolume(501), start: '2026-02-14' },
-    [CHAIN.TRON]: { fetch: fetchVolume(728126428), start: '2026-03-25' },
+    [CHAIN.ETHEREUM]: { fetch: fetchVolume(1), start: "2025-12-13" },
+    [CHAIN.BASE]: { fetch: fetchVolume(8453), start: "2025-12-13" },
+    [CHAIN.ARBITRUM]: { fetch: fetchVolume(42161), start: "2025-12-13" },
+    [CHAIN.POLYGON]: { fetch: fetchVolume(137), start: "2025-12-13" },
+    [CHAIN.OPTIMISM]: { fetch: fetchVolume(10), start: "2025-12-13" },
+    [CHAIN.SOLANA]: { fetch: fetchVolume(501), start: "2026-02-14" },
+    [CHAIN.TRON]: { fetch: fetchVolume(728126428), start: "2026-03-25" },
   },
 };
 

--- a/aggregators/hinkal/index.ts
+++ b/aggregators/hinkal/index.ts
@@ -2,7 +2,7 @@ import { Adapter, FetchOptions } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 import fetchURL from "../../utils/fetchURL";
 
-const VOLUME_URL = "https://wallet-staging-v2.hinkal.io/server";
+const VOLUME_URL = "https://wallet-staging-v2.hinkal.io/relayer";
 
 const fetchVolume = (chainId: number) => async (options: FetchOptions) => {
   const { startTimestamp, endTimestamp } = options;
@@ -22,7 +22,7 @@ const methodology = {
 
 const adapter: Adapter = {
   version: 2,
-  pullHourly: false,
+  pullHourly: false, // backend only stores daily-aggregated volume
   methodology,
   adapter: {
     [CHAIN.ETHEREUM]: { fetch: fetchVolume(1), start: "2025-12-13" },

--- a/aggregators/hinkal/index.ts
+++ b/aggregators/hinkal/index.ts
@@ -4,35 +4,34 @@ import fetchURL from "../../utils/fetchURL";
 
 const VOLUME_URL = "https://wallet-staging-v2.hinkal.io/relayer";
 
-const fetchVolume = (chainId: number) => async (options: FetchOptions) => {
+const chainConfig = {
+  [CHAIN.ETHEREUM]: { id: 1, start: "2025-12-13" },
+  [CHAIN.BASE]: { id: 8453, start: "2025-12-13" },
+  [CHAIN.ARBITRUM]: { id: 42161, start: "2025-12-13" },
+  [CHAIN.POLYGON]: { id: 137, start: "2025-12-13" },
+  [CHAIN.OPTIMISM]: { id: 10, start: "2025-12-13" },
+  [CHAIN.SOLANA]: { id: 501, start: "2026-02-14" },
+  [CHAIN.TRON]: { id: 728126428, start: "2026-03-25" }
+}
+
+const fetch = async (options: FetchOptions) => {
   const { startTimestamp, endTimestamp } = options;
+  const chainId = chainConfig[options.chain].id;
   const url = `${VOLUME_URL}/totalVolume/${startTimestamp}/${endTimestamp}/${chainId}`;
   const data = await fetchURL(url);
   if (data?.dailyVolume === undefined) {
     console.error(`hinkal: no volume returned for chain ${chainId} (${url})`);
   }
   return {
-    dailyVolume: data?.dailyVolume || 0,
+    dailyVolume: Number(data.dailyVolume),
   };
 };
 
-const methodology = {
-  Volume: "Total value transacted through the Hinkal protocol",
-};
 
 const adapter: Adapter = {
   version: 2,
-  pullHourly: false, // backend only stores daily-aggregated volume
-  methodology,
-  adapter: {
-    [CHAIN.ETHEREUM]: { fetch: fetchVolume(1), start: "2025-12-13" },
-    [CHAIN.BASE]: { fetch: fetchVolume(8453), start: "2025-12-13" },
-    [CHAIN.ARBITRUM]: { fetch: fetchVolume(42161), start: "2025-12-13" },
-    [CHAIN.POLYGON]: { fetch: fetchVolume(137), start: "2025-12-13" },
-    [CHAIN.OPTIMISM]: { fetch: fetchVolume(10), start: "2025-12-13" },
-    [CHAIN.SOLANA]: { fetch: fetchVolume(501), start: "2026-02-14" },
-    [CHAIN.TRON]: { fetch: fetchVolume(728126428), start: "2026-03-25" },
-  },
+  fetch,
+  adapter: chainConfig,
 };
 
 export default adapter;

--- a/aggregators/hinkal/index.ts
+++ b/aggregators/hinkal/index.ts
@@ -2,106 +2,27 @@ import { Adapter, FetchOptions } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 import fetchURL from "../../utils/fetchURL";
 
-const fetchEthereum = async (options: FetchOptions) => {
-  const timestampStart = options.startTimestamp;
-  const timestampEnd = options.endTimestamp;
-  const urlVolume = `https://ethMainnet.server.hinkal.pro/totalVolume/${timestampStart}/${timestampEnd}/1`;
-  const responseVolume = await fetchURL(urlVolume);
-  const dataTotal = responseVolume;
-  const dailyVolume = dataTotal.internal_volume + dataTotal.external_volume;
+const VOLUME_URL = "https://wallet-staging-v2.hinkal.io/server";
+
+const fetchVolume = (chainId: number) => async (options: FetchOptions) => {
+  const { startTimestamp, endTimestamp } = options;
+  const url = `${VOLUME_URL}/totalVolume/${startTimestamp}/${endTimestamp}/${chainId}`;
+  const data = await fetchURL(url);
   return {
-    dailyVolume: dailyVolume || 0,
-  };
-};
-
-const fetchBase = async (options: FetchOptions) => {
-  const timestampStart = options.startTimestamp;
-  const timestampEnd = options.endTimestamp;
-  const urlVolume = `https://base.server.hinkal.pro/totalVolume/${timestampStart}/${timestampEnd}/8453`;
-  const responseVolume = await fetchURL(urlVolume);
-  const dataTotal = responseVolume;
-  const dailyVolume = dataTotal.internal_volume + dataTotal.external_volume;
-  return {
-    dailyVolume: dailyVolume || 0,
-  };
-};
-
-const fetchArbitrum = async (options: FetchOptions) => {
-  const timestampStart = options.startTimestamp;
-  const timestampEnd = options.endTimestamp;
-  const urlVolume = `https://arbMainnet.server.hinkal.pro/totalVolume/${timestampStart}/${timestampEnd}/42161`;
-
-  const responseVolume = await fetchURL(urlVolume);
-  const dataTotal = responseVolume;
-  const dailyVolume = dataTotal.internal_volume + dataTotal.external_volume;
-  return {
-    dailyVolume: dailyVolume || 0,
-  };
-};
-
-const fetchPolygon = async (options: FetchOptions) => {
-  const timestampStart = options.startTimestamp;
-  const timestampEnd = options.endTimestamp;
-  const urlVolume = `https://polygon.server.hinkal.pro/totalVolume/${timestampStart}/${timestampEnd}/137`;
-
-  const responseVolume = await fetchURL(urlVolume);
-  const dataTotal = responseVolume;
-  const dailyVolume = dataTotal.internal_volume + dataTotal.external_volume;
-  return {
-    dailyVolume: dailyVolume || 0,
-  };
-};
-
-const fetchBNB = async (options: FetchOptions) => {
-  const timestampStart = options.startTimestamp;
-  const timestampEnd = options.endTimestamp;
-  const urlVolume = `https://bnbMainnet.server.hinkal.pro/totalVolume/${timestampStart}/${timestampEnd}/56`;
-
-  const responseVolume = await fetchURL(urlVolume);
-  const dataTotal = responseVolume;
-  const dailyVolume = dataTotal.internal_volume + dataTotal.external_volume;
-  return {
-    dailyVolume: dailyVolume || 0,
-  };
-};
-
-const fetchAVALANCHE = async (options: FetchOptions) => {
-  const timestampStart = options.startTimestamp;
-  const timestampEnd = options.endTimestamp;
-  const urlVolume = `https://avalanche.server.hinkal.pro/totalVolume/${timestampStart}/${timestampEnd}/43114`;
-
-  const responseVolume = await fetchURL(urlVolume);
-  const dataTotal = responseVolume;
-  const dailyVolume = dataTotal.internal_volume + dataTotal.external_volume;
-  return {
-    dailyVolume: dailyVolume || 0,
-  };
-};
-
-const fetchOPTIMISM = async (options: FetchOptions) => {
-  const timestampStart = options.startTimestamp;
-  const timestampEnd = options.endTimestamp;
-  const urlVolume = `https://optimism.server.hinkal.pro/totalVolume/${timestampStart}/${timestampEnd}/10`;
-
-  const responseVolume = await fetchURL(urlVolume);
-  const dataTotal = responseVolume;
-  const dailyVolume = dataTotal.internal_volume + dataTotal.external_volume;
-
-  return {
-    dailyVolume: dailyVolume || 0,
+    dailyVolume: data?.dailyVolume || 0,
   };
 };
 
 const adapter: Adapter = {
   version: 2,
   adapter: {
-    [CHAIN.ETHEREUM]: { fetch: fetchEthereum, start: '2023-11-09' },
-    [CHAIN.BASE]: { fetch: fetchBase, start: '2024-03-21' },
-    [CHAIN.ARBITRUM]: { fetch: fetchArbitrum, start: '2023-11-08' },
-    [CHAIN.POLYGON]: { fetch: fetchPolygon, start: '2023-11-07' },
-    [CHAIN.BSC]: { fetch: fetchBNB, start: '2023-11-08' },
-    [CHAIN.AVAX]: { fetch: fetchAVALANCHE, start: '2023-11-08' },
-    [CHAIN.OPTIMISM]: { fetch: fetchOPTIMISM, start: '2023-11-07' },
+    [CHAIN.ETHEREUM]: { fetch: fetchVolume(1), start: '2025-12-13' },
+    [CHAIN.BASE]: { fetch: fetchVolume(8453), start: '2025-12-13' },
+    [CHAIN.ARBITRUM]: { fetch: fetchVolume(42161), start: '2025-12-13' },
+    [CHAIN.POLYGON]: { fetch: fetchVolume(137), start: '2025-12-13' },
+    [CHAIN.OPTIMISM]: { fetch: fetchVolume(10), start: '2025-12-13' },
+    [CHAIN.SOLANA]: { fetch: fetchVolume(501), start: '2026-02-14' },
+    [CHAIN.TRON]: { fetch: fetchVolume(728126428), start: '2026-03-25' },
   },
 };
 

--- a/aggregators/hinkal/index.ts
+++ b/aggregators/hinkal/index.ts
@@ -24,7 +24,6 @@ const adapter: Adapter = {
   version: 2,
   pullHourly: false,
   methodology,
-  // fetchVolume's argument is the Hinkal backend chainId for each network.
   adapter: {
     [CHAIN.ETHEREUM]: { fetch: fetchVolume(1), start: "2025-12-13" },
     [CHAIN.BASE]: { fetch: fetchVolume(8453), start: "2025-12-13" },

--- a/aggregators/hinkal/index.ts
+++ b/aggregators/hinkal/index.ts
@@ -1,3 +1,4 @@
+import { start } from "repl";
 import { Adapter, FetchOptions } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 import fetchURL from "../../utils/fetchURL";
@@ -15,9 +16,9 @@ const chainConfig = {
 }
 
 const fetch = async (options: FetchOptions) => {
-  const { startTimestamp, endTimestamp } = options;
+  const { startOfDay, endTimestamp } = options;
   const chainId = chainConfig[options.chain].id;
-  const url = `${VOLUME_URL}/totalVolume/${startTimestamp}/${endTimestamp}/${chainId}`;
+  const url = `${VOLUME_URL}/totalVolume/${startOfDay}/${endTimestamp}/${chainId}`;
   const data = await fetchURL(url);
   if (data?.dailyVolume === undefined) {
     console.error(`hinkal: no volume returned for chain ${chainId} (${url})`);
@@ -27,9 +28,8 @@ const fetch = async (options: FetchOptions) => {
   };
 };
 
-
 const adapter: Adapter = {
-  version: 2,
+  version: 1,
   fetch,
   adapter: chainConfig,
 };


### PR DESCRIPTION
Updates the backend URL (the old per-chain subdomains no longer resolve, so volume was 0) and collapses the seven near-identical per-chain fetch functions into a single reusable fetchVolume(chainId) helper. Removed old chains and added Solana Tron and Optimism to the supported chains