### PR TITLE
camelot-v3: read each pool's fee split on-chain

### DIFF
--- a/dexs/camelot-v3/index.ts
+++ b/dexs/camelot-v3/index.ts
@@ -1,64 +1,72 @@
 import { FetchOptions, SimpleAdapter } from '../../adapters/types';
 import { CHAIN } from '../../helpers/chains';
-import { getUniV3LogAdapter } from '../../helpers/uniswap';
+import { getUniV3LogAdapter, UniGetRevenueRatioProps } from '../../helpers/uniswap';
 
 // Camelot V3 uses Algebra (Uniswap V3-style concentrated liquidity)
-// Fees are pool-specific and read on-chain from the Algebra pool configuration
-// 85% for Liquidity Providers in LP tokens
-// 7% redistributed to xGRAIL holders through Real Yield Staking plugin
-// 3.5% dedicated to GRAIL buyback and burn
-// 3% to the Operating expenses
-// 1.5% to Algebra for licensing V3 AMM
+// The protocol's cut of each pool's swap fees is the pool's on-chain community fee:
+// 15% on Arbitrum, 20% on the other deployments, 0% on a handful of pools.
+// Camelot splits that cut 70% to GRAIL/xGRAIL holders (7% xGRAIL Real Yield Staking
+// + 3.5% GRAIL buyback & burn of a 15% cut) and 30% to the protocol
+// (3% operating expenses + 1.5% Algebra V3 licensing).
 // Source: https://docs.camelot.exchange/tokenomics/protocol-earnings
 // Architecture: https://docs.camelot.exchange/protocol/amm-v3
 
 const methodology = {
-  Fees: 'Trading fees charged on swaps. Camelot V3 uses Algebra with dynamic fees.',
-  UserFees: 'Users pay dynamic fees on each swap (typically 0.05% to 1%).',
+  Fees: 'Trading fees paid by swappers. Each pool sets its own fee, which moves with volatility, and is read from the pool itself.',
+  UserFees: 'Swappers pay the whole trading fee, typically between 0.01% and 1.5% of the trade.',
   Revenue:
-    'Portion of trading fees not paid to liquidity providers, totaling 15% of swap fees (10.5% to xGRAIL holders + buyback&burn, 4.5% to treasury and Algebra licensing).',
+    'The share of trading fees Camelot keeps rather than paying out to liquidity providers, read from each pool on-chain: 15% on Arbitrum, 20% on the other chains, and 0% on pools where Camelot has waived its cut.',
   ProtocolRevenue:
-    '4.5% of trading fees go to the protocol (3% operating expenses + 1.5% Algebra V3 licensing).',
+    '30% of what Camelot keeps, covering operating expenses and the Algebra V3 licence fee.',
   HoldersRevenue:
-    '10.5% of trading fees go to GRAIL/xGRAIL holders (7% via xGRAIL Real Yield Staking + 3.5% via GRAIL buyback & burn).',
-  SupplySideRevenue: '85% of trading fees go to liquidity providers.',
+    '70% of what Camelot keeps, paid to GRAIL/xGRAIL holders through xGRAIL Real Yield Staking and GRAIL buyback & burn.',
+  SupplySideRevenue: 'The rest of the trading fees, paid to liquidity providers — 85% on Arbitrum, 80% on the other chains, and 100% on pools where Camelot takes no cut.',
 };
 
 const breakdownMethodology = {
   UserFees: {
-    'Trading fees': 'Dynamic fees paid by users on each swap, typically ranging from 0.05% to 1% of trade volume depending on market conditions',
+    'Trading fees': 'Fees paid by swappers, set per pool and moving with volatility, typically 0.01% to 1.5% of the trade',
   },
   Fees: {
-    'Trading fees': 'Total trading fees collected from all swaps on Camelot V3 pools using Algebra\'s dynamic fee model',
+    'Token Swap Fees': 'All trading fees collected across Camelot V3 pools, using each pool\'s own live fee rate',
   },
   Revenue: {
-    'Protocol fees': 'Combined protocol-controlled revenue (15% of trading fees) not paid to liquidity providers',
+    'Protocol fees': 'The share of trading fees Camelot keeps instead of paying liquidity providers, taken from each pool\'s on-chain community fee setting',
   },
   ProtocolRevenue: {
-    'Protocol fees': 'Portion of trading fees allocated to the protocol, equal to 4.5% of total swap fees (3% operating expenses + 1.5% Algebra V3 AMM licensing)',
+    'Protocol fees': 'The part of Camelot\'s cut that funds operating expenses and the Algebra V3 AMM licence, 30% of what the protocol keeps',
   },
   HoldersRevenue: {
-    'Tokenholder fees': 'Portion of trading fees returned to GRAIL/xGRAIL holders, equal to 10.5% of total swap fees (7% via xGRAIL Real Yield Staking + 3.5% via GRAIL buyback & burn)',
+    'Tokenholder fees': 'The part of Camelot\'s cut paid to GRAIL/xGRAIL holders via Real Yield Staking and GRAIL buyback & burn, 70% of what the protocol keeps',
   },
   SupplySideRevenue: {
-    'LP fees': 'Portion of trading fees distributed to liquidity providers who supply capital to the pools, equal to 85% of total swap fees',
+    'LP fees': 'Trading fees paid straight to the liquidity providers backing each pool',
   },
 };
 
