### PR TITLE
bisonfi: add fees adapter

### DIFF
--- a/fees/bisonfi.ts
+++ b/fees/bisonfi.ts
@@ -1,0 +1,66 @@
+import { Dependencies, FetchOptions, SimpleAdapter } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+import { queryDuneSql } from "../helpers/dune";
+
+interface tokenFlow {
+    token: string,
+    amount_bought: number,
+    amount_sold: number
+}
+
+const fetch = async (options: FetchOptions) => {
+    const dailyRevenue = options.createBalances();
+
+    const query = `
+        SELECT
+            token,
+            COALESCE(SUM(amount_sold), 0) AS amount_sold,
+            COALESCE(SUM(amount_bought), 0) AS amount_bought
+        FROM (
+            SELECT
+                token_sold_mint_address AS token,
+                token_sold_amount_raw AS amount_sold,
+                0 AS amount_bought
+            FROM dex_solana.trades
+            WHERE project = 'bisonfi'
+            AND TIME_RANGE
+
+            UNION ALL
+
+            SELECT
+                token_bought_mint_address AS token,
+                0 AS amount_sold,
+                token_bought_amount_raw AS amount_bought
+            FROM dex_solana.trades
+            WHERE project = 'bisonfi'
+            AND TIME_RANGE
+        ) t
+        GROUP BY token
+    `;
+
+    const data = await queryDuneSql(options, query);
+    data.forEach((tokenFlow: tokenFlow) => dailyRevenue.add(tokenFlow.token, tokenFlow.amount_sold - tokenFlow.amount_bought))
+
+    return {
+        dailyFees: dailyRevenue,
+        dailyRevenue,
+        dailyProtocolRevenue: dailyRevenue,
+    };
+};
+
+const adapter: SimpleAdapter = {
+    version: 1,
+    fetch,
+    chains: [CHAIN.SOLANA],
+    start: '2025-12-05',
+    dependencies: [Dependencies.DUNE],
+    isExpensiveAdapter: true,
+    allowNegativeValue: true,
+    methodology: {
+        Fees: "Estimated from BisonFi's net trading flow as a proprietary market maker. Traders swap against BisonFi's own inventory (proprietary capital, no external liquidity providers), so the daily change in that inventory valued at current prices proxies for the spread BisonFi earns on trades.",
+        Revenue: "BisonFi's estimated daily trading PnL based on net inventory change. May diverge from actual net revenue if BisonFi hedges inventory off-chain (CEX hedges, funding costs, etc.).",
+        ProtocolRevenue: "All estimated trading revenue accrues to BisonFi, which trades entirely with its own proprietary capital.",
+    }
+};
+
+export default adapter;


### PR DESCRIPTION
Adds a `fees/bisonfi` adapter for BisonFi, a proprietary Solana AMM that earns revenue from bid/ask spread rather than explicit swap fees.

### Changes

- Added `fees/bisonfi.ts` using `dex_solana.trades` (`project = 'bisonfi'`).
- Estimates fees as the market maker's **daily net inventory change** (`sold − bought` per token, valued in USD), matching the methodology used by `fees/humidifi`.
- Reports `dailyFees = dailyRevenue = dailyProtocolRevenue`, with `allowNegativeValue: true` since inventory PnL can be negative.
- No supply-side revenue, as BisonFi trades against its own inventory rather than external LPs.

### Verification

- Confirmed on-chain that swaps settle directly against BisonFi vaults with **no dedicated fee-recipient account**, making spread capture the appropriate revenue model.
- Independent recomputation matched the adapter within ~1% for the same window.
- Historical tests produced values between **−$1.6k and +$0.8k/day**, consistent with the protocol's very tight spreads.
