### PR TITLE
[add] miroshark-x402 - x402 API fees adapter

### DIFF
--- a/fees/miroshark-x402.ts
+++ b/fees/miroshark-x402.ts
@@ -1,0 +1,63 @@
+import { Dependencies, FetchOptions, SimpleAdapter } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+import { queryDuneSql } from "../helpers/dune";
+
+// x402.miroshark.xyz — MiroShark's paid x402 API (https://www.miroshark.xyz/):
+// multi-agent social simulation runs priced at $1.00 USDC per POST /run call.
+//
+// Payments settle on Base as gasless USDC transfers (EIP-3009
+// transferWithAuthorization) submitted by x402 facilitators. Facilitator
+// sender addresses rotate, so instead of a facilitator allowlist we identify
+// x402 settlements structurally: the transaction is sent directly to the
+// token contract (tx_to = contract_address) by someone other than the token
+// sender ("from" != tx_from) — i.e. a gasless EIP-3009 settlement.
+const RECEIVERS = [
+  '0x6cab485fc28ec70d3845113b704d4824e4d2b24f', // payTo wallet (MiroShark deployer)
+  '0x67976cebb5266b50a08c0dcb676e03baf305e3a2', // early payments landed here due to a payTo misconfiguration
+];
+
+const prefetch = async (options: FetchOptions) => {
+  return queryDuneSql(options, `
+    select
+      CAST(contract_address as varchar) as token,
+      SUM(amount_raw) as revenue
+    from tokens.transfers
+    where blockchain = 'base'
+      and "to" IN (${RECEIVERS.join(', ')})
+      and tx_to = contract_address
+      and "from" != tx_from
+      and "from" != "to"
+      and TIME_RANGE
+    group by contract_address
+  `);
+};
+
+async function fetch(options: FetchOptions) {
+  const dailyFees = options.createBalances();
+  const results = options.preFetchedResults || [];
+  results.forEach((row: { token: string; revenue: string }) => dailyFees.add(row.token, row.revenue));
+
+  return {
+    dailyFees,
+    dailyUserFees: dailyFees,
+    dailyRevenue: dailyFees,
+    dailyProtocolRevenue: dailyFees,
+  };
+}
+
+const adapter: SimpleAdapter = {
+  version: 1,
+  fetch,
+  prefetch,
+  chains: [CHAIN.BASE],
+  dependencies: [Dependencies.DUNE],
+  start: '2026-04-01',
+  methodology: {
+    Fees: 'API usage fees paid by users of the x402.miroshark.xyz simulation API ($1.00 USDC per simulation run), settled on Base via x402 (gasless EIP-3009 USDC transfers submitted by x402 facilitators).',
+    UserFees: 'API usage fees paid by users.',
+    Revenue: 'All API fees accrue to MiroShark — there is no supply side and facilitators charge no on-chain cut.',
+    ProtocolRevenue: 'All API fees accrue to MiroShark.',
+  },
+};
+
+export default adapter;

