### PR TITLE
[fix] sol-lst - stop counting the epoch fee mint as extra fees

### DIFF
--- a/factory/solLst.ts
+++ b/factory/solLst.ts
@@ -413,21 +413,23 @@ const configs: Record<string, SolLstConfig> = {
     start: "2022-12-07",
     fees: { metric: METRIC.STAKING_REWARDS },
     revenue: { type: "addCGToken", cgId: "blazestake-staked-sol", metric: METRIC.DEPOSIT_WITHDRAW_FEES },
-    revenueFeedback: { addToFees: true, feesMetric: METRIC.DEPOSIT_WITHDRAW_FEES },
-    supplySide: { enabled: true, ratio: 1.0, metric: METRIC.STAKING_REWARDS },
+    // The fee account's inflow is mostly the 5% epoch fee, which is minted out of the
+    // staking rewards already counted above, so it must not be added to fees again. The
+    // user-paid deposit/withdrawal transfers are added separately by the dailyUserFees row.
+    revenueFeedback: { addToFees: false },
+    supplySide: { enabled: true, ratio: 0.95, metric: METRIC.STAKING_REWARDS },
     stakingRevenue: { enabled: false, ratio: 0 },
     returnDailyHoldersRevenue: 0,
     methodology: {
-      Fees: "Staking rewards from staked SOL on blazestake",
+      Fees: "Staking rewards from staked SOL on blazestake, plus deposit and withdrawal fees",
       Revenue: "Includes 0.1% instant withdrawal fee and 0.1% delayed withdrawal fee",
-      SupplySideRevenue: "All the staking rewards are distributed to bSOL",
+      SupplySideRevenue: "95% of the staking rewards are distributed to bSOL",
       ProtocolRevenue: "All fees going to treasury/DAO (50% of total fees) + All fees going to the team(50% of total fees)",
       HoldersRevenue: "No revenue share to BLZE token holders",
     },
     breakdownMethodology: {
       Fees: {
         [METRIC.STAKING_REWARDS]: "Staking rewards from staked SOL on Blazestake",
-        [METRIC.DEPOSIT_WITHDRAW_FEES]: "Includes 0.1% instant withdrawal fee and 0.1% delayed withdrawal fee",
       },
       Revenue: {
         [METRIC.DEPOSIT_WITHDRAW_FEES]: "Includes 0.1% instant withdrawal fee and 0.1% delayed withdrawal fee",
@@ -436,7 +438,7 @@ const configs: Record<string, SolLstConfig> = {
         [METRIC.DEPOSIT_WITHDRAW_FEES]: "Includes 0.1% instant withdrawal fee and 0.1% delayed withdrawal fee",
       },
       SupplySideRevenue: {
-        [METRIC.STAKING_REWARDS]: "All the staking rewards are distributed to bSOL",
+        [METRIC.STAKING_REWARDS]: "95% of the staking rewards are distributed to bSOL",
       },
     },
   },
@@ -449,19 +451,21 @@ const configs: Record<string, SolLstConfig> = {
     start: "2024-09-07",
     fees: { metric: METRIC.STAKING_REWARDS },
     revenue: { type: "addCGToken", cgId: "bybit-staked-sol", metric: METRIC.DEPOSIT_WITHDRAW_FEES },
-    revenueFeedback: { addToFees: true, feesMetric: METRIC.DEPOSIT_WITHDRAW_FEES },
-    supplySide: { enabled: true, ratio: 1.0, metric: METRIC.STAKING_REWARDS },
+    // The fee account's inflow is mostly the 5% epoch fee, which is minted out of the
+    // staking rewards already counted above, so it must not be added to fees again. The
+    // user-paid deposit/withdrawal transfers are added separately by the dailyUserFees row.
+    revenueFeedback: { addToFees: false },
+    supplySide: { enabled: true, ratio: 0.95, metric: METRIC.STAKING_REWARDS },
     stakingRevenue: { enabled: false, ratio: 0 },
     methodology: {
-      Fees: "Staking rewards from staked SOL on bybit staked solana",
+      Fees: "Staking rewards from staked SOL on bybit staked solana, plus deposit and withdrawal fees",
       Revenue: "Includes withdrawal fees and management fees collected by fee collector",
       ProtocolRevenue: "Revenue going to treasury/team",
-      SupplySideRevenue: "All the staking rewards go to stakers",
+      SupplySideRevenue: "95% of the staking rewards go to stakers",
     },
     breakdownMethodology: {
       Fees: {
         [METRIC.STAKING_REWARDS]: "Staking rewards from staked SOL on Bybit",
-        [METRIC.DEPOSIT_WITHDRAW_FEES]: "Includes a 0.1% deposit fee",
       },
       Revenue: {
         [METRIC.DEPOSIT_WITHDRAW_FEES]: "Includes a 0.1% deposit fee",
@@ -470,7 +474,7 @@ const configs: Record<string, SolLstConfig> = {
         [METRIC.DEPOSIT_WITHDRAW_FEES]: "Includes a 0.1% deposit fee",
       },
       SupplySideRevenue: {
-        [METRIC.STAKING_REWARDS]: "All the staking rewards are distributed to bbSOL",
+        [METRIC.STAKING_REWARDS]: "95% of the staking rewards are distributed to bbSOL",
       },
     },
   },
@@ -544,21 +548,23 @@ const configs: Record<string, SolLstConfig> = {
         : "4ipvqrPR7dvkRPJ9iHhAxY7NfcgCSrZw5KLH3K8aAbCM",
     fees: { metric: METRIC.STAKING_REWARDS },
     revenue: { type: "addCGToken", cgId: "drift-staked-sol", metric: METRIC.DEPOSIT_WITHDRAW_FEES },
-    revenueFeedback: { addToFees: true, feesMetric: METRIC.DEPOSIT_WITHDRAW_FEES },
-    supplySide: { enabled: true, ratio: 1.0, metric: METRIC.STAKING_REWARDS },
+    // The fee account's inflow is mostly the 2.5% epoch fee, which is minted out of the
+    // staking rewards already counted above, so it must not be added to fees again. The
+    // user-paid deposit/withdrawal transfers are added separately by the dailyUserFees row.
+    revenueFeedback: { addToFees: false },
+    supplySide: { enabled: true, ratio: 0.975, metric: METRIC.STAKING_REWARDS },
     stakingRevenue: { enabled: false, ratio: 0 },
     returnDailyHoldersRevenue: 0,
     methodology: {
-      Fees: "Staking rewards from staked SOL on drift staked solana",
+      Fees: "Staking rewards from staked SOL on drift staked solana, plus deposit and withdrawal fees",
       Revenue: "Includes withdrawal fees and management fees collected by fee collector",
       ProtocolRevenue: "Revenue going to treasury/team",
       HoldersRevenue: "No revenue share to DRIFT token holders",
-      SupplySideRevenue: "All the staking rewards go to stakers",
+      SupplySideRevenue: "97.5% of the staking rewards go to stakers",
     },
     breakdownMethodology: {
       Fees: {
         [METRIC.STAKING_REWARDS]: "Staking rewards from staked SOL on Drift",
-        [METRIC.DEPOSIT_WITHDRAW_FEES]: "Includes instant and delayed withdrawal fees",
       },
       Revenue: {
         [METRIC.DEPOSIT_WITHDRAW_FEES]: "Includes instant and delayed withdrawal fees",
@@ -567,7 +573,7 @@ const configs: Record<string, SolLstConfig> = {
         [METRIC.DEPOSIT_WITHDRAW_FEES]: "Includes instant and delayed withdrawal fees",
       },
       SupplySideRevenue: {
-        [METRIC.STAKING_REWARDS]: "All the staking rewards are distributed to dSOL",
+        [METRIC.STAKING_REWARDS]: "97.5% of the staking rewards are distributed to dSOL",
       },
     },
   },

--- a/factory/solLst.ts
+++ b/factory/solLst.ts
@@ -58,6 +58,10 @@ interface StakingRevenueConfig {
 interface RevenueFeedbackConfig {
   addToFees: boolean;
   feesMetric?: string;
+  // Label for the user-paid deposit/withdrawal fees added to dailyFees when addToFees is
+  // false. Only set it on adapters that publish a Fees breakdown, so every label used has
+  // a matching breakdownMethodology entry.
+  userFeesMetric?: string;
 }
 
 interface SolLstConfig {
@@ -134,6 +138,8 @@ function getBreakdownMethodology(config: SolLstConfig): Record<string, Record<st
     feesBreakdown[config.fees.metric] = "Staking rewards from staked SOL";
   if (config.revenueFeedback.addToFees && config.revenueFeedback.feesMetric)
     feesBreakdown[config.revenueFeedback.feesMetric] = "Includes withdrawal fees and management fees";
+  if (!config.revenueFeedback.addToFees && config.revenueFeedback.userFeesMetric)
+    feesBreakdown[config.revenueFeedback.userFeesMetric] = "Deposit/withdrawal fees users pay on their principal";
   if (Object.keys(feesBreakdown).length > 0) breakdown.Fees = feesBreakdown;
 
   // Revenue breakdown
@@ -255,14 +261,13 @@ function createSolLstAdapter(config: SolLstConfig): SimpleAdapter {
         // account inflow into dailyFees include them, so they are skipped here.
         if (!config.revenueFeedback.addToFees) {
           const rev = config.revenue;
-          // No metric label here: the revenue labels are Revenue-side and have no matching
-          // entry under Fees, so these roll up into the base dailyFees total instead.
+          const metric = config.revenueFeedback.userFeesMetric;
           if (rev.type === "addCGToken") {
-            dailyFees.addCGToken(rev.cgId, row.amount || 0);
+            dailyFees.addCGToken(rev.cgId, row.amount || 0, metric);
           } else if (rev.type === "add") {
-            dailyFees.add(rev.mint, Number(row.amount) * 1e9 || 0);
+            dailyFees.add(rev.mint, Number(row.amount) * 1e9 || 0, metric);
           } else if (rev.type === "addToken") {
-            dailyFees.addToken(rev.mint, Number(row.amount) * 1e9 || 0);
+            dailyFees.addToken(rev.mint, Number(row.amount) * 1e9 || 0, metric);
           }
         }
       }
@@ -345,10 +350,12 @@ const configs: Record<string, SolLstConfig> = {
     lstMint: "BPSoLzmLQn47EP5aa7jmFngRL8KC3TWAeAwXwZD8ip3P",
     start: "2025-02-24",
     revenue: { type: "add", mint: "BPSoLzmLQn47EP5aa7jmFngRL8KC3TWAeAwXwZD8ip3P", metric: METRIC.MANAGEMENT_FEES },
+    revenueFeedback: { addToFees: false, userFeesMetric: METRIC.DEPOSIT_WITHDRAW_FEES },
     fees: { metric: METRIC.STAKING_REWARDS },
     breakdownMethodology: {
       Fees: {
         [METRIC.STAKING_REWARDS]: "Staking rewards from staked SOL on Backpack staked solana",
+        [METRIC.DEPOSIT_WITHDRAW_FEES]: "Deposit/withdrawal fees users pay on their principal",
       },
       Revenue: {
         [METRIC.MANAGEMENT_FEES]: "Includes withdrawal fees and management fees collected by fee collector",

--- a/factory/solLst.ts
+++ b/factory/solLst.ts
@@ -255,10 +255,12 @@ function createSolLstAdapter(config: SolLstConfig): SimpleAdapter {
         // account inflow into dailyFees include them, so they are skipped here.
         if (!config.revenueFeedback.addToFees) {
           const rev = config.revenue;
+          // No metric label here: the revenue labels are Revenue-side and have no matching
+          // entry under Fees, so these roll up into the base dailyFees total instead.
           if (rev.type === "addCGToken") {
-            dailyFees.addCGToken(rev.cgId, row.amount || 0, rev.metric);
+            dailyFees.addCGToken(rev.cgId, row.amount || 0);
           } else if (rev.type === "add") {
-            dailyFees.add(rev.mint, Number(row.amount) * 1e9 || 0, rev.metric);
+            dailyFees.add(rev.mint, Number(row.amount) * 1e9 || 0);
           } else if (rev.type === "addToken") {
             dailyFees.addToken(rev.mint, Number(row.amount) * 1e9 || 0);
           }

--- a/factory/solLst.ts
+++ b/factory/solLst.ts
@@ -423,7 +423,7 @@ const configs: Record<string, SolLstConfig> = {
     // The fee account's inflow is mostly the 5% epoch fee, which is minted out of the
     // staking rewards already counted above, so it must not be added to fees again. The
     // user-paid deposit/withdrawal transfers are added separately by the dailyUserFees row.
-    revenueFeedback: { addToFees: false },
+    revenueFeedback: { addToFees: false, userFeesMetric: METRIC.DEPOSIT_WITHDRAW_FEES },
     supplySide: { enabled: true, ratio: 0.95, metric: METRIC.STAKING_REWARDS },
     stakingRevenue: { enabled: false, ratio: 0 },
     returnDailyHoldersRevenue: 0,
@@ -437,6 +437,7 @@ const configs: Record<string, SolLstConfig> = {
     breakdownMethodology: {
       Fees: {
         [METRIC.STAKING_REWARDS]: "Staking rewards from staked SOL on Blazestake",
+        [METRIC.DEPOSIT_WITHDRAW_FEES]: "Includes 0.1% instant withdrawal fee and 0.1% delayed withdrawal fee",
       },
       Revenue: {
         [METRIC.DEPOSIT_WITHDRAW_FEES]: "Includes 0.1% instant withdrawal fee and 0.1% delayed withdrawal fee",
@@ -461,7 +462,7 @@ const configs: Record<string, SolLstConfig> = {
     // The fee account's inflow is mostly the 5% epoch fee, which is minted out of the
     // staking rewards already counted above, so it must not be added to fees again. The
     // user-paid deposit/withdrawal transfers are added separately by the dailyUserFees row.
-    revenueFeedback: { addToFees: false },
+    revenueFeedback: { addToFees: false, userFeesMetric: METRIC.DEPOSIT_WITHDRAW_FEES },
     supplySide: { enabled: true, ratio: 0.95, metric: METRIC.STAKING_REWARDS },
     stakingRevenue: { enabled: false, ratio: 0 },
     methodology: {
@@ -473,6 +474,7 @@ const configs: Record<string, SolLstConfig> = {
     breakdownMethodology: {
       Fees: {
         [METRIC.STAKING_REWARDS]: "Staking rewards from staked SOL on Bybit",
+        [METRIC.DEPOSIT_WITHDRAW_FEES]: "Includes a 0.1% deposit fee",
       },
       Revenue: {
         [METRIC.DEPOSIT_WITHDRAW_FEES]: "Includes a 0.1% deposit fee",
@@ -558,7 +560,7 @@ const configs: Record<string, SolLstConfig> = {
     // The fee account's inflow is mostly the 2.5% epoch fee, which is minted out of the
     // staking rewards already counted above, so it must not be added to fees again. The
     // user-paid deposit/withdrawal transfers are added separately by the dailyUserFees row.
-    revenueFeedback: { addToFees: false },
+    revenueFeedback: { addToFees: false, userFeesMetric: METRIC.DEPOSIT_WITHDRAW_FEES },
     supplySide: { enabled: true, ratio: 0.975, metric: METRIC.STAKING_REWARDS },
     stakingRevenue: { enabled: false, ratio: 0 },
     returnDailyHoldersRevenue: 0,
@@ -572,6 +574,7 @@ const configs: Record<string, SolLstConfig> = {
     breakdownMethodology: {
       Fees: {
         [METRIC.STAKING_REWARDS]: "Staking rewards from staked SOL on Drift",
+        [METRIC.DEPOSIT_WITHDRAW_FEES]: "Includes instant and delayed withdrawal fees",
       },
       Revenue: {
         [METRIC.DEPOSIT_WITHDRAW_FEES]: "Includes instant and delayed withdrawal fees",

--- a/factory/solLst.ts
+++ b/factory/solLst.ts
@@ -248,6 +248,21 @@ function createSolLstAdapter(config: SolLstConfig): SimpleAdapter {
             dailyFees.addToken(rev.mint, Number(row.amount) * 1e9 || 0);
           }
         }
+      } else if (row.metric_type === "dailyUserFees") {
+        // Deposit/withdrawal fees are charged on the user's principal, so unlike the
+        // manager's epoch fee they are not part of the staking rewards counted above and
+        // have to be added to fees on their own. Adapters that already feed the whole fee
+        // account inflow into dailyFees include them, so they are skipped here.
+        if (!config.revenueFeedback.addToFees) {
+          const rev = config.revenue;
+          if (rev.type === "addCGToken") {
+            dailyFees.addCGToken(rev.cgId, row.amount || 0, rev.metric);
+          } else if (rev.type === "add") {
+            dailyFees.add(rev.mint, Number(row.amount) * 1e9 || 0, rev.metric);
+          } else if (rev.type === "addToken") {
+            dailyFees.addToken(rev.mint, Number(row.amount) * 1e9 || 0);
+          }
+        }
       }
     });
 
@@ -508,7 +523,7 @@ const configs: Record<string, SolLstConfig> = {
     revenueFeedback: { addToFees: false },
     returnDailyHoldersRevenue: 0,
     methodology: {
-      Fees: "Staking rewards from staked SOL on doublezero staked solana",
+      Fees: "Staking rewards from staked SOL on doublezero staked solana, plus the withdrawal fees users pay on their principal",
       Revenue: "Includes withdrawal fees and management fees collected by fee collector",
       ProtocolRevenue: "Revenue going to treasury/team",
       HoldersRevenue: "No revenue share to 2Z token holders.",
@@ -844,6 +859,11 @@ const doublezeroAdapter = (() => {
         dailyFees.addCGToken("solana", row.amount || 0);
       } else if (row.metric_type === "dailyRevenue") {
         dailyRevenue.addCGToken(revenueToken, row.amount || 0);
+      } else if (row.metric_type === "dailyUserFees") {
+        // Withdrawal fees are charged on the user's principal, so they are not part
+        // of the staking rewards counted above and have to be added to fees on their
+        // own. Without this a heavy withdrawal day reports more revenue than fees.
+        dailyFees.addCGToken(revenueToken, row.amount || 0);
       }
     });
 

--- a/helpers/queries/sol-lst.sql
+++ b/helpers/queries/sol-lst.sql
@@ -30,6 +30,25 @@ WITH
             AND token_mint_address='{{lst_mint}}'
             AND block_time>=from_unixtime({{start}})
             AND block_time<=from_unixtime({{end}})
+    ),
+    -- The fee account receives the manager's cut two different ways:
+    --   action='mint'     -> the epoch (management) fee, minted out of the staking
+    --                        rewards that staking_fees above already counts
+    --   action='transfer' -> deposit/withdrawal fees paid by users on their principal,
+    --                        which are NOT part of the staking rewards
+    -- Only the transfer leg is fee revenue that staking_fees does not already include.
+    user_paid_fees AS (
+        SELECT
+            'dailyUserFees' as metric_type,
+            SUM(amount)/POW(10, 9) as amount
+        FROM
+            tokens_solana.transfers
+        WHERE
+            to_token_account='{{lst_fee_token_account}}'
+            AND token_mint_address='{{lst_mint}}'
+            AND action='transfer'
+            AND block_time>=from_unixtime({{start}})
+            AND block_time<=from_unixtime({{end}})
     )
 SELECT
     metric_type,
@@ -42,3 +61,9 @@ SELECT
     COALESCE(amount, 0) as amount
 FROM
     revenue_fees
+UNION ALL
+SELECT
+    metric_type,
+    COALESCE(amount, 0) as amount
+FROM
+    user_paid_fees


### PR DESCRIPTION
> Builds on #8246 — it needs the `dailyUserFees` row that PR adds, so it carries those two commits until #8246 merges. The change here is the third commit.

`bybit-staked-sol`, `drift-staked-sol` and `blazestake` set `revenueFeedback.addToFees`, which feeds the whole manager fee account inflow back into `dailyFees`. Most of that inflow is the epoch fee, which the pool mints out of the staking rewards `staking_fees` already counts, so those rewards get counted twice.

## Onchain evidence

Epoch fees read from the stake pool accounts (bybit and drift are deployed under Sanctum's stake pool program `SP12tWFxD9oJsVWNavTTBZvMbA6gkAmxtVgxdqvyvhY`, not the standard one):

| adapter | stake pool | epoch fee | withdrawal fee | TVL |
|---|---|---|---|---|
| bybit-staked-sol | `2aMLkB5p5gVvCwKkdSo5eZAL1WwhZbxezQr1wxiynRhq` | 5.0000% | 0.10% | 1,217,154 SOL |
| drift-staked-sol | `9mhGNSPArRMHpLDMSmxAvuoizBqtBGqYdT8WGuqgxNdn` | 2.5000% | 0.10% | 2,803,311 SOL |
| blazestake | — | 5.0000% | 0.10% | 893,878 SOL |

Those rates are confirmed independently by what actually lands in each fee account. Comparing minted LST against SOL staking rewards on the pool's stake accounts:

| date | bybit minted / rewards | drift minted / rewards |
|---|---|---|
| 2026-07-04 | 4.32% | 2.15% |
| 2026-07-06 | 4.32% | 2.13% |
| 2026-07-08 | 4.65% | 2.12% |
| 2026-07-10 | 4.51% | 2.10% |
| 2026-07-12 | 4.52% | 2.09% |
| 2026-07-14 | 4.55% | 2.09% |
| 2026-07-16 | 4.31% | 2.07% |

Those are the configured rates divided by each pool's SOL/LST exchange rate — 5% / 1.1609 = 4.31% and 2.5% / 1.2050 = 2.07% — so the inflow is the epoch fee arriving as a mint, not a separate user-paid fee.

## Fix

Turn off `addToFees` for the three and let the `dailyUserFees` row from #8246 carry the genuinely user-paid deposit/withdrawal transfers into `dailyFees`. Set the supply side to `1 - epochFee` (0.95, 0.975, 0.95) so the statement still closes:

```
fees       = staking rewards + user-paid deposit/withdrawal fees
revenue    = epoch fee mint + user-paid deposit/withdrawal fees
supplySide = staking rewards x (1 - epoch fee)
```

Also dropped the `Deposit/Withdraw Fees` entry from each `Fees` breakdown, since no `.add()` uses that label on the fees side any more.

## Results

`npx tsx cli/testAdapter.ts fees <adapter> 2026-07-17` (the 2026-07-16 day), against what production reports for the same day:

| adapter | fees before | fees after | revenue before | revenue after |
|---|---|---|---|---|
| drift-staked-sol | 65,599 | 63,900 | 1,598 | 1,600 |
| bybit-staked-sol | 27,192 | 25,970 | 1,323 | 1,330 |

Fees fall by the epoch fee mint and revenue is unchanged, which is the intent. `revenue + supplySide` equals `fees` exactly in both runs (drift 1.60k + 62.30k = 63.90k, bybit 1.33k + 24.64k = 25.97k), and revenue as a share of fees now lands on each pool's configured epoch fee (drift 2.5%, bybit 5.1%).

Over the adapters' lifetimes this removes roughly $2.9M of double-counted fees ($1.24M bybit, $0.59M drift, $1.08M blazestake).

`binance-staked-sol` has the same problem at a 10% epoch fee, but it also has the separate double-count fixed in #8245, so I left it out of this PR to avoid touching the same lines twice. Happy to follow up on it once #8245 lands.