### PR TITLE
add fees adapter for AlphaFi Lending

### DIFF
--- a/fees/lending-by-alphafi/index.ts
+++ b/fees/lending-by-alphafi/index.ts
@@ -1,0 +1,73 @@
+import { FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import fetchURL from "../../utils/fetchURL";
+
+// Returns USD amounts for an arbitrary time range (max 25 hours)
+const FEES_API = "https://api-staging.alphafi.xyz/public/metrics/fees";
+
+interface FeesResponse {
+  start: number;
+  end: number;
+  alphalend: {
+    fees: number;
+    revenue: number;
+    supplySideRevenue: number;
+  };
+}
+
+const LENDING_FEES = 'Lending Fees';
+const PROTOCOL_SHARE = 'Protocol Share';
+const SUPPLY_SIDE_INTEREST = 'Supply Side Interest';
+
+const fetch = async (options: FetchOptions) => {
+  const res: FeesResponse = await fetchURL(`${FEES_API}?start=${options.fromTimestamp}&end=${options.toTimestamp}`);
+
+  const dailyFees = options.createBalances();
+  const dailyRevenue = options.createBalances();
+  const dailySupplySideRevenue = options.createBalances();
+
+  dailyFees.addUSDValue(res.alphalend.fees, LENDING_FEES);
+  dailyRevenue.addUSDValue(res.alphalend.revenue, PROTOCOL_SHARE);
+  dailySupplySideRevenue.addUSDValue(res.alphalend.supplySideRevenue, SUPPLY_SIDE_INTEREST);
+
+  return {
+    dailyFees,
+    dailyRevenue,
+    dailyProtocolRevenue: dailyRevenue,
+    dailySupplySideRevenue,
+  };
+};
+
+const methodology = {
+  Fees: "Interest paid by borrowers and liquidation fees collected on AlphaLend markets.",
+  Revenue: "Share of borrow interest and liquidation fees kept by the AlphaFi protocol.",
+  ProtocolRevenue: "Share of borrow interest and liquidation fees kept by the AlphaFi protocol.",
+  SupplySideRevenue: "Share of borrow interest distributed to lenders.",
+};
+
+const breakdownMethodology = {
+  Fees: {
+    [LENDING_FEES]: "Interest paid by borrowers and liquidation fees collected on AlphaLend markets.",
+  },
+  Revenue: {
+    [PROTOCOL_SHARE]: "Share of borrow interest and liquidation fees kept by the AlphaFi protocol.",
+  },
+  ProtocolRevenue: {
+    [PROTOCOL_SHARE]: "Share of borrow interest and liquidation fees kept by the AlphaFi protocol.",
+  },
+  SupplySideRevenue: {
+    [SUPPLY_SIDE_INTEREST]: "Share of borrow interest distributed to lenders.",
+  },
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  fetch,
+  chains: [CHAIN.SUI],
+  start: '2026-03-02',
+  methodology,
+  breakdownMethodology,
+  pullHourly: true,
+};
+
+export default adapter;


### PR DESCRIPTION
This PR adds a fees adapter for **AlphaFi Lending** (AlphaLend), which is already
listed on DefiLlama: https://defillama.com/protocol/alphafi-lending (under the
AlphaFi parent protocol). Adapter placed at `fees/lending-by-alphafi/` to match
the protocol's module.

### Implementation
- `version: 2` with `pullHourly: true`
- Data comes from our public metrics API (`api-staging.alphafi.xyz/public/metrics/fees`),
  which accepts arbitrary start/end timestamps (max 25h range) and returns USD values
- Data available from 2026-03-02