### PR TITLE
vvs-flawless: track v3 volume and fees

### DIFF
--- a/factory/uniSubgraph.ts
+++ b/factory/uniSubgraph.ts
@@ -267,6 +267,28 @@ const configs: Record<string, SubgraphConfig> = {
       SupplySideRevenue: 0.2,
     }
   },
+  // VVS concentrated liquidity (v3), fee varies per pool so fees come from the
+  // subgraph, the protocol keeps 1/4 of swap fees (feeProtocol 0x44 on pools)
+  'vvs-flawless': {
+    graphUrls: {
+      [CHAIN.CRONOS]: "https://graph.cronoslabs.com/subgraphs/name/vvs/exchange-v3"
+    },
+    totalVolume: {
+      factory: "factories"
+    },
+    totalFees: {
+      factory: "factories",
+      field: "totalFeesUSD"
+    },
+    feesPercent: {
+      type: "fees",
+      UserFees: 100,
+      Revenue: 25,
+      ProtocolRevenue: 25,
+      SupplySideRevenue: 75,
+    },
+    start: '2023-09-20',
+  },
   taraswap: {
     graphUrls: {
       [CHAIN.TARA]: "https://indexer.lswap.app/subgraphs/name/taraxa/uniswap-v3"


### PR DESCRIPTION
https://defillama.com/protocol/vvs-flawless

VVS Flawless (the v3/CLMM side of VVS on Cronos) has its TVL listed but no volume or fees. This adds it to the uniSubgraph factory using the official vvs exchange-v3 subgraph, next to the existing vvs-finance entry.

- volume and fees come straight from the subgraph factory entity, fee tier varies per pool (0.01% to 0.3%) so a flat percent on volume would be wrong here
- protocol keeps 1/4 of swap fees, verified on chain (slot0 feeProtocol is 0x44 on the pools), the rest goes to LPs
- start is the first pool creation, 2023-09-20

Test run:
```
CRONOS
Daily volume: 673.38 k
Daily fees: 1.16 k
Daily user fees: 1.16 k
Daily revenue: 291.00
Daily protocol revenue: 291.00
Daily supply side revenue: 872.00
```

Also sanity-checked the existing vvs-finance entry still runs clean from the same file (4.33 M volume / 12.98 k fees, matches the live dashboard).

Follow-up to DefiLlama/yield-server#2785 where the flawless pools were added on the yield side; volume/fees was the missing piece for the protocol.