### PR TITLE
fix(coal-works): scale revenue split to the fee basis (was 10x under)

### DIFF
--- a/fees/coal-works/index.ts
+++ b/fees/coal-works/index.ts
@@ -8,8 +8,13 @@ import {
   
   const fetch: any = async (options: FetchOptions) => {
     const dailyFees = await oreHelperCountSolBalanceDiff(options, 'Az6VVPggdbxjrt4sL7FzjBunWD7piMZCUKvx316yLLmw')
-    const dailyProtocolRevenue = dailyFees.clone(0.01);
-    const dailyHoldersRevenue = dailyFees.clone(0.0305);
+    // dailyFees is the SOL actually received by the protocol wallet, i.e. the 10%
+    // board fee. The methodology splits that fee as 1% admin + 7% buyback + 1%
+    // motherlode + 1% LP of total SOL deployed (summing to the 10% fee), so as a
+    // fraction of fees the protocol (admin) share is 1%/10% = 0.1 and the holders
+    // share (1.05% stakers + 1% motherlode + 1% LP = 3.05% of deployed) is 0.305.
+    const dailyProtocolRevenue = dailyFees.clone(0.1);
+    const dailyHoldersRevenue = dailyFees.clone(0.305);
 
     return {
       dailyFees,


### PR DESCRIPTION
The COAL adapter reads `dailyFees` from the `ore` helper, which sums the SOL **received by the protocol wallet** — i.e. the 10% board fee (the methodology: "fees gathered from 10% of the total SOL allocated to COAL boards and sent to the protocol wallet").

The revenue split is then applied as a fraction of `dailyFees`:
```
dailyProtocolRevenue = dailyFees.clone(0.01)    // 1%
dailyHoldersRevenue  = dailyFees.clone(0.0305)  // 3.05%
```
But `0.01` / `0.0305` are the **of-deployed** percentages (1% admin, 3.05% to holders), and the methodology's component breakdown (1% admin + 7% buyback + 1% motherlode + 1% LP) sums to the **10% of deployed** that *is* `dailyFees`. So as a fraction of fees the shares are 1%/10% = **0.1** (protocol) and 3.05%/10% = **0.305** (holders). The current constants under-report both protocol and holders revenue by **10x**.

The sibling `fees/ore` adapter (same helper, same author pattern) confirms the intended of-fees convention — it uses `0.01` + `0.99` = 1.0 of fees. COAL pasted the of-deployed numbers without rescaling.

Production evidence (`api.llama.fi/summary/fees/coal`): every day shows `protocolRevenue/fees = 0.0100` and `holdersRevenue/fees = 0.0305`, while the methodology implies 0.10 and 0.305. The protocol is live (~\$4k–\$22k/day fees), so this 10x understatement is current.

Fix: set the multipliers to `0.1` and `0.305` so they match the documented split on the fee basis. (Note: per the existing methodology the 5.95%-of-deployed burn portion remains excluded from holders revenue — unchanged here.)