### PR TITLE
avalon-usda: value USDa interest at its $1 peg (was reporting $0)

### DIFF
--- a/fees/avalon-usda.ts
+++ b/fees/avalon-usda.ts
@@ -64,7 +64,13 @@ async function fetch(options: FetchOptions): Promise<FetchResultV2> {
 		target: poolAddress,
 	})
 
-	dailyFees.add(feeTokenAddress, Number(protocolProfitAccumulateAfter) - Number(protocolProfitAccumulateBefore), METRIC.BORROW_INTEREST)
+	// USDa is Avalon's USD-pegged stablecoin (peggedUSD on DefiLlama's stablecoin
+	// list, ~$145m circulating) but coins.llama.fi does not price it, so
+	// dailyFees.add(feeTokenAddress, ...) values the interest at $0. Value the USDa
+	// interest at its $1 peg using the token's own decimals instead.
+	const usdaDecimals = Number(await options.fromApi.call({ abi: 'erc20:decimals', target: feeTokenAddress }))
+	const usdaInterest = (Number(protocolProfitAccumulateAfter) - Number(protocolProfitAccumulateBefore)) / 10 ** usdaDecimals
+	dailyFees.addUSDValue(usdaInterest, METRIC.BORROW_INTEREST)
 
 	// @dev Ethereum has both V1 and V2 pools, so we need to add the fees from the V1 pool
 	if (options.chain === CHAIN.ETHEREUM) {

--- a/fees/avalon-usda.ts
+++ b/fees/avalon-usda.ts
@@ -69,7 +69,7 @@ async function fetch(options: FetchOptions): Promise<FetchResultV2> {
 	// dailyFees.add(feeTokenAddress, ...) values the interest at $0. Value the USDa
 	// interest at its $1 peg using the token's own decimals instead.
 	const usdaDecimals = Number(await options.fromApi.call({ abi: 'erc20:decimals', target: feeTokenAddress }))
-	const usdaInterest = (Number(protocolProfitAccumulateAfter) - Number(protocolProfitAccumulateBefore)) / 10 ** usdaDecimals
+	const usdaInterest = Number(BigInt(protocolProfitAccumulateAfter) - BigInt(protocolProfitAccumulateBefore)) / 10 ** usdaDecimals
 	dailyFees.addUSDValue(usdaInterest, METRIC.BORROW_INTEREST)
 
 	// @dev Ethereum has both V1 and V2 pools, so we need to add the fees from the V1 pool
@@ -85,7 +85,7 @@ async function fetch(options: FetchOptions): Promise<FetchResultV2> {
 			target: v1PoolAddress,
 		})
 
-		dailyFees.add(v1FeeTokenAddress, Number(protocolProfitAccumulateAfter) - Number(protocolProfitAccumulateBefore), METRIC.BORROW_INTEREST)
+		dailyFees.add(v1FeeTokenAddress, BigInt(protocolProfitAccumulateAfter) - BigInt(protocolProfitAccumulateBefore), METRIC.BORROW_INTEREST)
 	}
 
 	return {


### PR DESCRIPTION
## Problem

`fees/avalon-usda.ts` has reported `$0` every day since 2025-11-07 (`total1y` `$7,786,147`, `total30d` `0`). The adapter's arithmetic is correct — it measures `protocolProfitAccumulate` growth (borrower interest) denominated in **USDa** — but USDa is not priced by `coins.llama.fi`, so `dailyFees.add(feeTokenAddress, ...)` values every day at $0. Fixes #8269.

## Root cause

USDa is **Avalon's USD-pegged stablecoin** — `peggedUSD` on DefiLlama's stablecoin list, ~$145m circulating — but the six per-chain USDa fee-token addresses don't resolve on `coins.llama.fi`, so the interest values to zero.

## Fix

Value the USDa interest at its **$1 peg** using the token's own decimals, instead of relying on a market price that doesn't exist:

```diff
- dailyFees.add(feeTokenAddress, after - before, METRIC.BORROW_INTEREST)
+ const usdaDecimals = Number(await options.fromApi.call({ abi: 'erc20:decimals', target: feeTokenAddress }))
+ dailyFees.addUSDValue((after - before) / 10 ** usdaDecimals, METRIC.BORROW_INTEREST)
```

The Ethereum **V1** pool settles in USDT (priced normally) and is left unchanged.

## Verification (live, on-chain)

For the 2026-06-28 window on Ethereum (the issue's example, `protocolProfitAccumulate` at blocks 25412421 → 25419591):

| | value |
|---|---|
| `before` | `8991723792647852136509573` |
| `after` | `13302160862659025417251244` |
| delta | **`4,310,437.07` USDa** (decimals 18, confirmed on-chain) |
| Old adapter | `$0` (USDa unpriced) |
| Fixed adapter | **`$4,310,437.07`** (USDa at $1) |

Matches the issue's reported delta exactly. The same fix applies to all six chains (BSC's single-day delta in the issue was ~8.6M USDa).
