### PR TITLE
Add SwapHood volume and fee adapters

### DIFF
--- a/dexs/swaphood/index.ts
+++ b/dexs/swaphood/index.ts
@@ -1,0 +1,70 @@
+import {
+  FetchOptions,
+  FetchResponseValue,
+  FetchResult,
+  FetchV2,
+  SimpleAdapter,
+} from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import swaphoodV2 from "./swaphood";
+import swaphoodV3 from "./swaphood-v3";
+
+function requireFetch(
+  adapter: SimpleAdapter,
+  version: string,
+): FetchV2 {
+  if (adapter.fetch) return adapter.fetch;
+
+  const chainFetch = adapter.adapter?.[CHAIN.ROBINHOOD]?.fetch;
+
+  if (chainFetch) return chainFetch;
+
+  throw new Error(`Missing SwapHood ${version} fetch function`);
+}
+
+const fetchV2 = requireFetch(swaphoodV2, "V2");
+const fetchV3 = requireFetch(swaphoodV3, "V3");
+
+function addResponseValue(
+  balances: ReturnType<FetchOptions["createBalances"]>,
+  value: FetchResponseValue | undefined,
+): void {
+  if (value === undefined) return;
+
+  if (typeof value === "string" || typeof value === "number") {
+    balances.addUSDValue(value);
+    return;
+  }
+
+  balances.addBalances(value);
+}
+
+const fetch = async (
+  options: FetchOptions,
+): Promise<FetchResult> => {
+  const [v2Stats, v3Stats] = await Promise.all([
+    fetchV2(options),
+    fetchV3(options),
+  ]);
+
+  const dailyVolume = options.createBalances();
+
+  addResponseValue(dailyVolume, v2Stats.dailyVolume);
+  addResponseValue(dailyVolume, v3Stats.dailyVolume);
+
+  return { dailyVolume };
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  pullHourly: true,
+  fetch,
+  chains: [CHAIN.ROBINHOOD],
+  start: "2026-07-10",
+  methodology: {
+    Volume:
+      "Combined swap volume from SwapHood V2 pairs and SwapHood V3 pools on Robinhood Chain.",
+  },
+};
+
+export default adapter;

