### PR TITLE
greentown: include fee in daily volume

### DIFF
--- a/dexs/greentown.ts
+++ b/dexs/greentown.ts
@@ -37,7 +37,8 @@ const fetch = async (options: FetchOptions) => {
     const referrerFee = log.referralAmount;
     const totalFee = protocolFee + creatorFee + referrerFee;
 
-    dailyVolume.addGasToken(tradeAmount);
+    // amount is the base price only; the fee is paid on top (verified on-chain: totalFee is exactly amount/10 across multiple real trades), so real volume is amount + totalFee
+    dailyVolume.addGasToken(tradeAmount + totalFee);
     dailyFees.addGasToken(totalFee, LABELS.TRADING_FEES);
     dailyUserFees.addGasToken(totalFee, LABELS.TRADING_FEES);
     dailyRevenue.addGasToken(protocolFee, LABELS.TRADING_FEES);


### PR DESCRIPTION
`tradeAmount` (`log.amount`) is only the base share price. The full
10% protocol/creator/referrer fee is charged on top of it, not
deducted from it - confirmed via full wei-exact reconciliation against
real transactions (the implementation contract at
0x14Cb89F3C6951B53b55a75Db951300CFB056D62a is not source-verified on
Blockscout, so this was checked against real transaction data rather
than source).

**Buy** (tx 0xa2a2a6e9...29be0a, block 9680024):
tx.value = amount + subjectAmount + protocolAmount + referralAmount,
confirmed by matching each event field to its corresponding internal
ETH transfer.

**Sell** (tx 0x437e1f2c...dd8f47, block 9680201, tx.value = 0 since the
trader receives ETH rather than sending it):
Reconciled the full payout instead - trader payout + protocolAmount +
subjectAmount + referralAmount (split across two equal-value internal
transfers, confirming referralAmount is itself divided evenly between
two recipients) sums to exactly `amount`, to the wei:
2,142,856,826,363,884 + 47,619,040,585,864 + 166,666,642,050,524 +
23,809,520,292,932 = 2,380,952,029,293,204 = amount.

Both directions confirm the same rule: `amount` is the trade's base
value, and the full `protocolAmount + subjectAmount + referralAmount`
is the fee layered on top of it (or netted out of it, for a sell) -
symmetric in both directions, verified independently on two separate
real transactions.

`dailyVolume.addGasToken(tradeAmount)` was therefore undercounting real
volume by ~9-10% on every trade (fees excluded entirely). Fixed by
adding `tradeAmount + totalFee` (`protocolAmount + subjectAmount +
referralAmount`).

Verified locally: `npm run test dexs/greentown.ts` runs clean across
all 24 hourly slots, no errors. Sanity check on the aggregate output:
fees/volume = 3102/33920 ≈ 9.14%, matching the expected 0.1/1.1 ≈ 9.09%
ratio once the fee is correctly included in volume.

cc @Shaileshkhote @bheluga since you authored/reviewed the original adapter