### PR TITLE
bitfi-btc: add Pharos, 21M of bfBTC currently uncounted

### DIFF
--- a/fees/bitfi-btc.ts
+++ b/fees/bitfi-btc.ts
@@ -29,6 +29,10 @@ const chainConfig: Record<string, config> = {
     token: '0x623F2774d9f27B59bc6b954544487532CE79d9DF',
     start: '2025-03-14',
   },
+  [CHAIN.PHAROS]: {
+    token: '0x623F2774d9f27B59bc6b954544487532CE79d9DF',
+    start: '2026-06-24',
+  },
   [CHAIN.CORE]: {
     token: '0xCdFb58c8C859Cb3F62ebe9Cf2767F9e036C7fb15',
     start: '2025-06-18',


### PR DESCRIPTION
bfBTC has been live on Pharos since 2026-06-24 but the chain is not in `chainConfig`, so none of it is counted. Pharos holds 330.01 bfBTC, about 21.0M, which is roughly 11% of the protocol's 190.9M.

## Why it belongs in this adapter and not the other one

Worth stating since the naming is confusing. The Pharos TVL shows up under the `bitfi-basis` slug, whose TVL module is `bitfi-cedefi/index.js` and whose token is bfBTC. That is this adapter's token. The similarly named `fees/bitfi-basis.ts` tracks a different token (bfUSD `0xa3eB7A9e57FCa4e40b79E394eD5eB37fEd205A24`, Ethereum only) and is not where this goes.

## Verification

Token is the same contract as BSC, Base and Hemi, `0x623F2774d9f27B59bc6b954544487532CE79d9DF`. Binary searched `eth_getCode` to the deploy block, 10713812, timestamp 2026-06-24T03:14:42Z, which is the `start`.

```
totalSupply()   33001014292  (8 decimals) = 330.01 bfBTC
currentEpoch()  35
currentRatio()  90884304     identical to BSC
```

330.01 bfBTC lines up with the 21,028,932 DefiLlama reports for Pharos.

The per-epoch history is populated, so `EpochUpdated` fires there and the existing yield path applies with no code change. `ratio(0)` is 91441111 and it steps down to 90884304 by `ratio(25)`, with `ratio(35)` still 0 as the open epoch. Epoch 0 is the deploy date and there are 35 epochs in 35 days, so it is one epoch per day.

Test runs, Pharos only:

| window | dailyFees | supply side |
| --- | --- | --- |
| 2026-07-14 | 5.86k | 5.86k |
| 2026-07-19 | 7.76k | 7.76k |
| 2026-07-05 | 0 | 0 |

The 0 on 2026-07-05 is correct rather than a miss. `ratio(8)` through `ratio(12)` are all 91240875, so the ratio genuinely did not move that day. Revenue is 0 on all three because no `FeeCollected` fired, there were no withdrawals in those windows.

## Two things to be straight about

The ratio is currently frozen protocol wide, not just on Pharos. Pharos has been flat at 90884304 since epoch 25 and BSC is flat at the same value since around epoch 393. So this reports 0 today, the same as every other chain in this adapter right now, and it starts counting again on its own when the ratio moves.

I could not run the full multi chain test locally. Every public BSC endpoint returns `missing trie node` on the historical `eth_call`. I stashed the change and ran the identical command against unmodified master and got the same failure, so it is pre existing infra and not this change. Pharos was tested in isolation, which is what the table above is.

Pharos block time is about 0.91s, so 95,333 blocks a day, and the free RPCs cap `eth_getLogs` at 1k to 10k blocks. Four other fees adapters already run on `CHAIN.PHAROS`, so this should be fine, but flagging it in case the log range matters at your end.
