### PR TITLE
silentswap: throw loudly on unpublished snapshots instead of silently reporting $0

### DIFF
--- a/bridge-aggregators/silentswap/index.ts
+++ b/bridge-aggregators/silentswap/index.ts
@@ -12,6 +12,7 @@ import type { FetchOptions, SimpleAdapter } from "../../adapters/types";
  */
 
 const STATS_CONTRACT = "0x5894a9B8B342BDb1AD7570C3656eE406eE26f676"; // BNB mainnet, deployed 2026-05-25
+const DEPLOYMENT_DATE = 20260525n; // the day before this has no snapshot by design, not due to a stall
 
 const ONE_DAY_SECONDS = 24 * 60 * 60;
 
@@ -47,13 +48,36 @@ const fetch = async (options: FetchOptions) => {
     ],
   });
 
+  // publishedAt == 0 means this date's row was never written at all (the
+  // struct's default value) - a genuine "no volume that day" snapshot always
+  // has a real publishedAt timestamp. This is exactly the failure mode that
+  // caused issue #8100 (a stalled keeper left ~10 days unpublished, which the
+  // old code silently reported as $0/day instead of surfacing the outage).
+  if (inflowData[0].publishedAt === 0n) {
+    throw new Error(
+      `silentswap: no snapshot published yet for ${date} (publishedAt=0) - ` +
+      `stats keeper may be stalled, not a genuine zero-volume day`,
+    );
+  }
+  if (prevDate >= DEPLOYMENT_DATE && inflowData[1].publishedAt === 0n) {
+    throw new Error(
+      `silentswap: no snapshot published yet for prior day ${prevDate} ` +
+      `(publishedAt=0) - cannot compute a valid delta against it`,
+    );
+  }
+  // prevDate before DEPLOYMENT_DATE (i.e. the adapter's first day, 2026-05-25)
+  // will always have publishedAt=0 - the contract didn't exist yet, this is
+  // expected and not a stall. inflowsTillYesterday correctly defaults to 0n
+  // in that case, so delta = inflowsTillToday, the full first day's volume.
+
   const inflowsTillToday = inflowData[0].inflowUsd;
   const inflowsTillYesterday = inflowData[1].inflowUsd;
 
-  // Clamp to >=0 (as documented in the methodology): a missing or reset
-  // snapshot on either date must never produce a negative daily volume.
+  // Clamp to >=0 as a secondary safety net for any other edge case (e.g. a
+  // genuine on-chain correction) - the publishedAt checks above now catch the
+  // actual outage scenario loudly instead of silently clamping it to 0.
   const delta = inflowsTillToday - inflowsTillYesterday;
-  const dailyInflows = delta > 0 ? delta : 0;
+  const dailyInflows = delta > 0n ? delta : 0n;
 
   return {
     dailyBridgeVolume: Number(dailyInflows) / 1e6,


### PR DESCRIPTION
Issue #8100 reported ~10 days of adapter data silently showing ~$0/day
because the SilentSwapStats keeper stalled (out-of-gas) and stopped
publishing daily snapshots to the contract. The adapter's existing
delta calculation (today.inflowUsd - yesterday.inflowUsd, clamped to
≥0) had no way to distinguish a genuine zero-volume day from a day
whose snapshot was simply never written - both looked identical after
the clamp, so the outage was invisible until someone noticed the
numbers looked wrong and filed an issue.

The struct has a `publishedAt` field that defaults to 0 when a date's
row has never been written. Fix: throw explicitly when either the
current or prior day's `publishedAt` is 0, rather than silently
computing a delta against an unpublished snapshot and clamping the
result to 0.

Checked this wouldn't misfire in normal operation before relying on
it: `publishedAt` for 2026-07-02 (a genuine pre-outage healthy day)
is `2026-07-02 12:30:23 UTC` - published same-day, well before this
adapter's own fetch would run for it. By contrast, the backfilled
outage days (e.g. 07-03) all carry a `publishedAt` around
`2026-07-13`, ten days after the date they represent - exactly what
you'd expect from a keeper that resumed and wrote its missed history
in one batch once fixed. That gap is the actual signal this fix relies
on, and it only appears during a genuine stall, not routine operation.

Verified independently on-chain (`cast call` against the live
contract) that the historical outage this issue reports is real and
now resolved: reconstructed the daily series for 2026-07-03 through
2026-07-14 from raw `volumeByDate()` values, confirming figures now
fall in the expected $12M-$37M/day range. This PR doesn't fix the
historical gap itself (that needs an admin-side reindex, already
requested in #8100) - it hardens the adapter so the same failure mode
surfaces immediately next time instead of silently reporting $0 again.

Verified locally: `ts-node --transpile-only` loads the file with no
errors (exit code 0). `npm run test bridge-aggregators/silentswap/index.ts`
runs clean for the current day (Daily bridge volume: $21.92M),
confirming the new guard doesn't false-positive on normal operation.

Related to #8100.