### PR TITLE
hastra: add ethereum fees

### DIFF
--- a/fees/hastra/index.ts
+++ b/fees/hastra/index.ts
@@ -77,13 +77,10 @@ const breakdownMethodology = {
 
 const adapter: SimpleAdapter = {
     version: 1,
-    fetch: async (options: FetchOptions) => {
-        return options.chain === CHAIN.SOLANA
-            ? fetchSolana(options)
-            : fetchEthereum(options);
+    adapter: {
+      [CHAIN.SOLANA]: { start: '2025-11-21', fetch: fetchSolana},
+      [CHAIN.ETHEREUM]: { start: '2026-04-17', fetch: fetchEthereum},
     },
-    chains: [CHAIN.SOLANA, CHAIN.ETHEREUM],
-    start: "2025-11-21",
     isExpensiveAdapter: true,
     dependencies: [Dependencies.DUNE],
     methodology,

--- a/fees/hastra/index.ts
+++ b/fees/hastra/index.ts
@@ -2,14 +2,22 @@ import { FetchOptions, SimpleAdapter, Dependencies } from "../../adapters/types"
 import { CHAIN } from "../../helpers/chains";
 import { queryDuneSql } from "../../helpers/dune";
 import { METRIC } from "../../helpers/metrics";
+import { ethers } from "ethers";
 
+// --- Solana ---
 const WYLDS_MINT = "8fr7WGTVFszfyNWRMXj6fRjZZAnDwmXwEpCrtzmUkdih";
-
 const VAULT_STAKE_WYLDS_ACCOUNT = "FvkbfMm98jefJWrqkvXvsSZ9RFaRBae8k6c1jaYA5vY3";
-
 const VAULT_STAKE_OWNER = "DT7z9w9fGJ6sH7vmGbPCa5JLi2xp6XPrL61z2gctzmHb";
 
-const fetch = async (options: FetchOptions) => {
+// --- Ethereum ---
+// Yield = wYLDS minted (Transfer from 0x0) into the PRIME staking contract.
+// Mints to other addresses are new issuance, not yield, so filter to staking only.
+const ETH_WYLDS = "0x6aD038cA6C04e885630851278ca0a856Ad9a66Cc"; // 6 decimals
+const ETH_STAKING = "0x19ebb35279A16207Ec4ba82799CC64715065F7F6";
+const TRANSFER_TOPIC = "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef";
+const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
+
+const fetchSolana = async (options: FetchOptions) => {
     const dailyFees = options.createBalances();
 
     const query = `
@@ -35,25 +43,52 @@ const fetch = async (options: FetchOptions) => {
     };
 };
 
+const fetchEthereum = async (options: FetchOptions) => {
+    const dailyFees = options.createBalances();
+
+    const logs = await options.getLogs({
+        target: ETH_WYLDS,
+        eventAbi: "event Transfer(address indexed from, address indexed to, uint256 value)",
+        topics: [
+            TRANSFER_TOPIC,
+            ethers.zeroPadValue(ZERO_ADDRESS, 32),
+            ethers.zeroPadValue(ETH_STAKING, 32),
+        ],
+    });
+
+    for (const log of logs) {
+        dailyFees.add(ETH_WYLDS, log.value, METRIC.ASSETS_YIELDS);
+    }
+
+    return {
+        dailyFees,
+        dailySupplySideRevenue: dailyFees
+    };
+};
+
 const methodology = {
-    Fees: "wYLDS tokens minted into the vault-stake account via publish_rewards",
-    SupplySideRevenue: "Yields accumulated based on wYLDS holdings",
+    Fees: "wYLDS tokens minted into the PRIME staking vault via the publish_rewards reward stream (Solana vault-stake account / Ethereum staking contract).",
+    SupplySideRevenue: "Yields accumulated based on staked wYLDS holdings.",
     Revenue: "Hastra takes no on-chain protocol fee cut. Figure monetises via off-chain lending spreads on HELOCs.",
 };
 
 const breakdownMethodology = {
     Fees: {
-        [METRIC.ASSETS_YIELDS]: "wYLDS minted hourly into the vault-stake account via publish_rewards CPI from vault-mint, funded by Figure's Demo Prime HELOC lending operations.",
+        [METRIC.ASSETS_YIELDS]: "wYLDS minted hourly into the PRIME staking vault (Solana vault-stake account / Ethereum staking contract) via the publish_rewards reward stream, funded by Figure's Demo Prime HELOC lending operations. New-issuance mints to other addresses are excluded.",
     },
     SupplySideRevenue: {
-        [METRIC.ASSETS_YIELDS]: "Yields accumulated based on wYLDS holdings",
+        [METRIC.ASSETS_YIELDS]: "Yields accumulated based on staked wYLDS holdings.",
     },
 };
 
 const adapter: SimpleAdapter = {
     version: 1,
-    fetch,
-    chains: [CHAIN.SOLANA],
+    fetch: async (options: FetchOptions) => {
+        return options.chain === CHAIN.SOLANA
+            ? fetchSolana(options)
+            : fetchEthereum(options);
+    },
+    chains: [CHAIN.SOLANA, CHAIN.ETHEREUM],
     start: "2025-11-21",
     isExpensiveAdapter: true,
     dependencies: [Dependencies.DUNE],

--- a/fees/hastra/index.ts
+++ b/fees/hastra/index.ts
@@ -2,7 +2,6 @@ import { FetchOptions, SimpleAdapter, Dependencies } from "../../adapters/types"
 import { CHAIN } from "../../helpers/chains";
 import { queryDuneSql } from "../../helpers/dune";
 import { METRIC } from "../../helpers/metrics";
-import { ethers } from "ethers";
 
 // --- Solana ---
 const WYLDS_MINT = "8fr7WGTVFszfyNWRMXj6fRjZZAnDwmXwEpCrtzmUkdih";
@@ -14,8 +13,6 @@ const VAULT_STAKE_OWNER = "DT7z9w9fGJ6sH7vmGbPCa5JLi2xp6XPrL61z2gctzmHb";
 // Mints to other addresses are new issuance, not yield, so filter to staking only.
 const ETH_WYLDS = "0x6aD038cA6C04e885630851278ca0a856Ad9a66Cc"; // 6 decimals
 const ETH_STAKING = "0x19ebb35279A16207Ec4ba82799CC64715065F7F6";
-const TRANSFER_TOPIC = "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef";
-const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
 
 const fetchSolana = async (options: FetchOptions) => {
     const dailyFees = options.createBalances();
@@ -39,30 +36,27 @@ const fetchSolana = async (options: FetchOptions) => {
 
     return {
         dailyFees,
-        dailySupplySideRevenue: dailyFees
+        dailySupplySideRevenue: dailyFees,
+        dailyRevenue: 0,
     };
 };
 
 const fetchEthereum = async (options: FetchOptions) => {
     const dailyFees = options.createBalances();
 
-    const logs = await options.getLogs({
-        target: ETH_WYLDS,
-        eventAbi: "event Transfer(address indexed from, address indexed to, uint256 value)",
-        topics: [
-            TRANSFER_TOPIC,
-            ethers.zeroPadValue(ZERO_ADDRESS, 32),
-            ethers.zeroPadValue(ETH_STAKING, 32),
-        ],
+    const rewardDistributionLogs = await options.getLogs({
+        target: ETH_STAKING,
+        eventAbi: "event RewardsDistributed (uint256 amount, uint256 timestamp)",
     });
 
-    for (const log of logs) {
-        dailyFees.add(ETH_WYLDS, log.value, METRIC.ASSETS_YIELDS);
+    for (const log of rewardDistributionLogs) {
+        dailyFees.add(ETH_WYLDS, log.amount, METRIC.ASSETS_YIELDS);
     }
 
     return {
         dailyFees,
-        dailySupplySideRevenue: dailyFees
+        dailySupplySideRevenue: dailyFees,
+        dailyRevenue: 0,
     };
 };
 


### PR DESCRIPTION
- Hastra's fees adapter only tracked Solana wYLDS yield. This adds the Ethereum deployment (~$176M staked wYLDS, previously uncounted).
- Ethereum yield is read on-chain via getLogs: wYLDS (0x6aD038…) minted (Transfer from 0x0) into the PRIME staking contract (0x19ebb3…), mirroring Solana's hourly publish_rewards stream. Counted as dailyFees = dailySupplySideRevenue (Assets Yields).
- New-issuance mints (USDC deposits → wYLDS) go to other addresses and are excluded.

### Verification (2026-06-16)

- Adapter Ethereum yield ≈ $24.8k/day; on-chain staking mints that day = 24 events / 24,825.90 wYLDS — exact match.
- Only the staking contract receives the hourly cadence; no second reward vault missed.
- Staked balance $175.8M (= tracked TVL); implied APY 5.15%, in line with YLDS = SOFR − 0.5%.
- Solana path unchanged. No cross-chain double-count (separate deployments).