### PR TITLE
sideshift: add deadFrom and start date

### DIFF
--- a/fees/sideshift.ts
+++ b/fees/sideshift.ts
@@ -25,9 +25,11 @@ const fetchFees = async (options: FetchOptions) => {
 const adapters: SimpleAdapter = {
   version: 2,
   pullHourly: true,
+  deadFrom: '2026-06-03',
   adapter: {
     [CHAIN.ETHEREUM]: {
       fetch: fetchFees,
+      start: '2024-06-24',
     }
   },
   methodology: {

--- a/fees/sideshift.ts
+++ b/fees/sideshift.ts
@@ -25,7 +25,7 @@ const fetchFees = async (options: FetchOptions) => {
 const adapters: SimpleAdapter = {
   version: 2,
   pullHourly: true,
-  deadFrom: '2026-06-03',
+  deadFrom: '2026-06-03', // https://sideshift.ghost.io/staking-rewards-update
   adapter: {
     [CHAIN.ETHEREUM]: {
       fetch: fetchFees,


### PR DESCRIPTION
#### Sources
- Staking termination: https://sideshift.ghost.io/staking-rewards-update/
- svXAI vault last deposit: Etherscan 0x3808708e761b988d23ae011ed0e12674fb66bd62 — no inbound XAI Transfer after Jun 2 2026