### PR TITLE
Add Openlaunch V2 + V3 (Stable)

### DIFF
--- a/dexs/openlaunch-v2.ts
+++ b/dexs/openlaunch-v2.ts
@@ -1,0 +1,71 @@
+import { Adapter, FetchOptions, FetchV2 } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+import { addOneToken } from "../helpers/prices";
+import { filterPools } from "../helpers/uniswap";
+
+const FACTORY = '0x701F02d3133E14a9dfd94C399586aC22A05bCa25'
+const SWAP_EVENT = 'event Swap(address indexed sender, uint256 amount0In, uint256 amount1In, uint256 amount0Out, uint256 amount1Out, address indexed to)'
+const FEE = 0.003 // 0.3%, PoolV2Pair.sol's fixed FEE_BPS constant (= 30 bps)
+
+// Openlaunch's own V2 factory (PoolFactoryV2) is functionally a Uniswap v2
+// fork but with a non-standard enumeration interface (a parameterless
+// getAllPools() returning the whole pool array at once, rather than the
+// classic allPairsLength()/allPairs(uint256) indexed-getter pair the generic
+// getUniV2LogAdapter helper's built-in pair-discovery assumes) -- written as
+// a custom fetch here instead, reusing the same underlying primitives
+// (filterPools, addOneToken, getLogs, createBalances) the generic helper
+// itself is built from. See projects/openlaunch/index.js in
+// DefiLlama-Adapters for the same distinction on the TVL side.
+const fetch: FetchV2 = async (fetchOptions: FetchOptions) => {
+  const { createBalances, getLogs, api } = fetchOptions
+
+  const pools: string[] = await api.call({
+    abi: 'function getAllPools() view returns (address[])',
+    target: FACTORY,
+  })
+
+  const dailyVolume = createBalances()
+  const dailyFees = createBalances()
+
+  if (!pools.length) return { dailyVolume, dailyFees }
+
+  const token0s = await api.multiCall({ abi: 'address:token0', calls: pools })
+  const token1s = await api.multiCall({ abi: 'address:token1', calls: pools })
+  const pairObject: Record<string, string[]> = {}
+  pools.forEach((pool, i) => { pairObject[pool] = [token0s[i], token1s[i]] })
+
+  const filteredPairs = await filterPools({ api, pairs: pairObject, createBalances })
+  const pairIds = Object.keys(filteredPairs)
+  if (!pairIds.length) return { dailyVolume, dailyFees }
+
+  const allLogs = await getLogs({ targets: pairIds, eventAbi: SWAP_EVENT, flatten: false })
+  allLogs.forEach((logs: any[], index: number) => {
+    const pool = pairIds[index]
+    const [token0, token1] = pairObject[pool]
+    logs.forEach((log: any) => {
+      addOneToken({ chain: CHAIN.STABLE, balances: dailyVolume, token0, token1, amount0: log.amount0In, amount1: log.amount1In })
+      addOneToken({ chain: CHAIN.STABLE, balances: dailyVolume, token0, token1, amount0: log.amount0Out, amount1: log.amount1Out })
+      addOneToken({ chain: CHAIN.STABLE, balances: dailyFees, token0, token1, amount0: Number(log.amount0In) * FEE, amount1: Number(log.amount1In) * FEE })
+      addOneToken({ chain: CHAIN.STABLE, balances: dailyFees, token0, token1, amount0: Number(log.amount0Out) * FEE, amount1: Number(log.amount1Out) * FEE })
+    })
+  })
+
+  // No protocol fee today -- 100% of swap fees go to LPs (see openlaunch-v3.ts).
+  return {
+    dailyVolume,
+    dailyFees,
+    dailySupplySideRevenue: dailyFees,
+  }
+}
+
+const adapter: Adapter = {
+  version: 2,
+  adapter: {
+    [CHAIN.STABLE]: {
+      fetch,
+      start: '2026-08-03',
+    },
+  },
+};
+
+export default adapter;

