### PR TITLE
deluthium: fix fee token and double-counted volume

### DIFF
--- a/aggregators/deluthium/index.ts
+++ b/aggregators/deluthium/index.ts
@@ -33,8 +33,7 @@ const fetch = async ({ getLogs, createBalances, chain }: FetchOptions) => {
 
   logs.forEach((log: any) => {
     addOneToken({ chain, balances: dailyVolume, token0: log.outputToken, amount0: log.amountOut, token1: log.inputToken, amount1: log.grossAmountIn });
-    dailyVolume.add(log.outputToken, log.amountOut);
-    dailyFees.add(log.feeTo, log.feeAmount, SWAP_FEE_LABEL);
+    dailyFees.add(log.inputToken, log.feeAmount, SWAP_FEE_LABEL);
   });
 
   return { dailyVolume, dailyFees, dailyRevenue: dailyFees, dailyProtocolRevenue: dailyFees, };


### PR DESCRIPTION
## Summary
Fees were tracked against feeTo (a recipient address, not a token) and volume was double-counted, fixed by charging fees on inputToken (the token the fee is actually taken from, per the settlement contract) and removing the redundant dailyVolume.add.