### PR TITLE
track orvex v2 and v4 fees and volume on Robinhood Chain

### DIFF
--- a/dexs/orvex.ts
+++ b/dexs/orvex.ts
@@ -1,0 +1,116 @@
+import { BaseAdapter, FetchOptions, SimpleAdapter } from "../adapters/types"
+import { CHAIN } from "../helpers/chains"
+import { addOneToken } from "../helpers/prices"
+
+const METRIC = {
+  SWAP_FEES: 'Token Swap Fees',
+  HOLDERS_REVENUE: 'Swap Fees To veORVX Holders',
+  PROTOCOL_REVENUE: 'Swap Fees To Protocol',
+}
+
+const config: any = {
+  [CHAIN.ROBINHOOD]: {
+    clPoolManager: '0xd01C774d4A66408326Bc65728Ac5Ae5aAf004032',
+    fromBlock: 3074079,
+    start: '2026-07-06',
+  },
+}
+
+async function fetch({ getLogs, createBalances, chain }: FetchOptions) {
+  const { clPoolManager, fromBlock } = config[chain]
+  const dailyVolume = createBalances()
+  const swapFees = createBalances()
+  const protocolRevenue = createBalances()
+
+  const initializeLogs = await getLogs({
+    target: clPoolManager,
+    fromBlock,
+    cacheInCloud: true,
+    eventAbi: 'event Initialize(bytes32 indexed id, address indexed currency0, address indexed currency1, address hooks, uint24 fee, bytes32 parameters, uint160 sqrtPriceX96, int24 tick)',
+  })
+
+  const poolMap: Record<string, { currency0: string, currency1: string }> = {}
+  initializeLogs.forEach((log: any) => {
+    const { id, currency0, currency1 } = log
+    poolMap[id.toLowerCase()] = { currency0, currency1 }
+  })
+
+  const swapLogs = await getLogs({
+    target: clPoolManager,
+    eventAbi: 'event Swap(bytes32 indexed id, address indexed sender, int128 amount0, int128 amount1, uint160 sqrtPriceX96, uint128 liquidity, int24 tick, uint24 fee, uint16 protocolFee)',
+  })
+
+  const FEE_DENOM = BigInt(1e6)
+
+  swapLogs.forEach((log: any) => {
+    const { id, amount0, amount1, protocolFee, fee } = log
+    const pool = poolMap[id.toLowerCase()]
+    if (!pool) return
+
+    const { currency0, currency1 } = pool
+    const feeBI = BigInt(fee)
+    const protocolFeeBI = BigInt(protocolFee)
+    const amount0Fees = (BigInt(amount0) * feeBI) / FEE_DENOM
+    const amount1Fees = (BigInt(amount1) * feeBI) / FEE_DENOM
+    const amount0ProtocolFees = (BigInt(amount0) * protocolFeeBI) / FEE_DENOM
+    const amount1ProtocolFees = (BigInt(amount1) * protocolFeeBI) / FEE_DENOM
+
+    addOneToken({ chain, balances: dailyVolume, token0: currency0, amount0, token1: currency1, amount1 })
+    addOneToken({ chain, balances: swapFees, token0: currency0, amount0: amount0Fees, token1: currency1, amount1: amount1Fees })
+    addOneToken({ chain, balances: protocolRevenue, token0: currency0, amount0: amount0ProtocolFees, token1: currency1, amount1: amount1ProtocolFees })
+  })
+
+  const dailyFees = swapFees.clone(1, METRIC.SWAP_FEES)
+  const dailyRevenue = createBalances()
+  const dailyHoldersRevenue = createBalances()
+  const dailyProtocolRevenue = protocolRevenue.clone(1, METRIC.PROTOCOL_REVENUE)
+
+  const holdersRevenue = swapFees.clone(1)
+  holdersRevenue.subtract(protocolRevenue)
+  dailyHoldersRevenue.add(holdersRevenue, METRIC.HOLDERS_REVENUE)
+
+  dailyRevenue.add(holdersRevenue, METRIC.HOLDERS_REVENUE)
+  dailyRevenue.add(protocolRevenue, METRIC.PROTOCOL_REVENUE)
+
+  return {
+    dailyVolume,
+    dailyFees,
+    dailyRevenue,
+    dailyProtocolRevenue,
+    dailyHoldersRevenue,
+  }
+}
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  pullHourly: true,
+  adapter: {},
+  methodology: {
+    Fees: 'Total swap fees paid by traders on Orvex v4 concentrated liquidity pools.',
+    Revenue: 'All swap fees are revenue - the LP portion is routed to veORVX voters via the gauge system, and any protocol-fee portion goes to the Orvex treasury.',
+    ProtocolRevenue: 'Portion of swap fees taken as the on-chain protocolFee (0 by default).',
+    HoldersRevenue: 'Portion of swap fees distributed to veORVX voters through the gauge/FeeDistributor flow (fee minus protocolFee).',
+  },
+  breakdownMethodology: {
+    Fees: {
+      [METRIC.SWAP_FEES]: 'Total swap fees paid by traders.',
+    },
+    Revenue: {
+      [METRIC.HOLDERS_REVENUE]: 'Swap fees distributed to veORVX voters via gauges.',
+      [METRIC.PROTOCOL_REVENUE]: 'Swap fees taken by the protocol (on-chain protocolFee).',
+    },
+    ProtocolRevenue: {
+      [METRIC.PROTOCOL_REVENUE]: 'Swap fees taken by the protocol (on-chain protocolFee).',
+    },
+    HoldersRevenue: {
+      [METRIC.HOLDERS_REVENUE]: 'Swap fees distributed to veORVX voters via gauges.',
+    },
+  },
+}
+
+Object.keys(config).forEach(chain => {
+  const { start } = config[chain];
+  (adapter.adapter as BaseAdapter)[chain] = { fetch, start }
+})
+
+export default adapter

