### PR TITLE
thalaswap-v3: don't count each 30-minute bucket twice

### DIFF
--- a/dexs/thalaswap-v3.ts
+++ b/dexs/thalaswap-v3.ts
@@ -27,16 +27,31 @@ interface IVolumeall {
   timestamp: string;
 }
 
+// The 1D endpoints return 30-minute buckets, but each datapoint is emitted twice —
+// once at :30 and again at the following :00 with the identical value — so summing
+// every bucket counts each hour of activity twice.
+const sumBuckets = (points: IVolumeall[]) => {
+  const sorted = [...points].sort((a, b) => Number(a.timestamp) - Number(b.timestamp));
+  return sorted.reduce((total: number, point: IVolumeall, i: number) => {
+    const previous = sorted[i - 1];
+    const isRepeat =
+      previous !== undefined &&
+      Number(point.timestamp) - Number(previous.timestamp) === 1800 &&
+      Number(point.value) === Number(previous.value);
+    return isRepeat ? total : total + Number(point.value);
+  }, 0);
+};
+
 const fetch = async (options: FetchOptions) => {
   const dayVolumeQuery = (await fetchURL(volumeEndpoint(options.toTimestamp, "1D")))?.data;
-  const dailyVolume = dayVolumeQuery.reduce((partialSum: number, a: IVolumeall) => partialSum + a.value, 0);
+  const dailyVolume = sumBuckets(dayVolumeQuery);
 
 
   const dayFeesQuery = (await fetchURL(feesEndpoint(options.toTimestamp, "1D")))?.data;
-  const dailyFees = dayFeesQuery.reduce((partialSum: number, a: IVolumeall) => partialSum + a.value, 0);
+  const dailyFees = sumBuckets(dayFeesQuery);
 
   const dayRevenueQuery = (await fetchURL(revenueEndpoint(options.toTimestamp, "1D")))?.data;
-  const dailyRevenue = dayRevenueQuery.reduce((partialSum: number, a: IVolumeall) => partialSum + a.value, 0);
+  const dailyRevenue = sumBuckets(dayRevenueQuery);
 
 
   return {


### PR DESCRIPTION
The `1D` endpoints return 48 half-hour buckets, but each datapoint is emitted **twice** — once at `:30` and again at the following `:00` with an identical value. The adapter sums every bucket, so each hour of activity is counted twice.

A sample of the raw response:

```
2026-07-18T15:30:00Z   612976.76
2026-07-18T16:00:00Z   612976.76   <- same value
2026-07-18T16:30:00Z   681830.58
2026-07-18T17:00:00Z   681830.58   <- same value
```

### It's consistent, not occasional

Sampling 7 days across 3 weeks, in every case 23 of the 24 `(:30, :00)` pairs are byte-identical, and all three series move together:

| endTimestamp | buckets | identical pairs | sum ÷ deduped |
|---|---|---|---|
| T-1d | 48 | 23/24 | 1.931 |
| T-2d | 48 | 23/24 | 1.973 |
| T-3d | 48 | 23/24 | 1.837 |
| T-5d | 48 | 23/24 | 1.896 |
| T-8d | 48 | 23/24 | 1.889 |
| T-13d | 48 | 23/24 | 1.921 |
| T-21d | 48 | 23/24 | 1.881 |

volume, fees and revenue return the same ratio as each other on each day (e.g. all three are exactly 1.837 on T-3d), so one fix covers all three.

### Independent cross-check

GeckoTerminal's on-chain aggregation for `thalaswap-cl` on Aptos reports **$17,059,704** of 24h volume. That is the complete pool set — it returns 8 pools with no second page, and their reserves total $1,737,107 against DefiLlama's own $1,735,026 TVL for this protocol, a 0.12% match.

Measured against that figure:

```
current (sum all 48 buckets)   1.83x
deduplicated                   0.95x
```

### Verification

`npx ts-node cli/testAdapter.ts dexs thalaswap-v3 2026-07-19`:

```
                        before      after
Daily volume            25.78 M    14.91 M
Daily fees               2.60 k     1.37 k
Daily revenue           781.00     438.00
Daily supply side rev    1.82 k    932.00
```

`tsc --project tsconfig.json` exits 0.

Against the reported trailing 30d ($751,539,525 volume, $76,924 fees, $23,046 revenue), roughly 47% of each is duplicated.

### Note on the approach

The dedupe drops a bucket only when it is exactly 1800s after the previous one *and* carries an identical value, rather than filtering on a fixed `:30`/`:00` phase. One `:00` bucket per day legitimately differs from its predecessor (the boundary bucket), and phase filtering would discard it. If you'd prefer the simpler phase filter I'm happy to switch — the two differ by under 4%.
