### PR TITLE
HoodMint: add fees, revenue & volume adapter (memecoin launchpad on Robinhood Chain)

### DIFF
--- a/fees/hoodmint.ts
+++ b/fees/hoodmint.ts
@@ -42,7 +42,7 @@ const fetch = async (options: FetchOptions) => {
   const tradeLogs = await options.getLogs({ target: HOODMINT_CURVE, eventAbi: TRADE });
 
   for (const log of tradeLogs) {
-    dailyFees.addGasToken(log.protocolFee + log.creatorFee, METRIC.TRADING_FEES);
+    dailyFees.addGasToken(BigInt(log.protocolFee) + BigInt(log.creatorFee), METRIC.TRADING_FEES);
     dailyRevenue.addGasToken(log.protocolFee, "Trading Fees To Protocol");
     dailySupplySideRevenue.addGasToken(log.creatorFee, "Trading Fees To Creators");
     dailyVolume.addGasToken(log.ethGross);

--- a/fees/hoodmint.ts
+++ b/fees/hoodmint.ts
@@ -1,0 +1,87 @@
+// HoodMint — fees, revenue & volume adapter.
+//
+// HoodMint (https://hoodmint.fun) is a memecoin launchpad on Robinhood Chain
+// (chainId 4663). Every launch and trade goes through a single singleton
+// bonding-curve contract, HoodMintCurve:
+//   https://robinhoodchain.blockscout.com/address/0x570e51c509a20C63C409A43Bc8d9e2aeA564B61b
+//
+// Fee source (the only fee HoodMint charges — there is no launch/creation fee
+// and no graduation fee): a 1.25% fee on the ETH leg of every bonding-curve
+// buy and sell, split creator-first: 0.88% to the token's creator and 0.37%
+// to the protocol (CREATOR_FEE_BPS = 88, PROTOCOL_FEE_BPS = 37). The exact
+// per-trade split is emitted in wei on each Trade event (protocolFee /
+// creatorFee fields), so this adapter stays correct if a future deployment
+// changes the split.
+//
+// dailyFees              = sum(protocolFee + creatorFee)
+// dailyRevenue           = sum(protocolFee)   (== dailyProtocolRevenue)
+// dailySupplySideRevenue = sum(creatorFee)    (creator earnings, like pump.fun)
+// dailyVolume            = sum(ethGross): ETH paid in on buys (fee-inclusive)
+//                          and gross ETH taken out of the reserve on sells.
+//
+// On graduation the raised ETH moves into a permanently locked Uniswap V3
+// position; post-graduation swaps are ordinary Uniswap trades and are not
+// counted here.
+//
+// -----------------------------------------------------------------------------------------------------
+import { Adapter, FetchOptions } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+import { METRIC } from "../helpers/metrics";
+
+const HOODMINT_CURVE = "0x570e51c509a20C63C409A43Bc8d9e2aeA564B61b";
+
+const TRADE =
+  "event Trade(address indexed token, address indexed trader, bool isBuy, uint256 ethGross, uint256 ethNet, uint256 tokenAmount, uint256 protocolFee, uint256 creatorFee, uint128 virtualEth, uint128 virtualToken, uint128 realEth, uint128 realToken, bool complete)";
+
+const fetch = async (options: FetchOptions) => {
+  const dailyFees = options.createBalances();
+  const dailyRevenue = options.createBalances();
+  const dailySupplySideRevenue = options.createBalances();
+  const dailyVolume = options.createBalances();
+
+  const tradeLogs = await options.getLogs({ target: HOODMINT_CURVE, eventAbi: TRADE });
+
+  for (const log of tradeLogs) {
+    dailyFees.addGasToken(log.protocolFee + log.creatorFee, METRIC.TRADING_FEES);
+    dailyRevenue.addGasToken(log.protocolFee, "Trading Fees To Protocol");
+    dailySupplySideRevenue.addGasToken(log.creatorFee, "Trading Fees To Creators");
+    dailyVolume.addGasToken(log.ethGross);
+  }
+
+  return { dailyFees, dailyRevenue, dailyProtocolRevenue: dailyRevenue, dailySupplySideRevenue, dailyVolume };
+};
+
+const methodology = {
+  Volume: "ETH side of every bonding-curve trade: ETH paid in on buys (fee-inclusive) and gross ETH taken out of the curve reserve on sells. Post-graduation Uniswap V3 swaps are not counted.",
+  Fees: "A 1.25% fee charged on the ETH leg of every bonding-curve buy and sell, read per trade from the Trade event's protocolFee and creatorFee fields. HoodMint has no launch fee and no graduation fee.",
+  Revenue: "The protocol slice of the bonding-curve trade fee.",
+  ProtocolRevenue: "Same as Revenue — the protocol slice of the bonding-curve trade fee.",
+  SupplySideRevenue: "The creator slice of the bonding-curve trade fee, claimable by each token's creator.",
+};
+
+const breakdownMethodology = {
+  Fees: {
+    [METRIC.TRADING_FEES]: "1.25% bonding-curve trade fee on the ETH leg of every buy and sell (protocolFee + creatorFee from the Trade event).",
+  },
+  Revenue: {
+    "Trading Fees To Protocol": "Protocol slice of the bonding-curve trade fee (protocolFee field of the Trade event).",
+  },
+  ProtocolRevenue: {
+    "Trading Fees To Protocol": "Protocol slice of the bonding-curve trade fee (protocolFee field of the Trade event).",
+  },
+  SupplySideRevenue: {
+    "Trading Fees To Creators": "Creator slice of the bonding-curve trade fee (creatorFee field of the Trade event), claimable by the token's creator.",
+  },
+};
+
+const adapter: Adapter = {
+  version: 2,
+  pullHourly: true,
+  methodology,
+  breakdownMethodology,
+  chains: [CHAIN.ROBINHOOD],
+  fetch,
+  start: "2026-07-21", // HoodMintCurve deployment (block 15675879)
+};
+
+export default adapter;


### PR DESCRIPTION
Adds a fees / revenue / volume adapter for HoodMint, a memecoin launchpad on Robinhood Chain (`CHAIN.ROBINHOOD`, chainId 4663 — same chain as the existing `fees/prynt.ts`, `fees/quiver.ts`, `fees/hoodpump` and `fees/ponsdotfamily` launchpad adapters).

Every HoodMint token launches and trades on one singleton bonding-curve contract, HoodMintCurve (`0x570e51c509a20C63C409A43Bc8d9e2aeA564B61b`, deployed at block 15,675,879 / 2026-07-21). The only fee the protocol charges is a 1.25% fee on the ETH leg of every curve buy/sell; there is no launch fee and no graduation fee. Each `Trade` event emits the exact `protocolFee` and `creatorFee` in wei, so the adapter reads the split directly from the logs (robust to future split changes):

- `dailyFees` = sum(protocolFee + creatorFee)
- `dailyRevenue` = `dailyProtocolRevenue` = sum(protocolFee)
- `dailySupplySideRevenue` = sum(creatorFee) — creator earnings, same mapping as pump.fun
- `dailyVolume` = sum(ethGross) — the ETH side of each curve trade (same approach as `fees/prynt.ts`)

All amounts are denominated in native ETH via `addGasToken`. A corresponding TVL adapter is submitted in DefiLlama/DefiLlama-Adapters#20163.

Tested locally with `npm test fees hoodmint` — output matches an independent raw `eth_getLogs` scan of the curve's Trade events. Note: the curve went live 2026-07-21, so the harness's 24h-start guard leaves day-0 slots empty; daily figures populate from 2026-07-22.

---
##### Name (to be shown on DefiLlama):
HoodMint

##### Twitter Link:
https://x.com/HoodMintFun

##### List of audit links if any:
None

##### Website Link:
https://hoodmint.fun

##### Logo (High resolution, will be shown with rounded borders):
https://hoodmint.fun/brand-mark-512-black.png (512×512 PNG)

##### Current TVL:
~$3 as of 2026-07-21 — the curve went live earlier today (block 15,675,879) and the first launches are already on it

##### Treasury Addresses (if the protocol has treasury)
`0x7C008EfE8428b473852DCCb9FeBa918d559878C2` (protocol fee recipient)

##### Chain:
Robinhood Chain (chainId 4663)

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed):

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed):

