### PR TITLE
Fanex — Solana creator-token launchpad (volume, fees, revenue)

### DIFF
--- a/dexs/fanex.ts
+++ b/dexs/fanex.ts
@@ -3,6 +3,7 @@ import { Dependencies, FetchOptions, FetchResult, SimpleAdapter } from '../adapt
 import { CHAIN } from '../helpers/chains'
 import { queryDuneSql } from '../helpers/dune'
 import { getSolanaReceived } from '../helpers/token'
+import { METRIC } from '../helpers/metrics'
 
 // Fanex — YouTube creator-token launchpad on Solana. New tokens trade on a custom on-chain
 // bonding-curve program `fanex_curve` (program id CDPwGWGWbAE8FL5f2oVdzfkTutrnsKJcAcgqWktC3dwZ).
@@ -40,7 +41,7 @@ const VOLUME_SQL = (options: FetchOptions) => `
 // `
 
 const fetch = async (options: FetchOptions): Promise<FetchResult> => {
-  const [rows, dailyFees] = await Promise.all([
+  const [rows, feesReceived] = await Promise.all([
     queryDuneSql(options, VOLUME_SQL(options)),
     // If treasury top-ups from known Fanex-owned wallets ever need excluding, add `blacklists: [...]`.
     getSolanaReceived({ target: FANEX_FEE_WALLET, options }),
@@ -48,6 +49,12 @@ const fetch = async (options: FetchOptions): Promise<FetchResult> => {
 
   const dailyVolume = options.createBalances()
   dailyVolume.add(ADDRESSES.solana.SOL, Number(rows?.[0]?.volume_lamports ?? 0))
+
+  // All fee-wallet inflow is booked under a single label: getSolanaReceived returns
+  // one SOL total, so the 6% fundraise share, 1% swap fee, 3% dividend cut and
+  // harvested LP fees can't be split into distinct on-chain labels.
+  const dailyFees = options.createBalances()
+  dailyFees.addBalances(feesReceived, METRIC.TRADING_FEES)
 
   return {
     dailyVolume,
@@ -71,6 +78,18 @@ const adapter: SimpleAdapter = {
     Fees: 'All value received by the Fanex fee wallet on Solana: the 6% fundraise share plus the 1% platform swap fee taken on every fanex_curve buy/sell, the 3% cut on creator dividend distributions, and harvested Raydium CPMM LP fees.',
     Revenue: 'Fanex retains 100% of what its fee wallet collects, so revenue equals fees.',
     ProtocolRevenue: 'Equal to revenue — all of it accrues to the Fanex treasury. The 94% creator fundraise share is paid directly to creators and is not received by this wallet.',
+  },
+  breakdownMethodology: {
+    Fees: {
+      [METRIC.TRADING_FEES]:
+        'All SOL received by the Fanex fee wallet: the 6% fundraise share + 1% platform swap fee on every fanex_curve buy/sell, the 3% cut on creator dividend distributions, and harvested Raydium CPMM LP fees.',
+    },
+    Revenue: {
+      [METRIC.TRADING_FEES]: 'Fanex retains all fee-wallet inflow, so revenue equals fees.',
+    },
+    ProtocolRevenue: {
+      [METRIC.TRADING_FEES]: 'All fee-wallet inflow accrues to the Fanex treasury.',
+    },
   },
 }
 

--- a/dexs/fanex.ts
+++ b/dexs/fanex.ts
@@ -1,0 +1,75 @@
+import ADDRESSES from '../helpers/coreAssets.json'
+import { Dependencies, FetchOptions, FetchResult, SimpleAdapter } from '../adapters/types'
+import { CHAIN } from '../helpers/chains'
+import { queryDuneSql } from '../helpers/dune'
+import { getSolanaReceived } from '../helpers/token'
+
+// Fanex — YouTube creator-token launchpad on Solana. New tokens trade on a custom on-chain
+// bonding-curve program `fanex_curve` (program id CDPwGWGWbAE8FL5f2oVdzfkTutrnsKJcAcgqWktC3dwZ).
+//
+// Volume  → SOL paid into bonding-curve buys (fanex_curve `buy` instruction, arg `sol_in`).
+//           Post-graduation Raydium CPMM trading is excluded — that volume is already counted by
+//           Raydium. See the buy-side note on VOLUME_SQL below.
+// Fees    → everything received by the Fanex fee wallet: the 6% fundraise share + 1% platform swap
+//           fee on every trade, the 3% cut on creator dividend distributions, and harvested Raydium
+//           CPMM LP fees. The 94% creator fundraise share is paid directly to creators and never
+//           touches this wallet, so it is correctly excluded from protocol fees/revenue.
+const FANEX_FEE_WALLET = 'FanexC732Lqr6k2vg93ipaRkpaUJx4vz47zfeeHj9MFx'
+
+// Volume is taken from the decoded `buy` INSTRUCTION table (sol_in = exact SOL paid). Dune decoded
+// the fanex_curve instruction tables (fanex_curve_call_buy / _call_sell) but NOT the emit_cpi! Trade
+// EVENT table — fanex_curve_evt_trade is still empty weeks after the decode was accepted (Anchor's
+// emit_cpi! writes the event as a self-CPI that Dune's decoder isn't materializing). This is
+// therefore BUY-SIDE volume: sell realized-SOL isn't in the instruction args (call_sell only carries
+// token_in + a min_sol_out slippage floor), so sells are not counted — a negligible share of early
+// launchpad volume, which is heavily buy-dominated. When fanex_curve_evt_trade populates, switch to
+// the commented event query below for exact buy + sell volume (Trade.sol_amount).
+const VOLUME_SQL = (options: FetchOptions) => `
+  SELECT COALESCE(SUM(sol_in), 0) AS volume_lamports
+  FROM fanex_solana.fanex_curve_call_buy
+  WHERE call_block_time >= from_unixtime(${options.startTimestamp})
+    AND call_block_time <  from_unixtime(${options.endTimestamp})
+`
+
+// Upgrade path (exact buy + sell) once Dune decodes the emit_cpi! Trade event:
+// const VOLUME_SQL = (options: FetchOptions) => `
+//   SELECT COALESCE(SUM(sol_amount), 0) AS volume_lamports
+//   FROM fanex_solana.fanex_curve_evt_trade
+//   WHERE evt_block_time >= from_unixtime(${options.startTimestamp})
+//     AND evt_block_time <  from_unixtime(${options.endTimestamp})
+// `
+
+const fetch = async (options: FetchOptions): Promise<FetchResult> => {
+  const [rows, dailyFees] = await Promise.all([
+    queryDuneSql(options, VOLUME_SQL(options)),
+    // If treasury top-ups from known Fanex-owned wallets ever need excluding, add `blacklists: [...]`.
+    getSolanaReceived({ target: FANEX_FEE_WALLET, options }),
+  ])
+
+  const dailyVolume = options.createBalances()
+  dailyVolume.add(ADDRESSES.solana.SOL, Number(rows?.[0]?.volume_lamports ?? 0))
+
+  return {
+    dailyVolume,
+    dailyFees,
+    dailyRevenue: dailyFees,
+    dailyProtocolRevenue: dailyFees,
+  }
+}
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  fetch,
+  chains: [CHAIN.SOLANA],
+  start: '2026-06-30', // first fanex_curve mainnet trade (2026-06-30T19:52:40Z)
+  dependencies: [Dependencies.DUNE, Dependencies.ALLIUM],
+  isExpensiveAdapter: true,
+  methodology: {
+    Volume: 'SOL paid into fanex_curve bonding-curve buys (the decoded buy instruction arg sol_in, fanex_solana.fanex_curve_call_buy). Buy-side only for now — the emit_cpi! Trade event that carries realized sell SOL is not yet decoded by Dune; sells are a negligible share of early volume. Post-graduation Raydium CPMM trading is excluded (counted by Raydium).',
+    Fees: 'All value received by the Fanex fee wallet on Solana: the 6% fundraise share plus the 1% platform swap fee taken on every fanex_curve buy/sell, the 3% cut on creator dividend distributions, and harvested Raydium CPMM LP fees.',
+    Revenue: 'Fanex retains 100% of what its fee wallet collects, so revenue equals fees.',
+    ProtocolRevenue: 'Equal to revenue — all of it accrues to the Fanex treasury. The 94% creator fundraise share is paid directly to creators and is not received by this wallet.',
+  },
+}
+
+export default adapter

--- a/dexs/fanex.ts
+++ b/dexs/fanex.ts
@@ -50,17 +50,23 @@ const fetch = async (options: FetchOptions): Promise<FetchResult> => {
   const dailyVolume = options.createBalances()
   dailyVolume.add(ADDRESSES.solana.SOL, Number(rows?.[0]?.volume_lamports ?? 0))
 
-  // All fee-wallet inflow is booked under a single label: getSolanaReceived returns
-  // one SOL total, so the 6% fundraise share, 1% swap fee, 3% dividend cut and
-  // harvested LP fees can't be split into distinct on-chain labels.
+  // Fees = gross inflow to the fee wallet, labeled by SOURCE (trading fees).
+  // getSolanaReceived returns one SOL total, so the 6% fundraise share, 1% swap
+  // fee, 3% dividend cut and harvested LP fees can't be split into distinct labels.
   const dailyFees = options.createBalances()
   dailyFees.addBalances(feesReceived, METRIC.TRADING_FEES)
+
+  // Revenue = the same SOL, labeled by DESTINATION: Fanex keeps 100% of what its
+  // fee wallet collects (no supply-side cut is netted here — see methodology), so
+  // it all accrues to the protocol treasury.
+  const dailyRevenue = options.createBalances()
+  dailyRevenue.addBalances(feesReceived, METRIC.PROTOCOL_FEES)
 
   return {
     dailyVolume,
     dailyFees,
-    dailyRevenue: dailyFees,
-    dailyProtocolRevenue: dailyFees,
+    dailyRevenue,
+    dailyProtocolRevenue: dailyRevenue,
   }
 }
 
@@ -85,10 +91,10 @@ const adapter: SimpleAdapter = {
         'All SOL received by the Fanex fee wallet: the 6% fundraise share + 1% platform swap fee on every fanex_curve buy/sell, the 3% cut on creator dividend distributions, and harvested Raydium CPMM LP fees.',
     },
     Revenue: {
-      [METRIC.TRADING_FEES]: 'Fanex retains all fee-wallet inflow, so revenue equals fees.',
+      [METRIC.PROTOCOL_FEES]: 'All fee-wallet inflow is retained by Fanex, so revenue equals fees.',
     },
     ProtocolRevenue: {
-      [METRIC.TRADING_FEES]: 'All fee-wallet inflow accrues to the Fanex treasury.',
+      [METRIC.PROTOCOL_FEES]: 'All fee-wallet inflow accrues to the Fanex protocol treasury.',
     },
   },
 }

--- a/dexs/fanex.ts
+++ b/dexs/fanex.ts
@@ -58,7 +58,9 @@ const fetch = async (options: FetchOptions): Promise<FetchResult> => {
 }
 
 const adapter: SimpleAdapter = {
-  version: 2,
+  // v1 is required for Dune-backed adapters: Dune runs once per day, so a v2
+  // (hourly) adapter would needlessly re-run the same expensive query.
+  version: 1,
   fetch,
   chains: [CHAIN.SOLANA],
   start: '2026-06-30', // first fanex_curve mainnet trade (2026-06-30T19:52:40Z)

--- a/dexs/fanex.ts
+++ b/dexs/fanex.ts
@@ -71,8 +71,6 @@ const fetch = async (options: FetchOptions): Promise<FetchResult> => {
 }
 
 const adapter: SimpleAdapter = {
-  // v1 is required for Dune-backed adapters: Dune runs once per day, so a v2
-  // (hourly) adapter would needlessly re-run the same expensive query.
   version: 1,
   fetch,
   chains: [CHAIN.SOLANA],
@@ -82,8 +80,8 @@ const adapter: SimpleAdapter = {
   methodology: {
     Volume: 'SOL paid into fanex_curve bonding-curve buys (the decoded buy instruction arg sol_in, fanex_solana.fanex_curve_call_buy). Buy-side only for now — the emit_cpi! Trade event that carries realized sell SOL is not yet decoded by Dune; sells are a negligible share of early volume. Post-graduation Raydium CPMM trading is excluded (counted by Raydium).',
     Fees: 'All value received by the Fanex fee wallet on Solana: the 6% fundraise share plus the 1% platform swap fee taken on every fanex_curve buy/sell, the 3% cut on creator dividend distributions, and harvested Raydium CPMM LP fees.',
-    Revenue: 'Fanex retains 100% of what its fee wallet collects, so revenue equals fees.',
-    ProtocolRevenue: 'Equal to revenue — all of it accrues to the Fanex treasury. The 94% creator fundraise share is paid directly to creators and is not received by this wallet.',
+    Revenue: 'All value received by the Fanex fee wallet on Solana: the 6% fundraise share plus the 1% platform swap fee taken on every fanex_curve buy/sell, the 3% cut on creator dividend distributions, and harvested Raydium CPMM LP fees.',
+    ProtocolRevenue: 'All value received by the Fanex fee wallet on Solana: the 6% fundraise share plus the 1% platform swap fee taken on every fanex_curve buy/sell, the 3% cut on creator dividend distributions, and harvested Raydium CPMM LP fees.',
   },
   breakdownMethodology: {
     Fees: {


### PR DESCRIPTION
## Fanex — Solana creator-token launchpad (volume, fees, revenue)

New protocol listing. Fanex is a creator-token launchpad on Solana — live for YouTube today, with
OnlyFans, Spotify and Twitch coming soon. New tokens trade on a custom on-chain bonding-curve program `fanex_curve`
(program id `CDPwGWGWbAE8FL5f2oVdzfkTutrnsKJcAcgqWktC3dwZ`); graduated tokens migrate to a Raydium
CPMM pool.

- **Adapter:** `dexs/fanex.ts` (single file — volume + fees + revenue)
- **Dependencies:** `Dependencies.DUNE` (volume) + `Dependencies.ALLIUM` (fees) → `isExpensiveAdapter`, runs daily
- **Start:** 2026-06-30 (first `fanex_curve` mainnet trade)

**Validation**
- Volume SQL validated live against the Dune-decoded table: **48 buys / ~11.63 SOL** (2026-06-30 → 2026-07-21). Public dashboard: https://dune.com/queries/8013352
- Fee routing verified against a real mainnet buy — `fanex_fee` of **0.0060144 SOL** landing in `FanexC732…`, matching the on-chain transfer and the protocol's internal `fanex_received_sol` ledger.


##### Name (to be shown on DefiLlama):
Fanex

##### Twitter Link:
https://x.com/fanexmarket

##### List of audit links if any:
None

##### Website Link:
https://fanex.market

##### Logo (High resolution, will be shown with rounded borders):
High-res 1024×1024 transparent PNG attached below (`fanex.png`). Please host under slug `fanex` (i.e. `icons.llama.fi/fanex.png`).

##### Current TVL:
N/A — Fanex is a launchpad/trading venue; this is a dimension-adapters listing reporting **Volume, Fees and Revenue only** (no TVL adapter).

##### Treasury Addresses (if the protocol has treasury)
Fanex fee/treasury wallet (Solana): `FanexC732Lqr6k2vg93ipaRkpaUJx4vz47zfeeHj9MFx`

##### Chain:
Solana

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed):
(none — no protocol token)

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed):
(none — no protocol token)

##### Short Description (to be shown on DefiLlama):
Creator-token launchpad on Solana — live for YouTube, with OnlyFans, Spotify and Twitch coming soon. Creators launch tokens on a custom on-chain bonding curve; tokens graduate to a Raydium CPMM pool.

##### Token address and ticker if any:
None (no protocol token)

##### Category (full list at https://defillama.com/categories)
Launchpad

##### Oracle Provider(s):
N/A — no oracle used by the protocol. SOL→USD pricing for the adapter is handled by DefiLlama's own price oracle.

##### Implementation Details:
N/A (no oracle).

##### Documentation/Proof:
N/A (no oracle).

##### forkedFrom (Does your project originate from another project):
No

##### methodology (what is being counted as tvl, how is tvl being calculated):
- **Volume** — SOL paid into `fanex_curve` bonding-curve buys, from the Dune-decoded buy instruction arg `sol_in` (`fanex_solana.fanex_curve_call_buy`). Buy-side only for now: Anchor's `emit_cpi!` `Trade` event (which carries realized sell SOL) is not yet materialized by Dune; sells are a negligible share of early launchpad volume. Post-graduation Raydium CPMM trading is excluded (already counted by Raydium).
- **Fees** — all SOL received by the Fanex fee wallet `FanexC732Lqr6k2vg93ipaRkpaUJx4vz47zfeeHj9MFx` (`getSolanaReceived`, Allium): the 6% fundraise share, the 1% platform swap fee on every buy/sell, the 3% cut on creator dividend distributions, and harvested Raydium CPMM LP fees.
- **Revenue / ProtocolRevenue** — Fanex retains what lands in its fee wallet, so revenue ≈ fees. A small referral rebate (10% of a referred user's Fanex fee, paid back out of this wallet to Level-2+ referrers, live since 2026-07-07) and the creator's LP-fee cut are distributions out of the wallet; `getSolanaReceived` measures inflow only, so it does not net them out. Both are currently negligible (~0); the gross figure is used and can be netted once material.

##### Github org/user
(optional — add your GitHub org/user if desired)

##### Does this project have a referral program?
Yes — referral links use the format `https://fanex.market/?ref=<code>` (also `https://fanex.market/r/<code>`). Referrers earn a points boost and a SOL fee-share on their referred users' trading.

---

### CI note (post as a PR comment)

Note on CI: this adapter uses `Dependencies.DUNE` + `Dependencies.ALLIUM`, so the fork-PR test fails with `DUNE_API_KEYS environment variable is not set` — expected, since fork PRs don't receive repo secrets. The adapter itself loads/compiles fine (the log prints "adapter exports" before the key check).

Validation on our side:
- Volume SQL run live against the decoded table `fanex_solana.fanex_curve_call_buy` → 48 buys / ~11.63 SOL (2026-06-30 → 2026-07-21). Public dashboard: https://dune.com/queries/8013352
- Fees use the standard `getSolanaReceived` (Allium) on the Fanex fee wallet `FanexC732Lqr6k2vg93ipaRkpaUJx4vz47zfeeHj9MFx`.

Please run with your DUNE/ALLIUM keys — happy to adjust anything.
