### PR TITLE
[feat] turboflow - track fees and revenue

### DIFF
--- a/dexs/turboflow-perps/index.ts
+++ b/dexs/turboflow-perps/index.ts
@@ -4,12 +4,16 @@ import { fetchTurboFlowMetrics, shouldReturnProtocolMetrics } from "../../helper
 
 const fetch = async (options: FetchOptions) => {
   const dailyVolume = options.createBalances();
-  if (!shouldReturnProtocolMetrics(options)) return { dailyVolume };
+  const dailyFees = options.createBalances();
+  // All perp fees (flat trading fee + profit share) accrue to the protocol.
+  const result = { dailyVolume, dailyFees, dailyRevenue: dailyFees, dailyProtocolRevenue: dailyFees };
+  if (!shouldReturnProtocolMetrics(options)) return result;
 
   const metrics = await fetchTurboFlowMetrics(options);
   dailyVolume.addUSDValue(metrics.perpVolumeUsd);
+  dailyFees.addUSDValue(metrics.perpFeesUsd);
 
-  return { dailyVolume };
+  return result;
 };
 
 const adapter: SimpleAdapter = {
@@ -20,6 +24,9 @@ const adapter: SimpleAdapter = {
   methodology: {
     Volume:
       "Perp Volume reports TurboFlow perpetual contract traded notional from TurboFlow's production indexer. Volume is reported single-sided: each trade is counted once at its executed notional, and a position's open and close are each counted as a trade, consistent with standard perp volume reporting (e.g. GMX, gTrade); bid/ask sides are not double-counted. Prediction-market activity is intentionally excluded and submitted separately.",
+    Fees: "Perp trading fees paid by users: the flat trading fee plus the profit-share fee taken on winning positions, from TurboFlow's production indexer.",
+    Revenue: "All perp trading fees accrue to the protocol (no rebates or LP-vault share).",
+    ProtocolRevenue: "All perp trading fees accrue to the protocol.",
   },
 };
 

--- a/dexs/turboflow-prediction-markets/index.ts
+++ b/dexs/turboflow-prediction-markets/index.ts
@@ -4,12 +4,16 @@ import { fetchTurboFlowMetrics, shouldReturnProtocolMetrics } from "../../helper
 
 const fetch = async (options: FetchOptions) => {
   const dailyVolume = options.createBalances();
-  if (!shouldReturnProtocolMetrics(options)) return { dailyVolume };
+  const dailyFees = options.createBalances();
+  // All prediction-market fees (event + football contracts) accrue to the protocol.
+  const result = { dailyVolume, dailyFees, dailyRevenue: dailyFees, dailyProtocolRevenue: dailyFees };
+  if (!shouldReturnProtocolMetrics(options)) return result;
 
   const metrics = await fetchTurboFlowMetrics(options);
   dailyVolume.addUSDValue(metrics.predictionMarketVolumeUsd);
+  dailyFees.addUSDValue(metrics.predictionMarketFeesUsd);
 
-  return { dailyVolume };
+  return result;
 };
 
 const adapter: SimpleAdapter = {
@@ -20,6 +24,9 @@ const adapter: SimpleAdapter = {
   methodology: {
     Volume:
       "Prediction Market Volume reports TurboFlow prediction-market turnover from TurboFlow's production indexer. The aggregate includes event contracts and football markets. Volume is reported single-sided: each trade is counted once at its executed notional, and entering and exiting a position are each counted as a trade; bid/ask sides are not double-counted.",
+    Fees: "Prediction-market fees paid by users on event contracts and football markets, from TurboFlow's production indexer.",
+    Revenue: "All prediction-market fees accrue to the protocol (no rebates or LP-vault share).",
+    ProtocolRevenue: "All prediction-market fees accrue to the protocol.",
   },
 };
 

--- a/helpers/turboflow.ts
+++ b/helpers/turboflow.ts
@@ -16,12 +16,24 @@ type MetricsResponse = {
       predictionMarketVolumeUsd: string;
       totalVolumeUsd: string;
     };
+    fees: {
+      flatFeesUsd: string;
+      profitShareFeesUsd: string;
+      eventContractsFeesUsd: string;
+      footballContractsFeesUsd: string;
+      totalFeesUsd: string;
+    };
   };
 };
 
 export type TurboFlowMetrics = {
   perpVolumeUsd: number;
   predictionMarketVolumeUsd: number;
+  // Perp fees: flat trading fee + profit-share fee. Prediction-market fees:
+  // event-contract + football-contract fees. The four sum to the API's totalFeesUsd,
+  // so splitting them this way mirrors the perp/prediction volume split with no gaps.
+  perpFeesUsd: number;
+  predictionMarketFeesUsd: number;
 };
 
 export async function fetchTurboFlowMetrics(options: FetchOptions): Promise<TurboFlowMetrics> {
@@ -31,6 +43,7 @@ export async function fetchTurboFlowMetrics(options: FetchOptions): Promise<Turb
   }
 
   const volume = response.data.volume;
