### PR TITLE
[fix] gmx-sol - exclude points-farming volume from GMTrade

### DIFF
--- a/dexs/gmx-sol.ts
+++ b/dexs/gmx-sol.ts
@@ -28,15 +28,19 @@ const MAX_EVENTS = 1_000_000;
 //   positions   distinct positions the wallet touched during the day.
 //
 // Churn plus either a flat book or a wide book. Not every farmer hedges: on
-// 2026-06-01 the largest wallet on the venue ran 24.6x turnover on $28.6M with
-// imbalance 0.36, and imbalance alone let it through. Requiring a flat book OR a
-// wide book catches it without reaching the other thing that clears 20x turnover,
-// a directional scalper working one or two positions with small capital. Those
-// exist mostly in early history: on 2025-03-15 and 2026-02-15, turnover alone
-// would take 60.7% and 71.7% of the day off wallets holding 1 to 7 positions on
-// $39k to $755k. The position count is what separates the two. Anything from 8 to
-// 20 gives the same answer on every day tested, so it is not a fitted line; 6
-// starts reaching into the 2025 days, which is the floor.
+// 2026-06-01 the largest wallet on the venue ran 24.6x turnover on $28.6M across
+// 76 positions with imbalance 0.36, and the flat book test alone let it through.
+// Accepting a wide book too catches it without reaching the other thing that
+// clears 20x turnover, a directional scalper working a handful of positions with
+// small capital. Those dominate early history: on 2025-03-15 and 2026-02-15
+// turnover alone would take 60.7% and 71.7% of the day off wallets holding 1 to 7
+// positions on $3k to $755k. The 02-15 leader is the shape of it, 221x turnover
+// on $78k across a single position at imbalance 1.00, which is one directional
+// trade reopened all day.
+//
+// The position count separates the two. Anything from 8 to 20 gives the same
+// answer on every day tested, so it is not a fitted line; 6 starts reaching into
+// the 2025 days, which is the floor.
 //
 // Turnover has to be measured against total concurrent capital, not against the
 // largest single position. Running dozens of positions at once, as these do, means
@@ -177,7 +181,7 @@ const adapter: SimpleAdapter = {
   chains: [CHAIN.SOLANA],
   start: '2025-02-12',
   methodology: {
-    Volume: "Notional volume of perpetual trades from the GMX Solana subgraph, taken as the change in position size on each trade event. Volume from wallets farming the GT points programme is excluded, meaning those that turn over more than 20x their peak concurrent capital in a day while either holding a flat book or working eight or more positions. See issue #7120.",
+    Volume: "Notional volume of perpetual trades from the GMX Solana subgraph, taken as the change in position size on each trade event. Volume from wallets farming the GT points programme is excluded, meaning those that turn over 20x or more of their peak concurrent capital in a day while either holding a flat book or working eight or more positions. See issue #7120.",
   },
 };
 

--- a/dexs/gmx-sol.ts
+++ b/dexs/gmx-sol.ts
@@ -47,10 +47,21 @@ const MAX_EVENTS = 1_000_000;
 // keying off the biggest one understates their capital by about that factor and
 // sweeps in ordinary multi-market traders.
 //
-// Capital sitting in a position that is never touched during the day is not counted,
-// since the position only becomes visible when it trades. That is nil in practice:
-// every wallet this flags churns its whole book, so it carries no untouched
-// positions into the day.
+// The one thing this cannot see. A position that is never touched during the day
+// does not appear in tradeEvents at all, and the subgraph exposes no position
+// entity, so its capital is invisible. Capital carried in IS counted, because the
+// first event on a position contributes its beforeSizeInUsd, but a position that
+// sits idle all day is not. Measured capital is therefore a lower bound and
+// turnover an upper bound.
+//
+// This matters more than it looks. Inflating every wallet's peak capital to stand
+// in for idle positions, 2026-06-01 removes 55.4% at +0%, 52.7% at +10%, 32.7% at
+// +25% and 9.3% at +50%. The 06-01 leader sits at 24.6x, only 23% clear of the
+// threshold. What keeps it honest is that these wallets touch nearly everything
+// they hold: 88% of their positions on 06-01 are opened fresh that day, on 3,079
+// trades across 76 positions for the leader. A wallet churning 76 positions is
+// unlikely to be sitting on a large 77th all day. Marginal wallets near 20x have
+// no such protection, which is the main reason not to lower the threshold.
 //
 // Turnover is bounded on both sides. At 20 the quiet and historical days come
 // out identical to the adapter without this filter. Dropping it to 10 costs an

