### PR TITLE
[fix] surge-credit - correct InterestAccrued field names in fees adapter

### DIFF
--- a/fees/surgecredit.ts
+++ b/fees/surgecredit.ts
@@ -3,13 +3,27 @@ import { CHAIN } from "../helpers/chains"
 import { METRIC } from "../helpers/metrics"
 import CoreAssets from "../helpers/coreAssets.json"
 
-// Surge Credit: Bitcoin collateralised USDC lending on Base.
+// Surge Credit: Bitcoin-collateralised USDC lending on Base.
 // https://docs.surge.credit/
+//
+// Fees come entirely from borrow interest. On every state-changing interaction the
+// LiquidityPool accrues interest on the outstanding debt and emits ONE event:
+//
+//   event InterestAccrued(
+//     uint256 indexed marketId,
+//     uint256 borrowInterest,  // total interest added to the debt this accrual
+//     uint256 protocolCut,     // reserve share kept by the protocol (reserveRateBps)
+//     uint256 lenderCut        // remainder distributed to USDC LPs
+//   )
+//
+// borrowInterest == protocolCut + lenderCut, all in USDC (1e6). There is no
+// origination fee (originationFeeBps == 0 on every market) and no other fee source,
+// so borrow interest is the whole of Fees.
 const LIQUIDITY_POOL = '0xEE755F1BbcbF6e3260469D0f473522d71d3bdDda'
 const USDC = CoreAssets.base.USDC
 
 const InterestAccruedAbi =
-  'event InterestAccrued(uint256 indexed marketId, uint256 interestAccrued, uint256 borrowIndex, uint256 supplyIndex)'
+  'event InterestAccrued(uint256 indexed marketId, uint256 borrowInterest, uint256 protocolCut, uint256 lenderCut)'
 
 async function fetch(options: FetchOptions) {
   const dailyFees = options.createBalances()
@@ -19,9 +33,9 @@ async function fetch(options: FetchOptions) {
   const interestLogs = await options.getLogs({ target: LIQUIDITY_POOL, eventAbi: InterestAccruedAbi })
 
   for (const log of interestLogs) {
-    dailyFees.add(USDC, log.interestAccrued, METRIC.BORROW_INTEREST)
-    dailyRevenue.add(USDC, log.borrowIndex, METRIC.BORROW_INTEREST)
-    dailySupplySideRevenue.add(USDC, log.supplyIndex, METRIC.BORROW_INTEREST)
+    dailyFees.add(USDC, log.borrowInterest, METRIC.BORROW_INTEREST)
+    dailyRevenue.add(USDC, log.protocolCut, METRIC.BORROW_INTEREST)
+    dailySupplySideRevenue.add(USDC, log.lenderCut, METRIC.BORROW_INTEREST)
   }
 
   return {
@@ -40,22 +54,22 @@ const adapter: SimpleAdapter = {
   start: '2026-03-20',
   methodology: {
     Fees: 'Borrow interest paid by borrowers on Bitcoin-collateralised USDC loans.',
-    Revenue: 'Protocol reserve portion of borrow interest, as emitted by the InterestAccrued event on the LiquidityPool.',
-    ProtocolRevenue: 'Protocol reserve portion of borrow interest, as emitted by the InterestAccrued event on the LiquidityPool.',
-    SupplySideRevenue: 'Borrow interest distributed to USDC liquidity providers (LPs).',
+    Revenue: 'Protocol reserve share of borrow interest (reserveRateBps), from the protocolCut field of the InterestAccrued event.',
+    ProtocolRevenue: 'Protocol reserve share of borrow interest (reserveRateBps), from the protocolCut field of the InterestAccrued event.',
+    SupplySideRevenue: 'Borrow interest distributed to USDC liquidity providers (LPs), from the lenderCut field of the InterestAccrued event.',
   },
   breakdownMethodology: {
     Fees: {
-      [METRIC.BORROW_INTEREST]: 'Gross USDC interest accrued across all markets, read from the interestAccrued field of the InterestAccrued event.',
+      [METRIC.BORROW_INTEREST]: 'Gross USDC interest accrued across all markets, from the borrowInterest field of the InterestAccrued event.',
     },
     Revenue: {
-      [METRIC.BORROW_INTEREST]: 'Protocol reserve portion of borrow interest, read from the borrowIndex field of the InterestAccrued event.',
+      [METRIC.BORROW_INTEREST]: 'Protocol reserve share of borrow interest, from the protocolCut field of the InterestAccrued event.',
     },
     ProtocolRevenue: {
-      [METRIC.BORROW_INTEREST]: 'Protocol reserve portion of borrow interest, read from the borrowIndex field of the InterestAccrued event.',
+      [METRIC.BORROW_INTEREST]: 'Protocol reserve share of borrow interest, from the protocolCut field of the InterestAccrued event.',
     },
     SupplySideRevenue: {
-      [METRIC.BORROW_INTEREST]: 'Borrow interest distributed to USDC liquidity providers (LPs), read from the supplyIndex field of the InterestAccrued event.',
+      [METRIC.BORROW_INTEREST]: 'Borrow interest distributed to USDC liquidity providers (LPs), from the lenderCut field of the InterestAccrued event.',
     },
   },
 }


### PR DESCRIPTION
### What

Corrects the `InterestAccrued` event signature and field mapping in the Surge Credit fees adapter (`fees/surgecredit.ts`).

The adapter declared the event as:

```
InterestAccrued(uint256 indexed marketId, uint256 interestAccrued, uint256 borrowIndex, uint256 supplyIndex)
```

but the deployed LiquidityPool actually emits:

```
InterestAccrued(uint256 indexed marketId, uint256 borrowInterest, uint256 protocolCut, uint256 lenderCut)
```

All parameters are `uint256`, so the event signature hash matched and the log decoded positionally to the correct values, but the field names and the methodology text referenced `borrowIndex` / `supplyIndex` fields that do not exist on the contract.

### Change

Use the real field names and map them explicitly:

- `dailyFees` = `borrowInterest` (total interest)
- `dailyRevenue` / `dailyProtocolRevenue` = `protocolCut` (reserve share, `reserveRateBps`)
- `dailySupplySideRevenue` = `lenderCut` (distributed to USDC LPs)

Methodology text updated to match. Also noted that there is no origination fee (`originationFeeBps == 0` on every market), so borrow interest is the entirety of Fees.

### Values are unchanged

This is a naming and methodology correction only. Because the decode was already positional, the numbers are identical before and after. Local test output for the latest day:

```
Daily fees: 135.19
Daily revenue: 26.96
Daily protocol revenue: 26.96
Daily supply side revenue: 107.95
```

`fees == revenue + supplySideRevenue`, and revenue/fees = 19.9% (the 20% reserve rate).
