### PR TITLE
fix Kinetiq Earn performance fee accounting

### DIFF
--- a/fees/kinetiq-earn/index.ts
+++ b/fees/kinetiq-earn/index.ts
@@ -1,4 +1,3 @@
-import { Interface } from "ethers";
 import * as sdk from "@defillama/sdk";
 import { Adapter, FetchOptions, FetchResultV2 } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
@@ -59,17 +58,16 @@ async function fetch(options: FetchOptions): Promise<FetchResultV2> {
   const dailySupplySideRevenue = options.createBalances();
   const dailyProtocolRevenue = options.createBalances();
 
-  const accountantInterface = new Interface([exchangeRateUpdatedAbi]);
   const events: ExchangeRateUpdatedEvent[] = (await options.getLogs({
     target: ACCOUNTANT,
     eventAbi: exchangeRateUpdatedAbi,
     entireLog: true,
+    parseLog: true,
   })).map((log) => {
-    const decoded = accountantInterface.parseLog(log)!;
     return {
       blockNumber: Number(log.blockNumber),
-      oldRate: decoded.args.oldRate,
-      newRate: decoded.args.newRate,
+      oldRate: log.args.oldRate,
+      newRate: log.args.newRate,
     };
   });
 

--- a/fees/kinetiq-earn/index.ts
+++ b/fees/kinetiq-earn/index.ts
@@ -1,5 +1,7 @@
-import { CHAIN } from "../../helpers/chains";
+import { Interface } from "ethers";
+import * as sdk from "@defillama/sdk";
 import { Adapter, FetchOptions, FetchResultV2 } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
 
 // Kinetiq Earn — an automated kHYPE DeFi strategy vault powered by Veda (curated by Seven Seas).
 // https://kinetiq.xyz/docs/earn
@@ -42,6 +44,14 @@ const ACCOUNTANT = "0x74392Fa56405081d5C7D93882856c245387Cece2";
 
 const accountantStateAbi =
   "function accountantState() view returns(address payoutAddress,uint96 highwaterMark,uint128 feesOwedInBase,uint128 totalSharesLastUpdate,uint96 exchangeRate,uint16 allowedExchangeRateChangeUpper,uint16 allowedExchangeRateChangeLower,uint64 lastUpdateTimestamp,bool isPaused,uint24 minimumUpdateDelayInSeconds,uint16 platformFee,uint16 performanceFee)";
+const exchangeRateUpdatedAbi =
+  "event ExchangeRateUpdated(uint96 oldRate, uint96 newRate, uint64 currentTime)";
+
+interface ExchangeRateUpdatedEvent {
+  blockNumber: number;
+  oldRate: bigint;
+  newRate: bigint;
+}
 
 async function fetch(options: FetchOptions): Promise<FetchResultV2> {
   const dailyFees = options.createBalances();
@@ -49,25 +59,52 @@ async function fetch(options: FetchOptions): Promise<FetchResultV2> {
   const dailySupplySideRevenue = options.createBalances();
   const dailyProtocolRevenue = options.createBalances();
 
-  const [rateBefore, rateAfter, totalSupply, state] = await Promise.all([
-    options.fromApi.call({ target: ACCOUNTANT, abi: "uint256:getRate" }),
-    options.toApi.call({ target: ACCOUNTANT, abi: "uint256:getRate" }),
-    options.api.call({ target: VAULT, abi: "uint256:totalSupply" }),
-    options.api.call({ target: ACCOUNTANT, abi: accountantStateAbi }),
-  ]);
+  const accountantInterface = new Interface([exchangeRateUpdatedAbi]);
+  const events: ExchangeRateUpdatedEvent[] = (await options.getLogs({
+    target: ACCOUNTANT,
+    eventAbi: exchangeRateUpdatedAbi,
+    entireLog: true,
+  })).map((log) => {
+    const decoded = accountantInterface.parseLog(log)!;
+    return {
+      blockNumber: Number(log.blockNumber),
+      oldRate: decoded.args.oldRate,
+      newRate: decoded.args.newRate,
+    };
+  });
 
-  const performanceFeeRate = Number(state.performanceFee) / 1e4;
+  for (const event of events) {
+    const [totalSupply, previousState] = await Promise.all([
+      sdk.api2.abi.call({
+        chain: options.chain,
+        target: VAULT,
+        abi: "uint256:totalSupply",
+        block: event.blockNumber,
+      }),
+      sdk.api2.abi.call({
+        chain: options.chain,
+        target: ACCOUNTANT,
+        abi: accountantStateAbi,
+        block: event.blockNumber - 1,
+      }),
+    ]);
 
-  const rateGrowth = (Number(rateAfter) - Number(rateBefore)) / 1e18;
-  const yieldAfterFees = (Number(totalSupply) / 1e18) * rateGrowth;
+    const highwaterMark = BigInt(previousState.highwaterMark);
+    const shareSupply = Math.min(Number(totalSupply), Number(previousState.totalSharesLastUpdate));
+    const grossYield = Number(event.newRate - event.oldRate) * shareSupply / 1e36;
 
-  const yieldTotal = yieldAfterFees / (1 - performanceFeeRate);
-  const performanceFees = yieldTotal - yieldAfterFees;
+    let performanceFees = 0;
+    if (event.newRate > highwaterMark) {
+      const yieldAboveHighwater = Number(event.newRate - highwaterMark) * shareSupply / 1e36;
+      performanceFees = yieldAboveHighwater * Number(previousState.performanceFee) / 1e4;
+    }
+    const depositorYield = grossYield - performanceFees;
 
-  dailyFees.addCGToken("hyperliquid", yieldTotal, METRICS.VaultYield);
-  dailyRevenue.addCGToken("hyperliquid", performanceFees, METRICS.PerformanceFees);
-  dailyProtocolRevenue.addCGToken("hyperliquid", performanceFees, METRICS.PerformanceFees);
-  dailySupplySideRevenue.addCGToken("hyperliquid", yieldAfterFees, METRICS.VaultYieldToDepositors);
+    dailyFees.addCGToken("hyperliquid", grossYield, METRICS.VaultYield);
+    dailyRevenue.addCGToken("hyperliquid", performanceFees, METRICS.PerformanceFees);
+    dailyProtocolRevenue.addCGToken("hyperliquid", performanceFees, METRICS.PerformanceFees);
+    dailySupplySideRevenue.addCGToken("hyperliquid", depositorYield, METRICS.VaultYieldToDepositors);
+  }
 
   return {
     dailyFees,


### PR DESCRIPTION
## Summary

Fixes Kinetiq Earn's gross yield and performance-fee calculation by reconstructing each onchain `ExchangeRateUpdated` settlement.

The previous adapter treated exchange-rate growth as depositor yield after fees and grossed it up by `1 / (1 - performanceFee)`. The deployed accountant treats that same rate growth as gross yield and calculates the performance fee directly from yield above its high-water mark. This overstated protocol revenue by about 25% when the configured fee was 20%.

## Onchain evidence

- Vault: `0x9BA2EDc44E0A4632EB4723E81d4142353e1bB160`
- Accountant: `0x74392Fa56405081d5C7D93882856c245387Cece2`
- The verified accountant computes `yieldEarned = (newRate - highwaterMark) * min(currentShares, totalSharesLastUpdate) / 1e18`, then `performanceFeesOwedInBase = yieldEarned * performanceFee / 1e4`.
- A fixed-seed sample of 35 positive updates from the 314 emitted events produced 3,620.41 HYPE under the old calculation versus 2,877.57 HYPE from the contract formula, a 25.8% aggregate overstatement.

The fix uses each event's pre-update high-water mark, prior recorded supply, current event-block supply, and configured performance fee.

## Validation

- `pnpm run ts-check`
- `pnpm test fees kinetiq-earn 1783465200`
  - 3,705 HYPE gross yield
  - 741 HYPE protocol revenue
  - 2,964 HYPE supply-side revenue
- `pnpm test fees kinetiq-earn 2025-08-29`
  - validates the historical capped-share-supply path