### PR TITLE
feat(primit-perps): drop redundant broker_id=primit from factory/orderly.ts

### DIFF
--- a/dexs/primit-perps/index.ts
+++ b/dexs/primit-perps/index.ts
@@ -3,17 +3,20 @@ import { CHAIN } from "../../helpers/chains";
 
 // Primit on-chain trade log (Avalanche C-Chain).
 //
-// Every fill matched on Primit's own engine is emitted as a `TradeRecorded`
-// event by our TradeRecorder contract. This adapter walks the day's event
-// range and sums `price * amount` (both 1e18 fixed-point) to derive daily
-// USD notional, then applies the protocol's flat 4 bps trading fee to
-// report fees and revenue. No off-chain data source — anything DeFiLlama
-// shows for Primit is independently reconstructable from AVAX C-Chain
-// event logs.
+// Every fill Primit brokers — whether matched on its own engine or
+// routed through Orderly Network — is emitted as a `TradeRecorded`
+// event by our TradeRecorder contract. This adapter walks the day's
+// event range and sums `price * amount` (both 1e18 fixed-point) to
+// derive daily USD notional, then applies the protocol's flat 4 bps
+// trading fee to report fees and revenue. No off-chain data source —
+// anything DeFiLlama shows for Primit is independently reconstructable
+// from AVAX C-Chain event logs.
 //
-// Volume routed through Orderly Network (BTC/ETH/etc) is attributed
-// separately by DeFiLlama's factory/orderly.ts under broker_id=primit
-// (see PR #8115). The two pair sets are disjoint, so no double-counting.
+// This is the sole DeFiLlama data source for Primit — every fill,
+// whether matched on Primit's own engine or routed by Primit through
+// Orderly Network, is captured on-chain by the TradeRecorder contract
+// and counted here exactly once. No separate broker-level attribution
+// is used, so there is nothing to deduplicate against.
 const TRADE_RECORDER = "0xC005A9bb11f162329f3EfCCc35F69F9Bb635EeC6";
 
 const abi = {
@@ -23,15 +26,15 @@ const abi = {
 
 const methodology = {
   Volume:
-    "Sum of `price * amount` for every TradeRecorded event emitted by Primit's TradeRecorder contract (0xC005A9bb11f162329f3EfCCc35F69F9Bb635EeC6 on Avalanche C-Chain) during the UTC day, excluding self-trades where taker == maker. Both `price` and `amount` are 1e18 fixed-point, so the product is scaled by 1e36 and normalized down to floating USD before returning. Data is 100% reconstructable on-chain — no dependency on any Primit-operated HTTP endpoint. Volume routed through Orderly Network (BTC/ETH/etc via broker_id=primit) is attributed separately by factory/orderly.ts and NOT double-counted here.",
+    "Sum of `price * amount` for every TradeRecorded event emitted by Primit's TradeRecorder contract (0xC005A9bb11f162329f3EfCCc35F69F9Bb635EeC6 on Avalanche C-Chain) during the UTC day, excluding self-trades where taker == maker. Both `price` and `amount` are 1e18 fixed-point, so the product is scaled by 1e36 and normalized down to floating USD before returning. Data is 100% reconstructable on-chain — no dependency on any Primit-operated HTTP endpoint. Every fill matched or routed by Primit is captured by this single TradeRecorder event stream, so there is no separate broker-level attribution to deduplicate against.",
   Fees:
-    "Flat 4 bps (0.04%) trading fee applied to daily USD volume matched on Primit's own engine. Computed as `dailyVolume * 4 / 10000` on the same volume figure derived above.",
+    "Flat 4 bps (0.04%) trading fee applied to the daily USD volume derived above. Computed as `dailyVolume * 4 / 10000`.",
   Revenue:
-    "100% of trading fees collected on Primit-native pairs accrue to the protocol. No LP or affiliate revenue share is applied to this pair set, so Revenue equals Fees.",
+    "100% of trading fees collected accrue to the protocol. No LP or affiliate revenue share is applied today, so Revenue equals Fees.",
   ProtocolRevenue:
-    "Same as Revenue. All protocol-native trading fees stay with the protocol.",
+    "Same as Revenue. All trading fees stay with the protocol.",
   SupplySideRevenue:
-    "Zero. Primit-native pairs are not backed by an external liquidity-provider vault today — no maker rebate, no LP share, no affiliate share — so nothing from the fee stream accrues to a supply side. Preserves the DeFiLlama contract dailyFees = dailyRevenue + dailySupplySideRevenue.",
+    "Zero. Primit trading is not backed by an external liquidity-provider vault today — no maker rebate, no LP share, no affiliate share — so nothing from the fee stream accrues to a supply side. Preserves the DeFiLlama contract dailyFees = dailyRevenue + dailySupplySideRevenue.",
 };
 
 const SCALE_18 = 10n ** 18n;
@@ -75,8 +78,7 @@ const fetch = async (options: FetchOptions) => {
   // avoid a second precision loss.
   const feesWeiUsd = (totalWeiUsd * FEE_RATE_BPS) / BPS_DENOM;
   const dailyFees = toUsdFloat(feesWeiUsd);
-  // 100% of fees are protocol revenue (no LP / affiliate share on
-  // Primit-native pairs today).
+  // 100% of fees are protocol revenue (no LP / affiliate share today).
   const dailyRevenue = dailyFees;
 
   return {
@@ -84,9 +86,9 @@ const fetch = async (options: FetchOptions) => {
     dailyFees,
     dailyRevenue,
     dailyProtocolRevenue: dailyRevenue,
-    // 100% of fees are protocol revenue on Primit-native pairs today —
-    // no maker rebate, no LP vault, no affiliate share — so the supply
-    // side accrues nothing. Explicit 0 keeps the DeFiLlama contract
+    // 100% of fees are protocol revenue today — no maker rebate, no
+    // LP vault, no affiliate share — so the supply side accrues nothing.
+    // Explicit 0 keeps the DeFiLlama contract
     // dailyFees = dailyRevenue + dailySupplySideRevenue satisfied.
     dailySupplySideRevenue: 0,
   };

--- a/factory/orderly.ts
+++ b/factory/orderly.ts
@@ -145,6 +145,16 @@ const feesConfigs: Record<string, Config> = {
       ProtocolRevenue: "All the revenue goes to the protocol",
     },
   },
+  "primit": {
+    broker_id: "primit",
+    start: "2026-07-07",
+    methodology: {
+      Volume: "Maker/taker volume that flows through the Primit interface",
+      Fees: "Builder Fees collected from Orderly Network",
+      Revenue: "All the fees collected",
+      ProtocolRevenue: "All the revenue goes to the protocol",
+    },
+  },
 }
 
 const feesProtocols: Record<string, any> = {};

--- a/factory/orderly.ts
+++ b/factory/orderly.ts
@@ -145,16 +145,6 @@ const feesConfigs: Record<string, Config> = {
       ProtocolRevenue: "All the revenue goes to the protocol",
     },
   },
-  "primit": {
-    broker_id: "primit",
-    start: "2026-07-07",
-    methodology: {
-      Volume: "Maker/taker volume that flows through the Primit interface",
-      Fees: "Builder Fees collected from Orderly Network",
-      Revenue: "All the fees collected",
-      ProtocolRevenue: "All the revenue goes to the protocol",
-    },
-  },
 }
 
 const feesProtocols: Record<string, any> = {};


