### PR TITLE
temple: add fees tracking

### DIFF
--- a/dexs/temple/index.ts
+++ b/dexs/temple/index.ts
@@ -4,8 +4,9 @@ import fetchURL from "../../utils/fetchURL";
 
 const TICKERS_URL = "https://api.templedigitalgroup.com/api/exchange/tickers";
 
-// Temple CLOB trading fees: maker 1 bps + taker 2 bps = 3 bps per matched notional, all retained by the protocol.
-const FEE_RATE = (1 + 2) / 10000;
+const MAKER_FEE_BPS = 1;
+const TAKER_FEE_BPS = 2;
+const BPS = 10000;
 
 type TempleTicker = {
   ticker_id: string;
@@ -14,7 +15,7 @@ type TempleTicker = {
   target_volume: string;
 };
 
-const fetch = async (_options: FetchOptions): Promise<FetchResult> => {
+const fetch = async (options: FetchOptions): Promise<FetchResult> => {
   const tickers: TempleTicker[] = await fetchURL(TICKERS_URL);
   if (!Array.isArray(tickers) || tickers.length === 0)
     throw new Error("Temple tickers response empty or malformed");
@@ -30,7 +31,9 @@ const fetch = async (_options: FetchOptions): Promise<FetchResult> => {
     return sum + volume;
   }, 0);
 
-  const dailyFees = dailyVolume * FEE_RATE;
+  const dailyFees = options.createBalances();
+  dailyFees.addUSDValue(dailyVolume * MAKER_FEE_BPS / BPS, "Maker Fees")
+  dailyFees.addUSDValue(dailyVolume * TAKER_FEE_BPS / BPS, "Taker Fees")
 
   return {
     dailyVolume,
@@ -45,11 +48,26 @@ const methodology = {
   Volume:
     "24h spot orderbook volume across all USDA-quoted Temple markets, summing each ticker's quote-side target_volume from Temple's public exchange-listing API. USDA is a fiat-backed 1:1 USD stablecoin, so quote volume is treated as USD; non-USDA markets are rejected.",
   Fees: "Trading fees charged by the Temple orderbook: 1 bps maker + 2 bps taker = 3 bps applied to daily volume.",
-  Revenue: "All trading fees are retained by the protocol; there is no fee rebate to market makers.",
-  ProtocolRevenue: "Same as Revenue — the full 3 bps of volume is retained by Temple.",
+  Revenue: "All trading fees (1 bps maker + 2 bps taker) are retained by the protocol; there is no fee rebate to market makers.",
+  ProtocolRevenue: "All trading fees (1 bps maker + 2 bps taker) are retained by the protocol; there is no fee rebate to market makers.",
   SupplySideRevenue:
     "Zero. No trading-fee share is paid to liquidity providers or market makers; the monthly Canton Coin leaderboard is a separately-funded incentive, not a fee redistribution.",
 };
+
+const breakdownMethodology = {
+  Fees: {
+    "Maker Fees": "1 bps maker fee applied to daily volume.",
+    "Taker Fees": "2 bps taker fee applied to daily volume.",
+  },
+  Revenue: {
+    "Maker Fees": "1 bps maker fee applied to daily volume.",
+    "Taker Fees": "2 bps taker fee applied to daily volume.",
+  },
+  ProtocolRevenue: {
+    "Maker Fees": "1 bps maker fee applied to daily volume.",
+    "Taker Fees": "2 bps taker fee applied to daily volume.",
+  },
+}
 
 const adapter: SimpleAdapter = {
   version: 2,
@@ -57,6 +75,7 @@ const adapter: SimpleAdapter = {
   chains: [CHAIN.CANTON],
   runAtCurrTime: true,
   methodology,
+  breakdownMethodology,
 };
 
 export default adapter;

--- a/dexs/temple/index.ts
+++ b/dexs/temple/index.ts
@@ -1,8 +1,11 @@
-import { FetchOptions, FetchResultVolume, SimpleAdapter } from "../../adapters/types";
+import { FetchOptions, FetchResult, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 import fetchURL from "../../utils/fetchURL";
 
 const TICKERS_URL = "https://api.templedigitalgroup.com/api/exchange/tickers";
+
+// Temple CLOB trading fees: maker 1 bps + taker 2 bps = 3 bps per matched notional, all retained by the protocol.
+const FEE_RATE = (1 + 2) / 10000;
 
 type TempleTicker = {
   ticker_id: string;
@@ -11,10 +14,15 @@ type TempleTicker = {
   target_volume: string;
 };
 
-const fetch = async (_options: FetchOptions): Promise<FetchResultVolume> => {
+const fetch = async (_options: FetchOptions): Promise<FetchResult> => {
   const tickers: TempleTicker[] = await fetchURL(TICKERS_URL);
+  if (!Array.isArray(tickers) || tickers.length === 0)
+    throw new Error("Temple tickers response empty or malformed");
 
   const dailyVolume = tickers.reduce((sum, ticker) => {
+    if (ticker.target_currency !== "USDA")
+      throw new Error(`Unexpected non-USDA quote for ticker ${ticker.ticker_id}: ${ticker.target_currency}`);
+
     const volume = Number(ticker.target_volume);
     if (!Number.isFinite(volume))
       throw new Error(`Invalid target_volume for ticker ${ticker.ticker_id}: ${ticker.target_volume}`);
@@ -22,12 +30,25 @@ const fetch = async (_options: FetchOptions): Promise<FetchResultVolume> => {
     return sum + volume;
   }, 0);
 
-  return { dailyVolume };
+  const dailyFees = dailyVolume * FEE_RATE;
+
+  return {
+    dailyVolume,
+    dailyFees,
+    dailyRevenue: dailyFees,
+    dailyProtocolRevenue: dailyFees,
+    dailySupplySideRevenue: 0,
+  };
 };
 
 const methodology = {
   Volume:
-    "24h spot orderbook volume for all mainnet-enabled Temple Lightspeed markets, fetched from Temple's public exchange-listing API. The adapter sums each ticker's quote-side `target_volume`; current production markets quote in USDA, treated as USD-pegged volume.",
+    "24h spot orderbook volume across all USDA-quoted Temple markets, summing each ticker's quote-side target_volume from Temple's public exchange-listing API. USDA is a fiat-backed 1:1 USD stablecoin, so quote volume is treated as USD; non-USDA markets are rejected.",
+  Fees: "Trading fees charged by the Temple orderbook: 1 bps maker + 2 bps taker = 3 bps applied to daily volume.",
+  Revenue: "All trading fees are retained by the protocol; there is no fee rebate to market makers.",
+  ProtocolRevenue: "Same as Revenue — the full 3 bps of volume is retained by Temple.",
+  SupplySideRevenue:
+    "Zero. No trading-fee share is paid to liquidity providers or market makers; the monthly Canton Coin leaderboard is a separately-funded incentive, not a fee redistribution.",
 };
 
 const adapter: SimpleAdapter = {


### PR DESCRIPTION
Adds fee tracking and improves validation for the Temple adapter.

## Changes

- Added fee metrics:
  - `dailyFees = dailyRevenue = dailyProtocolRevenue = 3 bps × volume`
  - `dailySupplySideRevenue = 0`
- Added methodology for all reported metrics.
- Added a USDA quote check to prevent future markets from being mispriced.
- Throw on empty or malformed API responses instead of reporting `$0`.
- Updated the return type from `FetchResultVolume` to `FetchResult`.

## Verification

- Verified against a live API response: **$5.47M** daily volume and **$1.64k** daily fees.