### PR TITLE
factory/curators: add Monad to Hyperithm

### DIFF
--- a/factory/curators.ts
+++ b/factory/curators.ts
@@ -150,11 +150,17 @@ const configs: Record<string, CuratorConfig> = {
         start: '2025-12-22'
       },
       [CHAIN.MONAD]: {
+        // Morpho V2 initialOwners, read from the indexed `owner` topic of CreateVaultV2 on factory
+        // 0x8B2F922162FBb60A6a072cC784A2E4168fB0bb0c (not owner(), which has since moved to 0xEe7E...18C8):
+        //   0xC56E...40fD — "hyperUSDCa" (0x7899...F371, fee 0%), "satUSDC" (0x7575...C079, fee 8%), "hyperAUSDd" (0x024C...9614, dust)
+        //   0x9B97...dAa8 — "hypercbBTCa" (0xe09A...8Ea0, fee 10%)
+        // all four curated by 0x75178137D3B4B9A0F771E0e149b00fB8167BA325, which Morpho's curator registry
+        // returns as Hyperithm on chainId 143, the same address it lists for chainIds 1 / 42161 / 747474
         morphoVaultV2Owners: [
           '0xC56EA16EA06B0a6A7b3B03B2f48751e549bE40fD',
           '0x9B97783B747c51b39c3d320050dc9C512868dAa8',
         ],
-        start: '2025-12-23',
+        start: '2025-12-23', // hyperAUSDd creation, earliest of the four
       },
     },
   },

--- a/factory/curators.ts
+++ b/factory/curators.ts
@@ -149,6 +149,13 @@ const configs: Record<string, CuratorConfig> = {
         morphoVaultV2Owners: ['0xC56EA16EA06B0a6A7b3B03B2f48751e549bE40fD'],
         start: '2025-12-22'
       },
