### PR TITLE
pancakeswap-v3: accumulate Solana revenue per pool

### DIFF
--- a/dexs/pancakeswap-v3.ts
+++ b/dexs/pancakeswap-v3.ts
@@ -289,10 +289,10 @@ const blacklistPools = [
 const fetchSolanaV3 = async (options: FetchOptions) => {
   const dailyVolume = options.createBalances();
   const dailyFees = options.createBalances();
-  let dailyRevenue = options.createBalances();
-  let dailyProtocolRevenue = options.createBalances();
-  let dailyHoldersRevenue = options.createBalances();
-  let dailySupplySideRevenue = options.createBalances();
+  const dailyRevenue = options.createBalances();
+  const dailyProtocolRevenue = options.createBalances();
+  const dailyHoldersRevenue = options.createBalances();
+  const dailySupplySideRevenue = options.createBalances();
 
   let page = 1;
   let allPools: Array<any> = [];
@@ -340,12 +340,10 @@ const fetchSolanaV3 = async (options: FetchOptions) => {
     const revenueRatio = protocolRevenueRatio + holdersRevenueRatio;
     const supplySideRevenueRatio = 1 - revenueRatio;
 
-    dailyProtocolRevenue = dailyFees.clone(protocolRevenueRatio)
-    dailyHoldersRevenue = dailyFees.clone(holdersRevenueRatio)
-    dailySupplySideRevenue = dailyFees.clone(supplySideRevenueRatio)
-    
-    dailyRevenue = dailyProtocolRevenue.clone(1)
-    dailyRevenue.add(dailyHoldersRevenue)
+    dailyRevenue.addUSDValue(fee * revenueRatio);
+    dailyProtocolRevenue.addUSDValue(fee * protocolRevenueRatio);
+    dailyHoldersRevenue.addUSDValue(fee * holdersRevenueRatio);
+    dailySupplySideRevenue.addUSDValue(fee * supplySideRevenueRatio);
   }
 
   return {


### PR DESCRIPTION
In `fetchSolanaV3`, the four revenue balances are **reassigned** inside the per-pool loop rather than accumulated:

```ts
dailyProtocolRevenue = dailyFees.clone(protocolRevenueRatio)   // clones CUMULATIVE dailyFees
dailyHoldersRevenue  = dailyFees.clone(holdersRevenueRatio)
dailySupplySideRevenue = dailyFees.clone(supplySideRevenueRatio)
dailyRevenue = dailyProtocolRevenue.clone(1)
dailyRevenue.add(dailyHoldersRevenue)
```

`clone(ratio)` returns a new Balances scaled from the whole cumulative object, so each iteration discards every previous pool. What survives is `total_fees × ratio_of_the_last_pool` — the entire day's split is decided by whichever pool happens to be last in the explorer's pagination.

Because `getProtocolRevenueRatio` / `getHolderRevenueRatio` return 0 for any tier outside {0.0001, 0.0005, 0.0025, 0.01}, whenever that last pool sits on an unlisted tier the day reports no revenue at all.

### The published series shows it directly

Across 373 Solana days, `dailyRevenue / dailyFees` takes essentially three values:

| ratio | days | corresponds to |
|---|---|---|
| 0.0000 | 195 | last pool on a tier absent from the tables |
| 0.3300 | 133 | 0.18 + 0.15 (tier 0.0001) |
| 0.3200 | 39 | 0.09 + 0.23 (tier 0.0025 / 0.01) |

A genuine volume-weighted blend across the live tier mix would vary continuously; instead it snaps to single-tier constants. The protocol/holders split flips with it — 2026-07-08 reports protocol 368 / holders 940, and 2026-07-09 reports protocol 696 / holders 580, a 2x swing driven by nothing real.

### Verification

Replaying both code paths over the live pool list (1,470 pools from `sol-explorer.pancakeswap.com`, 24h fees $3,617.28; last pool `FC1kypAhfoc2wVNSZjxVYqBqg19D3thAYTuzKEjB1F9K`, feeRate 0.002 → both ratios 0):

```
                     before          after
protocolRevenue       $0.00        $331.69
holdersRevenue        $0.00        $281.96
revenue               $0.00        $613.65
supplySideRevenue  $3,617.28      $3,003.62
revenue/fees         0.0000         0.1696
```

`dailyVolume` and `dailyFees` are untouched — they already accumulate via `addUSDValue`. Both identities (`protocol + holders = revenue`, `revenue + supplySide = fees`) hold before *and* after, which is why this never tripped an income-statement check.

`tsc --project tsconfig.json` exits 0.

### Fix

Accumulate per pool with `addUSDValue`, matching what the BSC path in this same file already does. The declarations become `const`, so reassigning them can no longer compile.

Out of scope, flagged for visibility: pools on tiers missing from the ratio tables still contribute 0 revenue after this change. I haven't touched the tables because the on-chain `config.protocolFeeRate` is a flat 160000 (16%) on every tier and can't be reconciled with the hardcoded 18/19/9/9 + 15/15/23/23 split, so the correct values aren't derivable from a first-party source.
