### PR TITLE
[fix] mellow-lrt - scale yield by share supply (expose totalSupply on erc4626 helper)

### DIFF
--- a/fees/mellow-lrt.ts
+++ b/fees/mellow-lrt.ts
@@ -96,8 +96,8 @@ const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
     if (vaultInfoOld && vaultInfoNew) {
       const vaultRateIncrease = vaultInfoNew.assetsPerShare - vaultInfoOld.assetsPerShare
       if (vaultRateIncrease > 0) {
-        dailyFees.add(vaultInfoOld.asset, vaultInfoOld.totalAssets * vaultRateIncrease / BigInt(1e18),METRIC.ASSETS_YIELDS);
-        dailySupplySideRevenue.add(vaultInfoOld.asset, vaultInfoOld.totalAssets * vaultRateIncrease / BigInt(1e18), METRIC.ASSETS_YIELDS);
+        dailyFees.add(vaultInfoOld.asset, vaultInfoOld.totalSupply * vaultRateIncrease / BigInt(1e18),METRIC.ASSETS_YIELDS);
+        dailySupplySideRevenue.add(vaultInfoOld.asset, vaultInfoOld.totalSupply * vaultRateIncrease / BigInt(1e18), METRIC.ASSETS_YIELDS);
       }
     }
   }

--- a/helpers/erc4626.ts
+++ b/helpers/erc4626.ts
@@ -8,6 +8,7 @@ const ERC4626Abis: any = {
   asset: 'address:asset',
   decimals: 'uint8:decimals',
   totalAssets: 'uint256:totalAssets',
+  totalSupply: 'uint256:totalSupply',
   assetsPerShare: 'function convertToAssets(uint256 shares) view returns (uint256 assets)',
 }
 
@@ -16,6 +17,7 @@ interface ERC4626VaultInfo {
   decimals: number;
   assetDecimals: number;
   totalAssets: bigint;
+  totalSupply: bigint;
   assetsPerShare: bigint;
 }
 
@@ -46,6 +48,11 @@ export async function getERC4626VaultsInfo(usingApi: ChainApi, vaults: Array<str
     permitFailure: true,
     calls: vaults,
   })
+  const totalSupplies: Array<string> = await usingApi.multiCall({
+    abi: ERC4626Abis.totalSupply,
+    permitFailure: true,
+    calls: vaults,
+  })
   const assetsPerShares: Array<string> = await usingApi.multiCall({
     abi: ERC4626Abis.assetsPerShare,
     permitFailure: true,
@@ -67,6 +74,7 @@ export async function getERC4626VaultsInfo(usingApi: ChainApi, vaults: Array<str
         decimals: Number(decimals[i]),
         assetDecimals: Number(assetsDecimals[i]),
         totalAssets: BigInt(totalAssets[i] ? totalAssets[i] : 0),
+        totalSupply: BigInt(totalSupplies[i] ? totalSupplies[i] : 0),
         assetsPerShare: BigInt(assetsPerShares[i] ? assetsPerShares[i] : 0),
       }
     } else {


### PR DESCRIPTION
`getERC4626VaultsInfo` returned `{asset, decimals, assetDecimals, totalAssets, assetsPerShare}` but not `totalSupply`. A caller computing vault yield (`rateDelta * shareSupply`) then has no correct multiplier in scope. Both existing callers had to work around the gap: varlamore reconstructs shares by hand (`totalAssets / assetsPerShare`, see its own comment), and mellow-lrt reached for `totalAssets` and over-reports the restaking yield by the vault exchange rate.

This exposes `totalSupply` on the struct (purely additive, one extra multiCall) and fixes mellow-lrt with it: `vaultInfoOld.totalAssets * vaultRateIncrease` becomes `vaultInfoOld.totalSupply * vaultRateIncrease`, same struct and same block, so no window-boundary behaviour moves. Same class as the merged #8232 (puffer), #8233 (BoringVault cluster), #8211 (swell), #8223 (shmonad) and #8218 (concrete), each of which swaps a total-assets or total-deposited multiplier to share supply in a yield expression. varlamore is already correct and left untouched; its workaround can be simplified in a follow-up.
