### PR TITLE
sablier: fix stream volume accounting, start dates, and query batching

### DIFF
--- a/dexs/sablier-flow.ts
+++ b/dexs/sablier-flow.ts
@@ -3,16 +3,12 @@ import { CHAIN } from "../helpers/chains";
 import { postURL } from "../utils/fetchURL";
 
 // Sablier Flow: rate-based recurring payment streams (payroll, grants,
-// subscriptions). Funded by deposits and topups. Volume is the value paid out to
-// recipients on chain: `amountA` on Withdraw actions only.
+// subscriptions). Volume is value paid out to recipients: `amountA` on
+// Withdraw actions.
 //
-// Void and Refund are deliberately excluded and must stay excluded. `_void`
-// moves no tokens at all -- its `amountB` is `writtenOffDebt`, i.e. debt the
-// sender never funded and now never will, which accrues unbounded on an
-// unfunded stream. Refund returns uncommitted deposits to the sender. Data
-// comes from Sablier's public Envio HyperIndex; per-chain queries filter by
-// chainId. Daily figures are lumpy (claim timing) but cumulative equals true
-// streamed value.
+// Void and Refund are excluded and must stay excluded. `_void` moves no tokens;
+// its `amountB` is written-off debt the sender never funded, unbounded on an
+// unfunded stream. Refund returns uncommitted deposits to the sender.
 
 const INDEXER = "https://indexer.hyperindex.xyz/53b7e25/v1/graphql";
 const PAGE_SIZE = 1000;
@@ -46,9 +42,7 @@ interface Row {
   stream: { asset_id: string } | null;
 }
 
