### PR TITLE
sushi-launchpad: price the quote leg with the pool's real quote token

### DIFF
--- a/fees/sushi-launchpad/index.ts
+++ b/fees/sushi-launchpad/index.ts
@@ -1,4 +1,3 @@
-import * as sdk from "@defillama/sdk";
 import { Adapter, FetchOptions } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 import { METRIC } from "../../helpers/metrics";
@@ -33,10 +32,9 @@ async function fetch(options: FetchOptions) {
   if (pools.length) {
     // token0/token1 are immutable, so read them at the latest block - the
     // window's block is historical and the public RPC is not archival.
-    const api = new sdk.ChainApi({ chain: options.chain });
     const [token0s, token1s] = await Promise.all([
-      api.multiCall({ abi: "address:token0", calls: pools }),
-      api.multiCall({ abi: "address:token1", calls: pools }),
+      options.api.multiCall({ abi: "address:token0", calls: pools }),
+      options.api.multiCall({ abi: "address:token1", calls: pools }),
     ]);
     pools.forEach((pool, i) => {
       pairs[pool.toLowerCase()] = [token0s[i], token1s[i]];
@@ -112,6 +110,7 @@ const adapter: Adapter = {
   start: "2026-07-28",
   methodology,
   breakdownMethodology,
+  doublecounted: true, // sushiswap
 };
 
 export default adapter;

--- a/fees/sushi-launchpad/index.ts
+++ b/fees/sushi-launchpad/index.ts
@@ -1,3 +1,4 @@
+import * as sdk from "@defillama/sdk";
 import { Adapter, FetchOptions } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 import { METRIC } from "../../helpers/metrics";
@@ -23,14 +24,45 @@ async function fetch(options: FetchOptions) {
     options.getLogs({ target: LAUNCHPAD, eventAbi: LAUNCH_FEES_WITHDRAWN }),
   ]);
 
+  // FeesDistributed carries no quote-token address, and launches are not all
+  // quoted in the gas token - on Robinhood Chain most pools pair the launch
+  // token against a tokenised stock (GME, AAPL, NVDA, ...) or USDG. Read the
+  // pool's pair and take whichever side is not the launch token.
+  const pools = [...new Set<string>(feeLogs.map((log: any) => log.pool))];
+  const pairs: Record<string, [string, string]> = {};
+  if (pools.length) {
+    // token0/token1 are immutable, so read them at the latest block - the
+    // window's block is historical and the public RPC is not archival.
+    const api = new sdk.ChainApi({ chain: options.chain });
+    const [token0s, token1s] = await Promise.all([
+      api.multiCall({ abi: "address:token0", calls: pools }),
+      api.multiCall({ abi: "address:token1", calls: pools }),
+    ]);
+    pools.forEach((pool, i) => {
+      pairs[pool.toLowerCase()] = [token0s[i], token1s[i]];
+    });
+  }
+
+  const quoteToken = (log: any) => {
+    const [token0, token1] = pairs[log.pool.toLowerCase()];
+    const launch = log.token.toLowerCase();
+    if (token0.toLowerCase() === launch) return token1;
+    if (token1.toLowerCase() === launch) return token0;
+    throw new Error(
+      `launch token ${log.token} is not in pool ${log.pool} (${token0}/${token1})`
+    );
+  };
+
   for (const log of feeLogs) {
-    dailyFees.addGasToken(log.quoteCollected, METRIC.TRADING_FEES);
+    const quote = quoteToken(log);
+
+    dailyFees.add(quote, log.quoteCollected, METRIC.TRADING_FEES);
     dailyFees.add(log.token, log.tokenCollected, METRIC.TRADING_FEES);
 
-    dailyRevenue.addGasToken(log.quoteToSushi, METRIC.TRADING_FEES);
+    dailyRevenue.add(quote, log.quoteToSushi, METRIC.TRADING_FEES);
     dailyRevenue.add(log.token, log.tokenToSushi, METRIC.TRADING_FEES);
 
-    dailySupplySideRevenue.addGasToken(log.quoteToCreator, "Creator Fees");
+    dailySupplySideRevenue.add(quote, log.quoteToCreator, "Creator Fees");
     dailySupplySideRevenue.add(log.token, log.tokenToCreator, "Creator Fees");
   }
 


### PR DESCRIPTION
`FeesDistributed` does not carry a quote-token address, so #8506 booked all three quote legs with `addGasToken`:

```ts
dailyFees.addGasToken(log.quoteCollected, METRIC.TRADING_FEES);
dailyRevenue.addGasToken(log.quoteToSushi, METRIC.TRADING_FEES);
dailySupplySideRevenue.addGasToken(log.quoteToCreator, "Creator Fees");
```

`addGasToken` books under the null address, which on Robinhood Chain prices as ETH at 18 decimals. But launches here are mostly not quoted in ETH. They pair against a tokenised stock, or USDG.

## What is on chain

24h window ending at block 25,259,960 (block time measured at 0.1002s, so 862,017 blocks). 200 `FeesDistributed` events across 82 distinct pools. Reading `token0()`/`token1()` on each pool gives 7 distinct quote tokens:

| quote | events | decimals | raw quoteCollected | valued as ETH | correct | price |
|---|---:|---:|---:|---:|---:|---:|
| GME | 6 | 18 | 97465753888876473285 | $179,271 | $2,093 | $21.48 |
| AAPL | 91 | 18 | 9342109369580711440 | $17,183 | $2,876 | $307.83 |
| WETH | 87 | 18 | 6153719412119935408 | $11,319 | $11,430 | $1,857.38 |
| NVDA | 7 | 18 | 1863968049864753532 | $3,428 | $370 | $198.26 |
| SPCX | 5 | 18 | 739707096378309945 | $1,361 | $80 | $108.75 |
| COIN | 3 | 18 | 121908704692626736 | $224 | $18 | $144.84 |
| USDG | 1 | 6 | 7856721 | $0 | $8 | $0.99 |

Only 87 of 200 events are actually WETH quoted. Totals: **$212,786 valued as ETH against $16,874 priced with the real quote token.** GME alone is $179k of the $196k gap, 97.47 units valued at $1,839 instead of $21.48.

Note USDG is 6 decimals, so this was not only a price error. A 6-decimal quote token was being read as 18-decimal and rounded to zero, the opposite direction. Reading the real token fixes both.

The launch-token leg (`dailyFees.add(log.token, log.tokenCollected)`) contributes nothing today. I checked 10 of the 82 launch tokens against coins.llama.fi and none of them are priced, so the quote leg is the entire reported figure.

## Sanity check against SushiSwap V3 itself

These 82 pools are all 1% SushiSwap V3 pools, so the launchpad's fees are a subset of the swap fees `sushiswap-v3` books for Robinhood Chain. Published daily fees for that adapter:

```
2026-07-28       492
2026-07-29    31,136
2026-07-30    16,835
2026-07-31    17,645
2026-08-01    28,496
```

Before this change the launchpad reported $209,411, which is 7.4x the whole chain's SushiSwap V3 fees. A subset cannot exceed its superset. After the change it reports $16,167, which sits inside that band.

## The change

Reads `token0`/`token1` for the day's pools and takes whichever side is not `log.token`. Throws if the launch token is not in the pair, since any value booked in that case would be wrong. Guarded on an empty log set so the multiCall is not called with no targets. The reads use a latest-block `ChainApi` because `token0`/`token1` are immutable and the public Robinhood RPC is not archival (`metadata is not found` at the window block).

`LaunchFeesWithdrawn` is deliberately left on `addGasToken`. That one really is a fixed ETH fee per launch.

## Test

```
$ DISABLE_PULL_HOURLY=true npm run test fees sushi-launchpad

ROBINHOOD
Daily fees: 16.17 k
Daily revenue: 4.91 k
Daily protocol revenue: 4.91 k
Daily supply side revenue: 11.26 k

label        | Daily fees | Daily revenue | Daily supply side revenue
Trading Fees | 16167      | 4910          |
Creator Fees |            |               | 11258
```

Was 209.41k / 62.88k / 146.53k. Identity holds, 4,910 + 11,258 = 16,168. The hourly path runs all 24 slots and aggregates to 16.13k, within 0.2% of the single-window run.

## Open question for a maintainer, not addressed here

Separately from the pricing, I think these fees are also double counted, and I did not want to decide the fix unilaterally.

All 82 pools return `factory()` = `0xe51960f1b45f1c9fb6d166e6a884f866fc70433b`, which is the `CHAIN.ROBINHOOD` factory in `dexs/sushiswap-v3.ts:27` (start `2026-07-10`, before this adapter's `2026-07-28`). `sushiswap-v3` sources its pool list from `tvl-adapter-cache/cache/logs/robinhood/<factory>.json` via `getUniV3LogAdapter`, and reading that cache directly, all **82 of 82** launchpad pools are in it. So `sushiswap-v3` already books the swap fees these pools generate, and the launchpad's `quoteCollected` is the launchpad's own LP share of those same fees.

Precedent on this chain is to flag it. `fees/arrowpad-fun.ts:93` is the closest match:

```ts
doublecounted: true, // pools are plain Uniswap V3, also counted by the uniswap adapter
```

with the same in `quiver.ts:179`, `tirelire.ts:106`, `aarotrade.ts:67`, `ravenhood.ts:82`, `aeon.ts:101`, `miroshark.ts:101`.

The complication is that `doublecounted` is adapter-wide, and this adapter has a second leg the precedent cases do not: the fixed ETH launch fee from `LaunchFeesWithdrawn`, which is genuinely not a pool swap fee and not counted anywhere else. Setting the flag would suppress that leg along with the pool fees. It reports $0 right now (no `LaunchFeesWithdrawn` events in the window I scanned, so I also could not confirm those fees are actually denominated in native ETH), so nothing is lost today, but it would be wrong if launches pick up.

Happy to send the flag as a follow-up either way, I just did not want to pick between "flag it and lose the launch-fee leg" and "leave it double counted" without a maintainer weighing in.

cc @uwezukwechibuzor as the author of #8506.
