### PR TITLE
feat: add CallPut fees and revenue adapter

### DIFF
--- a/fees/callput/index.ts
+++ b/fees/callput/index.ts
@@ -6,6 +6,7 @@ import { CHAIN } from "../../helpers/chains";
 // https://basescan.org/address/0x780b6b94C0FfCf8E659727CE421e976C1b6784Bc
 const CONTROLLER = "0xfc61ba50AE7B9C4260C9f04631Ff28D5A2Fa4EB2";
 const FEE_DISTRIBUTOR = "0x780b6b94C0FfCf8E659727CE421e976C1b6784Bc";
+// Vault feeUsd values emitted by CollectPositionFees and CollectFees are USD amounts scaled by 1e30.
 const PRICE_PRECISION = 1e30;
 
 const POSITION_FEE_EVENT =
@@ -115,6 +116,10 @@ const fetch = async (options: FetchOptions): Promise<FetchResult> => {
 const adapter: SimpleAdapter = {
   version: 2,
   pullHourly: true,
+  chains: [CHAIN.BASE],
+  fetch,
+  // First production Controller volume event on Base.
+  start: "2026-01-30",
   methodology: {
     Fees:
       "Gross options trading, liquidity, and swap fees paid by CallPut users. Referral and copy-trading rebates are added back because Vault fee events report the net amount after rebates.",
@@ -151,13 +156,6 @@ const adapter: SimpleAdapter = {
         "Net options trading fees allocated to OLP liquidity providers.",
       [LIQUIDITY_FEES_TO_LPS]:
         "Net liquidity and swap fees allocated to OLP liquidity providers.",
-    },
-  },
-  adapter: {
-    [CHAIN.BASE]: {
-      fetch,
-      // First production Controller volume event on Base.
-      start: "2026-01-30",
     },
   },
 };

--- a/fees/callput/index.ts
+++ b/fees/callput/index.ts
@@ -6,10 +6,8 @@ import { CHAIN } from "../../helpers/chains";
 // https://basescan.org/address/0x780b6b94C0FfCf8E659727CE421e976C1b6784Bc
 const CONTROLLER = "0xfc61ba50AE7B9C4260C9f04631Ff28D5A2Fa4EB2";
 const FEE_DISTRIBUTOR = "0x780b6b94C0FfCf8E659727CE421e976C1b6784Bc";
-// USD values emitted by Vault and VaultUtils fee events are scaled by 1e30.
+// USD values emitted by Vault fee events are scaled by 1e30.
 const PRICE_PRECISION = 1e30;
-// IVaultUtils.PriceType enum: MP = 0, RP = 1.
-const RISK_PREMIUM_PRICE_TYPE = 1;
 
 const POSITION_FEE_EVENT =
   "event CollectPositionFees(address indexed account, address indexed token, uint256 feeUsd, uint256 feeAmount, bool indexed isSettle)";
@@ -17,17 +15,13 @@ const LIQUIDITY_FEE_EVENT =
   "event CollectFees(address indexed token, uint256 feeUsd, uint256 feeAmount)";
 const FEE_REBATE_EVENT =
   "event FeeRebate(address indexed from, address indexed to, address token, uint256 feeRebateAmount, uint256 feeAmount, uint256 afterFeePaidAmount, uint256 tokenSpotPrice, address indexed underlyingAsset, uint256 size, uint256 price, bool isSettle, bool isCopyTrade)";
-const PENDING_AMOUNT_EVENT =
-  "event NotifyPendingAmount(uint8 indexed priceType, address indexed token, uint256 pendingUsd, uint256 pendingAmount)";
 
 const OPTIONS_FEES = "Options Trading Fees";
 const LIQUIDITY_FEES = "Liquidity and Swap Fees";
-const RISK_PREMIUM = "Risk Premium";
 const OPTIONS_FEES_TO_PROTOCOL = "Options Trading Fees To Protocol";
 const LIQUIDITY_FEES_TO_PROTOCOL = "Liquidity and Swap Fees To Protocol";
 const OPTIONS_FEES_TO_LPS = "Options Trading Fees To LPs";
 const LIQUIDITY_FEES_TO_LPS = "Liquidity and Swap Fees To LPs";
-const RISK_PREMIUM_TO_LPS = "Risk Premium To OLPs";
 const REFERRAL_REBATES = "Options Fee Rebates To Referrers";
 const COPY_TRADING_REBATES = "Options Fee Rebates To Copy Traders";
 
@@ -40,10 +34,6 @@ const fetch = async (options: FetchOptions): Promise<FetchResult> => {
   const vaults: string[] = await options.toApi.call({
     target: CONTROLLER,
     abi: "function getVaults() view returns (address[3])",
-  });
-  const vaultUtils: string[] = await options.toApi.multiCall({
-    calls: vaults,
-    abi: "address:vaultUtils",
   });
 
   const positionFeeLogs = await options.getLogs({
@@ -58,10 +48,6 @@ const fetch = async (options: FetchOptions): Promise<FetchResult> => {
     targets: vaults,
     eventAbi: FEE_REBATE_EVENT,
   });
-  const pendingAmountLogs = await options.getLogs({
-    targets: vaultUtils,
-    eventAbi: PENDING_AMOUNT_EVENT,
-  });
 
   const positionFeesUsd = positionFeeLogs.reduce(
     (sum, log) => sum + Number(log.feeUsd) / PRICE_PRECISION,
@@ -71,27 +57,9 @@ const fetch = async (options: FetchOptions): Promise<FetchResult> => {
     (sum, log) => sum + Number(log.feeUsd) / PRICE_PRECISION,
     0,
   );
-  const riskPremiumUsd = pendingAmountLogs.reduce(
-    (sum, log) =>
-      sum +
-      (Number(log.priceType) === RISK_PREMIUM_PRICE_TYPE
-        ? Number(log.pendingUsd) / PRICE_PRECISION
-        : 0),
-    0,
-  );
-
-  // CollectPositionFees is emitted after rebates have been deducted. Add each
-  // rebate back to gross fees, and classify the payout as supply-side revenue.
-  for (const log of rebateLogs) {
-    const rebateLabel = log.isCopyTrade ? COPY_TRADING_REBATES : REFERRAL_REBATES;
-    dailyFees.add(log.token, log.feeRebateAmount, OPTIONS_FEES);
-    dailySupplySideRevenue.add(log.token, log.feeRebateAmount, rebateLabel);
-  }
 
   dailyFees.addUSDValue(positionFeesUsd, OPTIONS_FEES);
   dailyFees.addUSDValue(liquidityFeesUsd, LIQUIDITY_FEES);
-  dailyFees.addUSDValue(riskPremiumUsd, RISK_PREMIUM);
-  dailySupplySideRevenue.addUSDValue(riskPremiumUsd, RISK_PREMIUM_TO_LPS);
 
   // Rates sum to 100 in FeeDistributor. Treasury and governance allocations
   // are retained by the protocol; OLP rewards are paid to liquidity providers.
@@ -129,6 +97,15 @@ const fetch = async (options: FetchOptions): Promise<FetchResult> => {
     LIQUIDITY_FEES_TO_LPS,
   );
 
+  // Referral and copy-trading rebates are paid from the protocol's fee share,
+  // not additional user fees.
+  for (const log of rebateLogs) {
+    const rebateLabel = log.isCopyTrade ? COPY_TRADING_REBATES : REFERRAL_REBATES;
+    dailyRevenue.subtractToken(log.token, log.feeRebateAmount, OPTIONS_FEES_TO_PROTOCOL);
+    dailyProtocolRevenue.subtractToken(log.token, log.feeRebateAmount, OPTIONS_FEES_TO_PROTOCOL);
+    dailySupplySideRevenue.add(log.token, log.feeRebateAmount, rebateLabel);
+  }
+
   return {
     dailyFees,
     dailyRevenue,
@@ -146,32 +123,30 @@ const adapter: SimpleAdapter = {
   start: "2026-01-30",
   methodology: {
     Fees:
-      "Gross options trading fees, liquidity and swap fees, and risk premiums paid by CallPut users. Referral and copy-trading rebates are added back because Vault fee events report the net amount after rebates.",
+      "Options trading fees and liquidity and swap fees paid by CallPut users.",
     Revenue:
-      "The share of net fees allocated to the CallPut treasury and governance addresses, based on the FeeDistributor's onchain OLP reward rate.",
+      "The share of fees allocated to the CallPut treasury and governance addresses, based on the FeeDistributor's onchain OLP reward rate, minus referral and copy-trading rebates.",
     ProtocolRevenue:
-      "The share of net fees allocated to the CallPut treasury and governance addresses.",
+      "The share of fees allocated to the CallPut treasury and governance addresses, minus referral and copy-trading rebates.",
     SupplySideRevenue:
-      "Risk premiums earned by OLP liquidity providers, referral and copy-trading rebates, and any share of net fees allocated by FeeDistributor to OLPs.",
+      "Referral and copy-trading rebates, and any share of net fees allocated by FeeDistributor to OLPs.",
   },
   breakdownMethodology: {
     Fees: {
       [OPTIONS_FEES]:
-        "Gross fees charged when users open, close, or settle options positions, including referral and copy-trading rebates.",
+        "Fees charged when users open, close, or settle options positions.",
       [LIQUIDITY_FEES]:
         "Fees charged when users mint or redeem vault liquidity tokens or swap supported collateral assets.",
-      [RISK_PREMIUM]:
-        "The execution-price spread relative to mark price charged to options traders and accrued to OLP liquidity providers.",
     },
     Revenue: {
       [OPTIONS_FEES_TO_PROTOCOL]:
-        "Net options trading fees allocated to CallPut treasury and governance addresses.",
+        "Options trading fees allocated to CallPut treasury and governance addresses, net of referral and copy-trading rebates.",
       [LIQUIDITY_FEES_TO_PROTOCOL]:
         "Net liquidity and swap fees allocated to CallPut treasury and governance addresses.",
     },
     ProtocolRevenue: {
       [OPTIONS_FEES_TO_PROTOCOL]:
-        "Net options trading fees allocated to CallPut treasury and governance addresses.",
+        "Options trading fees allocated to CallPut treasury and governance addresses, net of referral and copy-trading rebates.",
       [LIQUIDITY_FEES_TO_PROTOCOL]:
         "Net liquidity and swap fees allocated to CallPut treasury and governance addresses.",
     },
@@ -182,8 +157,6 @@ const adapter: SimpleAdapter = {
         "Net options trading fees allocated to OLP liquidity providers.",
       [LIQUIDITY_FEES_TO_LPS]:
         "Net liquidity and swap fees allocated to OLP liquidity providers.",
-      [RISK_PREMIUM_TO_LPS]:
-        "Risk premiums accrued to OLP liquidity providers through VaultUtils pending RP amounts.",
     },
   },
 };

--- a/fees/callput/index.ts
+++ b/fees/callput/index.ts
@@ -1,0 +1,165 @@
+import { FetchOptions, FetchResult, SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+
+// CallPut Controller and FeeDistributor proxies on Base:
+// https://basescan.org/address/0xfc61ba50AE7B9C4260C9f04631Ff28D5A2Fa4EB2
+// https://basescan.org/address/0x780b6b94C0FfCf8E659727CE421e976C1b6784Bc
+const CONTROLLER = "0xfc61ba50AE7B9C4260C9f04631Ff28D5A2Fa4EB2";
+const FEE_DISTRIBUTOR = "0x780b6b94C0FfCf8E659727CE421e976C1b6784Bc";
+const PRICE_PRECISION = 1e30;
+
+const POSITION_FEE_EVENT =
+  "event CollectPositionFees(address indexed account, address indexed token, uint256 feeUsd, uint256 feeAmount, bool indexed isSettle)";
+const LIQUIDITY_FEE_EVENT =
+  "event CollectFees(address indexed token, uint256 feeUsd, uint256 feeAmount)";
+const FEE_REBATE_EVENT =
+  "event FeeRebate(address indexed from, address indexed to, address token, uint256 feeRebateAmount, uint256 feeAmount, uint256 afterFeePaidAmount, uint256 tokenSpotPrice, address indexed underlyingAsset, uint256 size, uint256 price, bool isSettle, bool isCopyTrade)";
+
+const OPTIONS_FEES = "Options Trading Fees";
+const LIQUIDITY_FEES = "Liquidity and Swap Fees";
+const OPTIONS_FEES_TO_PROTOCOL = "Options Trading Fees To Protocol";
+const LIQUIDITY_FEES_TO_PROTOCOL = "Liquidity and Swap Fees To Protocol";
+const OPTIONS_FEES_TO_LPS = "Options Trading Fees To LPs";
+const LIQUIDITY_FEES_TO_LPS = "Liquidity and Swap Fees To LPs";
+const REFERRAL_REBATES = "Options Fee Rebates To Referrers";
+const COPY_TRADING_REBATES = "Options Fee Rebates To Copy Traders";
+
+const fetch = async (options: FetchOptions): Promise<FetchResult> => {
+  const dailyFees = options.createBalances();
+  const dailyRevenue = options.createBalances();
+  const dailyProtocolRevenue = options.createBalances();
+  const dailySupplySideRevenue = options.createBalances();
+
+  const vaults: string[] = await options.toApi.call({
+    target: CONTROLLER,
+    abi: "function getVaults() view returns (address[3])",
+  });
+
+  const positionFeeLogs = await options.getLogs({
+    targets: vaults,
+    eventAbi: POSITION_FEE_EVENT,
+  });
+  const liquidityFeeLogs = await options.getLogs({
+    targets: vaults,
+    eventAbi: LIQUIDITY_FEE_EVENT,
+  });
+  const rebateLogs = await options.getLogs({
+    targets: vaults,
+    eventAbi: FEE_REBATE_EVENT,
+  });
+
+  const positionFeesUsd = positionFeeLogs.reduce(
+    (sum, log) => sum + Number(log.feeUsd) / PRICE_PRECISION,
+    0,
+  );
+  const liquidityFeesUsd = liquidityFeeLogs.reduce(
+    (sum, log) => sum + Number(log.feeUsd) / PRICE_PRECISION,
+    0,
+  );
+
+  // CollectPositionFees is emitted after rebates have been deducted. Add each
+  // rebate back to gross fees, and classify the payout as supply-side revenue.
+  for (const log of rebateLogs) {
+    const rebateLabel = log.isCopyTrade ? COPY_TRADING_REBATES : REFERRAL_REBATES;
+    dailyFees.add(log.token, log.feeRebateAmount, OPTIONS_FEES);
+    dailySupplySideRevenue.add(log.token, log.feeRebateAmount, rebateLabel);
+  }
+
+  dailyFees.addUSDValue(positionFeesUsd, OPTIONS_FEES);
+  dailyFees.addUSDValue(liquidityFeesUsd, LIQUIDITY_FEES);
+
+  // Rates sum to 100 in FeeDistributor. Treasury and governance allocations
+  // are retained by the protocol; OLP rewards are paid to liquidity providers.
+  const olpRewardRate = Number(
+    await options.toApi.call({
+      target: FEE_DISTRIBUTOR,
+      abi: "uint256:olpRewardRate",
+    }),
+  );
+  const lpShare = olpRewardRate / 100;
+  const protocolShare = 1 - lpShare;
+
+  dailyRevenue.addUSDValue(
+    positionFeesUsd * protocolShare,
+    OPTIONS_FEES_TO_PROTOCOL,
+  );
+  dailyRevenue.addUSDValue(
+    liquidityFeesUsd * protocolShare,
+    LIQUIDITY_FEES_TO_PROTOCOL,
+  );
+  dailyProtocolRevenue.addUSDValue(
+    positionFeesUsd * protocolShare,
+    OPTIONS_FEES_TO_PROTOCOL,
+  );
+  dailyProtocolRevenue.addUSDValue(
+    liquidityFeesUsd * protocolShare,
+    LIQUIDITY_FEES_TO_PROTOCOL,
+  );
+  dailySupplySideRevenue.addUSDValue(
+    positionFeesUsd * lpShare,
+    OPTIONS_FEES_TO_LPS,
+  );
+  dailySupplySideRevenue.addUSDValue(
+    liquidityFeesUsd * lpShare,
+    LIQUIDITY_FEES_TO_LPS,
+  );
+
+  return {
+    dailyFees,
+    dailyRevenue,
+    dailyProtocolRevenue,
+    dailySupplySideRevenue,
+  };
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  pullHourly: true,
+  methodology: {
+    Fees:
+      "Gross options trading, liquidity, and swap fees paid by CallPut users. Referral and copy-trading rebates are added back because Vault fee events report the net amount after rebates.",
+    Revenue:
+      "The share of net fees allocated to the CallPut treasury and governance addresses, based on the FeeDistributor's onchain OLP reward rate.",
+    ProtocolRevenue:
+      "The share of net fees allocated to the CallPut treasury and governance addresses.",
+    SupplySideRevenue:
+      "Referral and copy-trading rebates plus any share of net fees allocated by FeeDistributor to OLP liquidity providers.",
+  },
+  breakdownMethodology: {
+    Fees: {
+      [OPTIONS_FEES]:
+        "Gross fees charged when users open, close, or settle options positions, including referral and copy-trading rebates.",
+      [LIQUIDITY_FEES]:
+        "Fees charged when users mint or redeem vault liquidity tokens or swap supported collateral assets.",
+    },
+    Revenue: {
+      [OPTIONS_FEES_TO_PROTOCOL]:
+        "Net options trading fees allocated to CallPut treasury and governance addresses.",
+      [LIQUIDITY_FEES_TO_PROTOCOL]:
+        "Net liquidity and swap fees allocated to CallPut treasury and governance addresses.",
+    },
+    ProtocolRevenue: {
+      [OPTIONS_FEES_TO_PROTOCOL]:
+        "Net options trading fees allocated to CallPut treasury and governance addresses.",
+      [LIQUIDITY_FEES_TO_PROTOCOL]:
+        "Net liquidity and swap fees allocated to CallPut treasury and governance addresses.",
+    },
+    SupplySideRevenue: {
+      [REFERRAL_REBATES]: "Options fee rebates paid to referral partners.",
+      [COPY_TRADING_REBATES]: "Options fee rebates paid to copy traders.",
+      [OPTIONS_FEES_TO_LPS]:
+        "Net options trading fees allocated to OLP liquidity providers.",
+      [LIQUIDITY_FEES_TO_LPS]:
+        "Net liquidity and swap fees allocated to OLP liquidity providers.",
+    },
+  },
+  adapter: {
+    [CHAIN.BASE]: {
+      fetch,
+      // First production Controller volume event on Base.
+      start: "2026-01-30",
+    },
+  },
+};
+
+export default adapter;

--- a/fees/callput/index.ts
+++ b/fees/callput/index.ts
@@ -6,8 +6,10 @@ import { CHAIN } from "../../helpers/chains";
 // https://basescan.org/address/0x780b6b94C0FfCf8E659727CE421e976C1b6784Bc
 const CONTROLLER = "0xfc61ba50AE7B9C4260C9f04631Ff28D5A2Fa4EB2";
 const FEE_DISTRIBUTOR = "0x780b6b94C0FfCf8E659727CE421e976C1b6784Bc";
-// Vault feeUsd values emitted by CollectPositionFees and CollectFees are USD amounts scaled by 1e30.
+// USD values emitted by Vault and VaultUtils fee events are scaled by 1e30.
 const PRICE_PRECISION = 1e30;
+// IVaultUtils.PriceType enum: MP = 0, RP = 1.
+const RISK_PREMIUM_PRICE_TYPE = 1;
 
 const POSITION_FEE_EVENT =
   "event CollectPositionFees(address indexed account, address indexed token, uint256 feeUsd, uint256 feeAmount, bool indexed isSettle)";
@@ -15,13 +17,17 @@ const LIQUIDITY_FEE_EVENT =
   "event CollectFees(address indexed token, uint256 feeUsd, uint256 feeAmount)";
 const FEE_REBATE_EVENT =
   "event FeeRebate(address indexed from, address indexed to, address token, uint256 feeRebateAmount, uint256 feeAmount, uint256 afterFeePaidAmount, uint256 tokenSpotPrice, address indexed underlyingAsset, uint256 size, uint256 price, bool isSettle, bool isCopyTrade)";
+const PENDING_AMOUNT_EVENT =
+  "event NotifyPendingAmount(uint8 indexed priceType, address indexed token, uint256 pendingUsd, uint256 pendingAmount)";
 
 const OPTIONS_FEES = "Options Trading Fees";
 const LIQUIDITY_FEES = "Liquidity and Swap Fees";
+const RISK_PREMIUM = "Risk Premium";
 const OPTIONS_FEES_TO_PROTOCOL = "Options Trading Fees To Protocol";
 const LIQUIDITY_FEES_TO_PROTOCOL = "Liquidity and Swap Fees To Protocol";
 const OPTIONS_FEES_TO_LPS = "Options Trading Fees To LPs";
 const LIQUIDITY_FEES_TO_LPS = "Liquidity and Swap Fees To LPs";
+const RISK_PREMIUM_TO_LPS = "Risk Premium To OLPs";
 const REFERRAL_REBATES = "Options Fee Rebates To Referrers";
 const COPY_TRADING_REBATES = "Options Fee Rebates To Copy Traders";
 
@@ -34,6 +40,10 @@ const fetch = async (options: FetchOptions): Promise<FetchResult> => {
   const vaults: string[] = await options.toApi.call({
     target: CONTROLLER,
     abi: "function getVaults() view returns (address[3])",
+  });
+  const vaultUtils: string[] = await options.toApi.multiCall({
+    calls: vaults,
+    abi: "address:vaultUtils",
   });
 
   const positionFeeLogs = await options.getLogs({
@@ -48,6 +58,10 @@ const fetch = async (options: FetchOptions): Promise<FetchResult> => {
     targets: vaults,
     eventAbi: FEE_REBATE_EVENT,
   });
+  const pendingAmountLogs = await options.getLogs({
+    targets: vaultUtils,
+    eventAbi: PENDING_AMOUNT_EVENT,
+  });
 
   const positionFeesUsd = positionFeeLogs.reduce(
     (sum, log) => sum + Number(log.feeUsd) / PRICE_PRECISION,
@@ -55,6 +69,14 @@ const fetch = async (options: FetchOptions): Promise<FetchResult> => {
   );
   const liquidityFeesUsd = liquidityFeeLogs.reduce(
     (sum, log) => sum + Number(log.feeUsd) / PRICE_PRECISION,
+    0,
+  );
+  const riskPremiumUsd = pendingAmountLogs.reduce(
+    (sum, log) =>
+      sum +
+      (Number(log.priceType) === RISK_PREMIUM_PRICE_TYPE
+        ? Number(log.pendingUsd) / PRICE_PRECISION
+        : 0),
     0,
   );
 
@@ -68,6 +90,8 @@ const fetch = async (options: FetchOptions): Promise<FetchResult> => {
 
   dailyFees.addUSDValue(positionFeesUsd, OPTIONS_FEES);
   dailyFees.addUSDValue(liquidityFeesUsd, LIQUIDITY_FEES);
+  dailyFees.addUSDValue(riskPremiumUsd, RISK_PREMIUM);
+  dailySupplySideRevenue.addUSDValue(riskPremiumUsd, RISK_PREMIUM_TO_LPS);
 
   // Rates sum to 100 in FeeDistributor. Treasury and governance allocations
   // are retained by the protocol; OLP rewards are paid to liquidity providers.
@@ -122,13 +146,13 @@ const adapter: SimpleAdapter = {
   start: "2026-01-30",
   methodology: {
     Fees:
-      "Gross options trading, liquidity, and swap fees paid by CallPut users. Referral and copy-trading rebates are added back because Vault fee events report the net amount after rebates.",
+      "Gross options trading fees, liquidity and swap fees, and risk premiums paid by CallPut users. Referral and copy-trading rebates are added back because Vault fee events report the net amount after rebates.",
     Revenue:
       "The share of net fees allocated to the CallPut treasury and governance addresses, based on the FeeDistributor's onchain OLP reward rate.",
     ProtocolRevenue:
       "The share of net fees allocated to the CallPut treasury and governance addresses.",
     SupplySideRevenue:
-      "Referral and copy-trading rebates plus any share of net fees allocated by FeeDistributor to OLP liquidity providers.",
+      "Risk premiums earned by OLP liquidity providers, referral and copy-trading rebates, and any share of net fees allocated by FeeDistributor to OLPs.",
   },
   breakdownMethodology: {
     Fees: {
@@ -136,6 +160,8 @@ const adapter: SimpleAdapter = {
         "Gross fees charged when users open, close, or settle options positions, including referral and copy-trading rebates.",
       [LIQUIDITY_FEES]:
         "Fees charged when users mint or redeem vault liquidity tokens or swap supported collateral assets.",
+      [RISK_PREMIUM]:
+        "The execution-price spread relative to mark price charged to options traders and accrued to OLP liquidity providers.",
     },
     Revenue: {
       [OPTIONS_FEES_TO_PROTOCOL]:
@@ -156,6 +182,8 @@ const adapter: SimpleAdapter = {
         "Net options trading fees allocated to OLP liquidity providers.",
       [LIQUIDITY_FEES_TO_LPS]:
         "Net liquidity and swap fees allocated to OLP liquidity providers.",
+      [RISK_PREMIUM_TO_LPS]:
+        "Risk premiums accrued to OLP liquidity providers through VaultUtils pending RP amounts.",
     },
   },
 };


### PR DESCRIPTION
## Reason

Adds fees and revenue tracking for the existing CallPut options protocol on Base. The adapter uses onchain logs and contract calls; no protocol-operated API is required.

## Data sources and accounting

- Discovers the three active Vault contracts through the CallPut Controller.
- Counts `CollectPositionFees` as net options trading fees.
- Counts `CollectFees` as liquidity and swap fees.
- Adds `FeeRebate` amounts back to gross fees and classifies referral/copy-trading rebates as supply-side revenue.
- Discovers each Vault's `vaultUtils()` contract and counts `NotifyPendingAmount` events with `priceType = RP (1)` as risk premiums.
- Adds risk premiums to both Fees and Supply-side Revenue because they are paid through the execution-price spread and accrue entirely to OLP liquidity providers.
- Reads `olpRewardRate` from FeeDistributor at the end of each window. Treasury and governance allocations are protocol revenue; OLP allocations are supply-side revenue.
- Uses hourly v2 windows and includes complete breakdown labels and methodology.

## Metric formula

- Fees = gross options trading fees + liquidity/swap fees + risk premiums.
- Revenue / Protocol Revenue = the protocol share of net options trading and liquidity/swap fees.
- Supply-side Revenue = referral/copy-trading rebates + OLP share of net fees + risk premiums.

## Validation

- `DEBUG_BREAKDOWN_FEES=1 pnpm test fees callput 2026-08-08`
- `pnpm run ts-check`
- `pnpm run ts-check-cli`
- `git diff --check`
- Independent 2026-08-07 Base RPC and Blockscout verification: 101 `CollectPositionFees` events totaling $496.9890.
- Independent 2026-08-07 official Base RPC verification: 44 `NotifyPendingAmount` RP events totaling $247.255335.

## Links

- Website: https://callput.app/
- Twitter: https://x.com/CallPutApp
- Existing DefiLlama profile: https://defillama.com/protocol/callput
- Controller: https://basescan.org/address/0xfc61ba50AE7B9C4260C9f04631Ff28D5A2Fa4EB2
- FeeDistributor: https://basescan.org/address/0x780b6b94C0FfCf8E659727CE421e976C1b6784Bc