### PR TITLE
synfutures-v3: query the day being reported, not the one before it

### DIFF
--- a/fees/synfutures-v3/index.ts
+++ b/fees/synfutures-v3/index.ts
@@ -1,7 +1,6 @@
 import BigNumber from "bignumber.js";
 import { request, gql } from "graphql-request";
 import { CHAIN } from "../../helpers/chains";
-import { getTimestampAtStartOfDayUTC } from "../../utils/date";
 import { Adapter, FetchOptions } from "../../adapters/types";
 
 const endpoints = {
@@ -28,7 +27,9 @@ function convertDecimals(value: string | number, decimals: number) {
 }
 
 const fetch = async (options: FetchOptions) => {
-  const todaysTimestamp = getTimestampAtStartOfDayUTC(options.startTimestamp)
+  // startTimestamp is one second before midnight, so flooring it to a day lands on the
+  // previous day's bucket. startOfDay is already the midnight of the day being reported.
+  const todaysTimestamp = options.startOfDay
   const graphQuery = gql
     `{
       dailyQuoteDatas(where: {timestamp: "${todaysTimestamp}"}){


### PR DESCRIPTION
`options.startTimestamp` is one second before midnight, so flooring it to the start of a day lands on the **previous** day's subgraph bucket:

```
dateString      = 2026-07-18
startTimestamp  = 1784332799  = 2026-07-17T23:59:59Z
getTimestampAtStartOfDayUTC(startTimestamp) -> 1784246400 = 2026-07-17T00:00:00Z
```

So the record filed as 2026-07-18 contains 2026-07-17's fees. `options.startOfDay` is 1784332800 — the midnight of the day actually being reported.

### Demonstrated

Running the adapter for three consecutive dates, before and after:

| CLI date | before | after |
|---|---|---|
| 2026-07-19 | 7662 | 6467 |
| 2026-07-18 | 6894 | 7662 |
| 2026-07-17 | 6639 | 6894 |

Each before-value is the next after-value — an exact one-day shift, not an approximation.

The published series matches the before column (2026-07-17 → 6894, 2026-07-18 → 7662), confirming the live data carries the offset rather than it being a local artefact.

### Note on how I checked this

My first attempt reconstructed the timestamps by hand as `start = end - 86400`, which gives exact midnight and makes the current code look correct. That reconstruction was wrong — the framework passes `endTimestamp - 86401`. The values above come from logging `options` inside the adapter during a real run rather than from reasoning about what they should be.

### Scope

This is a dating defect, not a missing-value one: the 30-day total ($248,188) is roughly preserved, but every individual day is attributed to the wrong date, which affects any date-range query and any day-over-day comparison. Volume and open-interest for this protocol come from separate adapters and are untouched.

The `getTimestampAtStartOfDayUTC` import is removed because nothing else in the file uses it. `tsc --project tsconfig.json` reports no errors for this file.
