### PR TITLE
[update] SparkDEX V3-1/V4: date-gated BBB fee split from 2026-05-18

### DIFF
--- a/factory/uniSubgraph.ts
+++ b/factory/uniSubgraph.ts
@@ -149,15 +149,25 @@ const configs: Record<string, SubgraphConfig> = {
       [CHAIN.FLARE]: "https://api.goldsky.com/api/public/project_cm1tgcbwdqg8b01un9jf4a64o/subgraphs/sparkdex-v3-2/latest/gn",
     },
     totalVolume: { factory: "factories", field: "totalVolumeUSD" },
+    // Static post-BBB split (factory cannot date-gate). Accurate pre/post history is in fees/sparkdex-v3-1.
     feesPercent: {
       type: "fees",
-      ProtocolRevenue: 0,
-      HoldersRevenue: 0,
+      Fees: 100,
       UserFees: 100,
-      SupplySideRevenue: 100,
-      Revenue: 0,
+      SupplySideRevenue: 75, // 75% to LPs (from 2026-05-18)
+      ProtocolRevenue: 0,
+      HoldersRevenue: 25, // 25% treasury → SPRK buyback-and-burn
+      Revenue: 25,
     },
     start: "2024-07-02",
+    methodology: {
+      Fees: "Swap fees paid by users on each trade.",
+      UserFees: "100% of collected fees.",
+      SupplySideRevenue: "75% of collected fees (87.5% before 2026-05-18; see fees/sparkdex-v3-1).",
+      ProtocolRevenue: "0% (2.5% before 2026-05-18; see fees/sparkdex-v3-1).",
+      HoldersRevenue: "25% of collected fees (5% buyback-and-burn + 5% staking rewards before 2026-05-18).",
+      Revenue: "25% of collected fees (12.5% before 2026-05-18; see fees/sparkdex-v3-1).",
+    },
   },
   // "kodiak-v3": {
   //   graphUrls: {
