### PR TITLE
Add Cherum adapters (fees, aggregators, bridge-aggregators)

### DIFF
--- a/aggregators/cherum/index.ts
+++ b/aggregators/cherum/index.ts
@@ -1,0 +1,36 @@
+import { FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { CherumContracts, BatchLegEvent } from "../../helpers/aggregators/cherum";
+
+// Same-chain fan-out batch swaps routed by CherumRouter. Volume is the input
+// notional per successful leg; failed legs are refunded in the same tx and
+// are not counted. Cross-chain legs are reported by the Cherum
+// bridge-aggregators adapter instead.
+const fetch = async (options: FetchOptions) => {
+  const dailyVolume = options.createBalances();
+  const logs: any[] = await options.getLogs({
+    target: CherumContracts[options.chain].router,
+    eventAbi: BatchLegEvent,
+  });
+  logs.forEach((log: any) => {
+    if (!log.success) return;
+    dailyVolume.add(log.fromToken, log.amountIn);
+  });
+  return { dailyVolume };
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  pullHourly: true,
+  adapter: Object.keys(CherumContracts).reduce(
+    (acc, chain) => ({
+      ...acc,
+      [chain]: { fetch, start: CherumContracts[chain].start },
+    }),
+    {},
+  ),
+  methodology: {
+    Volume: "Input notional of successful same-chain batch-swap legs routed through CherumRouter (BatchLeg events, after fees).",
+  },
+};
+
+export default adapter;

--- a/bridge-aggregators/cherum/index.ts
+++ b/bridge-aggregators/cherum/index.ts
@@ -1,0 +1,35 @@
+import { FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { CherumContracts, BatchOpenedEvent } from "../../helpers/aggregators/cherum";
+
+// Cross-chain fan-out batches opened on the source chain by
+// CherumFanOutRouter. Bridge volume is the principal actually dispatched
+// into bridges (input token, after fees), counted once on the source chain;
+// destination-side delivery is not counted again.
+const fetch = async (options: FetchOptions) => {
+  const dailyBridgeVolume = options.createBalances();
+  const logs: any[] = await options.getLogs({
+    target: CherumContracts[options.chain].fanout,
+    eventAbi: BatchOpenedEvent,
+  });
+  logs.forEach((log: any) => {
+    dailyBridgeVolume.add(log.tokenIn, log.principal);
+  });
+  return { dailyBridgeVolume };
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  pullHourly: true,
+  adapter: Object.keys(CherumContracts).reduce(
+    (acc, chain) => ({
+      ...acc,
+      [chain]: { fetch, start: CherumContracts[chain].start },
+    }),
+    {},
+  ),
+  methodology: {
+    BridgeVolume: "Principal dispatched into bridges by cross-chain fan-out batches on the source chain (BatchOpened events, input token, after fees).",
+  },
+};
+
+export default adapter;

--- a/fees/cherum/index.ts
+++ b/fees/cherum/index.ts
@@ -1,0 +1,79 @@
+import { FetchOptions, SimpleAdapter } from "../../adapters/types";
+import {
+  CherumContracts,
+  FeeCollectedEvent,
+  IntegratorFeeCollectedEvent,
+} from "../../helpers/aggregators/cherum";
+
+const ProtocolFee = "Cherum protocol fee";
+const IntegratorFee = "Integrator fee";
+
+const fetch = async (options: FetchOptions) => {
+  const dailyFees = options.createBalances();
+  const dailyRevenue = options.createBalances();
+  const dailySupplySideRevenue = options.createBalances();
+  const { router, fanout } = CherumContracts[options.chain];
+
+  // Both routers charge fees in the input token and emit the same events.
+  const protocolLogs: any[] = await options.getLogs({
+    targets: [router, fanout],
+    eventAbi: FeeCollectedEvent,
+    flatten: true,
+  });
+  protocolLogs.forEach((log: any) => {
+    dailyFees.add(log.token, log.amount, ProtocolFee);
+    dailyRevenue.add(log.token, log.amount, ProtocolFee);
+  });
+
+  const integratorLogs: any[] = await options.getLogs({
+    targets: [router, fanout],
+    eventAbi: IntegratorFeeCollectedEvent,
+    flatten: true,
+  });
+  integratorLogs.forEach((log: any) => {
+    dailyFees.add(log.token, log.amount, IntegratorFee);
+    dailySupplySideRevenue.add(log.token, log.amount, IntegratorFee);
+  });
+
+  return {
+    dailyFees,
+    dailyRevenue,
+    dailyProtocolRevenue: dailyRevenue,
+    dailySupplySideRevenue,
+  };
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  pullHourly: true,
+  adapter: Object.keys(CherumContracts).reduce(
+    (acc, chain) => ({
+      ...acc,
+      [chain]: { fetch, start: CherumContracts[chain].start },
+    }),
+    {},
+  ),
+  methodology: {
+    Fees: "Routing fees paid by users on each cross-chain fan-out and same-chain batch swap, charged in the input token.",
+    Revenue: "The portion of routing fees retained by the Cherum protocol.",
+    ProtocolRevenue: "The portion of routing fees retained by the Cherum protocol.",
+    SupplySideRevenue: "Integrator markups paid out to third-party partners that embed Cherum.",
+  },
+  breakdownMethodology: {
+    Fees: {
+      [ProtocolFee]: "Fee retained by the Cherum protocol (FeeCollected events).",
+      [IntegratorFee]: "Markup paid to third-party integrators (IntegratorFeeCollected events).",
+    },
+    Revenue: {
+      [ProtocolFee]: "Fee retained by the Cherum protocol.",
+    },
+    ProtocolRevenue: {
+      [ProtocolFee]: "Fee retained by the Cherum protocol.",
+    },
+    SupplySideRevenue: {
+      [IntegratorFee]: "Markup paid to third-party integrators.",
+    },
+  },
+};
+
+export default adapter;

--- a/fees/cherum/index.ts
+++ b/fees/cherum/index.ts
@@ -6,7 +6,9 @@ import {
 } from "../../helpers/aggregators/cherum";
 
 const ProtocolFee = "Cherum protocol fee";
+const ProtocolFeeToProtocol = "Cherum Protocol Fee To Protocol";
 const IntegratorFee = "Integrator fee";
+const IntegratorFeeToIntegrators = "Integrator Fee To Integrators";
 
 const fetch = async (options: FetchOptions) => {
   const dailyFees = options.createBalances();
@@ -22,7 +24,7 @@ const fetch = async (options: FetchOptions) => {
   });
   protocolLogs.forEach((log: any) => {
     dailyFees.add(log.token, log.amount, ProtocolFee);
-    dailyRevenue.add(log.token, log.amount, ProtocolFee);
+    dailyRevenue.add(log.token, log.amount, ProtocolFeeToProtocol);
   });
 
   const integratorLogs: any[] = await options.getLogs({
@@ -32,7 +34,7 @@ const fetch = async (options: FetchOptions) => {
   });
   integratorLogs.forEach((log: any) => {
     dailyFees.add(log.token, log.amount, IntegratorFee);
-    dailySupplySideRevenue.add(log.token, log.amount, IntegratorFee);
+    dailySupplySideRevenue.add(log.token, log.amount, IntegratorFeeToIntegrators);
   });
 
   return {
@@ -65,13 +67,13 @@ const adapter: SimpleAdapter = {
       [IntegratorFee]: "Markup paid to third-party integrators (IntegratorFeeCollected events).",
     },
     Revenue: {
-      [ProtocolFee]: "Fee retained by the Cherum protocol.",
+      [ProtocolFeeToProtocol]: "Fee retained by the Cherum protocol.",
     },
     ProtocolRevenue: {
-      [ProtocolFee]: "Fee retained by the Cherum protocol.",
+      [ProtocolFeeToProtocol]: "Fee retained by the Cherum protocol.",
     },
     SupplySideRevenue: {
-      [IntegratorFee]: "Markup paid to third-party integrators.",
+      [IntegratorFeeToIntegrators]: "Markup paid to third-party integrators.",
     },
   },
 };

--- a/helpers/aggregators/cherum.ts
+++ b/helpers/aggregators/cherum.ts
@@ -1,0 +1,59 @@
+import { CHAIN } from "../chains";
+
+// Cherum V2 routers (deployed 2026-06-26; HyperEVM 2026-07-05).
+// router  = CherumRouter (same-chain batch swaps)
+// fanout  = CherumFanOutRouter (cross-chain fan-out source side)
+// Note: the same address can play a different role on different chains
+// (CREATE from the same deployer nonce), so always map by (chain, role).
+export const CherumContracts: Record<string, { router: string; fanout: string; start: string }> = {
+  [CHAIN.ETHEREUM]: {
+    router: "0xc8e81fa8f5fac773b13866773005acb0a80fc5ca",
+    fanout: "0x7ba303dc458da48a5bcccad16ab529533935b9d7",
+    start: "2026-06-26",
+  },
+  [CHAIN.BASE]: {
+    router: "0xe7be2634a4bffe751f08cb2043651e2e9a13ca60",
+    fanout: "0x652f64bdb2f2cff37c2481636c7784c9f1f65e45",
+    start: "2026-06-26",
+  },
+  [CHAIN.ARBITRUM]: {
+    router: "0x833aaffba7ed2b1cbc32a49c1c40b5f76db1b5e1",
+    fanout: "0x0902e9819119a9d1b51efb85842983b76cab3145",
+    start: "2026-06-26",
+  },
+  [CHAIN.OPTIMISM]: {
+    router: "0xe7be2634a4bffe751f08cb2043651e2e9a13ca60",
+    fanout: "0xb0284630e35c7df89e6e18dcddb6e490fbe55560",
+    start: "2026-06-26",
+  },
+  [CHAIN.POLYGON]: {
+    router: "0xa0eca6a116b192d24df3d423e0839e44c1ee12fa",
+    fanout: "0x925a2eda850f786fc40bef6afb42c2b36631d391",
+    start: "2026-06-26",
+  },
+  [CHAIN.BSC]: {
+    router: "0x2b3428784aece90865251d94dedeb3efcfff4c6c",
+    fanout: "0x7d38a643f3592bc5532bba5d615f5b3d5bb97b7c",
+    start: "2026-06-26",
+  },
+};
+
+// Fees are always charged in the input token, skimmed up-front by the router.
+// Both contracts emit the same two events (identical signatures/topic0):
+//   FeeCollected           -> protocol fee kept by Cherum
+//   IntegratorFeeCollected -> markup paid out to a third-party integrator
+export const FeeCollectedEvent =
+  "event FeeCollected(bytes32 indexed intentId, address token, address collector, uint256 amount)";
+export const IntegratorFeeCollectedEvent =
+  "event IntegratorFeeCollected(bytes32 indexed intentId, address token, address recipient, uint256 amount)";
+
+// CherumRouter: one event per same-chain leg. amountIn is the leg's slice of
+// the principal (input token, after fees); success=false legs are refunded
+// to the user in the same tx and are not counted as volume.
+export const BatchLegEvent =
+  "event BatchLeg(bytes32 indexed intentId, uint256 indexed batchId, uint8 legIndex, address aggregator, address fromToken, address toToken, uint256 amountIn, uint256 amountOut, address recipient, bool success)";
+
+// CherumFanOutRouter: one event per cross-chain batch. principal is the
+// amount actually sent into bridges (input token, after fees).
+export const BatchOpenedEvent =
+  "event BatchOpened(bytes32 indexed intentId, address indexed account, address indexed tokenIn, uint256 principal, uint256 cherumFee, uint256 integratorFee, uint8 legsCount)";

--- a/helpers/aggregators/cherum.ts
+++ b/helpers/aggregators/cherum.ts
@@ -1,6 +1,7 @@
 import { CHAIN } from "../chains";
 
-// Cherum V2 routers (deployed 2026-06-26; HyperEVM 2026-07-05).
+// Cherum V2 routers (deployed 2026-06-26).
+// Source: https://docs.cherum.io/contracts (canonical per-chain addresses).
 // router  = CherumRouter (same-chain batch swaps)
 // fanout  = CherumFanOutRouter (cross-chain fan-out source side)
 // Note: the same address can play a different role on different chains


### PR DESCRIPTION
Adds Cherum adapters: `fees/cherum`, `aggregators/cherum`, `bridge-aggregators/cherum` (shared config in `helpers/aggregators/cherum.ts`).

Cherum is a non-custodial cross-chain fan-out swap: it sends funds to many recipients across different blockchains and tokens in a single signature. All three adapters read on-chain events from Cherum's routers (no protocol API).

- **Fees** = `FeeCollected` + `IntegratorFeeCollected` events (charged in the input token) from CherumRouter (same-chain batch swaps) and CherumFanOutRouter (cross-chain fan-outs).
- **Revenue / ProtocolRevenue** = `FeeCollected` only (retained by the protocol). Integrator markups paid to third-party partners are excluded from revenue and reported as SupplySideRevenue.
- **Volume (aggregators)** = input notional of successful same-chain batch-swap legs (`BatchLeg`, failed legs are refunded in-tx and not counted).
- **BridgeVolume** = principal dispatched into bridges on the source chain (`BatchOpened`); destination-side delivery is not counted again.

Tested with `pnpm test <type> cherum` on all six chains; values verified against known on-chain transactions to the cent.

---

**New protocol listing**

- Name: Cherum
- Website: https://cherum.io
- Twitter: https://x.com/cherum_io
- Logo: https://cherum.io/logo.svg + https://cherum.io/logo-400.png (400×400 PNG, transparent)
- Chains: Ethereum, Base, Arbitrum, Optimism, Polygon, BNB Chain
- Category: Cross Chain
- Current TVL: n/a (non-custodial router, no TVL)
- Treasury Addresses: n/a
- Coingecko ID / Coinmarketcap ID: none (no token)
- Token address: none
- Oracle Provider: none
- forkedFrom: none
- Referral program: no
- Audit links: n/a
- Short Description: Cherum is a non-custodial cross-chain fan-out swap: it sends funds to many recipients across different blockchains and tokens in a single signature. It handles bridging, swapping and delivery to each recipient, with gas included on arrival and an automatic refund for any leg that cannot complete. Cherum works across 26 networks, including Ethereum, Base, Arbitrum, Optimism, Polygon and BNB Chain, plus TON, Tron, Solana and Bitcoin.
- Methodology: Volume is the total notional swapped through Cherum's routers. Fees are the routing fees paid by users on each cross-chain fan-out and same-chain batch swap. Revenue is the portion of those fees retained by the Cherum protocol; integrator markups paid to third-party partners are excluded.
- Github org: https://github.com/cherum-io
