### PR TITLE
SLVR: add volume (ETH wagered per round)

### DIFF
--- a/fees/slvr/index.ts
+++ b/fees/slvr/index.ts
@@ -11,6 +11,7 @@ const VE_STAKING = "0xaF68598eBd245DC3cB92FF16E9Ba1814DD137200"; // SlvrVoteEscr
 const REWARD_DISTRIBUTED = "event RewardDistributed(uint256 amount)";
 
 const JACKPOT = "Jackpot"; // 2% of wagers routed to the jackpot pool
+const WAGERS = "Wagers"; // ETH wagered by players
 
 const fetch = async (options: FetchOptions) => {
   const rewards = await options.getLogs({ target: VE_STAKING, eventAbi: REWARD_DISTRIBUTED })
@@ -19,6 +20,10 @@ const fetch = async (options: FetchOptions) => {
   const stakerRewards = options.createBalances();
   rewards.forEach((log: any) => stakerRewards.addGasToken(log.amount, METRIC.STAKING_REWARDS));
   const jackpot = stakerRewards.clone(0.25, JACKPOT);
+  // Volume = ETH wagered per round. Staker rewards are a flat 8% of each round's wagers,
+  // so wagers = rewards / 0.08, without a second getLogs query (BetPlaced) against the
+  // rate-limited Robinhood RPC.
+  const dailyVolume = stakerRewards.clone(12.5, WAGERS);
 
   // Fees = the full 10% rake = staker rewards (8%) + jackpot (2%).
   const dailyFees = options.createBalances();
@@ -26,6 +31,7 @@ const fetch = async (options: FetchOptions) => {
   dailyFees.addBalances(jackpot);
 
   return {
+    dailyVolume,
     dailyFees,
     dailyRevenue: stakerRewards,
     dailyHoldersRevenue: stakerRewards,
@@ -34,6 +40,7 @@ const fetch = async (options: FetchOptions) => {
 };
 
 const methodology = {
+  Volume: "Total ETH wagered across all lottery bets each round, derived from staker rewards (a flat 8% of wagers).",
   Fees: "The 10% rake taken from every round's wagers: 8% distributed to veNFT stakers plus 2% routed to the jackpot.",
   Revenue: "All staker rewards — the ETH distributed to veNFT stakers (RewardDistributed events on SlvrVoteEscrowStaking).",
   HoldersRevenue: "All staker rewards — the ETH distributed to veNFT stakers.",
@@ -41,6 +48,9 @@ const methodology = {
 };
 
 const breakdownMethodology = {
+  Volume: {
+    [WAGERS]: "ETH wagered across the grid each round, derived as staker rewards / 0.08 (the flat 8% staker cut of wagers).",
+  },
   Fees: {
     [METRIC.STAKING_REWARDS]: "8% of wagers distributed to veNFT stakers (RewardDistributed events).",
     [JACKPOT]: "2% of wagers routed to the jackpot pool.",

--- a/fees/slvr/index.ts
+++ b/fees/slvr/index.ts
@@ -11,7 +11,6 @@ const VE_STAKING = "0xaF68598eBd245DC3cB92FF16E9Ba1814DD137200"; // SlvrVoteEscr
 const REWARD_DISTRIBUTED = "event RewardDistributed(uint256 amount)";
 
 const JACKPOT = "Jackpot"; // 2% of wagers routed to the jackpot pool
-const WAGERS = "Wagers"; // ETH wagered by players
 
 const fetch = async (options: FetchOptions) => {
   const rewards = await options.getLogs({ target: VE_STAKING, eventAbi: REWARD_DISTRIBUTED })
@@ -21,9 +20,8 @@ const fetch = async (options: FetchOptions) => {
   rewards.forEach((log: any) => stakerRewards.addGasToken(log.amount, METRIC.STAKING_REWARDS));
   const jackpot = stakerRewards.clone(0.25, JACKPOT);
   // Volume = ETH wagered per round. Staker rewards are a flat 8% of each round's wagers,
-  // so wagers = rewards / 0.08, without a second getLogs query (BetPlaced) against the
-  // rate-limited Robinhood RPC.
-  const dailyVolume = stakerRewards.clone(12.5, WAGERS);
+  // so wagers = rewards / 0.08,
+  const dailyVolume = stakerRewards.clone(12.5);
 
   // Fees = the full 10% rake = staker rewards (8%) + jackpot (2%).
   const dailyFees = options.createBalances();
@@ -48,9 +46,6 @@ const methodology = {
 };
 
 const breakdownMethodology = {
-  Volume: {
-    [WAGERS]: "ETH wagered across the grid each round, derived as staker rewards / 0.08 (the flat 8% staker cut of wagers).",
-  },
   Fees: {
     [METRIC.STAKING_REWARDS]: "8% of wagers distributed to veNFT stakers (RewardDistributed events).",
     [JACKPOT]: "2% of wagers routed to the jackpot pool.",


### PR DESCRIPTION
## Adds the Volume dimension to the existing SLVR adapter (listed in #8109)

SLVR is a 1-minute grid lottery on Robinhood Chain; volume = ETH wagered per round.

### Why derived rather than from BetPlaced events
During review of #8109, volume (from `BetPlaced` logs) was removed because the Robinhood sequencer RPC rate-limits `eth_getLogs` (429s in CI). This PR restores volume **without any additional RPC calls**: staker rewards (`RewardDistributed`, which the adapter already reads) are a flat 8% of each round's wagers, so:

```
dailyVolume = stakerRewards.clone(12.5, WAGERS)   // wagers = rewards / 0.08
```

Same pattern already used in the merged adapter for the jackpot (`clone(0.25)`).

### Accuracy check
Cross-checked on-chain against actual `BetPlaced` totals over a 10,000-block window (blocks 11327955-11337955 via the Blockscout archival RPC):

- actual wagered: **8.2225 ETH** (196 BetPlaced events)
- derived (rewards x 12.5): **8.1960 ETH** - within 0.4%, remainder being rounds not yet resolved at the window edge

### Test run (`npm test fees slvr`)
All 24 hourly slots populate; totals for the last day:

```
Daily volume: 1.06 M
Daily fees: 105.91 k
Daily revenue: 84.73 k
Daily holders revenue: 84.73 k
Daily supply side revenue: 21.18 k
```

Methodology + breakdownMethodology entries included for Volume.