### PR TITLE
jupiter-aggregator: count one row per swap, dex_solana.trades is per pool hop

### DIFF
--- a/aggregators/jupiter-aggregator/index.ts
+++ b/aggregators/jupiter-aggregator/index.ts
@@ -6,10 +6,22 @@ const DEX_TRADES_START = '2025-09-01'; //aggregator_swaps coverage incomplete fr
 
 const newQuery = (options: FetchOptions) => `
   SELECT COALESCE(SUM(amount_usd), 0) AS volume_24
-  FROM dex_solana.trades
-  WHERE block_time >= from_unixtime(${options.startTimestamp})
-    AND block_time <  from_unixtime(${options.endTimestamp})
-    AND trade_source = 'JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4'
+  FROM (
+    SELECT
+      amount_usd,
+      -- dex_solana.trades has one row per pool hop, so a multi-hop route would
+      -- otherwise be counted once per hop. One Jupiter swap is one outer
+      -- instruction, and a transaction can carry several of them.
+      ROW_NUMBER() OVER (
+        PARTITION BY tx_id, trader_id, outer_instruction_index
+        ORDER BY amount_usd DESC
+      ) AS rn
+    FROM dex_solana.trades
+    WHERE block_time >= from_unixtime(${options.startTimestamp})
+      AND block_time <  from_unixtime(${options.endTimestamp})
+      AND trade_source = 'JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4'
+  )
+  WHERE rn = 1
 `;
 
 const legacyQuery = (options: FetchOptions) => `


### PR DESCRIPTION
`dex_solana.trades` emits **one row per pool hop**, so summing `amount_usd` counts a multi-hop route once for every pool it touches.

### Measurement

For 2026-07-13, over exactly the rows this adapter selects (`trade_source = 'JUP6…'`):

| | |
|---|---|
| hop rows | 2,361,205 |
| distinct routes | 1,745,519 |
| routes spanning >1 hop | 489,284 |
| most hops in one route | 6 |
| **volume as summed today** | **$790,008,238** |
| **volume deduped per route** | **$602,013,540** |

That's 23.8% over-reported. Against the adapter's $21,350,343,621 of trailing-30d volume, roughly **$5.08B per 30 days**.

### Why the partition is `(tx_id, trader_id, outer_instruction_index)`

Deduping on the transaction alone would be wrong in the other direction. There were 1,745,519 routes across 1,690,834 distinct `(tx_id, trader_id)` pairs on that day, so ~55k transactions carry more than one genuinely separate Jupiter swap. One Jupiter swap is one outer instruction, so partitioning on the outer instruction keeps those distinct while still collapsing the hops within each route.

### Verification

Running the adapter for 2026-07-13:

```
before (production):  $790,004,665
after  (this change):  602.01 M
```

The "before" figure matches the raw Dune sum ($790,008,238) to 0.0005%, so the adapter's current output is exactly the un-deduped sum; the "after" matches the deduped figure ($602,013,540). `tsc --project tsconfig.json` exits 0.

Only the `dex_solana.trades` path is touched. Dates before 2025-09-01 use `jupiter_solana.aggregator_swaps`, which is already one row per swap and is left alone.

This is the same class as the recently merged fixes for rainbow-wallet (#8258) and binance-wallet (#8265).
