### PR TITLE
fix(hyperliquid): Kinetiq-Hyperion staking tracked the wrong (Purrposeful) validator

### DIFF
--- a/factory/hyperliquid.ts
+++ b/factory/hyperliquid.ts
@@ -811,7 +811,7 @@ const validatorConfigs: Record<string, ValidatorConfig> = {
     addressesOrNames: ['0xf8efb4cb844a8458114994203d7b0bfe2422a288'],
   },
   "Kinetiq-Hyperion": {
-    addressesOrNames: ['0xf8efb4cb844a8458114994203d7b0bfe2422a288'],
+    addressesOrNames: ['0xeeee86f718f9da3e7250624a460f6ea710e9c006'], // Kinetiq x Hyperion validator (previously duplicated Purrposeful's 0xf8efb4… address)
   },
   "Nansen-HypurrCollective": {
     addressesOrNames: ['0xb8f45222a3246a2b0104696a1df26842007c5bc5'],


### PR DESCRIPTION
### Problem
The `Kinetiq-Hyperion` validator-staking config in `factory/hyperliquid.ts` used **Purrposeful's** validator address (`0xf8efb4cb…288`) — the same address as the `purrposeful` config two lines above. This caused two issues:

1. **Double-count** — Purrposeful's staking rewards were counted twice (once by `purrposeful`, once by `Kinetiq-Hyperion`). On the public fees API the two protocols report near-identical numbers (~$0.86m/30d each).
2. **Missing coverage** — the actual **Kinetiq x Hyperion** validator (`0xeeee86f7…006`, ~7M HYPE staked, active) was tracked by no adapter.

Both identities verified against `api.hyperliquid.xyz` `validatorSummaries`:
- `0xf8efb4…288` → `Purrposeful x HyBridge x PiP`
- `0xeeee86…006` → `Kinetiq x Hyperion`

The correct address does not appear anywhere else in the repo, so `Kinetiq-Hyperion` has pointed at the wrong validator since it was added.

### Fix
Point `Kinetiq-Hyperion` at its own validator address (one-line change).

Verified the shared `exportValidatorStakingAdapter` code path via the testable sibling `purrposeful` (`npm run test fees purrposeful` → fees $26.5k/day, commission/supply-side split correct). The uppercase factory name can't run through the lowercase-only test CLI, but the fix only swaps the address to another confirmed-active validator on the same code path.
