### PR TITLE
[add] Quay - volume adapter

### DIFF
--- a/dexs/quay/index.ts
+++ b/dexs/quay/index.ts
@@ -28,8 +28,7 @@ const fetch = async (options: FetchOptions) => {
             inner join swaps s on t.tx_id = s.tx_id
             and t.outer_instruction_index = s.outer_instruction_index
             and t.inner_instruction_index = coalesce(s.inner_instruction_index, -1) + 1
-        where t.block_time >= from_unixtime(${options.startTimestamp})
-        and t.block_time <= from_unixtime(${options.endTimestamp})
+        where TIME_RANGE
     `;
     const data = await queryDuneSql(options, query);
 
@@ -39,6 +38,7 @@ const fetch = async (options: FetchOptions) => {
 };
 
 const adapter: SimpleAdapter = {
+    version: 1,
     fetch,
     dependencies: [Dependencies.DUNE],
     chains: [CHAIN.SOLANA],

--- a/dexs/quay/index.ts
+++ b/dexs/quay/index.ts
@@ -1,0 +1,51 @@
+// Program: QUayE6nexQWYNZAEqfN8FxoNwQDSu3CAzT2qq9J1ArG (Quay Markets)
+// Oracle-quoted MM venue on Solana. Takers swap via the `swap` (0x20) or
+// `agg_swap` (0x21) entrypoints; keeper quote pushes (0x04) and admin/MM
+// instructions carry no taker flow and are excluded by discriminator.
+
+import { Dependencies, FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import { queryDuneSql } from "../../helpers/dune";
+
+const QUAY_PROGRAM = 'QUayE6nexQWYNZAEqfN8FxoNwQDSu3CAzT2qq9J1ArG';
+
+const fetch = async (options: FetchOptions) => {
+    const query = `
+        with swaps as (
+            select
+                tx_id
+                , outer_instruction_index
+                , inner_instruction_index
+            from solana.instruction_calls
+            where executing_account = '${QUAY_PROGRAM}'
+                and bytearray_substring(data, 1, 1) in (0x20, 0x21) -- swap / agg_swap
+                and TIME_RANGE
+                and tx_success = true
+        )
+        select
+            SUM(amount_usd) as daily_volume
+        from tokens_solana.transfers t
+            inner join swaps s on t.tx_id = s.tx_id
+            and t.outer_instruction_index = s.outer_instruction_index
+            and t.inner_instruction_index = coalesce(s.inner_instruction_index, -1) + 1
+        where t.block_time >= from_unixtime(${options.startTimestamp})
+        and t.block_time <= from_unixtime(${options.endTimestamp})
+    `;
+    const data = await queryDuneSql(options, query);
+
+    return {
+        dailyVolume: data[0]?.daily_volume ?? 0
+    };
+};
+
+const adapter: SimpleAdapter = {
+    fetch,
+    dependencies: [Dependencies.DUNE],
+    chains: [CHAIN.SOLANA],
+    start: '2026-07-17',
+    methodology: {
+        Volume: "Sum of the input-leg token transfer (USD) of every successful Quay swap/agg_swap instruction, counted once per swap.",
+    },
+};
+
+export default adapter;

--- a/dexs/quay/index.ts
+++ b/dexs/quay/index.ts
@@ -23,7 +23,7 @@ const fetch = async (options: FetchOptions) => {
                 and tx_success = true
         )
         select
-            SUM(amount_usd) as daily_volume
+            COALESCE(SUM(amount_usd), 0) as daily_volume
         from tokens_solana.transfers t
             inner join swaps s on t.tx_id = s.tx_id
             and t.outer_instruction_index = s.outer_instruction_index
@@ -33,7 +33,7 @@ const fetch = async (options: FetchOptions) => {
     const data = await queryDuneSql(options, query);
 
     return {
-        dailyVolume: data[0]?.daily_volume ?? 0
+        dailyVolume: data[0].daily_volume
     };
 };
 
@@ -46,6 +46,7 @@ const adapter: SimpleAdapter = {
     methodology: {
         Volume: "Sum of the input-leg token transfer (USD) of every successful Quay swap/agg_swap instruction, counted once per swap.",
     },
+    isExpensiveAdapter: true,
 };
 
 export default adapter;


### PR DESCRIPTION
## New listing: Quay

- **Name**: Quay
- **Website**: https://quay.markets
- **Twitter**: https://x.com/quaymarkets
- **Logo**: https://quay.markets/favicon.svg (SVG, vector)
- **Chain**: Solana
- **Category**: Dexs
- **Program**: `QUayE6nexQWYNZAEqfN8FxoNwQDSu3CAzT2qq9J1ArG`
- **Short description**: Multi-maker oracle based DEX on Solana

## Adapter

Dune-based, modeled on `dexs/solfi-v2`:

- Selects successful calls to the Quay program filtered to the two taker entrypoints by discriminator (`0x20` swap, `0x21` agg_swap) — this excludes keeper quote pushes (the bulk of program traffic) and MM vault deposits, so only taker flow is counted.
- Joins each swap to the input-leg token transfer at the next inner-instruction index and sums `amount_usd`, i.e. volume is counted once per swap.
- `start: '2026-07-17'` (first swap).

## Validation

The same SQL runs on Dune and reconciles with an independent transaction-level index of the program (swap counts match exactly; USD within 0.04%):

| UTC day | swaps | volume |
|---|---|---|
| 2026-07-19 | 455 | $38,133 |
| 2026-07-20 | 1,938 | $149,437 |
| 2026-07-21 | 1,412 | $120,562 |
