### PR TITLE
feat(hyperliquid): track Kinetiq Markets' active HIP-3 dex (mkts, was dormant km)

### DIFF
--- a/dexs/kinetiq-markets.ts
+++ b/dexs/kinetiq-markets.ts
@@ -23,11 +23,11 @@ const fetch = async (options: FetchOptions) => {
 
   // Builder-code fees are retained entirely by Kinetiq.
   dailyFees.add(builderFees, 'Hyperliquid Builder Code Fees');
-  dailyRevenue.add(builderFees, 'Hyperliquid Builder Code Fees');
+  dailyRevenue.add(builderFees, 'Builder Code Fees To Kinetiq');
 
   // On HIP-3 markets Kinetiq only keeps its deployer-fee cut; the rest is paid through to Hyperliquid.
   dailyFees.add(hip3Fees, 'Hyperliquid HIP-3 Markets Fees');
-  dailyRevenue.add(hip3DeployerFee, 'Hyperliquid HIP-3 Markets Fees');
+  dailyRevenue.add(hip3DeployerFee, 'HIP-3 Deployer Fees To Kinetiq');
   const hip3ToHyperliquid = hip3Fees.clone();
   hip3ToHyperliquid.subtract(hip3DeployerFee);
   dailySupplySideRevenue.add(hip3ToHyperliquid, 'HIP-3 Fees To Hyperliquid');
@@ -58,12 +58,12 @@ const adapter: SimpleAdapter = {
       'Hyperliquid HIP-3 Markets Fees': 'All perps trading fees from Hyperliquid HIP-3 markets.',
     },
     Revenue: {
-      'Hyperliquid Builder Code Fees': 'Builder-code fees retained by Kinetiq.',
-      'Hyperliquid HIP-3 Markets Fees': "Kinetiq's deployer-fee cut of HIP-3 market fees.",
+      'Builder Code Fees To Kinetiq': 'Builder-code fees retained by Kinetiq.',
+      'HIP-3 Deployer Fees To Kinetiq': "Kinetiq's deployer-fee cut of HIP-3 market fees.",
     },
     ProtocolRevenue: {
-      'Hyperliquid Builder Code Fees': 'Builder-code fees retained by Kinetiq.',
-      'Hyperliquid HIP-3 Markets Fees': "Kinetiq's deployer-fee cut of HIP-3 market fees.",
+      'Builder Code Fees To Kinetiq': 'Builder-code fees retained by Kinetiq.',
+      'HIP-3 Deployer Fees To Kinetiq': "Kinetiq's deployer-fee cut of HIP-3 market fees.",
     },
     SupplySideRevenue: {
       'HIP-3 Fees To Hyperliquid': 'HIP-3 market fees paid through to Hyperliquid (not retained by Kinetiq).',

--- a/dexs/kinetiq-markets.ts
+++ b/dexs/kinetiq-markets.ts
@@ -9,7 +9,8 @@ const fetch = async (options: FetchOptions) => {
   });
   const { dailyPerpVolume: hip3Volume, dailyPerpFee: hip3Fees } = await fetchHIP3DeployerData({
     options,
-    hip3DeployerId: 'km',
+    // Kinetiq migrated its HIP-3 dex from the now-dormant "km" to the active "mkts"
+    hip3DeployerId: 'mkts',
   });
   
   const dailyVolume = options.createBalances();

--- a/dexs/kinetiq-markets.ts
+++ b/dexs/kinetiq-markets.ts
@@ -2,15 +2,17 @@ import { CHAIN } from "../helpers/chains";
 import { fetchBuilderCodeRevenue, fetchHIP3DeployerData } from "../helpers/hyperliquid";
 import { FetchOptions, SimpleAdapter } from "../adapters/types";
 
+const KINETIQ_MARKETS_LEGACY_END_DATE = "2026-06-20";
+
 const fetch = async (options: FetchOptions) => {
+  const deployerId = options.dateString > KINETIQ_MARKETS_LEGACY_END_DATE ? 'mkts' : 'km';
   const { dailyVolume: builderVolume, dailyFees: builderFees } = await fetchBuilderCodeRevenue({
     options,
     builder_address: '0x42f3226007290b02c5a0b15bccbb1ba6df04f992',
   });
   const { dailyPerpVolume: hip3Volume, dailyPerpFee: hip3Fees, dailyDeployerFee: hip3DeployerFee } = await fetchHIP3DeployerData({
     options,
-    // Kinetiq migrated its HIP-3 dex from the now-dormant "km" to the active "mkts"
-    hip3DeployerId: 'mkts',
+    hip3DeployerId: deployerId,
   });
 
   const dailyVolume = options.createBalances();

--- a/dexs/kinetiq-markets.ts
+++ b/dexs/kinetiq-markets.ts
@@ -7,25 +7,37 @@ const fetch = async (options: FetchOptions) => {
     options,
     builder_address: '0x42f3226007290b02c5a0b15bccbb1ba6df04f992',
   });
-  const { dailyPerpVolume: hip3Volume, dailyPerpFee: hip3Fees } = await fetchHIP3DeployerData({
+  const { dailyPerpVolume: hip3Volume, dailyPerpFee: hip3Fees, dailyDeployerFee: hip3DeployerFee } = await fetchHIP3DeployerData({
     options,
     // Kinetiq migrated its HIP-3 dex from the now-dormant "km" to the active "mkts"
     hip3DeployerId: 'mkts',
   });
-  
+
   const dailyVolume = options.createBalances();
   const dailyFees = options.createBalances();
-  
+  const dailyRevenue = options.createBalances();
+  const dailySupplySideRevenue = options.createBalances();
+
   dailyVolume.add(builderVolume);
   dailyVolume.add(hip3Volume);
+
+  // Builder-code fees are retained entirely by Kinetiq.
   dailyFees.add(builderFees, 'Hyperliquid Builder Code Fees');
+  dailyRevenue.add(builderFees, 'Hyperliquid Builder Code Fees');
+
+  // On HIP-3 markets Kinetiq only keeps its deployer-fee cut; the rest is paid through to Hyperliquid.
   dailyFees.add(hip3Fees, 'Hyperliquid HIP-3 Markets Fees');
-  
+  dailyRevenue.add(hip3DeployerFee, 'Hyperliquid HIP-3 Markets Fees');
+  const hip3ToHyperliquid = hip3Fees.clone();
+  hip3ToHyperliquid.subtract(hip3DeployerFee);
+  dailySupplySideRevenue.add(hip3ToHyperliquid, 'HIP-3 Fees To Hyperliquid');
+
   return {
     dailyVolume,
     dailyFees,
-    dailyRevenue: dailyFees,
-    dailyProtocolRevenue: dailyFees,
+    dailyRevenue,
+    dailyProtocolRevenue: dailyRevenue,
+    dailySupplySideRevenue,
   };
 };
 
@@ -35,9 +47,10 @@ const adapter: SimpleAdapter = {
   start: '2025-12-16',
   doublecounted: true,
   methodology: {
-    Fees: "Trading fees paid by users for perps in using Hyperliquid HIP-3 markets and builder code.",
-    Revenue: "Fees collected by Kinetiq Revenue from Hyperliquid and HIP-3 markets.",
-    ProtocolRevenue: "Fees collected by Kinetiq as Builder Revenue from Hyperliquid and HIP-3 markets.",
+    Fees: "Trading fees paid by users on Hyperliquid via Kinetiq's builder code and its HIP-3 markets.",
+    Revenue: "Builder-code fees (retained by Kinetiq) plus Kinetiq's deployer-fee cut of its HIP-3 market fees.",
+    ProtocolRevenue: "Same as Revenue — retained by Kinetiq.",
+    SupplySideRevenue: "The remainder of HIP-3 market fees, paid through to Hyperliquid.",
   },
   breakdownMethodology: {
     Fees: {
@@ -45,12 +58,15 @@ const adapter: SimpleAdapter = {
       'Hyperliquid HIP-3 Markets Fees': 'All perps trading fees from Hyperliquid HIP-3 markets.',
     },
     Revenue: {
-      'Hyperliquid Builder Code Fees': 'All perps trading fees using Hyperliquid builder code.',
-      'Hyperliquid HIP-3 Markets Fees': 'All perps trading fees from Hyperliquid HIP-3 markets.',
+      'Hyperliquid Builder Code Fees': 'Builder-code fees retained by Kinetiq.',
+      'Hyperliquid HIP-3 Markets Fees': "Kinetiq's deployer-fee cut of HIP-3 market fees.",
     },
     ProtocolRevenue: {
-      'Hyperliquid Builder Code Fees': 'All perps trading fees using Hyperliquid builder code.',
-      'Hyperliquid HIP-3 Markets Fees': 'All perps trading fees from Hyperliquid HIP-3 markets.',
+      'Hyperliquid Builder Code Fees': 'Builder-code fees retained by Kinetiq.',
+      'Hyperliquid HIP-3 Markets Fees': "Kinetiq's deployer-fee cut of HIP-3 market fees.",
+    },
+    SupplySideRevenue: {
+      'HIP-3 Fees To Hyperliquid': 'HIP-3 market fees paid through to Hyperliquid (not retained by Kinetiq).',
     },
   }
 };

--- a/factory/hyperliquid.ts
+++ b/factory/hyperliquid.ts
@@ -883,7 +883,7 @@ const hip3DexConfigs: Record<string, { dexId: string; start: string; methodology
   "dreamcash-markets": { dexId: "cash", start: "2026-01-20", methodologyName: "Dreamcash" },
   "felix-perp": { dexId: "flx", start: "2025-11-13", methodologyName: "Felix protocol" },
   "hyena": { dexId: "hyna", start: "2025-12-01", methodologyName: "Based and Ethena teams" },
-  "kinetiq-markets": { dexId: "mkts", start: "2026-06-01", methodologyName: "Kinetiq" }, // Kinetiq migrated its HIP-3 dex from the now-dormant "km" to the active "mkts"
+  // "kinetiq-markets" fees/volume is handled by the standalone dexs/kinetiq-markets.ts (builder code + HIP-3 dex "mkts")
   "tradexyz": { dexId: "xyz", start: "2025-11-01", methodologyName: "Trade.xyz" },
   "ventuals": { dexId: "vntl", start: "2025-11-13", methodologyName: "Ventuals" },
   "paragon": { dexId: "para", start: "2026-03-30", methodologyName: "Paragon" },

--- a/factory/hyperliquid.ts
+++ b/factory/hyperliquid.ts
@@ -883,7 +883,7 @@ const hip3DexConfigs: Record<string, { dexId: string; start: string; methodology
   "dreamcash-markets": { dexId: "cash", start: "2026-01-20", methodologyName: "Dreamcash" },
   "felix-perp": { dexId: "flx", start: "2025-11-13", methodologyName: "Felix protocol" },
   "hyena": { dexId: "hyna", start: "2025-12-01", methodologyName: "Based and Ethena teams" },
-  // "kinetiq-markets": { dexId: "km", start: "2025-12-16", methodologyName: "Kinetiq Markets" },
+  "kinetiq-markets": { dexId: "mkts", start: "2026-06-01", methodologyName: "Kinetiq" }, // Kinetiq migrated its HIP-3 dex from the now-dormant "km" to the active "mkts"
   "tradexyz": { dexId: "xyz", start: "2025-11-01", methodologyName: "Trade.xyz" },
   "ventuals": { dexId: "vntl", start: "2025-11-13", methodologyName: "Ventuals" },
   "paragon": { dexId: "para", start: "2026-03-30", methodologyName: "Paragon" },
@@ -894,7 +894,7 @@ const hip3OiConfigs: Record<string, string> = {
   "dreamcash-markets-oi": "cash",
   "felix-perp-oi": "flx",
   "hyena-oi": "hyna",
-  "kinetiq-markets-oi": "km",
+  "kinetiq-markets-oi": "mkts",
   "tradexyz-oi": "xyz",
   "ventuals-oi": "vntl",
   "paragon-oi": "para",


### PR DESCRIPTION
### Problem
Kinetiq deployed its "Markets by Kinetiq" HIP-3 perp dex on dexId `km` (now dormant, $0) and migrated to a new dexId `mkts` (active). DefiLlama's `kinetiq-markets` config still points at the dormant `km`:
- fees/volume config was commented out (`km`)
- OI config tracked `km`

Meanwhile the active `mkts` dex is tracked by **no adapter**, despite being the **2nd-largest HIP-3 dex after tradeXYZ** — larger than every other tracked HIP-3 dex (felix / ventuals / dreamcash are all $0).

### Verification (public HL API)
`km` and `mkts` are the same protocol — confirmed via `perpDexs`:

| dexId | fullName | deployer | feeRecipient | 24h vol | OI |
|---|---|---|---|---|---|
| `km` | Markets by Kinetiq | `0x71f0019c…` | `0xbcd4071d…` | $0 | $0 |
| `mkts` | Markets by Kinetiq | `0x71f0019c…` | `0xbcd4071d…` | ~$8.0m | ~$5.5m |

`mkts` has 23 active markets (US index / RWA perps: US500, USTECH, …). A repo-wide scan of all HIP-3 dexs grouped by deployer confirms this is the **only** "tracked-dormant → untracked-active" migration gap (felix/ventuals/dreamcash are genuinely dormant single-dex deployers, so their $0 is correct).

### Fix
Point `kinetiq-markets` at the active `mkts` dexId (uncomment the fees/volume config, update the OI config).

Note: HIP-3 fee/volume adapters run on the `LLAMA_HL_INDEXER`, so this can't be exercised by the local test CLI — verified instead against the public `api.hyperliquid.xyz` `perpDexs` + `metaAndAssetCtxs`.
