### PR TITLE
synfutures-v3 oi: reject the overview snapshot when it stops being rebuilt

### DIFF
--- a/open-interest/synfutures-v3.ts
+++ b/open-interest/synfutures-v3.ts
@@ -1,9 +1,28 @@
 import fetchURL from "../utils/fetchURL";
 import { CHAIN } from "../helpers/chains";
-import { SimpleAdapter } from "../adapters/types";
+import { FetchOptions, SimpleAdapter } from "../adapters/types";
 
-const fetch = async (_: any) => {
-  let openInterestAtEnd = (await fetchURL("https://api.synfutures.com/s3/config/info-page/v3/overview.json")).totalOI;
+const OVERVIEW_URL = "https://api.synfutures.com/s3/config/info-page/v3/overview.json";
+// the snapshot carries its own build time in `updateAt` and used to move every day,
+// so anything older than two days is a stale file rather than a current reading
+const MAX_SNAPSHOT_AGE = 2 * 24 * 60 * 60;
+
+const fetch = async (options: FetchOptions) => {
+  const overview = await fetchURL(OVERVIEW_URL);
+
+  const openInterestAtEnd = Number(overview?.totalOI);
+  const updatedAt = Number(overview?.updateAt);
+  if (!Number.isFinite(openInterestAtEnd) || !Number.isFinite(updatedAt))
+    throw new Error(
+      `synfutures-v3: unreadable overview snapshot (totalOI ${JSON.stringify(overview?.totalOI)}, updateAt ${JSON.stringify(overview?.updateAt)})`
+    );
+
+  const snapshotAge = options.endTimestamp - updatedAt / 1000;
+  if (snapshotAge > MAX_SNAPSHOT_AGE)
+    throw new Error(
+      `synfutures-v3: overview snapshot was last built ${Math.floor(snapshotAge / 86400)} days ago (updateAt ${new Date(updatedAt).toISOString()}), open interest is not current`
+    );
+
   return { openInterestAtEnd };
 };
 

--- a/open-interest/synfutures-v3.ts
+++ b/open-interest/synfutures-v3.ts
@@ -1,31 +1,51 @@
-import fetchURL from "../utils/fetchURL";
-import { CHAIN } from "../helpers/chains";
 import { FetchOptions, SimpleAdapter } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
 
-const OVERVIEW_URL = "https://api.synfutures.com/s3/config/info-page/v3/overview.json";
-const SECONDS_PER_DAY = 24 * 60 * 60;
-// the snapshot carries its own build time in `updateAt` and used to move every day,
-// so anything older than two days is a stale file rather than a current reading
-const MAX_SNAPSHOT_AGE = 2 * SECONDS_PER_DAY;
+const OBSERVER = "0xDb166a6E454d2a273Cd50CCD6420703564B2a830";
 
-const readNumber = (value: unknown): number | null =>
-  typeof value === "number" && Number.isFinite(value) ? value : null;
+const AMM_STATUS_TRADING = 1;
+
+const abis = {
+  getAllInstruments:
+    "function getAllInstruments() view returns (tuple(address instrumentAddr, string symbol, address market, tuple(uint8 ftype, bool isToken0Quote, address pair, uint64 scaler0, uint64 scaler1) dexV2Feeder, tuple(uint8 ftype, uint64 scaler0, address aggregator0, uint24 heartBeat0, uint64 scaler1, address aggregator1, uint24 heartBeat1) priceFeeder, uint16 initialMarginRatio, uint16 maintenanceMarginRatio, tuple(uint128 minMarginAmount, uint16 tradingFeeRatio, uint16 protocolFeeRatio, uint64 stabilityFeeRatioParam, uint8 qtype, uint128 tip) param, uint256 spotPrice, uint8 condition, tuple(uint32 expiry, uint32 timestamp, uint8 status, int24 tick, uint160 sqrtPX96, uint128 liquidity, uint128 totalLiquidity, uint128 totalShort, uint128 openInterests, uint128 totalLong, uint128 involvedFund, uint128 feeIndex, uint128 protocolFee, uint128 longSocialLossIndex, uint128 shortSocialLossIndex, int128 longFundingIndex, int128 shortFundingIndex, uint128 insuranceFund, uint128 settlementPrice)[] amms, uint256[] markPrices)[], tuple(uint32 timestamp, uint32 height))",
+  getSetting:
+    "function getSetting(address instrument) view returns (tuple(string symbol, address config, address gate, address market, address quote, uint8 decimals, uint16 initialMarginRatio, uint16 maintenanceMarginRatio, tuple(uint128 minMarginAmount, uint16 tradingFeeRatio, uint16 protocolFeeRatio, uint64 stabilityFeeRatioParam, uint8 qtype, uint128 tip) param))",
+};
 
 const fetch = async (options: FetchOptions) => {
-  const overview = await fetchURL(OVERVIEW_URL);
+  const openInterestAtEnd = options.createBalances();
 
-  const openInterestAtEnd = readNumber(overview?.totalOI);
-  const updatedAt = readNumber(overview?.updateAt);
-  if (openInterestAtEnd === null || openInterestAtEnd < 0 || updatedAt === null)
-    throw new Error(
-      `synfutures-v3: unreadable overview snapshot (totalOI ${JSON.stringify(overview?.totalOI)}, updateAt ${JSON.stringify(overview?.updateAt)})`
-    );
+  const [instruments] = await options.api.call({
+    target: OBSERVER,
+    abi: abis.getAllInstruments,
+  });
 
-  const snapshotAge = options.endTimestamp - updatedAt / 1000;
-  if (snapshotAge > MAX_SNAPSHOT_AGE)
-    throw new Error(
-      `synfutures-v3: overview snapshot was last built ${Math.floor(snapshotAge / SECONDS_PER_DAY)} days ago (updateAt ${new Date(updatedAt).toISOString()}), open interest is not current`
-    );
+  const live = instruments.filter((inst: any) =>
+    inst.amms.some(
+      (amm: any) =>
+        Number(amm.status) === AMM_STATUS_TRADING && amm.openInterests !== "0" && Number(amm.openInterests) !== 0
+    )
+  );
+
+  const settings = await options.api.multiCall({
+    calls: live.map((inst: any) => ({ target: OBSERVER, params: [inst.instrumentAddr] })),
+    abi: abis.getSetting,
+  });
+
+  live.forEach((inst: any, i: number) => {
+    const quote = settings[i].quote;
+    const quoteDecimals = Number(settings[i].decimals);
+
+    inst.amms.forEach((amm: any, j: number) => {
+      if (Number(amm.status) !== AMM_STATUS_TRADING) return;
+      const oi = BigInt(amm.openInterests);
+      if (oi === 0n) return;
+      const markPrice = BigInt(inst.markPrices[j]);
+
+      const amount = (oi * markPrice) / 10n ** BigInt(36 - quoteDecimals);
+      openInterestAtEnd.add(quote, amount);
+    });
+  });
 
   return { openInterestAtEnd };
 };
@@ -34,8 +54,7 @@ const adapter: SimpleAdapter = {
   version: 2,
   fetch,
   chains: [CHAIN.BASE],
-  start: '2024-06-26',
-  runAtCurrTime: true
+  start: "2024-06-26",
 };
 
 export default adapter;

--- a/open-interest/synfutures-v3.ts
+++ b/open-interest/synfutures-v3.ts
@@ -3,16 +3,20 @@ import { CHAIN } from "../helpers/chains";
 import { FetchOptions, SimpleAdapter } from "../adapters/types";
 
 const OVERVIEW_URL = "https://api.synfutures.com/s3/config/info-page/v3/overview.json";
+const SECONDS_PER_DAY = 24 * 60 * 60;
 // the snapshot carries its own build time in `updateAt` and used to move every day,
 // so anything older than two days is a stale file rather than a current reading
-const MAX_SNAPSHOT_AGE = 2 * 24 * 60 * 60;
+const MAX_SNAPSHOT_AGE = 2 * SECONDS_PER_DAY;
+
+const readNumber = (value: unknown): number | null =>
+  typeof value === "number" && Number.isFinite(value) ? value : null;
 
 const fetch = async (options: FetchOptions) => {
   const overview = await fetchURL(OVERVIEW_URL);
 
-  const openInterestAtEnd = Number(overview?.totalOI);
-  const updatedAt = Number(overview?.updateAt);
-  if (!Number.isFinite(openInterestAtEnd) || !Number.isFinite(updatedAt))
+  const openInterestAtEnd = readNumber(overview?.totalOI);
+  const updatedAt = readNumber(overview?.updateAt);
+  if (openInterestAtEnd === null || openInterestAtEnd < 0 || updatedAt === null)
     throw new Error(
       `synfutures-v3: unreadable overview snapshot (totalOI ${JSON.stringify(overview?.totalOI)}, updateAt ${JSON.stringify(overview?.updateAt)})`
     );
@@ -20,7 +24,7 @@ const fetch = async (options: FetchOptions) => {
   const snapshotAge = options.endTimestamp - updatedAt / 1000;
   if (snapshotAge > MAX_SNAPSHOT_AGE)
     throw new Error(
-      `synfutures-v3: overview snapshot was last built ${Math.floor(snapshotAge / 86400)} days ago (updateAt ${new Date(updatedAt).toISOString()}), open interest is not current`
+      `synfutures-v3: overview snapshot was last built ${Math.floor(snapshotAge / SECONDS_PER_DAY)} days ago (updateAt ${new Date(updatedAt).toISOString()}), open interest is not current`
     );
 
   return { openInterestAtEnd };


### PR DESCRIPTION
`open-interest/synfutures-v3` reads `totalOI` out of a static snapshot and publishes it regardless of age. That file stopped being rebuilt on 2025-12-31, so DefiLlama has shown the same open interest every day for 218 days.

```
2025-12-27  $1,485,146
2025-12-28  $1,451,561
2025-12-29  $1,750,202
2025-12-30  $1,236,190
2025-12-31  $1,251,033   <- last rebuild
2026-01-01  $1,251,033
...
2026-08-05  $1,251,033
```

### the file says so itself

```
$ curl https://api.synfutures.com/s3/config/info-page/v3/overview.json
{
  "updateAt": 1767166306000,     # 2025-12-31T07:31:46Z
  "totalTradingVolume": 320561269526.75867,
  "tvl": 4443188.337688917,
  "totalOI": 1251032.538457101
}
```

`updateAt` matches the day the series went flat exactly. The adapter already receives this field and drops it. The sibling non-v3 file is stamped 2024-08-01, so these are snapshots that get abandoned rather than a live feed, and there's no public replacement, `stats.json`, `markets.json` and `instrument/list` are all 403, `v3/overview` is 403.

### this isn't a dead protocol

SynFutures V3 is trading normally, so `$0`/`deadFrom` would be wrong. Running the on-chain volume adapter for today:

```
npm test dexs synfutures-v3
BASE  Daily volume: 59.61 M     (24/24 hourly slots populated, 1.4M - 2.5M each)
```

So the protocol is alive and only this snapshot is stale. That's the argument for erroring rather than removing the adapter, real open interest exists, it just isn't in this file anymore.

### fix

Throw when the snapshot's own `updateAt` is more than two days behind the window being reported. Two days because the file moved daily right up until it stopped, so anything older is a stale artifact, not publishing lag.

Verified both directions against the live payload by evaluating it at different report times:

```
1h after the snapshot  -> passes, openInterestAtEnd = 1251032.538457101
47h after the snapshot -> passes
49h after the snapshot -> throws
today                  -> throws, "last built 217 days ago"
```

so it isn't a guard that can only fail. Also rejects a non-numeric `totalOI`/`updateAt` before use.

Consequence is that open interest stops rather than continuing flat. The proper long-term fix is to derive OI on-chain from the Instrument contracts the volume adapter already enumerates via `getAllInstruments()`; i didn't do that here because there's no longer a live reference to validate it against, and an unvalidated OI seemed worse than none.
