### PR TITLE
truemarkets: track Launchpad protocol fees

### DIFF
--- a/dexs/truemarkets.ts
+++ b/dexs/truemarkets.ts
@@ -1,11 +1,14 @@
 import { FetchOptions, FetchResult, SimpleAdapter } from '../adapters/types'
 import { CHAIN } from '../helpers/chains'
 import ADDRESSES from '../helpers/coreAssets.json'
+import { addTokensReceived } from '../helpers/token'
 import { filterPools2 } from '../helpers/uniswap'
 
 // TrueMarkets contract addresses on Base: https://github.com/truemarketsorg/true-contracts/blob/main/network_config.json
 const TRUTH_MARKET_MANAGER = '0x61A98Bef11867c69489B91f340fE545eEfc695d7'
 const FEE_COLLECTOR = '0x39339E149c2D916aa899Bf73D2Debb15F4755d9D'
+const LAUNCHPAD = '0xeD3ebc2e17a0CC20D22Ff7b7d13488F187fD1af6'
+const LAUNCHPAD_FEE_RECEIVER = '0x3F168219dadf4460dC6Ad93eaa3641340C1330D6'
 const UNISWAP_V4_POOL_MANAGER = '0x498581fF718922c3f8e6A244956aF099B2652b2b'
 const UNISWAP_V4_POSITION_MANAGER = '0x7c5f5a4bbd8fd63184577525326123b519429bdc'
 const TYD_TOKEN = '0xb13CF163d916917d9cD6E836905cA5f12a1dEF4B'.toLowerCase()
