### PR TITLE
[add] jupiter-lend-dex - volume and fees adapter

### DIFF
--- a/dexs/jupiter-lend-dex/index.ts
+++ b/dexs/jupiter-lend-dex/index.ts
@@ -69,7 +69,7 @@ const fetch = async (options: FetchOptions) => {
 };
 
 const adapter: SimpleAdapter = {
-  version: 2,
+  version: 1,
   fetch,
   chains: [CHAIN.SOLANA],
   start: '2026-06-18',

--- a/dexs/jupiter-lend-dex/index.ts
+++ b/dexs/jupiter-lend-dex/index.ts
@@ -11,7 +11,7 @@ import { queryDuneSql } from "../../helpers/dune";
 //   the 3 historical swap_out txs decode to 1,283,885 / 1,283,391 / 1,501,258 — matching
 //   the actual token transfers.
 //
-// LogSwap discriminator = [0xCA,0xF2,0xE4,0x1C,0x25,0xC2,0x34,0x22]; base64 prefix "yvLkHCXC".
+// LogSwap discriminator = [0xCA,0xF2,0xE4,0x1C,0x25,0xC2,0x34,0x22]; base64 = "yvLkHCXCNCIC".
 
 const fetch = async (options: FetchOptions) => {
   const sql = `
@@ -40,7 +40,7 @@ const fetch = async (options: FetchOptions) => {
       CROSS JOIN UNNEST(s.call_log_messages) AS t(msg)
       WHERE s.call_block_time >= from_unixtime(${options.startTimestamp})
         AND s.call_block_time <  from_unixtime(${options.endTimestamp})
-        AND msg LIKE 'Program data: yvLkHCXC%'
+        AND msg LIKE 'Program data: yvLkHCXCNCIC%'
     ),
     all_swaps AS (
       SELECT pool, swap0to1, amount_in FROM swap_in_vol
@@ -77,7 +77,7 @@ const adapter: SimpleAdapter = {
   isExpensiveAdapter: true,
   methodology: {
     Volume:
-      "Notional traded (input-side, priced in the input token) across all Jupiter Lend AMM pools. For exact-in swaps (dex_call_swap_in), amount_in is read directly from the call argument. For exact-out swaps (dex_call_swap_out), amount_in is decoded from the LogSwap Anchor event embedded in call_log_messages (Program data: yvLkHCXC... base64 line): after the 8-byte discriminator and u16/u8 header, the u64 little-endian at byte 11 is amount_in. Per-pool token identity comes from dex_call_init_dex.",
+      "Notional traded (input-side, priced in the input token) across all Jupiter Lend AMM pools. For exact-in swaps (dex_call_swap_in), amount_in is read directly from the call argument. For exact-out swaps (dex_call_swap_out), amount_in is decoded from the LogSwap Anchor event embedded in call_log_messages (Program data: yvLkHCXCNCIC... base64 line): after the 8-byte discriminator and u16/u8 header, the u64 little-endian at byte 11 is amount_in. Per-pool token identity comes from dex_call_init_dex.",
   },
 };
 

--- a/dexs/jupiter-lend-dex/index.ts
+++ b/dexs/jupiter-lend-dex/index.ts
@@ -1,0 +1,84 @@
+import { Dependencies, FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import { queryDuneSql } from "../../helpers/dune";
+
+// Volume = every swap's input-side amount priced in the input token.
+// - swap_in (exact-in): amount_in is a call argument (dex_call_swap_in.amount_in).
+// - swap_out (exact-out): amount_in is not a call arg, but the DEX emits a LogSwap event
+//   (Anchor `emit!`) which appears as a "Program data: yvLkHCXC..." line in call_log_messages.
+//   We decode the base64 payload and read amount_in (u64 LE at byte 11 after the 8-byte
+//   Anchor discriminator + u16 dex_id + u8 swap_0_to_1). Verified against on-chain data:
+//   the 3 historical swap_out txs decode to 1,283,885 / 1,283,391 / 1,501,258 — matching
+//   the actual token transfers.
+//
+// LogSwap discriminator = [0xCA,0xF2,0xE4,0x1C,0x25,0xC2,0x34,0x22]; base64 prefix "yvLkHCXC".
+
+const fetch = async (options: FetchOptions) => {
+  const sql = `
+    WITH pools AS (
+      SELECT DISTINCT
+        account_dex     AS pool,
+        account_token_0 AS token_0,
+        account_token_1 AS token_1
+      FROM jupiter_lend_solana.dex_call_init_dex
+    ),
+    swap_in_vol AS (
+      SELECT
+        s.account_dex                     AS pool,
+        s.swap0to1                        AS swap0to1,
+        CAST(s.amount_in AS DOUBLE)       AS amount_in
+      FROM jupiter_lend_solana.dex_call_swap_in s
+      WHERE s.call_block_time >= from_unixtime(${options.startTimestamp})
+        AND s.call_block_time <  from_unixtime(${options.endTimestamp})
+    ),
+    swap_out_events AS (
+      SELECT
+        s.account_dex                                                             AS pool,
+        s.swap0to1                                                                AS swap0to1,
+        CAST(from_big_endian_64(reverse(SUBSTR(from_base64(SUBSTR(msg, 15)), 12, 8))) AS DOUBLE) AS amount_in
+      FROM jupiter_lend_solana.dex_call_swap_out s
+      CROSS JOIN UNNEST(s.call_log_messages) AS t(msg)
+      WHERE s.call_block_time >= from_unixtime(${options.startTimestamp})
+        AND s.call_block_time <  from_unixtime(${options.endTimestamp})
+        AND msg LIKE 'Program data: yvLkHCXC%'
+    ),
+    all_swaps AS (
+      SELECT pool, swap0to1, amount_in FROM swap_in_vol
+      UNION ALL
+      SELECT pool, swap0to1, amount_in FROM swap_out_events
+    )
+    SELECT
+      p.token_0,
+      p.token_1,
+      a.swap0to1,
+      SUM(a.amount_in) AS amount_in_sum
+    FROM all_swaps a
+    JOIN pools p ON a.pool = p.pool
+    GROUP BY p.token_0, p.token_1, a.swap0to1
+  `;
+
+  const rows: any[] = await queryDuneSql(options, sql);
+  const dailyVolume = options.createBalances();
+
+  for (const row of rows) {
+    const inputMint: string = row.swap0to1 ? row.token_0 : row.token_1;
+    dailyVolume.add(inputMint, Number(row.amount_in_sum));
+  }
+
+  return { dailyVolume };
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  fetch,
+  chains: [CHAIN.SOLANA],
+  start: '2026-06-18',
+  dependencies: [Dependencies.DUNE],
+  isExpensiveAdapter: true,
+  methodology: {
+    Volume:
+      "Notional traded (input-side, priced in the input token) across all Jupiter Lend AMM pools. For exact-in swaps (dex_call_swap_in), amount_in is read directly from the call argument. For exact-out swaps (dex_call_swap_out), amount_in is decoded from the LogSwap Anchor event embedded in call_log_messages (Program data: yvLkHCXC... base64 line): after the 8-byte discriminator and u16/u8 header, the u64 little-endian at byte 11 is amount_in. Per-pool token identity comes from dex_call_init_dex.",
+  },
+};
+
+export default adapter;

--- a/fees/jupiter-lend-dex/index.ts
+++ b/fees/jupiter-lend-dex/index.ts
@@ -1,0 +1,147 @@
+import { Dependencies, FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import { queryDuneSql } from "../../helpers/dune";
+
+// Fees = per-swap (input notional * fee_at_that_time / 1e6), priced in the input token.
+// Fee history is init_dex ∪ every subsequent update_fee_and_revenue_cut call, window-joined
+// so a swap always uses the fee that was live at its block_time.
+//
+// amount_in resolution:
+// - swap_in: exact from call arg (dex_call_swap_in.amount_in).
+// - swap_out: decoded from the Anchor LogSwap event in call_log_messages
+//   ("Program data: yvLkHCXC..." — base64 payload after 8-byte discriminator + u16 dex_id
+//   + u8 swap_0_to_1, u64 little-endian amount_in at byte 11).
+//
+// Revenue split: LP = fee * (1 - revenue_cut/1e6). Protocol = fee * revenue_cut/1e6.
+// Jupiter and Fluid share the protocol cut 50/50. AMM fees do NOT feed the JUP buyback.
+
+const FEE_SCALE = 1e6;            // fee arg is in ppm (u32 in IDL)
+const REVENUE_CUT_SCALE = 1e6;    // revenue_cut arg is in ppm (u32 in IDL)
+const JUPITER_SHARE_OF_PROTOCOL = 0.5;
+
+const fetch = async (options: FetchOptions) => {
+  const sql = `
+    WITH pools AS (
+      SELECT DISTINCT
+        account_dex     AS pool,
+        account_token_0 AS token_0,
+        account_token_1 AS token_1
+      FROM jupiter_lend_solana.dex_call_init_dex
+    ),
+    fee_events AS (
+      SELECT
+        account_dex AS pool,
+        CAST(json_extract_scalar(params, '$.InitDexParams.fee') AS BIGINT)         AS fee,
+        CAST(json_extract_scalar(params, '$.InitDexParams.revenue_cut') AS BIGINT) AS revenue_cut,
+        call_block_time
+      FROM jupiter_lend_solana.dex_call_init_dex
+      UNION ALL
+      SELECT
+        account_dex AS pool,
+        fee,
+        revenue_cut,
+        call_block_time
+      FROM jupiter_lend_solana.dex_call_update_fee_and_revenue_cut
+    ),
+    fee_ranges AS (
+      SELECT
+        pool, fee, revenue_cut,
+        call_block_time                                                        AS effective_from,
+        LEAD(call_block_time) OVER (PARTITION BY pool ORDER BY call_block_time) AS effective_to
+      FROM fee_events
+    ),
+    swap_in_rows AS (
+      SELECT
+        s.account_dex                     AS pool,
+        s.swap0to1                        AS swap0to1,
+        s.call_block_time,
+        CAST(s.amount_in AS DOUBLE)       AS amount_in
+      FROM jupiter_lend_solana.dex_call_swap_in s
+      WHERE s.call_block_time >= from_unixtime(${options.startTimestamp})
+        AND s.call_block_time <  from_unixtime(${options.endTimestamp})
+    ),
+    swap_out_rows AS (
+      SELECT
+        s.account_dex                     AS pool,
+        s.swap0to1                        AS swap0to1,
+        s.call_block_time,
+        CAST(from_big_endian_64(reverse(SUBSTR(from_base64(SUBSTR(msg, 15)), 12, 8))) AS DOUBLE) AS amount_in
+      FROM jupiter_lend_solana.dex_call_swap_out s
+      CROSS JOIN UNNEST(s.call_log_messages) AS t(msg)
+      WHERE s.call_block_time >= from_unixtime(${options.startTimestamp})
+        AND s.call_block_time <  from_unixtime(${options.endTimestamp})
+        AND msg LIKE 'Program data: yvLkHCXC%'
+    ),
+    all_swaps AS (
+      SELECT pool, swap0to1, call_block_time, amount_in FROM swap_in_rows
+      UNION ALL
+      SELECT pool, swap0to1, call_block_time, amount_in FROM swap_out_rows
+    ),
+    priced AS (
+      SELECT
+        p.token_0,
+        p.token_1,
+        a.swap0to1,
+        a.amount_in,
+        fr.fee,
+        fr.revenue_cut
+      FROM all_swaps a
+      JOIN pools p       ON a.pool = p.pool
+      JOIN fee_ranges fr ON fr.pool = a.pool
+        AND a.call_block_time >= fr.effective_from
+        AND (fr.effective_to IS NULL OR a.call_block_time < fr.effective_to)
+    )
+    SELECT * FROM priced
+  `;
+
+  const rows: any[] = await queryDuneSql(options, sql);
+
+  const dailyFees = options.createBalances();
+  const dailySupplySideRevenue = options.createBalances();
+  const dailyRevenue = options.createBalances();
+  const dailyProtocolRevenue = options.createBalances();
+
+  for (const row of rows) {
+    const inputMint: string = row.swap0to1 ? row.token_0 : row.token_1;
+    const amountIn = Number(row.amount_in);
+    if (!amountIn) continue;
+
+    const feeRate = Number(row.fee) / FEE_SCALE;
+    const revenueCutFraction = Number(row.revenue_cut) / REVENUE_CUT_SCALE;
+
+    const feeInToken = amountIn * feeRate;
+    const protocolCut = feeInToken * revenueCutFraction;
+    const lpShare = feeInToken - protocolCut;
+    const jupiterShare = protocolCut * JUPITER_SHARE_OF_PROTOCOL;
+    const fluidShare = protocolCut - jupiterShare;
+
+    dailyFees.add(inputMint, feeInToken);
+    dailySupplySideRevenue.add(inputMint, lpShare + fluidShare);
+    dailyRevenue.add(inputMint, jupiterShare);
+    dailyProtocolRevenue.add(inputMint, jupiterShare);
+  }
+
+  return {
+    dailyFees,
+    dailySupplySideRevenue,
+    dailyRevenue,
+    dailyProtocolRevenue,
+  };
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  fetch,
+  chains: [CHAIN.SOLANA],
+  start: '2026-06-18',
+  dependencies: [Dependencies.DUNE],
+  isExpensiveAdapter: true,
+  methodology: {
+    Fees: "Total swap fees, priced in the input token. Per-swap fee = amount_in x (pool.fee / 1e6) where pool.fee is the value live at the swap's block_time (sourced from init_dex plus every update_fee_and_revenue_cut call, window-joined via effective range). amount_in is exact for swap_in (call arg) and swap_out (LogSwap Anchor event decoded from call_log_messages, u64 LE at byte 11 of the payload).",
+    SupplySideRevenue: "LP share of swap fees plus Fluid's protocol share. LP share = fees x (1 - revenue_cut/1e6). Fluid receives 50% of the protocol cut per Jupiter Lend / Fluid arrangement.",
+    Revenue: "Jupiter's share of the protocol cut: fees x (revenue_cut/1e6) x 50%.",
+    ProtocolRevenue: "Same as Revenue - AMM fees do not feed the JUP buyback.",
+  },
+};
+
+export default adapter;

--- a/fees/jupiter-lend-dex/index.ts
+++ b/fees/jupiter-lend-dex/index.ts
@@ -142,7 +142,7 @@ const breakdownMethodology = {
     "Jupiter Lend Dex Swap Fees to Protocol": "Jupiter's share of the protocol cut: fees x (revenue_cut/1e6) x 50%.",
   },
   SupplySideRevenue: {
-    "Jupiter Lend Dex Swap Fees to LPs": "LP share of swap fees plus Fluid's protocol share. LP share = fees x (1 - revenue_cut/1e6). Fluid receives 50% of the protocol cut per Jupiter Lend / Fluid arrangement.",
+    "Jupiter Lend Dex Swap Fees to LPs": "LP share of swap fees. LP share = fees x (1 - revenue_cut/1e6).",
     "Jupiter Lend Dex Swap Fees to Fluid": "Fluid's share of the protocol cut: fees x (revenue_cut/1e6) x 50%.",
   }
 }
@@ -158,7 +158,7 @@ const adapter: SimpleAdapter = {
     Fees: "Total swap fees, priced in the input token. Per-swap fee = amount_in x (pool.fee / 1e6) where pool.fee is the value live at the swap's block_time (sourced from init_dex plus every update_fee_and_revenue_cut call, window-joined via effective range). amount_in is exact for swap_in (call arg) and swap_out (LogSwap Anchor event decoded from call_log_messages, u64 LE at byte 11 of the payload).",
     SupplySideRevenue: "LP share of swap fees plus Fluid's protocol share. LP share = fees x (1 - revenue_cut/1e6). Fluid receives 50% of the protocol cut per Jupiter Lend / Fluid arrangement.",
     Revenue: "Jupiter's share of the protocol cut: fees x (revenue_cut/1e6) x 50%.",
-    ProtocolRevenue: "Same as Revenue - AMM fees do not feed the JUP buyback.",
+    ProtocolRevenue: "Jupiter's share of the protocol cut: fees x (revenue_cut/1e6) x 50%.",
   },
   breakdownMethodology,
 };

--- a/fees/jupiter-lend-dex/index.ts
+++ b/fees/jupiter-lend-dex/index.ts
@@ -130,7 +130,7 @@ const fetch = async (options: FetchOptions) => {
 };
 
 const adapter: SimpleAdapter = {
-  version: 2,
+  version: 1,
   fetch,
   chains: [CHAIN.SOLANA],
   start: '2026-06-18',

--- a/fees/jupiter-lend-dex/index.ts
+++ b/fees/jupiter-lend-dex/index.ts
@@ -70,7 +70,7 @@ const fetch = async (options: FetchOptions) => {
       CROSS JOIN UNNEST(s.call_log_messages) AS t(msg)
       WHERE s.call_block_time >= from_unixtime(${options.startTimestamp})
         AND s.call_block_time <  from_unixtime(${options.endTimestamp})
-        AND msg LIKE 'Program data: yvLkHCXC%'
+        AND msg LIKE 'Program data: yvLkHCXCNCIC%'
     ),
     all_swaps AS (
       SELECT pool, swap0to1, call_block_time, amount_in FROM swap_in_rows

--- a/fees/jupiter-lend-dex/index.ts
+++ b/fees/jupiter-lend-dex/index.ts
@@ -1,6 +1,7 @@
 import { Dependencies, FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 import { queryDuneSql } from "../../helpers/dune";
+import { METRIC } from "../../helpers/metrics";
 
 // Fees = per-swap (input notional * fee_at_that_time / 1e6), priced in the input token.
 // Fee history is init_dex ∪ every subsequent update_fee_and_revenue_cut call, window-joined
@@ -115,10 +116,11 @@ const fetch = async (options: FetchOptions) => {
     const jupiterShare = protocolCut * JUPITER_SHARE_OF_PROTOCOL;
     const fluidShare = protocolCut - jupiterShare;
 
-    dailyFees.add(inputMint, feeInToken);
-    dailySupplySideRevenue.add(inputMint, lpShare + fluidShare);
-    dailyRevenue.add(inputMint, jupiterShare);
-    dailyProtocolRevenue.add(inputMint, jupiterShare);
+    dailyFees.add(inputMint, feeInToken, "Jupiter Lend Dex Swap Fees");
+    dailySupplySideRevenue.add(inputMint, lpShare, "Jupiter Lend Dex Swap Fees to LPs");
+    dailySupplySideRevenue.add(inputMint, fluidShare, "Jupiter Lend Dex Swap Fees to Fluid");
+    dailyRevenue.add(inputMint, jupiterShare, "Jupiter Lend Dex Swap Fees to Protocol");
+    dailyProtocolRevenue.add(inputMint, jupiterShare, "Jupiter Lend Dex Swap Fees to Protocol");
   }
 
   return {
@@ -128,6 +130,22 @@ const fetch = async (options: FetchOptions) => {
     dailyProtocolRevenue,
   };
 };
+
+const breakdownMethodology = {
+  Fees: {
+    "Jupiter Lend Dex Swap Fees": "Total swap fees, priced in the input token.",
+  },
+  Revenue: {
+    "Jupiter Lend Dex Swap Fees to Protocol": "Jupiter's share of the protocol cut: fees x (revenue_cut/1e6) x 50%.",
+  },
+  ProtocolRevenue: {
+    "Jupiter Lend Dex Swap Fees to Protocol": "Jupiter's share of the protocol cut: fees x (revenue_cut/1e6) x 50%.",
+  },
+  SupplySideRevenue: {
+    "Jupiter Lend Dex Swap Fees to LPs": "LP share of swap fees plus Fluid's protocol share. LP share = fees x (1 - revenue_cut/1e6). Fluid receives 50% of the protocol cut per Jupiter Lend / Fluid arrangement.",
+    "Jupiter Lend Dex Swap Fees to Fluid": "Fluid's share of the protocol cut: fees x (revenue_cut/1e6) x 50%.",
+  }
+}
 
 const adapter: SimpleAdapter = {
   version: 1,
@@ -142,6 +160,7 @@ const adapter: SimpleAdapter = {
     Revenue: "Jupiter's share of the protocol cut: fees x (revenue_cut/1e6) x 50%.",
     ProtocolRevenue: "Same as Revenue - AMM fees do not feed the JUP buyback.",
   },
+  breakdownMethodology,
 };
 
 export default adapter;

--- a/fees/jupiter-lend-dex/index.ts
+++ b/fees/jupiter-lend-dex/index.ts
@@ -9,7 +9,7 @@ import { queryDuneSql } from "../../helpers/dune";
 // amount_in resolution:
 // - swap_in: exact from call arg (dex_call_swap_in.amount_in).
 // - swap_out: decoded from the Anchor LogSwap event in call_log_messages
-//   ("Program data: yvLkHCXC..." — base64 payload after 8-byte discriminator + u16 dex_id
+//   ("Program data: yvLkHCXCNCIC..." — base64 payload after 8-byte discriminator + u16 dex_id
 //   + u8 swap_0_to_1, u64 little-endian amount_in at byte 11).
 //
 // Revenue split: LP = fee * (1 - revenue_cut/1e6). Protocol = fee * revenue_cut/1e6.


### PR DESCRIPTION
## Summary

Adds volume and fees adapters for Jupiter Lend DEX, the AMM on Jupiter Lend's shared liquidity layer (Solana).

## Methodology

Volume: input-side notional per swap, priced in the input token.
- swap_in (exact-in): amount_in read directly from `dex_call_swap_in`.
- swap_out (exact-out): amount_in is not a call arg, so it is decoded from the `LogSwap` Anchor event embedded in `call_log_messages` (base64 payload, u64 LE at byte 11).

Fees: per-swap fee = `amount_in * pool.fee / 1e6`, using the fee that was effective at the swap's block_time. Fee history is `init_dex` unioned with every `update_fee_and_revenue_cut` call, window-joined via effective range so mid-period fee changes are handled.

Revenue split:
- LP: `fee * (1 - revenue_cut / 1e6)`
- Protocol: `fee * revenue_cut / 1e6`, split 50/50 between Jupiter and Fluid.
- Jupiter's share populates `dailyRevenue` and `dailyProtocolRevenue`; Fluid's share is included in `dailySupplySideRevenue`. AMM fees do not feed the JUP buyback.

Per-pool `revenue_cut` values differ on-chain (FfEJYz4h uses 2.5%, others use 25%) and are read per-swap from Dune.

## Validation

```
npm test dexs jupiter-lend-dex 1784917800
  Daily volume: 72.00

npm test fees jupiter-lend-dex 1784917800
  Daily fees: 0.01
  Daily supply side revenue: 0.01
  Daily revenue: 0.00
  Daily protocol revenue: 0.00
```

Fee-history join verified against the real fee change on the SyrupUSDC/USDC pool (500 -> 100 on 2026-07-21).

##### Name (to be shown on DefiLlama):
Jupiter Lend DEX

##### Twitter Link:
https://x.com/JupiterExchange

##### Website Link:
https://jup.ag/lend

##### Category:
Dexs

##### Parent Protocol:
Jupiter