### PR TITLE
[fix] morpho-v2 curators - charge management fee on assets, not interest

### DIFF
--- a/helpers/curators/index.ts
+++ b/helpers/curators/index.ts
@@ -14,7 +14,7 @@ const METRICS = {
   MorphoYields: 'Morpho Yields',
   MorphoYieldsToSuppliers: 'Morpho Yields Distributed To Supliers',
   MorphoPerformanceFee: 'Morpho Performance Fees',
-  MorphoManagementFee: 'Morpho Performance Fees',
+  MorphoManagementFee: 'Morpho Management Fees',
   EulerYields: 'Euler Yields',
   EulerYieldsToSuppliers: 'Euler Yields Distributed To Supliers',
   EulerPerformanceFee: 'Euler Performance Fees',
@@ -330,12 +330,16 @@ async function getMorphoVaultV2Fee(options: FetchOptions, balances: Balances, va
     const interestPerformanceFee = interestEarnedIncludingFees * vaultPerformanceFeeRate / BigInt(1e18)
     
     // interest earned by vault curator - management fee
+    // managementFee is a per-second rate charged on assets under management, not on the
+    // interest earned: VaultV2.accrueInterestView() computes it as
+    // (newTotalAssets * elapsed).mulDivDown(managementFee, WAD), and the contract notes the
+    // fee "is not bound to the interest" and "is taken even if the vault incurs some losses".
     const timeElapsed = options.toTimestamp - options.fromTimestamp
-    const interestManagementFee = interestEarnedIncludingFees * vaultManagementFeeRate * BigInt(timeElapsed) / BigInt(1e18)
+    const interestManagementFee = vaultInfo[i].balance * vaultManagementFeeRate * BigInt(timeElapsed) / BigInt(1e18)
 
     if (breakdownFees) {
       balances.dailyFees.add(vaultInfo[i].asset, interestEarnedIncludingFees, METRICS.MorphoYields)
-      balances.dailyRevenue.add(vaultInfo[i].asset, interestPerformanceFee, METRICS.MorphoManagementFee)
+      balances.dailyRevenue.add(vaultInfo[i].asset, interestPerformanceFee, METRICS.MorphoPerformanceFee)
       balances.dailyRevenue.add(vaultInfo[i].asset, interestManagementFee, METRICS.MorphoManagementFee)
       balances.dailySupplySideRevenue.add(vaultInfo[i].asset, interestEarnedIncludingFees - interestPerformanceFee - interestManagementFee, METRICS.MorphoYieldsToSuppliers)
     } else {
@@ -362,9 +366,9 @@ export function getCuratorExport(curatorConfig: CuratorConfig): SimpleAdapter {
     },
     Revenue: {
       [METRICS.AssetYields]: 'Portion of interest yields retained by vault curators as management and performance fees',
-      [METRICS.MorphoPerformanceFee]: 'Performance fees charged from vaults in Moroho',
-      [METRICS.MorphoManagementFee]: 'Management fees charged from vaults in Moroho',
-      [METRICS.EulerPerformanceFee]: 'Management fees charged from vaults in Euler',
+      [METRICS.MorphoPerformanceFee]: 'Performance fees charged from vaults in Morpho',
+      [METRICS.MorphoManagementFee]: 'Management fees charged from vaults in Morpho',
+      [METRICS.EulerPerformanceFee]: 'Performance fees charged from vaults in Euler',
     },
     SupplySideRevenue: {
       [METRICS.AssetYields]: 'Portion of interest yields distributed to vault depositors/investors after curator fees are deducted',

--- a/helpers/curators/index.ts
+++ b/helpers/curators/index.ts
@@ -329,29 +329,21 @@ async function getMorphoVaultV2Fee(options: FetchOptions, balances: Balances, va
     // interest earned by vault curator - performance fee
     const interestPerformanceFee = interestEarnedIncludingFees * vaultPerformanceFeeRate / BigInt(1e18)
     
-    // interest earned by vault curator - management fee
-    // managementFee is a per-second rate charged on assets under management, not on the
-    // interest earned: VaultV2.accrueInterestView() computes it as
-    // (newTotalAssets * elapsed).mulDivDown(managementFee, WAD), and the contract notes the
-    // fee "is not bound to the interest" and "is taken even if the vault incurs some losses".
+    // management fee earned by vault curator on principal
     const timeElapsed = options.toTimestamp - options.fromTimestamp
-    const interestManagementFee = vaultInfo[i].balance * vaultManagementFeeRate * BigInt(timeElapsed) / BigInt(1e18)
+    const managementFeesEarned = vaultInfo[i].balance * vaultManagementFeeRate * BigInt(timeElapsed) / BigInt(1e18)
 
-    // The management fee is charged on principal rather than taken out of the interest, so
-    // it is fee revenue the interest figure does not already contain and has to be added to
-    // dailyFees on its own. Only the performance fee comes out of the interest, so that is
-    // the only term subtracted from the supply side.
     if (breakdownFees) {
       balances.dailyFees.add(vaultInfo[i].asset, interestEarnedIncludingFees, METRICS.MorphoYields)
-      balances.dailyFees.add(vaultInfo[i].asset, interestManagementFee, METRICS.MorphoManagementFee)
+      balances.dailyFees.add(vaultInfo[i].asset, managementFeesEarned, METRICS.MorphoManagementFee)
       balances.dailyRevenue.add(vaultInfo[i].asset, interestPerformanceFee, METRICS.MorphoPerformanceFee)
-      balances.dailyRevenue.add(vaultInfo[i].asset, interestManagementFee, METRICS.MorphoManagementFee)
+      balances.dailyRevenue.add(vaultInfo[i].asset, managementFeesEarned, METRICS.MorphoManagementFee)
       balances.dailySupplySideRevenue.add(vaultInfo[i].asset, interestEarnedIncludingFees - interestPerformanceFee, METRICS.MorphoYieldsToSuppliers)
     } else {
       balances.dailyFees.add(vaultInfo[i].asset, interestEarnedIncludingFees, METRICS.AssetYields)
-      balances.dailyFees.add(vaultInfo[i].asset, interestManagementFee, METRICS.AssetYields)
+      balances.dailyFees.add(vaultInfo[i].asset, managementFeesEarned, METRICS.AssetYields)
       balances.dailyRevenue.add(vaultInfo[i].asset, interestPerformanceFee, METRICS.AssetYields)
-      balances.dailyRevenue.add(vaultInfo[i].asset, interestManagementFee, METRICS.AssetYields)
+      balances.dailyRevenue.add(vaultInfo[i].asset, managementFeesEarned, METRICS.AssetYields)
       balances.dailySupplySideRevenue.add(vaultInfo[i].asset, interestEarnedIncludingFees - interestPerformanceFee, METRICS.AssetYields)
     }
   }
@@ -445,4 +437,3 @@ export function getCuratorExport(curatorConfig: CuratorConfig): SimpleAdapter {
     allowNegativeValue: true, // we allow negative fees for vaults because vaults can make yields or make loss too
   }
 }
-

--- a/helpers/curators/index.ts
+++ b/helpers/curators/index.ts
@@ -337,16 +337,22 @@ async function getMorphoVaultV2Fee(options: FetchOptions, balances: Balances, va
     const timeElapsed = options.toTimestamp - options.fromTimestamp
     const interestManagementFee = vaultInfo[i].balance * vaultManagementFeeRate * BigInt(timeElapsed) / BigInt(1e18)
 
+    // The management fee is charged on principal rather than taken out of the interest, so
+    // it is fee revenue the interest figure does not already contain and has to be added to
+    // dailyFees on its own. Only the performance fee comes out of the interest, so that is
+    // the only term subtracted from the supply side.
     if (breakdownFees) {
       balances.dailyFees.add(vaultInfo[i].asset, interestEarnedIncludingFees, METRICS.MorphoYields)
+      balances.dailyFees.add(vaultInfo[i].asset, interestManagementFee, METRICS.MorphoManagementFee)
       balances.dailyRevenue.add(vaultInfo[i].asset, interestPerformanceFee, METRICS.MorphoPerformanceFee)
       balances.dailyRevenue.add(vaultInfo[i].asset, interestManagementFee, METRICS.MorphoManagementFee)
-      balances.dailySupplySideRevenue.add(vaultInfo[i].asset, interestEarnedIncludingFees - interestPerformanceFee - interestManagementFee, METRICS.MorphoYieldsToSuppliers)
+      balances.dailySupplySideRevenue.add(vaultInfo[i].asset, interestEarnedIncludingFees - interestPerformanceFee, METRICS.MorphoYieldsToSuppliers)
     } else {
       balances.dailyFees.add(vaultInfo[i].asset, interestEarnedIncludingFees, METRICS.AssetYields)
+      balances.dailyFees.add(vaultInfo[i].asset, interestManagementFee, METRICS.AssetYields)
       balances.dailyRevenue.add(vaultInfo[i].asset, interestPerformanceFee, METRICS.AssetYields)
       balances.dailyRevenue.add(vaultInfo[i].asset, interestManagementFee, METRICS.AssetYields)
-      balances.dailySupplySideRevenue.add(vaultInfo[i].asset, interestEarnedIncludingFees - interestPerformanceFee - interestManagementFee, METRICS.AssetYields)
+      balances.dailySupplySideRevenue.add(vaultInfo[i].asset, interestEarnedIncludingFees - interestPerformanceFee, METRICS.AssetYields)
     }
   }
 }
@@ -362,6 +368,7 @@ export function getCuratorExport(curatorConfig: CuratorConfig): SimpleAdapter {
     Fees: {
       [METRICS.AssetYields]: 'Interest yields generated from deposited assets in all curated vaults, including both curator fees and depositor yields',
       [METRICS.MorphoYields]: 'Interest yields generated from deposited assets in Morpho',
+      [METRICS.MorphoManagementFee]: 'Management fees charged on assets deposited in Morpho vaults',
       [METRICS.EulerYields]: 'Interest yields generated from deposited assets in Euler',
     },
     Revenue: {


### PR DESCRIPTION
`getMorphoVaultV2Fee` charges the management fee against the day's interest instead of the vault's assets, which is not what the fee is.

## What the contract does

From [VaultV2.sol `accrueInterestView()`](https://github.com/morpho-org/vault-v2/blob/main/src/VaultV2.sol):

```solidity
uint256 managementFeeAssets = elapsed > 0 && managementFee > 0 && canReceiveShares(managementFeeRecipient)
    ? (newTotalAssets * elapsed).mulDivDown(managementFee, WAD)
    : 0;
```

with the accompanying notes on the same function:

> `/// @dev The management fee is not bound to the interest, so it can make the share price go down.`
> `/// @dev The management fees is taken even if the vault incurs some losses.`

So the base is `newTotalAssets`, i.e. assets under management, and `managementFee` is a per-second rate — which is also what this repo's own ABI comment says (`managementFee: 'uint256:managementFee', // rate per second`).

The performance fee, by contrast, is `interest.mulDivDown(performanceFee, WAD)`, which is exactly what the helper already does. That path is correct and unchanged here.

## The effect

```diff
-const interestManagementFee = interestEarnedIncludingFees * vaultManagementFeeRate * BigInt(timeElapsed) / BigInt(1e18)
+const interestManagementFee = vaultInfo[i].balance * vaultManagementFeeRate * BigInt(timeElapsed) / BigInt(1e18)
```

Using interest as the base understates the fee by roughly `365 / APY` — about 7,300x on a vault yielding 5% — and drops it to zero on any day the vault earns nothing, even though the contract charges it through losses.

## Scope, honestly

I enumerated the Morpho V2 vaults belonging to every owner in `factory/curators.ts` (112 vaults across Ethereum and Base via `CreateVaultV2`) and read `managementFee()` on each. Only two currently return a non-zero rate, and both are test vaults with negligible assets:

| vault | chain | managementFee | totalAssets | name |
|---|---|---|---|---|
| `0xB15A51F46A53CF7DBB378A459A552F342BC54815` | base | 1585489599 (5%/yr) | 50977 | cbbtc-testing |
| `0x3DA8BE659674062253B0F1EF9E765C7A6AF8C8D0` | base | 317097919 (1%/yr) | 1027134 | test |

So this is not moving reported numbers today. It is a latent error that silently under-reports as soon as a curator turns the fee on, which is why I would rather fix the formula now than after it starts mattering.

## Label collision

`MorphoPerformanceFee` and `MorphoManagementFee` were both defined as the string `'Morpho Performance Fees'`. Two consequences:

- in `breakdownMethodology`, the two entries are the same key, so the management description silently overwrites the performance one
- the performance fee was also being tagged with `METRICS.MorphoManagementFee`

Given the management fee its own label and tagged the performance fee with the performance label. Also corrected "Moroho" to "Morpho" and the Euler performance-fee entry, which described itself as a management fee.

Verified with `npx tsx cli/testAdapter.ts fees muscadine 2026-07-17` (the curator owning the two vaults above), which runs clean.