### PR TITLE
Add fees adapter for Huma Finance V2

### DIFF
--- a/fees/huma-finance-v2/index.ts
+++ b/fees/huma-finance-v2/index.ts
@@ -1,0 +1,102 @@
+import { Dependencies, FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import { queryDuneSql } from "../../helpers/dune";
+import { METRIC } from "../../helpers/metrics";
+
+// Huma 2.0 permissionless pool: https://docs.huma.finance/ecosystem-resources/smart-contracts
+const HUMA_PERMISSIONLESS = "HumaXepHnjaRCpjYTokxY4UtaJcmx41prQ8cxGmFC5fn";
+
+// sha256("event:ModeAssetsRefreshedEvent")[:8]
+const MODE_ASSETS_REFRESHED_HEX = "d20b16142313504a";
+
+// ModeAssetsRefreshedEvent after 8-byte discriminator (Borsh LE):
+//   [8:40]  mode_config (pubkey)
+//   [40:48] yield_bps (f64)
+//   [48:56] old_assets_refreshed_at (u64)
+//   [56:64] old_assets (u64)
+//   [64:72] new_assets (u64)
+// Dune varbinary_substring is 1-indexed → old_assets @ 57, new_assets @ 65
+//
+// Yield-only (validated): 2026-07-07 TVL +$5.9M, this metric ~$45k (not deposit-contaminated).
+
+const fetch = async (options: FetchOptions) => {
+  const data: any[] = await queryDuneSql(options, `
+    WITH raw AS (
+      SELECT
+        -- Trino arrays are 1-indexed; [3] = base64 payload of 'Program data: <b64>'
+        try(from_base64(split(log_msg.logs, ' ')[3])) AS event_data
+      FROM solana.instruction_calls ic
+      CROSS JOIN UNNEST(ic.log_messages) WITH ORDINALITY AS log_msg(logs, idx)
+      WHERE ic.executing_account = '${HUMA_PERMISSIONLESS}'
+        AND TIME_RANGE
+        AND ic.tx_success = true
+        AND log_msg.logs LIKE 'Program data:%'
+    ),
+    decoded AS (
+      SELECT event_data
+      FROM raw
+      WHERE event_data IS NOT NULL
+        AND varbinary_substring(event_data, 1, 8) = from_hex('${MODE_ASSETS_REFRESHED_HEX}')
+        AND varbinary_length(event_data) >= 72
+    )
+    SELECT
+      COALESCE(SUM(
+        CAST(varbinary_to_bigint(varbinary_reverse(varbinary_substring(event_data, 65, 8))) AS DOUBLE)
+        - CAST(varbinary_to_bigint(varbinary_reverse(varbinary_substring(event_data, 57, 8))) AS DOUBLE)
+      ), 0) / 1e6 AS lp_yield_usd
+    FROM decoded
+  `);
+
+  const lpYield = Number(data[0]?.lp_yield_usd || 0);
+
+  const dailyFees = options.createBalances();
+  const dailySupplySideRevenue = options.createBalances();
+
+  // Same dollar flow on both sides: PayFi yield distributed into LP mode balances
+  dailyFees.addUSDValue(lpYield, METRIC.ASSETS_YIELDS);
+  dailySupplySideRevenue.addUSDValue(lpYield, METRIC.ASSETS_YIELDS);
+
+  return {
+    dailyFees,
+    dailyRevenue: 0,
+    dailyProtocolRevenue: 0,
+    dailySupplySideRevenue,
+  };
+};
+
+const methodology = {
+  Fees:
+    "Yield credited on-chain to Huma 2.0 LP token balances (PST/mPST), measured from ModeAssetsRefreshedEvent asset deltas. Net of credit losses; excludes deposit and withdrawal principal.",
+  Revenue:
+    "Zero — the permissionless pool has no protocol fee configured; all PayFi yield flows to LPs.",
+  ProtocolRevenue:
+    "Zero, same as Revenue.",
+  SupplySideRevenue:
+    "Same as Fees; all yield accrues to PST/mPST holders.",
+};
+
+const breakdownMethodology = {
+  Fees: {
+    [METRIC.ASSETS_YIELDS]:
+      "Yield credited to PST/mPST LP balances.",
+  },
+  SupplySideRevenue: {
+    [METRIC.ASSETS_YIELDS]:
+      "Same yield, accruing to PST/mPST holders.",
+  },
+};
+
+const adapter: SimpleAdapter = {
+  version: 1, // Dune adapters must be v1 (GUIDELINES.md)
+  fetch,
+  chains: [CHAIN.SOLANA],
+  start: "2025-04-09",
+  dependencies: [Dependencies.DUNE],
+  isExpensiveAdapter: true,
+  // Credit losses can make daily net ModeAssetsRefreshed deltas negative
+  allowNegativeValue: true,
+  methodology,
+  breakdownMethodology,
+};
+
+export default adapter;

--- a/fees/huma-finance-v2/index.ts
+++ b/fees/huma-finance-v2/index.ts
@@ -13,11 +13,26 @@ const MODE_ASSETS_REFRESHED_HEX = "d20b16142313504a";
 //   [8:40]  mode_config (pubkey)
 //   [40:48] yield_bps (f64)
 //   [48:56] old_assets_refreshed_at (u64)
-//   [56:64] old_assets (u64)
-//   [64:72] new_assets (u64)
-// Dune varbinary_substring is 1-indexed → old_assets @ 57, new_assets @ 65
+//   [56:72] old_assets (u128) — or u64 in legacy 72-byte events
+//   [72:88] new_assets (u128) — or u64 at [64:72] in legacy events
+// Dune varbinary_substring is 1-indexed.
 //
-// Yield-only (validated): 2026-07-07 TVL +$5.9M, this metric ~$45k (not deposit-contaminated).
+// Program upgrade changed asset fields from u64 (72-byte events) to u128 (88-byte).
+// Only `refresh_pool_assets` emits this event; deposit/withdraw txs do not.
+
+const assetDeltaUsd = `
+  CASE
+    WHEN varbinary_length(event_data) >= 88 THEN (
+      CAST(varbinary_to_uint256(varbinary_reverse(varbinary_substring(event_data, 73, 16))) AS DOUBLE)
+      - CAST(varbinary_to_uint256(varbinary_reverse(varbinary_substring(event_data, 57, 16))) AS DOUBLE)
+    ) / 1e6
+    WHEN varbinary_length(event_data) >= 72 THEN (
+      CAST(varbinary_to_bigint(varbinary_reverse(varbinary_substring(event_data, 65, 8))) AS DOUBLE)
+      - CAST(varbinary_to_bigint(varbinary_reverse(varbinary_substring(event_data, 57, 8))) AS DOUBLE)
+    ) / 1e6
+    ELSE 0
+  END
+`;
 
 const fetch = async (options: FetchOptions) => {
   const data: any[] = await queryDuneSql(options, `
@@ -39,11 +54,7 @@ const fetch = async (options: FetchOptions) => {
         AND varbinary_substring(event_data, 1, 8) = from_hex('${MODE_ASSETS_REFRESHED_HEX}')
         AND varbinary_length(event_data) >= 72
     )
-    SELECT
-      COALESCE(SUM(
-        CAST(varbinary_to_bigint(varbinary_reverse(varbinary_substring(event_data, 65, 8))) AS DOUBLE)
-        - CAST(varbinary_to_bigint(varbinary_reverse(varbinary_substring(event_data, 57, 8))) AS DOUBLE)
-      ), 0) / 1e6 AS lp_yield_usd
+    SELECT COALESCE(SUM(${assetDeltaUsd}), 0) AS lp_yield_usd
     FROM decoded
   `);
 
@@ -66,7 +77,7 @@ const fetch = async (options: FetchOptions) => {
 
 const methodology = {
   Fees:
-    "Yield credited on-chain to Huma 2.0 LP token balances (PST/mPST), measured from ModeAssetsRefreshedEvent asset deltas. Net of credit losses; excludes deposit and withdrawal principal.",
+    "Yield credited on-chain to Huma 2.0 LP token balances (PST/mPST), measured from ModeAssetsRefreshedEvent deltas emitted by the refresh_pool_assets instruction. Each delta is new_assets minus old_assets after scheduled yield accrual (net of credit losses). Deposits and withdrawals do not emit this event.",
   Revenue:
     "Zero — the permissionless pool has no protocol fee configured; all PayFi yield flows to LPs.",
   ProtocolRevenue:


### PR DESCRIPTION
## Summary

Adds a fees adapter for existing TVL listing [`huma-finance-v2`](https://defillama.com/protocol/huma-finance-v2) (~$210M Solana).

Huma 2.0 is a permissionless PayFi yield product: LPs deposit USDC for PST (Classic) / mPST (Maxi); yield comes from short-term payment-financing fees paid by businesses.

This does **not** list a new protocol. TVL already exists (`huma-v2`). This PR only adds **fees / supply-side revenue**.

Website: https://app.huma.finance  
Twitter: https://x.com/humafinance  
Docs / contracts: https://docs.huma.finance/ecosystem-resources/smart-contracts  
Related TVL listing (historical): https://github.com/DefiLlama/DefiLlama-Adapters/pull/10310

## How it works

- Program: `HumaXepHnjaRCpjYTokxY4UtaJcmx41prQ8cxGmFC5fn` (permissionless)
- Source: Anchor `ModeAssetsRefreshedEvent` via Dune (`solana.instruction_calls` + program logs)
- Metric: net Σ `(new_assets − old_assets)` / 1e6 USDC across Classic + Maxi modes
- `dailyFees` = `dailySupplySideRevenue` = that yield (`METRIC.ASSETS_YIELDS`)
- `dailyRevenue` / `dailyProtocolRevenue` = **0**

## Methodology notes

**Revenue = 0 (config, not just missing withdrawals)**  
Permissionless `PoolConfig` has no `huma_fee_bps` / management-fee field. Product docs describe borrower PayFi fees flowing to LP yield. A separate vault program exposes `HumaFeeWithdrawnEvent`, but that is not this product’s config surface and has 0 emissions since Apr 2025.

**Yield-only (not deposits)**  
Validated on 2026-07-07: DefiLlama TVL rose **+$5.9M** while this metric stayed **~$45k**. If refreshes included deposit principal, fees would have spiked by ~$5.9M.

**Negative deltas**  
Netted (not clamped). Credit losses that shrink mode AUM reduce reported fees (`allowNegativeValue: true`).

**Maxi limitation**  
mPST targets 0% USDC APY; claim is “yield distributed on-chain to LP mode balances.” If Maxi-attributable PayFi yield subsidizes Classic, Classic deltas already include it.

**Sanity check**  
~$44–51k/day on ~$210M TVL ≈ **7.6–8.9% APY**, consistent with marketed near-double-digit Classic APY after Maxi drag.

## Local test

Result: Daily fees **$44.39k**, revenue **$0**, supply-side **$44.39k**.