### PR TITLE
Add Abstract and Solana chains to DropSwap aggregator adapter

### DIFF
--- a/aggregators/dropswap/index.ts
+++ b/aggregators/dropswap/index.ts
@@ -24,6 +24,8 @@ const chains: Record<string, string> = {
   [CHAIN.MANTLE]: 'mantle',
   [CHAIN.XDAI]: 'gnosis',
   [CHAIN.SONEIUM]: 'soneium',
+  [CHAIN.ABSTRACT]: 'abstract',
+  [CHAIN.SOLANA]: 'solana',
 };
 
 interface IVolumeByChainRecord {


### PR DESCRIPTION
Adds Abstract and Solana chains to the DropSwap aggregator adapter (follow-up
to #8102, which added the initial 20-chain adapter).

DropSwap added support for these two chains after the original PR was merged.
No other logic changes — same prefetch/fetch pattern, same API endpoint
(https://dropswap.finance/api/defillama/volume-by-chain).

Tested locally with `npm test aggregators dropswap`.