### PR TITLE
feat(primit): standalone Primit derivatives adapter (self-reported native volume)

### DIFF
--- a/dexs/primit-perps/index.ts
+++ b/dexs/primit-perps/index.ts
@@ -61,6 +61,8 @@ const fetch = async (options: FetchOptions) => {
 };
 
 const adapter: SimpleAdapter = {
+  version: 2,
+  pullHourly: true,
   fetch,
   chains: [CHAIN.AVAX],
   start: "2026-07-16",

--- a/dexs/primit/index.ts
+++ b/dexs/primit/index.ts
@@ -1,53 +1,63 @@
-import { httpGet } from "../../utils/fetchURL";
-import { SimpleAdapter, FetchOptions } from "../../adapters/types";
+import { FetchOptions, FetchV2, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 
-// Primit self-reported daily volume.
+// Primit on-chain trade log (Avalanche C-Chain).
 //
-// Data comes from Primit's own matching engine only (LAB permanent-futures
-// market and other native pairs written to Primit's `public.trades` table),
-// with market-maker self-trades excluded.
+// Every fill matched on Primit's own engine is emitted as a `TradeRecorded`
+// event by our TradeRecorder contract. This adapter walks the day's event
+// range and sums `price * amount` (both 1e18 fixed-point) to derive daily
+// USD notional. No off-chain data source — anything DeFiLlama shows for
+// Primit is independently reconstructable from AVAX C-Chain event logs.
 //
-// Volume that Primit routes to Orderly Network (BTC/ETH/SOL/etc via
-// broker_id=primit) is NOT reported here — that portion is attributed
-// separately by DeFiLlama via `factory/orderly.ts` (see PR #8115). The
-// two pair sets do not overlap, so no double-counting occurs.
-//
-// Endpoint is public, unauthenticated, and returns strictly UTC-day totals.
-const API = "https://api.primit.io/api/v1/public/stats/daily-volume";
+// Volume routed through Orderly Network (BTC/ETH/etc) is attributed
+// separately by DeFiLlama's factory/orderly.ts under broker_id=primit
+// (see PR #8115). The two pair sets are disjoint, so no double-counting.
+const TRADE_RECORDER = "0xC005A9bb11f162329f3EfCCc35F69F9Bb635EeC6";
+
+const abi = {
+  TradeRecorded:
+    "event TradeRecorded(bytes32 indexed tradeId, address indexed taker, address indexed maker, string symbol, uint8 side, uint256 price, uint256 amount, int256 takerFee, int256 makerFee, bool isClose, uint64 filledAt)",
+};
 
 const methodology = {
   Volume:
-    "Trading volume settled on Primit's own matching engine (LAB perpetual-futures market and other Primit-native pairs). Excludes market-maker self-trades. Excludes volume routed through Orderly Network (attributed separately via factory/orderly.ts under broker_id=primit; the two pair sets are disjoint, so no double-counting).",
+    "Sum of `price * amount` for every TradeRecorded event emitted by Primit's TradeRecorder contract (0xC005A9bb11f162329f3EfCCc35F69F9Bb635EeC6 on Avalanche C-Chain) during the UTC day. Both `price` and `amount` are 1e18 fixed-point, so the product is scaled by 1e36 and normalized down to floating USD before returning. Data is 100% reconstructable on-chain — no dependency on any Primit-operated HTTP endpoint. Volume routed through Orderly Network (BTC/ETH/etc via broker_id=primit) is attributed separately by factory/orderly.ts and NOT double-counted here.",
 };
 
-interface PrimitVolumeResponse {
-  date: string;
-  start_of_day_unix: number;
-  end_of_day_unix: number;
-  total_volume_usd: string;
-  trade_count: number;
-  scope: string;
-}
+const SCALE_18 = 10n ** 18n;
 
-const fetch = async (options: FetchOptions) => {
-  const date = new Date(options.startOfDay * 1000)
-    .toISOString()
-    .slice(0, 10);
-  const res: PrimitVolumeResponse = await httpGet(
-    `${API}?date=${date}`,
-    { timeout: 15000 }
-  );
-  return {
-    dailyVolume: Number(res.total_volume_usd),
-  };
+const fetch: FetchV2 = async (options: FetchOptions) => {
+  const logs: any[] = await options.getLogs({
+    target: TRADE_RECORDER,
+    eventAbi: abi.TradeRecorded,
+  });
+
+  // Accumulate as bigint in 1e18 fixed-point USD, then convert once at the
+  // end. price * amount is 1e36 fixed-point, so /1e18 keeps it at 1e18.
+  // A single trade at $1M notional is 1e6 * 1e18 = 1e24 wei-USD; the daily
+  // sum easily fits in a bigint. Final divide to Number is safe because
+  // realistic daily USD totals stay below 2^53 / 1e18 (≈ 9e9 USD).
+  let totalWeiUsd: bigint = 0n;
+  for (const log of logs) {
+    const price = BigInt(log.price.toString());
+    const amount = BigInt(log.amount.toString());
+    totalWeiUsd += (price * amount) / SCALE_18;
+  }
+
+  const dailyVolume = Number(totalWeiUsd) / 1e18;
+
+  return { dailyVolume };
 };
 
 const adapter: SimpleAdapter = {
-  fetch,
-  chains: [CHAIN.AVAX],
-  start: "2026-07-01",
-  methodology,
+  version: 2,
+  adapter: {
+    [CHAIN.AVAX]: {
+      fetch,
+      start: "2026-07-16",
+      meta: { methodology },
+    },
+  },
 };
 
 export default adapter;

--- a/dexs/primit/index.ts
+++ b/dexs/primit/index.ts
@@ -32,9 +32,8 @@ const fetch = async (options: FetchOptions) => {
     eventAbi: abi.TradeRecorded,
   });
 
-  // Accumulate as bigint in 1e18 fixed-point USD, then convert once at the
-  // end. price * amount is 1e36 fixed-point, so /1e18 keeps it at 1e18.
-  // Realistic daily USD totals stay well below 2^53 / 1e18 (≈ 9e9 USD).
+  // Accumulate as bigint in 1e18 fixed-point USD. price * amount is 1e36
+  // fixed-point, so /1e18 keeps it at 1e18.
   let totalWeiUsd: bigint = 0n;
   for (const log of logs) {
     // Defense in depth: skip self-trades (backend also filters, but the
@@ -48,7 +47,15 @@ const fetch = async (options: FetchOptions) => {
     totalWeiUsd += (price * amount) / SCALE_18;
   }
 
-  const dailyVolume = Number(totalWeiUsd) / 1e18;
+  // Convert bigint → float in two parts to avoid Number precision loss.
+  // Number can only represent integers exactly up to 2^53 (~9e15); a
+  // single-shot `Number(totalWeiUsd) / 1e18` silently rounds once the
+  // day's wei-USD sum exceeds that (≈ 0.009 USD in wei-USD terms — i.e.
+  // essentially always). Split into whole USD (safe up to ~9 quadrillion
+  // USD/day) plus sub-USD fraction to keep full precision.
+  const wholeUsd = Number(totalWeiUsd / SCALE_18);
+  const fracUsd = Number(totalWeiUsd % SCALE_18) / 1e18;
+  const dailyVolume = wholeUsd + fracUsd;
 
   return { dailyVolume };
 };

--- a/dexs/primit/index.ts
+++ b/dexs/primit/index.ts
@@ -1,4 +1,4 @@
-import { FetchOptions, FetchV2, SimpleAdapter } from "../../adapters/types";
+import { FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 
 // Primit on-chain trade log (Avalanche C-Chain).
@@ -21,12 +21,12 @@ const abi = {
 
 const methodology = {
   Volume:
-    "Sum of `price * amount` for every TradeRecorded event emitted by Primit's TradeRecorder contract (0xC005A9bb11f162329f3EfCCc35F69F9Bb635EeC6 on Avalanche C-Chain) during the UTC day. Both `price` and `amount` are 1e18 fixed-point, so the product is scaled by 1e36 and normalized down to floating USD before returning. Data is 100% reconstructable on-chain — no dependency on any Primit-operated HTTP endpoint. Volume routed through Orderly Network (BTC/ETH/etc via broker_id=primit) is attributed separately by factory/orderly.ts and NOT double-counted here.",
+    "Sum of `price * amount` for every TradeRecorded event emitted by Primit's TradeRecorder contract (0xC005A9bb11f162329f3EfCCc35F69F9Bb635EeC6 on Avalanche C-Chain) during the UTC day, excluding self-trades where taker == maker. Both `price` and `amount` are 1e18 fixed-point, so the product is scaled by 1e36 and normalized down to floating USD before returning. Data is 100% reconstructable on-chain — no dependency on any Primit-operated HTTP endpoint. Volume routed through Orderly Network (BTC/ETH/etc via broker_id=primit) is attributed separately by factory/orderly.ts and NOT double-counted here.",
 };
 
 const SCALE_18 = 10n ** 18n;
 
-const fetch: FetchV2 = async (options: FetchOptions) => {
+const fetch = async (options: FetchOptions) => {
   const logs: any[] = await options.getLogs({
     target: TRADE_RECORDER,
     eventAbi: abi.TradeRecorded,
@@ -34,11 +34,15 @@ const fetch: FetchV2 = async (options: FetchOptions) => {
 
   // Accumulate as bigint in 1e18 fixed-point USD, then convert once at the
   // end. price * amount is 1e36 fixed-point, so /1e18 keeps it at 1e18.
-  // A single trade at $1M notional is 1e6 * 1e18 = 1e24 wei-USD; the daily
-  // sum easily fits in a bigint. Final divide to Number is safe because
-  // realistic daily USD totals stay below 2^53 / 1e18 (≈ 9e9 USD).
+  // Realistic daily USD totals stay well below 2^53 / 1e18 (≈ 9e9 USD).
   let totalWeiUsd: bigint = 0n;
   for (const log of logs) {
+    // Defense in depth: skip self-trades (backend also filters, but the
+    // adapter shouldn't trust off-chain filtering when the reviewer can
+    // verify only what's on-chain).
+    if (String(log.taker).toLowerCase() === String(log.maker).toLowerCase()) {
+      continue;
+    }
     const price = BigInt(log.price.toString());
     const amount = BigInt(log.amount.toString());
     totalWeiUsd += (price * amount) / SCALE_18;
@@ -50,14 +54,10 @@ const fetch: FetchV2 = async (options: FetchOptions) => {
 };
 
 const adapter: SimpleAdapter = {
-  version: 2,
-  adapter: {
-    [CHAIN.AVAX]: {
-      fetch,
-      start: "2026-07-16",
-      meta: { methodology },
-    },
-  },
+  fetch,
+  chains: [CHAIN.AVAX],
+  start: "2026-07-16",
+  methodology,
 };
 
 export default adapter;

--- a/dexs/primit/index.ts
+++ b/dexs/primit/index.ts
@@ -1,0 +1,53 @@
+import { httpGet } from "../../utils/fetchURL";
+import { SimpleAdapter, FetchOptions } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+
+// Primit self-reported daily volume.
+//
+// Data comes from Primit's own matching engine only (LAB permanent-futures
+// market and other native pairs written to Primit's `public.trades` table),
+// with market-maker self-trades excluded.
+//
+// Volume that Primit routes to Orderly Network (BTC/ETH/SOL/etc via
+// broker_id=primit) is NOT reported here — that portion is attributed
+// separately by DeFiLlama via `factory/orderly.ts` (see PR #8115). The
+// two pair sets do not overlap, so no double-counting occurs.
+//
+// Endpoint is public, unauthenticated, and returns strictly UTC-day totals.
+const API = "https://api.primit.io/api/v1/public/stats/daily-volume";
+
+const methodology = {
+  Volume:
+    "Trading volume settled on Primit's own matching engine (LAB perpetual-futures market and other Primit-native pairs). Excludes market-maker self-trades. Excludes volume routed through Orderly Network (attributed separately via factory/orderly.ts under broker_id=primit; the two pair sets are disjoint, so no double-counting).",
+};
+
+interface PrimitVolumeResponse {
+  date: string;
+  start_of_day_unix: number;
+  end_of_day_unix: number;
+  total_volume_usd: string;
+  trade_count: number;
+  scope: string;
+}
+
+const fetch = async (options: FetchOptions) => {
+  const date = new Date(options.startOfDay * 1000)
+    .toISOString()
+    .slice(0, 10);
+  const res: PrimitVolumeResponse = await httpGet(
+    `${API}?date=${date}`,
+    { timeout: 15000 }
+  );
+  return {
+    dailyVolume: Number(res.total_volume_usd),
+  };
+};
+
+const adapter: SimpleAdapter = {
+  fetch,
+  chains: [CHAIN.AVAX],
+  start: "2026-07-01",
+  methodology,
+};
+
+export default adapter;


### PR DESCRIPTION
## Summary

Adds `dexs/primit/index.ts` — a standalone derivatives adapter that reports Primit's own matching-engine daily volume, pulled from a public JSON endpoint at `api.primit.io`.

**Context:** Primit was previously added as an Orderly Network builder in [#8115](https://github.com/DefiLlama/dimension-adapters/pull/8115) via `factory/orderly.ts` with `broker_id=primit`. Since then Primit has launched its own perpetual-futures matching engine hosting native pairs (Primit-native perpetual markets, with more coming) that don't route through Orderly.

This PR reports **only** that native-engine volume. The existing `factory/orderly.ts` entry is left in place — it continues to attribute the Orderly-routed portion (BTC/ETH/etc). The two pair sets are disjoint, so no double-counting.

### Data flow

```
Primit backend (Rust · Axum · sqlx)
  └─ public.trades table (self-hosted matching engine, our reference perpetual pair + native pairs)
       └─ SQL: SUM(amount * price) WHERE created_at ∈ [start, end) UTC
                                     AND is_self_trade = false
                └─ GET https://api.primit.io/api/v1/public/stats/daily-volume?date=YYYY-MM-DD
                     └─ dexs/primit/index.ts (this PR)
                          └─ dailyVolume in USD → DeFiLlama
```

Endpoint is public and unauthenticated. `is_self_trade = false` filter excludes market-maker wash trades so the publicly reported number isn't inflated.

### Endpoint contract

```
GET https://api.primit.io/api/v1/public/stats/daily-volume?date=YYYY-MM-DD
```

Example (real production data):
```
$ curl 'https://api.primit.io/api/v1/public/stats/daily-volume?date=2026-07-30'
{
  "date": "2026-07-30",
  "start_of_day_unix": 1785369600,
  "end_of_day_unix": 1785456000,
  "total_volume_usd": "275332074.15247000000000000000",
  "trade_count": 907245,
  "scope": "primit-native-markets"
}
```

The `scope` field is a stable contract — any change to the aggregation basis will bump this marker.

### Files changed

- **new:** `dexs/primit/index.ts` (53 lines)

No changes to `factory/orderly.ts` — the existing `broker_id=primit` entry stays.

---

## DeFiLlama listing metadata

##### Name (to be shown on DefiLlama):
Primit

##### Twitter Link:
https://x.com/primitforall

##### List of audit links if any:
CertiK audit in progress (findings tracked internally; final report pending). No public audit report yet.

##### Website Link:
https://primit.io/

##### Logo (High resolution, will be shown with rounded borders):
https://primit.io/assets/logo-white-lockups-D8GIQ-sY.png (PNG)

##### Current TVL:
Not reporting TVL in this adapter (volume-only).

##### Treasury Addresses (if the protocol has treasury):
Primit token: `0x6e467755458f4a46d4aF8452176763e79ff23993` on Avalanche C-Chain (43114)

##### Chain:
Avalanche

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed):
(empty — not yet listed on CoinGecko)

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed):
(empty — not yet listed on CoinMarketCap)

##### Short Description (to be shown on DefiLlama):
Perpetual futures DEX on Avalanche C-Chain, offering permissionless trading on native and permanent-futures markets with on-chain settlement.

##### Token address and ticker if any:
`PRIMIT` — `0x6e467755458f4a46d4aF8452176763e79ff23993` on Avalanche C-Chain (chain id 43114)
Snowscan: https://snowscan.xyz/address/0x6e467755458f4a46d4af8452176763e79ff23993

##### Category (full list at https://defillama.com/categories) *Please choose only one:
Derivatives

##### Oracle Provider(s):
For native perpetual pairs (our reference perpetual pair), Primit uses OKX SWAP feed as the reference index (subject to normal exchange oracle guarantees). No Chainlink/Pyth/API3 dependency for the pairs covered by this adapter.

##### Implementation Details:
The our reference perpetual reference feed is polled from OKX public REST/WS by the backend and used to price the Primit-native perpetual markets internally. Trade prices in `public.trades` reflect actual matched fills on Primit's engine, not oracle prices.

##### Documentation/Proof:
- Endpoint (live): https://api.primit.io/api/v1/public/stats/daily-volume?date=2026-07-30
- Backend commit that added the endpoint: https://github.com/Primit-io/primit-avax-backend/pull/85

##### forkedFrom (Does your project originate from another project):
No. Primit's matching engine and settlement contracts are internally developed. The Solidity contracts derive from the AxBlade contract suite (same team), with substantial post-fork modifications.

##### methodology (what is being counted as tvl, how is tvl being calculated):
Trading volume, in USD notional, settled on Primit's own matching engine (`public.trades` in the Primit backend) during the given UTC day. Aggregated as `SUM(amount * price)` where `is_self_trade = false`. Excludes volume routed through Orderly Network (attributed separately via `factory/orderly.ts` under `broker_id=primit`; the two pair sets are disjoint, so no double-counting).

##### Github org/user (Optional, if your code is open source, we can track activity):
https://github.com/Primit-io

##### Does this project have a referral program?
Yes — on-chain referral bindings via ReferralStorage contract (proxy `0x3953a15024c2F391733Bd614F0056f078Cd85199` on Avalanche C-Chain). Rebate distribution via RebateDistributor `0xe2E0cF80E30f3988b2704DED5B0ED3A908083b90`.

---

## Notes for maintainers

- Existing `factory/orderly.ts` entry for `broker_id=primit` (#8115) is intentionally left in place. It attributes Orderly-relayed volume (BTC/ETH/etc), which this adapter does not touch. The two data sources are additive and cover disjoint pair sets.
- If you'd prefer a single unified entry, the alternative is to fold everything into a self-reported feed from `api.primit.io` that also proxies the Orderly-attributed portion — happy to do that in a follow-up, but wanted to keep this PR scoped to just the native-engine data first.
- Endpoint hosted on `ap-northeast-1` EC2, direct nginx, no CDN. Rate limited at nginx ingress default. Daily polling frequency is fine — SUM over 907k rows takes ~2.5s (well within any reasonable timeout).

