### PR TITLE
[feat] Subscan-Stats: extend subscan coverage to 3 more chains

### DIFF
--- a/users/utils/subscanStats.ts
+++ b/users/utils/subscanStats.ts
@@ -21,6 +21,9 @@ const subscanStatsChains: Record<string, ChainConfig> = {
   robonomics: { chain: CHAIN.ROBONOMICS, subscanName: "robonomics" },
   darwinia: { chain: CHAIN.DARWINIA, subscanName: "darwinia" },
   bifrost: { chain: CHAIN.BIFROST, subscanName: "bifrost" },
+  moonriver: { chain: CHAIN.MOONRIVER, subscanName: "moonriver" },
+  acala: { chain: CHAIN.ACALA, subscanName: "acala" },
+  "space-and-time": { chain: CHAIN.SPACE_AND_TIME, subscanName: "sxt" },
 };
 
 function fetchSubscanDaily(subscanName: string, category: string, date: string) {


### PR DESCRIPTION
## Summary
- Adds Subscan-backed chain user stats coverage for Moonriver, Acala, and Space and Time.
- Reuses the existing Subscan helper to generate both active-users and new-users adapters through `users/list.ts`.

## Changes
- Added `moonriver`, `acala`, and `space-and-time` entries to `users/utils/subscanStats.ts`.
- Maps the new entries to `CHAIN.MOONRIVER`, `CHAIN.ACALA`, and `CHAIN.SPACE_AND_TIME`.
- Uses Subscan daily categories already supported by the helper: `ActiveAccount`, `NewAccount`, and `extrinsic`.

## Data Quality / Risk
- Subscan requests require `SUBSCAN_API_KEY`, matching the existing helper behavior.
- No new methodology was introduced; the added chains use the same daily Subscan aggregation path as the existing Subscan-backed chains.

## Tests
- `pnpm exec tsc --noEmit --skipLibCheck --module commonjs --target es2020 --esModuleInterop users/utils/subscanStats.ts`
- Live adapter tests not run; Subscan API calls require `SUBSCAN_API_KEY`.