### PR TITLE
Add Mercury (HyperEVM) fees/revenue/volume adapter

### DIFF
--- a/fees/mercury.ts
+++ b/fees/mercury.ts
@@ -38,6 +38,8 @@ const TREASURY = "0x3a648289259b9F12B3678E79E6Fa85e7Ab982002"; // TreasuryV3 (em
 // Fee rate, from GridMining._deploy: adminFee = value * ADMIN_FEE_BPS / 10000.
 const ADMIN_FEE_BPS = 100n; // 1% of gross HYPE deployed -> dev/ops treasury (team)
 const BPS = 10_000n;
+const VAULT_FEE_TO_BURN = 0.9;
+const VAULT_FEE_TO_STAKERS = 0.1;
 
 const DEPLOYED =
   "event Deployed(uint64 indexed roundId, address indexed user, uint256 amountPerBlock, uint32 blockMask, uint256 totalAmount)";
@@ -46,7 +48,6 @@ const DEPLOYED_FOR =
 const RECEIVED_VAULT = "event ReceivedVault(uint256 amount, uint256 newVaulted)";
 
 // Breakdown labels (must each appear in breakdownMethodology below).
-const HYPE_DEPLOYED = "HYPE Deployed";
 const ADMIN_FEE = "Admin Fee";
 const VAULT_FEE = "Vault Fee";
 
