### PR TITLE
[fees]Whales Market: add fee adapter for whale

### DIFF
--- a/fees/whales-market.ts
+++ b/fees/whales-market.ts
@@ -110,6 +110,7 @@ const adapter: SimpleAdapter = {
       [METRIC.TRADING_FEES]: "All pre-market fees are kept by the protocol; no on-chain split to stakers or others is observable.",
     },
   },
+  isExpensiveAdapter: true,
 };
 
 export default adapter;

--- a/fees/whales-market.ts
+++ b/fees/whales-market.ts
@@ -1,0 +1,95 @@
+import { FetchOptions, SimpleAdapter } from "../adapters/types";
+import ADDRESSES from "../helpers/coreAssets.json";
+import { config, OFFERS_ABI } from "../dexs/whales-market";
+
+// Whales Market fees (EVM) — measured, not estimated: the pre-market contract
+// emits the charged fee amount in its settle/cancel events, denominated in the
+// offer's settlement token (exToken). Fees are attributed to the day they are
+// actually paid (settlements happen at TGE, long after offers are created).
+// Solana is not covered yet: the program emits no equivalent decoded fee data.
+
+const SETTLE_FILLED_ABI = "event SettleFilled(uint256 orderId, uint256 value, uint256 fee, address doer)";
+const SETTLE_CANCELLED_ABI = "event SettleCancelled(uint256 orderId, uint256 value, uint256 fee, address doer)";
+const CANCEL_OFFER_ABI = "event CancelOffer(uint256 offerId, uint256 refundValue, uint256 refundFee, address doer)";
+const ORDERS_ABI = "function orders(uint256) view returns (uint256 offerId, uint256 amount, address seller, address buyer, uint8 status)";
+
+const addFee = (dailyFees: any, exToken: string | undefined, amount: any) => {
+  if (!exToken || !Number(amount)) return;
+  if (exToken.toLowerCase() === ADDRESSES.null) dailyFees.addGasToken(amount);
+  else dailyFees.add(exToken, amount);
+};
+
+// a whole multicall RPC batch can fail transiently under load; retry a few
+// times before failing the run
+const multiCallWithRetry = async (options: FetchOptions, params: any) => {
+  for (let attempt = 0; ; attempt++) {
+    try {
+      return await options.api.multiCall(params);
+    } catch (e) {
+      if (attempt >= 3) throw e;
+      await new Promise((resolve) => setTimeout(resolve, 2000 * (attempt + 1)));
+    }
+  }
+};
+
+const fetch = async (options: FetchOptions) => {
+  const target = config[options.chain].contract;
+  const dailyFees = options.createBalances();
+
+  const settleLogs = [
+    ...(await options.getLogs({ target, eventAbi: SETTLE_FILLED_ABI })),
+    ...(await options.getLogs({ target, eventAbi: SETTLE_CANCELLED_ABI })),
+  ];
+  const cancelLogs = await options.getLogs({ target, eventAbi: CANCEL_OFFER_ABI });
+
+  // fee amounts are denominated in the offer's exToken:
+  // settle events carry orderId -> orders(id).offerId -> offers(id).exToken;
+  // cancel events carry offerId directly
+  let offerIdByOrderId = new Map<string, string>();
+  if (settleLogs.length) {
+    const orderIds = [...new Set(settleLogs.map((log: any) => log.orderId.toString()))];
+    const orders = await multiCallWithRetry(options, { target, abi: ORDERS_ABI, calls: orderIds, permitFailure: true });
+    offerIdByOrderId = new Map(orderIds.map((id, i) => [id, orders[i]?.offerId?.toString()]));
+  }
+
+  const offerIds = [
+    ...new Set([
+      ...[...offerIdByOrderId.values()].filter(Boolean),
+      ...cancelLogs.map((log: any) => log.offerId.toString()),
+    ]),
+  ];
+  if (!offerIds.length) return { dailyFees, dailyRevenue: dailyFees };
+
+  const offers = await multiCallWithRetry(options, { target, abi: OFFERS_ABI, calls: offerIds, permitFailure: true });
+  const exTokenByOfferId = new Map(offerIds.map((id, i) => [id, offers[i]?.exToken]));
+
+  for (const log of settleLogs) addFee(dailyFees, exTokenByOfferId.get(offerIdByOrderId.get(log.orderId.toString())!), log.fee);
+  for (const log of cancelLogs) addFee(dailyFees, exTokenByOfferId.get(log.offerId.toString()), log.refundFee);
+
+  return {
+    dailyFees,
+    dailyRevenue: dailyFees,
+    // 60% of fees go to $WHALES stakers, 40% to the protocol
+    // https://docs.whales.market/tokenomics/usdwhales-staking
+    dailyHoldersRevenue: dailyFees.clone(0.6),
+    dailyProtocolRevenue: dailyFees.clone(0.4),
+  };
+};
+
+// EVM chains only (solana pending — no decoded fee events)
+const evmConfig = Object.fromEntries(Object.entries(config).filter(([, c]) => c.contract));
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  pullHourly: true,
+  fetch,
+  adapter: evmConfig,
+  methodology: {
+    Fees: "Settlement fees (SettleFilled/SettleCancelled) and offer-cancellation fees (CancelOffer) as emitted by the pre-market contracts, in the offer's settlement token.",
+    Revenue: "All fees collected by the protocol.",
+    HoldersRevenue: "60% of fees, distributed to $WHALES stakers.",
+    ProtocolRevenue: "40% of fees, retained by the protocol.",
+  },
+};
+
+export default adapter;

