### PR TITLE
aerodrome: dynamic wash filter, the fake-ticker factory moved from uniswap

### DIFF
--- a/dexs/aerodrome-slipstream/index.ts
+++ b/dexs/aerodrome-slipstream/index.ts
@@ -3,6 +3,7 @@ import { FetchOptions, FetchResult, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 import { getDefaultDexTokensBlacklisted } from '../../helpers/lists';
 import { addOneToken } from '../../helpers/prices';
+import { getEstablishedTokens, getWashPools } from '../../helpers/uniswap';
 import { formatAddress } from '../../utils/utils';
 import { ethers } from "ethers";
 import PromisePool from "@supercharge/promise-pool";
@@ -127,6 +128,19 @@ const fetch = async (fetchOptions: FetchOptions): Promise<FetchResult> => {
   // downstream (volume, fees, revenue splits) derives from rawPools
   const blacklistTokens = new Set(getDefaultDexTokensBlacklisted(chain))
   rawPools = rawPools.filter(({ token0, token1 }: any) => !blacklistTokens.has(formatAddress(token0)) && !blacklistTokens.has(formatAddress(token1)))
+
+  // drop the day's wash-flagged pools (see getWashPools), unless every side is
+  // established (core asset or CoinGecko-listed) - the fake-ticker factory
+  // moved here from uniswap v4 the day the filter shipped there
+  const washPools: Set<string> = fetchOptions.preFetchedResults?.washPools ?? new Set()
+  const flagged = rawPools.filter((p: any) => washPools.has(formatAddress(p.pool)))
+  if (flagged.length) {
+    const established = await getEstablishedTokens(chain, flagged.flatMap((p: any) => [p.token0, p.token1]))
+    const drop = new Set(flagged
+      .filter((p: any) => !(established.has(formatAddress(p.token0)) && established.has(formatAddress(p.token1))))
+      .map((p: any) => formatAddress(p.pool)))
+    rawPools = rawPools.filter((p: any) => !drop.has(formatAddress(p.pool)))
+  }
 
   const _pools = rawPools.map((i: any) => i.pool.toLowerCase())
   const [fees, gaugeFeesStart, gaugeFeesEnd] = await Promise.all([
@@ -278,7 +292,12 @@ const fetch = async (fetchOptions: FetchOptions): Promise<FetchResult> => {
   }
 }
 
+const prefetch: any = async (options: FetchOptions) => {
+  return { washPools: await getWashPools(options, { blockchain: 'base', project: 'aerodrome', version: 'slipstream' }) }
+}
+
 const methodology = {
+  Volume: 'Swap volume, excluding wash trading: pools whose daily trades come from too few distinct addresses to be organic, unless every pool token is a core asset or CoinGecko-listed.',
   Fees: "Total swap fees paid by traders. Per-pool fee rate read from CLPool.fee() (tickSpacing-based default, customizable) applied to each swap's input amount.",
   Revenue: "veAERO holders' share of swap fees, equal to HoldersRevenue (Aerodrome's zero-leak model routes all protocol revenue to voters).",
   HoldersRevenue: "Sum of (a) staked-LP fees and (b) the unstaked-LP rake (CLFactory.getUnstakedFee, default 10% of unstaked share), both routed into the gauge's CLPool.gaugeFees() accumulator. Measured on-chain as gaugeFees(toBlock) - gaugeFees(fromBlock) plus CollectFees event amounts (which drain the accumulator each Voter.distribute call).",
@@ -306,6 +325,7 @@ const breakdownMethodology = {
 const adapters: SimpleAdapter = {
   version: 2,
   pullHourly: true,
+  prefetch,
   methodology,
   breakdownMethodology,
   adapter: {

--- a/dexs/aerodrome/index.ts
+++ b/dexs/aerodrome/index.ts
@@ -3,6 +3,7 @@ import { FetchOptions, FetchResult, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 import { getDefaultDexTokensBlacklisted } from '../../helpers/lists';
 import { addOneToken } from '../../helpers/prices';
+import { getEstablishedTokens, getWashPools } from '../../helpers/uniswap';
 import { formatAddress } from '../../utils/utils';
 import { ethers } from "ethers";
 import PromisePool from "@supercharge/promise-pool";
@@ -96,8 +97,20 @@ const getVolumeFeesAndRevenue = async (
   // ignore pools holding blacklisted (scam/wash-traded) tokens - everything
   // downstream (volume, fees, revenue splits) derives from rawPools
   const blacklistTokens = new Set(getDefaultDexTokensBlacklisted(chain))
-  const rawPools = (await fetchOptions.getLogs({ target: CONFIG.PoolFactory, fromBlock: 3200668, eventAbi: eventAbis.event_pool_created, onlyArgs: true, cacheInCloud: true, skipIndexer: true }))
+  let rawPools = (await fetchOptions.getLogs({ target: CONFIG.PoolFactory, fromBlock: 3200668, eventAbi: eventAbis.event_pool_created, onlyArgs: true, cacheInCloud: true, skipIndexer: true }))
     .filter(({ token0, token1 }: any) => !blacklistTokens.has(formatAddress(token0)) && !blacklistTokens.has(formatAddress(token1)))
+
+  // drop the day's wash-flagged pools (see getWashPools), unless every side is
+  // established (core asset or CoinGecko-listed)
+  const washPools: Set<string> = fetchOptions.preFetchedResults?.washPools ?? new Set()
+  const flagged = rawPools.filter((p: any) => washPools.has(formatAddress(p.pool)))
+  if (flagged.length) {
+    const established = await getEstablishedTokens(chain, flagged.flatMap((p: any) => [p.token0, p.token1]))
+    const drop = new Set(flagged
+      .filter((p: any) => !(established.has(formatAddress(p.token0)) && established.has(formatAddress(p.token1))))
+      .map((p: any) => formatAddress(p.pool)))
+    rawPools = rawPools.filter((p: any) => !drop.has(formatAddress(p.pool)))
+  }
 
   const fees = await api.multiCall({
     abi: abis.fees, target: CONFIG.PoolFactory, calls: rawPools.map(i => ({ params: [i.pool, i.stable] }))
@@ -225,7 +238,12 @@ const fetch = async (options: FetchOptions): Promise<FetchResult> => {
   }
 }
 
+const prefetch: any = async (options: FetchOptions) => {
+  return { washPools: await getWashPools(options, { blockchain: 'base', project: 'aerodrome', version: '1' }) }
+}
+
 const methodology = {
+  Volume: 'Swap volume, excluding wash trading: pools whose daily trades come from too few distinct addresses to be organic, unless every pool token is a core asset or CoinGecko-listed.',
   Fees: "Total swap fees paid by traders. Per-pool fee rate read from PoolFactory.getFee (default sAMM 0.05%, vAMM 0.30%; customizable per pool) applied to each swap's input amount.",
   Revenue: "veAERO holders' share of swap fees, equal to HoldersRevenue (Aerodrome's zero-leak model routes all protocol revenue to voters).",
   HoldersRevenue: "Fees earned by LPs staked in the gauge — forwarded to FeeVotingReward for distribution to veAERO voters. Computed per pool as fees × pool.balanceOf(gauge) / pool.totalSupply.",
@@ -254,6 +272,7 @@ const adapters: SimpleAdapter = {
   version: 2,
   pullHourly: true,
   fetch,
+  prefetch,
   chains: [CHAIN.BASE],
   start: '2023-08-28',
   methodology,

--- a/helpers/uniswap.ts
+++ b/helpers/uniswap.ts
@@ -3,6 +3,7 @@ import ADDRESSES from './coreAssets.json'
 import { Balances, ChainApi, cache } from "@defillama/sdk";
 import { BaseAdapter, FetchOptions, FetchV2, IJSON, SimpleAdapter } from "../adapters/types";
 import { addOneToken, isCoreAsset } from "./prices";
+import { queryDune } from "./dune";
 import { httpGet } from "../utils/fetchURL";
 import { ethers } from "ethers";
 
@@ -31,6 +32,36 @@ export const WASH_USD_MIN_TRADES_PER_EOA = 30;
 // price at all (SUM(amount_usd) IS NULL) stay flagged - catching those is what
 // test A is for.
 export const WASH_DUST_USD = 25_000;
+
+// The day's wash-flagged pool set for one project+chain, for adapters whose
+// pools are their own contracts in dex.trades (uniswap-v3 style). The caller's
+// prefetch stores it and fetch drops those pools unless getEstablishedTokens
+// clears every side. A Dune failure throws - reporting unfiltered would
+// republish the wash volume as real.
+export async function getWashPools(options: FetchOptions, { blockchain, project, version }: { blockchain: string; project: string; version?: string }): Promise<Set<string>> {
+  const dayStart = Math.floor(options.startTimestamp / 86400) * 86400;
+  const fullQuery = `
+    SELECT CAST(project_contract_address AS VARCHAR) AS pool
+    FROM dex.trades
+    WHERE blockchain = '${blockchain}'
+      AND project = '${project}'
+      ${version ? `AND version = '${version}'` : ''}
+      AND block_time >= from_unixtime(${dayStart})
+      AND block_time < from_unixtime(${dayStart + 86400})
+    GROUP BY project_contract_address
+    HAVING ((
+      COUNT(*) >= ${WASH_MIN_TRADES}
+      AND COUNT(*) / CAST(COUNT(DISTINCT tx_from) AS DOUBLE) >= ${WASH_TRADES_PER_EOA}
+    ) OR (
+      COALESCE(SUM(amount_usd), 0) >= ${WASH_MIN_USD}
+      AND COALESCE(SUM(amount_usd), 0) / CAST(COUNT(DISTINCT tx_from) AS DOUBLE) >= ${WASH_USD_PER_EOA}
+      AND COUNT(*) / CAST(COUNT(DISTINCT tx_from) AS DOUBLE) >= ${WASH_USD_MIN_TRADES_PER_EOA}
+    ))
+    AND NOT (SUM(amount_usd) IS NOT NULL AND SUM(amount_usd) < ${WASH_DUST_USD})`;
+
+  const rows: any[] = await queryDune('3996608', { fullQuery }, options, { extraUIDKey: 'wash' });
+  return new Set(rows.map((r) => String(r.pool ?? '').toLowerCase()).filter(Boolean));
+}
 
 // Never flag a pool whose every side is established, meaning either
 //  - a core asset: concentrated flow on a major/stable pair is just arb bots


### PR DESCRIPTION
Follow-up to #8515 and #8528.

The day the uniswap wash filter shipped, the fake-ticker factory moved to aerodrome slipstream. Per-day flagged wash volume on base (same tests as #8515, dust floor and CG exemption applied):

| day | uniswap | aerodrome |
|---|---|---|
| Jul 25-29 | $50-100k/day (ETD residual) | none |
| Jul 30 | $83k | $52.2M (OpenAI-USDC, the token blacklisted in #8515) |
| Jul 31 | $118k | $221.3M (PIPEDOG $82M, OpenAI $81M, Anthropic $58M) |
| Aug 1 | $138k | $142.9M (Claude $89M, OpenAI $54M), 40% of slipstream volume that day |

Every new token is a fresh contract ending in the same b07 vanity suffix as the 53 uniswap v4 pools. One new token per day means the manual blacklist added in #8515 cannot keep up, so both aerodrome adapters now run the same per-day dynamic filter as uniswap v3:

- prefetch pulls the day's concentration-flagged pools from dex.trades via a shared getWashPools helper in helpers/uniswap.ts (tests A/B ORed, $25k dust floor, throws on Dune failure rather than republishing wash volume)
- fetch drops flagged pools from rawPools unless every side is a core asset or CoinGecko-listed (getEstablishedTokens), so ZEST-style real-token bot churn stays counted

Verified for Aug 1: getWashPools returns exactly three pools, ZEST (spared, CG-listed) plus the two fake pools (dropped, their tokens have no CG listing).

Jul 31 and Aug 1 aerodrome need a refill once this is live to strip the ~$364M already published.