### PR TITLE
[fix] shmonad - scale yield by share supply, not total assets

### DIFF
--- a/fees/shmonad/index.ts
+++ b/fees/shmonad/index.ts
@@ -28,7 +28,7 @@ const fetch = async (options: FetchOptions) => {
   // Compute exchange rate
   const rateBefore = (assetsBefore * 1e18) / supplyBefore;
   const rateAfter = (assetsAfter * 1e18) / supplyAfter;
-  const netRewards = ((rateAfter - rateBefore) * assetsBefore) / 1e18; 
+  const netRewards = ((rateAfter - rateBefore) * supplyBefore) / 1e18;
 
   const grossRewards = netRewards / (1 - PROTOCOL_FEE); 
   


### PR DESCRIPTION
shMonad overstates its fees by the shMON/MON exchange rate because the daily yield multiplies the rate change by total assets instead of the share supply.

The exchange rate is assets-per-share, so the total yield is the per-share rate gain times the number of shares (`supplyBefore`), not total assets (`assetsBefore`). Since `assetsBefore = supplyBefore * rate`, the code multiplied the yield by an extra factor of the exchange rate (>= 1, and growing as the vault accrues). Sibling ERC-4626 adapters scale by supply.

Fix: multiply by `supplyBefore`. This corrects `dailyFees`, `dailyProtocolRevenue` and `dailySupplySideRevenue`.
