### PR TITLE
factory/curators: add Steakhouse's missing Morpho V2 deployers on ethereum, base and katana

### DIFF
--- a/factory/curators.ts
+++ b/factory/curators.ts
@@ -391,14 +391,34 @@ const configs: Record<string, CuratorConfig> = {
   "steakhouse": {
     breakdownFees: true,
     vaults: {
+      // Steakhouse deploys most V2 vaults from a per-vault deployer rather than one shared safe, so
+      // the V2 owner lists below carry several addresses. Each is the indexed `owner` of that vault's
+      // CreateVaultV2 event, taken from its creation receipt, not the current owner() (nearly all of
+      // these vaults are owned today by 0x4D7bd498 on ethereum and 0x639bfA26 on base). Morpho's
+      // curators API names the curator of every vault called out below "Steakhouse Financial".
       [CHAIN.ETHEREUM]: {
         morphoVaultOwners: ['0x0000aeB716a0DF7A9A1AAd119b772644Bc089dA8', '0x255c7705e8BB334DfCae438197f7C4297988085a', '0x0A0e559bc3b0950a7e448F0d4894db195b9cf8DD', '0xc01Ba42d4Bd241892B813FA8bD4589EAa4C60672'],
-        morphoVaultV2Owners: ['0xec0Caa2CbAe100CEAaC91A665157377603a6B766'],
+        morphoVaultV2Owners: [
+          '0xec0Caa2CbAe100CEAaC91A665157377603a6B766', // Prime USDT, Prime ETH, High Yield Instant, Prime Instant
+          '0x328dc4a2950b4A19fD440e9FfC6E9c3a496AFCFd', // Prime EURCV (0xbeef...DB2f), High Yield USDT, Safe x Steakhouse Prime Instant
+          '0x7E17eC774bECD5f4f129fa5f150046dd0eCe5bB0', // Prime USDC (0xbeef...0f51), High Yield USDC. owner() is 0x0A0e559b, already a Steakhouse owner above
+          '0x25FC16504b809FF3c730000544b8583011Ee7545', // Confidential Prime USDC (0xbEEF...542B)
+          '0x966cdEEfFAa232e4137385731413E2be6FCBe0e7', // 3F x Steakhouse USDC (0xBEEf...183D), Prime EURC
+          '0xcb0a0b2f84D0EaD648De7e10B85093b7F0FdA072', // tGBP (0xbeef...f04F)
+          '0x274c71c8C071f2E29f0cC964767a7C8b31F5C544', // Grove x Steakhouse USDC (0xBeeF...4111)
+        ],
         start: '2024-07-29',
       },
       [CHAIN.BASE]: {
         morphoVaultOwners: ['0x0A0e559bc3b0950a7e448F0d4894db195b9cf8DD', '0x0000aeB716a0DF7A9A1AAd119b772644Bc089dA8'],
-        morphoVaultV2Owners: ['0x351D76EC45f0aD6Deb498806F1320F75F861a114'],
+        morphoVaultV2Owners: [
+          '0x351D76EC45f0aD6Deb498806F1320F75F861a114', // High Yield USDC
+          '0xC7cf133140A6AF6c2379BE2b353Ed5B66511FE04', // High Yield USDC Edition (0xbeef...8845)
+          '0xF1F12e6a1b58fCce6D2Ed181CB55302c831Eb2Ac', // Ethena x Steakhouse USDC (0xBeEf...739e)
+          '0x8A7CdA8322fB96D3457a5B32c8869A7B1a5B1Db7', // Prime EURC, Prime ETH
+          '0x769699C75c4E17EbD5d678a9C58776179ddC254b', // Prime XSGD
+          '0x8396d2B322f5f533531f960B042a15AAa2784529', // Farcaster x Steakhouse Prime
+        ],
         start: '2024-07-29',
       },
       [CHAIN.CORN]: {
@@ -412,6 +432,8 @@ const configs: Record<string, CuratorConfig> = {
       },
       [CHAIN.KATANA]: {
         morphoVaultOwners: ['0xe6FC2a011153DD5a230725a9F0c89a9c81aB4887'],
+        // High Yield USDC (0xbeef...b6c6) and Prime USDC (0xbeef...62D7), both created by this deployer
+        morphoVaultV2Owners: ['0x627E54a84134FfB3c8Ee85a5A675cd50c2Db239b'],
         start: '2025-06-23',
       },
       [CHAIN.MONAD]: {


### PR DESCRIPTION
Steakhouse deploys most of its V2 vaults from a per-vault deployer rather than one shared safe. `ethereum` and `base` each listed a single `morphoVaultV2Owners` entry and `katana` listed none, so a large part of their V2 book was attributed to no curator.

Every address added is the indexed `owner` of that vault's `CreateVaultV2` event, read off its creation receipt. The current `owner()` is not usable here: nearly all of these vaults are owned today by `0x4D7bd498` on ethereum and `0x639bfA26` on base, and neither is the creation owner of any of them.

### Largest vaults this brings in

| chain | vault | address | TVL |
| --- | --- | --- | --- |
| base | Steakhouse High Yield USDC Edition | `0xbeeff2490FEffa212faC2f6553682C219E6a8845` | $292.6M |
| ethereum | Steakhouse Prime EURCV | `0xbeef0C075Da5D01112AE5cF34d257074fB5DDB2f` | $124.8M |
| ethereum | Steakhouse Prime USDC | `0xbeef088055857739C12CD3765F20b7679Def0f51` | $108.7M |
| base | Ethena x Steakhouse USDC | `0xBeEfF0be997Cca5B1c13A7433c2004637975739e` | $85.0M |
| ethereum | Steakhouse High Yield USDC | `0xbeeff2C5bF38f90e3482a8b19F12E5a6D2FCa757` | $44.8M |
| ethereum | Steakhouse Confidential Prime USDC | `0xbEEF00A59B577423653A1526c7009bdE103F542B` | $44.5M |
| ethereum | Grove x Steakhouse AUSD | `0xBEEfF0d672ab7F5018dFB614c93981045D4aA98a` | $21.0M |
| ethereum | 3F x Steakhouse USDC | `0xBEEf3f3A04e28895f3D5163d910474901981183D` | $14.6M |
| ethereum | Steakhouse tGBP | `0xbeeffABcd0dB09589Dd21854aa760C52aB4bf04F` | $5.2M |
| base | Steakhouse Prime EURC | `0xbeef009F28cCf367444a9F79096862920e025DC1` | $3.3M |

plus Prime XSGD, Prime ETH and Farcaster x Steakhouse Prime on base, High Yield USDT, Safe x Steakhouse Prime Instant, Grove x Steakhouse USDC and Prime EURC on ethereum, and both katana vaults.

### Sweep check

An owner address pulls in everything it created, so I logged the resolved vault list before and after instead of assuming. `ethereum` went 5 -> 49 vaults, `base` 4 -> 28, `katana` 0 -> 2.

I looked up all 79 in Morpho's API. Everything holding more than $50k is named **Steakhouse Financial** except the three called out below. The rest are Steakhouse's own empty deployments and contribute nothing.

### The three exceptions, stated plainly

Two of the added deployers also created vaults Morpho labels **Waterline**:

- Waterline Reservoir USDC `0xBEeFF047C03714965a54b671A37C18beF6b96210`, $16.5M, shares deployer `0x966cdEEf` with 3F x Steakhouse USDC
- M1 USDC `0xAb5955EB671d150527f8E61A42B703832F86616C`, $8.4M, shares deployer `0x25FC1650` with Confidential Prime USDC

Waterline was confirmed as Steakhouse's own white-label service line by @yelidrissi on DefiLlama/DefiLlama-Adapters#20375, when the same question came up on the TVL side, so I have counted them here. If you would rather keep them separate, the fix is to list the Steakhouse vaults from those two deployers by address instead of by owner and drop the two addresses. Happy to push that if you prefer it.

Safe x Steakhouse Prime Instant `0xbeef0D24920098C404c7Fc7942ee6d0f66d65D57` ($1.9M) has no curator set in Morpho's API. It shares deployer `0x328dc4a2` with Prime EURCV.

### Deliberately left out

Trezor Steakhouse USDT Prime `0xE4DB1c5A...` ($19.1M) and Trezor Steakhouse USDC Prime `0xde6c23E5...` ($11.3M). Morpho lists no curator for either, and their deployers created nothing else, so the only evidence is the vault name. That is not enough to attribute them.

### Test

`npm run test fees steakhouse`, daily fees / revenue, before -> after:

| chain | fees | revenue |
| --- | --- | --- |
| ethereum | 42.69k -> 98.13k | 1.91k -> 2.50k |
| base | 110.70k -> 139.76k | 4.58k -> 10.31k |
| katana | 506 -> 550 | 51 -> 55 |
| arbitrum / monad / robinhood | unchanged | unchanged |

The added ethereum fees work out to 5.1% a year against the roughly $394M added there, and the added base fees to 2.8% against roughly $383M.

Revenue moves the way the fee schedules say it should. Base revenue over added fees is 19.7%, in line with High Yield USDC Edition charging a 25% performance fee and Ethena x Steakhouse 5%. Ethereum only adds 1.1%, which is expected because Prime EURCV, Prime USDC and High Yield USDC all have `performanceFee` 0.
