### PR TITLE
[fix] almanak - management fee is basis points, use /10000 not /100

### DIFF
--- a/fees/almanak/index.ts
+++ b/fees/almanak/index.ts
@@ -34,7 +34,7 @@ async function fetch(options: FetchOptions): Promise<FetchResultV2> {
     for (let i = 0; i < vaults.length; i++) {
         const { performanceRate, managementRate } = feeDetails[i]; //fee in BPs
         const dailyYield = await getERC4626VaultsYield({ options, vaults: [vaults[i]] });
-        const dailyManagementFee = (totalAssets[i]) * (managementRate / 100) * ((options.toTimestamp - options.fromTimestamp) / ONE_YEAR)
+        const dailyManagementFee = (totalAssets[i]) * (managementRate / 10000) * ((options.toTimestamp - options.fromTimestamp) / ONE_YEAR)
         dailySupplySideRevenue.add(dailyYield, METRIC.ASSETS_YIELDS);
         dailyFees = dailySupplySideRevenue.clone(1 / (1 - performanceRate / 10000));
         dailyFees.add(asset[i], dailyManagementFee, METRIC.MANAGEMENT_FEES);


### PR DESCRIPTION
Follows the same basis-points fix merged in #8216 (autofinance).

`fees/almanak/index.ts` reads `managementRate` from the vault's `feeRates()` and divides it by `100`:

```ts
const dailyManagementFee = (totalAssets[i]) * (managementRate / 100) * ((options.toTimestamp - options.fromTimestamp) / ONE_YEAR)
```

`managementRate` is in basis points. On-chain, both vaults return `managementRate = 10` (0.10%), which matches this adapter's own methodology note `'Annual management fees (usually 0.1%)'`. Dividing by `100` scales it as whole percent (10%), so the management-fee component is 100x too high. The correct divisor is `10000`.

The scale is confirmed in-file: `performanceRate`, read from the same `feeRates()` tuple, already divides by `10000` two lines down:

```ts
dailyFees = dailySupplySideRevenue.clone(1 / (1 - performanceRate / 10000));
```

`performanceRate = 2000` gives 20% at `/10000`. Both rates come from the same struct on the same contract, so `/100` on one and `/10000` on the other cannot both be correct.

Measured on a pinned block (from 25552080 to 25559280, one-day window), the management-fee component:

| vault | managementRate | before (`/100`) | after (`/10000`) | ratio |
|---|---|---|---|---|
| alUSD (`0xDCD0f5ab30856F28385F641580Bbd85f88349124`) | 10 (0.10%) | $123.88 | $1.24 | 100 |
| alpUSD (`0x5a97B0B97197299456Af841F8605543b13b12eE3`) | 10 (0.10%) | $4.48 | $0.04 | 100 |

The management fee feeds `dailyFees`, `dailyRevenue`, and `dailyProtocolRevenue`, so correcting it lowers those totals by the overstated amount. This is a one-line change: divide `managementRate` by `10000` instead of `100`.
