### PR TITLE
lifi/jumper: route taiko, flare, xdc via analytics API

### DIFF
--- a/aggregators/jumper-exchange/index.ts
+++ b/aggregators/jumper-exchange/index.ts
@@ -1,5 +1,5 @@
 import { FetchOptions, FetchResultVolume, SimpleAdapter } from "../../adapters/types";
-import { LifiDiamonds, fetchVolumeFromLIFIAPI } from "../../helpers/aggregators/lifi";
+import { LifiDiamonds, LIFI_API_CHAINS, fetchVolumeFromLIFIAPI } from "../../helpers/aggregators/lifi";
 import { CHAIN } from "../../helpers/chains";
 import { getDefaultDexTokensBlacklisted } from "../../helpers/lists";
 import { formatAddress } from "../../utils/utils";
@@ -8,7 +8,7 @@ const LifiSwapEvent = "event LiFiGenericSwapCompleted(bytes32 indexed transactio
 const integrators = ['jumper.exchange', 'transferto.xyz', 'jumper.exchange.gas', 'lifi-gasless-jumper']
 
 const fetch: any = async (options: FetchOptions): Promise<FetchResultVolume> => {
-  if (options.chain === CHAIN.BITCOIN || options.chain === CHAIN.SOLANA || options.chain === CHAIN.SUI || options.chain === CHAIN.SEI || options.chain === CHAIN.ROOTSTOCK) {
+  if (LIFI_API_CHAINS.includes(options.chain as CHAIN)) {
     const dailyVolume = await fetchVolumeFromLIFIAPI(options.chain, options.startTimestamp, options.endTimestamp, integrators, [], 'same-chain');
     return { dailyVolume } as any;
   }

--- a/aggregators/lifi/index.ts
+++ b/aggregators/lifi/index.ts
@@ -1,5 +1,5 @@
 import { FetchOptions, FetchResultVolume, SimpleAdapter } from "../../adapters/types";
-import { LifiDiamonds, fetchVolumeFromLIFIAPI } from "../../helpers/aggregators/lifi";
+import { LifiDiamonds, LIFI_API_CHAINS, fetchVolumeFromLIFIAPI } from "../../helpers/aggregators/lifi";
 import { CHAIN } from "../../helpers/chains";
 import { getDefaultDexTokensBlacklisted, getDefaultDexTokensWhitelisted } from "../../helpers/lists";
 import { formatAddress } from "../../utils/utils";
@@ -9,7 +9,7 @@ const LifiSwapEvent = "event LiFiGenericSwapCompleted(bytes32 indexed transactio
 const integrators = ['jumper.exchange', 'transferto.xyz', 'jumper.exchange.gas', 'lifi-gasless-jumper']
 
 const fetch: any = async (options: FetchOptions): Promise<FetchResultVolume> => {
-  if (options.chain === CHAIN.BITCOIN || options.chain === CHAIN.SOLANA || options.chain === CHAIN.SUI || options.chain === CHAIN.SEI || options.chain === CHAIN.ROOTSTOCK) {
+  if (LIFI_API_CHAINS.includes(options.chain as CHAIN)) {
     // exclude jumper integrators to match the on-chain path (this adapter counts LI.FI ex-Jumper)
     const dailyVolume = await fetchVolumeFromLIFIAPI(options.chain, options.startTimestamp, options.endTimestamp, [], integrators, 'same-chain');
     return {

--- a/bridge-aggregators/jumper.exchange/index.ts
+++ b/bridge-aggregators/jumper.exchange/index.ts
@@ -1,12 +1,12 @@
 import { FetchOptions, FetchResultVolume, SimpleAdapter } from "../../adapters/types";
-import { LifiDiamonds, fetchVolumeFromLIFIAPI } from "../../helpers/aggregators/lifi";
+import { LifiDiamonds, LIFI_API_CHAINS, fetchVolumeFromLIFIAPI } from "../../helpers/aggregators/lifi";
 import { CHAIN } from "../../helpers/chains";
 
 const LifiBridgeEvent = "event LiFiTransferStarted((bytes32 transactionId, string bridge, string integrator, address referrer, address sendingAssetId, address receiver, uint256 minAmount, uint256 destinationChainId, bool hasSourceSwaps, bool hasDestinationCall) bridgeData)"
 const integrators = ['jumper.exchange', 'transferto.xyz', 'jumper.exchange.gas','lifi-gasless-jumper']
 
 const fetch: any = async (options: FetchOptions): Promise<FetchResultVolume> => {
-  if (options.chain === CHAIN.BITCOIN || options.chain === CHAIN.SOLANA || options.chain === CHAIN.SUI || options.chain === CHAIN.SEI || options.chain === CHAIN.ROOTSTOCK) {
+  if (LIFI_API_CHAINS.includes(options.chain as CHAIN)) {
     const dailyVolume = await fetchVolumeFromLIFIAPI(options.chain, options.startTimestamp, options.endTimestamp, integrators, [], 'cross-chain');
     return {
       dailyBridgeVolume: dailyVolume

--- a/bridge-aggregators/lifi/index.ts
+++ b/bridge-aggregators/lifi/index.ts
@@ -1,13 +1,13 @@
 import { FetchOptions, FetchResultVolume, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
-import { fetchVolumeFromLIFIAPI, LifiDiamonds } from "../../helpers/aggregators/lifi";
+import { fetchVolumeFromLIFIAPI, LifiDiamonds, LIFI_API_CHAINS } from "../../helpers/aggregators/lifi";
 
 
 const LifiBridgeEvent = "event LiFiTransferStarted((bytes32 transactionId, string bridge, string integrator, address referrer, address sendingAssetId, address receiver, uint256 minAmount, uint256 destinationChainId, bool hasSourceSwaps, bool hasDestinationCall) bridgeData)"
 const exclude_integrators = ['jumper.exchange', 'transferto.xyz', 'jumper.exchange.gas', 'lifi-gasless-jumper']
 
 const fetch: any = async (options: FetchOptions): Promise<FetchResultVolume> => {
-  if (options.chain === CHAIN.BITCOIN || options.chain === CHAIN.SOLANA || options.chain === CHAIN.SUI || options.chain === CHAIN.SEI || options.chain === CHAIN.ROOTSTOCK) {
+  if (LIFI_API_CHAINS.includes(options.chain as CHAIN)) {
     const dailyVolume = await fetchVolumeFromLIFIAPI(options.chain, options.startTimestamp, options.endTimestamp, [], exclude_integrators, 'cross-chain');
     return {
       dailyBridgeVolume: dailyVolume

--- a/helpers/aggregators/lifi.ts
+++ b/helpers/aggregators/lifi.ts
@@ -6,6 +6,9 @@ type IContract = {
   [c: string | Chain]: {
     id: string;
     startTime: string;
+    // numeric LI.FI chainId for the analytics API; set only when `id` is a contract
+    // address but the chain is API-routed (see LIFI_API_CHAINS). Falls back to `id`.
+    chainId?: string;
   }
 }
 
@@ -172,6 +175,7 @@ export const LifiDiamonds: IContract = {
   },
   [CHAIN.TAIKO]: {
     id: '0x3A9A5dBa8FE1C4Da98187cE4755701BCA182f63b',
+    chainId: '167000', // API-routed (see LIFI_API_CHAINS)
     startTime: '2024-08-15'
   },
   [CHAIN.BLAST]: {
@@ -260,6 +264,7 @@ export const LifiDiamonds: IContract = {
   },
   [CHAIN.XDC]: {
     id: '0x055d4612Ec74aD799C6cB4dF72C0Ab8dbDBCBAfa',
+    chainId: '50', // API-routed (see LIFI_API_CHAINS)
     startTime: '2025-05-19'
   },
   [CHAIN.BOB]: {
@@ -268,6 +273,7 @@ export const LifiDiamonds: IContract = {
   },
   [CHAIN.FLARE]: {
     id: '0x198FC70Dfe05E755C81e54bd67Bff3F729344B9b',
+    chainId: '14', // API-routed (see LIFI_API_CHAINS)
     startTime: '2025-06-04'
   },
   [CHAIN.RONIN]: {
@@ -299,6 +305,15 @@ export const LifiDiamonds: IContract = {
     startTime: '2025-11-11'
   }
 }
+
+// Chains whose volume is fetched via the LI.FI analytics API instead of on-chain getLogs
+// (non-EVM chains, or EVM chains whose public RPCs do not serve eth_getLogs reliably).
+// For every chain here, LifiDiamonds[chain].id MUST be the numeric LI.FI chainId (the API
+// fromChain param), not a diamond contract address, or the API returns 400.
+export const LIFI_API_CHAINS = [
+  CHAIN.BITCOIN, CHAIN.SOLANA, CHAIN.SUI, CHAIN.SEI, CHAIN.ROOTSTOCK,
+  CHAIN.TAIKO, CHAIN.FLARE, CHAIN.XDC,
+]
 
 export const LifiFeeCollectors: IContract = {
   [CHAIN.ABSTRACT]: {
@@ -504,9 +519,12 @@ export const fetchVolumeFromLIFIAPI = async (chain: Chain, startTime: number, en
   let totalValue = 0;
   let nextCursor: string | undefined;
 
+  // the analytics API keys on the numeric LI.FI chainId; `id` may be a diamond address
+  const apiChainId = LifiDiamonds[chain].chainId ?? LifiDiamonds[chain].id;
+
   while (hasMore) {
     const params = new URLSearchParams({
-      fromChain: LifiDiamonds[chain].id,
+      fromChain: apiChainId,
       fromTimestamp: startTime.toString(),
       toTimestamp: endTime.toString(),
       status: 'DONE',
@@ -532,7 +550,7 @@ export const fetchVolumeFromLIFIAPI = async (chain: Chain, startTime: number, en
         // enforce the requested window client-side: the API filter is by chain, but with hourly
         // runs we must drop any transfer whose timestamp falls outside [startTime, endTime]
         tx.sending.timestamp >= startTime && tx.sending.timestamp < endTime &&
-        (swapType === 'cross-chain' ? tx.receiving.chainId !== Number(LifiDiamonds[chain].id) : tx.receiving.chainId === Number(LifiDiamonds[chain].id)) &&
+        (swapType === 'cross-chain' ? tx.receiving.chainId !== Number(apiChainId) : tx.receiving.chainId === Number(apiChainId)) &&
         (integrators && integrators.length > 0 ? integrators.includes(tx.metadata.integrator) : true) &&
         (exclude_integrators && exclude_integrators.length > 0 ? !exclude_integrators.includes(tx.metadata.integrator) : true)
       ) {


### PR DESCRIPTION
Taiko, Flare and XDC have unreliable eth_getLogs on public nodes, so they are routed through the LI.FI analytics API like Sei and Rootstock. Their diamond address stays in `id` for getLogs; a numeric `chainId` is added for the API fromChain param (the API rejects a contract address). The per-adapter API-chain lists are consolidated into a shared `LIFI_API_CHAINS`.