### PR TITLE
insightx: throw when the api returns no volume instead of writing zero

### DIFF
--- a/dexs/insightx/index.ts
+++ b/dexs/insightx/index.ts
@@ -28,10 +28,14 @@ const fetch = async (options: FetchOptions) => {
 
   const data: InsightXDailyStats = response;
 
+  if (!data || !data.volume) {
+    throw new Error(`insightx api returned no volume for ${options.dateString}`);
+  }
+
   const dailyVolume = options.createBalances();
   const dailyFees = options.createBalances();
 
-  dailyVolume.addUSDValue(data.volume || 0);
+  dailyVolume.addUSDValue(data.volume);
   dailyFees.addUSDValue(data.fees || 0);
 
   return {


### PR DESCRIPTION
same silent-zero class as #8525/#8526; insightx went $14.9m on 07-30 to a hard $0 on 07-31:

```
07-29  15,105,682
07-30  14,897,584
07-31  0
```

their stats api has a one-day hole: `?date=2026-07-30` returns volume 14897584, `?date=2026-07-31` returns volume 0, and `?date=2026-08-01` is already back at $9.7m. the adapter does `data.volume || 0` so the hole got stored as a real zero-volume day for a $15m/day platform.

fix: throw when the api returns no volume so the runner retries instead of booking the hole. a genuine zero-volume day on a platform this size would be its own incident worth investigating, so failing loud is the right default either way.

harness: 07-30 returns $14.90m / $37.24k fees matching production to the dollar, 07-31 now throws instead of storing $0. the stored 07-31 zero needs a refill if their api ever backfills the day.