+      [CHAIN.MONAD]: {
+        morphoVaultV2Owners: [
+          '0xC56EA16EA06B0a6A7b3B03B2f48751e549bE40fD',
+          '0x9B97783B747c51b39c3d320050dc9C512868dAa8',
+        ],
+        start: '2025-12-23',
+      },
     },
   },
   "keyring": {

--- a/factory/curators.ts
+++ b/factory/curators.ts
@@ -150,12 +150,6 @@ const configs: Record<string, CuratorConfig> = {
         start: '2025-12-22'
       },
       [CHAIN.MONAD]: {
-        // Morpho V2 initialOwners, read from the indexed `owner` topic of CreateVaultV2 on factory
-        // 0x8B2F922162FBb60A6a072cC784A2E4168fB0bb0c (not owner(), which has since moved to 0xEe7E...18C8):
-        //   0xC56E...40fD — "hyperUSDCa" (0x7899...F371, fee 0%), "satUSDC" (0x7575...C079, fee 8%), "hyperAUSDd" (0x024C...9614, dust)
-        //   0x9B97...dAa8 — "hypercbBTCa" (0xe09A...8Ea0, fee 10%)
-        // all four curated by 0x75178137D3B4B9A0F771E0e149b00fB8167BA325, which Morpho's curator registry
-        // returns as Hyperithm on chainId 143, the same address it lists for chainIds 1 / 42161 / 747474
         morphoVaultV2Owners: [
           '0xC56EA16EA06B0a6A7b3B03B2f48751e549bE40fD',
           '0x9B97783B747c51b39c3d320050dc9C512868dAa8',


### PR DESCRIPTION
## Summary

Hyperithm curates three sized Morpho **V2** vaults on Monad worth **$53.08M** combined. `factory/curators.ts` has no Monad entry for Hyperithm, so none of that yield or performance fee is attributed to any curator today. This adds the chain with the two `initialOwner` addresses that actually deployed those vaults.

This is not a missed bug in #7203. That PR was scoped to Morpho **V1.1** coverage, and its call to treat Hyperithm/Monad as dormant at $25 was correct for V1.1 vaults, which are still dust today (`hyperUSDCa` V1 `0xA8665084...` is $23, the other two are $1 and $0). The Monad exposure sits in Morpho V2 vaults, which were outside that PR's scope. The deployment #7203 correctly treated as dormant has since grown into a real position.

## Vaults picked up

Morpho V2 factory `0x8B2F922162FBb60A6a072cC784A2E4168fB0bb0c`, all curated by `0x75178137D3B4B9A0F771E0e149b00fB8167BA325`.

| Vault | Address | initialOwner | On-chain totalAssets | USD | perfFee |
|---|---|---|---:|---:|---:|
| hyperUSDCa | `0x78999cc96d2Ba0341588C60CcB0E91c6C33CF371` | `0xC56EA16E...` | 39,785,463.024938 USDC | $39.78M | 0% |
| satUSDC | `0x75753e494e5e374C52E1d84fc04EB14B10F2C079` | `0xC56EA16E...` | 7,737,400.657531 USDC | $7.74M | 8% |
| hypercbBTCa | `0xe09A93786275546690247d70f1767cF0b69e8Ea0` | `0x9B97783B...` | 86.49953284 cbBTC | $5.56M | 10% |
| hyperAUSDd | `0x024C304307cd4Aa63C28C082512c87c0452C9614` | `0xC56EA16E...` | 0.1 AUSD | dust | 0% |

`start: '2025-12-23'` is hyperAUSDd's creation date, the earliest of the four.

## How the addresses were confirmed as Hyperithm's

Two independent sources, not name matching:

1. Morpho's own curator registry (`curators` query on blue-api) returns **Hyperithm** for curator `0x75178137D3B4B9A0F771E0e149b00fB8167BA325` on chainId **143**, and returns the same address for chainIds 1 / 42161 / 747474, which are exactly the Ethereum / Arbitrum / Katana entries already in this config.
2. `initialOwner` read from the indexed `owner` topic of the `CreateVaultV2` event at each vault's creation block. Both values, `0xC56EA16EA06B0a6A7b3B03B2f48751e549bE40fD` and `0x9B97783B747c51b39c3d320050dc9C512868dAa8`, resolve to addresses already used for Hyperithm elsewhere in DefiLlama (the first is already in this file on Ethereum/Arbitrum/Katana; the second is Hyperithm's Monad/Katana/Stable owner in the TVL adapter).

`initialOwner` is what `getMorphoVaultsV2` filters on, so that is the value that was checked, not the current `owner()` (which is `0xEe7E9bb2...`, also registered to Hyperithm).

Monad's public RPC caps `eth_getLogs` at a 100-block range, so the creation events were read at the exact creation block of each vault rather than by scanning from the factory's `fromBlock`.

## Test

`npm run test fees hyperithm`, window 25-26 Jul 2026:

```
chain     | Daily fees | Daily revenue | Daily protocol revenue | Daily supply side revenue
ethereum  | 4.36 k     | 404.00        | 404.00                 | 3.95 k
arbitrum  | 42.00      | 4.18          | 4.18                   | 38.00
katana    | 0.00       | 0.00          | 0.00                   | 0.00
monad     | 9.63 k     | 94.00         | 94.00                  | 9.53 k
Aggregate | 14.03 k    | 502.18        | 502.18                 | 13.53 k
```

Monad's $9.63k/day annualises to 6.6% on $53.08M, which is in range for these vaults. Revenue is only $94/day because the largest vault by far, hyperUSDCa at $39.78M, runs a 0% performance fee; the fee-charging revenue comes from satUSDC (8%) and hypercbBTCa (10%).

Cross-checked against Morpho's own reported APYs as an independent estimate: implied gross $8,978/day and implied revenue $102/day, vs the adapter's $9,630 and $94. Within 7-8%, which is what I would expect given Morpho publishes a spot rate while the adapter measures realised share-price growth across the window.

`npx tsc --project tsconfig.json` is clean.

## Double-count check

- Neither owner address appears under any other curator in `factory/curators.ts`. `0x9B97783B...` appears nowhere else in the repo.
- None of the three sized vault addresses are referenced anywhere in the repo today.
- `MorphoConfigs[CHAIN.MONAD].vaultV2Factories` already exists, so no helper change is needed.

## Deliberately left out, flagging for a maintainer

Hyperithm also has Euler vaults on Monad. The Euler factory `0xba4Dd672062dE8FeeDb665DD4410658864483f1E` has 7 proxies with `creator() == 0x594c5eE5a326295FF6212C31BB3311747D3bD562` (Hyperithm's `eulerVaultOwners` in the TVL adapter), but 5 of them are empty and the funded ones total only about $1.3M with 0.5 cbBTC borrowed.

I did not add `eulerVaultOwners` here because attribution is ambiguous: the largest of them, `ecbBTC-4` `0x19CE855d819B2a753d4CEcfFff9dCAac721f1FbB`, was created by that address but its `governorAdmin` is `0xdE9014cEbbfe9575B321cbE0197Dce2D1f3Eb9A8`, not Hyperithm's. Since `getEulerVaults` filters on `creator()`, adding the owner would book that vault's fees to Hyperithm even though governance has moved elsewhere. Happy to add it if you consider creator-based attribution correct there.

Morpho V1.1 vaults on Monad under Hyperithm are also left out, still dust, consistent with the dormancy convention in #7203.

Out of scope for this framework entirely: Hyperithm's Monad TVL is ~$155M, of which the ~$95M in the Accountable delta-neutral vaults (`aHYPER`, `aHyperBTC`) and Midas `mHYPER` is not a Morpho or Euler vault, so the curator helper cannot read it.
