### PR TITLE
add frontier

### DIFF
--- a/active-users/frontier-fun.ts
+++ b/active-users/frontier-fun.ts
@@ -1,0 +1,81 @@
+import { FetchOptions, SimpleAdapter } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+
+// Frontier (frontier.fun) — bonding-curve token launchpad on Robinhood Chain (4663).
+// Every market trades against one shared BondingCurve, and every launch goes
+// through one factory, so two targets cover all user-facing activity. Swaps on a
+// graduated token's Uniswap V4 pool are Uniswap activity, not Frontier's, and are
+// excluded for the same reason the volume adapter excludes them.
+// Both deployed in block 23472343; the factory registered this curve in the same
+// block (BondingCurveUpdated) and has never pointed at another one.
+// https://robinhoodchain.blockscout.com/address/0xCCa442899dFD80bf04340fa8C245C7EB02F71DD4
+const BONDING_CURVE = "0xCCa442899dFD80bf04340fa8C245C7EB02F71DD4";
+// https://robinhoodchain.blockscout.com/address/0x3cbC9395046607C083B383DC3588A3e8308dFf54
+const FACTORY = "0x3cbC9395046607C083B383DC3588A3e8308dFf54";
+
+const activityEvents = [
+  {
+    target: BONDING_CURVE,
+    userField: "user",
+    eventAbi:
+      "event Buy(address indexed user, address indexed token, uint256 amount, uint256 amountOut, uint256 totalSupply, uint256 marketCap, uint256 price, uint256 reserveBalance)",
+  },
+  {
+    target: BONDING_CURVE,
+    userField: "user",
+    eventAbi:
+      "event Sell(address indexed user, address indexed token, uint256 amount, uint256 amountOut, uint256 totalSupply, uint256 marketCap, uint256 price, uint256 reserveBalance)",
+  },
+  {
+    target: FACTORY,
+    userField: "creator",
+    eventAbi:
+      "event CoinDeployed(address indexed creator, address indexed token, address factory, address lp, string name, string symbol, string description, string image, uint256 initialSupply, uint256 maxSupply, uint256 initialETHReserves, uint256 initialPrice, uint256 initialMarketCap, uint256 targetETH)",
+  },
+] as const;
+
+async function fetch(options: FetchOptions) {
+  const logsByEvent = await Promise.all(
+    activityEvents.map(({ target, eventAbi }) =>
+      options.getLogs({ targets: [target], eventAbi, onlyArgs: false })
+    )
+  );
+
+  const users = new Set<string>();
+  const transactions = new Set<string>();
+
+  logsByEvent.forEach((logs, eventIndex) => {
+    const { userField } = activityEvents[eventIndex];
+    logs.forEach((log: any) => {
+      const user = log.args?.[userField];
+      if (typeof user === "string") users.add(user.toLowerCase());
+      if (typeof log.transactionHash === "string")
+        transactions.add(log.transactionHash.toLowerCase());
+    });
+  });
+
+  return {
+    dailyActiveUsers: users.size,
+    dailyTransactionsCount: transactions.size,
+  };
+}
+
+// Version 1 deliberately, despite this reading on-chain logs. dailyActiveUsers is
+// a daily-unique count, which does not decompose into hourly slices: under
+// version 2 the runner sums 24 hourly results, so a wallet that trades in six
+// different hours is counted six times. Measured on 2026-08-05, the same day
+// reports 20 active users at version 1 and 401 at version 2 + pullHourly, off the
+// identical 914 transactions. Transaction counts do partition correctly, but the
+// adapter cannot be split per metric. Every other active-users adapter is
+// version 1 for the same reason.
+const adapter: SimpleAdapter = {
+  version: 1,
+  fetch,
+  chains: [CHAIN.ROBINHOOD],
+  // First CoinDeployed event, block 23650298.
+  start: "2026-07-30",
+  methodology:
+    "Counts unique addresses that bought or sold on a Frontier bonding curve (BondingCurve Buy/Sell) or launched a token (BCTokenFactory CoinDeployed), and the transactions those actions occurred in. Swaps on graduated tokens' Uniswap V4 pools are counted as Uniswap activity and excluded here.",
+};
+
+export default adapter;

--- a/dexs/frontier-fun/index.ts
+++ b/dexs/frontier-fun/index.ts
@@ -3,14 +3,13 @@ import { Adapter, FetchOptions, FetchResultV2 } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 import ADDRESSES from "../../helpers/coreAssets.json";
 
-// Frontier (frontier.fun) — bonding-curve token launchpad on Robinhood Chain (4663).
+// Frontier (frontier.fun) is a bonding-curve token launchpad on Robinhood Chain (4663).
 //
-// Every launched token trades against a single shared BondingCurve contract that
-// emits Buy/Sell for all markets, so one target covers the whole protocol. When a
-// curve fills, the token contract wraps its raised ETH, pays out the graduation
-// fees and seeds a Uniswap V4 pool (LPSeeded), after which the market trades on
-// the canonical V4 PoolManager. Those post-graduation swaps are already counted by
-// the uniswap-v4 adapter on this chain, so they are deliberately not counted here.
+// Every launched token trades against one shared BondingCurve contract that emits
+// Buy/Sell for all markets. When a curve fills, the token wraps its raised ETH,
+// pays out graduation fees, and seeds a Uniswap V4 pool (LPSeeded); post-graduation
+// swaps are already counted by the uniswap-v4 adapter on this chain and are not
+// double counted here.
 // https://robinhoodchain.blockscout.com/address/0xCCa442899dFD80bf04340fa8C245C7EB02F71DD4
 const BONDING_CURVE = "0xCCa442899dFD80bf04340fa8C245C7EB02F71DD4";
 // https://robinhoodchain.blockscout.com/address/0x3cbC9395046607C083B383DC3588A3e8308dFf54
