### PR TITLE
Add Hoodit (DLMM DEX on Robinhood Chain) volume + fees

### DIFF
--- a/factory/joeLiquidityBook.ts
+++ b/factory/joeLiquidityBook.ts
@@ -15,6 +15,7 @@
  *   - traderjoe-v2 (dexs only)
  *   - joe-v2.1 (dexs + fees)
  *   - merchant-moe-liquidity-book (dexs only)
+ *   - hoodit (dexs + fees)
  *   - hyperbrick (dexs only)
  */
 
@@ -199,6 +200,31 @@ const configs: Record<string, JoeLBProtocolConfig> = {
       Revenue: 'Share of amount of swap fees.',
       ProtocolRevenue: 'No protocol fees.',
       HoldersRevenue: 'All revenue distributed to MOE stakers.',
+    },
+  },
+
+  "hoodit": {
+    exportConfig: {
+      [CHAIN.ROBINHOOD]: {
+        factories: [
+          {
+            factory: '0x22602d966DeFd638ee94E97A92e2Eb0934c3fE1B',
+            version: 2.2 as any,
+            fromBlock: 7297329,
+          },
+        ],
+        start: "2026-07-12",
+      },
+    },
+    feesConfig: {
+      protocolRevenueFromRevenue: 1, // protocol share accrues to the protocol treasury
+    },
+    methodology: {
+      Fees: 'Total swap fees paid by users, typically 0.1% up to ~8% of swap amount depending on pool bin step and volatility.',
+      UserFees: 'Total swap fees paid by users, typically 0.1% up to ~8% of swap amount depending on pool bin step and volatility.',
+      Revenue: 'Protocol share (25%) of swap fees.',
+      ProtocolRevenue: 'Protocol share (25%) of swap fees, collected by the protocol treasury.',
+      SupplySideRevenue: 'Share of swap fees distributed to liquidity providers (75%).',
     },
   },
 


### PR DESCRIPTION
Adds volume + fees for Hoodit, a Liquidity Book (Trader Joe V2.2) DLMM DEX on Robinhood Chain.

- Registered `hoodit` in `factory/joeLiquidityBook.ts` — factory `0x22602d966DeFd638ee94E97A92e2Eb0934c3fE1B`, chain `robinhood`, LB v2.2.
- Protocol takes a 25% share of swap fees (`protocolRevenueFromRevenue: 1`), matching the on-chain preset.

TVL adapter already merged: DefiLlama/DefiLlama-Adapters#19999 (protocol id 8203, https://defillama.com/protocol/hoodit).

Test: `npm run test dexs hoodit` → ~$13k daily volume, fees, and revenue = 25% of fees.