### PR TITLE
fix(usdai): fees adapter throwing on loans migrated from the v1 router

### DIFF
--- a/fees/usdai/index.ts
+++ b/fees/usdai/index.ts
@@ -65,6 +65,14 @@ const loanOriginatedByHashQuery = gql`
   }
 `;
 
+const loanMigratedByV2HashQuery = gql`
+  query GetLoanMigrationByV2Hash($loanTermsHash: Bytes!) {
+    loanMigrateds(where: { loanTermsHashV2: $loanTermsHash }, first: 1) {
+      loanTerms
+    }
+  }
+`;
+
 // 10,000 basis points = 100%, 10% of interest going to protocol
 const BASIS_POINTS_SCALE = 10_000n;
 const BASE_YIELD_ADMIN_FEE_RATE = 1_000n;
@@ -131,11 +139,19 @@ const fetch: any = async (options: FetchOptions) => {
     let cached = v2CurrencyTokenCache.get(loanTermsHash);
     if (!cached) {
       cached = request(LOAN_ROUTER_V2_SUBGRAPH_API, loanOriginatedByHashQuery, { loanTermsHash })
-        .then((response: any) => {
-          if (!response.loanOriginateds?.length) {
-            throw new Error(`No v2 loan origination found for loan terms hash ${loanTermsHash}`);
+        .then(async (response: any) => {
+          if (response.loanOriginateds?.length) {
+            return response.loanOriginateds[0].currencyToken.id;
           }
-          return response.loanOriginateds[0].currencyToken.id;
+          // Loans migrated from the v1 router emit LoanMigrated instead of LoanOriginated, and the
+          // migration redenominates the loan (v1 PYUSD loans became USDai loans), so the currency
+          // token has to come from the abi-encoded v2 loan terms (4th word) rather than the v1
+          // origination.
+          const migration = await request(LOAN_ROUTER_V2_SUBGRAPH_API, loanMigratedByV2HashQuery, { loanTermsHash });
+          if (!migration.loanMigrateds?.length) {
+            throw new Error(`No v2 loan origination or migration found for loan terms hash ${loanTermsHash}`);
+          }
+          return '0x' + migration.loanMigrateds[0].loanTerms.slice(2 + 3 * 64 + 24, 2 + 4 * 64);
         });
       v2CurrencyTokenCache.set(loanTermsHash, cached);
     }


### PR DESCRIPTION
USD AI fees have been dead since 2026-07-01, the day #7874 shipped the loan router v2 support. api.llama.fi/summary/fees/usd-ai shows missing/zero days from Jul 1 onward (~$1.1M/30d before that).

Root cause: loans migrated from the v1 router are registered on v2 through a `LoanMigrated` event, not `LoanOriginated`, so `getV2CurrencyToken` finds no origination in the subgraph and throws, killing the whole day. First migration tx: 0xd9b28abebf9f53691b73255548366930a4b6dda31dbae2d62bd5d8877c18ea52 (Jul 2). Any repayment on a migrated loan since then (e.g. 0xbf8fbed0405342ca1bfc6437b42922adafe566c67e5673f4fa341fd61e9c9d1e on Jul 9) reproduces it.

One subtlety: the migration also redenominates the loan, v1 PYUSD loans became USDai loans, so falling back to the v1 origination's currency token would inflate amounts by 1e12 (6 vs 18 decimals). I hit exactly that on the first attempt ("value is too damn high"). The currency token instead comes out of the abi-encoded v2 loan terms stored on the `loanMigrateds` entity (4th word, fixed offset on all 17 migrations so far).

Tested the previously-failing days:
- Jul 9→10 (the repayment above): $4.07k fees / $407 revenue, 10% admin clip checks out
- Jul 1→2: $190.4k, Jul 2→3 (migration day): $91.8k, Jul 5→6: $701
- Days where the current code already succeeds are untouched, the change only replaces the throw path.