@@ -22,24 +21,14 @@ const LIQUIDITY_MANAGER = "0x97f3578083396D4ef2042868c6aE9d4eC91007A6";
 const REFERRAL_MANAGER = "0x6Fb1160A663834e8E53E411CC7202A01F1b144DD";
 const WETH = ADDRESSES.robinhood.WETH;
 
-// keccak256("Transfer(address,address,uint256)") — the standard ERC20 topic0.
+// keccak256("Transfer(address,address,uint256)"), the standard ERC20 topic0.
 const TRANSFER_TOPIC = "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef";
 const asTopic = (address: string) => "0x" + address.slice(2).toLowerCase().padStart(64, "0");
 
-// Both events emit the GROSS ETH notional and the trade fee is withheld from it,
-// but the two legs are denominated differently:
-//
-//   Buy.amount     is msg.value, i.e. fee-inclusive. The fee is 1.5% of the
-//                  post-fee cost, so as a share of the emitted figure it is
-//                  txFee / (10000 + txFee).
-//   Sell.amountOut is the pre-fee proceeds leaving the curve; the seller
-//                  receives amountOut - fee, and the fee is txFee / 10000 of it.
-//
-// Verified against the contract's own books: the BondingCurve retains its fees
-// on-chain and has never been swept (Withdrawn has never fired), so its ETH
-// balance is cumulative lifetime fees. Applying the two rates above to all 5,025
-// trades reproduces that balance to the wei; treating either leg as net of the
-// fee overstates it by 2.47%.
+// Both events emit the GROSS ETH notional, but the fee's share of it differs by leg:
+//   Buy.amount     is msg.value (fee-inclusive), so the fee is txFee / (10000 + txFee).
+//   Sell.amountOut is pre-fee proceeds, so the fee is txFee / 10000.
+// Treating either leg as net of the fee overstates both volume and fees.
 const BUY_EVENT =
   "event Buy(address indexed user, address indexed token, uint256 amount, uint256 amountOut, uint256 totalSupply, uint256 marketCap, uint256 price, uint256 reserveBalance)";
 const SELL_EVENT =
@@ -65,11 +54,9 @@ const INITIAL_TX_FEE_BPS = 150n;
 
 // Fee rates on these contracts are basis points out of 10000.
 const BPS = 10_000n;
-// Split of the curve trade fee: 75% to the token's creator, 25% to the protocol,
-// with any referral reward carved out of the protocol's quarter rather than the
-// creator's. Documented at https://docs.frontier.fun/fees-and-revenue. The curve
-// accrues the whole fee on-chain and the split is applied when it is distributed,
-// so this is the entitlement rather than a settled transfer.
+// Split of the curve trade fee: 75% to the token's creator, 25% to the protocol
+// (referral rewards come out of the protocol's quarter, never the creator's).
+// Documented at https://docs.frontier.fun/fees-and-revenue.
 const CURVE_FEE_CREATOR_BPS = 7_500n;
 
 const LABEL = {
@@ -135,19 +122,12 @@ const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
     }),
   ]);
 
-  // Rate history, oldest first, so each trade is priced with the rate actually in
-  // force when it executed rather than the one in force at the end of the window.
   const feeTimeline = asTimeline(feeChanges, (log: any) => BigInt(log.args.fee));
   const txFeeBpsAt = (log: any) => valueAt(feeTimeline, log, INITIAL_TX_FEE_BPS);
 
-  // Both legs emit gross notional, so volume is the emitted figure as-is; only
-  // the fee's share of it differs between them (see the event comments above).
   const addTrade = (gross: bigint, fee: bigint) => {
     dailyVolume.addGasToken(gross);
     dailyFees.addGasToken(fee, LABEL.CurveTradeFees);
-    // Three quarters of every curve fee is the creator's, which is unusual for a
-    // launchpad and is the reason this adapter's protocol revenue is a quarter of
-    // its fees rather than all of them.
     const creatorCut = (fee * CURVE_FEE_CREATOR_BPS) / BPS;
     dailySupplySideRevenue.addGasToken(creatorCut, LABEL.TradeFeesToCreators);
     dailyProtocolRevenue.addGasToken(fee - creatorCut, LABEL.TradeFeesToProtocol);
@@ -163,13 +143,10 @@ const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
     addTrade(gross, (gross * txFeeBpsAt(log)) / BPS);
   });
 
