### PR TITLE
uniswap helper: dont report pools as empty when every balance call fails

### DIFF
--- a/helpers/uniswap.ts
+++ b/helpers/uniswap.ts
@@ -10,6 +10,8 @@ const ZERO_ADDRESS = ADDRESSES.null;
 export async function filterPools({ api, pairs, createBalances, maxPairSize = 42, minUSDValue = 200 }: { api: ChainApi, pairs: IJSON<string[]>, createBalances: any, maxPairSize?: number, minUSDValue?: number }): Promise<IJSON<number>> {
   const balanceCalls = Object.entries(pairs).map(([pair, tokens]) => tokens.map(i => ({ target: i, params: pair }))).flat()
   const res = await api.multiCall({ abi: 'erc20:balanceOf', calls: balanceCalls, permitFailure: true, })
+  if (balanceCalls.length && res.every((bal: any) => bal == null))
+    throw new Error(`filterPools: every pooled balance call failed on ${api.chain}, refusing to report ${Object.keys(pairs).length} pools as empty`)
   const balances: Balances = createBalances()
   const pairBalances: IJSON<Balances> = {}
   res.forEach((bal, i) => {

--- a/helpers/uniswap.ts
+++ b/helpers/uniswap.ts
@@ -10,7 +10,7 @@ const ZERO_ADDRESS = ADDRESSES.null;
 export async function filterPools({ api, pairs, createBalances, maxPairSize = 42, minUSDValue = 200 }: { api: ChainApi, pairs: IJSON<string[]>, createBalances: any, maxPairSize?: number, minUSDValue?: number }): Promise<IJSON<number>> {
   const balanceCalls = Object.entries(pairs).map(([pair, tokens]) => tokens.map(i => ({ target: i, params: pair }))).flat()
   const res = await api.multiCall({ abi: 'erc20:balanceOf', calls: balanceCalls, permitFailure: true, })
-  if (balanceCalls.length && res.every((bal: any) => bal == null))
+  if (balanceCalls.length && res.every((bal) => bal == null))
     throw new Error(`filterPools: every pooled balance call failed on ${api.chain}, refusing to report ${Object.keys(pairs).length} pools as empty`)
   const balances: Balances = createBalances()
   const pairBalances: IJSON<Balances> = {}


### PR DESCRIPTION
found this chasing katana v3 on ronin, which published $0 on 07-23, 07-26, 07-28 and again today. it has 613 days of history and only 5 zero days ever, 4 of them in the last 12 days, against a median day of $869k. geckoterminal shows its top pool (FLOWER/WRON) traded on every one of those days: $2,863 on 07-23, $2,161 on 07-26, $2,729 on 07-28, $20,689 today. so the zeros arent real.

running the adapter locally for 07-26 gives $115.9k volume / $394 fees, so the code is fine and the production run just failed that day. the problem is what happens when it fails: filterPools does the pooled-balance multiCall with permitFailure, so if the rpc is having a bad minute every call comes back null, every pair reads as $0 pooled, everything gets filtered out, and getUniV3LogAdapter hits its empty-pairs early return and reports $0. a transient rpc failure becomes a permanent published zero instead of an error the runner can retry.

the fix only covers the case where there is nothing to interpret: calls were made and every single one failed. one successful call, even returning 0, keeps the current behaviour, so a genuinely dead fork whose pools are all under the $200 floor still filters down to nothing exactly like today. checked the three paths directly, all-fail throws, partial-fail returns the same pools it used to, no-pools returns empty.

filterPools2 goes through filterPools so it is covered too. harness on katana-v3 for 07-26 still gives 115.9k after the change, and solarbeam (v2 path, same helper) is unchanged.