### PR TITLE
Add Quiver Protocol fees adapter (Robinhood Chain)

### DIFF
--- a/fees/quiver-protocol.ts
+++ b/fees/quiver-protocol.ts
@@ -1,5 +1,6 @@
 import { FetchOptions, SimpleAdapter } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
+import { METRIC } from "../helpers/metrics";
 
 // Quiver Protocol: AI-managed concentrated-liquidity vaults on Robinhood Chain
 // (Uniswap V3 + V4, incl. tokenized-stock pairs). Each vault's strategy emits
@@ -28,11 +29,9 @@ const fetch = async (options: FetchOptions) => {
     api.fetchList({ lengthAbi: abis.vaultCount, itemAbi: abis.allVaults, target })
   ))).flat();
   const strategies = await api.multiCall({ abi: 'address:strategy', calls: vaults });
-  const [token0s, token1s, feeSplits] = await Promise.all([
-    api.multiCall({ abi: 'address:token0', calls: strategies }),
-    api.multiCall({ abi: 'address:token1', calls: strategies }),
-    api.multiCall({ abi: abis.getFees, target: FEE_CONFIG, calls: vaults }),
-  ]);
+  const token0s = await api.multiCall({ abi: 'address:token0', calls: strategies });
+  const token1s = await api.multiCall({ abi: 'address:token1', calls: strategies });
+  const feeSplits = await api.multiCall({ abi: abis.getFees, target: FEE_CONFIG, calls: vaults });
 
   const logsPerStrategy = await options.getLogs({ targets: strategies, eventAbi: HARVEST_ABI, flatten: false });
   logsPerStrategy.forEach((logs: any[], i: number) => {
@@ -40,8 +39,8 @@ const fetch = async (options: FetchOptions) => {
     logs.forEach((log: any) => {
       dailyFees.add(token0s[i], log.fees0, 'LP fees harvested');
       dailyFees.add(token1s[i], log.fees1, 'LP fees harvested');
-      dailyRevenue.add(token0s[i], (BigInt(log.fees0) * BigInt(perfBps)) / 10000n, 'Performance fee');
-      dailyRevenue.add(token1s[i], (BigInt(log.fees1) * BigInt(perfBps)) / 10000n, 'Performance fee');
+      dailyRevenue.add(token0s[i], (BigInt(log.fees0) * BigInt(perfBps)) / 10000n, METRIC.PERFORMANCE_FEES);
+      dailyRevenue.add(token1s[i], (BigInt(log.fees1) * BigInt(perfBps)) / 10000n, METRIC.PERFORMANCE_FEES);
       dailySupplySideRevenue.add(token0s[i], (BigInt(log.fees0) * BigInt(10000 - perfBps)) / 10000n, 'Compounded to LPs');
       dailySupplySideRevenue.add(token1s[i], (BigInt(log.fees1) * BigInt(10000 - perfBps)) / 10000n, 'Compounded to LPs');
     });
@@ -53,19 +52,34 @@ const fetch = async (options: FetchOptions) => {
 const methodology = {
   Fees: 'Gross Uniswap V3/V4 LP fees collected by Quiver vault strategies, taken from Harvest events (fees realize when harvested or rebalanced; small fee amounts settled inline during V4 withdrawals are not tracked).',
   Revenue: 'Performance fee share of harvested LP fees (currently 10%, read live from FeeConfig), sent to the protocol treasury.',
-  ProtocolRevenue: 'All revenue goes to the protocol treasury; Quiver has no token.',
+  ProtocolRevenue: 'Performance fee share of harvested LP fees (currently 10%, read live from FeeConfig), sent to the protocol treasury.',
   SupplySideRevenue: 'The remaining ~90% of harvested LP fees, compounded back into vault positions for depositors.',
 };
 
+const breakdownMethodology = {
+  Fees: {
+    "LP fees harvested": "Gross Uniswap V3/V4 LP fees collected by Quiver vault strategies, taken from Harvest events (fees realize when harvested or rebalanced; small fee amounts settled inline during V4 withdrawals are not tracked).",
+  },
+  Revenue: {
+    [METRIC.PERFORMANCE_FEES]: "Performance fee share of harvested LP fees (currently 10%, read live from FeeConfig), sent to the protocol treasury.",
+  },
+  ProtocolRevenue: {
+    [METRIC.PERFORMANCE_FEES]: "Performance fee share of harvested LP fees (currently 10%, read live from FeeConfig), sent to the protocol treasury.",
+  },
+  SupplySideRevenue: {
+    "Compounded to LPs": "The remaining ~90% of harvested LP fees, compounded back into vault positions for depositors.",
+  },
+}
+
 const adapter: SimpleAdapter = {
   version: 2,
+  pullHourly: true,
   fetch,
   methodology,
-  adapter: {
-    [CHAIN.ROBINHOOD]: {
-      start: '2026-07-16',
-    },
-  },
+  breakdownMethodology,
+  chains: [CHAIN.ROBINHOOD],
+  start: '2026-07-16',
+  doublecounted: true, // uniswap
 };
 
 export default adapter;

--- a/fees/quiver-protocol.ts
+++ b/fees/quiver-protocol.ts
@@ -1,0 +1,71 @@
+import { FetchOptions, SimpleAdapter } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+
+// Quiver Protocol: AI-managed concentrated-liquidity vaults on Robinhood Chain
+// (Uniswap V3 + V4, incl. tokenized-stock pairs). Each vault's strategy emits
+// Harvest(caller, fees0, fees1, ppsAfter) with the GROSS LP fees collected;
+// a 10% performance fee (FeeConfig.getFees) goes to the treasury and the rest
+// compounds back into the LP position.
+const FACTORY_V3 = '0xa511D763a79293b306BeAfd3e7eEB5e2884A71d5';
+const FACTORY_V4 = '0x3941116A9fF2d3e0B4CFa396d7927e8462dF7b38';
+const FEE_CONFIG = '0x777bBe1F53ae75f478DaF22b0E5A5d9513e98E31';
+
+const HARVEST_ABI = 'event Harvest(address indexed caller, uint256 fees0, uint256 fees1, uint256 ppsAfter)';
+
+const abis = {
+  allVaults: 'function allVaults(uint256) view returns (address)',
+  vaultCount: 'uint256:vaultCount',
+  getFees: 'function getFees(address vault) view returns (uint256 totalBps, uint256 callerBps, address treasury)',
+};
+
+const fetch = async (options: FetchOptions) => {
+  const { api } = options;
+  const dailyFees = options.createBalances();
+  const dailyRevenue = options.createBalances();
+  const dailySupplySideRevenue = options.createBalances();
+
+  const vaults = (await Promise.all([FACTORY_V3, FACTORY_V4].map((target) =>
+    api.fetchList({ lengthAbi: abis.vaultCount, itemAbi: abis.allVaults, target })
+  ))).flat();
+  const strategies = await api.multiCall({ abi: 'address:strategy', calls: vaults });
+  const [token0s, token1s, feeSplits] = await Promise.all([
+    api.multiCall({ abi: 'address:token0', calls: strategies }),
+    api.multiCall({ abi: 'address:token1', calls: strategies }),
+    api.multiCall({ abi: abis.getFees, target: FEE_CONFIG, calls: vaults }),
+  ]);
+
+  const logsPerStrategy = await options.getLogs({ targets: strategies, eventAbi: HARVEST_ABI, flatten: false });
+  logsPerStrategy.forEach((logs: any[], i: number) => {
+    const perfBps = Number(feeSplits[i].totalBps);
+    logs.forEach((log: any) => {
+      dailyFees.add(token0s[i], log.fees0, 'LP fees harvested');
+      dailyFees.add(token1s[i], log.fees1, 'LP fees harvested');
+      dailyRevenue.add(token0s[i], (BigInt(log.fees0) * BigInt(perfBps)) / 10000n, 'Performance fee');
+      dailyRevenue.add(token1s[i], (BigInt(log.fees1) * BigInt(perfBps)) / 10000n, 'Performance fee');
+      dailySupplySideRevenue.add(token0s[i], (BigInt(log.fees0) * BigInt(10000 - perfBps)) / 10000n, 'Compounded to LPs');
+      dailySupplySideRevenue.add(token1s[i], (BigInt(log.fees1) * BigInt(10000 - perfBps)) / 10000n, 'Compounded to LPs');
+    });
+  });
+
+  return { dailyFees, dailyRevenue, dailyProtocolRevenue: dailyRevenue, dailySupplySideRevenue };
+};
+
+const methodology = {
+  Fees: 'Gross Uniswap V3/V4 LP fees collected by Quiver vault strategies, taken from Harvest events (fees realize when harvested or rebalanced; small fee amounts settled inline during V4 withdrawals are not tracked).',
+  Revenue: 'Performance fee share of harvested LP fees (currently 10%, read live from FeeConfig), sent to the protocol treasury.',
+  ProtocolRevenue: 'All revenue goes to the protocol treasury; Quiver has no token.',
+  SupplySideRevenue: 'The remaining ~90% of harvested LP fees, compounded back into vault positions for depositors.',
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  fetch,
+  methodology,
+  adapter: {
+    [CHAIN.ROBINHOOD]: {
+      start: '2026-07-16',
+    },
+  },
+};
+
+export default adapter;


### PR DESCRIPTION
Adds a fees & revenue adapter for **Quiver Protocol** (Liquidity Manager on Robinhood Chain) — companion to the TVL listing in DefiLlama/DefiLlama-Adapters#20112.

## Methodology
- **Fees**: gross Uniswap V3/V4 LP fees collected by vault strategies, from on-chain `Harvest(caller, fees0, fees1, ppsAfter)` events (emitted on both harvest and rebalance). Vaults/strategies enumerated live from both factories.
- **Revenue / ProtocolRevenue**: performance-fee share of each harvest (currently 10%, read live per-vault from FeeConfig), sent to the protocol treasury. No token, so all revenue is protocol revenue.
- **SupplySideRevenue**: the remaining ~90%, compounded back into vault positions for depositors.

## Test output
```
ROBINHOOD 👇
Daily fees: 30.00
Daily revenue: 3.03
Daily protocol revenue: 3.03
Daily supply side revenue: 27.00
```
Start 2026-07-16 (factory deploy).
