### PR TITLE
xrpl-dex: throw when the dune row isnt there instead of writing zero

### DIFF
--- a/dexs/xrpl-dex/index.ts
+++ b/dexs/xrpl-dex/index.ts
@@ -9,8 +9,12 @@ const fetch = async (options: FetchOptions) => {
     const query = `select dex_xrp_pair_volume_xrp,amm_xrp_volume_xrp from xrpl.aggregated_metrics_daily where date = Date('${formattedDate}')`;
     const queryResults = await queryDuneSql(options, query);
 
-    const dexVolumeXrp = queryResults.length > 0 ? queryResults[0].dex_xrp_pair_volume_xrp : 0;
-    const ammVolumeXrp = queryResults.length > 0 ? queryResults[0].amm_xrp_volume_xrp : 0;
+    if (!queryResults.length) {
+        throw new Error(`no row in xrpl.aggregated_metrics_daily for ${formattedDate} yet`);
+    }
+
+    const dexVolumeXrp = queryResults[0].dex_xrp_pair_volume_xrp;
+    const ammVolumeXrp = queryResults[0].amm_xrp_volume_xrp;
 
     const dailyVolume = options.createBalances();
     dailyVolume.addCGToken("ripple", Number(ammVolumeXrp) + Number(dexVolumeXrp));

--- a/dexs/xrpl-dex/index.ts
+++ b/dexs/xrpl-dex/index.ts
@@ -1,10 +1,9 @@
 import { CHAIN } from "../../helpers/chains";
-import { Dependencies, FetchOptions } from "../../adapters/types";
+import { Dependencies, FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { queryDuneSql } from "../../helpers/dune";
 
 const fetch = async (options: FetchOptions) => {
-    const date = new Date(options.fromTimestamp * 1000);
-    const formattedDate = date.toISOString().split("T")[0];
+    const formattedDate = options.dateString
 
     const query = `select dex_xrp_pair_volume_xrp,amm_xrp_volume_xrp from xrpl.aggregated_metrics_daily where date = Date('${formattedDate}')`;
     const queryResults = await queryDuneSql(options, query);
@@ -22,11 +21,12 @@ const fetch = async (options: FetchOptions) => {
     return { dailyVolume };
 };
 
-const adapter: any = {
+const adapter: SimpleAdapter = {
     fetch,
     dependencies: [Dependencies.DUNE],
     chains: [CHAIN.RIPPLE],
     start: '2025-03-19',
+    isExpensiveAdapter: true,
 };
 
 export default adapter;


### PR DESCRIPTION
part of #8521 (credit to quepasaquepasa for spotting the hard stop); xrpl dex showed $4.6m on 07-29 then a hard $0 on 07-30 with no taper.

the adapter queries one row from `xrpl.aggregated_metrics_daily` on dune and returns 0 when the row is missing. that table publishes with lag, so any day the runner fires before the row lands gets a permanent $0 stored instead of a retry. xrpl itself obviously didn't stop trading.

fix: throw on the empty result so the runner retries later, like other single-row dune adapters. couldn't run the harness locally (no dune key), typecheck only; ci run will exercise it. the stored $0 days need a refill once this lands.