### PR TITLE
uniswap v3: keep the wash query out of the bulk-mode batch

### DIFF
--- a/dexs/uniswap-v3.ts
+++ b/dexs/uniswap-v3.ts
@@ -120,7 +120,9 @@ async function fetchWashPools(blockchains: string[], options: FetchOptions): Pro
     -- priced-but-dust pools are noise either way; NULL usd (unpriceable) stays flagged
     AND NOT (SUM(amount_usd) IS NOT NULL AND SUM(amount_usd) < ${WASH_DUST_USD})`;
 
-  const rows: any[] = await queryDune('3996608', { fullQuery }, options);
+  // extraUIDKey keeps DUNE_BULK_MODE from UNION ALLing this 2-column query with
+  // the 4-column volume query of the same module - the shapes don't match
+  const rows: any[] = await queryDune('3996608', { fullQuery }, options, { extraUIDKey: 'wash' });
   const washPools: Record<string, Set<string>> = {};
   for (const row of rows) {
     if (!row.blockchain || !row.pool) continue;


### PR DESCRIPTION
Follow-up to #8515.

Under DUNE_BULK_MODE the runner UNION ALLs same-module queries against queryId 3996608 into one execution. The uniswap-v3 prefetch issues two of them in parallel, and their shapes differ (volume: blockchain, pool, token, amount; wash: blockchain, pool), so the merged query fails on Dune with a field-count mismatch and the whole adapter errors in production.

Tag the wash query with extraUIDKey so it batches separately.

Verified locally with DUNE_BULK_MODE=true: before the fix the batched UNION ALL query fails, after the fix both queries execute on their own, the 32k-row per-chain fallback still works, and the adapter completes (base 2026-07-30: volume $79.3M). uniswap-v4 is unaffected, its prefetch is a single query.