### PR TITLE
morpho: blacklist fake ethereum market inflating fees

### DIFF
--- a/fees/morpho/index.ts
+++ b/fees/morpho/index.ts
@@ -14,7 +14,11 @@ const blacklistedMarketIds: Record<string, Array<any>> = {
   [CHAIN.WC]: [{
     from: "2025-11-07",
     id: '0x5a96ea60ddb8ece11b0dd1176f05bbc44ec92197ba206adb086db559146cc964' //sdeUSD
-  }]
+  }],
+  [CHAIN.ETHEREUM]: [{
+    from: "2026-07-21",
+    id: '0x23a7d0ff682b323363fb8ba58327ed87001f6306e09b7fd7413bbe4698e749c8' // fake USDC market, ~$6M/day fabricated interest
+  }],
 }
 
 export const MorphoBlues: Record<string, MorphoBlueConfig> = {


### PR DESCRIPTION
One fake market fabricated AccrueInterest, inflating Ethereum fees to ~6M/day (normally <1M).

Market `0x23a7d0ff682b323363fb8ba58327ed87001f6306e09b7fd7413bbe4698e749c8` (loan token USDC) alone: 5.92M on 07-21, 1.08M on 07-22. Blacklisted from 2026-07-21.

Verified: 07-22 Ethereum fees drop from 6.15M to 221k.