### PR TITLE
Fix Temple maker and taker fee rates

### DIFF
--- a/dexs/temple/index.ts
+++ b/dexs/temple/index.ts
@@ -4,8 +4,8 @@ import fetchURL from "../../utils/fetchURL";
 
 const API_BASE_URL = "https://api.templedigitalgroup.com/api/exchange";
 const SETTLED_VOLUME_URL = `${API_BASE_URL}/settled_volume`;
-const MAKER_FEE_BPS = 1;
-const TAKER_FEE_BPS = 2;
+const MAKER_FEE_BPS = 0.5;
+const TAKER_FEE_BPS = 1;
 const BPS = 10000;
 
 type SettledVolumeResponse = {
@@ -54,7 +54,7 @@ const fetch = async (options: FetchOptions): Promise<FetchResult> => {
 const methodology = {
   Volume:
     "Settled spot orderbook volume across Temple markets quoted in the USD-pegged USDA and USDCx assets. Temple aggregates current and legacy markets for the requested half-open time window.",
-  Fees: "Trading fees charged by the Temple orderbook: 1 bps maker + 2 bps taker = 3 bps applied to settled volume.",
+  Fees: "Trading fees charged by the Temple orderbook: 0.5 bps maker + 1 bp taker = 1.5 bps applied to settled volume.",
   Revenue: "All trading fees are retained by the protocol.",
   ProtocolRevenue: "All trading fees are retained by the protocol.",
   SupplySideRevenue: "Zero. No trading-fee share is paid to liquidity providers or market makers.",
@@ -62,16 +62,16 @@ const methodology = {
 
 const breakdownMethodology = {
   Fees: {
-    "Maker Fees": "1 bps maker fee applied to settled volume.",
-    "Taker Fees": "2 bps taker fee applied to settled volume.",
+    "Maker Fees": "0.5 bps maker fee applied to settled volume.",
+    "Taker Fees": "1 bp taker fee applied to settled volume.",
   },
   Revenue: {
-    "Maker Fees": "1 bps maker fee applied to settled volume.",
-    "Taker Fees": "2 bps taker fee applied to settled volume.",
+    "Maker Fees": "0.5 bps maker fee applied to settled volume.",
+    "Taker Fees": "1 bp taker fee applied to settled volume.",
   },
   ProtocolRevenue: {
-    "Maker Fees": "1 bps maker fee applied to settled volume.",
-    "Taker Fees": "2 bps taker fee applied to settled volume.",
+    "Maker Fees": "0.5 bps maker fee applied to settled volume.",
+    "Taker Fees": "1 bp taker fee applied to settled volume.",
   },
 };
 


### PR DESCRIPTION
## Summary

- correct Temple's maker fee from 1 bp to 0.5 bps
- correct Temple's taker fee from 2 bps to 1 bp
- update the fee, revenue, and protocol-revenue methodology breakdowns

## Why

The adapter currently overstates both rates by 2x, reporting a combined 3 bps instead of the correct combined 1.5 bps.

## Validation

- `pnpm test dexs temple 2026-08-10`
  - `$6.90M` daily volume
  - `$345` maker fees at 0.5 bps
  - `$690` taker fees at 1 bp
  - `$1.03K` total fees and revenue
- `pnpm ts-check`
- `git diff --check`
