### PR TITLE
feat: add stratium & liquidiction hip4 markets

### DIFF
--- a/factory/hyperliquid.ts
+++ b/factory/hyperliquid.ts
@@ -253,6 +253,16 @@ const builderConfigs: Record<string, BuilderConfig> = {
       ProtocolRevenue: "Builder code fees collected by Omni Terminal from Hyperliquid perps trades.",
     },
   },
+  "stratium": {
+    addresses: ["0xcbd0ab1f5872dba6667c23765613de93453e3320"],
+    start: "2026-05-08",
+    market: "hip4",
+  },
+  "liquidiction": {
+    addresses: ["0x2e10360cbfb68080b72c17f35633700e75fe461b"],
+    start: "2026-05-13",
+    market: "hip4",
+  },
   "pear-interface": {
     addresses: ["0xa47d4d99191db54a4829cdf3de2417e527c3b042"],
     start: "2025-07-08",


### PR DESCRIPTION
## #7602

Added support for the following builders:

- **Stratium**
  - Source: https://stratium.xyz/
  - App: https://markets.stratium.xyz/
  - Builder: `0xcbd0ab1...`
  - Retrieved from the app config (`NEXT_PUBLIC_HL_BUILDER_ADDRESS`).

- **Liquidiction**
  - Source: https://liquidiction.xyz/
  - Builder: `0x2e10360c...`
  - Retrieved from the app's mainnet config.

### Stratium

| Command | Market Date | Expected Volume | Actual Volume |
|---------|-------------|----------------:|--------------:|
| `pnpm test dexs stratium 2026-05-21` | 2026-05-20 | $1.05k | $1,048.72 |
| `pnpm test dexs stratium 2026-06-11` | 2026-06-10 | $50.00 | $49.95 |
| `pnpm test dexs stratium 2026-06-16` | 2026-06-15 | $1.50k | $1,495.10 |

### Liquidiction

| Command | Market Date | Expected Volume | Actual Volume |
|---------|-------------|----------------:|--------------:|
| `pnpm test dexs liquidiction 2026-05-21` | 2026-05-20 | $1.34k | $1,340.04 |
| `pnpm test dexs liquidiction 2026-06-02` | 2026-06-01 | $3.96k | $3,965.71 |
| `pnpm test dexs liquidiction 2026-06-16` | 2026-06-15 | $1.80k | $1,795.92 |