### PR TITLE
monster: stop double-counting credit-card volume, fix methodology and…

### DIFF
--- a/dexs/monster/index.ts
+++ b/dexs/monster/index.ts
@@ -15,11 +15,17 @@ const USDM = "0xFAfDdbb3FC7688494971a79cc65DCa3EF82079E7";
 const USDC = "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913";
 const PAYMENT_WALLET = "0x61fccfC0279B09c387608efF56Fd9187e61D2874";
 const TREASURY = "0x7Fc8d4b747dAc14b68bEe79d93C7130257c98a62";
+// settles credit-card payments to the payment wallet on Base — sole sender since the leg began
+const CARD_PROCESSOR = "0x853f2c11774bb08031e7dea93803569bbe2058f8";
 
 const GachaPlayedEvent =
   "event GachaPlayed(address indexed player, uint256 indexed requestId, uint256 costPaid)";
 const TransferEvent =
   "event Transfer(address indexed from, address indexed to, uint256 value)";
+const TRANSFER_TOPIC =
+  "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef";
+const addressTopic = (address: string) =>
+  "0x000000000000000000000000" + address.slice(2).toLowerCase();
 
 
 const fetch = async (options: FetchOptions) => {
@@ -40,15 +46,13 @@ const fetch = async (options: FetchOptions) => {
   const transferLogs = await options.getLogs({
     target: USDM,
     eventAbi: TransferEvent,
-    topics: [
-      "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
-      "0x000000000000000000000000" + PAYMENT_WALLET.slice(2).toLowerCase(),
-    ],
+    topics: [TRANSFER_TOPIC, addressTopic(PAYMENT_WALLET)],
   });
   for (const log of transferLogs) {
     const to = String(log.to).toLowerCase();
+    // sweeps to the protocol's own treasury are internal, not a payout
     if (to === TREASURY.toLowerCase()) continue;
-    dailyFees.subtractToken(USDM, log.value, 'Card Buyback Spends');
+    dailyFees.subtractToken(USDM, log.value, 'Card Sellback Payouts To Players');
   }
 
   return {
@@ -69,16 +73,18 @@ const fetchOffchain = async (options: FetchOptions) => {
     toTimestamp: options.toTimestamp,
     target: USDC,
     eventAbi: TransferEvent,
+    onlyArgs: true,
     topics: [
-      "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
-      null,
-      "0x000000000000000000000000" + PAYMENT_WALLET.slice(2).toLowerCase(),
+      TRANSFER_TOPIC,
+      addressTopic(CARD_PROCESSOR),
+      addressTopic(PAYMENT_WALLET),
     ],
   });
 
+  // no volume here: card money is credited to the player as USDm and is already
+  // counted on megaeth when they open a pack with it
   for (const log of transferLogs) {
-    dailyVolume.addUSDValue(Number(log.args.value) / 1e6);
-    dailyFees.addUSDValue(Number(log.args.value) / 1e6, 'Gacha Play Spends - Credit Card');
+    dailyFees.addUSDValue(Number(log.value) / 1e6, 'Gacha Play Spends - Credit Card');
   }
 
   return {
@@ -90,18 +96,22 @@ const fetchOffchain = async (options: FetchOptions) => {
 };
 
 const methodology = {
-  Volume: "USDm paid by users into the six Gacha contracts when calling play(). Sourced from the costPaid field on GachaPlayed events.",
-  Fees: "Net USDm retained by the protocol: gross play fees minus sellback payouts.",
-  Revenue: "Net USDm retained by the protocol: gross play fees minus sellback payouts.",
-  ProtocolRevenue: "Net USDm retained by the protocol: gross play fees minus sellback payouts.",
+  Volume: "USDm players spend opening Gacha packs across the six tiers (50, 100, 150, 250, 500 and 1250 USDm a pack). Promotional free packs cost the player nothing and add nothing. Credit-card purchases are not counted again here: that money is credited to the player as USDm and already shows up when they open a pack with it.",
+  Fees: "What the protocol keeps from the game: pack spend plus credit-card payments, minus the USDm paid back to players who sell their cards back at up to 95% of fair market value. Goes negative on days when players sell back more than they spend.",
+  Revenue: "Same as Fees — pack spend and card payments less sellback payouts to players. Nothing is shared with liquidity providers or any other supplier.",
+  ProtocolRevenue: "All of it. Every dollar the protocol keeps ends up in its treasury.",
+};
+
+const feeBreakdown = {
+  'Gacha Play Spends - On-Chain': 'USDm players pay to open packs on MegaETH.',
+  'Gacha Play Spends - Credit Card': 'Credit-card purchases, settled to the protocol in USDC on Base before the player is credited USDm to open a pack with.',
+  'Card Sellback Payouts To Players': 'USDm paid back to players who sold their cards back to the protocol, subtracted from what the protocol keeps.',
 };
 
 const breakdownMethodology = {
-  Fees: {
-    'Gacha Play Spends - On-Chain': 'USDm paid by users into the six Gacha contracts when calling play(). Sourced from the costPaid field on GachaPlayed events.',
-    'Gacha Play Spends - Credit Card': 'Amount paid by users into the six Gacha contracts when calling play() via credit card.',
-    'Card Buyback Spends': 'USDm spent by the protocol to buy back cards.',
-  }
+  Fees: feeBreakdown,
+  Revenue: feeBreakdown,
+  ProtocolRevenue: feeBreakdown,
 }
 
 const adapter: SimpleAdapter = {
@@ -111,7 +121,7 @@ const adapter: SimpleAdapter = {
   adapter: {
     [CHAIN.MEGAETH]: {
       fetch,
-      start: "2026-04-04",
+      start: "2026-04-15",
     },
     [CHAIN.OFF_CHAIN]: {
       fetch: fetchOffchain,

--- a/dexs/monster/index.ts
+++ b/dexs/monster/index.ts
@@ -22,10 +22,13 @@ const GachaPlayedEvent =
   "event GachaPlayed(address indexed player, uint256 indexed requestId, uint256 costPaid)";
 const TransferEvent =
   "event Transfer(address indexed from, address indexed to, uint256 value)";
+// keccak256("Transfer(address,address,uint256)")
 const TRANSFER_TOPIC =
   "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef";
+// indexed address args are left-padded to 32 bytes
 const addressTopic = (address: string) =>
   "0x000000000000000000000000" + address.slice(2).toLowerCase();
+const USDC_DECIMALS = 6; // Base USDC (0x8335…2913)
 
 
 const fetch = async (options: FetchOptions) => {
@@ -66,7 +69,6 @@ const fetch = async (options: FetchOptions) => {
 const fetchOffchain = async (options: FetchOptions) => {
   const baseApi = new ChainApi({ chain: CHAIN.BASE });
   const dailyFees = options.createBalances();
-  const dailyVolume = options.createBalances();
 
   const transferLogs = await baseApi.getLogs({
     fromTimestamp: options.fromTimestamp,
@@ -84,11 +86,10 @@ const fetchOffchain = async (options: FetchOptions) => {
   // no volume here: card money is credited to the player as USDm and is already
   // counted on megaeth when they open a pack with it
   for (const log of transferLogs) {
-    dailyFees.addUSDValue(Number(log.value) / 1e6, 'Gacha Play Spends - Credit Card');
+    dailyFees.addUSDValue(Number(log.value) / 10 ** USDC_DECIMALS, 'Gacha Play Spends - Credit Card');
   }
 
   return {
-    dailyVolume,
     dailyFees,
     dailyRevenue: dailyFees,
     dailyProtocolRevenue: dailyFees,


### PR DESCRIPTION
## Changes

* Remove double-counted Base credit-card volume; keep the card leg in `dailyFees`.
* Filter Base inflows to the verified payment processor and centralize topic construction.
* Correct `start` to `2026-04-15`.
* Fix methodology and breakdown labels for card spends, sellback payouts, volume, fees, and revenue.
* Use `onlyArgs: true` consistently for Base logs.

## Verification

* `pnpm test dexs monster 2026-08-05`: aggregate volume **411.77k → 410.18k**; fees **13.90k → 13.71k**.
* Off-chain volume drops **1.60k → $0**, while fees remain exactly **$1,600**, matching a direct scan.
* MegaETH volume remains unchanged apart from expected sub-0.05% hourly pricing drift.
