### PR TITLE
[fix] Indigo - track all fee assets and fix token pricing

### DIFF
--- a/fees/indigo/index.ts
+++ b/fees/indigo/index.ts
@@ -1,14 +1,30 @@
 import axios from "axios";
+import { Balances } from "@defillama/sdk";
 import { Adapter, FetchOptions, FetchResult } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 
 const ANALYTICS_API_ENDPOINT = 'https://analytics.indigoprotocol.io';
 
-const INDY_TOKEN = '533bb94a8850ee3ccbe483106489399112b74c905342cb1792a797a0494e4459';
-const IUSD_TOKEN = 'f66d78b4a3cb3d37afa0ec36461e51ecbde00f26c8f0a68f94b6988069555344';
-const IBTC_TOKEN = 'f66d78b4a3cb3d37afa0ec36461e51ecbde00f26c8f0a68f94b6988069425443';
-const IETH_TOKEN = 'f66d78b4a3cb3d37afa0ec36461e51ecbde00f26c8f0a68f94b6988069455448';
-const ISOL_TOKEN = 'f66d78b4a3cb3d37afa0ec36461e51ecbde00f26c8f0a68f94b6988069534f4c';
+const fetchRevenueTotals = async (endpoint: string, options: FetchOptions): Promise<Record<string, string | number>> => {
+  const url = `${ANALYTICS_API_ENDPOINT}/api/revenue/${endpoint}?totals&inflows_only&from=${options.startTimestamp}&to=${options.endTimestamp}`;
+  const { data } = await axios.get(url);
+  if (!data || typeof data.totals !== 'object' || data.totals === null) {
+    throw new Error(`Indigo ${endpoint} returned an unexpected response: ${JSON.stringify(data)?.slice(0, 200)}`);
+  }
+  return data.totals;
+};
+
+const addTotals = (balances: Balances, totals: Record<string, string | number>) => {
+  for (const [unit, amount] of Object.entries(totals)) {
+    const raw = Number(amount);
+    if (!raw) continue;
+    if (unit === 'lovelace') {
+      balances.addCGToken('cardano', raw / 1_000_000);
+    } else {
+      balances.add(unit, raw);
+    }
+  }
+};
 
 const fetch = async (options: FetchOptions): Promise<FetchResult> => {
   // Fees are CDP fees paid by users: mint fees, interest payments, and redemption fees,
@@ -23,53 +39,31 @@ const fetch = async (options: FetchOptions): Promise<FetchResult> => {
 
   // Collector Flows are all fees that are sent to INDY stakers:
   // CDP Mint Fees, (partially) CDP Interest Payments, and Redemption Fees.
-  const collectorFlowResponse = await axios.get(
-    ANALYTICS_API_ENDPOINT + `/api/revenue/collector-flows?totals&inflows_only&from=${options.startTimestamp}&to=${options.endTimestamp}`,
-  );
-  const totalLovelaceToIndyStakers = Number(collectorFlowResponse.data.totals['lovelace'] ?? 0);
+  const collectorTotals = await fetchRevenueTotals('collector-flows', options);
 
   // Treasury captures the following assets: ADA, INDY, iUSD, iBTC, iETH, and iSOL.
   // This collects: CDP Interest Payments (to treasury), INDY returned from emissions, and buybacks.
-  const flowsResponse = await axios.get(
-    ANALYTICS_API_ENDPOINT + `/api/revenue/flows?totals&inflows_only&from=${options.startTimestamp}&to=${options.endTimestamp}`,
-  );
-  const totalLovelaceTreasuryInflows = Number(flowsResponse.data.totals['lovelace'] ?? 0);
+  const treasuryTotals = await fetchRevenueTotals('flows', options);
 
+  const dailyFees = options.createBalances();
+  addTotals(dailyFees, treasuryTotals);
+  addTotals(dailyFees, collectorTotals);
 
-  const dailyFeesUSD = options.createBalances();
-  dailyFeesUSD.addCGToken('cardano', (totalLovelaceTreasuryInflows + totalLovelaceToIndyStakers) / 1_000_000);
-  dailyFeesUSD.addCGToken('indigo-protocol', Number(flowsResponse.data.totals[INDY_TOKEN] ?? 0) / 1_000_000);
-  dailyFeesUSD.addCGToken('indigo-protocol-iusd', Number(flowsResponse.data.totals[IUSD_TOKEN] ?? 0) / 1_000_000);
-  dailyFeesUSD.addCGToken('indigo-protocol-ibtc', Number(flowsResponse.data.totals[IBTC_TOKEN] ?? 0) / 1_000_000);
-  dailyFeesUSD.addCGToken('indigo-protocol-ieth', Number(flowsResponse.data.totals[IETH_TOKEN] ?? 0) / 1_000_000);
-  dailyFeesUSD.addCGToken('indigo-protocol-isol', Number(flowsResponse.data.totals[ISOL_TOKEN] ?? 0) / 1_000_000);
+  const dailyRevenue = options.createBalances();
+  addTotals(dailyRevenue, treasuryTotals);
+  addTotals(dailyRevenue, collectorTotals);
 
+  const dailyProtocolRevenue = options.createBalances();
+  addTotals(dailyProtocolRevenue, treasuryTotals);
 
-  const dailyRevenueUSD = options.createBalances();
-  dailyRevenueUSD.addCGToken('cardano', (totalLovelaceTreasuryInflows + totalLovelaceToIndyStakers) / 1_000_000);
-  dailyRevenueUSD.addCGToken('indigo-protocol', Number(flowsResponse.data.totals[INDY_TOKEN] ?? 0) / 1_000_000);
-  dailyRevenueUSD.addCGToken('indigo-protocol-iusd', Number(flowsResponse.data.totals[IUSD_TOKEN] ?? 0) / 1_000_000);
-  dailyRevenueUSD.addCGToken('indigo-protocol-ibtc', Number(flowsResponse.data.totals[IBTC_TOKEN] ?? 0) / 1_000_000);
-  dailyRevenueUSD.addCGToken('indigo-protocol-ieth', Number(flowsResponse.data.totals[IETH_TOKEN] ?? 0) / 1_000_000);
-  dailyRevenueUSD.addCGToken('indigo-protocol-isol', Number(flowsResponse.data.totals[ISOL_TOKEN] ?? 0) / 1_000_000);
-
-  const dailyProtocolRevenueUSD = options.createBalances();
-  dailyProtocolRevenueUSD.addCGToken('cardano', (totalLovelaceTreasuryInflows) / 1_000_000);
-  dailyProtocolRevenueUSD.addCGToken('indigo-protocol', Number(flowsResponse.data.totals[INDY_TOKEN] ?? 0) / 1_000_000);
-  dailyProtocolRevenueUSD.addCGToken('indigo-protocol-iusd', Number(flowsResponse.data.totals[IUSD_TOKEN] ?? 0) / 1_000_000);
-  dailyProtocolRevenueUSD.addCGToken('indigo-protocol-ibtc', Number(flowsResponse.data.totals[IBTC_TOKEN] ?? 0) / 1_000_000);
-  dailyProtocolRevenueUSD.addCGToken('indigo-protocol-ieth', Number(flowsResponse.data.totals[IETH_TOKEN] ?? 0) / 1_000_000);
-  dailyProtocolRevenueUSD.addCGToken('indigo-protocol-isol', Number(flowsResponse.data.totals[ISOL_TOKEN] ?? 0) / 1_000_000);
-
-
-  const dailyHoldersRevenueUSD = options.createBalances();
-  dailyHoldersRevenueUSD.addCGToken('cardano', (totalLovelaceToIndyStakers) / 1_000_000);
+  const dailyHoldersRevenue = options.createBalances();
+  addTotals(dailyHoldersRevenue, collectorTotals);
 
   return {
-    dailyFees: dailyFeesUSD,
-    dailyRevenue: dailyRevenueUSD,
-    dailyProtocolRevenue: dailyProtocolRevenueUSD,
-    dailyHoldersRevenue: dailyHoldersRevenueUSD,
+    dailyFees,
+    dailyRevenue,
+    dailyProtocolRevenue,
+    dailyHoldersRevenue,
   };
 };
 
@@ -85,6 +79,8 @@ const adapter: Adapter = {
   methodology: {
     Fees: "CDP fees paid by users (mint fees, interest payments, and redemption fees), collected by the Treasury and INDY stakers. Excludes liquidated collateral, which is distributed to Stability Pool depositors rather than paid to the protocol.",
     Revenue: "CDP fees collected by the Treasury and distributed to INDY stakers.",
+    ProtocolRevenue: "CDP fees captured by the Indigo Treasury.",
+    HoldersRevenue: "CDP fees distributed to INDY stakers.",
   }
 };
 


### PR DESCRIPTION
## Summary

The Indigo adapter reads two endpoints to compute fees/revenue:

  - `/api/revenue/collector-flows` — fees sent to INDY stakers (ADA)
  - `/api/revenue/flows` — assets captured by the DAO Treasury

  The `flows` endpoint returns a `totals` map keyed by **Cardano asset unit**:

  ```json
  // https://analytics.indigoprotocol.io/api/revenue/flows?totals&inflows_only&from=1751328000&to=1759276800
  {
    "totals": {
      "lovelace": 538558652411,
      "f66d…069555344": 5282062794,   // iUSD
      "f66d…069534f4c": 812415,        // iSOL
      "533b…94e4459": 236180292971,    // INDY
      "f66d…069425443": 17939,         // iBTC
      "f66d…069455448": 152820,        // iETH
      "25c5…55534443": 8666829483,     // USDC (8 decimals)
      "c48c…5553444d": 53243554,       // USDM
      "25c5…425443": 14773             // bridged BTC
    }
  }
  ```

  ### Problems

  **1. Hardcoded token list went stale.** The adapter only read 6 keys (`lovelace` + 5 hardcoded constants: INDY,
  iUSD, iBTC, iETH, iSOL). Those reflected the assets the endpoint returned when it was first written
  (mid-2025). Since then the treasury started capturing more assets (USDC, USDM, bridged BTC, …) — and because
  the keys were hardcoded, **every asset outside the list was silently dropped**.

  **2. Wrong CoinGecko IDs → tokens priced at $0.** Pricing used `addCGToken` with guessed IDs that mostly don't
  exist:    

  | Token | ID used | Real ID | Result |
  |---|---|---|---|
  | INDY | `indigo-protocol` | `indigo-dao-governance-token` | $0 |
  | iUSD | `indigo-protocol-iusd` | `iusd` | $0 |
  | iBTC | `indigo-protocol-ibtc` | `ibtc-2` | $0 |
  | iSOL | `indigo-protocol-isol` | *(none exists)* | $0 |
  | iETH | `indigo-protocol-ieth` | `indigo-protocol-ieth` | ✅ only correct one |

  Only iETH was right; everything else contributed **$0**, so the reported fees/revenue were materially
  understated.

  **3. Hardcoded decimals.** Every token was divided by `1_000_000` (6 decimals). That's wrong for bridged
  **USDC, which has 8 decimals**

  **4. Silent failures.** Missing/malformed responses defaulted to `{}`/`0`, so an API shape change would quietly
  report $0 forever instead of failing.

  ### Solution

  **Removed the hardcoded token constants.** The adapter now iterates **every key the API returns** and maps it
  into the balances via `add(unit, rawAmount)`:

  ```ts
  const addTotals = (balances, totals) => {
    for (const [unit, amount] of Object.entries(totals)) {
      const raw = Number(amount);
      if (!raw) continue;
      if (unit === 'lovelace') balances.addCGToken('cardano', raw / 1_000_000);
      else                     balances.add(unit, raw); // -> cardano:<unit>
    }
  };
  ```

  This fixes problems 1–3 at once:

  - **Tracks all assets** the endpoint returns (current and future) — no more stale list.
  - **Prices by on-chain Cardano unit** (`cardano:<policyId+nameHex>`) instead of CoinGecko IDs. DefiLlama's
  coins server resolves the price directly.
  - **Resolves decimals per token** automatically, so passing the raw amount is correct regardless of whether a
  token uses 6 or 8 decimals.
  
  **Added response validation** via `fetchRevenueTotals(endpoint, options)`, which builds the request, fetches,
  and **throws** on an unexpected shape instead of silently returning 0:

  ```ts
  const fetchRevenueTotals = async (endpoint, options) => {
    const url = `${ANALYTICS_API_ENDPOINT}/api/revenue/${endpoint}?totals&inflows_only&from=${options.startTimest
  amp}&to=${options.endTimestamp}`;
    const { data } = await axios.get(url);
    if (!data || typeof data.totals !== 'object' || data.totals === null)
      throw new Error(`Indigo ${endpoint} returned an unexpected response: ${JSON.stringify(data)?.slice(0,
  200)}`);
    return data.totals;
  };
  ```

  **Logic is unchanged:**

  - `dailyFees` / `dailyRevenue` = treasury inflows + collector flows
  - `dailyProtocolRevenue` = treasury inflows
  - `dailyHoldersRevenue` = collector flows 

  ### Result

  - Previously $0-priced assets (INDY, iUSD, iBTC, iSOL) now contribute real USD.
  - Newly-captured assets (USDC, USDM, bridged BTC) are counted instead of dropped.
  - Correct decimals for all tokens.
  
  ### Testing

  ```
  npm test -- fees indigo 2025-09-15
  # Fees 2.71k / Revenue 2.71k / ProtocolRevenue 2.57k / HoldersRevenue 142
  ```

