### PR TITLE
[feat] Lukso-Stats: track lukso stats via blockscoutStats

### DIFF
--- a/users/utils/blockscoutStats.ts
+++ b/users/utils/blockscoutStats.ts
@@ -80,6 +80,7 @@ const blockscoutStatsChains: Record<string, ChainConfig> = {
   fluent: { chain: CHAIN.FLUENT, baseUrl: "https://fluentscan.xyz", statsUrl: "https://fluentscan.xyz/node-api/proxy", version: 1 },
   citrea: { chain: CHAIN.CITREA, baseUrl: "https://explorer.mainnet.citrea.xyz", statsUrl: "https://explorer-stats.mainnet.citrea.xyz", version: 1 },
   gatelayer: { chain: CHAIN.GATE_LAYER, baseUrl: "https://www.gatescan.org/gatelayer", statsUrl: "https://gl-exp-api-m.gatescan.org/stats", version: 1 },
+  lukso: { chain: CHAIN.LUKSO, baseUrl: "https://explorer.execution.mainnet.lukso.network", statsUrl: "https://stats-explorer.execution.mainnet.lukso.network", version: 1 },
 };
 
 async function fetchLine(config: ChainConfig, line: string, date: string) {


### PR DESCRIPTION
## Summary
- Adds LUKSO active and new user tracking through the shared Blockscout stats helper.
- Validates the existing LUKSO Blockscout fees/factory wiring against the live explorer.

## Changes
- Added `lukso` to `users/utils/blockscoutStats.ts` using `https://stats-explorer.execution.mainnet.lukso.network`.
- Reuses the existing LUKSO chain mapping and Blockscout fees config.

## Tests
- `pnpm test fees lukso 2026-06-16`
- `pnpm test active-users lukso 2026-06-16`
- `pnpm test new-users lukso 2026-06-16`