### PR TITLE
[fix] liquid-collective - gross up rewards, the exchange rate is already net of the service fee

### DIFF
--- a/fees/liquid-collective/index.ts
+++ b/fees/liquid-collective/index.ts
@@ -31,7 +31,11 @@ const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
     abi: 'uint256:totalUnderlyingSupply',
   })
 
-  const dailyLsEthHoldersYield = (totalUnderlyingSupplyAfter / totalSupplyAfter - totalUnderlyingSupplyBefore / totalSupplyBefore) * (totalSupplyAfter / 1e18) * 1e18;
+  // The service fee is charged by minting new lsETH to the collector, not by reducing the
+  // exchange rate, so the rate growth below is already net of it. Gross it back up to get
+  // the total rewards before the fee.
+  const lsEthHoldersYield = (totalUnderlyingSupplyAfter / totalSupplyAfter - totalUnderlyingSupplyBefore / totalSupplyBefore) * (totalSupplyAfter / 1e18) * 1e18;
+  const dailyLsEthHoldersYield = lsEthHoldersYield / (1 - ProtocolFeeRate);
 
   // MEV and execution rewards
   let mevRewards = 0


### PR DESCRIPTION
The adapter derives its base quantity from lsETH exchange-rate growth and then splits 10/90 on top of it:

```ts
const dailyLsEthHoldersYield = (totalUnderlyingSupplyAfter / totalSupplyAfter - totalUnderlyingSupplyBefore / totalSupplyBefore) * (totalSupplyAfter / 1e18) * 1e18;
const dfExcludeMev = dailyLsEthHoldersYield - mevRewards;
dailyFees.addGasToken(dfExcludeMev, ...)
dailyRevenue.addGasToken(dfExcludeMev * ProtocolFeeRate, ...)
dailySupplySideRevenue.addGasToken(dfExcludeMev * (1 - ProtocolFeeRate), ...)
```

The 10% service fee is not carved out of the exchange rate — it is charged by **minting new lsETH to the collector**. So the rate growth that expression measures is already net of the fee, and the split is applied to an already-netted base. Every metric ends up 10% low.

### The fee is a mint, not a rate cut

Read on the proxy `0x8c1BEd5b9a0928467c9B1341Da1D7BD5e10b6549`:

```
getGlobalFee()          = 1000 bps  (10.00%)
getCollector()          = 0x53b5c4231fba19de04866a84fed928aeca0102fe
totalSupply()           = 286,729.429385 lsETH
totalUnderlyingSupply() = 319,178.294527 ETH
exchange rate           = 1.11316894
```

There is exactly one oracle report per day, and exactly one lsETH mint from `0x0` to that collector per day:

| day | mints | lsETH minted to collector |
|---|---|---|
| 2026-07-18 | 1 | 2.118452969 |
| 2026-07-17 | 1 | 2.000844708 |
| 2026-07-16 | 1 | 2.084875533 |
| 2026-07-15 | 1 | 2.138188435 |
| 2026-07-14 | 1 | 2.087081400 |

If the fee were taken out of the exchange rate there would be no such mint. Because it is a mint, the rate only grows by the holders' 90%.

### Decomposing one report

For the 2026-07-18 report, valuing the minted shares at the post-report rate:

```
fee            = 2.118452969 lsETH x 1.11316894  = 2.3582 ETH
rate growth    (what the adapter measures)       = 21.2239 ETH
gross rewards  = 21.2239 + 2.3582                = 23.5821 ETH

fee / gross = 2.3582 / 23.5821 = 0.10000
```

which is exactly `getGlobalFee()`. So `dailyLsEthHoldersYield` is 0.90 x gross, and the correct `dailyFees` for that day is 23.5821 ETH, not 21.2239 ETH.

Production agrees it is publishing the netted figure: `/summary/fees/liquid-collective` gives $39,124 for 2026-07-18, which at the day's ETH price is ~20.9 ETH, and `dailyRevenue / dailyFees` is exactly 0.1000 on every day of the last 30.

### The three sibling adapters already do this

Every other adapter in the repo written in this same rate-growth style grosses up first:

```ts
fees/cbeth/index.ts:            const grossRewards = netRewards / (1 - PROTOCOL_FEE);
fees/meth-protocol.ts:          const df = totalSupply * (exchangeRateAfter - exchangeRateBefore) / 0.9 / 1e18
fees/binance-staked-eth.ts:     const df = totalSupply * (exchangeRateAfter - exchangeRateBefore) / 0.9 / 1e18
```

This one is the only outlier, so the change just brings it in line.

### Impact

Reported values are 0.90 of the true ones, structurally, on every day since `start: '2022-11-19'` — this is not a recent regression.

| metric | reported 30d | corrected 30d | understated by |
|---|---|---|---|
| dailyFees | $1,149,695 | $1,277,439 | $127,744 |
| dailySupplySideRevenue | $1,034,724 | $1,149,693 | $114,969 |
| dailyRevenue | $114,969 | $127,743 | $12,774 |

On `total1y`, dailyFees goes from $25,703,530 to $28,559,478.

### Change

One expression, matching the sibling adapters. The gross-up is applied before the MEV subtraction (as in `fees/cbeth/index.ts`) so both legs are on the same gross basis — previously a gross MEV figure was being subtracted from a net total.

An alternative would be to derive the fee directly from the mint (sum `Transfer(0x0 -> collector)` over the window and value it at the post rate) rather than using the hardcoded 10%. That is exact even on days when part of the inflow is fee-exempt, but it adds a log dependency, so I went with the form the other three adapters already use. Happy to switch if you prefer the mint-derived version.

I could not run this one locally end to end — `sdk.indexer.getTransactions` for the MEV leg needs the Llama Indexer key, which I don't have (`Error: Llama Indexer URL/api key is not set`). The change does not touch that path, and the numbers above come from the contract and the production API, both re-runnable independently.