### PR TITLE
[feat] rocky - add Canton volume and fees adapter

### DIFF
--- a/dexs/rocky-perp/index.ts
+++ b/dexs/rocky-perp/index.ts
@@ -1,0 +1,137 @@
+import { CHAIN } from "../../helpers/chains";
+import { FetchOptions, FetchResult, SimpleAdapter } from "../../adapters/types";
+import fetchURL from "../../utils/fetchURL";
+
+/*
+ * Rocky Exchange — Canton Network perpetual futures DEX (volume + fees).
+ *
+ * Sibling adapter: dexs/rocky-spot/index.ts (spot orderbook).
+ *
+ * Source (public, unauthenticated, Binance-compatible perp market-data):
+ *   https://api.rocky.exchange/fapi/v1/ticker/24hr
+ *
+ * Returns a rolling 24-hour aggregation across every perp symbol.
+ * `quoteVolume` on each row is USD-denominated because Rocky's perp markets
+ * margin in USD-pegged assets (all symbols end in USDT), so summing rows
+ * directly yields USD notional.
+ *
+ * Perpetual margin is collateralized on Canton mainnet via `LockedAmulet`
+ * contracts; matching is performed off-chain by Rocky's engine, same pattern
+ * as most orderbook DEXes.
+ *
+ * runAtCurrTime + pullHourly:false — Rocky's Binance-compat ticker exposes a
+ * live rolling 24h window only; there is no historical time-travel or
+ * per-hour bucketing.
+ */
+
+const PERP_TICKER_URL = "https://api.rocky.exchange/fapi/v1/ticker/24hr";
+
+// Rocky internal-ledger fee schedule (source: rocky-backend
+// services/internal-ledger/src/fees.rs).
+const MAKER_FEE_BPS = 1;
+const TAKER_FEE_BPS = 5;
+const BPS = 10_000;
+
+// USD-pegged quote assets on Rocky perp — every perp symbol is Binance-style
+// concatenated (e.g. BTCUSDT), so we look for a trailing USD-quote suffix.
+const USD_QUOTE_ASSETS = new Set(["USDT", "USDC", "USDCX", "CUSD"]);
+
+const quoteAsset = (symbol: string): string => {
+  const upper = symbol.toUpperCase();
+  for (const q of USD_QUOTE_ASSETS) {
+    if (upper.endsWith(q)) return q;
+  }
+  return "";
+};
+
+type Ticker24hRow = {
+  symbol: string;
+  quoteVolume: string;
+};
+
+const sumUsdQuoteVolume = (rows: unknown): number => {
+  if (!Array.isArray(rows) || rows.length === 0) {
+    throw new Error("Rocky perp ticker/24hr returned empty or non-array payload");
+  }
+  let total = 0;
+  let usdQuotedRowCount = 0;
+  for (const row of rows as Ticker24hRow[]) {
+    const symbol = typeof row?.symbol === "string" ? row.symbol.trim() : "";
+    if (!symbol) {
+      throw new Error("Rocky perp ticker/24hr row missing symbol");
+    }
+    if (!USD_QUOTE_ASSETS.has(quoteAsset(symbol))) continue;
+    const rawVolume = typeof row?.quoteVolume === "string" ? row.quoteVolume.trim() : "";
+    if (rawVolume.length === 0) {
+      throw new Error(`Rocky perp ticker/24hr row ${symbol} missing quoteVolume`);
+    }
+    const v = Number(rawVolume);
+    if (!Number.isFinite(v) || v < 0) {
+      throw new Error(`Rocky perp ticker/24hr row ${symbol} invalid quoteVolume=${rawVolume}`);
+    }
+    total += v;
+    usdQuotedRowCount += 1;
+  }
+  if (usdQuotedRowCount === 0) {
+    throw new Error("Rocky perp ticker/24hr returned no USD-quoted rows");
+  }
+  return total;
+};
+
+const fetch = async (options: FetchOptions): Promise<FetchResult> => {
+  const rows = await fetchURL(PERP_TICKER_URL);
+  const dailyVolume = sumUsdQuoteVolume(rows);
+
+  const dailyFees = options.createBalances();
+  dailyFees.addUSDValue((dailyVolume * MAKER_FEE_BPS) / BPS, "Maker Fees");
+  dailyFees.addUSDValue((dailyVolume * TAKER_FEE_BPS) / BPS, "Taker Fees");
+
+  return {
+    dailyVolume,
+    dailyFees,
+    dailyRevenue: dailyFees,
+    dailyProtocolRevenue: dailyFees,
+    dailySupplySideRevenue: 0,
+  };
+};
+
+const methodology = {
+  Volume:
+    "Sum of `quoteVolume` for every USD-quoted perp symbol returned by Rocky's Binance-compatible 24h ticker endpoint at /fapi/v1/ticker/24hr. Rocky's perp markets margin in USD-pegged assets (BTCUSDT, ETHUSDT, CCUSDT), so `quoteVolume` is directly USD notional and the sum requires no external price conversion.",
+  Fees:
+    "Trading fees charged by Rocky's internal ledger: 1 bps maker + 5 bps taker (= 6 bps aggregate) applied to the same 24h volume figure. Rate source: rocky-backend services/internal-ledger/src/fees.rs.",
+  Revenue: "100% of trading fees accrue to the protocol.",
+  ProtocolRevenue: "100% of trading fees accrue to the protocol.",
+  SupplySideRevenue:
+    "Zero. Rocky has no LP vault or affiliate fee-share program today, so no portion of the fee stream is paid to a supply side.",
+};
+
+const breakdownMethodology = {
+  Fees: {
+    "Maker Fees": "1 bps maker fee applied to 24h volume.",
+    "Taker Fees": "5 bps taker fee applied to 24h volume.",
+  },
+  Revenue: {
+    "Maker Fees": "1 bps maker fee applied to 24h volume.",
+    "Taker Fees": "5 bps taker fee applied to 24h volume.",
+  },
+  ProtocolRevenue: {
+    "Maker Fees": "1 bps maker fee applied to 24h volume.",
+    "Taker Fees": "5 bps taker fee applied to 24h volume.",
+  },
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  fetch,
+  chains: [CHAIN.CANTON],
+  start: "2026-07-01",
+  runAtCurrTime: true,
+  // Rocky's ticker/24hr endpoint exposes a live rolling 24h window only.
+  // There is no per-hour bucketing, so pullHourly must be false.
+  pullHourly: false,
+  methodology,
+  breakdownMethodology,
+};
+
+export default adapter;

