### PR TITLE
[Fees] Rainbow Predictions - Route fees back on-chain from 2026-06-29

### DIFF
--- a/fees/rainbow-predictions.ts
+++ b/fees/rainbow-predictions.ts
@@ -3,24 +3,24 @@ import { CHAIN } from "../helpers/chains"
 import { addTokensReceived } from "../helpers/token"
 import { fetchPolymarketV2BuilderFees } from "../helpers/polymarket"
 
-// Rainbow Wallet predictions fee wallet on Polygon (pre-Polymarket-v2)
+// Rainbow Wallet predictions fee wallet on Polygon
 const RainbowFeeWallet = '0x757758506d6a4F8a433F8BECaFd52545f9Cb050a';
 
-// USDC.e on Polygon (used pre-Polymarket-v2)
+// USDC.e on Polygon
 const USDC_E = '0x2791bca1f2de4661ed88a30c99a7a9449aa84174';
 
 // Rainbow's builder code in Polymarket v2
 const RAINBOW_BUILDER_CODE = '0xabce5abdc189cba6fb85edb9170e3e6e41607e946b06d112b7f87e2f2977020c';
 
-// 2026-04-29 00:00 UTC — Polymarket v2 cutover. Before: on-chain. On/after: API.
-const POLYMARKET_V2_CUTOVER = 1777420800;
+// Polymarket v2 builder-fee window (00:00 UTC boundaries). On-chain USDC.e to the
+// Rainbow fee wallet before START and again from END; builder-fee API in between.
+const POLYMARKET_V2_START = 1777420800; // 2026-04-29
+const POLYMARKET_V2_END = 1782691200;   // 2026-06-29
 
 const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
   const dailyFees = options.createBalances()
 
