### PR TITLE
Add Eden chain fees and bot.fun revenue adapters

### DIFF
--- a/factory/blockscout.ts
+++ b/factory/blockscout.ts
@@ -130,6 +130,7 @@ const protocolChainMap: Record<string, string> = {
   "shido": CHAIN.SHIDO,
   "b3": CHAIN.B3,
   "degen": CHAIN.DEGEN,
+  "eden-chain": CHAIN.EDEN,
   "bsquared": CHAIN.BSQUARED,
 }
 

--- a/fees/bot-fun.ts
+++ b/fees/bot-fun.ts
@@ -1,9 +1,6 @@
-import { PromisePool } from '@supercharge/promise-pool'
-import { Interface } from 'ethers'
 import { FetchOptions, SimpleAdapter } from '../adapters/types'
 import { CHAIN } from '../helpers/chains'
 import { METRIC } from '../helpers/metrics'
-import { httpGet } from '../utils/fetchURL'
 
 const FACTORY = '0x279dc5E05d43644C6cd2F2813F306a320e785cdD'
 
@@ -15,97 +12,65 @@ const REFERRAL_ACCRUED = 'event ReferralAccrued(address indexed token, address i
 const BURNED_PROTOCOL_FEES = 'Burned Protocol Fees'
 const REFERRAL_FEES = 'Referral Fees'
 const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000'
