### PR TITLE
onixswap: update methodology strings for Onix.Finance rebrand

### DIFF
--- a/fees/onixswap/index.ts
+++ b/fees/onixswap/index.ts
@@ -22,20 +22,20 @@ const fetch = async (options: FetchOptions) => {
 };
 
 const methodology = {
-  Fees: "0.3% platform fee collected on every swap, filtered to USDC/USDT/SOL inflows to the OnixSwap fee wallet. Swaps route through Jupiter v6, Raydium, Orca, and Meteora.",
-  Revenue: "0.3% platform fee collected on every swap, filtered to USDC/USDT/SOL inflows to the OnixSwap fee wallet. Swaps route through Jupiter v6, Raydium, Orca, and Meteora.",
-  ProtocolRevenue: "0.3% platform fee collected on every swap, filtered to USDC/USDT/SOL inflows to the OnixSwap fee wallet. Swaps route through Jupiter v6, Raydium, Orca, and Meteora.",
+  Fees: "0.3% platform fee collected on every swap, filtered to USDC/USDT/SOL inflows to the Onix.Finance fee wallet. Swaps route through Jupiter v6, Raydium, Orca, and Meteora.",
+  Revenue: "0.3% platform fee collected on every swap, filtered to USDC/USDT/SOL inflows to the Onix.Finance fee wallet. Swaps route through Jupiter v6, Raydium, Orca, and Meteora.",
+  ProtocolRevenue: "0.3% platform fee collected on every swap, filtered to USDC/USDT/SOL inflows to the Onix.Finance fee wallet. Swaps route through Jupiter v6, Raydium, Orca, and Meteora.",
 }
 
 const breakdownMethodology = {
   Fees: {
-    'Platform Fees': "0.3% platform fee collected on every swap, filtered to USDC/USDT/SOL inflows to the OnixSwap fee wallet. Swaps route through Jupiter v6, Raydium, Orca, and Meteora.",
+    'Platform Fees': "0.3% platform fee collected on every swap, filtered to USDC/USDT/SOL inflows to the Onix.Finance fee wallet. Swaps route through Jupiter v6, Raydium, Orca, and Meteora.",
   },
   Revenue: {
-    'Platform Fees': "0.3% platform fee collected on every swap, filtered to USDC/USDT/SOL inflows to the OnixSwap fee wallet. Swaps route through Jupiter v6, Raydium, Orca, and Meteora.",
+    'Platform Fees': "0.3% platform fee collected on every swap, filtered to USDC/USDT/SOL inflows to the Onix.Finance fee wallet. Swaps route through Jupiter v6, Raydium, Orca, and Meteora.",
   },
   ProtocolRevenue: {
-    'Platform Fees': "0.3% platform fee collected on every swap, filtered to USDC/USDT/SOL inflows to the OnixSwap fee wallet. Swaps route through Jupiter v6, Raydium, Orca, and Meteora.",
+    'Platform Fees': "0.3% platform fee collected on every swap, filtered to USDC/USDT/SOL inflows to the Onix.Finance fee wallet. Swaps route through Jupiter v6, Raydium, Orca, and Meteora.",
   },
 }
 


### PR DESCRIPTION
Refs #7951. The protocol rebranded OnixSwap -> Onix.Finance (swap.onix.finance now 301s to onix.finance), so the methodology tooltip strings referring to "the OnixSwap fee wallet" would go stale once the rename lands. This updates those 6 strings to say Onix.Finance. No logic changes - same fee wallet, mints, and math.

The rest of #7951 (display name, website, twitter, description) lives in protocol metadata on the server side, so that part needs someone on the team.

Ran `npm test fees onixswap` - compiles and runs up to the Allium fetch, which needs the CI-only API key (the harness marks that error as ignorable for the bot).