### PR TITLE
feat: track aelf chain fees and users

### DIFF
--- a/active-users/aelf.ts
+++ b/active-users/aelf.ts
@@ -1,0 +1,33 @@
+import { FetchOptions, ProtocolType, SimpleAdapter } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+import fetchURL from "../utils/fetchURL";
+
+const DAILY_ACTIVE_ADDRESSES_URL = "https://aelfscan.io/api/app/statistics/dailyActiveAddresses";
+const DAILY_TRANSACTIONS_URL = "https://aelfscan.io/api/app/statistics/dailyTransactions";
+
+const fetch = async (options: FetchOptions) => {
+  const [activeResponse, txResponse] = await Promise.all([
+    fetchURL(DAILY_ACTIVE_ADDRESSES_URL),
+    fetchURL(DAILY_TRANSACTIONS_URL),
+  ]);
+
+  const activeRow = activeResponse.data.list.find((item: any) => item.dateStr === options.dateString);
+  const txRow = txResponse.data.list.find((item: any) => item.dateStr === options.dateString);
+
+  if (!activeRow || !txRow) throw new Error(`No aelf user stats found for ${options.dateString}`);
+
+  return {
+    dailyActiveUsers: activeRow.mergeAddressCount,
+    dailyTransactionsCount: txRow.mergeTransactionCount,
+  };
+};
+
+const adapter: SimpleAdapter = {
+  version: 1,
+  fetch,
+  chains: [CHAIN.AELF],
+  protocolType: ProtocolType.CHAIN,
+  start: "2020-12-10",
+};
+
+export default adapter;

--- a/fees/aelf.ts
+++ b/fees/aelf.ts
@@ -1,0 +1,55 @@
+import { Adapter, FetchOptions, ProtocolType } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+import fetchURL from "../utils/fetchURL";
+
+// Source: https://docs.aelf.io/en/latest/reference/acs/acs1.html
+// 10% of the fees are destroyed.
+// 90% goes to the dividend pool on the main chain and to the FeeReceiver on the side chain.
+// If the SideChain has no FeeReceiver set, ALL fees are burned.
+const MAIN_CHAIN_BURN_RATIO = 0.1;
+const FEE_URL = "https://aelfscan.io/api/app/statistics/dailyTxFee";
+const BURNT_URL = "https://aelfscan.io/api/app/statistics/dailyTotalBurnt";
+
+const fetch = async (options: FetchOptions) => {
+  const dailyFees = options.createBalances();
+  const dailyRevenue = options.createBalances();
+
+  const [feeResponse, burntResponse] = await Promise.all([
+    fetchURL(FEE_URL),
+    fetchURL(BURNT_URL),
+  ]);
+
+  const feeRow = feeResponse.data.list.find((item: any) => item.dateStr === options.dateString);
+  const burntRow = burntResponse.data.list.find((item: any) => item.dateStr === options.dateString);
+  if (!feeRow || !burntRow) throw new Error(`No aelf fee/burnt data found for ${options.dateString}`);
+
+  const mainChainBurn = Number(feeRow.mainChainTotalFeeElf) * MAIN_CHAIN_BURN_RATIO;
+  const sideChainBurn = Number(burntRow.sideChainBurnt);
+
+  dailyFees.addCGToken("aelf", Number(feeRow.mergeTotalFeeElf), "Transaction Fees");
+  dailyRevenue.addCGToken("aelf", mainChainBurn + sideChainBurn, "Burned Fees");
+
+  return { dailyFees, dailyRevenue };
+};
+
+const adapter: Adapter = {
+  version: 1,
+  fetch,
+  chains: [CHAIN.AELF],
+  protocolType: ProtocolType.CHAIN,
+  start: "2020-12-10",
+  methodology: {
+    Fees: "Transaction fees paid by users on aelf Main chain and Side chain.",
+    Revenue: "Transaction fees burned by the protocol.",
+  },
+  breakdownMethodology: {
+    Fees: {
+      "Transaction Fees": "Total transaction fees paid by users across aelf Main chain and Side chain.",
+    },
+    Revenue: {
+      "Burned Fees": "Portion of transaction fees burned by the protocol on both chains.",
+    },
+  },
+};
+
+export default adapter;

--- a/helpers/chains.ts
+++ b/helpers/chains.ts
@@ -384,4 +384,5 @@ export enum CHAIN {
   BFC = "bfc",
   B3 = "b3",
   DEGEN = "degen",
+  AELF = "aelf",
 }

--- a/new-users/aelf.ts
+++ b/new-users/aelf.ts
@@ -1,0 +1,26 @@
+import { FetchOptions, ProtocolType, SimpleAdapter } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+import fetchURL from "../utils/fetchURL";
+
+const STATS_URL = "https://aelfscan.io/api/app/statistics/uniqueAddresses";
+
+const fetch = async (options: FetchOptions) => {
+  const response = await fetchURL(STATS_URL);
+  const row = response.data.list.find((item: any) => item.dateStr === options.dateString);
+
+  if (!row) throw new Error(`No aelf new user stats found for ${options.dateString}`);
+
+  return {
+    dailyNewUsers: row.mergeAddressCount,
+  };
+};
+
+const adapter: SimpleAdapter = {
+  version: 1,
+  fetch,
+  chains: [CHAIN.AELF],
+  protocolType: ProtocolType.CHAIN,
+  start: "2020-12-10",
+};
+
+export default adapter;


### PR DESCRIPTION
 ## Summary
   - Adds fees, active-users and new-users adapters for the aelf chain
  (MainChain AELF + SideChain tDVV) using the aelfscan.io statistics API.
   - Fees = total tx fees across both chains. Revenue = ACS1 fee burn only:
  mainChainTotalFeeElf × 10% + sideChainBurnt (raw mainChainBurnt is
  skipped because it also includes TokenConverter and ERC-20 swap
  retirement burns that aren't user-paid fees).
   - Adds CHAIN.AELF to helpers/chains.ts.
   - https://defillama.com/chain/aelf