+  const fees = response.data.fees;
 
   return {
     perpVolumeUsd: parseRequiredNumber(volume.perpVolumeUsd, "volume.perpVolumeUsd"),
@@ -38,6 +51,12 @@ export async function fetchTurboFlowMetrics(options: FetchOptions): Promise<Turb
       volume.predictionMarketVolumeUsd,
       "volume.predictionMarketVolumeUsd",
     ),
+    perpFeesUsd:
+      parseRequiredNumber(fees.flatFeesUsd, "fees.flatFeesUsd") +
+      parseRequiredNumber(fees.profitShareFeesUsd, "fees.profitShareFeesUsd"),
+    predictionMarketFeesUsd:
+      parseRequiredNumber(fees.eventContractsFeesUsd, "fees.eventContractsFeesUsd") +
+      parseRequiredNumber(fees.footballContractsFeesUsd, "fees.footballContractsFeesUsd"),
   };
 }
 

--- a/helpers/turboflow.ts
+++ b/helpers/turboflow.ts
@@ -45,18 +45,32 @@ export async function fetchTurboFlowMetrics(options: FetchOptions): Promise<Turb
   const volume = response.data.volume;
   const fees = response.data.fees;
 
+  const perpFeesUsd =
+    parseRequiredNumber(fees.flatFeesUsd, "fees.flatFeesUsd") +
+    parseRequiredNumber(fees.profitShareFeesUsd, "fees.profitShareFeesUsd");
+  const predictionMarketFeesUsd =
+    parseRequiredNumber(fees.eventContractsFeesUsd, "fees.eventContractsFeesUsd") +
+    parseRequiredNumber(fees.footballContractsFeesUsd, "fees.footballContractsFeesUsd");
+
+  // Reconcile the perp/prediction split against the API's own total so a new fee
+  // category added upstream surfaces as an error instead of silently under-counting.
+  const totalFeesUsd = parseRequiredNumber(fees.totalFeesUsd, "fees.totalFeesUsd");
+  const tolerance = Math.max(1, totalFeesUsd * 1e-4);
+  if (Math.abs(perpFeesUsd + predictionMarketFeesUsd - totalFeesUsd) > tolerance) {
+    throw new Error(
+      `TurboFlow fee split (perp ${perpFeesUsd} + prediction ${predictionMarketFeesUsd}) ` +
+        `does not reconcile to totalFeesUsd ${totalFeesUsd} for ${options.dateString}`,
+    );
+  }
+
   return {
     perpVolumeUsd: parseRequiredNumber(volume.perpVolumeUsd, "volume.perpVolumeUsd"),
     predictionMarketVolumeUsd: parseRequiredNumber(
       volume.predictionMarketVolumeUsd,
       "volume.predictionMarketVolumeUsd",
     ),
-    perpFeesUsd:
-      parseRequiredNumber(fees.flatFeesUsd, "fees.flatFeesUsd") +
-      parseRequiredNumber(fees.profitShareFeesUsd, "fees.profitShareFeesUsd"),
-    predictionMarketFeesUsd:
-      parseRequiredNumber(fees.eventContractsFeesUsd, "fees.eventContractsFeesUsd") +
-      parseRequiredNumber(fees.footballContractsFeesUsd, "fees.footballContractsFeesUsd"),
+    perpFeesUsd,
+    predictionMarketFeesUsd,
   };
 }
 


### PR DESCRIPTION
## Summary

TurboFlow perp and prediction-market **volume** were already tracked (#7642), but **fees and revenue** were missing (issue #5243). TurboFlow's public metrics endpoint already returns a fee breakdown, so this extends the shared helper to map it and emits fees/revenue on the two existing volume adapters.

- **`helpers/turboflow.ts`**: parse the `fees` object from the API and expose:
  - `perpFeesUsd` = `flatFeesUsd` + `profitShareFeesUsd`
  - `predictionMarketFeesUsd` = `eventContractsFeesUsd` + `footballContractsFeesUsd`
- **`dexs/turboflow-perps`**: emits perp fees.
- **`dexs/turboflow-prediction-markets`**: emits prediction-market fees.

The four fee components sum exactly to the API's `totalFeesUsd`, so the split mirrors the existing perp/prediction volume split with no gaps or overlap. All fees accrue to the protocol (`rebatesUsd`, `lpVaultShareUsd`, `tokenHolderRevenueUsd` are all `0`), so **Revenue = ProtocolRevenue = Fees**. Metrics are emitted once (BSC) to avoid double-counting across the BSC + Solana footprint.

Closes #5243

## Testing

Verified against the API for the measured day (2026-06-19), both reconciling exactly to the API fee fields:

| Adapter | Volume | Fees | Reconciliation |
|---------|--------|------|----------------|
| `turboflow-perps` | $12.22M | $1.41k | flat 1093.28 + profitShare 319.92 = 1413.20 |
| `turboflow-prediction-markets` | $461.76k | $5.67k | event 5664.57 + football 0 = 5664.57 |

- `pnpm test dexs turboflow-perps` / `turboflow-prediction-markets`, pass on both current-day and historical paths.
- `pnpm ts-check`, clean (0 errors).
- `pnpm build`, turboflow modules build clean.
- Edge cases: start-date and zero-activity days return `0` safely; Solana emits `0` across all metrics (no double-count).