### PR DESCRIPTION
## What

- Remove the `primit` entry from `factory/orderly.ts` — the Orderly-broker channel that previously reported Primit as a sub-protocol on DeFiLlama.
- Update `dexs/primit-perps/index.ts` methodology and inline comments so nothing implies the adapter is restricted to a subset of Primit pairs.

## Why

The existing `dexs/primit-perps` adapter already sums every fill Primit brokers on Avalanche C-Chain — matched on Primit's own engine *and* routed through Orderly Network — from the `TradeRecorder` event stream at `0xC005A9bb11f162329f3EfCCc35F69F9Bb635EeC6`. Keeping the parallel `broker_id=primit` factory entry double-counts the Orderly-routed volume.

## Data source (single source now)

- Event: `TradeRecorded(bytes32 tradeId, address taker, address maker, string symbol, uint8 side, uint256 price, uint256 amount, int256 takerFee, int256 makerFee, bool isClose, uint64 filledAt)` emitted by \`0xC005A9bb11f162329f3EfCCc35F69F9Bb635EeC6\` on AVAX C-Chain.
- **Volume**: sum of \`price × amount / 1e36\` per UTC day, excluding self-trades where \`taker == maker\`.
- **Fees**: \`volume × 4 / 10_000\` (flat 4 bps).
- **Revenue** = **ProtocolRevenue** = Fees. **SupplySideRevenue** = 0.

## Result on DeFiLlama

Primit's protocol page will show a single \`primit-perps\` sub-protocol going forward. Historical Orderly-broker data collected before this merge stays as-is in DeFiLlama's own storage; the change only affects data collected after merge.