### PR TITLE
fees(aries-markets): charge interest on all reserves, split by each reserve_ratio

### DIFF
--- a/fees/aries-markets/index.ts
+++ b/fees/aries-markets/index.ts
@@ -5,11 +5,9 @@ import { METRIC } from "../../helpers/metrics";
 
 const rateURL = "https://api-v2.ariesmarkets.xyz/reserve.rateHistory?input=";
 const reserveURL = "https://api-v2.ariesmarkets.xyz/reserve.current";
-const USDTReserveKey = "0x9770fa9c725cbd97eb50b2be5f7416efdfd1f1554beb0750d4dae4c64e860da3::fa_to_coin_wrapper::WrappedUSDT";
-const USDCReserveKey = "0x9770fa9c725cbd97eb50b2be5f7416efdfd1f1554beb0750d4dae4c64e860da3::wrapped_coins::WrappedUSDC";
 
-const STABLE_COIN_DECIMAL = 6;
 const DAY_IN_YEARS = 365;
+const PROTOCOL_REVENUE_SHARE = 0.2;
 
 const getRateHistoryURL = (timestamp: number, reserveKey: string) => {
   const input = encodeURIComponent(JSON.stringify({
@@ -23,37 +21,28 @@ const getRateHistoryURL = (timestamp: number, reserveKey: string) => {
 const fetch = async (options: FetchOptions) => {
   const reserves = (await fetchURL(reserveURL)).result.data.stats;
 
-  let df = 0;
-  for (const reserveKey of [USDTReserveKey, USDCReserveKey]) {
-    const dayFeesQuery = (await fetchURL(getRateHistoryURL(options.startOfDay, reserveKey))).result.data[0];
-
-    const matchingReserve = reserves.find(
-      (reserve) => reserve.key === reserveKey
-    );
-    const borrowApr = Number(dayFeesQuery?.borrowApr);
-    const totalBorrowed = Number(matchingReserve?.value?.total_borrowed);
-
-    if (isNaN(borrowApr) || isNaN(totalBorrowed)) {
-      throw new Error(`Invalid data for date ${options.dateString}`);
-    }
-
-    df +=
-      borrowApr *
-      totalBorrowed /
-      10 ** STABLE_COIN_DECIMAL /
-      DAY_IN_YEARS;
-  }
-
-  const dpr = df * 0.2;
-  const dssr = df * 0.8;
-
   const dailyFees = options.createBalances();
   const dailyRevenue = options.createBalances();
   const dailySupplySideRevenue = options.createBalances();
 
-  dailyFees.addUSDValue(df, METRIC.BORROW_INTEREST);
-  dailyRevenue.addUSDValue(dpr, METRIC.PROTOCOL_FEES);
-  dailySupplySideRevenue.addUSDValue(dssr, METRIC.BORROW_INTEREST);
+  // Aries lists every borrowable market in reserve.current; charge interest on
+  // all of them (the coin type is the reserve key, priced by the framework so
+  // each market's own decimals/price are applied).
+  for (const reserve of reserves) {
+    const reserveKey = reserve.key;
+    const totalBorrowed = Number(reserve?.value?.total_borrowed);
+    if (!totalBorrowed) continue;
+
+    const rateHistory = (await fetchURL(getRateHistoryURL(options.startOfDay, reserveKey))).result.data[0];
+    const borrowApr = Number(rateHistory?.borrowApr);
+    if (isNaN(borrowApr)) continue;
+
+    const dailyInterest = borrowApr * totalBorrowed / DAY_IN_YEARS;
+
+    dailyFees.add(reserveKey, dailyInterest, METRIC.BORROW_INTEREST);
+    dailyRevenue.add(reserveKey, dailyInterest * PROTOCOL_REVENUE_SHARE, METRIC.PROTOCOL_FEES);
+    dailySupplySideRevenue.add(reserveKey, dailyInterest * (1 - PROTOCOL_REVENUE_SHARE), METRIC.BORROW_INTEREST);
+  }
 
   return {
     dailyFees,
@@ -64,7 +53,7 @@ const fetch = async (options: FetchOptions) => {
 };
 
 const methodology = {
-  Fees: "Interest paid by borrowers across all lending markets (USDT and USDC).",
+  Fees: "Interest paid by borrowers across all Aries lending markets.",
   Revenue: "Portion of borrow interest kept by Aries Markets (20% of total interest).",
   SupplySideRevenue: "Interest distributed to lenders who supply assets (80% of total interest).",
   ProtocolRevenue: "Portion of borrow interest kept by Aries Markets treasury (20% of total interest).",
@@ -72,7 +61,7 @@ const methodology = {
 
 const breakdownMethodology = {
   Fees: {
-    [METRIC.BORROW_INTEREST]: 'Interest accrued from borrowers on USDT and USDC reserves, calculated from daily borrow APR and total borrowed amounts',
+    [METRIC.BORROW_INTEREST]: 'Interest accrued from borrowers across all reserves, calculated from each reserve daily borrow APR and total borrowed amount',
   },
   Revenue: {
     [METRIC.PROTOCOL_FEES]: 'Aries Markets keeps 20% of all borrow interest as protocol revenue',

--- a/fees/aries-markets/index.ts
+++ b/fees/aries-markets/index.ts
@@ -69,13 +69,13 @@ const breakdownMethodology = {
     [METRIC.BORROW_INTEREST]: 'Interest accrued from borrowers across all reserves, calculated from each reserve daily borrow APR and total borrowed amount',
   },
   Revenue: {
-    [METRIC.PROTOCOL_FEES]: 'Aries Markets keeps 20% of all borrow interest as protocol revenue',
+    [METRIC.PROTOCOL_FEES]: `Protocol's share of borrow interest, set per market by each reserve's reserve_ratio.`,
   },
   ProtocolRevenue: {
-    [METRIC.PROTOCOL_FEES]: 'Aries Markets keeps 20% of all borrow interest as protocol revenue',
+    [METRIC.PROTOCOL_FEES]: `Protocol's share of borrow interest, set per market by each reserve's reserve_ratio.`,
   },
   SupplySideRevenue: {
-    [METRIC.BORROW_INTEREST]: 'Lenders receive 80% of borrow interest as yield on their supplied assets',
+    [METRIC.BORROW_INTEREST]: `Interest distributed to lenders who supply assets (the remainder of each market's interest).`,
   },
 };
 

--- a/fees/aries-markets/index.ts
+++ b/fees/aries-markets/index.ts
@@ -7,7 +7,6 @@ const rateURL = "https://api-v2.ariesmarkets.xyz/reserve.rateHistory?input=";
 const reserveURL = "https://api-v2.ariesmarkets.xyz/reserve.current";
 
 const DAY_IN_YEARS = 365;
-const PROTOCOL_REVENUE_SHARE = 0.2;
 
 const getRateHistoryURL = (timestamp: number, reserveKey: string) => {
   const input = encodeURIComponent(JSON.stringify({
@@ -37,11 +36,17 @@ const fetch = async (options: FetchOptions) => {
     const borrowApr = Number(rateHistory?.borrowApr);
     if (isNaN(borrowApr)) continue;
 
+    // Each reserve keeps a different cut of borrow interest for the protocol
+    // (reserve_ratio, in percent); the rest accrues to lenders. Confirmed
+    // against the reserve's supplyApr/borrowApr/utilization.
+    const reserveRatio = Number(reserve?.value?.reserve_config?.reserve_ratio) / 100;
+    if (isNaN(reserveRatio)) continue;
+
     const dailyInterest = borrowApr * totalBorrowed / DAY_IN_YEARS;
 
     dailyFees.add(reserveKey, dailyInterest, METRIC.BORROW_INTEREST);
-    dailyRevenue.add(reserveKey, dailyInterest * PROTOCOL_REVENUE_SHARE, METRIC.PROTOCOL_FEES);
-    dailySupplySideRevenue.add(reserveKey, dailyInterest * (1 - PROTOCOL_REVENUE_SHARE), METRIC.BORROW_INTEREST);
+    dailyRevenue.add(reserveKey, dailyInterest * reserveRatio, METRIC.PROTOCOL_FEES);
+    dailySupplySideRevenue.add(reserveKey, dailyInterest * (1 - reserveRatio), METRIC.BORROW_INTEREST);
   }
 
   return {
@@ -54,9 +59,9 @@ const fetch = async (options: FetchOptions) => {
 
 const methodology = {
   Fees: "Interest paid by borrowers across all Aries lending markets.",
-  Revenue: "Portion of borrow interest kept by Aries Markets (20% of total interest).",
-  SupplySideRevenue: "Interest distributed to lenders who supply assets (80% of total interest).",
-  ProtocolRevenue: "Portion of borrow interest kept by Aries Markets treasury (20% of total interest).",
+  Revenue: "Protocol's share of borrow interest, set per market by each reserve's reserve_ratio.",
+  SupplySideRevenue: "Interest distributed to lenders who supply assets (the remainder of each market's interest).",
+  ProtocolRevenue: "Protocol's share of borrow interest, set per market by each reserve's reserve_ratio.",
 };
 
 const breakdownMethodology = {


### PR DESCRIPTION
## Summary

Two issues in the Aries Markets fee adapter, both verified against the protocol's own on-chain state via its API:

### 1. Only two reserves were tracked
The adapter computed borrow interest for only `WrappedUSDT` and `WrappedUSDC`, although `reserve.current` lists every borrowable market. Active markets such as APT, amAPT, native USDC/USDT, WETH and USDY were ignored — understating **fees by ~38%**. Fixed by iterating every reserve with a non-zero borrowed amount and booking interest under its own coin type (so the framework prices each market with its own decimals/price).

### 2. The protocol/lender split was a hardcoded 20/80
Each reserve actually keeps a different cut of borrow interest (`reserve_ratio`, ranging **10–72%**), not a flat 20%. I confirmed `reserve_ratio` is the protocol cut independently of the field name, by deriving it from each reserve's APRs:

```
lender_share = supplyApr / (borrowApr × utilizationRatio)
protocol_cut = 1 − lender_share
```

This matches `reserve_ratio` exactly on all 16 active reserves (e.g. WrappedUSDC: supplyApr 0.01368 / (borrowApr 0.06538 × util 0.5231) = 40% to lenders → 60% protocol = reserve_ratio 60). The dominant markets (USDC/USDT/WrappedUSDC/WrappedUSDT = 60%, APT/amAPT = 72%) are far above the assumed 20%, so protocol revenue was understated ~3×. Fixed by splitting each market's interest with its own `reserve_ratio`.

## Result (verified locally)

- Daily fees: $111 → **$176** (all reserves now included)
- Daily protocol revenue: $35 (flat 20%) → **$106** (real per-reserve cut)
- Supply-side: $70; identity holds (106 + 70 = 176)