### PR TITLE
[feat]Bow.Fun: add fees adapter for bowdotfun launchpad on rh

### DIFF
--- a/fees/bowdotfun/index.ts
+++ b/fees/bowdotfun/index.ts
@@ -76,10 +76,16 @@ const fetch = async (options: FetchOptions) => {
     if (!row.pool || !launchedPools.has(row.pool.toLowerCase())) continue;
 
     const amount = toBigInt(row.amount ?? 0);
-    const swapFee =
-      row.side === "sold"
-        ? (amount * FEES.POOL_FEE_BPS) / FEES.BPS
-        : (amount * FEES.POOL_FEE_BPS) / (FEES.BPS - FEES.POOL_FEE_BPS);
+    let swapFee: bigint;
+    if (row.side === "sold") {
+      swapFee = (amount * FEES.POOL_FEE_BPS) / FEES.BPS;
+    } else {
+      // WETH-bought rows are WETH output; grossing up by the pool-fee
+      // denominator is a proxy that assumes symmetric fee accrual across the pair
+      // and may otherwise inflate dailyFees.
+      swapFee = (amount * FEES.POOL_FEE_BPS) / (FEES.BPS - FEES.POOL_FEE_BPS);
+    }
+    // Source: bow.fun docs give creators 35% of collected fees; protocol keeps the remaining 65%.
     const creatorFee = (swapFee * FEES.CREATOR_SHARE_BPS) / FEES.BPS;
     const protocolFee = swapFee - creatorFee;
 

--- a/fees/bowdotfun/index.ts
+++ b/fees/bowdotfun/index.ts
@@ -1,0 +1,130 @@
+import { Dependencies, FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import { queryDuneSql } from "../../helpers/dune";
+import { METRIC } from "../../helpers/metrics";
+
+const FEES = {
+  BPS: 10_000n,
+  // Source: bow.fun docs use the 1% Uniswap V3 tier and split collected WETH fees 35% to creators.
+  POOL_FEE_BPS: 100n,
+  CREATOR_SHARE_BPS: 3_500n,
+};
+const LAUNCHED =
+  "event Launched(address indexed token, address indexed deployer, address pool, uint256 positionId, uint256 launchId)";
+
+const chainConfig: Record<string, { start: string; factory: string; fromBlock: number; weth: string; duneChain: string }> = {
+  [CHAIN.ROBINHOOD]: {
+    // https://bow.fun/docs.html#deployed-contracts
+    start: "2026-07-11",
+    factory: "0xC70E510E14710Ea535CAB7b2414860aF63FEab79",
+    fromBlock: 7158095,
+    weth: "0x0Bd7D308f8E1639FAb988df18A8011f41EAcAD73",
+    duneChain: "robinhood",
+  },
+};
+
+const toBigInt = (amount: string | number | bigint) => BigInt(amount.toString());
+
+function buildDuneQuery(options: FetchOptions) {
+  const { duneChain, weth } = chainConfig[options.chain];
+
+  return `
+    SELECT project_contract_address AS pool, t.side, CAST(SUM(t.amount) AS VARCHAR) AS amount
+    FROM dex.trades
+    CROSS JOIN UNNEST(
+      ARRAY['bought', 'sold'],
+      ARRAY[token_bought_address, token_sold_address],
+      ARRAY[token_bought_amount_raw, token_sold_amount_raw]
+    ) AS t (side, token, amount)
+    WHERE blockchain = '${duneChain}'
+      AND project = 'uniswap'
+      AND version = '3'
+      AND block_time >= from_unixtime(${options.startTimestamp})
+      AND block_time < from_unixtime(${options.endTimestamp})
+      AND t.token = ${weth}
+    GROUP BY project_contract_address, t.side`;
+}
+
+const fetch = async (options: FetchOptions) => {
+  const tenHoursAgo = Date.now() - 10 * 60 * 60 * 1000;
+  if (options.toTimestamp * 1000 > tenHoursAgo) {
+    throw new Error("End timestamp is less than 10 hours ago, skipping due to dune indexing delay");
+  }
+
+  const dailyFees = options.createBalances();
+  const dailyRevenue = options.createBalances();
+  const dailyProtocolRevenue = options.createBalances();
+  const dailySupplySideRevenue = options.createBalances();
+  const { factory, fromBlock, weth } = chainConfig[options.chain];
+
+  const launches = (await options.getLogs({
+    target: factory,
+    eventAbi: LAUNCHED,
+    fromBlock,
+    cacheInCloud: true,
+  })) as { pool: string }[];
+
+  const launchedPools = new Set(launches.map((launch) => launch.pool.toLowerCase()));
+  if (!launchedPools.size) {
+    return { dailyFees, dailyRevenue, dailyProtocolRevenue, dailySupplySideRevenue };
+  }
+
+  const rows: { pool?: string; side?: string; amount?: string | number }[] =
+    await queryDuneSql(options, buildDuneQuery(options));
+
+  for (const row of rows) {
+    if (!row.pool || !launchedPools.has(row.pool.toLowerCase())) continue;
+
+    const amount = toBigInt(row.amount ?? 0);
+    const swapFee =
+      row.side === "sold"
+        ? (amount * FEES.POOL_FEE_BPS) / FEES.BPS
+        : (amount * FEES.POOL_FEE_BPS) / (FEES.BPS - FEES.POOL_FEE_BPS);
+    const creatorFee = (swapFee * FEES.CREATOR_SHARE_BPS) / FEES.BPS;
+    const protocolFee = swapFee - creatorFee;
+
+    dailyFees.add(weth, swapFee, METRIC.SWAP_FEES);
+    dailyRevenue.add(weth, protocolFee, "Token Swap Fees to Protocol");
+    dailyProtocolRevenue.add(weth, protocolFee, "Token Swap Fees to Protocol");
+    dailySupplySideRevenue.add(weth, creatorFee, "Token Swap Fees to Creators");
+  }
+
+  return { dailyFees, dailyRevenue, dailyProtocolRevenue, dailySupplySideRevenue };
+};
+
+const methodology = {
+  Fees:
+    "1% swap fees from bow.fun factory-launched Uniswap V3 pools on Robinhood Chain.",
+  Revenue: "65% of swap fees retained by the bow.fun protocol.",
+  ProtocolRevenue: "65% of swap fees retained by the bow.fun protocol.",
+  SupplySideRevenue: "35% of swap fees routed to launched-token creators.",
+};
+
+const breakdownMethodology = {
+  Fees: {
+    [METRIC.SWAP_FEES]:
+      "1% swap fees from bow.fun factory-launched Uniswap V3 pools.",
+  },
+  Revenue: {
+    "Token Swap Fees to Protocol": "The protocol's 65% share of swap fees.",
+  },
+  ProtocolRevenue: {
+    "Token Swap Fees to Protocol": "The protocol's 65% share of swap fees.",
+  },
+  SupplySideRevenue: {
+    "Token Swap Fees to Creators": "The launched token creator's 35% share of swap fees.",
+  },
+};
+
+const adapter: SimpleAdapter = {
+  version: 1,
+  fetch,
+  adapter: chainConfig,
+  dependencies: [Dependencies.DUNE],
+  methodology,
+  breakdownMethodology,
+  doublecounted: true, // Bow.fun pools are Uniswap V3 pools.
+  isExpensiveAdapter: true,
+};
+
+export default adapter;

--- a/fees/bowdotfun/index.ts
+++ b/fees/bowdotfun/index.ts
@@ -39,8 +39,7 @@ function buildDuneQuery(options: FetchOptions) {
     WHERE blockchain = '${duneChain}'
       AND project = 'uniswap'
       AND version = '3'
-      AND block_time >= from_unixtime(${options.startTimestamp})
-      AND block_time < from_unixtime(${options.endTimestamp})
+      AND TIME_RANGE
       AND t.token = ${weth}
     GROUP BY project_contract_address, t.side`;
 }

--- a/fees/bowdotfun/index.ts
+++ b/fees/bowdotfun/index.ts
@@ -1,7 +1,8 @@
-import { Dependencies, FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { FetchOptions, IJSON, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
-import { queryDuneSql } from "../../helpers/dune";
 import { METRIC } from "../../helpers/metrics";
+import { filterPools } from "../../helpers/uniswap";
+import ADDRESSES from "../../helpers/coreAssets.json";
 
 const FEES = {
   BPS: 10_000n,
@@ -12,79 +13,72 @@ const FEES = {
 const LAUNCHED =
   "event Launched(address indexed token, address indexed deployer, address pool, uint256 positionId, uint256 launchId)";
 
-const chainConfig: Record<string, { start: string; factory: string; fromBlock: number; weth: string; duneChain: string }> = {
+const SWAP_EVENT = "event Swap(address indexed sender, address indexed recipient, int256 amount0, int256 amount1, uint160 sqrtPriceX96, uint128 liquidity, int24 tick)"
+
+const chainConfig: Record<string, { start: string; factory: string; fromBlock: number; weth: string }> = {
   [CHAIN.ROBINHOOD]: {
     // https://bow.fun/docs.html#deployed-contracts
     start: "2026-07-11",
     factory: "0xC70E510E14710Ea535CAB7b2414860aF63FEab79",
-    fromBlock: 7158095,
-    weth: "0x0Bd7D308f8E1639FAb988df18A8011f41EAcAD73",
-    duneChain: "robinhood",
+    fromBlock: 17158095,
+    weth: ADDRESSES.robinhood.WETH,
   },
 };
 
 const toBigInt = (amount: string | number | bigint) => BigInt(amount.toString());
-
-function buildDuneQuery(options: FetchOptions) {
-  const { duneChain, weth } = chainConfig[options.chain];
-
-  return `
-    SELECT project_contract_address AS pool, t.side, CAST(SUM(t.amount) AS VARCHAR) AS amount
-    FROM dex.trades
-    CROSS JOIN UNNEST(
-      ARRAY['bought', 'sold'],
-      ARRAY[token_bought_address, token_sold_address],
-      ARRAY[token_bought_amount_raw, token_sold_amount_raw]
-    ) AS t (side, token, amount)
-    WHERE blockchain = '${duneChain}'
-      AND project = 'uniswap'
-      AND version = '3'
-      AND TIME_RANGE
-      AND t.token = ${weth}
-    GROUP BY project_contract_address, t.side`;
-}
+const MIN_TVL = 1000;
 
 const fetch = async (options: FetchOptions) => {
-  const tenHoursAgo = Date.now() - 10 * 60 * 60 * 1000;
-  if (options.toTimestamp * 1000 > tenHoursAgo) {
-    throw new Error("End timestamp is less than 10 hours ago, skipping due to dune indexing delay");
-  }
-
   const dailyFees = options.createBalances();
   const dailyRevenue = options.createBalances();
   const dailyProtocolRevenue = options.createBalances();
   const dailySupplySideRevenue = options.createBalances();
   const { factory, fromBlock, weth } = chainConfig[options.chain];
 
-  const launches = (await options.getLogs({
+  const launches = await options.getLogs({
     target: factory,
     eventAbi: LAUNCHED,
     fromBlock,
     cacheInCloud: true,
-  })) as { pool: string }[];
+  });
 
-  const launchedPools = new Set(launches.map((launch) => launch.pool.toLowerCase()));
-  if (!launchedPools.size) {
+  const pairObject: IJSON<string[]> = {};
+  for (const launch of launches) {
+    const [token0, token1] = launch.token < weth
+      ? [launch.token, weth]
+      : [weth, launch.token];
+    pairObject[launch.pool.toLowerCase()] = [token0.toLowerCase(), token1.toLowerCase()];
+  }
+
+  const filteredPools = await filterPools({
+    api: options.api,
+    pairs: pairObject,
+    createBalances: options.createBalances,
+    minUSDValue: MIN_TVL,
+    maxPairSize: 5000,
+  });
+  if (!launches.length) {
     return { dailyFees, dailyRevenue, dailyProtocolRevenue, dailySupplySideRevenue };
   }
 
-  const rows: { pool?: string; side?: string; amount?: string | number }[] =
-    await queryDuneSql(options, buildDuneQuery(options));
+  const swapLogs = await options.getLogs({
+    targets: Object.keys(filteredPools),
+    eventAbi: SWAP_EVENT,
+    entireLog: true,
+    parseLog: true,
+  })
 
-  for (const row of rows) {
-    if (!row.pool || !launchedPools.has(row.pool.toLowerCase())) continue;
+  for (const log of swapLogs) {
+    const [token0, _token1] = pairObject[log.address.toLowerCase()];
+    const wethIsToken0 = token0.toLowerCase() === weth.toLowerCase();
+    const raw = toBigInt(wethIsToken0 ? log.args.amount0 : log.args.amount1);
+    if (raw === 0n) continue;
 
-    const amount = toBigInt(row.amount ?? 0);
-    let swapFee: bigint;
-    if (row.side === "sold") {
-      swapFee = (amount * FEES.POOL_FEE_BPS) / FEES.BPS;
-    } else {
-      // WETH-bought rows are WETH output; grossing up by the pool-fee
-      // denominator is a proxy that assumes symmetric fee accrual across the pair
-      // and may otherwise inflate dailyFees.
-      swapFee = (amount * FEES.POOL_FEE_BPS) / (FEES.BPS - FEES.POOL_FEE_BPS);
-    }
-    // Source: bow.fun docs give creators 35% of collected fees; protocol keeps the remaining 65%.
+    const wethIn = raw > 0n;
+    const wethLeg = wethIn ? raw : -raw;
+    const swapFee = wethIn
+      ? (wethLeg * FEES.POOL_FEE_BPS) / FEES.BPS
+      : (wethLeg * FEES.POOL_FEE_BPS) / (FEES.BPS - FEES.POOL_FEE_BPS);
     const creatorFee = (swapFee * FEES.CREATOR_SHARE_BPS) / FEES.BPS;
     const protocolFee = swapFee - creatorFee;
 
@@ -98,11 +92,10 @@ const fetch = async (options: FetchOptions) => {
 };
 
 const methodology = {
-  Fees:
-    "1% swap fees from bow.fun factory-launched Uniswap V3 pools on Robinhood Chain.",
-  Revenue: "65% of swap fees retained by the bow.fun protocol.",
-  ProtocolRevenue: "65% of swap fees retained by the bow.fun protocol.",
-  SupplySideRevenue: "35% of swap fees routed to launched-token creators.",
+  Fees: "1% swap fees from bow.fun factory-launched Uniswap V3 pools on Robinhood Chain, filtered for pools with at least $1,000 TVL.",
+  Revenue: "65% of swap fees retained by the bow.fun protocol, filtered for pools with at least $1,000 TVL.",
+  ProtocolRevenue: "65% of swap fees retained by the bow.fun protocol, filtered for pools with at least $1,000 TVL.",
+  SupplySideRevenue: "35% of swap fees routed to launched-token creators, filtered for pools with at least $1,000 TVL.",
 };
 
 const breakdownMethodology = {
@@ -122,14 +115,13 @@ const breakdownMethodology = {
 };
 
 const adapter: SimpleAdapter = {
-  version: 1,
+  version: 2,
+  pullHourly: true,
   fetch,
   adapter: chainConfig,
-  dependencies: [Dependencies.DUNE],
   methodology,
   breakdownMethodology,
   doublecounted: true, // Bow.fun pools are Uniswap V3 pools.
-  isExpensiveAdapter: true,
 };
 
 export default adapter;


### PR DESCRIPTION
**NOTE**

#### Please enable "Allow edits by maintainers" while putting up the PR.

---

> - If you would like to add a `tvl` adapter please submit the PR [here](https://github.com/DefiLlama/DefiLlama-Adapters).

1. Once your adapter has been merged, it takes time to show on the UI. If more than 24 hours have passed, please let us know in Discord.
2. Please fill the form below **only if the PR is for listing a new protocol** else it can be ignored/replaced with reason/details about the PR
3. **For updating listing info** Please send a mail to metadata@defillama.com
4. Do not edit/push `package.json/package-lock.json` file as part of your changes
5. No need to go to our discord/other channel and announce that you've created a PR, we monitor all PRs and will review it asap

---

##### Name (to be shown on DefiLlama):
bow.fun

##### Twitter Link:
https://x.com/bowdotfun

##### Website Link:
https://bow.fun/

##### Chain:
Robinhood Chain

##### Short Description (to be shown on DefiLlama):
Fair-launch token platform on Robinhood Chain where tokens launch into locked Uniswap V3 pools and creators earn a share of swap fees.

##### Category (full list at https://defillama.com/categories) \*Please choose only one:
Launchpad

##### methodology (what is being counted as tvl, how is tvl being calculated):
Adds a fees adapter for `fees/bowdotfun`. The adapter counts 1% swap fees from bow.fun factory-launched Uniswap V3 pools on Robinhood Chain. Revenue is 65% of swap fees retained by the protocol, and supply-side revenue is 35% of swap fees routed to launched-token creators. Bow.fun pools are marked as double-counted because the underlying swaps are also Uniswap V3 pool activity.

##### Tests:
- `pnpm test fees bowdotfun 2026-07-12` - passed, daily fees `75`, revenue `49`, supply-side revenue `26`
- `pnpm test fees bowdotfun 2026-07-14` - passed, daily fees `70.62k`, revenue `45.91k`, supply-side revenue `24.72k`
- `pnpm test fees bowdotfun 2026-07-20` - passed, daily fees `35.66k`, revenue `23.18k`, supply-side revenue `12.48k`
- `pnpm test fees bowdotfun 2026-07-27` - passed, daily fees `17.38k`, revenue `11.30k`, supply-side revenue `6.08k`