### PR TITLE
Add SOGO Terminal builder code

### DIFF
--- a/factory/hyperliquid.ts
+++ b/factory/hyperliquid.ts
@@ -43,7 +43,7 @@ const builderConfigs: Record<string, BuilderConfig> = {
     },
     breakdownFees: true,
   },
-"sogo-terminal": {
+  "sogo-terminal": {
     addresses: ["0x980adfdcb7655198ea69d2e19eb7daca594a9e67"],
     start: "2026-07-12",
     methodology: {

--- a/factory/hyperliquid.ts
+++ b/factory/hyperliquid.ts
@@ -43,6 +43,17 @@ const builderConfigs: Record<string, BuilderConfig> = {
     },
     breakdownFees: true,
   },
+"sogo-terminal": {
+    addresses: ["0x980adfdcb7655198ea69d2e19eb7daca594a9e67"],
+    start: "2026-07-12",
+    methodology: {
+      Volume: "Notional volume of Hyperliquid perpetual trades routed through SOGO Terminal's non-custodial Telegram interface.",
+      Fees: "Builder code fees paid by users on Hyperliquid perpetual trades executed through SOGO Terminal.",
+      Revenue: "Builder code fees collected by SOGO Terminal from Hyperliquid perpetual trades.",
+      ProtocolRevenue: "Builder code fees collected by SOGO Terminal from Hyperliquid perpetual trades.",
+    },
+    breakdownFees: true,
+  },
   "stablejack-perps": {
     addresses: [
       "0x68b7e8be8f1a62f99e37f1ac191dd23486e8a2ad",


### PR DESCRIPTION
Adding SOGO Terminal as a Hyperliquid builder code entry in
factory/hyperliquid.ts. This is a fees/volume adapter only — no TVL.

Builder wallet: 0x980adfdcb7655198ea69d2e19eb7daca594a9e67
First builder fill: 2026-07-12
Verified against stats-data.hyperliquid.xyz builder_fills.

#### Name (to be shown on DefiLlama): SOGO Terminal
#### Twitter Link: https://x.com/sogoterminal
#### List of audit links if any: None
#### Website Link: https://sogoterminal.com
#### Logo: available on request, can supply high-res PNG
#### Current TVL: N/A — non-custodial, no assets held
#### Treasury Addresses (if the protocol has treasury): N/A
#### Chain: Hyperliquid L1
#### Coingecko ID: N/A — no token
#### Coinmarketcap ID: N/A — no token
#### Short Description: Non-custodial Hyperliquid perps interface
delivered through Telegram. Keys stay with the user; the agent key is
trade-only and cannot withdraw.
#### Token address and ticker if any: None
#### Category: Interface
#### Oracle Provider(s): N/A — orders route to Hyperliquid, no own oracle
#### Implementation Details: N/A
#### Documentation/Proof: Hyperliquid builder codes
https://hyperliquid.gitbook.io/hyperliquid-docs/trading/builder-codes
#### forkedFrom: No
#### methodology: Builder code fees on Hyperliquid perpetual trades routed
through SOGO Terminal, via the existing exportBuilderAdapter in
factory/hyperliquid.ts
#### Github org/user: https://github.com/sogo-hq
#### Does this project have a referral program?: No referral links used
in this listing.