### PR TITLE
fix(dexs): align flowr fees with gamified-mining category accounting

### DIFF
--- a/dexs/flowr.ts
+++ b/dexs/flowr.ts
@@ -24,6 +24,7 @@ async function fetch(options: FetchOptions) {
   const dailyRevenue = options.createBalances();
   const dailyProtocolRevenue = options.createBalances();
   const dailyHoldersRevenue = options.createBalances();
+  const dailySupplySideRevenue = options.createBalances();
 
   const logs = await options.getLogs({
     target: FLOWR_GARDEN,
@@ -49,8 +50,13 @@ async function fetch(options: FetchOptions) {
     }
 
     dailyVolume.addGasToken(price);
+    // Full takeover payment counts as fees: the 25% protocol envelope plus the 75% payout the
+    // protocol distributes to the replaced gardener (the game's supply side). This keeps the
+    // accounting identity dailyFees = dailyRevenue + dailySupplySideRevenue.
     dailyFees.addGasToken(envelope, "Protocol Envelope Fees");
+    dailyFees.addGasToken(payout, "Previous Gardener Payout");
     dailyRevenue.addGasToken(envelope, "Protocol Envelope Fees");
+    dailySupplySideRevenue.addGasToken(payout, "Previous Gardener Payout");
 
     dailyHoldersRevenue.addGasToken(toStakers, "Envelope Fees to $FLOWR Stakers");
     dailyHoldersRevenue.addGasToken(toBuybacks, "Envelope Fees to $FLOWR Buybacks");
@@ -64,20 +70,23 @@ async function fetch(options: FetchOptions) {
     dailyRevenue,
     dailyProtocolRevenue,
     dailyHoldersRevenue,
+    dailySupplySideRevenue,
   };
 }
 
 const methodology = {
   Volume: "ETH paid into FlowrGarden to take over flower plots (Planted.price).",
-  Fees: "25% of each takeover, paid by players to the protocol envelope.",
+  Fees: "The full takeover payment (Planted.price): players pay it to perform the core game action, and the protocol splits it between the 75% previous-gardener payout (supply side) and the 25% protocol envelope.",
   Revenue: "The protocol envelope of each takeover — Planted.price minus the previous-gardener payout — which is 25% of the payment by construction.",
   ProtocolRevenue: "8.25% of each takeover goes to the protocol treasury.",
   HoldersRevenue: "Includes 10.5% of each takeover going to $FLOWR buybacks and the 6.25% staking distribution, live since 2026-07-11.",
+  SupplySideRevenue: "The previous-gardener payout: 75% of each takeover, paid on the spot to the gardener being replaced — plot holders are the game's supply side.",
 };
 
 const breakdownMethodology = {
   Fees: {
     "Protocol Envelope Fees": "25% of each takeover, paid by players to the protocol envelope.",
+    "Previous Gardener Payout": "75% of each takeover, distributed by the protocol to the gardener being replaced.",
   },
   Revenue: {
     "Protocol Envelope Fees": "25% of each takeover, paid by players to the protocol envelope.",
@@ -88,6 +97,9 @@ const breakdownMethodology = {
   HoldersRevenue: {
     "Envelope Fees to $FLOWR Stakers": "6.25% of each takeover, distributed to FLOWR stakers.",
     "Envelope Fees to $FLOWR Buybacks": "10.5% of each takeover, distributed to $FLOWR buybacks.",
+  },
+  SupplySideRevenue: {
+    "Previous Gardener Payout": "75% of each takeover, paid on the spot to the gardener being replaced.",
   },
 };
 


### PR DESCRIPTION
Resubmission of #8157 and #8174. Opening once more to ask for a second opinion on a methodology question that the category currently answers both ways, cc @noateden.

The question: should flowr count the full takeover payment as fees with the participant payout as supply-side revenue, or only the 25% protocol envelope?

The category currently does both:

- `fees/pizza-city.ts`: "Total ETH bid into Dutch auctions (100% of pot)" as fees, with 85% of each pot as `supplySideRevenue`
- `fees/zinc/index.ts`: fees include the prize-pool flows paid back to players, reported as supply side
- `fees/minebtc.ts`: `dailyFees` is built as protocol + holders + supply-side components
- `dexs/landbid.ts`: fees are 100% of the takeover payment, with the previous-holder payout as `supplySideRevenue`
- `dexs/flowr.ts` after the #8150 revision: envelope-only fees, no supply side reported

flowr's flow is not peer-to-peer: the contract receives the full payment and pays the previous participant out of it in the same transaction. Example: [0x81e1ef...b11294](https://robinhoodchain.blockscout.com/tx/0x81e1ef1ffe2616b483f61818160e40b9a7d88f5b24b61c3ea7d63be252b11294), 0.0894 ETH into FlowrGarden and 0.0670 ETH (exactly 75%) paid out by the contract to the replaced gardener. That matches the adapters above that report the full payment as fees.

This PR aligns flowr with those adapters, keeping the identity `dailyFees = dailyRevenue + dailySupplySideRevenue`. If envelope-only is the intended convention going forward, no problem: happy to close this and keep the current treatment, but in that case the category is inconsistent and the adapters above presumably deserve the same revision.

Test output (`pnpm test dexs flowr`): volume 18.12k, fees 18.12k, revenue 4.53k, supply side 13.59k, holders 3.04k, protocol 1.50k. The identities hold exactly.

**NOTE**

#### "Allow edits by maintainers" is enabled.
