### PR TITLE
fix: deprecated flow explorer

### DIFF
--- a/helpers/blockscoutFees.ts
+++ b/helpers/blockscoutFees.ts
@@ -12,7 +12,7 @@ export const chainConfigMap: any = {
   [CHAIN.CRONOS]: { explorer: 'https://cronos.org/explorer', CGToken: 'crypto-com-chain', },
   [CHAIN.MIXIN]: { explorer: 'https://scan.mvm.dev', CGToken: 'mixin' },
   [CHAIN.ENERGYWEB]: { explorer: 'https://explorer.energyweb.org', CGToken: 'energy-web-token', burnRatio: 0 },
-  [CHAIN.FLOW]: { explorer: 'https://evm.flowscan.io', CGToken: 'flow', allStatsApi: 'https://evm.flowscan.io:8080' },
+  [CHAIN.FLOW]: { explorer: 'https://evm.flow.com', CGToken: 'flow', allStatsApi: 'https://evm.flow.com:8080' },
   [CHAIN.IMX]: { explorer: 'https://explorer.immutable.com', CGToken: 'immutable-x', allStatsApi: 'https://stats-immutable-mainnet.k8s.blockscout.com' },
   [CHAIN.ZETA]: { explorer: 'https://zetachain.blockscout.com', CGToken: 'zetachain' },
   [CHAIN.ETHERLINK]: { explorer: 'https://explorer.etherlink.com', CGToken: 'tezos', allStatsApi: 'https://stats-etherlink-mainnet.k8s-prod-1.blockscout.com' },

--- a/users/utils/blockscoutStats.ts
+++ b/users/utils/blockscoutStats.ts
@@ -33,7 +33,7 @@ const blockscoutStatsChains: Record<string, ChainConfig> = {
   filecoin: { chain: CHAIN.FILECOIN, baseUrl: "https://filecoin.blockscout.com", version: 2, start: "2023-03-14" },
   flare: { chain: CHAIN.FLARE, baseUrl: "https://flare-explorer.flare.network", version: 1, start: "2022-07-13" },
   flynet: { chain: CHAIN.FLYNET, baseUrl: "https://explorer.flynet.org", version: 1, start: "2025-02-14" },
-  flow: { chain: CHAIN.FLOW, baseUrl: "https://evm.flowscan.io", statsUrl: "https://evm.flowscan.io:8080", version: 1, start: "2024-09-04" },
+  flow: { chain: CHAIN.FLOW, baseUrl: "https://evm.flow.com", version: 2, start: "2024-09-04" },
   fuse: { chain: CHAIN.FUSE, baseUrl: "https://explorer.fuse.io", version: 2, start: "2019-07-29" },
   harmony: { chain: CHAIN.HARMONY, baseUrl: "https://explorer.harmony.one", statsUrl: "https://stats.explorer.harmony.one", version: 1, start: "2019-08-15" },
   hemi: { chain: CHAIN.HEMI, baseUrl: "https://explorer.hemi.xyz", version: 1, start: "2024-09-09" },


### PR DESCRIPTION
Blockscout instance on the v2 stats API verified returning real daily data (newTxns/activeAccounts/newAccounts). 