### PR TITLE
[new protocol] crshmarket - fees adapter on Monad

### DIFF
--- a/fees/crshmarket/index.ts
+++ b/fees/crshmarket/index.ts
@@ -36,8 +36,6 @@ const fetch = async (options: FetchOptions) => {
 const methodology = {
   Fees:
     "Realized CRSH fees from ProtocolFeeReleased events emitted by the current and legacy parimutuel market contracts. Canceled or waived markets emit no release event and are excluded.",
-  UserFees:
-    "The USDC amount released as the market protocol fee after settlement.",
   Revenue:
     "All ProtocolFeeReleased USDC is retained by the CRSH protocol.",
   ProtocolRevenue:
@@ -48,10 +46,6 @@ const breakdownMethodology = {
   Fees: {
     [METRIC.TRADING_FEES]:
       "Protocol fee amounts released by CRSH market contracts after settlement.",
-  },
-  UserFees: {
-    [METRIC.TRADING_FEES]:
-      "USDC fees charged by CRSH's parimutuel market settlement flow.",
   },
   Revenue: {
     [METRIC.TRADING_FEES]:

--- a/fees/crshmarket/index.ts
+++ b/fees/crshmarket/index.ts
@@ -1,0 +1,76 @@
+import { FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import { METRIC } from "../../helpers/metrics";
+
+// CRSH's parimutuel market contracts on Monad. The second address is the
+// legacy deployment; keeping it here preserves historical coverage.
+// Current: https://monadscan.com/address/0x968279784d780c02a79b1c58ad69aaa832f09342
+// Legacy: https://monadscan.com/address/0x7b9256fd345b6dfa78017094cae64b153de21fb2
+const MARKET_CONTRACTS = [
+  "0x968279784d780c02a79b1c58ad69aaa832f09342",
+  "0x7b9256fd345b6dFa78017094caE64B153dE21fb2",
+];
+// USDC (6 decimals): https://monadscan.com/token/0x754704bc059f8c67012fed69bc8a327a5aafb603
+const USDC = "0x754704Bc059F8C67012fEd69BC8A327a5aafb603";
+
+const PROTOCOL_FEE_RELEASED_EVENT =
+  "event ProtocolFeeReleased(uint256 indexed marketId, uint256 amount)";
+
+const fetch = async (options: FetchOptions) => {
+  const dailyFees = options.createBalances();
+  const logs = await options.getLogs({
+    targets: MARKET_CONTRACTS,
+    eventAbi: PROTOCOL_FEE_RELEASED_EVENT,
+  });
+
+  for (const log of logs) dailyFees.add(USDC, log.amount, METRIC.TRADING_FEES);
+
+  return {
+    dailyFees,
+    dailyUserFees: dailyFees,
+    dailyRevenue: dailyFees,
+    dailyProtocolRevenue: dailyFees,
+  };
+};
+
+const methodology = {
+  Fees:
+    "Realized CRSH fees from ProtocolFeeReleased events emitted by the current and legacy parimutuel market contracts. Canceled or waived markets emit no release event and are excluded.",
+  UserFees:
+    "The USDC amount released as the market protocol fee after settlement.",
+  Revenue:
+    "All ProtocolFeeReleased USDC is retained by the CRSH protocol.",
+  ProtocolRevenue:
+    "All ProtocolFeeReleased USDC is retained by the CRSH protocol.",
+};
+
+const breakdownMethodology = {
+  Fees: {
+    [METRIC.TRADING_FEES]:
+      "Protocol fee amounts released by CRSH market contracts after settlement.",
+  },
+  UserFees: {
+    [METRIC.TRADING_FEES]:
+      "USDC fees charged by CRSH's parimutuel market settlement flow.",
+  },
+  Revenue: {
+    [METRIC.TRADING_FEES]:
+      "Protocol fee amounts retained by CRSH after settlement.",
+  },
+  ProtocolRevenue: {
+    [METRIC.TRADING_FEES]:
+      "Protocol fee amounts retained by CRSH after settlement.",
+  },
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  pullHourly: true,
+  fetch,
+  chains: [CHAIN.MONAD],
+  start: "2026-07-31",
+  methodology,
+  breakdownMethodology,
+};
+
+export default adapter;


### PR DESCRIPTION
## Summary

Adds CRSHMARKET realized fee tracking on Monad from `ProtocolFeeReleased` events emitted by both the current and legacy parimutuel market contracts.

## Methodology

Counts actual USDC amounts released by the market contracts after settlement. Canceled or waived markets with no release event are excluded. All released fees are reported as fees, user fees, revenue, and protocol revenue because the release event is the realized protocol amount.

## Evidence

- All-time indexed replay through Monad block `93,887,603`: `$24,989.276993` in realized `ProtocolFeeReleased` amounts across `5,460` release events, split between current `$16,032.361940` (`2,426` events) and legacy `$8,956.915053` (`3,034` events). Deployment-level and market-level aggregates reconcile exactly; the adapter remains dynamic for later events.
- Website: https://app.crshmarket.com/
- Official app metadata: https://app.crshmarket.com/manifest.webmanifest
- Logo: https://app.crshmarket.com/logo.png (official 512x512 PNG)
- Show snapshot: https://app.crshmarket.com/api/public/show-snapshot?showId=r970k29cnjrz3smaazc8yq6b9s8c1kt6
- Current market contract: https://monadscan.com/address/0x968279784d780c02a79b1c58ad69aaa832f09342
- Legacy market contract: https://monadscan.com/address/0x7b9256fd345b6dFa78017094caE64B153dE21fb2
- Market 2612 resolution: https://monadscan.com/tx/0x0a339dd3d7c97edb3efb796aa0e704a6e958327696bbdedfb7f8034b823f540e

## Validation

- `tsc --noEmit --project tsconfig.json`
- `npm test -- fees crshmarket 2026-08-07`
- `npm test -- fees crshmarket 2026-08-01`
- Latest settled UTC day (`2026-08-07`, command date `2026-08-08`): `$2,218` fees, user fees, revenue, and protocol revenue.
- Independent Convex history and Monad receipt/log replay reconcile the sampled current and legacy markets.

##### Name (to be shown on DefiLlama): CRSHMARKET
##### Twitter Link: N/A — no official social link is published in the reviewed app metadata
##### List of audit links if any: N/A — no public audit link was found in the reviewed official metadata
##### Website Link: https://app.crshmarket.com/
##### Logo (High resolution, will be shown with rounded borders): https://app.crshmarket.com/logo.png
##### Current TVL: N/A — this PR adds fees, not TVL
##### Treasury Addresses (if the protocol has treasury): N/A
##### Chain: Monad (chain ID 143)
##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed): N/A
##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed): N/A
##### Short Description (to be shown on DefiLlama): Livestreams you can predict on.
##### Token address and ticker if any: N/A
##### Category (full list at https://defillama.com/categories) *Please choose only one: Prediction Market
##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.): N/A — this adapter reads CRSH settlement/fee events and does not consume an external oracle.
##### Implementation Details: Briefly describe how the oracle is integrated into your project: N/A — this fee adapter counts ProtocolFeeReleased events from the current and legacy market contracts.
##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage: N/A — oracle integration is outside this adapter's scope; contract and app links above provide implementation evidence.
##### forkedFrom (Does your project originate from another project): N/A
##### methodology (what is being counted as tvl, how is tvl being calculated): Fees are realized USDC amounts from ProtocolFeeReleased; all realized amounts are retained by the protocol.
##### Github org/user (Optional, if the protocol is open source, we can track activity): N/A
##### Does this project have a referral program?: N/A
