### PR TITLE
Add Crovia (NFT marketplace + aggregator) — fees & aggregator adapters

### DIFF
--- a/aggregators/crovia.ts
+++ b/aggregators/crovia.ts
@@ -1,0 +1,60 @@
+/**
+ * Crovia — NFT marketplace aggregator adapter (Cronos).
+ *
+ * Drop-in for github.com/DefiLlama/dimension-adapters at `aggregators/crovia.ts`.
+ * Source: on-chain `Buy` events from every CroviaRouter version (all share the
+ * same ABI). When a user buys from an external marketplace (Ebisusbay / Minted)
+ * through Crovia, the Router forwards `purchaseValue` to that marketplace and
+ * collects `feeAmount` (Crovia's 1.5% aggregation fee) for the protocol.
+ *
+ * dailyVolume here is the GMV *routed through Crovia* to external marketplaces —
+ * disjoint from the native marketplace volume in fees/crovia.ts (native fills go
+ * through CroviaTrade.fillListing -> `Filled`, never the Router).
+ */
+import { FetchOptions, SimpleAdapter } from '../adapters/types'
+import { CHAIN } from '../helpers/chains'
+
+const BUY_EVENT =
+  'event Buy(address indexed buyer, address indexed marketplace, address indexed nftContract, uint256 tokenId, uint256 purchaseValue, uint256 feeAmount)'
+
+// Authoritative addresses — resolved from contracts/deployments/cronos/*.json.
+const ROUTER_CONTRACTS = [
+  '0xC34D2af8ca5784a53a2615f1CA6Ff61B988E32D8', // CroviaRouter   (2026-04-22)
+  '0x929bD3860B9b615A3ba954FDdaD922306b03A6e5', // CroviaRouterV3 (2026-05-15)
+  '0xCd5D596801c90fB345d5C4aFD5a740D08AF8b0De', // CroviaRouterV4 (proxy, live since 2026-05-18)
+]
+
+const fetch = async (options: FetchOptions) => {
+  const dailyVolume = options.createBalances()
+  const dailyFees = options.createBalances()
+  const dailyRevenue = options.createBalances()
+  const dailyProtocolRevenue = options.createBalances()
+
+  const logs = await options.getLogs({ targets: ROUTER_CONTRACTS, eventAbi: BUY_EVENT })
+
+  for (const log of logs) {
+    dailyVolume.addGasToken(log.purchaseValue) // GMV routed to external marketplaces
+    dailyFees.addGasToken(log.feeAmount) // Crovia's 1.5% aggregation fee
+    dailyRevenue.addGasToken(log.feeAmount)
+    dailyProtocolRevenue.addGasToken(log.feeAmount)
+  }
+
+  return { dailyVolume, dailyFees, dailyRevenue, dailyProtocolRevenue }
+}
+
+const methodology = {
+  Volume: 'CRO value of NFT purchases routed through the Crovia aggregator to external Cronos marketplaces (Ebisusbay, Minted).',
+  Fees: "Crovia's 1.5% aggregation fee charged on each routed purchase.",
+  Revenue: "Crovia's 1.5% aggregation fee (all retained by the protocol).",
+  ProtocolRevenue: "Crovia's 1.5% aggregation fee.",
+}
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  fetch,
+  chains: [CHAIN.CRONOS],
+  start: '2026-04-22', // first CroviaRouter deploy
+  methodology,
+}
+
+export default adapter

