### PR TITLE
metric: replace with onchain logs

### DIFF
--- a/dexs/metric/index.ts
+++ b/dexs/metric/index.ts
@@ -1,85 +1,74 @@
-import * as sdk from "@defillama/sdk";
 import { FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 import { addOneToken } from "../../helpers/prices";
 
-const chainConfig: Record<string, { start: string }> = {
-    [CHAIN.ETHEREUM]: { start: "2026-02-23" },
-    [CHAIN.BASE]: { start: "2026-04-05" },
-    [CHAIN.ARBITRUM]: { start: "2026-02-17" },
-    [CHAIN.BSC]: { start: "2026-02-23" },
-    [CHAIN.AVAX]: { start: "2026-02-23" },
-    [CHAIN.POLYGON]: { start: "2026-02-23" },
-    [CHAIN.MEGAETH]: { start: "2026-02-23" },
-    [CHAIN.HYPERLIQUID]: { start: "2026-03-26" },
-    [CHAIN.MONAD]: { start: "2026-03-30" },
+const factory = "0xe22F9fc0f04486dE25ed6CF1800a4a47aFD82e0C";
+
+const chainConfig: Record<string, { fromBlock: number, start: string }> = {
+  [CHAIN.ETHEREUM]: { fromBlock: 24521317, start: "2026-02-23" },
+  [CHAIN.BASE]: { fromBlock: 42570144, start: "2026-04-05" },
+  [CHAIN.ARBITRUM]: { fromBlock: 435210755, start: "2026-02-17" },
+  [CHAIN.BSC]: { fromBlock: 82964761, start: "2026-02-23" },
+  [CHAIN.AVAX]: { fromBlock: 78822864, start: "2026-02-23" },
+  [CHAIN.POLYGON]: { fromBlock: 83380134, start: "2026-02-23" },
+  [CHAIN.MEGAETH]: { fromBlock: 9083666, start: "2026-02-23" },
+  [CHAIN.HYPERLIQUID]: { fromBlock: 30774348, start: "2026-03-26" },
+  [CHAIN.MONAD]: { fromBlock: 64807339, start: "2026-03-30" },
 };
 
-const InitializeTopic =
-    "0x84a943c81b92b2786bc7029e8331096d28689c016f71cbb66a5d7498a20674f1";
-
 const SwapEvent =
-    "event Swap(address sender, address recipient, bool exactInput, int128 amount0Delta, int128 amount1Delta, int16 newTick, uint104 newPositionInBin)";
+  "event Swap(address sender, address recipient, bool exactInput, int128 amount0Delta, int128 amount1Delta, int16 newTick, uint104 newPositionInBin)";
+
+const poolCreatedEvent = "event PoolCreated(address indexed token0,address indexed token1,address indexed priceProvider,address pool,bytes32 poolId)"
 
 const methodology = {
-    Volume:
-        "Sum of all input token amounts from Swap events across every pool created by Metric. Pools are discovered on-chain from each pool's Initialize event.",
+  Volume:
+    "Sum of all input token amounts from Swap events across every pool created by Metric. Pools are discovered on-chain from factory contract's PoolCreated event.",
 };
 
 const fetch = async (options: FetchOptions) => {
-    const dailyVolume = options.createBalances();
+  const dailyVolume = options.createBalances();
 
-    const startTimestamp = Math.floor(new Date(`${chainConfig[options.chain].start}T00:00:00Z`).getTime() / 1000);
-    const fromBlock = await sdk.blocks.getBlockNumber(options.chain, startTimestamp);
-    const toBlock = await options.getEndBlock();
+  const fromBlock = chainConfig[options.chain].fromBlock;
 
-    const initLogs = await sdk.getEventLogs({
-        chain: options.chain,
-        noTarget: true,
-        topic: InitializeTopic,
-        entireLog: true,
-        fromBlock,
-        toBlock,
-        cacheInCloud: true,
-        maxBlockRange: 10000,
-    });
+  const poolCreatedLogs = await options.getLogs({
+    target: factory,
+    eventAbi: poolCreatedEvent,
+    fromBlock,
+    cacheInCloud: true,
+  })
 
-    const tokensByPool: Record<string, { token0: string, token1: string }> = {};
-    for (const log of initLogs) {
-        tokensByPool[log.address.toLowerCase()] = {
-            token0: `0x${log.topics[1].slice(26)}`,
-            token1: `0x${log.topics[2].slice(26)}`,
-        };
+  const tokensByPool: Map<string, { token0: string, token1: string }> = new Map(poolCreatedLogs.map(log => [log.pool.toLowerCase(), { token0: log.token0.toLowerCase(), token1: log.token1.toLowerCase() }]))
+  const poolAddresses = poolCreatedLogs.map(log => log.pool.toLowerCase());
+  if (!poolAddresses.length) return { dailyVolume };
+
+  const swapLogs = await options.getLogs({
+    targets: poolAddresses,
+    eventAbi: SwapEvent,
+    flatten: false,
+  });
+
+  swapLogs.forEach((logs: any[], index: number) => {
+    if (!logs.length) return;
+    const poolDetails = tokensByPool.get(poolAddresses[index]);
+    if (!poolDetails) return;
+    const { token0, token1 } = poolDetails;
+    for (const log of logs) {
+      const amount0 = BigInt(log.amount0Delta);
+      const amount1 = BigInt(log.amount1Delta);
+      addOneToken({ balances: dailyVolume, token0, amount0, token1, amount1 });
     }
+  });
 
-    const poolAddresses = Object.keys(tokensByPool);
-    if (!poolAddresses.length) return { dailyVolume };
-
-    const allLogs = await options.getLogs({
-        targets: poolAddresses,
-        eventAbi: SwapEvent,
-        flatten: false,
-    });
-
-    allLogs.forEach((logs: any[], index: number) => {
-        if (!logs.length) return;
-        const { token0, token1 } = tokensByPool[poolAddresses[index]];
-        for (const log of logs) {
-            const amount0 = BigInt(log.amount0Delta);
-            const amount1 = BigInt(log.amount1Delta);
-            addOneToken({ balances: dailyVolume, token0, amount0, token1, amount1 });
-        }
-    });
-
-    return { dailyVolume };
+  return { dailyVolume };
 };
 
 const adapter: SimpleAdapter = {
-    version: 2,
-    fetch,
-    pullHourly: true,
-    adapter: chainConfig,
-    methodology,
+  version: 2,
+  fetch,
+  pullHourly: true,
+  adapter: chainConfig,
+  methodology,
 };
 
 export default adapter;

--- a/dexs/metric/index.ts
+++ b/dexs/metric/index.ts
@@ -1,47 +1,59 @@
+import * as sdk from "@defillama/sdk";
 import { FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 import { addOneToken } from "../../helpers/prices";
-import { getConfig } from "../../helpers/cache";
 
-// const API_BASE = "https://api.metric.xyz";
-const API_BASE = "http://54.199.103.16:8080";
-
-const chainConfig: Record<string, { name: string, start: string }> = {
-    [CHAIN.ETHEREUM]: { name: "ethereum", start: "2026-02-23" },
-    [CHAIN.BASE]: { name: "base", start: "2026-04-05" },
-    [CHAIN.ARBITRUM]: { name: "arbitrum", start: "2026-02-17" },
-    [CHAIN.BSC]: { name: "bsc", start: "2026-02-23" },
-    [CHAIN.AVAX]: { name: "avax", start: "2026-02-23" },
-    [CHAIN.POLYGON]: { name: "polygon", start: "2026-02-23" },
-    [CHAIN.MEGAETH]: { name: "megaeth", start: "2026-02-23" },
-    [CHAIN.HYPERLIQUID]: { name: "hyperevm", start: "2026-03-26" },
-    [CHAIN.MONAD]: { name: "monad", start: "2026-03-30" },
+const chainConfig: Record<string, { start: string }> = {
+    [CHAIN.ETHEREUM]: { start: "2026-02-23" },
+    [CHAIN.BASE]: { start: "2026-04-05" },
+    [CHAIN.ARBITRUM]: { start: "2026-02-17" },
+    [CHAIN.BSC]: { start: "2026-02-23" },
+    [CHAIN.AVAX]: { start: "2026-02-23" },
+    [CHAIN.POLYGON]: { start: "2026-02-23" },
+    [CHAIN.MEGAETH]: { start: "2026-02-23" },
+    [CHAIN.HYPERLIQUID]: { start: "2026-03-26" },
+    [CHAIN.MONAD]: { start: "2026-03-30" },
 };
+
+const InitializeTopic =
+    "0x84a943c81b92b2786bc7029e8331096d28689c016f71cbb66a5d7498a20674f1";
 
 const SwapEvent =
     "event Swap(address sender, address recipient, bool exactInput, int128 amount0Delta, int128 amount1Delta, int16 newTick, uint104 newPositionInBin)";
 
 const methodology = {
     Volume:
-        "Sum of all input token amounts from Swap events across every pool deployed by the Metric factory.",
+        "Sum of all input token amounts from Swap events across every pool created by Metric. Pools are discovered on-chain from each pool's Initialize event.",
 };
-
-interface PoolMeta {
-    poolAddress: string;
-    token0: string;
-    token1: string;
-}
 
 const fetch = async (options: FetchOptions) => {
     const dailyVolume = options.createBalances();
-    const chainName = chainConfig[options.chain].name;
 
-    const pools: PoolMeta[] = await getConfig(`metric.xyz-pools-${chainName}`, `${API_BASE}/${chainName}/metadata`);
+    const startTimestamp = Math.floor(new Date(`${chainConfig[options.chain].start}T00:00:00Z`).getTime() / 1000);
+    const fromBlock = await sdk.blocks.getBlockNumber(options.chain, startTimestamp);
+    const toBlock = await options.getEndBlock();
 
-    if (!pools.length) return { dailyVolume };
+    const initLogs = await sdk.getEventLogs({
+        chain: options.chain,
+        noTarget: true,
+        topic: InitializeTopic,
+        entireLog: true,
+        fromBlock,
+        toBlock,
+        cacheInCloud: true,
+        maxBlockRange: 10000,
+    });
 
-    const poolAddresses = pools.map((p) => p.poolAddress);
-    const tokensByIndex = pools.map((p) => ({ token0: p.token0, token1: p.token1 }));
+    const tokensByPool: Record<string, { token0: string, token1: string }> = {};
+    for (const log of initLogs) {
+        tokensByPool[log.address.toLowerCase()] = {
+            token0: `0x${log.topics[1].slice(26)}`,
+            token1: `0x${log.topics[2].slice(26)}`,
+        };
+    }
+
+    const poolAddresses = Object.keys(tokensByPool);
+    if (!poolAddresses.length) return { dailyVolume };
 
     const allLogs = await options.getLogs({
         targets: poolAddresses,
@@ -51,7 +63,7 @@ const fetch = async (options: FetchOptions) => {
 
     allLogs.forEach((logs: any[], index: number) => {
         if (!logs.length) return;
-        const { token0, token1 } = tokensByIndex[index];
+        const { token0, token1 } = tokensByPool[poolAddresses[index]];
         for (const log of logs) {
             const amount0 = BigInt(log.amount0Delta);
             const amount1 = BigInt(log.amount1Delta);


### PR DESCRIPTION
Removes Metric's dependency on a hardcoded HTTP endpoint by discovering pools directly on-chain.

## Changes

- Replaced the external pool metadata source with on-chain `Initialize` event discovery.
- Builds the pool → token mapping from creation events, while keeping the existing swap volume calculation unchanged.
- Eliminates the adapter's reliance on an undocumented, unauthenticated endpoint.

## Verification

- On-chain discovery finds all previously tracked pools plus older inactive deployments that contribute no volume.
- Ethereum daily volume is **unchanged** (**35.26M** on 2026-07-08) before and after the change.
- Verified discovered `token0`/`token1` values match the previous metadata.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pool discovery now uses on-chain initialization events to improve coverage of available pools.
  * Daily volume is derived from on-chain swap activity for more consistent reporting.
* **Bug Fixes**
  * Improved cross-chain metric collection by using chain-specific historical starting points and the newly discovered pool set, reducing gaps in volume calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->