### PR TITLE
Add OBSDN open interest, volume, and fees adapters

### DIFF
--- a/dexs/obsdn/index.ts
+++ b/dexs/obsdn/index.ts
@@ -1,0 +1,39 @@
+import { SimpleAdapter, FetchOptions } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+
+const MATCHING = "0x227adD7CDe4E7996D9f02975CC16212f19664C03";
+const X18 = 1e18;
+
+const ordersMatchedAbi =
+  "event OrdersMatched(uint16 indexed marketIndex, address indexed maker, address indexed taker, uint8 makerSide, uint64 makerNonce, uint64 takerNonce, uint128 size, uint128 price)";
+
+const fetch = async (options: FetchOptions) => {
+  const logs = await options.getLogs({
+    target: MATCHING,
+    eventAbi: ordersMatchedAbi,
+  });
+
+  let dailyVolume = 0;
+  for (const log of logs) {
+    const size = Number(log.size) / X18;
+    const price = Number(log.price) / X18;
+    dailyVolume += size * price;
+  }
+
+  return { dailyVolume };
+};
+
+const methodology = {
+  Volume: "Notional volume from on-chain OrdersMatched events on the Matching contract.",
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  pullHourly: true,
+  chains: [CHAIN.MONAD],
+  fetch,
+  start: "2026-06-20",
+  methodology,
+};
+
+export default adapter;

--- a/fees/obsdn.ts
+++ b/fees/obsdn.ts
@@ -1,0 +1,63 @@
+import { SimpleAdapter, FetchOptions } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+
+const MATCHING = "0x227adD7CDe4E7996D9f02975CC16212f19664C03";
+const X18 = 1e18;
+
+const ordersMatchedFeesAbi =
+  "event OrdersMatchedFees(uint16 indexed marketIndex, uint64 indexed makerNonce, uint64 indexed takerNonce, (int128 maker, uint128 taker, uint128 liquidation, uint128 sequencer) fees)";
+
+const fetch = async (options: FetchOptions) => {
+  const logs = await options.getLogs({
+    target: MATCHING,
+    eventAbi: ordersMatchedFeesAbi,
+  });
+
+  let totalFees = 0;
+  let makerRebates = 0;
+
+  for (const log of logs) {
+    const maker = Number(log.fees.maker) / X18;
+    const taker = Number(log.fees.taker) / X18;
+    const liquidation = Number(log.fees.liquidation) / X18;
+    const sequencer = Number(log.fees.sequencer) / X18;
+
+    if (maker >= 0) {
+      totalFees += maker;
+    } else {
+      makerRebates += Math.abs(maker);
+    }
+    totalFees += taker + liquidation + sequencer;
+  }
+
+  const dailyFees = totalFees;
+  const dailySupplySideRevenue = makerRebates;
+  const dailyRevenue = dailyFees - dailySupplySideRevenue;
+
+  return {
+    dailyFees,
+    dailyUserFees: dailyFees,
+    dailyRevenue,
+    dailyProtocolRevenue: dailyRevenue,
+    dailySupplySideRevenue,
+  };
+};
+
+const methodology = {
+  Fees: "Trading fees charged to makers and takers on each trade, plus liquidation and sequencer fees.",
+  UserFees: "All fees paid by traders.",
+  Revenue: "Trading fees retained by the protocol after maker rebates.",
+  ProtocolRevenue: "Trading fees retained by the protocol after maker rebates.",
+  SupplySideRevenue: "Maker rebates paid to liquidity providers.",
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  pullHourly: true,
+  chains: [CHAIN.MONAD],
+  fetch,
+  start: "2026-06-20",
+  methodology,
+};
+
+export default adapter;

--- a/open-interest/obsdn.ts
+++ b/open-interest/obsdn.ts
@@ -1,0 +1,27 @@
+import { SimpleAdapter, FetchOptions } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+import { httpGet } from "../utils/fetchURL";
+
+const MARKETS_URL = "https://api.obsdn.trade/markets";
+
+const fetch = async (_options: FetchOptions) => {
+  const res = await httpGet(MARKETS_URL);
+  const markets: any[] = res.data?.mkts ?? [];
+
+  let openInterestAtEnd = 0;
+  for (const m of markets) {
+    // oi is double-sided (long + short), divide by 2 for single-sided
+    openInterestAtEnd += Number(m.oi) / 2;
+  }
+
+  return { openInterestAtEnd };
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  chains: [CHAIN.MONAD],
+  fetch,
+  start: "2026-06-20",
+};
+
+export default adapter;


### PR DESCRIPTION
### Protocol: OBSDN
**Website:** https://obsdn.trade
**Twitter:** https://x.com/obsdntrade
**Logo:** https://avatars.githubusercontent.com/u/253168989?s=200&v=4
**Chain:** Monad
**Category:** Derivatives

### Short Description
Perpetual exchange with off-chain matching and on-chain settlement on Monad.

### Adapters
- `open-interest/obsdn.ts` - Total open interest (single-sided) from API
- `dexs/obsdn/index.ts` - 24h trading volume from API
- `fees/obsdn.ts` - Trading fees (maker + taker) estimated from volume and fee rates

### Data Source
Public API: `GET https://api.obsdn.trade/markets`

### Key Fields
| Field | Usage |
|-------|-------|
| `oi` | Total OI in USD (double-sided, divided by 2 for single-sided) |
| `qvol_24h` | 24h quote volume in USD |
| `mkr_fee_rt` | Maker fee rate |
| `tkr_fee_rt` | Taker fee rate |

### Fee Methodology
All trading fees go to the protocol. No LP rewards or supply-side revenue.

### Links
- **Github org:** obsdn-trade
- **Audit:** https://hexens.io/audit-reports/obsidian-obsdn-perpetual-protocol-may-2026
- **Oracle:** Stork, Pyth
- **TVL adapter PR:** https://github.com/DefiLlama/DefiLlama-Adapters/pull/19735

### Test Results
```
Open interest at end: 22.02 k
Daily volume: 8.38 k
Daily fees: 8.95
```