### PR TITLE
Add Barker fees adapter (x402 pay-per-call)

### DIFF
--- a/fees/barker.ts
+++ b/fees/barker.ts
@@ -23,8 +23,9 @@ const TOKENS: Record<string, { token: string; cg: string }> = {
 
 const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
   const { token, cg } = TOKENS[options.chain];
-  // skipIndexer: X Layer isn't covered by the indexer; logs are cheap at this volume.
-  const received = await addTokensReceived({ options, tokens: [token], targets: [PAY_TO], skipIndexer: true });
+  // X Layer isn't covered by DefiLlama's indexer — fall back to logs there only;
+  // other chains use the indexer to keep RPC load down.
+  const received = await addTokensReceived({ options, tokens: [token], targets: [PAY_TO], skipIndexer: options.chain === CHAIN.XLAYER });
   const raw = Object.values(received.getBalances()).reduce((sum: number, v: any) => sum + Number(v), 0);
   const dailyFees = options.createBalances();
   dailyFees.addCGToken(cg, raw / 1e6, "x402 Call Fees");
@@ -33,6 +34,7 @@ const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
 
 const adapter: SimpleAdapter = {
   version: 2,
+  pullHourly: true,
   fetch,
   chains: [CHAIN.XLAYER, CHAIN.BASE, CHAIN.ETHEREUM, CHAIN.POLYGON, CHAIN.ARBITRUM],
   start: "2026-05-20",

--- a/fees/barker.ts
+++ b/fees/barker.ts
@@ -22,13 +22,10 @@ const TOKENS: Record<string, { token: string; cg: string }> = {
 };
 
 const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
-  const { token, cg } = TOKENS[options.chain];
-  // X Layer isn't covered by DefiLlama's indexer — fall back to logs there only;
-  // other chains use the indexer to keep RPC load down.
-  const received = await addTokensReceived({ options, tokens: [token], targets: [PAY_TO], skipIndexer: options.chain === CHAIN.XLAYER });
-  const raw = Object.values(received.getBalances()).reduce((sum: number, v: any) => sum + Number(v), 0);
+  const { token } = TOKENS[options.chain];
+  const x402Fees = await addTokensReceived({ options, token, target: PAY_TO });
   const dailyFees = options.createBalances();
-  dailyFees.addCGToken(cg, raw / 1e6, "x402 Call Fees");
+  dailyFees.add( x402Fees, "x402 Call Fees");
   return { dailyFees, dailyRevenue: dailyFees, dailyProtocolRevenue: dailyFees };
 };
 
@@ -40,13 +37,13 @@ const adapter: SimpleAdapter = {
   start: "2026-05-20",
   methodology: {
     Fees: "x402 pay-per-call fees paid by AI agents for Barker's MCP stablecoin-yield tools ($0.001–$0.05 per call), settled onchain in stablecoins to the protocol payment wallet.",
-    Revenue: "All call fees are kept by the protocol.",
-    ProtocolRevenue: "All call fees go to the protocol.",
+    Revenue: "All x402 call fees paid by AI agents are kept by the protocol.",
+    ProtocolRevenue: "All x402 call fees paid by AI agents are kept by the protocol.",
   },
   breakdownMethodology: {
     Fees: { "x402 Call Fees": "Per-call x402 payments by AI agents for MCP yield data, routing and execution-quote tools." },
-    Revenue: { "x402 Call Fees": "All call fees are kept by the protocol." },
-    ProtocolRevenue: { "x402 Call Fees": "All call fees go to the protocol." },
+    Revenue: { "x402 Call Fees": "All x402 call fees paid by AI agents are kept by the protocol." },
+    ProtocolRevenue: { "x402 Call Fees": "All x402 call fees paid by AI agents are kept by the protocol." },
   },
 };
 

--- a/fees/barker.ts
+++ b/fees/barker.ts
@@ -1,0 +1,51 @@
+import { FetchOptions, FetchResultV2, SimpleAdapter } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+import { addTokensReceived } from "../helpers/token";
+
+// Barker (https://barker.money) serves stablecoin yield data, routing and
+// non-custodial execution quotes to AI agents over MCP (mcp.barker.money),
+// priced per call via the x402 payment protocol ($0.001–$0.05 per tool call).
+// Agents settle in stablecoins through the OKX, Coinbase CDP and Circle
+// facilitators to Barker's dedicated payment wallet. The wallet receives
+// nothing but these call payments, so stablecoins arriving there are the
+// protocol's realized fees.
+const PAY_TO = "0x83f15f5bea445109e255ab82622fbdfecd1e4c9f";
+
+// 6-decimal stablecoin accepted on each chain + CoinGecko id for
+// deterministic $1 pricing (USDT0 on X Layer isn't reliably auto-priced).
+const TOKENS: Record<string, { token: string; cg: string }> = {
+  [CHAIN.XLAYER]: { token: "0x779ded0c9e1022225f8e0630b35a9b54be713736", cg: "tether" }, // USDT0
+  [CHAIN.BASE]: { token: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913", cg: "usd-coin" },
+  [CHAIN.ETHEREUM]: { token: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48", cg: "usd-coin" },
+  [CHAIN.POLYGON]: { token: "0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359", cg: "usd-coin" },
+  [CHAIN.ARBITRUM]: { token: "0xaf88d065e77c8cC2239327C5EDb3A432268e5831", cg: "usd-coin" },
+};
+
+const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
+  const { token, cg } = TOKENS[options.chain];
+  // skipIndexer: X Layer isn't covered by the indexer; logs are cheap at this volume.
+  const received = await addTokensReceived({ options, tokens: [token], targets: [PAY_TO], skipIndexer: true });
+  const raw = Object.values(received.getBalances()).reduce((sum: number, v: any) => sum + Number(v), 0);
+  const dailyFees = options.createBalances();
+  dailyFees.addCGToken(cg, raw / 1e6, "x402 Call Fees");
+  return { dailyFees, dailyRevenue: dailyFees, dailyProtocolRevenue: dailyFees };
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  fetch,
+  chains: [CHAIN.XLAYER, CHAIN.BASE, CHAIN.ETHEREUM, CHAIN.POLYGON, CHAIN.ARBITRUM],
+  start: "2026-05-20",
+  methodology: {
+    Fees: "x402 pay-per-call fees paid by AI agents for Barker's MCP stablecoin-yield tools ($0.001–$0.05 per call), settled onchain in stablecoins to the protocol payment wallet.",
+    Revenue: "All call fees are kept by the protocol.",
+    ProtocolRevenue: "All call fees go to the protocol.",
+  },
+  breakdownMethodology: {
+    Fees: { "x402 Call Fees": "Per-call x402 payments by AI agents for MCP yield data, routing and execution-quote tools." },
+    Revenue: { "x402 Call Fees": "All call fees are kept by the protocol." },
+    ProtocolRevenue: { "x402 Call Fees": "All call fees go to the protocol." },
+  },
+};
+
+export default adapter;


### PR DESCRIPTION
Follows up on @RohanNero's suggestion in DefiLlama/DefiLlama-Adapters#20033 (zero-TVL listing closed → track fees here instead).

## What the fees are

[Barker](https://barker.money) serves stablecoin yield data, routing and non-custodial execution quotes to AI agents over MCP (`mcp.barker.money`), priced per call via the **x402 payment protocol** ($0.001–$0.05/call). Agents settle in stablecoins through the OKX, Coinbase CDP and Circle facilitators to a dedicated payment wallet that receives nothing else — tokens arriving there are realized fees.

- Method: `addTokensReceived` on the payment wallet, per-chain stablecoin (USDT0 on X Layer, USDC on Base/Ethereum/Polygon/Arbitrum), CG-priced at $1
- Revenue = ProtocolRevenue = Fees (no fee sharing)

## Test output (real payments caught on Base today)

```
chain     | Daily fees | Daily revenue | Daily protocol revenue
xlayer    | 0.00       | 0.00          | 0.00
base      | 0.01       | 0.01          | 0.01
ethereum  | 0.00       | 0.00          | 0.00
polygon   | 0.00       | 0.00          | 0.00
arbitrum  | 0.00       | 0.00          | 0.00
```

## Protocol metadata (new listing)

- Name: Barker · Website: https://barker.money · Twitter: [BarkerMoneyX](https://x.com/BarkerMoneyX)
- Logo (square): https://barker.money/images/brand-assets/logo-square.png
- Category: AI Agents / Yield (whichever fits your taxonomy)
- Description: Stablecoin yield data, routing and non-custodial execution for AI agents, paid per call via x402.

Once the protocol slug/id is registered, DefiLlama/yield-server#2817 (Barker boost pools for the Yields dashboard, validation-green except the slug checks) can go in too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)