### PR TITLE
Add PumpDaily subscription fees

### DIFF
--- a/fees/pumpbox/index.ts
+++ b/fees/pumpbox/index.ts
@@ -4,11 +4,15 @@ import ADDRESSES from '../../helpers/coreAssets.json';
 
 const CHECKOUT_CONTRACT = "0x64FEeB41A17Dd29b9BAF6d45Ca2d359aE55d8C68";
 const USDC_BASE = ADDRESSES.base.USDC;
+const PUMPDAILY_SUBSCRIPTION_RECEIVER = "0x646308ef20fb48101662dda0fb2dc7c677bc1b59";
 
 const OPEN_BOX_REQUESTED =
   "event OpenBoxRequested(address indexed user, bytes32 indexed boxId, uint256 indexed requestId, uint32 quantity, uint256 paidAmount, uint256 clientEntropy)";
 
 const BUYBACK_EXECUTED = "event BuybackExecuted(address indexed seller, uint256 indexed tokenId, uint256 buybackPrice)";
+const USDC_TRANSFER = "event Transfer(address indexed from, address indexed to, uint256 value)";
+
+const addressToTopic = (address: string) => `0x${address.toLowerCase().slice(2).padStart(64, "0")}`;
 
 const fetch = async ({ getLogs, createBalances }: FetchOptions) => {
   const dailyFees = createBalances();
@@ -25,6 +29,12 @@ const fetch = async ({ getLogs, createBalances }: FetchOptions) => {
     eventAbi: BUYBACK_EXECUTED,
   });
 
+  const subscriptionLogs = await getLogs({
+    target: USDC_BASE,
+    eventAbi: USDC_TRANSFER,
+    topics: [null as any, null as any, addressToTopic(PUMPDAILY_SUBSCRIPTION_RECEIVER)],
+  });
+
   for (const log of boxOpenedLogs) {
     dailyVolume.add(USDC_BASE, log.paidAmount);
     dailyFees.add(USDC_BASE, log.paidAmount, "Box Opening Fees");
@@ -34,6 +44,12 @@ const fetch = async ({ getLogs, createBalances }: FetchOptions) => {
   for (const log of buybackLogs) {
     dailyFees.add(USDC_BASE, -1 * Number(log.buybackPrice), "Buyback Spends");
     dailyRevenue.add(USDC_BASE, -1 * Number(log.buybackPrice), "Buyback Spends");
+  }
+
+  for (const log of subscriptionLogs) {
+    if (log.from?.toLowerCase() === CHECKOUT_CONTRACT.toLowerCase()) continue;
+    dailyFees.add(USDC_BASE, log.value, "Subscription Fees");
+    dailyRevenue.add(USDC_BASE, log.value, "Subscription Fees");
   }
 
   return {
@@ -46,22 +62,25 @@ const fetch = async ({ getLogs, createBalances }: FetchOptions) => {
 
 const methodology = {
   Volume: "All USDC payments made by users when opening blind boxes. Each box has a fixed USDC price; users pay price × quantity.",
-  Fees: "USDC paid by users to request blind box openings net of buyback spends.",
-  Revenue: "USDC paid by users to request blind box openings net of buyback spends.",
-  ProtocolRevenue: "USDC paid by users to request blind box openings net of buyback spends.",
+  Fees: "USDC paid by users to request blind box openings plus PumpDaily subscriptions, net of buyback spends.",
+  Revenue: "USDC paid by users to request blind box openings plus PumpDaily subscriptions, net of buyback spends.",
+  ProtocolRevenue: "USDC paid by users to request blind box openings plus PumpDaily subscriptions, net of buyback spends.",
 };
 
 const breakdownMethodology = {
   Fees: {
     "Box Opening Fees": "USDC paid by users to request blind box openings. The checkout contract escrows USDC and transfers it to the payment receiver upon fulfillment.",
+    "Subscription Fees": "USDC paid by users for PumpDaily subscriptions via direct transfers to the protocol treasury.",
     "Buyback Spends": "USDC spent by the protocol on box buybacks.",
   },
   Revenue: {
     "Box Opening Fees": "USDC paid by users to request blind box openings.",
+    "Subscription Fees": "USDC paid by users for PumpDaily subscriptions.",
     "Buyback Spends": "USDC spent by the protocol on box buybacks.",
   },
   ProtocolRevenue: {
     "Box Opening Fees": "USDC paid by users to request blind box openings.",
+    "Subscription Fees": "USDC paid by users for PumpDaily subscriptions.",
     "Buyback Spends": "USDC spent by the protocol on box buybacks.",
   },
 };


### PR DESCRIPTION
## Summary

Adds PumpDaily subscription payments to the existing PumpBox fees adapter.

## What Changed

- Tracks USDC `Transfer` events into the PumpBox treasury address:
  `0x646308ef20fb48101662dda0fb2dc7c677bc1b59`
- Counts direct PumpDaily subscription payments as `Subscription Fees`
- Adds subscription payments to:
  - `dailyFees`
  - `dailyRevenue`
  - `dailyProtocolRevenue`
- Keeps box opening payments and buyback spend logic unchanged
- Excludes transfers from the checkout contract to avoid double-counting box opening settlement transfers

## Methodology

PumpBox fees now include:

1. Box opening fees from `OpenBoxRequested.paidAmount`
2. PumpDaily subscription payments sent directly to the protocol treasury
3. Buyback spends as negative fees/revenue

PumpDaily subscriptions are paid by directly transferring USDC to the PumpBox treasury, so these transfers are counted as protocol revenue.

## Addresses

- Checkout contract: `0x64FEeB41A17Dd29b9BAF6d45Ca2d359aE55d8C68`
- PumpDaily / Treasury receiver: `0x646308ef20fb48101662dda0fb2dc7c677bc1b59`
- USDC on Base: `0x833589fcd6edb6e08f4c7c32d4f71b54bda02913`