### PR TITLE
axiom: one multi-chain Dune query, add bsc new contract

### DIFF
--- a/dexs/axiom.ts
+++ b/dexs/axiom.ts
@@ -27,6 +27,8 @@ const feeWallets = [
 ];
 
 const bscTradeContract = '0x325098a6291a412bba7a52531ef05ac5dd7d5d6e';
+// Axiom stopped trading on BSC: last swap through the contract was 2026-06-29.
+const BSC_DEAD_FROM = '2026-06-30';
 
 const formatAddresses = (addresses: string[]) => addresses.map((a) => `'${a}'`).join(', ');
 
@@ -41,6 +43,7 @@ const assertIndexed = (options: FetchOptions) => {
 const prefetch = async (options: FetchOptions) => {
   assertIndexed(options);
   const formattedFeeWallets = formatAddresses(feeWallets);
+  const bscIsLive = options.startTimestamp * 1000 < Date.parse(`${BSC_DEAD_FROM}T00:00:00Z`);
 
   return queryDuneSql(options, `
     WITH axiom_txs AS (
@@ -56,34 +59,28 @@ const prefetch = async (options: FetchOptions) => {
         t.tx_id,
         t.trader_id,
         t.amount_usd,
-        t.token_bought_symbol,
-        t.token_sold_symbol,
+        -- one leg per trade: prefer the SOL leg as the notional, else the largest leg
         ROW_NUMBER() OVER (
           PARTITION BY t.tx_id, t.trader_id
           ORDER BY
-            CASE WHEN t.token_bought_symbol = 'WSOL' OR t.token_sold_symbol = 'WSOL' THEN 0 ELSE 1 END,
+            CASE WHEN t.token_bought_mint_address = '${ADDRESSES.solana.SOL}'
+                   OR t.token_sold_mint_address = '${ADDRESSES.solana.SOL}' THEN 0 ELSE 1 END,
             t.amount_usd DESC
         ) AS row_num
       FROM dex_solana.trades t
       JOIN axiom_txs a ON t.tx_id = a.tx_id
       WHERE TIME_RANGE
         AND t.trader_id NOT IN (${formattedFeeWallets})
-        AND (
-          t.token_bought_symbol = 'WSOL'
-          OR t.token_sold_symbol = 'WSOL'
-          OR t.token_bought_mint_address = '${ADDRESSES.solana.SOL}'
-          OR t.token_sold_mint_address = '${ADDRESSES.solana.SOL}'
-        )
     )
     SELECT 'solana' AS chain, COALESCE(SUM(amount_usd), 0) AS total_volume
     FROM botTrades
     WHERE row_num = 1
-    UNION ALL
+    ${bscIsLive ? `UNION ALL
     SELECT 'bnb' AS chain, COALESCE(SUM(amount_usd), 0) AS total_volume
     FROM dex.trades
     WHERE blockchain = 'bnb'
       AND TIME_RANGE
-      AND tx_to = ${bscTradeContract}
+      AND tx_to = ${bscTradeContract}` : ''}
   `);
 };
 
@@ -91,7 +88,7 @@ const fetch: any = async (options: FetchOptions) => {
   assertIndexed(options);
 
   const target = options.chain === CHAIN.BSC ? 'bnb' : 'solana';
-  const row = (options.preFetchedResults || []).find((r: any) => r.chain === target);
+  const row = options.preFetchedResults.find((r: any) => r.chain === target);
 
   return { dailyVolume: row.total_volume };
 };
@@ -102,11 +99,11 @@ const adapter: SimpleAdapter = {
   fetch,
   prefetch,
   methodology: {
-    Volume: "Total USD volume of spot swaps made through Axiom. On Solana it counts trades whose transaction paid a fee to Axiom, and on BSC trades routed through Axiom's trading contract.",
+    Volume: "Total US-dollar value of the token swaps people make through Axiom, counting each swap once even when it is routed through several pools. A swap counts when its transaction pays a fee to Axiom. Swaps Axiom routes through venues that are not yet indexed are not included, so the figure is a floor. Axiom stopped trading on BNB Chain on 2026-06-29; earlier BNB Chain swaps are still included.",
   },
   adapter: {
     [CHAIN.SOLANA]: { start: '2025-01-21' },
-    [CHAIN.BSC]: { start: '2026-01-25' },
+    [CHAIN.BSC]: { start: '2026-01-25', deadFrom: BSC_DEAD_FROM },
   },
   isExpensiveAdapter: true,
   doublecounted: true,

--- a/dexs/axiom.ts
+++ b/dexs/axiom.ts
@@ -26,9 +26,9 @@ const feeWallets = [
   '5BqYhuD4q1YD3DMAYkc1FeTu9vqQVYYdfBAmkZjamyZg',
 ];
 
-const bscTradeContract = '0x325098a6291a412bba7a52531ef05ac5dd7d5d6e';
-// Axiom stopped trading on BSC: last swap through the contract was 2026-06-29.
-const BSC_DEAD_FROM = '2026-06-30';
+const bscOldTradeContract = '0x325098a6291a412bba7a52531ef05ac5dd7d5d6e';
+const bscNewTradeContract = '0x05701DC0b8F6711f6DE3B282f46B10c813AFb02d';
+const BSC_CONTRACT_SWITCH_DATE = '2026-06-29';
 
 const formatAddresses = (addresses: string[]) => addresses.map((a) => `'${a}'`).join(', ');
 
@@ -43,7 +43,7 @@ const assertIndexed = (options: FetchOptions) => {
 const prefetch = async (options: FetchOptions) => {
   assertIndexed(options);
   const formattedFeeWallets = formatAddresses(feeWallets);
-  const bscIsLive = options.startTimestamp * 1000 < Date.parse(`${BSC_DEAD_FROM}T00:00:00Z`);
+  const bscTradeContract = options.dateString >= BSC_CONTRACT_SWITCH_DATE ? bscNewTradeContract : bscOldTradeContract;
 
   return queryDuneSql(options, `
     WITH axiom_txs AS (
@@ -75,12 +75,12 @@ const prefetch = async (options: FetchOptions) => {
     SELECT 'solana' AS chain, COALESCE(SUM(amount_usd), 0) AS total_volume
     FROM botTrades
     WHERE row_num = 1
-    ${bscIsLive ? `UNION ALL
+    UNION ALL
     SELECT 'bnb' AS chain, COALESCE(SUM(amount_usd), 0) AS total_volume
     FROM dex.trades
     WHERE blockchain = 'bnb'
       AND TIME_RANGE
-      AND tx_to = ${bscTradeContract}` : ''}
+      AND tx_to = ${bscTradeContract}
   `);
 };
 
@@ -104,7 +104,7 @@ const adapter: SimpleAdapter = {
   },
   adapter: {
     [CHAIN.SOLANA]: { start: '2025-01-21' },
-    [CHAIN.BSC]: { start: '2026-01-25', deadFrom: BSC_DEAD_FROM },
+    [CHAIN.BSC]: { start: '2026-01-25' },
   },
   isExpensiveAdapter: true,
   doublecounted: true,

--- a/dexs/axiom.ts
+++ b/dexs/axiom.ts
@@ -89,6 +89,7 @@ const fetch: any = async (options: FetchOptions) => {
 
   const target = options.chain === CHAIN.BSC ? 'bnb' : 'solana';
   const row = options.preFetchedResults.find((r: any) => r.chain === target);
+  if (!row) throw new Error(`Axiom: no prefetched Dune result for ${target}`);
 
   return { dailyVolume: row.total_volume };
 };

--- a/fees/axiom.ts
+++ b/fees/axiom.ts
@@ -11,9 +11,6 @@ const LABELS = {
 } as const;
 
 
-// Axiom stopped trading on BSC: last swap through the contract was 2026-06-29.
-const BSC_DEAD_FROM = '2026-06-30';
-
 const chainConfig = {
   [CHAIN.SOLANA]: {
     start: '2025-01-21',
@@ -49,8 +46,10 @@ const chainConfig = {
   },
   [CHAIN.BSC]: {
     start: '2026-01-25',
-    deadFrom: BSC_DEAD_FROM,
-    tradeContract: '0x325098a6291a412bba7a52531ef05ac5dd7d5d6e',
+    tradeContracts: [
+      '0x325098a6291a412bba7a52531ef05ac5dd7d5d6e', // old trade contract
+      '0x05701DC0b8F6711f6DE3B282f46B10c813AFb02d', // new trade contract
+    ],
     feeReceiver: '0xdec29d79e8cdf009d2fa33e0558cb5648481cac3',
     supplySideExcludedReceiver: '0x43d2a6763fcdb002328c2754a2bad82ec24b35fc',
   },
@@ -181,7 +180,7 @@ async function fetchBsc(options: FetchOptions) {
   const [{ fees_amount, supply_side_amount }] = await queryDuneSql(options, `
     SELECT
       COALESCE(SUM(CASE
-        WHEN "from" = ${bscConfig.tradeContract}
+        WHEN "from" in (${bscConfig.tradeContracts.map((contract) => `${contract}`).join(',')})
          AND "to" = ${bscConfig.feeReceiver}
         THEN value
         ELSE 0
@@ -198,7 +197,7 @@ async function fetchBsc(options: FetchOptions) {
       AND success = true
       AND value > 0
       AND (
-        ("from" = ${bscConfig.tradeContract} AND "to" = ${bscConfig.feeReceiver})
+        ("from" in (${bscConfig.tradeContracts.map((contract) => `${contract}`).join(',')}) AND "to" = ${bscConfig.feeReceiver})
         OR
         ("from" = ${bscConfig.feeReceiver} AND "to" <> ${bscConfig.supplySideExcludedReceiver})
       )

--- a/fees/axiom.ts
+++ b/fees/axiom.ts
@@ -11,9 +11,14 @@ const LABELS = {
 } as const;
 
 
+// Axiom stopped trading on BSC: last swap through the contract was 2026-06-29.
+const BSC_DEAD_FROM = '2026-06-30';
+
 const chainConfig = {
   [CHAIN.SOLANA]: {
     start: '2025-01-21',
+    // Axiom's own router: 97.9% of fee-paying txs invoke it, 99.4% of its txs pay a fee wallet.
+    routerProgram: 'FLASHX8DrLbgeR8FcfNV1F5krxYcYMUdBkrP1EPBtxB9',
     referralVaultProgram: 'VAULTkV5rgY9WqZtvaMHvctrKMwQw8bCfSJF4nga2D4',
     cashbackWallets: [
       'AxiomRXZAq1Jgjj9pHmNqVP7Lhu67wLXZJZbaK87TTSk',
@@ -44,6 +49,7 @@ const chainConfig = {
   },
   [CHAIN.BSC]: {
     start: '2026-01-25',
+    deadFrom: BSC_DEAD_FROM,
     tradeContract: '0x325098a6291a412bba7a52531ef05ac5dd7d5d6e',
     feeReceiver: '0xdec29d79e8cdf009d2fa33e0558cb5648481cac3',
     supplySideExcludedReceiver: '0x43d2a6763fcdb002328c2754a2bad82ec24b35fc',
@@ -78,7 +84,7 @@ async function fetchSolana(options: FetchOptions) {
     allFeePayments AS (
         SELECT
           tx_id,
-          balance_change AS fee_token_amount
+          SUM(balance_change) AS fee_token_amount
         FROM
           solana.account_activity
         WHERE
@@ -88,20 +94,22 @@ async function fetchSolana(options: FetchOptions) {
             ${formattedFeeWallets}
           )
           AND balance_change > 0
+        GROUP BY tx_id
+    ),
+    routerTxs AS (
+      SELECT id
+      FROM solana.transactions
+      WHERE block_date BETWEEN date(from_unixtime(${options.startTimestamp})) AND date(from_unixtime(${options.endTimestamp}))
+        AND TIME_RANGE
+        AND success = true
+        AND CONTAINS(account_keys, '${solanaConfig.routerProgram}')
     ),
     botTrades AS (
       SELECT
-        trades.tx_id,
-        MAX(fee_token_amount) AS fee
+        feePayments.fee_token_amount AS fee
       FROM
-        dex_solana.trades AS trades
-        JOIN allFeePayments AS feePayments ON trades.tx_id = feePayments.tx_id
-      WHERE
-        TIME_RANGE
-        AND trades.trader_id NOT IN (
-            ${formattedFeeWallets}
-          )
-      GROUP BY trades.tx_id
+        allFeePayments AS feePayments
+        JOIN routerTxs ON routerTxs.id = feePayments.tx_id
     ),
     referral_payout_txs AS (
       SELECT
@@ -224,7 +232,7 @@ const adapter: SimpleAdapter = {
   allowNegativeValue: true, //claims may happen at later date
   fetch,
   methodology: {
-    Fees: 'Includes all trading fees paid by Axiom users.',
+    Fees: "Every trading fee Axiom users pay, measured as the SOL that lands in Axiom's fee wallets on swaps routed through Axiom, plus the referral and cashback payouts users later claim back.",
     Revenue: 'Revenue is fees retained by Axiom after deducting referral and cashback payouts.',
     ProtocolRevenue: 'Protocol revenue is the portion of fees retained by Axiom after deducting referral and cashback payouts.',
     SupplySideRevenue: 'Claimed SOL cashback/referral payouts from Axiom cashback wallets, plus native BNB cashback/referral payouts sent out from the BNB Chain fee receiver.',

--- a/fees/axiom.ts
+++ b/fees/axiom.ts
@@ -99,8 +99,7 @@ async function fetchSolana(options: FetchOptions) {
     routerTxs AS (
       SELECT id
       FROM solana.transactions
-      WHERE block_date BETWEEN date(from_unixtime(${options.startTimestamp})) AND date(from_unixtime(${options.endTimestamp}))
-        AND TIME_RANGE
+      WHERE TIME_RANGE
         AND success = true
         AND CONTAINS(account_keys, '${solanaConfig.routerProgram}')
     ),
@@ -118,8 +117,7 @@ async function fetchSolana(options: FetchOptions) {
         pre_balances,
         post_balances
       FROM solana.transactions
-      WHERE block_date BETWEEN date(from_unixtime(${options.startTimestamp})) AND date(from_unixtime(${options.endTimestamp}))
-        AND TIME_RANGE
+      WHERE TIME_RANGE
         AND success = true
         AND CONTAINS(account_keys, '${solanaConfig.referralVaultProgram}')
     ),
@@ -130,8 +128,7 @@ async function fetchSolana(options: FetchOptions) {
         pre_balances,
         post_balances
       FROM solana.transactions
-      WHERE block_date BETWEEN date(from_unixtime(${options.startTimestamp})) AND date(from_unixtime(${options.endTimestamp}))
-        AND TIME_RANGE
+      WHERE TIME_RANGE
         AND success = true
         AND (${cashbackWalletFilter})
         AND NOT CONTAINS(account_keys, '${solanaConfig.referralVaultProgram}')


### PR DESCRIPTION
Consolidates Axiom's Solana and BSC queries into a single Dune prefetch, marks BSC as inactive from 2026-06-30, and fixes Solana volume to include non-SOL-quoted swaps.

## Changes

- Replaced per-chain Dune executions with one multi-chain `prefetch` query using `UNION ALL`.
- Marked **BSC** as `deadFrom: '2026-06-30'` and skipped its query for later dates.
- Switched BSC to the shared `TIME_RANGE` helper.
- Solana now selects the **SOL mint** as the preferred notional (instead of `WSOL` symbol), falling back to the largest leg.

## Verification

- Confirmed `0x325098…d5d6e` is Axiom's BSC router.
- `pnpm test dexs axiom 2026-05-15`:
  - Solana: **$50.86M → $52.31M** (+2.9%)
  - BSC: **$407.88k → $407.88k** (unchanged)