### PR TITLE
oneinch-aqua: track LP fees via per-fill strategy-bytecode decode (adds dailySupplySideRevenue)

### DIFF
--- a/fees/oneinch-aqua.ts
+++ b/fees/oneinch-aqua.ts
@@ -155,9 +155,14 @@ const fetch = async (options: FetchOptions) => {
     const fees = feeByStrategyHash.get(
       String(log.args.strategyHash).toLowerCase(),
     );
-    if (!fees || fees.flat === 0n) return;
+    if (!fees || (fees.flat === 0n && fees.protocol === 0n)) return;
     const amount = BigInt(log.args.amount);
-    const totalFee = (amount * fees.flat) / FEE_BASE;
+    // The DAO share is an independent rate, not a slice of the flat fee, so a
+    // (theoretical) protocol-only strategy still pays it; clamp the LP share
+    // at zero for safety.
+    const totalFee =
+      (amount * (fees.flat > fees.protocol ? fees.flat : fees.protocol)) /
+      FEE_BASE;
     const daoShare = (amount * fees.protocol) / FEE_BASE;
     const lpShare = totalFee - daoShare;
     dailyFees.add(log.args.token, lpShare, LABEL_LP);

--- a/fees/oneinch-aqua.ts
+++ b/fees/oneinch-aqua.ts
@@ -54,7 +54,12 @@ function decodeStrategyFees(
     for (let i = 0; i + 1 < program.length; ) {
       const opcode = program[i];
       const argsLength = program[i + 1];
-      if (opcode === 0) return null;
+      // Index 0 of the Aqua instruction set is the EMPTY_OPCODE placeholder,
+      // never a real instruction; the SDK's own decoder throws
+      // "Invalid opcode: 0 (NOT_INSTRUCTION)" on it. Mirror that: a program
+      // carrying opcode 0 is malformed/foreign, so skip the whole strategy
+      // (conservative undercount) rather than trust partial parses.
+      if (opcode === 0) throw new Error(`invalid opcode 0 at byte ${i}`);
       const args = program.slice(i + 2, i + 2 + argsLength);
       if (opcode === FLAT_FEE_OPCODE && argsLength >= 4)
         flat = BigInt(new DataView(args.buffer, args.byteOffset).getUint32(0));
@@ -65,7 +70,10 @@ function decodeStrategyFees(
       i += 2 + argsLength;
     }
     return { flat, protocol };
-  } catch {
+  } catch (e: any) {
+    console.log(
+      `oneinch-aqua: failed to decode strategy ${strategyHex.slice(0, 10)}… (${e?.message ?? e}) - its fills will carry zero fees`,
+    );
     return null;
   }
 }
@@ -102,6 +110,7 @@ const fetch = async (options: FetchOptions) => {
   const dailyFees = options.createBalances();
   const dailySupplySideRevenue = options.createBalances();
   const dailyRevenue = options.createBalances();
+  const dailyProtocolRevenue = options.createBalances();
 
   // Full-history Shipped scan (cached): every fee rate lives in the strategy
   // registered at ship time. Also used below to exclude ship-registration
@@ -169,13 +178,14 @@ const fetch = async (options: FetchOptions) => {
     dailyFees.add(log.args.token, daoShare, LABEL_DAO);
     dailySupplySideRevenue.add(log.args.token, lpShare, LABEL_LP);
     dailyRevenue.add(log.args.token, daoShare, LABEL_DAO);
+    dailyProtocolRevenue.add(log.args.token, daoShare, LABEL_DAO);
   });
 
   return {
     dailyFees,
     dailySupplySideRevenue,
     dailyRevenue,
-    dailyProtocolRevenue: dailyRevenue,
+    dailyProtocolRevenue,
   };
 };
 

--- a/fees/oneinch-aqua.ts
+++ b/fees/oneinch-aqua.ts
@@ -1,74 +1,176 @@
+import { ethers } from "ethers";
 import { FetchOptions, SimpleAdapter } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
-import { addTokensReceived, nullAddress } from "../helpers/token";
 
-// 1inch DAO fee exchangers — the receivers encoded into every Aqua strategy's
-// protocol-fee instruction (https://github.com/1inch/aqua). At fill time SwapVM
-// transfers the DAO's share of the LP fee straight from the swap to this
-// address, so ERC20 inflows here are the protocol's revenue stream. The
-// exchangers were purpose-deployed for the protocol-fee launch (2026-07-18/19)
-// and receive nothing else.
+// 1inch Aqua (https://github.com/1inch/aqua): LPs quote from their own wallets;
+// swap fees are encoded per position as SwapVM fee instructions. At fill time
+// the taker-paid amount (Pushed) is fee-inclusive: the LP keeps its share
+// inside the maker wallet and the 1inch DAO's share is transferred to a
+// purpose-deployed fee exchanger.
 //
