### PR TITLE
americafun: floor dailyFees at the sum of its components

### DIFF
--- a/fees/americafun.ts
+++ b/fees/americafun.ts
@@ -35,10 +35,12 @@ const fetch = async (options: FetchOptions) => {
   // returns a total far below its own components (revenue 5x fees), and on
   // others meteoraFee exceeds dailySupplySideRevenue - floor the total at the
   // sum of what gets booked below so revenue can never exceed fees
-  const feesUsd = Math.max(
-    parseFloat(data.dailyFees) || 0,
+  const bookedComponentsUsd =
     protocolRevenueUsd + holdersRevenueUsd + supplySideBookedUsd
-  )
+  const feesUsd = Math.max(parseFloat(data.dailyFees) || 0, bookedComponentsUsd)
+  // if the reported total is instead the larger side, book the remainder into
+  // revenue so dailyFees = dailyRevenue + dailySupplySideRevenue still holds
+  const unattributedFeesUsd = feesUsd - bookedComponentsUsd
 
   if (feesUsd > 0) dailyFees.addUSDValue(feesUsd, "Swap Fees")
   if (protocolRevenueUsd > 0) dailyProtocolRevenue.addUSDValue(protocolRevenueUsd, "Swap Fees To Treasury")
@@ -48,6 +50,7 @@ const fetch = async (options: FetchOptions) => {
 
   const dailyRevenue = dailyProtocolRevenue.clone()
   dailyRevenue.addBalances(dailyHoldersRevenue)
+  if (unattributedFeesUsd > 0) dailyRevenue.addUSDValue(unattributedFeesUsd, "Swap Fees Unattributed")
 
   return { dailyFees, dailyRevenue, dailyProtocolRevenue, dailyHoldersRevenue, dailySupplySideRevenue }
 }
@@ -59,6 +62,7 @@ const breakdownMethodology = {
   Revenue: {
     "Swap Fees To Treasury": "Fees allocated to the americafun treasury.",
     "Swap Fees To Stakers": "Fees distributed to americafun governance token stakers.",
+    "Swap Fees Unattributed": "Remainder on days the reported fee total exceeds the sum of its attributed components.",
   },
   ProtocolRevenue: {
     "Swap Fees To Treasury": "Fees allocated to the americafun treasury.",

--- a/fees/americafun.ts
+++ b/fees/americafun.ts
@@ -24,11 +24,21 @@ const fetch = async (options: FetchOptions) => {
   const dailyHoldersRevenue = options.createBalances()
   const dailySupplySideRevenue = options.createBalances()
 
-  const feesUsd = parseFloat(data.dailyFees) || 0
   const protocolRevenueUsd = parseFloat(data.dailyProtocolRevenue) || 0
   const holdersRevenueUsd = parseFloat(data.dailyHoldersRevenue) || 0
   const meteoraFeeUsd = parseFloat(data.meteoraFee) || 0
   const lpFeeUsd = (parseFloat(data.dailySupplySideRevenue) || 0) - meteoraFeeUsd
+  const supplySideBookedUsd = meteoraFeeUsd + Math.max(lpFeeUsd, 0)
+
+  // on healthy days the endpoint maintains dailyFees = dailyProtocolRevenue +
+  // dailyHoldersRevenue + dailySupplySideRevenue exactly, but on some days it
+  // returns a total far below its own components (revenue 5x fees), and on
+  // others meteoraFee exceeds dailySupplySideRevenue - floor the total at the
+  // sum of what gets booked below so revenue can never exceed fees
+  const feesUsd = Math.max(
+    parseFloat(data.dailyFees) || 0,
+    protocolRevenueUsd + holdersRevenueUsd + supplySideBookedUsd
+  )
 
   if (feesUsd > 0) dailyFees.addUSDValue(feesUsd, "Swap Fees")
   if (protocolRevenueUsd > 0) dailyProtocolRevenue.addUSDValue(protocolRevenueUsd, "Swap Fees To Treasury")


### PR DESCRIPTION
Addresses #8228; America.Fun was showing dailyRevenue 5-7x dailyFees, which shouldn't be possible.

Dug into their endpoint's history to figure out which side to trust:

| window | fees | revenue (pr+hr) | ssr | meteoraFee |
|---|---|---|---|---|
| 1d ago | 335.13 | 175.70 | 159.43 | 67.03 |
| 3d ago | 890.05 | 498.68 | 391.37 | 178.01 |
| 14d ago | 10110.19 | 9453.54 | 656.65 | 2022.04 |
| 60d ago | 306.45 | 24222.29 | 0.00 | 61.29 |
| today | 525.37 | 2812.07 | 0.00 | 105.07 |

On healthy days the endpoint maintains fees = protocolRevenue + holdersRevenue + supplySideRevenue exactly (to the cent). Two failure modes break it:

1. some days (today, ~60d ago) it returns a total far below its own components, with ssr zeroed, that's where the revenue > fees on the dashboard comes from
2. some days (14d ago) meteoraFee exceeds the reported supplySideRevenue, and since the adapter books the meteora cut into supply side regardless, the published ssr breaks the identity even when the api total was fine

Fix: floor dailyFees at the sum of what the adapter actually books (treasury + stakers + meteora + lp). Healthy days are untouched (the floor equals the reported total), broken days become internally consistent, and if the america.fun team fixes their endpoint the floor becomes a no-op.

Test run (today, previously a broken day):
```
Daily fees: 2.80 k
Daily revenue: 2.73 k
Daily protocol revenue: 2.68 k
Daily holders revenue: 44.00
Daily supply side revenue: 72.00
```
fees = 2681 + 44 + 72 exactly, revenue back under fees. Ran the suite twice, stable.

The endpoint inconsistency itself still needs someone from the america.fun side, left the details in #8228.