### PR TITLE
Add LiquidBots volume adapter

### DIFF
--- a/dexs/liquidbots.ts
+++ b/dexs/liquidbots.ts
@@ -1,0 +1,43 @@
+import { FetchOptions, SimpleAdapter } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+import { httpGet } from "../utils/fetchURL";
+
+// LiquidBots — automated grid-trading bots on Hyperliquid perps.
+// Daily trading volume (filled-order notional the bots executed), from the protocol's
+// public stats endpoint (same source/methodology family as the fees adapter).
+const STATS_URL = "https://api.liquidbots.xyz/api/v1/stats/volume";
+
+interface VolumeDay {
+  date: string; // UTC day, "YYYY-MM-DD"
+  volume: number; // filled-order notional that day, in USD
+}
+
+const fetch = async (options: FetchOptions) => {
+  const res = await httpGet(STATS_URL);
+  const row: VolumeDay | undefined = (res?.daily || []).find(
+    (d: VolumeDay) => d.date === options.dateString,
+  );
+  const rawVolume: unknown = row?.volume;
+  const volume =
+    (typeof rawVolume === "number" || typeof rawVolume === "string") &&
+    (typeof rawVolume !== "string" || rawVolume.trim() !== "")
+      ? Number(rawVolume)
+      : NaN;
+  // A negative can't be filled-order notional — reject it alongside missing/non-finite.
+  if (!row || !Number.isFinite(volume) || volume < 0)
+    throw new Error(`No data found for date: ${options.dateString}`);
+  return { dailyVolume: volume };
+};
+
+const adapter: SimpleAdapter = {
+  version: 1,
+  fetch,
+  chains: [CHAIN.HYPERLIQUID],
+  start: '2026-02-10', // first day reported by /stats/volume
+  methodology: {
+    Volume:
+      "Total filled-order notional (filled quantity x fill price) executed by LiquidBots' grid/DCA/arbitrage bots on Hyperliquid perps.",
+  },
+};
+
+export default adapter;

--- a/dexs/liquidbots.ts
+++ b/dexs/liquidbots.ts
@@ -38,6 +38,7 @@ const adapter: SimpleAdapter = {
     Volume:
       "Total filled-order notional (filled quantity x fill price) executed by LiquidBots' grid/DCA/arbitrage bots on Hyperliquid perps.",
   },
+  doublecounted: true, // double counted with hyperliquid
 };
 
 export default adapter;


### PR DESCRIPTION
## LiquidBots — volume adapter

LiquidBots runs non-custodial automated grid / DCA / arbitrage bots on Hyperliquid
perps — users trade through their own agent-wallet LqTrader accounts. The TVL adapter
(`projects/liquidbots`) and fees adapter (`fees/liquidbots.ts`) are already merged;
this adds the **volume** dimension.

### What it reports
`dailyVolume` — the total notional the bots executed that UTC day.

### Methodology
`volume` = filled-order notional (`filled_quantity × fill_price`) summed across every
user's bots, served by the protocol's public stats endpoint:
`https://api.liquidbots.xyz/api/v1/stats/volume`

Same source/methodology family as the merged fees adapter (`fees/liquidbots.ts`), which
reads the sibling `/stats/fees` endpoint.

### Note on dimension
This is **perp notional executed on Hyperliquid**. I placed it under `dexs/` (the general
volume dimension); happy to move it to a perps/derivatives dimension if you'd prefer.

Site: https://liquidbots.xyz · X: https://x.com/liquidbots