### PR TITLE
sui: fullnode json-rpc is deprecated, point at a live endpoint

### DIFF
--- a/helpers/sui.ts
+++ b/helpers/sui.ts
@@ -1,8 +1,7 @@
 const http = require('axios')
 const { getEnv } = require('./env')
 
-// const endpoint = () => getEnv('SUI_RPC')
-const endpoint = () => 'https://fullnode.mainnet.sui.io/'
+const endpoint = () => getEnv('SUI_RPC') || 'https://rpc-mainnet.suiscan.xyz'
 
 export async function getObject(objectId:string) {
   return (await call('sui_getObject', [objectId, {


### PR DESCRIPTION
sui deprecated json-rpc on public fullnodes; every method on `fullnode.mainnet.sui.io` now returns `-32601 Method not found. JSON-RPC on public fullnodes has been deprecated`. helpers/sui.ts hardcodes that endpoint (the SUI_RPC env override was commented out), so all 17 adapters importing it are broken: volo-lst crashes outright, flowx-v3 silently reports $0 (its dune leg still returns rows, but getObject fails inside Promise.allSettled so every pool gets skipped), bluemove, typus, ondo, allbridge-core, wormhole, alphafi, honeyplay, waterx, hashlock etc all hit the same wall.

the onset is staggered per adapter (flowx died 07-28, bluemove's last nonzero day is 07-21) because in-memory caches like flowx's poolCache mask the breakage until the process recycles; which is also why this connects to #8521's zero-day list.

fix: restore the SUI_RPC env override with a live public default. probed the alternatives: suiet, suiscan and blockvision still serve json-rpc; blastapi is shut down, publicnode empty, drpc 404. went with `rpc-mainnet.suiscan.xyz`.

verified: volo-lst harness on the old endpoint crashes (`Cannot read properties of undefined`), on the new one returns $614 daily fees with a clean breakdown; bluemove runs clean and returns 0 which geckoterminal confirms is its real current volume. flowx-v3 needs a dune key so ci will exercise that one.