### PR TITLE
BasedBid: add Solana revenue/fees and volume adapters

### DIFF
--- a/dexs/basedbid/index.ts
+++ b/dexs/basedbid/index.ts
@@ -1,0 +1,72 @@
+import ADDRESSES from "../../helpers/coreAssets.json";
+import { Dependencies, FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import { queryAllium } from "../../helpers/allium";
+
+// BasedBid bonding-curve launchpad program on Solana.
+const SOLANA_PROGRAM = "CuodpYRDz4k87K6ZUFxk7X8JkVv5dNVZAcTQX2TEzTef";
+// Hardcoded admin wallet receiving the protocol fee share — excluded so fees are not
+// counted as trade principal.
+const SOLANA_FEE_WALLET = "8umVV7k9HoVm4yy5DiRtKSH5qbKtw8xWDARGX8QiLfLe";
+// Post-graduation DEX programs: transactions touching these are pool finalization or
+// LP fee claims, not bonding-curve trades (that volume belongs to Raydium/Meteora).
+const DEX_PROGRAMS = [
+  "CPMMoo8L3F4NbTegBCKVNunggL7H1ZpdTHKxQB5qKP1C", // Raydium CPMM
+  "CAMMCzo5YL8w4VFF8KVHrK22GGUsp5VTaW7grrKgrWqK", // Raydium CLMM
+  "cpamdpZCGKUy5JxQXB4dcpGPiikHawvSWAd6mEn1sGG", // Meteora DAMM v2
+  "LBUZKhRxPF3XUpBCjp4YzTKgLccjZhTSDM9YuVaPwxo", // Meteora DLMM
+];
+const BASE_MINTS = [
+  ADDRESSES.solana.SOL,
+  ADDRESSES.solana.USDC,
+  "USD1ttGY1N17NEEHLmELoaybftRBUSErhqYiQzvEmuB", // USD1
+];
+
+// A bonding-curve buy moves the trade principal from the trader to the pool account
+// (plus smaller percentage fees to admin/sub-board/referrer wallets); a sell moves the
+// principal from the pool back to the trader. Per transaction the largest base-token
+// transfer that does not touch the admin fee wallet is the trade principal.
+const fetchSolana = async (options: FetchOptions) => {
+  const rows = await queryAllium(`
+    WITH program_txs AS (
+      SELECT txn_id
+      FROM solana.raw.transactions
+      WHERE block_timestamp >= TO_TIMESTAMP_NTZ(${options.startTimestamp})
+        AND block_timestamp <  TO_TIMESTAMP_NTZ(${options.endTimestamp})
+        AND success = true
+        AND ARRAY_CONTAINS('${SOLANA_PROGRAM}'::VARIANT, account_keys)
+        ${DEX_PROGRAMS.map((p) => `AND NOT ARRAY_CONTAINS('${p}'::VARIANT, account_keys)`).join("\n        ")}
+    ),
+    trade_amounts AS (
+      SELECT tr.txn_id, MAX(tr.usd_amount) AS trade_usd
+      FROM solana.assets.transfers tr
+      JOIN program_txs p ON p.txn_id = tr.txn_id
+      WHERE tr.block_timestamp >= TO_TIMESTAMP_NTZ(${options.startTimestamp})
+        AND tr.block_timestamp <  TO_TIMESTAMP_NTZ(${options.endTimestamp})
+        AND tr.mint IN (${BASE_MINTS.map((m) => `'${m}'`).join(", ")})
+        AND tr.to_address != '${SOLANA_FEE_WALLET}'
+        AND tr.from_address != '${SOLANA_FEE_WALLET}'
+        AND tr.to_address != tr.from_address
+      GROUP BY tr.txn_id
+    )
+    SELECT COALESCE(SUM(trade_usd), 0) AS daily_volume FROM trade_amounts
+  `);
+  return { dailyVolume: Number(rows[0].daily_volume) };
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  adapter: {
+    [CHAIN.SOLANA]: {
+      fetch: fetchSolana,
+      start: "2025-12-24",
+    },
+  },
+  dependencies: [Dependencies.ALLIUM],
+  methodology: {
+    Volume:
+      "Bonding-curve trade volume on BasedBid: per trade, the base-token (SOL/USDC/USD1) amount moved between the trader and the bonding-curve pool. Pool finalization and LP fee claims on Raydium/Meteora are excluded, as post-graduation trading volume belongs to those DEXs.",
+  },
+};
+
+export default adapter;

--- a/dexs/basedbid/index.ts
+++ b/dexs/basedbid/index.ts
@@ -56,12 +56,10 @@ const fetchSolana = async (options: FetchOptions) => {
 
 const adapter: SimpleAdapter = {
   version: 2,
-  adapter: {
-    [CHAIN.SOLANA]: {
-      fetch: fetchSolana,
-      start: "2025-12-24",
-    },
-  },
+  pullHourly: true,
+  chains: [CHAIN.SOLANA],
+  start: "2025-12-24",
+  fetch: fetchSolana,
   dependencies: [Dependencies.ALLIUM],
   methodology: {
     Volume:

--- a/dexs/basedbid/index.ts
+++ b/dexs/basedbid/index.ts
@@ -34,8 +34,8 @@ const fetchSolana = async (options: FetchOptions) => {
       WHERE block_timestamp >= TO_TIMESTAMP_NTZ(${options.startTimestamp})
         AND block_timestamp <  TO_TIMESTAMP_NTZ(${options.endTimestamp})
         AND success = true
-        AND ARRAY_CONTAINS('${SOLANA_PROGRAM}'::VARIANT, account_keys)
-        ${DEX_PROGRAMS.map((p) => `AND NOT ARRAY_CONTAINS('${p}'::VARIANT, account_keys)`).join("\n        ")}
+        AND ARRAY_CONTAINS('${SOLANA_PROGRAM}'::VARIANT, TRANSFORM(account_keys, x -> x:pubkey))
+        ${DEX_PROGRAMS.map((p) => `AND NOT ARRAY_CONTAINS('${p}'::VARIANT, TRANSFORM(account_keys, x -> x:pubkey))`).join("\n        ")}
     ),
     trade_amounts AS (
       SELECT tr.txn_id, MAX(tr.usd_amount) AS trade_usd
@@ -50,7 +50,9 @@ const fetchSolana = async (options: FetchOptions) => {
       GROUP BY tr.txn_id
     )
     SELECT COALESCE(SUM(trade_usd), 0) AS daily_volume FROM trade_amounts
-  `);
+    `
+  )
+
   return { dailyVolume: Number(rows[0].daily_volume) };
 };
 

--- a/fees/basedbid/index.ts
+++ b/fees/basedbid/index.ts
@@ -1,5 +1,6 @@
-import { FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { Dependencies, FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
+import { queryAllium } from "../../helpers/allium";
 import { AbiCoder, keccak256 } from "ethers";
 
 const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
@@ -48,6 +49,36 @@ const chainConfig: Record<string, { TREASURY_CONTRACT: string; CORE_CONTRACT: st
     fromBlock: 4791637,
   },
 }
+
+// Solana: the BasedBid program transfers the protocol's share of creation/trading/
+// finalize/LP-claim fees (WSOL/USDC/USD1) to the hardcoded admin fee wallet. The wallet
+// also collects fees for other products of the team, so inflows are restricted to
+// transactions that include the BasedBid program. Sub-board, meme-owner and referral
+// shares are paid directly to per-token wallets and are not tracked here.
+const SOLANA_PROGRAM = "CuodpYRDz4k87K6ZUFxk7X8JkVv5dNVZAcTQX2TEzTef";
+const SOLANA_FEE_WALLET = "8umVV7k9HoVm4yy5DiRtKSH5qbKtw8xWDARGX8QiLfLe";
+
+const fetchSolana = async (options: FetchOptions) => {
+  const rows = await queryAllium(`
+    SELECT COALESCE(SUM(tr.usd_amount), 0) AS daily_fees
+    FROM solana.assets.transfers tr
+    JOIN solana.raw.transactions tx ON tx.txn_id = tr.txn_id
+    WHERE tr.block_timestamp >= TO_TIMESTAMP_NTZ(${options.startTimestamp})
+      AND tr.block_timestamp <  TO_TIMESTAMP_NTZ(${options.endTimestamp})
+      AND tx.block_timestamp >= TO_TIMESTAMP_NTZ(${options.startTimestamp})
+      AND tx.block_timestamp <  TO_TIMESTAMP_NTZ(${options.endTimestamp})
+      AND tr.to_address = '${SOLANA_FEE_WALLET}'
+      AND tr.from_address != '${SOLANA_FEE_WALLET}'
+      AND tx.success = true
+      AND ARRAY_CONTAINS('${SOLANA_PROGRAM}'::VARIANT, tx.account_keys)
+  `);
+  const dailyFees = Number(rows[0].daily_fees);
+  return {
+    dailyFees,
+    dailyRevenue: dailyFees,
+    dailyProtocolRevenue: dailyFees,
+  };
+};
 
 const METRICS = {
   treasuryRevenue: "Treasury Revenue",
@@ -360,13 +391,20 @@ const adapter: SimpleAdapter = {
   version: 2,
   pullHourly: true,
   fetch,
-  adapter: chainConfig,
+  dependencies: [Dependencies.ALLIUM],
+  adapter: {
+    ...chainConfig,
+    [CHAIN.SOLANA]: {
+      fetch: fetchSolana,
+      start: "2025-12-24",
+    },
+  },
   methodology: {
     Fees:
-      "Fees include treasury revenue, BasedBid core fee-recipient events, and BasedBid V4/PCS hook distribution events priced by token.",
-    Revenue: "Revenue is measured only from FeeCollected inflows emitted by the treasury contract.",
-    ProtocolRevenue: "Protocol revenue equals treasury FeeCollected inflows.",
-    SupplySideRevenue: "Includes all fees collected from liquidity added, buyback, reward distributed, and custom wallet fees.",
+      "Fees include treasury revenue, BasedBid core fee-recipient events, and BasedBid V4/PCS hook distribution events priced by token. On Solana, fees are the protocol fee share (creation, trading, finalize and LP-claim fees) received by the BasedBid admin fee wallet in transactions involving the BasedBid program.",
+    Revenue: "Revenue is measured only from FeeCollected inflows emitted by the treasury contract. On Solana, revenue equals tokens received by the BasedBid admin fee wallet in transactions involving the BasedBid program.",
+    ProtocolRevenue: "Protocol revenue equals treasury FeeCollected inflows. On Solana, protocol revenue equals tokens received by the BasedBid admin fee wallet in transactions involving the BasedBid program.",
+    SupplySideRevenue: "Includes all fees collected from liquidity added, buyback, reward distributed, and custom wallet fees. Not tracked on Solana.",
   },
   breakdownMethodology: {
     Fees: {

--- a/fees/basedbid/index.ts
+++ b/fees/basedbid/index.ts
@@ -56,19 +56,14 @@ const chainConfig: Record<string, { TREASURY_CONTRACT: string; CORE_CONTRACT: st
 // also collects fees for other products of the team, so inflows are restricted to
 // transactions that include the BasedBid program.
 //
-// Supply side: in each bonding-curve trade the sub-board, meme-owner and referral fee
-// shares are paid as separate base-token transfer legs next to the trade principal
-// (the largest leg). Per trade transaction, SUM(non-admin legs) - MAX(principal leg)
-// therefore equals the supply-side payouts. Transactions touching Raydium/Meteora
-// programs are excluded from that measurement (finalization/LP flows, not trades).
+// Only the protocol fee share is counted. The sub-board, meme-owner and referral fee
+// shares are paid directly to per-token wallets configured at token creation; they
+// cannot be isolated from transfer data alone (a trade also contains the principal leg
+// and temporary WSOL account funding, either of which can exceed the fee legs), and
+// there is no decoded model for this program to read the split from. Solana fees are
+// therefore a conservative undercount limited to the protocol share.
 const SOLANA_PROGRAM = "CuodpYRDz4k87K6ZUFxk7X8JkVv5dNVZAcTQX2TEzTef";
 const SOLANA_FEE_WALLET = "8umVV7k9HoVm4yy5DiRtKSH5qbKtw8xWDARGX8QiLfLe";
-const SOLANA_DEX_PROGRAMS = [
-  "CPMMoo8L3F4NbTegBCKVNunggL7H1ZpdTHKxQB5qKP1C", // Raydium CPMM
-  "CAMMCzo5YL8w4VFF8KVHrK22GGUsp5VTaW7grrKgrWqK", // Raydium CLMM
-  "cpamdpZCGKUy5JxQXB4dcpGPiikHawvSWAd6mEn1sGG", // Meteora DAMM v2
-  "LBUZKhRxPF3XUpBCjp4YzTKgLccjZhTSDM9YuVaPwxo", // Meteora DLMM
-];
 const SOLANA_FEE_MINTS = [
   ADDRESSES.solana.SOL,
   ADDRESSES.solana.USDC,
@@ -76,59 +71,30 @@ const SOLANA_FEE_MINTS = [
 ];
 
 const fetchSolana = async (options: FetchOptions) => {
-  const timeFilter = (alias: string) => `
-      ${alias}.block_timestamp >= TO_TIMESTAMP_NTZ(${options.startTimestamp})
-      AND ${alias}.block_timestamp < TO_TIMESTAMP_NTZ(${options.endTimestamp})`;
-  const mintFilter = SOLANA_FEE_MINTS.map((m) => `'${m}'`).join(", ");
-
   const rows = await queryAllium(`
     WITH program_txs AS (
       SELECT txn_id
-      FROM solana.raw.transactions tx
-      WHERE ${timeFilter("tx")}
-        AND tx.success = true
+      FROM solana.raw.transactions
+      WHERE block_timestamp >= TO_TIMESTAMP_NTZ(${options.startTimestamp})
+        AND block_timestamp <  TO_TIMESTAMP_NTZ(${options.endTimestamp})
+        AND success = true
         AND ARRAY_CONTAINS('${SOLANA_PROGRAM}'::VARIANT, TRANSFORM(account_keys, x -> x:pubkey))
-    ),
-    trade_txs AS (
-      SELECT txn_id
-      FROM solana.raw.transactions tx
-      WHERE ${timeFilter("tx")}
-        AND tx.success = true
-        AND ARRAY_CONTAINS('${SOLANA_PROGRAM}'::VARIANT, TRANSFORM(tx.account_keys, x -> x:pubkey))
-        ${SOLANA_DEX_PROGRAMS.map((p) => `AND NOT ARRAY_CONTAINS('${p}'::VARIANT, TRANSFORM(tx.account_keys, x -> x:pubkey))`).join("\n        ")}
-    ),
-    admin_fees AS (
-      SELECT COALESCE(SUM(tr.usd_amount), 0) AS usd
-      FROM solana.assets.transfers tr
-      JOIN program_txs p ON p.txn_id = tr.txn_id
-      WHERE ${timeFilter("tr")}
-        AND tr.to_address = '${SOLANA_FEE_WALLET}'
-        AND tr.from_address != '${SOLANA_FEE_WALLET}'
-        AND tr.mint IN (${mintFilter})
-    ),
-    trade_legs AS (
-      SELECT tr.txn_id, SUM(tr.usd_amount) AS total_usd, MAX(tr.usd_amount) AS principal_usd
-      FROM solana.assets.transfers tr
-      JOIN trade_txs t ON t.txn_id = tr.txn_id
-      WHERE ${timeFilter("tr")}
-        AND tr.mint IN (${mintFilter})
-        AND tr.to_address != '${SOLANA_FEE_WALLET}'
-        AND tr.from_address != '${SOLANA_FEE_WALLET}'
-        AND tr.to_address != tr.from_address
-      GROUP BY tr.txn_id
     )
-    SELECT
-      (SELECT usd FROM admin_fees) AS admin_usd,
-      (SELECT COALESCE(SUM(total_usd - principal_usd), 0) FROM trade_legs) AS supply_side_usd
+    SELECT COALESCE(SUM(tr.usd_amount), 0) AS daily_fees
+    FROM solana.assets.transfers tr
+    JOIN program_txs p ON p.txn_id = tr.txn_id
+    WHERE tr.block_timestamp >= TO_TIMESTAMP_NTZ(${options.startTimestamp})
+      AND tr.block_timestamp <  TO_TIMESTAMP_NTZ(${options.endTimestamp})
+      AND tr.to_address = '${SOLANA_FEE_WALLET}'
+      AND tr.from_address != '${SOLANA_FEE_WALLET}'
+      AND tr.mint IN (${SOLANA_FEE_MINTS.map((m) => `'${m}'`).join(", ")})
   `);
 
-  const dailyRevenue = Number(rows[0].admin_usd);
-  const dailySupplySideRevenue = Number(rows[0].supply_side_usd);
+  const dailyFees = Number(rows[0].daily_fees);
   return {
-    dailyFees: dailyRevenue + dailySupplySideRevenue,
-    dailyRevenue,
-    dailyProtocolRevenue: dailyRevenue,
-    dailySupplySideRevenue,
+    dailyFees,
+    dailyRevenue: dailyFees,
+    dailyProtocolRevenue: dailyFees,
   };
 };
 
@@ -453,10 +419,10 @@ const adapter: SimpleAdapter = {
   },
   methodology: {
     Fees:
-      "Fees include treasury revenue, BasedBid core fee-recipient events, and BasedBid V4/PCS hook distribution events priced by token. On Solana, fees are the protocol fee share received by the BasedBid admin fee wallet plus the sub-board/meme-owner/referral fee legs paid inside bonding-curve trade transactions.",
+      "Fees include treasury revenue, BasedBid core fee-recipient events, and BasedBid V4/PCS hook distribution events priced by token. On Solana, fees are the protocol fee share (creation, trading, finalize and LP-claim fees) received by the BasedBid admin fee wallet in transactions involving the BasedBid program.",
     Revenue: "Revenue is measured only from FeeCollected inflows emitted by the treasury contract. On Solana, revenue equals tokens received by the BasedBid admin fee wallet in transactions involving the BasedBid program.",
     ProtocolRevenue: "Protocol revenue equals treasury FeeCollected inflows. On Solana, protocol revenue equals tokens received by the BasedBid admin fee wallet in transactions involving the BasedBid program.",
-    SupplySideRevenue: "Includes all fees collected from liquidity added, buyback, reward distributed, and custom wallet fees. On Solana, the sub-board, meme-owner and referral fee transfer legs paid inside bonding-curve trade transactions.",
+    SupplySideRevenue: "Includes all fees collected from liquidity added, buyback, reward distributed, and custom wallet fees. Not tracked on Solana, where sub-board, meme-owner and referral shares are paid directly to per-token wallets.",
   },
   breakdownMethodology: {
     Fees: {

--- a/fees/basedbid/index.ts
+++ b/fees/basedbid/index.ts
@@ -87,15 +87,15 @@ const fetchSolana = async (options: FetchOptions) => {
       FROM solana.raw.transactions tx
       WHERE ${timeFilter("tx")}
         AND tx.success = true
-        AND ARRAY_CONTAINS('${SOLANA_PROGRAM}'::VARIANT, tx.account_keys)
+        AND ARRAY_CONTAINS('${SOLANA_PROGRAM}'::VARIANT, TRANSFORM(account_keys, x -> x:pubkey))
     ),
     trade_txs AS (
       SELECT txn_id
       FROM solana.raw.transactions tx
       WHERE ${timeFilter("tx")}
         AND tx.success = true
-        AND ARRAY_CONTAINS('${SOLANA_PROGRAM}'::VARIANT, tx.account_keys)
-        ${SOLANA_DEX_PROGRAMS.map((p) => `AND NOT ARRAY_CONTAINS('${p}'::VARIANT, tx.account_keys)`).join("\n        ")}
+        AND ARRAY_CONTAINS('${SOLANA_PROGRAM}'::VARIANT, TRANSFORM(tx.account_keys, x -> x:pubkey))
+        ${SOLANA_DEX_PROGRAMS.map((p) => `AND NOT ARRAY_CONTAINS('${p}'::VARIANT, TRANSFORM(tx.account_keys, x -> x:pubkey))`).join("\n        ")}
     ),
     admin_fees AS (
       SELECT COALESCE(SUM(tr.usd_amount), 0) AS usd

--- a/fees/basedbid/index.ts
+++ b/fees/basedbid/index.ts
@@ -1,3 +1,4 @@
+import ADDRESSES from "../../helpers/coreAssets.json";
 import { Dependencies, FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 import { queryAllium } from "../../helpers/allium";
@@ -57,6 +58,11 @@ const chainConfig: Record<string, { TREASURY_CONTRACT: string; CORE_CONTRACT: st
 // shares are paid directly to per-token wallets and are not tracked here.
 const SOLANA_PROGRAM = "CuodpYRDz4k87K6ZUFxk7X8JkVv5dNVZAcTQX2TEzTef";
 const SOLANA_FEE_WALLET = "8umVV7k9HoVm4yy5DiRtKSH5qbKtw8xWDARGX8QiLfLe";
+const SOLANA_FEE_MINTS = [
+  ADDRESSES.solana.SOL,
+  ADDRESSES.solana.USDC,
+  "USD1ttGY1N17NEEHLmELoaybftRBUSErhqYiQzvEmuB", // USD1
+];
 
 const fetchSolana = async (options: FetchOptions) => {
   const rows = await queryAllium(`
@@ -69,6 +75,7 @@ const fetchSolana = async (options: FetchOptions) => {
       AND tx.block_timestamp <  TO_TIMESTAMP_NTZ(${options.endTimestamp})
       AND tr.to_address = '${SOLANA_FEE_WALLET}'
       AND tr.from_address != '${SOLANA_FEE_WALLET}'
+      AND tr.mint IN (${SOLANA_FEE_MINTS.map((m) => `'${m}'`).join(", ")})
       AND tx.success = true
       AND ARRAY_CONTAINS('${SOLANA_PROGRAM}'::VARIANT, tx.account_keys)
   `);

--- a/fees/basedbid/index.ts
+++ b/fees/basedbid/index.ts
@@ -54,10 +54,21 @@ const chainConfig: Record<string, { TREASURY_CONTRACT: string; CORE_CONTRACT: st
 // Solana: the BasedBid program transfers the protocol's share of creation/trading/
 // finalize/LP-claim fees (WSOL/USDC/USD1) to the hardcoded admin fee wallet. The wallet
 // also collects fees for other products of the team, so inflows are restricted to
-// transactions that include the BasedBid program. Sub-board, meme-owner and referral
-// shares are paid directly to per-token wallets and are not tracked here.
+// transactions that include the BasedBid program.
+//
+// Supply side: in each bonding-curve trade the sub-board, meme-owner and referral fee
+// shares are paid as separate base-token transfer legs next to the trade principal
+// (the largest leg). Per trade transaction, SUM(non-admin legs) - MAX(principal leg)
+// therefore equals the supply-side payouts. Transactions touching Raydium/Meteora
+// programs are excluded from that measurement (finalization/LP flows, not trades).
 const SOLANA_PROGRAM = "CuodpYRDz4k87K6ZUFxk7X8JkVv5dNVZAcTQX2TEzTef";
 const SOLANA_FEE_WALLET = "8umVV7k9HoVm4yy5DiRtKSH5qbKtw8xWDARGX8QiLfLe";
+const SOLANA_DEX_PROGRAMS = [
+  "CPMMoo8L3F4NbTegBCKVNunggL7H1ZpdTHKxQB5qKP1C", // Raydium CPMM
+  "CAMMCzo5YL8w4VFF8KVHrK22GGUsp5VTaW7grrKgrWqK", // Raydium CLMM
+  "cpamdpZCGKUy5JxQXB4dcpGPiikHawvSWAd6mEn1sGG", // Meteora DAMM v2
+  "LBUZKhRxPF3XUpBCjp4YzTKgLccjZhTSDM9YuVaPwxo", // Meteora DLMM
+];
 const SOLANA_FEE_MINTS = [
   ADDRESSES.solana.SOL,
   ADDRESSES.solana.USDC,
@@ -65,25 +76,59 @@ const SOLANA_FEE_MINTS = [
 ];
 
 const fetchSolana = async (options: FetchOptions) => {
+  const timeFilter = (alias: string) => `
+      ${alias}.block_timestamp >= TO_TIMESTAMP_NTZ(${options.startTimestamp})
+      AND ${alias}.block_timestamp < TO_TIMESTAMP_NTZ(${options.endTimestamp})`;
+  const mintFilter = SOLANA_FEE_MINTS.map((m) => `'${m}'`).join(", ");
+
   const rows = await queryAllium(`
-    SELECT COALESCE(SUM(tr.usd_amount), 0) AS daily_fees
-    FROM solana.assets.transfers tr
-    JOIN solana.raw.transactions tx ON tx.txn_id = tr.txn_id
-    WHERE tr.block_timestamp >= TO_TIMESTAMP_NTZ(${options.startTimestamp})
-      AND tr.block_timestamp <  TO_TIMESTAMP_NTZ(${options.endTimestamp})
-      AND tx.block_timestamp >= TO_TIMESTAMP_NTZ(${options.startTimestamp})
-      AND tx.block_timestamp <  TO_TIMESTAMP_NTZ(${options.endTimestamp})
-      AND tr.to_address = '${SOLANA_FEE_WALLET}'
-      AND tr.from_address != '${SOLANA_FEE_WALLET}'
-      AND tr.mint IN (${SOLANA_FEE_MINTS.map((m) => `'${m}'`).join(", ")})
-      AND tx.success = true
-      AND ARRAY_CONTAINS('${SOLANA_PROGRAM}'::VARIANT, tx.account_keys)
+    WITH program_txs AS (
+      SELECT txn_id
+      FROM solana.raw.transactions tx
+      WHERE ${timeFilter("tx")}
+        AND tx.success = true
+        AND ARRAY_CONTAINS('${SOLANA_PROGRAM}'::VARIANT, tx.account_keys)
+    ),
+    trade_txs AS (
+      SELECT txn_id
+      FROM solana.raw.transactions tx
+      WHERE ${timeFilter("tx")}
+        AND tx.success = true
+        AND ARRAY_CONTAINS('${SOLANA_PROGRAM}'::VARIANT, tx.account_keys)
+        ${SOLANA_DEX_PROGRAMS.map((p) => `AND NOT ARRAY_CONTAINS('${p}'::VARIANT, tx.account_keys)`).join("\n        ")}
+    ),
+    admin_fees AS (
+      SELECT COALESCE(SUM(tr.usd_amount), 0) AS usd
+      FROM solana.assets.transfers tr
+      JOIN program_txs p ON p.txn_id = tr.txn_id
+      WHERE ${timeFilter("tr")}
+        AND tr.to_address = '${SOLANA_FEE_WALLET}'
+        AND tr.from_address != '${SOLANA_FEE_WALLET}'
+        AND tr.mint IN (${mintFilter})
+    ),
+    trade_legs AS (
+      SELECT tr.txn_id, SUM(tr.usd_amount) AS total_usd, MAX(tr.usd_amount) AS principal_usd
+      FROM solana.assets.transfers tr
+      JOIN trade_txs t ON t.txn_id = tr.txn_id
+      WHERE ${timeFilter("tr")}
+        AND tr.mint IN (${mintFilter})
+        AND tr.to_address != '${SOLANA_FEE_WALLET}'
+        AND tr.from_address != '${SOLANA_FEE_WALLET}'
+        AND tr.to_address != tr.from_address
+      GROUP BY tr.txn_id
+    )
+    SELECT
+      (SELECT usd FROM admin_fees) AS admin_usd,
+      (SELECT COALESCE(SUM(total_usd - principal_usd), 0) FROM trade_legs) AS supply_side_usd
   `);
-  const dailyFees = Number(rows[0].daily_fees);
+
+  const dailyRevenue = Number(rows[0].admin_usd);
+  const dailySupplySideRevenue = Number(rows[0].supply_side_usd);
   return {
-    dailyFees,
-    dailyRevenue: dailyFees,
-    dailyProtocolRevenue: dailyFees,
+    dailyFees: dailyRevenue + dailySupplySideRevenue,
+    dailyRevenue,
+    dailyProtocolRevenue: dailyRevenue,
+    dailySupplySideRevenue,
   };
 };
 
@@ -408,10 +453,10 @@ const adapter: SimpleAdapter = {
   },
   methodology: {
     Fees:
-      "Fees include treasury revenue, BasedBid core fee-recipient events, and BasedBid V4/PCS hook distribution events priced by token. On Solana, fees are the protocol fee share (creation, trading, finalize and LP-claim fees) received by the BasedBid admin fee wallet in transactions involving the BasedBid program.",
+      "Fees include treasury revenue, BasedBid core fee-recipient events, and BasedBid V4/PCS hook distribution events priced by token. On Solana, fees are the protocol fee share received by the BasedBid admin fee wallet plus the sub-board/meme-owner/referral fee legs paid inside bonding-curve trade transactions.",
     Revenue: "Revenue is measured only from FeeCollected inflows emitted by the treasury contract. On Solana, revenue equals tokens received by the BasedBid admin fee wallet in transactions involving the BasedBid program.",
     ProtocolRevenue: "Protocol revenue equals treasury FeeCollected inflows. On Solana, protocol revenue equals tokens received by the BasedBid admin fee wallet in transactions involving the BasedBid program.",
-    SupplySideRevenue: "Includes all fees collected from liquidity added, buyback, reward distributed, and custom wallet fees. Not tracked on Solana.",
+    SupplySideRevenue: "Includes all fees collected from liquidity added, buyback, reward distributed, and custom wallet fees. On Solana, the sub-board, meme-owner and referral fee transfer legs paid inside bonding-curve trade transactions.",
   },
   breakdownMethodology: {
     Fees: {


### PR DESCRIPTION
BasedBid (based.bid) is already listed with fees/revenue on its EVM chains (Ethereum, BSC, Base, MegaETH, Robinhood). This PR adds the Solana part (protocol already listed, so the new-listing form is omitted per template note 2).

**`fees/basedbid` - Solana fees & revenue**
- On Solana the BasedBid program (`CuodpYRDz4k87K6ZUFxk7X8JkVv5dNVZAcTQX2TEzTef`) transfers the protocol's fee share (creation, trading, finalize and LP-claim fees, paid in WSOL/USDC/USD1) to the hardcoded admin fee wallet `8umVV7k9HoVm4yy5DiRtKSH5qbKtw8xWDARGX8QiLfLe`.
- That wallet also collects fees for other products of the team, so instead of raw wallet inflows the adapter uses an Allium query that only counts inflows from transactions that include the BasedBid program (same pattern as `dexs/moonshot-money`).
- Reported as dailyFees = dailyRevenue = dailyProtocolRevenue. Sub-board / meme-owner / referral fee shares are paid directly to per-token wallets and are not tracked.
- Start: 2025-12-24 (first mainnet transaction of the program).

**`dexs/basedbid` - Solana bonding-curve volume (new adapter)**
- Per trade, the principal is the largest base-token (SOL/USDC/USD1) transfer between the trader and the bonding-curve pool, excluding transfers touching the admin fee wallet and self-transfers (SOL wrapping).
- Transactions that also touch Raydium CPMM/CLMM or Meteora DAMM/DLMM are excluded - those are pool finalizations / LP fee claims, and post-graduation trading volume belongs to those DEXs.

Could not run the Allium queries locally (no API key), please rely on the CI bot results. EVM chains are unchanged (Solana has its own per-chain fetch).