### PR TITLE
0x: add cross-chain bridge volume adapter

### DIFF
--- a/bridge-aggregators/zrx/index.ts
+++ b/bridge-aggregators/zrx/index.ts
@@ -1,7 +1,15 @@
+import asyncRetry from "async-retry";
 import { CHAIN } from "../../helpers/chains";
 import { FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { getEnv } from "../../helpers/env";
 import { httpGet } from "../../utils/fetchURL";
+const plimit = require("p-limit");
+
+// Every chain is fetched at once but the stats API allows 5 requests per second per
+// key, so requests are serialised and spaced to stay under the cap even if the API
+// responds instantly.
+const limits = plimit(1);
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
 // originChainId query param: numeric chain id for EVM chains, lowercase name for non-EVM
 const CHAINS: Record<string, number | string> = {
@@ -31,18 +39,30 @@ const CHAINS: Record<string, number | string> = {
   // [CHAIN.TRON]: "tron",
 };
 
-const fetch = async (options: FetchOptions) => {
-  const response = await httpGet(
-    `https://api.0x.org/stats/cross-chain/volume/daily?timestamp=${options.startOfDay}&originChainId=${CHAINS[options.chain]}`,
-    {
-      headers: {
-        "0x-api-key": getEnv("AGGREGATOR_0X_API_KEY"),
-      },
+async function getBridgeVolume(options: FetchOptions) {
+  return asyncRetry(
+    async () => {
+      const response = await httpGet(
+        `https://api.0x.org/stats/cross-chain/volume/daily?timestamp=${options.startOfDay}&originChainId=${CHAINS[options.chain]}`,
+        {
+          headers: {
+            "0x-api-key": getEnv("AGGREGATOR_0X_API_KEY"),
+          },
+        },
+      );
+
+      await sleep(250);
+      return response.data.volume;
     },
+    { retries: 3, minTimeout: 1000, maxTimeout: 5000, factor: 2 },
   );
+}
+
+const fetch = async (options: FetchOptions) => {
+  const dailyBridgeVolume = await limits(() => getBridgeVolume(options));
 
   return {
-    dailyBridgeVolume: response.data.volume,
+    dailyBridgeVolume,
   };
 };
 

--- a/bridge-aggregators/zrx/index.ts
+++ b/bridge-aggregators/zrx/index.ts
@@ -41,18 +41,26 @@ const CHAINS: Record<string, number | string> = {
 
 async function getBridgeVolume(options: FetchOptions) {
   return asyncRetry(
-    async () => {
-      const response = await httpGet(
-        `https://api.0x.org/stats/cross-chain/volume/daily?timestamp=${options.startOfDay}&originChainId=${CHAINS[options.chain]}`,
-        {
-          headers: {
-            "0x-api-key": getEnv("AGGREGATOR_0X_API_KEY"),
+    async (bail) => {
+      try {
+        const response = await httpGet(
+          `https://api.0x.org/stats/cross-chain/volume/daily?timestamp=${options.startOfDay}&originChainId=${CHAINS[options.chain]}`,
+          {
+            headers: {
+              "0x-api-key": getEnv("AGGREGATOR_0X_API_KEY"),
+            },
           },
-        },
-      );
+        );
 
-      await sleep(250);
-      return response.data.volume;
+        await sleep(250);
+        return response.data.volume;
+      } catch (e: any) {
+        const status = String(e?.message).match(/status code (\d{3})/)?.[1];
+        // retrying only helps rate limits (429) and transient server errors;
+        // client errors like 401/400 fail every attempt, so surface them immediately
+        if (status?.startsWith("4") && status !== "429") bail(e);
+        else throw e;
+      }
     },
     { retries: 3, minTimeout: 1000, maxTimeout: 5000, factor: 2 },
   );

--- a/bridge-aggregators/zrx/index.ts
+++ b/bridge-aggregators/zrx/index.ts
@@ -1,0 +1,60 @@
+import { CHAIN } from "../../helpers/chains";
+import { FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { getEnv } from "../../helpers/env";
+import { httpGet } from "../../utils/fetchURL";
+
+// originChainId query param: numeric chain id for EVM chains, lowercase name for non-EVM
+const CHAINS: Record<string, number | string> = {
+  [CHAIN.ETHEREUM]: 1,
+  [CHAIN.OPTIMISM]: 10,
+  [CHAIN.BSC]: 56,
+  [CHAIN.UNICHAIN]: 130,
+  [CHAIN.POLYGON]: 137,
+  [CHAIN.MONAD]: 143,
+  [CHAIN.SONIC]: 146,
+  [CHAIN.WC]: 480,
+  [CHAIN.HYPERLIQUID]: 999, // HyperEVM; hypercore has no separate DefiLlama chain, so it is not counted
+  [CHAIN.ABSTRACT]: 2741,
+  [CHAIN.TEMPO]: 4217,
+  [CHAIN.ROBINHOOD]: 4663,
+  [CHAIN.MANTLE]: 5000,
+  [CHAIN.BASE]: 8453,
+  [CHAIN.PLASMA]: 9745,
+  [CHAIN.ARBITRUM]: 42161,
+  [CHAIN.AVAX]: 43114,
+  [CHAIN.INK]: 57073,
+  [CHAIN.LINEA]: 59144,
+  [CHAIN.BERACHAIN]: 80094,
+  [CHAIN.SCROLL]: 534352,
+  // trades originating on non-EVM chains are not collected yet, enable once they are
+  // [CHAIN.SOLANA]: "solana",
+  // [CHAIN.TRON]: "tron",
+};
+
+const fetch = async (options: FetchOptions) => {
+  const response = await httpGet(
+    `https://api.0x.org/stats/cross-chain/volume/daily?timestamp=${options.startOfDay}&originChainId=${CHAINS[options.chain]}`,
+    {
+      headers: {
+        "0x-api-key": getEnv("AGGREGATOR_0X_API_KEY"),
+      },
+    },
+  );
+
+  return {
+    dailyBridgeVolume: response.data.volume,
+  };
+};
+
+const adapter: SimpleAdapter = {
+  version: 1, // the stats API only serves daily aggregates keyed to UTC midnight
+  fetch,
+  chains: Object.keys(CHAINS),
+  start: "2026-02-25",
+  methodology: {
+    BridgeVolume:
+      "USD value of filled 0x cross-chain trades, attributed to the origin chain, as reported by the 0x stats API.",
+  },
+};
+
+export default adapter;


### PR DESCRIPTION
Adds 0x cross-chain (bridge) volume. 0x is already tracked as a DEX aggregator by `aggregators/zrx`; this is a separate dataset, so the two do not overlap. Not a new protocol listing, so the template form is replaced with details, per its note.

**Source:** `GET https://api.0x.org/stats/cross-chain/volume/daily`, a public endpoint 0x added for this listing. Returns USD volume of filled cross-chain trades for one UTC day, filtered by origin chain. Attributed to the origin chain, as `bridge-aggregators/lifi` does. `version: 1` because the endpoint only serves daily aggregates keyed to UTC midnight.

**Auth:** reuses `AGGREGATOR_0X_API_KEY`, already in `helpers/env.ts` and already used by `aggregators/zrx`, so no new secret. The `test` check fails with a 401 because CI injects no keys — same as previous 0x PRs (e.g. #7964, which failed on `DUNE_API_KEYS`). 

**Rate limiting:** the API allows 5 req/s per key and `runAdapter` fetches all chains at once, so an unthrottled 21-chain run had 16 requests rejected with a 429. Requests are serialised with `p-limit` and spaced, with `asyncRetry` as a safety net, following `bridge-aggregators/okx`. 

**Chains:** 21 EVM origin chains. Solana and Tron are commented out because 0x does not yet collect trades originating on non-EVM chains.

**Verified** against the live API with a key: `2026-08-05` returns all 21 chains, aggregate $1.18M. Data goes back to the `start` of 2026-02-25 (private beta; GA was 2026-06-04).