### PR TITLE
Fix trading-terminal Solana fees undercount and negative revenue

### DIFF
--- a/fees/trading-terminal/index.ts
+++ b/fees/trading-terminal/index.ts
@@ -15,7 +15,6 @@ const LABELS = {
 const solanaConfig = {
   mainFeeWallet: 'J5XGHmzrRmnYWbmw45DbYkdZAU2bwERFZ11qCDXPvFB5',
   feeCashbackWallet: 'DoAsxPQgiyAxyaJNvpAAUb2ups6rbJRdYrCPyWxwRxBb',
-  burnWallet: '9jHrTCwpDANHLNQz5cem6XLUBM8KiTWKe766Br6KVCXM',
 }
 
 const evmChainConfig: any = {
@@ -31,7 +30,13 @@ const evmChainConfig: any = {
 }
 
 async function fetchSolana(options: FetchOptions) {
-  const { mainFeeWallet, feeCashbackWallet, burnWallet } = solanaConfig
+  const { mainFeeWallet, feeCashbackWallet } = solanaConfig
+  // Each trade fee is split in-tx: the protocol portion lands in mainFeeWallet (swept to treasury)
+  // and the cashback/referral portion lands in feeCashbackWallet (paid out to ~thousands of users).
+  // Fees = the full charge = every non-internal inflow to BOTH wallets. The previous query took
+  // MAX(inflow) per tx (dropping the smaller split leg, ~32%) and inner-joined dex_solana.trades
+  // (dropping undecoded Pump/router trades, ~24% more), which understated fees ~2x and made the
+  // ~46% cashback look like ~90%, crushing revenue.
   const query = `
     WITH
     interfundTransfers AS (
@@ -48,10 +53,9 @@ async function fetchSolana(options: FetchOptions) {
         SUM(CASE WHEN address = '${mainFeeWallet}' AND balance_change < 0 THEN 1 ELSE 0 END) > 0
         AND SUM(CASE WHEN address = '${feeCashbackWallet}' AND balance_change > 0 THEN 1 ELSE 0 END) > 0
     ),
-    allFeePayments AS (
+    feeInflows AS (
       SELECT
-        tx_id,
-        balance_change AS fee_token_amount
+        COALESCE(SUM(balance_change), 0) AS fee_amount
       FROM
         solana.account_activity
       WHERE
@@ -71,44 +75,15 @@ async function fetchSolana(options: FetchOptions) {
         AND address = '${feeCashbackWallet}'
         AND tx_success
         AND balance_change < 0
-    ),
-    burnWalletInflows AS (
-      SELECT
-        COALESCE(SUM(balance_change), 0) AS buyback_burn_amount
-      FROM
-        solana.account_activity
-      WHERE
-        TIME_RANGE
-        AND address = '${burnWallet}'
-        AND tx_success
-        AND balance_change > 0
-    ),
-    botTrades AS (
-      SELECT
-        trades.tx_id,
-        MAX(fee_token_amount) AS fee
-      FROM
-        dex_solana.trades AS trades
-        JOIN allFeePayments AS feePayments ON trades.tx_id = feePayments.tx_id
-      WHERE
-        TIME_RANGE
-        AND trades.trader_id != '${mainFeeWallet}'
-        AND trades.trader_id != '${feeCashbackWallet}'
-        AND trades.trader_id != '${burnWallet}'
-      GROUP BY trades.tx_id
     )
     SELECT
-      SUM(fee) AS fee,
-      (SELECT payout_amount FROM cashbackPayouts) AS cashback_payout_amount,
-      (SELECT buyback_burn_amount FROM burnWalletInflows) AS buyback_burn_amount
-    FROM
-      botTrades
+      (SELECT fee_amount FROM feeInflows) AS fee,
+      (SELECT payout_amount FROM cashbackPayouts) AS cashback_payout_amount
   `;
 
   const [row] = await queryDuneSql(options, query);
   const tradingFees = Number(row?.fee ?? 0);
   const cashbackPayouts = Number(row?.cashback_payout_amount ?? 0);
-  const buybackBurnAmount = Number(row?.buyback_burn_amount ?? 0);
 
   const dailyFees = options.createBalances();
   const dailySupplySideRevenue = options.createBalances();
@@ -116,7 +91,10 @@ async function fetchSolana(options: FetchOptions) {
 
   dailyFees.add(ADDRESSES.solana.SOL, tradingFees, LABELS.TRADING_TERMINAL_FEES);
   dailySupplySideRevenue.add(ADDRESSES.solana.SOL, cashbackPayouts, LABELS.CASHBACK_REFERRAL_PAYOUTS);
-  dailyRevenue.add(ADDRESSES.solana.SOL, tradingFees - cashbackPayouts - buybackBurnAmount, LABELS.TRADING_TERMINAL_FEES_TO_PROTOCOL);
+  // Revenue = the protocol's portion = fees minus what the cashback wallet pays back out to
+  // users/referrers. (Buyback/burn is a lumpy treasury distribution funded out of this retained
+  // revenue, not a daily fee deduction, so it is intentionally not subtracted here.)
+  dailyRevenue.add(ADDRESSES.solana.SOL, tradingFees - cashbackPayouts, LABELS.TRADING_TERMINAL_FEES_TO_PROTOCOL);
 
   return { dailyFees, dailyRevenue, dailyProtocolRevenue: dailyRevenue, dailySupplySideRevenue }
 }
@@ -155,10 +133,10 @@ export const breakdownMethodology = {
     [LABELS.TRADING_TERMINAL_FEES]: 'Fees charged on each trade executed through the trading terminal.',
   },
   Revenue: {
-    [LABELS.TRADING_TERMINAL_FEES_TO_PROTOCOL]: 'Trading terminal fees retained by the protocol after cashback/referral payouts and buyback/burn allocations.',
+    [LABELS.TRADING_TERMINAL_FEES_TO_PROTOCOL]: 'Trading terminal fees retained by the protocol after cashback/referral payouts.',
   },
   ProtocolRevenue: {
-    [LABELS.TRADING_TERMINAL_FEES_TO_PROTOCOL]: 'Trading terminal fees retained by the protocol after cashback/referral payouts and buyback/burn allocations.',
+    [LABELS.TRADING_TERMINAL_FEES_TO_PROTOCOL]: 'Trading terminal fees retained by the protocol after cashback/referral payouts.',
   },
   SupplySideRevenue: {
     [LABELS.CASHBACK_REFERRAL_PAYOUTS]: 'All outbound transfers from the cashback/referral wallet.',
@@ -175,8 +153,8 @@ const adapter: SimpleAdapter = {
   breakdownMethodology,
   methodology: {
     Fees: "Trading fees paid by users while using Pump Trading Terminal(previously known as Padre).",
-    Revenue: "Trading terminal fees retained by Pump.fun after cashback/referral payouts and buyback/burn allocations.",
-    ProtocolRevenue: "Trading terminal fees retained by Pump.fun after cashback/referral payouts and buyback/burn allocations.",
+    Revenue: "Trading terminal fees retained by Pump.fun after cashback/referral payouts.",
+    ProtocolRevenue: "Trading terminal fees retained by Pump.fun after cashback/referral payouts.",
     SupplySideRevenue: "All outbound transfers from the cashback/referral wallet.",
   },
   allowNegativeValue: true,


### PR DESCRIPTION
## Problem

Trading-terminal Solana revenue went heavily negative on 2026-03-14..20 and 03-31..04-01 (-6k to -15k SOL/day), and on normal days implied an implausible ~90% cashback rate (Padre advertises up to 35% cashback + referral).

## Root cause (verified on-chain)

Each trade fee is **split within the same tx** between two wallets:

```
trade fee --split in-tx--> mainFeeWallet (J5XG...) --> ~4 treasury/cold addrs   = protocol revenue
                       \--> cashbackWallet (DoAs...) --> ~4k distinct users      = cashback + referral
```

Both wallets are pass-throughs; the main wallet only ever sweeps to ~4 treasury addresses, the cashback wallet pays out to ~4k users. Largest single inflow is ~1 SOL, so every inflow is a per-trade fee (no large non-fee deposits).

Two compounding bugs understated fees ~2x:

1. **`MAX(fee_token_amount)` per tx** kept only the larger of the two split legs, discarding the smaller (~32% of fees).
2. **`JOIN dex_solana.trades`** dropped fees from undecoded Pump/router trades (~24% more).

This made cashback look like ~90% of fees and collapsed revenue. Separately, revenue subtracted **buyback/burn** wallet inflows, which only arrive in lumpy biweekly treasury sweeps (10k-15k SOL/batch) - subtracting a multi-week buyback against one day's fees produced the large negatives.

## Fix

- Fees = flat sum of all non-internal SOL inflows to **both** fee wallets (no MAX, no trades-join).
- Revenue = ProtocolRevenue = Fees - cashback payouts. Buyback/burn no longer subtracted.
- Satisfies `Fees = Revenue + SupplySide`.

## Result

- Every formerly-negative day is now positive (e.g. Mar 17: -15,260 SOL -> +649 SOL).
- Cashback rate is now a stable **40-52%/day** instead of volatile 88-98% - matching up-to-35% cashback + referral.

EVM chains and the volume (dexs) adapter are untouched.