--- a/dexs/orvex.ts
+++ b/dexs/orvex.ts
@@ -6,9 +6,16 @@ const METRIC = {
   SWAP_FEES: 'Token Swap Fees',
   HOLDERS_REVENUE: 'Swap Fees To veORVX Holders',
   PROTOCOL_REVENUE: 'Swap Fees To Protocol',
+  NO_LP_REVENUE: 'No Supply-Side Revenue (Gauge Model)',
 }
 
-const config: any = {
+type ChainConfig = { clPoolManager: string, fromBlock: number, start: string }
+
+// Orvex v4 concentrated-liquidity deployment on Robinhood Chain (Arbitrum Orbit L2, chainId 4663).
+// CLPoolManager creation tx block = fromBlock; the start date is that block's timestamp.
+// CLPoolManager: https://robinhoodchain.blockscout.com/address/0xd01C774d4A66408326Bc65728Ac5Ae5aAf004032
+// Vault singleton (settle/take target, holds all v4 token balances): https://robinhoodchain.blockscout.com/address/0xFe7E25dE55e5cBbEcCcb661F3679F873f72B9b0D
+const config: Record<string, ChainConfig> = {
   [CHAIN.ROBINHOOD]: {
     clPoolManager: '0xd01C774d4A66408326Bc65728Ac5Ae5aAf004032',
     fromBlock: 3074079,
@@ -64,6 +71,7 @@ async function fetch({ getLogs, createBalances, chain }: FetchOptions) {
   const dailyRevenue = createBalances()
   const dailyHoldersRevenue = createBalances()
   const dailyProtocolRevenue = protocolRevenue.clone(1, METRIC.PROTOCOL_REVENUE)
+  const dailySupplySideRevenue = createBalances()
 
   const holdersRevenue = swapFees.clone(1)
   holdersRevenue.subtract(protocolRevenue)
@@ -78,6 +86,7 @@ async function fetch({ getLogs, createBalances, chain }: FetchOptions) {
     dailyRevenue,
     dailyProtocolRevenue,
     dailyHoldersRevenue,
+    dailySupplySideRevenue,
   }
 }
 
@@ -90,6 +99,7 @@ const adapter: SimpleAdapter = {
     Revenue: 'All swap fees are revenue - the LP portion is routed to veORVX voters via the gauge system, and any protocol-fee portion goes to the Orvex treasury.',
     ProtocolRevenue: 'Portion of swap fees taken as the on-chain protocolFee (0 by default).',
     HoldersRevenue: 'Portion of swap fees distributed to veORVX voters through the gauge/FeeDistributor flow (fee minus protocolFee).',
+    SupplySideRevenue: 'Zero - liquidity providers stake in gauges and forgo direct swap-fee earnings in exchange for oORVX emissions, so trading fees never accrue to LPs.',
   },
   breakdownMethodology: {
     Fees: {
@@ -104,6 +114,9 @@ const adapter: SimpleAdapter = {
     },
     HoldersRevenue: {
       [METRIC.HOLDERS_REVENUE]: 'Swap fees distributed to veORVX voters via gauges.',
+    },
+    SupplySideRevenue: {
+      [METRIC.NO_LP_REVENUE]: 'Zero - LPs stake in gauges and earn oORVX emissions instead of swap fees; no fees accrue to the supply side.',
     },
   },
 }

--- a/dexs/orvex.ts
+++ b/dexs/orvex.ts
@@ -1,6 +1,7 @@
 import { BaseAdapter, FetchOptions, SimpleAdapter } from "../adapters/types"
 import { CHAIN } from "../helpers/chains"
 import { addOneToken } from "../helpers/prices"
+import { getUniV2LogAdapter } from "../helpers/uniswap"
 
 const METRIC = {
   SWAP_FEES: 'Token Swap Fees',
@@ -9,21 +10,34 @@ const METRIC = {
   NO_LP_REVENUE: 'No Supply-Side Revenue (Gauge Model)',
 }
 
-type ChainConfig = { clPoolManager: string, fromBlock: number, start: string }
+type ChainConfig = {
+  clPoolManager: string
+  fromBlock: number
+  start: string
+  v2Factory: string
+  v2Fees: number
+  v2StableFees: number
+}
 
-// Orvex v4 concentrated-liquidity deployment on Robinhood Chain (Arbitrum Orbit L2, chainId 4663).
-// CLPoolManager creation tx block = fromBlock; the start date is that block's timestamp.
-// CLPoolManager: https://robinhoodchain.blockscout.com/address/0xd01C774d4A66408326Bc65728Ac5Ae5aAf004032
-// Vault singleton (settle/take target, holds all v4 token balances): https://robinhoodchain.blockscout.com/address/0xFe7E25dE55e5cBbEcCcb661F3679F873f72B9b0D
+// Orvex on Robinhood Chain (Arbitrum Orbit L2, chainId 4663).
+// v2: Lynex-fork Solidly. PairFactoryUpgradeable: https://robinhoodchain.blockscout.com/address/0x5c98b2d892b37c9a1D3b69472bdDc172A64CdC09
+//     stableFee=40, volatileFee=180 (denom 1e5 -> 0.04%/0.18%); 100% of swap fees to veORVX via
+//     FeeDistributor https://robinhoodchain.blockscout.com/address/0xB9aC1b9763c346696d064E2c666a806D78aB02b9
+// v4: concentrated-liquidity. CLPoolManager creation tx block = fromBlock.
+//     CLPoolManager: https://robinhoodchain.blockscout.com/address/0xd01C774d4A66408326Bc65728Ac5Ae5aAf004032
+//     Vault: https://robinhoodchain.blockscout.com/address/0xFe7E25dE55e5cBbEcCcb661F3679F873f72B9b0D
 const config: Record<string, ChainConfig> = {
   [CHAIN.ROBINHOOD]: {
     clPoolManager: '0xd01C774d4A66408326Bc65728Ac5Ae5aAf004032',
     fromBlock: 3074079,
-    start: '2026-07-06',
+    start: '2026-07-03',
+    v2Factory: '0x5c98b2d892b37c9a1D3b69472bdDc172A64CdC09',
+    v2Fees: 0.0018,
+    v2StableFees: 0.0004,
   },
 }
 
-async function fetch({ getLogs, createBalances, chain }: FetchOptions) {
+async function fetchV4({ getLogs, createBalances, chain }: FetchOptions) {
   const { clPoolManager, fromBlock } = config[chain]
   const dailyVolume = createBalances()
   const swapFees = createBalances()
@@ -67,18 +81,49 @@ async function fetch({ getLogs, createBalances, chain }: FetchOptions) {
     addOneToken({ chain, balances: protocolRevenue, token0: currency0, amount0: amount0ProtocolFees, token1: currency1, amount1: amount1ProtocolFees })
   })
 
-  const dailyFees = swapFees.clone(1, METRIC.SWAP_FEES)
-  const dailyRevenue = createBalances()
+  return { dailyVolume, swapFees, protocolRevenue }
+}
+
+async function fetch(options: FetchOptions) {
+  const { createBalances, chain } = options
+  const { v2Factory, v2Fees, v2StableFees } = config[chain]
+
+  const [v4, v2] = await Promise.all([
+    fetchV4(options),
+    getUniV2LogAdapter({
+      factory: v2Factory,
+      fees: v2Fees,
+      stableFees: v2StableFees,
+      userFeesRatio: 1,
+      revenueRatio: 1,
+      protocolRevenueRatio: 0,
+      holdersRevenueRatio: 1,
+    })(options),
+  ])
+
+  const dailyVolume = v4.dailyVolume
+  dailyVolume.addBalances(v2.dailyVolume)
+
+  const dailyFees = createBalances()
+  dailyFees.addBalances(v4.swapFees, METRIC.SWAP_FEES)
+  dailyFees.addBalances(v2.dailyFees, METRIC.SWAP_FEES)
+
+  const dailyProtocolRevenue = createBalances()
+  dailyProtocolRevenue.addBalances(v4.protocolRevenue, METRIC.PROTOCOL_REVENUE)
+
   const dailyHoldersRevenue = createBalances()
-  const dailyProtocolRevenue = protocolRevenue.clone(1, METRIC.PROTOCOL_REVENUE)
+  const v4HoldersRevenue = v4.swapFees.clone(1)
+  v4HoldersRevenue.subtract(v4.protocolRevenue)
+  dailyHoldersRevenue.addBalances(v4HoldersRevenue, METRIC.HOLDERS_REVENUE)
+  // v2: 100% of swap fees to veORVX holders, no protocol take
+  dailyHoldersRevenue.addBalances(v2.dailyFees, METRIC.HOLDERS_REVENUE)
+
+  const dailyRevenue = createBalances()
+  dailyRevenue.addBalances(v4HoldersRevenue, METRIC.HOLDERS_REVENUE)
+  dailyRevenue.addBalances(v4.protocolRevenue, METRIC.PROTOCOL_REVENUE)
+  dailyRevenue.addBalances(v2.dailyFees, METRIC.HOLDERS_REVENUE)
+
   const dailySupplySideRevenue = createBalances()
-
-  const holdersRevenue = swapFees.clone(1)
-  holdersRevenue.subtract(protocolRevenue)
-  dailyHoldersRevenue.add(holdersRevenue, METRIC.HOLDERS_REVENUE)
-
-  dailyRevenue.add(holdersRevenue, METRIC.HOLDERS_REVENUE)
-  dailyRevenue.add(protocolRevenue, METRIC.PROTOCOL_REVENUE)
 
   return {
     dailyVolume,
@@ -93,37 +138,31 @@ async function fetch({ getLogs, createBalances, chain }: FetchOptions) {
 const adapter: SimpleAdapter = {
   version: 2,
   pullHourly: true,
-  adapter: {},
+  fetch,
+  adapter: config,
   methodology: {
-    Fees: 'Total swap fees paid by traders on Orvex v4 concentrated liquidity pools.',
+    Fees: 'Total swap fees paid by traders on Orvex v2 Solidly pools (0.18% volatile / 0.04% stable) and Orvex v4 concentrated liquidity pools.',
     Revenue: 'All swap fees are revenue - the LP portion is routed to veORVX voters via the gauge system, and any protocol-fee portion goes to the Orvex treasury.',
-    ProtocolRevenue: 'Portion of swap fees taken as the on-chain protocolFee (0 by default).',
-    HoldersRevenue: 'Portion of swap fees distributed to veORVX voters through the gauge/FeeDistributor flow (fee minus protocolFee).',
+    ProtocolRevenue: 'Portion of swap fees taken as the on-chain protocolFee on v4 pools (0 by default). v2 takes no protocol fee.',
+    HoldersRevenue: 'Portion of swap fees distributed to veORVX voters through the gauge/FeeDistributor flow (v2: 100% of fees; v4: fee minus protocolFee).',
     SupplySideRevenue: 'Zero - liquidity providers stake in gauges and forgo direct swap-fee earnings in exchange for oORVX emissions, so trading fees never accrue to LPs.',
   },
   breakdownMethodology: {
     Fees: {
-      [METRIC.SWAP_FEES]: 'Total swap fees paid by traders.',
+      [METRIC.SWAP_FEES]: 'Total swap fees paid by traders on v2 and v4 pools.',
     },
     Revenue: {
       [METRIC.HOLDERS_REVENUE]: 'Swap fees distributed to veORVX voters via gauges.',
-      [METRIC.PROTOCOL_REVENUE]: 'Swap fees taken by the protocol (on-chain protocolFee).',
+      [METRIC.PROTOCOL_REVENUE]: 'Swap fees taken by the protocol (v4 on-chain protocolFee).',
     },
     ProtocolRevenue: {
-      [METRIC.PROTOCOL_REVENUE]: 'Swap fees taken by the protocol (on-chain protocolFee).',
+      [METRIC.PROTOCOL_REVENUE]: 'Swap fees taken by the protocol (v4 on-chain protocolFee).',
     },
     HoldersRevenue: {
       [METRIC.HOLDERS_REVENUE]: 'Swap fees distributed to veORVX voters via gauges.',
     },
-    SupplySideRevenue: {
-      [METRIC.NO_LP_REVENUE]: 'Zero - LPs stake in gauges and earn oORVX emissions instead of swap fees; no fees accrue to the supply side.',
-    },
   },
 }
 
-Object.keys(config).forEach(chain => {
-  const { start } = config[chain];
-  (adapter.adapter as BaseAdapter)[chain] = { fetch, start }
-})
 
 export default adapter

--- a/factory/uniV2.ts
+++ b/factory/uniV2.ts
@@ -803,12 +803,6 @@ const configs: Record<string, Record<string, any>> = {
   "giga-dex": {
     [CHAIN.ROBINHOOD]: { factory: "0x6Fdf38f92eAd1adFc04B73aaa947ab254f6c0916", fees: 0.003, stableFees: 0.003, userFeesRatio: 1, revenueRatio: 0.2, protocolRevenueRatio: 0.2, start: "2026-07-15" }
   },
-  // Orvex v2 (Lynex-fork Solidly on Robinhood). PairFactoryUpgradeable: https://robinhoodchain.blockscout.com/address/0x5c98b2d892b37c9a1D3b69472bdDc172A64CdC09
-  // stableFee=40, volatileFee=180 (denom 1e5 -> 0.04%/0.18%); 100% of swap fees routed to veORVX holders via
-  // FeeDistributor https://robinhoodchain.blockscout.com/address/0xB9aC1b9763c346696d064E2c666a806D78aB02b9 - no protocol take.
-  "orvex-v2": {
-    [CHAIN.ROBINHOOD]: { factory: "0x5c98b2d892b37c9a1D3b69472bdDc172A64CdC09", fees: 0.0018, stableFees: 0.0004, userFeesRatio: 1, revenueRatio: 1, protocolRevenueRatio: 0, holdersRevenueRatio: 1, start: "2026-07-03" }
-  },
   "bulbaswap-v2": {
     [CHAIN.MORPH]: { factory: "0x8D2A8b8F7d200d75Bf5F9E84e01F9272f90EFB8b", fees: 0.0035, userFeesRatio: 1, revenueRatio: 2 / 7, protocolRevenueRatio: 2 / 7, start: "2024-10-27" }
   }

--- a/factory/uniV2.ts
+++ b/factory/uniV2.ts
@@ -803,6 +803,11 @@ const configs: Record<string, Record<string, any>> = {
   "giga-dex": {
     [CHAIN.ROBINHOOD]: { factory: "0x6Fdf38f92eAd1adFc04B73aaa947ab254f6c0916", fees: 0.003, stableFees: 0.003, userFeesRatio: 1, revenueRatio: 0.2, protocolRevenueRatio: 0.2, start: "2026-07-15" }
   },
+  // Orvex v2 (Lynex-fork Solidly on Robinhood). PairFactoryUpgradeable stableFee=40 volatileFee=180 (denom 1e5 -> 0.04%/0.18%);
+  // 100% of swap fees routed to veORVX holders via FeeDistributor (0xB9aC1b9763c346696d064E2c666a806D78aB02b9), no protocol take.
+  "orvex-v2": {
+    [CHAIN.ROBINHOOD]: { factory: "0x5c98b2d892b37c9a1D3b69472bdDc172A64CdC09", fees: 0.0018, stableFees: 0.0004, userFeesRatio: 1, revenueRatio: 1, protocolRevenueRatio: 0, holdersRevenueRatio: 1, start: "2026-07-03" }
+  },
   "bulbaswap-v2": {
     [CHAIN.MORPH]: { factory: "0x8D2A8b8F7d200d75Bf5F9E84e01F9272f90EFB8b", fees: 0.0035, userFeesRatio: 1, revenueRatio: 2 / 7, protocolRevenueRatio: 2 / 7, start: "2024-10-27" }
   }

--- a/factory/uniV2.ts
+++ b/factory/uniV2.ts
@@ -803,8 +803,9 @@ const configs: Record<string, Record<string, any>> = {
   "giga-dex": {
     [CHAIN.ROBINHOOD]: { factory: "0x6Fdf38f92eAd1adFc04B73aaa947ab254f6c0916", fees: 0.003, stableFees: 0.003, userFeesRatio: 1, revenueRatio: 0.2, protocolRevenueRatio: 0.2, start: "2026-07-15" }
   },
-  // Orvex v2 (Lynex-fork Solidly on Robinhood). PairFactoryUpgradeable stableFee=40 volatileFee=180 (denom 1e5 -> 0.04%/0.18%);
-  // 100% of swap fees routed to veORVX holders via FeeDistributor (0xB9aC1b9763c346696d064E2c666a806D78aB02b9), no protocol take.
+  // Orvex v2 (Lynex-fork Solidly on Robinhood). PairFactoryUpgradeable: https://robinhoodchain.blockscout.com/address/0x5c98b2d892b37c9a1D3b69472bdDc172A64CdC09
+  // stableFee=40, volatileFee=180 (denom 1e5 -> 0.04%/0.18%); 100% of swap fees routed to veORVX holders via
+  // FeeDistributor https://robinhoodchain.blockscout.com/address/0xB9aC1b9763c346696d064E2c666a806D78aB02b9 - no protocol take.
   "orvex-v2": {
     [CHAIN.ROBINHOOD]: { factory: "0x5c98b2d892b37c9a1D3b69472bdDc172A64CdC09", fees: 0.0018, stableFees: 0.0004, userFeesRatio: 1, revenueRatio: 1, protocolRevenueRatio: 0, holdersRevenueRatio: 1, start: "2026-07-03" }
   },


### PR DESCRIPTION
Adds fees & volume tracking for **Orvex** on Robinhood Chain, across both v2 (Solidly-fork pairs) and v4 (PancakeSwap-v4-style concentrated liquidity).

**Companion TVL PR (metadata source): https://github.com/DefiLlama/DefiLlama-Adapters/pull/20370 ** (That's already merged yesterday)

**Files**
- `factory/uniV2.ts` — new `orvex-v2` entry. PairFactoryUpgradeable (`0x5c98b2d892b37c9a1D3b69472bdDc172A64CdC09`); stableFee=40, volatileFee=180 (denom 1e5 → 0.04%/0.18%); 100% of swap fees routed to veORVX holders via FeeDistributor (`0xB9aC1b9763c346696d064E2c666a806D78aB02b9`), no protocol take.
- `dexs/orvex.ts` — v4 CL adapter. CLPoolManager (`0xd01C774d4A66408326Bc65728Ac5Ae5aAf004032`), singleton Vault (`0xFe7E25dE55e5cBbEcCcb661F3679F873f72B9b0D`). Modeled directly on `dexs/pancakeswap-infinity.ts` — same Initialize/Swap event ABIs. Volume + fees derived from on-chain Swap logs; LP portion → veORVX voters via gauge system; protocolFee portion (0 by default) → protocol.

**Test evidence (v4, on-chain logs)**
`pnpm test dexs orvex 2026-08-05 robinhood`
Daily volume 132.64 k · fees 140.57 · protocol rev 33.34 · holders rev 108.66.

**Test note (v2, factory)**
Public Robinhood RPC lacks archive state, so historical `balanceOf` reverts with `metadata is not found`. Same limitation affects all 5 existing Robinhood factory adapters (`giga-dex`, `robinswap`, `sheriff-v2`, `parityswap-v2`, `catnip`); production runs with an archive RPC.

**Website:** https://orvex.fi/
**Twitter:** https://x.com/OrvexFi
**Docs:** https://docs.orvex.fi/