### PR TITLE
[StableJack] Add StableJack Perps Hyperliquid Builder

### DIFF
--- a/factory/hyperliquid.ts
+++ b/factory/hyperliquid.ts
@@ -30,6 +30,19 @@ const superxConfig: BuilderConfig = {
 // factory export. The DefiLlama dimension framework picks the appropriate
 // fields (volume vs fees) based on each protocol's metadata adapter type.
 const builderConfigs: Record<string, BuilderConfig> = {
+  "stablejack-perps": {
+    addresses: [
+      "0x68b7e8be8f1a62f99e37f1ac191dd23486e8a2ad",
+    ],
+    start: "2026-06-17",
+    methodology: {
+      Volume: "Notional volume of perpetual trades routed through StableJack on Hyperliquid.",
+      Fees: "Builder code fees paid by users trading Hyperliquid perpetuals through StableJack.",
+      Revenue: "Builder code fees collected by StableJack from Hyperliquid perpetual trades.",
+      ProtocolRevenue: "Builder code fees collected by StableJack from Hyperliquid perpetual trades.",
+    },
+    breakdownFees: true,
+  },
     "hyperank-perps": {
     addresses: ["0x860343ba897f44a9a87353d93795f417b9a22226"],
     start: "2026-07-01",


### PR DESCRIPTION
## Summary

Adds StableJack Perps to the existing Hyperliquid builder factory to track perpetual trading volume and builder-code fee revenue.

Stable Jack is already listed on DefiLlama:
https://defillama.com/protocol/stable-jack

This PR adds dimensions tracking only and does not modify the existing TVL adapter or listing metadata.

## Builder details

- Name: StableJack Perps
- Parent protocol: StableJack
- Website: https://stablejack.xyz/
- X: https://x.com/StableJack_xyz
- Chain: Hyperliquid 
- Builder address: `0x68b7e8be8f1a62f99e37f1ac191dd23486e8a2ad`
- Start date: `2026-06-17`
- Hyperliquid builder data: https://stats-data.hyperliquid.xyz/Mainnet/builder_fills/0x68b7e8be8f1a62f99e37f1ac191dd23486e8a2ad/20260617.csv.lz4

Please associate the `stablejack-perps` dimensions record with the existing Stable Jack parent protocol and classify it as an Interface / Hyperliquid Builder.

## Metrics tracked

- Perp Volume: Notional volume of perpetual trades routed through StableJack on Hyperliquid.
- Fees: Builder-code fees paid by users trading Hyperliquid perpetuals through StableJack.
- Revenue: Builder-code fees collected by StableJack.
- Protocol Revenue: Builder-code fees collected by StableJack.

Referral rewards and Hyperliquid base trading fees are not included.

## Changes

Adds `stablejack-perps` to `builderConfigs` in `factory/hyperliquid.ts`.

No other files, dependencies, lockfiles, or package files were modified.

## Validation

The following checks pass:

```text
pnpm ts-check
pnpm test fees stablejack-perps 2026-06-19
pnpm test dexs stablejack-perps 2026-06-19
git diff --check