### PR TITLE
Add BetterSwap V3 volume adapter

### DIFF
--- a/dexs/betterswap-v3/index.ts
+++ b/dexs/betterswap-v3/index.ts
@@ -1,0 +1,27 @@
+import { FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import fetchURL from "../../utils/fetchURL";
+
+interface BetterSwapResponse {
+    volumeUSD: string;
+}
+
+const factoryAddress = "0xf9f1722f95d036efbd1352d84e3a3755f8027b39";
+
+const fetch = async (options: FetchOptions) => {
+    const url = `https://www.betterswap.io/api/volume?startDate=${options.dateString}&factoryAddress=${factoryAddress}`;
+    const response: BetterSwapResponse = await fetchURL(url);
+
+    return {
+        dailyVolume: parseFloat(response.volumeUSD),
+    };
+};
+
+const adapter: SimpleAdapter = {
+    version: 1,
+    fetch,
+    chains: [CHAIN.VECHAIN],
+    start: "2026-07-20",
+};
+
+export default adapter;


### PR DESCRIPTION
## Summary

This PR adds daily trading volume tracking for the current BetterSwap V3 deployment on VeChain.

The adapter uses BetterSwap's existing volume API and filters results by the current V3 factory:

- V3 factory: `0xf9f1722f95d036efbd1352d84e3a3755f8027b39`
- Chain: VeChain
- Start date: `2026-07-20`
- Endpoint: `https://www.betterswap.io/api/volume`
- Adapter key: `betterswap-v3`

The existing `betterswap` adapter continues to track only the BetterSwap V2 factory and remains unchanged.

---

##### Name (to be shown on DefiLlama):

BetterSwap V3

##### Twitter Link:

https://x.com/BetterSwap_io

##### List of audit links if any:

There is currently no V3-specific audit.

The existing BetterSwap V2 contracts were audited by Hacken, but that audit does not cover this V3 deployment:

https://hacken.io/audits/betterswap/sca-betterswap-diff-check-jan2025/

##### Website Link:

https://www.betterswap.io/

##### Logo (High resolution, will be shown with rounded borders):

https://betterswap.io/betterswap-logo.svg

##### Current TVL:

Approximately $7.67k at the time of testing.

##### Treasury Addresses (if the protocol has treasury)

N/A

##### Chain:

VeChain

##### Coingecko ID:

N/A

##### Coinmarketcap ID:

N/A

##### Short Description (to be shown on DefiLlama):

BetterSwap V3 is a concentrated-liquidity decentralized exchange on VeChainThor. It is part of BetterSwap, a DEX and aggregation platform that provides access to liquidity across the VeChain ecosystem.

##### Token address and ticker if any:

N/A

##### Category:

Dexes

##### Oracle Provider(s):

Uniswap V3 built-in TWAP oracle.

##### Implementation Details:

Each V3 pool maintains historical price and liquidity observations using the standard Uniswap V3 oracle implementation.

##### Documentation/Proof:

https://docs.uniswap.org/concepts/protocol/oracle

##### forkedFrom:

Uniswap V3

##### methodology:

Daily volume is calculated from indexed on-chain swaps belonging to pools created by the current BetterSwap V3 factory. The adapter requests the daily USD volume from BetterSwap's volume endpoint and filters it using the V3 factory address.

##### Github org/user:

https://github.com/the-better-collective

##### Does this project have a referral program?

No

---

## V2/V3 naming

BetterSwap V2 is already tracked by the existing `betterswap` adapter using factory `0x5970dcbebac33e75eff315c675f1d2654f7bf1f5`.

This PR adds the current concentrated-liquidity deployment separately as `betterswap-v3`.

We would prefer the two versions to be displayed consistently as:

- BetterSwap V2
- BetterSwap V3

Please let us know whether the existing V2 display name should be updated separately through `metadata@defillama.com`. We intentionally left the existing V2 adapter unchanged to preserve its historical volume data.

## Testing

```bash
pnpm test dexs betterswap-v3 2026-07-29
Result for July 28, 2026:
VECHAIN
Backfill start time: 20/7/2026
Daily volume: 255.00
Additional verification:
pnpm exec tsc --noEmit --project tsconfig.json
git diff --check
All checks passed. No dependencies or lockfiles were changed.