### PR TITLE
factory/curators: add Robinhood Chain to Steakhouse Financial

### DIFF
--- a/factory/curators.ts
+++ b/factory/curators.ts
@@ -394,6 +394,10 @@ const configs: Record<string, CuratorConfig> = {
         morphoVaultV2Owners: ['0xD546Dc0dB55c28860176147b2D0FEFcc533eCf08'],
         start: '2025-12-15',
       },
+      [CHAIN.ROBINHOOD]: {
+        morphoVaultV2Owners: ['0xfeed46c11F57B7126a773EeC6ae9cA7aE1C03C9a', '0xE9c34c8Fe2d8452807eA13148b3F52b91354eA04'],
+        start: '2026-05-29',
+      },
     },
   },
   "telosc": {


### PR DESCRIPTION
### What

Adds Robinhood Chain to the Steakhouse Financial curator config in `factory/curators.ts`. Steakhouse curates Morpho V2 vaults on Robinhood that currently have no dimensions attribution.

### Vaults picked up

The two Steakhouse deployer addresses on Robinhood created six beef-vanity vaults in total, all Steakhouse-branded and asset USDG (`0x5fc5360D0400a0Fd4f2af552ADD042D716F1d168`):

| Vault | Name | curator() role | TVL (USDG) |
|-------|------|----------------|-----------|
| `0xbeeff033f34c046626b8d0a041844c5d1a5409dd` | Steakhouse USDG | `0x9023FBD6A0…` | ~290.2M |
| `0xbeeff0fb1dc19344a87b8479dab60a2e16160737` | Ethena x Steakhouse USDG | `0x9023FBD6A0…` | ~50.1M |
| `0xbeefff136e3684273e6aa75a1669b784b373a4fd` | Steakhouse Turbo USDG | `0x9023FBD6A0…` | ~2.7M |
| `0xbeeff039907422219fb367e525954ddc092854d9` | Grove x Steakhouse USDG | `0x9023FBD6A0…` | ~2 |
| `0xb97a135c344862bbacbb585a3b0db051698cf905` | Ethena USDG Turbo | `0x9023FBD6A0…` | ~2 |
| `0xbeeff0db1d6c020e525c09af1a4e6fba94190c2f` | RHNC x Steakhouse USDG | `0xfeed46c11f…` (deployer) | 0 |

Five of the six have their curator role set to Steakhouse's canonical address `0x9023FBD6A08C666491A2d1648737E400cF42D2Fb`, which Morpho's own API labels "Steakhouse Financial" (the $290M Steakhouse USDG vault is tagged directly). The sixth, RHNC x Steakhouse USDG, is Steakhouse-deployed and branded but holds zero and has not transferred the curator role yet, so it contributes nothing today.

### Why the two owner addresses are correct

The framework matches the `CreateVaultV2` creation-owner topic. Both configured owners (`0xfeed46c11F…`, `0xE9c34c8Fe2…`) created only these Steakhouse vaults on the Robinhood factory (`0x0FBad98595b0186dA120E41f77C102beb49f803c`) — 28 total `CreateVaultV2` events on that factory, 6 matched by these two owners, none of them non-Steakhouse. So no unrelated vault is swept in.

### Numbers

Robinhood already exists in the curator `MorphoConfigs` (V2 factory only), so this is a config-only change on the same code path as the six existing Steakhouse chains. At ~3% APY on ~340M USDG combined, this attributes roughly $28k/day in Fees. Performance fee is currently 0 on the vaults (`netApy == apy` in Morpho's API), so Revenue reads 0 and all yield flows to suppliers; `getMorphoVaultV2Fee` reads `performanceFee` live per vault, so Revenue updates automatically if the fee is switched on.

### Testing note

Local `npm run test fees steakhouse` returns 0 on the Robinhood leg because the public Robinhood RPC is not archival — it serves `asset()`/`convertToAssets` at latest but returns `metadata is not found` at the window's pinned historical blocks, so the before/after rate reads come back null. Verified this is RPC-only: the owner filter correctly resolves the 6 vaults (confirmed via instrumentation), share price accrues on chain (`convertToAssets(1e18)` = 1.003190 USDG at latest), and the $290M/$50M TVL and ~3% APY are cross-checked against Morpho's API. Production uses archival RPCs, where the same code path already works for the six other Steakhouse chains.
