### PR TITLE
kalshi: throw when the dune report rows arent there instead of writing zero

### DIFF
--- a/dexs/kalshi.ts
+++ b/dexs/kalshi.ts
@@ -27,13 +27,17 @@ async function fetch(options: FetchOptions) {
   FROM trade_report_agg tr
   CROSS JOIN market_report_agg mr
   `
-  const data: { 
+  const data: {
     cash_volume: string,
     open_interest: string,
     notional_volume: string,
   }[] = await queryDuneSql(options, query)
-  
-  const dailyVolume = Number(data[0]?.cash_volume) || 0
+
+  if (!data?.length || data[0].cash_volume == null) {
+    throw new Error(`no rows in kalshi.trade_report on dune for ${dateString} yet`)
+  }
+
+  const dailyVolume = Number(data[0].cash_volume)
   const openInterestAtEnd = Number(data[0]?.open_interest) || 0
   const dailyNotionalVolume = Number(data[0]?.notional_volume) || 0
 

--- a/dexs/kalshi.ts
+++ b/dexs/kalshi.ts
@@ -28,9 +28,9 @@ async function fetch(options: FetchOptions) {
   CROSS JOIN market_report_agg mr
   `
   const data: {
-    cash_volume: string,
-    open_interest: string,
-    notional_volume: string,
+    cash_volume: string | null,
+    open_interest: string | null,
+    notional_volume: string | null,
   }[] = await queryDuneSql(options, query)
 
   if (!data?.length || data[0].cash_volume == null) {


### PR DESCRIPTION
same bug class as #8525; kalshi went $402m on 07-30 to a hard $0 on 07-31 with no taper:

```
07-29  381,504,308
07-30  402,083,584
07-31  0
```

the adapter sums `kalshi.trade_report` for the day on dune and defaults to 0 when the row isn't there (`Number(data[0]?.cash_volume) || 0`). the query already looks one day back because the table publishes late, but when the lag stretches past that the runner stores a permanent $0 for a $400m/day protocol instead of retrying.

fix: throw when the result has no rows or a null cash_volume, so the runner retries once dune catches up. open interest and notional keep their defaults since market_report publishes separately and cash volume is the metric that matters.

no local harness (needs a dune key), typecheck only, same situation as #8525. the stored 07-31 zero needs a refill once the row lands.