### PR TITLE
Add celo, megaeth and tempo to uniswap v4

### DIFF
--- a/dexs/uniswap-v4.ts
+++ b/dexs/uniswap-v4.ts
@@ -173,6 +173,24 @@ const Configs: Record<string, IUniswapConfig> = {
     source: 'LOGS',
     positionManager: '0xcf1eafc6928dc385a342e7c6491d371d2871458b',
     start: '2026-01-07'
+  },
+  [CHAIN.CELO]: {
+    poolManager: '0x288dc841a52fca2707c6947b3a777c5e56cd87bc',
+    source: 'LOGS',
+    positionManager: '0xf7965f3981e4d5bc383bfbcb61501763e9068ca9',
+    start: '2025-08-22',
+  },
+  [CHAIN.MEGAETH]: {
+    poolManager: '0xacb7e78fa05d562e0a5d3089ec896d57d057d38e',
+    source: 'LOGS',
+    positionManager: '0x9ae0921e981aaa7308f176f8d4f9129b9247c89d',
+    start: '2026-01-30',
+  },
+  [CHAIN.TEMPO]: {
+    poolManager: '0x33620f62c5b9b2086dd6b62f4a297a9f30347029',
+    source: 'LOGS',
+    positionManager: '0x3fc79444f8eacc1894775493ff3fa41f1e35ce11',
+    start: '2026-02-24',
   }
 }
 
@@ -245,7 +263,7 @@ async function fetch(options: FetchOptions) {
     });
 
     if (events.length > 0) {
-      const pools: {[key: string]: IPool | null} = {}
+      const pools: { [key: string]: IPool | null } = {}
       for (const event of events) {
         if (config.blacklistPoolIds && config.blacklistPoolIds.includes(event.id.toLowerCase())) {
           // ignore blacklist pools
@@ -283,7 +301,7 @@ async function fetch(options: FetchOptions) {
           }
         }
       }
-      
+
       for (const event of events) {
         const poolId = String(event.id)
         if (pools[poolId] as IPool) {
@@ -296,7 +314,7 @@ async function fetch(options: FetchOptions) {
           dailyFees.add(token, Math.abs(Number(event.amount0)) * (Number(event.fee) / 1e6))
           dailyVolume.add(token, Math.abs(Number(event.amount0)))
         }
-      }      
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
Adds three missing mainnet deployments to the Uniswap v4 dimension adapter, bringing it to full parity with [Uniswap's official v4 deployments](https://developers.uniswap.org/contracts/v4/deployments)
### Changes
New `Configs` entries in `dexs/uniswap-v4.ts`:

| Chain | PoolManager | PositionManager | start |
|-------|-------------|----------------
| Celo | `0x288dc841a52fca2707c6947b3a777c5e56cd87bc` | `0xf7965f3981e4d5bc383bfbcb61501763e9068ca9` |
2025-08-22 |
| MegaETH | `0xacb7e78fa05d562e0a5d3089ec896d57d057d38e` | `0x9ae0921e981aaa7308f176f8d4f9129b9247c89d` |
2026-01-30 |
| Tempo | `0x33620f62c5b9b2086dd6b62f4a297a9f30347029` | `0x3fc79444f8eacc1894775493ff3fa41f1e35ce11` |
2026-02-24 |

### Test
`pnpm test dexs uniswap-v4` runs clean  fees for all three:

```
chain     | Daily volume | Daily fees
celo      | 53.06 k      | 5.69
megaeth   | 459.40       | 1.03
tempo     | 701.31       | 1.36
```