### PR TITLE
quickswap-v2: migrate polygon from dead subgraph to onchain log adapter

### DIFF
--- a/dexs/quickswap-v2.ts
+++ b/dexs/quickswap-v2.ts
@@ -1,57 +1,35 @@
-import * as sdk from "@defillama/sdk";
 import { CHAIN } from "../helpers/chains";
-import { FetchOptions, SimpleAdapter } from "../adapters/types";
+import { SimpleAdapter } from "../adapters/types";
 import { uniV2Exports } from "../helpers/uniswap";
-import request from "graphql-request"
 
-const endpoints = {
-  [CHAIN.POLYGON]: sdk.graph.modifyEndpoint("FUWdkXWpi8JyhAnhKL5pZcVshpxuaUQG8JHMDqNCxjPd"),
+// 0.3% swap fee: 0.25% to LPs, 0.04% to community buybacks, 0.01% to foundation
+const feeConfig = {
+  userFeesRatio: 1,
+  revenueRatio: 0.05 / 0.3,
+  protocolRevenueRatio: 0.01 / 0.3,
+  holdersRevenueRatio: 0.04 / 0.3,
 };
 
-const onChainAdapter: any = uniV2Exports({
+const adapter: SimpleAdapter = uniV2Exports({
+  [CHAIN.POLYGON]: {
+    factory: '0x5757371414417b8C6CAad45bAeF941aBc7d3Ab32',
+    start: '2020-10-09',
+    ...feeConfig,
+  },
   [CHAIN.BASE]: {
     factory: '0xEC6540261aaaE13F236A032d454dc9287E52e56A',
     start: '2025-06-04',
-    userFeesRatio: 1,
-    revenueRatio: 0.05 / 0.3,
-    protocolRevenueRatio: 0.01 / 0.3,
-    holdersRevenueRatio: 0.04 / 0.3,
-
+    ...feeConfig,
   },
-}, { runAsV1: true })
+}, { runAsV1: true });
 
-async function fetch({ startOfDay }: FetchOptions) {
-  const dayId = Math.floor(startOfDay / 86400)
-
-  const query = `{    uniswapDayData(id: ${dayId}) {      dailyVolumeUSD    }  }`
-  const { uniswapDayData: { dailyVolumeUSD } } = await request(endpoints[CHAIN.POLYGON], query)
-  const dailyFees = dailyVolumeUSD * 0.003
-  return {
-    dailyVolume: dailyVolumeUSD,
-    dailyFees,
-    dailyRevenue: dailyFees * 0.05 / 0.3,
-    dailyProtocolRevenue: dailyFees * 0.01 / 0.3,
-    dailyHoldersRevenue: dailyFees * 0.04 / 0.3,
-    dailySupplySideRevenue: dailyFees * 0.25 / 0.3,
-    dailyUserFees: dailyFees,
-  }
-}
-
-const adapter: SimpleAdapter = {
-  version: 1,
-  methodology: {
-    UserFees: "User pays 0.3% fees on each swap.",
-    Fees: "0.3% of each swap is collected as trading fees",
-    Revenue: "Protocol takes 16.66% of collected fees (0.04% community + 0.01% foundation).",
-    ProtocolRevenue: "Foundation receives 3.33% of collected fees (0.01% of swap volume).",
-    SupplySideRevenue: "83.33% of collected fees go to liquidity providers (0.25% of swap volume).",
-    HoldersRevenue: "Community receives 13.33% of collected fees for buybacks (0.04% of swap volume).",
-  },
-  adapter: {
-    [CHAIN.POLYGON]: { fetch, },
-    [CHAIN.BASE]: onChainAdapter!.adapter.base,
-    // [CHAIN.DOGECHAIN]: { fetch: getUniV2LogAdapter({ factory: '0xC3550497E591Ac6ed7a7E03ffC711CfB7412E57F', ...univ2LogConfig }), start: '2023-04-11' },
-  },
-}
+adapter.methodology = {
+  UserFees: "User pays 0.3% fees on each swap.",
+  Fees: "0.3% of each swap is collected as trading fees",
+  Revenue: "Protocol takes 16.66% of collected fees (0.04% community + 0.01% foundation).",
+  ProtocolRevenue: "Foundation receives 3.33% of collected fees (0.01% of swap volume).",
+  SupplySideRevenue: "83.33% of collected fees go to liquidity providers (0.25% of swap volume).",
+  HoldersRevenue: "Community receives 13.33% of collected fees for buybacks (0.04% of swap volume).",
+};
 
 export default adapter;

--- a/dexs/quickswap-v2.ts
+++ b/dexs/quickswap-v2.ts
@@ -21,6 +21,11 @@ const adapter: SimpleAdapter = uniV2Exports({
     start: '2025-06-04',
     ...feeConfig,
   },
+  // [CHAIN.DOGECHAIN]: {
+  //   factory: '0xC3550497E591Ac6ed7a7E03ffC711CfB7412E57F',
+  //   start: '2023-04-11',
+  //   ...feeConfig,
+  // }
 }, { runAsV1: true });
 
 adapter.methodology = {


### PR DESCRIPTION
Fixes #7344.

The Polygon leg read `uniswapDayData` from subgraph deployment `FUWdkXWpi8JyhAnhKL5pZcVshpxuaUQG8JHMDqNCxjPd`, which now returns 404 (deployment removed), so quickswap-v2 volume has been dead. Base was already on the onchain log adapter.

This moves Polygon onto `uniV2Exports` next to Base (factory 0x5757371414417b8C6CAad45bAeF941aBc7d3Ab32, live since 2020-10-09), same migration as #7030 did for metropolis-amm. Fee split unchanged and now applied uniformly to both chains: 0.3% swap fee, 0.25% LPs / 0.04% community buybacks / 0.01% foundation, same methodology strings as before.

Local RPC rate limits make a full-day Polygon run impractical here (the factory has tens of thousands of pairs), so the CI bot's adapter output is the meaningful check for the volume numbers.