### PR TITLE
Add fee tracking to Tinyman adapter

### DIFF
--- a/dexs/tinyman/index.ts
+++ b/dexs/tinyman/index.ts
@@ -1,6 +1,7 @@
 import fetchURL from "../../utils/fetchURL"
-import type { SimpleAdapter } from "../../adapters/types";
+import type { FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
+import { METRIC } from "../../helpers/metrics";
 
 const URL = "https://mainnet.analytics.tinyman.org/api/v1/general-statistics/"
 
@@ -16,20 +17,42 @@ interface IAPIResponse {
   last_day_algo_price_change: string;
 };
 
-const fetch = async () => {
+const fetch = async (options: FetchOptions) => {
   const response: IAPIResponse = (await fetchURL(URL));
   const dailyVolume = Number(response.last_day_total_volume_in_usd);
 
-  const dailyFees = dailyVolume * TOTAL_FEE;
+  const dailyFees = options.createBalances();
+  const dailyRevenue = options.createBalances();
+  const dailySupplySideRevenue = options.createBalances();
+
+  dailyFees.addUSDValue(dailyVolume * TOTAL_FEE, METRIC.SWAP_FEES);
+  dailyRevenue.addUSDValue(dailyVolume * PROTOCOL_FEE, "Token Swap Fees to Protocol");
+  dailySupplySideRevenue.addUSDValue(dailyVolume * LP_FEE, "Token Swap Fees to LPs");
+
   return {
     dailyVolume,
     dailyFees,
     dailyUserFees: dailyFees,
-    dailyRevenue: dailyVolume * PROTOCOL_FEE,
-    dailyProtocolRevenue: dailyVolume * PROTOCOL_FEE,
-    dailySupplySideRevenue: dailyVolume * LP_FEE,
+    dailyRevenue,
+    dailyProtocolRevenue: dailyRevenue,
+    dailySupplySideRevenue,
   };
 };
+
+const breakdownMethodology = {
+  Fees: {
+    [METRIC.SWAP_FEES]: "0.3% fee charged on every swap.",
+  },
+  Revenue: {
+    "Token Swap Fees to Protocol": "1/6 of swap fees (0.05%) sent to the Tinyman Treasury.",
+  },
+  ProtocolRevenue: {
+    "Token Swap Fees to Protocol": "1/6 of swap fees (0.05%) sent to the Tinyman Treasury.",
+  },
+  SupplySideRevenue: {
+    "Token Swap Fees to LPs": "5/6 of swap fees (0.25%) distributed to liquidity providers.",
+  }
+}
 
 const adapter: SimpleAdapter = {
   fetch,
@@ -42,6 +65,7 @@ const adapter: SimpleAdapter = {
     ProtocolRevenue: "1/6 of swap fees (0.05%) sent to the Tinyman Treasury.",
     SupplySideRevenue: "5/6 of swap fees (0.25%) distributed to liquidity providers.",
   },
+  breakdownMethodology,
 };
 
 export default adapter;

--- a/dexs/tinyman/index.ts
+++ b/dexs/tinyman/index.ts
@@ -1,8 +1,14 @@
 import fetchURL from "../../utils/fetchURL"
-import type { SimpleAdapter, FetchOptions } from "../../adapters/types";
+import type { SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 
 const URL = "https://mainnet.analytics.tinyman.org/api/v1/general-statistics/"
+
+// https://docs.tinyman.org/tinyman-v1/fees
+// 0.3% total swap fee: 5/6 (0.25%) to LPs, 1/6 (0.05%) to Tinyman Treasury
+const TOTAL_FEE = 0.003;
+const LP_FEE = 0.0025;
+const PROTOCOL_FEE = 0.0005;
 
 interface IAPIResponse {
   total_liquidity_in_usd: string;
@@ -10,10 +16,18 @@ interface IAPIResponse {
   last_day_algo_price_change: string;
 };
 
-const fetch = async (options: FetchOptions) => {
+const fetch = async () => {
   const response: IAPIResponse = (await fetchURL(URL));
+  const dailyVolume = Number(response.last_day_total_volume_in_usd);
+
+  const dailyFees = dailyVolume * TOTAL_FEE;
   return {
-    dailyVolume: `${response.last_day_total_volume_in_usd}`,
+    dailyVolume,
+    dailyFees,
+    dailyUserFees: dailyFees,
+    dailyRevenue: dailyVolume * PROTOCOL_FEE,
+    dailyProtocolRevenue: dailyVolume * PROTOCOL_FEE,
+    dailySupplySideRevenue: dailyVolume * LP_FEE,
   };
 };
 
@@ -21,6 +35,13 @@ const adapter: SimpleAdapter = {
   fetch,
   chains: [CHAIN.ALGORAND],
   runAtCurrTime: true,
+  methodology: {
+    Fees: "0.3% fee charged on every swap.",
+    UserFees: "0.3% fee paid by traders on every swap.",
+    Revenue: "1/6 of swap fees (0.05%) sent to the Tinyman Treasury.",
+    ProtocolRevenue: "1/6 of swap fees (0.05%) sent to the Tinyman Treasury.",
+    SupplySideRevenue: "5/6 of swap fees (0.25%) distributed to liquidity providers.",
+  },
 };
 
 export default adapter;


### PR DESCRIPTION
## Summary
Adds fee tracking to the existing Tinyman DEX adapter by computing daily fees from the last_day_total_volume_in_usd field already returned by the Tinyman analytics API. The 0.3% total swap fee is split per the [Tinyman fee docs](https://docs.tinyman.org/tinyman-v1/fees): 5/6 (0.25%) goes to liquidity providers as dailySupplySideRevenue and 1/6 (0.05%) goes to the Tinyman Treasury as dailyRevenue/dailyProtocolRevenue.
https://defillama.com/protocol/tinyman