### PR TITLE
factory/curators: add Clearstar's Morpho V2 vaults on ethereum, base and monad

### DIFF
--- a/factory/curators.ts
+++ b/factory/curators.ts
@@ -86,15 +86,29 @@ const configs: Record<string, CuratorConfig> = {
   },
   "clearstar": {
     vaults: {
+      // The V2 owner lists below are the indexed `owner` of CreateVaultV2, taken from each vault's
+      // creation receipt, not the current owner() (every one of these vaults is owned today by
+      // 0xb3CF59A5, a Clearstar address in Morpho's curators registry on chains 1, 143 and 8453).
+      // 0x829A1385 is already registered as a Clearstar V2 owner on katana below.
       [CHAIN.BASE]: {
         morphoVaultOwners: ['0x30988479C2E6a03E7fB65138b94762D41a733458'],
+        // 0x829A1385 created "Clearstar cbAssets Vault" (0x91C0...3a3c), "Clearstar Core ETH"
+        // (0xBCA4...71da) and "Clearstar CoreUSDC" (0x116e...0E46); 0x3098...3458 created
+        // "Clearstar Reactor EURC" (0x4C7b...C55C) and "Clearstar Boring USDC" (0x0282...0681).
+        // https://base.blockscout.com/tx/0xebe8310f28cb502a87403f501db7fce667c7fafd95d65c56d5e913bd7139e6f2
         morphoVaultV2Owners: ['0x829A13850b684A575C0580a83322890e19c5eFaa', '0x30988479C2E6a03E7fB65138b94762D41a733458'],
       },
       [CHAIN.ETHEREUM]: {
         morphoVaultOwners: ['0x30988479C2E6a03E7fB65138b94762D41a733458'],
+        // 0x3098...3458 created "3Jane Ecosystem Vault" (0xe05f...9826), "Re Ecosystem Vault"
+        // (0xD1E9...4A7e) and "Clearstar USDC Core" (0x69A2...c284); 0x829A1385 created
+        // "Clearstar Boring USDC" (0xF3Cc...Db49).
+        // https://etherscan.io/tx/0x54939debbe1cf29d026262333b63b209613f4a84ef32739d07658d47a9287335
         morphoVaultV2Owners: ['0x30988479C2E6a03E7fB65138b94762D41a733458', '0x829A13850b684A575C0580a83322890e19c5eFaa'],
       },
       [CHAIN.MONAD]: {
+        // 0x829A1385 created "Clearstar Accountable AUSD" (0xbe3E...E9a1, the start date below is
+        // its creation) and "Clearstar Yield AUSD" (0x8192...ad06).
         morphoVaultV2Owners: ['0x829A13850b684A575C0580a83322890e19c5eFaa'],
         start: '2026-05-28',
       },

--- a/factory/curators.ts
+++ b/factory/curators.ts
@@ -86,8 +86,18 @@ const configs: Record<string, CuratorConfig> = {
   },
   "clearstar": {
     vaults: {
-      [CHAIN.BASE]: { morphoVaultOwners: ['0x30988479C2E6a03E7fB65138b94762D41a733458'] },
-      [CHAIN.ETHEREUM]: { morphoVaultOwners: ['0x30988479C2E6a03E7fB65138b94762D41a733458'] },
+      [CHAIN.BASE]: {
+        morphoVaultOwners: ['0x30988479C2E6a03E7fB65138b94762D41a733458'],
+        morphoVaultV2Owners: ['0x829A13850b684A575C0580a83322890e19c5eFaa', '0x30988479C2E6a03E7fB65138b94762D41a733458'],
+      },
+      [CHAIN.ETHEREUM]: {
+        morphoVaultOwners: ['0x30988479C2E6a03E7fB65138b94762D41a733458'],
+        morphoVaultV2Owners: ['0x30988479C2E6a03E7fB65138b94762D41a733458', '0x829A13850b684A575C0580a83322890e19c5eFaa'],
+      },
+      [CHAIN.MONAD]: {
+        morphoVaultV2Owners: ['0x829A13850b684A575C0580a83322890e19c5eFaa'],
+        start: '2026-05-28',
+      },
       [CHAIN.POLYGON]: { morphoVaultOwners: ['0x30988479C2E6a03E7fB65138b94762D41a733458'] },
       [CHAIN.UNICHAIN]: { morphoVaultOwners: ['0x30988479C2E6a03E7fB65138b94762D41a733458'], start: '2025-10-01' },
       [CHAIN.ARBITRUM]: { morphoVaultOwners: ['0x30988479C2E6a03E7fB65138b94762D41a733458'] },

--- a/helpers/curators/index.ts
+++ b/helpers/curators/index.ts
@@ -74,6 +74,13 @@ const blacklistedVaults: Record<string, Array<{ vault: string, from: string }>> 
     // bad debt; excluding from the freeze onset also keeps the eventual write-off out of the series.
     vault: '0x9B5E92fd227876b4C07a8c02367E2CB23c639DfA',
     from: '2026-03-21',
+  }, {
+    // Clearstar Yield USDC v2 (0xFa17...F853) - the v2 vault of the same name, allocated to the same
+    // frozen market. Share price ran 1.009084 -> 1.019572 over 2026-03-21..04-04 and 1.794800 ->
+    // 1.908595 over the last week alone, ~165% APR against ~5.2% before the freeze, on a USDC vault
+    // that has now marked itself up 91%. Same phantom accrual as the v1 above, same onset date.
+    vault: '0xFa17f7AAdbfAc2C5d3C8125555404c1AE17Df853',
+    from: '2026-03-21',
   }],
 }
 


### PR DESCRIPTION
Clearstar's `ethereum` and `base` entries in `factory/curators.ts` only had `morphoVaultOwners`, so their V1 vaults were counted and every Morpho V2 vault on those two chains was attributed to no curator. Monad had no entry at all. Katana already has `morphoVaultV2Owners`, and both addresses added here are already registered there, so this is bringing the other chains in line with it.

### What is added

`ethereum` and `base` get `morphoVaultV2Owners` with `0x829A13850b684A575C0580a83322890e19c5eFaa` and `0x30988479C2E6a03E7fB65138b94762D41a733458`, and there is a new `monad` entry with `0x829A1385`.

Both are the `CreateVaultV2` creation owners. I read them off each vault's creation receipt rather than trusting the current `owner()`, because the framework filters on the indexed creation owner and the two differ here: every one of these vaults is owned today by `0xb3CF59A5`.

Vaults this brings in:

| chain | vault | address | TVL |
| --- | --- | --- | --- |
| base | Clearstar cbAssets Vault | `0x91C056B6d4311a743614FBc03ac32d4E6A2d3a3c` | $28.8M |
| ethereum | 3Jane Ecosystem Vault | `0xe05faDf242331808f504661BEA65972594869826` | $23.4M |
| ethereum | Re Ecosystem Vault | `0xD1E9242e075Db4bdd3f3c721D7d5fd4180A94A7e` | $7.6M |
| monad | Clearstar Accountable AUSD | `0xbe3E6d3F857812B4731677C88288D4F3afF8E9a1` | $1.76M |
| ethereum | Clearstar USDC Core | `0x69A238Ae7ebeb3c53ff3B544E48B96a2142fc284` | $865k |
| base | Clearstar Core ETH | `0xBCA4E2E24A7cFa776E4282CC8Eb06f04738b71da` | $305k |
| base | Clearstar CoreUSDC | `0x116e1A65717A534B73EcB7d4F6543c65DBCd0E46` | $105k |

I logged the resolved vault list before and after rather than assuming, since adding an owner address pulls in everything that address created. The owner lists also sweep in a tail of Clearstar's own empty test deployments (names like "test", "ready", "ACS TEST", and unlisted ones). They hold $0 and contribute nothing. Everything with real TVL in the resolved set is in the table above.

### Attribution

Three independent ways:

- Morpho's `curators` API names the curator of cbAssets Vault, 3Jane Ecosystem Vault and Re Ecosystem Vault as **Clearstar** (verified: true).
- `0xb3CF59A5`, the current owner of all of them, is listed as a Clearstar address on chains 1, 143 and 8453 in that same registry.
- `0x829A1385` is already a registered Clearstar V2 owner on katana in this file.

The two "Ecosystem Vault" names are third-party vaults Clearstar curates, same shape as the existing white-label entries elsewhere in this file.

### Blacklisting Clearstar Yield USDC v2

`0xFa17f7AAdbfAc2C5d3C8125555404c1AE17Df853` is blacklisted from `2026-03-21`.

This is the V2 vault of the same name as `0x9B5E92fd`, which is already blacklisted from that exact date for allocating to a market frozen at 100% utilization and accruing phantom interest. The V2 vault is doing the same thing. `convertToAssets(1e18)` on it:

```
2026-03-07   1.007061      5.5% APR
2026-03-21   1.009084      5.2% APR   <- freeze onset
2026-04-04   1.019572     49.7% APR
2026-05-02   1.162728    193.8% APR
2026-07-25   1.794800    175.9% APR
2026-08-08   1.908595    164.7% APR
```

A USDC vault that has marked itself up 91%, running ~165% APR against ~5.2% before the freeze. Left in, this single $518k vault took ethereum from 4.61k to 8.77k daily fees on its own, more than doubling the figure. Onset lands on the same date as the V1 twin, which is consistent with both being allocated to the same frozen market.

### Test

`npm run test fees clearstar`, daily fees / revenue, before -> after:

| chain | fees | revenue |
| --- | --- | --- |
| ethereum | 334 -> 4.61k | 67 -> 637 |
| base | 235 -> 3.81k | 47 -> 402 |
| monad | new, 236 | new, 12 |
| katana | 22, unchanged | unchanged |
| flare | 1.64k, unchanged | unchanged |

Sanity check on the new numbers: revenue over fees comes out at 13.8% on ethereum (a mix of 10% and 15% performance fees), 10.5% on base (cbAssets charges 10%) and 5.1% on monad (Accountable AUSD charges 5%), each matching the vault's on-chain `performanceFee`. Per-vault expected daily fees derived from Morpho's reported gross APYs also line up with the adapter output within a few percent on base and monad.
