### PR TITLE
feat(dexs): add flowr adapter

### DIFF
--- a/dexs/flowr.ts
+++ b/dexs/flowr.ts
@@ -8,13 +8,13 @@ import { CHAIN } from "../helpers/chains";
 // The remaining 25% powers FLOWR buybacks, staking rewards and the treasury.
 const FLOWR_GARDEN = "0x0bD039335a08f9b143ecBD0d29CdC89083697B96";
 
-const PLANTED_EVENT =
-  "event Planted(uint8 indexed flowerId,address indexed newHolder,address indexed prevHolder,uint256 price,uint256 prevHolderPayout,uint256 tokensAccrued)";
+const PLANTED_EVENT = "event Planted(uint8 indexed flowerId,address indexed newHolder,address indexed prevHolder,uint256 price,uint256 prevHolderPayout,uint256 tokensAccrued)";
 
 // The previous-gardener share (75%) is immutable, so the protocol envelope is always the
 // remaining 25% of each payment. Inside the envelope, the staking distribution (6.25%)
 // went live on 2026-07-11; on launch day the full envelope accrued to the protocol.
 const STAKING_SHARE_BPS = 625n;
+const BUYBACKS_SHARE_BPS = 1050n;
 const BPS = 10_000n;
 const STAKING_LIVE_FROM = 1783728000; // 2026-07-11T00:00:00Z
 
