### PR TITLE
smardex: dont call getLogs when every pair gets filtered out

### DIFF
--- a/dexs/smardex/index.ts
+++ b/dexs/smardex/index.ts
@@ -24,6 +24,8 @@ export async function getAmmSwapVolume(options: FetchOptions) {
   ({ pairs, token0s, token1s } = await filterPools2({ fetchOptions: options, pairs, token0s, token1s }));
 
   const dailyVolume = options.createBalances();
+  if (!pairs.length) return dailyVolume;
+
   const allLogs = await options.getLogs({ targets: pairs, eventAbi: SWAP_EVENT, flatten: false });
   allLogs.forEach((logs: any[], i: number) => {
     for (const log of logs) {


### PR DESCRIPTION
follow-up to #8493; the last ci run there showed `Error: target|targets is required or set the flag "noTarget" to true`: when filterPools drops every pair on a chain (possible on the dust chains, pooled value threshold is $200), getLogs gets an empty targets array and throws. return the empty balances instead. rechecked ethereum and polygon on 2026-07-21, values unchanged