### PR TITLE
[fix] marginfi-staked-sol - use its own stake pool authority, not hylo's

### DIFF
--- a/factory/solLst.ts
+++ b/factory/solLst.ts
@@ -693,8 +693,8 @@ const configs: Record<string, SolLstConfig> = {
   }),
 
   "marginfi-staked-sol": simpleConfig({
-    stakePoolReserveAccount: "3b7XQeZ8nSMyjcQGTFJS5kBw4pXS2SqtB9ooHCnF2xV9",
-    stakePoolWithdrawAuthority: "2C9aTiNL6VyrPhFKspZC8BY9JeL3j4RtkPP2e4PrVAwP",
+    stakePoolReserveAccount: "AWDrV3Va8RKGMAo9bi5iYhqhETRsTT7NasRFC22uBj4A",
+    stakePoolWithdrawAuthority: "3b7XQeZ8nSMyjcQGTFJS5kBw4pXS2SqtB9ooHCnF2xV9",
     lstFeeTokenAccount: "3zaVJxg2HCEYF9n2ndgm2SemrDiYniru7oS26yb7fep2",
     lstMint: "LSTxxxnJzKDFSLr4dUkPcmCf5VyryEqzPLz5j4bpxFp",
     start: "2024-07-17",


### PR DESCRIPTION
`marginfi-staked-sol` sums staking rewards for the wrong pool. Its `stakePoolWithdrawAuthority` is `2C9aTiNL6VyrPhFKspZC8BY9JeL3j4RtkPP2e4PrVAwP`, which is hylo's — it is the same constant `fees/hylo-lst.ts` uses for the hyloSOL pool. marginfi's own authority is sitting in the `stakePoolReserveAccount` field instead, and the reserve account is missing entirely.

### What the two addresses actually are

`3b7XQeZ8nSMyjcQGTFJS5kBw4pXS2SqtB9ooHCnF2xV9`, currently configured as the reserve, does not exist as an account at all. It is the pool's authority: reading marginfi's real reserve stake account shows it as the staker and withdrawer.

```
AWDrV3Va8RKGMAo9bi5iYhqhETRsTT7NasRFC22uBj4A
  owner       Stake11111111111111111111111111111111111111
  lamports    1010.422277 SOL
  type        initialized (no delegation)
  withdrawer  3b7XQeZ8nSMyjcQGTFJS5kBw4pXS2SqtB9ooHCnF2xV9
  staker      3b7XQeZ8nSMyjcQGTFJS5kBw4pXS2SqtB9ooHCnF2xV9
```

And `AWDrV3Va...` is the `reserve_stake` stored in the pool account itself, at the standard offset. The `lstFeeTokenAccount` and `lstMint` in this config both match that same pool account, so only these two fields are off.

### The two authorities select disjoint stake accounts

`helpers/queries/sol-lst.sql` builds its stake account set from `delegatestake` calls filtered on `account_stakeAuthority`. Comparing the configured authority against marginfi's real one over the last 30 days:

| | stake accounts | staking rewards 30d |
|---|---|---|
| configured (`2C9aTiNL...`, hylo's) | 2 | **868.892934 SOL** |
| marginfi's own (`3b7XQeZ8...`) | 2,034 | **451.601714 SOL** |
| overlap | **0** | |

The sets do not intersect at all, so none of what is currently reported is marginfi's.

Both figures line up with the pools behind them. marginfi's pool holds 93,890 SOL, and 451.60 SOL over 30 days is about 5.8% annualised. hylo's pool holds 185,592 SOL, and 868.89 SOL over 30 days is about 5.7%. The reported number is roughly double the real one because hylo's pool is roughly double the size.

### Production confirms it

DefiLlama reports $4,191 for marginfi LST on 2026-07-16. Running this branch for the same day:

```
Daily fees: 2.12 k
Daily revenue: 3.43
Daily protocol revenue: 3.43
```

$4,191 to $2,120, a factor of 1.98, against the 1.92 the reward sums predict. Over 30 days that is $61,177 reported where roughly $31,800 is correct.

There is a second effect worth noting: because `fees/hylo-lst.ts` reads that same authority for hyloSOL, hylo's staking rewards are currently counted twice across DefiLlama, once under Hylo LSTs and once under marginfi LST. This fixes both by pointing marginfi at its own pool.

### Change

Two addresses:

- `stakePoolWithdrawAuthority` becomes `3b7XQeZ8nSMyjcQGTFJS5kBw4pXS2SqtB9ooHCnF2xV9`, marginfi's pool authority
- `stakePoolReserveAccount` becomes `AWDrV3Va8RKGMAo9bi5iYhqhETRsTT7NasRFC22uBj4A`, the pool's actual reserve

The reserve is undelegated and earns no staking rewards (querying it and several other pools' reserves returns no rows in `solana.rewards` over 90 days), so that field is not what moves the number here — but it was pointing at a non-existent account, so it seemed worth correcting at the same time.