### PR TITLE
normalized-volume: read from the markets API instead of elastic

### DIFF
--- a/factory/normalizedVolume.ts
+++ b/factory/normalizedVolume.ts
@@ -1,318 +1,116 @@
 import { FetchOptions, SimpleAdapter } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
 import { createFactoryExports } from "./registry";
-import { elastic } from "@defillama/sdk";
+import { getEnv } from "../helpers/env";
+import { httpGet } from "../utils/fetchURL";
 
-const HOURLY_VOLUME_INDEX = 'perp-metrics';
+const PERP_SEGMENTS = ['linear_perp', 'inverse_perp'];
+const LIVE_RUN_LAG = 12 * 60 * 60;
+const MAX_SNAPSHOT_AGE = 24 * 60 * 60;
 
-interface NormalizedVolumeConfig {
-  protocolName: string;
-  chains: string[];
-  start?: number | string;
-  version?: 1 | 2;
-  minContracts?: number;
-}
+const asDate = (timestamp?: number) => timestamp ? new Date(timestamp * 1000).toISOString().slice(0, 10) : 'n/a';
 
-interface HourlyVolumeRecord {
-  dayTimestamp: number;
-  timestamp: number;
-  updated_at: number;
-  exchange: string;
-  normalized_volume: number;
-  reported_volume: number;
-  contracts: number;
-  active_liquidity?: number;
-}
-
-
-function fetchV1({ protocolName, minContracts }: { protocolName: string, minContracts?: number }){
-  return async (options: FetchOptions) => {
-
-    const response = await elastic.search({
-      index: HOURLY_VOLUME_INDEX,
-      body: {
-        query: {
-          bool: {
-            must: [
-              {
-                term: {
-                  dayTimestamp: options.startOfDay * 1000
-                }
-              },
-              { term: { 'exchange.keyword': protocolName } }
-            ]
-          }
-        },
-        size: 100
-      }
-    });
-
-    const records = (response.hits?.hits || []).map((hit: any) => hit._source as HourlyVolumeRecord);
-    // console.log(records);
-    // Verify data accuracy with min_contracts (5% miss rate threshold)
-    let completeRecords = records;
-    let accuracyRate = 100;
-    
-    if (minContracts !== undefined) {
-      const expectedMinContracts = minContracts * 0.95; // 5% miss rate tolerance per record
-      completeRecords = records.filter(record => (record.contracts || 0) >= expectedMinContracts);
-      accuracyRate = records.length > 0 ? (completeRecords.length / records.length) * 100 : 0;
-      
-      if (completeRecords.length < 24) {
-        throw new Error(
-          `Incomplete orderbook data for ${protocolName}: ${completeRecords.length}/24 complete records (accuracy rate: ${accuracyRate.toFixed(2)}%). ` +
-          `Expected at least ${expectedMinContracts.toFixed(0)} contracts per record.`
-        );
-      }
-    } else if (records.length < 24) {
-      throw new Error(`Incomplete orderbook data for ${protocolName}: ${records.length}/24 records`);
-    }
-    
-    const dailyNormalizedVolume = completeRecords.reduce((sum, record) => {
-      return sum + (record.normalized_volume || 0);
-    }, 0);
-    
-    // Calculate average active_liquidity where >0 and not undefined
-    const validActiveLiquidity = completeRecords
-      .map(record => record.active_liquidity)
-      .filter(val => val !== undefined && val > 0) as number[];
-    
-    const dailyActiveLiquidity = validActiveLiquidity.length > 0
-      ? validActiveLiquidity.reduce((sum, val) => sum + val, 0) / validActiveLiquidity.length
-      : 0;
-    
-    // const dailyVolume = completeRecords.reduce((sum, record) => {
-    //   return sum + (record.reported_volume || 0);
-    // }, 0);
-
-    return {
-      dailyNormalizedVolume: dailyNormalizedVolume.toString(),
-      dailyActiveLiquidity: dailyActiveLiquidity.toString(),
-      // dailyVolume: dailyVolume.toString()
-    };
-  }
-}
-
-function fetchV2({ protocolName, minContracts }: { protocolName: string, minContracts?: number }){
-  return async (options: FetchOptions) => {
-    const { startTimestamp, endTimestamp } = options;
-    
-    const response = await elastic.search({
-      index: HOURLY_VOLUME_INDEX,
-      body: {
-        query: {
-          bool: {
-            must: [
-              { 
-                range: { 
-                  timestamp: {
-                    gte: (startTimestamp + 1) * 1000,
-                    lt: endTimestamp * 1000
-                  }
-                }
-              },
-              { term: { 'exchange.keyword': protocolName } }
-            ]
-          }
-        },
-        size: 100
-      }
-    });
-
-    const records = (response.hits?.hits || []).map((hit: any) => hit._source as HourlyVolumeRecord);
-    // console.log(records);
-
-    // Verify data accuracy with min_contracts (5% miss rate threshold)
-    let completeRecords = records;
-    let accuracyRate = 100;
-    
-    if (minContracts !== undefined) {
-      const expectedMinContracts = minContracts * 0.95; // 5% miss rate tolerance per record
-      completeRecords = records.filter(record => (record.contracts || 0) >= expectedMinContracts);
-      accuracyRate = records.length > 0 ? (completeRecords.length / records.length) * 100 : 0;
-      
-      if (completeRecords.length < 24) {
-        throw new Error(
-          `Incomplete orderbook data for ${protocolName}: ${completeRecords.length}/24 complete records (accuracy rate: ${accuracyRate.toFixed(2)}%). ` +
-          `Expected at least ${expectedMinContracts.toFixed(0)} contracts per record.`
-        );
-      }
-    } else if (records.length < 24) {
-      throw new Error(`Incomplete orderbook data for ${protocolName}: ${records.length}/24 records`);
-    }
-
-    const dailyNormalizedVolume = completeRecords.reduce((sum, record) => {
-      return sum + (record.normalized_volume || 0);
-    }, 0);
-    
-    // Calculate average active_liquidity where >0 and not undefined
-    const validActiveLiquidity = completeRecords
-      .map(record => record.active_liquidity)
-      .filter(val => val !== undefined && val > 0) as number[];
-    
-    const dailyActiveLiquidity = validActiveLiquidity.length > 0
-      ? validActiveLiquidity.reduce((sum, val) => sum + val, 0) / validActiveLiquidity.length
-      : 0;
-    
-    // const dailyVolume = completeRecords.reduce((sum, record) => {
-    //   return sum + (record.reported_volume || 0);
-    // }, 0);
-
-    return {
-      dailyNormalizedVolume: dailyNormalizedVolume.toString(),
-      dailyActiveLiquidity: dailyActiveLiquidity.toString(),
-      // dailyVolume: dailyVolume.toString()
-    };
-  }
-}
-
-function dailyNormalizedVolumeAdapter(config: NormalizedVolumeConfig): SimpleAdapter {
-  const { protocolName, chains, start, version = 1, minContracts } = config;
-
-  const adapter: any = {};
-  const fetchFn = version === 2 ? fetchV2({ protocolName, minContracts }) : fetchV1({ protocolName, minContracts });
-
-  chains.forEach(chain => {
-    adapter[chain] = {
-      fetch: fetchFn,
-      start
-    };
+async function get(slug: string, file: string, { allow404 = false } = {}) {
+  const apiKey = getEnv('INTERNAL_API_KEY');
+  const base = getEnv('MARKETS_API');
+  if (!apiKey || !base) throw new Error('INTERNAL_API_KEY and MARKETS_API must be set');
+  return httpGet(`${base.replace('{key}', apiKey)}/${slug}/${file}`).catch((e: any) => {
+    const message = String(e?.message ?? 'request failed').split(apiKey).join('<key>');
+    if (allow404 && (e?.axiosError === 'Not found' || message.includes('404'))) return null;
+    throw new Error(`${slug}: ${file} - ${message}`);
   });
+}
 
+async function fromHistory(slug: string, startOfDay: number) {
+  const data = await get(slug, 'series/all.json', { allow404: true });
+  if (!data) return { day: null, coverage: 'no history file' };
+
+  const { first_day, last_day, stale } = data.freshness ?? {};
+  const coverage = `history covers ${asDate(first_day)}..${asDate(last_day)}${stale ? ' (stale)' : ''}`;
+
+  const dayIndex = (data.days ?? []).indexOf(startOfDay);
+  if (dayIndex === -1) return { day: null, coverage };
+
+  const sumSegments = (metric: string) => {
+    let total: number | null = null;
+    for (const segment of PERP_SEGMENTS) {
+      const value = data.series[data.key.indexOf(`${segment}_${metric}`)]?.[dayIndex];
+      if (typeof value === 'number') total = (total ?? 0) + value;
+    }
+    return total;
+  };
+
+  const dailyNormalizedVolume = sumSegments('normalized_volume');
+  if (dailyNormalizedVolume === null) return { day: null, coverage };
+  return {
+    day: { dailyNormalizedVolume, dailyActiveLiquidity: sumSegments('active_liquidity') ?? 0 },
+    coverage,
+  };
+}
+
+async function fromSnapshot(slug: string) {
+  const data = await get(slug, 'index.json');
+
+  const now = Math.trunc(Date.now() / 1000);
+  for (const metric of ['volume', 'depth']) {
+    const observedAt = data?.freshness?.[metric];
+    const age = now - new Date(observedAt).getTime() / 1000;
+    if (!Number.isFinite(age) || age > MAX_SNAPSHOT_AGE)
+      throw new Error(`${slug}: stale snapshot, ${metric} last observed ${observedAt}`);
+  }
+
+  const pairs = PERP_SEGMENTS.flatMap((segment) => data?.segments?.[segment]?.pairs ?? []);
+  if (!pairs.length) throw new Error(`${slug}: no perp markets in snapshot`);
+
+  let dailyNormalizedVolume = 0;
+  let dailyActiveLiquidity = 0;
+  for (const { nvol } of pairs) {
+    dailyNormalizedVolume += nvol?.normalized ?? 0;
+    dailyActiveLiquidity += nvol?.active_liquidity ?? 0;
+  }
+  return { dailyNormalizedVolume, dailyActiveLiquidity };
+}
+
+function fetchNormalizedVolume(slug: string, version: 1 | 2) {
+  return async ({ startOfDay, endTimestamp, dateString }: FetchOptions) => {
+    const { day, coverage } = await fromHistory(slug, startOfDay);
+    if (day) return day;
+
+    const isLiveRun = Math.trunc(Date.now() / 1000) - endTimestamp < LIVE_RUN_LAG;
+    if (version !== 2 || !isLiveRun)
+      throw new Error(`${slug}: no settled history for ${dateString}, ${coverage}`);
+
+    return fromSnapshot(slug);
+  };
+}
+
+function normalizedVolumeAdapter(slug: string, chain: string, start: string, version: 1 | 2 = 1): SimpleAdapter {
   return {
     version,
-    adapter
+    adapter: { [chain]: { fetch: fetchNormalizedVolume(slug, version), start } },
   };
 }
 
 const protocols = {
-  'hyperliquid': dailyNormalizedVolumeAdapter({
-    protocolName: 'hyperliquid',
-    chains: [CHAIN.HYPERLIQUID],
-    start: '2026-01-20',
-    minContracts: 250
-  }),
-  'edgex': dailyNormalizedVolumeAdapter({
-    protocolName: 'edgex',
-    chains: [CHAIN.EDGEX],
-    start: '2026-01-20',
-    minContracts: 40
-  }),
-  'lighter': dailyNormalizedVolumeAdapter({
-    protocolName: 'lighter',
-    chains: [CHAIN.ZK_LIGHTER],
-    start: '2026-01-20',
-    minContracts: 100
-  }),
-  'aster': dailyNormalizedVolumeAdapter({
-    protocolName: 'aster',
-    chains: [CHAIN.OFF_CHAIN],
-    start: '2026-01-20',
-    minContracts: 150
-  }),
-  'paradex': dailyNormalizedVolumeAdapter({
-    protocolName: 'paradex',
-    chains: [CHAIN.PARADEX],
-    start: '2026-01-20',
-    version: 2,
-    minContracts: 10
-  }),
-  'sunx': dailyNormalizedVolumeAdapter({
-    protocolName: 'sunx',
-    chains: [CHAIN.TRON],
-    start: '2026-01-20',
-    minContracts: 100
-  }),
-  'apex-omni': dailyNormalizedVolumeAdapter({
-    protocolName: 'apex-omni',
-    chains: [CHAIN.ETHEREUM],
-    start: '2026-01-20',
-    minContracts: 90
-  }),
-  'grvt': dailyNormalizedVolumeAdapter({
-    protocolName: 'grvt',
-    chains: [CHAIN.GRVT],
-    start: '2026-01-20',
-    version: 1,
-    minContracts: 80
-  }),
-  'pacifica': dailyNormalizedVolumeAdapter({
-    protocolName: 'pacifica',
-    chains: [CHAIN.SOLANA],
-    start: '2026-01-20',
-    version: 2,
-    minContracts: 45
-  }),
-  'extended': dailyNormalizedVolumeAdapter({
-    protocolName: 'extended',
-    chains: [CHAIN.STARKNET],
-    start: '2026-01-20',
-    minContracts: 75
-  }),
-  'nado': dailyNormalizedVolumeAdapter({
-    protocolName: 'nado',
-    chains: [CHAIN.INK],
-    start: '2026-01-20',
-    version: 1,
-    minContracts: 30
-  }),
-  'standx': dailyNormalizedVolumeAdapter({
-    protocolName: 'standx',
-    chains: [CHAIN.STANDX],
-    start: '2026-01-20',
-    version: 1,
-    minContracts: 4
-  }),
-  'evedex': dailyNormalizedVolumeAdapter({
-    protocolName: 'evedex',
-    chains: [CHAIN.EVENTUM],
-    start: '2026-03-30',
-    version: 1,
-    minContracts: 14
-  }),
-  'antarctic': dailyNormalizedVolumeAdapter({
-    protocolName: 'antarctic',
-    chains: [CHAIN.OFF_CHAIN],
-    start: '2026-03-06',
-    version: 1,
-    minContracts: 25
-  }),
-  'risex': dailyNormalizedVolumeAdapter({
-    protocolName: 'risex',
-    chains: [CHAIN.RISE],
-    start: '2026-05-25',
-    version: 2,
-    minContracts: 8
-  }),
-  'edgeX-v2': dailyNormalizedVolumeAdapter({
-    protocolName: 'edgex-v2',
-    chains: [CHAIN.EDGEX],
-    start: '2026-05-28',
-    version: 1,
-    minContracts: 50
-  }),
-  'dango': dailyNormalizedVolumeAdapter({
-    protocolName: 'dango',
-    chains: [CHAIN.DANGO],
-    start: '2026-05-28',
-    version: 2,
-    minContracts: 6
-  }),
-  'sodex': dailyNormalizedVolumeAdapter({
-    protocolName: 'sodex',
-    chains: [CHAIN.VALUECHAIN],
-    start: '2026-05-31',
-    version: 1,
-    minContracts: 65,
-  }),
-  'orderly': dailyNormalizedVolumeAdapter({
-    protocolName: 'orderly',
-    chains: [CHAIN.ORDERLY],
-    start: '2026-05-28',
-    version: 1,
-    minContracts: 90
-  }),
-
+  'hyperliquid': normalizedVolumeAdapter('hyperliquid', CHAIN.HYPERLIQUID, '2026-01-20'),
+  'edgex-v2': normalizedVolumeAdapter('edgex', CHAIN.EDGEX, '2026-01-20'),
+  'lighter': normalizedVolumeAdapter('lighter', CHAIN.ZK_LIGHTER, '2026-01-20'),
+  'aster': normalizedVolumeAdapter('aster', CHAIN.OFF_CHAIN, '2026-01-20'),
+  'paradex': normalizedVolumeAdapter('paradex', CHAIN.PARADEX, '2026-01-20', 2),
+  'sunx': normalizedVolumeAdapter('sunx', CHAIN.TRON, '2026-01-20'),
+  'apex-omni': normalizedVolumeAdapter('apex-omni', CHAIN.ETHEREUM, '2026-01-20'),
+  'grvt': normalizedVolumeAdapter('grvt', CHAIN.GRVT, '2026-01-20'),
+  'pacifica': normalizedVolumeAdapter('pacifica', CHAIN.SOLANA, '2026-01-20', 2),
+  'extended': normalizedVolumeAdapter('extended', CHAIN.STARKNET, '2026-01-20'),
+  'nado': normalizedVolumeAdapter('nado', CHAIN.INK, '2026-01-20'),
+  'standx': normalizedVolumeAdapter('standx', CHAIN.STANDX, '2026-01-20'),
+  'evedex': normalizedVolumeAdapter('evedex', CHAIN.EVENTUM, '2026-03-30'),
+  'antarctic': normalizedVolumeAdapter('antarctic', CHAIN.OFF_CHAIN, '2026-03-06'),
+  'risex': normalizedVolumeAdapter('risex', CHAIN.RISE, '2026-05-25', 2),
+  'dango': normalizedVolumeAdapter('dango', CHAIN.DANGO, '2026-05-28', 2),
+  'sodex': normalizedVolumeAdapter('sodex', CHAIN.VALUECHAIN, '2026-05-31'),
+  // 'edgeX': normalizedVolumeAdapter('edgex', CHAIN.EDGEX, '2026-05-28'),
+  // 'orderly': normalizedVolumeAdapter('orderly', CHAIN.ORDERLY, '2026-05-28'),
 } as const;
 
 export const { protocolList, getAdapter } = createFactoryExports(protocols);

--- a/helpers/env.ts
+++ b/helpers/env.ts
@@ -93,7 +93,9 @@ export const ENV_KEYS = new Set([
   'PEARL_BLOCKBOOK_API',
   'OKLINK_API_KEY',
   'TRONSCAN_API_KEY',
-  'ROBINHOOD_RPC'
+  'ROBINHOOD_RPC',
+  'INTERNAL_API_KEY',
+  'MARKETS_API'
 ])
 
 // This is done to support both ZEROx_API_KEY and ZEROX_API_KEY


### PR DESCRIPTION
Replaces the elastic `perp-metrics` index with the markets cache.

- **History** `series/all.json`, matched on the run's UTC day. Source of truth for v1 and for every refill.
- **Rolling** `index.json`, trailing 24h. Used by v2 only on a current run.
- A settled day wins whenever it exists, so a v2 rolling value is replaced by the real day once the history publishes it. A refill can never write today's snapshot onto a past date.
- `version` per protocol is unchanged, so these stay comparable with the dexs volume adapters.

The base url comes from a `MARKETS_API` template holding a `{key}` placeholder, filled at request time from the existing `INTERNAL_API_KEY`. So the url stays out of the repo, no secret is duplicated across env vars, and rotating the key touches one place. The key is redacted from request errors. `MARKETS_API` is set in defillama-server `storeAdaptorData`, so the cron needs no new env var; local CLI runs need it in `.env`.

`minContracts` is dropped, it had no equivalent in the new source. Snapshot staleness is gated on per-metric `freshness` (`volume` and `depth`, since active liquidity is depth derived).

Verified live and refill for all 17 protocols. Not available in the source: `edgex` and `orderly` have no slug and stay commented out; `evedex` has no history file, and its `eventum` chain is already in `deadChains`. `sunx`, `sodex` and `dango` history starts 2026-06-22, later than their configured start, and `extended` has gaps in its series, so refills before those points fail with the covered range in the message.
