### PR TITLE
Count DYLI buybacks in volume

### DIFF
--- a/fees/dyli/index.ts
+++ b/fees/dyli/index.ts
@@ -101,6 +101,7 @@ const fetch = async (options: FetchOptions) => {
 
   dailyVolume.add(serviceFees);
   dailyVolume.add(cardSales);
+  dailyVolume.add(cardBuybackVolume); // Buybacks are gross card activity, while fees are net of the payout.
 
   dailyFees.add(serviceFees, METRIC.SERVICE_FEES);
   dailyFees.add(cardSales, CARD_SALES);


### PR DESCRIPTION
### Summary
- include DYLI vending-machine buyback payouts in daily volume
- keep fees and revenue net of buyback payouts

### Tests
- pnpm test fees dyli
- pnpm test fees dyli 2026-06-20
