### PR TITLE
durianfun-launchpad: track V4.6.7 factory (volume + fees)

### DIFF
--- a/dexs/durianfun-launchpad/index.ts
+++ b/dexs/durianfun-launchpad/index.ts
@@ -13,7 +13,7 @@
  * liquidity is migrated to a `DurianAMM` pool (covered by a separate
  * adapter, `durian-amm`).
  *
- * Two generations of the factory are LIVE and indexed together so the
+ * Three generations of the factory are LIVE and indexed together so the
  * volume series is continuous:
  *
  *   V4.5   — `0xdf4f3dB298A9aDe853191F58b4b2a322D47EC005` (deploy
@@ -23,8 +23,15 @@
  *            block 31,393,573). Same event ABIs; adds referral
  *            routing but trade-side events are byte-for-byte
  *            identical to V4.5.
+ *   V4.6.7 — `0x0480017E51dC813a0fad8aA73EAb2f8476ac0e8F` (deploy
+ *            block 32,196,516 / 2026-05-31). Current production
+ *            launchpad (dual graduation: in-contract Durian AMM or an
+ *            external KUBLERX V3 pool). TokensBought / TokensSold are
+ *            byte-identical to V4.5 / V4.6.6; only `TokenCreated`
+ *            differs (appends `uint8 graduationTarget`), so V4.6.7
+ *            markets are discovered with an 8-arg ABI.
  *
- * ── Event ABIs (confirmed identical V4.5 ⇄ V4.6.6) ─────────────────
+ * ── Event ABIs (trade events identical V4.5 / V4.6.6 / V4.6.7) ──────
  *
  *   Factory.TokenCreated(
  *       address indexed token,
@@ -52,7 +59,7 @@
  * ── Why we enumerate markets via TokenCreated ──────────────────────
  *
  * Each BCM is a fresh contract; we discover them by scanning every
- * `TokenCreated` log emitted by either factory since genesis (NOT
+ * `TokenCreated` log emitted by each factory since its deploy block (NOT
  * limited to the daily window — DefiLlama's `getLogs` with no
  * fromBlock fetches the per-day window for the trade events, but we
  * need ALL historical markets so trades in surviving (pre-grad)
@@ -65,6 +72,7 @@ import { METRIC } from "../../helpers/metrics"
 
 const FACTORY_V45  = "0xdf4f3dB298A9aDe853191F58b4b2a322D47EC005";
 const FACTORY_V466 = "0x89b6b73BD18dbEA0e2218c25c1963fd5FBaB3c87";
+const FACTORY_V467 = "0x0480017E51dC813a0fad8aA73EAb2f8476ac0e8F"; // current prod launchpad (2026-05-31)
 
 // KKUB (wrapped KUB) — the priced token DefiLlama's Bitkub oracle
 // resolves. Native-KUB amounts are credited to this address.
@@ -72,6 +80,13 @@ const KKUB = "0x67eBD850304c70d983B2d1b93ea79c7CD6c3F6b5";
 
 const TOKEN_CREATED_ABI =
   "event TokenCreated(address indexed token, address indexed market, address indexed creator, string name, string symbol, uint256 totalSupply, uint256 timestamp)";
+
+// V4.6.7 appends a trailing `uint8 graduationTarget`, changing the TokenCreated
+// event hash — its markets must be discovered with this 8-arg ABI (the 7-arg ABI
+// above matches zero V4.6.7 events). The TRADE events (TokensBought/TokensSold)
+// are byte-identical across all three generations and reuse the ABIs below.
+const TOKEN_CREATED_ABI_V467 =
+  "event TokenCreated(address indexed token, address indexed market, address indexed creator, string name, string symbol, uint256 totalSupply, uint256 timestamp, uint8 graduationTarget)";
 
 const TOKENS_BOUGHT_ABI =
   "event TokensBought(address indexed buyer, uint256 kubIn, uint256 tokensOut, uint256 fee, uint256 newKubRaised, uint256 price)";
@@ -86,10 +101,11 @@ const fetch = async (options: FetchOptions) => {
   const dailyRevenue = createBalances();
   const dailySupplySideRevenue   = createBalances();
 
-  // 1) Enumerate every BCM market spawned by either factory.
+  // 1) Enumerate every BCM market spawned by each factory.
   const factoryLogs = await Promise.all([
-    getLogs({ target: FACTORY_V45,  eventAbi: TOKEN_CREATED_ABI, onlyArgs: true, entireLog: false, fromBlock: 30_999_992, cacheInCloud: true }),
-    getLogs({ target: FACTORY_V466, eventAbi: TOKEN_CREATED_ABI, onlyArgs: true, entireLog: false, fromBlock: 31_393_573, cacheInCloud: true }),
+    getLogs({ target: FACTORY_V45,  eventAbi: TOKEN_CREATED_ABI,      onlyArgs: true, entireLog: false, fromBlock: 30_999_992, cacheInCloud: true }),
+    getLogs({ target: FACTORY_V466, eventAbi: TOKEN_CREATED_ABI,      onlyArgs: true, entireLog: false, fromBlock: 31_393_573, cacheInCloud: true }),
+    getLogs({ target: FACTORY_V467, eventAbi: TOKEN_CREATED_ABI_V467, onlyArgs: true, entireLog: false, fromBlock: 32_196_516, cacheInCloud: true }),
   ]);
   const markets: string[] = factoryLogs
     .flat()


### PR DESCRIPTION
## Update: Durianfun Launchpad — track the V4.6.7 factory

`dexs/durianfun-launchpad/index.ts` indexes bonding-curve trading volume + fees across the V4.5 and V4.6.6 launchpad factories on Bitkub Chain (chainId 96). This adds the **V4.6.7** factory (current production launchpad, deployed 2026-05-31) that the adapter was missing — its trades were going untracked.

### Change (discovery only — fee/revenue logic untouched)
- Add factory `0x0480017E51dC813a0fad8aA73EAb2f8476ac0e8F` (deploy block 32196516).
- V4.6.7's `TokenCreated` appends a trailing `uint8 graduationTarget`, which changes the event hash, so its markets are discovered with an 8-arg ABI (the 7-arg ABI matches zero V4.6.7 events).
- `TokensBought` / `TokensSold` are **byte-identical** to V4.5 / V4.6.6, so the existing trade ABIs, the 90/10 protocol/creator split, and the methodology are reused unchanged — V4.6.7 markets just join the existing `markets` array.

### On-chain verification (KUB mainnet, block 32,663,300)
Discovered 4 V4.6.7 markets via the 8-arg `TokenCreated` (SAYWALLH, MOOPING, ICEMAN, THB) and decoded their trades with the existing ABI: **8 buys + 6 sells, 15.68 KUB volume, 0.183 KUB fees** all-time — currently untracked.

> Note: V4.6.7's fee is parameterized per-factory; the observed effective rate is ~1.17% (vs 1.0% on V4.5/V4.6.6). Total `Fees` stays exact (summed from the on-chain `fee` field); the 90/10 protocol/creator `Revenue` split is applied uniformly as the adapter already does for the older factories. Happy to special-case the V4.6.7 split if you'd prefer.