### PR TITLE
Add Temple Lightspeed DEX volume adapter

### DIFF
--- a/dexs/temple/index.ts
+++ b/dexs/temple/index.ts
@@ -1,0 +1,37 @@
+import { FetchOptions, FetchResultVolume, SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import fetchURL from "../../utils/fetchURL";
+
+const TICKERS_URL = "https://api.templedigitalgroup.com/api/exchange/tickers";
+
+type TempleTicker = {
+  ticker_id: string;
+  base_currency: string;
+  target_currency: string;
+  target_volume: string;
+};
+
+const fetch = async (_options: FetchOptions): Promise<FetchResultVolume> => {
+  const tickers: TempleTicker[] = await fetchURL(TICKERS_URL);
+
+  const dailyVolume = tickers.reduce((sum, ticker) => {
+    return sum + Number(ticker.target_volume || 0);
+  }, 0);
+
+  return { dailyVolume };
+};
+
+const methodology = {
+  Volume:
+    "24h spot orderbook volume for all mainnet-enabled Temple Lightspeed markets, fetched from Temple's public exchange-listing API. The adapter sums each ticker's quote-side `target_volume`; current production markets quote in USDA, treated as USD-pegged volume.",
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  fetch,
+  chains: [CHAIN.CANTON],
+  runAtCurrTime: true,
+  methodology,
+};
+
+export default adapter;

--- a/dexs/temple/index.ts
+++ b/dexs/temple/index.ts
@@ -1,4 +1,4 @@
-import { FetchOptions, FetchResultVolume, SimpleAdapter } from "../../adapters/types";
+import { FetchResultVolume, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 import fetchURL from "../../utils/fetchURL";
 
@@ -11,7 +11,7 @@ type TempleTicker = {
   target_volume: string;
 };
 
-const fetch = async (_options: FetchOptions): Promise<FetchResultVolume> => {
+const fetch = async (): Promise<FetchResultVolume> => {
   const tickers: TempleTicker[] = await fetchURL(TICKERS_URL);
 
   const dailyVolume = tickers.reduce((sum, ticker) => {
@@ -27,7 +27,7 @@ const methodology = {
 };
 
 const adapter: SimpleAdapter = {
-  version: 2,
+  version: 1,
   fetch,
   chains: [CHAIN.CANTON],
   runAtCurrTime: true,

--- a/dexs/temple/index.ts
+++ b/dexs/temple/index.ts
@@ -31,7 +31,7 @@ const methodology = {
 };
 
 const adapter: SimpleAdapter = {
-  version: 1,
+  version: 2,
   fetch,
   chains: [CHAIN.CANTON],
   runAtCurrTime: true,

--- a/dexs/temple/index.ts
+++ b/dexs/temple/index.ts
@@ -1,4 +1,4 @@
-import { FetchResultVolume, SimpleAdapter } from "../../adapters/types";
+import { FetchOptions, FetchResultVolume, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 import fetchURL from "../../utils/fetchURL";
 
@@ -11,11 +11,15 @@ type TempleTicker = {
   target_volume: string;
 };
 
-const fetch = async (): Promise<FetchResultVolume> => {
+const fetch = async (_options: FetchOptions): Promise<FetchResultVolume> => {
   const tickers: TempleTicker[] = await fetchURL(TICKERS_URL);
 
   const dailyVolume = tickers.reduce((sum, ticker) => {
-    return sum + Number(ticker.target_volume || 0);
+    const volume = Number(ticker.target_volume);
+    if (!Number.isFinite(volume))
+      throw new Error(`Invalid target_volume for ticker ${ticker.ticker_id}: ${ticker.target_volume}`);
+
+    return sum + volume;
   }, 0);
 
   return { dailyVolume };


### PR DESCRIPTION
## Summary

Adds a DeFiLlama dimension adapter for Temple Lightspeed spot volume.

This is a dimension-adapters PR for volume reporting. The paired TVL/new-listing PR is:

https://github.com/DefiLlama/DefiLlama-Adapters/pull/19722

## Methodology

The adapter fetches Temple's public exchange-listing tickers from:

`https://api.templedigitalgroup.com/api/exchange/tickers`

It sums each listed market's quote-side `target_volume`, which is Temple's rolling 24h target/quote volume. Current production markets quote in USDA, treated as USD-pegged volume.

The adapter is marked `runAtCurrTime: true` because the public exchange-listing endpoint exposes the current rolling 24h window and is not used for historical backfills.

## Test

`pnpm test dexs temple`

Output:

```text
CANTON
Daily volume: 2.88 M
```
