### PR TITLE
[feat] Metis-Stats: track stats via routescan explorer

### DIFF
--- a/active-users/metis.ts
+++ b/active-users/metis.ts
@@ -1,0 +1,33 @@
+import { FetchOptions, ProtocolType, SimpleAdapter } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+import fetchURL from "../utils/fetchURL";
+
+const BASE_URL = "https://cdn.routescan.io/api/evm/all/aggregations";
+const CHAIN_ID = 1088;
+
+type RouteScanRow = [string, string];
+
+const fetch = async (options: FetchOptions) => {
+  const [txs, addresses] = await Promise.all([
+    fetchURL(`${BASE_URL}/txs?includedChainIds=${CHAIN_ID}&unit=day`),
+    fetchURL(`${BASE_URL}/addresses?includedChainIds=${CHAIN_ID}&unit=day`),
+  ]);
+
+  const txsEntry = (txs as RouteScanRow[]).find(([timestamp]) => timestamp.startsWith(options.dateString));
+  const addressesEntry = (addresses as RouteScanRow[]).find(([timestamp]) => timestamp.startsWith(options.dateString));
+
+  return {
+    dailyActiveUsers: Number(addressesEntry?.[1]),
+    dailyTransactionsCount: Number(txsEntry?.[1]),
+  };
+};
+
+const adapter: SimpleAdapter = {
+  version: 1,
+  fetch,
+  chains: [CHAIN.METIS],
+  protocolType: ProtocolType.CHAIN,
+  start: "2021-11-18",
+};
+
+export default adapter;

--- a/new-users/metis.ts
+++ b/new-users/metis.ts
@@ -1,0 +1,28 @@
+import { FetchOptions, ProtocolType, SimpleAdapter } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+import fetchURL from "../utils/fetchURL";
+
+const UNIQUE_ADDRESSES_URL = "https://cdn.routescan.io/api/evm/all/aggregations/unique-addresses?includedChainIds=1088&unit=day";
+
+type RouteScanRow = [string, string];
+
+const fetch = async (options: FetchOptions) => {
+  const data = await fetchURL(UNIQUE_ADDRESSES_URL);
+  const rows = data as RouteScanRow[];
+  const previousDate = new Date((options.startOfDay - 86400) * 1000).toISOString().slice(0, 10);
+  const currentEntry = rows.find(([timestamp]) => timestamp.startsWith(options.dateString));
+  const previousEntry = rows.find(([timestamp]) => timestamp.startsWith(previousDate));
+  const dailyNewUsers = Number(currentEntry?.[1]) - Number(previousEntry?.[1]);
+
+  return { dailyNewUsers };
+};
+
+const adapter: SimpleAdapter = {
+  version: 1,
+  fetch,
+  chains: [CHAIN.METIS],
+  protocolType: ProtocolType.CHAIN,
+  start: "2021-11-19",
+};
+
+export default adapter;


### PR DESCRIPTION
## Summary
- Adds Metis user metrics adapters for `active-users` and `new-users`.
- Uses Routescan daily aggregate endpoints for active addresses, transaction count, and cumulative unique addresses.
- Website: https://www.metis.io/
- Twitter/X: https://x.com/MetisL2

## Changes
- Added `active-users/metis.ts` for Metis daily active users and daily transaction count.
- Added `new-users/metis.ts` for Metis daily new users by diffing cumulative `unique-addresses`.
- Set backfill starts to `2021-11-18` for active users and `2021-11-19` for new users.

## Methodology
- `dailyActiveUsers` comes from Routescan `addresses` daily aggregation for chain ID `1088`.
- `dailyTransactionsCount` comes from Routescan `txs` daily aggregation for chain ID `1088`.
- `dailyNewUsers` is calculated as the day-over-day difference of Routescan cumulative `unique-addresses`.

## Tests
- `pnpm test active-users metis`
- `pnpm test new-users metis`
- Ran both adapters across 20 distinct historical timestamps from 2021 through 2026.

| Test date | Active users | Txs | New users |
|---|---:|---:|---:|
| 2021-11-20 | 78 | 232 | 70 |
| 2021-12-16 | 275 | 684 | 19 |
| 2022-03-11 | 5.10k | 32.68k | 1.10k |
| 2022-06-21 | 1.06k | 5.48k | 70 |
| 2022-09-08 | 1.50k | 8.31k | 65 |
| 2022-12-29 | 1.15k | 4.26k | 102 |
| 2023-02-14 | 1.73k | 11.86k | 168 |
| 2023-05-03 | 1.73k | 10.19k | 400 |
| 2023-08-18 | 4.22k | 24.02k | 1.61k |
| 2023-11-27 | 1.90k | 9.62k | 230 |
| 2024-01-12 | 8.04k | 43.63k | 1.78k |
| 2024-04-24 | 8.15k | 31.09k | 1.14k |
| 2024-07-15 | 5.13k | 20.38k | 384 |
| 2024-10-30 | 23.31k | 49.95k | 3.64k |
| 2025-01-22 | 29.03k | 106.19k | 4.07k |
| 2025-04-09 | 4.22k | 55.95k | 1.24k |
| 2025-07-28 | 2.89k | 26.71k | 890 |
| 2025-10-16 | 8.48k | 40.76k | 3.82k |
| 2026-02-05 | 1.59k | 25.36k | 20 |
| 2026-06-12 | 586 | 6.24k | 6 |