### PR TITLE
fix(ens): correct registrar NameRegistered ABIs and backfill full history

### DIFF
--- a/fees/ens.ts
+++ b/fees/ens.ts
@@ -1,91 +1,71 @@
 import { Adapter, FetchOptions } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
 
-/* ---------- ABIs ---------- */
+// ENS .eth registrar controllers, oldest -> newest.
+// The 2019 and 2020 controllers report a single combined `cost` in NameRegistered; the current
+// controller (deployed 2023-03) splits it into `baseCost` + temporary Dutch-auction `premium`.
+// (Verified on-chain: 0x283af0 emits cost-only, 0x253553 emits baseCost+premium.) All three
+// share the same NameRenewed signature.
+const controllers_cost = [
+  "0xf0ad5cad05e10572efceb849f6ff0c68f9700455", // 2019 launch
+  "0x283af0b28c62c092c9727f1ee09c02ca627eb7f5", // 2020
+];
+const controller_premium = "0x253553366da8546fc250f225fe3d25d0c782303b"; // 2023-03 (current)
+const all_controllers = [...controllers_cost, controller_premium];
 
-// v4
-const abi_v4 = {
-  nameRegistered:
-    "event NameRegistered(string name,bytes32 indexed label,address indexed owner,uint256 baseCost,uint256 premium,uint256 expires)",
-  nameRenewed:
-    "event NameRenewed(string name,bytes32 indexed label,uint256 cost,uint256 expires)",
-};
-
-// v5
-const abi_v5 = {
-  nameRegistered:
-    "event NameRegistered(string name,bytes32 indexed label,address indexed owner,uint256 cost,uint256 expires)",
-  nameRenewed:
-    "event NameRenewed(string name,bytes32 indexed label,uint256 cost,uint256 expires)",
-};
-
-const address_v4 = "0x283af0b28c62c092c9727f1ee09c02ca627eb7f5";
-const address_v5 = "0x253553366da8546fc250f225fe3d25d0c782303b";
+const nameRegistered_cost =
+  "event NameRegistered(string name,bytes32 indexed label,address indexed owner,uint256 cost,uint256 expires)";
+const nameRegistered_premium =
+  "event NameRegistered(string name,bytes32 indexed label,address indexed owner,uint256 baseCost,uint256 premium,uint256 expires)";
+const nameRenewed =
+  "event NameRenewed(string name,bytes32 indexed label,uint256 cost,uint256 expires)";
 
 const fetch = async (options: FetchOptions) => {
   const dailyFees = options.createBalances();
 
-  /* ----- v4 registrations ----- */
-  const v4Registered = await options.getLogs({
-    target: address_v4,
-    eventAbi: abi_v4.nameRegistered,
-  });
+  // Registrations on the 2019 + 2020 controllers: single combined cost.
+  const costRegs = await options.getLogs({ targets: controllers_cost, eventAbi: nameRegistered_cost });
+  costRegs.forEach((tx: any) => dailyFees.addGasToken(tx.cost, "Name registration fees"));
 
-  v4Registered.forEach((tx: any) => {
-    const total = Number(tx.baseCost) + Number(tx.premium);
-    if (total / 1e18 < 10) {
-      dailyFees.addGasToken(total, "V4 name registration fees");
-    }
-  });
+  // Current controller: base cost + temporary (Dutch-auction) premium, both real treasury
+  // revenue, so count the full amount. The premium is a legitimate auction price (a 21-day
+  // exponential decay from a high start down to 0 on recently-expired names), not a data glitch,
+  // so there is nothing anomalous to cap.
+  const premiumRegs = await options.getLogs({ target: controller_premium, eventAbi: nameRegistered_premium });
+  premiumRegs.forEach((tx: any) =>
+    dailyFees.addGasToken(Number(tx.baseCost) + Number(tx.premium), "Name registration fees")
+  );
 
-  /* ----- v5 registrations ----- */
-  const v5Registered = await options.getLogs({
-    target: address_v5,
-    eventAbi: abi_v5.nameRegistered,
-  });
-
-  v5Registered.forEach((tx: any) => {
-    if (Number(tx.cost) / 1e18 < 10) {
-      dailyFees.addGasToken(tx.cost, "V5 name registration fees");
-    }
-  });
-
-  /* ----- renewals (same for v4 & v5) ----- */
-  const renewedLogs = await options.getLogs({
-    targets: [address_v4, address_v5],
-    eventAbi: abi_v4.nameRenewed,
-  });
-
-  renewedLogs.forEach((tx: any) => {
-    if (Number(tx.cost) / 1e18 < 10) {
-      dailyFees.addGasToken(tx.cost, "Name renewal fees");
-    }
-  });
+  // Renewals: same event across every controller.
+  const renewals = await options.getLogs({ targets: all_controllers, eventAbi: nameRenewed });
+  renewals.forEach((tx: any) => dailyFees.addGasToken(tx.cost, "Name renewal fees"));
 
   return {
     dailyFees,
     dailyRevenue: dailyFees,
+    dailyProtocolRevenue: dailyFees,
   };
-}
-
-const methodology = {
-  Fees: "ENS name registration and renewal costs",
-  Revenue: "ENS name registration and renewal costs",
 };
 
