### PR TITLE
feat: Beam - Add fees, active users and new users adapters

### DIFF
--- a/fees/beam.ts
+++ b/fees/beam.ts
@@ -1,0 +1,28 @@
+import { Adapter, FetchOptions, ProtocolType } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+import fetchURL from "../utils/fetchURL";
+
+async function fetch(options: FetchOptions) {
+    const dailyFees = options.createBalances();
+    const dateString = options.dateString;
+    const feeData = await fetchURL(`https://api.routescan.io/v2/network/mainnet/evm/4337/etherscan/api?module=stats&action=dailytxnfee`);
+    if (!Array.isArray(feeData?.result))
+        throw new Error(`Beam: invalid Routescan response (expected array, got ${typeof feeData?.result})`);
+    const feeToday = feeData.result.find((fee: any) => fee.UTCDate === dateString);
+    if (!feeToday) {
+        throw new Error(`Beam: no fee data for ${dateString}`);
+    }
+
+    dailyFees.addCGToken("beam-2", +feeToday.transactionFee_Eth);
+    return { dailyFees };
+}
+
+const adapter: Adapter = {
+    version: 1,
+    fetch,
+    chains: [CHAIN.BEAM],
+    start: "2023-08-14",
+    protocolType: ProtocolType.CHAIN,
+};
+
+export default adapter;

--- a/helpers/chains.ts
+++ b/helpers/chains.ts
@@ -23,6 +23,7 @@ export enum CHAIN {
   BSC = "bsc",
   BIFROST = "bifrost",
   BOTANIX = "btnx",
+  BEAM = "beam",
   CELO = "celo",
   ETHEREUM = "ethereum",
   FANTOM = "fantom",

--- a/users/utils/routescanStats.ts
+++ b/users/utils/routescanStats.ts
@@ -22,6 +22,7 @@ const routescanStatsChains: Record<string, ChainConfig> = {
   chz: { chain: CHAIN.CHILIZ, chainId: 88888, start: "2023-02-08" },
   nibiru: { chain: CHAIN.NIBIRU, chainId: 6900, start: "2025-02-11" },
   btnx: { chain: CHAIN.BOTANIX, chainId: 3637, start: "2025-05-22" },
+  beam: { chain: CHAIN.BEAM, chainId: 4337, start: "2023-08-14" },
 };
 
 async function fetchMetric(config: ChainConfig, metric: string, date: string) {


### PR DESCRIPTION
  ### Summary

  Adds dimension tracking for the Beam chain (chainId 4337), covering fees, active users, and
  new users. All data is sourced from Routescan, which fully indexes Beam.

  Changes
  - helpers/chains.ts — registered BEAM = "beam" in the CHAIN enum.
  - fees/beam.ts — new chain-fees adapter using Routescan's dailytxnfee endpoint; fees are denominated in the
  native gas token and priced via CoinGecko id beam-2.
  - users/utils/routescanStats.ts — added Beam to routescanStatsChains, which auto-generates the active-users
  (addresses + txs) and new-users (unique-addresses delta) exports via the existing users/chains.ts wiring.
  - https://defillama.com/chain/beam