### PR TITLE
Add FrostyFi fees adapter

### DIFF
--- a/fees/frostyfi.ts
+++ b/fees/frostyfi.ts
@@ -1,0 +1,99 @@
+// FrostyFi — Fees & Revenue adapter.
+//
+// FrostyFi (https://frostylabs.ai) is a no-code platform for building, deploying and
+// monetizing AI agents on Base. Every product payment — Pro/Enterprise subscriptions,
+// $5 pay-per-deploy, Architect builds and first-party x402 agent income — is pulled in
+// USDC and split on-chain by the FrostyRevenueSplitter in a single transaction:
+// operating / dev / protocol-owned-liquidity reserve / DAO buckets, plus a 3-level
+// affiliate program paid from the same split.
+//
+// Splitter (source-verified): 0x5663213c20dd4d62E6f69ec240FE2f4e88B4dFd6
+//
+//   event PaymentSplit(uint8 indexed streamId, address indexed payer,
+//                      address indexed subscriber, address referrer, uint256 amount)
+//     — one event per product payment, `amount` = gross USDC entering the splitter.
+//   event AffiliateCredited(address indexed referrer, uint8 level,
+//                           address indexed subscriber, uint256 amount)
+//     — the affiliate legs (6% / 2.5% / 1.5%) credited to third-party referrers;
+//       when a payment has no referrer these legs roll into the protocol's
+//       liquidity reserve instead (and no event is emitted).
+//
+//   => dailyFees              = Σ PaymentSplit.amount      [gross product payments]
+//      dailySupplySideRevenue = Σ AffiliateCredited.amount [third-party referrer share]
+//      dailyRevenue           = fees − affiliate           [protocol share: operating,
+//                                                           dev, POL reserve, DAO]
+//      dailyProtocolRevenue   = dailyRevenue
+//
+// Direct USDC donations to the splitter (accounted via `Swept`) are excluded — they
+// are not payments for the product. FrostyFi takes 0% of third-party agents' x402
+// income, so nothing here double-counts external agent earnings.
+
+import ADDRESSES from "../helpers/coreAssets.json";
+import { FetchOptions, SimpleAdapter } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+
+const SPLITTER = "0x5663213c20dd4d62E6f69ec240FE2f4e88B4dFd6";
+const USDC = ADDRESSES.base.USDC;
+
+const PAYMENT_SPLIT =
+  "event PaymentSplit(uint8 indexed streamId, address indexed payer, address indexed subscriber, address referrer, uint256 amount)";
+const AFFILIATE_CREDITED =
+  "event AffiliateCredited(address indexed referrer, uint8 level, address indexed subscriber, uint256 amount)";
+
+const fetch = async (options: FetchOptions) => {
+  const dailyFees = options.createBalances();
+  const dailyRevenue = options.createBalances();
+  const dailySupplySideRevenue = options.createBalances();
+
+  const payments = await options.getLogs({ target: SPLITTER, eventAbi: PAYMENT_SPLIT });
+  const affiliateLegs = await options.getLogs({ target: SPLITTER, eventAbi: AFFILIATE_CREDITED });
+
+  let gross = 0n;
+  let referral = 0n;
+  for (const log of payments) gross += BigInt(log.amount);
+  for (const log of affiliateLegs) referral += BigInt(log.amount);
+
+  dailyFees.add(USDC, gross, "Product payments");
+  dailySupplySideRevenue.add(USDC, referral, "Affiliate payouts");
+  dailyRevenue.add(USDC, gross - referral, "Protocol share");
+
+  return {
+    dailyFees,
+    dailyRevenue,
+    dailyProtocolRevenue: dailyRevenue,
+    dailySupplySideRevenue,
+  };
+};
+
+const methodology = {
+  Fees: "Gross USDC product payments (subscriptions, pay-per-deploy, Architect builds, first-party agent income) entering the on-chain revenue splitter, summed from PaymentSplit events.",
+  Revenue: "The protocol's share of every payment — operating, dev, protocol-owned-liquidity reserve and DAO buckets — i.e. gross payments minus third-party affiliate payouts.",
+  ProtocolRevenue: "Same as Revenue: all non-affiliate buckets are protocol-controlled.",
+  SupplySideRevenue: "The 3-level affiliate share (6% / 2.5% / 1.5%) credited to third-party referrers, from AffiliateCredited events.",
+};
+
+const breakdownMethodology = {
+  Fees: {
+    "Product payments": "Gross USDC entering the FrostyRevenueSplitter via PaymentSplit events — subscriptions, pay-per-deploy, Architect builds and first-party agent income.",
+  },
+  Revenue: {
+    "Protocol share": "Gross payments minus affiliate payouts — the operating, dev, POL reserve and DAO buckets.",
+  },
+  ProtocolRevenue: {
+    "Protocol share": "Gross payments minus affiliate payouts — the operating, dev, POL reserve and DAO buckets.",
+  },
+  SupplySideRevenue: {
+    "Affiliate payouts": "USDC credited to third-party referrers via AffiliateCredited events (3-level: 6% / 2.5% / 1.5%).",
+  },
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  fetch,
+  chains: [CHAIN.BASE],
+  start: "2026-07-26",
+  methodology,
+  breakdownMethodology,
+};
+
+export default adapter;

