### PR TITLE
Add AGNT (my.agnt.social) launchpad fees adapter

### DIFF
--- a/fees/agnt/index.ts
+++ b/fees/agnt/index.ts
@@ -29,6 +29,8 @@ const DOPPLER_INITIALIZERS = [
 ];
 // Platform keeps 32% of the pool fee → total user-paid fee = platform revenue / 0.32.
 const PLATFORM_SHARE = 0.32;
+const CREATOR_SHARE = 0.63;
+const DOPPLER_SHARE = 0.05;
 
 const fetch = async (options: FetchOptions) => {
   const dailyFees = options.createBalances();
@@ -45,9 +47,10 @@ const fetch = async (options: FetchOptions) => {
     fromAdddesses: DOPPLER_INITIALIZERS, // count only fee releases (note: helper's param is spelled fromAdddesses)
   });
 
-  dailyRevenue.addBalances(revenue);
-  dailyFees.addBalances(revenue.clone(1 / PLATFORM_SHARE));
-  dailySupplySideRevenue.addBalances(revenue.clone((1 - PLATFORM_SHARE) / PLATFORM_SHARE));
+  dailyRevenue.addBalances(revenue, "Launchpad Fees to Protocol");
+  dailyFees.addBalances(revenue.clone(1 / PLATFORM_SHARE), "Launchpad Fees");
+  dailySupplySideRevenue.addBalances(revenue.clone(CREATOR_SHARE / PLATFORM_SHARE), "Launchpad Fees to Creators");
+  dailySupplySideRevenue.addBalances(revenue.clone(DOPPLER_SHARE / PLATFORM_SHARE), "Launchpad Fees to Doppler");
 
   return {
     dailyFees,
@@ -58,11 +61,11 @@ const fetch = async (options: FetchOptions) => {
 };
 
 const adapter: SimpleAdapter = {
-  version: 1,
+  version: 2,
   pullHourly: true,
   fetch,
   chains: [CHAIN.BASE],
-  start: "2026-07-15", // first platform WETH release to 0x5bF5805e… (verified on Base).
+  start: "2026-07-15",
   methodology: {
     Fees: "Estimated total fees paid by users on tokens launched via the AGNT launchpad (Doppler V4 on Base): the 1.095% terminal pool fee, derived from the observed on-chain platform fee share. CONSERVATIVE — only the WETH leg is measured (launched-token leg excluded), so figures are a lower bound. In-app swap (trading) fees are not yet included.",
     Revenue: "Fees kept by AGNT: the 32% platform share of launchpad pool fees, measured as WETH released to the platform fee wallet 0x5bF5805e…C5f0 by the Doppler initializers.",
@@ -71,8 +74,14 @@ const adapter: SimpleAdapter = {
   },
   breakdownMethodology: {
     Fees: { "Launchpad Fees": "1.095% Doppler terminal fee (WETH leg), estimated as platform WETH share / 0.32." },
-    Revenue: { "Launchpad Fees": "32% platform share, WETH released to 0x5bF5805e…C5f0." },
+    Revenue: { "Launchpad Fees to Protocol": "32% platform share, WETH released to fee recipient wallet" },
+    ProtocolRevenue: { "Launchpad Fees to Protocol": "32% platform share, WETH released to fee recipient wallet" },
+    SupplySideRevenue: {
+      "Launchpad Fees to Creators": "63% of launchpad pool fees paid to third-party token creators",
+      "Launchpad Fees to Doppler": "5% of launchpad pool fees paid to the Doppler protocol"
+    },
   },
+  doublecounted: true, // uniswap
 };
 
 export default adapter;

--- a/fees/agnt/index.ts
+++ b/fees/agnt/index.ts
@@ -1,0 +1,78 @@
+// DefiLlama dimension-adapters fees/revenue adapter for AGNT (my.agnt.social)
+// Fork path: dimension-adapters/fees/agnt/index.ts
+//
+// Method: Clanker-style claimed fees (fees/clanker.ts) — count WETH received by the
+// AGNT platform fee wallet, which the Doppler launchpad releases on fee claims.
+//
+// On-chain verification (Base, 35-day window, 2026-07-27):
+//   • Platform wallet 0x5bF5805e… received 0.0725 WETH in 35 transfers, all since
+//     2026-07-15 (this wallet's first fee release) — ~$16/day WETH, ~$500/mo, recent/growing.
+//   • ALL 35 came from exactly the 2 Doppler initializers below (x31 + x4) — NO other
+//     WETH source. So WETH inflows == fee releases; contamination risk is nil. The
+//     fromAdddesses filter below is belt-and-suspenders on an already fee-dedicated leg.
+//   • Volume is small. Claimed vs accrued is visually identical at this scale, so the
+//     heavy accrued V4 swap-indexing build is deferred until volume grows.
+//   • Pre-2026-07-15 launchpad history sits under a prior fee wallet/collector (fee-system-v2
+//     flipped beneficiary) — out of scope for this v0; add those addresses to backfill later.
+
+import { FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import CoreAssets from "../../helpers/coreAssets.json";
+import { addTokensReceived } from "../../helpers/token";
+
+// AGNT launch-fee platform beneficiary (32% of the 1.095% Doppler terminal pool fee).
+const PLATFORM_FEE_WALLET = "0x5bF5805e4809A447a61621f8698CEdeA2D1fC5f0"; // CLAW_FEE_ADDRESS
+// The only contracts that release WETH fees to the platform wallet (verified on-chain).
+const DOPPLER_INITIALIZERS = [
+  "0xd59ce43e53d69f190e15d9822fb4540dccc91178", // DecayMulticurveInitializer (current)
+  "0xbdf938149ac6a781f94faa0ed45e6a0e984c6544", // DopplerHookInitializer (legacy)
+];
+// Platform keeps 32% of the pool fee → total user-paid fee = platform revenue / 0.32.
+const PLATFORM_SHARE = 0.32;
+
+const fetch = async (options: FetchOptions) => {
+  const dailyFees = options.createBalances();
+  const dailyRevenue = options.createBalances();
+  const dailySupplySideRevenue = options.createBalances();
+
+  // Platform's 32% launch-fee share (WETH leg), released by the Doppler initializers.
+  // CONSERVATIVE: the launched-token leg of the fee is excluded (unpriced/illiquid) —
+  // figures are a WETH-side lower bound.
+  const revenue = await addTokensReceived({
+    options,
+    targets: [PLATFORM_FEE_WALLET],
+    tokens: [CoreAssets.base.WETH],
+    fromAdddesses: DOPPLER_INITIALIZERS, // count only fee releases (note: helper's param is spelled fromAdddesses)
+  });
+
+  dailyRevenue.addBalances(revenue);
+  dailyFees.addBalances(revenue.clone(1 / PLATFORM_SHARE));
+  dailySupplySideRevenue.addBalances(revenue.clone((1 - PLATFORM_SHARE) / PLATFORM_SHARE));
+
+  return {
+    dailyFees,
+    dailyRevenue,
+    dailyProtocolRevenue: dailyRevenue,
+    dailySupplySideRevenue,
+  };
+};
+
+const adapter: SimpleAdapter = {
+  version: 1,
+  pullHourly: true,
+  fetch,
+  chains: [CHAIN.BASE],
+  start: "2026-07-15", // first platform WETH release to 0x5bF5805e… (verified on Base).
+  methodology: {
+    Fees: "Estimated total fees paid by users on tokens launched via the AGNT launchpad (Doppler V4 on Base): the 1.095% terminal pool fee, derived from the observed on-chain platform fee share. CONSERVATIVE — only the WETH leg is measured (launched-token leg excluded), so figures are a lower bound. In-app swap (trading) fees are not yet included.",
+    Revenue: "Fees kept by AGNT: the 32% platform share of launchpad pool fees, measured as WETH released to the platform fee wallet 0x5bF5805e…C5f0 by the Doppler initializers.",
+    ProtocolRevenue: "Same as Revenue — all AGNT launchpad fees accrue to the platform treasury.",
+    SupplySideRevenue: "The 68% of launchpad pool fees paid to third-party token creators (63%) and the Doppler protocol (~5%), estimated from the observed platform WETH share.",
+  },
+  breakdownMethodology: {
+    Fees: { "Launchpad Fees": "1.095% Doppler terminal fee (WETH leg), estimated as platform WETH share / 0.32." },
+    Revenue: { "Launchpad Fees": "32% platform share, WETH released to 0x5bF5805e…C5f0." },
+  },
+};
+
+export default adapter;


### PR DESCRIPTION
## AGNT — launchpad fees adapter

Adds a fees/revenue adapter for **AGNT** (my.agnt.social), an AI-agent platform whose token launchpad launches tokens via **Doppler V4 on Base**.

**Metric:** `fees` · **Chain:** Base · **Data source:** 100% on-chain — `addTokensReceived` (ERC-20 Transfer logs), filtered to the Doppler initializers so only fee releases count. No external APIs.

### Methodology
- Terminal pool fee **1.095%**, split creator **63%** / platform **32%** / Doppler **~5%**.
- Platform's 32% share is released as WETH to `0x5bF5805e4809A447a61621f8698CEdeA2D1fC5f0` by the Doppler initializers (`0xd59ce43e…`, `0xbdf93814…`).
- `dailyRevenue` = platform WETH share; `dailyFees` = revenue / 0.32; `dailySupplySideRevenue` = creator (63%) + Doppler (5%).
- Conservative: only the WETH leg is counted (launched-token leg excluded → lower bound).

### Verification
- `npm test fees agnt` → e.g. 2026-07-15: dailyFees 434 / dailyRevenue 139 / dailySupplySideRevenue 295 (32/68 split consistent).

Start `2026-07-15` (first fee release to this beneficiary). Thanks @bheluga for the breakdown + doublecounted flag. In-app **trading fees** (0.40% Relay app-fee) will follow in a separate PR — they're a non-double-counted surcharge, so they don't belong under this adapter's `doublecounted` flag.
