### PR TITLE
[new protocol] crshmarket volume adapter on Monad

### DIFF
--- a/dexs/crshmarket/index.ts
+++ b/dexs/crshmarket/index.ts
@@ -1,0 +1,42 @@
+import { FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+
+// CRSH's parimutuel market contracts on Monad. The second address is the
+// legacy deployment; keeping it here preserves historical coverage.
+// Current: https://monadscan.com/address/0x968279784d780c02a79b1c58ad69aaa832f09342
+// Legacy: https://monadscan.com/address/0x7b9256fd345b6dfa78017094cae64b153de21fb2
+const MARKET_CONTRACTS = [
+  "0x968279784d780c02a79b1c58ad69aaa832f09342",
+  "0x7b9256fd345b6dFa78017094caE64B153dE21fb2",
+];
+// USDC (6 decimals): https://monadscan.com/token/0x754704bc059f8c67012fed69bc8a327a5aafb603
+const USDC = "0x754704Bc059F8C67012fEd69BC8A327a5aafb603";
+
+const BET_PLACED_EVENT =
+  "event BetPlaced(uint256 indexed marketId, address indexed user, uint8 option, uint256 amount, uint256 weightBps, uint256 weightedAmount, uint256 impactAmount)";
+
+const fetch = async (options: FetchOptions) => {
+  const dailyVolume = options.createBalances();
+  const logs = await options.getLogs({
+    targets: MARKET_CONTRACTS,
+    eventAbi: BET_PLACED_EVENT,
+  });
+
+  for (const log of logs) dailyVolume.add(USDC, log.amount);
+
+  return { dailyVolume };
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  pullHourly: true,
+  fetch,
+  chains: [CHAIN.MONAD],
+  start: "2026-07-31",
+  methodology: {
+    Volume:
+      "USDC entry amounts from BetPlaced events emitted by CRSH's current and legacy parimutuel market contracts on Monad. Each bet is counted once; treasury seed liquidity is excluded.",
+  },
+};
+
+export default adapter;


### PR DESCRIPTION
## Summary

Adds CRSHMARKET volume tracking on Monad from `BetPlaced` events emitted by both the current and legacy parimutuel market contracts.

## Methodology

Each trader entry amount is counted once in USDC. The per-market treasury seed is excluded from volume. The adapter starts at 2026-07-31 and uses hourly pulls.

## Evidence

- All-time indexed replay through Monad block `93,887,603`: `$1,180,408.174991` across `127,835` bets, split between current `$602,705.893775` (`36,848` bets) and legacy `$577,702.281216` (`90,987` bets). Deployment-level and market-level aggregates reconcile exactly; the adapter remains dynamic for later events.
- Website: https://app.crshmarket.com/
- Official app metadata: https://app.crshmarket.com/manifest.webmanifest
- Logo: https://app.crshmarket.com/logo.png (official 512x512 PNG)
- Show snapshot: https://app.crshmarket.com/api/public/show-snapshot?showId=r970k29cnjrz3smaazc8yq6b9s8c1kt6
- Current market contract: https://monadscan.com/address/0x968279784d780c02a79b1c58ad69aaa832f09342
- Legacy market contract: https://monadscan.com/address/0x7b9256fd345b6dFa78017094caE64B153dE21fb2
- USDC: https://monadscan.com/token/0x754704Bc059F8C67012fEd69BC8A327a5aafb603

## Validation

- `tsc --noEmit --project tsconfig.json`
- `npm test -- dexs crshmarket 2026-08-07`
- `npm test -- dexs crshmarket 2026-08-01`
- Latest settled UTC day (`2026-08-07`, command date `2026-08-08`): `$43.57k` volume.
- Independent Convex history and Monad receipt replay reconcile the sampled current markets.

##### Name (to be shown on DefiLlama): CRSHMARKET
##### Twitter Link: N/A — no official social link is published in the reviewed app metadata
##### List of audit links if any: N/A — no public audit link was found in the reviewed official metadata
##### Website Link: https://app.crshmarket.com/
##### Logo (High resolution, will be shown with rounded borders): https://app.crshmarket.com/logo.png
##### Current TVL: N/A — this PR adds volume, not TVL
##### Treasury Addresses (if the protocol has treasury): N/A
##### Chain: Monad (chain ID 143)
##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed): N/A
##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed): N/A
##### Short Description (to be shown on DefiLlama): Livestreams you can predict on.
##### Token address and ticker if any: N/A
##### Category (full list at https://defillama.com/categories) *Please choose only one: Prediction Market
##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.): N/A — this adapter reads CRSH settlement events and does not consume an external oracle.
##### Implementation Details: Briefly describe how the oracle is integrated into your project: N/A — this volume adapter counts BetPlaced events from the current and legacy market contracts.
##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage: N/A — oracle integration is outside this adapter's scope; contract and app links above provide implementation evidence.
##### forkedFrom (Does your project originate from another project): N/A
##### methodology (what is being counted as tvl, how is tvl being calculated): Volume is each BetPlaced USDC entry amount; treasury seed liquidity is excluded.
##### Github org/user (Optional, if the protocol is open source, we can track activity): N/A
##### Does this project have a referral program?: N/A
