### PR TITLE
four-meme: measure bonding-curve volume directly

### DIFF
--- a/dexs/four-meme/index.ts
+++ b/dexs/four-meme/index.ts
@@ -4,8 +4,9 @@ import { queryDuneSql } from '../../helpers/dune';
 
 // Trades emit on TokenManager V1 (BNB) and TokenManager2 (BNB or ERC-20 quote), regardless of router.
 const WBNB = '0xbb4cdb9cbd36b01bd1cbaebf2de08d9173bc095c'
+const TOKEN_MANAGER_V2 = '0x5c952063c7fc8610ffdb798152d69f0b9550762b'
 
-// Quote token: a supported ERC-20 quote (USDT/USD1/USDC/BUSD/CAKE) if it's in most of a token's trades, else BNB (native BNB pays emit no transfer).
+// Quote token: a supported ERC-20 quote (USDT/USD1/USDC/BUSD/CAKE) if it moves to/from TokenManager2 in most of a token's trades, else BNB (native BNB pays emit no transfer).
 const fetch = async (options: FetchOptions) => {
   const query = `
     WITH v2_trades AS (
@@ -22,6 +23,7 @@ const fetch = async (options: FetchOptions) => {
       FROM erc20_bnb.evt_transfer tr
       JOIN tx_tokens tt ON tt.evt_tx_hash = tr.evt_tx_hash
       WHERE tr.evt_block_time >= from_unixtime(${options.startTimestamp}) AND tr.evt_block_time < from_unixtime(${options.endTimestamp})
+        AND (tr."to" = ${TOKEN_MANAGER_V2} OR tr."from" = ${TOKEN_MANAGER_V2})
         AND tr.contract_address IN (
           0x55d398326f99059ff775485246999027b3197955, -- USDT
           0x8d0d000ee44948fc98c9b98a4fa4921476f08b0d, -- USD1

--- a/dexs/four-meme/index.ts
+++ b/dexs/four-meme/index.ts
@@ -2,73 +2,64 @@ import { Dependencies, FetchOptions, SimpleAdapter } from "../../adapters/types"
 import { CHAIN } from "../../helpers/chains";
 import { queryDuneSql } from '../../helpers/dune';
 
-const feeReceiverMultisig = [
-  "0x48735904455eDa3aa9a0c9e43EE9999c795E30b9",
-  "0x55d571b7475F4382C2a15D24A7C864cA679407c4",
-  "0x60Be34554F193f4f6862b0E12DC16BA30163D6d0",
-  "0x31120f443365efa63330d2D962f537aE28f0d672",
-  "0xf89b36B36A634745eEFbbF17d5F777A494F8B6F7",
-  "0xC1865A53609eaEC415b530632F43F4297392b224",
-  "0xAaC9B5c6bC7D8bE29A4021138f8A0b29e557Ff90",
-  "0xbB389e252bDf9d55332D217d9FE06bED43b23c2f",
-  "0xC1D73ed52f810dB8A2C1a5785C5b743F1996DbB4",
-  "0x15Eb4Cbc2C53bf6CDBE49711E8b2E97D2712439a",
-  "0xB5afC2F8836682AFD5A711Ad555e7FD55ec38a20",
-  "0x060aeca503f7383Fe8FBA8c9659ee0b8bf637077",
-  "0x0232fCa3F2E8bb567e851151c396cEB3D0D47c11",
-  "0x821cfB3921Bae561fbF9527fdc5A4285468740AA",
-  "0xb10c5381fC00Bc8296016EC21B7E29a852414c48"
-] // source: https://dune.com/queries/4068894/6851717
+// Trades emit on TokenManager V1 (BNB) and TokenManager2 (BNB/stablecoin), regardless of router.
+const WBNB = '0xbb4cdb9cbd36b01bd1cbaebf2de08d9173bc095c'
 
-const fromAddresses = [
-  "0xEC4549caDcE5DA21Df6E6422d448034B5233bFbC",
-  "0x5c952063c7fc8610FFDB798152D69F0B9550762b"
-]
-
+// Quote currency: stablecoin if it's in most of a token's trades, else BNB (native BNB pays emit no transfer).
 const fetch = async (options: FetchOptions) => {
   const query = `
-    SELECT
-      COALESCE(SUM(p.price * (CAST(bytearray_to_uint256(bytearray_substring(l.data, 1, 32)) AS DOUBLE) / 1e18)), 0) AS daily_fees_usd
-    FROM bnb.logs l
-    LEFT JOIN prices.usd p ON 
-      p.blockchain = 'bnb'
-      AND p.contract_address = 0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c
-      AND p.minute = date_trunc('minute', l.block_time)
-    WHERE l.topic0 = 0x3d0ce9bfc3ed7d6862dbb28b2dea94561fe714a1b4d019aa8af39730d1ad7c3d
-    AND l.contract_address IN (
-      0x48735904455eDa3aa9a0c9e43EE9999c795E30b9,
-      0x55d571b7475F4382C2a15D24A7C864cA679407c4,
-      0x60Be34554F193f4f6862b0E12DC16BA30163D6d0,
-      0x31120f443365efa63330d2D962f537aE28f0d672,
-      0xf89b36B36A634745eEFbbF17d5F777A494F8B6F7,
-      0xC1865A53609eaEC415b530632F43F4297392b224,
-      0xAaC9B5c6bC7D8bE29A4021138f8A0b29e557Ff90,
-      0xbB389e252bDf9d55332D217d9FE06bED43b23c2f,
-      0xC1D73ed52f810dB8A2C1a5785C5b743F1996DbB4,
-      0x15Eb4Cbc2C53bf6CDBE49711E8b2E97D2712439a,
-      0xB5afC2F8836682AFD5A711Ad555e7FD55ec38a20,
-      0x060aeca503f7383Fe8FBA8c9659ee0b8bf637077,
-      0x0232fCa3F2E8bb567e851151c396cEB3D0D47c11,
-      0x821cfB3921Bae561fbF9527fdc5A4285468740AA,
-      0xb10c5381fC00Bc8296016EC21B7E29a852414c48
+    WITH v2_trades AS (
+      SELECT evt_tx_hash, token, cost FROM four_meme_bnb.tokenmanager2_evt_tokenpurchase
+      WHERE evt_block_time >= from_unixtime(${options.startTimestamp}) AND evt_block_time < from_unixtime(${options.endTimestamp})
+      UNION ALL
+      SELECT evt_tx_hash, token, cost FROM four_meme_bnb.tokenmanager2_evt_tokensale
+      WHERE evt_block_time >= from_unixtime(${options.startTimestamp}) AND evt_block_time < from_unixtime(${options.endTimestamp})
+    ),
+    tx_tokens AS (SELECT DISTINCT evt_tx_hash, token FROM v2_trades),
+    token_trades AS (SELECT token AS meme, COUNT(DISTINCT evt_tx_hash) AS n_tx FROM v2_trades GROUP BY 1),
+    stable_hits AS (
+      SELECT tt.token AS meme, tr.contract_address AS base, COUNT(DISTINCT tt.evt_tx_hash) AS tx_hits
+      FROM erc20_bnb.evt_transfer tr
+      JOIN tx_tokens tt ON tt.evt_tx_hash = tr.evt_tx_hash
+      WHERE tr.evt_block_time >= from_unixtime(${options.startTimestamp}) AND tr.evt_block_time < from_unixtime(${options.endTimestamp})
+        AND tr.contract_address IN (
+          0x55d398326f99059ff775485246999027b3197955, -- USDT
+          0x8d0d000ee44948fc98c9b98a4fa4921476f08b0d, -- USD1
+          0x8ac76a51cc950d9822d68b83fe1ad97b32cd580d, -- USDC
+          0xe9e7cea3dedca5984780bafc599bd69add087d56, -- BUSD
+          0x0e09fabb73bd3ade0a17ecc321fd13a19e81ce82  -- CAKE
+        )
+      GROUP BY 1, 2
+    ),
+    stable_base AS (
+      SELECT meme, base FROM (
+        SELECT s.meme, s.base, ROW_NUMBER() OVER (PARTITION BY s.meme ORDER BY s.tx_hits DESC) AS rn
+        FROM stable_hits s JOIN token_trades tt ON tt.meme = s.meme
+        WHERE s.tx_hits * 2 >= tt.n_tx
+      ) x WHERE rn = 1
+    ),
+    per_base AS (
+      SELECT COALESCE(sb.base, ${WBNB}) AS base_token, SUM(t.cost) AS amount
+      FROM v2_trades t LEFT JOIN stable_base sb ON sb.meme = t.token
+      GROUP BY 1
+      UNION ALL
+      SELECT ${WBNB} AS base_token, SUM(amount) AS amount FROM (
+        SELECT etheramount AS amount FROM four_meme_bnb.tokenmanager_evt_tokenpurchase
+        WHERE evt_block_time >= from_unixtime(${options.startTimestamp}) AND evt_block_time < from_unixtime(${options.endTimestamp})
+        UNION ALL
+        SELECT etheramount AS amount FROM four_meme_bnb.tokenmanager_evt_tokensale
+        WHERE evt_block_time >= from_unixtime(${options.startTimestamp}) AND evt_block_time < from_unixtime(${options.endTimestamp})
+      ) v1
     )
-    AND l.topic1 IN (
-      0x000000000000000000000000EC4549caDcE5DA21Df6E6422d448034B5233bFbC,
-      0x0000000000000000000000005c952063c7fc8610FFDB798152D69F0B9550762b
-    )
-    AND l.block_time >= from_unixtime(${options.startTimestamp})
-    AND l.block_time < from_unixtime(${options.endTimestamp})
+    SELECT lower('0x' || to_hex(base_token)) AS base_token, CAST(SUM(amount) AS varchar) AS amount
+    FROM per_base GROUP BY 1
   `
 
-  let dailyVolume = options.createBalances()
-  const result = await queryDuneSql(options, query)
-
-  if (result && result.length > 0) {
-    dailyVolume.addUSDValue(result[0].daily_fees_usd * 100)
+  const dailyVolume = options.createBalances()
+  const rows = await queryDuneSql(options, query)
+  for (const row of rows) {
+    if (row.amount) dailyVolume.add(row.base_token, row.amount)
   }
-
-  // await addGasTokensReceived({ multisigs: feeReceiverMultisig, balances: dailyVolume, options, fromAddresses })
-  // dailyVolume = dailyVolume.resizeBy(100) // because of 1% fixed platform fee as per docs
 
   return { dailyVolume }
 }
@@ -80,6 +71,9 @@ const adapter: SimpleAdapter = {
   start: '2024-12-25',
   dependencies: [Dependencies.DUNE],
   isExpensiveAdapter: true,
+  methodology: {
+    Volume: "Sum of every buy and sell on four.meme's V1 and V2 bonding curves, taken from the on-chain TokenPurchase/TokenSale events. Each trade's cost is valued in the curve's quote currency: BNB by default, or the stablecoin (USDT, USD1, USDC, BUSD, CAKE) the curve is priced in.",
+  },
 }
 
 export default adapter

--- a/dexs/four-meme/index.ts
+++ b/dexs/four-meme/index.ts
@@ -2,10 +2,10 @@ import { Dependencies, FetchOptions, SimpleAdapter } from "../../adapters/types"
 import { CHAIN } from "../../helpers/chains";
 import { queryDuneSql } from '../../helpers/dune';
 
-// Trades emit on TokenManager V1 (BNB) and TokenManager2 (BNB/stablecoin), regardless of router.
+// Trades emit on TokenManager V1 (BNB) and TokenManager2 (BNB or ERC-20 quote), regardless of router.
 const WBNB = '0xbb4cdb9cbd36b01bd1cbaebf2de08d9173bc095c'
 
-// Quote currency: stablecoin if it's in most of a token's trades, else BNB (native BNB pays emit no transfer).
+// Quote token: a supported ERC-20 quote (USDT/USD1/USDC/BUSD/CAKE) if it's in most of a token's trades, else BNB (native BNB pays emit no transfer).
 const fetch = async (options: FetchOptions) => {
   const query = `
     WITH v2_trades AS (
@@ -72,7 +72,7 @@ const adapter: SimpleAdapter = {
   dependencies: [Dependencies.DUNE],
   isExpensiveAdapter: true,
   methodology: {
-    Volume: "Sum of every buy and sell on four.meme's V1 and V2 bonding curves, taken from the on-chain TokenPurchase/TokenSale events. Each trade's cost is valued in the curve's quote currency: BNB by default, or the stablecoin (USDT, USD1, USDC, BUSD, CAKE) the curve is priced in.",
+    Volume: "Sum of every buy and sell on four.meme's V1 and V2 bonding curves, taken from the on-chain TokenPurchase/TokenSale events. Each trade's cost is valued in the curve's quote token: BNB by default, or the ERC-20 quote token (USDT, USD1, USDC, BUSD, CAKE) the curve is priced in.",
   },
 }
 


### PR DESCRIPTION
Reworks the Four.Meme adapter to measure bonding-curve volume directly from trade events instead of estimating it from collected fees.

### Changes

- Switched from fee-based volume estimation to decoding `TokenPurchase` and `TokenSale` events from both V1 and V2 bonding curves.
- Added support for curves quoted in multiple base currencies (BNB, USDT, USD1, USDC, etc.), with pricing handled by the SDK.
- Removed the fixed **1% fee × 100** assumption and the hardcoded fee-recipient list.
- Added a methodology section.

### Verification

- Verified on-chain that event `cost` represents the trade size and `fee` is exactly **1%** of it.
- Confirmed the quote-currency detection prevents stablecoin trades from being mispriced as BNB.
- Daily volume for **2026-07-14** increases from **$4.33M → $4.91M**, primarily from previously untracked stablecoin-quoted curves.