### PR TITLE
ondo: add stellar, sei and xrpl

### DIFF
--- a/fees/ondo.ts
+++ b/fees/ondo.ts
@@ -136,14 +136,12 @@ async function getSupply(useChainApi: sdk.ChainApi): Promise<{
     // claimable balances, liquidity pools).
     const { USDY_CODE, USDY_ISSUER } = OndoContracts[CHAIN.STELLAR]
     const res = await axios.get(`https://horizon.stellar.org/assets?asset_code=${USDY_CODE}&asset_issuer=${USDY_ISSUER}`)
-    const record = res.data?._embedded?.records?.[0]
-    const usdy = record
-      ? Number(record.balances?.authorized ?? 0)
-      + Number(record.balances?.authorized_to_maintain_liabilities ?? 0)
-      + Number(record.contracts_amount ?? 0)
-      + Number(record.claimable_balances_amount ?? 0)
-      + Number(record.liquidity_pools_amount ?? 0)
-      : 0
+    const record = res.data._embedded.records[0]
+    const usdy =  Number(record.balances.authorized)
+      + Number(record.balances.authorized_to_maintain_liabilities)
+      + Number(record.contracts_amount)
+      + Number(record.claimable_balances_amount)
+      + Number(record.liquidity_pools_amount)
     return {
       OUSG: 0,
       USDY: usdy,
@@ -156,9 +154,9 @@ async function getSupply(useChainApi: sdk.ChainApi): Promise<{
       ledger_index: 'validated',
       strict: true,
     }])
