### PR TITLE
Add hyperliquid to toros volume adapter

### DIFF
--- a/dexs/toros/index.ts
+++ b/dexs/toros/index.ts
@@ -40,6 +40,10 @@ const CONFIG = {
     endpoint: sdk.graph.modifyEndpoint("HSPZATdnDvYRNPBJm7eSrzkTeRZqhqYvy7c3Ngm9GCTL"),
     torosManagerAddress: "0xfbd2b4216f422dc1eee1cff4fb64b726f099def5",
   },
+  [CHAIN.HYPERLIQUID]: {
+    endpoint: 'https://api.subgraph.ormilabs.com/api/public/a5914000-d7d2-47be-b0cb-6719f6678ff0/subgraphs/dhedge/v0.0.3/gn',
+    torosManagerAddress: "0xfbd2b4216f422dc1eee1cff4fb64b726f099def5",
+  },
 };
 
 const fetchSubgraphData = async (chainId: CHAIN, query: string, dataField: string, startTimestamp: number, endTimestamp: number) => {
@@ -111,6 +115,7 @@ const adapter: SimpleAdapter = {
     [CHAIN.ARBITRUM]: { start: '2023-03-27', },
     [CHAIN.BASE]: { start: '2023-12-20', },
     [CHAIN.ETHEREUM]: { start: '2025-08-10', },
+    [CHAIN.HYPERLIQUID]: { start: '2026-04-20', },
   },
   version: 2
 }


### PR DESCRIPTION
## Summary
Adds Hyperliquid support to the Toros DEX volume adapter (`dexs/toros/index.ts`)

### Changes
- New `[CHAIN.HYPERLIQUID]` entry in `CONFIG` (subgraph endpoint + Toros manager address)
- New `[CHAIN.HYPERLIQUID]: { start: '2026-04-20' }` entry in `adapter.adapter`

### Test
```
pnpm test dexs toros 2026-05-20

chain       | Daily volume | Start Time
---         | ---          | ---
optimism    | 0.00         | 2/12/2021
polygon     | 4.38         | 29/7/2021
arbitrum    | 391.27 k     | 27/3/2023
base        | 12.00        | 20/12/2023
ethereum    | 0.00         | 10/8/2025
hyperliquid | 13.01 k      | 20/4/2026
Aggregate   | 404.30 k     |
```

```
pnpm test dexs toros 2026-05-30

chain       | Daily volume | Start Time
---         | ---          | ---
optimism    | 0.00         | 2/12/2021
polygon     | 0.00         | 29/7/2021
arbitrum    | 96.88 k      | 27/3/2023
base        | 39.00        | 20/12/2023
ethereum    | 2.31 k       | 10/8/2025
hyperliquid | 2.64 k       | 20/4/2026
Aggregate   | 101.86 k     |
```