### PR TITLE
[fix] phygitals - scale luckydraw/royalties fees and volume by 1e6

### DIFF
--- a/fees/phygitals/index.ts
+++ b/fees/phygitals/index.ts
@@ -75,9 +75,9 @@ const fetch = async (options: FetchOptions) => {
     const gachaTotalSpend = (result.gacha_spend || 0) + (result.gacha_spend1 || 0);
     const gachaNetRevenue = gachaTotalSpend - (result.buyback || 0);
     dailyFees.add(ADDRESSES.solana.USDC, gachaNetRevenue > 0 ? gachaNetRevenue * 1e6 : 0, 'GACHA_FEES');
-    dailyFees.add(ADDRESSES.solana.USDC, result.luckydraw_fees || 0, 'LUCKYDRAW_FEES');
-    dailyFees.add(ADDRESSES.solana.USDC, result.royalties || 0, 'ROYALTIES');
-    dailyVolume.add(ADDRESSES.solana.USDC, gachaTotalSpend);
+    dailyFees.add(ADDRESSES.solana.USDC, (result.luckydraw_fees || 0) * 1e6, 'LUCKYDRAW_FEES');
+    dailyFees.add(ADDRESSES.solana.USDC, (result.royalties || 0) * 1e6, 'ROYALTIES');
+    dailyVolume.add(ADDRESSES.solana.USDC, gachaTotalSpend * 1e6);
   }
 
   return {

--- a/fees/phygitals/index.ts
+++ b/fees/phygitals/index.ts
@@ -74,7 +74,7 @@ const fetch = async (options: FetchOptions) => {
     const result = data[0];
     const gachaTotalSpend = (result.gacha_spend || 0) + (result.gacha_spend1 || 0);
     const gachaNetRevenue = gachaTotalSpend - (result.buyback || 0);
-    dailyFees.add(ADDRESSES.solana.USDC, gachaNetRevenue > 0 ? gachaNetRevenue * 1e6 : 0, 'GACHA_FEES');
+    dailyFees.add(ADDRESSES.solana.USDC, gachaNetRevenue * 1e6, 'GACHA_FEES');
     dailyFees.add(ADDRESSES.solana.USDC, (result.luckydraw_fees || 0) * 1e6, 'LUCKYDRAW_FEES');
     dailyFees.add(ADDRESSES.solana.USDC, (result.royalties || 0) * 1e6, 'ROYALTIES');
     dailyVolume.add(ADDRESSES.solana.USDC, gachaTotalSpend * 1e6);
@@ -116,6 +116,7 @@ const adapter: SimpleAdapter = {
   methodology,
   breakdownMethodology,
   pullHourly: true,
+  allowNegativeValue: true,
 }
 
 export default adapter;


### PR DESCRIPTION
Fixes #8206

Phygitals reports dailyFees far larger than dailyVolume, which is impossible since fees are a subset of volume.

Live API (30d): dailyFees about $1.23M vs dailyVolume about $12.

The Allium query returns USDC amounts already divided by 1e6 (whole USDC units). The gacha fee is scaled back to raw units before adding:

```js
dailyFees.add(ADDRESSES.solana.USDC, gachaNetRevenue > 0 ? gachaNetRevenue * 1e6 : 0, 'GACHA_FEES');
```

but the luckydraw fee, royalties, and volume were added without the `* 1e6`, so `balances.add` treated whole USDC as raw 6-decimal units and divided by 1e6 again. That understated luckydraw fees, royalties, and the entire dailyVolume by 1e6.

This scales those three by 1e6 to match the gacha line. After the fix, dailyVolume reflects real USDC spend (roughly $12M rather than $12) and luckydraw/royalties fees are counted at full value. The gacha fee, which was already correct, is unchanged.
