### PR TITLE
uniswap-v3: track 0G (Oku) volume and fees

### DIFF
--- a/dexs/uniswap-v3.ts
+++ b/dexs/uniswap-v3.ts
@@ -3,6 +3,7 @@ import { FetchOptions, FetchV2, SimpleAdapter } from "../adapters/types";
 import { addOneToken } from "../helpers/prices";
 import { queryDune } from "../helpers/dune";
 import { httpPost } from "../utils/fetchURL";
+import { getUniV3LogAdapter } from "../helpers/uniswap";
 
 // Hybrid variant of old dexs/uniswap-v3.ts.
 // Each chain is described once in chainConfig { blockchain, start, fetch }:
@@ -192,6 +193,18 @@ async function fetchFromOku(options: FetchOptions) {
   }
 }
 
+// On-chain fallback for chains that neither Dune (dex.trades) nor the Oku API
+// cover. Reads swaps from pool logs via the shared TVL-adapter pool-log cache,
+// same source the 0G uni-v3 forks (factory/uniV3.ts) use. Fees to LPs (revenue 0),
+// matching the rest of this adapter's convention.
+const fetchFromChain = getUniV3LogAdapter({
+  factory: "0xcb2436774C3e191c85056d248EF4260ce5f27A9D", // Oku's UniswapV3Factory on 0G
+  userFeesRatio: 1,
+  revenueRatio: 0,
+  protocolRevenueRatio: 0,
+  holdersRevenueRatio: 0,
+}) as FetchV2;
+
 // One entry per chain. blockchain = the source's own slug (Dune dex.trades name
 // or Oku slug). start = first uni-v3 data on that source:
 //  - Dune rows: MIN(block_time) in dex.trades
@@ -235,6 +248,9 @@ const chainConfig: Record<string, { blockchain: string; start: string; fetch: Fe
   [CHAIN.XDC]: { blockchain: 'xdc', start: '2025-04-12', fetch: fetchFromOku },
   [CHAIN.NIBIRU]: { blockchain: 'nibiru', start: '2025-05-12', fetch: fetchFromOku },
   [CHAIN.ETHERLINK]: { blockchain: 'etherlink', start: '2025-05-12', fetch: fetchFromOku },
+
+  // On-chain logs (no Dune dex.trades or Oku API coverage)
+  [CHAIN.OG]: { blockchain: '0g', start: '2025-09-24', fetch: fetchFromChain },
 }
 
 const methodology = {

--- a/dexs/uniswap-v3.ts
+++ b/dexs/uniswap-v3.ts
@@ -193,17 +193,38 @@ async function fetchFromOku(options: FetchOptions) {
   }
 }
 
-// On-chain fallback for chains that neither Dune (dex.trades) nor the Oku API
-// cover. Reads swaps from pool logs via the shared TVL-adapter pool-log cache,
-// same source the 0G uni-v3 forks (factory/uniV3.ts) use. Fees to LPs (revenue 0),
-// matching the rest of this adapter's convention.
-const fetchFromChain = getUniV3LogAdapter({
-  factory: "0xcb2436774C3e191c85056d248EF4260ce5f27A9D", // Oku's UniswapV3Factory on 0G
-  userFeesRatio: 1,
-  revenueRatio: 0,
-  protocolRevenueRatio: 0,
-  holdersRevenueRatio: 0,
-}) as FetchV2;
+const factoryConfig: Record<string, string> ={
+  [CHAIN.OG]: "0xcb2436774C3e191c85056d248EF4260ce5f27A9D",
+}
+
+async function fetchFromLogs(options: FetchOptions) {
+  const factory = factoryConfig[options.chain];
+  if (!factory) {
+    throw new Error(`uniswap-v3: factory not found for chain ${options.chain}`);
+  }
+
+  const { dailyVolume, dailyFees, dailyUserFees } = await getUniV3LogAdapter({
+    factory,
+    userFeesRatio: 1,
+    revenueRatio: 0,
+    protocolRevenueRatio: 0,
+  })(options);
+
+  const dailyHoldersRevenue = await fetchHoldersRevenue(options);
+  const feesToLps = (await dailyFees.getUSDValue()) - (await dailyHoldersRevenue.getUSDValue());
+  const dailySupplySideRevenue = options.createBalances();
+  dailySupplySideRevenue.addUSDValue(feesToLps, "LP fees");
+
+  return {
+    dailyVolume,
+    dailyFees,
+    dailyUserFees,
+    dailyRevenue: dailyHoldersRevenue,
+    dailyProtocolRevenue: 0,
+    dailyHoldersRevenue,
+    dailySupplySideRevenue,
+  };
+}
 
 // One entry per chain. blockchain = the source's own slug (Dune dex.trades name
 // or Oku slug). start = first uni-v3 data on that source:
@@ -250,7 +271,7 @@ const chainConfig: Record<string, { blockchain: string; start: string; fetch: Fe
   [CHAIN.ETHERLINK]: { blockchain: 'etherlink', start: '2025-05-12', fetch: fetchFromOku },
 
   // On-chain logs (no Dune dex.trades or Oku API coverage)
-  [CHAIN.OG]: { blockchain: '0g', start: '2025-09-24', fetch: fetchFromChain },
+  [CHAIN.OG]: { blockchain: '0g', start: '2025-09-24', fetch: fetchFromLogs },
 }
 
 const methodology = {


### PR DESCRIPTION
### Summary

Adds **0G** volume/fees to the Uniswap V3 adapter. Uniswap V3 (the Oku deployment) currently shows only TVL on 0G — this wires it into DEX volume/fees, matching the recently-added 0G forks (tradegpt/bond/jaine, #7908).

### Why an on-chain fetch (not Dune/Oku)

This adapter's two sources don't cover 0G:
- **Dune** `dex.trades` has no uniswap-v3 rows for 0G.
- **Oku API** (`omni.icarus.tools/0g/...`) returns `chain not found`.

So 0G uses `getUniV3LogAdapter` (on-chain swap logs via the shared TVL pool-log cache) — the same mechanism as the 0G uni-v3 forks in `factory/uniV3.ts`. Factory `0xcb2436774C3e191c85056d248EF4260ce5f27A9D` is Oku's UniswapV3Factory on 0G (matches the Uniswap V3 TVL adapter). Fee split follows this adapter's convention (`userFeesRatio: 1, revenueRatio: 0`).

### Testing

Verified locally against an archival 0G RPC — the 0G entry returns valid `dailyVolume` / `dailyFees` / `dailyRevenue` / `dailySupplySideRevenue` (~$16k/day volume, ~$166 fees). Repo `tsc --noEmit` passes.

⚠️ The `test-adapter` CI check will fail on `DUNE_API_KEYS not set` — that's the pre-existing Dune dependency of this adapter in forked-PR CI, unrelated to the 0G change (0G uses the on-chain path, no Dune). It runs fine with an archival 0G RPC configured, which the server env already has.

@bheluga tagging you since you merged the 0G forks (#7908) — same chain, same on-chain source.
