### PR TITLE
[adapter] dreamDEX - spot volume (Somnia)

### DIFF
--- a/dexs/dreamdex/index.ts
+++ b/dexs/dreamdex/index.ts
@@ -1,0 +1,50 @@
+import { FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import { httpGet } from "../../utils/fetchURL";
+
+// dreamDEX — on-chain spot central limit order book (CLOB) on Somnia.
+// Volume is sourced from the dreamDEX indexer API (one summation request per market per day),
+// not on-chain logs: the public Somnia RPC caps eth_getLogs at 1000 blocks and the chain's block
+// rate makes a per-day log scan impractical. The API returns per-market base-token volume, which
+// DefiLlama prices itself (we do not trust the API's own USD figures).
+const API = "https://api.dreamdex.io";
+
+// A market whose base is native SOMI reports a codeless sentinel address; value it as the gas token.
+const NATIVE_BASE_SENTINEL = "0x28f34defd2b4cb48d9ee6d89f2be4bc601694c00";
+
+const fetch = async (options: FetchOptions) => {
+  const dailyVolume = options.createBalances();
+  // API window is unix-ms, half-open [since, until) — matches DefiLlama's day bounds (seconds).
+  const since = options.fromTimestamp * 1000;
+  const until = options.toTimestamp * 1000;
+
+  const { markets } = await httpGet(`${API}/v0/markets`);
+
+  for (const market of markets) {
+    const { baseVolumeRaw } = await httpGet(
+      `${API}/v0/markets/${market.symbol}/volume?since=${since}&until=${until}`
+    );
+    if (market.base.toLowerCase() === NATIVE_BASE_SENTINEL) {
+      dailyVolume.addGasToken(baseVolumeRaw); // native SOMI base
+    } else {
+      dailyVolume.add(market.base, baseVolumeRaw); // ERC20 base (USDC.e / WBTC / WETH)
+    }
+  }
+
+  return { dailyVolume };
+};
+
+const adapter: SimpleAdapter = {
+  fetch,
+  chains: [CHAIN.SOMNIA],
+  start: "2026-05-11", // SpotPool mainnet deploy (Foundry broadcast); no volume before this
+  methodology: {
+    Volume:
+      "Spot trading volume on the dreamDEX CLOB on Somnia. For each market the dreamDEX indexer API " +
+      "(GET /v0/markets/{symbol}/volume) returns the base-token quantity filled in the requested " +
+      "window; each base token (native SOMI, USDC.e, WBTC, WETH) is valued by DefiLlama. On-chain " +
+      "getLogs is impractical because the public Somnia RPC caps eth_getLogs at 1000 blocks.",
+  },
+};
+
+export default adapter;

--- a/dexs/dreamdex/index.ts
+++ b/dexs/dreamdex/index.ts
@@ -1,7 +1,8 @@
 import { FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
-import { httpGet } from "../../utils/fetchURL";
+import fetchURL, { fetchURLAutoHandleRateLimit } from "../../utils/fetchURL";
 import PromisePool from "@supercharge/promise-pool";
+import { sleep } from "../../utils/utils";
 
 // dreamDEX — on-chain spot central limit order book (CLOB) on Somnia.
 // Volume is sourced from the dreamDEX indexer API (one summation request per market per window),
@@ -20,12 +21,12 @@ const fetch = async (options: FetchOptions) => {
   const since = options.startTimestamp * 1000;
   const until = options.endTimestamp * 1000;
 
-  const { markets } = await httpGet(`${API}/v0/markets`);
+  const { markets } = await fetchURL(`${API}/v0/markets`);
 
   await PromisePool.withConcurrency(5)
     .for(markets)
     .process(async (market: any) => {
-      const { baseVolumeRaw } = await httpGet(
+      const { baseVolumeRaw } = await fetchURLAutoHandleRateLimit(
         `${API}/v0/markets/${market.symbol}/volume?since=${since}&until=${until}`
       );
       if (market.base.toLowerCase() === NATIVE_BASE_SENTINEL) {
@@ -33,6 +34,7 @@ const fetch = async (options: FetchOptions) => {
       } else {
         dailyVolume.add(market.base, baseVolumeRaw); // ERC20 base (USDC.e / WBTC / WETH)
       }
+      await sleep(500);
     });
 
   return { dailyVolume };

--- a/dexs/dreamdex/index.ts
+++ b/dexs/dreamdex/index.ts
@@ -1,11 +1,12 @@
 import { FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 import { httpGet } from "../../utils/fetchURL";
+import PromisePool from "@supercharge/promise-pool";
 
 // dreamDEX — on-chain spot central limit order book (CLOB) on Somnia.
-// Volume is sourced from the dreamDEX indexer API (one summation request per market per day),
+// Volume is sourced from the dreamDEX indexer API (one summation request per market per window),
 // not on-chain logs: the public Somnia RPC caps eth_getLogs at 1000 blocks and the chain's block
-// rate makes a per-day log scan impractical. The API returns per-market base-token volume, which
+// rate makes a per-window log scan impractical. The API returns per-market base-token volume, which
 // DefiLlama prices itself (we do not trust the API's own USD figures).
 const API = "https://api.dreamdex.io";
 
@@ -14,27 +15,32 @@ const NATIVE_BASE_SENTINEL = "0x28f34defd2b4cb48d9ee6d89f2be4bc601694c00";
 
 const fetch = async (options: FetchOptions) => {
   const dailyVolume = options.createBalances();
-  // API window is unix-ms, half-open [since, until) — matches DefiLlama's day bounds (seconds).
-  const since = options.fromTimestamp * 1000;
-  const until = options.toTimestamp * 1000;
+  // API window is unix-ms, half-open [since, until) — keyed off the v2 window bounds (seconds),
+  // not startOfDay, so hourly pulls query their own window.
+  const since = options.startTimestamp * 1000;
+  const until = options.endTimestamp * 1000;
 
   const { markets } = await httpGet(`${API}/v0/markets`);
 
-  for (const market of markets) {
-    const { baseVolumeRaw } = await httpGet(
-      `${API}/v0/markets/${market.symbol}/volume?since=${since}&until=${until}`
-    );
-    if (market.base.toLowerCase() === NATIVE_BASE_SENTINEL) {
-      dailyVolume.addGasToken(baseVolumeRaw); // native SOMI base
-    } else {
-      dailyVolume.add(market.base, baseVolumeRaw); // ERC20 base (USDC.e / WBTC / WETH)
-    }
-  }
+  await PromisePool.withConcurrency(5)
+    .for(markets)
+    .process(async (market: any) => {
+      const { baseVolumeRaw } = await httpGet(
+        `${API}/v0/markets/${market.symbol}/volume?since=${since}&until=${until}`
+      );
+      if (market.base.toLowerCase() === NATIVE_BASE_SENTINEL) {
+        dailyVolume.addGasToken(baseVolumeRaw); // native SOMI base
+      } else {
+        dailyVolume.add(market.base, baseVolumeRaw); // ERC20 base (USDC.e / WBTC / WETH)
+      }
+    });
 
   return { dailyVolume };
 };
 
 const adapter: SimpleAdapter = {
+  version: 2,
+  pullHourly: true,
   fetch,
   chains: [CHAIN.SOMNIA],
   start: "2026-05-11", // SpotPool mainnet deploy (Foundry broadcast); no volume before this


### PR DESCRIPTION
Adds a spot **volume** adapter for **dreamDEX**, an on-chain spot central limit order book (CLOB) on Somnia mainnet.

**Depends on / pairs with** the TVL adapter PR that adds the dreamDEX protocol: DefiLlama/DefiLlama-Adapters#19686. This volume adapter attaches to that protocol — please merge / link that one so this renders under dreamDEX.

## Methodology
Per-market spot volume is sourced from the dreamDEX indexer API (`GET /v0/markets/{symbol}/volume`), which returns the base-token quantity filled in a half-open `[from, to)` window. The adapter enumerates markets via `GET /v0/markets`, then for each market adds the base-token volume to `dailyVolume`, **valued by DefiLlama itself** (native SOMI via the gas token; USDC.e / WBTC / WETH by address) — the API returns no USD.

On-chain `getLogs` is impractical here: the public Somnia RPC caps `eth_getLogs` at 1000 blocks and the chain's block rate makes a per-day log scan unreliable, so the protocol's own indexer (which aggregates the `OrderFilled` fills) is the source.

Tested: `pnpm test dexs dreamdex 2026-06-15` → ~$420K for that UTC day; cross-checked to within ~3% of the API's quote-side notional (difference is price source).

---

Protocol metadata is in the TVL PR above. Key fields for reference:

- **Name:** dreamDEX
- **Chain:** Somnia
- **Category:** Dexs
- **Twitter:** https://x.com/dreamDEXSomnia
- **Website:** https://dreamdex.io
- **Audit:** https://hacken.io/audits/somnia/ (Hacken — Spot DEX core, Apr 2026)
- **Github:** somnia-chain
