### PR TITLE
Update send.fun fees methodology to plain language

### DIFF
--- a/fees/send-fun-dex/index.ts
+++ b/fees/send-fun-dex/index.ts
@@ -118,35 +118,32 @@ const fetch = async (options: FetchOptions) => {
 };
 
 const methodology = {
-  Fees: "Protocol, creator, and LP fees charged on every DEX trade, plus any direct pool creation fees.",
-  Revenue:
-    "Protocol trade-fee slice plus creation fees (equals Fees minus creator and LP fees).",
-  ProtocolRevenue:
-    "Zero - send.fun keeps no treasury cut; 100% of protocol revenue is distributed to SEND stakers (see HoldersRevenue).",
-  HoldersRevenue:
-    "Protocol trade-fee slice and creation fees, routed 100% to SEND stakers.",
+  Fees: "Free on send.fun and partners, 0.05% on non-partner swaps.",
+  Revenue: "Protocol fees minus creator fees.",
+  ProtocolRevenue: "None. All of send.fun's revenue goes to SEND stakers.",
+  HoldersRevenue: "All of send.fun's revenue is paid out to people who stake SEND.",
   SupplySideRevenue:
-    "Trade fees paid to coin creators plus LP fees retained in DEX pool reserves for liquidity providers.",
+    "Creator fees paid to token creators, plus LP fees kept in the pool for liquidity providers.",
 };
 
 const breakdownMethodology = {
   Fees: {
-    [METRIC.PROTOCOL_FEES]: "Protocol slice of every DEX trade fee.",
-    [METRIC.CREATOR_FEES]: "Creator slice of every DEX trade fee.",
-    [METRIC.LP_FEES]: "DEX trade fee retained in pool reserves for liquidity providers.",
-    "Pool Creation Fee": "Pool creation fee charged on direct DEX pool creation.",
+    [METRIC.PROTOCOL_FEES]: "0.05% fee on non-partner swaps (free on send.fun and partners).",
+    [METRIC.CREATOR_FEES]: "0.1% creator fee on all swaps.",
+    [METRIC.LP_FEES]: "No LP fee on the DEX.",
+    "Pool Creation Fee": "No pool-creation fees on the DEX.",
   },
   Revenue: {
-    [METRIC.PROTOCOL_FEES]: "Protocol slice of trade fees (routed to SEND stakers).",
-    "Pool Creation Fee": "Pool creation fees (routed to SEND stakers).",
+    [METRIC.PROTOCOL_FEES]: "Protocol fees (paid to SEND stakers).",
+    "Pool Creation Fee": "Pool-creation fees (paid to SEND stakers).",
   },
   HoldersRevenue: {
-    [METRIC.PROTOCOL_FEES]: "Protocol slice of trade fees distributed to SEND stakers.",
-    "Pool Creation Fee": "Pool creation fees distributed to SEND stakers.",
+    [METRIC.PROTOCOL_FEES]: "Protocol fees paid to SEND stakers.",
+    "Pool Creation Fee": "Pool-creation fees paid to SEND stakers.",
   },
   SupplySideRevenue: {
-    [METRIC.CREATOR_FEES]: "DEX trade fees paid out to coin creators.",
-    [METRIC.LP_FEES]: "DEX trade fees retained in pool reserves for LPs.",
+    [METRIC.CREATOR_FEES]: "Creator fees paid out to token creators.",
+    [METRIC.LP_FEES]: "Swap fees kept in the pool for liquidity providers.",
   },
 };
 

