### PR TITLE
stader: add hedera fees

### DIFF
--- a/fees/stader.ts
+++ b/fees/stader.ts
@@ -41,10 +41,10 @@ const fetchEthereum: FetchV2 = async (options: FetchOptions) => {
   });
   dailyFees.addBalances(dailyMaticXFees);
   dailyRevenue.addBalances(dailyMaticXRev);
-  
+
   const dailySupplySideRevenue = dailyFees.clone(1);
   dailySupplySideRevenue.subtract(dailyRevenue);
-  
+
   const dailyProtocolRevenue = dailyRevenue.clone(0.5)
   const dailyHoldersRevenue = dailyRevenue.clone(0.5)
 
@@ -69,12 +69,50 @@ const fetch: FetchV2 = async (option: FetchOptions) => {
   });
 
   const dailyRevenue = dailyFees.clone(1 / 9);
-  
+
   const dailySupplySideRevenue = dailyFees.clone(1);
   dailySupplySideRevenue.subtract(dailyRevenue);
-  
+
   const dailyProtocolRevenue = dailyRevenue.clone(0.5)
   const dailyHoldersRevenue = dailyRevenue.clone(0.5)
+
+  return {
+    dailyFees,
+    dailyRevenue,
+    dailySupplySideRevenue,
+    dailyProtocolRevenue,
+    dailyHoldersRevenue,
+  };
+};
+
+// Hedera HBARX: liquid-staked HBAR. The StakePoolsManager contract takes a 10%
+// protocol fee on staking rewards and emits it as nodeStakingDaoFeeTransfer; the
+// remaining 90% accrues to HBARX holders via the HBARX:HBAR exchange rate.
+const STADER_HEDERA_STAKE_MANAGER = "0x0000000000000000000000000000000000158d97"; // 0.0.1412503
+
+const fetchHedera: FetchV2 = async (options: FetchOptions) => {
+  const dailyFees = options.createBalances();
+  const dailyRevenue = options.createBalances();
+
+  const feeLogs = await options.getLogs({
+    target: STADER_HEDERA_STAKE_MANAGER,
+    eventAbi: "event nodeStakingDaoFeeTransfer(address indexed to, uint256 amount)",
+  });
+
+  let daoFeeHbar = 0;
+  feeLogs.forEach((log: any) => {
+    daoFeeHbar += Number(log.amount) / 1e8; // amount is in tinybar (HBAR has 8 decimals)
+  });
+
+  // daoFee is the 10% protocol cut on staking rewards => gross rewards = daoFee * 10
+  dailyRevenue.addCGToken("hedera-hashgraph", daoFeeHbar);
+  dailyFees.addCGToken("hedera-hashgraph", daoFeeHbar * 10);
+
+  const dailySupplySideRevenue = dailyFees.clone(1);
+  dailySupplySideRevenue.subtract(dailyRevenue);
+
+  const dailyProtocolRevenue = dailyRevenue.clone(0.8);
+  const dailyHoldersRevenue = dailyRevenue.clone(0.2);
 
   return {
     dailyFees,
@@ -95,6 +133,10 @@ const adapter: SimpleAdapter = {
     [CHAIN.BSC]: {
       fetch: fetch,
       start: "2022-07-27",
+    },
+    [CHAIN.HEDERA]: {
+      fetch: fetchHedera,
+      start: "2022-11-06",
     },
   },
   dependencies: [Dependencies.DUNE],

--- a/fees/stader.ts
+++ b/fees/stader.ts
@@ -45,8 +45,8 @@ const fetchEthereum: FetchV2 = async (options: FetchOptions) => {
   const dailySupplySideRevenue = dailyFees.clone(1);
   dailySupplySideRevenue.subtract(dailyRevenue);
 
-  const dailyProtocolRevenue = dailyRevenue.clone(0.5)
-  const dailyHoldersRevenue = dailyRevenue.clone(0.5)
+  const dailyProtocolRevenue = dailyRevenue.clone(0.8)
+  const dailyHoldersRevenue = dailyRevenue.clone(0.2)
 
   return {
     dailyFees,
@@ -73,8 +73,8 @@ const fetch: FetchV2 = async (option: FetchOptions) => {
   const dailySupplySideRevenue = dailyFees.clone(1);
   dailySupplySideRevenue.subtract(dailyRevenue);
 
-  const dailyProtocolRevenue = dailyRevenue.clone(0.5)
-  const dailyHoldersRevenue = dailyRevenue.clone(0.5)
+  const dailyProtocolRevenue = dailyRevenue.clone(0.8)
+  const dailyHoldersRevenue = dailyRevenue.clone(0.2)
 
   return {
     dailyFees,


### PR DESCRIPTION
Adds Hedera (HBARX liquid staking) to the Stader fees adapter, which previously only covered Ethereum and BSC. HBARX is ~$36M TVL and was reporting zero fees.

Also reconciles the Ethereum/BSC protocol-vs-holders revenue split from `0.5/0.5` to `0.8/0.2`, which now matches what the adapter's own `methodology` already states ("80% revenue as protocol revenue", "20% … buyback").

## How

The Hedera StakePoolsManager (`0.0.1412503` / `0x…158d97`) takes a **10% protocol fee on staking rewards** and emits it as `nodeStakingDaoFeeTransfer(address,uint256)`; the other 90% accrues to HBARX holders via the HBARX:HBAR exchange rate.

- `dailyFees` = DAO fee × 10 (the fee is 10% of gross rewards)
- `dailyRevenue` = DAO fee
- `dailySupplySideRevenue` = 90% of rewards (to holders)
- `dailyProtocolRevenue` / `dailyHoldersRevenue` = 80% / 20% of revenue

## Verification

Adapter run — `pnpm test fees stader 2026-06-19`:

```
chain     | Daily fees | Daily revenue | Supply side | Protocol rev | Holders rev | Start
ethereum  | 21.14 k    | 1.17 k        | 19.96 k     | 937.00       | 234.00      | 12/4/2022
bsc       | 0.00       | 0.00          | 0.00        | 0.00         | 0.00        | 27/7/2022
hedera    | 1.88 k     | 188.00        | 1.69 k      | 150.00       | 38.00       | 6/11/2022
Aggregate | 23.02 k    | 1.36 k        | 21.66 k     | 1.09 k       | 272.00      |
```

## Sources

- [Stader Hedera fees docs](https://stader.gitbook.io/stader/hedera/fees) — 10% protocol fee on staking rewards.
- [Stader HBARX docs](https://www.staderlabs.com/docs-v1/hedera/HBARX/) — exchange-rate mechanics.
- Deployed StakePoolsManager `0.0.1412503` (verified on Sourcify, chain 295) — `nodeStakingDaoFeeTransfer` event + `getExchangeRate()`/`totalSupply()` getters.
- Buyback policy (`HoldersRevenue` 20%): [Stader SD intro](https://staderlabs.notion.site/Introducing-SD-1160c9a4217d477eaafb963e21f90aba).
