### PR TITLE
morpho: add etherlink, tempo, stable

### DIFF
--- a/fees/morpho/index.ts
+++ b/fees/morpho/index.ts
@@ -138,6 +138,8 @@ const MorphoBlues: Record<string, MorphoBlueConfig> = {
     blue: "0x99D31FEcc885204b4136ea5D2ef2a37F36E3AeB8",
     start: "2026-01-23",
   },
+  // Sei deferred: not in Morpho API, and getLogs is disabled for sei (runAdapter problematicChains).
+  // blue 0xc9cDAc20FCeAAF616f7EB0bb6Cd2c69dcfa9094c, block 166036723.
   [CHAIN.ETHERLINK]: {
     fromBlock: 21047448,
     blue: "0xbCE7364E63C3B13C73E9977a83c9704E2aCa876e",
@@ -153,11 +155,8 @@ const MorphoBlues: Record<string, MorphoBlueConfig> = {
     blue: "0xa40103088A899514E3fe474cD3cc5bf811b1102e",
     start: "2025-11-10",
   },
-  // [CHAIN.TAC]: {
-  //   fromBlock: 853025,
-  //   blue: "0x918B9F2E4B44E20c6423105BB6cCEB71473aD35c",
-  //   start: "2025-06-25",
-  // },
+  // TAC deferred: not in Morpho API, and its CreateMarket log scan isn't indexed.
+  // blue 0x918B9F2E4B44E20c6423105BB6cCEB71473aD35c, block 853025.
 };
 
 const info = {

--- a/fees/morpho/index.ts
+++ b/fees/morpho/index.ts
@@ -138,11 +138,21 @@ const MorphoBlues: Record<string, MorphoBlueConfig> = {
     blue: "0x99D31FEcc885204b4136ea5D2ef2a37F36E3AeB8",
     start: "2026-01-23",
   },
-  // [CHAIN.STABLE]: {
-  //   fromBlock: 4342501,
-  //   blue: "0xa40103088A899514E3fe474cD3cc5bf811b1102e",
-  //   start: "2025-12-08",
-  // },
+  [CHAIN.ETHERLINK]: {
+    fromBlock: 21047448,
+    blue: "0xbCE7364E63C3B13C73E9977a83c9704E2aCa876e",
+    start: "2025-07-14",
+  },
+  [CHAIN.TEMPO]: {
+    chainId: 4217,
+    blue: "0x10EE9AAC980A180dd4DcFc96C746d60B0EA88f97",
+    start: "2026-01-30",
+  },
+  [CHAIN.STABLE]: {
+    chainId: 988,
+    blue: "0xa40103088A899514E3fe474cD3cc5bf811b1102e",
+    start: "2025-11-10",
+  },
   // [CHAIN.TAC]: {
   //   fromBlock: 853025,
   //   blue: "0x918B9F2E4B44E20c6423105BB6cCEB71473aD35c",
@@ -235,15 +245,15 @@ const _fetchMarkets = async (chainId: number, url: string): Promise<Array<Morpho
   do {
     const res = await request(url, query, { chainId, first, skip });
     marketsBatch = res.markets.items
-    .map((item: any) => {
-      return {
-        marketId: item.marketId,
-        loanAsset: item.loanAsset.address,
-        collateralAsset: item.collateralAsset ? item.collateralAsset.address : undefined,
-        lltv: BigInt(item.lltv),
-        lif: _getLIFFromLLTV(BigInt(item.lltv)),
-      };
-    });
+      .map((item: any) => {
+        return {
+          marketId: item.marketId,
+          loanAsset: item.loanAsset.address,
+          collateralAsset: item.collateralAsset ? item.collateralAsset.address : undefined,
+          lltv: BigInt(item.lltv),
+          lif: _getLIFFromLLTV(BigInt(item.lltv)),
+        };
+      });
     allMarkets = allMarkets.concat(marketsBatch);
     skip += first;
   } while (marketsBatch.length === first);
@@ -286,7 +296,7 @@ async function fetchMarketsFromSubgraph(
 
 const fetchEvents = async (
   options: FetchOptions
-): Promise<{interests: Array<MorphoBlueAccrueInterestEvent>, liquidations: Array<MorphoBlueLiquidateEvent>}> => {
+): Promise<{ interests: Array<MorphoBlueAccrueInterestEvent>, liquidations: Array<MorphoBlueLiquidateEvent> }> => {
   let markets: Array<MorphoMarket> = []
   if (MorphoBlues[options.chain].chainId) {
     markets = await fetchMarketsFromSubgraph(
@@ -297,7 +307,7 @@ const fetchEvents = async (
     markets = await fetchMarketsFromLogs(options);
   }
 
-  const marketMap = {} as {[key: string]: MorphoMarket};
+  const marketMap = {} as { [key: string]: MorphoMarket };
   markets.forEach((item) => {
     marketMap[item.marketId.toLowerCase()] = item;
   });
@@ -311,7 +321,7 @@ const fetchEvents = async (
     })
   ).map((log: any) => {
     let interest = log.interest;
-    if(blacklistedIds.includes(log.id)) interest = 0;
+    if (blacklistedIds.includes(log.id)) interest = 0;
     return {
       token: marketMap[String(log.id).toLowerCase()] ? marketMap[String(log.id).toLowerCase()].loanAsset : null,
       interest: BigInt(interest),


### PR DESCRIPTION
- **Etherlink** — added via `CreateMarket` log discovery.
- **Tempo (4217)** and **Stable (988)** — added via the Morpho Blue API.
- Fixed Stable's old deploy block (`1504506`, not `4342501`); API-based indexing makes the block irrelevant.
- **Sei** and **TAC** — documented but still deferred.

## Results
Ran `pnpm test fees morpho`:

- **Stable** — `$47.00` daily fees on 2026-06-20. Matches raw `AccrueInterest` totals; market matching verified end-to-end.
- **Etherlink** — runs clean; 16 markets discovered.
- **Tempo** — runs clean; near-zero activity (~$1.9k borrowed).


## Deferred: Sei & TAC
- **Sei** ($29M TVL) — not indexed by the Morpho API, and `getLogs` is disabled due to RPC instability.
- **TAC** — not in the Morpho API, and `CreateMarket` log discovery times out over ~20M blocks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded support for additional Morpho Blue networks, including Etherlink, Tempo, and Stable.
  * Updated market and fee event handling for these supported markets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->