### PR TITLE
whale.ag: add Hyperliquid builder code fees adapter

### DIFF
--- a/factory/hyperliquid.ts
+++ b/factory/hyperliquid.ts
@@ -34,7 +34,7 @@ const builderConfigs: Record<string, BuilderConfig> = {
     addresses: ["0xfa4a0d1ca5288478f2c515d5574d53631e7fa711"],
     start: "2026-04-23",
     methodology: {
-      Volume: "Notional volume of Hyperliquid perpetual trades executed through whale.ag.",
+      Volume: "Notional volume of Hyperliquid perpetual trades executed through whale.ag's non-custodial copy-trading platform and perps terminal.",
       Fees: "Builder code fees (0.05%) paid by users on Hyperliquid perpetual trades executed through whale.ag.",
       Revenue: "Builder code fees collected by whale.ag from Hyperliquid perpetual trades.",
       ProtocolRevenue: "Builder code fees collected by whale.ag from Hyperliquid perpetual trades.",

--- a/factory/hyperliquid.ts
+++ b/factory/hyperliquid.ts
@@ -30,6 +30,17 @@ const superxConfig: BuilderConfig = {
 // factory export. The DefiLlama dimension framework picks the appropriate
 // fields (volume vs fees) based on each protocol's metadata adapter type.
 const builderConfigs: Record<string, BuilderConfig> = {
+  "whale-ag": {
+    addresses: ["0xfa4a0d1ca5288478f2c515d5574d53631e7fa711"],
+    start: "2026-04-23",
+    methodology: {
+      Volume: "Notional volume of Hyperliquid perpetual trades executed through whale.ag.",
+      Fees: "Builder code fees (0.05%) paid by users on Hyperliquid perpetual trades executed through whale.ag.",
+      Revenue: "Builder code fees collected by whale.ag from Hyperliquid perpetual trades.",
+      ProtocolRevenue: "Builder code fees collected by whale.ag from Hyperliquid perpetual trades.",
+    },
+    breakdownFees: true,
+  },
   "signalview": {
     addresses: [
       "0x7c7f5fab1e78a08274a2f2a36c4e7dd3557c9cfa",


### PR DESCRIPTION
## New listing: whale.ag

Adds **whale.ag** to the Hyperliquid builder factory (`factory/hyperliquid.ts`), tracking **only Hyperliquid builder code fees** (no other revenue streams are included).

**Protocol info**
- Name: whale.ag
- Website: https://whale.ag
- Description: whale.ag is a non-custodial copy-trading platform and pro perps terminal for Hyperliquid. Track whale and insider wallets, verify their real on-chain performance — PnL, Sharpe and drawdown computed from actual fills — and copy them in one click from a wallet you own.
- Chain: Hyperliquid
- Category: Copy trading / Perps terminal

**Adapter details**
- Builder address: `0xfa4a0d1ca5288478f2c515d5574d53631e7fa711`
- Start: `2026-04-23` (first date with builder fills published at `stats-data.hyperliquid.xyz`)
- Fees = Revenue = ProtocolRevenue = builder code fees (0.05%) paid by users on perp trades routed through whale.ag
- Volume = notional volume of trades carrying the whale.ag builder code

**Test run** (`npm run test dexs whale-ag 2026-08-01`):
```
HYPERLIQUID
Backfill start time: 23/4/2026
Daily volume: 149.99 k
Daily fees: 75.00
Daily revenue: 75.00
Daily protocol revenue: 75.00
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)