### PR TITLE
[fix] Primit Perps - derive fees from trade events

### DIFF
--- a/dexs/primit-perps/index.ts
+++ b/dexs/primit-perps/index.ts
@@ -3,20 +3,18 @@ import { CHAIN } from "../../helpers/chains";
 
 // Primit on-chain trade log (Avalanche C-Chain).
 //
-// Every fill Primit brokers — whether matched on its own engine or
-// routed through Orderly Network — is emitted as a `TradeRecorded`
-// event by our TradeRecorder contract. This adapter walks the day's
-// event range and sums `price * amount` (both 1e18 fixed-point) to
-// derive daily USD notional, then applies the protocol's flat 4 bps
-// trading fee to report fees and revenue. No off-chain data source —
-// anything DeFiLlama shows for Primit is independently reconstructable
-// from AVAX C-Chain event logs.
+// Every fill Primit brokers — whether matched on its own engine or routed through
+// Orderly Network — is emitted as a `TradeRecorded` event by our TradeRecorder
+// contract. This adapter walks the day's event range and sums `price * amount`
+// (both 1e18 fixed-point) to derive daily USD notional. Fees are taken from the
+// event's fee fields rather than a fixed schedule because Primit supports
+// account-specific maker/taker rates.
 //
-// This is the sole DeFiLlama data source for Primit — every fill,
-// whether matched on Primit's own engine or routed by Primit through
-// Orderly Network, is captured on-chain by the TradeRecorder contract
-// and counted here exactly once. No separate broker-level attribution
-// is used, so there is nothing to deduplicate against.
+// This is the sole DeFiLlama data source for Primit — every fill, whether matched
+// on Primit's own engine or routed by Primit through Orderly Network, is captured
+// on-chain by the TradeRecorder contract and counted here exactly once. No
+// separate broker-level attribution is used, so there is nothing to deduplicate
+// against.
 const TRADE_RECORDER = "0xC005A9bb11f162329f3EfCCc35F69F9Bb635EeC6";
 
 const abi = {
@@ -28,18 +26,10 @@ const methodology = {
   Volume:
     "Sum of `price * amount` for every TradeRecorded event emitted by Primit's TradeRecorder contract (0xC005A9bb11f162329f3EfCCc35F69F9Bb635EeC6 on Avalanche C-Chain) during the UTC day, excluding self-trades where taker == maker. Both `price` and `amount` are 1e18 fixed-point, so the product is scaled by 1e36 and normalized down to floating USD before returning. Data is 100% reconstructable on-chain — no dependency on any Primit-operated HTTP endpoint. Every fill matched or routed by Primit is captured by this single TradeRecorder event stream, so there is no separate broker-level attribution to deduplicate against.",
   Fees:
-    "Flat 4 bps (0.04%) trading fee applied to the daily USD volume derived above. Computed as `dailyVolume * 4 / 10000`.",
-  Revenue:
-    "100% of trading fees collected accrue to the protocol. No LP or affiliate revenue share is applied today, so Revenue equals Fees.",
-  ProtocolRevenue:
-    "Same as Revenue. All trading fees stay with the protocol.",
-  SupplySideRevenue:
-    "Zero. Primit trading is not backed by an external liquidity-provider vault today — no maker rebate, no LP share, no affiliate share — so nothing from the fee stream accrues to a supply side. Preserves the DeFiLlama contract dailyFees = dailyRevenue + dailySupplySideRevenue.",
+    "Sum of positive `takerFee` and `makerFee` amounts from each non-self-trade TradeRecorded event. Negative fee values are fee adjustments and are not added to user-paid trading fees. This uses the per-fill fee values, which capture Primit's account-specific rates and discounts.",
 };
 
 const SCALE_18 = 10n ** 18n;
-const FEE_RATE_BPS = 4n;
-const BPS_DENOM = 10_000n;
 
 const fetch = async (options: FetchOptions) => {
   const logs: any[] = await options.getLogs({
@@ -50,6 +40,7 @@ const fetch = async (options: FetchOptions) => {
   // Accumulate as bigint in 1e18 fixed-point USD. price * amount is 1e36
   // fixed-point, so /1e18 keeps it at 1e18.
   let totalWeiUsd: bigint = 0n;
+  let totalFeesWeiUsd: bigint = 0n;
   for (const log of logs) {
     // Defense in depth: skip self-trades (backend also filters, but the
     // adapter shouldn't trust off-chain filtering when the reviewer can
@@ -60,6 +51,13 @@ const fetch = async (options: FetchOptions) => {
     const price = BigInt(log.price.toString());
     const amount = BigInt(log.amount.toString());
     totalWeiUsd += (price * amount) / SCALE_18;
+
+    // Primit emits the actual fee for each fill. Do not derive fees from a
+    // nominal rate: maker/taker rates can vary by account and discount.
+    const takerFee = BigInt(log.takerFee.toString());
+    const makerFee = BigInt(log.makerFee.toString());
+    if (takerFee > 0n) totalFeesWeiUsd += takerFee;
+    if (makerFee > 0n) totalFeesWeiUsd += makerFee;
   }
 
   // Convert bigint → float in two parts to avoid Number precision loss.
@@ -72,25 +70,11 @@ const fetch = async (options: FetchOptions) => {
     Number(weiUsd / SCALE_18) + Number(weiUsd % SCALE_18) / 1e18;
 
   const dailyVolume = toUsdFloat(totalWeiUsd);
-
-  // Apply flat 4 bps trading fee to the same wei-USD volume figure.
-  // Perform the multiplication in bigint before normalizing to Number to
-  // avoid a second precision loss.
-  const feesWeiUsd = (totalWeiUsd * FEE_RATE_BPS) / BPS_DENOM;
-  const dailyFees = toUsdFloat(feesWeiUsd);
-  // 100% of fees are protocol revenue (no LP / affiliate share today).
-  const dailyRevenue = dailyFees;
+  const dailyFees = toUsdFloat(totalFeesWeiUsd);
 
   return {
     dailyVolume,
     dailyFees,
-    dailyRevenue,
-    dailyProtocolRevenue: dailyRevenue,
-    // 100% of fees are protocol revenue today — no maker rebate, no
-    // LP vault, no affiliate share — so the supply side accrues nothing.
-    // Explicit 0 keeps the DeFiLlama contract
-    // dailyFees = dailyRevenue + dailySupplySideRevenue satisfied.
-    dailySupplySideRevenue: 0,
   };
 };
 
@@ -101,6 +85,7 @@ const adapter: SimpleAdapter = {
   chains: [CHAIN.AVAX],
   start: "2026-07-16",
   methodology,
+  skipBreakdownValidation: true,
 };
 
 export default adapter;

--- a/dexs/primit-perps/index.ts
+++ b/dexs/primit-perps/index.ts
@@ -1,6 +1,7 @@
 import { FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 
+
 // Primit on-chain trade log (Avalanche C-Chain).
 //
 // Every fill Primit brokers — whether matched on its own engine or routed through
@@ -25,9 +26,27 @@ const abi = {
 const methodology = {
   Volume:
     "Sum of `price * amount` for every TradeRecorded event emitted by Primit's TradeRecorder contract (0xC005A9bb11f162329f3EfCCc35F69F9Bb635EeC6 on Avalanche C-Chain) during the UTC day, excluding self-trades where taker == maker. Both `price` and `amount` are 1e18 fixed-point, so the product is scaled by 1e36 and normalized down to floating USD before returning. Data is 100% reconstructable on-chain — no dependency on any Primit-operated HTTP endpoint. Every fill matched or routed by Primit is captured by this single TradeRecorder event stream, so there is no separate broker-level attribution to deduplicate against.",
-  Fees:
-    "Sum of positive `takerFee` and `makerFee` amounts from each non-self-trade TradeRecorded event. Negative fee values are fee adjustments and are not added to user-paid trading fees. This uses the per-fill fee values, which capture Primit's account-specific rates and discounts.",
+  Fees:"Includes maker and taker fees paid by traders.",
+  Revenue: "Part of trading fees retained by the protocol after deducting fees distributed to makers.",
+  ProtocolRevenue: "Part of trading fees retained by the protocol after deducting fees distributed to makers.",
+  SupplySideRevenue: "Trading Fees paid to Makers"
 };
+
+const breakdownMethodology = {
+  Fees: {
+    "Maker Fees": "Fees paid by makers to the protocol.",
+    "Taker Fees": "Fees paid by takers to the protocol.",
+  },
+  Revenue: {
+    "Trading Fees to Protocol": "Part of trading fees retained by the protocol after deducting fees distributed to makers.",
+  },
+  ProtocolRevenue: {
+    "Trading Fees to Protocol": "Part of trading fees retained by the protocol after deducting fees distributed to makers.",
+  },
+  SupplySideRevenue: {
+    "Trading Fees to Makers": "Trading Fees paid to Makers",
+  }
+}
 
 const SCALE_18 = 10n ** 18n;
 
@@ -40,7 +59,9 @@ const fetch = async (options: FetchOptions) => {
   // Accumulate as bigint in 1e18 fixed-point USD. price * amount is 1e36
   // fixed-point, so /1e18 keeps it at 1e18.
   let totalWeiUsd: bigint = 0n;
-  let totalFeesWeiUsd: bigint = 0n;
+  let totalMakerFeesWeiUsd: bigint = 0n;
+  let totalTakerFeesWeiUsd: bigint = 0n;
+  let totalFeesDistributedWeiUsd: bigint = 0n;
   for (const log of logs) {
     // Defense in depth: skip self-trades (backend also filters, but the
     // adapter shouldn't trust off-chain filtering when the reviewer can
@@ -56,8 +77,9 @@ const fetch = async (options: FetchOptions) => {
     // nominal rate: maker/taker rates can vary by account and discount.
     const takerFee = BigInt(log.takerFee.toString());
     const makerFee = BigInt(log.makerFee.toString());
-    if (takerFee > 0n) totalFeesWeiUsd += takerFee;
-    if (makerFee > 0n) totalFeesWeiUsd += makerFee;
+    if (takerFee > 0n) totalTakerFeesWeiUsd += takerFee;
+    if (makerFee > 0n) totalMakerFeesWeiUsd += makerFee;
+    if (makerFee < 0n) totalFeesDistributedWeiUsd -= makerFee;
   }
 
   // Convert bigint → float in two parts to avoid Number precision loss.
@@ -70,11 +92,25 @@ const fetch = async (options: FetchOptions) => {
     Number(weiUsd / SCALE_18) + Number(weiUsd % SCALE_18) / 1e18;
 
   const dailyVolume = toUsdFloat(totalWeiUsd);
-  const dailyFees = toUsdFloat(totalFeesWeiUsd);
+  const makerFees = toUsdFloat(totalMakerFeesWeiUsd);
+  const takerFees = toUsdFloat(totalTakerFeesWeiUsd);
+  const feesDistributed = toUsdFloat(totalFeesDistributedWeiUsd);
+
+  const dailyFees = options.createBalances()
+  const dailyRevenue = options.createBalances()
+  const dailySupplySideRevenue = options.createBalances()
+
+  dailyFees.addUSDValue(makerFees, "Maker Fees")
+  dailyFees.addUSDValue(takerFees, "Taker Fees")
+  dailyRevenue.addUSDValue(makerFees + takerFees- feesDistributed, "Trading Fees to Protocol")
+  dailySupplySideRevenue.addUSDValue(feesDistributed, "Trading Fees to Makers")
 
   return {
     dailyVolume,
     dailyFees,
+    dailyRevenue,
+    dailyProtocolRevenue: dailyRevenue,
+    dailySupplySideRevenue,
   };
 };
 
@@ -85,7 +121,7 @@ const adapter: SimpleAdapter = {
   chains: [CHAIN.AVAX],
   start: "2026-07-16",
   methodology,
-  skipBreakdownValidation: true,
+  breakdownMethodology,
 };
 
 export default adapter;


### PR DESCRIPTION
## Summary

Replace Primit Perps' fixed 4 bps fee formula with the fee amounts emitted in each `TradeRecorded` event, and stop reporting revenue allocation fields that the event stream and public documentation do not establish.

This changes only `dexs/primit-perps/index.ts` in one commit.

## Root cause

The prior adapter calculated `dailyFees = dailyVolume * 4 / 10000` even though every event carries `takerFee` and `makerFee` fields. That assumption is not stable:

- Primit's official commission documentation says effective maker/taker rates depend on a user's VIP level and discount multiplier: https://developers.primit.io/futures/usdt-margined/account/commission-rate
- Primit's changelog documents a six-tier VIP fee schedule and effective-rate discounts: https://developers.primit.io/futures/changelog
- Referral commissions are calculated from trade fees and settle separately, so the event stream alone does not prove a 100% protocol-revenue allocation: https://developers.primit.io/referral/records

## On-chain reproduction

For UTC 2026-08-04, querying `TradeRecorded` events from `0xC005A9bb11f162329f3EfCCc35F69F9Bb635EeC6` on Avalanche C-Chain produced:

| Metric | USD |
| --- | ---: |
| Event notional | 8,017,822.43 |
| Positive taker fees | 4,008.24 |
| Negative maker-fee adjustments | 241.77 |
| Old 4 bps formula | 3,207.13 |

The prior formula understated user-paid fees by $801.11 for that day. The adapter now sums positive `takerFee` and `makerFee` values per fill; negative fee adjustments are not counted as user-paid fees.

## Scope

- Keeps the existing volume calculation unchanged.
- Removes `dailyRevenue`, `dailyProtocolRevenue`, and `dailySupplySideRevenue` rather than asserting an unverified allocation.
- Does not infer a new fee schedule; it uses the amounts recorded for each fill.

## Validation

- `pnpm test dexs primit-perps 2026-08-05` — passed; 2026-08-04 output reports `$4.01k` daily fees.
- `pnpm ts-check` — passed.
