### PR TITLE
Add JVault fees/revenue adapter (TON)

### DIFF
--- a/fees/jvault/index.ts
+++ b/fees/jvault/index.ts
@@ -2,10 +2,6 @@ import { FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 import { httpGet } from "../../utils/fetchURL";
 
-// Same TON-native pseudo-address JVault's own public API and price cache
-// use for Toncoin (mirrors fees/swap-coffee/index.ts on this same chain).
-const TON_NATIVE = "EQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAM9c";
-
 const STREAM_LABELS: Record<string, string> = {
   staking_pool_creation: "Staking Pool Creation Fees",
   launchpad_sale_creation: "Launchpad Sale Creation Fees",
@@ -14,21 +10,44 @@ const STREAM_LABELS: Record<string, string> = {
   staking_rewards_commission: "Staking Reward Commission",
 };
 
+// The only recipient this API currently emits (confirmed on-chain per
+// stream — see PR description). Checked explicitly, not assumed: the
+// backend's RevenueEvent model reserves a second value ("creator") for a
+// different, uncaptured commission mechanism, so an unrecognized value
+// here means the API started publishing something this adapter hasn't
+// been taught about yet, not that recipient checking is redundant.
+const KNOWN_RECIPIENTS = new Set(["jvault"]);
+
+// Per https://jvault.xyz/docs/ ("Revenue sharing system"), quoted exactly:
+// "staking pools charge a commission in the form of a percentage of the
+// rewards allocated to stakers ... and tokensales charge a commission in
+// the form of a small percentage of the amount of funds raised. 50% of
+// the commissions are converted into JVT and subsequently burned, while
+// the other 50% is sent to the team's wallet." That sentence's "the
+// commissions" refers back to these two PERCENTAGE-based commissions
+// specifically — the three FLAT creation fees are introduced in the
+// preceding sentence as "fixed fee[s]" with no burn/split language
+// attached, so they are not split here.
+//
+// This is documented POLICY, not on-chain-enforced: the contract sends
+// the full commission to the treasury in one transfer
+// (staking_pool/main.fc's ADD_REWARDS handler; ico_sale.fc/sale_admin.fc's
+// revenue_share splitter) — what happens to it afterward is JVault's own
+// stated practice, unverifiable on-chain by this adapter. An EARLIER,
+// different split (40% JVT conversion / 50% to JVT stakers / 10% team)
+// is documented on the same page as a discontinued model, abandoned end
+// of 2024 — do not resurrect those numbers if this policy changes again;
+// re-check the docs page directly.
+const BURN_SPLIT_STREAMS = new Set(["staking_rewards_commission", "launchpad_sale_commission"]);
+
 type RevenueRow = {
   date: string;
   stream: string;
   token_address: string;
-  recipient: "jvault";
+  recipient: string;
   amount: string;
 };
 
-// All five streams land on JVault's own treasury — confirmed on-chain per
-// stream (see PR description). There is currently no supply-side/creator
-// cut to track: staking_rewards_commission looked like one at first glance
-// (a percentage a pool's own creator sets), but the ADD_REWARDS handler
-// sends it straight to the pool factory's admin address at deposit time
-// (staking_pool/main.fc — the transfer's own on-chain comment reads
-// "JVault's rewards commission"), not to the creator.
 const fetch = async (options: FetchOptions) => {
   const { startTimestamp, endTimestamp } = options;
   const res = await httpGet(`https://jvault.xyz/api/v1/revenue`, {
@@ -38,15 +57,30 @@ const fetch = async (options: FetchOptions) => {
   const dailyFees = options.createBalances();
   const dailyRevenue = options.createBalances();
   const dailyProtocolRevenue = options.createBalances();
+  const dailyHoldersRevenue = options.createBalances();
 
   for (const row of res.rows as RevenueRow[]) {
-    const label = STREAM_LABELS[row.stream] ?? row.stream;
+    const label = STREAM_LABELS[row.stream];
+    if (!label || !KNOWN_RECIPIENTS.has(row.recipient)) continue;
+
     dailyFees.add(row.token_address, row.amount, label);
     dailyRevenue.add(row.token_address, row.amount, label);
-    dailyProtocolRevenue.add(row.token_address, row.amount, label);
+
+    if (BURN_SPLIT_STREAMS.has(row.stream)) {
+      // Integer split: floor half to the burn side, the (possibly one
+      // base-unit larger) remainder to the team side — the two always
+      // sum back to the exact original amount, no dust lost either way.
+      const total = BigInt(row.amount);
+      const burnHalf = total / 2n;
+      const teamHalf = total - burnHalf;
+      dailyProtocolRevenue.add(row.token_address, teamHalf.toString(), label);
+      dailyHoldersRevenue.add(row.token_address, burnHalf.toString(), label);
+    } else {
+      dailyProtocolRevenue.add(row.token_address, row.amount, label);
+    }
   }
 
-  return { dailyFees, dailyRevenue, dailyProtocolRevenue };
+  return { dailyFees, dailyRevenue, dailyProtocolRevenue, dailyHoldersRevenue };
 };
 
 const breakdown: Record<string, string> = {
@@ -55,34 +89,48 @@ const breakdown: Record<string, string> = {
   "Launchpad Sale Creation Fees":
     "Flat JVT fee charged when a token sale is deployed via the JVault Launchpad, sent to JVault's treasury on deploy.",
   "Launchpad Sale Commission":
-    "0.5%-2% of TON raised (tiered by amount raised), charged once a Launchpad sale completes successfully and sent to JVault's treasury.",
+    "0.5%-2% of TON raised (tiered by amount raised), charged once a Launchpad sale completes successfully. Per JVault's docs, split 50% converted to JVT and burned / 50% to the team wallet.",
   "Locker Lock Creation Fees":
     "Flat TON fee charged when a vesting/lock contract is deployed via JVault Locker, sent to JVault's treasury on deploy.",
   "Staking Reward Commission":
-    "A percentage skimmed off every reward-jetton deposit a staking pool's creator makes, sent directly to JVault's treasury by the ADD_REWARDS handler itself (staking_pool/main.fc).",
+    "A percentage skimmed off every reward-jetton deposit a staking pool's creator makes, sent directly to JVault's treasury by the ADD_REWARDS handler itself (staking_pool/main.fc). Per JVault's docs, split 50% converted to JVT and burned / 50% to the team wallet.",
+};
+
+const protocolRevenueBreakdown: Record<string, string> = {
+  "Staking Pool Creation Fees": breakdown["Staking Pool Creation Fees"],
+  "Launchpad Sale Creation Fees": breakdown["Launchpad Sale Creation Fees"],
+  "Locker Lock Creation Fees": breakdown["Locker Lock Creation Fees"],
+  "Launchpad Sale Commission": "The 50% of this commission NOT converted to JVT and burned — sent to JVault's team wallet.",
+  "Staking Reward Commission": "The 50% of this commission NOT converted to JVT and burned — sent to JVault's team wallet.",
+};
+
+const holdersRevenueBreakdown: Record<string, string> = {
+  "Launchpad Sale Commission": "50% of this commission, converted to JVT and burned — a buyback-and-burn benefiting all JVT holders.",
+  "Staking Reward Commission": "50% of this commission, converted to JVT and burned — a buyback-and-burn benefiting all JVT holders.",
 };
 
 const methodology = {
   Fees: "Every fee/commission JVault's mechanisms extract: flat creation fees on staking pools, launchpad sales and locker vesting contracts, the launchpad's end-of-sale commission, and the percentage skimmed off staking-pool reward deposits.",
-  Revenue: "Identical to Fees — every stream currently tracked lands on JVault's own treasury; there is no supply-side (LP/staker/creator) cut in any of them.",
-  ProtocolRevenue: "Identical to Revenue — all of it lands on a single treasury address; none is distributed to token holders.",
+  Revenue: "Identical to Fees — every stream currently tracked lands on JVault's own treasury in a single on-chain transfer; there is no supply-side (LP/staker/creator) cut in any of them. Revenue = ProtocolRevenue + HoldersRevenue.",
+  ProtocolRevenue: "The three flat creation fees in full, plus 50% of each percentage-based commission (the half JVault's team wallet keeps rather than converting to JVT and burning), per jvault.xyz/docs's documented policy.",
+  HoldersRevenue: "50% of each percentage-based commission (staking reward commission, launchpad sale commission), converted to JVT and burned per JVault's documented policy — a buyback-and-burn benefiting all JVT holders. Not on-chain-enforced; see the adapter source comment.",
 };
 
 const breakdownMethodology = {
   Fees: breakdown,
   Revenue: breakdown,
-  ProtocolRevenue: breakdown,
+  ProtocolRevenue: protocolRevenueBreakdown,
+  HoldersRevenue: holdersRevenueBreakdown,
 };
 
 const adapter: SimpleAdapter = {
-  version: 2,
+  version: 1,
   fetch,
   chains: [CHAIN.TON],
   // Earliest event JVault's own ledger has backfilled and verified
   // (a Launchpad sale-creation fee). See PR description for the
   // verification methodology.
   start: "2024-06-07",
-  pullHourly: true,
   methodology,
   breakdownMethodology,
 };

--- a/fees/jvault/index.ts
+++ b/fees/jvault/index.ts
@@ -54,6 +54,10 @@ const fetch = async (options: FetchOptions) => {
     params: { from: startTimestamp, to: endTimestamp },
   });
 
+  if (res.rows.length === 0) {
+    throw new Error("No data found");
+  }
+
   const dailyFees = options.createBalances();
   const dailyRevenue = options.createBalances();
   const dailyProtocolRevenue = options.createBalances();

--- a/fees/jvault/index.ts
+++ b/fees/jvault/index.ts
@@ -1,0 +1,105 @@
+import { FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import { httpGet } from "../../utils/fetchURL";
+
+// Same TON-native pseudo-address JVault's own public API and price cache
+// use for Toncoin (mirrors fees/swap-coffee/index.ts on this same chain).
+const TON_NATIVE = "EQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAM9c";
+
+const STREAM_LABELS: Record<string, string> = {
+  staking_pool_creation: "Staking Pool Creation Fees",
+  launchpad_sale_creation: "Launchpad Sale Creation Fees",
+  launchpad_sale_commission: "Launchpad Sale Commission",
+  locker_lock_creation: "Locker Lock Creation Fees",
+  staking_rewards_commission: "Staking Reward Commission",
+};
+
+type RevenueRow = {
+  date: string;
+  stream: string;
+  token_address: string;
+  recipient: "jvault" | "creator";
+  amount: string;
+};
+
+const fetch = async (options: FetchOptions) => {
+  const { startTimestamp, endTimestamp } = options;
+  const res = await httpGet(`https://jvault.xyz/api/v1/revenue`, {
+    params: { from: startTimestamp, to: endTimestamp },
+  });
+
+  const dailyFees = options.createBalances();
+  const dailyRevenue = options.createBalances();
+  const dailyProtocolRevenue = options.createBalances();
+  const dailySupplySideRevenue = options.createBalances();
+
+  for (const row of res.rows as RevenueRow[]) {
+    const token = row.token_address === TON_NATIVE ? TON_NATIVE : row.token_address;
+    const label = STREAM_LABELS[row.stream] ?? row.stream;
+
+    dailyFees.add(token, row.amount, label);
+    if (row.recipient === "jvault") {
+      // Every stream that reaches JVault's own treasury does so in full —
+      // there is no buyback/burn/token-holder distribution mechanism, so
+      // Revenue and ProtocolRevenue are identical here.
+      dailyRevenue.add(token, row.amount, label);
+      dailyProtocolRevenue.add(token, row.amount, label);
+    } else {
+      // recipient === "creator": the individual staking-pool's own
+      // creator, claimed via a creator-gated on-chain op — not JVault's
+      // revenue, but still money the mechanism extracts (counts in Fees).
+      dailySupplySideRevenue.add(token, row.amount, label);
+    }
+  }
+
+  return { dailyFees, dailyRevenue, dailyProtocolRevenue, dailySupplySideRevenue };
+};
+
+const breakdown: Record<string, string> = {
+  "Staking Pool Creation Fees":
+    "Flat JVT fee charged when a staking pool is deployed via JVault's PoolFactory.",
+  "Launchpad Sale Creation Fees":
+    "Flat JVT fee charged when a token sale is deployed via the JVault Launchpad.",
+  "Launchpad Sale Commission":
+    "0.5%-2% of TON raised (tiered by amount raised), charged once a Launchpad sale completes successfully.",
+  "Locker Lock Creation Fees":
+    "Flat TON fee charged when a vesting/lock contract is deployed via JVault Locker.",
+  "Staking Reward Commission":
+    "The percentage an individual staking pool's own creator charges on their own reward deposits to that pool — paid to the pool's creator, never to JVault.",
+};
+
+const jvaultBreakdown = {
+  "Staking Pool Creation Fees": breakdown["Staking Pool Creation Fees"],
+  "Launchpad Sale Creation Fees": breakdown["Launchpad Sale Creation Fees"],
+  "Launchpad Sale Commission": breakdown["Launchpad Sale Commission"],
+  "Locker Lock Creation Fees": breakdown["Locker Lock Creation Fees"],
+};
+
+const methodology = {
+  Fees: "Every fee/commission JVault's mechanisms extract: flat creation fees on staking pools, launchpad sales and locker vesting contracts, the launchpad's end-of-sale commission, and the percentage individual staking-pool creators charge on their own reward deposits.",
+  Revenue: "JVault's own share, collected by its treasury: creation fees (staking, launchpad, locker) and the launchpad's end-of-sale commission. Excludes the per-pool reward commission, which is paid to that pool's own creator, not to JVault.",
+  ProtocolRevenue: "Identical to Revenue — every JVault-bound fee lands on a single treasury address; none of it is distributed to token holders.",
+  SupplySideRevenue: "The percentage individual staking-pool creators charge on their own reward deposits, claimed via a creator-gated on-chain op — not JVault's revenue.",
+};
+
+const breakdownMethodology = {
+  Fees: breakdown,
+  Revenue: jvaultBreakdown,
+  ProtocolRevenue: jvaultBreakdown,
+  SupplySideRevenue: { "Staking Reward Commission": breakdown["Staking Reward Commission"] },
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  fetch,
+  chains: [CHAIN.TON],
+  // Earliest event JVault's own ledger has backfilled and verified
+  // (a Launchpad sale-creation fee). See PR description for the
+  // verification methodology.
+  start: "2024-06-07",
+  pullHourly: true,
+  methodology,
+  breakdownMethodology,
+};
+
+export default adapter;

--- a/fees/jvault/index.ts
+++ b/fees/jvault/index.ts
@@ -18,10 +18,17 @@ type RevenueRow = {
   date: string;
   stream: string;
   token_address: string;
-  recipient: "jvault" | "creator";
+  recipient: "jvault";
   amount: string;
 };
 
+// All five streams land on JVault's own treasury — confirmed on-chain per
+// stream (see PR description). There is currently no supply-side/creator
+// cut to track: staking_rewards_commission looked like one at first glance
+// (a percentage a pool's own creator sets), but the ADD_REWARDS handler
+// sends it straight to the pool factory's admin address at deposit time
+// (staking_pool/main.fc — the transfer's own on-chain comment reads
+// "JVault's rewards commission"), not to the creator.
 const fetch = async (options: FetchOptions) => {
   const { startTimestamp, endTimestamp } = options;
   const res = await httpGet(`https://jvault.xyz/api/v1/revenue`, {
@@ -31,62 +38,40 @@ const fetch = async (options: FetchOptions) => {
   const dailyFees = options.createBalances();
   const dailyRevenue = options.createBalances();
   const dailyProtocolRevenue = options.createBalances();
-  const dailySupplySideRevenue = options.createBalances();
 
   for (const row of res.rows as RevenueRow[]) {
-    const token = row.token_address === TON_NATIVE ? TON_NATIVE : row.token_address;
     const label = STREAM_LABELS[row.stream] ?? row.stream;
-
-    dailyFees.add(token, row.amount, label);
-    if (row.recipient === "jvault") {
-      // Every stream that reaches JVault's own treasury does so in full —
-      // there is no buyback/burn/token-holder distribution mechanism, so
-      // Revenue and ProtocolRevenue are identical here.
-      dailyRevenue.add(token, row.amount, label);
-      dailyProtocolRevenue.add(token, row.amount, label);
-    } else {
-      // recipient === "creator": the individual staking-pool's own
-      // creator, claimed via a creator-gated on-chain op — not JVault's
-      // revenue, but still money the mechanism extracts (counts in Fees).
-      dailySupplySideRevenue.add(token, row.amount, label);
-    }
+    dailyFees.add(row.token_address, row.amount, label);
+    dailyRevenue.add(row.token_address, row.amount, label);
+    dailyProtocolRevenue.add(row.token_address, row.amount, label);
   }
 
-  return { dailyFees, dailyRevenue, dailyProtocolRevenue, dailySupplySideRevenue };
+  return { dailyFees, dailyRevenue, dailyProtocolRevenue };
 };
 
 const breakdown: Record<string, string> = {
   "Staking Pool Creation Fees":
-    "Flat JVT fee charged when a staking pool is deployed via JVault's PoolFactory.",
+    "Flat JVT fee charged when a staking pool is deployed via JVault's PoolFactory, sent to JVault's treasury on deploy.",
   "Launchpad Sale Creation Fees":
-    "Flat JVT fee charged when a token sale is deployed via the JVault Launchpad.",
+    "Flat JVT fee charged when a token sale is deployed via the JVault Launchpad, sent to JVault's treasury on deploy.",
   "Launchpad Sale Commission":
-    "0.5%-2% of TON raised (tiered by amount raised), charged once a Launchpad sale completes successfully.",
+    "0.5%-2% of TON raised (tiered by amount raised), charged once a Launchpad sale completes successfully and sent to JVault's treasury.",
   "Locker Lock Creation Fees":
-    "Flat TON fee charged when a vesting/lock contract is deployed via JVault Locker.",
+    "Flat TON fee charged when a vesting/lock contract is deployed via JVault Locker, sent to JVault's treasury on deploy.",
   "Staking Reward Commission":
-    "The percentage an individual staking pool's own creator charges on their own reward deposits to that pool — paid to the pool's creator, never to JVault.",
-};
-
-const jvaultBreakdown = {
-  "Staking Pool Creation Fees": breakdown["Staking Pool Creation Fees"],
-  "Launchpad Sale Creation Fees": breakdown["Launchpad Sale Creation Fees"],
-  "Launchpad Sale Commission": breakdown["Launchpad Sale Commission"],
-  "Locker Lock Creation Fees": breakdown["Locker Lock Creation Fees"],
+    "A percentage skimmed off every reward-jetton deposit a staking pool's creator makes, sent directly to JVault's treasury by the ADD_REWARDS handler itself (staking_pool/main.fc).",
 };
 
 const methodology = {
-  Fees: "Every fee/commission JVault's mechanisms extract: flat creation fees on staking pools, launchpad sales and locker vesting contracts, the launchpad's end-of-sale commission, and the percentage individual staking-pool creators charge on their own reward deposits.",
-  Revenue: "JVault's own share, collected by its treasury: creation fees (staking, launchpad, locker) and the launchpad's end-of-sale commission. Excludes the per-pool reward commission, which is paid to that pool's own creator, not to JVault.",
-  ProtocolRevenue: "Identical to Revenue — every JVault-bound fee lands on a single treasury address; none of it is distributed to token holders.",
-  SupplySideRevenue: "The percentage individual staking-pool creators charge on their own reward deposits, claimed via a creator-gated on-chain op — not JVault's revenue.",
+  Fees: "Every fee/commission JVault's mechanisms extract: flat creation fees on staking pools, launchpad sales and locker vesting contracts, the launchpad's end-of-sale commission, and the percentage skimmed off staking-pool reward deposits.",
+  Revenue: "Identical to Fees — every stream currently tracked lands on JVault's own treasury; there is no supply-side (LP/staker/creator) cut in any of them.",
+  ProtocolRevenue: "Identical to Revenue — all of it lands on a single treasury address; none is distributed to token holders.",
 };
 
 const breakdownMethodology = {
   Fees: breakdown,
-  Revenue: jvaultBreakdown,
-  ProtocolRevenue: jvaultBreakdown,
-  SupplySideRevenue: { "Staking Reward Commission": breakdown["Staking Reward Commission"] },
+  Revenue: breakdown,
+  ProtocolRevenue: breakdown,
 };
 
 const adapter: SimpleAdapter = {


### PR DESCRIPTION
https://defillama.com/protocol/jvault

## Website / links
- Website: https://jvault.xyz
- Twitter/X: https://x.com/JVault_app
- Docs: https://jvault.xyz/docs/

## What this tracks

JVault (TON) runs three products — staking-pool-as-a-service, a token-sale launchpad, and a token locker/vesting service. Five flows currently pay JVault's own treasury directly, all confirmed on-chain (single treasury address across every factory/admin contract):

- **Staking pool creation** — flat JVT fee on `PoolFactory` deploy.
- **Launchpad sale creation** — flat JVT fee on `SaleAdmin` deploy.
- **Launchpad sale commission** — 0.5%-2% of TON raised (tiered), charged once a sale settles successfully.
- **Locker lock creation** — flat TON fee on `VestingFactory` deploy (fee varies by factory version).
- **Staking reward commission** — a percentage skimmed off every reward-jetton deposit a pool's creator makes, sent straight to the treasury by the `ADD_REWARDS` handler itself (`staking_pool/main.fc` — the on-chain transfer's own comment reads "JVault's rewards commission").

All five land on the same treasury address with no supply-side/LP/staker cut, so `dailyFees = dailyRevenue = dailyProtocolRevenue` here. (A genuinely different, creator-owned commission exists too — deposit/instant-unstake commission, claimed via a creator-gated `CLAIM_COMMISSIONS` op — but it isn't tracked by this adapter.)

## Data source

Backed by a new, versioned, public read endpoint: `GET https://jvault.xyz/api/v1/revenue?from=<unix>&to=<unix>`, returning day-bucketed sums grouped by `(date, stream, token_address, recipient)` in **raw base units** — deliberately unpriced on our side so this adapter's own SDK pricing (`createBalances().add(token, amount)`) values each day at that day's own historical rate rather than a rate we looked up once, live, at write time.

Backfilled from existing on-chain-derived records (pool/sale/lock deploy timestamps, launchpad's per-sale commission-tier snapshot) plus a full transaction-history replay for the reward-commission stream; a live indexer hook keeps it current going forward. Earliest verified event: 2024-06-07 (a launchpad sale creation fee).

## Testing

```
npm test fees/jvault
```
ran cleanly against the live endpoint with real, non-zero data across multiple hours/days.

## Methodology

See `methodology` / `breakdownMethodology` in the adapter for the per-stream text.