### PR TITLE
feat(hyperliquid): add Hyperliquid Strategies HYPE staking validator

### DIFF
--- a/factory/hyperliquid.ts
+++ b/factory/hyperliquid.ts
@@ -876,6 +876,12 @@ const validatorConfigs: Record<string, ValidatorConfig> = {
       '0x914d7f841b5ee14d1cd3852c7b2601b6ff6a8c52', // Enigma-Hypedexer-Meria-HypurrFi
     ],
   },
+  "hyperliquid-strategies-staking": {
+    // "Hyperliquid Strategies x Unit" validator, run by Hyperliquid Strategies Inc
+    // (NASDAQ: PURR) — the largest publicly listed HYPE treasury company — with Unit Labs.
+    // Largest HYPE validator not yet tracked by any staking adapter (~22.5M HYPE).
+    addressesOrNames: ['0xd6a72f04b9868d5d6050376d5d7b729f47305cec'],
+  },
 }
 
 // HIP3 deployer dex configs: protocol name -> { dexId, start, methodology }


### PR DESCRIPTION
### What
Adds a validator-staking fees adapter for the **Hyperliquid Strategies x Unit** validator (`0xd6a72f04…cec`) via the existing `exportValidatorStakingAdapter` factory.

### Why
This is the **largest HYPE validator not yet tracked** by any staking adapter (~22.5M HYPE, ~$1.4B staked). It is run by **Hyperliquid Strategies Inc (NASDAQ: PURR)** — the largest publicly listed HYPE treasury company — in partnership with **Unit Labs**. DefiLlama already tracks 25+ HYPE staking validators (Bitwise, Galaxy Digital, Anchorage, etc.); this fills the biggest remaining gap.

### Test (`npm run test fees hyperliquid-strategies-staking`, 20→21 Jul 2026)
```
Daily fees (total staking rewards):      ~$83.3k/day  (~$2.5m/30d)
Daily revenue (2% validator commission): ~$1.7k/day
Daily supply-side (rewards to stakers):  ~$81.6k/day
```
Breakdown balances: `dailyFees = dailyRevenue + dailySupplySideRevenue` ✓

### Verification
Validator identity confirmed against `api.hyperliquid.xyz` `validatorSummaries`: `0xd6a72f04…cec` → "Hyperliquid Strategies x Unit", active, 2% commission. Not covered by any existing config (no double-count).

Suggested protocol listing: **Hyperliquid Strategies HYPE Staking** (category: Staking Pool), site https://hypestrat.xyz.
