### PR TITLE
openeden-t-bills: fix ProcessDeposit event signature, transaction fees have read zero since 2024-12-20

### DIFF
--- a/fees/openeden-t-bills/index.ts
+++ b/fees/openeden-t-bills/index.ts
@@ -7,17 +7,30 @@ import { getTokenSupply } from '../../helpers/solana';
 import { rpcCall } from '../../helpers/ripple';
 import { METRIC } from "../../helpers/metrics";
 
-const eventAbi = `event ProcessDeposit(
-  address sender,
-  address receiver,
-  uint256 assets,
-  uint256 shares,
-  uint256 oeFee,
-  int256 pFee,
-  uint256 totalFee,
-  address oplTreasury,
-  address treasury
-)`;
+// The vault is a proxy and ProcessDeposit has had three shapes. Each one has a
+// different topic0, so all three have to be queried to cover the full history
+// back to the adapter's start date. A log carries exactly one topic0, so the
+// three result sets are disjoint and cannot double count.
+//
+//   V2  2023-10-18 to 2024-02-15  single txFee field at index 4
+//   V3  2024-02-15 to 2024-12-20  oeFee/pFee/totalFee, pFee unsigned
+//   V4+ 2024-12-20 onwards        same fields, pFee signed
+//
+// feeIndex points at the fee the contract actually transfers to oplTreasury.
+const depositEvents = [
+  {
+    abi: `event ProcessDeposit(address sender, address receiver, uint256 assets, uint256 shares, uint256 oeFee, int256 pFee, uint256 totalFee, address oplTreasury, address treasury)`,
+    feeIndex: 6,
+  },
+  {
+    abi: `event ProcessDeposit(address sender, address receiver, uint256 assets, uint256 shares, uint256 oeFee, uint256 pFee, uint256 totalFee, address oplTreasury, address treasury)`,
+    feeIndex: 6,
+  },
+  {
+    abi: `event ProcessDeposit(address sender, address receiver, uint256 assets, uint256 shares, uint256 txFee, address oplTreasury, address treasury)`,
+    feeIndex: 4,
+  },
+];
 
 const CHAIN_CONFIGS: any = {
   [CHAIN.ETHEREUM]: "0xdd50C053C096CB04A3e3362E2b622529EC5f2e8a",
@@ -54,19 +67,21 @@ const fetch = async (
   } else if (chain === CHAIN.SOLANA) {
     dailyFees.addUSDValue((await getTokenSupply(config)) * DAILY_MANAGEMENT_FEES, METRIC.MANAGEMENT_FEES)
   } else {
-    let [logs, totalUSDC] = await Promise.all([
-      getLogs({ target: config, eventAbi }),
+    const [logSets, totalUSDC] = await Promise.all([
+      Promise.all(depositEvents.map(({ abi }) => getLogs({ target: config, eventAbi: abi }))),
       api.call({ target: config, abi: "uint256:totalAssets" }),
     ]);
 
     dailyFees.add(ADDRESSES[api.chain].USDC, totalUSDC * DAILY_MANAGEMENT_FEES, METRIC.MANAGEMENT_FEES);
 
-    logs.forEach((log) => {
-      // totalFee is the amount actually transferred to oplTreasury. oeFee is the
-      // pre-rebate gross figure and is often much larger than what is collected,
-      // because a negative partnership fee (pFee) can cancel it out entirely.
-      const feeAmount = log[6];
-      dailyFees.add(ADDRESSES[api.chain].USDC, feeAmount, "Transaction Fees");
+    logSets.forEach((logs, i) => {
+      // Count the fee the contract actually transfers to oplTreasury, not oeFee.
+      // oeFee is the gross figure before the partnership adjustment, so on the
+      // V4+ shape a negative pFee can leave oeFee large while nothing is collected.
+      const { feeIndex } = depositEvents[i];
+      logs.forEach((log: any) => {
+        dailyFees.add(ADDRESSES[api.chain].USDC, log[feeIndex], "Transaction Fees");
+      });
     });
   }
 
@@ -76,24 +91,24 @@ const fetch = async (
 const breakdownMethodology = {
   Fees: {
     [METRIC.MANAGEMENT_FEES]: 'Management fee of 0.30% per annum accrued daily on assets under management.',
-    "Transaction Fees": 'Transaction fee actually collected on subscriptions (the totalFee routed to oplTreasury). Base rate is 5 basis points, reduced or waived by a negative partnership fee where one applies.',
+    "Transaction Fees": 'Transaction fee actually collected on subscriptions, the totalFee the vault transfers to oplTreasury. Base rate is 5 basis points, then adjusted by the partnership fee where one applies. That adjustment can raise or lower the fee, is floored at the minimum transaction fee when it is not negative, and leaves nothing collected when it fully offsets the base fee.',
   },
   Revenue: {
     [METRIC.MANAGEMENT_FEES]: 'Management fee of 0.30% per annum accrued daily on assets under management.',
-    "Transaction Fees": 'Transaction fee actually collected on subscriptions (the totalFee routed to oplTreasury). Base rate is 5 basis points, reduced or waived by a negative partnership fee where one applies.',
+    "Transaction Fees": 'Transaction fee actually collected on subscriptions, the totalFee the vault transfers to oplTreasury. Base rate is 5 basis points, then adjusted by the partnership fee where one applies. That adjustment can raise or lower the fee, is floored at the minimum transaction fee when it is not negative, and leaves nothing collected when it fully offsets the base fee.',
   },
   ProtocolRevenue: {
     [METRIC.MANAGEMENT_FEES]: 'Management fee of 0.30% per annum accrued daily on assets under management.',
-    "Transaction Fees": 'Transaction fee actually collected on subscriptions (the totalFee routed to oplTreasury). Base rate is 5 basis points, reduced or waived by a negative partnership fee where one applies.',
+    "Transaction Fees": 'Transaction fee actually collected on subscriptions, the totalFee the vault transfers to oplTreasury. Base rate is 5 basis points, then adjusted by the partnership fee where one applies. That adjustment can raise or lower the fee, is floored at the minimum transaction fee when it is not negative, and leaves nothing collected when it fully offsets the base fee.',
   },
 }
 
 
 const adapter: Adapter = {
   methodology: {
-    Fees: 'Management fee of 0.30% per annum accrued daily on assets under management, plus the transaction fee collected on subscriptions (base rate 5 basis points, net of any partnership rebate).',
-    Revenue: 'Management fees of 0.30% per annum accrued daily on assets under management and the transaction fee collected on subscriptions (base rate 5 basis points, net of any partnership rebate).',
-    ProtocolRevenue: 'Management fees of 0.30% per annum accrued daily on assets under management and the transaction fee collected on subscriptions (base rate 5 basis points, net of any partnership rebate).',
+    Fees: 'Management fee of 0.30% per annum accrued daily on assets under management, plus the transaction fee collected on subscriptions (base rate 5 basis points, net of any partnership adjustment up or down).',
+    Revenue: 'Management fees of 0.30% per annum accrued daily on assets under management and the transaction fee collected on subscriptions (base rate 5 basis points, net of any partnership adjustment up or down).',
+    ProtocolRevenue: 'Management fees of 0.30% per annum accrued daily on assets under management and the transaction fee collected on subscriptions (base rate 5 basis points, net of any partnership adjustment up or down).',
   },
   breakdownMethodology,
   version: 2,

--- a/fees/openeden-t-bills/index.ts
+++ b/fees/openeden-t-bills/index.ts
@@ -13,7 +13,7 @@ const eventAbi = `event ProcessDeposit(
   uint256 assets,
   uint256 shares,
   uint256 oeFee,
-  uint256 pFee,
+  int256 pFee,
   uint256 totalFee,
   address oplTreasury,
   address treasury
@@ -62,7 +62,10 @@ const fetch = async (
     dailyFees.add(ADDRESSES[api.chain].USDC, totalUSDC * DAILY_MANAGEMENT_FEES, METRIC.MANAGEMENT_FEES);
 
     logs.forEach((log) => {
-      const feeAmount = log[4];
+      // totalFee is the amount actually transferred to oplTreasury. oeFee is the
+      // pre-rebate gross figure and is often much larger than what is collected,
+      // because a negative partnership fee (pFee) can cancel it out entirely.
+      const feeAmount = log[6];
       dailyFees.add(ADDRESSES[api.chain].USDC, feeAmount, "Transaction Fees");
     });
   }
@@ -73,24 +76,24 @@ const fetch = async (
 const breakdownMethodology = {
   Fees: {
     [METRIC.MANAGEMENT_FEES]: 'Management fee of 0.30% per annum accrued daily on assets under management.',
-    "Transaction Fees": 'Transaction fees (5 basis points) charged on subscriptions/redemptions used to cover operational costs.',
+    "Transaction Fees": 'Transaction fee actually collected on subscriptions (the totalFee routed to oplTreasury). Base rate is 5 basis points, reduced or waived by a negative partnership fee where one applies.',
   },
   Revenue: {
     [METRIC.MANAGEMENT_FEES]: 'Management fee of 0.30% per annum accrued daily on assets under management.',
-    "Transaction Fees": 'Transaction fees (5 basis points) charged on subscriptions/redemptions used to cover operational costs.',
+    "Transaction Fees": 'Transaction fee actually collected on subscriptions (the totalFee routed to oplTreasury). Base rate is 5 basis points, reduced or waived by a negative partnership fee where one applies.',
   },
   ProtocolRevenue: {
     [METRIC.MANAGEMENT_FEES]: 'Management fee of 0.30% per annum accrued daily on assets under management.',
-    "Transaction Fees": 'Transaction fees (5 basis points) charged on subscriptions/redemptions used to cover operational costs.',
+    "Transaction Fees": 'Transaction fee actually collected on subscriptions (the totalFee routed to oplTreasury). Base rate is 5 basis points, reduced or waived by a negative partnership fee where one applies.',
   },
 }
 
 
 const adapter: Adapter = {
   methodology: {
-    Fees: 'Management fee of 0.30% per annum accrued daily on assets under management, plus the OpenEden transaction fee (oeFee) of 5 basis points charged on subscriptions/redemptions used to cover operational costs.',
-    Revenue: 'Management fees of 0.30% per annum accrued daily on assets under management and transaction fees (5 basis points) charged on subscriptions/redemptions used to cover operational costs.',
-    ProtocolRevenue: 'Management fees of 0.30% per annum accrued daily on assets under management and transaction fees (5 basis points) charged on subscriptions/redemptions used to cover operational costs.',
+    Fees: 'Management fee of 0.30% per annum accrued daily on assets under management, plus the transaction fee collected on subscriptions (base rate 5 basis points, net of any partnership rebate).',
+    Revenue: 'Management fees of 0.30% per annum accrued daily on assets under management and the transaction fee collected on subscriptions (base rate 5 basis points, net of any partnership rebate).',
+    ProtocolRevenue: 'Management fees of 0.30% per annum accrued daily on assets under management and the transaction fee collected on subscriptions (base rate 5 basis points, net of any partnership rebate).',
   },
   breakdownMethodology,
   version: 2,


### PR DESCRIPTION
The `ProcessDeposit` ABI in this adapter declares `pFee` as `uint256`. The vault has emitted it as `int256` since 2024-12-20. That is part of the canonical event signature, so the topic0 the adapter filters on stopped matching then:

```
on chain since 2024-12-20   0x2e86963f63dca2028f5099657159e8ea17bd1c2272891dc9d48de6d2ef01875d
adapter                     0xab1d926f2bb1e0bbe5e0416fbfbb5af33aa5881c5f8efae571452c4068578c18
```

`getLogs` returns nothing, so the "Transaction Fees" component reads zero on ethereum and arbitrum and only the management fee is reported.

## Three event shapes, all now queried

The adapter was correct when it was merged in #1812. The vault is a proxy and `ProcessDeposit` has had three shapes. Read off each implementation's runtime bytecode for which topic0 constant it carries, cross-checked against the logs the proxy actually emitted:

| implementation | active | shape | topic0 | logs emitted |
| --- | --- | --- | --- | --- |
| `0x9f423065` OpenEdenVaultV2 | 2023-10-18 to 2024-02-15 | `(..., uint256 txFee, address, address)` | `0x1ec21a57` | 25, 2023-10-19 to 2024-02-06 |
| `0xcd2f1a0b` OpenEdenVaultV3 | 2024-02-15 to 2024-12-20 | `uint256 pFee` | `0xab1d926f` | 135, 2024-03-21 to 2024-12-11 |
| `0xbda6391f` / `0x301998ae` / `0xc4545bf8` | 2024-12-20 onwards | `int256 pFee` | `0x2e86963f` | 229, 2024-12-20 to 2026-07-24 |

Since `start` is `2023-10-18` and backfills replay the full range, fixing only the current shape would have dropped the V3 era that the old ABI was reading correctly. All three signatures are queried and each is decoded by its own shape. A log carries exactly one topic0, so the result sets are disjoint and cannot double count.

The V2 era was never counted, including on master, since the adapter's ABI has never matched its 7-arg shape. From the verified V2 source, index 4 is `txFee`, the whole fee transferred to `oplTreasury`, with no `oeFee`/`pFee` split yet, so it needs no handling beyond its own index. It is 25.00 USDC in total, one minimum-fee charge on the first deposit.

The Arbitrum vault's current implementation `0x78365404` also carries only the `int256` topic0. I did not pin down the exact Arbitrum upgrade date; querying all three shapes makes that unnecessary.

## Counting totalFee rather than oeFee

`txsFee` returns three values and only one of them is money that moves:

```solidity
(uint256 oeFee, int256 pFee, uint256 totalFee) = txsFee(ActionType.DEPOSIT, _sender, _assets);
if (totalFee > 0) safeTransferFrom(underlying, _sender, oplTreasury, totalFee);
```

`oeFee` is the gross figure before the partnership adjustment. `totalFee` is what reaches `oplTreasury`. In the V3 era this makes no difference: `pFee` is unsigned there and was 0 on all 135 logs, so both sum to 70,094.52 USDC and reading `totalFee` reproduces master's numbers exactly. From the 2024-12-20 upgrade onward `pFee` is signed and they diverge sharply, 205,929.08 USDC of `oeFee` against 25,805.73 USDC actually collected.

Two real V4+ logs, opposite cases:

```
tx 0xf4032be3 (2026-07-24)          tx 0x178acd71 (2026-05-20)
  assets   =        400,000.00        assets   =   50,000,000.00
  oeFee    =            200.00        oeFee    =       25,000.00
  pFee     =              0.00        pFee     =      -50,000.00
  totalFee =            200.00        totalFee =            0.00
```

Receipts confirm it. The 400k subscription moves exactly `200.00 USDC -> oplTreasury 0x26C02c2A...`. The 50M subscription moves **zero** to oplTreasury; the full 50M goes to `treasury 0xdF596281...`. Counting `oeFee` would have booked 25,000 USDC of revenue that never existed.

Methodology strings updated to match, including that a signed `pFee` can raise the fee as well as lower it.

## Tests, ethereum column

```
2023-10-20    96.00 -> 121.00     V2 era, picks up the 25.00 never counted before
2024-10-17     8.52k -> 8.52k     V3 era, matches master exactly, 7498 tx fees
2026-07-25   202.00 -> 402.00     V4+ era, picks up 200 from tx 0xf4032be3
2026-05-21   unchanged            V4+ era, fully rebated 50M subscription stays 0
```

Cost is three `getLogs` calls per EVM chain per window instead of one. The two legacy shapes return empty on any recent window.

## Not in scope

Redemption fees are still not tracked. `ProcessWithdraw` is never read, so the methodology's "subscriptions/redemptions" framing is still only half true. Leaving it out deliberately: the queue path emits a populated `oeFee`, the instant path emits `oeFee = 0` with a nonzero `totalFee`, and the two are not symmetric enough to pick a field without more thought. Worth a separate change.