### PR TITLE
Add Orchard fees, revenue and volume adapter (Robinhood Chain)

### DIFF
--- a/fees/orchard/index.ts
+++ b/fees/orchard/index.ts
@@ -199,10 +199,8 @@ const breakdownMethodology = {
     RAKE: "The rake taken on every revealed round with a winner.",
   },
   UserFees: {
-    [ADMIN_FEE]: "Admin fee paid by players on every plant.",
-    [STAKING_REWARDS]: "Stakers' portion of the rake paid by players out of the loss pool.",
-    [JACKPOT]: "Jackpot portion of the rake paid by players out of the loss pool.",
-    [TREASURY_BUYBACK]: "Buyback portion of the rake paid by players out of the loss pool used to buy SEED back on the DEX and burn it.",
+    [ADMIN_FEE]: "The configured adminFeeBps share of the AAPL bought on every plant (Planted and PlantedMany events), resolved per event so rate changes apply only from the block they take effect.",
+    RAKE: "The rake taken on every revealed round with a winner.",
   },
   Revenue: {
     [ADMIN_FEE]: "Admin fee on every plant, at the configured adminFeeBps rate.",

--- a/fees/orchard/index.ts
+++ b/fees/orchard/index.ts
@@ -19,8 +19,8 @@
 // 2. Rake, on every revealed round with a winner (Orchard._reveal):
 //      lossPool = totalStake - winningStake
 //      rake     = lossPool * rakeBps / BPS     (10% today)
-//    split into stakers = rake * STAKERS_BPS / BPS (10%, a contract constant),
-//    jackpot = rake * jackpotBps / BPS (50%), treasury = the remainder (40%).
+//    split into stakers = rake * STAKERS_BPS / BPS (a fixed 10%, contract constant),
+//    jackpot = rake * jackpotBps / BPS (50% today), treasury = the remainder (40% today).
 //
 // rakeBps and jackpotBps are owner-adjustable and stored per round, so both are read
 // back from rounds(id) instead of being hardcoded — historical rounds keep their own rate.
@@ -185,21 +185,21 @@ const fetch = async (options: FetchOptions) => {
 const methodology = {
   Volume: "Total ETH planted on the grid, taken from the Planted and PlantedMany events.",
   Fees:
-    "Every plant pays an admin fee, at the configured adminFeeBps rate (1% at time of writing), on the AAPL bought with it. Every revealed round with a winner pays a 10% rake on the loss pool (the stakes on the 24 plots that did not bloom), split into 10% to SEED stakers, 50% to the Golden Apple jackpot and 40% to the treasury. Rounds where the blooming plot is empty take no rake — the whole pot rolls into the jackpot.",
+    "Every plant pays an admin fee, at the configured adminFeeBps rate (1% at time of writing), on the AAPL bought with it. Every revealed round with a winner pays that round's configured rakeBps on the loss pool (the stakes on the 24 plots that did not bloom), split into a fixed 10% to SEED stakers (STAKERS_BPS, a contract constant), the round's configured jackpotBps share to the Golden Apple jackpot, and the remainder to the treasury. Rounds where the blooming plot is empty take no rake — the whole pot rolls into the jackpot.",
   UserFees: "Same as Fees — both the admin fee and the rake are paid by players out of what they planted.",
   Revenue: "Gross profit: the admin fee plus the stakers and treasury cuts of the rake. The jackpot cut is excluded because it is paid back out to players.",
   ProtocolRevenue: "The admin fee taken on every plant at the configured adminFeeBps rate, withdrawn by the owner via collectAdmin.",
   HoldersRevenue:
-    "Value reaching SEED holders: the 10% of the rake flushed to SeedStaking as AAPL yield for stakers, plus the 40% treasury cut that buys SEED back on the DEX and burns it.",
-  SupplySideRevenue: "The 50% of the rake routed to the Golden Apple jackpot, which is paid back out to players when it hits.",
+    "Value reaching SEED holders: the fixed 10% of each round's rake flushed to SeedStaking as AAPL yield for stakers, plus the treasury remainder that buys SEED back on the DEX and burns it.",
+  SupplySideRevenue: "The round's configured jackpotBps share of its rake, routed to the Golden Apple jackpot and paid back out to players when it hits.",
 };
 
 const breakdownMethodology = {
   Fees: {
     [ADMIN_FEE]: "The configured adminFeeBps share of the AAPL bought on every plant (Planted and PlantedMany events), resolved per event so rate changes apply only from the block they take effect.",
-    [METRIC.STAKING_REWARDS]: "10% of each round's rake, accrued for SEED stakers.",
-    [JACKPOT]: "50% of each round's rake, routed to the Golden Apple jackpot.",
-    [TREASURY]: "40% of each round's rake, accrued to the treasury.",
+    [METRIC.STAKING_REWARDS]: "A fixed 10% of each round's rake (STAKERS_BPS, a contract constant), accrued for SEED stakers.",
+    [JACKPOT]: "The round's configured jackpotBps share of its rake, routed to the Golden Apple jackpot.",
+    [TREASURY]: "The remainder of each round's rake after the staker and jackpot shares, accrued to the treasury.",
   },
   UserFees: {
     [ADMIN_FEE]: "Admin fee paid by players on every plant.",
@@ -209,18 +209,18 @@ const breakdownMethodology = {
   },
   Revenue: {
     [ADMIN_FEE]: "Admin fee on every plant, at the configured adminFeeBps rate.",
-    [METRIC.STAKING_REWARDS]: "10% of the rake accrued for SEED stakers.",
-    [TREASURY]: "40% of the rake accrued to the treasury.",
+    [METRIC.STAKING_REWARDS]: "The fixed 10% staker share of each round's rake.",
+    [TREASURY]: "The treasury remainder of each round's rake.",
   },
   ProtocolRevenue: {
     [ADMIN_FEE]: "Admin fee on every plant at the configured adminFeeBps rate, withdrawn by the owner via collectAdmin.",
   },
   HoldersRevenue: {
-    [METRIC.STAKING_REWARDS]: "10% of the rake flushed to SeedStaking as AAPL yield for SEED stakers.",
-    [TREASURY]: "40% of the rake spent buying SEED back on the DEX and burning it.",
+    [METRIC.STAKING_REWARDS]: "The fixed 10% staker share of each round's rake, flushed to SeedStaking as AAPL yield for SEED stakers.",
+    [TREASURY]: "The treasury remainder of each round's rake, spent buying SEED back on the DEX and burning it.",
   },
   SupplySideRevenue: {
-    [JACKPOT]: "50% of the rake routed to the Golden Apple jackpot, paid back out to players when it hits.",
+    [JACKPOT]: "The round's configured jackpotBps share of its rake, routed to the Golden Apple jackpot and paid back out to players when it hits.",
   },
 };
 

--- a/fees/orchard/index.ts
+++ b/fees/orchard/index.ts
@@ -12,7 +12,7 @@
 // Two fees are extracted, both in AAPL:
 //
 // 1. Admin fee, on every plant (Orchard._credit /._creditMany):
-//      adminCut = bought * adminFeeBps / BPS   (1% today)
+//      adminCut = bought * adminFeeBps / BPS   (the configured rate; 1% at time of writing)
 //      stake    = bought - adminCut
 //    Withdrawn by the owner via collectAdmin(address) -> protocol revenue.
 //
@@ -24,6 +24,8 @@
 //
 // rakeBps and jackpotBps are owner-adjustable and stored per round, so both are read
 // back from rounds(id) instead of being hardcoded — historical rounds keep their own rate.
+// adminFeeBps is likewise owner-adjustable; it is resolved per plant from the window's
+// opening value plus any AdminFeeBpsSet emitted inside the window.
 //
 // Rounds where the blooming plot is empty settle through an early return in _reveal:
 // no rake is taken at all and the whole pot rolls into the jackpot, so they contribute
@@ -53,6 +55,7 @@ const PLANTED_MANY =
   "event PlantedMany(address indexed player, uint256 indexed startRound, uint16 roundCount, uint32 plotMask, uint256 ethIn, uint256 totalStake)";
 const REVEALED =
   "event Revealed(uint256 indexed round, uint8 winningPlot, uint256 winningStake, uint256 netLossPool)";
+const ADMIN_FEE_BPS_SET = "event AdminFeeBpsSet(uint16 bps)";
 
 const ROUNDS_ABI =
   "function rounds(uint256) view returns (uint64 sealBlock, bool revealed, bool voided, uint8 winningPlot, uint16 rakeBps, uint16 jackpotBps, uint32 jackpotOdds, uint256 totalStake, uint256 winningStake, uint256 netLossPool, uint256 entryIndex, uint256 jackpotWon)";
@@ -80,31 +83,51 @@ const fetch = async (options: FetchOptions) => {
   const dailyHoldersRevenue = options.createBalances();
   const dailyProtocolRevenue = options.createBalances();
 
-  // --- 1. plants: ETH wagered (volume) + the 1% admin cut on the AAPL bought ---
-  // adminFeeBps is owner-adjustable and not carried in the event, so read the rate
-  // in effect for this window rather than hardcoding it.
-  const adminFeeBps = BigInt(
-    await options.api.call({ abi: "uint16:adminFeeBps", target: ORCHARD })
+  // --- 1. plants: ETH wagered (volume) + the admin cut on the AAPL bought ---
+  // adminFeeBps is owner-adjustable and is not carried in the Planted events, so the
+  // configured rate is resolved per event: start from the value at the window's first
+  // block and replay any AdminFeeBpsSet emitted inside the window on top of it. A rate
+  // change mid-window therefore applies only to the plants that came after it.
+  const startAdminFeeBps = BigInt(
+    await options.fromApi.call({ abi: "uint16:adminFeeBps", target: ORCHARD })
   );
+
+  const feeChanges = (await options.getLogs({ target: ORCHARD, eventAbi: ADMIN_FEE_BPS_SET }))
+    .map((log: any) => ({
+      blockNumber: Number(log.blockNumber),
+      logIndex: Number(log.logIndex),
+      bps: BigInt(log.bps),
+    }))
+    .sort((a, b) => a.blockNumber - b.blockNumber || a.logIndex - b.logIndex);
+
+  // Rate in effect for a log, i.e. the last change emitted strictly before it.
+  const rateAt = (blockNumber: number, logIndex: number): bigint => {
+    let bps = startAdminFeeBps;
+    for (const change of feeChanges) {
+      if (
+        change.blockNumber > blockNumber ||
+        (change.blockNumber === blockNumber && change.logIndex > logIndex)
+      )
+        break;
+      bps = change.bps;
+    }
+    return bps;
+  };
 
   const planted = await options.getLogs({ target: ORCHARD, eventAbi: PLANTED });
   const plantedMany = await options.getLogs({ target: ORCHARD, eventAbi: PLANTED_MANY });
 
-  for (const log of planted) {
+  const addPlant = (log: any, stake: bigint) => {
     dailyVolume.addGasToken(log.ethIn);
-    const adminCut = deriveAdminCut(BigInt(log.stake), adminFeeBps);
+    const bps = rateAt(Number(log.blockNumber), Number(log.logIndex));
+    const adminCut = deriveAdminCut(stake, bps);
     dailyFees.add(AAPL, adminCut, ADMIN_FEE);
     dailyRevenue.add(AAPL, adminCut, ADMIN_FEE);
     dailyProtocolRevenue.add(AAPL, adminCut, ADMIN_FEE);
-  }
+  };
 
-  for (const log of plantedMany) {
-    dailyVolume.addGasToken(log.ethIn);
-    const adminCut = deriveAdminCut(BigInt(log.totalStake), adminFeeBps);
-    dailyFees.add(AAPL, adminCut, ADMIN_FEE);
-    dailyRevenue.add(AAPL, adminCut, ADMIN_FEE);
-    dailyProtocolRevenue.add(AAPL, adminCut, ADMIN_FEE);
-  }
+  for (const log of planted) addPlant(log, BigInt(log.stake));
+  for (const log of plantedMany) addPlant(log, BigInt(log.totalStake));
 
   // --- 2. reveals: the rake and its three destinations ---
   // The emitted netLossPool already has any jackpot payout folded in, so the round
@@ -162,10 +185,10 @@ const fetch = async (options: FetchOptions) => {
 const methodology = {
   Volume: "Total ETH planted on the grid, taken from the Planted and PlantedMany events.",
   Fees:
-    "Every plant pays a 1% admin fee on the AAPL bought with it. Every revealed round with a winner pays a 10% rake on the loss pool (the stakes on the 24 plots that did not bloom), split into 10% to SEED stakers, 50% to the Golden Apple jackpot and 40% to the treasury. Rounds where the blooming plot is empty take no rake — the whole pot rolls into the jackpot.",
+    "Every plant pays an admin fee, at the configured adminFeeBps rate (1% at time of writing), on the AAPL bought with it. Every revealed round with a winner pays a 10% rake on the loss pool (the stakes on the 24 plots that did not bloom), split into 10% to SEED stakers, 50% to the Golden Apple jackpot and 40% to the treasury. Rounds where the blooming plot is empty take no rake — the whole pot rolls into the jackpot.",
   UserFees: "Same as Fees — both the admin fee and the rake are paid by players out of what they planted.",
   Revenue: "Gross profit: the admin fee plus the stakers and treasury cuts of the rake. The jackpot cut is excluded because it is paid back out to players.",
-  ProtocolRevenue: "The 1% admin fee taken on every plant, withdrawn by the owner via collectAdmin.",
+  ProtocolRevenue: "The admin fee taken on every plant at the configured adminFeeBps rate, withdrawn by the owner via collectAdmin.",
   HoldersRevenue:
     "Value reaching SEED holders: the 10% of the rake flushed to SeedStaking as AAPL yield for stakers, plus the 40% treasury cut that buys SEED back on the DEX and burns it.",
   SupplySideRevenue: "The 50% of the rake routed to the Golden Apple jackpot, which is paid back out to players when it hits.",
@@ -173,7 +196,7 @@ const methodology = {
 
 const breakdownMethodology = {
   Fees: {
-    [ADMIN_FEE]: "1% of the AAPL bought on every plant (Planted and PlantedMany events).",
+    [ADMIN_FEE]: "The configured adminFeeBps share of the AAPL bought on every plant (Planted and PlantedMany events), resolved per event so rate changes apply only from the block they take effect.",
     [METRIC.STAKING_REWARDS]: "10% of each round's rake, accrued for SEED stakers.",
     [JACKPOT]: "50% of each round's rake, routed to the Golden Apple jackpot.",
     [TREASURY]: "40% of each round's rake, accrued to the treasury.",
@@ -185,12 +208,12 @@ const breakdownMethodology = {
     [TREASURY]: "Treasury portion of the rake paid by players out of the loss pool.",
   },
   Revenue: {
-    [ADMIN_FEE]: "1% admin fee on every plant.",
+    [ADMIN_FEE]: "Admin fee on every plant, at the configured adminFeeBps rate.",
     [METRIC.STAKING_REWARDS]: "10% of the rake accrued for SEED stakers.",
     [TREASURY]: "40% of the rake accrued to the treasury.",
   },
   ProtocolRevenue: {
-    [ADMIN_FEE]: "1% admin fee on every plant, withdrawn by the owner via collectAdmin.",
+    [ADMIN_FEE]: "Admin fee on every plant at the configured adminFeeBps rate, withdrawn by the owner via collectAdmin.",
   },
   HoldersRevenue: {
     [METRIC.STAKING_REWARDS]: "10% of the rake flushed to SeedStaking as AAPL yield for SEED stakers.",

--- a/fees/orchard/index.ts
+++ b/fees/orchard/index.ts
@@ -1,0 +1,214 @@
+// Orchard — fees & revenue adapter.
+//
+// Orchard is a plot game on Robinhood Chain (chainId 4663). Players plant ETH on a
+// 5x5 grid; the ETH is swapped to AAPL (Apple stock token) inside the same transaction,
+// so the game is played in AAPL. Every 75s round one plot blooms and whoever planted
+// there splits the harvest from the other 24 plots.
+//
+// Contracts (Robinhood Chain):
+//   Orchard: 0xEbB8b167c0992cFdc497A995a8Cf7167acAA0A1A
+//   AAPL:    0xaF3D76f1834A1d425780943C99Ea8A608f8a93f9
+//
+// Two fees are extracted, both in AAPL:
+//
+// 1. Admin fee, on every plant (Orchard._credit /._creditMany):
+//      adminCut = bought * adminFeeBps / BPS   (1% today)
+//      stake    = bought - adminCut
+//    Withdrawn by the owner via collectAdmin(address) -> protocol revenue.
+//
+// 2. Rake, on every revealed round with a winner (Orchard._reveal):
+//      lossPool = totalStake - winningStake
+//      rake     = lossPool * rakeBps / BPS     (10% today)
+//    split into stakers = rake * STAKERS_BPS / BPS (10%, a contract constant),
+//    jackpot = rake * jackpotBps / BPS (50%), treasury = the remainder (40%).
+//
+// rakeBps and jackpotBps are owner-adjustable and stored per round, so both are read
+// back from rounds(id) instead of being hardcoded — historical rounds keep their own rate.
+//
+// Rounds where the blooming plot is empty settle through an early return in _reveal:
+// no rake is taken at all and the whole pot rolls into the jackpot, so they contribute
+// volume but no fees.
+//
+// The 10% juice on claim(): NOT counted. It is a hardcoded constant that is recycled to
+// players who have not claimed yet (juiceIndex) — it never reaches protocol control, so
+// it is a player-to-player transfer rather than a fee.
+
+import { Adapter, FetchOptions } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import { METRIC } from "../../helpers/metrics";
+
+const ORCHARD = "0xEbB8b167c0992cFdc497A995a8Cf7167acAA0A1A";
+const AAPL = "0xaF3D76f1834A1d425780943C99Ea8A608f8a93f9";
+
+const BPS = 10000n;
+const STAKERS_BPS = 1000n; // Orchard.STAKERS_BPS, a contract constant: 10% of the rake
+
+const ADMIN_FEE = "Admin Fee";
+const JACKPOT = "Jackpot";
+const TREASURY = "Treasury Buyback";
+
+const PLANTED =
+  "event Planted(address indexed player, uint256 indexed round, uint8 plot, uint256 ethIn, uint256 stake)";
+const PLANTED_MANY =
+  "event PlantedMany(address indexed player, uint256 indexed startRound, uint16 roundCount, uint32 plotMask, uint256 ethIn, uint256 totalStake)";
+const REVEALED =
+  "event Revealed(uint256 indexed round, uint8 winningPlot, uint256 winningStake, uint256 netLossPool)";
+
+const ROUNDS_ABI =
+  "function rounds(uint256) view returns (uint64 sealBlock, bool revealed, bool voided, uint8 winningPlot, uint16 rakeBps, uint16 jackpotBps, uint32 jackpotOdds, uint256 totalStake, uint256 winningStake, uint256 netLossPool, uint256 entryIndex, uint256 jackpotWon)";
+
+// Invert stake -> bought for the admin cut. The contract floors adminCut, so
+// stake = bought - floor(bought * bps / BPS); start from the closed form and nudge
+// within the flooring error until the contract's math reproduces the emitted stake.
+const deriveAdminCut = (stake: bigint, bps: bigint): bigint => {
+  if (bps === 0n) return 0n;
+  const candidate = (stake * BPS) / (BPS - bps);
+  for (let offset = -3n; offset <= 3n; offset++) {
+    const bought = candidate + offset;
+    if (bought < 0n) continue;
+    const cut = (bought * bps) / BPS;
+    if (bought - cut === stake) return cut;
+  }
+  return candidate - stake;
+};
+
+const fetch = async (options: FetchOptions) => {
+  const dailyVolume = options.createBalances();
+  const dailyFees = options.createBalances();
+  const dailySupplySideRevenue = options.createBalances();
+  const dailyRevenue = options.createBalances();
+  const dailyHoldersRevenue = options.createBalances();
+  const dailyProtocolRevenue = options.createBalances();
+
+  // --- 1. plants: ETH wagered (volume) + the 1% admin cut on the AAPL bought ---
+  // adminFeeBps is owner-adjustable and not carried in the event, so read the rate
+  // in effect for this window rather than hardcoding it.
+  const adminFeeBps = BigInt(
+    await options.api.call({ abi: "uint16:adminFeeBps", target: ORCHARD })
+  );
+
+  const planted = await options.getLogs({ target: ORCHARD, eventAbi: PLANTED });
+  const plantedMany = await options.getLogs({ target: ORCHARD, eventAbi: PLANTED_MANY });
+
+  for (const log of planted) {
+    dailyVolume.addGasToken(log.ethIn);
+    const adminCut = deriveAdminCut(BigInt(log.stake), adminFeeBps);
+    dailyFees.add(AAPL, adminCut, ADMIN_FEE);
+    dailyRevenue.add(AAPL, adminCut, ADMIN_FEE);
+    dailyProtocolRevenue.add(AAPL, adminCut, ADMIN_FEE);
+  }
+
+  for (const log of plantedMany) {
+    dailyVolume.addGasToken(log.ethIn);
+    const adminCut = deriveAdminCut(BigInt(log.totalStake), adminFeeBps);
+    dailyFees.add(AAPL, adminCut, ADMIN_FEE);
+    dailyRevenue.add(AAPL, adminCut, ADMIN_FEE);
+    dailyProtocolRevenue.add(AAPL, adminCut, ADMIN_FEE);
+  }
+
+  // --- 2. reveals: the rake and its three destinations ---
+  // The emitted netLossPool already has any jackpot payout folded in, so the round
+  // state is read back instead of deriving the loss pool from the event.
+  const revealed = await options.getLogs({ target: ORCHARD, eventAbi: REVEALED });
+
+  if (revealed.length) {
+    const rounds = await options.api.multiCall({
+      abi: ROUNDS_ABI,
+      target: ORCHARD,
+      calls: revealed.map((log: any) => ({ params: [log.round.toString()] })),
+    });
+
+    for (const round of rounds) {
+      const totalStake = BigInt(round.totalStake);
+      const winningStake = BigInt(round.winningStake);
+      // Empty blooming plot: _reveal returns early, no rake is taken.
+      if (winningStake === 0n) continue;
+
+      const rake = ((totalStake - winningStake) * BigInt(round.rakeBps)) / BPS;
+      if (rake === 0n) continue;
+
+      const toStakers = (rake * STAKERS_BPS) / BPS;
+      const toJackpot = (rake * BigInt(round.jackpotBps)) / BPS;
+      const toTreasury = rake - toStakers - toJackpot;
+
+      dailyFees.add(AAPL, toStakers, METRIC.STAKING_REWARDS);
+      dailyFees.add(AAPL, toJackpot, JACKPOT);
+      dailyFees.add(AAPL, toTreasury, TREASURY);
+
+      // The jackpot is paid back out to players, so it is a cost of revenue.
+      dailySupplySideRevenue.add(AAPL, toJackpot, JACKPOT);
+
+      dailyRevenue.add(AAPL, toStakers, METRIC.STAKING_REWARDS);
+      dailyRevenue.add(AAPL, toTreasury, TREASURY);
+
+      // Both destinations end up with SEED holders: the stakers' cut is flushed to
+      // SeedStaking as AAPL yield, the treasury cut buys SEED back and burns it.
+      dailyHoldersRevenue.add(AAPL, toStakers, METRIC.STAKING_REWARDS);
+      dailyHoldersRevenue.add(AAPL, toTreasury, TREASURY);
+    }
+  }
+
+  return {
+    dailyVolume,
+    dailyFees,
+    dailyUserFees: dailyFees,
+    dailyRevenue,
+    dailySupplySideRevenue,
+    dailyHoldersRevenue,
+    dailyProtocolRevenue,
+  };
+};
+
+const methodology = {
+  Volume: "Total ETH planted on the grid, taken from the Planted and PlantedMany events.",
+  Fees:
+    "Every plant pays a 1% admin fee on the AAPL bought with it. Every revealed round with a winner pays a 10% rake on the loss pool (the stakes on the 24 plots that did not bloom), split into 10% to SEED stakers, 50% to the Golden Apple jackpot and 40% to the treasury. Rounds where the blooming plot is empty take no rake — the whole pot rolls into the jackpot.",
+  UserFees: "Same as Fees — both the admin fee and the rake are paid by players out of what they planted.",
+  Revenue: "Gross profit: the admin fee plus the stakers and treasury cuts of the rake. The jackpot cut is excluded because it is paid back out to players.",
+  ProtocolRevenue: "The 1% admin fee taken on every plant, withdrawn by the owner via collectAdmin.",
+  HoldersRevenue:
+    "Value reaching SEED holders: the 10% of the rake flushed to SeedStaking as AAPL yield for stakers, plus the 40% treasury cut that buys SEED back on the DEX and burns it.",
+  SupplySideRevenue: "The 50% of the rake routed to the Golden Apple jackpot, which is paid back out to players when it hits.",
+};
+
+const breakdownMethodology = {
+  Fees: {
+    [ADMIN_FEE]: "1% of the AAPL bought on every plant (Planted and PlantedMany events).",
+    [METRIC.STAKING_REWARDS]: "10% of each round's rake, accrued for SEED stakers.",
+    [JACKPOT]: "50% of each round's rake, routed to the Golden Apple jackpot.",
+    [TREASURY]: "40% of each round's rake, accrued to the treasury.",
+  },
+  UserFees: {
+    [ADMIN_FEE]: "Admin fee paid by players on every plant.",
+    [METRIC.STAKING_REWARDS]: "Stakers' portion of the rake paid by players out of the loss pool.",
+    [JACKPOT]: "Jackpot portion of the rake paid by players out of the loss pool.",
+    [TREASURY]: "Treasury portion of the rake paid by players out of the loss pool.",
+  },
+  Revenue: {
+    [ADMIN_FEE]: "1% admin fee on every plant.",
+    [METRIC.STAKING_REWARDS]: "10% of the rake accrued for SEED stakers.",
+    [TREASURY]: "40% of the rake accrued to the treasury.",
+  },
+  ProtocolRevenue: {
+    [ADMIN_FEE]: "1% admin fee on every plant, withdrawn by the owner via collectAdmin.",
+  },
+  HoldersRevenue: {
+    [METRIC.STAKING_REWARDS]: "10% of the rake flushed to SeedStaking as AAPL yield for SEED stakers.",
+    [TREASURY]: "40% of the rake spent buying SEED back on the DEX and burning it.",
+  },
+  SupplySideRevenue: {
+    [JACKPOT]: "50% of the rake routed to the Golden Apple jackpot, paid back out to players when it hits.",
+  },
+};
+
+const adapter: Adapter = {
+  version: 2,
+  pullHourly: true,
+  fetch,
+  chains: [CHAIN.ROBINHOOD],
+  start: "2026-07-22",
+  methodology,
+  breakdownMethodology,
+};
+
+export default adapter;

--- a/fees/orchard/index.ts
+++ b/fees/orchard/index.ts
@@ -37,7 +37,6 @@
 
 import { Adapter, FetchOptions } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
-import { METRIC } from "../../helpers/metrics";
 
 const ORCHARD = "0xEbB8b167c0992cFdc497A995a8Cf7167acAA0A1A";
 const AAPL = "0xaF3D76f1834A1d425780943C99Ea8A608f8a93f9";
@@ -45,9 +44,11 @@ const AAPL = "0xaF3D76f1834A1d425780943C99Ea8A608f8a93f9";
 const BPS = 10000n;
 const STAKERS_BPS = 1000n; // Orchard.STAKERS_BPS, a contract constant: 10% of the rake
 
+const RAKE = "Rake";
 const ADMIN_FEE = "Admin Fee";
-const JACKPOT = "Jackpot";
-const TREASURY = "Treasury Buyback";
+const JACKPOT = "Rake to Jackpot";
+const TREASURY_BUYBACK = "Rake to Buyback";
+const STAKING_REWARDS = "Rake to Stakers";
 
 const PLANTED =
   "event Planted(address indexed player, uint256 indexed round, uint8 plot, uint256 ethIn, uint256 stake)";
@@ -154,20 +155,18 @@ const fetch = async (options: FetchOptions) => {
       const toJackpot = (rake * BigInt(round.jackpotBps)) / BPS;
       const toTreasury = rake - toStakers - toJackpot;
 
-      dailyFees.add(AAPL, toStakers, METRIC.STAKING_REWARDS);
-      dailyFees.add(AAPL, toJackpot, JACKPOT);
-      dailyFees.add(AAPL, toTreasury, TREASURY);
+      dailyFees.add(AAPL, toStakers + toJackpot + toTreasury, RAKE);
 
       // The jackpot is paid back out to players, so it is a cost of revenue.
       dailySupplySideRevenue.add(AAPL, toJackpot, JACKPOT);
 
-      dailyRevenue.add(AAPL, toStakers, METRIC.STAKING_REWARDS);
-      dailyRevenue.add(AAPL, toTreasury, TREASURY);
+      dailyRevenue.add(AAPL, toStakers, STAKING_REWARDS);
+      dailyRevenue.add(AAPL, toTreasury, TREASURY_BUYBACK);
 
       // Both destinations end up with SEED holders: the stakers' cut is flushed to
       // SeedStaking as AAPL yield, the treasury cut buys SEED back and burns it.
-      dailyHoldersRevenue.add(AAPL, toStakers, METRIC.STAKING_REWARDS);
-      dailyHoldersRevenue.add(AAPL, toTreasury, TREASURY);
+      dailyHoldersRevenue.add(AAPL, toStakers, STAKING_REWARDS);
+      dailyHoldersRevenue.add(AAPL, toTreasury, TREASURY_BUYBACK);
     }
   }
 
@@ -197,27 +196,25 @@ const methodology = {
 const breakdownMethodology = {
   Fees: {
     [ADMIN_FEE]: "The configured adminFeeBps share of the AAPL bought on every plant (Planted and PlantedMany events), resolved per event so rate changes apply only from the block they take effect.",
-    [METRIC.STAKING_REWARDS]: "A fixed 10% of each round's rake (STAKERS_BPS, a contract constant), accrued for SEED stakers.",
-    [JACKPOT]: "The round's configured jackpotBps share of its rake, routed to the Golden Apple jackpot.",
-    [TREASURY]: "The remainder of each round's rake after the staker and jackpot shares, accrued to the treasury.",
+    RAKE: "The rake taken on every revealed round with a winner.",
   },
   UserFees: {
     [ADMIN_FEE]: "Admin fee paid by players on every plant.",
-    [METRIC.STAKING_REWARDS]: "Stakers' portion of the rake paid by players out of the loss pool.",
+    [STAKING_REWARDS]: "Stakers' portion of the rake paid by players out of the loss pool.",
     [JACKPOT]: "Jackpot portion of the rake paid by players out of the loss pool.",
-    [TREASURY]: "Treasury portion of the rake paid by players out of the loss pool.",
+    [TREASURY_BUYBACK]: "Buyback portion of the rake paid by players out of the loss pool used to buy SEED back on the DEX and burn it.",
   },
   Revenue: {
     [ADMIN_FEE]: "Admin fee on every plant, at the configured adminFeeBps rate.",
-    [METRIC.STAKING_REWARDS]: "The fixed 10% staker share of each round's rake.",
-    [TREASURY]: "The treasury remainder of each round's rake.",
+    [STAKING_REWARDS]: "The fixed 10% staker share of each round's rake.",
+    [TREASURY_BUYBACK]: "The treasury remainder of each round's rake used to buy SEED back on the DEX and burn it.",
   },
   ProtocolRevenue: {
     [ADMIN_FEE]: "Admin fee on every plant at the configured adminFeeBps rate, withdrawn by the owner via collectAdmin.",
   },
   HoldersRevenue: {
-    [METRIC.STAKING_REWARDS]: "The fixed 10% staker share of each round's rake, flushed to SeedStaking as AAPL yield for SEED stakers.",
-    [TREASURY]: "The treasury remainder of each round's rake, spent buying SEED back on the DEX and burning it.",
+    [STAKING_REWARDS]: "The fixed 10% staker share of each round's rake, flushed to SeedStaking as AAPL yield for SEED stakers.",
+    [TREASURY_BUYBACK]: "The treasury remainder of each round's rake, spent buying SEED back on the DEX and burning it.",
   },
   SupplySideRevenue: {
     [JACKPOT]: "The round's configured jackpotBps share of its rake, routed to the Golden Apple jackpot and paid back out to players when it hits.",


### PR DESCRIPTION
Adds a fees, revenue and volume adapter for **Orchard**, a plot game on Robinhood Chain (chainId 4663).

The TVL adapter for the same protocol is in DefiLlama/DefiLlama-Adapters#20259.

Website: https://orchard.gold — Twitter: https://x.com/orcharddotgold

All dimensions come from on-chain event logs plus per-round contract state. No API, no npm dependencies, no lockfile changes.

## Methodology

Orchard is a 5x5 plot game. Players plant ETH; the ETH is swapped to AAPL (Apple stock token) in the same transaction, so the game itself is played in AAPL. Two fees are extracted, both in AAPL:

1. **Admin fee** — `adminFeeBps` (1% today) of the AAPL bought on every plant, taken in `_credit`/`_creditMany` before the stake is credited. Withdrawn by the owner via `collectAdmin(address)`, so it is protocol revenue.
2. **Rake** — `rakeBps` (10% today) of the loss pool on every revealed round that had a winner, split into 10% to SEED stakers (`STAKERS_BPS`, a contract constant), `jackpotBps` (50%) to the Golden Apple jackpot, and the remainder (40%) to the treasury.

`rakeBps` and `jackpotBps` are owner-adjustable **and stored per round**, so both are read back from `rounds(id)` rather than hardcoded — historical rounds keep whatever rate was in effect at the time. `adminFeeBps` is read at the window's block for the same reason.

Two deliberate exclusions, both documented inline:

- **Rounds where the blooming plot is empty** take no rake at all (`_reveal` returns early and the entire pot rolls into the jackpot). They contribute volume but no fees.
- **The 10% juice on `claim()`** is not counted. It is a hardcoded constant recycled to players who have not claimed yet via `juiceIndex` — it never reaches protocol control, so it is a player-to-player transfer rather than a fee.

The jackpot cut is classified as `dailySupplySideRevenue` because it is paid back out to players, matching how the SLVR and STEEL adapters on the same chain treat their jackpot/motherlode.

## Test output

`pnpm test fees orchard` over 24 hourly windows (2026-07-27 13:00 → 2026-07-28 13:00 UTC):

```
Daily volume:              2.24 k
Daily fees:                189.81
Daily user fees:           189.81
Daily revenue:             105.82
Daily supply side revenue: 84.22
Daily holders revenue:     84.22
Daily protocol revenue:    22.31

FEES BREAKDOWN
label            | Daily fees | Daily revenue | Daily holders rev | Daily supply side rev
Admin Fee        | 22.31      | 22.31         |                   |
Staking Rewards  | 16.85      | 16.85         | 16.85             |
Jackpot          | 84.22      |               |                   | 84.22
Treasury Buyback | 67.22      | 67.22         | 67.22             |
```

Sanity checks on that window: the rake splits 10.01% / 50.05% / 39.94% across stakers / jackpot / treasury, matching the on-chain configuration, and the admin fee of 22.31 is 1.00% of the 2.24k volume.

---
## (New listing details)

##### Name (to be shown on DefiLlama):
Orchard

##### Twitter Link:
https://x.com/orcharddotgold

##### List of audit links if any:
No third-party audit. Internal security review only (manual review + Slither 0.11.5 + `forge lint`, 126 tests).

##### Website Link:
https://orchard.gold

##### Logo (High resolution, will be shown with rounded borders):
https://orchard.gold/icon.png

##### Current TVL:
~$10,800 — see DefiLlama/DefiLlama-Adapters#20259

##### Treasury Addresses (if the protocol has treasury)
(none) — no standing treasury wallet. Treasury fees accrue inside the Orchard contract (`treasuryAccrued`) and are either burned via `buybackSeed()` (AAPL swapped for SEED, SEED sent to `0x…dEaD`) or withdrawn to a destination passed at call time via `collectTreasury(address)`.

##### Chain:
Robinhood Chain (`robinhood`, chainId 4663)

##### Coingecko ID:
(none)

##### Coinmarketcap ID:
(none)

##### Short Description (to be shown on DefiLlama):
Orchard is a 5x5 plot game on Robinhood Chain. Players plant ETH on a plot; the ETH is swapped to AAPL (Apple stock token) in the same transaction. Each 75-second round one plot blooms and the players who planted there split the harvest from the other 24 plots, minus a 10% rake that funds SEED stakers, the Golden Apple jackpot and the treasury.

##### Token address and ticker if any:
SEED — `0x5eED45d9cD4c21280db5b190D9c263f086401b9D` (name "Orchard", 18 decimals) on Robinhood Chain

##### Category:
Gamified Mining

##### Oracle Provider(s):
None. Orchard uses no price oracle. Round randomness comes from EIP-2935 historical block hashes on-chain (`Arb2935Randomness`, seal -> reveal), and all swaps go through the on-chain DEX router.

##### Implementation Details:
N/A — no oracle integration.

##### Documentation/Proof:
N/A — no oracle integration.

##### forkedFrom:
(none — the contracts are original Solidity written for this project, not a code fork)

##### methodology:
See the Methodology section above; the same text is in the adapter's `methodology` and `breakdownMethodology`.

##### Github org/user:
(none — repository is private)

##### Does this project have a referral program?
No

---

Contracts, verified on Blockscout:
- Orchard: https://robinhoodchain.blockscout.com/address/0xEbB8b167c0992cFdc497A995a8Cf7167acAA0A1A
- SeedStaking: https://robinhoodchain.blockscout.com/address/0xd5d5f5Dff96E53fc6337b4aCf549d61b12882F2b
- SEED: https://robinhoodchain.blockscout.com/address/0x5eED45d9cD4c21280db5b190D9c263f086401b9D