+// Per ENS docs: 100% of registration + renewal fees flow through the ETHRegistrarController to the
+// ENS DAO treasury. There is no supply-side split, no distribution to ENS token holders, and no
+// buyback - so fees, revenue and protocol revenue are all equal.
+const methodology = {
+  Fees: "ENS .eth name registration and renewal costs (base cost plus temporary premium) across every registrar controller since the 2019 launch.",
+  Revenue: "Same as fees: ENS keeps 100% of registration and renewal costs in the DAO treasury, so revenue equals fees.",
+  ProtocolRevenue: "Same as revenue: all fees accrue to the ENS DAO treasury. ENS token holders receive no direct fee distribution and there is no buyback.",
+};
 
 const adapter: Adapter = {
   version: 2,
-  pullHourly: true,
   fetch,
   chains: [CHAIN.ETHEREUM],
-  start: '2023-02-23',
+  start: '2019-05-04', // ENS .eth permanent registrar launch (legacy controller 0xf0ad5cad)
   methodology,
   breakdownMethodology: {
     Fees: {
-      "V4 name registration fees": "fees paid for .eth name registrations through the V4 ETHRegistrarController contract, including base cost and premium.",
-      "V5 name registration fees": "fees paid for .eth name registrations through the V5 ETHRegistrarController contract.",
-      "Name renewal fees": "fees paid for .eth name renewals through both V4 and V5 ETHRegistrarController contracts.",
+      "Name registration fees": "Cost paid to register .eth names across all ETHRegistrarController versions. The 2019 and 2020 controllers report a single combined cost; the current controller (2023+) reports base cost plus temporary Dutch-auction premium, both counted in full.",
+      "Name renewal fees": "Cost paid to renew .eth names across all ETHRegistrarController versions.",
     },
   },
 };

--- a/fees/ens.ts
+++ b/fees/ens.ts
@@ -1,44 +1,58 @@
 import { Adapter, FetchOptions } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
 
-// ENS .eth registrar controllers, oldest -> newest.
-// The 2019 and 2020 controllers report a single combined `cost` in NameRegistered; the current
-// controller (deployed 2023-03) splits it into `baseCost` + temporary Dutch-auction `premium`.
-// (Verified on-chain: 0x283af0 emits cost-only, 0x253553 emits baseCost+premium.) All three
-// share the same NameRenewed signature.
+// ENS .eth registrar controllers, oldest -> newest. Verified against ENS's own Dune model
+// (ethereumnameservice_ethereum.ETHRegistrarController_1..5) and the on-chain event schemas.
+// NameRegistered comes in three shapes:
+//   - controllers 1-3 (2019-2023): a single combined `cost`
+//   - controller 4 (0x253553, 2023):    baseCost + premium
+//   - controller 5 (0x59e16f, current): baseCost + premium + referrer (label/labelhash naming)
+// NameRenewed is the classic 4-field event on controllers 1-4 and a 5-field (referrer) event on 5.
 const controllers_cost = [
-  "0xf0ad5cad05e10572efceb849f6ff0c68f9700455", // 2019 launch
-  "0x283af0b28c62c092c9727f1ee09c02ca627eb7f5", // 2020
+  "0xf0ad5cad05e10572efceb849f6ff0c68f9700455", // 1 - 2019 launch
+  "0xb22c1c159d12461ea124b0deb4b5b93020e6ad16", // 2 - 2019
+  "0x283af0b28c62c092c9727f1ee09c02ca627eb7f5", // 3 - 2020
 ];
