### PR TITLE
fix(bullet-perp): match actual contractType values so volume isn't 0

### DIFF
--- a/dexs/bullet-perp/index.ts
+++ b/dexs/bullet-perp/index.ts
@@ -12,7 +12,7 @@ async function fetch(_: any) {
 
   const perpSymbols = new Set<string>(
     exchangeInfo.symbols
-      .filter((s: any) => s.contractType === "Perp")
+      .filter((s: any) => s.contractType.includes("Perp"))
       .map((s: any) => s.symbol)
   );
 


### PR DESCRIPTION
Bullet perp volume has been reporting **0** on DefiLlama since the adapter was added in #6575.

### Root cause

The adapter builds its symbol allowlist by filtering `exchangeInfo` on an exact string match:

```ts
.filter((s: any) => s.contractType === "Perp")
```

The Bullet API never returns the bare string `"Perp"`. The live values across all 16 listed markets are:

| `contractType` | count |
| --- | --- |
| `CryptoPerp` | 8 |
| `RwaPerpUsEquity` | 4 |
| `RwaPerpCommodities` | 3 |
| `RwaPerpKrEquity` | 1 |

So `perpSymbols` is always an empty `Set`, the ticker `.filter()` drops every row, and `.reduce(…, 0)` returns its seed. That yields `dailyVolume: 0` cleanly with no thrown error, which is why this surfaced as zero volume rather than as a broken adapter.

`open-interest/bullet.ts`, added in the same PR, doesn't reference `contractType` and has been reporting correctly throughout — confirming this is the filter, not connectivity.

### Fix

Substring match instead of exact match. All 16 markets are perps today, so the filter is currently a no-op either way, but keeping it means the adapter stays correct if spot or dated futures are listed later.

### Verification

Ran against the live API on this branch:

```
BEFORE (master):  Daily volume: 0.00
AFTER  (fix):     Daily volume: 3.87 M
```

The 3.87 M total matches Bullet's own UI, which displays the same `quoteVolume` field the adapter reads — spot-checked per market (LIT-PERP $20,567 and TAO-PERP $8,197 match to the dollar; the rest agree within snapshot drift). `npm run ts-check` reports no new type errors.