### PR TITLE
[add] house-of-joshi-swap - add volume and fee adapters

### DIFF
--- a/aggregators/house-of-joshi-swap/index.ts
+++ b/aggregators/house-of-joshi-swap/index.ts
@@ -1,0 +1,19 @@
+import { FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { chainConfig, fetchHouseOfJoshiMetrics } from "../../helpers/aggregators/house-of-joshi-swap";
+
+const fetch = async (options: FetchOptions) => {
+  const { dailyVolume } = await fetchHouseOfJoshiMetrics(options);
+  return { dailyVolume };
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  pullHourly: true,
+  adapter: chainConfig,
+  fetch,
+  methodology: {
+    Volume: "Gross sell-token amounts routed through HojswapRouterV2, read from its SwapExecuted events. Underlying DEX volume is not attributed as House of Joshi liquidity.",
+  },
+};
+
+export default adapter;

--- a/aggregators/house-of-joshi-swap/index.ts
+++ b/aggregators/house-of-joshi-swap/index.ts
@@ -1,5 +1,9 @@
 import { FetchOptions, SimpleAdapter } from "../../adapters/types";
-import { chainConfig, fetchHouseOfJoshiMetrics } from "../../helpers/aggregators/house-of-joshi-swap";
+import {
+  chainConfig,
+  fetchHouseOfJoshiMetrics,
+  VOLUME_LABEL,
+} from "../../helpers/aggregators/house-of-joshi-swap";
 
 const fetch = async (options: FetchOptions) => {
   const { dailyVolume } = await fetchHouseOfJoshiMetrics(options);
@@ -13,6 +17,11 @@ const adapter: SimpleAdapter = {
   fetch,
   methodology: {
     Volume: "Gross sell-token amounts routed through HojswapRouterV2, read from its SwapExecuted events. Underlying DEX volume is not attributed as House of Joshi liquidity.",
+  },
+  breakdownMethodology: {
+    Volume: {
+      [VOLUME_LABEL]: "Gross sell-token amounts emitted by HojswapRouterV2 for completed swaps.",
+    },
   },
 };
 

--- a/fees/house-of-joshi-swap/index.ts
+++ b/fees/house-of-joshi-swap/index.ts
@@ -23,16 +23,12 @@ const adapter: SimpleAdapter = {
   fetch,
   methodology: {
     Fees: "The 1% House fee paid by users on swaps executed through HojswapRouterV2, using the exact feeAmount emitted for each trade.",
-    UserFees: "Same as Fees: the 1% House fee is paid directly by the user as part of the gross sell amount.",
     Revenue: "All House swap fees are retained by the protocol; there is no supply-side fee allocation.",
     ProtocolRevenue: "Same as Revenue: the full House swap fee sent to the configured House wallet.",
   },
   breakdownMethodology: {
     Fees: {
       [SWAP_FEE_LABEL]: "The feeAmount emitted by HojswapRouterV2 for each completed swap.",
-    },
-    UserFees: {
-      [SWAP_FEE_LABEL]: "The 1% House fee paid directly by the swapping user.",
     },
     Revenue: {
       [PROTOCOL_REVENUE_LABEL]: "The full House fee sent to the protocol's configured House wallet.",

--- a/fees/house-of-joshi-swap/index.ts
+++ b/fees/house-of-joshi-swap/index.ts
@@ -1,0 +1,46 @@
+import { FetchOptions, SimpleAdapter } from "../../adapters/types";
+import {
+  chainConfig,
+  fetchHouseOfJoshiMetrics,
+  PROTOCOL_REVENUE_LABEL,
+  SWAP_FEE_LABEL,
+} from "../../helpers/aggregators/house-of-joshi-swap";
+
+const fetch = async (options: FetchOptions) => {
+  const { dailyFees, dailyRevenue, dailyUserFees } = await fetchHouseOfJoshiMetrics(options);
+  return {
+    dailyFees,
+    dailyUserFees,
+    dailyRevenue,
+    dailyProtocolRevenue: dailyRevenue,
+  };
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  pullHourly: true,
+  adapter: chainConfig,
+  fetch,
+  methodology: {
+    Fees: "The 1% House fee paid by users on swaps executed through HojswapRouterV2, using the exact feeAmount emitted for each trade.",
+    UserFees: "Same as Fees: the 1% House fee is paid directly by the user as part of the gross sell amount.",
+    Revenue: "All House swap fees are retained by the protocol; there is no supply-side fee allocation.",
+    ProtocolRevenue: "Same as Revenue: the full House swap fee sent to the configured House wallet.",
+  },
+  breakdownMethodology: {
+    Fees: {
+      [SWAP_FEE_LABEL]: "The feeAmount emitted by HojswapRouterV2 for each completed swap.",
+    },
+    UserFees: {
+      [SWAP_FEE_LABEL]: "The 1% House fee paid directly by the swapping user.",
+    },
+    Revenue: {
+      [PROTOCOL_REVENUE_LABEL]: "The full House fee sent to the protocol's configured House wallet.",
+    },
+    ProtocolRevenue: {
+      [PROTOCOL_REVENUE_LABEL]: "The full House fee retained by the protocol.",
+    },
+  },
+};
+
+export default adapter;

--- a/helpers/aggregators/house-of-joshi-swap.ts
+++ b/helpers/aggregators/house-of-joshi-swap.ts
@@ -6,8 +6,12 @@ type ChainConfig = {
   start: string;
 };
 
-// HojswapRouterV2 deployment addresses and conservative indexing start dates.
+// Router deployments are sourced from the project's public app configuration:
+// https://github.com/queenjoshi/Swap-Simulation/blob/da9ac37eb59442988e40d578c8fababeb0e90b86/hojswap-next/src/lib/hojswap-router.ts
+// Start dates conservatively precede the first indexed swaps so no events are omitted.
 const SHARED_ROUTER = "0x2C5F372746330465C3f4084CE6C6aBce22a48B4d";
+// HojswapRouterV2 uses address(0) as the native gas-token sentinel.
+const NATIVE_TOKEN = "0x0000000000000000000000000000000000000000";
 
 export const chainConfig: Record<string, ChainConfig> = {
   [CHAIN.ETHEREUM]: { contract: SHARED_ROUTER, start: "2026-07-16" },
@@ -27,15 +31,21 @@ const SWAP_EXECUTED =
 
 export const SWAP_FEE_LABEL = "Swap Fees";
 export const PROTOCOL_REVENUE_LABEL = "Swap Fees To Protocol";
+export const VOLUME_LABEL = "Router Swap Volume";
 
 function addAsset(balance: ReturnType<FetchOptions["createBalances"]>, token: string, amount: bigint, label?: string) {
-  if (token === "0x0000000000000000000000000000000000000000") {
+  if (token === NATIVE_TOKEN) {
     balance.addGasToken(amount, label);
   } else {
     balance.add(token, amount, label);
   }
 }
 
+/**
+ * Fetches completed HojswapRouterV2 swaps for the requested chain and time window.
+ * @param options DefiLlama fetch context used for log queries and balance creation.
+ * @returns Daily volume, fees, user fees, and protocol revenue balance collections.
+ */
 export async function fetchHouseOfJoshiMetrics(options: FetchOptions) {
   const dailyVolume = options.createBalances();
   const dailyFees = options.createBalances();
@@ -52,7 +62,7 @@ export async function fetchHouseOfJoshiMetrics(options: FetchOptions) {
     const feeAmount = BigInt(log.feeAmount);
 
     // sellAmount is the user's gross input and already includes feeAmount.
-    addAsset(dailyVolume, log.sellToken, sellAmount);
+    addAsset(dailyVolume, log.sellToken, sellAmount, VOLUME_LABEL);
     addAsset(dailyFees, log.sellToken, feeAmount, SWAP_FEE_LABEL);
     addAsset(dailyRevenue, log.sellToken, feeAmount, PROTOCOL_REVENUE_LABEL);
     addAsset(dailyUserFees, log.sellToken, feeAmount, SWAP_FEE_LABEL);

--- a/helpers/aggregators/house-of-joshi-swap.ts
+++ b/helpers/aggregators/house-of-joshi-swap.ts
@@ -1,0 +1,62 @@
+import { FetchOptions } from "../../adapters/types";
+import { CHAIN } from "../chains";
+
+type ChainConfig = {
+  contract: string;
+  start: string;
+};
+
+// HojswapRouterV2 deployment addresses and conservative indexing start dates.
+const SHARED_ROUTER = "0x2C5F372746330465C3f4084CE6C6aBce22a48B4d";
+
+export const chainConfig: Record<string, ChainConfig> = {
+  [CHAIN.ETHEREUM]: { contract: SHARED_ROUTER, start: "2026-07-16" },
+  [CHAIN.BASE]: { contract: "0x6aCaf964bCf4551CC55Afaf12d6e6a8ef7138875", start: "2026-07-14" },
+  [CHAIN.POLYGON]: { contract: SHARED_ROUTER, start: "2026-07-14" },
+  [CHAIN.BSC]: { contract: SHARED_ROUTER, start: "2026-07-14" },
+  [CHAIN.ARBITRUM]: { contract: SHARED_ROUTER, start: "2026-07-14" },
+  [CHAIN.OPTIMISM]: { contract: SHARED_ROUTER, start: "2026-07-14" },
+  [CHAIN.AVAX]: { contract: SHARED_ROUTER, start: "2026-07-14" },
+  [CHAIN.UNICHAIN]: { contract: SHARED_ROUTER, start: "2026-07-14" },
+  [CHAIN.CRONOS]: { contract: SHARED_ROUTER, start: "2026-07-14" },
+  [CHAIN.ROBINHOOD]: { contract: SHARED_ROUTER, start: "2026-07-14" },
+};
+
+const SWAP_EXECUTED =
+  "event SwapExecuted(address indexed sender, address indexed recipient, address indexed sellToken, address buyToken, uint256 sellAmount, uint256 feeAmount, uint256 buyAmount, address swapTarget)";
+
+export const SWAP_FEE_LABEL = "Swap Fees";
+export const PROTOCOL_REVENUE_LABEL = "Swap Fees To Protocol";
+
+function addAsset(balance: ReturnType<FetchOptions["createBalances"]>, token: string, amount: bigint, label?: string) {
+  if (token === "0x0000000000000000000000000000000000000000") {
+    balance.addGasToken(amount, label);
+  } else {
+    balance.add(token, amount, label);
+  }
+}
+
+export async function fetchHouseOfJoshiMetrics(options: FetchOptions) {
+  const dailyVolume = options.createBalances();
+  const dailyFees = options.createBalances();
+  const dailyRevenue = options.createBalances();
+  const dailyUserFees = options.createBalances();
+
+  const logs = await options.getLogs({
+    target: chainConfig[options.chain].contract,
+    eventAbi: SWAP_EXECUTED,
+  });
+
+  for (const log of logs) {
+    const sellAmount = BigInt(log.sellAmount);
+    const feeAmount = BigInt(log.feeAmount);
+
+    // sellAmount is the user's gross input and already includes feeAmount.
+    addAsset(dailyVolume, log.sellToken, sellAmount);
+    addAsset(dailyFees, log.sellToken, feeAmount, SWAP_FEE_LABEL);
+    addAsset(dailyRevenue, log.sellToken, feeAmount, PROTOCOL_REVENUE_LABEL);
+    addAsset(dailyUserFees, log.sellToken, feeAmount, SWAP_FEE_LABEL);
+  }
+
+  return { dailyVolume, dailyFees, dailyRevenue, dailyUserFees };
+}


### PR DESCRIPTION
## What changed

- adds the House of Joshi Swap aggregator-volume adapter
- adds fee, user-fee, revenue, and protocol-revenue accounting
- indexes `SwapExecuted` logs from `HojswapRouterV2`
- supports Ethereum, Base, Polygon, BNB Chain, Arbitrum, Optimism, Avalanche, Unichain, Cronos, and Robinhood Chain

## Methodology

Volume is the gross sell-token amount emitted for each completed router swap. Fees use the exact `feeAmount` emitted by the contract. The 1% House fee is entirely protocol revenue; underlying DEX liquidity-provider fees and volume are not attributed to House of Joshi Swap.

## Project metadata

- Website: https://swap.thehouseofjoshi.com
- X/Twitter: https://x.com/thehouseofjoshi
- External audit: No external audit
- EVM fee wallet: `0x6736d2eA9807297F0e56967361B9410854B86a5f`
- Shared router: `0x2C5F372746330465C3f4084CE6C6aBce22a48B4d`
- Base router: `0x6aCaf964bCf4551CC55Afaf12d6e6a8ef7138875`

Native XRPL activity is intentionally excluded because this adapter reads EVM logs only.

## Validation

- `pnpm test aggregators house-of-joshi-swap 2026-08-06 base`
- `DEBUG_BREAKDOWN_FEES=1 pnpm test fees house-of-joshi-swap 2026-08-06 base`
- `pnpm run ts-check`
- `pnpm run ts-check-cli`
- `git diff --check`

The focused Base sample returned $0.04 daily volume and an exact $0.0004 fee, matching the configured 1% fee.
