### PR TITLE
Add Lighter Robinhood perps fees adapter

### DIFF
--- a/fees/lighter-rh/index.ts
+++ b/fees/lighter-rh/index.ts
@@ -1,7 +1,8 @@
 import { FetchOptions, FetchResultV2, SimpleAdapter } from '../../adapters/types'
 import { CHAIN } from '../../helpers/chains'
 import { METRIC } from '../../helpers/metrics'
-import fetchURL from '../../utils/fetchURL'
+import fetchURL, { fetchURLAutoHandleRateLimit } from '../../utils/fetchURL'
+import PromisePool from '@supercharge/promise-pool'
 
 const API_BASE = 'https://api.rh.lighter.xyz/api/v1'
 
@@ -10,28 +11,63 @@ interface ExchangeMetricResponse {
   metrics: Array<{ timestamp: number; data: number }>
 }
 
-/** Lighter's Robinhood perpetuals deployment exposes the same exchangeMetrics
- * API as mainnet Lighter (see fees/lighterv2). Each `kind` returns a daily USD
- * series keyed by UTC-midnight timestamp. The unfiltered (exchange-wide) value
- * equals the sum across every market — verified against the per-market
- * `filter=byMarket` breakdown — so we read the global metric directly instead
- * of iterating all markets, keeping the adapter light. */
-async function fetchMetric(kind: string, startOfDay: number): Promise<number> {
-  const response: ExchangeMetricResponse = await fetchURL(
-    `${API_BASE}/exchangeMetrics?period=all&kind=${kind}`
+interface OrderBookDetail {
+  symbol: string
+  market_id: number
+  market_type: string
+  status: string
+}
+
+/** Perp markets only. Lighter's Robinhood spot markets (e.g. NVDA/USDG) are a
+ * separate protocol tracked by dexs/lighter-spot, and the unfiltered
+ * exchangeMetrics value is the perp+spot total — so we scope fees to the active
+ * perp markets, exactly like mainnet Lighter (fees/lighterv2). */
+async function getActivePerpMarkets(): Promise<OrderBookDetail[]> {
+  const res: { order_book_details?: OrderBookDetail[] } = await fetchURL(`${API_BASE}/orderBookDetails`)
+  return (res?.order_book_details || []).filter(
+    (m) => m.market_type === 'perp' && m.status === 'active'
   )
-  if (!response?.metrics || !Array.isArray(response.metrics)) return 0
-  const metric = response.metrics.find(m => m.timestamp === startOfDay)
+}
+
+async function fetchMetricByMarket(kind: string, symbol: string, startOfDay: number): Promise<number> {
+  const res: ExchangeMetricResponse = await fetchURLAutoHandleRateLimit(
+    `${API_BASE}/exchangeMetrics?period=all&kind=${kind}&filter=byMarket&value=${encodeURIComponent(symbol)}`
+  )
+  const metric = (res?.metrics || []).find((m) => m.timestamp === startOfDay)
+  return metric?.data || 0
+}
+
+async function fetchMetricGlobal(kind: string, startOfDay: number): Promise<number> {
+  const res: ExchangeMetricResponse = await fetchURL(`${API_BASE}/exchangeMetrics?period=all&kind=${kind}`)
+  const metric = (res?.metrics || []).find((m) => m.timestamp === startOfDay)
   return metric?.data || 0
 }
 
 async function fetch(options: FetchOptions): Promise<FetchResultV2> {
-  const [makerFee, takerFee, liquidationFee, transferFee, withdrawFee] = await Promise.all([
-    fetchMetric('maker_fee', options.startOfDay),
-    fetchMetric('taker_fee', options.startOfDay),
-    fetchMetric('liquidation_fee', options.startOfDay),
-    fetchMetric('transfer_fee', options.startOfDay),
-    fetchMetric('withdraw_fee', options.startOfDay),
+  const markets = await getActivePerpMarkets()
+  options.api.log('Lighter Robinhood active perp markets #', markets.length)
+
+  let makerFee = 0
+  let takerFee = 0
+  let liquidationFee = 0
+
+  await PromisePool.withConcurrency(3)
+    .for(markets)
+    .process(async (market) => {
+      const [mk, tk, lq] = await Promise.all([
+        fetchMetricByMarket('maker_fee', market.symbol, options.startOfDay),
+        fetchMetricByMarket('taker_fee', market.symbol, options.startOfDay),
+        fetchMetricByMarket('liquidation_fee', market.symbol, options.startOfDay),
+      ])
+      makerFee += mk
+      takerFee += tk
+      liquidationFee += lq
+    })
+
+  // Transfer / withdraw fees are account-level (not per-market); read globally.
+  const [transferFee, withdrawFee] = await Promise.all([
+    fetchMetricGlobal('transfer_fee', options.startOfDay),
+    fetchMetricGlobal('withdraw_fee', options.startOfDay),
   ])
 
   const tradingFees = makerFee + takerFee
@@ -62,7 +98,7 @@ async function fetch(options: FetchOptions): Promise<FetchResultV2> {
 }
 
 const methodology = {
-  Fees: 'All fees paid by traders on the Lighter Robinhood perpetuals deployment: maker, taker, transfer, withdraw and liquidation fees.',
+  Fees: 'All fees paid by traders on the Lighter Robinhood perpetuals deployment: maker, taker, transfer, withdraw and liquidation fees. Scoped to perp markets (spot is tracked separately as lighter-spot).',
   Revenue: 'Protocol revenue from maker, taker, transfer and withdraw fees. Liquidation fees are excluded — they go to the LLP (see SupplySideRevenue).',
   ProtocolRevenue: 'Same as Revenue: maker, taker, transfer and withdraw fees retained by the protocol.',
   SupplySideRevenue: 'Liquidation fees, which are paid to the Lighter Liquidity Pool (LLP) — i.e. to liquidity providers, not the protocol.',
@@ -70,7 +106,7 @@ const methodology = {
 
 const breakdownMethodology = {
   Fees: {
-    [METRIC.TRADING_FEES]: 'Maker and taker fees from perpetual trading.',
+    [METRIC.TRADING_FEES]: 'Maker and taker fees from perpetual trading (summed across active perp markets).',
     'Transfer Fees': 'Transfer fees paid by traders on Lighter.',
     [METRIC.DEPOSIT_WITHDRAW_FEES]: 'Withdraw fees paid by traders on Lighter.',
     [METRIC.LIQUIDATION_FEES]: 'Liquidation fees paid by traders, routed to the LLP.',

--- a/fees/lighter-rh/index.ts
+++ b/fees/lighter-rh/index.ts
@@ -90,7 +90,7 @@ async function fetch(options: FetchOptions): Promise<FetchResultV2> {
   // Protocol revenue: maker, taker, transfer and withdrawal fees.
   dailyRevenue.addUSDValue(tradingFees, METRIC.TRADING_FEES)
   dailyRevenue.addUSDValue(totals.transfer_fee, 'Transfer Fees')
-  dailyRevenue.addUSDValue(totals.withdraw_fee, 'Withdrawal Fees')
+  dailyRevenue.addUSDValue(totals.withdraw_fee, METRIC.DEPOSIT_WITHDRAW_FEES)
 
   // Liquidation fees go to the Lighter Liquidity Pool (LLP) — the supply side
   // (liquidity providers), not the protocol. Booking them here keeps
@@ -119,18 +119,18 @@ const breakdownMethodology = {
   Fees: {
     [METRIC.TRADING_FEES]: 'Maker and taker fees from perpetual trading (summed across active perp markets).',
     'Transfer Fees': 'Transfer fees paid by traders on Lighter.',
-    'Withdrawal Fees': 'Withdrawal fees paid by traders on Lighter.',
+    [METRIC.DEPOSIT_WITHDRAW_FEES]: 'Withdrawal fees paid by traders on Lighter.',
     [METRIC.LIQUIDATION_FEES]: 'Liquidation fees paid by traders, routed to the LLP.',
   },
   Revenue: {
     [METRIC.TRADING_FEES]: 'Maker and taker fees retained by the protocol.',
     'Transfer Fees': 'Transfer fees retained by the protocol.',
-    'Withdrawal Fees': 'Withdrawal fees retained by the protocol.',
+    [METRIC.DEPOSIT_WITHDRAW_FEES]: 'Withdrawal fees retained by the protocol.',
   },
   ProtocolRevenue: {
     [METRIC.TRADING_FEES]: 'Maker and taker fees retained by the protocol.',
     'Transfer Fees': 'Transfer fees retained by the protocol.',
-    'Withdrawal Fees': 'Withdrawal fees retained by the protocol.',
+    [METRIC.DEPOSIT_WITHDRAW_FEES]: 'Withdrawal fees retained by the protocol.',
   },
   SupplySideRevenue: {
     [METRIC.LIQUIDATION_FEES]: 'Liquidation fees paid to the Lighter Liquidity Pool (LLP).',

--- a/fees/lighter-rh/index.ts
+++ b/fees/lighter-rh/index.ts
@@ -38,24 +38,34 @@ async function fetch(options: FetchOptions): Promise<FetchResultV2> {
 
   const dailyFees = options.createBalances()
   const dailyRevenue = options.createBalances()
+  const dailySupplySideRevenue = options.createBalances()
 
+  // Protocol revenue: maker, taker, transfer and withdraw fees.
   dailyRevenue.addUSDValue(tradingFees, METRIC.TRADING_FEES)
   dailyRevenue.addUSDValue(transferFee, 'Transfer Fees')
   dailyRevenue.addUSDValue(withdrawFee, METRIC.DEPOSIT_WITHDRAW_FEES)
-  dailyFees.addUSDValue(liquidationFee, METRIC.LIQUIDATION_FEES)
+
+  // Liquidation fees are routed to the Lighter Liquidity Pool (LLP) — i.e. the
+  // supply side (liquidity providers), not the protocol. Booking them as
+  // supply-side revenue keeps dailyFees = dailyRevenue + dailySupplySideRevenue.
+  dailySupplySideRevenue.addUSDValue(liquidationFee, METRIC.LIQUIDATION_FEES)
+
   dailyFees.addBalances(dailyRevenue)
+  dailyFees.addBalances(dailySupplySideRevenue)
 
   return {
     dailyFees,
     dailyRevenue,
     dailyProtocolRevenue: dailyRevenue,
+    dailySupplySideRevenue,
   }
 }
 
 const methodology = {
-  Fees: 'Maker, taker and liquidation fees paid by traders on the Lighter Robinhood perpetuals deployment.',
-  Revenue: 'Protocol revenue from maker and taker fees, plus transfer and withdraw fees. Liquidation fees are excluded as they go directly to LLP.',
-  ProtocolRevenue: 'All trading and operational fees collected by the protocol treasury.',
+  Fees: 'All fees paid by traders on the Lighter Robinhood perpetuals deployment: maker, taker, transfer, withdraw and liquidation fees.',
+  Revenue: 'Protocol revenue from maker, taker, transfer and withdraw fees. Liquidation fees are excluded — they go to the LLP (see SupplySideRevenue).',
+  ProtocolRevenue: 'Same as Revenue: maker, taker, transfer and withdraw fees retained by the protocol.',
+  SupplySideRevenue: 'Liquidation fees, which are paid to the Lighter Liquidity Pool (LLP) — i.e. to liquidity providers, not the protocol.',
 }
 
 const breakdownMethodology = {
@@ -63,7 +73,20 @@ const breakdownMethodology = {
     [METRIC.TRADING_FEES]: 'Maker and taker fees from perpetual trading.',
     'Transfer Fees': 'Transfer fees paid by traders on Lighter.',
     [METRIC.DEPOSIT_WITHDRAW_FEES]: 'Withdraw fees paid by traders on Lighter.',
-    [METRIC.LIQUIDATION_FEES]: 'Liquidation fees paid by traders on Lighter.',
+    [METRIC.LIQUIDATION_FEES]: 'Liquidation fees paid by traders, routed to the LLP.',
+  },
+  Revenue: {
+    [METRIC.TRADING_FEES]: 'Maker and taker fees retained by the protocol.',
+    'Transfer Fees': 'Transfer fees retained by the protocol.',
+    [METRIC.DEPOSIT_WITHDRAW_FEES]: 'Withdraw fees retained by the protocol.',
+  },
+  ProtocolRevenue: {
+    [METRIC.TRADING_FEES]: 'Maker and taker fees retained by the protocol.',
+    'Transfer Fees': 'Transfer fees retained by the protocol.',
+    [METRIC.DEPOSIT_WITHDRAW_FEES]: 'Withdraw fees retained by the protocol.',
+  },
+  SupplySideRevenue: {
+    [METRIC.LIQUIDATION_FEES]: 'Liquidation fees paid to the Lighter Liquidity Pool (LLP).',
   },
 }
 

--- a/fees/lighter-rh/index.ts
+++ b/fees/lighter-rh/index.ts
@@ -18,73 +18,84 @@ interface OrderBookDetail {
   status: string
 }
 
-/** Perp markets only. Lighter's Robinhood spot markets (e.g. NVDA/USDG) are a
- * separate protocol tracked by dexs/lighter-spot, and the unfiltered
- * exchangeMetrics value is the perp+spot total — so we scope fees to the active
- * perp markets, exactly like mainnet Lighter (fees/lighterv2). */
-async function getActivePerpMarkets(): Promise<OrderBookDetail[]> {
-  const res: { order_book_details?: OrderBookDetail[] } = await fetchURL(`${API_BASE}/orderBookDetails`)
-  return (res?.order_book_details || []).filter(
-    (m) => m.market_type === 'perp' && m.status === 'active'
-  )
+/** Reads the value for `startOfDay` from an exchangeMetrics response. Throws on a
+ * malformed response (missing / non-array `metrics`) so an outage or schema
+ * change surfaces instead of silently underreporting fees as zero; returns 0
+ * only when the series simply has no entry for that day (a genuine no-fee day). */
+function pickDailyValue(res: ExchangeMetricResponse, startOfDay: number, label: string): number {
+  if (!res || !Array.isArray(res.metrics)) {
+    throw new Error(`Lighter Robinhood exchangeMetrics returned an unexpected shape for ${label}`)
+  }
+  const metric = res.metrics.find((m) => m.timestamp === startOfDay)
+  return metric ? Number(metric.data) : 0
 }
 
 async function fetchMetricByMarket(kind: string, symbol: string, startOfDay: number): Promise<number> {
   const res: ExchangeMetricResponse = await fetchURLAutoHandleRateLimit(
     `${API_BASE}/exchangeMetrics?period=all&kind=${kind}&filter=byMarket&value=${encodeURIComponent(symbol)}`
   )
-  const metric = (res?.metrics || []).find((m) => m.timestamp === startOfDay)
-  return metric?.data || 0
+  return pickDailyValue(res, startOfDay, `${kind} (${symbol})`)
 }
 
 async function fetchMetricGlobal(kind: string, startOfDay: number): Promise<number> {
   const res: ExchangeMetricResponse = await fetchURL(`${API_BASE}/exchangeMetrics?period=all&kind=${kind}`)
-  const metric = (res?.metrics || []).find((m) => m.timestamp === startOfDay)
-  return metric?.data || 0
+  return pickDailyValue(res, startOfDay, kind)
+}
+
+/** Perp markets only. Lighter's Robinhood spot markets (e.g. NVDA/USDG) are a
+ * separate protocol (dexs/lighter-spot), and the unfiltered exchangeMetrics
+ * value is the perp+spot total — so fees are scoped to the active perp markets,
+ * exactly like mainnet Lighter (fees/lighterv2). */
+async function getActivePerpMarkets(): Promise<OrderBookDetail[]> {
+  const res: { order_book_details?: OrderBookDetail[] } = await fetchURL(`${API_BASE}/orderBookDetails`)
+  return (res?.order_book_details || []).filter((m) => m.market_type === 'perp' && m.status === 'active')
 }
 
 async function fetch(options: FetchOptions): Promise<FetchResultV2> {
   const markets = await getActivePerpMarkets()
   options.api.log('Lighter Robinhood active perp markets #', markets.length)
 
-  let makerFee = 0
-  let takerFee = 0
-  let liquidationFee = 0
+  // Build every request up-front and run them through one bounded pool so
+  // concurrency and upstream rate-limiting stay explicit: per-market maker /
+  // taker / liquidation fees + account-level transfer / withdraw fees.
+  const tasks: Array<{ kind: string; symbol?: string }> = []
+  for (const market of markets) {
+    tasks.push({ kind: 'maker_fee', symbol: market.symbol })
+    tasks.push({ kind: 'taker_fee', symbol: market.symbol })
+    tasks.push({ kind: 'liquidation_fee', symbol: market.symbol })
+  }
+  tasks.push({ kind: 'transfer_fee' })
+  tasks.push({ kind: 'withdraw_fee' })
+
+  const totals: Record<string, number> = {
+    maker_fee: 0, taker_fee: 0, liquidation_fee: 0, transfer_fee: 0, withdraw_fee: 0,
+  }
 
   await PromisePool.withConcurrency(3)
-    .for(markets)
-    .process(async (market) => {
-      const [mk, tk, lq] = await Promise.all([
-        fetchMetricByMarket('maker_fee', market.symbol, options.startOfDay),
-        fetchMetricByMarket('taker_fee', market.symbol, options.startOfDay),
-        fetchMetricByMarket('liquidation_fee', market.symbol, options.startOfDay),
-      ])
-      makerFee += mk
-      takerFee += tk
-      liquidationFee += lq
+    .handleError((error) => { throw error }) // propagate malformed-data / outage failures
+    .for(tasks)
+    .process(async (task) => {
+      const value = task.symbol
+        ? await fetchMetricByMarket(task.kind, task.symbol, options.startOfDay)
+        : await fetchMetricGlobal(task.kind, options.startOfDay)
+      totals[task.kind] += value
     })
 
-  // Transfer / withdraw fees are account-level (not per-market); read globally.
-  const [transferFee, withdrawFee] = await Promise.all([
-    fetchMetricGlobal('transfer_fee', options.startOfDay),
-    fetchMetricGlobal('withdraw_fee', options.startOfDay),
-  ])
-
-  const tradingFees = makerFee + takerFee
+  const tradingFees = totals.maker_fee + totals.taker_fee
 
   const dailyFees = options.createBalances()
   const dailyRevenue = options.createBalances()
   const dailySupplySideRevenue = options.createBalances()
 
-  // Protocol revenue: maker, taker, transfer and withdraw fees.
+  // Protocol revenue: maker, taker, transfer and withdrawal fees.
   dailyRevenue.addUSDValue(tradingFees, METRIC.TRADING_FEES)
-  dailyRevenue.addUSDValue(transferFee, 'Transfer Fees')
-  dailyRevenue.addUSDValue(withdrawFee, METRIC.DEPOSIT_WITHDRAW_FEES)
+  dailyRevenue.addUSDValue(totals.transfer_fee, 'Transfer Fees')
+  dailyRevenue.addUSDValue(totals.withdraw_fee, 'Withdrawal Fees')
 
-  // Liquidation fees are routed to the Lighter Liquidity Pool (LLP) — i.e. the
-  // supply side (liquidity providers), not the protocol. Booking them as
-  // supply-side revenue keeps dailyFees = dailyRevenue + dailySupplySideRevenue.
-  dailySupplySideRevenue.addUSDValue(liquidationFee, METRIC.LIQUIDATION_FEES)
+  // Liquidation fees go to the Lighter Liquidity Pool (LLP) — the supply side
+  // (liquidity providers), not the protocol. Booking them here keeps
+  // dailyFees = dailyRevenue + dailySupplySideRevenue.
+  dailySupplySideRevenue.addUSDValue(totals.liquidation_fee, METRIC.LIQUIDATION_FEES)
 
   dailyFees.addBalances(dailyRevenue)
   dailyFees.addBalances(dailySupplySideRevenue)
@@ -98,9 +109,9 @@ async function fetch(options: FetchOptions): Promise<FetchResultV2> {
 }
 
 const methodology = {
-  Fees: 'All fees paid by traders on the Lighter Robinhood perpetuals deployment: maker, taker, transfer, withdraw and liquidation fees. Scoped to perp markets (spot is tracked separately as lighter-spot).',
-  Revenue: 'Protocol revenue from maker, taker, transfer and withdraw fees. Liquidation fees are excluded — they go to the LLP (see SupplySideRevenue).',
-  ProtocolRevenue: 'Same as Revenue: maker, taker, transfer and withdraw fees retained by the protocol.',
+  Fees: 'All fees paid by traders on the Lighter Robinhood perpetuals deployment: maker, taker, transfer, withdrawal and liquidation fees. Scoped to perp markets (spot is tracked separately as lighter-spot).',
+  Revenue: 'Protocol revenue from maker, taker, transfer and withdrawal fees. Liquidation fees are excluded — they go to the LLP (see SupplySideRevenue).',
+  ProtocolRevenue: 'Same as Revenue: maker, taker, transfer and withdrawal fees retained by the protocol.',
   SupplySideRevenue: 'Liquidation fees, which are paid to the Lighter Liquidity Pool (LLP) — i.e. to liquidity providers, not the protocol.',
 }
 
@@ -108,18 +119,18 @@ const breakdownMethodology = {
   Fees: {
     [METRIC.TRADING_FEES]: 'Maker and taker fees from perpetual trading (summed across active perp markets).',
     'Transfer Fees': 'Transfer fees paid by traders on Lighter.',
-    [METRIC.DEPOSIT_WITHDRAW_FEES]: 'Withdraw fees paid by traders on Lighter.',
+    'Withdrawal Fees': 'Withdrawal fees paid by traders on Lighter.',
     [METRIC.LIQUIDATION_FEES]: 'Liquidation fees paid by traders, routed to the LLP.',
   },
   Revenue: {
     [METRIC.TRADING_FEES]: 'Maker and taker fees retained by the protocol.',
     'Transfer Fees': 'Transfer fees retained by the protocol.',
-    [METRIC.DEPOSIT_WITHDRAW_FEES]: 'Withdraw fees retained by the protocol.',
+    'Withdrawal Fees': 'Withdrawal fees retained by the protocol.',
   },
   ProtocolRevenue: {
     [METRIC.TRADING_FEES]: 'Maker and taker fees retained by the protocol.',
     'Transfer Fees': 'Transfer fees retained by the protocol.',
-    [METRIC.DEPOSIT_WITHDRAW_FEES]: 'Withdraw fees retained by the protocol.',
+    'Withdrawal Fees': 'Withdrawal fees retained by the protocol.',
   },
   SupplySideRevenue: {
     [METRIC.LIQUIDATION_FEES]: 'Liquidation fees paid to the Lighter Liquidity Pool (LLP).',

--- a/fees/lighter-rh/index.ts
+++ b/fees/lighter-rh/index.ts
@@ -1,0 +1,79 @@
+import { FetchOptions, FetchResultV2, SimpleAdapter } from '../../adapters/types'
+import { CHAIN } from '../../helpers/chains'
+import { METRIC } from '../../helpers/metrics'
+import fetchURL from '../../utils/fetchURL'
+
+const API_BASE = 'https://api.rh.lighter.xyz/api/v1'
+
+interface ExchangeMetricResponse {
+  code: number
+  metrics: Array<{ timestamp: number; data: number }>
+}
+
+/** Lighter's Robinhood perpetuals deployment exposes the same exchangeMetrics
+ * API as mainnet Lighter (see fees/lighterv2). Each `kind` returns a daily USD
+ * series keyed by UTC-midnight timestamp. The unfiltered (exchange-wide) value
+ * equals the sum across every market — verified against the per-market
+ * `filter=byMarket` breakdown — so we read the global metric directly instead
+ * of iterating all markets, keeping the adapter light. */
+async function fetchMetric(kind: string, startOfDay: number): Promise<number> {
+  const response: ExchangeMetricResponse = await fetchURL(
+    `${API_BASE}/exchangeMetrics?period=all&kind=${kind}`
+  )
+  if (!response?.metrics || !Array.isArray(response.metrics)) return 0
+  const metric = response.metrics.find(m => m.timestamp === startOfDay)
+  return metric?.data || 0
+}
+
+async function fetch(options: FetchOptions): Promise<FetchResultV2> {
+  const [makerFee, takerFee, liquidationFee, transferFee, withdrawFee] = await Promise.all([
+    fetchMetric('maker_fee', options.startOfDay),
+    fetchMetric('taker_fee', options.startOfDay),
+    fetchMetric('liquidation_fee', options.startOfDay),
+    fetchMetric('transfer_fee', options.startOfDay),
+    fetchMetric('withdraw_fee', options.startOfDay),
+  ])
+
+  const tradingFees = makerFee + takerFee
+
+  const dailyFees = options.createBalances()
+  const dailyRevenue = options.createBalances()
+
+  dailyRevenue.addUSDValue(tradingFees, METRIC.TRADING_FEES)
+  dailyRevenue.addUSDValue(transferFee, 'Transfer Fees')
+  dailyRevenue.addUSDValue(withdrawFee, METRIC.DEPOSIT_WITHDRAW_FEES)
+  dailyFees.addUSDValue(liquidationFee, METRIC.LIQUIDATION_FEES)
+  dailyFees.addBalances(dailyRevenue)
+
+  return {
+    dailyFees,
+    dailyRevenue,
+    dailyProtocolRevenue: dailyRevenue,
+  }
+}
+
+const methodology = {
+  Fees: 'Maker, taker and liquidation fees paid by traders on the Lighter Robinhood perpetuals deployment.',
+  Revenue: 'Protocol revenue from maker and taker fees, plus transfer and withdraw fees. Liquidation fees are excluded as they go directly to LLP.',
+  ProtocolRevenue: 'All trading and operational fees collected by the protocol treasury.',
+}
+
+const breakdownMethodology = {
+  Fees: {
+    [METRIC.TRADING_FEES]: 'Maker and taker fees from perpetual trading.',
+    'Transfer Fees': 'Transfer fees paid by traders on Lighter.',
+    [METRIC.DEPOSIT_WITHDRAW_FEES]: 'Withdraw fees paid by traders on Lighter.',
+    [METRIC.LIQUIDATION_FEES]: 'Liquidation fees paid by traders on Lighter.',
+  },
+}
+
+const adapter: SimpleAdapter = {
+  version: 1,
+  fetch,
+  chains: [CHAIN.ROBINHOOD],
+  start: '2026-06-26',
+  methodology,
+  breakdownMethodology,
+}
+
+export default adapter


### PR DESCRIPTION
## What

Adds a fees adapter for **Lighter's Robinhood perpetuals deployment**. Its trading volume is already tracked (`dexs/lighter-rh`), but no fees adapter existed — so DefiLlama shows the protocol's volume while reporting no fees, even though it collects real maker/taker/liquidation fees.

## Gap

- `dexs/lighter-rh` tracks Lighter Robinhood's perp volume via `api.rh.lighter.xyz`.
- The existing `fees/lighterv2` adapter only covers mainnet Lighter (`chains: [ZK_LIGHTER]`, `mainnet.zklighter.elliot.ai`) — it does not reach the Robinhood deployment.
- No `fees/lighter-rh` existed → Lighter Robinhood fees were untracked.

## Data & methodology

The Robinhood deployment exposes the **same `exchangeMetrics` API** as mainnet Lighter, returning **actual collected fees** (not `volume × rate` estimates). This adapter mirrors `fees/lighterv2`:

- Sums `maker_fee`, `taker_fee`, `liquidation_fee` per **active perp market** (`orderBookDetails` filtered to `market_type === 'perp'`), plus global `transfer_fee` / `withdraw_fee`.
- **Perp-scoped:** the unfiltered (exchange-wide) exchangeMetrics value is the perp **+ spot** total, and Lighter Robinhood spot markets (e.g. `NVDA/USDG`) are a separate protocol (`dexs/lighter-spot`). Summing per perp-market keeps this adapter aligned with `dexs/lighter-rh` (also perp-only) and avoids double-counting spot.
- **Income-statement split:** `Revenue` = maker + taker + transfer + withdraw; **liquidation fees are booked as `SupplySideRevenue`** because they go to the Lighter Liquidity Pool (LLP), so `dailyFees = dailyRevenue + dailySupplySideRevenue` holds.
- LIT buybacks are **not** included — those are executed by the mainnet treasury and already attributed to mainnet Lighter (`fees/lighterv2`); counting them here would double-count.

## Verification

- Test (2026-07-21): Fees `$170.43` = Revenue `$125.61` (maker + taker) + SupplySide `$44.82` (liquidation). Matches the raw per-market API series.
- Fee data begins 2026-06-26, matching `start` and `dexs/lighter-rh`.

Recent daily trading fees run ~`$125–500`/day and are trending up.
