### PR TITLE
frothswap: track volume and fees (robinhood chain)

### DIFF
--- a/factory/uniV2.ts
+++ b/factory/uniV2.ts
@@ -803,6 +803,13 @@ const configs: Record<string, Record<string, any>> = {
   "giga-dex": {
     [CHAIN.ROBINHOOD]: { factory: "0x6Fdf38f92eAd1adFc04B73aaa947ab254f6c0916", fees: 0.003, stableFees: 0.003, userFeesRatio: 1, revenueRatio: 0.2, protocolRevenueRatio: 0.2, start: "2026-07-15" }
   },
+  "frothswap": {
+    // every pair charges 1.8% on swaps: a fixed 0.3% LP fee plus 1.5% of per-pair
+    // creator/bidwall/FROTH-burn fees (94/95 pairs at 50/50/50 bps, one at 0/0/150,
+    // both sum to 150 bps - read from feeConfig() on all pairs). the burn share is
+    // counted as holders revenue, creator and bidwall stay supply side
+    [CHAIN.ROBINHOOD]: { factory: "0x2B1b1FB977e1CD5f18F45571C64E373b1A73dD7f", fees: 0.018, userFeesRatio: 1, revenueRatio: 50 / 180, protocolRevenueRatio: 0, holdersRevenueRatio: 50 / 180, start: "2026-07-11" }
+  },
 }
 
 const optionsMap: Record<string, any> = {


### PR DESCRIPTION
adds frothswap (95 pairs on robinhood chain, dl already tracks its tvl via the uniswapV2 registry, no dimensions yet) as a uniV2 factory config entry.

the fee model is custom so i read it from the verified contracts instead of assuming 0.3%: every swap pays a fixed 30 bps lp fee plus per-pair creator/bidwall/froth-burn fees from feeConfig(). read feeConfig() on all 95 pairs - 94 are at 50/50/50 bps and one at 0/0/150, so every pair totals exactly 180 bps -> fees: 0.018.

split: the 50 bps froth burn is counted as holders revenue (revenueRatio 50/180, protocolRevenueRatio 0), lp + creator + bidwall stay supply side (creator fees as supply side follows the flaunch precedent).

harness (ran twice, matching): volume 267.9k, fees 4.82k, revenue/holders 1.34k, supply side 3.48k for the last 24h. start date is the factory deploy (2026-07-11).