### PR TITLE
element: fix revenue, return protocol revenue instead of total fees

### DIFF
--- a/fees/element/index.ts
+++ b/fees/element/index.ts
@@ -82,7 +82,7 @@ const fetch = async ({ chain, getLogs, createBalances }: FetchOptions) => {
       dailyFees.add(log.erc20Token, fee.amount)
     }
   }
-  return { dailyFees, dailyRevenue: dailyFees, dailyProtocolRevenue: dailyFees, dailySupplySideRevenue };
+  return { dailyFees, dailyRevenue, dailyProtocolRevenue: dailyRevenue, dailySupplySideRevenue };
 };
 
 const adapter: Adapter = {


### PR DESCRIPTION
## Summary
Fixes Element revenue, which was reporting total fees (protocol + creator royalties) instead of just Element's feeCollector share.
https://defillama.com/protocol/element-nft-marketplace