### PR TITLE
lifi/jumper: drop pullHourly to stop LI.FI API 429s

### DIFF
--- a/aggregators/jumper-exchange/index.ts
+++ b/aggregators/jumper-exchange/index.ts
@@ -36,7 +36,6 @@ const fetch: any = async (options: FetchOptions): Promise<FetchResultVolume> => 
 
 const adapter: SimpleAdapter = {
   version: 2,
-  pullHourly: true,
   adapter: Object.keys(LifiDiamonds).reduce((acc, chain) => {
     return {
       ...acc,

--- a/aggregators/lifi/index.ts
+++ b/aggregators/lifi/index.ts
@@ -45,7 +45,6 @@ const fetch: any = async (options: FetchOptions): Promise<FetchResultVolume> => 
 
 const adapter: SimpleAdapter = {
   version: 2,
-  pullHourly: true,
   adapter: Object.keys(LifiDiamonds).reduce((acc, chain) => {
     return {
       ...acc,

--- a/bridge-aggregators/jumper.exchange/index.ts
+++ b/bridge-aggregators/jumper.exchange/index.ts
@@ -31,7 +31,6 @@ const fetch: any = async (options: FetchOptions): Promise<FetchResultVolume> => 
 
 const adapter: SimpleAdapter = {
   version: 2,
-  pullHourly: true,
   adapter: Object.keys(LifiDiamonds).reduce((acc, chain) => {
     return {
       ...acc,

--- a/bridge-aggregators/lifi/index.ts
+++ b/bridge-aggregators/lifi/index.ts
@@ -32,7 +32,6 @@ const fetch: any = async (options: FetchOptions): Promise<FetchResultVolume> => 
 
 const adapter: SimpleAdapter = {
   version: 2,
-  pullHourly: true,
   adapter: Object.keys(LifiDiamonds).reduce((acc, chain) => {
     return {
       ...acc,

--- a/helpers/aggregators/lifi.ts
+++ b/helpers/aggregators/lifi.ts
@@ -1,6 +1,6 @@
 import { CHAIN } from "../../helpers/chains";
 import { Chain } from "../../adapters/types";
-import fetchURL from "../../utils/fetchURL";
+import { fetchURLAutoHandleRateLimit } from "../../utils/fetchURL";
 
 type IContract = {
   [c: string | Chain]: {
@@ -536,7 +536,9 @@ export const fetchVolumeFromLIFIAPI = async (chain: Chain, startTime: number, en
     }
 
     const url = `https://li.quest/v2/analytics/transfers?${params}`;
-    const response = await fetchURL(url) as LifiResponse;
+    // pullHourly runs this fetch 24x/day per chain and each call paginates, so the LI.FI
+    // analytics API 429s under the burst; back off + retry instead of failing the adapter
+    const response = await fetchURLAutoHandleRateLimit(url) as LifiResponse;
 
     if (!response?.data || !Array.isArray(response.data)) {
       break;


### PR DESCRIPTION
pullHourly ran the fetch 24x/day per chain, and each hourly call paginated the LI.FI analytics API - the burst 429'd and killed the adapter mid-day. These adapters aggregate to a daily total, so pullHourly is removed across the four lifi/jumper volume adapters; each API-routed chain now hits li.quest once/day. Also switched the helper to the backoff-aware fetch as insurance during pagination. fees/lifi left as-is (on-chain getLogs, no API path). Verified 2026-06-25: all four run clean.