### PR TITLE
tonco: count swaps in both directions and include native TON pools

### DIFF
--- a/dexs/tonco/index.ts
+++ b/dexs/tonco/index.ts
@@ -4,9 +4,12 @@ import { postURL } from "../../utils/fetchURL";
 
 const GRAPHQL_ENDPOINT = 'https://indexer.tonco.io';
 
+// Numeraires with a reliable indexer USD price; a swap is counted (in either
+// direction) when one side of its pool is one of these.
 const WHITELIST_JETTONS = [
     '0:b113a994b5024a16719f69139328eb759596c38a25f59028b146fecdc3621dfe', // USDT
     '0:949c4c66760c002800e2fa3d8a3ca4e1c90a9373b53ae7472033483bf14cd95e', // WTTON
+    '0:0000000000000000000000000000000000000000000000000000000000000000', // TON
 ]
 
 const SWAPS_QUERY = (from: number, to: number) => `
@@ -46,8 +49,8 @@ const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
     for (const swap of swaps.data.swaps) {
 
         const fromJetton = swap.isZeroToOne ? swap.pool.jetton0 : swap.pool.jetton1;
-        
-        if (!WHITELIST_JETTONS.includes(fromJetton.address)) {
+
+        if (!WHITELIST_JETTONS.includes(swap.pool.jetton0.address) && !WHITELIST_JETTONS.includes(swap.pool.jetton1.address)) {
             continue;
         }
 

--- a/dexs/tonco/index.ts
+++ b/dexs/tonco/index.ts
@@ -74,6 +74,7 @@ const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
 
 const adapter: SimpleAdapter = {
     version: 2,
+    pullHourly: true,
     adapter: {
         [CHAIN.TON]: {
             start: '2024-11-25',

--- a/fees/tonco/index.ts
+++ b/fees/tonco/index.ts
@@ -104,7 +104,8 @@ const adapter: SimpleAdapter = {
             fetch,
             start: '2024-11-25',
         },
-    }
+    },
+    pullHourly: true,
 };
 
 export default adapter;

--- a/fees/tonco/index.ts
+++ b/fees/tonco/index.ts
@@ -4,9 +4,12 @@ import { postURL } from "../../utils/fetchURL";
 
 const GRAPHQL_ENDPOINT = 'https://indexer.tonco.io';
 
+// Numeraires with a reliable indexer USD price; a swap is counted (in either
+// direction) when one side of its pool is one of these.
 const WHITELIST_JETTONS = [
     '0:b113a994b5024a16719f69139328eb759596c38a25f59028b146fecdc3621dfe', // USDT
     '0:949c4c66760c002800e2fa3d8a3ca4e1c90a9373b53ae7472033483bf14cd95e', // WTTON
+    '0:0000000000000000000000000000000000000000000000000000000000000000', // TON
 ]
 
 const SWAPS_QUERY = (from: number, to: number) => `
@@ -58,7 +61,7 @@ const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
             continue;
         }
 
-        if (!WHITELIST_JETTONS.includes(fromJetton.address)) {
+        if (!WHITELIST_JETTONS.includes(swap.pool.jetton0.address) && !WHITELIST_JETTONS.includes(swap.pool.jetton1.address)) {
             continue;
         }
 


### PR DESCRIPTION
## Summary

Both the TONCO volume and fees adapters decide whether to count a swap by checking only the **input** jetton against a 2-token whitelist (USDT, WTTON):

```ts
const fromJetton = swap.isZeroToOne ? swap.pool.jetton0 : swap.pool.jetton1;
if (!WHITELIST_JETTONS.includes(fromJetton.address)) continue;
```

Two consequences, both undercounts:
1. **Only one direction of each USDT/WTTON pool is counted.** When the stablecoin is the *output* (e.g. a `X → USDT` sell), the input is `X`, so the swap is dropped — even though it is a real trade in a reliably-priced pool.
2. **Native TON pools are dropped entirely.** The whitelist has wrapped `WTTON` but not native TON, so every `TON/X` pool is skipped — and TON is the chain's most reliably priced asset.

## Measurement (indexer.tonco.io, last 24h, 854 swaps)

Valuing each swap by its input side (the adapter's own method):

| bucket | $ |
|---|---|
| counted today (input = USDT/WTTON) | ~21,400 |
| dropped: other side is USDT/WTTON (reverse direction) | ~31,300 |
| dropped: native TON pools (TON/UTYA, TON/cbBTC, …) | ~17,700 |
| **true total** | **~70,400** |

So the adapter currently reports only **~30%** of swap volume (and proportionally of fees). Production `total24h` (~$23k) matches the "counted" figure, confirming the gap.

## Fix

Count a swap when **either** side of its pool is a numeraire (USDT, WTTON, or native TON), keeping the existing input-side valuation via the indexer's `derivedUsd`. Pools with no numeraire side stay excluded (none observed in the 24h sample — they were all TON-paired). The 80/20 fee split and the v1.5 exclusion are unchanged.

Verified locally: volume $23k → $75k; fees $492 with supply-side $394 (80%) + revenue $98 (20%).