### PR TITLE
polymarket: track builder fees for MetaMask, Based, traderline

### DIFF
--- a/factory/polymarket.ts
+++ b/factory/polymarket.ts
@@ -35,8 +35,6 @@ const feesConfigs: Record<string, { builderName: string; builderCode: string; st
   "metamask": { builderName: "MetaMask", builderCode: "0x11a22276beb720e66a072cba8b8e74cded60afda510af535b947b81a1b81a883", start: "2026-04-28" },
   "based-predict": { builderName: "Based", builderCode: "0x07aa1a8523160e8e9c2d07ac890d56d21c3fe0f11292558f941f69624788d1cf", start: "2026-04-28" },
   "traderline": { builderName: "traderline", builderCode: "0x6b0e773fada0a2ec67c956b25a737d353a534ea33db56c717ba7854346c67984", start: "2026-04-28" },
-  "rainbow-predictions": { builderName: "Rainbow", builderCode: "0xabce5abdc189cba6fb85edb9170e3e6e41607e946b06d112b7f87e2f2977020c", start: "2026-04-28" },
-  "frenflow": { builderName: "FrenFlow", builderCode: "0x1a907452bfffcc46534332a0882c2fb78e289fec946ea88f603f5767e080fcd5", start: "2026-04-28" },
 }
 
 const dexsProtocols: Record<string, any> = {};

--- a/factory/polymarket.ts
+++ b/factory/polymarket.ts
@@ -32,7 +32,7 @@ const feesConfigs: Record<string, { builderName: string; builderCode: string; st
   "preddy-trade": { builderName: "Preddy.trade", builderCode: "0x25d56a25be81b183908e80ccc522e72d4187480a4aa29fa7e4dd1112546fabef", start: "2026-04-28" },
   "polytrader-app": { builderName: "Polytrader.app", builderCode: "0x6f5dfb79b61e701021143a9426b4188bda94da794068dec5454a0ac2ec82bc64", start: "2026-04-28" },
   "kiyotaka": { builderName: "Kiyotaka", builderCode: "0x2096c1dd5e4d0c660ce764ab20a3a95853d11e27724b3c73cad543352da1555f", start: "2026-04-28" },
-  "metamask": { builderName: "MetaMask", builderCode: "0x11a22276beb720e66a072cba8b8e74cded60afda510af535b947b81a1b81a883", start: "2026-04-28" },
+  "metamask-predictions": { builderName: "MetaMask", builderCode: "0x11a22276beb720e66a072cba8b8e74cded60afda510af535b947b81a1b81a883", start: "2026-04-28" },
   "based-predict": { builderName: "Based", builderCode: "0x07aa1a8523160e8e9c2d07ac890d56d21c3fe0f11292558f941f69624788d1cf", start: "2026-04-28" },
   "traderline": { builderName: "traderline", builderCode: "0x6b0e773fada0a2ec67c956b25a737d353a534ea33db56c717ba7854346c67984", start: "2026-04-28" },
 }

--- a/factory/polymarket.ts
+++ b/factory/polymarket.ts
@@ -32,6 +32,11 @@ const feesConfigs: Record<string, { builderName: string; builderCode: string; st
   "preddy-trade": { builderName: "Preddy.trade", builderCode: "0x25d56a25be81b183908e80ccc522e72d4187480a4aa29fa7e4dd1112546fabef", start: "2026-04-28" },
   "polytrader-app": { builderName: "Polytrader.app", builderCode: "0x6f5dfb79b61e701021143a9426b4188bda94da794068dec5454a0ac2ec82bc64", start: "2026-04-28" },
   "kiyotaka": { builderName: "Kiyotaka", builderCode: "0x2096c1dd5e4d0c660ce764ab20a3a95853d11e27724b3c73cad543352da1555f", start: "2026-04-28" },
+  "metamask": { builderName: "MetaMask", builderCode: "0x11a22276beb720e66a072cba8b8e74cded60afda510af535b947b81a1b81a883", start: "2026-04-28" },
+  "based-predict": { builderName: "Based", builderCode: "0x07aa1a8523160e8e9c2d07ac890d56d21c3fe0f11292558f941f69624788d1cf", start: "2026-04-28" },
+  "traderline": { builderName: "traderline", builderCode: "0x6b0e773fada0a2ec67c956b25a737d353a534ea33db56c717ba7854346c67984", start: "2026-04-28" },
+  "rainbow-predictions": { builderName: "Rainbow", builderCode: "0xabce5abdc189cba6fb85edb9170e3e6e41607e946b06d112b7f87e2f2977020c", start: "2026-04-28" },
+  "frenflow": { builderName: "FrenFlow", builderCode: "0x1a907452bfffcc46534332a0882c2fb78e289fec946ea88f603f5767e080fcd5", start: "2026-04-28" },
 }
 
 const dexsProtocols: Record<string, any> = {};


### PR DESCRIPTION
Adds Polymarket v2 builder-fee tracking for five builders that are already tracked for volume in dexsConfigs but were missing from feesConfigs: MetaMask, Based, traderline, Rainbow, and FrenFlow.

Why: these builders earn real, currently-untracked builder-code revenue. I sampled the CLOB /builder/trades endpoint (builderFee field, same source the existing polymarketV2BuilderFeesExports helper uses) over a 6-hour window and measured: MetaMask ~$9.8K, Based ~$336, traderline ~$233, Rainbow ~$3, FrenFlow ~$0.26. MetaMask alone annualizes to roughly $14M in builder fees that DefiLlama wasn't capturing.

Verification: I only added builders with confirmed nonzero fees. Builders that showed zero builder-fee activity in the same sample (betmoar, FlowBot, Polycule, Gate, polytraderpro, standtrade, Kreo, WagerUpPilot) were deliberately left out to avoid adding empty adapters. Builder codes match the values from /v1/builders/volume. Start date aligns with the existing cohort (Polymarket v2 builder fees, 2026-04-28); earlier dates simply return zero and are harmless.

No new dependencies, no helper changes, config-only addition using the existing polymarketV2BuilderFeesExports path.
