### PR TITLE
near-intents: split revenue by wallet to fix negative revenue component

### DIFF
--- a/fees/near-intents/index.ts
+++ b/fees/near-intents/index.ts
@@ -12,19 +12,19 @@ import { queryDuneSql } from "../../helpers/dune";
  * Revenue: NEAR's net captured revenue, measured as NEAR/wNEAR swept into its
  *   revenue wallets (NEAR's own query 6740088). Reconciles with revenue.near.org
  *   "Revenue by Stream" total (~2.4M NEAR / ~$4.2M) and the on-chain buyback.
- *   revenue.near.org splits this into Front-end, Quote Improvement,
- *   Authorized/Unauthorized partner and Private agreement streams; those shares
- *   are computed in NEAR's backend and vary over time, and the same wallets
- *   receive every stream, so we cannot attribute the captured total to a stream
- *   from on-chain data. We therefore break Revenue into the front-end affiliate
- *   fees we CAN identify by referral and lump the remainder as "Other Revenue"
- *   (see breakdown).
+ *   Split by destination wallet (NEAR's query 6732239 designations):
+ *     - Front-end Affiliate Revenue = the front-end fund (fefundsadmin, "fe").
+ *     - Other Revenue = the 1Click fund (1csfundsadmin) + buyback wallet, i.e.
+ *       1Click/partner revenue shares, quote improvement, private agreements.
+ *   Both come from the same wallet sweeps, so the split is consistent and each
+ *   part is always >= 0 (revenue.near.org's exact per-stream split is backend
+ *   logic and not reproducible from on-chain data).
  *
  * SupplySideRevenue: gross fees minus NEAR's captured revenue - the affiliate
- *   fees kept by solvers and third-party distribution channels (e.g. SwapKit,
- *   the largest). Captured revenue is realized in periodic on-chain sweeps, so
- *   on a sweep day it can exceed that day's accrued gross fees and supply-side
- *   goes briefly negative (allowNegativeValue); it nets out positive over time.
+ *   fees kept by solvers and third-party distribution channels (e.g. SwapKit).
+ *   Captured revenue is realized in periodic sweeps, so on a sweep day it can
+ *   exceed that day's accrued gross fees and supply-side goes briefly negative
+ *   (allowNegativeValue); it nets out positive over time.
  *
  * ProtocolRevenue / HoldersRevenue: captured revenue is held in treasury before
  *   BUYBACK_START and, since 2026-02-23, used to buy back $NEAR (not burned).
@@ -33,18 +33,8 @@ import { queryDuneSql } from "../../helpers/dune";
 // Date NEAR began using captured Intents revenue to buy back $NEAR
 const BUYBACK_START = '2026-02-23';
 
-// NEAR's own frontends' referral codes - used only to split Revenue into the
-// identifiable front-end affiliate portion vs Other. Best-effort (~80% of the
-// dashboard's Front-end stream); the unidentified remainder falls into Other.
-const NEAR_FRONTEND_REFERRALS = [
-  'near-intents.intents-referral.near', // near.com / app.near-intents.org
-  'new.intents-referral.near',
-  'near-intents-app',
-  'near-mobile',
-  'intents.tg',
-];
-
-// NEAR's revenue wallets (NEAR's own dune query 6740088)
+const FRONTEND_WALLET = 'fefundsadmin.sputnik-dao.near'; // NEAR front-end fund ("fe")
+// All of NEAR's revenue wallets (NEAR's own dune query 6740088)
 const FEE_WALLETS = `(VALUES
   ('fefundsadmin.sputnik-dao.near'),
   ('1csfundsadmin.sputnik-dao.near'),
@@ -52,7 +42,6 @@ const FEE_WALLETS = `(VALUES
 ) AS t(wallet)`;
 
 const fetch = async (options: FetchOptions) => {
-  const frontendList = NEAR_FRONTEND_REFERRALS.map((r) => `'${r}'`).join(', ');
   const query = `
     WITH fee_wallets AS (SELECT wallet FROM ${FEE_WALLETS}),
     gross AS (
@@ -66,21 +55,14 @@ const fetch = async (options: FetchOptions) => {
         WHERE CAST(from_iso8601_timestamp(date_at) AS DATE) = DATE '${options.dateString}'
       )
     ),
-    frontend AS (
-      SELECT SUM(CAST(fee AS double)) AS usd
-      FROM dune.near.dataset_near_intents_fees
-      WHERE CAST(from_iso8601_timestamp(date_at) AS DATE) = DATE '${options.dateString}'
-        AND referral IN (${frontendList})
-    ),
-    native AS (
-      SELECT SUM(CAST(action_transfer_deposit AS DOUBLE) / 1e24) AS near_amt
+    moves AS (
+      SELECT receipt_receiver_account_id AS wallet, CAST(action_transfer_deposit AS DOUBLE) / 1e24 AS amt
       FROM near.actions
       WHERE action_kind = 'TRANSFER' AND execution_status = 'SUCCESS_VALUE'
         AND receipt_receiver_account_id IN (SELECT wallet FROM fee_wallets)
         AND block_date = DATE '${options.dateString}'
-    ),
-    wnear AS (
-      SELECT SUM(CAST(delta_amount AS DOUBLE) / 1e24) AS near_amt
+      UNION ALL
+      SELECT affected_account_id AS wallet, CAST(delta_amount AS DOUBLE) / 1e24 AS amt
       FROM near.ft_transfers
       WHERE contract_account_id = 'wrap.near' AND delta_amount > 0
         AND affected_account_id IN (SELECT wallet FROM fee_wallets)
@@ -88,27 +70,24 @@ const fetch = async (options: FetchOptions) => {
     )
     SELECT
       COALESCE((SELECT fees_usd FROM gross), 0) AS fees_usd,
-      COALESCE((SELECT usd FROM frontend), 0) AS frontend_usd,
-      COALESCE((SELECT near_amt FROM native), 0) + COALESCE((SELECT near_amt FROM wnear), 0) AS revenue_near
+      COALESCE((SELECT SUM(amt) FROM moves WHERE wallet = '${FRONTEND_WALLET}'), 0) AS frontend_near,
+      COALESCE((SELECT SUM(amt) FROM moves WHERE wallet <> '${FRONTEND_WALLET}'), 0) AS other_near
   `;
 
   const res = await queryDuneSql(options, query);
   const fees_usd = res[0]?.fees_usd ?? 0;
-  const frontend_usd = res[0]?.frontend_usd ?? 0;
-  const revenue_near = res[0]?.revenue_near ?? 0;
-
-  // Price NEAR's captured revenue (the total that matches the buyback).
-  const captured = options.createBalances();
-  captured.addCGToken('near', revenue_near);
-  const revenue_usd = await captured.getUSDValue();
+  const frontend_near = res[0]?.frontend_near ?? 0;
+  const other_near = res[0]?.other_near ?? 0;
+  const revenue_near = frontend_near + other_near;
 
   const dailyFees = options.createBalances();
   dailyFees.addUSDValue(fees_usd, 'Swap Fees');
 
-  // Total revenue = captured; split into identifiable front-end affiliate + Other.
+  // Total revenue = captured, split by destination wallet (both >= 0).
   const dailyRevenue = options.createBalances();
-  dailyRevenue.addUSDValue(frontend_usd, 'Front-end Affiliate Revenue');
-  dailyRevenue.addUSDValue(revenue_usd - frontend_usd, 'Other Revenue');
+  dailyRevenue.addCGToken('near', frontend_near, 'Front-end Affiliate Revenue');
+  dailyRevenue.addCGToken('near', other_near, 'Other Revenue');
+  const revenue_usd = await dailyRevenue.getUSDValue();
 
   const dailySupplySideRevenue = options.createBalances();
   dailySupplySideRevenue.addUSDValue(fees_usd - revenue_usd, 'Fees To Solvers & Distribution Channels');
@@ -141,7 +120,7 @@ const adapter: SimpleAdapter = {
   allowNegativeValue: true, // sweep days: captured revenue can exceed that day's accrued fees
   methodology: {
     Fees: "Gross fees charged on NEAR Intents swaps - the protocol fee plus the affiliate (distribution) fee each frontend collects, summed across all integrators.",
-    Revenue: "NEAR's net captured revenue, measured as NEAR/wNEAR swept into its revenue wallets (reconciles with revenue.near.org and the on-chain buyback). Split into the front-end affiliate fees identifiable by referral and Other.",
+    Revenue: "NEAR's net captured revenue, measured as NEAR/wNEAR swept into its revenue wallets (reconciles with revenue.near.org and the on-chain buyback). Split by destination wallet into front-end affiliate revenue and Other.",
     ProtocolRevenue: "Captured revenue held by the treasury before the 2026-02-23 buyback program.",
     HoldersRevenue: "Since 2026-02-23, NEAR's captured Intents revenue is used to buy back $NEAR on the open market (not burned), returning value to holders.",
     SupplySideRevenue: "Gross fees minus NEAR's captured revenue - the affiliate fees kept by solvers and third-party distribution channels (e.g. SwapKit).",
@@ -151,8 +130,8 @@ const adapter: SimpleAdapter = {
       'Swap Fees': "Gross protocol + affiliate fees charged on NEAR Intents swaps across all integrators.",
     },
     Revenue: {
-      'Front-end Affiliate Revenue': "Affiliate fees from NEAR's own frontends (near.com / app.near-intents.org, NEAR mobile, etc.), identified by referral code.",
-      'Other Revenue': "All other captured revenue: quote improvement (positive slippage), authorized/unauthorized partner revenue shares, private agreements, the protocol fee, and any front-end revenue not attributed by referral.",
+      'Front-end Affiliate Revenue': "Revenue collected by NEAR's front-end fund wallet (near.com / app.near-intents.org).",
+      'Other Revenue': "All other captured revenue: 1Click and partner revenue shares, quote improvement (positive slippage), private agreements, and buyback-wallet flows.",
     },
     ProtocolRevenue: {
       'NEAR Treasury': "Captured revenue retained by the treasury before the 2026-02-23 buyback program.",


### PR DESCRIPTION
Follow-up to the merged NEAR Intents revenue PRs.

The front-end vs other revenue split mixed two timescales: front-end was read from the fee dataset (accrued daily) while the total came from wallet sweeps (realized in lumpy batches), so on a no-sweep day Other Revenue went deeply negative (e.g. 2025-10-03 showed Front-end +22055 / Other -22037, net = the $18 actually captured).

Fix: split the captured revenue by destination wallet instead, so both parts share the same basis and are always >= 0:
- Front-end Affiliate Revenue = fefundsadmin (NEAR's front-end fund)
- Other Revenue = 1csfundsadmin (1Click) + buybacks.multisignature

Total Revenue still equals captured revenue (matches the buyback). Supply-side keeps allowNegativeValue for the separate sweep-day timing.