### PR TITLE
feat: add OwlOrderFi volume adapter (Base, Polygon)

### DIFF
--- a/dexs/owlorderfi.ts
+++ b/dexs/owlorderfi.ts
@@ -1,5 +1,6 @@
 import { SimpleAdapter, FetchV2 } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
+import { METRIC } from "../helpers/metrics";
 
 /**
  * OwlOrderFi — non-custodial limit / stop / TWAP / DCA order router for
@@ -50,21 +51,20 @@ const fetch: FetchV2 = async ({ getLogs, chain, createBalances }) => {
   const dailyVolume = createBalances();
   const dailyFees = createBalances();
 
-  // One call per router rather than a single `targets` call: the shape of a
-  // multi-target result depends on the `flatten` default, and a wrong guess
-  // there iterates arrays instead of logs. Two calls are unambiguous.
-  for (const router of config[chain].routers) {
-    const logs = await getLogs({ target: router, eventAbi: ORDER_EXECUTED });
+  const logs = await getLogs({
+    targets: config[chain].routers,
+    eventAbi: ORDER_EXECUTED,
+    flatten: true,
+  });
 
-    for (const log of logs) {
-      if (BigInt(log.orderType) === CANCEL_SENTINEL) continue;
-      // Input leg only. Adding tokenOut as well would double-count the same
-      // trade, and `amountOut` is already net of the protocol fee.
-      dailyVolume.add(log.tokenIn, log.amountIn);
-      // The fee is taken from the output token, before the remainder is
-      // forwarded to the maker.
-      dailyFees.add(log.tokenOut, log.fee);
-    }
+  for (const log of logs) {
+    if (BigInt(log.orderType) === CANCEL_SENTINEL) continue;
+    // Input leg only. Adding tokenOut as well would double-count the same
+    // trade, and `amountOut` is already net of the protocol fee.
+    dailyVolume.add(log.tokenIn, log.amountIn);
+    // The fee is taken from the output token, before the remainder is
+    // forwarded to the maker.
+    dailyFees.add(log.tokenOut, log.fee, METRIC.PROTOCOL_FEES);
   }
 
   return {
@@ -79,6 +79,10 @@ const fetch: FetchV2 = async ({ getLogs, chain, createBalances }) => {
   };
 };
 
+// Deliberately a separate object from `config`. cli/buildModules.ts deletes
+// every per-chain key that is not in `whitelistedBaseAdapterKeys`, so passing
+// `config` straight through as `adapter` would strip `routers` from the very
+// object `fetch` closes over — no build error, then an undefined at run time.
 const adapters: any = {};
 Object.keys(config).forEach((chain) => {
   adapters[chain] = { fetch, start: config[chain].start };
@@ -86,6 +90,7 @@ Object.keys(config).forEach((chain) => {
 
 const adapter: SimpleAdapter = {
   version: 2,
+  pullHourly: true,
   adapter: adapters,
   methodology: {
     Volume:
@@ -94,6 +99,18 @@ const adapter: SimpleAdapter = {
     Revenue: "All fees. The router has no liquidity providers, so nothing is shared out.",
     ProtocolRevenue: "All fees.",
     SupplySideRevenue: "None. Liquidity is Uniswap's; its pool fees are not counted here.",
+  },
+  breakdownMethodology: {
+    Fees: {
+      [METRIC.PROTOCOL_FEES]:
+        "Protocol fee deducted from the output token of each executed order. The rate is signed by the maker as part of the order payload and capped on-chain at 1%.",
+    },
+    Revenue: {
+      [METRIC.PROTOCOL_FEES]: "All of the fee. The router has no liquidity providers to share it with.",
+    },
+    ProtocolRevenue: {
+      [METRIC.PROTOCOL_FEES]: "All of the fee.",
+    },
   },
 };
 

--- a/dexs/owlorderfi.ts
+++ b/dexs/owlorderfi.ts
@@ -70,34 +70,24 @@ const fetch: FetchV2 = async ({ getLogs, chain, createBalances }) => {
   return {
     dailyVolume,
     dailyFees,
-    // The whole fee accrues to the protocol: the router has no liquidity
-    // providers of its own. Pool fees belong to Uniswap and are not counted
-    // here.
     dailyRevenue: dailyFees,
     dailyProtocolRevenue: dailyFees,
     dailySupplySideRevenue: 0,
   };
 };
 
-// Deliberately a separate object from `config`. cli/buildModules.ts deletes
-// every per-chain key that is not in `whitelistedBaseAdapterKeys`, so passing
-// `config` straight through as `adapter` would strip `routers` from the very
-// object `fetch` closes over — no build error, then an undefined at run time.
-const adapters: any = {};
-Object.keys(config).forEach((chain) => {
-  adapters[chain] = { fetch, start: config[chain].start };
-});
 
 const adapter: SimpleAdapter = {
   version: 2,
   pullHourly: true,
-  adapter: adapters,
+  adapter: config,
+  fetch,
   methodology: {
     Volume:
       "Sum of the input amount of every executed order, taken from the router's OrderExecuted logs. Only the input leg is counted, so a single trade is never counted twice. Cancellations, which the previous router encoded as an OrderExecuted with orderType 255, are excluded.",
     Fees: "Protocol fee deducted from the output token of each executed order. The rate is signed by the maker as part of the order and capped on-chain at 1%.",
-    Revenue: "All fees. The router has no liquidity providers, so nothing is shared out.",
-    ProtocolRevenue: "All fees.",
+    Revenue: "All the protocol fees deducted from the output token of each executed order. The router has no liquidity providers, so nothing is shared out.",
+    ProtocolRevenue: "All the protocol fees deducted from the output token of each executed order. The router has no liquidity providers, so nothing is shared out.",
     SupplySideRevenue: "None. Liquidity is Uniswap's; its pool fees are not counted here.",
   },
   breakdownMethodology: {
@@ -106,12 +96,13 @@ const adapter: SimpleAdapter = {
         "Protocol fee deducted from the output token of each executed order. The rate is signed by the maker as part of the order payload and capped on-chain at 1%.",
     },
     Revenue: {
-      [METRIC.PROTOCOL_FEES]: "All of the fee. The router has no liquidity providers to share it with.",
+      [METRIC.PROTOCOL_FEES]: "All the protocol fees deducted from the output token of each executed order. The router has no liquidity providers, so nothing is shared out.",
     },
     ProtocolRevenue: {
-      [METRIC.PROTOCOL_FEES]: "All of the fee.",
+      [METRIC.PROTOCOL_FEES]: "All the protocol fees deducted from the output token of each executed order. The router has no liquidity providers, so nothing is shared out.",
     },
   },
+  doublecounted: true, // uniswap
 };
 
 export default adapter;

--- a/dexs/owlorderfi.ts
+++ b/dexs/owlorderfi.ts
@@ -1,0 +1,100 @@
+import { SimpleAdapter, FetchV2 } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+
+/**
+ * OwlOrderFi — non-custodial limit / stop / TWAP / DCA order router for
+ * Uniswap V3. Makers sign EIP-712 order intents off-chain; an authorized
+ * keeper executes them on-chain when the conditions are met. The router holds
+ * no user funds between transactions, which is why the protocol is tracked by
+ * volume rather than TVL.
+ *
+ * Two routers per chain: the current deployment and the one it replaced. Both
+ * are indexed so history is continuous across the redeploy.
+ */
+
+const config = {
+  [CHAIN.BASE]: {
+    routers: [
+      "0xC11fC6362d29D6831B7431F3B7d5F9a6128bd5aA", // current, from 2026-07-27
+      "0x30e744fB8120C3f6f8CF958e5110E6349fAaA259", // previous, from 2026-05-31
+    ],
+    start: "2026-05-31", // first Base deployment
+  },
+  [CHAIN.POLYGON]: {
+    routers: [
+      "0x42cB3F5D39d11193cC9436b155F094Aa7cbcf52B", // current, from 2026-07-27
+      "0x30e744fB8120C3f6f8CF958e5110E6349fAaA259", // previous, from 2026-06-01
+    ],
+    start: "2026-06-01", // first Polygon deployment
+  },
+} as { [chain: string]: { routers: string[]; start: string } };
+
+const ORDER_EXECUTED =
+  "event OrderExecuted(bytes32 indexed orderHash, address indexed maker, address indexed keeper, address tokenIn, address tokenOut, uint256 amountIn, uint256 amountOut, uint256 fee, uint8 orderType)";
+
+/**
+ * The previous router signals a cancellation by emitting OrderExecuted with
+ * `orderType = type(uint8).max` and every amount zeroed, which is
+ * indistinguishable from a fill unless the sentinel is filtered. Counting one
+ * would also feed a zero token address into the balance lookup.
+ *
+ * No such log exists in the history so far — every cancellation to date was
+ * recorded off-chain only — but the old router is still live and anyone can
+ * still invalidate their own nonce on it, so the guard is against future logs
+ * rather than a correction of past ones. The current router emits a dedicated
+ * OrderCancelled event, so this only ever applies to the previous address.
+ */
+const CANCEL_SENTINEL = 255n;
+
+const fetch: FetchV2 = async ({ getLogs, chain, createBalances }) => {
+  const dailyVolume = createBalances();
+  const dailyFees = createBalances();
+
+  // One call per router rather than a single `targets` call: the shape of a
+  // multi-target result depends on the `flatten` default, and a wrong guess
+  // there iterates arrays instead of logs. Two calls are unambiguous.
+  for (const router of config[chain].routers) {
+    const logs = await getLogs({ target: router, eventAbi: ORDER_EXECUTED });
+
+    for (const log of logs) {
+      if (BigInt(log.orderType) === CANCEL_SENTINEL) continue;
+      // Input leg only. Adding tokenOut as well would double-count the same
+      // trade, and `amountOut` is already net of the protocol fee.
+      dailyVolume.add(log.tokenIn, log.amountIn);
+      // The fee is taken from the output token, before the remainder is
+      // forwarded to the maker.
+      dailyFees.add(log.tokenOut, log.fee);
+    }
+  }
+
+  return {
+    dailyVolume,
+    dailyFees,
+    // The whole fee accrues to the protocol: the router has no liquidity
+    // providers of its own. Pool fees belong to Uniswap and are not counted
+    // here.
+    dailyRevenue: dailyFees,
+    dailyProtocolRevenue: dailyFees,
+    dailySupplySideRevenue: 0,
+  };
+};
+
+const adapters: any = {};
+Object.keys(config).forEach((chain) => {
+  adapters[chain] = { fetch, start: config[chain].start };
+});
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  adapter: adapters,
+  methodology: {
+    Volume:
+      "Sum of the input amount of every executed order, taken from the router's OrderExecuted logs. Only the input leg is counted, so a single trade is never counted twice. Cancellations, which the previous router encoded as an OrderExecuted with orderType 255, are excluded.",
+    Fees: "Protocol fee deducted from the output token of each executed order. The rate is signed by the maker as part of the order and capped on-chain at 1%.",
+    Revenue: "All fees. The router has no liquidity providers, so nothing is shared out.",
+    ProtocolRevenue: "All fees.",
+    SupplySideRevenue: "None. Liquidity is Uniswap's; its pool fees are not counted here.",
+  },
+};
+
+export default adapter;


