### PR TITLE
fees: add Squeeze (Base, Robinhood, Solana)

### DIFF
--- a/fees/squeeze.ts
+++ b/fees/squeeze.ts
@@ -1,0 +1,197 @@
+/**
+ * DefiLlama fees adapter draft for Squeeze (https://squeeze.run)
+ *
+ * Copy this file into DefiLlama/dimension-adapters as:
+ *   fees/squeeze.ts
+ *
+ * Then run (from dimension-adapters):
+ *   pnpm i
+ *   pnpm test fees squeeze
+ *
+ * Methodology (on-chain wallet receipts — Clanker / Flaunch style):
+ * - EVM (Base + Robinhood): track numeraire tokens + native received by the
+ *   Squeeze platform / integrator wallet. That wallet is the Airlock
+ *   `integrator` and the 47.5% swap-fee beneficiary on Doppler launches.
+ * - Gross pool fees are extrapolated: platform share = 47.5% of pool fees
+ *   → dailyFees ≈ dailyRevenue * (100 / 47.5).
+ * - Solana: track value received by the LaunchLab claim wallet (platform fees
+ *   claimed from pools tagged with Squeeze platformId). Treat 100% of those
+ *   receipts as Squeeze protocol revenue (LaunchLab platform fee path).
+ *
+ * Do NOT invent TVL from Uniswap V4 / Raydium pool balances.
+ *
+ * Canonical addresses: https://squeeze.run/api/defillama
+ * Docs: https://squeeze.run/docs#defillama
+ * Source of truth in Squeeze repo: utils/squeezeIntegration.js
+ */
+
+import { FetchOptions, SimpleAdapter } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+import { METRIC } from "../helpers/metrics";
+import {
+  addTokensReceived,
+  getETHReceived,
+  getSolanaReceived,
+} from "../helpers/token";
+
+/** Canonical Squeeze identity — greppable for reviewers. */
+const IDENTITY = {
+  /** Platform fee beneficiary + Doppler Airlock integrator (Base + Robinhood). */
+  evmFeeWallet: "0x6C61feE73584670AbEd65101946734006DAB12d6",
+  /** Base Airlock — filter creates where integrator == evmFeeWallet. */
+  baseAirlock: "0x660eAaEdEBc968f8f3694354FA8EC0b4c5Ba8D12",
+  /** Robinhood Airlock — same integrator filter. */
+  robinhoodAirlock: "0xeb7c034704ef8dcd2d32324c1545f62fb4ad0862",
+  /** Raydium LaunchLab platformId for Squeeze-tagged pools. */
+  solanaPlatformId: "FpKUW9vDSRPTByNu4MerR2SU4YPkJU9pLWQTnChGAW3h",
+  /** LaunchLab claim / platform-admin wallet (platform fee destination). */
+  solanaClaimWallet: "2qUg6a3yCSATL7stUyJHDBgFJwLW8DXzemZQDePxscws",
+} as const;
+
+/**
+ * Platform share of Doppler multicurve swap fees.
+ * Split: 5% Doppler protocol owner / 47.5% Squeeze / 47.5% creator.
+ * @see https://squeeze.run/docs#terminals
+ */
+const PLATFORM_FEE_SHARE = 0.475;
+
+/** Base numeraires used as Doppler quote tokens. */
+const BASE_FEE_TOKENS = [
+  "0x4200000000000000000000000000000000000006", // WETH
+  "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913", // USDC
+];
+
+/** Robinhood numeraires used as Doppler quote tokens. */
+const ROBINHOOD_FEE_TOKENS = [
+  "0x0Bd7D308f8E1639FAb988df18A8011f41EAcAD73", // WETH
+  "0x5fc5360D0400a0Fd4f2af552ADD042D716F1d168", // USDG
+  "0xF444F3C77C77a33F7c8d8fcab8a1E88aFb843dA5", // SQUEEZE (optional quote)
+];
+
+const chainConfig: Record<
+  string,
+  { start: string; kind: "evm" | "solana"; tokens?: string[] }
+> = {
+  [CHAIN.BASE]: {
+    start: "2025-06-01", // TODO: tighten to first Squeeze Base claim day after local test
+    kind: "evm",
+    tokens: BASE_FEE_TOKENS,
+  },
+  [CHAIN.ROBINHOOD]: {
+    start: "2026-04-20", // Robinhood Chain DefiLlama history start; tighten after test
+    kind: "evm",
+    tokens: ROBINHOOD_FEE_TOKENS,
+  },
+  [CHAIN.SOLANA]: {
+    start: "2025-06-01", // TODO: tighten to first LaunchLab platform claim
+    kind: "solana",
+  },
+};
+
+const fetch = async (options: FetchOptions) => {
+  const cfg = chainConfig[options.chain];
+  const dailyRevenue = options.createBalances();
+  const dailyFees = options.createBalances();
+  const dailySupplySideRevenue = options.createBalances();
+
+  if (cfg.kind === "evm") {
+    // ERC-20 numeraires received by the Squeeze fee wallet.
+    // Airlocks (IDENTITY.baseAirlock / IDENTITY.robinhoodAirlock) are the
+    // create-path identity; v1 tracks the fee wallet receipts instead.
+    const erc20 = await addTokensReceived({
+      options,
+      target: IDENTITY.evmFeeWallet,
+      tokens: cfg.tokens,
+    });
+    dailyRevenue.addBalances(erc20, METRIC.PROTOCOL_FEES);
+
+    // Native ETH / RH gas token received (if any direct native claims).
+    // getETHReceived falls back to Allium traces when the chain is not in
+    // the named chainMap (covers Robinhood).
+    const native = await getETHReceived({
+      options,
+      target: IDENTITY.evmFeeWallet,
+    });
+    dailyRevenue.addBalances(native, METRIC.PROTOCOL_FEES);
+
+    // Extrapolate gross pool fees from the 47.5% platform share.
+    // Note: 0x affiliate (25 bps) also lands in this wallet and slightly
+    // overstates extrapolated fees — acceptable for v1; refine later by
+    // filtering transfer senders to Doppler collect paths only.
+    //
+    // platform 47.5% → gross = revenue / 0.475
+    // supply-side (creator 47.5% + Doppler protocol 5%) = 52.5% of gross
+    //   = revenue * (0.525 / 0.475)
+    dailyFees.addBalances(
+      dailyRevenue.clone(1 / PLATFORM_FEE_SHARE),
+      METRIC.TRADING_FEES
+    );
+    dailySupplySideRevenue.addBalances(
+      dailyRevenue.clone((1 - PLATFORM_FEE_SHARE) / PLATFORM_FEE_SHARE),
+      METRIC.CREATOR_FEES
+    );
+  } else {
+    // Solana: LaunchLab platform fees claimed to the claim wallet.
+    // Use getSolanaReceived (not addTokensReceived — that helper is EVM-only).
+    // Pools are tagged with IDENTITY.solanaPlatformId; v1 does not filter
+    // by platformId yet (wallet is Squeeze-controlled).
+    const sol = options.createBalances();
+    await getSolanaReceived({
+      options,
+      balances: sol,
+      target: IDENTITY.solanaClaimWallet,
+    });
+    dailyRevenue.addBalances(sol, METRIC.PROTOCOL_FEES);
+    dailyFees.addBalances(sol, METRIC.TRADING_FEES);
+    // Creator / Raydium cuts are not in this wallet — leave supply-side empty
+    // until a LaunchLab event decoder or Dune query filters by platformId.
+  }
+
+  return {
+    dailyFees,
+    dailyRevenue,
+    dailyProtocolRevenue: dailyRevenue,
+    dailySupplySideRevenue,
+  };
+};
+
+const methodology = {
+  Fees:
+    "Gross trading fees on Squeeze launches. On Base/Robinhood, Doppler pools charge 2.5%; Squeeze’s platform wallet receives 47.5% of those fees (plus optional 0x affiliate on Squeeze trade proxies). Gross fees are extrapolated from platform receipts. On Solana, LaunchLab platform fees claimed to Squeeze’s claim wallet.",
+  Revenue:
+    "Squeeze platform share (47.5% of Doppler swap fees on EVM; LaunchLab platform fees on Solana) received by Squeeze-controlled wallets.",
+  ProtocolRevenue:
+    "Same as Revenue — Squeeze treasury / platform wallet.",
+  SupplySideRevenue:
+    "On EVM: remainder of extrapolated pool fees (creator 47.5% + Doppler protocol owner 5%). On Solana: not yet attributed in v1.",
+};
+
+const breakdownMethodology = {
+  Fees: {
+    [METRIC.TRADING_FEES]:
+      "User-paid trading fees on Squeeze-launched pools (extrapolated on EVM from 47.5% platform share; Solana = claim-wallet receipts).",
+    [METRIC.PROTOCOL_FEES]:
+      "Direct protocol fee receipts where not extrapolated.",
+  },
+  Revenue: {
+    [METRIC.PROTOCOL_FEES]:
+      "Tokens received by Squeeze platform / claim wallets.",
+  },
+  SupplySideRevenue: {
+    [METRIC.CREATOR_FEES]:
+      "Estimated creator (+ Doppler protocol) share of EVM pool fees.",
+  },
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  pullHourly: true,
+  fetch,
+  adapter: chainConfig,
+  methodology,
+  breakdownMethodology,
+  // Extrapolated EVM pool fees may overlap Uniswap V4 / Raydium fee dashboards.
+  doublecounted: true,
+};
+
+export default adapter;

