### PR TITLE
Add complete Ophis volume and fee reporting

### DIFF
--- a/aggregators/ophis/index.ts
+++ b/aggregators/ophis/index.ts
@@ -1,0 +1,20 @@
+import { FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { fetchOphisChainDay, OPHIS_CHAINS } from "../../helpers/ophis";
+
+const fetch = async (options: FetchOptions) => {
+  const dailyVolume = options.createBalances();
+  const row = await fetchOphisChainDay(options);
+  if (row) dailyVolume.addUSDValue(row.volumeUsd);
+  return { dailyVolume };
+};
+
+const adapter: SimpleAdapter = {
+  fetch,
+  start: "2026-05-14",
+  chains: Object.keys(OPHIS_CHAINS),
+  methodology: {
+    Volume: "USD value of settled Ophis-attributed trades. Ophis resolves each settled order's appData, deduplicates fills by trade UID, and prices the executed amount in its public reporting indexer.",
+  },
+};
+
+export default adapter;

--- a/aggregators/ophis/index.ts
+++ b/aggregators/ophis/index.ts
@@ -1,19 +1,26 @@
 import { FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { fetchOphisChainDay, OPHIS_CHAINS } from "../../helpers/ophis";
 
+const VOLUME_LABEL = "Settled Ophis Trades";
+
 const fetch = async (options: FetchOptions) => {
   const dailyVolume = options.createBalances();
   const row = await fetchOphisChainDay(options);
-  if (row) dailyVolume.addUSDValue(row.volumeUsd);
+  if (row) dailyVolume.addUSDValue(row.volumeUsd, VOLUME_LABEL);
   return { dailyVolume };
 };
+
+const volumeMethodology = "USD value of settled Ophis-attributed trades. Ophis resolves each settled order's appData, deduplicates fills by trade UID, and prices the executed amount in its public reporting indexer.";
 
 const adapter: SimpleAdapter = {
   fetch,
   start: "2026-05-14",
   chains: Object.keys(OPHIS_CHAINS),
   methodology: {
-    Volume: "USD value of settled Ophis-attributed trades. Ophis resolves each settled order's appData, deduplicates fills by trade UID, and prices the executed amount in its public reporting indexer.",
+    Volume: volumeMethodology,
+  },
+  breakdownMethodology: {
+    Volume: { [VOLUME_LABEL]: volumeMethodology },
   },
 };
 

--- a/fees/ophis/index.ts
+++ b/fees/ophis/index.ts
@@ -1,51 +1,48 @@
-import { CHAIN } from "../../helpers/chains";
 import { FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { fetchOphisChainDay, OPHIS_CHAINS } from "../../helpers/ophis";
 
-const FEE_RECIPIENT = "0x858f0F5eE954846D47155F5203c04aF1819eCeF8";
-const START = "2026-06-08";
-const SAFE_RECEIVED_EVENT = "event SafeReceived (address indexed sender, uint256 value)"
+const LABELS = {
+  FEES: "Ophis Volume Fees",
+  REVENUE: "Volume Fees Retained By Ophis",
+  SUPPLY_SIDE: "CoW Protocol Service Share",
+};
 
 const fetch = async (options: FetchOptions) => {
-  const SafeReceivedLogs = await options.getLogs({
-    target: FEE_RECIPIENT,
-    eventAbi: SAFE_RECEIVED_EVENT,
-  })
+  const dailyFees = options.createBalances();
+  const dailyRevenue = options.createBalances();
+  const dailyProtocolRevenue = options.createBalances();
+  const dailySupplySideRevenue = options.createBalances();
+  const row = await fetchOphisChainDay(options);
 
-  const dailyFees = options.createBalances()
-
-  for (const log of SafeReceivedLogs) {
-    dailyFees.addGasToken(log.value, 'Partner Fees')
+  if (row) {
+    dailyFees.addUSDValue(row.feesUsd, LABELS.FEES);
+    dailyRevenue.addUSDValue(row.revenueUsd, LABELS.REVENUE);
+    dailyProtocolRevenue.addUSDValue(row.revenueUsd, LABELS.REVENUE);
+    dailySupplySideRevenue.addUSDValue(row.supplySideRevenueUsd, LABELS.SUPPLY_SIDE);
   }
-
-  return { dailyFees, dailyRevenue: dailyFees, dailyProtocolRevenue: dailyFees };
+  return { dailyFees, dailyRevenue, dailyProtocolRevenue, dailySupplySideRevenue };
 };
 
 const methodology = {
-  Fees: "Flat partner fee taken on every Ophis swap (10 bps standard, 1 bp on stablecoin pairs), measured as gas tokens received by protocol safe wallet.",
-  Revenue: "All flat partner fees taken on every Ophis swap (10 bps standard, 1 bp on stablecoin pairs), measured as gas tokens received by protocol safe wallet is retained by Ophis.",
-  ProtocolRevenue: "All flat partner fees taken on every Ophis swap (10 bps standard, 1 bp on stablecoin pairs), measured as gas tokens received by protocol safe wallet is retained by Ophis.",
+  Fees: "Gross flat volume fee encoded in each settled Ophis order's appData, using the executed USD volume and that order's verified 1, 5, or 10 bps rate.",
+  Revenue: "Ophis retains 100% of its volume fee on Ophis-operated chains and 75% on CoW-hosted chains after CoW Protocol's 25% service share.",
+  ProtocolRevenue: "The volume-fee portion retained by the Ophis protocol.",
+  SupplySideRevenue: "CoW Protocol's 25% service share of Ophis partner fees on CoW-hosted chains; zero on Ophis-operated chains.",
 };
 
 const breakdownMethodology = {
-  Fees: {
-    'Partner Fees': 'Flat partner fee taken on every Ophis swap (10 bps standard, 1 bp on stablecoin pairs), measured as gas tokens received by protocol safe wallet.',
-  },
-  Revenue: {
-    'Partner Fees': 'All flat partner fees taken on every Ophis swap (10 bps standard, 1 bp on stablecoin pairs), measured as gas tokens received by protocol safe wallet is retained by Ophis.',
-  },
-  ProtocolRevenue: {
-    'Partner Fees': 'All flat partner fees taken on every Ophis swap (10 bps standard, 1 bp on stablecoin pairs), measured as gas tokens received by protocol safe wallet is retained by Ophis.',
-  },
-}
+  Fees: { [LABELS.FEES]: methodology.Fees },
+  Revenue: { [LABELS.REVENUE]: methodology.Revenue },
+  ProtocolRevenue: { [LABELS.REVENUE]: methodology.ProtocolRevenue },
+  SupplySideRevenue: { [LABELS.SUPPLY_SIDE]: methodology.SupplySideRevenue },
+};
 
 const adapter: SimpleAdapter = {
-  version: 2,
-  pullHourly: true,
   fetch,
+  start: "2026-05-14",
+  chains: Object.keys(OPHIS_CHAINS),
   methodology,
   breakdownMethodology,
-  start: START,
-  chains: [CHAIN.ETHEREUM, CHAIN.OPTIMISM, CHAIN.BSC, CHAIN.XDAI, CHAIN.POLYGON, CHAIN.BASE, CHAIN.ARBITRUM, CHAIN.AVAX, CHAIN.LINEA, CHAIN.INK, CHAIN.PLASMA],
 };
 
 export default adapter;

--- a/helpers/ophis.ts
+++ b/helpers/ophis.ts
@@ -1,0 +1,46 @@
+import { FetchOptions } from "../adapters/types";
+import { CHAIN } from "./chains";
+import fetchURL from "../utils/fetchURL";
+
+const URL = "https://rebates.ophis.fi/defillama";
+
+export const OPHIS_CHAINS: Record<string, number> = {
+  [CHAIN.ETHEREUM]: 1,
+  [CHAIN.OPTIMISM]: 10,
+  [CHAIN.BSC]: 56,
+  [CHAIN.XDAI]: 100,
+  [CHAIN.UNICHAIN]: 130,
+  [CHAIN.POLYGON]: 137,
+  [CHAIN.ROBINHOOD]: 4663,
+  [CHAIN.BASE]: 8453,
+  [CHAIN.PLASMA]: 9745,
+  [CHAIN.ARBITRUM]: 42161,
+  [CHAIN.AVAX]: 43114,
+  [CHAIN.INK]: 57073,
+  [CHAIN.LINEA]: 59144,
+};
+
+export interface OphisChainDay {
+  chainId: number;
+  volumeUsd: number;
+  feesUsd: number;
+  revenueUsd: number;
+  supplySideRevenueUsd: number;
+  trades: number;
+}
+
+interface OphisDayResponse {
+  ok: boolean;
+  date: string;
+  chains: OphisChainDay[];
+}
+
+export async function fetchOphisChainDay(options: FetchOptions): Promise<OphisChainDay | undefined> {
+  const chainId = OPHIS_CHAINS[options.chain];
+  if (chainId === undefined) throw new Error(`Unsupported Ophis chain ${options.chain}`);
+  const response: OphisDayResponse = await fetchURL(`${URL}?date=${options.dateString}`);
+  if (!response.ok || response.date !== options.dateString || !Array.isArray(response.chains)) {
+    throw new Error(`Invalid Ophis daily metrics response for ${options.dateString}`);
+  }
+  return response.chains.find((row) => row.chainId === chainId);
+}

--- a/helpers/ophis.ts
+++ b/helpers/ophis.ts
@@ -35,12 +35,30 @@ interface OphisDayResponse {
   chains: OphisChainDay[];
 }
 
+const dailyResponseCache = new Map<string, Promise<OphisDayResponse>>();
+
+function getOphisDayResponse(dateString: string): Promise<OphisDayResponse> {
+  let response = dailyResponseCache.get(dateString);
+  if (!response) {
+    response = fetchURL(`${URL}?date=${dateString}`).then((data: OphisDayResponse) => {
+      if (!data.ok || data.date !== dateString || !Array.isArray(data.chains)) {
+        throw new Error(`Invalid Ophis daily metrics response for ${dateString}`);
+      }
+      return data;
+    });
+    dailyResponseCache.set(dateString, response);
+  }
+  return response;
+}
+
+/**
+ * Fetches the Ophis daily metrics for `options.chain` on `options.dateString`.
+ * @param options DefiLlama fetch options identifying the requested chain and UTC date.
+ * @returns The matching chain metrics, or `undefined` when the daily response has no data for that chain.
+ */
 export async function fetchOphisChainDay(options: FetchOptions): Promise<OphisChainDay | undefined> {
   const chainId = OPHIS_CHAINS[options.chain];
   if (chainId === undefined) throw new Error(`Unsupported Ophis chain ${options.chain}`);
-  const response: OphisDayResponse = await fetchURL(`${URL}?date=${options.dateString}`);
-  if (!response.ok || response.date !== options.dateString || !Array.isArray(response.chains)) {
-    throw new Error(`Invalid Ophis daily metrics response for ${options.dateString}`);
-  }
+  const response = await getOphisDayResponse(options.dateString);
   return response.chains.find((row) => row.chainId === chainId);
 }


### PR DESCRIPTION
## Summary

Adds complete Ophis reporting to DefiLlama:

- DEX aggregator volume across all 13 supported EVM chains
- exact order-level gross fees
- Ophis protocol revenue
- CoW Protocol's hosted-chain service share as supply-side revenue
- a shared, validated daily reporting helper

This replaces the previous native-token Safe deposit proxy, which could not capture ERC-20 fees or each settled order's encoded fee rate.

## Data source and accounting

The adapter reads Ophis' public daily aggregate endpoint: https://rebates.ophis.fi/defillama

The underlying indexer resolves each settled order's appData, deduplicates fills by trade UID, uses the priced executed amount, and applies that order's explicit fee rate. On Ophis-operated chains Ophis retains 100% of the fee. On CoW-hosted chains Ophis retains 75% and CoW Protocol receives 25% as supply-side revenue.

The production endpoint implementation was reviewed and merged in https://github.com/ophis-fi/ophis/pull/1079.

## Verification

- TypeScript: `pnpm exec tsc --noEmit` passed
- Aggregator runner: `pnpm test aggregators ophis 2026-08-02` passed
- Fees runner: `pnpm test fees ophis 2026-08-02` passed
- Reconciled every UTC day from 2026-05-01 through 2026-08-03
- First activity: 2026-05-14
- 67/67 indexed trades reconciled
- $37,640.8742 / $37,640.8742 lifetime volume reconciled
- Every day and chain satisfies `fees = revenue + supplySideRevenue`
- Empty days return valid zero values

## Existing listing metadata correction

Ophis is already listed, but its current protocol record has a blank URL and Ethereum-only metadata. Please update the associated listing to:

- Website: https://ophis.fi
- X/Twitter: https://x.com/ophisfi
- Category: DEX Aggregator
- Chains: Ethereum, Optimism, BSC, Gnosis, Unichain, Polygon, Robinhood, Base, Plasma, Arbitrum, Avalanche, Ink, Linea
- TVL: keep the existing no-TVL/dummy treatment; Ophis is non-custodial and does not hold persistent user liquidity

Website: https://ophis.fi

Twitter: https://x.com/ophisfi
