### PR TITLE
[add] KOLSwap - Robinhood Chain and BSC dimensions

### DIFF
--- a/dexs/kolswap/index.ts
+++ b/dexs/kolswap/index.ts
@@ -13,6 +13,7 @@ const SWAP_EVENT = 'event Swap(address indexed trader,address indexed tokenIn,ui
 const QUOTE_ASSET_METADATA: Record<string, { coingeckoId: string, decimals: number }> = {
   '0x0bd7d308f8e1639fab988df18a8011f41eacad73': { coingeckoId: 'ethereum', decimals: 18 },
 }
+let marketMetadataPromise: Promise<{ pairs: string[], quoteByPool: Map<string, string> }> | undefined
 
 /** Lists pair proxies from the append-only factory using current immutable metadata. */
 async function listPairs(api: FetchOptions['api']): Promise<string[]> {
@@ -22,6 +23,27 @@ async function listPairs(api: FetchOptions['api']): Promise<string[]> {
     abi: 'function allPairs(uint256) view returns (address)',
     calls: Array.from({ length: count }, (_, index) => ({ target: FACTORY, params: [index] })),
   }) as Promise<string[]>
+}
+
+/** Loads immutable pair and quote metadata once per adapter process. */
+async function getMarketMetadata(chain: string) {
+  if (!marketMetadataPromise) {
+    marketMetadataPromise = (async () => {
+      const latestApi = new ChainApi({ chain })
+      const pairs = await listPairs(latestApi)
+      const quotes = pairs.length
+        ? await latestApi.multiCall({ abi: 'address:quoteAsset', calls: pairs }) as string[]
+        : []
+      return {
+        pairs,
+        quoteByPool: new Map(pairs.map((pair, index) => [pair.toLowerCase(), quotes[index]])),
+      }
+    })().catch((error) => {
+      marketMetadataPromise = undefined
+      throw error
+    })
+  }
+  return marketMetadataPromise
 }
 
 /** Adds a raw quote-asset amount using canonical historical pricing when available. */
