### PR TITLE
Add SLVR fees/volume/revenue adapter (Robinhood Chain)

### DIFF
--- a/fees/slvr/index.ts
+++ b/fees/slvr/index.ts
@@ -6,34 +6,19 @@ import { METRIC } from "../../helpers/metrics";
 // Native wager token is ETH. Each resolved round takes a flat 10% rake on wagers: 8% is distributed
 // to veNFT stakers (SlvrVoteEscrowStaking) and 2% goes to the jackpot (paid back out to players).
 // Winners keep the other 90%.
-const LOTTERY = "0x284Eb4016305Fa7FbC162Fb68F27227271001c7f"; // SlvrGridLottery
 const VE_STAKING = "0xaF68598eBd245DC3cB92FF16E9Ba1814DD137200"; // SlvrVoteEscrowStaking
 
-const BET_PLACED = "event BetPlaced(uint256 indexed roundId, address indexed beneficiary, uint256 total, uint8[] squares)";
 const REWARD_DISTRIBUTED = "event RewardDistributed(uint256 amount)";
 
-const WAGERS = "Wagers"; // ETH wagered by players
 const JACKPOT = "Jackpot"; // 2% of wagers routed to the jackpot pool
 
 const fetch = async (options: FetchOptions) => {
-  const [bets, rewards] = await Promise.all([
-    options.getLogs({ target: LOTTERY, eventAbi: BET_PLACED }),
-    options.getLogs({ target: VE_STAKING, eventAbi: REWARD_DISTRIBUTED }),
-  ]);
-
-  // Volume = total ETH wagered across all bets this period. Jackpot = 2% of each wager, routed to
-  // the jackpot pool and paid back out to winning players (supply-side).
-  const dailyVolume = options.createBalances();
-  const jackpot = options.createBalances();
-  bets.forEach((log: any) => {
-    dailyVolume.addGasToken(log.total, WAGERS);
-    jackpot.addGasToken((BigInt(log.total) * 2n) / 100n, JACKPOT);
-  });
-
+  const rewards = await options.getLogs({ target: VE_STAKING, eventAbi: REWARD_DISTRIBUTED })
   // Revenue = all staker rewards, taken straight from the ETH actually distributed to veNFT stakers
   // (RewardDistributed events on SlvrVoteEscrowStaking) — the real 8% cut of every round.
   const stakerRewards = options.createBalances();
   rewards.forEach((log: any) => stakerRewards.addGasToken(log.amount, METRIC.STAKING_REWARDS));
+  const jackpot = stakerRewards.clone(0.25, JACKPOT);
 
   // Fees = the full 10% rake = staker rewards (8%) + jackpot (2%).
   const dailyFees = options.createBalances();
@@ -41,7 +26,6 @@ const fetch = async (options: FetchOptions) => {
   dailyFees.addBalances(jackpot);
 
   return {
-    dailyVolume,
     dailyFees,
     dailyRevenue: stakerRewards,
     dailyHoldersRevenue: stakerRewards,
@@ -50,7 +34,6 @@ const fetch = async (options: FetchOptions) => {
 };
 
 const methodology = {
-  Volume: "Total ETH wagered across all lottery bets (BetPlaced events).",
   Fees: "The 10% rake taken from every round's wagers: 8% distributed to veNFT stakers plus 2% routed to the jackpot.",
   Revenue: "All staker rewards — the ETH distributed to veNFT stakers (RewardDistributed events on SlvrVoteEscrowStaking).",
   HoldersRevenue: "All staker rewards — the ETH distributed to veNFT stakers.",
@@ -58,9 +41,6 @@ const methodology = {
 };
 
 const breakdownMethodology = {
-  Volume: {
-    [WAGERS]: "ETH wagered across the grid each round (BetPlaced events).",
-  },
   Fees: {
     [METRIC.STAKING_REWARDS]: "8% of wagers distributed to veNFT stakers (RewardDistributed events).",
     [JACKPOT]: "2% of wagers routed to the jackpot pool.",

--- a/fees/slvr/index.ts
+++ b/fees/slvr/index.ts
@@ -1,0 +1,89 @@
+import { CHAIN } from "../../helpers/chains";
+import { FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { METRIC } from "../../helpers/metrics";
+
+// SLVR — 1-minute on-chain grid lottery on Robinhood Chain (Arbitrum Orbit L2, chainId 4663).
+// Native wager token is ETH. Each resolved round takes a flat 10% rake on wagers: 8% is distributed
+// to veNFT stakers (SlvrVoteEscrowStaking) and 2% goes to the jackpot (paid back out to players).
+// Winners keep the other 90%.
+const LOTTERY = "0x284Eb4016305Fa7FbC162Fb68F27227271001c7f"; // SlvrGridLottery
+const VE_STAKING = "0xaF68598eBd245DC3cB92FF16E9Ba1814DD137200"; // SlvrVoteEscrowStaking
+
+const BET_PLACED = "event BetPlaced(uint256 indexed roundId, address indexed beneficiary, uint256 total, uint8[] squares)";
+const REWARD_DISTRIBUTED = "event RewardDistributed(uint256 amount)";
+
+const WAGERS = "Wagers"; // ETH wagered by players
+const JACKPOT = "Jackpot"; // 2% of wagers routed to the jackpot pool
+
+const fetch = async (options: FetchOptions) => {
+  const [bets, rewards] = await Promise.all([
+    options.getLogs({ target: LOTTERY, eventAbi: BET_PLACED }),
+    options.getLogs({ target: VE_STAKING, eventAbi: REWARD_DISTRIBUTED }),
+  ]);
+
+  // Volume = total ETH wagered across all bets this period. Jackpot = 2% of each wager, routed to
+  // the jackpot pool and paid back out to winning players (supply-side).
+  const dailyVolume = options.createBalances();
+  const jackpot = options.createBalances();
+  bets.forEach((log: any) => {
+    dailyVolume.addGasToken(log.total, WAGERS);
+    jackpot.addGasToken((BigInt(log.total) * 2n) / 100n, JACKPOT);
+  });
+
+  // Revenue = all staker rewards, taken straight from the ETH actually distributed to veNFT stakers
+  // (RewardDistributed events on SlvrVoteEscrowStaking) — the real 8% cut of every round.
+  const stakerRewards = options.createBalances();
+  rewards.forEach((log: any) => stakerRewards.addGasToken(log.amount, METRIC.STAKING_REWARDS));
+
+  // Fees = the full 10% rake = staker rewards (8%) + jackpot (2%).
+  const dailyFees = options.createBalances();
+  dailyFees.addBalances(stakerRewards);
+  dailyFees.addBalances(jackpot);
+
+  return {
+    dailyVolume,
+    dailyFees,
+    dailyRevenue: stakerRewards,
+    dailyHoldersRevenue: stakerRewards,
+    dailySupplySideRevenue: jackpot,
+  };
+};
+
+const methodology = {
+  Volume: "Total ETH wagered across all lottery bets (BetPlaced events).",
+  Fees: "The 10% rake taken from every round's wagers: 8% distributed to veNFT stakers plus 2% routed to the jackpot.",
+  Revenue: "All staker rewards — the ETH distributed to veNFT stakers (RewardDistributed events on SlvrVoteEscrowStaking).",
+  HoldersRevenue: "All staker rewards — the ETH distributed to veNFT stakers.",
+  SupplySideRevenue: "The 2% of wagers routed to the jackpot pool, which is paid back out to winning players.",
+};
+
+const breakdownMethodology = {
+  Volume: {
+    [WAGERS]: "ETH wagered across the grid each round (BetPlaced events).",
+  },
+  Fees: {
+    [METRIC.STAKING_REWARDS]: "8% of wagers distributed to veNFT stakers (RewardDistributed events).",
+    [JACKPOT]: "2% of wagers routed to the jackpot pool.",
+  },
+  Revenue: {
+    [METRIC.STAKING_REWARDS]: "8% of wagers distributed to veNFT stakers.",
+  },
+  HoldersRevenue: {
+    [METRIC.STAKING_REWARDS]: "8% of wagers distributed to veNFT stakers.",
+  },
+  SupplySideRevenue: {
+    [JACKPOT]: "2% of wagers routed to the jackpot pool, paid back out to winning players.",
+  },
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  pullHourly: true,
+  fetch,
+  chains: [CHAIN.ROBINHOOD],
+  start: "2026-07-09",
+  methodology,
+  breakdownMethodology,
+};
+
+export default adapter;

--- a/helpers/env.ts
+++ b/helpers/env.ts
@@ -26,7 +26,7 @@ const DEFAULTS: any = {
   XRPL_EVM_RPC: 'https://explorer.xrplevm.org/api/eth-rpc',
   MANTLE_ARCHIVAL_RPC: 'https://explorer.mantle.xyz/api/eth-rpc',
   GATELAYER_RPC: 'https://www.gatescan.org/gatelayer/api/eth-rpc',
-  ROBINHOOD_RPC: 'https://robinhoodchain.blockscout.com/api/eth-rpc',
+  ROBINHOOD_RPC: 'https://rpc.mainnet.chain.robinhood.com',
   SHIDO_RPC: 'https://shidoscan.net/api/eth-rpc',
   SAGA_RPC: "https://sagaevm.jsonrpc.sagarpc.io",
   SAGA_WHITELISTED_RPC: 'https://sagaevm-archive.jsonrpc.sagarpc.io',

--- a/helpers/env.ts
+++ b/helpers/env.ts
@@ -26,7 +26,7 @@ const DEFAULTS: any = {
   XRPL_EVM_RPC: 'https://explorer.xrplevm.org/api/eth-rpc',
   MANTLE_ARCHIVAL_RPC: 'https://explorer.mantle.xyz/api/eth-rpc',
   GATELAYER_RPC: 'https://www.gatescan.org/gatelayer/api/eth-rpc',
-  ROBINHOOD_RPC: 'https://rpc.mainnet.chain.robinhood.com',
+  ROBINHOOD_RPC: 'https://robinhoodchain.blockscout.com/api/eth-rpc',
   SHIDO_RPC: 'https://shidoscan.net/api/eth-rpc',
   SAGA_RPC: "https://sagaevm.jsonrpc.sagarpc.io",
   SAGA_WHITELISTED_RPC: 'https://sagaevm-archive.jsonrpc.sagarpc.io',


### PR DESCRIPTION
Adds a fees/volume/revenue adapter for **SLVR**, a 1-minute on-chain grid lottery on Robinhood Chain (chainId 4663). New folder `fees/slvr/`.

- **Volume**: ETH wagered across the grid (`BetPlaced` events on SlvrGridLottery).
- **Fees**: the flat 10% rake on wagers (8% to veNFT stakers + 2% to the jackpot).
- **Revenue / Holders revenue**: all staker rewards — the ETH actually distributed to veNFT stakers, sourced directly from `RewardDistributed` events on SlvrVoteEscrowStaking (~70 ETH cumulative).
- **Supply-side revenue**: the 2% jackpot, paid back out to winning players.

v2 adapter, start 2026-07-09. Tested with `npm run test fees slvr` against the live chain.

---
Name (to be shown on DefiLlama):
SLVR

Twitter Link:
https://x.com/S_L_V_R_FUN

List of audit links if any:
None (no third-party audit yet)

Website Link:
https://slvr.fun/

Logo (High resolution, will be shown with rounded borders):
https://slvr.fun/SLVR_TOKEN_SYMBOL.png (512x512)

Current TVL:
about $73k - native ETH locked in the game contracts (~$42.6k) plus SLVR held on behalf of users, priced from the SLVR/WETH pair. Staking ~$18k, pool2 ~$1.5k.

Treasury Addresses (if the protocol has treasury):
Chain:
Robinhood Chain

Coingecko ID (leave empty if not listed):
Coinmarketcap ID (leave empty if not listed):
Short Description (to be shown on DefiLlama):
A 1-minute on-chain grid lottery on Robinhood Chain. Players wager ETH on a 5x5 grid; each round a winning square is drawn with verifiable drand randomness, paying ETH prizes, an accumulating jackpot, and SLVR emissions. SLVR can be vote-escrow locked for a share of protocol fees, and LP-staked for ETH rewards.

Token address and ticker if any:
SLVR — 0x791229E3EbD6CFdC3D8157f48722684173C29aD9 (Robinhood Chain)

Category (choose one):
Gamified Mining

Oracle Provider(s):
drand (verifiable randomness beacon). No price oracle is used.

Implementation Details:
Round outcomes use the drand evmnet beacon, verified on-chain (threshold BLS on BN254 via the alt-bn128 pairing precompile) by the DrandRandomnessProvider contract (0x1F3B0992FaBCF77d4df7Baa416b9185e464d58f3). requestResolve pins a specific future drand round derived from the round's end time, so no bettor can know the outcome while they can still act; resolution is permissionless.

Documentation/Proof:
Provider contract on Blockscout: https://robinhoodchain.blockscout.com/address/0x1F3B0992FaBCF77d4df7Baa416b9185e464d58f3 · drand: https://drand.love/

forkedFrom:
No (original protocol)

methodology (what is being counted as tvl, how is tvl calculated):
TVL sums the native ETH and SLVR held by the SLVR game contracts on behalf of users: live round pots and carry pools plus unclaimed winner emissions (SlvrGridLottery), the accumulating jackpot (SlvrJackpot), pending veNFT staker rewards (SlvrVoteEscrowStaking), auto-commit user deposits (SlvrAutoCommit), locked winnings (SlvrClaimLocker) and undistributed growth-fund revenue (SlvrGrowthFund). Staking counts SLVR locked into withdrawable vote-escrow NFTs; permanently-locked SLVR is burned (removed from supply) and excluded. Pool2 counts SLVR/WETH LP staked in SlvrLiquidityStaking. SLVR has no external price feed and is priced from the SLVR/WETH pair reserves against WETH.

Github org/user (optional):
(source repo is private)

Does this project have a referral program?
No