### PR TITLE
[add] PEPTIDES - fees adapter

### DIFF
--- a/fees/peptimart/index.ts
+++ b/fees/peptimart/index.ts
@@ -3,8 +3,6 @@ import { CHAIN } from "../../helpers/chains";
 import fetchURL from "../../utils/fetchURL";
 
 const FEES_API = "https://peptimart.xyz/api/defillama/fees";
-// Solana mint: https://pump.fun/coin/61aNNrrRp81a3ZztDL69dNyrcshBsqWZdWVSrpYpump
-const PEPTI_MINT = "61aNNrrRp81a3ZztDL69dNyrcshBsqWZdWVSrpYpump";
 
 type FeesPayload = {
   date: string;
@@ -37,21 +35,19 @@ const breakdownMethodology = {
     "Merchandise Sales":
       "Total paid checkout value at PEPTIDES for the calendar day (UTC).",
   },
-  SupplySideRevenue: {
-    "Buyback Allocation":
+  HoldersRevenue: {
+    "Merchandise Sales to Buybacks":
       "Ten percent of gross merchandise sales allocated to the $PEPTI buyback program.",
   },
-  HoldersRevenue: {
-    "Token Burns":
-      "Total $PEPTI permanently burned on Solana during the calendar day (UTC). Not counted as protocol revenue.",
-  },
   ProtocolRevenue: {
-    "Store Operations":
-      "Gross merchandise sales less the ten percent buyback allocation.",
+    "Merchandise Sales to Store Operations":
+      "Net revenue retained for PEPTIDES store operations after the buyback allocation.",
   },
   Revenue: {
-    "Store Operations":
-      "Net revenue supporting PEPTIDES operations and catalog.",
+    "Merchandise Sales to Buybacks":
+      "Ten percent of gross merchandise sales allocated to the $PEPTI buyback program.",
+    "Merchandise Sales to Store Operations":
+      "Net revenue retained for PEPTIDES store operations after the buyback allocation.",
   },
 };
 
@@ -69,33 +65,25 @@ const fetch = async (options: FetchOptions) => {
 
   const dailyFees = options.createBalances();
   const dailyRevenue = options.createBalances();
-  const dailySupplySideRevenue = options.createBalances();
   const dailyHoldersRevenue = options.createBalances();
   const dailyProtocolRevenue = options.createBalances();
 
   dailyFees.addUSDValue(data.purchasesUsd, "Merchandise Sales");
-  dailySupplySideRevenue.addUSDValue(data.buybackUsd, "Buyback Allocation");
-  dailyProtocolRevenue.addUSDValue(storeOperationsUsd, "Store Operations");
-  dailyRevenue.addUSDValue(storeOperationsUsd, "Store Operations");
-
-  if (data.peptiBurned > 0) {
-    // Pump.fun SPL tokens use 6 decimal places
-    const raw = Math.round(data.peptiBurned * 1e6).toString();
-    dailyHoldersRevenue.add(PEPTI_MINT, raw, "Token Burns");
-  }
+  dailyProtocolRevenue.addUSDValue(storeOperationsUsd, "Merchandise Sales to Store Operations");
+  dailyRevenue.addUSDValue(storeOperationsUsd, "Merchandise Sales to Store Operations");
+  dailyRevenue.addUSDValue(data.buybackUsd, "Merchandise Sales to Buybacks");
+  dailyHoldersRevenue.addUSDValue(data.buybackUsd, "Merchandise Sales to Buybacks");
 
   return {
     dailyFees,
     dailyRevenue,
-    dailySupplySideRevenue,
     dailyHoldersRevenue,
     dailyProtocolRevenue,
   };
 };
 
 const adapter: SimpleAdapter = {
-  version: 2,
-  pullHourly: false, // peptimart.xyz API returns one UTC daily aggregate per date param
+  version: 1,
   fetch,
   chains: [CHAIN.SOLANA],
   start: "2026-05-27",

--- a/fees/peptimart/index.ts
+++ b/fees/peptimart/index.ts
@@ -3,9 +3,6 @@ import { CHAIN } from "../../helpers/chains";
 import { httpGet } from "../../utils/fetchURL";
 
 const FEES_API = "https://peptimart.xyz/api/defillama/fees";
-/** Origin fallback when Cloudflare bot protection blocks datacenter IPs (e.g. GitHub Actions CI). */
-const FEES_API_ORIGIN_FALLBACK =
-  "https://pepti-mart-production.up.railway.app/api/defillama/fees";
 
 type FeesPayload = {
   date: string;
@@ -56,33 +53,10 @@ function feesRequestHeaders(): Record<string, string> {
   return headers;
 }
 
-function isForbiddenError(error: unknown): boolean {
-  const status =
-    (error as { response?: { status?: number } })?.response?.status ??
-    (error as { status?: number })?.status;
-  return status === 403;
-}
-
-async function fetchFeesPayload(dateString: string): Promise<ApiResponse> {
-  const query = `?date=${dateString}`;
-  const headers = feesRequestHeaders();
-  const urls = [`${FEES_API}${query}`, `${FEES_API_ORIGIN_FALLBACK}${query}`];
-
-  let lastError: unknown;
-  for (const url of urls) {
-    try {
-      return (await httpGet(url, { headers })) as ApiResponse;
-    } catch (error) {
-      lastError = error;
-      if (!isForbiddenError(error)) throw error;
-    }
-  }
-
-  throw lastError;
-}
-
 const fetch = async (options: FetchOptions) => {
-  const response = await fetchFeesPayload(options.dateString);
+  const response = (await httpGet(`${FEES_API}?date=${options.dateString}`, {
+    headers: feesRequestHeaders(),
+  })) as ApiResponse;
 
   if (!response?.ok || !response.data) {
     throw new Error(`Invalid response from PEPTIDES fees API for ${options.dateString}`);

--- a/fees/peptimart/index.ts
+++ b/fees/peptimart/index.ts
@@ -47,8 +47,8 @@ const fetch = async (options: FetchOptions) => {
 
 const methodology = {
   Fees: "Gross revenue from paid merchandise sales at PEPTIDES (tracked as 10 times of $PEPTIDES burnt using burn wallet).",
-  Revenue: "Includes 90% of revenue retained for PEPTIDES store and 10% allocated to the $PEPTI buyback program.",
-  HoldersRevenue: "10% of gross merchandise sales allocated to the $PEPTI buyback program.",
+  Revenue: "Includes 90% of revenue retained for PEPTIDES store and 10% allocated to the $PEPTIDES buyback program.",
+  HoldersRevenue: "10% of gross merchandise sales allocated to the $PEPTIDES buyback program.",
   ProtocolRevenue: "90% of revenue retained for PEPTIDES store operations.",
 };
 
@@ -57,13 +57,13 @@ const breakdownMethodology = {
     "Merchandise Sales": "Daily gross revenue from paid merchandise sales at PEPTIDES (tracked as 10 times of $PEPTIDES burnt using burn wallet).",
   },
   HoldersRevenue: {
-    "Merchandise Sales to Buybacks": "10% of gross merchandise sales allocated to the $PEPTI buyback and burn program.",
+    "Merchandise Sales to Buybacks": "10% of gross merchandise sales allocated to the $PEPTIDES buyback and burn program.",
   },
   ProtocolRevenue: {
     "Merchandise Sales to Store Operations": "90% of revenue retained for PEPTIDES store operations.",
   },
   Revenue: {
-    "Merchandise Sales to Buybacks": "10% of gross merchandise sales allocated to the $PEPTI buyback program.",
+    "Merchandise Sales to Buybacks": "10% of gross merchandise sales allocated to the $PEPTIDES buyback program.",
     "Merchandise Sales to Store Operations": "90% of revenue retained for PEPTIDES store operations.",
   },
 };

--- a/fees/peptimart/index.ts
+++ b/fees/peptimart/index.ts
@@ -1,0 +1,95 @@
+import { FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import fetchURL from "../../utils/fetchURL";
+
+const FEES_API = "https://peptimart.xyz/api/defillama/fees";
+const PEPTI_MINT = "61aNNrrRp81a3ZztDL69dNyrcshBsqWZdWVSrpYpump";
+
+type FeesPayload = {
+  date: string;
+  purchasesUsd: number;
+  buybackUsd: number;
+  orderCount: number;
+  burnsCount: number;
+  peptiBurned: number;
+};
+
+type ApiResponse = {
+  ok: boolean;
+  data: FeesPayload;
+};
+
+const methodology = {
+  Fees: "Gross revenue from paid merchandise sales at PEPTI MART.",
+  Revenue:
+    "Net protocol revenue from store sales after the ten percent buyback allocation.",
+  HoldersRevenue:
+    "On-chain $PEPTI permanently burned during the day. This is supply reduction, not protocol revenue.",
+  ProtocolRevenue:
+    "Net revenue retained for PEPTI MART operations after the buyback allocation.",
+};
+
+const breakdownMethodology = {
+  Fees: {
+    "Merchandise Sales":
+      "Total paid checkout value at PEPTI MART for the calendar day (UTC).",
+  },
+  HoldersRevenue: {
+    "Token Burns":
+      "Total $PEPTI permanently burned on Solana during the calendar day (UTC). Not counted as protocol revenue.",
+  },
+  ProtocolRevenue: {
+    "Store Operations":
+      "Gross merchandise sales less the ten percent buyback allocation.",
+  },
+  Revenue: {
+    "Store Operations":
+      "Net revenue supporting PEPTI MART operations and catalog.",
+  },
+};
+
+const fetch = async (options: FetchOptions) => {
+  const response = (await fetchURL(
+    `${FEES_API}?date=${options.dateString}`,
+  )) as ApiResponse;
+
+  if (!response?.ok || !response.data) {
+    throw new Error(`Invalid response from PEPTI MART fees API for ${options.dateString}`);
+  }
+
+  const data = response.data;
+  const storeOperationsUsd = data.purchasesUsd - data.buybackUsd;
+
+  const dailyFees = options.createBalances();
+  const dailyRevenue = options.createBalances();
+  const dailyHoldersRevenue = options.createBalances();
+  const dailyProtocolRevenue = options.createBalances();
+
+  dailyFees.addUSDValue(data.purchasesUsd, "Merchandise Sales");
+  dailyProtocolRevenue.addUSDValue(storeOperationsUsd, "Store Operations");
+  dailyRevenue.addUSDValue(storeOperationsUsd, "Store Operations");
+
+  if (data.peptiBurned > 0) {
+    const raw = Math.round(data.peptiBurned * 1e6).toString();
+    dailyHoldersRevenue.add(PEPTI_MINT, raw, "Token Burns");
+  }
+
+  return {
+    dailyFees,
+    dailyRevenue,
+    dailyHoldersRevenue,
+    dailyProtocolRevenue,
+  };
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  pullHourly: false,
+  fetch,
+  chains: [CHAIN.SOLANA],
+  start: "2026-05-27",
+  methodology,
+  breakdownMethodology,
+};
+
+export default adapter;

--- a/fees/peptimart/index.ts
+++ b/fees/peptimart/index.ts
@@ -1,8 +1,11 @@
 import { FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
-import fetchURL from "../../utils/fetchURL";
+import { httpGet } from "../../utils/fetchURL";
 
 const FEES_API = "https://peptimart.xyz/api/defillama/fees";
+/** Origin fallback when Cloudflare bot protection blocks datacenter IPs (e.g. GitHub Actions CI). */
+const FEES_API_ORIGIN_FALLBACK =
+  "https://pepti-mart-production.up.railway.app/api/defillama/fees";
 
 type FeesPayload = {
   date: string;
@@ -43,10 +46,43 @@ const breakdownMethodology = {
   },
 };
 
+function feesRequestHeaders(): Record<string, string> {
+  const headers: Record<string, string> = {
+    Accept: "application/json",
+    "User-Agent": "defillama-dimension-adapters/1.0",
+  };
+  const apiKey = process.env.PEPTIMART_FEES_API_KEY?.trim();
+  if (apiKey) headers["x-defillama-api-key"] = apiKey;
+  return headers;
+}
+
+function isForbiddenError(error: unknown): boolean {
+  const status =
+    (error as { response?: { status?: number } })?.response?.status ??
+    (error as { status?: number })?.status;
+  return status === 403;
+}
+
+async function fetchFeesPayload(dateString: string): Promise<ApiResponse> {
+  const query = `?date=${dateString}`;
+  const headers = feesRequestHeaders();
+  const urls = [`${FEES_API}${query}`, `${FEES_API_ORIGIN_FALLBACK}${query}`];
+
+  let lastError: unknown;
+  for (const url of urls) {
+    try {
+      return (await httpGet(url, { headers })) as ApiResponse;
+    } catch (error) {
+      lastError = error;
+      if (!isForbiddenError(error)) throw error;
+    }
+  }
+
+  throw lastError;
+}
+
 const fetch = async (options: FetchOptions) => {
-  const response = (await fetchURL(
-    `${FEES_API}?date=${options.dateString}`,
-  )) as ApiResponse;
+  const response = await fetchFeesPayload(options.dateString);
 
   if (!response?.ok || !response.data) {
     throw new Error(`Invalid response from PEPTIDES fees API for ${options.dateString}`);

--- a/fees/peptimart/index.ts
+++ b/fees/peptimart/index.ts
@@ -3,6 +3,7 @@ import { CHAIN } from "../../helpers/chains";
 import fetchURL from "../../utils/fetchURL";
 
 const FEES_API = "https://peptimart.xyz/api/defillama/fees";
+// Solana mint: https://pump.fun/coin/61aNNrrRp81a3ZztDL69dNyrcshBsqWZdWVSrpYpump
 const PEPTI_MINT = "61aNNrrRp81a3ZztDL69dNyrcshBsqWZdWVSrpYpump";
 
 type FeesPayload = {
@@ -20,19 +21,25 @@ type ApiResponse = {
 };
 
 const methodology = {
-  Fees: "Gross revenue from paid merchandise sales at PEPTI MART.",
+  Fees: "Gross revenue from paid merchandise sales at PEPTIDES.",
+  SupplySideRevenue:
+    "Ten percent of gross merchandise sales allocated to the $PEPTI buyback program.",
   Revenue:
     "Net protocol revenue from store sales after the ten percent buyback allocation.",
   HoldersRevenue:
     "On-chain $PEPTI permanently burned during the day. This is supply reduction, not protocol revenue.",
   ProtocolRevenue:
-    "Net revenue retained for PEPTI MART operations after the buyback allocation.",
+    "Net revenue retained for PEPTIDES store operations after the buyback allocation.",
 };
 
 const breakdownMethodology = {
   Fees: {
     "Merchandise Sales":
-      "Total paid checkout value at PEPTI MART for the calendar day (UTC).",
+      "Total paid checkout value at PEPTIDES for the calendar day (UTC).",
+  },
+  SupplySideRevenue: {
+    "Buyback Allocation":
+      "Ten percent of gross merchandise sales allocated to the $PEPTI buyback program.",
   },
   HoldersRevenue: {
     "Token Burns":
@@ -44,7 +51,7 @@ const breakdownMethodology = {
   },
   Revenue: {
     "Store Operations":
-      "Net revenue supporting PEPTI MART operations and catalog.",
+      "Net revenue supporting PEPTIDES operations and catalog.",
   },
 };
 
@@ -54,7 +61,7 @@ const fetch = async (options: FetchOptions) => {
   )) as ApiResponse;
 
   if (!response?.ok || !response.data) {
-    throw new Error(`Invalid response from PEPTI MART fees API for ${options.dateString}`);
+    throw new Error(`Invalid response from PEPTIDES fees API for ${options.dateString}`);
   }
 
   const data = response.data;
@@ -62,14 +69,17 @@ const fetch = async (options: FetchOptions) => {
 
   const dailyFees = options.createBalances();
   const dailyRevenue = options.createBalances();
+  const dailySupplySideRevenue = options.createBalances();
   const dailyHoldersRevenue = options.createBalances();
   const dailyProtocolRevenue = options.createBalances();
 
   dailyFees.addUSDValue(data.purchasesUsd, "Merchandise Sales");
+  dailySupplySideRevenue.addUSDValue(data.buybackUsd, "Buyback Allocation");
   dailyProtocolRevenue.addUSDValue(storeOperationsUsd, "Store Operations");
   dailyRevenue.addUSDValue(storeOperationsUsd, "Store Operations");
 
   if (data.peptiBurned > 0) {
+    // Pump.fun SPL tokens use 6 decimal places
     const raw = Math.round(data.peptiBurned * 1e6).toString();
     dailyHoldersRevenue.add(PEPTI_MINT, raw, "Token Burns");
   }
@@ -77,6 +87,7 @@ const fetch = async (options: FetchOptions) => {
   return {
     dailyFees,
     dailyRevenue,
+    dailySupplySideRevenue,
     dailyHoldersRevenue,
     dailyProtocolRevenue,
   };
@@ -84,7 +95,7 @@ const fetch = async (options: FetchOptions) => {
 
 const adapter: SimpleAdapter = {
   version: 2,
-  pullHourly: false,
+  pullHourly: false, // peptimart.xyz API returns one UTC daily aggregate per date param
   fetch,
   chains: [CHAIN.SOLANA],
   start: "2026-05-27",

--- a/fees/peptimart/index.ts
+++ b/fees/peptimart/index.ts
@@ -20,14 +20,9 @@ type ApiResponse = {
 
 const methodology = {
   Fees: "Gross revenue from paid merchandise sales at PEPTIDES.",
-  SupplySideRevenue:
-    "Ten percent of gross merchandise sales allocated to the $PEPTI buyback program.",
-  Revenue:
-    "Net protocol revenue from store sales after the ten percent buyback allocation.",
-  HoldersRevenue:
-    "On-chain $PEPTI permanently burned during the day. This is supply reduction, not protocol revenue.",
-  ProtocolRevenue:
-    "Net revenue retained for PEPTIDES store operations after the buyback allocation.",
+  Revenue: "Includes 90% of revenue retained for PEPTIDES store and 10% allocated to the $PEPTI buyback program.",
+  HoldersRevenue: "10% of gross merchandise sales allocated to the $PEPTI buyback program.",
+  ProtocolRevenue: "90% of revenue retained for PEPTIDES store operations.",
 };
 
 const breakdownMethodology = {
@@ -37,17 +32,14 @@ const breakdownMethodology = {
   },
   HoldersRevenue: {
     "Merchandise Sales to Buybacks":
-      "Ten percent of gross merchandise sales allocated to the $PEPTI buyback program.",
+      "10% of gross merchandise sales allocated to the $PEPTI buyback program.",
   },
   ProtocolRevenue: {
-    "Merchandise Sales to Store Operations":
-      "Net revenue retained for PEPTIDES store operations after the buyback allocation.",
+    "Merchandise Sales to Store Operations": "90% of revenue retained for PEPTIDES store operations.",
   },
   Revenue: {
-    "Merchandise Sales to Buybacks":
-      "Ten percent of gross merchandise sales allocated to the $PEPTI buyback program.",
-    "Merchandise Sales to Store Operations":
-      "Net revenue retained for PEPTIDES store operations after the buyback allocation.",
+    "Merchandise Sales to Buybacks": "10% of gross merchandise sales allocated to the $PEPTI buyback program.",
+    "Merchandise Sales to Store Operations": "90% of revenue retained for PEPTIDES store operations.",
   },
 };
 

--- a/fees/peptimart/index.ts
+++ b/fees/peptimart/index.ts
@@ -1,25 +1,52 @@
-import { FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { Dependencies, FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
-import { httpGet } from "../../utils/fetchURL";
+import { queryAllium } from "../../helpers/allium";
 
-const FEES_API = "https://peptimart.xyz/api/defillama/fees";
+const PEPTIDES_CG_ID = "peptides-2";
+const PEPTIDES_MINT = "61aNNrrRp81a3ZztDL69dNyrcshBsqWZdWVSrpYpump";
+const BURN_WALLET = "6TfZee8VA7FKGKxrt56z3YnffrSS3aBX1kKJNiDh5a3N";
+const BURN_FEE_RATE = 0.1;
+const PEPTIDES_DECIMALS = 6;
 
-type FeesPayload = {
-  date: string;
-  purchasesUsd: number;
-  buybackUsd: number;
-  orderCount: number;
-  burnsCount: number;
-  peptiBurned: number;
-};
+const fetch = async (options: FetchOptions) => {
+  const dailyFees = options.createBalances();
+  const dailyHoldersRevenue = options.createBalances();
+  const dailyProtocolRevenue = options.createBalances();
 
-type ApiResponse = {
-  ok: boolean;
-  data: FeesPayload;
+  const query = `
+    SELECT
+      COALESCE(SUM(raw_amount) / 1e${PEPTIDES_DECIMALS}, 0) AS peptides_burnt
+    FROM solana.assets.transfers
+    WHERE mint = '${PEPTIDES_MINT}'
+      AND from_address = '${BURN_WALLET}'
+      AND type IN ('burn', 'burnChecked')
+      AND block_timestamp >= TO_TIMESTAMP_NTZ(${options.startTimestamp})
+      AND block_timestamp <  TO_TIMESTAMP_NTZ(${options.endTimestamp})
+  `;
+  const data = await queryAllium(query);
+
+  const peptidesBurnt = data[0].peptides_burnt;
+  if (peptidesBurnt > 0) {
+    const grossSales = peptidesBurnt * (1 / (BURN_FEE_RATE));
+    const ProtocolRevenue = grossSales - peptidesBurnt;
+    dailyFees.addCGToken(PEPTIDES_CG_ID, grossSales, "Merchandise Sales");
+    dailyHoldersRevenue.addCGToken(PEPTIDES_CG_ID, peptidesBurnt, "Merchandise Sales to Buybacks");
+    dailyProtocolRevenue.addCGToken(PEPTIDES_CG_ID, ProtocolRevenue, "Merchandise Sales to Protocol Operations");
+  }
+
+  const dailyRevenue = dailyHoldersRevenue.clone();
+  dailyRevenue.add(dailyProtocolRevenue);
+
+  return {
+    dailyFees,
+    dailyRevenue,
+    dailyHoldersRevenue,
+    dailyProtocolRevenue,
+  };
 };
 
 const methodology = {
-  Fees: "Gross revenue from paid merchandise sales at PEPTIDES.",
+  Fees: "Gross revenue from paid merchandise sales at PEPTIDES (tracked as 10 times of $PEPTIDES burnt using burn wallet).",
   Revenue: "Includes 90% of revenue retained for PEPTIDES store and 10% allocated to the $PEPTI buyback program.",
   HoldersRevenue: "10% of gross merchandise sales allocated to the $PEPTI buyback program.",
   ProtocolRevenue: "90% of revenue retained for PEPTIDES store operations.",
@@ -27,12 +54,10 @@ const methodology = {
 
 const breakdownMethodology = {
   Fees: {
-    "Merchandise Sales":
-      "Total paid checkout value at PEPTIDES for the calendar day (UTC).",
+    "Merchandise Sales": "Daily gross revenue from paid merchandise sales at PEPTIDES (tracked as 10 times of $PEPTIDES burnt using burn wallet).",
   },
   HoldersRevenue: {
-    "Merchandise Sales to Buybacks":
-      "10% of gross merchandise sales allocated to the $PEPTI buyback program.",
+    "Merchandise Sales to Buybacks": "10% of gross merchandise sales allocated to the $PEPTI buyback and burn program.",
   },
   ProtocolRevenue: {
     "Merchandise Sales to Store Operations": "90% of revenue retained for PEPTIDES store operations.",
@@ -43,54 +68,16 @@ const breakdownMethodology = {
   },
 };
 
-function feesRequestHeaders(): Record<string, string> {
-  const headers: Record<string, string> = {
-    Accept: "application/json",
-    "User-Agent": "defillama-dimension-adapters/1.0",
-  };
-  const apiKey = process.env.PEPTIMART_FEES_API_KEY?.trim();
-  if (apiKey) headers["x-defillama-api-key"] = apiKey;
-  return headers;
-}
-
-const fetch = async (options: FetchOptions) => {
-  const response = (await httpGet(`${FEES_API}?date=${options.dateString}`, {
-    headers: feesRequestHeaders(),
-  })) as ApiResponse;
-
-  if (!response?.ok || !response.data) {
-    throw new Error(`Invalid response from PEPTIDES fees API for ${options.dateString}`);
-  }
-
-  const data = response.data;
-  const storeOperationsUsd = data.purchasesUsd - data.buybackUsd;
-
-  const dailyFees = options.createBalances();
-  const dailyRevenue = options.createBalances();
-  const dailyHoldersRevenue = options.createBalances();
-  const dailyProtocolRevenue = options.createBalances();
-
-  dailyFees.addUSDValue(data.purchasesUsd, "Merchandise Sales");
-  dailyProtocolRevenue.addUSDValue(storeOperationsUsd, "Merchandise Sales to Store Operations");
-  dailyRevenue.addUSDValue(storeOperationsUsd, "Merchandise Sales to Store Operations");
-  dailyRevenue.addUSDValue(data.buybackUsd, "Merchandise Sales to Buybacks");
-  dailyHoldersRevenue.addUSDValue(data.buybackUsd, "Merchandise Sales to Buybacks");
-
-  return {
-    dailyFees,
-    dailyRevenue,
-    dailyHoldersRevenue,
-    dailyProtocolRevenue,
-  };
-};
-
 const adapter: SimpleAdapter = {
-  version: 1,
+  version: 2,
   fetch,
   chains: [CHAIN.SOLANA],
   start: "2026-05-27",
+  dependencies: [Dependencies.ALLIUM],
+  isExpensiveAdapter: true,
   methodology,
   breakdownMethodology,
+  pullHourly: true,
 };
 
 export default adapter;


### PR DESCRIPTION
**NOTE**

#### Please enable "Allow edits by maintainers" while putting up the PR.

---

> - If you would like to add a `tvl` adapter please submit the PR [here](https://github.com/DefiLlama/DefiLlama-Adapters).

1. Once your adapter has been merged, it takes time to show on the UI. If more than 24 hours have passed, please let us know in Discord.
2. Please fill the form below **only if the PR is for listing a new protocol** else it can be ignored/replaced with reason/details about the PR
3. **For updating listing info** Please send a mail to metadata@defillama.com
4. Do not edit/push `package.json/package-lock.json` file as part of your changes
5. No need to go to our discord/other channel and announce that you've created a PR, we monitor all PRs and will review it asap

---

## Summary

Adds PEPTIDES to the Solana Revenue Rankings.

PEPTIDES is a peptide research catalog operated at peptimart.xyz. Gross store revenue funds automated $PEPTI buybacks and burns on Solana. Live metrics are published at https://peptimart.xyz/token/burns.

## Data source

https://peptimart.xyz/api/defillama/fees?date=YYYY-MM-DD

The API returns one UTC daily aggregate per date. `pullHourly: false` because hourly windows are not supported by the endpoint.

## Methodology

- **Fees:** Gross revenue from paid merchandise sales at PEPTIDES (peptimart.xyz).
- **Supply-side revenue:** Gross merchandise sales allocated to the $PEPTI buyback program (`Buyback Allocation`).
- **Revenue:** Net protocol revenue from store sales after the buyback allocation (`Store Operations`). Balances as `dailyFees = dailyRevenue + dailySupplySideRevenue`.
- **Protocol revenue:** Same net store operations amount retained for PEPTIDES operations.
- **Holders revenue:** On-chain $PEPTI token burns only (supply reduction, not protocol revenue).

## Links

- Website: https://peptimart.xyz
- Buybacks tracker: https://peptimart.xyz/token/burns
- Token: https://pump.fun/coin/61aNNrrRp81a3ZztDL69dNyrcshBsqWZdWVSrpYpump
- Twitter: https://x.com/peptimart_

## Test plan

- [x] `pnpm test fees peptimart`
- [x] `pnpm test fees peptimart 2026-07-06`
- [x] Production API verified on peptimart.xyz
- [x] Income statement balances (e.g. 2026-07-05: $1,730 fees = $1,557 revenue + $173 supply-side)
- [ ] Allow edits by maintainers enabled

---

##### Name (to be shown on DefiLlama):

PEPTIDES

##### Twitter Link:

https://x.com/peptimart_

##### List of audit links if any:

(none)

##### Website Link:

https://peptimart.xyz

##### Logo (High resolution, will be shown with rounded borders):

https://peptimart.xyz/android-chrome-512x512.png

##### Current TVL:

$0 — revenue/fees listing only, not a TVL protocol

##### Treasury Addresses (if the protocol has treasury)

(optional)

##### Chain:

Solana

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed): (https://api.coingecko.com/api/v3/coins/list)

peptides-2

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)

##### Short Description (to be shown on DefiLlama):

PEPTIDES is a peptide research catalog. Gross store revenue funds automated $PEPTI buybacks and burns on Solana.

##### Token address and ticker if any:

61aNNrrRp81a3ZztDL69dNyrcshBsqWZdWVSrpYpump ($PEPTI, Solana)

##### Category (full list at https://defillama.com/categories) *Please choose only one:

Commerce

##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.):

N/A

##### Implementation Details: Briefly describe how the oracle is integrated into your project:

N/A

##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage:

N/A

##### forkedFrom (Does your project originate from another project):

(none)

##### methodology (what is being counted as tvl, how is tvl being calculated):

Gross paid merchandise sales as dailyFees; 10% buyback allocation as dailySupplySideRevenue; net store operations as dailyRevenue/dailyProtocolRevenue; on-chain $PEPTI burns as dailyHoldersRevenue only. See fees/peptimart/index.ts.

##### Github org/user (Optional, if your code is open source, we can track activity):

https://github.com/peptimart

##### Does this project have a referral program?

Yes — affiliate referral commissions (supply-side; not broken out in this adapter)