### PR TITLE
fix(tristero): add June 18 v3 contract rollover

### DIFF
--- a/helpers/tristero.ts
+++ b/helpers/tristero.ts
@@ -143,8 +143,8 @@ const TRISTERO_MARGIN_CONFIGS: Record<string, TristeroMarginChainConfig> = {
 } as const;
 
 // V3 margin contracts follow Tristero backend addresses.yml rollouts
-// (d10f35b9 / 161a80b0). Older escrows stay active so still-open positions
-// continue to be counted; day overlaps reflect public explorer cutover activity.
+// (d10f35b9 / 161a80b0) and production contract updates. Older escrows stay
+// active so still-open positions continue to be counted.
 const TRISTERO_V3_MARGIN_CONFIGS: Record<string, TristeroV3MarginChainConfig> = {
   [CHAIN.ARBITRUM]: {
     start: '2026-05-21',
@@ -163,6 +163,11 @@ const TRISTERO_V3_MARGIN_CONFIGS: Record<string, TristeroV3MarginChainConfig> = 
         address: '0x25E1c35721F8826B29401ed628D120037891312c',
         vault: '0xB49781E8c39c75f413C1178f395bF68b0BEE8d00',
         start: '2026-06-14',
+      },
+      {
+        address: '0x66b53dBA061715CC52059b466eB64e3bF49F12EB',
+        vault: '0xB49781E8c39c75f413C1178f395bF68b0BEE8d00',
+        start: '2026-06-18',
       },
     ],
   },
@@ -184,6 +189,11 @@ const TRISTERO_V3_MARGIN_CONFIGS: Record<string, TristeroV3MarginChainConfig> = 
         vault: '0xB49781E8c39c75f413C1178f395bF68b0BEE8d00',
         start: '2026-06-15',
       },
+      {
+        address: '0x66b53dBA061715CC52059b466eB64e3bF49F12EB',
+        vault: '0xB49781E8c39c75f413C1178f395bF68b0BEE8d00',
+        start: '2026-06-18',
+      },
     ],
   },
   [CHAIN.ETHEREUM]: {
@@ -198,6 +208,11 @@ const TRISTERO_V3_MARGIN_CONFIGS: Record<string, TristeroV3MarginChainConfig> = 
         address: '0x25E1c35721F8826B29401ed628D120037891312c',
         vault: '0xB49781E8c39c75f413C1178f395bF68b0BEE8d00',
         start: '2026-06-15',
+      },
+      {
+        address: '0x66b53dBA061715CC52059b466eB64e3bF49F12EB',
+        vault: '0xB49781E8c39c75f413C1178f395bF68b0BEE8d00',
+        start: '2026-06-18',
       },
     ],
   },
@@ -239,22 +254,25 @@ export const TRISTERO_DEX_CHAINS: Record<string, { start: string }> = {
 };
 
 // V3 source-side volume is indexed from router.send() calls. The schedule mirrors
-// Tristero backend addresses.yml generations (d10f35b9 / 161a80b0); day overlaps
-// reflect public explorer cutover activity and are safe because each tx has one router.
+// Tristero backend addresses.yml generations and production contract updates;
+// day overlaps reflect public explorer cutovers and are safe because each tx has one router.
 const TRISTERO_V3_ROUTER_CONFIGS: Record<string, TristeroV3RouterConfig[]> = {
   [CHAIN.ARBITRUM]: [
     { start: "2026-05-21", end: "2026-06-09", router: "0x739DfF607F5303a2EB4D2271d11AEC6f642f6480" },
     { start: "2026-06-09", end: "2026-06-15", router: "0xb998aE9B130a04ac1c56f6877daFE8666aDc38b0" },
-    { start: "2026-06-14", router: "0x93DeA893cef33bE999133efa3Dd3f514211F56ba" },
+    { start: "2026-06-14", end: "2026-06-18", router: "0x93DeA893cef33bE999133efa3Dd3f514211F56ba" },
+    { start: "2026-06-18", router: "0x3341F2d46441118e3FB819E5b0166E25cFC4b3A1" },
   ],
   [CHAIN.BASE]: [
     { start: "2026-05-21", end: "2026-06-08", router: "0x739DfF607F5303a2EB4D2271d11AEC6f642f6480" },
     { start: "2026-06-09", end: "2026-06-14", router: "0xb998aE9B130a04ac1c56f6877daFE8666aDc38b0" },
-    { start: "2026-06-15", router: "0x93DeA893cef33bE999133efa3Dd3f514211F56ba" },
+    { start: "2026-06-15", end: "2026-06-18", router: "0x93DeA893cef33bE999133efa3Dd3f514211F56ba" },
+    { start: "2026-06-18", router: "0x3341F2d46441118e3FB819E5b0166E25cFC4b3A1" },
   ],
   [CHAIN.ETHEREUM]: [
     { start: "2026-06-09", end: "2026-06-14", router: "0xb998aE9B130a04ac1c56f6877daFE8666aDc38b0" },
-    { start: "2026-06-15", router: "0x93DeA893cef33bE999133efa3Dd3f514211F56ba" },
+    { start: "2026-06-15", end: "2026-06-18", router: "0x93DeA893cef33bE999133efa3Dd3f514211F56ba" },
+    { start: "2026-06-18", router: "0x3341F2d46441118e3FB819E5b0166E25cFC4b3A1" },
   ],
 };
 
