### PR TITLE
Add Trasia Perps Hyperliquid builder

### DIFF
--- a/factory/hyperliquid.ts
+++ b/factory/hyperliquid.ts
@@ -712,12 +712,16 @@ const builderConfigs: Record<string, BuilderConfig> = {
     },
     breakdownFees: true,
   },
-  
-
-
-
-
-
+  "trasia-perps": {
+    addresses: ["0xa9300365e8f6d0112a756c98f9acfc3543b295c0"],
+    start: "2026-06-03",
+    methodology: {
+      Fees: "Builder code fees paid by users on Hyperliquid perps trades routed through Trasia Perps.",
+      Revenue: "Builder code fees collected by Trasia Perps from Hyperliquid perps trades.",
+      ProtocolRevenue: "Builder code fees collected by Trasia Perps from Hyperliquid perps trades.",
+    },
+    breakdownFees: true,
+  },
 };
 
 


### PR DESCRIPTION
### What

Adds **Trasia Perps** as a Hyperliquid builder-code protocol. Like the other Hyperliquid builders, it is a single entry in `factory/hyperliquid.ts` -> `builderConfigs`, fed through the shared `exportBuilderAdapter()` helper, so it surfaces both **fees/revenue** (builder-code fees) and **dexs** (routed perp notional).

```ts
  "trasia-perps": {
    addresses: ["0xa9300365e8f6d0112a756c98f9acfc3543b295c0"],
    start: "2026-06-03",
    methodology: {
      Fees: "Builder code fees paid by users on Hyperliquid perps trades routed through Trasia Perps.",
      Revenue: "Builder code fees collected by Trasia Perps from Hyperliquid perps trades.",
      ProtocolRevenue: "Builder code fees collected by Trasia Perps from Hyperliquid perps trades.",
    },
    breakdownFees: true,
  }
```

- **Builder address:** `0xa9300365e8f6d0112a756c98f9acfc3543b295c0`
- **Start:** `2026-06-03` - first builder fill date for this address.
- `doublecounted: true` is set by `exportBuilderAdapter` (builder fees are a carve-out of Hyperliquid's own fees).

### Verification

- Evidence of first builder fill:
  `https://stats-data.hyperliquid.xyz/Mainnet/builder_fills/0xa9300365e8f6d0112a756c98f9acfc3543b295c0/20260603.csv.lz4`

### Listing info

- **Name:** Trasia
- **Website** https://trasia.xyz
- **Twitter** https://x.com/trasiaxyz
- **Chain:** Hyperliquid
- **Builder address:** `0xa9300365e8f6d0112a756c98f9acfc3543b295c0`
- **Short description:** Trasia Perps is a Hyperliquid trading interface for discovering and trading perpetual markets, with market search, charts, order book, recent trades, favorites, and account-level workspace features.
- **Methodology:** 
  - Volume: Total volume from users trading Hyperliquid perps through Trasia Perps.
  - Fees: Builder code fees paid by users on Hyperliquid perps trades routed through Trasia Perps.
  - Revenue: Builder code fees collected by Trasia Perps from Hyperliquid perps trades.
  - ProtocolRevenue: Builder code fees collected by Trasia Perps from Hyperliquid perps trades.
- **Category / slug:** 
  - Category: Interface
  - Sub Category: Hyperliquid Builder

Per the template: only `factory/hyperliquid.ts` is touched (no metadata, logo, or new adapter files).
