### PR TITLE
fix(silentswap): set backfill start to 2025-12-02

### DIFF
--- a/bridge-aggregators/silentswap/index.ts
+++ b/bridge-aggregators/silentswap/index.ts
@@ -73,7 +73,7 @@ const methodology = {
 const adapter: SimpleAdapter = {
   version: 1,
   chains: [CHAIN.CHAIN_GLOBAL], // data from all chains but stored on BNB Chain
-  start: "2025-10-31",
+  start: "2025-12-02",
   fetch,
   methodology,
 };


### PR DESCRIPTION
Updates the SilentSwap bridge-aggregator adapter's backfill `start` to **2025-12-02**, the first date with reliable on-chain inflow data in the `SilentSwapStats` reporter contract on BNB Chain (`0x5894a9B8B342BDb1AD7570C3656eE406eE26f676`).

No methodology change — the adapter still reads the anonymized daily inflow series at the latest block and derives `dailyVolume = volumeByDate(date).inflowUsd − volumeByDate(date-1).inflowUsd` (clamped ≥0).
