### PR TITLE
[fix] puffer-finance - scale yield by share supply not total assets

### DIFF
--- a/fees/puffer-finance/index.ts
+++ b/fees/puffer-finance/index.ts
@@ -59,7 +59,7 @@ const fetch = async (options: FetchOptions) => {
   const rateAfter = (assetsAfter * 1e18) / supplyAfter;
 
   // Net rewards
-  const netRewards = ((rateAfter - rateBefore) * assetsBefore) / 1e18;
+  const netRewards = ((rateAfter - rateBefore) * supplyBefore) / 1e18;
 
   // Gross rewards before protocol and guardian fees
   // https://docs.puffer.fi/yield/protocol/rewards


### PR DESCRIPTION
Same class as the already-merged #8223 (shmonad), #8211 (swell), and #8218 (concrete): a per-share exchange-rate delta scaled by total assets instead of share supply.

`fees/puffer-finance/index.ts` derives pufETH yield from the exchange-rate change but multiplies by `assetsBefore` where it should use `supplyBefore`.

Wrong:
```ts
const netRewards = ((rateAfter - rateBefore) * assetsBefore) / 1e18;
```
Correct:
```ts
const netRewards = ((rateAfter - rateBefore) * supplyBefore) / 1e18;
```

`rateBefore` / `rateAfter` are already per-share rates (`assets * 1e18 / supply`), so the multiplier must be the share count. Because `assetsBefore = supplyBefore * rate / 1e18`, the current line over-reports the whole fee stack (`dailyFees`, `dailyProtocolRevenue`, `dailySupplySideRevenue` all scale off `netRewards`) by the pufETH exchange rate. `supplyBefore` is already read at the same block as `assetsBefore`, so this is a pure substitution with no new call.

Error factor: pufETH exchange rate, currently 1.0798 (+7.98%), verified on-chain (totalAssets / totalSupply of the PufferVault at `0xD9A442856C234a39a81a089C06451EBAa4306a72`).

Pinned 30-day window (2026-06-16 to 2026-07-16), adapter before vs after the fix:
- current (`assetsBefore`): 38.85 ETH = $74,462
- fixed (`supplyBefore`): 36.05 ETH = $69,103
- ratio 1.0775 (equals the exchange rate at the window start)

Identical shape to #8223, which changed `* assetsBefore` to `* supplyBefore` in the same expression.
