### PR TITLE
fix(tristero): drop unused cacheKey param from getV3CloseSettlements

### DIFF
--- a/fees/tristero-margin.ts
+++ b/fees/tristero-margin.ts
@@ -555,7 +555,7 @@ const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
         const [startLoanValues, endLoanValues, closeRepayments, reductions] = await Promise.all([
             readV3LoanValuesByPositionBlock(options, startPositionBlocks),
             readV3LoanValuesAtBlock(options, openV3Positions, toBlock),
-            getV3CloseSettlements(options, closedV3Positions, "tristero-v3-margin-close-fees"),
+            getV3CloseSettlements(options, closedV3Positions),
             getTristeroV3MarginReductions(options, v3Escrows, fromBlock, toBlock),
         ]);
         const reductionRepayments = getV3ReductionRepayments(reductions, startBlockByPosition, toBlock);

--- a/helpers/tristero.ts
+++ b/helpers/tristero.ts
@@ -1002,7 +1002,6 @@ async function getV3CloseReceipt(chain: string, txHash: string): Promise<any | n
 export async function getV3CloseSettlements(
   options: FetchOptions,
   closedPositions: TristeroV3MarginPosition[],
-  cacheKey: string,
 ): Promise<Map<string, bigint>> {
   const settlementByPosition = new Map<string, bigint>();
   const txHashes = [...new Set(closedPositions.map((position) => position.closeTxHash).filter((txHash): txHash is string => !!txHash))];


### PR DESCRIPTION
`getV3CloseSettlements` in `helpers/tristero.ts` declares a `cacheKey` parameter
(added in the v3 rollover #7712) that's never used, so `tsc --project tsconfig.json`
fails the whole repo:

helpers/tristero.ts(1005,3): error TS6133: 'cacheKey' is declared but its value is never read.

With strict `noUnusedParameters` this fails `ts-check` on every open PR. This removes
the unused param and its single call-site arg in `fees/tristero-margin.ts`. No behavior change.