@@ -61,7 +62,7 @@ const fetch = async (options: FetchOptions) => {
   const deployedFor = await options.getLogs({ target: GRID_MINING, eventAbi: DEPLOYED_FOR });
   for (const log of [...deployed, ...deployedFor]) {
     const value = log.totalAmount; // gross HYPE sent (incl. the 1% admin fee)
-    dailyVolume.addGasToken(value, HYPE_DEPLOYED);
+    dailyVolume.addGasToken(value);
     const adminFee = (value * ADMIN_FEE_BPS) / BPS;
     dailyFees.addGasToken(adminFee, ADMIN_FEE);
     dailyProtocolRevenue.addGasToken(adminFee, ADMIN_FEE); // -> team treasury
@@ -71,7 +72,8 @@ const fetch = async (options: FetchOptions) => {
   const vaultLogs = await options.getLogs({ target: TREASURY, eventAbi: RECEIVED_VAULT });
   for (const log of vaultLogs) {
     dailyFees.addGasToken(log.amount, VAULT_FEE);
-    dailyHoldersRevenue.addGasToken(log.amount, VAULT_FEE); // buyback: 90% burn + 10% stakers
+    dailyHoldersRevenue.addGasToken(Number(log.amount) * VAULT_FEE_TO_STAKERS, 'Vault Fees to $MRCY Stakers');
+    dailyHoldersRevenue.addGasToken(Number(log.amount) * VAULT_FEE_TO_BURN, 'Vault Fees to $MRCY Burn');
   }
 
   return {
@@ -89,14 +91,10 @@ const methodology = {
   Fees: "The 1% admin fee on every HYPE deploy plus the vault fee (10% of the losers' pool, routed to the buyback). The winners' pot (player-to-player) and the $MRCY refining fee (a holder-to-holder redistribution with no protocol cut) are not counted.",
   Revenue: "All extracted fees: the admin fee accrues to the team treasury and the vault fee accrues to MRCY holders via the buyback. There is no LP/supply-side cut, so Revenue equals Fees.",
   ProtocolRevenue: "The 1% admin fee on HYPE deployed, sent to the dev/ops treasury (team multisig).",
-  HoldersRevenue:
-    "The vault fee (10% of the losers' pool) funds the on-chain buyback — 90% of the bought MRCY is burned and 10% is distributed to stakers.",
+  HoldersRevenue: "The vault fee (10% of the losers' pool) funds the on-chain buyback — 90% of the bought MRCY is burned and 10% is distributed to stakers.",
 };
 
 const breakdownMethodology = {
-  Volume: {
-    [HYPE_DEPLOYED]: "Gross HYPE deployed onto the grid each round (Deployed + DeployedFor events).",
-  },
   Fees: {
     [ADMIN_FEE]: "1% admin fee skimmed from every HYPE deploy.",
     [VAULT_FEE]: "10% vault fee on the losers' pool, routed to the buyback at round settle.",
@@ -109,15 +107,14 @@ const breakdownMethodology = {
     [ADMIN_FEE]: "1% admin fee sent to the dev/ops treasury (team multisig).",
   },
   HoldersRevenue: {
-    [VAULT_FEE]: "Vault fee funds the buyback: 90% of bought MRCY burned, 10% to stakers.",
+    'Vault Fees to $MRCY Stakers': "10% of the 10% vault fee on the losers' pool, routed to the buyback and distribution to stakers at round settle.",
+    'Vault Fees to $MRCY Burn': "90% of the 10% vault fee on the losers' pool, routed to the buyback and burn at round settle.",
   },
 };
 
 const adapter: SimpleAdapter = {
   version: 2,
   fetch,
-  // HyperEVM (chain 999). `hyperliquid` is @defillama/sdk's only key for the
-  // HyperEVM chain — there is no separate `hyperevm` constant.
   chains: [CHAIN.HYPERLIQUID],
   start: "2026-06-16", // GridMining mainnet deploy (block 37979317, 2026-06-16T12:15Z)
   pullHourly: true, // ~1700 rounds/day: chunk log queries hourly

--- a/fees/mercury.ts
+++ b/fees/mercury.ts
@@ -1,0 +1,126 @@
+import { FetchOptions, SimpleAdapter } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+
+/*
+ * Mercury ($MRCY) — ORE/BEAN-style on-chain mining game on HyperEVM (chain 999).
+ *
+ * Players "deploy" native HYPE onto a 5x5 grid each ~50s round. One block wins
+ * the pot; the protocol takes two HYPE fees, both derivable from on-chain events:
+ *
+ *   1. Admin fee — 1% of every HYPE deployed, skimmed at deploy time
+ *      (GridMining._deploy: adminFee = value * 100 / 10000). Sent to the dev/ops
+ *      treasury (team multisig). -> Protocol revenue.
+ *   2. Vault fee — 10% of the losers' pool, routed to the Treasury buyback at
+ *      settle and emitted as Treasury.ReceivedVault(amount, ...). The buyback
+ *      burns 90% of the bought MRCY and sends 10% to stakers, so this value
+ *      accrues to MRCY holders. -> Holders revenue. (ReceivedVault also carries
+ *      the admin rounding dust + the swept affiliate-escrow remainder; all of it
+ *      is HYPE flowing to the buyback, i.e. holders.)
+ *
+ * Explicitly NOT counted:
+ *   - The winners' pot — a player<->player redistribution, not protocol revenue.
+ *   - The AutoMiner executor fee (0.8% + flat) — pays the keeper, not the protocol.
+ *   - The $MRCY refining fee (10% on claim) — a pure holder<->holder redistribution
+ *     (re-credited to other unclaimed holders via accRefiningPerUnclaimed: no
+ *     protocol cut, no burn), so it is neither a fee nor revenue.
+ *
+ * Volume = total HYPE deployed into the game (gross, incl. the 1% admin fee) =
+ * Σ Deployed.totalAmount + Σ DeployedFor.totalAmount (mutually exclusive: a
+ * direct deploy emits Deployed, an AutoMiner deployFor emits DeployedFor).
+ *
+ * Event signatures mirror contracts/src/GridMining.sol + contracts/src/TreasuryV3.sol.
+ */
+
+// Mainnet contracts (HyperEVM, chain 999). Deployed 2026-06-16, block 37979317.
+const GRID_MINING = "0xa406a36648E0ca782dD2fFdEb4E2Ac9893A1a436"; // GridMining
+const TREASURY = "0x3a648289259b9F12B3678E79E6Fa85e7Ab982002"; // TreasuryV3 (emits ReceivedVault)
+
+// Fee rate, from GridMining._deploy: adminFee = value * ADMIN_FEE_BPS / 10000.
+const ADMIN_FEE_BPS = 100n; // 1% of gross HYPE deployed -> dev/ops treasury (team)
+const BPS = 10_000n;
+
+const DEPLOYED =
+  "event Deployed(uint64 indexed roundId, address indexed user, uint256 amountPerBlock, uint32 blockMask, uint256 totalAmount)";
+const DEPLOYED_FOR =
+  "event DeployedFor(uint64 indexed roundId, address indexed user, address indexed executor, uint256 amountPerBlock, uint32 blockMask, uint256 totalAmount)";
+const RECEIVED_VAULT = "event ReceivedVault(uint256 amount, uint256 newVaulted)";
+
+// Breakdown labels (must each appear in breakdownMethodology below).
+const HYPE_DEPLOYED = "HYPE Deployed";
+const ADMIN_FEE = "Admin Fee";
+const VAULT_FEE = "Vault Fee";
+
+const fetch = async (options: FetchOptions) => {
+  const dailyVolume = options.createBalances();
+  const dailyFees = options.createBalances();
+  const dailyProtocolRevenue = options.createBalances();
+  const dailyHoldersRevenue = options.createBalances();
+
+  // ── Volume + admin fee (1% of every HYPE deploy, user or AutoMiner) ──
+  const deployed = await options.getLogs({ target: GRID_MINING, eventAbi: DEPLOYED });
+  const deployedFor = await options.getLogs({ target: GRID_MINING, eventAbi: DEPLOYED_FOR });
+  for (const log of [...deployed, ...deployedFor]) {
+    const value = log.totalAmount; // gross HYPE sent (incl. the 1% admin fee)
+    dailyVolume.addGasToken(value, HYPE_DEPLOYED);
+    const adminFee = (value * ADMIN_FEE_BPS) / BPS;
+    dailyFees.addGasToken(adminFee, ADMIN_FEE);
+    dailyProtocolRevenue.addGasToken(adminFee, ADMIN_FEE); // -> team treasury
+  }
+
+  // ── Vault fee: exact HYPE routed to the buyback at settle (-> holders) ──
+  const vaultLogs = await options.getLogs({ target: TREASURY, eventAbi: RECEIVED_VAULT });
+  for (const log of vaultLogs) {
+    dailyFees.addGasToken(log.amount, VAULT_FEE);
+    dailyHoldersRevenue.addGasToken(log.amount, VAULT_FEE); // buyback: 90% burn + 10% stakers
+  }
+
+  return {
+    dailyVolume,
+    dailyFees,
+    dailyRevenue: dailyFees, // all fees accrue to protocol (admin) + holders (buyback); no supply-side cut
+    dailyProtocolRevenue,
+    dailyHoldersRevenue,
+  };
+};
+
+const methodology = {
+  Volume:
+    "Total native HYPE deployed into the mining game (gross, including the 1% admin fee), summed from the GridMining Deployed and DeployedFor events.",
+  Fees: "The 1% admin fee on every HYPE deploy plus the vault fee (10% of the losers' pool, routed to the buyback). The winners' pot (player-to-player) and the $MRCY refining fee (a holder-to-holder redistribution with no protocol cut) are not counted.",
+  Revenue: "All extracted fees: the admin fee accrues to the team treasury and the vault fee accrues to MRCY holders via the buyback. There is no LP/supply-side cut, so Revenue equals Fees.",
+  ProtocolRevenue: "The 1% admin fee on HYPE deployed, sent to the dev/ops treasury (team multisig).",
+  HoldersRevenue:
+    "The vault fee (10% of the losers' pool) funds the on-chain buyback — 90% of the bought MRCY is burned and 10% is distributed to stakers.",
+};
+
+const breakdownMethodology = {
+  Volume: {
+    [HYPE_DEPLOYED]: "Gross HYPE deployed onto the grid each round (Deployed + DeployedFor events).",
+  },
+  Fees: {
+    [ADMIN_FEE]: "1% admin fee skimmed from every HYPE deploy.",
+    [VAULT_FEE]: "10% vault fee on the losers' pool, routed to the buyback at round settle.",
+  },
+  Revenue: {
+    [ADMIN_FEE]: "Admin fee kept by the protocol (team treasury).",
+    [VAULT_FEE]: "Vault fee spent on the MRCY buyback (accrues to holders).",
+  },
+  ProtocolRevenue: {
+    [ADMIN_FEE]: "1% admin fee sent to the dev/ops treasury (team multisig).",
+  },
+  HoldersRevenue: {
+    [VAULT_FEE]: "Vault fee funds the buyback: 90% of bought MRCY burned, 10% to stakers.",
+  },
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  fetch,
+  chains: [CHAIN.HYPERLIQUID],
+  start: "2026-06-16", // GridMining mainnet deploy (block 37979317, 2026-06-16T12:15Z)
+  pullHourly: true, // ~1700 rounds/day: chunk log queries hourly
+  methodology,
+  breakdownMethodology,
+};
+
+export default adapter;

--- a/fees/mercury.ts
+++ b/fees/mercury.ts
@@ -116,6 +116,8 @@ const breakdownMethodology = {
 const adapter: SimpleAdapter = {
   version: 2,
   fetch,
+  // HyperEVM (chain 999). `hyperliquid` is @defillama/sdk's only key for the
+  // HyperEVM chain — there is no separate `hyperevm` constant.
   chains: [CHAIN.HYPERLIQUID],
   start: "2026-06-16", // GridMining mainnet deploy (block 37979317, 2026-06-16T12:15Z)
   pullHourly: true, // ~1700 rounds/day: chunk log queries hourly


### PR DESCRIPTION
<!--
  PR body for DeFiLlama/dimension-adapters — adds fees/mercury.ts.
  Mercury is NOT yet listed on DefiLlama, so the new-protocol listing form
  (required by the repo's pull_request_template) is filled in below.
  Remember to tick "Allow edits by maintainers" when opening the PR.
-->

# Add Mercury (HyperEVM) — fees / revenue / volume adapter

Adds a dimension adapter for **Mercury** (`$MRCY`), an ORE/BEAN-style on-chain
mining game on **HyperEVM** (chain 999). The adapter reads HyperEVM event logs only
— no project API or private RPC dependency. Mercury is **not yet listed** on
DefiLlama; listing form below.

> Chain key: the adapter uses `CHAIN.HYPERLIQUID`, which is `@defillama/sdk`'s only
> key for the **HyperEVM** chain (there is no `hyperevm` constant).

## Adapter — `fees/mercury.ts`

| DefiLlama metric | Source |
|---|---|
| `dailyVolume` | HYPE deployed into the game — `GridMining.Deployed` + `DeployedFor` `.totalAmount` |
| `dailyProtocolRevenue` | 1% admin fee on every deploy → team multisig |
| `dailyHoldersRevenue` | vault fee (10% of the losers' pool) → buyback (90% burn / 10% stakers), via `Treasury.ReceivedVault` |
| `dailyFees` / `dailyRevenue` | admin + vault (no supply-side cut → Revenue = Fees) |

Breakdown labels (`Admin Fee`, `Vault Fee`, `HYPE Deployed`) + `breakdownMethodology` included.

**Deliberately excluded** (documented in-file): the winners' pot (player↔player
redistribution), the AutoMiner executor fee (pays the keeper, not the protocol),
and the `$MRCY` refining fee (a holder↔holder redistribution via
`accRefiningPerUnclaimed` — no protocol cut, no burn).

### Contracts (HyperEVM, chain 999)
- GridMining: `0xa406a36648E0ca782dD2fFdEb4E2Ac9893A1a436`
- TreasuryV3: `0x3a648289259b9F12B3678E79E6Fa85e7Ab982002`
- Deployed 2026-06-16 (block 37979317).

### Test
`pnpm test fees mercury 2026-06-18` runs green. Sample complete day (2026-06-17):

```
Daily volume:           $98.7k
Daily fees / revenue:   $10.36k
Daily protocol revenue: $988    (= 1.0% of volume — the admin fee ✓)
Daily holders revenue:  $9.37k  (vault → buyback ✓)
Breakdown: Admin Fee → protocol, Vault Fee → holders
```

---

## New-protocol listing form

##### Name (to be shown on DefiLlama):
Mercury

##### Twitter Link:
https://x.com/MRCYsupply

##### List of audit links if any:
None.

##### Website Link:
https://mrcy.supply

##### Logo (High resolution, will be shown with rounded borders):
https://pbs.twimg.com/profile_images/2061838904991645697/stXs-1cA_400x400.jpg

##### Current TVL:
None — this is a fees / volume / revenue listing only (no TVL adapter).

##### Treasury Addresses (if the protocol has treasury):
`0xF33A4A8d0125dE8FCbc28F004C38160f14E336a9` (team multisig — admin-fee + owner)

##### Chain:
HyperEVM (the adapter's chain key is `hyperliquid`, the only HyperEVM key in @defillama/sdk)

##### Coingecko ID (leave empty if not listed):
(empty — MRCY not on CoinGecko)

##### Coinmarketcap ID (leave empty if not listed):
(empty — MRCY not on CMC)

##### Short Description (to be shown on DefiLlama):
ORE-style on-chain mining game native to HyperEVM. Players deploy HYPE onto a 5×5
grid each ~50s round; one block wins the pot and the protocol mints fresh $MRCY to
the winners.

##### Token address and ticker if any:
`0x1145d266ad5A9411fd47eC4d4d48bC265682A1F6` — `$MRCY`

##### Category (one only):
Gaming

##### Oracle Provider(s):
Randomness: drand (evmnet) via the Anyrand audited verifier. No price oracle; the
Treasury buyback uses an embedded Hyperswap V3 pool TWAP as its slippage guard.

##### Implementation Details:
Each round is resolved from a drand beacon round (winning block selection,
single-winner / motherlode rolls). See contracts/src/randomness.

##### Documentation/Proof:
https://mrcy.supply (about / how-it-works pages)

##### forkedFrom:
ORE / BEAN (ORE-style mining game lineage).

##### Github org/user:
(private repo)

##### Does this project have a referral program?
Yes — on-chain `AffiliateRegistry`: a referrer earns 0.5% of each referred loser's
vault-fee contribution (buyback-side, never taken from winners).
