### PR TITLE
Fix Tether fees methodology to match adapter calculation

### DIFF
--- a/fees/tether/index.ts
+++ b/fees/tether/index.ts
@@ -153,9 +153,9 @@ const adapter = buildStablecoinAdapter(CHAIN.OFF_CHAIN, '1', 30 * 3,
   ]);
 
 adapter.methodology = {
-  Fees: 'All yields from USDT backing asset investments (US Treasury Bills, other fixed-income assets), price fluctuations in gold, and bitcoin held in the Tether reserves. Price fluctuations in other backing assets are excluded.',
-  Revenue: 'All yields from USDT backing assets investments (US Treasury Bills, other fixed income assets) price fluctuations in gold, and bitcoin held in the Tether reserves.',
-  ProtocolRevenue: 'All yields from USDT backing assets investments (US Treasury Bills, other fixed income assets) price fluctuations in gold, and bitcoin held in the Tether reserves.',
+  Fees: 'Asset yields from USDT backing investments: US Treasury Bills and other fixed-income assets like repos, commercial paper, money market funds and secured loans.',
+  Revenue: 'Asset yields from USDT backing investments (US Treasury Bills and other fixed-income assets like repos, commercial paper, money market funds and secured loans) collected by Tether.',
+  ProtocolRevenue: 'Asset yields from USDT backing investments (US Treasury Bills and other fixed-income assets like repos, commercial paper, money market funds and secured loans) collected by Tether.',
 }
 
 adapter.breakdownMethodology = {


### PR DESCRIPTION
Follow-up to #7619, which updated the Tether methodology text to mention gold and bitcoin price fluctuations.

The adapter only computes fixed-income yields on the allocated reserves (`allocated * tbillYield`), where `allocated` is t-bills, repos, money market funds and secured loans. Gold and bitcoin are not in `allocated` and are never marked to market, so the methodology overstated what is captured.

This aligns the top-level `methodology` with the actual calculation and the existing `breakdownMethodology` (which was already correct). No code/data changes.