-// One query serves every chain in the window and the in-flight promise is
-// shared, so a run costs one paginated pass rather than one per chain. The
-// indexer rate-limits bursts, and the per-chain shape tripped it.
+// One shared query per window, not one per chain -- the indexer rate-limits bursts.
 const CHAIN_IDS = Object.values(CONFIG).map(({ chainId }) => chainId);
 
 const buildQuery = (from: number, to: number, cursor: string) => `{
@@ -69,26 +63,29 @@ const buildQuery = (from: number, to: number, cursor: string) => `{
   }
 }`;
 
-const inFlight: Record<string, Promise<Row[]>> = {};
+const fetchWindow = async (from: number, to: number) => {
+  const all: Row[] = [];
+  let cursor = "";
+  while (true) {
+    const res: { data: { FlowAction: Row[] } } = await postURL(INDEXER, {
+      query: buildQuery(from, to, cursor),
+    });
+    const rows = res.data.FlowAction;
+    all.push(...rows);
+    if (rows.length < PAGE_SIZE) break;
+    cursor = rows[rows.length - 1].id;
+  }
+  return all;
+};
+
+// Hold only the active window: keeping all of them grows unbounded on backfills,
+// and dropping on settle refetches per chain when chains run sequentially.
+let cached: { key: string; rows: Promise<Row[]> } | undefined;
 
 const getWindow = (from: number, to: number) => {
   const key = `${from}-${to}`;
-  if (!inFlight[key])
-    inFlight[key] = (async () => {
-      const all: Row[] = [];
-      let cursor = "";
-      while (true) {
-        const res: { data: { FlowAction: Row[] } } = await postURL(INDEXER, {
-          query: buildQuery(from, to, cursor),
-        });
-        const rows = res.data.FlowAction;
-        all.push(...rows);
-        if (rows.length < PAGE_SIZE) break;
-        cursor = rows[rows.length - 1].id;
-      }
-      return all;
-    })();
-  return inFlight[key];
+  if (cached?.key !== key) cached = { key, rows: fetchWindow(from, to) };
+  return cached.rows;
 };
 
 const fetch = async (options: FetchOptions) => {

--- a/dexs/sablier-flow.ts
+++ b/dexs/sablier-flow.ts
@@ -4,13 +4,15 @@ import { postURL } from "../utils/fetchURL";
 
 // Sablier Flow: rate-based recurring payment streams (payroll, grants,
 // subscriptions). Funded by deposits and topups. Volume is the value paid out to
-// recipients on chain. We sum two action categories: Withdraw (recipient pulls
-// accrued funds, recorded in `amountA` for Flow's single-party shape) and Void
-// (auto-settles the accrued-but-unwithdrawn portion to the recipient on stream
-// termination, recorded in `amountB` for the two-party shape). Refund is the
-// sender pulling back uncommitted deposits and is excluded. Data comes from
-// Sablier's public Envio HyperIndex; per-chain queries filter by chainId. Daily
-// figures are lumpy (claim/void timing) but cumulative equals true streamed value.
+// recipients on chain: `amountA` on Withdraw actions only.
+//
+// Void and Refund are deliberately excluded and must stay excluded. `_void`
+// moves no tokens at all -- its `amountB` is `writtenOffDebt`, i.e. debt the
+// sender never funded and now never will, which accrues unbounded on an
+// unfunded stream. Refund returns uncommitted deposits to the sender. Data
+// comes from Sablier's public Envio HyperIndex; per-chain queries filter by
+// chainId. Daily figures are lumpy (claim timing) but cumulative equals true
+// streamed value.
 
 const INDEXER = "https://indexer.hyperindex.xyz/53b7e25/v1/graphql";
 const PAGE_SIZE = 1000;
@@ -39,17 +41,21 @@ const CONFIG: Record<string, { chainId: number; start: string }> = {
 
 interface Row {
   id: string;
-  category: "Withdraw" | "Void";
+  chainId: string;
   amountA: string | null;
-  amountB: string | null;
   stream: { asset_id: string } | null;
 }
 
-const buildQuery = (chainId: number, from: number, to: number, cursor: string) => `{
+// One query serves every chain in the window and the in-flight promise is
+// shared, so a run costs one paginated pass rather than one per chain. The
+// indexer rate-limits bursts, and the per-chain shape tripped it.
+const CHAIN_IDS = Object.values(CONFIG).map(({ chainId }) => chainId);
+
+const buildQuery = (from: number, to: number, cursor: string) => `{
   FlowAction(
     where: {
-      category: {_in: [Withdraw, Void]}
-      chainId: {_eq: ${chainId}}
+      category: {_eq: Withdraw}
+      chainId: {_in: [${CHAIN_IDS.join(", ")}]}
       timestamp: {_gte: "${from}", _lt: "${to}"}
       id: {_gt: "${cursor}"}
     }
@@ -57,32 +63,46 @@ const buildQuery = (chainId: number, from: number, to: number, cursor: string) =
     limit: ${PAGE_SIZE}
   ) {
     id
-    category
+    chainId
     amountA
-    amountB
     stream { asset_id }
   }
 }`;
 
+const inFlight: Record<string, Promise<Row[]>> = {};
+
+const getWindow = (from: number, to: number) => {
+  const key = `${from}-${to}`;
+  if (!inFlight[key])
+    inFlight[key] = (async () => {
+      const all: Row[] = [];
+      let cursor = "";
+      while (true) {
+        const res: { data: { FlowAction: Row[] } } = await postURL(INDEXER, {
+          query: buildQuery(from, to, cursor),
+        });
+        const rows = res.data.FlowAction;
+        all.push(...rows);
+        if (rows.length < PAGE_SIZE) break;
+        cursor = rows[rows.length - 1].id;
+      }
+      return all;
+    })();
+  return inFlight[key];
+};
+
 const fetch = async (options: FetchOptions) => {
   const dailyVolume = options.createBalances();
-  const cfg = CONFIG[options.chain];
-  let cursor = "";
-  while (true) {
-    const query = buildQuery(cfg.chainId, options.fromTimestamp, options.toTimestamp, cursor);
-    const res: { data: { FlowAction: Row[] } } = await postURL(INDEXER, { query });
-    const rows = res.data.FlowAction;
-    if (!rows.length) break;
-    for (const r of rows) {
-      const amount = r.amountA;
-      if (!amount || amount === "0" || !r.stream?.asset_id || r.category !== "Withdraw") continue;
-      // asset_id format: `asset-<chainId>-<tokenAddress>`; take the address suffix.
-      const parts = r.stream.asset_id.split("-");
-      const token = parts[parts.length - 1];
-      dailyVolume.add(token, amount);
-    }
-    if (rows.length < PAGE_SIZE) break;
-    cursor = rows[rows.length - 1].id;
+  const { chainId } = CONFIG[options.chain];
+  const rows = await getWindow(options.fromTimestamp, options.toTimestamp);
+  for (const r of rows) {
+    if (Number(r.chainId) !== chainId) continue;
+    const amount = r.amountA;
+    if (!amount || amount === "0" || !r.stream?.asset_id) continue;
+    // asset_id format: `asset-<chainId>-<tokenAddress>`; take the address suffix.
+    const parts = r.stream.asset_id.split("-");
+    const token = parts[parts.length - 1];
+    dailyVolume.add(token, amount);
   }
   return { dailyVolume };
 };

--- a/dexs/sablier-lockup.ts
+++ b/dexs/sablier-lockup.ts
@@ -2,18 +2,12 @@ import type { FetchOptions, SimpleAdapter } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
 import { postURL } from "../utils/fetchURL";
 
-// Sablier Lockup: pre-funded token streams with optional cliff, used predominantly
-// for project-token vesting (team / investor / airdrop allocations). Volume is the
-// value paid out to recipients on chain: `amountB` on Withdraw actions only.
+// Sablier Lockup: pre-funded token streams, mostly project-token vesting.
+// Volume is value paid out to recipients: `amountB` on Withdraw actions.
 //
-// Cancel is deliberately excluded. `_cancel` transfers only the unstreamed
-// remainder back to the sender; the recipient's accrued balance stays in the
-// contract (the indexer calls it `intactAmount`) until they withdraw it, which
-// emits its own Withdraw action. Counting Cancel too would book that balance
-// twice. Data comes from Sablier's public Envio HyperIndex; per-chain queries
-// filter by chainId. Streams are pre-funded at creation so every settlement is
-// funded value. Daily figures are lumpy (claim timing) but cumulative equals
-// true streamed value over time.
+// Cancel is excluded: `_cancel` refunds only the unstreamed remainder to the
+// sender. The recipient's accrued balance stays in the contract until they
+// withdraw it, which emits its own Withdraw -- counting Cancel double-books it.
 
 const INDEXER = "https://indexer.hyperindex.xyz/53b7e25/v1/graphql";
 const PAGE_SIZE = 1000;
@@ -54,9 +48,7 @@ interface Row {
   stream: { asset_id: string } | null;
 }
 
-// One query serves every chain in the window and the in-flight promise is
-// shared, so a run costs one paginated pass rather than one per chain. The
-// indexer rate-limits bursts, and the per-chain shape tripped it.
+// One shared query per window, not one per chain -- the indexer rate-limits bursts.
 const CHAIN_IDS = Object.values(CONFIG).map(({ chainId }) => chainId);
 
 const buildQuery = (from: number, to: number, cursor: string) => `{
@@ -77,26 +69,29 @@ const buildQuery = (from: number, to: number, cursor: string) => `{
   }
 }`;
 
-const inFlight: Record<string, Promise<Row[]>> = {};
+const fetchWindow = async (from: number, to: number) => {
+  const all: Row[] = [];
+  let cursor = "";
+  while (true) {
+    const res: { data: { LockupAction: Row[] } } = await postURL(INDEXER, {
+      query: buildQuery(from, to, cursor),
+    });
+    const rows = res.data.LockupAction;
+    all.push(...rows);
+    if (rows.length < PAGE_SIZE) break;
+    cursor = rows[rows.length - 1].id;
+  }
+  return all;
+};
+
+// Hold only the active window: keeping all of them grows unbounded on backfills,
+// and dropping on settle refetches per chain when chains run sequentially.
+let cached: { key: string; rows: Promise<Row[]> } | undefined;
 
 const getWindow = (from: number, to: number) => {
   const key = `${from}-${to}`;
-  if (!inFlight[key])
-    inFlight[key] = (async () => {
-      const all: Row[] = [];
-      let cursor = "";
-      while (true) {
-        const res: { data: { LockupAction: Row[] } } = await postURL(INDEXER, {
-          query: buildQuery(from, to, cursor),
-        });
-        const rows = res.data.LockupAction;
-        all.push(...rows);
-        if (rows.length < PAGE_SIZE) break;
-        cursor = rows[rows.length - 1].id;
-      }
-      return all;
-    })();
-  return inFlight[key];
+  if (cached?.key !== key) cached = { key, rows: fetchWindow(from, to) };
+  return cached.rows;
 };
 
 const fetch = async (options: FetchOptions) => {

--- a/dexs/sablier-lockup.ts
+++ b/dexs/sablier-lockup.ts
@@ -4,13 +4,16 @@ import { postURL } from "../utils/fetchURL";
 
 // Sablier Lockup: pre-funded token streams with optional cliff, used predominantly
 // for project-token vesting (team / investor / airdrop allocations). Volume is the
-// value paid out to recipients on chain. We sum `amountB` across two action
-// categories: Withdraw (recipient pulls accrued funds) and Cancel (auto-settles
-// the accrued-but-unwithdrawn portion to the recipient on cancellation). Both
-// record the recipient amount in `amountB`. Data comes from Sablier's public
-// Envio HyperIndex; per-chain queries filter by chainId. Streams are pre-funded
-// at creation so every settlement is funded value. Daily figures are lumpy
-// (claim/cancel timing) but cumulative equals true streamed value over time.
+// value paid out to recipients on chain: `amountB` on Withdraw actions only.
+//
+// Cancel is deliberately excluded. `_cancel` transfers only the unstreamed
+// remainder back to the sender; the recipient's accrued balance stays in the
+// contract (the indexer calls it `intactAmount`) until they withdraw it, which
+// emits its own Withdraw action. Counting Cancel too would book that balance
+// twice. Data comes from Sablier's public Envio HyperIndex; per-chain queries
+// filter by chainId. Streams are pre-funded at creation so every settlement is
+// funded value. Daily figures are lumpy (claim timing) but cumulative equals
+// true streamed value over time.
 
 const INDEXER = "https://indexer.hyperindex.xyz/53b7e25/v1/graphql";
 const PAGE_SIZE = 1000;
@@ -25,35 +28,42 @@ const CONFIG: Record<string, { chainId: number; start: string }> = {
   [CHAIN.XDAI]: { chainId: 100, start: "2023-07-01" },
   [CHAIN.AVAX]: { chainId: 43114, start: "2023-07-01" },
   [CHAIN.SCROLL]: { chainId: 534352, start: "2023-10-01" },
-  [CHAIN.LINEA]: { chainId: 59144, start: "2023-07-01" },
+  [CHAIN.LINEA]: { chainId: 59144, start: "2024-08-28" },
   [CHAIN.BLAST]: { chainId: 81457, start: "2024-02-01" },
-  [CHAIN.ERA]: { chainId: 324, start: "2023-07-01" },
-  [CHAIN.SONIC]: { chainId: 146, start: "2024-12-01" },
-  [CHAIN.MODE]: { chainId: 34443, start: "2024-01-01" },
+  [CHAIN.ERA]: { chainId: 324, start: "2024-05-06" },
+  [CHAIN.SONIC]: { chainId: 146, start: "2025-08-21" },
+  [CHAIN.MODE]: { chainId: 34443, start: "2024-10-29" },
   [CHAIN.ABSTRACT]: { chainId: 2741, start: "2025-01-01" },
-  [CHAIN.UNICHAIN]: { chainId: 130, start: "2025-02-01" },
-  [CHAIN.SEI]: { chainId: 1329, start: "2024-12-01" },
+  [CHAIN.UNICHAIN]: { chainId: 130, start: "2025-08-14" },
+  [CHAIN.SEI]: { chainId: 1329, start: "2025-03-28" },
   [CHAIN.BERACHAIN]: { chainId: 80094, start: "2025-02-01" },
-  [CHAIN.HYPERLIQUID]: { chainId: 999, start: "2025-02-01" },
+  [CHAIN.HYPERLIQUID]: { chainId: 999, start: "2025-07-17" },
   [CHAIN.SSEED]: { chainId: 5330, start: "2024-11-01" },
-  [CHAIN.MORPH]: { chainId: 2818, start: "2024-12-01" },
+  [CHAIN.MORPH]: { chainId: 2818, start: "2024-10-29" },
   [CHAIN.CHILIZ]: { chainId: 88888, start: "2024-12-01" },
   [CHAIN.XDC]: { chainId: 50, start: "2025-02-01" },
   [CHAIN.SOPHON]: { chainId: 50104, start: "2025-05-01" },
-  [CHAIN.MONAD]: { chainId: 143, start: "2025-12-01" },
+  [CHAIN.MONAD]: { chainId: 143, start: "2025-11-10" },
+  [CHAIN.ROBINHOOD]: { chainId: 4663, start: "2026-07-22" },
 };
 
 interface Row {
   id: string;
+  chainId: string;
   amountB: string | null;
   stream: { asset_id: string } | null;
 }
 
-const buildQuery = (chainId: number, from: number, to: number, cursor: string) => `{
+// One query serves every chain in the window and the in-flight promise is
+// shared, so a run costs one paginated pass rather than one per chain. The
+// indexer rate-limits bursts, and the per-chain shape tripped it.
+const CHAIN_IDS = Object.values(CONFIG).map(({ chainId }) => chainId);
+
+const buildQuery = (from: number, to: number, cursor: string) => `{
   LockupAction(
     where: {
-      category: {_in: [Withdraw, Cancel]}
-      chainId: {_eq: ${chainId}}
+      category: {_eq: Withdraw}
+      chainId: {_in: [${CHAIN_IDS.join(", ")}]}
       timestamp: {_gte: "${from}", _lt: "${to}"}
       id: {_gt: "${cursor}"}
     }
@@ -61,29 +71,45 @@ const buildQuery = (chainId: number, from: number, to: number, cursor: string) =
     limit: ${PAGE_SIZE}
   ) {
     id
+    chainId
     amountB
     stream { asset_id }
   }
 }`;
 
+const inFlight: Record<string, Promise<Row[]>> = {};
+
+const getWindow = (from: number, to: number) => {
+  const key = `${from}-${to}`;
+  if (!inFlight[key])
+    inFlight[key] = (async () => {
+      const all: Row[] = [];
+      let cursor = "";
+      while (true) {
+        const res: { data: { LockupAction: Row[] } } = await postURL(INDEXER, {
+          query: buildQuery(from, to, cursor),
+        });
+        const rows = res.data.LockupAction;
+        all.push(...rows);
+        if (rows.length < PAGE_SIZE) break;
+        cursor = rows[rows.length - 1].id;
+      }
+      return all;
+    })();
+  return inFlight[key];
+};
+
 const fetch = async (options: FetchOptions) => {
   const dailyVolume = options.createBalances();
-  const cfg = CONFIG[options.chain];
-  let cursor = "";
-  while (true) {
-    const query = buildQuery(cfg.chainId, options.fromTimestamp, options.toTimestamp, cursor);
-    const res: { data: { LockupAction: Row[] } } = await postURL(INDEXER, { query });
-    const rows = res.data.LockupAction;
-    if (!rows.length) break;
-    for (const r of rows) {
-      if (!r.amountB || r.amountB === "0" || !r.stream?.asset_id) continue;
-      // asset_id format: `asset-<chainId>-<tokenAddress>`; take the address suffix.
-      const parts = r.stream.asset_id.split("-");
-      const token = parts[parts.length - 1];
-      dailyVolume.add(token, r.amountB);
-    }
-    if (rows.length < PAGE_SIZE) break;
-    cursor = rows[rows.length - 1].id;
+  const { chainId } = CONFIG[options.chain];
+  const rows = await getWindow(options.fromTimestamp, options.toTimestamp);
+  for (const r of rows) {
+    if (Number(r.chainId) !== chainId) continue;
+    if (!r.amountB || r.amountB === "0" || !r.stream?.asset_id) continue;
+    // asset_id format: `asset-<chainId>-<tokenAddress>`; take the address suffix.
+    const parts = r.stream.asset_id.split("-");
+    const token = parts[parts.length - 1];
+    dailyVolume.add(token, r.amountB);
   }
   return { dailyVolume };
 };
@@ -93,7 +119,7 @@ const adapter: SimpleAdapter = {
   pullHourly: true,
   methodology: {
     Volume:
-      "Value paid out to Sablier Lockup stream recipients per chain. Sum of `amountB` on `LockupAction` rows where category is Withdraw (recipient pulls accrued funds) or Cancel (auto-settles the accrued-but-unwithdrawn portion to the recipient on cancellation). Streams are pre-funded at creation so every settlement is funded value. Data is sourced from Sablier's public Envio HyperIndex. Lockup is overwhelmingly used for project-token vesting, so daily volume is dominated by vesting unlocks.",
+      "The value of tokens Sablier Lockup actually paid out to stream recipients each day, added up per chain. Cancelling a stream is not counted: it returns the unvested remainder to whoever funded the stream, and the recipient's already-vested share stays in the contract until they claim it, at which point that claim is counted. Streams are fully funded up front, so every payout is real money moving. Lockup is used almost entirely for project-token vesting, so daily figures are lumpy and driven by vesting unlocks.",
   },
   adapter: CONFIG,
   fetch,


### PR DESCRIPTION
Fixes incorrect volume attribution across sablier flow and lockup, removes stale metadata, adds robinhood support, and reduces indexer load. No Flow numbers change.

### What changed

**Flow**
- Count `Withdraw` actions only; `Void` actions do not transfer tokens.
- Filter `Void` server-side and remove unused fields.
- Fetch all 19 chains in one request per window instead of one request per chain.

`Void.amountB` is written-off debt, not a payment. Treating it as volume would inflate Flow by ~325,000×. Withdraw-only volume over 30d is **$680.11M**, matching DefiLlama within **0.005%**.

**Lockup**
- Stop counting `Cancel.amountB` as volume. Cancellation transfers only the sender's refund; the recipient amount remains escrowed and is later counted by `Withdraw`.
- Count `Withdraw` actions only to avoid double-counting recipient payouts.
- Correct start dates from first on-chain activity.
- Add **Robinhood Chain** support.
- Fetch all chains in one request per window instead of per-chain queries.

Cancel volume is only 0.043% of the current 30d total, but excluding one dominant token, it overstated volume by **1.249%** over 30d and up to **50.60%** on individual days.

### Verification

- Contract source and on-chain traces confirm `Cancel.amountB` is the recipient balance retained in the contract.
- `Cancel.amountB − intactAmount = subsequent withdrawals` for **3,175/3,175** indexed cases.
- Flow: **$13.76k** on the 2026-08-04/05 test window.
- Lockup: **$120.68k** on the same window.