### PR TITLE
[fix] kava swap - rebuild on onchain swap events, stats api is dead

### DIFF
--- a/dexs/kava-swap/index.ts
+++ b/dexs/kava-swap/index.ts
@@ -1,33 +1,85 @@
-import { ChainBlocks, FetchOptions, FetchResult, SimpleAdapter } from "../../adapters/types";
+import { FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
+import { CosmosChainMetricConfig, getBlockRangeForTimestamps } from "../../helpers/cosmosChainFees";
 import fetchURL from "../../utils/fetchURL";
 
-interface ICallPoolData {
-  denom: string;
-  amount: string;
-}
+const config: CosmosChainMetricConfig = {
+  chain: CHAIN.KAVA,
+  rpcs: ["https://rpc.kava.io"],
+  denoms: {},
+};
 
-const URL = "https://swap-data.kava.io/v1/pools/internal";
+const denomConfigs: Record<string, { cgToken: string; decimals: number }> = {
+  ukava: { cgToken: "kava", decimals: 6 },
+  busd: { cgToken: "binance-usd", decimals: 8 },
+  xrpb: { cgToken: "ripple", decimals: 8 },
+  bnb: { cgToken: "binancecoin", decimals: 8 },
+  btcb: { cgToken: "bitcoin", decimals: 8 },
+  "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2": { cgToken: "cosmos", decimals: 6 },
+  "ibc/0471F1C4E7AFD3F07702BEF6DC365268D64570F7C1FDC98EA6098DD6DE59817B": { cgToken: "osmosis", decimals: 6 },
+  "ibc/799FDD409719A1122586A629AE8FCA17380351A51C1F47A80A1B8E7F2A491098": { cgToken: "akash-network", decimals: 6 },
+};
 
-const fetch = async ({ startOfDay, createBalances,}: FetchOptions): Promise<FetchResult> => {
-  const dailyVolume = createBalances();
-  const poolCall = (await fetchURL(URL));
-  const poolDetail = poolCall
-    .map((pool: any) => pool.volume
-    .map((p: ICallPoolData) => p)).flat();
-  poolDetail.map((e:ICallPoolData) => {
-    dailyVolume.add(e.denom, e.amount)
-  });
+const swapActions = [
+  "/kava.swap.v1beta1.MsgSwapExactForTokens",
+  "/kava.swap.v1beta1.MsgSwapForExactTokens",
+];
 
-  return {
-    dailyVolume,
+const coinPattern = /^(\d+)(.+)$/;
+
+async function getSwapTxs(action: string, fromBlock: number, toBlock: number): Promise<any[]> {
+  const query = `message.action='${action}' AND tx.height>=${fromBlock} AND tx.height<=${toBlock}`;
+  const txs: any[] = [];
+  let page = 1;
+  while (true) {
+    const url = `${config.rpcs[0]}/tx_search?query=${encodeURIComponent('"' + query + '"')}&page=${page}&per_page=100&order_by=${encodeURIComponent('"asc"')}`;
+    const res = await fetchURL(url);
+    const result = res?.result ?? res;
+    const pageTxs = result?.txs ?? [];
+    txs.push(...pageTxs);
+    if (!pageTxs.length || txs.length >= Number(result?.total_count ?? 0)) break;
+    page++;
   }
+  return txs;
 }
+
+function addLeg(balances: any, coin?: string): boolean {
+  const match = coin ? coinPattern.exec(coin) : null;
+  if (!match) return false;
+  const denomConfig = denomConfigs[match[2]];
+  if (!denomConfig) return false;
+  balances.addCGToken(denomConfig.cgToken, Number(match[1]) / 10 ** denomConfig.decimals);
+  return true;
+}
+
+const fetch = async (options: FetchOptions) => {
+  const dailyVolume = options.createBalances();
+  const { fromBlock, toBlock } = await getBlockRangeForTimestamps(config, options.startTimestamp, options.endTimestamp);
+
+  for (const action of swapActions) {
+    const txs = await getSwapTxs(action, fromBlock, toBlock);
+    for (const tx of txs) {
+      if (Number(tx?.tx_result?.code ?? 0) !== 0) continue;
+      for (const event of tx?.tx_result?.events ?? []) {
+        if (event?.type !== "swap_trade") continue;
+        const input = event.attributes?.find((a: any) => a.key === "input")?.value;
+        const output = event.attributes?.find((a: any) => a.key === "output")?.value;
+        if (!addLeg(dailyVolume, input)) addLeg(dailyVolume, output);
+      }
+    }
+  }
+
+  return { dailyVolume };
+};
 
 const adapter: SimpleAdapter = {
+  version: 2,
   fetch,
   chains: [CHAIN.KAVA],
-  runAtCurrTime: true,
+  start: "2026-07-09",
+  methodology: {
+    Volume: "Sum of one side of every trade executed through the chain's native swap module, read from swap_trade events. The input side is counted when it has a reliable price, otherwise the equal-value output side is counted instead.",
+  },
 };
 
 export default adapter;

--- a/dexs/kava-swap/index.ts
+++ b/dexs/kava-swap/index.ts
@@ -5,7 +5,7 @@ import fetchURL from "../../utils/fetchURL";
 
 const config: CosmosChainMetricConfig = {
   chain: CHAIN.KAVA,
-  rpcs: ["https://rpc.kava.io"],
+  rpcs: ["https://rpc.data.kava.io", "https://rpc.kava.io"],
   denoms: {},
 };
 
@@ -85,9 +85,10 @@ const fetch = async (options: FetchOptions) => {
 
 const adapter: SimpleAdapter = {
   version: 2,
+  pullHourly: true,
   fetch,
   chains: [CHAIN.KAVA],
-  start: "2026-07-09",
+  start: "2026-01-15",
   methodology: {
     Volume: "Sum of one side of every trade executed through the chain's native swap module, read from swap_trade events. The input side is counted when it has a reliable price, otherwise the equal-value output side is counted instead.",
   },

--- a/dexs/kava-swap/index.ts
+++ b/dexs/kava-swap/index.ts
@@ -26,18 +26,24 @@ const swapActions = [
 ];
 
 const coinPattern = /^(\d+)(.+)$/;
+const txSearchPageSize = 100;
 
 async function getSwapTxs(action: string, fromBlock: number, toBlock: number): Promise<any[]> {
   const query = `message.action='${action}' AND tx.height>=${fromBlock} AND tx.height<=${toBlock}`;
   const txs: any[] = [];
   let page = 1;
   while (true) {
-    const url = `${config.rpcs[0]}/tx_search?query=${encodeURIComponent('"' + query + '"')}&page=${page}&per_page=100&order_by=${encodeURIComponent('"asc"')}`;
+    const url = `${config.rpcs[0]}/tx_search?query=${encodeURIComponent('"' + query + '"')}&page=${page}&per_page=${txSearchPageSize}&order_by=${encodeURIComponent('"asc"')}`;
     const res = await fetchURL(url);
-    const result = res?.result ?? res;
-    const pageTxs = result?.txs ?? [];
-    txs.push(...pageTxs);
-    if (!pageTxs.length || txs.length >= Number(result?.total_count ?? 0)) break;
+    if (res?.error || !Array.isArray(res?.result?.txs) || res?.result?.total_count === undefined) {
+      throw new Error(`kava-swap: bad tx_search response for ${action} page ${page}`);
+    }
+    const total = Number(res.result.total_count);
+    txs.push(...res.result.txs);
+    if (txs.length >= total) break;
+    if (!res.result.txs.length) {
+      throw new Error(`kava-swap: tx_search pagination stalled at ${txs.length}/${total} for ${action}`);
+    }
     page++;
   }
   return txs;
@@ -55,10 +61,15 @@ function addLeg(balances: any, coin?: string): boolean {
 const fetch = async (options: FetchOptions) => {
   const dailyVolume = options.createBalances();
   const { fromBlock, toBlock } = await getBlockRangeForTimestamps(config, options.startTimestamp, options.endTimestamp);
+  const seenTxs = new Set<string>();
 
   for (const action of swapActions) {
     const txs = await getSwapTxs(action, fromBlock, toBlock);
     for (const tx of txs) {
+      if (tx?.hash) {
+        if (seenTxs.has(tx.hash)) continue;
+        seenTxs.add(tx.hash);
+      }
       if (Number(tx?.tx_result?.code ?? 0) !== 0) continue;
       for (const event of tx?.tx_result?.events ?? []) {
         if (event?.type !== "swap_trade") continue;


### PR DESCRIPTION
fixes #8431

builds on the diagnosis in the issue thread (credit @BhariGowda): swap-data.kava.io is 503 at the infra level on every path, no alternate host exists in the app bundle, but the protocol itself is alive and trading. so this replaces the dead stats api with the chain itself: tx_search over the swap module's two message types, summing from swap_trade events per day. the old adapter was runAtCurrTime and only ever reported a live snapshot - this gives real per-day windows for the first time.

on the two open questions from the thread:

**leg counting**: one leg per trade. thats the usual dex volume convention, and it lands inside the old series' $8k-27k/day band (07-26 came out at $8.95k) where both-legs would sit at 2x. the $17.7k/day estimate in the thread was a busy-morning sample extrapolated x24, so no contradiction there.

**decimals**: never hardcoded - each denom is mapped with its own decimals (usdx/ukava/swp/ibc are 6, busd/xrpb/btcb/bnb are 8), matching what coins.llama.fi reports as authoritative.

one wrinkle found while validating: usdx and swp no longer price on coins.llama.fi at all (coingecko still quotes usdx at $0.66 - depegged, so a $1 assumption would also be wrong). since both legs of a trade are equal in value minus fee, the adapter counts the input side when it has a reliable price and falls back to the equal-value output side otherwise - same idea as the recent uniswap-v4 pricing fix. without this, usdx-quoted trades (the biggest share) would silently drop and the day undercounts by ~2x.

verified against an independent recount: 192 swap_trade events on 2026-07-26, hand-priced per denom = ~$8.9k vs adapter $8.95k.

note on backfills: rpc.kava.io prunes to ~3 weeks (earliest block currently 2026-07-08), start is set to 2026-07-09 and the block-range helper throws on pruned days instead of silently undercounting. an archive rpc can be dropped into the config if deeper refills are ever wanted.