### PR TITLE
[add] Catapult Trade - synthetic trading volume, fees, and revenue adapter

### DIFF
--- a/dexs/catapult.ts
+++ b/dexs/catapult.ts
@@ -1,12 +1,15 @@
-// DefiLlama dimension adapter for Catapult — a perps/futures trading venue.
+// DefiLlama dimension adapter for Catapult Trade — a gamified synthetic-trading app. Its live product,
+// Turbo Mode, is synthetic (derivatives) trading; a planned Hyper Mode adds an omnichain aggregator
+// terminal and a token launcher. This adapter reports the live Turbo Mode trading activity.
 // ***This file lives in DefiLlama's dimension-adapters repo (dexs/catapult.ts), not ours.*** It is
 // kept here as the canonical, version-controlled source we submit via PR. It is intentionally OUTSIDE
 // src/ so our own tsc build ignores it (the imports resolve against DefiLlama's repo, not this one).
 //
 // Volume, fees and revenue are reported by Catapult via a public metrics API that returns the full
 // daily series in USD (one point per UTC day). Only final aggregates leave our server — the SQL, raw
-// rows and modelling stay private. Catapult is a centralized venue, so there is no on-chain contract
-// to read TVL from (no TVL), and no open-interest feed. Modelled on kalshi.ts (a fellow off-chain venue).
+// rows and modelling stay private. It's an off-chain synthetic-trading app, so there is no on-chain
+// contract to read TVL from (no TVL) and no open-interest feed. Modelled on kalshi.ts (a fellow
+// off-chain venue).
 import { FetchOptions, SimpleAdapter } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
 import fetchURL from "../utils/fetchURL";
