### PR TITLE
Sentry: bump subgraph endpoint to 1.2.0

### DIFF
--- a/fees/sentry/index.ts
+++ b/fees/sentry/index.ts
@@ -15,7 +15,7 @@ import ADDRESSES from "../../helpers/coreAssets.json";
 // 2. LP fees on Sentry-launched pools: every launch locks its
 //    liquidity in a Uniswap V3 1% pool; the factory splits collected
 //    LP fees 70% to the token creator / 30% to the Sentry treasury.
-const ENDPOINT = "https://api.goldsky.com/api/public/project_cmm7vh5xwsa8m01qmdr7w7u62/subgraphs/sentry-robinhood/1.1.0/gn";
+const ENDPOINT = "https://api.goldsky.com/api/public/project_cmm7vh5xwsa8m01qmdr7w7u62/subgraphs/sentry-robinhood/1.2.0/gn";
 
 const WETH = ADDRESSES.robinhood.WETH;
 const CREATOR_LP_SHARE = 0.7;


### PR DESCRIPTION
The Sentry Goldsky subgraph was redeployed as `sentry-robinhood/1.2.0` to index a newly deployed Uniswap v4 native-pool fee router (the previous v4 router could only trade WETH-keyed pools). The `1.1.0` deployment it replaces is no longer served, so the adapter needs the endpoint bump. Schema and entities are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)