### PR TITLE
bluefin7k: throw when 7k.ag returns 0 instead of publishing it as no volume

### DIFF
--- a/aggregators/bluefin7k-aggregator/index.ts
+++ b/aggregators/bluefin7k-aggregator/index.ts
@@ -9,9 +9,10 @@ const fetch: FetchV2 = async ({ fromTimestamp, toTimestamp }) => {
 	const dailyVolume = await fetchURL(
 		`${URL}/volume-with-ts?from_timestamp=${fromTimestamp}&to_timestamp=${toTimestamp}`,
 	);
-	if (!(Number(dailyVolume) > 0))
+	const volume = Number(dailyVolume);
+	if (!Number.isFinite(volume) || volume <= 0)
 		throw new Error(
-			`bluefin7k: statistic.7k.ag returned no volume (${dailyVolume}) for ${fromTimestamp}-${toTimestamp}`,
+			`bluefin7k: statistic.7k.ag returned no usable volume (${dailyVolume}) for ${fromTimestamp}-${toTimestamp}`,
 		);
 	return { dailyVolume };
 };

--- a/aggregators/bluefin7k-aggregator/index.ts
+++ b/aggregators/bluefin7k-aggregator/index.ts
@@ -9,6 +9,10 @@ const fetch: FetchV2 = async ({ fromTimestamp, toTimestamp }) => {
 	const dailyVolume = await fetchURL(
 		`${URL}/volume-with-ts?from_timestamp=${fromTimestamp}&to_timestamp=${toTimestamp}`,
 	);
+	if (!(Number(dailyVolume) > 0))
+		throw new Error(
+			`bluefin7k: statistic.7k.ag returned no volume (${dailyVolume}) for ${fromTimestamp}-${toTimestamp}`,
+		);
 	return { dailyVolume };
 };
 


### PR DESCRIPTION
Fixes #8685.

`statistic.7k.ag` has returned the literal string `"0"` since 2026-06-18, and the adapter published it, so the aggregator has recorded 54 consecutive days of `$0` volume while it is still routing trades on Sui.

The endpoint is up and still serves real numbers for older ranges; it just stopped ingesting:

```
2026-06-17  "49063.135086680428629794442134..."
2026-06-18  "0"
2026-08-09  "0"
```

and its cumulative total is frozen to the last decimal between 06-18 and now (`"15974325942.82599630790889469781629454202543333541288337786680636476432937342906370759010314941406 25"` either way), with the delta between them returning `"0"`.

The aggregator itself is live; package `0x62412b7268c35f3808336aee57a52836501f40b8ba5d936f8ad275e672befd04` was transacting seconds apart minutes before I filed the issue, and Sui peers report normally over the same window. Full evidence in #8685.

Zero has never been a real value from this endpoint: over the 379 days before the break the minimum non-zero day is $49,063 and the median is $11.9M, and the 32 zero days in that period sit in tight clusters that look like earlier outages of the same service.

Throwing rather than recording the zero, matching #8525, #8526, #8538, #8539 and #8547. `!(Number(x) > 0)` so a null, empty or missing body is caught the same way as `"0"`.

Verified both directions, twice each:

```
$ npm test aggregators bluefin7k-aggregator 2026-08-05
Error: bluefin7k: statistic.7k.ag returned no volume (0) for 1785801599-1785887999

$ npm test aggregators bluefin7k-aggregator 2026-06-16
Daily volume: 63.44 k
```

which matches what the endpoint serves for that day (`63435.899…`). `npm run ts-check` passes.

The 54 days already recorded stay wrong until the upstream refills; this only stops more from being added.
