### PR TITLE
[feat] hyperliquid - track CCXT and Owly.fi builder codes

### DIFF
--- a/factory/hyperliquid.ts
+++ b/factory/hyperliquid.ts
@@ -782,6 +782,29 @@ const builderConfigs: Record<string, BuilderConfig> = {
     },
     breakdownFees: true,
   },
+  // CCXT trading library builder code (HyperTracker public builder registry,
+  // refCode "CCXT1", joined 2025-07-16). ~$310k of accrued builder fees on
+  // HyperCore, not tracked by any existing config.
+  "ccxt-perps": {
+    addresses: ["0x6530512a6c89c7cfcebc3ba7fcd9ada5f30827a6"],
+    start: "2025-07-16",
+    methodology: {
+      Fees: "Builder code fees paid by users trading Hyperliquid perps via CCXT.",
+      Revenue: "Builder code fees collected by CCXT from Hyperliquid perps trades.",
+      ProtocolRevenue: "Builder code fees collected by CCXT from Hyperliquid perps trades.",
+    },
+  },
+  // Owly.fi asset-management / copy-trading app on Hyperliquid (app.owly.fi;
+  // HyperTracker public builder registry, joined 2025-12-17). Untracked builder.
+  "owly-fi-perps": {
+    addresses: ["0x2e2e7c7696134f740aea7242a55b55d5cf769fab"],
+    start: "2025-12-17",
+    methodology: {
+      Fees: "Builder code fees paid by users trading Hyperliquid perps via Owly.fi.",
+      Revenue: "Builder code fees collected by Owly.fi from Hyperliquid perps trades.",
+      ProtocolRevenue: "Builder code fees collected by Owly.fi from Hyperliquid perps trades.",
+    },
+  },
 };
 
 


### PR DESCRIPTION
## What

Adds two Hyperliquid builder codes to `factory/hyperliquid.ts` that earn real builder fees but are not tracked by any existing config:

| Builder | Address | Accrued builder fees (HyperCore) | Since | website |
|---|---|---|---|---|
| CCXT | `0x6530512a6c89c7cfcebc3ba7fcd9ada5f30827a6` | ~$310k | 2025-07-16 | https://ccxt.com/ |
| Owly.fi | `0x2e2e7c7696134f740aea7242a55b55d5cf769fab` | ~$24k | 2025-12-17 | Owly.fi |

## Verification

- Addresses come from the HyperTracker public builder registry (refCode `CCXT1` for CCXT; Owly.fi joined 2025-12-17), independent of DefiLlama.
- Neither address nor name appears anywhere in `factory/hyperliquid.ts`, and neither surfaces in `/overview/fees/Hyperliquid` — they are entirely untracked.
- On-chain, the two builder addresses hold ~$310k and ~$24k of accrued USDC builder fees on HyperCore.
- CCXT is the widely-used trading library (ccxt.com); Owly.fi is a Hyperliquid asset-management / copy-trading app (app.owly.fi).

Both entries use the existing `exportBuilderAdapter` path, identical to the ~90 builder codes already configured here.

## Note

A separate scan against the same registry surfaced a handful of other untracked builders that are dormant ($0 accrued), so they are intentionally not added here.
