### PR TITLE
[feat] Citrea-GateLayer-Stats: track stats via blockscout

### DIFF
--- a/users/utils/blockscoutStats.ts
+++ b/users/utils/blockscoutStats.ts
@@ -78,6 +78,8 @@ const blockscoutStatsChains: Record<string, ChainConfig> = {
   zora: { chain: CHAIN.ZORA, baseUrl: "https://explorer.zora.co", version: 1 },
   "zksync-era": { chain: CHAIN.ZKSYNC, baseUrl: "https://zksync.blockscout.com", version: 2 },
   fluent: { chain: CHAIN.FLUENT, baseUrl: "https://fluentscan.xyz", statsUrl: "https://fluentscan.xyz/node-api/proxy", version: 1 },
+  citrea: { chain: CHAIN.CITREA, baseUrl: "https://explorer.mainnet.citrea.xyz", statsUrl: "https://explorer-stats.mainnet.citrea.xyz", version: 1 },
+  gatelayer: { chain: CHAIN.GATE_LAYER, baseUrl: "https://www.gatescan.org/gatelayer", statsUrl: "https://gl-exp-api-m.gatescan.org/stats", version: 1 },
 };
 
 async function fetchLine(config: ChainConfig, line: string, date: string) {


### PR DESCRIPTION
## Summary
- Adds Blockscout stats-backed user metrics for Citrea and GateLayer.
- Enables both active users / transaction counts and new users through the shared `users/utils/blockscoutStats.ts` helper.

## Changes
- Added `citrea` using `CHAIN.CITREA` with stats served from `https://explorer-stats.mainnet.citrea.xyz`.
- Added `gatelayer` using `CHAIN.GATE_LAYER` with stats served from `https://gl-exp-api-m.gatescan.org/stats`.
- Reuses the existing Blockscout stats line mapping: `activeAccounts`, `newAccounts`, and `newTxns`.

## Tests
- `pnpm test active-users citrea`
- `pnpm test new-users citrea`
- `pnpm test active-users gatelayer`
- `pnpm test new-users gatelayer`
- Historical validation: 40/40 dated runs passed across 10 month-spaced dates for both chains and both categories.

| Test date | Reported day | Citrea | GateLayer |
|---|---:|---:|---:|
| 2025-09-30 | 2025-09-29 | 0 DAU / 0 new / 0 txs | 2.12k DAU / 1.48k new / 122.60k txs |
| 2025-10-22 | 2025-10-21 | 0 / 0 / 0 | 1.81k / 202 / 212.23k |
| 2025-11-13 | 2025-11-12 | 0 / 0 / 0 | 1.24k / 72 / 255.87k |
| 2025-12-19 | 2025-12-18 | 8 / 3 / 2.57k | 750 / 93 / 231.03k |
| 2026-01-27 | 2026-01-26 | 13 / 2 / 2.20k | 1.15k / 3 / 136.13k |
| 2026-02-08 | 2026-02-07 | 316 / 144 / 7.44k | 1.21k / 23 / 143.75k |
| 2026-03-21 | 2026-03-20 | 412 / 31 / 6.64k | 346 / 10 / 123.80k |
| 2026-04-10 | 2026-04-09 | 416 / 31 / 5.85k | 540 / 5 / 124.31k |
| 2026-05-26 | 2026-05-25 | 249 / 14 / 3.88k | 307 / 4 / 117.20k |
| 2026-06-12 | 2026-06-11 | 297 / 20 / 5.77k | 278 / 2 / 122.81k |