### PR TITLE
lifi/jumper: fix fees adapter after fee-router migration, throttle analytics API, jumper parity

### DIFF
--- a/aggregators/jumper-exchange/index.ts
+++ b/aggregators/jumper-exchange/index.ts
@@ -1,7 +1,7 @@
 import { FetchOptions, FetchResultVolume, SimpleAdapter } from "../../adapters/types";
 import { LifiDiamonds, LIFI_API_CHAINS, fetchVolumeFromLIFIAPI } from "../../helpers/aggregators/lifi";
 import { CHAIN } from "../../helpers/chains";
-import { getDefaultDexTokensBlacklisted } from "../../helpers/lists";
+import { getDefaultDexTokensBlacklisted, getDefaultDexTokensWhitelisted } from "../../helpers/lists";
 import { formatAddress } from "../../utils/utils";
 
 const LifiSwapEvent = "event LiFiGenericSwapCompleted(bytes32 indexed transactionId, string integrator, string referrer, address receiver, address fromAssetId, address toAssetId, uint256 fromAmount, uint256 toAmount)"
@@ -21,8 +21,15 @@ const fetch: any = async (options: FetchOptions): Promise<FetchResultVolume> => 
     maxBlockRange: 10000, // chunk the RPC-fallback range so chains not on the indexer (e.g. cronos) don't blow the eth_getLogs limit over a full day
   });
 
+  // count volume only from whitelisted tokens (same filter as the LI.FI dex adapter)
   const blacklistedTokens = getDefaultDexTokensBlacklisted(options.chain)
