### PR TITLE
[fix] wormhole - remove hardcoded 1 SUI added to Sui dailyFees

### DIFF
--- a/fees/wormhole/index.ts
+++ b/fees/wormhole/index.ts
@@ -206,7 +206,6 @@ const fetchSui: any = async (options: FetchOptions): Promise<FetchResultFees> =>
   // Sui message fees are currently set at 0, it can be adjusted with gov in the future.
   // source: https://suiscan.xyz/mainnet/object/0xaeab97f96cf9877fee2883315d459552b2b921edc16d7ceac6eab944dd88919c/fields
   const dailyFees = options.createBalances()
-  dailyFees.add(ADDRESSES.sui.SUI, 1e9, FEE_LABELS.executor);
 
   const events = await querySuiEvents({
     eventType:


### PR DESCRIPTION
The Wormhole Sui path added a hardcoded `1e9` (1 SUI) to `dailyFees` on every fetch, contradicting the comment right above it ("Sui message fees are currently set at 0").

The constant was added unconditionally before the real executor events, so Sui `dailyFees` (and `dailySupplySideRevenue`, which equals `dailyFees`) were inflated by about 1 SUI every window, reporting about 1 SUI on zero-activity days. No other chain path (EVM, Aptos) has such a constant.

Fix: remove the hardcoded line and rely on the real Sui executor events.