--- a/fees/send-fun-launchpad/index.ts
+++ b/fees/send-fun-launchpad/index.ts
@@ -111,32 +111,29 @@ const fetch = async (options: FetchOptions) => {
 };
 
 const methodology = {
-  Fees: "Protocol and creator fees charged on every bonding-curve trade, plus token creation fees.",
-  Revenue:
-    "Protocol trade-fee slice plus token creation fees (equals Fees minus creator fees).",
-  ProtocolRevenue:
-    "Zero - send.fun keeps no treasury cut; 100% of protocol revenue is distributed to SEND stakers (see HoldersRevenue).",
-  HoldersRevenue:
-    "Protocol trade-fee slice and token creation fees, routed 100% to SEND stakers.",
-  SupplySideRevenue: "Bonding-curve trade fees paid to coin creators.",
+  Fees: "Free on send.fun and partners, 2% on non-partner swaps.",
+  Revenue: "Protocol fees minus creator fees.",
+  ProtocolRevenue: "None. All of send.fun's revenue goes to SEND stakers.",
+  HoldersRevenue: "100% of send.fun's revenue is paid out to people who stake SEND.",
+  SupplySideRevenue: "None. Zero creator fees on the bonding curve.",
 };
 
 const breakdownMethodology = {
   Fees: {
-    [METRIC.PROTOCOL_FEES]: "Protocol slice of every bonding-curve trade fee.",
-    [METRIC.CREATOR_FEES]: "Creator slice of every bonding-curve trade fee.",
-    "Token Creation Fee": "Token launch fee charged at token creation.",
+    [METRIC.PROTOCOL_FEES]: "2% fee on non-partner swaps (free on send.fun and partners).",
+    [METRIC.CREATOR_FEES]: "None. Zero creator fees on the bonding curve.",
+    "Token Creation Fee": "One-time fee to launch a token.",
   },
   Revenue: {
-    [METRIC.PROTOCOL_FEES]: "Protocol slice of trade fees (routed to SEND stakers).",
-    "Token Creation Fee": "Token creation fees (routed to SEND stakers).",
+    [METRIC.PROTOCOL_FEES]: "Protocol fees paid to SEND stakers.",
+    "Token Creation Fee": "Token-launch fees paid to SEND stakers.",
   },
   HoldersRevenue: {
-    [METRIC.PROTOCOL_FEES]: "Protocol slice of trade fees distributed to SEND stakers.",
-    "Token Creation Fee": "Token creation fees distributed to SEND stakers.",
+    [METRIC.PROTOCOL_FEES]: "Protocol fees paid to SEND stakers.",
+    "Token Creation Fee": "Token-launch fees paid to SEND stakers.",
   },
   SupplySideRevenue: {
-    [METRIC.CREATOR_FEES]: "Bonding-curve trade fees paid out to coin creators.",
+    [METRIC.CREATOR_FEES]: "None. Zero creator fees on the bonding curve.",
   },
 };
 


### PR DESCRIPTION
Follow-up to #7665 (thanks for merging that in @bheluga).

This rewrites the Fees / Revenue / Holders methodology on `send-fun-launchpad` and `send-fun-dex` so it reads in plain language and reflects how fees actually work, instead of the jargon-y first pass. send.fun is a 0%-fee launchpad/DEX on its own and partner frontends; a fee only applies to non-partner swaps:

- **Launchpad** — Fees: free on send.fun and partners, 2% on non-partner swaps. Revenue: protocol fees minus creator fees. 100% of revenue goes to SEND stakers. No creator fees on the bonding curve.
- **DEX** — Fees: free on send.fun and partners, 0.05% on non-partner swaps. Revenue: protocol fees minus creator fees. 100% of revenue goes to SEND stakers.

Only the `methodology` / `breakdownMethodology` strings change. The Dune query, fee accounting, and your metric labels (`Token Creation Fee` / `Pool Creation Fee`, `COALESCE(..., 0)`) are untouched.

---

Two small metadata fixes on the server side when you get a chance (we can't edit `defillama-server` from here):

1. **Capitalize the name** — `data6.ts` has `name: "sendfun Launchpad"`; should be `"Sendfun Launchpad"` to match `"Sendfun DEX"` and the `Sendfun` parent.
2. **Add the website** — both children still have `url: " "`. It's `https://send.fun`.

Happy to adjust any wording.