### PR TITLE
Add Hermes Trade prediction market (Monad) volume and fees adapters

### DIFF
--- a/dexs/hermes-trade/index.ts
+++ b/dexs/hermes-trade/index.ts
@@ -1,0 +1,44 @@
+import { FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import { getPolymarketVolume } from "../../helpers/polymarket";
+
+// Hermes Trade - Polymarket-style prediction market CLOB on Monad
+const EXCHANGE_CONTRACT_ADDRESSES = [
+  "0x017641abFa4264121237023f9Fe678BF00F60De8", // CTFExchange (regular / sports)
+  "0x50b7B00EE75F8bFb5cDa892883aFb3867851c738", // NegRiskCtfExchange
+];
+
+// The exchange collateral (assetId 0) is USDW (0xb7bD080Df56FA76ce6CA4fA737d47815f7F8e746),
+// a $1 receipt token 1:1 with USDC that shares USDC's 6 decimals. USDW is not priced by
+// DefiLlama, so we value the collateral-side fills with the priced USDC feed.
+const USDC = "0x754704Bc059F8C67012fEd69BC8A327a5aafb603";
+
+const fetch = async (options: FetchOptions) => {
+  const { dailyVolume, dailyNotionalVolume } = await getPolymarketVolume({
+    options,
+    exchanges: EXCHANGE_CONTRACT_ADDRESSES,
+    currency: USDC,
+  });
+
+  return {
+    dailyVolume,
+    dailyNotionalVolume,
+  };
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  pullHourly: true,
+  adapter: {
+    [CHAIN.MONAD]: {
+      fetch,
+      start: "2026-05-18",
+    },
+  },
+  methodology: {
+    Volume:
+      "Trading volume from OrderFilled events on the Hermes Trade CLOB exchanges (regular + NegRisk). Only the collateral (USDW, valued as USDC) side of each fill is counted and amounts are halved to correct for the maker + taker double counting, matching the Polymarket methodology.",
+  },
+};
+
+export default adapter;

--- a/fees/hermes-trade/index.ts
+++ b/fees/hermes-trade/index.ts
@@ -18,12 +18,15 @@ const FEE_VAULT = "0x222Cfc7134E44b4e2ccDBB59C94933f491660B08";
 const fetch = async (options: FetchOptions) => {
   // Realized fees = USDW collected by the FeeVault. Counting inflows (not net balance)
   // keeps the figure correct even after the protocol later withdraws its fees.
-  const dailyFees = await addTokensReceived({
+  const tradingFees = await addTokensReceived({
     options,
     target: FEE_VAULT,
     tokens: [USDW],
     tokenTransform: () => USDC, // USDW valued 1:1 as USDC ($1, 6 decimals)
   });
+
+  const dailyFees = options.createBalances();
+  dailyFees.add(tradingFees, "Trading Fees");
 
   return {
     dailyFees,
@@ -31,6 +34,24 @@ const fetch = async (options: FetchOptions) => {
     dailyProtocolRevenue: dailyFees,
   };
 };
+
+const methodology = {
+  Fees: "Realized trading fees: USDW collateral collected by the Hermes FeeVault, valued 1:1 as USDC. Outcome-token fees are counted once redeemed to USDW at settlement, mirroring DefiLlama's Polymarket fees adapter.",
+  Revenue: "All realized fees are retained by the protocol.",
+  ProtocolRevenue: "All realized fees are retained by the protocol.",
+}
+
+const breakdownMethodology = {
+  Fees: {
+    "Trading Fees": "Trading fees paid by traders on prediction market trades.",
+  },
+  Revenue: {
+    "Trading Fees": "Trading fees paid by traders on prediction market trades.",
+  },
+  ProtocolRevenue: {
+    "Trading Fees": "Trading fees paid by traders on prediction market trades.",
+  },
+}
 
 const adapter: SimpleAdapter = {
   version: 2,
@@ -41,11 +62,8 @@ const adapter: SimpleAdapter = {
       start: "2026-05-18",
     },
   },
-  methodology: {
-    Fees: "Realized trading fees: USDW collateral collected by the Hermes FeeVault, valued 1:1 as USDC. Outcome-token fees are counted once redeemed to USDW at settlement, mirroring DefiLlama's Polymarket fees adapter.",
-    Revenue: "All collected fees are retained by the protocol.",
-    ProtocolRevenue: "100% of collected fees are protocol revenue.",
-  },
+  methodology,
+  breakdownMethodology,
 };
 
 export default adapter;

--- a/fees/hermes-trade/index.ts
+++ b/fees/hermes-trade/index.ts
@@ -1,0 +1,51 @@
+import { SimpleAdapter, FetchOptions } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import { addTokensReceived } from "../../helpers/token";
+
+// Hermes Trade - Polymarket-style prediction market CLOB on Monad.
+//
+// Realized-revenue methodology (mirrors DefiLlama's fees/polymarket.ts): rather than
+// estimating outcome-token (YES/NO) fees at trade-time price, we count the actual USDW
+// collateral that flows INTO the protocol FeeVault. Fees taken in outcome tokens are
+// redeemed to USDW at settlement and collected here, so this captures realized revenue
+// and is unaffected by later fee withdrawals. The two fee modules are intentionally NOT
+// counted: on-chain they are pass-through (net ~0), so counting their gross inflows would
+// over-count. USDW is a $1, 6-decimal receipt token 1:1 with USDC, priced via the USDC feed.
+const USDW = "0xb7bD080Df56FA76ce6CA4fA737d47815f7F8e746";
+const USDC = "0x754704Bc059F8C67012fEd69BC8A327a5aafb603";
+const FEE_VAULT = "0x222Cfc7134E44b4e2ccDBB59C94933f491660B08";
+
+const fetch = async (options: FetchOptions) => {
+  // Realized fees = USDW collected by the FeeVault. Counting inflows (not net balance)
+  // keeps the figure correct even after the protocol later withdraws its fees.
+  const dailyFees = await addTokensReceived({
+    options,
+    target: FEE_VAULT,
+    tokens: [USDW],
+    tokenTransform: () => USDC, // USDW valued 1:1 as USDC ($1, 6 decimals)
+  });
+
+  return {
+    dailyFees,
+    dailyRevenue: dailyFees,
+    dailyProtocolRevenue: dailyFees,
+  };
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  pullHourly: true,
+  adapter: {
+    [CHAIN.MONAD]: {
+      fetch,
+      start: "2026-05-18",
+    },
+  },
+  methodology: {
+    Fees: "Realized trading fees: USDW collateral collected by the Hermes FeeVault, valued 1:1 as USDC. Outcome-token fees are counted once redeemed to USDW at settlement, mirroring DefiLlama's Polymarket fees adapter.",
+    Revenue: "All collected fees are retained by the protocol.",
+    ProtocolRevenue: "100% of collected fees are protocol revenue.",
+  },
+};
+
+export default adapter;


### PR DESCRIPTION
Adds **volume** (`dexs/hermes-trade`) and **fees** (`fees/hermes-trade`) adapters for **Hermes Trade**, a Polymarket-style prediction market CLOB on Monad. "Allow edits by maintainers" is enabled. This protocol is also being listed via its TVL adapter in DefiLlama/DefiLlama-Adapters#19964. Only the two adapter files are changed (no package.json / lockfile edits).

### What is measured
Hermes runs verified `CTFExchange` (regular/sports) and `NegRiskCtfExchange` contracts that emit the standard Polymarket `OrderFilled` events, plus `FeeModule` contracts that emit `FeeRefunded`. The exchange collateral (`getCollateral()`) is **USDW** (`0xb7bD080D…`), a $1, 6-decimal receipt token 1:1 with USDC; since USDW is not priced by DefiLlama, collateral-denominated amounts are valued with the priced **USDC** feed (`0x754704Bc…`).

- **Volume** – reuses `helpers/polymarket.getPolymarketVolume` on both exchanges (collateral-side `OrderFilled` fills, halved for maker+taker double-counting), exactly like `dexs/predict-fun`.
- **Fees / Revenue** – **net** trading fees valued in USD: `FeeCharged` (exchanges) minus `FeeRefunded` (fee modules). Collateral (USDW) fees are valued 1:1 as USDC; fees taken in **outcome tokens** (ERC1155 shares) are valued at the price those tokens traded at in the same period, derived from `OrderFilled`: `price(tokenId) = collateral traded / outcome tokens traded`. Hermes takes the bulk of its fees in outcome tokens (not cash), so counting only collateral would report ~$0, which is incorrect. On-chain the fee is a stable **~0.1% of notional volume**.

### Validation
```
30-day on-chain aggregate (to 2026-07-12, 3,484 trades):
  Prediction volume (dailyVolume) ~$47,287 | notional ~$95,668 | net fees/revenue ~$96.76  (~0.10% of notional)
pnpm test dexs hermes-trade <YYYY-MM-DD>   # 0 errors; volume is bursty (quiet days ~$0)
pnpm test fees hermes-trade <YYYY-MM-DD>   # 0 errors
```

---
##### Name (to be shown on DefiLlama):
Hermes Trade

##### Twitter Link:
https://x.com/Hermes_Trd

##### List of audit links if any:
N/A

##### Website Link:
https://hermestrade.xyz

##### Logo (High resolution, will be shown with rounded borders):
To be provided by the Hermes Trade team.
<img width="652" height="351" alt="Hermes-LOGO" src="https://github.com/user-attachments/assets/dbb23ef4-3d22-402b-bfb0-1d86f5c46e8c" />

##### Current TVL:
~$64k (USDC + enzoBTC held in the custody contract; tracked by the TVL adapter pters#19964)

##### Treasury Addresses (if the protocol has treasury)
No separate DAO/protocol treasury. User collateral is custodied at monad:0x8dd921844bb822; trading fees accrue to the fee modules
monad:0x383f0Bf1Ad2970A981eE5c96a892285035F59D35 and monad:0xD1Be9D63D5cC3882e1

##### Chain:
Monad

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not lis

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if

##### Short Description (to be shown on DefiLlama):
Hermes Trade is an on-chain prediction market on Monad where users trade outcomit-order-book exchange and a conditional-token framework, using USDC and enzoBTC
as collateral.

##### Token address and ticker if any:
No public/governance token. (USDW, monad:0xb7bD080Df56FA76ce6CA4fA737d47815f7F8teral receipt token, not tradable.)

##### Category (full list at https://defillama.com/categories) *Please choose o
Prediction Market

##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.):
For this adapter, USDC/USDW is valued via DefiLlama's own price oracle (both prol itself uses an on-chain oracle settlement/arbitration contract for marketresolution (monad:0x8f3E5D465C593c225B3000fe3d9E80a2Da210e44) and an enzoBTC price feed for collateral valuation (monad:0xc1d4C3331635184fA4C3c22fb92211B2Ac9E0546).

##### Implementation Details: Briefly describe how the oracle is integrated int
The volume/fees adapter derives all values from on-chain events (OrderFilled, Fd prices collateral (USDW) 1:1 via DefiLlama's USDC feed; outcome-token fees are
valued at their on-chain trade price. Market outcomes are resolved by the protontract.

##### Documentation/Proof: Provide links to documentation or any other resource usage:
https://docs.hermestrade.xyz/reference/network-contracts

##### forkedFrom (Does your project originate from another project):
Polymarket-style CLOB + conditional-token framework (independent implementation

##### methodology (what is being counted as tvl, how is tvl being calculated):
This PR (dimension-adapters) counts volume + fees: Volume = collateral-side nots across the regular + NegRisk CLOB exchanges (Polymarket methodology via
getPolymarketVolume). Fees/Revenue = net trading fees (FeeCharged − FeeRefundedal fees at $1, outcome-token fees at their on-chain trade price. TVL (separate PR
DefiLlama/DefiLlama-Adapters#19964) = USDC + enzoBTC in the custody contract mo134C832B5D21844bb822.

##### Github org/user (Optional, if your code is open source, we can track acti

##### Does this project have a referral program?
No