### PR TITLE
Decibel: include fee treasury deposits in fees and revenue

### DIFF
--- a/dexs/decibel/index.ts
+++ b/dexs/decibel/index.ts
@@ -1,9 +1,22 @@
 import { FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 import { getEnv } from "../../helpers/env";
-import { httpGet } from "../../utils/fetchURL";
+import { httpGet, httpPost } from "../../utils/fetchURL";
 
 const API_URL = "https://api.mainnet.aptoslabs.com/decibel/api/v1/daily_stats";
+const APTOS_GRAPHQL = "https://api.mainnet.aptoslabs.com/v1/graphql";
+
+const FEE_TREASURY_ADDRESS =
+  "0xa6ebf45cef6b683cf4275ee8c5f8f92f956a332174f8fd69143daf90115077f2";
+
+const FEE_ASSET_TYPES = new Set([
+  // Native USDC on Aptos (Circle CCTP)
+  "0xbae207659db88bea0cbead6da0ed00aac12edcdda169e591cd41c94180b46f3b",
+  // USDCbl
+  "0x96401f1e3ab3245d056d5a1ba67eef066ac3edc4d5f1b16adc5d567e79a845b0",
+]);
+
+const USD_DECIMALS = 1e6;
 
 interface DailyStatsResponse {
   daily_volume: number;
@@ -12,25 +25,78 @@ interface DailyStatsResponse {
   open_interest: number;
 }
 
-const fetch = async (options: FetchOptions) => {
-  const url = `${API_URL}?start_timestamp=${options.startTimestamp}&end_timestamp=${options.endTimestamp}`;
-  const data: DailyStatsResponse = await httpGet(url, {
+const getTreasuryDepositsUsd = async (
+  fromTimestamp: number,
+  toTimestamp: number
+): Promise<number> => {
+  const fromDate = new Date(fromTimestamp * 1000).toISOString();
+  const toDate = new Date(toTimestamp * 1000).toISOString();
+
+  // Note: filtering by asset_type alongside owner_address triggers a slow query plan on
+  // the Aptos indexer, so we fetch all deposits to the treasury in the window and filter
+  // to the fee-bearing asset types client-side.
+  const query = {
+    query: `
+      query GetTreasuryDeposits($owner: String!, $fromDate: timestamp!, $toDate: timestamp!) {
+        fungible_asset_activities(
+          where: {
+            owner_address: { _eq: $owner },
+            type: { _eq: "0x1::fungible_asset::Deposit" },
+            transaction_timestamp: { _gte: $fromDate, _lt: $toDate }
+          }
+        ) {
+          amount
+          asset_type
+        }
+      }
+    `,
+    variables: {
+      owner: FEE_TREASURY_ADDRESS,
+      fromDate,
+      toDate,
+    },
+  };
+
+  const response = await httpPost(APTOS_GRAPHQL, query, {
     headers: { Authorization: `Bearer ${getEnv("DECIBEL_API_KEY")}` },
   });
+  const activities: { amount: string; asset_type: string }[] =
+    response?.data?.fungible_asset_activities || [];
+
+  let total = 0;
+  for (const activity of activities) {
+    if (FEE_ASSET_TYPES.has(activity.asset_type)) {
+      total += Number(activity.amount) / USD_DECIMALS;
+    }
+  }
+  return total;
+};
+
+const fetch = async (options: FetchOptions) => {
+  const url = `${API_URL}?start_timestamp=${options.startTimestamp}&end_timestamp=${options.endTimestamp}`;
+  const [data, treasuryDepositsUsd] = await Promise.all([
+    httpGet(url, {
+      headers: { Authorization: `Bearer ${getEnv("DECIBEL_API_KEY")}` },
+    }) as Promise<DailyStatsResponse>,
+    getTreasuryDepositsUsd(options.fromTimestamp, options.toTimestamp),
+  ]);
+
+  const dailyFees = data.daily_fees + treasuryDepositsUsd;
+  const dailyRevenue = data.daily_revenue + treasuryDepositsUsd;
 
   return {
     dailyVolume: data.daily_volume,
-    dailyFees: data.daily_fees,
-    dailyUserFees: data.daily_fees,
-    dailyRevenue: data.daily_revenue,
+    dailyFees,
+    dailyUserFees: dailyFees,
+    dailyRevenue,
     openInterestAtEnd: data.open_interest,
   };
 };
 
 const methodology = {
   Volume: "Sum of notional value of all taker fills across perpetual futures markets.",
-  Fees: "Trading fees collected from takers on all perpetual futures markets.",
-  Revenue: "Net protocol revenue after maker rebates.",
+  Fees: "Trading fees collected from takers on all perpetual futures markets, plus USDC and USDCbl deposits to the protocol fee treasury.",
+  Revenue: "Net protocol revenue after maker rebates, plus USDC and USDCbl deposits to the protocol fee treasury.",
 };
 
 const adapter: SimpleAdapter = {


### PR DESCRIPTION
Include on-chain USDC and USDCbl deposits to the protocol fee treasury (0xa6ebf45cef6b683cf4275ee8c5f8f92f956a332174f8fd69143daf90115077f2) in daily fees and revenue, on top of values returned by the Decibel stats API.

## Summary
- Include on-chain USDC and USDCbl deposits to the Decibel fee treasury
  (0xa6ebf45cef6b683cf4275ee8c5f8f92f956a332174f8fd69143daf90115077f2) in
  dailyFees, dailyUserFees, and dailyRevenue, on top of values returned by
  the Decibel stats API.
- Deposits are fetched from the Aptos indexer (fungible_asset_activities
  with type = 0x1::fungible_asset::Deposit), authenticated with DECIBEL_API_KEY.
- asset_type is filtered client-side; adding it to the server-side where
  clause triggers a slow query plan on this owner.
- Updated the Fees and Revenue methodology strings.

## Test plan
- [x] `npm run ts-check` passes
- [x] `DECIBEL_API_KEY=... npm test -- dexs/decibel` runs cleanly
- [x] Verified daily deposit totals against fungible_asset_activities for Jun 1–7 2026
