### PR TITLE
fix(aur): holders revenue is 11/12 of fees, not 1/2

### DIFF
--- a/fees/aur/index.ts
+++ b/fees/aur/index.ts
@@ -39,8 +39,11 @@ const aurEvent =
 const fetch: any = async (options: FetchOptions) => {
   const dailyFees = await aurHelperTotalSuiDeployed(options, aurEvent);
 
-  const dailyProtocolRevenue = dailyFees.clone(0.083, METRIC.PROTOCOL_FEES);
-  const dailyHoldersRevenue = dailyFees.clone(0.5, METRIC.TOKEN_BUY_BACK);
+  // dailyFees is the full 12% deployment fee. Per the methodology it splits into
+  // 1% of deployed to the treasury and 11% to AUR buybacks, i.e. 1/12 and 11/12
+  // of fees respectively (they sum to the full fee).
+  const dailyProtocolRevenue = dailyFees.clone(1 / 12, METRIC.PROTOCOL_FEES);
+  const dailyHoldersRevenue = dailyFees.clone(11 / 12, METRIC.TOKEN_BUY_BACK);
 
   return {
     dailyFees,


### PR DESCRIPTION
The AUR fees adapter splits the 12% deployment fee into protocol treasury and AUR-buyback (holders) revenue, but the holders multiplier is wrong.

`dailyFees` is the full **12%** of deployed SUI (`... / 1e9 * 0.12`). The adapter's own methodology states the split:
- ProtocolRevenue = "1% of total deployed SUI ... treasury" → 1/12 of fees
- HoldersRevenue = "11% of deployed SUI used to buyback AUR" → 11/12 of fees

The protocol side was correct (`clone(0.083)` ≈ 1/12), but the holders side used `clone(0.5)` = 6% of deployed, which matches neither the documented 11% nor any other figure, and breaks the income statement (0.083 + 0.5 = 0.583, so ~42% of revenue is unaccounted).

Fix: holders = 11/12 of fees (and protocol = 1/12 exactly), so `protocolRevenue + holdersRevenue = dailyFees` as the methodology intends.

Verified against production (`api.llama.fi/summary/fees/aur-protocol`): every historical day shows `holdersRevenue / fees = 0.500` (the bug) while `protocolRevenue / fees = 0.083` (correct) — so holders revenue has been undercounted by ~45% across the adapter's history. After the fix a sample day (fees 114) gives protocol 9.5 and holders 104.5, which reconcile to fees.