### PR TITLE
feat: add Ayebot fees adapter (Solana + BSC)

### DIFF
--- a/fees/ayebot.ts
+++ b/fees/ayebot.ts
@@ -1,6 +1,6 @@
-import ADDRESSES from "../helpers/coreAssets.json";
-import { Adapter, Dependencies, FetchOptions, FetchResultV2 } from "../adapters/types";
+import { Dependencies, FetchOptions, SimpleAdapter } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
+import ADDRESSES from "../helpers/coreAssets.json";
 import { queryDuneSql } from "../helpers/dune";
 import { addTokensReceived, getETHReceived } from "../helpers/token";
 import { METRIC } from "../helpers/metrics";
@@ -8,104 +8,94 @@ import { METRIC } from "../helpers/metrics";
 /**
  * Ayebot — self-custodial multichain Telegram trading bot (Solana + BSC).
  *
- * Fee flow (PLATFORM_FEE_TO_TREASURY_ENABLED = true):
- *  - Platform swap fees and leader copy-trading carry both land directly on a
- *    "hot" treasury wallet per chain (derived from the bot's key vault).
- *  - A periodic surplus sweep later forwards part of the native balance to a
- *    cold fee wallet, but that is downstream and partial, so fees are measured
- *    at the treasury where they first arrive in full.
- *
- * Assets received by the treasury:
+ * Swap platform fees and leader copy-trading carry are both collected on-chain
+ * by the protocol treasury wallet on each chain, where fees are measured:
  *  - Solana: native SOL (lamports) for both platform fees and carry.
  *  - BSC: WBNB for inline platform fees + native BNB for leader carry.
- *
- * Dimensions: all fees collected by the treasury are reported as dailyFees and,
- * since Ayebot is the recipient, as dailyRevenue / dailyProtocolRevenue.
+ * All collected fees are protocol revenue (Ayebot is the recipient).
  * All figures are derived from on-chain data; no off-chain API is used.
  */
 
-// Hot treasury wallets (where fees land first, in full).
+// Treasury wallets — verified on-chain as the recipients of fee inflows.
 const SOL_TREASURY = "FaYFaP8f6JNzTuZ1gsKn7nRUKcVzJ4TiLqErWESBnLT4";
 const BSC_TREASURY = "0xb49230598A51770Ccd5281B83e2CaF01086E61eA";
+// Canonical Wrapped BNB (WBNB) token on BSC.
 const WBNB = "0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c";
 
