### PR TITLE
hinkal: throw when the relayer returns null instead of publishing it as zero volume

### DIFF
--- a/aggregators/hinkal/index.ts
+++ b/aggregators/hinkal/index.ts
@@ -1,4 +1,3 @@
-import { start } from "repl";
 import { Adapter, FetchOptions } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 import fetchURL from "../../utils/fetchURL";
@@ -20,11 +19,17 @@ const fetch = async (options: FetchOptions) => {
   const chainId = chainConfig[options.chain].id;
   const url = `${VOLUME_URL}/totalVolume/${startOfDay}/${endTimestamp}/${chainId}`;
   const data = await fetchURL(url);
-  if (data?.dailyVolume === undefined) {
-    console.error(`hinkal: no volume returned for chain ${chainId} (${url})`);
-  }
+  const reported = data?.dailyVolume;
+  const dailyVolume =
+    reported == null || (typeof reported === "string" && reported.trim() === "")
+      ? NaN
+      : Number(reported);
+  if (!Number.isFinite(dailyVolume))
+    throw new Error(
+      `hinkal: relayer returned ${JSON.stringify(reported)} for chain ${chainId} on ${options.dateString}, it only serves the day thats still in progress`
+    );
   return {
-    dailyVolume: Number(data.dailyVolume),
+    dailyVolume,
   };
 };
 


### PR DESCRIPTION
`aggregators/hinkal` publishes `$0` whenever the relayer has no number for a day, because the guard checks the wrong thing:

```ts
if (data?.dailyVolume === undefined) {
  console.error(`hinkal: no volume returned for chain ${chainId} (${url})`);
}
return { dailyVolume: Number(data.dailyVolume) };
```

the relayer returns `{"dailyVolume": null}`, not `undefined`. `null === undefined` is false so nothing is logged, and `Number(null)` is `0` and finite, so a missing day is published as a real zero-volume day.

**why it fires every day**

the relayer only answers for the day that's still in progress. every completed day comes back null:

```
2026-07-27 -> null
2026-07-31 -> null
2026-08-02 -> null
2026-08-03 -> null
2026-08-04 -> 28280.17943193073   <- today, still open
2026-08-05 -> 0
```

(arbitrum, `totalVolume/{start}/{end}/42161`. same shape on the other chains. checked repeatedly, it's stable, not flaky.)

so the day the adapter actually asks for is always the one the relayer has already dropped. running master for a completed day gives zeros on all seven chains:

```
chain     | Daily volume
ethereum  | 0.00
base      | 0.00
arbitrum  | 0.00
polygon   | 0.00
optimism  | 0.00
solana    | 0.00
tron      | 0.00
Aggregate | 0.00
```

that's what the published series has been drifting into, 08-01 $2,395 and 08-02 $7,549 against an $80k-ish norm, and 08-03 with no chains reporting at all.

**what this changes**

throws instead, so the day shows as missing rather than as genuinely zero volume. same shape as #8525, #8526, #8538, #8539 and #8547.

a real numeric `0` is still respected as `0`, only null/undefined/blank/unparseable throw:

```
null      -> throw        0        -> 0
undefined -> throw        "0"      -> 0
""        -> throw        1234.5   -> 1234.5
"   "     -> throw        "1234.5" -> 1234.5
"NaN"     -> throw
```

live values still pass through untouched: arbitrum 28280.17943193073, base 4595.546042445872, polygon 9220.633859123749.

also dropped `import { start } from "repl"` at the top of the file, which is unused and pulls in node's repl module.

**worth saying out loud**

if the relayer keeps only serving the in-progress day, this will throw daily and hinkal's chart will stop rather than fill with zeros. i think that's the right signal, it says "the source isn't serving this day" instead of asserting no one traded, but it does mean the fix surfaces the problem rather than hiding it, and the real repair is on their side. the protocol is alive (hinkal.pro, app.hinkal.pro, hinkal.io all up), and there's no non-staging host: `wallet-v2`, `wallet`, `relayer` don't resolve and `api.hinkal.io` 404s, so i left `wallet-staging-v2.hinkal.io` alone rather than guess at a production URL.

**one thing i could not resolve**

two days spike far above the norm and i can't check them, since the relayer no longer serves those dates:

```
2026-07-27   ethereum $10,039,958   arbitrum $2,011,903
2026-07-31   ethereum $17,784,893   arbitrum $2,960,017
```

against $37k-$254k ethereum days either side. hinkal is a privacy protocol so a couple of whale-sized days is entirely plausible, and both chains moving together is consistent with one user routing through both. i'm not claiming it's a bug, just flagging it in case it's a known units issue. it's untouched by this pr.

typechecks clean.
