### PR TITLE
[feat] Prophet Market - add volume adapter

### DIFF
--- a/dexs/prophet-market/index.ts
+++ b/dexs/prophet-market/index.ts
@@ -29,7 +29,7 @@ const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
   const dailyVolume = options.createBalances();
 
   const logs = await options.getLogs({
-    target: EXCHANGE_ADDRESS,
+    targets: [EXCHANGE_ADDRESS],
     eventAbi: ORDER_FILLED_ABI,
     onlyArgs: true,
   });
@@ -47,18 +47,16 @@ const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
 
 const adapter: SimpleAdapter = {
   version: 2,
+  pullHourly: true,
   methodology: {
     Volume:
       "USDC notional traded through OrderFilled events on Prophet's CTF exchange. Each trade's USDC leg " +
       "(the side with asset id 0) is summed; complementary mint/merge legs sum to the collateral of a complete " +
       "set, so the raw sum is the true notional and is not divided.",
   },
-  adapter: {
-    [CHAIN.POLYGON]: {
-      fetch,
-      start: 1777608094, // block 86244025, ProphetCTFExchange deployment (2026-05-01)
-    },
-  },
+  chains: [CHAIN.POLYGON],
+  start: 1777608094, // block 86244025, ProphetCTFExchange deployment (2026-05-01)
+  fetch,
 };
 
 export default adapter;

--- a/dexs/prophet-market/index.ts
+++ b/dexs/prophet-market/index.ts
@@ -1,0 +1,64 @@
+import {
+  FetchOptions,
+  FetchResultV2,
+  SimpleAdapter,
+} from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+
+// Prophet Market is an on-chain prediction market on Polygon where outcomes are settled
+// through AI-powered resolution. Each trade settles through an `OrderFilled` event on the
+// ProphetCTFExchange, where one leg is native USDC collateral (asset id 0) and the
+// other is an ERC-1155 outcome token (a non-zero id).
+//
+// Volume = the USDC leg of every OrderFilled. Prophet's order flow is almost entirely
+// complementary mint/merge matches: the two counterparties of a trade pay different
+// USDC amounts for opposite outcomes (YES/NO), and those two USDC legs sum to the
+// collateral of one complete set. So summing every USDC leg yields the true notional
+// traded — this must NOT be divided by 2 (that would halve genuine mint/merge volume).
+// This mirrors Polymarket's production adapter, which likewise sums the USDC leg of
+// all OrderFilled events without dividing.
+
+const EXCHANGE_ADDRESS = "0x127aD3A6e55EbBDaecC0eaeb12615879611e1839"; // ProphetCTFExchange
+const USDC = "0x3c499c542cef5e3811e1192ce70d8cc03d5c3359"; // native Circle USDC on Polygon
+
+const ORDER_FILLED_ABI =
+  "event OrderFilled(bytes32 indexed orderHash, address indexed maker, address indexed taker, " +
+  "uint256 makerAssetId, uint256 takerAssetId, uint256 makerAmountFilled, uint256 takerAmountFilled, uint256 fee)";
+
+const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
+  const dailyVolume = options.createBalances();
+
+  const logs = await options.getLogs({
+    target: EXCHANGE_ADDRESS,
+    eventAbi: ORDER_FILLED_ABI,
+    onlyArgs: true,
+  });
+
+  for (const log of logs) {
+    // Count the USDC leg only: asset id 0 is collateral (USDC), any non-zero id is an outcome token.
+    if (BigInt(log.makerAssetId) === 0n)
+      dailyVolume.add(USDC, log.makerAmountFilled);
+    else if (BigInt(log.takerAssetId) === 0n)
+      dailyVolume.add(USDC, log.takerAmountFilled);
+  }
+
+  return { dailyVolume };
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  methodology: {
+    Volume:
+      "USDC notional traded through OrderFilled events on Prophet's CTF exchange. Each trade's USDC leg " +
+      "(the side with asset id 0) is summed; complementary mint/merge legs sum to the collateral of a complete " +
+      "set, so the raw sum is the true notional and is not divided.",
+  },
+  adapter: {
+    [CHAIN.POLYGON]: {
+      fetch,
+      start: 1777608094, // block 86244025, ProphetCTFExchange deployment (2026-05-01)
+    },
+  },
+};
+
+export default adapter;

