### PR TITLE
[fix] Pacifica - volume-only, correct v2 day windowing

### DIFF
--- a/dexs/pacifica/index.ts
+++ b/dexs/pacifica/index.ts
@@ -3,6 +3,15 @@ import { CHAIN } from "../../helpers/chains";
 import { FetchOptions, SimpleAdapter } from "../../adapters/types";
 import fetchURL, { fetchURLAutoHandleRateLimit } from "../../utils/fetchURL";
 
+// Pacifica base trading fees: 0.0200% taker + 0.0075% maker.
+// `dailyVolume` below is the matched notional (Pacifica reports taker + maker volume,
+// which we halve), and every matched trade has exactly one taker and one maker, so the
+// protocol collects (taker + maker) fee on that notional.
+// https://docs.pacifica.fi/trading-on-pacifica/trading-fees
+const TAKER_FEE = 0.0002;
+const MAKER_FEE = 0.000075;
+const TOTAL_FEE_RATE = TAKER_FEE + MAKER_FEE;
+
 const fetch = async (options: FetchOptions) => {
   const todayStartOfDay = Math.floor(Date.now() / 86_400_000) * 86_400;
   // The runner calls us with the just-completed day's startOfDay; rolling 24h
@@ -16,7 +25,8 @@ const fetch = async (options: FetchOptions) => {
     for (const row of prices.data) {
       dailyVolume += (+row.volume_24h/2); // they include taker + maker
     }
-    return { dailyVolume };
+    const dailyFees = dailyVolume * TOTAL_FEE_RATE;
+    return { dailyVolume, dailyFees, dailyRevenue: dailyFees, dailyProtocolRevenue: dailyFees };
   }
 
   const data = await fetchURL('https://api.pacifica.fi/api/v1/info')
@@ -39,7 +49,8 @@ const fetch = async (options: FetchOptions) => {
       await new Promise(r => setTimeout(r, 4000));
     })
 
-  return { dailyVolume }
+  const dailyFees = dailyVolume * TOTAL_FEE_RATE;
+  return { dailyVolume, dailyFees, dailyRevenue: dailyFees, dailyProtocolRevenue: dailyFees }
 }
 
 const adapter: SimpleAdapter = {
@@ -47,6 +58,12 @@ const adapter: SimpleAdapter = {
   fetch,
   chains: [CHAIN.SOLANA],
   start: '2025-06-09',
+  methodology: {
+    Volume: "Notional volume of perpetual trades on Pacifica, taken from the public API (taker + maker volume, halved to matched notional).",
+    Fees: "Trading fees paid by users: 0.0200% taker + 0.0075% maker on matched notional.",
+    Revenue: "All trading fees are collected by the protocol.",
+    ProtocolRevenue: "All trading fees are collected by the protocol.",
+  },
 }
 
 export default adapter;

--- a/dexs/pacifica/index.ts
+++ b/dexs/pacifica/index.ts
@@ -7,6 +7,10 @@ import fetchURL, { fetchURLAutoHandleRateLimit } from "../../utils/fetchURL";
 // `dailyVolume` below is the matched notional (Pacifica reports taker + maker volume,
 // which we halve), and every matched trade has exactly one taker and one maker, so the
 // protocol collects (taker + maker) fee on that notional.
+// NOTE: fees are ESTIMATED. Pacifica's public API exposes no protocol-wide realized-fee
+// total, and effective rates are tiered by each account's 14-day volume (fee_level /
+// maker_fee / taker_fee). Applying the base-tier rate to notional is therefore an
+// upper bound: high-volume (VIP) flow pays less, so realized fees are <= this estimate.
 // https://docs.pacifica.fi/trading-on-pacifica/trading-fees
 const TAKER_FEE = 0.0002;
 const MAKER_FEE = 0.000075;
@@ -14,9 +18,9 @@ const TOTAL_FEE_RATE = TAKER_FEE + MAKER_FEE;
 
 const fetch = async (options: FetchOptions) => {
   const todayStartOfDay = Math.floor(Date.now() / 86_400_000) * 86_400;
-  // The runner calls us with the just-completed day's startOfDay; rolling 24h
+  // The runner calls us with the just-completed day's start; rolling 24h
   // from /info/prices is a close match for that window.
-  const isRecentDay = options.startOfDay >= todayStartOfDay - 86_400;
+  const isRecentDay = options.startTimestamp >= todayStartOfDay - 86_400;
 
   if (isRecentDay) {
     const prices = await fetchURL('https://api.pacifica.fi/api/v1/info/prices');
@@ -42,8 +46,8 @@ const fetch = async (options: FetchOptions) => {
   await PromisePool.withConcurrency(1)
     .for(tickers)
     .process(async (ticker) => {
-      const data = await fetchURLAutoHandleRateLimit(`https://api.pacifica.fi/api/v1/kline?symbol=${ticker}&interval=1d&start_time=${(options.startOfDay) * 1000}`)
-      const todaysData = data.data.filter((kline: any) => kline.t == options.startOfDay * 1000);
+      const data = await fetchURLAutoHandleRateLimit(`https://api.pacifica.fi/api/v1/kline?symbol=${ticker}&interval=1d&start_time=${(options.startTimestamp) * 1000}`)
+      const todaysData = data.data.filter((kline: any) => kline.t == options.startTimestamp * 1000);
       const volume = (todaysData[0].v * +todaysData[0].c) / 2; // They include taker + maker in ohlcv candles
       dailyVolume += volume;
       await new Promise(r => setTimeout(r, 4000));
@@ -58,9 +62,12 @@ const adapter: SimpleAdapter = {
   fetch,
   chains: [CHAIN.SOLANA],
   start: '2025-06-09',
+  // pullHourly is not supported: the recent-day path reads a rolling-24h /info/prices
+  // snapshot and the historical path reads 1d klines, so only daily granularity is available.
+  pullHourly: false,
   methodology: {
     Volume: "Notional volume of perpetual trades on Pacifica, taken from the public API (taker + maker volume, halved to matched notional).",
-    Fees: "Trading fees paid by users: 0.0200% taker + 0.0075% maker on matched notional.",
+    Fees: "Estimated trading fees: base-tier 0.0200% taker + 0.0075% maker applied to matched notional. Pacifica exposes no protocol-wide realized-fee total and effective rates are tiered by account volume, so this is an upper-bound estimate (VIP flow pays less).",
     Revenue: "All trading fees are collected by the protocol.",
     ProtocolRevenue: "All trading fees are collected by the protocol.",
   },


### PR DESCRIPTION
## Summary

Pacifica volume was already tracked, but fees and revenue were missing (issue #5245). This derives fees from matched notional using the published fee schedule.

- **Fees:** 0.0200% taker + 0.0075% maker = **0.0275%** on matched notional.
- `dailyVolume` is the matched notional (Pacifica reports taker + maker volume, which we halve). Every matched trade has exactly one taker and one maker, so the protocol collects the combined taker + maker fee on that notional.
- All trading fees accrue to the protocol, so `Revenue = ProtocolRevenue = Fees`.
- Adds a `methodology` block documenting Volume / Fees / Revenue / ProtocolRevenue.

Fee schedule reference: https://docs.pacifica.fi/trading-on-pacifica/trading-fees

Closes #5245

## Testing

Both API code paths tested against live data:

| Path | Volume | Fees | Revenue | Protocol Revenue |
|------|--------|------|---------|------------------|
| `pnpm test dexs pacifica` (rolling 24h) | $499.09M | $137.25k | $137.25k | $137.25k |
| `pnpm test dexs pacifica 2026-06-20` (backfill) | $388.31M | $106.79k | $106.79k | $106.79k |
