### PR TITLE
feat(hyperliquid): add Signalview builder code fees/revenue

### DIFF
--- a/factory/hyperliquid.ts
+++ b/factory/hyperliquid.ts
@@ -30,6 +30,19 @@ const superxConfig: BuilderConfig = {
 // factory export. The DefiLlama dimension framework picks the appropriate
 // fields (volume vs fees) based on each protocol's metadata adapter type.
 const builderConfigs: Record<string, BuilderConfig> = {
+  "signalview": {
+    addresses: [
+      "0x7c7f5fab1e78a08274a2f2a36c4e7dd3557c9cfa",
+    ],
+    start: "2026-06-02",
+    methodology: {
+      Volume: "Notional volume of Hyperliquid perpetual trades routed by Signalview's AI trading agents.",
+      Fees: "Builder code fees paid by users whose Hyperliquid perpetual trades are executed through Signalview.",
+      Revenue: "Builder code fees collected by Signalview from Hyperliquid perpetual trades.",
+      ProtocolRevenue: "Builder code fees collected by Signalview from Hyperliquid perpetual trades.",
+    },
+    breakdownFees: true,
+  },
   "stablejack-perps": {
     addresses: [
       "0x68b7e8be8f1a62f99e37f1ac191dd23486e8a2ad",


### PR DESCRIPTION
## What this adds

Adds **Signalview** to the Hyperliquid builder factory (`factory/hyperliquid.ts`) so its Hyperliquid builder-code fees, revenue and routed volume are tracked.

Signalview runs non-custodial AI trading agents that execute backtested signals on Hyperliquid perpetuals. Orders are routed under the builder code below, so this is a fees/revenue (+ dexs volume) protocol, not TVL.

## Protocol information

- **Name:** Signalview
- **Website:** https://www.signalview.xyz
- **Twitter/X:** https://x.com/signalview_xyz
- **GitHub:** https://github.com/mokshyaprotocol/signalview
- **Logo:** https://www.signalview.xyz/icon-512.png
- **Category:** Trading App (Hyperliquid builder code)
- **Builder address:** `0x7c7f5fab1e78a08274a2f2a36c4e7dd3557c9cfa`
- **Start:** 2026-06-02 (first day Hyperliquid published builder_fills data for this address)

## Methodology

Builder-code fees paid by users whose Hyperliquid perpetual trades are routed by Signalview's AI agents (fees == revenue == protocol revenue; volume = notional routed).

## Verification (run locally)

```
npm test fees signalview 1783728000
```
```
🦙 Running SIGNALVIEW adapter from hyperliquid factory 🦙
Start Date: Fri, 10 Jul 2026  End Date: Sat, 11 Jul 2026
Daily volume: 4.90 k
Daily fees: 4.90
Daily revenue: 4.90
Daily protocol revenue: 4.90
FEES BREAKDOWN: Hyperliquid Builder Code Fees | 4.9 | 4.9
```

Cumulative builder rewards for this address are ~$682 (Hyperliquid `referral`/builderRewards), earned since early June 2026 and ongoing.

## Checklist
- [x] Only `factory/hyperliquid.ts` changed; no lockfile / workspace / dependency changes
- [x] Lowercase builder address (matches Hyperliquid's `builder_fills` S3 path)
- [x] Adapter returns data locally for a date with published fills
- [x] Allow edits by maintainers
