### PR TITLE
add Liquidium fees and revenue

### DIFF
--- a/fees/liquidium/index.ts
+++ b/fees/liquidium/index.ts
@@ -3,7 +3,7 @@ import { CHAIN } from "../../helpers/chains";
 import { METRIC } from "../../helpers/metrics";
 import { httpGet } from "../../utils/fetchURL";
 
-const FEES_API = "https://app.liquidium.fi/api/sdk/v1/history/fees";
+const FEES_API = "https://app.liquidium.fi/api/defi-llama/fees";
 
 const COINGECKO_IDS: Record<string, string> = {
   BTC: "bitcoin",
@@ -18,11 +18,11 @@ type FeeHistoryItem = {
   poolId: string;
   chain: string;
   asset: string;
-  decimals: number;
+  decimals: unknown;
   ledgerId?: string;
-  fees: string;
-  revenue: string;
-  supplySideRevenue: string;
+  fees: unknown;
+  revenue: unknown;
+  supplySideRevenue: unknown;
 };
 
 type FeeHistoryResponse = {
@@ -30,8 +30,20 @@ type FeeHistoryResponse = {
   items: FeeHistoryItem[];
 };
 
-function toTokenAmount(rawAmount: string, decimals: number): number {
-  if (!/^\d+$/.test(rawAmount) || !Number.isInteger(decimals) || decimals < 0) {
+function parseRawTokenAmount(rawAmount: unknown): bigint {
+  if (typeof rawAmount !== "string" || !/^\d+$/.test(rawAmount)) {
+    throw new Error("Liquidium fees API returned an invalid token amount");
+  }
+
+  return BigInt(rawAmount);
+}
+
+function toTokenAmount(rawAmount: bigint, decimals: unknown): number {
+  if (
+    typeof decimals !== "number" ||
+    !Number.isInteger(decimals) ||
+    decimals < 0
+  ) {
     throw new Error("Liquidium fees API returned an invalid token amount");
   }
 
@@ -63,6 +75,16 @@ async function fetch(options: FetchOptions) {
   const dailySupplySideRevenue = options.createBalances();
 
   for (const item of response.items) {
+    const fees = parseRawTokenAmount(item.fees);
+    const revenue = parseRawTokenAmount(item.revenue);
+    const supplySideRevenue = parseRawTokenAmount(item.supplySideRevenue);
+
+    if (fees !== revenue + supplySideRevenue) {
+      throw new Error(
+        `Liquidium fees API returned inconsistent accounting for pool ${item.poolId}`,
+      );
+    }
+
     const coingeckoId = COINGECKO_IDS[item.asset];
     if (!coingeckoId) {
       throw new Error(`Missing CoinGecko ID for Liquidium asset ${item.asset}`);
@@ -70,17 +92,17 @@ async function fetch(options: FetchOptions) {
 
     dailyFees.addCGToken(
       coingeckoId,
-      toTokenAmount(item.fees, item.decimals),
+      toTokenAmount(fees, item.decimals),
       METRIC.BORROW_INTEREST,
     );
     dailyRevenue.addCGToken(
       coingeckoId,
-      toTokenAmount(item.revenue, item.decimals),
+      toTokenAmount(revenue, item.decimals),
       "Borrow Interest To Treasury",
     );
     dailySupplySideRevenue.addCGToken(
       coingeckoId,
-      toTokenAmount(item.supplySideRevenue, item.decimals),
+      toTokenAmount(supplySideRevenue, item.decimals),
       "Borrow Interest To Lenders",
     );
   }

--- a/fees/liquidium/index.ts
+++ b/fees/liquidium/index.ts
@@ -1,0 +1,128 @@
+import { FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import { METRIC } from "../../helpers/metrics";
+import { httpGet } from "../../utils/fetchURL";
+
+const FEES_API = "https://app.liquidium.fi/api/sdk/v1/history/fees";
+
+const COINGECKO_IDS: Record<string, string> = {
+  BTC: "bitcoin",
+  ETH: "ethereum",
+  ICP: "internet-computer",
+  SOL: "solana",
+  USDC: "usd-coin",
+  USDT: "tether",
+};
+
+type FeeHistoryItem = {
+  poolId: string;
+  chain: string;
+  asset: string;
+  decimals: number;
+  ledgerId?: string;
+  fees: string;
+  revenue: string;
+  supplySideRevenue: string;
+};
+
+type FeeHistoryResponse = {
+  success: boolean;
+  items: FeeHistoryItem[];
+};
+
+function toTokenAmount(rawAmount: string, decimals: number): number {
+  if (!/^\d+$/.test(rawAmount) || !Number.isInteger(decimals) || decimals < 0) {
+    throw new Error("Liquidium fees API returned an invalid token amount");
+  }
+
+  const amount = Number(rawAmount) / 10 ** decimals;
+  if (!Number.isFinite(amount)) {
+    throw new Error("Liquidium fees API returned an invalid token amount");
+  }
+  return amount;
+}
+
+async function fetch(options: FetchOptions) {
+  const query = new URLSearchParams({
+    from: new Date(options.startTimestamp * 1000).toISOString(),
+    to: new Date(options.endTimestamp * 1000).toISOString(),
+  });
+  const response = (await httpGet(`${FEES_API}?${query}`)) as FeeHistoryResponse;
+
+  if (response.success !== true || !Array.isArray(response.items)) {
+    throw new Error("Liquidium fees API returned an invalid response");
+  }
+
+  const dailyFees = options.createBalances();
+  const dailyRevenue = options.createBalances();
+  const dailySupplySideRevenue = options.createBalances();
+
+  for (const item of response.items) {
+    const coingeckoId = COINGECKO_IDS[item.asset];
+    if (!coingeckoId) {
+      throw new Error(`Missing CoinGecko ID for Liquidium asset ${item.asset}`);
+    }
+
+    dailyFees.addCGToken(
+      coingeckoId,
+      toTokenAmount(item.fees, item.decimals),
+      METRIC.BORROW_INTEREST,
+    );
+    dailyRevenue.addCGToken(
+      coingeckoId,
+      toTokenAmount(item.revenue, item.decimals),
+      "Borrow Interest To Treasury",
+    );
+    dailySupplySideRevenue.addCGToken(
+      coingeckoId,
+      toTokenAmount(item.supplySideRevenue, item.decimals),
+      "Borrow Interest To Lenders",
+    );
+  }
+
+  return {
+    dailyFees,
+    dailyUserFees: dailyFees,
+    dailyRevenue,
+    dailyProtocolRevenue: dailyRevenue,
+    dailySupplySideRevenue,
+  };
+}
+
+const methodology = {
+  UserFees: "Gross interest accrued by borrowers across Liquidium lending pools.",
+  Fees: "Gross interest accrued by borrowers across Liquidium lending pools.",
+  Revenue: "The reserve-factor share of borrower interest allocated to the Liquidium treasury.",
+  ProtocolRevenue: "The reserve-factor share of borrower interest allocated to the Liquidium treasury.",
+  SupplySideRevenue: "Borrower interest allocated to lenders after the Liquidium reserve-factor cut.",
+};
+
+const breakdownMethodology = {
+  UserFees: {
+    [METRIC.BORROW_INTEREST]: "Gross interest accrued by borrowers.",
+  },
+  Fees: {
+    [METRIC.BORROW_INTEREST]: "Gross interest accrued by borrowers.",
+  },
+  Revenue: {
+    "Borrow Interest To Treasury": "Borrow interest allocated to the Liquidium treasury through each pool's reserve factor.",
+  },
+  ProtocolRevenue: {
+    "Borrow Interest To Treasury": "Borrow interest allocated to the Liquidium treasury through each pool's reserve factor.",
+  },
+  SupplySideRevenue: {
+    "Borrow Interest To Lenders": "Borrow interest allocated to lenders after the reserve-factor cut.",
+  },
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  fetch,
+  chains: [CHAIN.ICP],
+  start: "2026-02-28",
+  pullHourly: true,
+  methodology,
+  breakdownMethodology,
+};
+
+export default adapter;

--- a/fees/liquidium/index.ts
+++ b/fees/liquidium/index.ts
@@ -35,7 +35,12 @@ function toTokenAmount(rawAmount: string, decimals: number): number {
     throw new Error("Liquidium fees API returned an invalid token amount");
   }
 
-  const amount = Number(rawAmount) / 10 ** decimals;
+  const divisor = 10 ** decimals;
+  if (!Number.isFinite(divisor)) {
+    throw new Error("Liquidium fees API returned an invalid token amount");
+  }
+
+  const amount = Number(rawAmount) / divisor;
   if (!Number.isFinite(amount)) {
     throw new Error("Liquidium fees API returned an invalid token amount");
   }


### PR DESCRIPTION
## Summary

This PR adds **Liquidium fees and revenue to DeFiLlama**.

It introduces a version 2 hourly fees adapter that:

- reports gross borrower interest as fees and user fees
- reports the reserve-factor share as protocol revenue
- reports the remaining interest as supply-side revenue
- discovers every pool returned by the Liquidium API, so new pools and chains are included automatically
- supports every asset currently exposed by the Liquidium lending canister: BTC, ETH, ICP, SOL, USDC, and USDT
- rejects malformed or non-reconciling API data before publishing metrics

## Data source

The adapter reads historical interval totals from the deployed public endpoint:

`https://app.liquidium.fi/api/defi-llama/fees`

The endpoint was implemented and merged in Liquidium-Inc/liquidium-cross-chain-app#475.

## Methodology

For each pool and interval:

- Fees = gross interest accrued by borrowers
- Revenue = reserve-factor share allocated to the Liquidium treasury
- Supply-side revenue = interest allocated to lenders after the reserve-factor share
- Fees = revenue + supply-side revenue

## Validation

- `pnpm ts-check`
- production endpoint returned HTTP 200 with five pool records for a completed UTC day
- every production record reconciled exactly using raw integer units
- DeFiLlama adapter harness validated the supported asset and metric breakdown
- TruffleHog secret scan
- full-diff and delta reviewer rounds

Website: https://liquidium.fi  
Twitter: https://twitter.com/LiquidiumFi