### PR TITLE
Add Ravenhood (RVH) fees/revenue adapter

### DIFF
--- a/fees/ravenhood.ts
+++ b/fees/ravenhood.ts
@@ -1,5 +1,6 @@
 import { Adapter, FetchOptions } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
+import { METRIC } from "../helpers/metrics";
 
 // RavenhoodRitual (the protocol's core contract) periodically calls
 // RavenhoodVault.claimFees()/claimBurn(), both of which call the Uniswap V3
@@ -23,10 +24,8 @@ const EVENTS = {
 const fetch = async (options: FetchOptions) => {
   const dailyFees = options.createBalances();
 
-  const [collectLogs, decreaseLogs] = await Promise.all([
-    options.getLogs({ target: POSITION_MANAGER, eventAbi: EVENTS.collect, entireLog: true, parseLog: true }),
-    options.getLogs({ target: POSITION_MANAGER, eventAbi: EVENTS.decreaseLiquidity, entireLog: true, parseLog: true }),
-  ]);
+  const collectLogs = await options.getLogs({ target: POSITION_MANAGER, eventAbi: EVENTS.collect, entireLog: true, parseLog: true });
+  const decreaseLogs = await options.getLogs({ target: POSITION_MANAGER, eventAbi: EVENTS.decreaseLiquidity, entireLog: true, parseLog: true });
 
   const withdrawnMap = new Map<string, { amount0: bigint; amount1: bigint }>();
   for (const log of decreaseLogs as any[]) {
@@ -40,8 +39,7 @@ const fetch = async (options: FetchOptions) => {
   }
 
   for (const log of collectLogs as any[]) {
-    if (String(log.args.tokenId) !== POSITION_ID) continue;
-    if (log.args.recipient.toLowerCase() !== RAVENHOOD_RITUAL.toLowerCase()) continue;
+    if (String(log.args.tokenId) !== POSITION_ID || log.args.recipient.toLowerCase() !== RAVENHOOD_RITUAL.toLowerCase()) continue;
     const key = log.transactionHash.toLowerCase();
     const withdrawn = withdrawnMap.get(key);
 
@@ -52,25 +50,36 @@ const fetch = async (options: FetchOptions) => {
       amount1 = amount1 > withdrawn.amount1 ? amount1 - withdrawn.amount1 : 0n;
     }
 
-    if (amount0 > 0n) dailyFees.add(WETH, amount0.toString());
-    if (amount1 > 0n) dailyFees.add(RVH, amount1.toString());
+    if (amount0 > 0n) dailyFees.add(WETH, amount0, METRIC.SWAP_FEES);
+    if (amount1 > 0n) dailyFees.add(RVH, amount1, METRIC.SWAP_FEES);
   }
 
   return { dailyFees, dailyRevenue: dailyFees };
 };
 
+const methodology = {
+  Fees: "Swap fees collected from RavenhoodVault's single permanently-locked RVH/WETH Uniswap V3 position (tokenId 17757), read from Collect events on the position manager, with any co-occurring DecreaseLiquidity principal subtracted out.",
+  Revenue: "100% of collected fees - the locked position is the protocol's own treasury (routed to buyback+burn or the owner depending on burn progress), not third-party LP yield paid to external depositors.",
+}
+
+const breakdownMethodology = {
+  Fees: {
+    [METRIC.SWAP_FEES]: "Swap fees collected from RavenhoodVault's single permanently-locked RVH/WETH Uniswap V3 position (tokenId 17757), read from Collect events on the position manager, with any co-occurring DecreaseLiquidity principal subtracted out.",
+  },
+  Revenue: {
+    [METRIC.SWAP_FEES]: "100% of collected fees - the locked position is the protocol's own treasury (routed to buyback+burn or the owner depending on burn progress), not third-party LP yield paid to external depositors.",
+  },
+}
+
 const adapter: Adapter = {
   version: 2,
-  adapter: {
-    [CHAIN.ROBINHOOD]: {
-      fetch,
-      start: "2026-07-08",
-    },
-  },
-  methodology: {
-    Fees: "Swap fees collected from RavenhoodVault's single permanently-locked RVH/WETH Uniswap V3 position (tokenId 17757), read from Collect events on the position manager, with any co-occurring DecreaseLiquidity principal subtracted out.",
-    Revenue: "100% of collected fees - the locked position is the protocol's own treasury (routed to buyback+burn or the owner depending on burn progress), not third-party LP yield paid to external depositors.",
-  },
+  fetch,
+  pullHourly: true,
+  chains: [CHAIN.ROBINHOOD],
+  start: "2026-07-08",
+  methodology,
+  breakdownMethodology,
+  doublecounted: true, // uniswap
 };
 
 export default adapter;

--- a/fees/ravenhood.ts
+++ b/fees/ravenhood.ts
@@ -1,0 +1,76 @@
+import { Adapter, FetchOptions } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+
+// RavenhoodRitual (the protocol's core contract) periodically calls
+// RavenhoodVault.claimFees()/claimBurn(), both of which call the Uniswap V3
+// NonfungiblePositionManager's collect() on the vault's single permanently-locked
+// RVH/WETH position (tokenId 17757), with recipient = RavenhoodRitual. claimBurn()
+// also decreases liquidity (removes 0.5% of the locked principal) in the same
+// transaction as its collect() call, so Collect events need any co-occurring
+// DecreaseLiquidity principal subtracted out to isolate pure swap-fee revenue -
+// same technique used in fees/olympus-dao.ts for its own treasury-owned positions.
+const POSITION_MANAGER = "0x73991a25C818Bf1f1128dEAaB1492D45638DE0D3";
+const RAVENHOOD_RITUAL = "0xF65227639636288F3ec7D1368DBf6e6F7a99b533"; // recipient of every collect()
+const POSITION_ID = "17757";
+const WETH = "0x0Bd7D308f8E1639FAb988df18A8011f41EAcAD73"; // token0 (lower address)
+const RVH = "0x96765066f6a040a21EB027167D2315B707c82633"; // token1
+
+const EVENTS = {
+  collect: "event Collect(uint256 indexed tokenId, address recipient, uint256 amount0, uint256 amount1)",
+  decreaseLiquidity: "event DecreaseLiquidity(uint256 indexed tokenId, uint128 liquidity, uint256 amount0, uint256 amount1)",
+};
+
+const fetch = async (options: FetchOptions) => {
+  const dailyFees = options.createBalances();
+
+  const [collectLogs, decreaseLogs] = await Promise.all([
+    options.getLogs({ target: POSITION_MANAGER, eventAbi: EVENTS.collect, entireLog: true, parseLog: true }),
+    options.getLogs({ target: POSITION_MANAGER, eventAbi: EVENTS.decreaseLiquidity, entireLog: true, parseLog: true }),
+  ]);
+
+  const withdrawnMap = new Map<string, { amount0: bigint; amount1: bigint }>();
+  for (const log of decreaseLogs as any[]) {
+    if (String(log.args.tokenId) !== POSITION_ID) continue;
+    const key = log.transactionHash.toLowerCase();
+    const existing = withdrawnMap.get(key) || { amount0: 0n, amount1: 0n };
+    withdrawnMap.set(key, {
+      amount0: existing.amount0 + BigInt(log.args.amount0 || 0),
+      amount1: existing.amount1 + BigInt(log.args.amount1 || 0),
+    });
+  }
+
+  for (const log of collectLogs as any[]) {
+    if (String(log.args.tokenId) !== POSITION_ID) continue;
+    if (log.args.recipient.toLowerCase() !== RAVENHOOD_RITUAL.toLowerCase()) continue;
+    const key = log.transactionHash.toLowerCase();
+    const withdrawn = withdrawnMap.get(key);
+
+    let amount0 = BigInt(log.args.amount0 || 0);
+    let amount1 = BigInt(log.args.amount1 || 0);
+    if (withdrawn) {
+      amount0 = amount0 > withdrawn.amount0 ? amount0 - withdrawn.amount0 : 0n;
+      amount1 = amount1 > withdrawn.amount1 ? amount1 - withdrawn.amount1 : 0n;
+    }
+
+    if (amount0 > 0n) dailyFees.add(WETH, amount0.toString());
+    if (amount1 > 0n) dailyFees.add(RVH, amount1.toString());
+  }
+
+  return { dailyFees, dailyRevenue: dailyFees };
+};
+
+const adapter: Adapter = {
+  version: 2,
+  adapter: {
+    [CHAIN.ROBINHOOD]: {
+      fetch,
+      start: "2026-07-08",
+    },
+  },
+  methodology: {
+    Fees: "Swap fees collected from RavenhoodVault's single permanently-locked RVH/WETH Uniswap V3 position (tokenId 17757), read from Collect events on the position manager, with any co-occurring DecreaseLiquidity principal subtracted out.",
+    Revenue: "100% of collected fees - the locked position is the protocol's own treasury (routed to buyback+burn or the owner depending on burn progress), not third-party LP yield paid to external depositors.",
+  },
+};
+
+export default adapter;


### PR DESCRIPTION
https://defillama.com/protocol/ravenhood

## Summary
Ravenhood (RVH, Robinhood Chain) has TVL/staking tracked in DefiLlama-Adapters but has never had fees/revenue tracked here.

Tracks swap fees collected from `RavenhoodVault`'s single permanently-locked RVH/WETH Uniswap V3 position (tokenId 17757) via `Collect` events on the position manager, subtracting out any co-occurring `DecreaseLiquidity` principal - the protocol's `claimBurn()` function removes 0.5% of the locked liquidity and collects accumulated fees in the same transaction, so the two need to be disambiguated. This is the same technique already used in `fees/olympus-dao.ts`'s `fetchUniV3POLFees` for its own treasury-owned Uniswap V3 positions.

100% of collected fees are counted as protocol revenue - the locked position is the protocol's own treasury (routed to buyback+burn or the owner depending on burn progress via `RavenhoodRitual`), not third-party LP yield paid out to external depositors.

## Test plan
```
$ npx ts-node --transpile-only cli/testAdapter.ts fees/ravenhood

ROBINHOOD 👇
Daily fees: 234.00
Daily revenue: 234.00
```