### PR TITLE
[fix] swell - compute staking rewards from totalSupply, not totalDeposited

### DIFF
--- a/fees/swell-restaking/index.ts
+++ b/fees/swell-restaking/index.ts
@@ -21,11 +21,9 @@ async function fetch(options: FetchOptions): Promise<FetchResultV2> {
     target: rswETH,
     abi: 'uint256:totalSupply',
   })
-  const totalDeposited = BigInt(totalSupply) * BigInt(exchangeRateBefore) / BigInt(1e18)
-  
   // swell distribute 90% rewards to stakers post protocol revenue and node operators cut
   // 90% to stakers, 5% to node operators, 5% to Swell treasury
-  const df = Number(totalDeposited) * (exchangeRateAfter - exchangeRateBefore) / 0.9 / 1e18
+  const df = Number(totalSupply) * (exchangeRateAfter - exchangeRateBefore) / 0.9 / 1e18
 
   const swellTreasuryRewards = df * 0.05
   const supplySideRewards = df - swellTreasuryRewards

--- a/fees/swell.ts
+++ b/fees/swell.ts
@@ -37,11 +37,9 @@ async function fetch(options: FetchOptions): Promise<FetchResultV2> {
     abi: 'uint256:totalSupply',
   })
 
-  const totalDeposited = BigInt(totalSupply) * BigInt(exchangeRateBefore) / BigInt(1e18)
-
   // swell distribute 90% rewards to stakers post protocol revenue and node operators cut
   // 90% to stakers, 5% to node operators, 5% to Swell treasury
-  const df = Number(totalDeposited) * (exchangeRateAfter - exchangeRateBefore) / 0.9 / 1e18
+  const df = Number(totalSupply) * (exchangeRateAfter - exchangeRateBefore) / 0.9 / 1e18
 
   const swellTreasuryRewards = df * 0.05
   const nodeOperatorsRewards = df * 0.05


### PR DESCRIPTION
Fixes #8209

The Swell fee adapters overstate dailyFees, dailyRevenue and dailySupplySideRevenue by the swETH / rswETH exchange rate (about 1.1x today, and growing as the rate climbs).

`df` (the gross daily staking reward) was computed from `totalDeposited` (the ETH value staked = `totalSupply * exchangeRateBefore`) instead of the token supply:

```js
const totalDeposited = BigInt(totalSupply) * BigInt(exchangeRateBefore) / BigInt(1e18)
const df = Number(totalDeposited) * (exchangeRateAfter - exchangeRateBefore) / 0.9 / 1e18
```

The daily reward in ETH is `totalSupply * (exchangeRateAfter - exchangeRateBefore)`, the value increase of the swETH supply. Since `totalDeposited` already carries a factor of `exchangeRateBefore`, using it here multiplies the reward by an extra `exchangeRateBefore / 1e18` (the exchange rate, about 1.1).

This computes `df` from `totalSupply` directly and drops the now-unused `totalDeposited`. Same fix in `fees/swell.ts` and `fees/swell-restaking/index.ts`.
