### PR TITLE
[feat] Avici-Card-Fees: track fees and revenue

### DIFF
--- a/dexs/avici.ts
+++ b/dexs/avici.ts
@@ -3,6 +3,11 @@ import { FetchOptions, SimpleAdapter } from "../adapters/types";
 import { httpGet } from "../utils/fetchURL";
 
 const OVERVIEW_API = "https://www.endbanks.org/api/relay-swaps/overview?timePeriod=all";
+// Source: https://dune.com/queries/7336077/11261155
+// Float yield is excluded because the 50% yield share is an estimate and can be wrong.
+// Card issuing fees are excluded because there are not enough reliable sources to track them.
+const INTERCHANGE_RATE = 0.0125;
+const INTERCHANGE_FEES = "Interchange Fees";
 
 interface GraphDataPoint {
   dateFull: string; // e.g. "2025-12-18T00:00:00.000Z"
@@ -12,16 +17,41 @@ interface GraphDataPoint {
 
 const fetch = async (options: FetchOptions) => {
   const dailyVolume = options.createBalances();
+  const dailyFees = options.createBalances();
+  const dailyRevenue = options.createBalances();
 
   const res = await httpGet(OVERVIEW_API);
   const graphData: GraphDataPoint[] = res?.graph_data ?? [];
 
   const dayItem = graphData.find((point: GraphDataPoint) => options.startOfDay === Math.floor(new Date(point.dateFull).getTime() / 1000))
   if (!dayItem) throw Error(`no data found for day ${options.dateString}`);
-  
-  dailyVolume.addUSDValue(dayItem.total_volume_usd)
 
-  return { dailyVolume };
+  const interchangeFees = dayItem.total_volume_usd * INTERCHANGE_RATE;
+
+  dailyVolume.addUSDValue(dayItem.total_volume_usd)
+  dailyFees.addUSDValue(interchangeFees, INTERCHANGE_FEES);
+  dailyRevenue.addUSDValue(interchangeFees, INTERCHANGE_FEES);
+
+  return { dailyVolume, dailyFees, dailyRevenue, dailyProtocolRevenue: dailyRevenue };
+};
+
+const methodology = {
+  Volume: "Total USD value of Relay swaps routed through Avici, sourced from the endbanks.org overview API.",
+  Fees: "Includes interchange fees, calculated as 1.25% of Avici card spend.",
+  Revenue: "Revenue is the full interchange amount retained by Avici.",
+  ProtocolRevenue: "Protocol revenue is the full interchange amount retained by Avici.",
+};
+
+const breakdownMethodology = {
+  Fees: {
+    [INTERCHANGE_FEES]: "Interchange fees calculated as 1.25% of Avici card spend.",
+  },
+  Revenue: {
+    [INTERCHANGE_FEES]: "Interchange fees retained by Avici.",
+  },
+  ProtocolRevenue: {
+    [INTERCHANGE_FEES]: "Interchange fees retained by Avici.",
+  },
 };
 
 const adapter: SimpleAdapter = {
@@ -29,9 +59,8 @@ const adapter: SimpleAdapter = {
   fetch,
   chains: [CHAIN.ETHEREUM],
   start: '2025-12-18',
-  methodology: {
-    Volume: "Total USD value of Relay swaps routed through Avici, from the endbanks.org overview API.",
-  },
+  methodology,
+  breakdownMethodology,
 };
 
 export default adapter;


### PR DESCRIPTION
Tracks avici #7678 

## Summary
- Adds Avici fee and revenue tracking to `dexs/avici.ts` alongside existing Relay swap volume.
- Reports interchange fees as Avici revenue and protocol revenue using the endbanks.org overview API card spend data.

## Changes
- Added `dailyFees`, `dailyRevenue`, and `dailyProtocolRevenue` for Avici on Ethereum.
- Calculates interchange fees as `1.25%` of daily Avici card spend.
- Added fee/revenue labels plus `methodology` and `breakdownMethodology` metadata.
- Added source and limitation comments for the Dune reference query, excluding float yield and card issuing fees due to unreliable or insufficient source data.

## Methodology
- Volume is the total USD value of Relay swaps routed through Avici from the endbanks.org overview API.
- Fees are interchange fees calculated as `1.25%` of Avici card spend.
- Revenue and protocol revenue are the full interchange amount retained by Avici.
- Float yield is not included because the `50%` yield share is an estimate and may be wrong.
- Card issuing fees are not included because there are not enough reliable sources to track them.

## Tests
- `pnpm test dexs avici`