### PR TITLE
lifi/jumper: fix start field on the 4 adapters missed by the rename

### DIFF
--- a/aggregators/jumper-exchange/index.ts
+++ b/aggregators/jumper-exchange/index.ts
@@ -47,7 +47,7 @@ const adapter: SimpleAdapter = {
   adapter: Object.keys(LifiDiamonds).reduce((acc, chain) => {
     return {
       ...acc,
-      [chain]: { fetch, start: LifiDiamonds[chain].startTime, }
+      [chain]: { fetch, start: LifiDiamonds[chain].start, }
     }
   }, {})
 };

--- a/aggregators/lifi/index.ts
+++ b/aggregators/lifi/index.ts
@@ -49,7 +49,7 @@ const adapter: SimpleAdapter = {
   adapter: Object.keys(LifiDiamonds).reduce((acc, chain) => {
     return {
       ...acc,
-      [chain]: { fetch, start: LifiDiamonds[chain].startTime, }
+      [chain]: { fetch, start: LifiDiamonds[chain].start, }
     }
   }, {})
 };

--- a/bridge-aggregators/jumper.exchange/index.ts
+++ b/bridge-aggregators/jumper.exchange/index.ts
@@ -35,7 +35,7 @@ const adapter: SimpleAdapter = {
   adapter: Object.keys(LifiDiamonds).reduce((acc, chain) => {
     return {
       ...acc,
-      [chain]: { fetch, start: LifiDiamonds[chain].startTime, }
+      [chain]: { fetch, start: LifiDiamonds[chain].start, }
     }
   }, {})
 };

--- a/bridge-aggregators/lifi/index.ts
+++ b/bridge-aggregators/lifi/index.ts
@@ -36,7 +36,7 @@ const adapter: SimpleAdapter = {
   adapter: Object.keys(LifiDiamonds).reduce((acc, chain) => {
     return {
       ...acc,
-      [chain]: { fetch, start: LifiDiamonds[chain].startTime, }
+      [chain]: { fetch, start: LifiDiamonds[chain].start, }
     }
   }, {})
 };


### PR DESCRIPTION
#8483 renamed `startTime` to `start` throughout `helpers/aggregators/lifi.ts` (both `LifiDiamonds` and `LifiFeeCollectors`, all 115 entries) and updated the two consumers it touched, `fees/lifi` and `fees/jumper-exchange`. Four other consumers still read the old name:

- `aggregators/lifi/index.ts:52`
- `aggregators/jumper-exchange/index.ts:50`
- `bridge-aggregators/lifi/index.ts:39`
- `bridge-aggregators/jumper.exchange/index.ts:38`

All four do `[chain]: { fetch, start: LifiDiamonds[chain].startTime, }`. There are zero occurrences of `startTime` left in the helper, so every entry resolves to `undefined`.

## Effect

`adapters/utils/runAdapter.ts:466` does `let _start = adapterObject![chain]?.start ?? 0`, so every chain gets `startTimestamp: 0` (1970-01-01) and `canRun` is unconditionally true. The pre-launch guard at `runAdapter.ts:201` can no longer fire for these adapters, and any backfill or refill is told the adapter has data from the epoch rather than from each chain's real launch date. For `aggregators/lifi` that means paginating the analytics API per-day back to 1970 across 64 chains.

## Before and after

Module-loading each adapter and counting entries where `start === undefined`:

```
at master:
aggregators/lifi                     chains: 64 | undefined: 64
aggregators/jumper-exchange          chains: 64 | undefined: 64
bridge-aggregators/lifi              chains: 64 | undefined: 64
bridge-aggregators/jumper.exchange   chains: 64 | undefined: 64
fees/lifi                            chains: 43 | undefined:  0
fees/jumper-exchange                 chains: 43 | undefined:  0

with this PR:
aggregators/lifi                     chains: 64 | undefined:  0 | bitcoin=2023-03-11 solana=2024-01-01
aggregators/jumper-exchange          chains: 64 | undefined:  0
bridge-aggregators/lifi              chains: 64 | undefined:  0
bridge-aggregators/jumper.exchange   chains: 64 | undefined:  0
```

The restored values match what these adapters had at `67503aa^`.

## Why CI did not catch it

`tsconfig.json` `include` uses globs like `"aggregators/*"`, which pick up only the flat `.ts` files in each directory. Sub-directory adapters enter the program only if an included flat file imports them. `tsc --project tsconfig.json --listFiles` shows 8 files under `aggregators/`, all flat, and `aggregators/lifi/index.ts` is not among them. `bridge-aggregators/` is not in `include` at all. `pnpm run ts-check` exits 0 on current master.

That is a separate repo-wide question so I have not touched it here, but widening the globs would catch this class of typo at review time.