### PR TITLE
fomo: count one row per swap, dex_solana.trades is per pool hop

### DIFF
--- a/dexs/fomo/index.ts
+++ b/dexs/fomo/index.ts
@@ -24,7 +24,10 @@ const fetch = async (options: FetchOptions) => {
     botTrades AS (
       SELECT
         t.tx_id,
-        t.amount_usd
+        t.amount_usd,
+        -- dex_solana.trades has one row per pool hop, and a route through USDC matches the
+        -- filter below on both of its legs, so summing every row counts one swap twice
+        ROW_NUMBER() OVER (PARTITION BY t.tx_id, t.trader_id ORDER BY t.amount_usd DESC) AS rn
       FROM dex_solana.trades t
       JOIN fomo_txs f ON t.tx_id = f.tx_id
       WHERE TIME_RANGE
@@ -38,6 +41,7 @@ const fetch = async (options: FetchOptions) => {
     )
     SELECT COALESCE(SUM(amount_usd), 0) AS total_volume
     FROM botTrades
+    WHERE rn = 1
   `);
 
   return { dailyVolume: result[0].total_volume };


### PR DESCRIPTION
`dex_solana.trades` emits **one row per pool hop**, so a multi-hop route produces several rows sharing a `tx_id`. This adapter sums every row, which counts one user swap more than once.

The USDC filter makes it worse rather than better: a route like `TOKEN -> USDC -> TOKEN2` matches on *both* legs (the first buys USDC, the second sells it), so both rows are kept and a single swap is counted twice.

### Measurement

Over 2026-07-14 to 2026-07-17, restricted to exactly the transactions and filters this adapter selects:

| | |
|---|---|
| hop rows | 308,940 |
| distinct transactions | 287,165 |
| transactions with >1 row | 20,624 |
| most rows in a single tx | 5 |
| **volume as summed today** | **$39,281,354** |
| volume deduped per `(tx_id, trader_id)` | $37,022,092 |

That's a 5.75% overstatement, roughly **$22.5M of phantom volume per 30 days** against the adapter's $390.8M.

### Verification

Running the adapter for 2026-07-15:

```
before:  Daily volume 12.74 M
after:   Daily volume 12.01 M      (-5.7%)
```

The "before" figure reproduces what the API reports for that day ($12,738,557), so the local run matches production and the post-fix number is the corrected one. `tsc --project tsconfig.json` exits 0.

### Fix

Partitions on `(tx_id, trader_id)` rather than `tx_id` alone, so a transaction that batches swaps from different traders keeps one row per trader instead of collapsing to one row overall. This matches the convention already used by the other Solana bot adapters in this repo (photon, bullx, axiom, trojan, telemetry, sol-trading-bot), and is the same class as the recently merged fixes for rainbow-wallet (#8258) and binance-wallet (#8265).
