### PR TITLE
[feat] Arcus-Perps: track volume and oi from candles api

### DIFF
--- a/dexs/arcus-perps/index.ts
+++ b/dexs/arcus-perps/index.ts
@@ -1,0 +1,52 @@
+import { PromisePool } from "@supercharge/promise-pool";
+import { FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import fetchURL, { fetchURLAutoHandleRateLimit } from "../../utils/fetchURL";
+
+const API_BASE = "https://api.arcus.xyz/v1";
+
+const fetch = async (options: FetchOptions) => {
+  // Arcus candle timestamps are Unix microseconds.
+  const start = options.startOfDay * 1e6;
+  const end = (options.startOfDay + 86400) * 1e6;
+  const { markets } = await fetchURL(`${API_BASE}/markets`);
+  const perpMarkets: string[] = markets
+    .filter((market: any) => market.type === "PERPETUAL")
+    .map((market: any) => market.marketDisplayName);
+
+  const { results } = await PromisePool.withConcurrency(3)
+    .for(perpMarkets)
+    .process(async (market: string) => {
+      const url = new URL(`${API_BASE}/candles`);
+      url.searchParams.set("market", market);
+      url.searchParams.set("timeframe", "1d");
+      url.searchParams.set("from", `${start}`);
+      url.searchParams.set("to", `${end}`);
+
+      const { candles = [] } = await fetchURLAutoHandleRateLimit(url.toString());
+
+      return candles.reduce((sum: number, candle: any) => {
+        const openTime = Number(candle.openTime);
+        if (!candle.isFinal || openTime < start || openTime >= end) return sum;
+        return sum + Number(candle.notionalVolume);
+      }, 0);
+    });
+
+  const dailyVolume = results.reduce((sum: number, volume: number) => sum + volume, 0);
+
+  return { dailyVolume };
+};
+
+const methodology = {
+  Volume: "Total daily trading volume from all perpetual markets on Arcus.",
+};
+
+const adapter: SimpleAdapter = {
+  version: 1,
+  fetch,
+  chains: [CHAIN.ROBINHOOD],
+  start: "2026-07-03",
+  methodology,
+};
+
+export default adapter;

--- a/open-interest/arcus-oi.ts
+++ b/open-interest/arcus-oi.ts
@@ -1,0 +1,29 @@
+import { SimpleAdapter } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+import fetchURL from "../utils/fetchURL";
+
+const API = "https://api.arcus.xyz/v1/markets";
+
+const fetch = async () => {
+  const { markets } = await fetchURL(API);
+  const openInterestAtEnd = markets
+    .filter((market: any) => market.type === "PERPETUAL")
+    .reduce((sum: number, market: any) => sum + Number(market.openInterest) * Number(market.markPrice), 0);
+
+  return { openInterestAtEnd };
+};
+
+const methodology = {
+  OpenInterest: "Open interest is the sum of notional open interest from Arcus's markets API.",
+};
+
+const adapter: SimpleAdapter = {
+  version: 1,
+  fetch,
+  chains: [CHAIN.ROBINHOOD],
+  start: "2026-07-03",
+  runAtCurrTime: true,
+  methodology,
+};
+
+export default adapter;


### PR DESCRIPTION
https://arcus.xyz/

## Summary
- Adds Arcus perpetuals volume tracking on Robinhood under `dexs/arcus-perps`.
- Adds Arcus open interest tracking on Robinhood under `open-interest/arcus-oi`.
- Uses Arcus public market and OHLCV APIs with start date `2026-07-03`.

## Changes
- Added `dexs/arcus-perps/index.ts` to sum daily perpetual trading volume from Arcus `1d` OHLCV candle `notionalVolume` across all perpetual markets.
- Added `open-interest/arcus-oi.ts` to sum notional open interest from Arcus markets API as `openInterest * markPrice`.
- Set both adapters to `CHAIN.ROBINHOOD`.

## Methodology
- Volume: Total daily trading volume from all perpetual markets on Arcus.
- OpenInterest: Open interest is the sum of notional open interest from Arcus's markets API.

## Tests
- `pnpm test dexs arcus-perps 2026-07-04`
  - `ROBINHOOD` daily volume: `236.53 k`
- `pnpm test open-interest arcus-oi`
  - `ROBINHOOD` open interest at end: `276.25 k`
- `git diff --check`