--- a/fees/miroshark-x402.ts
+++ b/fees/miroshark-x402.ts
@@ -39,7 +39,6 @@ async function fetch(options: FetchOptions) {
 
   return {
     dailyFees,
-    dailyUserFees: dailyFees,
     dailyRevenue: dailyFees,
     dailyProtocolRevenue: dailyFees,
   };
@@ -54,7 +53,6 @@ const adapter: SimpleAdapter = {
   start: '2026-04-01',
   methodology: {
     Fees: 'API usage fees paid by users of the x402.miroshark.xyz simulation API ($1.00 USDC per simulation run), settled on Base via x402 (gasless EIP-3009 USDC transfers submitted by x402 facilitators).',
-    UserFees: 'API usage fees paid by users.',
     Revenue: 'All API fees accrue to MiroShark — there is no supply side and facilitators charge no on-chain cut.',
     ProtocolRevenue: 'All API fees accrue to MiroShark.',
   },

--- a/fees/miroshark-x402.ts
+++ b/fees/miroshark-x402.ts
@@ -1,6 +1,6 @@
-import { Dependencies, FetchOptions, SimpleAdapter } from "../adapters/types";
+import { FetchOptions, SimpleAdapter } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
-import { queryDuneSql } from "../helpers/dune";
+import ADDRESSES from "../helpers/coreAssets.json";
 
 // x402.miroshark.xyz — MiroShark's paid x402 API (https://www.miroshark.xyz/):
 // multi-agent social simulation runs priced at $1.00 USDC per POST /run call.
@@ -8,34 +8,56 @@ import { queryDuneSql } from "../helpers/dune";
 // Payments settle on Base as gasless USDC transfers (EIP-3009
 // transferWithAuthorization) submitted by x402 facilitators. Facilitator
 // sender addresses rotate, so instead of a facilitator allowlist we identify
-// x402 settlements structurally: the transaction is sent directly to the
-// token contract (tx_to = contract_address) by someone other than the token
-// sender ("from" != tx_from) — i.e. a gasless EIP-3009 settlement.
+// x402 settlements structurally: a USDC Transfer to the payTo wallet whose
+// transaction also emits AuthorizationUsed(authorizer = payer) — the signature
+// of a gasless EIP-3009 settlement. Plain transfers (CEX withdrawals, manual
+// sends, swap outputs) emit no AuthorizationUsed and are excluded.
+const USDC = ADDRESSES.base.USDC;
 const RECEIVERS = [
   '0x6cab485fc28ec70d3845113b704d4824e4d2b24f', // payTo wallet (MiroShark deployer)
   '0x67976cebb5266b50a08c0dcb676e03baf305e3a2', // early payments landed here due to a payTo misconfiguration
 ];
 
-const prefetch = async (options: FetchOptions) => {
-  return queryDuneSql(options, `
-    select
-      CAST(contract_address as varchar) as token,
-      SUM(amount_raw) as revenue
-    from tokens.transfers
-    where blockchain = 'base'
-      and "to" IN (${RECEIVERS.join(', ')})
-      and tx_to = contract_address
-      and "from" != tx_from
-      and "from" != "to"
-      and TIME_RANGE
-    group by contract_address
-  `);
-};
+const TRANSFER_TOPIC = '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef';
+const AUTHORIZATION_USED_TOPIC = '0x98de503528ee59b575ef0c0a2576a82497bfc029a5685b209e9ec333479b10a5'; // AuthorizationUsed(address,bytes32)
+
+const padAddress = (address: string) => '0x000000000000000000000000' + address.slice(2).toLowerCase();
+const topicToAddress = (topic: string) => '0x' + topic.slice(26).toLowerCase();
 
 async function fetch(options: FetchOptions) {
   const dailyFees = options.createBalances();
-  const results = options.preFetchedResults || [];
-  results.forEach((row: { token: string; revenue: string }) => dailyFees.add(row.token, row.revenue));
+  const ownWallets = new Set(RECEIVERS.map((a) => a.toLowerCase()));
+
+  for (const receiver of RECEIVERS) {
+    const transfers = await options.getLogs({
+      target: USDC,
+      topics: [TRANSFER_TOPIC, null as any, padAddress(receiver)],
+      entireLog: true,
+    });
+
+    // external payers seen today
+    const payers = [...new Set(
+      transfers.map((log: any) => topicToAddress(log.topics[1])).filter((payer: string) => !ownWallets.has(payer))
+    )];
+
+    // transactions where a payer used an EIP-3009 authorization (x402 settlement)
+    const authorizedTxs = new Set<string>();
+    for (const payer of payers) {
+      const auths = await options.getLogs({
+        target: USDC,
+        topics: [AUTHORIZATION_USED_TOPIC, padAddress(payer)],
+        entireLog: true,
+      });
+      auths.forEach((log: any) => authorizedTxs.add(log.transactionHash.toLowerCase()));
+    }
+
+    for (const log of transfers) {
+      const payer = topicToAddress(log.topics[1]);
+      if (ownWallets.has(payer)) continue; // internal transfer
+      if (!authorizedTxs.has(log.transactionHash.toLowerCase())) continue; // not a gasless EIP-3009 settlement
+      dailyFees.add(USDC, BigInt(log.data).toString());
+    }
+  }
 
   return {
     dailyFees,
@@ -45,11 +67,10 @@ async function fetch(options: FetchOptions) {
 }
 
 const adapter: SimpleAdapter = {
-  version: 1,
+  version: 2,
+  pullHourly: true,
   fetch,
-  prefetch,
   chains: [CHAIN.BASE],
-  dependencies: [Dependencies.DUNE],
   start: '2026-04-01',
   methodology: {
     Fees: 'API usage fees paid by users of the x402.miroshark.xyz simulation API ($1.00 USDC per simulation run), settled on Base via x402 (gasless EIP-3009 USDC transfers submitted by x402 facilitators).',

--- a/fees/miroshark-x402.ts
+++ b/fees/miroshark-x402.ts
@@ -55,7 +55,7 @@ async function fetch(options: FetchOptions) {
       const payer = topicToAddress(log.topics[1]);
       if (ownWallets.has(payer)) continue; // internal transfer
       if (!authorizedTxs.has(log.transactionHash.toLowerCase())) continue; // not a gasless EIP-3009 settlement
-      dailyFees.add(USDC, BigInt(log.data).toString());
+      dailyFees.add(USDC, BigInt(log.data).toString(), "API usage fees");
     }
   }
 
@@ -76,6 +76,17 @@ const adapter: SimpleAdapter = {
     Fees: 'API usage fees paid by users of the x402.miroshark.xyz simulation API ($1.00 USDC per simulation run), settled on Base via x402 (gasless EIP-3009 USDC transfers submitted by x402 facilitators).',
     Revenue: 'All API fees accrue to MiroShark — there is no supply side and facilitators charge no on-chain cut.',
     ProtocolRevenue: 'All API fees accrue to MiroShark.',
+  },
+  breakdownMethodology: {
+    Fees: {
+      'API usage fees': 'Fees paid by users of the x402.miroshark.xyz simulation API ($1.00 USDC per simulation run), settled on Base via x402.',
+    },
+    Revenue: {
+      'API usage fees': 'All API usage fees accrue to MiroShark.',
+    },
+    ProtocolRevenue: {
+      'API usage fees': 'All API usage fees accrue to MiroShark.',
+    },
   },
 };
 


### PR DESCRIPTION
## MiroShark x402 API

- Endpoint: https://x402.miroshark.xyz — multi-agent social simulation API, $1.00 USDC per `POST /run` (x402 / HTTP 402 payments)
- Website: https://www.miroshark.xyz/
- Twitter: https://x.com/miroshark_
- Related: MiroShark token adapter #8188 (same project; this tracks the API product — suggest listing as a separate protocol, category `AI Agents` or as the team sees fit, optionally under a MiroShark parent)

## What this adapter tracks

API usage fees paid via x402 on Base. Payments settle as **gasless EIP-3009 USDC transfers** (`transferWithAuthorization`) submitted by x402 facilitators to the project's payTo wallets:

- [`0x6cab485fc28ec70d3845113b704d4824e4d2b24f`](https://basescan.org/address/0x6cab485fc28ec70d3845113b704d4824e4d2b24f) — current payTo (MiroShark deployer)
- [`0x67976cebb5266b50a08c0dcb676e03baf305e3a2`](https://basescan.org/address/0x67976cebb5266b50a08c0dcb676e03baf305e3a2) — received early payments due to a payTo misconfiguration

**Filter design** (pure on-chain, no Dune): facilitator sender EOAs rotate, so instead of a facilitator allowlist the adapter identifies settlements structurally — a USDC `Transfer` to the payTo wallet counts only if the same transaction emits `AuthorizationUsed(authorizer = payer)` on the USDC contract, which is the signature of a gasless EIP-3009 settlement. Plain transfers (CEX withdrawals, manual sends, swap outputs) emit no `AuthorizationUsed` and are excluded, which is what isolates x402 revenue on these mixed-use wallets.

## Test

```
🦙 Running MIROSHARK-X402 adapter 🦙  (2026-07-15 → 24h window covering Jul 14)
Daily fees: 8.00
Daily revenue: 8.00
```

Verified against ground truth: exactly 8 × $1.00 x402 payments on-chain that day ([example settlement](https://basescan.org/tx/0xec18341bbb4a6822afe6f9090abf274c25659b0e6097c92f7a3eda7a8b80a993)). Also tested: Jul 13 → $1.00 (1 payment ✓), current 24h → $0 (no payments in window ✓).