### PR TITLE
[fix] BoringVault adapters - scale yield by share supply not total assets

### DIFF
--- a/fees/hyperwave/hwhype.ts
+++ b/fees/hyperwave/hwhype.ts
@@ -181,7 +181,7 @@ export async function getHwhypeHwusdFees(options: FetchOptions): Promise<{
                         vaultRateBase;
 
                     const supplySideYield =
-                        (totalDeposited * growthRate) / vaultRateBase;
+                        (Number(totalSupplyAtUpdated) * growthRate) / vaultRateBase;
                     const totalYield =
                         supplySideYield / (1 - performanceFeeRate);
                     const protocolFee = totalYield - supplySideYield;

--- a/fees/kraken-bitcoin-vault.ts
+++ b/fees/kraken-bitcoin-vault.ts
@@ -65,7 +65,7 @@ async function fetch(options: FetchOptions): Promise<FetchResultV2> {
       const performanceFeeRate = Number(accountantState[11]) / FeeRateBase
 
       const totalDeposited = Number(totalSupply) * exchangeRate / rateBase
-      const supplySideYield = totalDeposited * growthRate / rateBase
+      const supplySideYield = Number(totalSupply) * growthRate / rateBase
       const totalYield = supplySideYield / (1 - performanceFeeRate)
       const protocolFee = totalYield - supplySideYield
 

--- a/fees/lombard-vault/index.ts
+++ b/fees/lombard-vault/index.ts
@@ -176,7 +176,7 @@ async function fetch(options: FetchOptions): Promise<FetchResultV2> {
         // rate is always greater than or equal 1
         const totalDeposited = Number(totalSupplyAtUpdated) * Number(exchangeRate) / vaultRateBase
 
-        const supplySideYield = totalDeposited * growthRate / vaultRateBase
+        const supplySideYield = Number(totalSupplyAtUpdated) * growthRate / vaultRateBase
         const totalYield = supplySideYield / (1 - performanceFeeRate)
         const protocolFee = totalYield - supplySideYield
 

--- a/fees/mantle-restaking/index.ts
+++ b/fees/mantle-restaking/index.ts
@@ -78,7 +78,7 @@ async function fetch(options: FetchOptions): Promise<FetchResultV2> {
 
     const totalDeposited = Number(totalSupplyAtStart) * Number(startRate) / vaultRateBase
 
-    const supplySideYield = totalDeposited * growthRate / vaultRateBase
+    const supplySideYield = Number(totalSupplyAtStart) * growthRate / vaultRateBase
 
     dailyFees.add(token, supplySideYield, METRIC.ASSETS_YIELDS)
     dailySupplySideRevenue.add(token, supplySideYield, METRIC.ASSETS_YIELDS)

--- a/fees/solid-yield.ts
+++ b/fees/solid-yield.ts
@@ -154,7 +154,7 @@ async function fetch(options: FetchOptions): Promise<FetchResultV2> {
         // rate is always greater than or equal 1
         const totalDeposited = Number(totalSupplyAtUpdated) * Number(exchangeRate) / vaultRateBase
 
-        const supplySideYield = totalDeposited * growthRate / vaultRateBase
+        const supplySideYield = Number(totalSupplyAtUpdated) * growthRate / vaultRateBase
         const totalYield = supplySideYield / (1 - performanceFeeRate)
         const protocolFee = totalYield - supplySideYield
 

--- a/fees/veda.ts
+++ b/fees/veda.ts
@@ -240,7 +240,7 @@ async function fetch(options: FetchOptions): Promise<FetchResultV2> {
           // rate is always greater than or equal 1
           const totalDeposited = Number(totalSupplyAtUpdated) * Number(exchangeRate) / vaultRateBase
 
-          const supplySideYield = totalDeposited * growthRate / vaultRateBase
+          const supplySideYield = Number(totalSupplyAtUpdated) * growthRate / vaultRateBase
           const totalYield = supplySideYield / (1 - performanceFeeRate)
           const protocolFee = totalYield - supplySideYield
 


### PR DESCRIPTION
Same class and fix as the already-merged #8211 (swell), #8223 (shmonad) and #8218 (concrete). swell #8211 changed `totalDeposited` to `totalSupply` in this exact expression; six other BoringVault adapters copied the pre-fix template and carry the same bug.

Each computes `supplySideYield = totalDeposited * growthRate / base`, where `totalDeposited = totalSupply * exchangeRate / base` (total assets). Multiplying a per-share rate delta by total assets adds an extra exchange-rate factor, over-reporting the yield-derived fees by the vault exchange rate. The fix uses the share supply already in scope (the same variable `totalDeposited` was built from), so the block read is unchanged and no window-boundary behaviour moves; only the erroneous `* exchangeRate` factor is removed. Platform-fee lines (a management fee genuinely charged on total assets) are correct and left untouched.

Verified on-chain, supply-side yield over a pinned 30-day window (2026-06-16 to 07-16), current vs fixed:
- veda Staked ETHFI: $381,004 to $317,861 (rate 1.199)
- veda Liquid USD: $172,525 to $147,815 (rate 1.167)
- veda Liquid ETH: $400,504 to $364,334 (rate 1.099)
- lombard LBTCv: $7,646 to $7,465 (rate 1.024)

Measured on the three largest veda ETH vaults; the same expression governs every vault in the adapter, so the protocol-level delta is larger but unmeasured here.

Unlike #8211, `totalDeposited` is left in place: removing it orphans an `exchangeRate` local entangled with the performance-fee branch in 3 of the 6, which would take this diff into fee-config logic. Happy to strip it in a follow-up if preferred.

Files: veda, lombard-vault, mantle-restaking, solid-yield, kraken-bitcoin-vault, hyperwave (one line each). kraken-bitcoin-vault and mantle-restaking read exchange rate 1.0000 today, so their fix is a no-op now, included as same class, latent, activating as the rate rises above 1.0. The other four are live (rate 1.02 to 1.20).
