### PR TITLE
dexs(deepbookv3-sui): add suiUSDe and usdSUI quote tokens

### DIFF
--- a/dexs/deepbookv3-sui/index.ts
+++ b/dexs/deepbookv3-sui/index.ts
@@ -63,6 +63,7 @@ const methodology = {
 
 export default {
   version: 2,
+  pullHourly: true,
   methodology,
   adapter: {
     [CHAIN.SUI]: {

--- a/dexs/deepbookv3-sui/index.ts
+++ b/dexs/deepbookv3-sui/index.ts
@@ -19,6 +19,8 @@ const coins: Record<string, string> = {
   DRF: "0x294de7579d55c110a00a7c4946e09a1b5cbeca2592fbb83fd7bfacba3cfeaf0e::drf::DRF",
   SEND: "0xb45fcfcc2cc07ce0702cc2d229621e046c906ef14d9b25e8e4d25f6e8763fef7::send::SEND",
   XBTC: "0x876a4b7bce8aeaef60464c11f4026903e9afacab79b9b142686158aa86560b50::xbtc::XBTC",
+  SUIUSDE: "0x41d587e5336f1c86cad50d38a7136db99333bb9bda91cea4ba69115defeb1402::sui_usde::SUI_USDE",
+  USDSUI: "0x44f838219cf67b058f3b37907b655f226153c18e33dfcd0da559a844fea9b1c1::usdsui::USDSUI",
 };
 
 const fetchVolumeInUsd = (


### PR DESCRIPTION
## Summary

The DeepBook V3 volume adapter resolves each pool's quote token by looking up the quote symbol in a hardcoded `coins` dict, and **silently skips** any pool whose quote token isn't present:

```ts
const quoteToken = coins[quoteTokenSymbol];
if (!quoteToken) {
  console.warn(`Quote token for poolName ${poolName} not found`);
  continue;
}
```

Two active pools quote in tokens missing from the dict, so their volume is dropped:

| pool | quote token | quote type |
|---|---|---|
| `SUI_SUIUSDE` | suiUSDe | `0x41d587e5...::sui_usde::SUI_USDE` |
| `SUI_USDSUI` | usdSUI | `0x44f83821...::usdsui::USDSUI` |

## Impact

Measured against the DeepBook indexer (`all_historical_volume`) over the last 7 days, the two skipped pools account for **~$1.75M of ~$63M (≈2.8%)** of total volume, and the share is growing as these stablecoin pairs gain traction. Both tokens are priceable (DefiLlama confidence 0.99), so they were previously contributing $0.

## Fix

Add the two quote tokens to the `coins` dict — the same maintenance pattern as prior additions (e.g. WAL in #2947, the asset batch in #3654). Verified the adapter runs and picks the pools up.

Pool metadata source: `https://deepbook-indexer.mainnet.mystenlabs.com/get_pools`