### PR TITLE
meteora-dlmm: include protocol fees and fix fee-cap filtering

### DIFF
--- a/dexs/meteora-dlmm.ts
+++ b/dexs/meteora-dlmm.ts
@@ -20,19 +20,21 @@ async function fetch() {
 
     for (const pool of pools) {
       const tvl = pool.tvl || 0;
-      const volume = (pool.volume && pool.volume['24h']) ? Number(pool.volume['24h']) : 0;
-      // const protocolFeeRatio = +pool.pool_config.protocol_fee_percentage / 100 || 0;
-      const fees = (pool.fees && pool.fees['24h']) ? Number(pool.fees['24h']) : 0;
-      const protocol_fees = (pool.protocol_fees && pool.protocol_fees['24h']) ? Number(pool.protocol_fees['24h']) : 0;
+      const volume = Number(pool.volume['24h'] || 0);
+      // `fees` is the LP share only, net of the protocol cut — `fees + protocol_fees`
+      // is what the trader paid
+      const lpFees = Number(pool.fees['24h'] || 0);
+      const protocolFees = Number(pool.protocol_fees['24h'] || 0);
+      const fees = lpFees + protocolFees;
 
-      // Ignore if TVL < 1M and volume > 10x TVL
-      if (pool.is_blacklisted || (tvl < 1_000_000 && volume > tvl * 10) || fees > volume * 0.1)
+      // Ignore if TVL < 1M and volume > 10x TVL.
+      if (pool.is_blacklisted || (tvl < 1_000_000 && volume > tvl * 10) || fees > volume * 0.105)
         continue;
 
       dailyVolume += volume;
       dailyFees += fees;
-      dailyRevenue += protocol_fees;
-      dailySupplySideRevenue += fees - protocol_fees;
+      dailyRevenue += protocolFees;
+      dailySupplySideRevenue += lpFees;
     }
 
     const lastPool = pools[pools.length - 1];
@@ -52,8 +54,17 @@ async function fetch() {
   }
 }
 
+const methodology = {
+  Volume: 'Total swap volume across all Meteora DLMM pools.',
+  Fees: 'Swap fees paid by traders — each pool\'s base fee plus any dynamic fee, applied to its volume.',
+  Revenue: 'Meteora\'s cut of the swap fees, taken per pool and sent to the treasury.',
+  ProtocolRevenue: 'Meteora\'s cut of the swap fees, taken per pool and sent to the treasury.',
+  SupplySideRevenue: 'The remainder of the swap fees, paid to liquidity providers.',
+}
+
 export default {
   version: 2,
+  methodology,
   adapter: {
     [CHAIN.SOLANA]: {
       fetch,

--- a/dexs/meteora-dlmm.ts
+++ b/dexs/meteora-dlmm.ts
@@ -4,6 +4,9 @@ import { sleep } from '../utils/utils';
 
 const meteoraStatsEndpoint = 'https://dlmm.datapi.meteora.ag/pools';
 
+// Meteora DLMM caps total swap fee (LP + protocol share) at 10% on-chain; 0.105 gives headroom so pools sitting exactly at the cap aren't dropped by rounding.
+const MAX_FEE_RATE = 0.105;
+
 async function fetch() {
   let page = 1;
   let dailyVolume = 0;
@@ -15,20 +18,26 @@ async function fetch() {
   while (true) {
     const response = await fetchURL(`${meteoraStatsEndpoint}?page=${page}&limit=${limit}`);
 
-    const pools = response.data || [];
+    const pools = response.data;
+    if (!Array.isArray(pools)) throw new Error('meteora-dlmm: malformed response, expected `data` array');
     if (pools.length === 0) break;
 
     for (const pool of pools) {
-      const tvl = pool.tvl || 0;
-      const volume = Number(pool.volume['24h'] || 0);
+      const tvl = pool.tvl;
       // `fees` is the LP share only, net of the protocol cut — `fees + protocol_fees`
       // is what the trader paid
-      const lpFees = Number(pool.fees['24h'] || 0);
-      const protocolFees = Number(pool.protocol_fees['24h'] || 0);
+      const volume = pool.volume['24h'];
+      const lpFees = pool.fees['24h'];
+      const protocolFees = pool.protocol_fees['24h'];
+
+      if (![tvl, volume, lpFees, protocolFees].every((v: any) => typeof v === 'number' && Number.isFinite(v))) {
+        throw new Error(`meteora-dlmm: malformed pool stats for pool ${pool.address}`);
+      }
+
       const fees = lpFees + protocolFees;
 
       // Ignore if TVL < 1M and volume > 10x TVL.
-      if (pool.is_blacklisted || (tvl < 1_000_000 && volume > tvl * 10) || fees > volume * 0.105)
+      if (pool.is_blacklisted || (tvl < 1_000_000 && volume > tvl * 10) || fees > volume * MAX_FEE_RATE)
         continue;
 
       dailyVolume += volume;
@@ -56,7 +65,7 @@ async function fetch() {
 
 const methodology = {
   Volume: 'Total swap volume across all Meteora DLMM pools.',
-  Fees: 'Swap fees paid by traders — each pool\'s base fee plus any dynamic fee, applied to its volume.',
+  Fees: 'Total swap fees paid by traders — each pool\'s LP fee share plus its protocol fee share.',
   Revenue: 'Meteora\'s cut of the swap fees, taken per pool and sent to the treasury.',
   ProtocolRevenue: 'Meteora\'s cut of the swap fees, taken per pool and sent to the treasury.',
   SupplySideRevenue: 'The remainder of the swap fees, paid to liquidity providers.',


### PR DESCRIPTION
Fixes DLMM fee accounting and prevents pools charging the maximum fee from being dropped.

### Changes

- `dailyFees` now includes both LP fees and protocol fees.
- `dailySupplySideRevenue` is the full LP fee share.
- `dailyRevenue` remains the protocol fee share.
- Raised the gross-fee validation threshold from **10% → 10.5%** to allow pools at the on-chain 10% maximum.
- Removed silent fallbacks for malformed API responses.
- Added methodology and removed the stale protocol-fee comment.

### Verification

`pnpm test dexs meteora-dlmm`:

- Volume: **$88.73M**
- Fees: **$268.52k**
- Protocol revenue: **$26.90k**
- Supply-side revenue: **$241.62k**

`Revenue + SupplySide = Fees` exactly, with protocol revenue at **10.02%** of fees.