### PR TITLE
imf: fix sell-side volume double-adding fee

### DIFF
--- a/fees/imf/index.ts
+++ b/fees/imf/index.ts
@@ -51,14 +51,21 @@ const fetch = async (options: FetchOptions): Promise<FetchResult> => {
   const accruedLogs = await dayLogs(FeesAccruedEvent);
   const graduatedLogs = await dayLogs(GraduatedEvent);
 
-  // ethIn/ethOut are net of fee — volume is reported gross (fee included),
-  // matching the standard DEX convention where the fee sits inside the swap.
+  // ethIn/ethOut are net of fee. On a buy, the trader's real tx.value equals
+  // ethIn + ethFee (verified on-chain, exact to the wei) - the fee is paid on
+  // top of the trade. On a sell, the trader's real payout (verified via
+  // Blockscout internal-transactions) equals ethOut exactly, with no separate
+  // transfer for the fee anywhere in the transaction - the fee has no
+  // discrete payment on this side, it's netted out of the curve math itself.
+  // So volume only adds the fee on buys, matching the same asymmetric
+  // convention already established for fees/based-alpha/index.ts after the
+  // same on-chain verification there.
   for (const log of buyLogs) {
     dailyVolume.addGasToken(BigInt(log.ethIn) + BigInt(log.ethFee));
     dailyFees.addGasToken(log.ethFee, METRIC.TRADING_FEES);
   }
   for (const log of sellLogs) {
-    dailyVolume.addGasToken(BigInt(log.ethOut) + BigInt(log.ethFee));
+    dailyVolume.addGasToken(log.ethOut);
     dailyFees.addGasToken(log.ethFee, METRIC.TRADING_FEES);
   }
   for (const log of accruedLogs) {


### PR DESCRIPTION
`ethIn`/`ethOut` are net of fee. On a buy, the trader's real `tx.value`
equals `ethIn + ethFee` (verified on-chain, exact to the wei) - the fee
is paid on top. On a sell, the trader's real payout (verified via
Blockscout internal-transactions) equals `ethOut` exactly, with no
separate transfer for the fee anywhere in the transaction:

**Buy** (`0x988e23ec...3219d17c`): `tx.value` = 50,000,000,000,000,000,
`ethIn` = 49,375,000,000,000,000, `ethFee` = 625,000,000,000,000.
`tx.value = ethIn + ethFee`, exact to the wei.

**Sell** (`0x76db2f1f...ec25a7cf9`): `ethOut` = 4,910,529,623, matching
the trader's real payout (confirmed via Blockscout internal-transactions)
exactly, with `ethFee` (62,158,603) nowhere in what was actually paid out.

Volume was adding the fee on both sides symmetrically, but the fee
only has a discrete, observable payment on the buy side - on a sell
it's netted out of the curve math itself, not a separate transfer.
Fixed to match the same asymmetric convention already established for
`fees/based-alpha/index.ts` after the same on-chain verification there
(#8163): fee added to volume on buys, sells left at `ethOut` alone.

Verified locally: `ts-node --transpile-only` loads the file with no
errors (exit code 0). `npm run test fees/imf/index.ts` runs clean
across all 24 hourly slots - Daily volume 30.32k, Daily fees 382.44,
ratio ~1.26%, matching the stated 1.25% trading fee rate.

cc @monodev-eth since you co-authored the original adapter