### PR TITLE
kittenswap: revenue distribution

### DIFF
--- a/dexs/kittenswap-cl/index.ts
+++ b/dexs/kittenswap-cl/index.ts
@@ -118,7 +118,21 @@ const fetch = async (options: FetchOptions): Promise<FetchResult> => {
   return {
     dailyVolume,
     dailyFees,
+    dailyUserFees: dailyFees,
+    dailyRevenue: dailyFees,
+    dailyHoldersRevenue: dailyFees,
+    dailyProtocolRevenue: 0,
+    dailySupplySideRevenue: 0,
   };
+};
+
+const methodology = {
+  Fees: "All swap fees paid by traders across kittenswap concentrated-liquidity pools.",
+  UserFees: "All swap fees paid by traders.",
+  Revenue: "100% of swap fees — the protocol retains the full fee to redistribute to voters.",
+  ProtocolRevenue: "Zero. Under ve(3,3) the treasury takes no cut of swap fees.",
+  HoldersRevenue: "100% of swap fees are distributed weekly to veKITTEN voters/holders.",
+  SupplySideRevenue: "Zero. Liquidity providers are rewarded with KITTEN emissions (incentives), not swap fees.",
 };
 
 const adapters: SimpleAdapter = {
@@ -126,5 +140,6 @@ const adapters: SimpleAdapter = {
   fetch,
   chains: [CHAIN.HYPERLIQUID],
   start: "2025-04-04",
+  methodology,
 };
 export default adapters;

--- a/dexs/kittenswap/index.ts
+++ b/dexs/kittenswap/index.ts
@@ -134,7 +134,24 @@ const fetch = async (options: FetchOptions): Promise<FetchResult> => {
 
   if (errorFound) throw errorFound;
 
-  return { dailyVolume, dailyFees };
+  return {
+    dailyVolume,
+    dailyFees,
+    dailyUserFees: dailyFees,
+    dailyRevenue: dailyFees,
+    dailyHoldersRevenue: dailyFees,
+    dailyProtocolRevenue: 0,
+    dailySupplySideRevenue: 0,
+  };
+};
+
+const methodology = {
+  Fees: "All swap fees paid by traders across kittenswap pools.",
+  UserFees: "All swap fees paid by traders.",
+  Revenue: "100% of swap fees — the protocol retains the full fee to redistribute to voters.",
+  ProtocolRevenue: "Zero. Under ve(3,3) the treasury takes no cut of swap fees.",
+  HoldersRevenue: "100% of swap fees are distributed weekly to veKITTEN voters/holders.",
+  SupplySideRevenue: "Zero. Liquidity providers are rewarded with KITTEN emissions (incentives), not swap fees.",
 };
 
 const adapters: SimpleAdapter = {
@@ -142,6 +159,7 @@ const adapters: SimpleAdapter = {
   fetch,
   chains: [CHAIN.HYPERLIQUID],
   start: "2025-02-18",
+  methodology,
 };
 
 export default adapters;


### PR DESCRIPTION
* **KittenSwap / KittenSwap CL** uses a **ve(3,3)** model where **100% of swap fees go to veKITTEN holders**. Previously, fees were only reported as `dailyFees`.

* Updated mapping:

  * `dailyFees` → `dailyUserFees`, `dailyRevenue`, `dailyHoldersRevenue`
  * `dailyProtocolRevenue = 0`
  * `dailySupplySideRevenue = 0`

* Added a `methodology` note explaining the ve(3,3) fee distribution.
