### PR TITLE
[fix] yeet-bgt-auction - fix revenue split, breakdowns, and start date

### DIFF
--- a/fees/yeet-bgt-auction.ts
+++ b/fees/yeet-bgt-auction.ts
@@ -17,6 +17,7 @@ const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
 	const dailyRevenue = options.createBalances();
 	const dailyProtocolRevenue = options.createBalances();
 	const dailyHoldersRevenue = options.createBalances();
+	const dailySupplySideRevenue = options.createBalances();
 
 	const recipients: string[] = await options.api.call({ target: TAX_SPLITTER, abi: abis.getRecipients });
 	const recipientInfos = await options.api.multiCall({
@@ -25,14 +26,13 @@ const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
 		calls: recipients,
 	});
 
-	const bpsByRole: Record<string, bigint> = {};
-	for (const info of recipientInfos) {
-		const name = info.name.toLowerCase();
-		bpsByRole[name] = BigInt(info.percentage);
-	}
-
-	const protocolBps = bpsByRole["treasury"] ?? 0n;
-	const buybackBps = bpsByRole["redacted"] ?? 0n;
+	// Each tax-splitter recipient is classified by its on-chain name:
+	//   Treasury -> protocol revenue, Redacted -> YEET buyback (holders revenue),
+	//   everything else (Bribes, YeetPrizeManager) -> supply side, paid back to participants.
+	const recipientRoles = recipientInfos.map((info: any) => ({
+		role: info.name.toLowerCase(),
+		bps: BigInt(info.percentage),
+	}));
 
 	const logs = await options.getLogs({
 		target: TAX_SPLITTER,
@@ -41,12 +41,22 @@ const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
 
 	logs.forEach((log) => {
 		const amount = log.totalAmount;
-		const protocolAmount = amount * protocolBps / PERCENTAGE_SCALE;
-		const buybackAmount = amount * buybackBps / PERCENTAGE_SCALE;
-    dailyFees.add(ADDRESSES.berachain.WBERA, amount, 'BGT Auction Fees');
-    dailyRevenue.add(ADDRESSES.berachain.WBERA, amount, 'BGT Auction Fees');
-		dailyProtocolRevenue.add(ADDRESSES.berachain.WBERA, protocolAmount, 'BGT Auction Fees To Protocol');
-		dailyHoldersRevenue.add(ADDRESSES.berachain.WBERA, buybackAmount, 'Token Buy Back');
+		dailyFees.add(ADDRESSES.berachain.WBERA, amount, 'BGT Auction Fees');
+
+		for (const { role, bps } of recipientRoles) {
+			const share = amount * bps / PERCENTAGE_SCALE;
+			if (role === "treasury") {
+				dailyRevenue.add(ADDRESSES.berachain.WBERA, share, 'BGT Auction Fees To Protocol');
+				dailyProtocolRevenue.add(ADDRESSES.berachain.WBERA, share, 'BGT Auction Fees To Protocol');
+			} else if (role === "redacted") {
+				dailyRevenue.add(ADDRESSES.berachain.WBERA, share, 'Token Buy Back');
+				dailyHoldersRevenue.add(ADDRESSES.berachain.WBERA, share, 'Token Buy Back');
+			} else if (role === "bribes") {
+				dailySupplySideRevenue.add(ADDRESSES.berachain.WBERA, share, 'BGT Bribes');
+			} else if (role === "yeetprizemanager") {
+				dailySupplySideRevenue.add(ADDRESSES.berachain.WBERA, share, 'Prize Pool');
+			}
+		}
 	});
 
 	return {
@@ -54,35 +64,45 @@ const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
 		dailyRevenue,
 		dailyProtocolRevenue,
 		dailyHoldersRevenue,
+		dailySupplySideRevenue,
 	};
 };
 
 const adapter: Adapter = {
-  version: 2,
-  pullHourly: true,
+	version: 2,
+	pullHourly: true,
 	adapter: {
 		[CHAIN.BERACHAIN]: {
 			fetch,
-			start: "2025-03-01",
+			start: "2025-07-14",
 		},
 	},
-  methodology: {
-    Fees: "Protocol fees extracted from BGT Auction bids (treasury + YEET buybacks).",
-  	Revenue: "Protocol treasury + YEET buyback portion of auction bids.",
-  	ProtocolRevenue: "Portion of auction bids retained by the Yeet protocol treasury.",
-  	HoldersRevenue: "Portion of auction bids used for YEET buyback and burn via the Yeetarded Buyback Vault.",
-  },
-  breakdownMethodology: {
-    Fees: {
-     'BGT Auction Fees': 'Protocol fees extracted from BGT Auction bids (treasury + YEET buybacks).', 
-    },
-    Revenue: {
-     'BGT Auction Fees': 'Protocol treasury + YEET buyback portion of auction bids.', 
-    },
-    HoldersRevenue: {
-     'Token Buy Back': 'Portion of auction bids used for YEET buyback and burn via the Yeetarded Buyback Vault.', 
-    },
-  }
+	methodology: {
+		Fees: "Total BERA bid into the BGT Auction and distributed by the tax splitter.",
+		Revenue: "Protocol treasury + YEET buyback portion of auction bids.",
+		ProtocolRevenue: "Portion of auction bids retained by the Yeet protocol treasury.",
+		HoldersRevenue: "Portion of auction bids used for YEET buyback and burn via the Yeetarded Buyback Vault.",
+		SupplySideRevenue: "Portion of auction bids paid out as BGT bribes (reward vault) and prize pool to auction participants.",
+	},
+	breakdownMethodology: {
+		Fees: {
+			'BGT Auction Fees': 'Total BERA bid into the BGT Auction and distributed by the tax splitter.',
+		},
+		Revenue: {
+			'BGT Auction Fees To Protocol': 'Portion of auction bids retained by the Yeet protocol treasury.',
+			'Token Buy Back': 'Portion of auction bids used for YEET buyback and burn via the Yeetarded Buyback Vault.',
+		},
+		ProtocolRevenue: {
+			'BGT Auction Fees To Protocol': 'Portion of auction bids retained by the Yeet protocol treasury.',
+		},
+		HoldersRevenue: {
+			'Token Buy Back': 'Portion of auction bids used for YEET buyback and burn via the Yeetarded Buyback Vault.',
+		},
+		SupplySideRevenue: {
+			'BGT Bribes': 'Portion of auction bids paid out as BGT bribes via the reward vault to auction participants.',
+			'Prize Pool': 'Portion of auction bids added to the prize pool, paid out to the winning slot leader.',
+		},
+	}
 };
 
 export default adapter;


### PR DESCRIPTION
## Summary

Problem: dailyRevenue was set to the full auction bid amount, even though only the treasury and buyback portions are actual protocol revenue, so revenue was overstated and didn't reconcile with its own breakdown. The ProtocolRevenue breakdown was missing, the ~81% of bids paid back to participants was untracked, and the start date predated the tax splitter's existence.

Solution: Revenue is now derived from the on-chain recipient bps (treasury + buyback only), the remaining bids are tracked as dailySupplySideRevenue (BGT Bribes + Prize Pool) so Fees = Revenue + SupplySide, the breakdowns for Revenue/ProtocolRevenue/SupplySide are completed, and start is corrected to 2025-07-14.

https://docs.yeetit.xyz/yeet/yeetarded-products/yeet-bgt-auction/mechanics