### PR TITLE
Add Project 0 fees adapter (Solana lending)

### DIFF
--- a/fees/project-0/index.ts
+++ b/fees/project-0/index.ts
@@ -1,6 +1,7 @@
-import { SimpleAdapter } from "../../adapters/types";
+import { FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 import { httpGet } from "../../utils/fetchURL";
+import { METRIC } from "../../helpers/metrics";
 
 // Project 0 (P0) is a permissionless prime broker / lending protocol on Solana,
 // built on mrgnLendv2. Borrowers pay interest on their loans (the fees); the
@@ -8,9 +9,9 @@ import { httpGet } from "../../utils/fetchURL";
 //
 // Data comes from P0's public API (/v0/bankMetrics), which returns the current
 // state of every bank only (no historical/timestamp param) — the same source
-// the TVL adapter (`p0`) uses. Fees are therefore a live snapshot: this is a
-// version-1 `runAtCurrTime` adapter, and per bank the daily borrower interest
-// is totalBorrowsUsd * borrowApr / 365.
+// the TVL adapter (`p0`) uses. Fees are therefore a live snapshot
+// (`runAtCurrTime`): per bank, daily borrower interest = totalBorrowsUsd *
+// borrowApr / 365.
 const METRICS_ENDPOINT = "https://api.0.xyz/v0/bankMetrics";
 
 interface Bank {
@@ -21,12 +22,13 @@ interface Bank {
   utilization: string;
 }
 
-const fetch = async () => {
+const fetch = async ({ createBalances }: FetchOptions) => {
+  const dailyFees = createBalances();
+  const dailyRevenue = createBalances();
+  const dailySupplySideRevenue = createBalances();
+
   const data = await httpGet(METRICS_ENDPOINT);
   const banks: Bank[] = data?.banks ?? [];
-
-  let dailyFees = 0;
-  let dailyRevenue = 0;
 
   for (const bank of banks) {
     if (!bank.priced) continue;
@@ -51,8 +53,11 @@ const fetch = async () => {
       if (reserveFactor > 1) reserveFactor = 1;
     }
 
-    dailyFees += borrowInterest;
-    dailyRevenue += borrowInterest * reserveFactor;
+    const revenue = borrowInterest * reserveFactor;
+
+    dailyFees.addUSDValue(borrowInterest, METRIC.BORROW_INTEREST);
+    dailyRevenue.addUSDValue(revenue, METRIC.BORROW_INTEREST);
+    dailySupplySideRevenue.addUSDValue(borrowInterest - revenue, METRIC.BORROW_INTEREST);
   }
 
   return {
@@ -60,12 +65,12 @@ const fetch = async () => {
     dailyUserFees: dailyFees,
     dailyRevenue,
     dailyProtocolRevenue: dailyRevenue,
-    dailySupplySideRevenue: dailyFees - dailyRevenue,
+    dailySupplySideRevenue,
   };
 };
 
 const adapter: SimpleAdapter = {
-  version: 1,
+  version: 2,
   runAtCurrTime: true,
   fetch,
   chains: [CHAIN.SOLANA],
@@ -75,6 +80,17 @@ const adapter: SimpleAdapter = {
     Revenue: "Protocol's reserve share of the borrower interest.",
     ProtocolRevenue: "Protocol's reserve share of the borrower interest.",
     SupplySideRevenue: "Borrower interest distributed to depositors/lenders.",
+  },
+  breakdownMethodology: {
+    Fees: {
+      [METRIC.BORROW_INTEREST]: "Interest paid by borrowers on all outstanding loans.",
+    },
+    Revenue: {
+      [METRIC.BORROW_INTEREST]: "Protocol reserve cut of borrower interest.",
+    },
+    SupplySideRevenue: {
+      [METRIC.BORROW_INTEREST]: "Borrower interest paid out to depositors.",
+    },
   },
 };
 

--- a/fees/project-0/index.ts
+++ b/fees/project-0/index.ts
@@ -1,0 +1,97 @@
+import { FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import { httpGet } from "../../utils/fetchURL";
+import { METRIC } from "../../helpers/metrics";
+
+// Project 0 (P0) is a permissionless prime broker / lending protocol on Solana,
+// built on mrgnLendv2. Borrowers pay interest on their loans (the fees); the
+// protocol keeps a reserve cut (revenue) and the rest is paid to depositors.
+//
+// Data comes from P0's public API (/v0/bankMetrics), which returns the current
+// state of every bank only (no historical param) — same source the TVL adapter
+// uses. So fees are computed as a live snapshot (runAtCurrTime): for each bank,
+// daily borrower interest = totalBorrowsUsd * borrowApr / 365.
+const METRICS_ENDPOINT = "https://api.0.xyz/v0/bankMetrics";
+
+interface Bank {
+  mint: string;
+  symbol: string;
+  priced: boolean;
+  totalBorrowsUsd: string;
+  totalDepositsUsd: string;
+  borrowApr: string;
+  depositApr: string;
+  utilization: string;
+}
+
+const fetch = async (options: FetchOptions) => {
+  const dailyFees = options.createBalances();
+  const dailyRevenue = options.createBalances();
+  const dailySupplySideRevenue = options.createBalances();
+
+  const data = await httpGet(METRICS_ENDPOINT);
+  const banks: Bank[] = data?.banks ?? [];
+
+  for (const bank of banks) {
+    if (!bank.priced) continue;
+
+    const borrowsUsd = Number(bank.totalBorrowsUsd) || 0;
+    const borrowApr = Number(bank.borrowApr) || 0;
+    const depositApr = Number(bank.depositApr) || 0;
+    const utilization = Number(bank.utilization) || 0;
+
+    const dailyBorrowInterest = (borrowsUsd * borrowApr) / 365;
+    if (dailyBorrowInterest <= 0) continue;
+
+    // Implied protocol reserve factor from the rate spread:
+    //   depositApr = borrowApr * utilization * (1 - reserveFactor)
+    // Integration banks earn external (e.g. staking) yield on top of the lending
+    // spread, which pushes this negative — floor at 0 so external yield is never
+    // counted as protocol revenue and the split stays 0 <= revenue <= fees.
+    let reserveFactor = 0;
+    if (borrowApr > 0 && utilization > 0) {
+      reserveFactor = 1 - depositApr / (borrowApr * utilization);
+      if (!isFinite(reserveFactor) || reserveFactor < 0) reserveFactor = 0;
+      if (reserveFactor > 1) reserveFactor = 1;
+    }
+
+    const revenue = dailyBorrowInterest * reserveFactor;
+
+    dailyFees.addUSDValue(dailyBorrowInterest, METRIC.BORROW_INTEREST);
+    dailyRevenue.addUSDValue(revenue, METRIC.BORROW_INTEREST);
+    dailySupplySideRevenue.addUSDValue(dailyBorrowInterest - revenue, METRIC.BORROW_INTEREST);
+  }
+
+  return {
+    dailyFees,
+    dailyRevenue,
+    dailyProtocolRevenue: dailyRevenue,
+    dailySupplySideRevenue,
+  };
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  runAtCurrTime: true,
+  fetch,
+  chains: [CHAIN.SOLANA],
+  methodology: {
+    Fees: "Interest paid by borrowers across all Project 0 banks (borrows x borrow APR).",
+    Revenue: "Protocol's reserve share of the borrower interest.",
+    ProtocolRevenue: "Protocol's reserve share of the borrower interest.",
+    SupplySideRevenue: "Borrower interest distributed to depositors/lenders.",
+  },
+  breakdownMethodology: {
+    Fees: {
+      [METRIC.BORROW_INTEREST]: "Interest paid by borrowers on all outstanding loans.",
+    },
+    Revenue: {
+      [METRIC.BORROW_INTEREST]: "Protocol reserve cut of borrower interest.",
+    },
+    SupplySideRevenue: {
+      [METRIC.BORROW_INTEREST]: "Borrower interest paid out to depositors.",
+    },
+  },
+};
+
+export default adapter;

--- a/fees/project-0/index.ts
+++ b/fees/project-0/index.ts
@@ -1,36 +1,32 @@
-import { FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 import { httpGet } from "../../utils/fetchURL";
-import { METRIC } from "../../helpers/metrics";
 
 // Project 0 (P0) is a permissionless prime broker / lending protocol on Solana,
 // built on mrgnLendv2. Borrowers pay interest on their loans (the fees); the
 // protocol keeps a reserve cut (revenue) and the rest is paid to depositors.
 //
 // Data comes from P0's public API (/v0/bankMetrics), which returns the current
-// state of every bank only (no historical param) — same source the TVL adapter
-// uses. So fees are computed as a live snapshot (runAtCurrTime): for each bank,
-// daily borrower interest = totalBorrowsUsd * borrowApr / 365.
+// state of every bank only (no historical/timestamp param) — the same source
+// the TVL adapter (`p0`) uses. Fees are therefore a live snapshot: this is a
+// version-1 `runAtCurrTime` adapter, and per bank the daily borrower interest
+// is totalBorrowsUsd * borrowApr / 365.
 const METRICS_ENDPOINT = "https://api.0.xyz/v0/bankMetrics";
 
 interface Bank {
-  mint: string;
-  symbol: string;
   priced: boolean;
   totalBorrowsUsd: string;
-  totalDepositsUsd: string;
   borrowApr: string;
   depositApr: string;
   utilization: string;
 }
 
-const fetch = async (options: FetchOptions) => {
-  const dailyFees = options.createBalances();
-  const dailyRevenue = options.createBalances();
-  const dailySupplySideRevenue = options.createBalances();
-
+const fetch = async () => {
   const data = await httpGet(METRICS_ENDPOINT);
   const banks: Bank[] = data?.banks ?? [];
+
+  let dailyFees = 0;
+  let dailyRevenue = 0;
 
   for (const bank of banks) {
     if (!bank.priced) continue;
@@ -40,8 +36,8 @@ const fetch = async (options: FetchOptions) => {
     const depositApr = Number(bank.depositApr) || 0;
     const utilization = Number(bank.utilization) || 0;
 
-    const dailyBorrowInterest = (borrowsUsd * borrowApr) / 365;
-    if (dailyBorrowInterest <= 0) continue;
+    const borrowInterest = (borrowsUsd * borrowApr) / 365;
+    if (borrowInterest <= 0) continue;
 
     // Implied protocol reserve factor from the rate spread:
     //   depositApr = borrowApr * utilization * (1 - reserveFactor)
@@ -55,42 +51,30 @@ const fetch = async (options: FetchOptions) => {
       if (reserveFactor > 1) reserveFactor = 1;
     }
 
-    const revenue = dailyBorrowInterest * reserveFactor;
-
-    dailyFees.addUSDValue(dailyBorrowInterest, METRIC.BORROW_INTEREST);
-    dailyRevenue.addUSDValue(revenue, METRIC.BORROW_INTEREST);
-    dailySupplySideRevenue.addUSDValue(dailyBorrowInterest - revenue, METRIC.BORROW_INTEREST);
+    dailyFees += borrowInterest;
+    dailyRevenue += borrowInterest * reserveFactor;
   }
 
   return {
     dailyFees,
+    dailyUserFees: dailyFees,
     dailyRevenue,
     dailyProtocolRevenue: dailyRevenue,
-    dailySupplySideRevenue,
+    dailySupplySideRevenue: dailyFees - dailyRevenue,
   };
 };
 
 const adapter: SimpleAdapter = {
-  version: 2,
+  version: 1,
   runAtCurrTime: true,
   fetch,
   chains: [CHAIN.SOLANA],
   methodology: {
     Fees: "Interest paid by borrowers across all Project 0 banks (borrows x borrow APR).",
+    UserFees: "Interest paid by borrowers on their outstanding loans.",
     Revenue: "Protocol's reserve share of the borrower interest.",
     ProtocolRevenue: "Protocol's reserve share of the borrower interest.",
     SupplySideRevenue: "Borrower interest distributed to depositors/lenders.",
-  },
-  breakdownMethodology: {
-    Fees: {
-      [METRIC.BORROW_INTEREST]: "Interest paid by borrowers on all outstanding loans.",
-    },
-    Revenue: {
-      [METRIC.BORROW_INTEREST]: "Protocol reserve cut of borrower interest.",
-    },
-    SupplySideRevenue: {
-      [METRIC.BORROW_INTEREST]: "Borrower interest paid out to depositors.",
-    },
   },
 };
 


### PR DESCRIPTION
https://defillama.com/protocol/project-0

Adds a fees/revenue adapter for **Project 0** (P0), a permissionless prime broker / lending protocol on Solana (~$54M TVL, ~$20M borrowed), built on mrgnLendv2.

### Methodology
- **Fees** — interest paid by borrowers across all P0 banks (`totalBorrowsUsd * borrowApr / 365`).
- **Revenue** — the protocol reserve cut, implied from the borrow/deposit rate spread (`1 - depositApr / (borrowApr * utilization)`), floored at 0 so integration banks' external (e.g. staking) yield is never counted as protocol revenue.
- **SupplySideRevenue** — borrower interest paid out to depositors.

Data comes from P0's public API (`/v0/bankMetrics`) — the same source the TVL adapter (`p0`) uses. The endpoint returns current bank state only (no historical param), so the adapter runs as a live snapshot (`runAtCurrTime`), matching the TVL adapter's `timetravel: false`.

Tested locally: ~$2.9k/day fees, ~$77/day revenue, ~$2.85k/day supply-side.
