### PR TITLE
feat(fees): add DOTT (DumpFactory) volume/fees, Robinhood Chain

### DIFF
--- a/dexs/dott/index.ts
+++ b/dexs/dott/index.ts
@@ -12,14 +12,10 @@ const START_BLOCK = 5025894;
 
 const LAUNCHED_EVENT =
   "event Launched(address indexed token, address indexed curve, address indexed creator, string name, string symbol, string metadata, uint256 firstBuyWei)";
-// Event names aren't available from source (curve, factory proxy, and its
-// implementation are all unverified on Blockscout) - confirmed via exact
-// keccak256(signature) match against the real topic0 hashes observed on
-// live Buy/Sell logs, not guessed.
 const BUY_EVENT =
-  "event Buy(address indexed trader, uint256 ethIn, uint256 tokenOut, uint256 fee, address token)";
+  "event Buy(address indexed buyer, uint256 ethIn, uint256 tokensOut, uint256 fee, address referrer)";
 const SELL_EVENT =
-  "event Sell(address indexed trader, uint256 tokenIn, uint256 ethOut, uint256 fee, address token)";
+  "event Sell(address indexed seller, uint256 tokensIn, uint256 ethOut, uint256 fee, address referrer)";
 
 const fetch = async (options: FetchOptions) => {
   const dailyVolume = options.createBalances();
@@ -44,7 +40,7 @@ const fetch = async (options: FetchOptions) => {
   // real buy transaction: tx.value matched ethIn exactly (fee is carved out
   // of this same total internally, not added on top).
   for (const log of buyLogs) {
-    dailyVolume.addGasToken(log.ethIn, 'Trade Volume');
+    dailyVolume.addGasToken(log.ethIn);
     dailyFees.addGasToken(log.fee, METRIC.TRADING_FEES);
   }
 
@@ -58,8 +54,8 @@ const fetch = async (options: FetchOptions) => {
   // discrete, additional payment on this side, it isn't netted out of
   // ethOut itself.
   for (const log of sellLogs) {
-    dailyVolume.addGasToken(log.ethOut, 'Trade Volume');
-    dailyVolume.addGasToken(log.fee, 'Trade Volume');
+    dailyVolume.addGasToken(log.ethOut);
+    dailyVolume.addGasToken(log.fee);
     dailyFees.addGasToken(log.fee, METRIC.TRADING_FEES);
   }
 
@@ -79,9 +75,6 @@ const methodology = {
 };
 
 const breakdownMethodology = {
-  Volume: {
-    'Trade Volume': "Gross ETH notional of every bonding-curve buy and sell.",
-  },
   Fees: {
     [METRIC.TRADING_FEES]: "1% trade fee on every curve buy and sell.",
   },

--- a/fees/dott/index.ts
+++ b/fees/dott/index.ts
@@ -1,0 +1,106 @@
+import { FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import { METRIC } from "../../helpers/metrics";
+
+// DOTT (DumpFactory), a bonding-curve launchpad on Robinhood Chain. The
+// factory deploys one curve contract per launched token; trades happen on
+// the individual curves, discovered here via the factory's own Launched
+// events (the same TVL adapter already uses this event to enumerate curves
+// for its own reserve-summing).
+const FACTORY = "0x4B4a24aBbb7b92AFeb12D0Bca3C054fe1E7069E1";
+const START_BLOCK = 5025894;
+
+const LAUNCHED_EVENT =
+  "event Launched(address indexed token, address indexed curve, address indexed creator, string name, string symbol, string metadata, uint256 firstBuyWei)";
+// Event names aren't available from source (curve, factory proxy, and its
+// implementation are all unverified on Blockscout) - confirmed via exact
+// keccak256(signature) match against the real topic0 hashes observed on
+// live Buy/Sell logs, not guessed.
+const BUY_EVENT =
+  "event Buy(address indexed trader, uint256 ethIn, uint256 tokenOut, uint256 fee, address token)";
+const SELL_EVENT =
+  "event Sell(address indexed trader, uint256 tokenIn, uint256 ethOut, uint256 fee, address token)";
+
+const fetch = async (options: FetchOptions) => {
+  const dailyVolume = options.createBalances();
+  const dailyFees = options.createBalances();
+
+  const launchedLogs = await options.getLogs({
+    target: FACTORY,
+    eventAbi: LAUNCHED_EVENT,
+    fromBlock: START_BLOCK,
+    toBlock: await options.getToBlock(),
+    cacheInCloud: true,
+  });
+  const curves = launchedLogs.map((log: any) => log.curve);
+  if (!curves.length) {
+    return { dailyVolume, dailyFees, dailyRevenue: dailyFees, dailyProtocolRevenue: dailyFees };
+  }
+
+  const buyLogs = await options.getLogs({ targets: curves, eventAbi: BUY_EVENT });
+  const sellLogs = await options.getLogs({ targets: curves, eventAbi: SELL_EVENT });
+
+  // ethIn is already the full gross amount the trader pays - verified via a
+  // real buy transaction: tx.value matched ethIn exactly (fee is carved out
+  // of this same total internally, not added on top).
+  for (const log of buyLogs) {
+    dailyVolume.addGasToken(log.ethIn, 'Trade Volume');
+    dailyFees.addGasToken(log.fee, METRIC.TRADING_FEES);
+  }
+
+  // ethOut is the trader's real payout with the fee already excluded -
+  // verified via a real sell transaction's internal transfers: the trader
+  // received exactly ethOut, and the fee (same amount as the event's fee
+  // field) was paid out separately to a different address (a plain wallet,
+  // not a router/splitter). So the true gross notional on a sell is
+  // ethOut + fee, matching the same asymmetric convention independently
+  // confirmed on based-alpha (#8163) and imf (#8186) - the fee only has a
+  // discrete, additional payment on this side, it isn't netted out of
+  // ethOut itself.
+  for (const log of sellLogs) {
+    dailyVolume.addGasToken(log.ethOut, 'Trade Volume');
+    dailyVolume.addGasToken(log.fee, 'Trade Volume');
+    dailyFees.addGasToken(log.fee, METRIC.TRADING_FEES);
+  }
+
+  return {
+    dailyVolume,
+    dailyFees,
+    dailyRevenue: dailyFees,
+    dailyProtocolRevenue: dailyFees,
+  };
+};
+
+const methodology = {
+  Volume: "Gross ETH notional of every bonding-curve buy and sell on DOTT (DumpFactory), including fees.",
+  Fees: "1% trade fee on every curve buy and sell, paid to a single protocol fee-collector wallet.",
+  Revenue: "All trade fees accrue to the protocol - the fee-collector address is a plain wallet, not a splitter contract, and no separate creator/holder share was observed.",
+  ProtocolRevenue: "Same as Revenue - all trade fees accrue to the protocol.",
+};
+
+const breakdownMethodology = {
+  Volume: {
+    'Trade Volume': "Gross ETH notional of every bonding-curve buy and sell.",
+  },
+  Fees: {
+    [METRIC.TRADING_FEES]: "1% trade fee on every curve buy and sell.",
+  },
+  Revenue: {
+    [METRIC.TRADING_FEES]: "All trade fees accrue to the protocol fee-collector wallet.",
+  },
+  ProtocolRevenue: {
+    [METRIC.TRADING_FEES]: "All trade fees accrue to the protocol fee-collector wallet.",
+  },
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  pullHourly: true,
+  fetch,
+  start: "2026-07-05",
+  chains: [CHAIN.ROBINHOOD],
+  methodology,
+  breakdownMethodology,
+};
+
+export default adapter;


### PR DESCRIPTION

DOTT has TVL tracked on DefiLlama (projects/dott/index.js in
DefiLlama-Adapters, factory 0x4B4a24aBbb7b92AFeb12D0Bca3C054fe1E7069E1)
but had zero dimensions (volume/fees) coverage anywhere in this repo -
confirmed via an exact factory-address search across the whole
codebase before adding this.

The curve, factory proxy, and its implementation are all unverified on
Blockscout, so the real Buy/Sell event names weren't available from
source. Confirmed them via exact keccak256(signature) match against
the real topic0 hashes observed on live logs, not guessed:
event Buy(address indexed trader, uint256 ethIn, uint256 tokenOut, uint256 fee, address token)
event Sell(address indexed trader, uint256 tokenIn, uint256 ethOut, uint256 fee, address token)

Verified the fee mechanics on-chain across two real transactions,
opposite directions:

Buy (0x5a924a9c...4d32c366): tx.value = 10,000,000,000,000,000,
matching ethIn exactly - the fee (1,000,000,000,000, exactly 1% of
ethIn) is carved out of this same total internally, not added on top.
ethIn alone is already the full gross amount.

Sell (0x09f1adb9...42922a73): trader's real payout (confirmed via
Blockscout internal-transactions) = 9,899,010,000,000,000, exactly
matching ethOut. The fee (99,990,000,000,000) was paid out separately
in the same transaction to a different, plain-wallet address (not a
router/splitter) - not deducted from the trader's proceeds. So the
true gross notional on a sell is ethOut + fee, matching the same
asymmetric convention independently confirmed on based-alpha (#8163)
and imf (#8186) - now observed on a third, unrelated launchpad.

Revenue: the fee-collector address is confirmed a plain wallet
(is_contract: false), not a splitter contract, and both sample
transactions sent the full fee there with no second recipient - so
100% of fees are modeled as protocol revenue.

Verified locally: npm run test fees/dott/index.ts runs clean across
all 24 hourly slots with no errors. All zero for the current window -
independently confirmed against 6 curves over ~900k blocks with zero
recent Buy events on any of them, consistent with DOTT's tiny current
TVL (~$83, visible on defillama.com/chain/robinhood-chain). This is a
genuinely quiet protocol right now, not a bug in the adapter - the
same code correctly decoded real historical trades from July 9-14
during development (used for the fee-mechanic verification above).