### PR TITLE
fix(swapr-v3): revenue is the 10% protocol cut, not 100% of fees

### DIFF
--- a/dexs/swapr-v3/index.ts
+++ b/dexs/swapr-v3/index.ts
@@ -25,7 +25,7 @@ const fetch = async (
     dailyVolume: req.algebraDayData?.volumeUSD,
     dailyFees: req.algebraDayData?.feesUSD,
     dailyUserFees: req.algebraDayData?.feesUSD,
-    dailyRevenue: req.algebraDayData?.feesUSD,
+    dailyRevenue: req.algebraDayData?.feesUSD * protocolFee,
     dailyProtocolRevenue: req.algebraDayData?.feesUSD * protocolFee,
     dailySupplySideRevenue: req.algebraDayData?.feesUSD * (1 - protocolFee),
   }


### PR DESCRIPTION
### Problem

```ts
const protocolFee = 0.1
...
dailyFees:              feesUSD,
dailyRevenue:           feesUSD,                 // <-- 100% of fees
dailyProtocolRevenue:   feesUSD * protocolFee,   // 10%
dailySupplySideRevenue: feesUSD * (1 - protocolFee), // 90%
```

`dailyRevenue` is set to the full `feesUSD`, but supply-side is already 90% of fees and the protocol cut is 10%. This makes `dailyRevenue + dailySupplySideRevenue = 190%` of fees (impossible — they must sum to `dailyFees`). The methodology also states *"Revenue: 10% swap fees collected by Swapr protocol."* With no holders split, revenue equals protocol revenue (10%).

### Evidence

- Production currently reports `dailyRevenue + dailySupplySideRevenue ≈ 1.9× dailyFees`.
- On-chain: Swapr runs on Algebra; reading `globalState()` on a Swapr pool on Gnosis (`0x4a3fec341be7134b8ef9e9edb6bf63ae2ba17f43`) returns `communityFee = 100`, i.e. 100/1000 = **10%** of swap fees go to the protocol — matching `protocolFee = 0.1`.

### Fix

Set `dailyRevenue = feesUSD * protocolFee` (the 10% protocol cut), matching `dailyProtocolRevenue` and the methodology, so `dailyRevenue + dailySupplySideRevenue = dailyFees`.