-const fetchSolana = async (options: FetchOptions): Promise<FetchResultV2> => {
-  const dailyFees = options.createBalances();
+const chainConfig: Record<string, { start: string; treasury: string }> = {
+  [CHAIN.SOLANA]: { start: "2026-05-22", treasury: SOL_TREASURY },
+  [CHAIN.BSC]: { start: "2026-05-24", treasury: BSC_TREASURY },
+};
 
+async function fetchSolana(options: FetchOptions, treasury: string) {
+  const dailyFees = options.createBalances();
   // Inbound native SOL to the treasury (positive balance changes), excluding
-  // any outbound-originated internal movements from the same wallet.
+  // transactions where the treasury also sends out (internal movements).
   const query = `
     SELECT COALESCE(SUM(balance_change), 0) AS lamports
     FROM solana.account_activity
     WHERE TIME_RANGE
       AND tx_success
-      AND address = '${SOL_TREASURY}'
+      AND address = '${treasury}'
       AND balance_change > 0
       AND tx_id NOT IN (
         SELECT tx_id FROM solana.account_activity
         WHERE TIME_RANGE
-          AND address = '${SOL_TREASURY}'
+          AND address = '${treasury}'
           AND balance_change < 0
       )
   `;
   const [row] = await queryDuneSql(options, query);
   dailyFees.add(ADDRESSES.solana.SOL, Number(row?.lamports ?? 0), METRIC.TRADING_FEES);
+  return dailyFees;
+}
 
-  return {
-    dailyFees,
-    dailyUserFees: dailyFees,
-    dailyRevenue: dailyFees,
-    dailyProtocolRevenue: dailyFees,
-  };
-};
-
-const fetchBsc = async (options: FetchOptions): Promise<FetchResultV2> => {
+async function fetchBsc(options: FetchOptions, treasury: string) {
   const dailyFees = options.createBalances();
-
   // Platform fees arrive as WBNB (inline KyberSwap).
-  await addTokensReceived({
-    options,
-    balances: dailyFees,
-    target: BSC_TREASURY,
-    tokens: [WBNB],
-  });
-
+  await addTokensReceived({ options, balances: dailyFees, target: treasury, tokens: [WBNB] });
   // Leader carry arrives as native BNB.
-  await getETHReceived({
-    options,
-    balances: dailyFees,
-    target: BSC_TREASURY,
-  });
+  await getETHReceived({ options, balances: dailyFees, target: treasury });
+  return dailyFees;
+}
+
+async function fetch(options: FetchOptions) {
+  const { treasury } = chainConfig[options.chain];
+  const dailyFees =
+    options.chain === CHAIN.SOLANA
+      ? await fetchSolana(options, treasury)
+      : await fetchBsc(options, treasury);
 
   return {
     dailyFees,
-    dailyUserFees: dailyFees,
     dailyRevenue: dailyFees,
     dailyProtocolRevenue: dailyFees,
   };
-};
+}
 
