### PR TITLE
[feat] Allium-Stats-Migrate: migrate 4 chains stats to routescan

### DIFF
--- a/users/chains.ts
+++ b/users/chains.ts
@@ -86,7 +86,6 @@ type ChainUserConfig = {
 
 const alliumChainMap: Record<string, string> = {
     arbitrum: CHAIN.ARBITRUM,
-    avalanche: CHAIN.AVAX,
     ethereum: CHAIN.ETHEREUM,
     optimism: CHAIN.OPTIMISM,
     polygon: CHAIN.POLYGON,
@@ -102,11 +101,8 @@ const alliumChainMap: Record<string, string> = {
     manta_pacific: CHAIN.MANTA,
     ronin: CHAIN.RONIN,
     sonic: CHAIN.SONIC,
-    mantle: CHAIN.MANTLE,
     berachain: CHAIN.BERACHAIN,
-    blast: CHAIN.BLAST,
     monad: CHAIN.MONAD,
-    plasma: CHAIN.PLASMA,
     sei: CHAIN.SEI,
     core: CHAIN.CORE,
     tempo: CHAIN.TEMPO,

--- a/users/utils/routescanStats.ts
+++ b/users/utils/routescanStats.ts
@@ -14,13 +14,17 @@ type RouteScanRow = [string, string];
 const BASE_URL = "https://cdn.routescan.io/api/evm/all/aggregations";
 
 const routescanStatsChains: Record<string, ChainConfig> = {
+  avalanche: { chain: CHAIN.AVAX, chainId: 43114, start: "2020-09-27" },
   dfk: { chain: CHAIN.DFK, chainId: 53935, start: "2022-03-16" },
   dexalot: { chain: CHAIN.DEXALOT, chainId: 432204, start: "2022-12-04" },
   step: { chain: CHAIN.STEP, chainId: 1234, start: "2022-08-12" },
   numbers: { chain: CHAIN.NUMBERS, chainId: 10507, start: "2022-10-12" },
   metis: { chain: CHAIN.METIS, chainId: 1088, start: "2021-11-18" },
   chz: { chain: CHAIN.CHILIZ, chainId: 88888, start: "2023-02-08" },
+  blast: { chain: CHAIN.BLAST, chainId: 81457, start: "2024-02-24" },
+  mantle: { chain: CHAIN.MANTLE, chainId: 5000, start: "2023-07-02" },
   nibiru: { chain: CHAIN.NIBIRU, chainId: 6900, start: "2025-02-11" },
+  plasma: { chain: CHAIN.PLASMA, chainId: 9745, start: "2025-09-03" },
   btnx: { chain: CHAIN.BOTANIX, chainId: 3637, start: "2025-05-22" },
 };
 


### PR DESCRIPTION
### No credit usage for stats

## Summary
- Moves selected RouteScan-supported chain user metrics from Allium to `routescanStats`.
- Keeps Ethereum and Berachain on Allium, while moving Avalanche, Blast, Mantle, and Plasma to RouteScan-backed active-users/new-users tracking.
- Uses RouteScan daily aggregation endpoints for tx count, active addresses, and cumulative unique addresses without changing the shared RouteScan calculation logic.

## Changes
- Removed `avalanche`, `blast`, `mantle`, and `plasma` from `alliumChainMap` in `users/chains.ts`.
- Added RouteScan configs in `users/utils/routescanStats.ts`:
  - Avalanche: chain id `43114`, start `2020-09-27`
  - Blast: chain id `81457`, start `2024-02-24`
  - Mantle: chain id `5000`, start `2023-07-02`
  - Plasma: chain id `9745`, start `2025-09-03`

## Tests

| Command | Result |
|---|---:|
| `pnpm test active-users avalanche 2026-06-22` | Pass: `779.42k` users, `2.01M` txs |
| `pnpm test new-users avalanche 2026-06-22` | Pass: `44.93k` new users |
| `pnpm test active-users blast 2026-06-22` | Pass: `2.81k` users, `207.04k` txs |
| `pnpm test new-users blast 2026-06-22` | Pass: `83` new users |
| `pnpm test active-users mantle 2026-06-22` | Pass: `2.36k` users, `67.04k` txs |
| `pnpm test new-users mantle 2026-06-22` | Pass: `378` new users |
| `pnpm test active-users plasma 2026-06-22` | Pass: `27.34k` users, `772.88k` txs |
| `pnpm test new-users plasma 2026-06-22` | Pass: `5.76k` new users |
| `pnpm test active-users avalanche 2020-09-28` | Pass: `2` users, `2` txs |
| `pnpm test new-users avalanche 2020-09-28` | Pass: `3` new users |
| `pnpm test active-users avalanche 2020-09-29` | Pass: `2` users, `1` tx |
| `pnpm test new-users avalanche 2020-09-29` | Pass: `0` new users |
| `pnpm test active-users avalanche 2020-09-30` | Pass: `6` users, `17` txs |
| `pnpm test new-users avalanche 2020-09-30` | Pass: `7` new users |
| `pnpm test active-users avalanche 2020-10-01` | Pass: `15` users, `36` txs |
| `pnpm test new-users avalanche 2020-10-01` | Pass: `16` new users |
| `pnpm test active-users avalanche 2020-10-02` | Pass: `77` users, `117` txs |
| `pnpm test new-users avalanche 2020-10-02` | Pass: `68` new users |
