### PR TITLE
factory/curators: add Flare to Clearstar

### DIFF
--- a/factory/curators.ts
+++ b/factory/curators.ts
@@ -97,6 +97,16 @@ const configs: Record<string, CuratorConfig> = {
         morphoVaultV2Owners: ['0x30988479C2E6a03E7fB65138b94762D41a733458', '0x829A13850b684A575C0580a83322890e19c5eFaa'],
         start: '2025-08-11'
       },
+      // Mystic is a Morpho fork, so its vaults are not reachable through the
+      // Morpho V2 factory lookup - listed by address instead.
+      [CHAIN.FLARE]: {
+        morphoV2: [
+          '0xE8dd6A1e13244A27bDaa19CcBf33013647C675d1', // Core USDT0 on Mystic
+          '0x1aEadA3C251215f1294720B80FcB3D1D005F3585', // Core wFLR on Mystic
+          '0x53184aDaBF312b490BF1EbcFdC896FEfF6019a14', // Core FXRP on Mystic
+        ],
+        start: '2026-02-02',
+      },
     },
   },
   "edge-capital": {


### PR DESCRIPTION
Clearstar curates three vaults on Flare through Mystic. They hold about $25.2M and have been live since 2026-02-02, but `factory/curators.ts` has no Flare entry for Clearstar, so none of the fees they generate are counted.

The TVL side already tracks them. `registries/curators.js` lists all three under `clearstar` / `flare`, so this is only the dimensions side catching up.

## Why `morphoV2` and not `morphoVaultV2Owners`

Mystic is a Morpho fork. Its vaults are not reachable through the factory-log lookup that `morphoVaultV2Owners` performs, and there is no Morpho factory registered for Flare. Listing by address sidesteps that: `getMorphoVaultsV2` only dereferences `MorphoConfigs[options.chain]` when `owners` is non-empty, so an explicit address list needs no factory config for the chain.

They are Morpho V2 style rather than V1:

```
fee()             -> reverts
performanceFee()  -> 100000000000000000   (10%)
managementFee()   -> 0
```

That is why `morphoV2` is the correct key. Using the V1 `morpho` key would read `fee()` under `permitFailure`, get null, and report the entire yield as supply side with zero revenue.

## Attribution

Three independent confirmations that these are Clearstar's:

- `owner()` on all three is `0x30988479C2E6a03E7fB65138b94762D41a733458`, the same address Clearstar already uses as `morphoVaultOwners` on all seven existing chains.
- All three were deployed by `0x829A13850b684A575C0580a83322890e19c5eFaa`, already registered as a Clearstar `morphoVaultV2Owner` on Katana, via the same Mystic factory `0x6fc83ecc0e8142635d77200e5052be8a0a9d2f42`.
- The TVL registry already assigns them to Clearstar.

## On chain

Share-rate growth measured over a 24.37h window (blocks 66717000 to 66794386):

| vault | address | balance | TVL | daily fees |
|---|---|---:|---:|---:|
| Core USDT0 | `0xE8dd6A1e13244A27bDaa19CcBf33013647C675d1` | 21,704,459 USDT0 | ~$21.68M | ~$1,751 |
| Core FXRP | `0x53184aDaBF312b490BF1EbcFdC896FEfF6019a14` | 2,815,224 FXRP | ~$2.94M | ~$23 |
| Core wFLR | `0x1aEadA3C251215f1294720B80FcB3D1D005F3585` | 97,283,494 WFLR | ~$0.58M | ~$58 |

All three assets are priced by `coins.llama.fi` at 0.99 confidence (USDT0 $0.999, FXRP $1.045, WFLR $0.005956).

## Test

`npm run test fees clearstar`

```
chain     | Daily fees | Daily revenue | Daily protocol revenue | Daily supply side revenue | Start Time
base      | 242.00     | 48.00         | 48.00                  | 194.00                    |
ethereum  | 352.00     | 70.00         | 70.00                  | 281.00                    |
polygon   | 0.00       | 0.00          | 0.00                   | 0.00                      |
unichain  | 0.00       | 0.00          | 0.00                   | 0.00                      | 1/10/2025
arbitrum  | 0.33       | 0.07          | 0.07                   | 0.27                      |
hemi      | 1.43       | 0.14          | 0.14                   | 1.29                      | 1/10/2025
katana    | 21.00      | 0.02          | 0.02                   | 21.00                     | 11/8/2025
flare     | 1.82 k     | 182.00        | 182.00                 | 1.64 k                    | 2/2/2026
Aggregate | 2.44 k     | 300.23        | 300.23                 | 2.14 k                    |
```

Aggregate daily fees go from 616.76 to 2436.77. The Flare row satisfies the expected identity (1.82k fees = 182 revenue + 1.64k supply side), and the 10% split matches the on-chain `performanceFee()`.

## Not included

The Upshift FXRP vault that the TVL registry also lists under Clearstar on Flare. The curator framework has no `upshiftV2` handler on the dimensions side, so it is out of scope for this PR.
