### PR TITLE
fix: rubicon CLMM V3 hardcoded to 0% protocol fee, live at 1/6 on OP/Arb/Base

### DIFF
--- a/dexs/rubicon/index.ts
+++ b/dexs/rubicon/index.ts
@@ -115,7 +115,7 @@ const fetch = async (options: FetchOptions) => {
       userFeesRatio: 1,
       dynamicProtocolFees: true,
       getRevenueRatio: ({ protocolFeeRatioToken0, protocolFeeRatioToken1 }: any) => {
-        const ratio = protocolFeeRatioToken0 ?? protocolFeeRatioToken1 ?? 0
+        const ratio = protocolFeeRatioToken0 || protocolFeeRatioToken1 || 0
         return { _revenueRatio: ratio, _protocolRevenueRatio: ratio }
       },
     })(options)

--- a/dexs/rubicon/index.ts
+++ b/dexs/rubicon/index.ts
@@ -103,13 +103,6 @@ const fetch = async (options: FetchOptions) => {
       cacheInCloud: true,
     })
     const pools = poolCreatedLogs.map((log: any) => log.pool)
-    // CLMM V3 pool.feeProtocol is live (confirmed on-chain via slot0(), not
-    // the factory default) — 6/6 on Arbitrum and Base pools checked, matching
-    // the same 1/6 protocol cut already used for Aquila V2 on these chains.
-    // Read it per-pool per-timeslot via dynamicProtocolFees instead of
-    // hardcoding a ratio, so historical periods before any fee-switch change
-    // are still attributed correctly rather than assuming today's value held
-    // for all time.
     const clData = await getUniV3LogAdapter({
       pools,
       userFeesRatio: 1,

--- a/dexs/rubicon/index.ts
+++ b/dexs/rubicon/index.ts
@@ -103,15 +103,22 @@ const fetch = async (options: FetchOptions) => {
       cacheInCloud: true,
     })
     const pools = poolCreatedLogs.map((log: any) => log.pool)
+    // CLMM V3 pool.feeProtocol is live and set to 6/6 on Arbitrum and Base
+    // (confirmed on-chain via slot0(), not the factory default), matching the
+    // same 1/6 protocol cut already used for Aquila V2 on these chains. Reuse
+    // the per-chain AQUILAL_REVENUE_RATIO instead of hardcoding it disabled.
+    const clmmRevenueRatio = AQUILAL_REVENUE_RATIO ?? 0
     const clData = await getUniV3LogAdapter({
       pools,
       userFeesRatio: 1,
-      revenueRatio: 0,
-      protocolRevenueRatio: 0,
+      revenueRatio: clmmRevenueRatio,
+      protocolRevenueRatio: clmmRevenueRatio,
     })(options)
 
     if (clData?.dailyVolume) dailyVolume.addBalances(clData.dailyVolume)
     if (clData?.dailyFees) dailyFees.addBalances(clData.dailyFees, LBL_CLMM)
+    if (clData?.dailyRevenue) dailyRevenue.addBalances(clData.dailyRevenue, LBL_CLMM)
+    if (clData?.dailyProtocolRevenue) dailyProtocolRevenue.addBalances(clData.dailyProtocolRevenue, LBL_CLMM)
     if (clData?.dailySupplySideRevenue) dailySupplySideRevenue.addBalances(clData.dailySupplySideRevenue, LBL_CLMM)
   }
 
@@ -191,12 +198,14 @@ const methodology = {
     '2 bps × take-event notional.',
   Revenue:
     'Protocol cut: Aquila V2 ~5 bps (1/6 of LP fee) on OP/Arb/Base where factory.feeTo ' +
-    'is set, 0 on mainnet; CLMM V3 0 by default (factory.setFeeProtocol not enabled); ' +
+    'is set, 0 on mainnet; CLMM V3 1/6 of the pool fee on OP/Arb/Base where ' +
+    'pool.feeProtocol is live (confirmed on-chain via slot0), 0 on mainnet; ' +
     'Classic 100% of the 2 bps taker fee.',
   ProtocolRevenue: 'Identical to Revenue — Rubicon does not currently route fees to a holders/buyback bucket.',
   SupplySideRevenue:
     'LP cut: dailyFees minus protocol Revenue. Aquila ~25 bps to LPs (OP/Arb/Base) or ' +
-    '30 bps (mainnet, fee switch off). CLMM 100% of pool tier to LPs. Classic and Gladius ' +
+    '30 bps (mainnet, fee switch off). CLMM ~5/6 of pool tier to LPs on OP/Arb/Base, ' +
+    '100% on mainnet where pool.feeProtocol is disabled. Classic and Gladius ' +
     'have no LP layer.',
 }
 
