### PR TITLE
phoenix - fix dead volume source, migrate to Allium

### DIFF
--- a/dexs/phoenix/index.ts
+++ b/dexs/phoenix/index.ts
@@ -5,7 +5,7 @@ import { queryAllium } from "../../helpers/allium";
 const fetch = async (options: FetchOptions) => {
   const data = await queryAllium(`
     SELECT
-      SUM(usd_amount) AS daily_volume
+      COALESCE(SUM(usd_amount), 0) AS daily_volume
     FROM solana.dex.trades
     WHERE project = 'phoenix'
       AND block_timestamp >= TO_TIMESTAMP_NTZ('${options.startTimestamp}')
@@ -13,12 +13,13 @@ const fetch = async (options: FetchOptions) => {
   `);
 
   return {
-    dailyVolume: data[0]?.daily_volume ?? 0,
+    dailyVolume: data[0].daily_volume,
   };
 };
 
 const adapter: SimpleAdapter = {
-  version: 1,
+  version: 2,
+  pullHourly: true,
   fetch,
   chains: [CHAIN.SOLANA],
   start: '2023-02-27',

--- a/dexs/phoenix/index.ts
+++ b/dexs/phoenix/index.ts
@@ -1,27 +1,32 @@
-import { CHAIN } from '../../helpers/chains';
-import { httpGet } from '../../utils/fetchURL';
-import { FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { Dependencies, FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import { queryAllium } from "../../helpers/allium";
 
-const ONE_DAY_IN_SECONDS = 60 * 60 * 24
+const fetch = async (options: FetchOptions) => {
+  const data = await queryAllium(`
+    SELECT
+      SUM(usd_amount) AS daily_volume
+    FROM solana.dex.trades
+    WHERE project = 'phoenix'
+      AND block_timestamp >= TO_TIMESTAMP_NTZ('${options.startTimestamp}')
+      AND block_timestamp < TO_TIMESTAMP_NTZ('${options.endTimestamp}')
+  `);
 
-const volumeEndpoint = "https://9senbezsz3.execute-api.us-east-1.amazonaws.com/Prod/get-global-volume";
-
-async function fetch(options: FetchOptions) {
-    const from = options.toTimestamp - ONE_DAY_IN_SECONDS;
-    const to = options.toTimestamp;
-    const response = await httpGet(volumeEndpoint, {
-        headers: { 'X-Api-Key': 'lty8FkZLKR87IA5g7uFEY6uH8MIk8mJT4OehR8hF' },
-        params: { start_timestamp: from, end_timestamp: to }
-    });
-
-    return {
-        dailyVolume: response.volume_in_quote_units,}
-}
+  return {
+    dailyVolume: data[0]?.daily_volume ?? 0,
+  };
+};
 
 const adapter: SimpleAdapter = {
-    fetch,
-    chains: [CHAIN.SOLANA],
-    start: '2023-02-27',
-}
+  version: 1,
+  fetch,
+  chains: [CHAIN.SOLANA],
+  start: '2023-02-27',
+  dependencies: [Dependencies.ALLIUM],
+  isExpensiveAdapter: true,
+  methodology: {
+    Volume: "Trading volume from Phoenix orderbook fills on Solana, sourced from Allium's solana.dex.trades.",
+  },
+};
 
 export default adapter;


### PR DESCRIPTION
The `dexs/phoenix` adapter pulled `dailyVolume` from a self-hosted AWS API Gateway endpoint (`9senbezsz3.execute-api.us-east-1.amazonaws.com`). That endpoint is dead — it now returns 403 Forbidden / HTTP 500, so the adapter has been failing.

## Fix

Source volume from Allium's `solana.dex.trades` (`SUM(usd_amount) WHERE project = 'phoenix'`) instead of the dead API. Removed the hardcoded API key and `httpGet` call.

Verified that Phoenix's orderbook fills are indexed in Allium: for 2025-06-14, $5.97M across 17,003 fills — same order of magnitude as Dune's `dex_solana.trades` for the same day, and a sane ~3.4 bps ratio against the existing `fees/phoenix` adapter.

Chain (`solana`) and start date (`2023-02-27`) unchanged.