-  if (blacklistedTokens.length > 0) {
+  const whitelistedTokens = await getDefaultDexTokensWhitelisted({ chain: options.chain })
+  if (whitelistedTokens.length > 0) {
+    logs = logs.filter(log => (whitelistedTokens.includes(formatAddress(log.fromAssetId)) || whitelistedTokens.includes(formatAddress(log.toAssetId)))
+      && !blacklistedTokens.includes(formatAddress(log.fromAssetId))
+      && !blacklistedTokens.includes(formatAddress(log.toAssetId))
+    )
+  } else if (blacklistedTokens.length > 0) {
     logs = logs.filter(log => !blacklistedTokens.includes(formatAddress(log.fromAssetId)) && !blacklistedTokens.includes(formatAddress(log.toAssetId)))
   }
 

--- a/fees/jumper-exchange/index.ts
+++ b/fees/jumper-exchange/index.ts
@@ -1,68 +1,23 @@
-import { Chain } from "../../adapters/types";
 import { FetchOptions, SimpleAdapter } from "../../adapters/types";
-import { CHAIN } from "../../helpers/chains";
+import { LifiFeeCollectors } from "../../helpers/aggregators/lifi";
 import { addTokensReceived } from "../../helpers/token";
 
-type IContract = {
-  [c: string | Chain]: string;
-};
-
-const collector: IContract = {
-  [CHAIN.AURORA]: "0xB0210dE78E28e2633Ca200609D9f528c13c26cD9",
-  [CHAIN.ARBITRUM]: "0xB0210dE78E28e2633Ca200609D9f528c13c26cD9",
-  [CHAIN.OPTIMISM]: "0xbD6C7B0d2f68c2b7805d88388319cfB6EcB50eA9",
-  [CHAIN.BASE]: "0x0A6d96E7f4D7b96CFE42185DF61E64d255c12DFf",
-  [CHAIN.ETHEREUM]: "0xbD6C7B0d2f68c2b7805d88388319cfB6EcB50eA9",
-  [CHAIN.AVAX]: "0xB0210dE78E28e2633Ca200609D9f528c13c26cD9",
-  [CHAIN.BSC]: "0xbD6C7B0d2f68c2b7805d88388319cfB6EcB50eA9",
-  [CHAIN.LINEA]: "0xA4A24BdD4608D7dFC496950850f9763B674F0DB2",
-  [CHAIN.MANTLE]: "0xF048e5816B0C7951AC179f656C5B86e5a79Bd7b5",
-  [CHAIN.POLYGON]: "0xbD6C7B0d2f68c2b7805d88388319cfB6EcB50eA9",
-  [CHAIN.POLYGON_ZKEVM]: "0xB49EaD76FE09967D7CA0dbCeF3C3A06eb3Aa0cB4",
-  [CHAIN.FANTOM]: "0xB0210dE78E28e2633Ca200609D9f528c13c26cD9",
-  [CHAIN.MODE]: "0xF048e5816B0C7951AC179f656C5B86e5a79Bd7b5",
-  [CHAIN.SCROLL]: "0xF048e5816B0C7951AC179f656C5B86e5a79Bd7b5",
-  [CHAIN.ERA]: "0x8dBf6f59187b2EB36B980F3D8F4cFC6DC4E4642e",
-  [CHAIN.METIS]: "0x27f0e36dE6B1BA8232f6c2e87E00A50731048C6B",
-  [CHAIN.XDAI]: "0xbD6C7B0d2f68c2b7805d88388319cfB6EcB50eA9",
-  [CHAIN.TAIKO]: "0xDd8A081efC90DFFD79940948a1528C51793C4B03",
-  [CHAIN.BLAST]: "0xF048e5816B0C7951AC179f656C5B86e5a79Bd7b5",
-  [CHAIN.BOBA]: "0xB0210dE78E28e2633Ca200609D9f528c13c26cD9",
-  [CHAIN.FUSE]: "0xB0210dE78E28e2633Ca200609D9f528c13c26cD9",
-  [CHAIN.CRONOS]: "0x11d40Dc8Ff0CE92F54A315aD8e674a55a866cBEe",
-  [CHAIN.GRAVITY]: "0x79540403cdE176Ca5f1fb95bE84A7ec91fFDEF76",
-  // [CHAIN.SEI]: '0x7956280Ec4B4d651C4083Ca737a1fa808b5319D8',
-  // [CHAIN.ROOTSTOCK]: '0xF048e5816B0C7951AC179f656C5B86e5a79Bd7b5',
-  [CHAIN.CELO]: "0xF048e5816B0C7951AC179f656C5B86e5a79Bd7b5",
-  [CHAIN.EVMOS]: "0xB49EaD76FE09967D7CA0dbCeF3C3A06eb3Aa0cB4",
-  [CHAIN.FRAXTAL]: "0x7956280Ec4B4d651C4083Ca737a1fa808b5319D8",
-  //   [CHAIN.HARMONY]: "0xB0210dE78E28e2633Ca200609D9f528c13c26cD9",
-  //   [CHAIN.IMMUTABLEX]: "0x1a4E99aB56BBac95810C0A957F173054f6FA8fDc",
-  [CHAIN.LISK]: "0x50D5a8aCFAe13Dceb217E9a071F6c6Bd5bDB4155",
-  [CHAIN.MOONBEAM]: "0xB0210dE78E28e2633Ca200609D9f528c13c26cD9",
-  //   [CHAIN.MOONRIVER]: "0xB0210dE78E28e2633Ca200609D9f528c13c26cD9",
-  [CHAIN.ARBITRUM_NOVA]: "0xB0210dE78E28e2633Ca200609D9f528c13c26cD9",
-  //   [CHAIN.OKEXCHAIN]: "0xB0210dE78E28e2633Ca200609D9f528c13c26cD9",
-  [CHAIN.OP_BNB]: "0x6A2420650139854F17964b8C3Bb60248470aB57E",
-  [CHAIN.SONIC]: "0xaFb8cC8fCd71cd768Ce117C11eB723119FCDb1f8",
-  // [CHAIN.VELAS]: "0xB0210dE78E28e2633Ca200609D9f528c13c26cD9",
-  // [CHAIN.XLAYER]: "0xC69994fd72824ca98F8a0B1E2ABc954E65a91cf4",
-};
-
+// Jumper is LI.FI powered, so it shares LI.FI's fee collectors; derive the chain list from
+// LifiFeeCollectors instead of a hand-maintained copy that drifts out of date.
 const adapter: SimpleAdapter = {
   version: 2,
   pullHourly: true,
-  adapter: Object.keys(collector).reduce((acc, chain) => {
+  adapter: Object.keys(LifiFeeCollectors).reduce((acc, chain) => {
     return {
       ...acc,
       [chain]: {
         fetch: async (options: FetchOptions) => ({
           dailyFees: await addTokensReceived({
             options,
-            target: collector[options.chain],
+            target: LifiFeeCollectors[options.chain].id,
           }),
         }),
-        start: "2023-08-10",
+        start: LifiFeeCollectors[chain].startTime,
       },
     };
   }, {}),

--- a/fees/lifi/index.ts
+++ b/fees/lifi/index.ts
@@ -1,8 +1,22 @@
 import { FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { LifiFeeCollectors } from "../../helpers/aggregators/lifi";
+import { CHAIN } from "../../helpers/chains";
 import { DefaultDexTokensBlacklisted } from "../../helpers/lists"
 
 const FeeCollectedEvent = "event FeesCollected(address indexed _token, address indexed _integrator, uint256 _integratorFee, uint256 _lifiFee)"
+const FeesForwardedEvent = "event FeesForwarded(address indexed token, (address recipient, uint256 amount)[] fees)"
+
+// Around 2026-04-10 LI.FI retired the per-chain FeeCollector contracts (FeesCollected) in favour of
+// a fee router that emits FeesForwarded with the full recipient split. Both are read so refills stay
+// correct across the migration: the old event stops emitting after it, the new one before it.
+const FeeRouters: Record<string, string> = {
+    [CHAIN.ETHEREUM]: '0x685527c551cc40ce1f1c9818cd8683307076e4ed',
+}
+const DefaultFeeRouter = '0xc18d9e84b8687a2645447a61e52c455dac1675e1'
+
+// LI.FI's own share of a FeesForwarded payout; every other recipient is an integrator. Verified as
+// the one recipient present on all 21 chains that had payouts on 2026-07-23.
+const LifiRecipient = '0xc06ebbefd94032b85424d51906e2a335efae264b'
 
 const IntegratorFee = 'Integration & Partnership Fees'
 const LifiProtocolFee = 'LiFi Fees'
@@ -12,25 +26,34 @@ const fetch = async (options: FetchOptions) => {
     const dailyRevenue = options.createBalances();
     const dailySupplySideRevenue = options.createBalances();
 
-    try {
-        const data: any[] = await options.getLogs({
-            target: LifiFeeCollectors[options.chain].id,
-            topic: '0x28a87b6059180e46de5fb9ab35eb043e8fe00ab45afcc7789e3934ecbbcde3ea',
-            eventAbi: FeeCollectedEvent,
-        });
-        // 0x0000000000000000000000000000000000000000 is the gas token for all chains, we already handle it in the Balances
-        const blacklistForChain = new Set(DefaultDexTokensBlacklisted[options.chain]);
-        data.forEach((log: any) => {
-            if (blacklistForChain.has((log._token).toLowerCase())) return;
-            dailyFees.add(log._token, log._integratorFee, IntegratorFee);
-            dailyFees.add(log._token, log._lifiFee, LifiProtocolFee);
+    // 0x0000000000000000000000000000000000000000 is the gas token for all chains, we already handle it in the Balances
+    const blacklistForChain = new Set(DefaultDexTokensBlacklisted[options.chain]);
 
-            dailyRevenue.add(log._token, log._lifiFee, LifiProtocolFee);
-            dailySupplySideRevenue.add(log._token, log._integratorFee, IntegratorFee);
+    const addFee = (token: string, amount: any, isLifi: boolean) => {
+        if (blacklistForChain.has(token.toLowerCase())) return;
+        const label = isLifi ? LifiProtocolFee : IntegratorFee;
+        dailyFees.add(token, amount, label);
+        (isLifi ? dailyRevenue : dailySupplySideRevenue).add(token, amount, label);
+    };
+
+    const legacy: any[] = await options.getLogs({
+        target: LifiFeeCollectors[options.chain].id,
+        eventAbi: FeeCollectedEvent,
+    });
+    legacy.forEach((log: any) => {
+        addFee(log._token, log._integratorFee, false);
+        addFee(log._token, log._lifiFee, true);
+    });
+
+    const forwarded: any[] = await options.getLogs({
+        target: FeeRouters[options.chain] ?? DefaultFeeRouter,
+        eventAbi: FeesForwardedEvent,
+    });
+    forwarded.forEach((log: any) => {
+        log.fees.forEach((fee: any) => {
+            addFee(log.token, fee.amount, String(fee.recipient).toLowerCase() === LifiRecipient);
         });
-    } catch (e) {
-        //lifi has so many chains and some of them fail periodically due to rpc issues, a single chain failure should not break the whole adapter
-    }
+    });
 
     return {
         dailyFees,

--- a/helpers/aggregators/lifi.ts
+++ b/helpers/aggregators/lifi.ts
@@ -1,6 +1,7 @@
 import { CHAIN } from "../../helpers/chains";
 import { Chain } from "../../adapters/types";
 import { fetchURLAutoHandleRateLimit } from "../../utils/fetchURL";
+import { sleep } from "../../utils/utils";
 
 type IContract = {
   [c: string | Chain]: {
@@ -346,6 +347,13 @@ export const LIFI_API_CHAINS = [
   CHAIN.MOONBEAM, CHAIN.FRAXTAL, CHAIN.CELO, CHAIN.LISK, CHAIN.APECHAIN, CHAIN.INK, CHAIN.MANTLE, CHAIN.METIS, CHAIN.BOBA, CHAIN.FUSE, CHAIN.CRONOS, CHAIN.GRAVITY, CHAIN.KLAYTN, CHAIN.PLUME, CHAIN.IMX, CHAIN.WC, CHAIN.SWELLCHAIN, CHAIN.ETHERLINK, CHAIN.SUPERPOSITION, CHAIN.LENS, CHAIN.BOB, CHAIN.RONIN, CHAIN.VANA, CHAIN.SOPHON, CHAIN.PLASMA, CHAIN.FLOW, CHAIN.HEMI, CHAIN.STABLE,
 ]
 
+// LI.FI dropped support for these chains: they are absent from li.quest/v1/chains and the analytics
+// API answers 400, which burned 3 retries per chain on every run. They stay in LifiDiamonds and
+// LIFI_API_CHAINS so their history is preserved and getLogs (unreliable on all four) is not used.
+const LIFI_UNSUPPORTED_CHAINS: string[] = [
+  CHAIN.TAIKO, CHAIN.SWELLCHAIN, CHAIN.SUPERPOSITION, CHAIN.SOPHON,
+]
+
 export const LifiFeeCollectors: IContract = {
   [CHAIN.ABSTRACT]: {
     id: '0xde6A2171959d7b82aAD8e8B14cc84684C3a186AC',
@@ -552,7 +560,22 @@ export const LifiFeeCollectors: IContract = {
 // ponytail: blunt magnitude cap, catches the egregious 10^8-off errors, not subtle mispricing.
 const MAX_TRANSFER_USD = 50_000_000;
 
+// li.quest 429s when every API-routed chain paginates at once, so all analytics requests from this
+// process go through a single queue with a gap between them. Retrying alone does not help: the
+// retries just rejoin the same stampede.
+// ponytail: one global lock, serial by design. Move to a small concurrency pool if runs get too slow.
+const REQUEST_GAP_MS = 300;
+let requestQueue: Promise<any> = Promise.resolve();
+
+const queuedFetch = (url: string): Promise<any> => {
+  const result = requestQueue.then(() => fetchURLAutoHandleRateLimit(url));
+  requestQueue = result.catch(() => undefined).then(() => sleep(REQUEST_GAP_MS));
+  return result;
+};
+
 export const fetchVolumeFromLIFIAPI = async (chain: Chain, startTime: number, endTime: number, integrators?: string[], exclude_integrators?: string[], swapType?: 'cross-chain' | 'same-chain'): Promise<number> => {
+  if (LIFI_UNSUPPORTED_CHAINS.includes(chain)) return 0;
+
   let hasMore = true;
   let totalValue = 0;
   let nextCursor: string | undefined;
@@ -574,8 +597,7 @@ export const fetchVolumeFromLIFIAPI = async (chain: Chain, startTime: number, en
     }
 
     const url = `https://li.quest/v2/analytics/transfers?${params}`;
-    // paginating a busy chain can 429 the analytics API; back off + retry instead of failing
-    const response = await fetchURLAutoHandleRateLimit(url) as LifiResponse;
+    const response = await queuedFetch(url) as LifiResponse;
 
     if (!response?.data || !Array.isArray(response.data)) {
       break;


### PR DESCRIPTION
### fees/lifi was reporting $0 since 2026-05

Around 2026-04-10 LI.FI retired the per-chain `FeeCollector` contracts and moved to a fee router emitting `FeesForwarded(address indexed token, (address recipient, uint256 amount)[] fees)`. The adapter still read the old `FeesCollected` event. Log counts on the old collectors:

| date | ethereum | arbitrum | base |
|---|---|---|---|
| 2025-08-01 | 4054 | 1537 | 21839 |
| 2026-04-09 | 0 | 424 | 1318 |
| 2026-04-11 | 0 | 1 | 0 |
| 2026-07-24 | 0 | 0 | 0 |

Matches the API: $543k in March, $104k in April, $0 from May on.

Both events are now read and summed so refills stay correct across the boundary. Routers are `0x685527c5` on ethereum and `0xc18d9e84` elsewhere. `0xc06ebbef` is LI.FI's share of each payout and every other recipient is an integrator, preserving the revenue / supply-side split. Verified on ethereum, base, arbitrum, polygon, bsc, optimism, avax: $13.8k on 2026-03-01 from the old event, $44.2k on 2026-04-15 from the new one, LI.FI's share steady at 13-22% against the 14% reported historically.

The catch-all around `getLogs` is removed. It turned this migration into a silent $0 for three and a half months.

### 429 and 400 on the analytics API

Requests now go through one queue with a gap between them, instead of every API-routed chain paginating concurrently. Taiko, Swellchain, Superposition and Sophon are skipped: LI.FI delisted them (absent from `li.quest/v1/chains`), the API answers 400, and each burned three retries per run. All four volume adapters now complete without errors.

### jumper parity

`aggregators/jumper-exchange` had a blacklist-only token filter while `aggregators/lifi` filters to whitelisted tokens, so junk-token swaps inflated Jumper volume on spike days. Checked on eth/arb/base/bsc for 2026-07-23: 5.31M to 5.25M.

`fees/jumper-exchange` kept a hand-copied collector map 14 chains behind `LifiFeeCollectors` with one wrong start date for every chain. It now reads the shared map with per-chain start times.
