### PR TITLE
mooniswap: fix volume to use trade amount, not pool reserve

### DIFF
--- a/dexs/mooniswap/index.ts
+++ b/dexs/mooniswap/index.ts
@@ -1,10 +1,46 @@
 import { FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 
+const FACTORY = '0x71CD6666064C3A1354a3B4dca5fA1E2D3ee7D303'
+const FEE_DENOMINATOR = 1e18
+
+const eventAbi = 'event Swapped (address indexed account, address indexed src, address indexed dst, uint256 amount, uint256 result, uint256 srcBalance, uint256 dstBalance, uint256 totalSupply, address referral)'
+
+async function fetch(options: FetchOptions) {
+  const dailyVolume = options.createBalances()
+
+  // governance-set, capped at 0.3%; read at the historical block
+  const fee = await options.api.call({ abi: 'uint256:fee', target: FACTORY })
+  const feeRatio = Number(fee) / FEE_DENOMINATOR
+
+  const pools = await options.api.call({ abi: 'address[]:getAllPools', target: FACTORY })
+  const logs = await options.getLogs({ targets: pools, eventAbi })
+
+  logs.forEach(log => dailyVolume.add(log.src, log.amount))
+
+  const dailyFees = dailyVolume.clone(feeRatio)
+
+  return {
+    dailyVolume,
+    dailyFees,
+    dailyRevenue: 0,
+    dailyProtocolRevenue: 0,
+    dailyHoldersRevenue: 0,
+    dailySupplySideRevenue: dailyFees,
+  }
+}
 
 const adapter: SimpleAdapter = {
   version: 2,
   pullHourly: true,
+  methodology: {
+    Volume: "Sum of source-token input across every Swapped event from Mooniswap pools.",
+    Fees: "Each swap charges the factory fee on the source input.",
+    Revenue: "Zero. Mooniswap V1 takes no protocol or governance cut on swaps.",
+    ProtocolRevenue: "Zero.",
+    HoldersRevenue: "Zero.",
+    SupplySideRevenue: "All swap fees accrue to liquidity providers as the pool reserves grow.",
+  },
   adapter: {
     [CHAIN.ETHEREUM]: {
       fetch,
@@ -13,12 +49,3 @@ const adapter: SimpleAdapter = {
 };
 
 export default adapter;
-
-async function fetch(options: FetchOptions) {
-  const dailyVolume = options.createBalances()
-  const eventAbi = 'event Swapped (address indexed account, address indexed src, address indexed dst, uint256 amount, uint256 result, uint256 srcBalance, uint256 dstBalance, uint256 totalSupply, address referral)'
-  const pools = await options.api.call({ abi: 'address[]:getAllPools', target: '0x71CD6666064C3A1354a3B4dca5fA1E2D3ee7D303' })
-  const logs = await options.getLogs({ targets: pools, eventAbi })
-  logs.forEach(log => dailyVolume.add(log.dst, log.dstBalance))
-  return { dailyVolume, dailyFees: dailyVolume.clone(0.003) }
-}

--- a/dexs/mooniswap/index.ts
+++ b/dexs/mooniswap/index.ts
@@ -1,5 +1,6 @@
 import { FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
+import { METRIC } from "../../helpers/metrics";
 
 const FACTORY = '0x71CD6666064C3A1354a3B4dca5fA1E2D3ee7D303'
 const FEE_DENOMINATOR = 1e18
@@ -18,34 +19,41 @@ async function fetch(options: FetchOptions) {
 
   logs.forEach(log => dailyVolume.add(log.src, log.amount))
 
-  const dailyFees = dailyVolume.clone(feeRatio)
+  const dailyFees = dailyVolume.clone(feeRatio, METRIC.SWAP_FEES)
+  const dailySupplySideRevenue = dailyVolume.clone(feeRatio, "Swap Fees to LPs")
 
   return {
     dailyVolume,
     dailyFees,
     dailyRevenue: 0,
     dailyProtocolRevenue: 0,
-    dailyHoldersRevenue: 0,
-    dailySupplySideRevenue: dailyFees,
+    dailySupplySideRevenue,
   }
+}
+
+const breakdownMethodology = {
+  Fees:{
+    [METRIC.SWAP_FEES]: "Each swap charges the factory fee (capped at 0.3%) on the source input.",
+  },
+  SupplySideRevenue: {
+    "Swap Fees to LPs": "All swap fees accrue to liquidity providers as the pool reserves grow.",
+  },
 }
 
 const adapter: SimpleAdapter = {
   version: 2,
+  fetch,
+  chains: [CHAIN.ETHEREUM],
+  start: "2020-08-10",
   pullHourly: true,
   methodology: {
     Volume: "Sum of source-token input across every Swapped event from Mooniswap pools.",
     Fees: "Each swap charges the factory fee on the source input.",
     Revenue: "Zero. Mooniswap V1 takes no protocol or governance cut on swaps.",
-    ProtocolRevenue: "Zero.",
-    HoldersRevenue: "Zero.",
+    ProtocolRevenue: "Zero. Mooniswap V1 takes no protocol or governance cut on swaps.",
     SupplySideRevenue: "All swap fees accrue to liquidity providers as the pool reserves grow.",
   },
-  adapter: {
-    [CHAIN.ETHEREUM]: {
-      fetch,
-    },
-  },
+  breakdownMethodology,
 };
 
 export default adapter;


### PR DESCRIPTION
### Fix

* Use `amount` (swap input) as volume instead of `Swapped.dstBalance`.
* Read the swap fee from the factory `fee()` and apply it to the input amount.
* Set `dailySupplySideRevenue = dailyFees` since all swap fees accrue to LPs.
* Set `dailyRevenue`, `dailyProtocolRevenue`, and `dailyHoldersRevenue` to `0`.

### Why

`Swapped.dstBalance` is the **pool reserve before the swap**, not the traded amount. Using it inflated reported volume.
