### PR TITLE
feat: add yeno-markets configuration to dexsConfigs and feesConfigs

### DIFF
--- a/factory/polymarket.ts
+++ b/factory/polymarket.ts
@@ -27,6 +27,7 @@ const dexsConfigs: Record<string, { builder: string; start: string; builderCode?
   "traderline": { builder: "traderline", start: "2025-12-01", builderCode: "0x6b0e773fada0a2ec67c956b25a737d353a534ea33db56c717ba7854346c67984" },
   "metamask": { builder: "MetaMask", start: "2025-11-10", builderCode: "0x11a22276beb720e66a072cba8b8e74cded60afda510af535b947b81a1b81a883" },
   "wager-up-pilot": { builder: "WagerUpPilot", start: "2026-04-07", builderCode: "0xbc37cc54237a06aa0d380814fadf2f5b6d20483300833f381e4727f1066845fb" },
+  "yeno": { builder: "yeno-markets", start: "2026-06-26", builderCode: "0x5bffd61a6dbfca06f19a543cac4b9e433378ac9992d70b8a40824720e353498f" },
 };
 
 const feesConfigs: Record<string, { builderName: string; builderCode: string; start: string }> = {
@@ -39,6 +40,7 @@ const feesConfigs: Record<string, { builderName: string; builderCode: string; st
   "metamask-predictions": { builderName: "MetaMask", builderCode: "0x11a22276beb720e66a072cba8b8e74cded60afda510af535b947b81a1b81a883", start: "2026-04-28" },
   "based-predict": { builderName: "Based", builderCode: "0x07aa1a8523160e8e9c2d07ac890d56d21c3fe0f11292558f941f69624788d1cf", start: "2026-04-28" },
   "traderline": { builderName: "traderline", builderCode: "0x6b0e773fada0a2ec67c956b25a737d353a534ea33db56c717ba7854346c67984", start: "2026-04-28" },
+  "yeno": { builderName: "yeno-markets", builderCode: "0x5bffd61a6dbfca06f19a543cac4b9e433378ac9992d70b8a40824720e353498f", start: "2026-06-26" },
 }
 
 const dexsProtocols: Record<string, any> = {};


### PR DESCRIPTION
Adds YeNo as a verified Polymarket builder to the existing `polymarket.ts` factory for DEX volume and builder fees tracking.

##### Name (to be shown on DefiLlama):
YeNo

##### Twitter Link:
https://x.com/yenomarkets


##### Website Link:
http://yeno.trade/

##### Logo (High resolution, will be shown with rounded borders):
https://polymarket-upload.s3.us-east-2.amazonaws.com/profile-image-6849077-fcbfb190-b7e4-4dec-95f9-38ba413693ca.jpg

##### Current TVL:
YeNo is listed as a Polymarket builder interface (volume + fees). User collateral and positions are held in Polymarket infrastructure on Polygon.

##### Chain:
Polygon

##### Short Description (to be shown on DefiLlama):
YeNo is a prediction market where you trade event contracts on Yes-or-No questions about politics, macro, sports, crypto, and culture.

##### Category (full list at https://defillama.com/categories) *Please choose only one:
Interface

##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.):
Chainlink

##### Implementation Details: Briefly describe how the oracle is integrated into your project:
Markets resolve through Polymarket’s resolution infrastructure (UMA Optimistic Oracle + CTF Adapter). Chainlink Data Streams are used where applicable for underlying reference data.

##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage:
- https://docs.chain.link/data-streams
- https://docs.polymarket.com/concepts/resolution
- https://help.polymarket.com/en/articles/13364518-how-are-prediction-markets-resolved
- https://github.com/Polymarket/uma-ctf-adapter
- https://polymarket-uma-ctf-adapter.mintlify.app/introduction
- https://docs.umaproject.org/oracle/optimistic-oracle-interface

##### forkedFrom (Does your project originate from another project):
None. YeNo is an independent trading interface that integrates with Polymarket’s CLOB and resolution infrastructure via API. It does not fork or redeploy Polymarket smart contracts.

##### methodology (what is being counted as tvl, how is tvl being calculated):
**Volume (this PR):** Attributed notional and USD cash volume from Polymarket’s builders API for builder `yeno-markets`, plus USD volume summed from CLOB builder trades for builder code `0x5bffd61a6dbfca06f19a543cac4b9e433378ac9992d70b8a40824720e353498f`.

**Fees (this PR):** Builder fees received from Polymarket CLOB builder trades for the same builder code.

**TVL (not tracked in this PR):** Through Polymarket. TVL on YeNo = mark-to-market value of open Polymarket outcome positions plus pUSD collateral reserved for unmatched BUY limits placed via YeNo, using order placement notional (shares × price). Excludes idle withdrawable pUSD, promo-funded trades, and post-resolution redemptions.

##### Does this project have a referral program?
Yes
