### PR TITLE
Sweep n' Flip: add Abstract + Ronin chains

### DIFF
--- a/dexs/sweep-n-flip/index.js
+++ b/dexs/sweep-n-flip/index.js
@@ -64,6 +64,14 @@ const chainConfig = {
     subgraph: 'https://api.goldsky.com/api/public/project_cmoiys0pk3brg01un76ukdj5r/subgraphs/snf-monad/1.0.0/gn',
     start: '2026-03-30'
   },
+  [CHAIN.ABSTRACT]: {
+    subgraph: 'https://api.goldsky.com/api/public/project_cmejhyc7rqen501wed6sxgbn3/subgraphs/snf-abstract/1.0.0/gn',
+    start: '2026-06-15'
+  },
+  [CHAIN.RONIN]: {
+    subgraph: 'https://api.goldsky.com/api/public/project_cmejhyc7rqen501wed6sxgbn3/subgraphs/snf-ronin/1.0.0/gn',
+    start: '2026-06-15'
+  },
 }
 
 // DERIVED fee model (CONFIRMED 2026-06-01) — applied to NFT-pool volume only.


### PR DESCRIPTION
Adds **Abstract (2741)** and **Ronin (2020)** to the existing, already-merged Sweep n' Flip dexs (volume + fees) adapter. Both chains went live on 2026-06-15. No other changes — same `chainConfig` shape and same fee model approved in #7392.

### What changed
Two entries appended to `chainConfig` in `dexs/sweep-n-flip/index.js`, each pointing at the chain's Goldsky subgraph (same SnF v2 schema as the other chains):

| Chain | `CHAIN` key | Subgraph |
| --- | --- | --- |
| Abstract | `CHAIN.ABSTRACT` | `…/snf-abstract/1.0.0/gn` |
| Ronin | `CHAIN.RONIN` | `…/snf-ronin/1.0.0/gn` |

### Local validation
Both subgraph endpoints verified live; the adapter's exact `pairDays { volumeUSD pair { isNFTPool } }` query resolves on both (schema matches; no volume yet → empty set, identical to a quiet day on the other chains). Fee model (2% LP + 2.5% marketplace on NFT-pool volume) unchanged.