### PR TITLE
haedal-vault: throw when the api reports more revenue than fees

### DIFF
--- a/fees/haedal-vault/index.ts
+++ b/fees/haedal-vault/index.ts
@@ -7,12 +7,33 @@ const methodology = {
     ProtocolRevenue: 'A Part of protocol fees are charged as revenue.',
 };
 
-const fetch = async ({ startTimestamp, endTimestamp, startOfDay }: FetchOptions) => {
+const readAmount = (value: unknown): number | null => {
+    if (typeof value !== 'number' && typeof value !== 'string') return null;
+    if (typeof value === 'string' && value.trim() === '') return null;
+    const parsed = Number(value);
+    return Number.isFinite(parsed) && parsed >= 0 ? parsed : null;
+};
+
+const fetch = async ({ startTimestamp, endTimestamp, dateString }: FetchOptions) => {
     const fees = (await fetchURL(`https://haedal.xyz/api/v1/wal/vault/fees?fromTimestamp=${startTimestamp}&toTimestamp=${endTimestamp}`)).data;
+
+    const dailyFees = readAmount(fees?.fee);
+    const dailyRevenue = readAmount(fees?.revenue);
+
+    if (dailyFees === null || dailyRevenue === null)
+        throw new Error(
+            `haedal-vault: unreadable vault fee response for ${dateString} (fee ${JSON.stringify(fees?.fee)}, revenue ${JSON.stringify(fees?.revenue)})`
+        );
+
+    if (dailyRevenue > dailyFees)
+        throw new Error(
+            `haedal-vault: api returned ${dailyRevenue} revenue against ${dailyFees} fees for ${dateString}, revenue is a share of the fees and cannot exceed them`
+        );
+
     return {
-        dailyFees: fees.fee,
-        dailyRevenue: fees.revenue,
-        dailyProtocolRevenue: fees.revenue,
+        dailyFees,
+        dailyRevenue,
+        dailyProtocolRevenue: dailyRevenue,
     };
 }
 


### PR DESCRIPTION
Fixes #8250.

`fees/haedal-vault` forwards `fee` and `revenue` from `haedal.xyz/api/v1/wal/vault/fees` straight through. Since 2026-02-18 that endpoint has returned `fee: 0` while `revenue` keeps accruing, so the protocol page shows revenue with nothing behind it. Today:

```
{"fee":0,"revenue":144.68609594032674}
```

revenue is the protocol's cut of the fees, so it can't be larger than them. The adapter now throws instead of publishing the pair.

### the same guard catches something worse

While mapping how long the field had been broken i swept the endpoint back 500 days, and on scattered dates it returns a raw unscaled number for `revenue`:

```
$ curl '.../fees?fromTimestamp=1754352000&toTimestamp=1754438400'
{"code":200,"msg":"","data":{"fee":834.0654269255554,"revenue":12420960347434628}}
```

that's $1.24e16 of revenue against $834 of fees. Same shape on 2025-09-09, 2025-10-14, 2025-11-18 and 2025-12-23, roughly one a month. None of them are in the published series (2025-08-05 shows $8,915), so the endpoint's answers for past windows have drifted from what it served at the time, worth knowing before anyone refills this adapter, because on master those days would land as quadrillions. `revenue <= fee` rejects them without needing a magnitude threshold.

### why not derive the fee from the revenue

That was my first idea and the numbers don't support it. The split isn't fixed:

```
2025-07-26  fee=959.93   rev=121.95   ratio=0.1270
2025-10-19  fee=738.59   rev=93.41    ratio=0.1265
2025-11-28  fee=673.84   rev=200.46   ratio=0.2975
2025-12-28  fee=454.82   rev=192.24   ratio=0.4227
2026-01-07  fee=763.35   rev=8.07     ratio=0.0106
```

0.127 for months, then drifting to 0.42, then collapsing. Any back-computed fee would be invented, so this only rejects what's wrong rather than guessing what's right. Deriving the true fee needs Haedal to fix the field.

### behaviour

- healthy historical day is untouched, `npm test fees haedal-vault 2025-10-19` gives fees 627.00 / revenue 80.00 / protocol revenue 80.00, same as master
- today throws: `api returned 144.64434539037728 revenue against 0 fees for 2026-08-05`
- the 2025-08-05 window throws on the 1.24e16 value
- also rejects null/blank/non-finite before conversion, since `Number(null)` is `0` and finite

this makes the chart stop rather than continue with revenue-only days. that's the intent; the fees number was never real, and the real repair is on Haedal's side.
