### PR TITLE
morpho: fix pharos config, use log scanning

### DIFF
--- a/fees/morpho/index.ts
+++ b/fees/morpho/index.ts
@@ -166,7 +166,7 @@ export const MorphoBlues: Record<string, MorphoBlueConfig> = {
     start: "2025-11-10",
   },
   [CHAIN.PHAROS]: {
-    chainId: 1672,
+    // no chainId: Pharos (1672) isn't in the Morpho API, so use log scanning. Adding chainId forces the API path and throws "unsupported chainId".
     blue: "0x18573fA18fd17dDfD790B4a5B5b2977aad3b4Efb",
     fromBlock: 4202147,
     start: "2026-06-01",

--- a/helpers/curators/configs.ts
+++ b/helpers/curators/configs.ts
@@ -105,7 +105,7 @@ export const MorphoConfigs: any = {
     ],
   },
   [CHAIN.PHAROS]: {
-    vaultFactoriesV2: [
+    vaultV2Factories: [
       {
         address: '0x8e01ed1e1a41029b3137fce9aa880c0a54827498',
         fromBlock: 4240410,


### PR DESCRIPTION
Pharos (chainId 1672) is a real Morpho Blue deployment but is not indexed by the Morpho GraphQL API (missing from its `chains` list). The config set `chainId: 1672`, forcing the API path, which throws `unsupported chainId "1672"` and crashes the whole multi-chain adapter.

Removing `chainId` routes Pharos through log scanning like other non-API chains (Fraxtal, Ink). Verified it returns real data (~150/day).