### PR TITLE
Add Satsuma DEX volume and fees on Citrea

### DIFF
--- a/dexs/satsuma/index.ts
+++ b/dexs/satsuma/index.ts
@@ -1,0 +1,40 @@
+import { SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import { getGraphDimensions2 } from "../../helpers/getUniSubgraph";
+
+const endpoints = {
+  [CHAIN.CITREA]:
+    "https://api.goldsky.com/api/public/project_cmamb6kkls0v2010932jjhxj4/subgraphs/analytics-mainnet/v1.0.3/gn",
+};
+
+const v3Graphs = getGraphDimensions2({
+  graphUrls: endpoints,
+  totalVolume: {
+    factory: "factories",
+    field: "totalVolumeUSD",
+  },
+  totalFees: {
+    factory: "factories",
+    field: "totalFeesUSD",
+  },
+});
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  adapter: {
+    [CHAIN.CITREA]: {
+      fetch: v3Graphs(CHAIN.CITREA),
+      // Analytics subgraph genesis on Citrea mainnet (first indexed day).
+      start: "2026-01-20",
+      meta: {
+        methodology: {
+          Volume:
+            "Daily volume is the delta of factories.totalVolumeUSD between day boundaries.",
+          Fees: "Daily fees are the delta of factories.totalFeesUSD between day boundaries.",
+        },
+      },
+    },
+  },
+};
+
+export default adapter;


### PR DESCRIPTION
## Summary
- Adds volume/fees adapter for Satsuma DEX on Citrea using the analytics subgraph v1.0.3
- Daily volume/fees computed as delta of cumulative `factories.totalVolumeUSD` / `totalFeesUSD` at day boundaries (standard getGraphDimensions2 pattern)
- Start date: 2026-01-20 (subgraph genesis on Citrea mainnet)

## Test plan
- [x] Subgraph fields verified: `factories { totalVolumeUSD totalFeesUSD }` with block queries
- [x] Factory totals: ~$54.2M volume, ~$31.1k fees (Jun 2026)
- [ ] `npx ts-node dexs/satsuma/index.ts` after merge

## Related
- TVL: DefiLlama/DefiLlama-Adapters#19824
- Coins: 0xsis/defillama-server#2
- Website: https://www.satsuma.exchange
- Subgraph: https://api.goldsky.com/api/public/project_cmamb6kkls0v2010932jjhxj4/subgraphs/analytics-mainnet/v1.0.3/gn