### PR TITLE
[add] MagicMarkets - add volume adapter (prediction market)

### DIFF
--- a/dexs/magicmarkets.ts
+++ b/dexs/magicmarkets.ts
@@ -1,0 +1,55 @@
+import { Dependencies, FetchOptions, SimpleAdapter } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+import { queryDuneSql } from "../helpers/dune";
+
+// Data source: public Dune dataset maintained by the Magic Markets team,
+// refreshed daily via the Dune API.
+// Dataset: https://dune.com/data/dune.magicmarkets.data
+// Dashboard: https://dune.com/magicmarkets/magicmarkets
+// Columns used: snapshot_date, taker_volume_usd, total_volume_usd
+// (dataset also carries matched_trades, active_traders, open_interest_usd,
+// available_liquidity_usd for future dimensions)
+
+const fetch = async (options: FetchOptions) => {
+  const query = `
+    SELECT
+      SUM(taker_volume_usd) AS matched_volume_usd,
+      SUM(total_volume_usd) AS notional_volume_usd
+    FROM dune.magicmarkets.data
+    WHERE CAST(snapshot_date AS DATE) = DATE '${options.dateString}'
+  `;
+  const data: {
+    matched_volume_usd: string;
+    notional_volume_usd: string;
+  }[] = await queryDuneSql(options, query);
+
+  // Fail loudly if the dataset has no row for the requested day rather than
+  // silently reporting 0 volume; the daily upload should always precede this run.
+  if (!data.length || data[0].matched_volume_usd == null) {
+    throw new Error(`dune.magicmarkets.data has no rows for ${options.dateString}`);
+  }
+
+  const dailyVolume = Number(data[0].matched_volume_usd);
+  const dailyNotionalVolume = Number(data[0].notional_volume_usd);
+
+  return { dailyVolume, dailyNotionalVolume };
+};
+
+const methodology = {
+  Volume:
+    "USD value of stakes matched on the Magic Markets exchange each day, counted once per matched trade (taker side only). Sourced from the team-maintained public Dune dataset dune.magicmarkets.data, which is refreshed daily from production settlement records.",
+  NotionalVolume:
+    "Both sides of each matched trade (taker + maker stakes), i.e. exactly 2x Volume.",
+};
+
+const adapter: SimpleAdapter = {
+  version: 1, // Dune-backed adapters must be version 1 (daily, not hourly)
+  fetch,
+  chains: [CHAIN.OFF_CHAIN],
+  start: "2026-05-12",
+  dependencies: [Dependencies.DUNE],
+  isExpensiveAdapter: true,
+  methodology,
+};
+
+export default adapter;

--- a/dexs/magicmarkets.ts
+++ b/dexs/magicmarkets.ts
@@ -25,12 +25,20 @@ const fetch = async (options: FetchOptions) => {
 
   // Fail loudly if the dataset has no row for the requested day rather than
   // silently reporting 0 volume; the daily upload should always precede this run.
-  if (!data.length || data[0].matched_volume_usd == null) {
+  if (
+    !data.length ||
+    data[0].matched_volume_usd == null ||
+    data[0].notional_volume_usd == null
+  ) {
     throw new Error(`dune.magicmarkets.data has no rows for ${options.dateString}`);
   }
 
   const dailyVolume = Number(data[0].matched_volume_usd);
   const dailyNotionalVolume = Number(data[0].notional_volume_usd);
+  // Guard against malformed aggregates becoming NaN and corrupting the series.
+  if (!Number.isFinite(dailyVolume) || !Number.isFinite(dailyNotionalVolume)) {
+    throw new Error(`dune.magicmarkets.data has invalid volume data for ${options.dateString}`);
+  }
 
   return { dailyVolume, dailyNotionalVolume };
 };


### PR DESCRIPTION
##### Name (to be shown on DefiLlama):
MagicMarkets

##### Twitter Link:
https://x.com/magicmarkets

##### List of audit links if any:
n/a

##### Website Link:
https://magicmarkets.com

##### Logo (High resolution, will be shown with rounded borders):
<img width="400" height="400" alt="magicmarkets-logo-400" src="https://github.com/user-attachments/assets/4edcd18f-4b70-43b4-9399-69c2db503c20" />


##### Current TVL:
n/a (volume listing only)

##### Treasury Addresses (if the protocol has treasury)
n/a

##### Chain:
Off-chain (centralized matching; same treatment as Kalshi)

##### Coingecko ID:
n/a (no token)

##### Coinmarketcap ID:
n/a (no token)

##### Short Description (to be shown on DefiLlama):
The prediction market for serious sports traders.

##### Token address and ticker if any:
n/a

##### Category (full list at https://defillama.com/categories) *Please choose only one:
Prediction Market

##### Oracle Provider(s):
n/a (centralized settlement against official results)

##### Implementation Details:
n/a

##### Documentation/Proof:
Public data: https://dune.com/magicmarkets/magicmarkets (dashboard) and https://dune.com/data/dune.magicmarkets.data (dataset, public and queryable by any Dune account).

##### forkedFrom (Does your project originate from another project):
n/a

##### methodology (what is being counted as tvl, how is tvl being calculated):
Daily matched volume from the team-maintained public Dune dataset `dune.magicmarkets.data`, refreshed daily from production settlement records. dailyVolume counts each matched trade once (taker-side stake, USD), consistent with the one-sided convention used by the Polymarket and Kalshi adapters; dailyNotionalVolume counts both sides (exactly 2x). Sanity invariants visible in the public data: transactions = 2 x matched_trades; taker volume = total / 2.

##### Github org/user (Optional, if your code is open source, we can track activity):
n/a

##### Does this project have a referral program?
Yes. Refer users with your personal link to participate in the trading rewards program.

---

**Test output** (`pnpm test dexs magicmarkets`, against the public Dune dataset):

```
🦙 Running MAGICMARKETS adapter 🦙
---------------------------------------------------
Start Date:	Wed, 22 Jul 2026 00:00:00 GMT
End Date:	Thu, 23 Jul 2026 00:00:00 GMT
---------------------------------------------------
OFF_CHAIN 👇
Backfill start time: 12/5/2026
Daily volume: 677.47 k
Daily notional volume: 1.35 M
```

Explicit past date (`pnpm test dexs magicmarkets 2026-07-15`):

```
🦙 Running MAGICMARKETS adapter 🦙
---------------------------------------------------
Start Date:	Tue, 14 Jul 2026 00:00:00 GMT
End Date:	Wed, 15 Jul 2026 00:00:00 GMT
---------------------------------------------------
OFF_CHAIN 👇
Backfill start time: 12/5/2026
Daily volume: 552.74 k
Daily notional volume: 1.11 M
```

Notional volume is exactly 2x volume in both runs, matching the one-sided methodology. The dataset and all queries are public, so results are reproducible with any Dune account.
