### PR TITLE
thorchain-dex: correct fee/revenue per core-dev review

### DIFF
--- a/fees/thorchain-dex/index.ts
+++ b/fees/thorchain-dex/index.ts
@@ -80,7 +80,8 @@ const fetch: any = async (options: FetchOptions) => {
   const startOfDay = options.startOfDay;
   const chainShortName = chainConfig[options.chain].symbol;
   const earningsUrl = `https://gateway.liquify.com/chain/thorchain_midgard/v2/history/earnings?interval=day&from=${options.startTimestamp}&to=${options.endTimestamp}`;
-  const reserveUrl = `https://vanaheimex.com/api/reserve?interval=day&from=${options.startTimestamp}&to=${options.endTimestamp}`;
+  // Official Midgard reserve history via the Liquify gateway (full daily history; same fields as before).
+  const reserveUrl = `https://gateway.liquify.com/chain/thorchain_midgard/v2/history/reserve?interval=day&from=${options.startTimestamp}&to=${options.endTimestamp}`;
   const poolsUrl = `https://gateway.liquify.com/chain/thorchain_midgard/v2/pools?period=24h`;
 
   const earnings = await fetchCacheURL(earningsUrl);

--- a/fees/thorchain-dex/index.ts
+++ b/fees/thorchain-dex/index.ts
@@ -26,7 +26,6 @@ interface Pool {
   pool: string
   rewards: string
   runeLiquidityFees: string
-  saverEarning: string
   totalLiquidityFeesRune: string
 }
 
@@ -124,11 +123,11 @@ const fetch: any = async (options: FetchOptions) => {
   const bondingEarnings = BigNumber(selectedEarningInterval.bondingEarnings || 0);
   const nodeShareRatio = systemIncome.isZero() ? BigNumber(0) : bondingEarnings.div(systemIncome);
 
-  // Slip-based liquidity (swap) fees and saver-vault earnings paid by users on this chain's pools, in USD.
+  // Slip-based liquidity (swap) fees paid by users on this chain's pools, in USD. Savers yield is NOT a
+  // separate user fee: it is paid out of these same liquidity fees, so counting it on top would double-count.
   const chainSwapFeesUSD = poolsByChainEarnings.reduce((acum, pool) => {
     const liquidityFees = BigNumber(pool.totalLiquidityFeesRune).div(1e8).times(runePriceUSD);
-    const saverFees = BigNumber(pool.saverEarning).div(1e8).times(runePriceUSD);
-    return acum.plus(liquidityFees).plus(saverFees);
+    return acum.plus(liquidityFees);
   }, BigNumber(0));
 
   // Affiliate fees charged by interfaces/wallets (pass-through to integrators, so they are also supply-side).
@@ -137,17 +136,17 @@ const fetch: any = async (options: FetchOptions) => {
     ? BigNumber(affiliateEarnings.intervals[0].volumeUSD).div(1e2)
     : BigNumber(0);
 
-  // Documented THORChain governance carve-outs from system income (= swap fees here; RUNE block-reward
-  // emissions are ~0 and excluded). Percentages are fixed protocol constants; activation dates are
-  // best-effort from public sources (on-chain mimir history is the source of truth - verify before relying).
-  //   5% RUNE burn: from the V3 launch ~2024-12-21 (ADR-017; a negligible 0.01% ran from ~2024-09-28, treated as 0).
-  //   10% to TCY stakers: from the TCY launch ~2025-05-05.
-  //   5% developer fund + 5% marketing fund: from ~2025-09-01 (ADR-021; APPROXIMATE date - verify).
+  // THORChain governance carve-outs from system income (= swap fees here; RUNE block-reward emissions are
+  // ~0 and excluded). Percentages are fixed protocol constants; activation dates:
+  //   5% RUNE burn:       from 2024-09-16.
+  //   5% developer fund:  from 2024-09-16.
+  //   10% to TCY stakers: from 2025-05-01.
+  //   5% marketing fund:  from 2025-11-04.
   const dateStr = new Date(options.startOfDay * 1000).toISOString().slice(0, 10);
-  const burnPct = dateStr >= '2024-12-21' ? 0.05 : 0;
-  const tcyPct = dateStr >= '2025-05-05' ? 0.10 : 0;
-  const devPct = dateStr >= '2025-09-01' ? 0.05 : 0;
-  const marketingPct = dateStr >= '2025-09-01' ? 0.05 : 0;
+  const burnPct = dateStr >= '2024-09-16' ? 0.05 : 0;
+  const devPct = dateStr >= '2024-09-16' ? 0.05 : 0;
+  const tcyPct = dateStr >= '2025-05-01' ? 0.10 : 0;
+  const marketingPct = dateStr >= '2025-11-04' ? 0.05 : 0;
 
   const burnUSD = chainSwapFeesUSD.times(burnPct);
   const tcyUSD = chainSwapFeesUSD.times(tcyPct);
@@ -162,8 +161,9 @@ const fetch: any = async (options: FetchOptions) => {
   const lpRevenueUSD = nodePoolUSD.minus(nodeRevenueUSD);
 
   // Emit each component under its own label so the breakdown is itemized in the UI.
-  // RUNE-holder value (bonder rewards + RUNE burn) -> holders; LP, affiliate (integrator) and TCY -> supply;
-  // outbound fee and developer/marketing funds -> protocol.
+  // Only the RUNE burn accrues to every RUNE holder -> holders. The node-bonder (security) share, the LP
+  // share, affiliate (integrator) fees and TCY rewards all pay suppliers -> supply. Outbound fee and the
+  // developer/marketing funds are kept by the protocol -> protocol.
   const dailyFees = options.createBalances();
   dailyFees.addUSDValue(chainSwapFeesUSD.toNumber(), 'Swap Fees');
   dailyFees.addUSDValue(chainOutboundFeeUSD.toNumber(), 'Outbound Fees');
@@ -174,11 +174,14 @@ const fetch: any = async (options: FetchOptions) => {
   dailyUserFees.addUSDValue(chainOutboundFeeUSD.toNumber(), 'Outbound Fees');
   dailyUserFees.addUSDValue(affiliateFeesUSD.toNumber(), 'Affiliate Fees');
 
+  // RUNE-holder value is only the RUNE burn - the single component that accrues to every RUNE holder.
   const dailyHoldersRevenue = options.createBalances();
-  dailyHoldersRevenue.addUSDValue(nodeRevenueUSD.toNumber(), 'Swap Fees To RUNE Bonders');
   dailyHoldersRevenue.addUSDValue(burnUSD.toNumber(), 'RUNE Burn');
 
+  // Supply-side value: the node-operator (RUNE bonder) share is a security cost, the LP share pays
+  // liquidity providers, affiliate fees pass through to integrators, and TCY rewards pay TCY stakers.
   const dailySupplySideRevenue = options.createBalances();
+  dailySupplySideRevenue.addUSDValue(nodeRevenueUSD.toNumber(), 'Swap Fees To RUNE Bonders');
   dailySupplySideRevenue.addUSDValue(lpRevenueUSD.toNumber(), 'Swap Fees To LPs');
   dailySupplySideRevenue.addUSDValue(affiliateFeesUSD.toNumber(), 'Affiliate Fees To Integrators');
   dailySupplySideRevenue.addUSDValue(tcyUSD.toNumber(), 'TCY Staker Rewards');
@@ -188,8 +191,9 @@ const fetch: any = async (options: FetchOptions) => {
   dailyProtocolRevenue.addUSDValue(devUSD.toNumber(), 'Developer Fund');
   dailyProtocolRevenue.addUSDValue(marketingUSD.toNumber(), 'Marketing Fund');
 
+  // Revenue = value kept by the protocol + the RUNE burn. The node-bonder share is a security cost and the
+  // LP/affiliate/TCY shares pay suppliers, so none of those count as revenue.
   const dailyRevenue = options.createBalances();
-  dailyRevenue.addUSDValue(nodeRevenueUSD.toNumber(), 'Swap Fees To RUNE Bonders');
   dailyRevenue.addUSDValue(burnUSD.toNumber(), 'RUNE Burn');
   dailyRevenue.addUSDValue(chainOutboundFeeUSD.toNumber(), 'Outbound Fees To Protocol');
   dailyRevenue.addUSDValue(devUSD.toNumber(), 'Developer Fund');
@@ -206,45 +210,44 @@ const fetch: any = async (options: FetchOptions) => {
 };
 
 const methodology = {
-  Fees: "Slip-based liquidity (swap) fees and saver-vault earnings paid by users on each chain's THORChain pools, the protocol's net outbound (network) fee, and affiliate fees charged by interfaces/wallets (affiliate fees are attributed to the THORChain native chain). RUNE block-reward emissions are excluded.",
-  UserFees: "All swap, saver, outbound and affiliate fees paid by users when swapping through THORChain.",
-  Revenue: "RUNE-holder value (the node-bonder share of swap fees plus the RUNE burn) and protocol-kept income (net outbound network fee, developer fund and marketing fund).",
+  Fees: "Slip-based liquidity (swap) fees paid by users on each chain's THORChain pools, the protocol's net outbound (network) fee, and affiliate fees charged by interfaces/wallets (affiliate fees are attributed to the THORChain native chain). RUNE block-reward emissions are excluded.",
+  UserFees: "All swap, outbound and affiliate fees paid by users when swapping through THORChain.",
+  Revenue: "The 5% RUNE burn (value to all RUNE holders) plus protocol-kept income (net outbound network fee, developer fund and marketing fund). The node-bonder share of swap fees is treated as a security cost and the LP, affiliate and TCY shares as supplier payments, so none of those count as revenue.",
   ProtocolRevenue: "Income kept by the protocol: net outbound network fee plus the 5% developer fund and 5% marketing fund taken from system income.",
-  HoldersRevenue: "Value to RUNE holders: the node-operator (RUNE bonder) share of swap fees set by the Incentive Pendulum, plus the 5% of system income burned (RUNE permanently removed from supply).",
-  SupplySideRevenue: "Value paid to suppliers: the liquidity-provider share of swap fees (LP side of the Incentive Pendulum), affiliate fees passed through to integrators, and the 10% of system income paid to TCY stakers.",
+  HoldersRevenue: "Value to RUNE holders: the 5% of system income burned (RUNE permanently removed from supply), the only component that accrues to every RUNE holder.",
+  SupplySideRevenue: "Value paid to suppliers: the node-operator (RUNE bonder) share of swap fees set by the Incentive Pendulum (a security cost), the liquidity-provider share of swap fees (LP side of the Incentive Pendulum), affiliate fees passed through to integrators, and the 10% of system income paid to TCY stakers.",
 };
 
 const breakdownMethodology = {
   Fees: {
-    'Swap Fees': "Slip-based liquidity (swap) fees and saver-vault earnings paid by users on each chain's THORChain pools.",
+    'Swap Fees': "Slip-based liquidity (swap) fees paid by users on each chain's THORChain pools.",
     'Outbound Fees': "Net outbound network fee (outbound gas charged minus gas reimbursed) paid by users.",
     'Affiliate Fees': "Fees charged by the interface or wallet that built the swap (attributed to the THORChain native chain).",
   },
   UserFees: {
-    'Swap Fees': "Slip-based liquidity (swap) fees and saver-vault earnings paid by users on each chain's THORChain pools.",
+    'Swap Fees': "Slip-based liquidity (swap) fees paid by users on each chain's THORChain pools.",
     'Outbound Fees': "Net outbound network fee (outbound gas charged minus gas reimbursed) paid by users.",
     'Affiliate Fees': "Fees charged by the interface or wallet that built the swap (attributed to the THORChain native chain).",
   },
   Revenue: {
-    'Swap Fees To RUNE Bonders': "Node operators' (RUNE bonders') share of swap fees, set network-wide by the Incentive Pendulum.",
-    'RUNE Burn': "5% of system income burned, permanently removing RUNE from supply (since the V3 launch, ~2024-12-21).",
+    'RUNE Burn': "5% of system income burned, permanently removing RUNE from supply (since 2024-09-16).",
     'Outbound Fees To Protocol': "Net outbound network fee kept by the protocol.",
-    'Developer Fund': "5% of system income allocated to the developer fund (approx. since 2025-09-01).",
-    'Marketing Fund': "5% of system income allocated to the marketing fund (approx. since 2025-09-01).",
+    'Developer Fund': "5% of system income allocated to the developer fund (since 2024-09-16).",
+    'Marketing Fund': "5% of system income allocated to the marketing fund (since 2025-11-04).",
   },
   ProtocolRevenue: {
     'Outbound Fees To Protocol': "Net outbound network fee kept by the protocol, attributed per chain by RUNE pool-depth share.",
-    'Developer Fund': "5% of system income allocated to the developer fund (approx. since 2025-09-01).",
-    'Marketing Fund': "5% of system income allocated to the marketing fund (approx. since 2025-09-01).",
+    'Developer Fund': "5% of system income allocated to the developer fund (since 2024-09-16).",
+    'Marketing Fund': "5% of system income allocated to the marketing fund (since 2025-11-04).",
   },
   HoldersRevenue: {
-    'Swap Fees To RUNE Bonders': "Node operators' (RUNE bonders') share of swap fees in RUNE, set network-wide by the Incentive Pendulum.",
-    'RUNE Burn': "5% of system income burned, permanently removing RUNE from supply and accruing value to RUNE holders (since the V3 launch, ~2024-12-21).",
+    'RUNE Burn': "5% of system income burned, permanently removing RUNE from supply and accruing value to RUNE holders (since 2024-09-16).",
   },
   SupplySideRevenue: {
+    'Swap Fees To RUNE Bonders': "Node operators' (RUNE bonders') share of swap fees, set network-wide by the Incentive Pendulum - a security cost paid to the nodes that bond RUNE to secure the network.",
     'Swap Fees To LPs': "Liquidity providers' share of swap fees (the LP side of the Incentive Pendulum).",
     'Affiliate Fees To Integrators': "Affiliate fees passed through to the integrator that built the swap.",
-    'TCY Staker Rewards': "10% of system income paid in RUNE to TCY stakers (since the TCY launch, ~2025-05-05).",
+    'TCY Staker Rewards': "10% of system income paid in RUNE to TCY stakers (since 2025-05-01).",
   },
 };
 

--- a/fees/thorchain.ts
+++ b/fees/thorchain.ts
@@ -11,9 +11,9 @@ interface IChartItem {
 }
 
 const fetch = async (options: FetchOptions) => {
-  // const feeEndpoint = `https://midgard.ninerealms.com/v2/history/reserve?interval=day&count=100`;
-  const feeEndpoint = `https://vanaheimex.com/api/reserve?from=${options.startOfDay}&to=${options.endTimestamp}`;
-  const historicalFees: IChartItem[] = (await httpGet(feeEndpoint, { headers: {"x-client-id": "defillama"}})).intervals;
+  // Official Midgard reserve history via the Liquify gateway (full daily history; same fields as before).
+  const feeEndpoint = `https://gateway.liquify.com/chain/thorchain_midgard/v2/history/reserve?interval=day&from=${options.startOfDay}&to=${options.endTimestamp}`;
+  const historicalFees: IChartItem[] = (await httpGet(feeEndpoint, { headers: { "x-client-id": "defillama" } })).intervals;
 
   const dayData = historicalFees.find((feeItem: IChartItem) =>
     feeItem.startTime === String(options.startOfDay) && feeItem.endTime === String(options.endTimestamp)


### PR DESCRIPTION
Follow-up to #7612 applying corrections from the THORChain dev review.

### Changes
- **Drop savers yield from swap fees.** The devs confirmed savers yield is not a separate user fee; it is paid out of the same liquidity fees, so adding `saverEarning` on top double-counted.
- **Fix carve-out activation dates** (previous dates were best-effort guesses):

  | Carve-out | Was | Now |
  |---|---|---|
  | 5% RUNE burn | 2024-12-21 | 2024-09-16 |
  | 5% developer fund | 2025-09-01 | 2024-09-16 |
  | 10% TCY | 2025-05-05 | 2025-05-01 |
  | 5% marketing fund | 2025-09-01 | 2025-11-04 |

- **Reclassify node-bonder rewards as supply-side revenue** (a security cost) rather than holders revenue. Only the 5% RUNE burn now counts as holders revenue, matching how the devs frame it and keeping THORChain comparable to other chains on DefiLlama.

### Buckets after this change
- Holders Revenue: RUNE burn only
- Supply-Side Revenue: node-bonder share + LP share + affiliate + TCY
- Protocol Revenue: net outbound fee + developer fund + marketing fund
- Revenue: burn + outbound + developer + marketing

The income-statement identity still holds in every date regime: `node + LP + burn + TCY + dev + marketing = swap fees`, and `Fees = Revenue + SupplySideRevenue`.

The native transaction fee (0.02 RUNE) is intentionally left out of this DEX adapter; it is an L1 chain-level fee that belongs to the THORChain chain adapter.