### PR TITLE
uniswap-v4: price swap legs via the native/core side of the pair

### DIFF
--- a/dexs/uniswap-v4.ts
+++ b/dexs/uniswap-v4.ts
@@ -57,6 +57,7 @@ import { BaseAdapter, FetchOptions, SimpleAdapter } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
 import ADDRESSES from '../helpers/coreAssets.json';
 import { getDefaultDexTokensBlacklisted } from "../helpers/lists";
+import { isCoreAsset } from "../helpers/prices";
 import { formatAddress } from "../utils/utils";
 
 interface IUniswapConfig {
@@ -308,17 +309,23 @@ async function fetch(options: FetchOptions) {
         }
       }
 
+      const blacklistTokens = new Set(getDefaultDexTokensBlacklisted(options.chain))
       for (const event of events) {
         const poolId = String(event.id)
         if (pools[poolId] as IPool) {
-          const blacklistTokens = new Set(getDefaultDexTokensBlacklisted(options.chain))
-          if (blacklistTokens.has(formatAddress((pools[poolId] as IPool).currency0)) || blacklistTokens.has(formatAddress((pools[poolId] as IPool).currency1))) {
+          const { currency0, currency1 } = pools[poolId] as IPool
+          if (blacklistTokens.has(formatAddress(currency0)) || blacklistTokens.has(formatAddress(currency1))) {
             continue;
           }
 
-          const token = (pools[poolId] as IPool).currency0
-          dailyFees.add(token, Math.abs(Number(event.amount0)) * (Number(event.fee) / 1e6))
-          dailyVolume.add(token, Math.abs(Number(event.amount0)))
+          // price via the native coin (currency0 is the zero address in native pools)
+          // or a core asset where possible, so long-tail tokens with thin liquidity
+          // don't set the USD value - same preference addOneToken applies for v2/v3
+          const useToken0 = currency0 === ADDRESSES.null || isCoreAsset(options.chain, currency0) || !isCoreAsset(options.chain, currency1)
+          const token = useToken0 ? currency0 : currency1
+          const amount = Math.abs(Number(useToken0 ? event.amount0 : event.amount1))
+          dailyFees.add(token, amount * (Number(event.fee) / 1e6))
+          dailyVolume.add(token, amount)
         }
       }
     }


### PR DESCRIPTION
Fixes #8242

uniswap-v4 books every swap's volume and fee in currency0, no matter what it is. v2/v3 go through `addOneToken`, which prefers whichever side of the pair is a core asset exactly so that thin long-tail tokens never set the USD value. v4 never got that treatment, and on chains like Robinhood where fresh launches with low addresses sort as currency0 against WETH/USDG, the whole day's fees end up valued at whatever coins thinks the meme is worth.

This switches the v4 swap loop to the same preference: native coin (currency0 is the zero address in native pools) or core asset first, currency1 if it's the core side, and current behavior (currency0) only when neither side is core. Also hoists the blacklist Set out of the per-event loop - it was being rebuilt ~1M times per day on robinhood alone.

Numbers backing this up, all measured against the official robinhood RPC:

- full day 2026-07-22 (blocks 15977411-16839577, 1,047,163 swaps): replaying the current rule off-chain gives $823,745 vs $781,504 in production for that day, so the replay is faithful (~5%, price snapshot timing). Same day, same pools valued via the paired core side instead: PONS drops from $58,742 to $1,019 (58x), CASHCAT $16,494 -> $736 (22x), Index $22,607 -> ~0, TENDIES $7,934 -> ~0. The mispricing nets out to only 0.93x that day, but it's pure luck which direction wins - on 07-16 it went the other way and production booked $5.01M against $1.29M measured on-chain (the 3.9x in the issue).
- under the new rule >99.5% of the day's fee USD flows through native ETH / WETH / USDG instead of long-tail tokens.

Ran the adapter on robinhood with the change: hourly slices come out at $33-82k fees / $6-8.4M volume per hour, consistent with the on-chain measurement above. Note the public robinhood RPC rate-limits hard on getLogs bursts, so a full local day-run needs a paid RPC - same story CI will see for any robinhood log adapter.
