### PR TITLE
Add ParitySwap V2 + V3 volume & fees (Robinhood Chain)

### DIFF
--- a/dexs/parityswap-v2.ts
+++ b/dexs/parityswap-v2.ts
@@ -4,7 +4,7 @@ import { uniV2Exports } from "../helpers/uniswap";
 // ParitySwap V2 is a Uniswap V2 fork on Robinhood Chain with the protocol fee
 // switch on: swappers pay the stock 0.30% fee, 1/6 of fees (0.05% of volume)
 // accrues to the protocol treasury via the standard feeTo mint, LPs keep 0.25%.
-export default uniV2Exports({
+const adapter = uniV2Exports({
   [CHAIN.ROBINHOOD]: {
     factory: '0xaA5f8c18EF9be81ffED30c223F9CD0D012a2AdB9',
     start: '2026-07-20',
@@ -14,14 +14,16 @@ export default uniV2Exports({
     holdersRevenueRatio: 0,
     allowReadPairs: true,
   },
-}, {
-  methodology: {
-    Volume: 'Swap volume from Swap events on all ParitySwap V2 pairs.',
-    Fees: 'Swap fees paid by traders: 0.30% of swap volume.',
-    UserFees: 'Same as Fees — all fees are paid by swappers.',
-    Revenue: 'Protocol treasury share: 1/6 of swap fees (0.05% of volume), accrued via the Uniswap V2 feeTo mechanism.',
-    ProtocolRevenue: 'Same as Revenue.',
-    SupplySideRevenue: 'LP share: 5/6 of swap fees (0.25% of volume).',
-    HoldersRevenue: 'No revenue to token holders.',
-  },
 })
+
+adapter.methodology = {
+  Volume: 'Swap volume from Swap events on all ParitySwap V2 pairs.',
+  Fees: 'Swap fees paid by traders: 0.30% of swap volume.',
+  UserFees: 'Same as Fees — all fees are paid by swappers.',
+  Revenue: 'Protocol treasury share: 1/6 of swap fees (0.05% of volume), accrued via the Uniswap V2 feeTo mechanism.',
+  ProtocolRevenue: 'Same as Revenue.',
+  SupplySideRevenue: 'LP share: 5/6 of swap fees (0.25% of volume).',
+  HoldersRevenue: 'No revenue to token holders.',
+}
+
+export default adapter

--- a/dexs/parityswap-v2.ts
+++ b/dexs/parityswap-v2.ts
@@ -1,0 +1,27 @@
+import { CHAIN } from "../helpers/chains";
+import { uniV2Exports } from "../helpers/uniswap";
+
+// ParitySwap V2 is a Uniswap V2 fork on Robinhood Chain with the protocol fee
+// switch on: swappers pay the stock 0.30% fee, 1/6 of fees (0.05% of volume)
+// accrues to the protocol treasury via the standard feeTo mint, LPs keep 0.25%.
+export default uniV2Exports({
+  [CHAIN.ROBINHOOD]: {
+    factory: '0xaA5f8c18EF9be81ffED30c223F9CD0D012a2AdB9',
+    start: '2026-07-20',
+    userFeesRatio: 1,
+    revenueRatio: 1 / 6,
+    protocolRevenueRatio: 1 / 6,
+    holdersRevenueRatio: 0,
+    allowReadPairs: true,
+  },
+}, {
+  methodology: {
+    Volume: 'Swap volume from Swap events on all ParitySwap V2 pairs.',
+    Fees: 'Swap fees paid by traders: 0.30% of swap volume.',
+    UserFees: 'Same as Fees — all fees are paid by swappers.',
+    Revenue: 'Protocol treasury share: 1/6 of swap fees (0.05% of volume), accrued via the Uniswap V2 feeTo mechanism.',
+    ProtocolRevenue: 'Same as Revenue.',
+    SupplySideRevenue: 'LP share: 5/6 of swap fees (0.25% of volume).',
+    HoldersRevenue: 'No revenue to token holders.',
+  },
+})

--- a/dexs/parityswap-v2.ts
+++ b/dexs/parityswap-v2.ts
@@ -26,4 +26,25 @@ adapter.methodology = {
   HoldersRevenue: 'No revenue to token holders.',
 }
 
+adapter.breakdownMethodology = {
+  Fees: {
+    'Token Swap Fees': 'Swap fees paid by traders: 0.30% of swap volume.',
+  },
+  UserFees: {
+    'Trading fees': 'Swap fees paid directly by traders.',
+  },
+  Revenue: {
+    'Protocol fees': 'Protocol treasury share: 1/6 of swap fees (0.05% of volume), accrued via the Uniswap V2 feeTo mechanism.',
+  },
+  ProtocolRevenue: {
+    'Protocol fees': 'Protocol treasury share: 1/6 of swap fees (0.05% of volume), accrued via the Uniswap V2 feeTo mechanism.',
+  },
+  SupplySideRevenue: {
+    'LP fees': 'LP share: 5/6 of swap fees (0.25% of volume) retained by liquidity providers.',
+  },
+  HoldersRevenue: {
+    'Tokenholder fees': 'No revenue to token holders.',
+  },
+}
+
 export default adapter

--- a/dexs/parityswap-v2.ts
+++ b/dexs/parityswap-v2.ts
@@ -4,6 +4,13 @@ import { uniV2Exports } from "../helpers/uniswap";
 // ParitySwap V2 is a Uniswap V2 fork on Robinhood Chain with the protocol fee
 // switch on: swappers pay the stock 0.30% fee, 1/6 of fees (0.05% of volume)
 // accrues to the protocol treasury via the standard feeTo mint, LPs keep 0.25%.
+//
+// Sources:
+// - Factory (Blockscout-verified; feeTo() returns the treasury, so the stock
+//   UniswapV2Pair._mintFee 1/6 split is active):
+//   https://robinhoodchain.blockscout.com/address/0xaA5f8c18EF9be81ffED30c223F9CD0D012a2AdB9?tab=contract
+// - 0.30% is the stock Uniswap V2 swap fee (997/1000 in the verified pair code).
+// - TVL adapter: https://github.com/DefiLlama/DefiLlama-Adapters/pull/20143
 const adapter = uniV2Exports({
   [CHAIN.ROBINHOOD]: {
     factory: '0xaA5f8c18EF9be81ffED30c223F9CD0D012a2AdB9',

--- a/dexs/parityswap-v3.ts
+++ b/dexs/parityswap-v3.ts
@@ -1,0 +1,26 @@
+import { CHAIN } from "../helpers/chains";
+import { uniV3Exports } from "../helpers/uniswap";
+
+// ParitySwap V3 is a Uniswap V3 fork on Robinhood Chain where every pool is
+// initialized with feeProtocol = 68: 25% of swap fees go to the protocol
+// (factory owner), 75% to LPs. Swappers pay the standard tier fee unchanged.
+export default uniV3Exports({
+  [CHAIN.ROBINHOOD]: {
+    factory: '0xd479E71C45aEB1E846A7B549c346D62fE77B39bA',
+    start: '2026-07-20',
+    userFeesRatio: 1,
+    revenueRatio: 0.25,
+    protocolRevenueRatio: 0.25,
+    holdersRevenueRatio: 0,
+  },
+}, {
+  methodology: {
+    Volume: 'Swap volume from Swap events on all ParitySwap V3 pools.',
+    Fees: 'Swap fees paid by traders at each pool\'s fee tier (0.05% / 0.30% / 1%).',
+    UserFees: 'Same as Fees — all fees are paid by swappers.',
+    Revenue: 'Protocol share: 25% of swap fees, set via feeProtocol at pool initialization and collected by the factory owner.',
+    ProtocolRevenue: 'Same as Revenue.',
+    SupplySideRevenue: 'LP share: 75% of swap fees.',
+    HoldersRevenue: 'No revenue to token holders.',
+  },
+})

--- a/dexs/parityswap-v3.ts
+++ b/dexs/parityswap-v3.ts
@@ -4,7 +4,7 @@ import { uniV3Exports } from "../helpers/uniswap";
 // ParitySwap V3 is a Uniswap V3 fork on Robinhood Chain where every pool is
 // initialized with feeProtocol = 68: 25% of swap fees go to the protocol
 // (factory owner), 75% to LPs. Swappers pay the standard tier fee unchanged.
-export default uniV3Exports({
+const adapter = uniV3Exports({
   [CHAIN.ROBINHOOD]: {
     factory: '0xd479E71C45aEB1E846A7B549c346D62fE77B39bA',
     start: '2026-07-20',
@@ -13,14 +13,37 @@ export default uniV3Exports({
     protocolRevenueRatio: 0.25,
     holdersRevenueRatio: 0,
   },
-}, {
-  methodology: {
-    Volume: 'Swap volume from Swap events on all ParitySwap V3 pools.',
-    Fees: 'Swap fees paid by traders at each pool\'s fee tier (0.05% / 0.30% / 1%).',
-    UserFees: 'Same as Fees — all fees are paid by swappers.',
-    Revenue: 'Protocol share: 25% of swap fees, set via feeProtocol at pool initialization and collected by the factory owner.',
-    ProtocolRevenue: 'Same as Revenue.',
-    SupplySideRevenue: 'LP share: 75% of swap fees.',
-    HoldersRevenue: 'No revenue to token holders.',
-  },
 })
+
+adapter.methodology = {
+  Volume: 'Swap volume from Swap events on all ParitySwap V3 pools.',
+  Fees: 'Swap fees paid by traders at each pool\'s fee tier (0.05% / 0.30% / 1%).',
+  UserFees: 'Same as Fees — all fees are paid by swappers.',
+  Revenue: 'Protocol share: 25% of swap fees, set via feeProtocol at pool initialization and collected by the factory owner.',
+  ProtocolRevenue: 'Same as Revenue.',
+  SupplySideRevenue: 'LP share: 75% of swap fees.',
+  HoldersRevenue: 'No revenue to token holders.',
+}
+
+adapter.breakdownMethodology = {
+  Fees: {
+    'Token Swap Fees': 'Swap fees paid by traders at each pool\'s fee tier (0.05% / 0.30% / 1%).',
+  },
+  UserFees: {
+    'Trading fees': 'Swap fees paid directly by traders.',
+  },
+  Revenue: {
+    'Protocol fees': 'Protocol share: 25% of swap fees (feeProtocol = 68, set at pool initialization), collected by the factory owner.',
+  },
+  ProtocolRevenue: {
+    'Protocol fees': 'Protocol share: 25% of swap fees (feeProtocol = 68, set at pool initialization), collected by the factory owner.',
+  },
+  SupplySideRevenue: {
+    'LP fees': 'LP share: 75% of swap fees retained by in-range liquidity providers.',
+  },
+  HoldersRevenue: {
+    'Tokenholder fees': 'No revenue to token holders.',
+  },
+}
+
+export default adapter

--- a/dexs/parityswap-v3.ts
+++ b/dexs/parityswap-v3.ts
@@ -4,6 +4,14 @@ import { uniV3Exports } from "../helpers/uniswap";
 // ParitySwap V3 is a Uniswap V3 fork on Robinhood Chain where every pool is
 // initialized with feeProtocol = 68: 25% of swap fees go to the protocol
 // (factory owner), 75% to LPs. Swappers pay the standard tier fee unchanged.
+//
+// Sources:
+// - Factory (Blockscout-verified; UniswapV3Pool.initialize hardcodes
+//   feeProtocol = 68 = 4 + (4 << 4), i.e. 1/4 of fees per direction = 25%):
+//   https://robinhoodchain.blockscout.com/address/0xd479E71C45aEB1E846A7B549c346D62fE77B39bA?tab=contract
+// - Observable live: slot0().feeProtocol == 68 on the WETH/USDG 0.30% pool:
+//   https://robinhoodchain.blockscout.com/address/0x12eEe2FAF5d447203fe371e564Bd884D8Aa3A679?tab=read_contract
+// - TVL adapter: https://github.com/DefiLlama/DefiLlama-Adapters/pull/20143
 const adapter = uniV3Exports({
   [CHAIN.ROBINHOOD]: {
     factory: '0xd479E71C45aEB1E846A7B549c346D62fE77B39bA',


### PR DESCRIPTION
Adds volume + fees adapters for **ParitySwap V2** and **ParitySwap V3** (Uniswap V2/V3 fork DEX on Robinhood Chain), using the standard `uniV2Exports` / `uniV3Exports` helpers.

TVL adapters: https://github.com/DefiLlama/DefiLlama-Adapters/pull/20143 (`parityswap-v2` / `parityswap-v3` — the V3 log adapter depends on the pool-log cache that adapter populates).

## Fee splits (contract-enforced)

- **V2:** stock 0.30% swap fee; **1/6 of fees (0.05% of volume) → protocol treasury** via the standard `feeTo` mint; 5/6 → LPs.
- **V3:** pool tier fee (500 / 3000 / 10000); **25% of fees → protocol** (`feeProtocol = 68`, hardcoded at pool initialization); 75% → LPs.

Ratios in the adapters: V2 `revenueRatio = 1/6`, V3 `revenueRatio = 0.25`, `userFeesRatio = 1`, `holdersRevenueRatio = 0` for both.

## Factories (Blockscout-verified: https://robinhoodchain.blockscout.com)

| Contract | Address | Deploy block |
|---|---|---|
| UniswapV2Factory | `0xaA5f8c18EF9be81ffED30c223F9CD0D012a2AdB9` | 14320587 |
| UniswapV3Factory | `0xd479E71C45aEB1E846A7B549c346D62fE77B39bA` | 14320075 |

Start date 2026-07-20 (deploy day).

Tested with `npm run test -- dexs parityswap-v2` and `npm run test -- dexs parityswap-v3` — both run clean; reported volume is near zero because the DEX launched on 2026-07-20.
