### PR TITLE
feat: add surgecredit fees and revenue adapter

### DIFF
--- a/fees/surgecredit.ts
+++ b/fees/surgecredit.ts
@@ -1,0 +1,66 @@
+import { FetchOptions, SimpleAdapter } from "../adapters/types"
+import { CHAIN } from "../helpers/chains"
+import { METRIC } from "../helpers/metrics"
+import CoreAssets from "../helpers/coreAssets.json"
+
+// Surge Credit: Bitcoin collateralised USDC lending on Base.
+// https://docs.surge.credit/
+const LIQUIDITY_POOL = '0xEE755F1BbcbF6e3260469D0f473522d71d3bdDda'
+const USDC = CoreAssets.base.USDC
+
+const InterestAccruedAbi =
+  'event InterestAccrued(uint256 indexed marketId, uint256 totalInterest, uint256 protocolFee, uint256 supplierRevenue)'
+
+async function fetch(options: FetchOptions) {
+  const dailyFees = options.createBalances()
+  const dailyRevenue = options.createBalances()
+  const dailySupplySideRevenue = options.createBalances()
+
+  const logs = await options.getLogs({
+    target: LIQUIDITY_POOL,
+    eventAbi: InterestAccruedAbi,
+  })
+
+  for (const log of logs) {
+    dailyFees.add(USDC, log.totalInterest, METRIC.BORROW_INTEREST)
+    dailyRevenue.add(USDC, log.protocolFee, METRIC.BORROW_INTEREST)
+    dailySupplySideRevenue.add(USDC, log.supplierRevenue, METRIC.BORROW_INTEREST)
+  }
+
+  return {
+    dailyFees,
+    dailyRevenue,
+    dailyProtocolRevenue: dailyRevenue,
+    dailySupplySideRevenue,
+  }
+}
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  pullHourly: true,
+  chains: [CHAIN.BASE],
+  fetch,
+  start: '2026-03-20',
+  methodology: {
+    Fees: 'Total interest paid by borrowers on USDC credit lines collateralised by Bitcoin.',
+    Revenue: 'Protocol reserve portion of borrow interest, as emitted by the InterestAccrued event on the LiquidityPool.',
+    ProtocolRevenue: 'Protocol reserve portion of borrow interest, as emitted by the InterestAccrued event on the LiquidityPool.',
+    SupplySideRevenue: 'Portion of borrow interest distributed to USDC liquidity providers, as emitted by the InterestAccrued event on the LiquidityPool.',
+  },
+  breakdownMethodology: {
+    Fees: {
+      [METRIC.BORROW_INTEREST]: 'Gross USDC interest charged to borrowers, read from the totalInterest field of the InterestAccrued event.',
+    },
+    Revenue: {
+      [METRIC.BORROW_INTEREST]: 'Protocol reserve portion of borrow interest, read from the protocolFee field of the InterestAccrued event.',
+    },
+    ProtocolRevenue: {
+      [METRIC.BORROW_INTEREST]: 'Protocol reserve portion of borrow interest, read from the protocolFee field of the InterestAccrued event.',
+    },
+    SupplySideRevenue: {
+      [METRIC.BORROW_INTEREST]: 'LP portion of borrow interest, read from the supplierRevenue field of the InterestAccrued event.',
+    },
+  },
+}
+
+export default adapter

--- a/fees/surgecredit.ts
+++ b/fees/surgecredit.ts
@@ -9,22 +9,19 @@ const LIQUIDITY_POOL = '0xEE755F1BbcbF6e3260469D0f473522d71d3bdDda'
 const USDC = CoreAssets.base.USDC
 
 const InterestAccruedAbi =