##### Short Description (to be shown on DefiLlama):
HoodMint is a memecoin launchpad on Robinhood Chain. Tokens launch on a pump.fun-style bonding curve; on graduation the raised ETH moves into a permanently locked Uniswap V3 position.

##### Token address and ticker if any:
HOODMINT — `0xb31ee86d3b45503e32c8ad27911d67e08c4b9f94` (Robinhood Chain)

##### Category (full list at https://defillama.com/categories) \*Please choose only one:
Launchpad

##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.):
None

##### Implementation Details: Briefly describe how the oracle is integrated into your project:
N/A — no oracle; pricing is a constant-product bonding curve computed on-chain

##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage:
https://hoodmint.fun/docs (contract addresses, event ABIs, fee split)

##### forkedFrom (Does your project originate from another project):
No — original contracts implementing pump.fun-style bonding-curve math

##### methodology (what is being counted as tvl, how is tvl being calculated):
Fees: 1.25% bonding-curve trade fee on the ETH leg of every buy/sell, read per trade from the Trade event's `protocolFee`/`creatorFee` fields. Revenue/ProtocolRevenue: the protocol slice. SupplySideRevenue: the creator slice. Volume: `ethGross` of each curve trade. All in native ETH.

##### Github org/user (Optional, if your code is open source, we can track activity):
Not public yet

##### Does this project have a referral program?
No

🤖 Generated with [Claude Code](https://claude.com/claude-code)
