### PR TITLE
[volume]whales-market: add volume adapter for whales market

### DIFF
--- a/dexs/whales-market.ts
+++ b/dexs/whales-market.ts
@@ -1,0 +1,110 @@
+import asyncRetry from "async-retry";
+import { Dependencies, FetchOptions, SimpleAdapter } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+import { queryDuneSql } from "../helpers/dune";
+import ADDRESSES from "../helpers/coreAssets.json";
+
+const NEW_ORDER_ABI = "event NewOrder(uint256 id, uint256 offerId, uint256 amount, address seller, address buyer)";
+const OFFERS_ABI = "function offers(uint256) view returns (uint8 offerType, bytes32 tokenId, address exToken, uint256 amount, uint256 value, uint256 collateral, uint256 filledAmount, uint8 status, address offeredBy, bool fullMatch)";
+const SOLANA_PROGRAM = "stPdYNaJNsV3ytS9Xtx4GXXXRcVqVS6x66ZFa26K39S";
+
+const config: Record<string, { contract?: string; start: string }> = {
+  [CHAIN.SOLANA]: { start: "2023-12-13" },
+  [CHAIN.ETHEREUM]: { contract: "0x1ecdb32e59e948c010a189a0798c674a2d0c6603", start: "2024-01-29" },
+  [CHAIN.BASE]: { contract: "0xdf02eeaB3CdF6eFE6B7cf2EB3a354dCA92A23092", start: "2024-01-29" },
+  [CHAIN.ERA]: { contract: "0xE6c5F63623A2aE769dd3D505Bc44D7EB21dd974b", start: "2024-01-29" },
+  [CHAIN.ARBITRUM]: { contract: "0x7a560269480Ef38B885526C8bBecdc4686d8bF7A", start: "2024-01-29" },
+  [CHAIN.BSC]: { contract: "0x7a560269480Ef38B885526C8bBecdc4686d8bF7A", start: "2024-01-29" },
+  [CHAIN.OPTIMISM]: { contract: "0x0e57fFf83aE53b22c5B656745168b21A9d2AC3DA", start: "2024-01-29" },
+  [CHAIN.LINEA]: { contract: "0x7a560269480Ef38B885526C8bBecdc4686d8bF7A", start: "2024-01-29" },
+  [CHAIN.MODE]: { contract: "0x7a560269480Ef38B885526C8bBecdc4686d8bF7A", start: "2024-02-15" },
+  [CHAIN.SCROLL]: { contract: "0x7a560269480Ef38B885526C8bBecdc4686d8bF7A", start: "2024-01-29" },
+  [CHAIN.TAIKO]: { contract: "0x7a560269480Ef38B885526C8bBecdc4686d8bF7A", start: "2024-06-01" },
+  [CHAIN.BERACHAIN]: { contract: "0x7a560269480Ef38B885526C8bBecdc4686d8bF7A", start: "2025-02-06" },
+  [CHAIN.AVAX]: { contract: "0x7a560269480Ef38B885526C8bBecdc4686d8bF7A", start: "2024-01-29" },
+  [CHAIN.HYPERLIQUID]: { contract: "0xE2300eC1a92e3ca0Cf91269C28CaDCa58826E72C", start: "2025-02-18" },
+  [CHAIN.ABSTRACT]: { contract: "0xeFFcBE4711Bc9360F596CA615b3C4003A0d7Ea33", start: "2025-01-27" },
+};
+
+const addVolume = (dailyVolume: any, exToken: string, amount: number) => {
+  if (amount <= 0) return;
+  if (exToken.toLowerCase() === ADDRESSES.null) dailyVolume.addGasToken(amount);
+  else dailyVolume.add(exToken, amount);
+};
+
+const fetchEvm = async (options: FetchOptions) => {
+  const target = config[options.chain].contract;
+  const dailyVolume = options.createBalances();
+
+  const orders = await options.getLogs({ target, eventAbi: NEW_ORDER_ABI });
+
+  if (orders.length) {
+    const offerIds = [...new Set(orders.map((o: any) => o.offerId.toString()))];
+    // multicall was crashing sometimes while testing, so we retry a few times before failing
+    const offers = await asyncRetry(
+      () => options.api.multiCall({ target, abi: OFFERS_ABI, calls: offerIds, permitFailure: true }),
+      { retries: 3, minTimeout: 2000 },
+    );
+    const offersById = new Map(offerIds.map((id, i) => [id, offers[i]]));
+
+    for (const order of orders) {
+      const offer: any = offersById.get(order.offerId.toString());
+      if (!offer || Number(offer.amount) === 0) continue;
+      addVolume(dailyVolume, offer.exToken, Number(offer.value) * Number(order.amount) / Number(offer.amount));
+    }
+  }
+
+  return { dailyVolume };
+};
+
+// Escrow authority that owns the pre-market vault token accounts: an off-curve
+// PDA whose account is owned by the whales program itself (verifiable via
+// getAccountInfo); same address the DefiLlama TVL adapter sums balances for.
+const SOLANA_ESCROW = "GDsMbTq82sYcxPRLdQ9RHL9ZLY3HNVpXjXtCnyxpb2rQ";
+
+const solSql = () => `
+    WITH fill_txs AS (
+        SELECT DISTINCT tx_id
+        FROM solana.instruction_calls
+        WHERE tx_success
+          AND executing_account = '${SOLANA_PROGRAM}'
+          AND is_inner = false
+          AND TIME_RANGE
+          AND ANY_MATCH(log_messages, x -> x LIKE '%FillOffer%')
+    )
+    SELECT
+        t.token_mint_address AS mint,
+        SUM(t.amount) AS amount
+    FROM tokens_solana.transfers t
+    JOIN fill_txs f ON t.tx_id = f.tx_id
+    WHERE t.to_owner = '${SOLANA_ESCROW}'
+      AND TIME_RANGE
+    GROUP BY t.token_mint_address
+`;
+
+const fetchSolana = async (options: FetchOptions) => {
+  const dailyVolume = options.createBalances();
+  const rows = await queryDuneSql(options, solSql());
+  for (const row of rows || []) {
+    if (row.mint && row.amount) dailyVolume.add(row.mint, row.amount);
+  }
+  return { dailyVolume };
+};
+
+const fetch = async (options: FetchOptions) => {
+  if (options.chain === CHAIN.SOLANA) return fetchSolana(options);
+  return fetchEvm(options);
+};
+
+const adapter: SimpleAdapter = {
+  version: 1, 
+  fetch,
+  adapter: config,
+  dependencies: [Dependencies.DUNE],
+  methodology: {
+    Volume:
+      "USD value of filled OTC orders on Whales Market pre-markets. EVM fills are valued pro-rata against the offer they fill (read from the contract); Solana fills are valued as the tokens deposited into the program escrow in the fill transaction.",
+  },
+};
+
+export default adapter;

