### PR TITLE
invariant: reject the stats snapshot once it stops advancing

### DIFF
--- a/dexs/invariant/index.ts
+++ b/dexs/invariant/index.ts
@@ -17,9 +17,13 @@ type StatsApiResponse = {
   };
 };
 
+const SECONDS_PER_DAY = 24 * 60 * 60;
 // the interval snapshot stamps the day it covers and used to advance daily,
 // so anything older than two days is a stale snapshot rather than a fresh one
-const MAX_SNAPSHOT_AGE = 2 * 24 * 60 * 60;
+const MAX_SNAPSHOT_AGE = 2 * SECONDS_PER_DAY;
+
+const readNumber = (value: unknown): number | null =>
+  typeof value === "number" && Number.isFinite(value) ? value : null;
 
 const fetch = async (
   fullSnapEndpoint: string,
@@ -29,22 +33,24 @@ const fetch = async (
     fullSnapEndpoint
   );
 
-  const dailyVolume = Number(fullSnapResponse.data.volume24?.value);
-  const dailyFees = Number(fullSnapResponse.data.fees24?.value);
-  const snapshotTimestamp = Number(fullSnapResponse.data.timestamp);
+  const dailyVolume = readNumber(fullSnapResponse.data.volume24?.value);
+  const dailyFees = readNumber(fullSnapResponse.data.fees24?.value);
+  const snapshotTimestamp = readNumber(fullSnapResponse.data.timestamp);
   if (
-    !Number.isFinite(dailyVolume) ||
-    !Number.isFinite(dailyFees) ||
-    !Number.isFinite(snapshotTimestamp)
+    dailyVolume === null ||
+    dailyFees === null ||
+    snapshotTimestamp === null ||
+    dailyVolume < 0 ||
+    dailyFees < 0
   )
     throw new Error(
-      `invariant: unreadable stats snapshot from ${fullSnapEndpoint}`
+      `invariant: unreadable stats snapshot from ${fullSnapEndpoint} (volume24 ${JSON.stringify(fullSnapResponse.data.volume24?.value)}, fees24 ${JSON.stringify(fullSnapResponse.data.fees24?.value)}, timestamp ${JSON.stringify(fullSnapResponse.data.timestamp)})`
     );
 
   const snapshotAge = options.endTimestamp - snapshotTimestamp / 1000;
   if (snapshotAge > MAX_SNAPSHOT_AGE)
     throw new Error(
-      `invariant: ${fullSnapEndpoint} last advanced ${Math.floor(snapshotAge / 86400)} days ago (timestamp ${new Date(snapshotTimestamp).toISOString()}), its 24h figures are not current`
+      `invariant: ${fullSnapEndpoint} last advanced ${Math.floor(snapshotAge / SECONDS_PER_DAY)} days ago (timestamp ${new Date(snapshotTimestamp).toISOString()}), its 24h figures are not current`
     );
 
   return {

--- a/dexs/invariant/index.ts
+++ b/dexs/invariant/index.ts
@@ -11,18 +11,44 @@ const PROTOCOL_FEE_RATIO = 0.01;
 
 type StatsApiResponse = {
   data: {
+    timestamp: number;
     volume24: { value: number; };
     fees24: { value: number; };
   };
 };
 
-const fetch = async (fullSnapEndpoint: string): Promise<FetchResult> => {
+// the interval snapshot stamps the day it covers and used to advance daily,
+// so anything older than two days is a stale snapshot rather than a fresh one
+const MAX_SNAPSHOT_AGE = 2 * 24 * 60 * 60;
+
+const fetch = async (
+  fullSnapEndpoint: string,
+  options: FetchOptions
+): Promise<FetchResult> => {
   const fullSnapResponse = await axios.get<any, StatsApiResponse>(
     fullSnapEndpoint
   );
-  const dailyFees = fullSnapResponse.data.fees24.value;
+
+  const dailyVolume = Number(fullSnapResponse.data.volume24?.value);
+  const dailyFees = Number(fullSnapResponse.data.fees24?.value);
+  const snapshotTimestamp = Number(fullSnapResponse.data.timestamp);
+  if (
+    !Number.isFinite(dailyVolume) ||
+    !Number.isFinite(dailyFees) ||
+    !Number.isFinite(snapshotTimestamp)
+  )
+    throw new Error(
+      `invariant: unreadable stats snapshot from ${fullSnapEndpoint}`
+    );
+
+  const snapshotAge = options.endTimestamp - snapshotTimestamp / 1000;
+  if (snapshotAge > MAX_SNAPSHOT_AGE)
+    throw new Error(
+      `invariant: ${fullSnapEndpoint} last advanced ${Math.floor(snapshotAge / 86400)} days ago (timestamp ${new Date(snapshotTimestamp).toISOString()}), its 24h figures are not current`
+    );
+
   return {
-    dailyVolume: fullSnapResponse.data.volume24.value,
+    dailyVolume,
     dailyFees,
     dailySupplySideRevenue: dailyFees * (1 - PROTOCOL_FEE_RATIO),
     dailyRevenue: dailyFees * PROTOCOL_FEE_RATIO,
@@ -30,12 +56,12 @@ const fetch = async (fullSnapEndpoint: string): Promise<FetchResult> => {
   };
 };
 
-const fetchSolana = async (_options: FetchOptions) => {
-  return fetch(solanaStatsApiEndpoint);
+const fetchSolana = async (options: FetchOptions) => {
+  return fetch(solanaStatsApiEndpoint, options);
 };
 
-const fetchEclipse = async (_options: FetchOptions) => {
-  return fetch(eclipseStatsApiEndpoint);
+const fetchEclipse = async (options: FetchOptions) => {
+  return fetch(eclipseStatsApiEndpoint, options);
 };
 
 const adapter: SimpleAdapter = {


### PR DESCRIPTION
`dexs/invariant` publishes `volume24`/`fees24` from the stats snapshot without checking whether the snapshot moved. It stopped moving, so the same numbers have been republished every day since 2026-04-29, 99 days of an identical $25,741 volume and $20.52 fees.

```
2026-07-23  $25,741
2026-07-24  $25,741
...
2026-08-05  $25,741
```

### the endpoints are 200 but frozen

Both carry a `timestamp` for the day they cover, and it hasn't advanced since 2026-03-09. Two calls two seconds apart:

```
$ curl '.../eclipse/intervals/eclipse-mainnet?interval=daily'
timestamp 1773057600000  cumVol 598390375.9273833  vol24 20552.947459827006
timestamp 1773057600000  cumVol 598390375.9273833  vol24 20552.947459827006
```

`cumulativeVolume` is pinned too, which it couldn't be if anything were still trading through it. solana 5,187.99 + eclipse 20,552.94 = 25,740.94, exactly the value on the chart.

This is the follow-on from #6602. The old `full_snap` endpoints were 500ing, #6607 proposed marking the source dead, and #6602 repointed to these `intervals` endpoints instead and was merged. They answer 200, so the adapter looks healthy, but they serve a fixed snapshot, arguably worse than the 500 because nothing surfaces it.

### protocol is alive, so deadFrom would be wrong

DefiLlama's own TVL for Invariant is computed independently of this API and still moves daily:

```
2026-08-01  $241,407
2026-08-02  $259,736
2026-08-03  $261,923
2026-08-04  $260,967
2026-08-05  $261,920
```

invariant.app is up. So this is a stale feed on a live protocol, same as the state #6607 was trying to describe, just now hidden behind a 200.

### fix

Throw when the snapshot's own `timestamp` is more than two days behind the window being reported, and reject non-numeric fields before use. Two days because the snapshot advanced daily while it was healthy.

Checked both directions on both chains against the live payload by evaluating at different report times, so it isn't a guard that can only fail:

```
solana   1h after snapshot  -> vol=5187.996657561      fees=0.520793613
solana   47h after snapshot -> passes
solana   49h after snapshot -> throws
solana   today              -> throws, "last advanced 148 days ago"
eclipse  1h after snapshot  -> vol=20552.947459827006  fees=19.769089934
eclipse  47h / 49h / today  -> passes / throws / throws
```

Volume and fees stop rather than repeating a fixed number. If Invariant publishes a working endpoint this only needs the URL swapped, the staleness check can stay.
