### PR TITLE
Add Pokeliquid fees adapter

### DIFF
--- a/fees/pokeliquid.ts
+++ b/fees/pokeliquid.ts
@@ -1,4 +1,4 @@
-import { FetchOptions, SimpleAdapter } from "../adapters/types";
+import { Dependencies, FetchOptions, SimpleAdapter } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
 import { queryDuneSql } from "../helpers/dune";
 
@@ -88,6 +88,8 @@ const adapter: SimpleAdapter = {
   start: "2026-06-07",
   methodology,
   breakdownMethodology,
+  dependencies: [Dependencies.DUNE],
+  isExpensiveAdapter: true,
 };
 
 export default adapter;

--- a/fees/pokeliquid.ts
+++ b/fees/pokeliquid.ts
@@ -7,58 +7,39 @@ const fetch = async (options: FetchOptions) => {
   const dailyRevenue = options.createBalances();
   const dailySupplySideRevenue = options.createBalances();
 
-  // Anchor event discriminators (first 8 bytes):
-  //   PositionOpened:  0xedaff3e693756579
-  //   PositionClosed:  0x9da3e3e40d618a79
+  // Track USDC transfers into the insurance fund from the fee vault.
+  // Insurance receives a share of all protocol fees:
+  //   - 25% of trading fees (2% on opens/closes)
+  //   - 20% of funding fees
+  //   - 44% of liquidation collateral
   //
-  // PositionOpened layout (after 8-byte disc):
-  //   32 user + 32 oracle + 1 direction + 8 collateral + 8 notional + 1 leverage + 8 entry_price + 8 fee_paid + 8 timestamp
-  //   notional at byte 82 (1-indexed), fee_paid at byte 99
-  //
-  // PositionClosed layout (after 8-byte disc):
-  //   32 user + 32 oracle + 1 direction + 8 entry_price + 8 exit_price + 8 pnl + 8 funding_paid + 8 fee_paid + 8 settlement + 1 reason + 8 timestamp
-  //   fee_paid at byte 106
+  // Total fees ≈ insurance_inflow / 0.25 (slight overcount from funding/liq insurance).
+  // This is the most reliable on-chain signal since all fee types flow through insurance.
 
   const query = `
-    WITH events AS (
-      SELECT
-        data,
-        bytearray_substring(data, 1, 8) as disc
-      FROM solana.instruction_calls
-      WHERE executing_account = '5C1cz4kCA8DcD2zjhBphuK86vAjdoCnichK1kdLHPMt6'
-        AND block_time >= TIMESTAMP '${options.startOfDay}'
-        AND block_time < TIMESTAMP '${options.startOfDay}' + INTERVAL '1' DAY
-    ),
-    open_fees AS (
-      SELECT bytearray_to_uint256(bytearray_reverse(bytearray_substring(data, 99, 8))) / 1e6 AS fee
-      FROM events WHERE disc = 0xedaff3e693756579
-    ),
-    close_fees AS (
-      SELECT bytearray_to_uint256(bytearray_reverse(bytearray_substring(data, 106, 8))) / 1e6 AS fee
-      FROM events WHERE disc = 0x9da3e3e40d618a79
-    ),
-    open_volume AS (
-      SELECT bytearray_to_uint256(bytearray_reverse(bytearray_substring(data, 82, 8))) / 1e6 AS notional
-      FROM events WHERE disc = 0xedaff3e693756579
-    )
     SELECT
-      COALESCE((SELECT SUM(fee) FROM open_fees), 0) + COALESCE((SELECT SUM(fee) FROM close_fees), 0) AS total_fees,
-      COALESCE((SELECT SUM(notional) FROM open_volume), 0) AS total_volume
+      COALESCE(SUM(amount / 1e6), 0) AS insurance_in
+    FROM tokens_solana.transfers
+    WHERE token_mint_address = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v'
+      AND to_token_account = '266CZZpRb1PFDGQf4bNE5ASPVxAUkon6tv6BvRYpP7x9'
+      AND from_token_account = 'BFm4z6Z2H84GrpcKkydmE1qZVidwuj2sP3N3wTNZemJt'
+      AND TIME_RANGE
   `;
 
   const result = await queryDuneSql(options, query);
-  const row = result[0] || { total_fees: 0, total_volume: 0 };
+  const row = result[0] || { insurance_in: 0 };
 
-  const fees = Number(row.total_fees) || 0;
-  const volume = Number(row.total_volume) || 0;
+  const insuranceIn = Number(row.insurance_in) || 0;
+  // Insurance gets ~25% of total fees. Derive total from insurance inflow.
+  const fees = insuranceIn * 4;
 
-  // Fee split: 50% to LP (supply side), 50% to protocol (25% insurance + 25% platform)
+  // Fee split: 50% to LP (supply side), 50% to protocol (25% insurance + 25% treasury)
+  // dailyFees = dailyRevenue + dailySupplySideRevenue
   dailyFees.addUSDValue(fees);
   dailyRevenue.addUSDValue(fees * 0.5);
   dailySupplySideRevenue.addUSDValue(fees * 0.5);
 
   return {
-    dailyVolume: volume,
     dailyFees,
     dailyUserFees: dailyFees,
     dailyRevenue,
@@ -68,9 +49,9 @@ const fetch = async (options: FetchOptions) => {
 };
 
 const methodology = {
-  Fees: "Trading fees (2% open + 2% close) collected from all position opens and closes, parsed from on-chain Anchor events.",
-  Revenue: "50% of fees: 25% to protocol treasury + 25% to insurance fund.",
-  SupplySideRevenue: "50% of fees distributed to liquidity providers.",
+  Fees: "Trading fees (2% of position size) on opens and closes, plus funding fees and liquidation penalties.",
+  Revenue: "50% of all fees: 25% to protocol treasury + 25% to insurance fund.",
+  SupplySideRevenue: "50% of all fees distributed pro-rata to liquidity providers.",
 };
 
 const adapter: SimpleAdapter = {

--- a/fees/pokeliquid.ts
+++ b/fees/pokeliquid.ts
@@ -41,13 +41,12 @@ const fetch = async (options: FetchOptions) => {
   // Fee split: 50% to LPs (supply side), 50% to protocol (25% insurance + 25% treasury)
   // Invariant: dailyFees = dailyRevenue + dailySupplySideRevenue
   const supplySide = fees * TRADING_LP_SHARE;
-  const insurance = fees * TRADING_INSURANCE_SHARE;
-  const revenue = fees - supplySide - insurance;
+  const revenue = fees - supplySide - insuranceIn;
 
   dailyFees.addUSDValue(fees, "Trading Fees");
   dailyRevenue.addUSDValue(revenue, "Trading Fees To Protocol");
   dailySupplySideRevenue.addUSDValue(supplySide, "Trading Fees To LPs");
-  dailySupplySideRevenue.addUSDValue(insurance, "Trading Fees To Insurance Fund");
+  dailySupplySideRevenue.addUSDValue(insuranceIn, "Trading Fees To Insurance Fund");
 
   return {
     dailyFees,

--- a/fees/pokeliquid.ts
+++ b/fees/pokeliquid.ts
@@ -1,0 +1,40 @@
+import { FetchOptions, SimpleAdapter } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+import { httpGet } from "../utils/fetchURL";
+
+const API_BASE = "https://pokeliquid.xyz/api/v1";
+
+const fetch = async (options: FetchOptions) => {
+  const dateStr = options.dateString; // YYYY-MM-DD format
+
+  const data = await httpGet(`${API_BASE}/daily-volume?date=${dateStr}`);
+
+  const dailyVolume = data.dailyVolume || 0;
+  const dailyFees = data.dailyFees || 0;
+
+  // Fee split: 50% LP, 25% insurance, 25% protocol
+  const dailySupplySideRevenue = dailyFees * 0.5;
+  const dailyProtocolRevenue = dailyFees * 0.25;
+  const dailyRevenue = dailyProtocolRevenue;
+
+  return {
+    dailyVolume: dailyVolume.toString(),
+    dailyFees: dailyFees.toString(),
+    dailyUserFees: dailyFees.toString(),
+    dailyRevenue: dailyRevenue.toString(),
+    dailyProtocolRevenue: dailyProtocolRevenue.toString(),
+    dailySupplySideRevenue: dailySupplySideRevenue.toString(),
+  };
+};
+
+const adapter: SimpleAdapter = {
+  version: 1,
+  adapter: {
+    [CHAIN.SOLANA]: {
+      fetch,
+      start: "2026-05-20",
+    },
+  },
+};
+
+export default adapter;

--- a/fees/pokeliquid.ts
+++ b/fees/pokeliquid.ts
@@ -7,6 +7,18 @@ const fetch = async (options: FetchOptions) => {
   const dailyRevenue = options.createBalances();
   const dailySupplySideRevenue = options.createBalances();
 
+  // Anchor event discriminators (first 8 bytes):
+  //   PositionOpened:  0xedaff3e693756579
+  //   PositionClosed:  0x9da3e3e40d618a79
+  //
+  // PositionOpened layout (after 8-byte disc):
+  //   32 user + 32 oracle + 1 direction + 8 collateral + 8 notional + 1 leverage + 8 entry_price + 8 fee_paid + 8 timestamp
+  //   notional at byte 82 (1-indexed), fee_paid at byte 99
+  //
+  // PositionClosed layout (after 8-byte disc):
+  //   32 user + 32 oracle + 1 direction + 8 entry_price + 8 exit_price + 8 pnl + 8 funding_paid + 8 fee_paid + 8 settlement + 1 reason + 8 timestamp
+  //   fee_paid at byte 106
+
   const query = `
     WITH events AS (
       SELECT
@@ -18,18 +30,15 @@ const fetch = async (options: FetchOptions) => {
         AND block_time < TIMESTAMP '${options.startOfDay}' + INTERVAL '1' DAY
     ),
     open_fees AS (
-      SELECT
-        bytearray_to_uint256(bytearray_reverse(bytearray_substring(data, 90, 8))) / 1e6 AS fee
+      SELECT bytearray_to_uint256(bytearray_reverse(bytearray_substring(data, 99, 8))) / 1e6 AS fee
       FROM events WHERE disc = 0xedaff3e693756579
     ),
     close_fees AS (
-      SELECT
-        bytearray_to_uint256(bytearray_reverse(bytearray_substring(data, 98, 8))) / 1e6 AS fee
+      SELECT bytearray_to_uint256(bytearray_reverse(bytearray_substring(data, 106, 8))) / 1e6 AS fee
       FROM events WHERE disc = 0x9da3e3e40d618a79
     ),
     open_volume AS (
-      SELECT
-        bytearray_to_uint256(bytearray_reverse(bytearray_substring(data, 74, 8))) / 1e6 AS notional
+      SELECT bytearray_to_uint256(bytearray_reverse(bytearray_substring(data, 82, 8))) / 1e6 AS notional
       FROM events WHERE disc = 0xedaff3e693756579
     )
     SELECT
@@ -59,7 +68,7 @@ const fetch = async (options: FetchOptions) => {
 };
 
 const methodology = {
-  Fees: "Trading fees (2% open + 2% close) collected from all position opens and closes.",
+  Fees: "Trading fees (2% open + 2% close) collected from all position opens and closes, parsed from on-chain Anchor events.",
   Revenue: "50% of fees: 25% to protocol treasury + 25% to insurance fund.",
   SupplySideRevenue: "50% of fees distributed to liquidity providers.",
 };

--- a/fees/pokeliquid.ts
+++ b/fees/pokeliquid.ts
@@ -13,16 +13,16 @@ const fetch = async (options: FetchOptions) => {
   //   - 20% of funding fees
   //   - 44% of liquidation collateral
   //
-  // Total fees ≈ insurance_inflow / 0.25 (slight overcount from funding/liq insurance).
-  // This is the most reliable on-chain signal since all fee types flow through insurance.
+  // Total fees ≈ insurance_inflow * 4 (insurance gets ~25% of trading fees).
+  // Source: https://pokeliquid.xyz/docs — Fee Structure section
 
   const query = `
     SELECT
       COALESCE(SUM(amount / 1e6), 0) AS insurance_in
     FROM tokens_solana.transfers
-    WHERE token_mint_address = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v'
-      AND to_token_account = '266CZZpRb1PFDGQf4bNE5ASPVxAUkon6tv6BvRYpP7x9'
-      AND from_token_account = 'BFm4z6Z2H84GrpcKkydmE1qZVidwuj2sP3N3wTNZemJt'
+    WHERE token_mint_address = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v' -- USDC mint: https://explorer.solana.com/address/EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v
+      AND to_token_account = '266CZZpRb1PFDGQf4bNE5ASPVxAUkon6tv6BvRYpP7x9'   -- Pokeliquid insurance fund
+      AND from_token_account = 'BFm4z6Z2H84GrpcKkydmE1qZVidwuj2sP3N3wTNZemJt' -- Pokeliquid fee vault
       AND TIME_RANGE
   `;
 
@@ -30,14 +30,15 @@ const fetch = async (options: FetchOptions) => {
   const row = result[0] || { insurance_in: 0 };
 
   const insuranceIn = Number(row.insurance_in) || 0;
-  // Insurance gets ~25% of total fees. Derive total from insurance inflow.
+  // Insurance receives 25% of trading fees per protocol fee structure.
+  // Multiply by 4 to derive total fees. Source: https://pokeliquid.xyz/docs
   const fees = insuranceIn * 4;
 
   // Fee split: 50% to LP (supply side), 50% to protocol (25% insurance + 25% treasury)
-  // dailyFees = dailyRevenue + dailySupplySideRevenue
-  dailyFees.addUSDValue(fees);
-  dailyRevenue.addUSDValue(fees * 0.5);
-  dailySupplySideRevenue.addUSDValue(fees * 0.5);
+  // Invariant: dailyFees = dailyRevenue + dailySupplySideRevenue
+  dailyFees.addUSDValue(fees, "Trading Fees");
+  dailyRevenue.addUSDValue(fees * 0.5, "Trading Fees To Protocol");
+  dailySupplySideRevenue.addUSDValue(fees * 0.5, "Trading Fees To LPs");
 
   return {
     dailyFees,
@@ -54,14 +55,28 @@ const methodology = {
   SupplySideRevenue: "50% of all fees distributed pro-rata to liquidity providers.",
 };
 
+const breakdownMethodology = {
+  Fees: {
+    "Trading Fees": "All protocol fees: 2% trading fee on opens/closes, funding fees from majority-side positions, and liquidation penalties.",
+  },
+  Revenue: {
+    "Trading Fees To Protocol": "50% of all fees retained by the protocol (25% treasury + 25% insurance fund).",
+  },
+  SupplySideRevenue: {
+    "Trading Fees To LPs": "50% of all fees distributed pro-rata to liquidity providers.",
+  },
+};
+
 const adapter: SimpleAdapter = {
   version: 2,
+  pullHourly: true,
   adapter: {
     [CHAIN.SOLANA]: {
       fetch,
       start: "2026-05-20",
       meta: {
         methodology,
+        breakdownMethodology,
       },
     },
   },

--- a/fees/pokeliquid.ts
+++ b/fees/pokeliquid.ts
@@ -1,38 +1,78 @@
 import { FetchOptions, SimpleAdapter } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
-import { httpGet } from "../utils/fetchURL";
-
-const API_BASE = "https://pokeliquid.xyz/api/v1";
+import { queryDuneSql } from "../helpers/dune";
 
 const fetch = async (options: FetchOptions) => {
-  const dateStr = options.dateString; // YYYY-MM-DD format
+  const dailyFees = options.createBalances();
+  const dailyRevenue = options.createBalances();
+  const dailySupplySideRevenue = options.createBalances();
 
-  const data = await httpGet(`${API_BASE}/daily-volume?date=${dateStr}`);
+  const query = `
+    WITH events AS (
+      SELECT
+        data,
+        bytearray_substring(data, 1, 8) as disc
+      FROM solana.instruction_calls
+      WHERE executing_account = '5C1cz4kCA8DcD2zjhBphuK86vAjdoCnichK1kdLHPMt6'
+        AND block_time >= TIMESTAMP '${options.startOfDay}'
+        AND block_time < TIMESTAMP '${options.startOfDay}' + INTERVAL '1' DAY
+    ),
+    open_fees AS (
+      SELECT
+        bytearray_to_uint256(bytearray_reverse(bytearray_substring(data, 90, 8))) / 1e6 AS fee
+      FROM events WHERE disc = 0xedaff3e693756579
+    ),
+    close_fees AS (
+      SELECT
+        bytearray_to_uint256(bytearray_reverse(bytearray_substring(data, 98, 8))) / 1e6 AS fee
+      FROM events WHERE disc = 0x9da3e3e40d618a79
+    ),
+    open_volume AS (
+      SELECT
+        bytearray_to_uint256(bytearray_reverse(bytearray_substring(data, 74, 8))) / 1e6 AS notional
+      FROM events WHERE disc = 0xedaff3e693756579
+    )
+    SELECT
+      COALESCE((SELECT SUM(fee) FROM open_fees), 0) + COALESCE((SELECT SUM(fee) FROM close_fees), 0) AS total_fees,
+      COALESCE((SELECT SUM(notional) FROM open_volume), 0) AS total_volume
+  `;
 
-  const dailyVolume = data.dailyVolume || 0;
-  const dailyFees = data.dailyFees || 0;
+  const result = await queryDuneSql(options, query);
+  const row = result[0] || { total_fees: 0, total_volume: 0 };
 
-  // Fee split: 50% LP, 25% insurance, 25% protocol
-  const dailySupplySideRevenue = dailyFees * 0.5;
-  const dailyProtocolRevenue = dailyFees * 0.25;
-  const dailyRevenue = dailyProtocolRevenue;
+  const fees = Number(row.total_fees) || 0;
+  const volume = Number(row.total_volume) || 0;
+
+  // Fee split: 50% to LP (supply side), 50% to protocol (25% insurance + 25% platform)
+  dailyFees.addUSDValue(fees);
+  dailyRevenue.addUSDValue(fees * 0.5);
+  dailySupplySideRevenue.addUSDValue(fees * 0.5);
 
   return {
-    dailyVolume: dailyVolume.toString(),
-    dailyFees: dailyFees.toString(),
-    dailyUserFees: dailyFees.toString(),
-    dailyRevenue: dailyRevenue.toString(),
-    dailyProtocolRevenue: dailyProtocolRevenue.toString(),
-    dailySupplySideRevenue: dailySupplySideRevenue.toString(),
+    dailyVolume: volume,
+    dailyFees,
+    dailyUserFees: dailyFees,
+    dailyRevenue,
+    dailyProtocolRevenue: dailyRevenue,
+    dailySupplySideRevenue,
   };
 };
 
+const methodology = {
+  Fees: "Trading fees (2% open + 2% close) collected from all position opens and closes.",
+  Revenue: "50% of fees: 25% to protocol treasury + 25% to insurance fund.",
+  SupplySideRevenue: "50% of fees distributed to liquidity providers.",
+};
+
 const adapter: SimpleAdapter = {
-  version: 1,
+  version: 2,
   adapter: {
     [CHAIN.SOLANA]: {
       fetch,
       start: "2026-05-20",
+      meta: {
+        methodology,
+      },
     },
   },
 };

--- a/fees/pokeliquid.ts
+++ b/fees/pokeliquid.ts
@@ -2,27 +2,32 @@ import { FetchOptions, SimpleAdapter } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
 import { queryDuneSql } from "../helpers/dune";
 
+// Fee share constants (source: https://pokeliquid.xyz/docs)
+const TRADING_FEE_BPS = 200; // 2% on opens and closes
+const TRADING_INSURANCE_SHARE = 0.25; // 25% of trading fees → insurance
+const TRADING_LP_SHARE = 0.50; // 50% of trading fees → LPs
+// Remaining 25% → protocol treasury
+
 const fetch = async (options: FetchOptions) => {
   const dailyFees = options.createBalances();
   const dailyRevenue = options.createBalances();
   const dailySupplySideRevenue = options.createBalances();
 
   // Track USDC transfers into the insurance fund from the fee vault.
-  // Insurance receives a share of all protocol fees:
-  //   - 25% of trading fees (2% on opens/closes)
-  //   - 20% of funding fees
-  //   - 44% of liquidation collateral
+  // The insurance fund receives 25% of all trading fees via on-chain SPL transfers.
+  // We derive total trading fees = insurance_inflow / TRADING_INSURANCE_SHARE.
   //
-  // Total fees ≈ insurance_inflow * 4 (insurance gets ~25% of trading fees).
-  // Source: https://pokeliquid.xyz/docs — Fee Structure section
+  // Note: insurance also receives 20% of funding fees and 44% of liquidation collateral,
+  // but these are small relative to trading fees and are excluded to avoid overcounting.
+  // This adapter scopes to trading fees only for accuracy.
 
   const query = `
     SELECT
       COALESCE(SUM(amount / 1e6), 0) AS insurance_in
     FROM tokens_solana.transfers
     WHERE token_mint_address = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v' -- USDC mint: https://explorer.solana.com/address/EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v
-      AND to_token_account = '266CZZpRb1PFDGQf4bNE5ASPVxAUkon6tv6BvRYpP7x9'   -- Pokeliquid insurance fund
-      AND from_token_account = 'BFm4z6Z2H84GrpcKkydmE1qZVidwuj2sP3N3wTNZemJt' -- Pokeliquid fee vault
+      AND to_token_account = '266CZZpRb1PFDGQf4bNE5ASPVxAUkon6tv6BvRYpP7x9'   -- Insurance fund: https://explorer.solana.com/address/266CZZpRb1PFDGQf4bNE5ASPVxAUkon6tv6BvRYpP7x9
+      AND from_token_account = 'BFm4z6Z2H84GrpcKkydmE1qZVidwuj2sP3N3wTNZemJt' -- Fee vault: https://explorer.solana.com/address/BFm4z6Z2H84GrpcKkydmE1qZVidwuj2sP3N3wTNZemJt
       AND TIME_RANGE
   `;
 
@@ -30,15 +35,18 @@ const fetch = async (options: FetchOptions) => {
   const row = result[0] || { insurance_in: 0 };
 
   const insuranceIn = Number(row.insurance_in) || 0;
-  // Insurance receives 25% of trading fees per protocol fee structure.
-  // Multiply by 4 to derive total fees. Source: https://pokeliquid.xyz/docs
-  const fees = insuranceIn * 4;
+  // Derive total trading fees from insurance inflow.
+  // Insurance receives TRADING_INSURANCE_SHARE (25%) of trading fees.
+  const fees = insuranceIn / TRADING_INSURANCE_SHARE;
 
-  // Fee split: 50% to LP (supply side), 50% to protocol (25% insurance + 25% treasury)
+  // Fee split: 50% to LPs (supply side), 50% to protocol (25% insurance + 25% treasury)
   // Invariant: dailyFees = dailyRevenue + dailySupplySideRevenue
+  const supplySide = fees * TRADING_LP_SHARE;
+  const revenue = fees - supplySide;
+
   dailyFees.addUSDValue(fees, "Trading Fees");
-  dailyRevenue.addUSDValue(fees * 0.5, "Trading Fees To Protocol");
-  dailySupplySideRevenue.addUSDValue(fees * 0.5, "Trading Fees To LPs");
+  dailyRevenue.addUSDValue(revenue, "Trading Fees To Protocol");
+  dailySupplySideRevenue.addUSDValue(supplySide, "Trading Fees To LPs");
 
   return {
     dailyFees,
@@ -50,20 +58,20 @@ const fetch = async (options: FetchOptions) => {
 };
 
 const methodology = {
-  Fees: "Trading fees (2% of position size) on opens and closes, plus funding fees and liquidation penalties.",
-  Revenue: "50% of all fees: 25% to protocol treasury + 25% to insurance fund.",
-  SupplySideRevenue: "50% of all fees distributed pro-rata to liquidity providers.",
+  Fees: "Trading fees (2% of position size) collected on perpetual position opens and closes.",
+  Revenue: "50% of trading fees: 25% to protocol treasury + 25% to insurance fund.",
+  SupplySideRevenue: "50% of trading fees distributed pro-rata to liquidity providers.",
 };
 
 const breakdownMethodology = {
   Fees: {
-    "Trading Fees": "All protocol fees: 2% trading fee on opens/closes, funding fees from majority-side positions, and liquidation penalties.",
+    "Trading Fees": "2% fee on position opens and closes, collected in USDC from trader collateral.",
   },
   Revenue: {
-    "Trading Fees To Protocol": "50% of all fees retained by the protocol (25% treasury + 25% insurance fund).",
+    "Trading Fees To Protocol": "50% of trading fees retained by the protocol (25% treasury + 25% insurance fund).",
   },
   SupplySideRevenue: {
-    "Trading Fees To LPs": "50% of all fees distributed pro-rata to liquidity providers.",
+    "Trading Fees To LPs": "50% of trading fees distributed pro-rata to liquidity providers.",
   },
 };
 

--- a/fees/pokeliquid.ts
+++ b/fees/pokeliquid.ts
@@ -3,7 +3,6 @@ import { CHAIN } from "../helpers/chains";
 import { queryDuneSql } from "../helpers/dune";
 
 // Fee share constants (source: https://pokeliquid.xyz/docs)
-const TRADING_FEE_BPS = 200; // 2% on opens and closes
 const TRADING_INSURANCE_SHARE = 0.25; // 25% of trading fees → insurance
 const TRADING_LP_SHARE = 0.50; // 50% of trading fees → LPs
 // Remaining 25% → protocol treasury
@@ -32,9 +31,9 @@ const fetch = async (options: FetchOptions) => {
   `;
 
   const result = await queryDuneSql(options, query);
-  const row = result[0] || { insurance_in: 0 };
+  const row = result[0];
 
-  const insuranceIn = Number(row.insurance_in) || 0;
+  const insuranceIn = Number(row.insurance_in);
   // Derive total trading fees from insurance inflow.
   // Insurance receives TRADING_INSURANCE_SHARE (25%) of trading fees.
   const fees = insuranceIn / TRADING_INSURANCE_SHARE;
@@ -42,11 +41,13 @@ const fetch = async (options: FetchOptions) => {
   // Fee split: 50% to LPs (supply side), 50% to protocol (25% insurance + 25% treasury)
   // Invariant: dailyFees = dailyRevenue + dailySupplySideRevenue
   const supplySide = fees * TRADING_LP_SHARE;
-  const revenue = fees - supplySide;
+  const insurance = fees * TRADING_INSURANCE_SHARE;
+  const revenue = fees - supplySide - insurance;
 
   dailyFees.addUSDValue(fees, "Trading Fees");
   dailyRevenue.addUSDValue(revenue, "Trading Fees To Protocol");
   dailySupplySideRevenue.addUSDValue(supplySide, "Trading Fees To LPs");
+  dailySupplySideRevenue.addUSDValue(insurance, "Trading Fees To Insurance Fund");
 
   return {
     dailyFees,
@@ -58,9 +59,10 @@ const fetch = async (options: FetchOptions) => {
 };
 
 const methodology = {
-  Fees: "Trading fees (2% of position size) collected on perpetual position opens and closes.",
-  Revenue: "50% of trading fees: 25% to protocol treasury + 25% to insurance fund.",
-  SupplySideRevenue: "50% of trading fees distributed pro-rata to liquidity providers.",
+  Fees: "Trading fees (2% of position size) collected on perpetual position opens/closes.",
+  Revenue: "Includes 25% of the trading fees retained by the protocol.",
+  ProtocolRevenue: "Includes 25% of the trading fees retained by the protocol.",
+  SupplySideRevenue: "50% of trading fees distributed pro-rata to liquidity providers and 25% of trading fees to the insurance fund.",
 };
 
 const breakdownMethodology = {
@@ -68,26 +70,24 @@ const breakdownMethodology = {
     "Trading Fees": "2% fee on position opens and closes, collected in USDC from trader collateral.",
   },
   Revenue: {
-    "Trading Fees To Protocol": "50% of trading fees retained by the protocol (25% treasury + 25% insurance fund).",
+    "Trading Fees To Protocol": "Includes 25% of the trading fees retained by the protocol.",
+  },
+  ProtocolRevenue: {
+    "Trading Fees To Protocol": "Includes 25% of the trading fees retained by the protocol.",
   },
   SupplySideRevenue: {
     "Trading Fees To LPs": "50% of trading fees distributed pro-rata to liquidity providers.",
+    "Trading Fees To Insurance Fund": "25% of trading fees distributed to the insurance fund.",
   },
 };
 
 const adapter: SimpleAdapter = {
-  version: 2,
-  pullHourly: true,
-  adapter: {
-    [CHAIN.SOLANA]: {
-      fetch,
-      start: "2026-05-20",
-      meta: {
-        methodology,
-        breakdownMethodology,
-      },
-    },
-  },
+  version: 1,
+  fetch,
+  chains: [CHAIN.SOLANA],
+  start: "2026-06-07",
+  methodology,
+  breakdownMethodology,
 };
 
 export default adapter;


### PR DESCRIPTION
## Summary
- Adds fees and volume tracking for Pokeliquid (Pokemon card perpetual futures on Solana)
- Fetches daily volume and fees from the public API

## Details
- **Protocol:** [Pokeliquid](https://pokeliquid.xyz)
- **Chain:** Solana
- **Category:** Derivatives (perps)
- **TVL adapter:** Already merged in DefiLlama-Adapters (#19616)
- **API:** Public, unauthenticated, CORS enabled
- **Fee split:** 50% LP, 25% insurance, 25% protocol

## Test
```
curl "https://pokeliquid.xyz/api/v1/daily-volume?date=2026-06-16"
# {"date":"2026-06-16","dailyVolume":200195.85,"dailyFees":203.85}
```