--- a/dexs/prophet-market/index.ts
+++ b/dexs/prophet-market/index.ts
@@ -28,8 +28,8 @@ const adapter: SimpleAdapter = {
   version: 2,
   pullHourly: true,
   methodology: {
-    Volume:
-      "USDC notional traded through OrderFilled events on Prophet's CTF exchange. Only the collateral (USDC) side of each fill is counted and amounts are halved to correct for maker + taker double counting, matching the Polymarket methodology.",
+    Volume: "USDC volume traded through OrderFilled events on Prophet's CTF exchange. Only the collateral (USDC) side of each fill is counted and amounts are halved to correct for maker + taker double counting, matching the Polymarket methodology.",
+    NotionalVolume: "Notional volume (1 USDC = 1 outcome token) traded through OrderFilled events on Prophet's CTF exchange.",
   },
   chains: [CHAIN.POLYGON],
   start: "2026-05-01", // block 86244025, ProphetCTFExchange deployment

--- a/dexs/prophet-market/index.ts
+++ b/dexs/prophet-market/index.ts
@@ -1,48 +1,27 @@
-import {
-  FetchOptions,
-  FetchResultV2,
-  SimpleAdapter,
-} from "../../adapters/types";
+import { FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
+import { getPolymarketVolume } from "../../helpers/polymarket";
+import ADDRESSES from '../../helpers/coreAssets.json'
 
 // Prophet Market is an on-chain prediction market on Polygon where outcomes are settled
 // through AI-powered resolution. Each trade settles through an `OrderFilled` event on the
 // ProphetCTFExchange, where one leg is native USDC collateral (asset id 0) and the
 // other is an ERC-1155 outcome token (a non-zero id).
-//
-// Volume = the USDC leg of every OrderFilled. Prophet's order flow is almost entirely
-// complementary mint/merge matches: the two counterparties of a trade pay different
-// USDC amounts for opposite outcomes (YES/NO), and those two USDC legs sum to the
-// collateral of one complete set. So summing every USDC leg yields the true notional
-// traded — this must NOT be divided by 2 (that would halve genuine mint/merge volume).
-// This mirrors Polymarket's production adapter, which likewise sums the USDC leg of
-// all OrderFilled events without dividing.
 
 const EXCHANGE_ADDRESS = "0x127aD3A6e55EbBDaecC0eaeb12615879611e1839"; // ProphetCTFExchange
-const USDC = "0x3c499c542cef5e3811e1192ce70d8cc03d5c3359"; // native Circle USDC on Polygon
+const USDC = ADDRESSES.polygon.USDC_CIRCLE
 
-const ORDER_FILLED_ABI =
-  "event OrderFilled(bytes32 indexed orderHash, address indexed maker, address indexed taker, " +
-  "uint256 makerAssetId, uint256 takerAssetId, uint256 makerAmountFilled, uint256 takerAmountFilled, uint256 fee)";
-
-const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
-  const dailyVolume = options.createBalances();
-
-  const logs = await options.getLogs({
-    targets: [EXCHANGE_ADDRESS],
-    eventAbi: ORDER_FILLED_ABI,
-    onlyArgs: true,
+const fetch = async (options: FetchOptions) => {
+  const { dailyVolume, dailyNotionalVolume } = await getPolymarketVolume({
+    options,
+    exchanges: [EXCHANGE_ADDRESS],
+    currency: USDC,
   });
 
-  for (const log of logs) {
-    // Count the USDC leg only: asset id 0 is collateral (USDC), any non-zero id is an outcome token.
-    if (BigInt(log.makerAssetId) === 0n)
-      dailyVolume.add(USDC, log.makerAmountFilled);
-    else if (BigInt(log.takerAssetId) === 0n)
-      dailyVolume.add(USDC, log.takerAmountFilled);
-  }
-
-  return { dailyVolume };
+  return {
+    dailyVolume,
+    dailyNotionalVolume,
+  };
 };
 
 const adapter: SimpleAdapter = {
@@ -50,12 +29,10 @@ const adapter: SimpleAdapter = {
   pullHourly: true,
   methodology: {
     Volume:
-      "USDC notional traded through OrderFilled events on Prophet's CTF exchange. Each trade's USDC leg " +
-      "(the side with asset id 0) is summed; complementary mint/merge legs sum to the collateral of a complete " +
-      "set, so the raw sum is the true notional and is not divided.",
+      "USDC notional traded through OrderFilled events on Prophet's CTF exchange. Only the collateral (USDC) side of each fill is counted and amounts are halved to correct for maker + taker double counting, matching the Polymarket methodology.",
   },
   chains: [CHAIN.POLYGON],
-  start: 1777608094, // block 86244025, ProphetCTFExchange deployment (2026-05-01)
+  start: "2026-05-01", // block 86244025, ProphetCTFExchange deployment
   fetch,
 };
 


### PR DESCRIPTION
##### Name (to be shown on DefiLlama): Prophet

##### Twitter Link: https://x.com/prophetmarketai

##### List of audit links if any: 

- Hashlock: https://github.com/ProphetMarket/contracts/blob/master/audits/hashlock--audit-report-v1.pdf
- Failsafe: https://github.com/ProphetMarket/contracts/blob/master/audits/failsafe--prophet-markets-security-assessment-v1.pdf

##### Website Link: https://app.prophetmarket.ai

##### Logo (High resolution, will be shown with rounded borders):  https://app.prophetmarket.ai/logo.svg

##### Current TVL: 14.5K

##### Treasury Addresses (if the protocol has treasury) 

0x2C5f34744c445613f9ecbb3c8e109F1c8D86De76
0xBA8065151BC3191d0A032ca9499AA54E97899E8E

##### Chain: Polygon

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed): (https://api.coingecko.com/api/v3/coins/list)

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)

##### Short Description (to be shown on DefiLlama): 

Prophet Market is an on-chain prediction market on Polygon where outcomes are settled through AI-powered resolution.

##### Token address and ticker if any:

No token

##### Category (full list at https://defillama.com/categories) \*Please choose only one:

Prediction Market

##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.):

USDC as collateral, no price provider's

##### Implementation Details: Briefly describe how the oracle is integrated into your project:

##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage:

##### forkedFrom (Does your project originate from another project):

Polymarket

##### methodology (what is being counted as tvl, how is tvl being calculated):

Volume = the USDC leg of every OrderFilled. Prophet's order flow is almost entirely
complementary mint/merge matches: the two counterparties of a trade pay different
USDC amounts for opposite outcomes (YES/NO), and those two USDC legs sum to the
collateral of one complete set. So summing every USDC leg yields the true notional
traded — this must NOT be divided by 2 (that would halve genuine mint/merge volume).
This mirrors Polymarket's production adapter, which likewise sums the USDC leg of
all OrderFilled events without dividing.

##### Github org/user (Optional, if your code is open source, we can track activity):

https://github.com/prophetmarket

##### Does this project have a referral program?

Yes