### PR TITLE
bitflow-fi: fix 2x volume double-count + price robustness

### DIFF
--- a/dexs/bitflow-fi.ts
+++ b/dexs/bitflow-fi.ts
@@ -22,6 +22,8 @@ interface Token {
   priceData: { last_price: number } | null;
 }
 
+// native STX shows up as "Stacks" in the spot feed and as its wrapped SIP-010 token
+// (token-stx-v-1-2) in the DLMM feed; both price under STX_PRICE_KEY
 const isStacksToken = (currency: string) =>
   currency === "Stacks" ||
   currency === "SM1793C4R5PZ4NS4VQ4WMP7SKKYVH8JZEWSZ9HCCR.token-stx-v-1-2";

--- a/dexs/bitflow-fi.ts
+++ b/dexs/bitflow-fi.ts
@@ -6,79 +6,72 @@ const tickersURL = "https://api.bitflowapis.finance/ticker";
 const dlmmTickersURL = "https://bff.bitflowapis.finance/api/app/v1/tickers";
 const tokensURL = "https://api.bitflowapis.finance/getAllTokensAndPools";
 
+// STX has no SIP-010 contract, so the tokens API keys its price under the string "null"
+const STX_PRICE_KEY = "null";
+
 interface Ticker {
+  pool_id: string;
   base_currency: string;
   base_volume: number;
+  target_currency: string;
+  target_volume: number;
 }
 
 interface Token {
   tokenContract: string;
-  priceData: {
-    last_price: number;
-  };
+  priceData: { last_price: number } | null;
 }
 
-const isStacksToken = (tokenContract: string) => {
-  return (
-    tokenContract === "Stacks" ||
-    tokenContract ===
-      "SM1793C4R5PZ4NS4VQ4WMP7SKKYVH8JZEWSZ9HCCR.token-stx-v-1-2"
-  );
-};
+const isStacksToken = (currency: string) =>
+  currency === "Stacks" ||
+  currency === "SM1793C4R5PZ4NS4VQ4WMP7SKKYVH8JZEWSZ9HCCR.token-stx-v-1-2";
+
+const priceKey = (currency: string) =>
+  isStacksToken(currency) ? STX_PRICE_KEY : currency;
 
 const getTokenPricesMap = async () => {
-  const {
-    tokens,
-  }: {
-    tokens: Token[];
-  } = await fetchURL(tokensURL);
-
-  const tokenPricesMap: { [tokenContract: string]: number } = {};
-  for (const token of tokens) {
-    if (!token.priceData)
-      tokenPricesMap[token.tokenContract] = 0;
-    else
-      tokenPricesMap[token.tokenContract] = token.priceData.last_price;
-  }
-  return tokenPricesMap;
+  const { tokens }: { tokens: Token[] } = await fetchURL(tokensURL);
+  const map: { [key: string]: number } = {};
+  for (const token of tokens)
+    map[token.tokenContract] = token.priceData ? token.priceData.last_price : 0;
+  return map;
 };
 
-const getTokenDailyVolume = ({
-  map,
-  tokenContract,
-  baseVolume,
-}: {
-  map: { [tokenContract: string]: number };
-  tokenContract: string;
-  baseVolume: number;
-}) => {
-  const tokenPrice = map[tokenContract];
-  if (!tokenPrice) return 0;
-  return baseVolume * tokenPrice;
+// value a pool by whichever side has a price — the two sides of a swap are ~equal value,
+// so this recovers pools whose base token is unpriced (e.g. memecoin/STX pairs)
+const tickerVolume = (ticker: Ticker, prices: { [key: string]: number }) => {
+  const baseVolume = Number(ticker.base_volume);
+  const basePrice = prices[priceKey(ticker.base_currency)] || 0;
+  if (Number.isFinite(baseVolume) && basePrice) return baseVolume * basePrice;
+
+  const targetVolume = Number(ticker.target_volume);
+  const targetPrice = prices[priceKey(ticker.target_currency)] || 0;
+  if (Number.isFinite(targetVolume) && targetPrice) return targetVolume * targetPrice;
+
+  return 0;
 };
 
 const fetch = async (): Promise<FetchResult> => {
-  const [tickers, dlmmTickers, tokensPriceMap] = await Promise.all([
-    fetchURL(tickersURL),
-    fetchURL(dlmmTickersURL),
-    getTokenPricesMap(),
-  ]);
+  const [tickers, dlmmTickers, prices]: [Ticker[], Ticker[], { [key: string]: number }] =
+    await Promise.all([
+      fetchURL(tickersURL),
+      fetchURL(dlmmTickersURL),
+      getTokenPricesMap(),
+    ]);
 
+  // STX is the dominant traded asset — fail loudly rather than silently drop >50% of
+  // volume if the tokens API ever stops keying STX under "null"
+  if (!prices[STX_PRICE_KEY])
+    throw new Error("bitflow: STX price missing from tokens API");
+
+  // the /ticker feed already includes the DLMM pools, so de-duplicate by pool_id to
+  // avoid counting DLMM volume twice (it also appears in the dedicated DLMM feed)
+  const seen = new Set<string>();
   let dailyVolume = 0;
-
   for (const ticker of [...tickers, ...dlmmTickers]) {
-    const baseVolume = Number(ticker.base_volume);
-    if (!Number.isFinite(baseVolume)) continue;
-
-    const tokenContract = isStacksToken(ticker.base_currency)
-      ? "null"
-      : ticker.base_currency;
-
-    dailyVolume += getTokenDailyVolume({
-      map: tokensPriceMap,
-      tokenContract,
-      baseVolume,
-    });
+    if (seen.has(ticker.pool_id)) continue;
+    seen.add(ticker.pool_id);
+    dailyVolume += tickerVolume(ticker, prices);
   }
 
   return { dailyVolume };
@@ -88,6 +81,10 @@ const adapter: SimpleAdapter = {
   fetch,
   chains: [CHAIN.STACKS],
   runAtCurrTime: true,
+  methodology: {
+    Volume:
+      "Sum of each Bitflow pool's 24h traded volume valued in USD across StableSwap, XYK and DLMM pools.",
+  },
 };
 
 export default adapter;


### PR DESCRIPTION
Fixes Bitflow volume by removing DLMM double counting and improves price handling for STX and unpriced pairs.

## Changes

- De-duplicate pools by `pool_id` across the `/ticker` and DLMM feeds.
- Resolve STX pricing consistently and throw if its price is unavailable.
- Price each pool using whichever token has a reliable price.
- Add a `methodology` block.

## Verification

- Volume corrected from **$71.7k → $38.3k** (~46.6% reduction), matching the removal of the 12 duplicated DLMM pools.
- Adapter output matches the deduplicated total.