### PR TITLE
[codex] Add Tristero v3 delegated both-side volume

### DIFF
--- a/dexs/tristero/index.ts
+++ b/dexs/tristero/index.ts
@@ -6,7 +6,7 @@ const adapter: SimpleAdapter = {
   fetch: async (options) => ({ dailyVolume: await fetchDailyVolume(options) }),
   adapter: TRISTERO_DEX_CHAINS,
   methodology: {
-    Volume: "Source-side token amounts from legacy OrderFilled events and v3 router.send orders. Margin opens include collateral and loan; margin closes include loan settlement transfers.",
+    Volume: "Source token amounts from legacy OrderFilled events. V3 router.send swaps count both maker and filler assets, including delegated execute() batches containing router.send calls. Margin opens include collateral and loan; margin closes include loan settlement transfers.",
   },
 };
 

--- a/dexs/tristero/index.ts
+++ b/dexs/tristero/index.ts
@@ -6,7 +6,7 @@ const adapter: SimpleAdapter = {
   fetch: async (options) => ({ dailyVolume: await fetchDailyVolume(options) }),
   adapter: TRISTERO_DEX_CHAINS,
   methodology: {
-    Volume: "Source token amounts from legacy OrderFilled events. V3 router.send swaps count both maker and filler assets, including delegated execute() batches containing router.send calls. Margin opens include collateral and loan; margin closes include loan settlement transfers.",
+    Volume: "Source-side token amounts from legacy OrderFilled events and v3 router.send orders, including delegated execute() batches containing router.send calls. Margin opens include collateral and loan; margin closes include loan settlement transfers.",
   },
 };
 

--- a/helpers/tristero.ts
+++ b/helpers/tristero.ts
@@ -49,8 +49,6 @@ type DecodedV3SendOrder = {
   orderType: string;
   srcToken: string;
   srcQuantity: bigint;
-  dstToken: string;
-  dstQuantity: bigint;
   customData: string;
 };
 
@@ -277,7 +275,7 @@ export const TRISTERO_DEX_CHAINS: Record<string, { start: string }> = {
   [CHAIN.UNICHAIN]: { start: "2025-11-27" },
 };
 
