### PR TITLE
[fix] graphite-protocol - apply protocol/holders percentages to total…

### DIFF
--- a/fees/graphite-protocol/index.ts
+++ b/fees/graphite-protocol/index.ts
@@ -64,8 +64,8 @@ const fetch = async (options: FetchOptions) => {
     }
 
     const dailyRevenue = dailyFees.clone(graphiteTotalPercentage)
-    const dailyProtocolRevenue = dailyRevenue.clone(graphiteProtocolRevenuePercentage)
-    const dailyHoldersRevenue = dailyRevenue.clone(graphiteHoldersRevenuePercentage)
+    const dailyProtocolRevenue = dailyFees.clone(graphiteProtocolRevenuePercentage)
+    const dailyHoldersRevenue = dailyFees.clone(graphiteHoldersRevenuePercentage)
 
     return {
         dailyFees: dailyRevenue,


### PR DESCRIPTION
## Summary

Problem: In fees/graphite-protocol/index.ts, dailyProtocolRevenue and dailyHoldersRevenue were cloned from dailyRevenue (already fees × 0.40), even though their percentages (0.3233, 0.0767) are fractions of total fees, so protocol + holders summed to less than % of fees instead of equaling dailyRevenue.

Solution: Clone both from the dailyFees base so the percentages apply correctly, making dailyProtocolRevenue + dailyHoldersRevenue = dailyRevenue.