### PR TITLE
[fix] squeeze - count fee claims from the multicurve initializer

### DIFF
--- a/fees/squeeze.ts
+++ b/fees/squeeze.ts
@@ -64,10 +64,10 @@ const LABEL_CREATOR = "Creator Fees";
 const LABEL_DOPPLER = "Doppler Protocol Fees";
 const LABEL_LAUNCHLAB_PLATFORM = "LaunchLab Platform Fees";
 
-const chainConfig: Record<
-  string,
-  { start: string; kind: "evm" | "solana"; feeSources?: string[]; feeTokens?: string[] }
-> = {
+type EvmChainConfig = { start: string; kind: "evm"; feeSources: string[]; feeTokens: string[] };
+type SolanaChainConfig = { start: string; kind: "solana" };
+
+const chainConfig: Record<string, EvmChainConfig | SolanaChainConfig> = {
   [CHAIN.BASE]: {
     // Approx. Squeeze Doppler activity window on Base; tighten after first claim-day spot-check.
     // Source: product launch window documented at https://squeeze.run/docs#defillama
@@ -109,6 +109,10 @@ const fetch = async (options: FetchOptions) => {
     // proceeds and 0x affiliate (25 bps) that also land in the same wallet
     // (those must not be grossed up as if they were 47.5% of Doppler pool fees).
     // Note: helper param is historically misspelled `fromAdddesses`.
+    // Fail closed: without a sender filter addTokensReceived would count every
+    // deposit into the wallet (swap proceeds, 0x affiliate) as fee revenue.
+    if (!cfg.feeSources.length || !cfg.feeTokens.length)
+      throw new Error(`squeeze: feeSources/feeTokens not configured for ${options.chain}`);
     const erc20 = await addTokensReceived({
       options,
       target: IDENTITY.evmFeeWallet,

--- a/fees/squeeze.ts
+++ b/fees/squeeze.ts
@@ -3,8 +3,9 @@
  *
  * Methodology (on-chain receipts — Clanker / Flaunch style):
  * - EVM (Base + Robinhood): count numeraire ERC-20s received by the Squeeze
- *   platform wallet **from the chain Airlock** (fee-collect sender). That wallet
- *   is the Airlock `integrator` and the 47.5% swap-fee beneficiary.
+ *   platform wallet **from the Doppler fee contracts** (multicurve initializer
+ *   collectFees payouts + Airlock). That wallet is the Airlock `integrator`
+ *   and the 47.5% swap-fee beneficiary.
  * - Gross pool fees are extrapolated: platform share = 47.5% of pool fees
  *   → dailyFees ≈ dailyRevenue * (100 / 47.5).
  * - Supply-side split of the remaining 52.5%: creator 47.5% + Doppler owner 5%.
@@ -29,10 +30,18 @@ import ADDRESSES from '../helpers/coreAssets.json'
 const IDENTITY = {
   /** Platform fee beneficiary + Doppler Airlock integrator (Base + Robinhood). */
   evmFeeWallet: "0x6C61feE73584670AbEd65101946734006DAB12d6",
-  /** Base Airlock — fee-collect sender + create-path integrator filter. */
+  /** Base Airlock — create-path integrator filter. */
   baseAirlock: "0x660eAaEdEBc968f8f3694354FA8EC0b4c5Ba8D12",
   /** Robinhood Airlock — same role on chain 4663. */
   robinhoodAirlock: "0xeb7c034704ef8dcd2d32324c1545f62fb4ad0862",
+  /**
+   * Doppler UniswapV4MulticurveInitializer — where swap fees are actually
+   * claimed from: the wallet calls collectFees(poolId) on it and receives its
+   * beneficiary share directly (airlock() getter on each ties it to the chain
+   * Airlock above). The Airlock itself never pays the wallet — see #8379.
+   */
+  baseMulticurveInitializer: "0x65de470da664a5be139a5d812be5fda0d76cc951",
+  robinhoodMulticurveInitializer: "0x4e3468951d49f2eea976ed0d6e75ffcb44a9a544",
   /** Raydium LaunchLab platformId for Squeeze-tagged pools. */
   solanaPlatformId: "FpKUW9vDSRPTByNu4MerR2SU4YPkJU9pLWQTnChGAW3h",
   /** LaunchLab claim / platform-admin wallet (platform fee destination). */
@@ -57,14 +66,14 @@ const LABEL_LAUNCHLAB_PLATFORM = "LaunchLab Platform Fees";
 
 const chainConfig: Record<
   string,
-  { start: string; kind: "evm" | "solana"; airlock?: string; feeTokens?: string[] }
+  { start: string; kind: "evm" | "solana"; feeSources?: string[]; feeTokens?: string[] }
 > = {
   [CHAIN.BASE]: {
     // Approx. Squeeze Doppler activity window on Base; tighten after first claim-day spot-check.
     // Source: product launch window documented at https://squeeze.run/docs#defillama
     start: "2025-06-01",
     kind: "evm",
-    airlock: IDENTITY.baseAirlock,
+    feeSources: [IDENTITY.baseAirlock, IDENTITY.baseMulticurveInitializer],
     feeTokens: [ADDRESSES.base.WETH, ADDRESSES.base.USDC]
   },
   [CHAIN.ROBINHOOD]: {
@@ -72,7 +81,7 @@ const chainConfig: Record<
     // Source: DefiLlama robinhood chain listing + Squeeze RH Airlock deploy.
     start: "2026-07-10",
     kind: "evm",
-    airlock: IDENTITY.robinhoodAirlock,
+    feeSources: [IDENTITY.robinhoodAirlock, IDENTITY.robinhoodMulticurveInitializer],
     feeTokens: [
       ADDRESSES.robinhood.WETH,
       ADDRESSES.robinhood.USDG,
@@ -94,16 +103,17 @@ const fetch = async (options: FetchOptions) => {
   const dailySupplySideRevenue = options.createBalances();
 
   if (cfg.kind === "evm") {
-    // Only count numeraire transfers from the chain Airlock → platform wallet.
-    // Excludes unrelated deposits and 0x affiliate (25 bps) that also land in
-    // the same wallet via Squeeze trade proxies (those must not be grossed up
-    // as if they were 47.5% of Doppler pool fees).
+    // Only count numeraire transfers from the Doppler fee contracts → platform
+    // wallet (multicurve initializer collectFees payouts, plus the Airlock for
+    // completeness). Excludes unrelated deposits, the wallet's own swap
+    // proceeds and 0x affiliate (25 bps) that also land in the same wallet
+    // (those must not be grossed up as if they were 47.5% of Doppler pool fees).
     // Note: helper param is historically misspelled `fromAdddesses`.
     const erc20 = await addTokensReceived({
       options,
       target: IDENTITY.evmFeeWallet,
       tokens: cfg.feeTokens,
-      fromAdddesses: cfg.airlock ? [cfg.airlock] : undefined,
+      fromAdddesses: cfg.feeSources,
     });
     dailyRevenue.addBalances(erc20, LABEL_SQUEEZE_PLATFORM);
 
@@ -150,11 +160,11 @@ const fetch = async (options: FetchOptions) => {
 
 const methodology = {
   Fees:
-    "On Base/Robinhood: gross Doppler pool trading fees (2.5%), extrapolated from Squeeze’s 47.5% Airlock→wallet platform receipts. On Solana: LaunchLab *platform* fees claimed to Squeeze’s claim wallet only (not creator/protocol/referral cuts).",
+    "On Base/Robinhood: gross Doppler pool trading fees (2.5%), extrapolated from Squeeze’s 47.5% Doppler fee-collect receipts. On Solana: LaunchLab *platform* fees claimed to Squeeze’s claim wallet only (not creator/protocol/referral cuts).",
   Revenue:
-    "Squeeze platform share — EVM: 47.5% of Doppler swap fees from Airlock collect; Solana: LaunchLab platform fees to the claim wallet.",
+    "Squeeze platform share — EVM: 47.5% of Doppler swap fees claimed via collectFees; Solana: LaunchLab platform fees to the claim wallet.",
   ProtocolRevenue:
-    "Squeeze platform share — EVM: 47.5% of Doppler swap fees from Airlock collect; Solana: LaunchLab platform fees to the claim wallet.",
+    "Squeeze platform share — EVM: 47.5% of Doppler swap fees claimed via collectFees; Solana: LaunchLab platform fees to the claim wallet.",
   SupplySideRevenue:
     "On EVM: extrapolated creator share (47.5%) and Doppler protocol-owner share (5%). On Solana: not attributed in v1 (those cuts never hit the Squeeze claim wallet).",
 };
@@ -162,13 +172,13 @@ const methodology = {
 const breakdownMethodology = {
   Fees: {
     [LABEL_DOPPLER_POOL_FEES]:
-      "EVM only — user-paid Doppler pool trading fees, extrapolated from 47.5% Airlock→platform receipts.",
+      "EVM only — user-paid Doppler pool trading fees, extrapolated from 47.5% Doppler fee-collect receipts.",
     [LABEL_LAUNCHLAB_PLATFORM]:
       "Solana only — LaunchLab platform fee claims to Squeeze’s claim wallet (platform slice, not gross pool fees).",
   },
   Revenue: {
     [LABEL_SQUEEZE_PLATFORM]:
-      "EVM — numeraires received by Squeeze platform wallet from Airlock.",
+      "EVM — numeraires received by Squeeze platform wallet from the Doppler fee contracts.",
     [LABEL_LAUNCHLAB_PLATFORM]:
       "Solana — LaunchLab platform fees received by Squeeze claim wallet.",
   },

--- a/fees/squeeze.ts
+++ b/fees/squeeze.ts
@@ -34,12 +34,6 @@ const IDENTITY = {
   baseAirlock: "0x660eAaEdEBc968f8f3694354FA8EC0b4c5Ba8D12",
   /** Robinhood Airlock — same role on chain 4663. */
   robinhoodAirlock: "0xeb7c034704ef8dcd2d32324c1545f62fb4ad0862",
-  /**
-   * Doppler UniswapV4MulticurveInitializer — where swap fees are actually
-   * claimed from: the wallet calls collectFees(poolId) on it and receives its
-   * beneficiary share directly (airlock() getter on each ties it to the chain
-   * Airlock above). The Airlock itself never pays the wallet — see #8379.
-   */
   baseMulticurveInitializer: "0x65de470da664a5be139a5d812be5fda0d76cc951",
   robinhoodMulticurveInitializer: "0x4e3468951d49f2eea976ed0d6e75ffcb44a9a544",
   /** Raydium LaunchLab platformId for Squeeze-tagged pools. */
@@ -103,14 +97,6 @@ const fetch = async (options: FetchOptions) => {
   const dailySupplySideRevenue = options.createBalances();
 
   if (cfg.kind === "evm") {
-    // Only count configured fee-token transfers from the Doppler fee contracts → platform
-    // wallet (multicurve initializer collectFees payouts, plus the Airlock for
-    // completeness). Excludes unrelated deposits, the wallet's own swap
-    // proceeds and 0x affiliate (25 bps) that also land in the same wallet
-    // (those must not be grossed up as if they were 47.5% of Doppler pool fees).
-    // Note: helper param is historically misspelled `fromAdddesses`.
-    // Fail closed: without a sender filter addTokensReceived would count every
-    // deposit into the wallet (swap proceeds, 0x affiliate) as fee revenue.
     if (!cfg.feeSources.length || !cfg.feeTokens.length)
       throw new Error(`squeeze: feeSources/feeTokens not configured for ${options.chain}`);
     const erc20 = await addTokensReceived({

--- a/fees/squeeze.ts
+++ b/fees/squeeze.ts
@@ -2,7 +2,7 @@
  * DefiLlama fees adapter for Squeeze (https://squeeze.run)
  *
  * Methodology (on-chain receipts — Clanker / Flaunch style):
- * - EVM (Base + Robinhood): count numeraire ERC-20s received by the Squeeze
+ * - EVM (Base + Robinhood): count configured fee-token ERC-20s received by the Squeeze
  *   platform wallet **from the Doppler fee contracts** (multicurve initializer
  *   collectFees payouts + Airlock). That wallet is the Airlock `integrator`
  *   and the 47.5% swap-fee beneficiary.
@@ -103,7 +103,7 @@ const fetch = async (options: FetchOptions) => {
   const dailySupplySideRevenue = options.createBalances();
 
   if (cfg.kind === "evm") {
-    // Only count numeraire transfers from the Doppler fee contracts → platform
+    // Only count configured fee-token transfers from the Doppler fee contracts → platform
     // wallet (multicurve initializer collectFees payouts, plus the Airlock for
     // completeness). Excludes unrelated deposits, the wallet's own swap
     // proceeds and 0x affiliate (25 bps) that also land in the same wallet


### PR DESCRIPTION
fixes #8379

#8379 is right that the airlock never pays the fee wallet. traced where the money actually comes from on robinhood and it's the doppler UniswapV4MulticurveInitializer - the wallet calls collectFees(poolId) on it (selector 0x817db73b, verified sig) and receives its beneficiary share straight from that contract, not from the airlock.

receipts on robinhood (4663):
- the initializer 0x4e3468951d49f2eea976ed0d6e75ffcb44a9a544 has `airlock() = 0xeb7c...0862` (the airlock already configured in this adapter) and `poolManager() = 0x8366...0951` (the v4 pool manager), so it's the doppler deployment wired to the same stack
- 289 transfers initializer -> fee wallet since the jul 10 start date: 15.24 WETH + 26.5M SQUEEZE + dust USDG, all of which the adapter currently reports as $0 because the sender filter only accepts the airlock
- the airlock holds ~nothing itself (0.00018 WETH), so there are no unclaimed fees sitting there either - in the multicurve setup fees just never flow through it
- the other inflows to the wallet are its own swap proceeds (0x allowance holder / universal router txs with the wallet as sender), which is what #8379 saw as "RobinHoodSettler" - those stay excluded, as intended

on base the multicurve initializer is 0x65de470da664a5be139a5d812be5fda0d76cc951 (its `airlock()` matches the configured base airlock too). scanned the last 45 days of transfers into the wallet from airlock / initializer / both streamable fee lockers: zero matches, so base fees look simply unclaimed so far. added the initializer there anyway since that's where claims will land when they happen.

kept the airlock in the filter as well - `fromAdddesses` is a whitelist union so it costs nothing and covers any direct airlock collect path.

test run for 2026-07-24:

```
chain     | Daily fees | Daily revenue | Daily protocol revenue | Daily supply side revenue
base      | 0.00       | 0.00          | 0.00                   | 0.00
robinhood | 2.21 k     | 1.05 k        | 1.05 k                 | 1.16 k

(second run on a 2026-07-23 window: robinhood 2.74k fees / 1.30k revenue, base 0)
```
