### PR TITLE
feat(primit-perps): add fees + revenue at flat 4 bps

### DIFF
--- a/dexs/primit-perps/index.ts
+++ b/dexs/primit-perps/index.ts
@@ -30,6 +30,8 @@ const methodology = {
     "100% of trading fees collected on Primit-native pairs accrue to the protocol. No LP or affiliate revenue share is applied to this pair set, so Revenue equals Fees.",
   ProtocolRevenue:
     "Same as Revenue. All protocol-native trading fees stay with the protocol.",
+  SupplySideRevenue:
+    "Zero. Primit-native pairs are not backed by an external liquidity-provider vault today — no maker rebate, no LP share, no affiliate share — so nothing from the fee stream accrues to a supply side. Preserves the DeFiLlama contract dailyFees = dailyRevenue + dailySupplySideRevenue.",
 };
 
 const SCALE_18 = 10n ** 18n;
@@ -82,6 +84,11 @@ const fetch = async (options: FetchOptions) => {
     dailyFees,
     dailyRevenue,
     dailyProtocolRevenue: dailyRevenue,
+    // 100% of fees are protocol revenue on Primit-native pairs today —
+    // no maker rebate, no LP vault, no affiliate share — so the supply
+    // side accrues nothing. Explicit 0 keeps the DeFiLlama contract
+    // dailyFees = dailyRevenue + dailySupplySideRevenue satisfied.
+    dailySupplySideRevenue: 0,
   };
 };
 

--- a/dexs/primit-perps/index.ts
+++ b/dexs/primit-perps/index.ts
@@ -6,8 +6,10 @@ import { CHAIN } from "../../helpers/chains";
 // Every fill matched on Primit's own engine is emitted as a `TradeRecorded`
 // event by our TradeRecorder contract. This adapter walks the day's event
 // range and sums `price * amount` (both 1e18 fixed-point) to derive daily
-// USD notional. No off-chain data source — anything DeFiLlama shows for
-// Primit is independently reconstructable from AVAX C-Chain event logs.
+// USD notional, then applies the protocol's flat 4 bps trading fee to
+// report fees and revenue. No off-chain data source — anything DeFiLlama
+// shows for Primit is independently reconstructable from AVAX C-Chain
+// event logs.
 //
 // Volume routed through Orderly Network (BTC/ETH/etc) is attributed
 // separately by DeFiLlama's factory/orderly.ts under broker_id=primit
