### PR TITLE
chainflip: protocol keeps nothing, network fee is all burned

### DIFF
--- a/fees/chainflip/index.ts
+++ b/fees/chainflip/index.ts
@@ -41,7 +41,7 @@ const fetch = async (options: FetchOptions) => {
 
     // Fees collected from burning $FLIP. This is a fixed percentage of swap value.
     dailyRevenue,
-    dailyProtocolRevenue: dailyRevenue,
+    dailyProtocolRevenue: 0,
 
     // Ingress, Egress, and Broker fees paid by the user per swap
     dailyUserFees,
@@ -66,6 +66,7 @@ const adapter: SimpleAdapter = {
     SupplySideRevenue:
       "Fees collected by the LPs + Broker, Ingress and Egress fees",
     HoldersRevenue: 'Fees collected from burning $FLIP.',
+    ProtocolRevenue: 'Protocol keeps no fees, network fees are entirely used to buy and burn $FLIP.',
   },
   breakdownMethodology: {
     Fees: {


### PR DESCRIPTION
the adapter returns `dailyProtocolRevenue: dailyRevenue` and `dailyHoldersRevenue` = the same network fees; the same dollars booked as both treasury-kept and burned. chainflip's network fee is entirely used to buy and burn FLIP (that's what the holders revenue booking from 7a21705a4 says, and the docs agree), so protocol revenue should be 0.

looks like a leftover: `dailyProtocolRevenue: dailyRevenue` predates the holders-revenue addition in march and never got updated when the burn booking landed, since then revenue fails the protocolRevenue + holdersRevenue identity (currently ~$7k/day booked twice, ~$2.5m/yr at current rates).

one line + a ProtocolRevenue methodology string. harness on 07-29 and 07-25: fees unchanged, revenue == holders revenue, protocol revenue 0, fees == revenue + supply side to the cent.