--- a/dexs/swaphood/swaphood-v3.ts
+++ b/dexs/swaphood/swaphood-v3.ts
@@ -1,0 +1,23 @@
+import { SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import { uniV3Exports } from "../../helpers/uniswap";
+
+const FACTORY = "0x0Ec554F0BfF0Be6C99d1e95C8015bb0950f6A2C7";
+const START = "2026-07-10";
+
+const adapter: SimpleAdapter = uniV3Exports(
+  {
+    [CHAIN.ROBINHOOD]: {
+      factory: FACTORY,
+      start: START,
+    },
+  },
+  {
+    methodology: {
+      Volume:
+        "Swap volume from SwapHood V3 pools on Robinhood Chain, calculated from PancakeSwap V3-compatible Swap events.",
+    },
+  },
+);
+
+export default adapter;

--- a/dexs/swaphood/swaphood.ts
+++ b/dexs/swaphood/swaphood.ts
@@ -1,0 +1,33 @@
+import {
+  FetchResult,
+  SimpleAdapter,
+} from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import { uniV2Exports } from "../../helpers/uniswap";
+
+const FACTORY = "0xE7206Ecac3A51afe7e6179182ad4130A26068dD1";
+const START = "2026-07-10";
+
+const rootOptions = {
+  pullHourly: true,
+  methodology: {
+    Volume:
+      "Swap volume from SwapHood V2 pairs on Robinhood Chain. Pairs are TVL-filtered before their Swap logs are queried.",
+  },
+};
+
+const adapter: SimpleAdapter = uniV2Exports(
+  {
+    [CHAIN.ROBINHOOD]: {
+      factory: FACTORY,
+      start: START,
+      allowReadPairs: true,
+      customLogic: ({ dailyVolume }: FetchResult) => ({
+        dailyVolume,
+      }),
+    },
+  },
+  rootOptions,
+);
+
+export default adapter;

--- a/fees/swaphood/index.ts
+++ b/fees/swaphood/index.ts
@@ -1,0 +1,151 @@
+import {
+  FetchOptions,
+  FetchResponseValue,
+  FetchResult,
+  FetchV2,
+  SimpleAdapter,
+} from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import swaphoodV2Adapter, { START as V2_START } from "./swaphood";
+import swaphoodV2 from "./swaphood";
+import swaphoodV3 from "./swaphood-v3";
+
+const METRIC = {
+  SWAP_FEES: "Token Swap Fees",
+  PROTOCOL_REVENUE: "Swap Fees Retained By Protocol",
+  V2_HOLDERS_REVENUE: "Swap Fees Distributed To Holders",
+  V3_HOLDERS_REVENUE: "Swap Fees Used For HOOD Buybacks",
+  HOOD_BUYBACKS: "HOOD Buybacks",
+  LP_REVENUE: "Swap Fees To Liquidity Providers",
+};
+
+function requireFetch(
+  adapter: SimpleAdapter,
+  version: string,
+): FetchV2 {
+  if (!adapter.fetch) {
+    throw new Error(`Missing SwapHood ${version} fetch function`);
+  }
+
+  return adapter.fetch;
+}
+
+const fetchV2 = requireFetch(swaphoodV2, "V2");
+const fetchV3 = requireFetch(swaphoodV3, "V3");
+
+function addResponseValue(
+  balances: ReturnType<FetchOptions["createBalances"]>,
+  value: FetchResponseValue | undefined,
+): void {
+  if (value === undefined) return;
+
+  if (typeof value === "string" || typeof value === "number") {
+    balances.addUSDValue(value);
+    return;
+  }
+
+  balances.addBalances(value);
+}
+
+const fetch = async (
+  options: FetchOptions,
+): Promise<FetchResult> => {
+  const [v2Stats, v3Stats] = await Promise.all([
+    fetchV2(options),
+    fetchV3(options),
+  ]);
+
+  const dailyFees = options.createBalances();
+  const dailyUserFees = options.createBalances();
+  const dailyRevenue = options.createBalances();
+  const dailyProtocolRevenue = options.createBalances();
+  const dailyHoldersRevenue = options.createBalances();
+  const dailySupplySideRevenue = options.createBalances();
+
+  for (const stats of [v2Stats, v3Stats]) {
+    addResponseValue(dailyFees, stats.dailyFees);
+    addResponseValue(dailyUserFees, stats.dailyUserFees);
+    addResponseValue(dailyRevenue, stats.dailyRevenue);
+    addResponseValue(
+      dailyProtocolRevenue,
+      stats.dailyProtocolRevenue,
+    );
+    addResponseValue(
+      dailyHoldersRevenue,
+      stats.dailyHoldersRevenue,
+    );
+    addResponseValue(
+      dailySupplySideRevenue,
+      stats.dailySupplySideRevenue,
+    );
+  }
+
+  return {
+    dailyFees,
+    dailyUserFees,
+    dailyRevenue,
+    dailyProtocolRevenue,
+    dailyHoldersRevenue,
+    dailySupplySideRevenue,
+  };
+};
+
+const methodology = {
+  Fees:
+    "All swap fees paid by users across SwapHood V2 pairs and V3 pools.",
+  UserFees:
+    "All swap fees paid directly by SwapHood V2 and V3 users.",
+  Revenue:
+    "For staked V2 pairs, 95% of fees goes to holders and 5% to the protocol. Non-staked V2 fees go to LPs. SwapHood V3 allocates 95% of fees to HOOD buybacks and retains 5% as protocol revenue.",
+  ProtocolRevenue:
+    "5% of fees from staked V2 pairs and 5% of V3 fees is retained by the protocol.",
+  HoldersRevenue:
+    "95% of fees from staked V2 pairs is distributed to holders, while 95% of V3 fees funds HOOD buybacks.",
+  SupplySideRevenue:
+    "Non-staked V2 pair fees go entirely to liquidity providers. V3 liquidity providers receive no swap-fee revenue.",
+};
+
+const breakdownMethodology = {
+  Fees: {
+    [METRIC.SWAP_FEES]:
+      "All swap fees paid by SwapHood V2 and V3 users.",
+  },
+  UserFees: {
+    [METRIC.SWAP_FEES]:
+      "All swap fees paid directly by SwapHood V2 and V3 users.",
+  },
+  Revenue: {
+    [METRIC.PROTOCOL_REVENUE]:
+      "The protocol share of staked V2 pair fees and V3 fees.",
+    [METRIC.V2_HOLDERS_REVENUE]:
+      "The holders share of fees from staked V2 pairs.",
+    [METRIC.V3_HOLDERS_REVENUE]:
+      "The share of V3 fees allocated to HOOD buybacks.",
+  },
+  ProtocolRevenue: {
+    [METRIC.PROTOCOL_REVENUE]:
+      "5% of fees from staked V2 pairs and 5% of V3 fees.",
+  },
+  HoldersRevenue: {
+    [METRIC.V2_HOLDERS_REVENUE]:
+      "95% of fees from staked V2 pairs distributed to holders.",
+    [METRIC.HOOD_BUYBACKS]:
+      "95% of V3 fees allocated to HOOD buybacks.",
+  },
+  SupplySideRevenue: {
+    [METRIC.LP_REVENUE]:
+      "100% of fees from non-staked V2 pairs distributed to liquidity providers.",
+  },
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  pullHourly: true,
+  fetch,
+  chains: [CHAIN.ROBINHOOD],
+  start: V2_START,
+  methodology,
+  breakdownMethodology,
+};
+
+export default adapter;

--- a/fees/swaphood/swaphood-v3.ts
+++ b/fees/swaphood/swaphood-v3.ts
@@ -1,0 +1,161 @@
+import {
+  FetchOptions,
+  FetchResult,
+  SimpleAdapter,
+} from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import { getUniV3LogAdapter } from "../../helpers/uniswap";
+
+const FACTORY = "0x0Ec554F0BfF0Be6C99d1e95C8015bb0950f6A2C7";
+const START = "2026-07-10";
+
+const METRIC = {
+  SWAP_FEES: "Token Swap Fees",
+  PROTOCOL_REVENUE: "Swap Fees Retained By Protocol",
+  HOLDERS_REVENUE: "Swap Fees Used For HOOD Buybacks",
+  LP_REVENUE: "Swap Fees To Liquidity Providers",
+  HOOD_BUYBACKS: "HOOD Buybacks",
+};
+
+const fetchPancakeV3Fork = getUniV3LogAdapter({
+  factory: FACTORY,
+  userFeesRatio: 1,
+
+  // Project-confirmed policy: SwapHood retains 5% of V3 swap fees and routes
+  // 95% to HOOD buybacks for holders. Verified fee-collector deployment:
+  // https://robinhoodchain.blockscout.com/address/0x626a38d441620a6c6f151dc97309417165f86f3c?tab=contract
+  getRevenueRatio: () => ({
+    _revenueRatio: 1,
+    _protocolRevenueRatio: 0.05,
+    _holdersRevenueRatio: 0.95,
+  }),
+});
+
+const fetch = async (
+  options: FetchOptions,
+): Promise<FetchResult> => {
+  const stats = await fetchPancakeV3Fork(options);
+
+  const dailyFees = options.createBalances();
+  const dailyUserFees = options.createBalances();
+  const dailyRevenue = options.createBalances();
+  const dailyProtocolRevenue = options.createBalances();
+  const dailyHoldersRevenue = options.createBalances();
+  const dailySupplySideRevenue = options.createBalances();
+
+  dailyFees.addBalances(
+    stats.dailyFees.clone(1, METRIC.SWAP_FEES),
+  );
+
+  if (stats.dailyUserFees) {
+    dailyUserFees.addBalances(
+      stats.dailyUserFees.clone(1, METRIC.SWAP_FEES),
+    );
+  }
+
+  if (stats.dailyProtocolRevenue) {
+    dailyProtocolRevenue.addBalances(
+      stats.dailyProtocolRevenue.clone(
+        1,
+        METRIC.PROTOCOL_REVENUE,
+      ),
+    );
+
+    dailyRevenue.addBalances(
+      stats.dailyProtocolRevenue.clone(
+        1,
+        METRIC.PROTOCOL_REVENUE,
+      ),
+    );
+  }
+
+  if (stats.dailyHoldersRevenue) {
+    dailyHoldersRevenue.addBalances(
+      stats.dailyHoldersRevenue.clone(
+        1,
+        METRIC.HOOD_BUYBACKS,
+      ),
+    );
+
+    dailyRevenue.addBalances(
+      stats.dailyHoldersRevenue.clone(
+        1,
+        METRIC.HOLDERS_REVENUE,
+      ),
+    );
+  }
+
+  if (stats.dailySupplySideRevenue) {
+    dailySupplySideRevenue.addBalances(
+      stats.dailySupplySideRevenue.clone(
+        1,
+        METRIC.LP_REVENUE,
+      ),
+    );
+  }
+
+  return {
+    dailyFees,
+    dailyUserFees,
+    dailyRevenue,
+    dailyProtocolRevenue,
+    dailyHoldersRevenue,
+    dailySupplySideRevenue,
+  };
+};
+
+const methodology = {
+  Fees:
+    "All swap fees paid by users across SwapHood V3 pools. Each pool's configured fee tier is used.",
+  UserFees:
+    "All swap fees paid directly by SwapHood V3 users.",
+  Revenue:
+    "SwapHood collects 100% of V3 swap fees. 95% is allocated to HOOD buybacks for holders and 5% is retained by the protocol.",
+  ProtocolRevenue:
+    "5% of SwapHood V3 swap fees is retained by the protocol.",
+  HoldersRevenue:
+    "95% of SwapHood V3 swap fees is allocated to HOOD buybacks for holders.",
+  SupplySideRevenue:
+    "Liquidity providers receive no SwapHood V3 swap fees. LP rewards are provided separately through protocol incentives and are not counted as supply-side revenue.",
+};
+
+const breakdownMethodology = {
+  Fees: {
+    [METRIC.SWAP_FEES]:
+      "All swap fees paid by users across SwapHood V3 pools.",
+  },
+  UserFees: {
+    [METRIC.SWAP_FEES]:
+      "All swap fees paid directly by SwapHood V3 users.",
+  },
+  Revenue: {
+    [METRIC.PROTOCOL_REVENUE]:
+      "5% of SwapHood V3 swap fees retained by the protocol.",
+    [METRIC.HOLDERS_REVENUE]:
+      "95% of SwapHood V3 swap fees allocated to HOOD buybacks.",
+  },
+  ProtocolRevenue: {
+    [METRIC.PROTOCOL_REVENUE]:
+      "5% of SwapHood V3 swap fees retained by the protocol.",
+  },
+  HoldersRevenue: {
+    [METRIC.HOOD_BUYBACKS]:
+      "95% of SwapHood V3 swap fees allocated to HOOD buybacks.",
+  },
+  SupplySideRevenue: {
+    [METRIC.LP_REVENUE]:
+      "SwapHood V3 liquidity providers receive no swap fees. LP incentives are distributed separately.",
+  },
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  pullHourly: true,
+  fetch,
+  chains: [CHAIN.ROBINHOOD],
+  start: START,
+  methodology,
+  breakdownMethodology,
+};
+
+export default adapter;

--- a/fees/swaphood/swaphood.ts
+++ b/fees/swaphood/swaphood.ts
@@ -1,0 +1,375 @@
+import BigNumber from "bignumber.js";
+import {
+  FetchOptions,
+  FetchResult,
+  SimpleAdapter,
+} from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+
+const FACTORY = "0xE7206Ecac3A51afe7e6179182ad4130A26068dD1";
+const MASTERCHEF = "0x734c9ef24AEeb9654Be9A19f6d3991b5D91c587B";
+export const START = "2026-07-10";
+
+// SwapHood V2 Pair.sol uses 10,000 as 100%.
+const FEE_DENOMINATOR = new BigNumber(10_000);
+
+// Project-confirmed policy: staked-pair fees are split 5% to the protocol and
+// 95% to holders. The verified MasterChef/fee-collector deployment is at:
+// https://robinhoodchain.blockscout.com/address/0x734c9ef24AEeb9654Be9A19f6d3991b5D91c587B?tab=contract
+const PROTOCOL_FEE_PERCENT = new BigNumber(5);
+const PERCENT_DENOMINATOR = new BigNumber(100);
+const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
+
+const SWAP_EVENT =
+  "event Swap(address indexed sender, uint256 amount0In, uint256 amount1In, uint256 amount0Out, uint256 amount1Out, address indexed to)";
+
+const ABIS = {
+  allPairsLength: "uint256:allPairsLength",
+  allPairs: "function allPairs(uint256) view returns (address)",
+  token0: "address:token0",
+  token1: "address:token1",
+  getFee: "uint256:getFee",
+  gauges: "function gauges(address) view returns (address)",
+};
+
+const METRIC = {
+  SWAP_FEES: "Token Swap Fees",
+  PROTOCOL_REVENUE: "Swap Fees Retained By Protocol",
+  HOLDERS_REVENUE: "Swap Fees Distributed To Holders",
+  LP_REVENUE: "Swap Fees To Liquidity Providers",
+};
+
+type NumericValue = string | number | bigint | BigNumber;
+
+type SwapLog = {
+  amount0In: NumericValue;
+  amount1In: NumericValue;
+};
+
+type PairInfo = {
+  token0: string;
+  token1: string;
+  rawFee: BigNumber;
+  isStaked: boolean;
+};
+
+function toBN(
+  value: NumericValue | null | undefined,
+  context: string,
+): BigNumber {
+  if (value === null || value === undefined) {
+    throw new Error(`Missing ${context}`);
+  }
+
+  const result = BigNumber.isBigNumber(value)
+    ? value
+    : new BigNumber(value.toString());
+
+  if (!result.isFinite()) {
+    throw new Error(`Invalid ${context}: ${value.toString()}`);
+  }
+
+  return result;
+}
+
+function calculateFee(
+  amountIn: BigNumber,
+  rawFee: BigNumber,
+): BigNumber {
+  return amountIn
+    .times(rawFee)
+    .div(FEE_DENOMINATOR)
+    .integerValue(BigNumber.ROUND_FLOOR);
+}
+
+function splitStakedFee(totalFee: BigNumber): {
+  protocolFee: BigNumber;
+  holdersFee: BigNumber;
+} {
+  const protocolFee = totalFee
+    .times(PROTOCOL_FEE_PERCENT)
+    .div(PERCENT_DENOMINATOR)
+    .integerValue(BigNumber.ROUND_FLOOR);
+
+  return {
+    protocolFee,
+    holdersFee: totalFee.minus(protocolFee),
+  };
+}
+
+const fetch = async (
+  options: FetchOptions,
+): Promise<FetchResult> => {
+  const {
+    api,
+    createBalances,
+    getLogs,
+  } = options;
+
+  const dailyFees = createBalances();
+  const dailyUserFees = createBalances();
+  const dailyRevenue = createBalances();
+  const dailyProtocolRevenue = createBalances();
+  const dailyHoldersRevenue = createBalances();
+  const dailySupplySideRevenue = createBalances();
+
+  const pairCountResult = await api.call({
+    target: FACTORY,
+    abi: ABIS.allPairsLength,
+  });
+
+  const pairCount = Number(pairCountResult);
+
+  if (!Number.isFinite(pairCount) || pairCount < 0) {
+    throw new Error(
+      `Invalid SwapHood V2 pair count: ${pairCountResult}`,
+    );
+  }
+
+  if (pairCount === 0) {
+    return {
+      dailyFees,
+      dailyUserFees,
+      dailyRevenue,
+      dailyProtocolRevenue,
+      dailyHoldersRevenue,
+      dailySupplySideRevenue,
+    };
+  }
+
+  const pairResults = await api.multiCall({
+    target: FACTORY,
+    abi: ABIS.allPairs,
+    calls: Array.from(
+      { length: pairCount },
+      (_, index) => ({ params: [index] }),
+    ),
+    permitFailure: true,
+  }) as Array<string | null | undefined>;
+
+  const pairs = pairResults.filter(
+    (pair): pair is string =>
+      typeof pair === "string" &&
+      pair.toLowerCase() !== ZERO_ADDRESS,
+  );
+
+  const [token0s, token1s, rawFees, gauges] = await Promise.all([
+    api.multiCall({
+      abi: ABIS.token0,
+      calls: pairs,
+      permitFailure: true,
+    }) as Promise<Array<string | null | undefined>>,
+    api.multiCall({
+      abi: ABIS.token1,
+      calls: pairs,
+      permitFailure: true,
+    }) as Promise<Array<string | null | undefined>>,
+    api.multiCall({
+      abi: ABIS.getFee,
+      calls: pairs,
+      permitFailure: true,
+    }) as Promise<Array<NumericValue | null | undefined>>,
+    api.multiCall({
+      target: MASTERCHEF,
+      abi: ABIS.gauges,
+      calls: pairs.map((pair) => ({ params: [pair] })),
+      permitFailure: true,
+    }) as Promise<Array<string | null | undefined>>,
+  ]);
+
+  const pairInfo: Record<string, PairInfo> = {};
+
+  pairs.forEach((pair: string, index: number) => {
+    const token0 = token0s[index];
+    const token1 = token1s[index];
+    const rawFee = rawFees[index];
+    const gauge = gauges[index];
+
+    if (
+      !token0 ||
+      !token1 ||
+      rawFee === null ||
+      rawFee === undefined ||
+      !gauge
+    ) return;
+
+    const pairId = pair.toLowerCase();
+
+    pairInfo[pairId] = {
+      token0,
+      token1,
+      rawFee: toBN(rawFee, `${pairId} fee`),
+      isStaked: gauge.toLowerCase() !== ZERO_ADDRESS,
+    };
+  });
+
+  const validPairs = pairs.filter(
+    (pair) => pairInfo[pair.toLowerCase()],
+  );
+
+  if (validPairs.length === 0) {
+    return {
+      dailyFees,
+      dailyUserFees,
+      dailyRevenue,
+      dailyProtocolRevenue,
+      dailyHoldersRevenue,
+      dailySupplySideRevenue,
+    };
+  }
+
+  function addFeeAllocation(
+    token: string,
+    fee: BigNumber,
+    isStaked: boolean,
+  ): void {
+    if (fee.isZero()) return;
+
+    const feeAmount = fee.toFixed(0);
+
+    dailyFees.add(token, feeAmount, METRIC.SWAP_FEES);
+    dailyUserFees.add(token, feeAmount, METRIC.SWAP_FEES);
+
+    if (!isStaked) {
+      dailySupplySideRevenue.add(
+        token,
+        feeAmount,
+        METRIC.LP_REVENUE,
+      );
+      return;
+    }
+
+    const { protocolFee, holdersFee } = splitStakedFee(fee);
+
+    if (!protocolFee.isZero()) {
+      const protocolFeeAmount = protocolFee.toFixed(0);
+
+      dailyProtocolRevenue.add(
+        token,
+        protocolFeeAmount,
+        METRIC.PROTOCOL_REVENUE,
+      );
+
+      dailyRevenue.add(
+        token,
+        protocolFeeAmount,
+        METRIC.PROTOCOL_REVENUE,
+      );
+    }
+
+    if (!holdersFee.isZero()) {
+      const holdersFeeAmount = holdersFee.toFixed(0);
+
+      dailyHoldersRevenue.add(
+        token,
+        holdersFeeAmount,
+        METRIC.HOLDERS_REVENUE,
+      );
+
+      dailyRevenue.add(
+        token,
+        holdersFeeAmount,
+        METRIC.HOLDERS_REVENUE,
+      );
+    }
+  }
+
+  const swapLogsByPair = (await getLogs({
+    targets: validPairs,
+    eventAbi: SWAP_EVENT,
+    flatten: false,
+  })) as SwapLog[][];
+
+  swapLogsByPair.forEach(
+    (logs: SwapLog[], pairIndex: number) => {
+      const pairAddress = validPairs[pairIndex];
+
+      if (!pairAddress) return;
+
+      const pairId = pairAddress.toLowerCase();
+      const info = pairInfo[pairId];
+
+      if (!info) return;
+
+      for (const log of logs) {
+        const fee0 = calculateFee(
+          toBN(log.amount0In, `${pairId} amount0In`),
+          info.rawFee,
+        );
+
+        const fee1 = calculateFee(
+          toBN(log.amount1In, `${pairId} amount1In`),
+          info.rawFee,
+        );
+
+        addFeeAllocation(info.token0, fee0, info.isStaked);
+        addFeeAllocation(info.token1, fee1, info.isStaked);
+      }
+    },
+  );
+
+  return {
+    dailyFees,
+    dailyUserFees,
+    dailyRevenue,
+    dailyProtocolRevenue,
+    dailyHoldersRevenue,
+    dailySupplySideRevenue,
+  };
+};
+
+const methodology = {
+  Fees:
+    "Total SwapHood V2 trading fees paid by users. The adapter reads getFee() independently from every pair and divides it by the Pair contract's 10,000 fee denominator.",
+  UserFees:
+    "All trading fees paid directly by SwapHood V2 users. Fees are calculated from each swap's input amount using that pair's own on-chain fee.",
+  Revenue:
+    "For pairs registered in the SwapHood V2 MasterChef, 100% of swap fees is protocol revenue: 95% is distributed to holders and 5% is retained by the protocol. Fees from non-staked pairs go entirely to liquidity providers.",
+  ProtocolRevenue:
+    "5% of swap fees from pairs registered in the SwapHood V2 MasterChef is retained by the protocol.",
+  HoldersRevenue:
+    "95% of swap fees from pairs registered in the SwapHood V2 MasterChef is distributed to holders.",
+  SupplySideRevenue:
+    "100% of swap fees from pairs not registered in the SwapHood V2 MasterChef goes to liquidity providers.",
+};
+
+const breakdownMethodology = {
+  Fees: {
+    [METRIC.SWAP_FEES]:
+      "Trading fees calculated from the effective on-chain fee configured on each SwapHood V2 pair.",
+  },
+  UserFees: {
+    [METRIC.SWAP_FEES]:
+      "Trading fees paid directly by SwapHood V2 users.",
+  },
+  Revenue: {
+    [METRIC.PROTOCOL_REVENUE]:
+      "5% of trading fees from staked SwapHood V2 pairs retained by the protocol.",
+    [METRIC.HOLDERS_REVENUE]:
+      "95% of trading fees from staked SwapHood V2 pairs distributed to holders.",
+  },
+  ProtocolRevenue: {
+    [METRIC.PROTOCOL_REVENUE]:
+      "5% of trading fees from staked SwapHood V2 pairs retained by the protocol.",
+  },
+  HoldersRevenue: {
+    [METRIC.HOLDERS_REVENUE]:
+      "95% of trading fees from staked SwapHood V2 pairs distributed to holders.",
+  },
+  SupplySideRevenue: {
+    [METRIC.LP_REVENUE]:
+      "100% of trading fees from non-staked SwapHood V2 pairs distributed to liquidity providers.",
+  },
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  pullHourly: true,
+  fetch,
+  chains: [CHAIN.ROBINHOOD],
+  start: START,
+  methodology,
+  breakdownMethodology,
+};
+
+export default adapter;


### PR DESCRIPTION
PR to update SwapHood ( V2 and V3 ) volume and fees.
Tested locally with ROBINHOOD_RPC configured:
- pnpm ts-check
- pnpm test dexs swaphood 2026-07-20T13:00:00Z
- pnpm test fees swaphood 2026-07-20T13:00:00Z