### PR TITLE
[fix] swaap maker v2 - skip chains with deleted subgraphs

### DIFF
--- a/dexs/swaap-v2.ts
+++ b/dexs/swaap-v2.ts
@@ -102,7 +102,7 @@ const getVolume = async (options: FetchOptions) => {
   }
   `;
   const url = config[options.chain].api;
-  const graphQLClient = new GraphQLClient(url, { timeout: 3000 });
+  const graphQLClient = new GraphQLClient(url, { timeout: 30000 });
   const result: Data = await graphQLClient.request(query);
   const dailyVolume = Number(result.end?.totalSwapVolume || 0) - Number(result.start?.totalSwapVolume || 0);
   return {
@@ -141,15 +141,19 @@ const adapter: SimpleAdapter = {
     },
     [CHAIN.MODE]: {
       start: '2024-05-02',
+      deadFrom: '2026-07-01',
     },
     [CHAIN.SCROLL]: {
       start: '2024-06-27',
+      deadFrom: '2026-07-01',
     },
     [CHAIN.LINEA]: {
       start: '2024-06-27',
+      deadFrom: '2026-07-01',
     },
     [CHAIN.MANTLE]: {
       start: '2024-06-27',
+      deadFrom: '2026-07-01',
     },
   },
 };


### PR DESCRIPTION
fixes #8432

adapter has reported nothing since jun 30. root cause: the goldsky subgraphs for mode, scroll, linea and mantle were deleted (404 "Subgraph not found"), and since all chains run together the throw killed the whole adapter every day.

- marked those 4 chains deadFrom 2026-07-01 (last stored datapoint is jun 30). no alternate deployment tags exist for them (tried prod/1.0.0/1.0.1/latest/live), so history there is not recoverable anyway
- the 6 remaining subgraphs are alive and synced to head. note the resumed numbers are much higher than the old series: swaap re-indexed these subgraphs and the old data was undercounting badly. cross-checked on-chain for 2026-06-29 on ethereum: 1,002 Swap events on the swaap vault (0xd315a9c3...) with $2.68M counting only the usdc side of pairs, vs $26k stored for that day. the subgraph now reports $5.65M for the same day, consistent with the usdc-side figure being roughly half the flow (weth/wsteth style pairs dont touch usdc). so the level jump on resume is the data getting fixed, not a regression
- bumped the graphql client timeout 3s -> 30s, goldsky intermittently takes longer than 3s and a single slow chain should not cost the whole day

test run (all 6 live chains, day 2026-07-26): ethereum $6.07M, base $76.9k, optimism $25.2k, bsc $9.1k, polygon $1.2k, arbitrum $0, aggregate $6.18M