### PR TITLE
fix(radiant): revenue is 75% of fees (protocol+holders), not 85%

### DIFF
--- a/fees/radiant.ts
+++ b/fees/radiant.ts
@@ -21,7 +21,7 @@ const fetch = async ({ chain, createBalances, getLogs }: FetchOptions) => {
   const dailySupplySideRevenue = dailyFees.clone(0.25);
   const dailyHoldersRevenue = dailyFees.clone(0.60);
   const dailyProtocolRevenue = dailyFees.clone(0.15);
-  const dailyRevenue = dailyFees.clone(0.85);
+  const dailyRevenue = dailyFees.clone(0.75); // 15% protocol + 60% holders (supply-side is the remaining 25%)
 
   return { dailyRevenue, dailyHoldersRevenue, dailyProtocolRevenue, dailySupplySideRevenue, dailyFees, };
 }


### PR DESCRIPTION
The Radiant fees adapter sets the split as:
```
dailySupplySideRevenue = dailyFees.clone(0.25)  // 25% lenders
dailyHoldersRevenue    = dailyFees.clone(0.60)  // 60% holders
dailyProtocolRevenue   = dailyFees.clone(0.15)  // 15% protocol
dailyRevenue           = dailyFees.clone(0.85)  // <-- wrong
```
`dailyRevenue` should be `protocolRevenue + holdersRevenue = 0.15 + 0.60 = 0.75`, not `0.85`. The adapter's own methodology states it: *"Revenue: 75% fees earned by Radiant and token holders"*.

The `0.85` is provably wrong:
- It contradicts the methodology ("75%") and `protocol(15%) + holders(60%) = 75%`.
- It breaks the income statement: `revenue(0.85) + supplySide(0.25) = 1.10`, i.e. 110% of fees — impossible.

Verified against production (`api.llama.fi/summary/fees/radiant`): on a day with `fees=72`, `revenue=62` (≈0.86) and `revenue + supplySide = 80 = 111% of fees`. With the fix, `revenue + supplySide = fees` as it should.

Fix: `dailyRevenue = dailyFees.clone(0.75)`.