### PR TITLE
Add Mantle chain to Apex Omni perps adapter

### DIFF
--- a/dexs/apex-omni/index.ts
+++ b/dexs/apex-omni/index.ts
@@ -51,7 +51,7 @@ const fetch = async (options: FetchOptions) => {
 
 const adapter: SimpleAdapter = {
     fetch,
-    chains: [CHAIN.ETHEREUM],
+    chains: [CHAIN.ETHEREUM, CHAIN.MANTLE],
     start: '2024-06-14',
 };
 


### PR DESCRIPTION
## Change
Add CHAIN.MANTLE to Apex Omni perps adapter chains list.

## Verification
Apex Omni's API (https://omni.apex.exchange/api/v3/all-open-tickers) returns
MNTUSDT trading pair with .3M daily volume. The adapter fetches all tickers
regardless of chain, so adding MANTLE will correctly attribute MNT-denominated
perps volume to Mantle.

## Current situation
- Mantle perps volume on DefiLlama: $0
- SYMMIO already has a Mantle adapter - may need data refresh
- KTX Perps still needs a separate adapter