### PR TITLE
[feat] Lifi-Jumper: track robinhood chain 

### DIFF
--- a/aggregators/jumper-exchange/index.ts
+++ b/aggregators/jumper-exchange/index.ts
@@ -32,6 +32,7 @@ const contract: IContract = {
   [CHAIN.FUSE]: '0x1231deb6f5749ef6ce6943a275a1d3e7486f4eae',
   [CHAIN.CRONOS]: '0x1231deb6f5749ef6ce6943a275a1d3e7486f4eae',
   [CHAIN.GRAVITY]: '0x1231deb6f5749ef6ce6943a275a1d3e7486f4eae',
+  [CHAIN.ROBINHOOD]: '0xB477751B76CF82d00a686A1232f5fCD772414Af3',
 }
 
 const fetch = async ({ chain, getLogs, createBalances, }: FetchOptions) => {

--- a/helpers/aggregators/lifi.ts
+++ b/helpers/aggregators/lifi.ts
@@ -206,6 +206,10 @@ export const LifiDiamonds: IContract = {
     id: '0x6f5C8Bb0C5Fe4ECeAC40EE1C238EaB6bbb29761c',
     startTime: '2025-09-01'
   },
+  [CHAIN.ROBINHOOD]: {
+    id: '0xB477751B76CF82d00a686A1232f5fCD772414Af3',
+    startTime: '2026-05-11'
+  },
   [CHAIN.MONAD]: {
     id: '0x026F252016A7C47CDEf1F05a3Fc9E20C92a49C37',
     startTime: '2025-10-02'
@@ -396,6 +400,10 @@ export const LifiFeeCollectors: IContract = {
   [CHAIN.PLUME]: {
     id: '0x3e46137a80BB3c14906505d0f78ADbb2deDb9E3f',
     startTime: '2025-09-01'
+  },
+  [CHAIN.ROBINHOOD]: {
+    id: '0xAD257784C6D50640d1EFa31cfB3e75bD566f63BA',
+    startTime: '2026-05-11'
   },
   [CHAIN.HEMI]: {
     id: '0x026F252016A7C47CDEf1F05a3Fc9E20C92a49C37',


### PR DESCRIPTION
## Summary
- Adds Robinhood chain support for LI.FI and Jumper volume tracking.
- Adds the LI.FI Robinhood FeeCollector so `fees/lifi` can report Robinhood fees when fee events begin emitting.

## Changes
- Added Robinhood to `LifiDiamonds` in `helpers/aggregators/lifi.ts` using LI.FI Diamond `0xB477751B76CF82d00a686A1232f5fCD772414Af3`.
- Added Robinhood to `LifiFeeCollectors` in `helpers/aggregators/lifi.ts` using FeeCollector `0xAD257784C6D50640d1EFa31cfB3e75bD566f63BA`.
- Added Robinhood to the Jumper aggregator contract map in `aggregators/jumper-exchange/index.ts`.
- Uses `2026-05-11` as the start date from Robinhood Blockscout deployment timestamps.

## Methodology
- LI.FI and Jumper volume continue to use existing LI.FI Diamond swap and bridge events.
- LI.FI fees continue to use the existing `FeesCollected(address,address,uint256,uint256)` event emitted by the LI.FI FeeCollector.
- The Robinhood FeeCollector address is sourced from LI.FI's official `robinhood.json` deployment artifact and verified on Blockscout as `FeeCollector`.
- A full-chain Robinhood scan for `FeesCollected` found only unrelated emitters so far; the verified LI.FI FeeCollector currently has no fee logs, so Robinhood fees return zero until fees are collected.

## Links
- LI.FI website: https://li.fi
- LI.FI X/Twitter: https://x.com/lifiprotocol
- Jumper website: https://jumper.exchange
- Jumper X/Twitter: https://x.com/JumperExchange

## Tests
- Robinhood-only `aggregators/lifi` validation with `ROBINHOOD_RPC=https://rpc.mainnet.chain.robinhood.com`: `dailyVolume = 13`
- Robinhood-only `aggregators/jumper-exchange` validation with `ROBINHOOD_RPC=https://rpc.mainnet.chain.robinhood.com`: `dailyVolume = 309`
- Robinhood-only `bridge-aggregators/lifi` validation with `ROBINHOOD_RPC=https://rpc.mainnet.chain.robinhood.com`: `dailyBridgeVolume = 12037`
- Robinhood-only `bridge-aggregators/jumper.exchange` validation with `ROBINHOOD_RPC=https://rpc.mainnet.chain.robinhood.com`: `dailyBridgeVolume = 564`
- Robinhood-only `fees/lifi` validation with `ROBINHOOD_RPC=https://rpc.mainnet.chain.robinhood.com`: all fee dimensions returned `0`, matching the no-log scan.
- `git diff --check`