### PR TITLE
[feat] WNS: track wei name service fees and revenue (New Listing)

### DIFF
--- a/fees/wei-name-service.ts
+++ b/fees/wei-name-service.ts
@@ -1,0 +1,54 @@
+import { Dependencies, FetchOptions, SimpleAdapter } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+import { getETHReceived } from "../helpers/token";
+
+const chainConfig: Record<string, { start: string; contract: string }> = {
+  [CHAIN.ETHEREUM]: {
+    // Source: official Wei Names docs; contract creation timestamp 2026-02-01 07:07:23 UTC.
+    start: "2026-02-01",
+    contract: "0x0000000000696760e15f265e828db644a0c242eb",
+  },
+};
+
+const fetch = async (options: FetchOptions) => {
+  const { contract } = chainConfig[options.chain];
+  const received = await getETHReceived({ options, target: contract });
+  const dailyFees = options.createBalances();
+  dailyFees.addBalances(received, "Registration & Renewal Fees");
+
+  return {
+    dailyFees,
+    dailyRevenue: dailyFees,
+    dailyProtocolRevenue: dailyFees,
+  };
+};
+
+const methodology = {
+  Fees: "Wei Name Service name registration and renewal costs.",
+  Revenue: "Wei Name Service name registration and renewal costs.",
+  ProtocolRevenue: "Wei Name Service name registration and renewal costs.",
+};
+
+const breakdownMethodology = {
+  Fees: {
+    "Registration & Renewal Fees": "Fees paid for .wei name registrations and renewals.",
+  },
+  Revenue: {
+    "Registration & Renewal Fees": "Fees paid for .wei name registrations and renewals.",
+  },
+  ProtocolRevenue: {
+    "Registration & Renewal Fees": "Fees paid for .wei name registrations and renewals.",
+  },
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  pullHourly: true,
+  fetch,
+  adapter: chainConfig,
+  methodology,
+  breakdownMethodology,
+  dependencies: [Dependencies.ALLIUM],
+};
+
+export default adapter;


### PR DESCRIPTION
Please enable "Allow edits by maintainers" for this PR.

## Summary

Adds a fees adapter for Wei Name Service, tracking ETH received by the NameNFT contract for `.wei` name registrations and renewals.

## New protocol listing

##### Name (to be shown on DefiLlama):
Wei Name Service

##### List of audit links if any:
- https://github.com/z0r0z/wei-names/blob/main/audit/plainshift.md
- https://github.com/z0r0z/wei-names/blob/main/audit/cantina.md
- https://github.com/z0r0z/wei-names/blob/main/audit/zellic.md

##### Website Link:
https://wei.domains

##### Logo (High resolution, will be shown with rounded borders):
https://raw.githubusercontent.com/z0r0z/wei-names/main/wns-logo.png

##### Treasury Addresses (if the protocol has treasury)
Ethereum NameNFT contract: `0x0000000000696760e15f265e828db644a0c242eb`

##### Chain:
Ethereum

##### Short Description (to be shown on DefiLlama):
Wei Name Service is a simple namespace on Ethereum that provides `.wei` names as ERC-721 NFTs with address resolution, IPFS contenthash support, subdomains, text records, and reverse resolution.

##### Category (full list at https://defillama.com/categories) *Please choose only one:
Services

##### Documentation/Proof:
- Docs/GitHub: https://github.com/z0r0z/wei-names
- Contract: https://etherscan.io/address/0x0000000000696760E15f265e828DB644A0c242EB
- OpenSea: https://opensea.io/collection/wei-name-service

##### Github org/user (Optional, if your code is open source, we can track activity):
https://github.com/z0r0z/wei-names

##### methodology:
Fees are ETH received by the Wei Name Service NameNFT contract from `.wei` name registrations and renewals.