### PR TITLE
fix(hyperwave): supply-side revenue excludes the protocol platform fee

### DIFF
--- a/fees/hyperwave/index.ts
+++ b/fees/hyperwave/index.ts
@@ -13,9 +13,14 @@ const fetch = async (options: FetchOptions) => {
     dailyFees.addBalances(hwhlpFees);
     dailyFees.addBalances(hwhypeFees);
 
+    // Supply side is the yield paid to hwHLP/hwHYPE holders, i.e. fees minus the
+    // platform fee the protocol keeps as revenue (not the full fees).
+    const dailySupplySideRevenue = dailyFees.clone();
+    dailySupplySideRevenue.subtract(dailyRevenue);
+
     return {
         dailyFees,
-        dailySupplySideRevenue: dailyFees,
+        dailySupplySideRevenue,
         dailyRevenue: dailyRevenue,
         dailyProtocolRevenue: dailyRevenue,
     };


### PR DESCRIPTION
### Problem

```ts
const dailyFees = options.createBalances();
dailyFees.addBalances(hwhlpFees);
dailyFees.addBalances(hwhypeFees);
return {
    dailyFees,
    dailySupplySideRevenue: dailyFees,   // <-- full fees
    dailyRevenue: dailyRevenue,          // platform fee
    dailyProtocolRevenue: dailyRevenue,
};
```

`dailyRevenue` is the platform fee the protocol charges on AUM (computed in `getHwhypeHwusdFees` from the Veda accountant's `platformFeeRate`), and it is a part of `dailyFees`. But `dailySupplySideRevenue` is set to the full `dailyFees`, so `dailyRevenue + dailySupplySideRevenue` exceeds `dailyFees` (currently ~1.08× in production). The methodology comment "currently, no revenue" is stale — there is a platform fee now.

### Evidence (on-chain)

Reading `accountantState()` on the Veda accountants (HyperEVM) shows a non-zero `platformFeeRate`:
- hwHYPE accountant `0xCf9be8BF79ad26fdD7aA73f3dd5bA73eCDee2a32` → `38` = **0.38%**
- hwUSD accountant `0xa77F32BaDEeA2d2B7De78680C3A6d8B88C46055D` → `56` = **0.56%**

So the platform fee (revenue) is structurally non-zero, and counting it in both `dailyRevenue` and the full `dailySupplySideRevenue` double-books it.

### Fix

Supply side is the yield paid to hwHLP/hwHYPE holders, i.e. `dailyFees` minus the platform-fee revenue:

```ts
const dailySupplySideRevenue = dailyFees.clone();
dailySupplySideRevenue.subtract(dailyRevenue);
```

This restores `dailyFees = dailyRevenue + dailySupplySideRevenue`.