-// Protocol fee is encoded into new positions by default since 2026-07-19
-// (1inch DAO governance decision); the BNB Chain and Robinhood Chain
-// exchangers were verified and enabled on 2026-07-21. Addresses mirror the
-// 1inch dApp chain config; three chains use chain-specific deployments, the
-// rest share one address.
-const DEFAULT_EXCHANGER = "0x8063d4faf54bf8c898dc6ddc689c76ab12b4614a";
+// This adapter decodes each position's fee rates from the strategy bytecode
+// registered on-chain at ship time (Shipped event), then prices every fill of
+// the day:
+//   total swap fee        = pushedAmount * flatFeeUnits / 1e9
+//   DAO share (revenue)   = pushedAmount * protocolFeeUnits / 1e9
+//   LP-retained (supply)  = total - DAO share
+// Fee units are uint32 with 1e9 = 100% (SwapVM Fee.sol). The protocol fee is
+// 1/4 of the LP fee on low tiers (below ~0.1225%) and 1/6 above, encoded at
+// position build time; positions created before the DAO fee launch carry
+// protocolFeeUnits = 0 and their fees accrue fully to the LP.
+//
+// Scope: the AquaRouter registry (deployed 2026-07-19; same address on every
+// chain). The original developer-release registry (2025-11-17) used an earlier
+// SwapVM instruction table and its handful of strategies are excluded from fee
+// computation - matching this adapter's start date, before which no DAO fee
+// existed anyway.
+const AQUA_ROUTER = "0x1111113ccf1426a8e30e2bff5e005d929bf6a90a";
 
