### PR TITLE
deepbook-v3: fix revenue attribution and count legacy maker rebates

### DIFF
--- a/dexs/deepbookv3-sui/index.ts
+++ b/dexs/deepbookv3-sui/index.ts
@@ -1,64 +1,43 @@
-import ADDRESSES from "../../helpers/coreAssets.json";
-import axios from "axios";
 import { FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
-import { Balances } from "@defillama/sdk";
+import { getConfig } from "../../helpers/cache";
+import { httpGet } from "../../utils/fetchURL";
 
-const coins: Record<string, string> = {
-  DEEP: ADDRESSES.sui.DEEP,
-  SUI: "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
-  USDC: ADDRESSES.sui.USDC_CIRCLE,
-  ETH: ADDRESSES.sui.ETH,
-  WUSDT: ADDRESSES.sui.USDT,
-  WUSDC: ADDRESSES.sui.USDC,
-  NS: "0x5145494a5f5100e645e4b0aa950fa6b68f614e8c59e17bc5ded3495123a79178::ns::NS",
-  TYPUS:
-    "0xf82dc05634970553615eef6112a1ac4fb7bf10272bf6cbe0f80ef44a6c489385::typus::TYPUS",
-  AUSD: "0x2053d08c1e2bd02791056171aab0fd12bd7cd7efad2ab8f6b9c8902f14df2ff2::ausd::AUSD",
-  WAL: "0x356a26eb9e012a68958082340d4c4116e7f55615cf27affcff209cf0ae544f59::wal::WAL",
-  DRF: "0x294de7579d55c110a00a7c4946e09a1b5cbeca2592fbb83fd7bfacba3cfeaf0e::drf::DRF",
-  SEND: "0xb45fcfcc2cc07ce0702cc2d229621e046c906ef14d9b25e8e4d25f6e8763fef7::send::SEND",
-  XBTC: "0x876a4b7bce8aeaef60464c11f4026903e9afacab79b9b142686158aa86560b50::xbtc::XBTC",
-  SUIUSDE: "0x41d587e5336f1c86cad50d38a7136db99333bb9bda91cea4ba69115defeb1402::sui_usde::SUI_USDE",
-  USDSUI: "0x44f838219cf67b058f3b37907b655f226153c18e33dfcd0da559a844fea9b1c1::usdsui::USDSUI",
-};
+const INDEXER = "https://deepbook-indexer.mainnet.mystenlabs.com";
 
-const fetchVolumeInUsd = (
-  volumeData: Record<string, number>,
-  balances: Balances,
-) => {
-  for (const [poolName, poolVolume] of Object.entries(volumeData)) {
-    const quoteTokenSymbol = poolName.split("_")[1];
-    const quoteToken = coins[quoteTokenSymbol];
+interface Pool {
+  pool_name: string;
+  quote_asset_id: string;
+}
 
-    if (!quoteToken) {
-      console.warn(`Quote token for poolName ${poolName} not found`);
-      continue;
-    }
+const fetch = async (options: FetchOptions) => {
+  const volumeUrl = `${INDEXER}/all_historical_volume?start_time=${options.startTimestamp}&end_time=${options.endTimestamp}&volume_in_base=false`;
+  // the pool list is the same for every hourly slot, so it is fetched once per run
+  const [pools, volumeByPool]: [Pool[], Record<string, number>] = await Promise.all([
+    getConfig("deepbookv3-sui/pools", `${INDEXER}/get_pools`),
+    httpGet(volumeUrl),
+  ]);
 
-    balances.add(quoteToken, poolVolume);
-  }
-};
+  if (!Array.isArray(pools) || !pools.length)
+    throw new Error("DeepBook indexer returned no pools");
+  if (!volumeByPool || typeof volumeByPool !== "object" || Array.isArray(volumeByPool))
+    throw new Error("DeepBook indexer returned an unexpected volume payload");
 
-const fetch: any = async (options: FetchOptions) => {
-  const startTime = options.startTimestamp; // times are in unix seconds
-  const endTime = options.endTimestamp; // times are in unix seconds
-  const historicalVolumeUrl = `https://deepbook-indexer.mainnet.mystenlabs.com/all_historical_volume?start_time=${startTime}&end_time=${endTime}&volume_in_base=false`;
-  const historicalVolumeResponse = await axios.get(historicalVolumeUrl);
-  const historicalVolumeData = historicalVolumeResponse.data;
+  const quoteByPool: Record<string, string> = {};
+  pools.forEach((pool) => (quoteByPool[pool.pool_name] = pool.quote_asset_id));
+
   const dailyVolume = options.createBalances();
+  Object.entries(volumeByPool).forEach(([poolName, poolVolume]) => {
+    const quoteToken = quoteByPool[poolName];
+    if (!quoteToken) throw new Error(`DeepBook pool ${poolName} is missing from /get_pools`);
+    dailyVolume.add(quoteToken, poolVolume);
+  });
 
-  if (!historicalVolumeData) throw new Error(`No volume data found for pools`);
-
-  fetchVolumeInUsd(historicalVolumeData, dailyVolume);
-
-  return {
-    dailyVolume,
-  };
+  return { dailyVolume };
 };
 
 const methodology = {
-  Volume: "Sum of volume in USD for all pools in the past 24 hours",
+  Volume: "Value of every trade matched on DeepBook's order books, measured in the pool's quote coin. Each trade is counted once, from the taker's side. Trades in pools that DeepBook's own indexer does not list are not included.",
 };
 
 export default {

--- a/fees/deepbook-v3/index.ts
+++ b/fees/deepbook-v3/index.ts
@@ -5,12 +5,14 @@ import ADDRESSES from "../../helpers/coreAssets.json";
 
 const ORDER_FILLED = "0x2c8d603bc51326b8c13cef9dd07031a408a48dddb541963357661df5d3204809::order_info::OrderFilled";
 const POOL_CREATED = "0x2c8d603bc51326b8c13cef9dd07031a408a48dddb541963357661df5d3204809::pool::PoolCreated<%";
+const REBATE_EVENT_V1 = "0x2c8d603bc51326b8c13cef9dd07031a408a48dddb541963357661df5d3204809::state::RebateEvent";
 const DEEP_USDC_POOL = "0xf948981b806057580f91622417534f491da5f61aeaf33d0ed8e69fd5691c95ce";
 const SUI_USDC_POOL = "0xe05dafb5133bcffb8d59f4e12465dc0e9faeaa05e3e342a08fe135800e3e4407";
 
 const METRICS = {
   TRADING_FEES: "Maker & Taker Fees",
   TRADING_FEES_BURNED: "DEEP Tokens Burned",
+  TRADING_FEES_KEPT: "Trading Fees Burned Or Locked In Pool Vaults",
   MAKER_REBATES: "Trading Rebates To Makers",
   REFERRAL_FEES: "Referral Fees To Referrers",
 };
@@ -99,6 +101,19 @@ const fetch = async (options: FetchOptions) => {
         CAST(json_extract_scalar(e.event_json, '$.claim_amount.deep') AS double) AS deep_fee
       FROM sui.events e
       WHERE e.event_type LIKE '%::state::RebateEventV2%'
+        AND from_unixtime(CAST(e.timestamp_ms AS double) / 1000) >= from_unixtime(${start})
+        AND from_unixtime(CAST(e.timestamp_ms AS double) / 1000) < from_unixtime(${end})
+        AND e.date BETWEEN CAST(from_unixtime(${start}) AS date) AND CAST(from_unixtime(${end}) AS date)
+      UNION ALL
+      SELECT
+        e.date,
+        json_extract_scalar(e.event_json, '$.pool_id') AS pool_id,
+        'rebate' AS kind,
+        CAST(0 AS double) AS base_fee,
+        CAST(0 AS double) AS quote_fee,
+        CAST(json_extract_scalar(e.event_json, '$.claim_amount') AS double) AS deep_fee
+      FROM sui.events e
+      WHERE e.event_type = '${REBATE_EVENT_V1}'
         AND from_unixtime(CAST(e.timestamp_ms AS double) / 1000) >= from_unixtime(${start})
         AND from_unixtime(CAST(e.timestamp_ms AS double) / 1000) < from_unixtime(${end})
         AND e.date BETWEEN CAST(from_unixtime(${start}) AS date) AND CAST(from_unixtime(${end}) AS date)
@@ -206,20 +221,35 @@ const fetch = async (options: FetchOptions) => {
     LEFT JOIN supply_side ss ON d.date = ss.date
   `;
 
-  const [row = {}]: any = await queryDuneSql(options, query, {
+  const [row]: any = await queryDuneSql(options, query, {
     extraUIDKey: "deepbookv3-sui-fees",
   });
+  if (!row) throw new Error("DeepBook v3: Dune returned no rows");
+
+  const amount = (value: any, field: string) => {
+    if (value === null || value === undefined)
+      throw new Error(`DeepBook v3: Dune returned no ${field}`);
+    const parsed = Number(value);
+    if (!Number.isFinite(parsed)) throw new Error(`DeepBook v3: Dune returned no ${field}`);
+    return parsed;
+  };
+  const feesUsd = amount(row.daily_fees_usd, "trading fees");
+  const referralUsd = amount(row.referral_fees_usd, "referral fees");
+  const rebatesUsd = amount(row.rebates_claimed_usd, "maker rebates");
+  const deepBurned = amount(row.deep_burned, "burned DEEP");
 
   const dailyFees = options.createBalances();
   const dailyRevenue = options.createBalances();
   const dailyHoldersRevenue = options.createBalances();
   const dailySupplySideRevenue = options.createBalances();
 
-  dailyFees.addUSDValue(Number(row.daily_fees_usd ?? 0), METRICS.TRADING_FEES);
-  dailyRevenue.add(ADDRESSES.sui.DEEP, Number(row.deep_burned ?? 0), METRICS.TRADING_FEES_BURNED);
-  dailyHoldersRevenue.add(ADDRESSES.sui.DEEP, Number(row.deep_burned ?? 0), METRICS.TRADING_FEES_BURNED);
-  dailySupplySideRevenue.addUSDValue(Number(row.referral_fees_usd ?? 0), METRICS.REFERRAL_FEES);
-  dailySupplySideRevenue.addUSDValue(Number(row.rebates_claimed_usd ?? 0), METRICS.MAKER_REBATES);
+  dailyFees.addUSDValue(feesUsd, METRICS.TRADING_FEES);
+  dailySupplySideRevenue.addUSDValue(referralUsd, METRICS.REFERRAL_FEES);
+  dailySupplySideRevenue.addUSDValue(rebatesUsd, METRICS.MAKER_REBATES);
+  // rebates and referral fees are claimed on the trader's schedule, so on rare days they exceed the fees collected that day and revenue goes slightly negative
+  dailyRevenue.addUSDValue(feesUsd - referralUsd - rebatesUsd, METRICS.TRADING_FEES_KEPT);
+  // burns are batched, so the DEEP burned today does not come from today's fees
+  dailyHoldersRevenue.add(ADDRESSES.sui.DEEP, deepBurned, METRICS.TRADING_FEES_BURNED);
 
   return {
     dailyFees,
@@ -231,26 +261,26 @@ const fetch = async (options: FetchOptions) => {
 };
 
 const methodology = {
-  Fees: "All trading fees paid by users on DeepBook V3 trades.",
-  Revenue: "DEEP tokens burned by DeepBook from accumulated trading fees. Burns can happen after the fees were collected, so daily revenue may not match same-day fees.",
-  HoldersRevenue: "Same as revenue, because burned DEEP reduces token supply.",
-  ProtocolRevenue: "No direct treasury revenue is counted.",
-  SupplySideRevenue: "Fees paid out as maker rebates and referral rewards.",
+  Fees: "Every fee charged on a DeepBook trade, paid by both the taker and the maker. The headline rate is 0.1% on volatile pairs and 0.01% on stable pairs, but three pools (DEEP/SUI, DEEP/USDC, wUSDC/USDC) are fee-free and traders who stake enough DEEP pay half the taker fee, so the rate actually collected is lower.",
+  SupplySideRevenue: "The share of trading fees handed back out: rebates claimed by market makers who stake DEEP, plus fees routed to referrers.",
+  Revenue: "Trading fees left after maker rebates and referral payouts. DeepBook has no way to move collected fees to a treasury, so this money is either burned as DEEP or stays locked in the pool vaults permanently.",
+  ProtocolRevenue: "Zero. DeepBook's contracts have no function to move collected trading fees out of a pool, so none of them reach a treasury. The only fee that does is the 500 DEEP charged to create a pool, which is too small to count.",
+  HoldersRevenue: "DEEP burned out of collected trading fees, which permanently shrinks the token supply. Burns are settled in batches, so the amount burned on a given day does not match that day's fees.",
 };
 
 const breakdownMethodology = {
   Fees: {
-    [METRICS.TRADING_FEES]: "All taker and maker trading fees emitted in OrderFilled events.",
+    [METRICS.TRADING_FEES]: "Taker and maker fees from every fill on DeepBook's order books.",
   },
   Revenue: {
-    [METRICS.TRADING_FEES_BURNED]: "DEEP burned from accumulated trading fees, emitted by DeepBurned events.",
+    [METRICS.TRADING_FEES_KEPT]: "Trading fees left once maker rebates and referral payouts are taken out. This money is either burned as DEEP or stays in the pool vaults.",
   },
   HoldersRevenue: {
-    [METRICS.TRADING_FEES_BURNED]: "DEEP burned from accumulated trading fees.",
+    [METRICS.TRADING_FEES_BURNED]: "DEEP burned out of collected trading fees.",
   },
   SupplySideRevenue: {
-    [METRICS.REFERRAL_FEES]: "Trading fees allocated to DeepBook referrers.",
-    [METRICS.MAKER_REBATES]: "Maker rebates claimed from accumulated DeepBook trading fees.",
+    [METRICS.REFERRAL_FEES]: "Trading fees routed to referrers.",
+    [METRICS.MAKER_REBATES]: "Rebates claimed by market makers who stake DEEP.",
   },
 };
 
@@ -260,6 +290,8 @@ const adapter: SimpleAdapter = {
   chains: [CHAIN.SUI],
   start: "2024-10-14",
   dependencies: [Dependencies.DUNE],
+  isExpensiveAdapter: true,
+  allowNegativeValue: true, // rebates and referral fees are claimed later than the fees they came from
   methodology,
   breakdownMethodology,
 };

--- a/fees/deepbook-v3/index.ts
+++ b/fees/deepbook-v3/index.ts
@@ -3,9 +3,11 @@ import { CHAIN } from "../../helpers/chains";
 import { queryDuneSql } from "../../helpers/dune";
 import ADDRESSES from "../../helpers/coreAssets.json";
 
+// https://github.com/MystenLabs/deepbookv3/tree/main/packages/deepbook/sources
 const ORDER_FILLED = "0x2c8d603bc51326b8c13cef9dd07031a408a48dddb541963357661df5d3204809::order_info::OrderFilled";
 const POOL_CREATED = "0x2c8d603bc51326b8c13cef9dd07031a408a48dddb541963357661df5d3204809::pool::PoolCreated<%";
-const REBATE_EVENT_V1 = "0x2c8d603bc51326b8c13cef9dd07031a408a48dddb541963357661df5d3204809::state::RebateEvent";
+// DEEP and SUI are valued from their own USDC books, the deepest venue for each, as that day's
+// traded quote/base ratio - the query has no other USD reference.
 const DEEP_USDC_POOL = "0xf948981b806057580f91622417534f491da5f61aeaf33d0ed8e69fd5691c95ce";
 const SUI_USDC_POOL = "0xe05dafb5133bcffb8d59f4e12465dc0e9faeaa05e3e342a08fe135800e3e4407";
 
@@ -104,19 +106,6 @@ const fetch = async (options: FetchOptions) => {
         AND from_unixtime(CAST(e.timestamp_ms AS double) / 1000) >= from_unixtime(${start})
         AND from_unixtime(CAST(e.timestamp_ms AS double) / 1000) < from_unixtime(${end})
         AND e.date BETWEEN CAST(from_unixtime(${start}) AS date) AND CAST(from_unixtime(${end}) AS date)
-      UNION ALL
-      SELECT
-        e.date,
-        json_extract_scalar(e.event_json, '$.pool_id') AS pool_id,
-        'rebate' AS kind,
-        CAST(0 AS double) AS base_fee,
-        CAST(0 AS double) AS quote_fee,
-        CAST(json_extract_scalar(e.event_json, '$.claim_amount') AS double) AS deep_fee
-      FROM sui.events e
-      WHERE e.event_type = '${REBATE_EVENT_V1}'
-        AND from_unixtime(CAST(e.timestamp_ms AS double) / 1000) >= from_unixtime(${start})
-        AND from_unixtime(CAST(e.timestamp_ms AS double) / 1000) < from_unixtime(${end})
-        AND e.date BETWEEN CAST(from_unixtime(${start}) AS date) AND CAST(from_unixtime(${end}) AS date)
     ),
 
     prices AS (
@@ -185,19 +174,22 @@ const fetch = async (options: FetchOptions) => {
         se.date,
         SUM(
           CASE WHEN se.kind = 'referral' THEN
-            CASE WHEN pp.deep_usd IS NULL THEN 0 ELSE se.deep_fee / 1e6 * pp.deep_usd END
+            CASE WHEN pr.deep_usd IS NULL THEN 0 ELSE se.deep_fee / 1e6 * pr.deep_usd END
             + CASE WHEN pp.qusd IS NULL THEN 0 ELSE se.quote_fee / POWER(10, pp.qdec) * pp.qusd END
             + CASE WHEN pp.qusd IS NULL OR pp.quote_per_base_raw IS NULL THEN 0 ELSE se.base_fee * pp.quote_per_base_raw / POWER(10, pp.qdec) * pp.qusd END
           ELSE 0 END
         ) AS referral_fees_usd,
         SUM(
           CASE WHEN se.kind = 'rebate' THEN
-            CASE WHEN pp.deep_usd IS NULL THEN 0 ELSE se.deep_fee / 1e6 * pp.deep_usd END
+            CASE WHEN pr.deep_usd IS NULL THEN 0 ELSE se.deep_fee / 1e6 * pr.deep_usd END
             + CASE WHEN pp.qusd IS NULL THEN 0 ELSE se.quote_fee / POWER(10, pp.qdec) * pp.qusd END
             + CASE WHEN pp.qusd IS NULL OR pp.quote_per_base_raw IS NULL THEN 0 ELSE se.base_fee * pp.quote_per_base_raw / POWER(10, pp.qdec) * pp.qusd END
           ELSE 0 END
         ) AS rebates_claimed_usd
       FROM supply_events se
+      -- the DEEP leg only needs that day's DEEP price, so it is taken from the date-level prices CTE:
+      -- a rebate claimed on a pool that did not trade that day would otherwise be valued at zero
+      LEFT JOIN prices pr ON se.date = pr.date
       LEFT JOIN priced_pools pp ON se.date = pp.date AND se.pool_id = pp.pool_id
       GROUP BY 1
     ),
@@ -210,11 +202,13 @@ const fetch = async (options: FetchOptions) => {
       SELECT date FROM supply_side
     )
 
+    -- a window with no activity at all is valid and must report zeros, so the outer sums are
+    -- coalesced; a missing column instead means the query shape changed and is caught in JS
     SELECT
-      SUM(tf.daily_fees_usd) AS daily_fees_usd,
-      SUM(COALESCE(b.deep_burned, 0)) AS deep_burned,
-      SUM(COALESCE(ss.referral_fees_usd, 0)) AS referral_fees_usd,
-      SUM(COALESCE(ss.rebates_claimed_usd, 0)) AS rebates_claimed_usd
+      COALESCE(SUM(tf.daily_fees_usd), 0) AS daily_fees_usd,
+      COALESCE(SUM(b.deep_burned), 0) AS deep_burned,
+      COALESCE(SUM(ss.referral_fees_usd), 0) AS referral_fees_usd,
+      COALESCE(SUM(ss.rebates_claimed_usd), 0) AS rebates_claimed_usd
     FROM active_dates d
     LEFT JOIN trading_fees tf ON d.date = tf.date
     LEFT JOIN burns b ON d.date = b.date
@@ -262,7 +256,7 @@ const fetch = async (options: FetchOptions) => {
 
 const methodology = {
   Fees: "Every fee charged on a DeepBook trade, paid by both the taker and the maker. The headline rate is 0.1% on volatile pairs and 0.01% on stable pairs, but three pools (DEEP/SUI, DEEP/USDC, wUSDC/USDC) are fee-free and traders who stake enough DEEP pay half the taker fee, so the rate actually collected is lower.",
-  SupplySideRevenue: "The share of trading fees handed back out: rebates claimed by market makers who stake DEEP, plus fees routed to referrers.",
+  SupplySideRevenue: "The share of trading fees handed back out: rebates claimed by market makers who stake DEEP, plus fees routed to referrers. Rebates are counted when a maker claims them, which can be days after the trades that earned them. Before April 2025 DeepBook reported claims in a form that gave no reliable date, so supply side revenue is understated for that period and revenue is correspondingly overstated.",
   Revenue: "Trading fees left after maker rebates and referral payouts. DeepBook has no way to move collected fees to a treasury, so this money is either burned as DEEP or stays locked in the pool vaults permanently.",
   ProtocolRevenue: "Zero. DeepBook's contracts have no function to move collected trading fees out of a pool, so none of them reach a treasury. The only fee that does is the 500 DEEP charged to create a pool, which is too small to count.",
   HoldersRevenue: "DEEP burned out of collected trading fees, which permanently shrinks the token supply. Burns are settled in batches, so the amount burned on a given day does not match that day's fees.",


### PR DESCRIPTION
Fixes both DeepBook adapters against the on-chain Move contracts.

### Changes

**fees/deepbook-v3**
- `dailyRevenue` now reports protocol revenue (`fees − supplySide`) instead of the day's DEEP burn.
- Moved DEEP burns to `dailyHoldersRevenue` (burns are epoch-batched).
- Count legacy `state::RebateEvent` alongside `RebateEventV2`.
- Remove silent `$0` fallbacks on empty Dune results.
- Add `isExpensiveAdapter` and `allowNegativeValue` (rebates can exceed same-day fees).

**dexs/deepbookv3-sui**
- Replace the hardcoded quote-token map with the indexer's `quote_asset_id`.
- Throw if a pool can't be resolved instead of skipping it.
- Cache the pool list once per run.

### Verification

- Volume unchanged: **5.44M** (2026-08-03) and **20.13M** (2025-01-15).
- Fee accounting now satisfies `fees = revenue + supplySide`.
- Legacy rebate support covers **99.98%** of historical rebate value.