### PR TITLE
stabble: count gross swap fees, not the LP share

### DIFF
--- a/dexs/stabble/index.ts
+++ b/dexs/stabble/index.ts
@@ -15,19 +15,20 @@ const fetch = async (options: FetchOptions) => {
   const url = `${volumeURL}?startTimestamp=${options.startTimestamp}&endTimestamp=${options.endTimestamp}`;
   const stats: DailyStats = await fetchURL(url);
 
+  // `fees` is the LP share only (70% of gross) and `revenue` is the treasury's 30%,
   return {
     dailyVolume: stats.volume,
-    dailyFees: stats.fees,
+    dailyFees: stats.fees + stats.revenue,
     dailyRevenue: stats.revenue,
-    dailySupplySideRevenue: stats.fees - stats.revenue,
+    dailySupplySideRevenue: stats.fees,
   };
 };
 
 const methodology = {
   Volume: "Trading volume across stabble's stable and weighted AMM pools.",
-  Fees: "Total swap fees paid by traders.",
-  Revenue: "The protocol's cut of swap fees (treasury / $STB staking pool).",
-  SupplySideRevenue: "The portion of swap fees distributed to liquidity providers.",
+  Fees: "Total swap fees paid by traders — the liquidity providers' share plus the protocol's cut.",
+  Revenue: "The 30% of swap fees sent to the stabble multisig treasury that funds the $STB staking pool.",
+  SupplySideRevenue: "The 70% of swap fees kept by liquidity providers.",
 };
 
 const adapter: SimpleAdapter = {

--- a/dexs/stabble/index.ts
+++ b/dexs/stabble/index.ts
@@ -1,5 +1,6 @@
 import { CHAIN } from "../../helpers/chains";
 import { FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { METRIC } from "../../helpers/metrics";
 import fetchURL from "../../utils/fetchURL";
 
 const volumeURL = "https://api.stabble.org/metric";
@@ -15,12 +16,21 @@ const fetch = async (options: FetchOptions) => {
   const url = `${volumeURL}?startTimestamp=${options.startTimestamp}&endTimestamp=${options.endTimestamp}`;
   const stats: DailyStats = await fetchURL(url);
 
+  const dailyFees = options.createBalances();
+  const dailyRevenue = options.createBalances();
+  const dailySupplySideRevenue = options.createBalances();
+
   // `fees` is the LP share only (70% of gross) and `revenue` is the treasury's 30%,
+  // so gross swap fees are the sum of the two.
+  dailyFees.addUSDValue(stats.fees + stats.revenue, METRIC.SWAP_FEES);
+  dailyRevenue.addUSDValue(stats.revenue, 'Token Swap Fees To Protocol');
+  dailySupplySideRevenue.addUSDValue(stats.fees, 'Token Swap Fees To LPs');
+
   return {
     dailyVolume: stats.volume,
-    dailyFees: stats.fees + stats.revenue,
-    dailyRevenue: stats.revenue,
-    dailySupplySideRevenue: stats.fees,
+    dailyFees,
+    dailyRevenue,
+    dailySupplySideRevenue,
   };
 };
 
@@ -31,12 +41,25 @@ const methodology = {
   SupplySideRevenue: "The 70% of swap fees kept by liquidity providers.",
 };
 
+const breakdownMethodology = {
+  Fees: {
+    [METRIC.SWAP_FEES]: "Gross swap fees charged on trades routed through stabble's stable and weighted AMM pools, before the LP/treasury split.",
+  },
+  Revenue: {
+    'Token Swap Fees To Protocol': "The 30% of swap fees sent to the stabble multisig treasury that funds the $STB staking pool.",
+  },
+  SupplySideRevenue: {
+    'Token Swap Fees To LPs': "The 70% of swap fees kept by the liquidity providers of each pool.",
+  },
+};
+
 const adapter: SimpleAdapter = {
   version: 1,
   fetch,
   chains: [CHAIN.SOLANA],
   start: '2024-06-05',
   methodology,
+  breakdownMethodology,
 };
 
 export default adapter;

--- a/dexs/stabble/index.ts
+++ b/dexs/stabble/index.ts
@@ -23,13 +23,14 @@ const fetch = async (options: FetchOptions) => {
   // `fees` is the LP share only (70% of gross) and `revenue` is the treasury's 30%,
   // so gross swap fees are the sum of the two.
   dailyFees.addUSDValue(stats.fees + stats.revenue, METRIC.SWAP_FEES);
-  dailyRevenue.addUSDValue(stats.revenue, 'Token Swap Fees To Protocol');
+  dailyRevenue.addUSDValue(stats.revenue, 'Token Swap Fees To $STB staking pool');
   dailySupplySideRevenue.addUSDValue(stats.fees, 'Token Swap Fees To LPs');
 
   return {
     dailyVolume: stats.volume,
     dailyFees,
     dailyRevenue,
+    dailyHoldersRevenue: dailyRevenue,
     dailySupplySideRevenue,
   };
 };
@@ -38,6 +39,7 @@ const methodology = {
   Volume: "Trading volume across stabble's stable and weighted AMM pools.",
   Fees: "Total swap fees paid by traders — the liquidity providers' share plus the protocol's cut.",
   Revenue: "The 30% of swap fees sent to the stabble multisig treasury that funds the $STB staking pool.",
+  HoldersRevenue: "The 30% of swap fees sent to the stabble multisig treasury that funds the $STB staking pool.",
   SupplySideRevenue: "The 70% of swap fees kept by liquidity providers.",
 };
 
@@ -46,7 +48,10 @@ const breakdownMethodology = {
     [METRIC.SWAP_FEES]: "Gross swap fees charged on trades routed through stabble's stable and weighted AMM pools, before the LP/treasury split.",
   },
   Revenue: {
-    'Token Swap Fees To Protocol': "The 30% of swap fees sent to the stabble multisig treasury that funds the $STB staking pool.",
+    'Token Swap Fees To $STB staking pool': "The 30% of swap fees sent to the stabble multisig treasury that funds the $STB staking pool.",
+  },
+  HoldersRevenue: {
+    'Token Swap Fees To $STB staking pool': "The 30% of swap fees sent to the stabble multisig treasury that funds the $STB staking pool.",
   },
   SupplySideRevenue: {
     'Token Swap Fees To LPs': "The 70% of swap fees kept by the liquidity providers of each pool.",


### PR DESCRIPTION
The adapter treated the API's `fees` field as gross swap fees, but it only represents the LP share.

### Changes

- Compute `dailyFees` as `fees + revenue` (gross swap fees).
- Set `dailySupplySideRevenue` to the LP share returned by the API.
- Keep `dailyRevenue` unchanged and update the methodology to document the 70/30 LP/protocol split.