--- a/dexs/openlaunch-v3.ts
+++ b/dexs/openlaunch-v3.ts
@@ -1,0 +1,22 @@
+import { SimpleAdapter } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+import { getUniV3LogAdapter } from "../helpers/uniswap";
+
+// Real, unmodified UniswapV3Factory -- every launch's automatic single-sided
+// locked position and every permissionlessly-created general pool both go
+// through this same factory (see projects/openlaunch/index.js in
+// DefiLlama-Adapters for the TVL side of the same distinction).
+const adapter: SimpleAdapter = {
+  version: 2,
+  adapter: {
+    [CHAIN.STABLE]: {
+      // Protocol-fee switch on the real UniswapV3Factory is currently off
+      // (dormant capability, disclosed on /docs/safety) -- 100% of swap fees
+      // go to LPs today, 0% to the protocol.
+      fetch: getUniV3LogAdapter({ factory: '0xC837ab0f8919Fb47f17b7cD302d88895032e5908', revenueRatio: 0 }),
+      start: '2026-08-03',
+    },
+  },
+};
+
+export default adapter;


### PR DESCRIPTION
**NOTE**

#### Please enable "Allow edits by maintainers" while putting up the PR.

- [x] Allow edits by maintainers is enabled.

---

Adds V2 and V3 volume/fees adapters for Openlaunch (real forked Uniswap v2 + v3, permissionless DEX + safety-first launchpad), live on Stable Network mainnet.

- `openlaunch-v3.ts` — `getUniV3LogAdapter({ factory: '0xC837ab0f8919Fb47f17b7cD302d88895032e5908' })`. This is the real, unmodified `UniswapV3Factory`; every token launch's automatic single-sided locked position is created directly against it too (bypassing our own pool-creation wrapper), so it's covered without special-casing. **Testing note**: local `pnpm test` currently returns "No pairs found" for `factory:` mode since it reads from the shared pool-log cache that (per `helpers/uniswap.ts`) only gets populated once a TVL adapter is live for this factory — I've opened the matching TVL PR here: https://github.com/DefiLlama/DefiLlama-Adapters/pull/20346. I locally verified the event-parsing/volume-calculation logic itself is correct by temporarily swapping to `pools: [...]` with the one real pool that exists today, which ran clean with no errors.
- `openlaunch-v2.ts` — custom fetch (not the generic `getUniV2LogAdapter` helper) because our own V2 factory has a non-standard enumeration interface (`getAllPools()` returning the whole array, not the classic `allPairsLength`/`allPairs(uint256)` indexed shape the helper's built-in pair-discovery assumes). Reuses the same underlying primitives (`filterPools`, `addOneToken`, `getLogs`, `createBalances`). Tested locally via `pnpm test dexs openlaunch-v2` — runs clean, correctly reports zero volume (no V2 pools exist yet, only V3 so far).

Protocol-fee switch on the real `UniswapV3Factory` is currently off (dormant capability, disclosed on our own docs) — `revenueRatio: 0` on both, 100% of swap fees go to LPs today.

##### Name (to be shown on DefiLlama):
Openlaunch

##### Twitter Link:
https://x.com/OpenLaunchFI

##### List of audit links if any:
None — not audited. Disclosed openly, not gated on an audit happening later.

##### Website Link:
https://openlaunchfi.xyz

##### Logo (High resolution, will be shown with rounded borders):
https://www.openlaunchfi.xyz/icon.svg

##### Current TVL:
~$1 (brand new deployment, deployed 2026-08-03)

##### Treasury Addresses (if the protocol has treasury)
Stable mainnet: `0x1870F0B2521773c3621BCa5244E950900c38cc2C` (real Safe multisig, 2-of-3)

##### Chain:
Stable

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed): (https://api.coingecko.com/api/v3/coins/list)


##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)


##### Short Description (to be shown on DefiLlama):
Permissionless DEX + safety-first launchpad. No hidden mints, no admin backdoors — liquidity locked forever, verifiably, not by promise.

##### Token address and ticker if any:
None — Openlaunch itself has no token.

##### Category (full list at https://defillama.com/categories) \*Please choose only one:
Dexs

##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.):
None used.

##### Implementation Details: Briefly describe how the oracle is integrated into your project:
N/A

##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage:
N/A

##### forkedFrom (Does your project originate from another project):
Uniswap v2 and v3 (vendored source for the DEX/AMM engine; the launchpad and safety model are original).

##### methodology (what is being counted as tvl, how is tvl being calculated):
Swap volume and fees are read directly from `Swap` event logs emitted by every V2 pair and V3 pool created through Openlaunch's contracts on Stable mainnet.

##### Github org/user (Optional, if your code is open source, we can track activity):
Source is currently in a private repository; happy to open it up on request.

##### Does this project have a referral program?
No
