### PR TITLE
fix(shuriken): track new Solana fee collection address

### DIFF
--- a/fees/shuriken.ts
+++ b/fees/shuriken.ts
@@ -52,7 +52,8 @@ const fetchSolana = async (options: FetchOptions) => {
         TIME_RANGE
         AND address IN (
           '9cSuF94JWPb1HQzWMcifJzkoggwAtfjsojcUqny5XuJy',
-          'shuvodtwMMFFB6KmqCDYaiAe1hRokCVwr4LkT1pLAL5'
+          'shuvodtwMMFFB6KmqCDYaiAe1hRokCVwr4LkT1pLAL5',
+          'shrknHaCuVXmahvxLER4Qm9vooBzhbYsMP7HnAAS9Hn'
         )
         AND tx_success
         AND balance_change > 0 
@@ -68,7 +69,8 @@ const fetchSolana = async (options: FetchOptions) => {
         TIME_RANGE
         AND trades.trader_id not IN (
           '9cSuF94JWPb1HQzWMcifJzkoggwAtfjsojcUqny5XuJy',
-          'shuvodtwMMFFB6KmqCDYaiAe1hRokCVwr4LkT1pLAL5'
+          'shuvodtwMMFFB6KmqCDYaiAe1hRokCVwr4LkT1pLAL5',
+          'shrknHaCuVXmahvxLER4Qm9vooBzhbYsMP7HnAAS9Hn'
         )
       GROUP BY trades.tx_id
     )


### PR DESCRIPTION
This PR whitelists Shuriken's upgraded Solana fee collection address, recovering currently uncaptured trading fees.

### Background & On-Chain Proof
Shuriken's public fee series has flatlined at $0 because the existing adapter only tracked native SOL balance changes on two obsolete fee wallets:
- `9cSuF94JWPb1HQzWMcifJzkoggwAtfjsojcUqny5XuJy`
- `shuvodtwMMFFB6KmqCDYaiAe1hRokCVwr4LkT1pLAL5`

Dune queries on these old wallets over the last 7 days show exactly `null` SOL collected.

However, Shuriken has upgraded its contract routing and migrated its fee collection. Its new active fee receiver address is:
- `shrknHaCuVXmahvxLER4Qm9vooBzhbYsMP7HnAAS9Hn`

Executing custom queries on Dune Analytics for this active address confirms it collected **4.621 SOL** across **513 distinct trade transactions** over the last 7 days:
- `2026-06-30`: 0.359 SOL (45 txs)
- `2026-06-29`: 1.135 SOL (136 txs)
- `2026-06-28`: 1.347 SOL (132 txs)
- `2026-06-27`: 0.605 SOL (53 txs)
- `2026-06-26`: 0.195 SOL (47 txs)
- `2026-06-25`: 0.458 SOL (51 txs)
- `2026-06-24`: 0.469 SOL (45 txs)
- `2026-06-23`: 0.053 SOL (4 txs)

These fees are completely uncaptured in the current adapter.

### Fix
This PR adds `shrknHaCuVXmahvxLER4Qm9vooBzhbYsMP7HnAAS9Hn` to the whitelisted wallets and excluding list on Solana. The fix is fully backwards-compatible (preserving the historical tracking of the obsolete addresses).

Closes #7844.
