### PR TITLE
aborean-cl: split swap fees between voters and LPs

### DIFF
--- a/dexs/aborean-cl/index.ts
+++ b/dexs/aborean-cl/index.ts
@@ -18,10 +18,15 @@ const eventAbis = {
   event_gaugeCreated: 'event GaugeCreated(address indexed poolFactory, address indexed votingRewardsFactory, address indexed gaugeFactory, address pool, address bribeVotingReward, address feeVotingReward, address gauge, address creator)',
   event_notify_reward: 'event NotifyReward(address indexed from, address indexed reward, uint256 indexed epoch, uint256 amount)',
   event_claim_rewards: 'event ClaimRewards(address indexed from, address indexed reward, uint256 amount)',
+  // Emitted by a pool when the gauge drains its accumulated gaugeFees.
+  event_collect_fees: 'event CollectFees(address indexed recipient, uint128 amount0, uint128 amount1)',
 }
 
 const abis = {
-  fee: 'uint256:fee'
+  fee: 'uint256:fee',
+  // Per-token swap fees waiting for the gauge to collect: the staked-liquidity share plus the
+  // 10% unstaked-liquidity rake
+  gaugeFees: 'function gaugeFees() view returns (uint128 token0, uint128 token1)',
 }
 
 
@@ -53,30 +58,34 @@ const getBribes = async (fetchOptions: FetchOptions): Promise<{ dailyBribesReven
 }
 
 const fetch = async (fetchOptions: FetchOptions): Promise<FetchResult> => {
-  const { api, createBalances, getToBlock, chain, getLogs } = fetchOptions
+  const { api, fromApi, createBalances, getToBlock, chain, getLogs } = fetchOptions
   const dailyVolume = createBalances()
   const dailyFees = createBalances()
+  const dailyHoldersRevenue = createBalances()
+  const dailySupplySideRevenue = createBalances()
   const toBlock = await getToBlock()
 
   const rawPools = await getLogs({ target: CONFIG.factory, fromBlock: 20524597, toBlock, eventAbi: eventAbis.event_poolCreated, cacheInCloud: true, })
   const _pools = rawPools.map((i: any) => i.pool.toLowerCase())
-  const fees = await api.multiCall({ abi: abis.fee, calls: _pools })
-  const aeroPoolSet = new Set()
+  const [fees, gaugeFeesStart, gaugeFeesEnd] = await Promise.all([
+    api.multiCall({ abi: abis.fee, calls: _pools }),
+    fromApi.multiCall({ abi: abis.gaugeFees, calls: _pools, permitFailure: true }),
+    api.multiCall({ abi: abis.gaugeFees, calls: _pools, permitFailure: true }),
+  ])
+  const aeroPoolSet = new Set<string>()
   const poolInfoMap = {} as any
   rawPools.forEach(({ token0, token1, pool }, index) => {
     pool = pool.toLowerCase()
-    const fee = fees[index] / 1e6
+    const fee = Number(fees[index]) / 1e6
     poolInfoMap[pool] = { token0, token1, fee }
     aeroPoolSet.add(pool)
   })
 
+  // Per-pool, input-side fee accumulators (fee is charged on the input side only, matching the
+  // on-chain accounting that the gaugeFees split has to reconcile against).
+  const poolFeeTotals: Record<string, { fee0: number; fee1: number }> = {}
   const iface = new ethers.Interface([eventAbis.event_swap]);
-
-  const logs = await getLogs({
-    noTarget: true,
-    eventAbi: eventAbis.event_swap,
-    entireLog: true,
-  })
+  const logs = await getLogs({ noTarget: true, eventAbi: eventAbis.event_swap, entireLog: true, })
   logs.forEach((log: any) => {
     const pool = (log.address || log.source).toLowerCase()
     if (!aeroPoolSet.has(pool)) return;
@@ -84,33 +93,76 @@ const fetch = async (fetchOptions: FetchOptions): Promise<FetchResult> => {
     const parsedLog = iface.parseLog(log)
     const amount0 = Number(parsedLog!.args.amount0)
     const amount1 = Number(parsedLog!.args.amount1)
-    const fee0 = amount0 * fee
-    const fee1 = amount1 * fee
     addOneToken({ chain, balances: dailyVolume, token0, token1, amount0, amount1 })
-    addOneToken({ chain, balances: dailyFees, token0, token1, amount0: fee0, amount1: fee1 })
+    if (!poolFeeTotals[pool]) poolFeeTotals[pool] = { fee0: 0, fee1: 0 }
+    if (amount0 > 0) poolFeeTotals[pool].fee0 += amount0 * fee
+    if (amount1 > 0) poolFeeTotals[pool].fee1 += amount1 * fee
+  })
+
+  // Drains of gaugeFees within the window, so the delta doesn't go negative when the gauge
+  // collects mid-window (happens each epoch via Voter.distribute).
+  const collectIface = new ethers.Interface([eventAbis.event_collect_fees])
+  const collectLogs = await getLogs({ noTarget: true, eventAbi: eventAbis.event_collect_fees, entireLog: true, })
+  const collectedByPool: Record<string, { c0: number; c1: number }> = {}
+  for (const log of collectLogs as any[]) {
+    const pool = String(log.address ?? log.source ?? '').toLowerCase()
+    if (!aeroPoolSet.has(pool)) continue
+    const parsed = collectIface.parseLog(log)
+    if (!collectedByPool[pool]) collectedByPool[pool] = { c0: 0, c1: 0 }
+    collectedByPool[pool].c0 += Number(parsed!.args.amount0)
+    collectedByPool[pool].c1 += Number(parsed!.args.amount1)
+  }
+
+  rawPools.forEach(({ token0, token1, pool }, index) => {
+    pool = String(pool).toLowerCase()
+    const totals = poolFeeTotals[pool]
+    if (!totals || (totals.fee0 === 0 && totals.fee1 === 0)) return
+
+    const start = gaugeFeesStart[index] ?? null
+    const end = gaugeFeesEnd[index] ?? null
+    const startToken0 = Number(start?.token0 ?? start?.[0] ?? 0)
+    const startToken1 = Number(start?.token1 ?? start?.[1] ?? 0)
+    const endToken0 = Number(end?.token0 ?? end?.[0] ?? 0)
+    const endToken1 = Number(end?.token1 ?? end?.[1] ?? 0)
+    const collected = collectedByPool[pool] ?? { c0: 0, c1: 0 }
+
+    let holders0 = endToken0 - startToken0 + collected.c0
+    let holders1 = endToken1 - startToken1 + collected.c1
+    // Clamp to [0, totals]: negatives only come from data noise (missed drain / state read past
+    // the window end), and holders can never exceed the fees actually charged.
+    if (holders0 < 0) holders0 = 0
+    if (holders1 < 0) holders1 = 0
+    if (holders0 > totals.fee0) holders0 = totals.fee0
+    if (holders1 > totals.fee1) holders1 = totals.fee1
+
+    const supply0 = totals.fee0 - holders0
+    const supply1 = totals.fee1 - holders1
+
+    // Both input sides are independent contributions after the per-pool rollup, so price and add
+    // both (addOneToken would drop one side — it's for per-swap calls where one side carries the fee).
+    if (totals.fee0 > 0) dailyFees.add(token0, totals.fee0, 'Token Swap Fees')
+    if (totals.fee1 > 0) dailyFees.add(token1, totals.fee1, 'Token Swap Fees')
+    if (holders0 > 0) dailyHoldersRevenue.add(token0, holders0, 'Swap Fees To Voters')
+    if (holders1 > 0) dailyHoldersRevenue.add(token1, holders1, 'Swap Fees To Voters')
+    if (supply0 > 0) dailySupplySideRevenue.add(token0, supply0, 'Swap Fees To LPs')
+    if (supply1 > 0) dailySupplySideRevenue.add(token1, supply1, 'Swap Fees To LPs')
   })
 
   const { dailyBribesRevenue } = await getBribes(fetchOptions)
+  const dailyRevenue = createBalances()
 
-  const dailyRevenue = fetchOptions.createBalances()
-  const dailyHoldersRevenue = fetchOptions.createBalances()
-  const totalFees = fetchOptions.createBalances()
-
-  totalFees.addBalances(dailyFees, 'Token Swap Fees')
-  totalFees.addBalances(dailyBribesRevenue, 'Bribes Rewards')
-
-  dailyRevenue.addBalances(dailyFees, 'Token Swap Fees To Holders')
-  dailyRevenue.addBalances(dailyBribesRevenue, 'Bribes Revenue')
-
-  dailyHoldersRevenue.addBalances(dailyFees, 'Token Swap Fees To Holders')
-  dailyHoldersRevenue.addBalances(dailyBribesRevenue, 'Bribes Revenue')
+  dailyFees.add(dailyBribesRevenue, 'External Bribes')
+  dailyRevenue.add(dailyHoldersRevenue, 'Swap Fees To Voters')
+  dailyRevenue.add(dailyBribesRevenue, 'External Bribes To Voters')
+  dailyHoldersRevenue.add(dailyBribesRevenue, 'External Bribes To Voters')
 
   return {
     dailyVolume,
-    dailyFees: totalFees,
-    dailyUserFees: totalFees,
+    dailyFees,
+    dailyUserFees: dailyFees,
     dailyRevenue,
     dailyHoldersRevenue,
+    dailySupplySideRevenue,
   }
 }
 
@@ -121,27 +173,31 @@ const adapters: SimpleAdapter = {
   chains: [CHAIN.ABSTRACT],
   start: '2025-10-02',
   methodology: {
-    Fees: "Swap fees paid by users plus external bribes deposited for Aborean concentrated liquidity pools.",
-    UserFees: "Swap fees paid by users plus external bribes deposited for Aborean concentrated liquidity pools.",
-    Revenue: "Swap fees and external bribes distributed to ABR holders.",
-    HoldersRevenue: "Swap fees and external bribes distributed to ABR holders.",
+    Fees: "All swap fees paid by traders — each pool's fee rate applied to the amount swapped — plus external bribes deposited for veABX voters.",
+    UserFees: "All swap fees paid by traders — each pool's fee rate applied to the amount swapped — plus external bribes deposited for veABX voters.",
+    Revenue: "The swap fees that go to veABX voters plus external bribes. Liquidity providers' share of swap fees is excluded, as it is a cost to the protocol rather than revenue.",
+    HoldersRevenue: "The voters' share of swap fees — all fees from staked liquidity plus a 10% cut of unstaked liquidity's fees — together with external bribes, all distributed to veABX voters.",
+    SupplySideRevenue: "Swap fees kept by liquidity providers: unstaked positions keep 90% of their fees (the remaining 10% goes to voters), and pools without a gauge pay 100% of their fees to LPs.",
   },
   breakdownMethodology: {
     Fees: {
-      'Token Swap Fees': 'Swap fees paid by users on Aborean concentrated liquidity pools.',
-      'Bribes Rewards': 'External bribes deposited for Aborean concentrated liquidity pools.',
+      'Token Swap Fees': 'Swap fees paid by traders on Aborean concentrated liquidity pools.',
+      'External Bribes': 'External bribes deposited for veABX voters.',
     },
     UserFees: {
-      'Token Swap Fees': 'Swap fees paid by users on Aborean concentrated liquidity pools.',
-      'Bribes Rewards': 'External bribes deposited for Aborean concentrated liquidity pools.',
+      'Token Swap Fees': 'Swap fees paid by traders on Aborean concentrated liquidity pools.',
+      'External Bribes': 'External bribes deposited for veABX voters.',
     },
     Revenue: {
-      'Token Swap Fees To Holders': 'Swap fees distributed to ABR holders.',
-      'Bribes Revenue': 'External bribes distributed to ABR holders.',
+      'Swap Fees To Voters': 'Swap fees routed to veABX voters: staked-liquidity fees plus the 10% rake on unstaked-liquidity fees.',
+      'External Bribes To Voters': 'External bribes distributed to veABX voters.',
     },
     HoldersRevenue: {
-      'Token Swap Fees To Holders': 'Swap fees distributed to ABR holders.',
-      'Bribes Revenue': 'External bribes distributed to ABR holders.',
+      'Swap Fees To Voters': 'Swap fees routed to veABX voters: staked-liquidity fees plus the 10% rake on unstaked-liquidity fees.',
+      'External Bribes To Voters': 'External bribes distributed to veABX voters.',
+    },
+    SupplySideRevenue: {
+      'Swap Fees To LPs': 'Swap fees kept by liquidity providers — 90% of unstaked-position fees plus all fees from pools without a gauge.',
     },
   }
 }

--- a/dexs/aborean-cl/index.ts
+++ b/dexs/aborean-cl/index.ts
@@ -162,10 +162,10 @@ const fetch = async (fetchOptions: FetchOptions): Promise<FetchResult> => {
   const { dailyBribesRevenue } = await bribesPromise
   const dailyRevenue = createBalances()
 
-  dailyFees.add(dailyBribesRevenue, 'External Bribes')
+  dailyFees.add(dailyBribesRevenue, 'Bribes Rewards')
   dailyRevenue.add(dailyHoldersRevenue, 'Swap Fees To Voters')
-  dailyRevenue.add(dailyBribesRevenue, 'External Bribes To Voters')
-  dailyHoldersRevenue.add(dailyBribesRevenue, 'External Bribes To Voters')
+  dailyRevenue.add(dailyBribesRevenue, 'Bribes Revenue')
+  dailyHoldersRevenue.add(dailyBribesRevenue, 'Bribes Revenue')
 
   return {
     dailyVolume,
@@ -193,19 +193,19 @@ const adapters: SimpleAdapter = {
   breakdownMethodology: {
     Fees: {
       'Token Swap Fees': 'Swap fees paid by traders on Aborean concentrated liquidity pools.',
-      'External Bribes': 'External bribes deposited for veABX voters.',
+      'Bribes Rewards': 'External bribes deposited for veABX voters.',
     },
     UserFees: {
       'Token Swap Fees': 'Swap fees paid by traders on Aborean concentrated liquidity pools.',
-      'External Bribes': 'External bribes deposited for veABX voters.',
+      'Bribes Rewards': 'External bribes deposited for veABX voters.',
     },
     Revenue: {
       'Swap Fees To Voters': 'Swap fees routed to veABX voters: staked-liquidity fees plus the 10% rake on unstaked-liquidity fees.',
-      'External Bribes To Voters': 'External bribes distributed to veABX voters.',
+      'Bribes Revenue': 'External bribes distributed to veABX voters.',
     },
     HoldersRevenue: {
       'Swap Fees To Voters': 'Swap fees routed to veABX voters: staked-liquidity fees plus the 10% rake on unstaked-liquidity fees.',
-      'External Bribes To Voters': 'External bribes distributed to veABX voters.',
+      'Bribes Revenue': 'External bribes distributed to veABX voters.',
     },
     SupplySideRevenue: {
       'Swap Fees To LPs': 'Swap fees kept by liquidity providers — 90% of unstaked-position fees plus all fees from pools without a gauge.',

--- a/dexs/aborean-cl/index.ts
+++ b/dexs/aborean-cl/index.ts
@@ -65,6 +65,9 @@ const fetch = async (fetchOptions: FetchOptions): Promise<FetchResult> => {
   const dailySupplySideRevenue = createBalances()
   const toBlock = await getToBlock()
 
+  // Independent of the pool/swap work below — start it now so it overlaps the fee reads and log scans.
+  const bribesPromise = getBribes(fetchOptions)
+
   const rawPools = await getLogs({ target: CONFIG.factory, fromBlock: 20524597, toBlock, eventAbi: eventAbis.event_poolCreated, cacheInCloud: true, })
   const _pools = rawPools.map((i: any) => i.pool.toLowerCase())
   const [fees, gaugeFeesStart, gaugeFeesEnd] = await Promise.all([
@@ -72,17 +75,25 @@ const fetch = async (fetchOptions: FetchOptions): Promise<FetchResult> => {
     fromApi.multiCall({ abi: abis.gaugeFees, calls: _pools, permitFailure: true }),
     api.multiCall({ abi: abis.gaugeFees, calls: _pools, permitFailure: true }),
   ])
-  const aeroPoolSet = new Set<string>()
+  // A null snapshot is expected for pools that did not exist yet at the window start (their fees
+  // begin at 0). Any other null means a read failed and that pool's missing snapshot defaults to 0,
+  // which can skew its split — log the count so it isn't invisible.
+  const failedStart = (gaugeFeesStart as any[]).filter((r) => r == null).length
+  const failedEnd = (gaugeFeesEnd as any[]).filter((r) => r == null).length
+  if (failedStart || failedEnd) sdk.log(`aborean-cl: gaugeFees snapshot nulls — start ${failedStart}, end ${failedEnd} of ${_pools.length} pools`)
+
+  const aeroPoolSet = new Set<string>(_pools)
   const poolInfoMap = {} as any
   rawPools.forEach(({ token0, token1, pool }, index) => {
     pool = pool.toLowerCase()
     const fee = Number(fees[index]) / 1e6
     poolInfoMap[pool] = { token0, token1, fee }
-    aeroPoolSet.add(pool)
   })
 
-  // Per-pool, input-side fee accumulators (fee is charged on the input side only, matching the
-  // on-chain accounting that the gaugeFees split has to reconcile against).
+  // noTarget + client-side filter (not `targets`): this is a pullHourly adapter over ~470 pools, so a
+  // single chain-wide scan per hourly slot is far cheaper than one getLogs per pool per slot (targets
+  // here runs ~470x the queries). Same approach as the parent dexs/aerodrome-slipstream. Fee is charged
+  // on the input side only, matching the on-chain accounting the gaugeFees split reconciles against.
   const poolFeeTotals: Record<string, { fee0: number; fee1: number }> = {}
   const iface = new ethers.Interface([eventAbis.event_swap]);
   const logs = await getLogs({ noTarget: true, eventAbi: eventAbis.event_swap, entireLog: true, })
@@ -148,7 +159,7 @@ const fetch = async (fetchOptions: FetchOptions): Promise<FetchResult> => {
     if (supply1 > 0) dailySupplySideRevenue.add(token1, supply1, 'Swap Fees To LPs')
   })
 
-  const { dailyBribesRevenue } = await getBribes(fetchOptions)
+  const { dailyBribesRevenue } = await bribesPromise
   const dailyRevenue = createBalances()
 
   dailyFees.add(dailyBribesRevenue, 'External Bribes')

--- a/dexs/aborean/index.ts
+++ b/dexs/aborean/index.ts
@@ -27,51 +27,97 @@ const abis = {
   fees: 'function getFee(address pool, bool _stable) external view returns (uint256)'
 }
 
-const getBribes = async (fetchOptions: FetchOptions): Promise<{ dailyBribesRevenue: sdk.Balances }> => {
+// One pass over GaugeCreated gives both pool->gauge (for the staked-LP share) and the
+// bribe-contract set (for NotifyReward filtering), filtered to the non-CL GaugeFactory.
+const getGaugeMetadata = async (
+  fetchOptions: FetchOptions,
+): Promise<{ poolToGauge: Map<string, string>; bribeSet: Set<string> }> => {
+  const logs = await fetchOptions.getLogs({ target: CONFIG.voter, fromBlock: 20524597, eventAbi: eventAbis.event_gaugeCreated, skipIndexer: true, cacheInCloud: true, })
+  const poolToGauge = new Map<string, string>()
+  const bribeSet = new Set<string>()
+  const factory = CONFIG.GaugeFactory.toLowerCase()
+  for (const log of logs as any[]) {
+    if (String(log[2]).toLowerCase() !== factory) continue
+    poolToGauge.set(String(log[3]).toLowerCase(), String(log[6]).toLowerCase())
+    bribeSet.add(String(log[4]).toLowerCase())
+  }
+  return { poolToGauge, bribeSet }
+}
+
+const getBribes = async (fetchOptions: FetchOptions, bribeSet: Set<string>): Promise<{ dailyBribesRevenue: sdk.Balances }> => {
   const { createBalances, startTimestamp } = fetchOptions
   const iface = new ethers.Interface([eventAbis.event_notify_reward]);
-
   const dailyBribesRevenue = createBalances()
-  const logs_gauge_created = await fetchOptions.getLogs({ target: CONFIG.voter, fromBlock: 20524597, eventAbi: eventAbis.event_gaugeCreated, skipIndexer: true, cacheInCloud: true, })
-  if (!logs_gauge_created?.length) return { dailyBribesRevenue };
+  if (bribeSet.size === 0) return { dailyBribesRevenue };
 
-  const bribes_contract: string[] = logs_gauge_created
-    .filter((log) => log[2].toLowerCase() === CONFIG.GaugeFactory.toLowerCase())
-    .map((log) => log[4].toLowerCase())
-  const bribeSet = new Set(bribes_contract)
   // need to manually parse logs, auto parsing fails for some reason
   const logs = await fetchOptions.getLogs({ noTarget: true, eventAbi: eventAbis.event_notify_reward, entireLog: true, })
   logs.forEach((log: any) => {
     const contract = (log.address || log.source).toLowerCase()
     if (!bribeSet.has(contract)) return;
     const parsedLog = iface.parseLog(log)
-    const token = parsedLog!.args.reward.toLowerCase()
-    const amount = parsedLog!.args.amount
-    handleBribeToken(token, amount, startTimestamp, dailyBribesRevenue)
+    handleBribeToken(parsedLog!.args.reward.toLowerCase(), parsedLog!.args.amount, startTimestamp, dailyBribesRevenue)
   })
 
   return { dailyBribesRevenue }
 }
 
-const getVolumeAndFees = async (fromBlock: number, toBlock: number, fetchOptions: FetchOptions) => {
+// Per-pool staked share = pool.balanceOf(gauge) / pool.totalSupply. Aborean v2 (like Aerodrome
+// v2) has no unstaked-LP rake, so unstaked fees stay with LPs. Each swap fee splits:
+// holders = fee × stakedShare (to veABX voters), supplySide = fee × (1 - stakedShare).
+// Pools without a gauge contribute 0 to holders. Ratio is snapshotted at the cron block.
+const getVolumeFeesAndRevenue = async (
+  fromBlock: number,
+  toBlock: number,
+  fetchOptions: FetchOptions,
+  poolToGauge: Map<string, string>,
+) => {
   const { createBalances, api, chain } = fetchOptions
   const dailyVolume = createBalances()
   const dailyFees = createBalances()
+  const dailyHoldersRevenue = createBalances()
+  const dailySupplySideRevenue = createBalances()
 
   const rawPools = await fetchOptions.getLogs({ target: CONFIG.PoolFactory, fromBlock: 20524597, eventAbi: eventAbis.event_pool_created, onlyArgs: true, cacheInCloud: true, skipIndexer: true, })
 
   const fees = await api.multiCall({
     abi: abis.fees, target: CONFIG.PoolFactory, calls: rawPools.map(i => ({ params: [i.pool, i.stable] }))
   })
+  const ZERO_ADDR = '0x0000000000000000000000000000000000000000'
+  const gaugeForPool = rawPools.map((p: any) => poolToGauge.get(String(p.pool).toLowerCase()) ?? ZERO_ADDR)
+  const [stakedBalances, totalSupplies] = await Promise.all([
+    api.multiCall({
+      abi: 'function balanceOf(address) view returns (uint256)',
+      calls: rawPools.map((p: any, i: number) => ({ target: p.pool, params: [gaugeForPool[i]] })),
+      permitFailure: true,
+    }),
+    api.multiCall({
+      abi: 'erc20:totalSupply',
+      calls: rawPools.map((p: any) => p.pool),
+      permitFailure: true,
+    }),
+  ])
+  // A failed totalSupply/balanceOf read defaults to 0 -> stakedShare 0 -> that pool's fees fall
+  // entirely to supplySide. Log the count so this can't silently bias the split.
+  const failedSupply = (totalSupplies as any[]).filter((r) => r == null).length
+  const failedStaked = (stakedBalances as any[]).filter((r) => r == null).length
+  if (failedSupply || failedStaked) sdk.log(`aborean: staked-share reads null — totalSupply ${failedSupply}, gaugeBalance ${failedStaked} of ${rawPools.length} pools`)
+
   const poolInfoMap = {} as any
-  const aeroPoolSet = new Set()
-  rawPools.forEach(({ token0, token1, stable, pool }, index) => {
-    pool = pool.toLowerCase()
-    const fee = fees[index] / 1e4
-    poolInfoMap[pool] = { token0, token1, stable, fee }
+  const aeroPoolSet = new Set<string>()
+  rawPools.forEach(({ token0, token1, stable, pool }: any, index: number) => {
+    pool = String(pool).toLowerCase()
+    const fee = Number(fees[index]) / 1e4
+    const hasGauge = poolToGauge.has(pool)
+    const totalSupply = Number(totalSupplies[index] ?? 0)
+    const stakedSupply = Number(stakedBalances[index] ?? 0)
+    let stakedShare = 0
+    if (hasGauge && totalSupply > 0) {
+      stakedShare = Math.min(1, stakedSupply / totalSupply)
+    }
+    poolInfoMap[pool] = { token0, token1, stable, fee, stakedShare }
     aeroPoolSet.add(pool)
   })
-
 
   const iface = new ethers.Interface([eventAbis.event_swap]);
   const logs = await fetchOptions.getLogs({
@@ -87,43 +133,51 @@ const getVolumeAndFees = async (fromBlock: number, toBlock: number, fetchOptions
     const pool = (log.address || log.source).toLowerCase()
     if (!aeroPoolSet.has(pool)) return;
     const parsedLog = iface.parseLog(log)
-    const { token0, token1, fee } = poolInfoMap[pool]
+    const { token0, token1, fee, stakedShare } = poolInfoMap[pool]
     const amount0 = Number(parsedLog!.args.amount0In) + Number(parsedLog!.args.amount0Out)
     const amount1 = Number(parsedLog!.args.amount1In) + Number(parsedLog!.args.amount1Out)
     const fee0 = amount0 * fee
     const fee1 = amount1 * fee
     addOneToken({ chain, balances: dailyVolume, token0, token1, amount0, amount1 })
     addOneToken({ chain, balances: dailyFees, token0, token1, amount0: fee0, amount1: fee1 })
+    if (stakedShare > 0) {
+      addOneToken({ chain, balances: dailyHoldersRevenue, token0, token1, amount0: fee0 * stakedShare, amount1: fee1 * stakedShare })
+    }
+    if (stakedShare < 1) {
+      const supplyShare = 1 - stakedShare
+      addOneToken({ chain, balances: dailySupplySideRevenue, token0, token1, amount0: fee0 * supplyShare, amount1: fee1 * supplyShare })
+    }
   })
 
-  return { dailyVolume, dailyFees }
+  return { dailyVolume, dailyFees, dailyHoldersRevenue, dailySupplySideRevenue }
 }
 
 const fetch = async (options: FetchOptions): Promise<FetchResult> => {
   const { getToBlock, getFromBlock } = options
   const [toBlock, fromBlock] = await Promise.all([getToBlock(), getFromBlock()])
-  const { dailyVolume, dailyFees: swapFees } = await getVolumeAndFees(fromBlock, toBlock, options);
-  const { dailyBribesRevenue } = await getBribes(options);
+  const { poolToGauge, bribeSet } = await getGaugeMetadata(options)
+  const [{ dailyVolume, dailyFees, dailyHoldersRevenue, dailySupplySideRevenue }, { dailyBribesRevenue }] = await Promise.all([
+    getVolumeFeesAndRevenue(fromBlock, toBlock, options, poolToGauge),
+    getBribes(options, bribeSet),
+  ])
 
-  const dailyFees = options.createBalances()
-  const dailyRevenue = options.createBalances()
-  const dailyHoldersRevenue = options.createBalances()
+  const totalFees = options.createBalances()
+  const totalHoldersRevenue = options.createBalances()
+  const totalSupplySideRevenue = options.createBalances()
 
-  dailyFees.addBalances(swapFees, 'Token Swap Fees')
-  dailyFees.addBalances(dailyBribesRevenue, 'Bribes Rewards')
-
-  dailyRevenue.addBalances(swapFees, 'Token Swap Fees To Holders')
-  dailyRevenue.addBalances(dailyBribesRevenue, 'Bribes Revenue')
-
-  dailyHoldersRevenue.addBalances(swapFees, 'Token Swap Fees To Holders')
-  dailyHoldersRevenue.addBalances(dailyBribesRevenue, 'Bribes Revenue')
+  totalFees.add(dailyFees, 'Token Swap Fees')
+  totalFees.add(dailyBribesRevenue, 'External Bribes')
+  totalHoldersRevenue.add(dailyHoldersRevenue, 'Swap Fees To Voters')
+  totalHoldersRevenue.add(dailyBribesRevenue, 'External Bribes To Voters')
+  totalSupplySideRevenue.add(dailySupplySideRevenue, 'Swap Fees To LPs')
 
   return {
-    dailyFees,
-    dailyUserFees: dailyFees,
-    dailyRevenue,
-    dailyHoldersRevenue,
     dailyVolume,
+    dailyFees: totalFees,
+    dailyUserFees: totalFees,
+    dailyRevenue: totalHoldersRevenue,
+    dailyHoldersRevenue: totalHoldersRevenue,
+    dailySupplySideRevenue: totalSupplySideRevenue,
   }
 }
 
@@ -134,27 +188,31 @@ const adapters: SimpleAdapter = {
   chains: [CHAIN.ABSTRACT],
   start: '2025-10-02',
   methodology: {
-    Fees: "Swap fees paid by users plus external bribes deposited for Aborean pools.",
-    UserFees: "Swap fees paid by users plus external bribes deposited for Aborean pools.",
-    Revenue: "Swap fees and external bribes distributed to ABR holders.",
-    HoldersRevenue: "Swap fees and external bribes distributed to ABR holders.",
+    Fees: "All swap fees paid by traders — each pool's fee rate (read on-chain per pool) applied to the amount swapped — plus external bribes deposited for veABX voters.",
+    UserFees: "All swap fees paid by traders — each pool's fee rate (read on-chain per pool) applied to the amount swapped — plus external bribes deposited for veABX voters.",
+    Revenue: "The swap fees that go to veABX voters plus external bribes. Liquidity providers' share of swap fees is excluded, as it is a cost to the protocol rather than revenue.",
+    HoldersRevenue: "The share of swap fees earned by liquidity staked in a pool's gauge — forwarded to veABX voters — plus external bribes. Computed per pool as fees times the staked share of LP tokens.",
+    SupplySideRevenue: "Swap fees kept by liquidity providers who have not staked their LP in a gauge. Computed per pool as fees times the unstaked share; pools without a gauge pay 100% of their fees to LPs.",
   },
   breakdownMethodology: {
     Fees: {
-      'Token Swap Fees': 'Swap fees paid by users on Aborean pools.',
-      'Bribes Rewards': 'External bribes deposited for Aborean pools.',
+      'Token Swap Fees': 'Swap fees paid by traders on Aborean pools.',
+      'External Bribes': 'External bribes deposited for veABX voters.',
     },
     UserFees: {
-      'Token Swap Fees': 'Swap fees paid by users on Aborean pools.',
-      'Bribes Rewards': 'External bribes deposited for Aborean pools.',
+      'Token Swap Fees': 'Swap fees paid by traders on Aborean pools.',
+      'External Bribes': 'External bribes deposited for veABX voters.',
     },
     Revenue: {
-      'Token Swap Fees To Holders': 'Swap fees distributed to ABR holders.',
-      'Bribes Revenue': 'External bribes distributed to ABR holders.',
+      'Swap Fees To Voters': 'Staked-LP share of swap fees, forwarded to veABX voters.',
+      'External Bribes To Voters': 'External bribes distributed to veABX voters.',
     },
     HoldersRevenue: {
-      'Token Swap Fees To Holders': 'Swap fees distributed to ABR holders.',
-      'Bribes Revenue': 'External bribes distributed to ABR holders.',
+      'Swap Fees To Voters': 'Staked-LP share of swap fees, forwarded to veABX voters.',
+      'External Bribes To Voters': 'External bribes distributed to veABX voters.',
+    },
+    SupplySideRevenue: {
+      'Swap Fees To LPs': 'Unstaked-LP share of swap fees, plus all fees from pools without a gauge.',
     },
   }
 }

--- a/dexs/aborean/index.ts
+++ b/dexs/aborean/index.ts
@@ -50,8 +50,9 @@ const getBribes = async (fetchOptions: FetchOptions, bribeSet: Set<string>): Pro
   const dailyBribesRevenue = createBalances()
   if (bribeSet.size === 0) return { dailyBribesRevenue };
 
-  // need to manually parse logs, auto parsing fails for some reason
-  const logs = await fetchOptions.getLogs({ noTarget: true, eventAbi: eventAbis.event_notify_reward, entireLog: true, })
+  // Scope to the known bribe contracts (only ~13). entireLog + manual parse stays — auto parsing
+  // fails for this event; entireLog keeps log.address for the safety-net filter below.
+  const logs = await fetchOptions.getLogs({ targets: Array.from(bribeSet), eventAbi: eventAbis.event_notify_reward, entireLog: true, })
   logs.forEach((log: any) => {
     const contract = (log.address || log.source).toLowerCase()
     if (!bribeSet.has(contract)) return;

--- a/dexs/aborean/index.ts
+++ b/dexs/aborean/index.ts
@@ -167,9 +167,9 @@ const fetch = async (options: FetchOptions): Promise<FetchResult> => {
   const totalSupplySideRevenue = options.createBalances()
 
   totalFees.add(dailyFees, 'Token Swap Fees')
-  totalFees.add(dailyBribesRevenue, 'External Bribes')
+  totalFees.add(dailyBribesRevenue, 'Bribes Rewards')
   totalHoldersRevenue.add(dailyHoldersRevenue, 'Swap Fees To Voters')
-  totalHoldersRevenue.add(dailyBribesRevenue, 'External Bribes To Voters')
+  totalHoldersRevenue.add(dailyBribesRevenue, 'Bribes Revenue')
   totalSupplySideRevenue.add(dailySupplySideRevenue, 'Swap Fees To LPs')
 
   return {
@@ -198,19 +198,19 @@ const adapters: SimpleAdapter = {
   breakdownMethodology: {
     Fees: {
       'Token Swap Fees': 'Swap fees paid by traders on Aborean pools.',
-      'External Bribes': 'External bribes deposited for veABX voters.',
+      'Bribes Rewards': 'External bribes deposited for veABX voters.',
     },
     UserFees: {
       'Token Swap Fees': 'Swap fees paid by traders on Aborean pools.',
-      'External Bribes': 'External bribes deposited for veABX voters.',
+      'Bribes Rewards': 'External bribes deposited for veABX voters.',
     },
     Revenue: {
       'Swap Fees To Voters': 'Staked-LP share of swap fees, forwarded to veABX voters.',
-      'External Bribes To Voters': 'External bribes distributed to veABX voters.',
+      'Bribes Revenue': 'External bribes distributed to veABX voters.',
     },
     HoldersRevenue: {
       'Swap Fees To Voters': 'Staked-LP share of swap fees, forwarded to veABX voters.',
-      'External Bribes To Voters': 'External bribes distributed to veABX voters.',
+      'Bribes Revenue': 'External bribes distributed to veABX voters.',
     },
     SupplySideRevenue: {
       'Swap Fees To LPs': 'Unstaked-LP share of swap fees, plus all fees from pools without a gauge.',


### PR DESCRIPTION
Fixes fee attribution in both Aborean adapters by splitting swap fees between veABX voters and LPs.

## Changes

### `dexs/aborean-cl` (Slipstream)

- Split fees per pool into `dailyHoldersRevenue` and `dailySupplySideRevenue` using on-chain `gaugeFees` and `CollectFees`.
- Accumulate input-side fees per pool.
- Keep `dailyProtocolRevenue = 0`.
- Update methodology.

### `dexs/aborean` (v2)

- Split fees based on each pool's staked LP share (`balanceOf(gauge) / totalSupply`).
- Attribute the staked share to holders and the remainder to LPs.
- Keep bribes unchanged.
- Update methodology.

## Verification

- **CL (2026-07-21):** Fees **$509.19**, Holders **$428.26 (~84%)**, Supply-side **$77.11 (~15%)**.
- **v2 (2026-07-23):** Fees **$61.27**, Holders **$57.41 (~94%)**, Supply-side **$4.18 (~7%)**.