@@ -38,6 +41,17 @@ async function fetch(options: FetchOptions): Promise<FetchResult> {
   const feeTrackedLogs = await options.getLogs({
     target: FEE_COLLECTOR,
     eventAbi: ABI.PoolFeeTracked,
+  })
+
+  // Launchpad protocol fees: charged on proposal graduation (launch) and on
+  // Live-phase withdrawals, paid in TYD from the Launchpad to the fee receiver
+  await addTokensReceived({
+    options,
+    targets: [LAUNCHPAD_FEE_RECEIVER],
+    fromAddressFilter: LAUNCHPAD,
+    tokens: [TYD_TOKEN],
+    balances: dailyFees,
+    tokenTransform: (token: string) => (token.toLowerCase() === TYD_TOKEN ? USDC_TOKEN : token),
   })
 
   const v4PoolIdsFromFees = [...new Set(feeTrackedLogs.map((log: any) => log.poolId as string))]
@@ -167,7 +181,7 @@ async function fetch(options: FetchOptions): Promise<FetchResult> {
 const methodology = {
   Volume:
     'Volume is calculated from Swap events on TrueMarkets prediction market pools. V1 markets use Uniswap V3 pools (USDC pairs), V2 markets use Uniswap V4 pools (TYD pairs). Only the stablecoin side of swaps is counted.',
-  Fees: 'Fees are tracked via PoolFeeTracked events from the FeeCollector contract (V4 pools only).',
+  Fees: 'Trading fees are tracked via PoolFeeTracked events from the FeeCollector contract (V4 pools only). Launchpad protocol fees (charged on proposal graduation and Live-phase withdrawals) are tracked via TYD transfers from the Launchpad to the fee receiver.',
   Revenue: 'All collected fees are considered protocol revenue.',
   ProtocolRevenue: 'All collected fees are considered protocol revenue.',
 }

--- a/dexs/truemarkets.ts
+++ b/dexs/truemarkets.ts
@@ -37,6 +37,7 @@ const getPoolKey = (poolId: string) => poolId.slice(0, 52)
 async function fetch(options: FetchOptions): Promise<FetchResult> {
   const dailyVolume = options.createBalances()
   const dailyFees = options.createBalances()
+  const launchpadFees = options.createBalances()
 
   const feeTrackedLogs = await options.getLogs({
     target: FEE_COLLECTOR,
@@ -50,15 +51,17 @@ async function fetch(options: FetchOptions): Promise<FetchResult> {
     targets: [LAUNCHPAD_FEE_RECEIVER],
     fromAddressFilter: LAUNCHPAD,
     tokens: [TYD_TOKEN],
-    balances: dailyFees,
+    balances: launchpadFees,
     tokenTransform: (token: string) => (token.toLowerCase() === TYD_TOKEN ? USDC_TOKEN : token),
   })
+
+  dailyFees.add(launchpadFees, "Launchpad Fees")
 
   const v4PoolIdsFromFees = [...new Set(feeTrackedLogs.map((log: any) => log.poolId as string))]
 
   feeTrackedLogs.forEach((log: any) => {
     const currency = log.currency.toLowerCase()
-    dailyFees.add(currency === TYD_TOKEN ? USDC_TOKEN : log.currency, log.amount)
+    dailyFees.add(currency === TYD_TOKEN ? USDC_TOKEN : log.currency, log.amount, "Trading Fees")
   })
 
   if (v4PoolIdsFromFees.length > 0) {
@@ -182,8 +185,23 @@ const methodology = {
   Volume:
     'Volume is calculated from Swap events on TrueMarkets prediction market pools. V1 markets use Uniswap V3 pools (USDC pairs), V2 markets use Uniswap V4 pools (TYD pairs). Only the stablecoin side of swaps is counted.',
   Fees: 'Trading fees are tracked via PoolFeeTracked events from the FeeCollector contract (V4 pools only). Launchpad protocol fees (charged on proposal graduation and Live-phase withdrawals) are tracked via TYD transfers from the Launchpad to the fee receiver.',
-  Revenue: 'All collected fees are considered protocol revenue.',
-  ProtocolRevenue: 'All collected fees are considered protocol revenue.',
+  Revenue: 'All the trading fees (v4 pools only) and launchpad fees are considered revenue.',
+  ProtocolRevenue: 'All the trading fees (v4 pools only) and launchpad fees are considered protocol revenue.',
+}
+
+const breakdownMethodology = {
+  Fees: {
+    "Trading Fees": "Trading fees are tracked via PoolFeeTracked events from the FeeCollector contract (V4 pools only).",
+    "Launchpad Fees": "Launchpad protocol fees (charged on proposal graduation and Live-phase withdrawals) are tracked via TYD transfers from the Launchpad to the fee receiver.",
+  },
+  Revenue: {
+    "Trading Fees": "Trading fees are tracked via PoolFeeTracked events from the FeeCollector contract (V4 pools only).",
+    "Launchpad Fees": "Launchpad protocol fees (charged on proposal graduation and Live-phase withdrawals) are tracked via TYD transfers from the Launchpad to the fee receiver.",
+  },
+  ProtocolRevenue: {
+    "Trading Fees": "Trading fees are tracked via PoolFeeTracked events from the FeeCollector contract (V4 pools only).",
+    "Launchpad Fees": "Launchpad protocol fees (charged on proposal graduation and Live-phase withdrawals) are tracked via TYD transfers from the Launchpad to the fee receiver.",
+  },
 }
 
 const adapter: SimpleAdapter = {
@@ -196,6 +214,7 @@ const adapter: SimpleAdapter = {
     },
   },
   methodology,
+  breakdownMethodology,
 }
 
 export default adapter


### PR DESCRIPTION
## Description

Adds TrueMarkets (Trueo) **Launchpad protocol fees** to the existing `dexs/truemarkets.ts` adapter's `dailyFees` (and therefore `dailyRevenue` / `dailyProtocolRevenue`, which mirror it).

## Background

TrueMarkets (rebranded as **Trueo**, trueo.com) runs a Launchpad on Base ([`0xeD3e...1af6`](https://basescan.org/address/0xeD3ebc2e17a0CC20D22Ff7b7d13488F187fD1af6)) where users deposit into prediction market proposals. The Launchpad charges a protocol fee (currently 5%, `protocolFee()` = 500/10000) in two cases:

- when a proposal **graduates** (launches into a live market), on total deposits
- on **Live-phase withdrawals**

Both are paid in TYD from the Launchpad contract to the fee receiver ([`0x3F16...30D6`](https://basescan.org/address/0x3F168219dadf4460dC6Ad93eaa3641340C1330D6)).

Since the contract emits no dedicated fee event, fees are tracked via TYD transfers from the Launchpad to the fee receiver using the `addTokensReceived` helper.

Since deployment on 2026-06-23 the Launchpad has had 132 proposal graduations, paying ~1,390 TYD in protocol fees to date.

Contract source: https://github.com/truemarketsorg/true-contracts (`src/Launchpad.sol`, fee logic in `_distribute` and `withdraw`)

## Test output

```
npm run test dexs truemarkets

BASE 👇
End timestamp: 1784005199 (2026-07-14T04:59:59.000Z)
Daily volume: 673.30
Daily fees: 20.45      <- 20.00 launchpad fees + 0.45 swap fees
Daily revenue: 20.45
Daily protocol revenue: 20.45
```

Historical backfill check (2026-06-30): daily fees 328.00, matching on-chain Launchpad fee transfers for that day. Methodology text updated accordingly.