### PR TITLE
pancakeswap-v2: fix 100x overstated Aptos fees

### DIFF
--- a/dexs/pancakeswap-v2.ts
+++ b/dexs/pancakeswap-v2.ts
@@ -393,20 +393,9 @@ const fetchAptosVolume: FetchV2 = async ({ fromTimestamp, toTimestamp, createBal
   const dailyVolume = createBalances();
   dailyVolume.addUSDValue(await balances.getUSDString());
   
-  const dailyFees = dailyVolume.clone(FEE_CONFIG.Fees);
-  const dailyRevenue = dailyVolume.clone(FEE_CONFIG.Revenue);
-  const dailyProtocolRevenue = dailyVolume.clone(FEE_CONFIG.ProtocolRevenue);
-  const dailySupplySideRevenue = dailyVolume.clone(FEE_CONFIG.SupplySideRevenue);
-  const dailyHoldersRevenue = dailyVolume.clone(FEE_CONFIG.HoldersRevenue);
-
   return {
     dailyVolume,
-    dailyFees,
-    dailyUserFees: dailyFees,
-    dailyRevenue,
-    dailyProtocolRevenue,
-    dailySupplySideRevenue,
-    dailyHoldersRevenue,
+    ...calculateFeesBalances(dailyVolume),
   }
 }
 


### PR DESCRIPTION
`FEE_CONFIG` holds percentages (`Fees: 0.25` meaning 0.25%). Every chain goes through `calculateFeesBalances()`, which divides by 100. The Aptos branch applied the same constants raw, so it books **25% of Aptos volume as fees instead of 0.25%** — a 100x overstatement of fees, user fees, revenue, protocol revenue, supply-side revenue and holders revenue on that chain.

The adapter's own methodology states the intended rate: *"User pays 0.25% fees on each swap."*

### Confirmation from production data

Implied fee rate (fees ÷ volume) per chain, from `api.llama.fi/summary`:

| chain | days | implied rate | days above 5% |
|---|---|---|---|
| Ethereum | 1,388 | 0.2476% | 0 |
| BSC | 1,909 | 0.2471% | 0 |
| **Aptos** | 40 (with volume) | **25.08% (median)** | **40 / 40** |

The Aptos series crosses over on **2026-06-07** and every day since sits ~100x above the other chains.

### Why it went unnoticed

`Revenue (0.08) + SupplySideRevenue (0.17) = Fees (0.25)` holds identically before and after, because every component is scaled by the same factor — so the usual income-statement check can't surface it. Aptos is also ~0.13% of PancakeSwap AMM volume, so the blended protocol-level rate only moves from 0.2500% to 0.2670%, which reads as noise unless you split by chain.

### Verification

Feeding an identical volume through both code paths:

```
volume = $10,000 (identical input to both paths)

OLD aptos path                    fees=$2500   rev=$800   ss=$1700   implied 25.0000%
shared helper (all other chains)  fees=$25     rev=$8     ss=$17     implied  0.2500%

ratio = 100.00x
```

Running the adapter against Aptos with the change applied returns a 0.2500% fee/volume ratio, matching the other chains, with `protocolRevenue + holdersRevenue = revenue` and `revenue + supplySideRevenue = fees` both intact. `tsc --project tsconfig.json` exits 0.

### Fix

Reuses the file's existing `calculateFeesBalances()` helper rather than adding `/100` in five places, so the Aptos path can't drift from the others again. Net 1 insertion, 12 deletions, one file.

Impact: roughly $285k of phantom fees over the last 30 days, ~$464k since the crossover.
