### PR TITLE
LeverUp: sync adapter with V2

### DIFF
--- a/dexs/leverup/index.ts
+++ b/dexs/leverup/index.ts
@@ -20,7 +20,9 @@ const closeTradeSuccessfulV2Abi =
   'event CloseTradeSuccessfulV2(address indexed user,bytes32 indexed tradeHash, (uint128 closePrice, int96 fundingFee, uint96 closeFee, int96 pnl, uint96 holdingFee) closeInfo, (address user, uint32 userOpenTradeIndex, uint40 holdingFeeRate, uint128 entryPrice, uint128 qty, address pairBase, address tokenPay, address lvToken, uint96 lvMargin, uint128 stopLoss, uint128 takeProfit, uint24 broker, bool isLong, uint32 timestamp, uint96 lvOpenFee, uint96 lvExecutionFee, int256 longAccFundingFeePerShare, uint256 openBlock) ot)';
 const executeCloseSuccessfulV2Abi =
   'event ExecuteCloseSuccessfulV2(address indexed user,bytes32 indexed tradeHash, uint8 executionType, (uint128 closePrice, int96 fundingFee, uint96 closeFee, int96 pnl, uint96 holdingFee) closeInfo, (address user, uint32 userOpenTradeIndex, uint40 holdingFeeRate, uint128 entryPrice, uint128 qty, address pairBase, address tokenPay, address lvToken, uint96 lvMargin, uint128 stopLoss, uint128 takeProfit, uint24 broker, bool isLong, uint32 timestamp, uint96 lvOpenFee, uint96 lvExecutionFee, int256 longAccFundingFeePerShare, uint256 openBlock) ot)';
-const interestDistributedAbi = 
+const lpRevenueAbi =
+  'event LpRevenue(address indexed user,bytes32 indexed tradeHash,address lvToken,uint256 slippageAmount,uint256 liquidationAmount)';
+const interestDistributedAbi =
   'event InterestDistributed(uint256 interest,uint256 interestFee,uint256 interestReceiverAmount)';
 const redeemFeeCollectedAbi = 
   'event RedeemFeeCollected(address indexed payer,address indexed recipient,address indexed reserveToken,uint256 grossAmount,uint256 feeAmount,bool isFastRedeem)';
