### PR TITLE
Fix velodrome v2

### DIFF
--- a/dexs/velodrome-v2/index.ts
+++ b/dexs/velodrome-v2/index.ts
@@ -120,13 +120,13 @@ const customLogic = async ({ dailyVolume, dailyFees, fetchOptions, filteredPairs
 export default {
   ...uniV2Exports({
     [CHAIN.OPTIMISM]: { factory: '0xF1046053aa5682b4F9a81b5481394DA16BE5FF5a', swapEvent, voter: '0x41c914ee0c7e1a5edcd0295623e6dc557b5abf3c', maxPairSize: 500, customLogic, start: '2023-06-23' },
-    [CHAIN.MODE]: { factory: leaf_pool_factory, customLogic, start: '2024-12-11' },
+    [CHAIN.MODE]: { factory: leaf_pool_factory, swapEvent, customLogic, start: '2024-12-11' },
     [CHAIN.BOB]: { factory: leaf_pool_factory, swapEvent, customLogic, start: '2024-12-11' },
-    [CHAIN.LISK]: {factory: leaf_pool_factory, customLogic, start: '2024-12-11' },
-    [CHAIN.FRAXTAL]: {factory: leaf_pool_factory, customLogic, start: '2024-12-11' },
-    [CHAIN.INK]: {factory: leaf_pool_factory, customLogic, start: '2025-01-15' },
-    [CHAIN.SONEIUM]: {factory: leaf_pool_factory, customLogic, start: '2025-01-15' },
-    [CHAIN.UNICHAIN]: {factory: leaf_pool_factory, customLogic, start: '2025-02-22' },
+    [CHAIN.LISK]: {factory: leaf_pool_factory, swapEvent, customLogic, start: '2024-12-11' },
+    [CHAIN.FRAXTAL]: {factory: leaf_pool_factory, swapEvent, customLogic, start: '2024-12-11' },
+    [CHAIN.INK]: {factory: leaf_pool_factory, swapEvent, customLogic, start: '2025-01-15' },
+    [CHAIN.SONEIUM]: {factory: leaf_pool_factory, swapEvent, customLogic, start: '2025-01-15' },
+    [CHAIN.UNICHAIN]: {factory: leaf_pool_factory, swapEvent, customLogic, start: '2025-02-22' },
     // [CHAIN.SWELLCHAIN]: {factory: leaf_pool_factory, swapEvent, voter: '0x97cDBCe21B6fd0585d29E539B1B99dAd328a1123', customLogic,} // dead chain
   }),
   version: 2,

--- a/dexs/velodrome-v2/index.ts
+++ b/dexs/velodrome-v2/index.ts
@@ -44,7 +44,7 @@ const superchainConfig: Record<string, any> = {
 }
 
 
-const customLogic = async ({ dailyFees, fetchOptions, filteredPairs, }: any) => {
+const customLogic = async ({ dailyVolume, dailyFees, fetchOptions, filteredPairs, }: any) => {
   const { createBalances, getLogs, chain, api, getToBlock, } = fetchOptions
   const dailyBribes = createBalances()
 
@@ -114,7 +114,7 @@ const customLogic = async ({ dailyFees, fetchOptions, filteredPairs, }: any) => 
   totalHoldersRevenue.add(dailyFees, 'Swap Fees To Voters')
   totalHoldersRevenue.add(dailyBribes, 'External Bribes Revenue')
 
-  return { dailyFees: totalFees, dailyRevenue: totalHoldersRevenue, dailyHoldersRevenue: totalHoldersRevenue } as any
+  return { dailyVolume, dailyFees: totalFees, dailyRevenue: totalHoldersRevenue, dailyHoldersRevenue: totalHoldersRevenue } as any
 }
 
 export default {


### PR DESCRIPTION
## Summary

### Problem

1. **Volume dropped.** `customLogic` didn't return the `dailyVolume` the helper computed, so it was discarded and reported as `0` across all chains, volume last returned **June 24th 2026**.
2. **Wrong Swap event on 6 leaf chains.** Mode, Lisk, Fraxtal, Ink, Soneium, and Unichain omitted `swapEvent` and fell back to the standard uni-v2 `Swap` event instead of Velodrome's own, so zero logs matched and volume were `0` on those chains (OPTIMISM/BOB already set it).

### Solution

1. Return `dailyVolume` from `customLogic`
2. Add `swapEvent` to the six leaf configs.

https://defillama.com/protocol/velodrome-v2