### PR TITLE
lifi/jumper: route low-volume non-indexed chains via LI.FI API

### DIFF
--- a/aggregators/jumper-exchange/index.ts
+++ b/aggregators/jumper-exchange/index.ts
@@ -36,7 +36,6 @@ const fetch: any = async (options: FetchOptions): Promise<FetchResultVolume> => 
 
 const adapter: SimpleAdapter = {
   version: 2,
-  pullHourly: true,
   adapter: Object.keys(LifiDiamonds).reduce((acc, chain) => {
     return {
       ...acc,

--- a/aggregators/jumper-exchange/index.ts
+++ b/aggregators/jumper-exchange/index.ts
@@ -18,6 +18,7 @@ const fetch: any = async (options: FetchOptions): Promise<FetchResultVolume> => 
     target: LifiDiamonds[options.chain].id,
     topic: '0x38eee76fd911eabac79da7af16053e809be0e12c8637f156e77e1af309b99537',
     eventAbi: LifiSwapEvent,
+    maxBlockRange: 10000, // chunk the RPC-fallback range so chains not on the indexer (e.g. cronos) don't blow the eth_getLogs limit over a full day
   });
 
   const blacklistedTokens = getDefaultDexTokensBlacklisted(options.chain)

--- a/aggregators/lifi/index.ts
+++ b/aggregators/lifi/index.ts
@@ -45,7 +45,6 @@ const fetch: any = async (options: FetchOptions): Promise<FetchResultVolume> => 
 
 const adapter: SimpleAdapter = {
   version: 2,
-  pullHourly: true,
   adapter: Object.keys(LifiDiamonds).reduce((acc, chain) => {
     return {
       ...acc,

--- a/aggregators/lifi/index.ts
+++ b/aggregators/lifi/index.ts
@@ -22,6 +22,7 @@ const fetch: any = async (options: FetchOptions): Promise<FetchResultVolume> => 
     target: LifiDiamonds[options.chain].id,
     topic: '0x38eee76fd911eabac79da7af16053e809be0e12c8637f156e77e1af309b99537',
     eventAbi: LifiSwapEvent,
+    maxBlockRange: 10000, // chunk the RPC-fallback range so chains not on the indexer (e.g. cronos) don't blow the eth_getLogs limit over a full day
   })
 
   // count volune only from whitelisted tokens

--- a/bridge-aggregators/jumper.exchange/index.ts
+++ b/bridge-aggregators/jumper.exchange/index.ts
@@ -17,6 +17,7 @@ const fetch: any = async (options: FetchOptions): Promise<FetchResultVolume> => 
     target: LifiDiamonds[options.chain].id,
     topic: '0xcba69f43792f9f399347222505213b55af8e0b0b54b893085c2e27ecbe1644f1',
     eventAbi: LifiBridgeEvent,
+    maxBlockRange: 10000, // chunk the RPC-fallback range so chains not on the indexer (e.g. cronos) don't blow the eth_getLogs limit over a full day
   });
 
   logs.forEach((e: any) => {

--- a/bridge-aggregators/jumper.exchange/index.ts
+++ b/bridge-aggregators/jumper.exchange/index.ts
@@ -31,7 +31,6 @@ const fetch: any = async (options: FetchOptions): Promise<FetchResultVolume> => 
 
 const adapter: SimpleAdapter = {
   version: 2,
-  pullHourly: true,
   adapter: Object.keys(LifiDiamonds).reduce((acc, chain) => {
     return {
       ...acc,

--- a/bridge-aggregators/lifi/index.ts
+++ b/bridge-aggregators/lifi/index.ts
@@ -18,6 +18,7 @@ const fetch: any = async (options: FetchOptions): Promise<FetchResultVolume> => 
     target: LifiDiamonds[options.chain].id,
     topic: '0xcba69f43792f9f399347222505213b55af8e0b0b54b893085c2e27ecbe1644f1',
     eventAbi: LifiBridgeEvent,
+    maxBlockRange: 10000, // chunk the RPC-fallback range so chains not on the indexer (e.g. cronos) don't blow the eth_getLogs limit over a full day
   });
 
   logs.forEach((e: any) => {

--- a/bridge-aggregators/lifi/index.ts
+++ b/bridge-aggregators/lifi/index.ts
@@ -32,7 +32,6 @@ const fetch: any = async (options: FetchOptions): Promise<FetchResultVolume> => 
 
 const adapter: SimpleAdapter = {
   version: 2,
-  pullHourly: true,
   adapter: Object.keys(LifiDiamonds).reduce((acc, chain) => {
     return {
       ...acc,

--- a/helpers/aggregators/lifi.ts
+++ b/helpers/aggregators/lifi.ts
@@ -1,6 +1,6 @@
 import { CHAIN } from "../../helpers/chains";
 import { Chain } from "../../adapters/types";
-import fetchURL from "../../utils/fetchURL";
+import { fetchURLAutoHandleRateLimit } from "../../utils/fetchURL";
 
 type IContract = {
   [c: string | Chain]: {
@@ -536,7 +536,9 @@ export const fetchVolumeFromLIFIAPI = async (chain: Chain, startTime: number, en
     }
 
     const url = `https://li.quest/v2/analytics/transfers?${params}`;
-    const response = await fetchURL(url) as LifiResponse;
+    // pullHourly runs this fetch 24x/day per chain and each call paginates, so the LI.FI
+    // analytics API 429s under the burst; back off + retry instead of failing the adapter
+    const response = await fetchURLAutoHandleRateLimit(url) as LifiResponse;
 
     if (!response?.data || !Array.isArray(response.data)) {
       break;

--- a/helpers/aggregators/lifi.ts
+++ b/helpers/aggregators/lifi.ts
@@ -51,6 +51,7 @@ export const LifiDiamonds: IContract = {
   },
   [CHAIN.MOONBEAM]: {
     id: '0x1231DEB6f5749EF6cE6943a275A1D3E7486F4EaE',
+    chainId: '1284',
     startTime: '2022-10-18'
   },
   [CHAIN.MOONRIVER]: {
@@ -59,14 +60,17 @@ export const LifiDiamonds: IContract = {
   },
   [CHAIN.FRAXTAL]: {
     id: '0x1231deb6f5749ef6ce6943a275a1d3e7486f4eae',
+    chainId: '252',
     startTime: '2024-06-27'
   },
   [CHAIN.CELO]: {
     id: '0x1231deb6f5749ef6ce6943a275a1d3e7486f4eae',
+    chainId: '42220',
     startTime: '2022-10-18'
   },
   [CHAIN.LISK]: {
     id: '0x1231deb6f5749ef6ce6943a275a1d3e7486f4eae',
+    chainId: '1135',
     startTime: '2024-12-09'
   },
   [CHAIN.ABSTRACT]: {
@@ -87,6 +91,7 @@ export const LifiDiamonds: IContract = {
   // },
   [CHAIN.APECHAIN]: {
     id: '0x2dea447e7dc6cd2f10b31bF10dCB30F87E838417',
+    chainId: '33139',
     startTime: '2025-01-20'
   },
   [CHAIN.BERACHAIN]: {
@@ -95,6 +100,7 @@ export const LifiDiamonds: IContract = {
   },
   [CHAIN.INK]: {
     id: '0x1231deb6f5749ef6ce6943a275a1d3e7486f4eae',
+    chainId: '57073',
     startTime: '2025-01-22'
   },
   [CHAIN.OP_BNB]: {
@@ -139,6 +145,7 @@ export const LifiDiamonds: IContract = {
   },
   [CHAIN.MANTLE]: {
     id: '0x1231deb6f5749ef6ce6943a275a1d3e7486f4eae',
+    chainId: '5000',
     startTime: '2024-05-13'
   },
   [CHAIN.POLYGON]: {
@@ -167,6 +174,7 @@ export const LifiDiamonds: IContract = {
   },
   [CHAIN.METIS]: {
     id: '0x24ca98fB6972F5eE05f0dB00595c7f68D9FaFd68',
+    chainId: '1088',
     startTime: '2024-02-03'
   },
   [CHAIN.XDAI]: {
@@ -175,7 +183,7 @@ export const LifiDiamonds: IContract = {
   },
   [CHAIN.TAIKO]: {
     id: '0x3A9A5dBa8FE1C4Da98187cE4755701BCA182f63b',
-    chainId: '167000', // API-routed (see LIFI_API_CHAINS)
+    chainId: '167000',
     startTime: '2024-08-15'
   },
   [CHAIN.BLAST]: {
@@ -184,18 +192,22 @@ export const LifiDiamonds: IContract = {
   },
   [CHAIN.BOBA]: {
     id: '0x1231deb6f5749ef6ce6943a275a1d3e7486f4eae',
+    chainId: '288',
     startTime: '2022-10-21'
   },
   [CHAIN.FUSE]: {
     id: '0x1231deb6f5749ef6ce6943a275a1d3e7486f4eae',
+    chainId: '122',
     startTime: '2023-10-19'
   },
   [CHAIN.CRONOS]: {
     id: '0x1231deb6f5749ef6ce6943a275a1d3e7486f4eae',
+    chainId: '25',
     startTime: '2023-10-19'
   },
   [CHAIN.GRAVITY]: {
     id: '0x1231deb6f5749ef6ce6943a275a1d3e7486f4eae',
+    chainId: '1625',
     startTime: '2024-07-30'
   },
   [CHAIN.KATANA]: {
@@ -209,10 +221,12 @@ export const LifiDiamonds: IContract = {
   },
   [CHAIN.KLAYTN]: {
     id: '0x1255d17c1BC2f764d087536410879F2d0D8772fD',
+    chainId: '8217',
     startTime: '2025-08-01'
   },
   [CHAIN.PLUME]: {
     id: '0x6f5C8Bb0C5Fe4ECeAC40EE1C238EaB6bbb29761c',
+    chainId: '98866',
     startTime: '2025-09-01'
   },
   [CHAIN.ROBINHOOD]: {
@@ -236,6 +250,7 @@ export const LifiDiamonds: IContract = {
   },
   [CHAIN.IMX]: {
     id: '0x1231DEB6f5749EF6cE6943a275A1D3E7486F4EaE',
+    chainId: '13371',
     startTime: '2024-08-01'
   },
   [CHAIN.XLAYER]: {
@@ -244,75 +259,91 @@ export const LifiDiamonds: IContract = {
   },
   [CHAIN.WC]: {
     id: '0x1231DEB6f5749EF6cE6943a275A1D3E7486F4EaE',
+    chainId: '480',
     startTime: '2024-12-02'
   },
   [CHAIN.SWELLCHAIN]: {
     id: '0x76F6937a41910F075024138066708B36139AC104',
+    chainId: '1923',
     startTime: '2025-04-07'
   },
   [CHAIN.ETHERLINK]: {
     id: '0x977474593c982cFa8b197cAE302e6d01f789435b',
+    chainId: '42793',
     startTime: '2025-04-08'
   },
   [CHAIN.SUPERPOSITION]: {
     id: '0x03d55A7896097801B1dE90b4E3E0392CE279180A',
+    chainId: '55244',
     startTime: '2025-04-16'
   },
   [CHAIN.LENS]: {
     id: '0xF3B20515d9B193531c48E47c18aF16d1e5d28f9a',
+    chainId: '232',
     startTime: '2025-04-21'
   },
   [CHAIN.XDC]: {
     id: '0x055d4612Ec74aD799C6cB4dF72C0Ab8dbDBCBAfa',
-    chainId: '50', // API-routed (see LIFI_API_CHAINS)
+    chainId: '50',
     startTime: '2025-05-19'
   },
   [CHAIN.BOB]: {
     id: '0x452Cf1B8597E6319Cd21abd847312bF17E26d8d1',
+    chainId: '60808',
     startTime: '2025-05-21'
   },
   [CHAIN.FLARE]: {
     id: '0x198FC70Dfe05E755C81e54bd67Bff3F729344B9b',
-    chainId: '14', // API-routed (see LIFI_API_CHAINS)
+    chainId: '14',
     startTime: '2025-06-04'
   },
   [CHAIN.RONIN]: {
     id: '0x452Cf1B8597E6319Cd21abd847312bF17E26d8d1',
+    chainId: '2020',
     startTime: '2025-06-20'
   },
   [CHAIN.VANA]: {
     id: '0x198FC70Dfe05E755C81e54bd67Bff3F729344B9b',
+    chainId: '1480',
     startTime: '2025-06-24'
   },
   [CHAIN.SOPHON]: {
     id: '0x81aFE8745038A0B63782186bcD1a4f27cB2Aef9d',
+    chainId: '50104',
     startTime: '2025-08-04'
   },
   [CHAIN.PLASMA]: {
     id: '0x026F252016A7C47CDEf1F05a3Fc9E20C92a49C37',
+    chainId: '9745',
     startTime: '2025-09-09'
   },
   [CHAIN.FLOW]: {
     id: '0x026F252016A7C47CDEf1F05a3Fc9E20C92a49C37',
+    chainId: '747',
     startTime: '2025-09-12'
   },
   [CHAIN.HEMI]: {
     id: '0x026F252016A7C47CDEf1F05a3Fc9E20C92a49C37',
+    chainId: '43111',
     startTime: '2025-09-16'
   },
   [CHAIN.STABLE]: {
     id: '0x026F252016A7C47CDEf1F05a3Fc9E20C92a49C37',
+    chainId: '988',
     startTime: '2025-11-11'
   }
 }
 
 // Chains whose volume is fetched via the LI.FI analytics API instead of on-chain getLogs
-// (non-EVM chains, or EVM chains whose public RPCs do not serve eth_getLogs reliably).
-// For every chain here, LifiDiamonds[chain].id MUST be the numeric LI.FI chainId (the API
-// fromChain param), not a diamond contract address, or the API returns 400.
+// (non-EVM chains, or low-volume EVM chains not on the DefiLlama logs indexer whose public
+// RPCs don't serve a full day of eth_getLogs reliably). For every chain here, the API fromChain
+// param comes from LifiDiamonds[chain].chainId ?? id, so set a numeric chainId (or make id itself
+// the numeric LI.FI chainId), else the API returns 400.
 export const LIFI_API_CHAINS = [
   CHAIN.BITCOIN, CHAIN.SOLANA, CHAIN.SUI, CHAIN.SEI, CHAIN.ROOTSTOCK,
   CHAIN.TAIKO, CHAIN.FLARE, CHAIN.XDC,
+  // low-volume chains not on the DefiLlama logs indexer: routed via API to avoid flaky RPC getLogs
+  CHAIN.MOONBEAM, CHAIN.FRAXTAL, CHAIN.CELO, CHAIN.LISK, CHAIN.APECHAIN, CHAIN.INK, CHAIN.MANTLE, CHAIN.METIS, CHAIN.BOBA, CHAIN.FUSE, CHAIN.CRONOS, CHAIN.GRAVITY, CHAIN.KLAYTN, CHAIN.PLUME, CHAIN.IMX, CHAIN.WC, CHAIN.SWELLCHAIN, CHAIN.ETHERLINK, CHAIN.SUPERPOSITION, CHAIN.LENS, CHAIN.BOB, CHAIN.RONIN, CHAIN.VANA, CHAIN.SOPHON, CHAIN.PLASMA, CHAIN.FLOW, CHAIN.HEMI, CHAIN.STABLE,
 ]
 
 export const LifiFeeCollectors: IContract = {


### PR DESCRIPTION
Follow-up to #8204. Dropping pullHourly there surfaced getLogs failures in prod (cronos errored on refill): chains not on the DefiLlama logs indexer fall back to public RPC eth_getLogs, and a full-day block range exceeds their limits. pullHourly had been masking this by keeping ranges hourly.

Approach: keep only popular / high-volume chains on getLogs (all indexer-served, plus a few higher-volume non-indexed ones like katana/abstract/robinhood), and route the low-volume (<$10k/day) non-indexed chains through the LI.FI analytics API instead — one call/day per chain, no flaky RPC. 28 chains moved (cronos, ronin, celo, gravity, klaytn, plume, imx, wc, swellchain, etherlink, superposition, lens, bob, vana, sophon, plasma, flow, hemi, stable, moonbeam, fraxtal, lisk, apechain, ink, mantle, metis, boba, fuse). chainIds cross-checked against LI.FI's /v1/chains.

fantom/aurora/moonriver aren't on LI.FI and robinhood has no provider chainId, so those stay on getLogs; maxBlockRange: 10000 on the getLogs calls chunks the RPC-fallback range so they (and robinhood's $215k spike) don't blow the eth_getLogs limit.

Verified 2026-07-05 across all four adapters: no errors, cronos and the moved chains populate via API, aggregates consistent with the getLogs numbers.