### PR TITLE
stonkbrokers: Broker Box fees + volume, lockers, swap-desk

### DIFF
--- a/fees/stonkbrokers/index.ts
+++ b/fees/stonkbrokers/index.ts
@@ -1,6 +1,7 @@
 import { FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 import ADDRESSES from "../../helpers/coreAssets.json";
+import { addTokensReceived } from "../../helpers/token";
 
 /**
  * StonkBrokers — Anvil NFTFi + Broker Box + Safety Deposit Box on Robinhood,
@@ -171,7 +172,6 @@ function addProtocolCut(
   else balances.addToken(token, amount, label);
 }
 
-const MACHINE_SET = new Set(GACHA_MACHINES.map((a) => a.toLowerCase()));
 const LOCKER_META: { addr: string; isV4: boolean }[] = [
   { addr: LOCKER_V3, isV4: false },
   { addr: LOCKER_V4, isV4: true },
@@ -186,68 +186,42 @@ const fetchRobinhood = async (options: FetchOptions) => {
   const dailySupplySideRevenue = options.createBalances();
   const dailyHoldersRevenue = options.createBalances();
 
-  // Robinhood's public RPC rate-limits hard under CI's 24× hourly fan-out.
-  // Fetch in small batches, use noTarget for multi-machine EdgeSkimmed (1
-  // request instead of 9), and cacheInCloud so retries hit Llama's cache.
-  const logOpts = { cacheInCloud: true } as const;
-
   const [soldLogs, boughtLogs, loansLogs] = await Promise.all([
-    options.getLogs({ target: AMM_VAULT, eventAbi: NFT_SOLD, ...logOpts }),
-    options.getLogs({ target: AMM_VAULT, eventAbi: NFT_BOUGHT, ...logOpts }),
-    options.getLogs({ target: LOAN_VAULT, eventAbi: LOAN_CREATED, ...logOpts }),
+    options.getLogs({ target: AMM_VAULT, eventAbi: NFT_SOLD,}),
+    options.getLogs({ target: AMM_VAULT, eventAbi: NFT_BOUGHT,}),
+    options.getLogs({ target: LOAN_VAULT, eventAbi: LOAN_CREATED,}),
   ]);
 
   const [activatedLogs, upgradedLogs, counterLogs] = await Promise.all([
-    options.getLogs({ target: ACTIVATION_MANAGER, eventAbi: ACTIVATED, ...logOpts }),
+    options.getLogs({ target: ACTIVATION_MANAGER, eventAbi: ACTIVATED,}),
     options.getLogs({
       target: ACTIVATION_MANAGER,
       eventAbi: ACTIVATION_UPGRADED,
-      ...logOpts,
     }),
     options.getLogs({
       target: CERTIFICATE_COUNTER,
       eventAbi: CERTIFICATE_BOUGHT,
-      ...logOpts,
     }),
   ]);
 
-  // Chain-wide Broker Box scans, then keep only production machines (1 RPC
-  // each instead of 9× per event — Robinhood public RPC rate-limits hard).
-  const [edgeRaw, pullRaw, soldBackRaw, soldBackUsdgRaw] = await Promise.all([
+  const [edgeLogs, pullLogs, soldBackLogs, soldBackUsdgLogs] = await Promise.all([
     options.getLogs({
-      noTarget: true,
+      targets: GACHA_MACHINES,
       eventAbi: EDGE_SKIMMED,
-      entireLog: true,
-      parseLog: true,
-      ...logOpts,
     }),
     options.getLogs({
-      noTarget: true,
+      targets: GACHA_MACHINES,
       eventAbi: PULL_OPENED,
-      entireLog: true,
-      parseLog: true,
-      ...logOpts,
     }),
     options.getLogs({
-      noTarget: true,
+      targets: GACHA_MACHINES,
       eventAbi: SOLD_BACK,
-      entireLog: true,
-      parseLog: true,
-      ...logOpts,
     }),
     options.getLogs({
-      noTarget: true,
+      targets: GACHA_MACHINES,
       eventAbi: SOLD_BACK_USDG,
-      entireLog: true,
-      parseLog: true,
-      ...logOpts,
     }),
   ]);
-  const onMachine = (log: any) => MACHINE_SET.has(String(log.address).toLowerCase());
-  const edgeLogs = edgeRaw.filter(onMachine).map((log: any) => log.args);
-  const pullLogs = pullRaw.filter(onMachine).map((log: any) => log.args);
-  const soldBackLogs = soldBackRaw.filter(onMachine).map((log: any) => log.args);
-  const soldBackUsdgLogs = soldBackUsdgRaw.filter(onMachine).map((log: any) => log.args);
 
   // Robinhood is not in addTokensReceived's log-fallback chain map, so locker
   // cuts are read from the fee events + a lockPositions lookup.
@@ -255,16 +229,10 @@ const fetchRobinhood = async (options: FetchOptions) => {
     options.getLogs({
       targets: [LOCKER_V3, LOCKER_V4],
       eventAbi: LOCK_FEES_COLLECTED,
-      entireLog: true,
-      parseLog: true,
-      ...logOpts,
     }),
     options.getLogs({
       targets: [LOCKER_V3, LOCKER_V4],
       eventAbi: LOCK_LIQUIDITY_DECREASED,
-      entireLog: true,
-      parseLog: true,
-      ...logOpts,
     }),
   ]);
 
@@ -369,9 +337,7 @@ const fetchRobinhood = async (options: FetchOptions) => {
   // (Robinhood has no Transfer-log fallback in addTokensReceived); collect /
   // withdraw cuts dominate live volume and are fully covered.
   const lockCache = new Map<string, [string, string]>();
-  const lockerLogs = [...lockerCollectLogs, ...lockerDecreaseLogs].filter((log: any) =>
-    LOCKER_SET.has(String(log.address).toLowerCase()),
-  );
+  const lockerLogs = [...lockerCollectLogs, ...lockerDecreaseLogs];
   // Group by locker so lockPositions multicalls stay batched.
   const byLocker = new Map<string, { isV4: boolean; logs: any[] }>();
   for (const log of lockerLogs) {
@@ -381,7 +347,7 @@ const fetchRobinhood = async (options: FetchOptions) => {
       bucket = { isV4: LOCKER_SET.get(addr)!, logs: [] };
       byLocker.set(addr, bucket);
     }
-    bucket.logs.push(log.args ?? log);
+    bucket.logs.push( log);
   }
   for (const [locker, batch] of byLocker) {
     const ids = [...new Set(batch.logs.map((l) => String(l.lockTokenId)))];
@@ -415,37 +381,21 @@ const fetchRobinhood = async (options: FetchOptions) => {
   };
 };
 
-const TRANSFER =
-  "event Transfer(address indexed from, address indexed to, uint256 value)";
-const TRANSFER_TOPIC =
-  "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef";
-
-function padAddress(addr: string): string {
-  return "0x" + addr.toLowerCase().replace(/^0x/, "").padStart(64, "0");
-}
-
 /** Base: Relay swap-desk 1% app fee, measured as Base USDC leaving the fee wallet
  *  on its way to StockBooster via Relay (the wallet's only USDC outflows). */
 const fetchBase = async (options: FetchOptions) => {
-  const dailyFees = options.createBalances();
-  const logs = await options.getLogs({
-    target: BASE_USDC,
-    eventAbi: TRANSFER,
-    topics: [TRANSFER_TOPIC, padAddress(RELAY_FEE_WALLET)] as any,
-    cacheInCloud: true,
-  });
-  for (const log of logs) {
-    dailyFees.addToken(BASE_USDC, BigInt(log.value), LABELS.SWAP_DESK_FEES);
-  }
+  const swapDeskFees = await addTokensReceived({options, fromAddressFilter: RELAY_FEE_WALLET, tokens: [BASE_USDC]});
+  
+  const dailyFees = swapDeskFees.clone(1, LABELS.SWAP_DESK_FEES);
 
   return {
     dailyFees,
     // Entire desk fee is forwarded to StockBooster as a Clock In bonus top-up —
     // supply-side only (mirrors how NFTFi booster share is attributed).
     dailySupplySideRevenue: dailyFees,
-    dailyRevenue: options.createBalances(),
-    dailyProtocolRevenue: options.createBalances(),
-    dailyHoldersRevenue: options.createBalances(),
+    dailyRevenue: 0,
+    dailyProtocolRevenue: 0,
+    dailyHoldersRevenue: 0,
   };
 };
 

--- a/fees/stonkbrokers/index.ts
+++ b/fees/stonkbrokers/index.ts
@@ -63,8 +63,9 @@ const CERTIFICATE_BOUGHT =
   "event CertificateBought(uint256 indexed tokenId, address indexed buyer, address indexed recipient, address stockToken, uint256 stockAmount, uint256 spendWei, uint256 feeWei, address wallet)";
 const LOCK_FEES_COLLECTED =
   "event LockFeesCollected(uint256 indexed lockTokenId, uint256 userAmount0, uint256 userAmount1, uint256 protocolAmount0, uint256 protocolAmount1)";
+// liquidity is uint128 on-chain — wrong width → wrong topic0 and silent misses.
 const LOCK_LIQUIDITY_DECREASED =
-  "event LockLiquidityDecreased(uint256 indexed lockTokenId, uint256 liquidity, uint256 userAmount0, uint256 userAmount1, uint256 protocolAmount0, uint256 protocolAmount1)";
+  "event LockLiquidityDecreased(uint256 indexed lockTokenId, uint128 liquidity, uint256 userAmount0, uint256 userAmount1, uint256 protocolAmount0, uint256 protocolAmount1)";
 
 const LABELS = {
   AMM_FEES: "NFT AMM trade fees",

--- a/fees/stonkbrokers/index.ts
+++ b/fees/stonkbrokers/index.ts
@@ -1,7 +1,6 @@
-import { Dependencies, FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 import ADDRESSES from "../../helpers/coreAssets.json";
-import { getEVMTokenTransfers } from "../../helpers/token";
 
 /**
  * StonkBrokers — Anvil NFTFi + Broker Box + Safety Deposit Box on Robinhood,
@@ -295,16 +294,27 @@ const fetchRobinhood = async (options: FetchOptions) => {
   };
 };
 
+const TRANSFER =
+  "event Transfer(address indexed from, address indexed to, uint256 value)";
+const TRANSFER_TOPIC =
+  "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef";
+
+function padAddress(addr: string): string {
+  return "0x" + addr.toLowerCase().replace(/^0x/, "").padStart(64, "0");
+}
+
 /** Base: Relay swap-desk 1% app fee, measured as Base USDC leaving the fee wallet
  *  on its way to StockBooster via Relay (the wallet's only USDC outflows). */
 const fetchBase = async (options: FetchOptions) => {
-  const transferred = await getEVMTokenTransfers({
-    options,
-    fromAddresses: [RELAY_FEE_WALLET],
-    tokens: [BASE_USDC],
-  });
   const dailyFees = options.createBalances();
-  dailyFees.addBalances(transferred, LABELS.SWAP_DESK_FEES);
+  const logs = await options.getLogs({
+    target: BASE_USDC,
+    eventAbi: TRANSFER,
+    topics: [TRANSFER_TOPIC, padAddress(RELAY_FEE_WALLET)] as any,
+  });
+  for (const log of logs) {
+    dailyFees.addToken(BASE_USDC, BigInt(log.value), LABELS.SWAP_DESK_FEES);
+  }
 
   return {
     dailyFees,
@@ -320,7 +330,6 @@ const fetchBase = async (options: FetchOptions) => {
 const adapter: SimpleAdapter = {
   version: 2,
   pullHourly: true,
-  dependencies: [Dependencies.ALLIUM],
   adapter: {
     [CHAIN.ROBINHOOD]: {
       fetch: fetchRobinhood,
@@ -355,7 +364,7 @@ const adapter: SimpleAdapter = {
       [LABELS.LOCKER_FEES]:
         "Protocol cut on Safety Deposit Box locks from LockFeesCollected / LockLiquidityDecreased (20% of LP fee collects / 1% withdraw; upfront 0.5% not evented).",
       [LABELS.SWAP_DESK_FEES]:
-        "1% Relay app fee on the crypto swap desk, measured as Base USDC forwarded from the fee wallet toward StockBooster.",
+        "1% Relay app fee on the crypto swap desk, measured as Base USDC Transfer outflows from the fee wallet toward StockBooster.",
     },
     Revenue: {
       [LABELS.AMM_PROTOCOL_TREASURY]: "30% of ETH AMM fees retained by ProtocolFeeSink.",

--- a/fees/stonkbrokers/index.ts
+++ b/fees/stonkbrokers/index.ts
@@ -154,6 +154,13 @@ function addProtocolCut(
   else balances.addToken(token, amount, label);
 }
 
+const MACHINE_SET = new Set(GACHA_MACHINES.map((a) => a.toLowerCase()));
+const LOCKER_META: { addr: string; isV4: boolean }[] = [
+  { addr: LOCKER_V3, isV4: false },
+  { addr: LOCKER_V4, isV4: true },
+];
+const LOCKER_SET = new Map(LOCKER_META.map((l) => [l.addr.toLowerCase(), l.isV4]));
+
 const fetchRobinhood = async (options: FetchOptions) => {
   const dailyVolume = options.createBalances();
   const dailyFees = options.createBalances();
@@ -162,32 +169,61 @@ const fetchRobinhood = async (options: FetchOptions) => {
   const dailySupplySideRevenue = options.createBalances();
   const dailyHoldersRevenue = options.createBalances();
 
-  const [
-    soldLogs,
-    boughtLogs,
-    loansLogs,
-    activatedLogs,
-    upgradedLogs,
-    edgeLogs,
-    counterLogs,
-    v3CollectLogs,
-    v3DecreaseLogs,
-    v4CollectLogs,
-    v4DecreaseLogs,
-  ] = await Promise.all([
-    options.getLogs({ target: AMM_VAULT, eventAbi: NFT_SOLD }),
-    options.getLogs({ target: AMM_VAULT, eventAbi: NFT_BOUGHT }),
-    options.getLogs({ target: LOAN_VAULT, eventAbi: LOAN_CREATED }),
-    options.getLogs({ target: ACTIVATION_MANAGER, eventAbi: ACTIVATED }),
-    options.getLogs({ target: ACTIVATION_MANAGER, eventAbi: ACTIVATION_UPGRADED }),
-    options.getLogs({ targets: GACHA_MACHINES, eventAbi: EDGE_SKIMMED }),
-    options.getLogs({ target: CERTIFICATE_COUNTER, eventAbi: CERTIFICATE_BOUGHT }),
-    // Robinhood is not in addTokensReceived's log-fallback chain map, so
-    // locker cuts are read from the fee events + a lockPositions lookup.
-    options.getLogs({ target: LOCKER_V3, eventAbi: LOCK_FEES_COLLECTED }),
-    options.getLogs({ target: LOCKER_V3, eventAbi: LOCK_LIQUIDITY_DECREASED }),
-    options.getLogs({ target: LOCKER_V4, eventAbi: LOCK_FEES_COLLECTED }),
-    options.getLogs({ target: LOCKER_V4, eventAbi: LOCK_LIQUIDITY_DECREASED }),
+  // Robinhood's public RPC rate-limits hard under CI's 24× hourly fan-out.
+  // Fetch in small batches, use noTarget for multi-machine EdgeSkimmed (1
+  // request instead of 9), and cacheInCloud so retries hit Llama's cache.
+  const logOpts = { cacheInCloud: true } as const;
+
+  const [soldLogs, boughtLogs, loansLogs] = await Promise.all([
+    options.getLogs({ target: AMM_VAULT, eventAbi: NFT_SOLD, ...logOpts }),
+    options.getLogs({ target: AMM_VAULT, eventAbi: NFT_BOUGHT, ...logOpts }),
+    options.getLogs({ target: LOAN_VAULT, eventAbi: LOAN_CREATED, ...logOpts }),
+  ]);
+
+  const [activatedLogs, upgradedLogs, counterLogs] = await Promise.all([
+    options.getLogs({ target: ACTIVATION_MANAGER, eventAbi: ACTIVATED, ...logOpts }),
+    options.getLogs({
+      target: ACTIVATION_MANAGER,
+      eventAbi: ACTIVATION_UPGRADED,
+      ...logOpts,
+    }),
+    options.getLogs({
+      target: CERTIFICATE_COUNTER,
+      eventAbi: CERTIFICATE_BOUGHT,
+      ...logOpts,
+    }),
+  ]);
+
+  // One chain-wide EdgeSkimmed scan, then keep only production machines.
+  const edgeLogs = (
+    await options.getLogs({
+      noTarget: true,
+      eventAbi: EDGE_SKIMMED,
+      entireLog: true,
+      parseLog: true,
+      ...logOpts,
+    })
+  )
+    .filter((log: any) => MACHINE_SET.has(String(log.address).toLowerCase()))
+    .map((log: any) => log.args);
+
+  // Robinhood is not in addTokensReceived's log-fallback chain map, so locker
+  // cuts are read from the fee events + a lockPositions lookup.
+  const [lockerCollectLogs, lockerDecreaseLogs] = await Promise.all([
+    options.getLogs({
+      targets: [LOCKER_V3, LOCKER_V4],
+      eventAbi: LOCK_FEES_COLLECTED,
+      entireLog: true,
+      parseLog: true,
+      ...logOpts,
+    }),
+    options.getLogs({
+      targets: [LOCKER_V3, LOCKER_V4],
+      eventAbi: LOCK_LIQUIDITY_DECREASED,
+      entireLog: true,
+      parseLog: true,
+      ...logOpts,
+    }),
   ]);
 
   // ── NFT AMM + loans ──────────────────────────────────────────────────────
@@ -257,16 +293,25 @@ const fetchRobinhood = async (options: FetchOptions) => {
   // (Robinhood has no Transfer-log fallback in addTokensReceived); collect /
   // withdraw cuts dominate live volume and are fully covered.
   const lockCache = new Map<string, [string, string]>();
-  const lockerBatches: { locker: string; isV4: boolean; logs: any[] }[] = [
-    { locker: LOCKER_V3, isV4: false, logs: [...v3CollectLogs, ...v3DecreaseLogs] },
-    { locker: LOCKER_V4, isV4: true, logs: [...v4CollectLogs, ...v4DecreaseLogs] },
-  ];
-  for (const batch of lockerBatches) {
-    if (batch.logs.length === 0) continue;
+  const lockerLogs = [...lockerCollectLogs, ...lockerDecreaseLogs].filter((log: any) =>
+    LOCKER_SET.has(String(log.address).toLowerCase()),
+  );
+  // Group by locker so lockPositions multicalls stay batched.
+  const byLocker = new Map<string, { isV4: boolean; logs: any[] }>();
+  for (const log of lockerLogs) {
+    const addr = String(log.address).toLowerCase();
+    let bucket = byLocker.get(addr);
+    if (!bucket) {
+      bucket = { isV4: LOCKER_SET.get(addr)!, logs: [] };
+      byLocker.set(addr, bucket);
+    }
+    bucket.logs.push(log.args ?? log);
+  }
+  for (const [locker, batch] of byLocker) {
     const ids = [...new Set(batch.logs.map((l) => String(l.lockTokenId)))];
-    await resolveLockTokens(options, batch.locker, ids, batch.isV4, lockCache);
+    await resolveLockTokens(options, locker, ids, batch.isV4, lockCache);
     for (const log of batch.logs) {
-      const pair = lockCache.get(`${batch.locker}:${String(log.lockTokenId)}`);
+      const pair = lockCache.get(`${locker}:${String(log.lockTokenId)}`);
       if (!pair) continue;
       const amounts: [string, bigint][] = [
         [pair[0], BigInt(log.protocolAmount0)],
@@ -311,6 +356,7 @@ const fetchBase = async (options: FetchOptions) => {
     target: BASE_USDC,
     eventAbi: TRANSFER,
     topics: [TRANSFER_TOPIC, padAddress(RELAY_FEE_WALLET)] as any,
+    cacheInCloud: true,
   });
   for (const log of logs) {
     dailyFees.addToken(BASE_USDC, BigInt(log.value), LABELS.SWAP_DESK_FEES);

--- a/fees/stonkbrokers/index.ts
+++ b/fees/stonkbrokers/index.ts
@@ -1,19 +1,51 @@
-import { FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { Dependencies, FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
+import ADDRESSES from "../../helpers/coreAssets.json";
+import { addTokensReceived, getEVMTokenTransfers } from "../../helpers/token";
 
 /**
- * StonkBrokers — Anvil NFTFi on Robinhood Chain.
+ * StonkBrokers — Anvil NFTFi + Broker Box + Safety Deposit Box on Robinhood,
+ * plus the Relay swap-desk fee rail on Base.
  *
- * ETH fees on NFT AMM trades + NFT-backed loans:
- *   70% → StockBooster (buys AAPL/AMZN/NVDA, airdrops to activated broker TBAs)
- *   30% → ProtocolFeeSink treasury
- *
- * Activation fees (paid in $STONKBROKER) are also tracked; 50% burned / 50% protocol by default.
+ * Fee sources:
+ *  1. NFT AMM trades + NFT-backed loans (70% StockBooster / 30% ProtocolFeeSink)
+ *  2. Broker activation fees in $STONKBROKER (50% burn / 50% protocol)
+ *  3. Broker Box gachapon edge (10% of ticket: 5% StockBooster+creator / 5% protocol)
+ *     plus Certificate Counter flat $2 fee ($1 StockBooster / $1 treasury)
+ *  4. Safety Deposit Box liquidity-locker protocol cuts (V3 + V4) →
+ *     SafetyDepositClockInV3 (90% brokers / 10% protocol wallet)
+ *  5. Swap-desk 1% Relay app fee: Base USDC forwarded from the fee wallet
+ *     (claimed from Relay, then bridged to StockBooster as ETH)
  */
+
 const AMM_VAULT = "0xE302733accF4800146E55fC45B46b4E4fFC032D2";
 const LOAN_VAULT = "0xa7B9AC696B252B79568A5a01b2Fd02177EF23664";
 const ACTIVATION_MANAGER = "0xacD5ae3c060C1137FE2Ee86B0aB2EF697456f664";
 const STONKBROKER = "0xe934e36A439C94017B64a3FecE66AF12099aBF50";
+
+// Broker Box production machines (deployed 2026-07-31) + certificate counter.
+const GACHA_MACHINES = [
+  "0x8F1836209C42d4F6B6caA782c055eE13F8aC95b0", // GME
+  "0xF9bc0777C087Af0fe7214dE8A5360bE6a71D0D44", // AAPL
+  "0x2829b754784352dd2BeFfa5Eb26d5B499315b715", // AMZN
+  "0xc5e3E9C2a835Ec9319Fd8C1d516fD4323c5758A0", // NVDA
+  "0xFF20b4b8E08beAA4064E3ca4CC5a2E40AcaC072f", // GOOGL
+  "0xfC253E0062eEf614E20E0726e5f6FF7559c35402", // MSFT
+  "0x9d2c3355502be065975ad47EF5A902f02c772504", // SLV
+  "0xf58979D35C3F0Ff6A6F7EDd909fE8a95a2894609", // SPCX
+  "0x5B1282B6Ad40b3DC294404A2b33FF7657B66c33c", // USO
+];
+const CERTIFICATE_COUNTER = "0x2599882AaF5C14834562eE59ca7a3D1FFCC229D7";
+
+// Safety Deposit Box lockers → fee router (live 2026-07-25).
+const LOCKER_V3 = "0xFc96CF67eCC55bE4AdABc3AecBe6Ad6349f11223";
+const LOCKER_V4 = "0x5a28ce098750f73bc9eC142D4bCE464E1A0BBdA6";
+const SAFETY_DEPOSIT_CLOCK_IN = "0x55642A3F10F1Af5145D3d59021B1D6b03BB8692c";
+
+// Relay swap-desk 1% app fee accrues off-chain, is claimed as Base USDC to the
+// treasury fee wallet, then forwarded via Relay to StockBooster as ETH.
+const RELAY_FEE_WALLET = "0xb668382cF44038a3E8140E789060F6A809787CDa";
+const BASE_USDC = ADDRESSES.base.USDC;
 
 const NFT_SOLD =
   "event NFTSold(address indexed seller, uint256 indexed tokenId, uint256 tokensOut, uint256 ethFeePaid, uint256 boosterShare, uint256 protocolShare)";
@@ -25,6 +57,14 @@ const ACTIVATED =
   "event Activated(uint256 indexed tokenId, address indexed owner, uint8 tier, uint256 feePaid)";
 const ACTIVATION_UPGRADED =
   "event ActivationUpgraded(uint256 indexed tokenId, address indexed owner, uint8 fromTier, uint8 toTier, uint256 feePaid)";
+const EDGE_SKIMMED =
+  "event EdgeSkimmed(uint256 indexed roundId, uint256 creatorWei, uint256 boosterWei, uint256 protocolWei)";
+const CERTIFICATE_BOUGHT =
+  "event CertificateBought(uint256 indexed tokenId, address indexed buyer, address indexed recipient, address stockToken, uint256 stockAmount, uint256 spendWei, uint256 feeWei, address wallet)";
+const LOCK_FEES_COLLECTED =
+  "event LockFeesCollected(uint256 indexed lockTokenId, uint256 userAmount0, uint256 userAmount1, uint256 protocolAmount0, uint256 protocolAmount1)";
+const LOCK_LIQUIDITY_DECREASED =
+  "event LockLiquidityDecreased(uint256 indexed lockTokenId, uint256 liquidity, uint256 userAmount0, uint256 userAmount1, uint256 protocolAmount0, uint256 protocolAmount1)";
 
 const LABELS = {
   AMM_FEES: "NFT AMM trade fees",
@@ -36,15 +76,85 @@ const LABELS = {
   LOAN_PROTOCOL_TREASURY: "NFT loan fees → ProtocolFeeSink",
   ACTIVATION_BURN: "Activation fees burned (deflationary $STONKBROKER)",
   ACTIVATION_PROTOCOL: "Activation fees → protocol",
+  GACHA_FEES: "Broker Box gachapon edge (10% of ticket)",
+  GACHA_STOCK_DIVIDENDS: "Broker Box edge → StockBooster / creator",
+  GACHA_PROTOCOL: "Broker Box edge → protocol accrual",
+  COUNTER_FEES: "Certificate Counter flat $2 fee",
+  COUNTER_STOCK_DIVIDENDS: "Certificate Counter fee → StockBooster",
+  COUNTER_PROTOCOL: "Certificate Counter fee → treasury",
+  LOCKER_FEES: "Safety Deposit Box liquidity-locker protocol fees",
+  LOCKER_STOCK_DIVIDENDS: "Locker fees → SafetyDepositClockIn brokers (90%)",
+  LOCKER_PROTOCOL: "Locker fees → protocol wallet (10%)",
+  SWAP_DESK_FEES: "Swap-desk Relay app fees (1%)",
 };
 
 const RANDOM_FEE_BPS = 1000n;
 const SPECIFIC_FEE_BPS = 1500n;
-// Default ActivationManager split: 50% burn / 50% protocol
 const ACTIVATION_BURN_BPS = 5000n;
 const ACTIVATION_PROTOCOL_BPS = 5000n;
+const LOCKER_PROTOCOL_BPS = 1000n; // SafetyDepositClockInV3 PROTOCOL_BPS
+const LOCKER_BROKER_BPS = 9000n;
 
-const fetch = async (options: FetchOptions) => {
+const ZERO = "0x0000000000000000000000000000000000000000";
+
+/** Resolve token0/token1 (or currency0/currency1) for a lock, caching per id. */
+async function resolveLockTokens(
+  options: FetchOptions,
+  locker: string,
+  lockIds: string[],
+  isV4: boolean,
+  cache: Map<string, [string, string]>,
+) {
+  const missing = lockIds.filter((id) => !cache.has(`${locker}:${id}`));
+  if (missing.length === 0) return;
+
+  if (isV4) {
+    // V4Lock: currency0, currency1, fee, tickSpacing, hooks, tickLower, tickUpper, ...
+    const abi =
+      "function lockPositions(uint256) view returns (address currency0, address currency1, uint24 fee, int24 tickSpacing, address hooks, int24 tickLower, int24 tickUpper, uint128 initialLiquidity, uint128 withdrawnLiquidity, uint64 startUnlock, uint64 finishUnlock, uint8 feeMode, bool closed)";
+    const rows = await options.api.multiCall({
+      abi,
+      calls: missing.map((id) => ({ target: locker, params: [id] })),
+      permitFailure: true,
+    });
+    rows.forEach((row: any, i: number) => {
+      if (!row) return;
+      cache.set(`${locker}:${missing[i]}`, [
+        (row.currency0 || row[0] || ZERO).toLowerCase(),
+        (row.currency1 || row[1] || ZERO).toLowerCase(),
+      ]);
+    });
+  } else {
+    // LockPosition: positionTokenId, lockTokenId, token0, token1, ...
+    const abi =
+      "function lockPositions(uint256) view returns (uint256 positionTokenId, uint256 lockTokenId, address token0, address token1, uint128 initialLiquidity, uint128 withdrawnLiquidity, uint64 startUnlock, uint64 finishUnlock, uint8 feeMode, bool closed)";
+    const rows = await options.api.multiCall({
+      abi,
+      calls: missing.map((id) => ({ target: locker, params: [id] })),
+      permitFailure: true,
+    });
+    rows.forEach((row: any, i: number) => {
+      if (!row) return;
+      cache.set(`${locker}:${missing[i]}`, [
+        (row.token0 || row[2] || ZERO).toLowerCase(),
+        (row.token1 || row[3] || ZERO).toLowerCase(),
+      ]);
+    });
+  }
+}
+
+function addProtocolCut(
+  balances: ReturnType<FetchOptions["createBalances"]>,
+  token: string,
+  amount: bigint,
+  label: string,
+) {
+  if (amount <= 0n) return;
+  if (!token || token === ZERO) balances.addGasToken(amount, label);
+  else balances.addToken(token, amount, label);
+}
+
+const fetchRobinhood = async (options: FetchOptions) => {
   const dailyVolume = options.createBalances();
   const dailyFees = options.createBalances();
   const dailyRevenue = options.createBalances();
@@ -52,12 +162,32 @@ const fetch = async (options: FetchOptions) => {
   const dailySupplySideRevenue = options.createBalances();
   const dailyHoldersRevenue = options.createBalances();
 
-  const soldLogs = await options.getLogs({ target: AMM_VAULT, eventAbi: NFT_SOLD });
-  const boughtLogs = await options.getLogs({ target: AMM_VAULT, eventAbi: NFT_BOUGHT });
-  const loansLogs = await options.getLogs({ target: LOAN_VAULT, eventAbi: LOAN_CREATED });
-  const activatedLogs = await options.getLogs({ target: ACTIVATION_MANAGER, eventAbi: ACTIVATED });
-  const upgradedLogs = await options.getLogs({ target: ACTIVATION_MANAGER, eventAbi: ACTIVATION_UPGRADED });
+  const [
+    soldLogs,
+    boughtLogs,
+    loansLogs,
+    activatedLogs,
+    upgradedLogs,
+    edgeLogs,
+    counterLogs,
+    v4CollectLogs,
+    v4DecreaseLogs,
+  ] = await Promise.all([
+    options.getLogs({ target: AMM_VAULT, eventAbi: NFT_SOLD }),
+    options.getLogs({ target: AMM_VAULT, eventAbi: NFT_BOUGHT }),
+    options.getLogs({ target: LOAN_VAULT, eventAbi: LOAN_CREATED }),
+    options.getLogs({ target: ACTIVATION_MANAGER, eventAbi: ACTIVATED }),
+    options.getLogs({ target: ACTIVATION_MANAGER, eventAbi: ACTIVATION_UPGRADED }),
+    options.getLogs({ targets: GACHA_MACHINES, eventAbi: EDGE_SKIMMED }),
+    options.getLogs({ target: CERTIFICATE_COUNTER, eventAbi: CERTIFICATE_BOUGHT }),
+    // V3 locker cuts are always ERC20 (WETH/token) and are covered by
+    // addTokensReceived below. V4 native-ETH sides need the collect/decrease
+    // events because they do not emit ERC20 Transfers.
+    options.getLogs({ target: LOCKER_V4, eventAbi: LOCK_FEES_COLLECTED }),
+    options.getLogs({ target: LOCKER_V4, eventAbi: LOCK_LIQUIDITY_DECREASED }),
+  ]);
 
+  // ── NFT AMM + loans ──────────────────────────────────────────────────────
   for (const log of [...soldLogs, ...boughtLogs]) {
     const bps = log.isSpecific ? SPECIFIC_FEE_BPS : RANDOM_FEE_BPS;
     dailyVolume.addGasToken((log.ethFeePaid * 10_000n) / bps);
@@ -75,14 +205,130 @@ const fetch = async (options: FetchOptions) => {
     dailyRevenue.addGasToken(log.protocolShare, LABELS.LOAN_PROTOCOL_TREASURY);
   }
 
+  // ── Activation fees ──────────────────────────────────────────────────────
   for (const log of [...activatedLogs, ...upgradedLogs]) {
     const fee = BigInt(log.feePaid);
     dailyFees.addToken(STONKBROKER, fee, LABELS.ACTIVATION_FEES);
-    dailyHoldersRevenue.addToken(STONKBROKER, (fee * ACTIVATION_BURN_BPS) / 10_000n, LABELS.ACTIVATION_BURN);
-    dailyProtocolRevenue.addToken(STONKBROKER, (fee * ACTIVATION_PROTOCOL_BPS) / 10_000n, LABELS.ACTIVATION_PROTOCOL);
+    dailyHoldersRevenue.addToken(
+      STONKBROKER,
+      (fee * ACTIVATION_BURN_BPS) / 10_000n,
+      LABELS.ACTIVATION_BURN,
+    );
+    dailyProtocolRevenue.addToken(
+      STONKBROKER,
+      (fee * ACTIVATION_PROTOCOL_BPS) / 10_000n,
+      LABELS.ACTIVATION_PROTOCOL,
+    );
     dailyRevenue.addToken(STONKBROKER, fee, LABELS.ACTIVATION_FEES);
   }
 
+  // ── Broker Box gachapon ──────────────────────────────────────────────────
+  // Official machines set creator = StockBooster, so creatorWei + boosterWei
+  // both fund Clock In stock drops. protocolWei accrues for the treasury.
+  for (const log of edgeLogs) {
+    const creator = BigInt(log.creatorWei);
+    const booster = BigInt(log.boosterWei);
+    const protocol = BigInt(log.protocolWei);
+    const total = creator + booster + protocol;
+    if (total <= 0n) continue;
+    dailyFees.addGasToken(total, LABELS.GACHA_FEES);
+    dailySupplySideRevenue.addGasToken(creator + booster, LABELS.GACHA_STOCK_DIVIDENDS);
+    dailyProtocolRevenue.addGasToken(protocol, LABELS.GACHA_PROTOCOL);
+    dailyRevenue.addGasToken(protocol, LABELS.GACHA_PROTOCOL);
+  }
+
+  for (const log of counterLogs) {
+    const fee = BigInt(log.feeWei);
+    if (fee <= 0n) continue;
+    const half = fee / 2n;
+    const rest = fee - half; // remainder to treasury on odd wei
+    dailyFees.addGasToken(fee, LABELS.COUNTER_FEES);
+    dailySupplySideRevenue.addGasToken(half, LABELS.COUNTER_STOCK_DIVIDENDS);
+    dailyProtocolRevenue.addGasToken(rest, LABELS.COUNTER_PROTOCOL);
+    dailyRevenue.addGasToken(rest, LABELS.COUNTER_PROTOCOL);
+  }
+
+  // ── Liquidity locker protocol cuts ───────────────────────────────────────
+  // ERC20 cuts (V3 always; V4 when the side is an ERC20) land as Transfer
+  // events locker → SafetyDepositClockIn. Attribute 90/10 to match the
+  // clock-in's hardwired split.
+  const lockerErc20 = await addTokensReceived({
+    options,
+    fromAdddesses: [LOCKER_V3, LOCKER_V4],
+    target: SAFETY_DEPOSIT_CLOCK_IN,
+    fetchTokenList: true,
+  });
+  if (lockerErc20) {
+    dailyFees.addBalances(lockerErc20, LABELS.LOCKER_FEES);
+    dailySupplySideRevenue.addBalances(
+      lockerErc20.clone(Number(LOCKER_BROKER_BPS) / 10_000, LABELS.LOCKER_STOCK_DIVIDENDS),
+    );
+    const protocolShare = lockerErc20.clone(
+      Number(LOCKER_PROTOCOL_BPS) / 10_000,
+      LABELS.LOCKER_PROTOCOL,
+    );
+    dailyProtocolRevenue.addBalances(protocolShare);
+    dailyRevenue.addBalances(protocolShare);
+  }
+
+  // Native-ETH protocol cuts on V4 (currency0 = address(0)) do not emit ERC20
+  // Transfers — pull them from LockFeesCollected / LockLiquidityDecreased.
+  // V3 is always ERC20 (WETH), so it is fully covered by addTokensReceived
+  // above; we still resolve V3 tokens only if we need them for native (we don't).
+  const lockCache = new Map<string, [string, string]>();
+  const v4Logs = [...v4CollectLogs, ...v4DecreaseLogs];
+  if (v4Logs.length > 0) {
+    const ids = [...new Set(v4Logs.map((l: any) => String(l.lockTokenId)))];
+    await resolveLockTokens(options, LOCKER_V4, ids, true, lockCache);
+    for (const log of v4Logs) {
+      const pair = lockCache.get(`${LOCKER_V4}:${String(log.lockTokenId)}`);
+      if (!pair) continue;
+      const [c0, c1] = pair;
+      // Only count native sides here — ERC20 sides already counted via Transfer.
+      if (c0 === ZERO) {
+        addProtocolCut(dailyFees, ZERO, BigInt(log.protocolAmount0), LABELS.LOCKER_FEES);
+        addProtocolCut(
+          dailySupplySideRevenue,
+          ZERO,
+          (BigInt(log.protocolAmount0) * LOCKER_BROKER_BPS) / 10_000n,
+          LABELS.LOCKER_STOCK_DIVIDENDS,
+        );
+        addProtocolCut(
+          dailyProtocolRevenue,
+          ZERO,
+          (BigInt(log.protocolAmount0) * LOCKER_PROTOCOL_BPS) / 10_000n,
+          LABELS.LOCKER_PROTOCOL,
+        );
+        addProtocolCut(
+          dailyRevenue,
+          ZERO,
+          (BigInt(log.protocolAmount0) * LOCKER_PROTOCOL_BPS) / 10_000n,
+          LABELS.LOCKER_PROTOCOL,
+        );
+      }
+      if (c1 === ZERO) {
+        addProtocolCut(dailyFees, ZERO, BigInt(log.protocolAmount1), LABELS.LOCKER_FEES);
+        addProtocolCut(
+          dailySupplySideRevenue,
+          ZERO,
+          (BigInt(log.protocolAmount1) * LOCKER_BROKER_BPS) / 10_000n,
+          LABELS.LOCKER_STOCK_DIVIDENDS,
+        );
+        addProtocolCut(
+          dailyProtocolRevenue,
+          ZERO,
+          (BigInt(log.protocolAmount1) * LOCKER_PROTOCOL_BPS) / 10_000n,
+          LABELS.LOCKER_PROTOCOL,
+        );
+        addProtocolCut(
+          dailyRevenue,
+          ZERO,
+          (BigInt(log.protocolAmount1) * LOCKER_PROTOCOL_BPS) / 10_000n,
+          LABELS.LOCKER_PROTOCOL,
+        );
+      }
+    }
+  }
   return {
     dailyVolume,
     dailyFees,
@@ -93,48 +339,100 @@ const fetch = async (options: FetchOptions) => {
   };
 };
 
+/** Base: Relay swap-desk 1% app fee, measured as Base USDC leaving the fee wallet
+ *  on its way to StockBooster via Relay (the wallet's only USDC outflows). */
+const fetchBase = async (options: FetchOptions) => {
+  const transferred = await getEVMTokenTransfers({
+    options,
+    fromAddresses: [RELAY_FEE_WALLET],
+    tokens: [BASE_USDC],
+  });
+  const dailyFees = options.createBalances();
+  dailyFees.addBalances(transferred, LABELS.SWAP_DESK_FEES);
+
+  return {
+    dailyFees,
+    // Entire desk fee is forwarded to StockBooster as a Clock In bonus top-up —
+    // supply-side only (mirrors how NFTFi booster share is attributed).
+    dailySupplySideRevenue: dailyFees,
+    dailyRevenue: options.createBalances(),
+    dailyProtocolRevenue: options.createBalances(),
+    dailyHoldersRevenue: options.createBalances(),
+  };
+};
+
 const adapter: SimpleAdapter = {
   version: 2,
   pullHourly: true,
-  fetch,
+  dependencies: [Dependencies.ALLIUM],
   adapter: {
-    [CHAIN.ROBINHOOD]: { start: "2026-07-17" },
+    [CHAIN.ROBINHOOD]: {
+      fetch: fetchRobinhood,
+      start: "2026-07-17",
+    },
+    [CHAIN.BASE]: {
+      fetch: fetchBase,
+      start: "2026-07-17",
+    },
   },
   methodology: {
     Volume:
       "ETH notional of StonkBrokers NFT AMM fills, derived from ethFeePaid and vault fee bps (10% random / 15% snipe).",
     Fees:
-      "ETH fees on NFT AMM trades + NFT-backed loans, plus $STONKBROKER broker activation/upgrade fees.",
+      "ETH fees on NFT AMM trades + NFT-backed loans; $STONKBROKER broker activation/upgrade fees; Broker Box gachapon 10% edge + Certificate Counter $2 fee; Safety Deposit Box liquidity-locker protocol cuts; and the Relay swap-desk 1% app fee (Base USDC forwarded to StockBooster).",
     Revenue:
-      "30% of ETH fees (NFT AMM trades + NFT-backed loans) sent to ProtocolFeeSink plus all the $STONKBROKER activation/upgrade fees.",
+      "Protocol-retained share: 30% of NFTFi ETH fees, protocol share of activation fees, Broker Box protocol accrual + counter treasury half, and 10% of locker fees.",
     ProtocolRevenue:
-      "30% of ETH trade/loan fees to ProtocolFeeSink, plus the protocol share of $STONKBROKER activation fees.",
+      "30% of NFTFi ETH fees → ProtocolFeeSink; protocol share of $STONKBROKER activation fees; Broker Box protocol accrual + counter treasury half; 10% of locker fees → protocol wallet.",
     HoldersRevenue:
       "Half of the $STONKBROKER activation/upgrade fees burned.",
+    SupplySideRevenue:
+      "70% of NFTFi ETH fees → StockBooster stock dividends; Broker Box creator+booster edge + counter StockBooster half; 90% of locker fees → SafetyDepositClockIn broker claims; Relay swap-desk 1% app fees forwarded to StockBooster.",
   },
   breakdownMethodology: {
     Fees: {
       [LABELS.AMM_FEES]: "ETH trade fees on buyRandomNFT / buySpecificNFT / sellNFT.",
       [LABELS.LOAN_FEES]: "Upfront ETH borrow fees on NFT-backed loans.",
       [LABELS.ACTIVATION_FEES]: "One-time / upgrade $STONKBROKER activation fees.",
+      [LABELS.GACHA_FEES]: "10% house edge skimmed from every settled Broker Box ticket.",
+      [LABELS.COUNTER_FEES]: "Flat $2 Certificate Counter fee per OTC deed mint.",
+      [LABELS.LOCKER_FEES]:
+        "Protocol cut on Safety Deposit Box locks (0.5% upfront / 20% of LP fee collects / 1% withdraw).",
+      [LABELS.SWAP_DESK_FEES]:
+        "1% Relay app fee on the crypto swap desk, measured as Base USDC forwarded from the fee wallet toward StockBooster.",
     },
     Revenue: {
       [LABELS.AMM_PROTOCOL_TREASURY]: "30% of ETH AMM fees retained by ProtocolFeeSink.",
       [LABELS.LOAN_PROTOCOL_TREASURY]: "30% of ETH loan fees retained by ProtocolFeeSink.",
       [LABELS.ACTIVATION_FEES]: "Full $STONKBROKER activation fee (burn + protocol).",
+      [LABELS.GACHA_PROTOCOL]: "5% of Broker Box ticket accruing as protocol revenue.",
+      [LABELS.COUNTER_PROTOCOL]: "Half of the Certificate Counter $2 fee → treasury.",
+      [LABELS.LOCKER_PROTOCOL]: "10% of locker protocol fees → protocol wallet.",
     },
     ProtocolRevenue: {
       [LABELS.AMM_PROTOCOL_TREASURY]: "30% of ETH AMM fees retained by ProtocolFeeSink.",
       [LABELS.LOAN_PROTOCOL_TREASURY]: "30% of ETH loan fees retained by ProtocolFeeSink.",
       [LABELS.ACTIVATION_PROTOCOL]: "Protocol share of $STONKBROKER activation fees.",
+      [LABELS.GACHA_PROTOCOL]: "5% of Broker Box ticket accruing as protocol revenue.",
+      [LABELS.COUNTER_PROTOCOL]: "Half of the Certificate Counter $2 fee → treasury.",
+      [LABELS.LOCKER_PROTOCOL]: "10% of locker protocol fees → protocol wallet.",
     },
     HoldersRevenue: {
       [LABELS.ACTIVATION_BURN]: "Burned share of $STONKBROKER activation fees (deflationary).",
     },
     SupplySideRevenue: {
-      [LABELS.AMM_STOCK_DIVIDENDS]: "70% of ETH AMM fees → StockBooster stock-token dividend drops to activated brokers.",
-      [LABELS.LOAN_STOCK_DIVIDENDS]: "70% of ETH loan fees → StockBooster stock-token dividend drops to activated brokers.",
-    }
+      [LABELS.AMM_STOCK_DIVIDENDS]:
+        "70% of ETH AMM fees → StockBooster stock-token dividend drops to activated brokers.",
+      [LABELS.LOAN_STOCK_DIVIDENDS]:
+        "70% of ETH loan fees → StockBooster stock-token dividend drops to activated brokers.",
+      [LABELS.GACHA_STOCK_DIVIDENDS]:
+        "Broker Box creator + StockBooster edge (5% of ticket on official machines) → Clock In.",
+      [LABELS.COUNTER_STOCK_DIVIDENDS]: "Half of the Certificate Counter $2 fee → StockBooster.",
+      [LABELS.LOCKER_STOCK_DIVIDENDS]:
+        "90% of locker protocol fees → SafetyDepositClockIn broker claim rounds / StockBooster ETH flush.",
+      [LABELS.SWAP_DESK_FEES]:
+        "Relay swap-desk 1% app fee forwarded to StockBooster as a Clock In bonus top-up.",
+    },
   },
 };
 

--- a/fees/stonkbrokers/index.ts
+++ b/fees/stonkbrokers/index.ts
@@ -1,7 +1,7 @@
 import { Dependencies, FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 import ADDRESSES from "../../helpers/coreAssets.json";
-import { addTokensReceived, getEVMTokenTransfers } from "../../helpers/token";
+import { getEVMTokenTransfers } from "../../helpers/token";
 
 /**
  * StonkBrokers — Anvil NFTFi + Broker Box + Safety Deposit Box on Robinhood,
@@ -40,7 +40,8 @@ const CERTIFICATE_COUNTER = "0x2599882AaF5C14834562eE59ca7a3D1FFCC229D7";
 // Safety Deposit Box lockers → fee router (live 2026-07-25).
 const LOCKER_V3 = "0xFc96CF67eCC55bE4AdABc3AecBe6Ad6349f11223";
 const LOCKER_V4 = "0x5a28ce098750f73bc9eC142D4bCE464E1A0BBdA6";
-const SAFETY_DEPOSIT_CLOCK_IN = "0x55642A3F10F1Af5145D3d59021B1D6b03BB8692c";
+// Fee sink (not read on-chain here): SafetyDepositClockInV3
+// 0x55642A3F10F1Af5145D3d59021B1D6b03BB8692c — splits locker cuts 90/10.
 
 // Relay swap-desk 1% app fee accrues off-chain, is claimed as Base USDC to the
 // treasury fee wallet, then forwarded via Relay to StockBooster as ETH.
@@ -170,6 +171,8 @@ const fetchRobinhood = async (options: FetchOptions) => {
     upgradedLogs,
     edgeLogs,
     counterLogs,
+    v3CollectLogs,
+    v3DecreaseLogs,
     v4CollectLogs,
     v4DecreaseLogs,
   ] = await Promise.all([
@@ -180,9 +183,10 @@ const fetchRobinhood = async (options: FetchOptions) => {
     options.getLogs({ target: ACTIVATION_MANAGER, eventAbi: ACTIVATION_UPGRADED }),
     options.getLogs({ targets: GACHA_MACHINES, eventAbi: EDGE_SKIMMED }),
     options.getLogs({ target: CERTIFICATE_COUNTER, eventAbi: CERTIFICATE_BOUGHT }),
-    // V3 locker cuts are always ERC20 (WETH/token) and are covered by
-    // addTokensReceived below. V4 native-ETH sides need the collect/decrease
-    // events because they do not emit ERC20 Transfers.
+    // Robinhood is not in addTokensReceived's log-fallback chain map, so
+    // locker cuts are read from the fee events + a lockPositions lookup.
+    options.getLogs({ target: LOCKER_V3, eventAbi: LOCK_FEES_COLLECTED }),
+    options.getLogs({ target: LOCKER_V3, eventAbi: LOCK_LIQUIDITY_DECREASED }),
     options.getLogs({ target: LOCKER_V4, eventAbi: LOCK_FEES_COLLECTED }),
     options.getLogs({ target: LOCKER_V4, eventAbi: LOCK_LIQUIDITY_DECREASED }),
   ]);
@@ -249,86 +253,38 @@ const fetchRobinhood = async (options: FetchOptions) => {
   }
 
   // ── Liquidity locker protocol cuts ───────────────────────────────────────
-  // ERC20 cuts (V3 always; V4 when the side is an ERC20) land as Transfer
-  // events locker → SafetyDepositClockIn. Attribute 90/10 to match the
-  // clock-in's hardwired split.
-  const lockerErc20 = await addTokensReceived({
-    options,
-    fromAdddesses: [LOCKER_V3, LOCKER_V4],
-    target: SAFETY_DEPOSIT_CLOCK_IN,
-    fetchTokenList: true,
-  });
-  if (lockerErc20) {
-    dailyFees.addBalances(lockerErc20, LABELS.LOCKER_FEES);
-    dailySupplySideRevenue.addBalances(
-      lockerErc20.clone(Number(LOCKER_BROKER_BPS) / 10_000, LABELS.LOCKER_STOCK_DIVIDENDS),
-    );
-    const protocolShare = lockerErc20.clone(
-      Number(LOCKER_PROTOCOL_BPS) / 10_000,
-      LABELS.LOCKER_PROTOCOL,
-    );
-    dailyProtocolRevenue.addBalances(protocolShare);
-    dailyRevenue.addBalances(protocolShare);
-  }
-
-  // Native-ETH protocol cuts on V4 (currency0 = address(0)) do not emit ERC20
-  // Transfers — pull them from LockFeesCollected / LockLiquidityDecreased.
-  // V3 is always ERC20 (WETH), so it is fully covered by addTokensReceived
-  // above; we still resolve V3 tokens only if we need them for native (we don't).
+  // Attribute 90/10 to match SafetyDepositClockInV3's hardwired split.
+  // Upfront-mode cuts that never emit LockFeesCollected are not visible here
+  // (Robinhood has no Transfer-log fallback in addTokensReceived); collect /
+  // withdraw cuts dominate live volume and are fully covered.
   const lockCache = new Map<string, [string, string]>();
-  const v4Logs = [...v4CollectLogs, ...v4DecreaseLogs];
-  if (v4Logs.length > 0) {
-    const ids = [...new Set(v4Logs.map((l: any) => String(l.lockTokenId)))];
-    await resolveLockTokens(options, LOCKER_V4, ids, true, lockCache);
-    for (const log of v4Logs) {
-      const pair = lockCache.get(`${LOCKER_V4}:${String(log.lockTokenId)}`);
+  const lockerBatches: { locker: string; isV4: boolean; logs: any[] }[] = [
+    { locker: LOCKER_V3, isV4: false, logs: [...v3CollectLogs, ...v3DecreaseLogs] },
+    { locker: LOCKER_V4, isV4: true, logs: [...v4CollectLogs, ...v4DecreaseLogs] },
+  ];
+  for (const batch of lockerBatches) {
+    if (batch.logs.length === 0) continue;
+    const ids = [...new Set(batch.logs.map((l) => String(l.lockTokenId)))];
+    await resolveLockTokens(options, batch.locker, ids, batch.isV4, lockCache);
+    for (const log of batch.logs) {
+      const pair = lockCache.get(`${batch.locker}:${String(log.lockTokenId)}`);
       if (!pair) continue;
-      const [c0, c1] = pair;
-      // Only count native sides here — ERC20 sides already counted via Transfer.
-      if (c0 === ZERO) {
-        addProtocolCut(dailyFees, ZERO, BigInt(log.protocolAmount0), LABELS.LOCKER_FEES);
-        addProtocolCut(
-          dailySupplySideRevenue,
-          ZERO,
-          (BigInt(log.protocolAmount0) * LOCKER_BROKER_BPS) / 10_000n,
-          LABELS.LOCKER_STOCK_DIVIDENDS,
-        );
-        addProtocolCut(
-          dailyProtocolRevenue,
-          ZERO,
-          (BigInt(log.protocolAmount0) * LOCKER_PROTOCOL_BPS) / 10_000n,
-          LABELS.LOCKER_PROTOCOL,
-        );
-        addProtocolCut(
-          dailyRevenue,
-          ZERO,
-          (BigInt(log.protocolAmount0) * LOCKER_PROTOCOL_BPS) / 10_000n,
-          LABELS.LOCKER_PROTOCOL,
-        );
-      }
-      if (c1 === ZERO) {
-        addProtocolCut(dailyFees, ZERO, BigInt(log.protocolAmount1), LABELS.LOCKER_FEES);
-        addProtocolCut(
-          dailySupplySideRevenue,
-          ZERO,
-          (BigInt(log.protocolAmount1) * LOCKER_BROKER_BPS) / 10_000n,
-          LABELS.LOCKER_STOCK_DIVIDENDS,
-        );
-        addProtocolCut(
-          dailyProtocolRevenue,
-          ZERO,
-          (BigInt(log.protocolAmount1) * LOCKER_PROTOCOL_BPS) / 10_000n,
-          LABELS.LOCKER_PROTOCOL,
-        );
-        addProtocolCut(
-          dailyRevenue,
-          ZERO,
-          (BigInt(log.protocolAmount1) * LOCKER_PROTOCOL_BPS) / 10_000n,
-          LABELS.LOCKER_PROTOCOL,
-        );
+      const amounts: [string, bigint][] = [
+        [pair[0], BigInt(log.protocolAmount0)],
+        [pair[1], BigInt(log.protocolAmount1)],
+      ];
+      for (const [token, amount] of amounts) {
+        if (amount <= 0n) continue;
+        const brokerAmt = (amount * LOCKER_BROKER_BPS) / 10_000n;
+        const protocolAmt = (amount * LOCKER_PROTOCOL_BPS) / 10_000n;
+        addProtocolCut(dailyFees, token, amount, LABELS.LOCKER_FEES);
+        addProtocolCut(dailySupplySideRevenue, token, brokerAmt, LABELS.LOCKER_STOCK_DIVIDENDS);
+        addProtocolCut(dailyProtocolRevenue, token, protocolAmt, LABELS.LOCKER_PROTOCOL);
+        addProtocolCut(dailyRevenue, token, protocolAmt, LABELS.LOCKER_PROTOCOL);
       }
     }
   }
+
   return {
     dailyVolume,
     dailyFees,
@@ -397,7 +353,7 @@ const adapter: SimpleAdapter = {
       [LABELS.GACHA_FEES]: "10% house edge skimmed from every settled Broker Box ticket.",
       [LABELS.COUNTER_FEES]: "Flat $2 Certificate Counter fee per OTC deed mint.",
       [LABELS.LOCKER_FEES]:
-        "Protocol cut on Safety Deposit Box locks (0.5% upfront / 20% of LP fee collects / 1% withdraw).",
+        "Protocol cut on Safety Deposit Box locks from LockFeesCollected / LockLiquidityDecreased (20% of LP fee collects / 1% withdraw; upfront 0.5% not evented).",
       [LABELS.SWAP_DESK_FEES]:
         "1% Relay app fee on the crypto swap desk, measured as Base USDC forwarded from the fee wallet toward StockBooster.",
     },

--- a/fees/stonkbrokers/index.ts
+++ b/fees/stonkbrokers/index.ts
@@ -15,6 +15,12 @@ import ADDRESSES from "../../helpers/coreAssets.json";
  *     SafetyDepositClockInV3 (90% brokers / 10% protocol wallet)
  *  5. Swap-desk 1% Relay app fee: Base USDC forwarded from the fee wallet
  *     (claimed from Relay, then bridged to StockBooster as ETH)
+ *
+ * Volume (protocol volume chart):
+ *  - NFT AMM notional (ethFeePaid ÷ fee bps)
+ *  - Broker Box ticket notional (PullOpened.ticketWei)
+ *  - Certificate Counter stock purchase (CertificateBought.spendWei)
+ *  - Broker Box sell-backs (SoldBack ethOut + SoldBackUsdg usdgOut)
  */
 
 const AMM_VAULT = "0xE302733accF4800146E55fC45B46b4E4fFC032D2";
@@ -59,6 +65,12 @@ const ACTIVATION_UPGRADED =
   "event ActivationUpgraded(uint256 indexed tokenId, address indexed owner, uint8 fromTier, uint8 toTier, uint256 feePaid)";
 const EDGE_SKIMMED =
   "event EdgeSkimmed(uint256 indexed roundId, uint256 creatorWei, uint256 boosterWei, uint256 protocolWei)";
+const PULL_OPENED =
+  "event PullOpened(uint256 indexed roundId, address indexed player, uint8 tier, bool wantCertificate, uint256 ticketWei, uint256 requestId, uint256 stockReserved)";
+const SOLD_BACK =
+  "event SoldBack(address indexed seller, uint256 stockAmount, uint256 ethOut)";
+const SOLD_BACK_USDG =
+  "event SoldBackUsdg(address indexed seller, uint256 stockAmount, uint256 usdgOut)";
 const CERTIFICATE_BOUGHT =
   "event CertificateBought(uint256 indexed tokenId, address indexed buyer, address indexed recipient, address stockToken, uint256 stockAmount, uint256 spendWei, uint256 feeWei, address wallet)";
 const LOCK_FEES_COLLECTED =
@@ -66,6 +78,9 @@ const LOCK_FEES_COLLECTED =
 // liquidity is uint128 on-chain — wrong width → wrong topic0 and silent misses.
 const LOCK_LIQUIDITY_DECREASED =
   "event LockLiquidityDecreased(uint256 indexed lockTokenId, uint128 liquidity, uint256 userAmount0, uint256 userAmount1, uint256 protocolAmount0, uint256 protocolAmount1)";
+
+/** USDG on Robinhood Chain — sell-back rail payout token. */
+const ROBINHOOD_USDG = "0x5fc5360d0400a0fd4f2af552add042d716f1d168";
 
 const LABELS = {
   AMM_FEES: "NFT AMM trade fees",
@@ -80,6 +95,7 @@ const LABELS = {
   GACHA_FEES: "Broker Box gachapon edge (10% of ticket)",
   GACHA_STOCK_DIVIDENDS: "Broker Box edge → StockBooster / creator",
   GACHA_PROTOCOL: "Broker Box edge → protocol accrual",
+  GACHA_SELLBACK: "Broker Box 5% sell-back spread (retained in bankroll)",
   COUNTER_FEES: "Certificate Counter flat $2 fee",
   COUNTER_STOCK_DIVIDENDS: "Certificate Counter fee → StockBooster",
   COUNTER_PROTOCOL: "Certificate Counter fee → treasury",
@@ -195,18 +211,43 @@ const fetchRobinhood = async (options: FetchOptions) => {
     }),
   ]);
 
-  // One chain-wide EdgeSkimmed scan, then keep only production machines.
-  const edgeLogs = (
-    await options.getLogs({
+  // Chain-wide Broker Box scans, then keep only production machines (1 RPC
+  // each instead of 9× per event — Robinhood public RPC rate-limits hard).
+  const [edgeRaw, pullRaw, soldBackRaw, soldBackUsdgRaw] = await Promise.all([
+    options.getLogs({
       noTarget: true,
       eventAbi: EDGE_SKIMMED,
       entireLog: true,
       parseLog: true,
       ...logOpts,
-    })
-  )
-    .filter((log: any) => MACHINE_SET.has(String(log.address).toLowerCase()))
-    .map((log: any) => log.args);
+    }),
+    options.getLogs({
+      noTarget: true,
+      eventAbi: PULL_OPENED,
+      entireLog: true,
+      parseLog: true,
+      ...logOpts,
+    }),
+    options.getLogs({
+      noTarget: true,
+      eventAbi: SOLD_BACK,
+      entireLog: true,
+      parseLog: true,
+      ...logOpts,
+    }),
+    options.getLogs({
+      noTarget: true,
+      eventAbi: SOLD_BACK_USDG,
+      entireLog: true,
+      parseLog: true,
+      ...logOpts,
+    }),
+  ]);
+  const onMachine = (log: any) => MACHINE_SET.has(String(log.address).toLowerCase());
+  const edgeLogs = edgeRaw.filter(onMachine).map((log: any) => log.args);
+  const pullLogs = pullRaw.filter(onMachine).map((log: any) => log.args);
+  const soldBackLogs = soldBackRaw.filter(onMachine).map((log: any) => log.args);
+  const soldBackUsdgLogs = soldBackUsdgRaw.filter(onMachine).map((log: any) => log.args);
 
   // Robinhood is not in addTokensReceived's log-fallback chain map, so locker
   // cuts are read from the fee events + a lockPositions lookup.
@@ -262,9 +303,41 @@ const fetchRobinhood = async (options: FetchOptions) => {
     dailyRevenue.addToken(STONKBROKER, fee, LABELS.ACTIVATION_FEES);
   }
 
-  // ── Broker Box gachapon ──────────────────────────────────────────────────
+  // ── Broker Box gachapon volume + fees ────────────────────────────────────
+  // Volume: ticket notional at open + sell-back payouts + counter stock buys.
+  // Fees: EdgeSkimmed (10% of settled ticket) + Certificate Counter $2 fee.
   // Official machines set creator = StockBooster, so creatorWei + boosterWei
   // both fund Clock In stock drops. protocolWei accrues for the treasury.
+  for (const log of pullLogs) {
+    const ticket = BigInt(log.ticketWei);
+    if (ticket > 0n) dailyVolume.addGasToken(ticket);
+  }
+  // Sell-back pays 95% of the mark; the 5% spread stays in the machine bankroll
+  // (reclaimable by treasury on official machines). Implied from payout: spread =
+  // ethOut × 5/95. No separate fee event exists on-chain.
+  for (const log of soldBackLogs) {
+    const ethOut = BigInt(log.ethOut);
+    if (ethOut <= 0n) continue;
+    dailyVolume.addGasToken(ethOut);
+    const spread = (ethOut * 5n) / 95n;
+    if (spread > 0n) {
+      dailyFees.addGasToken(spread, LABELS.GACHA_SELLBACK);
+      dailyProtocolRevenue.addGasToken(spread, LABELS.GACHA_SELLBACK);
+      dailyRevenue.addGasToken(spread, LABELS.GACHA_SELLBACK);
+    }
+  }
+  for (const log of soldBackUsdgLogs) {
+    const usdgOut = BigInt(log.usdgOut);
+    if (usdgOut <= 0n) continue;
+    dailyVolume.addToken(ROBINHOOD_USDG, usdgOut);
+    const spread = (usdgOut * 5n) / 95n;
+    if (spread > 0n) {
+      dailyFees.addToken(ROBINHOOD_USDG, spread, LABELS.GACHA_SELLBACK);
+      dailyProtocolRevenue.addToken(ROBINHOOD_USDG, spread, LABELS.GACHA_SELLBACK);
+      dailyRevenue.addToken(ROBINHOOD_USDG, spread, LABELS.GACHA_SELLBACK);
+    }
+  }
+
   for (const log of edgeLogs) {
     const creator = BigInt(log.creatorWei);
     const booster = BigInt(log.boosterWei);
@@ -278,7 +351,9 @@ const fetchRobinhood = async (options: FetchOptions) => {
   }
 
   for (const log of counterLogs) {
+    const spend = BigInt(log.spendWei);
     const fee = BigInt(log.feeWei);
+    if (spend > 0n) dailyVolume.addGasToken(spend);
     if (fee <= 0n) continue;
     const half = fee / 2n;
     const rest = fee - half; // remainder to treasury on odd wei
@@ -389,17 +464,17 @@ const adapter: SimpleAdapter = {
   },
   methodology: {
     Volume:
-      "ETH notional of StonkBrokers NFT AMM fills, derived from ethFeePaid and vault fee bps (10% random / 15% snipe).",
+      "ETH notional of StonkBrokers NFT AMM fills (ethFeePaid ÷ fee bps) + Broker Box ticket notional (PullOpened.ticketWei) + Certificate Counter stock purchases (spendWei) + Broker Box sell-backs (SoldBack ethOut + SoldBackUsdg usdgOut).",
     Fees:
-      "ETH fees on NFT AMM trades + NFT-backed loans; $STONKBROKER broker activation/upgrade fees; Broker Box gachapon 10% edge + Certificate Counter $2 fee; Safety Deposit Box liquidity-locker protocol cuts; and the Relay swap-desk 1% app fee (Base USDC forwarded to StockBooster).",
+      "ETH fees on NFT AMM trades + NFT-backed loans; $STONKBROKER broker activation/upgrade fees; Broker Box gachapon 10% edge + 5% sell-back spread + Certificate Counter $2 fee; Safety Deposit Box liquidity-locker protocol cuts; and the Relay swap-desk 1% app fee (Base USDC forwarded to StockBooster).",
     Revenue:
-      "Protocol-retained share: 30% of NFTFi ETH fees, protocol share of activation fees, Broker Box protocol accrual + counter treasury half, and 10% of locker fees.",
+      "Protocol-retained share: 30% of NFTFi ETH fees, protocol share of activation fees, Broker Box protocol accrual (5% of ticket) + sell-back spread + counter treasury half, and 10% of locker fees.",
     ProtocolRevenue:
-      "30% of NFTFi ETH fees → ProtocolFeeSink; protocol share of $STONKBROKER activation fees; Broker Box protocol accrual + counter treasury half; 10% of locker fees → protocol wallet.",
+      "30% of NFTFi ETH fees → ProtocolFeeSink; protocol share of $STONKBROKER activation fees; Broker Box protocol accrual + sell-back bankroll spread + counter treasury half; 10% of locker fees → protocol wallet.",
     HoldersRevenue:
       "Half of the $STONKBROKER activation/upgrade fees burned.",
     SupplySideRevenue:
-      "70% of NFTFi ETH fees → StockBooster stock dividends; Broker Box creator+booster edge + counter StockBooster half; 90% of locker fees → SafetyDepositClockIn broker claims; Relay swap-desk 1% app fees forwarded to StockBooster.",
+      "70% of NFTFi ETH fees → StockBooster stock dividends; Broker Box creator+booster edge (5% of ticket on official machines) + counter StockBooster half; 90% of locker fees → SafetyDepositClockIn broker claims; Relay swap-desk 1% app fees forwarded to StockBooster.",
   },
   breakdownMethodology: {
     Fees: {
@@ -407,6 +482,8 @@ const adapter: SimpleAdapter = {
       [LABELS.LOAN_FEES]: "Upfront ETH borrow fees on NFT-backed loans.",
       [LABELS.ACTIVATION_FEES]: "One-time / upgrade $STONKBROKER activation fees.",
       [LABELS.GACHA_FEES]: "10% house edge skimmed from every settled Broker Box ticket.",
+      [LABELS.GACHA_SELLBACK]:
+        "5% sell-back spread retained in the machine bankroll (implied from SoldBack / SoldBackUsdg payouts at 95% of mark).",
       [LABELS.COUNTER_FEES]: "Flat $2 Certificate Counter fee per OTC deed mint.",
       [LABELS.LOCKER_FEES]:
         "Protocol cut on Safety Deposit Box locks from LockFeesCollected / LockLiquidityDecreased (20% of LP fee collects / 1% withdraw; upfront 0.5% not evented).",
@@ -418,6 +495,8 @@ const adapter: SimpleAdapter = {
       [LABELS.LOAN_PROTOCOL_TREASURY]: "30% of ETH loan fees retained by ProtocolFeeSink.",
       [LABELS.ACTIVATION_FEES]: "Full $STONKBROKER activation fee (burn + protocol).",
       [LABELS.GACHA_PROTOCOL]: "5% of Broker Box ticket accruing as protocol revenue.",
+      [LABELS.GACHA_SELLBACK]:
+        "5% sell-back spread retained in machine bankroll (treasury-reclaimable on official machines).",
       [LABELS.COUNTER_PROTOCOL]: "Half of the Certificate Counter $2 fee → treasury.",
       [LABELS.LOCKER_PROTOCOL]: "10% of locker protocol fees → protocol wallet.",
     },
@@ -426,6 +505,8 @@ const adapter: SimpleAdapter = {
       [LABELS.LOAN_PROTOCOL_TREASURY]: "30% of ETH loan fees retained by ProtocolFeeSink.",
       [LABELS.ACTIVATION_PROTOCOL]: "Protocol share of $STONKBROKER activation fees.",
       [LABELS.GACHA_PROTOCOL]: "5% of Broker Box ticket accruing as protocol revenue.",
+      [LABELS.GACHA_SELLBACK]:
+        "5% sell-back spread retained in machine bankroll (treasury-reclaimable on official machines).",
       [LABELS.COUNTER_PROTOCOL]: "Half of the Certificate Counter $2 fee → treasury.",
       [LABELS.LOCKER_PROTOCOL]: "10% of locker protocol fees → protocol wallet.",
     },


### PR DESCRIPTION
## Summary
Extends the live `fees/stonkbrokers` adapter so Broker Box, Safety Deposit Box lockers, and the Base swap-desk feed DefiLlama **fees / revenue / protocol volume**.

### Broker Box (production floor, 2026-07-31)
**Volume** (`dailyVolume`):
- `PullOpened.ticketWei` — ticket notional across the 9 machines
- `CertificateBought.spendWei` — OTC counter stock purchases
- `SoldBack.ethOut` + `SoldBackUsdg.usdgOut` — sell-back payouts

**Fees / revenue**:
- `EdgeSkimmed` — 10% house edge (5% StockBooster+creator → supply-side, 5% protocol accrual → protocol revenue)
- Certificate Counter flat $2 (`feeWei`) — 50/50 StockBooster / treasury
- 5% sell-back spread implied from 95% payouts (`ethOut × 5/95`) → fees + protocol revenue (bankroll / treasury-reclaimable on official machines)

### Also included
- Safety Deposit Box V3/V4 locker protocol cuts (90/10 brokers / protocol)
- Base Relay swap-desk 1% app fee (USDC outflows from fee wallet)

### Machines
GME / AAPL / AMZN / NVDA / GOOGL / MSFT / SLV / SPCX / USO (hardcoded production addresses).

Companion TVL PR: https://github.com/DefiLlama/DefiLlama-Adapters/pull/20327 (machine ETH + stock inventory).

## Test plan
- [ ] Adapter CI green on this PR
- [ ] Spot-check a recent day: volume ≈ ticket opens + counter spends + sell-backs
- [ ] Fees include EdgeSkimmed + counter + sell-back spread