### PR TITLE
feat(bsquared): track chain fees and users via blockscout

### DIFF
--- a/factory/blockscout.ts
+++ b/factory/blockscout.ts
@@ -130,6 +130,7 @@ const protocolChainMap: Record<string, string> = {
   "shido": CHAIN.SHIDO,
   "b3": CHAIN.B3,
   "degen": CHAIN.DEGEN,
+  "bsquared": CHAIN.BSQUARED,
 }
 
 const deadFromMap: Record<string, string> = {

--- a/helpers/blockscoutFees.ts
+++ b/helpers/blockscoutFees.ts
@@ -79,7 +79,7 @@ export const chainConfigMap: any = {
   [CHAIN.XRPL_EVM]: { CGToken: 'ripple', explorer: 'https://explorer.xrplevm.org' },
   [CHAIN.APPCHAIN]: { CGToken: 'ethereum', explorer: "https://explorer.appchain.xyz/", start: '2024-11-08' },
   [CHAIN.CAPX]: { CGToken: 'capx-ai', explorer: "https://www.capxscan.com/" },
-  [CHAIN.BSQUARED]: { CGToken: 'bitcoin', explorer: 'https://explorer.bsquared.network/node-api/proxy', start: '2024-04-15' },
+  [CHAIN.BSQUARED]: { CGToken: 'bitcoin', explorer: 'https://explorer.bsquared.network/node-api/proxy', start: '2025-07-06' },
   [CHAIN.SANKO]: { CGToken: 'dream-machine-token', explorer: 'https://explorer.sanko.xyz/' },
   [CHAIN.ALIENX]: { CGToken: 'ethereum', explorer: 'https://explorer.alienxchain.io/api' },
   [CHAIN.ADVENTURE_LAYER]: { CGToken: 'adventure-gold', explorer: 'https://advlayer-mainnet.cloud.blockscout.com/' },

--- a/helpers/blockscoutFees.ts
+++ b/helpers/blockscoutFees.ts
@@ -79,6 +79,7 @@ export const chainConfigMap: any = {
   [CHAIN.XRPL_EVM]: { CGToken: 'ripple', explorer: 'https://explorer.xrplevm.org' },
   [CHAIN.APPCHAIN]: { CGToken: 'ethereum', explorer: "https://explorer.appchain.xyz/", start: '2024-11-08' },
   [CHAIN.CAPX]: { CGToken: 'capx-ai', explorer: "https://www.capxscan.com/" },
+  [CHAIN.BSQUARED]: { CGToken: 'bitcoin', explorer: 'https://explorer.bsquared.network/node-api/proxy', start: '2024-04-15' },
   [CHAIN.SANKO]: { CGToken: 'dream-machine-token', explorer: 'https://explorer.sanko.xyz/' },
   [CHAIN.ALIENX]: { CGToken: 'ethereum', explorer: 'https://explorer.alienxchain.io/api' },
   [CHAIN.ADVENTURE_LAYER]: { CGToken: 'adventure-gold', explorer: 'https://advlayer-mainnet.cloud.blockscout.com/' },

--- a/users/utils/blockscoutStats.ts
+++ b/users/utils/blockscoutStats.ts
@@ -16,6 +16,7 @@ const blockscoutStatsChains: Record<string, ChainConfig> = {
   aurora: { chain: CHAIN.AURORA, baseUrl: "https://aurorascan.dev", version: 2 },
   bob: { chain: CHAIN.BOB, baseUrl: "https://explorer-bob-mainnet-0.t.conduit.xyz", version: 1 },
   boba: { chain: CHAIN.BOBA, baseUrl: "https://blockscout.boba.network", version: 2 },
+  bsquared: { chain: CHAIN.BSQUARED, baseUrl: "https://explorer.bsquared.network", statsUrl: "https://12d6a1773a-stats-blockscout.bsquared.network", version: 1, start: "2024-04-15" },
   celo: { chain: CHAIN.CELO, baseUrl: "https://celo.blockscout.com", version: 2 },
   corn: { chain: CHAIN.CORN, baseUrl: "https://explorer-corn-maizenet.t.conduit.xyz", version: 1 },
   coti: { chain: CHAIN.COTI, baseUrl: "https://mainnet.cotiscan.io", version: 2 },


### PR DESCRIPTION
## Summary

- Add B² Network (bsquared) chain fees and active/new user tracking via its Blockscout explorer and stats API.
- https://defillama.com/chain/bsquared