--- a/fees/squeeze.ts
+++ b/fees/squeeze.ts
@@ -70,7 +70,7 @@ const chainConfig: Record<
   [CHAIN.ROBINHOOD]: {
     // Robinhood Chain earliest DefiLlama history / RH Doppler go-live window.
     // Source: DefiLlama robinhood chain listing + Squeeze RH Airlock deploy.
-    start: "2026-04-20",
+    start: "2026-07-10",
     kind: "evm",
     airlock: IDENTITY.robinhoodAirlock,
     feeTokens: [

--- a/fees/squeeze.ts
+++ b/fees/squeeze.ts
@@ -23,6 +23,7 @@
 import { Dependencies, FetchOptions, SimpleAdapter } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
 import { addTokensReceived, getSolanaReceived } from "../helpers/token";
+import ADDRESSES from '../helpers/coreAssets.json'
 
 /** Canonical Squeeze identity — greppable for reviewers. */
 const IDENTITY = {
@@ -54,38 +55,29 @@ const LABEL_CREATOR = "Creator Fees";
 const LABEL_DOPPLER = "Doppler Protocol Fees";
 const LABEL_LAUNCHLAB_PLATFORM = "LaunchLab Platform Fees";
 
-/** Base numeraires used as Doppler quote tokens. */
-const BASE_FEE_TOKENS = [
-  "0x4200000000000000000000000000000000000006", // WETH
-  "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913", // USDC
-];
-
-/** Robinhood numeraires used as Doppler quote tokens. */
-const ROBINHOOD_FEE_TOKENS = [
-  "0x0Bd7D308f8E1639FAb988df18A8011f41EAcAD73", // WETH
-  "0x5fc5360D0400a0Fd4f2af552ADD042D716F1d168", // USDG
-  "0xF444F3C77C77a33F7c8d8fcab8a1E88aFb843dA5", // SQUEEZE (optional quote)
-];
-
 const chainConfig: Record<
   string,
-  { start: string; kind: "evm" | "solana"; tokens?: string[]; airlock?: string }
+  { start: string; kind: "evm" | "solana"; airlock?: string; feeTokens?: string[] }
 > = {
   [CHAIN.BASE]: {
     // Approx. Squeeze Doppler activity window on Base; tighten after first claim-day spot-check.
     // Source: product launch window documented at https://squeeze.run/docs#defillama
     start: "2025-06-01",
     kind: "evm",
-    tokens: BASE_FEE_TOKENS,
     airlock: IDENTITY.baseAirlock,
+    feeTokens: [ADDRESSES.base.WETH, ADDRESSES.base.USDC]
   },
   [CHAIN.ROBINHOOD]: {
     // Robinhood Chain earliest DefiLlama history / RH Doppler go-live window.
     // Source: DefiLlama robinhood chain listing + Squeeze RH Airlock deploy.
     start: "2026-04-20",
     kind: "evm",
-    tokens: ROBINHOOD_FEE_TOKENS,
     airlock: IDENTITY.robinhoodAirlock,
+    feeTokens: [
+      ADDRESSES.robinhood.WETH,
+      ADDRESSES.robinhood.USDG,
+      "0xF444F3C77C77a33F7c8d8fcab8a1E88aFb843dA5", // SQUEEZE (optional quote)
+    ]
   },
   [CHAIN.SOLANA]: {
     // Approx. LaunchLab platform claim window; tighten after first claim-day spot-check.
@@ -110,7 +102,7 @@ const fetch = async (options: FetchOptions) => {
     const erc20 = await addTokensReceived({
       options,
       target: IDENTITY.evmFeeWallet,
-      tokens: cfg.tokens,
+      tokens: cfg.feeTokens,
       fromAdddesses: cfg.airlock ? [cfg.airlock] : undefined,
     });
     dailyRevenue.addBalances(erc20, LABEL_SQUEEZE_PLATFORM);
@@ -162,7 +154,7 @@ const methodology = {
   Revenue:
     "Squeeze platform share — EVM: 47.5% of Doppler swap fees from Airlock collect; Solana: LaunchLab platform fees to the claim wallet.",
   ProtocolRevenue:
-    "Same as Revenue — Squeeze treasury / platform wallet.",
+    "Squeeze platform share — EVM: 47.5% of Doppler swap fees from Airlock collect; Solana: LaunchLab platform fees to the claim wallet.",
   SupplySideRevenue:
     "On EVM: extrapolated creator share (47.5%) and Doppler protocol-owner share (5%). On Solana: not attributed in v1 (those cuts never hit the Squeeze claim wallet).",
 };

--- a/fees/squeeze.ts
+++ b/fees/squeeze.ts
@@ -8,9 +8,10 @@
  * - Gross pool fees are extrapolated: platform share = 47.5% of pool fees
  *   → dailyFees ≈ dailyRevenue * (100 / 47.5).
  * - Supply-side split of the remaining 52.5%: creator 47.5% + Doppler owner 5%.
- * - Solana: value received by the LaunchLab claim wallet (Squeeze-controlled).
- *   Pools are tagged with `solanaPlatformId`; v1 counts claim-wallet receipts
- *   (platformId event/Dune filter can refine later).
+ * - Solana: LaunchLab **platform** fees claimed to the Squeeze claim wallet
+ *   (not gross pool fees / not creator+protocol+referral). Pools are tagged with
+ *   `solanaPlatformId`; v1 uses the Squeeze-controlled claim wallet (platformId
+ *   event/Dune filter can refine later).
  *
  * Do NOT invent TVL from Uniswap V4 / Raydium pool balances.
  *
@@ -21,7 +22,6 @@
 
 import { Dependencies, FetchOptions, SimpleAdapter } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
-import { METRIC } from "../helpers/metrics";
 import { addTokensReceived, getSolanaReceived } from "../helpers/token";
 
 /** Canonical Squeeze identity — greppable for reviewers. */
@@ -47,10 +47,12 @@ const PLATFORM_FEE_SHARE = 0.475;
 const CREATOR_FEE_SHARE = 0.475;
 const DOPPLER_PROTOCOL_SHARE = 0.05;
 
-/** Descriptive breakdown labels (avoid vague METRIC.PROTOCOL_FEES on supply side). */
+/** Descriptive breakdown labels (fee-adapter guidelines: source-specific). */
+const LABEL_DOPPLER_POOL_FEES = "Doppler Pool Trading Fees";
 const LABEL_SQUEEZE_PLATFORM = "Squeeze Platform Fees";
 const LABEL_CREATOR = "Creator Fees";
 const LABEL_DOPPLER = "Doppler Protocol Fees";
+const LABEL_LAUNCHLAB_PLATFORM = "LaunchLab Platform Fees";
 
 /** Base numeraires used as Doppler quote tokens. */
 const BASE_FEE_TOKENS = [
@@ -118,7 +120,7 @@ const fetch = async (options: FetchOptions) => {
     // Doppler protocol 5% of gross = revenue * (0.05 / 0.475)
     dailyFees.addBalances(
       dailyRevenue.clone(1 / PLATFORM_FEE_SHARE),
-      METRIC.TRADING_FEES
+      LABEL_DOPPLER_POOL_FEES
     );
     dailySupplySideRevenue.addBalances(
       dailyRevenue.clone(CREATOR_FEE_SHARE / PLATFORM_FEE_SHARE),
@@ -129,19 +131,21 @@ const fetch = async (options: FetchOptions) => {
       LABEL_DOPPLER
     );
   } else {
-    // Solana: LaunchLab platform fees claimed to the Squeeze claim wallet.
-    // IDENTITY.solanaPlatformId tags Squeeze pools; getSolanaReceived cannot
-    // filter by platformId yet, so v1 uses the Squeeze-controlled claim wallet
-    // (same wallet-receipt pattern as Clanker). Refine with LaunchLab events
-    // or Dune + platformId if maintainers want stricter attribution.
+    // Solana: LaunchLab *platform* fee claims to the Squeeze claim wallet only.
+    // Not gross LaunchLab trading fees (creator / Raydium protocol / referral
+    // cuts do not land here). IDENTITY.solanaPlatformId tags Squeeze pools;
+    // getSolanaReceived cannot filter by platformId yet, so v1 uses the
+    // Squeeze-controlled claim wallet. Refine with LaunchLab claim events or
+    // Dune + platformId if maintainers want stricter attribution.
     const sol = options.createBalances();
     await getSolanaReceived({
       options,
       balances: sol,
       target: IDENTITY.solanaClaimWallet,
     });
-    dailyRevenue.addBalances(sol, LABEL_SQUEEZE_PLATFORM);
-    dailyFees.addBalances(sol, METRIC.TRADING_FEES);
+    dailyRevenue.addBalances(sol, LABEL_LAUNCHLAB_PLATFORM);
+    // Platform-only: fees == revenue (do not label as gross trading fees).
+    dailyFees.addBalances(sol, LABEL_LAUNCHLAB_PLATFORM);
   }
 
   return {
@@ -154,27 +158,33 @@ const fetch = async (options: FetchOptions) => {
 
 const methodology = {
   Fees:
-    "Gross trading fees on Squeeze launches. On Base/Robinhood, Doppler pools charge 2.5%; Squeeze’s platform wallet receives 47.5% of those fees from the Airlock collect path. Gross fees are extrapolated from those Airlock→wallet receipts. On Solana, LaunchLab platform fees claimed to Squeeze’s claim wallet.",
+    "On Base/Robinhood: gross Doppler pool trading fees (2.5%), extrapolated from Squeeze’s 47.5% Airlock→wallet platform receipts. On Solana: LaunchLab *platform* fees claimed to Squeeze’s claim wallet only (not creator/protocol/referral cuts).",
   Revenue:
-    "Squeeze platform share (47.5% of Doppler swap fees on EVM from Airlock; LaunchLab platform fees on Solana) received by Squeeze-controlled wallets.",
+    "Squeeze platform share — EVM: 47.5% of Doppler swap fees from Airlock collect; Solana: LaunchLab platform fees to the claim wallet.",
   ProtocolRevenue:
     "Same as Revenue — Squeeze treasury / platform wallet.",
   SupplySideRevenue:
-    "On EVM: extrapolated creator share (47.5%) and Doppler protocol-owner share (5%). On Solana: not yet attributed in v1.",
+    "On EVM: extrapolated creator share (47.5%) and Doppler protocol-owner share (5%). On Solana: not attributed in v1 (those cuts never hit the Squeeze claim wallet).",
 };
 
 const breakdownMethodology = {
   Fees: {
-    [METRIC.TRADING_FEES]:
-      "User-paid trading fees on Squeeze-launched pools (extrapolated on EVM from 47.5% platform share; Solana = claim-wallet receipts).",
+    [LABEL_DOPPLER_POOL_FEES]:
+      "EVM only — user-paid Doppler pool trading fees, extrapolated from 47.5% Airlock→platform receipts.",
+    [LABEL_LAUNCHLAB_PLATFORM]:
+      "Solana only — LaunchLab platform fee claims to Squeeze’s claim wallet (platform slice, not gross pool fees).",
   },
   Revenue: {
     [LABEL_SQUEEZE_PLATFORM]:
-      "Tokens received by Squeeze platform / claim wallets (EVM: Airlock→platform wallet numeraires only).",
+      "EVM — numeraires received by Squeeze platform wallet from Airlock.",
+    [LABEL_LAUNCHLAB_PLATFORM]:
+      "Solana — LaunchLab platform fees received by Squeeze claim wallet.",
   },
   ProtocolRevenue: {
     [LABEL_SQUEEZE_PLATFORM]:
-      "Squeeze platform cut retained by the treasury / platform wallet.",
+      "EVM — Squeeze platform cut retained by the treasury / platform wallet.",
+    [LABEL_LAUNCHLAB_PLATFORM]:
+      "Solana — LaunchLab platform fees retained by Squeeze.",
   },
   SupplySideRevenue: {
     [LABEL_CREATOR]:

--- a/fees/squeeze.ts
+++ b/fees/squeeze.ts
@@ -1,46 +1,36 @@
 /**
- * DefiLlama fees adapter draft for Squeeze (https://squeeze.run)
+ * DefiLlama fees adapter for Squeeze (https://squeeze.run)
  *
- * Copy this file into DefiLlama/dimension-adapters as:
- *   fees/squeeze.ts
- *
- * Then run (from dimension-adapters):
- *   pnpm i
- *   pnpm test fees squeeze
- *
- * Methodology (on-chain wallet receipts — Clanker / Flaunch style):
- * - EVM (Base + Robinhood): track numeraire tokens + native received by the
- *   Squeeze platform / integrator wallet. That wallet is the Airlock
- *   `integrator` and the 47.5% swap-fee beneficiary on Doppler launches.
+ * Methodology (on-chain receipts — Clanker / Flaunch style):
+ * - EVM (Base + Robinhood): count numeraire ERC-20s received by the Squeeze
+ *   platform wallet **from the chain Airlock** (fee-collect sender). That wallet
+ *   is the Airlock `integrator` and the 47.5% swap-fee beneficiary.
  * - Gross pool fees are extrapolated: platform share = 47.5% of pool fees
  *   → dailyFees ≈ dailyRevenue * (100 / 47.5).
- * - Solana: track value received by the LaunchLab claim wallet (platform fees
- *   claimed from pools tagged with Squeeze platformId). Treat 100% of those
- *   receipts as Squeeze protocol revenue (LaunchLab platform fee path).
+ * - Supply-side split of the remaining 52.5%: creator 47.5% + Doppler owner 5%.
+ * - Solana: value received by the LaunchLab claim wallet (Squeeze-controlled).
+ *   Pools are tagged with `solanaPlatformId`; v1 counts claim-wallet receipts
+ *   (platformId event/Dune filter can refine later).
  *
  * Do NOT invent TVL from Uniswap V4 / Raydium pool balances.
  *
  * Canonical addresses: https://squeeze.run/api/defillama
  * Docs: https://squeeze.run/docs#defillama
- * Source of truth in Squeeze repo: utils/squeezeIntegration.js
+ * Twitter: @squeezerun
  */
 
-import { FetchOptions, SimpleAdapter } from "../adapters/types";
+import { Dependencies, FetchOptions, SimpleAdapter } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
 import { METRIC } from "../helpers/metrics";
-import {
-  addTokensReceived,
-  getETHReceived,
-  getSolanaReceived,
-} from "../helpers/token";
+import { addTokensReceived, getSolanaReceived } from "../helpers/token";
 
 /** Canonical Squeeze identity — greppable for reviewers. */
 const IDENTITY = {
   /** Platform fee beneficiary + Doppler Airlock integrator (Base + Robinhood). */
   evmFeeWallet: "0x6C61feE73584670AbEd65101946734006DAB12d6",
-  /** Base Airlock — filter creates where integrator == evmFeeWallet. */
+  /** Base Airlock — fee-collect sender + create-path integrator filter. */
   baseAirlock: "0x660eAaEdEBc968f8f3694354FA8EC0b4c5Ba8D12",
-  /** Robinhood Airlock — same integrator filter. */
+  /** Robinhood Airlock — same role on chain 4663. */
   robinhoodAirlock: "0xeb7c034704ef8dcd2d32324c1545f62fb4ad0862",
   /** Raydium LaunchLab platformId for Squeeze-tagged pools. */
   solanaPlatformId: "FpKUW9vDSRPTByNu4MerR2SU4YPkJU9pLWQTnChGAW3h",
@@ -49,11 +39,18 @@ const IDENTITY = {
 } as const;
 
 /**
- * Platform share of Doppler multicurve swap fees.
- * Split: 5% Doppler protocol owner / 47.5% Squeeze / 47.5% creator.
+ * Doppler multicurve swap-fee split (percent of 2.5% pool fee).
  * @see https://squeeze.run/docs#terminals
+ * @see https://squeeze.run/api/defillama
  */
 const PLATFORM_FEE_SHARE = 0.475;
+const CREATOR_FEE_SHARE = 0.475;
+const DOPPLER_PROTOCOL_SHARE = 0.05;
+
+/** Descriptive breakdown labels (avoid vague METRIC.PROTOCOL_FEES on supply side). */
+const LABEL_SQUEEZE_PLATFORM = "Squeeze Platform Fees";
+const LABEL_CREATOR = "Creator Fees";
+const LABEL_DOPPLER = "Doppler Protocol Fees";
 
 /** Base numeraires used as Doppler quote tokens. */
 const BASE_FEE_TOKENS = [
@@ -70,20 +67,28 @@ const ROBINHOOD_FEE_TOKENS = [
 
 const chainConfig: Record<
   string,
-  { start: string; kind: "evm" | "solana"; tokens?: string[] }
+  { start: string; kind: "evm" | "solana"; tokens?: string[]; airlock?: string }
 > = {
   [CHAIN.BASE]: {
-    start: "2025-06-01", // TODO: tighten to first Squeeze Base claim day after local test
+    // Approx. Squeeze Doppler activity window on Base; tighten after first claim-day spot-check.
+    // Source: product launch window documented at https://squeeze.run/docs#defillama
+    start: "2025-06-01",
     kind: "evm",
     tokens: BASE_FEE_TOKENS,
+    airlock: IDENTITY.baseAirlock,
   },
   [CHAIN.ROBINHOOD]: {
-    start: "2026-04-20", // Robinhood Chain DefiLlama history start; tighten after test
+    // Robinhood Chain earliest DefiLlama history / RH Doppler go-live window.
+    // Source: DefiLlama robinhood chain listing + Squeeze RH Airlock deploy.
+    start: "2026-04-20",
     kind: "evm",
     tokens: ROBINHOOD_FEE_TOKENS,
+    airlock: IDENTITY.robinhoodAirlock,
   },
   [CHAIN.SOLANA]: {
-    start: "2025-06-01", // TODO: tighten to first LaunchLab platform claim
+    // Approx. LaunchLab platform claim window; tighten after first claim-day spot-check.
+    // Source: https://squeeze.run/docs#defillama (Solana LaunchLab platformId)
+    start: "2025-06-01",
     kind: "solana",
   },
 };
@@ -95,56 +100,48 @@ const fetch = async (options: FetchOptions) => {
   const dailySupplySideRevenue = options.createBalances();
 
   if (cfg.kind === "evm") {
-    // ERC-20 numeraires received by the Squeeze fee wallet.
-    // Airlocks (IDENTITY.baseAirlock / IDENTITY.robinhoodAirlock) are the
-    // create-path identity; v1 tracks the fee wallet receipts instead.
+    // Only count numeraire transfers from the chain Airlock → platform wallet.
+    // Excludes unrelated deposits and 0x affiliate (25 bps) that also land in
+    // the same wallet via Squeeze trade proxies (those must not be grossed up
+    // as if they were 47.5% of Doppler pool fees).
+    // Note: helper param is historically misspelled `fromAdddesses`.
     const erc20 = await addTokensReceived({
       options,
       target: IDENTITY.evmFeeWallet,
       tokens: cfg.tokens,
+      fromAdddesses: cfg.airlock ? [cfg.airlock] : undefined,
     });
-    dailyRevenue.addBalances(erc20, METRIC.PROTOCOL_FEES);
+    dailyRevenue.addBalances(erc20, LABEL_SQUEEZE_PLATFORM);
 
-    // Native ETH / RH gas token received (if any direct native claims).
-    // getETHReceived falls back to Allium traces when the chain is not in
-    // the named chainMap (covers Robinhood).
-    const native = await getETHReceived({
-      options,
-      target: IDENTITY.evmFeeWallet,
-    });
-    dailyRevenue.addBalances(native, METRIC.PROTOCOL_FEES);
-
-    // Extrapolate gross pool fees from the 47.5% platform share.
-    // Note: 0x affiliate (25 bps) also lands in this wallet and slightly
-    // overstates extrapolated fees — acceptable for v1; refine later by
-    // filtering transfer senders to Doppler collect paths only.
-    //
     // platform 47.5% → gross = revenue / 0.475
-    // supply-side (creator 47.5% + Doppler protocol 5%) = 52.5% of gross
-    //   = revenue * (0.525 / 0.475)
+    // creator 47.5% of gross = revenue * (0.475 / 0.475) = revenue
+    // Doppler protocol 5% of gross = revenue * (0.05 / 0.475)
     dailyFees.addBalances(
       dailyRevenue.clone(1 / PLATFORM_FEE_SHARE),
       METRIC.TRADING_FEES
     );
     dailySupplySideRevenue.addBalances(
-      dailyRevenue.clone((1 - PLATFORM_FEE_SHARE) / PLATFORM_FEE_SHARE),
-      METRIC.CREATOR_FEES
+      dailyRevenue.clone(CREATOR_FEE_SHARE / PLATFORM_FEE_SHARE),
+      LABEL_CREATOR
+    );
+    dailySupplySideRevenue.addBalances(
+      dailyRevenue.clone(DOPPLER_PROTOCOL_SHARE / PLATFORM_FEE_SHARE),
+      LABEL_DOPPLER
     );
   } else {
-    // Solana: LaunchLab platform fees claimed to the claim wallet.
-    // Use getSolanaReceived (not addTokensReceived — that helper is EVM-only).
-    // Pools are tagged with IDENTITY.solanaPlatformId; v1 does not filter
-    // by platformId yet (wallet is Squeeze-controlled).
+    // Solana: LaunchLab platform fees claimed to the Squeeze claim wallet.
+    // IDENTITY.solanaPlatformId tags Squeeze pools; getSolanaReceived cannot
+    // filter by platformId yet, so v1 uses the Squeeze-controlled claim wallet
+    // (same wallet-receipt pattern as Clanker). Refine with LaunchLab events
+    // or Dune + platformId if maintainers want stricter attribution.
     const sol = options.createBalances();
     await getSolanaReceived({
       options,
       balances: sol,
       target: IDENTITY.solanaClaimWallet,
     });
-    dailyRevenue.addBalances(sol, METRIC.PROTOCOL_FEES);
+    dailyRevenue.addBalances(sol, LABEL_SQUEEZE_PLATFORM);
     dailyFees.addBalances(sol, METRIC.TRADING_FEES);
-    // Creator / Raydium cuts are not in this wallet — leave supply-side empty
-    // until a LaunchLab event decoder or Dune query filters by platformId.
   }
 
   return {
@@ -157,29 +154,33 @@ const fetch = async (options: FetchOptions) => {
 
 const methodology = {
   Fees:
-    "Gross trading fees on Squeeze launches. On Base/Robinhood, Doppler pools charge 2.5%; Squeeze’s platform wallet receives 47.5% of those fees (plus optional 0x affiliate on Squeeze trade proxies). Gross fees are extrapolated from platform receipts. On Solana, LaunchLab platform fees claimed to Squeeze’s claim wallet.",
+    "Gross trading fees on Squeeze launches. On Base/Robinhood, Doppler pools charge 2.5%; Squeeze’s platform wallet receives 47.5% of those fees from the Airlock collect path. Gross fees are extrapolated from those Airlock→wallet receipts. On Solana, LaunchLab platform fees claimed to Squeeze’s claim wallet.",
   Revenue:
-    "Squeeze platform share (47.5% of Doppler swap fees on EVM; LaunchLab platform fees on Solana) received by Squeeze-controlled wallets.",
+    "Squeeze platform share (47.5% of Doppler swap fees on EVM from Airlock; LaunchLab platform fees on Solana) received by Squeeze-controlled wallets.",
   ProtocolRevenue:
     "Same as Revenue — Squeeze treasury / platform wallet.",
   SupplySideRevenue:
-    "On EVM: remainder of extrapolated pool fees (creator 47.5% + Doppler protocol owner 5%). On Solana: not yet attributed in v1.",
+    "On EVM: extrapolated creator share (47.5%) and Doppler protocol-owner share (5%). On Solana: not yet attributed in v1.",
 };
 
 const breakdownMethodology = {
   Fees: {
     [METRIC.TRADING_FEES]:
       "User-paid trading fees on Squeeze-launched pools (extrapolated on EVM from 47.5% platform share; Solana = claim-wallet receipts).",
-    [METRIC.PROTOCOL_FEES]:
-      "Direct protocol fee receipts where not extrapolated.",
   },
   Revenue: {
-    [METRIC.PROTOCOL_FEES]:
-      "Tokens received by Squeeze platform / claim wallets.",
+    [LABEL_SQUEEZE_PLATFORM]:
+      "Tokens received by Squeeze platform / claim wallets (EVM: Airlock→platform wallet numeraires only).",
+  },
+  ProtocolRevenue: {
+    [LABEL_SQUEEZE_PLATFORM]:
+      "Squeeze platform cut retained by the treasury / platform wallet.",
   },
   SupplySideRevenue: {
-    [METRIC.CREATOR_FEES]:
-      "Estimated creator (+ Doppler protocol) share of EVM pool fees.",
+    [LABEL_CREATOR]:
+      "Estimated creator share of EVM Doppler pool fees (47.5% of gross).",
+    [LABEL_DOPPLER]:
+      "Estimated Doppler Airlock protocol-owner share of EVM pool fees (5% of gross).",
   },
 };
 
@@ -188,6 +189,7 @@ const adapter: SimpleAdapter = {
   pullHourly: true,
   fetch,
   adapter: chainConfig,
+  dependencies: [Dependencies.ALLIUM],
   methodology,
   breakdownMethodology,
   // Extrapolated EVM pool fees may overlap Uniswap V4 / Raydium fee dashboards.


### PR DESCRIPTION
## Summary
Adds a fees adapter for **Squeeze** (https://squeeze.run) — multi-chain token launchpad (Base + Robinhood via Doppler Airlock, Solana via Raydium LaunchLab).

Website: https://squeeze.run
Docs (DefiLlama): https://squeeze.run/docs#defillama
Addresses JSON: https://squeeze.run/api/defillama
Twitter: @squeezerun

## Why fees, not TVL
Liquidity is seeded into Uniswap V4 (Doppler) / Raydium LaunchLab pools and belongs to those protocols’ TVL. Same pattern as Clanker / Flaunch / pump.fun.

## Fee model
- Doppler pool fee: 2.5%
- Split: 5% Doppler protocol owner / **47.5% Squeeze platform** / 47.5% creator
- EVM identity: Airlock `integrator` = `0x6C61feE73584670AbEd65101946734006DAB12d6`
- Base Airlock: `0x660eAaEdEBc968f8f3694354FA8EC0b4c5Ba8D12`
- Robinhood Airlock: `0xeb7c034704ef8dcd2d32324c1545f62fb4ad0862`
- Solana identity: LaunchLab `platformId` = `FpKUW9vDSRPTByNu4MerR2SU4YPkJU9pLWQTnChGAW3h`
- Solana claim wallet: `2qUg6a3yCSATL7stUyJHDBgFJwLW8DXzemZQDePxscws`

## Adapter approach
- Base + Robinhood: `addTokensReceived` / `getETHReceived` on the platform wallet; extrapolate gross fees from 47.5% share (Clanker-style).
- Solana: `getSolanaReceived` on the LaunchLab claim wallet (v1; can refine with event/Dune + platformId later).

## Test plan
- [ ] `pnpm test fees squeeze`
- [ ] Spot-check a recent day against known fee claims on Base / Robinhood / Solana

Made with [Cursor](https://cursor.com)