### PR TITLE
[fix] sol-lst - count user-paid withdrawal fees in dailyFees

### DIFF
--- a/factory/solLst.ts
+++ b/factory/solLst.ts
@@ -58,6 +58,10 @@ interface StakingRevenueConfig {
 interface RevenueFeedbackConfig {
   addToFees: boolean;
   feesMetric?: string;
+  // Label for the user-paid deposit/withdrawal fees added to dailyFees when addToFees is
+  // false. Only set it on adapters that publish a Fees breakdown, so every label used has
+  // a matching breakdownMethodology entry.
+  userFeesMetric?: string;
 }
 
 interface SolLstConfig {
@@ -134,6 +138,8 @@ function getBreakdownMethodology(config: SolLstConfig): Record<string, Record<st
     feesBreakdown[config.fees.metric] = "Staking rewards from staked SOL";
   if (config.revenueFeedback.addToFees && config.revenueFeedback.feesMetric)
     feesBreakdown[config.revenueFeedback.feesMetric] = "Includes withdrawal fees and management fees";
+  if (!config.revenueFeedback.addToFees && config.revenueFeedback.userFeesMetric)
+    feesBreakdown[config.revenueFeedback.userFeesMetric] = "Deposit/withdrawal fees users pay on their principal";
   if (Object.keys(feesBreakdown).length > 0) breakdown.Fees = feesBreakdown;
 
   // Revenue breakdown
@@ -255,14 +261,13 @@ function createSolLstAdapter(config: SolLstConfig): SimpleAdapter {
         // account inflow into dailyFees include them, so they are skipped here.
         if (!config.revenueFeedback.addToFees) {
           const rev = config.revenue;
-          // No metric label here: the revenue labels are Revenue-side and have no matching
-          // entry under Fees, so these roll up into the base dailyFees total instead.
+          const metric = config.revenueFeedback.userFeesMetric;
           if (rev.type === "addCGToken") {
-            dailyFees.addCGToken(rev.cgId, row.amount || 0);
+            dailyFees.addCGToken(rev.cgId, row.amount || 0, metric);
           } else if (rev.type === "add") {
-            dailyFees.add(rev.mint, Number(row.amount) * 1e9 || 0);
+            dailyFees.add(rev.mint, Number(row.amount) * 1e9 || 0, metric);
           } else if (rev.type === "addToken") {
-            dailyFees.addToken(rev.mint, Number(row.amount) * 1e9 || 0);
+            dailyFees.addToken(rev.mint, Number(row.amount) * 1e9 || 0, metric);
           }
         }
       }
@@ -345,10 +350,12 @@ const configs: Record<string, SolLstConfig> = {
     lstMint: "BPSoLzmLQn47EP5aa7jmFngRL8KC3TWAeAwXwZD8ip3P",
     start: "2025-02-24",
     revenue: { type: "add", mint: "BPSoLzmLQn47EP5aa7jmFngRL8KC3TWAeAwXwZD8ip3P", metric: METRIC.MANAGEMENT_FEES },
+    revenueFeedback: { addToFees: false, userFeesMetric: METRIC.DEPOSIT_WITHDRAW_FEES },
     fees: { metric: METRIC.STAKING_REWARDS },
     breakdownMethodology: {
       Fees: {
         [METRIC.STAKING_REWARDS]: "Staking rewards from staked SOL on Backpack staked solana",
+        [METRIC.DEPOSIT_WITHDRAW_FEES]: "Deposit/withdrawal fees users pay on their principal",
       },
       Revenue: {
         [METRIC.MANAGEMENT_FEES]: "Includes withdrawal fees and management fees collected by fee collector",

--- a/factory/solLst.ts
+++ b/factory/solLst.ts
@@ -255,10 +255,12 @@ function createSolLstAdapter(config: SolLstConfig): SimpleAdapter {
         // account inflow into dailyFees include them, so they are skipped here.
         if (!config.revenueFeedback.addToFees) {
           const rev = config.revenue;
+          // No metric label here: the revenue labels are Revenue-side and have no matching
+          // entry under Fees, so these roll up into the base dailyFees total instead.
           if (rev.type === "addCGToken") {
-            dailyFees.addCGToken(rev.cgId, row.amount || 0, rev.metric);
+            dailyFees.addCGToken(rev.cgId, row.amount || 0);
           } else if (rev.type === "add") {
-            dailyFees.add(rev.mint, Number(row.amount) * 1e9 || 0, rev.metric);
+            dailyFees.add(rev.mint, Number(row.amount) * 1e9 || 0);
           } else if (rev.type === "addToken") {
             dailyFees.addToken(rev.mint, Number(row.amount) * 1e9 || 0);
           }

--- a/factory/solLst.ts
+++ b/factory/solLst.ts
@@ -248,6 +248,21 @@ function createSolLstAdapter(config: SolLstConfig): SimpleAdapter {
             dailyFees.addToken(rev.mint, Number(row.amount) * 1e9 || 0);
           }
         }
+      } else if (row.metric_type === "dailyUserFees") {
+        // Deposit/withdrawal fees are charged on the user's principal, so unlike the
+        // manager's epoch fee they are not part of the staking rewards counted above and
+        // have to be added to fees on their own. Adapters that already feed the whole fee
+        // account inflow into dailyFees include them, so they are skipped here.
+        if (!config.revenueFeedback.addToFees) {
+          const rev = config.revenue;
+          if (rev.type === "addCGToken") {
+            dailyFees.addCGToken(rev.cgId, row.amount || 0, rev.metric);
+          } else if (rev.type === "add") {
+            dailyFees.add(rev.mint, Number(row.amount) * 1e9 || 0, rev.metric);
+          } else if (rev.type === "addToken") {
+            dailyFees.addToken(rev.mint, Number(row.amount) * 1e9 || 0);
+          }
+        }
       }
     });
 
@@ -508,7 +523,7 @@ const configs: Record<string, SolLstConfig> = {
     revenueFeedback: { addToFees: false },
     returnDailyHoldersRevenue: 0,
     methodology: {
-      Fees: "Staking rewards from staked SOL on doublezero staked solana",
+      Fees: "Staking rewards from staked SOL on doublezero staked solana, plus the withdrawal fees users pay on their principal",
       Revenue: "Includes withdrawal fees and management fees collected by fee collector",
       ProtocolRevenue: "Revenue going to treasury/team",
       HoldersRevenue: "No revenue share to 2Z token holders.",
@@ -844,6 +859,11 @@ const doublezeroAdapter = (() => {
         dailyFees.addCGToken("solana", row.amount || 0);
       } else if (row.metric_type === "dailyRevenue") {
         dailyRevenue.addCGToken(revenueToken, row.amount || 0);
+      } else if (row.metric_type === "dailyUserFees") {
+        // Withdrawal fees are charged on the user's principal, so they are not part
+        // of the staking rewards counted above and have to be added to fees on their
+        // own. Without this a heavy withdrawal day reports more revenue than fees.
+        dailyFees.addCGToken(revenueToken, row.amount || 0);
       }
     });
 

--- a/fees/crypto-com-lst.ts
+++ b/fees/crypto-com-lst.ts
@@ -36,6 +36,8 @@ const fetch = async (options: FetchOptions) => {
       } else if (row.metric_type === 'dailyUserFees') {
         // Withdrawal fees are charged on the user's principal, so unlike the manager's
         // epoch fee they are not part of the staking rewards counted above.
+        // The query returns whole tokens, so scale by 1e9 for the LST's 9 decimals,
+        // same as the revenue branch above.
         dailyFees.add(LST_MINT, Number(row.amount) * 1e9 || 0);
       }
     });

--- a/fees/crypto-com-lst.ts
+++ b/fees/crypto-com-lst.ts
@@ -33,6 +33,10 @@ const fetch = async (options: FetchOptions) => {
         dailyFees.addCGToken("solana", row.amount || 0);
       } else if (row.metric_type === 'dailyRevenue') {
         dailyRevenue.add(LST_MINT, Number(row.amount) * 1e9 || 0);
+      } else if (row.metric_type === 'dailyUserFees') {
+        // Withdrawal fees are charged on the user's principal, so unlike the manager's
+        // epoch fee they are not part of the staking rewards counted above.
+        dailyFees.add(LST_MINT, Number(row.amount) * 1e9 || 0);
       }
     });
   }

