### PR TITLE
[add] Quiver - fees and revenue adapter

### DIFF
--- a/fees/quiver.ts
+++ b/fees/quiver.ts
@@ -13,6 +13,7 @@
 //
 // Contracts (Robinhood Chain):
 //   factoryV3 (active):     0xaA8Af274bba2b9dE53119CB117C8AC6A39e6F5Aa  block 10113641 (2026-07-15)
+//                           FACTORY_V3_DEPLOY_BLOCK gates live teamFeeRecipient reads
 //   lpLockerV3:             0x38daBB90C96eea7B90613ABbf019ABCe0808CF12  block 10113611
 //   factory (legacy v4):    0x3eDDD33805652c933a981F59055ef561660c54D2  block 9787616  (2026-07-14)
 //   lpLocker (legacy v4):   0x11e0B26508788ABbc6e1F2df8A86C4F10b897a98  block 9787616
@@ -44,10 +45,13 @@ import { CHAIN } from "../helpers/chains";
 import { METRIC } from "../helpers/metrics";
 
 const FACTORY_V3 = "0xaA8Af274bba2b9dE53119CB117C8AC6A39e6F5Aa";
+const FACTORY_V3_DEPLOY_BLOCK = 10113641;
 const LP_LOCKER_V3 = "0x38daBB90C96eea7B90613ABbf019ABCe0808CF12";
 const LP_LOCKER_V4 = "0x11e0B26508788ABbc6e1F2df8A86C4F10b897a98";
 const FEE_LOCKER = "0xd1B13382fDa3E165658F1d3502d6616A31B62491";
-// Historical + current protocol fee recipient (factory.teamFeeRecipient / owner).
+// Known protocol fee recipient from on-chain factory.teamFeeRecipient / owner EOA
+// (0x9748…AE5a). Used for all ranges, and as the sole classifier before FACTORY_V3
+// exists so we never eth_call a contract that has not been deployed yet.
 const PROTOCOL_RECIPIENT = "0x9748D3fe02890f155489dc4F76e413Bdcd97AE5a";
 
 const BPS = 10_000n;
