### PR TITLE
metamask-card: add Monad (FoxConnect contracts, live since Jun 12)

### DIFF
--- a/dexs/metamask-card.ts
+++ b/dexs/metamask-card.ts
@@ -22,6 +22,18 @@ const configs: Record<string, { withdrawContracts: Array<string>, start: string,
     ],
     getTrasnactionLimit: 10000,
   },
+  [CHAIN.MONAD]: {
+    // FoxConnect (MetaMask Card) contracts on Monad (eip155:143), sourced from
+    // MetaMask's own app config: metamask-mobile app/selectors/featureFlagController/card/index.ts
+    // Both are ERC1967 proxies to the same card implementation (0x716bf8c5...df5518),
+    // matching the Linea/Base architecture. Deployed at block 80727203 (2026-06-12).
+    start: '2026-06-12',
+    withdrawContracts: [
+      '0x40a695a16c213afef1c87fd471fb73157b948f3f', // global
+      '0x144c1ce815bd1eb71678978fe8641cc4e3fd59e6', // US
+    ],
+    getTrasnactionLimit: 10000,
+  },
 }
 
 const withdrawAbi = 'function withdraw(address[] tokens,address[] sources,uint256[] amounts)';

--- a/dexs/metamask-card.ts
+++ b/dexs/metamask-card.ts
@@ -6,6 +6,7 @@ import { sleep } from "../utils/utils";
 import { getSolanaReceived } from "../helpers/token";
 import coreAssets from "../helpers/coreAssets.json";
 
+//https://github.com/MetaMask/metamask-mobile/blob/main/app/selectors/featureFlagController/card/index.ts
 const configs: Record<string, { withdrawContracts: Array<string>, start: string, getTrasnactionLimit: number }> = {
   [CHAIN.LINEA]: {
     start: '2024-11-13',
@@ -23,11 +24,7 @@ const configs: Record<string, { withdrawContracts: Array<string>, start: string,
     getTrasnactionLimit: 10000,
   },
   [CHAIN.MONAD]: {
-    // FoxConnect (MetaMask Card) contracts on Monad (eip155:143), sourced from
-    // MetaMask's own app config: metamask-mobile app/selectors/featureFlagController/card/index.ts
-    // Both are ERC1967 proxies to the same card implementation (0x716bf8c5...df5518),
-    // matching the Linea/Base architecture. Deployed at block 80727203 (2026-06-12).
-    start: '2026-06-12',
+    start: '2026-03-10',
     withdrawContracts: [
       '0x40a695a16c213afef1c87fd471fb73157b948f3f', // global
       '0x144c1ce815bd1eb71678978fe8641cc4e3fd59e6', // US


### PR DESCRIPTION
MetaMask officially lists Monad as a supported card chain (metamask.io/card), but the adapter only covers Linea, Base, and Solana. This adds the Monad leg.

Addresses are sourced from MetaMask's own app config (metamask-mobile, app/selectors/featureFlagController/card/index.ts, config key eip155:143, foxConnectAddresses): global 0x40A695A16C213afEf1c87Fd471Fb73157b948f3f, US 0x144c1cE815Bd1Eb71678978fE8641cC4e3fd59e6. The same file lists the exact Linea and Base contracts this adapter already uses, so the config family matches.

Verified onchain via Monad RPC: both are deployed ERC1967 proxies sharing implementation 0x716bf8c59a6bfc7ef606ddfcabbd796110df5518, the same proxy pattern as the Base relayer (whose implementation is verified as W3Card on Base). Deployment block 80727203 (2026-06-12), which is the start date used. Same withdraw() decode path as the existing chains, no logic changes.

Note for maintainers: contracts are ~3 weeks old, so daily volume is early-stage. Local test hits the Allium key requirement (Solana leg), which the error itself says to ignore for the bot.