### PR TITLE
[fix] binance-wallet - count one row per swap, dex trades are per pool hop

### DIFF
--- a/aggregators/binancewallet/index.ts
+++ b/aggregators/binancewallet/index.ts
@@ -65,7 +65,7 @@ const prefetch = async (options: FetchOptions) => {
       SELECT
         blockchain,
         amount_usd,
-        ROW_NUMBER() OVER (PARTITION BY tx_hash ORDER BY amount_usd DESC) AS rn
+        ROW_NUMBER() OVER (PARTITION BY blockchain, tx_hash ORDER BY amount_usd DESC) AS rn
       FROM dex.trades
       WHERE TIME_RANGE
         AND (${evmFilter})

--- a/aggregators/binancewallet/index.ts
+++ b/aggregators/binancewallet/index.ts
@@ -41,20 +41,31 @@ const prefetch = async (options: FetchOptions) => {
         AND address = '${chainConfig[CHAIN.SOLANA].address}'
       GROUP BY 1
     ),
-    sol AS (
+    -- dex trades hold one row per pool hop, so a routed swap appears several times.
+    -- Keep the largest hop per transaction, which is the size of the swap the user made.
+    sol_hops AS (
       SELECT
         t.blockchain,
-        SUM(t.amount_usd) AS trading_volume
+        t.amount_usd,
+        ROW_NUMBER() OVER (PARTITION BY t.tx_id ORDER BY t.amount_usd DESC) AS rn
       FROM dex_solana.trades t
       INNER JOIN solana_txs b ON t.tx_id = b.tx_id
       WHERE TIME_RANGE
         AND t.amount_usd < 10000000
-      GROUP BY 1
     ),
-    evm AS (
+    sol AS (
       SELECT
         blockchain,
         SUM(amount_usd) AS trading_volume
+      FROM sol_hops
+      WHERE rn = 1
+      GROUP BY 1
+    ),
+    evm_hops AS (
+      SELECT
+        blockchain,
+        amount_usd,
+        ROW_NUMBER() OVER (PARTITION BY tx_hash ORDER BY amount_usd DESC) AS rn
       FROM dex.trades
       WHERE TIME_RANGE
         AND (${evmFilter})
@@ -62,6 +73,13 @@ const prefetch = async (options: FetchOptions) => {
         AND amount_usd < 10000000
         AND token_sold_address NOT IN (${blacklisted.toString()})
         AND token_bought_address NOT IN (${blacklisted.toString()})
+    ),
+    evm AS (
+      SELECT
+        blockchain,
+        SUM(amount_usd) AS trading_volume
+      FROM evm_hops
+      WHERE rn = 1
       GROUP BY 1
     ),
     total AS (

--- a/aggregators/binancewallet/index.ts
+++ b/aggregators/binancewallet/index.ts
@@ -42,12 +42,13 @@ const prefetch = async (options: FetchOptions) => {
       GROUP BY 1
     ),
     -- dex trades hold one row per pool hop, so a routed swap appears several times.
-    -- Keep the largest hop per transaction, which is the size of the swap the user made.
+    -- Keep the largest hop per trader per transaction: partitioning on the transaction
+    -- alone would drop the other traders in a batched transaction.
     sol_hops AS (
       SELECT
         t.blockchain,
         t.amount_usd,
-        ROW_NUMBER() OVER (PARTITION BY t.tx_id ORDER BY t.amount_usd DESC) AS rn
+        ROW_NUMBER() OVER (PARTITION BY t.tx_id, t.trader_id ORDER BY t.amount_usd DESC) AS rn
       FROM dex_solana.trades t
       INNER JOIN solana_txs b ON t.tx_id = b.tx_id
       WHERE TIME_RANGE
@@ -65,7 +66,7 @@ const prefetch = async (options: FetchOptions) => {
       SELECT
         blockchain,
         amount_usd,
-        ROW_NUMBER() OVER (PARTITION BY blockchain, tx_hash ORDER BY amount_usd DESC) AS rn
+        ROW_NUMBER() OVER (PARTITION BY blockchain, tx_hash, taker ORDER BY amount_usd DESC) AS rn
       FROM dex.trades
       WHERE TIME_RANGE
         AND (${evmFilter})


### PR DESCRIPTION
Same overcount that was fixed in `rainbow-wallet` (#8258) and `photon` (#8202): `dex.trades` and `dex_solana.trades` hold one row per pool hop, so `SUM(amount_usd)` counts a routed swap once per hop.

Both legs of the prefetch query sum raw hop rows, with no deduplication.

### The trades are batched, so this has to be per trader

Binance Wallet transactions frequently carry several independent traders. On BSC, one hour of 2026-07-16 (12:00-13:00 UTC):

```
transactions                        9,446
transactions with >1 distinct taker   907    (9.6%)
hop rows                           11,995

SUM(amount_usd)                      $14,258,485.82   <- what is published now
one row per (tx_hash, taker)         $14,016,293.22   <- this PR
one row per tx_hash                  $13,910,727.31   <- would drop batched traders
```

So collapsing on the transaction alone is not safe here: it silently discards the other traders in those 907 transactions. This partitions by `(blockchain, tx_hash, taker)` on the EVM leg and `(tx_id, trader_id)` on the Solana leg, which is the same per-trader shape merged in photon:

```sql
ROW_NUMBER() OVER (PARTITION BY t.tx_id, t.trader_id ORDER BY t.amount_usd DESC)
```

### Why not the `dex_aggregator.trades` route

#8258 fixed rainbow-wallet by unioning in `dex_aggregator.trades`, which carries the full order amount. That does not work here — the Binance Wallet router is barely decoded in that table. Over 7 days, `tx_to = 0xb300000b72DEAEb607a12d5f54773D1C19c7028d` gives about $9.9M total there (ethereum $4.30M, bnb $2.33M, avalanche_c $1.55M, polygon $707k, arbitrum $654k, base $360k) against $2.95B in `dex.trades`. Switching source would discard essentially all the volume, so this uses the photon remedy instead.

### Result

Local run for 2026-07-16:

```
chain     | Daily volume
ethereum  | 14.70 M
bsc       | 155.87 M
solana    | 1.81 M
polygon   | 781.08 k
avax      | 531.73 k
base      | 516.10 k
arbitrum  | 391.44 k
...
Aggregate | 174.60 M
```

against $188,418,331 currently published for that day, so about 7.3% lower. Most of the correction is on Ethereum and Base; BSC, which carries the bulk of the volume, only moves about 1.7%, so the headline effect is much smaller than the raw hop-row counts suggest.

The existing filters (the `< 10000000` cap, the blacklisted-token filters, the per-chain router match) are unchanged and still applied before ranking.

One caveat worth stating: keeping the largest hop per trader is a lower bound if a single trader genuinely makes two independent swaps inside one transaction, exactly as in the photon fix. The per-hop sum is an upper bound and the truth sits between, but the per-hop figure is the one that is clearly wrong for a multi-hop route.