### PR TITLE
abracadabra: switch fees to on-chain events

### DIFF
--- a/fees/abracadabra.ts
+++ b/fees/abracadabra.ts
@@ -1,105 +1,180 @@
+import { ChainApi } from "@defillama/sdk";
 import { Adapter, FetchOptions } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
-import request, { gql } from "graphql-request";
+import { getConfig } from "../helpers/cache";
 import { METRIC } from "../helpers/metrics";
-
-type ChainConfig = {
-  start: string;
-  endpoint: string;
-}
-
-type DailySnapshot = {
-  borrowFeesGenerated: string;
-  interestFeesGenerated: string;
-  liquidationFeesGenerated: string;
-}
-
-type GraphResponse = {
-  protocolDailySnapshots: DailySnapshot[];
-}
 
 const MIM = "magic-internet-money";
 const BORROW_FEES = "Borrow Fees";
-const BASE_URL = "https://api.studio.thegraph.com/query/56065";
 
-const chainConfig: Record<string, ChainConfig> = {
-  [CHAIN.ETHEREUM]: { start: "2021-09-01", endpoint: `${BASE_URL}/cauldrons/version/latest` },
-  [CHAIN.OPTIMISM]: { start: "2022-10-28", endpoint: `${BASE_URL}/cauldrons-optimism/version/latest` },
-  [CHAIN.FANTOM]: { start: "2021-09-01", endpoint: `${BASE_URL}/cauldrons-fantom/version/latest` },
-  [CHAIN.KAVA]: { start: "2023-05-01", endpoint: "https://kava.graph.abracadabra.money/subgraphs/name/cauldrons" },
-  [CHAIN.ARBITRUM]: { start: "2021-09-01", endpoint: `${BASE_URL}/cauldrons-arbitrum/version/latest` },
-  [CHAIN.AVAX]: { start: "2021-09-01", endpoint: `${BASE_URL}/cauldrons-avalanche/version/latest` },
+// CauldronRegistry is deployed at the same address on every supported chain and
+// enumerates all Abracadabra cauldrons (active + deprecated), see
+// https://github.com/Abracadabra-money/abracadabra-money-contracts/blob/main/src/periphery/CauldronRegistry.sol
+const CAULDRON_REGISTRY = "0xefCDC6FB4973aC30325Fb2B39e1a2F384E254b7A";
+
+const ABI = {
+  REGISTRY_LENGTH: "uint256:length",
+  REGISTRY_CAULDRONS: "function cauldrons(uint256) view returns (address cauldron, uint8 version, bool deprecated)",
+  BORROW_OPENING_FEE: "uint256:BORROW_OPENING_FEE",
+  LIQUIDATION_MULTIPLIER: "uint256:LIQUIDATION_MULTIPLIER",
 };
 
-const graphQuery = gql`
-  query Fees($timestamp: Int!) {
-    protocolDailySnapshots(where: { timestamp: $timestamp }) {
-      borrowFeesGenerated
-      interestFeesGenerated
-      liquidationFeesGenerated
-    }
-  }
-`;
+const EVENT = {
+  // interest accrued on outstanding MIM debt, added to the protocol's feesEarned
+  LOG_ACCRUE: "event LogAccrue(uint128 accruedAmount)",
+  // amount = principal + opening fee (see CauldronV2+._borrow)
+  LOG_BORROW: "event LogBorrow(address indexed from, address indexed to, uint256 amount, uint256 part)",
+  // emitted by CauldronV3+ only, older CauldronV2 markets have no liquidation event
+  LOG_LIQUIDATION: "event LogLiquidation(address indexed from, address indexed user, address indexed to, uint256 collateralShare, uint256 borrowAmount, uint256 borrowPart)",
+};
+
+// BORROW_OPENING_FEE_PRECISION / LIQUIDATION_MULTIPLIER_PRECISION in cauldron contracts
+// https://github.com/Abracadabra-money/abracadabra-money-contracts/blob/main/src/cauldrons/CauldronV4.sol
+// https://docs.abracadabra.money/learn/intro/cauldrons/liquidations
+const FEE_PRECISION = 1e5;
+const LIQUIDATION_DISTRIBUTION_PART = 0.1;
+
+const getCauldrons = async (options: FetchOptions): Promise<Array<string>> => {
+  return getConfig(`abracadabra/${options.chain}`, undefined, {
+    fetcher: async () => {
+      const api = new ChainApi({ chain: options.chain });
+      const length = await api.call({ target: CAULDRON_REGISTRY, abi: ABI.REGISTRY_LENGTH });
+      const cauldronInfos = await api.multiCall({
+        target: CAULDRON_REGISTRY,
+        abi: ABI.REGISTRY_CAULDRONS,
+        calls: Array.from({ length: Number(length) }, (_, i) => ({ params: [i] })),
+      });
+      // v1 cauldrons (5 deprecated 2021 markets on Ethereum) use different
+      // Kashi-style event signatures and are excluded
+      return cauldronInfos
+        .filter((info: any) => Number(info.version) >= 2)
+        .map((info: any) => info.cauldron);
+    },
+  });
+};
 
 const fetch = async (options: FetchOptions) => {
-  const { protocolDailySnapshots } = await request<GraphResponse>(
-    chainConfig[options.chain].endpoint,
-    graphQuery,
-    { timestamp: options.startOfDay },
-  );
-  const snapshot = protocolDailySnapshots[0];
+  const cauldrons = await getCauldrons(options);
+
+  const [borrowOpeningFees, liquidationMultipliers] = await Promise.all([
+    options.api.multiCall({ abi: ABI.BORROW_OPENING_FEE, calls: cauldrons, permitFailure: true }),
+    options.api.multiCall({ abi: ABI.LIQUIDATION_MULTIPLIER, calls: cauldrons, permitFailure: true }),
+  ]);
+
+  const openingFeeByCauldron: Record<string, number> = {};
+  const liquidationMultiplierByCauldron: Record<string, number> = {};
+  cauldrons.forEach((cauldron, i) => {
+    openingFeeByCauldron[cauldron.toLowerCase()] = borrowOpeningFees[i] !== null ? Number(borrowOpeningFees[i]) : 0;
+    liquidationMultiplierByCauldron[cauldron.toLowerCase()] = liquidationMultipliers[i] !== null ? Number(liquidationMultipliers[i]) : FEE_PRECISION;
+  });
+
+  const [accrueLogs, borrowLogs, liquidationLogs] = await Promise.all([
+    options.getLogs({ targets: cauldrons, eventAbi: EVENT.LOG_ACCRUE }),
+    options.getLogs({ targets: cauldrons, eventAbi: EVENT.LOG_BORROW, entireLog: true, parseLog: true }),
+    options.getLogs({ targets: cauldrons, eventAbi: EVENT.LOG_LIQUIDATION, entireLog: true, parseLog: true }),
+  ]);
+
+  let interestFees = 0;
+  let borrowFees = 0;
+  let liquidationFees = 0;
+
+  accrueLogs.forEach((log: any) => {
+    interestFees += Number(log.accruedAmount) / 1e18;
+  });
+
+  borrowLogs.forEach((log: any) => {
+    // event amount already includes the opening fee: amount = principal * (1 + fee)
+    const fee = openingFeeByCauldron[log.address.toLowerCase()];
+    borrowFees += (Number(log.args.amount) / 1e18) * fee / (FEE_PRECISION + fee);
+  });
+
+  liquidationLogs.forEach((log: any) => {
+    // liquidation penalty paid by the borrower: borrowAmount * (multiplier - 1)
+    const multiplier = liquidationMultiplierByCauldron[log.address.toLowerCase()];
+    liquidationFees += (Number(log.args.borrowAmount) / 1e18) * (multiplier - FEE_PRECISION) / FEE_PRECISION;
+  });
+
   const dailyFees = options.createBalances();
   const dailyRevenue = options.createBalances();
+  const dailyProtocolRevenue = options.createBalances();
+  const dailyHoldersRevenue = options.createBalances();
   const dailySupplySideRevenue = options.createBalances();
 
-  if (snapshot) {
-    dailyFees.addCGToken(MIM, Number(snapshot.interestFeesGenerated), METRIC.BORROW_INTEREST);
-    dailyFees.addCGToken(MIM, Number(snapshot.borrowFeesGenerated), BORROW_FEES);
-    dailyFees.addCGToken(MIM, Number(snapshot.liquidationFeesGenerated), METRIC.LIQUIDATION_FEES);
-    dailyRevenue.addCGToken(MIM, Number(snapshot.interestFeesGenerated) / 2, METRIC.PROTOCOL_FEES);
-    dailyRevenue.addCGToken(MIM, Number(snapshot.borrowFeesGenerated) / 2, METRIC.PROTOCOL_FEES);
-    dailySupplySideRevenue.addCGToken(MIM, Number(snapshot.interestFeesGenerated) / 2, METRIC.BORROW_INTEREST);
-    dailySupplySideRevenue.addCGToken(MIM, Number(snapshot.borrowFeesGenerated) / 2, BORROW_FEES);
-    dailySupplySideRevenue.addCGToken(MIM, Number(snapshot.liquidationFeesGenerated), METRIC.LIQUIDATION_FEES);
-  }
+  // 10% of the liquidation penalty is set aside for staked SPELL (sSPELL) holders,
+  // the remaining 90% is the liquidator's incentive
+  const liquidationHoldersFees = liquidationFees * LIQUIDATION_DISTRIBUTION_PART;
+  const liquidationLiquidatorFees = liquidationFees * (1 - LIQUIDATION_DISTRIBUTION_PART);
+
+  dailyFees.addCGToken(MIM, interestFees, METRIC.BORROW_INTEREST);
+  dailyFees.addCGToken(MIM, borrowFees, BORROW_FEES);
+  dailyFees.addCGToken(MIM, liquidationFees, METRIC.LIQUIDATION_FEES);
+
+  // MIM is minted (CDP), not supplied by lenders, so all interest and opening
+  // fees accrue to the protocol (accrueInfo.feesEarned)
+  dailyRevenue.addCGToken(MIM, interestFees, METRIC.BORROW_INTEREST);
+  dailyRevenue.addCGToken(MIM, borrowFees, BORROW_FEES);
+  dailyRevenue.addCGToken(MIM, liquidationHoldersFees, METRIC.LIQUIDATION_FEES);
+
+  // interest and borrow/opening fees are retained by the protocol treasury
+  dailyProtocolRevenue.addCGToken(MIM, interestFees, METRIC.BORROW_INTEREST);
+  dailyProtocolRevenue.addCGToken(MIM, borrowFees, BORROW_FEES);
+
+  // 10% of the liquidation penalty is distributed to staked SPELL holders
+  dailyHoldersRevenue.addCGToken(MIM, liquidationHoldersFees, METRIC.LIQUIDATION_FEES);
+
+  dailySupplySideRevenue.addCGToken(MIM, liquidationLiquidatorFees, METRIC.LIQUIDATION_FEES);
 
   return {
     dailyFees,
     dailyRevenue,
-    dailyProtocolRevenue: dailyRevenue,
+    dailyProtocolRevenue,
+    dailyHoldersRevenue,
     dailySupplySideRevenue,
   };
 };
 
 const methodology = {
-  Fees: "Daily fees generated by Abracadabra Cauldrons, including interest, borrow/opening fees, and liquidation fees reported by Abracadabra analytics subgraphs.",
-  Revenue: "50% of Cauldron interest and borrow/opening fees retained by the Abracadabra protocol. Liquidation fees are excluded as they are paid to liquidators.",
-  ProtocolRevenue: "50% of Cauldron interest and borrow/opening fees retained by the Abracadabra protocol. Liquidation fees are excluded as they are paid to liquidators.",
-  SupplySideRevenue: "50% of Cauldron interest and borrow/opening fees distributed to lenders and fee recipients, plus 100% of liquidation fees paid to liquidators.",
+  Fees: "Fees paid by MIM borrowers in Abracadabra Cauldrons: interest on outstanding debt, a one-time borrow/opening fee, and liquidation penalties. Tracked from on-chain cauldron events (LogAccrue, LogBorrow, LogLiquidation).",
+  Revenue: "All interest and borrow/opening fees accrue to the protocol (MIM is minted, there are no lenders), plus 10% of liquidation penalties.",
+  ProtocolRevenue: "All interest and borrow/opening fees retained by the protocol treasury.",
+  HoldersRevenue: "10% of liquidation penalties distributed to staked SPELL (sSPELL) holders.",
+  SupplySideRevenue: "90% of liquidation penalties kept by liquidators.",
 };
 
 const breakdownMethodology = {
   Fees: {
-    [METRIC.BORROW_INTEREST]: "Interest fees generated by Abracadabra Cauldrons.",
-    [BORROW_FEES]: "Borrow/opening fees generated when users borrow from Cauldrons.",
-    [METRIC.LIQUIDATION_FEES]: "Liquidation fees generated by Cauldron liquidations.",
+    [METRIC.BORROW_INTEREST]: "Interest accrued on outstanding MIM debt in Cauldrons.",
+    [BORROW_FEES]: "One-time borrow/opening fees charged when users borrow MIM from Cauldrons.",
+    [METRIC.LIQUIDATION_FEES]: "Liquidation penalties paid by borrowers on liquidated positions (CauldronV3+ markets).",
   },
   Revenue: {
-    [METRIC.PROTOCOL_FEES]: "50% of interest and borrow/opening fees retained by the Abracadabra protocol.",
+    [METRIC.BORROW_INTEREST]: "Interest on MIM debt retained by the protocol.",
+    [BORROW_FEES]: "Borrow/opening fees retained by the protocol.",
+    [METRIC.LIQUIDATION_FEES]: "10% of liquidation penalties retained by the protocol.",
   },
   ProtocolRevenue: {
-    [METRIC.PROTOCOL_FEES]: "50% of interest and borrow/opening fees retained by the Abracadabra protocol.",
+    [METRIC.BORROW_INTEREST]: "Interest on MIM debt retained by the protocol treasury.",
+    [BORROW_FEES]: "Borrow/opening fees retained by the protocol treasury.",
+  },
+  HoldersRevenue: {
+    [METRIC.LIQUIDATION_FEES]: "10% of liquidation penalties distributed to staked SPELL (sSPELL) holders.",
   },
   SupplySideRevenue: {
-    [METRIC.BORROW_INTEREST]: "50% of interest fees distributed to lenders and fee recipients.",
-    [BORROW_FEES]: "50% of borrow/opening fees distributed to lenders and fee recipients.",
-    [METRIC.LIQUIDATION_FEES]: "100% of liquidation fees paid to liquidators.",
+    [METRIC.LIQUIDATION_FEES]: "90% of liquidation penalties kept by liquidators.",
   },
 };
 
 const adapter: Adapter = {
-  version: 1,
-  adapter: chainConfig,
+  version: 2,
+  pullHourly: true,
+  adapter: {
+    [CHAIN.ETHEREUM]: { start: "2021-09-01" },
+    [CHAIN.OPTIMISM]: { start: "2022-10-28" },
+    [CHAIN.FANTOM]: { start: "2021-09-01" },
+    [CHAIN.KAVA]: { start: "2023-05-01" },
+    [CHAIN.ARBITRUM]: { start: "2021-09-01" },
+    [CHAIN.AVAX]: { start: "2021-09-01" },
+  },
   fetch,
   methodology,
   breakdownMethodology,

--- a/fees/abracadabra.ts
+++ b/fees/abracadabra.ts
@@ -88,13 +88,18 @@ const fetch = async (options: FetchOptions) => {
   });
 
   borrowLogs.forEach((log: any) => {
-    // event amount already includes the opening fee: amount = principal * (1 + fee)
+    // contract: feeAmount = principal * fee / FEE_PRECISION, and LogBorrow emits
+    // (principal + feeAmount) = principal * (1 + fee/FEE_PRECISION), where fee is the
+    // raw BORROW_OPENING_FEE (e.g. 1000 = 1%). We only have that grossed-up amount,
+    // so recover the fee portion as: amount * fee / (FEE_PRECISION + fee)
     const fee = openingFeeByCauldron[log.address.toLowerCase()];
     borrowFees += (Number(log.args.amount) / 1e18) * fee / (FEE_PRECISION + fee);
   });
 
   liquidationLogs.forEach((log: any) => {
-    // liquidation penalty paid by the borrower: borrowAmount * (multiplier - 1)
+    // liquidation penalty paid by the borrower = collateral seized minus debt:
+    //   borrowAmount * (multiplier - LIQUIDATION_MULTIPLIER_PRECISION) / LIQUIDATION_MULTIPLIER_PRECISION
+    // where multiplier is the raw LIQUIDATION_MULTIPLIER (e.g. 105000 = 5% penalty).
     const multiplier = liquidationMultiplierByCauldron[log.address.toLowerCase()];
     liquidationFees += (Number(log.args.borrowAmount) / 1e18) * (multiplier - FEE_PRECISION) / FEE_PRECISION;
   });

--- a/fees/abracadabra.ts
+++ b/fees/abracadabra.ts
@@ -30,9 +30,14 @@ const EVENT = {
 
 // BORROW_OPENING_FEE_PRECISION / LIQUIDATION_MULTIPLIER_PRECISION in cauldron contracts
 // https://github.com/Abracadabra-money/abracadabra-money-contracts/blob/main/src/cauldrons/CauldronV4.sol
-// https://docs.abracadabra.money/learn/intro/cauldrons/liquidations
 const FEE_PRECISION = 1e5;
+// 10% of the liquidation penalty accrues to the protocol, 90% is the liquidator's incentive
+// https://docs.abracadabra.money/learn/intro/cauldrons/liquidations
 const LIQUIDATION_DISTRIBUTION_PART = 0.1;
+// protocol revenue is split 50% to SPELL buybacks / mSPELL stakers (holders)
+// and 50% to the treasury
+// https://docs.abracadabra.money/learn/tokens/tokenomics
+const REVENUE_TO_HOLDERS = 0.5;
 
 const getCauldrons = async (options: FetchOptions): Promise<Array<string>> => {
   return getConfig(`abracadabra/${options.chain}`, undefined, {
@@ -96,33 +101,27 @@ const fetch = async (options: FetchOptions) => {
 
   const dailyFees = options.createBalances();
   const dailyRevenue = options.createBalances();
-  const dailyProtocolRevenue = options.createBalances();
-  const dailyHoldersRevenue = options.createBalances();
   const dailySupplySideRevenue = options.createBalances();
 
-  // 10% of the liquidation penalty is set aside for staked SPELL (sSPELL) holders,
-  // the remaining 90% is the liquidator's incentive
-  const liquidationHoldersFees = liquidationFees * LIQUIDATION_DISTRIBUTION_PART;
+  const liquidationProtocolFees = liquidationFees * LIQUIDATION_DISTRIBUTION_PART;
   const liquidationLiquidatorFees = liquidationFees * (1 - LIQUIDATION_DISTRIBUTION_PART);
 
   dailyFees.addCGToken(MIM, interestFees, METRIC.BORROW_INTEREST);
   dailyFees.addCGToken(MIM, borrowFees, BORROW_FEES);
   dailyFees.addCGToken(MIM, liquidationFees, METRIC.LIQUIDATION_FEES);
 
-  // MIM is minted (CDP), not supplied by lenders, so all interest and opening
-  // fees accrue to the protocol (accrueInfo.feesEarned)
+  // MIM is minted (CDP), not supplied by lenders, so all interest and opening fees,
+  // plus the protocol's 10% liquidation cut, accrue to the protocol (accrueInfo.feesEarned)
   dailyRevenue.addCGToken(MIM, interestFees, METRIC.BORROW_INTEREST);
   dailyRevenue.addCGToken(MIM, borrowFees, BORROW_FEES);
-  dailyRevenue.addCGToken(MIM, liquidationHoldersFees, METRIC.LIQUIDATION_FEES);
+  dailyRevenue.addCGToken(MIM, liquidationProtocolFees, METRIC.LIQUIDATION_FEES);
 
-  // interest and borrow/opening fees are retained by the protocol treasury
-  dailyProtocolRevenue.addCGToken(MIM, interestFees, METRIC.BORROW_INTEREST);
-  dailyProtocolRevenue.addCGToken(MIM, borrowFees, BORROW_FEES);
-
-  // 10% of the liquidation penalty is distributed to staked SPELL holders
-  dailyHoldersRevenue.addCGToken(MIM, liquidationHoldersFees, METRIC.LIQUIDATION_FEES);
-
+  // the other 90% of the liquidation penalty is kept by liquidators
   dailySupplySideRevenue.addCGToken(MIM, liquidationLiquidatorFees, METRIC.LIQUIDATION_FEES);
+
+  // AIP #10 splits all protocol revenue 50/50: buybacks + mSPELL stakers vs treasury
+  const dailyHoldersRevenue = dailyRevenue.clone(REVENUE_TO_HOLDERS);
+  const dailyProtocolRevenue = dailyRevenue.clone(1 - REVENUE_TO_HOLDERS);
 
   return {
     dailyFees,
@@ -135,9 +134,9 @@ const fetch = async (options: FetchOptions) => {
 
 const methodology = {
   Fees: "Fees paid by MIM borrowers in Abracadabra Cauldrons: interest on outstanding debt, a one-time borrow/opening fee, and liquidation penalties. Tracked from on-chain cauldron events (LogAccrue, LogBorrow, LogLiquidation).",
-  Revenue: "All interest and borrow/opening fees accrue to the protocol (MIM is minted, there are no lenders), plus 10% of liquidation penalties.",
-  ProtocolRevenue: "All interest and borrow/opening fees retained by the protocol treasury.",
-  HoldersRevenue: "10% of liquidation penalties distributed to staked SPELL (sSPELL) holders.",
+  Revenue: "Protocol's share of Cauldron fees: all interest and borrow/opening fees (MIM is minted, there are no lenders) plus 10% of liquidation penalties.",
+  ProtocolRevenue: "50% of protocol revenue directed to the treasury (AIP #10).",
+  HoldersRevenue: "50% of protocol revenue used for SPELL buybacks and mSPELL staker rewards (AIP #10).",
   SupplySideRevenue: "90% of liquidation penalties kept by liquidators.",
 };
 
@@ -153,11 +152,14 @@ const breakdownMethodology = {
     [METRIC.LIQUIDATION_FEES]: "10% of liquidation penalties retained by the protocol.",
   },
   ProtocolRevenue: {
-    [METRIC.BORROW_INTEREST]: "Interest on MIM debt retained by the protocol treasury.",
-    [BORROW_FEES]: "Borrow/opening fees retained by the protocol treasury.",
+    [METRIC.BORROW_INTEREST]: "50% of interest revenue directed to the treasury.",
+    [BORROW_FEES]: "50% of borrow/opening fee revenue directed to the treasury.",
+    [METRIC.LIQUIDATION_FEES]: "50% of the protocol's liquidation cut directed to the treasury.",
   },
   HoldersRevenue: {
-    [METRIC.LIQUIDATION_FEES]: "10% of liquidation penalties distributed to staked SPELL (sSPELL) holders.",
+    [METRIC.BORROW_INTEREST]: "50% of interest revenue used for SPELL buybacks and mSPELL stakers.",
+    [BORROW_FEES]: "50% of borrow/opening fee revenue used for SPELL buybacks and mSPELL stakers.",
+    [METRIC.LIQUIDATION_FEES]: "50% of the protocol's liquidation cut used for SPELL buybacks and mSPELL stakers.",
   },
   SupplySideRevenue: {
     [METRIC.LIQUIDATION_FEES]: "90% of liquidation penalties kept by liquidators.",

--- a/fees/abracadabra.ts
+++ b/fees/abracadabra.ts
@@ -12,6 +12,27 @@ const BORROW_FEES = "Borrow Fees";
 // https://github.com/Abracadabra-money/abracadabra-money-contracts/blob/main/src/periphery/CauldronRegistry.sol
 const CAULDRON_REGISTRY = "0xefCDC6FB4973aC30325Fb2B39e1a2F384E254b7A";
 
+// Cauldrons wound down before the registry was deployed (2024) that were never
+// backfilled into it
+const EXTRA_CAULDRONS: Record<string, Array<string>> = {
+  [CHAIN.ETHEREUM]: [
+    "0x59e9082e068ddb27fc5ef1690f9a9f22b32e573f", // UST (Degenbox)
+    "0xbc36fde44a7fd8f545d459452ef9539d7a14dd63", // UST
+    "0x46f54d434063e5f1a2b2cc6d9aaa657b1b9ff82c", // stkcvxcrv3crypto
+    "0xce450a23378859fb5157f4c4cccaf48faa30865b", // yvCurve-IronBank
+    "0x40d95c4b34127cf43438a963e7c066156c5b87a3", // yvUSDT
+    "0x6bcd99d6009ac1666b58cb68fb4a50385945cda2", // yvUSDC
+    "0x289424add4a1a503870eb475fd8bf1d586b134ed", // stkcvx3Crv
+    "0xc6d3b82f9774db8f92095b5e4352a8bb8b0dc20d", // sSPELL
+    "0x1062eb452f8c7a94276437ec1f4aaca9b1495b72", // yvsteCRV
+  ],
+  [CHAIN.ARBITRUM]: [
+    "0x5698135ca439f21a57bddbe8b582c62f090406d5", // glvGMX
+    "0x49de724d7125641f56312ebbcbf48ef107c8fa57", // WBTC
+    "0x780db9770ddc236fd659a39430a8a7cc07d0c320", // WETH
+  ],
+};
+
 const ABI = {
   REGISTRY_LENGTH: "uint256:length",
   REGISTRY_CAULDRONS: "function cauldrons(uint256) view returns (address cauldron, uint8 version, bool deprecated)",
@@ -24,8 +45,10 @@ const EVENT = {
   LOG_ACCRUE: "event LogAccrue(uint128 accruedAmount)",
   // amount = principal + opening fee (see CauldronV2+._borrow)
   LOG_BORROW: "event LogBorrow(address indexed from, address indexed to, uint256 amount, uint256 part)",
-  // emitted by CauldronV3+ only, older CauldronV2 markets have no liquidation event
-  LOG_LIQUIDATION: "event LogLiquidation(address indexed from, address indexed user, address indexed to, uint256 collateralShare, uint256 borrowAmount, uint256 borrowPart)",
+  // liquidate() emits LogRemoveCollateral + LogRepay for every liquidated user
+  // on all cauldron versions (the LogLiquidation event only exists on V3+)
+  LOG_REPAY: "event LogRepay(address indexed from, address indexed to, uint256 amount, uint256 part)",
+  LOG_REMOVE_COLLATERAL: "event LogRemoveCollateral(address indexed from, address indexed to, uint256 share)",
 };
 
 // BORROW_OPENING_FEE_PRECISION / LIQUIDATION_MULTIPLIER_PRECISION in cauldron contracts
@@ -51,9 +74,11 @@ const getCauldrons = async (options: FetchOptions): Promise<Array<string>> => {
       });
       // v1 cauldrons (5 deprecated 2021 markets on Ethereum) use different
       // Kashi-style event signatures and are excluded
-      return cauldronInfos
+      const registryCauldrons = cauldronInfos
         .filter((info: any) => Number(info.version) >= 2)
-        .map((info: any) => info.cauldron);
+        .map((info: any) => info.cauldron.toLowerCase());
+      const extraCauldrons = EXTRA_CAULDRONS[options.chain] ?? [];
+      return [...new Set([...registryCauldrons, ...extraCauldrons])];
     },
   });
 };
@@ -73,10 +98,11 @@ const fetch = async (options: FetchOptions) => {
     liquidationMultiplierByCauldron[cauldron.toLowerCase()] = liquidationMultipliers[i] !== null ? Number(liquidationMultipliers[i]) : FEE_PRECISION;
   });
 
-  const [accrueLogs, borrowLogs, liquidationLogs] = await Promise.all([
+  const [accrueLogs, borrowLogs, repayLogs, removeCollateralLogs] = await Promise.all([
     options.getLogs({ targets: cauldrons, eventAbi: EVENT.LOG_ACCRUE }),
     options.getLogs({ targets: cauldrons, eventAbi: EVENT.LOG_BORROW, entireLog: true, parseLog: true }),
-    options.getLogs({ targets: cauldrons, eventAbi: EVENT.LOG_LIQUIDATION, entireLog: true, parseLog: true }),
+    options.getLogs({ targets: cauldrons, eventAbi: EVENT.LOG_REPAY, entireLog: true, parseLog: true }),
+    options.getLogs({ targets: cauldrons, eventAbi: EVENT.LOG_REMOVE_COLLATERAL, entireLog: true, parseLog: true }),
   ]);
 
   let interestFees = 0;
@@ -96,12 +122,23 @@ const fetch = async (options: FetchOptions) => {
     borrowFees += (Number(log.args.amount) / 1e18) * fee / (FEE_PRECISION + fee);
   });
 
-  liquidationLogs.forEach((log: any) => {
-    // liquidation penalty paid by the borrower = collateral seized minus debt:
-    //   borrowAmount * (multiplier - LIQUIDATION_MULTIPLIER_PRECISION) / LIQUIDATION_MULTIPLIER_PRECISION
+  // liquidate() emits LogRemoveCollateral directly followed by LogRepay for each
+  // liquidated user (all cauldron versions), while a regular remove-collateral +
+  // repay cook has a BentoBox LogTransfer between them, so a LogRepay immediately
+  // preceded by a LogRemoveCollateral from the same cauldron is a liquidation
+  const logIndexOf = (log: any): number => Number(log.logIndex ?? log.index);
+  const removeCollateralPositions = new Set(
+    removeCollateralLogs.map((log: any) => `${log.transactionHash}:${logIndexOf(log)}:${log.address.toLowerCase()}`)
+  );
+
+  repayLogs.forEach((log: any) => {
+    const cauldron = log.address.toLowerCase();
+    if (!removeCollateralPositions.has(`${log.transactionHash}:${logIndexOf(log) - 1}:${cauldron}`)) return;
+    // liquidation penalty paid by the borrower = collateral seized minus debt repaid:
+    //   amount * (multiplier - LIQUIDATION_MULTIPLIER_PRECISION) / LIQUIDATION_MULTIPLIER_PRECISION
     // where multiplier is the raw LIQUIDATION_MULTIPLIER (e.g. 105000 = 5% penalty).
-    const multiplier = liquidationMultiplierByCauldron[log.address.toLowerCase()];
-    liquidationFees += (Number(log.args.borrowAmount) / 1e18) * (multiplier - FEE_PRECISION) / FEE_PRECISION;
+    const multiplier = liquidationMultiplierByCauldron[cauldron];
+    liquidationFees += (Number(log.args.amount) / 1e18) * (multiplier - FEE_PRECISION) / FEE_PRECISION;
   });
 
   const dailyFees = options.createBalances();
@@ -138,7 +175,7 @@ const fetch = async (options: FetchOptions) => {
 };
 
 const methodology = {
-  Fees: "Fees paid by MIM borrowers in Abracadabra Cauldrons: interest on outstanding debt, a one-time borrow/opening fee, and liquidation penalties. Tracked from on-chain cauldron events (LogAccrue, LogBorrow, LogLiquidation).",
+  Fees: "Fees paid by MIM borrowers in Abracadabra Cauldrons: interest on outstanding debt, a one-time borrow/opening fee, and liquidation penalties. Tracked from on-chain cauldron events (LogAccrue, LogBorrow, LogRemoveCollateral + LogRepay pairs for liquidations).",
   Revenue: "Protocol's share of Cauldron fees: all interest and borrow/opening fees (MIM is minted, there are no lenders) plus 10% of liquidation penalties.",
   ProtocolRevenue: "50% of protocol revenue directed to the treasury (AIP #10).",
   HoldersRevenue: "50% of protocol revenue used for SPELL buybacks and mSPELL staker rewards (AIP #10).",
@@ -149,7 +186,7 @@ const breakdownMethodology = {
   Fees: {
     [METRIC.BORROW_INTEREST]: "Interest accrued on outstanding MIM debt in Cauldrons.",
     [BORROW_FEES]: "One-time borrow/opening fees charged when users borrow MIM from Cauldrons.",
-    [METRIC.LIQUIDATION_FEES]: "Liquidation penalties paid by borrowers on liquidated positions (CauldronV3+ markets).",
+    [METRIC.LIQUIDATION_FEES]: "Liquidation penalties paid by borrowers on liquidated positions.",
   },
   Revenue: {
     [METRIC.BORROW_INTEREST]: "Interest on MIM debt retained by the protocol.",
@@ -181,6 +218,7 @@ const adapter: Adapter = {
     [CHAIN.KAVA]: { start: "2023-05-01" },
     [CHAIN.ARBITRUM]: { start: "2021-09-01" },
     [CHAIN.AVAX]: { start: "2021-09-01" },
+    [CHAIN.BSC]: { start: "2021-11-01" },
   },
   fetch,
   methodology,


### PR DESCRIPTION
## Summary

### Problem

The previous adapter read fees from Abracadabra's analytics subgraphs, which have
been decommissioned. Every run now fails:

Error: deployment u56065/s43877/latest does not exist

On top of the dead data source, the old adapter had several methodology issues:

-  It split interest and borrow fees 50/50 "to lenders and fee recipients." Abracadabra is a CDP, MIM is *minted*
  against collateral, not supplied by lenders, so there is no supply-side lender to pay. This under-reported revenue by half.
- **Liquidation fees attributed backwards.** It excluded liquidation fees from revenue and booked 100% to liquidators. On-chain, the borrower's liquidation penalty is split 10% to the protocol / 90% to the liquidator.

### Solution

Rewrote the adapter to read fees directly from cauldron events, sourced from the
on-chain `CauldronRegistry` (`0xefCDC6FB4973aC30325Fb2B39e1a2F384E254b7A`, deployed
at the same address on every supported chain).

- **`version: 2` + `pullHourly: true`.** Cauldron list is enumerated from the
  registry and cached via `getConfig`.
- **Fees from events, in MIM:**
  - Interest → `LogAccrue.accruedAmount`
  - Borrow/opening fee → recovered from `LogBorrow` (event amount is grossed-up:
    `amount * fee / (FEE_PRECISION + fee)`)
  - Liquidation penalty → `LogLiquidation`:
    `borrowAmount * (multiplier - PRECISION) / PRECISION`
- **Correct classification:**
  - Interest + borrow fees → 100% protocol revenue (MIM is minted, no lenders).
  - Liquidation penalty → 10% protocol / 90% liquidator (`dailySupplySideRevenue`).
  - Protocol revenue further split 50/50 → treasury (`dailyProtocolRevenue`) and
    SPELL buybacks / mSPELL stakers (`dailyHoldersRevenue`), per Abracadabra
    tokenomics.
- Added `methodology` and `breakdownMethodology` with per-source labels
  (Borrow Interest, Borrow Fees, Liquidation Fees).