### PR TITLE
[fees] PumpBox - add PumpDaily subscription fees

### DIFF
--- a/fees/pumpbox/index.ts
+++ b/fees/pumpbox/index.ts
@@ -37,7 +37,7 @@ const fetch = async (options: FetchOptions) => {
 
   const subscriptionFees = await addTokensReceived({
     options,
-    token: USDC_BASE,
+    tokens: [USDC_BASE],
     target: PUMPDAILY_SUBSCRIPTION_RECEIVER,
     logFilter: isSubscriptionFee,
   });

--- a/fees/pumpbox/index.ts
+++ b/fees/pumpbox/index.ts
@@ -3,8 +3,12 @@ import { CHAIN } from "../../helpers/chains";
 import ADDRESSES from '../../helpers/coreAssets.json';
 import { addTokensReceived } from "../../helpers/token";
 
+// PumpBox checkout contract on Base:
+// https://basescan.org/address/0x64FEeB41A17Dd29b9BAF6d45Ca2d359aE55d8C68
 const CHECKOUT_CONTRACT = "0x64FEeB41A17Dd29b9BAF6d45Ca2d359aE55d8C68";
 const USDC_BASE = ADDRESSES.base.USDC;
+// PumpBox treasury / PumpDaily subscription receiver on Base:
+// https://basescan.org/address/0x646308ef20fb48101662dda0fb2dc7c677bc1b59
 const PUMPDAILY_SUBSCRIPTION_RECEIVER = "0x646308ef20fb48101662dda0fb2dc7c677bc1b59";
 
 const OPEN_BOX_REQUESTED =
@@ -12,7 +16,8 @@ const OPEN_BOX_REQUESTED =
 
 const BUYBACK_EXECUTED = "event BuybackExecuted(address indexed seller, uint256 indexed tokenId, uint256 buybackPrice)";
 
-const isSubscriptionFee = (log: any) => (log.from_address ?? "").toLowerCase() !== CHECKOUT_CONTRACT.toLowerCase();
+const isSubscriptionFee = (log: any) =>
+  (log.from_address ?? log.from ?? "").toLowerCase() !== CHECKOUT_CONTRACT.toLowerCase();
 
 const fetch = async (options: FetchOptions) => {
   const { getLogs, createBalances } = options;
@@ -61,9 +66,9 @@ const fetch = async (options: FetchOptions) => {
 
 const methodology = {
   Volume: "All USDC payments made by users when opening blind boxes. Each box has a fixed USDC price; users pay price × quantity.",
-  Fees: "USDC paid by users to request blind box openings, net of buyback spends plus PumpDaily subscriptions.",
-  Revenue: "USDC paid by users to request blind box openings, net of buyback spends plus PumpDaily subscriptions.",
-  ProtocolRevenue: "USDC paid by users to request blind box openings, net of buyback spends plus PumpDaily subscriptions.",
+  Fees: "USDC paid by users to request blind box openings plus PumpDaily subscriptions, net of buyback spends.",
+  Revenue: "USDC paid by users to request blind box openings plus PumpDaily subscriptions, net of buyback spends.",
+  ProtocolRevenue: "USDC paid by users to request blind box openings plus PumpDaily subscriptions, net of buyback spends.",
 };
 
 const breakdownMethodology = {


### PR DESCRIPTION
## Summary

Adds PumpDaily subscription fees to the PumpBox fees adapter.

PumpDaily subscriptions are paid as direct USDC transfers to the PumpBox treasury on Base, so this PR tracks USDC received by the subscription receiver and adds it to fees, revenue, and protocol revenue under the `Subscription Fees` breakdown label.

## Fix

Uses `tokens: [USDC_BASE]` when calling `addTokensReceived` so the DefiLlama indexer path can apply the USDC token filter correctly in production.

## Methodology

- Box Opening Fees: USDC paid by users when requesting PumpBox box openings.
- Subscription Fees: USDC paid by users for PumpDaily subscriptions via direct transfers to the PumpBox treasury.
- Buyback Spends: USDC spent by the protocol on box buybacks, deducted from fees/revenue.

## Addresses

- PumpBox checkout contract on Base: `0x64FEeB41A17Dd29b9BAF6d45Ca2d359aE55d8C68`
- PumpDaily subscription receiver / treasury on Base: `0x646308ef20fb48101662dda0fb2dc7c677bc1b59`
- USDC on Base: `0x833589fcd6edb6e08f4c7c32d4f71b54bda02913`

## Validation

Ran:

```bash
pnpm test fees pumpbox 2026-07-03