### PR TITLE
[fix] trust-wallet - use Avalanche USDt for AVAX fee token, not Polygon USDT

### DIFF
--- a/fees/trust-wallet.ts
+++ b/fees/trust-wallet.ts
@@ -100,7 +100,7 @@ const tokens_type_percent: any = {
     ADDRESSES.polygon.USDT
   ],
   [CHAIN.AVAX]: [
-    ADDRESSES.polygon.USDT
+    ADDRESSES.avax.USDt
   ],
   [CHAIN.BSC]: [
     ADDRESSES.bsc.USDT


### PR DESCRIPTION
On Avalanche, Trust Wallet's USDT integrator-fee stream is dropped entirely because the AVAX entry of `tokens_type_percent` points at the Polygon USDT address (copy-pasted from the Polygon block above).

`0xc2132d05...` is Polygon's USDT and does not exist as USDT on Avalanche, so the `addTokensReceived` filter (transfers from fee router `0xB685760E` to collector `0x6fE04472`, 1%-scaled) matches nothing and the whole AVAX USDT fee component is 0.

Verified on-chain: on Avalanche the fee router `0xB685760E` sends native USDt (`0x9702230a8ea53601f5cd2dc00fdbc13d4df4a8c7`) to the collector (15 recent transfers, zero bridged USDT.e), exactly matching the adapter's from/to filter.

Fix: use `ADDRESSES.avax.USDt` (native Avalanche USDt).