@@ -859,14 +877,8 @@ export async function getOpenTristeroV3MarginPositions(
     permitFailure: true,
   });
 
-  owners.forEach((owner, index) => {
-    if (!normalizeAddress(owner)) {
-      const position = candidates[index];
-      throw new Error(`Unable to read Tristero v3 ownerOf for ${options.chain} position ${position.positionId} at ${position.escrow}`);
-    }
-  });
-
-  return candidates;
+  // Burned v3 position NFTs revert on ownerOf; after log replay they are not open.
+  return candidates.filter((_position, index) => normalizeAddress(owners[index]));
 }
 
 function topicAddress(address: string): string {

--- a/helpers/tristero.ts
+++ b/helpers/tristero.ts
@@ -143,8 +143,8 @@ const TRISTERO_MARGIN_CONFIGS: Record<string, TristeroMarginChainConfig> = {
 } as const;
 
 // V3 margin contracts follow Tristero backend addresses.yml rollouts
-// (d10f35b9 / 161a80b0) and production contract updates. Older escrows stay
-// active so still-open positions continue to be counted.
+// (d10f35b9 / 161a80b0; internal) and production contract updates. Older
+// escrows stay active so still-open positions continue to be counted.
 const TRISTERO_V3_MARGIN_CONFIGS: Record<string, TristeroV3MarginChainConfig> = {
   [CHAIN.ARBITRUM]: {
     start: '2026-05-21',
@@ -164,6 +164,9 @@ const TRISTERO_V3_MARGIN_CONFIGS: Record<string, TristeroV3MarginChainConfig> = 
         vault: '0xB49781E8c39c75f413C1178f395bF68b0BEE8d00',
         start: '2026-06-14',
       },
+      // 2026-06-18 prod rollout; escrow/vault deployed on Arbitrum:
+      // https://arbitrum.blockscout.com/address/0x66b53dBA061715CC52059b466eB64e3bF49F12EB
+      // https://arbitrum.blockscout.com/address/0xB49781E8c39c75f413C1178f395bF68b0BEE8d00
       {
         address: '0x66b53dBA061715CC52059b466eB64e3bF49F12EB',
         vault: '0xB49781E8c39c75f413C1178f395bF68b0BEE8d00',
@@ -189,6 +192,9 @@ const TRISTERO_V3_MARGIN_CONFIGS: Record<string, TristeroV3MarginChainConfig> = 
         vault: '0xB49781E8c39c75f413C1178f395bF68b0BEE8d00',
         start: '2026-06-15',
       },
+      // 2026-06-18 prod rollout; escrow/vault deployed on Base:
+      // https://base.blockscout.com/address/0x66b53dBA061715CC52059b466eB64e3bF49F12EB
+      // https://base.blockscout.com/address/0xB49781E8c39c75f413C1178f395bF68b0BEE8d00
       {
         address: '0x66b53dBA061715CC52059b466eB64e3bF49F12EB',
         vault: '0xB49781E8c39c75f413C1178f395bF68b0BEE8d00',
@@ -209,6 +215,9 @@ const TRISTERO_V3_MARGIN_CONFIGS: Record<string, TristeroV3MarginChainConfig> = 
         vault: '0xB49781E8c39c75f413C1178f395bF68b0BEE8d00',
         start: '2026-06-15',
       },
+      // 2026-06-18 prod rollout; escrow/vault deployed on Ethereum:
+      // https://eth.blockscout.com/address/0x66b53dBA061715CC52059b466eB64e3bF49F12EB
+      // https://eth.blockscout.com/address/0xB49781E8c39c75f413C1178f395bF68b0BEE8d00
       {
         address: '0x66b53dBA061715CC52059b466eB64e3bF49F12EB',
         vault: '0xB49781E8c39c75f413C1178f395bF68b0BEE8d00',
@@ -261,17 +270,23 @@ const TRISTERO_V3_ROUTER_CONFIGS: Record<string, TristeroV3RouterConfig[]> = {
     { start: "2026-05-21", end: "2026-06-09", router: "0x739DfF607F5303a2EB4D2271d11AEC6f642f6480" },
     { start: "2026-06-09", end: "2026-06-15", router: "0xb998aE9B130a04ac1c56f6877daFE8666aDc38b0" },
     { start: "2026-06-14", end: "2026-06-18", router: "0x93DeA893cef33bE999133efa3Dd3f514211F56ba" },
+    // 2026-06-18 prod router; send() activity verified on Arbitrum:
+    // https://arbitrum.blockscout.com/address/0x3341F2d46441118e3FB819E5b0166E25cFC4b3A1
     { start: "2026-06-18", router: "0x3341F2d46441118e3FB819E5b0166E25cFC4b3A1" },
   ],
   [CHAIN.BASE]: [
     { start: "2026-05-21", end: "2026-06-08", router: "0x739DfF607F5303a2EB4D2271d11AEC6f642f6480" },
     { start: "2026-06-09", end: "2026-06-14", router: "0xb998aE9B130a04ac1c56f6877daFE8666aDc38b0" },
     { start: "2026-06-15", end: "2026-06-18", router: "0x93DeA893cef33bE999133efa3Dd3f514211F56ba" },
+    // 2026-06-18 prod router; send() activity verified on Base:
+    // https://base.blockscout.com/address/0x3341F2d46441118e3FB819E5b0166E25cFC4b3A1
     { start: "2026-06-18", router: "0x3341F2d46441118e3FB819E5b0166E25cFC4b3A1" },
   ],
   [CHAIN.ETHEREUM]: [
     { start: "2026-06-09", end: "2026-06-14", router: "0xb998aE9B130a04ac1c56f6877daFE8666aDc38b0" },
     { start: "2026-06-15", end: "2026-06-18", router: "0x93DeA893cef33bE999133efa3Dd3f514211F56ba" },
+    // 2026-06-18 prod router; send() activity verified on Ethereum:
+    // https://eth.blockscout.com/address/0x3341F2d46441118e3FB819E5b0166E25cFC4b3A1
     { start: "2026-06-18", router: "0x3341F2d46441118e3FB819E5b0166E25cFC4b3A1" },
   ],
 };


### PR DESCRIPTION
## Summary

- add the June 18 Tristero v3 router generation on Ethereum, Arbitrum, and Base
- add the June 18 v3 margin escrow generation on Ethereum, Arbitrum, and Base using the existing vault
- keep prior escrows active for still-open positions and overlap router cutover day windows
- treat burned v3 position NFTs as closed during open-interest owner checks

## Context

Follow-up to #7680. Production has moved to:

- Router: `0x3341F2d46441118e3FB819E5b0166E25cFC4b3A1`
- Escrow: `0x66b53dBA061715CC52059b466eB64e3bF49F12EB`
- Vault: `0xB49781E8c39c75f413C1178f395bF68b0BEE8d00`

Executor `0x787473224aB2A6924FED08612A438016ea3efCB3` is not included because the adapter indexes router `send()` txs for source-side volume and escrow/vault state for margin OI/fees.

The new Base escrow has closed positions whose ERC721 position NFTs are burned, so `ownerOf` reverts for those token IDs. After log replay, those positions should not be counted as open OI.

## Validation

- `pnpm ts-check`
- `BASE_RPC=https://mainnet.base.org BASE_ARCHIVAL_RPC=https://mainnet.base.org pnpm test open-interest tristero-margin.ts 2026-06-19T00:00:00Z`
  - Aggregate OI: `557.23`
- `BASE_RPC=https://mainnet.base.org BASE_ARCHIVAL_RPC=https://mainnet.base.org pnpm test fees tristero-margin.ts 2026-06-19T00:00:00Z`
  - Aggregate daily fees: `0.02`
- `pnpm test dexs tristero 2026-06-19T00:00:00Z`
  - Local run stops at `Missing env CLICKHOUSE_CONFIG` before querying volume; exact DEX-volume output needs DefiLlama's ClickHouse env.