### PR TITLE
fix(springsui-ecosystem): protocol revenue is the protocol cut, not total fees

### DIFF
--- a/fees/springsui-ecosystem/index.ts
+++ b/fees/springsui-ecosystem/index.ts
@@ -27,7 +27,7 @@ const fetch = async (options: FetchOptions) => {
   return {
     dailyFees,
     dailyRevenue,
-    dailyProtocolRevenue: dailyFees,
+    dailyProtocolRevenue: dailyRevenue,
     dailySupplySideRevenue,
   };
 };


### PR DESCRIPTION
### Problem

`fees/springsui-ecosystem` sets `dailyProtocolRevenue: dailyFees`, but `dailyFees` here is the **sum of staker rewards + the protocol cut**:

```ts
dailyFees.addUSDValue(stakerFees + protocolRevenue, ...)        // total
dailySupplySideRevenue.addUSDValue(stakerFees, ...)             // staker rewards → suppliers
dailyRevenue.addUSDValue(protocolRevenue, ...)                  // protocol cut
...
dailyProtocolRevenue: dailyFees,   // <-- wrong: this is total, not the protocol cut
```

The staker rewards are supply-side (they go to LST stakers), so booking the full `dailyFees` as protocol revenue counts the suppliers' share as protocol revenue. This also makes `dailyProtocolRevenue > dailyRevenue`, which is impossible (protocol revenue is a part of revenue).

### Evidence

The protocol's own fee API (`global.suilend.fi/springsui/stats/fees`) returns the two amounts separately — the protocol cut is a tiny fraction of the total:

- `ecosystemFeesUsd` (protocol cut) ≈ **$34 / 7d**
- `ecosystemStakerRevenue` (to stakers, supply-side) ≈ **$6,169 / 7d**

Production currently reports protocol revenue ≈ total fees:

- `dailyFees` 7d = 6249
- `dailyRevenue` 7d = 32
- `dailyProtocolRevenue` 7d = **6249** (should track `dailyRevenue` ≈ 32)
- `dailySupplySideRevenue` 7d = 6213

So protocol revenue is overstated by ~195×.

### Fix

`dailyProtocolRevenue: dailyRevenue` — the protocol's actual cut. This matches the sibling adapter `fees/springsui/index.ts`, which already uses `dailyProtocolRevenue: dailyRevenue` for the identical structure, and restores `fees = revenue + supplySide` with `protocolRevenue = revenue`.