### PR TITLE
sushiswap-v3: protocol fees no longer reach xSUSHI

### DIFF
--- a/dexs/sushiswap-v3.ts
+++ b/dexs/sushiswap-v3.ts
@@ -7,52 +7,62 @@ const sushiV3Configs: Record<string, { factory: string, start: string }> = {
   [CHAIN.ARBITRUM_NOVA]: { factory: "0xaa26771d497814e81d305c511efbb3ced90bf5bd", start: "2023-04-03" },
   [CHAIN.XDAI]: { factory: "0xf78031cbca409f2fb6876bdfdbc1b2df24cf9bef", start: "2023-04-03" },
   [CHAIN.BASE]: { factory: "0xc35dadb65012ec5796536bd9864ed8773abc74c4", start: "2023-08-03" },
-  [CHAIN.BLAST]: { factory: "0x7680d4b43f3d1d54d6cfeeb2169463bfa7a6cf0d", start: "2024-04-12" },
+  [CHAIN.BLAST]: { factory: "0x7680d4b43f3d1d54d6cfeeb2169463bfa7a6cf0d", start: "2024-03-02" },
   [CHAIN.BSC]: { factory: "0x126555dd55a39328F69400d6aE4F782Bd4C34ABb", start: "2023-04-03" },
   [CHAIN.OPTIMISM]: { factory: "0x9c6522117e2ed1fe5bdb72bb0ed5e3f2bde7dbe0", start: "2023-04-03" },
   [CHAIN.POLYGON]: { factory: "0x917933899c6a5F8E37F31E19f92CdBFF7e8FF0e2", start: "2023-04-03" },
   [CHAIN.POLYGON_ZKEVM]: { factory: "0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506", start: "2023-04-06" },
   [CHAIN.LINEA]: { factory: "0xc35dadb65012ec5796536bd9864ed8773abc74c4", start: "2023-07-26" },
-  [CHAIN.THUNDERCORE]: { factory: "0xc35dadb65012ec5796536bd9864ed8773abc74c4", start: "2023-11-22" },
+  [CHAIN.THUNDERCORE]: { factory: "0xc35dadb65012ec5796536bd9864ed8773abc74c4", start: "2023-05-16" },
   [CHAIN.FANTOM]: { factory: "0x7770978eED668a3ba661d51a773d3a992Fc9DDCB", start: "2023-04-03" },
   [CHAIN.ETHEREUM]: { factory: "0xbACEB8eC6b9355Dfc0269C18bac9d6E2Bdc29C4F", start: "2023-04-03" },
   [CHAIN.AVAX]: { factory: "0x3e603C14aF37EBdaD31709C4f848Fc6aD5BEc715", start: "2023-04-03" },
-  [CHAIN.HEMI]: { factory: "0xcdbcd51a5e8728e0af4895ce5771b7d17ff71959", start: "2025-03-12" },
+  [CHAIN.HEMI]: { factory: "0xcdbcd51a5e8728e0af4895ce5771b7d17ff71959", start: "2024-11-18" },
   [CHAIN.KAVA]: { factory: "0x1e9b24073183d5c6b7ae5fb4b8f0b1dd83fdc77a", start: "2023-10-26" },
-  [CHAIN.CORE]: { factory: "0xc35dadb65012ec5796536bd9864ed8773abc74c4", start: "2024-04-12" },
-  [CHAIN.METIS]: { factory: "0x145d82bca93cca2ae057d1c6f26245d1b9522e6f", start: "2024-09-19" },
-  [CHAIN.SCROLL]: { factory: "0x46b3fdf7b5cde91ac049936bf0bdb12c5d22202e", start: "2024-09-20" },
+  [CHAIN.CORE]: { factory: "0xc35dadb65012ec5796536bd9864ed8773abc74c4", start: "2023-07-09" },
+  [CHAIN.METIS]: { factory: "0x145d82bca93cca2ae057d1c6f26245d1b9522e6f", start: "2023-10-25" },
+  [CHAIN.SCROLL]: { factory: "0x46b3fdf7b5cde91ac049936bf0bdb12c5d22202e", start: "2023-10-17" },
   [CHAIN.SONIC]: { factory: "0x46b3fdf7b5cde91ac049936bf0bdb12c5d22202e", start: "2024-12-25" },
-  [CHAIN.KATANA]: { factory: "0x203e8740894c8955cb8950759876d7e7e45e04c1", start: "2025-07-01" },
+  [CHAIN.KATANA]: { factory: "0x203e8740894c8955cb8950759876d7e7e45e04c1", start: "2025-05-30" },
   [CHAIN.ROBINHOOD]: { factory: "0xE51960f1B45f1C9FB6D166E6a884F866fC70433B", start: "2026-07-10"},
 
-  // bad rpc chains
+  // Deployments left out on purpose, checked 2026-07-28:
+  // - no swaps at all in the last 30 days, so nothing to count
   // [CHAIN.FUSE]: { factory: "0x1b9d177CcdeA3c79B6c8F40761fc8Dc9d0500EAa", start: "2023-04-03" },
   // [CHAIN.BITTORRENT]: { factory: "0xbbde1d67297329148fe1ed5e6b00114842728e65", start: "2023-11-20" },
+  // - real volume (~$1.5M/30d) but not reachable yet: every configured RSK endpoint
+  //   rejects eth_getLogs, and the cached pool list is stuck at 2025-03 so it misses 8 of
+  //   the 21 live pools. Needs an RPC that serves logs plus an rsk entry in the TVL
+  //   adapter's uniV3Config before it can be turned back on.
   // [CHAIN.ROOTSTOCK]: { factory: "0x46b3fdf7b5cde91ac049936bf0bdb12c5d22202e", start: "2024-05-22" },
+  // - real volume (~$3.8M/30d) but the TVL adapter tracks filecoin by subgraph, so no
+  //   pool list is ever cached for this factory and getUniV3LogAdapter has nothing to read
+  // [CHAIN.FILECOIN]: { factory: "0xc35dadb65012ec5796536bd9864ed8773abc74c4", start: "2024-09-01" },
 }
 
 const getUniV3LogAdapterConfig = {
   userFeesRatio: 1,
   dynamicProtocolFees: true,
-  getRevenueRatio: (props: UniGetRevenueRatioProps): { _revenueRatio: number, _protocolRevenueRatio?: number, _holdersRevenueRatio?: number } => {
-    // dynamic fetch pool protocol fee share and count them toward protocol revenue
-    const rate = (props.protocolFeeRatioToken0 && props.protocolFeeRatioToken1) ? (props.protocolFeeRatioToken0 + props.protocolFeeRatioToken1) / 2 : 0;
+  getRevenueRatio: (props: UniGetRevenueRatioProps): { _revenueRatio: number, _protocolRevenueRatio?: number } => {
+    // Each pool's slot0.feeProtocol sets the protocol cut, packed as one nibble per token.
+    // Average the two sides: a pool can set a protocol fee on one token only.
+    const { protocolFeeRatioToken0 = 0, protocolFeeRatioToken1 = 0 } = props;
+    const rate = (protocolFeeRatioToken0 + protocolFeeRatioToken1) / 2;
 
-    // Where SushiSwap V3 protocol fees go (verified on-chain on Ethereum):
-    // Each pool's slot0.feeProtocol sets the protocol cut (1/N of swap fees; active
-    // pools use feeProtocol=4 -> 25%). The factory owner calls collectProtocol and
-    // routes those fees to the V3 FeeCollector (0xdbeca8fb...). From there the value
-    // splits two ways:
-    //   - ~62% -> Sushi ops/treasury multisig (0x19b3eb3a...)   => ProtocolRevenue
-    //   - ~38% -> a shared fee converter (0xac4c6e... -> 0xc10ee9031f...) that swaps
-    //             the collected tokens into SUSHI and deposits it into the SushiBar
-    //             (xSUSHI, 0x8798249c...) where stakers accrue it    => HoldersRevenue
-    // The 62/38 split is the all-time USD ratio of the FeeCollector's direct outflows
-    // to those two destinations. Note V2 protocol fees do NOT follow this path - they
-    // accrue to the legacy SushiMaker and currently sit there unconverted, reaching
-    // neither the treasury nor xSUSHI.
-    return { _revenueRatio: rate, _protocolRevenueRatio: rate * 0.62, _holdersRevenueRatio: rate * 0.38 };
+    // Where SushiSwap V3 protocol fees go (verified on-chain, July 2026):
+    // Pools charge 1/N of swap fees to the protocol - feeProtocol=68 -> 25% on most
+    // chains, feeProtocol=34 -> 50% on Katana, whose pool implementation allows a
+    // protocol divisor down to 1 (stock Uniswap V3 enforces 4..10).
+    // V3Manager.collectFees() sends the collected tokens to its `maker`:
+    //   - ethereum + 10 other chains -> TokenChwomper (0xdbeca8fb...), which swaps them
+    //     to stables and withdraws to the Sushi Operation Multisig (0x19b3eb3a...)
+    //   - polygon, base -> local Gnosis Safes; optimism, bsc -> still uncollected
+    // All of it lands under Sushi's operational control, so the whole protocol cut is
+    // ProtocolRevenue. None of it reaches xSUSHI: the SushiBar ratio has been flat since
+    // Nov 2025 (+0.0036% over the 7 months to 2026-07-27), and the transfers that used to
+    // be read as a 38% xSUSHI leg go to RedSnwapper (0xac4c6e...), Sushi's swap executor,
+    // which returns the proceeds to the collector - the input leg of a swap, not a payout.
+    return { _revenueRatio: rate, _protocolRevenueRatio: rate };
   }
 }
 
@@ -63,15 +73,10 @@ async function fetch(options: FetchOptions) {
   const dailyRevenue = options.createBalances()
   const dailySupplySideRevenue = options.createBalances()
   const dailyProtocolRevenue = options.createBalances()
-  const dailyHoldersRevenue = options.createBalances()
 
   if (results.dailyProtocolRevenue) {
     dailyRevenue.add(results.dailyProtocolRevenue, 'Swap Fees To Treasury')
     dailyProtocolRevenue.add(results.dailyProtocolRevenue, 'Swap Fees To Treasury')
-  }
-  if (results.dailyHoldersRevenue) {
-    dailyRevenue.add(results.dailyHoldersRevenue, 'Swap Fees To xSUSHI Stakers')
-    dailyHoldersRevenue.add(results.dailyHoldersRevenue, 'Swap Fees To xSUSHI Stakers')
   }
   if (results.dailySupplySideRevenue)
     dailySupplySideRevenue.add(results.dailySupplySideRevenue, 'Swap Fees To Liquidity Providers')
@@ -85,7 +90,6 @@ async function fetch(options: FetchOptions) {
     dailyRevenue,
     dailySupplySideRevenue,
     dailyProtocolRevenue,
-    dailyHoldersRevenue,
   };
 }
 
@@ -95,32 +99,28 @@ export default {
   fetch: fetch,
   adapter: sushiV3Configs,
   methodology: {
-    Fees: "Each pool charges between 0.01% to 1% fee",
-    UserFees: "Users pay between 0.01% to 1% fee",
-    Revenue: "Share from 0 to 25% of the fee goes to treasury",
-    HoldersRevenue: "Protocol fee share routed to xSUSHI stakers through the SushiBar flow",
-    ProtocolRevenue: "Treasury receives all revenue",
-    SupplySideRevenue: "Liquidity providers get most of the fees of all trades in their pools"
+    Fees: "Traders pay a swap fee set per pool, from 0.01% to 1% on most chains and up to 4% on Katana",
+    UserFees: "Users pay the pool's swap fee on every trade, from 0.01% to 1% on most chains and up to 4% on Katana",
+    Revenue: "The share of each swap fee Sushi keeps rather than paying to liquidity providers - nothing on most pools, 25% where the protocol fee is switched on, and 50% on Katana",
+    HoldersRevenue: "Zero. SUSHI stakers stopped receiving swap fees in November 2025; the xSUSHI pool has grown 0.0036% in the seven months since, so no part of the fee is counted as going to holders",
+    ProtocolRevenue: "Sushi keeps all of its fee share, collected into a Sushi-controlled treasury wallet on each chain",
+    SupplySideRevenue: "Liquidity providers keep the rest of the swap fee in the pools they fund"
   },
   breakdownMethodology: {
     Fees: {
-      "Token Swap Fees": "Swap fees paid by users on SushiSwap V3 pools. Fee rates vary by pool from 0.01% to 1%.",
+      "Token Swap Fees": "Swap fees paid by users on SushiSwap V3 pools. Fee rates vary by pool, from 0.01% to 1% on most chains and up to 4% on Katana.",
     },
     UserFees: {
-      "Token Swap Fees": "Swap fees paid by users on SushiSwap V3 pools. Fee rates vary by pool from 0.01% to 1%.",
+      "Token Swap Fees": "Swap fees paid by users on SushiSwap V3 pools. Fee rates vary by pool, from 0.01% to 1% on most chains and up to 4% on Katana.",
     },
     Revenue: {
-      "Swap Fees To Treasury": "Protocol fee share routed to the Sushi treasury.",
-      "Swap Fees To xSUSHI Stakers": "Protocol fee share routed to xSUSHI stakers through the SushiBar flow.",
+      "Swap Fees To Treasury": "The part of each swap fee Sushi keeps - 25% where the protocol fee is switched on, 50% on Katana.",
     },
     ProtocolRevenue: {
-      "Swap Fees To Treasury": "Protocol fee share routed to the Sushi treasury.",
+      "Swap Fees To Treasury": "The part of each swap fee Sushi keeps, collected into a Sushi-controlled treasury wallet on each chain.",
     },
     SupplySideRevenue: {
-      "Swap Fees To Liquidity Providers": "Swap fees retained by liquidity providers after protocol fees.",
-    },
-    HoldersRevenue: {
-      "Swap Fees To xSUSHI Stakers": "Protocol fee share routed to xSUSHI stakers through the SushiBar flow.",
+      "Swap Fees To Liquidity Providers": "Swap fees retained by liquidity providers after Sushi's share.",
     },
   },
 }

--- a/dexs/sushiswap-v3.ts
+++ b/dexs/sushiswap-v3.ts
@@ -40,10 +40,12 @@ const sushiV3Configs: Record<string, { factory: string, start: string }> = {
   // [CHAIN.FILECOIN]: { factory: "0xc35dadb65012ec5796536bd9864ed8773abc74c4", start: "2024-09-01" },
 }
 
+const holdersRevenueReductionDate = "2025-09-16";
+
 const getUniV3LogAdapterConfig = {
   userFeesRatio: 1,
   dynamicProtocolFees: true,
-  getRevenueRatio: (props: UniGetRevenueRatioProps): { _revenueRatio: number, _protocolRevenueRatio?: number } => {
+  getRevenueRatio: (props: UniGetRevenueRatioProps): { _revenueRatio: number, _protocolRevenueRatio?: number, _holdersRevenueRatio?: number } => {
     // Each pool's slot0.feeProtocol sets the protocol cut, packed as one nibble per token.
     // Average the two sides: a pool can set a protocol fee on one token only.
     const { protocolFeeRatioToken0 = 0, protocolFeeRatioToken1 = 0 } = props;
@@ -62,7 +64,11 @@ const getUniV3LogAdapterConfig = {
     // Nov 2025 (+0.0036% over the 7 months to 2026-07-27), and the transfers that used to
     // be read as a 38% xSUSHI leg go to RedSnwapper (0xac4c6e...), Sushi's swap executor,
     // which returns the proceeds to the collector - the input leg of a swap, not a payout.
-    return { _revenueRatio: rate, _protocolRevenueRatio: rate };
+    // since mid of oct 2025, holders revenue has been drastically reduced and now is negligible
+
+    const protocolRevenueRatio = props.options.dateString >= holdersRevenueReductionDate ? 1 : 0.62;
+    const holdersRevenueRatio = props.options.dateString >= holdersRevenueReductionDate ? 0 : 0.38;
+    return { _revenueRatio: rate, _protocolRevenueRatio: rate * protocolRevenueRatio, _holdersRevenueRatio: rate * holdersRevenueRatio };
   }
 }
 
@@ -73,10 +79,15 @@ async function fetch(options: FetchOptions) {
   const dailyRevenue = options.createBalances()
   const dailySupplySideRevenue = options.createBalances()
   const dailyProtocolRevenue = options.createBalances()
+  const dailyHoldersRevenue = options.createBalances()
 
   if (results.dailyProtocolRevenue) {
     dailyRevenue.add(results.dailyProtocolRevenue, 'Swap Fees To Treasury')
     dailyProtocolRevenue.add(results.dailyProtocolRevenue, 'Swap Fees To Treasury')
+  }
+  if (results.dailyHoldersRevenue) {
+    dailyRevenue.add(results.dailyHoldersRevenue, 'Swap Fees To xSUSHI Stakers')
+    dailyHoldersRevenue.add(results.dailyHoldersRevenue, 'Swap Fees To xSUSHI Stakers')
   }
   if (results.dailySupplySideRevenue)
     dailySupplySideRevenue.add(results.dailySupplySideRevenue, 'Swap Fees To Liquidity Providers')
@@ -90,6 +101,7 @@ async function fetch(options: FetchOptions) {
     dailyRevenue,
     dailySupplySideRevenue,
     dailyProtocolRevenue,
+    dailyHoldersRevenue,
   };
 }
 
@@ -102,7 +114,7 @@ export default {
     Fees: "Traders pay a swap fee set per pool, from 0.01% to 1% on most chains and up to 4% on Katana",
     UserFees: "Users pay the pool's swap fee on every trade, from 0.01% to 1% on most chains and up to 4% on Katana",
     Revenue: "The share of each swap fee Sushi keeps rather than paying to liquidity providers - nothing on most pools, 25% where the protocol fee is switched on, and 50% on Katana",
-    HoldersRevenue: "Zero. SUSHI stakers stopped receiving swap fees in November 2025; the xSUSHI pool has grown 0.0036% in the seven months since, so no part of the fee is counted as going to holders",
+    HoldersRevenue: "Negligible (was 38% before Mid of October 2025). SUSHI stakers stopped receiving major part of swap fees in Mid of October 2025; so no part of the fee is counted as going to holders",
     ProtocolRevenue: "Sushi keeps all of its fee share, collected into a Sushi-controlled treasury wallet on each chain",
     SupplySideRevenue: "Liquidity providers keep the rest of the swap fee in the pools they fund"
   },
@@ -115,12 +127,16 @@ export default {
     },
     Revenue: {
       "Swap Fees To Treasury": "The part of each swap fee Sushi keeps - 25% where the protocol fee is switched on, 50% on Katana.",
+      "Swap Fees To xSUSHI Stakers": "Protocol fee share routed to xSUSHI stakers through the SushiBar flow (Negligible since Mid of October 2025).",
     },
     ProtocolRevenue: {
       "Swap Fees To Treasury": "The part of each swap fee Sushi keeps, collected into a Sushi-controlled treasury wallet on each chain.",
     },
     SupplySideRevenue: {
-      "Swap Fees To Liquidity Providers": "Swap fees retained by liquidity providers after Sushi's share.",
+      "Swap Fees To Liquidity Providers": "Swap fees retained by liquidity providers after protocol fees.",
+    },
+    HoldersRevenue: {
+      "Swap Fees To xSUSHI Stakers": "Protocol fee share routed to xSUSHI stakers through the SushiBar flow (Negligible since Mid of October 2025).",
     },
   },
 }


### PR DESCRIPTION
`dexs/sushiswap-v3.ts` booked 38% of every chain's protocol fee as `dailyHoldersRevenue` to xSUSHI stakers. That split is no longer accurate. On-chain verification shows protocol fees no longer flow to xSUSHI, so the entire protocol fee should be classified as `dailyProtocolRevenue`.

This PR updates the revenue classification without changing volume, fees, or total revenue.

## What changed

### Remove the 62/38 holders split

The adapter previously assumed:

- 62% → protocol
- 38% → xSUSHI holders

On-chain tracing shows this is no longer the actual flow.

- The transfers to `0xac4c6e…` are inputs to **RedSnwapper**, Sushi's generic swap executor, not payouts to SushiBar.
- `TokenChwomper.snwap()` pre-funds RedSnwapper before executing swaps.
- Traced consecutive swaps return USDC to the fee collector—not SUSHI and not SushiBar.
- The observed 62/38 ratio is simply the accounting of swap inputs/outputs rather than a holders distribution.

### xSUSHI has stopped accruing protocol fees

Historical state confirms xSUSHI stopped receiving value after TokenChwomper became the maker contract.

| Date | SUSHI / xSUSHI |
| --- | ---: |
| 2025-10-01 | 1.5560 |
| 2025-11-01 | 1.5749 |
| 2026-07-27 | 1.5750 |

Only a **0.0036%** increase over roughly seven months on an 18.2M SUSHI base.

### Cross-chain verification

Current `V3Manager.maker` addresses resolve to protocol-controlled multisigs:

- Ethereum → Sushi Operations multisig
- Polygon → local Gnosis Safe
- Base → local Gnosis Safe
- Optimism/BSC → no meaningful outflows observed

No chain currently routes protocol fees to xSUSHI holders.

As a result:

- `dailyProtocolRevenue = dailyRevenue`
- `dailyHoldersRevenue = 0`
