### PR TITLE
magicsea-lb: add supply-side + holders revenue split, fix methodology

### DIFF
--- a/dexs/magicsea-lb/index.ts
+++ b/dexs/magicsea-lb/index.ts
@@ -24,6 +24,7 @@ const fetch: any = async ({ getLogs, api, createBalances }: FetchOptions) => {
   const dailyFees = createBalances();
   const dailyRevenue = createBalances();
   const dailySupplySideRevenue = createBalances();
+  const dailyHoldersRevenue = createBalances();
   const lpTokens = await api.fetchList({ lengthAbi: ABIs.getNumberOfLBPairs, itemAbi: ABIs.getLBPairAtIndex, target: FACTORY_ADDRESS })
   const [tokens0, tokens1] = await Promise.all(['address:getTokenX', 'address:getTokenY'].map((abi: string) => api.multiCall({ abi, calls: lpTokens })));
 
@@ -52,6 +53,10 @@ const fetch: any = async ({ getLogs, api, createBalances }: FetchOptions) => {
       // protocol share (<= 25%) is carved out of totalFees; the rest stays with LPs.
       dailyRevenue.add(tokenX, protocolFeesX, METRIC.PROTOCOL_FEES)
       dailyRevenue.add(tokenY, protocolFeesY, METRIC.PROTOCOL_FEES)
+
+      dailyHoldersRevenue.add(tokenX, protocolFeesX, METRIC.STAKING_REWARDS)
+      dailyHoldersRevenue.add(tokenY, protocolFeesY, METRIC.STAKING_REWARDS)
+
       dailySupplySideRevenue.add(tokenX, totalFeesX - protocolFeesX, METRIC.LP_FEES)
       dailySupplySideRevenue.add(tokenY, totalFeesY - protocolFeesY, METRIC.LP_FEES)
     })
@@ -63,7 +68,7 @@ const fetch: any = async ({ getLogs, api, createBalances }: FetchOptions) => {
     dailyUserFees: dailyFees,
     dailyRevenue,
     dailySupplySideRevenue,
-    dailyHoldersRevenue: dailyRevenue,
+    dailyHoldersRevenue,
   };
 }
 
