### PR TITLE
[fix] autofinance - convert fee bps with /10000 not /100

### DIFF
--- a/fees/autofinance/index.ts
+++ b/fees/autofinance/index.ts
@@ -100,7 +100,7 @@ async function fetch(options: FetchOptions): Promise<FetchResult> {
 
         const yieldForPeriod = (Number(exchangeRatesAfter[index]) - Number(exchangeRatesBefore[index])) * Number(totalSupplies[index]) / 1e18;
 
-        const managmentFeesForPeriod = Number(totalAssets[index]) * feeDetails[index].periodicFeeBps * periodWrtYear / 100;
+        const managmentFeesForPeriod = Number(totalAssets[index]) * feeDetails[index].periodicFeeBps * periodWrtYear / 10000;
 
         dailyFees.add(baseAssetId, managmentFeesForPeriod, METRIC.MANAGEMENT_FEES);
         dailyRevenue.add(baseAssetId, managmentFeesForPeriod, METRIC.MANAGEMENT_FEES);
@@ -108,7 +108,7 @@ async function fetch(options: FetchOptions): Promise<FetchResult> {
         const currentNav = +(Number(exchangeRatesAfter[index]) / (10 ** assetDecimals[index])).toFixed(4);
         const isPositivePerformance = (currentNav > feeDetails[index].navPerShareLastFeeMark / 1e4) && (yieldForPeriod > 0);
 
-        const performanceFeesForPeriod = isPositivePerformance ? (yieldForPeriod * feeDetails[index].streamingFeeBps / 100) : 0;
+        const performanceFeesForPeriod = isPositivePerformance ? (yieldForPeriod * feeDetails[index].streamingFeeBps / 10000) : 0;
 
         dailyFees.add(baseAssetId, yieldForPeriod, METRIC.ASSETS_YIELDS);
         dailySupplySideRevenue.add(baseAssetId, yieldForPeriod, METRIC.ASSETS_YIELDS);


### PR DESCRIPTION
Fixes #8215

Autofinance overstates its fee metrics because two basis-point fee rates are converted with `/ 100` instead of `/ 10000`.

`periodicFeeBps` and `streamingFeeBps` are basis points (per the `getFeeSettings` ABI). A 100 bps (1%) rate becomes `100 / 100 = 1` (100%), so the management and performance fees were 100x too large. Both feed `dailyFees`, `dailyRevenue` and `dailyProtocolRevenue`.

Live API: dailyRevenue 30d is about $2.3k; with the fix it drops to about $23.

Two lines, `/ 100` to `/ 10000`.
