### PR TITLE
[fix] hoodfrens - value pack claims by tx.value so historical runs work

### DIFF
--- a/dexs/hoodfrens/index.ts
+++ b/dexs/hoodfrens/index.ts
@@ -155,9 +155,20 @@ const fetch = async (options: FetchOptions) => {
             // backoff, like the sequential getLogs calls above.
             const txHashes: string[] = [...new Set<string>(claimLogs.map((l: any) => String(l.transactionHash).toLowerCase()))];
             const provider = getProvider(CHAIN.ROBINHOOD);
+            // Retry budget for per-tx lookups on the public Robinhood RPC.
+            // The RPC rate-limits bursts but recovers within about a second;
+            // there is no published rate-limit policy to cite, so the budget
+            // is empirical: sequential fetches with this backoff completed
+            // 711/711 claim txs (incl. the 336-tx day) without exhausting a
+            // single retry budget, while helpers/getTxReceipts' concurrency-20
+            // pool tripped the limiter. 4 attempts with 500ms linear backoff
+            // (0, 500, 1000, 1500ms) caps a hopeless tx at ~3s before the
+            // fail-loud throw below.
+            const TX_FETCH_ATTEMPTS = 4;
+            const TX_FETCH_BACKOFF_MS = 500;
             const withRetry = async (fn: () => Promise<any>): Promise<any> => {
-                for (let attempt = 0; attempt < 4; attempt++) {
-                    if (attempt) await new Promise((r) => setTimeout(r, 500 * attempt));
+                for (let attempt = 0; attempt < TX_FETCH_ATTEMPTS; attempt++) {
+                    if (attempt) await new Promise((r) => setTimeout(r, TX_FETCH_BACKOFF_MS * attempt));
                     const res = await fn().catch(() => null);
                     if (res) return res;
                 }

--- a/dexs/hoodfrens/index.ts
+++ b/dexs/hoodfrens/index.ts
@@ -1,6 +1,7 @@
 import { FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 import { METRIC } from "../../helpers/metrics";
+import { getProvider } from "@defillama/sdk";
 
 // hoodfrens is a creator-fee fork of the audited TopStrike bonding-curve
 // contract, running on Robinhood Chain (chainId 4663). This adapter mirrors
@@ -10,11 +11,10 @@ import { METRIC } from "../../helpers/metrics";
 const TRADING_CONTRACT = "0xA50AdeC47FcCBDe24B0214A831d3BDde4A1E0106";
 
 // Pack shop — Thirdweb DropERC1155 (Edition Drop) on Robinhood Chain. Its
-// TokensClaimed event and getClaimConditionById return tuple match the ABIs
-// below exactly (checked against the Blockscout-verified implementation ABI,
-// 2026-07-25; sales priced in native ETH — currency is the 0xEee… sentinel the
-// claim block maps to the gas token). getLogs returns nothing on days without a
-// claim, so the pack-sales path is a no-op until packs actually sell.
+// TokensClaimed event matches the ABI below (checked against the
+// Blockscout-verified implementation ABI, 2026-07-25; claims are priced in
+// native ETH). getLogs returns nothing on days without a claim, so the
+// pack-sales path is a no-op until packs actually sell.
 const PACKSHOP_CONTRACT = "0x3647b90F769B473E7bCf3267D030E009705fd99D";
 
 const TRADE_EVENT_ABI =
@@ -40,17 +40,33 @@ const CREATOR_FEE_PAID_ABI =
 const CREATOR_FEE_ACCRUED_ABI =
     "event CreatorFeeAccrued(uint256 indexed playerId, uint256 amountInWei)";
 
-// Thirdweb DropERC1155 pack shop. TokensClaimed carries quantity but not
-// price — we look up pricePerToken via getClaimConditionById for each
-// unique (tokenId, claimConditionIndex) pair seen in the day's logs.
+// Thirdweb DropERC1155 pack shop. TokensClaimed carries quantity but not the
+// price paid — claims are valued from the claim transaction's tx.value rather
+// than a getClaimConditionById lookup. The contract's native-currency claim
+// path requires msg.value == pricePerToken * quantityClaimed, so for a direct
+// claim tx the value IS the sale amount — and, unlike contract state at a
+// historical block, transactions are never pruned. The previous
+// getClaimConditionById approach ran an eth_call pinned to the day's block,
+// and the public Robinhood RPC prunes state to a ~100-minute horizon
+// ("metadata is not found"), which made every historical run (backfill /
+// refill) of a pack-sale day fail permanently. Live runs were unaffected,
+// which is how the fees dimension stayed complete while dexs lost days.
+//
+// PRECONDITION: claim conditions are priced in NATIVE ETH (true for every
+// condition to date). tx.value cannot see an ERC20 payment, so a zero-value
+// claim is ambiguous: genuinely free (allowlisted distributions are real and
+// common), or priced in a token. The zero-value path below disambiguates via
+// the tx RECEIPT (also never pruned): an ERC20-priced claim must move a token
+// in the claim tx, a free claim moves none — and it fails loudly on the
+// former rather than silently scoring it as zero.
 const TOKENS_CLAIMED_ABI =
     "event TokensClaimed(uint256 indexed claimConditionIndex, address indexed claimer, address indexed receiver, uint256 tokenId, uint256 quantityClaimed)";
 
-const GET_CLAIM_CONDITION_ABI =
-    "function getClaimConditionById(uint256 _tokenId, uint256 _conditionId) view returns ((uint256 startTimestamp, uint256 maxClaimableSupply, uint256 supplyClaimed, uint256 quantityLimitPerWallet, bytes32 merkleRoot, uint256 pricePerToken, address currency, string metadata) condition)";
-
-const NATIVE_ETH = "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee";
-const NULL_ADDRESS = "0x0000000000000000000000000000000000000000";
+// keccak256("Transfer(address,address,uint256)") — ERC20 Transfer has 3 topics
+// (ERC721's shares topic0 but has 4; the claim's own ERC1155 TransferSingle
+// has a different topic0 entirely).
+const ERC20_TRANSFER_TOPIC =
+    "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef";
 
 // Trade.feeInWei carries the total user-paid fee on every fee-generating path
 // (IPO buy + all sells): the contract builds it as
@@ -126,51 +142,53 @@ const fetch = async (options: FetchOptions) => {
         const claimLogs = await options.getLogs({
             target: PACKSHOP_CONTRACT,
             eventAbi: TOKENS_CLAIMED_ABI,
+            entireLog: true,
         });
 
         if (claimLogs.length > 0) {
-            // Dedupe (tokenId, conditionIndex) pairs before resolving prices —
-            // many claims share the same active condition during a window.
-            const pairKey = (tokenId: any, conditionId: any) =>
-                `${tokenId.toString()}-${conditionId.toString()}`;
-            const uniquePairs = new Map<string, { tokenId: any; conditionId: any }>();
-            for (const log of claimLogs) {
-                const key = pairKey(log.tokenId, log.claimConditionIndex);
-                if (!uniquePairs.has(key)) {
-                    uniquePairs.set(key, {
-                        tokenId: log.tokenId,
-                        conditionId: log.claimConditionIndex,
-                    });
+            // A tx can batch several claims (multicall), and its value covers
+            // all of them — count each transaction's value exactly once.
+            // Raw provider rather than FetchOptions on purpose: FetchOptions
+            // has no transaction surface, and helpers/getTxReceipts' fixed
+            // concurrency-20 pool trips this RPC's burst limiting on heavy
+            // pack days (336 claim txs on 2026-07-28). Sequential with
+            // backoff, like the sequential getLogs calls above.
+            const txHashes: string[] = [...new Set<string>(claimLogs.map((l: any) => String(l.transactionHash).toLowerCase()))];
+            const provider = getProvider(CHAIN.ROBINHOOD);
+            const withRetry = async (fn: () => Promise<any>): Promise<any> => {
+                for (let attempt = 0; attempt < 4; attempt++) {
+                    if (attempt) await new Promise((r) => setTimeout(r, 500 * attempt));
+                    const res = await fn().catch(() => null);
+                    if (res) return res;
                 }
-            }
-            const pairs = [...uniquePairs.values()];
-            // No permitFailure: a claim log always carries a claimConditionIndex
-            // that existed at claim time, so an unresolved condition means a bad
-            // read, not a real state. Fail loudly rather than under-report packs.
-            const conditions = await options.api.multiCall({
-                target: PACKSHOP_CONTRACT,
-                abi: GET_CLAIM_CONDITION_ABI,
-                calls: pairs.map((p) => ({ params: [p.tokenId, p.conditionId] })),
-            });
-
-            const priceByPair = new Map<string, { price: bigint; currency: string }>();
-            pairs.forEach((p, i) => {
-                const c = conditions[i];
-                if (!c) throw new Error(`hoodfrens: unresolved pack claim condition (token ${p.tokenId}, index ${p.conditionId})`);
-                priceByPair.set(pairKey(p.tokenId, p.conditionId), {
-                    price: BigInt(c.pricePerToken),
-                    currency: String(c.currency).toLowerCase(),
-                });
-            });
-
-            for (const log of claimLogs) {
-                const cond = priceByPair.get(pairKey(log.tokenId, log.claimConditionIndex));
-                if (!cond) throw new Error(`hoodfrens: missing price for pack claim (token ${log.tokenId}, index ${log.claimConditionIndex})`);
-                if (cond.currency === NATIVE_ETH) cond.currency = NULL_ADDRESS;
-                const paid = cond.price * BigInt(log.quantityClaimed);
-                if (paid === 0n) continue;
+                return null;
+            };
+            for (const hash of txHashes) {
+                const tx: any = await withRetry(() => provider.getTransaction(hash));
+                // Fail loudly rather than under-report packs (same stance as
+                // the previous condition-lookup version took).
+                if (!tx) throw new Error(`hoodfrens: could not load pack claim tx ${hash}`);
+                if (String(tx.to).toLowerCase() !== PACKSHOP_CONTRACT.toLowerCase())
+                    throw new Error(`hoodfrens: pack claim routed through ${tx.to} (tx ${hash}) — tx.value is not attributable, extend the claim block`);
+                const paid = BigInt(tx.value ?? 0);
+                if (paid === 0n) {
+                    // Free (allowlisted) claims are real distributions and
+                    // correctly score zero — but an ERC20-priced condition
+                    // would ALSO arrive here, and silently zeroing it is the
+                    // exact failure shape this adapter version exists to fix.
+                    // The receipt (never pruned) distinguishes: token payment
+                    // moves an ERC20 in the claim tx, a free claim does not.
+                    const receipt: any = await withRetry(() => provider.getTransactionReceipt(hash));
+                    if (!receipt) throw new Error(`hoodfrens: could not load receipt for zero-value pack claim tx ${hash}`);
+                    const movedErc20 = (receipt.logs ?? []).some(
+                        (l: any) => l.topics?.[0] === ERC20_TRANSFER_TOPIC && l.topics.length === 3,
+                    );
+                    if (movedErc20)
+                        throw new Error(`hoodfrens: zero-value pack claim tx ${hash} moved an ERC20 — token-priced claim condition? tx.value cannot price it, extend the claim block`);
+                    continue; // genuinely free claim — no volume
+                }
                 // Volume only — mint proceeds are not fees (see header comment).
-                dailyVolume.add(cond.currency, paid, 'Pack Sales');
+                dailyVolume.addGasToken(paid, 'Pack Sales');
             }
         }
     }


### PR DESCRIPTION
### What

Values pack-shop primary mints by the claim transaction's `tx.value` instead of a `getClaimConditionById` state read. No change to trading volume, fees, or revenue accounting — only how the `Pack Sales` volume line is priced.

### The issue

The hoodfrens **dexs** dimension is missing **2026-07-11 → 2026-07-28** (~$155k of volume; the protocol page currently shows ~$141k cumulative vs ~$296k true). The **fees** dimension is complete for the same days, which looks contradictory since both come from the same `fetch` — the explanation:

- The adapter merged 2026-07-30 (#8414), so all earlier days depend on a historical refill. The fees dimension got one; the dexs dimension has only a single day (07-23) plus live collection from 07-29.
- Days **07-11 → 07-24** have no pack claims, are pure `getLogs`, and re-run fine today — they just need the refill.
- Days **07-25 → 07-28** (pack sales started 07-25) could **never** be refilled with the current code: `getClaimConditionById` runs as an `eth_call` pinned to the day's historical block, and the only RPC configured for `robinhood` (`https://rpc.mainnet.chain.robinhood.com`) **prunes state to a ~100-minute horizon** — older calls fail with `metadata is not found` (verified by binary-searching the state cutoff). Live hourly runs are always inside the horizon, which is exactly why fees stayed complete while dexs lost days; the same loss would recur any time a live run slips more than ~2 hours on a pack-sale day.

### The fix

`tx.value` is exact for this contract: Thirdweb `DropERC1155`'s native-currency claim path requires `msg.value == pricePerToken × quantityClaimed`, and transactions (unlike historical state) are never pruned, so backfills and refills work at any age. Details:

- Values are deduped per transaction — a multicall tx's value covers all its claims.
- Transactions are fetched sequentially via a raw provider: `FetchOptions` has no transaction surface, and `helpers/getTxReceipts`' fixed concurrency-20 pool trips this RPC's burst limiting (336 claim txs on 2026-07-28) — same reason the adapter's getLogs calls are sequential.
- The adapter throws on a claim routed through an intermediary contract rather than guessing. All 711 claims to date are direct EOA→drop transactions, and Σ `tx.value` matches the protocol's internal pack-revenue accounting to the wei (10.1215 ETH).
- **Native-ETH pricing is a stated precondition, guarded fail-loud.** A zero-value claim is ambiguous — genuinely free (allowlisted distributions are real: 128 of 711 claims to date) or an ERC20-priced condition `tx.value` cannot see. The adapter disambiguates via the claim tx's **receipt** (also never pruned): an ERC20-priced claim must move a token in the claim tx, a free claim moves none — and it throws on the former rather than silently scoring a paid claim as zero. Free claims score zero volume by design, so the `Pack Sales` line can legitimately go flat during free-distribution periods.

### Verification (`npm test dexs hoodfrens <date>`)

| UTC day | old code | new code | cross-check |
|---|---|---|---|
| 2026-07-25 | ❌ `metadata is not found` | vol $5.91k · fees $245.12 | stored fees $245 ✓ |
| 2026-07-26 | ❌ | vol $2.83k · fees $175.51 | stored fees $176 ✓ |
| 2026-07-27 | ❌ | vol $21.07k · fees $1.11k | stored fees $1,113 ✓ |
| 2026-07-28 | ❌ | vol $48.23k · fees $2.20k | stored fees $2,196 ✓ |
| 2026-08-05 (control) | collected live → $35,887 stored | $35.72k | old vs new method agree to 0.5% ✓ |
| 2026-08-07 (control, all claims free) | $10,155 stored | $10.18k | receipt guard passes every free claim, packs = 0 ✓ |

The 2026-08-05 control is the equivalence proof: that day was collected live with the old condition-read pricing, and `tx.value` reproduces it (residual is hourly-vs-daily ETH pricing). The 2026-08-07 control exercises the zero-value receipt path on a day where every claim was a free allowlisted distribution.

Per-day **pack volume** (the line this PR re-prices) cross-checked against the protocol's internal sales records, wei-exact:

| UTC day | on-chain tx.value | internal records |
|---|---|---|
| 2026-07-25 | 0.00003 ETH | 0.00003 ✓ |
| 2026-07-26 | 0.00015 ETH | 0.00015 ✓ |
| 2026-07-27 | 0.00029 ETH | 0.00029 ✓ |
| 2026-07-28 | 6.82205 ETH | 6.82205 ✓ |
| all-time Σ | 10.1215 ETH | 10.122 ✓ |

### ⚠️ Refill needed after merge

Please refill the **dexs** dimension for `hoodfrens` from **2026-07-11 → 2026-07-28** inclusive (the fees dimension needs nothing). Without this PR the refill would fail on 07-25 → 07-28; with it, every day runs. Expected daily volumes from an independent on-chain reconciliation (ETH-exact, priced at daily historical rates): 07-11→22 ≈ $56.7k total, 07-23 already stored ($22,567), 07-24 ≈ $20.4k, 07-25→28 ≈ $77.6k — cumulative volume should land ≈ **$296k**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
