### PR TITLE
[add] rysk-premium - add notional and premium volume tracking

### DIFF
--- a/options/rysk-premium/index.ts
+++ b/options/rysk-premium/index.ts
@@ -5,11 +5,11 @@ import { CHAIN } from "../../helpers/chains";
 const CONFIG: Record<string, { vaultRegistry: string; start: string }> = {
     [CHAIN.ETHEREUM]: {
         vaultRegistry: "0x12a86ae14992c5a5e8671d30cfd60289f9d0afbe",
-        start: '2026-07-11', 
+        start: '2026-07-11',
     },
     [CHAIN.HYPERLIQUID]: {
-        vaultRegistry: "0x425ffAB71CEFc7aB96CBFbb75282e731234C1885", 
-        start: '2026-02-05', 
+        vaultRegistry: "0x425ffAB71CEFc7aB96CBFbb75282e731234C1885",
+        start: '2026-02-05',
     },
 };
 
@@ -37,20 +37,23 @@ async function fetch(options: FetchOptions): Promise<FetchResultV2> {
         calls: pools.map((pool) => ({ target: pool })),
     });
 
+    // Batch all pools into one getLogs per event type; flatten:false keeps
+    // per-pool arrays aligned to `pools`, so we can attribute each log to its
+    // pool's collateralAsset.
+    const writeLogsByPool = await options.getLogs({ targets: pools, eventAbi: WRITE_OPTION, flatten: false });
+    const buybackLogsByPool = await options.getLogs({ targets: pools, eventAbi: BUYBACK_OPTION, flatten: false });
+
     for (let i = 0; i < pools.length; i++) {
-        const pool = pools[i];
         const collateral = collateralAssets[i];
 
         // Writes: buyer pays premium into the pool; escrow = collateral locked ~ notional.
-        const writeLogs = await options.getLogs({ target: pool, eventAbi: WRITE_OPTION });
-        writeLogs.forEach((log: any) => {
+        writeLogsByPool[i].forEach((log: any) => {
             dailyPremiumVolume.add(collateral, log.premium);
             dailyNotionalVolume.add(collateral, log.escrow);
         });
 
         // Buybacks: pool pays premium back to the seller — premium turnover.
-        const buybackLogs = await options.getLogs({ target: pool, eventAbi: BUYBACK_OPTION });
-        buybackLogs.forEach((log: any) => {
+        buybackLogsByPool[i].forEach((log: any) => {
             dailyPremiumVolume.add(collateral, log.premium);
         });
     }
@@ -60,10 +63,9 @@ async function fetch(options: FetchOptions): Promise<FetchResultV2> {
 
 const adapter: Adapter = {
     version: 2,
+    pullHourly: true,
     fetch,
-    adapter: Object.fromEntries(
-        Object.entries(CONFIG).map(([chain, { start }]) => [chain, { start }])
-    ),
+    adapter: CONFIG,
 };
 
 export default adapter;

--- a/options/rysk-premium/index.ts
+++ b/options/rysk-premium/index.ts
@@ -1,0 +1,69 @@
+import { Adapter, FetchOptions, FetchResultV2 } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+
+// Rysk Premium VaultRegistry per chain — lists every LiquidityPool (vault).
+const CONFIG: Record<string, { vaultRegistry: string; start: string }> = {
+    [CHAIN.ETHEREUM]: {
+        vaultRegistry: "0x12a86ae14992c5a5e8671d30cfd60289f9d0afbe",
+        start: '2026-07-11', 
+    },
+    [CHAIN.HYPERLIQUID]: {
+        vaultRegistry: "0x425ffAB71CEFc7aB96CBFbb75282e731234C1885", 
+        start: '2026-02-05', 
+    },
+};
+
+const WRITE_OPTION =
+    "event WriteOption(address indexed series, uint256 amount, uint256 premium, uint256 escrow, address indexed buyer)";
+const BUYBACK_OPTION =
+    "event BuybackOption(address indexed series, uint256 amount, uint256 premium, uint256 collateralReturned, address indexed seller)";
+
+async function fetch(options: FetchOptions): Promise<FetchResultV2> {
+    const dailyNotionalVolume = options.createBalances();
+    const dailyPremiumVolume = options.createBalances();
+
+    const { vaultRegistry } = CONFIG[options.chain];
+
+    // Discover all vaults (LiquidityPools) from the registry.
+    const pools: string[] = await options.api.call({
+        target: vaultRegistry,
+        abi: "address[]:getAllVaults",
+    });
+
+    // Premium + collateral are denominated in each pool's own collateralAsset
+    // (WETH for the call vault, USDT/USDC for put vaults), in native decimals.
+    const collateralAssets: string[] = await options.api.multiCall({
+        abi: "address:collateralAsset",
+        calls: pools.map((pool) => ({ target: pool })),
+    });
+
+    for (let i = 0; i < pools.length; i++) {
+        const pool = pools[i];
+        const collateral = collateralAssets[i];
+
+        // Writes: buyer pays premium into the pool; escrow = collateral locked ~ notional.
+        const writeLogs = await options.getLogs({ target: pool, eventAbi: WRITE_OPTION });
+        writeLogs.forEach((log: any) => {
+            dailyPremiumVolume.add(collateral, log.premium);
+            dailyNotionalVolume.add(collateral, log.escrow);
+        });
+
+        // Buybacks: pool pays premium back to the seller — premium turnover.
+        const buybackLogs = await options.getLogs({ target: pool, eventAbi: BUYBACK_OPTION });
+        buybackLogs.forEach((log: any) => {
+            dailyPremiumVolume.add(collateral, log.premium);
+        });
+    }
+
+    return { dailyNotionalVolume, dailyPremiumVolume };
+}
+
+const adapter: Adapter = {
+    version: 2,
+    fetch,
+    adapter: Object.fromEntries(
+        Object.entries(CONFIG).map(([chain, { start }]) => [chain, { start }])
+    ),
+};
+
+export default adapter;


### PR DESCRIPTION
**NOTE**

#### Please enable "Allow edits by maintainers" while putting up the PR.

---

> - If you would like to add a `tvl` adapter please submit the PR [here](https://github.com/DefiLlama/DefiLlama-Adapters).

1. Once your adapter has been merged, it takes time to show on the UI. If more than 24 hours have passed, please let us know in Discord.
2. Please fill the form below **only if the PR is for listing a new protocol** else it can be ignored/replaced with reason/details about the PR
3. **For updating listing info** Please send a mail to metadata@defillama.com
4. Do not edit/push `package.json/package-lock.json` file as part of your changes
5. No need to go to our discord/other channel and announce that you've created a PR, we monitor all PRs and will review it asap

---

##### Name (to be shown on DefiLlama): Rysk Premium

The project is already on Defillama https://defillama.com/protocol/rysk-premium under the rysk (combined) project

## Adapter
rysk-premium — Rysk Premium options vaults on Ethereum + Hyperliquid.

## Summary
Adds an options adapter tracking notional and premium volume for Rysk
Premium LiquidityPools. Pools are discovered dynamically via the per-chain
VaultRegistry (getAllVaults); volume is derived from WriteOption (premium +
escrow/notional) and BuybackOption (premium turnover) events, denominated in
each pool's collateralAsset.

## Reason
New protocol coverage — Rysk Premium was not previously tracked.

## Notes
- dailyNotionalVolume = write escrow (collateral locked ≈ notional)
- dailyPremiumVolume  = write premium + buyback premium
- ETH auto-skips before its start (Jul 11); no on-chain writes there yet.

