### PR TITLE
wash filter: query the recorded day, not the day before

### DIFF
--- a/dexs/uniswap-v3.ts
+++ b/dexs/uniswap-v3.ts
@@ -4,7 +4,7 @@ import { addOneToken } from "../helpers/prices";
 import { queryDune } from "../helpers/dune";
 import { httpPost } from "../utils/fetchURL";
 import {
-  getEstablishedTokens, getUniV3LogAdapter, WASH_DUST_USD, WASH_MIN_TRADES,
+  getEstablishedTokens, getUniV3LogAdapter, washDayStart, WASH_DUST_USD, WASH_MIN_TRADES,
   WASH_MIN_USD, WASH_TRADES_PER_EOA, WASH_USD_MIN_TRADES_PER_EOA, WASH_USD_PER_EOA,
 } from "../helpers/uniswap";
 
@@ -97,7 +97,7 @@ function buildQuery(blockchains: string[], options: FetchOptions): string {
 // migrating here once v4 is filtered. Measured over the whole UTC day.
 async function fetchWashPools(blockchains: string[], options: FetchOptions): Promise<Record<string, Set<string>>> {
   const inList = blockchains.map((b) => `'${b}'`).join(',');
-  const dayStart = Math.floor(options.startTimestamp / 86400) * 86400;
+  const dayStart = washDayStart(options);
   // v3 pools are their own contracts, so project_contract_address is the pool
   // and amount_usd is on the same rows - no join needed, unlike v4.
   const fullQuery = `

--- a/dexs/uniswap-v4.ts
+++ b/dexs/uniswap-v4.ts
@@ -60,7 +60,7 @@ import { queryDune } from "../helpers/dune";
 import { getDefaultDexTokensBlacklisted } from "../helpers/lists";
 import { isCoreAsset } from "../helpers/prices";
 import {
-  getEstablishedTokens, WASH_DUST_USD, WASH_MIN_TRADES, WASH_MIN_USD,
+  getEstablishedTokens, washDayStart, WASH_DUST_USD, WASH_MIN_TRADES, WASH_MIN_USD,
   WASH_TRADES_PER_EOA, WASH_USD_MIN_TRADES_PER_EOA, WASH_USD_PER_EOA,
 } from "../helpers/uniswap";
 import { formatAddress } from "../utils/utils";
@@ -296,7 +296,7 @@ const DUNE_CHAIN: Record<string, string> = {
 // pool id. Lets a Dune failure throw - reporting unfiltered would republish the
 // wash volume as real.
 const prefetch: any = async (options: FetchOptions) => {
-  const dayStart = Math.floor(options.startTimestamp / 86400) * 86400;
+  const dayStart = washDayStart(options);
   const chains = Object.values(DUNE_CHAIN).map(c => `'${c}'`).join(',');
   const fullQuery = `
     WITH ev AS (

--- a/helpers/uniswap.ts
+++ b/helpers/uniswap.ts
@@ -33,13 +33,21 @@ export const WASH_USD_MIN_TRADES_PER_EOA = 30;
 // test A is for.
 export const WASH_DUST_USD = 25_000;
 
+// UTC start of the day being recorded. runAdapter hands fetch a window of
+// [dayStart - 1s, dayEnd), so flooring startTimestamp lands on the PREVIOUS
+// day and the filter would apply yesterday's flag list - fatal for fake-ticker
+// pools that live a single day. Key off endTimestamp instead.
+export function washDayStart(options: FetchOptions): number {
+  return Math.floor((options.endTimestamp - 1) / 86400) * 86400;
+}
+
 // The day's wash-flagged pool set for one project+chain, for adapters whose
 // pools are their own contracts in dex.trades (uniswap-v3 style). The caller's
 // prefetch stores it and fetch drops those pools unless getEstablishedTokens
 // clears every side. A Dune failure throws - reporting unfiltered would
 // republish the wash volume as real.
 export async function getWashPools(options: FetchOptions, { blockchain, project, version }: { blockchain: string; project: string; version?: string }): Promise<Set<string>> {
-  const dayStart = Math.floor(options.startTimestamp / 86400) * 86400;
+  const dayStart = washDayStart(options);
   const fullQuery = `
     SELECT CAST(project_contract_address AS VARCHAR) AS pool
     FROM dex.trades


### PR DESCRIPTION
runAdapter sets startTimestamp to 1 second before the recorded day starts, so flooring it to a day resolved to the previous day: the wash prefetch applied yesterday's flag list and one-day fake-ticker pools were never dropped.

Fix: shared washDayStart keyed off endTimestamp, used by uniswap v3, v4 and, via getWashPools, both aerodrome adapters.

Verified on aerodrome-slipstream base:
- Jul 31: $624.6M -> $405.2M, strips the $221.3M of fake pools, ZEST spared
- Aug 1: $211.2M, strips $175.6M
- Aug 2 live partial-day run: new fake pool ASTEROID-USDC ($5M, 2 EOAs) dropped mid-ramp