### PR TITLE
Add Elixir DEX volume adapter

### DIFF
--- a/dexs/elixir/index.ts
+++ b/dexs/elixir/index.ts
@@ -1,0 +1,38 @@
+import { SimpleAdapter, FetchOptions } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import { request, gql } from "graphql-request";
+import * as sdk from "@defillama/sdk";
+
+const endpoint =
+  "https://gateway.thegraph.com/api/[api-key]/subgraphs/id/6unAN9LodW2k1NC8JZh12NuddZj48XTTq852GuPbsQmr";
+
+const dailyQuery = gql`
+  query daily($dayId: ID!) {
+    protocolDayData(id: $dayId) {
+      volumeUSD
+      txCount
+    }
+  }
+`;
+
+const fetch = async (options: FetchOptions) => {
+  const dayId = Math.floor(options.startOfDay / 86400).toString();
+  const url = sdk.graph.modifyEndpoint(endpoint);
+
+  const dailyRes = await request(url, dailyQuery, { dayId });
+
+  return {
+    dailyVolume: dailyRes?.protocolDayData?.volumeUSD ?? "0",
+  };
+};
+
+const adapter: SimpleAdapter = {
+  adapter: {
+    [CHAIN.BASE]: {
+      fetch,
+      start: "2025-03-14", // Block 47460790 on Base
+    },
+  },
+};
+
+export default adapter;

--- a/dexs/elixir/index.ts
+++ b/dexs/elixir/index.ts
@@ -21,16 +21,21 @@ const fetch = async (options: FetchOptions) => {
 
   const dailyRes = await request(url, dailyQuery, { dayId });
 
+  if (!dailyRes?.protocolDayData) {
+    throw new Error(`No data for day ${dayId}`);
+  }
+
   return {
-    dailyVolume: dailyRes?.protocolDayData?.volumeUSD ?? "0",
+    dailyVolume: dailyRes.protocolDayData.volumeUSD,
   };
 };
 
 const adapter: SimpleAdapter = {
+  version: 2,
   adapter: {
     [CHAIN.BASE]: {
       fetch,
-      start: "2025-03-14", // Block 47460790 on Base
+      start: "2025-03-14",
     },
   },
 };


### PR DESCRIPTION
Name: Elixir

Twitter Link: https://x.com/MachimaLabs

List of audit links if any: (N/A)

Website Link: https://elixir.machima.ai

Logo: [(link to a high-res logo, square, transparent background preferred)](https://machima.ai/machima-icon-MAIN.png)

Current TVL: $291,200

Treasury Addresses: (N/A)

Chain: Base

Coingecko ID: (N/A)

Coinmarketcap ID: (N/A)

Short Description: Token launchpad and DEX on Base with concentrated liquidity pools

Token address and ticker: XMA - 0xA4985Faeb1e64Ba215282255dBb78ff59C63d7A9 (Base)

Category: Dexes

Oracle Provider(s): Chainlink (ETH/USD price feed)

Implementation Details: Chainlink ETH/USD oracle on Base used for USD volume conversion in the subgraph. XMA/USD derived from on-chain Uniswap V3 pool price.

Documentation/Proof: Subgraph uses Chainlink aggregator at 0x71041dddad3595F9CEd3DcCFBe3D1F4b0a16Bb70 (Base ETH/USD feed)

forkedFrom: Uniswap V3

methodology: Daily trading volume in USD aggregated from all pool swap events. Volume is calculated by converting counter-asset amounts (WETH, USDC, XMA) to USD using Chainlink price feeds at time of swap.

Github org/user: MachimaLabs

Does this project have a referral program? no