### PR TITLE
swaphood-v2: stop dropping swaps where the core asset is the output token

### DIFF
--- a/dexs/swaphood-v2/index.ts
+++ b/dexs/swaphood-v2/index.ts
@@ -245,9 +245,18 @@ const fetch = async (options: FetchOptions): Promise<FetchResult> => {
     const feeMultiplier = info.rawFee.dividedBy(FEE_DENOMINATOR).toNumber();
 
     for (const log of logs) {
+      // addOneToken picks whichever leg is a core asset and ignores swap direction, so the In
+      // amounts on their own are not enough. When the core asset is the token leaving the pair
+      // its In amount is zero, and the swap gets recorded as zero volume and zero fee. Feed the
+      // Out amounts as well, the way helpers/uniswap.ts does for V2 pairs. Exactly one of the
+      // two calls is non zero for any given swap, so nothing is counted twice.
       addOneToken({ chain, balances: dailyVolume, token0: info.token0, token1: info.token1, amount0: log.amount0In, amount1: log.amount1In, });
+      addOneToken({ chain, balances: dailyVolume, token0: info.token0, token1: info.token1, amount0: log.amount0Out, amount1: log.amount1Out, });
 
-      const fee = addOneToken({ chain, balances: dailyFees, token0: info.token0, token1: info.token1, amount0: Number(log.amount0In) * feeMultiplier, amount1: Number(log.amount1In) * feeMultiplier, label: METRIC.SWAP_FEES });
+      const feeFromIn = addOneToken({ chain, balances: dailyFees, token0: info.token0, token1: info.token1, amount0: Number(log.amount0In) * feeMultiplier, amount1: Number(log.amount1In) * feeMultiplier, label: METRIC.SWAP_FEES });
+      const feeFromOut = addOneToken({ chain, balances: dailyFees, token0: info.token0, token1: info.token1, amount0: Number(log.amount0Out) * feeMultiplier, amount1: Number(log.amount1Out) * feeMultiplier, label: METRIC.SWAP_FEES });
+
+      const fee = feeFromIn?.amount ? feeFromIn : feeFromOut;
 
       if (!fee?.amount) continue;
 


### PR DESCRIPTION
Follow up to #8374.

`dexs/swaphood-v2` records zero volume and zero fees for any swap where the core asset is the token leaving the pair. On the two days I sampled that is most of them.

## Cause

The adapter feeds only the `In` legs to `addOneToken`:

```ts
addOneToken({ chain, balances: dailyVolume, token0, token1, amount0: log.amount0In, amount1: log.amount1In })
```

`addOneToken` returns `token0` whenever `token0` is a core asset, and it does that regardless of which direction the swap went. So for a WETH/ALT pair, a swap that sells ALT for WETH has `amount0In = 0`, and the call books WETH with an amount of 0. The fee call right below it has the same shape, so the fee is 0 too, and `allocateFees` then bails on `if (!fee?.amount) continue`. Revenue, protocol revenue, holders revenue and supply side revenue all hang off that fee, so they lose the swap as well.

`helpers/uniswap.ts:124-127` handles this by calling `addOneToken` twice per accumulator, once on the `In` amounts and once on the `Out` amounts. Exactly one of the two is non zero for any given swap, so nothing is double counted. This PR does the same thing in the v2 adapter.

## What it looks like on chain

Pulling the adapter's own filtered pairs and Swap logs, two separate 24h windows:

| window | swaps | counted today | dropped to zero | volume undercount |
|---|---|---|---|---|
| 2026-07-25 | 51 | 14 | 37 (72.5%) | 40.4% |
| 2026-07-20 | 78 | 12 | 66 (84.6%) | 79.0% |

Every dropped swap has the same shape. Example from `0xeA7ba72BE3baaB20546bFdA880b7E285E5a51168`, where `token0` is WETH:

```
a0In = 0
a1In = 11754091878211936179
a0Out = 4689335109440095
a1Out = 0
```

`addOneToken` picks WETH, reads its `In` amount of 0, and the swap contributes nothing. None of the 129 sampled swaps had both `In` legs non zero, so there is no ambiguity about which leg is which.

## Scope

This is independent of the methodology question I raised on #8403. That one is about how the fee gets split between protocol, holders and LPs once it is measured. This one is about the fee and the volume not being measured at all for a swap in one direction. The split logic in `allocateFees` is untouched here, so this is safe to land whichever way that question resolves.

I also left the fee valuation leg alone on purpose. Valuing the fee on the `Out` amount when the core asset is the output token carries the same approximation `helpers/uniswap.ts` already makes for V2 pairs, and changing that is a separate discussion from the zeroing.

Nothing in the sample double counts either. Across all 129 swaps there is not one where the selected token has both a non zero `In` and a non zero `Out`, so the two calls never both fire for the same swap.

## Testing

`npm run test dexs swaphood-v2`, and I could not get a full 24 slot run today. Robinhood's public RPC is the only one that serves this chain and it rate limits, while the Blockscout fallback (`https://robinhoodchain.blockscout.com/api/eth-rpc`) is now returning 429 after a day of use and the primary `https://rpc.mainnet.chain.robinhood.com` answers historical calls with `metadata is not found`.

Being straight about what that leaves. The patched adapter completed the first two slots cleanly before the endpoint cut it off:

```
(1/24) start: 2 PM - 24/07 | volume - 134.00 | fees - 1.34 | user fees - 1.34 | revenue - 1.34 | protocol revenue - 0.07 | holders revenue - 1.27
(2/24) start: 3 PM - 24/07 | volume - 223.00 | fees - 2.23 | user fees - 2.23 | revenue - 2.23 | protocol revenue - 0.11 | holders revenue - 2.12
```

I then stashed the change and ran the identical command against the unmodified adapter, which failed the same way on the same two hosts, so the failure is the RPC and not this patch. The numbers in the table above do not depend on the harness anyway. They come from pulling the adapter's own filtered pairs and Swap logs directly and replaying both code paths over the real logs.
