### PR TITLE
Fix Pokeliquid volume adapter URL (308 redirect)

### DIFF
--- a/dexs/pokeliquid/index.ts
+++ b/dexs/pokeliquid/index.ts
@@ -3,7 +3,7 @@ import { CHAIN } from "../../helpers/chains";
 import { METRIC } from "../../helpers/metrics";
 import fetchURL from "../../utils/fetchURL";
 
-const API = "https://pokeliquid.xyz/api/keeper";
+const API = "https://www.pokeliquid.xyz/api/keeper";
 
 // https://www.pokeliquid.xyz/docs#fees
 // Fee distribution rates (from on-chain program):


### PR DESCRIPTION
## Summary
- The Pokeliquid volume adapter at `dexs/pokeliquid/index.ts` uses `https://pokeliquid.xyz/api/keeper` which returns a **308 redirect** to `https://www.pokeliquid.xyz/api/keeper`
- `fetchURL` doesn't follow 308 redirects, so the adapter throws and volume data is missing
- Fix: use `https://www.pokeliquid.xyz/api/keeper` directly
- Also added the missing `liquidationFees` field to the API response (was previously named `liquidatedCollateral`)

## Test
```
curl -s "https://www.pokeliquid.xyz/api/keeper/daily-volume?date=2026-06-22"
# Returns: {"dailyVolume":80637,"tradingFees":110.48,"fundingFees":265.89,"liquidationFees":15.72,...}
```