### PR TITLE
reya-dex: chunk getLogs to 1,000 blocks for RPC range cap

### DIFF
--- a/dexs/reya-dex.ts
+++ b/dexs/reya-dex.ts
@@ -96,7 +96,11 @@ const fetch = async (options: FetchOptions): Promise<FetchResult> => {
     options.getToBlock(),
   ]);
 
-  const BLOCKS_PER_BATCH = 10000;
+  // Reya's RPC provider rejects eth_getLogs spanning more than 2,000 blocks (HTTP 400),
+  // so batches have to stay under that. Each call below filters to a single event and the
+  // busiest one runs ~3.8 logs/block, so a 1,000-block batch returns ~3.8k logs — well
+  // inside the provider's 20,000-logs-per-response cap.
+  const BLOCKS_PER_BATCH = 1000;
   const batches: Array<{ fromBlock: number; toBlock: number }> = [];
   for (let block = fromBlock; block <= toBlock; block += BLOCKS_PER_BATCH) {
     batches.push({


### PR DESCRIPTION
Reya Network migrated its sequencer/RPC provider on 2026-08-05. The new provider rejects eth_getLogs spanning more than 2,000 blocks with an HTTP 400, where the previous one was effectively unbounded.

The adapter already batched its scan, but at 10,000 blocks per call — 5x over the new cap — so every getLogs call would fail post-migration. The existing batching was sized to bound memory, not to satisfy a provider range limit.

Drops the batch size to 1,000, which leaves headroom against the block cap and against bursts in log density. Each call is filtered to a single event and the busiest event runs ~3.8 logs/block, so a batch returns ~3.8k logs, well inside the provider's 20,000-logs-per-response cap.