### PR TITLE
[feat] YourGrails - Add fees adapter

### DIFF
--- a/fees/yourgrails/index.ts
+++ b/fees/yourgrails/index.ts
@@ -68,7 +68,7 @@ const fetch = async (options: FetchOptions) => {
       const price = priceByPackId.get(key(packId));
       if (!price || price === 0n) continue;
       const packPriceUsd = toUsd(price);
-      dailyVolume.addUSDValue(packPriceUsd, "Gacha Pack Sales");
+      dailyVolume.addUSDValue(packPriceUsd);
       dailyFees.addUSDValue(packPriceUsd, "Gacha Pack Sales");
     }
   }
@@ -80,7 +80,7 @@ const fetch = async (options: FetchOptions) => {
   for (const { price, fee } of marketplaceSales as any[]) {
     const salePriceUsd = toUsd(toBigInt(price));
     const feeUsd = toUsd(toBigInt(fee));
-    if (salePriceUsd > 0) dailyVolume.addUSDValue(salePriceUsd, "Marketplace Sales");
+    if (salePriceUsd > 0) dailyVolume.addUSDValue(salePriceUsd);
     if (feeUsd > 0) {
       dailyFees.addUSDValue(feeUsd, "Marketplace Fees");
     }

--- a/fees/yourgrails/index.ts
+++ b/fees/yourgrails/index.ts
@@ -29,8 +29,6 @@ const toUsd = (value: bigint) => Number(value) / USDC_DECIMALS;
 const fetch = async (options: FetchOptions) => {
   const dailyVolume = options.createBalances();
   const dailyFees = options.createBalances();
-  const dailyRevenue = options.createBalances();
-  const dailyUserFees = options.createBalances();
   const dailySupplySideRevenue = options.createBalances();
 
   const packPurchaseLogs = await options.getLogs({
@@ -72,8 +70,6 @@ const fetch = async (options: FetchOptions) => {
       const packPriceUsd = toUsd(price);
       dailyVolume.addUSDValue(packPriceUsd, "Gacha Pack Sales");
       dailyFees.addUSDValue(packPriceUsd, "Gacha Pack Sales");
-      dailyRevenue.addUSDValue(packPriceUsd, "Gacha Pack Sales");
-      dailyUserFees.addUSDValue(packPriceUsd, "Gacha Pack Sales");
     }
   }
 
@@ -87,8 +83,6 @@ const fetch = async (options: FetchOptions) => {
     if (salePriceUsd > 0) dailyVolume.addUSDValue(salePriceUsd, "Marketplace Sales");
     if (feeUsd > 0) {
       dailyFees.addUSDValue(feeUsd, "Marketplace Fees");
-      dailyRevenue.addUSDValue(feeUsd, "Marketplace Fees");
-      dailyUserFees.addUSDValue(feeUsd, "Marketplace Fees");
     }
   }
 
@@ -108,10 +102,7 @@ const fetch = async (options: FetchOptions) => {
       const platformFee = toBigInt(battle.platformFee ?? battle[5]);
       const battleFeesUsd = toUsd(platformFee * BATTLE_PLAYER_COUNT);
       if (battleFeesUsd <= 0) continue;
-      dailyVolume.addUSDValue(battleFeesUsd, "Battle Platform Fees");
       dailyFees.addUSDValue(battleFeesUsd, "Battle Platform Fees");
-      dailyRevenue.addUSDValue(battleFeesUsd, "Battle Platform Fees");
-      dailyUserFees.addUSDValue(battleFeesUsd, "Battle Platform Fees");
     }
   }
 
@@ -123,63 +114,45 @@ const fetch = async (options: FetchOptions) => {
     const payoutUsd = toUsd(toBigInt(price));
     if (payoutUsd <= 0) continue;
     dailyFees.addUSDValue(-payoutUsd, "Pack Buyback Payouts");
-    dailyRevenue.addUSDValue(-payoutUsd, "Pack Buyback Payouts");
   }
 
   return {
     dailyVolume,
     dailyFees,
-    dailyRevenue,
-    dailyUserFees,
-    dailyProtocolRevenue: dailyRevenue,
+    dailyUserFees: dailyFees,
+    dailyRevenue: dailyFees,
+    dailyProtocolRevenue: dailyFees,
     dailySupplySideRevenue,
   };
 };
 
 const methodology = {
   Volume:
-    "Gross pack purchase volume, marketplace sale volume, and battle platform fees on Avalanche.",
+    "Gross pack purchase volume and marketplace sale volume.",
   Fees:
+    "Net fees from paid gacha pack sales, battle platform fees, and marketplace fees, minus instant pack buyback payouts.",
+  UserFees:
     "Net fees from paid gacha pack sales, battle platform fees, and marketplace fees, minus instant pack buyback payouts.",
   Revenue:
     "Protocol revenue from paid gacha pack sales, battle platform fees, and marketplace fees, net of instant pack buyback payouts.",
-  UserFees:
-    "Gross user-paid fees from paid pack sales, battle platform fees, and marketplace fees before buyback payouts.",
   ProtocolRevenue:
-    "Same as Revenue: protocol-retained revenue after instant buyback payouts.",
+    "Protocol revenue from paid gacha pack sales, battle platform fees, and marketplace fees, net of instant pack buyback payouts.",
   SupplySideRevenue:
     "No supply-side revenue is reported by this adapter.",
 };
 
+const commonBreakdown = {
+  "Gacha Pack Sales": "Paid pack purchases emitted by the GachaPacks contract. Coupon redemptions are excluded.",
+  "Battle Platform Fees": "Per-player battle platform fee, counted when the second player joins and the battle buys packs.",
+  "Marketplace Fees": "Platform fee from marketplace sales and accepted bids.",
+  "Pack Buyback Payouts": "Instant buyback payouts paid to users, subtracted from fees and revenue.",
+};
+
 const breakdownMethodology = {
-  Volume: {
-    "Gacha Pack Sales": "Paid pack purchase notional volume from the GachaPacks contract. Coupon redemptions are excluded.",
-    "Marketplace Sales": "Gross marketplace sale notional volume from MarketplaceEscrow Sale events.",
-    "Battle Platform Fees": "Battle platform fees paid when the second player joins and starts a battle.",
-  },
-  Fees: {
-    "Gacha Pack Sales": "Paid pack purchases emitted by the GachaPacks contract. Coupon redemptions are excluded.",
-    "Battle Platform Fees": "Per-player battle platform fee, counted when the second player joins and the battle buys packs.",
-    "Marketplace Fees": "Platform fee from marketplace sales and accepted bids.",
-    "Pack Buyback Payouts": "Instant buyback payouts paid to users, subtracted from fees and revenue.",
-  },
-  Revenue: {
-    "Gacha Pack Sales": "Protocol-recognized revenue from paid pack purchases.",
-    "Battle Platform Fees": "Protocol-recognized revenue from battle platform fees.",
-    "Marketplace Fees": "Protocol-recognized marketplace fee revenue.",
-    "Pack Buyback Payouts": "Instant buyback payouts netted against protocol revenue.",
-  },
-  UserFees: {
-    "Gacha Pack Sales": "Gross paid pack purchase fees paid by users before buyback netting.",
-    "Battle Platform Fees": "Gross battle platform fees paid by both players before buyback netting.",
-    "Marketplace Fees": "Gross marketplace platform fees paid by buyers or sellers before buyback netting.",
-  },
-  ProtocolRevenue: {
-    "Gacha Pack Sales": "Protocol-retained revenue from paid pack purchases.",
-    "Battle Platform Fees": "Protocol-retained revenue from battle platform fees.",
-    "Marketplace Fees": "Protocol-retained marketplace fee revenue.",
-    "Pack Buyback Payouts": "Instant buyback payouts netted against protocol revenue.",
-  },
+  Fees: commonBreakdown,
+  Revenue: commonBreakdown,
+  UserFees: commonBreakdown,
+  ProtocolRevenue: commonBreakdown,
 };
 
 const adapter: SimpleAdapter = {

--- a/fees/yourgrails/index.ts
+++ b/fees/yourgrails/index.ts
@@ -1,0 +1,162 @@
+import { FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+
+const GACHA_PACKS = "0xA26De0Ed1c24f54Cf316C9CDb8fEFF1ea68E5AB4";
+const MARKETPLACE_ESCROW = "0x90A40f2befe2CE0AA10e951dbc47e2B6837Cfd9d";
+const BUYBACK = "0x8D8669ADE9D390A6dD03D384983A5bb334369dAa";
+const PACK_BATTLE = "0x7cC8173A9eD2dF8BAb306bbF28eDa301032D3936";
+
+const PAYMENT_TYPE_PAID = 0;
+
+const abis = {
+  packPurchased:
+    "event PackPurchased(uint256 indexed purchaseId, address indexed buyer, uint256 packId, uint256 commitBlock, uint256 packNftTokenId)",
+  purchasePaymentType: "function purchasePaymentType(uint256 purchaseId) view returns (uint8)",
+  packs: "function packs(uint256 packId) view returns (uint256 price, bool active, uint256 cardsPerPack)",
+  sale: "event Sale(uint256 indexed listingId, address indexed buyer, uint256 price, uint256 fee)",
+  buybackExecuted: "event BuybackExecuted(uint256 indexed tokenId, address indexed seller, uint256 price)",
+  battleJoined: "event BattleJoined(uint256 indexed battleId, address indexed player2)",
+  getBattle:
+    "function getBattle(uint256 battleId) view returns (address player1, address player2, uint256 packId, uint256 packPrice, uint256 entryFee, uint256 platformFee, uint8 status, uint256 revealDeadline, bool player1Revealed, bool player2Revealed, address winner, uint256 player1Value, uint256 player2Value, uint256 createdAt, uint256 expiresAt)",
+};
+
+const toBigInt = (value: any) => BigInt(value?.toString?.() ?? value ?? 0);
+const key = (value: any) => value?.toString?.() ?? String(value);
+
+const fetch = async (options: FetchOptions) => {
+  const dailyVolume = options.createBalances();
+  const dailyFees = options.createBalances();
+  const dailyRevenue = options.createBalances();
+
+  const packPurchaseLogs = await options.getLogs({
+    target: GACHA_PACKS,
+    eventAbi: abis.packPurchased,
+  });
+
+  if (packPurchaseLogs.length > 0) {
+    const paymentTypes = await options.api.multiCall({
+      target: GACHA_PACKS,
+      abi: abis.purchasePaymentType,
+      calls: packPurchaseLogs.map(({ purchaseId }: any) => purchaseId),
+      permitFailure: true,
+    });
+
+    const paidPackIds = packPurchaseLogs
+      .filter((_: any, index: number) => Number(paymentTypes[index]) === PAYMENT_TYPE_PAID)
+      .map(({ packId }: any) => packId);
+    const uniquePackIds = [...new Map(paidPackIds.map((packId: any) => [key(packId), packId])).values()];
+
+    const packConfigs = uniquePackIds.length > 0
+      ? await options.api.multiCall({
+        target: GACHA_PACKS,
+        abi: abis.packs,
+        calls: uniquePackIds,
+        permitFailure: true,
+      })
+      : [];
+    const priceByPackId = new Map<string, bigint>();
+    uniquePackIds.forEach((packId: any, index: number) => {
+      const pack = packConfigs[index];
+      if (!pack) return;
+      priceByPackId.set(key(packId), toBigInt(pack.price ?? pack[0]));
+    });
+
+    for (const packId of paidPackIds) {
+      const price = priceByPackId.get(key(packId));
+      if (!price || price === 0n) continue;
+      dailyVolume.addUSDValue(Number(price) / 1e6, "Gacha Pack Sales");
+      dailyFees.addUSDValue(Number(price) / 1e6, "Gacha Pack Sales");
+      dailyRevenue.addUSDValue(Number(price) / 1e6, "Gacha Pack Sales");
+    }
+  }
+
+  const marketplaceSales = await options.getLogs({
+    target: MARKETPLACE_ESCROW,
+    eventAbi: abis.sale,
+  });
+  for (const { price, fee }: any of marketplaceSales) {
+    const salePriceUsd = Number(toBigInt(price)) / 1e6;
+    const feeUsd = Number(toBigInt(fee)) / 1e6;
+    if (salePriceUsd > 0) dailyVolume.addUSDValue(salePriceUsd, "Marketplace Sales");
+    if (feeUsd > 0) {
+      dailyFees.addUSDValue(feeUsd, "Marketplace Fees");
+      dailyRevenue.addUSDValue(feeUsd, "Marketplace Fees");
+    }
+  }
+
+  const battleJoinedLogs = await options.getLogs({
+    target: PACK_BATTLE,
+    eventAbi: abis.battleJoined,
+  });
+  if (battleJoinedLogs.length > 0) {
+    const battles = await options.api.multiCall({
+      target: PACK_BATTLE,
+      abi: abis.getBattle,
+      calls: battleJoinedLogs.map(({ battleId }: any) => battleId),
+      permitFailure: true,
+    });
+    for (const battle of battles) {
+      if (!battle) continue;
+      const platformFee = toBigInt(battle.platformFee ?? battle[5]);
+      const battleFeesUsd = Number(platformFee * 2n) / 1e6;
+      if (battleFeesUsd <= 0) continue;
+      dailyVolume.addUSDValue(battleFeesUsd, "Battle Platform Fees");
+      dailyFees.addUSDValue(battleFeesUsd, "Battle Platform Fees");
+      dailyRevenue.addUSDValue(battleFeesUsd, "Battle Platform Fees");
+    }
+  }
+
+  const buybackLogs = await options.getLogs({
+    target: BUYBACK,
+    eventAbi: abis.buybackExecuted,
+  });
+  for (const { price }: any of buybackLogs) {
+    const payoutUsd = Number(toBigInt(price)) / 1e6;
+    if (payoutUsd <= 0) continue;
+    dailyFees.addUSDValue(-payoutUsd, "Pack Buyback Payouts");
+    dailyRevenue.addUSDValue(-payoutUsd, "Pack Buyback Payouts");
+  }
+
+  return {
+    dailyVolume,
+    dailyFees,
+    dailyRevenue,
+    dailyUserFees: dailyFees,
+    dailyProtocolRevenue: dailyRevenue,
+  };
+};
+
+const methodology = {
+  Volume:
+    "Gross pack purchase volume, marketplace sale volume, and battle platform fees on Avalanche.",
+  Fees:
+    "Net fees from paid gacha pack sales, battle platform fees, and marketplace fees, minus instant pack buyback payouts.",
+  Revenue:
+    "Protocol revenue from paid gacha pack sales, battle platform fees, and marketplace fees, net of instant pack buyback payouts.",
+  UserFees:
+    "Same as Fees: paid pack sales, battle platform fees, and marketplace fees, net of instant buyback payouts.",
+  ProtocolRevenue:
+    "Same as Revenue: protocol-retained revenue after instant buyback payouts.",
+};
+
+const breakdownMethodology = {
+  Fees: {
+    "Gacha Pack Sales": "Paid pack purchases emitted by the GachaPacks contract. Coupon redemptions are excluded.",
+    "Battle Platform Fees": "Per-player battle platform fee, counted when the second player joins and the battle buys packs.",
+    "Marketplace Fees": "Platform fee from marketplace sales and accepted bids.",
+    "Pack Buyback Payouts": "Instant buyback payouts paid to users, subtracted from fees and revenue.",
+  },
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  pullHourly: true,
+  chains: [CHAIN.AVAX],
+  start: "2026-06-08",
+  fetch,
+  methodology,
+  breakdownMethodology,
+  allowNegativeValue: true,
+};
+
+export default adapter;

--- a/fees/yourgrails/index.ts
+++ b/fees/yourgrails/index.ts
@@ -7,6 +7,8 @@ const BUYBACK = "0x8D8669ADE9D390A6dD03D384983A5bb334369dAa";
 const PACK_BATTLE = "0x7cC8173A9eD2dF8BAb306bbF28eDa301032D3936";
 
 const PAYMENT_TYPE_PAID = 0;
+const USDC_DECIMALS = 1e6; // YourGrails accounting events are denominated in 6-decimal USDC.
+const BATTLE_PLAYER_COUNT = 2n; // platformFee is per player; BattleJoined means both players paid.
 
 const abis = {
   packPurchased:
@@ -22,11 +24,14 @@ const abis = {
 
 const toBigInt = (value: any) => BigInt(value?.toString?.() ?? value ?? 0);
 const key = (value: any) => value?.toString?.() ?? String(value);
+const toUsd = (value: bigint) => Number(value) / USDC_DECIMALS;
 
 const fetch = async (options: FetchOptions) => {
   const dailyVolume = options.createBalances();
   const dailyFees = options.createBalances();
   const dailyRevenue = options.createBalances();
+  const dailyUserFees = options.createBalances();
+  const dailySupplySideRevenue = options.createBalances();
 
   const packPurchaseLogs = await options.getLogs({
     target: GACHA_PACKS,
@@ -64,9 +69,11 @@ const fetch = async (options: FetchOptions) => {
     for (const packId of paidPackIds) {
       const price = priceByPackId.get(key(packId));
       if (!price || price === 0n) continue;
-      dailyVolume.addUSDValue(Number(price) / 1e6, "Gacha Pack Sales");
-      dailyFees.addUSDValue(Number(price) / 1e6, "Gacha Pack Sales");
-      dailyRevenue.addUSDValue(Number(price) / 1e6, "Gacha Pack Sales");
+      const packPriceUsd = toUsd(price);
+      dailyVolume.addUSDValue(packPriceUsd, "Gacha Pack Sales");
+      dailyFees.addUSDValue(packPriceUsd, "Gacha Pack Sales");
+      dailyRevenue.addUSDValue(packPriceUsd, "Gacha Pack Sales");
+      dailyUserFees.addUSDValue(packPriceUsd, "Gacha Pack Sales");
     }
   }
 
@@ -74,13 +81,14 @@ const fetch = async (options: FetchOptions) => {
     target: MARKETPLACE_ESCROW,
     eventAbi: abis.sale,
   });
-  for (const { price, fee }: any of marketplaceSales) {
-    const salePriceUsd = Number(toBigInt(price)) / 1e6;
-    const feeUsd = Number(toBigInt(fee)) / 1e6;
+  for (const { price, fee } of marketplaceSales as any[]) {
+    const salePriceUsd = toUsd(toBigInt(price));
+    const feeUsd = toUsd(toBigInt(fee));
     if (salePriceUsd > 0) dailyVolume.addUSDValue(salePriceUsd, "Marketplace Sales");
     if (feeUsd > 0) {
       dailyFees.addUSDValue(feeUsd, "Marketplace Fees");
       dailyRevenue.addUSDValue(feeUsd, "Marketplace Fees");
+      dailyUserFees.addUSDValue(feeUsd, "Marketplace Fees");
     }
   }
 
@@ -98,11 +106,12 @@ const fetch = async (options: FetchOptions) => {
     for (const battle of battles) {
       if (!battle) continue;
       const platformFee = toBigInt(battle.platformFee ?? battle[5]);
-      const battleFeesUsd = Number(platformFee * 2n) / 1e6;
+      const battleFeesUsd = toUsd(platformFee * BATTLE_PLAYER_COUNT);
       if (battleFeesUsd <= 0) continue;
       dailyVolume.addUSDValue(battleFeesUsd, "Battle Platform Fees");
       dailyFees.addUSDValue(battleFeesUsd, "Battle Platform Fees");
       dailyRevenue.addUSDValue(battleFeesUsd, "Battle Platform Fees");
+      dailyUserFees.addUSDValue(battleFeesUsd, "Battle Platform Fees");
     }
   }
 
@@ -110,8 +119,8 @@ const fetch = async (options: FetchOptions) => {
     target: BUYBACK,
     eventAbi: abis.buybackExecuted,
   });
-  for (const { price }: any of buybackLogs) {
-    const payoutUsd = Number(toBigInt(price)) / 1e6;
+  for (const { price } of buybackLogs as any[]) {
+    const payoutUsd = toUsd(toBigInt(price));
     if (payoutUsd <= 0) continue;
     dailyFees.addUSDValue(-payoutUsd, "Pack Buyback Payouts");
     dailyRevenue.addUSDValue(-payoutUsd, "Pack Buyback Payouts");
@@ -121,8 +130,9 @@ const fetch = async (options: FetchOptions) => {
     dailyVolume,
     dailyFees,
     dailyRevenue,
-    dailyUserFees: dailyFees,
+    dailyUserFees,
     dailyProtocolRevenue: dailyRevenue,
+    dailySupplySideRevenue,
   };
 };
 
@@ -134,17 +144,41 @@ const methodology = {
   Revenue:
     "Protocol revenue from paid gacha pack sales, battle platform fees, and marketplace fees, net of instant pack buyback payouts.",
   UserFees:
-    "Same as Fees: paid pack sales, battle platform fees, and marketplace fees, net of instant buyback payouts.",
+    "Gross user-paid fees from paid pack sales, battle platform fees, and marketplace fees before buyback payouts.",
   ProtocolRevenue:
     "Same as Revenue: protocol-retained revenue after instant buyback payouts.",
+  SupplySideRevenue:
+    "No supply-side revenue is reported by this adapter.",
 };
 
 const breakdownMethodology = {
+  Volume: {
+    "Gacha Pack Sales": "Paid pack purchase notional volume from the GachaPacks contract. Coupon redemptions are excluded.",
+    "Marketplace Sales": "Gross marketplace sale notional volume from MarketplaceEscrow Sale events.",
+    "Battle Platform Fees": "Battle platform fees paid when the second player joins and starts a battle.",
+  },
   Fees: {
     "Gacha Pack Sales": "Paid pack purchases emitted by the GachaPacks contract. Coupon redemptions are excluded.",
     "Battle Platform Fees": "Per-player battle platform fee, counted when the second player joins and the battle buys packs.",
     "Marketplace Fees": "Platform fee from marketplace sales and accepted bids.",
     "Pack Buyback Payouts": "Instant buyback payouts paid to users, subtracted from fees and revenue.",
+  },
+  Revenue: {
+    "Gacha Pack Sales": "Protocol-recognized revenue from paid pack purchases.",
+    "Battle Platform Fees": "Protocol-recognized revenue from battle platform fees.",
+    "Marketplace Fees": "Protocol-recognized marketplace fee revenue.",
+    "Pack Buyback Payouts": "Instant buyback payouts netted against protocol revenue.",
+  },
+  UserFees: {
+    "Gacha Pack Sales": "Gross paid pack purchase fees paid by users before buyback netting.",
+    "Battle Platform Fees": "Gross battle platform fees paid by both players before buyback netting.",
+    "Marketplace Fees": "Gross marketplace platform fees paid by buyers or sellers before buyback netting.",
+  },
+  ProtocolRevenue: {
+    "Gacha Pack Sales": "Protocol-retained revenue from paid pack purchases.",
+    "Battle Platform Fees": "Protocol-retained revenue from battle platform fees.",
+    "Marketplace Fees": "Protocol-retained marketplace fee revenue.",
+    "Pack Buyback Payouts": "Instant buyback payouts netted against protocol revenue.",
   },
 };
 
@@ -156,6 +190,7 @@ const adapter: SimpleAdapter = {
   fetch,
   methodology,
   breakdownMethodology,
+  // Buyback payouts can exceed gross sales in a window, so net fees/revenue may be negative.
   allowNegativeValue: true,
 };
 


### PR DESCRIPTION
Adds a fees/revenue/volume adapter for YourGrails on Avalanche.

The adapter reads YourGrails mainnet contract events directly from Avalanche:
- `GachaPacks.PackPurchased`, excluding coupon redemptions via `purchasePaymentType`
- `MarketplaceEscrow.Sale`
- `PackBattleV3.BattleJoined` + `getBattle` for battle platform fees
- `Buyback.BuybackExecuted` as negative fee/revenue adjustments

Tested with:

```bash
npm test fees yourgrails
npm run ts-check
```

24h test output on the current window produced AVAX daily volume, fees, revenue, user fees, protocol revenue, and fee breakdown without errors.

---

##### Name (to be shown on DefiLlama):
YourGrails

##### Twitter Link:
https://x.com/yourgrails

##### List of audit links if any:
None yet

##### Website Link:
https://yourgrails.com

##### Logo (High resolution, will be shown with rounded borders):
https://yourgrails.com/icon.jpg

##### Current TVL:
N/A for this dimensions adapter. This PR reports volume, fees, and revenue only.

##### Treasury Addresses (if the protocol has treasury)
Primary protocol contracts used by this adapter:
- GachaPacks: `0xA26De0Ed1c24f54Cf316C9CDb8fEFF1ea68E5AB4`
- MarketplaceEscrow: `0x90A40f2befe2CE0AA10e951dbc47e2B6837Cfd9d`
- Buyback: `0x8D8669ADE9D390A6dD03D384983A5bb334369dAa`
- PackBattleV3: `0x7cC8173A9eD2dF8BAb306bbF28eDa301032D3936`

##### Chain:
Avalanche

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed):


##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed):


##### Short Description (to be shown on DefiLlama):
YourGrails is an on-chain physical TCG platform for graded-card pack openings, pack battles, marketplace sales, and instant buybacks.

##### Token address and ticker if any:
None

##### Category (full list at https://defillama.com/categories) *Please choose only one:
Physical TCG

##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.):
Chainlink VRF for randomness.

##### Implementation Details: Briefly describe how the oracle is integrated into your project:
YourGrails uses Chainlink VRF for verified random pack and battle reveals. This dimensions adapter does not use oracle pricing; it computes metrics from on-chain USDC-denominated events.

##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage:
Verified Avalanche contract addresses are listed above.

##### forkedFrom (Does your project originate from another project):
No

##### methodology (what is being counted as tvl, how is tvl being calculated):
This is a dimensions adapter, not a TVL adapter. Volume counts gross paid pack purchase volume, marketplace sale volume, and battle platform fees. Fees/revenue count paid pack sales, battle platform fees, and marketplace fees, minus instant buyback payouts. Coupon redemptions are excluded.

##### Github org/user (Optional, if your code is open source, we can track activity):
https://github.com/Polypup

##### Does this project have a referral program?
Yes

