### PR TITLE
kuru-clob: add fees, revenue and supply-side revenue

### DIFF
--- a/dexs/kuru-clob.ts
+++ b/dexs/kuru-clob.ts
@@ -26,13 +26,21 @@ interface Market {
   quoteAsset: string;
   pricePrecision: number;
   sizePrecision: number;
+  takerFeeBps: bigint;
+  makerFeeBps: bigint;
 }
+
+const BPS_MULTIPLIER = BigInt(10000);
 
 async function fetch(options: FetchOptions) {
   const dailyVolume = options.createBalances();
+  const dailyFees = options.createBalances();
+  const dailyRevenue = options.createBalances();
+  const dailySupplySideRevenue = options.createBalances();
 
   const markets: Record<string, Market> = {}
   const quoteAssetPrecisions: Record<string, bigint> = {}
+  const baseAssetPrecisions: Record<string, bigint> = {}
 
   const MarketRegisteredEvents = await options.getLogs({
     target: CONFIGS[options.chain].router,
@@ -46,6 +54,7 @@ async function fetch(options: FetchOptions) {
 
   // indexer bug, missing exactly this event log
   // tx: 0x2630ba6a69d120c14fc6c2f0125e5f4499bd5125ab8f62a499cbe36a628934f7
+  // takerFeeBps/makerFeeBps verified live via Kuru's markets API (api.kuru.io/api/v1/markets): 0/0
   if (hasMissingMarket)
     MarketRegisteredEvents.push({
       market: '0x699AbC15308156E9a3AB89Ec7387e9CfE1c86A3b',
@@ -53,6 +62,8 @@ async function fetch(options: FetchOptions) {
       quoteAsset: '0x754704Bc059F8C67012fEd69BC8A327a5aafb603',
       pricePrecision: BigInt(100000000),
       sizePrecision: BigInt(1000000),
+      takerFeeBps: BigInt(0),
+      makerFeeBps: BigInt(0),
     })
 
   for (const log of MarketRegisteredEvents) {
@@ -63,12 +74,20 @@ async function fetch(options: FetchOptions) {
       quoteAsset: formatAddress(log.quoteAsset),
       pricePrecision: Number(log.pricePrecision),
       sizePrecision: Number(log.sizePrecision),
+      takerFeeBps: BigInt(log.takerFeeBps),
+      makerFeeBps: BigInt(log.makerFeeBps),
     }
 
     if (log.quoteAsset === '0x0000000000000000000000000000000000000000') {
       quoteAssetPrecisions[formatAddress(log.quoteAsset)] = BigInt(1e18);
     } else {
       quoteAssetPrecisions[formatAddress(log.quoteAsset)] = BigInt(0);
+    }
+
+    if (log.baseAsset === '0x0000000000000000000000000000000000000000') {
+      baseAssetPrecisions[formatAddress(log.baseAsset)] = BigInt(1e18);
+    } else {
+      baseAssetPrecisions[formatAddress(log.baseAsset)] = BigInt(0);
     }
   }
 
@@ -81,6 +100,18 @@ async function fetch(options: FetchOptions) {
   for (let i = 0; i < quoteAssets.length; i++) {
     if (decimals[i]) {
       quoteAssetPrecisions[quoteAssets[i]] = BigInt(10 ** Number(decimals[i]))
+    }
+  }
+
+  const baseAssets = Object.keys(baseAssetPrecisions)
+  const baseDecimals = await options.api.multiCall({
+    abi: ABIS.decimals,
+    permitFailure: true,
+    calls: baseAssets,
+  });
+  for (let i = 0; i < baseAssets.length; i++) {
+    if (baseDecimals[i]) {
+      baseAssetPrecisions[baseAssets[i]] = BigInt(10 ** Number(baseDecimals[i]))
     }
   }
 
@@ -102,12 +133,51 @@ async function fetch(options: FetchOptions) {
         / (BigInt(market.sizePrecision) * BigInt(1e18))
 
       dailyVolume.add(market.quoteAsset, String(volumeQuote))
+
+      if (market.takerFeeBps === BigInt(0)) continue
+
+      // Trade.isBuy reflects the resting maker order's side, not the taker's. The taker fee (and its matching maker rebate) is charged in whichever
+      // asset the taker receives - base on a buy, quote on a sell.
+      const isTakerBuy = !marketTradeEvent.isBuy
+      const preFeeAmount = isTakerBuy
+        ? BigInt(marketTradeEvent.filledSize) * baseAssetPrecisions[market.baseAsset] / BigInt(market.sizePrecision)
+        : volumeQuote
+      const feeToken = isTakerBuy ? market.baseAsset : market.quoteAsset
+
+      const takerFee = preFeeAmount * market.takerFeeBps / BPS_MULTIPLIER
+      const makerRebate = preFeeAmount * market.makerFeeBps / BPS_MULTIPLIER
+
+      dailyFees.add(feeToken, String(takerFee), 'Taker Fees')
+      if (makerRebate > BigInt(0)) dailySupplySideRevenue.add(feeToken, String(makerRebate), 'Taker Fees To Makers')
+      dailyRevenue.add(feeToken, String(takerFee - makerRebate), 'Taker Fees To Protocol')
     }
   }
 
   return {
     dailyVolume,
+    dailyFees,
+    dailyRevenue,
+    dailySupplySideRevenue,
   }
+}
+
+const methodology = {
+  Volume: "Dollar value of every trade, based on the price and size it executed at.",
+  Fees: "The taker fee charged on completed trades. Each market's fee is fixed forever once it's created.",
+  Revenue: "What the protocol keeps after paying makers their rebate.",
+  SupplySideRevenue: "A rebate paid to the maker.",
+}
+
+const breakdownMethodology = {
+  Fees: {
+    'Taker Fees': "Fee charged to the taker on each trade.",
+  },
+  Revenue: {
+    'Taker Fees To Protocol': "Taker fee net of the maker rebate - the protocol's own cut.",
+  },
+  SupplySideRevenue: {
+    'Taker Fees To Makers': "Rebate paid to the maker whose order was filled, funded from the taker fee.",
+  },
 }
 
 const adapter: SimpleAdapter = {
@@ -116,6 +186,8 @@ const adapter: SimpleAdapter = {
   fetch,
   start: '2025-11-23',
   chains: [CHAIN.MONAD],
+  methodology,
+  breakdownMethodology,
 }
 
 export default adapter;


### PR DESCRIPTION
Adds **fees**, **protocol revenue**, and **supply-side revenue** to the `kuru-clob` adapter using fee parameters already decoded from `MarketRegistered`.

## Changes

- Compute per-trade taker fees from `takerFeeBps`.
- Compute maker rebates from `makerFeeBps`.
- Report:
  - **dailyFees:** total taker fees
  - **dailySupplySideRevenue:** maker rebates
  - **dailyRevenue:** protocol fee (taker fee − maker rebate)
