### PR TITLE
Add hubra-staked-sol fees adapter

### DIFF
--- a/factory/solLst.ts
+++ b/factory/solLst.ts
@@ -646,6 +646,47 @@ const configs: Record<string, SolLstConfig> = {
       ProtocolRevenue: "Revenue going to treasury/team",
     },
   }),
+  
+  "hubra-staked-sol": {
+    stakePoolReserveAccount: "B4puwNbu1fARV4pdcDonreDTXec5JNAiG7MhiVjVRCtx",
+    stakePoolWithdrawAuthority: "Am87irh66UBgzkQUrw2XdUYE6r2XLFfADgmSFdZk2K4r",
+    lstFeeTokenAccount: "9x4pcNGeSuLasataBqdG3fS1gkzTTe8SgZkKAXt3hLm2",
+    lstFeeTokenAccountSwitcher: (startOfDay: number) =>
+      startOfDay < 1760054400
+        ? "2hE6xh1r41WESQZ73FXpsnw5h39GU5W2g692juJgrcY9"
+        : "9x4pcNGeSuLasataBqdG3fS1gkzTTe8SgZkKAXt3hLm2",
+    lstMint: "HUBsveNpjo5pWqNkH57QzxjQASdTVXcSK7bVKTSZtcSX",
+    start: "2024-11-10",
+    fees: { metric: METRIC.STAKING_REWARDS },
+    revenue: { type: "addCGToken", cgId: "solanahub-staked-sol", metric: METRIC.DEPOSIT_WITHDRAW_FEES },
+    revenueFeedback: { addToFees: true, feesMetric: METRIC.DEPOSIT_WITHDRAW_FEES },
+    supplySide: { enabled: true, ratio: 0.975, metric: METRIC.STAKING_REWARDS },
+    stakingRevenue: { enabled: true, ratio: 0.025, metric: METRIC.STAKING_REWARDS },
+    excludeMintsForRevenue: true,
+    methodology: {
+      Fees: "Staking rewards from staked SOL on Hubra staked solana (raSOL), plus withdrawal fees",
+      Revenue: "2.5% epoch fee on staking rewards plus 0.1% withdrawal fees collected by the fee collector",
+      ProtocolRevenue: "Revenue going to treasury/team",
+      SupplySideRevenue: "97.5% of the staking rewards go to stakers",
+    },
+    breakdownMethodology: {
+      Fees: {
+        [METRIC.STAKING_REWARDS]: "Staking rewards from staked SOL on Hubra",
+        [METRIC.DEPOSIT_WITHDRAW_FEES]: "Includes 0.1% withdrawal fee",
+      },
+      Revenue: {
+        [METRIC.STAKING_REWARDS]: "2.5% of the staking rewards are collected as fees",
+        [METRIC.DEPOSIT_WITHDRAW_FEES]: "Includes 0.1% withdrawal fee",
+      },
+      ProtocolRevenue: {
+        [METRIC.STAKING_REWARDS]: "2.5% of the staking rewards are collected as fees",
+        [METRIC.DEPOSIT_WITHDRAW_FEES]: "Includes 0.1% withdrawal fee",
+      },
+      SupplySideRevenue: {
+        [METRIC.STAKING_REWARDS]: "97.5% of the staking rewards are distributed to raSOL",
+      },
+    },
+  },
 
   "jagpool-staked-sol": simpleConfig({
     stakePoolReserveAccount: "jagDaER73YqodaLRGpYMvEjRjVCx962LLebG9QGh11X",


### PR DESCRIPTION
## Summary
Adds fees tracking for Hubra Staked SOL (raSOL) via the Solana LST factory, with a fee-account switcher for the 2025-10-10 manager wallet handover.
https://docs.hubra.app/
https://defillama.com/protocol/hubra-staked-sol