--- a/fees/hylo-lst.ts
+++ b/fees/hylo-lst.ts
@@ -27,6 +27,10 @@ const fetch = async (options: FetchOptions) => {
       dailyFees.addCGToken("solana", row.amount || 0);
     } else if (row.metric_type === 'dailyRevenue') {
       dailyRevenue.add(LST_MINT, Number(row.amount) * 1e9 || 0);
+    } else if (row.metric_type === 'dailyUserFees') {
+      // Withdrawal fees are charged on the user's principal, so unlike the manager's
+      // epoch fee they are not part of the staking rewards counted above.
+      dailyFees.add(LST_MINT, Number(row.amount) * 1e9 || 0);
     }
   });
 
@@ -51,6 +55,10 @@ const fetch = async (options: FetchOptions) => {
       dailyFees.addCGToken("solana", row.amount || 0);
     } else if (row.metric_type === 'dailyRevenue') {
       dailyRevenue.add(LST_MINT_PLUS, Number(row.amount) * 1e9 || 0);
+    } else if (row.metric_type === 'dailyUserFees') {
+      // Withdrawal fees are charged on the user's principal, so unlike the manager's
+      // epoch fee they are not part of the staking rewards counted above.
+      dailyFees.add(LST_MINT_PLUS, Number(row.amount) * 1e9 || 0);
     }
   });
 

