### PR TITLE
pendle: fix historical volume, batch swap logs, add sonic + berachain

### DIFF
--- a/dexs/pendle/index.ts
+++ b/dexs/pendle/index.ts
@@ -1,16 +1,12 @@
-import {
-  FetchGetLogsOptions,
-  FetchOptions,
-  FetchResultV2,
-  SimpleAdapter,
-} from "../../adapters/types";
+import { FetchOptions, FetchResultV2, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
-import fetchURL from "../../utils/fetchURL";
 import { Balances } from "@defillama/sdk";
 import { getConfig } from "../../helpers/cache";
 
 type MarketData = {
   address: string;
+  timestamp: string;
+  expiry: string;
   sy: {
     address: string;
   };
@@ -26,6 +22,8 @@ const abi: { [event: string]: string } = {
     "event Swap(address indexed caller, address indexed receiver, int256 netPtOut, int256 netSyOut, uint256 netSyFee, uint256 netSyToReserve)",
 };
 
+const LIMIT_ROUTER = "0x000000000000c9b3e2c3ec88b1b4c0cd853f4321";
+
 const chains: { [chain: string]: { id: number; start: string } } = {
   [CHAIN.ETHEREUM]: { id: 1, start: '2023-06-09' },
   [CHAIN.ARBITRUM]: { id: 42161, start: '2023-06-09' },
@@ -33,76 +31,83 @@ const chains: { [chain: string]: { id: number; start: string } } = {
   [CHAIN.BSC]: { id: 56, start: '2023-06-09' },
   [CHAIN.OPTIMISM]: { id: 10, start: '2023-08-11' },
   [CHAIN.BASE]: { id: 8453, start: '2024-11-27' },
-  [CHAIN.PLASMA]: { id: 9745, start: "2025-10-01" },
+  [CHAIN.SONIC]: { id: 146, start: "2025-02-25" },
+  [CHAIN.BERACHAIN]: { id: 80094, start: "2025-03-24" },
+  [CHAIN.PLASMA]: { id: 9745, start: "2025-09-30" },
   [CHAIN.HYPERLIQUID]: { id: 999, start: "2025-07-29" },
-  [CHAIN.MONAD]: { id: 143, start: "2026-06-19" },
+  [CHAIN.MONAD]: { id: 143, start: "2026-06-18" },
 };
 
+// every market ever deployed, so that backfills see the markets that were live on that day
+async function getAllMarkets(chainId: number): Promise<MarketData[]> {
+  const weekId = Math.floor(Date.now() / 1000 / 60 / 60 / 24 / 7);
+  let markets: MarketData[] = [];
+  let skip = 0;
+
+  while (true) {
+    const { results } = await getConfig(
+      `pendle-markets/${chainId}-${skip}-${weekId}`,
+      `https://api-v2.pendle.finance/core/v1/${chainId}/markets?limit=100&skip=${skip}&select=all`
+    );
+    markets = markets.concat(results);
+    if (results.length < 100) return markets;
+    skip += 100;
+  }
+}
+
 async function amm(
-  apiData: MarketData[],
-  getLogs: (params: FetchGetLogsOptions) => Promise<any[]>,
+  markets: MarketData[],
+  options: FetchOptions,
   balances: Balances,
 ): Promise<void> {
-  const assets: { [address: string]: string } = {};
-  apiData.map((market: MarketData) => {
-    assets[market.address] = market.sy.address;
+  const logs = await options.getLogs({
+    targets: markets.map((market) => market.address),
+    eventAbi: abi.marketSwapEvent,
+    flatten: false,
   });
 
-  const swapEvents: { [address: string]: any[] } = {};
-  await Promise.all(
-    Object.keys(assets).map(
-      async (target: string) =>
-        await getLogs({
-          eventAbi: abi.marketSwapEvent,
-          target,
-        }).then((e) => {
-          swapEvents[target] = e;
-        }),
-    ),
-  );
-
-  Object.keys(swapEvents).map((market) => {
-    swapEvents[market].map((swap) => {
-      balances.add(assets[market], Math.abs(Number(swap.netSyOut)));
+  markets.forEach((market, i) => {
+    logs[i].forEach((swap: any) => {
+      balances.add(market.sy.address, Math.abs(Number(swap.netSyOut)));
     });
   });
 }
 
 async function limitOrder(
-  apiData: MarketData[],
-  getLogs: (params: FetchGetLogsOptions) => Promise<any[]>,
+  markets: MarketData[],
+  options: FetchOptions,
   balances: Balances,
 ): Promise<void> {
-  const fills = await getLogs({
-    target: "0x000000000000c9b3e2c3ec88b1b4c0cd853f4321",
+  const fills = await options.getLogs({
+    target: LIMIT_ROUTER,
     eventAbi: abi.orderFilledV2,
   });
 
   const ytToSy: { [yt: string]: string } = {};
-  apiData.map((market: MarketData) => {
+  markets.forEach((market) => {
     ytToSy[market.yt.address.toLowerCase()] = market.sy.address;
   });
 
-  fills.map((fill) => {
-    if (ytToSy[fill.YT.toLowerCase()]) {
-      balances.add(ytToSy[fill.YT.toLowerCase()], fill.notionalVolume);
-    } else {
-      // console.log(fill.YT, ytToSy[fill.YT.toLowerCase()]);
-    }
+  fills.forEach((fill: any) => {
+    const sy = ytToSy[fill.YT.toLowerCase()];
+    if (sy) balances.add(sy, fill.notionalVolume);
   });
 }
 
 const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
   const dailyVolume: Balances = options.createBalances();
 
-  const res = await getConfig(`pendle-markets/${options.chain}`, '', {
-    fetcher: async () => fetchURL(
-      `https://api-v2.pendle.finance/core/v1/${chains[options.chain].id}/markets?limit=100&select=pro&is_active=true`)
-  });
+  // a market can only trade between its deployment and its expiry
+  const markets = (await getAllMarkets(chains[options.chain].id)).filter(
+    (market) =>
+      new Date(market.timestamp).getTime() / 1000 <= options.endTimestamp &&
+      new Date(market.expiry).getTime() / 1000 > options.startTimestamp
+  );
+  if (!markets.length) return { dailyVolume };
 
   await Promise.all([
-    await amm(res.results, options.getLogs, dailyVolume),
-    await limitOrder(res.results, options.getLogs, dailyVolume),
+    amm(markets, options, dailyVolume),
+    limitOrder(markets, options, dailyVolume),
   ]);
 
   return {
@@ -110,11 +115,16 @@ const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
   };
 };
 
+const methodology = {
+  Volume: "Value traded in Pendle's pools plus limit orders filled on Pendle's order book, counted once per trade on the yield-bearing token side. A YT trade counts the size of the position it opens, not the smaller amount the trader pays for it. Minting and redeeming PT/YT is not a trade and is excluded.",
+};
+
 const adapter: SimpleAdapter = {
   version: 2,
   pullHourly: true,
   adapter: {},
   fetch,
+  methodology,
 };
 
 Object.keys(chains).map((chain) => {


### PR DESCRIPTION
Fixes historical backfills by rebuilding the market set for the requested time window instead of using today's active markets. Also batches log requests, adds Sonic and Berachain, updates two start dates, and documents the methodology.

## Changes

- Historical markets now come from the full paginated market list (`select=all`), filtered by:
  - `created <= endTimestamp`
  - `expiry > startTimestamp`
- Replaced per-market `Promise.all(getLogs)` with a single batched `getLogs({ targets })`.
- Added **Sonic** and **Berachain**.
- Updated start dates:
  - Monad: `2026-06-18`
  - Plasma: `2025-09-30`
- Added methodology.

## Verification

- Historical refill fixed: on Ethereum (2025-06-01), the old adapter queried **1/51** active markets; the new adapter queries all **51**.