### PR TITLE
Add MinePea fees adapter (Robinhood Chain)

### DIFF
--- a/fees/minepea.ts
+++ b/fees/minepea.ts
@@ -37,6 +37,7 @@ const TREASURY = '0x78Df583557baa1b9C8b8839BeCAAe2eD665Bd7e6';
 const ADMIN_FEE_BPS = 100n;   // 1% of totalDeployed
 const VAULT_FEE_BPS = 1000n;  // 10% of losersPool after admin
 const BPS = 10000n;
+const TOKEN_STAKER_SHARE = 0.05
 
 // Replay of GridMining._calculateSettlementFees for a given losersPool,
 // using the contract's sequential floor divisions.
@@ -79,7 +80,8 @@ const fetch = async (options: FetchOptions) => {
   for (const log of vaultLogs as any[]) {
     const amount = BigInt(log.args.amount);
     dailyFees.addGasToken(amount, 'Vault fees');
-    dailyHoldersRevenue.addGasToken(amount, 'Vault fees');
+    dailyHoldersRevenue.addGasToken(Number(amount) * TOKEN_STAKER_SHARE, 'Vault Fees to Stakers');
+    dailyHoldersRevenue.addGasToken(Number(amount) * (1 - TOKEN_STAKER_SHARE), 'Vault Fees to Burn');
     vaultByTx.set(log.transactionHash.toLowerCase(), amount);
   }
 
@@ -148,7 +150,8 @@ const breakdownMethodology = {
     'Admin fees': 'Admin fees accruing to the protocol fee wallet.',
   },
   HoldersRevenue: {
-    'Vault fees': 'Treasury vault ETH spent on PEA buybacks: 95% burned, 5% to stakers.',
+    'Vault Fees to Stakers': '5% of the vault fees are used to buy PEA and distributed to PEA stakers.',
+    'Vault Fees to Burn': '95% of the vault fees are used to buy PEA and burned.',
   },
 };
 

--- a/fees/minepea.ts
+++ b/fees/minepea.ts
@@ -136,6 +136,14 @@ const breakdownMethodology = {
     'Vault fees': 'ETH routed to the Treasury vault at settlement (10% of losers pool after admin on normal rounds; the full pot minus admin on no-winner rounds), tracked via VaultReceived events.',
     'Admin fees': 'Admin fees (1% of deployed ETH + 1% of losers pool) derived from RoundSettled events, with no-winner rounds recovered from their paired VaultReceived amount.',
   },
+  UserFees: {
+    'Vault fees': 'Vault fee portion of the fees paid by players out of their deployed ETH.',
+    'Admin fees': 'Admin fee portion of the fees paid by players out of their deployed ETH.',
+  },
+  Revenue: {
+    'Vault fees': 'Holders revenue portion: vault fee ETH funding PEA buybacks.',
+    'Admin fees': 'Protocol revenue portion: admin fees accruing to the protocol fee wallet.',
+  },
   ProtocolRevenue: {
     'Admin fees': 'Admin fees accruing to the protocol fee wallet.',
   },
