### PR TITLE
fix: InsightX is Mantle-native, remove Off-Chain references

### DIFF
--- a/dexs/insightx/index.ts
+++ b/dexs/insightx/index.ts
@@ -41,7 +41,7 @@ const fetch = async (options: FetchOptions) => {
 };
 
 const adapter: SimpleAdapter = {
-  version: 2,
+  version: 1,
   adapter: {
     [CHAIN.MANTLE]: {
       fetch,

--- a/dexs/insightx/index.ts
+++ b/dexs/insightx/index.ts
@@ -4,28 +4,24 @@ import { httpGet } from "../../utils/fetchURL";
 
 /**
  * InsightX Adapter for DefiLlama
- * 
- * Platform: Prediction Market
+ *
+ * Platform: Prediction Market (Mantle)
  * Data Source: InsightX Backend API
- * 
- * Displays daily trading volume and protocol fees aggregated by the InsightX backend.
+ *
+ * InsightX is a Mantle-native prediction market protocol.
+ * All trading volume and fees are on-chain on Mantle.
  * Data is fetched from: https://mainnet-api.insightx.finance/predict/v2/llama/stats
  */
 
 interface InsightXDailyStats {
     date: string;
-    volume: number;      // Daily trading volume in USD
-    fees: number;        // Daily fees in USD
+    volume: number;
+    fees: number;
 }
 
 const INSIGHTX_API_BASE = "https://mainnet-api.insightx.finance/predict/v2/llama/stats";
 
-/**
- * Fetch daily metrics from InsightX Backend API (Off-Chain)
- * 
- * Returns aggregated trading volume and protocol fees calculated off-chain
- */
-const fetchOffChain = async (options: FetchOptions) => {
+const fetch = async (options: FetchOptions) => {
   const url = `${INSIGHTX_API_BASE}?date=${options.dateString}`;
 
   const response = await httpGet(url);
@@ -45,11 +41,10 @@ const fetchOffChain = async (options: FetchOptions) => {
 };
 
 const adapter: SimpleAdapter = {
-  version: 1,
-  skipBreakdownValidation: true,
+  version: 2,
   adapter: {
     [CHAIN.MANTLE]: {
-      fetch: fetchOffChain,
+      fetch,
       start: "2026-06-03",
     },
   },


### PR DESCRIPTION
## Problem

InsightX is a **single-chain protocol deployed exclusively on Mantle** (see [DefiLlama](https://defillama.com/protocol/insightx): "InsightX operates on Mantle"). However, the fee/volume data is split between "Off Chain" and "Mantle" because the adapter was originally registered under `CHAIN.OFF_CHAIN` in commit `d80a540`, then changed to `CHAIN.MANTLE` in commit `42c488c`.

This causes:
- Historical data (Jun 3 – Jul 21) stuck under "Off Chain"  
- Mantle shows identical 24h/7d/30d values (only 1 day of data)

## Changes

- Removed misleading "Off-Chain" / "fetchOffChain" naming  
- Updated doc comments to clarify Mantle-native deployment  
- Bumped version to 2 to trigger re-processing of historical data under Mantle  

## Request

Please migrate the existing "Off Chain" historical data for InsightX to "Mantle", so the protocol shows correctly as a single-chain deployment.