### PR TITLE
pact: point at the current volume endpoint

### DIFF
--- a/dexs/pact/index.ts
+++ b/dexs/pact/index.ts
@@ -3,9 +3,6 @@ import type { SimpleAdapter, FetchOptions } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 import { getTimestampAtStartOfPreviousDayUTC } from "../../utils/date";
 
-// The old /api/pools/overall/historical_stats path 404s. app.pact.fi now calls
-// this one, and it only serves a rolling ~31 day window: any older `start` comes
-// back with the same last 31 days, so dates beyond that return no matching row.
 const URL = (date: string) => `https://api.pact.fi/api/internal/pools_details/overall/historical_stats?interval=DAY&start=${date}`;
 
 interface IAPIResponse {
@@ -19,6 +16,10 @@ const fetch = async (options: FetchOptions) => {
   const response: IAPIResponse[] = (await fetchURL(url));
   const dailyVolume = response
     .find(dayItem => (new Date(dayItem.for_datetime.split('T')[0]).getTime() / 1000) === options.startOfDay)?.volume_usd;
+
+  if (dailyVolume == undefined) {
+    throw new Error(`No daily volume found for date ${options.dateString}`);
+  }
 
   return {
     dailyVolume: dailyVolume,

--- a/dexs/pact/index.ts
+++ b/dexs/pact/index.ts
@@ -3,11 +3,14 @@ import type { SimpleAdapter, FetchOptions } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 import { getTimestampAtStartOfPreviousDayUTC } from "../../utils/date";
 
-const URL = (date: string) => `https://api.pact.fi/api/pools/overall/historical_stats?interval=DAY&start=${date}`;
+// The old /api/pools/overall/historical_stats path 404s. app.pact.fi now calls
+// this one, and it only serves a rolling ~31 day window: any older `start` comes
+// back with the same last 31 days, so dates beyond that return no matching row.
+const URL = (date: string) => `https://api.pact.fi/api/internal/pools_details/overall/historical_stats?interval=DAY&start=${date}`;
 
 interface IAPIResponse {
   for_datetime: string;
-  volume: string;
+  volume_usd: string;
 };
 
 const fetch = async (options: FetchOptions) => {
@@ -15,7 +18,7 @@ const fetch = async (options: FetchOptions) => {
   const url = URL(new Date(yesterdaysTimestamp * 1000).toISOString());
   const response: IAPIResponse[] = (await fetchURL(url));
   const dailyVolume = response
-    .find(dayItem => (new Date(dayItem.for_datetime.split('T')[0]).getTime() / 1000) === options.startOfDay)?.volume;
+    .find(dayItem => (new Date(dayItem.for_datetime.split('T')[0]).getTime() / 1000) === options.startOfDay)?.volume_usd;
 
   return {
     dailyVolume: dailyVolume,


### PR DESCRIPTION
Closes #8428.

`/api/pools/overall/historical_stats` now 404s and serves the marketing site's HTML. Volume has been stuck since 2026-07-06, `total24h` null.

`app.pact.fi` calls `/api/internal/pools_details/overall/historical_stats`. Found it in the app's JS bundle (base client `https://api.pact.fi/api/`, call site `getAppStats` hitting `internal/pools_details/overall/historical_stats`). The response renamed the field too, so both the path and the parsed key change:

```
before  {"for_datetime": "...", "volume": "..."}
after   {"for_datetime": "...", "tvl_usd": "...", "volume_usd": "..."}
```

Real response:

```
GET https://api.pact.fi/api/internal/pools_details/overall/historical_stats?interval=DAY&start=2026-07-20T00:00:00.000Z
[{"for_datetime":"2026-07-20T00:00:00.000Z","tvl_usd":"1446410.00000000","volume_usd":"18654.800000"},
 {"for_datetime":"2026-07-21T00:00:00.000Z","tvl_usd":"1446630.00000000","volume_usd":"28289.800000"}, ...]
```

Units are USD, from the field name and from the sibling `tvl_usd` reading ~1.44M, a sane TVL here.

Not a deadFrom candidate: the Algorand indexer shows real application-call swaps on 2026-07-25 against the ALGO/gALGO pool `GX2RAYAGFF6G46645F2TM4OO53H3QDSGFQ5IWJP6IFWV3W4UYBO3OD2TUA`.

## Limitation, disclosed rather than papered over

The endpoint clamps to a rolling ~31 day window. `start=2022-11-04` returns the same 31 rows as any other old start (2026-06-26 through today). I left a comment on the URL saying so.

Dates older than the window find no matching row, so `dailyVolume` is `undefined`, and `adapters/utils/runAdapter.ts:278` skips storing undefined rather than writing zero. So refills cannot overwrite existing history with zeros. But a full re-onboard from the 2022 start date is not possible against this endpoint. The current gap (2026-07-06 to now) sits entirely inside the window.

## Tests

```
2026-07-22   404 error -> 28.29 k    matches the API's 28289.8 for 2026-07-21
2026-07-10   404 error -> 33.15 k
2026-01-15   outside the window, no value returned, nothing stored
```