### PR TITLE
pact: throw on api zero rows instead of recording them

### DIFF
--- a/dexs/pact/index.ts
+++ b/dexs/pact/index.ts
@@ -14,15 +14,23 @@ const fetch = async (options: FetchOptions) => {
   const yesterdaysTimestamp = getTimestampAtStartOfPreviousDayUTC(options.toTimestamp)
   const url = URL(new Date(yesterdaysTimestamp * 1000).toISOString());
   const response: IAPIResponse[] = (await fetchURL(url));
-  const dailyVolume = response
-    .find(dayItem => (new Date(dayItem.for_datetime.split('T')[0]).getTime() / 1000) === options.startOfDay)?.volume_usd;
+  const row = response
+    .find(dayItem => (new Date(dayItem.for_datetime.split('T')[0]).getTime() / 1000) === options.startOfDay);
 
-  if (dailyVolume == undefined) {
+  if (row == undefined) {
     throw new Error(`No daily volume found for date ${options.dateString}`);
   }
 
+  const dailyVolume = Number(row.volume_usd);
+  if (!Number.isFinite(dailyVolume)) {
+    throw new Error(`api.pact.fi returned a bad volume_usd (${row.volume_usd}) for ${options.dateString}`);
+  }
+  if (dailyVolume === 0) {
+    throw new Error(`api.pact.fi wrote a zero volume row for ${options.dateString} while pools still trade on-chain, their stats pipeline stalls like this instead of omitting the row`);
+  }
+
   return {
-    dailyVolume: dailyVolume,
+    dailyVolume,
   };
 };
 


### PR DESCRIPTION
pact went to $0 on aug 1 and 2 while it was doing 30k-130k every day before that. their stats api is what broke, not the protocol: api.pact.fi/api/internal/pools_details/overall/historical_stats writes an explicit volume_usd 0.000000 row for days it hasn't processed, so the adapter's existing missing-row throw never fires and the zero goes straight into the chart.

checked on chain before touching anything: the algorand indexer shows swap app calls to the top pact pool (app 885102197) all through aug 1, and their pools api is showing tvl_usd 0 even for the main usdc pool, so the whole stats pipeline is stalled. also looked at the full history: pact has 6 zero days ever, 5 of them clustered in sept 2025 between normal 26k+ days, which looks like the same stall happening before and never getting refilled. the protocol has never had a real zero day, so throwing on an exact zero is safe here.

change is small: parse volume_usd, throw if it's not finite or exactly 0 so the runner retries instead of recording a bogus zero. tested both paths, aug 1 throws with the new message, jul 31 returns 31.42k as before.