### PR TITLE
thalaswap: add missing dailySupplySideRevenue

### DIFF
--- a/dexs/thalaswap-v3.ts
+++ b/dexs/thalaswap-v3.ts
@@ -43,13 +43,22 @@ const fetch = async (options: FetchOptions) => {
     dailyVolume: dailyVolume,
     dailyFees,
     dailyRevenue,
+    dailySupplySideRevenue: dailyFees - dailyRevenue,
   };
+};
+
+const methodology = {
+  Volume: "Trading volume across all ThalaSwap v3 pools, summed from the protocol's trading-volume API.",
+  Fees: "Total swap fees paid by traders, summed from the protocol's trading-fee API.",
+  Revenue: "The protocol's cut of swap fees that accrues to the treasury, from the protocol's protocol-revenue API.",
+  SupplySideRevenue: "The portion of swap fees that accrues to liquidity providers, computed as total fees minus protocol revenue.",
 };
 
 const adapter: SimpleAdapter = {
   fetch,
   chains: [CHAIN.APTOS],
   start: '2025-09-04',
+  methodology,
 };
 
 export default adapter;

--- a/dexs/thalaswap/index.ts
+++ b/dexs/thalaswap/index.ts
@@ -44,13 +44,22 @@ const fetch = async (options: FetchOptions) => {
     dailyVolume: dailyVolume,
     dailyFees,
     dailyRevenue,
+    dailySupplySideRevenue: dailyFees - dailyRevenue,
   };
+};
+
+const methodology = {
+  Volume: "Trading volume across all ThalaSwap pools, summed from the protocol's trading-volume API.",
+  Fees: "Total swap fees paid by traders (0.05% on stable pools, 0.15% on weighted pools, up to 1% on LBPs), summed from the protocol's trading-fee API.",
+  Revenue: "The protocol's cut of swap fees that accrues to the treasury, from the protocol's protocol-revenue API.",
+  SupplySideRevenue: "The portion of swap fees that accrues to liquidity providers, computed as total fees minus protocol revenue.",
 };
 
 const adapter: SimpleAdapter = {
   fetch,
   chains: [CHAIN.APTOS],
   start: "2023-04-05",
+  methodology,
 };
 
 export default adapter;


### PR DESCRIPTION
### Verification

`revenue + supplySide = fees` reconciles for all three:

| adapter | fees | revenue | supply-side |
|---|---|---|---|
| thalaswap-v3 | 2.75k | 824 (~30%) | 1.93k (~70%) |
| thalaswap | 44 | 8.79 (~20%) | 35 (~80%) |

Confirmed  against [docs](https://docs.thala.fi/overview/amm/swap-fees)