-const REVENUE_RATIO = 0.15; // 15% total protocol-controlled 
 const USER_FEES_RATIO = 1; // Users pay 100% of fees
-const PROTOCOL_REVENUE_RATIO = 0.045; // 4.5% protocol: 3% operating expenses + 1.5% Algebra licensing
-const HOLDERS_REVENUE_RATIO = 0.105; // 10.5% holders: 7% xGRAIL Real Yield Staking + 3.5% GRAIL buyback & burn
+// Split of the pool community fee: docs give 7% + 3.5% to holders and 3% + 1.5% to the
+// protocol out of a 15% cut, i.e. 70/30
+const HOLDERS_SHARE = 0.7;
+const PROTOCOL_SHARE = 0.3;
 
 const algebraPoolCreatedEvent =
   'event Pool (address indexed token0, address indexed token1, address pool)';
 
-// Shared fee split
+// Revenue split comes from each pool's community fee, read on-chain
+const getRevenueRatio = ({ communityFeeRatio }: UniGetRevenueRatioProps) => {
+  if (communityFeeRatio === undefined) throw new Error('camelot-v3: could not read pool community fee');
+  return {
+    _revenueRatio: communityFeeRatio,
+    _protocolRevenueRatio: communityFeeRatio * PROTOCOL_SHARE,
+    _holdersRevenueRatio: communityFeeRatio * HOLDERS_SHARE,
+  };
+};
+
 const baseConfig = {
   userFeesRatio: USER_FEES_RATIO,
-  revenueRatio: REVENUE_RATIO,
-  protocolRevenueRatio: PROTOCOL_REVENUE_RATIO,
-  holdersRevenueRatio: HOLDERS_REVENUE_RATIO,
+  algebraCommunityFee: true,
+  getRevenueRatio,
 };
 
 // Most Camelot deployments use the original Algebra (v1.x) pools, where the

