### PR TITLE
[fix] 1inch-agg - backfill full history from 2019, add Solana, count each swap once

### DIFF
--- a/aggregators/1inch-agg/index.ts
+++ b/aggregators/1inch-agg/index.ts
@@ -1,37 +1,87 @@
-import { Dependencies, FetchOptions, FetchResult, SimpleAdapter } from "../../adapters/types";
+import {
+  Dependencies,
+  FetchOptions,
+  FetchResult,
+  SimpleAdapter,
+} from "../../adapters/types";
 import { queryDuneSql } from "../../helpers/dune";
 import { CHAIN } from "../../helpers/chains";
 import { getDefaultDexTokensBlacklisted } from "../../helpers/lists";
 
-const chainsMap: Record<string, string> = {
-  [CHAIN.ETHEREUM]: 'ethereum',
-  [CHAIN.ARBITRUM]: 'arbitrum',
-  [CHAIN.POLYGON]: 'polygon',
-  [CHAIN.BSC]: 'bnb',
-  [CHAIN.AVAX]: 'avalanche_c',
-  [CHAIN.OPTIMISM]: 'optimism',
-  [CHAIN.BASE]: 'base',
-  [CHAIN.XDAI]: 'gnosis',
-  [CHAIN.LINEA]: 'linea',
-  [CHAIN.SONIC]: 'sonic',
-  [CHAIN.UNICHAIN]: 'unichain',
-  [CHAIN.ERA]: 'zksync',
+// Data source: the 1inch-maintained Dune spellbook. oneinch.swaps carries the
+// full EVM history (AR = Aggregation Router v1-v6 classic swaps since
+// 2019-06-03, LO = Limit Order Protocol fills incl. Fusion intent settlements,
+// CC = Fusion+ cross-chain swaps). Solana (Fusion program, live 2025-04-25)
+// is NOT part of oneinch.swaps and comes from oneinch_solana.swaps instead.
+//
+// Per-chain start = min(block_date) actually present in the spellbook for that
+// chain. Fantom volume died with the chain's Sonic migration (last real volume
+// 2025), hence deadFrom.
+const chainConfig: Record<
+  string,
+  { dune: string; start: string; deadFrom?: string }
+> = {
+  [CHAIN.ETHEREUM]: { dune: "ethereum", start: "2019-06-03" },
+  [CHAIN.BSC]: { dune: "bnb", start: "2021-02-18" },
+  [CHAIN.POLYGON]: { dune: "polygon", start: "2021-05-05" },
+  [CHAIN.ARBITRUM]: { dune: "arbitrum", start: "2021-09-14" },
+  [CHAIN.OPTIMISM]: { dune: "optimism", start: "2021-11-13" },
+  [CHAIN.AVAX]: { dune: "avalanche_c", start: "2021-12-22" },
+  [CHAIN.XDAI]: { dune: "gnosis", start: "2022-01-14" },
+  [CHAIN.FANTOM]: {
+    dune: "fantom",
+    start: "2022-03-16",
+    deadFrom: "2026-01-01",
+  },
+  [CHAIN.ERA]: { dune: "zksync", start: "2023-04-25" },
+  [CHAIN.BASE]: { dune: "base", start: "2023-08-08" },
+  [CHAIN.LINEA]: { dune: "linea", start: "2025-02-12" },
+  [CHAIN.SOLANA]: { dune: "solana", start: "2025-04-25" },
+  [CHAIN.SONIC]: { dune: "sonic", start: "2025-05-26" },
+  [CHAIN.UNICHAIN]: { dune: "unichain", start: "2025-05-26" },
 };
 
 const prefetch = async (options: FetchOptions) => {
   const blacklisted = getDefaultDexTokensBlacklisted(CHAIN.BSC);
 
+  // Count each user swap exactly once (measured on 2026-07-28, whole-history
+  // proportions are similar):
+  // - The Aggregation Router uses the Limit Order Protocol as a routing
+  //   liquidity source, so an LO fill sharing a transaction with an AR swap is
+  //   a slice of that swap's amount (~57% of limit-order fill volume) - summing
+  //   both rows double-counts, therefore LO/CC rows inside AR transactions are
+  //   excluded.
+  // - Direct (non-resolver) LO fills emit a second row per fill flagged
+  //   second_side - the same fill seen from the counterparty - excluded.
+  // - Failed executions (present in the CC stream) are excluded.
   const sql_query = `
+    WITH ar_txs AS (
+      SELECT DISTINCT blockchain AS ar_blockchain, tx_hash AS ar_tx_hash
+      FROM oneinch.swaps
+      WHERE TIME_RANGE AND protocol = 'AR'
+    )
     SELECT
-      blockchain,
-      sum(amount_usd) as volume_24h
-    FROM oneinch.swaps
+      s.blockchain,
+      sum(s.amount_usd) as volume_24h
+    FROM oneinch.swaps s
+    LEFT JOIN ar_txs ON s.blockchain = ar_blockchain AND s.tx_hash = ar_tx_hash
     WHERE
       TIME_RANGE
-      -- AND src_token_address NOT IN (${blacklisted})
-      -- AND dst_token_address NOT IN (${blacklisted})
+      AND NOT coalesce(element_at(s.flags, 'second_side'), false)
+      AND coalesce(s.tx_success, true)
+      AND coalesce(s.call_success, true)
+      AND (s.protocol = 'AR' OR ar_tx_hash IS NULL)
+      -- AND s.src_token_address NOT IN (${blacklisted})
+      -- AND s.dst_token_address NOT IN (${blacklisted})
     GROUP BY 1
-    ORDER BY volume_24h DESC
+
+    UNION ALL
+
+    SELECT
+      'solana' as blockchain,
+      coalesce(sum(amount_usd), 0) as volume_24h
+    FROM oneinch_solana.swaps
+    WHERE TIME_RANGE
   `;
   const result = await queryDuneSql(options, sql_query);
 
@@ -40,7 +90,9 @@ const prefetch = async (options: FetchOptions) => {
 
 const fetch = async (options: FetchOptions): Promise<FetchResult> => {
   const results = options.preFetchedResults || [];
-  const chainData = results.find((item: any) => item.blockchain === chainsMap[options.chain]);
+  const chainData = results.find(
+    (item: any) => item.blockchain === chainConfig[options.chain]?.dune,
+  );
 
   return {
     dailyVolume: chainData ? chainData.volume_24h : 0,
@@ -50,11 +102,20 @@ const fetch = async (options: FetchOptions): Promise<FetchResult> => {
 const adapter: SimpleAdapter = {
   version: 1,
   fetch,
-  chains: Object.keys(chainsMap),
-  start: "2023-12-05",
+  chains: Object.entries(chainConfig).map(
+    ([chain, { start, deadFrom }]) =>
+      [chain, deadFrom ? { start, deadFrom } : { start }] as [
+        string,
+        { start: string; deadFrom?: string },
+      ],
+  ),
   prefetch,
   dependencies: [Dependencies.DUNE],
   isExpensiveAdapter: true,
+  methodology: {
+    Volume:
+      "All swaps executed through 1inch, as indexed by the 1inch-maintained Dune spellbook (oneinch.swaps; oneinch_solana.swaps for the Solana Fusion program): Aggregation Router v1-v6 classic swaps, standalone Limit Order Protocol fills including Fusion intent settlements, and Fusion+ cross-chain swaps. Each user swap is counted once: Limit Order Protocol fills executed inside an Aggregation Router transaction are routing liquidity already included in the router swap amount and are excluded, duplicate second-side rows of direct limit-order fills are excluded, and failed executions are excluded.",
+  },
 };
 
 export default adapter;

--- a/aggregators/1inch-agg/index.ts
+++ b/aggregators/1inch-agg/index.ts
@@ -102,13 +102,7 @@ const fetch = async (options: FetchOptions): Promise<FetchResult> => {
 const adapter: SimpleAdapter = {
   version: 1,
   fetch,
-  chains: Object.entries(chainConfig).map(
-    ([chain, { start, deadFrom }]) =>
-      [chain, deadFrom ? { start, deadFrom } : { start }] as [
-        string,
-        { start: string; deadFrom?: string },
-      ],
-  ),
+  adapter: chainConfig,
   prefetch,
   dependencies: [Dependencies.DUNE],
   isExpensiveAdapter: true,


### PR DESCRIPTION
## What is wrong today

The 1inch volume chart on DefiLlama is missing most of the protocol's history, for three stacked reasons:

1. **`start: "2023-12-05"` is just the date the adapter was added** — the `oneinch.swaps` spellbook it queries has complete history since **2019-06-03** (Aggregation Router v1/ExchangeV1). Nothing before Dec 2023 was ever backfilled.
2. **A stale pre-dimension-adapters segment** (Ethereum-only, 2021-01-07 → 2022-08-28, $13.5B total) is still in the DB, followed by a 464-day hole to 2023-12-05.
3. **Until the 2025-10-21 query update, the adapter's filter `(protocol = 'AR' OR flags['second_side'])` excluded all resolver-settled Fusion and standalone limit-order fills**, so even recorded years are badly under: 2024 recorded ≈ $111B vs ≈ $154B actual; 2025 recorded ≈ $118B vs ≈ $207B actual.

On top of that, **Solana is missing** (1inch Fusion live there since 2025-04-25; the spellbook covers it in `oneinch_solana.swaps`), and the pre-July-2025 chain map recorded zkSync Era volume under the "ZKsync Lite" chain label.

## What this PR changes

- Real **per-chain `start` dates** = `min(block_date)` actually present in the spellbook per chain (ethereum `2019-06-03`, bnb `2021-02-18`, polygon `2021-05-05`, arbitrum `2021-09-14`, optimism `2021-11-13`, avalanche `2021-12-22`, gnosis `2022-01-14`, fantom `2022-03-16`, zksync era `2023-04-25`, base `2023-08-08`, linea `2025-02-12`, solana `2025-04-25`, sonic `2025-05-26`, unichain `2025-05-26`).
- **Adds Solana** via `UNION ALL` with `oneinch_solana.swaps` (Fusion program fills; `oneinch.swaps` has no solana rows — verified).
- **Re-adds Fantom for its history** with `deadFrom: "2026-01-01"` (last real volume 2025, no live polling).
- **Counts each user swap exactly once** (see next section).
- Adds the missing `methodology` text.

## Methodology: count each user swap once

Decomposition of one day (2026-07-28, whole-history proportions similar):

| slice | fills | volume | of which in a tx that also has an AR row |
|---|---|---|---|
| AR (router swaps) | 17,752 | $67.79M | — |
| LO mode=fusion (intent settlements) | 7,317 | $32.01M | $0.51M (1.6%) |
| LO mode=limits (limit orders) | 12,541 | $14.42M | **$8.16M (57%)** |
| CC (Fusion+ cross-chain) | 72 | $0.10M | 0 |
| LO second_side rows | 132 | ~$918 | 0 |

The Aggregation Router uses the Limit Order Protocol as a routing **liquidity source**: an LO fill inside an AR transaction is a slice of that swap's amount, so summing both rows (the query since 2025-10-21) double-counts it (~7–8%/day). The pre-2025-10-21 filter had the opposite problem (excluded standalone fusion/limits entirely, ~33%/day). This PR keeps all AR rows and excludes: (a) LO/CC rows sharing a tx with an AR row, (b) `second_side` duplicate rows of direct limit-order fills, (c) failed executions (present in the CC stream). Cross-chain legs were checked too: of 158,226 Fusion+ (CC) orders in 2025, exactly **1** order appears on two chains — Fusion+ swaps land once, on the source chain, so there is no cross-leg double counting to correct (multiple same-chain rows per CC order exist, consistent with partial fills; worst-case bound ≤0.16% of annual volume). cc @grkhr (1inch data team, spellbook maintainer) to sanity-check this is the intended reading of `oneinch.swaps`.

## Backfill request (the point of this PR)

Please refill this adapter **from 2019-06-03 through today, all chains**, replacing what is stored — specifically:

- the legacy Ethereum-only 2021-01-07 → 2022-08-28 segment (different pipeline, ~10x under),
- everything recorded before 2025-10-21 (old filter, Fusion/limits missing),
- the stale **"ZKsync Lite"** chain rows (pre-#3690 chain-map mislabel; era volume lands on zkSync Era from the refill).

Expected result by year (deduped, from a one-shot full-history aggregation of `oneinch.swaps`):

| year | volume |
|---|---|
| 2019 (from Jun 3) | $25.9M |
| 2020 | $7.97B |
| 2021 | $148.5B |
| 2022 | $140.9B |
| 2023 | $108.2B |
| 2024 | $153.6B |
| 2025 | $207.2B |
| 2026 YTD | $26.4B |
| **lifetime** | **≈ $793B** (vs ≈ $270B currently recorded) |

To save Dune credits, a **public one-shot backfill query** is ready: [dune.com/queries/8158740](https://dune.com/queries/8158740) returns day × chain × volume for the whole range with the exact adapter methodology in a single execution (~10–15 credits on medium) instead of ~2,600 per-day runs — run/fork it, or point us at whichever refill path you prefer. A public parameterized day-window copy of the adapter SQL is at [dune.com/queries/8158737](https://dune.com/queries/8158737) for spot checks.

## Validation

- Byte-equivalent SQL (TIME_RANGE substituted exactly as `helpers/dune.ts` does) executed on Dune for four windows:
  - `2020-12-01`: ethereum $77.7M
  - `2021-05-10`: ethereum $663.0M + bnb $72.1M
  - `2025-06-01`: 12 chains incl. solana ($51.5k), total ≈ $1.17B — currently recorded: $411.6M (the pre-2025-10-21 filter, a 2.8x undercount on that day)
  - `2026-07-28`: 13 chains incl. solana, total ≈ $105.7M (currently recorded value for that day: $109.6M under the sum-everything query — the delta is the LOP-inside-AR dedup)
  - `2023-06-15` (inside the 464-day hole): 10 chains, total ≈ $883.8M — currently recorded: zero; this is the scale of data the refill draws
  - `2026-07-27`: 13 chains, total ≈ $106.7M vs $116.2M recorded — both recent-day deltas sit inside the expected envelope (dedup −7–8%, late-indexed rows +a few %)
- `tsc` clean on the file under the repo tsconfig.
- Note: `pnpm test aggregators 1inch-agg` was **not** run on this machine (no local `DUNE_API_KEY`) — the SQL itself was validated against Dune directly as above.

## Open question for maintainers

The bad-token blacklist is still commented out ("temp disable tokens filter 1inch", 2025-10-13). BSC 2025 alone is $82B across 69.6M fills, which looks like the wash-trading surface you fought in October 2025 ("remove 1inch bad vol bsc") — say the word and I'll re-enable `getDefaultDexTokensBlacklisted` in this PR so the backfill and ongoing data use one consistent filter.

Internal tracking: DAPP-7227.

Made with [Cursor](https://cursor.com)