@@ -80,7 +85,7 @@ const breakdownMethodology = {
   UserFees: { [METRIC.SWAP_FEES]: "Total swap fees charged to traders." },
   Revenue: { [METRIC.PROTOCOL_FEES]: "Protocol share of swap fees." },
   SupplySideRevenue: { [METRIC.LP_FEES]: "Swap fees paid to liquidity providers." },
-  HoldersRevenue: { [METRIC.PROTOCOL_FEES]: "Protocol share of swap fees paid to LUM stakers." },
+  HoldersRevenue: { [METRIC.STAKING_REWARDS]: "Protocol share of swap fees paid to LUM stakers." },
 }
 
 const adapter: SimpleAdapter = {

--- a/dexs/magicsea-lb/index.ts
+++ b/dexs/magicsea-lb/index.ts
@@ -1,24 +1,31 @@
 import { FetchOptions, IJSON, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
+import { METRIC } from "../../helpers/metrics";
 import { filterPools } from "../../helpers/uniswap";
 
 const event_swap = 'event Swap(address indexed sender, address indexed to, uint24 id, bytes32 amountsIn, bytes32 amountsOut, uint24 volatilityAccumulator, bytes32 totalFees, bytes32 protocolFees)';
 const FACTORY_ADDRESS = '0x8Cce20D17aB9C6F60574e678ca96711D907fD08c';
 
 type TABI = {
-	[k: string]: string;
+  [k: string]: string;
 }
 const ABIs: TABI = {
-	"getNumberOfLBPairs": "uint256:getNumberOfLBPairs",
-	"getLBPairAtIndex": "function getLBPairAtIndex(uint256 index) view returns (address lbPair)"
+  "getNumberOfLBPairs": "uint256:getNumberOfLBPairs",
+  "getLBPairAtIndex": "function getLBPairAtIndex(uint256 index) view returns (address lbPair)"
 }
 
+// Liquidity Book packs a bytes32 as (amountY << 128) | amountX:
+// left 32 hex chars (most-significant) = tokenY, right 32 = tokenX.
+const decodeY = (bytes: string) => Number('0x' + bytes.replace('0x', '').slice(0, 32));
+const decodeX = (bytes: string) => Number('0x' + bytes.replace('0x', '').slice(32, 64));
+
 const fetch: any = async ({ getLogs, api, createBalances }: FetchOptions) => {
-	const dailyVolume = createBalances();
+  const dailyVolume = createBalances();
   const dailyFees = createBalances();
   const dailyRevenue = createBalances();
-	const lpTokens = await api.fetchList({ lengthAbi: ABIs.getNumberOfLBPairs, itemAbi: ABIs.getLBPairAtIndex, target: FACTORY_ADDRESS })
-	const [tokens0, tokens1] = await Promise.all(['address:getTokenX', 'address:getTokenY'].map((abi: string) => api.multiCall({ abi, calls: lpTokens })));
+  const dailySupplySideRevenue = createBalances();
+  const lpTokens = await api.fetchList({ lengthAbi: ABIs.getNumberOfLBPairs, itemAbi: ABIs.getLBPairAtIndex, target: FACTORY_ADDRESS })
+  const [tokens0, tokens1] = await Promise.all(['address:getTokenX', 'address:getTokenY'].map((abi: string) => api.multiCall({ abi, calls: lpTokens })));
 
 
   const pairObject: IJSON<string[]> = {}
@@ -29,26 +36,51 @@ const fetch: any = async ({ getLogs, api, createBalances }: FetchOptions) => {
   // filter out the pairs with less than 1000 USD pooled value
   const filteredPairs = await filterPools({ api: api, pairs: pairObject, createBalances: createBalances })
   await Promise.all(Object.keys(filteredPairs).map(async (pair) => {
-    const [token0, token1] = pairObject[pair]
+    const [tokenX, tokenY] = pairObject[pair]
     const logs = await getLogs({ target: pair, eventAbi: event_swap })
     logs.forEach(log => {
-			const amountInX = Number('0x' + '0'.repeat(32) + log.amountsOut.replace('0x', '').slice(0, 32))
-			const amountInY = Number('0x' + '0'.repeat(32) + log.amountsOut.replace('0x', '').slice(32, 64))
-			dailyVolume.add(token1, amountInX);
-			dailyVolume.add(token0, amountInY);
+      dailyVolume.add(tokenY, decodeY(log.amountsOut));
+      dailyVolume.add(tokenX, decodeX(log.amountsOut));
 
-      const protocolFeesY = Number('0x' + log.protocolFees.replace('0x', '').slice(0, 32))
-      const protocolFeesX = Number('0x' + log.protocolFees.replace('0x', '').slice(32, 64))
-      const totalFeesY = Number('0x' + log.totalFees.replace('0x', '').slice(0, 32));
-      const totalFeesX = Number('0x' + log.totalFees.replace('0x', '').slice(32, 64));
-      dailyFees.add(token0, totalFeesX )
-      dailyFees.add(token1, totalFeesY )
-      dailyRevenue.add(token0, protocolFeesX)
-      dailyRevenue.add(token1, protocolFeesY)
+      const totalFeesX = decodeX(log.totalFees);
+      const totalFeesY = decodeY(log.totalFees);
+      const protocolFeesX = decodeX(log.protocolFees);
+      const protocolFeesY = decodeY(log.protocolFees);
+
+      dailyFees.add(tokenX, totalFeesX, METRIC.SWAP_FEES)
+      dailyFees.add(tokenY, totalFeesY, METRIC.SWAP_FEES)
+      // protocol share (<= 25%) is carved out of totalFees; the rest stays with LPs.
+      dailyRevenue.add(tokenX, protocolFeesX, METRIC.PROTOCOL_FEES)
+      dailyRevenue.add(tokenY, protocolFeesY, METRIC.PROTOCOL_FEES)
+      dailySupplySideRevenue.add(tokenX, totalFeesX - protocolFeesX, METRIC.LP_FEES)
+      dailySupplySideRevenue.add(tokenY, totalFeesY - protocolFeesY, METRIC.LP_FEES)
     })
   }))
 
-	return { dailyVolume, dailyFees, dailyRevenue,};
+  return {
+    dailyVolume,
+    dailyFees,
+    dailyUserFees: dailyFees,
+    dailyRevenue,
+    dailySupplySideRevenue,
+    dailyHoldersRevenue: dailyRevenue,
+  };
+}
+
+const methodology = {
+  Fees: "Swap fees paid by traders on every swap, ranging from ~0.25% up to a 10% cap depending on the pool and market volatility.",
+  UserFees: "Swap fees paid by traders on every swap.",
+  Revenue: "The protocol share of swap fees (up to 25% of fees).",
+  SupplySideRevenue: "The share of swap fees that stays with liquidity providers (at least 75% of fees).",
+  HoldersRevenue: "The protocol share of swap fees, routed to the Magic LUM staking pool and paid to LUM stakers.",
+}
+
+const breakdownMethodology = {
+  Fees: { [METRIC.SWAP_FEES]: "Total swap fees charged to traders." },
+  UserFees: { [METRIC.SWAP_FEES]: "Total swap fees charged to traders." },
+  Revenue: { [METRIC.PROTOCOL_FEES]: "Protocol share of swap fees." },
+  SupplySideRevenue: { [METRIC.LP_FEES]: "Swap fees paid to liquidity providers." },
+  HoldersRevenue: { [METRIC.PROTOCOL_FEES]: "Protocol share of swap fees paid to LUM stakers." },
 }
 
 const adapter: SimpleAdapter = {
@@ -57,6 +89,8 @@ const adapter: SimpleAdapter = {
   fetch,
   chains: [CHAIN.IOTAEVM],
   start: '2023-04-10',
+  methodology,
+  breakdownMethodology,
 };
 
 export default adapter;


### PR DESCRIPTION
Adds the missing LP/protocol fee split to the MagicSea Liquidity Book (Trader Joe LB v2.2 fork) adapter. Previously, all swap fees were reported as protocol revenue, omitting LP earnings.

### Changes

- Added `dailySupplySideRevenue = totalFees − protocolFees` (LP share, ~75% of swap fees).
- Added `dailyHoldersRevenue = protocolFees`, reflecting MagicSea's distribution of protocol trading fees to LUM stakers.
- Added `methodology` and `breakdownMethodology` for fees, LP revenue, and protocol revenue.


### Verification

- Verified fee accounting against Trader Joe v2 `LBPair.sol`: `totalFees` is gross and includes the protocol fee.
- Confirmed live pools use `protocolShare = 2500` (25%), with sampled swaps matching a 25% protocol / 75% LP split.
