### PR TITLE
feat: add Shift Protocol v2 Ethereum vault fees

### DIFF
--- a/fees/shift-protocol/index.ts
+++ b/fees/shift-protocol/index.ts
@@ -8,7 +8,15 @@ const abis = {
   baseToken: "address:baseToken",
   totalSupply: "uint256:totalSupply",
   getSharePrice: "uint256:getSharePrice",
+  // v2 vaults expose the same data under different names, and their fee rates on-chain
+  asset: "address:asset",
+  effectiveSupply: "uint256:effectiveSupply",
+  latestSharePrice: "uint256:latestSharePrice",
+  performanceFee: "uint256:performanceFeeBps",
+  managementFee: "uint256:maintenanceFeeBps",
 };
+
+const FEE_BPS_DIVISOR = 100; // bps -> percent
 
 interface VaultConfig {
   address: string;
@@ -28,6 +36,9 @@ const vaultConfigs: Record<string, VaultConfig[]> = {
     { address: "0x6d7C897cD8B402690C07e7263C9f59B3777ae3c2", managementFee: 0.5, performanceFee: 10, spikes: ["2026-03-04"] }, // vGRVT
     { address: "0x7174f0bD02664BebDB6Aa79a99fAF949570A10bd", managementFee: 2, performanceFee: 20 },   // hibaUSD
   ],
+  [CHAIN.ETHEREUM]: [
+    { address: "0xF4761cC51DC4532b064b7E0Bf0883bcA3F84375e", managementFee: 0, performanceFee: 15 },   // shiftEUR (v2 vault)
+  ],
 };
 
 const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
@@ -40,32 +51,42 @@ const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
 
   const vaultAddresses = chainVaults.map((v) => v.address);
 
-  const [baseTokens, totalSupplies] = await Promise.all([
+  const [baseTokens, assets, totalSupplies, effectiveSupplies, perfFeesOnchain, mgmtFeesOnchain] = await Promise.all([
     options.api.multiCall({ abi: abis.baseToken, calls: vaultAddresses, permitFailure: true }),
+    options.api.multiCall({ abi: abis.asset, calls: vaultAddresses, permitFailure: true }),
     options.api.multiCall({ abi: abis.totalSupply, calls: vaultAddresses, permitFailure: true }),
+    options.api.multiCall({ abi: abis.effectiveSupply, calls: vaultAddresses, permitFailure: true }),
+    options.api.multiCall({ abi: abis.performanceFee, calls: vaultAddresses, permitFailure: true }),
+    options.api.multiCall({ abi: abis.managementFee, calls: vaultAddresses, permitFailure: true }),
   ]);
 
-  const [sharePricesBefore, sharePricesAfter] = await Promise.all([
+  const [sharePricesBefore, sharePricesAfter, latestPricesBefore, latestPricesAfter] = await Promise.all([
     options.fromApi.multiCall({ abi: abis.getSharePrice, calls: vaultAddresses, permitFailure: true }),
     options.toApi.multiCall({ abi: abis.getSharePrice, calls: vaultAddresses, permitFailure: true }),
+    options.fromApi.multiCall({ abi: abis.latestSharePrice, calls: vaultAddresses, permitFailure: true }),
+    options.toApi.multiCall({ abi: abis.latestSharePrice, calls: vaultAddresses, permitFailure: true }),
   ]);
 
   for (let i = 0; i < chainVaults.length; i++) {
     const vault = chainVaults[i];
-    const baseToken = baseTokens[i];
-    const totalSupply = totalSupplies[i];
-    const priceBefore = sharePricesBefore[i];
-    const priceAfter = sharePricesAfter[i];
+    const baseToken = baseTokens[i] ?? assets[i];
+    const totalSupply = totalSupplies[i] ?? effectiveSupplies[i];
+    const priceBefore = sharePricesBefore[i] ?? latestPricesBefore[i];
+    const priceAfter = sharePricesAfter[i] ?? latestPricesAfter[i];
 
     if (!baseToken || !totalSupply || !priceBefore || !priceAfter || vault.spikes?.includes(options.dateString)) continue;
+
+    // v2 vaults expose their fee rates on-chain, v1 vaults fall back to the hardcoded rates
+    const performanceFeePct = perfFeesOnchain[i] != null ? Number(perfFeesOnchain[i]) / FEE_BPS_DIVISOR : vault.performanceFee;
+    const managementFeePct = mgmtFeesOnchain[i] != null ? Number(mgmtFeesOnchain[i]) / FEE_BPS_DIVISOR : vault.managementFee;
 
     if (BigInt(priceBefore) === 0n || BigInt(priceAfter) === 0n) continue;
 
     const priceChange = BigInt(priceAfter) - BigInt(priceBefore);
     const netYield = BigInt(totalSupply) * priceChange / BigInt(1e18);
 
-    if (vault.performanceFee > 0) {
-      const perfFee = BigInt(vault.performanceFee);
+    if (performanceFeePct > 0) {
+      const perfFee = BigInt(Math.round(performanceFeePct));
       const grossYield = netYield * 100n / (100n - perfFee);
       const perfFeeAmount = grossYield - netYield;
 
@@ -77,9 +98,9 @@ const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
       dailySupplySideRevenue.add(baseToken, netYield, METRIC.ASSETS_YIELDS);
     }
 
-    if (vault.managementFee > 0) {
+    if (managementFeePct > 0) {
       const totalAssets = Number(BigInt(totalSupply) * BigInt(priceAfter) / BigInt(1e18));
-      const mgmtFee = totalAssets * (vault.managementFee / 100) * ((options.toTimestamp - options.fromTimestamp) / ONE_YEAR);
+      const mgmtFee = totalAssets * (managementFeePct / 100) * ((options.toTimestamp - options.fromTimestamp) / ONE_YEAR);
 
       dailyFees.add(baseToken, mgmtFee, METRIC.MANAGEMENT_FEES);
       dailyRevenue.add(baseToken, mgmtFee, METRIC.MANAGEMENT_FEES);
@@ -124,6 +145,7 @@ const adapter: Adapter = {
   adapter: {
     [CHAIN.BASE]: { fetch, start: "2025-09-18" },
     [CHAIN.ARBITRUM]: { fetch, start: "2026-02-20" },
+    [CHAIN.ETHEREUM]: { fetch, start: "2026-07-20" },
   },
   pullHourly: true,
   allowNegativeValue: true,


### PR DESCRIPTION
## Summary

- Adds the new **shiftEUR** vault on **Ethereum** to the Shift Protocol fees adapter (originally added in #7270)
- Fee rates are now read **directly on-chain** from the vault contracts (`performanceFee()` / `managementFee()`), with hardcoded fallback for older vaults that don't expose the getters — existing Base and Arbitrum vaults are unaffected
- Yield calculation unchanged: `getSharePrice()` changes between periods

## New vault

| Vault    | Chain    | Management Fee | Performance Fee |
|----------|----------|----------------|-----------------|
| shiftEUR | Ethereum | 0%             | 15%             |

Contract: `0xF4761cC51DC4532b064b7E0Bf0883bcA3F84375e`