@@ -146,6 +154,7 @@ const breakdownMethodology = {
 
 const adapter: Adapter = {
   version: 2,
+  pullHourly: true,
   methodology,
   breakdownMethodology,
   chains: [CHAIN.ROBINHOOD],

--- a/fees/minepea.ts
+++ b/fees/minepea.ts
@@ -9,22 +9,23 @@
 //   GridMining: 0x46D5459F439E64B8CC2D02e89b137608eA5711CE
 //   Treasury:   0x78Df583557baa1b9C8b8839BeCAAe2eD665Bd7e6
 //
-// Settlement math (GridMining._calculateSettlementFees):
+// Settlement math (GridMining._calculateSettlementFees, all divisions floor):
 //   losersPool     = totalDeployed - winnersDeployed
 //   adminFee       = totalDeployed × 1%
 //   losersAdmin    = losersPool × 1%
 //   vaultAmount    = (losersPool - losersAdmin) × 10%
 //   totalWinnings  = (losersPool - losersAdmin) - vaultAmount
 //
-// So totalWinnings = losersPool × 0.99 × 0.9 = losersPool × 8910 / 10000,
-// which lets us derive losersPool (and from it the admin fees) from the
-// RoundSettled event alone.
+// So totalWinnings ≈ losersPool × 8910 / 10000, which lets us derive losersPool
+// (and from it the admin fees) from the RoundSettled event. The derivation
+// replays the contract's sequential integer divisions to stay wei-exact.
 //
-// Rounds where nobody deployed to the winning block settle via a separate
-// path: the ENTIRE pot minus the 1% admin fee is routed to the Treasury and
-// RoundSettled is emitted with totalWinnings = 0. That vault transfer is fully
-// captured by VaultReceived below; only the 1% admin fee of those rounds is
-// left uncounted (conservative undercount, avoids per-tx log matching).
+// Rounds where nobody deployed to the winning block settle via a separate path
+// (GridMining._settleNoWinners): the ENTIRE pot minus the 1% admin fee is
+// routed to the Treasury and RoundSettled is emitted with all-zero amounts.
+// Both events emit in the same settlement transaction, so those rounds' admin
+// fees are recovered by pairing RoundSettled with the VaultReceived of the
+// same transaction (vault = totalDeployed - adminFee → adminFee = vault/99).
 
 import { Adapter, FetchOptions } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
@@ -37,6 +38,27 @@ const ADMIN_FEE_BPS = 100n;   // 1% of totalDeployed
 const VAULT_FEE_BPS = 1000n;  // 10% of losersPool after admin
 const BPS = 10000n;
 
+// Replay of GridMining._calculateSettlementFees for a given losersPool,
+// using the contract's sequential floor divisions.
+const winningsFor = (losersPool: bigint): bigint => {
+  const losersAdmin = losersPool * ADMIN_FEE_BPS / BPS;
+  const afterAdmin = losersPool - losersAdmin;
+  const vaultAmount = afterAdmin * VAULT_FEE_BPS / BPS;
+  return afterAdmin - vaultAmount;
+};
+
+// Invert totalWinnings -> losersPool. Start from the closed-form candidate,
+// then adjust within the flooring error so the contract's sequential math
+// reproduces the emitted totalWinnings exactly.
+const deriveLosersPool = (totalWinnings: bigint): bigint => {
+  const candidate = totalWinnings * BPS * BPS / ((BPS - ADMIN_FEE_BPS) * (BPS - VAULT_FEE_BPS));
+  for (let offset = -3n; offset <= 3n; offset++) {
+    const pool = candidate + offset;
+    if (pool >= 0n && winningsFor(pool) === totalWinnings) return pool;
+  }
+  return candidate;
+};
+
 const fetch = async (options: FetchOptions) => {
   const dailyFees = options.createBalances();
   const dailyProtocolRevenue = options.createBalances();
@@ -47,37 +69,50 @@ const fetch = async (options: FetchOptions) => {
   const vaultLogs = await options.getLogs({
     target: TREASURY,
     eventAbi: 'event VaultReceived(uint256 amount, uint256 totalVaulted)',
+    entireLog: true,
+    parseLog: true,
   });
 
-  vaultLogs.forEach((log: any) => {
-    dailyFees.addGasToken(log.amount, 'Vault fees');
-    dailyHoldersRevenue.addGasToken(log.amount, 'Vault fees');
-  });
+  // One settlement per transaction -> map tx to its vault amount so no-winner
+  // rounds can recover their admin fee below
+  const vaultByTx = new Map<string, bigint>();
+  for (const log of vaultLogs as any[]) {
+    const amount = BigInt(log.args.amount);
+    dailyFees.addGasToken(amount, 'Vault fees');
+    dailyHoldersRevenue.addGasToken(amount, 'Vault fees');
+    vaultByTx.set(log.transactionHash.toLowerCase(), amount);
+  }
 
   // RoundSettled gives totalWinnings + winnersDeployed to derive admin fees
   const roundLogs = await options.getLogs({
     target: GRID_MINING,
     eventAbi: 'event RoundSettled(uint64 indexed roundId, uint8 winningBlock, address topMiner, uint256 totalWinnings, uint256 topMinerReward, uint256 peapotAmount, bool isSplit, uint256 topMinerSeed, uint256 winnersDeployed)',
+    entireLog: true,
+    parseLog: true,
   });
 
-  roundLogs.forEach((log: any) => {
-    const totalWinnings = log.totalWinnings;
-    const winnersDeployed = log.winnersDeployed;
+  for (const log of roundLogs as any[]) {
+    const totalWinnings = BigInt(log.args.totalWinnings);
+    const winnersDeployed = BigInt(log.args.winnersDeployed);
 
-    // Derive losersPool: totalWinnings = losersPool × (BPS - ADMIN) / BPS × (BPS - VAULT) / BPS
-    const losersPool = totalWinnings > 0n
-      ? totalWinnings * BPS * BPS / ((BPS - ADMIN_FEE_BPS) * (BPS - VAULT_FEE_BPS))
-      : 0n;
-    const totalDeployed = losersPool + winnersDeployed;
-
-    // Admin fees: 1% on totalDeployed + 1% on losersPool
-    const adminFee = totalDeployed * ADMIN_FEE_BPS / BPS;
-    const losersAdminFee = losersPool * ADMIN_FEE_BPS / BPS;
-    const totalAdminFees = adminFee + losersAdminFee;
+    let totalAdminFees: bigint;
+    if (totalWinnings > 0n) {
+      // Normal round: 1% on totalDeployed + 1% on losersPool
+      const losersPool = deriveLosersPool(totalWinnings);
+      const totalDeployed = losersPool + winnersDeployed;
+      totalAdminFees = totalDeployed * ADMIN_FEE_BPS / BPS + losersPool * ADMIN_FEE_BPS / BPS;
+    } else if (winnersDeployed > 0n) {
+      // Everyone deployed on the winning block: losersPool = 0, base admin fee only
+      totalAdminFees = winnersDeployed * ADMIN_FEE_BPS / BPS;
+    } else {
+      // No-winner round: vault = totalDeployed - adminFee, so adminFee = vault × 1/99
+      const vaultAmount = vaultByTx.get(log.transactionHash.toLowerCase()) ?? 0n;
+      totalAdminFees = vaultAmount * ADMIN_FEE_BPS / (BPS - ADMIN_FEE_BPS);
+    }
 
     dailyFees.addGasToken(totalAdminFees, 'Admin fees');
     dailyProtocolRevenue.addGasToken(totalAdminFees, 'Admin fees');
-  });
+  }
 
   return {
     dailyFees,
@@ -91,18 +126,18 @@ const fetch = async (options: FetchOptions) => {
 const methodology = {
   Fees: 'Fees extracted per round: 1% admin fee on all deployed ETH, 1% admin fee on the losers pool, and a 10% vault fee on the losers pool after admin. On rounds where nobody hit the winning block, the entire pot (minus the admin fee) is routed to the Treasury vault. Variable effective rate depending on winner/loser ratio.',
   UserFees: 'Same as Fees — all fees are paid by players out of their deployed ETH.',
-  Revenue: 'All extracted fees (admin + vault) are protocol revenue.',
-  ProtocolRevenue: 'Admin fees (1% of deployed ETH + 1% of losers pool) sent to the feeCollector wallet for protocol operations.',
+  Revenue: 'All extracted fees: the sum of protocol revenue (admin fees) and holders revenue (vault fees).',
+  ProtocolRevenue: 'Admin fees (1% of deployed ETH + 1% of losers pool) accruing to the protocol fee wallet.',
   HoldersRevenue: 'Vault fee ETH funds automated PEA buybacks — 95% of bought PEA is permanently burned, 5% is distributed to PEA stakers as yield.',
 };
 
 const breakdownMethodology = {
   Fees: {
     'Vault fees': 'ETH routed to the Treasury vault at settlement (10% of losers pool after admin on normal rounds; the full pot minus admin on no-winner rounds), tracked via VaultReceived events.',
-    'Admin fees': 'Admin fees (1% of deployed ETH + 1% of losers pool) derived from RoundSettled events.',
+    'Admin fees': 'Admin fees (1% of deployed ETH + 1% of losers pool) derived from RoundSettled events, with no-winner rounds recovered from their paired VaultReceived amount.',
   },
   ProtocolRevenue: {
-    'Admin fees': 'Admin fees sent to the feeCollector wallet.',
+    'Admin fees': 'Admin fees accruing to the protocol fee wallet.',
   },
   HoldersRevenue: {
     'Vault fees': 'Treasury vault ETH spent on PEA buybacks: 95% burned, 5% to stakers.',

--- a/fees/minepea.ts
+++ b/fees/minepea.ts
@@ -1,0 +1,121 @@
+// MinePea — fees & revenue adapter.
+//
+// MinePea is a gamified mining protocol on Robinhood Chain (chainId 4663).
+// Players compete in continuous 60-second rounds, deploying ETH to a 5x5 grid;
+// a verifiably random winning block is drawn each round and the winners split
+// the losers' pool (in ETH) plus freshly mined PEA.
+//
+// Contracts (Robinhood Chain):
+//   GridMining: 0x46D5459F439E64B8CC2D02e89b137608eA5711CE
+//   Treasury:   0x78Df583557baa1b9C8b8839BeCAAe2eD665Bd7e6
+//
+// Settlement math (GridMining._calculateSettlementFees):
+//   losersPool     = totalDeployed - winnersDeployed
+//   adminFee       = totalDeployed × 1%
+//   losersAdmin    = losersPool × 1%
+//   vaultAmount    = (losersPool - losersAdmin) × 10%
+//   totalWinnings  = (losersPool - losersAdmin) - vaultAmount
+//
+// So totalWinnings = losersPool × 0.99 × 0.9 = losersPool × 8910 / 10000,
+// which lets us derive losersPool (and from it the admin fees) from the
+// RoundSettled event alone.
+//
+// Rounds where nobody deployed to the winning block settle via a separate
+// path: the ENTIRE pot minus the 1% admin fee is routed to the Treasury and
+// RoundSettled is emitted with totalWinnings = 0. That vault transfer is fully
+// captured by VaultReceived below; only the 1% admin fee of those rounds is
+// left uncounted (conservative undercount, avoids per-tx log matching).
+
+import { Adapter, FetchOptions } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+
+const GRID_MINING = '0x46D5459F439E64B8CC2D02e89b137608eA5711CE';
+const TREASURY = '0x78Df583557baa1b9C8b8839BeCAAe2eD665Bd7e6';
+
+// GridMining fee constants (basis points, matching contract)
+const ADMIN_FEE_BPS = 100n;   // 1% of totalDeployed
+const VAULT_FEE_BPS = 1000n;  // 10% of losersPool after admin
+const BPS = 10000n;
+
+const fetch = async (options: FetchOptions) => {
+  const dailyFees = options.createBalances();
+  const dailyProtocolRevenue = options.createBalances();
+  const dailyHoldersRevenue = options.createBalances();
+
+  // VaultReceived gives the exact ETH routed to the Treasury per settlement
+  // (10% vault fee on normal rounds; full pot minus admin on no-winner rounds)
+  const vaultLogs = await options.getLogs({
+    target: TREASURY,
+    eventAbi: 'event VaultReceived(uint256 amount, uint256 totalVaulted)',
+  });
+
+  vaultLogs.forEach((log: any) => {
+    dailyFees.addGasToken(log.amount, 'Vault fees');
+    dailyHoldersRevenue.addGasToken(log.amount, 'Vault fees');
+  });
+
+  // RoundSettled gives totalWinnings + winnersDeployed to derive admin fees
+  const roundLogs = await options.getLogs({
+    target: GRID_MINING,
+    eventAbi: 'event RoundSettled(uint64 indexed roundId, uint8 winningBlock, address topMiner, uint256 totalWinnings, uint256 topMinerReward, uint256 peapotAmount, bool isSplit, uint256 topMinerSeed, uint256 winnersDeployed)',
+  });
+
+  roundLogs.forEach((log: any) => {
+    const totalWinnings = log.totalWinnings;
+    const winnersDeployed = log.winnersDeployed;
+
+    // Derive losersPool: totalWinnings = losersPool × (BPS - ADMIN) / BPS × (BPS - VAULT) / BPS
+    const losersPool = totalWinnings > 0n
+      ? totalWinnings * BPS * BPS / ((BPS - ADMIN_FEE_BPS) * (BPS - VAULT_FEE_BPS))
+      : 0n;
+    const totalDeployed = losersPool + winnersDeployed;
+
+    // Admin fees: 1% on totalDeployed + 1% on losersPool
+    const adminFee = totalDeployed * ADMIN_FEE_BPS / BPS;
+    const losersAdminFee = losersPool * ADMIN_FEE_BPS / BPS;
+    const totalAdminFees = adminFee + losersAdminFee;
+
+    dailyFees.addGasToken(totalAdminFees, 'Admin fees');
+    dailyProtocolRevenue.addGasToken(totalAdminFees, 'Admin fees');
+  });
+
+  return {
+    dailyFees,
+    dailyUserFees: dailyFees,
+    dailyRevenue: dailyFees,
+    dailyProtocolRevenue,
+    dailyHoldersRevenue,
+  };
+};
+
+const methodology = {
+  Fees: 'Fees extracted per round: 1% admin fee on all deployed ETH, 1% admin fee on the losers pool, and a 10% vault fee on the losers pool after admin. On rounds where nobody hit the winning block, the entire pot (minus the admin fee) is routed to the Treasury vault. Variable effective rate depending on winner/loser ratio.',
+  UserFees: 'Same as Fees — all fees are paid by players out of their deployed ETH.',
+  Revenue: 'All extracted fees (admin + vault) are protocol revenue.',
+  ProtocolRevenue: 'Admin fees (1% of deployed ETH + 1% of losers pool) sent to the feeCollector wallet for protocol operations.',
+  HoldersRevenue: 'Vault fee ETH funds automated PEA buybacks — 95% of bought PEA is permanently burned, 5% is distributed to PEA stakers as yield.',
+};
+
+const breakdownMethodology = {
+  Fees: {
+    'Vault fees': 'ETH routed to the Treasury vault at settlement (10% of losers pool after admin on normal rounds; the full pot minus admin on no-winner rounds), tracked via VaultReceived events.',
+    'Admin fees': 'Admin fees (1% of deployed ETH + 1% of losers pool) derived from RoundSettled events.',
+  },
+  ProtocolRevenue: {
+    'Admin fees': 'Admin fees sent to the feeCollector wallet.',
+  },
+  HoldersRevenue: {
+    'Vault fees': 'Treasury vault ETH spent on PEA buybacks: 95% burned, 5% to stakers.',
+  },
+};
+
+const adapter: Adapter = {
+  version: 2,
+  methodology,
+  breakdownMethodology,
+  chains: [CHAIN.ROBINHOOD],
+  fetch,
+  start: '2026-07-21',
+};
+
+export default adapter;


### PR DESCRIPTION
##### Name (to be shown on DefiLlama): MinePea

##### Twitter Link: https://x.com/minepea_

##### List of audit links if any:

##### Website Link: https://minepea.com/

##### Logo (High resolution, will be shown with rounded borders): https://www.minepea.com/pea-logo.png

##### Current TVL: $7,340

##### Treasury Addresses (if the protocol has treasury): 0x78Df583557baa1b9C8b8839BeCAAe2eD665Bd7e6

##### Chain: Robinhood Chain (4663)

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed):

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed):

##### Short Description (to be shown on DefiLlama): PEA is a gamified mining protocol on Robinhood Chain. Players compete in continuous 60-second rounds, deploying ETH across a 25-tile pentagon to earn ETH and PEA tokens. Competitive gaming mechanics layered with DeFi infrastructure.

##### Token address and ticker if any: 0xfe177128Df8d336cAf99F787b72183D1E68Ff9c2 (PEA)

##### Category (full list at https://defillama.com/categories) \*Please choose only one: Gamified Mining

##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.): Quiver (on-chain commit-reveal randomness), TWAP

##### Implementation Details: Briefly describe how the oracle is integrated into your project: A Quiver commit-reveal randomness coordinator generates the verifiable random winning block each round. A built-in PEA token TWAP oracle (Uniswap V4 tick-based) provides slippage protection for Treasury buybacks.

##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage:
Contract consuming the randomness (GridMining): https://robinhoodchain.blockscout.com/address/0x46D5459F439E64B8CC2D02e89b137608eA5711CE?tab=contract
Contract where the TWAP is used (PEA token): https://robinhoodchain.blockscout.com/address/0xfe177128Df8d336cAf99F787b72183D1E68Ff9c2?tab=contract
Treasury (buybacks): https://robinhoodchain.blockscout.com/address/0x78Df583557baa1b9C8b8839BeCAAe2eD665Bd7e6?tab=contract

##### forkedFrom (Does your project originate from another project):

##### methodology (what is being counted as tvl, how is tvl being calculated): Fees per round: 1% admin fee on all deployed ETH plus 1% on the losers pool (protocol revenue), and a 10% vault fee on the losers pool after admin that funds automated PEA buybacks — 95% of bought PEA is permanently burned, 5% distributed to PEA stakers. On rounds where nobody hits the winning block, the entire pot (minus admin fee) is routed to the Treasury vault. All fees tracked from on-chain events (VaultReceived + RoundSettled).

##### Github org/user (Optional, if your code is open source, we can track activity): https://github.com/nu11dotfun

##### Does this project have a referral program? No
