### PR TITLE
curve: fix missing avax pools, ng crypto-pool revenue, and volume def…

### DIFF
--- a/dexs/curve/api.ts
+++ b/dexs/curve/api.ts
@@ -13,6 +13,9 @@ interface CurveChainFees {
   fees_to_lp: number;
   fees_to_dao: number;
   fees_to_treasury: number;
+  // Yield Basis fees, already inside total_fees/fees_to_lp (those pools have admin_fee = 0).
+  // fees/yield-basis reports the same dollars.
+  lp_fees_yb: number;
   chain: string;
 }
 
@@ -33,8 +36,7 @@ export async function fetchCurveApiData(startOfDay: number): Promise<CurveFeesRe
     return cachedPromise.promise;
   }
 
-  // curve api accept exactly start and end timestamp of a given day
-  // other values always return 0
+  // api aggregates over the given [start, end], so pass exact day bounds
   const url = `${CURVE_API_BASE}?start=${startOfDay}&end=${startOfDay + 24 * 3600}`;
   const promise = httpGet(url).catch((err) => {
     // Clear cache on failure so retries can happen

--- a/dexs/curve/index.ts
+++ b/dexs/curve/index.ts
@@ -3,7 +3,7 @@ import { CHAIN } from "../../helpers/chains";
 import { ICurveDexConfig, ContractVersion, getCurveDexData } from "../../helpers/curve";
 import { fetchCurveApiData, getChainDataFromApiResponse } from "./api";
 
-const CurveDexConfigs: {[key: string]: ICurveDexConfig} = {
+const CurveDexConfigs: { [key: string]: ICurveDexConfig } = {
   [CHAIN.ETHEREUM]: {
     start: '2020-09-06',
     stable_factory: [
@@ -212,6 +212,12 @@ const CurveDexConfigs: {[key: string]: ICurveDexConfig} = {
     start: '2021-06-12',
     stable_factory: [
       '0xb17b674D9c5CB2e441F8e196a2f048A81355d031',
+    ],
+    factory_stable_ng: [
+      '0x6a8cbed756804b16e05e741edabd5cb544ae21bf',
+    ],
+    factory_twocrypto: [
+      '0x98EE851a00abeE0d95D08cF4CA2BdCE32aeaAF7F',
     ],
     customPools: {
       [ContractVersion.main]: [
@@ -533,14 +539,21 @@ const CurveDexConfigs: {[key: string]: ICurveDexConfig} = {
   // },
 }
 
+// admin fees: 90% veCRV holders, 10% DAO treasury
+const HOLDERS_SHARE_OF_ADMIN_FEES = 0.9
+const TREASURY_SHARE_OF_ADMIN_FEES = 0.1
+
+// only for chains the API doesn't cover - any other failure must propagate
+class ChainNotInApiError extends Error { }
+
 async function fetchFromApi(options: FetchOptions) {
-  if (options.startOfDay < 1704067200) throw Error('Can not fetch data from api older than 2024-01-01');
-  
+  if (options.startOfDay < 1704067200) throw new ChainNotInApiError('Can not fetch data from api older than 2024-01-01');
+
   const apiResponse = await fetchCurveApiData(options.startOfDay);
   const chainData = getChainDataFromApiResponse(apiResponse, options.chain);
 
   if (!chainData) {
-    throw new Error(`No data for chain ${options.chain} in API response`);
+    throw new ChainNotInApiError(`No data for chain ${options.chain} in API response`);
   }
 
   const dailyFees = options.createBalances();
@@ -554,9 +567,10 @@ async function fetchFromApi(options: FetchOptions) {
   dailyProtocolRevenue.addUSDValue(chainData.fees_to_treasury);
   dailySupplySideRevenue.addUSDValue(chainData.fees_to_lp);
   dailyHoldersRevenue.addUSDValue(chainData.fees_to_dao);
-  
+
   return {
-    dailyVolume: chainData.total_volume,
+    // trading_volume only - total_volume also counts add/remove liquidity
+    dailyVolume: chainData.trading_volume,
     dailyFees,
     dailyUserFees: dailyFees,
     dailyRevenue,
@@ -574,14 +588,15 @@ async function fetchFromOnChain(options: FetchOptions, config: ICurveDexConfig) 
   const dailyProtocolRevenue = options.createBalances();
   const dailySupplySideRevenue = options.createBalances();
   const dailyHoldersRevenue = options.createBalances();
-  
+
   const lpRevenue = swapFees.clone(1);
   lpRevenue.subtract(adminFees);
 
   dailyFees.add(swapFees);
   dailyRevenue.add(adminFees);
   dailySupplySideRevenue.add(lpRevenue);
-  dailyHoldersRevenue.add(adminFees);
+  dailyHoldersRevenue.add(adminFees.clone(HOLDERS_SHARE_OF_ADMIN_FEES));
+  dailyProtocolRevenue.add(adminFees.clone(TREASURY_SHARE_OF_ADMIN_FEES));
 
   return {
     dailyVolume,
@@ -594,19 +609,30 @@ async function fetchFromOnChain(options: FetchOptions, config: ICurveDexConfig) 
   };
 }
 
-export function getCurveExport(configs: {[key: string]: ICurveDexConfig}) {
+const methodology = {
+  Volume: "Value swapped in Curve pools, counting one side of each trade. Deposits and withdrawals are not counted as volume.",
+  Fees: "Swap fees paid by traders, set per pool (roughly 0.01% on stable pools, up to a few percent on volatile pools).",
+  UserFees: "Swap fees paid by traders.",
+  Revenue: "The share of swap fees taken by the protocol rather than paid to liquidity providers - usually half of the fee.",
+  ProtocolRevenue: "10% of the protocol's share, sent to the Curve DAO treasury.",
+  HoldersRevenue: "90% of the protocol's share, distributed to veCRV holders.",
+  SupplySideRevenue: "The share of swap fees paid to liquidity providers - usually half of the fee.",
+}
+
+export function getCurveExport(configs: { [key: string]: ICurveDexConfig }) {
   const adapter: SimpleAdapter = {
     version: 2,
+    methodology,
     adapter: Object.keys(configs).reduce((acc, chain) => {
       return {
         ...acc,
         [chain]: {
-          fetch: async function(options: FetchOptions): Promise<FetchResultV2> {
-            // Try API first, fall back to on-chain if chain not in API or API fails
+          fetch: async function (options: FetchOptions): Promise<FetchResultV2> {
+            // Fall back to onchain only when the chain isn't covered by the API.
             try {
               return await fetchFromApi(options);
             } catch (e) {
-              // Fall back to on-chain if API fails or chain not supported
+              if (!(e instanceof ChainNotInApiError)) throw e;
               return await fetchFromOnChain(options, configs[chain]);
             }
           },

--- a/fees/curve.ts
+++ b/fees/curve.ts
@@ -60,9 +60,12 @@ const fetch = async (options: FetchOptions) => {
   const dailyFees = options.createBalances();
   const dailyRevenue = options.createBalances();
   const dailyHoldersRevenue = options.createBalances();
-  
+
   dailyFees.add(dexData.dailyFees, LABELS.CurveDEXSwapFees);
   dailyFees.add(dailyBribesRevenue, LABELS.CurveBribesRewards);
+
+  // bribes are paid by gauge-vote bidders, not by users
+  const dailyUserFees = dexData.dailyFees.clone(1, LABELS.CurveDEXSwapFees);
 
   dailyRevenue.add(dexData.dailyRevenue, LABELS.CurveDEXSwapRevenue);
   dailyRevenue.add(dailyBribesRevenue, LABELS.CurveBribesRevenue);
@@ -72,7 +75,7 @@ const fetch = async (options: FetchOptions) => {
   
   return {
     dailyFees,
-    dailyUserFees: dailyFees,
+    dailyUserFees,
     dailyRevenue,
     dailyHoldersRevenue,
     dailyProtocolRevenue: dexData.dailyProtocolRevenue.clone(1, LABELS.CurveDEXFeesTreasury),
@@ -92,16 +95,16 @@ const adapter: SimpleAdapter = {
     return all
   }, {} as any),
   methodology: {
-    Fees: "Trading and liquidity fees from Curve pools (typically 0.01%-0.04%)",
-    UserFees: "Trading and liquidity fees paid by users",
-    Revenue: "Fees distributed to veCRV holders and protocol treasury",
-    ProtocolRevenue: "Fees allocated to the protocol treasury",
-    HoldersRevenue: "Fees distributed to veCRV governance token holders",
-    SupplySideRevenue: "Fees distributed to liquidity providers"
+    Fees: "Swap and liquidity fees charged by Curve pools, plus bribes paid to veCRV voters. Fee rates are set per pool - around 0.01%-0.04% on stable pools and up to a few percent on volatile pools.",
+    UserFees: "Swap and liquidity fees paid by traders. Excludes bribes, which are paid by third parties bidding for gauge votes, not by users.",
+    Revenue: "The share of pool fees kept by the protocol rather than paid to liquidity providers - usually half of the fee - plus bribes.",
+    ProtocolRevenue: "10% of the protocol's share of pool fees, sent to the Curve DAO treasury.",
+    HoldersRevenue: "90% of the protocol's share of pool fees, distributed to veCRV holders, plus all bribes.",
+    SupplySideRevenue: "The share of pool fees paid to liquidity providers - usually half of the fee."
   },
   breakdownMethodology: {
     Fees: {
-      [LABELS.CurveDEXSwapFees]: 'Trading and liquidity fees from Curve pools (typically 0.01%-0.04%)',
+      [LABELS.CurveDEXSwapFees]: 'Swap and liquidity fees charged by Curve pools',
       [LABELS.CurveBribesRewards]: 'All bribes rewards collected',
     },
     Revenue: {

--- a/helpers/curve/helpers.ts
+++ b/helpers/curve/helpers.ts
@@ -50,6 +50,8 @@ export interface ITokenExchangeEvent {
   tokens_sold: number;
   bought_id: number;
   tokens_bought: number;
+  // twocrypto/tricrypto only: exact fee charged, in the bought token
+  fee?: number;
 }
 
 export const CurveContractAbis: { [key: string]: any } = {
@@ -97,6 +99,8 @@ async function getVersionPools(options: FetchOptions, version: ContractVersion, 
   let allPoos: Array<string> = []
 
   for (const factory of factories) {
+    // keep permitFailure: factories deployed after the backfilled day legitimately revert.
+    // getAllPools catches the RPC-outage case instead.
     const pool_count = await options.api.call({
       target: factory,
       abi: CurveContractAbis[version].pool_count,
@@ -118,7 +122,8 @@ async function getVersionPools(options: FetchOptions, version: ContractVersion, 
     allPoos = allPoos.concat(pool_list);
   }
 
-  return allPoos;
+  // one pool can be listed by two factories - querying it twice would double count
+  return Array.from(new Set(allPoos.map(formatAddress)));
 }
 
 export async function getAllPools(options: FetchOptions, config: ICurveDexConfig): Promise<{[key: string]: Array<string>}> {
@@ -154,6 +159,14 @@ export async function getAllPools(options: FetchOptions, config: ICurveDexConfig
     customPools.factory_stable_ng = customPools.factory_stable_ng ? customPools.factory_stable_ng : []
     customPools.factory_stable_ng = customPools.factory_stable_ng.concat(await getVersionPools(options, ContractVersion.factory_stable_ng, config.factory_stable_ng));
     customPools.factory_stable_ng = customPools.factory_stable_ng.filter(p => !blacklistedPools.includes(p))
+  }
+
+  // all factories failing at once means a broken RPC, not an empty chain - don't report $0
+  const declaresFactories = Boolean(config.stable_factory || config.factory_crypto || config.factory_crvusd
+    || config.factory_twocrypto || config.factory_tricrypto || config.factory_stable_ng)
+  const poolsFound = Object.values(customPools).reduce((total, pools) => total + pools.length, 0)
+  if (declaresFactories && poolsFound === 0) {
+    throw new Error(`curve: every factory returned no pools on ${options.chain} - treating this as zero volume would be wrong`)
   }
 
   return customPools;
@@ -202,6 +215,12 @@ export async function getPoolTokens(options: FetchOptions, poolAddresses: Array<
     calls: poolAddresses,
     permitFailure: true,
   })
+  // ng crypto pools have no admin_fee(), only an immutable ADMIN_FEE constant
+  const adminFeeConstResults = await options.api.multiCall({
+    abi: 'uint256:ADMIN_FEE',
+    calls: poolAddresses,
+    permitFailure: true,
+  })
 
   for (let i = 0; i < poolAddresses.length; i++) {
     // coins
@@ -228,12 +247,15 @@ export async function getPoolTokens(options: FetchOptions, poolAddresses: Array<
       }
     }
 
+    // exactly one of the two resolves, depending on pool type
+    const adminFee = adminFeeResults[i] ?? adminFeeConstResults[i]
+
     pools[poolAddresses[i]] = {
       pool: poolAddresses[i],
       tokens: tokens,
       underlyingTokens: underlyingTokens,
       feeRate: feeResults[i] ? Number(feeResults[i]) / FEE_DENOMINATOR : 0,
-      adminFeeRate: adminFeeResults[i] ? Number(adminFeeResults[i]) / FEE_DENOMINATOR : 0,
+      adminFeeRate: adminFee ? Number(adminFee) / FEE_DENOMINATOR : 0,
     }
   }
 

--- a/helpers/curve/index.ts
+++ b/helpers/curve/index.ts
@@ -36,6 +36,7 @@ export async function getCurveDexData(options: FetchOptions, config: ICurveDexCo
           tokens_sold: Number(log.args.tokens_sold),
           bought_id: Number(log.args.bought_id),
           tokens_bought: Number(log.args.tokens_bought),
+          fee: log.args.fee === undefined ? undefined : Number(log.args.fee),
         })
       }
 
@@ -72,10 +73,17 @@ export async function getCurveDexData(options: FetchOptions, config: ICurveDexCo
     const amount1 = Number(event.tokens_bought)
 
     if (!token0 || !token1) continue
-  
+
     addOneToken({ chain: options.chain, balances: dailyVolume, token0, token1, amount0, amount1 })
-    addOneToken({ chain: options.chain, balances: swapFees, token0, token1, amount0: amount0 * feeRate, amount1: amount1 * feeRate })
-    addOneToken({ chain: options.chain, balances: adminFees, token0, token1, amount0: amount0 * feeRate * adminFeeRate, amount1: amount1 * feeRate * adminFeeRate })
+
+    if (event.fee !== undefined) {
+      // dynamic fee: the event carries the exact amount, spot fee() is off by up to 40%
+      swapFees.add(token1, event.fee)
+      adminFees.add(token1, event.fee * adminFeeRate)
+    } else {
+      addOneToken({ chain: options.chain, balances: swapFees, token0, token1, amount0: amount0 * feeRate, amount1: amount1 * feeRate })
+      addOneToken({ chain: options.chain, balances: adminFees, token0, token1, amount0: amount0 * feeRate * adminFeeRate, amount1: amount1 * feeRate * adminFeeRate })
+    }
   }
 
   for (const event of tokenExchangeUnderlyingEvents) {


### PR DESCRIPTION
Audits Curve's fee/volume logic against on-chain contracts and the Curve fees API.

### Changes

- Added the missing **Avalanche stable-ng** factory (54 pools).
- Fixed **NG crypto pools** by falling back to `ADMIN_FEE` when `admin_fee()` reverts (50% protocol share).
- Switched **twocrypto/tricrypto** fees from spot `fee()` reads to the actual fee emitted in swap events, matching dynamic-fee pools.
- Split admin fees **90% veCRV / 10% DAO treasury**, matching the current governance allocation.
- API path now uses **trading volume only**, excluding liquidity adds/removes to match the on-chain path and DEX methodology.
- Throw when every factory lookup fails instead of silently returning $0.
- Narrow API fallback to the expected "chain not supported" case.
- Exclude bribes from `dailyUserFees`, dedupe pool lists, and update methodology.

### Results

| Metric (2026-07-25) | Before | After |
|---|---:|---:|
| Avalanche volume | $2.23k | **$37.18k** |
| Avalanche fees | $0.91 | **$36.00** |
| Ethereum volume | 11.06M | **7.81M** |
| Gnosis volume | 821.65k | **407.58k** |
| Plasma / Monad / Avalanche protocol revenue | 0 | **9.35 / 4.35 / 1.79** |