### PR TITLE
[update] SparkDEX perps - V22 subgraph, Old/New merge, BBB revenue model

### DIFF
--- a/dexs/sparkdex-perps/index.ts
+++ b/dexs/sparkdex-perps/index.ts
@@ -299,20 +299,33 @@ const sumTreasuryBbbStats = (response: GraphDayResponse): DayMetrics => {
   for (const fee of response.feeStats) {
     const feeUsd = BigInt(fee.feeUsd);
     const total = BigInt(fee.fee);
-    tradingFeesUSD += feeUsd;
+    const poolFee = BigInt(fee.poolFee);
+    const keeperFee = BigInt(fee.keeperFee);
+    const treasuryFee = BigInt(fee.treasuryFee);
+    const components = poolFee + keeperFee + treasuryFee;
 
-    if (total === 0n) {
+    // Skip unattributable / inconsistent rows so feeUsd cannot leak into LP/dust.
+    if (total <= 0n || components <= 0n) {
       continue;
     }
-    treasuryUSD += (feeUsd * BigInt(fee.treasuryFee)) / total;
-    poolUSD += (feeUsd * BigInt(fee.poolFee)) / total;
-    keeperUSD += (feeUsd * BigInt(fee.keeperFee)) / total;
+    const componentDiff =
+      components >= total ? components - total : total - components;
+    // Subgraph rows are occasionally off by a few wei; reject only material mismatch.
+    if (componentDiff > 1000n && componentDiff * 1_000_000n > total) {
+      continue;
+    }
+
+    tradingFeesUSD += feeUsd;
+    treasuryUSD += (feeUsd * treasuryFee) / total;
+    poolUSD += (feeUsd * poolFee) / total;
+    keeperUSD += (feeUsd * keeperFee) / total;
   }
 
   const dailyFees = Number(tradingFeesUSD) / 1e18;
   const dailyHoldersRevenue = Number(treasuryUSD) / 1e18;
   const dailyLpFees = Number(poolUSD) / 1e18;
   const dailyKeeperFees = Number(keeperUSD) / 1e18;
+  // Integer-division dust only — counted feeUsd rows are attributed above.
   const attributed = dailyHoldersRevenue + dailyLpFees + dailyKeeperFees;
   const dust = dailyFees - attributed;
 

--- a/dexs/sparkdex-perps/index.ts
+++ b/dexs/sparkdex-perps/index.ts
@@ -129,12 +129,26 @@ const assertGraphDayResponse = (
   }
 
   const record = response as Record<string, unknown>;
-  for (const key of ["volumeStats", "feeStats", "tradingStats"] as const) {
+  const keys = ["volumeStats", "feeStats", "tradingStats"] as const;
+  for (const key of keys) {
     if (!Array.isArray(record[key])) {
       throw new Error(
         `SparkDEX ${deployment}: missing ${key} for ${todaysTimestamp}`,
       );
     }
+  }
+
+  const volumeStats = record.volumeStats as unknown[];
+  const feeStats = record.feeStats as unknown[];
+  const tradingStats = record.tradingStats as unknown[];
+  if (
+    volumeStats.length === 0 &&
+    feeStats.length === 0 &&
+    tradingStats.length === 0
+  ) {
+    throw new Error(
+      `SparkDEX ${deployment}: missing daily stats for ${todaysTimestamp}`,
+    );
   }
 
   return response as GraphDayResponse;

--- a/dexs/sparkdex-perps/index.ts
+++ b/dexs/sparkdex-perps/index.ts
@@ -36,11 +36,11 @@ const OLD_PERPS_SNAPSHOT_URL =
 const OLD_PERPS_USE_SNAPSHOT = false;
 
 /**
- * Inclusive last UTC day that may still carry Old Perps volume. After this day
- * the Old Perps contribution is 0 without reading live subgraph or snapshot.
- * Leave null while Old Perps can still trade / wind-down date is unknown.
+ * Inclusive last UTC day that may still carry Old Perps volume. Old Perps fully
+ * stops on 2026-07-31 12:00 UTC; until then wind-down days may have no stats.
+ * After this day the Old Perps contribution is 0 without reading live subgraph.
  */
-const OLD_PERPS_LAST_DAY: number | null = null;
+const OLD_PERPS_LAST_DAY = 1785456000; // 2026-07-31
 
 /**
  * Pre-BBB protocol share of fees (~treasury). After BBB, the same ratio is only
@@ -121,7 +121,8 @@ const assertGraphDayResponse = (
   response: unknown,
   deployment: string,
   todaysTimestamp: number,
-): GraphDayResponse => {
+  options?: { allowEmpty?: boolean },
+): GraphDayResponse | null => {
   if (!response || typeof response !== "object") {
     throw new Error(
       `SparkDEX ${deployment}: invalid GraphQL response for ${todaysTimestamp}`,
@@ -146,6 +147,9 @@ const assertGraphDayResponse = (
     feeStats.length === 0 &&
     tradingStats.length === 0
   ) {
+    if (options?.allowEmpty) {
+      return null;
+    }
     throw new Error(
       `SparkDEX ${deployment}: missing daily stats for ${todaysTimestamp}`,
     );
@@ -335,7 +339,12 @@ const sumPreBbbStats = (response: GraphDayResponse): DayMetrics => {
 
 const queryOldPerpsDay = async (todaysTimestamp: number): Promise<DayMetrics> => {
   const raw = await request(ENDPOINT_OLD_PERPS, graphQuery(todaysTimestamp));
-  const response = assertGraphDayResponse(raw, "Old Perps", todaysTimestamp);
+  const response = assertGraphDayResponse(raw, "Old Perps", todaysTimestamp, {
+    allowEmpty: true,
+  });
+  if (!response) {
+    return emptyDay();
+  }
   return todaysTimestamp >= BBB_START
     ? sumTreasuryBbbStats(response)
     : sumPreBbbStats(response);
@@ -344,6 +353,11 @@ const queryOldPerpsDay = async (todaysTimestamp: number): Promise<DayMetrics> =>
 const queryNewPerpsDay = async (todaysTimestamp: number): Promise<DayMetrics> => {
   const raw = await request(ENDPOINT_NEW_PERPS, graphQuery(todaysTimestamp));
   const response = assertGraphDayResponse(raw, "New Perps", todaysTimestamp);
+  if (!response) {
+    throw new Error(
+      `SparkDEX New Perps: missing daily stats for ${todaysTimestamp}`,
+    );
+  }
   // New Perps launched after BBB_START; always use treasury → BBB.
   return sumTreasuryBbbStats(response);
 };

--- a/dexs/sparkdex-perps/index.ts
+++ b/dexs/sparkdex-perps/index.ts
@@ -2,18 +2,64 @@ import { gql, request } from "graphql-request";
 import { SimpleAdapter, FetchResultV2, FetchOptions } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 import { getTimestampAtStartOfDayUTC } from "../../utils/date";
+import fetchURL from "../../utils/fetchURL";
 
-const endpoint = "https://api.goldsky.com/api/public/project_cm1tgcbwdqg8b01un9jf4a64o/subgraphs/sparkdex-trade/latest/gn";
+// Old Perps (V21) and New Perps (V22) are separate deployments; markets may share
+// names but pools/trading are isolated, so overlapping days are summed.
+const ENDPOINT_OLD_PERPS =
+  "https://api.goldsky.com/api/public/project_cm1tgcbwdqg8b01un9jf4a64o/subgraphs/sparkdex-trade/latest/gn";
+const ENDPOINT_NEW_PERPS =
+  "https://api.goldsky.com/api/public/project_cm1tgcbwdqg8b01un9jf4a64o/subgraphs/sparkdex-trade-v2/latest/gn";
+
+/** First UTC day with New Perps (V22) subgraph daily stats. */
+const NEW_PERPS_START = 1782172800; // 2026-06-23
+
+/**
+ * Governance proposal B (100% of protocol revenue → SPRK buyback/burn) effective
+ * date: https://sparkdex.ai/governance/proposal/6a046cbecd38e8c7fea826ee
+ * (passed 2026-05-17; counted from 2026-05-18 UTC).
+ */
+const BBB_START = 1779062400; // 2026-05-18
+
+/**
+ * Frozen Old Perps daily metrics hosted after the V21 subgraph is retired.
+ * Plan: publish the day map to this URL, then flip OLD_PERPS_USE_SNAPSHOT so
+ * historical refills read the snapshot instead of Goldsky V21.
+ */
+const OLD_PERPS_SNAPSHOT_URL =
+  "https://api.sparkdex.ai/defillama/sparkdex-perps-v21-daily.json";
+
+/**
+ * When true, Old Perps metrics come only from OLD_PERPS_SNAPSHOT_URL (throw if
+ * the day is missing — never return 0 and overwrite DefiLlama history).
+ * Keep false while the Old Perps subgraph is still live.
+ */
+const OLD_PERPS_USE_SNAPSHOT = false;
+
+/**
+ * Inclusive last UTC day that may still carry Old Perps volume. After this day
+ * the Old Perps contribution is 0 without reading live subgraph or snapshot.
+ * Leave null while Old Perps can still trade / wind-down date is unknown.
+ */
+const OLD_PERPS_LAST_DAY: number | null = null;
+
+/**
+ * Pre-BBB protocol share of fees (~treasury). After BBB, the same ratio is only
+ * used if a snapshot day lacks an explicit treasury/holders breakdown.
+ */
+const PROTOCOL_FEE_SHARE = 0.6;
 
 interface IVolumeStat {
-  cumulativeVolumeUsd: string;
   volumeUsd: string;
   id: string;
 }
 
 interface IFeeStat {
-  cumulativeFeeUsd: string;
   feeUsd: string;
+  fee: string;
+  poolFee: string;
+  keeperFee: string;
+  treasuryFee: string;
   id: string;
 }
 
@@ -22,84 +68,301 @@ interface ITradingStat {
   id: string;
 }
 
-const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
-  const todaysTimestamp = getTimestampAtStartOfDayUTC(options.toTimestamp);
+interface DayMetrics {
+  dailyVolume: number;
+  dailyUserFees: number;
+  dailyFees: number;
+  dailyProtocolRevenue: number;
+  dailyHoldersRevenue: number;
+  dailySupplySideRevenue: number;
+}
 
-  const period = "daily";
-  const graphQuery = gql`
-    query MyQuery {
-      volumeStats(where: {timestamp: ${todaysTimestamp}, period: "daily"}) {
-        cumulativeVolumeUsd
-        id
-        volumeUsd
-      }
-      feeStats(where: {timestamp: ${todaysTimestamp}, period: "${period}"}) {
-        id
-        timestamp
-        period
-        cumulativeFeeUsd
-        feeUsd
-      }
-      tradingStats(where: {timestamp: ${todaysTimestamp}, period: "${period}"}) {
-        id
-        fundingFeeUsd
-      }
+type GraphDayResponse = {
+  volumeStats: IVolumeStat[];
+  feeStats: IFeeStat[];
+  tradingStats: ITradingStat[];
+};
+
+const emptyDay = (): DayMetrics => ({
+  dailyVolume: 0,
+  dailyUserFees: 0,
+  dailyFees: 0,
+  dailyProtocolRevenue: 0,
+  dailyHoldersRevenue: 0,
+  dailySupplySideRevenue: 0,
+});
+
+const addDays = (a: DayMetrics, b: DayMetrics): DayMetrics => ({
+  dailyVolume: a.dailyVolume + b.dailyVolume,
+  dailyUserFees: a.dailyUserFees + b.dailyUserFees,
+  dailyFees: a.dailyFees + b.dailyFees,
+  dailyProtocolRevenue: a.dailyProtocolRevenue + b.dailyProtocolRevenue,
+  dailyHoldersRevenue: a.dailyHoldersRevenue + b.dailyHoldersRevenue,
+  dailySupplySideRevenue: a.dailySupplySideRevenue + b.dailySupplySideRevenue,
+});
+
+const graphQuery = (todaysTimestamp: number) => gql`
+  query SparkdexPerpsDay {
+    volumeStats(where: {timestamp: ${todaysTimestamp}, period: "daily"}) {
+      id
+      volumeUsd
     }
-  `;
+    feeStats(where: {timestamp: ${todaysTimestamp}, period: "daily"}) {
+      id
+      feeUsd
+      fee
+      poolFee
+      keeperFee
+      treasuryFee
+    }
+    tradingStats(where: {timestamp: ${todaysTimestamp}, period: "daily"}) {
+      id
+      fundingFeeUsd
+    }
+  }
+`;
 
-  const response = await request(endpoint, graphQuery);
-  const volumeStats: IVolumeStat[] = response.volumeStats;
-  const feeStats: IFeeStat[] = response.feeStats;
-  const tradingStats: ITradingStat[] = response.tradingStats;
+/** Pre-BBB (before 2026-05-18): 60% protocol / 40% LPs. */
+const attributePreBbb = (
+  dailyVolume: number,
+  dailyUserFees: number,
+  dailyFees: number,
+): DayMetrics => {
+  const dailyProtocolRevenue = dailyFees * PROTOCOL_FEE_SHARE;
+  return {
+    dailyVolume,
+    dailyUserFees,
+    dailyFees,
+    dailyProtocolRevenue,
+    dailyHoldersRevenue: 0,
+    dailySupplySideRevenue: dailyFees - dailyProtocolRevenue,
+  };
+};
 
+/**
+ * Fallback for post-BBB snapshot days without a treasury/holders breakdown:
+ * treat the historical ~60% protocol share as HoldersRevenue (BBB).
+ */
+const attributePostBbbApprox = (
+  dailyVolume: number,
+  dailyUserFees: number,
+  dailyFees: number,
+): DayMetrics => {
+  const dailyHoldersRevenue = dailyFees * PROTOCOL_FEE_SHARE;
+  return {
+    dailyVolume,
+    dailyUserFees,
+    dailyFees,
+    dailyProtocolRevenue: 0,
+    dailyHoldersRevenue,
+    dailySupplySideRevenue: dailyFees - dailyHoldersRevenue,
+  };
+};
+
+const attributeFromSnapshotRow = (
+  todaysTimestamp: number,
+  row: Partial<DayMetrics>,
+): DayMetrics => {
+  const dailyVolume = Number(row.dailyVolume) || 0;
+  const dailyUserFees = Number(row.dailyUserFees) || 0;
+  const dailyFees = Number(row.dailyFees) || 0;
+
+  // Prefer an explicit revenue breakdown when present on the snapshot row.
+  if (
+    row.dailyHoldersRevenue !== undefined ||
+    row.dailyProtocolRevenue !== undefined ||
+    row.dailySupplySideRevenue !== undefined
+  ) {
+    return {
+      dailyVolume,
+      dailyUserFees,
+      dailyFees,
+      dailyProtocolRevenue: Number(row.dailyProtocolRevenue) || 0,
+      dailyHoldersRevenue: Number(row.dailyHoldersRevenue) || 0,
+      dailySupplySideRevenue: Number(row.dailySupplySideRevenue) || 0,
+    };
+  }
+
+  return todaysTimestamp >= BBB_START
+    ? attributePostBbbApprox(dailyVolume, dailyUserFees, dailyFees)
+    : attributePreBbb(dailyVolume, dailyUserFees, dailyFees);
+};
+
+/**
+ * Proposal B / post-BBB: 100% of subgraph treasuryFee → SPRK buyback/burn
+ * (HoldersRevenue). Pool + keeper + funding → supply side. Protocol = 0.
+ */
+const sumTreasuryBbbStats = (response: GraphDayResponse): DayMetrics => {
+  let dailyVolumeUSD = BigInt(0);
+  let dailyUserFeesUSD = BigInt(0);
+  let dailyTreasuryUSD = BigInt(0);
+  let dailyPoolAndKeeperUSD = BigInt(0);
+  let dailyFundingUSD = BigInt(0);
+
+  for (const vol of response.volumeStats ?? []) {
+    dailyVolumeUSD += BigInt(vol.volumeUsd);
+  }
+
+  for (const fee of response.feeStats ?? []) {
+    const feeUsd = BigInt(fee.feeUsd);
+    const total = BigInt(fee.fee);
+    dailyUserFeesUSD += feeUsd;
+
+    if (total === 0n) {
+      continue;
+    }
+    const treasuryUsd = (feeUsd * BigInt(fee.treasuryFee)) / total;
+    dailyTreasuryUSD += treasuryUsd;
+    dailyPoolAndKeeperUSD += feeUsd - treasuryUsd;
+  }
+
+  for (const stat of response.tradingStats ?? []) {
+    dailyFundingUSD += BigInt(stat.fundingFeeUsd);
+  }
+
+  const dailyVolume = Number(dailyVolumeUSD) / 1e18;
+  const dailyUserFees = Number(dailyUserFeesUSD) / 1e18;
+  const dailyHoldersRevenue = Number(dailyTreasuryUSD) / 1e18;
+  const dailySupplySideRevenue =
+    (Number(dailyPoolAndKeeperUSD) + Number(dailyFundingUSD)) / 1e18;
+  const dailyFees = dailyUserFees + Number(dailyFundingUSD) / 1e18;
+
+  return {
+    dailyVolume,
+    dailyUserFees,
+    dailyFees,
+    dailyProtocolRevenue: 0,
+    dailyHoldersRevenue,
+    dailySupplySideRevenue,
+  };
+};
+
+const sumPreBbbStats = (response: GraphDayResponse): DayMetrics => {
   let dailyVolumeUSD = BigInt(0);
   let dailyFeeUSD = BigInt(0);
   let dailyFundingFeeUSD = BigInt(0);
 
-  volumeStats.forEach((vol) => {
+  for (const vol of response.volumeStats ?? []) {
     dailyVolumeUSD += BigInt(vol.volumeUsd);
-  });
-  
-  // Sum up trading fees from feeStats
-  feeStats.forEach((fee) => {
+  }
+  for (const fee of response.feeStats ?? []) {
     dailyFeeUSD += BigInt(fee.feeUsd);
-  });
-
-  // Sum up funding fees from tradingStats
-  tradingStats.forEach((stat) => {
+  }
+  for (const stat of response.tradingStats ?? []) {
     dailyFundingFeeUSD += BigInt(stat.fundingFeeUsd);
-  });
+  }
 
-  const dailyVolume = parseInt(dailyVolumeUSD.toString()) / 1e18;
-  const dailyFees = (Number(dailyFeeUSD) + Number(dailyFundingFeeUSD)) / 1e18
-  const dailyUserFees = Number(dailyFeeUSD) / 1e18
+  return attributePreBbb(
+    Number(dailyVolumeUSD) / 1e18,
+    Number(dailyFeeUSD) / 1e18,
+    (Number(dailyFeeUSD) + Number(dailyFundingFeeUSD)) / 1e18,
+  );
+};
 
-  const dailyRevenue = dailyFees * 0.6
-  const dailySupplySideRevenue = dailyFees - dailyRevenue
-  
+const queryOldPerpsDay = async (todaysTimestamp: number): Promise<DayMetrics> => {
+  const response: GraphDayResponse = await request(
+    ENDPOINT_OLD_PERPS,
+    graphQuery(todaysTimestamp),
+  );
+  return todaysTimestamp >= BBB_START
+    ? sumTreasuryBbbStats(response)
+    : sumPreBbbStats(response);
+};
+
+const queryNewPerpsDay = async (todaysTimestamp: number): Promise<DayMetrics> => {
+  const response: GraphDayResponse = await request(
+    ENDPOINT_NEW_PERPS,
+    graphQuery(todaysTimestamp),
+  );
+  // New Perps launched after BBB_START; always use treasury → BBB.
+  return sumTreasuryBbbStats(response);
+};
+
+let snapshotCache: Promise<Record<string, Partial<DayMetrics>>> | null = null;
+
+const loadOldPerpsSnapshot = async (): Promise<Record<string, Partial<DayMetrics>>> => {
+  if (!snapshotCache) {
+    snapshotCache = fetchURL(OLD_PERPS_SNAPSHOT_URL)
+      .then((res) => {
+        const days = res?.days ?? res;
+        if (!days || typeof days !== "object" || Array.isArray(days)) {
+          throw new Error(
+            `SparkDEX Old Perps snapshot at ${OLD_PERPS_SNAPSHOT_URL} is missing a day map`,
+          );
+        }
+        return days as Record<string, Partial<DayMetrics>>;
+      })
+      .catch((err) => {
+        snapshotCache = null;
+        throw err;
+      });
+  }
+  return snapshotCache;
+};
+
+const fetchOldPerpsDay = async (todaysTimestamp: number): Promise<DayMetrics> => {
+  if (OLD_PERPS_LAST_DAY !== null && todaysTimestamp > OLD_PERPS_LAST_DAY) {
+    return emptyDay();
+  }
+
+  if (OLD_PERPS_USE_SNAPSHOT) {
+    const days = await loadOldPerpsSnapshot();
+    const row = days[String(todaysTimestamp)];
+    if (!row) {
+      throw new Error(
+        `No SparkDEX Old Perps snapshot for ${todaysTimestamp}; refusing to return 0 so DefiLlama refill cannot overwrite stored history`,
+      );
+    }
+    return attributeFromSnapshotRow(todaysTimestamp, row);
+  }
+
+  return queryOldPerpsDay(todaysTimestamp);
+};
+
+const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
+  const todaysTimestamp = getTimestampAtStartOfDayUTC(options.toTimestamp);
+
+  const oldPerps = await fetchOldPerpsDay(todaysTimestamp);
+  const newPerps =
+    todaysTimestamp >= NEW_PERPS_START
+      ? await queryNewPerpsDay(todaysTimestamp)
+      : emptyDay();
+
+  const totals = addDays(oldPerps, newPerps);
+  const dailyRevenue = totals.dailyProtocolRevenue + totals.dailyHoldersRevenue;
+
   return {
-    dailyVolume,
-    dailyFees,
-    dailyUserFees,
+    dailyVolume: totals.dailyVolume,
+    dailyFees: totals.dailyFees,
+    dailyUserFees: totals.dailyUserFees,
     dailyRevenue,
-    dailySupplySideRevenue,
-    dailyProtocolRevenue: dailyRevenue,
+    dailyProtocolRevenue: totals.dailyProtocolRevenue,
+    dailyHoldersRevenue: totals.dailyHoldersRevenue,
+    dailySupplySideRevenue: totals.dailySupplySideRevenue,
   };
 };
 
 const methodology = {
-  Volume: "Total daily trading volume from all perpetual markets on SparkDEX.",
-  Fees: 'Fees collected from user trading fees and funding fees on SparkDEX perpetual markets.',
-  UserFees: 'Fees collected from user trading fees on SparkDEX perpetual markets.',
-  Revenue: "60% of fees are  revenue collected by protocol",
-  ProtocolRevenue: "60% of total fees are revenue goes to the protocol",
-  SupplySideRevenue: "40% of total fees goes to liquidity providers",
+  Volume:
+    "Old Perps + New Perps daily perpetual volume (isolated deployments; overlapping days are added). Old Perps from sparkdex-trade while live, then a frozen daily snapshot after the V21 subgraph is retired; New Perps from sparkdex-trade-v2 starting 2026-06-23.",
+  Fees:
+    "Old Perps + New Perps: user trading fees plus funding fees (summed on overlapping days).",
+  UserFees:
+    "Old Perps + New Perps: user trading fees only (summed on overlapping days).",
+  Revenue:
+    "Pre-2026-05-18 (Old Perps): 60% of fees retained as protocol revenue. From 2026-05-18 (governance proposal B): 100% of subgraph treasuryFee used for SPRK buyback/burn (BBB) on both Old Perps and New Perps.",
+  ProtocolRevenue:
+    "Pre-2026-05-18: 60% of Old Perps fees. From 2026-05-18: 0 — treasury share is fully allocated to BBB (HoldersRevenue).",
+  HoldersRevenue:
+    "From 2026-05-18 (proposal B): 100% of subgraph treasuryFee on Old Perps and New Perps allocated to SPRK buyback/burn. Before that date: not attributed separately (protocol kept the non-LP share).",
+  SupplySideRevenue:
+    "Pre-2026-05-18: 40% of Old Perps fees to LPs. From 2026-05-18: poolFee + keeperFee + funding fees to liquidity providers (Old Perps + New Perps).",
 };
 
 const adapter: SimpleAdapter = {
   fetch,
   chains: [CHAIN.FLARE],
-  start: '2024-11-05',
+  start: "2025-10-15",
   methodology,
 };
 

--- a/dexs/sparkdex-perps/index.ts
+++ b/dexs/sparkdex-perps/index.ts
@@ -1,7 +1,6 @@
 import { gql, request } from "graphql-request";
 import { SimpleAdapter, FetchResultV2, FetchOptions } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
-import { getTimestampAtStartOfDayUTC } from "../../utils/date";
 import fetchURL from "../../utils/fetchURL";
 
 // Old Perps (V21) and New Perps (V22) are separate deployments; markets may share
@@ -101,6 +100,46 @@ const addDays = (a: DayMetrics, b: DayMetrics): DayMetrics => ({
   dailySupplySideRevenue: a.dailySupplySideRevenue + b.dailySupplySideRevenue,
 });
 
+const isFiniteNumber = (value: unknown): value is number =>
+  typeof value === "number" && Number.isFinite(value);
+
+const requireSnapshotMetric = (
+  row: Partial<DayMetrics>,
+  key: keyof DayMetrics,
+  todaysTimestamp: number,
+): number => {
+  const value = row[key];
+  if (!isFiniteNumber(value)) {
+    throw new Error(
+      `SparkDEX Old Perps snapshot for ${todaysTimestamp} has invalid or missing ${key}`,
+    );
+  }
+  return value;
+};
+
+const assertGraphDayResponse = (
+  response: unknown,
+  deployment: string,
+  todaysTimestamp: number,
+): GraphDayResponse => {
+  if (!response || typeof response !== "object") {
+    throw new Error(
+      `SparkDEX ${deployment}: invalid GraphQL response for ${todaysTimestamp}`,
+    );
+  }
+
+  const record = response as Record<string, unknown>;
+  for (const key of ["volumeStats", "feeStats", "tradingStats"] as const) {
+    if (!Array.isArray(record[key])) {
+      throw new Error(
+        `SparkDEX ${deployment}: missing ${key} for ${todaysTimestamp}`,
+      );
+    }
+  }
+
+  return response as GraphDayResponse;
+};
+
 const graphQuery = (todaysTimestamp: number) => gql`
   query SparkdexPerpsDay {
     volumeStats(where: {timestamp: ${todaysTimestamp}, period: "daily"}) {
@@ -163,23 +202,44 @@ const attributeFromSnapshotRow = (
   todaysTimestamp: number,
   row: Partial<DayMetrics>,
 ): DayMetrics => {
-  const dailyVolume = Number(row.dailyVolume) || 0;
-  const dailyUserFees = Number(row.dailyUserFees) || 0;
-  const dailyFees = Number(row.dailyFees) || 0;
+  const dailyVolume = requireSnapshotMetric(row, "dailyVolume", todaysTimestamp);
+  const dailyUserFees = requireSnapshotMetric(row, "dailyUserFees", todaysTimestamp);
+  const dailyFees = requireSnapshotMetric(row, "dailyFees", todaysTimestamp);
 
-  // Prefer an explicit revenue breakdown when present on the snapshot row.
-  if (
-    row.dailyHoldersRevenue !== undefined ||
-    row.dailyProtocolRevenue !== undefined ||
-    row.dailySupplySideRevenue !== undefined
-  ) {
+  const hasProtocol = row.dailyProtocolRevenue !== undefined;
+  const hasHolders = row.dailyHoldersRevenue !== undefined;
+  const hasSupply = row.dailySupplySideRevenue !== undefined;
+  const anyRevenue = hasProtocol || hasHolders || hasSupply;
+  const allRevenue = hasProtocol && hasHolders && hasSupply;
+
+  if (anyRevenue && !allRevenue) {
+    throw new Error(
+      `SparkDEX Old Perps snapshot for ${todaysTimestamp} has incomplete revenue breakdown`,
+    );
+  }
+
+  if (allRevenue) {
+    const dailyProtocolRevenue = row.dailyProtocolRevenue!;
+    const dailyHoldersRevenue = row.dailyHoldersRevenue!;
+    const dailySupplySideRevenue = row.dailySupplySideRevenue!;
+
+    if (
+      !isFiniteNumber(dailyProtocolRevenue) ||
+      !isFiniteNumber(dailyHoldersRevenue) ||
+      !isFiniteNumber(dailySupplySideRevenue)
+    ) {
+      throw new Error(
+        `SparkDEX Old Perps snapshot for ${todaysTimestamp} has non-finite revenue breakdown`,
+      );
+    }
+
     return {
       dailyVolume,
       dailyUserFees,
       dailyFees,
-      dailyProtocolRevenue: Number(row.dailyProtocolRevenue) || 0,
-      dailyHoldersRevenue: Number(row.dailyHoldersRevenue) || 0,
-      dailySupplySideRevenue: Number(row.dailySupplySideRevenue) || 0,
+      dailyProtocolRevenue,
+      dailyHoldersRevenue,
+      dailySupplySideRevenue,
     };
   }
 
@@ -199,11 +259,11 @@ const sumTreasuryBbbStats = (response: GraphDayResponse): DayMetrics => {
   let dailyPoolAndKeeperUSD = BigInt(0);
   let dailyFundingUSD = BigInt(0);
 
-  for (const vol of response.volumeStats ?? []) {
+  for (const vol of response.volumeStats) {
     dailyVolumeUSD += BigInt(vol.volumeUsd);
   }
 
-  for (const fee of response.feeStats ?? []) {
+  for (const fee of response.feeStats) {
     const feeUsd = BigInt(fee.feeUsd);
     const total = BigInt(fee.fee);
     dailyUserFeesUSD += feeUsd;
@@ -216,7 +276,7 @@ const sumTreasuryBbbStats = (response: GraphDayResponse): DayMetrics => {
     dailyPoolAndKeeperUSD += feeUsd - treasuryUsd;
   }
 
-  for (const stat of response.tradingStats ?? []) {
+  for (const stat of response.tradingStats) {
     dailyFundingUSD += BigInt(stat.fundingFeeUsd);
   }
 
@@ -242,13 +302,13 @@ const sumPreBbbStats = (response: GraphDayResponse): DayMetrics => {
   let dailyFeeUSD = BigInt(0);
   let dailyFundingFeeUSD = BigInt(0);
 
-  for (const vol of response.volumeStats ?? []) {
+  for (const vol of response.volumeStats) {
     dailyVolumeUSD += BigInt(vol.volumeUsd);
   }
-  for (const fee of response.feeStats ?? []) {
+  for (const fee of response.feeStats) {
     dailyFeeUSD += BigInt(fee.feeUsd);
   }
-  for (const stat of response.tradingStats ?? []) {
+  for (const stat of response.tradingStats) {
     dailyFundingFeeUSD += BigInt(stat.fundingFeeUsd);
   }
 
@@ -260,20 +320,16 @@ const sumPreBbbStats = (response: GraphDayResponse): DayMetrics => {
 };
 
 const queryOldPerpsDay = async (todaysTimestamp: number): Promise<DayMetrics> => {
-  const response: GraphDayResponse = await request(
-    ENDPOINT_OLD_PERPS,
-    graphQuery(todaysTimestamp),
-  );
+  const raw = await request(ENDPOINT_OLD_PERPS, graphQuery(todaysTimestamp));
+  const response = assertGraphDayResponse(raw, "Old Perps", todaysTimestamp);
   return todaysTimestamp >= BBB_START
     ? sumTreasuryBbbStats(response)
     : sumPreBbbStats(response);
 };
 
 const queryNewPerpsDay = async (todaysTimestamp: number): Promise<DayMetrics> => {
-  const response: GraphDayResponse = await request(
-    ENDPOINT_NEW_PERPS,
-    graphQuery(todaysTimestamp),
-  );
+  const raw = await request(ENDPOINT_NEW_PERPS, graphQuery(todaysTimestamp));
+  const response = assertGraphDayResponse(raw, "New Perps", todaysTimestamp);
   // New Perps launched after BBB_START; always use treasury → BBB.
   return sumTreasuryBbbStats(response);
 };
@@ -320,7 +376,7 @@ const fetchOldPerpsDay = async (todaysTimestamp: number): Promise<DayMetrics> =>
 };
 
 const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
-  const todaysTimestamp = getTimestampAtStartOfDayUTC(options.toTimestamp);
+  const todaysTimestamp = options.startOfDay;
 
   const oldPerps = await fetchOldPerpsDay(todaysTimestamp);
   const newPerps =

--- a/dexs/sparkdex-perps/index.ts
+++ b/dexs/sparkdex-perps/index.ts
@@ -1,6 +1,7 @@
 import { gql, request } from "graphql-request";
 import { SimpleAdapter, FetchResultV2, FetchOptions } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
+import { METRIC } from "../../helpers/metrics";
 import fetchURL from "../../utils/fetchURL";
 
 // Old Perps (V21) and New Perps (V22) are separate deployments; markets may share
@@ -42,11 +43,10 @@ const OLD_PERPS_USE_SNAPSHOT = false;
  */
 const OLD_PERPS_LAST_DAY = 1785456000; // 2026-07-31
 
-/**
- * Pre-BBB protocol share of fees (~treasury). After BBB, the same ratio is only
- * used if a snapshot day lacks an explicit treasury/holders breakdown.
- */
+/** Pre-BBB protocol share of trading fees (~treasury). */
 const PROTOCOL_FEE_SHARE = 0.6;
+
+const KEEPER_FEES = "Keeper Fees";
 
 interface IVolumeStat {
   volumeUsd: string;
@@ -62,42 +62,43 @@ interface IFeeStat {
   id: string;
 }
 
-interface ITradingStat {
-  fundingFeeUsd: string;
-  id: string;
-}
-
-interface DayMetrics {
-  dailyVolume: number;
-  dailyUserFees: number;
-  dailyFees: number;
-  dailyProtocolRevenue: number;
-  dailyHoldersRevenue: number;
-  dailySupplySideRevenue: number;
-}
-
 type GraphDayResponse = {
   volumeStats: IVolumeStat[];
   feeStats: IFeeStat[];
-  tradingStats: ITradingStat[];
+  tradingStats: unknown[];
 };
+
+interface DayMetrics {
+  dailyVolume: number;
+  dailyFees: number;
+  dailyUserFees: number;
+  dailyProtocolRevenue: number;
+  dailyHoldersRevenue: number;
+  dailySupplySideRevenue: number;
+  dailyLpFees: number;
+  dailyKeeperFees: number;
+}
 
 const emptyDay = (): DayMetrics => ({
   dailyVolume: 0,
-  dailyUserFees: 0,
   dailyFees: 0,
+  dailyUserFees: 0,
   dailyProtocolRevenue: 0,
   dailyHoldersRevenue: 0,
   dailySupplySideRevenue: 0,
+  dailyLpFees: 0,
+  dailyKeeperFees: 0,
 });
 
 const addDays = (a: DayMetrics, b: DayMetrics): DayMetrics => ({
   dailyVolume: a.dailyVolume + b.dailyVolume,
-  dailyUserFees: a.dailyUserFees + b.dailyUserFees,
   dailyFees: a.dailyFees + b.dailyFees,
+  dailyUserFees: a.dailyUserFees + b.dailyUserFees,
   dailyProtocolRevenue: a.dailyProtocolRevenue + b.dailyProtocolRevenue,
   dailyHoldersRevenue: a.dailyHoldersRevenue + b.dailyHoldersRevenue,
   dailySupplySideRevenue: a.dailySupplySideRevenue + b.dailySupplySideRevenue,
+  dailyLpFees: a.dailyLpFees + b.dailyLpFees,
+  dailyKeeperFees: a.dailyKeeperFees + b.dailyKeeperFees,
 });
 
 const isFiniteNumber = (value: unknown): value is number =>
@@ -174,45 +175,45 @@ const graphQuery = (todaysTimestamp: number) => gql`
     }
     tradingStats(where: {timestamp: ${todaysTimestamp}, period: "daily"}) {
       id
-      fundingFeeUsd
     }
   }
 `;
 
-/** Pre-BBB (before 2026-05-18): 60% protocol / 40% LPs. */
-const attributePreBbb = (
-  dailyVolume: number,
-  dailyUserFees: number,
-  dailyFees: number,
-): DayMetrics => {
-  const dailyProtocolRevenue = dailyFees * PROTOCOL_FEE_SHARE;
+/** Pre-BBB: 60% protocol / 40% LPs on trading fees. */
+const attributePreBbb = (dailyVolume: number, tradingFees: number): DayMetrics => {
+  const dailyProtocolRevenue = tradingFees * PROTOCOL_FEE_SHARE;
+  const dailyLpFees = tradingFees - dailyProtocolRevenue;
   return {
     dailyVolume,
-    dailyUserFees,
-    dailyFees,
+    dailyFees: tradingFees,
+    dailyUserFees: tradingFees,
     dailyProtocolRevenue,
     dailyHoldersRevenue: 0,
-    dailySupplySideRevenue: dailyFees - dailyProtocolRevenue,
+    dailySupplySideRevenue: dailyLpFees,
+    dailyLpFees,
+    dailyKeeperFees: 0,
   };
 };
 
 /**
- * Fallback for post-BBB snapshot days without a treasury/holders breakdown:
+ * Fallback for post-BBB snapshot days without an explicit revenue breakdown:
  * treat the historical ~60% protocol share as HoldersRevenue (BBB).
  */
 const attributePostBbbApprox = (
   dailyVolume: number,
-  dailyUserFees: number,
-  dailyFees: number,
+  tradingFees: number,
 ): DayMetrics => {
-  const dailyHoldersRevenue = dailyFees * PROTOCOL_FEE_SHARE;
+  const dailyHoldersRevenue = tradingFees * PROTOCOL_FEE_SHARE;
+  const dailyLpFees = tradingFees - dailyHoldersRevenue;
   return {
     dailyVolume,
-    dailyUserFees,
-    dailyFees,
+    dailyFees: tradingFees,
+    dailyUserFees: tradingFees,
     dailyProtocolRevenue: 0,
     dailyHoldersRevenue,
-    dailySupplySideRevenue: dailyFees - dailyHoldersRevenue,
+    dailySupplySideRevenue: dailyLpFees,
+    dailyLpFees,
+    dailyKeeperFees: 0,
   };
 };
 
@@ -221,8 +222,11 @@ const attributeFromSnapshotRow = (
   row: Partial<DayMetrics>,
 ): DayMetrics => {
   const dailyVolume = requireSnapshotMetric(row, "dailyVolume", todaysTimestamp);
-  const dailyUserFees = requireSnapshotMetric(row, "dailyUserFees", todaysTimestamp);
   const dailyFees = requireSnapshotMetric(row, "dailyFees", todaysTimestamp);
+  const dailyUserFees =
+    row.dailyUserFees !== undefined
+      ? requireSnapshotMetric(row, "dailyUserFees", todaysTimestamp)
+      : dailyFees;
 
   const hasProtocol = row.dailyProtocolRevenue !== undefined;
   const hasHolders = row.dailyHoldersRevenue !== undefined;
@@ -251,90 +255,86 @@ const attributeFromSnapshotRow = (
       );
     }
 
+    const dailyLpFees = isFiniteNumber(row.dailyLpFees)
+      ? row.dailyLpFees
+      : dailySupplySideRevenue;
+    const dailyKeeperFees = isFiniteNumber(row.dailyKeeperFees)
+      ? row.dailyKeeperFees
+      : 0;
+
     return {
       dailyVolume,
-      dailyUserFees,
       dailyFees,
+      dailyUserFees,
       dailyProtocolRevenue,
       dailyHoldersRevenue,
       dailySupplySideRevenue,
+      dailyLpFees,
+      dailyKeeperFees,
     };
   }
 
   return todaysTimestamp >= BBB_START
-    ? attributePostBbbApprox(dailyVolume, dailyUserFees, dailyFees)
-    : attributePreBbb(dailyVolume, dailyUserFees, dailyFees);
+    ? attributePostBbbApprox(dailyVolume, dailyFees)
+    : attributePreBbb(dailyVolume, dailyFees);
 };
 
-/**
- * Proposal B / post-BBB: 100% of subgraph treasuryFee → SPRK buyback/burn
- * (HoldersRevenue). Pool + keeper + funding → supply side. Protocol = 0.
- */
-const sumTreasuryBbbStats = (response: GraphDayResponse): DayMetrics => {
+const sumVolume = (response: GraphDayResponse): number => {
   let dailyVolumeUSD = BigInt(0);
-  let dailyUserFeesUSD = BigInt(0);
-  let dailyTreasuryUSD = BigInt(0);
-  let dailyPoolAndKeeperUSD = BigInt(0);
-  let dailyFundingUSD = BigInt(0);
-
   for (const vol of response.volumeStats) {
     dailyVolumeUSD += BigInt(vol.volumeUsd);
   }
+  return Number(dailyVolumeUSD) / 1e18;
+};
+
+/**
+ * Post-BBB: protocol treasury share → SPRK buyback/burn (HoldersRevenue).
+ * Pool + keeper shares → supply side.
+ */
+const sumTreasuryBbbStats = (response: GraphDayResponse): DayMetrics => {
+  let tradingFeesUSD = BigInt(0);
+  let treasuryUSD = BigInt(0);
+  let poolUSD = BigInt(0);
+  let keeperUSD = BigInt(0);
 
   for (const fee of response.feeStats) {
     const feeUsd = BigInt(fee.feeUsd);
     const total = BigInt(fee.fee);
-    dailyUserFeesUSD += feeUsd;
+    tradingFeesUSD += feeUsd;
 
     if (total === 0n) {
       continue;
     }
-    const treasuryUsd = (feeUsd * BigInt(fee.treasuryFee)) / total;
-    dailyTreasuryUSD += treasuryUsd;
-    dailyPoolAndKeeperUSD += feeUsd - treasuryUsd;
+    treasuryUSD += (feeUsd * BigInt(fee.treasuryFee)) / total;
+    poolUSD += (feeUsd * BigInt(fee.poolFee)) / total;
+    keeperUSD += (feeUsd * BigInt(fee.keeperFee)) / total;
   }
 
-  for (const stat of response.tradingStats) {
-    dailyFundingUSD += BigInt(stat.fundingFeeUsd);
-  }
-
-  const dailyVolume = Number(dailyVolumeUSD) / 1e18;
-  const dailyUserFees = Number(dailyUserFeesUSD) / 1e18;
-  const dailyHoldersRevenue = Number(dailyTreasuryUSD) / 1e18;
-  const dailySupplySideRevenue =
-    (Number(dailyPoolAndKeeperUSD) + Number(dailyFundingUSD)) / 1e18;
-  const dailyFees = dailyUserFees + Number(dailyFundingUSD) / 1e18;
+  const dailyFees = Number(tradingFeesUSD) / 1e18;
+  const dailyHoldersRevenue = Number(treasuryUSD) / 1e18;
+  const dailyLpFees = Number(poolUSD) / 1e18;
+  const dailyKeeperFees = Number(keeperUSD) / 1e18;
+  const attributed = dailyHoldersRevenue + dailyLpFees + dailyKeeperFees;
+  const dust = dailyFees - attributed;
 
   return {
-    dailyVolume,
-    dailyUserFees,
+    dailyVolume: sumVolume(response),
     dailyFees,
+    dailyUserFees: dailyFees,
     dailyProtocolRevenue: 0,
     dailyHoldersRevenue,
-    dailySupplySideRevenue,
+    dailySupplySideRevenue: dailyLpFees + dailyKeeperFees + dust,
+    dailyLpFees: dailyLpFees + dust,
+    dailyKeeperFees,
   };
 };
 
 const sumPreBbbStats = (response: GraphDayResponse): DayMetrics => {
-  let dailyVolumeUSD = BigInt(0);
-  let dailyFeeUSD = BigInt(0);
-  let dailyFundingFeeUSD = BigInt(0);
-
-  for (const vol of response.volumeStats) {
-    dailyVolumeUSD += BigInt(vol.volumeUsd);
-  }
+  let tradingFeesUSD = BigInt(0);
   for (const fee of response.feeStats) {
-    dailyFeeUSD += BigInt(fee.feeUsd);
+    tradingFeesUSD += BigInt(fee.feeUsd);
   }
-  for (const stat of response.tradingStats) {
-    dailyFundingFeeUSD += BigInt(stat.fundingFeeUsd);
-  }
-
-  return attributePreBbb(
-    Number(dailyVolumeUSD) / 1e18,
-    Number(dailyFeeUSD) / 1e18,
-    (Number(dailyFeeUSD) + Number(dailyFundingFeeUSD)) / 1e18,
-  );
+  return attributePreBbb(sumVolume(response), Number(tradingFeesUSD) / 1e18);
 };
 
 const queryOldPerpsDay = async (todaysTimestamp: number): Promise<DayMetrics> => {
@@ -358,7 +358,6 @@ const queryNewPerpsDay = async (todaysTimestamp: number): Promise<DayMetrics> =>
       `SparkDEX New Perps: missing daily stats for ${todaysTimestamp}`,
     );
   }
-  // New Perps launched after BBB_START; always use treasury → BBB.
   return sumTreasuryBbbStats(response);
 };
 
@@ -385,7 +384,7 @@ const loadOldPerpsSnapshot = async (): Promise<Record<string, Partial<DayMetrics
 };
 
 const fetchOldPerpsDay = async (todaysTimestamp: number): Promise<DayMetrics> => {
-  if (OLD_PERPS_LAST_DAY !== null && todaysTimestamp > OLD_PERPS_LAST_DAY) {
+  if (todaysTimestamp > OLD_PERPS_LAST_DAY) {
     return emptyDay();
   }
 
@@ -412,35 +411,101 @@ const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
       ? await queryNewPerpsDay(todaysTimestamp)
       : emptyDay();
 
-  const totals = addDays(oldPerps, newPerps);
-  const dailyRevenue = totals.dailyProtocolRevenue + totals.dailyHoldersRevenue;
+  const metrics = addDays(oldPerps, newPerps);
+
+  const dailyFees = options.createBalances();
+  const dailyUserFees = options.createBalances();
+  const dailyRevenue = options.createBalances();
+  const dailyProtocolRevenue = options.createBalances();
+  const dailyHoldersRevenue = options.createBalances();
+  const dailySupplySideRevenue = options.createBalances();
+
+  dailyFees.addUSDValue(metrics.dailyFees, METRIC.MARGIN_FEES);
+  dailyUserFees.addUSDValue(metrics.dailyUserFees, METRIC.MARGIN_FEES);
+
+  if (metrics.dailyProtocolRevenue > 0) {
+    dailyProtocolRevenue.addUSDValue(
+      metrics.dailyProtocolRevenue,
+      METRIC.MARGIN_FEES,
+    );
+    dailyRevenue.addUSDValue(metrics.dailyProtocolRevenue, METRIC.MARGIN_FEES);
+  }
+
+  if (metrics.dailyHoldersRevenue > 0) {
+    dailyHoldersRevenue.addUSDValue(
+      metrics.dailyHoldersRevenue,
+      METRIC.TOKEN_BUY_BACK,
+    );
+    dailyRevenue.addUSDValue(
+      metrics.dailyHoldersRevenue,
+      METRIC.TOKEN_BUY_BACK,
+    );
+  }
+
+  if (metrics.dailyLpFees > 0) {
+    dailySupplySideRevenue.addUSDValue(metrics.dailyLpFees, METRIC.LP_FEES);
+  }
+  if (metrics.dailyKeeperFees > 0) {
+    dailySupplySideRevenue.addUSDValue(metrics.dailyKeeperFees, KEEPER_FEES);
+  }
 
   return {
-    dailyVolume: totals.dailyVolume,
-    dailyFees: totals.dailyFees,
-    dailyUserFees: totals.dailyUserFees,
+    dailyVolume: metrics.dailyVolume,
+    dailyFees,
+    dailyUserFees,
     dailyRevenue,
-    dailyProtocolRevenue: totals.dailyProtocolRevenue,
-    dailyHoldersRevenue: totals.dailyHoldersRevenue,
-    dailySupplySideRevenue: totals.dailySupplySideRevenue,
+    dailyProtocolRevenue,
+    dailyHoldersRevenue,
+    dailySupplySideRevenue,
   };
 };
 
 const methodology = {
   Volume:
-    "Old Perps + New Perps daily perpetual volume (isolated deployments; overlapping days are added). Old Perps from sparkdex-trade while live, then a frozen daily snapshot after the V21 subgraph is retired; New Perps from sparkdex-trade-v2 starting 2026-06-23.",
+    "Sum of daily perpetual trading volume on Old Perps and New Perps. The two deployments are isolated; overlapping days are added together.",
   Fees:
-    "Old Perps + New Perps: user trading fees plus funding fees (summed on overlapping days).",
+    "Trading fees paid by perpetual traders on Old Perps and New Perps (summed on overlapping days).",
   UserFees:
-    "Old Perps + New Perps: user trading fees only (summed on overlapping days).",
+    "Same as Fees — trading fees paid by perpetual traders.",
   Revenue:
-    "Pre-2026-05-18 (Old Perps): 60% of fees retained as protocol revenue. From 2026-05-18 (governance proposal B): 100% of subgraph treasuryFee used for SPRK buyback/burn (BBB) on both Old Perps and New Perps.",
+    "Before 2026-05-18: 60% of trading fees kept by the protocol. From 2026-05-18 (governance proposal B): the protocol treasury share of trading fees is used to buy back and burn SPRK.",
   ProtocolRevenue:
-    "Pre-2026-05-18: 60% of Old Perps fees. From 2026-05-18: 0 — treasury share is fully allocated to BBB (HoldersRevenue).",
+    "Before 2026-05-18: 60% of trading fees. From 2026-05-18: none — the treasury share goes to SPRK buyback and burn instead.",
   HoldersRevenue:
-    "From 2026-05-18 (proposal B): 100% of subgraph treasuryFee on Old Perps and New Perps allocated to SPRK buyback/burn. Before that date: not attributed separately (protocol kept the non-LP share).",
+    "From 2026-05-18: the protocol treasury share of trading fees used to buy back and burn SPRK. Before that date: not reported separately.",
   SupplySideRevenue:
-    "Pre-2026-05-18: 40% of Old Perps fees to LPs. From 2026-05-18: poolFee + keeperFee + funding fees to liquidity providers (Old Perps + New Perps).",
+    "Before 2026-05-18: 40% of trading fees to liquidity providers. From 2026-05-18: the LP and keeper shares of trading fees.",
+};
+
+const breakdownMethodology = {
+  Fees: {
+    [METRIC.MARGIN_FEES]:
+      "Perpetual trading fees paid by traders on Old Perps and New Perps.",
+  },
+  UserFees: {
+    [METRIC.MARGIN_FEES]:
+      "Trading fees paid by perpetual traders.",
+  },
+  Revenue: {
+    [METRIC.MARGIN_FEES]:
+      "Before 2026-05-18: protocol share of trading fees (60%).",
+    [METRIC.TOKEN_BUY_BACK]:
+      "From 2026-05-18: treasury share of trading fees used to buy back and burn SPRK.",
+  },
+  ProtocolRevenue: {
+    [METRIC.MARGIN_FEES]:
+      "Before 2026-05-18: 60% of trading fees to the protocol. From 2026-05-18: none.",
+  },
+  HoldersRevenue: {
+    [METRIC.TOKEN_BUY_BACK]:
+      "From 2026-05-18: treasury share of trading fees used to buy back and burn SPRK.",
+  },
+  SupplySideRevenue: {
+    [METRIC.LP_FEES]:
+      "Trading fees distributed to perpetual liquidity providers.",
+    [KEEPER_FEES]:
+      "Trading fees paid to keepers.",
+  },
 };
 
 const adapter: SimpleAdapter = {
@@ -448,6 +513,7 @@ const adapter: SimpleAdapter = {
   chains: [CHAIN.FLARE],
   start: "2025-10-15",
   methodology,
+  breakdownMethodology,
 };
 
 export default adapter;

--- a/dexs/sparkdex-perps/index.ts
+++ b/dexs/sparkdex-perps/index.ts
@@ -15,9 +15,8 @@ const ENDPOINT_NEW_PERPS =
 const NEW_PERPS_START = 1782172800; // 2026-06-23
 
 /**
- * Governance proposal B (100% of protocol revenue → SPRK buyback/burn) effective
- * date: https://sparkdex.ai/governance/proposal/6a046cbecd38e8c7fea826ee
- * (passed 2026-05-17; counted from 2026-05-18 UTC).
+ * From this UTC day, the protocol treasury share of trading fees is used to buy
+ * back and burn SPRK (no separate protocol revenue retention).
  */
 const BBB_START = 1779062400; // 2026-05-18
 
@@ -468,7 +467,7 @@ const methodology = {
   UserFees:
     "Same as Fees — trading fees paid by perpetual traders.",
   Revenue:
-    "Before 2026-05-18: 60% of trading fees kept by the protocol. From 2026-05-18 (governance proposal B): the protocol treasury share of trading fees is used to buy back and burn SPRK.",
+    "Before 2026-05-18: 60% of trading fees kept by the protocol. From 2026-05-18: the protocol treasury share of trading fees is used to buy back and burn SPRK.",
   ProtocolRevenue:
     "Before 2026-05-18: 60% of trading fees. From 2026-05-18: none — the treasury share goes to SPRK buyback and burn instead.",
   HoldersRevenue:


### PR DESCRIPTION
## Summary

Updates the SparkDEX perpetuals adapter on Flare (`dexs/sparkdex-perps`) to:

- Track **Old Perps** and **New Perps** as separate, isolated deployments and **sum** volume/fees on overlapping days
- Switch New Perps data to the `sparkdex-trade-v2` Goldsky subgraph (from 2026-06-23)
- From **2026-05-18**, attribute the protocol treasury share of trading fees to SPRK buyback/burn (`dailyHoldersRevenue`), with `dailyProtocolRevenue = 0`
- Align fee/revenue reporting with DefiLlama fees guidelines (`createBalances`, labels, `breakdownMethodology`)

## Background

SparkDEX runs two perpetual deployments:

| | Old Perps | New Perps |
|---|---|---|
| Subgraph | `sparkdex-trade` | `sparkdex-trade-v2` |
| Data from | 2025-10-15 | 2026-06-23 |
| Status | Winding down; full stop planned **2026-07-31 12:00 UTC** | Active |

Markets may share names, but pools and trading are fully isolated. On overlapping days, Old and New metrics are **added**.

## Changes

### Data sources
- **Old Perps**: live `sparkdex-trade` while still indexed; empty wind-down days return 0 (no throw) until `OLD_PERPS_LAST_DAY` (2026-07-31)
- **New Perps**: `sparkdex-trade-v2` from 2026-06-23
- Adapter `start`: `2025-10-15`

### Revenue attribution (trading fees only)

**Before 2026-05-18**
- `dailyProtocolRevenue` = 60% of trading fees
- `dailySupplySideRevenue` = 40% of trading fees
- `dailyHoldersRevenue` = 0

**From 2026-05-18 (Old Perps + New Perps)**
- `dailyHoldersRevenue` = protocol treasury share → SPRK buyback/burn
- `dailyProtocolRevenue` = 0
- `dailySupplySideRevenue` = LP + keeper shares
- `dailyRevenue` = Protocol + Holders

### Fees guidelines alignment
- Uses `options.createBalances()` with labels (`Margin Fees`, `LP Fees`, `Keeper Fees`, `Token Buy Back`)
- Adds `breakdownMethodology`
- Uses `options.startOfDay` for the UTC day window

### Future: Old Perps subgraph retirement
When V21 indexing is fully retired, Old Perps history will be served from a frozen daily snapshot at:

`https://api.sparkdex.ai/defillama/sparkdex-perps-v21-daily.json`

`OLD_PERPS_USE_SNAPSHOT` is currently `false`. When enabled, missing snapshot days throw (never return 0) so refill cannot overwrite stored history.

## Returned fields

- `dailyVolume`
- `dailyFees` / `dailyUserFees` (trading fees)
- `dailyRevenue`
- `dailyProtocolRevenue`
- `dailyHoldersRevenue`
- `dailySupplySideRevenue`

## Test plan

- [ ] Pre-cutover day (e.g. `2026-05-17`): `dailyProtocolRevenue > 0`, `dailyHoldersRevenue = 0`
- [ ] Cutover day (e.g. `2026-05-18`): `dailyProtocolRevenue = 0`, `dailyHoldersRevenue > 0`
- [ ] Overlap day (e.g. `2026-07-12`): Old + New summed; `Fees ≈ Revenue + SupplySide`
- [ ] Wind-down empty Old day (e.g. `2026-07-15`): succeeds using New Perps only

```bash
npm test -- dexs sparkdex-