### PR TITLE
odos: shut down on 2026-07-30, mark it dead

### DIFF
--- a/aggregators/odos/index.ts
+++ b/aggregators/odos/index.ts
@@ -120,6 +120,7 @@ const adapter: SimpleAdapter = {
   },
   fetch,
   start,
+  deadFrom: '2026-07-30',
   chains: Object.keys(ODOS_V2_ROUTERS),
 };
 


### PR DESCRIPTION
Odos shut down. The team announced it on 2026-07-23, the app went read-only on 07-27 and all services ended permanently on **2026-07-30**.

- https://crypto.news/odos-shuts-down-july-30-as-defi-aggregator-ends-all-services/
- https://cryptopotato.com/dex-aggregator-odos-is-shutting-down-what-users-need-to-do-before-july-30/

`api.odos.xyz` is already gone; every endpoint returns Cloudflare 1033 / HTTP 530.

The published series matches the announcement. Last non-zero day is **2026-07-28**, and since then the adapter has written an explicit `$0` on all 16 chains, every day:

```
2026-08-02  (16 chain keys, all zero)
2026-08-03  (16 chain keys, all zero)
...
2026-08-07  (16 chain keys, all zero)
```

Both dimensions are affected, `aggregators/odos` volume and the fees the same adapter reports. Peer aggregators are reporting normally over the same window (1inch $77.3M/24h, Jupiter $278.5M, CoWSwap $99.5M), so this is Odos specifically, not a pipeline gap.

On-chain agrees: the ethereum V2 router `0xCf5540fFFCdC3d510B18bFcA6d2b9987b0772559` and the V3 router `0x0D05a7D3448512B78fa8A9e46c4872C88C4a0D05` emit no `Swap` or `SwapMulti` in the last 2,000 blocks.

Dated `deadFrom` at 2026-07-30, the day services actually ended, rather than the last non-zero day, 07-29 and 07-30 were still live days that happened to record nothing.

Verified:

```
$ npm test aggregators odos 2026-08-05
🦙 ODOS is dead (deadFrom 2026-07-30); skipping run.

$ npm test aggregators odos 2026-07-20
(still runs, history before the shutdown is untouched)
```

`npm run ts-check` passes.