--- a/dexs/gmx-sol.ts
+++ b/dexs/gmx-sol.ts
@@ -13,64 +13,33 @@ const SCALE = 1e20;
 const PAGE = 50000;
 const MAX_EVENTS = 1_000_000;
 
-// Volume farming filter, see issue #7120.
+// Volume farming filter, see issue #7120. Measurements behind every number here
+// are in that thread.
 //
-// The wallets behind the spikes are farming the GT points programme. They churn a
-// wide book, turning over far more volume than they ever have capital at risk. On
-// 2026-05-20 this flags 17 of them holding $2.36B, the thirteen largest carry 94%
-// of it, and they look like one operation: $3.9M to $11.0M of capital each, 29 to
-// 41 positions, 20.0x to 32.8x turnover. Three numbers per wallet per day:
+// Wallets farming the GT points programme churn a wide book, turning over far more
+// volume than they ever have capital at risk. Three numbers per wallet per day:
 //
 //   turnover    volume / the largest capital the wallet ever had deployed at one
-//               time, summed across all its open positions. One open and close of
-//               the whole book is 2. Ten round trips is 20.
+//               time, summed across its open positions. One open and close of the
+//               whole book is 2. Ten round trips is 20.
 //   imbalance   |long volume - short volume| / volume. Flat books sit near 0.
 //   positions   distinct positions the wallet touched during the day.
 //
-// Churn plus either a flat book or a wide book. Not every farmer hedges: on
-// 2026-06-01 the largest wallet on the venue ran 24.6x turnover on $28.6M across
-// 76 positions with imbalance 0.36, and the flat book test alone let it through.
-// Accepting a wide book too catches it without reaching the other thing that
-// clears 20x turnover, a directional scalper working a handful of positions with
-// small capital. Those dominate early history: on 2025-03-15 and 2026-02-15
-// turnover alone would take 60.7% and 71.7% of the day off wallets holding 1 to 7
-// positions on $3k to $755k. The 02-15 leader is the shape of it, 221x turnover
-// on $78k across a single position at imbalance 1.00, which is one directional
-// trade reopened all day.
+// Flagged on churn plus either a flat book or a wide one. Both branches earn their
+// place: not every farmer hedges, and turnover on its own also catches directional
+// scalpers working one or two positions on small capital, who are most of the
+// early backfill.
 //
-// The position count separates the two. Anything from 8 to 20 gives the same
-// answer on every day tested, so it is not a fitted line; 6 starts reaching into
-// the 2025 days, which is the floor.
+// Turnover has to be measured against total concurrent capital rather than the
+// largest single position, or running dozens of positions at once understates a
+// wallet's capital by roughly that factor.
 //
-// Turnover has to be measured against total concurrent capital, not against the
-// largest single position. Running dozens of positions at once, as these do, means
-// keying off the biggest one understates their capital by about that factor and
-// sweeps in ordinary multi-market traders.
-//
-// The one thing this cannot see. A position that is never touched during the day
-// does not appear in tradeEvents at all, and the subgraph exposes no position
-// entity, so its capital is invisible. Capital carried in IS counted, because the
-// first event on a position contributes its beforeSizeInUsd, but a position that
-// sits idle all day is not. Measured capital is therefore a lower bound and
-// turnover an upper bound.
-//
-// This matters more than it looks. Inflating every wallet's peak capital to stand
-// in for idle positions, 2026-06-01 removes 55.4% at +0%, 52.7% at +10%, 32.7% at
-// +25% and 9.3% at +50%. The 06-01 leader sits at 24.6x, only 23% clear of the
-// threshold. What keeps it honest is that these wallets touch nearly everything
-// they hold: 88% of their positions on 06-01 are opened fresh that day, on 3,079
-// trades across 76 positions for the leader. A wallet churning 76 positions is
-// unlikely to be sitting on a large 77th all day. Marginal wallets near 20x have
-// no such protection, which is the main reason not to lower the threshold.
-//
-// Turnover is bounded on both sides. At 20 the quiet and historical days come
-// out identical to the adapter without this filter. Dropping it to 10 costs an
-// ordinary day real volume, 2026-07-17 goes 1.53B to 1.37B, and above 30 the
-// signal itself starts to go. Do not move it without rerunning both ends.
-//
-// Backfill runs to 2025-02-12, and the early days behave differently from the
-// 2026 spikes, so check both before touching any of these numbers.
-const MIN_TRADES = 20;
+// What this cannot see: a position that never trades during the day emits no
+// event, and the subgraph has no position entity, so its capital is invisible.
+// Capital carried in is counted, idle capital is not, which makes turnover an
+// upper bound and the flagged set sensitive to it. That is the reason not to lower
+// these. Backfill also runs to 2025-02-12 and the early days behave nothing like
+// the 2026 spikes, so measure both eras before changing any of them.
 const MIN_TURNOVER = 20;
 const MAX_IMBALANCE = 0.15;
 const MIN_POSITIONS = 8;
