### PR TITLE
etherex: count legacy pools and fix xREX instant-exit fee

### DIFF
--- a/dexs/etherex.ts
+++ b/dexs/etherex.ts
@@ -95,7 +95,7 @@ async function getBribes(options: FetchOptions) {
 
 async function getTokens(options: FetchOptions, tokens: string[]) {
   const tokenIds = tokens.map((e) => `"${e}"`).join(",");
-  
+
   // Use tokenDayDatas for historical prices instead of block-based queries
   const query = gql`
     query tokenDayDatas($first: Int!, $skip: Int!, $startOfDay: Int!) {
@@ -121,7 +121,7 @@ async function getTokens(options: FetchOptions, tokens: string[]) {
       first,
       skip,
       startOfDay: options.startOfDay,
-    }).then((data) => 
+    }).then((data) =>
       // Transform tokenDayDatas to match expected token format
       data.tokenDayDatas.map((td: any) => ({
         id: td.token.id,
@@ -222,36 +222,30 @@ const fetch = async (options: FetchOptions) => {
   const dailySupplySideRevenue = options.createBalances()
   const dailyHoldersRevenue = options.createBalances()
 
-  const swapFeesUSD = stats.clFeesUSD + stats.legacyFeesUSD
-  const holderSwapFeesUSD = stats.clUserFeesRevenueUSD + stats.legacyUserFeesRevenueUSD
-  const protocolSwapFeesUSD = stats.clProtocolRevenueUSD + stats.legacyProtocolRevenueUSD
-  const bribesUSD = stats.clBribeRevenueUSD + stats.legacyBribeRevenueUSD
-
-  // Fees — labelled by source
-  dailyFees.addUSDValue(swapFeesUSD, 'Token Swap Fees')
+  dailyFees.addUSDValue(stats.clFeesUSD, 'Token Swap Fees')
   dailyFees.addUSDValue(stats.dailyXrexInstantExitFeeUSD, 'Instant Exit Fees')
-  dailyFees.addUSDValue(bribesUSD, 'Bribes Rewards')
+  dailyFees.addUSDValue(stats.clBribeRevenueUSD, 'Bribes Rewards')
 
   // User fees — swap fees and the exit penalty are paid by users; bribes come from third parties
-  dailyUserFees.addUSDValue(swapFeesUSD, 'Token Swap Fees')
+  dailyUserFees.addUSDValue(stats.clFeesUSD, 'Token Swap Fees')
   dailyUserFees.addUSDValue(stats.dailyXrexInstantExitFeeUSD, 'Instant Exit Fees')
 
   // Revenue / holders / protocol — labelled by destination
-  dailyRevenue.addUSDValue(holderSwapFeesUSD, 'Token Swap Fees To Holders')
-  dailyRevenue.addUSDValue(protocolSwapFeesUSD, 'Token Swap Fees To Protocol')
+  dailyRevenue.addUSDValue(stats.clUserFeesRevenueUSD, 'Token Swap Fees To Holders')
+  dailyRevenue.addUSDValue(stats.clProtocolRevenueUSD, 'Token Swap Fees To Protocol')
   dailyRevenue.addUSDValue(stats.dailyXrexInstantExitFeeUSD, 'Instant Exit Fees To Holders')
-  dailyRevenue.addUSDValue(bribesUSD, 'Bribes Revenue')
+  dailyRevenue.addUSDValue(stats.clBribeRevenueUSD, 'Bribes Revenue')
 
-  dailyHoldersRevenue.addUSDValue(holderSwapFeesUSD, 'Token Swap Fees To Holders')
+  dailyHoldersRevenue.addUSDValue(stats.clUserFeesRevenueUSD, 'Token Swap Fees To Holders')
   dailyHoldersRevenue.addUSDValue(stats.dailyXrexInstantExitFeeUSD, 'Instant Exit Fees To Holders')
-  dailyHoldersRevenue.addUSDValue(bribesUSD, 'Bribes Revenue')
+  dailyHoldersRevenue.addUSDValue(stats.clBribeRevenueUSD, 'Bribes Revenue')
 
-  dailyProtocolRevenue.addUSDValue(protocolSwapFeesUSD, 'Token Swap Fees To Protocol')
+  dailyProtocolRevenue.addUSDValue(stats.clProtocolRevenueUSD, 'Token Swap Fees To Protocol')
 
-  dailySupplySideRevenue.addUSDValue(swapFeesUSD - holderSwapFeesUSD - protocolSwapFeesUSD, 'Token Swap Fees To LPs')
+  dailySupplySideRevenue.addUSDValue(stats.clFeesUSD - stats.clUserFeesRevenueUSD - stats.clProtocolRevenueUSD, 'Token Swap Fees To LPs')
 
   return {
-    dailyVolume: stats.clVolumeUSD + stats.legacyVolumeUSD,
+    dailyVolume: stats.clVolumeUSD,
     dailyFees,
     dailyUserFees,
     dailyHoldersRevenue,
@@ -262,7 +256,7 @@ const fetch = async (options: FetchOptions) => {
 };
 
 const methodology = {
-  Fees: "Swap fees paid by traders on Etherex concentrated-liquidity and legacy pools, plus the 50% penalty forfeited by xREX holders who exit instantly, plus vote bribes deposited for pools.",
+  Fees: "Swap fees paid by traders on Etherex concentrated-liquidity pools, plus the 50% penalty forfeited by xREX holders who exit instantly, plus vote bribes deposited for pools.",
   UserFees: "Swap fees paid by traders plus the xREX instant-exit penalty. Vote bribes come from third parties and are excluded.",
   Revenue: "Swap fees routed to xREX holders and the treasury, the instant-exit penalty streamed to xREX stakers, and vote bribes.",
   ProtocolRevenue: "Treasury share of swap fees.",
@@ -277,12 +271,12 @@ const adapter: SimpleAdapter = {
   methodology,
   breakdownMethodology: {
     Fees: {
-      'Token Swap Fees': 'Swap fees paid by traders on Etherex concentrated-liquidity and legacy pools.',
+      'Token Swap Fees': 'Swap fees paid by traders on Etherex concentrated-liquidity pools.',
       'Instant Exit Fees': 'The 50% penalty forfeited by xREX holders who exit instantly, streamed to xREX stakers as rebase rewards.',
       'Bribes Rewards': 'Vote bribes deposited for Etherex pools.',
     },
     UserFees: {
-      'Token Swap Fees': 'Swap fees paid by traders on Etherex concentrated-liquidity and legacy pools.',
+      'Token Swap Fees': 'Swap fees paid by traders on Etherex concentrated-liquidity pools.',
       'Instant Exit Fees': 'The 50% penalty forfeited by xREX holders who exit instantly.',
     },
     Revenue: {

--- a/dexs/etherex.ts
+++ b/dexs/etherex.ts
@@ -188,7 +188,7 @@ export async function fetchStats(options: FetchOptions): Promise<IGraphRes> {
   }
 
   // Calculate xREX rebase revenue in USD
-  const rexToken = tokens.find((t) => t.id === REX_TOKEN_CONTRACT);
+  const rexToken = tokens.find((t) => t.id === REX_TOKEN_CONTRACT.toLowerCase());
   const rexPriceUSD = Number(rexToken?.priceUSD ?? 0);
   const dailyXrexInstantExitFeeUSD = rexPenaltyAmount * rexPriceUSD; // Voters will get the rex token as rebase
 
@@ -216,30 +216,44 @@ const fetch = async (options: FetchOptions) => {
   const stats = await fetchStats(options);
 
   const dailyFees = options.createBalances()
+  const dailyUserFees = options.createBalances()
   const dailyRevenue = options.createBalances()
   const dailyProtocolRevenue = options.createBalances()
   const dailySupplySideRevenue = options.createBalances()
   const dailyHoldersRevenue = options.createBalances()
-  
-  dailyFees.addUSDValue(stats.clFeesUSD, 'Token Swap Fees')
+
+  const swapFeesUSD = stats.clFeesUSD + stats.legacyFeesUSD
+  const holderSwapFeesUSD = stats.clUserFeesRevenueUSD + stats.legacyUserFeesRevenueUSD
+  const protocolSwapFeesUSD = stats.clProtocolRevenueUSD + stats.legacyProtocolRevenueUSD
+  const bribesUSD = stats.clBribeRevenueUSD + stats.legacyBribeRevenueUSD
+
+  // Fees — labelled by source
+  dailyFees.addUSDValue(swapFeesUSD, 'Token Swap Fees')
   dailyFees.addUSDValue(stats.dailyXrexInstantExitFeeUSD, 'Instant Exit Fees')
-  dailyFees.addUSDValue(stats.clBribeRevenueUSD, 'Bribes Rewards')
+  dailyFees.addUSDValue(bribesUSD, 'Bribes Rewards')
 
-  dailyRevenue.addUSDValue(stats.clUserFeesRevenueUSD, 'Token Swap Fees To Holders')
-  dailyRevenue.addUSDValue(stats.clProtocolRevenueUSD, 'Token Swap Fees To Protocol')
-  dailyRevenue.addUSDValue(stats.clBribeRevenueUSD, 'Bribes Revenue')
+  // User fees — swap fees and the exit penalty are paid by users; bribes come from third parties
+  dailyUserFees.addUSDValue(swapFeesUSD, 'Token Swap Fees')
+  dailyUserFees.addUSDValue(stats.dailyXrexInstantExitFeeUSD, 'Instant Exit Fees')
 
-  dailyHoldersRevenue.addUSDValue(stats.clUserFeesRevenueUSD, 'Token Swap Fees To Holders')
-  dailyHoldersRevenue.addUSDValue(stats.clBribeRevenueUSD, 'Bribes Revenue')
-  
-  dailyProtocolRevenue.addUSDValue(stats.clProtocolRevenueUSD, 'Token Swap Fees To Protocol')
+  // Revenue / holders / protocol — labelled by destination
+  dailyRevenue.addUSDValue(holderSwapFeesUSD, 'Token Swap Fees To Holders')
+  dailyRevenue.addUSDValue(protocolSwapFeesUSD, 'Token Swap Fees To Protocol')
+  dailyRevenue.addUSDValue(stats.dailyXrexInstantExitFeeUSD, 'Instant Exit Fees To Holders')
+  dailyRevenue.addUSDValue(bribesUSD, 'Bribes Revenue')
 
-  dailySupplySideRevenue.addUSDValue(stats.clFeesUSD - stats.clUserFeesRevenueUSD - stats.clProtocolRevenueUSD, 'Token Swap Fees To LPs')
-  
+  dailyHoldersRevenue.addUSDValue(holderSwapFeesUSD, 'Token Swap Fees To Holders')
+  dailyHoldersRevenue.addUSDValue(stats.dailyXrexInstantExitFeeUSD, 'Instant Exit Fees To Holders')
+  dailyHoldersRevenue.addUSDValue(bribesUSD, 'Bribes Revenue')
+
+  dailyProtocolRevenue.addUSDValue(protocolSwapFeesUSD, 'Token Swap Fees To Protocol')
+
+  dailySupplySideRevenue.addUSDValue(swapFeesUSD - holderSwapFeesUSD - protocolSwapFeesUSD, 'Token Swap Fees To LPs')
+
   return {
-    dailyVolume: stats.clVolumeUSD,
+    dailyVolume: stats.clVolumeUSD + stats.legacyVolumeUSD,
     dailyFees,
-    dailyUserFees: dailyFees,
+    dailyUserFees,
     dailyHoldersRevenue,
     dailyProtocolRevenue,
     dailyRevenue,
@@ -248,13 +262,12 @@ const fetch = async (options: FetchOptions) => {
 };
 
 const methodology = {
-  Fees: "Fees are collected from users on each swap + xREX stakers instant exit penalty + bribes revenue.",
-  Revenue: "Revenue going to the protocol + Token holder Revenue.",
-  UserFees: "User pays fees on each swap.",
-  ProtocolRevenue: "Revenue going to the protocol.",
-  HoldersRevenue: "User fees are distributed among holders.",
-  SupplySideRevenue: "Fees distributed to LPs (from gauged pools).",
-  TokenTax: "xREX stakers instant exit penalty",
+  Fees: "Swap fees paid by traders on Etherex concentrated-liquidity and legacy pools, plus the 50% penalty forfeited by xREX holders who exit instantly, plus vote bribes deposited for pools.",
+  UserFees: "Swap fees paid by traders plus the xREX instant-exit penalty. Vote bribes come from third parties and are excluded.",
+  Revenue: "Swap fees routed to xREX holders and the treasury, the instant-exit penalty streamed to xREX stakers, and vote bribes.",
+  ProtocolRevenue: "Treasury share of swap fees.",
+  HoldersRevenue: "Swap fees routed to xREX voters, the instant-exit penalty rebased to xREX stakers, and vote bribes distributed to voters.",
+  SupplySideRevenue: "Swap fees kept by liquidity providers after the xREX-voter and treasury shares.",
 };
 
 const adapter: SimpleAdapter = {
@@ -264,29 +277,30 @@ const adapter: SimpleAdapter = {
   methodology,
   breakdownMethodology: {
     Fees: {
-      'Token Swap Fees': 'Swap fees paid by users on Etherex concentrated liquidity pools.',
-      'Instant Exit Fees': 'xREX instant exit penalties paid by users and distributed to xREX stakers as rebase rewards.',
-      'Bribes Rewards': 'Vote bribes deposited for Etherex concentrated liquidity pools.',
+      'Token Swap Fees': 'Swap fees paid by traders on Etherex concentrated-liquidity and legacy pools.',
+      'Instant Exit Fees': 'The 50% penalty forfeited by xREX holders who exit instantly, streamed to xREX stakers as rebase rewards.',
+      'Bribes Rewards': 'Vote bribes deposited for Etherex pools.',
     },
     UserFees: {
-      'Token Swap Fees': 'Swap fees paid by users on Etherex concentrated liquidity pools.',
-      'Instant Exit Fees': 'xREX instant exit penalties paid by users.',
-      'Bribes Rewards': 'Vote bribes deposited for Etherex concentrated liquidity pools.',
+      'Token Swap Fees': 'Swap fees paid by traders on Etherex concentrated-liquidity and legacy pools.',
+      'Instant Exit Fees': 'The 50% penalty forfeited by xREX holders who exit instantly.',
     },
     Revenue: {
-      'Token Swap Fees To Holders': 'Portion of concentrated liquidity swap fees distributed to xREX holders.',
-      'Token Swap Fees To Protocol': 'Treasury portion of concentrated liquidity swap fees.',
-      'Bribes Revenue': 'Vote bribes distributed to xREX holders.',
+      'Token Swap Fees To Holders': 'Portion of swap fees distributed to xREX voters.',
+      'Token Swap Fees To Protocol': 'Treasury portion of swap fees.',
+      'Instant Exit Fees To Holders': 'xREX instant-exit penalty rebased to xREX stakers.',
+      'Bribes Revenue': 'Vote bribes distributed to xREX voters.',
     },
     ProtocolRevenue: {
-      'Token Swap Fees To Protocol': 'Treasury portion of concentrated liquidity swap fees.',
+      'Token Swap Fees To Protocol': 'Treasury portion of swap fees.',
     },
     HoldersRevenue: {
-      'Token Swap Fees To Holders': 'Portion of concentrated liquidity swap fees distributed to xREX holders.',
-      'Bribes Revenue': 'Vote bribes distributed to xREX holders.',
+      'Token Swap Fees To Holders': 'Portion of swap fees distributed to xREX voters.',
+      'Instant Exit Fees To Holders': 'xREX instant-exit penalty rebased to xREX stakers.',
+      'Bribes Revenue': 'Vote bribes distributed to xREX voters.',
     },
     SupplySideRevenue: {
-      'Token Swap Fees To LPs': 'Concentrated liquidity swap fees retained by LPs after holder and treasury fee shares.',
+      'Token Swap Fees To LPs': 'Swap fees retained by liquidity providers after the xREX-voter and treasury shares.',
     },
   }
 };


### PR DESCRIPTION
Fixes several accounting issues in `dexs/etherex`, aligning fee and revenue reporting with the deployed contracts and subgraph.

### Changes

- Fixed REX price lookup by normalizing token addresses, restoring xREX instant-exit fees that were previously valued at $0.
- Included **legacy pools** in volume, fees, and all revenue fields instead of reporting only CL pools.
- Classified the xREX **instant-exit penalty** as `dailyHoldersRevenue`, ensuring `dailyFees = dailySupplySideRevenue + dailyRevenue`.
- Limited `dailyUserFees` to swap fees and instant-exit penalties, excluding third-party vote bribes.

### Verification

- Verified `XRex.sol` on Sourcify: the instant-exit penalty is a fixed **50%** and is rebased to remaining xREX stakers, making it holders revenue.
- Legacy pools account for roughly **23% of fees** and **3% of volume** over the past 30 days.