### PR TITLE
cmswap: add volume and fees/revenue adapters

### DIFF
--- a/dexs/cmswap.ts
+++ b/dexs/cmswap.ts
@@ -1,0 +1,58 @@
+/**
+ * cmswap / Junoswap.trade — DEX Aggregator + bonding-curve launchpad volume, on Bitkub Chain.
+ *
+ * Two independent volume sources, both routed through contracts owned by the protocol:
+ *  - AggRouterJunoswap: the multi-DEX aggregator router users swap through
+ *    (routes across Udonswap, KUBLERX, Diamond, Jibswap and Junoswap's own V3 pools).
+ *  - BondingCurveJunoswap: the memecoin launchpad's buy/sell bonding curve.
+ *
+ * Junoswap's own V3 pools (tracked for TVL under projects/cmswap in DefiLlama-Adapters)
+ * mainly host graduated launchpad tokens; their raw swap volume is not counted here since
+ * routed trades already surface as Aggregated events above.
+ */
+import { Adapter, FetchOptions } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+import { addOneToken } from "../helpers/prices";
+import ADDRESSES from "../helpers/coreAssets.json";
+
+const AGG_ROUTER = "0x869A40921A332e0D79300F91361A3DC77F2a0ebc";
+const BONDING_CURVE = "0x65F6EC30A9E70822721585f6Bba15c40c2F8ab4e";
+
+const AGGREGATED_ABI =
+  "event Aggregated(address indexed sender, address indexed tokenIn, address indexed tokenOut, uint256 amountIn, uint256 amountOut, uint256 fee, uint256 legs, address referrer)";
+const SWAP_ABI =
+  "event Swap(address indexed sender, bool indexed isBuy, address indexed tokenAddr, uint256 amountIn, uint256 amountOut, uint256 reserveIn, uint256 reserveOut)";
+
+const fetch = async ({ createBalances, getLogs, chain }: FetchOptions) => {
+  const dailyVolume = createBalances();
+
+  const aggLogs = await getLogs({ target: AGG_ROUTER, eventAbi: AGGREGATED_ABI });
+  for (const log of aggLogs) {
+    addOneToken({ chain, balances: dailyVolume, token0: log.tokenIn, amount0: log.amountIn, token1: log.tokenOut, amount1: log.amountOut });
+  }
+
+  const swapLogs = await getLogs({ target: BONDING_CURVE, eventAbi: SWAP_ABI });
+  for (const log of swapLogs) {
+    const [tokenIn, tokenOut] = log.isBuy ? [ADDRESSES.null, log.tokenAddr] : [log.tokenAddr, ADDRESSES.null];
+    addOneToken({ chain, balances: dailyVolume, token0: tokenIn, amount0: log.amountIn, token1: tokenOut, amount1: log.amountOut });
+  }
+
+  return { dailyVolume };
+};
+
+const methodology = {
+  Volume: "Sum of swap volume routed through the Junoswap Aggregator Router (multi-DEX best-price routing across several Bitkub Chain DEXs) plus buy/sell volume on the Junoswap bonding-curve launchpad.",
+};
+
+const adapter: Adapter = {
+  version: 2,
+  adapter: {
+    [CHAIN.BITKUB]: {
+      fetch,
+      start: "2026-06-17",
+    },
+  },
+  methodology,
+};
+
+export default adapter;

--- a/dexs/cmswap.ts
+++ b/dexs/cmswap.ts
@@ -31,10 +31,14 @@ const fetch = async ({ createBalances, getLogs, chain }: FetchOptions) => {
     addOneToken({ chain, balances: dailyVolume, token0: log.tokenIn, amount0: log.amountIn, token1: log.tokenOut, amount1: log.amountOut });
   }
 
+  // Every bonding-curve trade has native KUB on one side and a (usually brand-new, unpriced)
+  // launchpad token on the other, so we price off the native leg directly instead of using
+  // addOneToken's isCoreAsset guess — bitkub's coreAssets.json doesn't list the native address,
+  // so that heuristic would silently price off the token side on every buy.
   const swapLogs = await getLogs({ target: BONDING_CURVE, eventAbi: SWAP_ABI });
   for (const log of swapLogs) {
-    const [tokenIn, tokenOut] = log.isBuy ? [ADDRESSES.null, log.tokenAddr] : [log.tokenAddr, ADDRESSES.null];
-    addOneToken({ chain, balances: dailyVolume, token0: tokenIn, amount0: log.amountIn, token1: tokenOut, amount1: log.amountOut });
+    const nativeAmount = log.isBuy ? log.amountIn : log.amountOut;
+    dailyVolume.add(ADDRESSES.null, nativeAmount);
   }
 
   return { dailyVolume };

