### PR TITLE
fix(obol): drop revenue on days the API's total_revenue returns 0

### DIFF
--- a/fees/obol/index.ts
+++ b/fees/obol/index.ts
@@ -40,7 +40,16 @@ const fetch = async (options: FetchOptions) => {
   ]);
 
   const dailyFeesETH = current.totalFees - previous.totalFees;
-  const dailyRevenueETH = current.totalRevenue - previous.totalRevenue;
+  let dailyRevenueETH = current.totalRevenue - previous.totalRevenue;
+
+  // The Obol API's total_revenue field intermittently returns 0 (the correctedTotalRevenues map
+  // above patches individual known dates one at a time). When total_revenue is 0 on either the
+  // current or the previous day, this day-over-day delta becomes a phantom ~118 ETH (~$200k) swing
+  // (positive on the day it recovers to ~118, negative on the day it drops to 0) while real daily
+  // revenue is ~0.1-0.2 ETH, which surfaces on the protocol page as Revenue several times larger
+  // than Fees on some days and deeply negative on others. Revenue is a share of the fees, so treat
+  // a 0 on either side as missing data and book no revenue for that day.
+  if (current.totalRevenue === 0 || previous.totalRevenue === 0) dailyRevenueETH = 0;
 
   const dailyFees = options.createBalances();
   const dailyRevenue = options.createBalances();


### PR DESCRIPTION
Obol's Revenue currently shows values several times larger than its Fees on some days and deeply negative on others. That is impossible: Revenue here is Obol's share of the fees, so it can never exceed Fees or go negative.

The cause is upstream data, not the math. `fetchCumulativeData` reads two cumulative fields from the Obol API:

- `total_fees_eth_denominated` is stable and grows smoothly
- `total_revenue` intermittently returns 0

Daily revenue is booked as `current.total_revenue - previous.total_revenue`. When `total_revenue` flips 118 to 0 to 118, that delta becomes a phantom +/-118 ETH (about $200k) swing, while the real daily revenue is about 0.1 to 0.2 ETH.

Observed live on the API (cumulative `total_revenue`):

```
2026-07-06   118.89
2026-07-07   0        <- API returned 0
2026-07-08   0
2026-07-09   117.49   <- recovered
2026-07-10   0        <- 0 again
2026-07-11..14  0
2026-07-15   119.10   <- recovered
```

`total_fees_eth_denominated` over the same window stays 824 to 836 and never hits 0.

On 2026-07-15 the recovery (0 to 119.10) booked dailyRevenue of about $227k against dailyFees of about $18.6k, so the protocol page showed Revenue at roughly 12x Fees, with dailySupplySideRevenue (fees to node operators) going negative since it is derived from `dailyFees - dailyRevenue`.

The adapter already patches individual glitch dates by hand through `correctedTotalRevenues` (the comment there notes "api wrongly returns 0"), which confirms this is a known recurring glitch and not real data. This change generalizes that patch: when `total_revenue` is 0 on either the current or the previous day, treat it as missing and book no revenue for that day instead of a phantom swing.

One file, guards only the revenue branch. Fees are untouched (the fees field does not glitch), and dailySupplySideRevenue stays consistent because it is still `dailyFees - dailyRevenue`.

Verified against the live sequence above: every +/-118 ETH swing collapses to 0, while normal days keep their real small deltas.
