### PR TITLE
[fees]Fly-Trade: read protocol fees from DexAggregator Swap event

### DIFF
--- a/fees/fly-trade/index.ts
+++ b/fees/fly-trade/index.ts
@@ -2,9 +2,8 @@ import { FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 import { addTokensReceived } from "../../helpers/token";
 
-// fly.trade migrated to a new DexAggregator router on 2026-05-03. Before that, protocol fees
-// accrued to a legacy fee collector; after, each swap emits its fee token(s) + amount(s) directly.
-const MIGRATION_TS = 1777766400; 
+// fly.trade migrated to a new DexAggregator router on 2026-05-03.
+const MIGRATION_TS = 1777766400; // 2026-05-03
 const LEGACY_FEE_COLLECTOR = "0xd39B2A01D4dca42F32Ff52244a1b28811e40045F";
 
 // DexAggregator router addresses. Source: https://docs.fly.trade/developers/deployments
@@ -13,12 +12,47 @@ const ROUTER_B = "0xf5f3b8faf45023fd92c0c88fedf73fb0529fc1cd"; // polygon_zkevm,
 const ROUTER_C = "0xc5b20203b6807e742853c96ce7dcfb1e7b201c0a"; // zksync era
 const ROUTER_D = "0xf702814d2e1290f3d5f3202565df46272e1b1b92"; // metis, fantom, pharos
 
+const chainConfig: Record<string, { router: string; start: string }> = {
+  [CHAIN.ETHEREUM]: { router: ROUTER_A, start: "2025-08-18" },
+  [CHAIN.ARBITRUM]: { router: ROUTER_A, start: "2025-08-18" },
+  [CHAIN.OPTIMISM]: { router: ROUTER_A, start: "2025-08-18" },
+  [CHAIN.BASE]: { router: ROUTER_A, start: "2025-08-18" },
+  [CHAIN.BSC]: { router: ROUTER_A, start: "2025-08-18" },
+  [CHAIN.POLYGON]: { router: ROUTER_A, start: "2025-08-18" },
+  [CHAIN.AVAX]: { router: ROUTER_A, start: "2025-08-18" },
+  [CHAIN.SCROLL]: { router: ROUTER_A, start: "2025-08-18" },
+  [CHAIN.MANTA]: { router: ROUTER_A, start: "2025-08-18" },
+  [CHAIN.LINEA]: { router: ROUTER_A, start: "2025-08-18" },
+  [CHAIN.METIS]: { router: ROUTER_D, start: "2025-08-18" },
+  [CHAIN.FANTOM]: { router: ROUTER_D, start: "2025-08-18" },
+  [CHAIN.BERACHAIN]: { router: ROUTER_A, start: "2025-08-20" },
+  [CHAIN.TAIKO]: { router: ROUTER_B, start: "2025-08-20" },
+  [CHAIN.INK]: { router: ROUTER_A, start: "2025-11-01" },
+  [CHAIN.BLAST]: { router: ROUTER_A, start: "2026-05-03" },
+  [CHAIN.SONIC]: { router: ROUTER_A, start: "2026-05-03" },
+  [CHAIN.UNICHAIN]: { router: ROUTER_A, start: "2026-05-03" },
+  [CHAIN.ABSTRACT]: { router: ROUTER_A, start: "2026-05-03" },
+  [CHAIN.HYPERLIQUID]: { router: ROUTER_A, start: "2026-05-03" },
+  [CHAIN.KATANA]: { router: ROUTER_A, start: "2026-05-03" },
+  [CHAIN.MONAD]: { router: ROUTER_A, start: "2026-05-03" },
+  [CHAIN.PLASMA]: { router: ROUTER_A, start: "2026-05-03" },
+  [CHAIN.MEGAETH]: { router: ROUTER_A, start: "2026-05-03" },
+  [CHAIN.MORPH]: { router: ROUTER_A, start: "2026-05-03" },
+  [CHAIN.STABLE]: { router: ROUTER_A, start: "2026-05-03" },
+  [CHAIN.OG]: { router: ROUTER_A, start: "2026-05-03" },
+  [CHAIN.TEMPO]: { router: ROUTER_A, start: "2026-05-03" },
+  [CHAIN.POLYGON_ZKEVM]: { router: ROUTER_B, start: "2026-05-03" },
+  [CHAIN.TELOS]: { router: ROUTER_B, start: "2026-05-03" },
+  [CHAIN.ERA]: { router: ROUTER_C, start: "2026-05-03" },
+  [CHAIN.PHAROS]: { router: ROUTER_D, start: "2026-05-03" },
+};
 
 const swapEvent =
   "event Swap(address fromAddress, address toAddress, address fromAssetAddress, address toAssetAddress, uint256 amountIn, uint256 amountOut, uint256 expectedAmountOut, uint256 amountInSurplus, uint256 amountOutSurplus, bytes32 consumerId, address[] swapFeeAssetAddresses, address[] swapFeeReceivers, uint256[] swapFeeAmounts)";
 
-const getFetch = (router = ROUTER_A) => async (options: FetchOptions) => {
+const fetch = async (options: FetchOptions) => {
   const dailyFees = options.createBalances();
+  const { router } = chainConfig[options.chain];
 
   if (options.startTimestamp < MIGRATION_TS) {
     await addTokensReceived({ options, balances: dailyFees, targets: [LEGACY_FEE_COLLECTOR] });
@@ -26,7 +60,7 @@ const getFetch = (router = ROUTER_A) => async (options: FetchOptions) => {
     const logs = await options.getLogs({ target: router, eventAbi: swapEvent });
     for (const log of logs) {
       for (let i = 0; i < log.swapFeeAmounts.length; i++) {
-        dailyFees.add(log.swapFeeAssetAddresses[i], log.swapFeeAmounts[i]);
+        dailyFees.add(log.swapFeeAssetAddresses[i], log.swapFeeAmounts[i], "Swap Fees");
       }
     }
   }
@@ -40,49 +74,25 @@ const methodology = {
   ProtocolRevenue: "All fly.trade swap fees are retained by the protocol.",
 };
 
+const breakdownMethodology = {
+  Fees: {
+    "Swap Fees": "Conditional 0.01%-0.1% protocol fee on long-tail assets / specific pairs, summed from the swapFeeAmounts of each DexAggregator Swap event.",
+  },
+  Revenue: {
+    "Swap Fees": "All fly.trade swap fees are retained by the protocol.",
+  },
+  ProtocolRevenue: {
+    "Swap Fees": "All fly.trade swap fees are retained by the protocol.",
+  },
+};
+
 const adapter: SimpleAdapter = {
   version: 2,
   pullHourly: true,
+  fetch,
   methodology,
-  fetch: getFetch(),
-  start: "2025-08-18",
-  chains: [
-    CHAIN.ETHEREUM,
-    CHAIN.ARBITRUM,
-    CHAIN.OPTIMISM,
-    CHAIN.BASE,
-    CHAIN.BSC,
-    CHAIN.POLYGON,
-    CHAIN.AVAX,
-    CHAIN.SCROLL,
-    CHAIN.MANTA,
-    CHAIN.LINEA,
-  ],
-  // chains that differ by router address and/or start date
-  adapter: {
-    [CHAIN.METIS]: { fetch: getFetch(ROUTER_D), start: "2025-08-18" },
-    [CHAIN.FANTOM]: { fetch: getFetch(ROUTER_D), start: "2025-08-18" },
-    [CHAIN.BERACHAIN]: { fetch: getFetch(), start: "2025-08-20" },
-    [CHAIN.TAIKO]: { fetch: getFetch(ROUTER_B), start: "2025-08-20" },
-    [CHAIN.INK]: { fetch: getFetch(), start: "2025-11-01" },
-    [CHAIN.BLAST]: { fetch: getFetch(), start: "2026-05-03" },
-    [CHAIN.SONIC]: { fetch: getFetch(), start: "2026-05-03" },
-    [CHAIN.UNICHAIN]: { fetch: getFetch(), start: "2026-05-03" },
-    [CHAIN.ABSTRACT]: { fetch: getFetch(), start: "2026-05-03" },
-    [CHAIN.HYPERLIQUID]: { fetch: getFetch(), start: "2026-05-03" },
-    [CHAIN.KATANA]: { fetch: getFetch(), start: "2026-05-03" },
-    [CHAIN.MONAD]: { fetch: getFetch(), start: "2026-05-03" },
-    [CHAIN.PLASMA]: { fetch: getFetch(), start: "2026-05-03" },
-    [CHAIN.MEGAETH]: { fetch: getFetch(), start: "2026-05-03" },
-    [CHAIN.MORPH]: { fetch: getFetch(), start: "2026-05-03" },
-    [CHAIN.STABLE]: { fetch: getFetch(), start: "2026-05-03" },
-    [CHAIN.OG]: { fetch: getFetch(), start: "2026-05-03" },
-    [CHAIN.TEMPO]: { fetch: getFetch(), start: "2026-05-03" },
-    [CHAIN.POLYGON_ZKEVM]: { fetch: getFetch(ROUTER_B), start: "2026-05-03" },
-    [CHAIN.TELOS]: { fetch: getFetch(ROUTER_B), start: "2026-05-03" },
-    [CHAIN.ERA]: { fetch: getFetch(ROUTER_C), start: "2026-05-03" },
-    [CHAIN.PHAROS]: { fetch: getFetch(ROUTER_D), start: "2026-05-03" },
-  },
+  breakdownMethodology,
+  adapter: chainConfig,
 };
 
 export default adapter;

--- a/fees/fly-trade/index.ts
+++ b/fees/fly-trade/index.ts
@@ -52,7 +52,7 @@ const chainConfig: Record<string, { router: string; start: string }> = {
   [CHAIN.STABLE]: { router: ROUTER_A, start: "2026-05-03" },
   [CHAIN.OG]: { router: ROUTER_A, start: "2026-05-03" },
   [CHAIN.TEMPO]: { router: ROUTER_A, start: "2026-05-03" },
-  [CHAIN.POLYGON_ZKEVM]: { router: ROUTER_B, start: "2026-05-03" },
+  // [CHAIN.POLYGON_ZKEVM]: { router: ROUTER_B, start: "2026-05-03" }, // public RPC chronically stale
   [CHAIN.TELOS]: { router: ROUTER_B, start: "2026-05-03" },
   [CHAIN.ERA]: { router: ROUTER_C, start: "2026-05-03" },
   [CHAIN.PHAROS]: { router: ROUTER_D, start: "2026-05-03" },

--- a/fees/fly-trade/index.ts
+++ b/fees/fly-trade/index.ts
@@ -69,8 +69,9 @@ const fetch = async (options: FetchOptions) => {
 
   if (options.startTimestamp < MIGRATION_TS) {
     // Pre-migration fees were collected directly by fly's fee wallet, so all of it is fly revenue.
-    await addTokensReceived({ options, balances: dailyFees, targets: [LEGACY_FEE_COLLECTOR] });
-    dailyRevenue.addBalances(dailyFees, "Swap Fees");
+    const received = await addTokensReceived({ options, targets: [LEGACY_FEE_COLLECTOR] });
+    dailyFees.addBalances(received, "Swap Fees");
+    dailyRevenue.addBalances(received, "Swap Fees");
   } else {
     const logs = await options.getLogs({ target: router, eventAbi: swapEvent });
     for (const log of logs) {

--- a/fees/fly-trade/index.ts
+++ b/fees/fly-trade/index.ts
@@ -1,35 +1,54 @@
-import { SimpleAdapter, FetchOptions } from "../../adapters/types";
+import { FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 import { addTokensReceived } from "../../helpers/token";
 
-const SWAP_FEE_ADDRESS = "0xd39B2A01D4dca42F32Ff52244a1b28811e40045F";
+// fly.trade migrated to a new DexAggregator router on 2026-05-03. Before that, protocol fees
+// accrued to a legacy fee collector; after, each swap emits its fee token(s) + amount(s) directly.
+const MIGRATION_TS = 1777766400; 
+const LEGACY_FEE_COLLECTOR = "0xd39B2A01D4dca42F32Ff52244a1b28811e40045F";
 
-const fetch = async (options: FetchOptions) => {
-  const dailyFees = await addTokensReceived({
-    options,
-    targets: [SWAP_FEE_ADDRESS],
-  });
+// DexAggregator router addresses. Source: https://docs.fly.trade/developers/deployments
+const ROUTER_A = "0x20f6ee51340adeed01a59b0e65cb3703f3dc860c"; // default deployment (most chains)
+const ROUTER_B = "0xf5f3b8faf45023fd92c0c88fedf73fb0529fc1cd"; // polygon_zkevm, taiko, telos
+const ROUTER_C = "0xc5b20203b6807e742853c96ce7dcfb1e7b201c0a"; // zksync era
+const ROUTER_D = "0xf702814d2e1290f3d5f3202565df46272e1b1b92"; // metis, fantom, pharos
 
-  return {
-    dailyFees,
-    dailyRevenue: dailyFees,
-    dailyProtocolRevenue: dailyFees,
-  };
+
+const swapEvent =
+  "event Swap(address fromAddress, address toAddress, address fromAssetAddress, address toAssetAddress, uint256 amountIn, uint256 amountOut, uint256 expectedAmountOut, uint256 amountInSurplus, uint256 amountOutSurplus, bytes32 consumerId, address[] swapFeeAssetAddresses, address[] swapFeeReceivers, uint256[] swapFeeAmounts)";
+
+const getFetch = (router = ROUTER_A) => async (options: FetchOptions) => {
+  const dailyFees = options.createBalances();
+
+  if (options.startTimestamp < MIGRATION_TS) {
+    await addTokensReceived({ options, balances: dailyFees, targets: [LEGACY_FEE_COLLECTOR] });
+  } else {
+    const logs = await options.getLogs({ target: router, eventAbi: swapEvent });
+    for (const log of logs) {
+      for (let i = 0; i < log.swapFeeAmounts.length; i++) {
+        dailyFees.add(log.swapFeeAssetAddresses[i], log.swapFeeAmounts[i]);
+      }
+    }
+  }
+
+  return { dailyFees, dailyRevenue: dailyFees, dailyProtocolRevenue: dailyFees };
 };
 
 const methodology = {
-  Fees: "Fly charges a conditional protocol-level swap fee (0.01%–0.1%) on selected long-tail assets and specific trading pairs. Fees are enforced at the router level and transferred to a Fly-controlled fee collector address.",
-  Revenue: "All Fly swap fees are retained by the protocol.",
-  ProtocolRevenue: "All Fly swap fees are retained by the protocol.",
+  Fees: "Protocol swap fees charged by fly.trade — a conditional 0.01%-0.1% fee on long-tail assets and specific pairs. Since the 2026-05-03 router migration these are summed from the swapFeeAmounts of each DexAggregator Swap event; earlier fees are taken from the legacy fee collector.",
+  Revenue: "All fly.trade swap fees are retained by the protocol.",
+  ProtocolRevenue: "All fly.trade swap fees are retained by the protocol.",
 };
 
 const adapter: SimpleAdapter = {
   version: 2,
   pullHourly: true,
-  fetch,
+  methodology,
+  fetch: getFetch(),
+  start: "2025-08-18",
   chains: [
-    CHAIN.ARBITRUM,
     CHAIN.ETHEREUM,
+    CHAIN.ARBITRUM,
     CHAIN.OPTIMISM,
     CHAIN.BASE,
     CHAIN.BSC,
@@ -37,22 +56,33 @@ const adapter: SimpleAdapter = {
     CHAIN.AVAX,
     CHAIN.SCROLL,
     CHAIN.MANTA,
-    CHAIN.METIS,
-    CHAIN.FANTOM,
     CHAIN.LINEA,
   ],
+  // chains that differ by router address and/or start date
   adapter: {
-    [CHAIN.BERACHAIN]: {
-      start: "2025-08-20",
-    },
-    [CHAIN.TAIKO]: {
-      start: "2025-08-20",
-    },
-    [CHAIN.INK]: {
-      start: "2025-11-01",
-    },
+    [CHAIN.METIS]: { fetch: getFetch(ROUTER_D), start: "2025-08-18" },
+    [CHAIN.FANTOM]: { fetch: getFetch(ROUTER_D), start: "2025-08-18" },
+    [CHAIN.BERACHAIN]: { fetch: getFetch(), start: "2025-08-20" },
+    [CHAIN.TAIKO]: { fetch: getFetch(ROUTER_B), start: "2025-08-20" },
+    [CHAIN.INK]: { fetch: getFetch(), start: "2025-11-01" },
+    [CHAIN.BLAST]: { fetch: getFetch(), start: "2026-05-03" },
+    [CHAIN.SONIC]: { fetch: getFetch(), start: "2026-05-03" },
+    [CHAIN.UNICHAIN]: { fetch: getFetch(), start: "2026-05-03" },
+    [CHAIN.ABSTRACT]: { fetch: getFetch(), start: "2026-05-03" },
+    [CHAIN.HYPERLIQUID]: { fetch: getFetch(), start: "2026-05-03" },
+    [CHAIN.KATANA]: { fetch: getFetch(), start: "2026-05-03" },
+    [CHAIN.MONAD]: { fetch: getFetch(), start: "2026-05-03" },
+    [CHAIN.PLASMA]: { fetch: getFetch(), start: "2026-05-03" },
+    [CHAIN.MEGAETH]: { fetch: getFetch(), start: "2026-05-03" },
+    [CHAIN.MORPH]: { fetch: getFetch(), start: "2026-05-03" },
+    [CHAIN.STABLE]: { fetch: getFetch(), start: "2026-05-03" },
+    [CHAIN.OG]: { fetch: getFetch(), start: "2026-05-03" },
+    [CHAIN.TEMPO]: { fetch: getFetch(), start: "2026-05-03" },
+    [CHAIN.POLYGON_ZKEVM]: { fetch: getFetch(ROUTER_B), start: "2026-05-03" },
+    [CHAIN.TELOS]: { fetch: getFetch(ROUTER_B), start: "2026-05-03" },
+    [CHAIN.ERA]: { fetch: getFetch(ROUTER_C), start: "2026-05-03" },
+    [CHAIN.PHAROS]: { fetch: getFetch(ROUTER_D), start: "2026-05-03" },
   },
-  methodology,
 };
 
 export default adapter;

--- a/fees/fly-trade/index.ts
+++ b/fees/fly-trade/index.ts
@@ -12,6 +12,18 @@ const ROUTER_B = "0xf5f3b8faf45023fd92c0c88fedf73fb0529fc1cd"; // polygon_zkevm,
 const ROUTER_C = "0xc5b20203b6807e742853c96ce7dcfb1e7b201c0a"; // zksync era
 const ROUTER_D = "0xf702814d2e1290f3d5f3202565df46272e1b1b92"; // metis, fantom, pharos
 
+
+const FLY_FEE_RECEIVERS = new Set(
+  [
+    ROUTER_A,
+    ROUTER_B,
+    ROUTER_C,
+    ROUTER_D,
+    "0xcD6b980029E6E6e0733ac8eC3E02be9410D09799", // fee collector
+    LEGACY_FEE_COLLECTOR,
+  ].map((a) => a.toLowerCase())
+);
+
 const chainConfig: Record<string, { router: string; start: string }> = {
   [CHAIN.ETHEREUM]: { router: ROUTER_A, start: "2025-08-18" },
   [CHAIN.ARBITRUM]: { router: ROUTER_A, start: "2025-08-18" },
@@ -52,37 +64,73 @@ const swapEvent =
 
 const fetch = async (options: FetchOptions) => {
   const dailyFees = options.createBalances();
+  const dailyRevenue = options.createBalances();
+  const dailySupplySideRevenue = options.createBalances();
   const { router } = chainConfig[options.chain];
 
   if (options.startTimestamp < MIGRATION_TS) {
+    // Pre-migration fees were collected directly by fly's fee wallet, so all of it is fly revenue.
     await addTokensReceived({ options, balances: dailyFees, targets: [LEGACY_FEE_COLLECTOR] });
+    dailyRevenue.addBalances(dailyFees, "Swap Fees");
   } else {
     const logs = await options.getLogs({ target: router, eventAbi: swapEvent });
     for (const log of logs) {
-      for (let i = 0; i < log.swapFeeAmounts.length; i++) {
-        dailyFees.add(log.swapFeeAssetAddresses[i], log.swapFeeAmounts[i], "Swap Fees");
+      const { fromAssetAddress, toAssetAddress, amountInSurplus, amountOutSurplus, swapFeeAssetAddresses, swapFeeReceivers, swapFeeAmounts } = log;
+      for (let i = 0; i < swapFeeAmounts.length; i++) {
+        const token = swapFeeAssetAddresses[i];
+        const amount = swapFeeAmounts[i];
+        if (FLY_FEE_RECEIVERS.has(swapFeeReceivers[i].toLowerCase())) {
+          dailyFees.add(token, amount, "Swap Fees");
+          dailyRevenue.add(token, amount, "Swap Fees");
+        } else {
+          // fee routed to an affiliate / integrator address
+          dailyFees.add(token, amount, "Affiliate Fees");
+          dailySupplySideRevenue.add(token, amount, "Affiliate Fees");
+        }
+      }
+      // Positive slippage (surplus) retained by fly's router — capped at maxRetentionBps, fly revenue.
+      if (amountOutSurplus) {
+        dailyFees.add(toAssetAddress, amountOutSurplus, "Surplus");
+        dailyRevenue.add(toAssetAddress, amountOutSurplus, "Surplus");
+      }
+      if (amountInSurplus) {
+        dailyFees.add(fromAssetAddress, amountInSurplus, "Surplus");
+        dailyRevenue.add(fromAssetAddress, amountInSurplus, "Surplus");
       }
     }
   }
 
-  return { dailyFees, dailyRevenue: dailyFees, dailyProtocolRevenue: dailyFees };
+  return {
+    dailyFees,
+    dailyRevenue,
+    dailyProtocolRevenue: dailyRevenue,
+    dailySupplySideRevenue,
+  };
 };
 
 const methodology = {
-  Fees: "Protocol swap fees charged by fly.trade — a conditional 0.01%-0.1% fee on long-tail assets and specific pairs. Since the 2026-05-03 router migration these are summed from the swapFeeAmounts of each DexAggregator Swap event; earlier fees are taken from the legacy fee collector.",
-  Revenue: "All fly.trade swap fees are retained by the protocol.",
-  ProtocolRevenue: "All fly.trade swap fees are retained by the protocol.",
+  Fees: "Swap fees charged by fly.trade's DexAggregator (a conditional 0.01%-0.1% fee on long-tail assets and specific pairs) plus positive slippage (surplus) retained by the router, taken from each Swap event. Pre-2026-05-03 (router migration) fees are taken from the legacy fee collector.",
+  Revenue: "Swap fees routed to fly.trade's own fee collector, plus the retained positive slippage (surplus).",
+  ProtocolRevenue: "Swap fees and retained surplus kept by fly.trade.",
+  SupplySideRevenue: "Swap fees routed to affiliate / integrator addresses (the referral cut).",
 };
 
 const breakdownMethodology = {
   Fees: {
-    "Swap Fees": "Conditional 0.01%-0.1% protocol fee on long-tail assets / specific pairs, summed from the swapFeeAmounts of each DexAggregator Swap event.",
+    "Swap Fees": "Protocol fee routed to fly.trade's fee collector.",
+    "Affiliate Fees": "Fee routed to affiliate / integrator addresses.",
+    "Surplus": "Positive slippage retained by fly.trade's router (capped at maxRetentionBps).",
   },
   Revenue: {
-    "Swap Fees": "All fly.trade swap fees are retained by the protocol.",
+    "Swap Fees": "Fees retained by fly.trade.",
+    "Surplus": "Positive slippage retained by fly.trade.",
   },
   ProtocolRevenue: {
-    "Swap Fees": "All fly.trade swap fees are retained by the protocol.",
+    "Swap Fees": "Fees retained by fly.trade.",
+    "Surplus": "Positive slippage retained by fly.trade.",
+  },
+  SupplySideRevenue: {
+    "Affiliate Fees": "Fees paid out to affiliates / integrators.",
   },
 };
 

--- a/fees/fly-trade/index.ts
+++ b/fees/fly-trade/index.ts
@@ -19,7 +19,6 @@ const FLY_FEE_RECEIVERS = new Set(
     ROUTER_B,
     ROUTER_C,
     ROUTER_D,
-    "0xcD6b980029E6E6e0733ac8eC3E02be9410D09799", // fee collector
     LEGACY_FEE_COLLECTOR,
   ].map((a) => a.toLowerCase())
 );


### PR DESCRIPTION
Fixes #5235 

**Problem**
The adapter tracked fees by watching a single hardcoded wallet via `addTokensReceived`.
fly.trade migrated to a new DexAggregator router across all chains on 2026-05-03,
so fees no longer land on that wallet.

**Fix**
Fees are now read on-chain from the `DexAggregator` `Swap` event, which emits
`swapFeeAssetAddresses` / `swapFeeAmounts` per swap (conditional 0.01–0.1% fee on
long-tail assets / specific pairs; most swaps carry empty fee arrays). To preserve
history, the fetch is time-bounded at the migration: legacy fee collector before
2026-05-03, Swap event after. Expanded to the full 32-chain deployment list.

**Methodology**
- Fees: protocol swap fees summed from `swapFeeAmounts` (legacy collector pre-migration).
- Revenue / ProtocolRevenue: all fees are retained by fly.trade.

Verified on-chain: a single day on Base returns non-zero fees across 15+ long-tail tokens.

Website: https://fly.trade
Twitter: https://x.com/fly_trade
Docs (fees): https://docs.fly.trade/developers/protocol-fees
Docs (deployments): https://docs.fly.trade/developers/deployments