### PR TITLE
[feat] HypeMarket - Add volume + fees/revenue adapter (Supra)

### DIFF
--- a/dexs/hypemarket.ts
+++ b/dexs/hypemarket.ts
@@ -7,8 +7,8 @@ const VOLUME_URL = "https://api.hypemarket.trade/api/defillama/volume";
 const FEES_URL = "https://api.hypemarket.trade/api/defillama/fees";
 
 type Token = { decimals: number; coingeckoId: string | null };
-type VolumeDay = { day: string; volumeRaw: string };
-type FeesDay = { day: string; feesRaw: string; protocolRevenueRaw: string; supplySideRevenueRaw: string };
+type VolumeDay = { day: string; boughtRaw: string; soldRaw: string; mintedRaw: string };
+type FeesDay = { day: string; protocolRevenueRaw: string; supplySideRevenueRaw: string };
 type VolumePayload = { token: Token; days: VolumeDay[] };
 type FeesPayload = { token: Token; days: FeesDay[] };
 
@@ -20,15 +20,16 @@ const unwrap = (res: any) => res?.data ?? res;
 const getVolume = (): Promise<VolumePayload> => (cache.volume ??= httpGet(VOLUME_URL).then(unwrap));
 const getFees = (): Promise<FeesPayload> => (cache.fees ??= httpGet(FEES_URL).then(unwrap));
 
+// Raw base units -> whole SUPRA. Surface malformed data as an error rather than
+// coercing it to 0 (which would silently write incorrect history).
 const toSupra = (token: Token, raw: string | undefined): number => {
-  const amount = Number(raw) / 10 ** token.decimals; // raw base units -> whole SUPRA
-  return Number.isFinite(amount) && amount > 0 ? amount : 0;
+  if (raw === undefined) throw new Error("hypemarket: missing amount in API response");
+  const amount = Number(raw) / 10 ** token.decimals;
+  if (!Number.isFinite(amount) || amount < 0) {
+    throw new Error(`hypemarket: invalid amount raw=${raw} decimals=${token.decimals}`);
+  }
+  return amount;
 };
