### PR TITLE
lunarbase: add bsc volume

### DIFF
--- a/dexs/lunarbase/index.ts
+++ b/dexs/lunarbase/index.ts
@@ -1,8 +1,16 @@
 import { FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
+import ADDRESSES from "../../helpers/coreAssets.json";
 import { METRIC } from "../../helpers/metrics";
 
-const POOLS_BY_CHAIN = {
+type PoolConfig = {
+    address: string;
+    feeModel: "legacy" | "dark_pools_v2";
+    tokenXOverride?: string;
+    tokenYOverride?: string;
+};
+
+const POOLS_BY_CHAIN: Record<string, readonly PoolConfig[]> = {
     [CHAIN.BASE]: [
         {
             address: "0x6Ccc8223532fff07f47EF4311BEB3647326894Ab",
@@ -28,6 +36,7 @@ const POOLS_BY_CHAIN = {
         {
             address: "0x00007904d186680C709519e71f4Dc3e2Df8f1b99",
             feeModel: "dark_pools_v2",
+            tokenXOverride: ADDRESSES.bsc.WBNB,
         },
         {
             address: "0x0B1ce37bc7eE857916B4e2dF9F69775c36831B99",
@@ -109,9 +118,9 @@ const fetch = async (options: FetchOptions) => {
     );
 
     for (let i = 0; i < POOLS.length; i++) {
-        const { address: pool, feeModel } = POOLS[i];
-        const tokenX = tokenXs[i];
-        const tokenY = tokenYs[i];
+        const { address: pool, feeModel, tokenXOverride, tokenYOverride } = POOLS[i];
+        const tokenX = tokenXOverride ?? tokenXs[i];
+        const tokenY = tokenYOverride ?? tokenYs[i];
         const logs = swapLogs[i];
         if (!logs?.length) continue;
         if (typeof tokenX !== "string" || typeof tokenY !== "string") {

--- a/dexs/lunarbase/index.ts
+++ b/dexs/lunarbase/index.ts
@@ -34,11 +34,13 @@ const POOLS_BY_CHAIN: Record<string, readonly PoolConfig[]> = {
     ],
     [CHAIN.BSC]: [
         {
+            // BNB/USDT pool from TVL PR: https://github.com/DefiLlama/DefiLlama-Adapters/pull/20239
             address: "0x00007904d186680C709519e71f4Dc3e2Df8f1b99",
             feeModel: "dark_pools_v2",
             tokenXOverride: ADDRESSES.bsc.WBNB,
         },
         {
+            // BTCB/USDT pool from TVL PR: https://github.com/DefiLlama/DefiLlama-Adapters/pull/20239
             address: "0x0B1ce37bc7eE857916B4e2dF9F69775c36831B99",
             feeModel: "dark_pools_v2",
         },

--- a/dexs/lunarbase/index.ts
+++ b/dexs/lunarbase/index.ts
@@ -24,6 +24,16 @@ const POOLS_BY_CHAIN = {
             feeModel: "dark_pools_v2",
         },
     ],
+    [CHAIN.BSC]: [
+        {
+            address: "0x00007904d186680C709519e71f4Dc3e2Df8f1b99",
+            feeModel: "dark_pools_v2",
+        },
+        {
+            address: "0x0B1ce37bc7eE857916B4e2dF9F69775c36831B99",
+            feeModel: "dark_pools_v2",
+        },
+    ],
 } as const;
 
 const poolAbis = {
@@ -194,6 +204,7 @@ const adapter: SimpleAdapter = {
     adapter: {
         [CHAIN.BASE]: { fetch, start: "2026-03-19" },
         [CHAIN.MONAD]: { fetch, start: "2026-04-30" },
+        [CHAIN.BSC]: { fetch, start: "2026-07-25" },
     },
     methodology,
     breakdownMethodology,


### PR DESCRIPTION
## Summary

Adds BSC support to the LunarBase dimension adapter by registering the two BSC dark-pool contracts already listed in the TVL update:

- BNB/USDT: `0x00007904d186680C709519e71f4Dc3e2Df8f1b99`
- BTCB/USDT: `0x0B1ce37bc7eE857916B4e2dF9F69775c36831B99`

The LunarBase pools on Base and Monad were already covered by this adapter; this PR extends the same `SwapExecuted`-based volume/fee accounting to BSC.

## Context

Pool addresses come from the related TVL PR: https://github.com/DefiLlama/DefiLlama-Adapters/pull/20239

## Checks

- Verified both BSC pool contracts expose `X()` / `Y()` via BSC RPC.
- Did not run the adapter test suite locally because dependencies are not installed in this checkout.

cc @RohanNero @g1nt0ki