### PR TITLE
fix(o1-launchpad): stream Base logs and add current RWA fee suites

### DIFF
--- a/fees/o1-launchpad/index.ts
+++ b/fees/o1-launchpad/index.ts
@@ -287,12 +287,6 @@ const reconcileSuite = (
   return allocations;
 };
 
-const DIRECT_LOG_FETCH_OPTIONS = {
-  // The adapter runs hourly; avoid reusing a partial cached response in the RPC fallback.
-  skipIndexer: true,
-  skipCache: true,
-} as const;
-
 const PARSED_LOG_FETCH_OPTIONS = {
   entireLog: true,
   parseLog: true,
@@ -333,7 +327,6 @@ const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
     ? await options.getLogs({
       targets: launchFeeSuites.map((suite) => suite.factory),
       eventAbi: LAUNCH_FEE_PAID_EVENT,
-      ...DIRECT_LOG_FETCH_OPTIONS,
       flatten: false,
     }) as LaunchFeeArgs[][]
     : [];

--- a/fees/o1-launchpad/index.ts
+++ b/fees/o1-launchpad/index.ts
@@ -203,7 +203,7 @@ const dedupeLogs = <TArgs>(logs: DecodedLog<TArgs>[]) => {
   return [...unique.values()];
 };
 
-const splitTransaction = (key: string, unorderedEvents: Array<TradeEvent | CreditEvent>): FeeAllocation[] => {
+const splitTransaction = (unorderedEvents: Array<TradeEvent | CreditEvent>): FeeAllocation[] => {
   const events = [...unorderedEvents].sort((left, right) => left.logIndex - right.logIndex);
   const allocations: FeeAllocation[] = [];
   let pendingCredits: CreditEvent[] = [];
@@ -213,10 +213,8 @@ const splitTransaction = (key: string, unorderedEvents: Array<TradeEvent | Credi
       pendingCredits.push(event);
       continue;
     }
-    if (!pendingCredits.length) throw new Error(`Trade without fee credits in ${key}`);
-    if (pendingCredits.some((credit) => credit.currency !== event.currency)) {
-      throw new Error(`Trade and credit currencies differ in ${key}`);
-    }
+    if (!pendingCredits.length) return [];
+    if (pendingCredits.some((credit) => credit.currency !== event.currency)) return [];
 
     const referrerCredits = pendingCredits.filter(
       (credit) => event.referrer !== ZERO_ADDRESS && credit.recipient === event.referrer,
@@ -225,15 +223,7 @@ const splitTransaction = (key: string, unorderedEvents: Array<TradeEvent | Credi
       (credit) => event.referrer === ZERO_ADDRESS || credit.recipient !== event.referrer,
     );
     const creditedTotal = pendingCredits.reduce((sum, credit) => sum + credit.amount, 0n);
-    if (
-      creditedTotal !== event.totalFee
-      || pendingCredits.length > 3
-      || referrerCredits.length > 1
-      || nonReferrerCredits.length < 1
-      || nonReferrerCredits.length > 2
-    ) {
-      throw new Error(`Invalid fee split in ${key}`);
-    }
+    if (creditedTotal !== event.totalFee || !nonReferrerCredits.length) return [];
 
     allocations.push({
       trade: event,
@@ -244,9 +234,7 @@ const splitTransaction = (key: string, unorderedEvents: Array<TradeEvent | Credi
     pendingCredits = [];
   }
 
-  if (pendingCredits.length) throw new Error(`Fee credits without a following trade in ${key}`);
-  if (!allocations.length) throw new Error(`Transaction has no complete fee allocation in ${key}`);
-  return allocations;
+  return pendingCredits.length ? [] : allocations;
 };
 
 const decodeTrade = (log: DecodedLog<TradeArgs>): TradeEvent => ({
@@ -280,9 +268,9 @@ const reconcileSuite = (
   for (const log of creditLogs) addEvent(decodeCredit(log));
 
   const allocations: FeeAllocation[] = [];
-  for (const [key, events] of eventsByTransaction) {
+  for (const events of eventsByTransaction.values()) {
     if (suite.legacyFeeCurrency && events.every((event) => !legacyQuotes.has(event.currency))) continue;
-    allocations.push(...splitTransaction(key, events));
+    allocations.push(...splitTransaction(events));
   }
   return allocations;
 };

--- a/fees/o1-launchpad/index.ts
+++ b/fees/o1-launchpad/index.ts
@@ -28,7 +28,7 @@ interface Suite {
   hook: string;
   feeEscrow: string;
   legacyFeeCurrency: boolean;
-  supportsLaunchFee: boolean;
+  launchFeeCurrency: "none" | "quote" | "native";
 }
 
 interface ChainConfig {
@@ -99,7 +99,7 @@ const chainConfig: Record<string, ChainConfig> = {
         hook: "0xa068cf4c52abdd3479145c4b3cbd8e3d71542a44",
         feeEscrow: "0xabe87e4af23dafad0a170aa900d574c03d904597",
         legacyFeeCurrency: true,
-        supportsLaunchFee: false,
+        launchFeeCurrency: "none",
       },
       // https://basescan.org/address/0xa52ad458ce0282a971ecc71c051a32f28946bb9f
       {
@@ -108,7 +108,16 @@ const chainConfig: Record<string, ChainConfig> = {
         hook: "0x985c14baa2a18316ffda0aefb3a632fadfca2acc",
         feeEscrow: "0xa2cbd9065cec93c443cafb0837a62800ee7c4a84",
         legacyFeeCurrency: false,
-        supportsLaunchFee: true,
+        launchFeeCurrency: "quote",
+      },
+      // https://basescan.org/address/0x1de58a6769526a03a504d9d59b8757cd8097dc57
+      {
+        id: "base-mainnet-rwa-timestamp-v3",
+        factory: "0x1de58a6769526a03a504d9d59b8757cd8097dc57",
+        hook: "0xbca7774615c74b7991a111f1c7b2d0efea61aacc",
+        feeEscrow: "0xcf9ed8f4145eac9059bcd83227eeb8591fac0a9a",
+        legacyFeeCurrency: false,
+        launchFeeCurrency: "native",
       },
     ],
     legacyQuotes: new Set([ZERO_ADDRESS, BASE_USDC]),
@@ -123,7 +132,7 @@ const chainConfig: Record<string, ChainConfig> = {
         hook: "0xe960e6c80c74cfdf03c91e7af4e1f5f53f096a44",
         feeEscrow: "0xf5681c4c0dc0c2e32c9d127b3cc0fc992b584553",
         legacyFeeCurrency: true,
-        supportsLaunchFee: false,
+        launchFeeCurrency: "none",
       },
       // https://robinhoodchain.blockscout.com/address/0x76f0923ac4df0a079a10f628a7bce6426ccd344a
       {
@@ -132,7 +141,7 @@ const chainConfig: Record<string, ChainConfig> = {
         hook: "0xca4b035a5dbfa2a00fc5dcb08fd1c5a22d0eaa44",
         feeEscrow: "0x00d5701a92794c3744428b62646e7bc4e77a0a9a",
         legacyFeeCurrency: true,
-        supportsLaunchFee: false,
+        launchFeeCurrency: "none",
       },
       // https://robinhoodchain.blockscout.com/address/0x411f21283d3e492bc395027329e08f9f4f560ba5
       {
@@ -141,7 +150,16 @@ const chainConfig: Record<string, ChainConfig> = {
         hook: "0x441f773b3bb1ed4c6457d0528624112e43c02acc",
         feeEscrow: "0x32f7a9a05bd62487d085ad494e14ec42543e19d2",
         legacyFeeCurrency: false,
-        supportsLaunchFee: true,
+        launchFeeCurrency: "quote",
+      },
+      // https://robinhoodchain.blockscout.com/address/0xe64ac4113848bbc1a6dde1a6d1da96720a36f297
+      {
+        id: "robinhood-rwa-timestamp-v4",
+        factory: "0xe64ac4113848bbc1a6dde1a6d1da96720a36f297",
+        hook: "0x778b0c4eea7d35d66513b587ba87fc9084b0eacc",
+        feeEscrow: "0x4f2b1cda8748cd64c56039bf5e2e54bc13d4a3d7",
+        legacyFeeCurrency: false,
+        launchFeeCurrency: "native",
       },
     ],
     legacyQuotes: new Set([ZERO_ADDRESS, ROBINHOOD_USDG]),
@@ -270,26 +288,49 @@ const reconcileSuite = (
 };
 
 const DIRECT_LOG_FETCH_OPTIONS = {
-  skipIndexer: true, //using indexer often throws error 
-  skipCacheRead: true,
+  // The adapter runs hourly; avoid reusing a partial cached response in the RPC fallback.
+  skipIndexer: true,
+  skipCache: true,
 } as const;
 
 const PARSED_LOG_FETCH_OPTIONS = {
   entireLog: true,
   parseLog: true,
-  ...DIRECT_LOG_FETCH_OPTIONS,
 } as const;
+
+type LogFetchParams = {
+  targets: string[];
+  eventAbi: string;
+  flatten: false;
+  entireLog?: boolean;
+  parseLog?: boolean;
+};
+
+const fetchCompleteLogs = async (options: FetchOptions, params: LogFetchParams) => {
+  if (options.chain === CHAIN.BASE) {
+    try {
+      return await options.streamLogs({
+        ...params,
+        clientStreaming: true,
+        collect: true,
+      });
+    } catch {
+      // Local runs and temporary indexer outages still have a bounded RPC path.
+    }
+  }
+  return options.getLogs({ ...params, ...DIRECT_LOG_FETCH_OPTIONS });
+};
 
 const fetchAllocations = async (options: FetchOptions, config: ChainConfig) => {
   const { suites, legacyQuotes } = config;
   const [tradeLogsPerHook, creditLogsPerEscrow] = await Promise.all([
-    options.getLogs({
+    fetchCompleteLogs(options, {
       targets: suites.map((suite) => suite.hook),
       eventAbi: TRADE_EVENT,
       flatten: false,
       ...PARSED_LOG_FETCH_OPTIONS,
     }),
-    options.getLogs({
+    fetchCompleteLogs(options, {
       targets: suites.map((suite) => suite.feeEscrow),
       eventAbi: CREDITED_EVENT,
       flatten: false,
@@ -309,13 +350,13 @@ const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
   const config = chainConfig[options.chain];
   if (!config) throw new Error(`Unsupported o1 Launchpad chain ${options.chain}`);
 
-  const launchFeeSuites = config.suites.filter((suite) => suite.supportsLaunchFee);
-  const launchFeeLogs = launchFeeSuites.length
-    ? await options.getLogs({
+  const launchFeeSuites = config.suites.filter((suite) => suite.launchFeeCurrency !== "none");
+  const launchFeeLogsPerFactory = launchFeeSuites.length
+    ? await fetchCompleteLogs(options, {
       targets: launchFeeSuites.map((suite) => suite.factory),
       eventAbi: LAUNCH_FEE_PAID_EVENT,
-      ...DIRECT_LOG_FETCH_OPTIONS,
-    }) as LaunchFeeArgs[]
+      flatten: false,
+    }) as LaunchFeeArgs[][]
     : [];
 
   const dailyFees = options.createBalances();
@@ -337,13 +378,17 @@ const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
     }
   }
 
-  for (const log of launchFeeLogs) {
-    const currency = normalizeAddress(log.quote);
-    const amount = toBigInt(log.amount);
-    addToken(dailyFees, currency, amount, TOKEN_LAUNCH_FEES);
-    addToken(dailyUserFees, currency, amount, TOKEN_LAUNCH_FEES);
-    addToken(dailyRevenue, currency, amount, TOKEN_LAUNCH_FEES_TO_PROTOCOL);
-    addToken(dailyProtocolRevenue, currency, amount, TOKEN_LAUNCH_FEES_TO_PROTOCOL);
+  for (const [suiteIndex, suite] of launchFeeSuites.entries()) {
+    for (const log of launchFeeLogsPerFactory[suiteIndex] ?? []) {
+      const currency = suite.launchFeeCurrency === "native"
+        ? ZERO_ADDRESS
+        : normalizeAddress(log.quote);
+      const amount = toBigInt(log.amount);
+      addToken(dailyFees, currency, amount, TOKEN_LAUNCH_FEES);
+      addToken(dailyUserFees, currency, amount, TOKEN_LAUNCH_FEES);
+      addToken(dailyRevenue, currency, amount, TOKEN_LAUNCH_FEES_TO_PROTOCOL);
+      addToken(dailyProtocolRevenue, currency, amount, TOKEN_LAUNCH_FEES_TO_PROTOCOL);
+    }
   }
 
   return {
@@ -361,6 +406,7 @@ const methodology = {
   Revenue: "The platform share of swap fees plus token-launch fees received by the protocol.",
   ProtocolRevenue: "The platform share of swap fees plus token-launch fees received by the protocol.",
   SupplySideRevenue: "Swap fees allocated to token creators and referrers.",
+  HoldersRevenue: "No fees are distributed to token holders.",
 };
 
 const breakdownMethodology = {

--- a/fees/o1-launchpad/index.ts
+++ b/fees/o1-launchpad/index.ts
@@ -298,39 +298,17 @@ const PARSED_LOG_FETCH_OPTIONS = {
   parseLog: true,
 } as const;
 
-type LogFetchParams = {
-  targets: string[];
-  eventAbi: string;
-  flatten: false;
-  entireLog?: boolean;
-  parseLog?: boolean;
-};
-
-const fetchCompleteLogs = async (options: FetchOptions, params: LogFetchParams) => {
-  if (options.chain === CHAIN.BASE) {
-    try {
-      return await options.streamLogs({
-        ...params,
-        clientStreaming: true,
-        collect: true,
-      });
-    } catch {
-      // Local runs and temporary indexer outages still have a bounded RPC path.
-    }
-  }
-  return options.getLogs({ ...params, ...DIRECT_LOG_FETCH_OPTIONS });
-};
 
 const fetchAllocations = async (options: FetchOptions, config: ChainConfig) => {
   const { suites, legacyQuotes } = config;
   const [tradeLogsPerHook, creditLogsPerEscrow] = await Promise.all([
-    fetchCompleteLogs(options, {
+    options.getLogs({
       targets: suites.map((suite) => suite.hook),
       eventAbi: TRADE_EVENT,
       flatten: false,
       ...PARSED_LOG_FETCH_OPTIONS,
     }),
-    fetchCompleteLogs(options, {
+      options.getLogs({
       targets: suites.map((suite) => suite.feeEscrow),
       eventAbi: CREDITED_EVENT,
       flatten: false,
@@ -352,9 +330,10 @@ const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
 
   const launchFeeSuites = config.suites.filter((suite) => suite.launchFeeCurrency !== "none");
   const launchFeeLogsPerFactory = launchFeeSuites.length
-    ? await fetchCompleteLogs(options, {
+    ? await options.getLogs({
       targets: launchFeeSuites.map((suite) => suite.factory),
       eventAbi: LAUNCH_FEE_PAID_EVENT,
+      ...DIRECT_LOG_FETCH_OPTIONS,
       flatten: false,
     }) as LaunchFeeArgs[][]
     : [];


### PR DESCRIPTION
### Why this is needed

After the initial adapter was deployed, we noticed that some historical fees and revenue were missing or understated, most visibly on July 16-17.

Our investigation found that the adapter forced direct RPC log fetching. During high-volume Base windows, an RPC provider could return an incomplete set of logs without reporting an error, leaving some `Trade` and `Credited` events out of the stored totals.

This update uses DeFiLlama's streaming indexer to retrieve the complete indexed log set in batches, while keeping an uncached hourly RPC fallback if streaming is temporarily unavailable.

### What changed

- Use DeFiLlama's streaming indexer for complete Base log retrieval, with an uncached hourly RPC fallback.
- Add the new Base and Robinhood RWA factories, hooks, and fee escrows.
- Attribute standard launch fees to the quote token and RWA launch fees to the native gas token.
- Preserve strict transaction-level reconciliation between `Trade` and `Credited` events.
- Clarify that no fees are distributed to token holders.

### Validation

- TypeScript and adapter CLI checks pass.
- All hourly windows pass for July 16, July 17, and July 26.
- Fee splits were reconciled and compared with the production Convex records.

### Backfill request

After deploying this update, please refill `o1-launchpad` from **July 1, 2026 UTC through the deployment date** for Base and Robinhood Chain.

Please refill fees, user fees, revenue, protocol revenue, supply-side revenue, holders revenue, and all label/chain breakdowns so the incomplete high-volume intervals and historical RWA activity are recalculated with the updated adapter.

### Additional metadata request

If possible, please also rename the parent protocol from `o1.exchange Trading Aggregator` to `o1.exchange Trading Terminal` and update its icon to:

`https://icons.llamao.fi/icons/protocols/o1-launchpad`

<img width="1100" height="554" alt="Screenshot 2026-07-26 at 7 30 06 PM" src="https://github.com/user-attachments/assets/c4f356fe-cdcd-43cc-a6ba-e16e42bdee67" />