-// Priced by the framework at the day's historical SUPRA price via the CoinGecko id.
-const add = (bag: any, token: Token, amount: number) => {
-  if (amount > 0) bag.addCGToken(token.coingeckoId || "supra", amount);
-};
-
 const lastDay = (days: { day: string }[]): string | null => (days.length ? days[days.length - 1].day : null);
 
 const fetch = async (options: FetchOptions) => {
@@ -36,11 +37,9 @@ const fetch = async (options: FetchOptions) => {
   const day = options.dateString;
 
   // Fail (rather than emit 0) when the day is not yet covered by the backend. The volume
-  // series is the superset of active days, ordered ascending, refreshed to "today"; a day
-  // beyond its latest entry — or an empty series — means data is unavailable, not zero.
-  // A day *within* the covered range that is simply missing is a genuine no-activity day
-  // and correctly contributes 0 (volume and fees series can legitimately differ, e.g. a
-  // market-creation-only day has volume rows but no fee row).
+  // series is ordered ascending and refreshed to "today"; a day beyond its latest entry —
+  // or an empty series — means data is unavailable, not zero. A day within range with no
+  // row is a genuine no-activity day and correctly contributes 0.
   const volLatest = lastDay(vol.days);
   if (!volLatest || day > volLatest) {
     throw new Error(`hypemarket: no data available for ${day}`);
@@ -54,20 +53,38 @@ const fetch = async (options: FetchOptions) => {
   const dailyRevenue = options.createBalances();
   const dailySupplySideRevenue = options.createBalances();
 
-  // Volume = buys + sells + market-creation seed. The seed mints equal shares of every
-  // outcome (economically: buying one of each outcome), so it is counted as volume.
-  if (vRow) add(dailyVolume, vol.token, toSupra(vol.token, vRow.volumeRaw));
+  // Each balance is priced by the framework at the day's historical SUPRA price. Every
+  // label below matches a key in breakdownMethodology for the same dimension.
+  const cgVol = vol.token.coingeckoId || "supra";
+  const cgFee = fee.token.coingeckoId || "supra";
+
+  if (vRow) {
+    const trades = toSupra(vol.token, vRow.boughtRaw) + toSupra(vol.token, vRow.soldRaw);
+    const seed = toSupra(vol.token, vRow.mintedRaw);
+    if (trades > 0) dailyVolume.addCGToken(cgVol, trades, "Outcome trades");
+    if (seed > 0) dailyVolume.addCGToken(cgVol, seed, "Creation seed");
+  }
   if (fRow) {
-    add(dailyFees, fee.token, toSupra(fee.token, fRow.feesRaw)); // total fees paid by users
-    add(dailyRevenue, fee.token, toSupra(fee.token, fRow.protocolRevenueRaw)); // protocol's cut
-    add(dailySupplySideRevenue, fee.token, toSupra(fee.token, fRow.supplySideRevenueRaw)); // creator + user fees
+    const protocol = toSupra(fee.token, fRow.protocolRevenueRaw);
+    const supplySide = toSupra(fee.token, fRow.supplySideRevenueRaw);
+    // dailyFees = protocol + supply-side (= total fees); dailyRevenue / SupplySide split it.
+    if (protocol > 0) {
+      dailyFees.addCGToken(cgFee, protocol, "Protocol fee");
+      dailyRevenue.addCGToken(cgFee, protocol, "Protocol fee");
+    }
+    if (supplySide > 0) {
+      dailyFees.addCGToken(cgFee, supplySide, "Creator & user fees");
+      dailySupplySideRevenue.addCGToken(cgFee, supplySide, "Creator & user fees");
+    }
   }
 
   return { dailyVolume, dailyFees, dailyRevenue, dailySupplySideRevenue };
 };
 
 const adapter: SimpleAdapter = {
-  version: 2,
+  // v1: the backend exposes daily aggregates keyed by UTC date (options.dateString),
+  // not hourly windows — v1 is the correct model for a daily-aggregate API.
+  version: 1,
   fetch,
   chains: [CHAIN.SUPRA],
   // Days within range with no trades correctly return 0; days beyond the computed range
@@ -75,28 +92,28 @@ const adapter: SimpleAdapter = {
   start: "2026-06-08",
   methodology: {
     Volume:
-      "Daily trading volume across HypeMarket LS-LMSR prediction markets on Supra — buys + sells of outcome tokens plus market-creation seed liquidity — in native SUPRA priced at each day's SUPRA price. A market's creation seed is allocated evenly across all outcome tokens, which is economically equivalent to simultaneously buying one of every outcome, so it is counted as volume (matching the platform's reported total).",
+      "Daily trading volume across HypeMarket LS-LMSR prediction markets on Supra — buys + sells of outcome tokens plus market-creation seed liquidity — in native SUPRA priced at each day's SUPRA price. A market's creation seed mints equal shares of every outcome (economically equivalent to buying one of each), so it is counted as volume.",
     Fees:
-      "Total trading fees paid by users (creator + protocol + user fees), derived from the on-chain fee schedule: fee = (creatorFeeBps + protocolFeeBps + userFeeBps)/1e4 of each trade's base notional.",
+      "Total trading fees paid by users: creator fee + protocol fee + user fee, charged on each trade's base notional per the on-chain fee schedule.",
     Revenue: "Protocol's share of trading fees (protocol fee).",
     SupplySideRevenue: "Fees accruing to market creators and users (creator + user fees).",
   },
   breakdownMethodology: {
     Volume: {
       "Outcome trades": "Buys and sells of outcome tokens against the LS-LMSR AMM.",
-      "Creation seed": "Market-creation seed liquidity — equal shares minted across all outcomes (equivalent to buying one of each outcome).",
+      "Creation seed":
+        "Market-creation seed liquidity — equal shares minted across all outcomes (equivalent to buying one of each outcome).",
     },
     Fees: {
-      "Creator fees": "Per-market creator fee (creatorFeeBps) charged on each trade's base notional.",
       "Protocol fee": "Protocol fee (protocolFeeBps) charged on each trade's base notional.",
-      "User fees": "User fee (userFeeBps) charged on each trade's base notional.",
+      "Creator & user fees":
+        "Per-market creator fee (creatorFeeBps) plus user fee (userFeeBps) charged on each trade's base notional.",
     },
     Revenue: {
       "Protocol fee": "Protocol's share of trading fees (protocolFeeBps).",
     },
     SupplySideRevenue: {
-      "Creator fees": "Fees paid to market creators (creatorFeeBps).",
-      "User fees": "Fees accruing to users (userFeeBps).",
+      "Creator & user fees": "Fees accruing to market creators and users (creatorFeeBps + userFeeBps).",
     },
   },
 };

--- a/dexs/hypemarket.ts
+++ b/dexs/hypemarket.ts
@@ -36,17 +36,23 @@ const fetch = async (options: FetchOptions) => {
   const [vol, fee] = await Promise.all([getVolume(), getFees()]);
   const day = options.dateString;
 
-  // Fail (rather than emit 0) when the day is not yet covered by the backend. The volume
-  // series is ordered ascending and refreshed to "today"; a day beyond its latest entry —
-  // or an empty series — means data is unavailable, not zero. A day within range with no
-  // row is a genuine no-activity day and correctly contributes 0.
+  // Both feeds return a contiguous, zero-filled daily series up to the latest computed day
+  // (a no-activity day like a quiet weekend is present with all-zero values). A day beyond
+  // either series' latest entry means data is not computed yet — fail rather than report 0.
   const volLatest = lastDay(vol.days);
-  if (!volLatest || day > volLatest) {
+  const feeLatest = lastDay(fee.days);
+  if (!volLatest || !feeLatest || day > volLatest || day > feeLatest) {
     throw new Error(`hypemarket: no data available for ${day}`);
   }
 
   const vRow = vol.days.find((d) => d.day === day);
   const fRow = fee.days.find((d) => d.day === day);
+  // Within the covered range the two feeds are aligned day-for-day. A day present in one
+  // but not the other means the volume/fee snapshots are momentarily out of sync — fail
+  // rather than write an inconsistent day (e.g. volume with no fees).
+  if (Boolean(vRow) !== Boolean(fRow)) {
+    throw new Error(`hypemarket: inconsistent day rows for ${day} (snapshots may be lagging)`);
+  }
 
   const dailyVolume = options.createBalances();
   const dailyFees = options.createBalances();
@@ -54,7 +60,8 @@ const fetch = async (options: FetchOptions) => {
   const dailySupplySideRevenue = options.createBalances();
 
   // Each balance is priced by the framework at the day's historical SUPRA price. Every
-  // label below matches a key in breakdownMethodology for the same dimension.
+  // label matches a key in breakdownMethodology for the same dimension. A zero-activity
+  // day adds nothing and correctly reports 0 for every metric.
   const cgVol = vol.token.coingeckoId || "supra";
   const cgFee = fee.token.coingeckoId || "supra";
 

--- a/dexs/hypemarket.ts
+++ b/dexs/hypemarket.ts
@@ -1,0 +1,67 @@
+import { FetchOptions, SimpleAdapter } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+import { httpGet } from "../utils/fetchURL";
+
+// HypeMarket DefiLlama feeds, per UTC day, in raw SUPRA base units. SUPRA-only.
+const VOLUME_URL = "https://api.hypemarket.trade/api/defillama/volume";
+const FEES_URL = "https://api.hypemarket.trade/api/defillama/fees";
+
+type Token = { decimals: number; coingeckoId: string | null };
+type VolumeDay = { day: string; volumeRaw: string };
+type FeesDay = { day: string; feesRaw: string; protocolRevenueRaw: string; supplySideRevenueRaw: string };
+type VolumePayload = { token: Token; days: VolumeDay[] };
+type FeesPayload = { token: Token; days: FeesDay[] };
+
+// Fetch each full series once per run; per-day fetch() calls read from cache, so the
+// backend is hit at most once per series no matter how many days are backfilled.
+const cache: { volume?: Promise<VolumePayload>; fees?: Promise<FeesPayload> } = {};
+// The API wraps payloads in { data, success }; tolerate both that and a bare body.
+const unwrap = (res: any) => res?.data ?? res;
+const getVolume = (): Promise<VolumePayload> => (cache.volume ??= httpGet(VOLUME_URL).then(unwrap));
+const getFees = (): Promise<FeesPayload> => (cache.fees ??= httpGet(FEES_URL).then(unwrap));
+
+// Raw base units -> whole SUPRA, added to a balances bag and priced by the framework
+// at the day's historical SUPRA price via the CoinGecko id.
+const addSupra = (bag: any, token: Token, raw: string | undefined) => {
+  const amount = Number(raw) / 10 ** token.decimals;
+  if (Number.isFinite(amount) && amount > 0) bag.addCGToken(token.coingeckoId || "supra", amount);
+};
+
+const fetch = async (options: FetchOptions) => {
+  const [vol, fee] = await Promise.all([getVolume(), getFees()]);
+  const day = options.dateString;
+  const vRow = (vol.days || []).find((d) => d.day === day);
+  const fRow = (fee.days || []).find((d) => d.day === day);
+
+  const dailyVolume = options.createBalances();
+  const dailyFees = options.createBalances();
+  const dailyRevenue = options.createBalances();
+  const dailySupplySideRevenue = options.createBalances();
+
+  if (vRow) addSupra(dailyVolume, vol.token, vRow.volumeRaw);
+  if (fRow) {
+    addSupra(dailyFees, fee.token, fRow.feesRaw);
+    addSupra(dailyRevenue, fee.token, fRow.protocolRevenueRaw); // protocol's cut
+    addSupra(dailySupplySideRevenue, fee.token, fRow.supplySideRevenueRaw); // creator + user fees
+  }
+
+  return { dailyVolume, dailyFees, dailyRevenue, dailySupplySideRevenue };
+};
+
+const adapter: SimpleAdapter = {
+  fetch,
+  chains: [CHAIN.SUPRA],
+  // HypeMarket's first activity day (per /defillama/volume). Empty days harmlessly
+  // return 0, so an earlier start is safe.
+  start: "2026-06-04",
+  methodology: {
+    Volume:
+      "Daily notional collateral traded — buys + sells + market-creation liquidity mints — across HypeMarket LS-LMSR prediction markets on Supra, in native SUPRA priced at each day's SUPRA price. Matches the platform's reported total volume.",
+    Fees:
+      "Total trading fees paid by users (creator + protocol + user fees), derived from the on-chain fee schedule: fee = (creatorFeeBps + protocolFeeBps + userFeeBps)/1e4 of each trade's base notional.",
+    Revenue: "Protocol's share of trading fees (protocol fee).",
+    SupplySideRevenue: "Fees accruing to market creators and users (creator + user fees).",
+  },
+};
+
+export default adapter;

--- a/dexs/hypemarket.ts
+++ b/dexs/hypemarket.ts
@@ -20,47 +20,84 @@ const unwrap = (res: any) => res?.data ?? res;
 const getVolume = (): Promise<VolumePayload> => (cache.volume ??= httpGet(VOLUME_URL).then(unwrap));
 const getFees = (): Promise<FeesPayload> => (cache.fees ??= httpGet(FEES_URL).then(unwrap));
 
-// Raw base units -> whole SUPRA, added to a balances bag and priced by the framework
-// at the day's historical SUPRA price via the CoinGecko id.
-const addSupra = (bag: any, token: Token, raw: string | undefined) => {
-  const amount = Number(raw) / 10 ** token.decimals;
-  if (Number.isFinite(amount) && amount > 0) bag.addCGToken(token.coingeckoId || "supra", amount);
+const toSupra = (token: Token, raw: string | undefined): number => {
+  const amount = Number(raw) / 10 ** token.decimals; // raw base units -> whole SUPRA
+  return Number.isFinite(amount) && amount > 0 ? amount : 0;
 };
+// Priced by the framework at the day's historical SUPRA price via the CoinGecko id.
+const add = (bag: any, token: Token, amount: number) => {
+  if (amount > 0) bag.addCGToken(token.coingeckoId || "supra", amount);
+};
+
+const lastDay = (days: { day: string }[]): string | null => (days.length ? days[days.length - 1].day : null);
 
 const fetch = async (options: FetchOptions) => {
   const [vol, fee] = await Promise.all([getVolume(), getFees()]);
   const day = options.dateString;
-  const vRow = (vol.days || []).find((d) => d.day === day);
-  const fRow = (fee.days || []).find((d) => d.day === day);
+
+  // Fail (rather than emit 0) when the day is not yet covered by the backend. The volume
+  // series is the superset of active days, ordered ascending, refreshed to "today"; a day
+  // beyond its latest entry — or an empty series — means data is unavailable, not zero.
+  // A day *within* the covered range that is simply missing is a genuine no-activity day
+  // and correctly contributes 0 (volume and fees series can legitimately differ, e.g. a
+  // market-creation-only day has volume rows but no fee row).
+  const volLatest = lastDay(vol.days);
+  if (!volLatest || day > volLatest) {
+    throw new Error(`hypemarket: no data available for ${day}`);
+  }
+
+  const vRow = vol.days.find((d) => d.day === day);
+  const fRow = fee.days.find((d) => d.day === day);
 
   const dailyVolume = options.createBalances();
   const dailyFees = options.createBalances();
   const dailyRevenue = options.createBalances();
   const dailySupplySideRevenue = options.createBalances();
 
-  if (vRow) addSupra(dailyVolume, vol.token, vRow.volumeRaw);
+  // Volume = buys + sells + market-creation seed. The seed mints equal shares of every
+  // outcome (economically: buying one of each outcome), so it is counted as volume.
+  if (vRow) add(dailyVolume, vol.token, toSupra(vol.token, vRow.volumeRaw));
   if (fRow) {
-    addSupra(dailyFees, fee.token, fRow.feesRaw);
-    addSupra(dailyRevenue, fee.token, fRow.protocolRevenueRaw); // protocol's cut
-    addSupra(dailySupplySideRevenue, fee.token, fRow.supplySideRevenueRaw); // creator + user fees
+    add(dailyFees, fee.token, toSupra(fee.token, fRow.feesRaw)); // total fees paid by users
+    add(dailyRevenue, fee.token, toSupra(fee.token, fRow.protocolRevenueRaw)); // protocol's cut
+    add(dailySupplySideRevenue, fee.token, toSupra(fee.token, fRow.supplySideRevenueRaw)); // creator + user fees
   }
 
   return { dailyVolume, dailyFees, dailyRevenue, dailySupplySideRevenue };
 };
 
 const adapter: SimpleAdapter = {
+  version: 2,
   fetch,
   chains: [CHAIN.SUPRA],
-  // HypeMarket's first activity day (per /defillama/volume). Empty days harmlessly
-  // return 0, so an earlier start is safe.
-  start: "2026-06-04",
+  // Days within range with no trades correctly return 0; days beyond the computed range
+  // throw (unavailable).
+  start: "2026-06-08",
   methodology: {
     Volume:
-      "Daily notional collateral traded — buys + sells + market-creation liquidity mints — across HypeMarket LS-LMSR prediction markets on Supra, in native SUPRA priced at each day's SUPRA price. Matches the platform's reported total volume.",
+      "Daily trading volume across HypeMarket LS-LMSR prediction markets on Supra — buys + sells of outcome tokens plus market-creation seed liquidity — in native SUPRA priced at each day's SUPRA price. A market's creation seed is allocated evenly across all outcome tokens, which is economically equivalent to simultaneously buying one of every outcome, so it is counted as volume (matching the platform's reported total).",
     Fees:
       "Total trading fees paid by users (creator + protocol + user fees), derived from the on-chain fee schedule: fee = (creatorFeeBps + protocolFeeBps + userFeeBps)/1e4 of each trade's base notional.",
     Revenue: "Protocol's share of trading fees (protocol fee).",
     SupplySideRevenue: "Fees accruing to market creators and users (creator + user fees).",
+  },
+  breakdownMethodology: {
+    Volume: {
+      "Outcome trades": "Buys and sells of outcome tokens against the LS-LMSR AMM.",
+      "Creation seed": "Market-creation seed liquidity — equal shares minted across all outcomes (equivalent to buying one of each outcome).",
+    },
+    Fees: {
+      "Creator fees": "Per-market creator fee (creatorFeeBps) charged on each trade's base notional.",
+      "Protocol fee": "Protocol fee (protocolFeeBps) charged on each trade's base notional.",
+      "User fees": "User fee (userFeeBps) charged on each trade's base notional.",
+    },
+    Revenue: {
+      "Protocol fee": "Protocol's share of trading fees (protocolFeeBps).",
+    },
+    SupplySideRevenue: {
+      "Creator fees": "Fees paid to market creators (creatorFeeBps).",
+      "User fees": "Fees accruing to users (userFeeBps).",
+    },
   },
 };
 


### PR DESCRIPTION
Allow edits by maintainers: enabled.

## HypeMarket — volume + fees/revenue adapter (Supra)

HypeMarket is **already listed** on DefiLlama (TVL adapter merged in `DefiLlama-Adapters`): https://defillama.com/protocol/hypemarket. This PR adds its **Dimensions** adapter so **Volume**, **Fees**, and **Revenue** show on the same protocol page. Not a new listing, so the new-protocol form is omitted.

- **File:** `dexs/hypemarket.ts`
- **Chain:** Supra · **`version: 1`** (daily-aggregate API) · no new dependencies / no `package.json` changes.

#### What it reports (per UTC day, native SUPRA, priced at each day's historical price)
- `dailyVolume` — buys + sells of outcome tokens **plus market-creation seed liquidity**
- `dailyFees` — total trading fees paid by users
- `dailyRevenue` — protocol's share of fees
- `dailySupplySideRevenue` — fees accruing to market creators/users

#### Methodology
HypeMarket is an LS-LMSR prediction-market AMM on Supra; markets are collateralized in native SUPRA. The adapter reads per-day series from the project's public API (`/defillama/volume`, `/defillama/fees`) and adds the SUPRA amount via `addCGToken('supra', amount, label)` so the framework prices each day historically. `breakdownMethodology` is provided for the Volume/Fees/Revenue/SupplySideRevenue dimensions, and every emitted balance is labeled to match its breakdown key.

**Volume includes market-creation seed liquidity.** Unlike a passive LP deposit, an LS-LMSR market's creation seed mints equal shares of *every* outcome by paying collateral into the AMM — economically identical to simultaneously buying one of each outcome (a set of trades), not an idle liquidity add. So it is counted as volume and matches the platform's reported total.

**Fees** are derived from the on-chain fee schedule: per trade, `fee = (creatorFeeBps + protocolFeeBps + userFeeBps) / 1e4` of the base notional, with base backed out of the fee-inclusive buy cost / fee-net sell received. `creatorFeeBps` is per-market; `protocolFeeBps`/`userFeeBps` are read on-chain from `market_config_manager` (currently 100 bps / 0 bps). `dailyFees = dailyRevenue + dailySupplySideRevenue`.

**Data availability:** the adapter throws for days beyond the backend's latest computed day (unavailable) rather than reporting 0; days within range with no trades correctly return 0.

#### Links
- Site: https://beta.hypemarket.trade · Docs: https://hypemarket-protocol.gitbook.io/hypemarket-protocol-docs
- Twitter: https://x.com/HypeMarketTrade
