### PR TITLE
centrifuge: add base, monad and pharos

### DIFF
--- a/fees/centrifuge/index.ts
+++ b/fees/centrifuge/index.ts
@@ -38,11 +38,57 @@ const chainConfig = {
                 name: "ACRDX",
             },
         ]
+    },
+    [CHAIN.BASE]: {
+        start: "2025-08-25",
+        vaults: [
+            {
+                token: "0x5a0f93d040de44e78f251b03c43be9cf317dcf64",
+                vault: "0x2aef271f00a9d1b0da8065d396f4e601dbd0ef0b",
+                name: "JAAA",
+            },
+        ]
+    },
+    [CHAIN.MONAD]: {
+        start: "2026-03-27",
+        vaults: [
+            {
+                token: "0xc18e6f730896971a79d748e8dea61067a9bc6040",
+                vault: "0x796ba8a2f2d80340ddb6ca8e43e7883812f13cd5",
+                name: "JTRSY",
+            },
+            {
+                token: "0xad48f183e586e92a591a610397ebf534609df797",
+                vault: "0x926030b9912bd42b092151cfb2396499b967df3a",
+                name: "JAAA",
+            },
+            {
+                token: "0x2fabf1c784b8583d63c00c5c9c0377d8cf1a3245",
+                vault: "0x082c62088669facc1fa9f056c5efc8cbccda39b2",
+                name: "ACRDX",
+            },
+        ]
+    },
+    [CHAIN.PHAROS]: {
+        start: "2026-03-30",
+        vaults: [
+            {
+                token: "0xc18e6f730896971a79d748e8dea61067a9bc6040",
+                vault: "0x160e0dd4c4f693b05eca83bc2ec6fd51954fc434",
+                name: "JTRSY",
+            },
+            {
+                token: "0xad48f183e586e92a591a610397ebf534609df797",
+                vault: "0x499a9f1ec1d60e6d0d49d3812d326ea659efd6c2",
+                name: "JAAA",
+            },
+        ]
     }
 }
 
 const expenseRatio = {
     "JSTRY": 0.25,
+    "JTRSY": 0.25,
     "JAAA": 0.5,
     "ACRDX": 0.5,
 }

--- a/fees/centrifuge/index.ts
+++ b/fees/centrifuge/index.ts
@@ -9,7 +9,7 @@ const chainConfig = {
             {
                 token: "0x8c213ee79581ff4984583c6a801e5263418c4b86",
                 vault: "0xfe6920eb6c421f1179ca8c8d4170530cdbdfd77a",
-                name: "JSTRY",
+                name: "JTRSY",
             },
             {
                 token: "0x5a0f93d040de44e78f251b03c43be9cf317dcf64",
@@ -87,7 +87,6 @@ const chainConfig = {
 }
 
 const expenseRatio = {
-    "JSTRY": 0.25,
     "JTRSY": 0.25,
     "JAAA": 0.5,
     "ACRDX": 0.5,


### PR DESCRIPTION
Extends the Centrifuge fees adapter to cover three additional chains where its vaults are live:

| Chain | Vaults added | Fee |
|---|---|---|
| Base | JAAA | 0.5% |
| Monad | JTRSY, JAAA, ACRDX | 0.25% / 0.5% / 0.5% |
| Pharos | JTRSY, JAAA | 0.25% / 0.5% |

## Verification

Every address was confirmed on-chain, not just from docs:

- **Identity**: each token's `symbol()` matches its name (JTRSY/JAAA/ACRDX); decimals read per-token (JTRSY/JAAA = 6, ACRDX = 18).
- **Linkage**: each `vault.share()` equals the configured token, and each `vault.asset()` is USDC with 6 decimals — matching the adapter's `USDC_DECIMALS = 6`.
- **Provenance**: every vault's `root()` matches the official Centrifuge protocol root from `centrifuge/protocol` `env/<chain>.json`, and poolIds are consistent per fund across chains (JTRSY …662, JAAA …663, ACRDX …664).
- **Size**: Base JAAA NAV (~$48M) matches rwa.xyz to the cent.
- **Output**: `pnpm test fees centrifuge` passes; daily revenue annualizes to fee% × NAV on each chain (Base ~$686/day, Monad ~$175/day, Pharos ~$103/day). `pnpm run ts-check` clean.

## Excluded (deliberately)

- **deRWA wrappers (deJAAA, deJTRSY, …)** — these wrap the underlying fund 1:1; counting them alongside JAAA/JTRSY would double-count NAV.
- **Base SPXA** — distinct fund (additive), but its management fee could not be confirmed from docs/contract, so left out rather than guessed.
- **Pharos HYB / RWAt** — unknown products, zero supply.