### PR TITLE
Strike Finance: per-day V2 volume + OI methodology (RWA perps)

### DIFF
--- a/dexs/strike-finance/index.ts
+++ b/dexs/strike-finance/index.ts
@@ -2,20 +2,48 @@ import { CHAIN } from "../../helpers/chains";
 import { FetchOptions, SimpleAdapter } from "../../adapters/types";
 import fetchURL from "../../utils/fetchURL";
 
+// Docs: https://docs.strikefinance.org/api
+const DAILY_VOLUMES_ENDPOINT =
+  "https://api.strikefinance.org/stat/v1/dashboard/volumes";
+
+// [timestampMs, symbol, usdVolume] — one bucket per UTC day per market,
+// single-sided USD notional.
+type DailyVolumePoint = [number, string, number | string];
+
 export async function fetch(options: FetchOptions) {
-  const dailyVolume = options.createBalances();
-  const url = `https://app.strikefinance.org/api/analytics/volume?from=${options.startTimestamp}&to=${options.endTimestamp}`;
-  const { totalVolume } = await fetchURL(url);
-  dailyVolume.addCGToken("cardano", Number(totalVolume));
+  const { total_volume_daily }: { total_volume_daily: DailyVolumePoint[] } =
+    await fetchURL(DAILY_VOLUMES_ENDPOINT);
+
+  const dayStart = options.startOfDay * 1000;
+  const dayRows = total_volume_daily.filter(
+    ([timestamp]) => Number(timestamp) === dayStart,
+  );
+  if (!dayRows.length)
+    throw new Error(
+      `No Strike Finance volume data found for ${options.dateString}`,
+    );
+
+  const dailyVolume = dayRows.reduce(
+    (sum, [, , volume]) => sum + Number(volume),
+    0,
+  );
 
   return { dailyVolume };
 }
 
+const methodology = {
+  Volume:
+    "Single-sided USD notional of fills across all Strike Finance V2 perpetual markets, bucketed by UTC day.",
+};
+
 const adapter: SimpleAdapter = {
-  version: 2,
+  version: 1,
   fetch,
   chains: [CHAIN.CARDANO],
-  start: "2025-05-16",
+  // V2 stats history begins 2026-03-20; earlier volume (from 2025-05-16) was
+  // recorded by the previous adapter version against the V1 analytics API.
+  start: "2026-03-20",
+  methodology,
 };
 
 export default adapter;

--- a/open-interest/strike-finance-oi.ts
+++ b/open-interest/strike-finance-oi.ts
@@ -22,11 +22,17 @@ const fetch = async (options: FetchOptions) => {
   return { openInterestAtEnd };
 };
 
+const methodology = {
+  OpenInterest:
+    "Single-sided USD notional of open positions across all Strike Finance V2 perpetual markets, from the latest daily snapshot in the requested window.",
+};
+
 const adapter: SimpleAdapter = {
   version: 1,
   fetch,
   chains: [CHAIN.CARDANO],
   start: "2026-03-19",
+  methodology,
 };
 
 export default adapter;


### PR DESCRIPTION
## Summary

- switch Strike Finance perp volume to the V2 mainnet stats API (`/stat/v1/dashboard/volumes`), summing single-sided USD notional per UTC day — historical, backfillable across the full V2 stats history (from 2026-03-20), no `runAtCurrTime`
- keep open interest on the historical daily-snapshot endpoint (`/stat/v1/dashboard/open-interest`) and add explicit methodology to both adapters
- drop the `app.strikefinance.org` frontend proxy dependency; both adapters now read the canonical `api.strikefinance.org` backend directly

This updates the existing Strike Finance adapters to the public V2 market-data API and documents the per-market endpoints DefiLlama needs to ingest Strike as an RWA perps venue:

- `GET /price/v2/marketStats` — per-market 24h volume, USD + base open interest, funding rate, mark/index/last price, category (`TradFi`/`Crypto`) and sub-category (`Equity`/`Index`/`Commodity`/`FX`)
- `GET /price/v2/ticker/24hr`, `GET /price/v2/openInterest`, `GET /price/v2/markPrice` — Binance-style per-market snapshots
- `GET /v2/markets` — contract metadata (margin tiers / max leverage, tick sizes, funding interval)

## Project links

- Website: https://www.strikefinance.org/
- Twitter: https://x.com/strikecardano
- Ticker docs: https://docs.strikefinance.org/api/market/rest-api/ticker
- Open-interest docs: https://docs.strikefinance.org/api/market/rest-api/open-interest
- Mark-price docs: https://docs.strikefinance.org/api/market/rest-api/prices

## Mainnet verification

Verified on 2026-08-06 against `api.strikefinance.org`:

```bash
curl -sS https://api.strikefinance.org/stat/v1/dashboard/volumes
curl -sS https://api.strikefinance.org/stat/v1/dashboard/open-interest
curl -sS https://api.strikefinance.org/price/v2/marketStats
```

Snapshot (UTC day 2026-08-05):

- 20 total perpetual markets
- 11 RWA markets: CXMT, MU, NAS100, NVDA, SKHYNIX, SNDK, SPCX, TSLA, WTI, XAG, XAU
- $4,244,729 daily volume total, of which $3,382,086 RWA
- $789,260 open interest total, of which $284,534 RWA
- cross-checked against live `/price/v2/openInterest` × `/price/v2/markPrice` ($776,531 intraday) — consistent

## Notes on `start`

The V2 stats history begins 2026-03-20 (Strike's V1 -> V2 migration); `start` is set to match so backfills never request days the API cannot serve. Volume from 2025-05-16 to 2026-03-19 was already recorded live by the previous adapter version against the V1 analytics API and remains stored on DefiLlama's side.

## Checks

- `npm test dexs strike-finance` — $4.24M daily volume (UTC day 2026-08-05), matches a direct sum of the endpoint's buckets to the cent
- `npm test dexs strike-finance 2026-06-15` — $1.22M for UTC day 2026-06-14 (bucket sum 1,223,420.80 — exact)
- `npm test dexs strike-finance 2026-03-21` — $25.27k for the first available day (first bucket 25,274.51 — exact)
- `npm test dexs strike-finance 2026-03-20` — cleanly skipped (before `start`), no error, no zero reported
- days with no bucket inside history throw instead of reporting 0 (per no-incorrect-data guideline); the series currently has zero gap days
- `npm test open-interest strike-finance-oi.ts` — $789.26k, matches the 2026-08-05 daily snapshot sum; cross-checked against live `/price/v2/openInterest` x `/price/v2/markPrice` ($776.5k intraday)
- `npx tsc --noEmit` on both files — clean
- `git diff --check` — clean

#### Allow edits by maintainers

Enabled.
