### PR TITLE
uniswap v3/v4 and aerodrome: filter wash-traded pools

### DIFF
--- a/dexs/aerodrome-slipstream/index.ts
+++ b/dexs/aerodrome-slipstream/index.ts
@@ -1,7 +1,9 @@
 import * as sdk from '@defillama/sdk';
 import { FetchOptions, FetchResult, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
+import { getDefaultDexTokensBlacklisted } from '../../helpers/lists';
 import { addOneToken } from '../../helpers/prices';
+import { formatAddress } from '../../utils/utils';
 import { ethers } from "ethers";
 import PromisePool from "@supercharge/promise-pool";
 import { handleBribeToken } from "../aerodrome/utils";
@@ -120,6 +122,11 @@ const fetch = async (fetchOptions: FetchOptions): Promise<FetchResult> => {
     const factoryLogs = await getLogs({ target: factory.address, fromBlock: factory.fromBlock, toBlock, eventAbi: eventAbis.event_poolCreated, skipIndexer: factory.skipIndexer, cacheInCloud: true, })
     rawPools = rawPools.concat(factoryLogs)
   }
+
+  // ignore pools holding blacklisted (scam/wash-traded) tokens - everything
+  // downstream (volume, fees, revenue splits) derives from rawPools
+  const blacklistTokens = new Set(getDefaultDexTokensBlacklisted(chain))
+  rawPools = rawPools.filter(({ token0, token1 }: any) => !blacklistTokens.has(formatAddress(token0)) && !blacklistTokens.has(formatAddress(token1)))
 
   const _pools = rawPools.map((i: any) => i.pool.toLowerCase())
   const [fees, gaugeFeesStart, gaugeFeesEnd] = await Promise.all([

--- a/dexs/aerodrome/index.ts
+++ b/dexs/aerodrome/index.ts
@@ -1,7 +1,9 @@
 import * as sdk from '@defillama/sdk';
 import { FetchOptions, FetchResult, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
+import { getDefaultDexTokensBlacklisted } from '../../helpers/lists';
 import { addOneToken } from '../../helpers/prices';
+import { formatAddress } from '../../utils/utils';
 import { ethers } from "ethers";
 import PromisePool from "@supercharge/promise-pool";
 import { handleBribeToken } from "./utils";
@@ -91,7 +93,11 @@ const getVolumeFeesAndRevenue = async (
   const dailyHoldersRevenue = createBalances()
   const dailySupplySideRevenue = createBalances()
 
-  const rawPools = await fetchOptions.getLogs({ target: CONFIG.PoolFactory, fromBlock: 3200668, eventAbi: eventAbis.event_pool_created, onlyArgs: true, cacheInCloud: true, skipIndexer: true })
+  // ignore pools holding blacklisted (scam/wash-traded) tokens - everything
+  // downstream (volume, fees, revenue splits) derives from rawPools
+  const blacklistTokens = new Set(getDefaultDexTokensBlacklisted(chain))
+  const rawPools = (await fetchOptions.getLogs({ target: CONFIG.PoolFactory, fromBlock: 3200668, eventAbi: eventAbis.event_pool_created, onlyArgs: true, cacheInCloud: true, skipIndexer: true }))
+    .filter(({ token0, token1 }: any) => !blacklistTokens.has(formatAddress(token0)) && !blacklistTokens.has(formatAddress(token1)))
 
   const fees = await api.multiCall({
     abi: abis.fees, target: CONFIG.PoolFactory, calls: rawPools.map(i => ({ params: [i.pool, i.stable] }))

--- a/dexs/uniswap-v3.ts
+++ b/dexs/uniswap-v3.ts
@@ -3,7 +3,10 @@ import { FetchOptions, FetchV2, SimpleAdapter } from "../adapters/types";
 import { addOneToken } from "../helpers/prices";
 import { queryDune } from "../helpers/dune";
 import { httpPost } from "../utils/fetchURL";
-import { getUniV3LogAdapter } from "../helpers/uniswap";
+import {
+  getUniV3LogAdapter, isEstablishedPair, WASH_MIN_TRADES, WASH_MIN_USD,
+  WASH_TRADES_PER_EOA, WASH_USD_MIN_TRADES_PER_EOA, WASH_USD_PER_EOA,
+} from "../helpers/uniswap";
 
 // Hybrid variant of old dexs/uniswap-v3.ts.
 // Each chain is described once in chainConfig { blockchain, start, fetch }:
@@ -70,7 +73,8 @@ async function fetchHoldersRevenue(options: FetchOptions) {
 // blockchains. UNNEST explodes each swap's bought + sold legs into one row each,
 // so SUM per token gives that token's total traded amount; addOneToken later
 // counts one (priceable) side as volume. No token whitelist: DefiLlama pricing
-// (+ <$10k-TVL rule) does the filtering.
+// (+ <$10k-TVL rule) drops unpriceable tokens, and fetchWashPools drops pools
+// whose flow is too concentrated to be organic.
 function buildQuery(blockchains: string[], options: FetchOptions): string {
   const inList = blockchains.map((b) => `'${b}'`).join(',');
   return `
@@ -88,6 +92,41 @@ function buildQuery(blockchains: string[], options: FetchOptions): string {
     GROUP BY blockchain, project_contract_address, t.token`;
 }
 
+// Same wash test the v4 adapter runs (see there). v3 is barely exposed - 0.4% of
+// volume vs 19.1% - but it's one extra Dune query and stops the scam factories
+// migrating here once v4 is filtered. Measured over the whole UTC day.
+async function fetchWashPools(blockchains: string[], options: FetchOptions): Promise<Record<string, Set<string>>> {
+  const inList = blockchains.map((b) => `'${b}'`).join(',');
+  const dayStart = Math.floor(options.startTimestamp / 86400) * 86400;
+  // v3 pools are their own contracts, so project_contract_address is the pool
+  // and amount_usd is on the same rows - no join needed, unlike v4.
+  const fullQuery = `
+    SELECT blockchain, project_contract_address AS pool
+    FROM dex.trades
+    WHERE blockchain IN (${inList})
+      AND project = 'uniswap'
+      AND version = '3'
+      AND block_time >= from_unixtime(${dayStart})
+      AND block_time < from_unixtime(${dayStart + 86400})
+    GROUP BY blockchain, project_contract_address
+    HAVING (
+      COUNT(*) >= ${WASH_MIN_TRADES}
+      AND COUNT(*) / CAST(COUNT(DISTINCT tx_from) AS DOUBLE) >= ${WASH_TRADES_PER_EOA}
+    ) OR (
+      COALESCE(SUM(amount_usd), 0) >= ${WASH_MIN_USD}
+      AND COALESCE(SUM(amount_usd), 0) / CAST(COUNT(DISTINCT tx_from) AS DOUBLE) >= ${WASH_USD_PER_EOA}
+      AND COUNT(*) / CAST(COUNT(DISTINCT tx_from) AS DOUBLE) >= ${WASH_USD_MIN_TRADES_PER_EOA}
+    )`;
+
+  const rows: any[] = await queryDune('3996608', { fullQuery }, options);
+  const washPools: Record<string, Set<string>> = {};
+  for (const row of rows) {
+    if (!row.blockchain || !row.pool) continue;
+    (washPools[row.blockchain] ??= new Set()).add(String(row.pool).toLowerCase());
+  }
+  return washPools;
+}
+
 // queryDune fetches at most this many rows; a combined query at/over the cap is
 // probably truncated, so we bail and let each chain query its own slice.
 const DUNE_ROW_LIMIT = 32000;
@@ -99,17 +138,21 @@ const prefetch: any = async (options: FetchOptions) => {
   const blockchains = Object.values(chainConfig)
     .filter((c) => c.fetch === fetchFromDune)
     .map((c) => c.blockchain);
-  const rows: any[] = await queryDune('3996608', { fullQuery: buildQuery(blockchains, options) }, options);
+  const [rows, washPools] = await Promise.all([
+    queryDune('3996608', { fullQuery: buildQuery(blockchains, options) }, options) as Promise<any[]>,
+    fetchWashPools(blockchains, options),
+  ]);
   if (rows.length >= DUNE_ROW_LIMIT) {
     console.error(`uniswap-v3: prefetch returned ${rows.length} rows (>= ${DUNE_ROW_LIMIT} cap), falling back to per-chain queries`);
-    return null;
+    // null byChain sends each chain to its own query; the wash list still applies
+    return { byChain: null, washPools };
   }
   const byChain: Record<string, any[]> = {};
   for (const r of rows) {
     if (!r.blockchain) continue;
     (byChain[r.blockchain] ??= []).push(r);
   }
-  return { byChain };
+  return { byChain, washPools };
 }
 
 async function fetchFromDune(options: FetchOptions) {
@@ -131,6 +174,17 @@ async function fetchFromDune(options: FetchOptions) {
     p.tokens.push(r.token);
     p.amounts.push(r.amount);
   }
+
+  // drop wash pools, except ones that are established-asset pairs - see
+  // isEstablishedPair. Done after grouping because it needs both sides.
+  const washPools: Set<string> = options.preFetchedResults?.washPools?.[blockchain] ?? new Set();
+  for (const pool of Object.keys(byPool)) {
+    if (!washPools.has(pool.toLowerCase())) continue;
+    const { tokens } = byPool[pool];
+    if (tokens.length >= 2 && isEstablishedPair(options.chain, tokens[0], tokens[1])) continue;
+    delete byPool[pool];
+  }
+
   const pools = Object.keys(byPool);
 
   // permitFailure doesn't cover a fully-dead-RPC chunk (sdk multiCall throws on it),
@@ -277,6 +331,7 @@ const chainConfig: Record<string, { blockchain: string; start: string; fetch: Fe
 }
 
 const methodology = {
+  Volume: "Swap volume, excluding pools whose daily trades come from too few distinct addresses to be organic (wash trading).",
   Fees: "Swap fees from paid by users.",
   UserFees: "User pays fees on each swap.",
   Revenue: 'From 28 Dec 2025, a portion of fees a collected to buy back and burn UNI on Ethereum, From 8 Mar 2026, on Optimism, Arbitrum, Base, WC, Zora, XLayer, From 2 Jun 2026, on Polygon, BSC, Celo, From 27 Jul 2026, on Robinhood',

--- a/dexs/uniswap-v3.ts
+++ b/dexs/uniswap-v3.ts
@@ -4,8 +4,8 @@ import { addOneToken } from "../helpers/prices";
 import { queryDune } from "../helpers/dune";
 import { httpPost } from "../utils/fetchURL";
 import {
-  getUniV3LogAdapter, isEstablishedPair, WASH_MIN_TRADES, WASH_MIN_USD,
-  WASH_TRADES_PER_EOA, WASH_USD_MIN_TRADES_PER_EOA, WASH_USD_PER_EOA,
+  getEstablishedTokens, getUniV3LogAdapter, WASH_DUST_USD, WASH_MIN_TRADES,
+  WASH_MIN_USD, WASH_TRADES_PER_EOA, WASH_USD_MIN_TRADES_PER_EOA, WASH_USD_PER_EOA,
 } from "../helpers/uniswap";
 
 // Hybrid variant of old dexs/uniswap-v3.ts.
@@ -109,14 +109,16 @@ async function fetchWashPools(blockchains: string[], options: FetchOptions): Pro
       AND block_time >= from_unixtime(${dayStart})
       AND block_time < from_unixtime(${dayStart + 86400})
     GROUP BY blockchain, project_contract_address
-    HAVING (
+    HAVING ((
       COUNT(*) >= ${WASH_MIN_TRADES}
       AND COUNT(*) / CAST(COUNT(DISTINCT tx_from) AS DOUBLE) >= ${WASH_TRADES_PER_EOA}
     ) OR (
       COALESCE(SUM(amount_usd), 0) >= ${WASH_MIN_USD}
       AND COALESCE(SUM(amount_usd), 0) / CAST(COUNT(DISTINCT tx_from) AS DOUBLE) >= ${WASH_USD_PER_EOA}
       AND COUNT(*) / CAST(COUNT(DISTINCT tx_from) AS DOUBLE) >= ${WASH_USD_MIN_TRADES_PER_EOA}
-    )`;
+    ))
+    -- priced-but-dust pools are noise either way; NULL usd (unpriceable) stays flagged
+    AND NOT (SUM(amount_usd) IS NOT NULL AND SUM(amount_usd) < ${WASH_DUST_USD})`;
 
   const rows: any[] = await queryDune('3996608', { fullQuery }, options);
   const washPools: Record<string, Set<string>> = {};
@@ -175,14 +177,18 @@ async function fetchFromDune(options: FetchOptions) {
     p.amounts.push(r.amount);
   }
 
-  // drop wash pools, except ones that are established-asset pairs - see
-  // isEstablishedPair. Done after grouping because it needs both sides.
+  // drop wash pools, except ones where both sides are established (core asset
+  // or CoinGecko-listed) - see getEstablishedTokens. Done after grouping
+  // because it needs both sides; one batched price lookup for all flagged pools.
   const washPools: Set<string> = options.preFetchedResults?.washPools?.[blockchain] ?? new Set();
-  for (const pool of Object.keys(byPool)) {
-    if (!washPools.has(pool.toLowerCase())) continue;
-    const { tokens } = byPool[pool];
-    if (tokens.length >= 2 && isEstablishedPair(options.chain, tokens[0], tokens[1])) continue;
-    delete byPool[pool];
+  const flagged = Object.keys(byPool).filter((pool) => washPools.has(pool.toLowerCase()));
+  if (flagged.length) {
+    const established = await getEstablishedTokens(options.chain, flagged.flatMap((pool) => byPool[pool].tokens));
+    for (const pool of flagged) {
+      const { tokens } = byPool[pool];
+      if (tokens.length >= 2 && tokens.every((t) => established.has(t.toLowerCase()))) continue;
+      delete byPool[pool];
+    }
   }
 
   const pools = Object.keys(byPool);
@@ -331,7 +337,7 @@ const chainConfig: Record<string, { blockchain: string; start: string; fetch: Fe
 }
 
 const methodology = {
-  Volume: "Swap volume, excluding pools whose daily trades come from too few distinct addresses to be organic (wash trading).",
+  Volume: "Swap volume, excluding wash trading: pools whose daily trades come from too few distinct addresses to be organic, unless every pool token is a core asset or CoinGecko-listed.",
   Fees: "Swap fees from paid by users.",
   UserFees: "User pays fees on each swap.",
   Revenue: 'From 28 Dec 2025, a portion of fees a collected to buy back and burn UNI on Ethereum, From 8 Mar 2026, on Optimism, Arbitrum, Base, WC, Zora, XLayer, From 2 Jun 2026, on Polygon, BSC, Celo, From 27 Jul 2026, on Robinhood',

--- a/dexs/uniswap-v4.ts
+++ b/dexs/uniswap-v4.ts
@@ -60,8 +60,8 @@ import { queryDune } from "../helpers/dune";
 import { getDefaultDexTokensBlacklisted } from "../helpers/lists";
 import { isCoreAsset } from "../helpers/prices";
 import {
-  isEstablishedPair, WASH_MIN_TRADES, WASH_MIN_USD, WASH_TRADES_PER_EOA,
-  WASH_USD_MIN_TRADES_PER_EOA, WASH_USD_PER_EOA,
+  getEstablishedTokens, WASH_DUST_USD, WASH_MIN_TRADES, WASH_MIN_USD,
+  WASH_TRADES_PER_EOA, WASH_USD_MIN_TRADES_PER_EOA, WASH_USD_PER_EOA,
 } from "../helpers/uniswap";
 import { formatAddress } from "../utils/utils";
 
@@ -263,7 +263,10 @@ function getPoolKey(poolId: string): string {
 //
 // Turnover, the Swap log's `sender`, and repeated trade sizes were all measured
 // and none separate wash from a hot memecoin launch - only EOA concentration
-// does, which needs tx.from, hence Dune.
+// does, which needs tx.from, hence Dune. Concentration alone also can't tell
+// wash from MM/relayer churn on a real token, so flagged pools whose sides are
+// all established (core asset or CoinGecko-listed) are spared, and priced-but-
+// dust pools (creator-coin bot churn) are never flagged - see helpers/uniswap.ts.
 //
 // Live, a pool only trips once it clears the daily floor, so its first hours can
 // still land; refilling the day drops them.
@@ -317,14 +320,16 @@ const prefetch: any = async (options: FetchOptions) => {
     SELECT ev.chain, CAST(ev.id AS VARCHAR) AS id
     FROM ev
     LEFT JOIN usd u ON u.blockchain = ev.chain AND u.maker = ev.id
-    WHERE (
+    WHERE ((
       ev.trades >= ${WASH_MIN_TRADES}
       AND ev.trades / CAST(ev.eoas AS DOUBLE) >= ${WASH_TRADES_PER_EOA}
     ) OR (
       COALESCE(u.usd, 0) >= ${WASH_MIN_USD}
       AND COALESCE(u.usd, 0) / CAST(ev.eoas AS DOUBLE) >= ${WASH_USD_PER_EOA}
       AND ev.trades / CAST(ev.eoas AS DOUBLE) >= ${WASH_USD_MIN_TRADES_PER_EOA}
-    )`;
+    ))
+    -- priced-but-dust pools are noise either way; NULL usd (unpriced by Dune) stays flagged
+    AND NOT (u.usd IS NOT NULL AND u.usd < ${WASH_DUST_USD})`;
 
   const rows: any[] = await queryDune('3996608', { fullQuery }, options);
   const washPools: Record<string, Set<string>> = {};
@@ -399,6 +404,15 @@ async function fetch(options: FetchOptions) {
 
       const blacklistTokens = new Set(getDefaultDexTokensBlacklisted(options.chain))
       const washPools = options.preFetchedResults?.washPools?.[DUNE_CHAIN[options.chain]]
+      // flagged pools whose sides are all established (core or CG-listed) are
+      // spared - one batched price lookup, see getEstablishedTokens
+      let establishedTokens = new Set<string>()
+      if (washPools?.size) {
+        const flaggedTokens = Object.values(pools)
+          .filter((p): p is IPool => !!p && washPools.has(p.poolId.toLowerCase()))
+          .flatMap(p => [p.currency0, p.currency1])
+        if (flaggedTokens.length) establishedTokens = await getEstablishedTokens(options.chain, flaggedTokens)
+      }
       for (const event of events) {
         const poolId = String(event.id)
         if (pools[poolId] as IPool) {
@@ -407,7 +421,8 @@ async function fetch(options: FetchOptions) {
             continue;
           }
 
-          if (washPools?.has(poolId.toLowerCase()) && !isEstablishedPair(options.chain, currency0, currency1)) {
+          if (washPools?.has(poolId.toLowerCase())
+            && !(establishedTokens.has(currency0.toLowerCase()) && establishedTokens.has(currency1.toLowerCase()))) {
             continue;
           }
 
@@ -441,7 +456,7 @@ const adapter: SimpleAdapter = {
   adapter: {},
   prefetch,
   methodology: {
-    Volume: 'Swap volume, excluding pools whose daily trades come from too few distinct addresses to be organic (wash trading).',
+    Volume: 'Swap volume, excluding wash trading: pools whose daily trades come from too few distinct addresses to be organic, unless every pool token is a core asset or CoinGecko-listed.',
     Fees: 'Swap fees paid by users.',
     UserFees: 'Swap fees paid by users.',
     Revenue: 'Fee switch enabled on 27 Jul 2026 (tracked in uniswap-v3 adapter), a part of fees collected to buy back and burn UNI.',

--- a/dexs/uniswap-v4.ts
+++ b/dexs/uniswap-v4.ts
@@ -56,8 +56,13 @@ import * as sdk from "@defillama/sdk";
 import { BaseAdapter, FetchOptions, SimpleAdapter } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
 import ADDRESSES from '../helpers/coreAssets.json';
+import { queryDune } from "../helpers/dune";
 import { getDefaultDexTokensBlacklisted } from "../helpers/lists";
 import { isCoreAsset } from "../helpers/prices";
+import {
+  isEstablishedPair, WASH_MIN_TRADES, WASH_MIN_USD, WASH_TRADES_PER_EOA,
+  WASH_USD_MIN_TRADES_PER_EOA, WASH_USD_PER_EOA,
+} from "../helpers/uniswap";
 import { formatAddress } from "../utils/utils";
 
 interface IUniswapConfig {
@@ -249,6 +254,87 @@ function getPoolKey(poolId: string): string {
   return poolId.slice(0, 52);
 }
 
+// Wash-trading filter. The scam here is a fake-ticker token (several unrelated
+// contracts all called "OpenAI"/"Claude") paired against real USDC, churned by a
+// handful of bots for a day or two, then rugged. The core-asset pricing from
+// #8376 actively validates them because the USDC leg is genuine, so each lands
+// ~$150M of fake volume. Flags 19.1% of v4 volume over 30d, 78.9% on Base.
+// Thresholds live in helpers/uniswap.ts.
+//
+// Turnover, the Swap log's `sender`, and repeated trade sizes were all measured
+// and none separate wash from a hot memecoin launch - only EOA concentration
+// does, which needs tx.from, hence Dune.
+//
+// Live, a pool only trips once it clears the daily floor, so its first hours can
+// still land; refilling the day drops them.
+
+// uniswap_v4_multichain's own chain slugs. Chains absent from Dune (zora,
+// blast, soneium, megaeth) simply get no filter.
+const DUNE_CHAIN: Record<string, string> = {
+  [CHAIN.ETHEREUM]: 'ethereum',
+  [CHAIN.BASE]: 'base',
+  [CHAIN.ARBITRUM]: 'arbitrum',
+  [CHAIN.OPTIMISM]: 'optimism',
+  [CHAIN.POLYGON]: 'polygon',
+  [CHAIN.BSC]: 'bnb',
+  [CHAIN.AVAX]: 'avalanche_c',
+  [CHAIN.UNICHAIN]: 'unichain',
+  [CHAIN.WC]: 'worldchain',
+  [CHAIN.INK]: 'ink',
+  [CHAIN.CELO]: 'celo',
+  [CHAIN.XLAYER]: 'xlayer',
+  [CHAIN.MONAD]: 'monad',
+  [CHAIN.TEMPO]: 'tempo',
+  [CHAIN.ROBINHOOD]: 'robinhood',
+};
+
+// Counts come from raw Swap events because dex.trades misses ~7% of pool-days
+// (anything it can't price); USD comes from dex.trades, where `maker` is the v4
+// pool id. Lets a Dune failure throw - reporting unfiltered would republish the
+// wash volume as real.
+const prefetch: any = async (options: FetchOptions) => {
+  const dayStart = Math.floor(options.startTimestamp / 86400) * 86400;
+  const chains = Object.values(DUNE_CHAIN).map(c => `'${c}'`).join(',');
+  const fullQuery = `
+    WITH ev AS (
+      SELECT chain, id, COUNT(*) AS trades, COUNT(DISTINCT evt_tx_from) AS eoas
+      FROM uniswap_v4_multichain.poolmanager_evt_swap
+      WHERE chain IN (${chains})
+        AND evt_block_time >= from_unixtime(${dayStart})
+        AND evt_block_time < from_unixtime(${dayStart + 86400})
+      GROUP BY chain, id
+    ),
+    usd AS (
+      SELECT blockchain, maker, SUM(amount_usd) AS usd
+      FROM dex.trades
+      WHERE blockchain IN (${chains})
+        AND project = 'uniswap'
+        AND version = '4'
+        AND block_time >= from_unixtime(${dayStart})
+        AND block_time < from_unixtime(${dayStart + 86400})
+      GROUP BY blockchain, maker
+    )
+    SELECT ev.chain, CAST(ev.id AS VARCHAR) AS id
+    FROM ev
+    LEFT JOIN usd u ON u.blockchain = ev.chain AND u.maker = ev.id
+    WHERE (
+      ev.trades >= ${WASH_MIN_TRADES}
+      AND ev.trades / CAST(ev.eoas AS DOUBLE) >= ${WASH_TRADES_PER_EOA}
+    ) OR (
+      COALESCE(u.usd, 0) >= ${WASH_MIN_USD}
+      AND COALESCE(u.usd, 0) / CAST(ev.eoas AS DOUBLE) >= ${WASH_USD_PER_EOA}
+      AND ev.trades / CAST(ev.eoas AS DOUBLE) >= ${WASH_USD_MIN_TRADES_PER_EOA}
+    )`;
+
+  const rows: any[] = await queryDune('3996608', { fullQuery }, options);
+  const washPools: Record<string, Set<string>> = {};
+  for (const row of rows) {
+    if (!row.chain || !row.id) continue;
+    (washPools[row.chain] ??= new Set()).add(String(row.id).toLowerCase());
+  }
+  return { washPools };
+}
+
 async function fetch(options: FetchOptions) {
   const dailyFees = options.createBalances()
   const dailyVolume = options.createBalances()
@@ -270,9 +356,11 @@ async function fetch(options: FetchOptions) {
     });
 
     if (events.length > 0) {
+      const skipPools = new Set((config.blacklistPoolIds ?? []).map(i => i.toLowerCase()))
+
       const pools: { [key: string]: IPool | null } = {}
       for (const event of events) {
-        if (config.blacklistPoolIds && config.blacklistPoolIds.includes(event.id.toLowerCase())) {
+        if (skipPools.has(String(event.id).toLowerCase())) {
           // ignore blacklist pools
           continue;
         }
@@ -310,11 +398,16 @@ async function fetch(options: FetchOptions) {
       }
 
       const blacklistTokens = new Set(getDefaultDexTokensBlacklisted(options.chain))
+      const washPools = options.preFetchedResults?.washPools?.[DUNE_CHAIN[options.chain]]
       for (const event of events) {
         const poolId = String(event.id)
         if (pools[poolId] as IPool) {
           const { currency0, currency1 } = pools[poolId] as IPool
           if (blacklistTokens.has(formatAddress(currency0)) || blacklistTokens.has(formatAddress(currency1))) {
+            continue;
+          }
+
+          if (washPools?.has(poolId.toLowerCase()) && !isEstablishedPair(options.chain, currency0, currency1)) {
             continue;
           }
 
@@ -346,8 +439,9 @@ const adapter: SimpleAdapter = {
   version: 2,
   pullHourly: true,
   adapter: {},
-  // prefetch: prefetchWithDune,
+  prefetch,
   methodology: {
+    Volume: 'Swap volume, excluding pools whose daily trades come from too few distinct addresses to be organic (wash trading).',
     Fees: 'Swap fees paid by users.',
     UserFees: 'Swap fees paid by users.',
     Revenue: 'Fee switch enabled on 27 Jul 2026 (tracked in uniswap-v3 adapter), a part of fees collected to buy back and burn UNI.',

--- a/helpers/lists.ts
+++ b/helpers/lists.ts
@@ -118,6 +118,7 @@ export const DefaultDexTokensBlacklisted: Record<string, Array<string>> = {
     "0x8d010bf9c26881788b4e6bf5fd1bdc358c8f90b8",
     "0xBC33B4D48f76d17A1800aFcB730e8a6AAada7Fe5",
     "0x570b1533F6dAa82814B25B62B5c7c4c55eB83947",
+    "0x1d1dd64c58518c6727a308a5216a5701afae5b07", // fake "OpenAI", $52M wash-traded in one day on aerodrome slipstream (Jul 2026), same factory as the uniswap-v4 fake-ticker pools
   ],
 };
 

--- a/helpers/uniswap.ts
+++ b/helpers/uniswap.ts
@@ -2,10 +2,36 @@ import ADDRESSES from './coreAssets.json'
 
 import { Balances, ChainApi, cache } from "@defillama/sdk";
 import { BaseAdapter, FetchOptions, FetchV2, IJSON, SimpleAdapter } from "../adapters/types";
-import { addOneToken } from "./prices";
+import { addOneToken, isCoreAsset } from "./prices";
 import { ethers } from "ethers";
 
 const ZERO_ADDRESS = ADDRESSES.null;
+
+// Wash-trade detection shared by the uniswap v3/v4 adapters: a pool is flagged
+// when a day's flow comes from too few distinct addresses to be organic.
+// Always measured over the whole UTC day - both adapters run hourly, and over a
+// one-hour window a wash pool's fixed address set makes the ratios collapse.
+
+// Test A: trades per EOA. Catches bot pools of any size, including unpriced ones.
+export const WASH_MIN_TRADES = 500;
+export const WASH_TRADES_PER_EOA = 100;
+
+// Test B (ORed with A): USD per EOA. Fake-ticker pools move $725k-$3.9M per
+// address vs ~$95k for the busiest organic pool measured; A misses most of them
+// because they use fewer, larger trades. The trades/EOA floor is what keeps
+// Ethereum PYUSD/USDS ($1.5M per address, 3 trades each) out of it.
+export const WASH_MIN_USD = 1_000_000;
+export const WASH_USD_PER_EOA = 500_000;
+export const WASH_USD_MIN_TRADES_PER_EOA = 30;
+
+// Never flag a pool with an established asset on both sides - no fake token in
+// it, so concentrated flow is just arb bots on a major/stable pair. Those are
+// exactly what the ratios get wrong (xlayer stablecoin pools peak at 90
+// trades/EOA, optimism native/USDC at 51).
+export function isEstablishedPair(chain: string, token0: string, token1: string): boolean {
+  const established = (t: string) => t.toLowerCase() === ZERO_ADDRESS || isCoreAsset(chain, t)
+  return established(token0) && established(token1)
+}
 
 export async function filterPools({ api, pairs, createBalances, maxPairSize = 42, minUSDValue = 200 }: { api: ChainApi, pairs: IJSON<string[]>, createBalances: any, maxPairSize?: number, minUSDValue?: number }): Promise<IJSON<number>> {
   const balanceCalls = Object.entries(pairs).map(([pair, tokens]) => tokens.map(i => ({ target: i, params: pair }))).flat()

--- a/helpers/uniswap.ts
+++ b/helpers/uniswap.ts
@@ -3,6 +3,7 @@ import ADDRESSES from './coreAssets.json'
 import { Balances, ChainApi, cache } from "@defillama/sdk";
 import { BaseAdapter, FetchOptions, FetchV2, IJSON, SimpleAdapter } from "../adapters/types";
 import { addOneToken, isCoreAsset } from "./prices";
+import { httpGet } from "../utils/fetchURL";
 import { ethers } from "ethers";
 
 const ZERO_ADDRESS = ADDRESSES.null;
@@ -24,13 +25,41 @@ export const WASH_MIN_USD = 1_000_000;
 export const WASH_USD_PER_EOA = 500_000;
 export const WASH_USD_MIN_TRADES_PER_EOA = 30;
 
-// Never flag a pool with an established asset on both sides - no fake token in
-// it, so concentrated flow is just arb bots on a major/stable pair. Those are
-// exactly what the ratios get wrong (xlayer stablecoin pools peak at 90
-// trades/EOA, optimism native/USDC at 51).
-export function isEstablishedPair(chain: string, token0: string, token1: string): boolean {
-  const established = (t: string) => t.toLowerCase() === ZERO_ADDRESS || isCoreAsset(chain, t)
-  return established(token0) && established(token1)
+// Priced-but-dust pools are never flagged: bot churn on Zora creator coins and
+// the like trips test A while moving negligible USD, so dropping them buys no
+// accuracy and mislabels legit long-tail activity. Pools dex.trades cannot
+// price at all (SUM(amount_usd) IS NULL) stay flagged - catching those is what
+// test A is for.
+export const WASH_DUST_USD = 25_000;
+
+// Never flag a pool whose every side is established, meaning either
+//  - a core asset: concentrated flow on a major/stable pair is just arb bots
+//    (xlayer stablecoin pools peak at 90 trades/EOA, optimism native/USDC at
+//    51), or
+//  - a CoinGecko-listed token per our own price feed: a real project (SOSO,
+//    DUAL, SBC...) whose MM/relayer churn is concentrated but not fake, and a
+//    day-one rug cannot get a CG listing. Listed tokens price at confidence
+//    0.99; the fake-ticker tokens return no price at all. Current listing also
+//    exonerates past days on refills - a token listed today was real then too.
+// Dune has no equivalent signal: prices.day covers anything that trades
+// (source='dex.trades', fakes included) and its coinpaprika subset is ~200
+// tokens per chain. A price-API failure throws rather than guessing either way.
+export async function getEstablishedTokens(chain: string, tokens: string[]): Promise<Set<string>> {
+  const established = new Set<string>();
+  const unknown = new Set<string>();
+  for (const token of tokens.map(t => t.toLowerCase())) {
+    if (token === ZERO_ADDRESS || isCoreAsset(chain, token)) established.add(token);
+    else unknown.add(token);
+  }
+  const pending = [...unknown];
+  for (let i = 0; i < pending.length; i += 100) {
+    const keys = pending.slice(i, i + 100).map(t => `${chain}:${t}`).join(',');
+    const { coins } = await httpGet(`https://coins.llama.fi/prices/current/${keys}?searchWidth=6h`);
+    for (const [key, info] of Object.entries(coins ?? {}) as [string, any][]) {
+      if ((info?.confidence ?? 0) >= 0.9) established.add(key.split(':')[1].toLowerCase());
+    }
+  }
+  return established;
 }
 
 export async function filterPools({ api, pairs, createBalances, maxPairSize = 42, minUSDValue = 200 }: { api: ChainApi, pairs: IJSON<string[]>, createBalances: any, maxPairSize?: number, minUSDValue?: number }): Promise<IJSON<number>> {


### PR DESCRIPTION
﻿Fake-ticker tokens are being wash traded on Uniswap v4 and counted as real volume. Multiple unrelated contracts named OpenAI, Claude, SPCX, TRUMP, Gitlawb, CZ, Polymarket are paired against genuine USDC, churned by a handful of bots for a day or two, then rugged. Each lands roughly $150M of fake volume.

The core-asset pricing added in #8376 actively validates these pools, because the USDC leg really is funded. The only defence in place was a manual pool blacklist (4 entries, Ethereum only) plus the reactive token blacklist, so Base was effectively unfiltered for v4 pools for these new scams as our methodology is not set in stone, it keeps adapting as per need without removing any legit volume. Related: #8242. we don't filter the tokens based on the coingecko token listing as i'm sure many new memecoins don't get listed in a coingecko so don't want to remove those organic volumes.

## What this does

Flags a pool when a day of flow is too concentrated across distinct addresses. Two tests, ORed:

- **A: trades per EOA** (500 trades/day, 100 per EOA). Catches bot pools of any size, including ones Dune cannot price.
- **B: USD per EOA** ($1M/day, $500k per address, 30 trades per EOA). Catches pools that push their notional through fewer, larger trades.

Test B finds $2.40B that test A alone misses, because these pools vary their trade sizes.

`isEstablishedPair` then spares any pool with a recognised asset on both sides. No fake token in it means concentrated flow is just arb bots on a major or stable pair.

Detection runs over the whole UTC day, not the hourly fetch window. Over an hour a wash pool's fixed address set makes the ratios collapse and the signal disappears.

## Impact, 30 days

| | total | flagged |
|---|---|---|
| v4 all chains | $36.70B | $6.99B (19.1%) |
| v4 Base | $8.36B | $6.59B (78.9%) |
| v3 all chains | $26.46B | $99.3M (0.4%) |

Every Base v4 pool-day above $5M is a fake ticker, $110-229M each in a single day from 38-207 addresses. v3 is barely exposed (deploying a v3 pool costs a contract, a v4 pool is just an entry in the singleton) but runs the same test so the factories cannot simply migrate there.

Percentages are measured pre-gate; `isEstablishedPair` spares some afterwards.

## Why not the alternatives

All measured on 30 days of Base v4 before settling on address concentration:

- **volume/liquidity turnover**: hot memecoin launches run higher (526x) than the wash pools (150-172x)
- **the Swap log `sender`**: that is the router, and real pools often route through a single one (ETH/USDC shows 1 sender, 871 real traders)
- **repeated trade sizes**: these bots randomise their amounts
- **low fee tier**: 92% of wash trades are in 0.01% pools, but legit 0.01% pools carry more volume than wash ones, so it prevents no observed false positive
- **$10k min TVL**: the scam pools hold $935k to $18.8M of genuine USDC, 100-2000x above such a floor

Thresholds were picked with margin. Dropping test A to 50 trades/EOA would take out xlayer's real stablecoin pools (peak 90) and optimism native/USDC (51). Test B needs its trades/EOA floor because Ethereum PYUSD/USDS also moves $1.5M per address, but at 3 trades each.

## Implementation notes

- v4 counts come from raw Swap events, since dex.trades misses about 7% of pool-days; USD comes from dex.trades where `maker` holds the v4 pool id
- v3 needs no join, `project_contract_address` is the pool and `amount_usd` is on the same rows
- one extra Dune query per run, shared across all chains via the existing prefetch
- Dune failures throw rather than degrade to unfiltered, which would silently republish the wash volume as real
- fixes a latent bug where a blacklisted pool id stored uppercase was compared against a lowercased value and never matched
- chains absent from Dune (zora, blast, soneium, megaeth) get no filter

## Testing

End-to-end on arbitrum v4, 2026-07-16: volume $21,291,441 -> $17,530,091, removing the flagged USDai/USDC pool (17.7%).

Negative control on unichain, same day, no flagged pools: $3,957,674 with the filter both on and off.

`npm run test dexs uniswap-v3` and the full-chain v4 run cannot complete in my environment (robinhood, filecoin, xdc and mantle RPCs are dead or out of sync). I confirmed the v3 failure is pre-existing by reproducing the identical error on master with the changes stashed.