--- a/fees/cmswap.ts
+++ b/fees/cmswap.ts
@@ -1,0 +1,81 @@
+/**
+ * cmswap / Junoswap.trade — Fees & Revenue on Bitkub Chain.
+ *
+ * Three fee sources, all accruing 100% to the protocol's feeCollector (no LP split),
+ * so Revenue == Fees for this adapter:
+ *  - AggRouterJunoswap: `feeBps` skimmed from swap output on every Aggregated event
+ *    (feeBps is currently 0 on-chain — the mechanism exists but isn't turned on yet).
+ *  - BondingCurveJunoswap: `pumpFee` (currently 100 bps = 1%) skimmed from every buy/sell.
+ *    The Swap event's `amountIn` is already net of this fee, so the fee is backed out of it
+ *    using the live `pumpFee()` value: fee = amountIn * pumpFee / (10000 - pumpFee).
+ *  - BondingCurveJunoswap: a flat `createFee` (currently 0.1 KUB) charged per token creation.
+ */
+import { ChainApi } from "@defillama/sdk";
+import { Adapter, FetchOptions } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+import ADDRESSES from "../helpers/coreAssets.json";
+
+const AGG_ROUTER = "0x869A40921A332e0D79300F91361A3DC77F2a0ebc";
+const BONDING_CURVE = "0x65F6EC30A9E70822721585f6Bba15c40c2F8ab4e";
+
+const AGGREGATED_ABI =
+  "event Aggregated(address indexed sender, address indexed tokenIn, address indexed tokenOut, uint256 amountIn, uint256 amountOut, uint256 fee, uint256 legs, address referrer)";
+const SWAP_ABI =
+  "event Swap(address indexed sender, bool indexed isBuy, address indexed tokenAddr, uint256 amountIn, uint256 amountOut, uint256 reserveIn, uint256 reserveOut)";
+const CREATION_ABI =
+  "event Creation(address indexed creator, address tokenAddr, string logo, string description, string link1, string link2, string link3, uint256 createdTime)";
+
+const fetch = async ({ createBalances, getLogs, chain }: FetchOptions) => {
+  const dailyFees = createBalances();
+
+  const aggLogs = await getLogs({ target: AGG_ROUTER, eventAbi: AGGREGATED_ABI });
+  for (const log of aggLogs) {
+    dailyFees.add(log.tokenOut, log.fee, "Aggregator router fee");
+  }
+
+  // pumpFee/createFee changes aren't logged on-chain, so there's no historical value to read.
+  // We use a fresh *current-state* call (not the framework's block-pinned `api`) because
+  // Bitkub Chain's public RPC isn't an archive node and rejects eth_call at old blocks.
+  const currentApi = new ChainApi({ chain });
+  const [pumpFeeBps, createFeeAmount] = await Promise.all([
+    currentApi.call({ target: BONDING_CURVE, abi: "uint256:pumpFee" }),
+    currentApi.call({ target: BONDING_CURVE, abi: "uint256:createFee" }),
+  ]);
+  const pumpFeeBigInt = BigInt(pumpFeeBps);
+
+  if (pumpFeeBigInt > 0n) {
+    const swapLogs = await getLogs({ target: BONDING_CURVE, eventAbi: SWAP_ABI });
+    for (const log of swapLogs) {
+      const feeAmount = (BigInt(log.amountIn) * pumpFeeBigInt) / (10000n - pumpFeeBigInt);
+      const feeToken = log.isBuy ? ADDRESSES.null : log.tokenAddr;
+      dailyFees.add(feeToken, feeAmount.toString(), "Launchpad trading fee");
+    }
+  }
+
+  const creationLogs = await getLogs({ target: BONDING_CURVE, eventAbi: CREATION_ABI });
+  if (creationLogs.length) {
+    const totalCreationFees = BigInt(createFeeAmount) * BigInt(creationLogs.length);
+    dailyFees.add(ADDRESSES.null, totalCreationFees.toString(), "Launchpad token-creation fee");
+  }
+
+  return { dailyFees, dailyRevenue: dailyFees, dailyProtocolRevenue: dailyFees };
+};
+
+const methodology = {
+  Fees: "Aggregator: the router-skim fee (feeBps) deducted from swap output on the Junoswap Aggregator Router. Launchpad: the pump fee (bps) deducted from every bonding-curve buy/sell, plus the flat token-creation fee.",
+  Revenue: "All fees accrue entirely to the Junoswap protocol treasury (feeCollector) — there is no LP split — so Revenue equals Fees.",
+  "Protocol Revenue": "Same as Revenue: 100% of collected fees go to the protocol treasury.",
+};
+
+const adapter: Adapter = {
+  version: 2,
+  adapter: {
+    [CHAIN.BITKUB]: {
+      fetch,
+      start: "2026-06-17",
+    },
+  },
+  methodology,
+};
+
+export default adapter;


### PR DESCRIPTION
## Summary
- `dexs/cmswap.ts`: daily swap volume for Junoswap.trade (DefiLlama TVL slug `cmswap`) on Bitkub Chain — routed through the `AggRouterJunoswap` aggregator plus buy/sell volume on the `BondingCurveJunoswap` launchpad.
- `fees/cmswap.ts`: daily fees/revenue from the aggregator's router-skim fee, the launchpad's pump fee, and the flat token-creation fee. All fees accrue 100% to the protocol treasury, so Revenue = Fees = Protocol Revenue.

## Methodology notes
- The launchpad's `Swap` event emits `amountIn` net of the pump fee, so the fee is backed out using the live `pumpFee()` value (`fee = amountIn * pumpFee / (10000 - pumpFee)`) rather than assumed.
- Fee/creation-fee contract reads use a fresh current-state `ChainApi` rather than the framework's block-pinned one, since Bitkub Chain's public RPC isn't archive-capable and rejects `eth_call` at historical blocks.
- Aggregator router fee (`feeBps`) is currently 0 on-chain (mechanism exists, not yet turned on), so aggregator fee revenue is $0 until it's enabled — expected, not a bug.

## Test plan
- [x] `npx ts-node --transpile-only cli/testAdapter.ts dexs cmswap` — runs clean, correctly reports non-zero volume on historical dates with known launchpad activity.
- [x] `npx ts-node --transpile-only cli/testAdapter.ts fees cmswap` — runs clean on both current and historical dates after fixing the archive-node issue.
- [x] `tsc --project tsconfig.json --noEmit` — no errors in either file.