### PR TITLE
pendle: add hyperliquid

### DIFF
--- a/dexs/pendle/index.ts
+++ b/dexs/pendle/index.ts
@@ -34,6 +34,7 @@ const chains: { [chain: string]: { id: number; start: string } } = {
   [CHAIN.OPTIMISM]: { id: 10, start: '2023-08-11' },
   [CHAIN.BASE]: { id: 8453, start: '2024-11-27' },
   [CHAIN.PLASMA]: { id: 9745, start: "2025-10-01" },
+  [CHAIN.HYPERLIQUID]: { id: 999, start: "2025-07-29" },
   [CHAIN.MONAD]: { id: 143, start: "2026-06-19" },
 };
 


### PR DESCRIPTION
Adds **Hyperliquid (chainId 999)** support to the Pendle adapter.

## Changes

- Added Hyperliquid (999) to the supported chains.
- Enabled tracking for both AMM `Swap` events and limit-order `OrderFilledV2` events.

## Verification

- Verified **5 active markets** on Hyperliquid against Pendle's API.
- Confirmed the AMM market and limit-order router are deployed on-chain and emit the expected events.
- Verified all active SY tokens have DefiLlama prices available.
- Ran `pnpm test dexs pendle`: Hyperliquid reports **~$70k daily volume**