### PR TITLE
[add] defa - track daily USDC inflow (volume) into invoice-backed pools

### DIFF
--- a/dexs/defa/index.ts
+++ b/dexs/defa/index.ts
@@ -1,0 +1,50 @@
+import { CHAIN } from "../../helpers/chains";
+import { Dependencies, FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { queryDuneSql } from "../../helpers/dune";
+
+// DeFa — daily USDC inflow (capital raised) into invoice-backed real-world-credit pools.
+// The on-chain TVL loggers expose a cumulative "raised" figure per chain; a daily job
+// snapshots them into Dune (dune.defa_im.raised_daily: date, chain, raised_usd).
+// Here we take the day-over-day increase = that day's inflow. DefiLlama accumulates it
+// into cumulative volume, which is monotonic (never decreases) — the "total raised".
+//
+// First tracked day has no prior row, so it reports the full cumulative-to-date, making
+// the accumulated total equal actual total raised.
+
+const fetch = async (options: FetchOptions) => {
+  const dailyVolume = options.createBalances();
+  const query = `
+    WITH daily AS (
+      SELECT date, MAX(raised_usd) AS raised_usd            -- dedup re-runs: latest per day
+      FROM dune.defa_im.raised_daily
+      WHERE chain = '${options.chain}'
+      GROUP BY date
+    ),
+    delta AS (
+      SELECT date,
+             COALESCE(raised_usd - LAG(raised_usd) OVER (ORDER BY date), raised_usd) AS daily_raised
+      FROM daily
+    )
+    SELECT COALESCE(SUM(daily_raised), 0) AS daily_raised
+    FROM delta
+    WHERE date >= ${options.startTimestamp} AND date < ${options.endTimestamp}
+  `;
+  const rows: { daily_raised: number }[] = await queryDuneSql(options, query);
+  dailyVolume.addUSDValue(Number(rows?.[0]?.daily_raised || 0));
+  return { dailyVolume };
+};
+
+const adapter: SimpleAdapter = {
+  version: 1,
+  fetch,
+  chains: [CHAIN.STELLAR, CHAIN.STARKNET, "zigchain"],
+  start: "2026-07-04",
+  dependencies: [Dependencies.DUNE],
+  isExpensiveAdapter: true,
+  methodology: {
+    Volume:
+      "Daily USDC inflow (capital raised) into DeFa invoice-backed pools, read from the on-chain TVL loggers (Stellar, ZigChain, Starknet) snapshotted daily to Dune. Reported as the day-over-day increase in cumulative raised; the accumulated total equals total capital raised and is monotonic (never decreases).",
+  },
+};
+
+export default adapter;

--- a/dexs/defa/index.ts
+++ b/dexs/defa/index.ts
@@ -38,13 +38,13 @@ const fetch = async (options: FetchOptions) => {
 const adapter: SimpleAdapter = {
   version: 1,
   fetch,
-  chains: [CHAIN.STELLAR, CHAIN.STARKNET, "zigchain"],
+  chains: [CHAIN.ETHEREUM, CHAIN.STELLAR, CHAIN.STARKNET, "zigchain"],
   start: "2026-07-04",
   dependencies: [Dependencies.DUNE],
   isExpensiveAdapter: true,
   methodology: {
     Volume:
-      "Daily USDC inflow (capital raised) into DeFa invoice-backed pools, read from the on-chain TVL loggers (Stellar, ZigChain, Starknet) snapshotted daily to Dune. Reported as the day-over-day increase in cumulative raised; the accumulated total equals total capital raised and is monotonic (never decreases).",
+      "Daily USDC inflow (capital deployed) into DeFa's real-world-credit pools: invoice financing on Stellar, ZigChain and Starknet (from on-chain TVL loggers), plus PSP/PayFi lending on Ethereum (USDC inflow into the DeFa Safe). Snapshotted daily to Dune (dune.defa_im.raised_daily) and reported as the day-over-day increase in cumulative inflow; the accumulated total equals total capital deployed and is monotonic (never decreases).",
   },
 };
 

--- a/dexs/defa/index.ts
+++ b/dexs/defa/index.ts
@@ -20,6 +20,16 @@ const TRANSFER_TOPIC = "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a
 const toTopic = "0x000000000000000000000000" + DEFA_ETH.slice(2).toLowerCase();
 
 // Stellar / ZigChain / Starknet — one Dune query for all Dune-backed chains.
+//
+// Fallback reference (in case Dune is ever unavailable): each chain's cumulative "raised"
+// comes from an on-chain TVL logger contract that our snapshotter reads daily into Dune.
+// The raw on-chain values can be read directly from these, no Dune needed:
+//   Stellar (Soroban) : CDVVH3KWXWLVUO5OLLBBZSCZICV46PDKYA2G2HYBTWH4A6EJWTBRIXRK
+//                       fn get_tvl() -> raised_in_overall_pools, 7 decimals
+//   ZigChain (CosmWasm): zig19pp9rxhqktgpf2yqkwwx6yekmgvnu3hvj0c4e5rlpw88l0shh3qs9qcdyg
+//                       query {tvl:{}} -> raised_in_overall_pools, 6 decimals
+//   Starknet (Cairo)  : 0x0595a45952ef488d49342cd4fdf062482ab51c0718fcd8c11ff6614034b0939d
+//                       fn get_tvl_snapshot() -> total_deposited (1st field), 6 decimals
 const prefetch = async (options: FetchOptions) => {
   // Dune needs DUNE_API_KEYS, absent in fork-PR CI; skip there so the test doesn't
   // false-fail (production always has the key). Logged so it's not silent.

--- a/dexs/defa/index.ts
+++ b/dexs/defa/index.ts
@@ -11,32 +11,41 @@ import { queryDuneSql } from "../../helpers/dune";
 // First tracked day has no prior row, so it reports the full cumulative-to-date, making
 // the accumulated total equal actual total raised.
 
-const fetch = async (options: FetchOptions) => {
-  const dailyVolume = options.createBalances();
+const prefetch = async (options: FetchOptions) => {
   const query = `
     WITH daily AS (
-      SELECT date, MAX(raised_usd) AS raised_usd            -- dedup re-runs: latest per day
+      SELECT chain, date, MAX(raised_usd) AS raised_usd     -- dedup re-runs: latest per day
       FROM dune.defa_im.raised_daily
-      WHERE chain = '${options.chain}'
-      GROUP BY date
+      GROUP BY chain, date
     ),
     delta AS (
-      SELECT date,
-             COALESCE(raised_usd - LAG(raised_usd) OVER (ORDER BY date), raised_usd) AS daily_raised
+      SELECT chain, date,
+             COALESCE(raised_usd - LAG(raised_usd) OVER (PARTITION BY chain ORDER BY date), raised_usd) AS daily_raised
       FROM daily
     )
-    SELECT COALESCE(SUM(daily_raised), 0) AS daily_raised
+    SELECT chain, COALESCE(SUM(daily_raised), 0) AS daily_raised
     FROM delta
     -- 'date' is a unix-seconds bigint (not a SQL DATE), so compare directly to the unix bounds
     WHERE date >= ${options.startTimestamp} AND date < ${options.endTimestamp}
+    GROUP BY chain
   `;
-  const rows: { daily_raised: number }[] = await queryDuneSql(options, query);
-  dailyVolume.addUSDValue(Number(rows?.[0]?.daily_raised || 0));
+  return queryDuneSql(options, query);
+};
+
+const fetch = async (options: FetchOptions) => {
+  const dailyVolume = options.createBalances();
+  const rows: { chain: string; daily_raised: number }[] = options.preFetchedResults || [];
+  const row = rows.find((r) => r.chain === options.chain);
+  if(!row) {
+    throw new Error(`No row found for chain ${options.chain}`);
+  }
+  dailyVolume.addUSDValue(Number(row.daily_raised));
   return { dailyVolume };
 };
 
 const adapter: SimpleAdapter = {
   version: 1,
+  prefetch,
   fetch,
   chains: [CHAIN.ETHEREUM, CHAIN.STELLAR, CHAIN.STARKNET, "zigchain"],
   start: "2026-07-04",

--- a/dexs/defa/index.ts
+++ b/dexs/defa/index.ts
@@ -12,6 +12,9 @@ import { queryDuneSql } from "../../helpers/dune";
 // the accumulated total equal actual total raised.
 
 const prefetch = async (options: FetchOptions) => {
+  // Dune needs DUNE_API_KEYS, which fork-PR CI doesn't provide; skip there so the
+  // test doesn't false-fail (production always has the key).
+  if (!process.env.DUNE_API_KEYS) return [];
   const query = `
     WITH daily AS (
       SELECT chain, date, MAX(raised_usd) AS raised_usd     -- dedup re-runs: latest per day
@@ -36,7 +39,8 @@ const fetch = async (options: FetchOptions) => {
   const dailyVolume = options.createBalances();
   const rows: { chain: string; daily_raised: number }[] = options.preFetchedResults || [];
   const row = rows.find((r) => r.chain === options.chain);
-  if(!row) {
+  if (!row) {
+    if (!process.env.DUNE_API_KEYS) return { dailyVolume }; // no Dune key in fork CI → skip
     throw new Error(`No row found for chain ${options.chain}`);
   }
   dailyVolume.addUSDValue(Number(row.daily_raised));
@@ -53,7 +57,7 @@ const adapter: SimpleAdapter = {
   isExpensiveAdapter: true,
   methodology: {
     Volume:
-      "Daily USDC inflow (capital deployed) into DeFa's real-world-credit pools: invoice financing on Stellar, ZigChain and Starknet (from on-chain TVL loggers), plus PSP/PayFi lending on Ethereum (USDC inflow into the DeFa Safe). Snapshotted daily to Dune (dune.defa_im.raised_daily) and reported as the day-over-day increase in cumulative inflow; the accumulated total equals total capital deployed and is monotonic (never decreases).",
+      "Daily USDC inflow (capital deployed) into DeFa's real-world-credit pools: invoice financing on Stellar, ZigChain and Starknet (from on-chain TVL loggers), plus PSP/PayFi lending on Ethereum (USDC inflow into the DeFa PayFi layer). Snapshotted daily to Dune (dune.defa_im.raised_daily) and reported as the day-over-day increase in cumulative inflow; the accumulated total equals total capital deployed and is monotonic (never decreases).",
   },
 };
 

--- a/dexs/defa/index.ts
+++ b/dexs/defa/index.ts
@@ -13,8 +13,11 @@ import { queryDuneSql } from "../../helpers/dune";
 
 const prefetch = async (options: FetchOptions) => {
   // Dune needs DUNE_API_KEYS, which fork-PR CI doesn't provide; skip there so the
-  // test doesn't false-fail (production always has the key).
-  if (!process.env.DUNE_API_KEYS) return [];
+  // test doesn't false-fail (production always has the key). Logged so it's not silent.
+  if (!process.env.DUNE_API_KEYS) {
+    console.error("DeFa volume: DUNE_API_KEYS not set — skipping Dune query (expected only in fork-PR CI; production has the key)");
+    return [];
+  }
   const query = `
     WITH daily AS (
       SELECT chain, date, MAX(raised_usd) AS raised_usd     -- dedup re-runs: latest per day

--- a/dexs/defa/index.ts
+++ b/dexs/defa/index.ts
@@ -27,6 +27,7 @@ const fetch = async (options: FetchOptions) => {
     )
     SELECT COALESCE(SUM(daily_raised), 0) AS daily_raised
     FROM delta
+    -- 'date' is a unix-seconds bigint (not a SQL DATE), so compare directly to the unix bounds
     WHERE date >= ${options.startTimestamp} AND date < ${options.endTimestamp}
   `;
   const rows: { daily_raised: number }[] = await queryDuneSql(options, query);

--- a/dexs/defa/index.ts
+++ b/dexs/defa/index.ts
@@ -2,18 +2,27 @@ import { CHAIN } from "../../helpers/chains";
 import { Dependencies, FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { queryDuneSql } from "../../helpers/dune";
 
-// DeFa — daily USDC inflow (capital raised) into invoice-backed real-world-credit pools.
-// The on-chain TVL loggers expose a cumulative "raised" figure per chain; a daily job
-// snapshots them into Dune (dune.defa_im.raised_daily: date, chain, raised_usd).
-// Here we take the day-over-day increase = that day's inflow. DefiLlama accumulates it
-// into cumulative volume, which is monotonic (never decreases) — the "total raised".
+// DeFa — daily USDC inflow (capital deployed) into DeFa's real-world-credit pools.
 //
-// First tracked day has no prior row, so it reports the full cumulative-to-date, making
-// the accumulated total equal actual total raised.
+// - Invoice financing on Stellar / ZigChain / Starknet: the on-chain TVL loggers expose a
+//   cumulative "raised" figure. Stellar/Soroban RPC can't serve historical state, so these
+//   are snapshotted daily into Dune (dune.defa_im.raised_daily) and we take the day-over-day
+//   increase. (Requested by maintainer: Dune only for the chains where historical is hard.)
+// - PSP/PayFi lending on Ethereum: read on-chain directly — USDC Transfer logs into the
+//   DeFa PayFi address = that day's inflow. No Dune dependency.
+//
+// DefiLlama accumulates the dailies into cumulative volume (monotonic).
 
+const DEFA_ETH = "0x182D16434faa044B9216A490CF0955B04AE16904";
+const USDC = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48";
+const TRANSFER = "event Transfer(address indexed from, address indexed to, uint256 value)";
+const TRANSFER_TOPIC = "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef";
+const toTopic = "0x000000000000000000000000" + DEFA_ETH.slice(2).toLowerCase();
+
+// Stellar / ZigChain / Starknet — one Dune query for all Dune-backed chains.
 const prefetch = async (options: FetchOptions) => {
-  // Dune needs DUNE_API_KEYS, which fork-PR CI doesn't provide; skip there so the
-  // test doesn't false-fail (production always has the key). Logged so it's not silent.
+  // Dune needs DUNE_API_KEYS, absent in fork-PR CI; skip there so the test doesn't
+  // false-fail (production always has the key). Logged so it's not silent.
   if (!process.env.DUNE_API_KEYS) {
     console.error("DeFa volume: DUNE_API_KEYS not set — skipping Dune query (expected only in fork-PR CI; production has the key)");
     return [];
@@ -22,6 +31,7 @@ const prefetch = async (options: FetchOptions) => {
     WITH daily AS (
       SELECT chain, date, MAX(raised_usd) AS raised_usd     -- dedup re-runs: latest per day
       FROM dune.defa_im.raised_daily
+      WHERE chain != 'ethereum'                             -- Ethereum is read on-chain below
       GROUP BY chain, date
     ),
     delta AS (
@@ -40,6 +50,19 @@ const prefetch = async (options: FetchOptions) => {
 
 const fetch = async (options: FetchOptions) => {
   const dailyVolume = options.createBalances();
+
+  // Ethereum (PSP/PayFi): daily USDC inflow from on-chain Transfer logs into the DeFa address.
+  if (options.chain === CHAIN.ETHEREUM) {
+    const logs = await options.getLogs({
+      target: USDC,
+      eventAbi: TRANSFER,
+      topics: [TRANSFER_TOPIC, null as any, toTopic],
+    });
+    for (const log of logs) dailyVolume.add(USDC, log.value);
+    return { dailyVolume };
+  }
+
+  // Stellar / ZigChain / Starknet: from the daily Dune snapshot (prefetched).
   const rows: { chain: string; daily_raised: number }[] = options.preFetchedResults || [];
   const row = rows.find((r) => r.chain === options.chain);
   if (!row) {
@@ -50,17 +73,22 @@ const fetch = async (options: FetchOptions) => {
   return { dailyVolume };
 };
 
+const methodology = {
+  Volume:
+    "Daily USDC inflow into DeFa's real-world-credit pools. Invoice financing on Stellar, ZigChain and Starknet: from the on-chain TVL loggers (snapshotted daily to Dune, day-over-day delta). PSP/PayFi lending on Ethereum: USDC Transfer logs into the DeFa PayFi address, read on-chain. DefiLlama accumulates into cumulative volume (monotonic).",
+};
+
 const adapter: SimpleAdapter = {
   version: 1,
   prefetch,
-  fetch,
-  chains: [CHAIN.ETHEREUM, CHAIN.STELLAR, CHAIN.STARKNET, "zigchain"],
-  start: "2026-07-04",
   dependencies: [Dependencies.DUNE],
   isExpensiveAdapter: true,
-  methodology: {
-    Volume:
-      "Daily USDC inflow (capital deployed) into DeFa's real-world-credit pools: invoice financing on Stellar, ZigChain and Starknet (from on-chain TVL loggers), plus PSP/PayFi lending on Ethereum (USDC inflow into the DeFa PayFi layer). Snapshotted daily to Dune (dune.defa_im.raised_daily) and reported as the day-over-day increase in cumulative inflow; the accumulated total equals total capital deployed and is monotonic (never decreases).",
+  methodology,
+  adapter: {
+    [CHAIN.ETHEREUM]: { fetch, start: "2026-04-11" }, // first PSP inflow — backfills full history
+    [CHAIN.STELLAR]: { fetch, start: "2026-07-04" },
+    [CHAIN.STARKNET]: { fetch, start: "2026-07-04" },
+    zigchain: { fetch, start: "2026-07-04" },
   },
 };
 

--- a/dexs/defa/index.ts
+++ b/dexs/defa/index.ts
@@ -1,7 +1,8 @@
 import { CHAIN } from "../../helpers/chains";
 import { Dependencies, FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { queryDuneSql } from "../../helpers/dune";
-
+import { addTokensReceived } from "../../helpers/token";
+import ADDRESSES from "../../helpers/coreAssets.json";
 // DeFa — daily USDC inflow (capital deployed) into DeFa's real-world-credit pools.
 //
 // - Invoice financing on Stellar / ZigChain / Starknet: the on-chain TVL loggers expose a
@@ -14,10 +15,6 @@ import { queryDuneSql } from "../../helpers/dune";
 // DefiLlama accumulates the dailies into cumulative volume (monotonic).
 
 const DEFA_ETH = "0x182D16434faa044B9216A490CF0955B04AE16904";
-const USDC = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48";
-const TRANSFER = "event Transfer(address indexed from, address indexed to, uint256 value)";
-const TRANSFER_TOPIC = "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef";
-const toTopic = "0x000000000000000000000000" + DEFA_ETH.slice(2).toLowerCase();
 
 // Stellar / ZigChain / Starknet — one Dune query for all Dune-backed chains.
 //
@@ -31,12 +28,6 @@ const toTopic = "0x000000000000000000000000" + DEFA_ETH.slice(2).toLowerCase();
 //   Starknet (Cairo)  : 0x0595a45952ef488d49342cd4fdf062482ab51c0718fcd8c11ff6614034b0939d
 //                       fn get_tvl_snapshot() -> total_deposited (1st field), 6 decimals
 const prefetch = async (options: FetchOptions) => {
-  // Dune needs DUNE_API_KEYS, absent in fork-PR CI; skip there so the test doesn't
-  // false-fail (production always has the key). Logged so it's not silent.
-  if (!process.env.DUNE_API_KEYS) {
-    console.error("DeFa volume: DUNE_API_KEYS not set — skipping Dune query (expected only in fork-PR CI; production has the key)");
-    return [];
-  }
   const query = `
     WITH daily AS (
       SELECT chain, date, MAX(raised_usd) AS raised_usd     -- dedup re-runs: latest per day
@@ -63,12 +54,12 @@ const fetch = async (options: FetchOptions) => {
 
   // Ethereum (PSP/PayFi): daily USDC inflow from on-chain Transfer logs into the DeFa address.
   if (options.chain === CHAIN.ETHEREUM) {
-    const logs = await options.getLogs({
-      target: USDC,
-      eventAbi: TRANSFER,
-      topics: [TRANSFER_TOPIC, null as any, toTopic],
+    await addTokensReceived({
+      target: DEFA_ETH,
+      options,
+      token: ADDRESSES[CHAIN.ETHEREUM].USDC,
+      balances: dailyVolume,
     });
-    for (const log of logs) dailyVolume.add(USDC, log.value);
     return { dailyVolume };
   }
 
@@ -93,11 +84,12 @@ const adapter: SimpleAdapter = {
   dependencies: [Dependencies.DUNE],
   isExpensiveAdapter: true,
   methodology,
+  fetch,
   adapter: {
-    [CHAIN.ETHEREUM]: { fetch, start: "2026-04-11" }, // first PSP inflow — backfills full history
-    [CHAIN.STELLAR]: { fetch, start: "2026-07-04" },
-    [CHAIN.STARKNET]: { fetch, start: "2026-07-04" },
-    zigchain: { fetch, start: "2026-07-04" },
+    [CHAIN.ETHEREUM]: { start: "2026-04-11" }, // first PSP inflow — backfills full history
+    [CHAIN.STELLAR]: { start: "2026-07-04" },
+    [CHAIN.STARKNET]: { start: "2026-07-04" },
+    zigchain: { start: "2026-07-04" },
   },
 };
 

--- a/dexs/defa/index.ts
+++ b/dexs/defa/index.ts
@@ -63,13 +63,12 @@ const fetch = async (options: FetchOptions) => {
   }
 
   // Stellar / ZigChain / Starknet: from the daily Dune snapshot (prefetched).
+  // A day with no snapshot row = no recorded inflow that day = 0 volume (not an error).
+  // The delta is a LAG over whichever days exist, so a later snapshot still captures any
+  // inflow from a skipped day — cumulative volume stays correct with no gaps in the series.
   const rows: { chain: string; daily_raised: number }[] = options.preFetchedResults || [];
   const row = rows.find((r) => r.chain === options.chain);
-  if (!row) {
-    if (!process.env.DUNE_API_KEYS) return { dailyVolume }; // no Dune key in fork CI → skip
-    throw new Error(`No row found for chain ${options.chain}`);
-  }
-  dailyVolume.addUSDValue(Number(row.daily_raised));
+  if (row) dailyVolume.addUSDValue(Number(row.daily_raised));
   return { dailyVolume };
 };
 


### PR DESCRIPTION
Adds a volume adapter for **DeFa** — same protocol as the already-merged TVL adapter (`projects/defa` in DefiLlama-Adapters, PR #19885).

**What it tracks:** daily USDC inflow (capital raised) into DeFa's invoice-backed real-world-credit pools across **Stellar, ZigChain, and Starknet**.

**Methodology:** DeFa's on-chain TVL logger on each chain exposes a cumulative "raised" figure. A daily job snapshots those into Dune (`dune.defa_im.raised_daily`: date, chain, raised_usd). The adapter reports the **day-over-day increase** as daily volume; DefiLlama accumulates it into cumulative volume (monotonic — equals total capital raised). First tracked day reports the full cumulative-to-date so the accumulated total matches actual total raised.

**Dune test run** (query id 3996608):
```
chain     | daily volume
stellar   | 4.02 M
starknet  | 1.08 M
zigchain  | 2.10 M
aggregate | 7.19 M
```

Website: https://www.invoicemate.net · DefiLlama: https://defillama.com/protocol/defa
Version 1 (Dune-backed). Runs once/day.