### PR TITLE
prestocks: fix silent-zero from failed getProgramAccounts

### DIFF
--- a/fees/prestocks/index.ts
+++ b/fees/prestocks/index.ts
@@ -24,6 +24,8 @@ async function getMeteoraDLMMPositions(owner: string) {
             METEORA_DLMM_PROGRAM_ID,
             {
                 encoding: "base64",
+                // slice only lbPair (offset 8, 32 bytes) — memcmp still runs on full data
+                dataSlice: { offset: 8, length: 32 },
                 filters: [
                     {
                         memcmp: {
@@ -36,8 +38,12 @@ async function getMeteoraDLMMPositions(owner: string) {
         ]
     });
 
-    const accounts = response?.result || [];
-    return accounts.map((acc: any) => extractPubkey(acc.account.data[0], 8));
+    if (!Array.isArray(response?.result)) {
+        throw new Error(`getProgramAccounts failed for ${owner}: ${JSON.stringify(response)}`);
+    }
+
+    // lbPair is at offset 0 of the sliced data
+    return response.result.map((acc: any) => extractPubkey(acc.account.data[0], 0));
 }
 
 async function fetch(options: FetchOptions) {


### PR DESCRIPTION
`getProgramAccounts` was returning the full multi-KB payload for each DLMM position account. Production RPC providers rate-limit or time out on large program scans, causing the response to come back without a `result` array.

The original implementation coerced this to an empty array via `|| []`, so the pool loop never executed and the adapter silently returned all-zero fees for over **7 days** with no error.

## Verification

| Date | Daily Fees | Revenue |
|------|-----------:|--------:|
| Jun 18 | $26.6k | $23.5k |
| Jun 19 | $13.1k | $11.6k |
| Jun 20 | $4.1k | $3.6k |
| Jun 21 | $7.3k | $6.5k |
| Jun 22 | $1.7k | $1.5k |
| Jun 23 | $5.9k | $5.3k |
| Jun 24 | $3.5k | $3.1k |
| Jun 25 | $2.96k | $2.6k |
| Jun 26 | $7.7k | $6.9k |