### PR TITLE
[new protocol] dexlaunch - launchpad fees & revenue on Robinhood Chain

### DIFF
--- a/fees/dexlaunch.ts
+++ b/fees/dexlaunch.ts
@@ -15,27 +15,30 @@ import ADDRESSES from "../helpers/coreAssets.json";
 
 // deployments/<chainId>.json → the PlatformFeeCollector proxy (UUPS — the address is stable
 // across upgrades, only the impl behind it rotates).
-const COLLECTORS: Partial<Record<CHAIN, string>> = {
-  [CHAIN.ROBINHOOD]: "0x949a6e0530119d7cDBE5e904e47056b39BE1f156",
-};
+const COLLECTOR = "0x949a6e0530119d7cDBE5e904e47056b39BE1f156";
 
 const FEES_RECEIVED = "event FeesReceived(address indexed from, uint256 amount)";
 const FEES_DISTRIBUTED = "event FeesDistributed(uint256 holdersAmount, uint256 ownerAmount)";
 
+// One label per stream. FeesReceived carries no per-source discriminator worth decoding (the
+// sender set is open-ended: sales, pads, tokens, locker), so collected fees are one bucket.
+const PLATFORM_FEES = "Platform Fees";
+const FEES_TO_HOLDERS = "Fees To Governance Holders";
+const FEES_TO_TREASURY = "Fees To Treasury";
+
 async function fetch(options: FetchOptions) {
-  const collector = COLLECTORS[options.chain as CHAIN]!;
   const dailyFees = options.createBalances();
   const dailyHoldersRevenue = options.createBalances();
   const dailyProtocolRevenue = options.createBalances();
 
   const [received, distributed] = await Promise.all([
-    options.getLogs({ target: collector, eventAbi: FEES_RECEIVED }),
-    options.getLogs({ target: collector, eventAbi: FEES_DISTRIBUTED }),
+    options.getLogs({ target: COLLECTOR, eventAbi: FEES_RECEIVED }),
+    options.getLogs({ target: COLLECTOR, eventAbi: FEES_DISTRIBUTED }),
   ]);
-  for (const log of received) dailyFees.add(ADDRESSES.null, log.amount);
+  for (const log of received) dailyFees.add(ADDRESSES.null, log.amount, PLATFORM_FEES);
   for (const log of distributed) {
-    dailyHoldersRevenue.add(ADDRESSES.null, log.holdersAmount);
-    dailyProtocolRevenue.add(ADDRESSES.null, log.ownerAmount);
+    dailyHoldersRevenue.add(ADDRESSES.null, log.holdersAmount, FEES_TO_HOLDERS);
+    dailyProtocolRevenue.add(ADDRESSES.null, log.ownerAmount, FEES_TO_TREASURY);
   }
 
   return { dailyFees, dailyRevenue: dailyFees, dailyHoldersRevenue, dailyProtocolRevenue };
@@ -48,13 +51,32 @@ const methodology = {
   ProtocolRevenue: "The half of every distribution delivered to the protocol owner (FeesDistributed logs).",
 };
 
-export default {
-  version: 2,
-  adapter: {
-    [CHAIN.ROBINHOOD]: {
-      fetch,
-      start: "2026-08-01", // genesis deploy on Robinhood Chain (2026-08-01T16:24:06Z)
-    },
+const breakdownMethodology = {
+  Fees: {
+    [PLATFORM_FEES]:
+      "ETH received by the PlatformFeeCollector from every protocol stream: the 2% presale service fee, launch tokens' master fee, the bonding pad's 0.5% per-trade skim, and the locker's fee-claim cut (FeesReceived logs).",
   },
+  Revenue: {
+    [PLATFORM_FEES]: "Identical to Fees — all collected fees are protocol revenue, there is no supply-side cut.",
+  },
+  HoldersRevenue: {
+    [FEES_TO_HOLDERS]:
+      "The half of every distribution paid to GovernanceToken holders as native-ETH dividends (holdersAmount of FeesDistributed).",
+  },
+  ProtocolRevenue: {
+    [FEES_TO_TREASURY]:
+      "The half of every distribution paid to the protocol owner (ownerAmount of FeesDistributed).",
+  },
+};
+
+const adapter: Adapter = {
+  version: 2,
+  pullHourly: true, // pure EVM-log adapter, safe to run hourly
   methodology,
-} as Adapter;
+  breakdownMethodology,
+  chains: [CHAIN.ROBINHOOD],
+  fetch,
+  start: "2026-08-01", // genesis deploy on Robinhood Chain (2026-08-01T16:24:06Z)
+};
+
+export default adapter;

--- a/fees/dexlaunch.ts
+++ b/fees/dexlaunch.ts
@@ -55,7 +55,7 @@ async function fetch(options: FetchOptions) {
 
 const methodology = {
   Fees: "All protocol ETH revenue arriving at the PlatformFeeCollector: the 2% presale service fee, launch tokens' master fee, the bonding pad's 0.5% per-trade skim, and the locker's fee-claim cut (FeesReceived logs).",
-  Revenue: "Identical to Fees — there is no supply-side cut.",
+  Revenue: "All protocol ETH revenue arriving at the PlatformFeeCollector: the 2% presale service fee, launch tokens' master fee, the bonding pad's 0.5% per-trade skim, and the locker's fee-claim cut (FeesReceived logs).",
   HoldersRevenue: "The half of every distribution delivered to GovernanceToken holders as native-ETH dividends (FeesDistributed logs).",
   ProtocolRevenue: "The half of every distribution delivered to the protocol owner (FeesDistributed logs).",
 };
@@ -81,7 +81,7 @@ const breakdownMethodology = {
 
 const adapter: Adapter = {
   version: 2,
-  pullHourly: true, // pure EVM-log adapter, safe to run hourly
+  pullHourly: true,
   methodology,
   breakdownMethodology,
   chains: [CHAIN.ROBINHOOD],

--- a/fees/dexlaunch.ts
+++ b/fees/dexlaunch.ts
@@ -1,0 +1,60 @@
+// DexLaunch — DefiLlama FEES adapter (drop into dimension-adapters/fees/dexlaunch.ts).
+//
+// Every ETH revenue stream converges on the PlatformFeeCollector (presale 2% service fee,
+// launch tokens' master fee, the pad's 0.5% per-trade skim, the locker's fee-claim cut), and
+// the collector EMITS on both legs, so the daily figures come straight from its logs:
+//   dailyFees            = Σ FeesReceived.amount        (all value collected, ETH)
+//   dailyHoldersRevenue  = Σ FeesDistributed.holdersAmount (governance-holder half of the splits)
+//   dailyProtocolRevenue = Σ FeesDistributed.ownerAmount   (owner/treasury half)
+//   dailyRevenue         = dailyFees                    (no supply-side cut)
+// Logs, not lifetime-counter deltas, because Robinhood Chain's public RPC serves no archive
+// state — a historical eth_call at the period-start block fails ("metadata is not found").
+import { Adapter, FetchOptions } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+import ADDRESSES from "../helpers/coreAssets.json";
+
+// deployments/<chainId>.json → the PlatformFeeCollector proxy (UUPS — the address is stable
+// across upgrades, only the impl behind it rotates).
+const COLLECTORS: Partial<Record<CHAIN, string>> = {
+  [CHAIN.ROBINHOOD]: "0x949a6e0530119d7cDBE5e904e47056b39BE1f156",
+};
+
+const FEES_RECEIVED = "event FeesReceived(address indexed from, uint256 amount)";
+const FEES_DISTRIBUTED = "event FeesDistributed(uint256 holdersAmount, uint256 ownerAmount)";
+
+async function fetch(options: FetchOptions) {
+  const collector = COLLECTORS[options.chain as CHAIN]!;
+  const dailyFees = options.createBalances();
+  const dailyHoldersRevenue = options.createBalances();
+  const dailyProtocolRevenue = options.createBalances();
+
+  const [received, distributed] = await Promise.all([
+    options.getLogs({ target: collector, eventAbi: FEES_RECEIVED }),
+    options.getLogs({ target: collector, eventAbi: FEES_DISTRIBUTED }),
+  ]);
+  for (const log of received) dailyFees.add(ADDRESSES.null, log.amount);
+  for (const log of distributed) {
+    dailyHoldersRevenue.add(ADDRESSES.null, log.holdersAmount);
+    dailyProtocolRevenue.add(ADDRESSES.null, log.ownerAmount);
+  }
+
+  return { dailyFees, dailyRevenue: dailyFees, dailyHoldersRevenue, dailyProtocolRevenue };
+}
+
+const methodology = {
+  Fees: "All protocol ETH revenue arriving at the PlatformFeeCollector: the 2% presale service fee, launch tokens' master fee, the bonding pad's 0.5% per-trade skim, and the locker's fee-claim cut (FeesReceived logs).",
+  Revenue: "Identical to Fees — there is no supply-side cut.",
+  HoldersRevenue: "The half of every distribution delivered to GovernanceToken holders as native-ETH dividends (FeesDistributed logs).",
+  ProtocolRevenue: "The half of every distribution delivered to the protocol owner (FeesDistributed logs).",
+};
+
+export default {
+  version: 2,
+  adapter: {
+    [CHAIN.ROBINHOOD]: {
+      fetch,
+      start: "2026-08-01", // genesis deploy on Robinhood Chain (2026-08-01T16:24:06Z)
+    },
+  },
+  methodology,
+} as Adapter;

--- a/fees/dexlaunch.ts
+++ b/fees/dexlaunch.ts
@@ -13,8 +13,10 @@ import { Adapter, FetchOptions } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
 import ADDRESSES from "../helpers/coreAssets.json";
 
-// deployments/<chainId>.json → the PlatformFeeCollector proxy (UUPS — the address is stable
-// across upgrades, only the impl behind it rotates).
+// The PlatformFeeCollector proxy on Robinhood Chain (UUPS — the address is stable across
+// upgrades, only the impl behind it rotates). Listed in the protocol's address registry
+// (https://dexlaunch.fun/docs, "Deployed contracts"):
+// https://robinhoodchain.blockscout.com/address/0x949a6e0530119d7cDBE5e904e47056b39BE1f156
 const COLLECTOR = "0x949a6e0530119d7cDBE5e904e47056b39BE1f156";
 
 const FEES_RECEIVED = "event FeesReceived(address indexed from, uint256 amount)";
@@ -23,11 +25,13 @@ const FEES_DISTRIBUTED = "event FeesDistributed(uint256 holdersAmount, uint256 o
 // One label per stream. FeesReceived carries no per-source discriminator worth decoding (the
 // sender set is open-ended: sales, pads, tokens, locker), so collected fees are one bucket.
 const PLATFORM_FEES = "Platform Fees";
+const PLATFORM_REVENUE = "Platform Fees Retained By The Protocol";
 const FEES_TO_HOLDERS = "Fees To Governance Holders";
 const FEES_TO_TREASURY = "Fees To Treasury";
 
 async function fetch(options: FetchOptions) {
   const dailyFees = options.createBalances();
+  const dailyRevenue = options.createBalances();
   const dailyHoldersRevenue = options.createBalances();
   const dailyProtocolRevenue = options.createBalances();
 
@@ -35,13 +39,18 @@ async function fetch(options: FetchOptions) {
     options.getLogs({ target: COLLECTOR, eventAbi: FEES_RECEIVED }),
     options.getLogs({ target: COLLECTOR, eventAbi: FEES_DISTRIBUTED }),
   ]);
-  for (const log of received) dailyFees.add(ADDRESSES.null, log.amount, PLATFORM_FEES);
+  for (const log of received) {
+    dailyFees.add(ADDRESSES.null, log.amount, PLATFORM_FEES);
+    // Same amounts, its own balance + label: Revenue is the destination-side view (everything is
+    // retained — split later between governance holders and the treasury), Fees the source side.
+    dailyRevenue.add(ADDRESSES.null, log.amount, PLATFORM_REVENUE);
+  }
   for (const log of distributed) {
     dailyHoldersRevenue.add(ADDRESSES.null, log.holdersAmount, FEES_TO_HOLDERS);
     dailyProtocolRevenue.add(ADDRESSES.null, log.ownerAmount, FEES_TO_TREASURY);
   }
 
-  return { dailyFees, dailyRevenue: dailyFees, dailyHoldersRevenue, dailyProtocolRevenue };
+  return { dailyFees, dailyRevenue, dailyHoldersRevenue, dailyProtocolRevenue };
 }
 
 const methodology = {
@@ -57,7 +66,8 @@ const breakdownMethodology = {
       "ETH received by the PlatformFeeCollector from every protocol stream: the 2% presale service fee, launch tokens' master fee, the bonding pad's 0.5% per-trade skim, and the locker's fee-claim cut (FeesReceived logs).",
   },
   Revenue: {
-    [PLATFORM_FEES]: "Identical to Fees — all collected fees are protocol revenue, there is no supply-side cut.",
+    [PLATFORM_REVENUE]:
+      "Every collected fee is retained by the protocol (no supply-side cut) and later split between governance holders and the treasury — see HoldersRevenue / ProtocolRevenue for the split.",
   },
   HoldersRevenue: {
     [FEES_TO_HOLDERS]:


### PR DESCRIPTION
**DexLaunch** is a token launchpad on **Robinhood Chain**: fixed-price presales that auto-list their raise as locked DEX liquidity, pump.fun-style bonding curves that graduate to Uniswap V3, and instant single-sided V3 launches. (TVL adapter submitted separately to DefiLlama-Adapters — `projects/dexlaunch`.)

- Website / App: https://dexlaunch.fun
- API docs: https://dexlaunch.fun/docs
- Twitter/X: https://x.com/dexlaunchfun
- Chain: Robinhood Chain (`CHAIN.ROBINHOOD`)
- Category: **Launchpad**
- Logo: https://dexlaunch.fun/brand/logo-512.png (also [1024px](https://dexlaunch.fun/brand/logo-1024.png), [SVG](https://dexlaunch.fun/brand/logo.svg))

## Methodology

Every protocol ETH revenue stream (the 2% presale service fee, launch tokens' master fee, the bonding pad's 0.5% per-trade skim, the locker's fee-claim cut) converges on one contract, the **PlatformFeeCollector** ([`0x949a6e0530119d7cDBE5e904e47056b39BE1f156`](https://robinhoodchain.blockscout.com/address/0x949a6e0530119d7cDBE5e904e47056b39BE1f156)), which emits on both legs:

- `dailyFees` / `dailyRevenue` = Σ `FeesReceived.amount` (all fees are protocol revenue — no supply-side cut)
- `dailyHoldersRevenue` = Σ `FeesDistributed.holdersAmount` (the half paid to governance-token holders as native-ETH dividends)
- `dailyProtocolRevenue` = Σ `FeesDistributed.ownerAmount` (the treasury half)

Logs rather than lifetime-counter deltas because Robinhood Chain's public RPC serves no archive state (historical `eth_call` fails with "metadata is not found").

## Testing

```
$ npm run test fees dexlaunch

ROBINHOOD 👇
Backfill start time: 1/8/2026
Daily fees: 0.68
Daily revenue: 0.68
Daily holders revenue: 0.34
Daily protocol revenue: 0.34
```
