### PR TITLE
feat: track active and new users for mezo chain

### DIFF
--- a/active-users/mezo.ts
+++ b/active-users/mezo.ts
@@ -1,0 +1,32 @@
+import { Dependencies, FetchOptions, ProtocolType, SimpleAdapter } from "../adapters/types";
+import { queryDuneSql } from "../helpers/dune";
+import { CHAIN } from "../helpers/chains";
+
+const fetch = async (options: FetchOptions) => {
+  const query = `
+    SELECT
+      COALESCE(COUNT(DISTINCT "from"), 0) AS user_count,
+      COALESCE(COUNT(*), 0) AS transaction_count
+    FROM mezo.transactions
+    WHERE TIME_RANGE
+  `;
+
+  const result = await queryDuneSql(options, query);
+
+  return {
+    dailyActiveUsers: result[0].user_count,
+    dailyTransactionsCount: result[0].transaction_count,
+  };
+};
+
+const adapter: SimpleAdapter = {
+  version: 1,
+  fetch,
+  chains: [CHAIN.MEZO],
+  dependencies: [Dependencies.DUNE],
+  isExpensiveAdapter: true,
+  protocolType: ProtocolType.CHAIN,
+  start: "2025-05-06",
+};
+
+export default adapter;

--- a/new-users/mezo.ts
+++ b/new-users/mezo.ts
@@ -1,0 +1,31 @@
+import { Dependencies, FetchOptions, ProtocolType, SimpleAdapter } from "../adapters/types";
+import { queryDuneSql } from "../helpers/dune";
+import { CHAIN } from "../helpers/chains";
+
+const fetch = async (options: FetchOptions) => {
+  const query = `
+    SELECT
+      COALESCE(COUNT(DISTINCT "from"), 0) AS new_users
+    FROM mezo.transactions
+    WHERE TIME_RANGE
+      AND nonce = 0
+  `;
+
+  const result = await queryDuneSql(options, query);
+
+  return {
+    dailyNewUsers: result[0].new_users,
+  };
+};
+
+const adapter: SimpleAdapter = {
+  version: 1,
+  fetch,
+  chains: [CHAIN.MEZO],
+  dependencies: [Dependencies.DUNE],
+  isExpensiveAdapter: true,
+  protocolType: ProtocolType.CHAIN,
+  start: "2025-05-06",
+};
+
+export default adapter;


### PR DESCRIPTION
 ## Summary
  - Track Mezo daily active users, transactions, and new users via Dune (`mezo.transactions`)
  - https://defillama.com/chain/mezo