### PR TITLE
dexs(byreal): protocol fee is 20% of swap fees, not 12%

### DIFF
--- a/dexs/byreal/index.ts
+++ b/dexs/byreal/index.ts
@@ -9,13 +9,15 @@ const fetch = async (): Promise<FetchResultV2> => {
   const response = await httpGet(`https://api2.byreal.io/byreal/api/dex/v2/overview/global`, { httpsAgent: agent })
   const data = response.result.data
 
+  // Every Byreal CLMM AmmConfig sets protocol_fee_rate = 200000 (20% of swap
+  // fees) on-chain, with fund_fee_rate = 0; the remaining 80% goes to LPs.
   return {
     dailyVolume: data.volumeUsd24h,
     dailyFees: data.feeUsd24h,
     dailyUserFees: data.feeUsd24h,
-    dailyRevenue: data.feeUsd24h * 0.12, // 12%
-    dailyProtocolRevenue: data.feeUsd24h * 0.12, // 12% Treasury
-    dailySupplySideRevenue: data.feeUsd24h * 0.88, // 88%
+    dailyRevenue: data.feeUsd24h * 0.2,
+    dailyProtocolRevenue: data.feeUsd24h * 0.2,
+    dailySupplySideRevenue: data.feeUsd24h * 0.8,
   };
 };
 
@@ -31,9 +33,9 @@ const adapter: SimpleAdapter = {
     Volume: 'Total token swap volumes retrieved from Byreal API.',
     Fees: 'All fees from token swaps.',
     UserFees: 'Users pay fees on every token swap.',
-    Revenue: 'Amount of 12% swap fees to Byreal treasury.',
-    ProtocolRevenue: 'Amount of 12% swap fees to Byreal treasury.',
-    SupplySideRevenue: 'Amount of 88% swap fees distributed to LPs.',
+    Revenue: 'Amount of 20% swap fees taken as protocol fee (AmmConfig protocol_fee_rate).',
+    ProtocolRevenue: 'Amount of 20% swap fees taken as protocol fee (AmmConfig protocol_fee_rate).',
+    SupplySideRevenue: 'Amount of 80% swap fees distributed to LPs.',
   }
 };
 

--- a/dexs/byreal/index.ts
+++ b/dexs/byreal/index.ts
@@ -33,9 +33,9 @@ const adapter: SimpleAdapter = {
     Volume: 'Total token swap volumes retrieved from Byreal API.',
     Fees: 'All fees from token swaps.',
     UserFees: 'Users pay fees on every token swap.',
-    Revenue: 'Amount of 20% swap fees taken as protocol fee (AmmConfig protocol_fee_rate).',
-    ProtocolRevenue: 'Amount of 20% swap fees taken as protocol fee (AmmConfig protocol_fee_rate).',
-    SupplySideRevenue: 'Amount of 80% swap fees distributed to LPs.',
+    Revenue: 'Amount of 20% (12% before 2025-11-12) swap fees taken as protocol fee (AmmConfig protocol_fee_rate).',
+    ProtocolRevenue: 'Amount of 20% (12% before 2025-11-12) swap fees taken as protocol fee (AmmConfig protocol_fee_rate).',
+    SupplySideRevenue: 'Amount of 80% (88% before 2025-11-12) swap fees distributed to LPs.',
   }
 };
 


### PR DESCRIPTION
## Summary

The Byreal adapter splits swap fees **12% protocol / 88% LP**:

```ts
dailyRevenue: data.feeUsd24h * 0.12,
dailyProtocolRevenue: data.feeUsd24h * 0.12,
dailySupplySideRevenue: data.feeUsd24h * 0.88,
```

But on-chain, **every** Byreal CLMM `AmmConfig` sets `protocol_fee_rate = 200000` = **20%** (with `fund_fee_rate = 0`), so the protocol takes 20% of swap fees and LPs receive 80%.

## On-chain proof

Read every distinct `AmmConfig` referenced by Byreal's 113 pools (pool account → `amm_config` at offset 9 → `AmmConfig.protocol_fee_rate`). All **14** configs return `protocol_fee_rate = 200000` (20.00%) and `fund_fee_rate = 0`, e.g.:

| amm_config | protocol_fee_rate | fund_fee_rate | trade_fee_rate |
|---|---|---|---|
| CP4oFU3c… (USDC/USDT) | 20.00% | 0% | 0.0001% |
| G37RVgCr… | 20.00% | 0% | 0.10% |
| veWyQnnZ… | 20.00% | 0% | 0.20% |
| Cgc2VcAe… | 20.00% | 0% | 0.25% |

`feeUsd24h` is the **gross** swap fee, not the LP share: `feeUsd24h / volumeUsd24h` equals each pool's `trade_fee_rate` exactly (USDC/USDT 0.0001%, SPCX 0.10%, CRCL 0.20%), so the 20% cut applies to the reported fee directly.

## Fix

Split `feeUsd24h` 20% protocol / 80% LP. Total fees are unchanged; revenue rises from 12% to the on-chain 20% and supply-side drops to 80%. Verified locally: fees $9.53k, revenue $1.14k → **$1.91k**, supply-side $7.62k (identity holds).