### PR TITLE
Add tag breakdown to perp dexes

### DIFF
--- a/adapters/utils/runAdapter.ts
+++ b/adapters/utils/runAdapter.ts
@@ -102,6 +102,7 @@ type AdapterRunOptions = {
   withMetadata?: boolean, // if true, returns metadata with the response
   cacheResults?: boolean, // deprecated, if true, caches the results in adapterRunResponseCache
   runWindowInSeconds?: number, // time window for which the adapter should run, default is 1 day
+  getCategory?: (symbol: string) => string | undefined, // resolver mapping a token symbol to a sector/category bucket
   metadata?: {
     [key: string]: any
     adapterType?: string
@@ -139,6 +140,7 @@ async function _runAdapter({
   deadChains = new Set(),
   runWindowInSeconds = ONE_DAY_IN_SECONDS,
   metadata = {},
+  getCategory,
 }: AdapterRunOptions) {
   const cleanCurrentDayTimestamp = endTimestamp
   const adapterVersion = module.version
@@ -191,6 +193,7 @@ async function _runAdapter({
   let breakdownByToken: any = {}
   let breakdownByLabelByChain: any = {}
   let breakdownByLabel: any = {}
+  let breakdownByCategory: any = {}
 
   const response = await Promise.all(chains.filter(chain => {
     const res = validStart[chain]
@@ -210,6 +213,7 @@ async function _runAdapter({
   if (Object.keys(breakdownByToken).length === 0) breakdownByToken = undefined
   if (Object.keys(breakdownByLabel).length === 0) breakdownByLabel = undefined
   if (Object.keys(breakdownByLabelByChain).length === 0) breakdownByLabelByChain = undefined
+  if (Object.keys(breakdownByCategory).length === 0) breakdownByCategory = undefined
 
   // if the special chain_global metric is present, it holds the aggregated value for the metric, so we move it to the value field and remove it from the chains object to avoid double counting in the aggregated value
   if (chains.length > 1 && chains.includes(CHAIN.CHAIN_GLOBAL)) {
@@ -226,6 +230,7 @@ async function _runAdapter({
     aggregated,
     breakdownByLabel,
     breakdownByLabelByChain,
+    breakdownByCategory,
     timestamp: response.find(i => i?.timestamp)?.timestamp
   }
 
@@ -286,6 +291,17 @@ async function _runAdapter({
           result[recordType] = usdTvl
           breakdownByToken[chain] = breakdownByToken[chain] || {}
           breakdownByToken[chain][recordType] = { usdTvl, usdTokenBalances, rawTokenBalances }
+
+          // categoryBreakdown: bucket per-token usd values into sector categories, summed across chains.
+          if (getCategory && usdTokenBalances) {
+            for (const [symbol, usd] of Object.entries(usdTokenBalances)) {
+              const bucket = getCategory(symbol)
+              if (!bucket) continue
+              if (!breakdownByCategory[recordType]) breakdownByCategory[recordType] = {}
+              breakdownByCategory[recordType][bucket] =
+                (breakdownByCategory[recordType][bucket] || 0) + roundValue(usd as number)
+            }
+          }
 
           if (labelBreakdown) {
             if (!breakdownByLabel[recordType]) breakdownByLabel[recordType] = {}

--- a/adapters/utils/runAdapter.ts
+++ b/adapters/utils/runAdapter.ts
@@ -102,7 +102,7 @@ type AdapterRunOptions = {
   withMetadata?: boolean, // if true, returns metadata with the response
   cacheResults?: boolean, // deprecated, if true, caches the results in adapterRunResponseCache
   runWindowInSeconds?: number, // time window for which the adapter should run, default is 1 day
-  getCategory?: (symbol: string) => string | undefined, // resolver mapping a token symbol to a sector/category bucket
+  getTag?: (symbol: string) => string | undefined, // resolver mapping a token symbol to a tag
   metadata?: {
     [key: string]: any
     adapterType?: string
@@ -140,7 +140,7 @@ async function _runAdapter({
   deadChains = new Set(),
   runWindowInSeconds = ONE_DAY_IN_SECONDS,
   metadata = {},
-  getCategory,
+  getTag,
 }: AdapterRunOptions) {
   const cleanCurrentDayTimestamp = endTimestamp
   const adapterVersion = module.version
@@ -193,7 +193,7 @@ async function _runAdapter({
   let breakdownByToken: any = {}
   let breakdownByLabelByChain: any = {}
   let breakdownByLabel: any = {}
-  let breakdownByCategory: any = {}
+  let breakdownByTag: any = {}
 
   const response = await Promise.all(chains.filter(chain => {
     const res = validStart[chain]
@@ -213,7 +213,7 @@ async function _runAdapter({
   if (Object.keys(breakdownByToken).length === 0) breakdownByToken = undefined
   if (Object.keys(breakdownByLabel).length === 0) breakdownByLabel = undefined
   if (Object.keys(breakdownByLabelByChain).length === 0) breakdownByLabelByChain = undefined
-  if (Object.keys(breakdownByCategory).length === 0) breakdownByCategory = undefined
+  if (Object.keys(breakdownByTag).length === 0) breakdownByTag = undefined
 
   // if the special chain_global metric is present, it holds the aggregated value for the metric, so we move it to the value field and remove it from the chains object to avoid double counting in the aggregated value
   if (chains.length > 1 && chains.includes(CHAIN.CHAIN_GLOBAL)) {
@@ -230,7 +230,7 @@ async function _runAdapter({
     aggregated,
     breakdownByLabel,
     breakdownByLabelByChain,
-    breakdownByCategory,
+    breakdownByTag,
     timestamp: response.find(i => i?.timestamp)?.timestamp
   }
 
@@ -292,14 +292,14 @@ async function _runAdapter({
           breakdownByToken[chain] = breakdownByToken[chain] || {}
           breakdownByToken[chain][recordType] = { usdTvl, usdTokenBalances, rawTokenBalances }
 
-          // categoryBreakdown: bucket per-token usd values into sector categories, summed across chains.
-          if (getCategory && usdTokenBalances) {
+          // tagBreakdown: bucket per-token usd values into tags, summed across chains.
+          if (getTag && usdTokenBalances) {
             for (const [symbol, usd] of Object.entries(usdTokenBalances)) {
-              const bucket = getCategory(symbol)
+              const bucket = getTag(symbol)
               if (!bucket) continue
-              if (!breakdownByCategory[recordType]) breakdownByCategory[recordType] = {}
-              breakdownByCategory[recordType][bucket] =
-                (breakdownByCategory[recordType][bucket] || 0) + roundValue(usd as number)
+              if (!breakdownByTag[recordType]) breakdownByTag[recordType] = {}
+              breakdownByTag[recordType][bucket] =
+                (breakdownByTag[recordType][bucket] || 0) + roundValue(usd as number)
             }
           }
 

--- a/dexs/apollox/index.ts
+++ b/dexs/apollox/index.ts
@@ -1,3 +1,4 @@
+import { FetchOptions } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 import { httpGet } from "../../utils/fetchURL";
 
@@ -37,7 +38,7 @@ async function sleep(time: number) {
 }
 let sleepCount = 0;
 
-const fetchV2Volume = async (retry = 0) => {
+const fetchV2Volume = async (options: FetchOptions, retry = 0) => {
   if (retry >= 3) {
     throw new Error("Failed to fetch v2 volume after 3 retries");
   }
@@ -47,28 +48,34 @@ const fetchV2Volume = async (retry = 0) => {
   const res = (await httpGet(v2VolumeAPI, {
     params: { excludeCake: true },
   })) as { data: ResponseItem[]; success: boolean };
+  const dailyVolume = options.createBalances()
   if (res.data === null && res.success === false) {
-    return fetchV2Volume(retry + 1);
+    return fetchV2Volume(options, retry + 1);
   }
-  const dailyVolume = (res.data || []).reduce((p, c) => p + +c.qutoVol, 0);
-
+  res.data.forEach(row => {
+    dailyVolume.addUSDValue(row.qutoVol, {id: row.baseAsset, isUSDValue: true} )
+  })
   return { dailyVolume, };
 };
 
-const fetchV1Volume = async () => {
+const fetchV1Volume = async (options: FetchOptions) => {
+  const dailyVolume = options.createBalances()
   const data = (await httpGet(v1VolumeAPI)) as { data: V1TickerItem[] };
-  const dailyVolume = data.data.reduce((p, c) => p + +c.quoteVolume, 0);
-
-  return { dailyVolume };
+    data.data.forEach(row => {
+    dailyVolume.addUSDValue(row.quoteVolume, {id: row.baseAsset, isUSDValue: true} )
+  })
+  return { dailyVolume, };
 };
 
-const fetch = async () => {
-  const v1DailyVolume = await fetchV1Volume();
+const fetch = async (options: FetchOptions) => {
+  const v1DailyVolume = await fetchV1Volume(options);
 
-  const v2DailyVolume = await fetchV2Volume();
+  const v2DailyVolume = await fetchV2Volume(options);
 
-  let dailyVolume = v2DailyVolume.dailyVolume + v1DailyVolume.dailyVolume;
-  if (dailyVolume >= 35_000_000_000) {
+  const dailyVolume = v2DailyVolume.dailyVolume
+  dailyVolume.addBalances(v1DailyVolume.dailyVolume)
+  const usdValue = await dailyVolume.getUSDValue()
+  if (usdValue >= 35_000_000_000) {
     console.log("Daily volume is greater than 35 billion", dailyVolume);
     throw new Error("Daily volume is too high, something went wrong");
   }

--- a/dexs/bluefin-pro/index.ts
+++ b/dexs/bluefin-pro/index.ts
@@ -1,23 +1,20 @@
-import { SimpleAdapter } from "../../adapters/types";
+import { FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 import { fetchURLAutoHandleRateLimit } from "../../utils/fetchURL";
 
-const fetch = async () => {
+const fetch = async (options: FetchOptions) => {
   const exchangeInfo = (await fetchURLAutoHandleRateLimit(`https://api.sui-prod.bluefin.io/v1/exchange/info`))
   const tickers = (await fetchURLAutoHandleRateLimit(`https://api.sui-prod.bluefin.io/v1/exchange/tickers`))
   const activeMarkets = new Set(exchangeInfo.markets.filter((market: any) => market.status === "ACTIVE").map((market: any) => market.symbol));
-  let volume = 0;
+  const dailyVolume = options.createBalances();
   let openInterest = 0;
   for(const { symbol, quoteVolume24hrE9, openInterestE9 } of tickers){
     if(!activeMarkets.has(symbol)) continue;
-    volume += Number(quoteVolume24hrE9)
-    openInterest += Number(openInterestE9)
+    const baseAsset = symbol.split("-")[0]; // e.g. "BTC-PERP" -> "BTC"
+    dailyVolume.addUSDValue(Number(quoteVolume24hrE9) / 1e9, { id: baseAsset, isUSDValue: true });
+    openInterest += Number(openInterestE9) / 1e9;
   }
-
-  return {
-    dailyVolume: volume/1e9,
-    openInterestAtEnd: openInterest / 1e9,
-  };
+  return { dailyVolume, openInterestAtEnd: openInterest };
 };
 
 

--- a/dexs/citrex-markets/index.ts
+++ b/dexs/citrex-markets/index.ts
@@ -27,17 +27,17 @@ const fetch = async (options: FetchOptions) => {
   // Divide by 10^18 to convert from min units to USDC human-readable as per the contract
   const baseUnit = new BigNumber(10).pow(18);
 
-  const dailyVolume = response.reduce((acc, item) => {
-    return acc.plus(item.volume);
-  }, new BigNumber(0));
-
-  const openInterestAtEnd = response.reduce((acc, item) => {
-    return acc.plus(item.openInterest);
-  }, new BigNumber(0));
+  const dailyVolume = options.createBalances();
+  let openInterest = new BigNumber(0);
+  for (const item of response) {
+    const baseAsset = item.productSymbol.replace(/perp$/i, "").toUpperCase(); // "btcperp" -> "BTC"
+    dailyVolume.addUSDValue(new BigNumber(item.volume).div(baseUnit).toNumber(), { id: baseAsset, isUSDValue: true });
+    openInterest = openInterest.plus(item.openInterest);
+  }
 
   return {
-    dailyVolume: dailyVolume.div(baseUnit),
-    openInterestAtEnd: openInterestAtEnd.div(baseUnit),
+    dailyVolume,
+    openInterestAtEnd: openInterest.div(baseUnit),
   };
 };
 

--- a/dexs/dydx-v4/index.ts
+++ b/dexs/dydx-v4/index.ts
@@ -1,10 +1,15 @@
 import fetchURL from "../../utils/fetchURL"
 import { FetchResultVolume, SimpleAdapter, FetchOptions } from "../../adapters/types";
 
-const fetch = async (_options: FetchOptions): Promise<FetchResultVolume> => {
+const fetch = async (options: FetchOptions): Promise<FetchResultVolume> => {
   const markets = (await fetchURL("https://indexer.dydx.trade/v4/perpetualMarkets")).markets;
-  const dailyVolume = Object.values(markets).reduce((a: number, b: any) => a+Number(b.volume24H), 0)
-  const openInterestAtEnd = Object.values(markets).reduce((a: number, b: any) => a+(Number(b.openInterest)*Number(b.oraclePrice)), 0)
+  const dailyVolume = options.createBalances();
+  let openInterestAtEnd = 0;
+  for (const market of Object.values(markets) as any[]) {
+    const baseAsset = String(market.ticker).split("-")[0]; // "BTC-USD" -> "BTC"
+    dailyVolume.addUSDValue(Number(market.volume24H), { id: baseAsset, isUSDValue: true });
+    openInterestAtEnd += Number(market.openInterest) * Number(market.oraclePrice);
+  }
   return {
     dailyVolume,
     openInterestAtEnd,

--- a/dexs/jupiter-perpetual/index.ts
+++ b/dexs/jupiter-perpetual/index.ts
@@ -3,13 +3,13 @@ import { FetchOptions, FetchResult } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 import { httpGet } from "../../utils/fetchURL";
 
-const list_of_mints: string[] = [
-  ADDRESSES.solana.SOL,
-  "3NZ9JMVBmGAqocybic2c7LQCJScmgsAZ6vQqTDzcqmJh",
-  "7vfCXTUXx5WJV5JADk17DUJ4ksgau7utNKj4b963voxs",
+const markets: { mint: string; symbol: string }[] = [
+  { mint: ADDRESSES.solana.SOL, symbol: "SOL" },
+  { mint: "3NZ9JMVBmGAqocybic2c7LQCJScmgsAZ6vQqTDzcqmJh", symbol: "BTC" }, // Wrapped BTC (Wormhole)
+  { mint: "7vfCXTUXx5WJV5JADk17DUJ4ksgau7utNKj4b963voxs", symbol: "ETH" }, // Ethereum (Wormhole)
 ]
 
-const fetch = async (_options: FetchOptions): Promise<FetchResult> => {
+const fetch = async (options: FetchOptions): Promise<FetchResult> => {
   const header_user = {
     "accept": "*/*",
     "accept-language": "en-US,en;q=0.9",
@@ -26,8 +26,12 @@ const fetch = async (_options: FetchOptions): Promise<FetchResult> => {
     "user-agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4430.212 Safari/537.36",
   }
   const url = (token: string) => `https://perp-api.jup.ag/trpc/tradeVolume?batch=1&input={"0":{"json":{"mint":"${token}"}}}`
-  const fetches = (await Promise.all(list_of_mints.map(token => httpGet(url(token), { headers: header_user })))).flat();
-  const dailyVolume = fetches.reduce((acc, { result }) => acc + result.data.json.volume, 0);
+  const dailyVolume = options.createBalances();
+  await Promise.all(markets.map(async ({ mint, symbol }) => {
+    const res: any[] = (await httpGet(url(mint), { headers: header_user })).flat();
+    const volume = res.reduce((acc: number, { result }: any) => acc + result.data.json.volume, 0);
+    dailyVolume.addUSDValue(volume, { id: symbol, isUSDValue: true });
+  }));
 
   // // Fetch JLP pool info for open interest calculation
   // const jlpInfoUrl = 'https://perps-api.jup.ag/v1/jlp-info';

--- a/dexs/variational-omni/index.ts
+++ b/dexs/variational-omni/index.ts
@@ -1,16 +1,25 @@
-import { SimpleAdapter } from "../../adapters/types";
+import { FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 import fetchUrl from "../../utils/fetchURL";
 
 const URL =
   "https://omni-client-api.prod.ap-northeast-1.variational.io/metadata/stats";
 
-const fetch = async (_: any) => {
+// strip leading size-multiplier prefixes (e.g. "1000000MOG" -> "MOG", "1000PEPE" -> "PEPE")
+// while preserving genuine symbols that start with a digit (1INCH, 0G, 2Z, 4).
+const baseAsset = (ticker: string) => ticker.replace(/^(1000000|100000|10000|1000|1M|1K)/i, "");
+
+const fetch = async (options: FetchOptions) => {
   const data = await fetchUrl(URL);
+
+  const dailyVolume = options.createBalances();
+  for (const listing of data.listings ?? []) {
+    dailyVolume.addUSDValue(Number(listing.volume_24h), { id: baseAsset(String(listing.ticker)), isUSDValue: true });
+  }
 
   return {
     openInterestAtEnd: data.open_interest,
-    dailyVolume: data?.total_volume_24h ,
+    dailyVolume,
   };
 };
 

--- a/dexs/variational-omni/index.ts
+++ b/dexs/variational-omni/index.ts
@@ -13,7 +13,10 @@ const fetch = async (options: FetchOptions) => {
   const data = await fetchUrl(URL);
 
   const dailyVolume = options.createBalances();
-  for (const listing of data.listings ?? []) {
+  if (!Array.isArray(data.listings) || data.listings.length === 0) {
+    throw new Error("Variational response missing listings")
+  }
+  for (const listing of data.listings) {
     dailyVolume.addUSDValue(Number(listing.volume_24h), { id: baseAsset(String(listing.ticker)), isUSDValue: true });
   }
 

--- a/dexs/vest/index.ts
+++ b/dexs/vest/index.ts
@@ -1,21 +1,26 @@
 import {CHAIN} from "../../helpers/chains";
-import {FetchResultVolume, SimpleAdapter} from "../../adapters/types";
+import {FetchOptions, FetchResultVolume, SimpleAdapter} from "../../adapters/types";
 import fetchURL from "../../utils/fetchURL"
 
 const tickers_endpoint = 'https://server-prod.hz.vestmarkets.com/v2/ticker/24hr'
 
 const blacklisted_tickers = ['VC-PERP'] // wash trading
 
-const fetch = async (): Promise<FetchResultVolume> => {
+const fetch = async (options: FetchOptions): Promise<FetchResultVolume> => {
     // const from_date = getUniqStartOfTodayTimestamp(new Date(options.startOfDay * 1000));
     // const to_date = from_date + 86400;
     // const data = (await fetchURL(`https://serverprod.vest.exchange/v2/exchangeInfo/volume?from_date=${from_date * 1000}&to_date=${to_date * 1000}`));
 
     const data = (await fetchURL(tickers_endpoint)).tickers;
-    const dailyVolume = data.filter((ticker: any) => !blacklisted_tickers.includes(ticker.symbol)).reduce((acc: number, ticker: any) => acc + Number(ticker.quoteVolume || 0), 0);
+    const dailyVolume = options.createBalances();
+    for (const ticker of data) {
+        if (blacklisted_tickers.includes(ticker.symbol)) continue;
+        const baseAsset = String(ticker.symbol).split("-")[0]; // "TSM-USD-PERP" -> "TSM", "BZ-PERP" -> "BZ"
+        dailyVolume.addUSDValue(Number(ticker.quoteVolume || 0), { id: baseAsset, isUSDValue: true });
+    }
 
     return {
-        dailyVolume: dailyVolume,
+        dailyVolume,
     };
 };
 


### PR DESCRIPTION
https://github.com/DefiLlama/internal-docs/issues/40
Added breakdownByTag to the runner to return a breakdown of perp volume by asset tag (RWA, Layer 1, Meme...) and refactored multiple runAtCurrTime perp dex adapters to return balance objects with symbols