### PR TITLE
shuriken: fix Solana revenue attribution

### DIFF
--- a/fees/shuriken.ts
+++ b/fees/shuriken.ts
@@ -20,7 +20,7 @@ const fetchSolana = async (options: FetchOptions) => {
     blacklist_signers: FEE_WALLETS,
   })
 
-  return { dailyFees, dailyRevenue: dailyFees }
+  return { dailyFees, dailyRevenue: dailyFees, dailyProtocolRevenue: dailyFees }
 }
 
 const adapter: SimpleAdapter = {
@@ -37,8 +37,9 @@ const adapter: SimpleAdapter = {
     },
   },
   methodology: {
-    Fees: "Trading fees paid by users while using Shuriken bot.",
-    Revenue: "All fees are collected by Shuriken protocol.",
+    Fees: "Trading fees paid by users trading through the Shuriken bot (1% per swap, 0.9% via a referral link), collected in SOL by Shuriken's on-chain fee wallets.",
+    Revenue: "Collected fees are swept in full from the fee wallets to Shuriken's treasury and retained by the protocol.",
+    ProtocolRevenue: "All collected fees are retained by the Shuriken treasury.",
   }
 };
 


### PR DESCRIPTION
I traced the on-chain fee flow:

`fee wallet` → `treasury` → ~50/50 split between ops wallets and cold storage.

All fees are swept to the treasury and retained, with no on-chain distribution, so `revenue = fees` is correct. Cashback/referral rewards are settled off-chain and don't affect the on-chain fee flow.

### Changes

* Set `dailyProtocolRevenue = dailyFees`.
* Updated the methodology to reflect the actual fee model (1% per swap, 0.9% via referral) and the collect → treasury → retain flow.