### PR TITLE
feat: track Kayen Finance LST fees and revenue

### DIFF
--- a/fees/kayen-finance-lst.ts
+++ b/fees/kayen-finance-lst.ts
@@ -68,7 +68,7 @@ const fetch = async (options: FetchOptions) => {
 
 const methodology = {
   Fees: 'Total CHZ staking rewards earned by the CHZ staked through Kayen Finance LST.',
-  Revenue: 'Protocol fee taken from those rewards, currently 10%, read from ProtocolConfig.',
+  Revenue: 'Protocol fee taken from those rewards, at the rate ProtocolConfig holds at the time of the call.',
   ProtocolRevenue: 'All revenue goes to the protocol fee vault.',
   HoldersRevenue: 'No share of the rewards goes to token holders.',
   SupplySideRevenue: 'The rest of the rewards accrue to stCHZ holders through the rising CHZ per stCHZ rate.',
@@ -81,6 +81,9 @@ const breakdownMethodology = {
   Revenue: {
     [METRIC.PROTOCOL_FEES]: 'Share of the validator rewards kept by the protocol and sent to the fee vault.',
   },
+  ProtocolRevenue: {
+    [METRIC.PROTOCOL_FEES]: 'The whole fee cut reaches the protocol fee vault, none of it is shared out.',
+  },
   SupplySideRevenue: {
     [METRIC.STAKING_REWARDS]: 'Share of the validator rewards left in the pool, raising the CHZ redeemable per stCHZ.',
   },
@@ -89,14 +92,11 @@ const breakdownMethodology = {
 const adapter: SimpleAdapter = {
   version: 2,
   pullHourly: true,
+  fetch,
+  chains: [CHAIN.CHILIZ],
+  start: '2026-06-18',
   methodology,
   breakdownMethodology,
-  adapter: {
-    [CHAIN.CHILIZ]: {
-      fetch,
-      start: '2026-06-18',
-    },
-  },
 }
 
 export default adapter;

--- a/fees/kayen-finance-lst.ts
+++ b/fees/kayen-finance-lst.ts
@@ -1,0 +1,102 @@
+import { FetchOptions, SimpleAdapter } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+import { METRIC } from "../helpers/metrics";
+
+// Kayen Finance LST: liquid staking of native CHZ on Chiliz.
+//
+// stCHZ does not rebase. Balances are fixed shares and validator rewards show up as a
+// rise in the CHZ redeemable per share. ChilizDepositor.totalDeposits() reports the
+// pooled CHZ already net of the protocol fee, so the CHZ that accrued to holders over
+// a window is the rate delta applied to the shares outstanding, and grossing that up
+// by the fee rate recovers the validator rewards earned in total.
+//
+// https://chiliscan.com/address/0xBF4ca6F798b2e342E36dc2eC80667B58CF480787 (stCHZ)
+// https://chiliscan.com/address/0xc3cbf2c6b3ea81f1A8a9fd24D8179B6F39860DB7 (ChilizDepositor)
+// https://chiliscan.com/address/0xA603d53Fd1435dF23A5C0FE74c4c6E4ed3CE081C (ProtocolConfig)
+const STCHZ = '0xBF4ca6F798b2e342E36dc2eC80667B58CF480787'
+const CHILIZ_DEPOSITOR = '0xc3cbf2c6b3ea81f1A8a9fd24D8179B6F39860DB7'
+const PROTOCOL_CONFIG = '0xA603d53Fd1435dF23A5C0FE74c4c6E4ed3CE081C'
+
+const abi = {
+  totalDeposits: 'uint256:totalDeposits',
+  totalSupply: 'uint256:totalSupply',
+  // Fee taken from validator rewards, as a 1e18-scaled fraction. Read rather than
+  // hardcoded so a governance change is picked up without touching the adapter.
+  protocolFeeRate: 'uint256:protocolFeeRate',
+}
+
+const fetch = async (options: FetchOptions) => {
+  const [depositsBefore, supplyBefore] = await options.fromApi.batchCall([
+    { target: CHILIZ_DEPOSITOR, abi: abi.totalDeposits },
+    { target: STCHZ, abi: abi.totalSupply },
+  ])
+  const [depositsAfter, supplyAfter, feeRate] = await options.toApi.batchCall([
+    { target: CHILIZ_DEPOSITOR, abi: abi.totalDeposits },
+    { target: STCHZ, abi: abi.totalSupply },
+    { target: PROTOCOL_CONFIG, abi: abi.protocolFeeRate },
+  ])
+
+  const rateBefore = Number(depositsBefore) / Number(supplyBefore)
+  const rateAfter = Number(depositsAfter) / Number(supplyAfter)
+  const feeShare = Number(feeRate) / 1e18
+
+  // The rate is a step function: validator rewards land in one lump per epoch and the
+  // rate is flat in between, so the shares that earned a step are the ones outstanding
+  // when the window opened. Pricing a step against the closing supply would credit
+  // depositors who arrived after it was earned. On a pool that grew from 7.1M to 8.9M
+  // CHZ in a day, that overstates the reward by a quarter.
+  //
+  // Delegating also rounds down to whole units of the chain's staking precision, so a
+  // window can land a hair below the previous rate. Floor at zero rather than report a
+  // negative fee for what is a rounding artifact.
+  const holdersYield = Math.max(0, (rateAfter - rateBefore) * Number(supplyBefore))
+
+  const dailyFees = options.createBalances()
+  dailyFees.addGasToken(holdersYield / (1 - feeShare), METRIC.STAKING_REWARDS)
+
+  const dailyRevenue = dailyFees.clone(feeShare, METRIC.PROTOCOL_FEES)
+  const dailySupplySideRevenue = dailyFees.clone(1 - feeShare, METRIC.STAKING_REWARDS)
+
+  return {
+    dailyFees,
+    dailyRevenue,
+    dailyProtocolRevenue: dailyRevenue,
+    dailySupplySideRevenue,
+    dailyHoldersRevenue: 0,
+  }
+}
+
+const methodology = {
+  Fees: 'Total CHZ staking rewards earned by the CHZ staked through Kayen Finance LST.',
+  Revenue: 'Protocol fee taken from those rewards, currently 10%, read from ProtocolConfig.',
+  ProtocolRevenue: 'All revenue goes to the protocol fee vault.',
+  HoldersRevenue: 'No share of the rewards goes to token holders.',
+  SupplySideRevenue: 'The rest of the rewards accrue to stCHZ holders through the rising CHZ per stCHZ rate.',
+}
+
+const breakdownMethodology = {
+  Fees: {
+    [METRIC.STAKING_REWARDS]: 'CHZ rewards earned from the Chiliz validators the pooled CHZ is delegated to.',
+  },
+  Revenue: {
+    [METRIC.PROTOCOL_FEES]: 'Share of the validator rewards kept by the protocol and sent to the fee vault.',
+  },
+  SupplySideRevenue: {
+    [METRIC.STAKING_REWARDS]: 'Share of the validator rewards left in the pool, raising the CHZ redeemable per stCHZ.',
+  },
+}
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  pullHourly: true,
+  methodology,
+  breakdownMethodology,
+  adapter: {
+    [CHAIN.CHILIZ]: {
+      fetch,
+      start: '2026-06-18',
+    },
+  },
+}
+
+export default adapter;


### PR DESCRIPTION
Adds a fees and revenue adapter for Kayen Finance LST, liquid staking of native CHZ on Chiliz.

Website: https://app.kayen.finance/lst/stake
Twitter: https://x.com/KayenFinance

TVL adapter for the same protocol: https://github.com/DefiLlama/DefiLlama-Adapters/pull/20432

### Methodology

stCHZ does not rebase. Balances are fixed shares and validator rewards show up as a rise in the CHZ redeemable per share, where the rate is `ChilizDepositor.totalDeposits() / stCHZ.totalSupply()`. `totalDeposits()` is already net of the protocol fee, so the rate delta over a window gives the CHZ that accrued to holders, and grossing it up by the fee rate recovers the total validator rewards.

- Fees: total CHZ staking rewards earned by the staked CHZ
- Revenue: the protocol fee cut of those rewards, currently 10%, read from `ProtocolConfig.protocolFeeRate()` rather than hardcoded so a governance change is picked up automatically
- Supply side revenue: the remainder, which reaches stCHZ holders as a higher redemption rate
- Holders revenue: none, no rewards are shared with token holders

All values come from contract calls at the window's from and to blocks. No subgraph or off-chain API is involved.

### On attributing rewards to the right shares

Worth flagging since it changes the numbers by a lot. The rate is a step function rather than a smooth curve: validator rewards land in one lump roughly once a day and the rate is flat in between. So the shares that earned a step are the ones outstanding when it was earned, and the adapter prices each step against the supply at the window's opening block.

Pricing against the closing supply instead would credit depositors who arrived after the reward was earned. On 2026-08-08, when the pool grew from 7.1M to 8.9M CHZ in a day, that difference is 2,501 CHZ reported against 1,999 CHZ actually earned, a 25% overstatement. `pullHourly: true` keeps the windows short enough that the remaining error is bounded by one hour of deposit flow.

### Verification

Cross-checked against the protocol's subgraph for the window 2026-08-08 00:00 to 2026-08-09 00:00 UTC:

| | reward accrued to holders |
|---|---|
| adapter, from contract calls | 1,999.72 CHZ |
| subgraph hourly snapshots | 1,999.72 CHZ |

The same window read straight from the chain at the subgraph's own snapshot blocks reproduces the rate to 16 significant digits.

`npm test fees kayen-finance-lst` output for a few days:

```
2026-08-09   fees $29.00   revenue $2.87   supply side $26.00
2026-08-05   fees $11.00   revenue $1.06   supply side $9.58
2026-07-20   fees  $0.00   revenue $0.00   supply side  $0.00
```

The zero on 2026-07-20 is correct rather than a failure. The pool held 23.8 stCHZ that day and earned 0.0062 CHZ.
