### PR TITLE
fix(myriadmarkets): treasury revenue should use treasuryFee, not the LP fee

### DIFF
--- a/fees/myriadmarkets/index.ts
+++ b/fees/myriadmarkets/index.ts
@@ -30,7 +30,7 @@ async function fetch({ createBalances, chain, api, getLogs }: FetchOptions) {
     let toIndex = fromIndex + callSize;
     if (toIndex > marketIndex) toIndex = marketIndex;
     
-    const markets = [];
+    const markets: number[] = [];
     for (let i = fromIndex; i < toIndex; i++) markets.push(i);
     
     const marketData = await api.multiCall({ target: market, abi: abi.getMarketAltData, calls: markets })

--- a/fees/myriadmarkets/index.ts
+++ b/fees/myriadmarkets/index.ts
@@ -67,7 +67,7 @@ async function fetch({ createBalances, chain, api, getLogs }: FetchOptions) {
         dailyFees.add(token, value * totalFee, isBuy ? 'BuyFee' : 'SellFee')
         dailySupplySideRevenue.add(token, value * distributorFee, 'DistributorFee')
         dailySupplySideRevenue.add(token, value * fee, 'LPFee')
-        dailyRevenue.add(token, value * fee, 'TreasuryFee')
+        dailyRevenue.add(token, value * treasuryFee, 'TreasuryFee')
         break;
     }
   });


### PR DESCRIPTION
### Problem

`getMarketFees` returns three fee components per market: `(fee, treasuryFee, distributorFee)`. The adapter reads all three:

```ts
const fee = Number(fees[feeKey][0]) / 1e18
const treasuryFee = Number(fees[feeKey][1]) / 1e18
const distributorFee = Number(fees[feeKey][2]) / 1e18
const totalFee = fee + treasuryFee + distributorFee
...
dailyFees.add(token, value * totalFee, ...)                       // fee + treasuryFee + distributorFee
dailySupplySideRevenue.add(token, value * distributorFee, 'DistributorFee')
dailySupplySideRevenue.add(token, value * fee, 'LPFee')
dailyRevenue.add(token, value * fee, 'TreasuryFee')   // <-- uses `fee` again, not `treasuryFee`
```

`dailyRevenue` (labelled `TreasuryFee`) uses `fee` — the LP component, which is already booked as `LPFee` on the line above. So the LP fee is counted twice (once in supply-side, once in revenue), and `treasuryFee` (the actual treasury component) is read but never used.

Because `dailyFees` includes `treasuryFee` while revenue+supply-side substitute a second `fee` for it, `dailyRevenue + dailySupplySideRevenue` exceeds `dailyFees` (currently ~1.4× in production) whenever `fee ≠ treasuryFee`.

### Evidence (on-chain)

Reading `getMarketFees` on the BSC market contract `0x39e66ee6b2ddaf4defded3038e0162180dbef340`, the components differ per market — e.g. a live market returns `fee = 1.00%`, `treasuryFee = 0.00%`, `distributorFee = 1.00%`. With the current code that market reports 1% of value as treasury revenue when the on-chain treasury fee is 0, and double-counts the 1% LP fee.

### Fix

Use the `treasuryFee` component for treasury revenue:

```ts
dailyRevenue.add(token, value * treasuryFee, 'TreasuryFee')
```

This restores `dailyFees = dailyRevenue + dailySupplySideRevenue` (LP + distributor on the supply side, treasury on the revenue side) using the actual on-chain treasury fee per market.