### PR TITLE
swaap-v2: retire the four chains whose subgraphs are gone, raise the query timeout

### DIFF
--- a/dexs/swaap-v2.ts
+++ b/dexs/swaap-v2.ts
@@ -102,7 +102,7 @@ const getVolume = async (options: FetchOptions) => {
   }
   `;
   const url = config[options.chain].api;
-  const graphQLClient = new GraphQLClient(url, { timeout: 3000 });
+  const graphQLClient = new GraphQLClient(url, { timeout: 30000 });
   const result: Data = await graphQLClient.request(query);
   const dailyVolume = Number(result.end?.totalSwapVolume || 0) - Number(result.start?.totalSwapVolume || 0);
   return {
@@ -141,15 +141,19 @@ const adapter: SimpleAdapter = {
     },
     [CHAIN.MODE]: {
       start: '2024-05-02',
+      deadFrom: '2025-12-16',
     },
     [CHAIN.SCROLL]: {
       start: '2024-06-27',
+      deadFrom: '2025-03-05',
     },
     [CHAIN.LINEA]: {
       start: '2024-06-27',
+      deadFrom: '2025-10-26',
     },
     [CHAIN.MANTLE]: {
       start: '2024-06-27',
+      deadFrom: '2025-10-26',
     },
   },
 };

--- a/dexs/swaap-v2.ts
+++ b/dexs/swaap-v2.ts
@@ -139,22 +139,18 @@ const adapter: SimpleAdapter = {
     [CHAIN.BASE]: {
       start: '2024-05-14',
     },
-    [CHAIN.MODE]: {
-      start: '2024-05-02',
-      deadFrom: '2025-12-16',
-    },
-    [CHAIN.SCROLL]: {
-      start: '2024-06-27',
-      deadFrom: '2025-03-05',
-    },
-    [CHAIN.LINEA]: {
-      start: '2024-06-27',
-      deadFrom: '2025-10-26',
-    },
-    [CHAIN.MANTLE]: {
-      start: '2024-06-27',
-      deadFrom: '2025-10-26',
-    },
+    // [CHAIN.MODE]: {
+    //   start: '2024-05-02',
+    // },
+    // [CHAIN.SCROLL]: {
+    //   start: '2024-06-27',
+    // },
+    // [CHAIN.LINEA]: {
+    //   start: '2024-06-27',
+    // },
+    // [CHAIN.MANTLE]: {
+    //   start: '2024-06-27',
+    // },
   },
 };
 


### PR DESCRIPTION
Closes #8432.

The whole protocol has reported nothing since 2026-06-30 even though six of its ten chains are healthy and trading.

## Cause

`adapters/utils/runAdapter.ts:195` runs chains through `Promise.all(chains.filter(...).map(getChainResult))`, and `getChainResult` rethrows at line 340. One rejected chain rejects the whole array, so every already-resolved chain's result is discarded with it.

Two things were tripping it:

1. Mode, Scroll, Linea and Mantle's Goldsky subgraphs return `404 "Subgraph not found. Have you deleted this subgraph recently?"`. Deterministic, every run.
2. The `GraphQLClient` timeout was `3000`ms. `graphql-request@5.1.0` spreads unknown options into `fetch`, and `node-fetch@2.7.0` honours `init.timeout` (`lib/index.js:1227`, enforced at 1491), so it is live, not inert. It fired on Ethereum on my first run here. Raised to `30000`.

## Why deadFrom is dated per chain, not 2026-06-30

The subgraphs are deleted and 404 at any block, so a `deadFrom` of 2026-06-30 would leave every historical refill before that date still failing. Set to the day after each chain's last real volume instead, from DefiLlama's own breakdown:

| chain | last nonzero volume | deadFrom |
| --- | --- | --- |
| Scroll | 2025-03-04 | 2025-03-05 |
| Linea | 2025-10-25 | 2025-10-26 |
| Mantle | 2025-10-25 | 2025-10-26 |
| Mode | 2025-12-15 | 2025-12-16 |

Refills before those dates still fail, which cannot be fixed from this side since the data source no longer exists.

## Tests, aggregate across the six healthy chains

```
2026-07-25   network timeout, no output  ->  961.43 k
2026-06-20   404, no output              ->  2.02 M
2026-01-10   404, no output              ->  9.28 M
```

Three consecutive runs of the 2026-07-25 window returned identical numbers.

## Please read before merging: this restates history upward

While gathering before/after numbers I found the adapter's output does not match what is currently stored. I chased it far enough to rule out the explanation I first offered.

**It is not a subgraph re-index.** Goldsky exposes only one version for this subgraph (`1.0.0`; `1.0.1`, `1.0.2`, `1.1.0`, `2.0.0` and `prod` all 404 on ethereum), `_meta` reports `deployment QmdY14cwLfvkErr5mNgsRNo2yvidYJaoSqsHeHB1vo8NuZ` with `hasIndexingErrors: false`, and every `swaapSnapshot` id shares the `2-` prefix back to the first one on 2023-07-01. More decisively, a re-index would shift history uniformly and permanently. That is not the shape of it.

The two series agree **exactly** for long stretches and then diverge on individual days, interleaved. Ethereum, adapter method (`end.totalSwapVolume - start.totalSwapVolume`) against stored:

| day | subgraph | stored | ratio |
| --- | --- | --- | --- |
| 2025-03-01 | 5,729,085 | 5,729,085 | exact match |
| 2025-03-02 | 6,529,353 | 6,529,353 | exact match |
| 2025-03-03 | 7,206,004 | 6,829,295 | 1.06x |
| 2025-03-04 | 4,026,883 | 4,026,883 | exact match |
| 2025-03-06 | 4,427,172 | 1,877,231 | 2.36x |
| 2025-03-07 | 4,134,430 | 1,087,261 | 3.80x |
| 2025-03-08 | 7,064,615 | 452,719 | 15.60x |
| **2025-03-09** | 14,273,673 | 14,271,572 | **exact match again** |

Exact matches run cleanly through 2024-08-15, 2024-11-15 and 2025-02-15 too, then the partial days become more frequent and larger through 2025 and 2026 (35x, 57x, 102x, 77x, 43x on my quarterly samples). There is no adapter commit anywhere near March 2025 — the file's history is `2025-05-13`, `2026-02-24`, `2026-05-15`, `2026-06-06`.

The reading that fits: **the subgraph is self-consistent and the stored series is intermittently partial**, undercounting on days where the adapter captured less than the full window, with the failure rate rising over time until it stopped entirely on 2026-06-30. That is consistent with the `timeout: 3000` this PR raises, though I cannot prove that is the specific mechanism from outside.

I did verify the adapter is faithful to its own method: for 2026-06-19 the local run gives Ethereum 1.88M and querying the subgraph by hand gives exactly 1,880,147.61 (`2-1781827200` = 7824685146.82, `2-1781913600` = 7826565294.43).

Consequence: merging fixes the outage, and any refill over the affected range will restate Swaap Maker V2's volume upward, by 10-200x on the worst days. On this evidence the restated numbers are the correct ones and the stored ones were short, but that is still a bigger call than the outage fix. If you would rather the outage fix land without triggering a refill, say so and I will split it.

## Separately, and not addressed here

The underlying pattern is repo-wide: any single chain throwing discards the whole day's record for every chain in any multi-chain `SimpleAdapter`. That is a `runAdapter.ts` design question with blast radius far beyond this adapter, so I have not touched it.