-  'event InterestAccrued(uint256 indexed marketId, uint256 totalInterest, uint256 protocolFee, uint256 supplierRevenue)'
+  'event InterestAccrued(uint256 indexed marketId, uint256 interestAccrued, uint256 borrowIndex, uint256 supplyIndex)'
 
 async function fetch(options: FetchOptions) {
   const dailyFees = options.createBalances()
   const dailyRevenue = options.createBalances()
   const dailySupplySideRevenue = options.createBalances()
 
-  const logs = await options.getLogs({
-    target: LIQUIDITY_POOL,
-    eventAbi: InterestAccruedAbi,
-  })
+  const interestLogs = await options.getLogs({ target: LIQUIDITY_POOL, eventAbi: InterestAccruedAbi })
 
-  for (const log of logs) {
-    dailyFees.add(USDC, log.totalInterest, METRIC.BORROW_INTEREST)
-    dailyRevenue.add(USDC, log.protocolFee, METRIC.BORROW_INTEREST)
-    dailySupplySideRevenue.add(USDC, log.supplierRevenue, METRIC.BORROW_INTEREST)
+  for (const log of interestLogs) {
+    dailyFees.add(USDC, log.interestAccrued, METRIC.BORROW_INTEREST)
+    dailyRevenue.add(USDC, log.borrowIndex, METRIC.BORROW_INTEREST)
+    dailySupplySideRevenue.add(USDC, log.supplyIndex, METRIC.BORROW_INTEREST)
   }
 
   return {
@@ -37,28 +34,28 @@ async function fetch(options: FetchOptions) {
 
 const adapter: SimpleAdapter = {
   version: 2,
-  pullHourly: true,
   chains: [CHAIN.BASE],
+  pullHourly: true,
   fetch,
   start: '2026-03-20',
   methodology: {
-    Fees: 'Total interest paid by borrowers on USDC credit lines collateralised by Bitcoin.',
+    Fees: 'Borrow interest paid by borrowers on Bitcoin-collateralised USDC loans.',
     Revenue: 'Protocol reserve portion of borrow interest, as emitted by the InterestAccrued event on the LiquidityPool.',
     ProtocolRevenue: 'Protocol reserve portion of borrow interest, as emitted by the InterestAccrued event on the LiquidityPool.',
-    SupplySideRevenue: 'Portion of borrow interest distributed to USDC liquidity providers, as emitted by the InterestAccrued event on the LiquidityPool.',
+    SupplySideRevenue: 'Borrow interest distributed to USDC liquidity providers (LPs).',
   },
   breakdownMethodology: {
     Fees: {
-      [METRIC.BORROW_INTEREST]: 'Gross USDC interest charged to borrowers, read from the totalInterest field of the InterestAccrued event.',
+      [METRIC.BORROW_INTEREST]: 'Gross USDC interest accrued across all markets, read from the interestAccrued field of the InterestAccrued event.',
     },
     Revenue: {
-      [METRIC.BORROW_INTEREST]: 'Protocol reserve portion of borrow interest, read from the protocolFee field of the InterestAccrued event.',
+      [METRIC.BORROW_INTEREST]: 'Protocol reserve portion of borrow interest, read from the borrowIndex field of the InterestAccrued event.',
     },
     ProtocolRevenue: {
-      [METRIC.BORROW_INTEREST]: 'Protocol reserve portion of borrow interest, read from the protocolFee field of the InterestAccrued event.',
+      [METRIC.BORROW_INTEREST]: 'Protocol reserve portion of borrow interest, read from the borrowIndex field of the InterestAccrued event.',
     },
     SupplySideRevenue: {
-      [METRIC.BORROW_INTEREST]: 'LP portion of borrow interest, read from the supplierRevenue field of the InterestAccrued event.',
+      [METRIC.BORROW_INTEREST]: 'Borrow interest distributed to USDC liquidity providers (LPs), read from the supplyIndex field of the InterestAccrued event.',
     },
   },
 }


### PR DESCRIPTION
## Summary
Adds fees and revenue adapter for Surge Credit, a Bitcoin-collateralised USDC lending protocol on Base
- Tracks borrow interest via the `InterestAccrued` event on the LiquidityPool contract
- Docs: https://docs.surge.credit/
- https://defillama.com/protocol/surge-credit