### PR TITLE
icpswap: track fees, revenue, and LP fees

### DIFF
--- a/dexs/icpswap/index.ts
+++ b/dexs/icpswap/index.ts
@@ -1,20 +1,46 @@
-import { Adapter, FetchResultVolume, FetchOptions } from "../../adapters/types";import { CHAIN } from "../../helpers/chains";
+import { Adapter, FetchOptions } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
 import fetchURL from "../../utils/fetchURL";
 
-const fetch  = async (options: FetchOptions): Promise<FetchResultVolume> => {
-  const { volumeUSD } = await fetchURL('https://uvevg-iyaaa-aaaak-ac27q-cai.raw.ic0.app/overview')
-  
-  options.toTimestamp = options.startOfDay;
-  return {
-    dailyVolume: volumeUSD,}
-}
+// https://iloveics.gitbook.io/icpswap/ics/how-much-are-icpswap-fees
+// Fee breakdown: 0.3% total swap fee
+// 0.06% → ICS token buybacks/burns (protocol revenue)
+// 0.24% → liquidity providers (supply-side revenue)
+const TOTAL_FEE = 0.003;
+const PROTOCOL_FEE = 0.0006;
+const LP_FEE = 0.0024;
 
+const fetch = async (options: FetchOptions) => {
+  const { volumeUSD } = await fetchURL('https://uvevg-iyaaa-aaaak-ac27q-cai.raw.ic0.app/overview');
+
+  options.toTimestamp = options.startOfDay;
+
+  const dailyVolume = volumeUSD;
+  const dailyFees = dailyVolume * TOTAL_FEE;
+  const dailyRevenue = dailyVolume * PROTOCOL_FEE;
+  const dailySupplySideRevenue = dailyVolume * LP_FEE;
+
+  return {
+    dailyVolume,
+    dailyFees,
+    dailyRevenue,
+    dailySupplySideRevenue,
+  };
+};
+
+const methodology = {
+  Volume: "Trading volume across all ICPSwap pools.",
+  Fees: "0.3% fee charged on every swap.",
+  Revenue: "0.06% of each swap allocated to ICS token buybacks and burns.",
+  SupplySideRevenue: "0.24% of each swap distributed to liquidity providers.",
+};
 
 const adapter: Adapter = {
   fetch,
   chains: [CHAIN.ICP],
   start: '2023-07-16',
   runAtCurrTime: true,
-}
+  methodology,
+};
 
 export default adapter;

--- a/dexs/icpswap/index.ts
+++ b/dexs/icpswap/index.ts
@@ -1,6 +1,7 @@
 import { Adapter, FetchOptions } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 import fetchURL from "../../utils/fetchURL";
+import { METRIC } from "../../helpers/metrics";
 
 // https://iloveics.gitbook.io/icpswap/ics/how-much-are-icpswap-fees
 // Fee breakdown: 0.3% total swap fee
@@ -13,17 +14,20 @@ const LP_FEE = 0.0024;
 const fetch = async (options: FetchOptions) => {
   const { volumeUSD } = await fetchURL('https://uvevg-iyaaa-aaaak-ac27q-cai.raw.ic0.app/overview');
 
-  options.toTimestamp = options.startOfDay;
-
   const dailyVolume = volumeUSD;
-  const dailyFees = dailyVolume * TOTAL_FEE;
-  const dailyRevenue = dailyVolume * PROTOCOL_FEE;
-  const dailySupplySideRevenue = dailyVolume * LP_FEE;
+  const dailyFees = options.createBalances();
+  const dailyRevenue = options.createBalances();
+  const dailySupplySideRevenue = options.createBalances();
+
+  dailyFees.addUSDValue(dailyVolume * TOTAL_FEE, METRIC.SWAP_FEES);
+  dailyRevenue.addUSDValue(dailyVolume * PROTOCOL_FEE, "Token Swap Fees to Buyback and Burn");
+  dailySupplySideRevenue.addUSDValue(dailyVolume * LP_FEE, "Token Swap Fees to LPs");
 
   return {
     dailyVolume,
     dailyFees,
     dailyRevenue,
+    dailyHoldersRevenue: dailyRevenue,
     dailySupplySideRevenue,
   };
 };
@@ -32,8 +36,24 @@ const methodology = {
   Volume: "Trading volume across all ICPSwap pools.",
   Fees: "0.3% fee charged on every swap.",
   Revenue: "0.06% of each swap allocated to ICS token buybacks and burns.",
+  HoldersRevenue: "0.06% of each swap allocated to ICS token buybacks and burns.",
   SupplySideRevenue: "0.24% of each swap distributed to liquidity providers.",
 };
+
+const breakdownMethodology = {
+  Fees: {
+    [METRIC.SWAP_FEES]: "0.3% fee charged on every swap.",
+  },
+  Revenue: {
+    "Token Swap Fees to Buyback and Burn": "0.06% of each swap allocated to ICS token buybacks and burns.",
+  },
+  HoldersRevenue: {
+    "Token Swap Fees to Buyback and Burn": "0.06% of each swap allocated to ICS token buybacks and burns.",
+  },
+  SupplySideRevenue: {
+    "Token Swap Fees to LPs": "0.24% of each swap distributed to liquidity providers.",
+  },
+}
 
 const adapter: Adapter = {
   fetch,
@@ -41,6 +61,7 @@ const adapter: Adapter = {
   start: '2023-07-16',
   runAtCurrTime: true,
   methodology,
+  breakdownMethodology,
 };
 
 export default adapter;


### PR DESCRIPTION
## Summary
Adds fee tracking to the ICPSwap adapter based on the protocol's published tokenomics.
Fee breakdown sourced from [docs](https://iloveics.gitbook.io/icpswap/ics/how-much-are-icpswap-fees) , 0.3% total swap fee split between LP revenue (0.24%) and revenue via ICS buybacks/burns (0.06%).