### PR TITLE
Add AutoRange fees/revenue and volume adapters

### DIFF
--- a/dexs/autorange.ts
+++ b/dexs/autorange.ts
@@ -1,0 +1,88 @@
+import { FetchOptions, SimpleAdapter } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+
+// AutoRange — non-custodial Uniswap V3 concentrated-liquidity vault
+// platform. "Volume" here is NOT third-party swap volume routed through
+// AutoRange (it doesn't route trades for anyone) — it's the USD value the
+// keeper agent itself deploys into a fresh Uniswap V3 position every time
+// it builds or rebuilds one: initPosition() (a vault's very first mint) and
+// rebalance() (every subsequent re-mint after the price leaves the range or
+// on the owner's configured interval). See RangeVault.sol's PositionInitialized
+// and Rebalanced events.
+const config: Record<string, { factory: string; positionManager: string }> = {
+  [CHAIN.CELO]: {
+    factory: "0xa431a0bD0978d872C720cD3E3277e31cd6026e90",
+    positionManager: "0x3d79EdAaBC0EaB6F08ED885C05Fc0B014290D95A",
+  },
+  [CHAIN.ARBITRUM]: {
+    factory: "0x93590F9a18Ed444dD90ECBeCA094aa9367452472",
+    positionManager: "0xC36442b4a4522E871399CD717aBDD847Ab11FE88",
+  },
+};
+
+const positionInitAbi = "event PositionInitialized(uint256 tokenId, uint256 amount0, uint256 amount1)";
+// Rebalanced doesn't carry the new position's amount0/amount1 directly —
+// cross-referenced below against the shared NonfungiblePositionManager's own
+// IncreaseLiquidity event (emitted in the same transaction on every mint).
+const rebalancedAbi = "event Rebalanced(uint256 indexed newTokenId, int24 tickLower, int24 tickUpper, uint256 reinjectedAmount)";
+const increaseLiquidityAbi = "event IncreaseLiquidity(uint256 indexed tokenId, uint128 liquidity, uint256 amount0, uint256 amount1)";
+
+const fetch = async (options: FetchOptions) => {
+  const { factory, positionManager } = config[options.chain];
+  const dailyVolume = options.createBalances();
+
+  const vaults: string[] = await options.api.fetchList({ target: factory, lengthAbi: "vaultCount", itemAbi: "allVaults" });
+  if (!vaults.length) return { dailyVolume };
+
+  const [token0s, token1s] = await Promise.all([
+    options.api.multiCall({ calls: vaults, abi: "address:token0" }),
+    options.api.multiCall({ calls: vaults, abi: "address:token1" }),
+  ]);
+
+  const [positionInitLogs, rebalancedLogs] = await Promise.all([
+    options.getLogs({ targets: vaults, eventAbi: positionInitAbi, flatten: false }),
+    options.getLogs({ targets: vaults, eventAbi: rebalancedAbi, flatten: false }),
+  ]);
+
+  vaults.forEach((_, i) => {
+    (positionInitLogs[i] ?? []).forEach((log: any) => {
+      dailyVolume.add(token0s[i], log.amount0);
+      dailyVolume.add(token1s[i], log.amount1);
+    });
+  });
+
+  const anyRebalances = rebalancedLogs.some((logs: any[]) => logs?.length);
+  if (anyRebalances) {
+    const increaseLogs = await options.getLogs({ target: positionManager, eventAbi: increaseLiquidityAbi });
+    const byTokenId = new Map<string, any>();
+    (increaseLogs ?? []).forEach((log: any) => byTokenId.set(String(log.tokenId), log));
+
+    vaults.forEach((_, i) => {
+      (rebalancedLogs[i] ?? []).forEach((log: any) => {
+        const match = byTokenId.get(String(log.newTokenId));
+        if (!match) return; // best-effort — see methodology
+        dailyVolume.add(token0s[i], match.amount0);
+        dailyVolume.add(token1s[i], match.amount1);
+      });
+    });
+  }
+
+  return { dailyVolume };
+};
+
+const methodology = {
+  Volume:
+    "USD value deployed by AutoRange's keeper agent every time it builds or rebuilds a vault's Uniswap V3 position (initial mint or rebalance) — not third-party swap volume, since AutoRange doesn't route trades for anyone else.",
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  fetch,
+  adapter: {
+    [CHAIN.CELO]: { start: "2026-07-16" },
+    [CHAIN.ARBITRUM]: { start: "2026-07-18" },
+  },
+  methodology,
+};
+
+export default adapter;