-  // A referred trade routes part of that same fee to the referrer, paid in WETH
-  // held by the ReferralManager until claimed. It is not additional fee revenue,
-  // so it is moved out of the protocol's quarter rather than added — the docs are
-  // explicit that it never comes out of the creator's share. The reward is 9.09%
-  // of the fee (ReferralManager.directRefFeeBps), well inside that quarter, and it
-  // is emitted in the trade's own transaction, so it lands in the same window as
-  // the trade and the protocol's share cannot go negative.
+  // A referred trade routes part of the protocol's quarter to the referrer, paid
+  // in WETH by the ReferralManager. It comes out of protocol revenue rather than
+  // adding to it, since the docs are explicit it never comes out of the creator's
+  // share (ReferralManager.directRefFeeBps is 9.09% of the fee, well inside that quarter).
   const referralRewards = await options.getLogs({
     target: REFERRAL_MANAGER,
     eventAbi: REFERRAL_REWARD_EVENT,
@@ -186,17 +163,13 @@ const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
 
   if (graduations.length) {
     // At graduation a token wraps its fee share of the ETH it raised and pays it
-    // out — currently 5% to the creator (BCToken.CREATOR_FEE) and 0% to the
-    // factory owner (BCToken.PROTOCOL_FEE) — while the rest seeds the Uniswap V4
-    // pool as native ETH. Reading the WETH transfers instead of applying the
-    // configured rates keeps the split exact across per-token fee settings and
-    // across changes to them.
+    // out, currently 5% to the creator (BCToken.CREATOR_FEE) and 0% to the factory
+    // owner (BCToken.PROTOCOL_FEE), while the rest seeds the Uniswap V4 pool as
+    // native ETH. Reading the WETH transfers instead of applying the configured
+    // rates keeps the split exact across per-token fee settings and changes to them.
     //
-    // Both recipients are resolved from cumulative logs for the same
-    // pruned-RPC reason as the trade fee: the creator from the token's own
-    // CoinDeployed event, and the protocol from the factory's ownership history
-    // (Ownable emits OwnershipTransferred from its constructor, and the owner has
-    // already been rotated once).
+    // The creator comes from the token's own CoinDeployed event, and the protocol
+    // owner from the factory's ownership history, which has been rotated once.
     const [launches, ownershipChanges] = await Promise.all([
       options.getLogs({
         target: FACTORY,
@@ -218,7 +191,7 @@ const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
       creatorOf[String(log.token).toLowerCase()] = String(log.creator).toLowerCase();
     });
     // The owner has already been rotated once, so it is resolved per payout
-    // rather than taken as the latest — a graduation that predates the rotation
+    // rather than taken as the latest: a graduation that predates the rotation
     // paid the owner of the day.
     const ownerTimeline = asTimeline(ownershipChanges, (log: any) =>
       String(log.args.newOwner).toLowerCase()
@@ -261,8 +234,7 @@ const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
 
       // The contract pays exactly two fee legs here: CREATOR_FEE to the creator
       // and PROTOCOL_FEE to the factory owner. Anything else is not a known fee,
-      // so it is reported rather than guessed at — inventing a classification for
-      // an unobserved leg would be worse than surfacing it.
+      // so it is reported rather than guessed at.
       if (recipient === creatorOf[token]) {
         dailyFees.add(WETH, amount, LABEL.GraduationFees);
         dailySupplySideRevenue.add(WETH, amount, LABEL.GraduationToSupplySide);
@@ -296,7 +268,7 @@ const methodology = {
   Volume:
     "Gross ETH notional (fees included) of buys and sells executed on Frontier bonding curves, taken directly from the shared BondingCurve contract's Buy/Sell events, both of which emit the gross figure. Once a curve fills it graduates to a Uniswap V4 pool on the canonical PoolManager; those swaps are counted by the uniswap-v4 adapter on Robinhood Chain and are not double counted here.",
   Fees: "The bonding-curve trade fee charged on every buy and sell (1.5% of the trade's cost at the time of writing, rate tracked on-chain via TxFeeUpdated), plus the fees a token pays out of the ETH it raised when its curve fills and seeds its Uniswap V4 pool.",
-  UserFees: "Same as Fees — every fee is paid by traders out of their trade or out of the ETH they raised.",
+  UserFees: "Same as Fees: every fee is paid by traders out of their trade or out of the ETH they raised.",
   Revenue:
     "Protocol revenue: the protocol's 25% of the bonding-curve trade fee, net of the referrer's share on referred trades (which comes out of that 25%), plus the protocol owner's share of graduation payouts. Frontier has no protocol token, so there is no holders revenue and Revenue equals ProtocolRevenue.",
   ProtocolRevenue:
@@ -305,29 +277,26 @@ const methodology = {
     "The creator's 75% of every bonding-curve trade fee, the referrer's share on referred trades, and the graduation fee paid to the token creator (5% of the ETH its curve raised).",
 };
 
+const feesBreakdown = {
+  [LABEL.CurveTradeFees]:
+    "Trade fee withheld by the bonding curve on every buy and sell, at the on-chain txFee rate (150 bps at the time of writing). Buy.amount is fee-inclusive so the fee is txFee/(10000+txFee) of it; Sell.amountOut is pre-fee so the fee is txFee/10000 of it.",
+  [LABEL.GraduationFees]:
+    "WETH paid out of the ETH a token raised when its curve fills, to the creator (5%) and the factory owner (0% at the time of writing). The ETH that seeds the Uniswap V4 pool is liquidity, not a fee, and is excluded.",
+};
+
+const protocolRevenueBreakdown = {
+  [LABEL.TradeFeesToProtocol]:
+    "The protocol's 25% of the bonding-curve trade fee, net of the referrer's share on referred trades.",
+  [LABEL.GraduationToProtocol]: "Graduation payout sent to the factory owner.",
+};
+
 const breakdownMethodology = {
-  Fees: {
-    [LABEL.CurveTradeFees]:
-      "Trade fee withheld by the bonding curve on every buy and sell, at the on-chain txFee rate (150 bps at the time of writing). Buy.amount is fee-inclusive so the fee is txFee/(10000+txFee) of it; Sell.amountOut is pre-fee so the fee is txFee/10000 of it.",
-    [LABEL.GraduationFees]:
-      "WETH paid out of the ETH a token raised when its curve fills, to the creator (5%) and the factory owner (0% at the time of writing). The ETH that seeds the Uniswap V4 pool is liquidity, not a fee, and is excluded.",
-  },
-  UserFees: {
-    [LABEL.CurveTradeFees]:
-      "Trade fee withheld by the bonding curve on every buy and sell, at the on-chain txFee rate (150 bps at the time of writing). Buy.amount is fee-inclusive so the fee is txFee/(10000+txFee) of it; Sell.amountOut is pre-fee so the fee is txFee/10000 of it.",
-    [LABEL.GraduationFees]:
-      "WETH paid out of the ETH a token raised when its curve fills, to the creator (5%) and the factory owner (0% at the time of writing).",
-  },
-  Revenue: {
-    [LABEL.TradeFeesToProtocol]:
-      "The protocol's 25% of the bonding-curve trade fee, net of the referrer's share on referred trades.",
-    [LABEL.GraduationToProtocol]: "Graduation payout sent to the factory owner.",
-  },
-  ProtocolRevenue: {
-    [LABEL.TradeFeesToProtocol]:
-      "The protocol's 25% of the bonding-curve trade fee, net of the referrer's share on referred trades.",
-    [LABEL.GraduationToProtocol]: "Graduation payout sent to the factory owner.",
-  },
+  // dailyUserFees is dailyFees, and dailyRevenue is dailyProtocolRevenue, so those
+  // pairs share the same breakdown.
+  Fees: feesBreakdown,
+  UserFees: feesBreakdown,
+  Revenue: protocolRevenueBreakdown,
+  ProtocolRevenue: protocolRevenueBreakdown,
   SupplySideRevenue: {
     [LABEL.TradeFeesToCreators]:
       "The token creator's 75% of every bonding-curve trade fee.",

--- a/dexs/frontier-fun/index.ts
+++ b/dexs/frontier-fun/index.ts
@@ -1,0 +1,351 @@
+import { PromisePool } from "@supercharge/promise-pool";
+import { Adapter, FetchOptions, FetchResultV2 } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import ADDRESSES from "../../helpers/coreAssets.json";
+
+// Frontier (frontier.fun) — bonding-curve token launchpad on Robinhood Chain (4663).
+//
+// Every launched token trades against a single shared BondingCurve contract that
+// emits Buy/Sell for all markets, so one target covers the whole protocol. When a
+// curve fills, the token contract wraps its raised ETH, pays out the graduation
+// fees and seeds a Uniswap V4 pool (LPSeeded), after which the market trades on
+// the canonical V4 PoolManager. Those post-graduation swaps are already counted by
+// the uniswap-v4 adapter on this chain, so they are deliberately not counted here.
+// https://robinhoodchain.blockscout.com/address/0xCCa442899dFD80bf04340fa8C245C7EB02F71DD4
+const BONDING_CURVE = "0xCCa442899dFD80bf04340fa8C245C7EB02F71DD4";
+// https://robinhoodchain.blockscout.com/address/0x3cbC9395046607C083B383DC3588A3e8308dFf54
+const FACTORY = "0x3cbC9395046607C083B383DC3588A3e8308dFf54";
+// Seeds the Uniswap V4 pool at graduation. Source: BCTokenFactory.liquidityManager().
+const LIQUIDITY_MANAGER = "0x97f3578083396D4ef2042868c6aE9d4eC91007A6";
+// Takes a cut of the curve trade fee for referred trades and holds it as WETH
+// until the referrer claims. Source: BondingCurve.referralManager().
+const REFERRAL_MANAGER = "0x6Fb1160A663834e8E53E411CC7202A01F1b144DD";
+const WETH = ADDRESSES.robinhood.WETH;
+
+// keccak256("Transfer(address,address,uint256)") — the standard ERC20 topic0.
+const TRANSFER_TOPIC = "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef";
+const asTopic = (address: string) => "0x" + address.slice(2).toLowerCase().padStart(64, "0");
+
+// Both events emit the GROSS ETH notional and the trade fee is withheld from it,
+// but the two legs are denominated differently:
+//
+//   Buy.amount     is msg.value, i.e. fee-inclusive. The fee is 1.5% of the
+//                  post-fee cost, so as a share of the emitted figure it is
+//                  txFee / (10000 + txFee).
+//   Sell.amountOut is the pre-fee proceeds leaving the curve; the seller
+//                  receives amountOut - fee, and the fee is txFee / 10000 of it.
+//
+// Verified against the contract's own books: the BondingCurve retains its fees
+// on-chain and has never been swept (Withdrawn has never fired), so its ETH
+// balance is cumulative lifetime fees. Applying the two rates above to all 5,025
+// trades reproduces that balance to the wei; treating either leg as net of the
+// fee overstates it by 2.47%.
+const BUY_EVENT =
+  "event Buy(address indexed user, address indexed token, uint256 amount, uint256 amountOut, uint256 totalSupply, uint256 marketCap, uint256 price, uint256 reserveBalance)";
+const SELL_EVENT =
+  "event Sell(address indexed user, address indexed token, uint256 amount, uint256 amountOut, uint256 totalSupply, uint256 marketCap, uint256 price, uint256 reserveBalance)";
+const LP_SEEDED_EVENT = "event LPSeeded(address indexed token, address indexed pool)";
+const TRANSFER_EVENT = "event Transfer(address indexed from, address indexed to, uint256 value)";
+const TX_FEE_UPDATED_EVENT = "event TxFeeUpdated(uint256 fee)";
+const REFERRAL_REWARD_EVENT =
+  "event ReferralRewardReceived(address indexed referrer, address indexed referredUser, address indexed token, uint256 reward, bool isDirect)";
+const OWNERSHIP_TRANSFERRED_EVENT =
+  "event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)";
+const COIN_DEPLOYED_EVENT =
+  "event CoinDeployed(address indexed creator, address indexed token, address factory, address lp, string name, string symbol, string description, string image, uint256 initialSupply, uint256 maxSupply, uint256 initialETHReserves, uint256 initialPrice, uint256 initialMarketCap, uint256 targetETH)";
+
+// Block the BondingCurve and BCTokenFactory were both deployed in. The factory
+// registered this curve in the same block (BondingCurveUpdated) and has never
+// pointed at another one, so no earlier trades exist elsewhere.
+const DEPLOY_BLOCK = 23472343;
+// Trade fee the curve was constructed with. The constructor emits TxFeeUpdated,
+// so the log scan below normally supplies the rate; this is the documented
+// fallback if that scan ever comes back empty. Source: BondingCurve.txFee().
+const INITIAL_TX_FEE_BPS = 150n;
+
+// Fee rates on these contracts are basis points out of 10000.
+const BPS = 10_000n;
+// Split of the curve trade fee: 75% to the token's creator, 25% to the protocol,
+// with any referral reward carved out of the protocol's quarter rather than the
+// creator's. Documented at https://docs.frontier.fun/fees-and-revenue. The curve
+// accrues the whole fee on-chain and the split is applied when it is distributed,
+// so this is the entitlement rather than a settled transfer.
+const CURVE_FEE_CREATOR_BPS = 7_500n;
+
+const LABEL = {
+  // sources
+  CurveTradeFees: "Curve Trade Fees",
+  GraduationFees: "Graduation Fees",
+  // destinations
+  TradeFeesToProtocol: "Curve Trade Fees to Protocol",
+  TradeFeesToCreators: "Curve Trade Fees to Creators",
+  TradeFeesToReferrers: "Curve Trade Fees to Referrers",
+  GraduationToProtocol: "Graduation Fees to Protocol",
+  GraduationToSupplySide: "Graduation Fees to Creators",
+};
+
+const logIndexOf = (log: any) => Number(log.logIndex ?? log.index ?? 0);
+
+/**
+ * Cumulative governance logs as a timeline, oldest first, so a value can be
+ * resolved as of the moment a given log was emitted rather than as of the end of
+ * the window. Both the trade fee and the factory owner have changed on-chain.
+ */
+const asTimeline = (logs: any[], read: (log: any) => any) =>
+  logs
+    .map((log: any) => ({
+      block: Number(log.blockNumber),
+      index: logIndexOf(log),
+      value: read(log),
+    }))
+    .sort((a, b) => a.block - b.block || a.index - b.index);
+
+/** The timeline value in force when `log` was emitted. */
+const valueAt = (timeline: ReturnType<typeof asTimeline>, log: any, fallback: any) => {
+  const block = Number(log.blockNumber);
+  const index = logIndexOf(log);
+  let current = fallback;
+  for (const entry of timeline) {
+    if (entry.block > block || (entry.block === block && entry.index > index)) break;
+    current = entry.value;
+  }
+  return current;
+};
+
+const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
+  const dailyVolume = options.createBalances();
+  const dailyFees = options.createBalances();
+  const dailyProtocolRevenue = options.createBalances();
+  const dailySupplySideRevenue = options.createBalances();
+
+  // The trade fee is governed on-chain, so it is tracked through its own event
+  // rather than hardcoded. It is read from logs rather than an eth_call because
+  // Robinhood Chain's public RPC prunes state and rejects historical calls, which
+  // would break every backfill.
+  const [buyLogs, sellLogs, graduations, feeChanges] = await Promise.all([
+    options.getLogs({ target: BONDING_CURVE, eventAbi: BUY_EVENT, onlyArgs: false }),
+    options.getLogs({ target: BONDING_CURVE, eventAbi: SELL_EVENT, onlyArgs: false }),
+    options.getLogs({ target: BONDING_CURVE, eventAbi: LP_SEEDED_EVENT }),
+    options.getLogs({
+      target: BONDING_CURVE,
+      eventAbi: TX_FEE_UPDATED_EVENT,
+      fromBlock: DEPLOY_BLOCK,
+      cacheInCloud: true,
+      onlyArgs: false,
+    }),
+  ]);
+
+  // Rate history, oldest first, so each trade is priced with the rate actually in
+  // force when it executed rather than the one in force at the end of the window.
+  const feeTimeline = asTimeline(feeChanges, (log: any) => BigInt(log.args.fee));
+  const txFeeBpsAt = (log: any) => valueAt(feeTimeline, log, INITIAL_TX_FEE_BPS);
+
+  // Both legs emit gross notional, so volume is the emitted figure as-is; only
+  // the fee's share of it differs between them (see the event comments above).
+  const addTrade = (gross: bigint, fee: bigint) => {
+    dailyVolume.addGasToken(gross);
+    dailyFees.addGasToken(fee, LABEL.CurveTradeFees);
+    // Three quarters of every curve fee is the creator's, which is unusual for a
+    // launchpad and is the reason this adapter's protocol revenue is a quarter of
+    // its fees rather than all of them.
+    const creatorCut = (fee * CURVE_FEE_CREATOR_BPS) / BPS;
+    dailySupplySideRevenue.addGasToken(creatorCut, LABEL.TradeFeesToCreators);
+    dailyProtocolRevenue.addGasToken(fee - creatorCut, LABEL.TradeFeesToProtocol);
+  };
+
+  buyLogs.forEach((log: any) => {
+    const gross = BigInt(log.args.amount);
+    const txFeeBps = txFeeBpsAt(log);
+    addTrade(gross, (gross * txFeeBps) / (BPS + txFeeBps));
+  });
+  sellLogs.forEach((log: any) => {
+    const gross = BigInt(log.args.amountOut);
+    addTrade(gross, (gross * txFeeBpsAt(log)) / BPS);
+  });
+
+  // A referred trade routes part of that same fee to the referrer, paid in WETH
+  // held by the ReferralManager until claimed. It is not additional fee revenue,
+  // so it is moved out of the protocol's quarter rather than added — the docs are
+  // explicit that it never comes out of the creator's share. The reward is 9.09%
+  // of the fee (ReferralManager.directRefFeeBps), well inside that quarter, and it
+  // is emitted in the trade's own transaction, so it lands in the same window as
+  // the trade and the protocol's share cannot go negative.
+  const referralRewards = await options.getLogs({
+    target: REFERRAL_MANAGER,
+    eventAbi: REFERRAL_REWARD_EVENT,
+  });
+  referralRewards.forEach((log: any) => {
+    const reward = BigInt(log.reward);
+    if (reward === 0n) return;
+    // Denominations follow the money: the protocol's share accrued to the curve
+    // as native ETH, and the referrer's slice left it wrapped, so the referrer is
+    // credited in WETH rather than the gas token.
+    dailyProtocolRevenue.addGasToken(-reward, LABEL.TradeFeesToProtocol);
+    dailySupplySideRevenue.add(WETH, reward, LABEL.TradeFeesToReferrers);
+  });
+
+  if (graduations.length) {
+    // At graduation a token wraps its fee share of the ETH it raised and pays it
+    // out — currently 5% to the creator (BCToken.CREATOR_FEE) and 0% to the
+    // factory owner (BCToken.PROTOCOL_FEE) — while the rest seeds the Uniswap V4
+    // pool as native ETH. Reading the WETH transfers instead of applying the
+    // configured rates keeps the split exact across per-token fee settings and
+    // across changes to them.
+    //
+    // Both recipients are resolved from cumulative logs for the same
+    // pruned-RPC reason as the trade fee: the creator from the token's own
+    // CoinDeployed event, and the protocol from the factory's ownership history
+    // (Ownable emits OwnershipTransferred from its constructor, and the owner has
+    // already been rotated once).
+    const [launches, ownershipChanges] = await Promise.all([
+      options.getLogs({
+        target: FACTORY,
+        eventAbi: COIN_DEPLOYED_EVENT,
+        fromBlock: DEPLOY_BLOCK,
+        cacheInCloud: true,
+      }),
+      options.getLogs({
+        target: FACTORY,
+        eventAbi: OWNERSHIP_TRANSFERRED_EVENT,
+        fromBlock: DEPLOY_BLOCK,
+        cacheInCloud: true,
+        onlyArgs: false,
+      }),
+    ]);
+
+    const creatorOf: Record<string, string> = {};
+    launches.forEach((log: any) => {
+      creatorOf[String(log.token).toLowerCase()] = String(log.creator).toLowerCase();
+    });
+    // The owner has already been rotated once, so it is resolved per payout
+    // rather than taken as the latest — a graduation that predates the rotation
+    // paid the owner of the day.
+    const ownerTimeline = asTimeline(ownershipChanges, (log: any) =>
+      String(log.args.newOwner).toLowerCase()
+    );
+
+    // One getLogs per graduation, bounded so a backfill day with many
+    // graduations cannot flood the RPC endpoint.
+    const { results: payoutLegs, errors: payoutErrors } = await PromisePool.withConcurrency(5)
+      .for(graduations)
+      .process(async (log: any) => {
+        const transfers = await options.getLogs({
+          target: WETH,
+          eventAbi: TRANSFER_EVENT,
+          topics: [TRANSFER_TOPIC, asTopic(log.token)],
+          onlyArgs: false,
+        });
+        return transfers.map((transfer: any) => ({
+          transfer,
+          token: String(log.token).toLowerCase(),
+        }));
+      });
+
+    // PromisePool collects rejections instead of rethrowing them. Swallowing one
+    // would silently drop a graduation's fees and understate the day, so fail the
+    // run rather than report a partial figure.
+    if (payoutErrors.length) {
+      throw new Error(
+        `[frontier-fun] ${payoutErrors.length} of ${graduations.length} graduation payout queries failed: ${payoutErrors[0].message}`
+      );
+    }
+
+    payoutLegs.flat().forEach(({ transfer, token }: any) => {
+      const recipient = String(transfer.args.to).toLowerCase();
+      // Guard for a WETH-paired pool: today's markets seed with native ETH, so
+      // no WETH ever reaches the LiquidityManager, but a WETH leg would be
+      // liquidity rather than a fee.
+      if (recipient === LIQUIDITY_MANAGER.toLowerCase()) return;
+      const amount = BigInt(transfer.args.value);
+      if (amount === 0n) return;
+
+      // The contract pays exactly two fee legs here: CREATOR_FEE to the creator
+      // and PROTOCOL_FEE to the factory owner. Anything else is not a known fee,
+      // so it is reported rather than guessed at — inventing a classification for
+      // an unobserved leg would be worse than surfacing it.
+      if (recipient === creatorOf[token]) {
+        dailyFees.add(WETH, amount, LABEL.GraduationFees);
+        dailySupplySideRevenue.add(WETH, amount, LABEL.GraduationToSupplySide);
+      } else if (recipient === valueAt(ownerTimeline, transfer, "")) {
+        dailyFees.add(WETH, amount, LABEL.GraduationFees);
+        dailyProtocolRevenue.add(WETH, amount, LABEL.GraduationToProtocol);
+      } else {
+        console.error(
+          `[frontier-fun] unclassified graduation payout from ${token} to ${recipient}, not counted`
+        );
+      }
+    });
+  }
+
+  // Frontier has no protocol token, so there are no holders revenue and
+  // Revenue == ProtocolRevenue == Fees - SupplySideRevenue. Cloned so the two
+  // returned dimensions do not alias the same Balances instance.
+  const dailyRevenue = dailyProtocolRevenue.clone();
+
+  return {
+    dailyVolume,
+    dailyFees,
+    dailyUserFees: dailyFees,
+    dailyRevenue,
+    dailyProtocolRevenue,
+    dailySupplySideRevenue,
+  };
+};
+
+const methodology = {
+  Volume:
+    "Gross ETH notional (fees included) of buys and sells executed on Frontier bonding curves, taken directly from the shared BondingCurve contract's Buy/Sell events, both of which emit the gross figure. Once a curve fills it graduates to a Uniswap V4 pool on the canonical PoolManager; those swaps are counted by the uniswap-v4 adapter on Robinhood Chain and are not double counted here.",
+  Fees: "The bonding-curve trade fee charged on every buy and sell (1.5% of the trade's cost at the time of writing, rate tracked on-chain via TxFeeUpdated), plus the fees a token pays out of the ETH it raised when its curve fills and seeds its Uniswap V4 pool.",
+  UserFees: "Same as Fees — every fee is paid by traders out of their trade or out of the ETH they raised.",
+  Revenue:
+    "Protocol revenue: the protocol's 25% of the bonding-curve trade fee, net of the referrer's share on referred trades (which comes out of that 25%), plus the protocol owner's share of graduation payouts. Frontier has no protocol token, so there is no holders revenue and Revenue equals ProtocolRevenue.",
+  ProtocolRevenue:
+    "The protocol's 25% of the bonding-curve trade fee, net of referrer rewards, plus WETH sent to the factory owner at graduation.",
+  SupplySideRevenue:
+    "The creator's 75% of every bonding-curve trade fee, the referrer's share on referred trades, and the graduation fee paid to the token creator (5% of the ETH its curve raised).",
+};
+
+const breakdownMethodology = {
+  Fees: {
+    [LABEL.CurveTradeFees]:
+      "Trade fee withheld by the bonding curve on every buy and sell, at the on-chain txFee rate (150 bps at the time of writing). Buy.amount is fee-inclusive so the fee is txFee/(10000+txFee) of it; Sell.amountOut is pre-fee so the fee is txFee/10000 of it.",
+    [LABEL.GraduationFees]:
+      "WETH paid out of the ETH a token raised when its curve fills, to the creator (5%) and the factory owner (0% at the time of writing). The ETH that seeds the Uniswap V4 pool is liquidity, not a fee, and is excluded.",
+  },
+  UserFees: {
+    [LABEL.CurveTradeFees]:
+      "Trade fee withheld by the bonding curve on every buy and sell, at the on-chain txFee rate (150 bps at the time of writing). Buy.amount is fee-inclusive so the fee is txFee/(10000+txFee) of it; Sell.amountOut is pre-fee so the fee is txFee/10000 of it.",
+    [LABEL.GraduationFees]:
+      "WETH paid out of the ETH a token raised when its curve fills, to the creator (5%) and the factory owner (0% at the time of writing).",
+  },
+  Revenue: {
+    [LABEL.TradeFeesToProtocol]:
+      "The protocol's 25% of the bonding-curve trade fee, net of the referrer's share on referred trades.",
+    [LABEL.GraduationToProtocol]: "Graduation payout sent to the factory owner.",
+  },
+  ProtocolRevenue: {
+    [LABEL.TradeFeesToProtocol]:
+      "The protocol's 25% of the bonding-curve trade fee, net of the referrer's share on referred trades.",
+    [LABEL.GraduationToProtocol]: "Graduation payout sent to the factory owner.",
+  },
+  SupplySideRevenue: {
+    [LABEL.TradeFeesToCreators]:
+      "The token creator's 75% of every bonding-curve trade fee.",
+    [LABEL.TradeFeesToReferrers]:
+      "The referrer's share of the curve trade fee on a referred trade, held as WETH by the ReferralManager until claimed.",
+    [LABEL.GraduationToSupplySide]:
+      "The graduation fee paid to the token creator, 5% of the ETH its curve raised.",
+  },
+};
+
+const adapter: Adapter = {
+  version: 2,
+  pullHourly: true,
+  fetch,
+  chains: [CHAIN.ROBINHOOD],
+  start: "2026-07-30", // first CoinDeployed event, block 23650298
+  methodology,
+  breakdownMethodology,
+};
+
+export default adapter;


### PR DESCRIPTION
Adds volume / fees / revenue (`dexs/frontier-fun`) and active users (`active-users/frontier-fun`) for **Frontier**, a bonding-curve token launchpad on Robinhood Chain (4663).

##### Name (to be shown on DefiLlama):
Frontier

##### Twitter Link:
https://x.com/frontierhood

##### List of audit links if any:
None — the protocol has not been audited.

##### Website Link:
https://frontier.fun

##### Logo (High resolution, will be shown with rounded borders):
https://frontier.fun/favicon.svg

##### Current TVL:
~$3.4k — TVL adapter submitted separately as DefiLlama/DefiLlama-Adapters#20410

##### Treasury Addresses (if the protocol has treasury)
`0x97FcE327df892E77A0B1E64c2e59902505a842bB` (Safe, Robinhood Chain)

##### Chain:
Robinhood

##### Coingecko ID:
n/a — no protocol token

##### Coinmarketcap ID:
n/a — no protocol token

##### Short Description (to be shown on DefiLlama):
Bonding-curve token launchpad on Robinhood Chain. Tokens trade on a shared bonding curve until it fills, then graduate to a Uniswap V4 pool.

##### Token address and ticker if any:
None — Frontier has no protocol token.

##### Category:
Launchpad

##### Oracle Provider(s):
None — the adapter uses no oracle. All figures come from event logs.

##### Implementation Details:
n/a

##### Documentation/Proof:
https://docs.frontier.fun

##### forkedFrom:
n/a — original.

##### Github org/user:
n/a

##### Does this project have a referral program?
Yes — an off-chain points/referral rewards program. It is not a trade-time fee split, so it does not affect the fee accounting in this adapter.

---

### Methodology

Contracts (Robinhood Chain, both deployed in block 23472343):

| | |
|---|---|
| BCTokenFactory | `0x3cbC9395046607C083B383DC3588A3e8308dFf54` |
| BondingCurve | `0xCCa442899dFD80bf04340fa8C245C7EB02F71DD4` |

Every launched token trades against the one shared `BondingCurve`, so a single target covers the whole protocol.

- **Volume** — gross ETH notional of curve `Buy`/`Sell`, taken directly from the events, both of which emit the gross figure.
- **Fees** — the curve trade fee (150 bps today), plus the WETH a token pays out of the ETH it raised when its curve fills. The fee is withheld from the gross, at a different share per leg: `Buy.amount` is `msg.value` and therefore fee-inclusive, so the fee is `amount * txFee / (10000 + txFee)`; `Sell.amountOut` is the pre-fee proceeds, so the fee is `amountOut * txFee / 10000`.
- **Revenue / ProtocolRevenue** — the protocol's **25%** of the curve trade fee, net of the referrer's reward on referred trades (which comes out of that 25%, never the creator's share), plus any graduation leg to the factory owner (`PROTOCOL_FEE` is 0 today). No protocol token, so no holders revenue.
- **SupplySideRevenue** — the creator's **75%** of every curve trade fee, the referrer's reward, and the graduation fee to the token creator (`CREATOR_FEE`, 5% of the raise). The 75/25 split is documented at https://docs.frontier.fun/fees-and-revenue; the referral reward is 9.09% of the fee (`ReferralManager.directRefFeeBps = 909`) and is taken from the emitted `ReferralRewardReceived` amount rather than a rate.
- **dailyActiveUsers / dailyTransactionsCount** — unique addresses that traded on a curve or launched a token, and the transactions involved.

### Two notes for the reviewer

**1. Post-graduation swaps are deliberately excluded, to avoid double counting.** When a curve fills, the market graduates to a pool on the canonical Uniswap V4 PoolManager (`0x8366a39CC670B4001A1121B8F6A443A643e40951`), which `dexs/uniswap-v4.ts` already indexes on this chain for both volume and fees. Those swaps are therefore not counted here, matching the precedent set by `dexs/rhfun.ts` on the same chain. That is roughly half of Frontier's lifetime ETH notional, so this adapter reports the smaller, non-duplicated figure by design.

**2. No historical `eth_call`.** The trade fee, the per-token creator and the factory owner are all resolved from cumulative logs (`TxFeeUpdated`, `CoinDeployed`, `OwnershipTransferred`) rather than contract calls. Robinhood Chain's public RPC — the only one in `@defillama/sdk`'s `providers.json` for this chain — prunes state and returns `metadata is not found` for historical calls, which would break every backfill. All three values are governed and have changed or can change, so they are tracked rather than hardcoded.

### Validation

```
pnpm test dexs frontier-fun               # latest day
pnpm test dexs frontier-fun 2026-08-01    # 2026-07-31, the one graduation to date
pnpm test active-users frontier-fun       # active-users is not covered by CI, tested by hand
pnpm run ts-check && pnpm run ts-check-cli
```

2026-07-31, the day the first curve graduated:

```
Daily volume: 19.76 k
Daily fees: 708.54
Daily revenue: 73.13
Daily protocol revenue: 73.13
Daily supply side revenue: 636.40

label                        | Daily fees | Daily supply side revenue | Daily revenue
Curve Trade Fees             | 292.54     |                           |
Graduation Fees              | 416        |                           |
Curve Trade Fees to Creators |            | 219.40                    |
Graduation Fees to Creators  |            | 416                       |
Curve Trade Fees to Protocol |            |                           | 73.13
```

2026-08-02, a day containing referred trades:

```
Daily fees: 16.96
Daily revenue: 4.24
Daily supply side revenue: 12.73

label                         | Daily fees | Daily supply side revenue | Daily revenue
Curve Trade Fees              | 16.96      |                           |
Curve Trade Fees to Creators  |            | 12.72                     |
Curve Trade Fees to Referrers |            | 0.0054                    |
Curve Trade Fees to Protocol  |            |                           | 4.24
```

Active users: 20 daily active users, 753 transactions.

**Independent check on the fee math.** The `BondingCurve` retains its fees on-chain and has never been swept (`Withdrawn` has never fired), so its ETH balance is cumulative lifetime fees — which makes the per-leg fee shares checkable rather than assumed.

Summing all 5,025 curve trades from logs gives 16.771 ETH of buy notional and 10.105 ETH of sell notional. Applying the two rates above yields 416,256,126,047,887,982 wei of lifetime fees. The curve holds 416,234,626,547,934,408 wei and the ReferralManager holds 21,499,499,953,612 wei of WETH — together 38 wei off the computed total, which is integer truncation across 5,025 trades. Per-trade balance deltas match to the wei on both legs.

Treating either leg as *net* of the fee instead — i.e. grossing up by `10000/(10000 - txFee)` — overstates lifetime fees by 2.47% and volume by 1.52%, which is how the per-leg denominators above were pinned down.
