### PR TITLE
feat: add peeps.wtf adapter

### DIFF
--- a/dexs/peeps.ts
+++ b/dexs/peeps.ts
@@ -1,0 +1,99 @@
+import { Adapter, FetchOptions, FetchResultV2 } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+
+// https://peeps.wtf/launchpad
+// https://peeps-2.gitbook.io/peeps-docs
+// Fee structure:
+//   Bonding curve: 1.25% total — 0.40% creator / 0.85% protocol
+// Post-graduation swaps execute on Uniswap V3 (already tracked by the
+// uniswap-v3 adapter) and are not counted here to avoid double-counting.
+
+const FACTORY = "0x138C1C551bAd0F1c43084ddbC79F5E78225Eb9dD";
+const FACTORY_DEPLOY_BLOCK = 10814012;
+
+const TOKEN_CREATED =
+  "event TokenCreated(address indexed token, address indexed curve, address indexed creator, string name, string symbol, bytes32 metadataHash, string metadataUri, address pool, uint8 graduationCap, uint16 postGradCreatorShareBps)";
+const TRADE =
+  "event Trade(address indexed trader, bool indexed isBuy, uint256 ethAmount, uint256 tokenAmount, uint256 fee, uint256 virtualEthReserves, uint256 virtualTokenReserves, uint256 realEthReserves)";
+
+// Bonding curve: 1.25% = 40 creator + 85 protocol out of 125
+const CURVE_CREATOR_SHARE = 40n;
+const CURVE_PROTOCOL_SHARE = 85n;
+const CURVE_TOTAL_FEE = 125n;
+
+const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
+  const dailyVolume = options.createBalances();
+  const dailyFees = options.createBalances();
+  const dailyRevenue = options.createBalances();
+  const dailySupplySideRevenue = options.createBalances();
+
+  const tokenCreatedLogs = await options.getLogs({
+    target: FACTORY,
+    eventAbi: TOKEN_CREATED,
+    fromBlock: FACTORY_DEPLOY_BLOCK,
+    toBlock: await options.getToBlock(),
+    cacheInCloud: true,
+  });
+
+  const curves: string[] = [];
+  for (const log of tokenCreatedLogs) {
+    curves.push(log.curve as string);
+  }
+
+  if (curves.length > 0) {
+    const tradeLogs = await options.getLogs({ targets: curves, eventAbi: TRADE });
+    for (const log of tradeLogs) {
+      const fee = BigInt(log.fee);
+      dailyVolume.addGasToken(log.ethAmount);
+      dailyFees.addGasToken(fee, "Bonding Curve Fees");
+      dailyRevenue.addGasToken((fee * CURVE_PROTOCOL_SHARE) / CURVE_TOTAL_FEE, "Bonding Curve Protocol Fees");
+      dailySupplySideRevenue.addGasToken((fee * CURVE_CREATOR_SHARE) / CURVE_TOTAL_FEE, "Bonding Curve Creator Fees");
+    }
+  }
+
+  return {
+    dailyVolume,
+    dailyFees,
+    dailyRevenue,
+    dailyProtocolRevenue: dailyRevenue,
+    dailySupplySideRevenue,
+  };
+};
+
+const methodology = {
+  Volume: "ETH traded on PEEPS bonding curves.",
+  Fees: "1.25% fee on every bonding-curve trade, 0.40% paid to the token creator and 0.85% allocated to the PEEPS.WTF platform and ecosystem.",
+  Revenue: "0.85% platform fee from every bonding-curve trade, allocated to the PEEPS.WTF platform and ecosystem.",
+  ProtocolRevenue: "0.85% platform fee from every bonding-curve trade, allocated to the PEEPS.WTF platform and ecosystem.",
+  SupplySideRevenue: "0.40% creator fee from every bonding-curve trade, paid to the creator of the launched token.",
+};
+
+const breakdownMethodology = {
+  Fees: {
+    "Bonding Curve Fees": "1.25% fee on the ETH side of every bonding-curve buy and sell.",
+  },
+  Revenue: {
+    "Bonding Curve Protocol Fees": "0.85% of bonding-curve trade fees allocated to the PEEPS protocol.",
+  },
+  ProtocolRevenue: {
+    "Bonding Curve Protocol Fees": "0.85% of bonding-curve trade fees allocated to the PEEPS protocol.",
+  },
+  SupplySideRevenue: {
+    "Bonding Curve Creator Fees": "0.40% of bonding-curve trade fees claimable by each token's creator.",
+  },
+};
+
+const adapter: Adapter = {
+  version: 2,
+  pullHourly: true,
+  adapter: {
+    [CHAIN.ROBINHOOD]: {
+      fetch,
+      start: "2026-07-16",
+    },
+  },
+  methodology,
+  breakdownMethodology,
+};
+
+export default adapter;


### PR DESCRIPTION
## Summary
Adds a DEX adapter for PEEPS.WTF, a fair-launch bonding-curve launchpad on Robinhood Chain. Tracks volume and fees from bonding-curve trades via the factory's Trade events, with the 1.25% fee split between creators (0.40%) and the protocol (0.85%). Post-graduation Uniswap V3 swaps are excluded to avoid double-counting.
https://defillama.com/protocol/peeps

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Peeps protocol tracking on the Robinhood chain.
  * Reports daily trading volume, protocol fees, and creator revenue from bonding curve trades.
  * Accounts for fee distribution between the protocol and token creators.
  * Separately handles post-graduation Uniswap V3 activity to prevent duplicate reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->