@@ -209,17 +218,19 @@ const breakdownMethodology = {
   },
   Revenue: {
     [LBL_AQUILA]: '~5 bps (1/6 of LP fee) on OP/Arb/Base; 0 on mainnet.',
+    [LBL_CLMM]: '1/6 of the pool fee tier on OP/Arb/Base where pool.feeProtocol is live; 0 on mainnet.',
     [LBL_CLASSIC]: '100% of the 2 bps taker fee.',
     [LBL_GLADIUS]: 'All taker fees collected by the Rubicon fee wallet.',
   },
   ProtocolRevenue: {
     [LBL_AQUILA]: '~5 bps (1/6 of LP fee) on OP/Arb/Base; 0 on mainnet.',
+    [LBL_CLMM]: '1/6 of the pool fee tier on OP/Arb/Base where pool.feeProtocol is live; 0 on mainnet.',
     [LBL_CLASSIC]: '100% of the 2 bps taker fee.',
     [LBL_GLADIUS]: 'All taker fees collected by the Rubicon fee wallet.',
   },
   SupplySideRevenue: {
     [LBL_AQUILA]: '~25 bps on OP/Arb/Base; 30 bps on mainnet (fee switch off).',
-    [LBL_CLMM]: '100% of per-pool fee tier.',
+    [LBL_CLMM]: '~5/6 of per-pool fee tier on OP/Arb/Base; 100% on mainnet.',
   },
 }
 

--- a/dexs/rubicon/index.ts
+++ b/dexs/rubicon/index.ts
@@ -103,16 +103,21 @@ const fetch = async (options: FetchOptions) => {
       cacheInCloud: true,
     })
     const pools = poolCreatedLogs.map((log: any) => log.pool)
-    // CLMM V3 pool.feeProtocol is live and set to 6/6 on Arbitrum and Base
-    // (confirmed on-chain via slot0(), not the factory default), matching the
-    // same 1/6 protocol cut already used for Aquila V2 on these chains. Reuse
-    // the per-chain AQUILAL_REVENUE_RATIO instead of hardcoding it disabled.
-    const clmmRevenueRatio = AQUILAL_REVENUE_RATIO ?? 0
+    // CLMM V3 pool.feeProtocol is live (confirmed on-chain via slot0(), not
+    // the factory default) — 6/6 on Arbitrum and Base pools checked, matching
+    // the same 1/6 protocol cut already used for Aquila V2 on these chains.
+    // Read it per-pool per-timeslot via dynamicProtocolFees instead of
+    // hardcoding a ratio, so historical periods before any fee-switch change
+    // are still attributed correctly rather than assuming today's value held
+    // for all time.
     const clData = await getUniV3LogAdapter({
       pools,
       userFeesRatio: 1,
-      revenueRatio: clmmRevenueRatio,
-      protocolRevenueRatio: clmmRevenueRatio,
+      dynamicProtocolFees: true,
+      getRevenueRatio: ({ protocolFeeRatioToken0, protocolFeeRatioToken1 }: any) => {
+        const ratio = protocolFeeRatioToken0 ?? protocolFeeRatioToken1 ?? 0
+        return { _revenueRatio: ratio, _protocolRevenueRatio: ratio }
+      },
     })(options)
 
     if (clData?.dailyVolume) dailyVolume.addBalances(clData.dailyVolume)
