### PR TITLE
feat(aggregators): add PurrFlow aggregator (Bitkub Chain)

### DIFF
--- a/aggregators/purrflow/index.ts
+++ b/aggregators/purrflow/index.ts
@@ -1,0 +1,84 @@
+/**
+ * PurrFlow Aggregator — DEX-aggregator volume adapter.
+ * ── Protocol ───────────────────────────────────────────────────────
+ *
+ * PurrFlow (https://purrflow.xyz) is a trading terminal on Bitkub Chain
+ * that routes every swap through its own atomic multi-DEX router,
+ * `PurrflowAggregatorRouter` (on-chain contract name
+ * DurianAggregatorRouterV3 — it is a source fork of the Durian V2.67
+ * router, so the event surface is byte-identical).
+ *
+ *   Router: 0x6cbBBef3783CA0EfF752A1855206Fa4A69453b8c
+ *           deployed 2026-07-17, first swap in block 33,558,791
+ *
+ * It aggregates across Udonswap, KUBLERX (V3), Junoswap, Diamond and the
+ * Durian V4.5 / V4.6.6 / V4.6.7 launchpad curves + AMMs, wrapping and
+ * unwrapping KKUB around each route so users trade in native KUB.
+ *
+ *   Swapped event (8 fields, identical ABI to the Durian V2 family):
+ *     Swapped(user, tokenIn, tokenOut, amountIn, amountOutToUser,
+ *             fee, hops, referrer)
+ *
+ * Fee: the router skims `markupBps` (currently 60 = 0.60%) from the
+ * route, hard-capped at MAX_FEE_BPS = 100 (1.00%). On the normal path
+ * the skim is taken from the OUTPUT token, which is what the `fee`
+ * field carries and what this adapter prices; on the launchpad-BUY
+ * fast path the same skim is taken on the input side in native KUB.
+ * The skim accrues to the protocol treasury, so revenue == fees.
+ */
+
+import { Adapter, FetchOptions } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import { addOneToken } from "../../helpers/prices";
+import { METRIC } from "../../helpers/metrics"
+
+const ROUTER = "0x6cbBBef3783CA0EfF752A1855206Fa4A69453b8c";
+
+const SWAPPED_ABI =
+  "event Swapped(address indexed user, address indexed tokenIn, address indexed tokenOut, uint256 amountIn, uint256 amountOutToUser, uint256 fee, uint8 hops, address referrer)";
+
+const fetch = async ({ createBalances, getLogs, chain }: FetchOptions) => {
+  const dailyVolume = createBalances();
+  const dailyFees = createBalances();
+
+  const logs = await getLogs({
+    targets: [ROUTER],
+    eventAbi: SWAPPED_ABI,
+  });
+  for (const log of logs) {
+    addOneToken({ chain, balances: dailyVolume, token0: log.tokenIn, amount0: log.amountIn, token1: log.tokenOut, amount1: log.amountOutToUser })
+    dailyFees.add(log.tokenOut, log.fee, METRIC.SWAP_FEES)
+  }
+
+  return { dailyVolume, dailyFees, dailyRevenue: dailyFees };
+};
+
+const methodology = {
+  Volume: "Sum of swap volume routed through the PurrFlow Aggregator Router on Bitkub Chain.",
+  Fees: "Router-skim fee deducted from every Swapped event (currently 0.60%), hard-capped at 1.00% per route.",
+  Revenue: "100% of the swap fees accrue to the protocol treasury.",
+};
+
+const breakdownMethodology = {
+  Fees: {
+    [METRIC.SWAP_FEES]: "Router-skim fee deducted from each swap, currently 0.60% and hard-capped at 1.00% per route.",
+  },
+  Revenue: {
+    [METRIC.SWAP_FEES]: "Router-skim fee deducted from each swap, currently 0.60% and hard-capped at 1.00% per route.",
+  },
+};
+
+const adapter: Adapter = {
+  version: 2,
+  pullHourly: true,
+  adapter: {
+    [CHAIN.BITKUB]: {
+      fetch,
+      start: "2026-07-17",
+    },
+  },
+  methodology,
+  breakdownMethodology,
+};
+
+export default adapter;

--- a/aggregators/purrflow/index.ts
+++ b/aggregators/purrflow/index.ts
@@ -30,7 +30,6 @@
 import { Adapter, FetchOptions } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 import { addOneToken } from "../../helpers/prices";
-import { METRIC } from "../../helpers/metrics"
 
 const ROUTER = "0x6cbBBef3783CA0EfF752A1855206Fa4A69453b8c";
 
