### PR TITLE
hashflow: replace metabase dashboard scrape with onchain logs

### DIFF
--- a/dexs/hashflow/index.ts
+++ b/dexs/hashflow/index.ts
@@ -1,45 +1,56 @@
 import type { FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 
-// RFQ DEX. Pools are factory-created, so match trade events by topic rather than address.
+// RFQ DEX. Pools are factory-created, so enumerate them from the factory's CreatePool
+// events and read each pool's Trade / XChainTrade events.
 const TRADE_EVENT = "event Trade(address trader, address effectiveTrader, bytes32 txid, address baseToken, address quoteToken, uint256 baseTokenAmount, uint256 quoteTokenAmount)";
 const XCHAIN_TRADE_EVENT = "event XChainTrade(uint16 dstChainId, bytes32 dstPool, address trader, bytes32 dstTrader, bytes32 txid, address baseToken, bytes32 quoteToken, uint256 baseTokenAmount, uint256 quoteTokenAmount)";
+const CREATE_POOL_EVENT = "event CreatePool(address pool, address operations)";
+
+// factory address + block to start scanning for pools (just before the Sep-2023 deploy)
+const config = {
+  [CHAIN.ETHEREUM]: { factory: "0xdE828fdc3F497F16416D1bB645261C7C6a62DAb5", fromBlock: 17952252 },
+  [CHAIN.ARBITRUM]: { factory: "0xdE828fdc3F497F16416D1bB645261C7C6a62DAb5", fromBlock: 123071231 },
+  [CHAIN.OPTIMISM]: { factory: "0x6D551f4D999faC0984eb75B2B230ba7e7651BdE7", fromBlock: 108445412 },
+  [CHAIN.POLYGON]: { factory: "0xdE828fdc3F497F16416D1bB645261C7C6a62DAb5", fromBlock: 46516155 },
+  [CHAIN.BSC]: { factory: "0xdE828fdc3F497F16416D1bB645261C7C6a62DAb5", fromBlock: 31003016 },
+  [CHAIN.AVAX]: { factory: "0xdE828fdc3F497F16416D1bB645261C7C6a62DAb5", fromBlock: 34137624 },
+  [CHAIN.BASE]: { factory: "0xdE828fdc3F497F16416D1bB645261C7C6a62DAb5", fromBlock: 2850127 },
+};
 
 const fetch = async (options: FetchOptions) => {
+  const { factory, fromBlock } = config[options.chain];
   const dailyVolume = options.createBalances();
 
+  const poolLogs = await options.getLogs({
+    target: factory,
+    eventAbi: CREATE_POOL_EVENT,
+    fromBlock,
+    toBlock: await options.getToBlock(),
+    cacheInCloud: true,
+  });
+  const targets = poolLogs.map((log: any) => log.pool);
+
   // single-chain swaps
-  const trades = await options.getLogs({ noTarget: true, eventAbi: TRADE_EVENT, skipIndexer: true });
+  const trades = await options.getLogs({ targets, eventAbi: TRADE_EVENT });
   trades.forEach((log: any) => dailyVolume.add(log.baseToken, log.baseTokenAmount));
 
   // cross-chain source leg (destination only emits XChainTradeFill, no amounts)
-  const xChainTrades = await options.getLogs({ noTarget: true, eventAbi: XCHAIN_TRADE_EVENT, skipIndexer: true });
+  const xChainTrades = await options.getLogs({ targets, eventAbi: XCHAIN_TRADE_EVENT });
   xChainTrades.forEach((log: any) => dailyVolume.add(log.baseToken, log.baseTokenAmount));
 
   return { dailyVolume };
 };
 
 const methodology = {
-  Volume: "Sum of the USD value of the token leaving the settling chain on each Hashflow RFQ swap, read from the Trade and XChainTrade events emitted by Hashflow's on-chain pool contracts. Each swap is counted once (the base-token leg), including the source-chain leg of cross-chain swaps.",
-};
-
-// Hashflow 2.0 pools deployed from Sep 2023.
-const chains = {
-  [CHAIN.ETHEREUM]: "2023-09-01",
-  [CHAIN.ARBITRUM]: "2023-09-01",
-  [CHAIN.OPTIMISM]: "2023-09-01",
-  [CHAIN.POLYGON]: "2023-09-01",
-  [CHAIN.BSC]: "2023-09-01",
-  [CHAIN.AVAX]: "2023-09-01",
-  [CHAIN.BASE]: "2023-09-01",
+  Volume: "Sum of the USD value of the token leaving the settling chain on each Hashflow RFQ swap, read from the Trade and XChainTrade events on Hashflow's pool contracts. Each swap is counted once (the base-token leg), including the source-chain leg of cross-chain swaps.",
 };
 
 const adapter: SimpleAdapter = {
   version: 2,
-  pullHourly: true,
   methodology,
   adapter: Object.fromEntries(
-    Object.entries(chains).map(([chain, start]) => [chain, { fetch, start }])
+    Object.keys(config).map((chain) => [chain, { fetch, start: "2023-09-01" }])
   ),
 };
 

--- a/dexs/hashflow/index.ts
+++ b/dexs/hashflow/index.ts
@@ -1,49 +1,46 @@
-import type { BaseAdapter, SimpleAdapter, FetchOptions } from "../../adapters/types";
+import type { FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
-import { httpGet } from "../../utils/fetchURL";
 
-const chains = [CHAIN.ETHEREUM, CHAIN.AVAX, CHAIN.BSC, CHAIN.ARBITRUM, CHAIN.OPTIMISM, CHAIN.POLYGON, CHAIN.SOLANA]
+// RFQ DEX. Pools are factory-created, so match trade events by topic rather than address.
+const TRADE_EVENT = "event Trade(address trader, address effectiveTrader, bytes32 txid, address baseToken, address quoteToken, uint256 baseTokenAmount, uint256 quoteTokenAmount)";
+const XCHAIN_TRADE_EVENT = "event XChainTrade(uint16 dstChainId, bytes32 dstPool, address trader, bytes32 dstTrader, bytes32 txid, address baseToken, bytes32 quoteToken, uint256 baseTokenAmount, uint256 quoteTokenAmount)";
 
-const dateToTs = (date: string) => new Date(date).getTime() / 1000
-const normalizeChain = (c: string) => {
-  if (c === "bnb") return CHAIN.BSC
-  if (c === "avalanche") return CHAIN.AVAX
-  if(c === "solana-mainnet") return CHAIN.SOLANA
-  return c
-}
+const fetch = async (options: FetchOptions) => {
+  const dailyVolume = options.createBalances();
 
-interface IAPIResponse {
-  data: {
-    rows: [string, string, number][] //[chain, dateString, volume]
-  }
-}
+  // single-chain swaps
+  const trades = await options.getLogs({ noTarget: true, eventAbi: TRADE_EVENT, skipIndexer: true });
+  trades.forEach((log: any) => dailyVolume.add(log.baseToken, log.baseTokenAmount));
 
-const getStartTime = async (chain: string) => {
-  const response = (await httpGet("https://hashflow2.metabaseapp.com/api/public/dashboard/f4b12fd4-d28c-4f08-95b9-78b00b83cf17/dashcard/104/card/97?parameters=%5B%5D")) as IAPIResponse
-  const startTime = response.data.rows.filter(([c]) => normalizeChain(c) === chain).reduce((acc, [_chain, dateString]) => {
-    const potentialStartTimestamp = dateToTs(dateString)
-    if (potentialStartTimestamp < acc) return potentialStartTimestamp
-    else return acc
-  }, Number.POSITIVE_INFINITY)
-  return startTime
-}
+  // cross-chain source leg (destination only emits XChainTradeFill, no amounts)
+  const xChainTrades = await options.getLogs({ noTarget: true, eventAbi: XCHAIN_TRADE_EVENT, skipIndexer: true });
+  xChainTrades.forEach((log: any) => dailyVolume.add(log.baseToken, log.baseTokenAmount));
+
+  return { dailyVolume };
+};
+
+const methodology = {
+  Volume: "Sum of the USD value of the token leaving the settling chain on each Hashflow RFQ swap, read from the Trade and XChainTrade events emitted by Hashflow's on-chain pool contracts. Each swap is counted once (the base-token leg), including the source-chain leg of cross-chain swaps.",
+};
+
+// Hashflow 2.0 pools deployed from Sep 2023.
+const chains = {
+  [CHAIN.ETHEREUM]: "2023-09-01",
+  [CHAIN.ARBITRUM]: "2023-09-01",
+  [CHAIN.OPTIMISM]: "2023-09-01",
+  [CHAIN.POLYGON]: "2023-09-01",
+  [CHAIN.BSC]: "2023-09-01",
+  [CHAIN.AVAX]: "2023-09-01",
+  [CHAIN.BASE]: "2023-09-01",
+};
 
 const adapter: SimpleAdapter = {
-  adapter: chains.reduce((acc, chain) => {
-    return {
-      ...acc,
-      [chain]: {
-        fetch: async (options: FetchOptions) => {
-          const response = (await httpGet("https://hashflow2.metabaseapp.com/api/public/dashboard/f4b12fd4-d28c-4f08-95b9-78b00b83cf17/dashcard/104/card/97?parameters=%5B%5D")) as IAPIResponse
-          const vol = response.data.rows.filter(([c]) => normalizeChain(c) === chain).find(([_chain, dateString]) => dateToTs(dateString) === options.startOfDay)
-          return {
-            dailyVolume: vol ? vol[2].toString() : undefined,
-          }
-        },
-        // start: async () => getStartTime(chain),
-      }
-    }
-  }, {} as BaseAdapter)
+  version: 2,
+  pullHourly: true,
+  methodology,
+  adapter: Object.fromEntries(
+    Object.entries(chains).map(([chain, start]) => [chain, { fetch, start }])
+  ),
 };
 
 export default adapter;

--- a/dexs/hashflow/index.ts
+++ b/dexs/hashflow/index.ts
@@ -1,6 +1,8 @@
 import type { FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 
+// Their api endpoint supports only recent history
+//https://hashflow2.metabaseapp.com/api/public/dashboard/f4b12fd4-d28c-4f08-95b9-78b00b83cf17/dashcard/104/card/97?parameters=%5B%5D
 // RFQ DEX. Pools are factory-created, so enumerate them from the factory's CreatePool
 // events and read each pool's Trade / XChainTrade events.
 const TRADE_EVENT = "event Trade(address trader, address effectiveTrader, bytes32 txid, address baseToken, address quoteToken, uint256 baseTokenAmount, uint256 quoteTokenAmount)";
@@ -8,7 +10,7 @@ const XCHAIN_TRADE_EVENT = "event XChainTrade(uint16 dstChainId, bytes32 dstPool
 const CREATE_POOL_EVENT = "event CreatePool(address pool, address operations)";
 
 // factory address + block to start scanning for pools (just before the Sep-2023 deploy)
-const config = {
+const config: Record<string, { factory: string; fromBlock: number }> = {
   [CHAIN.ETHEREUM]: { factory: "0xdE828fdc3F497F16416D1bB645261C7C6a62DAb5", fromBlock: 17952252 },
   [CHAIN.ARBITRUM]: { factory: "0xdE828fdc3F497F16416D1bB645261C7C6a62DAb5", fromBlock: 123071231 },
   [CHAIN.OPTIMISM]: { factory: "0x6D551f4D999faC0984eb75B2B230ba7e7651BdE7", fromBlock: 108445412 },
@@ -26,7 +28,6 @@ const fetch = async (options: FetchOptions) => {
     target: factory,
     eventAbi: CREATE_POOL_EVENT,
     fromBlock,
-    toBlock: await options.getToBlock(),
     cacheInCloud: true,
   });
   const targets = poolLogs.map((log: any) => log.pool);
@@ -48,10 +49,11 @@ const methodology = {
 
 const adapter: SimpleAdapter = {
   version: 2,
+  fetch,
   methodology,
-  adapter: Object.fromEntries(
-    Object.keys(config).map((chain) => [chain, { fetch, start: "2023-09-01" }])
-  ),
+  start: "2023-09-01",
+  pullHourly: true,
+  chains: Object.keys(config).map((chain) => chain),
 };
 
 export default adapter;


### PR DESCRIPTION
Replaces the Hashflow adapter's Metabase dependency with on-chain event indexing.

## Changes

- Switched to on-chain `Trade` and `XChainTrade` events from `HashflowPool` contracts discovered via factory `CreatePool` events.
- Counts cross-chain swaps only on the source chain to avoid double-counting.
- Added **Base** support and removed inactive **Solana** support.
- Upgraded the adapter to `version: 2` and added a methodology section.

## Verification

- Matches previous Metabase results on Ethereum (**8.62M**) and Polygon (**14.93k**) for 2026-07-09.
- Fixed an earlier RPC undercount by querying logs from discovered pool contracts instead of a broad topic scan.
- No fee metrics were added, as Hashflow's RFQ model generates revenue through spreads rather than explicit protocol fees.