### PR TITLE
lists: add Polygon token config so uniswap-v2 stops reporting zero there

### DIFF
--- a/helpers/lists.ts
+++ b/helpers/lists.ts
@@ -177,6 +177,13 @@ const ChainConfigs: { [key: string]: ChainTokenConfig } = {
       'https://raw.githubusercontent.com/sushiswap/list/master/lists/token-lists/default-token-list/tokens/avalanche.json',
     ],
   },
+  [CHAIN.POLYGON]: {
+    chainId: 137,
+    tokenListUrls: [
+      'https://tokens.coingecko.com/polygon-pos/all.json',
+      'https://raw.githubusercontent.com/sushiswap/list/master/lists/token-lists/default-token-list/tokens/polygon.json',
+    ],
+  },
 };
 
 export async function getDefaultDexTokensWhitelisted({ chain }: { chain: string }): Promise<Array<string>> {


### PR DESCRIPTION
Uniswap V2 on Polygon has reported exactly **$0 on every day for the last 30 days** (last non-zero: 2026-05-31), while the deployment is still trading.

### Cause

`ChainConfigs` in `helpers/lists.ts` has entries for Ethereum, Arbitrum, BSC, Base and Avalanche, but none for Polygon. So:

```ts
export async function getDefaultDexTokensWhitelisted({ chain }) {
  if (ChainConfigs[chain]) { ... }
  return [];        // Polygon lands here
}
```

and `dexs/uniswap-v2.ts` bails out on the empty list before it queries anything:

```ts
const whitelistedTokens = (await getDefaultDexTokensWhitelisted({ chain: options.chain })).map(t => t.toLowerCase());
if (whitelistedTokens.length === 0) return emptyResult();
```

The ClickHouse path discovers pairs by requiring *both* tokens to be in that whitelist, so with an empty list there are no pairs, no swaps, and a clean $0 — no error and nothing in the logs.

Calling the helper directly confirms it, before this change:

```
ethereum   (list fetched)
polygon         0 tokens
bsc        (list fetched)
```

### The deployment is live

GeckoTerminal's on-chain aggregation for `uniswap-v2-polygon`:

```
60 pools    24h volume $1,463,190    reserves $29,734,344
```

against DefiLlama's $0 for the same day. At the adapter's own 0.3% rate that is roughly $4.4k/day of fees, ~$132k per 30 days, currently reported as nothing.

### Per-chain picture

Of the chains this adapter covers, four report all-zero. Polygon is the only material one:

| chain | 30d reported | independent 24h |
|---|---|---|
| Polygon | $0 (30/30 zero days) | $1,463,190 |
| Unichain | $0 | $83 |
| Blast | $0 | $42 |
| X Layer | $0 | — |

I've only added Polygon here; the others aren't worth a config entry at those volumes.

### Verification

After the change the helper returns 960 Polygon tokens, including the ones that form the main pairs:

```
polygon whitelist size: 960
   WMATIC  present
   USDC    present
   USDCe   present
   WETH    present
   USDT    present
   DAI     present
```

so the `whitelistedTokens.length === 0` gate no longer trips. Both list URLs return chainId-137 entries (coingecko 856, sushi 203). `tsc --project tsconfig.json` exits 0.

One thing I could not do locally: run the ClickHouse query end to end, since that needs `CLICKHOUSE_CONFIG`. I verified the gate that was returning early, not the resulting volume figure.

Note this helper is shared with pancakeswap-v2/v3, lifi, liquidmesh and sushiswap-agg. PancakeSwap has no Polygon deployment, and sushiswap-agg already reports Polygon normally, so the change should only affect the adapter that is currently returning zero.
