### PR TITLE
based-alpha: fix broken syntax, include fee in daily volume

### DIFF
--- a/fees/based-alpha/index.ts
+++ b/fees/based-alpha/index.ts
@@ -17,10 +17,14 @@ const fetch = async (options: FetchOptions) => {
 
   const tradeLogs = await options.getLogs({ target: LAUNCHPAD, eventAbi: TRADE_EVENT });
   for (const log of tradeLogs) {
-    // ethAmount is the gross ETH side of the trade (fees included on buys,
-    // pre-fee proceeds on sells) — the launchpad's notional curve volume.
-    dailyVolume.addGasToken(log.ethAmount);
-    dailyFees.addGasToken(log.protocolFee + log.creatorFee, METRIC.TRADING_FEES);
+    // ethAmount is the net curve-side amount only. Verified on-chain via two
+    // buys and one sell: on a buy, tx.value = ethAmount + protocolFee + creatorFee
+    // (confirmed exactly, twice); on a sell, the trader's payout equals ethAmount
+    // exactly with no fee deducted from it. So the true gross notional on both
+    // sides is ethAmount + protocolFee + creatorFee, not ethAmount alone.
+    const totalFee = log.protocolFee + log.creatorFee;
+    dailyVolume.addGasToken(log.ethAmount + totalFee);
+    dailyFees.addGasToken(totalFee, METRIC.TRADING_FEES);
     dailyRevenue.addGasToken(log.protocolFee, "Trading Fees to Protocol");
     dailySupplySideRevenue.addGasToken(log.creatorFee, 'Trading Fees to Creators');
   }
@@ -41,7 +45,7 @@ const fetch = async (options: FetchOptions) => {
 };
 
 const methodology = {
-  Volume: "Gross ETH notional of every bonding-curve buy and sell on the launchpad.",
+  Volume: "Gross ETH notional of every bonding-curve buy and sell on the launchpad, including fees.",
   Fees: "1.25% trade fee (0.95% protocol + 0.30% creator) on every curve trade, plus the flat migration fee skimmed when a token graduates to Based DEX.",
   Revenue: "Protocol share of trade fees (0.95% of each trade) plus migration fees.",
   ProtocolRevenue: "Same as Revenue — all protocol fees(0.95% of each trade) and migration fees accrue to the protocol.",
@@ -63,7 +67,8 @@ const breakdownMethodology = {
   ProtocolRevenue: {
     'Trading Fees to Protocol': "Protocol share of trade fees (0.95% of each trade)",
     "Migration Fees to Protocol": "All the migration fees go to the protocol",
-}
+  },
+};
 
 const adapter: SimpleAdapter = {
   version: 2,

--- a/fees/based-alpha/index.ts
+++ b/fees/based-alpha/index.ts
@@ -17,13 +17,9 @@ const fetch = async (options: FetchOptions) => {
 
   const tradeLogs = await options.getLogs({ target: LAUNCHPAD, eventAbi: TRADE_EVENT });
   for (const log of tradeLogs) {
-    // ethAmount is the net curve-side amount only. Verified on-chain via two
-    // buys and one sell: on a buy, tx.value = ethAmount + protocolFee + creatorFee
-    // (confirmed exactly, twice); on a sell, the trader's payout equals ethAmount
-    // exactly with no fee deducted from it. So the true gross notional on both
-    // sides is ethAmount + protocolFee + creatorFee, not ethAmount alone.
     const totalFee = log.protocolFee + log.creatorFee;
-    dailyVolume.addGasToken(log.ethAmount + totalFee);
+    const volume = log.isBuy ? log.ethAmount + totalFee : log.ethAmount;
+    dailyVolume.addGasToken(volume);
     dailyFees.addGasToken(totalFee, METRIC.TRADING_FEES);
     dailyRevenue.addGasToken(log.protocolFee, "Trading Fees to Protocol");
     dailySupplySideRevenue.addGasToken(log.creatorFee, 'Trading Fees to Creators');
@@ -45,7 +41,7 @@ const fetch = async (options: FetchOptions) => {
 };
 
 const methodology = {
-  Volume: "Gross ETH notional of every bonding-curve buy and sell on the launchpad, including fees.",
+  Volume: "Gross ETH notional of every bonding-curve buy and sell on the launchpad.",
   Fees: "1.25% trade fee (0.95% protocol + 0.30% creator) on every curve trade, plus the flat migration fee skimmed when a token graduates to Based DEX.",
   Revenue: "Protocol share of trade fees (0.95% of each trade) plus migration fees.",
   ProtocolRevenue: "Same as Revenue — all protocol fees(0.95% of each trade) and migration fees accrue to the protocol.",


### PR DESCRIPTION
Two separate issues in this newly-added adapter:

**1. Syntax error** - `breakdownMethodology`'s object literal (opened
at `const breakdownMethodology = {`) was never closed before
`const adapter` began. Confirmed via `ts-node --transpile-only` (the
same mechanism this repo's own test script uses) - the file could not
actually load. TypeScript's parser pointed directly at the unclosed
brace. Fixed by adding the missing `},\n};`.

**2. dailyVolume undercounting** - `ethAmount` is only the net
curve-side amount, not the gross trade value. Verified on-chain across
two buys and one sell:
- Buy (`0xd7720e97...530cf51`): `tx.value` = 4,000,000,000,000,001,
  `ethAmount` = 3,950,000,000,000,000, fee sum = 50,000,000,000,000.
  `tx.value = ethAmount + fees`, exact to 1 wei.
- Buy (`0xe109dd02...5637184`): `tx.value` = 10,000,000,000,000,000,
  `ethAmount` = 9,875,000,000,000,000, fee sum = 125,000,000,000,000.
  Exact to the wei.
- Sell (`0xa6c76003...44ca4b7c`): trader's real payout (confirmed via
  Blockscout internal-transactions) = 1,950,312,499,999,998, exactly
  equal to `ethAmount`, with zero fee deducted from it - the fee comes
  from the reserve, not the trader's proceeds.

Both directions confirm the same rule: the true gross notional is
`ethAmount + protocolFee + creatorFee`, symmetric for buys and sells.
Fixed by adding the fee to `dailyVolume`.

Verified locally: `ts-node --transpile-only` now loads the file with
no errors (exit code 0). `npm run test fees/based-alpha/index.ts` runs
clean across all 24 hourly slots - Daily volume 204.92, Daily fees
2.56, ratio ~1.25%, matching the stated fee rate.

cc @edmundbased @bheluga since you authored/reviewed the original adapter