@@ -38,7 +41,7 @@ const adapter: SimpleAdapter = {
   chains: [CHAIN.OFF_CHAIN],
   start: "2025-08-28",
   methodology: {
-    Volume: "Notional trading volume (perps + spot) settled on Catapult, reported daily in USD via Catapult's public metrics API.",
+    Volume: "Notional volume of synthetic trades (Turbo Mode) on Catapult Trade, reported daily in USD via Catapult's public metrics API.",
     Fees: "All trading fees collected from users (open + close + profit fees), reported daily in USD.",
     Revenue: "Protocol revenue — trading fees retained by Catapult (equal to Fees).",
   },

--- a/dexs/catapult.ts
+++ b/dexs/catapult.ts
@@ -25,8 +25,19 @@ interface Metrics {
   revenue: DailyPoint[];
 }
 
+// The endpoint returns the FULL daily series, so a backfill would otherwise re-download it once per
+// day. Memoize the payload for a short window → one fetch serves a whole backfill run.
+let cache: { at: number; data: Metrics } | undefined;
+const CACHE_MS = 5 * 60 * 1000;
+async function getMetrics(): Promise<Metrics> {
+  if (cache && Date.now() - cache.at < CACHE_MS) return cache.data;
+  const data: Metrics = await fetchURL(METRICS_URL); // fetchURL returns the parsed JSON body
+  cache = { at: Date.now(), data };
+  return data;
+}
+
 const fetch = async (options: FetchOptions) => {
-  const metrics: Metrics = await fetchURL(METRICS_URL); // fetchURL returns the parsed JSON body
+  const metrics = await getMetrics();
   const day = new Date(options.startOfDay * 1000).toISOString().slice(0, 10); // the UTC day being queried
   const valueOn = (series: DailyPoint[]) => series.find((p) => p.date === day)?.value ?? 0;
   return {

--- a/dexs/catapult.ts
+++ b/dexs/catapult.ts
@@ -23,7 +23,7 @@ interface Metrics {
 }
 
 const fetch = async (options: FetchOptions) => {
-  const metrics: Metrics = (await fetchURL(METRICS_URL)).data;
+  const metrics: Metrics = await fetchURL(METRICS_URL); // fetchURL returns the parsed JSON body
   const day = new Date(options.startOfDay * 1000).toISOString().slice(0, 10); // the UTC day being queried
   const valueOn = (series: DailyPoint[]) => series.find((p) => p.date === day)?.value ?? 0;
   return {

--- a/dexs/catapult.ts
+++ b/dexs/catapult.ts
@@ -36,10 +36,15 @@ async function getMetrics(): Promise<Metrics> {
   return data;
 }
 
-const fetch = async (options: FetchOptions) => {
+const fetch = async ({ dateString }: FetchOptions) => {
   const metrics = await getMetrics();
-  const day = new Date(options.startOfDay * 1000).toISOString().slice(0, 10); // the UTC day being queried
-  const valueOn = (series: DailyPoint[]) => series.find((p) => p.date === day)?.value ?? 0;
+  // Use the precomputed UTC day; throw (don't fall back to 0) when a day is absent, so the infra
+  // marks it missing instead of persisting a wrong zero into the historical chart.
+  const valueOn = (series: DailyPoint[]) => {
+    const point = series.find((p) => p.date === dateString);
+    if (!point) throw new Error(`No Catapult metrics data for ${dateString}`);
+    return point.value;
+  };
   return {
     dailyVolume: valueOn(metrics.volume),
     dailyFees: valueOn(metrics.fees),

--- a/dexs/catapult.ts
+++ b/dexs/catapult.ts
@@ -1,15 +1,3 @@
-// DefiLlama dimension adapter for Catapult Trade — a gamified synthetic-trading app. Its live product,
-// Turbo Mode, is synthetic (derivatives) trading; a planned Hyper Mode adds an omnichain aggregator
-// terminal and a token launcher. This adapter reports the live Turbo Mode trading activity.
-// ***This file lives in DefiLlama's dimension-adapters repo (dexs/catapult.ts), not ours.*** It is
-// kept here as the canonical, version-controlled source we submit via PR. It is intentionally OUTSIDE
-// src/ so our own tsc build ignores it (the imports resolve against DefiLlama's repo, not this one).
-//
-// Volume, fees and revenue are reported by Catapult via a public metrics API that returns the full
-// daily series in USD (one point per UTC day). Only final aggregates leave our server — the SQL, raw
-// rows and modelling stay private. It's an off-chain synthetic-trading app, so there is no on-chain
-// contract to read TVL from (no TVL) and no open-interest feed. Modelled on kalshi.ts (a fellow
-// off-chain venue).
 import { FetchOptions, SimpleAdapter } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
 import fetchURL from "../utils/fetchURL";
@@ -25,19 +13,8 @@ interface Metrics {
   revenue: DailyPoint[];
 }
 
-// The endpoint returns the FULL daily series, so a backfill would otherwise re-download it once per
-// day. Memoize the payload for a short window → one fetch serves a whole backfill run.
-let cache: { at: number; data: Metrics } | undefined;
-const CACHE_MS = 5 * 60 * 1000;
-async function getMetrics(): Promise<Metrics> {
-  if (cache && Date.now() - cache.at < CACHE_MS) return cache.data;
-  const data: Metrics = await fetchURL(METRICS_URL); // fetchURL returns the parsed JSON body
-  cache = { at: Date.now(), data };
-  return data;
-}
-
 const fetch = async ({ dateString }: FetchOptions) => {
-  const metrics = await getMetrics();
+  const metrics: Metrics = await fetchURL(METRICS_URL);
   // Use the precomputed UTC day; throw (don't fall back to 0) when a day is absent, so the infra
   // marks it missing instead of persisting a wrong zero into the historical chart.
   const valueOn = (series: DailyPoint[]) => {
@@ -45,10 +22,12 @@ const fetch = async ({ dateString }: FetchOptions) => {
     if (!point) throw new Error(`No Catapult metrics data for ${dateString}`);
     return point.value;
   };
+
   return {
     dailyVolume: valueOn(metrics.volume),
     dailyFees: valueOn(metrics.fees),
     dailyRevenue: valueOn(metrics.revenue),
+    dailyProtocolRevenue: valueOn(metrics.revenue),
   };
 };
 
@@ -58,8 +37,9 @@ const adapter: SimpleAdapter = {
   start: "2025-08-28",
   methodology: {
     Volume: "Notional volume of synthetic trades (Turbo Mode) on Catapult Trade, reported daily in USD via Catapult's public metrics API.",
-    Fees: "All trading fees collected from users (open + close + profit fees), reported daily in USD.",
-    Revenue: "Protocol revenue — trading fees retained by Catapult (equal to Fees).",
+    Fees: "All trading fees collected from users (open + close + profit fees), reported daily in USD via Catapult's public metrics API.",
+    Revenue: "All trading fees collected from users (open + close + profit fees), are retained by Catapult.",
+    ProtocolRevenue: "All trading fees collected from users (open + close + profit fees), are retained by Catapult.",
   },
 };
 

--- a/dexs/catapult.ts
+++ b/dexs/catapult.ts
@@ -1,0 +1,47 @@
+// DefiLlama dimension adapter for Catapult — a perps/futures trading venue.
+// ***This file lives in DefiLlama's dimension-adapters repo (dexs/catapult.ts), not ours.*** It is
+// kept here as the canonical, version-controlled source we submit via PR. It is intentionally OUTSIDE
+// src/ so our own tsc build ignores it (the imports resolve against DefiLlama's repo, not this one).
+//
+// Volume, fees and revenue are reported by Catapult via a public metrics API that returns the full
+// daily series in USD (one point per UTC day). Only final aggregates leave our server — the SQL, raw
+// rows and modelling stay private. Catapult is a centralized venue, so there is no on-chain contract
+// to read TVL from (no TVL), and no open-interest feed. Modelled on kalshi.ts (a fellow off-chain venue).
+import { FetchOptions, SimpleAdapter } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+import fetchURL from "../utils/fetchURL";
+
+const METRICS_URL = "https://cmtbsmcpbot.catapult.ink/defillama/metrics";
+
+interface DailyPoint { date: string; value: number }
+interface Metrics {
+  asOf: string;
+  unit: string; // "USD"
+  volume: DailyPoint[];
+  fees: DailyPoint[];
+  revenue: DailyPoint[];
+}
+
+const fetch = async (options: FetchOptions) => {
+  const metrics: Metrics = (await fetchURL(METRICS_URL)).data;
+  const day = new Date(options.startOfDay * 1000).toISOString().slice(0, 10); // the UTC day being queried
+  const valueOn = (series: DailyPoint[]) => series.find((p) => p.date === day)?.value ?? 0;
+  return {
+    dailyVolume: valueOn(metrics.volume),
+    dailyFees: valueOn(metrics.fees),
+    dailyRevenue: valueOn(metrics.revenue),
+  };
+};
+
+const adapter: SimpleAdapter = {
+  fetch,
+  chains: [CHAIN.OFF_CHAIN],
+  start: "2025-08-28",
+  methodology: {
+    Volume: "Notional trading volume (perps + spot) settled on Catapult, reported daily in USD via Catapult's public metrics API.",
+    Fees: "All trading fees collected from users (open + close + profit fees), reported daily in USD.",
+    Revenue: "Protocol revenue — trading fees retained by Catapult (equal to Fees).",
+  },
+};
+
+export default adapter;


### PR DESCRIPTION
Dimension adapter (volume / fees / revenue) for **Catapult Trade** — a gamified synthetic-trading app. Its live product, **Turbo Mode**, is synthetic (derivatives) trading; a planned **Hyper Mode** will add an omnichain aggregator terminal and a token launcher. This adapter reports the live Turbo Mode activity, pulled from Catapult's public metrics API (`https://cmtbsmcpbot.catapult.ink/defillama/metrics`) and modelled on `dexs/kalshi.ts` (`CHAIN.OFF_CHAIN`). "Allow edits by maintainers" is enabled.

This is a **dimension adapter, not a TVL adapter** — Catapult is an off-chain app with no on-chain contract, so there is no TVL and no open interest.

---

##### Name (to be shown on DefiLlama):
Catapult Trade

##### Twitter Link:
https://x.com/letsCatapult

##### List of audit links if any:
None

##### Website Link:
https://catapult.trade

##### Logo (High resolution, will be shown with rounded borders):
https://cmtbsmcpbot.catapult.ink/defillama/logo.png

##### Current TVL:
N/A — off-chain synthetic-trading app, no on-chain TVL

##### Treasury Addresses (if the protocol has treasury):
N/A

##### Chain:
Off-chain (`CHAIN.OFF_CHAIN`)

##### Coingecko ID:
_(none)_

##### Coinmarketcap ID:
_(none)_

##### Short Description (to be shown on DefiLlama):
A gamified synthetic-trading app. Turbo Mode (live) is synthetic derivatives trading; a planned Hyper Mode adds an omnichain aggregator terminal and a token launcher.

##### Token address and ticker if any:
No token live yet. A token (**$PULT**) is planned; not yet on Coingecko/Coinmarketcap.

##### Category (full list at https://defillama.com/categories) *Please choose only one:
Synthetics

##### Oracle Provider(s):
N/A

##### forkedFrom:
No

##### methodology (what is being counted):
Reported daily in USD, one point per UTC day, via Catapult's public metrics API.
- **dailyVolume** — notional volume of synthetic trades (Turbo Mode).
- **dailyFees** — all trading fees collected from users (open + close + profit fees).
- **dailyRevenue** — protocol revenue = fees retained by Catapult (equals fees).

##### Github org/user (Optional):
Catapult-Org

##### Does this project have a referral program?
No
