### PR TITLE
[fix] superstate-uscc - include full yield in fees

### DIFF
--- a/fees/superstate-uscc/index.ts
+++ b/fees/superstate-uscc/index.ts
@@ -37,7 +37,7 @@ const fetch = async (options: FetchOptions) => {
     const rate = priceToday - priceYesterday;
 
     const dailyFees = options.createBalances();
-    dailyFees.addUSDValue(totalSupply * rate > 0 ? rate : 0);
+    dailyFees.addUSDValue(totalSupply * rate > 0 ? totalSupply * rate : 0);
 
     const dailyRevenue = options.createBalances();
     const oneYear = 365 * 24 * 60 * 60;


### PR DESCRIPTION
Superstate USCC reports Fees almost equal to Revenue (fees/rev = 1.00 over 30d), while its sibling adapter (USTB, `fees/superstate`) reports a ratio of about 14. The USCC yield component is missing from Fees.

The cause is operator precedence on this line:

```js
dailyFees.addUSDValue(totalSupply * rate > 0 ? rate : 0);
```

In JavaScript `*` binds tighter than `>`, which binds tighter than the ternary, so it parses as:

```js
dailyFees.addUSDValue((totalSupply * rate > 0) ? rate : 0);
```

The condition uses `totalSupply * rate`, but the value added is just `rate` (the per-token daily price change, a fraction of a cent). The `totalSupply` multiplier is dropped, so the daily yield collapses from `totalSupply * rate` (thousands of dollars) to `rate` (sub-dollar), leaving only the 0.75% management fee (`dailyRevenue`) in Fees.

The sibling adapter shows the intended computation:

```js
// fees/superstate/index.ts
dailyFees.addUSDValue(totalSupply * (priceToday - priceYesterday));
```

The fix keeps the non-negative clamp the USCC adapter intended, but adds the full yield:

```js
dailyFees.addUSDValue(totalSupply * rate > 0 ? totalSupply * rate : 0);
```

Verified against the live API: superstate-uscc fees30d and rev30d are identical (about $69.6k each, ratio 1.00), whereas superstate is $2.21M vs $159.7k (ratio 13.8). After the fix, USCC Fees will include the yield term instead of only the management fee.

One file, one line. Revenue and supply side are untouched.
