### PR TITLE
feat: add Trending builder-code fees adapter

### DIFF
--- a/dexs/trending.ts
+++ b/dexs/trending.ts
@@ -1,0 +1,33 @@
+import { CHAIN } from "../helpers/chains";
+import { fetchBuilderCodeRevenue } from "../helpers/hyperliquid";
+import { FetchOptions, SimpleAdapter } from "../adapters/types";
+
+const HL_BUILDER_ADDRESS = "0xde579b19e57fa3e83305ebb50033b25c7f6ea2e8";
+
+const fetchHyperliquid = async (options: FetchOptions) => {
+  const { dailyVolume, dailyFees, dailyRevenue, dailyProtocolRevenue } =
+    await fetchBuilderCodeRevenue({
+      options,
+      builder_address: HL_BUILDER_ADDRESS,
+    });
+  return { dailyVolume, dailyFees, dailyRevenue, dailyProtocolRevenue };
+};
+
+const methodology = {
+  Fees: "Trading fees paid by users when executing perps through the Trending interface on Hyperliquid.",
+  Revenue: "Builder fees collected by Trending for trades executed through its non-custodial interface.",
+  ProtocolRevenue: "Builder fees collected by Trending for trades executed through its non-custodial interface.",
+};
+
+const adapter: SimpleAdapter = {
+  adapter: {
+    [CHAIN.HYPERLIQUID]: {
+      fetch: fetchHyperliquid,
+      start: "2026-07-21",
+    },
+  },
+  methodology,
+  doublecounted: true,
+};
+
+export default adapter;


### PR DESCRIPTION
Adds a Hyperliquid builder-code fees adapter for **Trending** (https://trending.trading), a non-custodial chart-native perpetuals interface built on Hyperliquid builder codes.

**Details**
- Builder address: `0xde579b19e57fa3e83305ebb50033b25c7f6ea2e8`
- Chain: Hyperliquid
- Start: `2026-07-21` (first day the builder address was active)
- Uses the existing `fetchBuilderCodeRevenue` helper from `helpers/hyperliquid`, matching the shape of the merged builder-code adapters (`dexs/dextrabot.ts`, `dexs/hypersignals.ts`)
- `doublecounted: true`, since builder fees are also counted at the Hyperliquid venue

**Methodology**
- Fees: trading fees paid by users executing perps through the Trending interface
- Revenue / ProtocolRevenue: builder fees collected by Trending

No TVL and no venue-wide Hyperliquid volume is claimed — builder fees only.

**Verification**
Daily builder-fill files from Hyperliquid's official per-builder endpoint were collected for seven consecutive completed UTC days before opening this PR. Volume is currently low/zero on some days; the adapter reports those honestly rather than omitting them.

```
pnpm test fees trending YYYY-MM-DD
```