### PR TITLE
feat: add truecurrent perps volume

### DIFF
--- a/dexs/truecurrent.ts
+++ b/dexs/truecurrent.ts
@@ -11,9 +11,14 @@ const fetch = async (options: FetchOptions) => {
   return { dailyVolume: derivativeRes.total_volume_usd };
 };
 
+const methodology = {
+  Volume: "Notional volume of all trades on Truecurrent interface (built on Injective DEX)",
+}
+
 export default {
-  doublecounted: true,
+  doublecounted: true, //injective perps
   fetch,
   start: "2026-05-15",
   chains: [CHAIN.INJECTIVE],
+  methodology,
 };

--- a/dexs/truecurrent.ts
+++ b/dexs/truecurrent.ts
@@ -1,0 +1,19 @@
+import { httpGet } from "../utils/fetchURL";
+import { FetchOptions } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+
+const DERIVATIVE_URL = `https://bigquery-api-636134865280.europe-west1.run.app/truecurrent_derivative_volume`;
+
+const fetch = async (options: FetchOptions) => {
+  const derivativeRes: any = await httpGet(`${DERIVATIVE_URL}?start_date=${options.dateString}`);
+  if (derivativeRes.days.length !== 1) throw new Error("No data found for the given date: " + options.dateString);
+
+  return { dailyVolume: derivativeRes.total_volume_usd };
+};
+
+export default {
+  doublecounted: true,
+  fetch,
+  start: "2026-05-15",
+  chains: [CHAIN.INJECTIVE],
+};


### PR DESCRIPTION
### Summary
Adds a new dimension adapter tracking daily perpetuals volume for [TrueCurrent](https://tc.xyz/) ([docs](https://docs.tc.xyz/)), a zero-fee, non-custodial perpetuals exchange on Injective. TrueCurrent settles trades through Injective's native exchange module via its RFQ contract


### Changes
- New adapter: `dexs/truecurrent.ts`
- Chain: `injective`
- Source: BigQuery indexer endpoint `truecurrent_derivative_volume` 
- Type: Interface

 https://x.com/TrueCurrentX

### Test
```
pnpm test dexs truecurrent 2026-06-25

🦙 Running TRUECURRENT adapter 🦙
---------------------------------------
Start Date:     Wed, 24 Jun 2026 00:00:00 GMT
End Date:       Thu, 25 Jun 2026 00:00:00 GMT
---------------------------------------------------

INJECTIVE 👇
Backfill start time: 15/5/2026
Daily volume: 1.51 M
```