-const LOG_BLOCK_RANGE = 100_000
-const BLOCKSCOUT_LOG_LIMIT = 1_000
-const BLOCKSCOUT_API = 'https://eden.blockscout.com/api'
-const factoryInterface = new Interface([BUY, SELL, CREATOR_FEE_ACCRUED, REFERRAL_ACCRUED])
-
-async function getLogsForRange(eventName: string, topic: string, fromBlock: number, toBlock: number): Promise<any[]> {
-  const response = await httpGet(`${BLOCKSCOUT_API}?module=logs&action=getLogs&fromBlock=${fromBlock}&toBlock=${toBlock}&address=${FACTORY}&topic0=${topic}`)
-  if (response.status === '0' && response.message === 'No logs found') return []
-  if (response.status !== '1' || !Array.isArray(response.result)) {
-    throw new Error(`Blockscout log query failed: ${response.message ?? 'unknown error'}`)
-  }
-
-  if (response.result.length < BLOCKSCOUT_LOG_LIMIT) {
-    return response.result.map((log: any) => {
-      const parsed = factoryInterface.parseLog({ data: log.data, topics: log.topics.filter(Boolean) })
-      if (!parsed) throw new Error(`Unable to decode ${eventName} log`)
-      return parsed.args
-    })
-  }
-
-  if (fromBlock === toBlock) throw new Error(`Blockscout returned ${BLOCKSCOUT_LOG_LIMIT} ${eventName} logs for one block`)
-  const midpoint = Math.floor((fromBlock + toBlock) / 2)
-  return [
-    ...await getLogsForRange(eventName, topic, fromBlock, midpoint),
-    ...await getLogsForRange(eventName, topic, midpoint + 1, toBlock),
-  ]
-}
-
-async function getLogs(eventName: string, fromBlock: number, toBlock: number) {
-  const event = factoryInterface.getEvent(eventName)
-  if (!event) throw new Error(`Missing ${eventName} event ABI`)
-  const ranges = []
-  for (let start = fromBlock; start <= toBlock; start += LOG_BLOCK_RANGE) {
-    ranges.push([start, Math.min(start + LOG_BLOCK_RANGE - 1, toBlock)])
-  }
-
-  const { results, errors } = await PromisePool
-    .for(ranges)
-    .withConcurrency(4)
-    .process(([start, end]) => getLogsForRange(eventName, event.topicHash, start, end))
-
-  if (errors.length) throw errors[0]
-  return results.flat()
-}
 
 const fetch = async (options: FetchOptions) => {
-  const [fromBlock, toBlock, treasury] = await Promise.all([
-    options.getStartBlock(),
-    options.getEndBlock(),
-    options.toApi.call({ target: FACTORY, abi: 'address:treasury' }),
-  ])
-  if (treasury.toLowerCase() !== ZERO_ADDRESS) {
-    throw new Error(`bot.fun treasury is no longer the zero address: ${treasury}`)
-  }
-  const buys = await getLogs('Buy', fromBlock, toBlock)
-  const sells = await getLogs('Sell', fromBlock, toBlock)
-  const creatorFees = await getLogs('CreatorFeeAccrued', fromBlock, toBlock)
-  const referralFees = await getLogs('ReferralAccrued', fromBlock, toBlock)
+  const treasury = await options.toApi.call({ target: FACTORY, abi: 'address:treasury' })
 
-  const totalFees = [...buys, ...sells].reduce<bigint>((sum, log) => sum + BigInt(log.fee), 0n)
-  const totalCreatorFees = creatorFees.reduce<bigint>((sum, log) => sum + BigInt(log.amount), 0n)
-  const totalReferralFees = referralFees.reduce<bigint>((sum, log) => sum + BigInt(log.amount), 0n)
-  const totalSupplySideRevenue = totalCreatorFees + totalReferralFees
-  const totalBurnedRevenue = totalFees - totalSupplySideRevenue
-
-  if (totalBurnedRevenue < 0n) throw new Error('Supply-side revenue exceeds bot.fun trading fees')
-
+  const dailyVolume = options.createBalances()
   const dailyFees = options.createBalances()
   const dailyUserFees = options.createBalances()
   const dailyRevenue = options.createBalances()
   const dailyHoldersRevenue = options.createBalances()
   const dailySupplySideRevenue = options.createBalances()
 
-  addTia(dailyFees, totalFees, METRIC.TRADING_FEES)
-  addTia(dailyUserFees, totalFees, METRIC.TRADING_FEES)
-  addTia(dailyRevenue, totalBurnedRevenue, BURNED_PROTOCOL_FEES)
-  addTia(dailyHoldersRevenue, totalBurnedRevenue, BURNED_PROTOCOL_FEES)
-  addTia(dailySupplySideRevenue, totalCreatorFees, METRIC.CREATOR_FEES)
-  addTia(dailySupplySideRevenue, totalReferralFees, REFERRAL_FEES)
+  let revenue = 0n
+
+  if (treasury.toLowerCase() !== ZERO_ADDRESS) {
+    throw new Error(`bot.fun treasury is no longer the zero address: ${treasury}`)
+  }
+
+  const buyLogs = await options.getLogs({ eventAbi: BUY, target: FACTORY })
+  const sellLogs = await options.getLogs({ eventAbi: SELL, target: FACTORY })
+  const creatorFeesLogs = await options.getLogs({ eventAbi: CREATOR_FEE_ACCRUED, target: FACTORY })
+  const referralFeesLogs = await options.getLogs({ eventAbi: REFERRAL_ACCRUED, target: FACTORY })
+
+  for (const log of buyLogs) {
+    revenue += BigInt(log.fee)
+    dailyVolume.addCGToken('celestia', Number(log.tiaIn) / 1e18)
+    dailyUserFees.addCGToken('celestia', Number(log.fee) / 1e18, METRIC.TRADING_FEES)
+    dailyFees.addCGToken('celestia', Number(log.fee) / 1e18, METRIC.TRADING_FEES)
+  }
+
+  for (const log of sellLogs) {
+    revenue += BigInt(log.fee)
+    dailyVolume.addCGToken('celestia', Number(log.tiaOut) / 1e18)
+    dailyUserFees.addCGToken('celestia', Number(log.fee) / 1e18, METRIC.TRADING_FEES)
+    dailyFees.addCGToken('celestia', Number(log.fee) / 1e18, METRIC.TRADING_FEES)
+  }
+
+  for (const log of creatorFeesLogs) {
+    revenue -= BigInt(log.amount)
+    dailySupplySideRevenue.addCGToken('celestia', Number(log.amount) / 1e18, METRIC.CREATOR_FEES)
+  }
+
+  for (const log of referralFeesLogs) {
+    revenue -= BigInt(log.amount)
+    dailySupplySideRevenue.addCGToken('celestia', Number(log.amount) / 1e18, REFERRAL_FEES)
+  }
+
+  if (revenue < 0n) throw new Error('Supply-side revenue exceeds bot.fun trading fees')
+
+  dailyRevenue.addCGToken('celestia', Number(revenue) / 1e18, BURNED_PROTOCOL_FEES)
+  dailyHoldersRevenue.addCGToken('celestia', Number(revenue) / 1e18, BURNED_PROTOCOL_FEES)
 
   return {
+    dailyVolume,
     dailyFees,
     dailyUserFees,
     dailyRevenue,
     dailyProtocolRevenue: 0,
     dailyHoldersRevenue,
     dailySupplySideRevenue,
-  }
-
-  function addTia(balances: ReturnType<FetchOptions['createBalances']>, amount: bigint, label: string) {
-    balances.addCGToken('celestia', Number(amount) / 1e18, label)
   }
 }
 
