### PR TITLE
quickswap: split revenue 30% foundation / 70% holders from Nov 5, 2025

### DIFF
--- a/dexs/quickswap-v2.ts
+++ b/dexs/quickswap-v2.ts
@@ -1,40 +1,41 @@
 import { CHAIN } from "../helpers/chains";
-import { SimpleAdapter } from "../adapters/types";
-import { uniV2Exports } from "../helpers/uniswap";
+import { FetchOptions, SimpleAdapter } from "../adapters/types";
+import { getUniV2LogAdapter } from "../helpers/uniswap";
 
-// 0.3% swap fee: 0.25% to LPs, 0.04% to community buybacks, 0.01% to foundation
-const feeConfig = {
-  userFeesRatio: 1,
-  revenueRatio: 0.05 / 0.3,
-  protocolRevenueRatio: 0.01 / 0.3,
-  holdersRevenueRatio: 0.04 / 0.3,
+// Governance vote executed ~9PM Nov 4, 2025; first full day under the new split is Nov 5.
+const nov5th2025 = 1762300800; // Nov 5, 2025 00:00 UTC
+
+// 0.3% swap fee: 0.25% to LPs, 0.05% is the protocol cut (revenue).
+// Revenue split foundation/holders: 20/80 before the vote, 30/70 after.
+const getFeeConfig = (timestamp: number) => {
+  const revenueRatio = 0.05 / 0.3;
+  const foundationShare = timestamp >= nov5th2025 ? 0.30 : 0.20;
+  return {
+    userFeesRatio: 1,
+    revenueRatio,
+    protocolRevenueRatio: revenueRatio * foundationShare,
+    holdersRevenueRatio: revenueRatio * (1 - foundationShare),
+  };
 };
 
-const adapter: SimpleAdapter = uniV2Exports({
-  [CHAIN.POLYGON]: {
-    factory: '0x5757371414417b8C6CAad45bAeF941aBc7d3Ab32',
-    start: '2020-10-09',
-    ...feeConfig,
-  },
-  [CHAIN.BASE]: {
-    factory: '0xEC6540261aaaE13F236A032d454dc9287E52e56A',
-    start: '2025-06-04',
-    ...feeConfig,
-  },
-  // [CHAIN.DOGECHAIN]: {
-  //   factory: '0xC3550497E591Ac6ed7a7E03ffC711CfB7412E57F',
-  //   start: '2023-04-11',
-  //   ...feeConfig,
-  // }
-}, { runAsV1: true });
+const mkFetch = (factory: string) => (options: FetchOptions) =>
+  getUniV2LogAdapter({ factory, ...getFeeConfig(options.startOfDay) })(options);
 
-adapter.methodology = {
-  UserFees: "User pays 0.3% fees on each swap.",
-  Fees: "0.3% of each swap is collected as trading fees",
-  Revenue: "Protocol takes 16.66% of collected fees (0.04% community + 0.01% foundation).",
-  ProtocolRevenue: "Foundation receives 3.33% of collected fees (0.01% of swap volume).",
-  SupplySideRevenue: "83.33% of collected fees go to liquidity providers (0.25% of swap volume).",
-  HoldersRevenue: "Community receives 13.33% of collected fees for buybacks (0.04% of swap volume).",
+const adapter: SimpleAdapter = {
+  version: 1,
+  adapter: {
+    [CHAIN.POLYGON]: { fetch: mkFetch('0x5757371414417b8C6CAad45bAeF941aBc7d3Ab32'), start: '2020-10-09' },
+    [CHAIN.BASE]: { fetch: mkFetch('0xEC6540261aaaE13F236A032d454dc9287E52e56A'), start: '2025-06-04' },
+    // [CHAIN.DOGECHAIN]: { fetch: mkFetch('0xC3550497E591Ac6ed7a7E03ffC711CfB7412E57F'), start: '2023-04-11' },
+  },
+  methodology: {
+    UserFees: "User pays 0.3% fees on each swap.",
+    Fees: "0.3% of each swap is collected as trading fees",
+    Revenue: "Protocol takes 16.66% of collected fees (0.05% of swap volume).",
+    ProtocolRevenue: "Foundation receives 30% of the protocol revenue since Nov 4, 2025 (before that 20%).",
+    SupplySideRevenue: "83.33% of collected fees go to liquidity providers (0.25% of swap volume).",
+    HoldersRevenue: "Community receives 70% of the protocol revenue since Nov 4, 2025 (before that 80%) for buybacks.",
+  },
 };
 
 export default adapter;

--- a/dexs/quickswap-v3.ts
+++ b/dexs/quickswap-v3.ts
@@ -13,8 +13,10 @@ const QuickswapV3Factories: Record<string, string> = {
 // Function to get correct fee ratios based on timestamp and chain
 const getV3FeePercentages = (timestamp: number, chain: string) => {
   const march1st2025 = 1740787200; // March 1, 2025 UTC timestamp
+  // Governance vote executed ~9PM Nov 4, 2025; first full day under the 30/70 (foundation/holders) split is Nov 5.
+  const nov5th2025 = 1762300800; // Nov 5, 2025 00:00 UTC
 
-  // For uni forks like IMX, use 10% total revenue structure
+  // For uni forks like IMX, use 10% total revenue structure (already 30/70 foundation/holders)
   if ([CHAIN.IMX, CHAIN.MANTA].includes(chain as CHAIN)) {
     return {
       protocolRevenueRatio: 0.03,
@@ -33,13 +35,21 @@ const getV3FeePercentages = (timestamp: number, chain: string) => {
       userFeesRatio: 1,
       revenueRatio: 0.085, // 1.7% + 6.8% (ignoring Algebra Labs 1.5%)
     };
-  } else {
-    // After March 1, 2025: 15% total revenue
+  } else if (timestamp < nov5th2025) {
+    // March 1 - Nov 4, 2025: 15% total revenue, ~24/76 foundation/holders
     return {
       protocolRevenueRatio: 0.0323,
       holdersRevenueRatio: 0.10, // Community fee (buybacks)
       userFeesRatio: 1,
       revenueRatio: 0.1323, // 3.23% + 10% (ignoring Algebra Labs 1.77%)
+    };
+  } else {
+    // From Nov 5, 2025: same 15% total revenue, split 30% foundation / 70% holders
+    return {
+      protocolRevenueRatio: 0.1323 * 0.30,
+      holdersRevenueRatio: 0.1323 * 0.70, // Community fee (buybacks)
+      userFeesRatio: 1,
+      revenueRatio: 0.1323, // (ignoring Algebra Labs 1.77%)
     };
   }
 };
@@ -63,10 +73,10 @@ const adapter: SimpleAdapter = {
   methodology: {
     UserFees: "User pays dynamic fees on each swap based on pool settings (typically 0.01% to 1%).",
     Fees: "Dynamic fees are collected on each swap based on pool configuration",
-    Revenue: "Protocol takes 15% of collected fees (current). Historical: 10% before March 2025, 10% on uni forks like IMX.",
-    ProtocolRevenue: "Foundation receives 3.23% of collected fees (current). Historical: 1.7% before March 2025, 3% on uni forks.",
-    SupplySideRevenue: "85% of collected fees go to liquidity providers (90% on uni forks like IMX).",
-    HoldersRevenue: "Community receives 10% of collected fees for buybacks (current). Historical: 6.8% before March 2025, 7% on uni forks.",
+    Revenue: "Protocol takes 13.23% of collected fees (current). Historical: 8.5% before March 2025; 10% on uni forks like IMX.",
+    ProtocolRevenue: "Foundation receives 30% of the protocol revenue since Nov 4, 2025 (~3.97% of fees). Before that ~3.23% of fees; 3% on uni forks.",
+    SupplySideRevenue: "~86.77% of collected fees go to liquidity providers (90% on uni forks like IMX).",
+    HoldersRevenue: "Community receives 70% of the protocol revenue since Nov 4, 2025 (~9.26% of fees) for buybacks. Before that 10% of fees; 7% on uni forks.",
   },
   fetch,
   adapter: {

--- a/dexs/quickswap-v4.ts
+++ b/dexs/quickswap-v4.ts
@@ -6,9 +6,17 @@ import { httpGet } from "../utils/fetchURL";
 const poolCreatedEvent = 'event Pool (address indexed token0, address indexed token1, address pool)'
 const swapEvent = 'event Swap(address indexed sender, address indexed recipient, int256 amount0, int256 amount1, uint160 price, uint128 liquidity, int24 tick, uint24 overrideFee, uint24 pluginFee)'
 
-const HOLDERS_RATIO = 0.10;
-const PROTOCOL_RATIO = 0.0323;
-const REVENUE_RATIO = HOLDERS_RATIO + PROTOCOL_RATIO;
+const REVENUE_RATIO = 0.1323;
+// Governance vote executed ~9PM Nov 4, 2025; first full day under the new split is Nov 5.
+const nov5th2025 = 1762300800; // Nov 5, 2025 00:00 UTC
+
+// Foundation/holders split of the protocol revenue: ~24/76 before the vote, 30/70 after.
+const getRatios = (timestamp: number) => {
+  if (timestamp >= nov5th2025) {
+    return { protocol: REVENUE_RATIO * 0.30, holders: REVENUE_RATIO * 0.70 };
+  }
+  return { protocol: 0.0323, holders: 0.10 };
+};
 
 const config = {
   isAlgebraV3: true,
@@ -16,8 +24,6 @@ const config = {
   swapEvent,
   userFeesRatio: 1,
   revenueRatio: REVENUE_RATIO,
-  protocolRevenueRatio: PROTOCOL_RATIO,
-  holdersRevenueRatio: HOLDERS_RATIO,
 }
 
 const chainData: any = {}
@@ -48,6 +54,7 @@ async function fetch(options: FetchOptions) {
 
   const fees = dayData?.feesUSD || 0;
   const volume = dayData?.dailyVolumeUSD || 0;
+  const { protocol, holders } = getRatios(startOfDay);
 
   return {
     dailyVolume: volume,
@@ -55,8 +62,8 @@ async function fetch(options: FetchOptions) {
     dailyUserFees: fees,
     dailyRevenue: fees * REVENUE_RATIO,
     dailySupplySideRevenue: fees * (1 - REVENUE_RATIO),
-    dailyProtocolRevenue: fees * PROTOCOL_RATIO,
-    dailyHoldersRevenue: fees * HOLDERS_RATIO,
+    dailyProtocolRevenue: fees * protocol,
+    dailyHoldersRevenue: fees * holders,
   }
 }
 
@@ -65,10 +72,10 @@ const adapter: SimpleAdapter = {
   methodology: {
     Fees: 'Swap fees paid by users',
     UserFees: 'Swap fees paid by users',
-    Revenue: 'Protocol takes 13.23% of collected fees (3.23% foundation + 10% community buybacks).',
-    ProtocolRevenue: 'Foundation receives 3.23% of collected fees.',
-    SupplySideRevenue: '85% of collected fees go to liquidity providers.',
-    HoldersRevenue: 'Community receives 10% of collected fees for buybacks.',
+    Revenue: 'Protocol takes 13.23% of collected fees.',
+    ProtocolRevenue: 'Foundation receives 30% of the protocol revenue since Nov 4, 2025 (before that ~3.23% of fees).',
+    SupplySideRevenue: '~86.77% of collected fees go to liquidity providers.',
+    HoldersRevenue: 'Community receives 70% of the protocol revenue since Nov 4, 2025 (before that 10% of fees) for buybacks.',
   },
   fetch,
   adapter: {


### PR DESCRIPTION
## What

QuickSwap governance vote ([snapshot quickvote.eth](https://snapshot.org/#/s:quickvote.eth/proposal/0xf811632a4449e83f639667b5371538f8343eba26d472c762c3c6ca4807fb4027)) changed the protocol revenue split to **30% foundation / 70% holders** across all QuickSwap children.

Vote executed ~9PM Nov 4, 2025, so the first full day under the new split is **Nov 5, 2025** (`1762300800`). The total protocol take is unchanged; only the foundation/holders split shifts.

## Changes

- **quickswap-v2.ts**: 20/80 to 30/70 of the 0.05% protocol cut
- **quickswap-v3.ts**: added a Nov 5 branch, 30/70 of the 13.23% revenue (IMX/MANTA forks already 30/70)
- **quickswap-v4.ts**: `getRatios` swaps to 30/70 at the cutoff

Perps and liquidityHub adapters untouched (no foundation/holders split).

A refill is needed to apply the corrected historical split.
