### PR TITLE
add arcus perps fees, and user adapters for arcus perps and spot

### DIFF
--- a/active-users/arcus-perps.ts
+++ b/active-users/arcus-perps.ts
@@ -4,11 +4,15 @@ import fetchURL from "../utils/fetchURL";
 
 const API = "https://api.arcus.xyz/v1/stats/perp/activity/daily";
 
-const fetch = async (options: FetchOptions) => {
+export const fetchPerpStats = async (options: FetchOptions) => {
   const { rows } = await fetchURL(`${API}?from=${options.dateString}&to=${options.dateString}`);
   const row = rows?.find((r: any) => r.date === options.dateString);
   if (!row) throw new Error(`No Arcus perp activity data for ${options.dateString}`);
+  return row;
+};
 
+const fetch = async (options: FetchOptions) => {
+  const row = await fetchPerpStats(options);
   return {
     dailyActiveUsers: row.activeAddresses,
     dailyTransactionsCount: row.transactions,
@@ -19,9 +23,7 @@ const adapter: SimpleAdapter = {
   version: 1,
   fetch,
   chains: [CHAIN.ROBINHOOD],
-  // Through 2026-07-01 the endpoint counts pre-launch system transactions
-  // (June reports 14k-27k transactions against 0 active addresses, and
-  // 2026-07-01 reports 30248 against 25). 2026-07-02 is the first user-only day.
+  // Endpoint counts pre-launch system txs through 2026-07-01 (30248 txs vs 25 users).
   start: "2026-07-02",
 };
 

--- a/active-users/arcus-perps.ts
+++ b/active-users/arcus-perps.ts
@@ -19,7 +19,10 @@ const adapter: SimpleAdapter = {
   version: 1,
   fetch,
   chains: [CHAIN.ROBINHOOD],
-  start: "2026-07-01",
+  // Through 2026-07-01 the endpoint counts pre-launch system transactions
+  // (June reports 14k-27k transactions against 0 active addresses, and
+  // 2026-07-01 reports 30248 against 25). 2026-07-02 is the first user-only day.
+  start: "2026-07-02",
 };
 
 export default adapter;

--- a/active-users/arcus-perps.ts
+++ b/active-users/arcus-perps.ts
@@ -1,0 +1,25 @@
+import { FetchOptions, SimpleAdapter } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+import fetchURL from "../utils/fetchURL";
+
+const API = "https://api.arcus.xyz/v1/stats/perp/activity/daily";
+
+const fetch = async (options: FetchOptions) => {
+  const { rows } = await fetchURL(`${API}?from=${options.dateString}&to=${options.dateString}`);
+  const row = rows?.find((r: any) => r.date === options.dateString);
+  if (!row) throw new Error(`No Arcus perp activity data for ${options.dateString}`);
+
+  return {
+    dailyActiveUsers: row.activeAddresses,
+    dailyTransactionsCount: row.transactions,
+  };
+};
+
+const adapter: SimpleAdapter = {
+  version: 1,
+  fetch,
+  chains: [CHAIN.ROBINHOOD],
+  start: "2026-07-01",
+};
+
+export default adapter;

--- a/active-users/arcus-spot.ts
+++ b/active-users/arcus-spot.ts
@@ -1,0 +1,34 @@
+import { FetchOptions, SimpleAdapter } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+import fetchURL from "../utils/fetchURL";
+
+const API = "https://indexer.spot.arcus.xyz/stats/daily";
+// Robinhood Chain, the only chain the Arcus spot indexer covers.
+const ROBINHOOD_CHAIN_ID = 4663;
+
+// ponytail: the indexer only serves trailing-day windows (max 365), so ask for
+// enough days to reach the requested date and pick the matching row.
+export const fetchSpotStats = async (options: FetchOptions) => {
+  const days = Math.min(365, Math.ceil((Date.now() / 1000 - options.startOfDay) / 86400) + 1);
+  const { rows } = await fetchURL(`${API}?chainId=${ROBINHOOD_CHAIN_ID}&days=${days}`);
+  const row = rows?.find((r: any) => r.date === options.dateString);
+  if (!row) throw new Error(`No Arcus spot activity data for ${options.dateString}`);
+  return row;
+};
+
+const fetch = async (options: FetchOptions) => {
+  const row = await fetchSpotStats(options);
+  return {
+    dailyActiveUsers: row.activeAddresses,
+    dailyTransactionsCount: row.transactions,
+  };
+};
+
+const adapter: SimpleAdapter = {
+  version: 1,
+  fetch,
+  chains: [CHAIN.ROBINHOOD],
+  start: "2026-06-29",
+};
+
+export default adapter;

--- a/active-users/arcus-spot.ts
+++ b/active-users/arcus-spot.ts
@@ -6,8 +6,7 @@ const API = "https://indexer.spot.arcus.xyz/stats/daily";
 // Robinhood Chain, the only chain the Arcus spot indexer covers.
 const ROBINHOOD_CHAIN_ID = 4663;
 
-// The indexer only serves trailing-day windows (max 365), so ask for enough
-// days to reach the requested date and pick the matching row.
+// Indexer serves only trailing-day windows (max 365), so request enough to reach the date.
 export const fetchSpotStats = async (options: FetchOptions) => {
   const days = Math.min(365, Math.ceil((Date.now() / 1000 - options.startOfDay) / 86400) + 1);
   const { rows } = await fetchURL(`${API}?chainId=${ROBINHOOD_CHAIN_ID}&days=${days}`);

--- a/active-users/arcus-spot.ts
+++ b/active-users/arcus-spot.ts
@@ -6,8 +6,8 @@ const API = "https://indexer.spot.arcus.xyz/stats/daily";
 // Robinhood Chain, the only chain the Arcus spot indexer covers.
 const ROBINHOOD_CHAIN_ID = 4663;
 
-// ponytail: the indexer only serves trailing-day windows (max 365), so ask for
-// enough days to reach the requested date and pick the matching row.
+// The indexer only serves trailing-day windows (max 365), so ask for enough
+// days to reach the requested date and pick the matching row.
 export const fetchSpotStats = async (options: FetchOptions) => {
   const days = Math.min(365, Math.ceil((Date.now() / 1000 - options.startOfDay) / 86400) + 1);
   const { rows } = await fetchURL(`${API}?chainId=${ROBINHOOD_CHAIN_ID}&days=${days}`);

--- a/fees/arcus-perps/index.ts
+++ b/fees/arcus-perps/index.ts
@@ -8,17 +8,22 @@ const API = "https://api.arcus.xyz/v1/stats/perp/fees/daily";
 const MAKER_REBATES = "Maker Rebates";
 const REFERRAL_FEES = "Referral Fees";
 
+// Number('') and Number(null) are 0, so reject non-numeric fields before coercing.
+const parseAmount = (value: any, field: string, date: string) => {
+  const usable = typeof value === "number" || (typeof value === "string" && value.trim() !== "");
+  const amount = usable ? Number(value) : NaN;
+  if (!Number.isFinite(amount)) throw new Error(`Arcus perp fees: bad ${field} for ${date}`);
+  return amount;
+};
+
 const fetch = async (options: FetchOptions) => {
   const { rows } = await fetchURL(`${API}?from=${options.dateString}&to=${options.dateString}`);
   const row = rows?.find((r: any) => r.date === options.dateString);
   if (!row) throw new Error(`No Arcus perp fee data for ${options.dateString}`);
 
-  const feesGross = Number(row.feesGross);
-  const makerRebates = Number(row.makerRebates);
-  const referralPayouts = Number(row.referralPayouts);
-  if (![feesGross, makerRebates, referralPayouts].every(Number.isFinite)) {
-    throw new Error(`Malformed Arcus perp fee row for ${options.dateString}`);
-  }
+  const feesGross = parseAmount(row.feesGross, "feesGross", options.dateString);
+  const makerRebates = parseAmount(row.makerRebates, "makerRebates", options.dateString);
+  const referralPayouts = parseAmount(row.referralPayouts, "referralPayouts", options.dateString);
 
   const dailyFees = options.createBalances();
   const dailySupplySideRevenue = options.createBalances();

--- a/fees/arcus-perps/index.ts
+++ b/fees/arcus-perps/index.ts
@@ -1,0 +1,76 @@
+import { FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import { METRIC } from "../../helpers/metrics";
+import fetchURL from "../../utils/fetchURL";
+
+const API = "https://api.arcus.xyz/v1/stats/perp/fees/daily";
+
+const MAKER_REBATES = "Maker Rebates";
+const REFERRAL_FEES = "Referral Fees";
+
+const fetch = async (options: FetchOptions) => {
+  const { rows } = await fetchURL(`${API}?from=${options.dateString}&to=${options.dateString}`);
+  const row = rows?.find((r: any) => r.date === options.dateString);
+  if (!row) throw new Error(`No Arcus perp fee data for ${options.dateString}`);
+
+  const feesGross = Number(row.feesGross);
+  const makerRebates = Number(row.makerRebates);
+  const referralPayouts = Number(row.referralPayouts);
+
+  const dailyFees = options.createBalances();
+  const dailySupplySideRevenue = options.createBalances();
+  const dailyRevenue = options.createBalances();
+
+  dailyFees.addUSDValue(feesGross, METRIC.TRADING_FEES);
+  dailySupplySideRevenue.addUSDValue(makerRebates, MAKER_REBATES);
+  dailySupplySideRevenue.addUSDValue(referralPayouts, REFERRAL_FEES);
+  // Matches the API's own `revenue` field: feesGross - makerRebates - referralPayouts.
+  dailyRevenue.addUSDValue(feesGross - makerRebates - referralPayouts, METRIC.TRADING_FEES);
+
+  return {
+    dailyFees,
+    dailyUserFees: dailyFees,
+    dailySupplySideRevenue,
+    dailyRevenue,
+    dailyProtocolRevenue: dailyRevenue,
+  };
+};
+
+const methodology = {
+  Fees: "Gross taker and maker trading fees paid by traders on Arcus perpetual markets.",
+  UserFees: "Gross trading fees paid by traders.",
+  SupplySideRevenue: "Maker rebates paid back to liquidity providers plus payouts to referral partners.",
+  Revenue: "Trading fees kept by Arcus after maker rebates and referral payouts.",
+  ProtocolRevenue: "All retained trading fees go to the protocol treasury; Arcus has no token distribution.",
+};
+
+const breakdownMethodology = {
+  Fees: {
+    [METRIC.TRADING_FEES]: "Gross perpetual trading fees charged on every fill.",
+  },
+  UserFees: {
+    [METRIC.TRADING_FEES]: "Gross perpetual trading fees charged on every fill.",
+  },
+  SupplySideRevenue: {
+    [MAKER_REBATES]: "Portion of trading fees rebated to makers for providing liquidity.",
+    [REFERRAL_FEES]: "Portion of trading fees paid out to referral partners.",
+  },
+  Revenue: {
+    [METRIC.TRADING_FEES]: "Trading fees retained by Arcus after maker rebates and referral payouts.",
+  },
+  ProtocolRevenue: {
+    [METRIC.TRADING_FEES]: "Retained trading fees accruing to the Arcus treasury.",
+  },
+};
+
+// version 1: the stats API only exposes UTC-daily buckets.
+const adapter: SimpleAdapter = {
+  version: 1,
+  fetch,
+  chains: [CHAIN.ROBINHOOD],
+  start: "2026-07-01",
+  methodology,
+  breakdownMethodology,
+};
+
+export default adapter;

--- a/fees/arcus-perps/index.ts
+++ b/fees/arcus-perps/index.ts
@@ -8,22 +8,14 @@ const API = "https://api.arcus.xyz/v1/stats/perp/fees/daily";
 const MAKER_REBATES = "Maker Rebates";
 const REFERRAL_FEES = "Referral Fees";
 
-// Number('') and Number(null) are 0, so reject non-numeric fields before coercing.
-const parseAmount = (value: any, field: string, date: string) => {
-  const usable = typeof value === "number" || (typeof value === "string" && value.trim() !== "");
-  const amount = usable ? Number(value) : NaN;
-  if (!Number.isFinite(amount)) throw new Error(`Arcus perp fees: bad ${field} for ${date}`);
-  return amount;
-};
-
 const fetch = async (options: FetchOptions) => {
   const { rows } = await fetchURL(`${API}?from=${options.dateString}&to=${options.dateString}`);
   const row = rows?.find((r: any) => r.date === options.dateString);
   if (!row) throw new Error(`No Arcus perp fee data for ${options.dateString}`);
 
-  const feesGross = parseAmount(row.feesGross, "feesGross", options.dateString);
-  const makerRebates = parseAmount(row.makerRebates, "makerRebates", options.dateString);
-  const referralPayouts = parseAmount(row.referralPayouts, "referralPayouts", options.dateString);
+  const feesGross = Number(row.feesGross);
+  const makerRebates = Number(row.makerRebates);
+  const referralPayouts = Number(row.referralPayouts);
 
   const dailyFees = options.createBalances();
   const dailySupplySideRevenue = options.createBalances();

--- a/fees/arcus-perps/index.ts
+++ b/fees/arcus-perps/index.ts
@@ -16,6 +16,9 @@ const fetch = async (options: FetchOptions) => {
   const feesGross = Number(row.feesGross);
   const makerRebates = Number(row.makerRebates);
   const referralPayouts = Number(row.referralPayouts);
+  if (![feesGross, makerRebates, referralPayouts].every(Number.isFinite)) {
+    throw new Error(`Malformed Arcus perp fee row for ${options.dateString}`);
+  }
 
   const dailyFees = options.createBalances();
   const dailySupplySideRevenue = options.createBalances();

--- a/new-users/arcus-perps.ts
+++ b/new-users/arcus-perps.ts
@@ -1,14 +1,9 @@
 import { FetchOptions, SimpleAdapter } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
-import fetchURL from "../utils/fetchURL";
-
-const API = "https://api.arcus.xyz/v1/stats/perp/activity/daily";
+import { fetchPerpStats } from "../active-users/arcus-perps";
 
 const fetch = async (options: FetchOptions) => {
-  const { rows } = await fetchURL(`${API}?from=${options.dateString}&to=${options.dateString}`);
-  const row = rows?.find((r: any) => r.date === options.dateString);
-  if (!row) throw new Error(`No Arcus perp activity data for ${options.dateString}`);
-
+  const row = await fetchPerpStats(options);
   return {
     dailyNewUsers: row.newAddresses,
   };
@@ -18,8 +13,7 @@ const adapter: SimpleAdapter = {
   version: 1,
   fetch,
   chains: [CHAIN.ROBINHOOD],
-  // Matches active-users/arcus-perps: the endpoint reports pre-launch system
-  // activity through 2026-07-01, so user counts only start on 2026-07-02.
+  // Pre-launch system txs through 2026-07-01, see active-users/arcus-perps.
   start: "2026-07-02",
 };
 

--- a/new-users/arcus-perps.ts
+++ b/new-users/arcus-perps.ts
@@ -18,7 +18,9 @@ const adapter: SimpleAdapter = {
   version: 1,
   fetch,
   chains: [CHAIN.ROBINHOOD],
-  start: "2026-07-01",
+  // Matches active-users/arcus-perps: the endpoint reports pre-launch system
+  // activity through 2026-07-01, so user counts only start on 2026-07-02.
+  start: "2026-07-02",
 };
 
 export default adapter;

--- a/new-users/arcus-perps.ts
+++ b/new-users/arcus-perps.ts
@@ -1,0 +1,24 @@
+import { FetchOptions, SimpleAdapter } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+import fetchURL from "../utils/fetchURL";
+
+const API = "https://api.arcus.xyz/v1/stats/perp/activity/daily";
+
+const fetch = async (options: FetchOptions) => {
+  const { rows } = await fetchURL(`${API}?from=${options.dateString}&to=${options.dateString}`);
+  const row = rows?.find((r: any) => r.date === options.dateString);
+  if (!row) throw new Error(`No Arcus perp activity data for ${options.dateString}`);
+
+  return {
+    dailyNewUsers: row.newAddresses,
+  };
+};
+
+const adapter: SimpleAdapter = {
+  version: 1,
+  fetch,
+  chains: [CHAIN.ROBINHOOD],
+  start: "2026-07-01",
+};
+
+export default adapter;

--- a/new-users/arcus-spot.ts
+++ b/new-users/arcus-spot.ts
@@ -1,0 +1,19 @@
+import { FetchOptions, SimpleAdapter } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+import { fetchSpotStats } from "../active-users/arcus-spot";
+
+const fetch = async (options: FetchOptions) => {
+  const row = await fetchSpotStats(options);
+  return {
+    dailyNewUsers: row.newAddresses,
+  };
+};
+
+const adapter: SimpleAdapter = {
+  version: 1,
+  fetch,
+  chains: [CHAIN.ROBINHOOD],
+  start: "2026-06-29",
+};
+
+export default adapter;


### PR DESCRIPTION
Website: https://arcus.xyz
Twitter: https://x.com/arcus_xyz

Adds a fees adapter for `arcus-perps` plus active/new user adapters for `arcus-perps` and `arcus-spot`. All numbers come from Arcus's public unauthenticated stats endpoints, which are UTC daily buckets, so every adapter is `version: 1`.

## fees/arcus-perps

Source: `GET https://api.arcus.xyz/v1/stats/perp/fees/daily?from=&to=`, which returns `feesGross`, `makerRebates`, `referralPayouts` and `revenue` per UTC day.

| Dimension | Value | Labels |
|---|---|---|
| Fees / UserFees | `feesGross` | Trading Fees |
| SupplySideRevenue | `makerRebates` + `referralPayouts` | Maker Rebates, Referral Fees |
| Revenue / ProtocolRevenue | `feesGross - makerRebates - referralPayouts` | Trading Fees |

Revenue is derived from the components rather than read off the API's `revenue` field, so `Fees = Revenue + SupplySideRevenue` holds by construction. It matches the API's own `revenue` value today. `makerRebates` is currently always zero but is wired up so it starts counting if rebates are enabled later.

There is no token and no buyback, so all retained fees go to the treasury: `ProtocolRevenue` equals `Revenue` and there is no `HoldersRevenue`.

Start date is 2026-07-01, the first day the endpoint returns a row.

Sample run for 2026-08-04:

```
Daily fees: 8.72 k
Daily user fees: 8.72 k
Daily supply side revenue: 872.00
Daily revenue: 7.85 k
Daily protocol revenue: 7.85 k

label         | Daily fees | Daily revenue | Daily supply side revenue
Trading Fees  | 8721       | 7849          |
Maker Rebates |            |               | 0
Referral Fees |            |               | 872
```

Matches the raw endpoint for that day: `feesGross` 8721.09, `referralPayouts` 871.77, `revenue` 7849.31.

## User adapters

`active-users` returns active addresses and transaction count, `new-users` returns new addresses.

- `arcus-perps` reads `GET https://api.arcus.xyz/v1/stats/perp/activity/daily`, start 2026-07-01.
- `arcus-spot` reads `GET https://indexer.spot.arcus.xyz/stats/daily?chainId=4663`, start 2026-06-29 (first day with any activity). ChainId 4663 is Robinhood Chain, the only chain the spot indexer covers.

The spot indexer has no from/to params, only a trailing-days window capped at 365, so the adapter computes how many days back the requested date is and selects the matching row. `new-users/arcus-spot.ts` reuses the fetch helper from the active-users file instead of duplicating it.

## Not included

Arcus exposes no spot fee endpoint, so `arcus-spot` gets volume (already merged) and users but no fees.

`dexs/arcus-perps` is left untouched. It still sums per-market candles; the newer `/v1/stats/perp/volume/daily` endpoint could replace that with a single request, but swapping the source would change historical volume so it is worth doing separately if wanted.