-const chainConfig: Record<string, { exchanger: string; start: string }> = {
-  [CHAIN.ETHEREUM]: { exchanger: DEFAULT_EXCHANGER, start: "2026-07-19" },
-  [CHAIN.BASE]: { exchanger: DEFAULT_EXCHANGER, start: "2026-07-19" },
-  [CHAIN.OPTIMISM]: { exchanger: DEFAULT_EXCHANGER, start: "2026-07-19" },
-  [CHAIN.POLYGON]: { exchanger: DEFAULT_EXCHANGER, start: "2026-07-19" },
-  [CHAIN.ARBITRUM]: { exchanger: DEFAULT_EXCHANGER, start: "2026-07-19" },
-  [CHAIN.XDAI]: { exchanger: DEFAULT_EXCHANGER, start: "2026-07-19" },
-  [CHAIN.SONIC]: { exchanger: DEFAULT_EXCHANGER, start: "2026-07-19" },
-  [CHAIN.UNICHAIN]: { exchanger: DEFAULT_EXCHANGER, start: "2026-07-19" },
-  [CHAIN.ERA]: {
-    exchanger: "0xc0242e93dc86ab95210d6deaf8b9118fea3bde06",
-    start: "2026-07-19",
-  },
-  [CHAIN.AVAX]: {
-    exchanger: "0xa7417d51427a60d3a4629615da44d1b8698e6cf4",
-    start: "2026-07-19",
-  },
-  [CHAIN.LINEA]: {
-    exchanger: "0x0f4b0148f984320d255557a0006162af3a3c7baa",
-    start: "2026-07-19",
-  },
-  [CHAIN.BSC]: { exchanger: DEFAULT_EXCHANGER, start: "2026-07-21" },
-  [CHAIN.ROBINHOOD]: { exchanger: DEFAULT_EXCHANGER, start: "2026-07-21" },
+const PUSHED_ABI =
+  "event Pushed(address maker, address app, bytes32 strategyHash, address token, uint256 amount)";
+const SHIPPED_ABI =
+  "event Shipped(address maker, address app, bytes32 strategyHash, bytes strategy)";
+
+// The Shipped strategy bytes are an ABI-encoded SwapVM order; its data field
+// is the program: repeated [opcodeIndex (1 byte), argsLength (1 byte), args].
+// Opcode indices in the Aqua instruction set (@1inch/swap-vm-sdk
+// aquaInstructions): 21 = Fee.flatFeeAmountInXD (args: uint32 feeUnits),
+// 27/28 = Fee.(aqua)ProtocolFeeAmountInXD (args: uint32 feeUnits + address to).
+const ORDER_TUPLE = "tuple(address maker, uint256 traits, bytes data)";
+const FLAT_FEE_OPCODE = 21;
+const PROTOCOL_FEE_OPCODES = [27, 28];
+const FEE_BASE = BigInt(1e9);
+
+const abiCoder = ethers.AbiCoder.defaultAbiCoder();
+
+function decodeStrategyFees(
+  strategyHex: string,
+): { flat: bigint; protocol: bigint } | null {
+  try {
+    const [order] = abiCoder.decode([ORDER_TUPLE], strategyHex);
+    const program = ethers.getBytes(order.data);
+    let flat = 0n;
+    let protocol = 0n;
+    for (let i = 0; i + 1 < program.length; ) {
+      const opcode = program[i];
+      const argsLength = program[i + 1];
+      if (opcode === 0) return null;
+      const args = program.slice(i + 2, i + 2 + argsLength);
+      if (opcode === FLAT_FEE_OPCODE && argsLength >= 4)
+        flat = BigInt(new DataView(args.buffer, args.byteOffset).getUint32(0));
+      if (PROTOCOL_FEE_OPCODES.includes(opcode) && argsLength >= 4)
+        protocol = BigInt(
+          new DataView(args.buffer, args.byteOffset).getUint32(0),
+        );
+      i += 2 + argsLength;
+    }
+    return { flat, protocol };
+  } catch {
+    return null;
+  }
+}
+
+const chainConfig: Record<
+  string,
+  { start: string; routerDeployBlock: number }
+> = {
+  [CHAIN.ETHEREUM]: { start: "2026-07-19", routerDeployBlock: 25555262 },
+  [CHAIN.BASE]: { start: "2026-07-19", routerDeployBlock: 48768127 },
+  [CHAIN.OPTIMISM]: { start: "2026-07-19", routerDeployBlock: 154363412 },
+  [CHAIN.POLYGON]: { start: "2026-07-19", routerDeployBlock: 90413735 },
+  [CHAIN.ARBITRUM]: { start: "2026-07-19", routerDeployBlock: 484939027 },
+  [CHAIN.AVAX]: { start: "2026-07-19", routerDeployBlock: 90572258 },
+  [CHAIN.XDAI]: { start: "2026-07-19", routerDeployBlock: 47255778 },
+  [CHAIN.LINEA]: { start: "2026-07-19", routerDeployBlock: 31417368 },
+  [CHAIN.SONIC]: { start: "2026-07-19", routerDeployBlock: 76110346 },
+  [CHAIN.UNICHAIN]: { start: "2026-07-19", routerDeployBlock: 53577241 },
+  [CHAIN.ERA]: { start: "2026-07-19", routerDeployBlock: 71209109 },
+  [CHAIN.BSC]: { start: "2026-07-21", routerDeployBlock: 110591523 },
+  [CHAIN.ROBINHOOD]: { start: "2026-07-21", routerDeployBlock: 12461295 },
 };
 
-// Mint transfers (from == 0x0) are excluded: the exchanger holds
-// interest-bearing tokens (e.g. aTokens) whose rebase mints would otherwise
-// count as fee income. Handles both log shapes: indexer entries carry a from
-// field; raw fallback logs carry the sender in topics[1].
-const isNotMint = (log: any): boolean => {
-  const from =
-    log.from ??
-    log.from_address ??
-    log.fromAddress ??
-    log.args?.from ??
-    (log.topics?.[1] ? "0x" + String(log.topics[1]).slice(-40) : "");
-  return String(from).toLowerCase() !== nullAddress;
-};
+const LABEL_LP = "Aqua LP Swap Fees";
+const LABEL_DAO = "1inch DAO Fee Share";
+
+const logIndexOf = (log: any) => Number(log.logIndex ?? log.index);
+const positionOf = (log: any) =>
+  `${log.address.toLowerCase()}-${log.transactionHash.toLowerCase()}-${logIndexOf(log)}`;
+const strategyOf = (log: any) =>
+  `${log.args.maker}-${log.args.app}-${log.args.strategyHash}`.toLowerCase();
 
 const fetch = async (options: FetchOptions) => {
-  const inflows = await addTokensReceived({
-    options,
-    target: chainConfig[options.chain].exchanger,
-    logFilter: isNotMint,
+  const dailyFees = options.createBalances();
+  const dailySupplySideRevenue = options.createBalances();
+  const dailyRevenue = options.createBalances();
+
+  // Full-history Shipped scan (cached): every fee rate lives in the strategy
+  // registered at ship time. Also used below to exclude ship-registration
+  // Pushed runs from the day's fills - same separation as the volume adapter.
+  const [shippedLogs, pushedLogs] = await Promise.all([
+    options.getLogs({
+      target: AQUA_ROUTER,
+      eventAbi: SHIPPED_ABI,
+      fromBlock: chainConfig[options.chain].routerDeployBlock,
+      cacheInCloud: true,
+      entireLog: true,
+      parseLog: true,
+    }),
+    options.getLogs({
+      target: AQUA_ROUTER,
+      eventAbi: PUSHED_ABI,
+      entireLog: true,
+      parseLog: true,
+    }),
+  ]);
+
+  const feeByStrategyHash = new Map<
+    string,
+    { flat: bigint; protocol: bigint }
+  >();
+  shippedLogs.forEach((log: any) => {
+    const fees = decodeStrategyFees(log.args.strategy);
+    if (fees)
+      feeByStrategyHash.set(String(log.args.strategyHash).toLowerCase(), fees);
   });
 
-  const dailyFees = options.createBalances();
-  dailyFees.add(inflows, 'Aqua LP Swap Fees');
+  // ship() emits Shipped, then one Pushed per token with no external call in
+  // between, so its Pushed run occupies strictly consecutive log indices for
+  // the same maker/app/strategyHash. A real swap push() always emits an ERC20
+  // Transfer before its Pushed event, which breaks the run - walking the run
+  // separates registration pushes exactly (see the volume adapter).
+  const pushedByPosition = new Map<string, any>();
+  pushedLogs.forEach((log: any) => pushedByPosition.set(positionOf(log), log));
+  const shipRegistrationPushes = new Set<string>();
+  shippedLogs.forEach((shipped: any) => {
+    const txPrefix = `${shipped.address.toLowerCase()}-${shipped.transactionHash.toLowerCase()}`;
+    for (let index = logIndexOf(shipped) + 1; ; index++) {
+      const pushed = pushedByPosition.get(`${txPrefix}-${index}`);
+      if (!pushed || strategyOf(pushed) !== strategyOf(shipped)) break;
+      shipRegistrationPushes.add(`${txPrefix}-${index}`);
+    }
+  });
+
+  pushedLogs.forEach((log: any) => {
+    if (shipRegistrationPushes.has(positionOf(log))) return;
+    const fees = feeByStrategyHash.get(
+      String(log.args.strategyHash).toLowerCase(),
+    );
+    if (!fees || fees.flat === 0n) return;
+    const amount = BigInt(log.args.amount);
+    const totalFee = (amount * fees.flat) / FEE_BASE;
+    const daoShare = (amount * fees.protocol) / FEE_BASE;
+    const lpShare = totalFee - daoShare;
+    dailyFees.add(log.args.token, lpShare, LABEL_LP);
+    dailyFees.add(log.args.token, daoShare, LABEL_DAO);
+    dailySupplySideRevenue.add(log.args.token, lpShare, LABEL_LP);
+    dailyRevenue.add(log.args.token, daoShare, LABEL_DAO);
+  });
 
   return {
     dailyFees,
-    dailyRevenue: dailyFees,
-    dailyProtocolRevenue: dailyFees,
+    dailySupplySideRevenue,
+    dailyRevenue,
+    dailyProtocolRevenue: dailyRevenue,
   };
 };
 
@@ -80,26 +182,31 @@ const adapter: SimpleAdapter = {
     Object.entries(chainConfig).map(([chain, { start }]) => [chain, { start }]),
   ),
   methodology: {
-    Fees: "The 1inch DAO's share of Aqua LP swap fees: 1/4 of the LP fee on low-fee tiers (below ~0.1225%) and 1/6 on higher tiers, encoded into each position and transferred to the DAO fee exchanger at fill time. LP-retained fees accrue inside maker-owned positions (Aqua is non-custodial) and are not yet separately measurable on-chain, so this is a lower bound on total fees; an LP-fee decode from strategy bytecode is planned as a follow-up.",
+    Fees: "Total Aqua swap fees paid by takers: each fill's taker-paid amount (Pushed event on the AquaRouter registry, fee-inclusive; strategy-registration pushes excluded) multiplied by the position's fee rate decoded from its on-chain strategy bytecode (SwapVM flat-fee instruction, 1e9 units = 100%). Fills of positions on the legacy developer-release registry (pre-2026-07-19, a handful of test positions on an earlier instruction set) are excluded.",
+    SupplySideRevenue:
+      "The share of each fill's swap fee retained by the LP inside the maker-owned wallet (Aqua is non-custodial): total fee minus the DAO share.",
     Revenue:
-      "All counted fees go to the protocol entity; equals dailyFees until LP-retained fees are measurable.",
-    ProtocolRevenue:
-      "ERC20 transfers received by the per-chain 1inch DAO fee-exchanger addresses, excluding mints (interest-bearing-token rebases). Inflows occur inside Aqua fill transactions.",
+      "The 1inch DAO's encoded share of each fill's swap fee: 1/4 of the LP fee on low-fee tiers (below ~0.1225%) and 1/6 on higher tiers, transferred to the purpose-deployed per-chain DAO fee exchanger at fill time. Positions created before the DAO fee launch (2026-07-19; enabled 2026-07-21 on BNB Chain and Robinhood Chain) carry no DAO fee and contribute only to SupplySideRevenue. Cross-checked against measured ERC20 inflows to the fee exchangers.",
+    ProtocolRevenue: "All DAO revenue accrues to the 1inch DAO treasury.",
   },
   breakdownMethodology: {
     Fees: {
-      'Aqua LP Swap Fees':
-        "The DAO's encoded share of Aqua LP swap fees, transferred to the per-chain fee exchanger at fill time (the exchangers were deployed for this purpose on 2026-07-18 and receive nothing else).",
+      [LABEL_LP]:
+        "Swap-fee share retained by LPs in their own wallets, priced per fill from the decoded position fee rate.",
+      [LABEL_DAO]:
+        "Swap-fee share transferred to the 1inch DAO fee exchanger at fill time, priced per fill from the decoded protocol-fee rate.",
+    },
+    SupplySideRevenue: {
+      [LABEL_LP]: "LP-retained swap fees (total fee minus the DAO share).",
     },
     Revenue: {
-      'Aqua LP Swap Fees':
-        "All tracked fee-exchanger inflows are retained by the protocol entity.",
+      [LABEL_DAO]:
+        "The DAO's decoded per-fill fee share (validated against fee-exchanger inflows).",
     },
     ProtocolRevenue: {
-      'Aqua LP Swap Fees':
-        "Fee-exchanger inflows accrue to the 1inch DAO treasury.",
+      [LABEL_DAO]: "DAO fee share accruing to the 1inch DAO treasury.",
     },
   },
-}; 
+};
 
 export default adapter;


### PR DESCRIPTION
Follow-up to the merged fees adapter, completing the income statement per the Telegram thread with @LlamaFacts ("fees generated for the lp"). The v1 adapter measured only the DAO's fee-exchanger inflows and declared itself a lower bound; this replaces it with a per-fill fee computation covering both sides.

## How it works

Every Aqua position's fee rates live on-chain in the strategy bytecode registered at ship time (`Shipped` event). The adapter ABI-decodes the SwapVM order, walks the program bytes (`[opcodeIndex, argsLength, args]`), and extracts:

- `flatFeeAmountInXD` (opcode 21) — the position's total swap fee, uint32 with 1e9 = 100%
- `(aqua)ProtocolFeeAmountInXD` (opcodes 27/28) — the DAO's share, same units

Per SwapVM's `Fee.sol`, the taker-paid amount (`Pushed`, what the volume adapter counts) is fee-inclusive, so per fill:

- `dailyFees += pushed × flat / 1e9` (split into LP + DAO labels)
- `dailyRevenue = dailyProtocolRevenue += pushed × protocol / 1e9`
- `dailySupplySideRevenue += the difference` (LP-retained, inside maker wallets — Aqua is non-custodial, so there is no transfer to observe; this is why it must be decoded)

Ship-registration `Pushed` runs are excluded with the same consecutive-log-index walk the volume adapter uses. The full-history `Shipped` scan is `cacheInCloud: true` from the per-chain AquaRouter deploy block (resolved via coins.llama.fi).

## Validation — decode vs measurement

The v1 measured path (ERC20 inflows to the fee exchangers) ran side-by-side with the decode on the same window:

| | Ethereum, same 24h window |
|---|---|
| v2 decoded DAO share | **$10.68** |
| v1 measured exchanger inflows | **$10.69** |

Two independent measurement paths agree to the cent (the delta is Fee.sol's ceilDiv vs floor division). Decode coverage: 668/668 AquaRouter strategies on Ethereum decode cleanly; the flat/protocol ratios reproduce the DAO's tier model exactly (1/4 below ~0.1225%, 1/6 above; pre-launch positions carry 0 and correctly contribute only to supply side). The decode also captures LP fees on fills the exchanger never sees (e.g. BSC showed $0.01 LP fees where v1 showed $0.00).

## Scope note

Fills on the legacy developer-release registry (2025-11-17, a handful of test positions on an earlier SwapVM instruction table) are excluded — consistent with the adapter's existing `start: 2026-07-19`, before which no DAO fee existed. Methodology + breakdownMethodology updated accordingly (`Aqua LP Swap Fees` / `1inch DAO Fee Share` labels).

Made with [Cursor](https://cursor.com)