### PR TITLE
Add ProFunding (Hyperliquid builder)

### DIFF
--- a/factory/hyperliquid.ts
+++ b/factory/hyperliquid.ts
@@ -732,6 +732,20 @@ const builderConfigs: Record<string, BuilderConfig> = {
     },
     breakdownFees: true,
   },
+  "profunding": {
+    // ProFunding (https://profunding.pro) builder code on Hyperliquid,
+    // lowercased to match HL's builder_fills files.
+    addresses: ["0x0078f290838ee72228944a716145aad0f2a384d5"],
+    // First day the ProFunding app attached its HL builder code
+    // (mandatory approval at login shipped 2026-02-22).
+    start: "2026-02-22",
+    methodology: {
+      Fees: "Builder code fees paid by users on Hyperliquid perps trades placed through ProFunding's funding-rate arbitrage terminal (manual delta-neutral trades, TWAP execution, and autopilot).",
+      Revenue: "Builder code fees collected by ProFunding from Hyperliquid perps trades.",
+      ProtocolRevenue: "Builder code fees collected by ProFunding from Hyperliquid perps trades.",
+    },
+    breakdownFees: true,
+  },
 };
 
 


### PR DESCRIPTION
This PR adds a Hyperliquid builder-code fees adapter for ProFunding, a funding-rate
arbitrage terminal (https://profunding.pro) for perpetual DEXes. Users find funding-rate
opportunities and open/manage delta-neutral positions across 20+ exchanges; Hyperliquid
trades placed through the app (manual delta-neutral trades, TWAP execution, and
autopilot) carry the ProFunding builder code, which took effect 2026-02-22.

Builder address: 0x0078f290838ee72228944a716145aad0f2a384d5
Start date: 2026-02-22

---

##### Name (to be shown on DefiLlama): ProFunding

##### Twitter Link: https://x.com/profundingpro

##### List of audit links if any: N/A

##### Website Link: https://profunding.pro

##### Logo (High resolution, will be shown with rounded borders): https://profunding.pro/icon.png

##### Current TVL: N/A (not a TVL protocol — Hyperliquid builder-fee/derivatives listing only)

##### Treasury Addresses (if the protocol has treasury): N/A

##### Chain: Hyperliquid

##### Coingecko ID: N/A (no token)

##### Coinmarketcap ID: N/A (no token)

##### Short Description (to be shown on DefiLlama): Funding-rate arbitrage terminal for
perpetual DEXes — find, open and manage delta-neutral positions across 20+ exchanges.

##### Token address and ticker if any: N/A

##### Category (full list at https://defillama.com/categories) *Please choose only one:
Trading App (suggested — please correct if DefiLlama has a more precise existing category
for HL builder-code frontends)

##### Oracle Provider(s): N/A

##### Implementation Details: N/A

##### Documentation/Proof: Builder address 0x0078f290838ee72228944a716145aad0f2a384d5 is
attached to every Hyperliquid order placed through the ProFunding app (mandatory
builder-code approval at login).

##### forkedFrom (Does your project originate from another project): No

##### methodology (what is being counted as tvl, how is tvl being calculated): N/A — this
is a fees adapter, not TVL. See `methodology` block in factory/hyperliquid.ts for the
Fees/Revenue/ProtocolRevenue definitions.

##### Github org/user (Optional): N/A

##### Does this project have a referral program? Yes, an influencer/affiliate program
(commission on referred users' trading fees) — not a DEX-native referral bounty.
