### PR TITLE
Add Bloxwap Hyperliquid builder fees adapter

### DIFF
--- a/factory/hyperliquid.ts
+++ b/factory/hyperliquid.ts
@@ -30,6 +30,16 @@ const superxConfig: BuilderConfig = {
 // factory export. The DefiLlama dimension framework picks the appropriate
 // fields (volume vs fees) based on each protocol's metadata adapter type.
 const builderConfigs: Record<string, BuilderConfig> = {
+  "bloxwap-perps": {
+    addresses: ["0x71b09a08257078a4d642f7dd7315e656c837329a"],
+    start: "2026-04-25",
+    methodology: {
+      Fees: "Builder code fees (0.05%) paid by users on perpetual trades routed to Hyperliquid through Bloxwap.",
+      Revenue: "Builder code fees collected by Bloxwap from Hyperliquid perps trades.",
+      ProtocolRevenue: "Builder code fees collected by Bloxwap from Hyperliquid perps trades.",
+    },
+    breakdownFees: true,
+  },
   "trust-wallet-perps": {
     addresses: ["0x5af1b5f44207784dcb850bbb4143c5dcd1885f71"],
     start: "2026-04-08",


### PR DESCRIPTION
### What

Adds **Bloxwap** as a Hyperliquid builder-code protocol. Like the other Hyperliquid builders (Trust Wallet, MetaMask, Phantom, Rabby, etc.), it is a single entry in `factory/hyperliquid.ts` → `builderConfigs`, fed through the shared `exportBuilderAdapter()` helper, so it surfaces both **fees/revenue** (builder-code fees) and **dexs** (routed perp notional).

```ts
"bloxwap-perps": {
  addresses: ["0x71b09a08257078a4d642f7dd7315e656c837329a"],
  start: "2026-04-25",
  methodology: { Fees: "Builder code fees (0.05%) …", Revenue: "…", ProtocolRevenue: "…" },
  breakdownFees: true,
}
```

- **Builder address:** `0x71b09a08257078a4d642f7dd7315e656c837329a` (the address Bloxwap registers its HL builder code to)
- **Start:** `2026-04-25` — first day HL publishes `builder_fills` for this address (2026-04-24 and earlier return HTTP 403)
- **Builder fee rate:** ~0.05% (50 tenths-bp), within HL's 0.1% perp builder-fee cap. Rate is descriptive only — fees come straight from HL's `builder_fee` column / indexer `feeByTokens`.
- `doublecounted: true` is set by `exportBuilderAdapter` (builder fees are a carve-out of Hyperliquid's own fees).

### Verification

Validated against live HL data (`stats-data.hyperliquid.xyz/Mainnet/builder_fills/<addr>/<YYYYMMDD>.csv.lz4`), replicating the helper's `builder_fee`/`px`/`sz` parsing:

| Date | builder_fee | notional (px·sz) | rate |
|---|---|---|---|
| 2026-05-01 | 36.855515 USDC | $73,711.09 | 0.04999996% |
| 2026-06-15 | 32.941046 USDC | — | (ongoing) |

`pnpm test fees bloxwap-perps 2026-05-01` runs clean (exit 0): resolves via the hyperliquid factory, non-zero daily fees/revenue/volume, with a `Hyperliquid Builder Code Fees` breakdown line.

### Listing info

- **Name:** Bloxwap
- **Website:** https://bloxwap.com
- **Chain:** Hyperliquid
- **Short description:** Mobile-first Hyperliquid trading app; routes perpetual trades to Hyperliquid and earns builder-code fees.
- **Methodology:** Counts the builder-code fees accruing to Bloxwap's Hyperliquid builder address on perps trades routed through the app (Fees = Revenue = ProtocolRevenue, since the builder keeps 100% of the builder fee).
- **Category / slug:** registry key is `bloxwap-perps` (matches the `-perps` convention used by the other wallet builders). Happy to align the slug/category to however you'd like Hyperliquid builders categorized.

Per the template: only `factory/hyperliquid.ts` is touched (no `package.json`/lockfile changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
