### PR TITLE
Add Catnip volume & fees (Robinhood Chain)

### DIFF
--- a/dexs/catnip.ts
+++ b/dexs/catnip.ts
@@ -1,0 +1,80 @@
+import ADDRESSES from '../helpers/coreAssets.json'
+import { FetchOptions, SimpleAdapter } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+import { addOneToken } from "../helpers/prices";
+
+// Alley (Catnip DEX) — Uniswap V2 fork, fixed 0.30% swap fee.
+// Factory feeTo is currently unset, so LPs receive the full fee and protocol revenue is 0.
+const FACTORY = '0x002EC9782d70f4e79396c58964D4691cA648FB49'
+const CATNIP_WETH = '0xc08751E47611F035B958889557EDBBE33d4a8Bce'
+const SWAP_FEE = 0.003 // 0.30%
+const SWAP_EVENT = 'event Swap(address indexed sender, uint amount0In, uint amount1In, uint amount0Out, uint amount1Out, address indexed to)'
+
+const remap = (token: string) =>
+  token.toLowerCase() === CATNIP_WETH.toLowerCase()
+    ? ADDRESSES.robinhood.WETH
+    : token
+
+const fetch = async (options: FetchOptions) => {
+  const { createBalances, getLogs, chain, api } = options
+
+  const pairLength = await api.call({ target: FACTORY, abi: 'uint256:allPairsLength' })
+  const pairIndexes = Array.from({ length: Number(pairLength) }, (_, i) => i)
+  // Only a handful of Alley pairs today; enumerate all of them instead of filtering by priced TVL.
+  const pairs = await api.multiCall({
+    abi: 'function allPairs(uint256) view returns (address)',
+    calls: pairIndexes.map((i) => ({ target: FACTORY, params: [i] })),
+  })
+  const token0s = await api.multiCall({ abi: 'address:token0', calls: pairs })
+  const token1s = await api.multiCall({ abi: 'address:token1', calls: pairs })
+
+  const dailyVolume = createBalances()
+  const dailyFees = createBalances()
+
+  const allLogs = await getLogs({ targets: pairs, eventAbi: SWAP_EVENT, flatten: false })
+  allLogs.forEach((logs: any[], index: number) => {
+    if (!logs.length) return
+    // Remap Catnip WETH -> Robinhood WETH only for pricing; amounts still come from on-chain Swap logs.
+    const token0 = remap(token0s[index])
+    const token1 = remap(token1s[index])
+    logs.forEach((log: any) => {
+      addOneToken({ chain, balances: dailyVolume, token0, token1, amount0: log.amount0In, amount1: log.amount1In })
+      addOneToken({ chain, balances: dailyVolume, token0, token1, amount0: log.amount0Out, amount1: log.amount1Out })
+      addOneToken({ chain, balances: dailyFees, token0, token1, amount0: Number(log.amount0In) * SWAP_FEE, amount1: Number(log.amount1In) * SWAP_FEE })
+      addOneToken({ chain, balances: dailyFees, token0, token1, amount0: Number(log.amount0Out) * SWAP_FEE, amount1: Number(log.amount1Out) * SWAP_FEE })
+    })
+  })
+
+  return {
+    dailyVolume,
+    dailyFees,
+    dailyUserFees: dailyFees,
+    dailyRevenue: 0,
+    dailySupplySideRevenue: dailyFees,
+    dailyProtocolRevenue: 0,
+    dailyHoldersRevenue: 0,
+  }
+}
+
+const methodology = {
+  UserFees: 'User pays 0.30% fees on each swap.',
+  Fees: 'A 0.30% fee is collected on each swap.',
+  SupplySideRevenue: 'LPs receive the full 0.30% swap fee while protocol fee collection is disabled.',
+  ProtocolRevenue: 'Protocol feeTo is unset, so the protocol receives 0%.',
+  Revenue: 'Protocol fee collection is disabled; revenue is 0.',
+  HoldersRevenue: 'No holder fee share.',
+}
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  pullHourly: true,
+  methodology,
+  adapter: {
+    [CHAIN.ROBINHOOD]: {
+      fetch,
+      start: '2026-07-14',
+    },
+  },
+}
+
+export default adapter

