### PR TITLE
fix(dexs/textile): use time-windowed settlementTradeVolumes + add Polygon

### DIFF
--- a/dexs/textile/index.ts
+++ b/dexs/textile/index.ts
@@ -12,31 +12,40 @@ const ENDPOINT = "https://api.textilecredit.com/graphql";
 const CHAIN_IDS: Record<string, number> = {
   [CHAIN.ETHEREUM]: 1,
   [CHAIN.BSC]: 56,
+  [CHAIN.POLYGON]: 137,
   [CHAIN.BASE]: 8453,
   [CHAIN.CELO]: 42220,
 };
 
-const QUERY = `{
-  settlementMakerStats {
-    makers {
-      trades { timestamp chainId volumeUsd }
+// Server-side [from, to) filter — same bounds as FetchOptions — so we don't
+// pull full maker history on every hourly run. settlementTradeVolumes includes
+// every reactor fill (Stitches and limit-order fills).
+const QUERY = `
+  query TextileVolumes($from: Int!, $to: Int!) {
+    settlementTradeVolumes(fromTimestamp: $from, toTimestamp: $to) {
+      timestamp
+      chainId
+      volumeUsd
     }
   }
-}`;
+`;
 
 async function fetch(options: FetchOptions): Promise<FetchResultV2> {
   const chainId = CHAIN_IDS[options.chain];
 
-  const res = await httpPost(ENDPOINT, { query: QUERY });
-  const makers = res?.data?.settlementMakerStats?.makers ?? [];
+  const res = await httpPost(ENDPOINT, {
+    query: QUERY,
+    variables: {
+      from: options.fromTimestamp,
+      to: options.toTimestamp,
+    },
+  });
+  const rows = res?.data?.settlementTradeVolumes ?? [];
 
   let dailyVolume = 0;
-  for (const m of makers) {
-    for (const t of m.trades ?? []) {
-      if (t.chainId !== chainId) continue;
-      if (t.timestamp < options.fromTimestamp || t.timestamp >= options.toTimestamp) continue;
-      dailyVolume += t.volumeUsd ?? 0;
-    }
+  for (const t of rows) {
+    if (t.chainId !== chainId) continue;
+    dailyVolume += t.volumeUsd ?? 0;
   }
 
   return { dailyVolume };
@@ -47,7 +56,7 @@ const adapter: SimpleAdapter = {
   pullHourly: true,
   methodology: {
     Volume:
-      "Sum of the USD value of the stable (USDT/USDC) leg of every reactor fill on the chain, as indexed from on-chain Fill transactions by the protocol subgraph and served by Textile's public API.",
+      "Sum of the USD value of the stable (USDT/USDC) leg of every reactor fill on the chain, as indexed from on-chain Fill transactions by the protocol subgraph and served by Textile's public API (settlementTradeVolumes).",
   },
   fetch,
   chains: Object.keys(CHAIN_IDS),


### PR DESCRIPTION
Not a new listing — this is a fix to an existing adapter (`dexs/textile`, Textile FX), so the template form below is replaced with details.

## Summary

Point the Textile FX volume adapter at our new time-windowed `settlementTradeVolumes(fromTimestamp, toTimestamp)` query, so each hourly/daily fetch pulls only that window server-side instead of pulling the full `settlementMakerStats` trade history and filtering client-side.

Also add Polygon (`137`), which has historical volume that was previously omitted.

## Why

DefiLlama's stored series for Textile FX is short by **$1.83M** over `2026-06-28` → `2026-07-29`.

Comparing your daily series (`/summary/dexs/textile-fx`) against our API for the same chains (ETH, BSC, Base, Celo, i.e. excluding the newly added Polygon):

| Range | DefiLlama | Textile API | Diff |
|---|---|---|---|
| `2026-06-07` → `2026-06-27` | $259,140 | $259,340 | +$200 |
| `2026-06-28` → `2026-07-29` | $596,514 | $2,431,338 | **+$1,834,824** |
| `2026-07-30` → `2026-08-05` | $1,645,005 | $1,645,005 | $0 |

Recent days match to the dollar. So the adapter's methodology was right, it just got throttled/timed out pulling full history on every run during the high-volume stretch. The windowed query removes that failure mode. There is no per-maker row cap on our side (verified against the subgraph).

**After this lands, please refill historical daily volume for Textile FX from `2026-06-07`** (at minimum `2026-06-28` → `2026-07-29`). The adapter change alone will not rewrite the old daily buckets, so without a refill the historical gap stays.

## API

```graphql
query TextileVolumes($from: Int!, $to: Int!) {
  settlementTradeVolumes(fromTimestamp: $from, toTimestamp: $to) {
    timestamp
    chainId
    volumeUsd
  }
}
```

- Endpoint: `https://api.textilecredit.com/graphql`
- Window: `[fromTimestamp, toTimestamp)` in unix seconds, same bounds as `FetchOptions`
- Includes every reactor fill (Stitches and limit-order fills)
- One row per subgraph `FillerReactorTradeMaker` (per tx, maker, directed pair), not per `Fill` event

Methodology is unchanged: sum of the USD value of the stable (USDT/USDC) leg of every reactor fill on the chain.

## Polygon

$34,070 all-time across 5 days (`2026-06-16` → `2026-06-25`). Small, but it's real volume the current adapter drops.

## Test plan

- [x] `pnpm test dexs textile`
- [x] `pnpm test dexs textile 2026-08-06` (UTC day `2026-08-05`) → `383.82 k` aggregate, ethereum `273.72 k` + bsc `110.10 k`, matching your stored value for that day
- [ ] After merge: refill historical days from `2026-06-07`

No changes to `package.json` / lockfiles.
