### PR TITLE
Add send.fun fees and volume adapters (launchpad + DEX)

### DIFF
--- a/dexs/send-fun-dex/index.ts
+++ b/dexs/send-fun-dex/index.ts
@@ -46,7 +46,9 @@ const fetch = async (options: FetchOptions) => {
 };
 
 const adapter: SimpleAdapter = {
-  version: 2,
+  // Dune-backed adapter: queries refresh once per day, so use version 1
+  // (a version 2 adapter would re-run the same expensive query hourly).
+  version: 1,
   fetch,
   chains: [CHAIN.SOLANA],
   start: "2026-06-11",

--- a/dexs/send-fun-dex/index.ts
+++ b/dexs/send-fun-dex/index.ts
@@ -1,0 +1,61 @@
+import ADDRESSES from "../../helpers/coreAssets.json";
+import { Dependencies, FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import { queryDuneSql } from "../../helpers/dune";
+
+// send.fun DEX trading volume. Pairs with the fee adapter (fees/send-fun-dex)
+// under the same "send-fun-dex" slug, mirroring PumpSwap (dexs/pump-swap +
+// fees/pump-swap). Volume is the gross quote-denominated size of every swap on
+// the constant-product AMM (program 84qj5FPZZdXkQy8mfowyg6RBZ3XKuTds6XS4ZYT1sfDX),
+// read from the Dune-decoded TradeEvent (quote_amount_gross = quote moved before
+// fees) and grouped by quote mint so DefiLlama prices it.
+//
+// Unlike PumpSwap (which reads Allium's curated solana.dex.trades with a
+// wash-trade filter), send.fun is sourced from its own decoded events; no
+// curated TVL/trader data is available to filter wash trades yet.
+const SCHEMA = "sendfun_dex_solana";
+const TRADE_TABLE = `${SCHEMA}.send_dex_evt_tradeevent`;
+
+// SOL-quoted pools settle in wrapped SOL; guard against a decoder emitting the
+// System Program id / null and normalize to WSOL so DefiLlama can price it.
+const SYSTEM_PROGRAM = "11111111111111111111111111111111";
+function normalizeQuoteMint(mint: string | null | undefined): string {
+  if (!mint || mint === SYSTEM_PROGRAM) return ADDRESSES.solana.SOL;
+  return mint;
+}
+
+const fetch = async (options: FetchOptions) => {
+  const sql = `
+    SELECT
+      quote_mint AS token,
+      SUM(CAST(quote_amount_gross AS decimal(38, 0))) AS volume
+    FROM ${TRADE_TABLE}
+    WHERE evt_block_time >= from_unixtime(${options.startTimestamp})
+      AND evt_block_time < from_unixtime(${options.endTimestamp})
+    GROUP BY quote_mint
+  `;
+
+  const rows = await queryDuneSql(options, sql);
+
+  const dailyVolume = options.createBalances();
+  for (const row of rows ?? []) {
+    dailyVolume.add(normalizeQuoteMint(row.token), row.volume ?? 0);
+  }
+
+  return { dailyVolume };
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  fetch,
+  chains: [CHAIN.SOLANA],
+  start: "2026-06-11",
+  dependencies: [Dependencies.DUNE],
+  isExpensiveAdapter: true,
+  methodology: {
+    Volume:
+      "Gross quote-denominated value of every swap on the send.fun DEX (constant-product AMM), summed from on-chain TradeEvents and priced by DefiLlama.",
+  },
+};
+
+export default adapter;

--- a/dexs/send-fun/index.ts
+++ b/dexs/send-fun/index.ts
@@ -42,7 +42,9 @@ const fetch = async (options: FetchOptions) => {
 };
 
 const adapter: SimpleAdapter = {
-  version: 2,
+  // Dune-backed adapter: queries refresh once per day, so use version 1
+  // (a version 2 adapter would re-run the same expensive query hourly).
+  version: 1,
   fetch,
   chains: [CHAIN.SOLANA],
   start: "2026-06-11",

--- a/dexs/send-fun/index.ts
+++ b/dexs/send-fun/index.ts
@@ -1,0 +1,57 @@
+import ADDRESSES from "../../helpers/coreAssets.json";
+import { Dependencies, FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import { queryDuneSql } from "../../helpers/dune";
+
+// send.fun launchpad (bonding-curve) trading volume. Pairs with the fee adapter
+// (fees/send-fun) under the same "send-fun" slug, mirroring pump.fun
+// (dexs/pumpfun + fees/pumpdotfun). Volume is the gross quote-denominated size
+// of every bonding-curve swap (program 5R1uFyEE4oxqkm7hJDqHq6gXaLVF9dxeF3LF4yz1sfLP),
+// read from the Dune-decoded TradeEvent (quote_amount_gross = quote moved before
+// fees) and grouped by quote mint so DefiLlama prices it.
+const SCHEMA = "sendfun_launchpad_solana";
+const TRADE_TABLE = `${SCHEMA}.send_launchpad_evt_tradeevent`;
+
+// SOL-quoted curves settle in wrapped SOL; guard against a decoder emitting the
+// System Program id / null and normalize to WSOL so DefiLlama can price it.
+const SYSTEM_PROGRAM = "11111111111111111111111111111111";
+function normalizeQuoteMint(mint: string | null | undefined): string {
+  if (!mint || mint === SYSTEM_PROGRAM) return ADDRESSES.solana.SOL;
+  return mint;
+}
+
+const fetch = async (options: FetchOptions) => {
+  const sql = `
+    SELECT
+      quote_mint AS token,
+      SUM(CAST(quote_amount_gross AS decimal(38, 0))) AS volume
+    FROM ${TRADE_TABLE}
+    WHERE evt_block_time >= from_unixtime(${options.startTimestamp})
+      AND evt_block_time < from_unixtime(${options.endTimestamp})
+    GROUP BY quote_mint
+  `;
+
+  const rows = await queryDuneSql(options, sql);
+
+  const dailyVolume = options.createBalances();
+  for (const row of rows ?? []) {
+    dailyVolume.add(normalizeQuoteMint(row.token), row.volume ?? 0);
+  }
+
+  return { dailyVolume };
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  fetch,
+  chains: [CHAIN.SOLANA],
+  start: "2026-06-11",
+  dependencies: [Dependencies.DUNE],
+  isExpensiveAdapter: true,
+  methodology: {
+    Volume:
+      "Gross quote-denominated value of every bonding-curve swap on the send.fun launchpad, summed from on-chain TradeEvents and priced by DefiLlama.",
+  },
+};
+
+export default adapter;

--- a/fees/send-fun-dex/index.ts
+++ b/fees/send-fun-dex/index.ts
@@ -152,7 +152,9 @@ const breakdownMethodology = {
 };
 
 const adapter: SimpleAdapter = {
-  version: 2,
+  // Dune-backed adapter: queries refresh once per day, so use version 1
+  // (a version 2 adapter would re-run the same expensive query hourly).
+  version: 1,
   fetch,
   chains: [CHAIN.SOLANA],
   start: "2026-06-11",

--- a/fees/send-fun-dex/index.ts
+++ b/fees/send-fun-dex/index.ts
@@ -1,0 +1,165 @@
+import ADDRESSES from "../../helpers/coreAssets.json";
+import { Dependencies, FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import { queryDuneSql } from "../../helpers/dune";
+import { METRIC } from "../../helpers/metrics";
+
+// send.fun DEX: the constant-product, permanent-liquidity AMM that tokens
+// migrate into after the bonding curve. This is the "Dexs" child of the
+// "send.fun" parent on DefiLlama; the launchpad is a sibling adapter
+// (fees/send-fun). Every fee is denominated in the pool's quote mint (WSOL,
+// USDC, ...) and is sourced from Dune-decoded Anchor `emit_cpi!` events on the
+// DEX program 84qj5FPZZdXkQy8mfowyg6RBZ3XKuTds6XS4ZYT1sfDX:
+//   TradeEvent       -> protocol_fee, creator_fee, lp_fee
+//   TokenCreateEvent -> creation_fee  (direct DEX pool creation, if any)
+//
+// Fee routing:
+//   protocol_fee + creation_fee -> SEND stakers (holders)      [Revenue + HoldersRevenue]
+//   creator_fee                 -> coin creator                [SupplySideRevenue]
+//   lp_fee                      -> DEX pool reserves / LPs      [SupplySideRevenue]
+const SCHEMA = "sendfun_dex_solana";
+const TABLES = {
+  trade: `${SCHEMA}.send_dex_evt_tradeevent`,
+  create: `${SCHEMA}.send_dex_evt_tokencreateevent`,
+};
+
+// SOL-quoted pools settle in wrapped SOL; guard against a decoder emitting the
+// System Program id / null and normalize to WSOL so DefiLlama can price it.
+const SYSTEM_PROGRAM = "11111111111111111111111111111111";
+function normalizeQuoteMint(mint: string | null | undefined): string {
+  if (!mint || mint === SYSTEM_PROGRAM) return ADDRESSES.solana.SOL;
+  return mint;
+}
+
+const fetch = async (options: FetchOptions) => {
+  const timeFilter = `evt_block_time >= from_unixtime(${options.startTimestamp})
+      AND evt_block_time < from_unixtime(${options.endTimestamp})`;
+
+  const sql = `
+    WITH trades AS (
+      SELECT
+        quote_mint AS token,
+        SUM(CAST(protocol_fee AS decimal(38, 0))) AS protocol_fee,
+        SUM(CAST(creator_fee AS decimal(38, 0))) AS creator_fee,
+        SUM(CAST(lp_fee AS decimal(38, 0))) AS lp_fee,
+        CAST(0 AS decimal(38, 0)) AS creation_fee
+      FROM ${TABLES.trade}
+      WHERE ${timeFilter}
+      GROUP BY quote_mint
+    ),
+    creates AS (
+      SELECT
+        quote_mint AS token,
+        CAST(0 AS decimal(38, 0)) AS protocol_fee,
+        CAST(0 AS decimal(38, 0)) AS creator_fee,
+        CAST(0 AS decimal(38, 0)) AS lp_fee,
+        SUM(CAST(creation_fee AS decimal(38, 0))) AS creation_fee
+      FROM ${TABLES.create}
+      WHERE ${timeFilter}
+      GROUP BY quote_mint
+    ),
+    combined AS (
+      SELECT * FROM trades
+      UNION ALL SELECT * FROM creates
+    )
+    SELECT
+      token,
+      SUM(protocol_fee) AS protocol_fee,
+      SUM(creator_fee) AS creator_fee,
+      SUM(lp_fee) AS lp_fee,
+      SUM(creation_fee) AS creation_fee
+    FROM combined
+    GROUP BY token
+  `;
+
+  const rows = await queryDuneSql(options, sql);
+
+  const dailyFees = options.createBalances();
+  const dailyRevenue = options.createBalances();
+  const dailyProtocolRevenue = options.createBalances();
+  const dailyHoldersRevenue = options.createBalances();
+  const dailySupplySideRevenue = options.createBalances();
+
+  for (const row of rows ?? []) {
+    const token = normalizeQuoteMint(row.token);
+    const protocolFee = row.protocol_fee ?? 0;
+    const creatorFee = row.creator_fee ?? 0;
+    const lpFee = row.lp_fee ?? 0;
+    const creationFee = row.creation_fee ?? 0;
+
+    // Fees: everything the user paid, labelled by source.
+    dailyFees.add(token, protocolFee, METRIC.PROTOCOL_FEES);
+    dailyFees.add(token, creatorFee, METRIC.CREATOR_FEES);
+    dailyFees.add(token, lpFee, METRIC.LP_FEES);
+    dailyFees.add(token, creationFee, METRIC.SERVICE_FEES);
+
+    // Revenue: protocol trade-fee slice + creation fees.
+    dailyRevenue.add(token, protocolFee, METRIC.PROTOCOL_FEES);
+    dailyRevenue.add(token, creationFee, METRIC.SERVICE_FEES);
+
+    // Holders: 100% of protocol revenue is distributed to SEND stakers.
+    dailyHoldersRevenue.add(token, protocolFee, METRIC.PROTOCOL_FEES);
+    dailyHoldersRevenue.add(token, creationFee, METRIC.SERVICE_FEES);
+
+    // Supply side: coin creators (creator_fee) and DEX LPs (lp_fee).
+    dailySupplySideRevenue.add(token, creatorFee, METRIC.CREATOR_FEES);
+    dailySupplySideRevenue.add(token, lpFee, METRIC.LP_FEES);
+  }
+
+  // dailyProtocolRevenue is intentionally empty (0): send.fun keeps no treasury
+  // cut; all protocol revenue is routed to SEND stakers (dailyHoldersRevenue).
+  return {
+    dailyFees,
+    dailyRevenue,
+    dailyProtocolRevenue,
+    dailyHoldersRevenue,
+    dailySupplySideRevenue,
+  };
+};
+
+const methodology = {
+  Fees: "Protocol, creator, and LP fees charged on every DEX trade, plus any direct pool creation fees.",
+  Revenue:
+    "Protocol trade-fee slice plus creation fees (equals Fees minus creator and LP fees).",
+  ProtocolRevenue:
+    "Zero - send.fun keeps no treasury cut; 100% of protocol revenue is distributed to SEND stakers (see HoldersRevenue).",
+  HoldersRevenue:
+    "Protocol trade-fee slice and creation fees, routed 100% to SEND stakers.",
+  SupplySideRevenue:
+    "Trade fees paid to coin creators plus LP fees retained in DEX pool reserves for liquidity providers.",
+};
+
+const breakdownMethodology = {
+  Fees: {
+    [METRIC.PROTOCOL_FEES]: "Protocol slice of every DEX trade fee.",
+    [METRIC.CREATOR_FEES]: "Creator slice of every DEX trade fee.",
+    [METRIC.LP_FEES]: "DEX trade fee retained in pool reserves for liquidity providers.",
+    [METRIC.SERVICE_FEES]: "Pool creation fee charged on direct DEX pool creation.",
+  },
+  Revenue: {
+    [METRIC.PROTOCOL_FEES]: "Protocol slice of trade fees (routed to SEND stakers).",
+    [METRIC.SERVICE_FEES]: "Pool creation fees (routed to SEND stakers).",
+  },
+  HoldersRevenue: {
+    [METRIC.PROTOCOL_FEES]:
+      "Protocol slice of trade fees distributed to SEND stakers.",
+    [METRIC.SERVICE_FEES]: "Pool creation fees distributed to SEND stakers.",
+  },
+  SupplySideRevenue: {
+    [METRIC.CREATOR_FEES]: "DEX trade fees paid out to coin creators.",
+    [METRIC.LP_FEES]: "DEX trade fees retained in pool reserves for LPs.",
+  },
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  fetch,
+  chains: [CHAIN.SOLANA],
+  start: "2026-06-11",
+  dependencies: [Dependencies.DUNE],
+  isExpensiveAdapter: true,
+  methodology,
+  breakdownMethodology,
+};
+
+export default adapter;

--- a/fees/send-fun/index.ts
+++ b/fees/send-fun/index.ts
@@ -1,0 +1,155 @@
+import ADDRESSES from "../../helpers/coreAssets.json";
+import { Dependencies, FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import { queryDuneSql } from "../../helpers/dune";
+import { METRIC } from "../../helpers/metrics";
+
+// send.fun launchpad (bonding-curve) fees. This is the "Launchpad" child of the
+// "send.fun" parent on DefiLlama; the permanent-liquidity DEX is a sibling
+// adapter (fees/send-fun-dex). Every fee is denominated in the curve's quote
+// mint (WSOL, USDC, ...) and is sourced from Dune-decoded Anchor `emit_cpi!`
+// events on the launchpad program 5R1uFyEE4oxqkm7hJDqHq6gXaLVF9dxeF3LF4yz1sfLP:
+//   TradeEvent       -> protocol_fee, creator_fee  (no LP fee on the curve)
+//   TokenCreateEvent -> creation_fee
+//
+// Fee routing:
+//   protocol_fee + creation_fee -> SEND stakers (holders)   [Revenue + HoldersRevenue]
+//   creator_fee                 -> coin creator             [SupplySideRevenue]
+//   migration (curve -> DEX pool)-> no fee
+const SCHEMA = "sendfun_launchpad_solana";
+const TABLES = {
+  trade: `${SCHEMA}.send_launchpad_evt_tradeevent`,
+  create: `${SCHEMA}.send_launchpad_evt_tokencreateevent`,
+};
+
+// SOL-quoted pools settle in wrapped SOL; guard against a decoder emitting the
+// System Program id / null and normalize to WSOL so DefiLlama can price it.
+const SYSTEM_PROGRAM = "11111111111111111111111111111111";
+function normalizeQuoteMint(mint: string | null | undefined): string {
+  if (!mint || mint === SYSTEM_PROGRAM) return ADDRESSES.solana.SOL;
+  return mint;
+}
+
+const fetch = async (options: FetchOptions) => {
+  const timeFilter = `evt_block_time >= from_unixtime(${options.startTimestamp})
+      AND evt_block_time < from_unixtime(${options.endTimestamp})`;
+
+  const sql = `
+    WITH trades AS (
+      SELECT
+        quote_mint AS token,
+        SUM(CAST(protocol_fee AS decimal(38, 0))) AS protocol_fee,
+        SUM(CAST(creator_fee AS decimal(38, 0))) AS creator_fee,
+        CAST(0 AS decimal(38, 0)) AS creation_fee
+      FROM ${TABLES.trade}
+      WHERE ${timeFilter}
+      GROUP BY quote_mint
+    ),
+    creates AS (
+      SELECT
+        quote_mint AS token,
+        CAST(0 AS decimal(38, 0)) AS protocol_fee,
+        CAST(0 AS decimal(38, 0)) AS creator_fee,
+        SUM(CAST(creation_fee AS decimal(38, 0))) AS creation_fee
+      FROM ${TABLES.create}
+      WHERE ${timeFilter}
+      GROUP BY quote_mint
+    ),
+    combined AS (
+      SELECT * FROM trades
+      UNION ALL SELECT * FROM creates
+    )
+    SELECT
+      token,
+      SUM(protocol_fee) AS protocol_fee,
+      SUM(creator_fee) AS creator_fee,
+      SUM(creation_fee) AS creation_fee
+    FROM combined
+    GROUP BY token
+  `;
+
+  const rows = await queryDuneSql(options, sql);
+
+  const dailyFees = options.createBalances();
+  const dailyRevenue = options.createBalances();
+  const dailyProtocolRevenue = options.createBalances();
+  const dailyHoldersRevenue = options.createBalances();
+  const dailySupplySideRevenue = options.createBalances();
+
+  for (const row of rows ?? []) {
+    const token = normalizeQuoteMint(row.token);
+    const protocolFee = row.protocol_fee ?? 0;
+    const creatorFee = row.creator_fee ?? 0;
+    const creationFee = row.creation_fee ?? 0;
+
+    // Fees: everything the user paid, labelled by source.
+    dailyFees.add(token, protocolFee, METRIC.PROTOCOL_FEES);
+    dailyFees.add(token, creatorFee, METRIC.CREATOR_FEES);
+    dailyFees.add(token, creationFee, METRIC.SERVICE_FEES);
+
+    // Revenue: protocol trade-fee slice + creation fees.
+    dailyRevenue.add(token, protocolFee, METRIC.PROTOCOL_FEES);
+    dailyRevenue.add(token, creationFee, METRIC.SERVICE_FEES);
+
+    // Holders: 100% of protocol revenue is distributed to SEND stakers.
+    dailyHoldersRevenue.add(token, protocolFee, METRIC.PROTOCOL_FEES);
+    dailyHoldersRevenue.add(token, creationFee, METRIC.SERVICE_FEES);
+
+    // Supply side: coin creators.
+    dailySupplySideRevenue.add(token, creatorFee, METRIC.CREATOR_FEES);
+  }
+
+  // dailyProtocolRevenue is intentionally empty (0): send.fun keeps no treasury
+  // cut; all protocol revenue is routed to SEND stakers (dailyHoldersRevenue).
+  return {
+    dailyFees,
+    dailyRevenue,
+    dailyProtocolRevenue,
+    dailyHoldersRevenue,
+    dailySupplySideRevenue,
+  };
+};
+
+const methodology = {
+  Fees: "Protocol and creator fees charged on every bonding-curve trade, plus token creation fees.",
+  Revenue:
+    "Protocol trade-fee slice plus token creation fees (equals Fees minus creator fees).",
+  ProtocolRevenue:
+    "Zero - send.fun keeps no treasury cut; 100% of protocol revenue is distributed to SEND stakers (see HoldersRevenue).",
+  HoldersRevenue:
+    "Protocol trade-fee slice and token creation fees, routed 100% to SEND stakers.",
+  SupplySideRevenue: "Bonding-curve trade fees paid to coin creators.",
+};
+
+const breakdownMethodology = {
+  Fees: {
+    [METRIC.PROTOCOL_FEES]: "Protocol slice of every bonding-curve trade fee.",
+    [METRIC.CREATOR_FEES]: "Creator slice of every bonding-curve trade fee.",
+    [METRIC.SERVICE_FEES]: "Token launch fee charged at token creation.",
+  },
+  Revenue: {
+    [METRIC.PROTOCOL_FEES]: "Protocol slice of trade fees (routed to SEND stakers).",
+    [METRIC.SERVICE_FEES]: "Token creation fees (routed to SEND stakers).",
+  },
+  HoldersRevenue: {
+    [METRIC.PROTOCOL_FEES]:
+      "Protocol slice of trade fees distributed to SEND stakers.",
+    [METRIC.SERVICE_FEES]: "Token creation fees distributed to SEND stakers.",
+  },
+  SupplySideRevenue: {
+    [METRIC.CREATOR_FEES]: "Bonding-curve trade fees paid out to coin creators.",
+  },
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  fetch,
+  chains: [CHAIN.SOLANA],
+  start: "2026-06-11",
+  dependencies: [Dependencies.DUNE],
+  isExpensiveAdapter: true,
+  methodology,
+  breakdownMethodology,
+};
+
+export default adapter;

--- a/fees/send-fun/index.ts
+++ b/fees/send-fun/index.ts
@@ -142,7 +142,9 @@ const breakdownMethodology = {
 };
 
 const adapter: SimpleAdapter = {
-  version: 2,
+  // Dune-backed adapter: queries refresh once per day, so use version 1
+  // (a version 2 adapter would re-run the same expensive query hourly).
+  version: 1,
   fetch,
   chains: [CHAIN.SOLANA],
   start: "2026-06-11",


### PR DESCRIPTION
## Summary

Adds dimension adapters for **send.fun**, a Solana token launchpad and permanent-liquidity DEX. Listed like Pump (a parent with a launchpad child and a DEX child); each child reports **fees** and **volume**:

| Adapter | Dimension | Covers |
| --- | --- | --- |
| `fees/send-fun` | fees/revenue | Launchpad (bonding curve) |
| `dexs/send-fun` | volume | Launchpad (bonding curve) |
| `fees/send-fun-dex` | fees/revenue | DEX (constant-product AMM) |
| `dexs/send-fun-dex` | volume | DEX (constant-product AMM) |

## Data source

All metrics come from **Dune-decoded Anchor `emit_cpi!` events** (`TradeEvent`, `TokenCreateEvent`) on the two on-chain programs, grouped by `quote_mint` so DefiLlama prices them:

- Launchpad: `5R1uFyEE4oxqkm7hJDqHq6gXaLVF9dxeF3LF4yz1sfLP`
- DEX: `84qj5FPZZdXkQy8mfowyg6RBZ3XKuTds6XS4ZYT1sfDX`

Uses `Dependencies.DUNE` and is flagged `isExpensiveAdapter`. The decoded per-program tables are small, so queries are cheap.

## Methodology

- **Fees** = `protocol_fee + creator_fee + lp_fee (DEX only) + creation_fee`
- **Revenue / HoldersRevenue** = `protocol_fee + creation_fee` — routed 100% to SEND stakers
- **SupplySideRevenue** = `creator_fee` (coin creators) + `lp_fee` (DEX pool reserves)
- **ProtocolRevenue** = `0` (no treasury cut)
- **Volume** = gross quote-denominated value of every swap (`quote_amount_gross`)

All fees are denominated in the pool's quote mint (WSOL, USDC, ...); the SQL groups by `quote_mint`, so new quote mints are covered with no code change.

## Test plan

Ran locally against live Dune data with a Dune API key:

- [x] `pnpm test fees send-fun` — executes, prices fees to USD, routes to HoldersRevenue (100% to stakers), ProtocolRevenue = 0
- [x] `pnpm test dexs send-fun` — reports launchpad bonding-curve volume
- [x] `pnpm test fees send-fun-dex` — executes (currently $0; no tokens have migrated to the DEX yet)
- [x] `pnpm test dexs send-fun-dex` — executes (currently $0; same reason)

Protocol metadata (parent + the two children, logo, links) will follow as a separate `defillama-server` PR that links these adapter slugs via `dimensions`.