@@ -85,7 +54,6 @@ interface TradeEvent {
 
 interface Wallet {
   volume: number;
-  trades: number;
   longVolume: number;
   shortVolume: number;
   // position -> its size in usd right now. closing a position sets the entry to 0
@@ -116,7 +84,6 @@ const tradesQuery = gql`
 
 const newWallet = (): Wallet => ({
   volume: 0,
-  trades: 0,
   longVolume: 0,
   shortVolume: 0,
   positionSize: new Map(),
@@ -125,7 +92,7 @@ const newWallet = (): Wallet => ({
 });
 
 const isVolumeFarmer = (wallet: Wallet): boolean => {
-  if (wallet.trades < MIN_TRADES || wallet.volume === 0 || wallet.peakExposure === 0) return false;
+  if (wallet.volume === 0 || wallet.peakExposure === 0) return false;
   if (wallet.volume / wallet.peakExposure < MIN_TURNOVER) return false;
   const imbalance = Math.abs(wallet.longVolume - wallet.shortVolume) / wallet.volume;
   const positionsTouched = wallet.positionSize.size;
@@ -170,20 +137,20 @@ const fetch = async (options: FetchOptions) => {
       wallets.set(event.user, wallet);
     }
 
-    // first sighting of a position: whatever it held before this trade is already
-    // capital at risk, so count it before applying the trade
-    if (!wallet.positionSize.has(event.position)) {
-      wallet.positionSize.set(event.position, before);
+    let held = wallet.positionSize.get(event.position);
+    if (held === undefined) {
+      // first sighting: whatever the position held before this trade is already
+      // capital at risk, so count it before applying the trade
+      held = before;
       wallet.exposure += before;
       wallet.peakExposure = Math.max(wallet.peakExposure, wallet.exposure);
     }
-    wallet.exposure += after - (wallet.positionSize.get(event.position) as number);
+    wallet.exposure += after - held;
     wallet.positionSize.set(event.position, after);
     wallet.peakExposure = Math.max(wallet.peakExposure, wallet.exposure);
 
     const volume = Math.abs(after - before);
     wallet.volume += volume;
-    wallet.trades += 1;
     if (isLong) wallet.longVolume += volume;
     else wallet.shortVolume += volume;
   }

--- a/dexs/gmx-sol.ts
+++ b/dexs/gmx-sol.ts
@@ -71,8 +71,12 @@ interface Wallet {
   trades: number;
   longVolume: number;
   shortVolume: number;
-  openSize: Map<string, number>; // position -> current size in usd
-  exposure: number;              // sum of openSize
+  // position -> its size in usd right now. closing a position sets the entry to 0
+  // rather than removing it, so the key count is how many distinct positions the
+  // wallet touched over the day, which is what MIN_POSITIONS reads. do not delete
+  // closed keys here, it would quietly change the filter.
+  positionSize: Map<string, number>;
+  exposure: number; // sum of positionSize
   peakExposure: number;
 }
 
@@ -98,7 +102,7 @@ const newWallet = (): Wallet => ({
   trades: 0,
   longVolume: 0,
   shortVolume: 0,
-  openSize: new Map(),
+  positionSize: new Map(),
   exposure: 0,
   peakExposure: 0,
 });
@@ -107,7 +111,8 @@ const isVolumeFarmer = (wallet: Wallet): boolean => {
   if (wallet.trades < MIN_TRADES || wallet.volume === 0 || wallet.peakExposure === 0) return false;
   if (wallet.volume / wallet.peakExposure < MIN_TURNOVER) return false;
   const imbalance = Math.abs(wallet.longVolume - wallet.shortVolume) / wallet.volume;
-  return imbalance <= MAX_IMBALANCE || wallet.openSize.size >= MIN_POSITIONS;
+  const positionsTouched = wallet.positionSize.size;
+  return imbalance <= MAX_IMBALANCE || positionsTouched >= MIN_POSITIONS;
 };
 
 const fetch = async (options: FetchOptions) => {
@@ -140,13 +145,13 @@ const fetch = async (options: FetchOptions) => {
 
     // first sighting of a position: whatever it held before this trade is already
     // capital at risk, so count it before applying the trade
-    if (!wallet.openSize.has(event.position)) {
-      wallet.openSize.set(event.position, before);
+    if (!wallet.positionSize.has(event.position)) {
+      wallet.positionSize.set(event.position, before);
       wallet.exposure += before;
       wallet.peakExposure = Math.max(wallet.peakExposure, wallet.exposure);
     }
-    wallet.exposure += after - (wallet.openSize.get(event.position) as number);
-    wallet.openSize.set(event.position, after);
+    wallet.exposure += after - (wallet.positionSize.get(event.position) as number);
+    wallet.positionSize.set(event.position, after);
     wallet.peakExposure = Math.max(wallet.peakExposure, wallet.exposure);
 
     const volume = Math.abs(after - before);

--- a/dexs/gmx-sol.ts
+++ b/dexs/gmx-sol.ts
@@ -2,39 +2,160 @@ import request, { gql } from "graphql-request";
 import { FetchOptions, SimpleAdapter } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
 
-const fetch = async (options: FetchOptions) => {
-  const targetDate = new Date(options.startOfDay * 1000).toISOString();
+const url = "https://gmx-solana-sqd.squids.live/gmx-solana-base:prod/api/graphql";
 
-  const query = gql`
-    {
-      volumeRecordDailies(
-        where: {timestamp_lte: "${targetDate}"},
-        orderBy: timestamp_ASC 
-      ) {
-          timestamp
-          tradeVolume
-      }
-    }
-  `
+// sizes in the subgraph are scaled by 1e20
+const SCALE = 1e20;
 
-  const url = "https://gmx-solana-sqd.squids.live/gmx-solana-base:prod/api/graphql"
-  const res = await request(url, query)
+// 50k rows per request covers the busiest day so far (129k events on 2026-06-01)
+// in three requests
+const PAGE = 50000;
 
-  const dailyVolume = res.volumeRecordDailies
-    .filter((record: { timestamp: string }) => record.timestamp.split('T')[0] === targetDate.split('T')[0])
-    .reduce((acc: number, record: { tradeVolume: string }) => acc + Number(record.tradeVolume), 0)
-  if (dailyVolume === 0) throw new Error('Not found daily data!.')
+// Volume farming filter, see issue #7120.
+//
+// The wallets behind the spikes are farming the GT points programme. They hold a
+// book that is flat overall and churn it, so they turn over far more volume than
+// they ever have capital at risk. On 2026-05-20 there are 13 of them carrying 99.8%
+// of the flagged volume, and they look like one operation: $2.8M to $11.0M of
+// capital each, 15 to 26 markets open at once, 20x to 33x turnover, VIP tier 4-5,
+// and GT ranks packed into 220-998. Two numbers per wallet per day catch that:
+//
+//   turnover    volume / the largest capital the wallet ever had deployed at one
+//               time, summed across all its open positions. One open and close of
+//               the whole book is 2. Ten round trips is 20.
+//   imbalance   |long volume - short volume| / volume. Flat books sit near 0.
+//
+// Turnover has to be measured against total concurrent capital, not against the
+// largest single position. These wallets run 15 to 26 markets at once, so keying
+// off the biggest position understates their capital by about that factor and
+// sweeps in ordinary multi-market traders.
+//
+// Capital sitting in a position that is never touched during the day is not counted,
+// since the position only becomes visible when it trades. That is nil in practice:
+// every wallet this flags churns its whole book, so it carries no untouched
+// positions into the day.
+//
+// Quiet days are untouched anywhere in turnover 10-30 and imbalance 0.05-0.25, so
+// the thresholds are not load bearing on the false positive side. Above 30 the
+// signal itself starts to go, so do not raise it.
+const MIN_TRADES = 20;
+const MIN_TURNOVER = 20;
+const MAX_IMBALANCE = 0.15;
 
-  return {
-    dailyVolume: dailyVolume / (10 ** 20),
-  }
+interface TradeEvent {
+  user: string;
+  position: string;
+  flags: string;
+  beforeSizeInUsd: string;
+  afterSizeInUsd: string;
 }
+
+interface Wallet {
+  volume: number;
+  trades: number;
+  longVolume: number;
+  shortVolume: number;
+  openSize: Map<string, number>; // position -> current size in usd
+  exposure: number;              // sum of openSize
+  peakExposure: number;
+}
+
+const tradesQuery = gql`
+  query trades($from: DateTime!, $to: DateTime!, $limit: Int!, $offset: Int!) {
+    tradeEvents(
+      where: { timestamp_gte: $from, timestamp_lt: $to }
+      orderBy: id_ASC
+      limit: $limit
+      offset: $offset
+    ) {
+      user
+      position
+      flags
+      beforeSizeInUsd
+      afterSizeInUsd
+    }
+  }
+`;
+
+const newWallet = (): Wallet => ({
+  volume: 0,
+  trades: 0,
+  longVolume: 0,
+  shortVolume: 0,
+  openSize: new Map(),
+  exposure: 0,
+  peakExposure: 0,
+});
+
+const isVolumeFarmer = (wallet: Wallet): boolean => {
+  if (wallet.trades < MIN_TRADES || wallet.volume === 0 || wallet.peakExposure === 0) return false;
+  const turnover = wallet.volume / wallet.peakExposure;
+  const imbalance = Math.abs(wallet.longVolume - wallet.shortVolume) / wallet.volume;
+  return turnover >= MIN_TURNOVER && imbalance <= MAX_IMBALANCE;
+};
+
+const fetch = async (options: FetchOptions) => {
+  const from = new Date(options.startOfDay * 1000).toISOString();
+  const to = new Date(options.endTimestamp * 1000).toISOString();
+
+  const events: TradeEvent[] = [];
+  for (let offset = 0; ; offset += PAGE) {
+    const res = await request(url, tradesQuery, { from, to, limit: PAGE, offset });
+    const page: TradeEvent[] = res.tradeEvents;
+    events.push(...page);
+    if (page.length < PAGE) break;
+  }
+
+  if (!events.length) throw new Error("Not found daily data!.");
+
+  const wallets = new Map<string, Wallet>();
+  for (const event of events) {
+    const before = Number(event.beforeSizeInUsd) / SCALE;
+    const after = Number(event.afterSizeInUsd) / SCALE;
+    // low bit of flags is the side: it never changes over a position's life, and
+    // realised pnl moves with the price when it is set and against it when it is not
+    const isLong = (Number(event.flags) & 1) === 1;
+
+    let wallet = wallets.get(event.user);
+    if (!wallet) {
+      wallet = newWallet();
+      wallets.set(event.user, wallet);
+    }
+
+    // first sighting of a position: whatever it held before this trade is already
+    // capital at risk, so count it before applying the trade
+    if (!wallet.openSize.has(event.position)) {
+      wallet.openSize.set(event.position, before);
+      wallet.exposure += before;
+      wallet.peakExposure = Math.max(wallet.peakExposure, wallet.exposure);
+    }
+    wallet.exposure += after - (wallet.openSize.get(event.position) as number);
+    wallet.openSize.set(event.position, after);
+    wallet.peakExposure = Math.max(wallet.peakExposure, wallet.exposure);
+
+    const volume = Math.abs(after - before);
+    wallet.volume += volume;
+    wallet.trades += 1;
+    if (isLong) wallet.longVolume += volume;
+    else wallet.shortVolume += volume;
+  }
+
+  let dailyVolume = 0;
+  wallets.forEach((wallet) => {
+    if (!isVolumeFarmer(wallet)) dailyVolume += wallet.volume;
+  });
+
+  return { dailyVolume };
+};
 
 const adapter: SimpleAdapter = {
   fetch,
   version: 1,
   chains: [CHAIN.SOLANA],
   start: '2025-02-12',
-}
+  methodology: {
+    Volume: "Notional volume of perpetual trades from the GMX Solana subgraph, taken as the change in position size on each trade event. Volume from wallets farming the GT points programme, meaning they turn over more than 20x their peak concurrent capital while holding a flat book, is excluded. See issue #7120.",
+  },
+};
 
 export default adapter;

--- a/dexs/gmx-sol.ts
+++ b/dexs/gmx-sol.ts
@@ -34,8 +34,9 @@ const MAX_EVENTS = 1_000_000;
 // a directional scalper working one or two positions with small capital. Those
 // exist mostly in early history: on 2025-03-15 and 2026-02-15, turnover alone
 // would take 60.7% and 71.7% of the day off wallets holding 1 to 7 positions on
-// $39k to $755k. The position count is what separates the two, and 8, 10 and 15
-// all give the same answer, so it is not a fitted line.
+// $39k to $755k. The position count is what separates the two. Anything from 8 to
+// 20 gives the same answer on every day tested, so it is not a fitted line; 6
+// starts reaching into the 2025 days, which is the floor.
 //
 // Turnover has to be measured against total concurrent capital, not against the
 // largest single position. Running dozens of positions at once, as these do, means
@@ -47,9 +48,10 @@ const MAX_EVENTS = 1_000_000;
 // every wallet this flags churns its whole book, so it carries no untouched
 // positions into the day.
 //
-// Quiet days are untouched anywhere in turnover 10-30 and imbalance 0.05-0.25, so
-// the thresholds are not load bearing on the false positive side. Above 30 the
-// signal itself starts to go, so do not raise it.
+// Turnover is bounded on both sides. At 20 the quiet and historical days come
+// out identical to the adapter without this filter. Dropping it to 10 costs an
+// ordinary day real volume, 2026-07-17 goes 1.53B to 1.37B, and above 30 the
+// signal itself starts to go. Do not move it without rerunning both ends.
 //
 // Backfill runs to 2025-02-12, and the early days behave differently from the
 // 2026 spikes, so check both before touching any of these numbers.

--- a/dexs/gmx-sol.ts
+++ b/dexs/gmx-sol.ts
@@ -15,21 +15,31 @@ const MAX_EVENTS = 1_000_000;
 
 // Volume farming filter, see issue #7120.
 //
-// The wallets behind the spikes are farming the GT points programme. They hold a
-// book that is flat overall and churn it, so they turn over far more volume than
-// they ever have capital at risk. On 2026-05-20 there are 13 of them carrying 99.8%
-// of the flagged volume, and they look like one operation: $2.8M to $11.0M of
-// capital each, 15 to 26 markets open at once, 20x to 33x turnover, VIP tier 4-5,
-// and GT ranks packed into 220-998. Two numbers per wallet per day catch that:
+// The wallets behind the spikes are farming the GT points programme. They churn a
+// wide book, turning over far more volume than they ever have capital at risk. On
+// 2026-05-20 this flags 17 of them holding $2.36B, the thirteen largest carry 94%
+// of it, and they look like one operation: $3.9M to $11.0M of capital each, 29 to
+// 41 positions, 20.0x to 32.8x turnover. Three numbers per wallet per day:
 //
 //   turnover    volume / the largest capital the wallet ever had deployed at one
 //               time, summed across all its open positions. One open and close of
 //               the whole book is 2. Ten round trips is 20.
 //   imbalance   |long volume - short volume| / volume. Flat books sit near 0.
+//   positions   distinct positions the wallet touched during the day.
+//
+// Churn plus either a flat book or a wide book. Not every farmer hedges: on
+// 2026-06-01 the largest wallet on the venue ran 24.6x turnover on $28.6M with
+// imbalance 0.36, and imbalance alone let it through. Requiring a flat book OR a
+// wide book catches it without reaching the other thing that clears 20x turnover,
+// a directional scalper working one or two positions with small capital. Those
+// exist mostly in early history: on 2025-03-15 and 2026-02-15, turnover alone
+// would take 60.7% and 71.7% of the day off wallets holding 1 to 7 positions on
+// $39k to $755k. The position count is what separates the two, and 8, 10 and 15
+// all give the same answer, so it is not a fitted line.
 //
 // Turnover has to be measured against total concurrent capital, not against the
-// largest single position. These wallets run 15 to 26 markets at once, so keying
-// off the biggest position understates their capital by about that factor and
+// largest single position. Running dozens of positions at once, as these do, means
+// keying off the biggest one understates their capital by about that factor and
 // sweeps in ordinary multi-market traders.
 //
 // Capital sitting in a position that is never touched during the day is not counted,
@@ -40,9 +50,13 @@ const MAX_EVENTS = 1_000_000;
 // Quiet days are untouched anywhere in turnover 10-30 and imbalance 0.05-0.25, so
 // the thresholds are not load bearing on the false positive side. Above 30 the
 // signal itself starts to go, so do not raise it.
+//
+// Backfill runs to 2025-02-12, and the early days behave differently from the
+// 2026 spikes, so check both before touching any of these numbers.
 const MIN_TRADES = 20;
 const MIN_TURNOVER = 20;
 const MAX_IMBALANCE = 0.15;
+const MIN_POSITIONS = 8;
 
 interface TradeEvent {
   user: string;
@@ -91,9 +105,9 @@ const newWallet = (): Wallet => ({
 
 const isVolumeFarmer = (wallet: Wallet): boolean => {
   if (wallet.trades < MIN_TRADES || wallet.volume === 0 || wallet.peakExposure === 0) return false;
-  const turnover = wallet.volume / wallet.peakExposure;
+  if (wallet.volume / wallet.peakExposure < MIN_TURNOVER) return false;
   const imbalance = Math.abs(wallet.longVolume - wallet.shortVolume) / wallet.volume;
-  return turnover >= MIN_TURNOVER && imbalance <= MAX_IMBALANCE;
+  return imbalance <= MAX_IMBALANCE || wallet.openSize.size >= MIN_POSITIONS;
 };
 
 const fetch = async (options: FetchOptions) => {
@@ -156,7 +170,7 @@ const adapter: SimpleAdapter = {
   chains: [CHAIN.SOLANA],
   start: '2025-02-12',
   methodology: {
-    Volume: "Notional volume of perpetual trades from the GMX Solana subgraph, taken as the change in position size on each trade event. Volume from wallets farming the GT points programme, meaning they turn over more than 20x their peak concurrent capital while holding a flat book, is excluded. See issue #7120.",
+    Volume: "Notional volume of perpetual trades from the GMX Solana subgraph, taken as the change in position size on each trade event. Volume from wallets farming the GT points programme is excluded, meaning those that turn over more than 20x their peak concurrent capital in a day while either holding a flat book or working eight or more positions. See issue #7120.",
   },
 };
 

--- a/dexs/gmx-sol.ts
+++ b/dexs/gmx-sol.ts
@@ -8,8 +8,10 @@ const url = "https://gmx-solana-sqd.squids.live/gmx-solana-base:prod/api/graphql
 const SCALE = 1e20;
 
 // 50k rows per request covers the busiest day so far (129k events on 2026-06-01)
-// in three requests
+// in three requests. The cap is a stop so a subgraph that keeps returning full
+// pages cannot spin here forever; it is well clear of any real day.
 const PAGE = 50000;
+const MAX_EVENTS = 1_000_000;
 
 // Volume farming filter, see issue #7120.
 //
@@ -99,14 +101,14 @@ const fetch = async (options: FetchOptions) => {
   const to = new Date(options.endTimestamp * 1000).toISOString();
 
   const events: TradeEvent[] = [];
-  for (let offset = 0; ; offset += PAGE) {
+  for (let offset = 0; offset < MAX_EVENTS; offset += PAGE) {
     const res = await request(url, tradesQuery, { from, to, limit: PAGE, offset });
     const page: TradeEvent[] = res.tradeEvents;
     events.push(...page);
     if (page.length < PAGE) break;
   }
 
-  if (!events.length) throw new Error("Not found daily data!.");
+  if (!events.length) throw new Error("No trade events found for the day.");
 
   const wallets = new Map<string, Wallet>();
   for (const event of events) {

--- a/dexs/gmx-sol.ts
+++ b/dexs/gmx-sol.ts
@@ -137,14 +137,24 @@ const fetch = async (options: FetchOptions) => {
   const to = new Date(options.endTimestamp * 1000).toISOString();
 
   const events: TradeEvent[] = [];
+  let complete = false;
   for (let offset = 0; offset < MAX_EVENTS; offset += PAGE) {
     const res = await request(url, tradesQuery, { from, to, limit: PAGE, offset });
     const page: TradeEvent[] = res.tradeEvents;
     events.push(...page);
-    if (page.length < PAGE) break;
+    if (page.length < PAGE) { complete = true; break; }
   }
 
   if (!events.length) throw new Error("No trade events found for the day.");
+  // a short page is the only proof the day is fully read. running out of budget
+  // with every page full means there is more, and carrying on would report a
+  // truncated day as if it were the whole one
+  if (!complete) {
+    throw new Error(
+      `Read ${events.length} trade events without reaching the end of the day. ` +
+      `Raise MAX_EVENTS above ${MAX_EVENTS}.`
+    );
+  }
 
   const wallets = new Map<string, Wallet>();
   for (const event of events) {

--- a/dexs/gmx-sol.ts
+++ b/dexs/gmx-sol.ts
@@ -100,6 +100,9 @@ const isVolumeFarmer = (wallet: Wallet): boolean => {
 };
 
 const fetch = async (options: FetchOptions) => {
+  // startOfDay pairs with endTimestamp to tile the calendar: 86400 seconds
+  // against the half-open filter below. startTimestamp is a second earlier, so
+  // consecutive days would share their boundary and double-count a trade on it.
   const from = new Date(options.startOfDay * 1000).toISOString();
   const to = new Date(options.endTimestamp * 1000).toISOString();
 


### PR DESCRIPTION
Closes #7120.

GMTrade volume on GMX Solana includes wallets farming the GT points programme.
This excludes them.

## How it works

Three numbers per wallet per day:

| | |
|---|---|
| turnover | volume / peak concurrent capital across all open positions |
| imbalance | \|long volume - short volume\| / volume |
| positions | distinct positions touched that day |

Flagged when `turnover >= 20` and either `imbalance <= 0.15` or `positions >= 8`.

On 2026-05-20 that is 17 wallets holding $2.36B, the thirteen largest carrying 94%
of it: $3.9M to $11.0M of capital each, 29 to 41 positions, 20.0x to 32.8x
turnover. That is one operation rather than a population of traders.

The second branch exists because not every farmer hedges. On 2026-06-01 the
largest wallet on the venue ran 24.6x turnover on $28.6M across 76 positions at
imbalance 0.36, and a flat-book test alone let it through. The position count is
what keeps the wider test away from directional scalpers on one or two positions,
which is the other population that clears 20x turnover and which dominates the
early backfill.

## Effect

| trading day | before | after |
|---|---|---|
| 2025-02-15 | 548.01 k | 548.01 k |
| 2025-03-15 | 368.67 M | 368.67 M |
| 2026-02-15 | 46.56 M | 46.56 M |
| 2026-05-20 | 3.22 B | 2.89 B |
| 2026-06-01 | 3.62 B | 1.97 B |
| 2026-06-04 | 3.30 B | 2.99 B |
| 2026-07-10 | 618.75 M | 618.75 M |
| 2026-07-17 | 1.53 B | 1.53 B |
| 2026-07-18 | 90.09 M | 90.09 M |

Sampling every 14th day from `start` to now instead of days I chose: 38 days, 2
change at all, none above 60% removed, every 2025 day identical.

## Thresholds

Both are bounded on both sides rather than fitted.

Positions 8, 10, 15 and 20 give identical output on every day tested; 6 starts
reaching into 2025-03-15 (368.67 M to 348.97 M), so 8 sits just above the floor.

Turnover at 20 leaves quiet and historical days identical to the unfiltered
adapter. At 10 an ordinary day loses real volume (2026-07-17, 1.53 B to 1.37 B).
Above 30 the signal itself starts to go.

## Limitation

A position that never trades during the day emits no event, and the subgraph has
no position entity, so its capital is invisible. Capital carried in is counted,
idle capital is not, which makes measured turnover an upper bound. Inflating peak
capital to stand in for idle positions, 2026-06-01 removes 55.4% at +0%, 52.7% at
+10%, 32.7% at +25%, 9.3% at +50%, and the 06-01 leader is only 23% clear of the
threshold at 24.6x. What limits this is that flagged wallets open a median 88% of
their positions fresh in-day and the leader trades 3,079 times across 76 of them.
Wallets near 20x have no such margin, which is the reason not to lower it.

## Why not the alternatives

Fee rate does not work: `totalFees` is a bucket (price impact, borrowing,
liquidation, funding), as `fees/gmx-sol.ts` documents, so a threshold on it fits
noise.

Hold time does not work at the scale suggested in #7120. Implementing ">= 90% of
closes held under 60s" literally flags 4 wallets and 0.095% of the 2026-05-20 day,
because only 1.9% of that day's 37,003 closes were held under 60s. The variable is
pointing at something real, but the cut is orders of magnitude off.

This is not self-matched wash trading. GMX Solana is pool-based with no orderbook,
so a wallet cannot trade against itself. It is real trading against the pool that
exists to earn points, which is why the question of whether to exclude it is a
judgement call rather than an obvious bug.

## Verification

Recomputing volume from `tradeEvents` reproduces the subgraph's own
`volumeRecordDailies.tradeVolume` exactly, so with nothing flagged the adapter
returns precisely the number it returns today.
