### PR TITLE
0x: count input token rows per swap on Solana

### DIFF
--- a/aggregators/zrx/index.ts
+++ b/aggregators/zrx/index.ts
@@ -78,19 +78,20 @@ const fetchSolana = async (options: FetchOptions) => {
     FROM (
       SELECT
         amount_usd,
-        -- dex_solana.trades has one row per pool hop, so a multi-hop route would
-        -- otherwise be counted once per hop. One 0x swap is one outer
-        -- instruction, and a transaction can carry several of them.
-        ROW_NUMBER() OVER (
+        token_sold_mint_address,
+        -- dex_solana.trades has one row per pool hop. One 0x swap is one
+        -- outer instruction; its volume is the sum of the legs that sell the
+        -- route's entry mint: each parallel branch once.
+        FIRST_VALUE(token_sold_mint_address) OVER (
           PARTITION BY tx_id, trader_id, outer_instruction_index
-          ORDER BY amount_usd DESC
-        ) AS rn
+          ORDER BY inner_instruction_index ASC
+        ) AS entry_mint
       FROM dex_solana.trades
       WHERE block_time >= from_unixtime(${options.startTimestamp})
         AND block_time <  from_unixtime(${options.endTimestamp})
         AND trade_source = '${SOLANA_PROGRAM}'
     )
-    WHERE rn = 1
+    WHERE token_sold_mint_address = entry_mint
   `,
   );
   const row = data[0];

--- a/aggregators/zrx/index.ts
+++ b/aggregators/zrx/index.ts
@@ -75,10 +75,22 @@ const fetchSolana = async (options: FetchOptions) => {
     options,
     `
     SELECT COALESCE(SUM(amount_usd), 0) AS volume_24
-    FROM dex_solana.trades
-    WHERE block_time >= from_unixtime(${options.startTimestamp})
-      AND block_time <  from_unixtime(${options.endTimestamp})
-      AND trade_source = '${SOLANA_PROGRAM}'
+    FROM (
+      SELECT
+        amount_usd,
+        -- dex_solana.trades has one row per pool hop, so a multi-hop route would
+        -- otherwise be counted once per hop. One 0x swap is one outer
+        -- instruction, and a transaction can carry several of them.
+        ROW_NUMBER() OVER (
+          PARTITION BY tx_id, trader_id, outer_instruction_index
+          ORDER BY amount_usd DESC
+        ) AS rn
+      FROM dex_solana.trades
+      WHERE block_time >= from_unixtime(${options.startTimestamp})
+        AND block_time <  from_unixtime(${options.endTimestamp})
+        AND trade_source = '${SOLANA_PROGRAM}'
+    )
+    WHERE rn = 1
   `,
   );
   const row = data[0];


### PR DESCRIPTION
`dex_solana.trades` emits **one row per pool hop**, so summing `amount_usd` counts a multi-hop route once for every pool it touches. Same class of fix as #8289 (jupiter-aggregator); this adapter uses the same query shape over `trade_source = 'Sett1erwx…'`.

### Why not the exact #8289 approach

#8289 keeps one row per route (the largest hop). That is exact for direct swaps and linear multi-hop chains. But this router mostly **splits a swap across parallel pools** rather than chaining hops. Decomposing the rows this adapter selects for 2026-07-20:

| | rows | amount_usd |
|---|---|---|
| all hop rows (summed today) | 937 | $287,377 |
| legs selling the route's entry mint (parallel branches) | 547 | $269,867 |
| downstream legs (selling an intermediate token) | 390 | $17,510 |
| one row per route, #8289 style | 345 | $208,165 |

Parallel branches each carry a fraction of the input, so they belong in the sum — only the $17.5k of downstream legs is double-counting. Keeping a single row per route would instead drop every branch but the largest and undercount by ~23%.

So this PR sums the legs that sell the route's **entry mint** — the sold mint of the route's first hop (`min inner_instruction_index`). For a linear route that is one leg; for a split route it is every parallel branch; intermediate hops are never counted. The partition is `(tx_id, trader_id, outer_instruction_index)` for the same reason as #8289: one swap is one outer instruction, and one transaction can carry several.

### Verification

DefiLlama production shows **$287,377** of Solana volume for 0x Aggregator on 2026-07-20 (`/summary/aggregators/0x-aggregator` chain breakdown). That matches the adapter's current un-deduped SQL run on Dune ($287,376.69) to the dollar, confirming production output is the raw per-hop sum.

```
before (current SQL):  $287,376.69
after  (this change):  $269,866.51
```

As a consistency check, computing the same figure from the other side of each route — legs *buying* the route's exit mint (`max inner_instruction_index`) — gives $266,089, within 1.4% of the entry-side figure (the residual is per-leg fees/price impact). The trailing-30d volume as summed today is $19,172,834, so the correction is material at that scale.

`tsc --project tsconfig.json` exits 0. Only the Solana fetch is touched; the EVM chains use the 0x stats API and are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