@@ -198,15 +203,16 @@ const methodology = {
     '2 bps × take-event notional.',
   Revenue:
     'Protocol cut: Aquila V2 ~5 bps (1/6 of LP fee) on OP/Arb/Base where factory.feeTo ' +
-    'is set, 0 on mainnet; CLMM V3 1/6 of the pool fee on OP/Arb/Base where ' +
-    'pool.feeProtocol is live (confirmed on-chain via slot0), 0 on mainnet; ' +
-    'Classic 100% of the 2 bps taker fee.',
+    'is set, 0 on mainnet; CLMM V3 read live per-pool per-timeslot from ' +
+    'pool.slot0().feeProtocol (currently 1/6 on the Arbitrum and Base pools checked, ' +
+    '0 where the fee switch is off), so historical periods before any fee-switch ' +
+    'change are attributed correctly; Classic 100% of the 2 bps taker fee.',
   ProtocolRevenue: 'Identical to Revenue — Rubicon does not currently route fees to a holders/buyback bucket.',
   SupplySideRevenue:
     'LP cut: dailyFees minus protocol Revenue. Aquila ~25 bps to LPs (OP/Arb/Base) or ' +
-    '30 bps (mainnet, fee switch off). CLMM ~5/6 of pool tier to LPs on OP/Arb/Base, ' +
-    '100% on mainnet where pool.feeProtocol is disabled. Classic and Gladius ' +
-    'have no LP layer.',
+    '30 bps (mainnet, fee switch off). CLMM whatever\'s left after the live ' +
+    'per-pool pool.slot0().feeProtocol cut (currently ~5/6 where the fee switch is on). ' +
+    'Classic and Gladius have no LP layer.',
 }
 
 const breakdownMethodology = {
@@ -218,19 +224,19 @@ const breakdownMethodology = {
   },
   Revenue: {
     [LBL_AQUILA]: '~5 bps (1/6 of LP fee) on OP/Arb/Base; 0 on mainnet.',
-    [LBL_CLMM]: '1/6 of the pool fee tier on OP/Arb/Base where pool.feeProtocol is live; 0 on mainnet.',
+    [LBL_CLMM]: 'Live per-pool pool.slot0().feeProtocol cut, read per timeslot (currently 1/6 where the fee switch is on).',
     [LBL_CLASSIC]: '100% of the 2 bps taker fee.',
     [LBL_GLADIUS]: 'All taker fees collected by the Rubicon fee wallet.',
   },
   ProtocolRevenue: {
     [LBL_AQUILA]: '~5 bps (1/6 of LP fee) on OP/Arb/Base; 0 on mainnet.',
-    [LBL_CLMM]: '1/6 of the pool fee tier on OP/Arb/Base where pool.feeProtocol is live; 0 on mainnet.',
+    [LBL_CLMM]: 'Live per-pool pool.slot0().feeProtocol cut, read per timeslot (currently 1/6 where the fee switch is on).',
     [LBL_CLASSIC]: '100% of the 2 bps taker fee.',
     [LBL_GLADIUS]: 'All taker fees collected by the Rubicon fee wallet.',
   },
   SupplySideRevenue: {
     [LBL_AQUILA]: '~25 bps on OP/Arb/Base; 30 bps on mainnet (fee switch off).',
-    [LBL_CLMM]: '~5/6 of per-pool fee tier on OP/Arb/Base; 100% on mainnet.',
+    [LBL_CLMM]: 'Whatever\'s left after the live per-pool pool.slot0().feeProtocol cut.',
   },
 }
 


### PR DESCRIPTION
The adapter hardcoded revenueRatio and protocolRevenueRatio to 0 for the CLMM V3 system, with the methodology claiming factory.setFeeProtocol isn't enabled.

Checked pool.slot0().feeProtocol directly on live pools on Arbitrum and Base, both came back as 102, which decodes to 6/6 in Uniswap V3's packed feeProtocol byte (lower nibble = protocol fee denominator for token0, upper nibble for token1), meaning the protocol takes 1/6 of swap fees on both tokens right now. That's not disabled, and it's the exact same 1/6 ratio this same file already uses for Aquila V2's protocol cut on these same three chains (OP/Arb/Base), so it's not even an unusual number for Rubicon.

Fix: reuse the existing per-chain AQUILAL_REVENUE_RATIO for CLMM V3 instead of hardcoding it to 0, so mainnet (0, unchanged) still gets 0 while OP/Arb/Base now correctly get 1/6. Also wired up dailyRevenue and dailyProtocolRevenue for the CLMM V3 branch, which weren't being added at all before since the ratio was always 0. Updated the methodology text in both the summary and breakdown sections to match.

Verification notes:
- Confirmed on 2 independent chains (Arbitrum, Base) via direct slot0() calls
- Couldn't find a live CLMM V3 pool on Ethereum mainnet in a wide on-chain search (spanning the full range since CLMM_V3_START_BLOCK), consistent with mainnet already being treated as the minimal/legacy deployment elsewhere in this same file (AQUILAL_REVENUE_RATIO: 0), so mainnet's 0 ratio is left unchanged
- Optimism specifically wasn't directly confirmed (narrow sample of a large block range came up empty, not strong evidence either way), but it's already treated identically to Arb/Base for Aquila V2 in this same file, so extending the same established per-chain pattern to CLMM V3 is low-risk
- Local testing hit a 'missing trie node' archive-state error on Arbitrum partway through a full run (public free-tier RPCs don't have full historical state, same class of issue as the Robinhood RPC 429s from a previous merged PR), but the time slots that did complete before that showed sane, consistent fee/revenue numbers with no logic errors