### PR TITLE
[fix] concrete - scale performance fee by vault total gain, not one share

### DIFF
--- a/fees/concrete/index.ts
+++ b/fees/concrete/index.ts
@@ -135,7 +135,7 @@ async function fetch(options: FetchOptions): Promise<FetchResult> {
         else {
             performanceFeeInBps = feeConfigs[v2Index].currentPerformanceFee;
         }
-        const performanceFees = priceDiff > 0n ? (BigInt(performanceFeeInBps) * (priceDiff)) / (100n * 100n) : 0n;
+        const performanceFees = priceDiff > 0n ? (BigInt(performanceFeeInBps) * yieldForPeriod) / (100n * 100n) : 0n;
 
         dailyFees.add(underlyingAsset, performanceFees, METRIC.PERFORMANCE_FEES);
         dailyRevenue.add(underlyingAsset, performanceFees, METRIC.PERFORMANCE_FEES);


### PR DESCRIPTION
Fixes #8217

Concrete's performance fee is computed on the gain of a single share instead of the whole vault, so it is understated by the vault's share count.

The yield and the management fee both scale the per-share price gain to the whole vault via `* totalSupplies / 10^vaultDecimals`:

```js
const yieldForPeriod = (priceDiff * BigInt(totalSupplies[index])) / (BigInt(10) ** BigInt(vaultDecimals));
```

but the performance fee used `priceDiff` (one share's gain) directly. That charges the fee on a single share rather than the whole vault, understating the PERFORMANCE_FEES component of `dailyFees` and `dailyRevenue` by the vault's share count (consistent with the live API showing `dailyRevenue` near 0).

Fix: use `yieldForPeriod` (the already-scaled total gain, the same quantity booked as yield) in place of `priceDiff`.
