### PR TITLE
[feat] moonwell-vaults - track curator fees on the morpho vaults

### DIFF
--- a/fees/moonwell-vaults.ts
+++ b/fees/moonwell-vaults.ts
@@ -1,0 +1,23 @@
+import { CuratorConfig, getCuratorExport } from "../helpers/curators";
+import { CHAIN } from "../helpers/chains";
+
+// Moonwell's Morpho vaults are listed explicitly rather than discovered by owner: the
+// factory records the deploying EOA as initialOwner and ownership was later moved to
+// Moonwell's governor, so owner-based discovery matches none of them. That same deployer
+// also created Relend ETH, which belongs to a different protocol and must stay out.
+const curatorConfig: CuratorConfig = {
+  breakdownFees: true,
+  vaults: {
+    [CHAIN.BASE]: {
+      morpho: [
+        '0xc1256ae5ff1cf2719d4937adb3bbccab2e00a2ca', // Moonwell Flagship USDC
+        '0xa0e430870c4604ccfc7b38ca7845b1ff653d0ff1', // Moonwell Flagship ETH
+        '0xf24608e0ccb972b0b0f4a6446a0bbf58c701a026', // Moonwell Flagship EURC
+        '0x543257ef2161176d7c8cd90ba65c2d4caef5a796', // Moonwell Frontier cbBTC
+      ],
+      start: '2024-06-10',
+    },
+  },
+}
+
+export default getCuratorExport(curatorConfig)


### PR DESCRIPTION
Moonwell Vaults is listed with `dimensions: { fees: "moonwell-vaults" }` but no adapter with that name exists, so it reports nothing while holding ~$18.3M and charging a 15% performance fee.

### Which vaults

They are MetaMorpho vaults — the TVL side already treats them that way (`projects/moonwell-vaults/index.js` calls `getMorphoVaultTvl(governor)`).

I enumerated every `CreateMetaMorpho` from the factories in `helpers/curators/configs.ts` (508 vaults across Base and Optimism), then read `owner()` on each. Four on Base are owned by the Moonwell governor `0x8b621804a7637b781e2BbD58e256a591F2dF7d51`:

| vault | name | assets | ~USD | fee() |
|---|---|---|---|---|
| `0xc1256ae5…` | Moonwell Flagship USDC | 8,142,864.61 USDC | $8,142,046 | 0.15 |
| `0xa0e43087…` | Moonwell Flagship ETH | 3,673.07 WETH | $6,866,593 | 0.15 |
| `0xf24608e0…` | Moonwell Flagship EURC | 1,070,569.58 EURC | $1,223,893 | 0.15 |
| `0x543257ef…` | Moonwell Frontier cbBTC | 31.73 cbBTC | $2,041,831 | 0.15 |

That totals **$18,274,363**, against the $18,306,332 DefiLlama currently publishes for the protocol — 0.17% apart, which is just the gap between the two reads. So this is the same vault set the TVL adapter resolves.

### Why the vaults are listed explicitly

`morphoVaultOwners` filters on `initialOwner` from the factory event, and **no vault has the governor as `initialOwner`** — all four were deployed by `0x17e7bb9fe7983947fdcf02c1e3d8e6c92c21da54` and ownership moved to the governor afterwards, which is why the TVL helper matches on the current `owner()` instead. Owner-based discovery here would match nothing.

Using that deployer as the owner instead does not work either: it created 7 vaults, and one of them (`0x70f796946ed919e4bc6cd506f8dacc45e4539771`) is **Relend ETH**, currently owned by `0x32f75c3e…`, a different protocol. Another (`0xadcb88c7…`, an older "Moonwell Flagship EURC") still sits with the deployer and holds 0 assets. So the explicit list is the only way to get exactly Moonwell's four.

### Output

```
$ npm run test fees moonwell-vaults 2026-07-18
chain | Daily fees | Daily revenue | Daily supply side revenue
base  | 1.15 k     | 172.00        | 974.00

label                                 | Daily fees | Daily supply side revenue | Daily revenue
Morpho Yields                         | 1146       |                           |
Morpho Yields Distributed To Supliers |            | 974                       |
Morpho Performance Fees               |            |                           | 172
```

Sampled across the vaults' life, the split matches the on-chain `fee()` on every day and the income statement closes exactly:

| date | fees | supplySide | revenue | revenue/fees |
|---|---|---|---|---|
| 2026-07-17 | 1,146 | 974 | 172 | 15.01% |
| 2026-06-15 | 1,383 | 1,176 | 207 | 14.97% |
| 2025-11-10 | 7,176 | 6,100 | 1,076 | 14.99% |

`start` is 2024-06-10, the block date of the first vault's creation (Base block 15620450).

### Optimism left out

There is a fifth vault, `0x3520e1a10038131a3c00bf2158835a75e929642d` ("Moonwell Flagship USDC" on Optimism), genuinely owned by the Optimism governor `0x17C9ba3fDa7EC71CcfD75f978Ef31E21927aFF3d`. I left it out because it is idle — `totalAssets()` reads **16,119.4638 USDC at the current block, one day ago and seven days ago**, byte-identical, so it earns nothing and the chain would report $0. Happy to add it in if you would rather have the chain wired up ahead of it being allocated.