### PR TITLE
[feat]Thorchain-Dex: track dex stats via dune

### DIFF
--- a/active-users/thorchain-dex.ts
+++ b/active-users/thorchain-dex.ts
@@ -1,0 +1,45 @@
+import { Dependencies, FetchOptions, SimpleAdapter } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+import { queryDuneSql } from "../helpers/dune";
+
+const fetch = async (options: FetchOptions) => {
+  const result = await queryDuneSql(options, `
+    WITH user_actions AS (
+      SELECT from_address, tx_id
+      FROM thorchain.defi_swaps
+      WHERE block_timestamp >= from_unixtime(${options.startTimestamp})
+        AND block_timestamp < from_unixtime(${options.endTimestamp})
+        AND from_address IS NOT NULL
+
+      UNION ALL
+
+      SELECT from_address, tx_id
+      FROM thorchain.defi_liquidity_actions
+      WHERE block_timestamp >= from_unixtime(${options.startTimestamp})
+        AND block_timestamp < from_unixtime(${options.endTimestamp})
+        AND day >= date_trunc('day', from_unixtime(${options.startTimestamp}))
+        AND day < date_trunc('day', from_unixtime(${options.endTimestamp}))
+        AND from_address IS NOT NULL
+    )
+    SELECT
+      COALESCE(COUNT(DISTINCT from_address), 0) AS user_count,
+      COALESCE(COUNT(DISTINCT tx_id), 0) AS transaction_count
+    FROM user_actions
+  `);
+
+  return {
+    dailyActiveUsers: result[0].user_count,
+    dailyTransactionsCount: result[0].transaction_count,
+  };
+};
+
+const adapter: SimpleAdapter = {
+  version: 1,
+  fetch,
+  chains: [CHAIN.THORCHAIN],
+  dependencies: [Dependencies.DUNE],
+  isExpensiveAdapter: true,
+  start: "2021-04-11",
+};
+
+export default adapter;

--- a/new-users/thorchain-dex.ts
+++ b/new-users/thorchain-dex.ts
@@ -1,0 +1,47 @@
+import { Dependencies, FetchOptions, SimpleAdapter } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+import { queryDuneSql } from "../helpers/dune";
+
+const fetch = async (options: FetchOptions) => {
+  const result = await queryDuneSql(options, `
+    WITH user_actions AS (
+      SELECT from_address, block_timestamp
+      FROM thorchain.defi_swaps
+      WHERE block_timestamp < from_unixtime(${options.endTimestamp})
+        AND from_address IS NOT NULL
+
+      UNION ALL
+
+      SELECT from_address, block_timestamp
+      FROM thorchain.defi_liquidity_actions
+      WHERE block_timestamp < from_unixtime(${options.endTimestamp})
+        AND from_address IS NOT NULL
+    ),
+    first_actions AS (
+      SELECT
+        from_address,
+        MIN(block_timestamp) AS first_seen
+      FROM user_actions
+      GROUP BY 1
+    )
+    SELECT COALESCE(COUNT(*), 0) AS new_users
+    FROM first_actions
+    WHERE first_seen >= from_unixtime(${options.startTimestamp})
+      AND first_seen < from_unixtime(${options.endTimestamp})
+  `);
+
+  return {
+    dailyNewUsers: result[0].new_users,
+  };
+};
+
+const adapter: SimpleAdapter = {
+  version: 1,
+  fetch,
+  chains: [CHAIN.THORCHAIN],
+  dependencies: [Dependencies.DUNE],
+  isExpensiveAdapter: true,
+  start: "2021-04-11",
+};
+
+export default adapter;


### PR DESCRIPTION
## Summary
- Adds active-users and new-users adapters for `thorchain-dex`.
- Tracks THORChain DEX user activity on THORChain using Dune-backed swap and liquidity action tables.

## Changes
- Added `active-users/thorchain-dex.ts` for daily active users and transaction count.
- Added `new-users/thorchain-dex.ts` for first-time DEX users.
- Counts users from `thorchain.defi_swaps` and `thorchain.defi_liquidity_actions`, covering swappers and LP add/withdraw activity.

## Methodology
- Active users are distinct `from_address` values from swaps and liquidity actions during the day.
- Transaction count is distinct `tx_id` across those same DEX activity tables.
- New users are addresses whose first observed swap or liquidity action occurred during the target day.
- Start date is `2021-04-11`, based on first indexed Dune activity.

## Tests
| Command | Result |
|---|---:|
| `pnpm test active-users thorchain-dex 2025-06-16` | active `597`, txs `14.23k` |
| `pnpm test new-users thorchain-dex 2025-06-16` | new users `349` |
| `pnpm test active-users thorchain-dex 2021-04-12` | active `9`, txs `51` |
| `pnpm test new-users thorchain-dex 2021-04-12` | new users `9` |