-// V3 send volume is indexed from router.send() calls. The schedule mirrors
+// V3 source-side volume is indexed from router.send() calls. The schedule mirrors
 // Tristero backend addresses.yml generations and production contract updates;
 // day overlaps reflect public explorer cutovers and are safe because each tx has one router.
 const TRISTERO_V3_ROUTER_CONFIGS: Record<string, TristeroV3RouterConfig[]> = {
@@ -1077,8 +1075,6 @@ function decodeV3SendOrder(data?: string): DecodedV3SendOrder | null {
       orderType: order.orderType,
       srcToken: order.parameters.srcAsset,
       srcQuantity: BigInt(order.parameters.srcQuantity),
-      dstToken: order.parameters.dstAsset,
-      dstQuantity: BigInt(order.parameters.dstQuantity),
       customData: order.customData,
     };
   } catch (error) {
@@ -1159,11 +1155,6 @@ function addDecodedV3SendOrderVolume(
 ) {
   const srcTokenAddress = normalizeVolumeToken(options.chain, decodedOrder.srcToken);
   if (srcTokenAddress) dailyVolume.add(srcTokenAddress, decodedOrder.srcQuantity);
-
-  if (decodedOrder.orderType.toUpperCase() !== "MARGIN") {
-    const dstTokenAddress = normalizeVolumeToken(options.chain, decodedOrder.dstToken);
-    if (dstTokenAddress) dailyVolume.add(dstTokenAddress, decodedOrder.dstQuantity);
-  }
 
   const marginLoan = decodeMarginLoan(decodedOrder);
   if (marginLoan?.quantity) {

--- a/helpers/tristero.ts
+++ b/helpers/tristero.ts
@@ -39,6 +39,21 @@ type TristeroV3RouterConfig = {
   router: string;
 };
 
+type TristeroV3DelegatedSendTargetConfig = {
+  start: string;
+  end?: string;
+  target: string;
+};
+
+type DecodedV3SendOrder = {
+  orderType: string;
+  srcToken: string;
+  srcQuantity: bigint;
+  dstToken: string;
+  dstQuantity: bigint;
+  customData: string;
+};
+
 const MULTICALL_FALLBACK_BATCH_SIZE = 5;
 
 type PermitFailureMultiCallParams = {
@@ -262,7 +277,7 @@ export const TRISTERO_DEX_CHAINS: Record<string, { start: string }> = {
   [CHAIN.UNICHAIN]: { start: "2025-11-27" },
 };
 
-// V3 source-side volume is indexed from router.send() calls. The schedule mirrors
+// V3 send volume is indexed from router.send() calls. The schedule mirrors
 // Tristero backend addresses.yml generations and production contract updates;
 // day overlaps reflect public explorer cutovers and are safe because each tx has one router.
 const TRISTERO_V3_ROUTER_CONFIGS: Record<string, TristeroV3RouterConfig[]> = {
@@ -291,6 +306,23 @@ const TRISTERO_V3_ROUTER_CONFIGS: Record<string, TristeroV3RouterConfig[]> = {
   ],
 };
 
+// Some v3 fills are submitted through EIP-7702/ERC-7579 delegated accounts. Those
+// transactions call execute(bytes32,bytes) on the taker account and carry one or
+// more inner router.send() calls targeted at the Tristero send executor.
+const TRISTERO_V3_DELEGATED_SEND_TARGET = "0xD4c2Ce98CbE2B02bE9449606fdfF75DD700B836F";
+const TRISTERO_V3_DELEGATED_SEND_TARGET_CONFIGS: Record<string, TristeroV3DelegatedSendTargetConfig[]> = {
+  [CHAIN.ARBITRUM]: [
+    { start: "2026-06-22", target: TRISTERO_V3_DELEGATED_SEND_TARGET },
+  ],
+  [CHAIN.BASE]: [
+    // https://basescan.org/tx/0x3a80afb7ea134650a7906ae05a68a59318967e543d905b3ede4b49db7c151f98
+    { start: "2026-06-22", target: TRISTERO_V3_DELEGATED_SEND_TARGET },
+  ],
+  [CHAIN.ETHEREUM]: [
+    { start: "2026-06-22", target: TRISTERO_V3_DELEGATED_SEND_TARGET },
+  ],
+};
+
 const V3_RECEIPT_RPC_FALLBACKS: Record<string, string[]> = {
   base: ["https://mainnet.base.org"],
 };
@@ -312,8 +344,12 @@ const ORDER_ROUTER_INTERFACE = new Interface([
 const ESCROW_INTERFACE = new Interface([
   "function close((uint128 positionId, uint256 sharesToClose, uint256 minOut, uint256 deadline, uint256 permit2Nonce) order, bytes signature, (address multicallTarget, (address target, bool allowFailure, uint256 value, bytes callData)[] calls, address refundTo, address nftRecipient) arb)"
 ]);
+const DELEGATED_EXECUTE_INTERFACE = new Interface([
+  "function execute(bytes32 mode, bytes executionCalldata)"
+]);
 const ABI_CODER = AbiCoder.defaultAbiCoder();
 const ORDER_ROUTER_SEND_SELECTOR = ORDER_ROUTER_INTERFACE.getFunction("send")?.selector.toLowerCase();
+const DELEGATED_EXECUTE_SELECTOR = DELEGATED_EXECUTE_INTERFACE.getFunction("execute")?.selector.toLowerCase();
 
 export function getActiveRouters(date: string): string[] {
   return TRISTERO_ROUTER_SCHEDULE
@@ -346,6 +382,11 @@ export function getActiveTristeroV3MarginEscrows(chain: string, date: string): T
 
 export function getActiveTristeroV3Routers(chain: string, date: string): TristeroV3RouterConfig[] {
   return (TRISTERO_V3_ROUTER_CONFIGS[chain] ?? [])
+    .filter(({ start, end }) => date >= start && (!end || date <= end));
+}
+
+function getActiveTristeroV3DelegatedSendTargets(chain: string, date: string): TristeroV3DelegatedSendTargetConfig[] {
+  return (TRISTERO_V3_DELEGATED_SEND_TARGET_CONFIGS[chain] ?? [])
     .filter(({ start, end }) => date >= start && (!end || date <= end));
 }
 
@@ -1024,7 +1065,7 @@ function normalizeVolumeToken(chain: string, tokenAddress?: string | null): stri
   return normalized;
 }
 
-function decodeV3SendOrder(data?: string) {
+function decodeV3SendOrder(data?: string): DecodedV3SendOrder | null {
   if (!data || !ORDER_ROUTER_SEND_SELECTOR || !data.toLowerCase().startsWith(ORDER_ROUTER_SEND_SELECTOR)) return null;
 
   try {
@@ -1036,6 +1077,8 @@ function decodeV3SendOrder(data?: string) {
       orderType: order.orderType,
       srcToken: order.parameters.srcAsset,
       srcQuantity: BigInt(order.parameters.srcQuantity),
+      dstToken: order.parameters.dstAsset,
+      dstQuantity: BigInt(order.parameters.dstQuantity),
       customData: order.customData,
     };
   } catch (error) {
@@ -1043,6 +1086,40 @@ function decodeV3SendOrder(data?: string) {
     sdk.log(`Unable to decode Tristero v3 router.send calldata ${calldataContext}: ${(error as Error).message}`);
     throw error;
   }
+}
+
+function isDelegatedBatchExecuteMode(mode: unknown): boolean {
+  const normalized = String(mode).toLowerCase();
+  return normalized.length === 66 && normalized.startsWith("0x01");
+}
+
+function decodeV3DelegatedBatchSendOrders(data: string | undefined, delegatedSendTargets: Set<string>): DecodedV3SendOrder[] {
+  if (!data || !DELEGATED_EXECUTE_SELECTOR || !data.toLowerCase().startsWith(DELEGATED_EXECUTE_SELECTOR)) return [];
+
+  let parsed;
+  try {
+    parsed = DELEGATED_EXECUTE_INTERFACE.parseTransaction({ data });
+  } catch {
+    return [];
+  }
+
+  if (!parsed || parsed.name !== "execute" || !isDelegatedBatchExecuteMode(parsed.args.mode)) return [];
+
+  let executions: Array<{ target: string; callData: string }>;
+  try {
+    [executions] = ABI_CODER.decode(
+      ["tuple(address target,uint256 value,bytes callData)[]"],
+      parsed.args.executionCalldata,
+    ) as unknown as [Array<{ target: string; callData: string }>];
+  } catch {
+    return [];
+  }
+
+  return executions.flatMap((execution) => {
+    if (!delegatedSendTargets.has(normalizeAddress(execution.target))) return [];
+    const decodedOrder = decodeV3SendOrder(String(execution.callData));
+    return decodedOrder ? [decodedOrder] : [];
+  });
 }
 
 function decodeV3CloseOrder(data?: string): boolean {
@@ -1066,6 +1143,28 @@ function decodeMarginLoan(order: { orderType: string; customData: string }) {
     return { token: String(loanAsset), quantity: BigInt(loanQuantity) };
   } catch (error) {
     throw new Error(`Unable to decode Tristero v3 MARGIN customData: ${(error as Error).message}`);
+  }
+}
+
+function addDecodedV3SendOrderVolume(
+  options: FetchOptions,
+  dailyVolume: Balances,
+  decodedOrder: DecodedV3SendOrder,
+  txHash: string,
+) {
+  const srcTokenAddress = normalizeVolumeToken(options.chain, decodedOrder.srcToken);
+  if (srcTokenAddress) dailyVolume.add(srcTokenAddress, decodedOrder.srcQuantity);
+
+  if (decodedOrder.orderType.toUpperCase() !== "MARGIN") {
+    const dstTokenAddress = normalizeVolumeToken(options.chain, decodedOrder.dstToken);
+    if (dstTokenAddress) dailyVolume.add(dstTokenAddress, decodedOrder.dstQuantity);
+  }
+
+  const marginLoan = decodeMarginLoan(decodedOrder);
+  if (marginLoan?.quantity) {
+    const loanToken = normalizeVolumeToken(options.chain, marginLoan.token);
+    if (!loanToken) throw new Error(`Unsupported Tristero v3 loan token in tx ${txHash}`);
+    dailyVolume.add(loanToken, marginLoan.quantity);
   }
 }
 
@@ -1159,17 +1258,42 @@ async function addV3RouterOpenVolume(options: FetchOptions, dailyVolume: Balance
     const decodedOrder = decodeV3SendOrder(String(row.input));
     if (!decodedOrder) continue;
 
-    const tokenAddress = normalizeVolumeToken(options.chain, decodedOrder.srcToken);
-    if (!tokenAddress) continue;
+    addDecodedV3SendOrderVolume(options, dailyVolume, decodedOrder, row.hash);
+  }
+}
 
-    dailyVolume.add(tokenAddress, decodedOrder.srcQuantity);
+async function addV3DelegatedSendOpenVolume(options: FetchOptions, dailyVolume: Balances) {
+  const activeDelegatedSendTargets = getActiveTristeroV3DelegatedSendTargets(options.chain, options.dateString);
+  if (!activeDelegatedSendTargets.length || !DELEGATED_EXECUTE_SELECTOR) return;
 
-    const marginLoan = decodeMarginLoan(decodedOrder);
-    if (marginLoan?.quantity) {
-      const loanToken = normalizeVolumeToken(options.chain, marginLoan.token);
-      if (!loanToken) throw new Error(`Unsupported Tristero v3 loan token in tx ${row.hash}`);
-      dailyVolume.add(loanToken, marginLoan.quantity);
-    }
+  const delegatedSendTargets = new Set(activeDelegatedSendTargets.map(({ target }) => normalizeAddress(target)));
+  const txRows = (
+    await Promise.all(activeDelegatedSendTargets.map(({ target }) => queryClickhouse<Row & { hash: string; input: string }>(`
+      SELECT hash, input
+      FROM evm_indexer.transactions
+      WHERE chain = {chain:UInt64}
+        AND startsWith(input, {selector:String})
+        AND input LIKE {targetPattern:String}
+        AND status = 'success'
+        AND timestamp >= toDateTime({fromTs:UInt32})
+        AND timestamp < toDateTime({toTs:UInt32})
+    `, {
+      chain: Number(options.api.chainId),
+      selector: DELEGATED_EXECUTE_SELECTOR,
+      targetPattern: `%${normalizeAddress(target).slice(2)}%`,
+      fromTs: options.fromTimestamp,
+      toTs: options.toTimestamp,
+    })))
+  ).flat();
+
+  const seenTxHashes = new Set<string>();
+  for (const row of txRows) {
+    const txHash = normalizeAddress(row.hash);
+    if (seenTxHashes.has(txHash)) continue;
+    seenTxHashes.add(txHash);
+
+    const decodedOrders = decodeV3DelegatedBatchSendOrders(String(row.input), delegatedSendTargets);
+    decodedOrders.forEach((decodedOrder) => addDecodedV3SendOrderVolume(options, dailyVolume, decodedOrder, row.hash));
   }
 }
 
@@ -1192,6 +1316,7 @@ export async function fetchDailyVolume(options: FetchOptions): Promise<Balances>
 
   await Promise.all([
     addV3RouterOpenVolume(options, dailyVolume),
+    addV3DelegatedSendOpenVolume(options, dailyVolume),
     addV3MarginCloseVolume(options, dailyVolume),
   ]);
 

--- a/helpers/tristero.ts
+++ b/helpers/tristero.ts
@@ -1099,7 +1099,9 @@ function decodeV3DelegatedBatchSendOrders(data: string | undefined, delegatedSen
   let parsed;
   try {
     parsed = DELEGATED_EXECUTE_INTERFACE.parseTransaction({ data });
-  } catch {
+  } catch (error) {
+    const calldataContext = `${data.slice(0, 74)}${data.length > 74 ? "..." : ""}`;
+    sdk.log(`Unable to parse Tristero delegated execute calldata ${calldataContext}: ${(error as Error).message}`);
     return [];
   }
 
@@ -1111,7 +1113,10 @@ function decodeV3DelegatedBatchSendOrders(data: string | undefined, delegatedSen
       ["tuple(address target,uint256 value,bytes callData)[]"],
       parsed.args.executionCalldata,
     ) as unknown as [Array<{ target: string; callData: string }>];
-  } catch {
+  } catch (error) {
+    const executionCalldata = String(parsed.args.executionCalldata);
+    const calldataContext = `${executionCalldata.slice(0, 74)}${executionCalldata.length > 74 ? "..." : ""}`;
+    sdk.log(`Unable to decode Tristero delegated execution calldata ${calldataContext}: ${(error as Error).message}`);
     return [];
   }
 


### PR DESCRIPTION
## Summary
- Decode Tristero v3 delegated account `execute(bytes32,bytes)` batches and count inner `router.send` calls targeted at `0xD4c2Ce98CbE2B02bE9449606fdfF75DD700B836F`.
- Count both maker and filler assets for non-margin v3 `router.send` swaps by adding `srcQuantity` and `dstQuantity`.
- Enable the delegated send target on Base, Arbitrum, and Ethereum from the observed 2026-06-22 cutover and update methodology text.

## Why
Some v3 fills are submitted through EIP-7702 delegated accounts, so the top-level tx calls `execute(...)` on the delegated account instead of directly calling the Tristero send target. The economic `send(...)` calls are inside the delegated batch.

For the Base sample tx `0x3a80afb7ea134650a7906ae05a68a59318967e543d905b3ede4b49db7c151f98`, the intended accounting is maker + filler volume: decoded source side is 40k USDT + 40k USDS, decoded destination side is 40k USDT + 40k USDS, for 160k total stable volume.

## Verification
- `yarn ts-check`
- Focused Base tx decode for `0x3a80afb7ea134650a7906ae05a68a59318967e543d905b3ede4b49db7c151f98`: outer selector `0xe9ae5c53`, 40 inner executions, 40 matching inner `send` calls, decoded both-side totals `80,000 USDT + 80,000 USDS`.
- `yarn test dexs tristero 1782157051` could not complete locally because this checkout is missing DefiLlama `CLICKHOUSE_CONFIG`.
