### PR TITLE
tapp-exchange: fix dead API, migrate to on-chain data

### DIFF
--- a/dexs/tapp-exchange/index.ts
+++ b/dexs/tapp-exchange/index.ts
@@ -1,63 +1,120 @@
-import { SimpleAdapter, FetchOptions } from "../../adapters/types";
+import { Dependencies, FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
-import { postURL } from "../../utils/fetchURL";
-import { randomInt } from "node:crypto";
-import { getTimestampAtStartOfDayUTC } from "../../utils/date";
+import { queryDuneSql } from "../../helpers/dune";
 
-const URL = 'https://api.tapp.exchange/api/v1'
+const ROUTER = "0x487e905f899ccb6d46fdaec56ba1e0c4cf119862a16c409904b8c78fab1f5e8a";
+const CLMM = "0x5c2e5a4d1b355b939ab160c618ed5504a6e1addf109388aa3b83b73b207ab6c7";
+const STABLE = "0xa611a8ba7261ed1f4d3afe4ac2166fc9f3180103e3296772d593a1e2720c7405";
 
-
-interface TappDefillamaDimension {
-    dailyVolume: number;
-    dailyFee: number;
-    dailyRevenue: number;
-}
-
-const getDefillamaDimension = async (start: number, end: number) => {
-    const body = {
-        "method": "public/defillama_dimension",
-        "jsonrpc": "2.0",
-        "id": randomInt(1, 1000),
-        "params": {
-            "startTime": start,
-            "endTime": end,
-        }
-    }
-    const dimension: { result: TappDefillamaDimension } = await postURL(URL, body)
-    return dimension.result;
-}
+// Swap fee is set per pool at creation: CLMM fee over 1e6 (e.g. 0.05%/0.3%), stable over 1e10 (0.01%).
+// Protocol takes a uniform 33% cut (PoolMeta.platform_fee_rate); the other 67% goes to veTAPP voters.
+// LPs earn TAPP emissions (incentives), not fees, so supply-side revenue is zero.
+const PLATFORM_FEE = 0.33;
+const DEFAULT_SWAP_FEE = 0.0005; // CLMM standard tier; fallback when no creation event is matched
 
 const fetch = async (options: FetchOptions) => {
-    const startOfDay = getTimestampAtStartOfDayUTC(options.toTimestamp) * 1000;
-    const endOfDay = startOfDay + 24 * 60 * 60 * 1000 - 1000;
+  const query = `
+    WITH fees AS (
+      SELECT pool, fee FROM (
+        SELECT json_extract_scalar(data, '$.pool_addr') AS pool,
+               TRY_CAST(json_extract_scalar(data, '$.fee') AS DOUBLE)
+                 / (CASE WHEN event_type = '${CLMM}::clmm::PoolCreated' THEN 1e6 ELSE 1e10 END) AS fee,
+               ROW_NUMBER() OVER (PARTITION BY json_extract_scalar(data, '$.pool_addr') ORDER BY block_time DESC) rn
+        FROM aptos.events
+        WHERE event_type IN ('${CLMM}::clmm::PoolCreated', '${STABLE}::stable::PoolCreated')
+          AND block_time <= from_unixtime(${options.endTimestamp})
+      ) WHERE rn = 1
+    ),
+    swaps AS (
+      SELECT json_extract_scalar(data, '$.pool_addr') AS pool,
+             element_at(CAST(json_extract(data, '$.assets') AS ARRAY(VARCHAR)),
+                        CAST(json_extract_scalar(data, '$.asset_out_index') AS INTEGER) + 1) AS token,
+             TRY_CAST(json_extract_scalar(data, '$.amount_out') AS DECIMAL(38,0)) AS amount_out
+      FROM aptos.events
+      WHERE event_type = '${ROUTER}::router::Swapped' AND TIME_RANGE
+    )
+    SELECT s.pool, s.token, SUM(s.amount_out) AS amount, MAX(f.fee) AS swap_fee
+    FROM swaps s LEFT JOIN fees f ON s.pool = f.pool
+    WHERE s.amount_out IS NOT NULL AND s.token IS NOT NULL AND s.pool IS NOT NULL
+    GROUP BY 1, 2
+  `;
+  const rows = await queryDuneSql(options, query);
 
-    const {
-        dailyFee,
-        dailyVolume,
-        dailyRevenue
-    } = await getDefillamaDimension(startOfDay, endOfDay);
-    const dailySupplySideRevenue = Number(dailyFee || 0) - Number(dailyRevenue || 0);
+  // Group volume per pool, carrying each pool's swap fee rate.
+  const dailyVolume = options.createBalances();
+  const perPool: Record<string, { bal: ReturnType<typeof options.createBalances>; swapFee: number }> = {};
+  for (const row of rows) {
+    if (!row.token) continue;
+    dailyVolume.add(row.token, row.amount);
+    const pool = (perPool[row.pool] ??= {
+      bal: options.createBalances(),
+      swapFee: row.swap_fee != null ? Number(row.swap_fee) : DEFAULT_SWAP_FEE,
+    });
+    pool.bal.add(row.token, row.amount);
+  }
 
-    return {
-        dailyVolume,
-        dailyFees: dailyFee,
-        dailyRevenue,
-        dailyProtocolRevenue: dailyRevenue,
-        dailySupplySideRevenue
-    };
-}
+  // Fees = per-pool USD volume * swap fee rate, split 33% treasury / 67% veTAPP voters.
+  const dailyFees = options.createBalances();
+  const dailyRevenue = options.createBalances();
+  const dailyProtocolRevenue = options.createBalances();
+  const dailyHoldersRevenue = options.createBalances();
+
+  await Promise.all(
+    Object.values(perPool).map(async ({ bal, swapFee }) => {
+      const fees = (await bal.getUSDValue()) * swapFee;
+      const protocol = fees * PLATFORM_FEE;
+      const holders = fees - protocol;
+      dailyFees.addUSDValue(fees, "Swap Fees");
+      dailyRevenue.addUSDValue(protocol, "Swap Fees To Treasury");
+      dailyRevenue.addUSDValue(holders, "Swap Fees To veTAPP Voters");
+      dailyProtocolRevenue.addUSDValue(protocol, "Swap Fees To Treasury");
+      dailyHoldersRevenue.addUSDValue(holders, "Swap Fees To veTAPP Voters");
+    })
+  );
+
+  return {
+    dailyVolume,
+    dailyFees,
+    dailyRevenue,
+    dailyProtocolRevenue,
+    dailyHoldersRevenue,
+    dailySupplySideRevenue: 0,
+  };
+};
+
+const methodology = {
+  Volume:
+    "Sum of the USD value of the output token of every swap.",
+  Fees: "Per-pool USD volume multiplied by the pool's swap fee rate.",
+  Revenue: "All swap fees: the protocol's platform-fee cut plus the share routed to veTAPP voters.",
+  ProtocolRevenue: "Platform fee taken to the protocol treasury.",
+  HoldersRevenue: "Remaining swap fees distributed to veTAPP voters via the pool gauges.",
+  SupplySideRevenue: "Liquidity providers are rewarded with TAPP emissions (incentives).",
+};
+
+const breakdownMethodology = {
+  Fees: { "Swap Fees": "Swap fees charged by each pool (per-pool fee rate from its PoolCreated event)." },
+  Revenue: {
+    "Swap Fees To Treasury": "Protocol platform-fee cut of swap fees (33%).",
+    "Swap Fees To veTAPP Voters": "Swap fees routed to veTAPP voters via pool gauges (67%).",
+  },
+  ProtocolRevenue: {
+    "Swap Fees To Treasury": "Platform fee taken to the protocol treasury (33% of swap fees).",
+  },
+  HoldersRevenue: {
+    "Swap Fees To veTAPP Voters": "Swap fees distributed to veTAPP voters via pool gauges (67% of swap fees).",
+  },
+};
 
 const adapter: SimpleAdapter = {
-    version: 1,
-    chains: [CHAIN.APTOS],
-    fetch,
-    start: "2025-06-12",
-    methodology: {
-        Fees: "Total fees from swaps, based on the fee tier of each pool.",
-        Revenue: "Calculated as 33% of the total fees.",
-        ProtocolRevenue: "33% of the total fees going to the protocol.",
-        SupplySideRevenue: "67% of the total fees going to the liquidity providers."
-    }
+  version: 1,
+  fetch,
+  chains: [CHAIN.APTOS],
+  dependencies: [Dependencies.DUNE],
+  isExpensiveAdapter: true,
+  start: "2025-06-12",
+  methodology,
+  breakdownMethodology,
 };
 
 export default adapter;

