### PR TITLE
hyperliquid-perp: builder fees counted twice in dailyFees

### DIFF
--- a/dexs/hyperliquid-perp/index.ts
+++ b/dexs/hyperliquid-perp/index.ts
@@ -72,6 +72,7 @@ async function fetch(options: FetchOptions): Promise<FetchResultV2> {
 
     // all perp fees
     dailyFees.add(result.dailyPerpRevenue, 'Perp Fees') // = hyperliquid fees + deployer fees
+    dailyFees.add(result.dailyBuildersRevenue.clone(-1), 'Perp Fees')
     dailyFees.add(result.dailyBuildersRevenue, 'Builder Code Fees')
     // dailyFees.add(result.dailyPriorityFeesUsd, 'Priority Fees')
 


### PR DESCRIPTION
Fixes #8318

on hyperliquid-perp, dailyFees exceeds dailyRevenue + dailySupplySideRevenue by exactly buildersRevenue every day (~9%, ~$5.1m/30d). spot and hlp reconcile to 0% with the same helper.

## root cause

the indexer's `perpsFeeByTokens` (what `dailyPerpRevenue` sums) already includes builder fees, the helper relies on that when it computes hyperliquid's net take as `perpRevenue - builders - deployers - rebates` (helpers/hyperliquid.ts:429). the adapter then adds `dailyBuildersRevenue` on top of `dailyPerpRevenue` a second time when building dailyFees, so builder fees are counted twice in the total.

## how i verified which side is wrong

the ambiguity was whether perpsFeeByTokens includes builders (then Fees is inflated) or excludes them (then the helper's line 429 over-subtracts and Revenue is understated). the assistance fund settles it: Revenue is defined as the 99% share that the AF uses to buy HYPE, and the AF's actual HYPE accumulation is public (`0xfefe...fefe`, via hypurrscan holdersAtTime + coins.llama.fi daily prices).

over 07-14 to 07-28 (14 days):

| | usd |
|---|---|
| AF actual HYPE bought | $15.48m |
| predicted if current revenue math is right (perp rev + spot rev) | $15.83m (ratio 0.978) |
| predicted if builders were wrongly subtracted at 429 | $17.88m (ratio 0.866) |

the AF matches the current revenue math within ~2% (buyback lag + price timing), and is 13% below the alternative. so the helper is right and the fees line is the double count.

## fix

net builders out of the 'Perp Fees' breakdown label and keep them under 'Builder Code Fees', so dailyFees totals `perpsFeeByTokens` exactly and Fees = Revenue + SupplySideRevenue reconciles. no change to revenue, supply side, holders, or volume. same `clone(-1)` labeled-netting pattern as fees/dyli.

using 07-27 published numbers: fees go from $2.153m to $1.943m, and Fees − (Rev + SS) goes from $210k to $0.
