### PR TITLE
Add 0G DEX volume adapters (TradeGPT, Bond, JAINE)

### DIFF
--- a/dexs/bond.ts
+++ b/dexs/bond.ts
@@ -1,0 +1,14 @@
+import { CHAIN } from "../helpers/chains";
+import { uniV3Exports } from "../helpers/uniswap";
+
+// Bond — Uniswap V3 fork on 0G
+export default uniV3Exports({
+  [CHAIN.OG]: {
+    factory: "0xBDDB3aCF0A90029a1e7ebC3F82C7D9391C429A75",
+    start: "2026-05-09",
+    userFeesRatio: 1,
+    revenueRatio: 0,
+    protocolRevenueRatio: 0,
+    holdersRevenueRatio: 0,
+  },
+});

--- a/dexs/bond.ts
+++ b/dexs/bond.ts
@@ -2,6 +2,8 @@ import { CHAIN } from "../helpers/chains";
 import { uniV3Exports } from "../helpers/uniswap";
 
 // Bond — Uniswap V3 fork on 0G
+// Factory (same address used by the Bond TVL adapter in DefiLlama-Adapters,
+// registries/uniswapV3.js): https://chainscan.0g.ai/address/0xBDDB3aCF0A90029a1e7ebC3F82C7D9391C429A75
 export default uniV3Exports({
   [CHAIN.OG]: {
     factory: "0xBDDB3aCF0A90029a1e7ebC3F82C7D9391C429A75",

--- a/dexs/jaine.ts
+++ b/dexs/jaine.ts
@@ -1,0 +1,14 @@
+import { CHAIN } from "../helpers/chains";
+import { uniV3Exports } from "../helpers/uniswap";
+
+// JAINE — Uniswap V3 fork on 0G
+export default uniV3Exports({
+  [CHAIN.OG]: {
+    factory: "0x9bdcA5798E52e592A08e3b34d3F18EeF76Af7ef4",
+    start: "2025-09-20",
+    userFeesRatio: 1,
+    revenueRatio: 0,
+    protocolRevenueRatio: 0,
+    holdersRevenueRatio: 0,
+  },
+});

--- a/dexs/jaine.ts
+++ b/dexs/jaine.ts
@@ -2,6 +2,8 @@ import { CHAIN } from "../helpers/chains";
 import { uniV3Exports } from "../helpers/uniswap";
 
 // JAINE — Uniswap V3 fork on 0G
+// Factory (same address used by the JAINE TVL adapter in DefiLlama-Adapters,
+// registries/uniswapV3.js): https://chainscan.0g.ai/address/0x9bdcA5798E52e592A08e3b34d3F18EeF76Af7ef4
 export default uniV3Exports({
   [CHAIN.OG]: {
     factory: "0x9bdcA5798E52e592A08e3b34d3F18EeF76Af7ef4",

--- a/dexs/tradegpt.ts
+++ b/dexs/tradegpt.ts
@@ -2,6 +2,8 @@ import { CHAIN } from "../helpers/chains";
 import { uniV3Exports } from "../helpers/uniswap";
 
 // TradeGPT — Uniswap V3 fork on 0G
+// Factory (same address used by the TradeGPT TVL adapter in DefiLlama-Adapters,
+// registries/uniswapV3.js): https://chainscan.0g.ai/address/0x6F3945Ab27296D1D66D8EEb042ff1B4fb2E0CE70
 export default uniV3Exports({
   [CHAIN.OG]: {
     factory: "0x6F3945Ab27296D1D66D8EEb042ff1B4fb2E0CE70",

--- a/dexs/tradegpt.ts
+++ b/dexs/tradegpt.ts
@@ -1,0 +1,14 @@
+import { CHAIN } from "../helpers/chains";
+import { uniV3Exports } from "../helpers/uniswap";
+
+// TradeGPT — Uniswap V3 fork on 0G
+export default uniV3Exports({
+  [CHAIN.OG]: {
+    factory: "0x6F3945Ab27296D1D66D8EEb042ff1B4fb2E0CE70",
+    start: "2025-09-19",
+    userFeesRatio: 1,
+    revenueRatio: 0,
+    protocolRevenueRatio: 0,
+    holdersRevenueRatio: 0,
+  },
+});

--- a/dexs/uniswap-v3.ts
+++ b/dexs/uniswap-v3.ts
@@ -244,14 +244,6 @@ okuChains.forEach(chain => {
   },
 };
 
-(adapter.adapter as BaseAdapter)[CHAIN.OG] = {
-  fetch: async (options: FetchOptions) => {
-    const adapter = getUniV3LogAdapter({ factory: "0xcb2436774C3e191c85056d248EF4260ce5f27A9D", ...uniLogAdapterConfig })
-    const response = await adapter(options)
-    return response;
-  },
-};
-
 (adapter.adapter as BaseAdapter)[CHAIN.BLAST] = {
   fetch: async (options: FetchOptions) => {
     const adapter = getUniV3LogAdapter({ factory: "0x792edAdE80af5fC680d96a2eD80A44247D2Cf6Fd", ...uniLogAdapterConfig })

--- a/dexs/uniswap-v3.ts
+++ b/dexs/uniswap-v3.ts
@@ -244,6 +244,14 @@ okuChains.forEach(chain => {
   },
 };
 
+(adapter.adapter as BaseAdapter)[CHAIN.OG] = {
+  fetch: async (options: FetchOptions) => {
+    const adapter = getUniV3LogAdapter({ factory: "0xcb2436774C3e191c85056d248EF4260ce5f27A9D", ...uniLogAdapterConfig })
+    const response = await adapter(options)
+    return response;
+  },
+};
+
 (adapter.adapter as BaseAdapter)[CHAIN.BLAST] = {
   fetch: async (options: FetchOptions) => {
     const adapter = getUniV3LogAdapter({ factory: "0x792edAdE80af5fC680d96a2eD80A44247D2Cf6Fd", ...uniLogAdapterConfig })


### PR DESCRIPTION
### Summary

Adds DEX volume/fees adapters for three Uniswap-V3-fork DEXs on the **0G** chain. All three already have TVL adapters in DefiLlama-Adapters but no volume tracking.

| DEX | File | Sample daily volume (tested) |
|---|---|---|
| TradeGPT | `dexs/tradegpt.ts` | ~$156k |
| Bond | `dexs/bond.ts` | ~$12k |
| JAINE | `dexs/jaine.ts` | ~$1.6k |

### Implementation

Standard Uniswap-V3 forks → `uniV3Exports` with the factory + start block taken from the existing TVL registry. Pool discovery reuses the TVL adapter's cached logs. Fee/revenue split follows the repo-standard V3 convention (`userFeesRatio: 1, revenueRatio: 0`, all fees to LPs).

### Testing

`npm test dexs/<name>` for all three — each returns valid `dailyVolume` / `dailyFees` / `dailyRevenue` / `dailySupplySideRevenue`.

Note: 0G's default public RPC (`https://evmrpc.0g.ai`) is not archival, so local testing needs an archival endpoint (e.g. `https://0g.drpc.org`).

### Scope note

Uniswap V3 also runs on 0G (Oku deployment). Adding it requires editing `dexs/uniswap-v3.ts`, but that adapter is Dune-gated and can't pass forked-PR CI without `DUNE_API_KEYS`. Happy to add the one-line `CHAIN.OG` block (factory `0xcb2436774C3e191c85056d248EF4260ce5f27A9D`, same as Plasma) if a maintainer can run it, or in a follow-up.
