### PR TITLE
fix(fragmetric): stop counting SW1TCH restaking yield as protocol revenue

### DIFF
--- a/fees/fragmetric/index.ts
+++ b/fees/fragmetric/index.ts
@@ -104,9 +104,12 @@ const fetch = async (options: FetchOptions) => {
 
     if (source === 'protocol') {
       if (mint === FRAGMETRIC.SW1TCH) {
-        // Jito restaking vault yield
-        dailyRevenue.add(mint, amount, METRIC.STAKING_REWARDS)
-        dailyFees.add(mint, amount, METRIC.STAKING_REWARDS)
+        // SW1TCH reaching the program-revenue account is restaking yield in
+        // transit to the reward reserves, where it is distributed to and claimed
+        // by LRT holders (already counted on the rewards leg below). The account
+        // forwards it onward rather than retaining it, so it is not protocol
+        // revenue; counting it here double-counts fees and overstates revenue.
+        continue
       } else if (mint === FRAGMETRIC.FRAGSOL || mint === FRAGMETRIC.FRAGJTO) {
         // LRT operation fees
         dailyRevenue.add(mint, amount, METRIC.MANAGEMENT_FEES)


### PR DESCRIPTION
## Problem

The Fragmetric fees adapter has two legs that both add to `dailyFees`:

- **protocol leg** – tokens arriving at the program-revenue account (`XEhpR3UauMkARQ8ztwaU9Kbv16jEpBbXs9ftELka9wj`) are counted as `dailyRevenue` + `dailyFees`.
- **rewards leg** – tokens leaving the reward-reserve accounts (user claims) are counted as `dailySupplySideRevenue` + `dailyFees`.

For **SW1TCH** these two legs are the *same* economic flow. The program-revenue account is not where SW1TCH is retained — it is a routing hub that forwards the SW1TCH on to the reward reserves, where LRT holders claim it. So the same restaking yield is counted twice in `dailyFees`, and the inbound side is also booked as protocol revenue even though the protocol keeps none of it.

## On-chain evidence

The 2025-09-09 fee spike resolves to two transactions:

- `3WLiRoMmaymT6Gsx3g9AcK6B872oNF82iNTxaPttSWHrmtZCNzqFck2wygdkYRuxJroq6tXKgxisDuJd2jtf1Zm` — instruction `HarvestRestakingYield`, moves **6,499,998 SW1TCH** into the program-revenue account.
- `hmRBuEPJjoF84st25oZUVbdrL7aVAsXocbkHuJSrGGMWijqz9HrHV57TX7mmAKpGuAUQoZKmmsiDrCgNwLwCuk6` — instruction `UserClaimReward`, a holder claiming SW1TCH out of the reward reserve.

Flow of funds: harvest → program-revenue → reward reserve → user claim. The program-revenue account forwards the SW1TCH onward rather than keeping it:

- Sep 2025 → Jun 2026: **33.4M SW1TCH** received, **~29.7M forwarded** to the reward reserve (directly and via an intermediary), only a working balance (~3.6M) on hand.
- Every month inflow ≈ outflow (≈80–100%), so this is structural, not a one-off.

This also matches the protocol's own model — protocol revenue is used for FRAG buybacks, which the adapter already tracks separately via the treasury wallet. SW1TCH yield passing through to holders is not part of that.

## Impact

SW1TCH was ~\$0.16 in Sep 2025 (it has since fallen ~100x to ~\$0.0013), so the distortion is concentrated in the historical numbers. Local run for 2025-09-09:

| metric | before | after |
| --- | --- | --- |
| dailyFees | \$1.64M | \$629k |
| dailyRevenue | \$1.01M | \$13 |
| dailySupplySideRevenue | \$629k | \$629k |

The real reward claims (supply-side) are unchanged; the fix removes the duplicated SW1TCH from fees and the pass-through amount wrongly booked as revenue. A recent day still reports normally.

## Fix

In the protocol leg, skip SW1TCH (it is already counted once on the rewards leg when holders claim it). Other protocol fees (fragSOL/fragJTO management fees, etc.) are unchanged.