### PR TITLE
add Panoptic V2 options metrics

### DIFF
--- a/options/panoptic-v2/index.ts
+++ b/options/panoptic-v2/index.ts
@@ -5,19 +5,30 @@ import { CHAIN } from "../../helpers/chains";
 import fetchURL from "../../utils/fetchURL";
 import { getLegNotionalAmount, PanopticLeg } from "./notional";
 
+// Panoptic V2 indexed on-chain activity API.
 const SUBGRAPH_URL =
   "https://api.goldsky.com/api/public/project_cl9gc21q105380hxuh8ks53k3/subgraphs/panoptic-subgraph-mainnet/v2_prod/gn";
+// Panoptic /info historical accrued-premium API.
 const PREMIUM_ENDPOINT = "https://app.panoptic.xyz/data/info-streamia-snapshot";
+// The Graph caps collection queries at 1,000 entities, after which they must be paginated:
+// https://thegraph.com/docs/en/subgraphs/developing/developer-faq/#is-there-a-limit-to-how-many-objects-the-graph-can-return-per-query
 const PAGE_SIZE = 1000;
+const OPTION_NOTIONAL = "Option Mint and Burn Notional";
+const STREAMING_PREMIUM = "Accrued Streaming Premium";
 const PROTOCOL_COMMISSION_FEES = "Protocol Option Commissions";
 const BUILDER_COMMISSION_FEES = "Builder Option Commissions";
 const PROTOCOL_COMMISSION_REVENUE = "Protocol Option Commissions To Treasury";
 const BUILDER_COMMISSION_REVENUE = "Builder Option Commissions To Protocol";
 
 const DAILY_ACTIVITY_QUERY = gql`
-  query DailyActivity($startTimestamp: BigInt!, $endTimestamp: BigInt!, $skip: Int!) {
+  query DailyActivity(
+    $startTimestamp: BigInt!
+    $endTimestamp: BigInt!
+    $pageSize: Int!
+    $skip: Int!
+  ) {
     optionMints(
-      first: 1000
+      first: $pageSize
       skip: $skip
       orderBy: timestamp
       orderDirection: asc
@@ -44,7 +55,7 @@ const DAILY_ACTIVITY_QUERY = gql`
       }
     }
     optionBurns(
-      first: 1000
+      first: $pageSize
       skip: $skip
       orderBy: timestamp
       orderDirection: asc
@@ -71,7 +82,7 @@ const DAILY_ACTIVITY_QUERY = gql`
       }
     }
     commissionPaids(
-      first: 1000
+      first: $pageSize
       skip: $skip
       orderBy: timestamp
       orderDirection: asc
@@ -130,6 +141,7 @@ async function fetchActivityPages(options: FetchOptions): Promise<ActivityPage[]
     const page = await request<ActivityPage>(SUBGRAPH_URL, DAILY_ACTIVITY_QUERY, {
       startTimestamp: options.startTimestamp.toString(),
       endTimestamp: options.endTimestamp.toString(),
+      pageSize: PAGE_SIZE,
       skip,
     });
     pages.push(page);
@@ -173,8 +185,11 @@ async function fetch(options: FetchOptions) {
     fetchPremiumUsd(options.dateString),
   ]);
   const dailyNotionalVolume = options.createBalances();
+  const dailyPremiumVolume = options.createBalances();
   const dailyFees = options.createBalances();
   const dailyRevenue = options.createBalances();
+
+  dailyPremiumVolume.addUSDValue(premiumUsd, STREAMING_PREMIUM);
 
   for (const page of pages) {
     for (const event of [...page.optionMints, ...page.optionBurns]) {
@@ -185,7 +200,11 @@ async function fetch(options: FetchOptions) {
           BigInt(event.positionSize),
           BigInt(event.tokenId.pool.tickSpacing),
         );
-        dailyNotionalVolume.add(tokens[notional.tokenType], notional.amount);
+        dailyNotionalVolume.add(
+          tokens[notional.tokenType],
+          notional.amount,
+          OPTION_NOTIONAL,
+        );
       }
     }
 
@@ -203,7 +222,7 @@ async function fetch(options: FetchOptions) {
 
   return {
     dailyNotionalVolume,
-    dailyPremiumVolume: premiumUsd,
+    dailyPremiumVolume,
     dailyFees,
     dailyRevenue,
     dailyProtocolRevenue: dailyRevenue,
@@ -212,12 +231,9 @@ async function fetch(options: FetchOptions) {
 
 const adapter: SimpleAdapter = {
   version: 1,
-  adapter: {
-    [CHAIN.ETHEREUM]: {
-      fetch,
-      start: "2026-04-06",
-    },
-  },
+  fetch,
+  chains: [CHAIN.ETHEREUM],
+  start: "2026-04-06",
   methodology: {
     NotionalVolume:
       "Gross underlying exposure of every Panoptic V2 option leg minted or burned. The raw token amounts use the same position-size and geometric-mean tick-range calculation as Panoptic's /info analytics and are valued by DefiLlama.",
@@ -231,6 +247,14 @@ const adapter: SimpleAdapter = {
       "All Panoptic V2 protocol and builder commissions currently controlled by the Panoptic protocol treasury.",
   },
   breakdownMethodology: {
+    NotionalVolume: {
+      [OPTION_NOTIONAL]:
+        "Gross underlying exposure of all Panoptic V2 option legs minted and burned.",
+    },
+    PremiumVolume: {
+      [STREAMING_PREMIUM]:
+        "Streaming premium accrued by Panoptic V2 positions during the UTC day.",
+    },
     Fees: {
       [PROTOCOL_COMMISSION_FEES]:
         "Option commission recorded on-chain as commissionPaidProtocol.",

--- a/options/panoptic-v2/index.ts
+++ b/options/panoptic-v2/index.ts
@@ -1,0 +1,255 @@
+import { gql, request } from "graphql-request";
+
+import { FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import fetchURL from "../../utils/fetchURL";
+import { getLegNotionalAmount, PanopticLeg } from "./notional";
+
+const SUBGRAPH_URL =
+  "https://api.goldsky.com/api/public/project_cl9gc21q105380hxuh8ks53k3/subgraphs/panoptic-subgraph-mainnet/v2_prod/gn";
+const PREMIUM_ENDPOINT = "https://app.panoptic.xyz/data/info-streamia-snapshot";
+const PAGE_SIZE = 1000;
+const PROTOCOL_COMMISSION_FEES = "Protocol Option Commissions";
+const BUILDER_COMMISSION_FEES = "Builder Option Commissions";
+const PROTOCOL_COMMISSION_REVENUE = "Protocol Option Commissions To Treasury";
+const BUILDER_COMMISSION_REVENUE = "Builder Option Commissions To Protocol";
+
+const DAILY_ACTIVITY_QUERY = gql`
+  query DailyActivity($startTimestamp: BigInt!, $endTimestamp: BigInt!, $skip: Int!) {
+    optionMints(
+      first: 1000
+      skip: $skip
+      orderBy: timestamp
+      orderDirection: asc
+      where: { timestamp_gte: $startTimestamp, timestamp_lt: $endTimestamp }
+    ) {
+      positionSize
+      tokenId {
+        pool {
+          tickSpacing
+          token0 {
+            id
+          }
+          token1 {
+            id
+          }
+        }
+        legs {
+          asset
+          optionRatio
+          strike
+          tokenType
+          width
+        }
+      }
+    }
+    optionBurns(
+      first: 1000
+      skip: $skip
+      orderBy: timestamp
+      orderDirection: asc
+      where: { timestamp_gte: $startTimestamp, timestamp_lt: $endTimestamp }
+    ) {
+      positionSize
+      tokenId {
+        pool {
+          tickSpacing
+          token0 {
+            id
+          }
+          token1 {
+            id
+          }
+        }
+        legs {
+          asset
+          optionRatio
+          strike
+          tokenType
+          width
+        }
+      }
+    }
+    commissionPaids(
+      first: 1000
+      skip: $skip
+      orderBy: timestamp
+      orderDirection: asc
+      where: { timestamp_gte: $startTimestamp, timestamp_lt: $endTimestamp }
+    ) {
+      commissionPaidBuilder
+      commissionPaidProtocol
+      collateral {
+        token {
+          id
+        }
+      }
+    }
+  }
+`;
+
+type OptionEvent = {
+  positionSize: string;
+  tokenId: {
+    legs: PanopticLeg[];
+    pool: {
+      tickSpacing: string;
+      token0: { id: string };
+      token1: { id: string };
+    };
+  };
+};
+
+type CommissionPaid = {
+  collateral: { token: { id: string } };
+  commissionPaidBuilder: string;
+  commissionPaidProtocol: string;
+};
+
+type ActivityPage = {
+  commissionPaids: CommissionPaid[];
+  optionBurns: OptionEvent[];
+  optionMints: OptionEvent[];
+};
+
+type PremiumSnapshot = {
+  data: {
+    chainId: number;
+    unavailableReason: string | null;
+    values: {
+      grossPanopticPremiumUsd: string;
+    };
+  };
+};
+
+async function fetchActivityPages(options: FetchOptions): Promise<ActivityPage[]> {
+  const pages: ActivityPage[] = [];
+  let skip = 0;
+
+  while (true) {
+    const page = await request<ActivityPage>(SUBGRAPH_URL, DAILY_ACTIVITY_QUERY, {
+      startTimestamp: options.startTimestamp.toString(),
+      endTimestamp: options.endTimestamp.toString(),
+      skip,
+    });
+    pages.push(page);
+
+    const hasAnotherPage =
+      page.optionMints.length === PAGE_SIZE ||
+      page.optionBurns.length === PAGE_SIZE ||
+      page.commissionPaids.length === PAGE_SIZE;
+    if (!hasAnotherPage) break;
+
+    skip += PAGE_SIZE;
+  }
+
+  return pages;
+}
+
+async function fetchPremiumUsd(dateString: string): Promise<number> {
+  const response = (await fetchURL(
+    `${PREMIUM_ENDPOINT}?from=${dateString}&to=${dateString}`,
+  )) as PremiumSnapshot;
+
+  if (response.data.chainId !== 1) {
+    throw new Error(`Expected Ethereum premium snapshot, got chain ${response.data.chainId}`);
+  }
+  if (response.data.unavailableReason !== null) {
+    throw new Error(`Panoptic premium snapshot unavailable: ${response.data.unavailableReason}`);
+  }
+
+  const premiumUsd = Number(response.data.values.grossPanopticPremiumUsd);
+  if (!Number.isFinite(premiumUsd) || premiumUsd < 0) {
+    throw new Error(
+      `Invalid Panoptic premium snapshot value ${response.data.values.grossPanopticPremiumUsd}`,
+    );
+  }
+  return premiumUsd;
+}
+
+async function fetch(options: FetchOptions) {
+  const [pages, premiumUsd] = await Promise.all([
+    fetchActivityPages(options),
+    fetchPremiumUsd(options.dateString),
+  ]);
+  const dailyNotionalVolume = options.createBalances();
+  const dailyFees = options.createBalances();
+  const dailyRevenue = options.createBalances();
+
+  for (const page of pages) {
+    for (const event of [...page.optionMints, ...page.optionBurns]) {
+      const tokens = [event.tokenId.pool.token0.id, event.tokenId.pool.token1.id];
+      for (const leg of event.tokenId.legs) {
+        const notional = getLegNotionalAmount(
+          leg,
+          BigInt(event.positionSize),
+          BigInt(event.tokenId.pool.tickSpacing),
+        );
+        dailyNotionalVolume.add(tokens[notional.tokenType], notional.amount);
+      }
+    }
+
+    for (const commission of page.commissionPaids) {
+      const token = commission.collateral.token.id;
+      const protocolAmount = BigInt(commission.commissionPaidProtocol);
+      const builderAmount = BigInt(commission.commissionPaidBuilder);
+
+      dailyFees.add(token, protocolAmount, PROTOCOL_COMMISSION_FEES);
+      dailyFees.add(token, builderAmount, BUILDER_COMMISSION_FEES);
+      dailyRevenue.add(token, protocolAmount, PROTOCOL_COMMISSION_REVENUE);
+      dailyRevenue.add(token, builderAmount, BUILDER_COMMISSION_REVENUE);
+    }
+  }
+
+  return {
+    dailyNotionalVolume,
+    dailyPremiumVolume: premiumUsd,
+    dailyFees,
+    dailyRevenue,
+    dailyProtocolRevenue: dailyRevenue,
+  };
+}
+
+const adapter: SimpleAdapter = {
+  version: 1,
+  adapter: {
+    [CHAIN.ETHEREUM]: {
+      fetch,
+      start: "2026-04-06",
+    },
+  },
+  methodology: {
+    NotionalVolume:
+      "Gross underlying exposure of every Panoptic V2 option leg minted or burned. The raw token amounts use the same position-size and geometric-mean tick-range calculation as Panoptic's /info analytics and are valued by DefiLlama.",
+    PremiumVolume:
+      "Gross streaming premium accrued during the UTC day, including premium accrued by positions that remain open. Panoptic calculates this from Uniswap fee-growth deltas and Panoptic's utilization spread at historical blocks.",
+    Fees:
+      "All protocol and builder commissions charged by Panoptic V2 during the UTC day.",
+    Revenue:
+      "All Panoptic V2 protocol and builder commissions. Builder commissions currently belong to the Panoptic protocol, so revenue equals fees.",
+    ProtocolRevenue:
+      "All Panoptic V2 protocol and builder commissions currently controlled by the Panoptic protocol treasury.",
+  },
+  breakdownMethodology: {
+    Fees: {
+      [PROTOCOL_COMMISSION_FEES]:
+        "Option commission recorded on-chain as commissionPaidProtocol.",
+      [BUILDER_COMMISSION_FEES]:
+        "Option commission recorded on-chain as commissionPaidBuilder.",
+    },
+    Revenue: {
+      [PROTOCOL_COMMISSION_REVENUE]:
+        "Protocol option commission paid to the Panoptic-controlled treasury.",
+      [BUILDER_COMMISSION_REVENUE]:
+        "Builder option commission currently owned by the Panoptic protocol.",
+    },
+    ProtocolRevenue: {
+      [PROTOCOL_COMMISSION_REVENUE]:
+        "Protocol option commission paid to the Panoptic-controlled treasury.",
+      [BUILDER_COMMISSION_REVENUE]:
+        "Builder option commission currently owned by the Panoptic protocol.",
+    },
+  },
+};
+
+export default adapter;

--- a/options/panoptic-v2/index.ts
+++ b/options/panoptic-v2/index.ts
@@ -189,7 +189,7 @@ async function fetch(options: FetchOptions) {
   const dailyFees = options.createBalances();
   const dailyRevenue = options.createBalances();
 
-  dailyPremiumVolume.addUSDValue(premiumUsd, STREAMING_PREMIUM);
+  dailyPremiumVolume.addUSDValue(premiumUsd);
 
   for (const page of pages) {
     for (const event of [...page.optionMints, ...page.optionBurns]) {
@@ -203,7 +203,6 @@ async function fetch(options: FetchOptions) {
         dailyNotionalVolume.add(
           tokens[notional.tokenType],
           notional.amount,
-          OPTION_NOTIONAL,
         );
       }
     }
@@ -247,14 +246,6 @@ const adapter: SimpleAdapter = {
       "All Panoptic V2 protocol and builder commissions currently controlled by the Panoptic protocol treasury.",
   },
   breakdownMethodology: {
-    NotionalVolume: {
-      [OPTION_NOTIONAL]:
-        "Gross underlying exposure of all Panoptic V2 option legs minted and burned.",
-    },
-    PremiumVolume: {
-      [STREAMING_PREMIUM]:
-        "Streaming premium accrued by Panoptic V2 positions during the UTC day.",
-    },
     Fees: {
       [PROTOCOL_COMMISSION_FEES]:
         "Option commission recorded on-chain as commissionPaidProtocol.",

--- a/options/panoptic-v2/notional.ts
+++ b/options/panoptic-v2/notional.ts
@@ -1,0 +1,118 @@
+const Q96 = 1n << 96n;
+const Q128 = 1n << 128n;
+const MAX_UINT256 = (1n << 256n) - 1n;
+const MAX_TICK = 887272n;
+
+const TICK_MULTIPLIERS: ReadonlyArray<readonly [bigint, bigint]> = [
+  [0x2n, 0xfff97272373d413259a46990580e213an],
+  [0x4n, 0xfff2e50f5f656932ef12357cf3c7fdccn],
+  [0x8n, 0xffe5caca7e10e4e61c3624eaa0941cd0n],
+  [0x10n, 0xffcb9843d60f6159c9db58835c926644n],
+  [0x20n, 0xff973b41fa98c081472e6896dfb254c0n],
+  [0x40n, 0xff2ea16466c96a3843ec78b326b52861n],
+  [0x80n, 0xfe5dee046a99a2a811c461f1969c3053n],
+  [0x100n, 0xfcbe86c7900a88aedcffc83b479aa3a4n],
+  [0x200n, 0xf987a7253ac413176f2b074cf7815e54n],
+  [0x400n, 0xf3392b0822b70005940c7a398e4b70f3n],
+  [0x800n, 0xe7159475a2c29b7443b29c7fa6e889d9n],
+  [0x1000n, 0xd097f3bdfd2022b8845ad8f792aa5825n],
+  [0x2000n, 0xa9f746462d870fdf8a65dc1f90e061e5n],
+  [0x4000n, 0x70d869a156d2a1b890bb3df62baf32f7n],
+  [0x8000n, 0x31be135f97d08fd981231505542fcfa6n],
+  [0x10000n, 0x9aa508b5b7a84e1c677de54f3e99bc9n],
+  [0x20000n, 0x5d6af8dedb81196699c329225ee604n],
+  [0x40000n, 0x2216e584f5fa1ea926041bedfe98n],
+  [0x80000n, 0x48a170391f7dc42444e8fa2n],
+];
+
+export type PanopticLeg = {
+  asset: string;
+  optionRatio: string;
+  strike: string;
+  tokenType: string;
+  width: string;
+};
+
+function divideRoundingUp(numerator: bigint, denominator: bigint): bigint {
+  const quotient = numerator / denominator;
+  return numerator % denominator === 0n ? quotient : quotient + 1n;
+}
+
+function getSqrtRatioAtTick(tick: bigint): bigint {
+  if (tick < -MAX_TICK || tick > MAX_TICK) {
+    throw new Error(`Panoptic leg tick ${tick} is outside the Uniswap V3 range`);
+  }
+
+  const absoluteTick = tick < 0n ? -tick : tick;
+  let ratio =
+    (absoluteTick & 0x1n) === 0n
+      ? Q128
+      : 0xfffcb933bd6fad37aa2d162d1a594001n;
+
+  for (const [mask, multiplier] of TICK_MULTIPLIERS) {
+    if ((absoluteTick & mask) !== 0n) {
+      ratio = (ratio * multiplier) >> 128n;
+    }
+  }
+
+  if (tick > 0n) {
+    ratio = MAX_UINT256 / ratio;
+  }
+
+  return divideRoundingUp(ratio, 1n << 32n);
+}
+
+function getLegTicks(strike: bigint, width: bigint, tickSpacing: bigint) {
+  const range = width * tickSpacing;
+  return {
+    lower: strike - range / 2n,
+    upper: strike + divideRoundingUp(range, 2n),
+  };
+}
+
+/**
+ * Returns the raw underlying-token notional used by Panoptic's /info analytics.
+ * Each leg is valued independently, so multi-leg mints and burns report gross
+ * options activity instead of netting the legs against one another.
+ */
+export function getLegNotionalAmount(
+  leg: PanopticLeg,
+  positionSize: bigint,
+  tickSpacing: bigint,
+): { amount: bigint; tokenType: 0 | 1 } {
+  const tokenType = Number(leg.tokenType);
+  if (tokenType !== 0 && tokenType !== 1) {
+    throw new Error(`Invalid Panoptic tokenType ${leg.tokenType}`);
+  }
+
+  const { lower, upper } = getLegTicks(
+    BigInt(leg.strike),
+    BigInt(leg.width),
+    tickSpacing,
+  );
+  const geometricMeanPriceX96 =
+    (getSqrtRatioAtTick(lower) * getSqrtRatioAtTick(upper)) / Q96;
+  const assetAmount = positionSize * BigInt(leg.optionRatio);
+
+  if (leg.asset === "0") {
+    return {
+      amount:
+        tokenType === 0
+          ? assetAmount
+          : divideRoundingUp(assetAmount * geometricMeanPriceX96, Q96),
+      tokenType,
+    };
+  }
+
+  if (leg.asset === "1") {
+    return {
+      amount:
+        tokenType === 1
+          ? assetAmount
+          : divideRoundingUp(assetAmount * Q96, geometricMeanPriceX96),
+      tokenType,
+    };
+  }
+
+  throw new Error(`Invalid Panoptic asset ${leg.asset}`);
+}

--- a/options/panoptic-v2/notional.ts
+++ b/options/panoptic-v2/notional.ts
@@ -1,8 +1,23 @@
+/** Q64.96 fixed-point scale used for Uniswap V3 square-root prices. */
 const Q96 = 1n << 96n;
+/** Q128.128 scale used internally by Uniswap V3 TickMath ratio multiplication. */
 const Q128 = 1n << 128n;
+/** Scale removed when TickMath converts its Q128.128 ratio to Q64.96. */
+const Q32 = 1n << 32n;
+/** Largest uint256, used by TickMath to invert ratios for positive ticks. */
 const MAX_UINT256 = (1n << 256n) - 1n;
+/** Largest absolute tick supported by Uniswap V3 TickMath. */
 const MAX_TICK = 887272n;
+/** Least-significant absolute-tick bit, handled by TickMath's initial ratio. */
+const LOWEST_TICK_BIT = 0x1n;
+/** TickMath multiplier for the least-significant bit of the absolute tick. */
+const ODD_TICK_MULTIPLIER = 0xfffcb933bd6fad37aa2d162d1a594001n;
 
+/**
+ * Remaining absolute-tick bit masks and fixed-point multipliers, ported from
+ * Uniswap V3 TickMath.getSqrtRatioAtTick:
+ * https://github.com/Uniswap/v3-core/blob/main/contracts/libraries/TickMath.sol
+ */
 const TICK_MULTIPLIERS: ReadonlyArray<readonly [bigint, bigint]> = [
   [0x2n, 0xfff97272373d413259a46990580e213an],
   [0x4n, 0xfff2e50f5f656932ef12357cf3c7fdccn],
@@ -45,9 +60,9 @@ function getSqrtRatioAtTick(tick: bigint): bigint {
 
   const absoluteTick = tick < 0n ? -tick : tick;
   let ratio =
-    (absoluteTick & 0x1n) === 0n
+    (absoluteTick & LOWEST_TICK_BIT) === 0n
       ? Q128
-      : 0xfffcb933bd6fad37aa2d162d1a594001n;
+      : ODD_TICK_MULTIPLIER;
 
   for (const [mask, multiplier] of TICK_MULTIPLIERS) {
     if ((absoluteTick & mask) !== 0n) {
@@ -59,7 +74,7 @@ function getSqrtRatioAtTick(tick: bigint): bigint {
     ratio = MAX_UINT256 / ratio;
   }
 
-  return divideRoundingUp(ratio, 1n << 32n);
+  return divideRoundingUp(ratio, Q32);
 }
 
 function getLegTicks(strike: bigint, width: bigint, tickSpacing: bigint) {


### PR DESCRIPTION
## Summary

Adds Panoptic V2 options metrics on Ethereum under `options/panoptic-v2`.

Panoptic V2 is already listed on DefiLlama. This PR adds the dimensions required for the Options dashboard.

## Metrics

- `dailyNotionalVolume`: Gross per-leg underlying exposure for Panoptic V2 option mints and burns. Raw token amounts use the same position-size and geometric-mean tick-range calculation as Panoptic's `/info` analytics.
- `dailyPremiumVolume`: Streaming premium accrued during each UTC day, including premium accrued by positions that remain open.
- `dailyFees`: `commissionPaidProtocol + commissionPaidBuilder`.
- `dailyRevenue`: Equal to fees because all builder revenue currently belongs to the Panoptic protocol.
- `dailyProtocolRevenue`: Equal to revenue under the current ownership model.

Protocol commissions and builder commissions have separate breakdown labels.

## Data sources

- Panoptic V2 production subgraph:
  https://api.goldsky.com/api/public/project_cl9gc21q105380hxuh8ks53k3/subgraphs/panoptic-subgraph-mainnet/v2_prod/gn
- Panoptic historical streaming-premium endpoint:
  https://app.panoptic.xyz/data/info-streamia-snapshot
- Uniswap V3 TickMath:
  https://github.com/Uniswap/v3-core/blob/main/contracts/libraries/TickMath.sol

## Coverage

- Chain: Ethereum
- Version: Panoptic V2 only
- Start date: 2026-04-06

## Validation

```bash
pnpm ts-check
pnpm test options panoptic-v2 2026-08-04