### PR TITLE
fix(spectra-v2): yield trading fee to holders is 60%, not 80%

### DIFF
--- a/dexs/spectra-v2.ts
+++ b/dexs/spectra-v2.ts
@@ -261,7 +261,7 @@ const fetch: FetchV2 = async (options) => {
   totalFees.add(dailyVotingFeesRevenue, 'Voting Fees')
   totalFees.add(dailyVotingIncentivesRevenue, 'Voting Incentives')
 
-  totalRevenue.add(dailyFees.clone(0.8), 'Yield Trading Fees To Holders')
+  totalRevenue.add(dailyFees.clone(0.6), 'Yield Trading Fees To Holders')
   totalRevenue.add(dailyVotingFeesRevenue, 'Voting Fees')
   totalRevenue.add(dailyVotingIncentivesRevenue, 'Voting Incentives')
 


### PR DESCRIPTION
### Problem

```ts
totalRevenue.add(dailyFees.clone(0.8), 'Yield Trading Fees To Holders')   // 80%
...
totalSupplySideRevenue.add(dailyFees.clone(0.2), 'Yield Trading Fees To LPs')        // 20%
totalSupplySideRevenue.add(dailyFees.clone(0.2), 'Yield Trading Fees To Curve DAO')  // 20%
```

For the yield trading fees, revenue (holders) is 80% and supply side is 20% + 20% = 40%, so `dailyRevenue + dailySupplySideRevenue` = 120% of the yield trading fees — more than the fees collected.

### Evidence

Spectra's own fee documentation (docs.spectra.finance/tokenomics/fees) states the collected swap fee is distributed: **60% to veSPECTRA voters, 20% to LPs, 20% to Curve DAO** (= 100%). The adapter's supply-side already encodes the 20% + 20%, so the holders share must be 60%, not 80%.

### Fix

`dailyFees.clone(0.6)` for the holders (veSPECTRA voters) share, so the yield trading fee splits 60% / 20% / 20% and `dailyRevenue + dailySupplySideRevenue = dailyFees`.