### PR TITLE
lotus-finance: throw on stale or missing feed instead of writing zero

### DIFF
--- a/dexs/lotus-finance/index.ts
+++ b/dexs/lotus-finance/index.ts
@@ -21,24 +21,33 @@ const fetch = async (options: FetchOptions) => {
 
   const data = await fetchURL(`${LOTUS_BASE}${LOTUS_PATH}?${qs}`);
 
-  let currentDayVolume = 0;
-  let previousDayVolume = 0;
+  let currentRow: any[] | null = null;
+  let previousRow: any[] | null = null;
 
   for (const row of data) {
     if (!Array.isArray(row) || row.length < 5) continue;
 
-    const [timeMs, totalValueLocked, tradingVolumeUsd, activeVaultCount, totalVaultCount] = row;
-    const ts = Number(timeMs) / 1000;
-    
+    const ts = Number(row[0]) / 1000;
+
     if (ts >= startTimestamp && ts < endTimestamp) {
-      currentDayVolume = Number(tradingVolumeUsd);
+      currentRow = row;
     } else if (ts < startTimestamp) {
-      previousDayVolume = Number(tradingVolumeUsd);
+      previousRow = row;
     }
   }
 
-  // Calculate daily volume as difference
-  const dailyVolumeUsd = currentDayVolume - previousDayVolume;
+  if (!currentRow || !previousRow) {
+    throw new Error(`lotus api returned no rows for ${options.dateString}`);
+  }
+
+  const [, currentTvl, currentCumVolume] = currentRow;
+  const [, previousTvl, previousCumVolume] = previousRow;
+
+  const dailyVolumeUsd = Number(currentCumVolume) - Number(previousCumVolume);
+  if (dailyVolumeUsd === 0 && currentTvl === previousTvl) {
+    throw new Error(`lotus api feed is stale: identical snapshot for consecutive days around ${options.dateString}`);
+  }
+
   if (dailyVolumeUsd > 0) {
     dailyVolume.addUSDValue(dailyVolumeUsd);
   }

--- a/dexs/lotus-finance/index.ts
+++ b/dexs/lotus-finance/index.ts
@@ -43,14 +43,18 @@ const fetch = async (options: FetchOptions) => {
   const [, currentTvl, currentCumVolume] = currentRow;
   const [, previousTvl, previousCumVolume] = previousRow;
 
-  const dailyVolumeUsd = Number(currentCumVolume) - Number(previousCumVolume);
+  const currentCumVolumeUsd = Number(currentCumVolume);
+  const previousCumVolumeUsd = Number(previousCumVolume);
+  if (!Number.isFinite(currentCumVolumeUsd) || !Number.isFinite(previousCumVolumeUsd) || currentCumVolumeUsd < previousCumVolumeUsd) {
+    throw new Error(`lotus api returned an invalid cumulative volume for ${options.dateString}`);
+  }
+
+  const dailyVolumeUsd = currentCumVolumeUsd - previousCumVolumeUsd;
   if (dailyVolumeUsd === 0 && currentTvl === previousTvl) {
     throw new Error(`lotus api feed is stale: identical snapshot for consecutive days around ${options.dateString}`);
   }
 
-  if (dailyVolumeUsd > 0) {
-    dailyVolume.addUSDValue(dailyVolumeUsd);
-  }
+  dailyVolume.addUSDValue(dailyVolumeUsd);
 
   return { dailyVolume };
 };


### PR DESCRIPTION
part of #8521 (credit to quepasaquepasa); lotus went $2.5m/day to hard $0 on 07-30.

root cause: their `/contract/performance` feed froze after 07-29; tvl and the cumulative volume counter are byte-identical for 07-29/30/31 (a real quiet day would still move tvl with prices). the adapter takes the day-over-day diff of the cumulative counter and silently reports $0 when the diff isn't positive, so a dead feed turns into fake zero-volume days instead of errors.

fix: throw when the requested day has no rows, and throw when the diff is 0 with tvl also unchanged (frozen snapshot). harness: 07-29 returns $2.53m matching the published $2,533,965 to the dollar, 07-30 now throws the stale error instead of storing $0.

if the protocol is actually winding down, deadFrom is your call, but the api serving frozen data shouldn't book zeros either way.