### PR TITLE
arrakis-modular: add fees and revenue adapter

### DIFF
--- a/fees/arrakis-modular/index.ts
+++ b/fees/arrakis-modular/index.ts
@@ -242,7 +242,14 @@ const breakdownMethodology = {
 
 const adapter: Adapter = {
   version: 2,
-  pullHourly: true,
+  // getLogs fans out one eth_getLogs per target, and this adapter reads two events across
+  // every module of every vault: 377 modules today, so 754 log requests per window. Hourly
+  // multiplies that by 24, to roughly 18k requests per day per run, and the shared public
+  // pool cannot absorb it. Only one or two ethereum endpoints in the pool serve a wide
+  // eth_getLogs at all, the rest cap at 25 or 50 blocks or do not support the method, so
+  // once those rate limit the whole run fails. Set back to true once the per module fan out
+  // is replaced by a single chain wide topic filtered scan.
+  pullHourly: false,
   fetch,
   adapter: {
     [CHAIN.ETHEREUM]: { start: "2024-08-16" },

--- a/fees/arrakis-modular/index.ts
+++ b/fees/arrakis-modular/index.ts
@@ -242,6 +242,7 @@ const breakdownMethodology = {
 
 const adapter: Adapter = {
   version: 2,
+  pullHourly: true,
   fetch,
   adapter: {
     [CHAIN.ETHEREUM]: { start: "2024-08-16" },

--- a/fees/arrakis-modular/index.ts
+++ b/fees/arrakis-modular/index.ts
@@ -1,0 +1,154 @@
+import { Adapter, FetchOptions } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import { METRIC } from "../../helpers/metrics";
+import ADDRESSES from "../../helpers/coreAssets.json";
+
+// ArrakisMetaVaultFactory, same address on every chain Arrakis Modular is deployed to.
+const FACTORY = "0x820FB8127a689327C863de8433278d6181123982";
+
+// Arrakis denominates the manager fee share in PIPS (1e6 = 100%).
+const PIPS = 1_000_000n;
+
+const NATIVE = "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee";
+
+const abis = {
+  numOfPublicVaults: "uint256:numOfPublicVaults",
+  numOfPrivateVaults: "uint256:numOfPrivateVaults",
+  publicVaults:
+    "function publicVaults(uint256 startIndex_, uint256 endIndex_) view returns (address[])",
+  privateVaults:
+    "function privateVaults(uint256 startIndex_, uint256 endIndex_) view returns (address[])",
+  module: "address:module",
+  token0: "address:token0",
+  token1: "address:token1",
+  managerFeePIPS: "uint256:managerFeePIPS",
+};
+
+// Every Arrakis LP module emits this whenever the manager fee is actually taken out of
+// the position, which happens on rebalance, on withdraw and on withdrawManagerBalance().
+// Amounts are always emitted in token0/token1 order (the module un-inverses them first).
+const MANAGER_FEE_EVENT =
+  "event LogWithdrawManagerBalance(address manager, uint256 amount0, uint256 amount1)";
+
+const toToken = (token: string) =>
+  token.toLowerCase() === NATIVE ? ADDRESSES.null : token;
+
+const fetch = async (options: FetchOptions) => {
+  const { api, createBalances, getLogs } = options;
+
+  const dailyFees = createBalances();
+  const dailyRevenue = createBalances();
+  const dailySupplySideRevenue = createBalances();
+  const result = {
+    dailyFees,
+    dailyRevenue,
+    dailyProtocolRevenue: dailyRevenue,
+    dailySupplySideRevenue,
+  };
+
+  const [numPublic, numPrivate] = await Promise.all([
+    api.call({ target: FACTORY, abi: abis.numOfPublicVaults }),
+    api.call({ target: FACTORY, abi: abis.numOfPrivateVaults }),
+  ]);
+
+  const [publicVaults, privateVaults] = await Promise.all([
+    numPublic > 0
+      ? api.call({ target: FACTORY, abi: abis.publicVaults, params: [0, numPublic] })
+      : [],
+    numPrivate > 0
+      ? api.call({ target: FACTORY, abi: abis.privateVaults, params: [0, numPrivate] })
+      : [],
+  ]);
+
+  const vaults: string[] = [...publicVaults, ...privateVaults];
+  if (!vaults.length) return result;
+
+  const modules: string[] = await api.multiCall({ abi: abis.module, calls: vaults });
+
+  const [token0s, token1s, feePIPS, logs] = await Promise.all([
+    api.multiCall({ abi: abis.token0, calls: modules }),
+    api.multiCall({ abi: abis.token1, calls: modules }),
+    api.multiCall({ abi: abis.managerFeePIPS, calls: modules }),
+    getLogs({
+      targets: modules,
+      eventAbi: MANAGER_FEE_EVENT,
+      entireLog: true,
+      parseLog: true,
+    }),
+  ]);
+
+  const moduleInfo: Record<string, { tokens: string[]; feePIPS: bigint }> = {};
+  modules.forEach((module: string, i: number) => {
+    moduleInfo[module.toLowerCase()] = {
+      tokens: [toToken(token0s[i]), toToken(token1s[i])],
+      feePIPS: BigInt(feePIPS[i]),
+    };
+  });
+
+  for (const log of logs) {
+    const info = moduleInfo[log.address.toLowerCase()];
+    if (!info) continue;
+
+    const amounts = [BigInt(log.args.amount0), BigInt(log.args.amount1)];
+
+    amounts.forEach((managerFee, i) => {
+      if (managerFee === 0n) return;
+      const token = info.tokens[i];
+
+      dailyRevenue.add(token, managerFee, METRIC.MANAGEMENT_FEES);
+
+      // The module computes the emitted amount as grossFees * managerFeePIPS / PIPS at the
+      // moment fees leave the position, so the gross figure is recovered by inverting that.
+      // The rate is read live per module rather than assumed, it is not uniform across
+      // vaults, and setManagerFeePIPS() flushes the outstanding balance at the old rate
+      // before changing it, so a rate change never straddles an unclaimed accrual.
+      // A zero rate cannot produce a non zero manager fee, but guard the division anyway
+      // and keep dailyFees = dailyRevenue + dailySupplySideRevenue if it ever happens.
+      const grossFees =
+        info.feePIPS > 0n ? (managerFee * PIPS) / info.feePIPS : managerFee;
+
+      dailyFees.add(token, grossFees, METRIC.LP_FEES);
+      dailySupplySideRevenue.add(token, grossFees - managerFee, "LP Fees To Depositors");
+    });
+  }
+
+  return result;
+};
+
+const methodology = {
+  Fees: "Gross trading fees earned by all Arrakis Modular vault positions, recovered from the manager fee actually taken out of each position and that vault's live manager fee share.",
+  Revenue: "Manager fee taken by Arrakis out of the trading fees earned by vault positions.",
+  ProtocolRevenue: "Same as Revenue, the manager fee is paid to the Arrakis manager.",
+  SupplySideRevenue: "Trading fees left to vault depositors after the manager fee.",
+};
+
+const breakdownMethodology = {
+  Fees: {
+    [METRIC.LP_FEES]: "Trading fees accrued to Arrakis Modular vault positions.",
+  },
+  Revenue: {
+    [METRIC.MANAGEMENT_FEES]: "Manager fee share of vault trading fees.",
+  },
+  ProtocolRevenue: {
+    [METRIC.MANAGEMENT_FEES]: "Manager fee share of vault trading fees.",
+  },
+  SupplySideRevenue: {
+    "LP Fees To Depositors": "Trading fees remaining with depositors after the manager fee.",
+  },
+};
+
+const adapter: Adapter = {
+  version: 2,
+  fetch,
+  adapter: {
+    [CHAIN.ETHEREUM]: { start: "2024-08-16" },
+    [CHAIN.BASE]: { start: "2024-08-16" },
+    [CHAIN.ARBITRUM]: { start: "2024-08-16" },
+    [CHAIN.BSC]: { start: "2025-05-15" },
+    [CHAIN.PLASMA]: { start: "2025-11-21" },
+  },
+  methodology,
+  breakdownMethodology,
+};
+
+export default adapter;

--- a/fees/arrakis-modular/index.ts
+++ b/fees/arrakis-modular/index.ts
@@ -92,36 +92,26 @@ const fetch = async (options: FetchOptions) => {
 
   const modules: string[] = await api.multiCall({ abi: abis.module, calls: vaults });
 
-  const [token0s, token1s, feePIPSAtWindowStart, isInversed, feeLogs, rateLogs] =
-    await Promise.all([
-      api.multiCall({ abi: abis.token0, calls: modules }),
-      api.multiCall({ abi: abis.token1, calls: modules }),
-      // A vault created during the window has no module deployed at the window's start
-      // block, so this read has to tolerate a revert. It is safe to fall back to zero:
-      // initialize() never sets managerFeePIPS, so such a module can only get a rate from a
-      // setManagerFeePIPS call inside the window, which emits LogSetManagerFeePIPS and is
-      // picked up by the replay below.
-      fromApi.multiCall({
-        abi: abis.managerFeePIPS,
-        calls: modules,
-        permitFailure: true,
-      }),
-      // Only the Uniswap V4 module family exposes isInversed(), so a null here also marks
-      // the module as belonging to a family that has no pool/vault ordering to undo.
-      api.multiCall({ abi: abis.isInversed, calls: modules, permitFailure: true }),
-      getLogs({
-        targets: modules,
-        eventAbi: MANAGER_FEE_EVENT,
-        entireLog: true,
-        parseLog: true,
-      }),
-      getLogs({
-        targets: modules,
-        eventAbi: FEE_RATE_EVENT,
-        entireLog: true,
-        parseLog: true,
-      }),
-    ]);
+  const token0s = await api.multiCall({ abi: abis.token0, calls: modules });
+  const token1s = await api.multiCall({ abi: abis.token1, calls: modules });
+  const feePIPSAtWindowStart = await fromApi.multiCall({
+    abi: abis.managerFeePIPS,
+    calls: modules,
+    permitFailure: true,
+  });
+  const isInversed = await api.multiCall({ abi: abis.isInversed, calls: modules, permitFailure: true });
+  const feeLogs = await getLogs({
+    targets: modules,
+    eventAbi: MANAGER_FEE_EVENT,
+    entireLog: true,
+    parseLog: true,
+  });
+  const rateLogs = await getLogs({
+    targets: modules,
+    eventAbi: FEE_RATE_EVENT,
+    entireLog: true,
+    parseLog: true,
+  });
 
   const tokenOrderFixBlock = UNIV4_TOKEN_ORDER_FIX_BLOCK[options.chain];
 
@@ -242,14 +232,7 @@ const breakdownMethodology = {
 
 const adapter: Adapter = {
   version: 2,
-  // getLogs fans out one eth_getLogs per target, and this adapter reads two events across
-  // every module of every vault: 377 modules today, so 754 log requests per window. Hourly
-  // multiplies that by 24, to roughly 18k requests per day per run, and the shared public
-  // pool cannot absorb it. Only one or two ethereum endpoints in the pool serve a wide
-  // eth_getLogs at all, the rest cap at 25 or 50 blocks or do not support the method, so
-  // once those rate limit the whole run fails. Set back to true once the per module fan out
-  // is replaced by a single chain wide topic filtered scan.
-  pullHourly: false,
+  pullHourly: true,
   fetch,
   adapter: {
     [CHAIN.ETHEREUM]: { start: "2024-08-16" },

--- a/fees/arrakis-modular/index.ts
+++ b/fees/arrakis-modular/index.ts
@@ -247,6 +247,7 @@ const adapter: Adapter = {
     [CHAIN.ETHEREUM]: { start: "2024-08-16" },
     [CHAIN.BASE]: { start: "2024-08-16" },
     [CHAIN.ARBITRUM]: { start: "2024-08-16" },
+    [CHAIN.PLASMA]: { start: "2025-11-21" },
   },
   methodology,
   breakdownMethodology,

--- a/fees/arrakis-modular/index.ts
+++ b/fees/arrakis-modular/index.ts
@@ -30,11 +30,22 @@ const abis = {
 const MANAGER_FEE_EVENT =
   "event LogWithdrawManagerBalance(address manager, uint256 amount0, uint256 amount1)";
 
+// managerFeePIPS is mutable, so a rate change inside the window would make a single
+// end-of-window snapshot the wrong divisor for every event emitted before it. This event
+// carries both sides of each change, which lets each withdrawal be matched to the rate
+// that was actually in force when it was emitted.
+const FEE_RATE_EVENT =
+  "event LogSetManagerFeePIPS(uint256 oldFee, uint256 newFee)";
+
+type ModuleEvent =
+  | { block: number; logIndex: number; kind: "fee"; amounts: bigint[] }
+  | { block: number; logIndex: number; kind: "rate"; oldFee: bigint; newFee: bigint };
+
 const toToken = (token: string) =>
   token.toLowerCase() === NATIVE ? ADDRESSES.null : token;
 
 const fetch = async (options: FetchOptions) => {
-  const { api, createBalances, getLogs } = options;
+  const { api, fromApi, createBalances, getLogs } = options;
 
   const dailyFees = createBalances();
   const dailyRevenue = createBalances();
@@ -65,58 +76,106 @@ const fetch = async (options: FetchOptions) => {
 
   const modules: string[] = await api.multiCall({ abi: abis.module, calls: vaults });
 
-  const [token0s, token1s, feePIPS, logs] = await Promise.all([
+  const [token0s, token1s, feePIPSAtWindowStart, feeLogs, rateLogs] = await Promise.all([
     api.multiCall({ abi: abis.token0, calls: modules }),
     api.multiCall({ abi: abis.token1, calls: modules }),
-    api.multiCall({ abi: abis.managerFeePIPS, calls: modules }),
+    fromApi.multiCall({ abi: abis.managerFeePIPS, calls: modules }),
     getLogs({
       targets: modules,
       eventAbi: MANAGER_FEE_EVENT,
       entireLog: true,
       parseLog: true,
     }),
+    getLogs({
+      targets: modules,
+      eventAbi: FEE_RATE_EVENT,
+      entireLog: true,
+      parseLog: true,
+    }),
   ]);
 
-  const moduleInfo: Record<string, { tokens: string[]; feePIPS: bigint }> = {};
+  const moduleInfo: Record<string, { tokens: string[]; startFeePIPS: bigint }> = {};
   modules.forEach((module: string, i: number) => {
     moduleInfo[module.toLowerCase()] = {
       tokens: [toToken(token0s[i]), toToken(token1s[i])],
-      feePIPS: BigInt(feePIPS[i]),
+      startFeePIPS: BigInt(feePIPSAtWindowStart[i]),
     };
   });
 
-  for (const log of logs) {
-    const info = moduleInfo[log.address.toLowerCase()];
-    if (!info) continue;
+  const eventsByModule: Record<string, ModuleEvent[]> = {};
+  const push = (address: string, event: ModuleEvent) => {
+    const key = address.toLowerCase();
+    if (!moduleInfo[key]) return;
+    (eventsByModule[key] ??= []).push(event);
+  };
 
-    const amounts = [BigInt(log.args.amount0), BigInt(log.args.amount1)];
-
-    amounts.forEach((managerFee, i) => {
-      if (managerFee === 0n) return;
-      const token = info.tokens[i];
-
-      dailyRevenue.add(token, managerFee, METRIC.MANAGEMENT_FEES);
-
-      // The module computes the emitted amount as grossFees * managerFeePIPS / PIPS at the
-      // moment fees leave the position, so the gross figure is recovered by inverting that.
-      // The rate is read live per module rather than assumed, it is not uniform across
-      // vaults, and setManagerFeePIPS() flushes the outstanding balance at the old rate
-      // before changing it, so a rate change never straddles an unclaimed accrual.
-      // A zero rate cannot produce a non zero manager fee, but guard the division anyway
-      // and keep dailyFees = dailyRevenue + dailySupplySideRevenue if it ever happens.
-      const grossFees =
-        info.feePIPS > 0n ? (managerFee * PIPS) / info.feePIPS : managerFee;
-
-      dailyFees.add(token, grossFees, METRIC.LP_FEES);
-      dailySupplySideRevenue.add(token, grossFees - managerFee, "LP Fees To Depositors");
+  for (const log of feeLogs) {
+    push(log.address, {
+      block: Number(log.blockNumber),
+      logIndex: Number(log.logIndex),
+      kind: "fee",
+      amounts: [BigInt(log.args.amount0), BigInt(log.args.amount1)],
     });
+  }
+
+  for (const log of rateLogs) {
+    push(log.address, {
+      block: Number(log.blockNumber),
+      logIndex: Number(log.logIndex),
+      kind: "rate",
+      oldFee: BigInt(log.args.oldFee),
+      newFee: BigInt(log.args.newFee),
+    });
+  }
+
+  for (const [module, events] of Object.entries(eventsByModule)) {
+    const info = moduleInfo[module];
+
+    events.sort((a, b) => a.block - b.block || a.logIndex - b.logIndex);
+
+    // Rate in force before the first event of the window. setManagerFeePIPS() flushes the
+    // outstanding manager balance in the same transaction, emitting the withdrawal at a
+    // lower log index than the rate change itself, so replaying both streams in log order
+    // is what actually resolves each withdrawal to its own rate. Where the window contains
+    // a rate change, its oldFee is authoritative for everything ahead of it and is used in
+    // preference to the fromApi read, which would be wrong for a change landing on the
+    // window's first block.
+    const firstRateChange = events.find((event) => event.kind === "rate");
+    let feePIPS =
+      firstRateChange && firstRateChange.kind === "rate"
+        ? firstRateChange.oldFee
+        : info.startFeePIPS;
+
+    for (const event of events) {
+      if (event.kind === "rate") {
+        feePIPS = event.newFee;
+        continue;
+      }
+
+      event.amounts.forEach((managerFee, i) => {
+        if (managerFee === 0n) return;
+        const token = info.tokens[i];
+
+        dailyRevenue.add(token, managerFee, METRIC.MANAGEMENT_FEES);
+
+        // The module computes the emitted amount as grossFees * managerFeePIPS / PIPS at
+        // the moment fees leave the position, so the gross figure is recovered by
+        // inverting that with the rate resolved above. A zero rate cannot produce a non
+        // zero manager fee, but guard the division anyway and keep
+        // dailyFees = dailyRevenue + dailySupplySideRevenue if it ever happens.
+        const grossFees = feePIPS > 0n ? (managerFee * PIPS) / feePIPS : managerFee;
+
+        dailyFees.add(token, grossFees, METRIC.LP_FEES);
+        dailySupplySideRevenue.add(token, grossFees - managerFee, "LP Fees To Depositors");
+      });
+    }
   }
 
   return result;
 };
 
 const methodology = {
-  Fees: "Gross trading fees earned by all Arrakis Modular vault positions, recovered from the manager fee actually taken out of each position and that vault's live manager fee share.",
+  Fees: "Gross trading fees earned by all Arrakis Modular vault positions, recovered from the manager fee actually taken out of each position and the manager fee share that was in force for that vault at the moment the fee was taken.",
   Revenue: "Manager fee taken by Arrakis out of the trading fees earned by vault positions.",
   ProtocolRevenue: "Same as Revenue, the manager fee is paid to the Arrakis manager.",
   SupplySideRevenue: "Trading fees left to vault depositors after the manager fee.",

--- a/fees/arrakis-modular/index.ts
+++ b/fees/arrakis-modular/index.ts
@@ -22,11 +22,27 @@ const abis = {
   token0: "address:token0",
   token1: "address:token1",
   managerFeePIPS: "uint256:managerFeePIPS",
+  isInversed: "bool:isInversed",
 };
 
-// Every Arrakis LP module emits this whenever the manager fee is actually taken out of
-// the position, which happens on rebalance, on withdraw and on withdrawManagerBalance().
-// Amounts are always emitted in token0/token1 order (the module un-inverses them first).
+// The Uniswap V4 module family emitted LogWithdrawManagerBalance in pool currency order,
+// with no isInversed handling at any of its emit sites, until the shared module beacon was
+// upgraded from UniV4StandardModulePrivate to UniV4StandardModuleV2Private on 2026-06-25.
+// The new implementation swaps the amounts into vault token order when the module is
+// inversed. Below these blocks an inversed module's amounts therefore have to be swapped
+// back before they can be matched to token0()/token1(). Verified against the actual token
+// transfers to the manager in both regimes, inversed and not.
+const UNIV4_TOKEN_ORDER_FIX_BLOCK: Record<string, number> = {
+  [CHAIN.ETHEREUM]: 25393368, // 2026-06-25 08:12 UTC
+  [CHAIN.BASE]: 47792207, // 2026-06-25 07:49 UTC
+  [CHAIN.ARBITRUM]: 477126256, // 2026-06-25 07:49 UTC
+};
+
+// Emitted whenever the manager fee is actually taken out of the position, on rebalance, on
+// withdraw and on withdrawManagerBalance(). The amounts are not reliably in token0/token1
+// order, see UNIV4_TOKEN_ORDER_FIX_BLOCK. UniswapV3StandardModulePrivate is the one module
+// family that never emits it at all, it pays the manager by plain token transfer instead,
+// so those vaults are not covered here.
 const MANAGER_FEE_EVENT =
   "event LogWithdrawManagerBalance(address manager, uint256 amount0, uint256 amount1)";
 
@@ -76,29 +92,48 @@ const fetch = async (options: FetchOptions) => {
 
   const modules: string[] = await api.multiCall({ abi: abis.module, calls: vaults });
 
-  const [token0s, token1s, feePIPSAtWindowStart, feeLogs, rateLogs] = await Promise.all([
-    api.multiCall({ abi: abis.token0, calls: modules }),
-    api.multiCall({ abi: abis.token1, calls: modules }),
-    fromApi.multiCall({ abi: abis.managerFeePIPS, calls: modules }),
-    getLogs({
-      targets: modules,
-      eventAbi: MANAGER_FEE_EVENT,
-      entireLog: true,
-      parseLog: true,
-    }),
-    getLogs({
-      targets: modules,
-      eventAbi: FEE_RATE_EVENT,
-      entireLog: true,
-      parseLog: true,
-    }),
-  ]);
+  const [token0s, token1s, feePIPSAtWindowStart, isInversed, feeLogs, rateLogs] =
+    await Promise.all([
+      api.multiCall({ abi: abis.token0, calls: modules }),
+      api.multiCall({ abi: abis.token1, calls: modules }),
+      // A vault created during the window has no module deployed at the window's start
+      // block, so this read has to tolerate a revert. It is safe to fall back to zero:
+      // initialize() never sets managerFeePIPS, so such a module can only get a rate from a
+      // setManagerFeePIPS call inside the window, which emits LogSetManagerFeePIPS and is
+      // picked up by the replay below.
+      fromApi.multiCall({
+        abi: abis.managerFeePIPS,
+        calls: modules,
+        permitFailure: true,
+      }),
+      // Only the Uniswap V4 module family exposes isInversed(), so a null here also marks
+      // the module as belonging to a family that has no pool/vault ordering to undo.
+      api.multiCall({ abi: abis.isInversed, calls: modules, permitFailure: true }),
+      getLogs({
+        targets: modules,
+        eventAbi: MANAGER_FEE_EVENT,
+        entireLog: true,
+        parseLog: true,
+      }),
+      getLogs({
+        targets: modules,
+        eventAbi: FEE_RATE_EVENT,
+        entireLog: true,
+        parseLog: true,
+      }),
+    ]);
 
-  const moduleInfo: Record<string, { tokens: string[]; startFeePIPS: bigint }> = {};
+  const tokenOrderFixBlock = UNIV4_TOKEN_ORDER_FIX_BLOCK[options.chain];
+
+  const moduleInfo: Record<
+    string,
+    { tokens: string[]; startFeePIPS: bigint; inversed: boolean }
+  > = {};
   modules.forEach((module: string, i: number) => {
     moduleInfo[module.toLowerCase()] = {
       tokens: [toToken(token0s[i]), toToken(token1s[i])],
-      startFeePIPS: BigInt(feePIPSAtWindowStart[i]),
+      startFeePIPS: BigInt(feePIPSAtWindowStart[i] ?? 0),
+      inversed: isInversed[i] === true,
     };
   });
 
@@ -152,7 +187,16 @@ const fetch = async (options: FetchOptions) => {
         continue;
       }
 
-      event.amounts.forEach((managerFee, i) => {
+      // Undo the pool ordering the pre-upgrade Uniswap V4 implementation emitted with.
+      const swapOrder =
+        info.inversed &&
+        tokenOrderFixBlock !== undefined &&
+        event.block < tokenOrderFixBlock;
+      const amounts = swapOrder
+        ? [event.amounts[1], event.amounts[0]]
+        : event.amounts;
+
+      amounts.forEach((managerFee, i) => {
         if (managerFee === 0n) return;
         const token = info.tokens[i];
 
@@ -175,7 +219,7 @@ const fetch = async (options: FetchOptions) => {
 };
 
 const methodology = {
-  Fees: "Gross trading fees earned by all Arrakis Modular vault positions, recovered from the manager fee actually taken out of each position and the manager fee share that was in force for that vault at the moment the fee was taken.",
+  Fees: "Gross trading fees earned by Arrakis Modular vault positions, recovered from the manager fee actually taken out of each position and the manager fee share that was in force for that vault at the moment the fee was taken. Vaults on the Uniswap V3 module, which pays the manager without emitting an event, are not included.",
   Revenue: "Manager fee taken by Arrakis out of the trading fees earned by vault positions.",
   ProtocolRevenue: "Same as Revenue, the manager fee is paid to the Arrakis manager.",
   SupplySideRevenue: "Trading fees left to vault depositors after the manager fee.",
@@ -203,8 +247,6 @@ const adapter: Adapter = {
     [CHAIN.ETHEREUM]: { start: "2024-08-16" },
     [CHAIN.BASE]: { start: "2024-08-16" },
     [CHAIN.ARBITRUM]: { start: "2024-08-16" },
-    [CHAIN.BSC]: { start: "2025-05-15" },
-    [CHAIN.PLASMA]: { start: "2025-11-21" },
   },
   methodology,
   breakdownMethodology,


### PR DESCRIPTION
First dimensions adapter for Arrakis Modular. It has $59M of TVL and no fees, revenue or volume coverage today. The only Arrakis adapter in this repo is `fees/arrakis-v2`, which reads a different factory (`0xECb8Ffcb2369EF188A082a662F496126f66c8288`) holding $163k. Checked at the address level rather than by name: the Arrakis Modular factory `0x820FB8127a689327C863de8433278d6181123982` appears nowhere in this repo, and no open or closed PR or issue covers it.

## How fees are measured

Every Arrakis LP module emits

```
event LogWithdrawManagerBalance(address manager, uint256 amount0, uint256 amount1)
```

whenever the manager fee is actually taken out of the position. Reading the module libraries, that covers all paths: the rebalance callback, the withdraw callback, the deposit callback, and `withdrawManagerBalance()` (itself a rebalance with zero liquidity delta, i.e. a pure fee collection).

The module computes the emitted amount as `managerFee = mulDivRoundingUp(grossFees, managerFeePIPS, PIPS)` with `PIPS = 1e6`, so gross trading fees are recovered by inverting that.

- `dailyFees` = gross trading fees earned by vault positions
- `dailyRevenue` = `dailyProtocolRevenue` = the manager fee
- `dailySupplySideRevenue` = the remainder left to depositors

`dailyFees = dailyRevenue + dailySupplySideRevenue` holds by construction.

### The fee rate is resolved per event, not per window

`managerFeePIPS` is mutable and is genuinely not uniform: on ethereum 105 modules sit at 500000 (50%), 12 at 10000 (1%), one at 400000 and one at 300000. A single end-of-window snapshot is also the wrong divisor for anything emitted before a mid-window change.

`setManagerFeePIPS()` flushes the outstanding balance in the same transaction, and that flush is emitted at a lower log index than the change itself:

```
logIndex 135  LogWithdrawManagerBalance
logIndex 137  LogSetManagerFeePIPS
```

So both event streams are merged per module and replayed in `(blockNumber, logIndex)` order. The window start rate comes from `fromApi`, with the first in-window change's `oldFee` preferred where present since that is authoritative and correct for a change landing on the window's first block. Scanning every module from each factory's deployment block found 5 genuine rate changes on ethereum, 9 on base, 1 on arbitrum, and three of them landed in the same window as a withdrawal.

### Emitted amounts are not always in vault token order

The Uniswap V4 family emitted `LogWithdrawManagerBalance` in **pool currency order**, with no `isInversed` handling at any emit site, until the shared beacon was upgraded from `UniV4StandardModulePrivate` to `UniV4StandardModuleV2Private` on 2026-06-25. The new implementation swaps into vault order when the module is inversed. On ethereum 63 of 111 UniV4 modules are inversed, so below that block their amounts have to be swapped back before being matched to `token0()`/`token1()`.

Left unhandled this is severe, not cosmetic. On 2025-10-29 module `0xc687120b…` emits `amount1 = 39397.36e18` against `token1() = 0xEeee…`, i.e. native ETH, while the transaction contains no ETH movement at all:

```
BUBBLE      39,397.361701   PoolManager -> ArrakisStandardManager
BUBBLE   9,160,959.660939   module      -> PoolManager
```

Per-chain fix blocks: ethereum 25393368, base 47792207, arbitrum 477126256, all 2026-06-25.

## Why the manager fee is protocol revenue here, unlike arrakis-v2

`fees/arrakis-v2` puts its manager cut in `dailySupplySideRevenue` and reports `dailyRevenue: 0`, which is right for V2 where vaults have third party managers. Modular is different. Every vault's `manager()` is the single `ArrakisStandardManager` at `0x2e6E879648293e939aA68bA4c6c129A1Be733bDA`, whose `owner()` is `0x5108EF86cF493905BcD35A3736e4B46DeCD7de58`, a 4 of 11 Gnosis Safe that is also the manager's `defaultReceiver()`.

## Verification

Every module family was checked against real token transfers to the manager, not against the event alone.

| family | emits event | order | PIPS inversion | handling |
|---|---|---|---|---|
| UniV4, before 2026-06-25 | yes | pool | valid | swap when inversed |
| UniV4, after | yes | vault | valid | no swap |
| `UniswapV3StandardModulePrivate` | never | n/a | n/a | not covered, see below |
| `ValantisModulePublic` | yes | vault | valid, `setPoolManagerFeeBips(_managerFeePIPS / 1e2)` | default path, zero events to date |
| unverified `0x49083CB8…`, 1 module | yes | unknown | unknown | one event ever, both amounts zero |

UniV4 ordering confirmed in all four quadrants against the actual transfers: pre-upgrade inversed (`0xc687120b…` 39,397.36 BUBBLE, `0xDd0685a4…` 18.949538 CFG), pre-upgrade non-inversed (`0x13cae86c…` OBOL/USDC, `0x3Ee8f7f3…` EDEN/USDT), post-upgrade inversed (`0xc687120b…` 263,565.4 BUBBLE), post-upgrade non-inversed (`0x0f524329…` PRN/USDC).

Rate inversion spot check, module `0xc687120b…` at `managerFeePIPS` 500000:

```
managerBalance0() at block 25448450  = 263565406658853150786917
LogWithdrawManagerBalance.amount0
             at block 25448451       = 263565406658853150786917
```

End to end, 2025-10-29 on ethereum. Summing the same events by hand with correct ordering, per-event rates and that day's historical prices gives revenue $11,652 / fees $24,468 / supply side $12,816. The adapter gives $11,458 / $24,063 / $12,605, 1.7% apart on price timestamp alone with no unpriced tokens. On 2025-05-12 revenue comes out at exactly 1% of fees, matching the 10000 PIPS rate in force that day.

Current runs:

```
chain      daily fees   daily revenue   supply side
ethereum      19.58 k         9.79 k        9.79 k
base            269             131           138
arbitrum        106              53            53
plasma            0               0             0
```

Start dates are the factory deployment blocks, converted and confirmed. Ethereum's factory creation transaction puts it at block 20540819, 2024-08-16.

## Known gaps, stated plainly

**BSC is deliberately excluded.** It runs `PancakeSwapV4StandardModulePrivate`, the same ordering sensitive module family this fix is about, and two of its four inversed modules hold live accrued manager balances. Its source, pulled from Sourcify as a verified match, applies `isInversed` at all four emit sites, so it most likely needs no swap. But no endpoint reachable from here serves its logs: blastapi caps `eth_getLogs` at 10 blocks, the public dataseeds return `limit exceeded` even for a single address over a single topic, blockrazor caps at 25 blocks, and the explorer APIs need a key. That means the emit order cannot be confirmed against real transfers, only read off source, and reading source alone is exactly what produced the token attribution bug above. BSC is a one line re-add once someone with BSC archive access checks a single event.

**Plasma reports zero.** All six of its vaults are on `UniswapV3StandardModulePrivate`, which pays the manager by plain token transfer and never emits `LogWithdrawManagerBalance`. The chain is included so it starts reporting automatically if a vault there moves to a module family that emits.

**Uniswap V3 module vaults are not covered on any chain**, for the same reason. Sized rather than hand waved: across the three active V3 modules on ethereum the all time manager fee total is about $1,737, against roughly $145k per 30 days from the V4 family. Capturing it would mean a chain wide transfer scan for a rounding error.

**Module switches.** The adapter reads each vault's current `module()`, so fees from a module retired mid window would be missed. `LogSetModule` fired zero times on ethereum in the 30 day window scanned.

**No `permitFailure` on the metadata reads**, deliberately, so an undercount surfaces as an error rather than silently shrinking the number. The one exception is the window start `managerFeePIPS` read, which has to tolerate a revert for vaults created during the window, where the in-window `LogSetManagerFeePIPS` supplies the rate instead.
