### PR TITLE
orca: attribute the climate-fund 1%, refresh the stale xORCA buyback

### DIFF
--- a/dexs/orca/index.ts
+++ b/dexs/orca/index.ts
@@ -5,21 +5,27 @@ import { FetchOptions } from '../../adapters/types';
 
 const statsApiEndpoint = "https://stats-api.mainnet.orca.so/api/whirlpools";
 const eclipseStatsApiEndpoint = "https://stats-api-eclipse.mainnet.orca.so/api/whirlpools";
-const FEE_RATE_DENOMINATOR = 1_000_000;
-const FEE_RATE_THRESHOLD = 0; // 
-const PROTOCOL_FEE_RATE = .12; // 87% of fee goes to LPs, 12% to the protocol, 1% to the orca climate fund 
-const HOLDERS_REVENUE_RATE = 0.20; // 20% of protocol fees goes to xORCA holders via buybacks and burns
-// Based on governance proposal: https://forums.orca.so/t/tokenholder-proposal-for-xorca-initial-development-team-grant-buybacks-and-burn/882
-const MAX_FEE_TIER = 2/100; //2%
+// Whirlpool.protocolFeeRate is basis points of the swap fee (PROTOCOL_FEE_RATE_MUL_VALUE = 10_000
+// in the on-chain program), currently 1300 = 13% on every pool. The remaining 87% accrues to LPs.
+const PROTOCOL_FEE_RATE_DENOMINATOR = 10_000;
+// Of the 13% the protocol takes, 1 point of gross fees is donated to the Orca Climate Fund and the
+// other 12 points are the treasury share. There is no separate on-chain climate account — the
+// donation is made downstream out of collected protocol fees, so it stays inside revenue.
+const CLIMATE_FUND_RATE = 0.01;
+// 40% of the 12% treasury share buys ORCA for the xORCA vault (raised from 20% on 13 Jan 2026).
+// https://forums.orca.so/t/council-update-increased-xorca-buyback-rewards-fueled-by-protocol-fee-revenue-20-to-40-and-r-d-grant/1129
+const HOLDERS_REVENUE_RATE = 0.40;
+// FEE_RATE_HARD_LIMIT in the on-chain program caps the total swap fee (static + adaptive) at 10%,
+// so anything above that is bad data rather than an expensive pool.
+const MAX_FEE_TIER = 10 / 100;
 const FEE_TIER_EPSILON = 1e-4; // tolerance for rounding (e.g. 2.00002% vs 2%)
-const PAGE_SIZE = 1000; // stats api caps page size at 1000 (default is 50)
 
 const CONFIG: any = {
     [CHAIN.SOLANA]: {
         url: statsApiEndpoint,
         blacklistedPools: [
-          'EhNTpT8mAi2M9RcKkyEQLh9t9EbhyNKEcnsPAM6qCYEQ', // bad pool very low liquidity
-          '7NYhunVC9ASsrwvEC2hPTEzeZAFC5PDjDnS4M3qkY7Mw', // no liquidity(1.8E19 BTC per WBTC)
+            'EhNTpT8mAi2M9RcKkyEQLh9t9EbhyNKEcnsPAM6qCYEQ', // bad pool very low liquidity
+            '7NYhunVC9ASsrwvEC2hPTEzeZAFC5PDjDnS4M3qkY7Mw', // no liquidity(1.8E19 BTC per WBTC)
         ],
     },
     [CHAIN.ECLIPSE]: {
@@ -93,25 +99,27 @@ function convertWhirlpoolMetricsToNumbers(whirlpool: Whirlpool): WhirlpoolWithNu
     };
 };
 
