### PR TITLE
Add Base and BSC to Lombard Vault fees adapter

### DIFF
--- a/fees/lombard-vault/index.ts
+++ b/fees/lombard-vault/index.ts
@@ -50,7 +50,19 @@ const BoringVaults: { [key: string]: Array<IBoringVault> } = {
       vault: '0x5401b8620E5FB570064CA9114fd1e135fd77D57c',
       accountantAbiVersion: 2,
     },
-  ]
+  ],
+  [CHAIN.BASE]: [
+    {
+      vault: '0x5401b8620E5FB570064CA9114fd1e135fd77D57c',
+      accountantAbiVersion: 2,
+    },
+  ],
+  [CHAIN.BSC]: [
+    {
+      vault: '0x5401b8620E5FB570064CA9114fd1e135fd77D57c',
+      accountantAbiVersion: 2,
+    },
+  ],
 }
 
 const BoringVaultAbis = {
@@ -215,8 +227,11 @@ const adapter: Adapter = {
   version: 2,
   pullHourly: true,
   fetch,
-  chains: [CHAIN.ETHEREUM],
-  start: '2024-07-22',
+  chains: [
+    [CHAIN.ETHEREUM, { start: '2024-07-22' }],
+    [CHAIN.BASE, { start: '2024-11-20' }],
+    [CHAIN.BSC, { start: '2024-11-20' }],
+  ],
   methodology,
   breakdownMethodology,
 }


### PR DESCRIPTION
## Summary
- Add Base and BSC chains to the Lombard Vault fees adapter