### PR TITLE
[add] hoodfrens - fees and volume adapter on Robinhood Chain

### DIFF
--- a/dexs/hoodfrens/index.ts
+++ b/dexs/hoodfrens/index.ts
@@ -86,14 +86,13 @@ const fetch = async (options: FetchOptions) => {
     const dailyProtocolRevenue = options.createBalances();
     const dailySupplySideRevenue = options.createBalances();
 
-    const [tradeLogs, referralLogs, prizeLogs, creatorPaidLogs, creatorAccruedLogs] =
-        await Promise.all([
-            options.getLogs({ target: TRADING_CONTRACT, eventAbi: TRADE_EVENT_ABI }),
-            options.getLogs({ target: TRADING_CONTRACT, eventAbi: REFERRAL_FEE_PAID_ABI }),
-            options.getLogs({ target: TRADING_CONTRACT, eventAbi: ETH_PRIZE_DEPOSITED_ABI }),
-            options.getLogs({ target: TRADING_CONTRACT, eventAbi: CREATOR_FEE_PAID_ABI }),
-            options.getLogs({ target: TRADING_CONTRACT, eventAbi: CREATOR_FEE_ACCRUED_ABI }),
-        ]);
+    // Sequential on purpose: the public Robinhood RPC rate-limits bursts
+    // (parallel getLogs from CI runners intermittently 429s).
+    const tradeLogs = await options.getLogs({ target: TRADING_CONTRACT, eventAbi: TRADE_EVENT_ABI });
+    const referralLogs = await options.getLogs({ target: TRADING_CONTRACT, eventAbi: REFERRAL_FEE_PAID_ABI });
+    const prizeLogs = await options.getLogs({ target: TRADING_CONTRACT, eventAbi: ETH_PRIZE_DEPOSITED_ABI });
+    const creatorPaidLogs = await options.getLogs({ target: TRADING_CONTRACT, eventAbi: CREATOR_FEE_PAID_ABI });
+    const creatorAccruedLogs = await options.getLogs({ target: TRADING_CONTRACT, eventAbi: CREATOR_FEE_ACCRUED_ABI });
 
     for (const log of tradeLogs) {
         // Buy:  priceInWei is gross (includes IPO fees when active)

--- a/dexs/hoodfrens/index.ts
+++ b/dexs/hoodfrens/index.ts
@@ -1,0 +1,226 @@
+import { FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import { METRIC } from "../../helpers/metrics";
+
+// hoodfrens is a creator-fee fork of the audited TopStrike bonding-curve
+// contract, running on Robinhood Chain (chainId 4663). This adapter mirrors
+// the sibling `dexs/topstrike/index.ts` and adds one supply-side line the
+// upstream contract does not have: the creator fee (a configurable share of
+// each sell; 3.4% at launch, adjustable by the owner via setCreatorFee).
+const TRADING_CONTRACT = "0xA50AdeC47FcCBDe24B0214A831d3BDde4A1E0106";
+
+// Pack shop — Thirdweb DropERC1155 (Edition Drop) on Robinhood Chain. Its
+// TokensClaimed event and getClaimConditionById return tuple match the ABIs
+// below exactly (checked against the Blockscout-verified implementation ABI,
+// 2026-07-25; sales priced in native ETH — currency is the 0xEee… sentinel the
+// claim block maps to the gas token). getLogs returns nothing on days without a
+// claim, so the pack-sales path is a no-op until packs actually sell.
+const PACKSHOP_CONTRACT = "0x3647b90F769B473E7bCf3267D030E009705fd99D";
+
+const TRADE_EVENT_ABI =
+    "event Trade(address indexed trader, uint256 indexed playerId, bool isBuy, uint256 amountInUnits, uint256 priceInWei, uint256 feeInWei, uint256 newSupplyInUnits, bool isIPOWindow)";
+
+const REFERRAL_FEE_PAID_ABI =
+    "event ReferralFeePaid(address indexed referrer, address indexed user, uint256 amountInWei)";
+
+const ETH_PRIZE_DEPOSITED_ABI =
+    "event EthPrizeDeposited(uint256 amountInWei)";
+
+// Creator fee (hoodfrens-only vs TopStrike). Each sell routes the creator fee
+// (3.4% at launch, owner-configurable via setCreatorFee) to the card's
+// creator: paid straight to a registered wallet (CreatorFeePaid) or
+// accrued on-chain when no wallet is bound yet (CreatorFeeAccrued). Both fire
+// exactly once per fee-generating sell, so summing the two captures every
+// creator fee generated on the day's trades. CreatorFeesClaimed is
+// deliberately NOT used — it only moves already-accrued fees out and would
+// double-count against CreatorFeeAccrued.
+const CREATOR_FEE_PAID_ABI =
+    "event CreatorFeePaid(uint256 indexed playerId, address indexed wallet, uint256 amountInWei)";
+
+const CREATOR_FEE_ACCRUED_ABI =
+    "event CreatorFeeAccrued(uint256 indexed playerId, uint256 amountInWei)";
+
+// Thirdweb DropERC1155 pack shop. TokensClaimed carries quantity but not
+// price — we look up pricePerToken via getClaimConditionById for each
+// unique (tokenId, claimConditionIndex) pair seen in the day's logs.
+const TOKENS_CLAIMED_ABI =
+    "event TokensClaimed(uint256 indexed claimConditionIndex, address indexed claimer, address indexed receiver, uint256 tokenId, uint256 quantityClaimed)";
+
+const GET_CLAIM_CONDITION_ABI =
+    "function getClaimConditionById(uint256 _tokenId, uint256 _conditionId) view returns ((uint256 startTimestamp, uint256 maxClaimableSupply, uint256 supplyClaimed, uint256 quantityLimitPerWallet, bytes32 merkleRoot, uint256 pricePerToken, address currency, string metadata) condition)";
+
+const NATIVE_ETH = "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee";
+const NULL_ADDRESS = "0x0000000000000000000000000000000000000000";
+
+// Trade.feeInWei carries the total user-paid fee on every fee-generating path
+// (IPO buy + all sells): the contract builds it as
+//   feeInWei = toPrize + toProtocol + toReferrer + toCreator
+// UserSharesChanged.totalFeesInWei is emitted 1:1 with each Trade and carries
+// the same value, so summing Trade.feeInWei captures all fees without
+// double-counting.
+//
+// Fee flow (sell):
+//   fees = prizePool + protocolTreasury + referrer(optional) + creator
+// Events used for the supply-side split:
+//   EthPrizeDeposited              -> prize pool inflow (holders revenue)
+//   ReferralFeePaid                -> actual referrer payouts (supply-side)
+//     (if the referrer transfer fails the amount is redirected to protocol and
+//      ReferralFeeRedirectedToProtocol is emitted instead — correctly excluded)
+//   CreatorFeePaid + CreatorFeeAccrued -> creator payouts (supply-side)
+//   Protocol treasury              -> fees - prize - referral - creator
+// The referral fee is carved OUT of the protocol's cut (seller pays nothing
+// extra), so it must not be added on top of fees — it is a redistribution of
+// fees already counted, exactly like prize and creator.
+//
+// Pack shop primary mints have no holder/referral/creator split: the full sale
+// value flows to the primary sale recipient (protocol treasury), so we book
+// pack sales under dailyFees with the 'Pack Sales' label and they fall through
+// to dailyRevenue via the existing fees − supplySide derivation.
+
+const fetch = async (options: FetchOptions) => {
+    const dailyVolume = options.createBalances();
+    const dailyFees = options.createBalances();
+    const dailyRevenue = options.createBalances();
+    const dailySupplySideRevenue = options.createBalances();
+
+    const [tradeLogs, referralLogs, prizeLogs, creatorPaidLogs, creatorAccruedLogs] =
+        await Promise.all([
+            options.getLogs({ target: TRADING_CONTRACT, eventAbi: TRADE_EVENT_ABI }),
+            options.getLogs({ target: TRADING_CONTRACT, eventAbi: REFERRAL_FEE_PAID_ABI }),
+            options.getLogs({ target: TRADING_CONTRACT, eventAbi: ETH_PRIZE_DEPOSITED_ABI }),
+            options.getLogs({ target: TRADING_CONTRACT, eventAbi: CREATOR_FEE_PAID_ABI }),
+            options.getLogs({ target: TRADING_CONTRACT, eventAbi: CREATOR_FEE_ACCRUED_ABI }),
+        ]);
+
+    for (const log of tradeLogs) {
+        // Buy:  priceInWei is gross (includes IPO fees when active)
+        // Sell: priceInWei is net; gross = priceInWei + feeInWei
+        const fee = log.feeInWei;
+        const grossVolume = log.isBuy ? log.priceInWei : log.priceInWei + fee;
+        dailyVolume.addGasToken(grossVolume);
+        dailyFees.addGasToken(fee, METRIC.TRADING_FEES);
+    }
+
+    for (const log of referralLogs) {
+        dailySupplySideRevenue.addGasToken(log.amountInWei, 'Referral Rewards');
+    }
+
+    for (const log of prizeLogs) {
+        dailySupplySideRevenue.addGasToken(log.amountInWei, 'Prize Pool Rewards');
+    }
+
+    for (const log of creatorPaidLogs) {
+        dailySupplySideRevenue.addGasToken(log.amountInWei, METRIC.CREATOR_FEES);
+    }
+
+    for (const log of creatorAccruedLogs) {
+        dailySupplySideRevenue.addGasToken(log.amountInWei, METRIC.CREATOR_FEES);
+    }
+
+    if (PACKSHOP_CONTRACT) {
+        const claimLogs = await options.getLogs({
+            target: PACKSHOP_CONTRACT,
+            eventAbi: TOKENS_CLAIMED_ABI,
+        });
+
+        if (claimLogs.length > 0) {
+            // Dedupe (tokenId, conditionIndex) pairs before resolving prices —
+            // many claims share the same active condition during a window.
+            const pairKey = (tokenId: any, conditionId: any) =>
+                `${tokenId.toString()}-${conditionId.toString()}`;
+            const uniquePairs = new Map<string, { tokenId: any; conditionId: any }>();
+            for (const log of claimLogs) {
+                const key = pairKey(log.tokenId, log.claimConditionIndex);
+                if (!uniquePairs.has(key)) {
+                    uniquePairs.set(key, {
+                        tokenId: log.tokenId,
+                        conditionId: log.claimConditionIndex,
+                    });
+                }
+            }
+            const pairs = [...uniquePairs.values()];
+            const conditions = await options.api.multiCall({
+                target: PACKSHOP_CONTRACT,
+                abi: GET_CLAIM_CONDITION_ABI,
+                calls: pairs.map((p) => ({ params: [p.tokenId, p.conditionId] })),
+                permitFailure: true,
+            });
+
+            const priceByPair = new Map<string, { price: bigint; currency: string }>();
+            pairs.forEach((p, i) => {
+                const c = conditions[i];
+                if (!c) return;
+                priceByPair.set(pairKey(p.tokenId, p.conditionId), {
+                    price: BigInt(c.pricePerToken),
+                    currency: String(c.currency).toLowerCase(),
+                });
+            });
+
+            for (const log of claimLogs) {
+                const cond = priceByPair.get(pairKey(log.tokenId, log.claimConditionIndex));
+                if (!cond) continue;
+                if (cond.currency === NATIVE_ETH) cond.currency = NULL_ADDRESS;
+                const paid = cond.price * BigInt(log.quantityClaimed);
+                if (paid === 0n) continue;
+                dailyVolume.add(cond.currency, paid);
+                dailyFees.add(cond.currency, paid, 'Pack Sales');
+            }
+        }
+    }
+
+    const revenue = await dailyFees.getUSDValue() - await dailySupplySideRevenue.getUSDValue();
+    dailyRevenue.addUSDValue(revenue, METRIC.PROTOCOL_FEES);
+
+    return {
+        dailyVolume,
+        dailyFees,
+        dailyUserFees: dailyFees,
+        dailyRevenue,
+        dailyProtocolRevenue: dailyRevenue,
+        dailySupplySideRevenue,
+    };
+};
+
+const methodology = {
+    Volume: "Gross ETH traded on card buys/sells plus pack shop primary mint sales",
+    Fees: "Trading fees on buy/sell plus the full value of pack shop primary mints (no holder/creator split on packs)",
+    UserFees: "Total ETH paid by users — trading fees plus pack shop purchase prices",
+    Revenue: "Part of fees retained by the protocol (trading fees minus prize/referral/creator payouts, plus 100% of pack sales)",
+    ProtocolRevenue: "All the revenue goes to the protocol",
+    SupplySideRevenue: "Referral rewards, prize pool rewards, and creator rewards (trading only — packs do not split)",
+};
+
+const breakdownMethodology = {
+    Fees: {
+        [METRIC.TRADING_FEES]: "Trading fees paid by users",
+        'Pack Sales': "Pack shop primary mints — full sale value accrues to the protocol",
+    },
+    UserFees: {
+        [METRIC.TRADING_FEES]: "Trading fees paid by users",
+        'Pack Sales': "Pack shop primary mints — full sale value accrues to the protocol",
+    },
+    Revenue: {
+        [METRIC.PROTOCOL_FEES]: "Part of fees retained by the protocol",
+    },
+    ProtocolRevenue: {
+        [METRIC.PROTOCOL_FEES]: "All the revenue goes to the protocol",
+    },
+    SupplySideRevenue: {
+        'Referral Rewards': "Referral rewards paid to referrers",
+        'Prize Pool Rewards': "Prize pool rewards paid to users holding fractional shares of creator cards",
+        [METRIC.CREATOR_FEES]: "Creator fees paid to the card's creator — a configurable share of each sell",
+    },
+};
+
+const adapter: SimpleAdapter = {
+    version: 2,
+    pullHourly: true,
+    fetch,
+    chains: [CHAIN.ROBINHOOD],
+    start: "2026-07-11", // contract deploy block 7003890
+    methodology,
+    breakdownMethodology,
+    allowNegativeValue: true, // direct prize deposits + prize/referral/creator payouts can exceed same-window fees
+};
+
+export default adapter;

--- a/dexs/hoodfrens/index.ts
+++ b/dexs/hoodfrens/index.ts
@@ -176,11 +176,15 @@ const fetch = async (options: FetchOptions) => {
 
     // Revenue = fees kept in-protocol: everything not paid out to referrers or
     // creators (i.e. protocol treasury + the prize pool that goes to holders).
+    // Split revenue by DESTINATION (not fee source): the protocol's own cut vs
+    // the prize pool that flows to card holders (a subset of revenue). Revenue
+    // metrics use destination labels; fee-source labels stay on dailyFees.
     const revenue = await dailyFees.getUSDValue() - await dailySupplySideRevenue.getUSDValue();
-    dailyRevenue.addUSDValue(revenue, METRIC.PROTOCOL_FEES);
-    // Protocol's own cut = revenue minus the holders' share (the prize pool).
     const holders = await dailyHoldersRevenue.getUSDValue();
-    dailyProtocolRevenue.addUSDValue(revenue - holders, METRIC.PROTOCOL_FEES);
+    const protocolCut = revenue - holders;
+    dailyRevenue.addUSDValue(protocolCut, 'Protocol Revenue');
+    dailyRevenue.addUSDValue(holders, 'Prize Pool Rewards');
+    dailyProtocolRevenue.addUSDValue(protocolCut, 'Protocol Revenue');
 
     return {
         dailyVolume,
@@ -217,10 +221,11 @@ const breakdownMethodology = {
         'Pack Sales': "Pack shop primary mints — full sale value accrues to the protocol",
     },
     Revenue: {
-        [METRIC.PROTOCOL_FEES]: "Fees retained in-protocol (protocol treasury + prize pool), plus pack sales",
+        'Protocol Revenue': "The protocol's own retained cut (treasury + 100% of pack sales)",
+        'Prize Pool Rewards': "Prize pool paid to card holders — a subset of revenue",
     },
     ProtocolRevenue: {
-        [METRIC.PROTOCOL_FEES]: "The protocol's own cut after the holders' prize-pool share",
+        'Protocol Revenue': "The protocol's own cut after the holders' prize-pool share",
     },
     HoldersRevenue: {
         'Prize Pool Rewards': "Prize pool rewards paid to users holding fractional shares of creator cards",

--- a/dexs/hoodfrens/index.ts
+++ b/dexs/hoodfrens/index.ts
@@ -81,6 +81,8 @@ const fetch = async (options: FetchOptions) => {
     const dailyVolume = options.createBalances();
     const dailyFees = options.createBalances();
     const dailyRevenue = options.createBalances();
+    const dailyProtocolRevenue = options.createBalances();
+    const dailyHoldersRevenue = options.createBalances();
     const dailySupplySideRevenue = options.createBalances();
 
     const [tradeLogs, referralLogs, prizeLogs, creatorPaidLogs, creatorAccruedLogs] =
@@ -97,7 +99,7 @@ const fetch = async (options: FetchOptions) => {
         // Sell: priceInWei is net; gross = priceInWei + feeInWei
         const fee = log.feeInWei;
         const grossVolume = log.isBuy ? log.priceInWei : log.priceInWei + fee;
-        dailyVolume.addGasToken(grossVolume);
+        dailyVolume.addGasToken(grossVolume, 'Trading Volume');
         dailyFees.addGasToken(fee, METRIC.TRADING_FEES);
     }
 
@@ -105,8 +107,10 @@ const fetch = async (options: FetchOptions) => {
         dailySupplySideRevenue.addGasToken(log.amountInWei, 'Referral Rewards');
     }
 
+    // Prize pool is distributed to users holding fractional shares of creator
+    // cards — holders revenue (a subset of revenue), not supply-side.
     for (const log of prizeLogs) {
-        dailySupplySideRevenue.addGasToken(log.amountInWei, 'Prize Pool Rewards');
+        dailyHoldersRevenue.addGasToken(log.amountInWei, 'Prize Pool Rewards');
     }
 
     for (const log of creatorPaidLogs) {
@@ -139,17 +143,19 @@ const fetch = async (options: FetchOptions) => {
                 }
             }
             const pairs = [...uniquePairs.values()];
+            // No permitFailure: a claim log always carries a claimConditionIndex
+            // that existed at claim time, so an unresolved condition means a bad
+            // read, not a real state. Fail loudly rather than under-report packs.
             const conditions = await options.api.multiCall({
                 target: PACKSHOP_CONTRACT,
                 abi: GET_CLAIM_CONDITION_ABI,
                 calls: pairs.map((p) => ({ params: [p.tokenId, p.conditionId] })),
-                permitFailure: true,
             });
 
             const priceByPair = new Map<string, { price: bigint; currency: string }>();
             pairs.forEach((p, i) => {
                 const c = conditions[i];
-                if (!c) return;
+                if (!c) throw new Error(`hoodfrens: unresolved pack claim condition (token ${p.tokenId}, index ${p.conditionId})`);
                 priceByPair.set(pairKey(p.tokenId, p.conditionId), {
                     price: BigInt(c.pricePerToken),
                     currency: String(c.currency).toLowerCase(),
@@ -158,25 +164,31 @@ const fetch = async (options: FetchOptions) => {
 
             for (const log of claimLogs) {
                 const cond = priceByPair.get(pairKey(log.tokenId, log.claimConditionIndex));
-                if (!cond) continue;
+                if (!cond) throw new Error(`hoodfrens: missing price for pack claim (token ${log.tokenId}, index ${log.claimConditionIndex})`);
                 if (cond.currency === NATIVE_ETH) cond.currency = NULL_ADDRESS;
                 const paid = cond.price * BigInt(log.quantityClaimed);
                 if (paid === 0n) continue;
-                dailyVolume.add(cond.currency, paid);
+                dailyVolume.add(cond.currency, paid, 'Pack Sales');
                 dailyFees.add(cond.currency, paid, 'Pack Sales');
             }
         }
     }
 
+    // Revenue = fees kept in-protocol: everything not paid out to referrers or
+    // creators (i.e. protocol treasury + the prize pool that goes to holders).
     const revenue = await dailyFees.getUSDValue() - await dailySupplySideRevenue.getUSDValue();
     dailyRevenue.addUSDValue(revenue, METRIC.PROTOCOL_FEES);
+    // Protocol's own cut = revenue minus the holders' share (the prize pool).
+    const holders = await dailyHoldersRevenue.getUSDValue();
+    dailyProtocolRevenue.addUSDValue(revenue - holders, METRIC.PROTOCOL_FEES);
 
     return {
         dailyVolume,
         dailyFees,
         dailyUserFees: dailyFees,
         dailyRevenue,
-        dailyProtocolRevenue: dailyRevenue,
+        dailyProtocolRevenue,
+        dailyHoldersRevenue,
         dailySupplySideRevenue,
     };
 };
@@ -185,12 +197,17 @@ const methodology = {
     Volume: "Gross ETH traded on card buys/sells plus pack shop primary mint sales",
     Fees: "Trading fees on buy/sell plus the full value of pack shop primary mints (no holder/creator split on packs)",
     UserFees: "Total ETH paid by users — trading fees plus pack shop purchase prices",
-    Revenue: "Part of fees retained by the protocol (trading fees minus prize/referral/creator payouts, plus 100% of pack sales)",
-    ProtocolRevenue: "All the revenue goes to the protocol",
-    SupplySideRevenue: "Referral rewards, prize pool rewards, and creator rewards (trading only — packs do not split)",
+    Revenue: "Fees retained in-protocol — protocol treasury plus the prize pool paid to card holders, plus 100% of pack sales (excludes referral/creator payouts)",
+    ProtocolRevenue: "The protocol's own cut — revenue minus the prize pool distributed to holders",
+    HoldersRevenue: "Prize pool distributed to users holding fractional shares of creator cards",
+    SupplySideRevenue: "Referral rewards and creator rewards (trading only — packs do not split)",
 };
 
 const breakdownMethodology = {
+    Volume: {
+        'Trading Volume': "Gross ETH traded on card buys/sells",
+        'Pack Sales': "Pack shop primary mints — quantity × claim-condition price",
+    },
     Fees: {
         [METRIC.TRADING_FEES]: "Trading fees paid by users",
         'Pack Sales': "Pack shop primary mints — full sale value accrues to the protocol",
@@ -200,14 +217,16 @@ const breakdownMethodology = {
         'Pack Sales': "Pack shop primary mints — full sale value accrues to the protocol",
     },
     Revenue: {
-        [METRIC.PROTOCOL_FEES]: "Part of fees retained by the protocol",
+        [METRIC.PROTOCOL_FEES]: "Fees retained in-protocol (protocol treasury + prize pool), plus pack sales",
     },
     ProtocolRevenue: {
-        [METRIC.PROTOCOL_FEES]: "All the revenue goes to the protocol",
+        [METRIC.PROTOCOL_FEES]: "The protocol's own cut after the holders' prize-pool share",
+    },
+    HoldersRevenue: {
+        'Prize Pool Rewards': "Prize pool rewards paid to users holding fractional shares of creator cards",
     },
     SupplySideRevenue: {
         'Referral Rewards': "Referral rewards paid to referrers",
-        'Prize Pool Rewards': "Prize pool rewards paid to users holding fractional shares of creator cards",
         [METRIC.CREATOR_FEES]: "Creator fees paid to the card's creator — a configurable share of each sell",
     },
 };
@@ -220,7 +239,7 @@ const adapter: SimpleAdapter = {
     start: "2026-07-11", // contract deploy block 7003890
     methodology,
     breakdownMethodology,
-    allowNegativeValue: true, // direct prize deposits + prize/referral/creator payouts can exceed same-window fees
+    allowNegativeValue: true, // direct prize deposits (holders revenue) can exceed the day's protocol cut → negative protocol revenue
 };
 
 export default adapter;

--- a/dexs/hoodfrens/index.ts
+++ b/dexs/hoodfrens/index.ts
@@ -62,7 +62,8 @@ const NULL_ADDRESS = "0x0000000000000000000000000000000000000000";
 // Fee flow (sell):
 //   fees = prizePool + protocolTreasury + referrer(optional) + creator
 // Events used for the supply-side split:
-//   EthPrizeDeposited              -> prize pool inflow (holders revenue)
+//   EthPrizeDeposited              -> prize pool paid out to card holders (supply-side —
+//     card holders are not governance token holders, so this is NOT holders revenue)
 //   ReferralFeePaid                -> actual referrer payouts (supply-side)
 //     (if the referrer transfer fails the amount is redirected to protocol and
 //      ReferralFeeRedirectedToProtocol is emitted instead — correctly excluded)
@@ -72,17 +73,17 @@ const NULL_ADDRESS = "0x0000000000000000000000000000000000000000";
 // extra), so it must not be added on top of fees — it is a redistribution of
 // fees already counted, exactly like prize and creator.
 //
-// Pack shop primary mints have no holder/referral/creator split: the full sale
-// value flows to the primary sale recipient (protocol treasury), so we book
-// pack sales under dailyFees with the 'Pack Sales' label and they fall through
-// to dailyRevenue via the existing fees − supplySide derivation.
+// Pack shop primary mints are counted as VOLUME only, not fees: mint proceeds
+// are sale revenue, not a fee charged on top of a trade, and the card
+// inventory that backs each pack is bought on the bonding curve up-front —
+// those buys already appear in Trading Volume / Trading Fees, so booking the
+// full mint value as fees would overstate the protocol's take.
 
 const fetch = async (options: FetchOptions) => {
     const dailyVolume = options.createBalances();
     const dailyFees = options.createBalances();
     const dailyRevenue = options.createBalances();
     const dailyProtocolRevenue = options.createBalances();
-    const dailyHoldersRevenue = options.createBalances();
     const dailySupplySideRevenue = options.createBalances();
 
     const [tradeLogs, referralLogs, prizeLogs, creatorPaidLogs, creatorAccruedLogs] =
@@ -108,9 +109,10 @@ const fetch = async (options: FetchOptions) => {
     }
 
     // Prize pool is distributed to users holding fractional shares of creator
-    // cards — holders revenue (a subset of revenue), not supply-side.
+    // cards. Card holders are not governance token holders, so per DefiLlama
+    // guidance this is supply-side revenue, not holders revenue.
     for (const log of prizeLogs) {
-        dailyHoldersRevenue.addGasToken(log.amountInWei, 'Prize Pool Rewards');
+        dailySupplySideRevenue.addGasToken(log.amountInWei, 'Prize Pool Rewards');
     }
 
     for (const log of creatorPaidLogs) {
@@ -168,22 +170,17 @@ const fetch = async (options: FetchOptions) => {
                 if (cond.currency === NATIVE_ETH) cond.currency = NULL_ADDRESS;
                 const paid = cond.price * BigInt(log.quantityClaimed);
                 if (paid === 0n) continue;
+                // Volume only — mint proceeds are not fees (see header comment).
                 dailyVolume.add(cond.currency, paid, 'Pack Sales');
-                dailyFees.add(cond.currency, paid, 'Pack Sales');
             }
         }
     }
 
-    // Revenue = fees kept in-protocol: everything not paid out to referrers or
-    // creators (i.e. protocol treasury + the prize pool that goes to holders).
-    // Split revenue by DESTINATION (not fee source): the protocol's own cut vs
-    // the prize pool that flows to card holders (a subset of revenue). Revenue
-    // metrics use destination labels; fee-source labels stay on dailyFees.
-    const revenue = await dailyFees.getUSDValue() - await dailySupplySideRevenue.getUSDValue();
-    const holders = await dailyHoldersRevenue.getUSDValue();
-    const protocolCut = revenue - holders;
+    // Revenue = the protocol treasury's retained cut: fees minus everything
+    // redistributed (prize pool to card holders, referrers, creators). Revenue
+    // metrics use a destination label; fee-source labels stay on dailyFees.
+    const protocolCut = await dailyFees.getUSDValue() - await dailySupplySideRevenue.getUSDValue();
     dailyRevenue.addUSDValue(protocolCut, 'Protocol Revenue');
-    dailyRevenue.addUSDValue(holders, 'Prize Pool Rewards');
     dailyProtocolRevenue.addUSDValue(protocolCut, 'Protocol Revenue');
 
     return {
@@ -192,19 +189,17 @@ const fetch = async (options: FetchOptions) => {
         dailyUserFees: dailyFees,
         dailyRevenue,
         dailyProtocolRevenue,
-        dailyHoldersRevenue,
         dailySupplySideRevenue,
     };
 };
 
 const methodology = {
     Volume: "Gross ETH traded on card buys/sells plus pack shop primary mint sales",
-    Fees: "Trading fees on buy/sell plus the full value of pack shop primary mints (no holder/creator split on packs)",
-    UserFees: "Total ETH paid by users — trading fees plus pack shop purchase prices",
-    Revenue: "Fees retained in-protocol — protocol treasury plus the prize pool paid to card holders, plus 100% of pack sales (excludes referral/creator payouts)",
-    ProtocolRevenue: "The protocol's own cut — revenue minus the prize pool distributed to holders",
-    HoldersRevenue: "Prize pool distributed to users holding fractional shares of creator cards",
-    SupplySideRevenue: "Referral rewards and creator rewards (trading only — packs do not split)",
+    Fees: "Trading fees paid by users on card buys/sells (pack primary-mint proceeds are counted as volume, not fees)",
+    UserFees: "Trading fees paid by users on card buys/sells",
+    Revenue: "Trading fees retained by the protocol treasury — fees minus the prize-pool, referral, and creator payouts",
+    ProtocolRevenue: "Same as Revenue — the protocol treasury's retained cut of trading fees",
+    SupplySideRevenue: "Prize-pool rewards distributed to card holders, referral rewards, and creator rewards",
 };
 
 const breakdownMethodology = {
@@ -214,23 +209,18 @@ const breakdownMethodology = {
     },
     Fees: {
         [METRIC.TRADING_FEES]: "Trading fees paid by users",
-        'Pack Sales': "Pack shop primary mints — full sale value accrues to the protocol",
     },
     UserFees: {
         [METRIC.TRADING_FEES]: "Trading fees paid by users",
-        'Pack Sales': "Pack shop primary mints — full sale value accrues to the protocol",
     },
     Revenue: {
-        'Protocol Revenue': "The protocol's own retained cut (treasury + 100% of pack sales)",
-        'Prize Pool Rewards': "Prize pool paid to card holders — a subset of revenue",
+        'Protocol Revenue': "The protocol treasury's retained cut of trading fees",
     },
     ProtocolRevenue: {
-        'Protocol Revenue': "The protocol's own cut after the holders' prize-pool share",
-    },
-    HoldersRevenue: {
-        'Prize Pool Rewards': "Prize pool rewards paid to users holding fractional shares of creator cards",
+        'Protocol Revenue': "The protocol treasury's retained cut of trading fees",
     },
     SupplySideRevenue: {
+        'Prize Pool Rewards': "Prize pool distributed to users holding fractional shares of creator cards",
         'Referral Rewards': "Referral rewards paid to referrers",
         [METRIC.CREATOR_FEES]: "Creator fees paid to the card's creator — a configurable share of each sell",
     },
@@ -244,7 +234,7 @@ const adapter: SimpleAdapter = {
     start: "2026-07-11", // contract deploy block 7003890
     methodology,
     breakdownMethodology,
-    allowNegativeValue: true, // direct prize deposits (holders revenue) can exceed the day's protocol cut → negative protocol revenue
+    allowNegativeValue: true, // direct prize deposits (supply-side, no matching trade fee) can exceed the day's fees → negative revenue
 };
 
 export default adapter;


### PR DESCRIPTION
**Name:** hoodfrens
**Website:** https://hoodfrens.xyz (app: https://app.hoodfrens.xyz)
**Category:** Gaming
**Chain:** Robinhood Chain (chainId 4663)
**Twitter:** https://x.com/HoodFrens

## hoodfrens

A fees + volume adapter for **hoodfrens** — creator-card bonding-curve trading on **Robinhood Chain**. hoodfrens runs a creator-fee fork of the same audited contract behind TopStrike, so **this adapter is a clone of the existing [`dexs/topstrike`](https://github.com/DefiLlama/dimension-adapters/blob/master/dexs/topstrike/index.ts) adapter**, with the differences below.

**Contracts:** trading `0xA50AdeC47FcCBDe24B0214A831d3BDde4A1E0106`, pack shop `0x3647b90F769B473E7bCf3267D030E009705fd99D` · **start:** 2026-07-11

### Changes vs the TopStrike adapter
1. **New fee category — creator fees.** Each sell routes a share to the card's creator, emitted as `CreatorFeePaid`/`CreatorFeeAccrued`, summed into `dailySupplySideRevenue` under `METRIC.CREATOR_FEES`. Already inside `Trade.feeInWei`, so it only re-attributes.
2. **Different chain** — `CHAIN.ROBINHOOD` (4663) instead of MegaETH.
3. **Different pack-shop contract, denominated in native ETH.** Own Thirdweb `DropERC1155` (`0x3647…d99D`); same `TokensClaimed` → `getClaimConditionById` mechanism, priced in native ETH (mapped to the gas token) rather than a USD stablecoin (USDM) as on TopStrike.

### Methodology
- **Volume** — gross ETH on card buys/sells (`Trading Volume`) + pack-shop primary mints (`Pack Sales`)
- **Fees / UserFees** — `Trade.feeInWei` (per-trade total) + full pack-mint value
- **HoldersRevenue** — prize pool (`EthPrizeDeposited`), distributed to users holding fractional shares of creator cards
- **SupplySideRevenue** — referral (`ReferralFeePaid`) + creator (`CreatorFeePaid` + `CreatorFeeAccrued`) payouts
- **Revenue** — fees − supply-side (protocol treasury + prize pool + 100% of pack sales)
- **ProtocolRevenue** — revenue − holders (the protocol's own cut)

### Addressed from CodeRabbit review
- Prize-pool rewards now booked as `dailyHoldersRevenue` (was supply-side), so the income statement splits protocol vs holders.
- Pack claim-condition lookups no longer use `permitFailure`; an unresolved condition throws rather than silently dropping packs.
- Both volume streams labeled (`Trading Volume` / `Pack Sales`) with matching `breakdownMethodology.Volume`.

Tested with `npx ts-node cli/testAdapter.ts dexs hoodfrens` — non-zero volume/fees, income statement balances (fees = revenue + supply-side; revenue = protocol + holders), pack sales and creator-fee lines populate.
