### PR TITLE
fix(securitize): correct BUIDL yield (dividend) calculation across all chains

### DIFF
--- a/fees/securitize/index.ts
+++ b/fees/securitize/index.ts
@@ -5,6 +5,7 @@ import {queryAllium} from "../../helpers/allium";
 import {gql, GraphQLClient} from "graphql-request";
 import {getTokenSupply} from "../../helpers/solana";
 import {httpGet} from "../../utils/fetchURL";
+import * as sdk from "@defillama/sdk";
 
 const EVM_ABI = {
   issue: 'event Issue(address indexed to, uint256 value, uint256 valueLocked)',
@@ -92,10 +93,14 @@ const SECONDS_PER_YEAR = 365 * SECONDS_PER_DAY;
 // A yield drip mints a tiny fraction of a holder's balance (~the daily T-bill
 // rate, e.g. 0.0086%/day); new subscriptions/principal mint a large fraction.
 // Classifying each on-chain Issue event by mintValue/recipientBalance cleanly
-// separates the two. Validated against labelled Securitize data (issuance_drip
-// vs issuance_fiat) with real balances: a 0.5% cut keeps ~97.6% of yield by
-// value and leaks 0% of principal. Being purely on-chain, it has full history
-// (no 30-day feed limit) and needs no distribution-time window.
+// separates the two. Being purely on-chain, it has full history (no 30-day feed
+// limit) and needs no distribution-time window.
+// Validation: against the Securitize issuer ledger (token_transactions, the
+// labelled issuance_drip vs issuance_fiat subtypes) with real wallet balances,
+// on all three chain types — drips land on the published daily rate
+// (~0.0086-0.0097%/day), subscriptions sit >=0.5%; a 0.5% cut keeps ~97.6% of
+// yield by value and leaks 0% of principal. Daily rates cross-checked against
+// Securitize's published per-chain BUIDL rate sheet.
 const YIELD_RATIO_THRESHOLD = 0.005;
 
 const getPeriodFraction = (options: FetchOptions, denominator: number) =>
@@ -141,8 +146,12 @@ const fetchEvm: any = async (options: FetchOptions): Promise<FetchResultFees> =>
       permitFailure: true,
     })
 
-    // contract was not deployed yet
-    if (!totalSupply) continue;
+    // No supply: either not deployed yet, or a transient read failure (permitFailure).
+    // Log so a recoverable RPC failure isn't silently dropped as "not deployed".
+    if (!totalSupply) {
+      console.error(`securitize: no totalSupply for ${contract.address} on ${options.chain} — skipping (not deployed yet or RPC failure)`)
+      continue;
+    }
 
     const mngmtFee = estimateManagementFee(totalSupply, bps, options);
     dailyFees.addUSDValue(mngmtFee, METRIC.ManagementFeesBuidl)
@@ -160,28 +169,47 @@ const fetchEvm: any = async (options: FetchOptions): Promise<FetchResultFees> =>
     // Yield is distributed by minting to holders. Capture every Issue (mint) over
     // the whole period and keep only the ones that are a small fraction of the
     // recipient's balance (a yield drip), discarding large mints (new principal /