--- a/fees/hylo-lst.ts
+++ b/fees/hylo-lst.ts
@@ -30,6 +30,8 @@ const fetch = async (options: FetchOptions) => {
     } else if (row.metric_type === 'dailyUserFees') {
       // Withdrawal fees are charged on the user's principal, so unlike the manager's
       // epoch fee they are not part of the staking rewards counted above.
+      // The query returns whole tokens, so scale by 1e9 for the LST's 9 decimals,
+      // same as the revenue branch above.
       dailyFees.add(LST_MINT, Number(row.amount) * 1e9 || 0);
     }
   });
@@ -58,6 +60,8 @@ const fetch = async (options: FetchOptions) => {
     } else if (row.metric_type === 'dailyUserFees') {
       // Withdrawal fees are charged on the user's principal, so unlike the manager's
       // epoch fee they are not part of the staking rewards counted above.
+      // The query returns whole tokens, so scale by 1e9 for the LST's 9 decimals,
+      // same as the revenue branch above.
       dailyFees.add(LST_MINT_PLUS, Number(row.amount) * 1e9 || 0);
     }
   });

--- a/helpers/queries/sol-lst.sql
+++ b/helpers/queries/sol-lst.sql
@@ -30,6 +30,25 @@ WITH
             AND token_mint_address='{{lst_mint}}'
             AND block_time>=from_unixtime({{start}})
             AND block_time<=from_unixtime({{end}})
+    ),
+    -- The fee account receives the manager's cut two different ways:
+    --   action='mint'     -> the epoch (management) fee, minted out of the staking
+    --                        rewards that staking_fees above already counts
+    --   action='transfer' -> deposit/withdrawal fees paid by users on their principal,
+    --                        which are NOT part of the staking rewards
+    -- Only the transfer leg is fee revenue that staking_fees does not already include.
+    user_paid_fees AS (
+        SELECT
+            'dailyUserFees' as metric_type,
+            SUM(amount)/POW(10, 9) as amount
+        FROM
+            tokens_solana.transfers
+        WHERE
+            to_token_account='{{lst_fee_token_account}}'
+            AND token_mint_address='{{lst_mint}}'
+            AND action='transfer'
+            AND block_time>=from_unixtime({{start}})
+            AND block_time<=from_unixtime({{end}})
     )
 SELECT
     metric_type,