@@ -207,16 +217,25 @@ const configs: Record<string, SubgraphConfig> = {
     graphUrls: {
       [CHAIN.FLARE]: "https://api.goldsky.com/api/public/project_cm1tgcbwdqg8b01un9jf4a64o/subgraphs/sparkdex-v4/latest/gn",
     },
-    start: '2024-10-29',
+    start: "2026-01-26",
     totalVolume: { factory: "factories", field: "totalVolumeUSD" },
+    // Static post-BBB split (factory cannot date-gate). Accurate pre/post history is in fees/sparkdex-v4.
     feesPercent: {
       type: "fees",
-      UserFees: 100, // 100% of fees are paid by users
+      UserFees: 100,
       Fees: 100,
       SupplySideRevenue: 75, // 75% to LPs
-      ProtocolRevenue: 5, // 5% to protocol
-      HoldersRevenue: 20, // 20% to holders (10% buyback + 10% staking rewards)
-      Revenue: 25, // 25% to protocol (5% ProtocolRevenue + 20% HoldersRevenue)
+      ProtocolRevenue: 0,
+      HoldersRevenue: 25, // 25% treasury → SPRK buyback-and-burn
+      Revenue: 25,
+    },
+    methodology: {
+      Fees: "Swap fees paid by users on each trade.",
+      UserFees: "100% of collected fees.",
+      SupplySideRevenue: "75% of collected fees.",
+      ProtocolRevenue: "0% (5% before 2026-05-18; see fees/sparkdex-v4).",
+      HoldersRevenue: "25% of collected fees (10% buyback-and-burn + 10% staking rewards before 2026-05-18).",
+      Revenue: "25% of collected fees.",
     },
   },
   mojitoswap: {

--- a/fees/sparkdex-v3-1/index.ts
+++ b/fees/sparkdex-v3-1/index.ts
@@ -14,9 +14,17 @@ interface IFeeStat {
   feeUsd: string;
   id: string;
 }
-const CONTRACT_SPARK_TOKEN = '0x657097cC15fdEc9e383dB8628B57eA4a763F2ba0';
+
+const CONTRACT_SPARK_TOKEN = "0x657097cC15fdEc9e383dB8628B57eA4a763F2ba0";
 // staked token is xSpark
-const CONTRACT_XSPARK = '0xB5Dc569d06be81Eb222a00cEe810c42976981986';
+const CONTRACT_XSPARK = "0xB5Dc569d06be81Eb222a00cEe810c42976981986";
+
+/**
+ * Governance proposal B (passed 2026-05-17; effective 2026-05-18):
+ * 1/4 of swap fees → treasury → 100% SPRK buyback-and-burn.
+ * https://sparkdex.ai/governance/proposal/6a046cbecd38e8c7fea826ee
+ */
+const BBB_START = 1779062400; // 2026-05-18 UTC
 
 const fetch = async (options: FetchOptions) => {
   const todaysTimestamp = getTimestampAtStartOfDayUTC(options.toTimestamp);
@@ -40,26 +48,41 @@ const fetch = async (options: FetchOptions) => {
     dailyFeeUSD += BigInt(fee.feeUsd);
   });
 
+  const feesUsd = Number(dailyFeeUSD / 10n ** 18n);
   const dailyFees = options.createBalances();
-  dailyFees.addUSDValue(dailyFeeUSD / (10n ** 18n));
-  const dailySupplySideRevenue = dailyFees.clone(0.875)
-  const dailyProtocolRevenue = dailyFees.clone(0.025) // 2.5% treasury
-  const dailyHoldersRevenue = dailyFees.clone(0.1) // 5% buyback and burn + 5% for stakers
-  const dailyRevenue = options.createBalances();
+  dailyFees.addUSDValue(feesUsd, METRIC.SWAP_FEES);
 
-  // Protocol burns a percentage of SPRK tokens if they get unstaked before redemption period, we can track them using FinalizeRedeem event
+  const dailyProtocolRevenue = options.createBalances();
+  const dailyHoldersRevenue = options.createBalances();
+  let dailySupplySideRevenue;
+
+  if (todaysTimestamp >= BBB_START) {
+    // 75% LP / 25% treasury BBB / 0% protocol
+    dailySupplySideRevenue = dailyFees.clone(0.75, METRIC.LP_FEES);
+    dailyHoldersRevenue.addUSDValue(feesUsd * 0.25, METRIC.TOKEN_BUY_BACK);
+  } else {
+    // Historical: 87.5% LP / 2.5% Foundation / 5% BBB / 5% staking
+    dailySupplySideRevenue = dailyFees.clone(0.875, METRIC.LP_FEES);
+    dailyProtocolRevenue.addUSDValue(feesUsd * 0.025, METRIC.SWAP_FEES);
+    dailyHoldersRevenue.addUSDValue(feesUsd * 0.05, METRIC.TOKEN_BUY_BACK);
+    dailyHoldersRevenue.addUSDValue(feesUsd * 0.05, METRIC.STAKING_REWARDS);
+  }
+
+  // Protocol burns a percentage of SPRK tokens if they get unstaked before redemption period
   const redeemLogs = await options.getLogs({
     target: CONTRACT_XSPARK,
-    eventAbi: 'event FinalizeRedeem(address indexed userAddress, uint256 xSPRKAmount, uint256 sprkAmount)',
+    eventAbi:
+      "event FinalizeRedeem(address indexed userAddress, uint256 xSPRKAmount, uint256 sprkAmount)",
   });
   redeemLogs.forEach((log: any) => {
     const burned = BigInt(log.xSPRKAmount) - BigInt(log.sprkAmount);
     if (burned > 0) {
-      dailyHoldersRevenue.add(CONTRACT_SPARK_TOKEN, burned);
-      dailyFees.add(CONTRACT_SPARK_TOKEN, burned)
+      dailyHoldersRevenue.add(CONTRACT_SPARK_TOKEN, burned, "Early Redemption Penalty");
+      dailyFees.add(CONTRACT_SPARK_TOKEN, burned, "Early Redemption Penalty");
     }
   });
 
+  const dailyRevenue = options.createBalances();
   dailyRevenue.addBalances(dailyProtocolRevenue);
   dailyRevenue.addBalances(dailyHoldersRevenue);
 
@@ -77,32 +100,37 @@ const adapter: Adapter = {
   version: 1,
   fetch,
   chains: [CHAIN.FLARE],
-  start: '2024-07-02',
+  start: "2024-07-02",
   methodology: {
-    Fees: "Swap fees paid by platform users.",
-    Revenue: "Swap Fees collected by SparkDEX Foundation or used for token buybacks or distributed to stakers + Early Staking redemption penalty burns",
-    ProtocolRevenue: "Swap Fees share collected by SparkDEX Foundation.",
-    SupplySideRevenue: "Swap Fees distributed to Liquidity Providers.",
-    HoldersRevenue: "Revenue used for buy back SPRK tokens + Early Staking redemption penalty burns",
+    Fees: "Swap fees paid by platform users + Early Staking redemption penalty burns.",
+    Revenue:
+      "Before 2026-05-18: 12.5% of swap fees. From 2026-05-18: 25% of swap fees. Plus Early Staking redemption penalty burns.",
+    ProtocolRevenue: "Before 2026-05-18: 2.5% of swap fees. From 2026-05-18: 0%.",
+    SupplySideRevenue: "Before 2026-05-18: 87.5% of swap fees. From 2026-05-18: 75% of swap fees.",
+    HoldersRevenue:
+      "Before 2026-05-18: 5% buyback-and-burn + 5% staking rewards. From 2026-05-18: 25% buyback-and-burn. Plus Early Staking redemption penalty burns.",
   },
   breakdownMethodology: {
     Fees: {
-      [METRIC.SWAP_FEES]: 'All Swap fees paid by platform users.',
+      [METRIC.SWAP_FEES]: "All swap fees paid by platform users.",
+      "Early Redemption Penalty": "Early Staking redemption penalty burns.",
     },
     Revenue: {
-      [METRIC.SWAP_FEES]: '12.5% of Swap Fees are considered as revenue',
-      'Early Redemption Penalty': 'Early Staking redemption penalty burns.',
+      [METRIC.SWAP_FEES]: "2.5% of swap fees (before 2026-05-18 only).",
+      [METRIC.TOKEN_BUY_BACK]: "5% of swap fees before 2026-05-18, 25% from 2026-05-18.",
+      [METRIC.STAKING_REWARDS]: "5% of swap fees (before 2026-05-18 only).",
+      "Early Redemption Penalty": "Early Staking redemption penalty burns.",
     },
     HoldersRevenue: {
-      [METRIC.TOKEN_BUY_BACK]: '5% of Swap Fees are used for token buybacks ',
-      [METRIC.STAKING_REWARDS]: '5% of Swap Fees distributed to stakers.',
-      'Early Redemption Penalty': 'Early Staking redemption penalty burns.',
+      [METRIC.TOKEN_BUY_BACK]: "5% of swap fees before 2026-05-18, 25% from 2026-05-18.",
+      [METRIC.STAKING_REWARDS]: "5% of swap fees (before 2026-05-18 only).",
+      "Early Redemption Penalty": "Early Staking redemption penalty burns.",
     },
     SupplySideRevenue: {
-      [METRIC.LP_FEES]: '87.5% of Swap Fees distributed to Liquidity Providers',
+      [METRIC.LP_FEES]: "87.5% of swap fees before 2026-05-18, 75% from 2026-05-18.",
     },
     ProtocolRevenue: {
-      [METRIC.SWAP_FEES]: '2.5% of Swap Fees share collected by SparkDEX Foundation.',
+      [METRIC.SWAP_FEES]: "2.5% of swap fees (before 2026-05-18 only).",
     },
   },
 };

--- a/fees/sparkdex-v3-1/index.ts
+++ b/fees/sparkdex-v3-1/index.ts
@@ -2,6 +2,7 @@ import { gql, request } from "graphql-request";
 import { Adapter, FetchOptions } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 import { METRIC } from "../../helpers/metrics";
+import { BBB_START } from "../../helpers/sparkdex";
 import { getTimestampAtStartOfDayUTC } from "../../utils/date";
 
 const endpoints = {
@@ -18,13 +19,6 @@ interface IFeeStat {
 const CONTRACT_SPARK_TOKEN = "0x657097cC15fdEc9e383dB8628B57eA4a763F2ba0";
 // staked token is xSpark
 const CONTRACT_XSPARK = "0xB5Dc569d06be81Eb222a00cEe810c42976981986";
-
-/**
- * Governance proposal B (passed 2026-05-17; effective 2026-05-18):
- * 1/4 of swap fees → treasury → 100% SPRK buyback-and-burn.
- * https://sparkdex.ai/governance/proposal/6a046cbecd38e8c7fea826ee
- */
-const BBB_START = 1779062400; // 2026-05-18 UTC
 
 const fetch = async (options: FetchOptions) => {
   const todaysTimestamp = getTimestampAtStartOfDayUTC(options.toTimestamp);

--- a/fees/sparkdex-v4/index.ts
+++ b/fees/sparkdex-v4/index.ts
@@ -2,6 +2,7 @@ import { gql, request } from "graphql-request";
 import { Adapter, FetchOptions } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 import { METRIC } from "../../helpers/metrics";
+import { BBB_START } from "../../helpers/sparkdex";
 import { getTimestampAtStartOfDayUTC } from "../../utils/date";
 
 const endpoints = {
@@ -9,15 +10,8 @@ const endpoints = {
     "https://api.goldsky.com/api/public/project_cm1tgcbwdqg8b01un9jf4a64o/subgraphs/sparkdex-v4/latest/gn",
 };
 
-/**
- * Governance proposal B (passed 2026-05-17; effective 2026-05-18):
- * 1/4 of swap fees → treasury → 100% SPRK buyback-and-burn.
- * https://sparkdex.ai/governance/proposal/6a046cbecd38e8c7fea826ee
- */
-const BBB_START = 1779062400; // 2026-05-18 UTC
-
 const fetch = async (options: FetchOptions) => {
-  const todaysTimestamp = getTimestampAtStartOfDayUTC(options.startOfDay);
+  const todaysTimestamp = getTimestampAtStartOfDayUTC(options.startTimestamp);
   const dateId = Math.floor(todaysTimestamp / 86400);
 
   const graphQuery = gql`
@@ -71,6 +65,8 @@ const adapter: Adapter = {
   fetch,
   chains: [CHAIN.FLARE],
   start: "2026-01-26",
+  // algebraDayData only exposes daily aggregates; hourly pull is unsupported
+  pullHourly: false,
   methodology: {
     Fees: "Swap fees paid by platform users on SparkDEX V4.",
     UserFees: "100% of collected fees.",

--- a/fees/sparkdex-v4/index.ts
+++ b/fees/sparkdex-v4/index.ts
@@ -1,0 +1,108 @@
+import { gql, request } from "graphql-request";
+import { Adapter, FetchOptions } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import { METRIC } from "../../helpers/metrics";
+import { getTimestampAtStartOfDayUTC } from "../../utils/date";
+
+const endpoints = {
+  [CHAIN.FLARE]:
+    "https://api.goldsky.com/api/public/project_cm1tgcbwdqg8b01un9jf4a64o/subgraphs/sparkdex-v4/latest/gn",
+};
+
+/**
+ * Governance proposal B (passed 2026-05-17; effective 2026-05-18):
+ * 1/4 of swap fees → treasury → 100% SPRK buyback-and-burn.
+ * https://sparkdex.ai/governance/proposal/6a046cbecd38e8c7fea826ee
+ */
+const BBB_START = 1779062400; // 2026-05-18 UTC
+
+const fetch = async (options: FetchOptions) => {
+  const todaysTimestamp = getTimestampAtStartOfDayUTC(options.startOfDay);
+  const dateId = Math.floor(todaysTimestamp / 86400);
+
+  const graphQuery = gql`
+    query {
+      algebraDayData(id: ${dateId}) {
+        id
+        feesUSD
+      }
+    }
+  `;
+
+  const graphRes = await request(endpoints[options.chain], graphQuery);
+  const feesUsd = Number(graphRes.algebraDayData?.feesUSD ?? 0);
+
+  const dailyFees = options.createBalances();
+  dailyFees.addUSDValue(feesUsd, METRIC.SWAP_FEES);
+
+  const dailyUserFees = dailyFees.clone(1, METRIC.SWAP_FEES);
+  const dailyProtocolRevenue = options.createBalances();
+  const dailyHoldersRevenue = options.createBalances();
+  let dailySupplySideRevenue;
+
+  if (todaysTimestamp >= BBB_START) {
+    // 75% LP / 25% treasury BBB / 0% protocol
+    dailySupplySideRevenue = dailyFees.clone(0.75, METRIC.LP_FEES);
+    dailyHoldersRevenue.addUSDValue(feesUsd * 0.25, METRIC.TOKEN_BUY_BACK);
+  } else {
+    // Historical: 75% LP / 5% Foundation / 10% BBB / 10% staking
+    dailySupplySideRevenue = dailyFees.clone(0.75, METRIC.LP_FEES);
+    dailyProtocolRevenue.addUSDValue(feesUsd * 0.05, METRIC.SWAP_FEES);
+    dailyHoldersRevenue.addUSDValue(feesUsd * 0.1, METRIC.TOKEN_BUY_BACK);
+    dailyHoldersRevenue.addUSDValue(feesUsd * 0.1, METRIC.STAKING_REWARDS);
+  }
+
+  const dailyRevenue = options.createBalances();
+  dailyRevenue.addBalances(dailyProtocolRevenue);
+  dailyRevenue.addBalances(dailyHoldersRevenue);
+
+  return {
+    dailyFees,
+    dailyUserFees,
+    dailyRevenue,
+    dailyProtocolRevenue,
+    dailyHoldersRevenue,
+    dailySupplySideRevenue,
+  };
+};
+
+const adapter: Adapter = {
+  version: 2,
+  fetch,
+  chains: [CHAIN.FLARE],
+  start: "2026-01-26",
+  methodology: {
+    Fees: "Swap fees paid by platform users on SparkDEX V4.",
+    UserFees: "100% of collected fees.",
+    Revenue: "25% of swap fees.",
+    ProtocolRevenue: "Before 2026-05-18: 5% of swap fees. From 2026-05-18: 0%.",
+    SupplySideRevenue: "75% of swap fees.",
+    HoldersRevenue:
+      "Before 2026-05-18: 10% buyback-and-burn + 10% staking rewards. From 2026-05-18: 25% buyback-and-burn.",
+  },
+  breakdownMethodology: {
+    Fees: {
+      [METRIC.SWAP_FEES]: "All swap fees paid by platform users.",
+    },
+    UserFees: {
+      [METRIC.SWAP_FEES]: "100% of collected fees.",
+    },
+    Revenue: {
+      [METRIC.SWAP_FEES]: "5% of swap fees (before 2026-05-18 only).",
+      [METRIC.TOKEN_BUY_BACK]: "10% of swap fees before 2026-05-18, 25% from 2026-05-18.",
+      [METRIC.STAKING_REWARDS]: "10% of swap fees (before 2026-05-18 only).",
+    },
+    HoldersRevenue: {
+      [METRIC.TOKEN_BUY_BACK]: "10% of swap fees before 2026-05-18, 25% from 2026-05-18.",
+      [METRIC.STAKING_REWARDS]: "10% of swap fees (before 2026-05-18 only).",
+    },
+    SupplySideRevenue: {
+      [METRIC.LP_FEES]: "75% of swap fees.",
+    },
+    ProtocolRevenue: {
+      [METRIC.SWAP_FEES]: "5% of swap fees (before 2026-05-18 only).",
+    },
+  },
+};
+
+export default adapter;

--- a/helpers/sparkdex.ts
+++ b/helpers/sparkdex.ts
@@ -1,0 +1,6 @@
+/**
+ * Governance proposal B (passed 2026-05-17; effective 2026-05-18):
+ * 1/4 of swap fees → treasury → 100% SPRK buyback-and-burn.
+ * https://sparkdex.ai/governance/proposal/6a046cbecd38e8c7fea826ee
+ */
+export const BBB_START = 1779062400; // 2026-05-18 UTC


### PR DESCRIPTION
## Summary
- Update SparkDEX V3-1 and V4 fee revenue attribution after governance proposal B (effective **2026-05-18**): **25%** of swap fees go to treasury for SPRK buyback-and-burn; **75%** to LPs; **0%** protocol revenue.
- Add `fees/sparkdex-v4` (factory cannot date-gate fee percentages; V3-1 already keeps a custom fees adapter).
- Align `factory/uniSubgraph.ts` static `feesPercent` with the post-BBB split (DEX volume surface).

Proposal: https://sparkdex.ai/governance/proposal/6a046cbecd38e8c7fea826ee

## Fee split

| Protocol | Period | LP | Protocol | Holders |
|---|---|---:|---:|---|
| V3-1 | before 2026-05-18 | 87.5% | 2.5% | 5% buyback + 5% staking |
| V3-1 | from 2026-05-18 | 75% | 0% | 25% buyback |
| V4 | before 2026-05-18 | 75% | 5% | 10% buyback + 10% staking |
| V4 | from 2026-05-18 | 75% | 0% | 25% buyback |

## Files
- `fees/sparkdex-v3-1/index.ts` — date-gated split + early-redemption burns unchanged
- `fees/sparkdex-v4/index.ts` — new fees adapter (`algebraDayData`)
- `factory/uniSubgraph.ts` — post-BBB static ratios + methodology

## Notes
- Accurate pre/post history lives in the fees adapters; `uniSubgraph` uses the current (post-BBB) static percentages because factory configs cannot switch by date.
- Perps BBB changes are **not** included (separate PR/branch).

## Test plan
- [ ] `fees/sparkdex-v3-1` for 2026-05-17 → 87.5 / 2.5 / 10
- [ ] `fees/sparkdex-v3-1` for 2026-05-18 → 75 / 0 / 25 (buyback)
- [ ] `fees/sparkdex-v4` for 2026-05-17 → 75 / 5 / 20
- [ ] `fees/sparkdex-v4` for 2026-05-18 → 75 / 0 / 25 (buyback)
- [ ] Confirm factory `sparkdex-v3-1` / `sparkdex-v4` still resolve for dexs volume

---
**NOTE**: Please enable "Allow edits by maintainers".