### PR TITLE
Add Sabre fees adapter (Telegram trading bot, Solana)

### DIFF
--- a/fees/sabre.ts
+++ b/fees/sabre.ts
@@ -1,0 +1,88 @@
+import { Dependencies, FetchOptions, SimpleAdapter } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+import ADDRESSES from "../helpers/coreAssets.json";
+import { queryAllium } from "../helpers/allium";
+import { METRIC } from "../helpers/metrics";
+
+// Sabre (t.me/sabrex_bot) Solana Telegram trading bot.
+// Platform fee (currently 0.4%) on every buy/sell swap is sent directly to this wallet.
+const FEE_WALLET = "7EGhZWjtN7S9EtuQisALPwiMu8TnsbtKM9CbNGJRX25A";
+// Referral rewards are paid out from the fee wallet to this wallet.
+const REFERRAL_WALLET = "EnDqft6H2HPimWKAd5ueAh8YaYuonMWfkc6Yog9yCjA4";
+
+const LABELS = {
+  BOT_REVENUE: "Sabre trading fees excluding referral rewards",
+  REFERRAL_REWARDS: "Referral rewards",
+};
+
+const fetch = async (options: FetchOptions) => {
+  const query = `
+    WITH data AS (
+      SELECT
+        COALESCE(SUM(CASE WHEN to_address = '${FEE_WALLET}' AND from_address != '${REFERRAL_WALLET}' THEN raw_amount ELSE 0 END), 0) AS fees,
+        COALESCE(SUM(CASE WHEN from_address = '${FEE_WALLET}' AND to_address = '${REFERRAL_WALLET}' THEN raw_amount ELSE 0 END), 0) AS referral_rewards
+      FROM solana.assets.transfers
+      WHERE mint = '${ADDRESSES.solana.SOL}'
+        AND block_timestamp >= TO_TIMESTAMP_NTZ(${options.startTimestamp})
+        AND block_timestamp < TO_TIMESTAMP_NTZ(${options.endTimestamp})
+        AND (
+          to_address = '${FEE_WALLET}'
+          OR (from_address = '${FEE_WALLET}' AND to_address = '${REFERRAL_WALLET}')
+        )
+    )
+    SELECT fees, referral_rewards FROM data
+  `;
+
+  const result = (await queryAllium(query))[0];
+
+  const dailyFees = options.createBalances();
+  const dailyRevenue = options.createBalances();
+  const dailySupplySideRevenue = options.createBalances();
+
+  dailyFees.add(ADDRESSES.solana.SOL, result.fees, METRIC.TRADING_FEES);
+  dailySupplySideRevenue.add(ADDRESSES.solana.SOL, result.referral_rewards, LABELS.REFERRAL_REWARDS);
+  dailyRevenue.add(ADDRESSES.solana.SOL, result.fees, LABELS.BOT_REVENUE);
+  dailyRevenue.subtract(dailySupplySideRevenue, LABELS.BOT_REVENUE);
+
+  return {
+    dailyFees,
+    dailyRevenue,
+    dailyProtocolRevenue: dailyRevenue,
+    dailySupplySideRevenue,
+  };
+};
+
+const methodology = {
+  Fees: "Platform fee paid by users on every buy/sell swap executed through the Sabre Telegram bot.",
+  Revenue: "Trading fees kept by Sabre after referral rewards are paid out.",
+  ProtocolRevenue: "Trading fees kept by Sabre after referral rewards are paid out.",
+  SupplySideRevenue: "Referral rewards funded from the Sabre fee wallet and sent to the referral rewards wallet.",
+};
+
+const breakdownMethodology = {
+  Fees: {
+    [METRIC.TRADING_FEES]: "SOL sent to the Sabre fee wallet for every executed swap (currently 0.4% of trade size).",
+  },
+  Revenue: {
+    [LABELS.BOT_REVENUE]: "SOL fees retained by Sabre after referral rewards.",
+  },
+  ProtocolRevenue: {
+    [LABELS.BOT_REVENUE]: "SOL fees retained by Sabre after referral rewards.",
+  },
+  SupplySideRevenue: {
+    [LABELS.REFERRAL_REWARDS]: "Referral rewards paid out in SOL from the fee wallet to referrers.",
+  },
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  fetch,
+  chains: [CHAIN.SOLANA],
+  start: '2026-07-24',
+  pullHourly: true,
+  dependencies: [Dependencies.ALLIUM],
+  methodology,
+  breakdownMethodology,
+};
+
+export default adapter;


### PR DESCRIPTION
**Please enable "Allow edits by maintainers" on this PR (checkbox in the sidebar).**

Adds a fees/revenue adapter for **Sabre**, a Solana trading bot on Telegram.

Fetches SOL received by the platform fee wallet via Allium, net of referral rewards paid out from that wallet to the referral rewards wallet.

##### Name (to be shown on DefiLlama):
Sabre

##### Twitter Link:
(none yet)

##### List of audit links if any:
None

##### Website Link:
https://t.me/sabrex_bot

##### Logo (High resolution, will be shown with rounded borders):
Will attach in a follow-up comment on this PR.

##### Current TVL:
N/A (Telegram trading bot, no TVL - tracked via Fees/Revenue only)

##### Treasury Addresses (if the protocol has treasury):
N/A

##### Chain:
Solana

##### Coingecko ID:
N/A

##### Coinmarketcap ID:
N/A

##### Short Description (to be shown on DefiLlama):
Sabre is a Solana trading bot on Telegram (t.me/sabrex_bot) for fast token swaps. Alongside instant market buy/sell, it features a smart "Recurring" execution engine that splits large orders into steps and only fills each step when its price beats an instant market order, reducing slippage and improving the average execution price on both buys and sells.

##### Token address and ticker if any:
None

##### Category (full list at https://defillama.com/categories):
Telegram Bot

##### Oracle Provider(s):
N/A

##### Implementation Details:
N/A

##### Documentation/Proof:
Fee wallet: `7EGhZWjtN7S9EtuQisALPwiMu8TnsbtKM9CbNGJRX25A`
Referral rewards wallet: `EnDqft6H2HPimWKAd5ueAh8YaYuonMWfkc6Yog9yCjA4`

##### forkedFrom:
N/A

##### methodology (what is being counted as tvl, how is tvl being calculated):
N/A - this PR adds a Fees/Revenue adapter, not TVL. See `methodology`/`breakdownMethodology` in `fees/sabre.ts`.

##### Github org/user (Optional):
N/A

##### Does this project have a referral program?
Yes - referral rewards are paid out in SOL from the fee wallet to `EnDqft6H2HPimWKAd5ueAh8YaYuonMWfkc6Yog9yCjA4`, which is subtracted from `dailyRevenue` as `dailySupplySideRevenue` in the adapter.
