### PR TITLE
angstrom: derive pool list dynamically from Initialize logs

### DIFF
--- a/dexs/angstrom/index.ts
+++ b/dexs/angstrom/index.ts
@@ -1,44 +1,33 @@
 import * as sdk from "@defillama/sdk";
 import { FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
-import ADDRESSES from '../../helpers/coreAssets.json';
 import { decode_bundle } from './helper/index'; // taken from https://github.com/SorellaLabs/angstrom-assembly-helper/tree/main
 
 interface IUniswapConfig {
   poolManager: string;
-  positionManager: string;
   hook: string;
   source: 'LOGS';
   start: string;
-  poolIds: Array<string>;
+  startBlock: number;
 }
 
 interface IPool {
   poolId: string;
-  poolKey: string;
   currency0: string;
   currency1: string;
 }
 
 const SwapEvent = 'event Swap(bytes32 indexed id, address indexed sender, int128 amount0, int128 amount1, uint160 sqrtPriceX96, uint128 liquidity, int24 tick, uint24 fee)';
-const FunctionPoolKeys = 'function poolKeys(bytes25) view returns(address currency0, address currency1, uint24 fee, int24 tickSpacing, address hooks)';
+const InitializeEvent = 'event Initialize(bytes32 indexed id, address indexed currency0, address indexed currency1, uint24 fee, int24 tickSpacing, address hooks, uint160 sqrtPriceX96, int24 tick)';
 
 const Configs: Record<string, IUniswapConfig> = {
   [CHAIN.ETHEREUM]: {
     poolManager: '0x000000000004444c5dc75cB358380D2e3dE08A90',
-    positionManager: '0xbd216513d74c8cf14cf4747e6aaa6420ff64ee9e',
     hook: '0x0000000aa232009084Bd71A5797d089AA4Edfad4',
     source: 'LOGS',
     start: '2025-07-23',
-    poolIds: [
-      '0xe500210c7ea6bfd9f69dce044b09ef384ec2b34832f132baec3b418208e3a657',
-      '0x90078845bceb849b171873cfbc92db8540e9c803ff57d9d21b1215ec158e79b3',
-    ],
+    startBlock: 22971782, // Angstrom hook deployment block
   },
-}
-
-function getPoolKey(poolId: string): string {
-  return poolId.slice(0, 52);
 }
 
 async function fetch(options: FetchOptions) {
@@ -88,42 +77,35 @@ async function fetch(options: FetchOptions) {
 
   // --- User swap fees from Uniswap v4 pool manager logs ---
   if (config.source === 'LOGS') {
+    const initLogs = await options.getLogs({
+      target: config.poolManager,
+      eventAbi: InitializeEvent,
+      fromBlock: config.startBlock,
+      toBlock: Number(options.toApi.block),
+    });
+
+    const pools: { [poolId: string]: IPool } = {}
+    for (const log of initLogs) {
+      if (String(log.hooks).toLowerCase() !== config.hook.toLowerCase()) continue
+      const poolId = String(log.id)
+      pools[poolId] = {
+        poolId,
+        currency0: String(log.currency0),
+        currency1: String(log.currency1),
+      }
+    }
+
     const events = await options.getLogs({
       target: config.poolManager,
       eventAbi: SwapEvent,
     });
 
-    // query pools info
-    const poolKeys = await options.api.multiCall({
-      abi: FunctionPoolKeys,
-      target: config.positionManager,
-      calls: config.poolIds.map(poolId => {
-        return {
-          params: [getPoolKey(poolId)],
-        }
-      }),
-      permitFailure: true,
-    })
-
-    const pools: { [key: string]: IPool | null } = {}
-    for (let i = 0; i < config.poolIds.length; i++) {
-      if (poolKeys[i] && (poolKeys[i].currency0 !== ADDRESSES.null || poolKeys[i].currency1 !== ADDRESSES.null)) {
-        pools[config.poolIds[i]] = {
-          poolId: config.poolIds[i],
-          poolKey: getPoolKey(config.poolIds[i]),
-          currency0: String(poolKeys[i].currency0),
-          currency1: String(poolKeys[i].currency1),
-        }
-      }
-    }
-
     for (const event of events) {
-      const poolId = String(event.id)
-      if (pools[poolId] as IPool) {
-        const token = (pools[poolId] as IPool).currency0
-        dailyUserFees.add(token, Math.abs(Number(event.amount0)) * (Number(event.fee) / 1e6))
-        dailyVolume.add(token, Math.abs(Number(event.amount0)))
-      }
+      const pool = pools[String(event.id)]
+      if (!pool) continue
+      const token = pool.currency0
+      dailyUserFees.add(token, Math.abs(Number(event.amount0)) * (Number(event.fee) / 1e6))
+      dailyVolume.add(token, Math.abs(Number(event.amount0)))
     }
   }
 
@@ -143,6 +125,7 @@ const adapter: SimpleAdapter = {
   pullHourly: true,
   // doublecounted: true,  // most of the fee come from the block auction
   methodology: {
+    Volume: 'Swap volume across all Angstrom-hooked Uniswap v4 pools, measured as the token0 amount of each swap.',
     Fees: 'Includes user swap fees from Uniswap v4 pool swaps and block auction fees from Angstrom bundles distributed to LPs.',
     UserFees: 'Swap fees paid by users on each trade.',
     SupplySideRevenue: 'All fees (swap fees + block auction rewards) are distributed to LPs.',


### PR DESCRIPTION
Removes the hardcoded Angstrom pool list by discovering pools on-chain, ensuring new pools are tracked automatically.

## Changes

- Replaced the fixed `poolIds` list with on-chain discovery from Uniswap v4 `Initialize` events.
- Filters pools by the Angstrom hook and derives token metadata directly from the event.
- Removes the now-unneeded `poolKeys` multicall and `PositionManager` dependency.

## Verification

- Confirmed the current on-chain configuration still contains the same two pools, so output is unchanged today.
- Verified the discovered pools match the previous metadata and produce identical pool IDs.
- Replayed ~20 hours of live swaps: **3,712** swaps matched with correct volume and fee attribution.