-  // On-chain leg: capture USDC.e transfers to the Rainbow fee wallet
-  // (only meaningful pre-Polymarket-v2; for windows fully after, this returns 0)
-  if (options.startTimestamp < POLYMARKET_V2_CUTOVER) {
+  if (options.startTimestamp < POLYMARKET_V2_START || options.endTimestamp > POLYMARKET_V2_END) {
     const onChain = await addTokensReceived({
       options,
       targets: [RainbowFeeWallet],
@@ -44,19 +44,19 @@ const adapter: SimpleAdapter = {
   version: 2,
   pullHourly: true,
   methodology: {
-    Fees: 'Pre-Polymarket-v2: ~1% of shares value on each prediction market trade routed through the Rainbow fee wallet. Post-Polymarket-v2: Builder fees received by Rainbow from trades on Polymarket v2',
-    Revenue: 'Builder fees received by Rainbow from trades on Polymarket v2',
-    ProtocolRevenue: 'Builder fees received by Rainbow from trades on Polymarket v2',
+    Fees: 'Rainbow charges up to 3% of each prediction market trade, with the fee shrinking as the bet gets safer. Before 2026-04-29 and again from 2026-06-29 these fees are collected on-chain as USDC.e in the Rainbow fee wallet. Between 2026-04-29 and 2026-06-29 they are the builder fees received by Rainbow from trades on Polymarket v2',
+    Revenue: 'All fees go to Rainbow (on-chain periods: USDC.e to the Rainbow fee wallet; Polymarket-v2 period: builder fees from trades on Polymarket v2)',
+    ProtocolRevenue: 'All fees go to Rainbow (on-chain periods: USDC.e to the Rainbow fee wallet; Polymarket-v2 period: builder fees from trades on Polymarket v2)',
   },
   breakdownMethodology: {
     Fees: {
-      'Polymarket Builder Fees': 'Pre-v2: USDC.e charged on each prediction market open/close trade. Post-v2: Builder fees received by Rainbow from trades on Polymarket v2',
+      'Polymarket Builder Fees': 'On-chain periods (before 2026-04-29 and from 2026-06-29): USDC.e charged on each prediction market open/close trade and received by the Rainbow fee wallet. Polymarket-v2 period (2026-04-29 to 2026-06-29): builder fees received by Rainbow from trades on Polymarket v2',
     },
     Revenue: {
-      'Polymarket Builder Fees': 'Builder fees received by Rainbow from trades on Polymarket using Rainbow builder interface',
+      'Polymarket Builder Fees': 'All trading fees flow to Rainbow (on-chain periods to the fee wallet, v2 period as builder fees on Polymarket v2)',
     },
     ProtocolRevenue: {
-      'Polymarket Builder Fees': 'Builder fees received by Rainbow from trades on Polymarket using Rainbow builder interface',
+      'Polymarket Builder Fees': 'All trading fees flow to Rainbow (on-chain periods to the fee wallet, v2 period as builder fees on Polymarket v2)',
     },
   },
   adapter: {


### PR DESCRIPTION
Name (as shown on DefiLlama): Rainbow Predictions
Twitter link: https://x.com/rainbowdotme
Website link: https://rainbow.me
Chain(s): Polygon

## Summary

Updates the existing `rainbow-predictions.ts` adapter (PR #6938) for the next change in how Rainbow's prediction-market fees are collected.

From **2026-06-29** builder fees no longer flow through Polymarket's `/builder/trades` API — Rainbow collects fees on-chain again as USDC.e transfers into the Rainbow fee wallet, the same way it did before Polymarket v2. This restores on-chain tracking for windows on/after the cutover while keeping the v2 builder-API leg for the window it covered.

## How it works

The adapter now keys off **two** cutover timestamps and splits into three periods:

- `POLYMARKET_V2_START = 1777420800` — 2026-04-29 00:00:00 UTC
- `POLYMARKET_V2_END   = 1782691200` — 2026-06-29 00:00:00 UTC

| Window | Source |
|--------|--------|
| before 2026-04-29 | `addTokensReceived` on USDC.e to the Rainbow fee wallet (`0x757758506d6a4F8a433F8BECaFd52545f9Cb050a`) |
| 2026-04-29 → 2026-06-29 | `fetchPolymarketV2BuilderFees` — `/builder/trades?builder_code=0xabce…`, paginate via `next_cursor`, sum `builderFee` |
| from 2026-06-29 | `addTokensReceived` on USDC.e to the Rainbow fee wallet (resumed) |

The on-chain leg runs for windows outside the builder-fee window; the API leg runs only inside it. The two branches are mutually exclusive, so no window is double-counted or missed. Adapter is `pullHourly`, so each hourly window falls entirely within one period.

## Methodology

| Metric | Description |
|--------|-------------|
| Fees | Rainbow charges up to 3% of each prediction market trade, with the fee shrinking as the outcome gets safer. Before 2026-04-29 and again from 2026-06-29 these fees are collected on-chain as USDC.e in the Rainbow fee wallet. Between 2026-04-29 and 2026-06-29 they are the builder fees attributed to Rainbow via the Polymarket v2 builder code |
| Revenue | All fees go to Rainbow |
| ProtocolRevenue | Same as Revenue |

Start date: 2025-12-01

## Verification

Ran the adapter end-to-end for sample days in each period (Polygon `dailyRevenue`).

**Builder-fee API leg** — spot-checked against direct paginated `/builder/trades` calls:

| Date | Direct API | Adapter |
|------|-----------|---------|
| 2026-05-01 | \$0.00 | \$0 |
| 2026-05-15 | \$76.51 | \$77 |
| 2026-06-01 | \$32.13 | \$32 |
| 2026-06-15 | \$170.78 | \$171 |

(2026-05-01 is genuinely \$0 — 118 builder trades that day, all with `builderFee = 0`.)

**On-chain legs** — USDC.e into the fee wallet:

| Date | Adapter | Period |
|------|---------|--------|
| 2026-03-25 | \$125 | pre-v2 |
| 2026-04-25 | \$601 | pre-v2 |
| 2026-06-29 | \$240 | post-v2 (resumed) |
| 2026-06-30 | \$322 | post-v2 (resumed) |
| 2026-07-01 | \$561 | post-v2 (resumed) |
| 2026-07-05 | \$430 | post-v2 (resumed) |

Results are deterministic across independent runs, and `dailyFees == dailyRevenue == dailyProtocolRevenue` (100% of fees accrue to Rainbow).