--- a/dexs/tapp-exchange/index.ts
+++ b/dexs/tapp-exchange/index.ts
@@ -2,15 +2,18 @@ import { Dependencies, FetchOptions, SimpleAdapter } from "../../adapters/types"
 import { CHAIN } from "../../helpers/chains";
 import { queryDuneSql } from "../../helpers/dune";
 
-const ROUTER = "0x487e905f899ccb6d46fdaec56ba1e0c4cf119862a16c409904b8c78fab1f5e8a";
-const CLMM = "0x5c2e5a4d1b355b939ab160c618ed5504a6e1addf109388aa3b83b73b207ab6c7";
-const STABLE = "0xa611a8ba7261ed1f4d3afe4ac2166fc9f3180103e3296772d593a1e2720c7405";
+// Mainnet packages (explorer: https://explorer.aptoslabs.com/account/<addr>?network=mainnet).
+// ROUTER is the Tapp package from @tapp-exchange/sdk mainnet config; hook engines were resolved
+// from active pools' on-chain resources (hook_factory::PoolMeta.hook_type).
+const ROUTER = "0x487e905f899ccb6d46fdaec56ba1e0c4cf119862a16c409904b8c78fab1f5e8a"; // router::Swapped
+const CLMM = "0x5c2e5a4d1b355b939ab160c618ed5504a6e1addf109388aa3b83b73b207ab6c7"; // CLMM hook (hook_type 3)
+const STABLE = "0xa611a8ba7261ed1f4d3afe4ac2166fc9f3180103e3296772d593a1e2720c7405"; // stable hook (hook_type 4)
+const AMM = "0xb01a9ecc89b51481d92c3a4ff831e7864eceaa6c609a3691e0e8c0a050eeab7"; // AMM hook (hook_type 2)
 