--- a/fees/frostyfi.ts
+++ b/fees/frostyfi.ts
@@ -55,7 +55,7 @@ const fetch = async (options: FetchOptions) => {
 
   dailyFees.add(USDC, gross, "Product payments");
   dailySupplySideRevenue.add(USDC, referral, "Affiliate payouts");
-  dailyRevenue.add(USDC, gross - referral, "Protocol share");
+  dailyRevenue.add(USDC, gross - referral, "Payments to operating, dev, POL reserve and DAO");
 
   return {
     dailyFees,
@@ -77,10 +77,10 @@ const breakdownMethodology = {
     "Product payments": "Gross USDC entering the FrostyRevenueSplitter via PaymentSplit events — subscriptions, pay-per-deploy, Architect builds and first-party agent income.",
   },
   Revenue: {
-    "Protocol share": "Gross payments minus affiliate payouts — the operating, dev, POL reserve and DAO buckets.",
+    "Payments to operating, dev, POL reserve and DAO": "Gross payments minus affiliate payouts — the operating, dev, POL reserve and DAO buckets.",
   },
   ProtocolRevenue: {
-    "Protocol share": "Gross payments minus affiliate payouts — the operating, dev, POL reserve and DAO buckets.",
+    "Payments to operating, dev, POL reserve and DAO": "Gross payments minus affiliate payouts — the operating, dev, POL reserve and DAO buckets.",
   },
   SupplySideRevenue: {
     "Affiliate payouts": "USDC credited to third-party referrers via AffiliateCredited events (3-level: 6% / 2.5% / 1.5%).",
@@ -89,6 +89,7 @@ const breakdownMethodology = {
 
 const adapter: SimpleAdapter = {
   version: 2,
+  pullHourly: true,
   fetch,
   chains: [CHAIN.BASE],
   start: "2026-07-26",


### PR DESCRIPTION
**NOTE**

#### Please enable "Allow edits by maintainers" while putting up the PR.

---

> - If you would like to add a `tvl` adapter please submit the PR [here](https://github.com/DefiLlama/DefiLlama-Adapters).

1. Once your adapter has been merged, it takes time to show on the UI. If more than 24 hours have passed, please let us know in Discord.
2. Please fill the form below **only if the PR is for listing a new protocol** else it can be ignored/replaced with reason/details about the PR
3. **For updating listing info** Please send a mail to metadata@defillama.com
4. Do not edit/push `package.json/package-lock.json` file as part of your changes
5. No need to go to our discord/other channel and announce that you've created a PR, we monitor all PRs and will review it asap

---

##### Name (to be shown on DefiLlama):
  FrostyFi

  ##### Twitter Link:
  https://x.com/FrostyLabsAi

  ##### List of audit links if any:
  None

  ##### Website Link:
  https://frostylabs.ai

  ##### Logo (High resolution, will be shown with rounded borders):
  https://frostylabs.ai/frostylogo.png

  ##### Current TVL:
  N/A — this PR adds a fees/revenue adapter only (no TVL adapter).

  ##### Treasury Addresses (if the protocol has treasury)
  base:0xad75685B9F297aab468b584bC2E084D7677E58cB (POL reserve — protocol-owned liquidity reserve, never spent)
  base:0x47b7702A4789912d0DFfdaDC07C50395c293ff0a (DAO treasury)

  ##### Chain:
  Base

  ##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed):


  ##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed):


  ##### Short Description (to be shown on DefiLlama):
  No-code platform to build, deploy, and monetize AI agents that charge per call via x402 (USDC) with ERC-8004 onchain
  identity. All product revenue (subscriptions, pay-per-deploy, first-party agents) splits onchain through a source-verified
  revenue splitter that funds protocol-owned liquidity.

  ##### Token address and ticker if any:
  None (no token launched)

  ##### Category (full list at https://defillama.com/categories) *Please choose only one:
  AI Agents

  ##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.):
  None

  ##### Implementation Details: Briefly describe how the oracle is integrated into your project:
  N/A — no oracles. The adapter reads PaymentSplit / AffiliateCredited events from the revenue splitter.

  ##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage:
  Docs: https://docs.frostylabs.ai
  Revenue splitter (source-verified): https://basescan.org/address/0x5663213c20dd4d62E6f69ec240FE2f4e88B4dFd6#code

  ##### forkedFrom (Does your project originate from another project):
  No

  ##### methodology (what is being counted as tvl, how is tvl being calculated):
  No TVL. Fees = gross USDC product payments (subscriptions, pay-per-deploy, Architect builds, first-party agent income)
  entering the onchain FrostyRevenueSplitter, summed from PaymentSplit events. Revenue = fees minus third-party affiliate
  payouts (AffiliateCredited events, 3-level: 6% / 2.5% / 1.5%) — i.e. the operating, dev, POL-reserve and DAO buckets.
  ProtocolRevenue = Revenue; SupplySideRevenue = affiliate payouts.

  ##### Github org/user (Optional, if your code is open source, we can track activity):
  FrostyLabsAi

  ##### Does this project have a referral program?
  Yes — a 3-level onchain affiliate program (6% / 2.5% / 1.5%) paid in USDC directly by the revenue splitter; unclaimed legs
  roll into the protocol-owned liquidity reserve.