### PR TITLE
[fees] exypnos - add fee adapter for exypnosis aggregator

### DIFF
--- a/fees/exypnos.ts
+++ b/fees/exypnos.ts
@@ -1,0 +1,40 @@
+import { CHAIN } from "../helpers/chains"
+import { Dependencies, FetchOptions, SimpleAdapter } from "../adapters/types";
+import { addTokensReceived, getETHReceived } from "../helpers/token";
+
+// Exypnos has no router of its own — it's a front-end over 0x's AllowanceHolder, taking a
+// 0.35% integrator fee that lands as a Transfer (ERC20) or native transfer to its fee wallet.
+// Launched 2026-07-07 across all 5 chains: https://medium.com/@exypnos_xyz/exypnos-a-cross-chain-swap-aggregator-66cf6032c580
+const chainConfig: Record<string, { id: number, start: string }> = {
+  [CHAIN.ETHEREUM]: { id: 1, start: '2026-07-07' },
+  [CHAIN.OPTIMISM]: { id: 10, start: '2026-07-07' },
+  [CHAIN.ARBITRUM]: { id: 42161, start: '2026-07-07' },
+  [CHAIN.BASE]: { id: 8453, start: '2026-07-07' },
+  [CHAIN.ROBINHOOD]: { id: 4663, start: '2026-07-07' },
+};
+
+const feeCollector = "0xad01c20d5886137e056775af56915de824c8fce5"
+
+async function fetch(options: FetchOptions) {
+  const dailyFees = await addTokensReceived({ target: feeCollector, options })
+  await getETHReceived({ target: feeCollector, options, balances: dailyFees })
+
+  return { dailyFees, dailyRevenue: dailyFees, dailyProtocolRevenue: dailyFees }
+}
+
+const methodology = {
+  Fees: 'Integrator fee (0.35% of sell amount) charged by Exypnos on swaps routed through 0x, pulled from ERC20 Transfer events and native gas-token transfers into the Exypnos fee wallet.',
+  Revenue: 'All collected integrator fees are retained by Exypnos.',
+  ProtocolRevenue: 'All collected integrator fees are retained by Exypnos.',
+}
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  pullHourly: true,
+  dependencies: [Dependencies.ALLIUM],
+  fetch,
+  adapter: chainConfig,
+  methodology,
+}
+
+export default adapter;


### PR DESCRIPTION
- Fee collector was found by decoding calldata, not from docs.
- Called the 0x-backed quote endpoint with a real `taker` to get full tx calldata:
  ```
  curl 'https://exypnos.xyz/api/swap?endpoint=quote&chainId=1&sellToken=0xEeee...EEeE&buyToken=0xdAC17F958D2ee523a2206206994597C13D831ec7&sellAmount=1000000000000000000&slippageBps=100&swapFeeToken=0xEeee...EEeE&taker=0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045'
  ```
- Inside `transaction.data`, a `transfer(address,uint256)` call (selector `0xa9059cbb`) sends the fee to `0xad01c20d5886137e056775af56915de824c8fce5`.
- Verified across chains/amounts: same address every time, always exactly 0.35% of sell amount.
- Confirmed on-chain as a live EOA: [Etherscan](https://etherscan.io/address/0xad01c20d5886137e056775af56915de824c8fce5)
- Also active on [Robinhood Chain](https://robinhoodchain.blockscout.com/address/0xad01c20d5886137e056775af56915de824c8fce5)
- Ref: [Exypnos launch post](https://medium.com/@exypnos_xyz/exypnos-a-cross-chain-swap-aggregator-66cf6032c580)
