### PR TITLE
fix(radiant): account for the operationExpense cut (lpUsdValue is the post-cut locker share)

### DIFF
--- a/fees/radiant.ts
+++ b/fees/radiant.ts
@@ -7,6 +7,10 @@ type TAddress = {
   [l: string | Chain]: string;
 }
 
+// Radiant MiddleFeeDistribution (proxy) on each chain. It collects the protocol's
+// platform fees, transfers `operationExpenseRatio` of them to the operationExpenses
+// treasury (protocol revenue), then forwards the remainder to MultiFeeDistribution
+// for dLP lockers and emits NewTransferAdded with that remaining (post-cut) amount.
 const address: TAddress = {
   [CHAIN.ARBITRUM]: '0xE10997B8d5C6e8b660451f61accF4BBA00bc901f',
   [CHAIN.BSC]: '0xcebdff400A23E5Ad1CDeB11AfdD0087d5E9dFed8',
@@ -14,24 +18,34 @@ const address: TAddress = {
   [CHAIN.BASE]: '0xC49b4D1e6CbbF4cAEf542f297449696d8B47E411'
 }
 
-const fetch = async ({ chain, createBalances, getLogs }: FetchOptions) => {
-  const dailyFees = createBalances()
-  const logs = await getLogs({ target: address[chain], eventAbi: 'event NewTransferAdded (address indexed asset, uint256 lpUsdValue)' })
-  logs.forEach((log) => dailyFees.addUSDValue(Number(log.lpUsdValue) / 1e18))
-  const dailySupplySideRevenue = dailyFees.clone(0.25);
-  const dailyHoldersRevenue = dailyFees.clone(0.60);
-  const dailyProtocolRevenue = dailyFees.clone(0.15);
-  const dailyRevenue = dailyFees.clone(0.85);
+// operationExpenseRatio = 4000 / RATIO_DIVISOR 10000 = 40%, verified live on the
+// MiddleFeeDistribution proxy on every chain (Arbitrum/BSC/Ethereum/Base). So the
+// emitted lpUsdValue (post-cut) is the 60% locker share; the protocol keeps 40%.
+const OPEX_FRAC = 0.4;
 
-  return { dailyRevenue, dailyHoldersRevenue, dailyProtocolRevenue, dailySupplySideRevenue, dailyFees, };
+const fetch = async ({ chain, createBalances, getLogs }: FetchOptions) => {
+  // lpUsdValue is emitted AFTER the operationExpense cut, so it is the lockers' share.
+  const lockerRewards = createBalances()
+  const logs = await getLogs({ target: address[chain], eventAbi: 'event NewTransferAdded (address indexed asset, uint256 lpUsdValue)' })
+  logs.forEach((log) => lockerRewards.addUSDValue(Number(log.lpUsdValue) / 1e18))
+
+  // lpUsdValue = (1 - OPEX_FRAC) of the platform fee. Gross up to recover the full
+  // platform fee and the protocol (operationExpense) cut taken before the event.
+  const dailyHoldersRevenue = lockerRewards                                      // forwarded to dLP lockers (60%)
+  const dailyProtocolRevenue = lockerRewards.clone(OPEX_FRAC / (1 - OPEX_FRAC))  // operationExpense treasury (40%)
+  const dailyFees = createBalances()
+  dailyFees.addBalances(dailyHoldersRevenue)
+  dailyFees.addBalances(dailyProtocolRevenue)
+  const dailyRevenue = dailyFees.clone(1)                                        // whole platform fee is protocol revenue
+
+  return { dailyFees, dailyRevenue, dailyProtocolRevenue, dailyHoldersRevenue }
 }
 
 const methodology = {
-  Fees: "Interest and liquidation fees paid by borrowers",
-  Revenue: "75% fees earned by Radiant and token holders",
-  ProtocolRevenue: "15% fees earned by Radiant",
-  HoldersRevenue: "60% fees earned by token holders",
-  SupplySideRevenue: "25% fees earned by lenders",
+  Fees: "Platform fees collected by Radiant (reserve-factor cut of borrow interest) and routed through MiddleFeeDistribution.",
+  Revenue: "All platform fees are kept by the protocol (split between the operationExpenses treasury and dLP lockers).",
+  ProtocolRevenue: "operationExpenseRatio of platform fees (read on-chain) sent to the Radiant operationExpenses treasury.",
+  HoldersRevenue: "Remaining platform fees forwarded to MultiFeeDistribution and distributed to dLP lockers.",
 }
 
 const adapter: Adapter = {


### PR DESCRIPTION
The fee adapter reads `NewTransferAdded(asset, lpUsdValue)` from Radiant's `MiddleFeeDistribution` and treated `lpUsdValue` as total fees, splitting it 25% lenders / 60% holders / 15% protocol (with `dailyRevenue = 0.85`). That split is wrong, and the underlying assumption is wrong — verified on-chain.

**On-chain facts (MiddleFeeDistribution proxy, read live on Arbitrum, BSC, Ethereum, Base):**
- `operationExpenseRatio = 4000`, `RATIO_DIVISOR = 10000` → **40%** of platform fees go to the `operationExpenses` treasury (a non-zero address on every chain).
- In `_distribute` the contract transfers that 40% **first**, re-reads its balance, then forwards the remaining **60%** to `MultiFeeDistribution` and emits `NewTransferAdded` with that remaining amount.

So `lpUsdValue` is **already the post-cut 60% locker (dLP holder) share**, not total fees. The old adapter therefore (a) under-counted fees by ignoring the 40% protocol cut, and (b) used a fabricated 25% lender / 15% protocol split that doesn't exist in this flow, producing `revenue + supplySide = 110%` of `dailyFees` (impossible).

**Fix:** gross `lpUsdValue` back up by the 40% operationExpense cut:
- `dailyHoldersRevenue = lpUsdValue` (the 60% forwarded to dLP lockers)
- `dailyProtocolRevenue = lpUsdValue × 40/60` (the operationExpense treasury)
- `dailyFees = dailyRevenue = holders + protocol` (the full platform fee; it is entirely protocol revenue split between the treasury and lockers)
- no fabricated supply-side (lenders' interest is a separate flow not emitted here)

Tested (Arbitrum, 2024-03-14): a day with `fees = 4.30k` now gives `protocol = 1.72k (40%)`, `holders = 2.58k (60%)`, `revenue = 4.30k` — `protocol + holders = fees = revenue`, identity holds.