### PR TITLE
Add prynt fees adapter (Robinhood Chain launchpad)

### DIFF
--- a/fees/prynt.ts
+++ b/fees/prynt.ts
@@ -50,17 +50,15 @@ const fetch = async (options: FetchOptions) => {
 
 const adapter: Adapter = {
   version: 2,
+  methodology: {
+    Fees: "All fees paid by users: the flat token-creation fee plus the bonding-curve trade fee (an inclusive fee capped at 2%, charged on the ETH leg of every buy and sell).",
+    Revenue:
+      "Protocol revenue: the full creation fee plus the protocol slice of trade fees. Creator fees are currently disabled, so the protocol keeps 100% of the trade fee.",
+  },
   adapter: {
     [CHAIN.ROBINHOOD]: {
       fetch,
       start: "2026-07-07",
-      meta: {
-        methodology: {
-          Fees: "All fees paid by users: the flat token-creation fee plus the bonding-curve trade fee (an inclusive fee capped at 2%, charged on the ETH leg of every buy and sell).",
-          Revenue:
-            "Protocol revenue: the full creation fee plus the protocol slice of trade fees. Creator fees are currently disabled, so the protocol keeps 100% of the trade fee.",
-        },
-      },
     },
   },
 };

--- a/fees/prynt.ts
+++ b/fees/prynt.ts
@@ -7,9 +7,10 @@
 //   2) Trade fee: an inclusive fee (<= 2%) charged on the ETH leg of every bonding-curve buy/sell, emitted
 //      by the FeeManager as FeesCollected(token, creator, totalFee, creatorFee, protocolFee).
 //
-// dailyFees    = all fees users pay          = creation fees + trade totalFee
-// dailyRevenue = protocol's take             = creation fees + trade protocolFee
-// Creator fees are currently disabled (creatorFee == 0), so protocol keeps 100% of trade fees today.
+// dailyFees             = creation fees + trade totalFee            (everything users pay)
+// dailyRevenue          = creation fees + trade protocolFee         (protocol's take)
+// dailySupplySideRevenue= trade creatorFee                          (creators; currently disabled == 0)
+// Identity holds: dailyFees == dailyRevenue + dailySupplySideRevenue (totalFee == protocolFee + creatorFee).
 //
 // Destination file in the PR: fees/prynt.ts
 //
@@ -28,32 +29,49 @@ const DEPOSITED = "event Deposited(address indexed from, uint256 amount)";
 const fetch = async (options: FetchOptions) => {
   const dailyFees = options.createBalances();
   const dailyRevenue = options.createBalances();
+  const dailySupplySideRevenue = options.createBalances();
 
   // (1) creation fees — Treasury deposits that originate from the factory
   const deposits = await options.getLogs({ target: TREASURY, eventAbi: DEPOSITED });
   for (const d of deposits) {
     if (d.from.toLowerCase() === FACTORY.toLowerCase()) {
-      dailyFees.addGasToken(d.amount);
-      dailyRevenue.addGasToken(d.amount);
+      dailyFees.addGasToken(d.amount, "Creation Fees");
+      dailyRevenue.addGasToken(d.amount, "Creation Fees");
     }
   }
 
   // (2) trade fees — from the FeeManager
   const collected = await options.getLogs({ target: FEE_MANAGER, eventAbi: FEES_COLLECTED });
   for (const c of collected) {
-    dailyFees.addGasToken(c.totalFee);
-    dailyRevenue.addGasToken(c.protocolFee);
+    dailyFees.addGasToken(c.totalFee, "Trade Fees");
+    dailyRevenue.addGasToken(c.protocolFee, "Trade Fees");
+    dailySupplySideRevenue.addGasToken(c.creatorFee, "Creator Fees"); // 0 while creator fees are disabled
   }
 
-  return { dailyFees, dailyRevenue };
+  return { dailyFees, dailyRevenue, dailySupplySideRevenue };
 };
 
 const adapter: Adapter = {
   version: 2,
+  pullHourly: true,
   methodology: {
     Fees: "All fees paid by users: the flat token-creation fee plus the bonding-curve trade fee (an inclusive fee capped at 2%, charged on the ETH leg of every buy and sell).",
-    Revenue:
-      "Protocol revenue: the full creation fee plus the protocol slice of trade fees. Creator fees are currently disabled, so the protocol keeps 100% of the trade fee.",
+    Revenue: "Protocol revenue: the full creation fee plus the protocol slice of trade fees.",
+    SupplySideRevenue:
+      "Creator slice of the bonding-curve trade fee. Creator fees are currently disabled, so this is 0 today; it is populated automatically if they are re-enabled.",
+  },
+  breakdownMethodology: {
+    Fees: {
+      "Creation Fees": "Flat fee paid on each token creation, forwarded to the Treasury.",
+      "Trade Fees": "Bonding-curve trade fee (inclusive, capped at 2%) on the ETH leg of every buy and sell.",
+    },
+    Revenue: {
+      "Creation Fees": "The full creation fee is protocol revenue (kept by the Treasury).",
+      "Trade Fees": "Protocol slice of the bonding-curve trade fee.",
+    },
+    SupplySideRevenue: {
+      "Creator Fees": "Creator slice of the bonding-curve trade fee (currently disabled, so 0).",
+    },
   },
   adapter: {
     [CHAIN.ROBINHOOD]: {

--- a/fees/prynt.ts
+++ b/fees/prynt.ts
@@ -36,6 +36,27 @@ const BOUGHT =
 const SOLD =
   "event Sold(address indexed seller, uint256 tokensIn, uint256 ethOut, uint256 fee, uint128 reserveEth, uint128 reserveToken)";
 
+// Module-level curve cache so hourly runs don't re-scan TokenCreated from the deploy block every time:
+// each run only scans the blocks added since the last one. The list is append-only (curves are never
+// deleted on-chain), so serving a superset to an out-of-order/backfill window is still correct — curves
+// created later simply have no Bought/Sold events inside that window.
+const curveCache = { curves: [] as string[], toBlock: 0 };
+
+async function getCurves(options: FetchOptions): Promise<string[]> {
+  const toBlock: number = await options.getToBlock();
+  if (toBlock > curveCache.toBlock) {
+    const created = await options.getLogs({
+      target: FACTORY,
+      eventAbi: TOKEN_CREATED,
+      fromBlock: curveCache.toBlock ? curveCache.toBlock + 1 : FROM_BLOCK,
+      toBlock,
+    });
+    for (const l of created) if (!curveCache.curves.includes(l.curve)) curveCache.curves.push(l.curve);
+    curveCache.toBlock = toBlock;
+  }
+  return curveCache.curves;
+}
+
 const fetch = async (options: FetchOptions) => {
   const dailyFees = options.createBalances();
   const dailyRevenue = options.createBalances();
@@ -47,7 +68,7 @@ const fetch = async (options: FetchOptions) => {
   for (const d of deposits) {
     if (d.from.toLowerCase() === FACTORY.toLowerCase()) {
       dailyFees.addGasToken(d.amount, "Token Creation Fees");
-      dailyRevenue.addGasToken(d.amount, "Token Creation Fees");
+      dailyRevenue.addGasToken(d.amount, "Token Creation Fees To Treasury");
     }
   }
 
@@ -55,13 +76,12 @@ const fetch = async (options: FetchOptions) => {
   const collected = await options.getLogs({ target: FEE_MANAGER, eventAbi: FEES_COLLECTED });
   for (const c of collected) {
     dailyFees.addGasToken(c.totalFee, METRIC.TRADING_FEES);
-    dailyRevenue.addGasToken(c.protocolFee, METRIC.TRADING_FEES);
-    dailySupplySideRevenue.addGasToken(c.creatorFee, "Creator Fees"); // 0 while creator fees are disabled
+    dailyRevenue.addGasToken(c.protocolFee, "Trade Fees To Protocol");
+    dailySupplySideRevenue.addGasToken(c.creatorFee, "Trade Fees To Creators"); // 0 while creator fees are disabled
   }
 
-  // (3) volume — Bought/Sold on every curve (curves enumerated from the factory since deployment)
-  const created = await options.getLogs({ target: FACTORY, eventAbi: TOKEN_CREATED, fromBlock: FROM_BLOCK });
-  const curves = created.map((l: any) => l.curve);
+  // (3) volume — Bought/Sold on every curve (incrementally cached enumeration)
+  const curves = await getCurves(options);
   if (curves.length) {
     const buys = await options.getLogs({ targets: curves, eventAbi: BOUGHT });
     const sells = await options.getLogs({ targets: curves, eventAbi: SOLD });
@@ -89,11 +109,11 @@ const adapter: Adapter = {
       [METRIC.TRADING_FEES]: "Bonding-curve trade fee (inclusive, capped at 2%) on the ETH leg of every buy and sell.",
     },
     Revenue: {
-      "Token Creation Fees": "The full creation fee is protocol revenue (kept by the Treasury).",
-      [METRIC.TRADING_FEES]: "Protocol slice of the bonding-curve trade fee.",
+      "Token Creation Fees To Treasury": "The full creation fee is protocol revenue (kept by the Treasury).",
+      "Trade Fees To Protocol": "Protocol slice of the bonding-curve trade fee.",
     },
     SupplySideRevenue: {
-      "Creator Fees": "Creator slice of the bonding-curve trade fee (currently disabled, so 0).",
+      "Trade Fees To Creators": "Creator slice of the bonding-curve trade fee (currently disabled, so 0).",
     },
   },
   adapter: {

--- a/fees/prynt.ts
+++ b/fees/prynt.ts
@@ -24,7 +24,7 @@ import { METRIC } from "../helpers/metrics";
 const FACTORY = "0x5c0cdFA92C6645b6ee83e686598DbC29260F885d";
 const FEE_MANAGER = "0x181e56B1d5BBf2A17089e4aAa576EAeCEeE1Ee40";
 const TREASURY = "0xCE1d15eC90738F9cd60fE4f8239a10eFb056eEa1";
-const FROM_BLOCK = 4394643; // factory deployment block
+const FACTORY_DEPLOYMENT_BLOCK = 4394643;
 
 const TOKEN_CREATED =
   "event TokenCreated(address indexed token, address indexed creator, address indexed curve, string name, string symbol, string metadataURI, uint256 timestamp)";
@@ -36,92 +36,78 @@ const BOUGHT =
 const SOLD =
   "event Sold(address indexed seller, uint256 tokensIn, uint256 ethOut, uint256 fee, uint128 reserveEth, uint128 reserveToken)";
 
-// Module-level curve cache so hourly runs don't re-scan TokenCreated from the deploy block every time:
-// each run only scans the blocks added since the last one. The list is append-only (curves are never
-// deleted on-chain), so serving a superset to an out-of-order/backfill window is still correct — curves
-// created later simply have no Bought/Sold events inside that window.
-const curveCache = { curves: [] as string[], toBlock: 0 };
-
-async function getCurves(options: FetchOptions): Promise<string[]> {
-  const toBlock: number = await options.getToBlock();
-  if (toBlock > curveCache.toBlock) {
-    const created = await options.getLogs({
-      target: FACTORY,
-      eventAbi: TOKEN_CREATED,
-      fromBlock: curveCache.toBlock ? curveCache.toBlock + 1 : FROM_BLOCK,
-      toBlock,
-    });
-    for (const l of created) if (!curveCache.curves.includes(l.curve)) curveCache.curves.push(l.curve);
-    curveCache.toBlock = toBlock;
-  }
-  return curveCache.curves;
-}
-
 const fetch = async (options: FetchOptions) => {
   const dailyFees = options.createBalances();
   const dailyRevenue = options.createBalances();
   const dailySupplySideRevenue = options.createBalances();
   const dailyVolume = options.createBalances();
 
-  // (1) creation fees — Treasury deposits that originate from the factory
-  const deposits = await options.getLogs({ target: TREASURY, eventAbi: DEPOSITED });
-  for (const d of deposits) {
-    if (d.from.toLowerCase() === FACTORY.toLowerCase()) {
-      dailyFees.addGasToken(d.amount, "Token Creation Fees");
-      dailyRevenue.addGasToken(d.amount, "Token Creation Fees To Treasury");
+  const treasuryDepositLogs = await options.getLogs({ target: TREASURY, eventAbi: DEPOSITED });
+  const feesCollectedLogs = await options.getLogs({ target: FEE_MANAGER, eventAbi: FEES_COLLECTED });
+  const curvesCreatedLogs = await options.getLogs({
+    target: FACTORY,
+    eventAbi: TOKEN_CREATED,
+    fromBlock: FACTORY_DEPLOYMENT_BLOCK,
+    cacheInCloud: true,
+  });
+
+  for (const log of treasuryDepositLogs) {
+    if (log.from.toLowerCase() === FACTORY.toLowerCase()) {
+      dailyFees.addGasToken(log.amount, "Token Creation Fees");
+      dailyRevenue.addGasToken(log.amount, "Token Creation Fees To Treasury");
     }
   }
 
-  // (2) trade fees — from the FeeManager
-  const collected = await options.getLogs({ target: FEE_MANAGER, eventAbi: FEES_COLLECTED });
-  for (const c of collected) {
-    dailyFees.addGasToken(c.totalFee, METRIC.TRADING_FEES);
-    dailyRevenue.addGasToken(c.protocolFee, "Trade Fees To Protocol");
-    dailySupplySideRevenue.addGasToken(c.creatorFee, "Trade Fees To Creators"); // 0 while creator fees are disabled
+  for (const log of feesCollectedLogs) {
+    dailyFees.addGasToken(log.totalFee, METRIC.TRADING_FEES);
+    dailyRevenue.addGasToken(log.protocolFee, "Trading Fees To Protocol");
+    dailySupplySideRevenue.addGasToken(log.creatorFee, "Trading Fees To Creators"); // 0 while creator fees are disabled
   }
 
-  // (3) volume — Bought/Sold on every curve (incrementally cached enumeration)
-  const curves = await getCurves(options);
-  if (curves.length) {
-    const buys = await options.getLogs({ targets: curves, eventAbi: BOUGHT });
-    const sells = await options.getLogs({ targets: curves, eventAbi: SOLD });
-    for (const b of buys) dailyVolume.addGasToken(b.ethSpent - b.fee); // ETH that entered the curve
-    for (const s of sells) dailyVolume.addGasToken(s.ethOut + s.fee); // gross ETH that left the curve
+  if (curvesCreatedLogs.length) {
+    const buysLogs = await options.getLogs({ targets: curvesCreatedLogs.map((log) => log.curve), eventAbi: BOUGHT });
+    const sellsLogs = await options.getLogs({ targets: curvesCreatedLogs.map((log) => log.curve), eventAbi: SOLD });
+    for (const log of buysLogs) dailyVolume.addGasToken(log.ethSpent - log.fee); // ETH that entered the curve
+    for (const log of sellsLogs) dailyVolume.addGasToken(log.ethOut + log.fee); // gross ETH that left the curve
   }
 
   return { dailyFees, dailyRevenue, dailyProtocolRevenue: dailyRevenue, dailySupplySideRevenue, dailyVolume };
 };
 
+const methodology = {
+  Volume: "ETH value traded against the bonding curves: ETH entering the curve on buys (ex-fee) plus gross ETH leaving on sells.",
+  Fees: "All fees paid by users: the flat token-creation fee plus the bonding-curve trade fee (an inclusive fee capped at 2%, charged on the ETH leg of every buy and sell).",
+  Revenue: "Protocol revenue: the full creation fee plus the protocol slice of trade fees.",
+  ProtocolRevenue: "Same as Revenue — the protocol keeps the full creation fee and its slice of trade fees.",
+  SupplySideRevenue: "Creator slice of the bonding-curve trade fee. Creator fees are currently disabled, so this is 0 today; it is populated automatically if they are re-enabled.",
+}
+
+const breakdownMethodology = {
+  Fees: {
+    "Token Creation Fees": "Flat fee paid on each token creation, forwarded to the Treasury.",
+    [METRIC.TRADING_FEES]: "Bonding-curve trade fee (inclusive, capped at 2%) on the ETH leg of every buy and sell.",
+  },
+  Revenue: {
+    "Token Creation Fees To Treasury": "The full creation fee is protocol revenue (kept by the Treasury).",
+    "Trading Fees To Protocol": "Protocol slice of the bonding-curve trade fees.",
+  },
+  ProtocolRevenue: {
+    "Token Creation Fees To Treasury": "The full creation fee is protocol revenue (kept by the Treasury).",
+    "Trading Fees To Protocol": "Protocol slice of the bonding-curve trade fees.",
+  },
+  SupplySideRevenue: {
+    "Trading Fees To Creators": "Creator slice of the bonding-curve trade fee (currently disabled, so 0).",
+  }
+}
+
 const adapter: Adapter = {
   version: 2,
   pullHourly: true,
-  methodology: {
-    Volume: "ETH value traded against the bonding curves: ETH entering the curve on buys (ex-fee) plus gross ETH leaving on sells.",
-    Fees: "All fees paid by users: the flat token-creation fee plus the bonding-curve trade fee (an inclusive fee capped at 2%, charged on the ETH leg of every buy and sell).",
-    Revenue: "Protocol revenue: the full creation fee plus the protocol slice of trade fees.",
-    ProtocolRevenue: "Same as Revenue — the protocol keeps the full creation fee and its slice of trade fees.",
-    SupplySideRevenue:
-      "Creator slice of the bonding-curve trade fee. Creator fees are currently disabled, so this is 0 today; it is populated automatically if they are re-enabled.",
-  },
-  breakdownMethodology: {
-    Fees: {
-      "Token Creation Fees": "Flat fee paid on each token creation, forwarded to the Treasury.",
-      [METRIC.TRADING_FEES]: "Bonding-curve trade fee (inclusive, capped at 2%) on the ETH leg of every buy and sell.",
-    },
-    Revenue: {
-      "Token Creation Fees To Treasury": "The full creation fee is protocol revenue (kept by the Treasury).",
-      "Trade Fees To Protocol": "Protocol slice of the bonding-curve trade fee.",
-    },
-    SupplySideRevenue: {
-      "Trade Fees To Creators": "Creator slice of the bonding-curve trade fee (currently disabled, so 0).",
-    },
-  },
-  adapter: {
-    [CHAIN.ROBINHOOD]: {
-      fetch,
-      start: "2026-07-07",
-    },
-  },
+  methodology,
+  breakdownMethodology,
+  chains: [CHAIN.ROBINHOOD],
+  fetch,
+  start: "2026-07-07",
 };
 
 export default adapter;

--- a/fees/prynt.ts
+++ b/fees/prynt.ts
@@ -1,0 +1,68 @@
+// prynt — fees & revenue adapter (dimension-adapters).
+//
+// Fee sources on Robinhood Chain (chainId 4663):
+//   1) Token creation fee: a flat fee paid on createToken(), forwarded to the Treasury. Captured exactly
+//      from the Treasury's Deposited(from, amount) logs where `from` == the factory (robust to any future
+//      change of the creation-fee amount, and excludes graduation refunds which arrive from the Migrator).
+//   2) Trade fee: an inclusive fee (<= 2%) charged on the ETH leg of every bonding-curve buy/sell, emitted
+//      by the FeeManager as FeesCollected(token, creator, totalFee, creatorFee, protocolFee).
+//
+// dailyFees    = all fees users pay          = creation fees + trade totalFee
+// dailyRevenue = protocol's take             = creation fees + trade protocolFee
+// Creator fees are currently disabled (creatorFee == 0), so protocol keeps 100% of trade fees today.
+//
+// Destination file in the PR: fees/prynt.ts
+//
+// -----------------------------------------------------------------------------------------------------
+import { Adapter, FetchOptions } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+
+const FACTORY = "0x5c0cdFA92C6645b6ee83e686598DbC29260F885d";
+const FEE_MANAGER = "0x181e56B1d5BBf2A17089e4aAa576EAeCEeE1Ee40";
+const TREASURY = "0xCE1d15eC90738F9cd60fE4f8239a10eFb056eEa1";
+
+const FEES_COLLECTED =
+  "event FeesCollected(address indexed token, address indexed creator, uint256 totalFee, uint256 creatorFee, uint256 protocolFee)";
+const DEPOSITED = "event Deposited(address indexed from, uint256 amount)";
+
+const fetch = async (options: FetchOptions) => {
+  const dailyFees = options.createBalances();
+  const dailyRevenue = options.createBalances();
+
+  // (1) creation fees — Treasury deposits that originate from the factory
+  const deposits = await options.getLogs({ target: TREASURY, eventAbi: DEPOSITED });
+  for (const d of deposits) {
+    if (d.from.toLowerCase() === FACTORY.toLowerCase()) {
+      dailyFees.addGasToken(d.amount);
+      dailyRevenue.addGasToken(d.amount);
+    }
+  }
+
+  // (2) trade fees — from the FeeManager
+  const collected = await options.getLogs({ target: FEE_MANAGER, eventAbi: FEES_COLLECTED });
+  for (const c of collected) {
+    dailyFees.addGasToken(c.totalFee);
+    dailyRevenue.addGasToken(c.protocolFee);
+  }
+
+  return { dailyFees, dailyRevenue };
+};
+
+const adapter: Adapter = {
+  version: 2,
+  adapter: {
+    [CHAIN.ROBINHOOD]: {
+      fetch,
+      start: "2026-07-07",
+      meta: {
+        methodology: {
+          Fees: "All fees paid by users: the flat token-creation fee plus the bonding-curve trade fee (an inclusive fee capped at 2%, charged on the ETH leg of every buy and sell).",
+          Revenue:
+            "Protocol revenue: the full creation fee plus the protocol slice of trade fees. Creator fees are currently disabled, so the protocol keeps 100% of the trade fee.",
+        },
+      },
+    },
+  },
+};
+
+export default adapter;

--- a/fees/prynt.ts
+++ b/fees/prynt.ts
@@ -1,73 +1,96 @@
-// prynt — fees & revenue adapter (dimension-adapters).
+// prynt — fees, revenue & volume adapter (dimension-adapters).
 //
-// Fee sources on Robinhood Chain (chainId 4663):
-//   1) Token creation fee: a flat fee paid on createToken(), forwarded to the Treasury. Captured exactly
-//      from the Treasury's Deposited(from, amount) logs where `from` == the factory (robust to any future
-//      change of the creation-fee amount, and excludes graduation refunds which arrive from the Migrator).
-//   2) Trade fee: an inclusive fee (<= 2%) charged on the ETH leg of every bonding-curve buy/sell, emitted
-//      by the FeeManager as FeesCollected(token, creator, totalFee, creatorFee, protocolFee).
+// Sources on Robinhood Chain (chainId 4663):
+//   1) Token creation fee: flat fee on createToken(), forwarded to the Treasury. Captured from the
+//      Treasury's Deposited(from, amount) logs where `from` == the factory (robust to fee changes;
+//      excludes graduation refunds, which arrive from the Migrator).
+//   2) Trade fee: inclusive fee (<= 2%) on the ETH leg of every bonding-curve buy/sell, emitted by the
+//      FeeManager as FeesCollected(token, creator, totalFee, creatorFee, protocolFee).
+//   3) Volume: per-curve Bought/Sold events. Per the contract docs, the ETH that traded against the
+//      curve is `ethSpent - fee` on buys and `ethOut + fee` on sells (ethOut is net-to-seller).
 //
-// dailyFees             = creation fees + trade totalFee            (everything users pay)
-// dailyRevenue          = creation fees + trade protocolFee         (protocol's take)
-// dailySupplySideRevenue= trade creatorFee                          (creators; currently disabled == 0)
-// Identity holds: dailyFees == dailyRevenue + dailySupplySideRevenue (totalFee == protocolFee + creatorFee).
+// dailyFees              = creation fees + trade totalFee
+// dailyRevenue           = creation fees + trade protocolFee        (== dailyProtocolRevenue)
+// dailySupplySideRevenue = trade creatorFee                         (currently disabled == 0)
+// Identity holds: dailyFees == dailyRevenue + dailySupplySideRevenue.
 //
 // Destination file in the PR: fees/prynt.ts
 //
 // -----------------------------------------------------------------------------------------------------
 import { Adapter, FetchOptions } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
+import { METRIC } from "../helpers/metrics";
 
 const FACTORY = "0x5c0cdFA92C6645b6ee83e686598DbC29260F885d";
 const FEE_MANAGER = "0x181e56B1d5BBf2A17089e4aAa576EAeCEeE1Ee40";
 const TREASURY = "0xCE1d15eC90738F9cd60fE4f8239a10eFb056eEa1";
+const FROM_BLOCK = 4394643; // factory deployment block
 
+const TOKEN_CREATED =
+  "event TokenCreated(address indexed token, address indexed creator, address indexed curve, string name, string symbol, string metadataURI, uint256 timestamp)";
 const FEES_COLLECTED =
   "event FeesCollected(address indexed token, address indexed creator, uint256 totalFee, uint256 creatorFee, uint256 protocolFee)";
 const DEPOSITED = "event Deposited(address indexed from, uint256 amount)";
+const BOUGHT =
+  "event Bought(address indexed buyer, address indexed to, uint256 ethSpent, uint256 tokensOut, uint256 fee, uint128 reserveEth, uint128 reserveToken)";
+const SOLD =
+  "event Sold(address indexed seller, uint256 tokensIn, uint256 ethOut, uint256 fee, uint128 reserveEth, uint128 reserveToken)";
 
 const fetch = async (options: FetchOptions) => {
   const dailyFees = options.createBalances();
   const dailyRevenue = options.createBalances();
   const dailySupplySideRevenue = options.createBalances();
+  const dailyVolume = options.createBalances();
 
   // (1) creation fees — Treasury deposits that originate from the factory
   const deposits = await options.getLogs({ target: TREASURY, eventAbi: DEPOSITED });
   for (const d of deposits) {
     if (d.from.toLowerCase() === FACTORY.toLowerCase()) {
-      dailyFees.addGasToken(d.amount, "Creation Fees");
-      dailyRevenue.addGasToken(d.amount, "Creation Fees");
+      dailyFees.addGasToken(d.amount, "Token Creation Fees");
+      dailyRevenue.addGasToken(d.amount, "Token Creation Fees");
     }
   }
 
   // (2) trade fees — from the FeeManager
   const collected = await options.getLogs({ target: FEE_MANAGER, eventAbi: FEES_COLLECTED });
   for (const c of collected) {
-    dailyFees.addGasToken(c.totalFee, "Trade Fees");
-    dailyRevenue.addGasToken(c.protocolFee, "Trade Fees");
+    dailyFees.addGasToken(c.totalFee, METRIC.TRADING_FEES);
+    dailyRevenue.addGasToken(c.protocolFee, METRIC.TRADING_FEES);
     dailySupplySideRevenue.addGasToken(c.creatorFee, "Creator Fees"); // 0 while creator fees are disabled
   }
 
-  return { dailyFees, dailyRevenue, dailySupplySideRevenue };
+  // (3) volume — Bought/Sold on every curve (curves enumerated from the factory since deployment)
+  const created = await options.getLogs({ target: FACTORY, eventAbi: TOKEN_CREATED, fromBlock: FROM_BLOCK });
+  const curves = created.map((l: any) => l.curve);
+  if (curves.length) {
+    const buys = await options.getLogs({ targets: curves, eventAbi: BOUGHT });
+    const sells = await options.getLogs({ targets: curves, eventAbi: SOLD });
+    for (const b of buys) dailyVolume.addGasToken(b.ethSpent - b.fee); // ETH that entered the curve
+    for (const s of sells) dailyVolume.addGasToken(s.ethOut + s.fee); // gross ETH that left the curve
+  }
+
+  return { dailyFees, dailyRevenue, dailyProtocolRevenue: dailyRevenue, dailySupplySideRevenue, dailyVolume };
 };
 
 const adapter: Adapter = {
   version: 2,
   pullHourly: true,
   methodology: {
+    Volume: "ETH value traded against the bonding curves: ETH entering the curve on buys (ex-fee) plus gross ETH leaving on sells.",
     Fees: "All fees paid by users: the flat token-creation fee plus the bonding-curve trade fee (an inclusive fee capped at 2%, charged on the ETH leg of every buy and sell).",
     Revenue: "Protocol revenue: the full creation fee plus the protocol slice of trade fees.",
+    ProtocolRevenue: "Same as Revenue — the protocol keeps the full creation fee and its slice of trade fees.",
     SupplySideRevenue:
       "Creator slice of the bonding-curve trade fee. Creator fees are currently disabled, so this is 0 today; it is populated automatically if they are re-enabled.",
   },
   breakdownMethodology: {
     Fees: {
-      "Creation Fees": "Flat fee paid on each token creation, forwarded to the Treasury.",
-      "Trade Fees": "Bonding-curve trade fee (inclusive, capped at 2%) on the ETH leg of every buy and sell.",
+      "Token Creation Fees": "Flat fee paid on each token creation, forwarded to the Treasury.",
+      [METRIC.TRADING_FEES]: "Bonding-curve trade fee (inclusive, capped at 2%) on the ETH leg of every buy and sell.",
     },
     Revenue: {
-      "Creation Fees": "The full creation fee is protocol revenue (kept by the Treasury).",
-      "Trade Fees": "Protocol slice of the bonding-curve trade fee.",
+      "Token Creation Fees": "The full creation fee is protocol revenue (kept by the Treasury).",
+      [METRIC.TRADING_FEES]: "Protocol slice of the bonding-curve trade fee.",
     },
     SupplySideRevenue: {
       "Creator Fees": "Creator slice of the bonding-curve trade fee (currently disabled, so 0).",

--- a/helpers/env.ts
+++ b/helpers/env.ts
@@ -17,7 +17,6 @@ const DEFAULTS: any = {
   PLANQ_RPC: "https://planq-rpc.nodies.app,https://jsonrpc.planq.nodestake.top",
   VELAS_RPC: 'https://evmexplorer.velas.com/api/eth-rpc',
   HARMONY_RPC: 'https://explorer.harmony.one/api/eth-rpc',
-  ROBINHOOD_RPC: 'https://robinhoodchain.blockscout.com/api/eth-rpc,https://rpc.mainnet.chain.robinhood.com',
   SMARTBCH_RPC: 'https://smartscout.cash//api/eth-rpc',
   HYPERLIQUID_RPC: 'https://rpc.purroofgroup.com',
   FUSE_RPC: 'https://explorer.fuse.io/api/eth-rpc',
@@ -92,6 +91,7 @@ export const ENV_KEYS = new Set([
   'PEARL_BLOCKBOOK_API',
   'OKLINK_API_KEY',
   'TRONSCAN_API_KEY',
+  'ROBINHOOD_RPC'
 ])
 
 // This is done to support both ZEROx_API_KEY and ZEROX_API_KEY

--- a/helpers/env.ts
+++ b/helpers/env.ts
@@ -17,6 +17,7 @@ const DEFAULTS: any = {
   PLANQ_RPC: "https://planq-rpc.nodies.app,https://jsonrpc.planq.nodestake.top",
   VELAS_RPC: 'https://evmexplorer.velas.com/api/eth-rpc',
   HARMONY_RPC: 'https://explorer.harmony.one/api/eth-rpc',
+  ROBINHOOD_RPC: 'https://robinhoodchain.blockscout.com/api/eth-rpc,https://rpc.mainnet.chain.robinhood.com',
   SMARTBCH_RPC: 'https://smartscout.cash//api/eth-rpc',
   HYPERLIQUID_RPC: 'https://rpc.purroofgroup.com',
   FUSE_RPC: 'https://explorer.fuse.io/api/eth-rpc',
@@ -91,7 +92,6 @@ export const ENV_KEYS = new Set([
   'PEARL_BLOCKBOOK_API',
   'OKLINK_API_KEY',
   'TRONSCAN_API_KEY',
-  'ROBINHOOD_RPC'
 ])
 
 // This is done to support both ZEROx_API_KEY and ZEROX_API_KEY


### PR DESCRIPTION
Adds a fees & revenue adapter for **prynt**, a bonding-curve memecoin launchpad on **Robinhood Chain** (Arbitrum Orbit L2, chainId 4663 — `CHAIN.ROBINHOOD`).

**Methodology**
- **Fees** = token-creation fees (flat fee per `createToken`, captured from the Treasury's `Deposited` logs originating from the factory) + bonding-curve **trade fees** (inclusive fee ≤ 2% on the ETH leg of every buy/sell, from the FeeManager's `FeesCollected` event).
- **Revenue** = creation fees + the protocol slice of trade fees. Creator fees are currently disabled, so the protocol keeps 100% of the trade fee.

- Chain: `robinhood`
- Factory: `0x5c0cdFA92C6645b6ee83e686598DbC29260F885d`
- FeeManager: `0x181e56B1d5BBf2A17089e4aAa576EAeCEeE1Ee40`
- Treasury: `0xCE1d15eC90738F9cd60fE4f8239a10eFb056eEa1`
- Site: https://www.prynt.fun

Tested with `ts-node cli/testAdapter.ts fees prynt` — returns non-zero daily fees/revenue matching on-chain events.