### PR TITLE
[fix] hyperliquid - correct splashos-perps builder address (was CoinPilot's)

### DIFF
--- a/factory/hyperliquid.ts
+++ b/factory/hyperliquid.ts
@@ -335,6 +335,9 @@ const builderConfigs: Record<string, BuilderConfig> = {
   "ranger-finance-perps": { addresses: ["0xf5bc9107916b91a3ea5966cd2e51655d21b7eb02"], start: "2025-08-12" },
   "senpi-perps": { addresses: ["0x1368f4311db5807f7c7924d736adaeb83e47bafe"], start: "2025-11-10" },
   "splashos-perps": {
+    // Splash Wallet builder code. Source: HyperTracker public builder registry
+    // (refCode "Splash", joined 2025-06-04). Was previously mis-set to CoinPilot's
+    // builder address (shared with coinpilot-perps above), which double-counted CoinPilot.
     addresses: ["0x3f24962739e6d703942dc2456e7c51c8d0ca4b70"],
     start: "2025-06-04",
     methodology: {

--- a/factory/hyperliquid.ts
+++ b/factory/hyperliquid.ts
@@ -335,8 +335,8 @@ const builderConfigs: Record<string, BuilderConfig> = {
   "ranger-finance-perps": { addresses: ["0xf5bc9107916b91a3ea5966cd2e51655d21b7eb02"], start: "2025-08-12" },
   "senpi-perps": { addresses: ["0x1368f4311db5807f7c7924d736adaeb83e47bafe"], start: "2025-11-10" },
   "splashos-perps": {
-    addresses: ["0xe9935bb291ab3603b4d7862e6f19315f759aa3a4"],
-    start: "2025-08-01",
+    addresses: ["0x3f24962739e6d703942dc2456e7c51c8d0ca4b70"],
+    start: "2025-06-04",
     methodology: {
       Fees: "Trading fees paid by users for perps in SplashOS Mobile App.",
       Revenue: "Fees collected by SplashOS from Hyperliquid Perps as Builder Revenue.",


### PR DESCRIPTION
## Problem

In `factory/hyperliquid.ts`, `splashos-perps` and `coinpilot-perps` both use the same builder address `0xe9935bb291ab3603b4d7862e6f19315f759aa3a4`, which belongs to CoinPilot.

Two consequences:

1. **Double-count** — CoinPilot's builder fees are attributed to two protocols. DefiLlama reports identical figures under both `Coinpilot` and `Splash Wallet Perps` (~$1.81k/30d, ~$153k all-time — the same numbers on each).
2. **Missing** — Splash's actual builder `0x3f24962739e6d703942dc2456e7c51c8d0ca4b70` (~$47k of accrued USDC builder fees on HyperCore) is not tracked at all.

Both entries were added together in #5675 with the same `start` date, consistent with a copy-paste.

## Fix

Point `splashos-perps` at Splash's real builder address, with its join date (`2025-06-04`) as `start`. `coinpilot-perps` is left unchanged — its address is correct.

## Verification

- The ~$153k currently shown under both protocols is earned by `0xe9935bb…` (CoinPilot's builder).
- Splash's address `0x3f2496…` matches the HyperTracker public builder registry (refCode "Splash", joined 2025-06-04) and holds ~$47k of accrued USDC builder fees on HyperCore; it appeared nowhere in the config before this change.
- CoinPilot and Splash Wallet are distinct apps (a copy-trading app vs. a Hyperliquid mobile wallet).
