### PR TITLE
[feat] Lighter-Robinhood: track lighter perps robinhood instance

### DIFF
--- a/dexs/lighterv2/index.ts
+++ b/dexs/lighterv2/index.ts
@@ -3,15 +3,24 @@ import { CHAIN } from "../../helpers/chains";
 import { httpGet, fetchURLAutoHandleRateLimit } from "../../utils/fetchURL";
 import PromisePool from "@supercharge/promise-pool";
 
-
-const API = "https://mainnet.zklighter.elliot.ai/api/v1";
+const chainConfig: Record<string, { api: string; start: string }> = {
+  [CHAIN.ZK_LIGHTER]: {
+    api: "https://mainnet.zklighter.elliot.ai/api/v1",
+    start: "2025-01-17",
+  },
+  [CHAIN.ROBINHOOD]: {
+    api: "https://api.rh.lighter.xyz/api/v1",
+    start: "2026-06-26",
+  },
+};
 
 const fetch = async (options: FetchOptions) => {
   let dailyVolume = 0;
   const start = options.startOfDay;
+  const { api } = chainConfig[options.chain];
 
   // Get all markets
-  const markets = await httpGet(`${API}/orderBooks?market_id=255`);
+  const markets = await httpGet(`${api}/orderBooks?market_id=255`);
   options.api.log('Lighter markets #', markets?.order_books?.length || 0);
 
   // Filter markets to only include those with market_id < 2048
@@ -28,7 +37,7 @@ const fetch = async (options: FetchOptions) => {
         end_timestamp: start + 1,
         count_back: 1,
       }
-      const url = `${API}/candles?${new URLSearchParams(params as any).toString()}`;
+      const url = `${api}/candles?${new URLSearchParams(params as any).toString()}`;
       const data = await fetchURLAutoHandleRateLimit(url);
 
       const candle = data?.c?.[0];
@@ -47,8 +56,7 @@ const methodology = {
 
 const adapter: SimpleAdapter = {
   fetch,
-  chains: [CHAIN.ZK_LIGHTER],
-  start: "2025-01-17",       // earliest candlestick data available
+  adapter: chainConfig,
   methodology,
 };
 

--- a/open-interest/lighter-v2.ts
+++ b/open-interest/lighter-v2.ts
@@ -1,11 +1,23 @@
-import { SimpleAdapter } from "../adapters/types";
+import { FetchOptions, SimpleAdapter } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
 import fetchURL from "../utils/fetchURL";
 
-const fetch = async (_: any) => {
-  let openInterestAtEnd = 0;
+const chainConfig: Record<string, { api: string; start: string }> = {
+  [CHAIN.ZK_LIGHTER]: {
+    api: "https://mainnet.zklighter.elliot.ai/api/v1",
+    start: "2025-01-17",
+  },
+  [CHAIN.ROBINHOOD]: {
+    api: "https://api.rh.lighter.xyz/api/v1",
+    start: "2026-06-26",
+  },
+};
 
-  const data = await fetchURL('https://mainnet.zklighter.elliot.ai/api/v1/orderBookDetails');
+const fetch = async (options: FetchOptions) => {
+  let openInterestAtEnd = 0;
+  const { api } = chainConfig[options.chain];
+
+  const data = await fetchURL(`${api}/orderBookDetails`);
   const markets = data.order_book_details;
   markets.forEach((market: any) => {
     openInterestAtEnd += (Number(market.open_interest || 0) * Number(market.last_trade_price || 0) * 2); // * 2 because of double sided OI
@@ -17,9 +29,8 @@ const fetch = async (_: any) => {
 const adapter: SimpleAdapter = {
   version: 2,
   fetch,
-  chains: [CHAIN.ZK_LIGHTER],
+  adapter: chainConfig,
   runAtCurrTime: true,
-  start: "2025-01-17",
 };
 
 export default adapter;


### PR DESCRIPTION
## Summary
- Adds Robinhood Chain coverage to the existing Lighter v2 volume and open interest adapters.
- Keeps Lighter under the existing adapter slug while routing each chain to its own API host.

## Changes
- Updated `dexs/lighterv2/index.ts` to use chain-specific API config for `zklighter` and `robinhood`.
- Added Robinhood Chain volume tracking through `https://api.rh.lighter.xyz/api/v1`, starting `2026-06-26`.
- Updated `open-interest/lighter-v2.ts` to use the same chain-specific API config.
- Added Robinhood Chain open interest tracking from the Robinhood Lighter `orderBookDetails` endpoint.

## Methodology
- Volume continues to use Lighter daily candles and sums markets with `market_id < 2048`, preserving the existing perp-market filtering.
- Open interest continues to sum `open_interest * last_trade_price * 2` across markets, preserving the existing double-sided OI methodology.
- Existing `zklighter` API behavior and start date are unchanged.

## Tests
- `pnpm test dexs lighterv2 2026-06-27`
- `pnpm test open-interest lighter-v2 2026-06-27`