### PR TITLE
fix(garden): point bridge adapter at v2 orders API, add new chains, f…

### DIFF
--- a/bridge-aggregators/garden/index.ts
+++ b/bridge-aggregators/garden/index.ts
@@ -81,8 +81,48 @@ const chainMapper: Record<string, { name: string, start: string, primaryCGToken:
         primaryCGToken: 'monad',
         decimals: 18
     },
+    [CHAIN.BOTANIX]: {
+        name: "botanix",
+        start: "2025-06-24",
+        primaryCGToken: 'bitcoin',
+        decimals: 18
+    },
+    [CHAIN.CITREA]: {
+        name: "citrea",
+        start: "2026-01-20",
+        primaryCGToken: 'bitcoin',
+        decimals: 18
+    },
+    [CHAIN.MEGAETH]: {
+        name: "megaeth",
+        start: "2026-02-06",
+        primaryCGToken: 'ethereum',
+        decimals: 18
+    },
+    [CHAIN.TRON]: {
+        name: "tron",
+        start: "2026-01-10",
+        primaryCGToken: 'tron',
+        decimals: 6
+    },
+    [CHAIN.LITECOIN]: {
+        name: "litecoin",
+        start: "2026-01-10",
+        primaryCGToken: 'litecoin',
+        decimals: 8
+    },
+    [CHAIN.SPARK]: {
+        name: "spark",
+        start: "2026-02-26",
+        primaryCGToken: 'bitcoin',
+        decimals: 8
+    },
 };
-const baseUrl = "https://api.garden.finance/orders";
+
+// Garden emits two chain strings for HyperEVM ("hyperliquid" legacy, "hyperevm" new);
+// both map to the DefiLlama hyperliquid chain.
+const normalizeChain = (chain: string): string => (chain === "hyperevm" ? "hyperliquid" : chain);
+const baseUrl = "https://api.garden.finance/v2/orders";
 
 type SwapDetails = {
     chain: string;
@@ -146,7 +186,7 @@ async function fetchTransactionsInDateRange(startTimestamp: number, endTimestamp
 
     while (shouldContinue) {
         const response: GardenApiResponse = await fetchURL(
-            `${baseUrl}/matched?page=${currentPage}&per_page=200&status=completed`
+            `${baseUrl}?page=${currentPage}&per_page=200&status=completed`
         );
         if (response.status !== "Ok" || !response.result.data.length) {
             break;
@@ -161,9 +201,11 @@ async function fetchTransactionsInDateRange(startTimestamp: number, endTimestamp
                     insideDateRange = true;
                 }
                 const { source_swap, destination_swap } = tx;
+                const sourceChain = normalizeChain(source_swap.chain);
+                const destChain = normalizeChain(destination_swap.chain);
                 addToVolume(
-                    source_swap.chain === destination_swap.chain ? volumes.sameChain : volumes.crossChain,
-                    source_swap.chain,
+                    sourceChain === destChain ? volumes.sameChain : volumes.crossChain,
+                    sourceChain,
                     source_swap.token_address,
                     source_swap.filled_amount
                 );


### PR DESCRIPTION
## Summary

Fixes the Garden bridge-aggregator adapter, which was failing with `HTTP 404`, and expands its chain coverage.

## Changes


- **Migrate to the v2 orders API** — the old `/orders/matched` endpoint now returns `404`. Updated the base URL to `https://api.garden.finance/v2/orders` (the `/matched` path segment is gone; `status=completed`). The response shape is unchanged, so the parsing logic stays the same.

- **Add missing chains** — extended `chainMapper` with `botanix`, `citrea`, `megaeth`, `tron`, `litecoin`, and `spark`, each with its correct `name`, `start` date, `primaryCGToken`, and `decimals`.

- **Fix HyperEVM bucketing** — Garden reports HyperEVM swaps under two different chain strings (`hyperliquid` legacy + `hyperevm` new), but the adapter only reads the `hyperliquid` bucket, so `hyperevm` volume was silently dropped. Added a `normalizeChain` helper that collapses `hyperevm` → `hyperliquid` so both land in the same bucket.

## Testing

`pnpm test bridge-aggregators garden` passes, with volume reported across all mapped chains. `hyperliquid` now shows non-zero volume where it previously read `0.00`, confirming the bucketing fix.