--- a/dexs/autorange.ts
+++ b/dexs/autorange.ts
@@ -1,4 +1,5 @@
 import { FetchOptions, SimpleAdapter } from "../adapters/types";
+import { chainConfig } from "../fees/aave-v3";
 import { CHAIN } from "../helpers/chains";
 
 // AutoRange — non-custodial Uniswap V3 concentrated-liquidity vault
@@ -9,14 +10,16 @@ import { CHAIN } from "../helpers/chains";
 // rebalance() (every subsequent re-mint after the price leaves the range or
 // on the owner's configured interval). See RangeVault.sol's PositionInitialized
 // and Rebalanced events.
-const config: Record<string, { factory: string; positionManager: string }> = {
+const config: Record<string, { factory: string; positionManager: string; start: string }> = {
   [CHAIN.CELO]: {
     factory: "0xa431a0bD0978d872C720cD3E3277e31cd6026e90",
     positionManager: "0x3d79EdAaBC0EaB6F08ED885C05Fc0B014290D95A",
+    start: "2026-07-16",
   },
   [CHAIN.ARBITRUM]: {
     factory: "0x93590F9a18Ed444dD90ECBeCA094aa9367452472",
     positionManager: "0xC36442b4a4522E871399CD717aBDD847Ab11FE88",
+    start: "2026-07-18",
   },
 };
 
@@ -77,11 +80,9 @@ const methodology = {
 
 const adapter: SimpleAdapter = {
   version: 2,
+  pullHourly: true,
   fetch,
-  adapter: {
-    [CHAIN.CELO]: { start: "2026-07-16" },
-    [CHAIN.ARBITRUM]: { start: "2026-07-18" },
-  },
+  adapter: chainConfig,
   methodology,
 };
 

--- a/dexs/autorange.ts
+++ b/dexs/autorange.ts
@@ -1,5 +1,4 @@
 import { FetchOptions, SimpleAdapter } from "../adapters/types";
-import { chainConfig } from "../fees/aave-v3";
 import { CHAIN } from "../helpers/chains";
 
 // AutoRange — non-custodial Uniswap V3 concentrated-liquidity vault
@@ -57,15 +56,25 @@ const fetch = async (options: FetchOptions) => {
   const anyRebalances = rebalancedLogs.some((logs: any[]) => logs?.length);
   if (anyRebalances) {
     const increaseLogs = await options.getLogs({ target: positionManager, eventAbi: increaseLiquidityAbi });
-    const byTokenId = new Map<string, any>();
-    (increaseLogs ?? []).forEach((log: any) => byTokenId.set(String(log.tokenId), log));
+
+    const byTokenId = new Map<string, any[]>();
+    (increaseLogs ?? []).forEach((log: any) => {
+      const key = String(log.tokenId);
+      const existing = byTokenId.get(key);
+      if (existing) existing.push(log);
+      else byTokenId.set(key, [log]);
+    });
 
     vaults.forEach((_, i) => {
       (rebalancedLogs[i] ?? []).forEach((log: any) => {
-        const match = byTokenId.get(String(log.newTokenId));
-        if (!match) return; // best-effort — see methodology
-        dailyVolume.add(token0s[i], match.amount0);
-        dailyVolume.add(token1s[i], match.amount1);
+        const matches = (byTokenId.get(String(log.newTokenId)) ?? []).filter(
+          (m: any) => m.transactionHash === log.transactionHash,
+        );
+        if (!matches.length) return;
+        matches.forEach((match) => {
+          dailyVolume.add(token0s[i], match.amount0);
+          dailyVolume.add(token1s[i], match.amount1);
+        });
       });
     });
   }
@@ -82,7 +91,7 @@ const adapter: SimpleAdapter = {
   version: 2,
   pullHourly: true,
   fetch,
-  adapter: chainConfig,
+  adapter: config,
   methodology,
 };
 

--- a/fees/autorange.ts
+++ b/fees/autorange.ts
@@ -1,14 +1,15 @@
 import { FetchOptions, SimpleAdapter } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
+import { METRIC } from "../helpers/metrics";
 
 // AutoRange — non-custodial Uniswap V3 concentrated-liquidity vault
 // platform. Every trading fee a vault's position earns is split on-chain
 // between the vault's owner (LP) and the platform, at rebalance time
 // (rebalance()) or on manual claim (collectFees()) — see RangeVault.sol's
 // _splitPerformanceFee(). Fees/Revenue here mirror that split exactly.
-const config: Record<string, { factory: string }> = {
-  [CHAIN.CELO]: { factory: "0xa431a0bD0978d872C720cD3E3277e31cd6026e90" },
-  [CHAIN.ARBITRUM]: { factory: "0x93590F9a18Ed444dD90ECBeCA094aa9367452472" },
+const config: Record<string, { factory: string; start: string }> = {
+  [CHAIN.CELO]: { factory: "0xa431a0bD0978d872C720cD3E3277e31cd6026e90", start: "2026-07-16" },
+  [CHAIN.ARBITRUM]: { factory: "0x93590F9a18Ed444dD90ECBeCA094aa9367452472", start: "2026-07-18" },
 };
 
 const lpFeesAbi = "event LpFeesPaidToOwner(uint256 amount0, uint256 amount1)";
@@ -41,17 +42,17 @@ const fetch = async (options: FetchOptions) => {
     const token1 = token1s[i];
 
     [...(ownerLogsA[i] ?? []), ...(ownerLogsB[i] ?? [])].forEach((log: any) => {
-      dailyFees.add(token0, log.amount0);
-      dailyFees.add(token1, log.amount1);
-      dailySupplySideRevenue.add(token0, log.amount0);
-      dailySupplySideRevenue.add(token1, log.amount1);
+      dailyFees.add(token0, log.amount0, METRIC.SWAP_FEES);
+      dailyFees.add(token1, log.amount1, METRIC.SWAP_FEES);
+      dailySupplySideRevenue.add(token0, log.amount0, METRIC.SWAP_FEES);
+      dailySupplySideRevenue.add(token1, log.amount1, METRIC.SWAP_FEES);
     });
 
     (platformLogs[i] ?? []).forEach((log: any) => {
-      dailyFees.add(token0, log.amount0);
-      dailyFees.add(token1, log.amount1);
-      dailyRevenue.add(token0, log.amount0);
-      dailyRevenue.add(token1, log.amount1);
+      dailyFees.add(token0, log.amount0, METRIC.PERFORMANCE_FEES);
+      dailyFees.add(token1, log.amount1, METRIC.PERFORMANCE_FEES);
+      dailyRevenue.add(token0, log.amount0, METRIC.PERFORMANCE_FEES);
+      dailyRevenue.add(token1, log.amount1, METRIC.PERFORMANCE_FEES);
     });
   });
 
@@ -61,19 +62,34 @@ const fetch = async (options: FetchOptions) => {
 const methodology = {
   Fees: "Total Uniswap V3 trading fees earned by all AutoRange vaults' positions, realized on rebalance or when the vault owner manually claims — the full amount before the platform/owner split.",
   Revenue: "The platform's performance-fee cut of those trading fees, set per-vault by PlatformConfig and capped by the vault owner.",
-  ProtocolRevenue: "Same as Revenue — the entire platform cut goes to the operator/treasury, there's no separate token-holder split.",
+  ProtocolRevenue: "The platform's performance-fee cut of those trading fees, set per-vault by PlatformConfig and capped by the vault owner.",
   SupplySideRevenue: "The vault owner's (LP's) net share of trading fees, after the platform's cut.",
 };
 
+const breakdownMethodology = {
+  Fees: {
+    [METRIC.SWAP_FEES]: "Total Uniswap V3 trading fees earned by all AutoRange vaults' positions, realized on rebalance or when the vault owner manually claims — the full amount before the platform/owner split.",
+    [METRIC.PERFORMANCE_FEES]: "The platform's performance-fee cut of those trading fees, set per-vault by PlatformConfig and capped by the vault owner.",
+  },
+  Revenue: {
+    [METRIC.PERFORMANCE_FEES]: "The platform's performance-fee cut of those trading fees, set per-vault by PlatformConfig and capped by the vault owner.",
+  },
+  ProtocolRevenue: {
+    [METRIC.PERFORMANCE_FEES]: "The platform's performance-fee cut of those trading fees, set per-vault by PlatformConfig and capped by the vault owner.",
+  },
+  SupplySideRevenue: {
+    [METRIC.SWAP_FEES]: "The vault owner's (LP's) net share of trading fees, after the platform's cut.",
+  },
+}
+
 const adapter: SimpleAdapter = {
   version: 2,
+  pullHourly: true,
   fetch,
-  adapter: {
-    [CHAIN.CELO]: { start: "2026-07-16" },
-    [CHAIN.ARBITRUM]: { start: "2026-07-18" },
-  },
+  adapter: config,
   methodology,
-  doublecounted: true,
+  breakdownMethodology,
+  doublecounted: true, // uniswap v3
 };
 
 export default adapter;

--- a/fees/autorange.ts
+++ b/fees/autorange.ts
@@ -1,0 +1,79 @@
+import { FetchOptions, SimpleAdapter } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+
+// AutoRange — non-custodial Uniswap V3 concentrated-liquidity vault
+// platform. Every trading fee a vault's position earns is split on-chain
+// between the vault's owner (LP) and the platform, at rebalance time
+// (rebalance()) or on manual claim (collectFees()) — see RangeVault.sol's
+// _splitPerformanceFee(). Fees/Revenue here mirror that split exactly.
+const config: Record<string, { factory: string }> = {
+  [CHAIN.CELO]: { factory: "0xa431a0bD0978d872C720cD3E3277e31cd6026e90" },
+  [CHAIN.ARBITRUM]: { factory: "0x93590F9a18Ed444dD90ECBeCA094aa9367452472" },
+};
+
+const lpFeesAbi = "event LpFeesPaidToOwner(uint256 amount0, uint256 amount1)";
+const feesCollectedAbi = "event FeesCollected(uint256 amount0, uint256 amount1)";
+const perfFeeAbi = "event PerformanceFeeCollected(uint256 amount0, uint256 amount1)";
+
+const fetch = async (options: FetchOptions) => {
+  const { factory } = config[options.chain];
+
+  const dailyFees = options.createBalances();
+  const dailyRevenue = options.createBalances();
+  const dailySupplySideRevenue = options.createBalances();
+
+  const vaults: string[] = await options.api.fetchList({ target: factory, lengthAbi: "vaultCount", itemAbi: "allVaults" });
+  if (!vaults.length) return { dailyFees, dailyRevenue, dailyProtocolRevenue: dailyRevenue, dailySupplySideRevenue };
+
+  const [token0s, token1s] = await Promise.all([
+    options.api.multiCall({ calls: vaults, abi: "address:token0" }),
+    options.api.multiCall({ calls: vaults, abi: "address:token1" }),
+  ]);
+
+  const [ownerLogsA, ownerLogsB, platformLogs] = await Promise.all([
+    options.getLogs({ targets: vaults, eventAbi: lpFeesAbi, flatten: false }),
+    options.getLogs({ targets: vaults, eventAbi: feesCollectedAbi, flatten: false }),
+    options.getLogs({ targets: vaults, eventAbi: perfFeeAbi, flatten: false }),
+  ]);
+
+  vaults.forEach((_, i) => {
+    const token0 = token0s[i];
+    const token1 = token1s[i];
+
+    [...(ownerLogsA[i] ?? []), ...(ownerLogsB[i] ?? [])].forEach((log: any) => {
+      dailyFees.add(token0, log.amount0);
+      dailyFees.add(token1, log.amount1);
+      dailySupplySideRevenue.add(token0, log.amount0);
+      dailySupplySideRevenue.add(token1, log.amount1);
+    });
+
+    (platformLogs[i] ?? []).forEach((log: any) => {
+      dailyFees.add(token0, log.amount0);
+      dailyFees.add(token1, log.amount1);
+      dailyRevenue.add(token0, log.amount0);
+      dailyRevenue.add(token1, log.amount1);
+    });
+  });
+
+  return { dailyFees, dailyRevenue, dailyProtocolRevenue: dailyRevenue, dailySupplySideRevenue };
+};
+
+const methodology = {
+  Fees: "Total Uniswap V3 trading fees earned by all AutoRange vaults' positions, realized on rebalance or when the vault owner manually claims — the full amount before the platform/owner split.",
+  Revenue: "The platform's performance-fee cut of those trading fees, set per-vault by PlatformConfig and capped by the vault owner.",
+  ProtocolRevenue: "Same as Revenue — the entire platform cut goes to the operator/treasury, there's no separate token-holder split.",
+  SupplySideRevenue: "The vault owner's (LP's) net share of trading fees, after the platform's cut.",
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  fetch,
+  adapter: {
+    [CHAIN.CELO]: { start: "2026-07-16" },
+    [CHAIN.ARBITRUM]: { start: "2026-07-18" },
+  },
+  methodology,
+  doublecounted: true,
+};
+
+export default adapter;


### PR DESCRIPTION
## Summary
[AutoRange](https://www.autorange.xyz/) ([@AutoRangexyz](https://x.com/AutoRangexyz)) is a non-custodial Uniswap V3 concentrated-liquidity vault platform, live on Celo and Arbitrum. Already listed for TVL: DefiLlama-Adapters#20126 (merged).

## `fees/autorange.ts`
Every vault's Uniswap V3 trading fees are split on-chain between the vault's owner (LP) and the platform, either at rebalance time or when the owner manually claims (`RangeVault.sol`'s `_splitPerformanceFee`):
- **Fees**: the full trading-fee amount, before the split (`LpFeesPaidToOwner` + `FeesCollected` + `PerformanceFeeCollected` events)
- **Revenue / ProtocolRevenue**: the platform's cut (`PerformanceFeeCollected`) — no separate token-holder split
- **SupplySideRevenue**: the owner's net share after the platform's cut

Marked `doublecounted: true` since these are Uniswap V3 pool fees, already reflected in Uniswap's own fee reporting — same convention as other concentrated-liquidity managers (Steer, Gamma).

## `dexs/autorange.ts`
**Volume here is a different definition than a typical DEX's `dailyVolume`** — AutoRange doesn't route trades for third parties, so there's no swap volume to attribute to it. Instead, this tracks the USD value the keeper agent itself deploys every time it builds or rebuilds a vault's position (`initPosition()`'s initial mint, or `rebalance()`'s re-mint after the price leaves the range or on the owner's configured interval). Flagging this explicitly for review — happy to adjust the categorization if this isn't the right dashboard for it.

## Verified
`npm test -- fees/autorange` and `npm test -- dexs/autorange` against live chain state (Celo + Arbitrum), sane proportional splits (Revenue + SupplySideRevenue == Fees) and volume in the expected order of magnitude vs. current TVL.