### PR TITLE
fix: users

### DIFF
--- a/users/routers/routerAddresses.ts
+++ b/users/routers/routerAddresses.ts
@@ -996,6 +996,7 @@ export default (
         polygon_zkevm: ["0x61f4ECD130291e5D5D7809A112f9F9081b8Ed3A5"],
       },
     },
+    // deprecated
     {
       id: "2763",
       name: "Dove Swap",
@@ -1003,6 +1004,7 @@ export default (
         polygon_zkevm: ["0xc4212b4f901C8Afac75A27C8E8be7b9fa82D74d8"],
       },
     },
+    // deprecated
     {
       id: "2762",
       name: "Dove Swap",

--- a/users/utils/blockscoutStats.ts
+++ b/users/utils/blockscoutStats.ts
@@ -15,7 +15,7 @@ type ChainConfig = {
 };
 
 const blockscoutStatsChains: Record<string, ChainConfig> = {
-  ancient8: { chain: CHAIN.ANCIENT8, baseUrl: "https://explorer-ancient8-mainnet-0.t.conduit.xyz", version: 1 },
+  ancient8: { chain: CHAIN.ANCIENT8, baseUrl: "https://explorer-ancient8-mainnet-0.t.conduit.xyz", version: 1, deadFrom: "2026-07-24" },
   apechain: { chain: CHAIN.APECHAIN, baseUrl: "https://apechain.calderaexplorer.xyz", statsUrl: "https://apechain.calderaexplorer.xyz/stats", version: 1 },
   astar: { chain: CHAIN.ASTAR, baseUrl: "https://astar.blockscout.com", version: 2 },
   aurora: { chain: CHAIN.AURORA, baseUrl: "https://aurorascan.dev", version: 2 },
@@ -98,7 +98,9 @@ async function fetchLine(config: ChainConfig, line: string, date: string) {
   const path = config.version === 1 ? "/api/v1/lines" : "/stats-service/api/v1/lines";
   const baseUrl = (config.statsUrl ?? config.baseUrl).replace(/\/$/, "");
   const data = await httpGet(`${baseUrl}${path}/${line}?from=${date}&to=${date}&resolution=DAY`, { headers });
-  return Number(data.chart.find((item: any) => item.date === date).value);
+  const entry = data.chart.find((item: any) => item.date === date);
+  if (!entry) throw new Error(`No Blockscout ${line} data for ${config.chain} on ${date}`);
+  return Number(entry.value);
 }
 
 function getBlockscoutUsers(config: ChainConfig) {


### PR DESCRIPTION
- Improved error handling: adapters now throw a clear per-chain error when a stats chart has no data for the requested day, instead of crashing with `Cannot read properties of undefined (reading 'value')` (seen on ApeChain and EnergyWeb when explorer stats lag).
- Marked **DoveSwap** as deprecated.