### PR TITLE
camelot-v3: mark rari dead, its rpc is gone and it takes the other chains down with it

### DIFF
--- a/dexs/camelot-v3/index.ts
+++ b/dexs/camelot-v3/index.ts
@@ -143,6 +143,7 @@ const adapter: SimpleAdapter = {
         ...adapterConfig,
       }),
       start: '2024-06-05',
+      deadFrom: '2026-07-08',
     },
     [CHAIN.REYA]: {
       fetch: getUniV3LogAdapter({

--- a/factory/uniV2.ts
+++ b/factory/uniV2.ts
@@ -490,7 +490,7 @@ const configs: Record<string, Record<string, any>> = {
     [CHAIN.APECHAIN]: { factory: '0x7d8c6B58BA2d40FC6E34C25f9A488067Fe0D2dB4', start: '2024-10-15', fees: 0.003, userFeesRatio: 1, revenueRatio: 0.4, protocolRevenueRatio: 0.175, holdersRevenueRatio: 0.225 },
     [CHAIN.ARBITRUM]: { factory: '0x6EcCab422D763aC031210895C81787E87B43A652', start: '2022-11-22', fees: 0.003, userFeesRatio: 1, revenueRatio: 0.4, protocolRevenueRatio: 0.175, holdersRevenueRatio: 0.225 },
     [CHAIN.GRAVITY]: { factory: '0x7d8c6B58BA2d40FC6E34C25f9A488067Fe0D2dB4', start: '2024-07-04', fees: 0.003, userFeesRatio: 1, revenueRatio: 0.4, protocolRevenueRatio: 0.175, holdersRevenueRatio: 0.225 },
-    [CHAIN.RARI]: { factory: '0x7d8c6B58BA2d40FC6E34C25f9A488067Fe0D2dB4', start: '2024-06-05', fees: 0.003, userFeesRatio: 1, revenueRatio: 0.4, protocolRevenueRatio: 0.175, holdersRevenueRatio: 0.225 },
+    [CHAIN.RARI]: { factory: '0x7d8c6B58BA2d40FC6E34C25f9A488067Fe0D2dB4', start: '2024-06-05', fees: 0.003, userFeesRatio: 1, revenueRatio: 0.4, protocolRevenueRatio: 0.175, holdersRevenueRatio: 0.225, deadFrom: '2026-07-08' },
     [CHAIN.REYA]: { factory: '0x7d8c6B58BA2d40FC6E34C25f9A488067Fe0D2dB4', start: '2024-06-20', fees: 0.003, userFeesRatio: 1, revenueRatio: 0.4, protocolRevenueRatio: 0.175, holdersRevenueRatio: 0.225 },
     // sanko: { factory: '0x7d8c6B58BA2d40FC6E34C25f9A488067Fe0D2dB4', start: '2024-04-17', fees: 0.003, userFeesRatio: 1, revenueRatio: 0.4, protocolRevenueRatio: 0.175, holdersRevenueRatio: 0.225 },
   },

--- a/helpers/uniswap.ts
+++ b/helpers/uniswap.ts
@@ -459,6 +459,7 @@ type UniV2Config = {
   maxPairSize?: number,
   customLogic?: any,
   start?: string,
+  deadFrom?: string,
   blacklistedAddresses?: string[],
   userFeesRatio?: number,
   revenueRatio?: number,
@@ -506,6 +507,7 @@ export function uniV2Exports(config: IJSON<UniV2Config>, { runAsV1 = false, pull
 
   Object.entries(config).map(([chain, chainConfig]) => {
     exportObject[chain] = { fetch: getUniV2LogAdapter(chainConfig), start: chainConfig.start }
+    if (chainConfig.deadFrom) exportObject[chain].deadFrom = chainConfig.deadFrom
   })
 
 


### PR DESCRIPTION
camelot-v3 has published nothing since 2026-08-03, not a zero, no row at all, on any of its 7 chains. Arbitrum alone was doing ~$2M/day.

The whole adapter dies on rari. Its only RPC in the sdk is `https://mainnet.rpc.rarichain.org/http` and that host now answers 404:

```
$ curl -X POST https://mainnet.rpc.rarichain.org/http -d '{"jsonrpc":"2.0","id":1,"method":"eth_blockNumber","params":[]}'
<hr><center>nginx</center>
HTTP:404
```

so the run never gets past fetching a block:

```
$ npm test dexs camelot-v3 2026-08-05
error fetching block Error: No RPCs available for rari
------ ERROR ------
Error: No RPCs available for rari
```

Every other chain is fine on its own, arbitrum 2.29M, apechain 29.02k, gravity 4.94k, plume_mainnet 4.44k, spn 2.51k, reya 0.00. It's only the dead one that takes the run down, and it takes the live ones with it.

rari itself has nothing left to report. Over 642 days in the breakdown it had volume on 591 of them, and the last was **2026-07-07**: it has been flat zero since, which is why `deadFrom` is dated 07-08 rather than the day the RPC went. Nothing is lost by stopping there, and the 591 real days stay in the chart.

Chain TVL is $6,162 (`api.llama.fi/v2/chains`), so this looks like the chain winding down rather than a temporary outage.

After the change the run completes and the live chains report again:

```
$ npm test dexs camelot-v3 2026-08-05
Skipping rari because the adapter ended at Wed, 08 Jul 2026 00:00:00 GMT

chain         | Daily volume
apechain      | 46.05 k
arbitrum      | 2.73 M
gravity       | 1.68 k
reya          | 0.00
plume_mainnet | 4.05 k
spn           | 3.02 k
Aggregate     | 2.78 M
```

and 2026-08-06 gives 3.45 M aggregate.

Sanity check that those numbers aren't invented; on days the API still has, a local run lands in the same band (local prices at now, production priced at the time):

| day | production arbitrum | local |
| --- | --- | --- |
| 07-31 | $3,421k | $3.23 M |
| 08-02 | $1,772k | $1.52 M |

`npm run ts-check` passes.

---

second commit: camelot v2 (`factory/uniV2.ts`, module `camelot`) declares the same rari deployment and dies the same way; which is why its chart also stops on 08-03. adding `deadFrom` to its config wasn't enough on its own: `uniV2Exports` only copied `fetch` and `start` out of the chain config, so a per-chain `deadFrom` was silently dropped, while `uniV3Exports` already honors it. added the same one-liner to the v2 path plus the field on `UniV2Config`. no existing config sets a per-chain `deadFrom` (checked every uniV2Exports caller), so nothing else changes behavior.

after, v2 runs clean too:

```
$ npm test dexs camelot 2026-08-05
Skipping rari because the adapter ended at Wed, 08 Jul 2026 00:00:00 GMT
apechain 45.35 | arbitrum 31.47 k | gravity 0.00 | reya 0.00 | Aggregate 31.51 k
```

same aggregate across repeat runs, ts-check still green.