### PR TITLE
[volume]Solidly V2 - Solidlydex volume fix

### DIFF
--- a/dexs/solidlydex.ts
+++ b/dexs/solidlydex.ts
@@ -1,6 +1,6 @@
 import * as sdk from "@defillama/sdk";
 import request, { gql } from "graphql-request";
-import { Adapter, FetchResultFees, FetchOptions } from "../adapters/types";
+import { Adapter, FetchResult, FetchOptions } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
 import { getBlock } from "../helpers/getBlock";
 import { getTimestampAtStartOfDayUTC, getTimestampAtStartOfPreviousDayUTC } from "../utils/date";
@@ -23,7 +23,7 @@ interface IQueryRange {
   today: IPair[];
 }
 
-const fetch = async (options: FetchOptions): Promise<FetchResultFees> => {
+const fetch = async (options: FetchOptions): Promise<FetchResult> => {
   const todaysTimestamp = getTimestampAtStartOfDayUTC(options.toTimestamp)
   const yesterdaysTimestamp = getTimestampAtStartOfPreviousDayUTC(options.toTimestamp)
 
@@ -54,11 +54,14 @@ const fetch = async (options: FetchOptions): Promise<FetchResultFees> => {
     } as IPairs
   });
 
+  const dailyVolume = pairs.reduce((a: number, b: IPairs) => a + Number(b.volumeUSD), 0);
+
   const dailyFees = pairs
     .filter((e: IPairs) => e.volumeUSD)
     .reduce((a: number, b: IPairs) => a + ((Number(b.fee)/10**6) * Number(b.volumeUSD)), 0);
 
   return {
+    dailyVolume,
     dailyFees,
     dailyRevenue: dailyFees,
     dailyHoldersRevenue: dailyFees,

--- a/factory/uniV2.ts
+++ b/factory/uniV2.ts
@@ -1320,12 +1320,6 @@ const subgraphConfigs: Record<string, SubgraphProtocolConfig> = {
     factoriesName: "factories",
     totalVolume: "volumeUSD",
   },
-  "solidlydex": {
-    endpoints: {
-      [CHAIN.ETHEREUM]: sdk.graph.modifyEndpoint('4GX8RE9TzEWormbkayeGj4NQmmhYE46izVVUvXv8WPDh'),
-    },
-    start: 1672444800,
-  },
   "sonic-market-cpmm": {
     endpoints: {
       [CHAIN.SONIC]: "https://subgraph.satsuma-prod.com/f6a8c4889b7b/clober/cpmm-v2-subgraph-sonic-mainnet/api",

--- a/fees/solidlydex.ts
+++ b/fees/solidlydex.ts
@@ -3,7 +3,7 @@ import request, { gql } from "graphql-request";
 import { Adapter, FetchResultFees, FetchOptions } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
 import { getBlock } from "../helpers/getBlock";
-import { getTimestampAtStartOfDayUTC, getTimestampAtStartOfNextDayUTC } from "../utils/date";
+import { getTimestampAtStartOfDayUTC, getTimestampAtStartOfPreviousDayUTC } from "../utils/date";
 
 
 const URL = sdk.graph.modifyEndpoint('4GX8RE9TzEWormbkayeGj4NQmmhYE46izVVUvXv8WPDh');
@@ -25,7 +25,7 @@ interface IQueryRange {
 
 const fetch = async (options: FetchOptions): Promise<FetchResultFees> => {
   const todaysTimestamp = getTimestampAtStartOfDayUTC(options.toTimestamp)
-  const yesterdaysTimestamp = getTimestampAtStartOfNextDayUTC(options.toTimestamp)
+  const yesterdaysTimestamp = getTimestampAtStartOfPreviousDayUTC(options.toTimestamp)
 
   const todaysBlock = (await getBlock(todaysTimestamp, 'ethereum', {}));
   const yesterdaysBlock = (await getBlock(yesterdaysTimestamp, 'ethereum', {}));
@@ -49,8 +49,8 @@ const fetch = async (options: FetchOptions): Promise<FetchResultFees> => {
     const yesterday =  graphResDaily.yesterday.find((se: IPair) => se.id === address);
     const today =  graphResDaily.today.find((se: IPair) => se.id === address);
     return {
-      volumeUSD: (yesterday && today) ? Number(yesterday.volumeUSD) - Number(today.volumeUSD) : 0,
-      fee: (yesterday && today) ? Number(yesterday.fee) : 0
+      volumeUSD: (yesterday && today) ? Number(today.volumeUSD) - Number(yesterday.volumeUSD) : 0,
+      fee: (today) ? Number(today.fee) : 0
     } as IPairs
   });
 


### PR DESCRIPTION
#8433 

`solidlydex.ts` computed volume as `nextDay − today` instead of `today − yesterday`. Theoretically, this should never go negative, but the adapter breaks if "next day" ever resolves to a future timestamp.

The fix aligns with the approach used in `fees/thena-v1.ts`.
