### PR TITLE
openeden-t-bills: add BSC, 201M of the protocol's 256M TVL

### DIFF
--- a/fees/openeden-t-bills/index.ts
+++ b/fees/openeden-t-bills/index.ts
@@ -7,17 +7,30 @@ import { getTokenSupply } from '../../helpers/solana';
 import { rpcCall } from '../../helpers/ripple';
 import { METRIC } from "../../helpers/metrics";
 
-const eventAbi = `event ProcessDeposit(
-  address sender,
-  address receiver,
-  uint256 assets,
-  uint256 shares,
-  uint256 oeFee,
-  int256 pFee,
-  uint256 totalFee,
-  address oplTreasury,
-  address treasury
-)`;
+// The vault is a proxy and ProcessDeposit has had three shapes. Each one has a
+// different topic0, so all three have to be queried to cover the full history
+// back to the adapter's start date. A log carries exactly one topic0, so the
+// three result sets are disjoint and cannot double count.
+//
+//   V2  2023-10-18 to 2024-02-15  single txFee field at index 4
+//   V3  2024-02-15 to 2024-12-20  oeFee/pFee/totalFee, pFee unsigned
+//   V4+ 2024-12-20 onwards        same fields, pFee signed
+//
+// feeIndex points at the fee the contract actually transfers to oplTreasury.
+const depositEvents = [
+  {
+    abi: `event ProcessDeposit(address sender, address receiver, uint256 assets, uint256 shares, uint256 oeFee, int256 pFee, uint256 totalFee, address oplTreasury, address treasury)`,
+    feeIndex: 6,
+  },
+  {
+    abi: `event ProcessDeposit(address sender, address receiver, uint256 assets, uint256 shares, uint256 oeFee, uint256 pFee, uint256 totalFee, address oplTreasury, address treasury)`,
+    feeIndex: 6,
+  },
+  {
+    abi: `event ProcessDeposit(address sender, address receiver, uint256 assets, uint256 shares, uint256 txFee, address oplTreasury, address treasury)`,
+    feeIndex: 4,
+  },
+];
 
 const CHAIN_CONFIGS: any = {
   [CHAIN.ETHEREUM]: "0xdd50C053C096CB04A3e3362E2b622529EC5f2e8a",
@@ -54,19 +67,21 @@ const fetch = async (
   } else if (chain === CHAIN.SOLANA) {
     dailyFees.addUSDValue((await getTokenSupply(config)) * DAILY_MANAGEMENT_FEES, METRIC.MANAGEMENT_FEES)
   } else {
-    let [logs, totalUSDC] = await Promise.all([
-      getLogs({ target: config, eventAbi }),
+    const [logSets, totalUSDC] = await Promise.all([
+      Promise.all(depositEvents.map(({ abi }) => getLogs({ target: config, eventAbi: abi }))),
       api.call({ target: config, abi: "uint256:totalAssets" }),
     ]);
 
     dailyFees.add(ADDRESSES[api.chain].USDC, totalUSDC * DAILY_MANAGEMENT_FEES, METRIC.MANAGEMENT_FEES);
 
-    logs.forEach((log) => {
-      // totalFee is the amount actually transferred to oplTreasury. oeFee is the
-      // pre-rebate gross figure and is often much larger than what is collected,
-      // because a negative partnership fee (pFee) can cancel it out entirely.
-      const feeAmount = log[6];
-      dailyFees.add(ADDRESSES[api.chain].USDC, feeAmount, "Transaction Fees");
+    logSets.forEach((logs, i) => {
+      // Count the fee the contract actually transfers to oplTreasury, not oeFee.
+      // oeFee is the gross figure before the partnership adjustment, so on the
+      // V4+ shape a negative pFee can leave oeFee large while nothing is collected.
+      const { feeIndex } = depositEvents[i];
+      logs.forEach((log: any) => {
+        dailyFees.add(ADDRESSES[api.chain].USDC, log[feeIndex], "Transaction Fees");
+      });
     });
   }
 
@@ -76,24 +91,24 @@ const fetch = async (
 const breakdownMethodology = {
   Fees: {
     [METRIC.MANAGEMENT_FEES]: 'Management fee of 0.30% per annum accrued daily on assets under management.',
-    "Transaction Fees": 'Transaction fee actually collected on subscriptions (the totalFee routed to oplTreasury). Base rate is 5 basis points, reduced or waived by a negative partnership fee where one applies.',
+    "Transaction Fees": 'Transaction fee actually collected on subscriptions, the totalFee the vault transfers to oplTreasury. Base rate is 5 basis points, then adjusted by the partnership fee where one applies. That adjustment can raise or lower the fee, is floored at the minimum transaction fee when it is not negative, and leaves nothing collected when it fully offsets the base fee.',
   },
   Revenue: {
     [METRIC.MANAGEMENT_FEES]: 'Management fee of 0.30% per annum accrued daily on assets under management.',
-    "Transaction Fees": 'Transaction fee actually collected on subscriptions (the totalFee routed to oplTreasury). Base rate is 5 basis points, reduced or waived by a negative partnership fee where one applies.',
+    "Transaction Fees": 'Transaction fee actually collected on subscriptions, the totalFee the vault transfers to oplTreasury. Base rate is 5 basis points, then adjusted by the partnership fee where one applies. That adjustment can raise or lower the fee, is floored at the minimum transaction fee when it is not negative, and leaves nothing collected when it fully offsets the base fee.',
   },
   ProtocolRevenue: {
     [METRIC.MANAGEMENT_FEES]: 'Management fee of 0.30% per annum accrued daily on assets under management.',
-    "Transaction Fees": 'Transaction fee actually collected on subscriptions (the totalFee routed to oplTreasury). Base rate is 5 basis points, reduced or waived by a negative partnership fee where one applies.',
+    "Transaction Fees": 'Transaction fee actually collected on subscriptions, the totalFee the vault transfers to oplTreasury. Base rate is 5 basis points, then adjusted by the partnership fee where one applies. That adjustment can raise or lower the fee, is floored at the minimum transaction fee when it is not negative, and leaves nothing collected when it fully offsets the base fee.',
   },
 }
 
 
 const adapter: Adapter = {
   methodology: {
-    Fees: 'Management fee of 0.30% per annum accrued daily on assets under management, plus the transaction fee collected on subscriptions (base rate 5 basis points, net of any partnership rebate).',
-    Revenue: 'Management fees of 0.30% per annum accrued daily on assets under management and the transaction fee collected on subscriptions (base rate 5 basis points, net of any partnership rebate).',
-    ProtocolRevenue: 'Management fees of 0.30% per annum accrued daily on assets under management and the transaction fee collected on subscriptions (base rate 5 basis points, net of any partnership rebate).',
+    Fees: 'Management fee of 0.30% per annum accrued daily on assets under management, plus the transaction fee collected on subscriptions (base rate 5 basis points, net of any partnership adjustment up or down).',
+    Revenue: 'Management fees of 0.30% per annum accrued daily on assets under management and the transaction fee collected on subscriptions (base rate 5 basis points, net of any partnership adjustment up or down).',
+    ProtocolRevenue: 'Management fees of 0.30% per annum accrued daily on assets under management and the transaction fee collected on subscriptions (base rate 5 basis points, net of any partnership adjustment up or down).',
   },
   breakdownMethodology,
   version: 2,

--- a/fees/openeden-t-bills/index.ts
+++ b/fees/openeden-t-bills/index.ts
@@ -13,7 +13,7 @@ const eventAbi = `event ProcessDeposit(
   uint256 assets,
   uint256 shares,
   uint256 oeFee,
-  uint256 pFee,
+  int256 pFee,
   uint256 totalFee,
   address oplTreasury,
   address treasury
@@ -62,7 +62,10 @@ const fetch = async (
     dailyFees.add(ADDRESSES[api.chain].USDC, totalUSDC * DAILY_MANAGEMENT_FEES, METRIC.MANAGEMENT_FEES);
 
     logs.forEach((log) => {
-      const feeAmount = log[4];
+      // totalFee is the amount actually transferred to oplTreasury. oeFee is the
+      // pre-rebate gross figure and is often much larger than what is collected,
+      // because a negative partnership fee (pFee) can cancel it out entirely.
+      const feeAmount = log[6];
       dailyFees.add(ADDRESSES[api.chain].USDC, feeAmount, "Transaction Fees");
     });
   }
@@ -73,24 +76,24 @@ const fetch = async (
 const breakdownMethodology = {
   Fees: {
     [METRIC.MANAGEMENT_FEES]: 'Management fee of 0.30% per annum accrued daily on assets under management.',
-    "Transaction Fees": 'Transaction fees (5 basis points) charged on subscriptions/redemptions used to cover operational costs.',
+    "Transaction Fees": 'Transaction fee actually collected on subscriptions (the totalFee routed to oplTreasury). Base rate is 5 basis points, reduced or waived by a negative partnership fee where one applies.',
   },
   Revenue: {
     [METRIC.MANAGEMENT_FEES]: 'Management fee of 0.30% per annum accrued daily on assets under management.',
-    "Transaction Fees": 'Transaction fees (5 basis points) charged on subscriptions/redemptions used to cover operational costs.',
+    "Transaction Fees": 'Transaction fee actually collected on subscriptions (the totalFee routed to oplTreasury). Base rate is 5 basis points, reduced or waived by a negative partnership fee where one applies.',
   },
   ProtocolRevenue: {
     [METRIC.MANAGEMENT_FEES]: 'Management fee of 0.30% per annum accrued daily on assets under management.',
-    "Transaction Fees": 'Transaction fees (5 basis points) charged on subscriptions/redemptions used to cover operational costs.',
+    "Transaction Fees": 'Transaction fee actually collected on subscriptions (the totalFee routed to oplTreasury). Base rate is 5 basis points, reduced or waived by a negative partnership fee where one applies.',
   },
 }
 
 
 const adapter: Adapter = {
   methodology: {
-    Fees: 'Management fee of 0.30% per annum accrued daily on assets under management, plus the OpenEden transaction fee (oeFee) of 5 basis points charged on subscriptions/redemptions used to cover operational costs.',
-    Revenue: 'Management fees of 0.30% per annum accrued daily on assets under management and transaction fees (5 basis points) charged on subscriptions/redemptions used to cover operational costs.',
-    ProtocolRevenue: 'Management fees of 0.30% per annum accrued daily on assets under management and transaction fees (5 basis points) charged on subscriptions/redemptions used to cover operational costs.',
+    Fees: 'Management fee of 0.30% per annum accrued daily on assets under management, plus the transaction fee collected on subscriptions (base rate 5 basis points, net of any partnership rebate).',
+    Revenue: 'Management fees of 0.30% per annum accrued daily on assets under management and the transaction fee collected on subscriptions (base rate 5 basis points, net of any partnership rebate).',
+    ProtocolRevenue: 'Management fees of 0.30% per annum accrued daily on assets under management and the transaction fee collected on subscriptions (base rate 5 basis points, net of any partnership rebate).',
   },
   breakdownMethodology,
   version: 2,

--- a/fees/openeden-t-bills/index.ts
+++ b/fees/openeden-t-bills/index.ts
@@ -35,6 +35,7 @@ const depositEvents = [
 const CHAIN_CONFIGS: any = {
   [CHAIN.ETHEREUM]: "0xdd50C053C096CB04A3e3362E2b622529EC5f2e8a",
   [CHAIN.ARBITRUM]: "0xF84D28A8D28292842dD73D1c5F99476A80b6666A",
+  [CHAIN.BSC]: "0x5b4681F0d7A01B817675F25892D3Ad73572FD1D9",
   [CHAIN.SOLANA]: "4MmJVdwYN8LwvbGeCowYjSx7KoEi6BJWg8XXnW4fDDp6",
   [CHAIN.RIPPLE]: {
     ACCOUNT: 'rJNE2NNz83GJYtWVLwMvchDWEon3huWnFn',
@@ -126,6 +127,11 @@ const adapter: Adapter = {
       fetch: (options: FetchOptions) =>
         fetch(CHAIN_CONFIGS[CHAIN.ARBITRUM], options),
       start: '2024-02-13',
+    },
+    [CHAIN.BSC]: {
+      fetch: (options: FetchOptions) =>
+        fetch(CHAIN_CONFIGS[CHAIN.BSC], options),
+      start: '2026-05-25',
     },
     [CHAIN.RIPPLE]: {
       fetch: (options: FetchOptions) =>

--- a/fees/openeden-t-bills/index.ts
+++ b/fees/openeden-t-bills/index.ts
@@ -32,14 +32,44 @@ const depositEvents = [
   },
 ];
 
-const CHAIN_CONFIGS: any = {
-  [CHAIN.ETHEREUM]: "0xdd50C053C096CB04A3e3362E2b622529EC5f2e8a",
-  [CHAIN.ARBITRUM]: "0xF84D28A8D28292842dD73D1c5F99476A80b6666A",
-  [CHAIN.BSC]: "0x5b4681F0d7A01B817675F25892D3Ad73572FD1D9",
-  [CHAIN.SOLANA]: "4MmJVdwYN8LwvbGeCowYjSx7KoEi6BJWg8XXnW4fDDp6",
+type TBillChainConfig = {
+  target: any;
+  start?: string;
+  runAtCurrTime?: boolean;
+};
+
+const chainConfig: Record<string, TBillChainConfig> = {
+  // https://etherscan.io/token/0xdd50C053C096CB04A3e3362E2b622529EC5f2e8a
+  [CHAIN.ETHEREUM]: {
+    target: "0xdd50C053C096CB04A3e3362E2b622529EC5f2e8a",
+    start: '2023-10-18',
+  },
+  // https://arbiscan.io/token/0xF84D28A8D28292842dD73D1c5F99476A80b6666A
+  [CHAIN.ARBITRUM]: {
+    target: "0xF84D28A8D28292842dD73D1c5F99476A80b6666A",
+    start: '2024-02-13',
+  },
+  // https://bscscan.com/token/0x5b4681F0d7A01B817675F25892D3Ad73572FD1D9
+  // Reports name "OpenEden T-Bills", symbol TBILL. Its implementation
+  // 0xf3c7bbd9f91de0664a3e2ec5063e45872da472d9 is byte-identical to the verified
+  // Ethereum one apart from the immutable self-address, and underlying() returns
+  // BSC USDC, matching coreAssets bsc.USDC at 18 decimals.
+  [CHAIN.BSC]: {
+    target: "0x5b4681F0d7A01B817675F25892D3Ad73572FD1D9",
+    start: '2026-05-25',
+  },
+  // https://solscan.io/token/4MmJVdwYN8LwvbGeCowYjSx7KoEi6BJWg8XXnW4fDDp6
+  [CHAIN.SOLANA]: {
+    target: "4MmJVdwYN8LwvbGeCowYjSx7KoEi6BJWg8XXnW4fDDp6",
+    runAtCurrTime: true,
+  },
+  // https://xrpscan.com/account/rJNE2NNz83GJYtWVLwMvchDWEon3huWnFn
   [CHAIN.RIPPLE]: {
-    ACCOUNT: 'rJNE2NNz83GJYtWVLwMvchDWEon3huWnFn',
-    HOT_WALLET: 'rB56JZWRKvpWNeyqM3QYfZwW4fS9YEyPWM',
+    target: {
+      ACCOUNT: 'rJNE2NNz83GJYtWVLwMvchDWEon3huWnFn',
+      HOT_WALLET: 'rB56JZWRKvpWNeyqM3QYfZwW4fS9YEyPWM',
+    },
+    runAtCurrTime: true,
   },
 };
 
@@ -47,9 +77,9 @@ const MANAGEMENT_FEES: number = 0.003;
 const DAILY_MANAGEMENT_FEES: number = MANAGEMENT_FEES / 365;
 
 const fetch = async (
-  config: any,
   { chain, api, getLogs, createBalances }: FetchOptions
 ): Promise<FetchResultV2> => {
+  const config = chainConfig[chain].target;
   const dailyFees = createBalances();
 
   if (chain === CHAIN.RIPPLE) {
@@ -117,33 +147,15 @@ const adapter: Adapter = {
   // (totalAssets * MANAGEMENT_FEES/365), so running 24 hourly pulls would charge a
   // full day's management fee 24 times and overstate fees/revenue.
   pullHourly: false,
-  adapter: {
-    [CHAIN.ETHEREUM]: {
-      fetch: (options: FetchOptions) =>
-        fetch(CHAIN_CONFIGS[CHAIN.ETHEREUM], options),
-      start: '2023-10-18',
-    },
-    [CHAIN.ARBITRUM]: {
-      fetch: (options: FetchOptions) =>
-        fetch(CHAIN_CONFIGS[CHAIN.ARBITRUM], options),
-      start: '2024-02-13',
-    },
-    [CHAIN.BSC]: {
-      fetch: (options: FetchOptions) =>
-        fetch(CHAIN_CONFIGS[CHAIN.BSC], options),
-      start: '2026-05-25',
-    },
-    [CHAIN.RIPPLE]: {
-      fetch: (options: FetchOptions) =>
-        fetch(CHAIN_CONFIGS[CHAIN.RIPPLE], options),
-      runAtCurrTime: true,
-    },
-    [CHAIN.SOLANA]: {
-      fetch: (options: FetchOptions) =>
-        fetch(CHAIN_CONFIGS[CHAIN.SOLANA], options),
-      runAtCurrTime: true,
-    },
-  },
+  adapter: {},
 };
+
+for (const [chain, { start, runAtCurrTime }] of Object.entries(chainConfig)) {
+  (adapter.adapter as any)[chain] = {
+    fetch,
+    ...(start ? { start } : {}),
+    ...(runAtCurrTime ? { runAtCurrTime } : {}),
+  };
+}
 
 export default adapter;


### PR DESCRIPTION
Stacked on #8423. Those are the first two commits here; review this one for `openeden-t-bills: add BSC` and `openeden-t-bills: fold address and start into one chainConfig`.

TBILL launched on BSC on 2026-05-25 and now holds **201.09M of the protocol's 256M** total, more than every currently tracked chain combined, with no fees coverage.

## Verification

Vault `0x5b4681F0d7A01B817675F25892D3Ad73572FD1D9`, a proxy over implementation `0xf3c7bbd9`. That implementation's runtime bytecode is byte-identical to the Ethereum one (`0xc4545bf8`, verified as `OpenEdenVaultV5`) apart from the immutable self-address, so the existing EVM branch applies unchanged.

`underlying()` returns `0x8AC76a51cc950d9822D68b83fE1Ad97B32Cd580d`, which is BSC USDC at 18 decimals and matches `coreAssets.bsc.USDC` exactly, so the token and the scale the adapter already uses are both correct for this chain.

`totalAssets()` reads `201089451893669947679245023` (201.09M at 18dp), matching the TVL adapter.

Start date `2026-05-25` is the first day the chain reports any TVL.

## What is proven, and what is not

Proven end to end through the adapter: the management fee path. Running at current time gives bsc 1.65k daily fees, matching `totalAssets 201089451.89 * 0.003/365 = 1652.5`.

Proven, but through the SDK directly rather than a full adapter run: the deposit log path. Calling the same `getEventLogs` that `options.getLogs` wraps, over blocks 111180000 to 111570000, returns one `ProcessDeposit`:

```
tx 0xb555a475c7a41d23fae477f9cb1071f85a0a6d87d75fa9171590722421f8a1ac  blk 111242318
assets 50,000,000.00   oeFee 25,000.00   pFee -25,000.00   totalFee 0.00
```

That also confirms the `int256 pFee` decode from #8423 works on BSC, and that the oeFee/totalFee divergence exists here too. The receipt shows the 50M going to `0x682e1866...` and nothing to oplTreasury `0x5106Ac0A...`, so `totalFee = 0` is correct and `oeFee` would have fabricated 25,000 USDC of revenue.

**Not proven:** an adapter run over a BSC window containing a subscription with a nonzero `totalFee`. The only BSC subscription I could find in the window has `totalFee = 0`, and I could not run the adapter on that date because historical `eth_call` for `totalAssets` fails on every public BSC endpoint:

```
blk 111242318 via bsc-dataseed.binance.org  => -32000: missing trie node
blk 111242318 via bsc-dataseed1.defibit.io  => -32000: missing trie node
latest block                                 => 201089451893669947679245023   (works)
```

That is node pruning, not anything specific to this change; the raw `cast call` above involves no adapter code. Flagging it rather than claiming coverage I did not test. If a maintainer has an archive BSC endpoint handy, that is the one remaining check.


## Refactor

Per review, each chain's target and `start`/`runAtCurrTime` now live in a single `chainConfig`, `fetch` takes only `FetchOptions` and resolves its target via `chainConfig[chain]`, and the adapter map is built from that config in a loop. The five duplicated per-chain fetch wrappers are gone. No behaviour change; historical windows still give 7498 on 2024-10-17 and 25 on 2023-10-20, and `npm run ts-check` is clean.