@@ -35,7 +37,7 @@ const fetch = async (options: FetchOptions) => {
   const dailyProtocolRevenue = options.createBalances();
   const dailySupplySideRevenue = options.createBalances()
 
-  const [openLogs, closeLogs, executeLogs, interestLogs, redeemLogs, withdrawalLogs] = await Promise.all([
+  const [openLogs, closeLogs, executeLogs, lpRevenueLogs, interestLogs, redeemLogs, withdrawalLogs] = await Promise.all([
     options.getLogs({
       target: LEVERUP_DIAMOND,
       eventAbi: openMarketTradeAbi,
@@ -47,6 +49,10 @@ const fetch = async (options: FetchOptions) => {
     options.getLogs({
       target: LEVERUP_DIAMOND,
       eventAbi: executeCloseSuccessfulV2Abi,
+    }),
+    options.getLogs({
+      target: LEVERUP_DIAMOND,
+      eventAbi: lpRevenueAbi,
     }),
     options.getLogs({
       target: LVMON_ISSUER,
@@ -123,7 +129,16 @@ const fetch = async (options: FetchOptions) => {
   closeLogs.forEach(processCloseLog);
   executeLogs.forEach(processCloseLog);
 
-  // 3. Process LVMON ecosystem fee events from new event addresses
+  // 3. LP Revenue
+  lpRevenueLogs.forEach((log: any) => {
+    const amount = BigInt(log.slippageAmount) + BigInt(log.liquidationAmount);
+    if (amount > 0n) {
+      addFee(dailyFees, log.lvToken, amount, METRIC.LP_FEES);
+      addFee(dailyProtocolRevenue, log.lvToken, amount, METRIC.LP_FEES);
+    }
+  });
+
+  // 4. Process LVMON ecosystem fee events from new event addresses
   interestLogs.forEach((log: any) => {
     const interest = BigInt(log.interest);
     const interestFee = BigInt(log.interestFee);

--- a/dexs/leverup/index.ts
+++ b/dexs/leverup/index.ts
@@ -134,7 +134,7 @@ const fetch = async (options: FetchOptions) => {
     const amount = BigInt(log.slippageAmount) + BigInt(log.liquidationAmount);
     if (amount > 0n) {
       addFee(dailyFees, log.lvToken, amount, METRIC.LP_FEES);
-      addFee(dailyProtocolRevenue, log.lvToken, amount, METRIC.LP_FEES);
+      addFee(dailySupplySideRevenue, log.lvToken, amount, METRIC.LP_FEES);
     }
   });
 

--- a/open-interest/leverup-oi.ts
+++ b/open-interest/leverup-oi.ts
@@ -3,12 +3,32 @@ import { CHAIN } from "../helpers/chains";
 
 const LEVERUP_DIAMOND = '0xea1b8E4aB7f14F7dCA68c5B214303B13078FC5ec';
 
+// LeverUp V2 reports open interest through an on-chain view. Days before the V2 upgrade
+// fall back to the original method so existing history stays unchanged.
+const OI_VIEW_FROM_TIME = 1782291416;
+
+const oiAbi =
+  'function tradingOpenInterestUsd() view returns (uint256 totalUsd, uint256 longUsd, uint256 shortUsd)';
 const pairsV4Abi =
   'function pairsV4() view returns ((string name, address base, uint16 basePosition, uint8 pairType, uint8 status, uint256 maxLongOiUsd, uint256 maxShortOiUsd, uint256 fundingFeePerSecondP, uint256 minFundingFeeR, uint256 maxFundingFeeR, (uint256 notionalUsd, uint16 maxLeverage, uint16 initialLostP, uint16 liqLostP)[] leverageMargins, uint16 slippageConfigIndex, uint16 slippagePosition, (string name, uint256 onePercentDepthAboveUsd, uint256 onePercentDepthBelowUsd, uint16 openSlippageP, uint16 closeSlippageP, uint16 longPutSlippageP, uint16 shortPutSlippageP) slippageConfig, uint16 feeConfigIndex, uint16 feePosition, (uint16 openFeeP, uint16 closeFeeP, uint24 shareP, uint24 minCloseFeeP, uint24 lvTokenDiscountP) feeConfig, uint40 longHoldingFeeRate, uint40 shortHoldingFeeRate)[])';
 const getMarketInfosAbi =
   'function getMarketInfos(address[] pairBases) view returns ((address pairBase, uint256 longQty, uint256 shortQty, uint128 lpLongAvgPrice, uint128 lpShortAvgPrice, int256 fundingFeeRate)[])';
 
 async function fetch(options: FetchOptions) {
+  // LeverUp V2: read open interest from the on-chain view.
+  if (options.startOfDay >= OI_VIEW_FROM_TIME) {
+    const oi = await options.api.call({
+      target: LEVERUP_DIAMOND,
+      abi: oiAbi,
+    });
+    return {
+      openInterestAtEnd: Number(oi.totalUsd) / 1e18,
+      longOpenInterestAtEnd: Number(oi.longUsd) / 1e18,
+      shortOpenInterestAtEnd: Number(oi.shortUsd) / 1e18,
+    };
+  }
+
+  // Pre-V2 days: original method, so existing history is reproduced unchanged.
   const pairs = await options.api.call({
     target: LEVERUP_DIAMOND,
     abi: pairsV4Abi,

--- a/open-interest/leverup-oi.ts
+++ b/open-interest/leverup-oi.ts
@@ -3,7 +3,7 @@ import { CHAIN } from "../helpers/chains";
 
 const LEVERUP_DIAMOND = '0xea1b8E4aB7f14F7dCA68c5B214303B13078FC5ec';
 
-// LeverUp V2 reports open interest through an on-chain view. Days before the V2 upgrade
+// LeverUp V2 reports open interest through an on-chain view. Periods before the V2 upgrade
 // fall back to the original method so existing history stays unchanged.
 const OI_VIEW_FROM_TIME = 1782291416;
 
@@ -16,7 +16,7 @@ const getMarketInfosAbi =
 
 async function fetch(options: FetchOptions) {
   // LeverUp V2: read open interest from the on-chain view.
-  if (options.startOfDay >= OI_VIEW_FROM_TIME) {
+  if (options.startTimestamp >= OI_VIEW_FROM_TIME) {
     const oi = await options.api.call({
       target: LEVERUP_DIAMOND,
       abi: oiAbi,


### PR DESCRIPTION
Sync the LeverUp adapter with the V2 contract upgrade on Monad.

- Fees: picks up the new V2 trade fee event
- Open interest: reads the on-chain open interest view introduced in V2;
  days before the upgrade keep the original method, so existing history is unchanged.

Tested locally: `npm test dexs leverup` and `npm test open-interest leverup-oi`.