--- a/aggregators/crovia.ts
+++ b/aggregators/crovia.ts
@@ -34,9 +34,9 @@ const fetch = async (options: FetchOptions) => {
 
   for (const log of logs) {
     dailyVolume.addGasToken(log.purchaseValue) // GMV routed to external marketplaces
-    dailyFees.addGasToken(log.feeAmount) // Crovia's 1.5% aggregation fee
-    dailyRevenue.addGasToken(log.feeAmount)
-    dailyProtocolRevenue.addGasToken(log.feeAmount)
+    dailyFees.addGasToken(log.feeAmount, "Aggregator Fees") // Crovia's 1.5% aggregation fee
+    dailyRevenue.addGasToken(log.feeAmount, "Aggregator Fees")
+    dailyProtocolRevenue.addGasToken(log.feeAmount, "Aggregator Fees")
   }
 
   return { dailyVolume, dailyFees, dailyRevenue, dailyProtocolRevenue }
@@ -46,15 +46,29 @@ const methodology = {
   Volume: 'CRO value of NFT purchases routed through the Crovia aggregator to external Cronos marketplaces (Ebisusbay, Minted).',
   Fees: "Crovia's 1.5% aggregation fee charged on each routed purchase.",
   Revenue: "Crovia's 1.5% aggregation fee (all retained by the protocol).",
-  ProtocolRevenue: "Crovia's 1.5% aggregation fee.",
+  ProtocolRevenue: "Crovia's 1.5% aggregation fee. (all retained by the protocol).",
+}
+
+const breakdownMethodology = {
+  Fees: {
+    "Aggregator Fees": "Crovia's 1.5% aggregation fee charged on each routed purchase.",
+  },
+  Revenue: {
+    "Aggregator Fees": "Crovia's 1.5% aggregation fee charged on each routed purchase.",
+  },
+  ProtocolRevenue: {
+    "Aggregator Fees": "Crovia's 1.5% aggregation fee retained by the protocol.",
+  },
 }
 
 const adapter: SimpleAdapter = {
   version: 2,
   fetch,
+  pullHourly: true,
   chains: [CHAIN.CRONOS],
-  start: '2026-04-22', // first CroviaRouter deploy
+  start: '2026-04-22',
   methodology,
+  breakdownMethodology,
 }
 
 export default adapter

--- a/aggregators/crovia.ts
+++ b/aggregators/crovia.ts
@@ -34,9 +34,9 @@ const fetch = async (options: FetchOptions) => {
 
   for (const log of logs) {
     dailyVolume.addGasToken(log.purchaseValue) // GMV routed to external marketplaces
-    dailyFees.addGasToken(log.feeAmount, "Aggregator Fees") // Crovia's 1.5% aggregation fee
-    dailyRevenue.addGasToken(log.feeAmount, "Aggregator Fees")
-    dailyProtocolRevenue.addGasToken(log.feeAmount, "Aggregator Fees")
+    dailyFees.addGasToken(log.feeAmount, 'Aggregation Fees') // Crovia's 1.5% aggregation fee
+    dailyRevenue.addGasToken(log.feeAmount, 'Aggregation Fees To Protocol')
+    dailyProtocolRevenue.addGasToken(log.feeAmount, 'Aggregation Fees To Protocol')
   }
 
   return { dailyVolume, dailyFees, dailyRevenue, dailyProtocolRevenue }
@@ -46,27 +46,21 @@ const methodology = {
   Volume: 'CRO value of NFT purchases routed through the Crovia aggregator to external Cronos marketplaces (Ebisusbay, Minted).',
   Fees: "Crovia's 1.5% aggregation fee charged on each routed purchase.",
   Revenue: "Crovia's 1.5% aggregation fee (all retained by the protocol).",
-  ProtocolRevenue: "Crovia's 1.5% aggregation fee. (all retained by the protocol).",
+  ProtocolRevenue: "Crovia's 1.5% aggregation fee.",
 }
 
 const breakdownMethodology = {
-  Fees: {
-    "Aggregator Fees": "Crovia's 1.5% aggregation fee charged on each routed purchase.",
-  },
-  Revenue: {
-    "Aggregator Fees": "Crovia's 1.5% aggregation fee charged on each routed purchase.",
-  },
-  ProtocolRevenue: {
-    "Aggregator Fees": "Crovia's 1.5% aggregation fee retained by the protocol.",
-  },
+  Fees: { 'Aggregation Fees': "Crovia's 1.5% aggregation fee on each routed purchase." },
+  Revenue: { 'Aggregation Fees To Protocol': "Crovia's 1.5% aggregation fee, retained by the protocol." },
+  ProtocolRevenue: { 'Aggregation Fees To Protocol': "Crovia's 1.5% aggregation fee." },
 }
 
 const adapter: SimpleAdapter = {
   version: 2,
   fetch,
-  pullHourly: true,
   chains: [CHAIN.CRONOS],
-  start: '2026-04-22',
+  start: '2026-04-22', // first CroviaRouter deploy
+  pullHourly: true,
   methodology,
   breakdownMethodology,
 }

--- a/fees/crovia-nft-marketplace.ts
+++ b/fees/crovia-nft-marketplace.ts
@@ -42,13 +42,13 @@ const fetch = async (options: FetchOptions) => {
 
   for (const log of logs) {
     dailyVolume.addGasToken(log.price)
-    dailyProtocolRevenue.addGasToken(log.fee, 'Marketplace Fees To Protocol') // Crovia's cut
-    dailySupplySideRevenue.addGasToken(log.royalty, 'Creator Royalties To Creators') // creator earnings (supply side)
-    // Fees = marketplace fee + creator royalty (gross value collected on a sale).
-    // Revenue = the protocol's cut only; the creator royalty is supply-side, not revenue.
-    dailyFees.addGasToken(log.fee, 'Marketplace Fees')
-    dailyFees.addGasToken(log.royalty, 'Creator Royalties')
-    dailyRevenue.addGasToken(log.fee, 'Marketplace Fees To Protocol')
+
+    dailyFees.addGasToken(log.fee, "Marketplace Fees")
+    dailyRevenue.addGasToken(log.fee, "Marketplace Fees to Protocol")
+    dailyProtocolRevenue.addGasToken(log.fee, "Marketplace Fees to Protocol")
+
+    dailyFees.addGasToken(log.royalty, "Creator Royalties")
+    dailySupplySideRevenue.addGasToken(log.royalty, "Royalties to Creators")
   }
 
   return {
@@ -58,45 +58,39 @@ const fetch = async (options: FetchOptions) => {
     dailyRevenue,
     dailyProtocolRevenue,
     dailySupplySideRevenue,
-    dailyHoldersRevenue: 0, // no on-chain token / revenue share
   }
 }
 
 const methodology = {
-  Fees: 'Total value collected on each Crovia marketplace sale: the Crovia marketplace fee (3%, or 2.5% for high-tier listings >= 4000 CRO) plus the creator royalty, both in CRO.',
-  UserFees: 'Fees paid by traders per sale: marketplace fee + creator royalty.',
-  Revenue: 'The Crovia marketplace fee retained by the protocol (3% / 2.5%). Creator royalties are reported separately as supply-side revenue, not protocol revenue.',
-  ProtocolRevenue: 'The Crovia marketplace fee retained by the protocol (3% / 2.5%).',
-  SupplySideRevenue: 'Creator royalties paid to collection creators on each sale.',
-  HoldersRevenue: 'Crovia has no on-chain token; no revenue is distributed to holders.',
+  Volume: 'NFT purchases on the Crovia marketplace.',
+  Fees: 'The Crovia marketplace fee (3%, or 2.5% for high-tier listings >= 4000 CRO) plus the creator royalty.',
+  Revenue: 'The Crovia marketplace fee (3%, or 2.5% for high-tier listings >= 4000 CRO).',
+  ProtocolRevenue: 'The Crovia marketplace fee (3%, or 2.5% for high-tier listings >= 4000 CRO) retained by the protocol.',
+  SupplySideRevenue: 'The creator royalties paid to collection creators on each sale.',
 }
 
 const breakdownMethodology = {
   Fees: {
-    'Marketplace Fees': 'Crovia marketplace fee (3%, or 2.5% for high-tier listings >= 4000 CRO).',
-    'Creator Royalties': 'Creator royalty paid out of seller proceeds on each sale.',
-  },
-  UserFees: {
-    'Marketplace Fees': 'Crovia marketplace fee paid by the trader.',
-    'Creator Royalties': 'Creator royalty paid by the trader.',
+    "Marketplace Fees": "The Crovia marketplace fee (3%, or 2.5% for high-tier listings >= 4000 CRO).",
+    "Creator Royalties": "The creator royalties paid to collection creators on each sale.",
   },
   Revenue: {
-    'Marketplace Fees To Protocol': 'Crovia marketplace fee retained by the protocol.',
+    "Marketplace Fees to Protocol": "The Crovia marketplace fee (3%, or 2.5% for high-tier listings >= 4000 CRO).",
   },
   ProtocolRevenue: {
-    'Marketplace Fees To Protocol': 'Crovia marketplace fee retained by the protocol.',
+    "Marketplace Fees to Protocol": "The Crovia marketplace fee (3%, or 2.5% for high-tier listings >= 4000 CRO).",
   },
   SupplySideRevenue: {
-    'Creator Royalties To Creators': 'Creator royalties paid to collection creators.',
+    "Royalties to Creators": "The creator royalties paid to collection creators on each sale.",
   },
 }
 
 const adapter: SimpleAdapter = {
   version: 2,
   fetch,
-  chains: [CHAIN.CRONOS],
-  start: '2026-04-28', // first CroviaTrade (V1) deploy
   pullHourly: true,
+  chains: [CHAIN.CRONOS],
+  start: '2026-04-28',
   methodology,
   breakdownMethodology,
 }

--- a/fees/crovia.ts
+++ b/fees/crovia.ts
@@ -1,0 +1,82 @@
+/**
+ * Crovia — NFT marketplace fees adapter (Cronos).
+ *
+ * Drop-in for github.com/DefiLlama/dimension-adapters at `fees/crovia.ts`.
+ * Source: on-chain `Filled` events from every CroviaTrade version (all share the
+ * same ABI). Each fill carries the exact CRO `price`, marketplace `fee`, and
+ * creator `royalty`, so every dimension is read straight from the log — no API,
+ * no off-chain data.
+ *
+ * Reference implementation in the Crovia repo:
+ *   nft-indexer/src/integrations/trade-event-scanner.ts  (same ABI + topic hash)
+ *
+ * Fees: Crovia charges the buyer 3% (2.5% for high-tier listings >= 4000 CRO),
+ * the seller pays the creator royalty out of proceeds. `fee` = Crovia's cut,
+ * `royalty` = creator earnings. Values are native CRO (wei) -> addGasToken().
+ */
+import { FetchOptions, SimpleAdapter } from '../adapters/types'
+import { CHAIN } from '../helpers/chains'
+
+// Every CroviaTrade version emits this identical event. Full-history coverage is
+// just the address list below.
+const FILLED_EVENT =
+  'event Filled(bytes32 indexed listingHash, address indexed seller, address indexed buyer, address nftContract, uint256 tokenId, uint256 price, uint256 fee, uint256 royalty, address royaltyReceiver)'
+
+// Authoritative addresses — resolved from contracts/deployments/cronos/*.json.
+const TRADE_CONTRACTS = [
+  '0x338eF6fFFFa25f60Fda4ab8C1A541bddC3eaE65a', // CroviaTrade   V1  (2026-04-28)
+  '0xe7639240a885a1f3d97b362da14310e4897db64f', // CroviaTrade   V2  (2026-05-11)
+  '0xA981F39EBB0484f69a3c4B3FaF439B054845F76A', // CroviaTrade   V3  (2026-05-14)
+  '0x402920d26dca469699395f606e4c68b982d44ce8', // CroviaTrade   V4  (dormant)
+  '0x6FE665F84daa4e104b478e0dcC169A5C7145De09', // CroviaTrade   V5  (proxy, live since 2026-06-01)
+]
+
+const fetch = async (options: FetchOptions) => {
+  const dailyVolume = options.createBalances()
+  const dailyFees = options.createBalances()
+  const dailyRevenue = options.createBalances()
+  const dailyProtocolRevenue = options.createBalances()
+  const dailySupplySideRevenue = options.createBalances()
+
+  const logs = await options.getLogs({ targets: TRADE_CONTRACTS, eventAbi: FILLED_EVENT })
+
+  for (const log of logs) {
+    dailyVolume.addGasToken(log.price)
+    dailyProtocolRevenue.addGasToken(log.fee) // Crovia's cut
+    dailySupplySideRevenue.addGasToken(log.royalty) // creator earnings
+    // Fees / Revenue = marketplace fee + creator royalty ("all value collected").
+    dailyFees.addGasToken(log.fee)
+    dailyFees.addGasToken(log.royalty)
+    dailyRevenue.addGasToken(log.fee)
+    dailyRevenue.addGasToken(log.royalty)
+  }
+
+  return {
+    dailyVolume,
+    dailyFees,
+    dailyUserFees: dailyFees,
+    dailyRevenue,
+    dailyProtocolRevenue,
+    dailySupplySideRevenue,
+    dailyHoldersRevenue: 0, // no on-chain token / revenue share
+  }
+}
+
+const methodology = {
+  Fees: 'Total value collected on each Crovia marketplace sale: the Crovia marketplace fee (3%, or 2.5% for high-tier listings >= 4000 CRO) plus the creator royalty, both in CRO.',
+  UserFees: 'Fees paid by traders per sale: marketplace fee + creator royalty.',
+  Revenue: 'Crovia marketplace fee + creator royalty (marketplace revenue + creator earnings).',
+  ProtocolRevenue: 'The Crovia marketplace fee retained by the protocol (3% / 2.5%).',
+  SupplySideRevenue: 'Creator royalties paid to collection creators on each sale.',
+  HoldersRevenue: 'Crovia has no on-chain token; no revenue is distributed to holders.',
+}
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  fetch,
+  chains: [CHAIN.CRONOS],
+  start: '2026-04-28', // first CroviaTrade (V1) deploy
+  methodology,
+}
+
+export default adapter

--- a/fees/crovia.ts
+++ b/fees/crovia.ts
@@ -42,13 +42,13 @@ const fetch = async (options: FetchOptions) => {
 
   for (const log of logs) {
     dailyVolume.addGasToken(log.price)
-    dailyProtocolRevenue.addGasToken(log.fee) // Crovia's cut
-    dailySupplySideRevenue.addGasToken(log.royalty) // creator earnings
-    // Fees / Revenue = marketplace fee + creator royalty ("all value collected").
-    dailyFees.addGasToken(log.fee)
-    dailyFees.addGasToken(log.royalty)
-    dailyRevenue.addGasToken(log.fee)
-    dailyRevenue.addGasToken(log.royalty)
+    dailyProtocolRevenue.addGasToken(log.fee, 'Marketplace Fees To Protocol') // Crovia's cut
+    dailySupplySideRevenue.addGasToken(log.royalty, 'Creator Royalties To Creators') // creator earnings (supply side)
+    // Fees = marketplace fee + creator royalty (gross value collected on a sale).
+    // Revenue = the protocol's cut only; the creator royalty is supply-side, not revenue.
+    dailyFees.addGasToken(log.fee, 'Marketplace Fees')
+    dailyFees.addGasToken(log.royalty, 'Creator Royalties')
+    dailyRevenue.addGasToken(log.fee, 'Marketplace Fees To Protocol')
   }
 
   return {
@@ -65,10 +65,30 @@ const fetch = async (options: FetchOptions) => {
 const methodology = {
   Fees: 'Total value collected on each Crovia marketplace sale: the Crovia marketplace fee (3%, or 2.5% for high-tier listings >= 4000 CRO) plus the creator royalty, both in CRO.',
   UserFees: 'Fees paid by traders per sale: marketplace fee + creator royalty.',
-  Revenue: 'Crovia marketplace fee + creator royalty (marketplace revenue + creator earnings).',
+  Revenue: 'The Crovia marketplace fee retained by the protocol (3% / 2.5%). Creator royalties are reported separately as supply-side revenue, not protocol revenue.',
   ProtocolRevenue: 'The Crovia marketplace fee retained by the protocol (3% / 2.5%).',
   SupplySideRevenue: 'Creator royalties paid to collection creators on each sale.',
   HoldersRevenue: 'Crovia has no on-chain token; no revenue is distributed to holders.',
+}
+
+const breakdownMethodology = {
+  Fees: {
+    'Marketplace Fees': 'Crovia marketplace fee (3%, or 2.5% for high-tier listings >= 4000 CRO).',
+    'Creator Royalties': 'Creator royalty paid out of seller proceeds on each sale.',
+  },
+  UserFees: {
+    'Marketplace Fees': 'Crovia marketplace fee paid by the trader.',
+    'Creator Royalties': 'Creator royalty paid by the trader.',
+  },
+  Revenue: {
+    'Marketplace Fees To Protocol': 'Crovia marketplace fee retained by the protocol.',
+  },
+  ProtocolRevenue: {
+    'Marketplace Fees To Protocol': 'Crovia marketplace fee retained by the protocol.',
+  },
+  SupplySideRevenue: {
+    'Creator Royalties To Creators': 'Creator royalties paid to collection creators.',
+  },
 }
 
 const adapter: SimpleAdapter = {
@@ -76,7 +96,9 @@ const adapter: SimpleAdapter = {
   fetch,
   chains: [CHAIN.CRONOS],
   start: '2026-04-28', // first CroviaTrade (V1) deploy
+  pullHourly: true,
   methodology,
+  breakdownMethodology,
 }
 
 export default adapter


### PR DESCRIPTION
Adds Crovia, an NFT marketplace + aggregator on Cronos (chainId 25).

Files:
- `fees/crovia.ts`        — native marketplace fees/revenue from on-chain CroviaTrade `Filled` events (V1–V5)
- `aggregators/crovia.ts` — GMV routed through the Crovia aggregator + 1.5% fee, from CroviaRouter `Buy` events

Data source: 100% on-chain event logs (`getLogs`), no external API.

**`fees/crovia.ts`** dimensions (CRO, native gas token):
- `dailyVolume`            = Σ sale price
- `dailyProtocolRevenue`   = Σ marketplace fee (3%, or 2.5% for high-tier listings ≥ 4000 CRO)
- `dailySupplySideRevenue` = Σ creator royalty
- `dailyFees` / `dailyRevenue` / `dailyUserFees` = fee + royalty

**`aggregators/crovia.ts`**:
- `dailyVolume` = GMV routed to external marketplaces (Ebisusbay, Minted)
- `dailyFees` / `dailyRevenue` / `dailyProtocolRevenue` = Σ 1.5% aggregation fee

The two adapters are disjoint, so there is no double-counting: native fills go through `CroviaTrade.fillListing` → `Filled`; the Router only handles external marketplaces → `Buy`.

Contracts (Cronos):
- CroviaTrade V1 `0x338eF6fFFFa25f60Fda4ab8C1A541bddC3eaE65a` … V5 (proxy) `0x6FE665F84daa4e104b478e0dcC169A5C7145De09`
- CroviaRouter `0xC34D2af8ca5784a53a2615f1CA6Ff61B988E32D8`, V3 `0x929bD3860B9b615A3ba954FDdaD922306b03A6e5`, V4 `0xCd5D596801c90fB345d5C4aFD5a740D08AF8b0De`

Validation: the adapters read only on-chain `getLogs` (no external API or keys), with event ABIs matching our live reference scanner. Please let CI run the standard `npm test fees crovia` / `npm test aggregators crovia` checks — happy to iterate on anything that flags.

Project: https://crovia.app · Twitter: https://x.com/CroviaNFT · Security/contracts: https://crovia.app/audit
