### PR TITLE
1inch-aqua: track redeployed registry (AquaRouter), add Robinhood chain, count taker-paid Pushed volume

### DIFF
--- a/dexs/1inch-aqua/index.ts
+++ b/dexs/1inch-aqua/index.ts
@@ -11,20 +11,67 @@ const AQUA_REGISTRIES = [
   "0x1111113ccf1426a8e30e2bff5e005d929bf6a90a", // AquaRouter, 2026-07-19
 ];
 
-const PULLED_ABI =
-  "event Pulled(address maker, address app, bytes32 strategyHash, address token, uint256 amount)";
+const PUSHED_ABI =
+  "event Pushed(address maker, address app, bytes32 strategyHash, address token, uint256 amount)";
+const SHIPPED_ABI =
+  "event Shipped(address maker, address app, bytes32 strategyHash, bytes strategy)";
+
+const logIndexOf = (log: any) => Number(log.logIndex ?? log.index);
+const positionOf = (log: any) =>
+  `${log.address.toLowerCase()}-${log.transactionHash.toLowerCase()}-${logIndexOf(log)}`;
+const strategyOf = (log: any) =>
+  `${log.args.maker}-${log.args.app}-${log.args.strategyHash}`.toLowerCase();
 
 const fetch = async (options: FetchOptions) => {
   const dailyVolume = options.createBalances();
 
-  // Pulled fires only when a strategy delivers tokens to a taker during swap
-  // execution. Strategy lifecycle operations (ship/dock) move no tokens and
-  // never emit Pulled, so all Pulled events count toward volume.
-  const pulledLogs = await options.getLogs({
-    targets: AQUA_REGISTRIES,
-    eventAbi: PULLED_ABI,
+  // Volume is the fee-inclusive side of each swap: the amount a taker pays
+  // into the maker wallet, emitted as Pushed by the registry's push().
+  // (Pulled, the taker-received side, is net of the maker fee and undercounts.)
+  //
+  // ship() also emits Pushed events, but those only register a strategy's
+  // initial virtual balances - no tokens move - and must not count as volume.
+  // entireLog keeps address/transactionHash/logIndex on the logs so they can
+  // be separated below; parseLog must be explicit because the indexer path
+  // does not auto-enable it the way the RPC path does.
+  const [pushedLogs, shippedLogs] = await Promise.all([
+    options.getLogs({
+      targets: AQUA_REGISTRIES,
+      eventAbi: PUSHED_ABI,
+      entireLog: true,
+      parseLog: true,
+    }),
+    options.getLogs({
+      targets: AQUA_REGISTRIES,
+      eventAbi: SHIPPED_ABI,
+      entireLog: true,
+      parseLog: true,
+    }),
+  ]);
+
+  const pushedByPosition = new Map<string, any>();
+  pushedLogs.forEach((log: any) => pushedByPosition.set(positionOf(log), log));
+
+  // ship() emits Shipped, then one Pushed per token with no external call in
+  // between, so its Pushed run occupies strictly consecutive log indices for
+  // the same maker/app/strategyHash. A real swap or deposit push() always
+  // emits an ERC20 Transfer before its Pushed event, which breaks the run -
+  // walking the run therefore separates registration pushes exactly, even
+  // when a ship and a swap share one transaction.
+  const shipRegistrationPushes = new Set<string>();
+  shippedLogs.forEach((shipped: any) => {
+    const txPrefix = `${shipped.address.toLowerCase()}-${shipped.transactionHash.toLowerCase()}`;
+    for (let index = logIndexOf(shipped) + 1; ; index++) {
+      const pushed = pushedByPosition.get(`${txPrefix}-${index}`);
+      if (!pushed || strategyOf(pushed) !== strategyOf(shipped)) break;
+      shipRegistrationPushes.add(`${txPrefix}-${index}`);
+    }
   });
-  pulledLogs.forEach((log: any) => dailyVolume.add(log.token, log.amount));
+
+  pushedLogs.forEach((log: any) => {
+    if (shipRegistrationPushes.has(positionOf(log))) return;
+    dailyVolume.add(log.args.token, log.args.amount);
+  });
 
   return { dailyVolume };
 };
@@ -51,7 +98,7 @@ const adapter: SimpleAdapter = {
   start: "2025-11-17", // Aqua developer release: https://blog.1inch.com/aqua-developer-release/
   methodology: {
     Volume:
-      "Sum of tokens delivered to takers by Aqua strategies during swap execution, measured as Pulled events on the Aqua registries (the current AquaRouter and the original developer-release registry). Only the taker-received side of each swap is counted to avoid double counting. Strategy deploy/close operations (Shipped/Docked) move no tokens and emit no Pulled events, so liquidity lifecycle operations add no volume.",
+      "Sum of tokens paid into maker wallets during Aqua swap execution, measured as Pushed events on the Aqua registries (the current AquaRouter and the original developer-release registry). Only the taker-paid side of each swap is counted, to avoid double counting and to include the maker fee (the Pulled side is net of fees and would undercount). Pushed events emitted by strategy deployment (the consecutive run following a Shipped event for the same strategy) only register virtual balances without moving tokens and are excluded.",
   },
 };
 

--- a/dexs/1inch-aqua/index.ts
+++ b/dexs/1inch-aqua/index.ts
@@ -1,38 +1,30 @@
 import { FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 
-// Aqua registry, deployed at the same address on every supported chain:
-// https://github.com/1inch/aqua#deployments
-const AQUA_REGISTRY = "0x499943e74fb0ce105688beee8ef2abec5d936d31";
+// Aqua registries (https://github.com/1inch/aqua), each deployed at the same
+// address on every supported chain. The protocol redeployed on 2026-07-19 as
+// AquaRouter with an unchanged event interface (source verified, e.g.
+// https://robinhoodchain.blockscout.com/address/0x1111113CCf1426A8e30e2BFF5e005D929bf6A90A?tab=contract);
+// the original developer-release registry is kept so earlier history stays reproducible.
+const AQUA_REGISTRIES = [
+  "0x499943e74fb0ce105688beee8ef2abec5d936d31", // developer release, 2025-11-17
+  "0x1111113ccf1426a8e30e2bff5e005d929bf6a90a", // AquaRouter, 2026-07-19
+];
 
-const PULLED_ABI = "event Pulled(address maker, address app, bytes32 strategyHash, address token, uint256 amount)";
-const SHIPPED_ABI = "event Shipped(address maker, address app, bytes32 strategyHash, bytes strategy)";
-const DOCKED_ABI = "event Docked(address maker, address app, bytes32 strategyHash)";
+const PULLED_ABI =
+  "event Pulled(address maker, address app, bytes32 strategyHash, address token, uint256 amount)";
 
 const fetch = async (options: FetchOptions) => {
   const dailyVolume = options.createBalances();
 
-  // entireLog keeps transactionHash on the logs so swap pulls can be separated
-  // from strategy lifecycle transactions below; parseLog must be explicit
-  // because the indexer path does not auto-enable it the way the RPC path does
-  const [pulledLogs, shippedLogs, dockedLogs] = await Promise.all([
-    options.getLogs({ target: AQUA_REGISTRY, eventAbi: PULLED_ABI, entireLog: true, parseLog: true }),
-    options.getLogs({ target: AQUA_REGISTRY, eventAbi: SHIPPED_ABI, entireLog: true, parseLog: true }),
-    options.getLogs({ target: AQUA_REGISTRY, eventAbi: DOCKED_ABI, entireLog: true, parseLog: true }),
-  ]);
-
-  // Transactions that ship (deploy) or dock (revoke) a strategy move liquidity,
-  // not swap volume - Pulled/Pushed events they emit must not be counted.
-  // Hashes are lowercased because the three fetches may be served by different
-  // backends (indexer/RPC/cache) with no canonical casing guarantee
-  const strategyLifecycleTxs = new Set<string>();
-  shippedLogs.forEach((log: any) => strategyLifecycleTxs.add(log.transactionHash.toLowerCase()));
-  dockedLogs.forEach((log: any) => strategyLifecycleTxs.add(log.transactionHash.toLowerCase()));
-
-  pulledLogs.forEach((log: any) => {
-    if (strategyLifecycleTxs.has(log.transactionHash.toLowerCase())) return;
-    dailyVolume.add(log.args.token, log.args.amount);
+  // Pulled fires only when a strategy delivers tokens to a taker during swap
+  // execution. Strategy lifecycle operations (ship/dock) move no tokens and
+  // never emit Pulled, so all Pulled events count toward volume.
+  const pulledLogs = await options.getLogs({
+    targets: AQUA_REGISTRIES,
+    eventAbi: PULLED_ABI,
   });
+  pulledLogs.forEach((log: any) => dailyVolume.add(log.token, log.amount));
 
   return { dailyVolume };
 };
@@ -54,11 +46,12 @@ const adapter: SimpleAdapter = {
     CHAIN.SONIC,
     CHAIN.UNICHAIN,
     CHAIN.ERA,
+    [CHAIN.ROBINHOOD, { start: "2026-07-19" }],
   ],
   start: "2025-11-17", // Aqua developer release: https://blog.1inch.com/aqua-developer-release/
   methodology: {
     Volume:
-      "Sum of tokens delivered to takers by Aqua strategies during swap execution, measured as Pulled events on the Aqua registry. Only the taker-received side of each swap is counted to avoid double counting. Pulled events emitted in transactions that also ship or dock a strategy are excluded, as those move liquidity rather than trade it. Liquidity withdrawals executed through the swap path are indistinguishable from swaps on-chain and are therefore included.",
+      "Sum of tokens delivered to takers by Aqua strategies during swap execution, measured as Pulled events on the Aqua registries (the current AquaRouter and the original developer-release registry). Only the taker-received side of each swap is counted to avoid double counting. Strategy deploy/close operations (Shipped/Docked) move no tokens and emit no Pulled events, so liquidity lifecycle operations add no volume.",
   },
 };
 


### PR DESCRIPTION
Follow-up to #8103 (1inch Aqua DEX volume adapter). The Aqua protocol redeployed its registry on 2026-07-19; this PR keeps the adapter pointed at live contracts and aligns the volume methodology with the protocol team's internal (backend) tracking.

## Changes

1. **New registry address.** Aqua redeployed as `AquaRouter` at `0x1111113ccf1426a8e30e2bff5e005d929bf6a90a` (same address on all supported chains, source verified, identical event interface — `Pulled`/`Pushed`/`Shipped`/`Docked`). The original developer-release registry `0x4999...6d31` stays in `targets` so pre-redeploy history remains reproducible for timetravel refills.
2. **New chain: Robinhood** (`CHAIN.ROBINHOOD`), where only the new registry exists — per-chain `start: "2026-07-19"` (deploy date, verified via Blockscout).
3. **Volume now counts the taker-paid `Pushed` side** (matching how the 1inch team tracks Aqua volume internally):
   - `Pulled` (what the taker receives) is net of the maker fee, so counting it undercounts trade notional. `Pushed` during swap execution is what the taker pays into the maker wallet, fee-inclusive.
   - `ship()` (strategy deployment) also emits `Pushed` events, but those only register a strategy's initial **virtual** balances — no tokens move — and are excluded. They are identified exactly: `ship()` emits `Shipped` followed by one `Pushed` per token with no external call in between, so registration pushes occupy strictly consecutive log indices after their `Shipped` for the same `maker/app/strategyHash`; a real swap `push()` always emits an ERC20 `Transfer` before its `Pushed`, which breaks the run. This stays correct even when a deploy and a swap share one batched transaction — which real history contains (e.g. Base [`0xce2ee0a6...b052b`](https://basescan.org/tx/0xce2ee0a6a50fd17180b811e7b11bd03971a62814a4c015b57181789d7e4b052b): swap `Pushed` counted, the re-ship's two registration `Pushed` excluded).
   - This also fixes an undercount in the previous adapter, which dropped *all* `Pulled` events in transactions containing `Shipped`/`Docked` — discarding the swap legs of such batched transactions entirely.

## Testing

Historical windows with known activity:

```
npm test dexs 1inch-aqua 1776002400   # 2026-04-12 (old registry)
arbitrum  | 2.94    (Pulled-based logic gave 2.93 — fee-inclusive side is slightly higher, as expected)

npm test dexs 1inch-aqua 1763863200   # 2025-11-23 (contains batched dock+ship+swap txs on Base)
base      | 6.85
arbitrum  | 0.50
```

Current day (both registries, incl. Robinhood): runs clean across all 13 chains, volume 0.00 — matches on-chain state (the new registry went live 2026-07-19; public UI launch is upcoming, so volume is expected to ramp).

Made with [Cursor](https://cursor.com)