### PR TITLE
1inch-aqua: add fees adapter (DAO protocol revenue from fee-exchanger inflows)

### DIFF
--- a/fees/1inch-aqua/index.ts
+++ b/fees/1inch-aqua/index.ts
@@ -6,42 +6,65 @@ import { addTokensReceived, nullAddress } from "../../helpers/token";
 // 1inch DAO fee exchangers — the receivers encoded into every Aqua strategy's
 // protocol-fee instruction (https://github.com/1inch/aqua). At fill time SwapVM
 // transfers the DAO's share of the LP fee straight from the swap to this
-// address, so ERC20 inflows here are the protocol's revenue stream.
-// Addresses mirror the 1inch dApp chain config; three chains use
-// chain-specific deployments, the rest share one address.
+// address, so ERC20 inflows here are the protocol's revenue stream. The
+// exchangers were purpose-deployed for the protocol-fee launch (2026-07-18/19)
+// and receive nothing else.
+//
+// Protocol fee is encoded into new positions by default since 2026-07-19
+// (1inch DAO governance decision); the BNB Chain and Robinhood Chain
+// exchangers were verified and enabled on 2026-07-21. Addresses mirror the
+// 1inch dApp chain config; three chains use chain-specific deployments, the
+// rest share one address.
 const DEFAULT_EXCHANGER = "0x8063d4faf54bf8c898dc6ddc689c76ab12b4614a";
 
