### PR TITLE
Add Textile (on-chain FX DEX) volume adapter

### DIFF
--- a/dexs/textile/index.ts
+++ b/dexs/textile/index.ts
@@ -1,0 +1,61 @@
+import { FetchOptions, FetchResultV2, SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import { httpPost } from "../../utils/fetchURL";
+
+// Textile is an on-chain FX DEX (RFQ-style: market-maker bots quote off-chain
+// prices, swaps settle atomically through a reactor contract — no AMM pools).
+// Volume is read from Textile's public GraphQL API, which serves the protocol's
+// Goldsky-indexed reactor fills with per-trade USD volume (the fill's stable
+// leg), timestamp and chainId. https://docs.textilecredit.com
+const ENDPOINT = "https://api.textilecredit.com/graphql";
+
+const CHAIN_IDS: Record<string, number> = {
+  [CHAIN.ETHEREUM]: 1,
+  [CHAIN.BSC]: 56,
+  [CHAIN.BASE]: 8453,
+  [CHAIN.CELO]: 42220,
+};
+
+const QUERY = `{
+  settlementMakerStats {
+    makers {
+      trades { timestamp chainId volumeUsd }
+    }
+  }
+}`;
+
+async function fetch(options: FetchOptions): Promise<FetchResultV2> {
+  const chainId = CHAIN_IDS[options.chain];
+  const from = options.startOfDay;
+  const to = from + 86400;
+
+  const res = await httpPost(ENDPOINT, { query: QUERY });
+  const makers = res?.data?.settlementMakerStats?.makers ?? [];
+
+  let dailyVolume = 0;
+  for (const m of makers) {
+    for (const t of m.trades ?? []) {
+      if (t.chainId !== chainId) continue;
+      if (t.timestamp < from || t.timestamp >= to) continue;
+      dailyVolume += t.volumeUsd ?? 0;
+    }
+  }
+
+  return { dailyVolume };
+}
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  methodology: {
+    Volume:
+      "Sum of the USD value of the stable (USDT/USDC) leg of every reactor fill on the chain, as indexed from on-chain Fill transactions by the protocol subgraph and served by Textile's public API.",
+  },
+  adapter: {
+    [CHAIN.ETHEREUM]: { fetch, start: "2026-06-07" },
+    [CHAIN.BSC]: { fetch, start: "2026-06-07" },
+    [CHAIN.BASE]: { fetch, start: "2026-06-07" },
+    [CHAIN.CELO]: { fetch, start: "2026-06-07" },
+  },
+};
+
+export default adapter;

--- a/dexs/textile/index.ts
+++ b/dexs/textile/index.ts
@@ -26,8 +26,6 @@ const QUERY = `{
 
 async function fetch(options: FetchOptions): Promise<FetchResultV2> {
   const chainId = CHAIN_IDS[options.chain];
-  const from = options.startOfDay;
-  const to = from + 86400;
 
   const res = await httpPost(ENDPOINT, { query: QUERY });
   const makers = res?.data?.settlementMakerStats?.makers ?? [];
@@ -36,7 +34,7 @@ async function fetch(options: FetchOptions): Promise<FetchResultV2> {
   for (const m of makers) {
     for (const t of m.trades ?? []) {
       if (t.chainId !== chainId) continue;
-      if (t.timestamp < from || t.timestamp >= to) continue;
+      if (t.timestamp < options.fromTimestamp || t.timestamp >= options.toTimestamp) continue;
       dailyVolume += t.volumeUsd ?? 0;
     }
   }
@@ -46,16 +44,14 @@ async function fetch(options: FetchOptions): Promise<FetchResultV2> {
 
 const adapter: SimpleAdapter = {
   version: 2,
+  pullHourly: true,
   methodology: {
     Volume:
       "Sum of the USD value of the stable (USDT/USDC) leg of every reactor fill on the chain, as indexed from on-chain Fill transactions by the protocol subgraph and served by Textile's public API.",
   },
-  adapter: {
-    [CHAIN.ETHEREUM]: { fetch, start: "2026-06-07" },
-    [CHAIN.BSC]: { fetch, start: "2026-06-07" },
-    [CHAIN.BASE]: { fetch, start: "2026-06-07" },
-    [CHAIN.CELO]: { fetch, start: "2026-06-07" },
-  },
+  fetch,
+  chains: Object.keys(CHAIN_IDS),
+  start: "2026-06-07",
 };
 
 export default adapter;


### PR DESCRIPTION
Adds a DEX volume adapter for **Textile**, an on-chain FX liquidity network.

**Site:** https://app.textilecredit.com · **Docs:** https://docs.textilecredit.com · **TVL adapter:** DefiLlama/DefiLlama-Adapters#20256 (open)

**What it is:** RFQ-style FX DEX — market makers ("Stitch" bots) quote both sides of each corridor from off-chain price feeds; swaps settle atomically through a reactor contract (UniswapX-style, no AMM pools). Pairs: cNGN/USDT, cNGN/USDC, wARS/USDT, wBRL/USDT, XAUt/USDT, WETH/USDT across Ethereum, BSC, Base, Celo.

**Methodology:** daily volume = USD value of the stable (USDT/USDC) leg of every reactor fill on the chain, filtered by chainId and day window. Source is Textile's public GraphQL API, which serves the protocol's Goldsky-subgraph-indexed on-chain fills with per-trade `timestamp`, `chainId`, `volumeUsd`. History is served from 2026-06-07, so backfill works from the `start` date.

USD volume comes precomputed from the indexer because several corridor tokens are local-currency FX stablecoins (cNGN, wARS, wBRL) that may lack reliable price feeds on pricing APIs — the stable leg valuation avoids mispricing them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)