@@ -47,24 +46,28 @@ const fetch = async ({ createBalances, getLogs, chain }: FetchOptions) => {
   });
   for (const log of logs) {
     addOneToken({ chain, balances: dailyVolume, token0: log.tokenIn, amount0: log.amountIn, token1: log.tokenOut, amount1: log.amountOutToUser })
-    dailyFees.add(log.tokenOut, log.fee, METRIC.SWAP_FEES)
+    dailyFees.add(log.tokenOut, log.fee, "Router Skim Fees")
   }
 
-  return { dailyVolume, dailyFees, dailyRevenue: dailyFees };
+  return { dailyVolume, dailyFees, dailyRevenue: dailyFees, dailyProtocolRevenue: dailyFees };
 };
 
 const methodology = {
   Volume: "Sum of swap volume routed through the PurrFlow Aggregator Router on Bitkub Chain.",
   Fees: "Router-skim fee deducted from every Swapped event (currently 0.60%), hard-capped at 1.00% per route.",
-  Revenue: "100% of the swap fees accrue to the protocol treasury.",
+  Revenue: "All the router-skim fees deducted from each swap accrue to the protocol treasury.",
+  "Protocol Revenue": "All the router-skim fees deducted from each swap accrue to the protocol treasury.",
 };
 
 const breakdownMethodology = {
   Fees: {
-    [METRIC.SWAP_FEES]: "Router-skim fee deducted from each swap, currently 0.60% and hard-capped at 1.00% per route.",
+    "Router Skim Fees": "Router-skim fee deducted from each swap, currently 0.60% and hard-capped at 1.00% per route.",
   },
   Revenue: {
-    [METRIC.SWAP_FEES]: "Router-skim fee deducted from each swap, currently 0.60% and hard-capped at 1.00% per route.",
+    "Router Skim Fees": "Router-skim fee deducted from each swap, currently 0.60% and hard-capped at 1.00% per route.",
+  },
+  "Protocol Revenue": {
+    "Router Skim Fees": "Router-skim fee deducted from each swap, currently 0.60% and hard-capped at 1.00% per route.",
   },
 };
 

--- a/aggregators/purrflow/index.ts
+++ b/aggregators/purrflow/index.ts
@@ -66,7 +66,7 @@ const breakdownMethodology = {
   Revenue: {
     "Router Skim Fees": "Router-skim fee deducted from each swap, currently 0.60% and hard-capped at 1.00% per route.",
   },
-  "Protocol Revenue": {
+  ProtocolRevenue: {
     "Router Skim Fees": "Router-skim fee deducted from each swap, currently 0.60% and hard-capped at 1.00% per route.",
   },
 };


### PR DESCRIPTION
### PurrFlow Aggregator — Bitkub Chain (chainId 96)

Adds `aggregators/purrflow/index.ts`. New adapter, single new folder, no existing files touched.

**Protocol.** [PurrFlow](https://purrflow.xyz) is a trading terminal on Bitkub Chain that routes every swap through its own atomic multi-DEX router. It aggregates Udonswap, KUBLERX (V3), Junoswap, Diamond and the Durian V4.5/V4.6.6/V4.6.7 launchpad curves + AMMs, wrapping/unwrapping KKUB around each route so users trade in native KUB.

| | |
|---|---|
| Router | `0x6cbBBef3783CA0EfF752A1855206Fa4A69453b8c` |
| Chain | Bitkub Chain (96) |
| Deployed | 2026-07-17 |
| First swap | block 33,558,791 |

**Event.** The router is a source fork of the Durian V2.67 router already indexed by `aggregators/durianfun`, so the `Swapped` ABI is byte-identical (8 fields, trailing `referrer`) and shares topic-0 `0xecc4522b23054b050d5dc668e4ea7a703d2160c990eb739208933119cb1fcd73`.

```
Swapped(user, tokenIn, tokenOut, amountIn, amountOutToUser, fee, hops, referrer)
```

**Verified on-chain** (KubScan `getLogs`, up to block 33,637,480): 7 `Swapped` events decode cleanly against this ABI; first at block 33,558,791 (2026-07-17T18:39:57Z). `start` is set to that date and `pullHourly` is on so history backfills.

**Methodology.** Volume = sum of routed swaps. Fees = the router skim, currently `markupBps = 60` (0.60%) and hard-capped at `MAX_FEE_BPS = 100` (1.00%). The skim accrues to the protocol treasury, so `dailyRevenue == dailyFees`.

**Note on the fee token** — mirrors the existing `aggregators/durianfun` adapter for the identical contract: on the normal path the skim is taken from the OUTPUT token, which is what `fee` carries and what this adapter prices. On the launchpad-BUY fast path the same skim is taken input-side in native KUB. The event does not distinguish the two, so fees are attributed to `tokenOut` exactly as the existing Durian adapter does; the launchpad-BUY case is a small share of routes.

**Disclosure.** Volume is early — the router went live to users on 2026-07-17, so the series starts small and grows from there. Happy to adjust methodology or naming to fit your conventions.