--- a/fees/catnip.ts
+++ b/fees/catnip.ts
@@ -1,0 +1,80 @@
+import ADDRESSES from '../helpers/coreAssets.json'
+import { FetchOptions, SimpleAdapter } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+import { addOneToken } from "../helpers/prices";
+
+// Alley (Catnip DEX) — Uniswap V2 fork, fixed 0.30% swap fee.
+// Factory feeTo is currently unset, so LPs receive the full fee and protocol revenue is 0.
+const FACTORY = '0x002EC9782d70f4e79396c58964D4691cA648FB49'
+const CATNIP_WETH = '0xc08751E47611F035B958889557EDBBE33d4a8Bce'
+const SWAP_FEE = 0.003 // 0.30%
+const SWAP_EVENT = 'event Swap(address indexed sender, uint amount0In, uint amount1In, uint amount0Out, uint amount1Out, address indexed to)'
+
+const remap = (token: string) =>
+  token.toLowerCase() === CATNIP_WETH.toLowerCase()
+    ? ADDRESSES.robinhood.WETH
+    : token
+
+const fetch = async (options: FetchOptions) => {
+  const { createBalances, getLogs, chain, api } = options
+
+  const pairLength = await api.call({ target: FACTORY, abi: 'uint256:allPairsLength' })
+  const pairIndexes = Array.from({ length: Number(pairLength) }, (_, i) => i)
+  // Only a handful of Alley pairs today; enumerate all of them instead of filtering by priced TVL.
+  const pairs = await api.multiCall({
+    abi: 'function allPairs(uint256) view returns (address)',
+    calls: pairIndexes.map((i) => ({ target: FACTORY, params: [i] })),
+  })
+  const token0s = await api.multiCall({ abi: 'address:token0', calls: pairs })
+  const token1s = await api.multiCall({ abi: 'address:token1', calls: pairs })
+
+  const dailyVolume = createBalances()
+  const dailyFees = createBalances()
+
+  const allLogs = await getLogs({ targets: pairs, eventAbi: SWAP_EVENT, flatten: false })
+  allLogs.forEach((logs: any[], index: number) => {
+    if (!logs.length) return
+    // Remap Catnip WETH -> Robinhood WETH only for pricing; amounts still come from on-chain Swap logs.
+    const token0 = remap(token0s[index])
+    const token1 = remap(token1s[index])
+    logs.forEach((log: any) => {
+      addOneToken({ chain, balances: dailyVolume, token0, token1, amount0: log.amount0In, amount1: log.amount1In })
+      addOneToken({ chain, balances: dailyVolume, token0, token1, amount0: log.amount0Out, amount1: log.amount1Out })
+      addOneToken({ chain, balances: dailyFees, token0, token1, amount0: Number(log.amount0In) * SWAP_FEE, amount1: Number(log.amount1In) * SWAP_FEE })
+      addOneToken({ chain, balances: dailyFees, token0, token1, amount0: Number(log.amount0Out) * SWAP_FEE, amount1: Number(log.amount1Out) * SWAP_FEE })
+    })
+  })
+
+  return {
+    dailyVolume,
+    dailyFees,
+    dailyUserFees: dailyFees,
+    dailyRevenue: 0,
+    dailySupplySideRevenue: dailyFees,
+    dailyProtocolRevenue: 0,
+    dailyHoldersRevenue: 0,
+  }
+}
+
+const methodology = {
+  UserFees: 'User pays 0.30% fees on each swap.',
+  Fees: 'A 0.30% fee is collected on each swap.',
+  SupplySideRevenue: 'LPs receive the full 0.30% swap fee while protocol fee collection is disabled.',
+  ProtocolRevenue: 'Protocol feeTo is unset, so the protocol receives 0%.',
+  Revenue: 'Protocol fee collection is disabled; revenue is 0.',
+  HoldersRevenue: 'No holder fee share.',
+}
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  pullHourly: true,
+  methodology,
+  adapter: {
+    [CHAIN.ROBINHOOD]: {
+      fetch,
+      start: '2026-07-14',
+    },
+  },
+}
+
+export default adapter


### PR DESCRIPTION
**NOTE**

#### Please enable "Allow edits by maintainers" while putting up the PR.

---

> - If you would like to add a `tvl` adapter please submit the PR [here](https://github.com/DefiLlama/DefiLlama-Adapters).

Companion TVL adapter PR: https://github.com/DefiLlama/DefiLlama-Adapters/pull/20050

---

##### Name (to be shown on DefiLlama):
Catnip

##### Twitter Link:
https://x.com/catnipexchange

##### List of audit links if any:
None

##### Website Link:
http://catnipexchange.com/

##### Logo (High resolution, will be shown with rounded borders):
https://raw.githubusercontent.com/satorioshi/DefiLlama-Adapters/listing-assets/catnip-logo.png

##### Current TVL:
~0.6k (from TVL adapter test)

##### Treasury Addresses (if the protocol has treasury)
PantryTimelock: `0x9375A7Bc2EF67dEa56010D7FfD6b38F9AC52A470`

##### Chain:
Robinhood Chain

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed):


##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed):


##### Short Description (to be shown on DefiLlama):
Catnip is a Uniswap V2-style DEX (Alley), farms (MasterProwl), and xNIP vault (Cache) on Robinhood Chain.

##### Token address and ticker if any:
NIP — `0xb06f3BE6d2b2D04e6e9276d99b3F134F5429934b` (Robinhood Chain)

##### Category (full list at https://defillama.com/categories) *Please choose only one:
Dexs

##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.):
None (constant-product AMM)

##### Implementation Details: Briefly describe how the oracle is integrated into your project:
N/A

##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage:
N/A

##### forkedFrom (Does your project originate from another project):
Uniswap V2 (via TenXSwap/VenomSwap parity)

##### methodology (what is being counted as tvl, how is tvl being calculated):
Volume and fees from Alley Swap logs (factory `0x002EC9782d70f4e79396c58964D4691cA648FB49`). Swap fee is 0.30%; factory feeTo is unset so protocol revenue is 0 and fees go to LPs. Catnip WETH is mapped 1:1 to Robinhood Chain WETH for pricing.

##### Github org/user (Optional, if your code is open source, we can track activity):
satorioshi

##### Does this project have a referral program?
No