### PR TITLE
fermiswap: add second swapper and document coverage

### DIFF
--- a/dexs/fermiswap/index.ts
+++ b/dexs/fermiswap/index.ts
@@ -18,19 +18,17 @@ const swappers = [
 async function fetch(options: FetchOptions) {
   const { getLogs, createBalances } = options;
   const dailyVolume = createBalances();
-  for (const { target, eventAbi } of swappers) {
-    const logs = await getLogs({ target, eventAbi });
-    logs.forEach((log: any) => {
-      addOneToken({
-        chain: options.chain,
-        balances: dailyVolume,
-        token0: log.tokenIn,
-        amount0: log.amountIn,
-        token1: log.tokenOut,
-        amount1: log.amountOut
-      })
-    });
-  }
+  const logs = await Promise.all(swappers.map(({ target, eventAbi }) => getLogs({ target, eventAbi })));
+  logs.flat().forEach((log: any) => {
+    addOneToken({
+      chain: options.chain,
+      balances: dailyVolume,
+      token0: log.tokenIn,
+      amount0: log.amountIn,
+      token1: log.tokenOut,
+      amount1: log.amountOut
+    })
+  });
   return { dailyVolume };
 }
 

--- a/dexs/fermiswap/index.ts
+++ b/dexs/fermiswap/index.ts
@@ -2,32 +2,49 @@ import { SimpleAdapter, FetchOptions } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 import { addOneToken } from "../../helpers/prices";
 
-const router = "0xb1076fE3AB5e28005C7c323Bac5AC06a680d452e";
-const swapEvent = 'event FermiSwap(address indexed recipient, address indexed tokenIn, address indexed tokenOut, uint256 amountIn, uint256 amountOut)'
+// Both swappers fill from the same inventory vault (0x585d44727129B9C69791B10238Ca605932938B4F).
+// The second one went live 2026-06-08 with a renamed event and carries ~23% of volume.
+const swappers = [
+  {
+    target: "0xb1076fE3AB5e28005C7c323Bac5AC06a680d452e",
+    eventAbi: 'event FermiSwap(address indexed recipient, address indexed tokenIn, address indexed tokenOut, uint256 amountIn, uint256 amountOut)',
+  },
+  {
+    target: "0x5979458912F80B96d30D4220af8E2e4925A33320",
+    eventAbi: 'event Swapped(address indexed sender, address indexed tokenIn, address indexed tokenOut, uint256 amountIn, uint256 amountOut, address recipient)',
+  },
+]
 
 async function fetch(options: FetchOptions) {
   const { getLogs, createBalances } = options;
   const dailyVolume = createBalances();
-  const logs = await getLogs({ target: router, eventAbi: swapEvent });
-  logs.forEach((log: any) => {
-    addOneToken({
-        chain: options.chain, 
-        balances: dailyVolume, 
-        token0: log.tokenIn, 
-        amount0: log.amountIn, 
-        token1: log.tokenOut, 
-        amount1: log.amountOut 
-    })
-  });
+  for (const { target, eventAbi } of swappers) {
+    const logs = await getLogs({ target, eventAbi });
+    logs.forEach((log: any) => {
+      addOneToken({
+        chain: options.chain,
+        balances: dailyVolume,
+        token0: log.tokenIn,
+        amount0: log.amountIn,
+        token1: log.tokenOut,
+        amount1: log.amountOut
+      })
+    });
+  }
   return { dailyVolume };
 }
 
+const methodology = {
+  Volume: "Total value traded against FermiSwap, counted once per swap. FermiSwap is a market maker that fills orders out of its own token inventory instead of shared liquidity pools, so this counts only the trades it fills itself.",
+}
+
 const adapter: SimpleAdapter = {
-    version: 2,
-    fetch,
-    pullHourly: true,
-    chains: [CHAIN.ETHEREUM],
-    start: "2026-05-12",
+  version: 2,
+  fetch,
+  pullHourly: true,
+  chains: [CHAIN.ETHEREUM],
+  start: "2026-05-12",
+  methodology,
 };
 
 export default adapter;


### PR DESCRIPTION
### Changes

* Added the second FermiSwapper (`0x5979…3320`), live since **2026-06-08**, using its `Swapped` event.
* Volume now includes both swapper contracts; the second was contributing **23.3%** of volume.
* Added methodology documenting the inventory model and volume attribution.

### Verification

* `pnpm test dexs fermiswap 2026-08-04` → **$8.32M**
* Vault approval history contains exactly the two swappers plus the excluded UniV3 hedger.