### PR TITLE
hyperion: fix methodology and add supply-side revenue

### DIFF
--- a/dexs/hyperion/index.ts
+++ b/dexs/hyperion/index.ts
@@ -5,16 +5,22 @@ import fetchURL from "../../utils/fetchURL";
 const BASE_URL =
   "https://api.hyperion.xyz/base/data/public/defillama/volume-fee-stat";
 
+// Hyperion takes a 20% protocol fee from swap fees and the remaining 80% is paid to LPs.
+const PROTOCOL_FEE_SHARE = 0.2;
+
 const fetch = async (options: FetchOptions) => {
   const { dailyVolume, dailyFees } = await fetchURL(
     `${BASE_URL}?timestamp=${options.startOfDay}`,
   );
-  const dailyRevenue = Number(dailyFees) * 0.2;
+  const fees = Number(dailyFees);
+  const dailyProtocolRevenue = fees * PROTOCOL_FEE_SHARE;
 
   return {
-    dailyFees,
-    dailyRevenue,
     dailyVolume,
+    dailyFees: fees,
+    dailySupplySideRevenue: fees * (1 - PROTOCOL_FEE_SHARE),
+    dailyRevenue: dailyProtocolRevenue,
+    dailyProtocolRevenue,
   };
 };
 
@@ -23,8 +29,11 @@ const adapter: SimpleAdapter = {
   chains: [CHAIN.APTOS],
   start: "2025-02-04",
   methodology: {
-    Fees: "Total Fee user pays for the trades",
-    Revenue: "Revenue is calculated as 0.2% of the daily fees",
+    Volume: "Sum of swap volume across all Hyperion concentrated-liquidity pools.",
+    Fees: "Swap fees paid by traders across all pool fee tiers.",
+    SupplySideRevenue: "80% of swap fees distributed to in-range liquidity providers.",
+    Revenue: "20% protocol fee taken from swap fees.",
+    ProtocolRevenue: "20% protocol fee taken from swap fees and sent to the Hyperion treasury.",
   },
 };
 


### PR DESCRIPTION
Fixes the Hyperion revenue methodology and completes fee reporting.

* Correct the methodology text from **0.2%** to **20%** protocol fees.
* Add the missing 80% LP share as `dailySupplySideRevenue`.
* Keep protocol revenue at 20%, with the fee split now fully accounted for.

### Why

The 20% protocol fee is verified directly on-chain.

* Queried all **329 pools** in the Aptos `pool_v3` module via `get_protocol_fee_rate`; every pool returns `200000` (20% using the same 1e6 denominator as `fee_rate`).
* All protocol fees are sent to the same treasury (`protocol_fee_receiver`).

### Changes

* Fix methodology wording (**20%**, not **0.2%**).
* Add `dailySupplySideRevenue` (80% to LPs).
* Report `dailyProtocolRevenue` (20% to treasury).
* Fee accounting now reconciles:

  ```
  dailyFees = dailySupplySideRevenue + dailyRevenue
  ```