### PR TITLE
fix Jupiter Gacha volume and add fees/revenue

### DIFF
--- a/dexs/jupiter-gacha/index.ts
+++ b/dexs/jupiter-gacha/index.ts
@@ -1,25 +1,35 @@
-import { Dependencies, FetchOptions, FetchResult, SimpleAdapter } from "../../adapters/types";
+import { Dependencies, FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 import { queryAllium } from "../../helpers/allium";
 
+// Jupiter Gacha settles through Collector Crypt's shared wallet; jupiter-* memos
+// isolate Jupiter activity. https://solscan.io/account/GachaNgyXTU3zFogQ8Z5jR2BLXs8215X2AtEH18VxJq3
 const GACHA_ADDRESS = "GachaNgyXTU3zFogQ8Z5jR2BLXs8215X2AtEH18VxJq3";
+// Canonical USDC mint on Solana.
 const USDC_MINT = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
+// Listed Jupiter Gacha pack prices; future/non-standard prices remain visible
+// under Other Gacha Pack Sales. https://jup.ag/gacha
+const GACHA_TIERS = new Set([25, 50, 100, 250, 1000, 2500]);
 
-const timeRange = (options: FetchOptions) =>
-  `block_timestamp >= TO_TIMESTAMP_NTZ(${options.startTimestamp}) AND block_timestamp < TO_TIMESTAMP_NTZ(${options.endTimestamp})`;
-
-const fetch = async (options: FetchOptions): Promise<FetchResult> => {
+const fetch = async (options: FetchOptions) => {
   const dailyVolume = options.createBalances();
+  const dailyFees = options.createBalances();
+  const timeRange = `block_timestamp >= TO_TIMESTAMP_NTZ(${options.startTimestamp}) AND block_timestamp < TO_TIMESTAMP_NTZ(${options.endTimestamp})`;
 
   const query = `
     WITH flows AS (
       SELECT
         txn_id,
-        amount AS usdc
+        from_address,
+        to_address,
+        amount
       FROM solana.assets.transfers
       WHERE mint = '${USDC_MINT}'
-        AND (to_address = '${GACHA_ADDRESS}' OR from_address = '${GACHA_ADDRESS}')
-        AND ${timeRange(options)}
+        AND (
+          to_address = '${GACHA_ADDRESS}'
+          OR from_address = '${GACHA_ADDRESS}'
+        )
+        AND ${timeRange}
     ),
     memos AS (
       SELECT
@@ -30,30 +40,94 @@ const fetch = async (options: FetchOptions): Promise<FetchResult> => {
           1, 1, 'e', 1
         ) AS memo
       FROM solana.raw.transactions
-      WHERE ${timeRange(options)}
+      WHERE ${timeRange}
         AND txn_id IN (SELECT txn_id FROM flows)
     ),
-    ev AS (
+    events AS (
       SELECT
-        f.usdc,
+        f.from_address,
+        f.to_address,
+        f.amount,
         REGEXP_SUBSTR(m.memo, ':([a-z]+)', 1, 1, 'e', 1) AS action
       FROM flows f
       JOIN memos m ON f.txn_id = m.txn_id
       WHERE m.memo LIKE 'jupiter-%'
+    ),
+    pack_sales AS (
+      SELECT
+        amount,
+        SUM(amount) AS total
+      FROM events
+      WHERE action = 'open'
+        AND to_address = '${GACHA_ADDRESS}'
+      GROUP BY amount
+    ),
+    buybacks AS (
+      SELECT
+        COALESCE(SUM(amount), 0) AS total
+      FROM events
+      WHERE action = 'buyback'
+        AND from_address = '${GACHA_ADDRESS}'
     )
-    SELECT COALESCE(SUM(CASE WHEN action = 'open' THEN usdc ELSE 0 END), 0) AS sale_volume
-    FROM ev
+    SELECT
+      'open' AS action,
+      amount,
+      total
+    FROM pack_sales
+    UNION ALL
+    SELECT
+      'buyback' AS action,
+      NULL AS amount,
+      total
+    FROM buybacks
   `;
 
-  const result = await queryAllium(query);
-  const saleVolume = Number(result[0]);
-  if (saleVolume) dailyVolume.addUSDValue(saleVolume);
+  const rows = await queryAllium(query);
 
-  return { dailyVolume };
+  for (const row of rows) {
+    const total = Number(row.total ?? 0);
+    if (!total) continue;
+
+    if (row.action === "open") {
+      const amount = Number(row.amount);
+      const label = GACHA_TIERS.has(amount)
+        ? `Gacha $${amount} Pack Sales`
+        : "Other Gacha Pack Sales";
+      dailyVolume.addUSDValue(total);
+      dailyFees.addUSDValue(total, label);
+    } else if (row.action === "buyback") {
+      dailyFees.addUSDValue(-total, "Pack Buyback Spends");
+    }
+  }
+
+  return {
+    dailyVolume,
+    dailyFees,
+    dailyRevenue: dailyFees,
+    dailyUserFees: dailyFees,
+    dailyProtocolRevenue: dailyFees,
+    dailyHoldersRevenue: "0",
+  };
 };
 
 const methodology = {
-  Volume: "Gacha pack sales volume on Jupiter's gacha platform.",
+  Volume: "Gross USDC spent on Jupiter Gacha packs.",
+  Fees: "Jupiter Gacha pack sales minus card buyback payouts.",
+  Revenue: "Net pack revenue after card buyback payouts.",
+  UserFees: "Net amount paid by users after card buybacks.",
+  ProtocolRevenue: "Net pack revenue after card buybacks.",
+  HoldersRevenue: "No holders revenue.",
+};
+
+const financialBreakdown = {
+  "Gacha $25 Pack Sales": "Gross sales of Jupiter Gacha packs purchased for $25.",
+  "Gacha $50 Pack Sales": "Gross sales of Jupiter Gacha packs purchased for $50.",
+  "Gacha $100 Pack Sales": "Gross sales of Jupiter Gacha packs purchased for $100.",
+  "Gacha $250 Pack Sales": "Gross sales of Jupiter Gacha packs purchased for $250.",
+  "Gacha $1000 Pack Sales": "Gross sales of Jupiter Gacha packs purchased for $1000.",
+  "Gacha $2500 Pack Sales": "Gross sales of Jupiter Gacha packs purchased for $2500.",
+  "Other Gacha Pack Sales": "Gross sales of Jupiter Gacha packs purchased at other prices.",
+  "Pack Buyback Spends": "USDC paid to users who sell pulled cards back within the buyback window.",
 };
 
 const adapter: SimpleAdapter = {
@@ -65,7 +139,13 @@ const adapter: SimpleAdapter = {
   dependencies: [Dependencies.ALLIUM],
   isExpensiveAdapter: true,
   methodology,
-  doublecounted: true, // collector-crypt
+  breakdownMethodology: {
+    Fees: financialBreakdown,
+    Revenue: financialBreakdown,
+    ProtocolRevenue: financialBreakdown,
+  },
+  allowNegativeValue: true, // hourly buyback payouts can exceed pack sales in the same interval
+  doublecounted: true, // Jupiter Gacha activity overlaps with Collector Crypt
 };
 
 export default adapter;

--- a/dexs/jupiter-gacha/index.ts
+++ b/dexs/jupiter-gacha/index.ts
@@ -103,20 +103,22 @@ const fetch = async (options: FetchOptions) => {
   return {
     dailyVolume,
     dailyFees,
-    dailyRevenue: dailyFees,
+    dailyRevenue: 0,
     dailyUserFees: dailyFees,
-    dailyProtocolRevenue: dailyFees,
-    dailyHoldersRevenue: "0",
+    dailyProtocolRevenue: 0,
+    dailyHoldersRevenue: 0,
+    dailySupplySideRevenue: dailyFees,
   };
 };
 
 const methodology = {
   Volume: "Gross USDC spent on Jupiter Gacha packs.",
   Fees: "Jupiter Gacha pack sales minus card buyback payouts.",
-  Revenue: "Net pack revenue after card buyback payouts.",
+  Revenue: "Jupiter doesn't retain any revenue, all the revenue belongs to Collector Crypt.",
   UserFees: "Net amount paid by users after card buybacks.",
-  ProtocolRevenue: "Net pack revenue after card buybacks.",
+  ProtocolRevenue: "Jupiter doesn't retain any revenue, all the revenue belongs to Collector Crypt.",
   HoldersRevenue: "No holders revenue.",
+  SupplySideRevenue: "All the revenue from pack sales minus buybacks belongs to Collector Crypt."
 };
 
 const financialBreakdown = {
@@ -141,8 +143,8 @@ const adapter: SimpleAdapter = {
   methodology,
   breakdownMethodology: {
     Fees: financialBreakdown,
-    Revenue: financialBreakdown,
-    ProtocolRevenue: financialBreakdown,
+    UserFees: financialBreakdown,
+    SupplySideRevenue: financialBreakdown,
   },
   allowNegativeValue: true, // hourly buyback payouts can exceed pack sales in the same interval
   doublecounted: true, // Jupiter Gacha activity overlaps with Collector Crypt

--- a/fees/collector-crypt/index.ts
+++ b/fees/collector-crypt/index.ts
@@ -195,7 +195,7 @@ const fetch = async (options: FetchOptions) => {
 }
 
 const methodology = {
-  Volume: "Volume from gacha card pack sales, including packs bought on-chain (USDC) and via the CC fiat/credit-card rail.",
+  Volume: "Gacha pack sales across Collector Crypt and integrated storefronts, including Jupiter Gacha, settled onchain or through the CC fiat/credit-card rail.",
   Fees: "Total fees from gacha card pack sales (on-chain and fiat/credit-card) and marketplace transactions, net of gacha pack buybacks.",
   Revenue: "Revenue from gacha sales (on-chain and fiat/credit-card) + marketplace fees/royalties, net of gacha pack buybacks.",
   UserFees: "Total fees paid by users for gacha and marketplace transactions.",


### PR DESCRIPTION
fix jupiter-gacha (volume was 0 due to result parsing bug), add fees/revenue with tier breakdown net of buybacks