### PR TITLE
[feat] Rooster Protocol V2 - add on-chain fees/revenue adapter

### DIFF
--- a/dexs/rooster-v2/index.ts
+++ b/dexs/rooster-v2/index.ts
@@ -1,0 +1,110 @@
+// Rooster Protocol V2 - Algebra Integral concentrated-liquidity DEX on Plume.
+// Volume, fees and revenue are computed fully on-chain from pool events:
+//  - Every swap emits `Swap(...amount0, amount1...)` (token deltas -> volume) and,
+//    in the same tx immediately before it, `SwapFee(sender, overrideFee, pluginFee)`
+//    where `overrideFee` is the exact dynamic fee applied to that swap (units 1e-6).
+//  - The Algebra fee is charged on the input amount, so for every swap
+//    feeAmount(inputToken) = inputDelta * feeRate / 1e6  (exact for exact-in and exact-out).
+//  - The protocol's cut is the pool `communityFee` (units 1e-3), read on-chain from
+//    `globalState()`; the remainder accrues to LPs.
+import { FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+
+const FACTORY = "0x1eB9822d5176C88B1d4eec353fa956C896D77Df9";
+const FACTORY_FROM_BLOCK = 23181592; // block of the first pool creation on Plume
+const FEE_DENOMINATOR = 1e6; // Algebra Constants.FEE_DENOMINATOR (fee in hundredths of a bip)
+const COMMUNITY_FEE_DENOMINATOR = 1e3; // Algebra Constants.COMMUNITY_FEE_DENOMINATOR (communityFee in thousandths)
+
+const POOL_CREATED = "event Pool(address indexed token0, address indexed token1, address pool)";
+const CUSTOM_POOL_CREATED = "event CustomPool(address indexed deployer, address indexed token0, address indexed token1, address pool)";
+const SWAP = "event Swap(address indexed sender, address indexed recipient, int256 amount0, int256 amount1, uint160 price, uint128 liquidity, int24 tick)";
+const SWAP_FEE = "event SwapFee(address indexed sender, uint24 overrideFee, uint24 pluginFee)";
+const GLOBAL_STATE = "function globalState() view returns (uint160 price, int24 tick, uint16 lastFee, uint8 pluginConfig, uint16 communityFee, bool unlocked)";
+
+const fetch = async (options: FetchOptions) => {
+  const dailyVolume = options.createBalances();
+  const dailyFees = options.createBalances();
+  const dailyRevenue = options.createBalances(); // protocol revenue (community fee)
+  const dailySupplySideRevenue = options.createBalances(); // LP share
+
+  // 1. Discover all pools (standard + custom) from the factory
+  const [poolLogs, customPoolLogs] = await Promise.all([
+    options.getLogs({ target: FACTORY, fromBlock: FACTORY_FROM_BLOCK, eventAbi: POOL_CREATED, cacheInCloud: true }),
+    options.getLogs({ target: FACTORY, fromBlock: FACTORY_FROM_BLOCK, eventAbi: CUSTOM_POOL_CREATED, cacheInCloud: true }),
+  ]);
+  const pools: string[] = [...new Set([...poolLogs, ...customPoolLogs].map((log: any) => log.pool))];
+
+  // 2. Per-pool token0/token1 and community fee (protocol cut) + static-fee fallback
+  const [token0s, token1s, globalStates] = await Promise.all([
+    options.api.multiCall({ abi: "address:token0", calls: pools, permitFailure: true }),
+    options.api.multiCall({ abi: "address:token1", calls: pools, permitFailure: true }),
+    options.api.multiCall({ abi: GLOBAL_STATE, calls: pools, permitFailure: true }),
+  ]);
+
+  // 3. Per-pool Swap logs (volume) and SwapFee logs (per-swap fee rate), index-aligned 1:1
+  const [swapLogs, swapFeeLogs] = await Promise.all([
+    options.getLogs({ targets: pools, eventAbi: SWAP, flatten: false }),
+    options.getLogs({ targets: pools, eventAbi: SWAP_FEE, flatten: false }),
+  ]);
+
+  swapLogs.forEach((poolSwaps: any[], i: number) => {
+    if (!poolSwaps.length) return;
+    const token0 = token0s[i];
+    const token1 = token1s[i];
+    if (!token0 || !token1) return;
+    const gs = globalStates[i];
+    const communityFee = gs ? Number(gs.communityFee) : 0; // 0..1000
+    const staticFee = gs ? Number(gs.lastFee) : 0; // fallback for non-dynamic-fee pools
+    const poolSwapFees = swapFeeLogs[i] || [];
+
+    poolSwaps.forEach((swap: any, j: number) => {
+      const amount0 = BigInt(swap.amount0);
+      const amount1 = BigInt(swap.amount1);
+      // input side = the positive delta (tokens paid into the pool, fee included)
+      const zeroForOne = amount0 > 0n;
+      const inputToken = zeroForOne ? token0 : token1;
+      const inputAmount = zeroForOne ? amount0 : amount1; // positive
+
+      // fee rate: exact per-swap overrideFee when present, else the pool's static fee
+      const overrideFee = poolSwapFees[j] ? Number(poolSwapFees[j].overrideFee) : 0;
+      const feeRate = overrideFee > 0 ? overrideFee : staticFee;
+
+      const feeAmount = (inputAmount * BigInt(Math.round(feeRate))) / BigInt(FEE_DENOMINATOR);
+      const protocolAmount = (feeAmount * BigInt(communityFee)) / BigInt(COMMUNITY_FEE_DENOMINATOR);
+      const supplyAmount = feeAmount - protocolAmount;
+
+      dailyVolume.add(inputToken, inputAmount);
+      dailyFees.add(inputToken, feeAmount);
+      dailyRevenue.add(inputToken, protocolAmount);
+      dailySupplySideRevenue.add(inputToken, supplyAmount);
+    });
+  });
+
+  return {
+    dailyVolume,
+    dailyFees,
+    dailyUserFees: dailyFees, // all fees are paid by swappers
+    dailyRevenue,
+    dailyProtocolRevenue: dailyRevenue,
+    dailySupplySideRevenue,
+  };
+};
+
+const methodology = {
+  Volume: "Sum of the input amount of every swap across all Rooster V2 (Algebra Integral) pools on Plume, read from on-chain Swap events.",
+  Fees: "Total swap fees paid by traders, computed per swap as inputAmount * dynamicFee, using the exact per-swap fee from the pool's SwapFee event.",
+  UserFees: "Total swap fees paid by traders (same as Fees).",
+  Revenue: "Protocol's share of swap fees, i.e. each pool's communityFee applied to that pool's fees, read on-chain from globalState().",
+  ProtocolRevenue: "Protocol's share of swap fees (the communityFee that accrues to the protocol community vault).",
+  SupplySideRevenue: "Share of swap fees retained by liquidity providers (total fees minus the communityFee).",
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  fetch,
+  chains: [CHAIN.PLUME],
+  start: "2025-08-23",
+  methodology,
+};
+
+export default adapter;

--- a/dexs/rooster-v2/index.ts
+++ b/dexs/rooster-v2/index.ts
@@ -1,15 +1,19 @@
 // Rooster Protocol V2 - Algebra Integral concentrated-liquidity DEX on Plume.
 // Volume, fees and revenue are computed fully on-chain from pool events:
 //  - Every swap emits `Swap(...amount0, amount1...)` (token deltas -> volume) and,
-//    in the same tx immediately before it, `SwapFee(sender, overrideFee, pluginFee)`
-//    where `overrideFee` is the exact dynamic fee applied to that swap (units 1e-6).
-//  - The Algebra fee is charged on the input amount, so for every swap
-//    feeAmount(inputToken) = inputDelta * feeRate / 1e6  (exact for exact-in and exact-out).
-//  - The protocol's cut is the pool `communityFee` (units 1e-3), read on-chain from
-//    `globalState()`; the remainder accrues to LPs.
+//    in the same tx immediately before it, `SwapFee(sender, overrideFee, pluginFee)`.
+//    `overrideFee` is the exact dynamic swap fee (units 1e-6); `pluginFee` is an
+//    extra fee routed to the pool plugin (units 1e-6). Both are charged on the input,
+//    so for every swap feeAmount(inputToken) = inputDelta * feeRate / 1e6.
+//  - The protocol's cut of the swap fee is the pool `communityFee` (units 1e-3), read
+//    on-chain from `globalState()`; the remainder accrues to LPs. The plugin fee is
+//    protocol-side revenue in full.
 import { FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 
+// Rooster V2 AlgebraFactory on Plume mainnet (chainId 98866). Source: app.rooster.trade
+// on-chain config; verifiable on the Plume explorer at
+// https://explorer.plume.org/address/0x1eB9822d5176C88B1d4eec353fa956C896D77Df9
 const FACTORY = "0x1eB9822d5176C88B1d4eec353fa956C896D77Df9";
 const FACTORY_FROM_BLOCK = 23181592; // block of the first pool creation on Plume
 const FEE_DENOMINATOR = 1e6; // Algebra Constants.FEE_DENOMINATOR (fee in hundredths of a bip)
@@ -24,7 +28,7 @@ const GLOBAL_STATE = "function globalState() view returns (uint160 price, int24 
 const fetch = async (options: FetchOptions) => {
   const dailyVolume = options.createBalances();
   const dailyFees = options.createBalances();
-  const dailyRevenue = options.createBalances(); // protocol revenue (community fee)
+  const dailyRevenue = options.createBalances(); // protocol revenue (community fee + plugin fee)
   const dailySupplySideRevenue = options.createBalances(); // LP share
 
   // 1. Discover all pools (standard + custom) from the factory
@@ -34,28 +38,30 @@ const fetch = async (options: FetchOptions) => {
   ]);
   const pools: string[] = [...new Set([...poolLogs, ...customPoolLogs].map((log: any) => log.pool))];
 
-  // 2. Per-pool token0/token1 and community fee (protocol cut) + static-fee fallback
-  const [token0s, token1s, globalStates] = await Promise.all([
-    options.api.multiCall({ abi: "address:token0", calls: pools, permitFailure: true }),
-    options.api.multiCall({ abi: "address:token1", calls: pools, permitFailure: true }),
-    options.api.multiCall({ abi: GLOBAL_STATE, calls: pools, permitFailure: true }),
-  ]);
-
-  // 3. Per-pool Swap logs (volume) and SwapFee logs (per-swap fee rate), index-aligned 1:1
+  // 2. Per-pool Swap logs (volume) and SwapFee logs (per-swap fee rate), index-aligned 1:1 with `pools`
   const [swapLogs, swapFeeLogs] = await Promise.all([
     options.getLogs({ targets: pools, eventAbi: SWAP, flatten: false }),
     options.getLogs({ targets: pools, eventAbi: SWAP_FEE, flatten: false }),
   ]);
 
-  swapLogs.forEach((poolSwaps: any[], i: number) => {
-    if (!poolSwaps.length) return;
-    const token0 = token0s[i];
-    const token1 = token1s[i];
+  // 3. Only fetch token pair + fees for pools that traded in this window
+  const activeIndexes = swapLogs.map((logs: any[], i: number) => (logs.length ? i : -1)).filter((i: number) => i >= 0);
+  const activePools = activeIndexes.map((i: number) => pools[i]);
+  const [token0s, token1s, globalStates] = await Promise.all([
+    options.api.multiCall({ abi: "address:token0", calls: activePools, permitFailure: true }),
+    options.api.multiCall({ abi: "address:token1", calls: activePools, permitFailure: true }),
+    options.api.multiCall({ abi: GLOBAL_STATE, calls: activePools, permitFailure: true }),
+  ]);
+
+  activeIndexes.forEach((poolIndex: number, k: number) => {
+    const token0 = token0s[k];
+    const token1 = token1s[k];
     if (!token0 || !token1) return;
-    const gs = globalStates[i];
+    const gs = globalStates[k];
     const communityFee = gs ? Number(gs.communityFee) : 0; // 0..1000
-    const staticFee = gs ? Number(gs.lastFee) : 0; // fallback for non-dynamic-fee pools
-    const poolSwapFees = swapFeeLogs[i] || [];
+    const staticFee = gs ? Number(gs.lastFee) : 0; // fallback for pools without a dynamic fee
+    const poolSwaps = swapLogs[poolIndex];
+    const poolSwapFees = swapFeeLogs[poolIndex] || [];
 
     poolSwaps.forEach((swap: any, j: number) => {
       const amount0 = BigInt(swap.amount0);
@@ -65,16 +71,20 @@ const fetch = async (options: FetchOptions) => {
       const inputToken = zeroForOne ? token0 : token1;
       const inputAmount = zeroForOne ? amount0 : amount1; // positive
 
-      // fee rate: exact per-swap overrideFee when present, else the pool's static fee
-      const overrideFee = poolSwapFees[j] ? Number(poolSwapFees[j].overrideFee) : 0;
+      const swapFee = poolSwapFees[j];
+      // swap fee: exact per-swap overrideFee when present, else the pool's static fee
+      const overrideFee = swapFee ? Number(swapFee.overrideFee) : 0;
       const feeRate = overrideFee > 0 ? overrideFee : staticFee;
+      const pluginFee = swapFee ? Number(swapFee.pluginFee) : 0; // extra fee to the plugin
 
-      const feeAmount = (inputAmount * BigInt(Math.round(feeRate))) / BigInt(FEE_DENOMINATOR);
-      const protocolAmount = (feeAmount * BigInt(communityFee)) / BigInt(COMMUNITY_FEE_DENOMINATOR);
-      const supplyAmount = feeAmount - protocolAmount;
+      const swapFeeAmount = (inputAmount * BigInt(feeRate)) / BigInt(FEE_DENOMINATOR);
+      const pluginFeeAmount = (inputAmount * BigInt(pluginFee)) / BigInt(FEE_DENOMINATOR);
+      // protocol cut = communityFee share of the swap fee + the whole plugin fee
+      const protocolAmount = (swapFeeAmount * BigInt(communityFee)) / BigInt(COMMUNITY_FEE_DENOMINATOR) + pluginFeeAmount;
+      const supplyAmount = swapFeeAmount + pluginFeeAmount - protocolAmount; // = LP share of the swap fee
 
       dailyVolume.add(inputToken, inputAmount);
-      dailyFees.add(inputToken, feeAmount);
+      dailyFees.add(inputToken, swapFeeAmount + pluginFeeAmount);
       dailyRevenue.add(inputToken, protocolAmount);
       dailySupplySideRevenue.add(inputToken, supplyAmount);
     });
@@ -83,7 +93,6 @@ const fetch = async (options: FetchOptions) => {
   return {
     dailyVolume,
     dailyFees,
-    dailyUserFees: dailyFees, // all fees are paid by swappers
     dailyRevenue,
     dailyProtocolRevenue: dailyRevenue,
     dailySupplySideRevenue,
@@ -92,15 +101,15 @@ const fetch = async (options: FetchOptions) => {
 
 const methodology = {
   Volume: "Sum of the input amount of every swap across all Rooster V2 (Algebra Integral) pools on Plume, read from on-chain Swap events.",
-  Fees: "Total swap fees paid by traders, computed per swap as inputAmount * dynamicFee, using the exact per-swap fee from the pool's SwapFee event.",
-  UserFees: "Total swap fees paid by traders (same as Fees).",
-  Revenue: "Protocol's share of swap fees, i.e. each pool's communityFee applied to that pool's fees, read on-chain from globalState().",
-  ProtocolRevenue: "Protocol's share of swap fees (the communityFee that accrues to the protocol community vault).",
-  SupplySideRevenue: "Share of swap fees retained by liquidity providers (total fees minus the communityFee).",
+  Fees: "Total swap fees paid by traders, computed per swap as inputAmount * (swapFee + pluginFee) using the exact per-swap rates from the pool's SwapFee event.",
+  Revenue: "Protocol's share of fees: each pool's communityFee applied to its swap fees (read on-chain from globalState()) plus the full plugin fee.",
+  ProtocolRevenue: "Protocol's share of fees (communityFee share of swap fees plus the plugin fee).",
+  SupplySideRevenue: "Share of swap fees retained by liquidity providers (swap fees minus the communityFee share).",
 };
 
 const adapter: SimpleAdapter = {
   version: 2,
+  pullHourly: true,
   fetch,
   chains: [CHAIN.PLUME],
   start: "2025-08-23",

--- a/dexs/rooster-v2/index.ts
+++ b/dexs/rooster-v2/index.ts
@@ -19,6 +19,14 @@ const FACTORY_FROM_BLOCK = 23181592; // block of the first pool creation on Plum
 const FEE_DENOMINATOR = 1e6; // Algebra Constants.FEE_DENOMINATOR (fee in hundredths of a bip)
 const COMMUNITY_FEE_DENOMINATOR = 1e3; // Algebra Constants.COMMUNITY_FEE_DENOMINATOR (communityFee in thousandths)
 
+const LABELS = {
+  SWAP_FEES: "Swap Fees",
+  PLUGIN_FEES: "Plugin Fees",
+  SWAP_FEES_TO_PROTOCOL: "Swap Fees to Protocol",
+  PLUGIN_FEES_TO_PROTOCOL: "Plugin Fees to Protocol",
+  SWAP_FEES_TO_LPS: "Swap Fees to LPs",
+};
+
 const POOL_CREATED = "event Pool(address indexed token0, address indexed token1, address pool)";
 const CUSTOM_POOL_CREATED = "event CustomPool(address indexed deployer, address indexed token0, address indexed token1, address pool)";
 const SWAP = "event Swap(address indexed sender, address indexed recipient, int256 amount0, int256 amount1, uint160 price, uint128 liquidity, int24 tick)";
@@ -32,17 +40,13 @@ const fetch = async (options: FetchOptions) => {
   const dailySupplySideRevenue = options.createBalances(); // LP share
 
   // 1. Discover all pools (standard + custom) from the factory
-  const [poolLogs, customPoolLogs] = await Promise.all([
-    options.getLogs({ target: FACTORY, fromBlock: FACTORY_FROM_BLOCK, eventAbi: POOL_CREATED, cacheInCloud: true }),
-    options.getLogs({ target: FACTORY, fromBlock: FACTORY_FROM_BLOCK, eventAbi: CUSTOM_POOL_CREATED, cacheInCloud: true }),
-  ]);
+  const poolLogs = await options.getLogs({ target: FACTORY, fromBlock: FACTORY_FROM_BLOCK, eventAbi: POOL_CREATED, cacheInCloud: true });
+  const customPoolLogs = await options.getLogs({ target: FACTORY, fromBlock: FACTORY_FROM_BLOCK, eventAbi: CUSTOM_POOL_CREATED, cacheInCloud: true });
   const pools: string[] = [...new Set([...poolLogs, ...customPoolLogs].map((log: any) => log.pool))];
 
   // 2. Per-pool Swap logs (volume) and SwapFee logs (per-swap fee rate), index-aligned 1:1 with `pools`
-  const [swapLogs, swapFeeLogs] = await Promise.all([
-    options.getLogs({ targets: pools, eventAbi: SWAP, flatten: false }),
-    options.getLogs({ targets: pools, eventAbi: SWAP_FEE, flatten: false }),
-  ]);
+  const swapLogs = await options.getLogs({ targets: pools, eventAbi: SWAP, flatten: false });
+  const swapFeeLogs = await options.getLogs({ targets: pools, eventAbi: SWAP_FEE, flatten: false });
 
   // 3. Only fetch token pair + fees for pools that traded in this window
   const activeIndexes = swapLogs.map((logs: any[], i: number) => (logs.length ? i : -1)).filter((i: number) => i >= 0);
@@ -50,11 +54,9 @@ const fetch = async (options: FetchOptions) => {
   // These pools all came from the factory's own creation events, so token0/token1/globalState
   // must resolve. Don't permit failures here: a failed call is a transient RPC error, and
   // silently zeroing it would undercount volume/fees for a pool that definitely traded.
-  const [token0s, token1s, globalStates] = await Promise.all([
-    options.api.multiCall({ abi: "address:token0", calls: activePools }),
-    options.api.multiCall({ abi: "address:token1", calls: activePools }),
-    options.api.multiCall({ abi: GLOBAL_STATE, calls: activePools }),
-  ]);
+  const token0s = await options.api.multiCall({ abi: "address:token0", calls: activePools });
+  const token1s = await options.api.multiCall({ abi: "address:token1", calls: activePools });
+  const globalStates = await options.api.multiCall({ abi: GLOBAL_STATE, calls: activePools });
 
   activeIndexes.forEach((poolIndex: number, k: number) => {
     const token0 = token0s[k];
@@ -81,14 +83,17 @@ const fetch = async (options: FetchOptions) => {
 
       const swapFeeAmount = (inputAmount * BigInt(feeRate)) / BigInt(FEE_DENOMINATOR);
       const pluginFeeAmount = (inputAmount * BigInt(pluginFee)) / BigInt(FEE_DENOMINATOR);
-      // protocol cut = communityFee share of the swap fee + the whole plugin fee
-      const protocolAmount = (swapFeeAmount * BigInt(communityFee)) / BigInt(COMMUNITY_FEE_DENOMINATOR) + pluginFeeAmount;
-      const supplyAmount = swapFeeAmount + pluginFeeAmount - protocolAmount; // = LP share of the swap fee
+      const swapProtocolAmount = (swapFeeAmount * BigInt(communityFee)) / BigInt(COMMUNITY_FEE_DENOMINATOR);
+      const supplyAmount = swapFeeAmount - swapProtocolAmount; // LP share of the swap fee
 
       dailyVolume.add(inputToken, inputAmount);
-      dailyFees.add(inputToken, swapFeeAmount + pluginFeeAmount);
-      dailyRevenue.add(inputToken, protocolAmount);
-      dailySupplySideRevenue.add(inputToken, supplyAmount);
+      dailyFees.add(inputToken, swapFeeAmount, LABELS.SWAP_FEES);
+      dailyFees.add(inputToken, pluginFeeAmount, LABELS.PLUGIN_FEES);
+
+      dailyRevenue.add(inputToken, swapProtocolAmount, LABELS.SWAP_FEES_TO_PROTOCOL);
+      dailyRevenue.add(inputToken, pluginFeeAmount, LABELS.PLUGIN_FEES_TO_PROTOCOL);
+
+      dailySupplySideRevenue.add(inputToken, supplyAmount, LABELS.SWAP_FEES_TO_LPS);
     });
   });
 
@@ -109,6 +114,24 @@ const methodology = {
   SupplySideRevenue: "Share of swap fees retained by liquidity providers (swap fees minus the communityFee share).",
 };
 
+const breakdownMethodology = {
+  Fees: {
+    [LABELS.SWAP_FEES]: "Swap fees paid by traders, computed per swap from the pool's overrideFee or static fee.",
+    [LABELS.PLUGIN_FEES]: "Extra plugin fees charged on swaps by Algebra Integral pool plugins.",
+  },
+  Revenue: {
+    [LABELS.SWAP_FEES_TO_PROTOCOL]: "Protocol share of swap fees, determined by each pool's on-chain communityFee.",
+    [LABELS.PLUGIN_FEES_TO_PROTOCOL]: "Full plugin fee routed to the protocol.",
+  },
+  ProtocolRevenue: {
+    [LABELS.SWAP_FEES_TO_PROTOCOL]: "Protocol share of swap fees, determined by each pool's on-chain communityFee.",
+    [LABELS.PLUGIN_FEES_TO_PROTOCOL]: "Full plugin fee routed to the protocol.",
+  },
+  SupplySideRevenue: {
+    [LABELS.SWAP_FEES_TO_LPS]: "LP share of swap fees (swap fees minus the protocol share).",
+  },
+};
+
 const adapter: SimpleAdapter = {
   version: 2,
   pullHourly: true,
@@ -116,6 +139,7 @@ const adapter: SimpleAdapter = {
   chains: [CHAIN.PLUME],
   start: "2025-08-23",
   methodology,
+  breakdownMethodology,
 };
 
 export default adapter;

--- a/dexs/rooster-v2/index.ts
+++ b/dexs/rooster-v2/index.ts
@@ -47,19 +47,21 @@ const fetch = async (options: FetchOptions) => {
   // 3. Only fetch token pair + fees for pools that traded in this window
   const activeIndexes = swapLogs.map((logs: any[], i: number) => (logs.length ? i : -1)).filter((i: number) => i >= 0);
   const activePools = activeIndexes.map((i: number) => pools[i]);
+  // These pools all came from the factory's own creation events, so token0/token1/globalState
+  // must resolve. Don't permit failures here: a failed call is a transient RPC error, and
+  // silently zeroing it would undercount volume/fees for a pool that definitely traded.
   const [token0s, token1s, globalStates] = await Promise.all([
-    options.api.multiCall({ abi: "address:token0", calls: activePools, permitFailure: true }),
-    options.api.multiCall({ abi: "address:token1", calls: activePools, permitFailure: true }),
-    options.api.multiCall({ abi: GLOBAL_STATE, calls: activePools, permitFailure: true }),
+    options.api.multiCall({ abi: "address:token0", calls: activePools }),
+    options.api.multiCall({ abi: "address:token1", calls: activePools }),
+    options.api.multiCall({ abi: GLOBAL_STATE, calls: activePools }),
   ]);
 
   activeIndexes.forEach((poolIndex: number, k: number) => {
     const token0 = token0s[k];
     const token1 = token1s[k];
-    if (!token0 || !token1) return;
     const gs = globalStates[k];
-    const communityFee = gs ? Number(gs.communityFee) : 0; // 0..1000
-    const staticFee = gs ? Number(gs.lastFee) : 0; // fallback for pools without a dynamic fee
+    const communityFee = Number(gs.communityFee); // 0..1000
+    const staticFee = Number(gs.lastFee); // fallback for pools without a dynamic fee
     const poolSwaps = swapLogs[poolIndex];
     const poolSwapFees = swapFeeLogs[poolIndex] || [];
 


### PR DESCRIPTION
https://defillama.com/protocol/rooster-protocol-v2

Adds an on-chain fees & revenue adapter for **Rooster Protocol V2**, an Algebra Integral concentrated-liquidity DEX on Plume. The protocol is already listed for TVL (`rooster-protocol-v2`) but has no fees/revenue yet.

This is a **new module** (`dexs/rooster-v2`), separate from the existing `dexs/rooster`, which tracks the Maverick-based **Rooster V1** (`rooster-protocol-v1`) on a different factory. Please attach this module to the existing DefiLlama protocol slug **`rooster-protocol-v2`**.

### How it works (fully on-chain, no subgraph)
- Discovers all pools from the AlgebraFactory (`0x1eB9822d5176C88B1d4eec353fa956C896D77Df9`) `Pool` / `CustomPool` events.
- For each swap, reads the pool `Swap` event (token deltas → volume) and the paired `SwapFee` event, whose `overrideFee` is the exact dynamic fee applied to that swap (1e-6 units). Fee is charged on the input amount, so `fee = inputAmount * feeRate / 1e6`.
- Revenue split uses each pool's on-chain `communityFee` (1e-3 units) from `globalState()`: protocol revenue = `fees * communityFee/1000`, the remainder is supply-side (LP) revenue.

### Local test results (`pnpm test dexs rooster-v2`)
- 2026-07-02 → volume ~$14.9k, fees ~$12.00, revenue ~$2.33, supply-side ~$9.33
- 2026-06-14 → volume ~$16.5k, fees ~$10.00, revenue ~$2.05, supply-side ~$8.21
- Invariant `Fees = Revenue + SupplySideRevenue` holds.

##### Name (to be shown on DefiLlama): Rooster Protocol V2
##### Twitter Link: https://twitter.com/roosterprotocol
##### Website Link: https://www.rooster.trade/
##### Chain: Plume
##### Category: Dexs
##### methodology: Volume is the sum of the input amount of every swap across all Rooster V2 (Algebra Integral) pools on Plume. Fees are the total swap fees paid by traders (per-swap `inputAmount * dynamicFee`, using the exact on-chain `SwapFee` rate). Revenue / ProtocolRevenue is each pool's `communityFee` share of fees (read on-chain from `globalState()`); SupplySideRevenue is the remainder retained by LPs.
##### forkedFrom: Algebra Integral
##### Github org/user: https://github.com/RoosterV2
