### PR TITLE
[fix] GnosisPay-Volume: track volume from gnosis pay new spender module

### DIFF
--- a/dexs/gnosispay.ts
+++ b/dexs/gnosispay.ts
@@ -1,9 +1,14 @@
 import { FetchOptions, SimpleAdapter } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
 
-const configs: Record<string, { spendModule: string }> = {
+const NEW_SPENDER_MODULE_DEPLOYMENT = 1780595045; // Jun-04-2026 05:44:05 PM UTC
+
+const configs: Record<string, { spendModules: string[] }> = {
   [CHAIN.XDAI]: {
-    spendModule: '0xcff260bfbc199dc82717494299b1acade25f549b',
+    spendModules: [
+      '0xcff260bfbc199dc82717494299b1acade25f549b', // old spend module
+      '0x5f07734E2B9C4dE6f9C32253d485741800da3F8a', // new spend module
+    ],
   }
 }
 
@@ -11,9 +16,13 @@ const SpendEvent = 'event Spend (address asset, address account, address receive
 
 const fetch = async (options: FetchOptions) => {
   const dailyVolume = options.createBalances();
+  const { spendModules } = configs[options.chain];
+  const spendModuleTargets = options.toTimestamp < NEW_SPENDER_MODULE_DEPLOYMENT ? [spendModules[0]]
+    : options.fromTimestamp >= NEW_SPENDER_MODULE_DEPLOYMENT ? [spendModules[1]]
+    : spendModules;
 
   const spendLogs = await options.getLogs({
-    target: configs[options.chain].spendModule,
+    targets: spendModuleTargets,
     eventAbi: SpendEvent,
   });
   for (const log of spendLogs) {


### PR DESCRIPTION
Partial Fix #7678 

## Summary
- Updates the Gnosis Pay DEX adapter to use the new spender module on Gnosis Chain after its deployment on Jun-04-2026 05:44:05 PM UTC.
- Preserves historical volume by continuing to query the old spend module before the deployment timestamp.

## Changes
- Updated `dexs/gnosispay.ts` to track both old and new spender module addresses.
- Added timestamp-based target selection so fetch windows before the deployment query the old module, windows after query the new module, and windows spanning the deployment query both.
- Switched the log query from a single `target` to `targets` for the selected spender module address list.

## Tests
- `pnpm test dexs gnosispay 2026-06-04` - passed; old-only day, XDAI daily volume `34.14`
- `pnpm test dexs gnosispay 2026-06-05` - passed; cutoff day, XDAI daily volume `64.54`
- `pnpm test dexs gnosispay 2026-06-06` - passed; new-only day, XDAI daily volume `17.37 k`