### PR TITLE
fix: correct Aster revenue attribution

### DIFF
--- a/fees/apollox/index.ts
+++ b/fees/apollox/index.ts
@@ -4,32 +4,47 @@ import { METRIC } from "../../helpers/metrics";
 import fetchURL from "../../utils/fetchURL";
 
 const FeesAndRevenueURL = "https://www.apollox.finance/bapi/futures/v1/public/future/apx/fee/all"
+const ASTER_BUYBACK_START_DATE = '2026-06-17';
+const ASTER_BUYBACK_SHARE = 0.99;
 
 const fetch = async (options: FetchOptions) => {
 
   const { data: { alpFeeVOFor24Hour } } = await fetchURL(FeesAndRevenueURL)
   const dailyFees = options.createBalances();
   dailyFees.addUSDValue(alpFeeVOFor24Hour.fee, METRIC.TRADING_FEES);
+  const dailyHoldersRevenue = options.dateString < ASTER_BUYBACK_START_DATE
+    ? options.createBalances()
+    : dailyFees.clone(ASTER_BUYBACK_SHARE, METRIC.TOKEN_BUY_BACK);
 
   return {
     dailyFees,
-    // dailyRevenue: alpFeeVOFor24Hour.revenue || 0,  // skipping this as we dont have a breakdown on how is returned as rebate
+    dailyRevenue: dailyHoldersRevenue,
+    dailyHoldersRevenue,
+    dailyProtocolRevenue: 0,
   };
 }
 
 const methodology = {
-  Fees: "All trading fees collected from perpetual futures trading, including opening/closing positions and funding fees"
+  Fees: "All trading fees collected from perpetual futures trading, including opening/closing positions and funding fees.",
+  Revenue: "From Jun 17, 2026, 99% of Aster perp trading fees is used to buy back ASTER via TWAP and distribute it to veASTER stakers. The undocumented remaining 1% is not attributed.",
+  HoldersRevenue: "From Jun 17, 2026, 99% of Aster perp trading fees is used to buy back ASTER via TWAP and distribute it to veASTER stakers. No holder allocation is backfilled before the policy start date.",
+  ProtocolRevenue: "No protocol revenue is reported; the undocumented remaining 1% is left unattributed."
 }
 
 const breakdownMethodology = {
   Fees: {
     [METRIC.TRADING_FEES]: "Trading fees paid by users on perpetual futures contracts, including position open/close fees and funding rate fees"
+  },
+  Revenue: {
+    [METRIC.TOKEN_BUY_BACK]: "99% of Aster perpetual trading fees from Jun 17, 2026 onward, used to buy back ASTER via TWAP for veASTER stakers"
+  },
+  HoldersRevenue: {
+    [METRIC.TOKEN_BUY_BACK]: "99% of Aster perpetual trading fees from Jun 17, 2026 onward, used to buy back ASTER via TWAP for veASTER stakers"
   }
 }
 
 const adapter: Adapter = {
   version: 1,
-  skipBreakdownValidation: true, // skipping breakdown validation as we dont have a breakdown on how much of the fee is returned as rebate
   fetch,
   start: '2023-07-17',
   chains: [CHAIN.OFF_CHAIN],

--- a/fees/aster-spot/index.ts
+++ b/fees/aster-spot/index.ts
@@ -45,21 +45,26 @@ async function fetch(options: FetchOptions) {
 
     return {
         dailyFees,
+        dailyRevenue: dailyHoldersRevenue,
         dailyHoldersRevenue,
     }
 }
 
 const methodology = {
-    Fees: "USDT listing fees (50K per listing) from permissionless token listings on Aster Spot, directed to ASTER stakers.",
-    HoldersRevenue: "Aster token strategic buybacks from platform fees. (Used to be burnt before Feb 2nd, 2026, now directed to ASTER stakers)"
+    Fees: "USDT listing fees (50K per listing) from permissionless token listings on Aster Spot. Listing fees are collected weekly and enter the platform-fee buyback program.",
+    Revenue: "Aster buybacks are treated as revenue. Buybacks were sent to the burn wallet through Feb 2, 2026; there was no tracked allocation from Feb 3 through Jun 16, 2026; from Jun 17, 2026, 99% of daily platform fees is used to buy back ASTER via TWAP for veASTER stakers.",
+    HoldersRevenue: "ASTER buybacks directed to token holders: buybacks were sent to the burn wallet through Feb 2, 2026; from Jun 17, 2026, 99% of daily platform fees is used to buy back ASTER via TWAP and distributed to veASTER stakers. This adapter currently captures ASTER transfers into the published buyback wallet indexed on BSC; it does not infer the execution contract from the ERC-20 Transfer sender, and Aster Chain transfers are not included because the repository has no supported Aster Chain source."
 }
 
 const breakdownMethodology = {
     Fees: {
-      "Listing Fees": "USDT listing fees (50K per listing) from permissionless token listings on Aster Spot, directed to ASTER stakers.",
+      "Listing Fees": "USDT listing fees (50K per listing) from permissionless token listings on Aster Spot. Listing fees are collected weekly and enter the platform-fee buyback program.",
+    },
+    Revenue: {
+      [METRIC.TOKEN_BUY_BACK]: "ASTER buybacks: burn-wallet purchases through Feb 2, 2026, and 99% of daily platform fees bought back via TWAP for veASTER stakers from Jun 17, 2026.",
     },
     HoldersRevenue: {
-      [METRIC.TOKEN_BUY_BACK]: "Aster tokens purchased by the protocol treasury through TWAP contract for strategic buybacks, funded by accumulated platform fees. (Used to be burnt before Feb 2nd, 2026, now directed to ASTER stakers)",
+      [METRIC.TOKEN_BUY_BACK]: "ASTER transfers into the published buyback wallet indexed on BSC: burn-wallet purchases through Feb 2, 2026, and the post-Jun 17, 2026 wallet settlement for the TWAP-funded veASTER buyback program. ERC-20 Transfer senders may be liquidity or processor contracts rather than the TWAP executor; Aster Chain transfers are out of scope.",
     }
 };
 


### PR DESCRIPTION
## Summary

Correct Aster fee and revenue attribution.

## Changes

- Add the missing `dailyRevenue` field to `fees/aster-spot`.
- Apply Aster’s official post–June 17, 2026 policy in `fees/apollox`: 99% of reported perpetual fees is attributed to ASTER holders.
- Update methodology and breakdown documentation.
- Keep Spot buyback tracking limited to the supported BSC source; no unsupported Aster Chain source is added.

## Methodology

Aster states that 99% of daily platform fees is used for ASTER buybacks via TWAP, with the purchased tokens distributed to veASTER stakers. The remaining 1% is left unattributed because its allocation is undocumented.

Reference: https://docs.asterdex.com/usdaster-token/tokenomics

