### PR TITLE
Add fee adapter for Mintpad NFT Marketplace on Cronos

### DIFF
--- a/fees/mintpad/index.ts
+++ b/fees/mintpad/index.ts
@@ -2,9 +2,11 @@ import { FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 
 // MintpadExchange proxy
+// https://explorer.cronos.com/address/0xdFbE43b2c154B6a790158fa2696cDb32A86Efc78#code
 const contractAddress = "0xdFbE43b2c154B6a790158fa2696cDb32A86Efc78";
 
-// Protocol fee is 200 bps = 2% (set in StrategyStandardSaleForFixedPrice constructor)
+// Protocol fee is 200 bps = 2%, hardcoded in the StrategyStandardSaleForFixedPrice constructor.
+// StrategyStandardSaleForFixedPrice deployment on Cronos: https://explorer.cronos.com/address/0x08Ad0524498C1e0cBd0e9e876031efDc7484D7B4#code
 const PROTOCOL_FEE_BPS = 200;
 
 // All three sale events emit a `price` field representing the full sale price
@@ -79,6 +81,9 @@ const adapter: SimpleAdapter = {
     },
     SupplySideRevenue: {
       'Creator Royalties': 'Royalties paid to NFT creators on secondary sales.',
+    },
+    ProtocolRevenue: {
+      'NFT Sales': 'Protocol fee (2% of volume) retained by Mintpad treasury.',
     },
     Volume: {
       'NFT Sales': 'Executed NFT sale notional from TakerBid, TakerAsk, and MakerMatch events.',

--- a/fees/mintpad/index.ts
+++ b/fees/mintpad/index.ts
@@ -25,14 +25,19 @@ const fetchCronosFees = async (options: FetchOptions) => {
 
   allEvents.forEach((event: any) => {
     // `currency` is the ERC20 used for payment (e.g. WCRO); price is denominated in that token
-    dailyVolume.add(event.currency, event.price);
+    dailyVolume.add(event.currency, event.price, 'NFT Sales');
   });
 
   // Protocol fee is 2% of total volume
   const dailyFees = dailyVolume.clone(PROTOCOL_FEE_BPS / 10000);
+  // Mintpad retains 100% of the protocol fee (no supply-side split modeled)
+  const dailyRevenue = dailyFees.clone(1);
+  const dailyProtocolRevenue = dailyFees.clone(1);
 
   return {
     dailyFees,
+    dailyRevenue,
+    dailyProtocolRevenue,
     dailyVolume,
   };
 };
@@ -48,7 +53,20 @@ const adapter: SimpleAdapter = {
   },
   methodology: {
     Fees: "2% protocol fee charged on all NFT marketplace sales",
+    Revenue: "Protocol-retained portion of marketplace fees",
+    ProtocolRevenue: "Treasury/protocol retained portion of fees",
     Volume: "Total volume of NFT sales on the Mintpad exchange (TakerBid + TakerAsk + MakerMatch events)"
+  },
+  breakdownMethodology: {
+    Fees: {
+      'Marketplace Fees': '2% fee applied to NFT sales volume from matched orders.',
+    },
+    Revenue: {
+      'Marketplace Fees To Treasury': 'Protocol-retained marketplace trading fees.',
+    },
+    Volume: {
+      'NFT Sales': 'Executed NFT sale notional from TakerBid, TakerAsk, and MakerMatch events.',
+    },
   }
 };
 

--- a/fees/mintpad/index.ts
+++ b/fees/mintpad/index.ts
@@ -1,0 +1,55 @@
+import { FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+
+// MintpadExchange proxy
+const contractAddress = "0xdFbE43b2c154B6a790158fa2696cDb32A86Efc78";
+
+// Protocol fee is 200 bps = 2% (set in StrategyStandardSaleForFixedPrice constructor)
+const PROTOCOL_FEE_BPS = 200;
+
+// All three sale events emit a `price` field representing the full sale price
+const takerBidAbi = "event TakerBid(bytes32 orderHash, uint256 orderNonce, address indexed taker, address indexed maker, address indexed strategy, address currency, address collection, uint256 tokenId, uint256 amount, uint256 price)";
+const takerAskAbi = "event TakerAsk(bytes32 orderHash, uint256 orderNonce, address indexed taker, address indexed maker, address indexed strategy, address currency, address collection, uint256 tokenId, uint256 amount, uint256 price)";
+const makerMatchAbi = "event MakerMatch(bytes32 orderHash, uint256 bidOrderNonce, uint256 askOrderNonce, address indexed taker, address indexed maker, address indexed strategy, address currency, address collection, uint256 tokenId, uint256 amount, uint256 price)";
+
+const fetchCronosFees = async (options: FetchOptions) => {
+  const dailyVolume = options.createBalances();
+
+  const [takerBidEvents, takerAskEvents, makerMatchEvents] = await Promise.all([
+    options.getLogs({ target: contractAddress, eventAbi: takerBidAbi }),
+    options.getLogs({ target: contractAddress, eventAbi: takerAskAbi }),
+    options.getLogs({ target: contractAddress, eventAbi: makerMatchAbi }),
+  ]);
+
+  const allEvents = [...takerBidEvents, ...takerAskEvents, ...makerMatchEvents];
+
+  allEvents.forEach((event: any) => {
+    // `currency` is the ERC20 used for payment (e.g. WCRO); price is denominated in that token
+    dailyVolume.add(event.currency, event.price);
+  });
+
+  // Protocol fee is 2% of total volume
+  const dailyFees = dailyVolume.clone(PROTOCOL_FEE_BPS / 10000);
+
+  return {
+    dailyFees,
+    dailyVolume,
+  };
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  pullHourly: true,
+  adapter: {
+    [CHAIN.CRONOS]: {
+      fetch: fetchCronosFees,
+      start: '2026-05-30',
+    },
+  },
+  methodology: {
+    Fees: "2% protocol fee charged on all NFT marketplace sales",
+    Volume: "Total volume of NFT sales on the Mintpad exchange (TakerBid + TakerAsk + MakerMatch events)"
+  }
+};
+
+export default adapter;

--- a/fees/mintpad/index.ts
+++ b/fees/mintpad/index.ts
@@ -11,14 +11,18 @@ const PROTOCOL_FEE_BPS = 200;
 const takerBidAbi = "event TakerBid(bytes32 orderHash, uint256 orderNonce, address indexed taker, address indexed maker, address indexed strategy, address currency, address collection, uint256 tokenId, uint256 amount, uint256 price)";
 const takerAskAbi = "event TakerAsk(bytes32 orderHash, uint256 orderNonce, address indexed taker, address indexed maker, address indexed strategy, address currency, address collection, uint256 tokenId, uint256 amount, uint256 price)";
 const makerMatchAbi = "event MakerMatch(bytes32 orderHash, uint256 bidOrderNonce, uint256 askOrderNonce, address indexed taker, address indexed maker, address indexed strategy, address currency, address collection, uint256 tokenId, uint256 amount, uint256 price)";
+// Emitted whenever a royalty is paid to a creator
+const royaltyPaymentAbi = "event RoyaltyPayment(address indexed collection, uint256 indexed tokenId, address indexed royaltyRecipient, address currency, uint256 amount)";
 
 const fetchCronosFees = async (options: FetchOptions) => {
   const dailyVolume = options.createBalances();
+  const dailySupplySideRevenue = options.createBalances();
 
-  const [takerBidEvents, takerAskEvents, makerMatchEvents] = await Promise.all([
+  const [takerBidEvents, takerAskEvents, makerMatchEvents, royaltyEvents] = await Promise.all([
     options.getLogs({ target: contractAddress, eventAbi: takerBidAbi }),
     options.getLogs({ target: contractAddress, eventAbi: takerAskAbi }),
     options.getLogs({ target: contractAddress, eventAbi: makerMatchAbi }),
+    options.getLogs({ target: contractAddress, eventAbi: royaltyPaymentAbi }),
   ]);
 
   const allEvents = [...takerBidEvents, ...takerAskEvents, ...makerMatchEvents];
@@ -28,16 +32,23 @@ const fetchCronosFees = async (options: FetchOptions) => {
     dailyVolume.add(event.currency, event.price, 'NFT Sales');
   });
 
-  // Protocol fee is 2% of total volume
-  const dailyFees = dailyVolume.clone(PROTOCOL_FEE_BPS / 10000);
-  // Mintpad retains 100% of the protocol fee (no supply-side split modeled)
-  const dailyRevenue = dailyFees.clone(1);
-  const dailyProtocolRevenue = dailyFees.clone(1);
+  royaltyEvents.forEach((event: any) => {
+    dailySupplySideRevenue.add(event.currency, event.amount, 'Creator Royalties');
+  });
+
+  // Protocol fee: 2% of total volume (retained by Mintpad)
+  const dailyProtocolRevenue = dailyVolume.clone(PROTOCOL_FEE_BPS / 10000);
+  const dailyRevenue = dailyProtocolRevenue.clone(1);
+
+  // Total fees = protocol fee + creator royalties (income statement identity)
+  const dailyFees = dailyProtocolRevenue.clone(1);
+  dailyFees.addBalances(dailySupplySideRevenue);
 
   return {
     dailyFees,
     dailyRevenue,
     dailyProtocolRevenue,
+    dailySupplySideRevenue,
     dailyVolume,
   };
 };
@@ -52,17 +63,22 @@ const adapter: SimpleAdapter = {
     },
   },
   methodology: {
-    Fees: "2% protocol fee charged on all NFT marketplace sales",
-    Revenue: "Protocol-retained portion of marketplace fees",
+    Fees: "Total fees from NFT sales: 2% protocol fee plus creator royalties",
+    Revenue: "Protocol-retained portion of marketplace fees (2% of volume)",
     ProtocolRevenue: "Treasury/protocol retained portion of fees",
+    SupplySideRevenue: "Creator royalties paid on each sale",
     Volume: "Total volume of NFT sales on the Mintpad exchange (TakerBid + TakerAsk + MakerMatch events)"
   },
   breakdownMethodology: {
     Fees: {
-      'Marketplace Fees': '2% fee applied to NFT sales volume from matched orders.',
+      'NFT Sales': '2% protocol fee applied to NFT sales volume from matched orders.',
+      'Creator Royalties': 'Creator royalties collected on each sale.',
     },
     Revenue: {
-      'Marketplace Fees To Treasury': 'Protocol-retained marketplace trading fees.',
+      'NFT Sales': 'Protocol-retained marketplace trading fees (2% of volume).',
+    },
+    SupplySideRevenue: {
+      'Creator Royalties': 'Royalties paid to NFT creators on secondary sales.',
     },
     Volume: {
       'NFT Sales': 'Executed NFT sale notional from TakerBid, TakerAsk, and MakerMatch events.',


### PR DESCRIPTION
##### Name (to be shown on DefiLlama):
Mintpad

##### Twitter Link:
https://x.com/mintpadx

##### List of audit links if any: N/A

##### Website Link:
https://mintpad.app

##### Logo (High resolution, will be shown with rounded borders):

https://cdn.mintpad.app/app/mintpad_logo.png

##### Current TVL:
N/A

##### Treasury Addresses (if the protocol has treasury):

##### Chain:
Cronos

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed): 

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed): 

##### Short Description (to be shown on DefiLlama):
NFT marketplace on Cronos with trading rewards, creator tools, and collection management features.

##### Token address and ticker if any: N/A

##### Category (full list at https://defillama.com/categories) \*Please choose only one:
NFT Marketplace

##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.):
None

##### Implementation Details: Briefly describe how the oracle is integrated into your project:
Mintpad is an order-book NFT marketplace. Prices are set by users via EIP-712 signed maker/taker orders matched on-chain. No external price oracle is used.

##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage:
N/A

##### forkedFrom (Does your project originate from another project):
LooksRare

##### methodology (what is being counted as tvl, how is tvl being calculated):
Fees adapter. Protocol revenue is 2% of total NFT sale volume processed by the MintpadExchange contract (0xdFbE43b2c154B6a790158fa2696cDb32A86Efc78) on Cronos. Volume is the sum of the `price` field across TakerBid, TakerAsk, and MakerMatch events. Daily fees = daily volume × 0.02.

##### Github org/user (Optional, if your code is open source, we can track activity):

##### Does this project have a referral program?
No
