### PR TITLE
[fix] veno-finance - scale zkSync Era yield to wei for addGasToken

### DIFF
--- a/fees/veno-finance.ts
+++ b/fees/veno-finance.ts
@@ -87,7 +87,7 @@ const fetchZkSyncFees = async (options: FetchOptions) => {
   // LETH - Liquid ETH
   const ethYield = await calculateLSTYield(options, CONTRACTS[CHAIN.ERA].LETH, 'getTotalPooledToken');
   if (ethYield > 0) {
-    dailyFees.addGasToken(ethYield);
+    dailyFees.addGasToken(ethYield * 1e18);
   }
 
   // 12% total fee: 50% to Reservoir (protocol), 50% to Kiln (service provider)

--- a/fees/veno-finance.ts
+++ b/fees/veno-finance.ts
@@ -62,9 +62,9 @@ const fetchCronosFees = async (options: FetchOptions) => {
   }
 
   // LATOM - Liquid ATOM (ATOM uses 6 decimals)
-  const atomYield = await calculateLSTYield(options, CONTRACTS[CHAIN.CRONOS].LATOM, 'getTotalPooledToken');
+  const atomYield = await calculateLSTYield(options, CONTRACTS[CHAIN.CRONOS].LATOM, 'getTotalPooledToken', 6);
   if (atomYield > 0) {
-    dailyFees.addCGToken("cosmos", atomYield / 1e6);
+    dailyFees.addCGToken("cosmos", atomYield);
   }
 
   const dailyRevenue = dailyFees.clone(CRONOS_FEE_RATE);


### PR DESCRIPTION
On zkSync Era, Veno's staking-reward fees are understated by ~1e18 (effectively $0) because a human-scaled yield is passed to `addGasToken`, which expects a raw (wei) amount.

`calculateLSTYield` returns a human-scaled number. The Cronos path books it with `addCGToken` (which takes human units):

```js
dailyFees.addCGToken("crypto-com-chain", croYield);
```

but the zkSync Era path used `addGasToken(ethYield)`, so 5 ETH/day of yield was recorded as 5 wei.

Fix: scale to wei with `addGasToken(ethYield * 1e18)`. The Cronos path is unaffected.