--- a/helpers/uniswap.ts
+++ b/helpers/uniswap.ts
@@ -172,12 +172,15 @@ export const getUniV2LogAdapter: any = (v2Config: UniV2Config): FetchV2 => {
 const defaultV3SwapEvent = 'event Swap(address indexed sender, address indexed recipient, int256 amount0, int256 amount1, uint160 sqrtPriceX96, uint128 liquidity, int24 tick)'
 const defaultPoolCreatedEvent = 'event PoolCreated(address indexed token0, address indexed token1, uint24 indexed fee, int24 tickSpacing, address pool)'
 const defaultAlgebraV3PoolCreatedEvent = 'event Pool (address indexed token0, address indexed token1, address pool)'
+// Algebra Constants.COMMUNITY_FEE_DENOMINATOR, same on V1.9 and Integral
+const COMMUNITY_FEE_DENOMINATOR = 1e3
 
-export const getUniV3LogAdapter: any = ({ factory, poolCreatedEvent, swapEvent = defaultV3SwapEvent, customLogic, isAlgebraV3 = false, isAlgebraV2 = false, userFeesRatio, revenueRatio, protocolRevenueRatio, holdersRevenueRatio, blacklistPools, pools, getRevenueRatio, dynamicProtocolFees = false }: UniV3Config): FetchV2 => {
+export const getUniV3LogAdapter: any = ({ factory, poolCreatedEvent, swapEvent = defaultV3SwapEvent, customLogic, isAlgebraV3 = false, isAlgebraV2 = false, userFeesRatio, revenueRatio, protocolRevenueRatio, holdersRevenueRatio, blacklistPools, pools, getRevenueRatio, dynamicProtocolFees = false, algebraCommunityFee = false }: UniV3Config): FetchV2 => {
   const fetch: FetchV2 = async (fetchOptions) => {
     const { createBalances, getLogs, chain, api } = fetchOptions
     const pairObject: IJSON<string[]> = {}
     const fees: any = {}
+    const communityFees: IJSON<number> = {}
 
     if (!chain) throw new Error('Wrong version?')
 
@@ -209,6 +212,16 @@ export const getUniV3LogAdapter: any = ({ factory, poolCreatedEvent, swapEvent =
       if (isAlgebraV2) {
         let _states = await api.multiCall({ abi: 'function globalState() view returns (uint160 price, int24 tick, uint16 fee, uint16 timepointIndex, uint16 communityFeeToken0, uint16 communityFeeToken1, bool unlocked)', calls: logs.map((log: any) => log.pool), permitFailure: true })
         _states.forEach((state: any, i: number) => { if (state != null) fees[logs[i].pool] = Number(state.fee) / 1e6 })
+      }
+
+      // share of swap fees the protocol keeps, stored in the pool's globalState:
+      // 6th value on Algebra V1/V1.9 pools, 5th on Algebra Integral pools
+      if (algebraCommunityFee) {
+        const abi = isAlgebraV3
+          ? 'function globalState() view returns (uint160 price, int24 tick, uint16 fee, uint8 pluginConfig, uint16 communityFee)'
+          : 'function globalState() view returns (uint160 price, int24 tick, uint16 feeZto, uint16 feeOtz, uint16 timepointIndex, uint16 communityFee)'
+        const _states = await api.multiCall({ abi, calls: logs.map((log: any) => log.pool), permitFailure: true })
+        _states.forEach((state: any, i: number) => { if (state != null) communityFees[logs[i].pool] = Number(state.communityFee) / COMMUNITY_FEE_DENOMINATOR })
       }
     } else if (Array.isArray(pools)) {
 
@@ -243,10 +256,10 @@ export const getUniV3LogAdapter: any = ({ factory, poolCreatedEvent, swapEvent =
       dailyVolume,
       dailyFees: swapFees,
       dailyUserFees: userFeesRatio !== undefined ? 0 : undefined,
-      dailyRevenue: revenueRatio !== undefined ? 0 : undefined,
-      dailySupplySideRevenue: revenueRatio !== undefined ? 0 : undefined,
-      dailyProtocolRevenue: protocolRevenueRatio !== undefined ? 0 : undefined,
-      dailyHoldersRevenue: holdersRevenueRatio !== undefined ? 0 : undefined,
+      dailyRevenue: revenueRatio !== undefined || getRevenueRatio ? 0 : undefined,
+      dailySupplySideRevenue: revenueRatio !== undefined || getRevenueRatio ? 0 : undefined,
+      dailyProtocolRevenue: protocolRevenueRatio !== undefined || getRevenueRatio ? 0 : undefined,
+      dailyHoldersRevenue: holdersRevenueRatio !== undefined || getRevenueRatio ? 0 : undefined,
     }
 
     const pairs = Object.keys(filteredPairs)
@@ -291,6 +304,7 @@ export const getUniV3LogAdapter: any = ({ factory, poolCreatedEvent, swapEvent =
           poolFeeTier: feeTier,
           protocolFeeRatioToken0: dynamicProtocolFees ? protocolFeeRatios[pair]?.token0 : undefined,
           protocolFeeRatioToken1: dynamicProtocolFees ? protocolFeeRatios[pair]?.token1 : undefined,
+          communityFeeRatio: algebraCommunityFee ? communityFees[pair] : undefined,
         })
 
         if (!pairRevenueRatio) pairRevenueRatio = _revenueRatio;
@@ -363,6 +377,8 @@ export interface UniGetRevenueRatioProps {
   poolFeeTier: number;
   protocolFeeRatioToken0?: number;
   protocolFeeRatioToken1?: number;
+  // Algebra community fee, as a share of the pool's swap fees
+  communityFeeRatio?: number;
 }
 
 type UniV3Config = {
@@ -381,6 +397,8 @@ type UniV3Config = {
   blacklistPools?: Array<string>,
   pools?: string[], // alternative to providing factory
   dynamicProtocolFees?: boolean,
+  // read each Algebra pool's community fee and pass it to getRevenueRatio
+  algebraCommunityFee?: boolean,
 
   // support to get custom revenue ratio from given pool fee tier
   getRevenueRatio?: (props: UniGetRevenueRatioProps) => { _revenueRatio: number, _protocolRevenueRatio?: number, _holdersRevenueRatio?: number };


### PR DESCRIPTION
Replaces the adapter's fixed 15% protocol fee assumption with each pool's on-chain `communityFee`, ensuring revenue is attributed correctly across all Camelot V3 deployments.

### Changes

- Read `communityFee` from each pool's `globalState()` and derive the protocol fee split dynamically.
- Added optional `algebraCommunityFee` support to `helpers/uniswap.ts`, leaving other adapters unchanged.
- Throw if a pool's community fee cannot be read instead of silently assuming zero protocol revenue.
- Updated `methodology` and `breakdownMethodology` to describe the on-chain calculation and corrected the fee breakdown label.

### Verification

- On-chain values:
  - **Arbitrum:** 15% protocol fee
  - **ApeChain, Gravity, Reya, Superposition, Plume:** 20%
  - Some pools: **0%** (all fees to LPs)
- Revenue ratios now match on-chain values across deployments (≈15% on Arbitrum, ≈20% elsewhere).