@@ -130,11 +95,13 @@ const breakdownMethodology = {
 
 const adapter: SimpleAdapter = {
   version: 2,
+  pullHourly: true,
   fetch,
   chains: [CHAIN.EDEN],
   start: '2026-05-01',
   breakdownMethodology,
   methodology: {
+    Volume: 'Volume of TIA traded on bot.fun bonding curves.',
     Fees: 'Trading fees paid by users on bot.fun bonding-curve buys and sells.',
     UserFees: 'Trading fees paid directly by bot.fun traders.',
     Revenue: 'Trading fees remaining after creator and referral allocations. The protocol currently sends this share to the zero address.',

--- a/fees/bot-fun.ts
+++ b/fees/bot-fun.ts
@@ -1,0 +1,147 @@
+import { PromisePool } from '@supercharge/promise-pool'
+import { Interface } from 'ethers'
+import { FetchOptions, SimpleAdapter } from '../adapters/types'
+import { CHAIN } from '../helpers/chains'
+import { METRIC } from '../helpers/metrics'
+import { httpGet } from '../utils/fetchURL'
+
+const FACTORY = '0x279dc5E05d43644C6cd2F2813F306a320e785cdD'
+
+const BUY = 'event Buy(address indexed token, address indexed buyer, uint256 tiaIn, uint256 fee, uint256 tokensOut, uint256 newVirtualTiaReserve, uint256 newVirtualTokenReserve, string message)'
+const SELL = 'event Sell(address indexed token, address indexed seller, uint256 tokensIn, uint256 fee, uint256 tiaOut, uint256 newVirtualTiaReserve, uint256 newVirtualTokenReserve, string message)'
+const CREATOR_FEE_ACCRUED = 'event CreatorFeeAccrued(address indexed token, address indexed creator, address indexed trader, uint256 amount)'
+const REFERRAL_ACCRUED = 'event ReferralAccrued(address indexed token, address indexed referrer, address indexed trader, uint256 amount)'
+
+const BURNED_PROTOCOL_FEES = 'Burned Protocol Fees'
+const REFERRAL_FEES = 'Referral Fees'
+const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000'
+const LOG_BLOCK_RANGE = 100_000
+const BLOCKSCOUT_LOG_LIMIT = 1_000
+const BLOCKSCOUT_API = 'https://eden.blockscout.com/api'
+const factoryInterface = new Interface([BUY, SELL, CREATOR_FEE_ACCRUED, REFERRAL_ACCRUED])
+
+async function getLogsForRange(eventName: string, topic: string, fromBlock: number, toBlock: number): Promise<any[]> {
+  const response = await httpGet(`${BLOCKSCOUT_API}?module=logs&action=getLogs&fromBlock=${fromBlock}&toBlock=${toBlock}&address=${FACTORY}&topic0=${topic}`)
+  if (response.status === '0' && response.message === 'No logs found') return []
+  if (response.status !== '1' || !Array.isArray(response.result)) {
+    throw new Error(`Blockscout log query failed: ${response.message ?? 'unknown error'}`)
+  }
+
+  if (response.result.length < BLOCKSCOUT_LOG_LIMIT) {
+    return response.result.map((log: any) => {
+      const parsed = factoryInterface.parseLog({ data: log.data, topics: log.topics.filter(Boolean) })
+      if (!parsed) throw new Error(`Unable to decode ${eventName} log`)
+      return parsed.args
+    })
+  }
+
+  if (fromBlock === toBlock) throw new Error(`Blockscout returned ${BLOCKSCOUT_LOG_LIMIT} ${eventName} logs for one block`)
+  const midpoint = Math.floor((fromBlock + toBlock) / 2)
+  return [
+    ...await getLogsForRange(eventName, topic, fromBlock, midpoint),
+    ...await getLogsForRange(eventName, topic, midpoint + 1, toBlock),
+  ]
+}
+
+async function getLogs(eventName: string, fromBlock: number, toBlock: number) {
+  const event = factoryInterface.getEvent(eventName)
+  if (!event) throw new Error(`Missing ${eventName} event ABI`)
+  const ranges = []
+  for (let start = fromBlock; start <= toBlock; start += LOG_BLOCK_RANGE) {
+    ranges.push([start, Math.min(start + LOG_BLOCK_RANGE - 1, toBlock)])
+  }
+
+  const { results, errors } = await PromisePool
+    .for(ranges)
+    .withConcurrency(4)
+    .process(([start, end]) => getLogsForRange(eventName, event.topicHash, start, end))
+
+  if (errors.length) throw errors[0]
+  return results.flat()
+}
+
+const fetch = async (options: FetchOptions) => {
+  const [fromBlock, toBlock, treasury] = await Promise.all([
+    options.getStartBlock(),
+    options.getEndBlock(),
+    options.toApi.call({ target: FACTORY, abi: 'address:treasury' }),
+  ])
+  if (treasury.toLowerCase() !== ZERO_ADDRESS) {
+    throw new Error(`bot.fun treasury is no longer the zero address: ${treasury}`)
+  }
+  const buys = await getLogs('Buy', fromBlock, toBlock)
+  const sells = await getLogs('Sell', fromBlock, toBlock)
+  const creatorFees = await getLogs('CreatorFeeAccrued', fromBlock, toBlock)
+  const referralFees = await getLogs('ReferralAccrued', fromBlock, toBlock)
+
+  const totalFees = [...buys, ...sells].reduce<bigint>((sum, log) => sum + BigInt(log.fee), 0n)
+  const totalCreatorFees = creatorFees.reduce<bigint>((sum, log) => sum + BigInt(log.amount), 0n)
+  const totalReferralFees = referralFees.reduce<bigint>((sum, log) => sum + BigInt(log.amount), 0n)
+  const totalSupplySideRevenue = totalCreatorFees + totalReferralFees
+  const totalBurnedRevenue = totalFees - totalSupplySideRevenue
+
+  if (totalBurnedRevenue < 0n) throw new Error('Supply-side revenue exceeds bot.fun trading fees')
+
+  const dailyFees = options.createBalances()
+  const dailyUserFees = options.createBalances()
+  const dailyRevenue = options.createBalances()
+  const dailyHoldersRevenue = options.createBalances()
+  const dailySupplySideRevenue = options.createBalances()
+
+  addTia(dailyFees, totalFees, METRIC.TRADING_FEES)
+  addTia(dailyUserFees, totalFees, METRIC.TRADING_FEES)
+  addTia(dailyRevenue, totalBurnedRevenue, BURNED_PROTOCOL_FEES)
+  addTia(dailyHoldersRevenue, totalBurnedRevenue, BURNED_PROTOCOL_FEES)
+  addTia(dailySupplySideRevenue, totalCreatorFees, METRIC.CREATOR_FEES)
+  addTia(dailySupplySideRevenue, totalReferralFees, REFERRAL_FEES)
+
+  return {
+    dailyFees,
+    dailyUserFees,
+    dailyRevenue,
+    dailyProtocolRevenue: 0,
+    dailyHoldersRevenue,
+    dailySupplySideRevenue,
+  }
+
+  function addTia(balances: ReturnType<FetchOptions['createBalances']>, amount: bigint, label: string) {
+    balances.addCGToken('celestia', Number(amount) / 1e18, label)
+  }
+}
+
+const breakdownMethodology = {
+  Fees: {
+    [METRIC.TRADING_FEES]: 'Fees paid by users when buying or selling coins on bot.fun bonding curves.',
+  },
+  UserFees: {
+    [METRIC.TRADING_FEES]: 'Fees paid directly by bot.fun traders.',
+  },
+  Revenue: {
+    [BURNED_PROTOCOL_FEES]: 'The protocol share of trading fees, transferred to the zero address and permanently burned.',
+  },
+  HoldersRevenue: {
+    [BURNED_PROTOCOL_FEES]: 'The protocol share of trading fees burned as native TIA.',
+  },
+  SupplySideRevenue: {
+    [METRIC.CREATOR_FEES]: 'Trading fees accrued to coin creators.',
+    [REFERRAL_FEES]: 'Trading fees accrued to referrers.',
+  },
+}
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  fetch,
+  chains: [CHAIN.EDEN],
+  start: '2026-05-01',
+  breakdownMethodology,
+  methodology: {
+    Fees: 'Trading fees paid by users on bot.fun bonding-curve buys and sells.',
+    UserFees: 'Trading fees paid directly by bot.fun traders.',
+    Revenue: 'Trading fees remaining after creator and referral allocations. The protocol currently sends this share to the zero address.',
+    ProtocolRevenue: 'Zero while the bot.fun treasury is configured as the zero address.',
+    HoldersRevenue: 'The protocol share of trading fees burned as native TIA.',
+    SupplySideRevenue: 'Trading fees accrued to coin creators and referrers.',
+  },
+}
+
+export default adapter

--- a/helpers/blockscoutFees.ts
+++ b/helpers/blockscoutFees.ts
@@ -150,6 +150,7 @@ export const chainConfigMap: any = {
   [CHAIN.SHIDO]: { CGToken: 'shido-2', explorer: 'https://shidoscan.net', start: '2024-04-22' },
   [CHAIN.B3]: { explorer: 'https://blockscout.b3.fun', CGToken: 'ethereum', allStatsApi: 'https://b3.calderaexplorer.xyz/stats', start: '2024-07-30' },
   [CHAIN.DEGEN]: { explorer: 'https://explorer.degen.tips', CGToken: 'degen-base', allStatsApi: 'https://explorer.degen.tips/stats-service', start: '2025-06-16' },
+  [CHAIN.EDEN]: { explorer: 'https://eden.blockscout.com', CGToken: 'celestia', allStatsApi: 'https://eden.blockscout.com/stats-service', start: '2026-01-16', burnRatio: 0 },
 }
 
 function getTimeString(timestamp: number) {

--- a/helpers/chains.ts
+++ b/helpers/chains.ts
@@ -206,6 +206,7 @@ export enum CHAIN {
   FUEL = "fuel",
   REAL = "real",
   CELESTIA = "celestia",
+  EDEN = "eden",
   MORPH = "morph",
   APECHAIN = "apechain",
   DCHAIN = "dchainmainnet",


### PR DESCRIPTION
## Eden chain fees

Eden is Celestia's native EVM chain (chain ID 714, TIA gas token). The TVL-side chain-listing dependency is satisfied by the merged DefiLlama/DefiLlama-Adapters#20141.

- Tracks daily Eden network gas fees through Blockscout, priced with CoinGecko `celestia`, with bulk backfill available from 2026-01-16.
- Keeps `burnRatio: 0` because Eden network gas fees are not burned: base and priority fees go to the sequencer fee collector.
- Uses the `eden-chain` slug because `eden` belongs to the discontinued Eden Network (MEV) adapter in `factory/deadAdapters.json`.

## bot.fun protocol fees

Adds `fees/bot-fun.ts` as a separate protocol adapter for bot.fun bonding-curve trading fees on Eden.

- `dailyFees` / `dailyUserFees`: fees emitted by bot.fun `Buy` and `Sell` events.
- `dailySupplySideRevenue`: creator and referral rewards emitted by `CreatorFeeAccrued` and `ReferralAccrued`.
- `dailyRevenue` / `dailyHoldersRevenue`: the remaining protocol share, which the factory currently sends to the zero address as burned native TIA.
- `dailyProtocolRevenue`: zero while the factory treasury remains the zero address.

The adapter derives bot.fun attribution from factory events rather than the shared zero-address balance. It also verifies the treasury is still the zero address and fails if that routing changes. Blockscout log queries are range-bounded and automatically subdivided when the API result cap is reached.

## Validation

Rerun after rebasing onto current `master` on 2026-07-20:

- `pnpm test fees eden-chain`
- `pnpm test fees bot-fun`
- `pnpm test fees bot-fun 2026-05-15`
- `pnpm test fees bot-fun 2026-06-15`
- `pnpm ts-check`

Values are USD-priced and change with activity and TIA price.
