### PR TITLE
[add] hololaunch - fees adapter

### DIFF
--- a/fees/hololaunch/index.ts
+++ b/fees/hololaunch/index.ts
@@ -37,6 +37,9 @@ const eventCollect =
 const LAUNCH_FEE_LABEL = "Token Launch Fees";
 const LP_FEE_LABEL = "LP Fees of Graduated Tokens";
 
+// the flat launch fee changes only via admin action - fetch it once per run
+let cachedLaunchFee: Promise<any> | undefined;
+
 async function fetch(options: FetchOptions) {
   const dailyFees = options.createBalances();
   const dailyRevenue = options.createBalances();
@@ -55,27 +58,27 @@ async function fetch(options: FetchOptions) {
   if (!curves.length)
     return { dailyFees, dailyRevenue, dailyProtocolRevenue: dailyRevenue, dailySupplySideRevenue };
 
+  const trades = await options.getLogs({
+    targets: curves,
+    eventAbi: eventReserveUpdated,
+    onlyArgs: false,
+  });
+
   // each launched token pays a flat one-time fee (0.001 ETH, HoloLaunch.getLaunchFee())
   // that goes 100% to the protocol. It is charged at deploy when the creator makes an
   // initial purchase (which emits ReserveUpdated from the constructor), otherwise it is
-  // deducted from the token's first buy - in both cases the fee is paid in the same tx
-  // as the curve's first-ever ReserveUpdated event, so we count a launch fee for every
-  // curve whose first trade falls inside the window.
-  const allTrades = await options.getLogs({
-    targets: curves,
-    eventAbi: eventReserveUpdated,
-    fromBlock: START_BLOCK,
-    cacheInCloud: true,
-    flatten: false,
-    onlyArgs: false,
-  });
-  const [windowFromBlock, windowToBlock] = await Promise.all([options.getFromBlock(), options.getToBlock()]);
-  const launchFeesPaid = allTrades.filter((logs: any[]) => {
-    if (!logs?.length) return false;
-    const firstBlock = Math.min(...logs.map((log: any) => Number(log.blockNumber)));
-    return firstBlock >= windowFromBlock && firstBlock < windowToBlock;
-  }).length;
-  const launchFee = await options.api.call({ target: HOLOLAUNCH_FACTORY, abi: "uint256:getLaunchFee" });
+  // deducted from the token's first buy. Either way the payer is the first buy on a
+  // curve whose public launchFeePaid flag was still false (or the curve not yet
+  // deployed, resolved as null via permitFailure) at the start of the window.
+  const curvesWithBuys: string[] = [
+    ...new Set(trades.filter((log: any) => log.args.isBuy).map((log: any) => log.address as string)),
+  ];
+  const paidBefore = curvesWithBuys.length
+    ? await options.fromApi.multiCall({ calls: curvesWithBuys, abi: "bool:launchFeePaid", permitFailure: true })
+    : [];
+  const launchFeesPaid = curvesWithBuys.filter((_, i) => !paidBefore[i]).length;
+  cachedLaunchFee ??= options.api.call({ target: HOLOLAUNCH_FACTORY, abi: "uint256:getLaunchFee" });
+  const launchFee = await cachedLaunchFee;
   dailyFees.addGasToken(Number(launchFee) * launchFeesPaid, LAUNCH_FEE_LABEL);
   dailyRevenue.addGasToken(Number(launchFee) * launchFeesPaid, LAUNCH_FEE_LABEL);
 
@@ -83,9 +86,6 @@ async function fetch(options: FetchOptions) {
   // same tx as TokenDeployed, and logs the net (post-fee) amount
   const deployTxs = new Set(allDeploys.map((log: any) => log.transactionHash));
 
-  const trades = allTrades
-    .flat()
-    .filter((log: any) => Number(log.blockNumber) >= windowFromBlock && Number(log.blockNumber) < windowToBlock);
   for (const log of trades) {
     let fee: number;
     if (log.args.isBuy) {

--- a/fees/hololaunch/index.ts
+++ b/fees/hololaunch/index.ts
@@ -67,7 +67,7 @@ async function fetch(options: FetchOptions) {
     await options.getLogs({
       eventAbi: eventReserveUpdated,
       topics: [topicReserveUpdated],
-      noTarget: true,
+      noTarget: true, // curveSet would have too many targets, noTarget is faster
       entireLog: true,
       parseLog: true,
     })
@@ -115,7 +115,7 @@ async function fetch(options: FetchOptions) {
     await options.getLogs({
       eventAbi: eventTransferLiquidityToDex,
       topics: [topicTransferLiquidityToDex],
-      noTarget: true,
+      noTarget: true, // curveSet would have too many targets, noTarget is faster
       entireLog: true,
       parseLog: true,
       fromBlock: START_BLOCK,
@@ -153,8 +153,8 @@ async function fetch(options: FetchOptions) {
 
 const methodology = {
   Fees: "Users pay a 1% fee in ETH on every bonding-curve buy and sell, plus a one-time 0.001 ETH launch fee per token. After a token graduates (6.9 ETH raised) its liquidity is locked in a full-range Uniswap V3 position whose LP fees accrue to the protocol.",
-  Revenue: "70% of bonding-curve trading fees, all launch fees, and the claimed LP fees of graduated tokens' locked liquidity positions.",
-  ProtocolRevenue: "Same as Revenue: all revenue goes to the protocol treasury.",
+  Revenue: "70% of bonding-curve trading fees, all launch fees (0.001 ETH per token), and the claimed LP fees of graduated tokens' locked liquidity positions.",
+  ProtocolRevenue: "70% of the 1% bonding-curve trading fee, all launch fees (0.001 ETH per token), and the claimed LP fees of graduated tokens' locked liquidity positions.",
   SupplySideRevenue: "30% of bonding-curve trading fees, paid instantly to token creators.",
 };
 
@@ -182,6 +182,7 @@ const adapter: SimpleAdapter = {
   start: "2026-07-14",
   methodology,
   breakdownMethodology,
+  doublecounted: true, // uniswap
 };
 
 export default adapter;

--- a/fees/hololaunch/index.ts
+++ b/fees/hololaunch/index.ts
@@ -48,34 +48,44 @@ async function fetch(options: FetchOptions) {
     eventAbi: eventTokenDeployed,
     fromBlock: START_BLOCK,
     cacheInCloud: true,
+    onlyArgs: false,
   });
-  const curves: string[] = allDeploys.map((log: any) => log.tokenAddr);
+  const curves: string[] = allDeploys.map((log: any) => log.args.tokenAddr);
 
   if (!curves.length)
     return { dailyFees, dailyRevenue, dailyProtocolRevenue: dailyRevenue, dailySupplySideRevenue };
 
-  // tokens launched within the window: each launch pays a flat one-time fee
-  // (0.001 ETH, HoloLaunch.getLaunchFee()) that goes 100% to the protocol.
-  // The fee is charged at deploy, or deducted from the first buy when the
-  // creator made no initial purchase - we count it at deploy time.
-  const windowDeploys = await options.getLogs({
-    target: HOLOLAUNCH_FACTORY,
-    eventAbi: eventTokenDeployed,
+  // each launched token pays a flat one-time fee (0.001 ETH, HoloLaunch.getLaunchFee())
+  // that goes 100% to the protocol. It is charged at deploy when the creator makes an
+  // initial purchase (which emits ReserveUpdated from the constructor), otherwise it is
+  // deducted from the token's first buy - in both cases the fee is paid in the same tx
+  // as the curve's first-ever ReserveUpdated event, so we count a launch fee for every
+  // curve whose first trade falls inside the window.
+  const allTrades = await options.getLogs({
+    targets: curves,
+    eventAbi: eventReserveUpdated,
+    fromBlock: START_BLOCK,
+    cacheInCloud: true,
+    flatten: false,
     onlyArgs: false,
   });
+  const [windowFromBlock, windowToBlock] = await Promise.all([options.getFromBlock(), options.getToBlock()]);
+  const launchFeesPaid = allTrades.filter((logs: any[]) => {
+    if (!logs?.length) return false;
+    const firstBlock = Math.min(...logs.map((log: any) => Number(log.blockNumber)));
+    return firstBlock >= windowFromBlock && firstBlock < windowToBlock;
+  }).length;
   const launchFee = await options.api.call({ target: HOLOLAUNCH_FACTORY, abi: "uint256:getLaunchFee" });
-  dailyFees.addGasToken(Number(launchFee) * windowDeploys.length, LAUNCH_FEE_LABEL);
-  dailyRevenue.addGasToken(Number(launchFee) * windowDeploys.length, LAUNCH_FEE_LABEL);
+  dailyFees.addGasToken(Number(launchFee) * launchFeesPaid, LAUNCH_FEE_LABEL);
+  dailyRevenue.addGasToken(Number(launchFee) * launchFeesPaid, LAUNCH_FEE_LABEL);
 
   // the creator's initial buy is emitted from the token constructor, i.e. in the
   // same tx as TokenDeployed, and logs the net (post-fee) amount
-  const deployTxs = new Set(windowDeploys.map((log: any) => log.transactionHash));
+  const deployTxs = new Set(allDeploys.map((log: any) => log.transactionHash));
 
-  const trades = await options.getLogs({
-    targets: curves,
-    eventAbi: eventReserveUpdated,
-    onlyArgs: false,
-  });
+  const trades = allTrades
+    .flat()
+    .filter((log: any) => Number(log.blockNumber) >= windowFromBlock && Number(log.blockNumber) < windowToBlock);
   for (const log of trades) {
     let fee: number;
     if (log.args.isBuy) {
@@ -156,6 +166,7 @@ const breakdownMethodology = {
 
 const adapter: SimpleAdapter = {
   version: 2,
+  pullHourly: true,
   fetch,
   chains: [CHAIN.ROBINHOOD],
   start: "2026-07-14",

--- a/fees/hololaunch/index.ts
+++ b/fees/hololaunch/index.ts
@@ -1,0 +1,166 @@
+import { FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import { METRIC } from "../../helpers/metrics";
+
+// HoloLaunch factory, deploys one BondingCurveERC20 per launched token
+// https://robinhoodchain.blockscout.com/address/0x5c8884546837066e3F3B573D3cb8B5C9eFbd7C77
+const HOLOLAUNCH_FACTORY = "0x5c8884546837066e3F3B573D3cb8B5C9eFbd7C77";
+// Uniswap V3 NonfungiblePositionManager on Robinhood Chain (graduated liquidity lives here)
+const POSITION_MANAGER = "0x73991a25c818bf1f1128deaab1492d45638de0d3";
+// WETH9 on Robinhood Chain, pair token of every graduated pool
+const WETH = "0x0bd7d308f8e1639fab988df18a8011f41eacad73";
+// Factory deployment block (2026-07-14)
+const START_BLOCK = 9292614;
+
+// Fee constants from BondingCurveERC20.sol:
+// - every bonding-curve buy/sell pays a 1% fee in native ETH
+//   (buy:  fee = amountIn * 1 / 100, sell: fee = outBaseToken * 1 / 100)
+// - the fee is split instantly: 70% to the protocol fee collector, 30% to the token creator
+//   (payable(feeCollector).transfer((fee * 7) / 10); payable(creator).transfer(fee - (fee * 7) / 10))
+const PROTOCOL_SHARE = 0.7;
+const CREATOR_SHARE = 0.3;
+
+const eventTokenDeployed =
+  "event TokenDeployed(address indexed tokenAddr, uint256 indexed tokenId, address indexed creator)";
+// emitted on every bonding-curve trade. For regular buys amountIn is gross (fee = amountIn / 100).
+// For the creator's initial buy (same tx as TokenDeployed) amountIn is net of the 1% fee,
+// and for sells amountOut is net of the 1% fee (fee = net / 99 in both cases).
+const eventReserveUpdated =
+  "event ReserveUpdated(bool isBuy, uint256 amountIn, uint256 amountOut, uint256 baseTokenReserves, uint256 tokenReserves)";
+// emitted when a graduated token's liquidity is moved into the locked full-range Uniswap V3 position
+const eventTransferLiquidityToDex =
+  "event TransferLiquidityToDEX(uint256 positionTokenId)";
+// Uniswap V3 position manager fee collection (the protocol claims LP fees of locked positions)
+const eventCollect =
+  "event Collect(uint256 indexed tokenId, address recipient, uint256 amount0, uint256 amount1)";
+
+const LAUNCH_FEE_LABEL = "Token Launch Fees";
+const LP_FEE_LABEL = "LP Fees of Graduated Tokens";
+
+async function fetch(options: FetchOptions) {
+  const dailyFees = options.createBalances();
+  const dailyRevenue = options.createBalances();
+  const dailySupplySideRevenue = options.createBalances();
+
+  // all bonding curves deployed since launch (each curve contract is also the token itself)
+  const allDeploys = await options.getLogs({
+    target: HOLOLAUNCH_FACTORY,
+    eventAbi: eventTokenDeployed,
+    fromBlock: START_BLOCK,
+    cacheInCloud: true,
+  });
+  const curves: string[] = allDeploys.map((log: any) => log.tokenAddr);
+
+  if (!curves.length)
+    return { dailyFees, dailyRevenue, dailyProtocolRevenue: dailyRevenue, dailySupplySideRevenue };
+
+  // tokens launched within the window: each launch pays a flat one-time fee
+  // (0.001 ETH, HoloLaunch.getLaunchFee()) that goes 100% to the protocol.
+  // The fee is charged at deploy, or deducted from the first buy when the
+  // creator made no initial purchase - we count it at deploy time.
+  const windowDeploys = await options.getLogs({
+    target: HOLOLAUNCH_FACTORY,
+    eventAbi: eventTokenDeployed,
+    onlyArgs: false,
+  });
+  const launchFee = await options.api.call({ target: HOLOLAUNCH_FACTORY, abi: "uint256:getLaunchFee" });
+  dailyFees.addGasToken(Number(launchFee) * windowDeploys.length, LAUNCH_FEE_LABEL);
+  dailyRevenue.addGasToken(Number(launchFee) * windowDeploys.length, LAUNCH_FEE_LABEL);
+
+  // the creator's initial buy is emitted from the token constructor, i.e. in the
+  // same tx as TokenDeployed, and logs the net (post-fee) amount
+  const deployTxs = new Set(windowDeploys.map((log: any) => log.transactionHash));
+
+  const trades = await options.getLogs({
+    targets: curves,
+    eventAbi: eventReserveUpdated,
+    onlyArgs: false,
+  });
+  for (const log of trades) {
+    let fee: number;
+    if (log.args.isBuy) {
+      fee = deployTxs.has(log.transactionHash)
+        ? Number(log.args.amountIn) / 99 // initial buy: amountIn is net of the 1% fee
+        : Number(log.args.amountIn) / 100; // regular buy: amountIn is gross
+    } else {
+      fee = Number(log.args.amountOut) / 99; // sell: amountOut is net of the 1% fee
+    }
+    dailyFees.addGasToken(fee, METRIC.SWAP_FEES);
+    dailyRevenue.addGasToken(fee * PROTOCOL_SHARE, METRIC.SWAP_FEES);
+    dailySupplySideRevenue.addGasToken(fee * CREATOR_SHARE, METRIC.SWAP_FEES);
+  }
+
+  // post-graduation: the LP NFT of every graduated token sits locked in the
+  // LiquidityManager and the protocol periodically claims its Uniswap V3 LP fees
+  const gradLogs = await options.getLogs({
+    targets: curves,
+    eventAbi: eventTransferLiquidityToDex,
+    fromBlock: START_BLOCK,
+    cacheInCloud: true,
+    flatten: false,
+    onlyArgs: false,
+  });
+  const positionToken: Record<string, string> = {};
+  gradLogs.forEach((logs: any[], i: number) => {
+    for (const log of logs ?? []) positionToken[log.args.positionTokenId.toString()] = curves[i];
+  });
+
+  if (Object.keys(positionToken).length) {
+    const collects = await options.getLogs({
+      target: POSITION_MANAGER,
+      eventAbi: eventCollect,
+    });
+    for (const log of collects) {
+      const token = positionToken[log.tokenId.toString()];
+      if (!token) continue;
+      // pool tokens are sorted by address, pair is always token/WETH
+      const [token0, token1] =
+        token.toLowerCase() < WETH.toLowerCase() ? [token, WETH] : [WETH, token];
+      dailyFees.add(token0, log.amount0, LP_FEE_LABEL);
+      dailyFees.add(token1, log.amount1, LP_FEE_LABEL);
+      dailyRevenue.add(token0, log.amount0, LP_FEE_LABEL);
+      dailyRevenue.add(token1, log.amount1, LP_FEE_LABEL);
+    }
+  }
+
+  return {
+    dailyFees,
+    dailyRevenue,
+    dailyProtocolRevenue: dailyRevenue,
+    dailySupplySideRevenue,
+  };
+}
+
+const methodology = {
+  Fees: "Users pay a 1% fee in ETH on every bonding-curve buy and sell, plus a one-time 0.001 ETH launch fee per token. After a token graduates (6.9 ETH raised) its liquidity is locked in a full-range Uniswap V3 position whose LP fees accrue to the protocol.",
+  Revenue: "70% of bonding-curve trading fees, all launch fees, and the claimed LP fees of graduated tokens' locked liquidity positions.",
+  ProtocolRevenue: "Same as Revenue: all revenue goes to the protocol treasury.",
+  SupplySideRevenue: "30% of bonding-curve trading fees, paid instantly to token creators.",
+};
+
+const breakdownMethodology = {
+  Fees: {
+    [METRIC.SWAP_FEES]: "1% fee in ETH on every bonding-curve buy and sell.",
+    [LAUNCH_FEE_LABEL]: "One-time 0.001 ETH fee per launched token.",
+    [LP_FEE_LABEL]: "Uniswap V3 LP fees claimed on graduated tokens' locked liquidity (these swaps also appear under Uniswap).",
+  },
+  Revenue: {
+    [METRIC.SWAP_FEES]: "70% of the 1% bonding-curve trading fee, sent to the protocol fee collector.",
+    [LAUNCH_FEE_LABEL]: "Launch fees go 100% to the protocol fee collector.",
+    [LP_FEE_LABEL]: "LP fees of locked graduated liquidity are claimable only by the protocol.",
+  },
+  SupplySideRevenue: {
+    [METRIC.SWAP_FEES]: "30% of the 1% bonding-curve trading fee, sent instantly to the token creator.",
+  },
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  fetch,
+  chains: [CHAIN.ROBINHOOD],
+  start: "2026-07-14",
+  methodology,
+  breakdownMethodology,
+};
+
+export default adapter;

--- a/fees/hololaunch/index.ts
+++ b/fees/hololaunch/index.ts
@@ -30,6 +30,10 @@ const eventReserveUpdated =
 // emitted when a graduated token's liquidity is moved into the locked full-range Uniswap V3 position
 const eventTransferLiquidityToDex =
   "event TransferLiquidityToDEX(uint256 positionTokenId)";
+// topic0 hashes for the two curve events, used for chain-wide topic scans (one chunked
+// eth_getLogs instead of one request per launched curve)
+const topicReserveUpdated = "0xf69b43589c419cfe01a18f772610b7607315b3c4ae99067295e537260d5e1315";
+const topicTransferLiquidityToDex = "0x4a3e3c33603e83b8c894c2eff0f5ffb67b2ce01e52292366a03dc828b6d5b813";
 // Uniswap V3 position manager fee collection (the protocol claims LP fees of locked positions)
 const eventCollect =
   "event Collect(uint256 indexed tokenId, address recipient, uint256 amount0, uint256 amount1)";
@@ -58,11 +62,16 @@ async function fetch(options: FetchOptions) {
   if (!curves.length)
     return { dailyFees, dailyRevenue, dailyProtocolRevenue: dailyRevenue, dailySupplySideRevenue };
 
-  const trades = await options.getLogs({
-    targets: curves,
-    eventAbi: eventReserveUpdated,
-    onlyArgs: false,
-  });
+  const curveSet = new Set(curves.map((curve) => curve.toLowerCase()));
+  const trades = (
+    await options.getLogs({
+      eventAbi: eventReserveUpdated,
+      topics: [topicReserveUpdated],
+      noTarget: true,
+      entireLog: true,
+      parseLog: true,
+    })
+  ).filter((log: any) => curveSet.has(log.address.toLowerCase()));
 
   // each launched token pays a flat one-time fee (0.001 ETH, HoloLaunch.getLaunchFee())
   // that goes 100% to the protocol. It is charged at deploy when the creator makes an
@@ -102,18 +111,19 @@ async function fetch(options: FetchOptions) {
 
   // post-graduation: the LP NFT of every graduated token sits locked in the
   // LiquidityManager and the protocol periodically claims its Uniswap V3 LP fees
-  const gradLogs = await options.getLogs({
-    targets: curves,
-    eventAbi: eventTransferLiquidityToDex,
-    fromBlock: START_BLOCK,
-    cacheInCloud: true,
-    flatten: false,
-    onlyArgs: false,
-  });
+  const gradLogs = (
+    await options.getLogs({
+      eventAbi: eventTransferLiquidityToDex,
+      topics: [topicTransferLiquidityToDex],
+      noTarget: true,
+      entireLog: true,
+      parseLog: true,
+      fromBlock: START_BLOCK,
+      cacheInCloud: true,
+    })
+  ).filter((log: any) => curveSet.has(log.address.toLowerCase()));
   const positionToken: Record<string, string> = {};
-  gradLogs.forEach((logs: any[], i: number) => {
-    for (const log of logs ?? []) positionToken[log.args.positionTokenId.toString()] = curves[i];
-  });
+  for (const log of gradLogs) positionToken[log.args.positionTokenId.toString()] = log.address;
 
   if (Object.keys(positionToken).length) {
     const collects = await options.getLogs({


### PR DESCRIPTION
Adds a fees & revenue adapter for **HoloLaunch**, an AI-agent token launchpad on Robinhood Chain.

**Protocol info**
- Name: HoloLaunch
- Category: Launchpad
- Chain: Robinhood Chain
- Website: https://www.hololaunch.ai (app: https://app.hololaunch.ai)
- X: https://x.com/holoworldai
- Logo: https://app.hololaunch.ai/brand/hololaunch-logo.svg (PNG 1024px: https://app.hololaunch.ai/brand/hololaunch-logo.png)
- Audit: Quantstamp — https://app.hololaunch.ai/audits/hololaunch-quantstamp-audit.pdf
- Description: Launch and trade AI agents and IPs in a few clicks — from memes to AI idols to agentic apps.

**Methodology**
- Users pay a 1% fee in ETH on every bonding-curve buy and sell, split instantly on-chain: 70% to the protocol fee collector, 30% to the token creator.
- One-time 0.001 ETH launch fee per token, 100% to the protocol.
- After graduation (6.9 ETH raised), liquidity is locked in a full-range Uniswap V3 (fork) position; the protocol claims those LP fees (labelled separately — these swaps also appear under Uniswap).
- All data from on-chain events: `TokenDeployed` (factory), `ReserveUpdated` (bonding curves), `TransferLiquidityToDEX` + position manager `Collect` (graduated LP fees).

**Test output** (`pnpm test fees hololaunch 2026-07-16`):
```
Daily fees: 7.20 k
Daily revenue: 5.19 k
Daily protocol revenue: 5.19 k
Daily supply side revenue: 2.00 k
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)