### PR TITLE
[feat] Starknet-Stats: track active,new users and tx count via allium

### DIFF
--- a/active-users/starknet.ts
+++ b/active-users/starknet.ts
@@ -1,0 +1,33 @@
+import { Dependencies, FetchOptions, ProtocolType, SimpleAdapter } from "../adapters/types";
+import { queryAllium } from "../helpers/allium";
+import { CHAIN } from "../helpers/chains";
+
+const fetch = async (options: FetchOptions) => {
+  const alliumQuery = `
+    SELECT
+      COALESCE(COUNT(DISTINCT sender_address), 0) AS user_count,
+      COALESCE(COUNT(*), 0) AS transaction_count
+    FROM starknet.raw.transactions
+    WHERE block_timestamp >= TO_TIMESTAMP_NTZ(${options.startTimestamp})
+      AND block_timestamp < TO_TIMESTAMP_NTZ(${options.endTimestamp})
+  `;
+
+  const alliumResult = await queryAllium(alliumQuery);
+
+  return {
+    dailyActiveUsers: alliumResult[0].user_count,
+    dailyTransactionsCount: alliumResult[0].transaction_count,
+  };
+};
+
+const adapter: SimpleAdapter = {
+  version: 1,
+  fetch,
+  chains: [CHAIN.STARKNET],
+  dependencies: [Dependencies.ALLIUM],
+  isExpensiveAdapter: true,
+  protocolType: ProtocolType.CHAIN,
+  start: "2022-06-15",
+};
+
+export default adapter;

--- a/new-users/starknet.ts
+++ b/new-users/starknet.ts
@@ -1,0 +1,32 @@
+import { Dependencies, FetchOptions, ProtocolType, SimpleAdapter } from "../adapters/types";
+import { queryAllium } from "../helpers/allium";
+import { CHAIN } from "../helpers/chains";
+
+const fetch = async (options: FetchOptions) => {
+  const alliumQuery = `
+    SELECT COALESCE(COUNT(DISTINCT sender_address), 0) AS new_users
+    FROM starknet.raw.transactions
+    WHERE nonce = 0
+      AND sender_address IS NOT NULL
+      AND block_timestamp >= TO_TIMESTAMP_NTZ(${options.startTimestamp})
+      AND block_timestamp < TO_TIMESTAMP_NTZ(${options.endTimestamp})
+  `;
+
+  const alliumResult = await queryAllium(alliumQuery);
+
+  return {
+    dailyNewUsers: alliumResult[0].new_users,
+  };
+};
+
+const adapter: SimpleAdapter = {
+  version: 1,
+  fetch,
+  chains: [CHAIN.STARKNET],
+  dependencies: [Dependencies.ALLIUM],
+  isExpensiveAdapter: true,
+  protocolType: ProtocolType.CHAIN,
+  start: "2022-06-15",
+};
+
+export default adapter;


### PR DESCRIPTION
> Maintainer Note
> I have explored the explorers fully before falling back to allium, checked voyager, oklink and viewblock, None worked.
> Tested it on dune (If allium does not work then we can fallback to dune)

## Summary
- Adds Starknet active-users and new-users adapters using Allium-backed transaction data.
- Uses Dune only to verify the user-metric start date from the first `sender_address` transaction.

## Changes
- Added `active-users/starknet.ts` to report daily active users and transaction count from `starknet.raw.transactions`.
- Added `new-users/starknet.ts` to report daily new users via `nonce = 0` transactions.
- Set Starknet start date to `2022-06-15`, based on Dune showing the first `sender_address` transaction at `2022-06-15 12:58:28 UTC`.

## Tests
- `pnpm exec ts-node --transpile-only -e "Promise.all([import('./active-users/starknet'), import('./new-users/starknet')]).then(() => console.log('starknet user adapters loaded'))"`
- `pnpm test active-users starknet` failed locally: missing `ALLIUM_API_KEY`.
- `pnpm test new-users starknet` failed locally: missing `ALLIUM_API_KEY`.