### PR TITLE
feat(metronome-synth): update MetBasis gauges and pools for migration

### DIFF
--- a/fees/metronome-synth/index.ts
+++ b/fees/metronome-synth/index.ts
@@ -70,12 +70,21 @@ const EXTRA_INFLOWS: Record<string, InflowEntry[]> = {
   ],
   [CHAIN.BASE]: [
     {
+      // Old MetBasis msUSD/msETH gauge (retired; kept for history).
       label: METBASIS_LABEL,
       target: "0x3b06D40f1a7AD2D936B5F11A161e84DD637945B6",
       tokens: ["0x940181a94A35A4569E4529A3CDfB74e38FD98631"], // AERO from MetBasis gauge
       fromAddressFilter: "0x019a8a996B6cb2e2e12fe95997FA9ef733c99765",
     },
     {
+      // New MetBasis msUSD/msETH gauge, live since the pool migration.
+      label: METBASIS_LABEL,
+      target: "0x3b06D40f1a7AD2D936B5F11A161e84DD637945B6",
+      tokens: ["0x940181a94A35A4569E4529A3CDfB74e38FD98631"], // AERO from MetBasis gauge
+      fromAddressFilter: "0xdf2bd73E1aB97CecCc583466c86C95d2eD1c1514",
+    },
+    {
+      // Old MetBasis msUSD/msETH pool (retired; kept for history).
       label: METBASIS_LABEL,
       target: "0x3b06D40f1a7AD2D936B5F11A161e84DD637945B6",
       tokens: [
@@ -85,10 +94,23 @@ const EXTRA_INFLOWS: Record<string, InflowEntry[]> = {
       fromAddressFilter: "0x8845126640B36df1D24bf3dF9B2903fD4c730FE6",
     },
     {
+      // New MetBasis msUSD/msETH pool, live since the pool migration.
+      label: METBASIS_LABEL,
+      target: "0x3b06D40f1a7AD2D936B5F11A161e84DD637945B6",
+      tokens: [
+        "0x526728DBc96689597F85ae4cd716d4f7fCcBAE9d", // msUSD
+        "0x7Ba6F01772924a82D9626c126347A28299E98c98", // msETH
+      ],
+      fromAddressFilter: "0x00145e8Fc9F06a0b71bd57fEfBF451ec1dB9D69f",
+    },
+    {
       label: AERO_LABEL,
       target: "0x3b06D40f1a7AD2D936B5F11A161e84DD637945B6",
       tokens: ["0x940181a94A35A4569E4529A3CDfB74e38FD98631"], // AERO
-      excludeFromAddresses: ["0x019a8a996B6cb2e2e12fe95997FA9ef733c99765"], // exclude MetBasis gauge
+      excludeFromAddresses: [
+        "0x019a8a996B6cb2e2e12fe95997FA9ef733c99765", // old MetBasis gauge
+        "0xdf2bd73E1aB97CecCc583466c86C95d2eD1c1514", // new MetBasis gauge
+      ],
     },
   ],
   [CHAIN.ETHEREUM]: [


### PR DESCRIPTION
- Added new MetBasis msUSD/msETH gauge and pool, reflecting recent migration.
- Retained historical references for retired gauges and pools.
- Updated exclusion list for AERO_LABEL to include both old and new MetBasis gauges.