-const methodology = {
-  Fees: "All trading fees collected by Ayebot: per-swap platform fees and leader copy-trading carry, received on-chain by the treasury wallet on each chain (native SOL on Solana; WBNB plus native BNB on BSC).",
-  Revenue: "All collected fees, received by the Ayebot treasury.",
-  ProtocolRevenue: "All collected fees, received by the Ayebot treasury.",
-};
-
-const adapter: Adapter = {
-  version: 2,
-  methodology,
+const adapter: SimpleAdapter = {
+  version: 1,
+  adapter: Object.fromEntries(
+    Object.entries(chainConfig).map(([chain, cfg]) => [chain, { fetch, start: cfg.start }])
+  ),
+  dependencies: [Dependencies.DUNE],
   isExpensiveAdapter: true,
-  adapter: {
-    [CHAIN.SOLANA]: {
-      fetch: fetchSolana,
-      start: "2026-05-22",
+  methodology: {
+    Fees: "All trading fees collected by Ayebot: per-swap platform fees and leader copy-trading carry, received on-chain by the treasury wallet on each chain (native SOL on Solana; WBNB plus native BNB on BSC).",
+    Revenue: "All collected fees, received by the Ayebot treasury.",
+    ProtocolRevenue: "All collected fees, received by the Ayebot treasury.",
+  },
+  breakdownMethodology: {
+    Fees: {
+      [METRIC.TRADING_FEES]: "All trading fees (platform fees + leader carry) received by the Ayebot treasury.",
     },
-    [CHAIN.BSC]: {
-      fetch: fetchBsc,
-      start: "2026-05-24",
+    Revenue: {
+      [METRIC.TRADING_FEES]: "All collected fees, retained by Ayebot.",
+    },
+    ProtocolRevenue: {
+      [METRIC.TRADING_FEES]: "All collected fees, retained by Ayebot.",
     },
   },
-  dependencies: [Dependencies.DUNE],
 };
 
 export default adapter;

--- a/fees/ayebot.ts
+++ b/fees/ayebot.ts
@@ -30,9 +30,6 @@ const BSC_TREASURY = "0xb49230598A51770Ccd5281B83e2CaF01086E61eA";
 // treasury and used as an internal-sender filter to net out the surplus sweep:
 //  https://bscscan.com/address/0x59cB774c3462D11C36F56E3a4007379Ea77299d3
 const BSC_FEE_WALLET = "0x59cB774c3462D11C36F56E3a4007379Ea77299d3";
-// Canonical Wrapped BNB (WBNB) on BSC:
-//  https://bscscan.com/token/0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c
-const WBNB = "0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c";
 
 const BSC_SINKS = [BSC_TREASURY, BSC_FEE_WALLET];
 
@@ -63,7 +60,7 @@ async function fetchBsc(options: FetchOptions) {
   await getETHReceived({ options, balances: dailyFees, targets: BSC_SINKS, notFromSenders: BSC_SINKS });
   // Inline KyberSwap platform fees arrive as WBNB (ERC-20). No internal sweep
   // moves WBNB, so no sender filter is needed.
-  await addTokensReceived({ options, balances: dailyFees, targets: BSC_SINKS, tokens: [WBNB] });
+  await addTokensReceived({ options, balances: dailyFees, targets: BSC_SINKS, tokens: [ADDRESSES.bsc.WBNB] });
   return dailyFees;
 }
 
@@ -76,7 +73,8 @@ async function fetch(options: FetchOptions) {
 }
 
 const adapter: SimpleAdapter = {
-  version: 1,
+  version: 2,
+  pullHourly: true,
   adapter: Object.fromEntries(
     Object.entries(chainConfig).map(([chain, cfg]) => [chain, { fetch, start: cfg.start }])
   ),

--- a/fees/ayebot.ts
+++ b/fees/ayebot.ts
@@ -8,26 +8,36 @@ import { METRIC } from "../helpers/metrics";
 /**
  * Ayebot — self-custodial multichain Telegram trading bot (Solana + BSC).
  *
- * Swap platform fees and leader copy-trading carry are both collected on-chain
- * by the protocol treasury wallet on each chain, where fees are measured:
- *  - Solana: native SOL (lamports) for both platform fees and carry.
- *  - BSC: WBNB for inline platform fees + native BNB for leader carry.
- * All collected fees are protocol revenue (Ayebot is the recipient).
- * All figures are derived from on-chain data; no off-chain API is used.
+ * Swap platform fees and leader copy-trading carry are collected on-chain by
+ * the protocol treasury wallet on each chain, where fees are measured:
+ *  - Solana: native SOL (lamports), both platform fees and carry.
+ *  - BSC: WBNB (inline platform fees) + native BNB (four.meme platform fee and
+ *    leader carry).
+ *
+ * Only dailyFees is reported (gross fees paid by users). Revenue is omitted: a
+ * portion of the collected fees (leader carry) is redistributed to leaders and
+ * is not separable on-chain, so a net protocol-revenue figure cannot be
+ * derived reliably. All figures are derived from on-chain data.
  */
 
-// Treasury wallets — verified on-chain as the recipients of fee inflows.
+// Treasury wallet — recipient of fee inflows on each chain (verified on-chain).
 const SOL_TREASURY = "FaYFaP8f6JNzTuZ1gsKn7nRUKcVzJ4TiLqErWESBnLT4";
 const BSC_TREASURY = "0xb49230598A51770Ccd5281B83e2CaF01086E61eA";
-// Canonical Wrapped BNB (WBNB) token on BSC.
+// Cold fee wallet (historical/fallback recipient). Tracked alongside the
+// treasury, and used as an internal-sender filter to net out the periodic
+// surplus sweep that rebalances native BNB between the two protocol wallets.
+const BSC_FEE_WALLET = "0x59cB774c3462D11C36F56E3a4007379Ea77299d3";
+// Canonical Wrapped BNB (WBNB) on BSC.
 const WBNB = "0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c";
 
-const chainConfig: Record<string, { start: string; treasury: string }> = {
-  [CHAIN.SOLANA]: { start: "2026-05-22", treasury: SOL_TREASURY },
-  [CHAIN.BSC]: { start: "2026-05-24", treasury: BSC_TREASURY },
+const BSC_SINKS = [BSC_TREASURY, BSC_FEE_WALLET];
+
+const chainConfig: Record<string, { start: string }> = {
+  [CHAIN.SOLANA]: { start: "2026-05-22" },
+  [CHAIN.BSC]: { start: "2026-05-24" },
 };
 
-async function fetchSolana(options: FetchOptions, treasury: string) {
+async function fetchSolana(options: FetchOptions) {
   const dailyFees = options.createBalances();
   // Inbound native SOL to the treasury (positive balance changes), excluding
   // transactions where the treasury also sends out (internal movements).
@@ -36,12 +46,12 @@ async function fetchSolana(options: FetchOptions, treasury: string) {
     FROM solana.account_activity
     WHERE TIME_RANGE
       AND tx_success
-      AND address = '${treasury}'
+      AND address = '${SOL_TREASURY}'
       AND balance_change > 0
       AND tx_id NOT IN (
         SELECT tx_id FROM solana.account_activity
         WHERE TIME_RANGE
-          AND address = '${treasury}'
+          AND address = '${SOL_TREASURY}'
           AND balance_change < 0
       )
   `;
@@ -50,27 +60,24 @@ async function fetchSolana(options: FetchOptions, treasury: string) {
   return dailyFees;
 }
 
-async function fetchBsc(options: FetchOptions, treasury: string) {
+async function fetchBsc(options: FetchOptions) {
   const dailyFees = options.createBalances();
-  // Platform fees arrive as WBNB (inline KyberSwap).
-  await addTokensReceived({ options, balances: dailyFees, target: treasury, tokens: [WBNB] });
-  // Leader carry arrives as native BNB.
-  await getETHReceived({ options, balances: dailyFees, target: treasury });
+  // Native BNB fees (four.meme platform fee + leader carry). notFromSenders
+  // excludes the two protocol wallets, netting out the internal surplus sweep
+  // in both directions; genuine fees are always sent by user/follower wallets.
+  await getETHReceived({ options, balances: dailyFees, targets: BSC_SINKS, notFromSenders: BSC_SINKS });
+  // Inline KyberSwap platform fees arrive as WBNB (ERC-20). No internal sweep
+  // moves WBNB, so no sender filter is needed.
+  await addTokensReceived({ options, balances: dailyFees, targets: BSC_SINKS, tokens: [WBNB] });
   return dailyFees;
 }
 
 async function fetch(options: FetchOptions) {
-  const { treasury } = chainConfig[options.chain];
   const dailyFees =
     options.chain === CHAIN.SOLANA
-      ? await fetchSolana(options, treasury)
-      : await fetchBsc(options, treasury);
-
-  return {
-    dailyFees,
-    dailyRevenue: dailyFees,
-    dailyProtocolRevenue: dailyFees,
-  };
+      ? await fetchSolana(options)
+      : await fetchBsc(options);
+  return { dailyFees };
 }
 
 const adapter: SimpleAdapter = {
@@ -81,19 +88,11 @@ const adapter: SimpleAdapter = {
   dependencies: [Dependencies.DUNE],
   isExpensiveAdapter: true,
   methodology: {
-    Fees: "All trading fees collected by Ayebot: per-swap platform fees and leader copy-trading carry, received on-chain by the treasury wallet on each chain (native SOL on Solana; WBNB plus native BNB on BSC).",
-    Revenue: "All collected fees, received by the Ayebot treasury.",
-    ProtocolRevenue: "All collected fees, received by the Ayebot treasury.",
+    Fees: "All trading fees paid by users and collected by the Ayebot treasury: per-swap platform fees and leader copy-trading carry (native SOL on Solana; WBNB plus native BNB on BSC).",
   },
   breakdownMethodology: {
     Fees: {
-      [METRIC.TRADING_FEES]: "All trading fees (platform fees + leader carry) received by the Ayebot treasury.",
-    },
-    Revenue: {
-      [METRIC.TRADING_FEES]: "All collected fees, retained by Ayebot.",
-    },
-    ProtocolRevenue: {
-      [METRIC.TRADING_FEES]: "All collected fees, retained by Ayebot.",
+      [METRIC.TRADING_FEES]: "Platform fees and leader carry received by the Ayebot treasury.",
     },
   },
 };

--- a/fees/ayebot.ts
+++ b/fees/ayebot.ts
@@ -1,0 +1,111 @@
+import ADDRESSES from "../helpers/coreAssets.json";
+import { Adapter, Dependencies, FetchOptions, FetchResultV2 } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+import { queryDuneSql } from "../helpers/dune";
+import { addTokensReceived, getETHReceived } from "../helpers/token";
+import { METRIC } from "../helpers/metrics";
+
+/**
+ * Ayebot — self-custodial multichain Telegram trading bot (Solana + BSC).
+ *
+ * Fee flow (PLATFORM_FEE_TO_TREASURY_ENABLED = true):
+ *  - Platform swap fees and leader copy-trading carry both land directly on a
+ *    "hot" treasury wallet per chain (derived from the bot's key vault).
+ *  - A periodic surplus sweep later forwards part of the native balance to a
+ *    cold fee wallet, but that is downstream and partial, so fees are measured
+ *    at the treasury where they first arrive in full.
+ *
+ * Assets received by the treasury:
+ *  - Solana: native SOL (lamports) for both platform fees and carry.
+ *  - BSC: WBNB for inline platform fees + native BNB for leader carry.
+ *
+ * Dimensions: all fees collected by the treasury are reported as dailyFees and,
+ * since Ayebot is the recipient, as dailyRevenue / dailyProtocolRevenue.
+ * All figures are derived from on-chain data; no off-chain API is used.
+ */
+
+// Hot treasury wallets (where fees land first, in full).
+const SOL_TREASURY = "FaYFaP8f6JNzTuZ1gsKn7nRUKcVzJ4TiLqErWESBnLT4";
+const BSC_TREASURY = "0xb49230598A51770Ccd5281B83e2CaF01086E61eA";
+const WBNB = "0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c";
+
+const fetchSolana = async (options: FetchOptions): Promise<FetchResultV2> => {
+  const dailyFees = options.createBalances();
+
+  // Inbound native SOL to the treasury (positive balance changes), excluding
+  // any outbound-originated internal movements from the same wallet.
+  const query = `
+    SELECT COALESCE(SUM(balance_change), 0) AS lamports
+    FROM solana.account_activity
+    WHERE TIME_RANGE
+      AND tx_success
+      AND address = '${SOL_TREASURY}'
+      AND balance_change > 0
+      AND tx_id NOT IN (
+        SELECT tx_id FROM solana.account_activity
+        WHERE TIME_RANGE
+          AND address = '${SOL_TREASURY}'
+          AND balance_change < 0
+      )
+  `;
+  const [row] = await queryDuneSql(options, query);
+  dailyFees.add(ADDRESSES.solana.SOL, Number(row?.lamports ?? 0), METRIC.TRADING_FEES);
+
+  return {
+    dailyFees,
+    dailyUserFees: dailyFees,
+    dailyRevenue: dailyFees,
+    dailyProtocolRevenue: dailyFees,
+  };
+};
+
+const fetchBsc = async (options: FetchOptions): Promise<FetchResultV2> => {
+  const dailyFees = options.createBalances();
+
+  // Platform fees arrive as WBNB (inline KyberSwap).
+  await addTokensReceived({
+    options,
+    balances: dailyFees,
+    target: BSC_TREASURY,
+    tokens: [WBNB],
+  });
+
+  // Leader carry arrives as native BNB.
+  await getETHReceived({
+    options,
+    balances: dailyFees,
+    target: BSC_TREASURY,
+  });
+
+  return {
+    dailyFees,
+    dailyUserFees: dailyFees,
+    dailyRevenue: dailyFees,
+    dailyProtocolRevenue: dailyFees,
+  };
+};
+
+const methodology = {
+  Fees: "All trading fees collected by Ayebot: per-swap platform fees and leader copy-trading carry, received on-chain by the treasury wallet on each chain (native SOL on Solana; WBNB plus native BNB on BSC).",
+  Revenue: "All collected fees, received by the Ayebot treasury.",
+  ProtocolRevenue: "All collected fees, received by the Ayebot treasury.",
+};
+
+const adapter: Adapter = {
+  version: 2,
+  methodology,
+  isExpensiveAdapter: true,
+  adapter: {
+    [CHAIN.SOLANA]: {
+      fetch: fetchSolana,
+      start: "2026-05-22",
+    },
+    [CHAIN.BSC]: {
+      fetch: fetchBsc,
+      start: "2026-05-24",
+    },
+  },
+  dependencies: [Dependencies.DUNE],
+};
+
+export default adapter;

--- a/fees/ayebot.ts
+++ b/fees/ayebot.ts
@@ -1,8 +1,7 @@
 import { Dependencies, FetchOptions, SimpleAdapter } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
 import ADDRESSES from "../helpers/coreAssets.json";
-import { queryDuneSql } from "../helpers/dune";
-import { addTokensReceived, getETHReceived } from "../helpers/token";
+import { addTokensReceived, getETHReceived, getSolanaReceived } from "../helpers/token";
 import { METRIC } from "../helpers/metrics";
 
 /**
@@ -45,24 +44,14 @@ const chainConfig: Record<string, { start: string }> = {
 
 async function fetchSolana(options: FetchOptions) {
   const dailyFees = options.createBalances();
-  // Inbound native SOL to the treasury (positive balance changes), excluding
-  // transactions where the treasury also sends out (internal movements).
-  const query = `
-    SELECT COALESCE(SUM(balance_change), 0) AS lamports
-    FROM solana.account_activity
-    WHERE TIME_RANGE
-      AND tx_success
-      AND address = '${SOL_TREASURY}'
-      AND balance_change > 0
-      AND tx_id NOT IN (
-        SELECT tx_id FROM solana.account_activity
-        WHERE TIME_RANGE
-          AND address = '${SOL_TREASURY}'
-          AND balance_change < 0
-      )
-  `;
-  const [row] = await queryDuneSql(options, query);
-  dailyFees.add(ADDRESSES.solana.SOL, Number(row?.lamports ?? 0), METRIC.TRADING_FEES);
+  // Native SOL fees received by the treasury (platform fees + leader carry),
+  // sourced from Allium transfers via getSolanaReceived.
+  await getSolanaReceived({
+    options,
+    balances: dailyFees,
+    target: SOL_TREASURY,
+    mints: [ADDRESSES.solana.SOL],
+  });
   return dailyFees;
 }
 
@@ -91,8 +80,7 @@ const adapter: SimpleAdapter = {
   adapter: Object.fromEntries(
     Object.entries(chainConfig).map(([chain, cfg]) => [chain, { fetch, start: cfg.start }])
   ),
-  dependencies: [Dependencies.DUNE],
-  isExpensiveAdapter: true,
+  dependencies: [Dependencies.ALLIUM],
   // Leader carry redistributed to leaders is a supply-side cost, but it is not
   // separable on-chain from the inbound fee flow, so no revenue/supply-side
   // split can be derived. Only gross dailyFees is reported.

--- a/fees/ayebot.ts
+++ b/fees/ayebot.ts
@@ -14,10 +14,10 @@ import { METRIC } from "../helpers/metrics";
  *  - BSC: WBNB (inline platform fees) + native BNB (four.meme platform fee and
  *    leader carry).
  *
- * Only dailyFees is reported (gross fees paid by users). Revenue is omitted: a
- * portion of the collected fees (leader carry) is redistributed to leaders and
- * is not separable on-chain, so a net protocol-revenue figure cannot be
- * derived reliably. All figures are derived from on-chain data.
+ * Fees are reported gross (everything users pay into the treasury). Revenue is
+ * reported equal to fees: a portion (leader carry) is later redistributed to
+ * leaders, but that share is not separable on-chain from the inbound flow, so
+ * no smaller net figure can be derived reliably. All figures are on-chain.
  */
 
 // Treasury wallet — recipient of fee inflows on each chain (verified on-chain).
@@ -77,7 +77,7 @@ async function fetch(options: FetchOptions) {
     options.chain === CHAIN.SOLANA
       ? await fetchSolana(options)
       : await fetchBsc(options);
-  return { dailyFees };
+  return { dailyFees, dailyRevenue: dailyFees, dailyProtocolRevenue: dailyFees };
 }
 
 const adapter: SimpleAdapter = {
@@ -89,10 +89,18 @@ const adapter: SimpleAdapter = {
   isExpensiveAdapter: true,
   methodology: {
     Fees: "All trading fees paid by users and collected by the Ayebot treasury: per-swap platform fees and leader copy-trading carry (native SOL on Solana; WBNB plus native BNB on BSC).",
+    Revenue: "Reported equal to fees. Part of the collected fees (leader carry) is redistributed to leaders, but that share is not separable on-chain from the inbound flow, so fees are reported gross.",
+    ProtocolRevenue: "Reported equal to fees, for the same reason as Revenue.",
   },
   breakdownMethodology: {
     Fees: {
       [METRIC.TRADING_FEES]: "Platform fees and leader carry received by the Ayebot treasury.",
+    },
+    Revenue: {
+      [METRIC.TRADING_FEES]: "Gross fees received by the Ayebot treasury.",
+    },
+    ProtocolRevenue: {
+      [METRIC.TRADING_FEES]: "Gross fees received by the Ayebot treasury.",
     },
   },
 };

--- a/fees/ayebot.ts
+++ b/fees/ayebot.ts
@@ -14,24 +14,30 @@ import { METRIC } from "../helpers/metrics";
  *  - BSC: WBNB (inline platform fees) + native BNB (four.meme platform fee and
  *    leader carry).
  *
- * Fees are reported gross (everything users pay into the treasury). Revenue is
- * reported equal to fees: a portion (leader carry) is later redistributed to
- * leaders, but that share is not separable on-chain from the inbound flow, so
- * no smaller net figure can be derived reliably. All figures are on-chain.
+ * Only dailyFees is reported. Part of the inflow (leader carry) is later
+ * redistributed to leaders — a supply-side cost — but that share is not
+ * separable on-chain from the inbound flow, so neither a clean protocol-revenue
+ * nor a supply-side figure can be derived. skipBreakdownValidation is set for
+ * this reason, rather than aliasing gross fees to revenue. All figures on-chain.
  */
 
-// Treasury wallet — recipient of fee inflows on each chain (verified on-chain).
+// Treasury wallet — recipient of fee inflows on each chain. Verified on-chain
+// as the sender of the periodic surplus sweep to the cold fee wallet:
+//  - Solana treasury: https://solscan.io/account/FaYFaP8f6JNzTuZ1gsKn7nRUKcVzJ4TiLqErWESBnLT4
+//  - BSC treasury:    https://bscscan.com/address/0xb49230598A51770Ccd5281B83e2CaF01086E61eA
 const SOL_TREASURY = "FaYFaP8f6JNzTuZ1gsKn7nRUKcVzJ4TiLqErWESBnLT4";
 const BSC_TREASURY = "0xb49230598A51770Ccd5281B83e2CaF01086E61eA";
-// Cold fee wallet (historical/fallback recipient). Tracked alongside the
-// treasury, and used as an internal-sender filter to net out the periodic
-// surplus sweep that rebalances native BNB between the two protocol wallets.
+// Cold fee wallet (historical/fallback recipient), tracked alongside the
+// treasury and used as an internal-sender filter to net out the surplus sweep:
+//  https://bscscan.com/address/0x59cB774c3462D11C36F56E3a4007379Ea77299d3
 const BSC_FEE_WALLET = "0x59cB774c3462D11C36F56E3a4007379Ea77299d3";
-// Canonical Wrapped BNB (WBNB) on BSC.
+// Canonical Wrapped BNB (WBNB) on BSC:
+//  https://bscscan.com/token/0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c
 const WBNB = "0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c";
 
 const BSC_SINKS = [BSC_TREASURY, BSC_FEE_WALLET];
 
+// Start dates = first on-chain fee inflow observed on each treasury.
 const chainConfig: Record<string, { start: string }> = {
   [CHAIN.SOLANA]: { start: "2026-05-22" },
   [CHAIN.BSC]: { start: "2026-05-24" },
@@ -77,7 +83,7 @@ async function fetch(options: FetchOptions) {
     options.chain === CHAIN.SOLANA
       ? await fetchSolana(options)
       : await fetchBsc(options);
-  return { dailyFees, dailyRevenue: dailyFees, dailyProtocolRevenue: dailyFees };
+  return { dailyFees };
 }
 
 const adapter: SimpleAdapter = {
@@ -87,20 +93,16 @@ const adapter: SimpleAdapter = {
   ),
   dependencies: [Dependencies.DUNE],
   isExpensiveAdapter: true,
+  // Leader carry redistributed to leaders is a supply-side cost, but it is not
+  // separable on-chain from the inbound fee flow, so no revenue/supply-side
+  // split can be derived. Only gross dailyFees is reported.
+  skipBreakdownValidation: true,
   methodology: {
     Fees: "All trading fees paid by users and collected by the Ayebot treasury: per-swap platform fees and leader copy-trading carry (native SOL on Solana; WBNB plus native BNB on BSC).",
-    Revenue: "Reported equal to fees. Part of the collected fees (leader carry) is redistributed to leaders, but that share is not separable on-chain from the inbound flow, so fees are reported gross.",
-    ProtocolRevenue: "Reported equal to fees, for the same reason as Revenue.",
   },
   breakdownMethodology: {
     Fees: {
       [METRIC.TRADING_FEES]: "Platform fees and leader carry received by the Ayebot treasury.",
-    },
-    Revenue: {
-      [METRIC.TRADING_FEES]: "Gross fees received by the Ayebot treasury.",
-    },
-    ProtocolRevenue: {
-      [METRIC.TRADING_FEES]: "Gross fees received by the Ayebot treasury.",
     },
   },
 };


### PR DESCRIPTION
Ayebot — fees adapter (Solana + BSC)

Website: https://ayebot.io/
Telegram Bot: https://t.me/trade_ayebot
X.com: [ayebot_io](https://x.com/ayebot_io)
Logo: https://github.com/DefiLlama/icons/pull/2415

Adds a fees/revenue adapter for Ayebot, a self-custodial multichain Telegram trading bot (Solana + BSC) with copy-trading.

### Methodology
Fees are measured on-chain at the protocol treasury on each chain, where swap platform fees and leader copy-trading carry are collected:
- **Solana**: native SOL received by the treasury (via Dune `solana.account_activity`).
- **BSC**: WBNB (inline platform fees) + native BNB (leader carry) received by the treasury.

All collected fees are reported as Fees, Revenue and ProtocolRevenue, as Ayebot is the recipient of the treasury inflows.

### Notes
- Adapter relies on Dune for Solana; `isExpensiveAdapter` and `dependencies: [DUNE]` set accordingly.
- Tested locally with `testAdapter.ts`; treasury inflows verified on-chain.