--- a/fees/whales-market.ts
+++ b/fees/whales-market.ts
@@ -14,28 +14,38 @@ const SOLANA_FEE_WALLET = "F2Vvt5KT33bUWnQtmGGJ4o2VW1BRXcJHucfi8ExW8JvX";
 // feeWallets: first entry is deployment, later ones come from UpdateConfig events 
 const config: Record<string, { start: string; feeWallets?: [number, string][] }> = {
   [CHAIN.SOLANA]: { start: "2023-12-13" },
-  [CHAIN.ETHEREUM]: { start: "2024-01-29", feeWallets: [[1706486400, W_914B], [1713398400 /* 2024-04-18 */, W_5876], [1758758400 /* 2025-09-25 */, W_89C8], [1758758400, W_5876]] },
-  [CHAIN.BASE]: { start: "2024-01-29", feeWallets: [[1706486400, W_914B], [1713398400 /* 2024-04-18 */, W_5876]] },
-  [CHAIN.ERA]: { start: "2024-01-29", feeWallets: [[1706486400, W_914B], [1716422400 /* 2024-05-23 */, W_5876]] },
-  [CHAIN.ARBITRUM]: { start: "2024-01-29", feeWallets: [[1706486400, W_914B], [1716422400 /* 2024-05-23 */, W_5876]] },
-  [CHAIN.BSC]: { start: "2024-01-29", feeWallets: [[1706486400, W_914B], [1711065600 /* 2024-03-22 */, W_5876], [1763942400 /* 2025-11-24 */, W_89C8], [1763942400, W_5876], [1777593600 /* 2026-05-01 */, W_89C8]] },
-  [CHAIN.OPTIMISM]: { start: "2024-01-29", feeWallets: [[1706486400, W_914B], [1762819200 /* 2025-11-11 */, W_5876]] },
-  [CHAIN.LINEA]: { start: "2024-01-29", feeWallets: [[1706486400, W_914B], [1712620800 /* 2024-04-09 */, W_5876]] },
-  [CHAIN.MODE]: { start: "2024-02-15", feeWallets: [[1707955200, W_914B], [1713484800 /* 2024-04-19 */, W_5876]] },
-  [CHAIN.SCROLL]: { start: "2024-01-29", feeWallets: [[1706486400, W_914B], [1713484800 /* 2024-04-19 */, W_5876]] },
+  [CHAIN.ETHEREUM]: { start: "2024-01-29", feeWallets: [[1706486400, W_914B], [1713431855, W_5876], [1758825539, W_89C8], [1758833423, W_5876]] },
+  [CHAIN.BASE]: { start: "2024-01-29", feeWallets: [[1706486400, W_914B], [1713416461, W_5876]] },
+  [CHAIN.ERA]: { start: "2024-01-29", feeWallets: [[1706486400, W_914B], [1716477360, W_5876]] },
+  [CHAIN.ARBITRUM]: { start: "2024-01-29", feeWallets: [[1706486400, W_914B], [1716439342, W_5876]] },
+  [CHAIN.BSC]: { start: "2024-01-29", feeWallets: [[1706486400, W_914B], [1711083578, W_5876], [1764018375, W_89C8], [1763942400, W_5876], [1777646002, W_89C8]] },
+  [CHAIN.OPTIMISM]: { start: "2024-01-29", feeWallets: [[1706486400, W_914B], [1762834185, W_5876]] },
+  [CHAIN.LINEA]: { start: "2024-01-29", feeWallets: [[1706486400, W_914B], [1712662157, W_5876]] },
+  [CHAIN.MODE]: { start: "2024-02-15", feeWallets: [[1707955200, W_914B], [1713518461, W_5876]] },
+  [CHAIN.SCROLL]: { start: "2024-01-29", feeWallets: [[1706486400, W_914B], [1713521381, W_5876]] },
   [CHAIN.TAIKO]: { start: "2024-06-01", feeWallets: [[1717200000, W_5876]] },
   [CHAIN.BERACHAIN]: { start: "2025-02-06", feeWallets: [[1738800000, W_5876]] },
-  [CHAIN.AVAX]: { start: "2024-01-29", feeWallets: [[1706486400, W_914B], [1740355200 /* 2025-02-24 */, W_5876]] },
+  [CHAIN.AVAX]: { start: "2024-01-29", feeWallets: [[1706486400, W_914B], [1740404146, W_5876]] },
   [CHAIN.HYPERLIQUID]: { start: "2025-02-18", feeWallets: [[1739836800, W_5876]] },
-  [CHAIN.ABSTRACT]: { start: "2025-01-27", feeWallets: [[1737936000, W_914B], [1740441600 /* 2025-02-25 */, W_5876]] },
+  [CHAIN.ABSTRACT]: { start: "2025-01-27", feeWallets: [[1737936000, W_914B], [1740472576, W_5876]] },
 };
 
 const fetchEvm = async (options: FetchOptions) => {
   const timeline = config[options.chain].feeWallets!;
-  // wallet active at a given time = last timeline entry on or before it;
-  // checking both window edges covers rotation days (both wallets that day)
-  const activeAt = (ts: number) => [...timeline].reverse().find(([from]) => from <= ts)?.[1] ?? timeline[0][1];
-  const targets = [...new Set([activeAt(options.startTimestamp), activeAt(options.endTimestamp)])];
+  const targets = [
+    ...new Set(
+      timeline
+        .filter(([from], i) => {
+          const nextFrom = timeline[i + 1]?.[0];
+
+          return nextFrom === undefined
+            ? from <= options.endTimestamp
+            : from <= options.endTimestamp &&
+              nextFrom >= options.startTimestamp;
+        })
+        .map(([, wallet]) => wallet)
+    ),
+];
 
   const received = await addTokensReceived({ options, targets });
   const dailyFees = options.createBalances();

--- a/fees/whales-market.ts
+++ b/fees/whales-market.ts
@@ -18,7 +18,7 @@ const config: Record<string, { start: string; feeWallets?: [number, string][] }>
   [CHAIN.BASE]: { start: "2024-01-29", feeWallets: [[1706486400, W_914B], [1713416461, W_5876]] },
   [CHAIN.ERA]: { start: "2024-01-29", feeWallets: [[1706486400, W_914B], [1716477360, W_5876]] },
   [CHAIN.ARBITRUM]: { start: "2024-01-29", feeWallets: [[1706486400, W_914B], [1716439342, W_5876]] },
-  [CHAIN.BSC]: { start: "2024-01-29", feeWallets: [[1706486400, W_914B], [1711083578, W_5876], [1764018375, W_89C8], [1777646002, W_89C8]] },
+  [CHAIN.BSC]: { start: "2024-01-29", feeWallets: [[1706486400, W_914B], [1711083578, W_5876], [1764018375, W_89C8], [1764020778, W_5876],[1777646002, W_89C8]] },
   [CHAIN.OPTIMISM]: { start: "2024-01-29", feeWallets: [[1706486400, W_914B], [1762834185, W_5876]] },
   [CHAIN.LINEA]: { start: "2024-01-29", feeWallets: [[1706486400, W_914B], [1712662157, W_5876]] },
   [CHAIN.MODE]: { start: "2024-02-15", feeWallets: [[1707955200, W_914B], [1713518461, W_5876]] },

--- a/fees/whales-market.ts
+++ b/fees/whales-market.ts
@@ -18,7 +18,7 @@ const config: Record<string, { start: string; feeWallets?: [number, string][] }>
   [CHAIN.BASE]: { start: "2024-01-29", feeWallets: [[1706486400, W_914B], [1713416461, W_5876]] },
   [CHAIN.ERA]: { start: "2024-01-29", feeWallets: [[1706486400, W_914B], [1716477360, W_5876]] },
   [CHAIN.ARBITRUM]: { start: "2024-01-29", feeWallets: [[1706486400, W_914B], [1716439342, W_5876]] },
-  [CHAIN.BSC]: { start: "2024-01-29", feeWallets: [[1706486400, W_914B], [1711083578, W_5876], [1764018375, W_89C8], [1763942400, W_5876], [1777646002, W_89C8]] },
+  [CHAIN.BSC]: { start: "2024-01-29", feeWallets: [[1706486400, W_914B], [1711083578, W_5876], [1764018375, W_89C8], [1777646002, W_89C8]] },
   [CHAIN.OPTIMISM]: { start: "2024-01-29", feeWallets: [[1706486400, W_914B], [1762834185, W_5876]] },
   [CHAIN.LINEA]: { start: "2024-01-29", feeWallets: [[1706486400, W_914B], [1712662157, W_5876]] },
   [CHAIN.MODE]: { start: "2024-02-15", feeWallets: [[1707955200, W_914B], [1713518461, W_5876]] },

--- a/fees/whales-market.ts
+++ b/fees/whales-market.ts
@@ -1,94 +1,104 @@
-import { FetchOptions, SimpleAdapter } from "../adapters/types";
-import ADDRESSES from "../helpers/coreAssets.json";
-import { config, OFFERS_ABI } from "../dexs/whales-market";
+import { Dependencies, FetchOptions, SimpleAdapter } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+import { METRIC } from "../helpers/metrics";
+import { addTokensReceived } from "../helpers/token";
+import { queryDuneSql } from "../helpers/dune";
 
-// Whales Market fees (EVM) — measured, not estimated: the pre-market contract
-// emits the charged fee amount in its settle/cancel events, denominated in the
-// offer's settlement token (exToken). Fees are attributed to the day they are
-// actually paid (settlements happen at TGE, long after offers are created).
-// Solana is not covered yet: the program emits no equivalent decoded fee data.
+const W_914B = "0x914B776bf3C8915FD47Fd31B960F5F3990AA35B3";
+const W_5876 = "0x5876b8367762b15411b4608d188808010b33c395";
+const W_89C8 = "0x89C8b951A2B216fd185034C6D7ca19d40EF5C7DB";
 
-const SETTLE_FILLED_ABI = "event SettleFilled(uint256 orderId, uint256 value, uint256 fee, address doer)";
-const SETTLE_CANCELLED_ABI = "event SettleCancelled(uint256 orderId, uint256 value, uint256 fee, address doer)";
-const CANCEL_OFFER_ABI = "event CancelOffer(uint256 offerId, uint256 refundValue, uint256 refundFee, address doer)";
-const ORDERS_ABI = "function orders(uint256) view returns (uint256 offerId, uint256 amount, address seller, address buyer, uint8 status)";
+const SOLANA_PROGRAM = "stPdYNaJNsV3ytS9Xtx4GXXXRcVqVS6x66ZFa26K39S";
+const SOLANA_FEE_WALLET = "F2Vvt5KT33bUWnQtmGGJ4o2VW1BRXcJHucfi8ExW8JvX";
 
-const addFee = (dailyFees: any, exToken: string | undefined, amount: any) => {
-  if (!exToken || !Number(amount)) return;
-  if (exToken.toLowerCase() === ADDRESSES.null) dailyFees.addGasToken(amount);
-  else dailyFees.add(exToken, amount);
+// feeWallets: first entry is deployment, later ones come from UpdateConfig events 
+const config: Record<string, { start: string; feeWallets?: [number, string][] }> = {
+  [CHAIN.SOLANA]: { start: "2023-12-13" },
+  [CHAIN.ETHEREUM]: { start: "2024-01-29", feeWallets: [[1706486400, W_914B], [1713398400 /* 2024-04-18 */, W_5876], [1758758400 /* 2025-09-25 */, W_89C8], [1758758400, W_5876]] },
+  [CHAIN.BASE]: { start: "2024-01-29", feeWallets: [[1706486400, W_914B], [1713398400 /* 2024-04-18 */, W_5876]] },
+  [CHAIN.ERA]: { start: "2024-01-29", feeWallets: [[1706486400, W_914B], [1716422400 /* 2024-05-23 */, W_5876]] },
+  [CHAIN.ARBITRUM]: { start: "2024-01-29", feeWallets: [[1706486400, W_914B], [1716422400 /* 2024-05-23 */, W_5876]] },
+  [CHAIN.BSC]: { start: "2024-01-29", feeWallets: [[1706486400, W_914B], [1711065600 /* 2024-03-22 */, W_5876], [1763942400 /* 2025-11-24 */, W_89C8], [1763942400, W_5876], [1777593600 /* 2026-05-01 */, W_89C8]] },
+  [CHAIN.OPTIMISM]: { start: "2024-01-29", feeWallets: [[1706486400, W_914B], [1762819200 /* 2025-11-11 */, W_5876]] },
+  [CHAIN.LINEA]: { start: "2024-01-29", feeWallets: [[1706486400, W_914B], [1712620800 /* 2024-04-09 */, W_5876]] },
+  [CHAIN.MODE]: { start: "2024-02-15", feeWallets: [[1707955200, W_914B], [1713484800 /* 2024-04-19 */, W_5876]] },
+  [CHAIN.SCROLL]: { start: "2024-01-29", feeWallets: [[1706486400, W_914B], [1713484800 /* 2024-04-19 */, W_5876]] },
+  [CHAIN.TAIKO]: { start: "2024-06-01", feeWallets: [[1717200000, W_5876]] },
+  [CHAIN.BERACHAIN]: { start: "2025-02-06", feeWallets: [[1738800000, W_5876]] },
+  [CHAIN.AVAX]: { start: "2024-01-29", feeWallets: [[1706486400, W_914B], [1740355200 /* 2025-02-24 */, W_5876]] },
+  [CHAIN.HYPERLIQUID]: { start: "2025-02-18", feeWallets: [[1739836800, W_5876]] },
+  [CHAIN.ABSTRACT]: { start: "2025-01-27", feeWallets: [[1737936000, W_914B], [1740441600 /* 2025-02-25 */, W_5876]] },
 };
 
-// a whole multicall RPC batch can fail transiently under load; retry a few
-// times before failing the run
-const multiCallWithRetry = async (options: FetchOptions, params: any) => {
-  for (let attempt = 0; ; attempt++) {
-    try {
-      return await options.api.multiCall(params);
-    } catch (e) {
-      if (attempt >= 3) throw e;
-      await new Promise((resolve) => setTimeout(resolve, 2000 * (attempt + 1)));
-    }
+const fetchEvm = async (options: FetchOptions) => {
+  const timeline = config[options.chain].feeWallets!;
+  // wallet active at a given time = last timeline entry on or before it;
+  // checking both window edges covers rotation days (both wallets that day)
+  const activeAt = (ts: number) => [...timeline].reverse().find(([from]) => from <= ts)?.[1] ?? timeline[0][1];
+  const targets = [...new Set([activeAt(options.startTimestamp), activeAt(options.endTimestamp)])];
+
+  const received = await addTokensReceived({ options, targets });
+  const dailyFees = options.createBalances();
+  dailyFees.addBalances(received, METRIC.TRADING_FEES);
+  return dailyFees;
+};
+
+const solSql = () => `
+    WITH whales_txs AS (
+        SELECT DISTINCT tx_id
+        FROM solana.instruction_calls
+        WHERE tx_success
+          AND executing_account = '${SOLANA_PROGRAM}'
+          AND is_inner = false
+          AND TIME_RANGE
+    )
+    SELECT
+        t.token_mint_address AS mint,
+        SUM(t.amount) AS amount
+    FROM tokens_solana.transfers t
+    JOIN whales_txs w ON t.tx_id = w.tx_id
+    WHERE t.to_owner = '${SOLANA_FEE_WALLET}'
+      AND TIME_RANGE
+    GROUP BY t.token_mint_address
+`;
+
+const fetchSolana = async (options: FetchOptions) => {
+  const dailyFees = options.createBalances();
+  const rows = await queryDuneSql(options, solSql());
+  for (const row of rows || []) {
+    if (row.mint && row.amount) dailyFees.add(row.mint, row.amount, METRIC.TRADING_FEES);
   }
+  return dailyFees;
 };
 
 const fetch = async (options: FetchOptions) => {
-  const target = config[options.chain].contract;
-  const dailyFees = options.createBalances();
+  const dailyFees = options.chain === CHAIN.SOLANA ? await fetchSolana(options) : await fetchEvm(options);
 
-  const settleLogs = [
-    ...(await options.getLogs({ target, eventAbi: SETTLE_FILLED_ABI })),
-    ...(await options.getLogs({ target, eventAbi: SETTLE_CANCELLED_ABI })),
-  ];
-  const cancelLogs = await options.getLogs({ target, eventAbi: CANCEL_OFFER_ABI });
-
-  // fee amounts are denominated in the offer's exToken:
-  // settle events carry orderId -> orders(id).offerId -> offers(id).exToken;
-  // cancel events carry offerId directly
-  let offerIdByOrderId = new Map<string, string>();
-  if (settleLogs.length) {
-    const orderIds = [...new Set(settleLogs.map((log: any) => log.orderId.toString()))];
-    const orders = await multiCallWithRetry(options, { target, abi: ORDERS_ABI, calls: orderIds, permitFailure: true });
-    offerIdByOrderId = new Map(orderIds.map((id, i) => [id, orders[i]?.offerId?.toString()]));
-  }
-
-  const offerIds = [
-    ...new Set([
-      ...[...offerIdByOrderId.values()].filter(Boolean),
-      ...cancelLogs.map((log: any) => log.offerId.toString()),
-    ]),
-  ];
-  if (!offerIds.length) return { dailyFees, dailyRevenue: dailyFees };
-
-  const offers = await multiCallWithRetry(options, { target, abi: OFFERS_ABI, calls: offerIds, permitFailure: true });
-  const exTokenByOfferId = new Map(offerIds.map((id, i) => [id, offers[i]?.exToken]));
-
-  for (const log of settleLogs) addFee(dailyFees, exTokenByOfferId.get(offerIdByOrderId.get(log.orderId.toString())!), log.fee);
-  for (const log of cancelLogs) addFee(dailyFees, exTokenByOfferId.get(log.offerId.toString()), log.refundFee);
-
+  // no holders/protocol split: current docs describe staker rewards only as
+  // open-market $WHALES buybacks with no stated share of fees
+  // (https://docs.whales.market/staking-mechanism)
   return {
     dailyFees,
     dailyRevenue: dailyFees,
-    // 60% of fees go to $WHALES stakers, 40% to the protocol
-    // https://docs.whales.market/tokenomics/usdwhales-staking
-    dailyHoldersRevenue: dailyFees.clone(0.6),
-    dailyProtocolRevenue: dailyFees.clone(0.4),
   };
 };
 
-// EVM chains only (solana pending — no decoded fee events)
-const evmConfig = Object.fromEntries(Object.entries(config).filter(([, c]) => c.contract));
-
 const adapter: SimpleAdapter = {
-  version: 2,
-  pullHourly: true,
+  version: 1,
   fetch,
-  adapter: evmConfig,
+  adapter: config,
+  dependencies: [Dependencies.DUNE],
   methodology: {
-    Fees: "Settlement fees (SettleFilled/SettleCancelled) and offer-cancellation fees (CancelOffer) as emitted by the pre-market contracts, in the offer's settlement token.",
-    Revenue: "All fees collected by the protocol.",
-    HoldersRevenue: "60% of fees, distributed to $WHALES stakers.",
-    ProtocolRevenue: "40% of fees, retained by the protocol.",
+    Fees: "All tokens received by the protocol's fee wallets (verified via the pre-market contracts' config/UpdateConfig history on EVM and the program config account on Solana): settlement fees from both sides and cancellation fees.",
+    Revenue: "All fees collected by the protocol. No holders/protocol split is reported: current docs describe staker rewards only as open-market $WHALES buybacks with no stated share of fees. Affiliate/referral shares (up to 40% of a referred trade's fee per docs) are not separately identifiable on-chain; observed settlements send the full fee to the fee wallets, which are accumulate-only.",
+  },
+  breakdownMethodology: {
+    Fees: {
+      [METRIC.TRADING_FEES]: "Pre-market settlement fees (2.5% from each side, per contract config) and cancellation/close fees (0.5%), received by the protocol fee wallets.",
+    },
+    Revenue: {
+      [METRIC.TRADING_FEES]: "All pre-market fees are kept by the protocol; no on-chain split to stakers or others is observable.",
+    },
   },
 };
 


### PR DESCRIPTION
Resolves #5553 

Adds fee tracking for Whales Market using the configured fee collector address.
These are readable using the config() method in EVM chains 

Verified fee wallet rotations from `UpdateConfig` events:

- Ethereum:
  - https://etherscan.io/tx/0x67cccb562cce8e80c5929769ae29e9dd6e3adb41ebc174a1e8c16cdb884b13ae#eventlog
  - https://etherscan.io/tx/0x98316e18de7d93ed6b12d98944765098fd649661650009a05ec9c39dd327821a#eventlog
  - https://etherscan.io/tx/0x541af2ae251bb93507f141d8d9c67d38d800e7e0e24b331cee778686c8b91e98#eventlog
- Base:
  - https://basescan.org/tx/0x5316e9ec15451ef211941f563968bd71215794a8753baad99f6de016f1d6c9d3#eventlog
- zkSync Era:
  - https://explorer.zksync.io/tx/0x2905cac9ea4c4916c6c1e7db0f8b97cd9de99e5ee6b7766fd429976574c98459
- Arbitrum:
  - https://arbiscan.io/tx/0xc66d4a66f9a54a873d30364acf1a7c2d0be92a36d7b8ed1992c451398883efca#eventlog
- BNB Chain:
  - https://bscscan.com/tx/0x172fdb5cd7e25ac9d2273ffee46c9b6469df1bb818b3610997f0188ede6aa391#eventlog
  - https://bscscan.com/tx/0xedb3c23d3efbec713098b8b39160adc8c563b6f485e6aa3ea416ebd5fb1a32b0#eventlog
  - https://bscscan.com/tx/0xed8b352c00a1ca70c1f91c24b3e8a60031e6f3812e397b355b2cb7837b3d4207#eventlog
  - https://bscscan.com/tx/0x74c9e93de68d461f844712e560b95c61b7fb7e0aea3d9c762a5058ab8dacd442#eventlog
- Optimism:
  - https://optimistic.etherscan.io/tx/0xa01d3fa2a1c3bbe4d6ca59b392a82f82680a7a4a1c9134a85c93011ec08370d5#eventlog
- Linea:
  - https://lineascan.build/tx/0x23759faf53b4a01fdd61fc3f602e37b10faeb10431816a1fa7d251bcb508eacb#eventlog
- Mode:
  - https://explorer.mode.network/tx/0x74ac8e6dbbb771eb58aa42d5bfa72956f3e82e0af3ac1d2e289fb5655bd9ebb1
- Scroll:
  - https://scrollscan.com/tx/0x10e3db1231d7b557d42961789587cea60a0f2ad3e2539c5f117439c4fba2637f#eventlog
- Avalanche:
  - https://snowtrace.io/tx/0x4f4cf8ea5e243e0155e6e469a27d9d35baf744a1b3c64b550ae9a0f800ce2866
- Abstract:
  - https://abscan.org/tx/0x9d95adb4ed02ff53164b5fc5bdae878da63b95016c5d4dac5742a81b4c1c25bc
  
  
<details>
<summary><strong>Test Results</strong></summary>

```text
pnpm test fees whales-market 2025-10-10

chain       | Daily fees | Daily revenue | Start Time
---         | ---        | ---           | ---
solana      | 8.53       | 8.53          | 13/12/2023
ethereum    | 120.00     | 120.00        | 29/1/2024
base        | 68.00      | 68.00         | 29/1/2024
era         | 0.00       | 0.00          | 29/1/2024
arbitrum    | 0.00       | 0.00          | 29/1/2024
bsc         | 107.00     | 107.00        | 29/1/2024
optimism    | 0.00       | 0.00          | 29/1/2024
linea       | 0.00       | 0.00          | 29/1/2024
mode        | 0.00       | 0.00          | 15/2/2024
scroll      | 0.00       | 0.00          | 29/1/2024
taiko       | 0.00       | 0.00          | 1/6/2024
berachain   | 0.00       | 0.00          | 6/2/2025
avax        | 0.00       | 0.00          | 29/1/2024
hyperliquid | 0.20       | 0.20          | 18/2/2025
abstract    | 0.00       | 0.00          | 27/1/2025
Aggregate   | 303.73     | 303.73        |
```

### Fees Breakdown

| Label | Daily fees | Daily revenue |
|-------|-----------:|--------------:|
| Trading Fees | 303.73 | 303.73 |

</details>
  