### PR TITLE
fix(hypurrquant): describe as self-custodial crypto wealth management

### DIFF
--- a/aggregators/hypurrquant/index.ts
+++ b/aggregators/hypurrquant/index.ts
@@ -2,11 +2,14 @@ import { FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 import { addTokensReceived } from "../../helpers/token";
 
-// HypurrQuant — non-custodial DeFi terminal / swap & LP aggregator on HyperEVM.
-// It routes user swaps through underlying aggregators (LiquidSwap, HyperBloom,
-// Relay, deBridge), passing its own fee recipient + fee bps so those routers pay
-// HypurrQuant a 0.05% integrator fee. We derive HypurrQuant's routed volume from
-// that integrator fee, so the underlying DEX volume is NOT double-counted.
+// HypurrQuant is a self-custodial crypto wealth management app on HyperEVM (the
+// Hyperliquid ecosystem): users grow and manage an on-chain portfolio across
+// liquidity provision, swaps, perps and yield, while keeping custody of their
+// assets via account abstraction. This adapter tracks the swap-routing feature:
+// HypurrQuant routes user swaps through underlying aggregators (LiquidSwap,
+// HyperBloom, Relay, deBridge), passing its own fee recipient + fee bps so those
+// routers pay HypurrQuant a 0.05% integrator fee. We derive HypurrQuant's routed
+// volume from that integrator fee, so the underlying DEX volume is NOT double-counted.
 //
 // Source — public app config, exposed in the client bundle (not a secret):
 //   FEE_RECIPIENT  = NEXT_PUBLIC_ROUTING_FEE_RECIPIENT


### PR DESCRIPTION
Small accuracy fix to the adapter's descriptive comment.

HypurrQuant is a self-custodial crypto wealth management app on HyperEVM (the Hyperliquid ecosystem). Swap routing (which this adapter tracks) is one feature within a broader on-chain portfolio-management product spanning liquidity provision, swaps, perps and yield, so the leading comment now reflects the full product.

- No logic change: fee recipient, fee sources, volume/fees/revenue computation, chains, and methodology fields are all untouched.
- Only the top descriptive comment is reworded.

Ref: https://hypurrquant.com

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded the adapter description with clearer details about swap-routing behavior and routed volume calculation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->