### PR TITLE
add stablecoin yield to Sui revenue

### DIFF
--- a/fees/sui.ts
+++ b/fees/sui.ts
@@ -1,7 +1,7 @@
 import { Dependencies, SimpleAdapter, ProtocolType, FetchOptions } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
 import { queryAllium } from "../helpers/allium";
-import { httpGet } from "../utils/fetchURL";
+import fetchURL from "../utils/fetchURL";
 
 // Daily Sui network revenue published by the data team. Keyed by "YYYY-MM-DD",
 // already filtered to non-anomalous rows, starts 2026-01-01 and lags ~3 days.
@@ -32,7 +32,7 @@ const fetch = async (options: FetchOptions) => {
 
   // Yield earned on the reserves backing the USDsui and suiUSDe stablecoins (USD).
   // Available from 2026-01-01 with a ~3-day lag; absent days simply report gas only.
-  const revenueByDate = await httpGet(REVENUE_URL);
+  const revenueByDate = await fetchURL(REVENUE_URL);
   const day = revenueByDate[options.dateString];
   if (day) {
     dailyFees.addUSDValue(day.STABLECOIN_YIELD_REVENUE_USD);
@@ -55,6 +55,9 @@ const methodology = {
   ProtocolRevenue: "Yield earned on the USDsui and suiUSDe reserves, retained by the Sui Foundation",
 }
 
+// Daily (no pullHourly): the stablecoin yield from the revenue JSON is a daily
+// figure and would be overcounted ~24x if fetch ran hourly. Gas totals are a
+// SUM over the full-day window, so daily is exactly as accurate as hourly.
 const adapter: SimpleAdapter = {
   version: 2,
   fetch,

--- a/fees/sui.ts
+++ b/fees/sui.ts
@@ -1,13 +1,18 @@
 import { Dependencies, SimpleAdapter, ProtocolType, FetchOptions } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
 import { queryAllium } from "../helpers/allium";
+import { httpGet } from "../utils/fetchURL";
+
+// Daily Sui network revenue published by the data team. Keyed by "YYYY-MM-DD",
+// already filtered to non-anomalous rows, starts 2026-01-01 and lags ~3 days.
+const REVENUE_URL = 'https://storage.googleapis.com/sui-public-data/sui-revenue.json';
 
 const fetch = async (options: FetchOptions) => {
   const start = new Date(options.fromTimestamp * 1000).toISOString()
   const end = new Date(options.toTimestamp * 1000).toISOString()
 
   const query = `
-    SELECT 
+    SELECT
         sum(gas_fees_mist) as tx_fees,
         sum(gas_non_refundable_storage_fee) as storage_fee_burnt
     FROM ${options.chain}.raw.transaction_blocks
@@ -17,26 +22,41 @@ const fetch = async (options: FetchOptions) => {
   const res = await queryAllium(query);
   const dailyFees = options.createBalances();
   const dailyRevenue = options.createBalances();
+  const dailyHoldersRevenue = options.createBalances();
+  const dailyProtocolRevenue = options.createBalances();
 
+  // On-chain gas, denominated in SUI.
   dailyFees.addCGToken('sui', res[0].tx_fees / 10 ** 9);
   dailyRevenue.addCGToken('sui', res[0].storage_fee_burnt / 10 ** 9);
+  dailyHoldersRevenue.addCGToken('sui', res[0].storage_fee_burnt / 10 ** 9);
+
+  // Yield earned on the reserves backing the USDsui and suiUSDe stablecoins (USD).
+  // Available from 2026-01-01 with a ~3-day lag; absent days simply report gas only.
+  const revenueByDate = await httpGet(REVENUE_URL);
+  const day = revenueByDate[options.dateString];
+  if (day) {
+    dailyFees.addUSDValue(day.STABLECOIN_YIELD_REVENUE_USD);
+    dailyRevenue.addUSDValue(day.STABLECOIN_YIELD_REVENUE_USD);
+    dailyProtocolRevenue.addUSDValue(day.STABLECOIN_YIELD_REVENUE_USD);
+  }
 
   return {
     dailyFees,
     dailyRevenue,
-    dailyHoldersRevenue: dailyRevenue,
+    dailyHoldersRevenue,
+    dailyProtocolRevenue,
   }
 }
 
 const methodology = {
-  Fees: "Transaction fees paid by users for executing transactions on the Sui network",
-  Revenue: "Includes non refundable storage fees that are burnt",
-  HoldersRevenue: "Includes non refundable storage fees that are burnt",
+  Fees: "Transaction fees paid by users on the Sui network, plus yield earned on the reserves backing the USDsui and suiUSDe stablecoins",
+  Revenue: "Non-refundable storage fees, permanently locked in the storage fund (removed from circulation), plus the stablecoin reserve yield retained by the Sui Foundation",
+  HoldersRevenue: "Non-refundable storage fees, permanently locked in the storage fund — removing SUI from circulation (deflationary, benefiting holders)",
+  ProtocolRevenue: "Yield earned on the USDsui and suiUSDe reserves, retained by the Sui Foundation",
 }
 
 const adapter: SimpleAdapter = {
   version: 2,
-  pullHourly: true,
   fetch,
   chains: [CHAIN.SUI],
   dependencies: [Dependencies.ALLIUM],


### PR DESCRIPTION


### TLDR
Updating Revenue and fees per discussed to include yield from USDSui and USDe on Sui. The stablecoins yield goes directly to treasury and will then Sui Foundation will use the stablecoin yield to buy back SUI.

### Implementation details: 
- Fetching daily stablecoin yield JSON from `sui-public-data` bucket
- Add the yield to protocol revenue and revenue if the trigger date matches the JSON file
- Updated description 