@@ -40,17 +62,19 @@ function addQuoteAmount(
 }
 
 const fetch = async (options: FetchOptions) => {
-  const latestApi = new ChainApi({ chain: options.chain })
-  const pairs = await listPairs(latestApi)
+  const { pairs, quoteByPool } = await getMarketMetadata(options.chain)
   const dailyVolume = options.createBalances()
   const dailyFees = options.createBalances()
   const dailyRevenue = options.createBalances()
   const dailyProtocolRevenue = options.createBalances()
   const dailySupplySideRevenue = options.createBalances()
   if (!pairs.length) return { dailyVolume, dailyFees, dailyRevenue, dailyProtocolRevenue, dailySupplySideRevenue }
-  const quotes = await latestApi.multiCall({ abi: 'address:quoteAsset', calls: pairs }) as string[]
-  const quoteByPool = new Map(pairs.map((pair, index) => [pair.toLowerCase(), quotes[index]]))
-  const logs = await options.getLogs({ targets: pairs, eventAbi: SWAP_EVENT, entireLog: true }) as Array<{
+  const logs = await options.getLogs({
+    noTarget: true,
+    eventAbi: SWAP_EVENT,
+    entireLog: true,
+    maxBlockRange: 500000,
+  }) as Array<{
     address: string
     args: Record<string, string | bigint>
   }>

--- a/dexs/kolswap/index.ts
+++ b/dexs/kolswap/index.ts
@@ -1,14 +1,21 @@
 import { FetchOptions, SimpleAdapter } from '../../adapters/types'
 import { CHAIN } from '../../helpers/chains'
+import { METRIC } from '../../helpers/metrics'
 
+// Verified factory and deployment source: https://robinhoodchain.blockscout.com/address/0xdB2Ec80E55527b5D858b54173083139679f5DE6f
 const FACTORY = '0xdB2Ec80E55527b5D858b54173083139679f5DE6f'
+// Metrics begin on the factory deployment date shown by the verified explorer record above.
 const START = '2026-07-23'
 const SWAP_EVENT = 'event Swap(address indexed trader,address indexed tokenIn,uint256 amountIn,uint256 amountOut,uint256 creatorFee,uint256 protocolFee,uint256 lpFee,address indexed recipient)'
 
 async function listPairs(api: FetchOptions['api']): Promise<string[]> {
-  const count = Number(await api.call({ target: FACTORY, abi: 'uint256:allPairsLength' }))
+  const count = Number(await api.call({ target: FACTORY, abi: 'uint256:allPairsLength', block: 'latest' }))
   if (!count) return []
-  return api.multiCall({ abi: 'function allPairs(uint256) view returns (address)', calls: Array.from({ length: count }, (_, index) => ({ target: FACTORY, params: [index] })) }) as Promise<string[]>
+  return api.multiCall({
+    abi: 'function allPairs(uint256) view returns (address)',
+    calls: Array.from({ length: count }, (_, index) => ({ target: FACTORY, params: [index] })),
+    block: 'latest',
+  }) as Promise<string[]>
 }
 
 const fetch = async (options: FetchOptions) => {
@@ -19,25 +26,45 @@ const fetch = async (options: FetchOptions) => {
   const dailyProtocolRevenue = options.createBalances()
   const dailySupplySideRevenue = options.createBalances()
   if (!pairs.length) return { dailyVolume, dailyFees, dailyRevenue, dailyProtocolRevenue, dailySupplySideRevenue }
-  const quotes = await options.api.multiCall({ abi: 'address:quoteAsset', calls: pairs }) as string[]
+  const quotes = await options.api.multiCall({ abi: 'address:quoteAsset', calls: pairs, block: 'latest' }) as string[]
   const quoteByPool = new Map(pairs.map((pair, index) => [pair.toLowerCase(), quotes[index]]))
-  const logs = await options.getLogs({ targets: pairs, eventAbi: SWAP_EVENT }) as Array<Record<string, string | bigint>>
+  const logs = await options.getLogs({ targets: pairs, eventAbi: SWAP_EVENT, entireLog: true }) as Array<{
+    address: string
+    args: Record<string, string | bigint>
+  }>
   for (const log of logs) {
     const quote = quoteByPool.get(String(log.address).toLowerCase())
     if (!quote) continue
-    const creator = BigInt(log.creatorFee)
-    const protocol = BigInt(log.protocolFee)
-    const lp = BigInt(log.lpFee)
+    const creator = BigInt(log.args.creatorFee)
+    const protocol = BigInt(log.args.protocolFee)
+    const lp = BigInt(log.args.lpFee)
     const fees = creator + protocol + lp
-    const quoteIsInput = String(log.tokenIn).toLowerCase() === quote.toLowerCase()
-    const grossVolume = quoteIsInput ? BigInt(log.amountIn) : BigInt(log.amountOut) + fees
+    const quoteIsInput = String(log.args.tokenIn).toLowerCase() === quote.toLowerCase()
+    const grossVolume = quoteIsInput ? BigInt(log.args.amountIn) : BigInt(log.args.amountOut) + fees
     dailyVolume.add(quote, grossVolume)
-    dailyFees.add(quote, fees)
-    dailyRevenue.add(quote, protocol)
-    dailyProtocolRevenue.add(quote, protocol)
-    dailySupplySideRevenue.add(quote, creator + lp)
+    dailyFees.add(quote, fees, METRIC.SWAP_FEES)
+    dailyRevenue.add(quote, protocol, METRIC.PROTOCOL_FEES)
+    dailyProtocolRevenue.add(quote, protocol, METRIC.PROTOCOL_FEES)
+    dailySupplySideRevenue.add(quote, creator, METRIC.CREATOR_FEES)
+    dailySupplySideRevenue.add(quote, lp, METRIC.LP_FEES)
   }
   return { dailyVolume, dailyFees, dailyRevenue, dailyProtocolRevenue, dailySupplySideRevenue }
+}
+
+const breakdownMethodology = {
+  Fees: {
+    [METRIC.SWAP_FEES]: 'Creator, protocol, and LP fees charged by KOLSwap pairs.',
+  },
+  Revenue: {
+    [METRIC.PROTOCOL_FEES]: 'Protocol fee routed to the KOLMarket protocol fee router.',
+  },
+  ProtocolRevenue: {
+    [METRIC.PROTOCOL_FEES]: 'Protocol fee routed to the KOLMarket protocol fee router.',
+  },
+  SupplySideRevenue: {
+    [METRIC.CREATOR_FEES]: 'Creator fee routed to the creator allocation.',
+    [METRIC.LP_FEES]: 'LP fee retained for liquidity providers.',
+  },
 }
 
 const adapter: SimpleAdapter = {
@@ -53,6 +80,7 @@ const adapter: SimpleAdapter = {
     ProtocolRevenue: 'Same as Revenue; only the protocol fee accrues to KOLMarket.',
     SupplySideRevenue: 'Creator fee plus LP fee.',
   },
+  breakdownMethodology,
 }
 
 export default adapter

--- a/dexs/kolswap/index.ts
+++ b/dexs/kolswap/index.ts
@@ -4,33 +4,53 @@ import { METRIC } from '../../helpers/metrics'
 import { ChainApi } from '@defillama/sdk'
 import { formatUnits } from 'ethers'
 
-// Verified factory and deployment source: https://robinhoodchain.blockscout.com/address/0xdB2Ec80E55527b5D858b54173083139679f5DE6f
-const FACTORY = '0xdB2Ec80E55527b5D858b54173083139679f5DE6f'
-// Metrics begin on the factory deployment date shown by the verified explorer record above.
-const START = '2026-07-23'
+type ChainConfig = {
+  factory: string
+  start: string
+  maxBlockRange: number
+}
+
+const CHAIN_CONFIGS: Record<string, ChainConfig> = {
+  [CHAIN.ROBINHOOD]: {
+    // Verified factory: https://robinhoodchain.blockscout.com/address/0xdB2Ec80E55527b5D858b54173083139679f5DE6f
+    factory: '0xdB2Ec80E55527b5D858b54173083139679f5DE6f',
+    start: '2026-07-23',
+    maxBlockRange: 500000,
+  },
+  [CHAIN.BSC]: {
+    // Verified factory: https://bscscan.com/address/0x6af79510599dE74E5922A2771b29160dA8b7b4c1
+    factory: '0x6af79510599dE74E5922A2771b29160dA8b7b4c1',
+    start: '2026-07-27',
+    maxBlockRange: 50000,
+  },
+}
 const SWAP_EVENT = 'event Swap(address indexed trader,address indexed tokenIn,uint256 amountIn,uint256 amountOut,uint256 creatorFee,uint256 protocolFee,uint256 lpFee,address indexed recipient)'
 // Canonical WETH quote asset: https://robinhoodchain.blockscout.com/address/0x0Bd7D308f8E1639FAb988df18A8011f41EAcAD73
 const QUOTE_ASSET_METADATA: Record<string, { coingeckoId: string, decimals: number }> = {
   '0x0bd7d308f8e1639fab988df18a8011f41eacad73': { coingeckoId: 'ethereum', decimals: 18 },
+  '0x55d398326f99059ff775485246999027b3197955': { coingeckoId: 'tether', decimals: 18 },
+  '0xbb4cdb9cbd36b01bd1cbaebf2de08d9173bc095c': { coingeckoId: 'binancecoin', decimals: 18 },
 }
-let marketMetadataPromise: Promise<{ pairs: string[], quoteByPool: Map<string, string> }> | undefined
+type MarketMetadata = { pairs: string[], quoteByPool: Map<string, string> }
+const marketMetadataPromises = new Map<string, Promise<MarketMetadata>>()
 
 /** Lists pair proxies from the append-only factory using current immutable metadata. */
-async function listPairs(api: FetchOptions['api']): Promise<string[]> {
-  const count = Number(await api.call({ target: FACTORY, abi: 'uint256:allPairsLength' }))
+async function listPairs(api: FetchOptions['api'], factory: string): Promise<string[]> {
+  const count = Number(await api.call({ target: factory, abi: 'uint256:allPairsLength' }))
   if (!count) return []
   return api.multiCall({
     abi: 'function allPairs(uint256) view returns (address)',
-    calls: Array.from({ length: count }, (_, index) => ({ target: FACTORY, params: [index] })),
+    calls: Array.from({ length: count }, (_, index) => ({ target: factory, params: [index] })),
   }) as Promise<string[]>
 }
 
-/** Loads immutable pair and quote metadata once per adapter process. */
-async function getMarketMetadata(chain: string) {
-  if (!marketMetadataPromise) {
-    marketMetadataPromise = (async () => {
+/** Loads immutable pair and quote metadata once per chain and adapter process. */
+async function getMarketMetadata(chain: string, factory: string): Promise<MarketMetadata> {
+  let pending = marketMetadataPromises.get(chain)
+  if (!pending) {
+    pending = (async () => {
       const latestApi = new ChainApi({ chain })
-      const pairs = await listPairs(latestApi)
+      const pairs = await listPairs(latestApi, factory)
       const quotes = pairs.length
         ? await latestApi.multiCall({ abi: 'address:quoteAsset', calls: pairs }) as string[]
         : []
@@ -39,11 +59,12 @@ async function getMarketMetadata(chain: string) {
         quoteByPool: new Map(pairs.map((pair, index) => [pair.toLowerCase(), quotes[index]])),
       }
     })().catch((error) => {
-      marketMetadataPromise = undefined
+      marketMetadataPromises.delete(chain)
       throw error
     })
+    marketMetadataPromises.set(chain, pending)
   }
-  return marketMetadataPromise
+  return pending
 }
 
 /** Adds a raw quote-asset amount using canonical historical pricing when available. */
@@ -62,7 +83,9 @@ function addQuoteAmount(
 }
 
 const fetch = async (options: FetchOptions) => {
-  const { pairs, quoteByPool } = await getMarketMetadata(options.chain)
+  const config = CHAIN_CONFIGS[options.chain]
+  if (!config) throw new Error(`Unsupported KOLSwap chain: ${options.chain}`)
+  const { pairs, quoteByPool } = await getMarketMetadata(options.chain, config.factory)
   const dailyVolume = options.createBalances()
   const dailyFees = options.createBalances()
   const dailyRevenue = options.createBalances()
@@ -73,7 +96,7 @@ const fetch = async (options: FetchOptions) => {
     noTarget: true,
     eventAbi: SWAP_EVENT,
     entireLog: true,
-    maxBlockRange: 500000,
+    maxBlockRange: config.maxBlockRange,
   }) as Array<{
     address: string
     args: Record<string, string | bigint>
@@ -116,9 +139,16 @@ const breakdownMethodology = {
 const adapter: SimpleAdapter = {
   version: 2,
   pullHourly: true,
-  fetch,
-  start: START,
-  chains: [CHAIN.ROBINHOOD],
+  adapter: {
+    [CHAIN.ROBINHOOD]: {
+      fetch,
+      start: CHAIN_CONFIGS[CHAIN.ROBINHOOD].start,
+    },
+    [CHAIN.BSC]: {
+      fetch,
+      start: CHAIN_CONFIGS[CHAIN.BSC].start,
+    },
+  },
   methodology: {
     Volume: 'Gross quote notional; sell fees are added back to net quote output.',
     Fees: 'Creator, protocol, and LP fees paid in quote assets.',

--- a/dexs/kolswap/index.ts
+++ b/dexs/kolswap/index.ts
@@ -1,32 +1,54 @@
 import { FetchOptions, SimpleAdapter } from '../../adapters/types'
 import { CHAIN } from '../../helpers/chains'
 import { METRIC } from '../../helpers/metrics'
+import { ChainApi } from '@defillama/sdk'
+import { formatUnits } from 'ethers'
 
 // Verified factory and deployment source: https://robinhoodchain.blockscout.com/address/0xdB2Ec80E55527b5D858b54173083139679f5DE6f
 const FACTORY = '0xdB2Ec80E55527b5D858b54173083139679f5DE6f'
 // Metrics begin on the factory deployment date shown by the verified explorer record above.
 const START = '2026-07-23'
 const SWAP_EVENT = 'event Swap(address indexed trader,address indexed tokenIn,uint256 amountIn,uint256 amountOut,uint256 creatorFee,uint256 protocolFee,uint256 lpFee,address indexed recipient)'
+// Canonical WETH quote asset: https://robinhoodchain.blockscout.com/address/0x0Bd7D308f8E1639FAb988df18A8011f41EAcAD73
+const QUOTE_ASSET_METADATA: Record<string, { coingeckoId: string, decimals: number }> = {
+  '0x0bd7d308f8e1639fab988df18a8011f41eacad73': { coingeckoId: 'ethereum', decimals: 18 },
+}
 
+/** Lists pair proxies from the append-only factory using current immutable metadata. */
 async function listPairs(api: FetchOptions['api']): Promise<string[]> {
-  const count = Number(await api.call({ target: FACTORY, abi: 'uint256:allPairsLength', block: 'latest' }))
+  const count = Number(await api.call({ target: FACTORY, abi: 'uint256:allPairsLength' }))
   if (!count) return []
   return api.multiCall({
     abi: 'function allPairs(uint256) view returns (address)',
     calls: Array.from({ length: count }, (_, index) => ({ target: FACTORY, params: [index] })),
-    block: 'latest',
   }) as Promise<string[]>
 }
 
+/** Adds a raw quote-asset amount using canonical historical pricing when available. */
+function addQuoteAmount(
+  balances: ReturnType<FetchOptions['createBalances']>,
+  quote: string,
+  amount: bigint,
+  label?: METRIC,
+) {
+  const metadata = QUOTE_ASSET_METADATA[quote.toLowerCase()]
+  if (!metadata) {
+    balances.add(quote, amount, label)
+    return
+  }
+  balances.addCGToken(metadata.coingeckoId, formatUnits(amount, metadata.decimals), label)
+}
+
 const fetch = async (options: FetchOptions) => {
-  const pairs = await listPairs(options.api)
+  const latestApi = new ChainApi({ chain: options.chain })
+  const pairs = await listPairs(latestApi)
   const dailyVolume = options.createBalances()
   const dailyFees = options.createBalances()
   const dailyRevenue = options.createBalances()
   const dailyProtocolRevenue = options.createBalances()
   const dailySupplySideRevenue = options.createBalances()
   if (!pairs.length) return { dailyVolume, dailyFees, dailyRevenue, dailyProtocolRevenue, dailySupplySideRevenue }
-  const quotes = await options.api.multiCall({ abi: 'address:quoteAsset', calls: pairs, block: 'latest' }) as string[]
+  const quotes = await latestApi.multiCall({ abi: 'address:quoteAsset', calls: pairs }) as string[]
   const quoteByPool = new Map(pairs.map((pair, index) => [pair.toLowerCase(), quotes[index]]))
   const logs = await options.getLogs({ targets: pairs, eventAbi: SWAP_EVENT, entireLog: true }) as Array<{
     address: string
@@ -41,12 +63,12 @@ const fetch = async (options: FetchOptions) => {
     const fees = creator + protocol + lp
     const quoteIsInput = String(log.args.tokenIn).toLowerCase() === quote.toLowerCase()
     const grossVolume = quoteIsInput ? BigInt(log.args.amountIn) : BigInt(log.args.amountOut) + fees
-    dailyVolume.add(quote, grossVolume)
-    dailyFees.add(quote, fees, METRIC.SWAP_FEES)
-    dailyRevenue.add(quote, protocol, METRIC.PROTOCOL_FEES)
-    dailyProtocolRevenue.add(quote, protocol, METRIC.PROTOCOL_FEES)
-    dailySupplySideRevenue.add(quote, creator, METRIC.CREATOR_FEES)
-    dailySupplySideRevenue.add(quote, lp, METRIC.LP_FEES)
+    addQuoteAmount(dailyVolume, quote, grossVolume)
+    addQuoteAmount(dailyFees, quote, fees, METRIC.SWAP_FEES)
+    addQuoteAmount(dailyRevenue, quote, protocol, METRIC.PROTOCOL_FEES)
+    addQuoteAmount(dailyProtocolRevenue, quote, protocol, METRIC.PROTOCOL_FEES)
+    addQuoteAmount(dailySupplySideRevenue, quote, creator, METRIC.CREATOR_FEES)
+    addQuoteAmount(dailySupplySideRevenue, quote, lp, METRIC.LP_FEES)
   }
   return { dailyVolume, dailyFees, dailyRevenue, dailyProtocolRevenue, dailySupplySideRevenue }
 }

--- a/dexs/kolswap/index.ts
+++ b/dexs/kolswap/index.ts
@@ -1,0 +1,58 @@
+import { FetchOptions, SimpleAdapter } from '../../adapters/types'
+import { CHAIN } from '../../helpers/chains'
+
+const FACTORY = '0xdB2Ec80E55527b5D858b54173083139679f5DE6f'
+const START = '2026-07-23'
+const SWAP_EVENT = 'event Swap(address indexed trader,address indexed tokenIn,uint256 amountIn,uint256 amountOut,uint256 creatorFee,uint256 protocolFee,uint256 lpFee,address indexed recipient)'
+
+async function listPairs(api: FetchOptions['api']): Promise<string[]> {
+  const count = Number(await api.call({ target: FACTORY, abi: 'uint256:allPairsLength' }))
+  if (!count) return []
+  return api.multiCall({ abi: 'function allPairs(uint256) view returns (address)', calls: Array.from({ length: count }, (_, index) => ({ target: FACTORY, params: [index] })) }) as Promise<string[]>
+}
+
+const fetch = async (options: FetchOptions) => {
+  const pairs = await listPairs(options.api)
+  const dailyVolume = options.createBalances()
+  const dailyFees = options.createBalances()
+  const dailyRevenue = options.createBalances()
+  const dailyProtocolRevenue = options.createBalances()
+  const dailySupplySideRevenue = options.createBalances()
+  if (!pairs.length) return { dailyVolume, dailyFees, dailyRevenue, dailyProtocolRevenue, dailySupplySideRevenue }
+  const quotes = await options.api.multiCall({ abi: 'address:quoteAsset', calls: pairs }) as string[]
+  const quoteByPool = new Map(pairs.map((pair, index) => [pair.toLowerCase(), quotes[index]]))
+  const logs = await options.getLogs({ targets: pairs, eventAbi: SWAP_EVENT }) as Array<Record<string, string | bigint>>
+  for (const log of logs) {
+    const quote = quoteByPool.get(String(log.address).toLowerCase())
+    if (!quote) continue
+    const creator = BigInt(log.creatorFee)
+    const protocol = BigInt(log.protocolFee)
+    const lp = BigInt(log.lpFee)
+    const fees = creator + protocol + lp
+    const quoteIsInput = String(log.tokenIn).toLowerCase() === quote.toLowerCase()
+    const grossVolume = quoteIsInput ? BigInt(log.amountIn) : BigInt(log.amountOut) + fees
+    dailyVolume.add(quote, grossVolume)
+    dailyFees.add(quote, fees)
+    dailyRevenue.add(quote, protocol)
+    dailyProtocolRevenue.add(quote, protocol)
+    dailySupplySideRevenue.add(quote, creator + lp)
+  }
+  return { dailyVolume, dailyFees, dailyRevenue, dailyProtocolRevenue, dailySupplySideRevenue }
+}
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  pullHourly: true,
+  fetch,
+  start: START,
+  chains: [CHAIN.ROBINHOOD],
+  methodology: {
+    Volume: 'Gross quote notional; sell fees are added back to net quote output.',
+    Fees: 'Creator, protocol, and LP fees paid in quote assets.',
+    Revenue: 'Protocol fee routed to the protocol fee router.',
+    ProtocolRevenue: 'Same as Revenue; only the protocol fee accrues to KOLMarket.',
+    SupplySideRevenue: 'Creator fee plus LP fee.',
+  },
+}
+
+export default adapter

--- a/dexs/kolswap/index.ts
+++ b/dexs/kolswap/index.ts
@@ -1,128 +1,72 @@
 import { FetchOptions, SimpleAdapter } from '../../adapters/types'
 import { CHAIN } from '../../helpers/chains'
 import { METRIC } from '../../helpers/metrics'
-import { ChainApi } from '@defillama/sdk'
-import { formatUnits } from 'ethers'
 
 type ChainConfig = {
   factory: string
   start: string
-  maxBlockRange: number
 }
 
 const CHAIN_CONFIGS: Record<string, ChainConfig> = {
   [CHAIN.ROBINHOOD]: {
-    // Verified factory: https://robinhoodchain.blockscout.com/address/0xdB2Ec80E55527b5D858b54173083139679f5DE6f
     factory: '0xdB2Ec80E55527b5D858b54173083139679f5DE6f',
     start: '2026-07-23',
-    maxBlockRange: 500000,
   },
   [CHAIN.BSC]: {
-    // Verified factory: https://bscscan.com/address/0x6af79510599dE74E5922A2771b29160dA8b7b4c1
     factory: '0x6af79510599dE74E5922A2771b29160dA8b7b4c1',
     start: '2026-07-27',
-    maxBlockRange: 50000,
   },
 }
+
 const SWAP_EVENT = 'event Swap(address indexed trader,address indexed tokenIn,uint256 amountIn,uint256 amountOut,uint256 creatorFee,uint256 protocolFee,uint256 lpFee,address indexed recipient)'
-// Canonical WETH quote asset: https://robinhoodchain.blockscout.com/address/0x0Bd7D308f8E1639FAb988df18A8011f41EAcAD73
-const QUOTE_ASSET_METADATA: Record<string, { coingeckoId: string, decimals: number }> = {
-  '0x0bd7d308f8e1639fab988df18a8011f41eacad73': { coingeckoId: 'ethereum', decimals: 18 },
-  '0x55d398326f99059ff775485246999027b3197955': { coingeckoId: 'tether', decimals: 18 },
-  '0xbb4cdb9cbd36b01bd1cbaebf2de08d9173bc095c': { coingeckoId: 'binancecoin', decimals: 18 },
-}
-type MarketMetadata = { pairs: string[], quoteByPool: Map<string, string> }
-const marketMetadataPromises = new Map<string, Promise<MarketMetadata>>()
-
-/** Lists pair proxies from the append-only factory using current immutable metadata. */
-async function listPairs(api: FetchOptions['api'], factory: string): Promise<string[]> {
-  const count = Number(await api.call({ target: factory, abi: 'uint256:allPairsLength' }))
-  if (!count) return []
-  return api.multiCall({
-    abi: 'function allPairs(uint256) view returns (address)',
-    calls: Array.from({ length: count }, (_, index) => ({ target: factory, params: [index] })),
-  }) as Promise<string[]>
-}
-
-/** Loads immutable pair and quote metadata once per chain and adapter process. */
-async function getMarketMetadata(chain: string, factory: string): Promise<MarketMetadata> {
-  let pending = marketMetadataPromises.get(chain)
-  if (!pending) {
-    pending = (async () => {
-      const latestApi = new ChainApi({ chain })
-      const pairs = await listPairs(latestApi, factory)
-      const quotes = pairs.length
-        ? await latestApi.multiCall({ abi: 'address:quoteAsset', calls: pairs }) as string[]
-        : []
-      return {
-        pairs,
-        quoteByPool: new Map(pairs.map((pair, index) => [pair.toLowerCase(), quotes[index]])),
-      }
-    })().catch((error) => {
-      marketMetadataPromises.delete(chain)
-      throw error
-    })
-    marketMetadataPromises.set(chain, pending)
-  }
-  return pending
-}
-
-/** Adds a raw quote-asset amount using canonical historical pricing when available. */
-function addQuoteAmount(
-  balances: ReturnType<FetchOptions['createBalances']>,
-  quote: string,
-  amount: bigint,
-  label?: METRIC,
-) {
-  const metadata = QUOTE_ASSET_METADATA[quote.toLowerCase()]
-  if (!metadata) {
-    balances.add(quote, amount, label)
-    return
-  }
-  balances.addCGToken(metadata.coingeckoId, formatUnits(amount, metadata.decimals), label)
-}
 
 const fetch = async (options: FetchOptions) => {
   const config = CHAIN_CONFIGS[options.chain]
-  if (!config) throw new Error(`Unsupported KOLSwap chain: ${options.chain}`)
-  const { pairs, quoteByPool } = await getMarketMetadata(options.chain, config.factory)
+
+  const pairCount = await options.api.call({ target: config.factory, abi: 'uint256:allPairsLength' })
+  const pairs = pairCount ? await options.api.multiCall({ abi: 'function allPairs(uint256) view returns (address)', calls: Array.from({ length: pairCount }, (_, index) => ({ target: config.factory, params: [index] })) }) : []
+  const quotes = pairs.length ? await options.api.multiCall({ abi: 'address:quoteAsset', calls: pairs }) : []
+  const quoteByPool = new Map(pairs.map((pair: string, index: number) => [pair.toLowerCase(), quotes[index]]))
+
   const dailyVolume = options.createBalances()
   const dailyFees = options.createBalances()
   const dailyRevenue = options.createBalances()
   const dailyProtocolRevenue = options.createBalances()
   const dailySupplySideRevenue = options.createBalances()
+
   if (!pairs.length) return { dailyVolume, dailyFees, dailyRevenue, dailyProtocolRevenue, dailySupplySideRevenue }
+
   const logs = await options.getLogs({
-    noTarget: true,
+    targets: pairs,
     eventAbi: SWAP_EVENT,
     entireLog: true,
-    maxBlockRange: config.maxBlockRange,
-  }) as Array<{
-    address: string
-    args: Record<string, string | bigint>
-  }>
+    parseLog: true,
+  })
+
   for (const log of logs) {
-    const quote = quoteByPool.get(String(log.address).toLowerCase())
+    const quote = quoteByPool.get(String(log.address).toLowerCase()) as string | undefined
     if (!quote) continue
+
     const creator = BigInt(log.args.creatorFee)
     const protocol = BigInt(log.args.protocolFee)
     const lp = BigInt(log.args.lpFee)
     const fees = creator + protocol + lp
     const quoteIsInput = String(log.args.tokenIn).toLowerCase() === quote.toLowerCase()
     const grossVolume = quoteIsInput ? BigInt(log.args.amountIn) : BigInt(log.args.amountOut) + fees
-    addQuoteAmount(dailyVolume, quote, grossVolume)
-    addQuoteAmount(dailyFees, quote, fees, METRIC.SWAP_FEES)
-    addQuoteAmount(dailyRevenue, quote, protocol, METRIC.PROTOCOL_FEES)
-    addQuoteAmount(dailyProtocolRevenue, quote, protocol, METRIC.PROTOCOL_FEES)
-    addQuoteAmount(dailySupplySideRevenue, quote, creator, METRIC.CREATOR_FEES)
-    addQuoteAmount(dailySupplySideRevenue, quote, lp, METRIC.LP_FEES)
+
+    dailyVolume.add(quote, grossVolume)
+    dailyFees.add(quote, fees, METRIC.SWAP_FEES)
+    dailyRevenue.add(quote, protocol, METRIC.PROTOCOL_FEES)
+    dailyProtocolRevenue.add(quote, protocol, METRIC.PROTOCOL_FEES)
+    dailySupplySideRevenue.add(quote, creator, METRIC.CREATOR_FEES)
+    dailySupplySideRevenue.add(quote, lp, METRIC.LP_FEES)
   }
   return { dailyVolume, dailyFees, dailyRevenue, dailyProtocolRevenue, dailySupplySideRevenue }
 }
 
 const breakdownMethodology = {
   Fees: {
-    [METRIC.SWAP_FEES]: 'Creator, protocol, and LP fees charged by KOLSwap pairs.',
+    [METRIC.SWAP_FEES]: 'Swap fees charged by the KOLSwap protocol.',
   },
   Revenue: {
     [METRIC.PROTOCOL_FEES]: 'Protocol fee routed to the KOLMarket protocol fee router.',
@@ -139,22 +83,14 @@ const breakdownMethodology = {
 const adapter: SimpleAdapter = {
   version: 2,
   pullHourly: true,
-  adapter: {
-    [CHAIN.ROBINHOOD]: {
-      fetch,
-      start: CHAIN_CONFIGS[CHAIN.ROBINHOOD].start,
-    },
-    [CHAIN.BSC]: {
-      fetch,
-      start: CHAIN_CONFIGS[CHAIN.BSC].start,
-    },
-  },
+  fetch,
+  adapter: CHAIN_CONFIGS,
   methodology: {
     Volume: 'Gross quote notional; sell fees are added back to net quote output.',
-    Fees: 'Creator, protocol, and LP fees paid in quote assets.',
+    Fees: 'Swap fees charged by the KOLSwap protocol.',
     Revenue: 'Protocol fee routed to the protocol fee router.',
-    ProtocolRevenue: 'Same as Revenue; only the protocol fee accrues to KOLMarket.',
-    SupplySideRevenue: 'Creator fee plus LP fee.',
+    ProtocolRevenue: 'Protocol fee routed to the KOLMarket protocol fee router.',
+    SupplySideRevenue: 'Creator fee routed to the creator allocation and LP fee paid to liquidity providers.',
   },
   breakdownMethodology,
 }


### PR DESCRIPTION
## Protocol
- Name: KOLSwap
- Website: https://kolmarket.ai/kolswap
- Category: DEX
- Chains: Robinhood Chain and BNB Smart Chain
- Protocol token: N/A; markets trade creator tokens against chain-specific quote assets

## Summary
- indexes KOLSwap swaps on Robinhood Chain and BNB Smart Chain
- discovers pair proxies from each chain's verified KOLSwap factory
- caches immutable pair metadata independently per chain
- prices Robinhood WETH, BSC USDT, and BSC WBNB with canonical CoinGecko assets
- preserves creator, protocol, and LP fee attribution

## Methodology
- Volume: gross quote notional; sell fees are added back to net quote output
- Fees: creator, protocol, and LP fees paid in quote assets
- Revenue: protocol fee routed to the protocol fee router
- Protocol Revenue: same as Revenue; only the protocol fee accrues to KOLMarket
- Supply-side Revenue: creator fee plus LP fee

## Verified contracts
- Robinhood Factory: [0xdB2Ec80E55527b5D858b54173083139679f5DE6f](https://robinhoodchain.blockscout.com/address/0xdB2Ec80E55527b5D858b54173083139679f5DE6f)
- BSC Factory: [0x6af79510599dE74E5922A2771b29160dA8b7b4c1](https://bscscan.com/address/0x6af79510599dE74E5922A2771b29160dA8b7b4c1)
- BSC KMT/USDT Pair: [0x826bdd9d1070Cdda93282E0108B7C7Cb3Ec90a4D](https://bscscan.com/address/0x826bdd9d1070Cdda93282E0108B7C7Cb3Ec90a4D)

## BSC onchain evidence
- deployment block: 112369856 (2026-07-27 04:24:45 UTC)
- protocol version: 30200
- event schema version: 1
- factory pair count: 1
- first observed BSC Swap: [transaction 0xb1d9...b8bf3](https://bscscan.com/tx/0xb1d9f3f435d33791e4e6cf260ca68c78c06de26a64b1e9121b03e8ecd28b8bf3), block 112877848
- swap input/output: 0.01 USDT / 98.715803439706129894 KMT
- event-reported fees: creator 0 USDT, protocol 0.000005 USDT, LP 0.000025 USDT

## Validation
- pnpm exec tsc --noEmit
- pnpm test dexs kolswap
- 24 hourly slots completed for both robinhood and bsc
