### PR TITLE
Add Ophis fees adapter

### DIFF
--- a/fees/ophis/index.ts
+++ b/fees/ophis/index.ts
@@ -1,0 +1,50 @@
+import { CHAIN } from "../../helpers/chains";
+import { FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { addTokensReceived } from "../../helpers/token";
+
+// Ophis is an intent-based DEX aggregator (a CoW Protocol fork). It holds no TVL.
+// Every swap on every chain pays a flat partner fee (10 bps standard, 1 bp on
+// stablecoin pairs) via CoW's CIP-75 partner-fee mechanism. The fee is paid in
+// the swap's buy/sell token to ONE deterministic CREATE2 fee-recipient address,
+// identical on every chain.
+const FEE_RECIPIENT = "0x858f0F5eE954846D47155F5203c04aF1819eCeF8";
+
+// Fee activation date. There were no Ophis fees before this, so a slightly
+// earlier start is harmless.
+const START = "2026-06-08";
+
+const fetch = async (options: FetchOptions) => {
+  // dailyFees = dailyRevenue = USD value of all tokens RECEIVED by the
+  // fee-recipient address on this chain for the day. This figure is already net
+  // of CoW's revenue share on CoW-hosted chains (Ophis self-hosts only on
+  // Optimism); option A deliberately reports the on-chain received amount and
+  // does not estimate gross volume.
+  const dailyFees = await addTokensReceived({ target: FEE_RECIPIENT, options });
+  return { dailyFees, dailyRevenue: dailyFees };
+};
+
+const methodology = {
+  Fees: "Flat partner fee taken on every Ophis swap (10 bps standard, 1 bp on stablecoin pairs), measured as the USD value of all tokens received by the deterministic CREATE2 fee-recipient address 0x858f0F5eE954846D47155F5203c04aF1819eCeF8, which is identical on every chain.",
+  Revenue: "All collected partner fees retained by Ophis. Equal to fees; this is the on-chain amount received by the fee recipient, already net of CoW's revenue share on CoW-hosted chains (Ophis self-hosts only on Optimism).",
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  fetch,
+  methodology,
+  adapter: {
+    [CHAIN.ETHEREUM]: { start: START },
+    [CHAIN.OPTIMISM]: { start: START },
+    [CHAIN.BSC]: { start: START },
+    [CHAIN.XDAI]: { start: START },
+    [CHAIN.POLYGON]: { start: START },
+    [CHAIN.BASE]: { start: START },
+    [CHAIN.ARBITRUM]: { start: START },
+    [CHAIN.AVAX]: { start: START },
+    [CHAIN.LINEA]: { start: START },
+    [CHAIN.INK]: { start: START },
+    [CHAIN.PLASMA]: { start: START },
+  },
+};
+
+export default adapter;

--- a/fees/ophis/index.ts
+++ b/fees/ophis/index.ts
@@ -1,50 +1,51 @@
 import { CHAIN } from "../../helpers/chains";
 import { FetchOptions, SimpleAdapter } from "../../adapters/types";
-import { addTokensReceived } from "../../helpers/token";
 
-// Ophis is an intent-based DEX aggregator (a CoW Protocol fork). It holds no TVL.
-// Every swap on every chain pays a flat partner fee (10 bps standard, 1 bp on
-// stablecoin pairs) via CoW's CIP-75 partner-fee mechanism. The fee is paid in
-// the swap's buy/sell token to ONE deterministic CREATE2 fee-recipient address,
-// identical on every chain.
 const FEE_RECIPIENT = "0x858f0F5eE954846D47155F5203c04aF1819eCeF8";
-
-// Fee activation date. There were no Ophis fees before this, so a slightly
-// earlier start is harmless.
 const START = "2026-06-08";
+const SAFE_RECEIVED_EVENT = "event SafeReceived (address indexed sender, uint256 value)"
 
 const fetch = async (options: FetchOptions) => {
-  // dailyFees = dailyRevenue = USD value of all tokens RECEIVED by the
-  // fee-recipient address on this chain for the day. This figure is already net
-  // of CoW's revenue share on CoW-hosted chains (Ophis self-hosts only on
-  // Optimism); option A deliberately reports the on-chain received amount and
-  // does not estimate gross volume.
-  const dailyFees = await addTokensReceived({ target: FEE_RECIPIENT, options });
-  return { dailyFees, dailyRevenue: dailyFees };
+  const SafeReceivedLogs = await options.getLogs({
+    target: FEE_RECIPIENT,
+    eventAbi: SAFE_RECEIVED_EVENT,
+  })
+
+  const dailyFees = options.createBalances()
+
+  for (const log of SafeReceivedLogs) {
+    dailyFees.addGasToken(log.value, 'Partner Fees')
+  }
+
+  return { dailyFees, dailyRevenue: dailyFees, dailyProtocolRevenue: dailyFees };
 };
 
 const methodology = {
-  Fees: "Flat partner fee taken on every Ophis swap (10 bps standard, 1 bp on stablecoin pairs), measured as the USD value of all tokens received by the deterministic CREATE2 fee-recipient address 0x858f0F5eE954846D47155F5203c04aF1819eCeF8, which is identical on every chain.",
-  Revenue: "All collected partner fees retained by Ophis. Equal to fees; this is the on-chain amount received by the fee recipient, already net of CoW's revenue share on CoW-hosted chains (Ophis self-hosts only on Optimism).",
+  Fees: "Flat partner fee taken on every Ophis swap (10 bps standard, 1 bp on stablecoin pairs), measured as gas tokens received by protocol safe wallet.",
+  Revenue: "All flat partner fees taken on every Ophis swap (10 bps standard, 1 bp on stablecoin pairs), measured as gas tokens received by protocol safe wallet is retained by Ophis.",
+  ProtocolRevenue: "All flat partner fees taken on every Ophis swap (10 bps standard, 1 bp on stablecoin pairs), measured as gas tokens received by protocol safe wallet is retained by Ophis.",
 };
+
+const breakdownMethodology = {
+  Fees: {
+    'Partner Fees': 'Flat partner fee taken on every Ophis swap (10 bps standard, 1 bp on stablecoin pairs), measured as gas tokens received by protocol safe wallet.',
+  },
+  Revenue: {
+    'Partner Fees': 'All flat partner fees taken on every Ophis swap (10 bps standard, 1 bp on stablecoin pairs), measured as gas tokens received by protocol safe wallet is retained by Ophis.',
+  },
+  ProtocolRevenue: {
+    'Partner Fees': 'All flat partner fees taken on every Ophis swap (10 bps standard, 1 bp on stablecoin pairs), measured as gas tokens received by protocol safe wallet is retained by Ophis.',
+  },
+}
 
 const adapter: SimpleAdapter = {
   version: 2,
+  pullHourly: true,
   fetch,
   methodology,
-  adapter: {
-    [CHAIN.ETHEREUM]: { start: START },
-    [CHAIN.OPTIMISM]: { start: START },
-    [CHAIN.BSC]: { start: START },
-    [CHAIN.XDAI]: { start: START },
-    [CHAIN.POLYGON]: { start: START },
-    [CHAIN.BASE]: { start: START },
-    [CHAIN.ARBITRUM]: { start: START },
-    [CHAIN.AVAX]: { start: START },
-    [CHAIN.LINEA]: { start: START },
-    [CHAIN.INK]: { start: START },
-    [CHAIN.PLASMA]: { start: START },
-  },
+  breakdownMethodology,
+  start: START,
+  chains: [CHAIN.ETHEREUM, CHAIN.OPTIMISM, CHAIN.BSC, CHAIN.XDAI, CHAIN.POLYGON, CHAIN.BASE, CHAIN.ARBITRUM, CHAIN.AVAX, CHAIN.LINEA, CHAIN.INK, CHAIN.PLASMA],
 };
 
 export default adapter;


### PR DESCRIPTION
Adds a fees adapter for [Ophis](https://ophis.fi) — an intent-based DEX aggregator built on CoW Protocol. Ophis holds no TVL, so this is a fees/revenue adapter only.

**Note: Ophis is a brand-new launch.** The partner fee went live in June 2026, so volume and fees are still ramping up. Two things follow from that: (1) early daily numbers will be small, and (2) on the CoW-hosted chains the partner fee is disbursed to the fee recipient **weekly** (only Optimism is self-hosted), so a single 24h test window can read ~0 even with volume — receipts arrive in weekly batches at the recipient address. The recipient has already done its first sweep on Optimism, so fees are flowing; the adapter will report real numbers as they accrue.

**Methodology:** every Ophis swap pays a flat partner fee (10 bps standard, 1 bp on stablecoin pairs) via CoW's CIP-75 partner-fee mechanism, paid in the swap token to a single deterministic CREATE2 fee recipient (0x858f0F5eE954846D47155F5203c04aF1819eCeF8), identical on every chain. dailyFees = dailyRevenue = USD value of all tokens received by that address per day (addTokensReceived). This is the on-chain received amount, already net of CoW Protocol's revenue share on CoW-hosted chains (Ophis self-hosts settlement only on Optimism).

**Chains:** ethereum, optimism, bsc, xdai, polygon, base, arbitrum, avax, linea, ink, plasma.

Tested locally with `npm test fees ophis <date>` — runs cleanly across all chains with no errors (real values require the LLAMA_INDEXER key, which CI has).