### PR DESCRIPTION
Adds a `dexs/` volume + fees adapter for **OwlOrderFi**, a non-custodial limit / stop / TWAP / DCA order router for Uniswap V3.

Makers sign EIP-712 order intents off-chain; an authorized keeper executes them on-chain once the signed conditions are met. The router never holds user funds between transactions, so there is no TVL to track — this is a volume-tracked protocol, in the same shape as the other order-router listings.

### Metadata

| Field | Value |
|---|---|
| Protocol name | OwlOrderFi |
| Category | DEX Aggregator |
| Chains | Base (8453), Polygon (137) |
| Website | https://owlorderfi.com |
| Twitter | https://x.com/owlorderfi |
| GitHub | https://github.com/owlorderfi/protocol |
| Logo | https://owlorderfi.com/icon-512.png |
| Token | None |
| License | BSL 1.1 |

### Contracts read

| Chain | Current router | Previous router |
|---|---|---|
| Base | [`0xC11fC636…d5aA`](https://basescan.org/address/0xC11fC6362d29D6831B7431F3B7d5F9a6128bd5aA) | [`0x30e744fB…A259`](https://basescan.org/address/0x30e744fB8120C3f6f8CF958e5110E6349fAaA259) |
| Polygon | [`0x42cB3F5D…f52B`](https://polygonscan.com/address/0x42cB3F5D39d11193cC9436b155F094Aa7cbcf52B) | [`0x30e744fB…A259`](https://polygonscan.com/address/0x30e744fB8120C3f6f8CF958e5110E6349fAaA259) |

Both current routers are source-verified on their explorers. The previous address is included so history stays continuous across a redeploy on 2026-07-27.

### Methodology

- **Volume** — the input leg of each `OrderExecuted` log. Only one side is counted; adding `tokenOut` would double-count the same trade, and `amountOut` is already net of the protocol fee.
- **Fees** — the protocol fee, deducted from the output token. The rate is signed by the maker as part of the order and capped on-chain at 1%.
- **Revenue** — all of the fees. The router has no liquidity providers of its own, so supply-side revenue is zero. Uniswap's pool fees are not counted here.

One filter worth flagging: the previous router signalled a cancellation by reusing `OrderExecuted` with `orderType = 255` and every amount zeroed. Counting one would register a cancel as a fill and push a zero token address into the balance lookup, so the adapter skips them. The current router emits a dedicated `OrderCancelled` event instead.

### Verification

```
npm test dexs owlorderfi 2026-06-07   ->  polygon  volume 58.00  fees 0.17
npm test dexs owlorderfi 2026-06-03   ->  base     volume 10.00  fees 0.03
```

Both figures were cross-checked against amounts decoded independently from the raw logs; the fee numbers match to the cent.

This is a small, recently launched protocol — lifetime volume is roughly $73 across seven executed orders. Flagging that up front so the scale is not a surprise.