### PR TITLE
fix(fullsail-finance): supply-side revenue is fees minus revenue, not full fees

### DIFF
--- a/fees/fullsail-finance/index.ts
+++ b/fees/fullsail-finance/index.ts
@@ -23,7 +23,7 @@ const fetch = async (options: FetchOptions) => {
     // Supply-side is the portion of fees NOT taken as revenue; the API has no
     // supply-side field, so derive it. (Setting it to dailyFees double-counted,
     // making revenue + supplySide = 2x fees.)
-    const dailySupplySideRevenue = Math.max(0, Number(data.fees_usd) - Number(data.revenue_usd)).toString()
+    const dailySupplySideRevenue = Math.max(0, Number(data.fees_usd) - Number(data.revenue_usd))
 
     return {
         dailyFees,
@@ -46,6 +46,7 @@ const methodology = {
 
 const adapter: SimpleAdapter = {
     version: 2,
+    pullHourly: true,
     adapter: {
         [CHAIN.SUI]: {
             fetch,

--- a/fees/fullsail-finance/index.ts
+++ b/fees/fullsail-finance/index.ts
@@ -20,7 +20,10 @@ const fetch = async (options: FetchOptions) => {
     const dailyRevenue = data.revenue_usd;
     const dailyHoldersRevenue = data.holders_revenue_usd;
     const dailyProtocolRevenue = data.protocol_revenue_usd;
-    const dailySupplySideRevenue = dailyFees
+    // Supply-side is the portion of fees NOT taken as revenue; the API has no
+    // supply-side field, so derive it. (Setting it to dailyFees double-counted,
+    // making revenue + supplySide = 2x fees.)
+    const dailySupplySideRevenue = Math.max(0, Number(data.fees_usd) - Number(data.revenue_usd)).toString()
 
     return {
         dailyFees,


### PR DESCRIPTION
The FullSail fees adapter set:
```
const dailySupplySideRevenue = dailyFees
```
i.e. supply-side revenue = the **full** fees. Supply-side should be the portion of fees *not* taken as revenue (`fees - revenue`). As written, `revenue + supplySide = 2 x fees`, which is impossible (revenue + supplySide must equal fees).

Verified against production (`api.llama.fi/summary/fees/full-sail`): every day shows `fees = revenue = supplySide`, so `(revenue + supplySide) / fees = 2.00` on every data point. The API reports `revenue_usd = fees_usd` (all swap fees go to veSAIL holders), so the correct supply-side is `fees - revenue = 0`.

The API response has no supply-side field, so it must be derived. Fix: `dailySupplySideRevenue = max(0, fees_usd - revenue_usd)`. After the fix a sample day (fees 1.45k) gives revenue 1.45k, supplySide 0, and `protocol(67) + holders(1.38k) = revenue`, so the income statement reconciles.