-const controller_premium = "0x253553366da8546fc250f225fe3d25d0c782303b"; // 2023-03 (current)
-const all_controllers = [...controllers_cost, controller_premium];
+const controller_premium = "0x253553366da8546fc250f225fe3d25d0c782303b"; // 4 - 2023
+const controller_referrer = "0x59e16fccd424cc24e280be16e11bcd56fb0ce547"; // 5 - current
 
-const nameRegistered_cost =
-  "event NameRegistered(string name,bytes32 indexed label,address indexed owner,uint256 cost,uint256 expires)";
-const nameRegistered_premium =
-  "event NameRegistered(string name,bytes32 indexed label,address indexed owner,uint256 baseCost,uint256 premium,uint256 expires)";
-const nameRenewed =
-  "event NameRenewed(string name,bytes32 indexed label,uint256 cost,uint256 expires)";
+const registered_cost =
+  "event NameRegistered(string name, bytes32 indexed label, address indexed owner, uint256 cost, uint256 expires)";
+const registered_premium =
+  "event NameRegistered(string name, bytes32 indexed label, address indexed owner, uint256 baseCost, uint256 premium, uint256 expires)";
+const registered_referrer =
+  "event NameRegistered(string label, bytes32 indexed labelhash, address indexed owner, uint256 baseCost, uint256 premium, uint256 expires, bytes32 referrer)";
+const renewed =
+  "event NameRenewed(string name, bytes32 indexed label, uint256 cost, uint256 expires)";
+const renewed_referrer =
+  "event NameRenewed(string label, bytes32 indexed labelhash, uint256 cost, uint256 expires, bytes32 referrer)";
+
+const REGISTRATION = "Name registration fees";
+const RENEWAL = "Name renewal fees";
 
 const fetch = async (options: FetchOptions) => {
   const dailyFees = options.createBalances();
 
-  // Registrations on the 2019 + 2020 controllers: single combined cost.
-  const costRegs = await options.getLogs({ targets: controllers_cost, eventAbi: nameRegistered_cost });
-  costRegs.forEach((tx: any) => dailyFees.addGasToken(tx.cost, "Name registration fees"));
+  // Controllers 1-3: single combined cost.
+  const costRegs = await options.getLogs({ targets: controllers_cost, eventAbi: registered_cost });
+  costRegs.forEach((tx: any) => dailyFees.addGasToken(tx.cost, REGISTRATION));
 
-  // Current controller: base cost + temporary (Dutch-auction) premium, both real treasury
-  // revenue, so count the full amount. The premium is a legitimate auction price (a 21-day
-  // exponential decay from a high start down to 0 on recently-expired names), not a data glitch,
-  // so there is nothing anomalous to cap.
-  const premiumRegs = await options.getLogs({ target: controller_premium, eventAbi: nameRegistered_premium });
-  premiumRegs.forEach((tx: any) =>
-    dailyFees.addGasToken(Number(tx.baseCost) + Number(tx.premium), "Name registration fees")
+  // Controllers 4 & 5: base cost + temporary Dutch-auction premium, both real treasury revenue,
+  // counted in full. The premium is a legitimate auction price (a 21-day exponential decay from a
+  // high start down to 0 on recently-expired names), not a data glitch, so there is nothing to cap.
+  // Controller 5 also records a `referrer`, but the full baseCost + premium is collected by the
+  // treasury (referralFee is 0 on-chain today); if a non-zero referral split is ever activated the
+  // referred portion would need to move to supply-side revenue.
+  const premiumRegs = await options.getLogs({ target: controller_premium, eventAbi: registered_premium });
+  const referrerRegs = await options.getLogs({ target: controller_referrer, eventAbi: registered_referrer });
+  [...premiumRegs, ...referrerRegs].forEach((tx: any) =>
+    dailyFees.addGasToken(Number(tx.baseCost) + Number(tx.premium), REGISTRATION)
   );
 
-  // Renewals: same event across every controller.
-  const renewals = await options.getLogs({ targets: all_controllers, eventAbi: nameRenewed });
-  renewals.forEach((tx: any) => dailyFees.addGasToken(tx.cost, "Name renewal fees"));
+  // Renewals: 4-field event on controllers 1-4, 5-field (referrer) event on controller 5.
+  const renewals = await options.getLogs({ targets: [...controllers_cost, controller_premium], eventAbi: renewed });
+  const referrerRenewals = await options.getLogs({ target: controller_referrer, eventAbi: renewed_referrer });
+  [...renewals, ...referrerRenewals].forEach((tx: any) => dailyFees.addGasToken(tx.cost, RENEWAL));
 
   return {
     dailyFees,
@@ -60,11 +74,11 @@ const adapter: Adapter = {
   version: 2,
   fetch,
   chains: [CHAIN.ETHEREUM],
-  start: '2019-05-04', // ENS .eth permanent registrar launch (legacy controller 0xf0ad5cad)
+  start: '2019-05-04', // ENS .eth permanent registrar launch (controller 1, 0xf0ad5cad)
   methodology,
   breakdownMethodology: {
     Fees: {
-      "Name registration fees": "Cost paid to register .eth names across all ETHRegistrarController versions. The 2019 and 2020 controllers report a single combined cost; the current controller (2023+) reports base cost plus temporary Dutch-auction premium, both counted in full.",
+      "Name registration fees": "Cost paid to register .eth names across all ETHRegistrarController versions. The 2019-2020 controllers report a single combined cost; the 2023+ controllers report base cost plus temporary Dutch-auction premium, both counted in full.",
       "Name renewal fees": "Cost paid to renew .eth names across all ETHRegistrarController versions.",
     },
   },

--- a/fees/ens.ts
+++ b/fees/ens.ts
@@ -46,7 +46,7 @@ const fetch = async (options: FetchOptions) => {
   const premiumRegs = await options.getLogs({ target: controller_premium, eventAbi: registered_premium });
   const referrerRegs = await options.getLogs({ target: controller_referrer, eventAbi: registered_referrer });
   [...premiumRegs, ...referrerRegs].forEach((tx: any) =>
-    dailyFees.addGasToken(Number(tx.baseCost) + Number(tx.premium), REGISTRATION)
+    dailyFees.addGasToken(BigInt(tx.baseCost) + BigInt(tx.premium), REGISTRATION)
   );
 
   // Renewals: 4-field event on controllers 1-4, 5-field (referrer) event on controller 5.


### PR DESCRIPTION
## Problem

The ENS fee adapter mapped the wrong `NameRegistered` event ABI to each registrar controller. Verified against on-chain logs:

| Controller | Real `NameRegistered` | Adapter used | Result |
|---|---|---|---|
| `0xf0ad5cad` (2019 launch) | cost-only | cost-only | ok |
| `0x283af0` (2020) | cost-only | baseCost+premium | topic0 never matches -> dropped |
| `0x253553` (current, 2023+) | baseCost+premium | cost-only | topic0 never matches -> dropped |

Because the active controller since 2023 (`0x253553`) emits `baseCost+premium` but was decoded as cost-only, **every registration through it was silently dropped** and the live series became renewals-only. The adapter also started at 2023-02-23 (launch was 2019) and applied a `< 10 ETH` cap that discarded premium-auction and short-name registrations.

## Fix

- Decode each controller with its real ABI: cost-only for `0xf0ad5cad` + `0x283af0`, `baseCost+premium` for `0x253553`.
- Add the original 2019 controller `0xf0ad5cad` and move `start` to 2019-05-04 (ENS .eth permanent registrar launch).
- Remove the `< 10 ETH` cap; the temporary premium is a legitimate Dutch-auction price, not a data glitch.
- Add `ProtocolRevenue`: per ENS docs, 100% of registration and renewal fees flow to the ENS DAO treasury, with no supply-side split, no distribution to token holders, and no buyback. So fees = revenue = protocol revenue.

## Verification

Tested across all controller eras (registration fees now decode where they previously read $0):

| Day | Registrations (before -> after) | Renewals |
|---|---|---|
| 2022-05-01 (cost controller) | $0 -> $583,815 | $37,913 |
| 2023-08-13 (premium controller, full day) | ~$198k cached -> $199,883 | $33,777 |
| recent day | $0 -> $20 | $1,390 |

Methodology confirmed against the ENS docs (.eth registrar pricing, 21-day temporary premium, treasury as sole recipient). A full refill will recompute accurate history from 2019 onward.