### PR TITLE
[fix] solv-finance: map mismatched chain keys (berachain, rootstock, …

### DIFF
--- a/fees/solv-finance/index.ts
+++ b/fees/solv-finance/index.ts
@@ -10,23 +10,28 @@ import BigNumber from "bignumber.js";
 const feesConfig =
   "https://raw.githubusercontent.com/solv-finance/solv-protocol-defillama/main/solv-fees-v2.json";
 
-const chains: { [chain: Chain]: { deployedAt: number } } = {
-  [CHAIN.ETHEREUM]: { deployedAt: 1726531200 },
-  [CHAIN.BSC]: { deployedAt: 1726531200 },
-  [CHAIN.ARBITRUM]: { deployedAt: 1726531200 },
-  [CHAIN.MANTLE]: { deployedAt: 1726531200 },
-  // [CHAIN.MERLIN]: { deployedAt: 1726531200 },
-  [CHAIN.CORE]: { deployedAt: 1726531200 },
-  [CHAIN.SCROLL]: { deployedAt: 1726531200 },
-  [CHAIN.SOLANA]: { deployedAt: 1726531200 },
-  [CHAIN.AVAX]: { deployedAt: 1726531200 },
-  [CHAIN.BOB]: { deployedAt: 1726531200 },
-  [CHAIN.BASE]: { deployedAt: 1726531200 },
-  [CHAIN.LINEA]: { deployedAt: 1726531200 },
-  [CHAIN.ROOTSTOCK]: { deployedAt: 1726531200 },
-  [CHAIN.SONEIUM]: { deployedAt: 1742169600 },
-  [CHAIN.INK]: { deployedAt: 1742169600 },
-  [CHAIN.BERACHAIN]: { deployedAt: 1742169600 },
+// `configKey` is Solv's key in solv-fees-v2.json when it differs from the
+// DefiLlama chain name (options.chain). Without it the config lookup silently
+// misses and the chain reports $0.
+const chains: { [chain: Chain]: { start: string; configKey?: string } } = {
+  [CHAIN.ETHEREUM]: { start: "2024-09-17" },
+  [CHAIN.BSC]: { start: "2024-09-17" },
+  [CHAIN.ARBITRUM]: { start: "2024-09-17" },
+  [CHAIN.MANTLE]: { start: "2024-09-17" },
+  [CHAIN.MERLIN]: { start: "2024-09-17" },
+  [CHAIN.CORE]: { start: "2024-09-17" },
+  [CHAIN.SCROLL]: { start: "2024-09-17" },
+  [CHAIN.SOLANA]: { start: "2024-09-17" },
+  [CHAIN.AVAX]: { start: "2024-09-17" },
+  [CHAIN.BOB]: { start: "2024-09-17" },
+  [CHAIN.BASE]: { start: "2024-09-17" },
+  [CHAIN.LINEA]: { start: "2024-09-17" },
+  [CHAIN.ROOTSTOCK]: { start: "2024-09-17", configKey: "rootstock" },
+  [CHAIN.AILAYER]: { start: "2024-09-17" },
+  [CHAIN.SONEIUM]: { start: "2025-03-17" },
+  [CHAIN.INK]: { start: "2025-03-17" },
+  [CHAIN.BERACHAIN]: { start: "2025-03-17", configKey: "bera" },
+  [CHAIN.HYPERLIQUID]: { start: "2025-03-17", configKey: "hyper" },
 };
 
 const fetch: FetchV2 = async (options) => {
@@ -53,10 +58,12 @@ const fetch: FetchV2 = async (options) => {
     }>;
   } = await getConfig('solv-fi/fees', feesConfig);
 
-  if (!contracts[options.chain])
+  const configKey = chains[options.chain]?.configKey ?? options.chain;
+  const pools = contracts[configKey];
+  if (!pools || pools.length === 0)
     return {}
 
-  const { dailyFees, dailyRevenue, dailySupplySideRevenue } = await fees(options, contracts);
+  const { dailyFees, dailyRevenue, dailySupplySideRevenue } = await fees(options, pools);
 
   return {
     dailyFees,
@@ -66,11 +73,10 @@ const fetch: FetchV2 = async (options) => {
   };
 };
 
-async function fees(options: FetchOptions, contracts: any) {
+async function fees(options: FetchOptions, pools: any[]) {
   const dailyFees = options.createBalances();
   const dailyRevenue = options.createBalances();
   const dailySupplySideRevenue = options.createBalances();
-  const pools = contracts[options.chain];
   if (!pools)
     return { dailyFees, dailyRevenue, dailySupplySideRevenue };
   const shareConcretes = await concrete(pools, options);
@@ -299,7 +305,7 @@ const adapter: SimpleAdapter = { adapter: {}, version: 2, pullHourly: true, meth
 Object.keys(chains).forEach((chain: Chain) => {
   adapter.adapter![chain] = {
     fetch,
-    start: chains[chain].deployedAt,
+    start: chains[chain].start,
   };
 });
 

--- a/fees/solv-finance/index.ts
+++ b/fees/solv-finance/index.ts
@@ -60,8 +60,6 @@ const fetch: FetchV2 = async (options) => {
 
   const configKey = chains[options.chain]?.configKey ?? options.chain;
   const pools = contracts[configKey];
-  if (!pools || pools.length === 0)
-    return {}
 
   const { dailyFees, dailyRevenue, dailySupplySideRevenue } = await fees(options, pools);
 
@@ -77,8 +75,10 @@ async function fees(options: FetchOptions, pools: any[]) {
   const dailyFees = options.createBalances();
   const dailyRevenue = options.createBalances();
   const dailySupplySideRevenue = options.createBalances();
-  if (!pools)
+
+  if (!pools || pools.length === 0)
     return { dailyFees, dailyRevenue, dailySupplySideRevenue };
+  
   const shareConcretes = await concrete(pools, options);
   const fromTimestamp = options.fromTimestamp * 1000;
   const toTimestamp = options.toTimestamp * 1000;

--- a/fees/solv-finance/index.ts
+++ b/fees/solv-finance/index.ts
@@ -26,7 +26,7 @@ const chains: { [chain: Chain]: { start: string; configKey?: string } } = {
   [CHAIN.BOB]: { start: "2024-09-17" },
   [CHAIN.BASE]: { start: "2024-09-17" },
   [CHAIN.LINEA]: { start: "2024-09-17" },
-  [CHAIN.ROOTSTOCK]: { start: "2024-09-17", configKey: "rootstock" },
+  //[CHAIN.ROOTSTOCK]: { start: "2024-09-17", configKey: "rootstock" },
   [CHAIN.AILAYER]: { start: "2024-09-17" },
   [CHAIN.SONEIUM]: { start: "2025-03-17" },
   [CHAIN.INK]: { start: "2025-03-17" },


### PR DESCRIPTION
## Summary

  Fixes silent `$0` reporting on several chains in the Solv Finance fees adapter caused by chain-key mismatches
  between DefiLlama chain names and Solv's fee config (`solv-fees-v2.json`).

  The adapter looked up pools with `contracts[options.chain]`, but Solv keys some chains differently from their
  DefiLlama names. When the names didn't match, the lookup returned `undefined`, the fetch early-returned `{}`,
  and those chains reported **$0 with no error** 

  ## The mismatches

  | DefiLlama name (`options.chain`) | Solv config key | Live pools | Before |
  | --- | --- | --- | --- |
  | `berachain` | `bera` | 3 | dropped → $0 |
  | `rsk` (rootstock) | `rootstock` | 2 | dropped → $0 |
  | `hyperliquid` | `hyper` | 2 | not registered |
  | `ailayer` | `ailayer` | 1 | not registered |
  | `merlin` | `merlin` | 1 | commented out |

  ## Changes

  - **Add a `configKey` override** for chains whose DefiLlama name differs from Solv's config key, and resolve
  the lookup through it:

    ```ts
    const configKey = chains[options.chain]?.configKey ?? options.chain;
    const pools = contracts[configKey];
    if (!pools || pools.length === 0) return {};

  [CHAIN.ROOTSTOCK]:   { start: "2024-09-17", configKey: "rootstock" },
  [CHAIN.BERACHAIN]:   { start: "2025-03-17", configKey: "bera" },
  [CHAIN.HYPERLIQUID]: { start: "2025-03-17", configKey: "hyper" },

  - Enable previously-missing live-pool chains: uncomment merlin, add ailayer and hyperliquid.
   - Resolve the chain's pools once in `fetch()` and pass them to `fees()`, so the same lookup bug can't reappear
  there. Also skip chains with no pools.
  - Convert start from a numeric timestamp (deployedAt: 1726531200) to the documented "YYYY-MM-DD" string format,
  which is type-clean against BaseAdapterChainConfig.start: string.