### PR TITLE
uniswap-auctions: track the new CCA factory

### DIFF
--- a/dexs/uniswap-auctions.ts
+++ b/dexs/uniswap-auctions.ts
@@ -4,6 +4,7 @@ import { formatAddress } from "../utils/utils";
 
 const CCA_FACTORY_V1 = "0x0000ccaDF55C911a2FbC0BB9d2942Aa77c6FAa1D";
 const CCA_FACTORY_V1_1 = "0xCCccCcCAE7503Cac057829BF2811De42E16e0bD5";
+const CCA_FACTORY_V1_2 = "0x000000001F26a0044BaA66024e7b6599c61963F8";
 
 const AUCTION_CREATED = "event AuctionCreated(address indexed auction, address indexed token, uint256 amount, bytes configData)";
 const BID_SUBMITTED_V1 = "event BidSubmitted(uint256 indexed id, address indexed owner, uint256 price, uint128 amount)";
@@ -25,6 +26,7 @@ const CONFIGS: Record<string, ChainConfig> = {
     factories: [
       { address: CCA_FACTORY_V1, fromBlock: 23780787 },
       { address: CCA_FACTORY_V1_1, fromBlock: 24321671 },
+      { address: CCA_FACTORY_V1_2, fromBlock: 25503401 },
     ],
   },
   [CHAIN.UNICHAIN]: {
@@ -32,6 +34,7 @@ const CONFIGS: Record<string, ChainConfig> = {
     factories: [
       { address: CCA_FACTORY_V1, fromBlock: 32316559 },
       { address: CCA_FACTORY_V1_1, fromBlock: 38733234 },
+      { address: CCA_FACTORY_V1_2, fromBlock: 52952712 },
     ],
   },
   [CHAIN.BASE]: {
@@ -39,6 +42,7 @@ const CONFIGS: Record<string, ChainConfig> = {
     factories: [
       { address: CCA_FACTORY_V1, fromBlock: 38441212 },
       { address: CCA_FACTORY_V1_1, fromBlock: 41336767 },
+      { address: CCA_FACTORY_V1_2, fromBlock: 48455862 },
     ],
   },
   [CHAIN.ARBITRUM]: {
@@ -46,6 +50,7 @@ const CONFIGS: Record<string, ChainConfig> = {
     factories: [
       { address: CCA_FACTORY_V1, fromBlock: 411868855 },
       { address: CCA_FACTORY_V1_1, fromBlock: 425561184 },
+      { address: CCA_FACTORY_V1_2, fromBlock: 482439583 },
     ],
   },
 };


### PR DESCRIPTION
A third `ContinuousClearingAuctionFactory` was deployed on 2026-07-10 at [`0x000000001F26a0044BaA66024e7b6599c61963F8`](https://basescan.org/address/0x000000001f26a0044baa66024e7b6599c61963f8) and is creating auctions alongside the still-active v1.1 factory, so the adapter was silently skipping them. Latest example: [base tx `0x8aa6de35`](https://basescan.org/tx/0x8aa6de3552ccc820ced8a6d8da1d40cb3d0985ffdd6ef73e8d35aeee2e511aad).

Missed auctions since the deploy: 50 on base, 60 on ethereum, 5 on arbitrum.

No ABI changes were needed:

- `AuctionCreated` topic0 is byte-identical (`0x7ede475f...`)
- auctions from the new factory still emit `BidSubmitted(uint256,address,uint256,uint128)` and `CurrencySwept(address,uint256)`
- `currency()` still resolves

`fromBlock` per chain is the block at the deploy timestamp (2026-07-10 16:31 UTC), which sits below the first observed `AuctionCreated` on each chain.

Verified with `testAdapter` on 2026-07-17, the day a new-factory auction swept 2.7 WETH from `0x51cf3d7d8baca7e932bc496833d0756534482a54`. Base daily volume goes from 0 to 5.06k, other chains unchanged.
