### PR TITLE
Fix: pump-swap pools base/quote ordering

### DIFF
--- a/dexs/pump-swap/index.ts
+++ b/dexs/pump-swap/index.ts
@@ -8,6 +8,15 @@ interface IData {
   clean_volume: number;
 }
 
+const QUOTE_TOKENS = [
+  ADDRESSES.solana.SOL,
+  'mSoLzYCxHdYgdzU16g5QSh3i5K3z3KZK7ytfqcJm7So',
+  ADDRESSES.solana.USDC,
+  ADDRESSES.solana.USDT,
+  ADDRESSES.solana.PUMP,
+  'DEkqHyPN7GMRJ5cArtQFAWefqbZb33Hyf6s5iCwjEonT',
+].map((a) => `'${a}'`).join(',')
+
 const fetch = async (options: FetchOptions) => {
   const data: IData[] = await queryAllium(
     `WITH pool_filter AS (
@@ -15,13 +24,9 @@ const fetch = async (options: FetchOptions) => {
         liquidity_pool_address
       FROM solana.dex.pools
       WHERE project = 'pumpswap'
-        AND token1_address IN (
-          '${ADDRESSES.solana.SOL}',
-          'mSoLzYCxHdYgdzU16g5QSh3i5K3z3KZK7ytfqcJm7So',
-          '${ADDRESSES.solana.USDC}',
-          '${ADDRESSES.solana.USDT}',
-          '${ADDRESSES.solana.PUMP}',
-          'DEkqHyPN7GMRJ5cArtQFAWefqbZb33Hyf6s5iCwjEonT'
+        AND (
+          token0_address IN (${QUOTE_TOKENS})
+          OR token1_address IN (${QUOTE_TOKENS})
         )
     ),
     volume_data AS (


### PR DESCRIPTION
PumpSwap pools auto-migrated to the pump.fun AMM are always created with the pump token as token0 and WSOL as token1, so the old token1_address IN 
(...) filter got them right (the min Pool TVL filter still weeds out the thin ones). But manually created pools could have the quote token on either side, so any pool that had the quote token in token0 was being completely missed. The fix is that it checks token0_address and token1_address against the quote-token list. This now includes manually created pools regardless of token order.