### PR TITLE
[fix] ENS - controller-4 renewals report cost in USD, not ETH

### DIFF
--- a/fees/ens.ts
+++ b/fees/ens.ts
@@ -49,10 +49,21 @@ const fetch = async (options: FetchOptions) => {
     dailyFees.addGasToken(BigInt(tx.baseCost) + BigInt(tx.premium), REGISTRATION)
   );
 
-  // Renewals: 4-field event on controllers 1-4, 5-field (referrer) event on controller 5.
-  const renewals = await options.getLogs({ targets: [...controllers_cost, controller_premium], eventAbi: renewed });
+  // Renewals. Unit quirk: the 2023 controller (0x253553) emits NameRenewed.cost in USD
+  // (attoUSD, 1e18 = $1), NOT ETH wei - a known bug in that controller version. Its
+  // registration events are still ETH, and the 2019/2020 controllers and the current controller
+  // (0x59e16f) emit renewal cost in ETH. ENS's own analytics work around this with a dedicated
+  // conversion table; here we add the 2023 controller's renewals as a USD value and the rest as
+  // the gas token. Verified on-chain: a 0x253553 renewal tx sending 0.22 ETH emits cost summing
+  // to ~257 (=$257), while a 0x59e16f renewal of 0.0065 ETH emits cost 0.0064 (ETH).
+  const renewalsEth = await options.getLogs({ targets: controllers_cost, eventAbi: renewed });
+  renewalsEth.forEach((tx: any) => dailyFees.addGasToken(tx.cost, RENEWAL));
+
   const referrerRenewals = await options.getLogs({ target: controller_referrer, eventAbi: renewed_referrer });
-  [...renewals, ...referrerRenewals].forEach((tx: any) => dailyFees.addGasToken(tx.cost, RENEWAL));
+  referrerRenewals.forEach((tx: any) => dailyFees.addGasToken(tx.cost, RENEWAL));
+
+  const renewalsUsd = await options.getLogs({ target: controller_premium, eventAbi: renewed });
+  renewalsUsd.forEach((tx: any) => dailyFees.addUSDValue(Number(tx.cost) / 1e18, RENEWAL));
 
   return {
     dailyFees,


### PR DESCRIPTION
Follow-up to #7978. After that merged, daily ENS fees showed impossible $10-35M spikes throughout 2025 (e.g. 2025-01-26 $17.99M, 2025-06-02 ~$35M) - more than ENS earns in a year, in a single day.

## Root cause

The 2023 controller `0x253553366Da8546fC250F225fe3d25d0C782303b` emits `NameRenewed.cost` denominated in **USD** (attoUSD, 1e18 = $1), not ETH wei. This is a bug specific to that controller version: its registration events are still in ETH, and the 2019/2020 controllers and the current controller (`0x59e16f`) emit renewal cost in ETH. Passing the USD value to `addGasToken` multiplied it by the ETH price (~2000-3000x), inflating renewals.

The old adapter's since-removed `< 10 ETH` cap had accidentally masked this (USD-scaled costs looked like ">10 ETH" and were dropped).

## Verification (on-chain)

- A `0x253553` renewal tx that sent **0.22 ETH** emits `cost` summing to **~257** — impossible as ETH (257 ETH), consistent as **$257** USD.
- `0x283af0` (2020): renewal event cost 0.0045 vs 0.0049 ETH sent -> ETH.
- `0x59e16f` (current): renewal event cost 0.0064 vs 0.0065 ETH sent -> ETH.

This matches ENS's own analytics, which route only controller-4 renewals through a trace-based (`value - refund`) conversion table while every other controller uses the raw event.

## Fix

Add controller-4 renewals via `addUSDValue(cost / 1e18)`; all other controllers' renewals stay on `addGasToken`. Registrations are unaffected (ETH on every controller). The event's USD `cost` equals `value - refund` valued in USD, so this is equivalent to ENS's trace-based figure.

Result (2025-01-26): renewals $17,982,339 -> $5,738; registrations unchanged ($11,264).