@@ -22,9 +24,17 @@ const abi = {
 const methodology = {
   Volume:
     "Sum of `price * amount` for every TradeRecorded event emitted by Primit's TradeRecorder contract (0xC005A9bb11f162329f3EfCCc35F69F9Bb635EeC6 on Avalanche C-Chain) during the UTC day, excluding self-trades where taker == maker. Both `price` and `amount` are 1e18 fixed-point, so the product is scaled by 1e36 and normalized down to floating USD before returning. Data is 100% reconstructable on-chain — no dependency on any Primit-operated HTTP endpoint. Volume routed through Orderly Network (BTC/ETH/etc via broker_id=primit) is attributed separately by factory/orderly.ts and NOT double-counted here.",
+  Fees:
+    "Flat 4 bps (0.04%) trading fee applied to daily USD volume matched on Primit's own engine. Computed as `dailyVolume * 4 / 10000` on the same volume figure derived above.",
+  Revenue:
+    "100% of trading fees collected on Primit-native pairs accrue to the protocol. No LP or affiliate revenue share is applied to this pair set, so Revenue equals Fees.",
+  ProtocolRevenue:
+    "Same as Revenue. All protocol-native trading fees stay with the protocol.",
 };
 
 const SCALE_18 = 10n ** 18n;
+const FEE_RATE_BPS = 4n;
+const BPS_DENOM = 10_000n;
 
 const fetch = async (options: FetchOptions) => {
   const logs: any[] = await options.getLogs({
@@ -49,15 +59,30 @@ const fetch = async (options: FetchOptions) => {
 
   // Convert bigint → float in two parts to avoid Number precision loss.
   // Number can only represent integers exactly up to 2^53 (~9e15); a
-  // single-shot `Number(totalWeiUsd) / 1e18` silently rounds once the
-  // day's wei-USD sum exceeds that (≈ 0.009 USD in wei-USD terms — i.e.
-  // essentially always). Split into whole USD (safe up to ~9 quadrillion
-  // USD/day) plus sub-USD fraction to keep full precision.
-  const wholeUsd = Number(totalWeiUsd / SCALE_18);
-  const fracUsd = Number(totalWeiUsd % SCALE_18) / 1e18;
-  const dailyVolume = wholeUsd + fracUsd;
+  // single-shot `Number(weiUsd) / 1e18` silently rounds once the day's
+  // wei-USD sum exceeds that (≈ 0.009 USD in wei-USD terms — i.e. always
+  // for any non-trivial day). Split into whole USD (safe up to ~9
+  // quadrillion USD/day) plus sub-USD fraction to keep full precision.
+  const toUsdFloat = (weiUsd: bigint) =>
+    Number(weiUsd / SCALE_18) + Number(weiUsd % SCALE_18) / 1e18;
 
-  return { dailyVolume };
+  const dailyVolume = toUsdFloat(totalWeiUsd);
+
+  // Apply flat 4 bps trading fee to the same wei-USD volume figure.
+  // Perform the multiplication in bigint before normalizing to Number to
+  // avoid a second precision loss.
+  const feesWeiUsd = (totalWeiUsd * FEE_RATE_BPS) / BPS_DENOM;
+  const dailyFees = toUsdFloat(feesWeiUsd);
+  // 100% of fees are protocol revenue (no LP / affiliate share on
+  // Primit-native pairs today).
+  const dailyRevenue = dailyFees;
+
+  return {
+    dailyVolume,
+    dailyFees,
+    dailyRevenue,
+    dailyProtocolRevenue: dailyRevenue,
+  };
 };
 
 const adapter: SimpleAdapter = {


### PR DESCRIPTION
## Summary

Extends the previously-merged \`dexs/primit-perps\` adapter (#8513) beyond \`dailyVolume\` to also report \`dailyFees\` and \`dailyRevenue\`, derived from the protocol's flat **4 bps (0.04%)** trading fee applied to the same on-chain volume figure.

## Changes

Single file: \`dexs/primit-perps/index.ts\` (+35 / -10 lines).

- \`dailyFees = dailyVolume * 4 / 10000\`
- \`dailyRevenue = dailyFees\` (100% goes to protocol; no LP or affiliate revenue share on Primit-native pairs today)
- \`dailyProtocolRevenue\` mirrors \`dailyRevenue\` for the same reason
- BigInt multiplication done before splitting to Number to avoid the same 2^53 precision loss the volume-side computation already handles

## Methodology (added in-file)

**Fees**: Flat 4 bps (0.04%) trading fee applied to daily USD volume matched on Primit's own engine. Computed as \`dailyVolume * 4 / 10000\` on the same volume figure already reported.

**Revenue**: 100% of trading fees collected on Primit-native pairs accrue to the protocol. No LP or affiliate revenue share is applied to this pair set, so Revenue equals Fees.

**ProtocolRevenue**: Same as Revenue.

## Why formula-based, not per-trade takerFee/makerFee

The \`TradeRecorded\` event does carry \`int256 takerFee, int256 makerFee\` fields, but this adapter uses the protocol's public fee schedule (4 bps flat) applied to the on-chain volume — the same reasoning many other exchange adapters use, and stable across any internal fee-schedule refactors. If DeFiLlama prefers per-event fee summation, happy to switch in a follow-up.

## Coexistence with \`factory/orderly.ts primit\`

The existing \`factory/orderly.ts\` \`broker_id=primit\` entry (#8115) reports fees for the Orderly-routed portion of Primit volume (BTC/ETH/etc). This adapter covers the disjoint Primit-native pair set. **No double-counting** — the two data sources are additive at the fill level.

## Test plan

- [ ] Review methodology text (Fees / Revenue / ProtocolRevenue sections)
- [ ] Confirm the flat-rate approach is acceptable (vs event \`takerFee\`+\`makerFee\` summation)
- [ ] CI \`test\` job should print non-zero dailyFees for a recent day (~\`dailyVolume * 0.0004\`)