### PR TITLE
[add] Hyperliquid - add hyperank-perps builder configuration

### DIFF
--- a/factory/hyperliquid.ts
+++ b/factory/hyperliquid.ts
@@ -30,6 +30,16 @@ const superxConfig: BuilderConfig = {
 // factory export. The DefiLlama dimension framework picks the appropriate
 // fields (volume vs fees) based on each protocol's metadata adapter type.
 const builderConfigs: Record<string, BuilderConfig> = {
+    "hyperank-perps": {
+    addresses: ["0x860343ba897f44a9a87353d93795f417b9a22226"],
+    start: "2026-07-01",
+    methodology: {
+      Fees: "Builder code fees paid by users on Hyperliquid perpetual trades executed through hypeRank.",
+      Revenue: "Builder code fees collected by hypeRank from Hyperliquid perps trades.",
+      ProtocolRevenue: "Builder code fees collected by hypeRank from Hyperliquid perps trades.",
+    },
+    breakdownFees: true,
+  },
   "ohayo-perps": {
     addresses: ["0x46f64c854d3736f31b1650823a7fcfc592e202f1"],
     start: "2026-03-15",

--- a/factory/hyperliquid.ts
+++ b/factory/hyperliquid.ts
@@ -34,11 +34,11 @@ const builderConfigs: Record<string, BuilderConfig> = {
     addresses: ["0x860343ba897f44a9a87353d93795f417b9a22226"],
     start: "2026-07-01",
     methodology: {
+      Volume: "Total volume from users trading Hyperliquid perps through hypeRank.",
       Fees: "Builder code fees paid by users on Hyperliquid perpetual trades executed through hypeRank.",
       Revenue: "Builder code fees collected by hypeRank from Hyperliquid perps trades.",
       ProtocolRevenue: "Builder code fees collected by hypeRank from Hyperliquid perps trades.",
     },
-    breakdownFees: true,
   },
   "ohayo-perps": {
     addresses: ["0x46f64c854d3736f31b1650823a7fcfc592e202f1"],


### PR DESCRIPTION
## Summary

Adds hypeRank to the existing Hyperliquid builder configuration.

hypeRank is a Hyperliquid-focused trader discovery and copy-trading platform. Users can discover traders using performance, risk, and consistency metrics and copy selected traders with configurable risk controls.

The platform is live and currently in public beta.

## Builder details

- Name: hypeRank
- Website: https://hyperank.io
- X: https://x.com/hypeRankio
- Builder address: 0x860343ba897f44a9a87353d93795f417b9a22226
- Start date: 2026-07-01

## Current traction

- 10 initial users
- Over $67,000 in trading volume generated through the platform

## Changes

Adds `hyperank-perps` to the existing Hyperliquid `builderConfigs` configuration with the builder address, start date, and fee/revenue methodology.