### PR TITLE
ave: add doublecounted

### DIFF
--- a/dexs/aveai/index.ts
+++ b/dexs/aveai/index.ts
@@ -97,7 +97,7 @@ const fetch = async (options: FetchOptions): Promise<FetchResult> => {
 };
 
 const methodology = {
-  Volume: "Total USD volume processed by ave.ai router contracts.",
+  Volume: "Total USD value of the swaps ave.ai routes through underlying DEXs. Double-counted, since those same swaps are also reported by the DEXs that actually execute them.",
 };
 
 const adapter: SimpleAdapter = {
@@ -105,6 +105,7 @@ const adapter: SimpleAdapter = {
   fetch,
   adapter: chainConfig,
   dependencies: [Dependencies.DUNE],
+  doublecounted: true,
   methodology,
 };
 


### PR DESCRIPTION
Marks ave.ai volume as `doublecounted` to reflect its role as a DEX aggregator rather than a liquidity venue.

## Verification

- Solana volume is sourced from underlying `dex_solana.trades`, making double counting inherent.
- Decoded Base transactions confirm ave.ai routes trades through Uniswap V3/V4 pools while emitting a wrapper `Swap` event.
- Adapter output is unchanged; only the classification is corrected.