### PR TITLE
momentum: fix per-pool protocol fee share

### DIFF
--- a/dexs/momentum.ts
+++ b/dexs/momentum.ts
@@ -50,20 +50,27 @@ const fetch = async (_: any): Promise<FetchResultV2> => {
   // const beginVolume = Number(values[0].value);
   // const latestVolume = Number(values[values.length - 1].value);
   // dailyVolume = latestVolume - beginVolume;
-  
+
   let dailyVolume = 0;
   let dailyFees = 0;
+  let dailyProtocolRevenue = 0;
+  let dailySupplySideRevenue = 0;
   const response = await httpGet('https://api.mmt.finance/pools/v3');
   for (const poolData of response.data) {
+    const poolFees = Number(poolData.fees24h);
+    const protocolShare = Number(poolData.protocolFeesPercent) / 100;
     dailyVolume += Number(poolData.volume24h);
-    dailyFees += Number(poolData.fees24h);
+    dailyFees += poolFees;
+    dailyProtocolRevenue += poolFees * protocolShare;
+    dailySupplySideRevenue += poolFees * (1 - protocolShare);
   }
 
   return {
     dailyVolume,
     dailyFees,
-    dailyRevenue: dailyFees * 0.2,
-    dailyProtocolRevenue: dailyFees * 0.2,
+    dailyRevenue: dailyProtocolRevenue,
+    dailyProtocolRevenue,
+    dailySupplySideRevenue,
   };
 }
 
@@ -74,9 +81,10 @@ const adapter: SimpleAdapter = {
   // start: '2025-03-08',
   runAtCurrTime: true,
   methodology: {
-    Fees: 'All swap fees paid by users from 6 fee tiers pools.',
-    Revenue: 'Amount of 20% swap fees is redirected to the Momentum treasury.',
-    ProtocolRevenue: 'Amount of 20% swap fees is redirected to the Momentum treasury.',
+    Fees: 'Gross swap fees paid by users across all CLMM pools.',
+    Revenue: "Each pool's protocolFeesPercent of swap fees redirected to the Momentum treasury.",
+    ProtocolRevenue: "Each pool's protocolFeesPercent of swap fees redirected to the Momentum treasury.",
+    SupplySideRevenue: "Remaining share of swap fees distributed to liquidity providers.",
   }
 };
 


### PR DESCRIPTION
This fixes fee and revenue accounting in the Momentum (Sui CLMM) adapter.

* Read each pool's `protocolFeesPercent` from the API instead of assuming a fixed 20% protocol fee.
* Add the LP share to `dailySupplySideRevenue`, which was previously not reported.

### Why

`fees24h` represents the **gross** swap fees, while `protocolFeesPercent` defines how those fees are split between the protocol and LPs. The adapter was hardcoding the protocol share and ignoring the LP portion, resulting in incomplete revenue attribution.

```
dailyFees              = Σ fees24h
dailyProtocolRevenue   = Σ fees24h × protocolFeesPercent / 100
dailyRevenue           = dailyProtocolRevenue
dailySupplySideRevenue = Σ fees24h × (1 - protocolFeesPercent / 100)
```

### Verification

Verified against the deployed Sui `pool::Pool` contract and the live API:

* `fees24h` matches gross swap fees (`swap_fee_rate` ↔ `lpFeesPercent`).
* `protocolFeesPercent` matches the on-chain `protocol_fee_share` for all 89 pools (currently 20%, but now read per pool).
* Revenue split aligns with the documented 20% protocol / 80% LP distribution.