### PR TITLE
Add Deriverse volume data

### DIFF
--- a/dexs/deriverse/index.ts
+++ b/dexs/deriverse/index.ts
@@ -3,11 +3,16 @@ import { CHAIN } from "../../helpers/chains";
 import { httpGet } from "../../utils/fetchURL";
 
 const API_URL = "https://vol.mainnet.deriverse.io/volumes";
-const MARKET = "all";
+const MARKET = "spot";
+const HOUR_SECONDS = 60 * 60;
+const HOURLY_START_TIMESTAMP = 1779321600; // 2026-05-21T00:00:00.000Z
 
 interface VolumeResponse {
   period?: string;
   market?: string;
+  date?: string | null;
+  windowStart?: string;
+  windowEnd?: string;
   totals?: {
     usd?: number | null;
   };
@@ -18,37 +23,81 @@ interface VolumeResponse {
   };
 }
 
-const fetch = async (options: FetchOptions) => {
-  const response: VolumeResponse = await httpGet(`${API_URL}?period=day&date=${options.dateString}&market=${MARKET}`);
-
-  if (response.period !== "day" || response.market !== MARKET) {
-    throw new Error(`Unexpected Deriverse volume API response for ${options.dateString}`);
-  }
-
+const getDailyVolume = (response: VolumeResponse, context: string) => {
   if (response.coverage && response.coverage.usdComplete === false) {
     throw new Error(`Deriverse volume API has ${response.coverage.rawOnlyRows ?? "some"} rows without USD coverage`);
   }
 
   const dailyVolume = response.totals?.usd;
   if (dailyVolume === null || dailyVolume === undefined) {
-    if (response.coverage?.totalRows === 0) return { dailyVolume: 0 };
-    throw new Error(`Deriverse volume API did not return USD volume for ${options.dateString}`);
+    if (response.coverage?.totalRows === 0) return 0;
+    throw new Error(`Deriverse volume API did not return USD volume for ${context}`);
   }
 
   if (!Number.isFinite(dailyVolume)) {
-    throw new Error(`Invalid Deriverse daily volume for ${options.dateString}`);
+    throw new Error(`Invalid Deriverse daily volume for ${context}`);
   }
 
-  return { dailyVolume };
+  return dailyVolume;
+};
+
+const fetchRangeVolume = async (options: FetchOptions, bucketStartTimestamp: number) => {
+  const response: VolumeResponse = await httpGet(
+    `${API_URL}?period=range&startTimestamp=${bucketStartTimestamp}&endTimestamp=${options.endTimestamp}&market=${MARKET}`
+  );
+
+  if (response.period !== "range" || response.market !== MARKET) {
+    throw new Error(`Unexpected Deriverse volume API response for ${bucketStartTimestamp}-${options.endTimestamp}`);
+  }
+
+  const expectedWindowStart = new Date(bucketStartTimestamp * 1000).toISOString();
+  const expectedWindowEnd = new Date(options.endTimestamp * 1000).toISOString();
+  if (response.windowStart !== expectedWindowStart || response.windowEnd !== expectedWindowEnd) {
+    throw new Error(
+      `Deriverse volume API returned window ${response.windowStart}-${response.windowEnd}, expected ${expectedWindowStart}-${expectedWindowEnd}`
+    );
+  }
+
+  return { dailyVolume: getDailyVolume(response, `${bucketStartTimestamp}-${options.endTimestamp}`) };
+};
+
+const fetchDailyBackfillVolume = async (options: FetchOptions) => {
+  const response: VolumeResponse = await httpGet(`${API_URL}?period=day&date=${options.dateString}&market=${MARKET}`);
+
+  if (
+    response.period !== "day" ||
+    response.market !== MARKET ||
+    response.date !== options.dateString ||
+    response.windowStart !== options.dateString
+  ) {
+    throw new Error(`Unexpected Deriverse daily volume API response for ${options.dateString}`);
+  }
+
+  return { dailyVolume: getDailyVolume(response, options.dateString) };
+};
+
+const fetch = async (options: FetchOptions) => {
+  const bucketStartTimestamp = options.endTimestamp - HOUR_SECONDS;
+
+  if (bucketStartTimestamp >= HOURLY_START_TIMESTAMP) {
+    return fetchRangeVolume(options, bucketStartTimestamp);
+  }
+
+  if (bucketStartTimestamp !== options.startOfDay) return { dailyVolume: 0 };
+
+  return fetchDailyBackfillVolume(options);
 };
 
 const adapter: SimpleAdapter = {
-  version: 1,
+  version: 2,
+  pullHourly: true,
   fetch,
   chains: [CHAIN.SOLANA],
-  start: "2026-04-27",
+  // The hourly runner gates slots by start <= endTimestamp - 1 day; this makes 2026-04-27 the first loaded UTC day.
+  start: "2026-04-26T01:00:00.000Z",
   methodology: {
-    Volume: "Daily spot and perpetual trading volume reported by the Deriverse hosted volume API.",
+    Volume:
+      "Deriverse spot volume.",
   },
 };
 

--- a/dexs/deriverse/index.ts
+++ b/dexs/deriverse/index.ts
@@ -5,6 +5,7 @@ import { httpGet } from "../../utils/fetchURL";
 const API_URL = "https://vol.mainnet.deriverse.io/volumes";
 const MARKET = "spot";
 const HOUR_SECONDS = 60 * 60;
+const DAY_SECONDS = 24 * HOUR_SECONDS;
 const HOURLY_START_TIMESTAMP = 1779321600; // 2026-05-21T00:00:00.000Z
 
 interface VolumeResponse {
@@ -63,12 +64,16 @@ const fetchRangeVolume = async (options: FetchOptions, bucketStartTimestamp: num
 
 const fetchDailyBackfillVolume = async (options: FetchOptions) => {
   const response: VolumeResponse = await httpGet(`${API_URL}?period=day&date=${options.dateString}&market=${MARKET}`);
+  const expectedWindowEnd = new Date((Date.parse(`${options.dateString}T00:00:00.000Z`) / 1000 + DAY_SECONDS) * 1000)
+    .toISOString()
+    .slice(0, 10);
 
   if (
     response.period !== "day" ||
     response.market !== MARKET ||
     response.date !== options.dateString ||
-    response.windowStart !== options.dateString
+    response.windowStart !== options.dateString ||
+    response.windowEnd !== expectedWindowEnd
   ) {
     throw new Error(`Unexpected Deriverse daily volume API response for ${options.dateString}`);
   }
@@ -83,7 +88,9 @@ const fetch = async (options: FetchOptions) => {
     return fetchRangeVolume(options, bucketStartTimestamp);
   }
 
-  if (bucketStartTimestamp !== options.startOfDay) return { dailyVolume: 0 };
+  if (bucketStartTimestamp !== options.startTimestamp + 1 || bucketStartTimestamp % DAY_SECONDS !== 0) {
+    return { dailyVolume: 0 };
+  }
 
   return fetchDailyBackfillVolume(options);
 };

--- a/dexs/deriverse/index.ts
+++ b/dexs/deriverse/index.ts
@@ -1,0 +1,55 @@
+import type { FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import { httpGet } from "../../utils/fetchURL";
+
+const API_URL = "https://vol.mainnet.deriverse.io/volumes";
+const MARKET = "all";
+
+interface VolumeResponse {
+  period?: string;
+  market?: string;
+  totals?: {
+    usd?: number | null;
+  };
+  coverage?: {
+    totalRows?: number;
+    rawOnlyRows?: number;
+    usdComplete?: boolean;
+  };
+}
+
+const fetch = async (options: FetchOptions) => {
+  const response: VolumeResponse = await httpGet(`${API_URL}?period=day&date=${options.dateString}&market=${MARKET}`);
+
+  if (response.period !== "day" || response.market !== MARKET) {
+    throw new Error(`Unexpected Deriverse volume API response for ${options.dateString}`);
+  }
+
+  if (response.coverage && response.coverage.usdComplete === false) {
+    throw new Error(`Deriverse volume API has ${response.coverage.rawOnlyRows ?? "some"} rows without USD coverage`);
+  }
+
+  const dailyVolume = response.totals?.usd;
+  if (dailyVolume === null || dailyVolume === undefined) {
+    if (response.coverage?.totalRows === 0) return { dailyVolume: 0 };
+    throw new Error(`Deriverse volume API did not return USD volume for ${options.dateString}`);
+  }
+
+  if (!Number.isFinite(dailyVolume)) {
+    throw new Error(`Invalid Deriverse daily volume for ${options.dateString}`);
+  }
+
+  return { dailyVolume };
+};
+
+const adapter: SimpleAdapter = {
+  version: 1,
+  fetch,
+  chains: [CHAIN.SOLANA],
+  start: "2026-04-27",
+  methodology: {
+    Volume: "Daily spot and perpetual trading volume reported by the Deriverse hosted volume API.",
+  },
+};
+
+export default adapter;

--- a/dexs/deriverse/index.ts
+++ b/dexs/deriverse/index.ts
@@ -88,7 +88,8 @@ const fetch = async (options: FetchOptions) => {
     return fetchRangeVolume(options, bucketStartTimestamp);
   }
 
-  if (bucketStartTimestamp !== options.startTimestamp + 1 || bucketStartTimestamp % DAY_SECONDS !== 0) {
+  const matchesWindowStart = bucketStartTimestamp === options.startTimestamp || bucketStartTimestamp === options.startTimestamp + 1;
+  if (!matchesWindowStart || bucketStartTimestamp % DAY_SECONDS !== 0) {
     return { dailyVolume: 0 };
   }
 


### PR DESCRIPTION
### Summary
- Adds Deriverse DEX volume adapter.
- Reports spot volume only via the hosted Deriverse volume API.
- Uses a v2 `pullHourly` adapter with exact `period=range` hourly windows from `2026-05-21` onward.
- Backfills `2026-04-27` through `2026-05-20` from daily spot totals, placing each daily total into the first UTC hourly bucket.

### Notes
Pre-`2026-05-21` hourly buckets are synthetic because reliable hourly range data is not available for that period. The daily totals are still accurate for historical backfill continuity.

The adapter also validates response period, market, window/date fields, USD coverage, and finite USD volume before returning data.