### PR TITLE
fix(perpl): open interest was double-counted (long + short)

### DIFF
--- a/open-interest/perpl.ts
+++ b/open-interest/perpl.ts
@@ -32,7 +32,10 @@ const fetch = async (options: FetchOptions) => {
     longOpenInterestAtEnd += longOI * markPrice;
     shortOpenInterestAtEnd += shortOI * markPrice;
   }
-  const openInterestAtEnd = longOpenInterestAtEnd + shortOpenInterestAtEnd;
+  // Perpl enforces longOpenInterestLNS == shortOpenInterestLNS on-chain
+  // (checkOpenInterestEquality), so open interest is one-sided; summing
+  // both sides double-counts it (~2x). Report a single side.
+  const openInterestAtEnd = longOpenInterestAtEnd;
 
   return { longOpenInterestAtEnd, shortOpenInterestAtEnd, openInterestAtEnd };
 };


### PR DESCRIPTION
## Bug: Perpl open interest is double-counted

`open-interest/perpl.ts` computes:

```js
const openInterestAtEnd = longOpenInterestAtEnd + shortOpenInterestAtEnd;
```

i.e. it sums **both sides** of every position. In a perpetual, every long is matched by an equal short — they are the two halves of the same contracts — so open interest is a **single-sided** quantity (the convention used across DeFiLlama's OI rankings). Perpl additionally **enforces `longOpenInterestLNS == shortOpenInterestLNS` on-chain** (the exchange runs an open-interest-equality check on every settlement/deleverage), so `long + short` is **exactly 2× the real OI**.

**Effect:** Perpl's reported OI is double its true value — at the time of writing, ~$7.3M reported vs ~$3.6M actual — inflating it ~2× versus every other perp on the OI rankings.

## Fix

Report a single side. The per-side values (`longOpenInterestAtEnd` / `shortOpenInterestAtEnd`) are unchanged and still returned, so the breakdown is preserved.

```diff
-  const openInterestAtEnd = longOpenInterestAtEnd + shortOpenInterestAtEnd;
+  // Perpl enforces longOI == shortOI on-chain (checkOpenInterestEquality),
+  // so OI is one-sided; summing both sides double-counts it (~2x).
+  const openInterestAtEnd = longOpenInterestAtEnd;
```
