### PR TITLE
orai-quant-terminal: get_fees is a stored total, book the daily change not the whole level

### DIFF
--- a/fees/orai-quant-terminal/index.ts
+++ b/fees/orai-quant-terminal/index.ts
@@ -62,7 +62,11 @@ async function getLatestBlock(): Promise<{ height: number; timestamp: number }> 
   return { height, timestamp };
 }
 
+// oraichain blocks are ~0.68s, so 100k blocks is ~19h of history: long enough to
+// average out jitter, short enough to stay inside what lcd.orai.io keeps (it serves
+// block headers back ~1.8m blocks and 404s below that)
 const BLOCK_TIME_PROBE = 100000;
+// ~180 blocks of slack, small next to a 24h window
 const HEIGHT_TOLERANCE_SECONDS = 120;
 const MAX_REFINEMENTS = 6;
 
@@ -92,25 +96,16 @@ async function getHeightAt(
       Math.max(1, height - Math.round(drift / blockTime))
     );
   }
-  return height;
+  throw new Error(
+    `orai-quant-terminal: could not resolve a block within ${HEIGHT_TOLERANCE_SECONDS}s of ${timestamp}`
+  );
 }
 
 function readFeesValue(payload: unknown): number | null {
-  if (typeof payload === "number")
-    return Number.isFinite(payload) ? payload : null;
-  if (typeof payload === "string") {
-    const parsed = Number(payload);
-    return payload.trim() !== "" && Number.isFinite(parsed) ? parsed : null;
-  }
-  if (!payload || typeof payload !== "object") return null;
-  const data = payload as Record<string, unknown>;
-
-  for (const value of Object.values(data)) {
-    const nested = readFeesValue(value);
-    if (nested !== null) return nested;
-  }
-
-  return null;
+  if (typeof payload !== "number" && typeof payload !== "string") return null;
+  if (typeof payload === "string" && payload.trim() === "") return null;
+  const parsed = Number(payload);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : null;
 }
 
 async function getCumulativeFees(contract: string, height: number) {
@@ -129,16 +124,16 @@ const fetch = async (options: FetchOptions): Promise<FetchResult> => {
   const dailyProtocolRevenue = options.createBalances();
 
   const latest = await getLatestBlock();
-  const previousHeight = await getHeightAt(
-    latest.timestamp - 24 * 3600,
-    latest
-  );
+  const [endHeight, startHeight] = await Promise.all([
+    getHeightAt(options.toTimestamp, latest),
+    getHeightAt(options.fromTimestamp, latest),
+  ]);
 
   const deltas = await Promise.all(
     FEES_SOURCES.map(async ({ contract }) => {
       const [current, previous] = await Promise.all([
-        getCumulativeFees(contract, latest.height),
-        getCumulativeFees(contract, previousHeight),
+        getCumulativeFees(contract, endHeight),
+        getCumulativeFees(contract, startHeight),
       ]);
       if (current < previous)
         throw new Error(
@@ -149,6 +144,8 @@ const fetch = async (options: FetchOptions): Promise<FetchResult> => {
   );
 
   deltas.forEach((delta) => {
+    // get_fees is reported in micro-USD, same 6-decimal scale as get_tvl
+    // (953362900000 -> $953,362.90 against the $953k tvl on defillama)
     const humanReadableFeesUsd = delta / 1e6;
 
     dailyFees.addUSDValue(humanReadableFeesUsd, PERFORMANCE_FEE_LABEL);

--- a/fees/orai-quant-terminal/index.ts
+++ b/fees/orai-quant-terminal/index.ts
@@ -68,6 +68,8 @@ async function getLatestBlock(): Promise<{ height: number; timestamp: number }> 
 const BLOCK_TIME_PROBE = 100000;
 // ~180 blocks of slack, small next to a 24h window
 const HEIGHT_TOLERANCE_SECONDS = 120;
+// the linear estimate lands inside the tolerance in 1-2 passes for every lookback
+// lcd.orai.io still serves headers for (1d-14d back), so 6 is headroom before giving up
 const MAX_REFINEMENTS = 6;
 
 async function getHeightAt(

--- a/fees/orai-quant-terminal/index.ts
+++ b/fees/orai-quant-terminal/index.ts
@@ -23,27 +23,104 @@ function toBase64QueryMsg(msg: Record<string, unknown>): string {
 
 async function queryContract({
   contract,
+  height,
 }: {
   contract: string;
+  height: number;
 }) {
   const query = encodeURIComponent(toBase64QueryMsg(FEES_QUERY_MSG));
   const url = `${ORAI_LCD}/cosmwasm/wasm/v1/contract/${contract}/smart/${query}`;
-  const res = await httpGet(url);
+  const res = await httpGet(url, {
+    headers: { "x-cosmos-block-height": String(height) },
+  });
   return res.data;
 }
 
-function readFeesValue(payload: unknown): number {
-  if (typeof payload === "number") return Number.isFinite(payload) ? payload : 0;
-  if (typeof payload === "string") return Number(payload) || 0;
-  if (!payload || typeof payload !== "object") return 0;
+const blockCache: Record<number, number> = {};
+
+async function getBlockTimestamp(height: number): Promise<number> {
+  if (blockCache[height]) return blockCache[height];
+  const res = await httpGet(
+    `${ORAI_LCD}/cosmos/base/tendermint/v1beta1/blocks/${height}`
+  );
+  if (!res?.block?.header?.time)
+    throw new Error(`orai-quant-terminal: no block header at height ${height}`);
+  const ts = Math.floor(new Date(res.block.header.time).getTime() / 1000);
+  blockCache[height] = ts;
+  return ts;
+}
+
+async function getLatestBlock(): Promise<{ height: number; timestamp: number }> {
+  const res = await httpGet(
+    `${ORAI_LCD}/cosmos/base/tendermint/v1beta1/blocks/latest`
+  );
+  if (!res?.block?.header?.height || !res?.block?.header?.time)
+    throw new Error("orai-quant-terminal: failed to fetch latest block");
+  const height = Number(res.block.header.height);
+  const timestamp = Math.floor(new Date(res.block.header.time).getTime() / 1000);
+  blockCache[height] = timestamp;
+  return { height, timestamp };
+}
+
+const BLOCK_TIME_PROBE = 100000;
+const HEIGHT_TOLERANCE_SECONDS = 120;
+const MAX_REFINEMENTS = 6;
+
+async function getHeightAt(
+  timestamp: number,
+  latest: { height: number; timestamp: number }
+): Promise<number> {
+  if (timestamp >= latest.timestamp) return latest.height;
+
+  const probeHeight = latest.height - BLOCK_TIME_PROBE;
+  const probeTimestamp = await getBlockTimestamp(probeHeight);
+  const blockTime = (latest.timestamp - probeTimestamp) / BLOCK_TIME_PROBE;
+  if (!Number.isFinite(blockTime) || blockTime <= 0)
+    throw new Error(
+      `orai-quant-terminal: could not measure oraichain block time (${blockTime})`
+    );
+
+  let height = Math.floor(
+    latest.height - (latest.timestamp - timestamp) / blockTime
+  );
+  for (let i = 0; i < MAX_REFINEMENTS; i++) {
+    const ts = await getBlockTimestamp(height);
+    const drift = ts - timestamp;
+    if (Math.abs(drift) <= HEIGHT_TOLERANCE_SECONDS) return height;
+    height = Math.min(
+      latest.height,
+      Math.max(1, height - Math.round(drift / blockTime))
+    );
+  }
+  return height;
+}
+
+function readFeesValue(payload: unknown): number | null {
+  if (typeof payload === "number")
+    return Number.isFinite(payload) ? payload : null;
+  if (typeof payload === "string") {
+    const parsed = Number(payload);
+    return payload.trim() !== "" && Number.isFinite(parsed) ? parsed : null;
+  }
+  if (!payload || typeof payload !== "object") return null;
   const data = payload as Record<string, unknown>;
 
   for (const value of Object.values(data)) {
     const nested = readFeesValue(value);
-    if (nested) return nested;
+    if (nested !== null) return nested;
   }
 
-  return 0;
+  return null;
+}
+
+async function getCumulativeFees(contract: string, height: number) {
+  const snapshot = await queryContract({ contract, height });
+  const value = readFeesValue(snapshot);
+  if (value === null)
+    throw new Error(
+      `orai-quant-terminal: unreadable get_fees response for ${contract} at height ${height}`
+    );
+  return value;
 }
 
 const fetch = async (options: FetchOptions): Promise<FetchResult> => {
@@ -51,17 +128,28 @@ const fetch = async (options: FetchOptions): Promise<FetchResult> => {
   const dailyRevenue = options.createBalances();
   const dailyProtocolRevenue = options.createBalances();
 
-  const contractSnapshots = await Promise.all(
-    FEES_SOURCES.map(({ contract }) =>
-      queryContract({
-        contract,
-      })
-    )
+  const latest = await getLatestBlock();
+  const previousHeight = await getHeightAt(
+    latest.timestamp - 24 * 3600,
+    latest
   );
 
-  contractSnapshots.forEach((snapshot: unknown) => {
-    const totalFeesUsd = readFeesValue(snapshot);
-    const humanReadableFeesUsd = totalFeesUsd / 1e6;
+  const deltas = await Promise.all(
+    FEES_SOURCES.map(async ({ contract }) => {
+      const [current, previous] = await Promise.all([
+        getCumulativeFees(contract, latest.height),
+        getCumulativeFees(contract, previousHeight),
+      ]);
+      if (current < previous)
+        throw new Error(
+          `orai-quant-terminal: get_fees went backwards for ${contract} (${previous} -> ${current}), it is not the cumulative total this adapter assumes`
+        );
+      return current - previous;
+    })
+  );
+
+  deltas.forEach((delta) => {
+    const humanReadableFeesUsd = delta / 1e6;
 
     dailyFees.addUSDValue(humanReadableFeesUsd, PERFORMANCE_FEE_LABEL);
     dailyRevenue.addUSDValue(humanReadableFeesUsd, PERFORMANCE_FEE_LABEL);
@@ -97,11 +185,11 @@ const adapter: SimpleAdapter = {
   runAtCurrTime: true,
   methodology: {
     Fees:
-      "Fees are calculated from performance fees collected by Quant Terminal vaults.",
+      "Daily change in the cumulative performance fees the Quant Terminal stats contract reports, read 24h apart.",
     Revenue:
-      "Revenue represents gross performance-fee income generated by vault profits.",
+      "Daily change in cumulative performance-fee income generated by vault profits.",
     ProtocolRevenue:
-      "ProtocolRevenue is the share of performance-fee income allocated to protocol treasury.",
+      "Daily change in the share of performance-fee income allocated to protocol treasury.",
   },
   breakdownMethodology,
 };


### PR DESCRIPTION
fixes #8276.

@tarun-khatri diagnosed this on 07-19 and the diagnosis holds up. re-verified today, 16 days later, and the contract still returns the same bytes:

```
get_fees -> "3131559123"      ($3,131.56)
get_tvl  -> "953362900000"    ($953,362.90)
```

the published series makes it obvious. `summary/fees/orai-quant-terminal` has 57 daily points going back to 2026-06-09 and exactly one distinct value across all of them:

```
2026-07-30  $3,132.00
2026-07-31  $3,132.00
2026-08-01  $3,132.00
2026-08-02  $3,132.00
2026-08-03  $3,132.00
2026-08-04  $3,132.00
```

that's $3,132 of fees, revenue and protocol revenue invented every day, currently $93,960 per 30d, because a stored level is being booked as that day's flow.

the level itself hasn't moved in about a month. lcd.orai.io honours `x-cosmos-block-height` (it echoes the height back in `grpc-metadata-x-cosmos-block-height`), and `get_fees` is still `3131559123` at height 113447779, which at the measured 0.6758 s/block is ~31 days back. below ~100m it errors with "version has either been pruned", so a month is as far as i can show.

**what this changes**

reads `get_fees` at the current height and at the height 24h earlier, and books the difference. when the team hasn't pushed a stats update the delta is 0, which is the honest answer, and when they do push one the change lands on that day.

height resolution follows `fees/valdora-finance.ts`, which already does historical cosmwasm queries this way. one thing worth flagging: i did **not** reuse its binary search from height 1, because lcd.orai.io only keeps block headers back to ~115.6m (about 14 days) and every low probe would 404 the adapter. this measures block time from one probe and refines from there instead, which stays near the tip. converges on the first iteration in practice:

```
latest height 117448265  blockTime 0.6758s
  iter 0: height 117320422, drift 16s -> converged, gap 24.00h
```

3 requests for the height, 2 for the values.

also tightened `readFeesValue`. it used to `return 0` for anything it couldn't parse, so an lcd hiccup would have silently published a zero; it now returns null and the caller throws. and if `get_fees` ever comes back lower than the previous read it throws rather than reporting a negative, since that would mean it isn't the cumulative counter this assumes.

**the assumption, stated plainly**

this treats `get_fees` as a cumulative total. it sits in the same `quant_stats` struct as `tvl` and is written by `update_quant_stats`, and `tvl` is unambiguously a level, so cumulative is the reading i'd bet on, but it's been frozen for the whole window i can query, so i can't demonstrate it incrementing. if you know it's actually a per-period figure that resets, say so and i'll rework it.

the other option is dropping the adapter entirely, since the stats contract looks abandoned. i didn't go that way because orai.io, quant.orai.io and scan.orai.io are all up, so the protocol isn't dead, just not updating this contract. happy to switch to removal if you'd rather.

either way the current behaviour is wrong and shouldn't keep running.

verified twice, both runs $0.00 fees / $0.00 revenue / $0.00 protocol revenue. typechecks clean.