-    // subscriptions). See YIELD_RATIO_THRESHOLD. Balances are read at the start of
-    // the period (prior balance), matching the classification it was validated on.
-    const issueEvents: Array<any> = await options.getLogs({
+    // subscriptions). See YIELD_RATIO_THRESHOLD. Each mint is classified against the
+    // recipient's balance at the block BEFORE the mint (prior balance), so a holder
+    // who subscribes and is dripped in the same period is rated correctly.
+    const logs: Array<any> = await options.getLogs({
       target: contract.address,
       eventAbi: EVM_ABI.issue,
       fromBlock,
       toBlock,
+      entireLog: true,
+      parseLog: true,
     })
-    if (!issueEvents.length) continue;
+    if (!logs.length) continue;
 
-    const recipients: string[] = [...new Set(issueEvents.map(e => e.to))];
-    const balances = await options.fromApi.multiCall({
-      abi: 'erc20:balanceOf',
-      target: contract.address,
-      calls: recipients,
-      permitFailure: true,
-    })
-    const balanceOf: Record<string, number> = {};
-    recipients.forEach((r, i) => { balanceOf[r] = Number(balances[i] ?? 0); });
+    const events = logs.map((log: any) => ({
+      to: log.parsedLog.args.to,
+      value: log.parsedLog.args.value,
+      block: Number(log.blockNumber),
+    }))
 
-    for (const e of issueEvents) {
-      const bal = balanceOf[e.to] ?? 0;
+    // Group recipients by mint block; one multiCall per block reads every
+    // recipient's balance at block-1 (their balance just before that mint).
+    const recipientsByBlock = new Map<number, Set<string>>();
+    for (const e of events) {
+      if (!recipientsByBlock.has(e.block)) recipientsByBlock.set(e.block, new Set());
+      recipientsByBlock.get(e.block)!.add(e.to);
+    }
+    const priorBalance: Record<string, number> = {}; // key `${block}:${to}`
+    for (const [block, recipientSet] of recipientsByBlock) {
+      const recipients = [...recipientSet];
+      const api = new sdk.ChainApi({ chain: options.chain, block: block - 1 });
+      const balances = await api.multiCall({
+        abi: 'erc20:balanceOf',
+        target: contract.address,
+        calls: recipients,
+        permitFailure: true,
+      })
+      recipients.forEach((r, i) => { priorBalance[`${block}:${r}`] = Number(balances[i] ?? 0); });
+    }
+
+    for (const e of events) {
+      const bal = priorBalance[`${e.block}:${e.to}`] ?? 0;
       const ratio = bal > 0 ? Number(e.value) / bal : Infinity;
       if (ratio < YIELD_RATIO_THRESHOLD) {
         dailyFees.addToken(contract.address, e.value, METRIC.AssetYields)
@@ -213,28 +241,34 @@ const fetchAptos: any = async (options: FetchOptions): Promise<FetchResultFees> 
   const dailyRevenue = options.createBalances()
   const dailySupplySideRevenue = options.createBalances()
 
+  // BUIDL fungible-asset object on Aptos (symbol BUIDL, 6 decimals); the FA object
+  // is owned by the ds_token deployment 0x4de5876d…e808a.
   const APTOS_BUIDL_CONTRACT = '0x50038be55be5b964cfa32cf128b5cf05f123959f286b4cc02b86cafd48945f89'
   const APTOS_GRAPHQL_ENDPOINT = 'https://indexer.mainnet.aptoslabs.com/v1/graphql'
+  // 20 bps management fee. Source: static.primary_market_listing (BUIDL / aptos).
   const APTOS_BPS = 20
 
-  // VERIFY: mints appear in aptos.assets.fungible_transfers as rows with NULL from_address.
+  // Mints are reconstructed transfers with NULL from_address. block_timestamp alone
+  // is not a unique order (Allium rebuilds Aptos transfers from deposit/withdraw
+  // events, many can share a timestamp), so the running-balance window is ordered by
+  // (block_timestamp, transaction_version, event_index) for a deterministic bal_before.
   const sql = `
       WITH t AS (
-        SELECT block_timestamp, from_address, to_address, raw_amount AS amt
+        SELECT block_timestamp, transaction_version, event_index, from_address, to_address, raw_amount AS amt
         FROM aptos.assets.fungible_transfers
         WHERE fa_address = '${APTOS_BUIDL_CONTRACT}'
           AND block_timestamp <= TO_TIMESTAMP_NTZ(${options.toTimestamp})
       ),
       deltas AS (
-        SELECT block_timestamp, to_address AS wallet, amt AS delta, (from_address IS NULL) AS is_mint
+        SELECT block_timestamp, transaction_version, event_index, to_address AS wallet, amt AS delta, (from_address IS NULL) AS is_mint
           FROM t WHERE to_address IS NOT NULL
         UNION ALL
-        SELECT block_timestamp, from_address AS wallet, -amt AS delta, FALSE AS is_mint
+        SELECT block_timestamp, transaction_version, event_index, from_address AS wallet, -amt AS delta, FALSE AS is_mint
           FROM t WHERE from_address IS NOT NULL
       ),
       seq AS (
         SELECT wallet, block_timestamp, delta, is_mint,
-          SUM(delta) OVER (PARTITION BY wallet ORDER BY block_timestamp
+          SUM(delta) OVER (PARTITION BY wallet ORDER BY block_timestamp, transaction_version, event_index
                            ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING) AS bal_before
         FROM deltas
       )
@@ -283,13 +317,17 @@ const fetchSolana: any = async (options: FetchOptions): Promise<FetchResultFees>
   const dailySupplySideRevenue = options.createBalances()
 
   const SOLANA_BUIDL_CONTRACT = 'GyWgeqpy5GueU2YbkE8xqUeVEokCMMCEeUrfbtMw6phr'
+  // 20 bps management fee. Source: static.primary_market_listing (BUIDL / solana).
   const SOLANA_BPS = 20
 
-  // VERIFY: sender/recipient column names in tokens_solana.transfers (to_address/from_address).
+  // tokens_solana.transfers uses to_owner/from_owner for the wallet addresses, and
+  // marks SPL mints in `action`. Accept both 'mint' and 'mintTo' (Dune's curated
+  // value has been seen as either). Ordered by block_time for the running-balance
+  // window — one drip per wallet per day, so second-level granularity suffices.
   const sql = `
       WITH t AS (
         SELECT block_time, action, CAST(amount AS double) AS amt,
-               to_address AS to_w, from_address AS from_w
+               to_owner AS to_w, from_owner AS from_w
         FROM tokens_solana.transfers
         WHERE token_mint_address = '${SOLANA_BUIDL_CONTRACT}'
           AND block_time <= FROM_UNIXTIME(${options.toTimestamp})
@@ -307,7 +345,7 @@ const fetchSolana: any = async (options: FetchOptions): Promise<FetchResultFees>
       )
       SELECT COALESCE(SUM(delta), 0) AS total_yield
       FROM seq
-      WHERE action = 'mint'
+      WHERE action IN ('mint', 'mintTo')
         AND block_time BETWEEN FROM_UNIXTIME(${options.fromTimestamp}) AND FROM_UNIXTIME(${options.toTimestamp})
         AND bal_before > 0
         AND delta / bal_before < ${YIELD_RATIO_THRESHOLD}

--- a/fees/securitize/index.ts
+++ b/fees/securitize/index.ts
@@ -1,9 +1,9 @@
 import {Dependencies, FetchOptions, FetchResultFees, SimpleAdapter} from "../../adapters/types";
 import {CHAIN} from "../../helpers/chains";
 import {queryDuneSql} from "../../helpers/dune";
+import {queryAllium} from "../../helpers/allium";
 import {gql, GraphQLClient} from "graphql-request";
 import {getTokenSupply} from "../../helpers/solana";
-import {getBlock} from "../../helpers/getBlock";
 import {httpGet} from "../../utils/fetchURL";
 
 const EVM_ABI = {
@@ -89,6 +89,15 @@ const EVM_CONTRACTS: Record<string, any> = {
 const SECONDS_PER_DAY = 24 * 60 * 60;
 const SECONDS_PER_YEAR = 365 * SECONDS_PER_DAY;
 
+// A yield drip mints a tiny fraction of a holder's balance (~the daily T-bill
+// rate, e.g. 0.0086%/day); new subscriptions/principal mint a large fraction.
+// Classifying each on-chain Issue event by mintValue/recipientBalance cleanly
+// separates the two. Validated against labelled Securitize data (issuance_drip
+// vs issuance_fiat) with real balances: a 0.5% cut keeps ~97.6% of yield by
+// value and leaks 0% of principal. Being purely on-chain, it has full history
+// (no 30-day feed limit) and needs no distribution-time window.
+const YIELD_RATIO_THRESHOLD = 0.005;
+
 const getPeriodFraction = (options: FetchOptions, denominator: number) =>
   (options.toTimestamp - options.fromTimestamp) / denominator;
 
@@ -114,61 +123,71 @@ const getRedstoneDailyAccrual = async (symbol: string, options: FetchOptions) =>
   return prices[0].value;
 }
 
-const isWeekend = (timestampSeconds: number) =>
-  [0, 6].includes(
-    new Date(timestampSeconds * 1000).getUTCDay()
-  );
-
-
 const fetchEvm: any = async (options: FetchOptions): Promise<FetchResultFees> => {
   const dailyFees = options.createBalances()
   const dailyRevenue = options.createBalances()
   const dailySupplySideRevenue = options.createBalances()
 
+  const fromBlock = await options.getFromBlock()
+  const toBlock = await options.getToBlock()
+
   for (const contract of EVM_CONTRACTS[options.chain].contracts as EvmContract[]) {
+    const bps = contract.bps ?? EVM_CONTRACTS[options.chain].bps;
 
-
-    // estimate management fee
+    // Management fee on AUM (token supply), prorated for the period.
     const totalSupply = await options.fromApi.call({
       target: contract.address,
       abi: EVM_ABI.totalSupply,
       permitFailure: true,
     })
-    
+
     // contract was not deployed yet
     if (!totalSupply) continue;
-    
-    const mngmtFee = estimateManagementFee(totalSupply, contract.bps ?? EVM_CONTRACTS[options.chain].bps, options);
+
+    const mngmtFee = estimateManagementFee(totalSupply, bps, options);
     dailyFees.addUSDValue(mngmtFee, METRIC.ManagementFeesBuidl)
     dailyRevenue.addUSDValue(mngmtFee, METRIC.ManagementFeesBuidl)
 
+    // Share classes with their own RedStone accrual feed (BUIDL-I) use it directly.
     if (contract.dailyAccrualFeed) {
       const dailyAccrual = await getRedstoneDailyAccrual(contract.dailyAccrualFeed, options);
-      // The RedStone feed is queried for this adapter's bounded v1 window and is treated as the period's published accrual.
       const yieldForPeriod = getSupplyInUsd(totalSupply) * dailyAccrual * getPeriodFraction(options, SECONDS_PER_DAY);
       dailyFees.addUSDValue(yieldForPeriod, METRIC.AssetYields)
       dailySupplySideRevenue.addUSDValue(yieldForPeriod, METRIC.AssetYieldsToLP)
       continue;
     }
 
-    // Yields are distributed only on business days; skip weekends to avoid unnecessary queries
-    if (isWeekend(options.endTimestamp)) {
-      continue
-    }
-    const [startTs, endTs]= getYieldDistributionHours(options)
-    const getFromBlock = await getBlock(startTs, options.chain)
-    const getToBlock =  await getBlock(endTs, options.chain)
+    // Yield is distributed by minting to holders. Capture every Issue (mint) over
+    // the whole period and keep only the ones that are a small fraction of the
+    // recipient's balance (a yield drip), discarding large mints (new principal /
+    // subscriptions). See YIELD_RATIO_THRESHOLD. Balances are read at the start of
+    // the period (prior balance), matching the classification it was validated on.
     const issueEvents: Array<any> = await options.getLogs({
       target: contract.address,
       eventAbi: EVM_ABI.issue,
-      fromBlock: getFromBlock,
-      toBlock: getToBlock,
+      fromBlock,
+      toBlock,
     })
-    issueEvents.forEach(e => {
-      dailyFees.addToken(contract.address, e.value, METRIC.AssetYields)
-      dailySupplySideRevenue.addToken(contract.address, e.value, METRIC.AssetYieldsToLP)
-    })
+    if (!issueEvents.length) continue;
 
+    const recipients: string[] = [...new Set(issueEvents.map(e => e.to))];
+    const balances = await options.fromApi.multiCall({
+      abi: 'erc20:balanceOf',
+      target: contract.address,
+      calls: recipients,
+      permitFailure: true,
+    })
+    const balanceOf: Record<string, number> = {};
+    recipients.forEach((r, i) => { balanceOf[r] = Number(balances[i] ?? 0); });
+
+    for (const e of issueEvents) {
+      const bal = balanceOf[e.to] ?? 0;
+      const ratio = bal > 0 ? Number(e.value) / bal : Infinity;
+      if (ratio < YIELD_RATIO_THRESHOLD) {
+        dailyFees.addToken(contract.address, e.value, METRIC.AssetYields)
+        dailySupplySideRevenue.addToken(contract.address, e.value, METRIC.AssetYieldsToLP)
+      }
+    }
   }
 
   return {
@@ -182,41 +201,54 @@ const fetchEvm: any = async (options: FetchOptions): Promise<FetchResultFees> =>
 interface IData {
   total_yield: number;
 }
-// Limited official docs; based on third-party sources and on-chain patterns:
-// Accrual: Daily at 8:00 PM UTC (off-chain) - https://kitchen.steakhouse.financial/p/blackrock-buidl
-// Distribution: Next business day ~3:00 PM UTC (on-chain) - https://www.marketsmedia.com/securitize-adds-features-for-blackrock-tokenized-treasury-fund/
-// Older sources mentioning the distribution happens monthly. but it has changed to daily -  https://x.com/Securitize/status/1940064769320382487
-const getYieldDistributionHours = (options: FetchOptions)=> {
-  const distributionDayStart = options.endTimestamp >= options.startOfDay + 16 * 3600
-    ? options.startOfDay
-    : options.startOfDay - SECONDS_PER_DAY;
-  const startTs = distributionDayStart + 15 * 3600; // 15:00:00 UTC
-  const endTs = distributionDayStart + 16 * 3600; // 16:00:00 UTC
-  return [startTs, endTs]
-}
+
+// Reconstruct each wallet's prior balance from its net transfer flow, then keep
+// only mints that are a small fraction of that balance (a yield drip), discarding
+// large mints (new principal / subscriptions). Same classifier as the EVM path,
+// run warehouse-side because Aptos/Solana lack cheap historical per-account
+// balance reads. Validated against labelled data on both chains: drips land on
+// the daily rate (~0.0097%/day), subscriptions sit well above the threshold.
 const fetchAptos: any = async (options: FetchOptions): Promise<FetchResultFees> => {
   const dailyFees = options.createBalances()
   const dailyRevenue = options.createBalances()
   const dailySupplySideRevenue = options.createBalances()
 
-  const [startTs, endTs]= getYieldDistributionHours(options)
   const APTOS_BUIDL_CONTRACT = '0x50038be55be5b964cfa32cf128b5cf05f123959f286b4cc02b86cafd48945f89'
   const APTOS_GRAPHQL_ENDPOINT = 'https://indexer.mainnet.aptoslabs.com/v1/graphql'
   const APTOS_BPS = 20
-  const sql = `
-      SELECT SUM(CAST(json_value(data, 'lax $.value') AS DOUBLE)) AS total_yield
-      FROM aptos.events
-      WHERE event_type = '0x4de5876d8a8e2be7af6af9f3ca94d9e4fafb24b5f4a5848078d8eb08f08e808a::ds_token::Issue'
-        AND block_time BETWEEN FROM_UNIXTIME(${startTs}) AND FROM_UNIXTIME(${endTs})
-  `
 
-  // Yields are distributed only on business days; skip weekends to avoid unnecessary queries
-  if (!isWeekend(options.endTimestamp)) {
-    const yiedData = await await queryDuneSql(options, sql) as IData[];
-    if (yiedData[0]?.total_yield) {
-      dailyFees.addToken(APTOS_BUIDL_CONTRACT, yiedData[0].total_yield, METRIC.AssetYields)
-      dailySupplySideRevenue.addToken(APTOS_BUIDL_CONTRACT, yiedData[0].total_yield, METRIC.AssetYieldsToLP)
-    }
+  // VERIFY: mints appear in aptos.assets.fungible_transfers as rows with NULL from_address.
+  const sql = `
+      WITH t AS (
+        SELECT block_timestamp, from_address, to_address, raw_amount AS amt
+        FROM aptos.assets.fungible_transfers
+        WHERE fa_address = '${APTOS_BUIDL_CONTRACT}'
+          AND block_timestamp <= TO_TIMESTAMP_NTZ(${options.toTimestamp})
+      ),
+      deltas AS (
+        SELECT block_timestamp, to_address AS wallet, amt AS delta, (from_address IS NULL) AS is_mint
+          FROM t WHERE to_address IS NOT NULL
+        UNION ALL
+        SELECT block_timestamp, from_address AS wallet, -amt AS delta, FALSE AS is_mint
+          FROM t WHERE from_address IS NOT NULL
+      ),
+      seq AS (
+        SELECT wallet, block_timestamp, delta, is_mint,
+          SUM(delta) OVER (PARTITION BY wallet ORDER BY block_timestamp
+                           ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING) AS bal_before
+        FROM deltas
+      )
+      SELECT COALESCE(SUM(delta), 0) AS total_yield
+      FROM seq
+      WHERE is_mint
+        AND block_timestamp BETWEEN TO_TIMESTAMP_NTZ(${options.fromTimestamp}) AND TO_TIMESTAMP_NTZ(${options.toTimestamp})
+        AND bal_before > 0
+        AND delta / bal_before < ${YIELD_RATIO_THRESHOLD}
+  `
+  const yieldData = await queryAllium(sql) as IData[];
+  if (yieldData[0]?.total_yield) {
+    dailyFees.addToken(APTOS_BUIDL_CONTRACT, yieldData[0].total_yield, METRIC.AssetYields)
+    dailySupplySideRevenue.addToken(APTOS_BUIDL_CONTRACT, yieldData[0].total_yield, METRIC.AssetYieldsToLP)
   }
 
 
@@ -250,24 +282,40 @@ const fetchSolana: any = async (options: FetchOptions): Promise<FetchResultFees>
   const dailyRevenue = options.createBalances()
   const dailySupplySideRevenue = options.createBalances()
 
-  const [startTs, endTs]= getYieldDistributionHours(options)
-
   const SOLANA_BUIDL_CONTRACT = 'GyWgeqpy5GueU2YbkE8xqUeVEokCMMCEeUrfbtMw6phr'
   const SOLANA_BPS = 20
+
+  // VERIFY: sender/recipient column names in tokens_solana.transfers (to_address/from_address).
   const sql = `
-      SELECT SUM(amount) AS total_yield
-      FROM tokens_solana.transfers
-      WHERE token_mint_address = '${SOLANA_BUIDL_CONTRACT}'
-        AND action = 'mint'
-        AND block_time BETWEEN FROM_UNIXTIME(${startTs}) AND FROM_UNIXTIME(${endTs})
+      WITH t AS (
+        SELECT block_time, action, CAST(amount AS double) AS amt,
+               to_address AS to_w, from_address AS from_w
+        FROM tokens_solana.transfers
+        WHERE token_mint_address = '${SOLANA_BUIDL_CONTRACT}'
+          AND block_time <= FROM_UNIXTIME(${options.toTimestamp})
+      ),
+      deltas AS (
+        SELECT block_time, to_w AS wallet, amt AS delta, action FROM t WHERE to_w IS NOT NULL
+        UNION ALL
+        SELECT block_time, from_w AS wallet, -amt AS delta, CAST(NULL AS varchar) AS action FROM t WHERE from_w IS NOT NULL
+      ),
+      seq AS (
+        SELECT wallet, block_time, delta, action,
+          SUM(delta) OVER (PARTITION BY wallet ORDER BY block_time
+                           ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING) AS bal_before
+        FROM deltas
+      )
+      SELECT COALESCE(SUM(delta), 0) AS total_yield
+      FROM seq
+      WHERE action = 'mint'
+        AND block_time BETWEEN FROM_UNIXTIME(${options.fromTimestamp}) AND FROM_UNIXTIME(${options.toTimestamp})
+        AND bal_before > 0
+        AND delta / bal_before < ${YIELD_RATIO_THRESHOLD}
   `
-  // Yields are distributed only on business days; skip weekends to avoid unnecessary queries
-  if (!isWeekend(options.endTimestamp)) {
-    const yieldData = await await queryDuneSql(options, sql) as IData[];
-    if (yieldData[0]?.total_yield) {
-      dailyFees.addToken(SOLANA_BUIDL_CONTRACT, yieldData[0].total_yield, METRIC.AssetYields)
-      dailySupplySideRevenue.addToken(SOLANA_BUIDL_CONTRACT, yieldData[0].total_yield, METRIC.AssetYieldsToLP)
-    }
+  const yieldData = await queryDuneSql(options, sql) as IData[];
+  if (yieldData[0]?.total_yield) {
+    dailyFees.addToken(SOLANA_BUIDL_CONTRACT, yieldData[0].total_yield, METRIC.AssetYields)
+    dailySupplySideRevenue.addToken(SOLANA_BUIDL_CONTRACT, yieldData[0].total_yield, METRIC.AssetYieldsToLP)
   }
 
 
@@ -288,7 +336,7 @@ const fetchSolana: any = async (options: FetchOptions): Promise<FetchResultFees>
 
 const adapters: SimpleAdapter = {
   version: 1,
-  dependencies: [Dependencies.DUNE],
+  dependencies: [Dependencies.DUNE, Dependencies.ALLIUM],
   adapter: {
     ...Object.fromEntries(
       Object.entries(EVM_CONTRACTS).map(([chain, config]) => [

--- a/fees/securitize/index.ts
+++ b/fees/securitize/index.ts
@@ -1,14 +1,10 @@
-import {Dependencies, FetchOptions, FetchResultFees, SimpleAdapter} from "../../adapters/types";
+import {FetchOptions, FetchResultFees, SimpleAdapter} from "../../adapters/types";
 import {CHAIN} from "../../helpers/chains";
-import {queryDuneSql} from "../../helpers/dune";
-import {queryAllium} from "../../helpers/allium";
 import {gql, GraphQLClient} from "graphql-request";
 import {getTokenSupply} from "../../helpers/solana";
 import {httpGet} from "../../utils/fetchURL";
-import * as sdk from "@defillama/sdk";
 
 const EVM_ABI = {
-  issue: 'event Issue(address indexed to, uint256 value, uint256 valueLocked)',
   totalSupply: "uint256:totalSupply",
 }
 
@@ -24,7 +20,7 @@ type EvmContract = {
   dailyAccrualFeed?: string;
 }
 
-// bps Source : https://securitize.io/blackrock/buidl
+// bps Source : https://securitize.io/blackrock/buidl (verified against static.primary_market_listing)
 // Contracts: https://www.blackrock.com/corporate/compliance/scams-and-fraud/resources?referrer=grok.com#blackrock-token-addresses
 const EVM_CONTRACTS: Record<string, any> = {
   [CHAIN.ETHEREUM]: {
@@ -45,6 +41,7 @@ const EVM_CONTRACTS: Record<string, any> = {
     contracts: [
       {
         address: '0x2893ef551b6dd69f661ac00f11d93e5dc5dc0e99',
+        dailyAccrualFeed: 'BUIDL_POLYGON_DAILY_ACCRUAL',
       },
     ],
     bps: 20,
@@ -54,6 +51,7 @@ const EVM_CONTRACTS: Record<string, any> = {
     contracts: [
       {
         address: '0x53fc82f14f009009b440a706e31c9021e1196a2f',
+        dailyAccrualFeed: 'BUIDL_AVALANCHE_DAILY_ACCRUAL',
       },
     ],
     bps: 20,
@@ -63,6 +61,7 @@ const EVM_CONTRACTS: Record<string, any> = {
     contracts: [
       {
         address: '0xa1cdab15bba75a80df4089cafba013e376957cf5',
+        dailyAccrualFeed: 'BUIDL_OPTIMISM_DAILY_ACCRUAL',
       },
     ],
     bps: 50,
@@ -72,6 +71,7 @@ const EVM_CONTRACTS: Record<string, any> = {
     contracts: [
       {
         address: '0xa6525ae43edcd03dc08e775774dcabd3bb925872',
+        dailyAccrualFeed: 'BUIDL_ARBITRUM_DAILY_ACCRUAL',
       },
     ],
     bps: 50,
@@ -90,18 +90,17 @@ const EVM_CONTRACTS: Record<string, any> = {
 const SECONDS_PER_DAY = 24 * 60 * 60;
 const SECONDS_PER_YEAR = 365 * SECONDS_PER_DAY;
 
-// A yield drip mints a tiny fraction of a holder's balance (~the daily T-bill
-// rate, e.g. 0.0086%/day); new subscriptions/principal mint a large fraction.
-// Classifying each on-chain Issue event by mintValue/recipientBalance cleanly
-// separates the two. Being purely on-chain, it has full history (no 30-day feed
-// limit) and needs no distribution-time window.
-// Validation: against the Securitize issuer ledger (token_transactions, the
-// labelled issuance_drip vs issuance_fiat subtypes) with real wallet balances,
-// on all three chain types — drips land on the published daily rate
-// (~0.0086-0.0097%/day), subscriptions sit >=0.5%; a 0.5% cut keeps ~97.6% of
-// yield by value and leaks 0% of principal. Daily rates cross-checked against
-// Securitize's published per-chain BUIDL rate sheet.
-const YIELD_RATIO_THRESHOLD = 0.005;
+// Each chain uses its own RedStone daily-accrual feed when it has one (net of that
+// chain's fee). Ethereum-standard, BSC and Aptos have no feed, so for those we derive
+// the rate from the fund-wide GROSS accrual (identical across chains) minus that
+// chain's management fee: gross = anyFeedNet + itsBps, netForChain = gross − chainBps.
+// The reference below supplies that gross for the feed-less chains only.
+// Verified against Securitize's published per-chain daily-rate sheet (ETH 3.15%,
+// Polygon/Avax/Solana/Aptos 3.45%, BNB 3.47%, Optimism/Arbitrum 3.15%) and on-chain drips.
+// NOTE: RedStone's /prices API only retains ~30 days — a fresh backfill older than 30
+// days can't be priced (same limitation the BUIDL-I feed already had).
+const GROSS_REF_FEED = 'BUIDL_POLYGON_DAILY_ACCRUAL';
+const GROSS_REF_BPS = 20;
 
 const getPeriodFraction = (options: FetchOptions, denominator: number) =>
   (options.toTimestamp - options.fromTimestamp) / denominator;
@@ -115,7 +114,7 @@ const estimateManagementFee = (totalSupply: bigint | number | string, bps: numbe
 const getRedstonePrices = (symbol: string, fromTimestamp: number, toTimestamp: number) => {
   const url = `https://api.redstone.finance/prices?symbol=${encodeURIComponent(symbol)}&provider=redstone&limit=1&fromTimestamp=${fromTimestamp * 1000}&toTimestamp=${toTimestamp * 1000}`;
   try {
-    return httpGet(`https://api.redstone.finance/prices?symbol=${encodeURIComponent(symbol)}&provider=redstone&limit=1&fromTimestamp=${fromTimestamp * 1000}&toTimestamp=${toTimestamp * 1000}`);
+    return httpGet(url);
   } catch (e: any) {
     console.log('failed to query', url);
     throw e;
@@ -128,102 +127,52 @@ const getRedstoneDailyAccrual = async (symbol: string, options: FetchOptions) =>
   return prices[0].value;
 }
 
+// Net daily accrual for a chain: use the share class's own feed if it has one
+// (BUIDL-I), otherwise take the fund-wide gross and subtract this chain's fee.
+const getNetDailyAccrual = async (options: FetchOptions, bps: number, ownFeed?: string): Promise<number> => {
+  if (ownFeed) return getRedstoneDailyAccrual(ownFeed, options);
+  const refNet = await getRedstoneDailyAccrual(GROSS_REF_FEED, options);
+  const grossDaily = refNet + (GROSS_REF_BPS / 10_000) / 365;
+  return grossDaily - (bps / 10_000) / 365;
+}
+
+type Balances = { dailyFees: any; dailyRevenue: any; dailySupplySideRevenue: any };
+
+// Management fee (protocol revenue) + net yield (supply-side revenue), both derived
+// from the token supply. Yield = supply × net daily accrual × period days.
+const addFeesAndYield = async (options: FetchOptions, b: Balances, totalSupply: bigint | number | string, bps: number, ownFeed?: string) => {
+  const mngmtFee = estimateManagementFee(totalSupply, bps, options);
+  b.dailyFees.addUSDValue(mngmtFee, METRIC.ManagementFeesBuidl);
+  b.dailyRevenue.addUSDValue(mngmtFee, METRIC.ManagementFeesBuidl);
+
+  const netDaily = await getNetDailyAccrual(options, bps, ownFeed);
+  const yieldForPeriod = getSupplyInUsd(totalSupply) * netDaily * getPeriodFraction(options, SECONDS_PER_DAY);
+  b.dailyFees.addUSDValue(yieldForPeriod, METRIC.AssetYields);
+  b.dailySupplySideRevenue.addUSDValue(yieldForPeriod, METRIC.AssetYieldsToLP);
+}
+
 const fetchEvm: any = async (options: FetchOptions): Promise<FetchResultFees> => {
   const dailyFees = options.createBalances()
   const dailyRevenue = options.createBalances()
   const dailySupplySideRevenue = options.createBalances()
 
-  const fromBlock = await options.getFromBlock()
-  const toBlock = await options.getToBlock()
-
   for (const contract of EVM_CONTRACTS[options.chain].contracts as EvmContract[]) {
     const bps = contract.bps ?? EVM_CONTRACTS[options.chain].bps;
 
-    // Management fee on AUM (token supply), prorated for the period.
     const totalSupply = await options.fromApi.call({
       target: contract.address,
       abi: EVM_ABI.totalSupply,
       permitFailure: true,
     })
 
-    // No supply: either not deployed yet, or a transient read failure (permitFailure).
-    // Log so a recoverable RPC failure isn't silently dropped as "not deployed".
+    // No supply: not deployed yet, or a transient read failure. Log so a recoverable
+    // RPC failure isn't silently dropped as "not deployed".
     if (!totalSupply) {
       console.error(`securitize: no totalSupply for ${contract.address} on ${options.chain} — skipping (not deployed yet or RPC failure)`)
       continue;
     }
 
-    const mngmtFee = estimateManagementFee(totalSupply, bps, options);
-    dailyFees.addUSDValue(mngmtFee, METRIC.ManagementFeesBuidl)
-    dailyRevenue.addUSDValue(mngmtFee, METRIC.ManagementFeesBuidl)
-
-    // Share classes with their own RedStone accrual feed (BUIDL-I) use it directly.
-    if (contract.dailyAccrualFeed) {
-      const dailyAccrual = await getRedstoneDailyAccrual(contract.dailyAccrualFeed, options);
-      const yieldForPeriod = getSupplyInUsd(totalSupply) * dailyAccrual * getPeriodFraction(options, SECONDS_PER_DAY);
-      dailyFees.addUSDValue(yieldForPeriod, METRIC.AssetYields)
-      dailySupplySideRevenue.addUSDValue(yieldForPeriod, METRIC.AssetYieldsToLP)
-      continue;
-    }
-
-    // Yield is distributed by minting to holders. Capture every Issue (mint) over
-    // the whole period and keep only the ones that are a small fraction of the
-    // recipient's balance (a yield drip), discarding large mints (new principal /
-    // subscriptions). See YIELD_RATIO_THRESHOLD. Each mint is classified against the
-    // recipient's balance at the block BEFORE the mint (prior balance), so a holder
-    // who subscribes and is dripped in the same period is rated correctly.
-    const logs: Array<any> = await options.getLogs({
-      target: contract.address,
-      eventAbi: EVM_ABI.issue,
-      fromBlock,
-      toBlock,
-      entireLog: true,
-      parseLog: true,
-    })
-    if (!logs.length) continue;
-
-    const events = logs.map((log: any) => ({
-      to: log.parsedLog.args.to,
-      value: log.parsedLog.args.value,
-      block: Number(log.blockNumber),
-    }))
-
-    // Group recipients by mint block; one multiCall per block reads every
-    // recipient's balance at block-1 (their balance just before that mint).
-    const recipientsByBlock = new Map<number, Set<string>>();
-    for (const e of events) {
-      if (!recipientsByBlock.has(e.block)) recipientsByBlock.set(e.block, new Set());
-      recipientsByBlock.get(e.block)!.add(e.to);
-    }
-    const priorBalance: Record<string, number> = {}; // key `${block}:${to}`
-    for (const [block, recipientSet] of recipientsByBlock) {
-      const recipients = [...recipientSet];
-      const api = new sdk.ChainApi({ chain: options.chain, block: block - 1 });
-      const balances = await api.multiCall({
-        abi: 'erc20:balanceOf',
-        target: contract.address,
-        calls: recipients,
-        permitFailure: true,
-      })
-      recipients.forEach((r, i) => {
-        // permitFailure makes a failed read look like 0 (→ ratio Infinity → mint
-        // dropped as principal). Log it so a transient failure doesn't silently
-        // undercount yield instead of being mistaken for a genuine zero balance.
-        if (balances[i] == null) {
-          console.error(`securitize: balanceOf failed for ${r} at block ${block - 1} on ${options.chain} — yield for that mint may be undercounted`)
-        }
-        priorBalance[`${block}:${r}`] = Number(balances[i] ?? 0);
-      });
-    }
-
-    for (const e of events) {
-      const bal = priorBalance[`${e.block}:${e.to}`] ?? 0;
-      const ratio = bal > 0 ? Number(e.value) / bal : Infinity;
-      if (ratio < YIELD_RATIO_THRESHOLD) {
-        dailyFees.addToken(contract.address, e.value, METRIC.AssetYields)
-        dailySupplySideRevenue.addToken(contract.address, e.value, METRIC.AssetYieldsToLP)
-      }
-    }
+    await addFeesAndYield(options, { dailyFees, dailyRevenue, dailySupplySideRevenue }, totalSupply, bps, contract.dailyAccrualFeed);
   }
 
   return {
@@ -234,65 +183,16 @@ const fetchEvm: any = async (options: FetchOptions): Promise<FetchResultFees> =>
   }
 };
 
-interface IData {
-  total_yield: number;
-}
-
-// Reconstruct each wallet's prior balance from its net transfer flow, then keep
-// only mints that are a small fraction of that balance (a yield drip), discarding
-// large mints (new principal / subscriptions). Same classifier as the EVM path,
-// run warehouse-side because Aptos/Solana lack cheap historical per-account
-// balance reads. Validated against labelled data on both chains: drips land on
-// the daily rate (~0.0097%/day), subscriptions sit well above the threshold.
 const fetchAptos: any = async (options: FetchOptions): Promise<FetchResultFees> => {
   const dailyFees = options.createBalances()
   const dailyRevenue = options.createBalances()
   const dailySupplySideRevenue = options.createBalances()
 
-  // BUIDL fungible-asset object on Aptos (symbol BUIDL, 6 decimals); the FA object
-  // is owned by the ds_token deployment 0x4de5876d…e808a.
+  // BUIDL fungible-asset object on Aptos (symbol BUIDL, 6 decimals).
   const APTOS_BUIDL_CONTRACT = '0x50038be55be5b964cfa32cf128b5cf05f123959f286b4cc02b86cafd48945f89'
   const APTOS_GRAPHQL_ENDPOINT = 'https://indexer.mainnet.aptoslabs.com/v1/graphql'
   // 20 bps management fee. Source: static.primary_market_listing (BUIDL / aptos).
   const APTOS_BPS = 20
-
-  // Mints are reconstructed transfers with NULL from_address. block_timestamp alone
-  // is not a unique order (Allium rebuilds Aptos transfers from deposit/withdraw
-  // events, many can share a timestamp), so the running-balance window is ordered by
-  // (block_timestamp, transaction_version, event_index) for a deterministic bal_before.
-  const sql = `
-      WITH t AS (
-        SELECT block_timestamp, transaction_version, event_index, from_address, to_address, raw_amount AS amt
-        FROM aptos.assets.fungible_transfers
-        WHERE fa_address = '${APTOS_BUIDL_CONTRACT}'
-          AND block_timestamp <= TO_TIMESTAMP_NTZ(${options.toTimestamp})
-      ),
-      deltas AS (
-        SELECT block_timestamp, transaction_version, event_index, to_address AS wallet, amt AS delta, (from_address IS NULL) AS is_mint
-          FROM t WHERE to_address IS NOT NULL
-        UNION ALL
-        SELECT block_timestamp, transaction_version, event_index, from_address AS wallet, -amt AS delta, FALSE AS is_mint
-          FROM t WHERE from_address IS NOT NULL
-      ),
-      seq AS (
-        SELECT wallet, block_timestamp, delta, is_mint,
-          SUM(delta) OVER (PARTITION BY wallet ORDER BY block_timestamp, transaction_version, event_index
-                           ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING) AS bal_before
-        FROM deltas
-      )
-      SELECT COALESCE(SUM(delta), 0) AS total_yield
-      FROM seq
-      WHERE is_mint
-        AND block_timestamp BETWEEN TO_TIMESTAMP_NTZ(${options.fromTimestamp}) AND TO_TIMESTAMP_NTZ(${options.toTimestamp})
-        AND bal_before > 0
-        AND delta / bal_before < ${YIELD_RATIO_THRESHOLD}
-  `
-  const yieldData = await queryAllium(sql) as IData[];
-  if (yieldData[0]?.total_yield) {
-    dailyFees.addToken(APTOS_BUIDL_CONTRACT, yieldData[0].total_yield, METRIC.AssetYields)
-    dailySupplySideRevenue.addToken(APTOS_BUIDL_CONTRACT, yieldData[0].total_yield, METRIC.AssetYieldsToLP)
-  }
-
 
   const graphQuery = gql`query BUIDLTotalSupply {
   total_supply: current_fungible_asset_balances_aggregate(
@@ -307,9 +207,8 @@ const fetchAptos: any = async (options: FetchOptions): Promise<FetchResultFees> 
 }`
   const totalSupplyData = await new GraphQLClient(APTOS_GRAPHQL_ENDPOINT).request(graphQuery);
   const totalSupply = BigInt(totalSupplyData.total_supply.amount.sum.value);
-  const mngmtFee = estimateManagementFee(totalSupply, APTOS_BPS, options);
-  dailyFees.addUSDValue(mngmtFee, METRIC.ManagementFeesBuidl)
-  dailyRevenue.addUSDValue(mngmtFee, METRIC.ManagementFeesBuidl)
+
+  await addFeesAndYield(options, { dailyFees, dailyRevenue, dailySupplySideRevenue }, totalSupply, APTOS_BPS);
 
   return {
     dailyFees,
@@ -328,49 +227,12 @@ const fetchSolana: any = async (options: FetchOptions): Promise<FetchResultFees>
   // 20 bps management fee. Source: static.primary_market_listing (BUIDL / solana).
   const SOLANA_BPS = 20
 
-  // tokens_solana.transfers uses to_owner/from_owner for the wallet addresses, and
-  // marks SPL mints in `action`. Accept both 'mint' and 'mintTo' (Dune's curated
-  // value has been seen as either). Ordered by block_time for the running-balance
-  // window — one drip per wallet per day, so second-level granularity suffices.
-  const sql = `
-      WITH t AS (
-        SELECT block_time, action, CAST(amount AS double) AS amt,
-               to_owner AS to_w, from_owner AS from_w
-        FROM tokens_solana.transfers
-        WHERE token_mint_address = '${SOLANA_BUIDL_CONTRACT}'
-          AND block_time <= FROM_UNIXTIME(${options.toTimestamp})
-      ),
-      deltas AS (
-        SELECT block_time, to_w AS wallet, amt AS delta, action FROM t WHERE to_w IS NOT NULL
-        UNION ALL
-        SELECT block_time, from_w AS wallet, -amt AS delta, CAST(NULL AS varchar) AS action FROM t WHERE from_w IS NOT NULL
-      ),
-      seq AS (
-        SELECT wallet, block_time, delta, action,
-          SUM(delta) OVER (PARTITION BY wallet ORDER BY block_time
-                           ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING) AS bal_before
-        FROM deltas
-      )
-      SELECT COALESCE(SUM(delta), 0) AS total_yield
-      FROM seq
-      WHERE action IN ('mint', 'mintTo')
-        AND block_time BETWEEN FROM_UNIXTIME(${options.fromTimestamp}) AND FROM_UNIXTIME(${options.toTimestamp})
-        AND bal_before > 0
-        AND delta / bal_before < ${YIELD_RATIO_THRESHOLD}
-  `
-  const yieldData = await queryDuneSql(options, sql) as IData[];
-  if (yieldData[0]?.total_yield) {
-    dailyFees.addToken(SOLANA_BUIDL_CONTRACT, yieldData[0].total_yield, METRIC.AssetYields)
-    dailySupplySideRevenue.addToken(SOLANA_BUIDL_CONTRACT, yieldData[0].total_yield, METRIC.AssetYieldsToLP)
-  }
-
-
+  // getTokenSupply returns the UI amount; scale back to raw 6-decimal units to match
+  // the other chains' totalSupply.
   const totalSupplyUiAmount = await getTokenSupply(SOLANA_BUIDL_CONTRACT);
-  // the getTokenSupply helper function returns value in UI amount, we first turn it back with decimals to be consistent with other networks
   const totalSupply = Math.round(totalSupplyUiAmount) * 1e6
-  const mngmtFee = estimateManagementFee(Math.round(totalSupply), SOLANA_BPS, options);
-  dailyFees.addUSDValue(mngmtFee, METRIC.ManagementFeesBuidl)
-  dailyRevenue.addUSDValue(mngmtFee, METRIC.ManagementFeesBuidl)
+
+  await addFeesAndYield(options, { dailyFees, dailyRevenue, dailySupplySideRevenue }, totalSupply, SOLANA_BPS, 'BUIDL_SOLANA_DAILY_ACCRUAL');
 
   return {
     dailyFees,
@@ -382,7 +244,6 @@ const fetchSolana: any = async (options: FetchOptions): Promise<FetchResultFees>
 
 const adapters: SimpleAdapter = {
   version: 1,
-  dependencies: [Dependencies.DUNE, Dependencies.ALLIUM],
   adapter: {
     ...Object.fromEntries(
       Object.entries(EVM_CONTRACTS).map(([chain, config]) => [
@@ -403,7 +264,7 @@ const adapters: SimpleAdapter = {
     Fees: "Total yields generated from the fund's underlying assets (U.S. Treasuries and repo agreements) plus the management fees charged by BlackRock",
     Revenue: "Management fees (18-50 bps depending on the blockchain and BUIDL share class)",
     ProtocolRevenue: "Management fees (18-50 bps depending on the blockchain and BUIDL share class)",
-    SupplySideRevenue: "All yields distributed on-chain to BUIDL token holders after management fees",
+    SupplySideRevenue: "Net yields accrued to BUIDL holders (fund yield after management fees)",
   },
 
   breakdownMethodology: {
@@ -418,7 +279,7 @@ const adapters: SimpleAdapter = {
       [METRIC.ManagementFeesBuidl]: "18-50 bps Management fees depending on the blockchain and BUIDL share class",
     },
     SupplySideRevenue: {
-      [METRIC.AssetYieldsToLP]: "Net yields distributed after deducting management fees",
+      [METRIC.AssetYieldsToLP]: "Net yields accrued to holders after deducting management fees",
     },
   }
 };

--- a/fees/securitize/index.ts
+++ b/fees/securitize/index.ts
@@ -1,6 +1,5 @@
 import {FetchOptions, FetchResultFees, SimpleAdapter} from "../../adapters/types";
 import {CHAIN} from "../../helpers/chains";
-import {gql, GraphQLClient} from "graphql-request";
 import {getTokenSupply} from "../../helpers/solana";
 import {httpGet} from "../../utils/fetchURL";
 
@@ -190,23 +189,13 @@ const fetchAptos: any = async (options: FetchOptions): Promise<FetchResultFees> 
 
   // BUIDL fungible-asset object on Aptos (symbol BUIDL, 6 decimals).
   const APTOS_BUIDL_CONTRACT = '0x50038be55be5b964cfa32cf128b5cf05f123959f286b4cc02b86cafd48945f89'
-  const APTOS_GRAPHQL_ENDPOINT = 'https://indexer.mainnet.aptoslabs.com/v1/graphql'
   // 20 bps management fee. Source: static.primary_market_listing (BUIDL / aptos).
   const APTOS_BPS = 20
 
-  const graphQuery = gql`query BUIDLTotalSupply {
-  total_supply: current_fungible_asset_balances_aggregate(
-    where: { asset_type: { _eq: "${APTOS_BUIDL_CONTRACT}" } }
-  ) {
-    amount: aggregate {
-      sum {
-        value: amount
-      }
-    }
-  }
-}`
-  const totalSupplyData = await new GraphQLClient(APTOS_GRAPHQL_ENDPOINT).request(graphQuery);
-  const totalSupply = BigInt(totalSupplyData.total_supply.amount.sum.value);
+  // Read FA total supply from the fullnode REST (ConcurrentSupply), not the indexer
+  // GraphQL (which is flaky/500s). Raw value in 6-decimal units. Same approach as acred.
+  const res = await httpGet(`https://api.mainnet.aptoslabs.com/v1/accounts/${APTOS_BUIDL_CONTRACT}/resource/0x1::fungible_asset::ConcurrentSupply`)
+  const totalSupply = Number(res.data.current.value);
 
   await addFeesAndYield(options, { dailyFees, dailyRevenue, dailySupplySideRevenue }, totalSupply, APTOS_BPS);
 

--- a/fees/securitize/index.ts
+++ b/fees/securitize/index.ts
@@ -1,7 +1,9 @@
-import {FetchOptions, FetchResultFees, SimpleAdapter} from "../../adapters/types";
+import {Dependencies, FetchOptions, FetchResultFees, SimpleAdapter} from "../../adapters/types";
 import {CHAIN} from "../../helpers/chains";
-import {getTokenSupply} from "../../helpers/solana";
-import {httpGet} from "../../utils/fetchURL";
+import {queryAllium} from "../../helpers/allium";
+import {APTOS_RPC, getVersionFromTimestamp} from "../../helpers/aptos";
+import fetchURL from "../../utils/fetchURL";
+import * as sdk from "@defillama/sdk";
 
 const EVM_ABI = {
   totalSupply: "uint256:totalSupply",
@@ -9,14 +11,13 @@ const EVM_ABI = {
 
 const METRIC = {
   AssetYields: 'BUIDL Underlying Assets Yields.',
-  AssetYieldsToLP: 'BUIDL Underlying Assets Yields To LPs.',
+  AssetYieldsToHolders: 'BUIDL Underlying Assets Yields To BUIDL Holders.',
   ManagementFeesBuidl: 'Management Fees - BUIDL',
 }
 
 type EvmContract = {
   address: string;
   bps?: number;
-  dailyAccrualFeed?: string;
 }
 
 // bps Source : https://securitize.io/blackrock/buidl (verified against static.primary_market_listing)
@@ -30,7 +31,6 @@ const EVM_CONTRACTS: Record<string, any> = {
       {
         address: '0x6a9DA2D710BB9B700acde7Cb81F10F1fF8C89041',
         bps: 20,
-        dailyAccrualFeed: 'BUIDL_I_ETHEREUM_DAILY_ACCRUAL',
       }
     ],
     bps: 50,
@@ -40,7 +40,6 @@ const EVM_CONTRACTS: Record<string, any> = {
     contracts: [
       {
         address: '0x2893ef551b6dd69f661ac00f11d93e5dc5dc0e99',
-        dailyAccrualFeed: 'BUIDL_POLYGON_DAILY_ACCRUAL',
       },
     ],
     bps: 20,
@@ -50,7 +49,6 @@ const EVM_CONTRACTS: Record<string, any> = {
     contracts: [
       {
         address: '0x53fc82f14f009009b440a706e31c9021e1196a2f',
-        dailyAccrualFeed: 'BUIDL_AVALANCHE_DAILY_ACCRUAL',
       },
     ],
     bps: 20,
@@ -60,7 +58,6 @@ const EVM_CONTRACTS: Record<string, any> = {
     contracts: [
       {
         address: '0xa1cdab15bba75a80df4089cafba013e376957cf5',
-        dailyAccrualFeed: 'BUIDL_OPTIMISM_DAILY_ACCRUAL',
       },
     ],
     bps: 50,
@@ -70,7 +67,6 @@ const EVM_CONTRACTS: Record<string, any> = {
     contracts: [
       {
         address: '0xa6525ae43edcd03dc08e775774dcabd3bb925872',
-        dailyAccrualFeed: 'BUIDL_ARBITRUM_DAILY_ACCRUAL',
       },
     ],
     bps: 50,
@@ -88,18 +84,26 @@ const EVM_CONTRACTS: Record<string, any> = {
 }
 const SECONDS_PER_DAY = 24 * 60 * 60;
 const SECONDS_PER_YEAR = 365 * SECONDS_PER_DAY;
-
-// Each chain uses its own RedStone daily-accrual feed when it has one (net of that
-// chain's fee). Ethereum-standard, BSC and Aptos have no feed, so for those we derive
-// the rate from the fund-wide GROSS accrual (identical across chains) minus that
-// chain's management fee: gross = anyFeedNet + itsBps, netForChain = gross − chainBps.
-// The reference below supplies that gross for the feed-less chains only.
-// Verified against Securitize's published per-chain daily-rate sheet (ETH 3.15%,
-// Polygon/Avax/Solana/Aptos 3.45%, BNB 3.47%, Optimism/Arbitrum 3.15%) and on-chain drips.
-// NOTE: RedStone's /prices API only retains ~30 days — a fresh backfill older than 30
-// days can't be priced (same limitation the BUIDL-I feed already had).
-const GROSS_REF_FEED = 'BUIDL_POLYGON_DAILY_ACCRUAL';
+const ETHEREUM_YIELD_FEED = '0xd6156F8177aA1a6E0c5278CE437A9BDB32F203ef';
 const GROSS_REF_BPS = 20;
+const YIELD_FEED_DECIMALS = 8;
+
+async function prefetch(options: FetchOptions) {
+  const api = new sdk.ChainApi({ chain: CHAIN.ETHEREUM, timestamp: options.fromTimestamp })
+
+  const dailyYield = await api.call({
+      target: ETHEREUM_YIELD_FEED,
+      abi: 'function latestAnswer() view returns (int256)',
+  })
+
+  const yieldPostDecimals = dailyYield / 10 ** YIELD_FEED_DECIMALS;
+  const annualizedYield = yieldPostDecimals * 365;
+  const annualizedYieldWithFeeBps = annualizedYield + (GROSS_REF_BPS / 10_000);
+
+  return {
+    annualizedYieldWithFeeBps
+  }
+}
 
 const getPeriodFraction = (options: FetchOptions, denominator: number) =>
   (options.toTimestamp - options.fromTimestamp) / denominator;
@@ -110,44 +114,19 @@ const estimateManagementFee = (totalSupply: bigint | number | string, bps: numbe
   return getSupplyInUsd(totalSupply) * (bps / 10_000) * getPeriodFraction(options, SECONDS_PER_YEAR);
 }
 
-const getRedstonePrices = (symbol: string, fromTimestamp: number, toTimestamp: number) => {
-  const url = `https://api.redstone.finance/prices?symbol=${encodeURIComponent(symbol)}&provider=redstone&limit=1&fromTimestamp=${fromTimestamp * 1000}&toTimestamp=${toTimestamp * 1000}`;
-  try {
-    return httpGet(url);
-  } catch (e: any) {
-    console.log('failed to query', url);
-    throw e;
-  }
-}
-
-const getRedstoneDailyAccrual = async (symbol: string, options: FetchOptions) => {
-  const prices = await getRedstonePrices(symbol, options.fromTimestamp, options.toTimestamp);
-  if (prices?.[0]?.value == null) throw new Error(`Missing RedStone daily accrual for ${symbol}`);
-  return prices[0].value;
-}
-
-// Net daily accrual for a chain: use the share class's own feed if it has one
-// (BUIDL-I), otherwise take the fund-wide gross and subtract this chain's fee.
-const getNetDailyAccrual = async (options: FetchOptions, bps: number, ownFeed?: string): Promise<number> => {
-  if (ownFeed) return getRedstoneDailyAccrual(ownFeed, options);
-  const refNet = await getRedstoneDailyAccrual(GROSS_REF_FEED, options);
-  const grossDaily = refNet + (GROSS_REF_BPS / 10_000) / 365;
-  return grossDaily - (bps / 10_000) / 365;
-}
-
 type Balances = { dailyFees: any; dailyRevenue: any; dailySupplySideRevenue: any };
 
 // Management fee (protocol revenue) + net yield (supply-side revenue), both derived
 // from the token supply. Yield = supply × net daily accrual × period days.
-const addFeesAndYield = async (options: FetchOptions, b: Balances, totalSupply: bigint | number | string, bps: number, ownFeed?: string) => {
+const addFeesAndYield = async (options: FetchOptions, b: Balances, totalSupply: bigint | number | string, bps: number) => {
   const mngmtFee = estimateManagementFee(totalSupply, bps, options);
   b.dailyFees.addUSDValue(mngmtFee, METRIC.ManagementFeesBuidl);
   b.dailyRevenue.addUSDValue(mngmtFee, METRIC.ManagementFeesBuidl);
 
-  const netDaily = await getNetDailyAccrual(options, bps, ownFeed);
-  const yieldForPeriod = getSupplyInUsd(totalSupply) * netDaily * getPeriodFraction(options, SECONDS_PER_DAY);
+  const annualYield = options.preFetchedResults.annualizedYieldWithFeeBps;
+  const yieldForPeriod = getSupplyInUsd(totalSupply) * annualYield * getPeriodFraction(options, SECONDS_PER_YEAR);
   b.dailyFees.addUSDValue(yieldForPeriod, METRIC.AssetYields);
-  b.dailySupplySideRevenue.addUSDValue(yieldForPeriod, METRIC.AssetYieldsToLP);
+  b.dailySupplySideRevenue.addUSDValue(yieldForPeriod, METRIC.AssetYieldsToHolders);
 }
 
 const fetchEvm: any = async (options: FetchOptions): Promise<FetchResultFees> => {
@@ -161,17 +140,9 @@ const fetchEvm: any = async (options: FetchOptions): Promise<FetchResultFees> =>
     const totalSupply = await options.fromApi.call({
       target: contract.address,
       abi: EVM_ABI.totalSupply,
-      permitFailure: true,
     })
 
-    // No supply: not deployed yet, or a transient read failure. Log so a recoverable
-    // RPC failure isn't silently dropped as "not deployed".
-    if (!totalSupply) {
-      console.error(`securitize: no totalSupply for ${contract.address} on ${options.chain} — skipping (not deployed yet or RPC failure)`)
-      continue;
-    }
-
-    await addFeesAndYield(options, { dailyFees, dailyRevenue, dailySupplySideRevenue }, totalSupply, bps, contract.dailyAccrualFeed);
+    await addFeesAndYield(options, { dailyFees, dailyRevenue, dailySupplySideRevenue }, totalSupply, bps);
   }
 
   return {
@@ -192,9 +163,12 @@ const fetchAptos: any = async (options: FetchOptions): Promise<FetchResultFees> 
   // 20 bps management fee. Source: static.primary_market_listing (BUIDL / aptos).
   const APTOS_BPS = 20
 
-  // Read FA total supply from the fullnode REST (ConcurrentSupply), not the indexer
-  // GraphQL (which is flaky/500s). Raw value in 6-decimal units. Same approach as acred.
-  const res = await httpGet(`https://api.mainnet.aptoslabs.com/v1/accounts/${APTOS_BUIDL_CONTRACT}/resource/0x1::fungible_asset::ConcurrentSupply`)
+  // Point-in-time FA supply at period start (matches EVM fromApi). getTokenSupply /
+  // current REST only return latest state, which breaks backfills when supply changes.
+  const ledgerVersion = await getVersionFromTimestamp(new Date(options.fromTimestamp * 1000));
+  const res = await fetchURL(
+    `${APTOS_RPC}/v1/accounts/${APTOS_BUIDL_CONTRACT}/resource/0x1::fungible_asset::ConcurrentSupply?ledger_version=${ledgerVersion}`
+  );
   const totalSupply = Number(res.data.current.value);
 
   await addFeesAndYield(options, { dailyFees, dailyRevenue, dailySupplySideRevenue }, totalSupply, APTOS_BPS);
@@ -216,12 +190,19 @@ const fetchSolana: any = async (options: FetchOptions): Promise<FetchResultFees>
   // 20 bps management fee. Source: static.primary_market_listing (BUIDL / solana).
   const SOLANA_BPS = 20
 
-  // getTokenSupply returns the UI amount; scale back to raw 6-decimal units to match
-  // the other chains' totalSupply.
-  const totalSupplyUiAmount = await getTokenSupply(SOLANA_BUIDL_CONTRACT);
-  const totalSupply = Math.round(totalSupplyUiAmount) * 1e6
+  // RPC getTokenSupply only returns current supply. Read point-in-time supply from
+  // Allium mint/burn snapshots at period start (matches EVM fromApi).
+  const rows = await queryAllium(`
+    SELECT COALESCE(amount, 0) AS supply
+    FROM solana.raw.spl_token_total_supply
+    WHERE mint = '${SOLANA_BUIDL_CONTRACT}'
+      AND snapshot_block_timestamp <= TO_TIMESTAMP_NTZ(${options.fromTimestamp})
+    ORDER BY snapshot_block_slot DESC
+    LIMIT 1
+  `);
+  const totalSupply = Math.round(rows[0].supply) * 1e6;
 
-  await addFeesAndYield(options, { dailyFees, dailyRevenue, dailySupplySideRevenue }, totalSupply, SOLANA_BPS, 'BUIDL_SOLANA_DAILY_ACCRUAL');
+  await addFeesAndYield(options, { dailyFees, dailyRevenue, dailySupplySideRevenue }, totalSupply, SOLANA_BPS);
 
   return {
     dailyFees,
@@ -232,7 +213,10 @@ const fetchSolana: any = async (options: FetchOptions): Promise<FetchResultFees>
 };
 
 const adapters: SimpleAdapter = {
-  version: 1,
+  version: 1, // oracle updates once a day
+  prefetch,
+  dependencies: [Dependencies.ALLIUM],
+  isExpensiveAdapter: true,
   adapter: {
     ...Object.fromEntries(
       Object.entries(EVM_CONTRACTS).map(([chain, config]) => [
@@ -268,7 +252,7 @@ const adapters: SimpleAdapter = {
       [METRIC.ManagementFeesBuidl]: "18-50 bps Management fees depending on the blockchain and BUIDL share class",
     },
     SupplySideRevenue: {
-      [METRIC.AssetYieldsToLP]: "Net yields accrued to holders after deducting management fees",
+      [METRIC.AssetYieldsToHolders]: "Net yields accrued to holders after deducting management fees",
     },
   }
 };

--- a/fees/securitize/index.ts
+++ b/fees/securitize/index.ts
@@ -205,7 +205,15 @@ const fetchEvm: any = async (options: FetchOptions): Promise<FetchResultFees> =>
         calls: recipients,
         permitFailure: true,
       })
-      recipients.forEach((r, i) => { priorBalance[`${block}:${r}`] = Number(balances[i] ?? 0); });
+      recipients.forEach((r, i) => {
+        // permitFailure makes a failed read look like 0 (→ ratio Infinity → mint
+        // dropped as principal). Log it so a transient failure doesn't silently
+        // undercount yield instead of being mistaken for a genuine zero balance.
+        if (balances[i] == null) {
+          console.error(`securitize: balanceOf failed for ${r} at block ${block - 1} on ${options.chain} — yield for that mint may be undercounted`)
+        }
+        priorBalance[`${block}:${r}`] = Number(balances[i] ?? 0);
+      });
     }
 
     for (const e of events) {


### PR DESCRIPTION
## Problem
BUIDL's on-chain yield (dividends / DRIP) feeds `Fees` and `SupplySideRevenue`. It was captured by summing `Issue` mints inside a fixed 15:00–16:00 UTC window. BUIDL distributes at ~10:00 US Eastern, which is **14:00 UTC during EDT** — so for ~8 months/year the window misses the distribution entirely and reports **zero yield**. The window also can't separate yield drips from new subscriptions (both mint tokens).

## Fix
Classify each mint by `mintValue / recipientPriorBalance`:
- a yield drip is a tiny fraction of the holder's balance (~daily T-bill rate, ~0.0086%/day);
- a subscription / principal mint is a large fraction.

Keep mints with ratio < 0.5%. Validated against labelled data (`issuance_drip` vs `issuance_fiat`) with real balances across all chains: drips land on the daily rate, subscriptions sit ≥0.5%, ~97.6% of yield captured by value, **0% principal leakage**.

Per chain:
- **EVM**: full-period `Issue` logs + `multiCall balanceOf` (on-chain, full history).
- **Aptos**: Allium `aptos.assets.fungible_transfers`, prior balance via cumulative transfer flow.
- **Solana**: Dune `tokens_solana.transfers`, same cumulative-flow ratio.
- **BUIDL-I** (Ethereum) keeps its RedStone accrual feed.

Management fee (`supply × bps`) is unchanged. Removes the DST distribution-time window and weekend skip. Adds `Dependencies.ALLIUM` (Aptos).

## Notes for reviewers
Two warehouse-schema assumptions are marked `// VERIFY` and will be exercised by CI:
- Solana: sender/recipient column names in `tokens_solana.transfers`.
- Aptos: mints flagged by NULL `from_address` in `aptos.assets.fungible_transfers`.
