### PR TITLE
factory/curators: add RockawayX's second deployer safe and Base

### DIFF
--- a/factory/curators.ts
+++ b/factory/curators.ts
@@ -331,9 +331,24 @@ const configs: Record<string, CuratorConfig> = {
     breakdownFees: true,
     vaults: {
       [CHAIN.ETHEREUM]: {
-        // Morpho V2 vaults — "RockawayX USDC Yield" (0xE018...1965) + "RockawayX wETH" (0x64C1...9cB9)
-        morphoVaultV2Owners: ['0x9ECBf5aB609E33EC90D69888362639d652Eb8bf3'],
+        // Morpho V2 vaults. 0x9ECB...8bf3 created "RockawayX USDC Yield" (0xE018...1965),
+        // "RockawayX wETH" (0x64C1...9cB9) and "roxpUSDC" (0x5f82...8e21). RockawayX moved to a
+        // second deployer safe, 0x22d4...676a, for "roxTORI" (0x3BD9...9478), "humaUSDC"
+        // (0x8aC9...475c) and "mpUSDC" (0xe99A...0b3b) — every one of them is owned today by the
+        // same RockawayX safe 0xbBacDCFB9691DFA1066aB29edfcc4A73f6DEf918 as the first three.
+        morphoVaultV2Owners: [
+          '0x9ECBf5aB609E33EC90D69888362639d652Eb8bf3',
+          '0x22d4dbFFf37c7d7A0C7Afb9427A51de6F90a676a',
+        ],
+        // "figrUSDC" was created straight from a signer EOA of that safe rather than from either
+        // deployer, so it is listed by address instead of widening the owner list to an individual.
+        morphoV2: ['0xd65d6E8dbC3Cd3D12418199E6f4014dB3aaa0097'],
         start: '2026-03-06',
+      },
+      [CHAIN.BASE]: {
+        // "RockawayX Midas USDC Prime" (0xAE41...9Edc), created by the same 0x22d4...676a safe.
+        morphoVaultV2Owners: ['0x22d4dbFFf37c7d7A0C7Afb9427A51de6F90a676a'],
+        start: '2026-06-01',
       },
       [CHAIN.BSC]: {
         // Lista/Moolah vault "RockawayX PT Yield" — fork MetaMorpho, fee() = 10%


### PR DESCRIPTION
RockawayX switched to a second deployer safe, `0x22d4dbFFf37c7d7A0C7Afb9427A51de6F90a676a`, partway through its Morpho V2 rollout. `factory/curators.ts` only listed the first one, `0x9ECBf5aB...`, so every vault created after the switch is attributed to no curator today.

The TVL side already tracks all of them in `projects/rockawayx/index.js`.

## What was missing

Ethereum, uncovered until now:

| vault | address | size | perf fee | created |
| --- | --- | --- | --- | --- |
| roxTORI | `0x3BD9AdAE6643dDcddD02746b8B60075E56DF9478` | $10.51M USDC | 10% | 2026-07-13 |
| humaUSDC | `0x8aC91877b93330f52b2979a31a4879506021475c` | $15.87M USDC | 0% | 2026-06-05 |
| figrUSDC | `0xd65d6E8dbC3Cd3D12418199E6f4014dB3aaa0097` | $37.3k USDC | 0% | 2026-05-15 |
| mpUSDC | `0xe99A27169c2aA26a8f2757949d09Fa3f9A8f0B3B` | $1 | 0% | 2026-06-01 |

plus four seed vaults still at about $1 each: RockawayX AUSD RWA, RockawayX EUROP, RockawayX Nuva Ecosystem, Huma USDC Main.

Base had no entry at all, so RockawayX Midas USDC Prime `0xAE4181CFB5aaA08bbE77d269c6B595672b9F9Edc` ($595k, created 2026-06-01) was missing outright. Base's V2 factory `0x4501...5857` is already registered in `MorphoConfigs`, so owner enumeration reaches it.

For reference, what was already counted: roxUSDCy `0xE018...1965` ($18.28M) and roxWETH `0x64C1...9cB9`. So the Ethereum line was reading two vaults out of six real ones.

## Attribution

Read the indexed `owner` out of each `CreateVaultV2` event rather than the current `owner()`, since the framework filters on the creation owner:

```
roxTORI    initialOwner=0x22d4dbff...676a  blk 25526209
humaUSDC   initialOwner=0x22d4dbff...676a  blk 25253796
mpUSDC     initialOwner=0x22d4dbff...676a  blk 25223264
base mpUSDC initialOwner=0x22d4dbff...676a
roxpUSDC   initialOwner=0x9ecbf5ab...8bf3  blk 24721295   (already covered)
figrUSDC   initialOwner=0xac851fcd...3a49  blk 25100277
```

Three things tie them to RockawayX:

1. All of them, including the three the first deployer created, are owned today by the same RockawayX safe `0xbBacDCFB9691DFA1066aB29edfcc4A73f6DEf918`.
2. `0x22d4dbff...676a` is itself a 1-of-1 safe whose only owner is `0xBDa66C6704d1170Ce3479a9a53465fAA2482f9e5`, the EOA that deployed the Base vault too.
3. `projects/rockawayx/index.js` already lists these same addresses.

I checked what the added owner actually pulls in rather than assuming. Logging the resolved vault list, Ethereum goes from 5 vaults to 13, and every one of the 8 added is RockawayX's own, four of them carrying the name directly. Nothing foreign rides along.

figrUSDC was created straight from a signer EOA of the safe rather than from either deployer, so I listed it by address instead of widening the owner list to an individual.

## Numbers

Realised 7d share price growth, measured on chain:

- roxTORI 3.78%
- humaUSDC 5.79%
- roxUSDCy 6.64% (already counted, as a control)

`npm run test fees rockawayx`:

| chain | before | after |
| --- | --- | --- |
| ethereum fees | 3.20k | 6.21k |
| ethereum revenue | 160 | 239 |
| base fees | not configured | 81 |
| aggregate fees | 5.00k | 8.10k |
| aggregate revenue | 429 | 509 |

`npm run ts-check` passes.

## Pharos left out on purpose

RockawayX USDC on Pharos `0x047cd0a91e9b92ed979189a6c8a120bf280f02e5` holds $9.96M and the TVL adapter tracks it, but it is not earning. Share price per 1e27 shares:

```
2026-08-01  1000699597632040
2026-08-03  1000502146354939
2026-08-05  1000528548823345
2026-08-07  1000549116765975
```

It is down over the window and about 0.4%/yr at best across Aug 3 to 7. That is roughly $16/day, and a falling share price could publish negative fees, so I would rather leave it until it actually accrues.

One note if you do want it later: it is a V2 vault (`fee()` reverts, `performanceFee()` is 1e17), so it needs the `morphoV2` key, not `morpho`. The TVL registry currently has it under `morpho`.
