### PR TITLE
clutch-anvil: add Robinhood Chain (volume, fees, ETH swap-fee revenue)

### DIFF
--- a/dexs/clutch-anvil/index.ts
+++ b/dexs/clutch-anvil/index.ts
@@ -145,9 +145,13 @@ const fetch = async (options: FetchOptions): Promise<FetchResult> => {
       eventAbi: ROBINHOOD_SWAP_FEE_ABI,
       flatten: true,
     });
+
+    const protocolShare = 0.5;
+
     for (const log of ethFeeLogs) {
       dailyFees.addGasToken(log.feeWei, METRIC.TRADING_FEES);
-      dailyRevenue.addGasToken(log.feeWei, 'Robinhood ETH swap fee');
+      dailyRevenue.addGasToken(Number(log.feeWei) * protocolShare, 'Robinhood ETH swap fee to protocol');
+      dailySupplySideRevenue.addGasToken(Number(log.feeWei) * (1 - protocolShare), 'Robinhood ETH swap fee to StockBooster rewards engine');
     }
   }
 
@@ -155,6 +159,7 @@ const fetch = async (options: FetchOptions): Promise<FetchResult> => {
     dailyVolume,
     dailyFees,
     dailyRevenue,
+    dailyProtocolRevenue: dailyRevenue,
     dailySupplySideRevenue,
   };
 };
