### PR TITLE
users: expand isAcceptedChain to full Allium chain set

### DIFF
--- a/users/utils/convertChain.ts
+++ b/users/utils/convertChain.ts
@@ -5,7 +5,13 @@ export const convertChain = (chain: string) => ({
 
 export const convertChainToAllium = (chain: string) => ({
     xdai: "gnosis",
-    avax: "avalanche"
+    avax: "avalanche",
+    manta: "manta_pacific"
 }[chain] ?? chain)
 
-export const isAcceptedChain = (chain:string) => ["arbitrum", "avax", "ethereum", "optimism", "polygon", "base", "bsc", "scroll", "polygon_zkevm", "starknet"].includes(chain)
+export const isAcceptedChain = (chain: string) => [
+    "arbitrum", "avax", "ethereum", "optimism", "polygon", "tron", "base",
+    "scroll", "polygon_zkevm", "bsc", "megaeth", "katana", "abstract", "linea",
+    "manta", "ronin", "sonic", "mantle", "berachain", "blast", "monad",
+    "plasma", "sei", "core", "tempo", "stable",
+].includes(chain)


### PR DESCRIPTION
Expands isAcceptedChain from 9 chains to the full set of chains already supported by alliumChainMap.

starknet is intentionally left out: Allium's starknet.raw.transactions has no to_address/from_address column, so the TO_ADDRESS IN (...) / distinct FROM_ADDRESS query in countUsers.ts cannot run there.