### PR TITLE
echo: replace noTarget with scoped getLogs targets

### DIFF
--- a/fees/echo/index.ts
+++ b/fees/echo/index.ts
@@ -15,28 +15,44 @@ import { ethers } from "ethers"
 import { FetchOptions, SimpleAdapter } from "../../adapters/types"
 import { CHAIN } from "../../helpers/chains"
 
-// Echo protocol contract addresses
-const ECHO_v1_DEAL_FACTORY = '0x32885c0174FBd53A3BDf418408415c7bEF679810'
-const ECHO_v2_DEAL_FACTORY = '0x31a85750a7fd18b598e1bc6dc5561ad1ef694fc4'
-const ECHO_v3_DEAL_FACTORY = '0xB6D2c5dc2d181E0E1D031F2b3B76Ea8b678EAA46'
+// Echo protocol deal-factory contracts. Each emits DealCreated(uuid, dealAddress)
+const ECHO_DEAL_FACTORIES = [
+  '0x32885c0174FBd53A3BDf418408415c7bEF679810', // v1
+  '0x31a85750a7fd18b598e1bc6dc5561ad1ef694fc4', // v2
+  '0xB6D2c5dc2d181E0E1D031F2b3B76Ea8b678EAA46', // v3
+  '0x475ddcfd166b80d41d2778ec3a8fa8bbcc887095', // v4
+  '0x97a77759519fe6e273c952e5921462b90066fe67',
+]
 
 const ECHO_FEE_RECEIVER = '0x395426cE9081aE5ceA3f9fBA3078B00f16E7aE21'
 const DEAL_FUNDS_WITHDRAWN_TOPIC = "0x7e63be7447cb592fc5a80b0ca7ceb813b777d8aa50ec5c00b89578b892b4b8e9"
 
+const FACTORY_DEPLOY_BLOCK = 12370761
+
 const fetchFees = async (options: FetchOptions) => {
   const fromBlock = await options.getBlock(options.fromTimestamp, options.chain, {})
   const toBlock = await options.getBlock(options.toTimestamp, options.chain, {})
-  // const fromBlock = 15111743
-  // const toBlock = 28654931
+
+  // DealFundsWithdrawn is emitted by the individual deal contracts, not the
+  // factories. Enumerate every deal ever created by the factories and pass them
+  // as `targets` instead of scanning every log on the chain (noTarget).
+  const dealCreatedLogs = await options.getLogs({
+    targets: ECHO_DEAL_FACTORIES,
+    eventAbi: "event DealCreated(bytes16 indexed uuid, address indexed dealAddress)",
+    fromBlock: FACTORY_DEPLOY_BLOCK,
+    toBlock,
+    onlyArgs: true,
+    cacheInCloud: true,
+  })
+  const deals = [...new Set<string>(dealCreatedLogs.map((log: any) => log.dealAddress))]
 
   const logs = await options.getLogs({
+    targets: deals,
     eventAbi: "event DealFundsWithdrawn (address indexed token, address indexed to, uint256 amount)",
     topics: [DEAL_FUNDS_WITHDRAWN_TOPIC, null as any, ethers.zeroPadValue(ECHO_FEE_RECEIVER, 32)],
     fromBlock,
     toBlock,
     entireLog: true,
-    skipIndexer: true,
-    noTarget: true,
   })
 
   const uniqueFees = new Map<string, { token: string, amount: bigint }>();


### PR DESCRIPTION
## Summary
Replaces the chain-wide `noTarget` log scan in the Echo fees adapter with scoped `getLogs({ targets: [...] })`, per [GUIDELINES.md](https://github.com/DefiLlama/dimension-adapters/blob/master/GUIDELINES.md) (noTarget scans every log on the chain and is very heavy).

## Changes

- **Removed `noTarget`** from the `DealFundsWithdrawn` query. Since that event is emitted by individual **deal contracts** (not the factories), the deal contracts are first enumerated via the factories' `DealCreated(uuid, dealAddress)` events, then passed as `targets`.
- **Added 2 missing factories.** The adapter only listed 3 factory addresses, but 5 contracts actually emit `DealCreated` on Base. The missing two (`0x475d...87095`, `0x97a7...6fe67`) account for ~109 deals, without them fees came back short. 

## Verification

Output is unchanged before vs. after the fix — `pnpm test fees echo 2026-07-11` returns the same value:

BASE 👇
Daily fees: 7.00 k
Daily revenue: 7.00 k