### PR TITLE
[fix] level, superfund - scale yield by share supply not total assets

### DIFF
--- a/fees/level.ts
+++ b/fees/level.ts
@@ -25,13 +25,13 @@ async function fetch(options: FetchOptions): Promise<FetchResultV2> {
     abi: 'function convertToAssets(uint256) view returns (uint256)',
     params: ['1000000000000000000'],
   })
-  const totalAssets = await options.api.call({
+  const totalSupply = await options.api.call({
     target: slvlUSD,
-    abi: 'uint256:totalAssets',
+    abi: 'uint256:totalSupply',
   })
 
   // fees distributed to slvlUSD holders - they are lvlUSD stakers
-  const totalYield = totalAssets * (exchangeRateAfter - exchangeRateBefore) / 1e18
+  const totalYield = totalSupply * (exchangeRateAfter - exchangeRateBefore) / 1e18
 
   dailyFees.add(lvlUSD, totalYield)
   const dailySupplySideRevenue = dailyFees.clone()

--- a/fees/superfund/index.ts
+++ b/fees/superfund/index.ts
@@ -12,11 +12,11 @@ const fetch = async (options: FetchOptions) => {
   const dailyFees = options.createBalances();
   const dailyRevenue = options.createBalances();
 
-  const totalAssets = await options.api.call({ abi: "uint256:totalAssets", target: SUPERLEND_USD })
+  const totalSupply = await options.api.call({ abi: "uint256:totalSupply", target: SUPERLEND_USD })
   const slUsdPriceYesterday = await options.fromApi.call({ abi: PRICE_ABI, target: SUPERLEND_USD, params: ["1000000000000000000"] })
   const slUsdPriceToday = await options.toApi.call({ abi: PRICE_ABI, target: SUPERLEND_USD, params: ["1000000000000000000"] })
 
-  const totalYieldIncludeProtocolFees = (slUsdPriceToday - slUsdPriceYesterday) * totalAssets / (1 - PROTOCOL_FEE) / 1e18;
+  const totalYieldIncludeProtocolFees = (slUsdPriceToday - slUsdPriceYesterday) * totalSupply / (1 - PROTOCOL_FEE) / 1e18;
   const protocolFees = totalYieldIncludeProtocolFees * PROTOCOL_FEE;
 
   dailyFees.add(USDC, totalYieldIncludeProtocolFees)


### PR DESCRIPTION
Closes the ERC-4626 share-scaling sweep started in #8232 and #8233: the last two Class A instances. Both are latent / tail-end with roughly zero current impact, stated up front.

Both scale a per-share exchange-rate delta by total assets instead of share supply, over-reporting the yield by the vault exchange rate. Same class and fix as the merged #8232, #8233, #8211, #8223 and #8218.

`level.ts:34`: `totalAssets * (convertToAssets_after - convertToAssets_before) / 1e18`. Fix reads `totalSupply` instead (same call, same block). Error factor is the slvlUSD exchange rate 1.1486 (+14.86%). Live impact is $0: slvlUSD's rate did not move across a pinned 30-day window (2026-06-16 to 2026-07-16), so buggy and correct both yield $0, TVL about $52k. The fix corrects the expression before it can misreport.

`superfund/index.ts:19`: `(slUsdPriceToday - slUsdPriceYesterday) * totalAssets / (1 - PROTOCOL_FEE) / 1e18`. Fix reads `totalSupply`. Error factor is the slUSD exchange rate 1.1265 (+12.65%, verified on-chain as totalAssets/totalSupply on Base). Live fees are about $903/30d, so the corrected value is about $801.

10 of 10 findings from the sweep are now fixed.
