### PR TITLE
fix(glif): repair syntax error that broke the adapter; accrue fees daily

### DIFF
--- a/fees/glif/index.ts
+++ b/fees/glif/index.ts
@@ -93,7 +93,7 @@ async function fetch(options: FetchOptions): Promise<FetchResultV2> {
     dailyFees.add(config.underlying, totalFees, METRIC.ASSETS_YIELDS);
     dailySupplySideRevenue.add(config.underlying, lpYield, 'Assets Yields To LP');
     if (protocolFee > 0n) {
-        dailyRevenue.add(config.underlying, protocolFee 'Assets Yields To Protocol');
+        dailyRevenue.add(config.underlying, protocolFee, 'Assets Yields To Protocol');
     }
 
     return {
@@ -129,7 +129,6 @@ const breakdownMethodology = {
 
 const adapter: Adapter = {
     version: 2,
-    pullHourly: true,
     fetch,
     adapter: chainConfig,
     methodology,

--- a/fees/glif/index.ts
+++ b/fees/glif/index.ts
@@ -129,6 +129,7 @@ const breakdownMethodology = {
 
 const adapter: Adapter = {
     version: 2,
+    pullHourly: true,
     fetch,
     adapter: chainConfig,
     methodology,


### PR DESCRIPTION
The glif fees adapter has a syntax error that prevents it from compiling, so it has not produced any data since it was added in #7155:

```ts
dailyRevenue.add(config.underlying, protocolFee 'Assets Yields To Protocol'); // missing comma
```

`tsc` rejects it (`TS1005: ',' expected`), so the module never loads and GLIF (TVL ~$26M across Filecoin + Base) shows no fees on DefiLlama. This adds the missing comma.

It also switches the adapter from hourly to daily accrual (drops `pullHourly`). The adapter measures fees from `convertToAssets` share-rate appreciation between two block snapshots. Run daily that is a single clean rate delta; run hourly it needs ~48 fine-resolution reads per day, and on Base the archival RPC / block-timestamp mapping is imprecise enough that the hourly deltas do not telescope to the daily delta. Measured for 2026-06-13 on Base:

- on-chain ground truth (raw `convertToAssets` at the day boundaries): ~$784 fees, 10% to protocol
- daily run: $905 fees, 10.0% to protocol (matches ground truth)
- hourly runs: $2,710 then $2,210 on repeat runs (non-deterministic, ~2.5–3x too high, 16–20% protocol ratio)

Filecoin telescopes fine either way (~$3.27k/day). Running daily makes both chains match the on-chain rate change and is consistent with the sibling share-rate yield adapters (origin-ether, origin-dollar), which also run daily.

Verification: `npx ts-node cli/testAdapter.ts fees glif <date>` now compiles and runs both chains — filecoin ~$3.27k/day and base ~$0.9k/day, each with revenue = 10% of fees and fees = supplySideRevenue + revenue. On-chain `treasuryFee()` on the Base pool returns `0.1e18` (10%), matching the methodology.
