### PR TITLE
Add Tirelire fees adapter (Robinhood Chain)

### DIFF
--- a/fees/tirelire.ts
+++ b/fees/tirelire.ts
@@ -28,6 +28,7 @@
 
 import { FetchOptions, SimpleAdapter } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
+import { METRIC } from "../helpers/metrics";
 
 const HYPERVISORS = [
   "0xb9F974d19425d93B3a9dC80c8f0d3aE428Cbb2B2", // Tirelire USDG-WETH (0.05%)
@@ -39,6 +40,7 @@ const ZERO_BURN = "event ZeroBurn(uint8 fee, uint256 fees0, uint256 fees1)";
 const fetch = async (options: FetchOptions) => {
   const dailyFees = options.createBalances();
   const dailyRevenue = options.createBalances();
+  const dailySupplySideRevenue = options.createBalances();
 
   for (const target of HYPERVISORS) {
     const [token0, token1] = await Promise.all([
@@ -52,11 +54,14 @@ const fetch = async (options: FetchOptions) => {
       const fees1 = BigInt(log.fees1);
       const divisor = BigInt(Number(log.fee) || 1);
 
-      dailyFees.add(token0, fees0);
-      dailyFees.add(token1, fees1);
+      dailyFees.add(token0, fees0, METRIC.SWAP_FEES);
+      dailyFees.add(token1, fees1, METRIC.SWAP_FEES);
       // Integer division mirrors the contract's SafeMath `.div(fee)` cut.
-      dailyRevenue.add(token0, fees0 / divisor);
-      dailyRevenue.add(token1, fees1 / divisor);
+      dailyRevenue.add(token0, fees0 / divisor, "Token Swap Fees to Protocol");
+      dailyRevenue.add(token1, fees1 / divisor, "Token Swap Fees to Protocol");
+
+      dailySupplySideRevenue.add(token0, (fees0-fees0/divisor), "Token Swap Fees to LPs");
+      dailySupplySideRevenue.add(token1, (fees1-fees1/divisor), "Token Swap Fees to LPs");
     }
   }
 
@@ -64,20 +69,41 @@ const fetch = async (options: FetchOptions) => {
     dailyFees,
     dailyRevenue,
     dailyProtocolRevenue: dailyRevenue,
+    dailySupplySideRevenue,
   };
 };
 
+
+const methodology = {
+  Fees: "All Uniswap V3 trading fees collected by the positions each Tirelire Hypervisor manages, summed on-chain from ZeroBurn events.",
+  Revenue: "The 10% performance fee taken from collected trading fees and sent to the protocol treasury (fees / fee, with the divisor read from each ZeroBurn event).",
+  ProtocolRevenue: "Same as Revenue — the 10% performance fee retained by the protocol treasury.",
+  SupplySideRevenue: "The 90% of collected trading fees that are compounded back to LPs.",
+}
+
+const breakdownMethodology = {
+  Fees: {
+    [METRIC.SWAP_FEES]: "All Uniswap V3 trading fees collected by the positions each Tirelire Hypervisor manages, summed on-chain from ZeroBurn events.",
+  },
+  Revenue: {
+    "Token Swap Fees to Protocol": "The 10% performance fee taken from collected trading fees and sent to the protocol treasury (fees / fee, with the divisor read from each ZeroBurn event).",
+  },
+  ProtocolRevenue: {
+    "Token Swap Fees to Protocol": "The 10% performance fee taken from collected trading fees and sent to the protocol treasury (fees / fee, with the divisor read from each ZeroBurn event).",
+  },
+  SupplySideRevenue: {
+    "Token Swap Fees to LPs": "The 90% of collected trading fees that are compounded back to LPs.",
+  },
+}
 const adapter: SimpleAdapter = {
   version: 2,
+  pullHourly: true,
   fetch,
-  adapter: {
-    [CHAIN.ROBINHOOD]: { start: "2026-07-22" }, // flagship deploy date
-  },
-  methodology: {
-    Fees: "All Uniswap V3 trading fees collected by the positions each Tirelire Hypervisor manages, summed on-chain from ZeroBurn events.",
-    Revenue: "The 10% performance fee taken from collected trading fees and sent to the protocol treasury (fees / fee, with the divisor read from each ZeroBurn event).",
-    ProtocolRevenue: "Same as Revenue — the 10% performance fee retained by the protocol treasury.",
-  },
+  chains: [CHAIN.ROBINHOOD],
+  start: "2026-07-22",
+  methodology,
+  breakdownMethodology,
+  doublecounted: true, // uniswap v3
 };
 
 export default adapter;

--- a/fees/tirelire.ts
+++ b/fees/tirelire.ts
@@ -1,0 +1,83 @@
+// Tirelire — Fees & Revenue adapter for DefiLlama dimension-adapters.
+//
+// TARGET PATH IN THE PR: fees/tirelire.ts
+// Repo: https://github.com/DefiLlama/dimension-adapters  (TypeScript)
+//
+// The canonical Gamma fees adapter (fees/gamma.ts) pulls from Gamma's own API
+// (wire2.gamma.xyz), which only covers Hypervisors registered with Gamma's
+// backend. Tirelire is an INDEPENDENT verbatim deployment on Robinhood Chain and
+// is not in that API, so we read fees straight from the chain instead.
+//
+// Fee mechanics (verbatim Gamma Hypervisor.sol `_zeroBurn`):
+//   pool.collect(...) pulls the position's accrued Uniswap V3 trading fees as
+//   (owed0, owed1), then emits:
+//       event ZeroBurn(uint8 fee, uint256 fees0, uint256 fees1)
+//   where fees0/fees1 == owed0/owed1 == the TOTAL fees collected, and the
+//   protocol treasury (feeRecipient) is sent owed{0,1} / fee. Both live vaults
+//   run fee = 10 (a 10% cut), and the divisor is emitted per event, so we read
+//   it from the log rather than hardcoding.
+//
+//   => dailyFees            = Σ (fees0 + fees1)            [all trading fees collected]
+//      dailyRevenue         = Σ (fees0/fee + fees1/fee)    [10% protocol cut]
+//      dailyProtocolRevenue = dailyRevenue                 [all revenue is protocol's]
+//
+// NOTE: fees are collected on-chain only when a position is touched (rebalance /
+// compound / withdraw), not continuously — so daily fees read ~0 on days with no
+// such call and spike on collection days. This is the true, honest fee signal for
+// this design; it is not a bug in the adapter.
+
+import { FetchOptions, SimpleAdapter } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+
+const HYPERVISORS = [
+  "0xb9F974d19425d93B3a9dC80c8f0d3aE428Cbb2B2", // Tirelire USDG-WETH (0.05%)
+  "0xcFefe9Ee6B45587939debB869394190432e72258", // Tirelire USDG-NVDA (0.05%)
+];
+
+const ZERO_BURN = "event ZeroBurn(uint8 fee, uint256 fees0, uint256 fees1)";
+
+const fetch = async (options: FetchOptions) => {
+  const dailyFees = options.createBalances();
+  const dailyRevenue = options.createBalances();
+
+  for (const target of HYPERVISORS) {
+    const [token0, token1] = await Promise.all([
+      options.api.call({ abi: "address:token0", target }),
+      options.api.call({ abi: "address:token1", target }),
+    ]);
+
+    const logs = await options.getLogs({ target, eventAbi: ZERO_BURN });
+    for (const log of logs) {
+      const fees0 = BigInt(log.fees0);
+      const fees1 = BigInt(log.fees1);
+      const divisor = BigInt(Number(log.fee) || 1);
+
+      dailyFees.add(token0, fees0);
+      dailyFees.add(token1, fees1);
+      // Integer division mirrors the contract's SafeMath `.div(fee)` cut.
+      dailyRevenue.add(token0, fees0 / divisor);
+      dailyRevenue.add(token1, fees1 / divisor);
+    }
+  }
+
+  return {
+    dailyFees,
+    dailyRevenue,
+    dailyProtocolRevenue: dailyRevenue,
+  };
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  fetch,
+  adapter: {
+    [CHAIN.ROBINHOOD]: { start: "2026-07-22" }, // flagship deploy date
+  },
+  methodology: {
+    Fees: "All Uniswap V3 trading fees collected by the positions each Tirelire Hypervisor manages, summed on-chain from ZeroBurn events.",
+    Revenue: "The 10% performance fee taken from collected trading fees and sent to the protocol treasury (fees / fee, with the divisor read from each ZeroBurn event).",
+    ProtocolRevenue: "Same as Revenue — the 10% performance fee retained by the protocol treasury.",
+  },
+};
+
+export default adapter;


### PR DESCRIPTION
## Tirelire fees & revenue adapter (Robinhood Chain)

Adds a fees adapter for **Tirelire**, an automated Uniswap V3 liquidity manager (ALM) on **Robinhood Chain** (Arbitrum Orbit L2, chainId 4663 — slug `robinhood`). Tirelire deploys the audited **Gamma Hypervisor** verbatim (config-only) and manages Uniswap V3 positions, auto-compounding trading fees.

### Listing metadata
- **Name:** Tirelire
- **Category:** Liquidity manager
- **Chain:** Robinhood
- **Website:** https://tirelire.xyz
- **Twitter:** https://x.com/TirelireXYZ
- **Explorer:** https://robinhoodchain.blockscout.com

### Methodology
Read fully on-chain from each Hypervisor's `ZeroBurn(uint8 fee, uint256 fees0, uint256 fees1)` event. `fees0/fees1` are the total Uniswap V3 trading fees the position collected; the protocol treasury takes `fees / fee` (both vaults run `fee = 10` → a 10% performance fee; the divisor is read per-event, not hardcoded).

- **Fees** = Σ (fees0 + fees1) — all trading fees collected
- **Revenue / ProtocolRevenue** = Σ (fees0/fee + fees1/fee) — the 10% treasury cut

The canonical Gamma fees adapter (`fees/gamma.ts`) pulls from Gamma's own API, which does not include this independent deployment — hence the on-chain event approach.

Vaults:
- `0xb9F974d19425d93B3a9dC80c8f0d3aE428Cbb2B2` — Tirelire USDG-WETH (0.05%)
- `0xcFefe9Ee6B45587939debB869394190432e72258` — Tirelire USDG-NVDA (0.05%)

### Test
```
$ npm test fees tirelire
ROBINHOOD 👇
Daily fees: 14.00
Daily revenue: 1.41
Daily protocol revenue: 1.41
```