@@ -42,3 +61,9 @@ SELECT
     COALESCE(amount, 0) as amount
 FROM
     revenue_fees
+UNION ALL
+SELECT
+    metric_type,
+    COALESCE(amount, 0) as amount
+FROM
+    user_paid_fees


### PR DESCRIPTION
Several SPL stake pool adapters report more revenue than fees on days with heavy withdrawals, which cannot happen since revenue is a subset of fees.

`helpers/queries/sol-lst.sql` returns every inflow to the pool's manager fee account as a single `dailyRevenue` figure. That account actually receives the manager's cut two different ways:

- **`action='mint'`** — the epoch (management) fee, minted out of the staking rewards. The `staking_fees` CTE already counts those rewards, so this leg is correctly inside `dailyFees`.
- **`action='transfer'`** — deposit/withdrawal fees, paid by users out of their principal. These are *not* part of staking rewards, so nothing in the query counts them as fees.

Adapters that do not feed the inflow back into `dailyFees` therefore book the withdrawal fees as revenue while never counting them as fees.

## Onchain evidence

Taking `doublezero-staked-sol` on 2026-07-14, splitting its fee account `GhN6PpyP6Ln4ycWcyvqsNcowLfYjpUcA9uWKAcFBjj2D` by `action`:

| date | mint (epoch fee) | transfer (user fees) |
|---|---|---|
| 2026-07-12 | 81.97 dzSOL | 0.003 |
| 2026-07-14 | 22.16 | **1,767.33** |
| 2026-07-16 | 23.75 | 0.003 |

The transfers are withdrawal fees. Decoding the largest one (`4tYCNHCsbeo7YzqzmrKrLgxEK3YdUFKN5Atvy2hshJNuvJw1pHnzrTjrh7s1EckoYJHAkZvbVafZr9LajCLu9GN9`) shows `Program log: Instruction: WithdrawStake` on `SPoo1Ku8WFXoNDMHPsrGSTSG1Y47rzgn41SLUNakuHy`, moving 364.811084189 dzSOL against an approved 729,622.168376599, i.e. exactly 0.05% — which is the `stake_withdrawal_fee` of 5/10000 read from stake pool `3fV1sdGeXaNEZj6EPDTpub82pYxcRXwt2oie6jkSzeWi`.

That the mint leg is the epoch fee is corroborated by it tracking rewards: on 2026-07-14 the mint fell to 22.16 from ~85 (26%) while staking rewards fell to $28.9k from $110.6k (26%).

## Affected adapters

Days where reported revenue exceeds reported fees:

| adapter | violation days | worst | excess |
|---|---|---|---|
| doublezero-staked-sol | 1 | 5.07x | $117,818 |
| edgevana | 1 | 3.35x | $42,977 |
| pico-staked-sol | 2 | 7.12x | $7,574 |
| lantern-staked-sol | 2 | 8.12x | $5,334 |
| starke-staked-sol | 1 | 13.51x | $4,866 |
| stronghold-staked-sol | 2 | 1.77x | $3,630 |

## Fix

Split the transfer leg out as its own `dailyUserFees` row and add it to `dailyFees`. `binance-staked-sol`, `bybit-staked-sol`, `drift-staked-sol` and `blazestake` set `revenueFeedback.addToFees`, so the whole inflow already reaches `dailyFees` for them; they are skipped so nothing is counted twice. The extra row is ignored by any adapter that does not read it, so nothing else changes.

## Results

`doublezero-staked-sol` on the 2026-07-14 day, previously fees $28.9k against revenue $146.8k:

```
Daily fees: 174.58 k
Daily revenue: 147.40 k
```

`edgevana` on the 2026-07-12 day, previously fees $18.3k against revenue $61.3k:

```
Daily fees: 80.25 k
Daily revenue: 62.55 k
```

Regression checks — a normal doublezero day is unchanged (fees 111.15k / revenue 6.67k, matching production 110.6k / 6.6k), and `binance-staked-sol` is unchanged (fees 254.05k / revenue 46.48k / supply side 207.56k, matching production).