### PR TITLE
lista-dex: page through the market list instead of asking for 1000 at once

### DIFF
--- a/dexs/lista-dex/index.ts
+++ b/dexs/lista-dex/index.ts
@@ -34,8 +34,24 @@ interface SwapEventArgs {
     token1: string;
 }
 
-async function prefetch(_options: FetchOptions) {
-    return await getConfig('lsita-dex-marketList', `https://api.lista.org/api/moolah/borrow/marketList?page=1&pageSize=1000`);
+// The market list endpoint silently caps pageSize at 200, so a single request for 1000
+// returns only the first 200 of the markets it reports in `total`.
+const MARKET_PAGE_SIZE = 200;
+
+async function prefetch(_options: FetchOptions): Promise<any> {
+    const marketListUrl = (page: number) =>
+        `https://api.lista.org/api/moolah/borrow/marketList?page=${page}&pageSize=${MARKET_PAGE_SIZE}`;
+
+    const firstPage: MarketResponse = await getConfig('lsita-dex-marketList-1', marketListUrl(1));
+    const list = [...(firstPage.data?.list ?? [])];
+    const pageCount = Math.ceil((firstPage.data?.total ?? 0) / MARKET_PAGE_SIZE);
+
+    for (let page = 2; page <= pageCount; page++) {
+        const nextPage: MarketResponse = await getConfig(`lsita-dex-marketList-${page}`, marketListUrl(page));
+        list.push(...(nextPage.data?.list ?? []));
+    }
+
+    return { ...firstPage, data: { ...firstPage.data, list } };
 }
 
 const getSwapPools = async (options: FetchOptions): Promise<PoolInfo[]> => {


### PR DESCRIPTION
`prefetch` asks for `pageSize=1000`, but the endpoint caps it at 200:

```
pageSize=1000  -> returned  200 of total 368
pageSize= 500  -> returned  200 of total 368
pageSize= 200  -> returned  200 of total 368
pageSize= 100  -> returned  100 of total 368
```

Paging at 200 returns all 368 across two pages. So the adapter has been working from the first 200 markets only, with no error — `total` is simply ignored.

### What that hides

Smart-lending markets visible to the adapter versus what exists:

| chain | adapter sees | actual |
|---|---|---|
| BSC | 14 | 24 |
| Ethereum | 5 | 10 |

The adapter dedupes markets down to distinct swap pools, so the count that matters is pools:

| chain | pools seen | pools total | missed |
|---|---|---|---|
| BSC | 6 | 7 | 1 |
| Ethereum | 3 | 6 | 3 |

### The missed BSC pool is the material one

Counting `TokenExchange` events over the last 24h on each missed pool:

```
bsc       0x6783a05b98cb83c3f456197a035b9c17a9d57388   23,239 swaps   2,316,805 tokens sold
ethereum  0xa838d405c6e62b1e030abe802fa42b2eb307cb78        1 swap
ethereum  0xd46bfa2b03a8467d3fe1685d8d79eb195cb19675        1 swap
ethereum  0x56a475772fc0a63752bc16ddc7e2f7a38eb97f86        0 swaps
```

That BSC pool is USDT/U — `bsc:0x55d398326f99059ff775485246999027b3197955` at $0.9990 and `bsc:0xce24439f2d9c6a2289f741120fe202248b666666` at $0.9998, both 18 decimals — so roughly **$2.3M of swap volume per day** currently uncounted, against $296,741,609 reported over the last 30 days. The three Ethereum pools are effectively dormant and add nothing.

### Fix

Reads `total` and pages through at the size the endpoint actually honours, keeping the existing `getConfig` caching (one cache key per page). Everything downstream is unchanged — `getSwapPools` still filters on `isSmartLending` and dedupes by pool address.

I was not able to complete a full before/after adapter run: `testAdapter` for this adapter walks 24 hourly buckets and the public BSC RPC pool rate-limits partway through (`limit exceeded` across bsc-dataseed hosts) on both the patched and unpatched runs. The evidence above is measured directly against the API and on-chain instead. `tsc --project tsconfig.json` reports no errors for this file.