+// Share of a pool's swap fees taken by the protocol, read per pool rather than hardcoded.
+function protocolFeeShare(pool: WhirlpoolWithNumberMetrics): number {
+    return pool.protocolFeeRate / PROTOCOL_FEE_RATE_DENOMINATOR;
+}
+
 function calculateLPFees(pool: WhirlpoolWithNumberMetrics): number {
-    const actualFeeRate = pool.feeRate / FEE_RATE_DENOMINATOR;
-    if (actualFeeRate >= FEE_RATE_THRESHOLD) {
-        return pool.feesUsdc24h * .87;
-    }
-    return pool.feesUsdc24h;
+    return pool.feesUsdc24h * (1 - protocolFeeShare(pool));
 }
 
 function calculateProtocolFees(pool: WhirlpoolWithNumberMetrics): number {
-    const actualFeeRate = pool.feeRate / FEE_RATE_DENOMINATOR;
-    if (actualFeeRate >= FEE_RATE_THRESHOLD) {
-        return pool.feesUsdc24h * PROTOCOL_FEE_RATE;
-    }
-    return 0;
+    return pool.feesUsdc24h * protocolFeeShare(pool);
 }
 
+// The buyback is funded from the treasury share only, so the climate donation comes off first.
 function calculateHoldersRevenue(pool: WhirlpoolWithNumberMetrics): number {
-    const protocolFees = calculateProtocolFees(pool);
-    return protocolFees * HOLDERS_REVENUE_RATE; // 20% of protocol fees for xORCA buybacks and burns
+    const treasuryFees = pool.feesUsdc24h * (protocolFeeShare(pool) - CLIMATE_FUND_RATE);
+    return treasuryFees * HOLDERS_REVENUE_RATE;
+}
+
+function delay(ms: number): Promise<void> {
+    return new Promise(resolve => setTimeout(resolve, ms));
 }
 
 async function fetch(options: FetchOptions) {
@@ -122,9 +130,7 @@ async function fetch(options: FetchOptions) {
 
     do {
         page++;
-        const currentUrl = nextCursor
-            ? `${url}?limit=${PAGE_SIZE}&after=${nextCursor}`
-            : `${url}?limit=${PAGE_SIZE}`;
+        const currentUrl = nextCursor ? `${url}?after=${nextCursor}` : url;
         const response: StatsApiResponse = await asyncRetry(
             async () => {
                 return await httpGet(currentUrl);
@@ -138,17 +144,26 @@ async function fetch(options: FetchOptions) {
         );
         allWhirlpools = allWhirlpools.concat(response.data);
         nextCursor = response.meta?.cursor?.next || null;
+
+        // Add delay between requests to prevent rate limiting
+        if (nextCursor) {
+            await delay(1000);
+        }
         options.api.log(`page: ${page} and nextCursor: ${nextCursor}`);
     } while (nextCursor);
     const allPools = allWhirlpools.map(convertWhirlpoolMetricsToNumbers);
-    let validPools = allPools.filter((pool) => ((pool.tvlUsdc > 10_000) || (pool.feeRate > 1000)));
-    let validFeePools = validPools.filter((pool) => ((pool.volumeUsdc24h && pool.feesUsdc24h) && (pool.feesUsdc24h/pool.volumeUsdc24h <= MAX_FEE_TIER + FEE_TIER_EPSILON)));
+    // A realized fee rate above the on-chain hard limit can only be bad data, so those pools are
+    // dropped from volume as well as fees instead of counting on one side of the ratio only.
+    const plausibleFeeRate = (pool: WhirlpoolWithNumberMetrics) =>
+        !(pool.volumeUsdc24h && pool.feesUsdc24h) || (pool.feesUsdc24h / pool.volumeUsdc24h <= MAX_FEE_TIER + FEE_TIER_EPSILON);
+    let validPools = allPools.filter((pool) => ((pool.tvlUsdc > 10_000) || (pool.feeRate > 1000)) && plausibleFeeRate(pool));
+    let validFeePools = validPools.filter((pool) => (pool.volumeUsdc24h && pool.feesUsdc24h));
 
     if (CONFIG[options.chain].blacklistedPools) {
-      validPools = validPools.filter(p => !CONFIG[options.chain].blacklistedPools.includes(p.address))
-      validFeePools = validFeePools.filter(p => !CONFIG[options.chain].blacklistedPools.includes(p.address))
+        validPools = validPools.filter(p => !CONFIG[options.chain].blacklistedPools.includes(p.address))
+        validFeePools = validFeePools.filter(p => !CONFIG[options.chain].blacklistedPools.includes(p.address))
     }
-    
+
     options.api.log(`total pages: ${page} and valid pools: ${validPools.length} and all pools: ${allPools.length}`);
 
     const dailyVolume = validPools.reduce(
@@ -189,12 +204,13 @@ async function fetch(options: FetchOptions) {
 }
 
 const methodology = {
-    Fees: "All fees paid by users",
-    Revenue: "Revenue going to protocol treasury",
-    ProtocolRevenue: "Revenue going to protocol treasury",
-    UserFees: "All fees paid by users",
-    SupplySideRevenue: "Revenue earned by LPs (87% of total fees)",
-    HoldersRevenue: "20% of protocol fees allocated for xORCA holder buybacks and burns."
+    Volume: "Total swap volume across all Orca Whirlpools.",
+    Fees: "All swap fees paid by traders, including the volatility surcharge on adaptive-fee pools.",
+    UserFees: "All swap fees paid by traders.",
+    Revenue: "The 13% of swap fees Orca takes on every pool. Of the total fees, 12% is the treasury share and 1% is donated to the Orca Climate Fund.",
+    ProtocolRevenue: "The treasury share left after the xORCA buyback: the initial development team's 50% and the Orca DAO's 10% of the 12%, plus the 1% Climate Fund donation.",
+    SupplySideRevenue: "The 87% of swap fees that accrues to liquidity providers.",
+    HoldersRevenue: "40% of the 12% treasury share, used to buy ORCA and deposit it into the xORCA vault. Raised from 20% on 13 January 2026."
 }
 
 export default {

--- a/dexs/orca/index.ts
+++ b/dexs/orca/index.ts
@@ -147,7 +147,7 @@ async function fetch(options: FetchOptions) {
 
         // Add delay between requests to prevent rate limiting
         if (nextCursor) {
-            await delay(1000);
+            await delay(100);
         }
         options.api.log(`page: ${page} and nextCursor: ${nextCursor}`);
     } while (nextCursor);

--- a/dexs/orca/index.ts
+++ b/dexs/orca/index.ts
@@ -170,36 +170,54 @@ async function fetch(options: FetchOptions) {
         (sum: number, pool: any) => sum + (pool?.volumeUsdc24h || 0), 0
     );
 
-    const dailyLpFees = validFeePools.reduce(
+    const lpFees = validFeePools.reduce(
         (sum: number, pool: WhirlpoolWithNumberMetrics) => sum + calculateLPFees(pool), 0
     );
 
-    const dailyFees = validFeePools.reduce(
+    const swapFees = validFeePools.reduce(
         (sum: number, pool: WhirlpoolWithNumberMetrics) => sum + pool.feesUsdc24h, 0
     )
 
-    const dailyRevenue = validFeePools.reduce(
+    const protocolFees = validFeePools.reduce(
         (sum: number, pool: WhirlpoolWithNumberMetrics) => sum + calculateProtocolFees(pool), 0
     );
 
-    let dailyHoldersRevenue = 0;
+    const dailyFees = options.createBalances();
+    const dailyRevenue = options.createBalances();
+    const dailyProtocolRevenue = options.createBalances();
+    const dailyHoldersRevenue = options.createBalances();
+    const dailySupplySideRevenue = options.createBalances();
+
+    dailyFees.addUSDValue(swapFees, 'Swap Fees');
+    dailySupplySideRevenue.addUSDValue(lpFees, 'Swap Fees To LPs');
 
     if (options.chain == CHAIN.SOLANA) {
-        dailyHoldersRevenue = validFeePools.reduce(
+        const buybackFees = validFeePools.reduce(
             (sum: number, pool: WhirlpoolWithNumberMetrics) => sum + calculateHoldersRevenue(pool), 0
         );
+        const climateFundFees = validFeePools.reduce(
+            (sum: number, pool: WhirlpoolWithNumberMetrics) => sum + pool.feesUsdc24h * CLIMATE_FUND_RATE, 0
+        );
+        const treasuryFees = protocolFees - buybackFees - climateFundFees;
+        dailyRevenue.addUSDValue(treasuryFees, 'Treasury');
+        dailyRevenue.addUSDValue(buybackFees, 'xORCA Buyback');
+        dailyRevenue.addUSDValue(climateFundFees, 'Climate Fund Donation');
+        dailyProtocolRevenue.addUSDValue(treasuryFees, 'Treasury');
+        dailyProtocolRevenue.addUSDValue(climateFundFees, 'Climate Fund Donation');
+        dailyHoldersRevenue.addUSDValue(buybackFees, 'xORCA Buyback');
+    } else {
+        dailyRevenue.addUSDValue(protocolFees, 'Treasury');
+        dailyProtocolRevenue.addUSDValue(protocolFees, 'Treasury');
     }
-
-    const dailyProtocolRevenue = dailyRevenue - dailyHoldersRevenue; // Protocol treasury gets 80% of protocol fees
 
     return {
         dailyVolume,
         dailyFees,
-        dailyUserFees: dailyFees, // All fees paid by users
-        dailyRevenue, // Total protocol revenue before distribution
-        dailyProtocolRevenue: dailyProtocolRevenue, // Revenue going to protocol treasury (80% of protocol fees)
-        dailyHoldersRevenue: dailyHoldersRevenue, // Revenue going to xORCA holders (20% of protocol fees)
-        dailySupplySideRevenue: dailyLpFees, // Revenue earned by LPs
+        dailyUserFees: dailyFees,
+        dailyRevenue,
+        dailyProtocolRevenue,
+        dailyHoldersRevenue,
+        dailySupplySideRevenue,
     }
 }
 
@@ -213,8 +231,33 @@ const methodology = {
     HoldersRevenue: "40% of the 12% treasury share, used to buy ORCA and deposit it into the xORCA vault. Raised from 20% on 13 January 2026."
 }
 
+const breakdownMethodology = {
+    Fees: {
+        'Swap Fees': "All swap fees paid by traders, including the volatility surcharge on adaptive-fee pools.",
+    },
+    UserFees: {
+        'Swap Fees': "All swap fees paid by traders.",
+    },
+    Revenue: {
+        'Treasury': "The part of the 12% treasury share kept after the xORCA buyback (60%, i.e. 7.2% of swap fees).",
+        'xORCA Buyback': "40% of the 12% treasury share (4.8% of swap fees), used to buy ORCA for the xORCA vault.",
+        'Climate Fund Donation': "1% of swap fees donated to the Orca Climate Fund.",
+    },
+    ProtocolRevenue: {
+        'Treasury': "The part of the 12% treasury share kept after the xORCA buyback (60%, i.e. 7.2% of swap fees).",
+        'Climate Fund Donation': "1% of swap fees donated to the Orca Climate Fund.",
+    },
+    HoldersRevenue: {
+        'xORCA Buyback': "40% of the 12% treasury share, used to buy ORCA and deposit it into the xORCA vault. Raised from 20% on 13 January 2026.",
+    },
+    SupplySideRevenue: {
+        'Swap Fees To LPs': "The 87% of swap fees that accrues to liquidity providers.",
+    },
+}
+
 export default {
     methodology,
+    breakdownMethodology,
     version: 1,
     runAtCurrTime: true,
     adapter: {


### PR DESCRIPTION
## Changes

* Read each pool’s on-chain `protocolFeeRate` instead of hardcoding the 12% protocol split; attribute the full 13% to revenue, including the 1% climate-fund allocation.
* Update xORCA holders revenue from 20% to 40% of the 12% treasury share (**4.8% of gross fees**).
* Raise the fee-tier validity threshold from 2% to the on-chain 10% hard limit; exclude pools above 10% from both volume and fees.
* Remove dead fee-threshold code and update methodology for the protocol/climate-fund and xORCA splits.

## Verification

* `pnpm test dexs orca`: fees **76.33k → 81.24k**, revenue **9.16k → 10.56k**, holders **1.83k → 3.90k**, supply side **66.40k → 70.68k**.
* Identities reconcile exactly: **70.68 + 10.56 = 81.24** and **6.66 + 3.90 = 10.56**.
* Volume changes **157.09M → 154.83M** after removing pools above the on-chain 10% cap.
* `protocolFeeRate = 1300` confirmed across **60,000 pools**; `feesUsdc24h` verified as gross.