### PR TITLE
polymarket: migrate active/new users from Allium to Dune

### DIFF
--- a/active-users/polymarket.ts
+++ b/active-users/polymarket.ts
@@ -12,28 +12,18 @@ const contractAddresses = [
 
 const fetch = async (options: FetchOptions) => {
     const contractAddressList = contractAddresses.map(a => a.toLowerCase()).join(', ')
+    const window = `evt_block_time >= from_unixtime(${options.startTimestamp}) AND evt_block_time < from_unixtime(${options.endTimestamp})`
     const query = `
-    WITH trades_data AS (
+    WITH fills AS (
+        SELECT maker, taker FROM polymarket_v2_polygon.ctfexchange_evt_orderfilled WHERE ${window}
+        UNION ALL
+        SELECT maker, taker FROM polymarket_polygon.NegRiskCtfExchange_evt_OrderFilled WHERE ${window}
+        UNION ALL
+        SELECT maker, taker FROM polymarket_polygon.CTFExchange_evt_OrderFilled WHERE ${window}
+    ),
+    trades_data AS (
         SELECT COUNT(DISTINCT trader) AS active_users
-        FROM (
-            SELECT maker AS trader FROM polymarket_v2_polygon.ctfexchange_evt_orderfilled
-              WHERE evt_block_time >= from_unixtime(${options.startTimestamp}) AND evt_block_time < from_unixtime(${options.endTimestamp})
-            UNION ALL
-            SELECT taker AS trader FROM polymarket_v2_polygon.ctfexchange_evt_orderfilled
-              WHERE evt_block_time >= from_unixtime(${options.startTimestamp}) AND evt_block_time < from_unixtime(${options.endTimestamp})
-            UNION ALL
-            SELECT maker AS trader FROM polymarket_polygon.NegRiskCtfExchange_evt_OrderFilled
-              WHERE evt_block_time >= from_unixtime(${options.startTimestamp}) AND evt_block_time < from_unixtime(${options.endTimestamp})
-            UNION ALL
-            SELECT taker AS trader FROM polymarket_polygon.NegRiskCtfExchange_evt_OrderFilled
-              WHERE evt_block_time >= from_unixtime(${options.startTimestamp}) AND evt_block_time < from_unixtime(${options.endTimestamp})
-            UNION ALL
-            SELECT maker AS trader FROM polymarket_polygon.CTFExchange_evt_OrderFilled
-              WHERE evt_block_time >= from_unixtime(${options.startTimestamp}) AND evt_block_time < from_unixtime(${options.endTimestamp})
-            UNION ALL
-            SELECT taker AS trader FROM polymarket_polygon.CTFExchange_evt_OrderFilled
-              WHERE evt_block_time >= from_unixtime(${options.startTimestamp}) AND evt_block_time < from_unixtime(${options.endTimestamp})
-        )
+        FROM fills CROSS JOIN UNNEST(ARRAY[maker, taker]) AS t(trader)
     ),
     blockchain_data AS (
         SELECT

--- a/active-users/polymarket.ts
+++ b/active-users/polymarket.ts
@@ -1,7 +1,8 @@
 import { Dependencies, SimpleAdapter, FetchOptions } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
-import { queryAllium } from "../helpers/allium";
+import { queryDuneSql } from "../helpers/dune";
 
+// CTF / NegRisk contracts (tx + gas are measured against direct interactions with these)
 const contractAddresses = [
     '0x4D97DCd97eC945f40cF65F87097ACe5EA0476045', // Ctf
     '0xd91E80cF2E7be2e162c6513ceD06f1dD0dA35296', // NegRiskCtf
@@ -10,35 +11,38 @@ const contractAddresses = [
 ]
 
 const fetch = async (options: FetchOptions) => {
-    const contractAddressList = contractAddresses.map(a => `'${a.toLowerCase()}'`).join(', ')
-    const alliumQuery = `
+    const contractAddressList = contractAddresses.map(a => a.toLowerCase()).join(', ')
+    const query = `
     WITH trades_data AS (
-        SELECT 
-            COALESCE(COUNT(DISTINCT trader), 0) AS active_users
+        SELECT COUNT(DISTINCT trader) AS active_users
         FROM (
-            SELECT maker AS trader
-            FROM polygon.predictions.trades
-            WHERE protocol = 'polymarket'
-              AND event_name = 'OrderFilled'
-              AND block_timestamp >= TO_TIMESTAMP_NTZ('${options.startTimestamp}')
-              AND block_timestamp < TO_TIMESTAMP_NTZ('${options.endTimestamp}')
+            SELECT maker AS trader FROM polymarket_v2_polygon.ctfexchange_evt_orderfilled
+              WHERE evt_block_time >= from_unixtime(${options.startTimestamp}) AND evt_block_time < from_unixtime(${options.endTimestamp})
             UNION ALL
-            SELECT taker AS trader
-            FROM polygon.predictions.trades
-            WHERE protocol = 'polymarket'
-              AND event_name = 'OrderFilled'
-              AND block_timestamp >= TO_TIMESTAMP_NTZ('${options.startTimestamp}')
-              AND block_timestamp < TO_TIMESTAMP_NTZ('${options.endTimestamp}')
+            SELECT taker AS trader FROM polymarket_v2_polygon.ctfexchange_evt_orderfilled
+              WHERE evt_block_time >= from_unixtime(${options.startTimestamp}) AND evt_block_time < from_unixtime(${options.endTimestamp})
+            UNION ALL
+            SELECT maker AS trader FROM polymarket_polygon.NegRiskCtfExchange_evt_OrderFilled
+              WHERE evt_block_time >= from_unixtime(${options.startTimestamp}) AND evt_block_time < from_unixtime(${options.endTimestamp})
+            UNION ALL
+            SELECT taker AS trader FROM polymarket_polygon.NegRiskCtfExchange_evt_OrderFilled
+              WHERE evt_block_time >= from_unixtime(${options.startTimestamp}) AND evt_block_time < from_unixtime(${options.endTimestamp})
+            UNION ALL
+            SELECT maker AS trader FROM polymarket_polygon.CTFExchange_evt_OrderFilled
+              WHERE evt_block_time >= from_unixtime(${options.startTimestamp}) AND evt_block_time < from_unixtime(${options.endTimestamp})
+            UNION ALL
+            SELECT taker AS trader FROM polymarket_polygon.CTFExchange_evt_OrderFilled
+              WHERE evt_block_time >= from_unixtime(${options.startTimestamp}) AND evt_block_time < from_unixtime(${options.endTimestamp})
         )
     ),
     blockchain_data AS (
         SELECT
-            COALESCE(SUM(receipt_effective_gas_price * receipt_gas_used) / 1e18, 0) AS total_gas,
+            SUM(CAST(gas_used AS double) * CAST(gas_price AS double)) / 1e18 AS total_gas,
             COUNT(*) AS total_transactions
-        FROM polygon.raw.transactions
-        WHERE to_address IN (${contractAddressList})
-          AND block_timestamp > TO_TIMESTAMP_NTZ('${options.startTimestamp}')
-          AND block_timestamp < TO_TIMESTAMP_NTZ('${options.endTimestamp}')
+        FROM polygon.transactions
+        WHERE "to" IN (${contractAddressList})
+          AND block_time >= from_unixtime(${options.startTimestamp})
+          AND block_time < from_unixtime(${options.endTimestamp})
     )
     SELECT
         trades_data.active_users,
@@ -48,12 +52,12 @@ const fetch = async (options: FetchOptions) => {
     CROSS JOIN blockchain_data
     `;
 
-    const alliumResult = await queryAllium(alliumQuery);
+    const result = await queryDuneSql(options, query);
 
     return {
-        dailyActiveUsers: alliumResult[0].active_users,
-        dailyTransactionsCount: alliumResult[0].total_transactions,
-        dailyGasUsed: alliumResult[0].total_gas,
+        dailyActiveUsers: result[0].active_users,
+        dailyTransactionsCount: result[0].total_transactions,
+        dailyGasUsed: result[0].total_gas,
     }
 }
 
@@ -61,7 +65,7 @@ const adapter: SimpleAdapter = {
     version: 1,
     fetch,
     chains: [CHAIN.POLYGON],
-    dependencies: [Dependencies.ALLIUM],
+    dependencies: [Dependencies.DUNE],
     isExpensiveAdapter: true,
     start: "2020-09-30",
 };

--- a/new-users/polymarket.ts
+++ b/new-users/polymarket.ts
@@ -1,34 +1,40 @@
 import { Dependencies, SimpleAdapter, FetchOptions } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
-import { queryAllium } from "../helpers/allium";
+import { queryDuneSql } from "../helpers/dune";
 
 const fetch = async (options: FetchOptions) => {
-    const alliumQuery = `
+    const query = `
     WITH trades AS (
-        SELECT maker AS trader, block_timestamp
-        FROM polygon.predictions.trades
-        WHERE protocol = 'polymarket'
-          AND event_name = 'OrderFilled'
-          AND block_timestamp < TO_TIMESTAMP_NTZ('${options.endTimestamp}')
+        SELECT maker AS trader, evt_block_time FROM polymarket_v2_polygon.ctfexchange_evt_orderfilled
+          WHERE evt_block_time < from_unixtime(${options.endTimestamp})
         UNION ALL
-        SELECT taker AS trader, block_timestamp
-        FROM polygon.predictions.trades
-        WHERE protocol = 'polymarket'
-          AND event_name = 'OrderFilled'
-          AND block_timestamp < TO_TIMESTAMP_NTZ('${options.endTimestamp}')
+        SELECT taker AS trader, evt_block_time FROM polymarket_v2_polygon.ctfexchange_evt_orderfilled
+          WHERE evt_block_time < from_unixtime(${options.endTimestamp})
+        UNION ALL
+        SELECT maker AS trader, evt_block_time FROM polymarket_polygon.NegRiskCtfExchange_evt_OrderFilled
+          WHERE evt_block_time < from_unixtime(${options.endTimestamp})
+        UNION ALL
+        SELECT taker AS trader, evt_block_time FROM polymarket_polygon.NegRiskCtfExchange_evt_OrderFilled
+          WHERE evt_block_time < from_unixtime(${options.endTimestamp})
+        UNION ALL
+        SELECT maker AS trader, evt_block_time FROM polymarket_polygon.CTFExchange_evt_OrderFilled
+          WHERE evt_block_time < from_unixtime(${options.endTimestamp})
+        UNION ALL
+        SELECT taker AS trader, evt_block_time FROM polymarket_polygon.CTFExchange_evt_OrderFilled
+          WHERE evt_block_time < from_unixtime(${options.endTimestamp})
     )
     SELECT
         COUNT(DISTINCT trader)
         - COUNT(DISTINCT CASE
-            WHEN block_timestamp < TO_TIMESTAMP_NTZ('${options.startTimestamp}') THEN trader
+            WHEN evt_block_time < from_unixtime(${options.startTimestamp}) THEN trader
           END) AS new_users
     FROM trades
     `;
 
-    const alliumResult = await queryAllium(alliumQuery);
+    const result = await queryDuneSql(options, query);
 
     return {
-        dailyNewUsers: alliumResult[0].new_users,
+        dailyNewUsers: result[0].new_users,
     }
 }
 
@@ -36,7 +42,7 @@ const adapter: SimpleAdapter = {
     version: 1,
     fetch,
     chains: [CHAIN.POLYGON],
-    dependencies: [Dependencies.ALLIUM],
+    dependencies: [Dependencies.DUNE],
     isExpensiveAdapter: true,
     start: "2020-09-30",
 };

--- a/new-users/polymarket.ts
+++ b/new-users/polymarket.ts
@@ -3,32 +3,23 @@ import { CHAIN } from "../helpers/chains";
 import { queryDuneSql } from "../helpers/dune";
 
 const fetch = async (options: FetchOptions) => {
+    const before = `evt_block_time < from_unixtime(${options.endTimestamp})`
     const query = `
-    WITH trades AS (
-        SELECT maker AS trader, evt_block_time FROM polymarket_v2_polygon.ctfexchange_evt_orderfilled
-          WHERE evt_block_time < from_unixtime(${options.endTimestamp})
+    WITH fills AS (
+        SELECT maker, taker, evt_block_time FROM polymarket_v2_polygon.ctfexchange_evt_orderfilled WHERE ${before}
         UNION ALL
-        SELECT taker AS trader, evt_block_time FROM polymarket_v2_polygon.ctfexchange_evt_orderfilled
-          WHERE evt_block_time < from_unixtime(${options.endTimestamp})
+        SELECT maker, taker, evt_block_time FROM polymarket_polygon.NegRiskCtfExchange_evt_OrderFilled WHERE ${before}
         UNION ALL
-        SELECT maker AS trader, evt_block_time FROM polymarket_polygon.NegRiskCtfExchange_evt_OrderFilled
-          WHERE evt_block_time < from_unixtime(${options.endTimestamp})
-        UNION ALL
-        SELECT taker AS trader, evt_block_time FROM polymarket_polygon.NegRiskCtfExchange_evt_OrderFilled
-          WHERE evt_block_time < from_unixtime(${options.endTimestamp})
-        UNION ALL
-        SELECT maker AS trader, evt_block_time FROM polymarket_polygon.CTFExchange_evt_OrderFilled
-          WHERE evt_block_time < from_unixtime(${options.endTimestamp})
-        UNION ALL
-        SELECT taker AS trader, evt_block_time FROM polymarket_polygon.CTFExchange_evt_OrderFilled
-          WHERE evt_block_time < from_unixtime(${options.endTimestamp})
+        SELECT maker, taker, evt_block_time FROM polymarket_polygon.CTFExchange_evt_OrderFilled WHERE ${before}
+    ),
+    first_seen AS (
+        SELECT trader, MIN(evt_block_time) AS first_ts
+        FROM fills CROSS JOIN UNNEST(ARRAY[maker, taker]) AS t(trader)
+        GROUP BY trader
     )
-    SELECT
-        COUNT(DISTINCT trader)
-        - COUNT(DISTINCT CASE
-            WHEN evt_block_time < from_unixtime(${options.startTimestamp}) THEN trader
-          END) AS new_users
-    FROM trades
+    SELECT COUNT(*) AS new_users
+    FROM first_seen
+    WHERE first_ts >= from_unixtime(${options.startTimestamp})
     `;
 
     const result = await queryDuneSql(options, query);


### PR DESCRIPTION
Migrates Polymarket active/new user adapters from Allium to Dune after the removal of `polygon.predictions.trades`, preserving the existing metrics.