@@ -69,10 +73,11 @@ const fetch = async (options: FetchOptions) => {
   const dailyRevenue = options.createBalances();
   const dailySupplySideRevenue = options.createBalances();
 
-  // Prefer the live factory recipient when the v3 factory exists; fall back to the
-  // known protocol address so historical ranges before factoryV3 still work.
+  // Default to the known historical protocol recipient. Only read the live
+  // factory.teamFeeRecipient once the v3 factory deployment block is in range.
   let teamFeeRecipient = PROTOCOL_RECIPIENT;
-  try {
+  const toBlock = await options.getToBlock();
+  if (toBlock >= FACTORY_V3_DEPLOY_BLOCK) {
     const current: string = await options.api.call({
       target: FACTORY_V3,
       abi: "function teamFeeRecipient() view returns (address)",
@@ -80,8 +85,6 @@ const fetch = async (options: FetchOptions) => {
     if (current && current !== "0x0000000000000000000000000000000000000000") {
       teamFeeRecipient = current;
     }
-  } catch {
-    // factoryV3 not yet deployed in this block range
   }
 
   // --- Legacy Uniswap v4 path: fee shares stored by lpLocker into feeLocker ---

--- a/fees/quiver.ts
+++ b/fees/quiver.ts
@@ -44,14 +44,10 @@ import { Adapter, FetchOptions } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
 import { METRIC } from "../helpers/metrics";
 
-const FACTORY_V3 = "0xaA8Af274bba2b9dE53119CB117C8AC6A39e6F5Aa"; // https://robinhoodchain.blockscout.com/address/0xaA8Af274bba2b9dE53119CB117C8AC6A39e6F5Aa
-const FACTORY_V3_DEPLOY_BLOCK = 10113641; // https://robinhoodchain.blockscout.com/block/10113641
-const LP_LOCKER_V3 = "0x38daBB90C96eea7B90613ABbf019ABCe0808CF12"; // https://robinhoodchain.blockscout.com/address/0x38daBB90C96eea7B90613ABbf019ABCe0808CF12
-const LP_LOCKER_V4 = "0x11e0B26508788ABbc6e1F2df8A86C4F10b897a98"; // https://robinhoodchain.blockscout.com/address/0x11e0B26508788ABbc6e1F2df8A86C4F10b897a98
-const FEE_LOCKER = "0xd1B13382fDa3E165658F1d3502d6616A31B62491"; // https://robinhoodchain.blockscout.com/address/0xd1B13382fDa3E165658F1d3502d6616A31B62491
-// Verified factory.teamFeeRecipient / owner EOA. Hardcoded (no historical eth_call)
-// because Robinhood public RPC often lacks archive state ("missing trie node") and
-// this address has not rotated. Update this constant if setTeamFeeRecipient changes it.
+const FACTORY_V3_DEPLOY_BLOCK = 10113641;
+const LP_LOCKER_V3 = "0x38daBB90C96eea7B90613ABbf019ABCe0808CF12";
+const LP_LOCKER_V4 = "0x11e0B26508788ABbc6e1F2df8A86C4F10b897a98";
+const FEE_LOCKER = "0xd1B13382fDa3E165658F1d3502d6616A31B62491";
 const PROTOCOL_RECIPIENT = "0x9748D3fe02890f155489dc4F76e413Bdcd97AE5a";
 
 const BPS = 10_000n;
@@ -94,28 +90,17 @@ const fetch = async (options: FetchOptions) => {
   const collectedLogs = await options.getLogs({
     target: LP_LOCKER_V3,
     eventAbi: REWARDS_COLLECTED,
-    fromBlock: FACTORY_V3_DEPLOY_BLOCK,
   });
 
   if (collectedLogs.length) {
     const rewardInfos = await options.api.multiCall({
       abi: TOKEN_REWARDS_V3,
       calls: collectedLogs.map((log: any) => ({ target: LP_LOCKER_V3, params: [log.token] })),
-      permitFailure: true,
     });
 
     for (let i = 0; i < collectedLogs.length; i++) {
       const log = collectedLogs[i];
       const info = rewardInfos[i];
-      // permitFailure: multicall returned null/undefined — recoverable RPC/contract failure
-      if (!info) {
-        console.error(
-          `[quiver] tokenRewards failed for token=${log.token} locker=${LP_LOCKER_V3}`,
-        );
-        continue;
-      }
-      // Present but empty recipients/bps: malformed or unconfigured reward data — skip quietly
-      if (!info.recipients?.length || !info.rewardBps?.length) continue;
 
       const amount0 = BigInt(log.amount0);
       const amount1 = BigInt(log.amount1);
@@ -162,7 +147,7 @@ const methodology = {
   Revenue:
     "Portion of collected LP fees credited to the Quiver protocol fee recipient (factory.teamFeeRecipient).",
   ProtocolRevenue:
-    "Same as Revenue — LP fee share retained by the Quiver protocol fee recipient.",
+    "Portion of collected LP fees credited to the Quiver protocol fee recipient (factory.teamFeeRecipient).",
   SupplySideRevenue:
     "Portion of collected LP fees credited to token creators (and any other non-protocol reward recipients configured at launch).",
 };

--- a/fees/quiver.ts
+++ b/fees/quiver.ts
@@ -13,7 +13,7 @@
 //
 // Contracts (Robinhood Chain):
 //   factoryV3 (active):     0xaA8Af274bba2b9dE53119CB117C8AC6A39e6F5Aa  block 10113641 (2026-07-15)
-//                           FACTORY_V3_DEPLOY_BLOCK gates live teamFeeRecipient reads
+//                           documented as FACTORY_V3 / FACTORY_V3_DEPLOY_BLOCK (no runtime eth_call)
 //   lpLockerV3:             0x38daBB90C96eea7B90613ABbf019ABCe0808CF12  block 10113611
 //   factory (legacy v4):    0x3eDDD33805652c933a981F59055ef561660c54D2  block 9787616  (2026-07-14)
 //   lpLocker (legacy v4):   0x11e0B26508788ABbc6e1F2df8A86C4F10b897a98  block 9787616
@@ -49,9 +49,9 @@ const FACTORY_V3_DEPLOY_BLOCK = 10113641; // https://robinhoodchain.blockscout.c
 const LP_LOCKER_V3 = "0x38daBB90C96eea7B90613ABbf019ABCe0808CF12"; // https://robinhoodchain.blockscout.com/address/0x38daBB90C96eea7B90613ABbf019ABCe0808CF12
 const LP_LOCKER_V4 = "0x11e0B26508788ABbc6e1F2df8A86C4F10b897a98"; // https://robinhoodchain.blockscout.com/address/0x11e0B26508788ABbc6e1F2df8A86C4F10b897a98
 const FEE_LOCKER = "0xd1B13382fDa3E165658F1d3502d6616A31B62491"; // https://robinhoodchain.blockscout.com/address/0xd1B13382fDa3E165658F1d3502d6616A31B62491
-// Known protocol fee recipient from on-chain factory.teamFeeRecipient / owner EOA
-// (0x9748…AE5a). Used for all ranges, and as the sole classifier before FACTORY_V3
-// exists so we never eth_call a contract that has not been deployed yet.
+// Verified factory.teamFeeRecipient / owner EOA. Hardcoded (no historical eth_call)
+// because Robinhood public RPC often lacks archive state ("missing trie node") and
+// this address has not rotated. Update this constant if setTeamFeeRecipient changes it.
 const PROTOCOL_RECIPIENT = "0x9748D3fe02890f155489dc4F76e413Bdcd97AE5a";
 
 const BPS = 10_000n;
@@ -63,29 +63,13 @@ const STORE_TOKENS =
 const TOKEN_REWARDS_V3 =
   "function tokenRewards(address token) view returns (address pool, (int24 tickLower, int24 tickUpper)[] positions, address[] recipients, uint16[] rewardBps)";
 
-const isProtocolRecipient = (addr: string, teamFeeRecipient: string) => {
-  const a = addr.toLowerCase();
-  return a === PROTOCOL_RECIPIENT.toLowerCase() || a === teamFeeRecipient.toLowerCase();
-};
+const isProtocolRecipient = (addr: string) =>
+  addr.toLowerCase() === PROTOCOL_RECIPIENT.toLowerCase();
 
 const fetch = async (options: FetchOptions) => {
   const dailyFees = options.createBalances();
   const dailyRevenue = options.createBalances();
   const dailySupplySideRevenue = options.createBalances();
-
-  // Default to the known historical protocol recipient. Only read the live
-  // factory.teamFeeRecipient once the v3 factory deployment block is in range.
-  let teamFeeRecipient = PROTOCOL_RECIPIENT;
-  const toBlock = await options.getToBlock();
-  if (toBlock >= FACTORY_V3_DEPLOY_BLOCK) {
-    const current: string = await options.api.call({
-      target: FACTORY_V3,
-      abi: "function teamFeeRecipient() view returns (address)",
-    });
-    if (current && current !== "0x0000000000000000000000000000000000000000") {
-      teamFeeRecipient = current;
-    }
-  }
 
   // --- Legacy Uniswap v4 path: fee shares stored by lpLocker into feeLocker ---
   const storeLogs = await options.getLogs({
@@ -99,7 +83,7 @@ const fetch = async (options: FetchOptions) => {
     if (amount === 0n || amount === "0") continue;
 
     dailyFees.add(log.token, amount, METRIC.SWAP_FEES);
-    if (isProtocolRecipient(log.feeOwner, teamFeeRecipient)) {
+    if (isProtocolRecipient(log.feeOwner)) {
       dailyRevenue.add(log.token, amount, "LP Fees To Protocol");
     } else {
       dailySupplySideRevenue.add(log.token, amount, "LP Fees To Creators");
@@ -110,6 +94,7 @@ const fetch = async (options: FetchOptions) => {
   const collectedLogs = await options.getLogs({
     target: LP_LOCKER_V3,
     eventAbi: REWARDS_COLLECTED,
+    fromBlock: FACTORY_V3_DEPLOY_BLOCK,
   });
 
   if (collectedLogs.length) {
@@ -151,7 +136,7 @@ const fetch = async (options: FetchOptions) => {
         allocated0 += share0;
         allocated1 += share1;
 
-        const toProtocol = isProtocolRecipient(recipients[j], teamFeeRecipient);
+        const toProtocol = isProtocolRecipient(recipients[j]);
         if (toProtocol) {
           dailyRevenue.add(log.currency0, share0, "LP Fees To Protocol");
           dailyRevenue.add(log.currency1, share1, "LP Fees To Protocol");

--- a/fees/quiver.ts
+++ b/fees/quiver.ts
@@ -1,0 +1,205 @@
+// Quiver — fees & revenue adapter (dimension-adapters).
+//
+// Quiver is a non-custodial token launchpad on Robinhood Chain (chainId 4663).
+// It deploys fixed-supply ERC20s into Uniswap pools and permanently locks the
+// initial LP in Quiver lockers. There is NO native launch / creation fee:
+// optional msg.value on deployToken is a same-tx "dev buy" through SwapRouter02
+// (liquidity principal + a swap), not protocol revenue.
+//
+// Fee source (the only user-paid fee Quiver routes):
+//   Uniswap pool swap fees (1% tier on v3; v4 hook pools historically) that
+//   accrue to Quiver-locked LP positions. When collectRewards runs, those fees
+//   are split across configured reward recipients (creator vs protocol).
+//
+// Contracts (Robinhood Chain):
+//   factoryV3 (active):     0xaA8Af274bba2b9dE53119CB117C8AC6A39e6F5Aa  block 10113641 (2026-07-15)
+//   lpLockerV3:             0x38daBB90C96eea7B90613ABbf019ABCe0808CF12  block 10113611
+//   factory (legacy v4):    0x3eDDD33805652c933a981F59055ef561660c54D2  block 9787616  (2026-07-14)
+//   lpLocker (legacy v4):   0x11e0B26508788ABbc6e1F2df8A86C4F10b897a98  block 9787616
+//   feeLocker (v4 claims):  0xd1B13382fDa3E165658F1d3502d6616A31B62491  block 9787616
+//   teamFeeRecipient:       0x9748D3fe02890f155489dc4F76e413Bdcd97AE5a
+//
+// Events counted:
+//   V3 — QuiverLpLockerV3.RewardsCollected(token, amount0, amount1, currency0, currency1)
+//        Split with locker.tokenRewards(token).recipients / rewardBps (immutable per token;
+//        currently 50/50 creator / teamFeeRecipient via factory.protocolBps = 5000).
+//   V4 — QuiverFeeLocker.StoreTokens(depositor, feeOwner, token, balance, amount)
+//        only when depositor == lpLocker v4 (filters out unrelated feeLocker deposits).
+//        amount is the exact share credited to feeOwner after ClaimedRewards.
+//
+// Explicitly excluded:
+//   - Gas
+//   - Token supply / LP principal deposited at launch
+//   - Optional launch-tx msg.value (dev buy, not a Quiver fee)
+//   - Ordinary Uniswap trading volume (no dailyVolume)
+//   - feeLocker.ClaimTokens (withdrawals of already-counted StoreTokens balances)
+//   - QuiverRushDistributor deposits (reward-program funding, not user fees)
+//
+// doublecounted: true — these LP fees originate as Uniswap pool fees and may
+// also appear under Uniswap if that adapter covers Robinhood pools.
+//
+//-----------------------------------------------------------------------------------------------------
+import { Adapter, FetchOptions } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+import { METRIC } from "../helpers/metrics";
+
+const FACTORY_V3 = "0xaA8Af274bba2b9dE53119CB117C8AC6A39e6F5Aa";
+const LP_LOCKER_V3 = "0x38daBB90C96eea7B90613ABbf019ABCe0808CF12";
+const LP_LOCKER_V4 = "0x11e0B26508788ABbc6e1F2df8A86C4F10b897a98";
+const FEE_LOCKER = "0xd1B13382fDa3E165658F1d3502d6616A31B62491";
+// Historical + current protocol fee recipient (factory.teamFeeRecipient / owner).
+const PROTOCOL_RECIPIENT = "0x9748D3fe02890f155489dc4F76e413Bdcd97AE5a";
+
+const BPS = 10_000n;
+
+const REWARDS_COLLECTED =
+  "event RewardsCollected(address indexed token, uint256 amount0, uint256 amount1, address currency0, address currency1)";
+const STORE_TOKENS =
+  "event StoreTokens(address indexed depositor, address indexed feeOwner, address indexed token, uint256 balance, uint256 amount)";
+const TOKEN_REWARDS_V3 =
+  "function tokenRewards(address token) view returns (address pool, (int24 tickLower, int24 tickUpper)[] positions, address[] recipients, uint16[] rewardBps)";
+
+const isProtocolRecipient = (addr: string, teamFeeRecipient: string) => {
+  const a = addr.toLowerCase();
+  return a === PROTOCOL_RECIPIENT.toLowerCase() || a === teamFeeRecipient.toLowerCase();
+};
+
+const fetch = async (options: FetchOptions) => {
+  const dailyFees = options.createBalances();
+  const dailyRevenue = options.createBalances();
+  const dailySupplySideRevenue = options.createBalances();
+
+  // Prefer the live factory recipient when the v3 factory exists; fall back to the
+  // known protocol address so historical ranges before factoryV3 still work.
+  let teamFeeRecipient = PROTOCOL_RECIPIENT;
+  try {
+    const current: string = await options.api.call({
+      target: FACTORY_V3,
+      abi: "function teamFeeRecipient() view returns (address)",
+    });
+    if (current && current !== "0x0000000000000000000000000000000000000000") {
+      teamFeeRecipient = current;
+    }
+  } catch {
+    // factoryV3 not yet deployed in this block range
+  }
+
+  // --- Legacy Uniswap v4 path: fee shares stored by lpLocker into feeLocker ---
+  const storeLogs = await options.getLogs({
+    target: FEE_LOCKER,
+    eventAbi: STORE_TOKENS,
+  });
+
+  for (const log of storeLogs) {
+    if (log.depositor.toLowerCase() !== LP_LOCKER_V4.toLowerCase()) continue;
+    const amount = log.amount;
+    if (amount === 0n || amount === "0") continue;
+
+    dailyFees.add(log.token, amount, METRIC.SWAP_FEES);
+    if (isProtocolRecipient(log.feeOwner, teamFeeRecipient)) {
+      dailyRevenue.add(log.token, amount, "LP Fees To Protocol");
+    } else {
+      dailySupplySideRevenue.add(log.token, amount, "LP Fees To Creators");
+    }
+  }
+
+  // --- Active Uniswap v3 path: direct collect + split from lpLockerV3 ---
+  const collectedLogs = await options.getLogs({
+    target: LP_LOCKER_V3,
+    eventAbi: REWARDS_COLLECTED,
+  });
+
+  if (collectedLogs.length) {
+    const rewardInfos = await options.api.multiCall({
+      abi: TOKEN_REWARDS_V3,
+      calls: collectedLogs.map((log: any) => ({ target: LP_LOCKER_V3, params: [log.token] })),
+      permitFailure: true,
+    });
+
+    for (let i = 0; i < collectedLogs.length; i++) {
+      const log = collectedLogs[i];
+      const info = rewardInfos[i];
+      if (!info || !info.recipients?.length || !info.rewardBps?.length) continue;
+
+      const amount0 = BigInt(log.amount0);
+      const amount1 = BigInt(log.amount1);
+      if (amount0 === 0n && amount1 === 0n) continue;
+
+      dailyFees.add(log.currency0, amount0, METRIC.SWAP_FEES);
+      dailyFees.add(log.currency1, amount1, METRIC.SWAP_FEES);
+
+      const recipients: string[] = info.recipients;
+      const rewardBps: (number | string)[] = info.rewardBps;
+      let allocated0 = 0n;
+      let allocated1 = 0n;
+
+      for (let j = 0; j < recipients.length; j++) {
+        const isLast = j === recipients.length - 1;
+        const share0 = isLast ? amount0 - allocated0 : (amount0 * BigInt(rewardBps[j])) / BPS;
+        const share1 = isLast ? amount1 - allocated1 : (amount1 * BigInt(rewardBps[j])) / BPS;
+        allocated0 += share0;
+        allocated1 += share1;
+
+        const toProtocol = isProtocolRecipient(recipients[j], teamFeeRecipient);
+        if (toProtocol) {
+          dailyRevenue.add(log.currency0, share0, "LP Fees To Protocol");
+          dailyRevenue.add(log.currency1, share1, "LP Fees To Protocol");
+        } else {
+          dailySupplySideRevenue.add(log.currency0, share0, "LP Fees To Creators");
+          dailySupplySideRevenue.add(log.currency1, share1, "LP Fees To Creators");
+        }
+      }
+    }
+  }
+
+  return {
+    dailyFees,
+    dailyRevenue,
+    dailyProtocolRevenue: dailyRevenue,
+    dailySupplySideRevenue,
+  };
+};
+
+const methodology = {
+  Fees:
+    "Uniswap LP swap fees collected from Quiver-locked positions when collectRewards runs. Quiver does not charge a separate native launch fee; optional launch-tx ETH is a same-tx Uniswap buy, not a Quiver fee. Liquidity principal and gas are excluded. Trading volume is not counted (ordinary Uniswap activity).",
+  Revenue:
+    "Portion of collected LP fees credited to the Quiver protocol fee recipient (factory.teamFeeRecipient).",
+  ProtocolRevenue:
+    "Same as Revenue — LP fee share retained by the Quiver protocol fee recipient.",
+  SupplySideRevenue:
+    "Portion of collected LP fees credited to token creators (and any other non-protocol reward recipients configured at launch).",
+};
+
+const breakdownMethodology = {
+  Fees: {
+    [METRIC.SWAP_FEES]:
+      "Uniswap pool swap fees collected from Quiver-locked LP positions (v3 RewardsCollected; v4 StoreTokens from the Quiver LP locker).",
+  },
+  Revenue: {
+    "LP Fees To Protocol":
+      "Share of collected LP fees sent to factory.teamFeeRecipient (v3 rewardBps protocol slice; v4 StoreTokens feeOwner).",
+  },
+  ProtocolRevenue: {
+    "LP Fees To Protocol":
+      "Share of collected LP fees sent to factory.teamFeeRecipient (v3 rewardBps protocol slice; v4 StoreTokens feeOwner).",
+  },
+  SupplySideRevenue: {
+    "LP Fees To Creators":
+      "Share of collected LP fees sent to token creators / other non-protocol reward recipients.",
+  },
+};
+
+const adapter: Adapter = {
+  version: 2,
+  pullHourly: true,
+  methodology,
+  breakdownMethodology,
+  doublecounted: true, // Uniswap pool fees may also be attributed to Uniswap
+  chains: [CHAIN.ROBINHOOD],
+  fetch,
+  // First Quiver factory deployment on Robinhood (legacy v4 factory).
+  start: "2026-07-14",
+};
+
+export default adapter;

--- a/fees/quiver.ts
+++ b/fees/quiver.ts
@@ -44,11 +44,11 @@ import { Adapter, FetchOptions } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
 import { METRIC } from "../helpers/metrics";
 
-const FACTORY_V3 = "0xaA8Af274bba2b9dE53119CB117C8AC6A39e6F5Aa";
-const FACTORY_V3_DEPLOY_BLOCK = 10113641;
-const LP_LOCKER_V3 = "0x38daBB90C96eea7B90613ABbf019ABCe0808CF12";
-const LP_LOCKER_V4 = "0x11e0B26508788ABbc6e1F2df8A86C4F10b897a98";
-const FEE_LOCKER = "0xd1B13382fDa3E165658F1d3502d6616A31B62491";
+const FACTORY_V3 = "0xaA8Af274bba2b9dE53119CB117C8AC6A39e6F5Aa"; // https://robinhoodchain.blockscout.com/address/0xaA8Af274bba2b9dE53119CB117C8AC6A39e6F5Aa
+const FACTORY_V3_DEPLOY_BLOCK = 10113641; // https://robinhoodchain.blockscout.com/block/10113641
+const LP_LOCKER_V3 = "0x38daBB90C96eea7B90613ABbf019ABCe0808CF12"; // https://robinhoodchain.blockscout.com/address/0x38daBB90C96eea7B90613ABbf019ABCe0808CF12
+const LP_LOCKER_V4 = "0x11e0B26508788ABbc6e1F2df8A86C4F10b897a98"; // https://robinhoodchain.blockscout.com/address/0x11e0B26508788ABbc6e1F2df8A86C4F10b897a98
+const FEE_LOCKER = "0xd1B13382fDa3E165658F1d3502d6616A31B62491"; // https://robinhoodchain.blockscout.com/address/0xd1B13382fDa3E165658F1d3502d6616A31B62491
 // Known protocol fee recipient from on-chain factory.teamFeeRecipient / owner EOA
 // (0x9748…AE5a). Used for all ranges, and as the sole classifier before FACTORY_V3
 // exists so we never eth_call a contract that has not been deployed yet.
@@ -122,7 +122,15 @@ const fetch = async (options: FetchOptions) => {
     for (let i = 0; i < collectedLogs.length; i++) {
       const log = collectedLogs[i];
       const info = rewardInfos[i];
-      if (!info || !info.recipients?.length || !info.rewardBps?.length) continue;
+      // permitFailure: multicall returned null/undefined — recoverable RPC/contract failure
+      if (!info) {
+        console.error(
+          `[quiver] tokenRewards failed for token=${log.token} locker=${LP_LOCKER_V3}`,
+        );
+        continue;
+      }
+      // Present but empty recipients/bps: malformed or unconfigured reward data — skip quietly
+      if (!info.recipients?.length || !info.rewardBps?.length) continue;
 
       const amount0 = BigInt(log.amount0);
       const amount1 = BigInt(log.amount1);


### PR DESCRIPTION
## Summary

Adds a Fees & Revenue adapter for **Quiver** (`fees/quiver.ts`) on Robinhood Chain (`CHAIN.ROBINHOOD`).

Quiver is a non-custodial token launchpad that deploys tokens into Uniswap pools and permanently locks initial LP. There is **no native launch / creation fee**. Optional `msg.value` on `deployToken` is a same-tx Uniswap “dev buy”, not protocol revenue.

### What is counted

| Metric | Source |
| --- | --- |
| `dailyFees` | Uniswap LP swap fees collected from Quiver-locked positions |
| `dailyRevenue` / `dailyProtocolRevenue` | Share credited to `teamFeeRecipient` (`0x9748…AE5a`) |
| `dailySupplySideRevenue` | Share credited to token creators / other non-protocol recipients |

**Events:**
- **Active v3 path:** `QuiverLpLockerV3.RewardsCollected` at `0x38daBB90…CF12`, split via per-token `tokenRewards` bps (currently 50/50 creator / protocol).
- **Legacy v4 path:** `QuiverFeeLocker.StoreTokens` at `0xd1B13382…2491` **only when** `depositor ==` LP locker `0x11e0B265…97a98` (filters unrelated deposits).

**Explicitly excluded:** gas, LP principal, launch-tx ETH (dev buy), Uniswap trading volume (`dailyVolume` not returned), `ClaimTokens` withdrawals, Rush reward-program funding.

`doublecounted: true` — these originate as Uniswap pool fees (same approach as Sentry on Robinhood).

### Contracts

| Role | Address | Deploy block |
| --- | --- | ---: |
| factoryV3 (active) | [`0xaA8Af274…F5Aa`](https://robinhoodchain.blockscout.com/address/0xaA8Af274bba2b9dE53119CB117C8AC6A39e6F5Aa) | 10113641 |
| lpLockerV3 | [`0x38daBB90…CF12`](https://robinhoodchain.blockscout.com/address/0x38daBB90C96eea7B90613ABbf019ABCe0808CF12) | 10113611 |
| factory (legacy v4) | [`0x3eDDD338…54D2`](https://robinhoodchain.blockscout.com/address/0x3eDDD33805652c933a981F59055ef561660c54D2) | 9787616 |
| lpLocker (legacy v4) | [`0x11e0B265…97a98`](https://robinhoodchain.blockscout.com/address/0x11e0B26508788ABbc6e1F2df8A86C4F10b897a98) | 9787616 |
| feeLocker | [`0xd1B13382…2491`](https://robinhoodchain.blockscout.com/address/0xd1B13382fDa3E165658F1d3502d6616A31B62491) | 9787616 |
| teamFeeRecipient | `0x9748D3fe02890f155489dc4F76e413Bdcd97AE5a` | — |

**Adapter start:** `2026-07-14` (legacy factory deployment).

### Listing info

- **Name:** Quiver
- **Website:** https://quiverfun.com
- **Chain:** Robinhood Chain
- **Verification:** https://quiverfun.com/verified
- **Twitter / X:** https://x.com/quiverfun
- **Logo:** https://quiverfun.com/logo.png
- **GitHub org:** https://github.com/quiverfun
- **Category:** Launchpad
- **Audit:** none (internal source verification only — not an independent audit)
- **Protocol token / CoinGecko / CMC:** n/a

### Test plan

- [x] `npm test -- fees quiver` (rolling last ~24h)
- [x] `npm test -- fees quiver 2026-07-14` → empty day before deploy (no fees)
- [x] `npm test -- fees quiver 2026-07-15` → deployment UTC day (factory online late; no StoreTokens yet) → fees 0
- [x] `npm test -- fees quiver 2026-07-16` → **2026-07-15 UTC** fee collections:
  - dailyFees ≈ **$0.56** (0.000298105682951145 WETH)
  - dailyRevenue / protocolRevenue = **$0** (legacy v4 launches credited 100% to creator)
  - dailySupplySideRevenue ≈ **$0.56**
- [x] Manual Blockscout reconciliation of three `StoreTokens` txs matches wei totals exactly:
  - https://robinhoodchain.blockscout.com/tx/0xead6947c4fadbb5e3e3c7f1765697163df36ede94c4c0bb68f5eff3623ddfc8e
  - https://robinhoodchain.blockscout.com/tx/0xf2394f311baabcde14cb899c855f0c0dc7b5ebf4f174094c161ce7bf8f0a6820
  - https://robinhoodchain.blockscout.com/tx/0x81b96585d0233ae300c72f85c421b267d2bba0e8470e21c9bbb48c1e29a88b95
- [x] Invariants: fees ≥ 0; revenue ≤ fees; fees = protocol + supplySide on tested days; no gas / LP principal / volume counted

### Notes for maintainers

- Active v3 factory has `protocolBps = 5000` (50/50). No `RewardsCollected` events yet on v3 locker — protocol revenue will appear once creators/protocol call `collectRewards` on v3 positions.
- Please enable **Allow edits by maintainers**.


Made with [Cursor](https://cursor.com)