### PR TITLE
fix(silentswap): backfill daily volume since 2025-10-31

### DIFF
--- a/bridge-aggregators/silentswap/index.ts
+++ b/bridge-aggregators/silentswap/index.ts
@@ -29,12 +29,15 @@ function toYYYYMMDD(ts: number): bigint {
 }
 
 const fetch = async (options: FetchOptions) => {
-  const { startTimestamp, toTimestamp } = options;
+  const { startTimestamp } = options;
 
   const date = toYYYYMMDD(startTimestamp);
   const prevDate = toYYYYMMDD(startTimestamp - ONE_DAY_SECONDS);
 
-  const bscApi = new ChainApi({ chain: CHAIN.BSC, timestamp: toTimestamp });
+  // Read at the latest block: the full daily series is persisted in current
+  // storage keyed by YYYYMMDD, and the contract did not exist before 2026, so
+  // historical-block reads of pre-deployment date keys would return 0.
+  const bscApi = new ChainApi({ chain: CHAIN.BSC });
 
   const inflowData = await bscApi.multiCall({
     abi: volumeByDateAbi,
@@ -70,7 +73,7 @@ const methodology = {
 const adapter: SimpleAdapter = {
   version: 1,
   chains: [CHAIN.CHAIN_GLOBAL], // data from all chains but stored on BNB Chain
-  start: "2026-05-29",
+  start: "2025-10-31",
   fetch,
   methodology,
 };


### PR DESCRIPTION
## What

The SilentSwapStats reporter contract on BNB Chain (`0x5894a9B8B342BDb1AD7570C3656eE406eE26f676`) now holds the full anonymized daily-volume history back to **2025-10-31** (previously only late-May 2026 onward). This updates the adapter to surface that history.

## Changes

- `start`: `2026-05-29` → `2025-10-31`.
- Read `volumeByDate` at the **latest block** instead of each requested day's historical block. The contract was deployed in 2026, so historical-block reads of pre-deployment date keys returned `0`. The full series is persisted in current storage keyed by `YYYYMMDD`, so a latest-block read returns the correct snapshot for any date.
- Original doc comment and methodology are unchanged; only a short note was added explaining the latest-block read.

## Methodology (unchanged)

`dailyVolume = volumeByDate(date).inflowUsd − volumeByDate(date-1).inflowUsd` (clamped to ≥0); DefiLlama accumulates the running total. Per-order gateway addresses are intentionally not exposed to preserve user privacy.

## Test

```
$ npm test bridge-aggregators/silentswap
🦙 Running SILENTSWAP adapter 🦙
Backfill start time: 31/10/2025
Daily bridge volume: 8.21 M
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)