-    const obligations = res?.result?.obligations || {}
+    const obligations = res.result.obligations
     return {
-      OUSG: Number(obligations[OUSG_CURRENCY] ?? 0),
+      OUSG: Number(obligations[OUSG_CURRENCY]),
       USDY: 0,
     }
   } else {

--- a/fees/ondo.ts
+++ b/fees/ondo.ts
@@ -5,6 +5,7 @@ import * as solana from '../helpers/solana'
 import axios from "axios"
 import { getCoinSupply } from "../helpers/aptos"
 import { getObject } from '../helpers/sui'
+import { rpcCall } from '../helpers/ripple'
 
 /**
  * 
@@ -18,10 +19,10 @@ import { getObject } from '../helpers/sui'
  */
 
 const methodology = {
-  Fees: 'Total yields were collected by investment assets.',
-  Revenue: 'Total yields were distributed to investors and Ondo protocol.',
-  ProtocolRevenue: 'Total yields were collected by Ondo protocol.',
-  SupplySideRevenue: 'Total yields were distributed to investors.',
+  Fees: "The daily yield earned by USDY and OUSG holders, calculated as each token's price increase over the day times the amount of tokens in circulation.",
+  Revenue: "Zero. Ondo passes all of this yield to token holders and currently charges no fee (USDY has no fee, OUSG's 0.15% fee is waived until 2027).",
+  ProtocolRevenue: 'Zero, for the same reason as Revenue.',
+  SupplySideRevenue: 'All of the yield, since 100% goes to USDY and OUSG holders.',
 }
 
 const OndoContracts: any = {
@@ -54,6 +55,17 @@ const OndoContracts: any = {
   },
   [CHAIN.NOBLE]: {
     USDY: 'ausdy',
+  },
+  [CHAIN.SEI]: {
+    USDY: '0x54cD901491AeF397084453F4372B93c33260e2A6',
+  },
+  [CHAIN.STELLAR]: {
+    USDY_CODE: 'USDY',
+    USDY_ISSUER: 'GAJMPX5NBOG6TQFPQGRABJEEB2YE7RFRLUKJDZAZGAD5GFX4J7TADAZ6',
+  },
+  [CHAIN.RIPPLE]: {
+    OUSG_ISSUER: 'rHuiXXjHLpMP8ZE9sSQU5aADQVWDwv6h5p',
+    OUSG_CURRENCY: '4F55534700000000000000000000000000000000',
   },
 }
 
@@ -118,6 +130,36 @@ async function getSupply(useChainApi: sdk.ChainApi): Promise<{
     return {
       OUSG: 0,
       USDY: Number(parseInt(res.data.amount.amount)) / 1e18,
+    }
+  } else if (useChainApi.chain === CHAIN.STELLAR) {
+    // Total supply = sum of every balance bucket (accounts, contracts/SAC,
+    // claimable balances, liquidity pools).
+    const { USDY_CODE, USDY_ISSUER } = OndoContracts[CHAIN.STELLAR]
+    const res = await axios.get(`https://horizon.stellar.org/assets?asset_code=${USDY_CODE}&asset_issuer=${USDY_ISSUER}`)
+    const record = res.data?._embedded?.records?.[0]
+    const usdy = record
+      ? Number(record.balances?.authorized ?? 0)
+      + Number(record.balances?.authorized_to_maintain_liabilities ?? 0)
+      + Number(record.contracts_amount ?? 0)
+      + Number(record.claimable_balances_amount ?? 0)
+      + Number(record.liquidity_pools_amount ?? 0)
+      : 0
+    return {
+      OUSG: 0,
+      USDY: usdy,
+    }
+  } else if (useChainApi.chain === CHAIN.RIPPLE) {
+    // obligations on the issuing account = total issued supply
+    const { OUSG_ISSUER, OUSG_CURRENCY } = OndoContracts[CHAIN.RIPPLE]
+    const res = await rpcCall('gateway_balances', [{
+      account: OUSG_ISSUER,
+      ledger_index: 'validated',
+      strict: true,
+    }])
+    const obligations = res?.result?.obligations || {}
+    return {
+      OUSG: Number(obligations[OUSG_CURRENCY] ?? 0),
+      USDY: 0,
     }
   } else {
     const [supplyOUSG, supplyUSDY, supplyUSDYc] = await useChainApi.multiCall({
@@ -188,6 +230,15 @@ const adapter: SimpleAdapter = {
       fetch: fetch,
     },
     [CHAIN.NOBLE]: {
+      fetch: fetch,
+    },
+    [CHAIN.SEI]: {
+      fetch: fetch,
+    },
+    [CHAIN.STELLAR]: {
+      fetch: fetch,
+    },
+    [CHAIN.RIPPLE]: {
       fetch: fetch,
     },
   },


### PR DESCRIPTION
USDY/OUSG yield was being undercounted because ~$0.9B of supply on newer chains was missing. This adds them and corrects the revenue methodology.

- **Sei** — USDY ERC20 (`0x54cD…0e2A6`), routed through the existing `totalSupply` branch.
- **Stellar** — USDY classic asset (`USDY` / issuer `GAJMPX5N…ADAZ6`), supply read from Horizon (sum of all balance buckets).
- **XRPL (ripple)** — OUSG, not USDY (`rHuiXX…6h5p`, currency hex-`OUSG`), supply read via `gateway_balances` obligations.
- **Methodology** — rewrote in plain language and made the zero-revenue result explicit: Ondo passes all yield to holders and charges no fee today (USDY none; OUSG 0.15% waived until 2027). Any spread Ondo keeps is set off-chain and isn't measurable here.

No change to the existing fee model: `dailyFees = supply × daily redemption-price increase`, summed per chain.

## Sources

- Ondo contract addresses: https://docs.ondo.finance/addresses
- USDY fees: https://docs.ondo.finance/general-access-products/usdy/faq/economics-and-fees
- OUSG fees (0.15% waived until 2027-01-01): https://docs.ondo.finance/qualified-access-products/ousg/fees-and-taxes
- Supply cross-check: https://app.rwa.xyz/assets/USDY · https://app.rwa.xyz/assets/OUSG · CoinGecko USDY

## Verification

Each address, decimal, and supply confirmed on-chain (contract/ledger as source of truth).

| Chain | Asset | Supply | Decimals | Status |
|---|---|---|---|---|
| Ethereum | USDY | 976.7M | 18 | ✅ |
| Stellar (new) | USDY | 462.8M | 7 (Horizon→whole) | ✅ |
| Sei (new) | USDY | 226.0M | 18 | ✅ |
| Solana | USDY | 159.3M | 6 | ✅ |
| Mantle | USDY | 25.4M | 18 | ✅ |
| Sui | USDY | 20.4M | 6 | ✅ |
| Aptos | USDY | 6.8M | 6 (dynamic) | ✅ logic |
| Arbitrum | USDY | 4.9M | 18 | ✅ |
| Noble | USDY | small | 18 | ✅ |
| Ethereum | OUSG | 1.899M | 18 | ✅ |
| XRPL (new) | OUSG | 2.245M | — | ✅ |

**Double-count:** none. Per-chain USDY sums to the global 1.862B and OUSG to 4.769M (rwa.xyz) — native issuance per chain, not bridged duplicates. `USDYc` totalSupply is 0 and holds no USDY (dead entry, no double-count).

**Plausibility:** ~$2.6B counted assets × ~4.5% APY ÷ 365 ≈ ~$320k/day fees.

## Notes
- OUSG's 0.15% management fee resumes **2027-01-01** — protocol revenue logic should be added then.