--- a/dexs/whales-market.ts
+++ b/dexs/whales-market.ts
@@ -1,7 +1,6 @@
 import { Dependencies, FetchOptions, SimpleAdapter } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
 import { queryDuneSql } from "../helpers/dune";
-import ADDRESSES from "../helpers/coreAssets.json";
 
 const NEW_ORDER_ABI = "event NewOrder(uint256 id, uint256 offerId, uint256 amount, address seller, address buyer)";
 const OFFERS_ABI = "function offers(uint256) view returns (uint8 offerType, bytes32 tokenId, address exToken, uint256 amount, uint256 value, uint256 collateral, uint256 filledAmount, uint8 status, address offeredBy, bool fullMatch)";
@@ -25,12 +24,6 @@ const config: Record<string, { contract?: string; start: string }> = {
   [CHAIN.ABSTRACT]: { contract: "0xeFFcBE4711Bc9360F596CA615b3C4003A0d7Ea33", start: "2025-01-27" },
 };
 
-const addVolume = (dailyVolume: any, exToken: string, amount: number) => {
-  if (amount <= 0) return;
-  if (exToken.toLowerCase() === ADDRESSES.null) dailyVolume.addGasToken(amount);
-  else dailyVolume.add(exToken, amount);
-};
-
 const fetchEvm = async (options: FetchOptions) => {
   const target = config[options.chain].contract;
   const dailyVolume = options.createBalances();
@@ -39,24 +32,13 @@ const fetchEvm = async (options: FetchOptions) => {
 
   if (orders.length) {
     const offerIds = [...new Set(orders.map((o: any) => o.offerId.toString()))];
-    // a whole multicall RPC batch can fail transiently under load; retry a few
-    // times before failing the run
-    let offers: any[] = [];
-    for (let attempt = 0; ; attempt++) {
-      try {
-        offers = await options.api.multiCall({ target, abi: OFFERS_ABI, calls: offerIds, permitFailure: true });
-        break;
-      } catch (e) {
-        if (attempt >= 3) throw e;
-        await new Promise((resolve) => setTimeout(resolve, 2000 * (attempt + 1)));
-      }
-    }
+    const offers = await options.api.multiCall({ target, abi: OFFERS_ABI, calls: offerIds, permitFailure: true });
     const offersById = new Map(offerIds.map((id, i) => [id, offers[i]]));
 
     for (const order of orders) {
       const offer: any = offersById.get(order.offerId.toString());
       if (!offer || Number(offer.amount) === 0) continue;
-      addVolume(dailyVolume, offer.exToken, Number(offer.value) * Number(order.amount) / Number(offer.amount));
+      dailyVolume.add(offer.exToken, Number(offer.value) * Number(order.amount) / Number(offer.amount));
     }
   }
 
@@ -80,7 +62,7 @@ const solSql = () => `
     )
     SELECT
         t.token_mint_address AS mint,
-        SUM(t.amount) AS amount
+        COALESCE(SUM(t.amount), 0) AS amount
     FROM tokens_solana.transfers t
     JOIN fill_txs f ON t.tx_id = f.tx_id
     WHERE t.to_owner = '${SOLANA_ESCROW}'
@@ -103,7 +85,7 @@ const fetch = async (options: FetchOptions) => {
 };
 
 const adapter: SimpleAdapter = {
-  version: 1, 
+  version: 1,
   fetch,
   adapter: config,
   dependencies: [Dependencies.DUNE],

--- a/dexs/whales-market.ts
+++ b/dexs/whales-market.ts
@@ -1,4 +1,3 @@
-import asyncRetry from "async-retry";
 import { Dependencies, FetchOptions, SimpleAdapter } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
 import { queryDuneSql } from "../helpers/dune";
@@ -40,11 +39,18 @@ const fetchEvm = async (options: FetchOptions) => {
 
   if (orders.length) {
     const offerIds = [...new Set(orders.map((o: any) => o.offerId.toString()))];
-    // multicall was crashing sometimes while testing, so we retry a few times before failing
-    const offers = await asyncRetry(
-      () => options.api.multiCall({ target, abi: OFFERS_ABI, calls: offerIds, permitFailure: true }),
-      { retries: 3, minTimeout: 2000 },
-    );
+    // a whole multicall RPC batch can fail transiently under load; retry a few
+    // times before failing the run
+    let offers: any[] = [];
+    for (let attempt = 0; ; attempt++) {
+      try {
+        offers = await options.api.multiCall({ target, abi: OFFERS_ABI, calls: offerIds, permitFailure: true });
+        break;
+      } catch (e) {
+        if (attempt >= 3) throw e;
+        await new Promise((resolve) => setTimeout(resolve, 2000 * (attempt + 1)));
+      }
+    }
     const offersById = new Map(offerIds.map((id, i) => [id, offers[i]]));
 
     for (const order of orders) {
@@ -97,7 +103,7 @@ const fetch = async (options: FetchOptions) => {
 };
 
 const adapter: SimpleAdapter = {
-  version: 1, 
+  version: 1, // Dune dependency (Solana): per guidelines, Dune adapters must be v1 so the query runs once per day
   fetch,
   adapter: config,
   dependencies: [Dependencies.DUNE],

--- a/dexs/whales-market.ts
+++ b/dexs/whales-market.ts
@@ -93,6 +93,7 @@ const adapter: SimpleAdapter = {
     Volume:
       "USD value of filled OTC orders on Whales Market pre-markets. EVM fills are valued pro-rata against the offer they fill (read from the contract); Solana fills are valued as the tokens deposited into the program escrow in the fill transaction.",
   },
+  isExpensiveAdapter: true,
 };
 
 export default adapter;

--- a/dexs/whales-market.ts
+++ b/dexs/whales-market.ts
@@ -103,7 +103,7 @@ const fetch = async (options: FetchOptions) => {
 };
 
 const adapter: SimpleAdapter = {
-  version: 1, // Dune dependency (Solana): per guidelines, Dune adapters must be v1 so the query runs once per day
+  version: 1, 
   fetch,
   adapter: config,
   dependencies: [Dependencies.DUNE],


### PR DESCRIPTION
https://defillama.com/protocol/whales-market

#5553

For volume, I currently count **only filled orders**. However, the Whales Market Dune dashboard appears to calculate volume as the sum of **order creations + order fills**, so the reported numbers don't match.

Website: https://whales.market/ | Twitter: https://twitter.com/WhalesMarket

<details><summary>Test runs</summary>

npm run test dexs whales-market 2024-03-29
solana 74.79k | ethereum 308.16k | arbitrum 6.93k | others 0 | Aggregate 389.88k

npm run test dexs whales-market 2024-04-16
solana 192.55k | ethereum 51.56k | base 8.89k | arbitrum 28.26k | bsc 1.32k | linea 291 | Aggregate 282.87k

npm run test dexs whales-market (2026-07-18)
all chains 0.00 — no fills on that day

</details>