### PR TITLE
[fix] bonk-staked-sol - stop counting the epoch fee mint as extra fees and revenue

### DIFF
--- a/factory/solLst.ts
+++ b/factory/solLst.ts
@@ -58,6 +58,10 @@ interface StakingRevenueConfig {
 interface RevenueFeedbackConfig {
   addToFees: boolean;
   feesMetric?: string;
+  // Label for the user-paid deposit/withdrawal fees added to dailyFees when addToFees is
+  // false. Only set it on adapters that publish a Fees breakdown, so every label used has
+  // a matching breakdownMethodology entry.
+  userFeesMetric?: string;
 }
 
 interface SolLstConfig {
@@ -134,6 +138,8 @@ function getBreakdownMethodology(config: SolLstConfig): Record<string, Record<st
     feesBreakdown[config.fees.metric] = "Staking rewards from staked SOL";
   if (config.revenueFeedback.addToFees && config.revenueFeedback.feesMetric)
     feesBreakdown[config.revenueFeedback.feesMetric] = "Includes withdrawal fees and management fees";
+  if (!config.revenueFeedback.addToFees && config.revenueFeedback.userFeesMetric)
+    feesBreakdown[config.revenueFeedback.userFeesMetric] = "Deposit/withdrawal fees users pay on their principal";
   if (Object.keys(feesBreakdown).length > 0) breakdown.Fees = feesBreakdown;
 
   // Revenue breakdown
@@ -255,14 +261,13 @@ function createSolLstAdapter(config: SolLstConfig): SimpleAdapter {
         // account inflow into dailyFees include them, so they are skipped here.
         if (!config.revenueFeedback.addToFees) {
           const rev = config.revenue;
-          // No metric label here: the revenue labels are Revenue-side and have no matching
-          // entry under Fees, so these roll up into the base dailyFees total instead.
+          const metric = config.revenueFeedback.userFeesMetric;
           if (rev.type === "addCGToken") {
-            dailyFees.addCGToken(rev.cgId, row.amount || 0);
+            dailyFees.addCGToken(rev.cgId, row.amount || 0, metric);
           } else if (rev.type === "add") {
-            dailyFees.add(rev.mint, Number(row.amount) * 1e9 || 0);
+            dailyFees.add(rev.mint, Number(row.amount) * 1e9 || 0, metric);
           } else if (rev.type === "addToken") {
-            dailyFees.addToken(rev.mint, Number(row.amount) * 1e9 || 0);
+            dailyFees.addToken(rev.mint, Number(row.amount) * 1e9 || 0, metric);
           }
         }
       }
@@ -345,10 +350,12 @@ const configs: Record<string, SolLstConfig> = {
     lstMint: "BPSoLzmLQn47EP5aa7jmFngRL8KC3TWAeAwXwZD8ip3P",
     start: "2025-02-24",
     revenue: { type: "add", mint: "BPSoLzmLQn47EP5aa7jmFngRL8KC3TWAeAwXwZD8ip3P", metric: METRIC.MANAGEMENT_FEES },
+    revenueFeedback: { addToFees: false, userFeesMetric: METRIC.DEPOSIT_WITHDRAW_FEES },
     fees: { metric: METRIC.STAKING_REWARDS },
     breakdownMethodology: {
       Fees: {
         [METRIC.STAKING_REWARDS]: "Staking rewards from staked SOL on Backpack staked solana",
+        [METRIC.DEPOSIT_WITHDRAW_FEES]: "Deposit/withdrawal fees users pay on their principal",
       },
       Revenue: {
         [METRIC.MANAGEMENT_FEES]: "Includes withdrawal fees and management fees collected by fee collector",

--- a/factory/solLst.ts
+++ b/factory/solLst.ts
@@ -255,10 +255,12 @@ function createSolLstAdapter(config: SolLstConfig): SimpleAdapter {
         // account inflow into dailyFees include them, so they are skipped here.
         if (!config.revenueFeedback.addToFees) {
           const rev = config.revenue;
+          // No metric label here: the revenue labels are Revenue-side and have no matching
+          // entry under Fees, so these roll up into the base dailyFees total instead.
           if (rev.type === "addCGToken") {
-            dailyFees.addCGToken(rev.cgId, row.amount || 0, rev.metric);
+            dailyFees.addCGToken(rev.cgId, row.amount || 0);
           } else if (rev.type === "add") {
-            dailyFees.add(rev.mint, Number(row.amount) * 1e9 || 0, rev.metric);
+            dailyFees.add(rev.mint, Number(row.amount) * 1e9 || 0);
           } else if (rev.type === "addToken") {
             dailyFees.addToken(rev.mint, Number(row.amount) * 1e9 || 0);
           }

--- a/factory/solLst.ts
+++ b/factory/solLst.ts
@@ -248,6 +248,21 @@ function createSolLstAdapter(config: SolLstConfig): SimpleAdapter {
             dailyFees.addToken(rev.mint, Number(row.amount) * 1e9 || 0);
           }
         }
+      } else if (row.metric_type === "dailyUserFees") {
+        // Deposit/withdrawal fees are charged on the user's principal, so unlike the
+        // manager's epoch fee they are not part of the staking rewards counted above and
+        // have to be added to fees on their own. Adapters that already feed the whole fee
+        // account inflow into dailyFees include them, so they are skipped here.
+        if (!config.revenueFeedback.addToFees) {
+          const rev = config.revenue;
+          if (rev.type === "addCGToken") {
+            dailyFees.addCGToken(rev.cgId, row.amount || 0, rev.metric);
+          } else if (rev.type === "add") {
+            dailyFees.add(rev.mint, Number(row.amount) * 1e9 || 0, rev.metric);
+          } else if (rev.type === "addToken") {
+            dailyFees.addToken(rev.mint, Number(row.amount) * 1e9 || 0);
+          }
+        }
       }
     });
 
@@ -508,7 +523,7 @@ const configs: Record<string, SolLstConfig> = {
     revenueFeedback: { addToFees: false },
     returnDailyHoldersRevenue: 0,
     methodology: {
-      Fees: "Staking rewards from staked SOL on doublezero staked solana",
+      Fees: "Staking rewards from staked SOL on doublezero staked solana, plus the withdrawal fees users pay on their principal",
       Revenue: "Includes withdrawal fees and management fees collected by fee collector",
       ProtocolRevenue: "Revenue going to treasury/team",
       HoldersRevenue: "No revenue share to 2Z token holders.",
@@ -844,6 +859,11 @@ const doublezeroAdapter = (() => {
         dailyFees.addCGToken("solana", row.amount || 0);
       } else if (row.metric_type === "dailyRevenue") {
         dailyRevenue.addCGToken(revenueToken, row.amount || 0);
+      } else if (row.metric_type === "dailyUserFees") {
+        // Withdrawal fees are charged on the user's principal, so they are not part
+        // of the staking rewards counted above and have to be added to fees on their
+        // own. Without this a heavy withdrawal day reports more revenue than fees.
+        dailyFees.addCGToken(revenueToken, row.amount || 0);
       }
     });
 

--- a/fees/bonk-staked-sol/index.ts
+++ b/fees/bonk-staked-sol/index.ts
@@ -30,7 +30,10 @@ const fetch = async (options: FetchOptions) => {
         dailySupplySideRevenue.addCGToken("solana", amount * 0.95, "BonkSOL Staking Rewards to Stakers")
         dailySupplySideRevenue.addCGToken("solana", amount * 0.025, "BonkSOL Staking Rewards to Sanctum")
         dailyRevenue.addCGToken("solana", amount * 0.025, "BonkSOL Staking Rewards to Bonk")
-    } else if (row.metric_type === 'dailyRevenue') {
+    } else if (row.metric_type === 'dailyUserFees') {
+        // Only the withdrawal fees users pay on their principal. The rest of the fee
+        // account inflow is the 5% epoch fee, which is minted out of the staking rewards
+        // above and is already booked through the 2.5% Sanctum / 2.5% Bonk split.
         const amount = Number(row.amount) || 0
         dailyFees.addCGToken("bonk-staked-sol", amount, "BonkSOL Withdrawal Fees")
         dailyRevenue.addCGToken("bonk-staked-sol", amount, "BonkSOL Withdrawal Fees");

--- a/helpers/queries/sol-lst.sql
+++ b/helpers/queries/sol-lst.sql
@@ -30,6 +30,25 @@ WITH
             AND token_mint_address='{{lst_mint}}'
             AND block_time>=from_unixtime({{start}})
             AND block_time<=from_unixtime({{end}})
+    ),
+    -- The fee account receives the manager's cut two different ways:
+    --   action='mint'     -> the epoch (management) fee, minted out of the staking
+    --                        rewards that staking_fees above already counts
+    --   action='transfer' -> deposit/withdrawal fees paid by users on their principal,
+    --                        which are NOT part of the staking rewards
+    -- Only the transfer leg is fee revenue that staking_fees does not already include.
+    user_paid_fees AS (
+        SELECT
+            'dailyUserFees' as metric_type,
+            SUM(amount)/POW(10, 9) as amount
+        FROM
+            tokens_solana.transfers
+        WHERE
+            to_token_account='{{lst_fee_token_account}}'
+            AND token_mint_address='{{lst_mint}}'
+            AND action='transfer'
+            AND block_time>=from_unixtime({{start}})
+            AND block_time<=from_unixtime({{end}})
     )
 SELECT
     metric_type,
@@ -42,3 +61,9 @@ SELECT
     COALESCE(amount, 0) as amount
 FROM
     revenue_fees
+UNION ALL
+SELECT
+    metric_type,
+    COALESCE(amount, 0) as amount
+FROM
+    user_paid_fees


### PR DESCRIPTION
`fees/bonk-staked-sol` adds the whole manager fee account inflow to both `dailyFees` and `dailyRevenue`. Most of that inflow is the pool's epoch fee, which is minted out of the staking rewards the adapter already counts, so it gets counted twice. The 2.5% Sanctum / 2.5% Bonk split right above it is already that same epoch fee.

### The epoch fee, on-chain

Pool `ArAQfbzsdotoKB5jJcZa3ajQrrPcWr2YQoDAEAiFxJAC`, owned by `SP12tWFxD9oJsVWNavTTBZvMbA6gkAmxtVgxdqvyvhY` (Sanctum's stake pool program, same `StakePool` layout as the standard SPL one). The account holds the exact `reserve_stake`, `manager_fee_account` and `pool_mint` this adapter uses, which is what identifies it as the right pool:

```
offset reserve_stake       = 130   5htyN73FSd1dvv8LEHrmy4EiDkXtrGn5EXv5ZizqVF3X
offset pool_mint           = 162   BonK1YhkXEGLZzwtcvRTip3gAL9nCeQD7ppZBLXhtTs
offset manager_fee_account = 194   2azKdTLTd7xBF3mKjVBrrpj5jgJHoCRXLNpFjhfgzXwv
epoch_fee                  = 50 / 1000  = 5.0000%
total_lamports             = 138,767.433790757 SOL
pool_token_supply          = 116,628.669029879
last_update_epoch          = 1003   (current epoch, pool is live)
exchange rate              = 1.189823 SOL per bonkSOL
```

### The fee account receives the cut two different ways

`tokens_solana.transfers.action` separates them. `mint` is the epoch fee, minted as new bonkSOL out of that epoch's staking rewards. `transfer` is the withdrawal fees users pay out of their principal.

| day | SOL staking rewards | minted bonkSOL | transferred bonkSOL | mint / rewards |
|---|---|---|---|---|
| 2026-07-16 | 42.040637 | 1.76668542 | 0.004254943 | 4.2023% |
| 2026-07-14 | 41.745527 | 1.77148929 | 0.005189016 | 4.2435% |
| 2026-07-12 | 41.855594 | 1.77776787 | 0.025915536 | 4.2474% |
| 2026-07-10 | 41.787494 | 1.78241702 | 0.006710193 | 4.2654% |
| 2026-07-08 | 41.762582 | 1.78961748 | 0            | 4.2852% |

The minted share has to equal `epochFee / exchange rate` = `5% / 1.189823` = **4.2023%**, and on 2026-07-16 it measures **4.2023%**. The earlier days sit slightly higher because the exchange rate was lower then. Put in SOL terms: 42.040637 x 5% = **2.1020 SOL**, and 1.76668542 bonkSOL x 1.189823 = **2.1021 SOL**. The mint is the epoch fee.

That mint is already inside `dailyFees` as staking rewards, and already inside `dailyRevenue` through the 2.5% Bonk line. Only the `transfer` leg is a fee the staking rewards do not already contain.

### Production shows the double count

DefiLlama for 2026-07-16: fees 3,328, revenue 237, supply side 3,091. Revenue decomposes exactly as 79 (the 2.5% Bonk cut) + 158 (the re-added mint, 1.76668542 bonkSOL at $89.63). Running this branch on the same day:

```
Daily fees: 3.17 k
Daily revenue: 80.00
Daily supply side revenue: 3.09 k

label                              | Daily fees | Daily revenue | Daily supply side revenue
BonkSOL Staking Rewards            | 3165       |               |
BonkSOL Withdrawal Fees            | 0.3802     | 0.3802        |
BonkSOL Staking Rewards to Stakers |            |               | 3007
BonkSOL Staking Rewards to Sanctum |            |               | 79
BonkSOL Staking Rewards to Bonk    |            | 79            |
```

Revenue goes from 237 to 80, and revenue + supply side (80 + 3,086) now reconciles to fees (3,165). Over the last 30 days revenue reads $3,630 where the true figure is about $1,230, so revenue is roughly 3x too high, and fees are about 4.8% too high ($49,825 reported). SOL $74.85 / bonkSOL $89.63, CoinGecko at time of writing.

### Change

Read the `dailyUserFees` row (the `transfer` leg) instead of the full inflow. The 2.5% / 2.5% split already carries the epoch fee, so nothing else moves and the identity closes.

Depends on #8246, which adds that row to the shared `helpers/queries/sol-lst.sql`; the first three commits here are that PR and drop out once it lands.