### PR TITLE
Fix Fuel Ignition fees adapter: migrate to new blob-fees indexer

### DIFF
--- a/fees/fuel-ignition.ts
+++ b/fees/fuel-ignition.ts
@@ -60,6 +60,11 @@ const fetch = async (options: FetchOptions) => {
   };
 };
 
+const methodology = {
+  Fees: "Transaction gas fees (in ETH) paid by users on the Fuel Ignition network.",
+  Revenue: "Blob/data-availability fees (in FUEL) for posting Fuel batch data to the DA layer.",
+};
+
 const adapter: SimpleAdapter = {
   version: 1,
   runAtCurrTime: true,
@@ -67,6 +72,7 @@ const adapter: SimpleAdapter = {
   chains: [CHAIN.FUEL],
   start: '2024-11-01',
   protocolType: ProtocolType.CHAIN,
+  methodology,
 };
 
 export default adapter;

--- a/fees/fuel-ignition.ts
+++ b/fees/fuel-ignition.ts
@@ -2,7 +2,7 @@ import { SimpleAdapter, FetchOptions, ProtocolType } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
 import { httpGet, httpPost } from "../utils/fetchURL";
 
-const INDEXER_URL = "https://indexer-fuel-seq.simplystaking.xyz";
+const INDEXER_URL = "https://index-api.sequencer.mainnet.fuel.network";
 const EXPLORER_URL = "https://explorer-indexer-mainnet.fuel.network/graphql";
 
 interface BlobFeesResponse {
@@ -17,7 +17,7 @@ interface BlobFeesResponse {
 const fetch = async (options: FetchOptions) => {
   const dailyFees = options.createBalances();
   const dailyRevenue = options.createBalances();
-  
+
   const url = `${INDEXER_URL}/seq/blob-fees?start=${options.fromTimestamp}&end=${options.toTimestamp}`;
   const res: BlobFeesResponse = await httpGet(url);
 
@@ -41,15 +41,15 @@ const fetch = async (options: FetchOptions) => {
       'x-api-key': 'Bearer nZ9GZ' + 'ayrd8',
     }
   });
-  
+
   let totalGasSpent = 0;
   for (const item of dataResponse.data.statistics.nodes.totalFee) {
     totalGasSpent += Number(item.value);
   }
-  
+
   // total gas spent in ETH, numbers are in 9 decimals
   dailyFees.addCGToken('ethereum', totalGasSpent / 1e9);
-  
+
   // totalFees is in smallest unit (10^9 = 1 FUEL)
   const fuelBlobFees = Number(res.totalFees) / Math.pow(10, res.decimals);
   dailyRevenue.addCGToken("fuel-network", fuelBlobFees);


### PR DESCRIPTION
## summary
 Fix Fuel Ignition fees adapter: migrate to new blob-fees indexer

  ### Problem

The Fuel Ignition adapter's blob/DA fee source, https://indexer-fuel-seq.simplystaking.xyz/seq/blob-fees, is down (returns 503), so the adapter could no longer fetch blob fees.

  Investigation

  I reached out to the Fuel team about where DA (blob) fees can still be tracked. They pointed me to a new
  sequencer indexer host:

  ▎ index-api.sequencer.mainnet.fuel.network

  The new host exposes the same path and response schema as the old one, just under a different domain. Confirmed
  it's live and serving daily data right up to the current date, e.g.:

 
  ```http
  GET https://index-api.sequencer.mainnet.fuel.network/seq/blob-fees?start=1767225600&end=1767312000

  {
    "totalFees": "7608815104",
    "feeDenom": "fuel",
    "decimals": 9,
    "blobCount": 7196,
    "startTimestamp": 1767225600,
    "endTimestamp": 1767312000
  }
  ```

  Changes

  - Point INDEXER_URL at the new host https://index-api.sequencer.mainnet.fuel.network (path /seq/blob-fees and
  schema unchanged).
  - Add a methodology block documenting the two metrics:
    - Fees — transaction gas fees (in ETH) paid by users on Fuel Ignition.
    - Revenue — blob/data-availability fees (in FUEL) for posting Fuel batch data to the DA layer.


