### PR TITLE
upshift: value multiAssetVaults off-chain, add Flare + Fluent

### DIFF
--- a/fees/upshift/index.ts
+++ b/fees/upshift/index.ts
@@ -12,11 +12,46 @@ const CHAIN_ID_MAP: any = {
   [CHAIN.HYPERLIQUID]: 999,
   [CHAIN.BSC]: 56,
   [CHAIN.MONAD]: 143,
+  [CHAIN.FLARE]: 14,
+  [CHAIN.FLUENT]: 25363,
 }
 const ONE_YEAR = 365 * 24 * 60 * 60;
 
 async function prefetch(_a: any): Promise<any> {
   return await getConfig('upshift-vaults', UPSHIFT_API);
+}
+
+// Reported NAV snapshot for off-chain valued vaults (multiAssetVault).
+// asset_share_ratio is the NAV per share in asset units, underlying_price is asset->USD.
+type Snapshot = {
+  asset_share_ratio: number;
+  total_shares: number;
+  underlying_price: number;
+  tvl: number; // USD
+  snapshot_datetime: string;
+};
+
+const snapshotSeconds = (s: Snapshot) => Date.parse(s.snapshot_datetime.split('.')[0] + 'Z') / 1000;
+
+// latest snapshot at or before the given timestamp (seconds)
+function snapshotAt(snapshots: Snapshot[], timestamp: number): Snapshot | undefined {
+  let best: Snapshot | undefined;
+  let bestTs = -Infinity;
+  for (const s of snapshots) {
+    const ts = snapshotSeconds(s);
+    if (ts <= timestamp && ts > bestTs) {
+      bestTs = ts;
+      best = s;
+    }
+  }
+  return best;
+}
+
+// a date-string waiver is active while now < the waived-until date
+const waivedByDate = (until: any, nowSeconds: number) => {
+  if (!until) return false;
+  const ts = Date.parse(until) / 1000;
+  return !isNaN(ts) && ts > nowSeconds;
 }
 
 async function fetch(options: FetchOptions): Promise<FetchResultV2> {
@@ -30,8 +65,42 @@ async function fetch(options: FetchOptions): Promise<FetchResultV2> {
   const currentChainVaults = vaultsData.filter((vault: any) => vault.chain === CHAIN_ID_MAP[options.chain]);
 
   await Promise.allSettled(currentChainVaults.map(async (vault: any) => {
-    const { address, weekly_performance_fee_bps, platform_fee_override } = vault;
+    const { address, weekly_performance_fee_bps, platform_fee_override, internal_type } = vault;
     const management_fee = platform_fee_override?.management_fee ?? 0;
+
+    // weekly_performance_fee_bps holds the performance fee as a percentage of yield
+    // (e.g. 10 = 10% of yield above the high watermark), waived while perf waiver is active.
+    const perfFee = waivedByDate(vault.performance_fee_waived_until_date, options.toTimestamp)
+      ? 0 : (weekly_performance_fee_bps ?? 0) / 100;
+    const mgmtWaived = platform_fee_override?.is_fee_waived === true
+      || waivedByDate(vault.management_fee_waived_until_date, options.toTimestamp);
+
+    if (internal_type === 'multiAssetVault') {
+      // multiAssetVault contracts expose no standard ERC4626 reads on-chain (asset() only);
+      // NAV is reported off-chain, so value from the API's daily NAV snapshots.
+      const snapshots: Snapshot[] = vault.historical_snapshots ?? [];
+      const before = snapshotAt(snapshots, options.fromTimestamp);
+      const after = snapshotAt(snapshots, options.toTimestamp);
+
+      if (before && after && after !== before) {
+        const netYieldUsd = (after.asset_share_ratio - before.asset_share_ratio) * after.total_shares * after.underlying_price;
+        if (netYieldUsd > 0) {
+          dailySupplySideRevenue.addUSDValue(netYieldUsd, 'Assets Yields To Suppliers');
+          const grossYieldUsd = netYieldUsd / (1 - perfFee);
+          dailyFees.addUSDValue(grossYieldUsd, METRIC.ASSETS_YIELDS);
+          dailyRevenue.addUSDValue(grossYieldUsd - netYieldUsd, METRIC.PERFORMANCE_FEES);
+        }
+      }
+
+      if (after && !mgmtWaived && management_fee) {
+        const dailyManagementFee = after.tvl * (management_fee / 100) * ((options.toTimestamp - options.fromTimestamp) / ONE_YEAR);
+        dailyFees.addUSDValue(dailyManagementFee, METRIC.MANAGEMENT_FEES);
+        dailyRevenue.addUSDValue(dailyManagementFee, METRIC.MANAGEMENT_FEES);
+      }
+      return;
+    }
+
+    // tokenizedVault / lendingPool: standard ERC4626 reads on-chain.
     const dailyYield = await getERC4626VaultsYield({ options, vaults: [address] });
     const totalAssets = await options.api.call({
       target: address,
@@ -46,11 +115,11 @@ async function fetch(options: FetchOptions): Promise<FetchResultV2> {
 
     if (+Object.values(dailyYield._balances)[0] > 0) {
       dailySupplySideRevenue.add(dailyYield, 'Assets Yields To Suppliers');
-      dailyFees.add(dailyYield.clone(1 / (1 - weekly_performance_fee_bps / 100)), METRIC.ASSETS_YIELDS);
-      dailyRevenue.add(dailyYield.clone(1 / (1 - weekly_performance_fee_bps / 100) - 1), METRIC.PERFORMANCE_FEES);
+      dailyFees.add(dailyYield.clone(1 / (1 - perfFee)), METRIC.ASSETS_YIELDS);
+      dailyRevenue.add(dailyYield.clone(1 / (1 - perfFee) - 1), METRIC.PERFORMANCE_FEES);
     }
 
-    if (totalAssets && asset) {
+    if (totalAssets && asset && !mgmtWaived && management_fee) {
       const dailyManagementFee = totalAssets * (management_fee / 100) * ((options.toTimestamp - options.fromTimestamp) / ONE_YEAR)
       dailyFees.add(asset, dailyManagementFee, METRIC.MANAGEMENT_FEES);
       dailyRevenue.add(asset, dailyManagementFee, METRIC.MANAGEMENT_FEES);
@@ -98,6 +167,8 @@ const adapter: Adapter = {
     [CHAIN.BSC]: { start: '2025-04-10' },
     [CHAIN.HYPERLIQUID]: { start: '2025-04-04' },
     [CHAIN.MONAD]: { start: '2025-11-23' },
+    [CHAIN.FLARE]: { start: '2025-12-09' },
+    [CHAIN.FLUENT]: { start: '2026-04-21' },
   },
   methodology,
   breakdownMethodology,

--- a/fees/upshift/index.ts
+++ b/fees/upshift/index.ts
@@ -84,6 +84,7 @@ async function fetch(options: FetchOptions): Promise<FetchResultV2> {
 
       if (before && after && after !== before) {
         const netYieldUsd = (after.asset_share_ratio - before.asset_share_ratio) * after.total_shares * after.underlying_price;
+        // floor at zero on NAV drawdowns: a loss day generates no fees and is not clawed back from suppliers
         if (netYieldUsd > 0) {
           dailySupplySideRevenue.addUSDValue(netYieldUsd, 'Assets Yields To Suppliers');
           const grossYieldUsd = netYieldUsd / (1 - perfFee);


### PR DESCRIPTION

* **Value `multiAssetVault` vaults from reported NAV snapshots.** These vaults do not expose the ERC4626 reads required by the existing valuation path (`decimals`, `totalSupply`, `convertToAssets`, and `totalAssets` all revert; only `asset()` succeeds), causing them to be valued at **$0**. This affected all Flare and Fluent vaults and portions of already-supported TVL (including Ethereum and Monad). For `is_charge_fees_manual: true` vaults, valuation now uses API NAV snapshots: supply-side yield is calculated from the change in `asset_share_ratio` over the fetch window, multiplied by `total_shares` and underlying asset price; management fees are derived from reported USD TVL.
* **Retain the existing on-chain ERC4626 path** for `tokenizedVault` and `lendingPool` vaults, which expose the required reads.
* **Add support for Flare** (chainId 14, inception 2025-12-09) and **Fluent** (chainId 25363, inception 2026-04-21).

### Impact (live run)

* Aggregate daily fees: **$14.9k → $36.3k**
* Supply-side revenue: **$12.4k → $31.4k**
* Flare: **$4.92k/day** (previously $0)
* Fluent: **$5.52k/day** (previously $0)

Flare currently contributes only performance-fee revenue because its management fee is waived (`is_fee_waived: true`).

### Verification

* Per-vault validation confirms that `daily_pnl_per_share` matches the day-over-day change in `asset_share_ratio`; calculations use realized NAV growth rather than the marketing-facing `reported_apy`.
