### PR TITLE
Add DropSwap aggregator adapter

### DIFF
--- a/aggregators/dropswap/index.ts
+++ b/aggregators/dropswap/index.ts
@@ -1,0 +1,61 @@
+import fetchURL from "../../utils/fetchURL";
+import { FetchOptions, FetchResult, SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+
+const chains: Record<string, string> = {
+  [CHAIN.ARBITRUM]: 'arbitrum',
+  [CHAIN.BASE]: 'base',
+  [CHAIN.BSC]: 'bsc',
+  [CHAIN.POLYGON]: 'polygon',
+  [CHAIN.OPTIMISM]: 'optimism',
+  [CHAIN.AVAX]: 'avalanche',
+  [CHAIN.ETHEREUM]: 'ethereum',
+  [CHAIN.UNICHAIN]: 'unichain',
+  [CHAIN.HYPERLIQUID]: 'hyperevm',
+  [CHAIN.SEI]: 'sei',
+  [CHAIN.BERACHAIN]: 'berachain',
+  [CHAIN.MONAD]: 'monad',
+  [CHAIN.ROBINHOOD]: 'robinhood',
+  [CHAIN.PLASMA]: 'plasma',
+  [CHAIN.LINEA]: 'linea',
+  [CHAIN.SCROLL]: 'scroll',
+  [CHAIN.BLAST]: 'blast',
+  [CHAIN.MANTLE]: 'mantle',
+  [CHAIN.XDAI]: 'gnosis',
+  [CHAIN.SONEIUM]: 'soneium',
+};
+
+interface IVolumeByChainRecord {
+  date: string;
+  timestamp: number;
+  chains: Record<string, { volume: number; transactions: number }>;
+}
+
+const fetch = async (options: FetchOptions): Promise<FetchResult> => {
+  const data: IVolumeByChainRecord[] = await fetchURL("https://dropswap.finance/api/defillama/volume-by-chain");
+  const dateStr = new Date(options.startOfDay * 1000).toISOString().slice(0, 10);
+  const dayRecord = data.find((d) => d.date === dateStr);
+  const chainKey = chains[options.chain];
+  const chainData = dayRecord?.chains?.[chainKey];
+
+  return {
+    dailyVolume: (chainData?.volume ?? 0).toString(),
+  };
+};
+
+const adapter: SimpleAdapter = {
+  version: 1,
+  adapter: {
+    ...Object.entries(chains).reduce((acc, [key]) => {
+      return {
+        ...acc,
+        [key]: {
+          fetch,
+          start: '2026-06-11',
+        },
+      };
+    }, {}),
+  },
+};
+
+export default adapter;

--- a/aggregators/dropswap/index.ts
+++ b/aggregators/dropswap/index.ts
@@ -36,14 +36,20 @@ interface IVolumeByChainRecord {
 // https://dropswap.finance/api/defillama/volume-by-chain
 const API_URL = "https://dropswap.finance/api/defillama/volume-by-chain";
 
-const fetch = async (options: FetchOptions): Promise<FetchResult> => {
+const prefetch = async (_options: FetchOptions): Promise<any> => {
   const data: IVolumeByChainRecord[] = await fetchURL(API_URL);
+  return data;
+}
+
+const fetch = async (options: FetchOptions): Promise<FetchResult> => {
+  const data: IVolumeByChainRecord[] =  options.preFetchedResults;
   const dayRecord = data.find((d) => d.date === options.dateString);
   const chainKey = chains[options.chain];
   const chainData = dayRecord?.chains?.[chainKey];
 
   return {
-    dailyVolume: (chainData?.volume ?? 0).toString(),
+    // 0 volume chains have no entry, so it's ok to return 0
+    dailyVolume: (chainData?.volume ?? 0),
   };
 };
 
@@ -51,6 +57,7 @@ const adapter: SimpleAdapter = {
   version: 1,
   chains: Object.keys(chains),
   fetch,
+  prefetch,
   start: '2026-06-11',
   methodology: {
     Volume: "Daily swap volume is the sum of USD value of all successful swaps routed through DropSwap's backend (via LI.FI and Odos), recorded per chain in DropSwap's own database.",

--- a/aggregators/dropswap/index.ts
+++ b/aggregators/dropswap/index.ts
@@ -2,6 +2,7 @@ import fetchURL from "../../utils/fetchURL";
 import { FetchOptions, FetchResult, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 
+// Maps DefiLlama chain identifiers to DropSwap's internal chain keys (used by its API)
 const chains: Record<string, string> = {
   [CHAIN.ARBITRUM]: 'arbitrum',
   [CHAIN.BASE]: 'base',
@@ -31,10 +32,13 @@ interface IVolumeByChainRecord {
   chains: Record<string, { volume: number; transactions: number }>;
 }
 
+// DropSwap's own public API, aggregating swap volume from its backend database, grouped by day and chain
+// https://dropswap.finance/api/defillama/volume-by-chain
+const API_URL = "https://dropswap.finance/api/defillama/volume-by-chain";
+
 const fetch = async (options: FetchOptions): Promise<FetchResult> => {
-  const data: IVolumeByChainRecord[] = await fetchURL("https://dropswap.finance/api/defillama/volume-by-chain");
-  const dateStr = new Date(options.startOfDay * 1000).toISOString().slice(0, 10);
-  const dayRecord = data.find((d) => d.date === dateStr);
+  const data: IVolumeByChainRecord[] = await fetchURL(API_URL);
+  const dayRecord = data.find((d) => d.date === options.dateString);
   const chainKey = chains[options.chain];
   const chainData = dayRecord?.chains?.[chainKey];
 
@@ -45,16 +49,11 @@ const fetch = async (options: FetchOptions): Promise<FetchResult> => {
 
 const adapter: SimpleAdapter = {
   version: 1,
-  adapter: {
-    ...Object.entries(chains).reduce((acc, [key]) => {
-      return {
-        ...acc,
-        [key]: {
-          fetch,
-          start: '2026-06-11',
-        },
-      };
-    }, {}),
+  chains: Object.keys(chains),
+  fetch,
+  start: '2026-06-11',
+  methodology: {
+    Volume: "Daily swap volume is the sum of USD value of all successful swaps routed through DropSwap's backend (via LI.FI and Odos), recorded per chain in DropSwap's own database.",
   },
 };
 


### PR DESCRIPTION
Adds an Aggregators adapter for DropSwap (https://dropswap.finance), a multi-chain
DEX aggregator routing swaps across 20 chains via LI.FI and Odos.

Volume data is served per-chain from our own API:
https://dropswap.finance/api/defillama/volume-by-chain

Protocol metadata:
https://dropswap.finance/api/defillama/protocol

Tested locally with `npm test aggregators dropswap` — adapter correctly returns
per-chain daily volume.
