### PR TITLE
[add] miroshark - fees adapter

### DIFF
--- a/fees/miroshark.ts
+++ b/fees/miroshark.ts
@@ -32,6 +32,7 @@ const SWAP_TOPIC = '0x40e9cecb9f5f1f1c5b9c97dec2917b7ee92e57ba5563708daca94dd84a
 async function fetch(options: FetchOptions) {
   const dailyFees = options.createBalances();
   const dailyRevenue = options.createBalances();
+  const dailySupplySideRevenue = options.createBalances();
 
   // treasury share of swap fees (WAD), read on-chain so beneficiary updates are reflected
   const shares = await options.api.multiCall({
@@ -46,6 +47,7 @@ async function fetch(options: FetchOptions) {
   const logs = await options.getLogs({
     target: UNIV4_POOL_MANAGER,
     eventAbi: SWAP_EVENT,
+    // filter by indexed poolId (topic1) — only swaps on the MiroShark/WETH pool
     topics: [SWAP_TOPIC, MIROSHARK_WETH_POOL_ID],
   });
 
@@ -54,32 +56,32 @@ async function fetch(options: FetchOptions) {
     // same approximation as the canonical uniswap-v4 adapter
     const amount0 = Math.abs(Number(log.amount0));
     const feeRate = Number(log.fee) / 1e6; // dynamic fee in ppm
-    dailyFees.add(WETH, amount0 * feeRate, METRIC.SWAP_FEES);
-    dailyRevenue.add(WETH, amount0 * feeRate * treasuryShare, METRIC.SWAP_FEES);
+    const fee = amount0 * feeRate;
+    dailyFees.add(WETH, fee, METRIC.SWAP_FEES);
+    dailyRevenue.add(WETH, fee * treasuryShare, METRIC.SWAP_FEES);
+    dailySupplySideRevenue.add(WETH, fee * (1 - treasuryShare), METRIC.SWAP_FEES);
   }
 
   return {
     dailyFees,
-    dailyUserFees: dailyFees,
     dailyRevenue,
     dailyProtocolRevenue: dailyRevenue,
+    dailySupplySideRevenue,
     dailyHoldersRevenue: 0,
   };
 }
 
 const adapter: SimpleAdapter = {
   version: 2,
-  adapter: {
-    [CHAIN.BASE]: {
-      fetch,
-      start: '2026-03-24',
-    },
-  },
+  pullHourly: true,
+  fetch,
+  chains: [CHAIN.BASE],
+  start: '2026-03-24',
   methodology: {
     Fees: 'Dynamic swap fee (1.2% steady-state) paid by users trading on the WETH/MiroShark Uniswap v4 pool on Base. Liquidity is protocol-owned multicurve positions — there are no third-party LPs.',
-    UserFees: 'Swap fees paid by users trading MiroShark.',
-    Revenue: '57% of swap fees routed to MiroShark, per the on-chain beneficiary split read from the multicurve initializer. The remaining 43% goes to launch platform beneficiaries (Bankr/Doppler & interface) and is not counted as MiroShark revenue.',
+    Revenue: '57% of swap fees routed to MiroShark, per the on-chain beneficiary split read from the multicurve initializer.',
     ProtocolRevenue: '57% of swap fees routed to MiroShark.',
+    SupplySideRevenue: '43% of swap fees going to the launch platform beneficiaries (Bankr/Doppler & interface), per the on-chain beneficiary split.',
     HoldersRevenue: 'Swap fees are not distributed to token holders directly.',
   },
   breakdownMethodology: {
@@ -88,6 +90,9 @@ const adapter: SimpleAdapter = {
     },
     Revenue: {
       [METRIC.SWAP_FEES]: '57% treasury share of swap fees, per the on-chain beneficiary split.',
+    },
+    SupplySideRevenue: {
+      [METRIC.SWAP_FEES]: '43% launch platform share of swap fees (Bankr/Doppler & interface beneficiaries).',
     },
   },
 };

--- a/fees/miroshark.ts
+++ b/fees/miroshark.ts
@@ -1,0 +1,95 @@
+import { FetchOptions, SimpleAdapter } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+import { METRIC } from "../helpers/metrics";
+
+// MiroShark token: https://www.miroshark.xyz/
+// WETH/MiroShark Uniswap v4 pool on Base, launched via Bankr using the Doppler
+// v4 multicurve stack (DecayMulticurveInitializerHook). The pool charges a
+// dynamic LP fee (1.2% steady-state, emitted per-swap in the Swap event) that
+// accrues to protocol-owned multicurve positions and is split between on-chain
+// beneficiaries — there are no third-party LPs.
+//
+// Beneficiary shares (DecayMulticurveInitializer 0xD59cE43E53D69F190E15d9822Fb4540dCcc91178,
+// getShares(poolId, beneficiary)):
+//   57%   MiroShark (initially 0x3735...7A2b, later moved to the deployer
+//         wallet 0x6cab...2b24f)
+//   43%   launch platform beneficiaries (Bankr/Doppler & interface)
+const UNIV4_POOL_MANAGER = '0x498581ff718922c3f8e6a244956af099b2652b2b';
+const MIROSHARK_WETH_POOL_ID = '0x83a29b6619907f80e5a47d40f53d4af239a69980f22a08b10f43d357a9f06209';
+const WETH = '0x4200000000000000000000000000000000000006';
+
+const MULTICURVE_INITIALIZER = '0xD59cE43E53D69F190E15d9822Fb4540dCcc91178';
+// MiroShark-controlled beneficiaries over the pool's lifetime — shares are
+// summed, so the beneficiary handoff between them doesn't skew historical revenue
+const MIROSHARK_BENEFICIARIES = [
+  '0x373509C3d065aE6049D6FF4e225B9936455d7A2b',
+  '0x6cab485fc28ec70d3845113b704d4824e4d2b24f', // deployer wallet
+];
+
+const SWAP_EVENT = 'event Swap(bytes32 indexed id, address indexed sender, int128 amount0, int128 amount1, uint160 sqrtPriceX96, uint128 liquidity, int24 tick, uint24 fee)';
+const SWAP_TOPIC = '0x40e9cecb9f5f1f1c5b9c97dec2917b7ee92e57ba5563708daca94dd84ad7112f';
+
+async function fetch(options: FetchOptions) {
+  const dailyFees = options.createBalances();
+  const dailyRevenue = options.createBalances();
+
+  // treasury share of swap fees (WAD), read on-chain so beneficiary updates are reflected
+  const shares = await options.api.multiCall({
+    abi: 'function getShares(bytes32 poolId, address beneficiary) view returns (uint256 shares)',
+    calls: MIROSHARK_BENEFICIARIES.map((beneficiary) => ({
+      target: MULTICURVE_INITIALIZER,
+      params: [MIROSHARK_WETH_POOL_ID, beneficiary],
+    })),
+  });
+  const treasuryShare = shares.reduce((sum: number, s: any) => sum + Number(s), 0) / 1e18;
+
+  const logs = await options.getLogs({
+    target: UNIV4_POOL_MANAGER,
+    eventAbi: SWAP_EVENT,
+    topics: [SWAP_TOPIC, MIROSHARK_WETH_POOL_ID],
+  });
+
+  for (const log of logs) {
+    // currency0 is WETH — measure fees on the WETH side of each swap,
+    // same approximation as the canonical uniswap-v4 adapter
+    const amount0 = Math.abs(Number(log.amount0));
+    const feeRate = Number(log.fee) / 1e6; // dynamic fee in ppm
+    dailyFees.add(WETH, amount0 * feeRate, METRIC.SWAP_FEES);
+    dailyRevenue.add(WETH, amount0 * feeRate * treasuryShare, METRIC.SWAP_FEES);
+  }
+
+  return {
+    dailyFees,
+    dailyUserFees: dailyFees,
+    dailyRevenue,
+    dailyProtocolRevenue: dailyRevenue,
+    dailyHoldersRevenue: 0,
+  };
+}
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  adapter: {
+    [CHAIN.BASE]: {
+      fetch,
+      start: '2026-03-24',
+    },
+  },
+  methodology: {
+    Fees: 'Dynamic swap fee (1.2% steady-state) paid by users trading on the WETH/MiroShark Uniswap v4 pool on Base. Liquidity is protocol-owned multicurve positions — there are no third-party LPs.',
+    UserFees: 'Swap fees paid by users trading MiroShark.',
+    Revenue: '57% of swap fees routed to MiroShark, per the on-chain beneficiary split read from the multicurve initializer. The remaining 43% goes to launch platform beneficiaries (Bankr/Doppler & interface) and is not counted as MiroShark revenue.',
+    ProtocolRevenue: '57% of swap fees routed to MiroShark.',
+    HoldersRevenue: 'Swap fees are not distributed to token holders directly.',
+  },
+  breakdownMethodology: {
+    Fees: {
+      [METRIC.SWAP_FEES]: 'Dynamic swap fee charged on WETH/MiroShark Uniswap v4 pool swaps, measured on the WETH side of each swap.',
+    },
+    Revenue: {
+      [METRIC.SWAP_FEES]: '57% treasury share of swap fees, per the on-chain beneficiary split.',
+    },
+  },
+};
+
+export default adapter;

--- a/fees/miroshark.ts
+++ b/fees/miroshark.ts
@@ -58,8 +58,8 @@ async function fetch(options: FetchOptions) {
     const feeRate = Number(log.fee) / 1e6; // dynamic fee in ppm
     const fee = amount0 * feeRate;
     dailyFees.add(WETH, fee, METRIC.SWAP_FEES);
-    dailyRevenue.add(WETH, fee * treasuryShare, METRIC.SWAP_FEES);
-    dailySupplySideRevenue.add(WETH, fee * (1 - treasuryShare), METRIC.SWAP_FEES);
+    dailyRevenue.add(WETH, fee * treasuryShare, "Token Swap Fees to Treasury");
+    dailySupplySideRevenue.add(WETH, fee * (1 - treasuryShare), "Token Swap Fees to Launch Platform");
   }
 
   return {
@@ -89,12 +89,16 @@ const adapter: SimpleAdapter = {
       [METRIC.SWAP_FEES]: 'Dynamic swap fee charged on WETH/MiroShark Uniswap v4 pool swaps, measured on the WETH side of each swap.',
     },
     Revenue: {
-      [METRIC.SWAP_FEES]: '57% treasury share of swap fees, per the on-chain beneficiary split.',
+      "Token Swap Fees to Treasury": '57% treasury share of swap fees, per the on-chain beneficiary split.',
+    },
+    ProtocolRevenue: {
+      "Token Swap Fees to Treasury": '57% treasury share of swap fees, per the on-chain beneficiary split.',
     },
     SupplySideRevenue: {
-      [METRIC.SWAP_FEES]: '43% launch platform share of swap fees (Bankr/Doppler & interface beneficiaries).',
+      "Token Swap Fees to Launch Platform": '43% launch platform share of swap fees (Bankr/Doppler & interface beneficiaries).',
     },
   },
+  doublecounted: true, // uniswap
 };
 
 export default adapter;


### PR DESCRIPTION
## MiroShark

- Website: https://www.miroshark.xyz/
- Twitter: https://x.com/miroshark_
- Token (Base): [`0xd7bc6a05a56655FB2052F742B012d1DFD66e1BA3`](https://basescan.org/token/0xd7bc6a05a56655fb2052f742b012d1dfd66e1ba3)

## What this adapter tracks

MiroShark trades on a WETH/MiroShark Uniswap v4 pool on Base (poolId `0x83a29b6619907f80e5a47d40f53d4af239a69980f22a08b10f43d357a9f06209`), launched via Bankr using the Doppler v4 multicurve stack (`DecayMulticurveInitializerHook`). The pool charges a dynamic LP fee (1.2% steady-state, emitted per-swap in the `Swap` event). Liquidity is protocol-owned multicurve positions — there are no third-party LPs.

- **Fees**: swap fees parsed from PoolManager `Swap` events filtered by poolId, using each swap's dynamic `fee` field, measured on the WETH side (same approximation as the `uniswap-v4` adapter).
- **Revenue / ProtocolRevenue**: the project's share of fees, read on-chain per day from `getShares(poolId, beneficiary)` on the `DecayMulticurveInitializer` ([`0xD59cE43E53D69F190E15d9822Fb4540dCcc91178`](https://basescan.org/address/0xD59cE43E53D69F190E15d9822Fb4540dCcc91178)) — currently 57%, held by the deployer wallet. Shares are summed across the two MiroShark-controlled beneficiary addresses so the on-chain beneficiary handoff between them doesn't skew historical values. The remaining 43% goes to launch-platform beneficiaries (Bankr/Doppler & interface) and is not counted as MiroShark revenue.

Same structure as the Aeon adapter (#8187) — both tokens use the identical Bankr/Doppler launch stack.

## Test

```
🦙 Running MIROSHARK adapter 🦙
BASE 👇
Daily fees: 13.00
Daily revenue: 7.46
```

Also tested on historical dates: 2026-04-15 ($2.15k / $1.22k), 2026-06-01 ($1.01k / $573).