### PR TITLE
fix(catfee): correct Tron API timestamps and add API key

### DIFF
--- a/fees/catfee/index.ts
+++ b/fees/catfee/index.ts
@@ -1,6 +1,7 @@
 import { FetchOptions } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
-import fetchURL from "../../utils/fetchURL";
+import { httpGet } from "../../utils/fetchURL";
+import { getEnv } from "../../helpers/env";
 const plimit = require('p-limit');
 const limits = plimit(1);
 
@@ -33,20 +34,21 @@ async function fetchTransactionPage(params: {
         limit: CONFIG.PAGE_LIMIT.toString(),
         direction: "2",
         reverse: "false",
-        start_timestamp: params.fromTimestamp.toString(),
-        end_timestamp: params.endTimestamp.toString(),
+        // FetchOptions timestamps are in seconds; Tronscan expects milliseconds.
+        start_timestamp: (params.fromTimestamp * 1000).toString(),
+        end_timestamp: (params.endTimestamp * 1000).toString(),
     };
 
     Object.entries(queryParams).forEach(([key, value]) =>
         url.searchParams.append(key, value)
     );
 
-    try {
-        return await limits(() => fetchURL(url.toString()));
-    } catch (error) {
-        console.error(`Failed to fetch Tron transactions: ${error}`);
-        throw error;
-    }
+    // A free Tronscan API key (header TRON-PRO-API-KEY) lifts the per-IP rate limit
+    // that otherwise returns HTTP 429. Get one at https://tronscan.org/#/myaccount/apiKeys
+    const apiKey = getEnv("TRONSCAN_API_KEY");
+    if (!apiKey) throw new Error("TRONSCAN_API_KEY is not set");
+    const headers = { "TRON-PRO-API-KEY": apiKey };
+    return limits(() => httpGet(url.toString(), { headers }));
 }
 
 async function getDailyFees(fromTimestamp: number, endTimestamp: number): Promise<number> {

--- a/fees/catfee/index.ts
+++ b/fees/catfee/index.ts
@@ -43,8 +43,6 @@ async function fetchTransactionPage(params: {
         url.searchParams.append(key, value)
     );
 
-    // A free Tronscan API key (header TRON-PRO-API-KEY) lifts the per-IP rate limit
-    // that otherwise returns HTTP 429. Get one at https://tronscan.org/#/myaccount/apiKeys
     const apiKey = getEnv("TRONSCAN_API_KEY");
     if (!apiKey) throw new Error("TRONSCAN_API_KEY is not set");
     const headers = { "TRON-PRO-API-KEY": apiKey };
@@ -106,4 +104,5 @@ export default {
     fetch,
     chains: [CHAIN.TRON],
     start: CONFIG.START_TIMESTAMP,
+    pullHourly: true,
 };

--- a/helpers/env.ts
+++ b/helpers/env.ts
@@ -89,6 +89,7 @@ export const ENV_KEYS = new Set([
   'SUBSCAN_API_KEY',
   'PEARL_BLOCKBOOK_API',
   'OKLINK_API_KEY',
+  'TRONSCAN_API_KEY',
 ])
 
 // This is done to support both ZEROx_API_KEY and ZEROX_API_KEY


### PR DESCRIPTION
## Summary

### Problem
The CatFee fees adapter ([defillama.com/protocol/catfee](https://defillama.com/protocol/catfee)) was failing and reporting **no fees**. Two root causes:

1. **Wrong timestamp unit → HTTP 400.** `FetchOptions` provides `fromTimestamp` /  `endTimestamp` in **seconds**, but Tronscan's `/api/transfer/trx` endpoint expects **milliseconds**. Sending seconds is rejected with `start_timestamp must be >= 1529884800000`, so the very first page request threw and the adapter returned nothing.

2. **Rate limiting → HTTP 429.** Unauthenticated requests are throttled per IP. While paging through a day's transfers the adapter would hit `429 Too Many Requests` and fail.

### Solution
1. Send the API query timestamps in milliseconds (`* 1000`). 
2. Authenticate with a free Tronscan API key via the `TRON-PRO-API-KEY` header, which lifts the per-IP rate limit. The key is read from `TRONSCAN_API_KEY` and is required (the adapter throws if it is unset). Free key: https://tronscan.org/#/myaccount/apiKeys

### Changes
- `fees/catfee/index.ts`
  - Send `start_timestamp` / `end_timestamp` in milliseconds (`* 1000`).
  - Attach `TRON-PRO-API-KEY` header from `getEnv("TRONSCAN_API_KEY")`; throw if missing.
- `helpers/env.ts`
  - Register `TRONSCAN_API_KEY` in `ENV_KEYS`.

Fees are returned instead of failing with HTTP 400/429.

### Notes
- `TRONSCAN_API_KEY` must be set or the adapter throws.