-// Swap fee is set per pool at creation: CLMM fee over 1e6 (e.g. 0.05%/0.3%), stable over 1e10 (0.01%).
-// Protocol takes a uniform 33% cut (PoolMeta.platform_fee_rate); the other 67% goes to veTAPP voters.
-// LPs earn TAPP emissions (incentives), not fees, so supply-side revenue is zero.
+// Swap fee is set per pool at creation (PoolCreated.fee): stable over 1e10 (Curve-style), CLMM/AMM over 1e6.
+// Protocol takes a uniform 33% cut — every pool's hook_factory::PoolMeta.platform_fee_rate = 330000/1e6,
+// verified on-chain; the other 67% goes to veTAPP voters. LPs earn TAPP emissions (incentives), not fees.
 const PLATFORM_FEE = 0.33;
-const DEFAULT_SWAP_FEE = 0.0005; // CLMM standard tier; fallback when no creation event is matched
 
 const fetch = async (options: FetchOptions) => {
   const query = `
@@ -18,10 +21,10 @@ const fetch = async (options: FetchOptions) => {
       SELECT pool, fee FROM (
         SELECT json_extract_scalar(data, '$.pool_addr') AS pool,
                TRY_CAST(json_extract_scalar(data, '$.fee') AS DOUBLE)
-                 / (CASE WHEN event_type = '${CLMM}::clmm::PoolCreated' THEN 1e6 ELSE 1e10 END) AS fee,
+                 / (CASE WHEN event_type = '${STABLE}::stable::PoolCreated' THEN 1e10 ELSE 1e6 END) AS fee,
                ROW_NUMBER() OVER (PARTITION BY json_extract_scalar(data, '$.pool_addr') ORDER BY block_time DESC) rn
         FROM aptos.events
-        WHERE event_type IN ('${CLMM}::clmm::PoolCreated', '${STABLE}::stable::PoolCreated')
+        WHERE event_type IN ('${CLMM}::clmm::PoolCreated', '${STABLE}::stable::PoolCreated', '${AMM}::amm::PoolCreated')
           AND block_time <= from_unixtime(${options.endTimestamp})
       ) WHERE rn = 1
     ),
@@ -45,11 +48,10 @@ const fetch = async (options: FetchOptions) => {
   const perPool: Record<string, { bal: ReturnType<typeof options.createBalances>; swapFee: number }> = {};
   for (const row of rows) {
     if (!row.token) continue;
+    // Every Tapp pool is created via a known hook (AMM/CLMM/stable). A missing rate means a new hook engine launched — fail so the day is refilled once it's mapped, rather than guessing a fee.
+    if (row.swap_fee == null) throw new Error(`tapp-exchange: no swap fee rate for pool ${row.pool}`);
     dailyVolume.add(row.token, row.amount);
-    const pool = (perPool[row.pool] ??= {
-      bal: options.createBalances(),
-      swapFee: row.swap_fee != null ? Number(row.swap_fee) : DEFAULT_SWAP_FEE,
-    });
+    const pool = (perPool[row.pool] ??= { bal: options.createBalances(), swapFee: Number(row.swap_fee) });
     pool.bal.add(row.token, row.amount);
   }
 
@@ -59,18 +61,16 @@ const fetch = async (options: FetchOptions) => {
   const dailyProtocolRevenue = options.createBalances();
   const dailyHoldersRevenue = options.createBalances();
 
-  await Promise.all(
-    Object.values(perPool).map(async ({ bal, swapFee }) => {
-      const fees = (await bal.getUSDValue()) * swapFee;
-      const protocol = fees * PLATFORM_FEE;
-      const holders = fees - protocol;
-      dailyFees.addUSDValue(fees, "Swap Fees");
-      dailyRevenue.addUSDValue(protocol, "Swap Fees To Treasury");
-      dailyRevenue.addUSDValue(holders, "Swap Fees To veTAPP Voters");
-      dailyProtocolRevenue.addUSDValue(protocol, "Swap Fees To Treasury");
-      dailyHoldersRevenue.addUSDValue(holders, "Swap Fees To veTAPP Voters");
-    })
-  );
+  for (const { bal, swapFee } of Object.values(perPool)) {
+    const fees = (await bal.getUSDValue()) * swapFee;
+    const protocol = fees * PLATFORM_FEE;
+    const holders = fees - protocol;
+    dailyFees.addUSDValue(fees, "Swap Fees");
+    dailyRevenue.addUSDValue(protocol, "Swap Fees To Treasury");
+    dailyRevenue.addUSDValue(holders, "Swap Fees To veTAPP Voters");
+    dailyProtocolRevenue.addUSDValue(protocol, "Swap Fees To Treasury");
+    dailyHoldersRevenue.addUSDValue(holders, "Swap Fees To veTAPP Voters");
+  }
 
   return {
     dailyVolume,


### PR DESCRIPTION
`api.tapp.exchange` is no longer usable. It resolves to a Kubernetes control plane and returns `403 system:anonymous` even when the self-signed certificate is ignored. Since the adapter depended on that API for volume and fee data, it now fails in the runner. As a result, TAPP data on DefiLlama has been flatlined since ~2026-05-30.

## Fix

The adapter was rewritten to calculate all metrics directly on-chain using Dune (`aptos.events`):

- Volume: derived from the output leg of each `router::Swapped` event, counting only one side of the swap to avoid double-counting. USD pricing comes from DefiLlama.
- Fees: calculated as pool USD volume × swap fee rate. Fee rates are loaded from each pool's `PoolCreated` event within the same query (CLMM rates use `1e6` precision; stable pools use `1e10` precision).
- Revenue split (ve(3,3), verified against contracts):
  - 33% platform fee (`PoolMeta.platform_fee_rate`) → `dailyProtocolRevenue`
  - 67% distributed to veTAPP voters → `dailyHoldersRevenue`
  - LPs receive TAPP emissions rather than swap fees, so `dailySupplySideRevenue = 0`

This also corrects the previous methodology, which incorrectly classified the 67% voter share as LP (supply-side) revenue.

The new implementation uses Dune as the sole data source, with no dependency on the protocol API or an Aptos full node.

## Verification

The adapter runs successfully (exit code `0`) with no `NaN` or negative values. Revenue identities hold throughout:

- `Fees = Revenue + SupplySideRevenue`
- `Revenue = ProtocolRevenue + HoldersRevenue`

Results closely match DefiLlama data before the outage (adapter run for date `D` covers the window labeled `D-1`):

| Day (DL) | DL Volume | Adapter Volume | DL Fees | Adapter Fees |
|----------|-----------|----------------|---------|--------------|
| 2026-05-27 | $145.6k | $147.2k (+1.1%) | $68 | $67 |
| 2026-05-28 | $262.6k | $267.7k (+1.9%) | $91 | ~$86 |
| 2026-05-30 | $45.3k | $46–53k | $18 | $18 |

Example breakdown (2026-05-28 run):

- Fees: $67
- Protocol revenue: $22
- Holder revenue: $45
- Supply-side revenue: $0

## Notes

- Swap fees use the rate defined at pool creation. While `stable::ApplyNewFee` can update fees, it does not include a `pool_addr`, and fee changes appear to be rare and small.
- The platform fee is consistently 33%, verified across all pools via `PoolMeta.platform_fee_rate`.