### PR TITLE
[fix] jupiter-staked-sol - stop counting the epoch fee mint as extra fees

### DIFF
--- a/factory/solLst.ts
+++ b/factory/solLst.ts
@@ -58,6 +58,10 @@ interface StakingRevenueConfig {
 interface RevenueFeedbackConfig {
   addToFees: boolean;
   feesMetric?: string;
+  // Label for the user-paid deposit/withdrawal fees added to dailyFees when addToFees is
+  // false. Only set it on adapters that publish a Fees breakdown, so every label used has
+  // a matching breakdownMethodology entry.
+  userFeesMetric?: string;
 }
 
 interface SolLstConfig {
@@ -134,6 +138,8 @@ function getBreakdownMethodology(config: SolLstConfig): Record<string, Record<st
     feesBreakdown[config.fees.metric] = "Staking rewards from staked SOL";
   if (config.revenueFeedback.addToFees && config.revenueFeedback.feesMetric)
     feesBreakdown[config.revenueFeedback.feesMetric] = "Includes withdrawal fees and management fees";
+  if (!config.revenueFeedback.addToFees && config.revenueFeedback.userFeesMetric)
+    feesBreakdown[config.revenueFeedback.userFeesMetric] = "Deposit/withdrawal fees users pay on their principal";
   if (Object.keys(feesBreakdown).length > 0) breakdown.Fees = feesBreakdown;
 
   // Revenue breakdown
@@ -255,14 +261,13 @@ function createSolLstAdapter(config: SolLstConfig): SimpleAdapter {
         // account inflow into dailyFees include them, so they are skipped here.
         if (!config.revenueFeedback.addToFees) {
           const rev = config.revenue;
-          // No metric label here: the revenue labels are Revenue-side and have no matching
-          // entry under Fees, so these roll up into the base dailyFees total instead.
+          const metric = config.revenueFeedback.userFeesMetric;
           if (rev.type === "addCGToken") {
-            dailyFees.addCGToken(rev.cgId, row.amount || 0);
+            dailyFees.addCGToken(rev.cgId, row.amount || 0, metric);
           } else if (rev.type === "add") {
-            dailyFees.add(rev.mint, Number(row.amount) * 1e9 || 0);
+            dailyFees.add(rev.mint, Number(row.amount) * 1e9 || 0, metric);
           } else if (rev.type === "addToken") {
-            dailyFees.addToken(rev.mint, Number(row.amount) * 1e9 || 0);
+            dailyFees.addToken(rev.mint, Number(row.amount) * 1e9 || 0, metric);
           }
         }
       }
@@ -345,10 +350,12 @@ const configs: Record<string, SolLstConfig> = {
     lstMint: "BPSoLzmLQn47EP5aa7jmFngRL8KC3TWAeAwXwZD8ip3P",
     start: "2025-02-24",
     revenue: { type: "add", mint: "BPSoLzmLQn47EP5aa7jmFngRL8KC3TWAeAwXwZD8ip3P", metric: METRIC.MANAGEMENT_FEES },
+    revenueFeedback: { addToFees: false, userFeesMetric: METRIC.DEPOSIT_WITHDRAW_FEES },
     fees: { metric: METRIC.STAKING_REWARDS },
     breakdownMethodology: {
       Fees: {
         [METRIC.STAKING_REWARDS]: "Staking rewards from staked SOL on Backpack staked solana",
+        [METRIC.DEPOSIT_WITHDRAW_FEES]: "Deposit/withdrawal fees users pay on their principal",
       },
       Revenue: {
         [METRIC.MANAGEMENT_FEES]: "Includes withdrawal fees and management fees collected by fee collector",

--- a/factory/solLst.ts
+++ b/factory/solLst.ts
@@ -255,10 +255,12 @@ function createSolLstAdapter(config: SolLstConfig): SimpleAdapter {
         // account inflow into dailyFees include them, so they are skipped here.
         if (!config.revenueFeedback.addToFees) {
           const rev = config.revenue;
+          // No metric label here: the revenue labels are Revenue-side and have no matching
+          // entry under Fees, so these roll up into the base dailyFees total instead.
           if (rev.type === "addCGToken") {
-            dailyFees.addCGToken(rev.cgId, row.amount || 0, rev.metric);
+            dailyFees.addCGToken(rev.cgId, row.amount || 0);
           } else if (rev.type === "add") {
-            dailyFees.add(rev.mint, Number(row.amount) * 1e9 || 0, rev.metric);
+            dailyFees.add(rev.mint, Number(row.amount) * 1e9 || 0);
           } else if (rev.type === "addToken") {
             dailyFees.addToken(rev.mint, Number(row.amount) * 1e9 || 0);
           }

--- a/factory/solLst.ts
+++ b/factory/solLst.ts
@@ -248,6 +248,21 @@ function createSolLstAdapter(config: SolLstConfig): SimpleAdapter {
             dailyFees.addToken(rev.mint, Number(row.amount) * 1e9 || 0);
           }
         }
+      } else if (row.metric_type === "dailyUserFees") {
+        // Deposit/withdrawal fees are charged on the user's principal, so unlike the
+        // manager's epoch fee they are not part of the staking rewards counted above and
+        // have to be added to fees on their own. Adapters that already feed the whole fee
+        // account inflow into dailyFees include them, so they are skipped here.
+        if (!config.revenueFeedback.addToFees) {
+          const rev = config.revenue;
+          if (rev.type === "addCGToken") {
+            dailyFees.addCGToken(rev.cgId, row.amount || 0, rev.metric);
+          } else if (rev.type === "add") {
+            dailyFees.add(rev.mint, Number(row.amount) * 1e9 || 0, rev.metric);
+          } else if (rev.type === "addToken") {
+            dailyFees.addToken(rev.mint, Number(row.amount) * 1e9 || 0);
+          }
+        }
       }
     });
 
@@ -508,7 +523,7 @@ const configs: Record<string, SolLstConfig> = {
     revenueFeedback: { addToFees: false },
     returnDailyHoldersRevenue: 0,
     methodology: {
-      Fees: "Staking rewards from staked SOL on doublezero staked solana",
+      Fees: "Staking rewards from staked SOL on doublezero staked solana, plus the withdrawal fees users pay on their principal",
       Revenue: "Includes withdrawal fees and management fees collected by fee collector",
       ProtocolRevenue: "Revenue going to treasury/team",
       HoldersRevenue: "No revenue share to 2Z token holders.",
@@ -844,6 +859,11 @@ const doublezeroAdapter = (() => {
         dailyFees.addCGToken("solana", row.amount || 0);
       } else if (row.metric_type === "dailyRevenue") {
         dailyRevenue.addCGToken(revenueToken, row.amount || 0);
+      } else if (row.metric_type === "dailyUserFees") {
+        // Withdrawal fees are charged on the user's principal, so they are not part
+        // of the staking rewards counted above and have to be added to fees on their
+        // own. Without this a heavy withdrawal day reports more revenue than fees.
+        dailyFees.addCGToken(revenueToken, row.amount || 0);
       }
     });
 

--- a/fees/jupiter-staked-sol/index.ts
+++ b/fees/jupiter-staked-sol/index.ts
@@ -42,7 +42,7 @@ const fetch = async (options: FetchOptions) => {
     } else if (row.metric_type === 'dailyUserFees') {
       // Deposit/withdrawal fees are paid by users on their principal, so unlike the epoch
       // fee they are not already inside the staking rewards counted above.
-      dailyFees.addCGToken("jupiter-staked-sol", row.amount || 0);
+      dailyFees.addCGToken("jupiter-staked-sol", row.amount || 0, JUPITER_METRICS.JupSOLDepositWithdrawFees);
     }
   });
   
@@ -80,6 +80,7 @@ const adapter: SimpleAdapter = {
   breakdownMethodology: {
     Fees: {
       [JUPITER_METRICS.JupSOLStakingRewards]: 'Staking rewards from staked SOL on Jupiter.',
+      [JUPITER_METRICS.JupSOLDepositWithdrawFees]: 'Deposit/withdrawal fees users pay on their principal.',
     },
     Revenue: {
       [JUPITER_METRICS.JupSOLDepositWithdrawFees]: 'Includes 0.1% deposit fee.',

--- a/fees/jupiter-staked-sol/index.ts
+++ b/fees/jupiter-staked-sol/index.ts
@@ -9,6 +9,8 @@ const STAKE_POOL_WITHDRAW_AUTHORITY = "EMjuABxELpYWYEwjkKmQKBNCwdaFAy4QYAs6W9bDQ
 const LST_FEE_TOKEN_ACCOUNT_OLD = "DG399HKiLgKxGG176QiojyTtiSeqAurK6FVXGfBPTzSD"; // old
 const LST_FEE_TOKEN_ACCOUNT_NEW = "GbvFCpMqKX65gQ8KNeob9JUAL7vHCHFSg8YN5bnpPT8g";
 const LST_MINT = ADDRESSES.solana.JupSOL;
+// epochFee on the stake pool 8VpRhuxa7sUUepdY3kQiTmX9rS5vx4WgaXiAnXq4KCtr, read onchain
+const EPOCH_FEE = 0.05;
 
 const fetch = async (options: FetchOptions) => {
   const LST_FEE_TOKEN_ACCOUNT = options.startOfDay <= 1760486400 ? LST_FEE_TOKEN_ACCOUNT_OLD : LST_FEE_TOKEN_ACCOUNT_NEW;
@@ -32,10 +34,15 @@ const fetch = async (options: FetchOptions) => {
   results.forEach((row: any) => {
     if (row.metric_type === 'dailyFees') {
       dailyFees.addCGToken("solana", row.amount || 0, JUPITER_METRICS.JupSOLStakingRewards);
-      dailySupplySideRevenue.addCGToken("solana", row.amount || 0, JUPITER_METRICS.JupSOLStakingRewardsToStakers);
+      // The pool keeps a 5% epoch fee out of the staking rewards, so only the rest
+      // reaches jupSOL holders.
+      dailySupplySideRevenue.addCGToken("solana", Number(row.amount) * (1 - EPOCH_FEE) || 0, JUPITER_METRICS.JupSOLStakingRewardsToStakers);
     } else if (row.metric_type === 'dailyRevenue') {
-      dailyFees.addCGToken("jupiter-staked-sol", row.amount || 0, JUPITER_METRICS.JupSOLDepositWithdrawFees);
       dailyRevenue.addCGToken("jupiter-staked-sol", row.amount || 0, JUPITER_METRICS.JupSOLDepositWithdrawFees);
+    } else if (row.metric_type === 'dailyUserFees') {
+      // Deposit/withdrawal fees are paid by users on their principal, so unlike the epoch
+      // fee they are not already inside the staking rewards counted above.
+      dailyFees.addCGToken("jupiter-staked-sol", row.amount || 0);
     }
   });
   
@@ -59,7 +66,7 @@ const methodology = {
   Revenue: 'Includes withdrawal fees and management fees collected by fee collector',
   ProtocolRevenue: '50% revenue going to treasury/team, it was 100% before 2025-02-17.',
   HoldersRevenue: 'From 2025-02-17, 50% revenue are used to buy back JUP tokens.',
-  SupplySideRevenue: 'All SOL staking rewards go to stakers.'
+  SupplySideRevenue: '95% of SOL staking rewards go to stakers, the pool keeps a 5% epoch fee.'
 }
 
 const adapter: SimpleAdapter = {
@@ -73,7 +80,6 @@ const adapter: SimpleAdapter = {
   breakdownMethodology: {
     Fees: {
       [JUPITER_METRICS.JupSOLStakingRewards]: 'Staking rewards from staked SOL on Jupiter.',
-      [JUPITER_METRICS.JupSOLDepositWithdrawFees]: 'Includes 0.1% deposit fee.',
     },
     Revenue: {
       [JUPITER_METRICS.JupSOLDepositWithdrawFees]: 'Includes 0.1% deposit fee.',
@@ -82,7 +88,7 @@ const adapter: SimpleAdapter = {
       [JUPITER_METRICS.JupSOLDepositWithdrawFees]: '50% revenue going to treasury/team, it was 100% before 2025-02-17.',
     },
     SupplySideRevenue: {
-      [JUPITER_METRICS.JupSOLStakingRewardsToStakers]: 'All the staking rewards are distributed to jupSOL.',
+      [JUPITER_METRICS.JupSOLStakingRewardsToStakers]: '95% of the staking rewards are distributed to jupSOL.',
     },
     HoldersRevenue: {
       [JUPITER_METRICS.TokenBuyBack]: 'From 2025-02-17, 50% revenue are used to buy back JUP tokens.',

--- a/helpers/queries/sol-lst.sql
+++ b/helpers/queries/sol-lst.sql
@@ -30,6 +30,25 @@ WITH
             AND token_mint_address='{{lst_mint}}'
             AND block_time>=from_unixtime({{start}})
             AND block_time<=from_unixtime({{end}})
+    ),
+    -- The fee account receives the manager's cut two different ways:
+    --   action='mint'     -> the epoch (management) fee, minted out of the staking
+    --                        rewards that staking_fees above already counts
+    --   action='transfer' -> deposit/withdrawal fees paid by users on their principal,
+    --                        which are NOT part of the staking rewards
+    -- Only the transfer leg is fee revenue that staking_fees does not already include.
+    user_paid_fees AS (
+        SELECT
+            'dailyUserFees' as metric_type,
+            SUM(amount)/POW(10, 9) as amount
+        FROM
+            tokens_solana.transfers
+        WHERE
+            to_token_account='{{lst_fee_token_account}}'
+            AND token_mint_address='{{lst_mint}}'
+            AND action='transfer'
+            AND block_time>=from_unixtime({{start}})
+            AND block_time<=from_unixtime({{end}})
     )
 SELECT
     metric_type,
@@ -42,3 +61,9 @@ SELECT
     COALESCE(amount, 0) as amount
 FROM
     revenue_fees
+UNION ALL
+SELECT
+    metric_type,
+    COALESCE(amount, 0) as amount
+FROM
+    user_paid_fees


### PR DESCRIPTION
> Builds on #8246 — it needs the `dailyUserFees` row that PR adds, so it carries those two commits until #8246 merges. The change here is the third commit.

`fees/jupiter-staked-sol` adds the whole manager fee account inflow to `dailyFees` and credits 100% of the staking rewards to the supply side. Most of that inflow is the pool's epoch fee, which is minted out of those same staking rewards, so the rewards are counted twice on the fee side and stakers are credited with a cut the pool never passed on.

## Onchain evidence

Stake pool `8VpRhuxa7sUUepdY3kQiTmX9rS5vx4WgaXiAnXq4KCtr` (deployed under Sanctum's multi stake pool program `SPMBzsVUuoHA4Jm6KunbsotaahvVikZs1JyTW6iJvbn`), read from account state:

- `epochFee` = **5.0000%**
- `stake_withdrawal_fee` = 0.10%
- TVL 5,246,008 SOL / supply 4,376,608 jupSOL → exchange rate 1.1986

Splitting the fee account `GbvFCpMqKX65gQ8KNeob9JUAL7vHCHFSg8YN5bnpPT8g` by transfer action, against SOL staking rewards on the pool's stake accounts:

| date | SOL rewards | minted jupSOL | user-paid jupSOL | minted / rewards |
|---|---|---|---|---|
| 2026-07-04 | 1,519.77 | 73.08 | 34.03 | 4.81% |
| 2026-07-06 | 1,506.47 | 71.10 | 16.90 | 4.72% |
| 2026-07-08 | 1,503.28 | 73.02 | 12.57 | 4.86% |
| 2026-07-10 | 1,498.68 | 70.53 | 9.40 | 4.71% |
| 2026-07-12 | 1,499.35 | 63.05 | 7.50 | 4.21% |
| 2026-07-14 | 1,494.21 | 62.91 | 2.60 | 4.21% |
| 2026-07-16 | 1,507.29 | 62.88 | 2.54 | **4.17%** |

5% / 1.1986 = 4.172%, against 4.1715% measured on 2026-07-16. The earlier days sit slightly higher because the exchange rate was lower then. So the bulk of the inflow is the epoch fee arriving as a mint, not a user-paid fee — the user-paid leg is the small right-hand column.

That the supply side is currently the full reward stream is visible in production too: over 30d `dailyFees` 1,831,711 − `dailyRevenue` 110,694 = 1,721,017, which is exactly the reported `dailySupplySideRevenue`.

## Fix

```
fees       = staking rewards + user-paid deposit/withdrawal fees
revenue    = epoch fee mint + user-paid deposit/withdrawal fees   (unchanged)
supplySide = staking rewards x 0.95
```

`revenue + supplySide` still equals `fees`. Also dropped the `Deposit/Withdraw Fees` entry from the `Fees` breakdown, since no `.add()` uses that label on the fees side any more, and corrected the methodology line that claimed all staking rewards go to stakers.

At a 5% epoch fee this removes about 4.76% of reported fees: roughly **$87k over 30d and $4.2M over the adapter's lifetime** (reported all-time fees are $88.6M).

## Verification

`tsc --noEmit` is clean. I could not exercise this one through `cli/testAdapter.ts` — the CLI does not resolve `jupiter-staked-sol` from `fees/` on my checkout (it fails the same way for other plain-directory adapters such as `sanctum-validator-lsts`, while factory-backed ones run fine), so I did not want to claim a local run I did not get. The numbers above are all read from chain and from the production API instead. Happy to add a run if there is an invocation I am missing.