@@ -23,7 +23,6 @@ async function fetch(options: FetchOptions) {
   const dailyFees = options.createBalances();
   const dailyRevenue = options.createBalances();
   const dailyProtocolRevenue = options.createBalances();
-  const dailySupplySideRevenue = options.createBalances();
   const dailyHoldersRevenue = options.createBalances();
 
   const logs = await options.getLogs({
@@ -34,8 +33,8 @@ async function fetch(options: FetchOptions) {
   const stakingLive = options.startTimestamp >= STAKING_LIVE_FROM;
 
   for (const log of logs) {
-    const price = BigInt(log.price.toString());
-    const payout = BigInt(log.prevHolderPayout.toString());
+    const price = BigInt(log.price);
+    const payout = BigInt(log.prevHolderPayout);
 
     if (payout > price) {
       throw new Error(`flowr: Planted payout ${payout} is larger than its price ${price}`);
@@ -44,16 +43,19 @@ async function fetch(options: FetchOptions) {
     // Derived from the event rather than assumed: envelope = price minus the 75% payout.
     const envelope = price - payout;
     const toStakers = stakingLive ? (price * STAKING_SHARE_BPS) / BPS : 0n;
+    const toBuybacks = (price * BUYBACKS_SHARE_BPS) / BPS;
     if (toStakers > envelope) {
       throw new Error(`flowr: staking share ${toStakers} cannot exceed the envelope ${envelope}`);
     }
 
-    dailyVolume.addGasToken(price.toString());
-    dailyFees.addGasToken(price.toString(), "Plot takeover payments");
-    dailySupplySideRevenue.addGasToken(payout.toString(), "Payout to the replaced gardener");
-    dailyHoldersRevenue.addGasToken(toStakers.toString(), "FLOWR staking rewards");
-    dailyRevenue.addGasToken(envelope.toString(), "Protocol envelope");
-    dailyProtocolRevenue.addGasToken((envelope - toStakers).toString(), "Buybacks and treasury");
+    dailyVolume.addGasToken(price);
+    dailyFees.addGasToken(envelope, "Protocol Envelope Fees");
+    dailyRevenue.addGasToken(envelope, "Protocol Envelope Fees");
+
+    dailyHoldersRevenue.addGasToken(toStakers, "Envelope Fees to $FLOWR Stakers");
+    dailyHoldersRevenue.addGasToken(toBuybacks, "Envelope Fees to $FLOWR Buybacks");
+
+    dailyProtocolRevenue.addGasToken(envelope - toStakers - toBuybacks, "Envelope Fees to Treasury");
   }
 
   return {
@@ -61,37 +63,31 @@ async function fetch(options: FetchOptions) {
     dailyFees,
     dailyRevenue,
     dailyProtocolRevenue,
-    dailySupplySideRevenue,
     dailyHoldersRevenue,
   };
 }
 
 const methodology = {
   Volume: "ETH paid into FlowrGarden to take over flower plots (Planted.price).",
-  Fees: "All ETH paid by players for plot takeovers.",
-  Revenue:
-    "The protocol envelope of each takeover — Planted.price minus the previous-gardener payout — which is 25% of the payment by construction.",
-  ProtocolRevenue:
-    "10.5% of each takeover funds FLOWR buybacks and 8.25% goes to the treasury. Before the staking program started (2026-07-11) the whole 25% envelope accrued here.",
-  SupplySideRevenue: "The 75% of every takeover paid to the gardener being replaced.",
-  HoldersRevenue: "The 6.25% staking distribution, live since 2026-07-11.",
+  Fees: "25% of each takeover, paid by players to the protocol envelope.",
+  Revenue: "The protocol envelope of each takeover — Planted.price minus the previous-gardener payout — which is 25% of the payment by construction.",
+  ProtocolRevenue: "8.25% of each takeover goes to the protocol treasury.",
+  HoldersRevenue: "Includes 10.5% of each takeover going to $FLOWR buybacks and the 6.25% staking distribution, live since 2026-07-11.",
 };
 
 const breakdownMethodology = {
   Fees: {
-    "Plot takeover payments": "Full Planted.price paid by players into FlowrGarden.",
+    "Protocol Envelope Fees": "25% of each takeover, paid by players to the protocol envelope.",
   },
   Revenue: {
-    "Protocol envelope": "Planted.price minus the previous-gardener payout (25% of each takeover).",
+    "Protocol Envelope Fees": "25% of each takeover, paid by players to the protocol envelope.",
   },
   ProtocolRevenue: {
-    "Buybacks and treasury": "10.5% for FLOWR buybacks plus 8.25% for the treasury.",
-  },
-  SupplySideRevenue: {
-    "Payout to the replaced gardener": "75% of each takeover, paid on the spot.",
+    "Envelope Fees to Treasury": "8.25% of each takeover goes to the protocol treasury.",
   },
   HoldersRevenue: {
-    "FLOWR staking rewards": "6.25% of each takeover, distributed to FLOWR stakers.",
+    "Envelope Fees to $FLOWR Stakers": "6.25% of each takeover, distributed to FLOWR stakers.",
+    "Envelope Fees to $FLOWR Buybacks": "10.5% of each takeover, distributed to $FLOWR buybacks.",
   },
 };
 

--- a/dexs/flowr.ts
+++ b/dexs/flowr.ts
@@ -1,0 +1,108 @@
+import { FetchOptions, SimpleAdapter } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+
+// flowr (https://flowrhood.app) — an on-chain garden game on Robinhood Chain. Four flower
+// plots are always live; anyone can take a plot over by paying its current ETH price into
+// the FlowrGarden contract. 75% of that payment goes straight back to the gardener being
+// replaced, and the plot mines FLOWR for its new holder until it wilts or is taken again.
+// The remaining 25% powers FLOWR buybacks, staking rewards and the treasury.
+const FLOWR_GARDEN = "0x0bD039335a08f9b143ecBD0d29CdC89083697B96";
+
+const PLANTED_EVENT =
+  "event Planted(uint8 indexed flowerId,address indexed newHolder,address indexed prevHolder,uint256 price,uint256 prevHolderPayout,uint256 tokensAccrued)";
+
+// The previous-gardener share (75%) is immutable, so the protocol envelope is always the
+// remaining 25% of each payment. Inside the envelope, the staking distribution (6.25%)
+// went live on 2026-07-11; on launch day the full envelope accrued to the protocol.
+const STAKING_SHARE_BPS = 625n;
+const BPS = 10_000n;
+const STAKING_LIVE_FROM = 1783728000; // 2026-07-11T00:00:00Z
+
+async function fetch(options: FetchOptions) {
+  const dailyVolume = options.createBalances();
+  const dailyFees = options.createBalances();
+  const dailyRevenue = options.createBalances();
+  const dailyProtocolRevenue = options.createBalances();
+  const dailySupplySideRevenue = options.createBalances();
+  const dailyHoldersRevenue = options.createBalances();
+
+  const logs = await options.getLogs({
+    target: FLOWR_GARDEN,
+    eventAbi: PLANTED_EVENT,
+  });
+
+  const stakingLive = options.startTimestamp >= STAKING_LIVE_FROM;
+
+  for (const log of logs) {
+    const price = BigInt(log.price.toString());
+    const payout = BigInt(log.prevHolderPayout.toString());
+
+    if (payout > price) {
+      throw new Error(`flowr: Planted payout ${payout} is larger than its price ${price}`);
+    }
+
+    // Derived from the event rather than assumed: envelope = price minus the 75% payout.
+    const envelope = price - payout;
+    const toStakers = stakingLive ? (price * STAKING_SHARE_BPS) / BPS : 0n;
+    if (toStakers > envelope) {
+      throw new Error(`flowr: staking share ${toStakers} cannot exceed the envelope ${envelope}`);
+    }
+
+    dailyVolume.addGasToken(price.toString());
+    dailyFees.addGasToken(price.toString(), "Plot takeover payments");
+    dailySupplySideRevenue.addGasToken(payout.toString(), "Payout to the replaced gardener");
+    dailyHoldersRevenue.addGasToken(toStakers.toString(), "FLOWR staking rewards");
+    dailyRevenue.addGasToken(envelope.toString(), "Protocol envelope");
+    dailyProtocolRevenue.addGasToken((envelope - toStakers).toString(), "Buybacks and treasury");
+  }
+
+  return {
+    dailyVolume,
+    dailyFees,
+    dailyRevenue,
+    dailyProtocolRevenue,
+    dailySupplySideRevenue,
+    dailyHoldersRevenue,
+  };
+}
+
+const methodology = {
+  Volume: "ETH paid into FlowrGarden to take over flower plots (Planted.price).",
+  Fees: "All ETH paid by players for plot takeovers.",
+  Revenue:
+    "The protocol envelope of each takeover — Planted.price minus the previous-gardener payout — which is 25% of the payment by construction.",
+  ProtocolRevenue:
+    "10.5% of each takeover funds FLOWR buybacks and 8.25% goes to the treasury. Before the staking program started (2026-07-11) the whole 25% envelope accrued here.",
+  SupplySideRevenue: "The 75% of every takeover paid to the gardener being replaced.",
+  HoldersRevenue: "The 6.25% staking distribution, live since 2026-07-11.",
+};
+
+const breakdownMethodology = {
+  Fees: {
+    "Plot takeover payments": "Full Planted.price paid by players into FlowrGarden.",
+  },
+  Revenue: {
+    "Protocol envelope": "Planted.price minus the previous-gardener payout (25% of each takeover).",
+  },
+  ProtocolRevenue: {
+    "Buybacks and treasury": "10.5% for FLOWR buybacks plus 8.25% for the treasury.",
+  },
+  SupplySideRevenue: {
+    "Payout to the replaced gardener": "75% of each takeover, paid on the spot.",
+  },
+  HoldersRevenue: {
+    "FLOWR staking rewards": "6.25% of each takeover, distributed to FLOWR stakers.",
+  },
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  pullHourly: true,
+  fetch,
+  chains: [CHAIN.ROBINHOOD],
+  start: "2026-07-10",
+  methodology,
+  breakdownMethodology,
+};
+
+export default adapter;


### PR DESCRIPTION
flowr is an on-chain garden game on Robinhood Chain. This adapter tracks FlowrGarden.Planted events and reports plot takeover payments as volume and fees, with the 75% previous-gardener payout as supply-side revenue and the 25% protocol envelope split across buybacks, staking and treasury.

**NOTE**

#### "Allow edits by maintainers" is enabled.

---

##### Name (to be shown on DefiLlama):

flowr

##### Twitter Link:

https://x.com/FlowrHoodApp

##### List of audit links if any:

N/A

##### Website Link:

https://flowrhood.app

##### Logo (High resolution, will be shown with rounded borders):

https://flowrhood.app/logo.png

##### Current TVL:

N/A for this fees adapter. TVL adapter is not included in this PR.

##### Treasury Addresses (if the protocol has treasury)

N/A

##### Chain:

Robinhood Chain

##### Coingecko ID:

N/A

##### Coinmarketcap ID:

N/A

##### Short Description (to be shown on DefiLlama):

flowr is an on-chain garden game on Robinhood Chain where players pay ETH to take over flower plots and earn FLOWR tokens through ongoing gameplay.

##### Token address and ticker if any:

FLOWR: 0x31EF2F4e678b3640A380C5882ae1A73763D138E9

##### Category:

Gamified Mining