--- a/dexs/rocky-perp/index.ts
+++ b/dexs/rocky-perp/index.ts
@@ -26,12 +26,6 @@ import fetchURL from "../../utils/fetchURL";
 
 const PERP_TICKER_URL = "https://api.rocky.exchange/fapi/v1/ticker/24hr";
 
-// Rocky internal-ledger fee schedule (source: rocky-backend
-// services/internal-ledger/src/fees.rs).
-const MAKER_FEE_BPS = 1;
-const TAKER_FEE_BPS = 5;
-const BPS = 10_000;
-
 // USD-pegged quote assets on Rocky perp — every perp symbol is Binance-style
 // concatenated (e.g. BTCUSDT), so we look for a trailing USD-quote suffix.
 const USD_QUOTE_ASSETS = new Set(["USDT", "USDC", "USDCX", "CUSD"]);
@@ -78,60 +72,30 @@ const sumUsdQuoteVolume = (rows: unknown): number => {
   return total;
 };
 
-const fetch = async (options: FetchOptions): Promise<FetchResult> => {
+const fetch = async (_options: FetchOptions): Promise<FetchResult> => {
   const rows = await fetchURL(PERP_TICKER_URL);
   const dailyVolume = sumUsdQuoteVolume(rows);
 
-  const dailyFees = options.createBalances();
-  dailyFees.addUSDValue((dailyVolume * MAKER_FEE_BPS) / BPS, "Maker Fees");
-  dailyFees.addUSDValue((dailyVolume * TAKER_FEE_BPS) / BPS, "Taker Fees");
-
   return {
     dailyVolume,
-    dailyFees,
-    dailyRevenue: dailyFees,
-    dailyProtocolRevenue: dailyFees,
-    dailySupplySideRevenue: 0,
   };
 };
 
 const methodology = {
   Volume:
     "Sum of `quoteVolume` for every USD-quoted perp symbol returned by Rocky's Binance-compatible 24h ticker endpoint at /fapi/v1/ticker/24hr. Rocky's perp markets margin in USD-pegged assets (BTCUSDT, ETHUSDT, CCUSDT), so `quoteVolume` is directly USD notional and the sum requires no external price conversion.",
-  Fees:
-    "Trading fees charged by Rocky's internal ledger: 1 bps maker + 5 bps taker (= 6 bps aggregate) applied to the same 24h volume figure. Rate source: rocky-backend services/internal-ledger/src/fees.rs.",
-  Revenue: "100% of trading fees accrue to the protocol.",
-  ProtocolRevenue: "100% of trading fees accrue to the protocol.",
-  SupplySideRevenue:
-    "Zero. Rocky has no LP vault or affiliate fee-share program today, so no portion of the fee stream is paid to a supply side.",
 };
 
-const breakdownMethodology = {
-  Fees: {
-    "Maker Fees": "1 bps maker fee applied to 24h volume.",
-    "Taker Fees": "5 bps taker fee applied to 24h volume.",
-  },
-  Revenue: {
-    "Maker Fees": "1 bps maker fee applied to 24h volume.",
-    "Taker Fees": "5 bps taker fee applied to 24h volume.",
-  },
-  ProtocolRevenue: {
-    "Maker Fees": "1 bps maker fee applied to 24h volume.",
-    "Taker Fees": "5 bps taker fee applied to 24h volume.",
-  },
-};
 
 const adapter: SimpleAdapter = {
   version: 2,
   fetch,
   chains: [CHAIN.CANTON],
-  start: "2026-07-01",
   runAtCurrTime: true,
   // Rocky's ticker/24hr endpoint exposes a live rolling 24h window only.
   // There is no per-hour bucketing, so pullHourly must be false.
   pullHourly: false,
   methodology,
-  breakdownMethodology,
 };
 
 export default adapter;

--- a/dexs/rocky-spot/index.ts
+++ b/dexs/rocky-spot/index.ts
@@ -3,26 +3,24 @@ import { FetchOptions, FetchResult, SimpleAdapter } from "../../adapters/types";
 import fetchURL from "../../utils/fetchURL";
 
 /*
- * Rocky Exchange — Canton Network perpetual + spot DEX (volume + fees).
+ * Rocky Exchange — Canton Network spot orderbook DEX (volume + fees).
  *
- * Source (public, unauthenticated, Binance-compatible market-data):
- *   Perp:   https://api.rocky.exchange/fapi/v1/ticker/24hr
- *   Spot:   https://api.rocky.exchange/api/v3/ticker/24hr
+ * Sibling adapter: dexs/rocky-perp/index.ts (perpetual futures).
  *
- * Both endpoints return a rolling 24-hour aggregation across every symbol.
- * `quoteVolume` on each row is USD-denominated for USD-quoted markets (Rocky's
- * spot markets quote in USDCx/CUSD and perp markets margin in USD-pegged
- * assets), so summing USD-quoted rows directly yields USD notional.
+ * Source (public, unauthenticated, Binance-compatible spot market-data):
+ *   https://api.rocky.exchange/api/v3/ticker/24hr
  *
- * runAtCurrTime + pullHourly:false — Rocky's Binance-compat tickers expose a
- * live rolling 24h window only; there is no historical time-travel and no
- * per-hour bucketing. Same posture as dexs/pool-party (also Canton), which
- * uses the same rolling-24h source shape.
+ * Returns a rolling 24-hour aggregation across every spot symbol.
+ * `quoteVolume` on each row is USD-denominated for USD-quoted markets
+ * (Rocky's spot markets quote in USD-pegged CUSD/USDCx), so summing
+ * USD-quoted rows directly yields USD notional.
+ *
+ * runAtCurrTime + pullHourly:false — Rocky's Binance-compat ticker exposes a
+ * live rolling 24h window only; there is no historical time-travel or
+ * per-hour bucketing. Same posture as dexs/pool-party (also Canton).
  */
 
-const API_BASE = "https://api.rocky.exchange";
-const PERP_TICKER_URL = `${API_BASE}/fapi/v1/ticker/24hr`;
-const SPOT_TICKER_URL = `${API_BASE}/api/v3/ticker/24hr`;
+const SPOT_TICKER_URL = "https://api.rocky.exchange/api/v3/ticker/24hr";
 
 // Rocky internal-ledger fee schedule (source: rocky-backend
 // services/internal-ledger/src/fees.rs).
@@ -37,8 +35,7 @@ const BPS = 10_000;
 const USD_QUOTE_ASSETS = new Set(["CUSD", "USDCX", "USDC", "USDT"]);
 
 const quoteAsset = (symbol: string): string => {
-  // Spot markets use `BASE-QUOTE` (e.g. CBTC-CUSD); perp uses concatenated
-  // Binance-style (e.g. BTCUSDT). Handle both.
+  // Spot markets use `BASE-QUOTE` (e.g. CBTC-CUSD).
   if (symbol.includes("-")) return symbol.split("-").pop()!.toUpperCase();
   const upper = symbol.toUpperCase();
   for (const q of USD_QUOTE_ASSETS) {
@@ -52,53 +49,42 @@ type Ticker24hRow = {
   quoteVolume: string;
 };
 
-const sumUsdQuoteVolume = (rows: unknown, source: string): number => {
+const sumUsdQuoteVolume = (rows: unknown): number => {
   if (!Array.isArray(rows) || rows.length === 0) {
-    throw new Error(`Rocky ${source} ticker/24hr returned empty or non-array payload`);
+    throw new Error("Rocky spot ticker/24hr returned empty or non-array payload");
   }
   let total = 0;
   let usdQuotedRowCount = 0;
   for (const row of rows as Ticker24hRow[]) {
     const symbol = typeof row?.symbol === "string" ? row.symbol.trim() : "";
     if (!symbol) {
-      throw new Error(`Rocky ${source} ticker/24hr row missing symbol`);
+      throw new Error("Rocky spot ticker/24hr row missing symbol");
     }
     if (!USD_QUOTE_ASSETS.has(quoteAsset(symbol))) continue;
     const rawVolume = typeof row?.quoteVolume === "string" ? row.quoteVolume.trim() : "";
     if (rawVolume.length === 0) {
-      throw new Error(`Rocky ${source} ticker/24hr row ${symbol} missing quoteVolume`);
+      throw new Error(`Rocky spot ticker/24hr row ${symbol} missing quoteVolume`);
     }
     const v = Number(rawVolume);
     if (!Number.isFinite(v) || v < 0) {
-      throw new Error(`Rocky ${source} ticker/24hr row ${symbol} invalid quoteVolume=${rawVolume}`);
+      throw new Error(`Rocky spot ticker/24hr row ${symbol} invalid quoteVolume=${rawVolume}`);
     }
     total += v;
     usdQuotedRowCount += 1;
   }
   if (usdQuotedRowCount === 0) {
-    throw new Error(`Rocky ${source} ticker/24hr returned no USD-quoted rows`);
+    throw new Error("Rocky spot ticker/24hr returned no USD-quoted rows");
   }
   return total;
 };
 
 const fetch = async (options: FetchOptions): Promise<FetchResult> => {
-  const [perpRows, spotRows] = await Promise.all([
-    fetchURL(PERP_TICKER_URL),
-    fetchURL(SPOT_TICKER_URL),
-  ]);
-
-  const dailyVolume =
-    sumUsdQuoteVolume(perpRows, "perp") + sumUsdQuoteVolume(spotRows, "spot");
+  const rows = await fetchURL(SPOT_TICKER_URL);
+  const dailyVolume = sumUsdQuoteVolume(rows);
 
   const dailyFees = options.createBalances();
-  dailyFees.addUSDValue(
-    (dailyVolume * MAKER_FEE_BPS) / BPS,
-    "Maker Fees",
-  );
-  dailyFees.addUSDValue(
-    (dailyVolume * TAKER_FEE_BPS) / BPS,
-    "Taker Fees",
-  );
+  dailyFees.addUSDValue((dailyVolume * MAKER_FEE_BPS) / BPS, "Maker Fees");
+  dailyFees.addUSDValue((dailyVolume * TAKER_FEE_BPS) / BPS, "Taker Fees");
 
   return {
     dailyVolume,
@@ -111,7 +97,7 @@ const fetch = async (options: FetchOptions): Promise<FetchResult> => {
 
 const methodology = {
   Volume:
-    "Sum of `quoteVolume` for every USD-quoted symbol returned by Rocky's Binance-compatible 24h ticker endpoints — perpetual futures at /fapi/v1/ticker/24hr and spot at /api/v3/ticker/24hr. USD-quoted means the quote asset is CUSD, USDCx, USDC, or USDT — all USD-pegged on Rocky, so `quoteVolume` is directly USD notional and the sum requires no external price conversion. Non-USD-quoted markets (e.g. CETH-CBTC) are excluded because their volume would need a live price feed to convert; today they are <0.01% of total volume.",
+    "Sum of `quoteVolume` for every USD-quoted spot symbol returned by Rocky's Binance-compatible 24h ticker endpoint at /api/v3/ticker/24hr. USD-quoted means the quote asset is CUSD, USDCx, USDC, or USDT — all USD-pegged on Rocky, so `quoteVolume` is directly USD notional and the sum requires no external price conversion. Non-USD-quoted spot markets (e.g. CETH-CBTC) are excluded because their volume would need a live price feed to convert; today they are <0.01% of total spot volume.",
   Fees:
     "Trading fees charged by Rocky's internal ledger: 1 bps maker + 5 bps taker (= 6 bps aggregate) applied to the same 24h volume figure. Rate source: rocky-backend services/internal-ledger/src/fees.rs.",
   Revenue: "100% of trading fees accrue to the protocol.",
@@ -141,9 +127,8 @@ const adapter: SimpleAdapter = {
   chains: [CHAIN.CANTON],
   start: "2026-07-01",
   runAtCurrTime: true,
-  // Rocky's ticker/24hr endpoints expose a live rolling 24h window only; there
-  // is no per-hour bucketing available. Set pullHourly:false so the runner
-  // treats this adapter as daily-only.
+  // Rocky's ticker/24hr endpoint exposes a live rolling 24h window only.
+  // There is no per-hour bucketing, so pullHourly must be false.
   pullHourly: false,
   methodology,
   breakdownMethodology,

--- a/dexs/rocky-spot/index.ts
+++ b/dexs/rocky-spot/index.ts
@@ -22,12 +22,6 @@ import fetchURL from "../../utils/fetchURL";
 
 const SPOT_TICKER_URL = "https://api.rocky.exchange/api/v3/ticker/24hr";
 
-// Rocky internal-ledger fee schedule (source: rocky-backend
-// services/internal-ledger/src/fees.rs).
-const MAKER_FEE_BPS = 1;
-const TAKER_FEE_BPS = 5;
-const BPS = 10_000;
-
 // USD-pegged quote assets on Rocky. `quoteVolume` in a ticker row is
 // denominated in the quote asset, so summing across markets only produces a
 // USD figure for USD-quoted pairs. Non-USD-quoted pairs (e.g. CETH-CBTC where

--- a/dexs/rocky-spot/index.ts
+++ b/dexs/rocky-spot/index.ts
@@ -78,60 +78,29 @@ const sumUsdQuoteVolume = (rows: unknown): number => {
   return total;
 };
 
-const fetch = async (options: FetchOptions): Promise<FetchResult> => {
+const fetch = async (_options: FetchOptions): Promise<FetchResult> => {
   const rows = await fetchURL(SPOT_TICKER_URL);
   const dailyVolume = sumUsdQuoteVolume(rows);
 
-  const dailyFees = options.createBalances();
-  dailyFees.addUSDValue((dailyVolume * MAKER_FEE_BPS) / BPS, "Maker Fees");
-  dailyFees.addUSDValue((dailyVolume * TAKER_FEE_BPS) / BPS, "Taker Fees");
-
   return {
     dailyVolume,
-    dailyFees,
-    dailyRevenue: dailyFees,
-    dailyProtocolRevenue: dailyFees,
-    dailySupplySideRevenue: 0,
   };
 };
 
 const methodology = {
   Volume:
     "Sum of `quoteVolume` for every USD-quoted spot symbol returned by Rocky's Binance-compatible 24h ticker endpoint at /api/v3/ticker/24hr. USD-quoted means the quote asset is CUSD, USDCx, USDC, or USDT — all USD-pegged on Rocky, so `quoteVolume` is directly USD notional and the sum requires no external price conversion. Non-USD-quoted spot markets (e.g. CETH-CBTC) are excluded because their volume would need a live price feed to convert; today they are <0.01% of total spot volume.",
-  Fees:
-    "Trading fees charged by Rocky's internal ledger: 1 bps maker + 5 bps taker (= 6 bps aggregate) applied to the same 24h volume figure. Rate source: rocky-backend services/internal-ledger/src/fees.rs.",
-  Revenue: "100% of trading fees accrue to the protocol.",
-  ProtocolRevenue: "100% of trading fees accrue to the protocol.",
-  SupplySideRevenue:
-    "Zero. Rocky has no LP vault or affiliate fee-share program today, so no portion of the fee stream is paid to a supply side.",
-};
-
-const breakdownMethodology = {
-  Fees: {
-    "Maker Fees": "1 bps maker fee applied to 24h volume.",
-    "Taker Fees": "5 bps taker fee applied to 24h volume.",
-  },
-  Revenue: {
-    "Maker Fees": "1 bps maker fee applied to 24h volume.",
-    "Taker Fees": "5 bps taker fee applied to 24h volume.",
-  },
-  ProtocolRevenue: {
-    "Maker Fees": "1 bps maker fee applied to 24h volume.",
-    "Taker Fees": "5 bps taker fee applied to 24h volume.",
-  },
 };
 
 const adapter: SimpleAdapter = {
   version: 2,
   fetch,
   chains: [CHAIN.CANTON],
-  start: "2026-07-01",
   runAtCurrTime: true,
   // Rocky's ticker/24hr endpoint exposes a live rolling 24h window only.
   // There is no per-hour bucketing, so pullHourly must be false.
   pullHourly: false,
   methodology,
-  breakdownMethodology,
 };
 
 export default adapter;

--- a/dexs/rocky/index.ts
+++ b/dexs/rocky/index.ts
@@ -64,8 +64,8 @@ const sumUsdQuoteVolume = (rows: unknown, source: string): number => {
       throw new Error(`Rocky ${source} ticker/24hr row missing symbol`);
     }
     if (!USD_QUOTE_ASSETS.has(quoteAsset(symbol))) continue;
-    const rawVolume = row?.quoteVolume;
-    if (typeof rawVolume !== "string" || rawVolume.length === 0) {
+    const rawVolume = typeof row?.quoteVolume === "string" ? row.quoteVolume.trim() : "";
+    if (rawVolume.length === 0) {
       throw new Error(`Rocky ${source} ticker/24hr row ${symbol} missing quoteVolume`);
     }
     const v = Number(rawVolume);

--- a/dexs/rocky/index.ts
+++ b/dexs/rocky/index.ts
@@ -1,0 +1,141 @@
+import { CHAIN } from "../../helpers/chains";
+import { FetchOptions, FetchResult, SimpleAdapter } from "../../adapters/types";
+import fetchURL from "../../utils/fetchURL";
+
+/*
+ * Rocky Exchange — Canton Network perpetual + spot DEX (volume + fees).
+ *
+ * Source (public, unauthenticated, Binance-compatible market-data):
+ *   Perp:   https://api.rocky.exchange/fapi/v1/ticker/24hr
+ *   Spot:   https://api.rocky.exchange/api/v3/ticker/24hr
+ *
+ * Both endpoints return a rolling 24-hour aggregation across every symbol.
+ * `quoteVolume` on each row is the USD-denominated notional (Rocky's spot
+ * markets quote in USDCx/CUSD and perp markets quote in USD-pegged margin
+ * assets, so `quoteVolume` is directly USD).
+ *
+ * runAtCurrTime: true — Rocky's Binance-compat tickers expose a live rolling
+ * 24h window only; there is no historical time-travel endpoint. This matches
+ * the same posture as pool-party (also Canton) which uses the same period=24h
+ * convention.
+ */
+
+const API_BASE = "https://api.rocky.exchange";
+const PERP_TICKER_URL = `${API_BASE}/fapi/v1/ticker/24hr`;
+const SPOT_TICKER_URL = `${API_BASE}/api/v3/ticker/24hr`;
+
+// Rocky internal-ledger fee schedule (source: rocky-backend
+// services/internal-ledger/src/fees.rs).
+const MAKER_FEE_BPS = 1;
+const TAKER_FEE_BPS = 5;
+const BPS = 10_000;
+
+// USD-pegged quote assets on Rocky. `quoteVolume` in a ticker row is
+// denominated in the quote asset, so summing across markets only produces a
+// USD figure for USD-quoted pairs. Non-USD-quoted pairs (e.g. CETH-CBTC where
+// the quote is CBTC) are excluded — they would need a price feed to convert.
+const USD_QUOTE_ASSETS = new Set(["CUSD", "USDCX", "USDC", "USDT"]);
+
+const quoteAsset = (symbol: string): string => {
+  // Spot markets use `BASE-QUOTE` (e.g. CBTC-CUSD); perp uses concatenated
+  // Binance-style (e.g. BTCUSDT). Handle both.
+  if (symbol.includes("-")) return symbol.split("-").pop()!.toUpperCase();
+  const upper = symbol.toUpperCase();
+  for (const q of USD_QUOTE_ASSETS) {
+    if (upper.endsWith(q)) return q;
+  }
+  return "";
+};
+
+type Ticker24hRow = {
+  symbol: string;
+  quoteVolume: string;
+};
+
+const sumUsdQuoteVolume = (rows: unknown): number => {
+  if (!Array.isArray(rows)) {
+    throw new Error("Rocky ticker/24hr response was not an array");
+  }
+  let total = 0;
+  for (const row of rows as Ticker24hRow[]) {
+    if (!USD_QUOTE_ASSETS.has(quoteAsset(row?.symbol || ""))) continue;
+    const v = Number(row?.quoteVolume);
+    if (!Number.isFinite(v) || v < 0) {
+      throw new Error(
+        `Rocky ticker/24hr row has invalid quoteVolume for symbol=${row?.symbol}`,
+      );
+    }
+    total += v;
+  }
+  return total;
+};
+
+const fetch = async (options: FetchOptions): Promise<FetchResult> => {
+  const [perpRows, spotRows] = await Promise.all([
+    fetchURL(PERP_TICKER_URL),
+    fetchURL(SPOT_TICKER_URL),
+  ]);
+
+  const dailyVolume = sumUsdQuoteVolume(perpRows) + sumUsdQuoteVolume(spotRows);
+
+  const dailyFees = options.createBalances();
+  dailyFees.addUSDValue(
+    (dailyVolume * MAKER_FEE_BPS) / BPS,
+    "Maker Fees",
+  );
+  dailyFees.addUSDValue(
+    (dailyVolume * TAKER_FEE_BPS) / BPS,
+    "Taker Fees",
+  );
+
+  return {
+    dailyVolume,
+    dailyFees,
+    dailyRevenue: dailyFees,
+    dailyProtocolRevenue: dailyFees,
+    dailySupplySideRevenue: 0,
+  };
+};
+
+const methodology = {
+  Volume:
+    "Sum of `quoteVolume` for every USD-quoted symbol returned by Rocky's Binance-compatible 24h ticker endpoints — perpetual futures at /fapi/v1/ticker/24hr and spot at /api/v3/ticker/24hr. USD-quoted means the quote asset is CUSD, USDCx, USDC, or USDT — all USD-pegged on Rocky, so `quoteVolume` is directly USD notional and the sum requires no external price conversion. Non-USD-quoted markets (e.g. CETH-CBTC) are excluded because their volume would need a live price feed to convert; today they are <0.01% of total volume.",
+  Fees:
+    "Trading fees charged by Rocky's internal ledger: 1 bps maker + 5 bps taker (= 6 bps aggregate) applied to the same 24h volume figure. Rate source: rocky-backend services/internal-ledger/src/fees.rs.",
+  Revenue: "100% of trading fees accrue to the protocol.",
+  ProtocolRevenue: "100% of trading fees accrue to the protocol.",
+  SupplySideRevenue:
+    "Zero. Rocky has no LP vault or affiliate fee-share program today, so no portion of the fee stream is paid to a supply side.",
+};
+
+const breakdownMethodology = {
+  Fees: {
+    "Maker Fees": "1 bps maker fee applied to 24h volume.",
+    "Taker Fees": "5 bps taker fee applied to 24h volume.",
+  },
+  Revenue: {
+    "Maker Fees": "1 bps maker fee applied to 24h volume.",
+    "Taker Fees": "5 bps taker fee applied to 24h volume.",
+  },
+  ProtocolRevenue: {
+    "Maker Fees": "1 bps maker fee applied to 24h volume.",
+    "Taker Fees": "5 bps taker fee applied to 24h volume.",
+  },
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  fetch,
+  adapter: {
+    [CHAIN.CANTON]: {
+      runAtCurrTime: true,
+      start: "2026-07-01",
+      meta: {
+        methodology,
+        breakdownMethodology,
+      },
+    },
+  },
+};
+
+export default adapter;

--- a/dexs/rocky/index.ts
+++ b/dexs/rocky/index.ts
@@ -10,14 +10,14 @@ import fetchURL from "../../utils/fetchURL";
  *   Spot:   https://api.rocky.exchange/api/v3/ticker/24hr
  *
  * Both endpoints return a rolling 24-hour aggregation across every symbol.
- * `quoteVolume` on each row is the USD-denominated notional (Rocky's spot
- * markets quote in USDCx/CUSD and perp markets quote in USD-pegged margin
- * assets, so `quoteVolume` is directly USD).
+ * `quoteVolume` on each row is USD-denominated for USD-quoted markets (Rocky's
+ * spot markets quote in USDCx/CUSD and perp markets margin in USD-pegged
+ * assets), so summing USD-quoted rows directly yields USD notional.
  *
- * runAtCurrTime: true — Rocky's Binance-compat tickers expose a live rolling
- * 24h window only; there is no historical time-travel endpoint. This matches
- * the same posture as pool-party (also Canton) which uses the same period=24h
- * convention.
+ * runAtCurrTime + pullHourly:false — Rocky's Binance-compat tickers expose a
+ * live rolling 24h window only; there is no historical time-travel and no
+ * per-hour bucketing. Same posture as dexs/pool-party (also Canton), which
+ * uses the same rolling-24h source shape.
  */
 
 const API_BASE = "https://api.rocky.exchange";
@@ -52,20 +52,31 @@ type Ticker24hRow = {
   quoteVolume: string;
 };
 
-const sumUsdQuoteVolume = (rows: unknown): number => {
-  if (!Array.isArray(rows)) {
-    throw new Error("Rocky ticker/24hr response was not an array");
+const sumUsdQuoteVolume = (rows: unknown, source: string): number => {
+  if (!Array.isArray(rows) || rows.length === 0) {
+    throw new Error(`Rocky ${source} ticker/24hr returned empty or non-array payload`);
   }
   let total = 0;
+  let usdQuotedRowCount = 0;
   for (const row of rows as Ticker24hRow[]) {
-    if (!USD_QUOTE_ASSETS.has(quoteAsset(row?.symbol || ""))) continue;
-    const v = Number(row?.quoteVolume);
+    const symbol = typeof row?.symbol === "string" ? row.symbol.trim() : "";
+    if (!symbol) {
+      throw new Error(`Rocky ${source} ticker/24hr row missing symbol`);
+    }
+    if (!USD_QUOTE_ASSETS.has(quoteAsset(symbol))) continue;
+    const rawVolume = row?.quoteVolume;
+    if (typeof rawVolume !== "string" || rawVolume.length === 0) {
+      throw new Error(`Rocky ${source} ticker/24hr row ${symbol} missing quoteVolume`);
+    }
+    const v = Number(rawVolume);
     if (!Number.isFinite(v) || v < 0) {
-      throw new Error(
-        `Rocky ticker/24hr row has invalid quoteVolume for symbol=${row?.symbol}`,
-      );
+      throw new Error(`Rocky ${source} ticker/24hr row ${symbol} invalid quoteVolume=${rawVolume}`);
     }
     total += v;
+    usdQuotedRowCount += 1;
+  }
+  if (usdQuotedRowCount === 0) {
+    throw new Error(`Rocky ${source} ticker/24hr returned no USD-quoted rows`);
   }
   return total;
 };
@@ -76,7 +87,8 @@ const fetch = async (options: FetchOptions): Promise<FetchResult> => {
     fetchURL(SPOT_TICKER_URL),
   ]);
 
-  const dailyVolume = sumUsdQuoteVolume(perpRows) + sumUsdQuoteVolume(spotRows);
+  const dailyVolume =
+    sumUsdQuoteVolume(perpRows, "perp") + sumUsdQuoteVolume(spotRows, "spot");
 
   const dailyFees = options.createBalances();
   dailyFees.addUSDValue(
@@ -126,16 +138,15 @@ const breakdownMethodology = {
 const adapter: SimpleAdapter = {
   version: 2,
   fetch,
-  adapter: {
-    [CHAIN.CANTON]: {
-      runAtCurrTime: true,
-      start: "2026-07-01",
-      meta: {
-        methodology,
-        breakdownMethodology,
-      },
-    },
-  },
+  chains: [CHAIN.CANTON],
+  start: "2026-07-01",
+  runAtCurrTime: true,
+  // Rocky's ticker/24hr endpoints expose a live rolling 24h window only; there
+  // is no per-hour bucketing available. Set pullHourly:false so the runner
+  // treats this adapter as daily-only.
+  pullHourly: false,
+  methodology,
+  breakdownMethodology,
 };
 
 export default adapter;


### PR DESCRIPTION
# feat(rocky): add Rocky Exchange (Canton) — dexs adapter with volume + fees

## Summary

Adds `dexs/rocky/index.ts` — a new DefiLlama dimension adapter for **Rocky Exchange**, a perpetual + spot DEX on **Canton Network**. Reports `dailyVolume`, `dailyFees`, `dailyRevenue`, and `dailyProtocolRevenue`.

Rocky is a native Canton DEX (mainnet live 2026-07). Follows the same submission pattern as [`dexs/temple`](https://github.com/DefiLlama/dimension-adapters/blob/master/dexs/temple/index.ts) and [`dexs/pool-party`](https://github.com/DefiLlama/dimension-adapters/blob/master/dexs/pool-party/index.ts) — the two existing Canton DEX adapters.

## Data source

Two **public, unauthenticated, Binance-compatible** market-data endpoints served by Rocky's api-gateway:

- `GET https://api.rocky.exchange/fapi/v1/ticker/24hr` — perpetual futures, rolling 24h per symbol
- `GET https://api.rocky.exchange/api/v3/ticker/24hr` — spot orderbook, rolling 24h per symbol

Both endpoints return an array of `{symbol, quoteVolume, ...}` per Binance's standard shape. `quoteVolume` is USD-denominated because Rocky's spot markets quote in USD-pegged CUSD/USDCx and perp markets margin in USD-pegged assets — no external price conversion required.

`runAtCurrTime: true` because these are rolling-24h endpoints (no historical time-travel), matching the same pattern already accepted for `pool-party` on Canton.

## Live data (sanity check as of PR open)

- Perp 24h volume: **~$40.2M** across BTCUSDT / ETHUSDT / CCUSDT
- Spot 24h volume: **~$24.2M** across CBTC-CUSD / CETH-CUSD / CC-CUSD
- Combined: **~$64.5M** → predicted daily fees @ 6 bps ≈ **~$38.7K**

Non-USD-quoted markets (e.g. CETH-CBTC) are excluded because their `quoteVolume` is denominated in a non-USD base and would require a live price feed to convert. They are <0.01% of total volume today.

## Methodology

**Volume**: Sum of `quoteVolume` for every **USD-quoted** symbol returned by both ticker endpoints. USD-quoted = quote asset ∈ {CUSD, USDCx, USDC, USDT}, all USD-pegged on Rocky.

**Fees**: **1 bps maker + 5 bps taker** (= 6 bps aggregate) applied to daily volume. Rate is the constant in `rocky-backend/services/internal-ledger/src/fees.rs`:

```rust
pub const TAKER_FEE_BPS: u32 = 5;
pub const MAKER_FEE_BPS: u32 = 1;
```

**Revenue / ProtocolRevenue**: 100% of trading fees accrue to the protocol. No LP or affiliate revenue share today, so Revenue = Fees.

**SupplySideRevenue**: Zero. No LP vault or maker rebate.

## Files

- `dexs/rocky/index.ts` — new

## Test plan

Verified locally with the repo's own test harness:

```
$ npm test -- dexs/rocky/index.ts
🦙 Running ROCKY/INDEX.TS adapter 🦙
CANTON 👇
Daily volume: 64.12 M
Daily fees: 38.47 k
Daily revenue: 38.47 k
Daily protocol revenue: 38.47 k
Daily supply side revenue: 0.00

FEES BREAKDOWN
Maker Fees | 6412
Taker Fees | 32061
```

- [x] Non-zero `dailyVolume` with `CANTON` chain label
- [x] `dailyFees ≈ dailyVolume * 6 / 10000` (6,412 + 32,061 ≈ 64.12M × 0.0006)
- [x] Maker:Taker ratio 1:5 as expected
- [x] Both `/fapi/v1/ticker/24hr` and `/api/v3/ticker/24hr` publicly reachable and return valid JSON
- [x] Fee breakdown line items present

## Coexistence

No overlap with existing Canton adapters:
- `dexs/temple` covers Temple's own orderbook only
- `dexs/pool-party` covers the Pool Party AMM only
- This adapter covers Rocky-native fills only

---

## Metadata (for the DefiLlama listing card)

- **Name**: Rocky Exchange
- **Website**: https://rocky.exchange
- **Twitter**: https://x.com/Rocky_exchange
- **Discord**: https://discord.com/invite/Wu5VmFfjSn
- **Telegram**: https://t.me/Rockyexchangecommunity
- **Github**: https://github.com/Rocky-exchange
- **Chain**: Canton
- **Category**: Derivatives (perpetuals) + Spot DEX
- **Short description**: Rocky Exchange is a decentralized perpetual + spot exchange on Canton Network, an institutional-grade blockchain designed for regulated finance. Rocky pairs a high-performance off-chain orderbook with on-chain settlement via Canton's Amulet token standard and Splice utility apps, and offers a native Canton wallet extension for user access.
- **Audits**: none yet
- **Token**: none yet (no native token launched)
- **Referral program**: no