-const FEE_EXCHANGER: Record<string, string> = {
-  [CHAIN.ETHEREUM]: DEFAULT_EXCHANGER,
-  [CHAIN.BASE]: DEFAULT_EXCHANGER,
-  [CHAIN.OPTIMISM]: DEFAULT_EXCHANGER,
-  [CHAIN.POLYGON]: DEFAULT_EXCHANGER,
-  [CHAIN.ARBITRUM]: DEFAULT_EXCHANGER,
-  [CHAIN.BSC]: DEFAULT_EXCHANGER,
-  [CHAIN.XDAI]: DEFAULT_EXCHANGER,
-  [CHAIN.SONIC]: DEFAULT_EXCHANGER,
-  [CHAIN.UNICHAIN]: DEFAULT_EXCHANGER,
-  [CHAIN.ROBINHOOD]: DEFAULT_EXCHANGER,
-  [CHAIN.ERA]: "0xc0242e93dc86ab95210d6deaf8b9118fea3bde06",
-  [CHAIN.AVAX]: "0xa7417d51427a60d3a4629615da44d1b8698e6cf4",
-  [CHAIN.LINEA]: "0x0f4b0148f984320d255557a0006162af3a3c7baa",
+const chainConfig: Record<string, { exchanger: string; start: string }> = {
+  [CHAIN.ETHEREUM]: { exchanger: DEFAULT_EXCHANGER, start: "2026-07-19" },
+  [CHAIN.BASE]: { exchanger: DEFAULT_EXCHANGER, start: "2026-07-19" },
+  [CHAIN.OPTIMISM]: { exchanger: DEFAULT_EXCHANGER, start: "2026-07-19" },
+  [CHAIN.POLYGON]: { exchanger: DEFAULT_EXCHANGER, start: "2026-07-19" },
+  [CHAIN.ARBITRUM]: { exchanger: DEFAULT_EXCHANGER, start: "2026-07-19" },
+  [CHAIN.XDAI]: { exchanger: DEFAULT_EXCHANGER, start: "2026-07-19" },
+  [CHAIN.SONIC]: { exchanger: DEFAULT_EXCHANGER, start: "2026-07-19" },
+  [CHAIN.UNICHAIN]: { exchanger: DEFAULT_EXCHANGER, start: "2026-07-19" },
+  [CHAIN.ERA]: {
+    exchanger: "0xc0242e93dc86ab95210d6deaf8b9118fea3bde06",
+    start: "2026-07-19",
+  },
+  [CHAIN.AVAX]: {
+    exchanger: "0xa7417d51427a60d3a4629615da44d1b8698e6cf4",
+    start: "2026-07-19",
+  },
+  [CHAIN.LINEA]: {
+    exchanger: "0x0f4b0148f984320d255557a0006162af3a3c7baa",
+    start: "2026-07-19",
+  },
+  [CHAIN.BSC]: { exchanger: DEFAULT_EXCHANGER, start: "2026-07-21" },
+  [CHAIN.ROBINHOOD]: { exchanger: DEFAULT_EXCHANGER, start: "2026-07-21" },
+};
+
+// Mint transfers (from == 0x0) are excluded: the exchanger holds
+// interest-bearing tokens (e.g. aTokens) whose rebase mints would otherwise
+// count as fee income. Handles both log shapes: indexer entries carry a from
+// field; raw fallback logs carry the sender in topics[1].
+const isNotMint = (log: any): boolean => {
+  const from =
+    log.from ??
+    log.from_address ??
+    log.fromAddress ??
+    log.args?.from ??
+    (log.topics?.[1] ? "0x" + String(log.topics[1]).slice(-40) : "");
+  return String(from).toLowerCase() !== nullAddress;
 };
 
 const fetch = async (options: FetchOptions) => {
-  // Mint transfers (from == 0x0) are excluded: the exchanger holds
-  // interest-bearing tokens (e.g. aTokens) whose rebase mints would otherwise
-  // count as fee income.
   const inflows = await addTokensReceived({
     options,
-    target: FEE_EXCHANGER[options.chain],
-    logFilter: (log: any) =>
-      String(
-        log.from ?? log.from_address ?? log.fromAddress ?? log.args?.from ?? "",
-      ).toLowerCase() !== nullAddress,
+    target: chainConfig[options.chain].exchanger,
+    logFilter: isNotMint,
   });
 
   const dailyFees = options.createBalances();
-  dailyFees.add(inflows, METRIC.PROTOCOL_FEES);
+  dailyFees.add(inflows, METRIC.SWAP_FEES);
 
   return {
     dailyFees,
@@ -52,26 +75,11 @@ const fetch = async (options: FetchOptions) => {
 
 const adapter: SimpleAdapter = {
   version: 2,
+  pullHourly: true,
   fetch,
-  chains: [
-    CHAIN.ETHEREUM,
-    CHAIN.BASE,
-    CHAIN.OPTIMISM,
-    CHAIN.POLYGON,
-    CHAIN.ARBITRUM,
-    CHAIN.AVAX,
-    CHAIN.XDAI,
-    CHAIN.LINEA,
-    CHAIN.SONIC,
-    CHAIN.UNICHAIN,
-    CHAIN.ERA,
-    [CHAIN.BSC, { start: "2026-07-21" }],
-    [CHAIN.ROBINHOOD, { start: "2026-07-21" }],
-  ],
-  // Protocol fee is encoded into new positions by default since 2026-07-19
-  // (1inch DAO governance decision; BNB Chain and Robinhood Chain exchangers
-  // were verified and enabled on 2026-07-21).
-  start: "2026-07-19",
+  adapter: Object.fromEntries(
+    Object.entries(chainConfig).map(([chain, { start }]) => [chain, { start }]),
+  ),
   methodology: {
     Fees: "The 1inch DAO's share of Aqua LP swap fees: 1/4 of the LP fee on low-fee tiers (below ~0.1225%) and 1/6 on higher tiers, encoded into each position and transferred to the DAO fee exchanger at fill time. LP-retained fees accrue inside maker-owned positions (Aqua is non-custodial) and are not yet separately measurable on-chain, so this is a lower bound on total fees; an LP-fee decode from strategy bytecode is planned as a follow-up.",
     Revenue:
@@ -81,15 +89,15 @@ const adapter: SimpleAdapter = {
   },
   breakdownMethodology: {
     Fees: {
-      [METRIC.PROTOCOL_FEES]:
+      [METRIC.SWAP_FEES]:
         "The DAO's encoded share of Aqua LP swap fees, transferred to the per-chain fee exchanger at fill time (the exchangers were deployed for this purpose on 2026-07-18 and receive nothing else).",
     },
     Revenue: {
-      [METRIC.PROTOCOL_FEES]:
+      [METRIC.SWAP_FEES]:
         "All tracked fee-exchanger inflows are retained by the protocol entity.",
     },
     ProtocolRevenue: {
-      [METRIC.PROTOCOL_FEES]:
+      [METRIC.SWAP_FEES]:
         "Fee-exchanger inflows accrue to the 1inch DAO treasury.",
     },
   },

--- a/fees/1inch-aqua/index.ts
+++ b/fees/1inch-aqua/index.ts
@@ -1,5 +1,6 @@
 import { FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
+import { METRIC } from "../../helpers/metrics";
 import { addTokensReceived, nullAddress } from "../../helpers/token";
 
 // 1inch DAO fee exchangers — the receivers encoded into every Aqua strategy's
@@ -30,7 +31,7 @@ const fetch = async (options: FetchOptions) => {
   // Mint transfers (from == 0x0) are excluded: the exchanger holds
   // interest-bearing tokens (e.g. aTokens) whose rebase mints would otherwise
   // count as fee income.
-  const dailyFees = await addTokensReceived({
+  const inflows = await addTokensReceived({
     options,
     target: FEE_EXCHANGER[options.chain],
     logFilter: (log: any) =>
@@ -38,6 +39,9 @@ const fetch = async (options: FetchOptions) => {
         log.from ?? log.from_address ?? log.fromAddress ?? log.args?.from ?? "",
       ).toLowerCase() !== nullAddress,
   });
+
+  const dailyFees = options.createBalances();
+  dailyFees.add(inflows, METRIC.PROTOCOL_FEES);
 
   return {
     dailyFees,
@@ -74,6 +78,20 @@ const adapter: SimpleAdapter = {
       "All counted fees go to the protocol entity; equals dailyFees until LP-retained fees are measurable.",
     ProtocolRevenue:
       "ERC20 transfers received by the per-chain 1inch DAO fee-exchanger addresses, excluding mints (interest-bearing-token rebases). Inflows occur inside Aqua fill transactions.",
+  },
+  breakdownMethodology: {
+    Fees: {
+      [METRIC.PROTOCOL_FEES]:
+        "The DAO's encoded share of Aqua LP swap fees, transferred to the per-chain fee exchanger at fill time (the exchangers were deployed for this purpose on 2026-07-18 and receive nothing else).",
+    },
+    Revenue: {
+      [METRIC.PROTOCOL_FEES]:
+        "All tracked fee-exchanger inflows are retained by the protocol entity.",
+    },
+    ProtocolRevenue: {
+      [METRIC.PROTOCOL_FEES]:
+        "Fee-exchanger inflows accrue to the 1inch DAO treasury.",
+    },
   },
 };
 

--- a/fees/1inch-aqua/index.ts
+++ b/fees/1inch-aqua/index.ts
@@ -1,0 +1,80 @@
+import { FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import { addTokensReceived, nullAddress } from "../../helpers/token";
+
+// 1inch DAO fee exchangers — the receivers encoded into every Aqua strategy's
+// protocol-fee instruction (https://github.com/1inch/aqua). At fill time SwapVM
+// transfers the DAO's share of the LP fee straight from the swap to this
+// address, so ERC20 inflows here are the protocol's revenue stream.
+// Addresses mirror the 1inch dApp chain config; three chains use
+// chain-specific deployments, the rest share one address.
+const DEFAULT_EXCHANGER = "0x8063d4faf54bf8c898dc6ddc689c76ab12b4614a";
+
+const FEE_EXCHANGER: Record<string, string> = {
+  [CHAIN.ETHEREUM]: DEFAULT_EXCHANGER,
+  [CHAIN.BASE]: DEFAULT_EXCHANGER,
+  [CHAIN.OPTIMISM]: DEFAULT_EXCHANGER,
+  [CHAIN.POLYGON]: DEFAULT_EXCHANGER,
+  [CHAIN.ARBITRUM]: DEFAULT_EXCHANGER,
+  [CHAIN.BSC]: DEFAULT_EXCHANGER,
+  [CHAIN.XDAI]: DEFAULT_EXCHANGER,
+  [CHAIN.SONIC]: DEFAULT_EXCHANGER,
+  [CHAIN.UNICHAIN]: DEFAULT_EXCHANGER,
+  [CHAIN.ROBINHOOD]: DEFAULT_EXCHANGER,
+  [CHAIN.ERA]: "0xc0242e93dc86ab95210d6deaf8b9118fea3bde06",
+  [CHAIN.AVAX]: "0xa7417d51427a60d3a4629615da44d1b8698e6cf4",
+  [CHAIN.LINEA]: "0x0f4b0148f984320d255557a0006162af3a3c7baa",
+};
+
+const fetch = async (options: FetchOptions) => {
+  // Mint transfers (from == 0x0) are excluded: the exchanger holds
+  // interest-bearing tokens (e.g. aTokens) whose rebase mints would otherwise
+  // count as fee income.
+  const dailyFees = await addTokensReceived({
+    options,
+    target: FEE_EXCHANGER[options.chain],
+    logFilter: (log: any) =>
+      String(
+        log.from ?? log.from_address ?? log.fromAddress ?? log.args?.from ?? "",
+      ).toLowerCase() !== nullAddress,
+  });
+
+  return {
+    dailyFees,
+    dailyRevenue: dailyFees,
+    dailyProtocolRevenue: dailyFees,
+  };
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  fetch,
+  chains: [
+    CHAIN.ETHEREUM,
+    CHAIN.BASE,
+    CHAIN.OPTIMISM,
+    CHAIN.POLYGON,
+    CHAIN.ARBITRUM,
+    CHAIN.AVAX,
+    CHAIN.XDAI,
+    CHAIN.LINEA,
+    CHAIN.SONIC,
+    CHAIN.UNICHAIN,
+    CHAIN.ERA,
+    [CHAIN.BSC, { start: "2026-07-21" }],
+    [CHAIN.ROBINHOOD, { start: "2026-07-21" }],
+  ],
+  // Protocol fee is encoded into new positions by default since 2026-07-19
+  // (1inch DAO governance decision; BNB Chain and Robinhood Chain exchangers
+  // were verified and enabled on 2026-07-21).
+  start: "2026-07-19",
+  methodology: {
+    Fees: "The 1inch DAO's share of Aqua LP swap fees: 1/4 of the LP fee on low-fee tiers (below ~0.1225%) and 1/6 on higher tiers, encoded into each position and transferred to the DAO fee exchanger at fill time. LP-retained fees accrue inside maker-owned positions (Aqua is non-custodial) and are not yet separately measurable on-chain, so this is a lower bound on total fees; an LP-fee decode from strategy bytecode is planned as a follow-up.",
+    Revenue:
+      "All counted fees go to the protocol entity; equals dailyFees until LP-retained fees are measurable.",
+    ProtocolRevenue:
+      "ERC20 transfers received by the per-chain 1inch DAO fee-exchanger addresses, excluding mints (interest-bearing-token rebases). Inflows occur inside Aqua fill transactions.",
+  },
+};
+
+export default adapter;

--- a/helpers/token.ts
+++ b/helpers/token.ts
@@ -1,30 +1,30 @@
-import * as sdk from '@defillama/sdk';
-import axios from 'axios';
+import * as sdk from "@defillama/sdk";
+import axios from "axios";
 import { ethers } from "ethers";
 import { FetchOptions } from "../adapters/types";
-import { queryAllium, getAlliumChain } from './allium';
+import { queryAllium, getAlliumChain } from "./allium";
 import { getCache, setCache } from "./cache";
-import { CHAIN } from './chains';
-import ADDRESSES from './coreAssets.json';
-import { getEnv } from './env';
-import { sleep } from '../utils/utils';
-import { queryDuneSql } from './dune';
+import { CHAIN } from "./chains";
+import ADDRESSES from "./coreAssets.json";
+import { getEnv } from "./env";
+import { sleep } from "../utils/utils";
+import { queryDuneSql } from "./dune";
 
-export const nullAddress = ADDRESSES.null
+export const nullAddress = ADDRESSES.null;
 
 // NOTE: this works only with multisig contracts
 /**
  * Track native gas token (ETH, BNB, etc.) received by Safe multisig wallets.
- * 
+ *
  * Listens for the SafeReceived event emitted when a Safe receives native tokens.
  * This is more accurate than tracking raw transfers since it only counts intentional
  * deposits to the Safe, not gas refunds or other internal transfers.
- * 
+ *
  * Use cases:
  * - Track protocol revenue received by treasury multisigs
  * - Monitor payments to DAO-controlled Safes
  * - Calculate fees collected in native tokens
- * 
+ *
  * @param params.multisig - Single Safe address to track
  * @param params.multisigs - Array of Safe addresses to track
  * @param params.fromAddresses - Optional. Only count deposits from these addresses
@@ -39,42 +39,54 @@ export async function addGasTokensReceived(params: {
   fromAddresses?: string[];
   blacklist_fromAddresses?: string[];
 }) {
-  let { multisig, multisigs, options, balances, fromAddresses, blacklist_fromAddresses } = params;
+  let {
+    multisig,
+    multisigs,
+    options,
+    balances,
+    fromAddresses,
+    blacklist_fromAddresses,
+  } = params;
   if (multisig) multisigs = [multisig];
   if (!balances) balances = options.createBalances();
-  if (!multisigs?.length) throw new Error('multisig or multisigs required');
+  if (!multisigs?.length) throw new Error("multisig or multisigs required");
 
   const batchSize = 5000;
   const allLogs: any[] = [];
   let batchLogs: any[];
   let offset = 0;
-  const fromBlock = (await options.getFromBlock()) - 200
-  const toBlock = (await options.getToBlock()) - 200
+  const fromBlock = (await options.getFromBlock()) - 200;
+  const toBlock = (await options.getToBlock()) - 200;
 
-  for (; ;) {
+  for (;;) {
     batchLogs = await sdk.indexer.getLogs({
       chain: options.chain,
       targets: multisigs,
-      topics: ['0x3d0ce9bfc3ed7d6862dbb28b2dea94561fe714a1b4d019aa8af39730d1ad7c3d'],
+      topics: [
+        "0x3d0ce9bfc3ed7d6862dbb28b2dea94561fe714a1b4d019aa8af39730d1ad7c3d",
+      ],
       onlyArgs: true,
-      eventAbi: 'event SafeReceived (address indexed sender, uint256 value)',
+      eventAbi: "event SafeReceived (address indexed sender, uint256 value)",
       // ~~ Around 150 confirmation blocks for L1s, less than 10 for L2s
       fromBlock,
       toBlock,
       limit: batchSize,
       offset,
-      all: false
+      all: false,
     });
     allLogs.push(...batchLogs);
     if (batchLogs.length < batchSize) break;
     offset += batchSize;
   }
 
-  const fromAddressSet = fromAddresses ? new Set(fromAddresses.map(a => a.toLowerCase())) : null;
-  const blacklistSet = blacklist_fromAddresses ? new Set(blacklist_fromAddresses.map(a => a.toLowerCase())) : null;
+  const fromAddressSet = fromAddresses
+    ? new Set(fromAddresses.map((a) => a.toLowerCase()))
+    : null;
+  const blacklistSet = blacklist_fromAddresses
+    ? new Set(blacklist_fromAddresses.map((a) => a.toLowerCase()))
+    : null;
 
-
-  allLogs.forEach(log => {
+  allLogs.forEach((log) => {
     const sender = log.sender?.toLowerCase?.();
     if (!sender) return;
     if (blacklistSet?.has(sender)) {
@@ -85,7 +97,6 @@ export async function addGasTokensReceived(params: {
     }
     balances!.addGasToken(log.value);
   });
-
 
   return balances;
 }
@@ -104,19 +115,19 @@ type AddTokensReceivedParams = {
   token?: string;
   skipIndexer?: boolean;
   logFilter?: (log: any) => boolean;
-}
+};
 
 /**
  * Track ERC20 token transfers received by one or more addresses.
- * 
+ *
  * Automatically tries to use the indexer first for better performance, falls back to getLogs if indexer fails.
  * Can fetch token list automatically using Ankr if tokens are not specified.
- * 
+ *
  * Use cases:
  * - Track protocol revenue: tokens received by treasury addresses
  * - Calculate fees collected: tokens sent to fee collector contracts
  * - Monitor payments: tokens received from specific senders
- * 
+ *
  * @param params.target - Single address to track tokens received
  * @param params.targets - Array of addresses to track tokens received (alternative to target)
  * @param params.tokens - Optional. Array of token addresses to track. If not provided and fetchTokenList=true, fetches from Ankr
@@ -130,203 +141,273 @@ type AddTokensReceivedParams = {
  * @returns Balances object with token amounts received
  */
 export async function addTokensReceived(params: AddTokensReceivedParams) {
-
   if (!params.skipIndexer) {
     for (let i = 0; i < 2; i++) {
       // retry 2 times if failed
       try {
-        const balances = await _addTokensReceivedIndexer(params)
-        return balances
+        const balances = await _addTokensReceivedIndexer(params);
+        return balances;
       } catch (e) {
         if (i === 1) {
-          console.error('Token transfers: Failed to use indexer, falling back to logs', params.options.chain, (e as any)?.message)
+          console.error(
+            "Token transfers: Failed to use indexer, falling back to logs",
+            params.options.chain,
+            (e as any)?.message,
+          );
         }
       }
       await sleep(5);
     }
   }
 
+  let {
+    target,
+    targets,
+    options,
+    balances,
+    tokens,
+    fromAddressFilter = null,
+    tokenTransform = (i: string) => i,
+    fetchTokenList = false,
+    token,
+    fromAdddesses,
+    logFilter = () => true,
+  } = params;
+  const { chain, createBalances, getLogs } = options;
 
-
-  let { target, targets, options, balances, tokens, fromAddressFilter = null, tokenTransform = (i: string) => i, fetchTokenList = false, token, fromAdddesses, logFilter = () => true, } = params;
-  const { chain, createBalances, getLogs, } = options
-
-  if (!balances) balances = createBalances()
+  if (!balances) balances = createBalances();
 
   if (fromAdddesses && fromAdddesses.length) {
-    if (fromAdddesses.length === 1) fromAddressFilter = fromAdddesses[0]
+    if (fromAdddesses.length === 1) fromAddressFilter = fromAdddesses[0];
     else {
-      const clonedOptions = { ...params, balances, skipIndexer: true }
-      delete clonedOptions.fromAdddesses
-      await Promise.all(fromAdddesses.map(fromAddressFilter => addTokensReceived({ ...clonedOptions, fromAddressFilter })))
-      return balances
+      const clonedOptions = { ...params, balances, skipIndexer: true };
+      delete clonedOptions.fromAdddesses;
+      await Promise.all(
+        fromAdddesses.map((fromAddressFilter) =>
+          addTokensReceived({ ...clonedOptions, fromAddressFilter }),
+        ),
+      );
+      return balances;
     }
   }
 
-  if (!tokens && token) tokens = [token]
-
+  if (!tokens && token) tokens = [token];
 
   if (targets?.length) {
-    const clonedOptions = { ...params }
-    delete clonedOptions.targets
-    clonedOptions.balances = balances
-    await Promise.all(targets.map(target => addTokensReceived({ ...clonedOptions, target })))
-    return balances
+    const clonedOptions = { ...params };
+    delete clonedOptions.targets;
+    clonedOptions.balances = balances;
+    await Promise.all(
+      targets.map((target) => addTokensReceived({ ...clonedOptions, target })),
+    );
+    return balances;
   } else if (!target && !fromAddressFilter) {
-    throw new Error('target/fromAddressFilter or targets required')
+    throw new Error("target/fromAddressFilter or targets required");
   }
 
-  const toAddressFilter = target ? ethers.zeroPadValue(target, 32) : null
-  if (fromAddressFilter) fromAddressFilter = ethers.zeroPadValue(fromAddressFilter, 32)
+  const toAddressFilter = target ? ethers.zeroPadValue(target, 32) : null;
+  if (fromAddressFilter)
+    fromAddressFilter = ethers.zeroPadValue(fromAddressFilter, 32);
 
   if (!tokens && target) {
     if (fetchTokenList) {
-      if (!ankrChainMapping[chain]) throw new Error('Chain Not supported: ' + chain)
-      const ankrTokens = await ankrGetTokens(target, { onlyWhitelisted: true })
-      tokens = ankrTokens[ankrChainMapping[chain]] ?? []
+      if (!ankrChainMapping[chain])
+        throw new Error("Chain Not supported: " + chain);
+      const ankrTokens = await ankrGetTokens(target, { onlyWhitelisted: true });
+      tokens = ankrTokens[ankrChainMapping[chain]] ?? [];
     } else {
-      return getAllTransfers(fromAddressFilter, toAddressFilter, balances, tokenTransform, options)
+      return getAllTransfers(
+        fromAddressFilter,
+        toAddressFilter,
+        balances,
+        tokenTransform,
+        options,
+        logFilter,
+      );
     }
   }
 
-  if (!tokens?.length) return balances
+  if (!tokens?.length) return balances;
 
-  tokens = sdk.util.getUniqueAddresses(tokens.filter(i => !!i), options.chain)
+  tokens = sdk.util.getUniqueAddresses(
+    tokens.filter((i) => !!i),
+    options.chain,
+  );
 
   const logs = await getLogs({
     targets: tokens,
     flatten: false,
     noTarget: true,
-    eventAbi: 'event Transfer (address indexed from, address indexed to, uint256 value)',
-    topics: ['0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef', fromAddressFilter as string, toAddressFilter as any],
-  })
+    eventAbi:
+      "event Transfer (address indexed from, address indexed to, uint256 value)",
+    topics: [
+      "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
+      fromAddressFilter as string,
+      toAddressFilter as any,
+    ],
+  });
 
   logs.forEach((logs, index) => {
-    const token = tokens![index]
-    logs.filter(logFilter).forEach((i: any) => balances!.add(tokenTransform(token), i.value))
-  })
-  return balances
+    const token = tokens![index];
+    logs
+      .filter(logFilter)
+      .forEach((i: any) => balances!.add(tokenTransform(token), i.value));
+  });
+  return balances;
 }
 
 async function _addTokensReceivedIndexer(params: AddTokensReceivedParams) {
-  let { balances, fromAddressFilter, target, targets, options, fromAdddesses, tokenTransform = (i: string) => i, tokens, logFilter = () => true, } = params
-  const { createBalances, chain, getFromBlock, getToBlock } = options
-  if (!balances) balances = createBalances()
-  if (fromAdddesses && fromAdddesses.length) (fromAddressFilter as any) = fromAdddesses
+  let {
+    balances,
+    fromAddressFilter,
+    target,
+    targets,
+    options,
+    fromAdddesses,
+    tokenTransform = (i: string) => i,
+    tokens,
+    logFilter = () => true,
+  } = params;
+  const { createBalances, chain, getFromBlock, getToBlock } = options;
+  if (!balances) balances = createBalances();
+  if (fromAdddesses && fromAdddesses.length)
+    (fromAddressFilter as any) = fromAdddesses;
   const logs = await sdk.indexer.getTokenTransfers({
     fromBlock: await getFromBlock(),
     toBlock: await getToBlock(),
     chain,
-    target, targets,
+    target,
+    targets,
     fromAddressFilter: fromAddressFilter as any,
     tokens,
-  })
+  });
   logs.filter(logFilter).forEach((i: any) => {
-    balances!.add(tokenTransform(i.token), i.value)
-  })
+    balances!.add(tokenTransform(i.token), i.value);
+  });
 
-  return balances
+  return balances;
 }
 
-const ankrTokenCalls: any = {}
+const ankrTokenCalls: any = {};
 
 const ankrChainMapping: {
-  [chain: string]: string
+  [chain: string]: string;
 } = {
-  [CHAIN.ETHEREUM]: 'eth',
-  [CHAIN.BASE]: 'base',
-  [CHAIN.BSC]: 'bsc',
-  [CHAIN.ARBITRUM]: 'arbitrum',
-  [CHAIN.OPTIMISM]: 'optimism',
-  [CHAIN.FANTOM]: 'fantom',
-  [CHAIN.POLYGON]: 'polygon',
-  [CHAIN.POLYGON_ZKEVM]: 'polygon_zkevm',
-  [CHAIN.ERA]: 'zksync_era',
-  [CHAIN.AVAX]: 'avalanche',
-  [CHAIN.FLARE]: 'flare',
-  [CHAIN.XDAI]: 'gnosis',
-  [CHAIN.LINEA]: 'linea',
-  [CHAIN.ROLLUX]: 'rollux',
-  [CHAIN.SCROLL]: 'scroll',
-  [CHAIN.SYSCOIN]: 'syscoin',
-}
+  [CHAIN.ETHEREUM]: "eth",
+  [CHAIN.BASE]: "base",
+  [CHAIN.BSC]: "bsc",
+  [CHAIN.ARBITRUM]: "arbitrum",
+  [CHAIN.OPTIMISM]: "optimism",
+  [CHAIN.FANTOM]: "fantom",
+  [CHAIN.POLYGON]: "polygon",
+  [CHAIN.POLYGON_ZKEVM]: "polygon_zkevm",
+  [CHAIN.ERA]: "zksync_era",
+  [CHAIN.AVAX]: "avalanche",
+  [CHAIN.FLARE]: "flare",
+  [CHAIN.XDAI]: "gnosis",
+  [CHAIN.LINEA]: "linea",
+  [CHAIN.ROLLUX]: "rollux",
+  [CHAIN.SCROLL]: "scroll",
+  [CHAIN.SYSCOIN]: "syscoin",
+};
 
-async function ankrGetTokens(address: string, { onlyWhitelisted = true }: {
-  onlyWhitelisted?: boolean
-} = {}) {
-  address = address.toLowerCase()
+async function ankrGetTokens(
+  address: string,
+  {
+    onlyWhitelisted = true,
+  }: {
+    onlyWhitelisted?: boolean;
+  } = {},
+) {
+  address = address.toLowerCase();
 
-  if (!ankrTokenCalls[address]) ankrTokenCalls[address] = _call()
-  return ankrTokenCalls[address]
+  if (!ankrTokenCalls[address]) ankrTokenCalls[address] = _call();
+  return ankrTokenCalls[address];
 
   async function _call() {
-    const project = 'ankr-cache'
-    const key = onlyWhitelisted ? address : `${address}/all`
-    const timeNow = Math.floor(Date.now() / 1e3)
-    const THREE_DAYS = 3 * 24 * 3600
-    const cache = (await getCache(project, key)) ?? {}
-    if (cache.timestamp && (timeNow - cache.timestamp) < THREE_DAYS / 3)
-      return cache.tokens
+    const project = "ankr-cache";
+    const key = onlyWhitelisted ? address : `${address}/all`;
+    const timeNow = Math.floor(Date.now() / 1e3);
+    const THREE_DAYS = 3 * 24 * 3600;
+    const cache = (await getCache(project, key)) ?? {};
+    if (cache.timestamp && timeNow - cache.timestamp < THREE_DAYS / 3)
+      return cache.tokens;
 
-    sdk.log('Pulling tokens for ' + address)
+    sdk.log("Pulling tokens for " + address);
 
     const options = {
-      method: 'POST',
-      url: `https://rpc.ankr.com/multichain/${getEnv('ANKR_API_KEY')}`,
-      headers: { accept: 'application/json', 'content-type': 'application/json' },
+      method: "POST",
+      url: `https://rpc.ankr.com/multichain/${getEnv("ANKR_API_KEY")}`,
+      headers: {
+        accept: "application/json",
+        "content-type": "application/json",
+      },
       data: {
-        jsonrpc: '2.0',
-        method: 'ankr_getAccountBalance',
+        jsonrpc: "2.0",
+        method: "ankr_getAccountBalance",
         params: {
           onlyWhitelisted,
           nativeFirst: true,
           skipSyncCheck: true,
-          walletAddress: address
+          walletAddress: address,
         },
-        id: 42
-      }
+        id: 42,
+      },
     };
-    const tokens: any = {}
-    const { data: { result: { assets } } } = await axios(options)
-    const tokenCache = { timestamp: timeNow, tokens, }
+    const tokens: any = {};
+    const {
+      data: {
+        result: { assets },
+      },
+    } = await axios(options);
+    const tokenCache = { timestamp: timeNow, tokens };
     for (const asset of assets) {
-      const { contractAddress, blockchain } = asset
+      const { contractAddress, blockchain } = asset;
       if (!contractAddress) continue;
-      if (!tokens[blockchain]) tokens[blockchain] = []
-      tokens[blockchain].push(contractAddress)
+      if (!tokens[blockchain]) tokens[blockchain] = [];
+      tokens[blockchain].push(contractAddress);
     }
     for (const [chain, values] of Object.entries(tokens)) {
-      tokens[chain] = getUniqueAddresses(values as any)
+      tokens[chain] = getUniqueAddresses(values as any);
     }
 
-    await setCache(project, key, tokenCache)
-    return tokens
+    await setCache(project, key, tokenCache);
+    return tokens;
   }
 
   function getUniqueAddresses(values: string[]) {
-    values = values.map(v => v.toLowerCase()).filter(v => v && v !== nullAddress)
-    return [...new Set(values)]
+    values = values
+      .map((v) => v.toLowerCase())
+      .filter((v) => v && v !== nullAddress);
+    return [...new Set(values)];
   }
 }
 
-async function getAllTransfers(fromAddressFilter: string | null, toAddressFilter: string | null,
-  balances: sdk.Balances, tokenTransform: (token: string) => string, options: FetchOptions) {
+async function getAllTransfers(
+  fromAddressFilter: string | null,
+  toAddressFilter: string | null,
+  balances: sdk.Balances,
+  tokenTransform: (token: string) => string,
+  options: FetchOptions,
+  logFilter: (log: any) => boolean = () => true,
+) {
   const logs = await options.getLogs({
     topics: [
       "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef", // Transfer(address,address,uint256)
       fromAddressFilter as any,
-      toAddressFilter as any
+      toAddressFilter as any,
     ],
     noTarget: true,
-    eventAbi: 'event Transfer (address indexed from, address indexed to, uint256 value)',
+    eventAbi:
+      "event Transfer (address indexed from, address indexed to, uint256 value)",
     entireLog: true,
-  })
+  });
 
-  logs.forEach((log) => {
-    if (log.data == '0x') return
-    balances!.add(tokenTransform(log.address), log.data)
-  })
-  return balances
+  logs.filter(logFilter).forEach((log) => {
+    if (log.data == "0x") return;
+    balances!.add(tokenTransform(log.address), log.data);
+  });
+  return balances;
 }
 
 export async function getTokenDiff(params: {
@@ -338,85 +419,104 @@ export async function getTokenDiff(params: {
   includeGasToken?: boolean;
   options: FetchOptions;
 }) {
-  let { target, targets, balances, tokens, includeGasToken = true, options, extraTokens = [] } = params;
-  const { api, createBalances, getFromBlock, chain, } = options
+  let {
+    target,
+    targets,
+    balances,
+    tokens,
+    includeGasToken = true,
+    options,
+    extraTokens = [],
+  } = params;
+  const { api, createBalances, getFromBlock, chain } = options;
 
-
-  if (!balances) balances = createBalances()
+  if (!balances) balances = createBalances();
 
   if (targets?.length) {
-    const clonedOptions = { ...params }
-    delete clonedOptions.targets
-    clonedOptions.balances = balances
-    await Promise.all(targets.map(target => getTokenDiff({ ...clonedOptions, target })))
-    return balances
+    const clonedOptions = { ...params };
+    delete clonedOptions.targets;
+    clonedOptions.balances = balances;
+    await Promise.all(
+      targets.map((target) => getTokenDiff({ ...clonedOptions, target })),
+    );
+    return balances;
   } else if (!target) {
-    throw new Error('target or targets required')
+    throw new Error("target or targets required");
   }
 
   if (!tokens) {
-    if (!ankrChainMapping[chain]) throw new Error('Chain Not supported: ' + chain)
-    const ankrTokens = await ankrGetTokens(target, { onlyWhitelisted: true })
-    tokens = ankrTokens[ankrChainMapping[chain]] ?? []
+    if (!ankrChainMapping[chain])
+      throw new Error("Chain Not supported: " + chain);
+    const ankrTokens = await ankrGetTokens(target, { onlyWhitelisted: true });
+    tokens = ankrTokens[ankrChainMapping[chain]] ?? [];
   }
 
-  if (includeGasToken && !tokens?.includes(nullAddress)) tokens!.push(nullAddress)
-  if (extraTokens.length) tokens!.push(...extraTokens)
+  if (includeGasToken && !tokens?.includes(nullAddress))
+    tokens!.push(nullAddress);
+  if (extraTokens.length) tokens!.push(...extraTokens);
 
-  if (!tokens!.length) return balances
+  if (!tokens!.length) return balances;
 
-  const fromBlock = await getFromBlock()
-  const fromApi = new sdk.ChainApi({ chain, block: fromBlock, })
+  const fromBlock = await getFromBlock();
+  const fromApi = new sdk.ChainApi({ chain, block: fromBlock });
 
-  await api.sumTokens({ tokens, owner: target })
-  await fromApi.sumTokens({ tokens, owner: target })
+  await api.sumTokens({ tokens, owner: target });
+  await fromApi.sumTokens({ tokens, owner: target });
 
-  balances.addBalances(api.getBalancesV2())
-  balances.subtract(fromApi.getBalancesV2())
+  balances.addBalances(api.getBalancesV2());
+  balances.subtract(fromApi.getBalancesV2());
 
-
-  return balances
+  return balances;
 }
-
 
 /**
  * Helper function that combines native token and ERC20 token tracking for a receiver wallet.
- * 
+ *
  * This is a convenient wrapper that calls both getETHReceived (for native tokens) and
  * addTokensReceived (for ERC20 tokens) and returns them as dailyFees/dailyRevenue.
- * 
+ *
  * Common use case: Simple fee adapters where all tokens received by a wallet = revenue.
- * 
+ *
  * @param receiverWallet - Address that receives the fees/revenue
  * @param tokens - Array of ERC20 token addresses to track
  * @returns Async function that returns { dailyFees, dailyRevenue } for the adapter
- * 
+ *
  * @example
  * const adapter = {
  *   fetch: evmReceivedGasAndTokens('0xTreasury...', ['0xUSDC...', '0xDAI...']),
  * }
  */
-export const evmReceivedGasAndTokens = (receiverWallet: string, tokens: string[]) =>
+export const evmReceivedGasAndTokens =
+  (receiverWallet: string, tokens: string[]) =>
   async (options: FetchOptions) => {
-    let dailyFees = options.createBalances()
+    let dailyFees = options.createBalances();
     if (tokens.length > 0) {
-      await addTokensReceived({ options, tokens: tokens, target: receiverWallet, balances: dailyFees })
+      await addTokensReceived({
+        options,
+        tokens: tokens,
+        target: receiverWallet,
+        balances: dailyFees,
+      });
     }
     //   const nativeTransfers = await queryDuneSql(options, `select sum(value) as received from CHAIN.traces
     // where to = ${receiverWallet} AND tx_success = TRUE
     // AND TIME_RANGE`)
     //   dailyFees.add(nullAddress, nativeTransfers[0].received)
-    await getETHReceived({ options, balances: dailyFees, target: receiverWallet })
+    await getETHReceived({
+      options,
+      balances: dailyFees,
+      target: receiverWallet,
+    });
 
     return {
       dailyFees,
       dailyRevenue: dailyFees,
-    }
-  }
+    };
+  };
 
 /**
  * Retrieves the total value of tokens received by a Solana address or addresses within a specified time period
- * 
+ *
  * @param options - FetchOptions containing timestamp range and other configuration
  * @param balances - Optional sdk.Balances object to add the results to
  * @param target - Single Solana address to query
@@ -425,7 +525,18 @@ export const evmReceivedGasAndTokens = (receiverWallet: string, tokens: string[]
  * @param blacklist_signers - Optional array of transaction signers to exclude
  * @returns The balances object with added USD value from received tokens
  */
-export async function getSolanaReceived({ options, balances, target, targets, mints, blacklists, blacklist_signers, blacklist_mints, fromAddress, fromAddresses }: {
+export async function getSolanaReceived({
+  options,
+  balances,
+  target,
+  targets,
+  mints,
+  blacklists,
+  blacklist_signers,
+  blacklist_mints,
+  fromAddress,
+  fromAddresses,
+}: {
   options: FetchOptions;
   balances?: sdk.Balances;
   target?: string;
@@ -444,46 +555,52 @@ export async function getSolanaReceived({ options, balances, target, targets, mi
   const addresses = targets?.length ? targets : target ? [target] : [];
   if (addresses.length === 0) return balances;
 
-  let fromAddressesCondition = '';
-  const combinedFromAddresses = fromAddress ? [fromAddress, ...(fromAddresses || [])] : fromAddresses;
+  let fromAddressesCondition = "";
+  const combinedFromAddresses = fromAddress
+    ? [fromAddress, ...(fromAddresses || [])]
+    : fromAddresses;
   if (combinedFromAddresses && combinedFromAddresses.length > 0) {
-    fromAddressesCondition = `AND from_address IN (${combinedFromAddresses.map(addr => `'${addr}'`).join(', ')})`;
+    fromAddressesCondition = `AND from_address IN (${combinedFromAddresses.map((addr) => `'${addr}'`).join(", ")})`;
   }
 
   // Build SQL condition to include only mints tokens
-  let mintsCondition = '';
+  let mintsCondition = "";
 
   if (mints && mints.length > 0) {
-    const formattedMints = mints.map(addr => `'${addr}'`).join(', ');
+    const formattedMints = mints.map((addr) => `'${addr}'`).join(", ");
     mintsCondition = `AND mint IN (${formattedMints})`;
   }
-  
+
   // Build SQL condition to exclude blacklisted sender addresses
-  let blacklistCondition = '';
+  let blacklistCondition = "";
 
   if (blacklists && blacklists.length > 0) {
-    const formattedBlacklist = blacklists.map(addr => `'${addr}'`).join(', ');
+    const formattedBlacklist = blacklists.map((addr) => `'${addr}'`).join(", ");
     blacklistCondition = `AND from_address NOT IN (${formattedBlacklist})`;
   }
 
   // Build SQL condition to exclude blacklisted transaction signers
-  let blacklist_signersCondition = '';
+  let blacklist_signersCondition = "";
 
   if (blacklist_signers && blacklist_signers.length > 0) {
-    const formattedBlacklist = blacklist_signers.map(addr => `'${addr}'`).join(', ');
+    const formattedBlacklist = blacklist_signers
+      .map((addr) => `'${addr}'`)
+      .join(", ");
     blacklist_signersCondition = `AND signer NOT IN (${formattedBlacklist})`;
   }
 
   // Build SQL condition to exclude blacklisted tokens
-  let blacklist_mintsCondition = '';
+  let blacklist_mintsCondition = "";
 
   if (blacklist_mints && blacklist_mints.length > 0) {
-    const formattedBlacklist = blacklist_mints.map(addr => `'${addr}'`).join(', ');
+    const formattedBlacklist = blacklist_mints
+      .map((addr) => `'${addr}'`)
+      .join(", ");
     blacklist_mintsCondition = `AND mint NOT IN (${formattedBlacklist})`;
   }
 
   // Format addresses for IN clause
-  const formattedAddresses = addresses.map(addr => `'${addr}'`).join(', ');
+  const formattedAddresses = addresses.map((addr) => `'${addr}'`).join(", ");
 
   // Construct SQL query to get sum of received token values in USD and native amount
   const query = `
@@ -517,15 +634,14 @@ export async function getSolanaReceived({ options, balances, target, targets, mi
 
   // Add the USD value to the balances object (defaulting to 0 if no results)
   res.forEach((row: any) => {
-    balances!.add(row.token, row.amount)
-  })
+    balances!.add(row.token, row.amount);
+  });
   return balances;
 }
 
-
 /**
  * Retrieves the total value of tokens received by a Solana address or addresses within a specified time period
- * 
+ *
  * @param options - FetchOptions containing timestamp range and other configuration
  * @param balances - Optional sdk.Balances object to add the results to
  * @param target - Single Solana address to query
@@ -534,7 +650,17 @@ export async function getSolanaReceived({ options, balances, target, targets, mi
  * @param blacklist_signers - Optional array of transaction signers to exclude
  * @returns The balances object with added USD value from received tokens
  */
-export async function getSolanaReceivedDune({ options, balances, target, targets, blacklists, blacklist_signers, blacklist_mints, fromAddress, fromAddresses }: {
+export async function getSolanaReceivedDune({
+  options,
+  balances,
+  target,
+  targets,
+  blacklists,
+  blacklist_signers,
+  blacklist_mints,
+  fromAddress,
+  fromAddresses,
+}: {
   options: FetchOptions;
   balances?: sdk.Balances;
   target?: string;
@@ -552,38 +678,44 @@ export async function getSolanaReceivedDune({ options, balances, target, targets
   const addresses = targets?.length ? targets : target ? [target] : [];
   if (addresses.length === 0) return balances;
 
-  let fromAddressesCondition = '';
-  const combinedFromAddresses = fromAddress ? [fromAddress, ...(fromAddresses || [])] : fromAddresses;
+  let fromAddressesCondition = "";
+  const combinedFromAddresses = fromAddress
+    ? [fromAddress, ...(fromAddresses || [])]
+    : fromAddresses;
   if (combinedFromAddresses && combinedFromAddresses.length > 0) {
-    fromAddressesCondition = `AND from_owner IN (${combinedFromAddresses.map(addr => `'${addr}'`).join(', ')})`;
+    fromAddressesCondition = `AND from_owner IN (${combinedFromAddresses.map((addr) => `'${addr}'`).join(", ")})`;
   }
 
   // Build SQL condition to exclude blacklisted sender addresses
-  let blacklistCondition = '';
+  let blacklistCondition = "";
 
   if (blacklists && blacklists.length > 0) {
-    const formattedBlacklist = blacklists.map(addr => `'${addr}'`).join(', ');
+    const formattedBlacklist = blacklists.map((addr) => `'${addr}'`).join(", ");
     blacklistCondition = `AND from_owner NOT IN (${formattedBlacklist})`;
   }
 
   // Build SQL condition to exclude blacklisted transaction signers
-  let blacklist_signersCondition = '';
+  let blacklist_signersCondition = "";
 
   if (blacklist_signers && blacklist_signers.length > 0) {
-    const formattedBlacklist = blacklist_signers.map(addr => `'${addr}'`).join(', ');
+    const formattedBlacklist = blacklist_signers
+      .map((addr) => `'${addr}'`)
+      .join(", ");
     blacklist_signersCondition = `AND tx_signer NOT IN (${formattedBlacklist})`;
   }
 
   // Build SQL condition to exclude blacklisted tokens
-  let blacklist_mintsCondition = '';
+  let blacklist_mintsCondition = "";
 
   if (blacklist_mints && blacklist_mints.length > 0) {
-    const formattedBlacklist = blacklist_mints.map(addr => `'${addr}'`).join(', ');
+    const formattedBlacklist = blacklist_mints
+      .map((addr) => `'${addr}'`)
+      .join(", ");
     blacklist_mintsCondition = `AND token_mint_address NOT IN (${formattedBlacklist})`;
   }
 
   // Format addresses for IN clause
-  const formattedAddresses = addresses.map(addr => `'${addr}'`).join(', ');
+  const formattedAddresses = addresses.map((addr) => `'${addr}'`).join(", ");
 
   // Construct SQL query to get sum of received token values in USD and native amount
   const query = `
@@ -615,23 +747,22 @@ export async function getSolanaReceivedDune({ options, balances, target, targets
 
   // Add the USD value to the balances object (defaulting to 0 if no results)
   res.forEach((row: any) => {
-    balances!.add(row.mint, row.amount)
-  })
+    balances!.add(row.mint, row.amount);
+  });
   return balances;
 }
 
-
 /**
  * Track native gas token (ETH, BNB, MATIC, etc.) received by one or more addresses.
- * 
+ *
  * Uses Allium's native token transfer tables or raw traces to query native token flows.
  * Automatically excludes self-transfers (address sending to itself) to avoid double counting.
- * 
+ *
  * Use cases:
  * - Track protocol revenue in native tokens
  * - Monitor ETH received by treasury or fee collector addresses
  * - Calculate gas token payments to contracts
- * 
+ *
  * @param options - FetchOptions with chain, timestamp range, etc.
  * @param balances - Optional. Balances object to add results to
  * @param target - Optional. Single address to track
@@ -639,49 +770,61 @@ export async function getSolanaReceivedDune({ options, balances, target, targets
  * @param notFromSenders - Optional. Exclude transfers from these addresses (in addition to self-transfers)
  * @returns Balances object with native token amounts received
  */
-export async function getETHReceived({ options, balances, target, targets = [], notFromSenders = [] }: { options: FetchOptions, balances?: sdk.Balances, target?: string, targets?: string[], notFromSenders?: string[] }) {
-  if (!balances) balances = options.createBalances()
+export async function getETHReceived({
+  options,
+  balances,
+  target,
+  targets = [],
+  notFromSenders = [],
+}: {
+  options: FetchOptions;
+  balances?: sdk.Balances;
+  target?: string;
+  targets?: string[];
+  notFromSenders?: string[];
+}) {
+  if (!balances) balances = options.createBalances();
 
-  if (!target && !targets?.length) return balances
+  if (!target && !targets?.length) return balances;
 
-  if (target) targets.push(target)
+  if (target) targets.push(target);
 
-  targets = targets.map(i => i.toLowerCase())
-  targets = [...new Set(targets)]
+  targets = targets.map((i) => i.toLowerCase());
+  targets = [...new Set(targets)];
 
-  notFromSenders = notFromSenders.map(i => i.toLowerCase())
-  notFromSenders = [...new Set(notFromSenders)]
+  notFromSenders = notFromSenders.map((i) => i.toLowerCase());
+  notFromSenders = [...new Set(notFromSenders)];
 
-  const excludeSenders = targets.concat(notFromSenders)
+  const excludeSenders = targets.concat(notFromSenders);
 
   // you can find the supported chains and the documentation here: https://docs.allium.so/historical-chains/supported-blockchains/evm/ethereum
   const chainMap: any = {
-    [CHAIN.ETHEREUM]: 'ethereum',
-    [CHAIN.BASE]: 'base',
-    [CHAIN.OPTIMISM]: 'optimism',
-    [CHAIN.SCROLL]: 'scroll',
-    [CHAIN.BSC]: 'bsc',
-    [CHAIN.ARBITRUM]: 'arbitrum',
-    [CHAIN.AVAX]: 'avalanche',
-    [CHAIN.POLYGON]: 'polygon',
+    [CHAIN.ETHEREUM]: "ethereum",
+    [CHAIN.BASE]: "base",
+    [CHAIN.OPTIMISM]: "optimism",
+    [CHAIN.SCROLL]: "scroll",
+    [CHAIN.BSC]: "bsc",
+    [CHAIN.ARBITRUM]: "arbitrum",
+    [CHAIN.AVAX]: "avalanche",
+    [CHAIN.POLYGON]: "polygon",
     // [CHAIN.CELO]: 'celo',
-    [CHAIN.TRON]: 'tron',
-    [CHAIN.UNICHAIN]: 'unichain',
-    [CHAIN.ZORA]: 'zora',
-    [CHAIN.NEAR]: 'near',
-    [CHAIN.XDAI]: 'gnosis',
-    [CHAIN.INK]: 'ink',
-    [CHAIN.BERACHAIN]: 'berachain',
-    [CHAIN.POLYGON_ZKEVM]: 'polygon_zkevm',
-    [CHAIN.PLASMA]: 'plasma',
-    [CHAIN.MONAD]: 'monad',
-    [CHAIN.HYPERLIQUID]: 'hyperevm',
-  }
-  
+    [CHAIN.TRON]: "tron",
+    [CHAIN.UNICHAIN]: "unichain",
+    [CHAIN.ZORA]: "zora",
+    [CHAIN.NEAR]: "near",
+    [CHAIN.XDAI]: "gnosis",
+    [CHAIN.INK]: "ink",
+    [CHAIN.BERACHAIN]: "berachain",
+    [CHAIN.POLYGON_ZKEVM]: "polygon_zkevm",
+    [CHAIN.PLASMA]: "plasma",
+    [CHAIN.MONAD]: "monad",
+    [CHAIN.HYPERLIQUID]: "hyperevm",
+  };
+
   // https://docs.allium.so/changelog/deprecated-schemas
   const tableMap: any = {
-    [CHAIN.TRON]: 'trx_token_transfers',
-    [CHAIN.NEAR]: 'near_token_transfers',
+    [CHAIN.TRON]: "trx_token_transfers",
+    [CHAIN.NEAR]: "near_token_transfers",
     // bsc: 'bnb_token_transfers',
     // avax: 'avax_token_transfers',
     // polygon: 'matic_token_transfers',
@@ -693,21 +836,22 @@ export async function getETHReceived({ options, balances, target, targets = [], 
     // sonic: 'native_token_transfers',
     // plasma: 'native_token_transfers',
     // monad: 'native_token_transfers'
-  }
+  };
 
-  let query = ``
-  const targetList = '( ' + targets.map(i => `'${i}'`).join(', ') + ' )'
-  const excludeSenderList = '( ' + excludeSenders.map(i => `'${i}'`).join(', ') + ' )'
-  const chainKey = chainMap[options.chain]
+  let query = ``;
+  const targetList = "( " + targets.map((i) => `'${i}'`).join(", ") + " )";
+  const excludeSenderList =
+    "( " + excludeSenders.map((i) => `'${i}'`).join(", ") + " )";
+  const chainKey = chainMap[options.chain];
   if (chainKey) {
     query = `
       SELECT SUM(raw_amount) as value
-      FROM ${chainKey}${tableMap[options.chain] ? `.assets.${tableMap[options.chain]}` : '.assets.native_token_transfers'}
+      FROM ${chainKey}${tableMap[options.chain] ? `.assets.${tableMap[options.chain]}` : ".assets.native_token_transfers"}
       WHERE to_address in ${targetList} 
-      ${excludeSenders.length > 0 ? `AND from_address not in ${excludeSenderList} ` : ' '}
+      ${excludeSenders.length > 0 ? `AND from_address not in ${excludeSenderList} ` : " "}
       AND transfer_type = 'value_transfer'
       AND block_timestamp BETWEEN TO_TIMESTAMP_NTZ(${options.startTimestamp}) AND TO_TIMESTAMP_NTZ(${options.endTimestamp})
-      `
+      `;
   } else {
     // support all EVM chain on allium now
     // sum value from traces calls to targets addresses
@@ -717,14 +861,14 @@ export async function getETHReceived({ options, balances, target, targets = [], 
       FROM ${getAlliumChain(options.chain)}.raw.traces
       WHERE to_address in ${targetList} 
       AND status = 1
-      ${excludeSenders.length > 0 ? `AND from_address not in ${excludeSenderList} ` : ' '}
+      ${excludeSenders.length > 0 ? `AND from_address not in ${excludeSenderList} ` : " "}
       AND block_timestamp BETWEEN TO_TIMESTAMP_NTZ(${options.startTimestamp}) AND TO_TIMESTAMP_NTZ(${options.endTimestamp})
-      `
+      `;
   }
 
-  const res = await queryAllium(query)
-  balances.add(nullAddress, res[0].value)
-  return balances
+  const res = await queryAllium(query);
+  balances.add(nullAddress, res[0].value);
+  return balances;
 }
 
 type GetEVMTokenTransfersParams = {
@@ -739,24 +883,24 @@ type GetEVMTokenTransfersParams = {
   blacklistToAddresses?: string[];
   blacklistTxFromAddresses?: string[];
   blacklistTxToAddresses?: string[];
-}
+};
 
 /**
  * Query token transfers on EVM chains using Allium's crosschain transfers table.
- * 
+ *
  * This method provides more flexible filtering than getLogs by allowing you to filter on:
  * - Transfer sender/receiver (from_address/to_address) - the addresses in the Transfer event
  * - Transaction sender/receiver (transaction_from_address/transaction_to_address) - the tx.from/tx.to addresses
  * - Specific tokens
  * - Blacklist addresses for any of the above
- * 
+ *
  * Use cases:
  * - Track token burns: filter transfers to zero address
  * - Track protocol revenue: filter transfers to treasury addresses
  * - Track routed volume: filter transfers from router addresses
  * - Track user payments: filter by transaction sender addresses
  * - Exclude internal transfers: blacklist protocol contract addresses
- * 
+ *
  * @param params.toAddresses - Filter transfers to these addresses (Transfer event 'to')
  * @param params.fromAddresses - Filter transfers from these addresses (Transfer event 'from')
  * @param params.txFromAddresses - Filter by transaction sender (tx.from)
@@ -786,25 +930,47 @@ export async function getEVMTokenTransfers(params: GetEVMTokenTransfersParams) {
 
   const balances = inputBalances || options.createBalances();
 
-  if (!toAddresses.length && !fromAddresses.length && !txFromAddresses.length && !txToAddresses.length) {
-    throw new Error('At least one of toAddresses, fromAddresses, txFromAddresses, or txToAddresses is required');
+  if (
+    !toAddresses.length &&
+    !fromAddresses.length &&
+    !txFromAddresses.length &&
+    !txToAddresses.length
+  ) {
+    throw new Error(
+      "At least one of toAddresses, fromAddresses, txFromAddresses, or txToAddresses is required",
+    );
   }
 
-  const normalizeAddresses = (addrs: string[]) => 
-    [...new Set(addrs.map(a => a.toLowerCase()))];
+  const normalizeAddresses = (addrs: string[]) => [
+    ...new Set(addrs.map((a) => a.toLowerCase())),
+  ];
 
   const toAddrs = toAddresses.length ? normalizeAddresses(toAddresses) : [];
-  const fromAddrs = fromAddresses.length ? normalizeAddresses(fromAddresses) : [];
+  const fromAddrs = fromAddresses.length
+    ? normalizeAddresses(fromAddresses)
+    : [];
   const tokenAddrs = tokens.length ? normalizeAddresses(tokens) : [];
-  const txFromAddrs = txFromAddresses.length ? normalizeAddresses(txFromAddresses) : [];
-  const txToAddrs = txToAddresses.length ? normalizeAddresses(txToAddresses) : [];
-  const blacklistFrom = blacklistFromAddresses.length ? normalizeAddresses(blacklistFromAddresses) : [];
-  const blacklistTo = blacklistToAddresses.length ? normalizeAddresses(blacklistToAddresses) : [];
-  const blacklistTxFrom = blacklistTxFromAddresses.length ? normalizeAddresses(blacklistTxFromAddresses) : [];
-  const blacklistTxTo = blacklistTxToAddresses.length ? normalizeAddresses(blacklistTxToAddresses) : [];
+  const txFromAddrs = txFromAddresses.length
+    ? normalizeAddresses(txFromAddresses)
+    : [];
+  const txToAddrs = txToAddresses.length
+    ? normalizeAddresses(txToAddresses)
+    : [];
+  const blacklistFrom = blacklistFromAddresses.length
+    ? normalizeAddresses(blacklistFromAddresses)
+    : [];
+  const blacklistTo = blacklistToAddresses.length
+    ? normalizeAddresses(blacklistToAddresses)
+    : [];
+  const blacklistTxFrom = blacklistTxFromAddresses.length
+    ? normalizeAddresses(blacklistTxFromAddresses)
+    : [];
+  const blacklistTxTo = blacklistTxToAddresses.length
+    ? normalizeAddresses(blacklistTxToAddresses)
+    : [];
 
-  const formatList = (addrs: string[]) => 
-    '( ' + addrs.map(a => `'${a}'`).join(', ') + ' )';
+  const formatList = (addrs: string[]) =>
+    "( " + addrs.map((a) => `'${a}'`).join(", ") + " )";
 
   const chainKey = getAlliumChain(options.chain);
 
@@ -861,14 +1027,20 @@ export async function getEVMTokenTransfers(params: GetEVMTokenTransfersParams) {
 
   const results = await queryAllium(query);
 
-  results.forEach((row: { token: string; amount: string | number; amount_usd: string | number }) => {
-    const tokenAddress = row.token || nullAddress;
-    if (tokenAddress.toLowerCase() === nullAddress.toLowerCase()) {
-      balances.addGasToken(row.amount);
-    } else {
-      balances.add(tokenAddress, row.amount);
-    }
-  });
+  results.forEach(
+    (row: {
+      token: string;
+      amount: string | number;
+      amount_usd: string | number;
+    }) => {
+      const tokenAddress = row.token || nullAddress;
+      if (tokenAddress.toLowerCase() === nullAddress.toLowerCase()) {
+        balances.addGasToken(row.amount);
+      } else {
+        balances.add(tokenAddress, row.amount);
+      }
+    },
+  );
 
   return balances;
 }


### PR DESCRIPTION
Follow-up to the 1inch-aqua volume adapter, per @LlamaFacts' guidance in the Telegram thread on PR DefiLlama/DefiLlama-Adapters#20173: skip TVL for this protocol shape, track fees instead.

## What it counts

**dailyFees = dailyRevenue = dailyProtocolRevenue** — ERC20 inflows to the 1inch DAO **fee exchangers**, the receivers encoded into every Aqua position's protocol-fee instruction. At fill time SwapVM transfers the DAO's share of the LP fee (1/4 of the LP fee on tiers below ~0.1225%, 1/6 above — set at position build time) straight to these addresses, so the inflows are an exact on-chain measure of protocol revenue. Mint transfers (`from == 0x0`) are excluded so interest-bearing-token rebases held by the exchanger don't count as fee income.

Addresses (mirrored from the 1inch dApp chain config, verified on-chain): `0x8063d4faf54bf8c898dc6ddc689c76ab12b4614a` on 10 chains; chain-specific deployments on zkSync Era (`0xc024…de06`), Avalanche (`0xa741…6cf4`), Linea (`0x0f4b…7baa`).

Start: 2026-07-19 (protocol fee ON by default for new positions, 1inch DAO governance); BSC + Robinhood 2026-07-21 (exchangers verified/enabled there later).

## What it deliberately does NOT count yet

**LP-retained fees (dailySupplySideRevenue).** Aqua is non-custodial — the LP fee accrues inside maker-owned positions on fill, with no separate transfer or event carrying the fee amount. Deriving it requires decoding each position's fee bps from the Shipped strategy bytecode and joining per-fill amounts, which we'd rather ship as a careful follow-up than approximate here. The methodology text states dailyFees is therefore a lower bound on total fees for now. (If you'd rather see `dailyFees = protocol share / protocolShare` extrapolation instead, happy to discuss — we preferred measured over modeled.)

## Test run

`npm test fees 1inch-aqua` (yesterday, RPC-fallback locally — production indexer path additionally applies the mint filter):

```
ethereum  | 150.00 | ... (other chains 0 — fee flag is 3 days old, protocol pre-public-launch)
Aggregate | 150.00
```

Small numbers today by design: the DAO fee shipped 2026-07-19 and only applies to positions created since. Happy to answer anything on the methodology!

Made with [Cursor](https://cursor.com)