### PR TITLE
origin-protocol: holders revenue is the performance fee, not gross yield

### DIFF
--- a/helpers/origin-protocol.ts
+++ b/helpers/origin-protocol.ts
@@ -127,7 +127,10 @@ export const fetchOriginFees = (products: OriginProduct[]) =>
       dailyFees.addUSDValue(productFees, ORIGIN_YIELD_LABEL);
       dailyRevenue.addUSDValue(productRevenue, ORIGIN_PROTOCOL_FEE_LABEL);
       dailySupplySideRevenue.addUSDValue(productSupplySide, ORIGIN_REBASE_LABEL);
-      dailyHoldersRevenue.addUSDValue(productFees, STAKING_REWARDS_LABEL);
+      // Holders revenue is the performance fee forwarded to OGN stakers, i.e. the
+      // protocol revenue — not the gross product yield (which mostly rebases to
+      // OToken holders as supply-side revenue).
+      dailyHoldersRevenue.addUSDValue(productRevenue, STAKING_REWARDS_LABEL);
     }
 
     return {


### PR DESCRIPTION
`helpers/origin-protocol.ts` reports `dailyHoldersRevenue` using the gross product yield (`productFees`) instead of the performance fee that is actually forwarded to OGN stakers.

For each Origin product (OToken vaults and ARM vaults) the helper computes:

- `dailyFees` = gross yield (`productFees`, from Origin's daily_revenue API)
- `dailyRevenue` = `productFees × feeBps / 10000` (the performance fee; `trusteeFeeBps`/`fee` read on-chain)
- `dailySupplySideRevenue` = `productFees − productRevenue` (yield rebased to OToken holders)
- `dailyHoldersRevenue` should be the performance fee forwarded to OGN stakers, i.e. `productRevenue`

The code added `productFees` to `dailyHoldersRevenue`, so holders revenue is overstated by `10000 / feeBps` — 5x for the 20% vaults (OUSD, OETH, Super OETH, ARM) and ~10x for OS on Sonic (10%). It also implies an inconsistent split: with the gross yield reported both as supply-side revenue (rebase to OToken holders) and, in full, as holders revenue (OGN stakers), the sum of the two exceeds total fees.

Verification:
- `trusteeFeeBps` on the OETH vault (`0x39254033945AA2E4809Cc2977E7087BEE48bd7Ab`) is `2000` (20%), so the performance fee is 20% of the yield.
- Current production figures match the bug exactly: dailyHoldersRevenue ≈ 5 × dailyRevenue for the 20% products (origin-ether 5392 vs 1078; origin-dollar 1131 vs 226; origin-arm 576 vs 115) and ≈ 10 × for origin-sonic (34 vs 3).
- After the change, `cli/testAdapter.ts fees origin-dollar 2026-06-14` returns dailyFees 964, dailyRevenue 193, dailyHoldersRevenue 193, dailySupplySideRevenue 771 (supply-side + holders now equals fees, and holders equals revenue).

This is a regression from #6992, whose docstring already described the intended behaviour ("dailyHoldersRevenue = revenue (entire performance fee goes to OGN stakers)") while the code used the gross amount. `dailyFees`, `dailyRevenue` and `dailySupplySideRevenue` are unchanged.
