### PR TITLE
[fees] chia - add chain-fees adapter

### DIFF
--- a/fees/chia.ts
+++ b/fees/chia.ts
@@ -2,62 +2,46 @@ import { Adapter, FetchOptions, ProtocolType } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
 import { httpPost } from "../utils/fetchURL";
 
-// Chia coin-set node RPC. get_block_records returns records in [start, end),
-// each with `fees` (transaction fees, in mojo) and `timestamp`
+// Chia coin-set node RPC. get_block_records returns records in [start, end), each
+// with `fees` (transaction fees, in mojo) and `timestamp`. Non-transaction blocks
+// carry null fees/timestamp. 1 XCH = 1e12 mojo. 
 const RPC = "https://api.coinset.org";
 const MOJO_PER_XCH = 1e12;
 const PAGE = 1000; // coinset caps get_block_records at 1000 blocks/call
-const PROBE = 32; // window scanned to skip past null-timestamp (non-tx) blocks
 
 const getBlockRecords = async (start: number, end: number): Promise<any[]> => {
   const res = await httpPost(`${RPC}/get_block_records`, { start, end });
   if (!res?.success) throw new Error(`Chia: get_block_records(${start}, ${end}) failed`);
-  return res.block_records ?? [];
-};
-
-// Smallest height whose timestamp is >= target, via plain binary search over the
-// height range. Non-transaction blocks have null timestamps, so at each midpoint we
-// probe a small window forward and read the first real timestamp.
-const heightAtOrAfter = async (target: number, peak: number): Promise<number> => {
-  let lo = 0;
-  let hi = peak;
-  while (lo < hi) {
-    const mid = (lo + hi) >> 1;
-    const recs = await getBlockRecords(mid, Math.min(mid + PROBE, peak + 1));
-    const ts = recs.find((r) => r.timestamp != null)?.timestamp;
-    if (ts == null) throw new Error(`Chia: no transaction block in [${mid}, ${mid + PROBE})`);
-    if (Number(ts) < target) lo = mid + 1;
-    else hi = mid;
-  }
-  return lo;
+  if (!Array.isArray(res.block_records)) throw new Error(`Chia: get_block_records(${start}, ${end}) returned no records`);
+  return res.block_records;
 };
 
 const fetch = async (options: FetchOptions) => {
   const dailyFees = options.createBalances();
+  const dailySupplySideRevenue = options.createBalances();
 
-  const state = await httpPost(`${RPC}/get_blockchain_state`, {});
-  const peak = Number(state?.blockchain_state?.peak?.height);
-  if (!Number.isFinite(peak)) throw new Error("Chia: could not read peak height");
-
-  const startHeight = await heightAtOrAfter(options.startTimestamp, peak);
-  const endHeight = await heightAtOrAfter(options.endTimestamp, peak);
+  const startHeight = await options.getFromBlock();
+  const endHeight = await options.getToBlock();
 
   let feesMojo = 0;
-  for (let h = startHeight; h < endHeight; h += PAGE) {
-    const recs = await getBlockRecords(h, Math.min(h + PAGE, endHeight));
+  for (let h = startHeight; h <= endHeight; h += PAGE) {
+    const recs = await getBlockRecords(h, Math.min(h + PAGE, endHeight + 1));
     for (const r of recs) {
       const ts = r.timestamp;
       if (ts == null) continue; // non-transaction block: no fees
       if (Number(ts) >= options.startTimestamp && Number(ts) < options.endTimestamp) {
-        feesMojo += Number(r.fees ?? 0); // fees are null on non-tx blocks (already skipped)
+        const fee = Number(r.fees);
+        if (!Number.isFinite(fee)) throw new Error(`Chia: non-finite fee at block ${r.height}`);
+        feesMojo += fee;
       }
     }
   }
 
-  dailyFees.addCGToken("chia", feesMojo / MOJO_PER_XCH);
+  const xch = feesMojo / MOJO_PER_XCH;
+  dailyFees.addCGToken("chia", xch, "Transaction Fees");
+  dailySupplySideRevenue.addCGToken("chia", xch, "Transaction Fees To Farmers");
 
-  // Chia does not burn fees; transaction fees are paid to farmers (block producers).
-  return { dailyFees, dailyRevenue: 0, dailySupplySideRevenue: dailyFees };
+  return { dailyFees, dailyRevenue: 0, dailySupplySideRevenue };
 };
 
 const methodology = {
@@ -66,17 +50,26 @@ const methodology = {
   SupplySideRevenue: "Chia transaction fees are paid to farmers (block producers).",
 };
 
+const breakdownMethodology = {
+  Fees: {
+    "Transaction Fees": "Transaction fees paid by users, summed per block (block rewards excluded).",
+  },
+  SupplySideRevenue: {
+    "Transaction Fees To Farmers": "All transaction fees are paid to farmers (block producers).",
+  },
+};
+
 const adapter: Adapter = {
   version: 2,
-  // pullHourly disabled: each run seeds and refines a search over ~9M block heights
-  // plus per-block paging; hourly granularity would multiply that RPC load ~24x.
+  // pullHourly disabled: fees are paged per-block over the whole day; daily
+  // granularity keeps the coinset RPC load low.
   pullHourly: false,
   fetch,
   chains: [CHAIN.CHIA],
   start: "2021-03-19", // Chia mainnet genesis
-  isExpensiveAdapter: true,
   protocolType: ProtocolType.CHAIN,
   methodology,
+  breakdownMethodology,
 };
 
 export default adapter;

--- a/fees/chia.ts
+++ b/fees/chia.ts
@@ -22,6 +22,7 @@ const fetch = async (options: FetchOptions) => {
 
   const startHeight = await options.getFromBlock();
   const endHeight = await options.getToBlock();
+  if (startHeight == null || endHeight == null) throw new Error("Chia: start or end height is null");
 
   let feesMojo = 0;
   for (let h = startHeight; h <= endHeight; h += PAGE) {
@@ -61,9 +62,7 @@ const breakdownMethodology = {
 
 const adapter: Adapter = {
   version: 2,
-  // pullHourly disabled: fees are paged per-block over the whole day; daily
-  // granularity keeps the coinset API load low.
-  pullHourly: false,
+  pullHourly: true,
   fetch,
   chains: [CHAIN.CHIA],
   start: "2021-03-19", // Chia mainnet genesis

--- a/fees/chia.ts
+++ b/fees/chia.ts
@@ -1,0 +1,82 @@
+import { Adapter, FetchOptions, ProtocolType } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+import { httpPost } from "../utils/fetchURL";
+
+// Chia coin-set node RPC. get_block_records returns records in [start, end),
+// each with `fees` (transaction fees, in mojo) and `timestamp`
+const RPC = "https://api.coinset.org";
+const MOJO_PER_XCH = 1e12;
+const PAGE = 1000; // coinset caps get_block_records at 1000 blocks/call
+const PROBE = 32; // window scanned to skip past null-timestamp (non-tx) blocks
+
+const getBlockRecords = async (start: number, end: number): Promise<any[]> => {
+  const res = await httpPost(`${RPC}/get_block_records`, { start, end });
+  if (!res?.success) throw new Error(`Chia: get_block_records(${start}, ${end}) failed`);
+  return res.block_records ?? [];
+};
+
+// Smallest height whose timestamp is >= target, via plain binary search over the
+// height range. Non-transaction blocks have null timestamps, so at each midpoint we
+// probe a small window forward and read the first real timestamp.
+const heightAtOrAfter = async (target: number, peak: number): Promise<number> => {
+  let lo = 0;
+  let hi = peak;
+  while (lo < hi) {
+    const mid = (lo + hi) >> 1;
+    const recs = await getBlockRecords(mid, Math.min(mid + PROBE, peak + 1));
+    const ts = recs.find((r) => r.timestamp != null)?.timestamp;
+    if (ts == null) throw new Error(`Chia: no transaction block in [${mid}, ${mid + PROBE})`);
+    if (Number(ts) < target) lo = mid + 1;
+    else hi = mid;
+  }
+  return lo;
+};
+
+const fetch = async (options: FetchOptions) => {
+  const dailyFees = options.createBalances();
+
+  const state = await httpPost(`${RPC}/get_blockchain_state`, {});
+  const peak = Number(state?.blockchain_state?.peak?.height);
+  if (!Number.isFinite(peak)) throw new Error("Chia: could not read peak height");
+
+  const startHeight = await heightAtOrAfter(options.startTimestamp, peak);
+  const endHeight = await heightAtOrAfter(options.endTimestamp, peak);
+
+  let feesMojo = 0;
+  for (let h = startHeight; h < endHeight; h += PAGE) {
+    const recs = await getBlockRecords(h, Math.min(h + PAGE, endHeight));
+    for (const r of recs) {
+      const ts = r.timestamp;
+      if (ts == null) continue; // non-transaction block: no fees
+      if (Number(ts) >= options.startTimestamp && Number(ts) < options.endTimestamp) {
+        feesMojo += Number(r.fees ?? 0); // fees are null on non-tx blocks (already skipped)
+      }
+    }
+  }
+
+  dailyFees.addCGToken("chia", feesMojo / MOJO_PER_XCH);
+
+  // Chia does not burn fees; transaction fees are paid to farmers (block producers).
+  return { dailyFees, dailyRevenue: 0, dailySupplySideRevenue: dailyFees };
+};
+
+const methodology = {
+  Fees: "Transaction fees paid by users on the Chia blockchain, summed from each block's transaction fees (block rewards excluded).",
+  Revenue: "None. Chia transaction fees are not burned.",
+  SupplySideRevenue: "Chia transaction fees are paid to farmers (block producers).",
+};
+
+const adapter: Adapter = {
+  version: 2,
+  // pullHourly disabled: each run seeds and refines a search over ~9M block heights
+  // plus per-block paging; hourly granularity would multiply that RPC load ~24x.
+  pullHourly: false,
+  fetch,
+  chains: [CHAIN.CHIA],
+  start: "2021-03-19", // Chia mainnet genesis
+  isExpensiveAdapter: true,
+  protocolType: ProtocolType.CHAIN,
+  methodology,
+};
+
+export default adapter;

--- a/fees/chia.ts
+++ b/fees/chia.ts
@@ -9,6 +9,11 @@ const API = "https://api.coinset.org";
 const MOJO_PER_XCH = 1e12;
 const PAGE = 1000; // coinset caps get_block_records at 1000 blocks/call
 
+/**
+ * Fetches Chia block records in the height range `[start, end)` from the coinset node API.
+ * Each record carries `fees` (transaction fees in mojo) and `timestamp`; non-transaction
+ * blocks have both null. Throws if the request fails or the records array is missing.
+ */
 const getBlockRecords = async (start: number, end: number): Promise<any[]> => {
   const res = await httpPost(`${API}/get_block_records`, { start, end });
   if (!res?.success) throw new Error(`Chia: get_block_records(${start}, ${end}) failed`);
@@ -16,6 +21,10 @@ const getBlockRecords = async (start: number, end: number): Promise<any[]> => {
   return res.block_records;
 };
 
+/**
+ * Sums Chia transaction fees over the day's block range and classifies them under the
+ * chain fee model: fees are paid to farmers (supply-side revenue)  Prices the total in XCH via CoinGecko.
+ */
 const fetch = async (options: FetchOptions) => {
   const dailyFees = options.createBalances();
   const dailySupplySideRevenue = options.createBalances();

--- a/fees/chia.ts
+++ b/fees/chia.ts
@@ -31,7 +31,6 @@ const fetch = async (options: FetchOptions) => {
 
   const startHeight = await options.getFromBlock();
   const endHeight = await options.getToBlock();
-  if (startHeight == null || endHeight == null) throw new Error("Chia: start or end height is null");
 
   let feesMojo = 0;
   for (let h = startHeight; h <= endHeight; h += PAGE) {

--- a/fees/chia.ts
+++ b/fees/chia.ts
@@ -2,15 +2,15 @@ import { Adapter, FetchOptions, ProtocolType } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
 import { httpPost } from "../utils/fetchURL";
 
-// Chia coin-set node RPC. get_block_records returns records in [start, end), each
+// Chia coin-set node API. get_block_records returns records in [start, end), each
 // with `fees` (transaction fees, in mojo) and `timestamp`. Non-transaction blocks
 // carry null fees/timestamp. 1 XCH = 1e12 mojo. 
-const RPC = "https://api.coinset.org";
+const API = "https://api.coinset.org";
 const MOJO_PER_XCH = 1e12;
 const PAGE = 1000; // coinset caps get_block_records at 1000 blocks/call
 
 const getBlockRecords = async (start: number, end: number): Promise<any[]> => {
-  const res = await httpPost(`${RPC}/get_block_records`, { start, end });
+  const res = await httpPost(`${API}/get_block_records`, { start, end });
   if (!res?.success) throw new Error(`Chia: get_block_records(${start}, ${end}) failed`);
   if (!Array.isArray(res.block_records)) throw new Error(`Chia: get_block_records(${start}, ${end}) returned no records`);
   return res.block_records;
@@ -62,7 +62,7 @@ const breakdownMethodology = {
 const adapter: Adapter = {
   version: 2,
   // pullHourly disabled: fees are paged per-block over the whole day; daily
-  // granularity keeps the coinset RPC load low.
+  // granularity keeps the coinset API load low.
   pullHourly: false,
   fetch,
   chains: [CHAIN.CHIA],

--- a/helpers/env.ts
+++ b/helpers/env.ts
@@ -4,6 +4,7 @@ const BOOL_KEYS = [
 
 const DEFAULTS: any = {
   ANKR_API_KEY: '79258ce7f7ee046decc3b5292a24eb4bf7c910d7e39b691384c7ce0cfb839a01',
+  SPACESCAN_API_KEY: 'tkn1qqqhsdmkq3pzrcvt24sgpstsndz2z95qsetg4zchsdmkq3p9wqqqdr2u6a', // free-plan key for api.spacescan.io (Chia block lookups)
   ALTHEA_RPC: "https://althea-l1-archive.althea.systems:8545",
   ZETA_RPC: "https://zetachain-evm.blockpi.network/v1/rpc/public,https://zetachain-mainnet-archive.allthatnode.com:8545",
   SOMNIA_ARCHIVAL_RPC: 'https://explorer.somnia.network/api/eth-rpc',

--- a/helpers/getBlock.ts
+++ b/helpers/getBlock.ts
@@ -123,7 +123,9 @@ async function getChiaBlock(unixTS: number) {
     () => httpGet(`https://api.spacescan.io/block/timestamp/${unixTS}`),
     { retries: 3, minTimeout: 6000 }
   )
-  return Number(res.data.number)
+  const block = Number(res.data.number)
+  if (!Number.isFinite(block)) throw new Error(`Chia: invalid block for timestamp ${unixTS}`)
+  return block
 }
 
 async function getBlocks(chain: Chain, timestamps: number[]) {

--- a/helpers/getBlock.ts
+++ b/helpers/getBlock.ts
@@ -113,9 +113,12 @@ async function getTonBlock(unixTS: number) {
   return data.result.seqno
 }
 
+/**
+ * Resolves a unix timestamp to the nearest Chia block height via the spacescan API.
+ * Retries with backoff to ride out the free-tier rate limit (5 req/min).
+ */
 async function getChiaBlock(unixTS: number) {
   // spacescan returns the nearest block to the timestamp (number is a string).
-  // Backoff retry rides out the free-tier rate limit (5 req/min ~= 1 per 12s).
   const res = await retry(
     () => httpGet(`https://api.spacescan.io/block/timestamp/${unixTS}`),
     { retries: 3, minTimeout: 6000 }

--- a/helpers/getBlock.ts
+++ b/helpers/getBlock.ts
@@ -2,6 +2,7 @@ import { Chain, ChainBlocks } from "../adapters/types";
 import { CHAIN } from "./chains";
 import * as sdk from "@defillama/sdk"
 import { httpGet, httpPost } from "../utils/fetchURL";
+import { getEnv } from "./env";
 const retry = require("async-retry")
 
 const blacklistedChains: string[] = [
@@ -119,8 +120,11 @@ async function getTonBlock(unixTS: number) {
  */
 async function getChiaBlock(unixTS: number) {
   // spacescan returns the nearest block to the timestamp (number is a string).
+  // Retry with backoff as insurance against rate-limit bursts during backfill.
   const res = await retry(
-    () => httpGet(`https://api.spacescan.io/block/timestamp/${unixTS}`),
+    () => httpGet(`https://api.spacescan.io/block/timestamp/${unixTS}`, {
+      headers: { "x-api-key": getEnv("SPACESCAN_API_KEY") },
+    }),
     { retries: 3, minTimeout: 6000 }
   )
   const block = Number(res.data.number)

--- a/helpers/getBlock.ts
+++ b/helpers/getBlock.ts
@@ -83,6 +83,8 @@ async function _getBlock(timestamp: number, chain: Chain, chainBlocks = {} as Ch
 
     if (chain === CHAIN.TON)
       block = await getTonBlock(timestamp)
+    else if (chain === CHAIN.CHIA)
+      block = await getChiaBlock(timestamp)
     else
       block = await sdk.blocks.getBlockNumber(chain, timestamp)
   } catch (e) {
@@ -109,6 +111,16 @@ async function _getBlock(timestamp: number, chain: Chain, chainBlocks = {} as Ch
 async function getTonBlock(unixTS: number) {
   const data = await httpGet(`https://toncenter.com/api/v2/lookupBlock?workchain=-1&shard=-1&unixtime=${unixTS}`)
   return data.result.seqno
+}
+
+async function getChiaBlock(unixTS: number) {
+  // spacescan returns the nearest block to the timestamp (number is a string).
+  // Backoff retry rides out the free-tier rate limit (5 req/min ~= 1 per 12s).
+  const res = await retry(
+    () => httpGet(`https://api.spacescan.io/block/timestamp/${unixTS}`),
+    { retries: 3, minTimeout: 6000 }
+  )
+  return Number(res.data.number)
 }
 
 async function getBlocks(chain: Chain, timestamps: number[]) {


### PR DESCRIPTION
#2622

## Chia — chain fees adapter

- **Protocol:** Chia
- **Chain:** Chia
- **Category:** Chain
- **CoinGecko ID:** chia

### Methodology
Sums each block's transaction `fees` from the coinset node API over the day, priced in XCH.
- **Fees** — transaction fees paid by users (block rewards excluded)
- **Revenue** — 0 (Chia does not burn fees)
- **SupplySideRevenue** — all fees, paid to farmers (block producers)

### Notes
- timestamp→block via spacescan; per-block fees via coinset (`api.coinset.org`)

Website: https://www.chia.net
Twitter: https://x.com/chia_project
Docs: https://docs.chia.net