@@ -162,8 +167,9 @@ const fetch = async (options: FetchOptions): Promise<FetchResult> => {
 const methodology = {
   Volume: "Sum of buy totalCost and sell grossPayout from NFTBought + NFTSold events across every AMM vault deployed by the Clutch Anvil factory.",
   Fees: "Sum of protocolFee + stakerFee fields from NFTBought + NFTSold events. Protocol fee is burned; staker fee streams to the NFT staking vault as rewards. On Robinhood Chain every swap additionally pays a flat oracle-priced ~$2 ETH fee (RobinhoodSwapFeePaid).",
-  Revenue: "Robinhood Chain only: the flat ETH swap fee, split 50% protocol treasury / 50% StonkBrokers StockBooster rewards engine. No protocol revenue on other chains.",
-  SupplySideRevenue: "Includes NFTs burned from protocol revenue and staker fees distributed to the NFT stakers",
+  Revenue: "Robinhood Chain only: the flat ETH swap fee, split 50% to the protocol treasury.",
+  ProtocolRevenue: "Robinhood Chain only: the flat ETH swap fee, split 50% to the protocol treasury.",
+  SupplySideRevenue: "Includes NFTs burned from protocol revenue and staker fees distributed to the NFT stakers plus 50% of the flat oracle-priced ~$2 ETH fee per Robinhood Chain that goes to the StonkBrokers StockBooster rewards engine.",
 }
 
 const breakdownMethodology = {
@@ -171,11 +177,15 @@ const breakdownMethodology = {
     [METRIC.TRADING_FEES]: "Sum of protocolFee + stakerFee fields from NFTBought + NFTSold events (protocol fee burned, staker fee to the NFT staking vault), plus the flat ~$2 ETH fee per swap on Robinhood Chain.",
   },
   Revenue: {
-    'Robinhood ETH swap fee': "Flat oracle-priced ~$2 ETH fee per Robinhood Chain swap, split 50% protocol treasury / 50% StonkBrokers StockBooster rewards engine.",
+    'Robinhood ETH swap fee to protocol': "50% of the flat oracle-priced ~$2 ETH fee per Robinhood Chain goes to the protocol treasury.",
+  },
+  ProtocolRevenue: {
+    'Robinhood ETH swap fee to protocol': "50% of the flat oracle-priced ~$2 ETH fee per Robinhood Chain goes to the protocol treasury.",
   },
   SupplySideRevenue: {
     'Fees to NFT burn': "Sum of protocolFee fields from NFTBought + NFTSold events. Protocol fee is burned directly rewarding NFT holders (supply side)",
     'Fees to NFT stakers': "Sum of stakerFee fields from NFTBought + NFTSold events. Staker fee streams to the NFT staking vault as rewards.",
+    'Robinhood ETH swap fee to StockBooster rewards engine': "50% of the flat oracle-priced ~$2 ETH fee per Robinhood Chain goes to the StonkBrokers StockBooster rewards engine.",
   },
 }
 

--- a/dexs/clutch-anvil/index.ts
+++ b/dexs/clutch-anvil/index.ts
@@ -23,6 +23,17 @@ import { METRIC } from "../../helpers/metrics";
 // Fees = sum of `protocolFee + stakerFee` from both events. Protocol fee is
 // burned (deflationary on the token), staker fee streams to the staking
 // vault as rewards. We expose the full fee tranche as protocol revenue.
+//
+// Robinhood Chain (v2 generation, live 2026-08-05) additionally charges a
+// flat oracle-priced ~$2 ETH fee on every swap, emitted per swap as:
+//
+//   event RobinhoodSwapFeePaid(
+//     address indexed payer, uint256 feeWei, address treasury, address booster
+//   )
+//
+// That ETH fee is protocol revenue (split 50% treasury / 50% StockBooster
+// rewards engine); the token-denominated protocolFee/stakerFee tranche keeps
+// the same burn/staker semantics as the other chains.
 
 const chainsConfig: Record<string, { factory: string; fromBlock: number; start: string }> = {
   [CHAIN.ETHEREUM]: {
@@ -40,6 +51,11 @@ const chainsConfig: Record<string, { factory: string; fromBlock: number; start: 
     fromBlock: 34900822,
     start: "2026-02-15",
   },
+  [CHAIN.ROBINHOOD]: {
+    factory: "0x432D20AAe5605b1E94C914283d7155eBc6727351",
+    fromBlock: 28775550,
+    start: "2026-08-05",
+  },
 };
 
 const MARKET_CREATED_ABI =
@@ -51,12 +67,16 @@ const NFT_BOUGHT_ABI =
 const NFT_SOLD_ABI =
   "event NFTSold(address indexed seller, uint256 indexed tokenId, uint256 grossPayout, uint256 netPayout, uint256 protocolFee, uint256 stakerFee)";
 
+const ROBINHOOD_SWAP_FEE_ABI =
+  "event RobinhoodSwapFeePaid(address indexed payer, uint256 feeWei, address treasury, address booster)";
+
 const fetch = async (options: FetchOptions): Promise<FetchResult> => {
   const { chain, createBalances, getLogs } = options;
   const { factory, fromBlock } = chainsConfig[chain];
 
   const dailyVolume = createBalances();
   const dailyFees = createBalances();
+  const dailyRevenue = createBalances();
   const dailySupplySideRevenue = createBalances();  
 
   const markets = await getLogs({
@@ -74,7 +94,7 @@ const fetch = async (options: FetchOptions): Promise<FetchResult> => {
 
   const ammVaults = Array.from(ammByToken.keys());
   if (ammVaults.length === 0) {
-    return { dailyVolume, dailyFees, dailyRevenue: 0, dailySupplySideRevenue };
+    return { dailyVolume, dailyFees, dailyRevenue, dailySupplySideRevenue };
   }
 
   const [buyLogs, sellLogs] = await Promise.all([
@@ -116,24 +136,42 @@ const fetch = async (options: FetchOptions): Promise<FetchResult> => {
     dailySupplySideRevenue.add(token, args.stakerFee, 'Fees to NFT stakers');
   }
 
+  // Robinhood markets also pay a flat oracle-priced ETH fee (~$2) per swap,
+  // routed 50% to the protocol treasury and 50% to the StonkBrokers
+  // StockBooster rewards engine — counted as protocol revenue.
+  if (chain === CHAIN.ROBINHOOD) {
+    const ethFeeLogs = await getLogs({
+      targets: ammVaults,
+      eventAbi: ROBINHOOD_SWAP_FEE_ABI,
+      flatten: true,
+    });
+    for (const log of ethFeeLogs) {
+      dailyFees.addGasToken(log.feeWei, METRIC.TRADING_FEES);
+      dailyRevenue.addGasToken(log.feeWei, 'Robinhood ETH swap fee');
+    }
+  }
+
   return {
     dailyVolume,
     dailyFees,
-    dailyRevenue: 0,
+    dailyRevenue,
     dailySupplySideRevenue,
   };
 };
 
 const methodology = {
   Volume: "Sum of buy totalCost and sell grossPayout from NFTBought + NFTSold events across every AMM vault deployed by the Clutch Anvil factory.",
-  Fees: "Sum of protocolFee + stakerFee fields from NFTBought + NFTSold events. Protocol fee is burned; staker fee streams to the NFT staking vault as rewards.",
-  Revenue: "No revenue",
+  Fees: "Sum of protocolFee + stakerFee fields from NFTBought + NFTSold events. Protocol fee is burned; staker fee streams to the NFT staking vault as rewards. On Robinhood Chain every swap additionally pays a flat oracle-priced ~$2 ETH fee (RobinhoodSwapFeePaid).",
+  Revenue: "Robinhood Chain only: the flat ETH swap fee, split 50% protocol treasury / 50% StonkBrokers StockBooster rewards engine. No protocol revenue on other chains.",
   SupplySideRevenue: "Includes NFTs burned from protocol revenue and staker fees distributed to the NFT stakers",
 }
 
 const breakdownMethodology = {
   Fees: {
-    [METRIC.TRADING_FEES]: "Sum of protocolFee + stakerFee fields from NFTBought + NFTSold events. Protocol fee is burned; staker fee streams to the NFT staking vault as rewards.",
+    [METRIC.TRADING_FEES]: "Sum of protocolFee + stakerFee fields from NFTBought + NFTSold events (protocol fee burned, staker fee to the NFT staking vault), plus the flat ~$2 ETH fee per swap on Robinhood Chain.",
+  },
+  Revenue: {
+    'Robinhood ETH swap fee': "Flat oracle-priced ~$2 ETH fee per Robinhood Chain swap, split 50% protocol treasury / 50% StonkBrokers StockBooster rewards engine.",
   },
   SupplySideRevenue: {
     'Fees to NFT burn': "Sum of protocolFee fields from NFTBought + NFTSold events. Protocol fee is burned directly rewarding NFT holders (supply side)",


### PR DESCRIPTION
## Summary

Clutch Anvil AMM went live on Robinhood Chain on 2026-08-05 (v2 factory generation). This adds the chain to the existing adapter:

- **Volume + token fees**: same `MarketCreated` → `NFTBought`/`NFTSold` pattern as the other chains, factory `0x432D20AAe5605b1E94C914283d7155eBc6727351` (from block 28775550).
- **Revenue (Robinhood only)**: the v2 generation charges a flat oracle-priced ~$2 ETH fee on every swap, emitted as `RobinhoodSwapFeePaid(payer, feeWei, treasury, booster)`. Counted as protocol revenue (split 50% treasury / 50% StonkBrokers StockBooster rewards engine). `dailyRevenue` stays empty on the other chains, matching the previous `dailyRevenue: 0`.

## Verification

- `npm run test dexs clutch-anvil` — Robinhood rows return volume/fees/revenue (the run only tripped on public Ethereum RPC rate limits at the end, unrelated to this change).
- Independent RPC check for the last 24h: 266 `RobinhoodSwapFeePaid` events totalling ~0.278 ETH across the factory's vaults, matching the adapter output.

No overlap with `fees/stonkbrokers`: that adapter tracks the standalone StonkBrokers market vault, which predates this factory and is not in its `MarketCreated` logs.

Made with [Cursor](https://cursor.com)