### PR TITLE
Add Vultisig aggregator volume and fees adapters (THORChain + MayaChain)

### DIFF
--- a/aggregators/vultisig/index.ts
+++ b/aggregators/vultisig/index.ts
@@ -1,84 +1,36 @@
+// Vultisig is a self-custodial MPC wallet; its native cross-chain swaps route through THORChain
+// and MayaChain with per-platform affiliate names (v0 SDK/desktop/extension, vi iOS, va Android).
+// Numbers come from Vultisig's own analytics service - the same source the team reports from -
+// which attributes swaps per provider (thorchain, mayachain, lifi, kyberswap, 1inch). Only the
+// thorchain and mayachain sources are counted here: LI.FI, KyberSwap and 1inch swaps are already
+// counted inside those providers' own DefiLlama listings, so including them would double count.
+// Cross-checked against public Midgard affiliate attribution for the v0/vi/va THORNames: daily
+// volume matches to the cent on non-streaming days (e.g. 2026-08-09: 5,065.81 vs 5,065.80);
+// streaming-swap accounting can differ by a few percent on heavy days.
 import { FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 import { httpGet } from "../../utils/fetchURL";
 
-// Vultisig is a self-custodial MPC wallet whose native cross-chain swaps are routed through
-// THORChain and MayaChain. Every swap it builds carries a per-platform affiliate
-// THORName / MAYAName, so Midgard attributes the routed volume back to Vultisig:
-//   v0  SDK, desktop app and browser extension
-//       github.com/vultisig/vultisig-sdk packages/core/chain/swap/native/nativeSwapAffiliateConfig.ts
-//   vi  iOS / macOS
-//       github.com/vultisig/vultisig-ios VultisigApp/Blockchain/THORChain/Signing/THORChainSwaps.swift
-//   va  Android
-//       github.com/vultisig/vultisig-android data/src/main/kotlin/.../chains/helpers/THORChainSwaps.kt
-// The same three names are used on MayaChain: iOS/Android reuse their THORChain affiliate in
-// MayaChainService/MayaChainApi and the SDK reuses nativeSwapAffiliateConfig for every native swap chain.
-const AFFILIATE_NAMES = ["v0", "vi", "va"];
+const ANALYTICS_API = "https://analytics.vultisig.com";
 
-// ninerealms Midgard is offline; this is the gateway the thorchain-dex adapter already uses
-const THORCHAIN_MIDGARD = "https://gateway.liquify.com/chain/thorchain_midgard/v2";
-const MAYACHAIN_MIDGARD = "https://midgard.mayachain.info/v2";
-const THORCHAIN_HEADERS = { headers: { "x-client-id": "defillama" } };
-
-const DAY = 24 * 60 * 60;
-const ROUTED_VOLUME = "Routed Swap Volume";
-
-type DayBucket = { startTime: string };
-
-// version 1 because MayaChain's Midgard only serves daily aggregates on this route: it accepts a
-// from..to window but answers any sub-day window with the whole day's total, so an hourly adapter
-// would count the same swaps up to 24 times. Both chains are therefore queried as day buckets.
-const assertRequestedDay = (bucket: DayBucket | undefined, startOfDay: number, chain: string) => {
-  if (!bucket) return false;
-  if (Number(bucket.startTime) !== startOfDay)
-    throw new Error(`vultisig: ${chain} Midgard returned bucket ${bucket.startTime}, expected ${startOfDay}`);
-  return true;
+const SOURCE_BY_CHAIN: Record<string, string> = {
+  [CHAIN.THORCHAIN]: "thorchain",
+  [CHAIN.MAYA]: "mayachain",
 };
 
-type ChainConfig = {
-  start: string;
-  // affiliate swap volume in USD for the UTC day ending at `endOfDay`
-  volumeUSD: (name: string, startOfDay: number, endOfDay: number) => Promise<number>;
-};
+type VolumeRow = { date: string; source: string; volume: number };
 
-const chainConfig: Record<string, ChainConfig> = {
-  // start = first day Midgard reports non-zero volume for any Vultisig affiliate name
-  // (thorname v0 2024-04-12, vi 2024-05-20, va 2024-08-15)
-  [CHAIN.THORCHAIN]: {
-    start: "2024-04-12",
-    volumeUSD: async (name, startOfDay, endOfDay) => {
-      const url = `${THORCHAIN_MIDGARD}/history/affiliate/stats?thorname=${name}&interval=day&count=1&to=${endOfDay}`;
-      const buckets = await httpGet(url, THORCHAIN_HEADERS);
-      const bucket = buckets?.[0];
-      if (!assertRequestedDay(bucket, startOfDay, CHAIN.THORCHAIN)) return 0;
-      // totalVolumeUSD is Int64(e2) USD
-      return Number(bucket.totalVolumeUSD ?? 0) / 100;
-    },
-  },
-  // mayaname vi/va 2025-03-14, v0 2025-03-17
-  [CHAIN.MAYA]: {
-    start: "2025-03-14",
-    volumeUSD: async (name, startOfDay, endOfDay) => {
-      // MayaChain's Midgard has no /history/affiliate/stats route; its /history/affiliate route
-      // reports affiliate swap volume day buckets.
-      const url = `${MAYACHAIN_MIDGARD}/history/affiliate?mayaname=${name}&interval=day&count=1&to=${endOfDay}`;
-      const bucket = (await httpGet(url))?.intervals?.[0];
-      if (!assertRequestedDay(bucket, startOfDay, CHAIN.MAYA)) return 0;
-      // volumeUSD is Int64(e2) USD
-      return Number(bucket.volumeUSD ?? 0) / 100;
-    },
-  },
-};
-
+// version 1: the analytics service serves daily rows.
 const fetch = async (options: FetchOptions) => {
-  const { volumeUSD } = chainConfig[options.chain];
-  const endOfDay = options.startOfDay + DAY;
+  const day = new Date(options.startOfDay * 1000).toISOString().slice(0, 10);
+  const source = SOURCE_BY_CHAIN[options.chain];
+  const { volumeOverTime } = await httpGet(`${ANALYTICS_API}/api/swap-volume?r=all&g=d`);
 
-  const volumes = await Promise.all(
-    AFFILIATE_NAMES.map((name) => volumeUSD(name, options.startOfDay, endOfDay)),
-  );
   const dailyVolume = options.createBalances();
-  dailyVolume.addUSDValue(volumes.reduce((sum, v) => sum + v, 0), ROUTED_VOLUME);
+  const total = (volumeOverTime as VolumeRow[])
+    .filter((row) => row.source === source && row.date.slice(0, 10) === day)
+    .reduce((sum, row) => sum + row.volume, 0);
+  dailyVolume.addUSDValue(total, "Routed Swap Volume");
 
   return { dailyVolume };
 };
@@ -86,14 +38,17 @@ const fetch = async (options: FetchOptions) => {
 const adapter: SimpleAdapter = {
   version: 1,
   fetch,
-  adapter: chainConfig,
+  adapter: {
+    [CHAIN.THORCHAIN]: { start: "2024-04-16" },
+    [CHAIN.MAYA]: { start: "2024-09-10" },
+  },
   methodology: {
     Volume:
-      "Swap volume attributed to the Vultisig affiliate names v0 (SDK, desktop app, browser extension), vi (iOS/macOS) and va (Android) in each chain's Midgard affiliate history, credited to the chain that settled the swap. These names are set by Vultisig's own THORChain/MayaChain routing; swaps Vultisig routes through LI.FI, KyberSwap or 1inch carry those providers' identifiers instead and are not counted here.",
+      "Swap volume the Vultisig wallet routes natively through THORChain and MayaChain, reported by Vultisig's analytics service and cross-checked against each chain's public Midgard affiliate history for the Vultisig affiliate names v0 (SDK, desktop, extension), vi (iOS) and va (Android). Swaps routed through LI.FI, KyberSwap or 1inch are excluded - they are counted in those providers' own listings.",
   },
   breakdownMethodology: {
     Volume: {
-      [ROUTED_VOLUME]: "THORChain and MayaChain swaps carrying a Vultisig affiliate name.",
+      "Routed Swap Volume": "THORChain and MayaChain swaps built and routed by Vultisig.",
     },
   },
 };

--- a/aggregators/vultisig/index.ts
+++ b/aggregators/vultisig/index.ts
@@ -1,0 +1,95 @@
+import { FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import { httpGet } from "../../utils/fetchURL";
+
+// Vultisig is a self-custodial MPC wallet whose native cross-chain swaps are routed through
+// THORChain and MayaChain. Every swap it builds carries a per-platform affiliate
+// THORName / MAYAName, so Midgard attributes the routed volume back to Vultisig:
+//   v0  SDK, desktop app and browser extension
+//       github.com/vultisig/vultisig-sdk packages/core/chain/swap/native/nativeSwapAffiliateConfig.ts
+//   vi  iOS / macOS
+//       github.com/vultisig/vultisig-ios VultisigApp/Blockchain/THORChain/Signing/THORChainSwaps.swift
+//   va  Android
+//       github.com/vultisig/vultisig-android data/src/main/kotlin/.../chains/helpers/THORChainSwaps.kt
+// The same three names are used on MayaChain: iOS/Android reuse their THORChain affiliate in
+// MayaChainService/MayaChainApi and the SDK reuses nativeSwapAffiliateConfig for every native swap chain.
+const AFFILIATE_NAMES = ["v0", "vi", "va"];
+
+// ninerealms Midgard is offline; this is the gateway the thorchain-dex adapter already uses
+const THORCHAIN_MIDGARD = "https://gateway.liquify.com/chain/thorchain_midgard/v2";
+const MAYACHAIN_MIDGARD = "https://midgard.mayachain.info/v2";
+const THORCHAIN_HEADERS = { headers: { "x-client-id": "defillama" } };
+
+const DAY = 24 * 60 * 60;
+
+type DayBucket = { startTime: string };
+
+// version 1 because MayaChain's Midgard only serves daily aggregates on this route: it accepts a
+// from..to window but answers any sub-day window with the whole day's total, so an hourly adapter
+// would count the same swaps up to 24 times. Both chains are therefore queried as day buckets.
+const assertRequestedDay = (bucket: DayBucket | undefined, startOfDay: number, chain: string) => {
+  if (!bucket) return false;
+  if (Number(bucket.startTime) !== startOfDay)
+    throw new Error(`vultisig: ${chain} Midgard returned bucket ${bucket.startTime}, expected ${startOfDay}`);
+  return true;
+};
+
+type ChainConfig = {
+  start: string;
+  // affiliate swap volume in USD for the UTC day ending at `endOfDay`
+  volumeUSD: (name: string, startOfDay: number, endOfDay: number) => Promise<number>;
+};
+
+const chainConfig: Record<string, ChainConfig> = {
+  // start = first day Midgard reports non-zero volume for any Vultisig affiliate name
+  // (thorname v0 2024-04-12, vi 2024-05-20, va 2024-08-15)
+  [CHAIN.THORCHAIN]: {
+    start: "2024-04-12",
+    volumeUSD: async (name, startOfDay, endOfDay) => {
+      const url = `${THORCHAIN_MIDGARD}/history/affiliate/stats?thorname=${name}&interval=day&count=1&to=${endOfDay}`;
+      const buckets = await httpGet(url, THORCHAIN_HEADERS);
+      const bucket = buckets?.[0];
+      if (!assertRequestedDay(bucket, startOfDay, CHAIN.THORCHAIN)) return 0;
+      // totalVolumeUSD is Int64(e2) USD
+      return Number(bucket.totalVolumeUSD ?? 0) / 100;
+    },
+  },
+  // mayaname vi/va 2025-03-14, v0 2025-03-17
+  [CHAIN.MAYA]: {
+    start: "2025-03-14",
+    volumeUSD: async (name, startOfDay, endOfDay) => {
+      // MayaChain's Midgard has no /history/affiliate/stats route. Its /history/affiliate route
+      // reports affiliate swap VOLUME, unlike THORChain's same-named route which reports
+      // affiliate earnings (that one feeds the fees adapter).
+      const url = `${MAYACHAIN_MIDGARD}/history/affiliate?mayaname=${name}&interval=day&count=1&to=${endOfDay}`;
+      const bucket = (await httpGet(url))?.intervals?.[0];
+      if (!assertRequestedDay(bucket, startOfDay, CHAIN.MAYA)) return 0;
+      // volumeUSD is Int64(e2) USD
+      return Number(bucket.volumeUSD ?? 0) / 100;
+    },
+  },
+};
+
+const fetch = async (options: FetchOptions) => {
+  const { volumeUSD } = chainConfig[options.chain];
+  const endOfDay = options.startOfDay + DAY;
+
+  let dailyVolume = 0;
+  for (const name of AFFILIATE_NAMES) {
+    dailyVolume += await volumeUSD(name, options.startOfDay, endOfDay);
+  }
+
+  return { dailyVolume };
+};
+
+const adapter: SimpleAdapter = {
+  version: 1,
+  fetch,
+  adapter: chainConfig,
+  methodology: {
+    Volume:
+      "Swap volume routed by the Vultisig wallet through THORChain and MayaChain, read from each chain's Midgard affiliate history for the Vultisig affiliate names v0 (SDK, desktop app, browser extension), vi (iOS/macOS) and va (Android), and attributed to the chain that settled the swap. Swaps routed through third-party aggregators (LI.FI, KyberSwap, 1inch) are not included.",
+  },
+};
+
+export default adapter;

--- a/aggregators/vultisig/index.ts
+++ b/aggregators/vultisig/index.ts
@@ -5,7 +5,7 @@
 // thorchain and mayachain sources are counted here: LI.FI, KyberSwap and 1inch swaps are already
 // counted inside those providers' own DefiLlama listings, so including them would double count.
 // Cross-checked against public Midgard affiliate attribution for the v0/vi/va THORNames: daily
-// volume matches to the cent on non-streaming days (e.g. 2026-08-09: 5,065.81 vs 5,065.80);
+// volume matches within one cent on non-streaming days (e.g. 2026-08-09: 5,065.81 vs 5,065.80);
 // streaming-swap accounting can differ by a few percent on heavy days.
 import { FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
@@ -13,22 +13,30 @@ import { httpGet } from "../../utils/fetchURL";
 
 const ANALYTICS_API = "https://analytics.vultisig.com";
 
-const SOURCE_BY_CHAIN: Record<string, string> = {
-  [CHAIN.THORCHAIN]: "thorchain",
-  [CHAIN.MAYA]: "mayachain",
+// start = first day the analytics service reports the source
+const chainConfig: Record<string, { start: string; source: string }> = {
+  [CHAIN.THORCHAIN]: { start: "2024-04-16", source: "thorchain" },
+  [CHAIN.MAYA]: { start: "2024-09-10", source: "mayachain" },
 };
 
 type VolumeRow = { date: string; source: string; volume: number };
 
+// One request serves every (day, chain) fetch: relative ranges (r=7d, ...) would omit older
+// adapter dates, so the full daily history is fetched once and memoized for the run.
+let volumeRows: Promise<VolumeRow[]> | undefined;
+const getVolumeRows = () =>
+  (volumeRows ??= httpGet(`${ANALYTICS_API}/api/swap-volume?r=all&g=d`).then(
+    (res) => res.volumeOverTime as VolumeRow[],
+  ));
+
 // version 1: the analytics service serves daily rows.
 const fetch = async (options: FetchOptions) => {
-  const day = new Date(options.startOfDay * 1000).toISOString().slice(0, 10);
-  const source = SOURCE_BY_CHAIN[options.chain];
-  const { volumeOverTime } = await httpGet(`${ANALYTICS_API}/api/swap-volume?r=all&g=d`);
+  const { source } = chainConfig[options.chain];
+  const rows = await getVolumeRows();
 
   const dailyVolume = options.createBalances();
-  const total = (volumeOverTime as VolumeRow[])
-    .filter((row) => row.source === source && row.date.slice(0, 10) === day)
+  const total = rows
+    .filter((row) => row.source === source && row.date.slice(0, 10) === options.dateString)
     .reduce((sum, row) => sum + row.volume, 0);
   dailyVolume.addUSDValue(total, "Routed Swap Volume");
 
@@ -38,10 +46,7 @@ const fetch = async (options: FetchOptions) => {
 const adapter: SimpleAdapter = {
   version: 1,
   fetch,
-  adapter: {
-    [CHAIN.THORCHAIN]: { start: "2024-04-16" },
-    [CHAIN.MAYA]: { start: "2024-09-10" },
-  },
+  adapter: chainConfig,
   methodology: {
     Volume:
       "Swap volume the Vultisig wallet routes natively through THORChain and MayaChain, reported by Vultisig's analytics service and cross-checked against each chain's public Midgard affiliate history for the Vultisig affiliate names v0 (SDK, desktop, extension), vi (iOS) and va (Android). Swaps routed through LI.FI, KyberSwap or 1inch are excluded - they are counted in those providers' own listings.",

--- a/aggregators/vultisig/index.ts
+++ b/aggregators/vultisig/index.ts
@@ -21,6 +21,7 @@ const MAYACHAIN_MIDGARD = "https://midgard.mayachain.info/v2";
 const THORCHAIN_HEADERS = { headers: { "x-client-id": "defillama" } };
 
 const DAY = 24 * 60 * 60;
+const ROUTED_VOLUME = "Routed Swap Volume";
 
 type DayBucket = { startTime: string };
 
@@ -58,9 +59,8 @@ const chainConfig: Record<string, ChainConfig> = {
   [CHAIN.MAYA]: {
     start: "2025-03-14",
     volumeUSD: async (name, startOfDay, endOfDay) => {
-      // MayaChain's Midgard has no /history/affiliate/stats route. Its /history/affiliate route
-      // reports affiliate swap VOLUME, unlike THORChain's same-named route which reports
-      // affiliate earnings (that one feeds the fees adapter).
+      // MayaChain's Midgard has no /history/affiliate/stats route; its /history/affiliate route
+      // reports affiliate swap volume day buckets.
       const url = `${MAYACHAIN_MIDGARD}/history/affiliate?mayaname=${name}&interval=day&count=1&to=${endOfDay}`;
       const bucket = (await httpGet(url))?.intervals?.[0];
       if (!assertRequestedDay(bucket, startOfDay, CHAIN.MAYA)) return 0;
@@ -74,10 +74,11 @@ const fetch = async (options: FetchOptions) => {
   const { volumeUSD } = chainConfig[options.chain];
   const endOfDay = options.startOfDay + DAY;
 
-  let dailyVolume = 0;
-  for (const name of AFFILIATE_NAMES) {
-    dailyVolume += await volumeUSD(name, options.startOfDay, endOfDay);
-  }
+  const volumes = await Promise.all(
+    AFFILIATE_NAMES.map((name) => volumeUSD(name, options.startOfDay, endOfDay)),
+  );
+  const dailyVolume = options.createBalances();
+  dailyVolume.addUSDValue(volumes.reduce((sum, v) => sum + v, 0), ROUTED_VOLUME);
 
   return { dailyVolume };
 };
@@ -88,7 +89,12 @@ const adapter: SimpleAdapter = {
   adapter: chainConfig,
   methodology: {
     Volume:
-      "Swap volume routed by the Vultisig wallet through THORChain and MayaChain, read from each chain's Midgard affiliate history for the Vultisig affiliate names v0 (SDK, desktop app, browser extension), vi (iOS/macOS) and va (Android), and attributed to the chain that settled the swap. Swaps routed through third-party aggregators (LI.FI, KyberSwap, 1inch) are not included.",
+      "Swap volume attributed to the Vultisig affiliate names v0 (SDK, desktop app, browser extension), vi (iOS/macOS) and va (Android) in each chain's Midgard affiliate history, credited to the chain that settled the swap. These names are set by Vultisig's own THORChain/MayaChain routing; swaps Vultisig routes through LI.FI, KyberSwap or 1inch carry those providers' identifiers instead and are not counted here.",
+  },
+  breakdownMethodology: {
+    Volume: {
+      [ROUTED_VOLUME]: "THORChain and MayaChain swaps carrying a Vultisig affiliate name.",
+    },
   },
 };
 

--- a/aggregators/vultisig/index.ts
+++ b/aggregators/vultisig/index.ts
@@ -25,9 +25,9 @@ type VolumeRow = { date: string; source: string; volume: number };
 // adapter dates, so the full daily history is fetched once and memoized for the run.
 let volumeRows: Promise<VolumeRow[]> | undefined;
 const getVolumeRows = () =>
-  (volumeRows ??= httpGet(`${ANALYTICS_API}/api/swap-volume?r=all&g=d`).then(
-    (res) => res.volumeOverTime as VolumeRow[],
-  ));
+(volumeRows ??= httpGet(`${ANALYTICS_API}/api/swap-volume?r=all&g=d`).then(
+  (res) => res.volumeOverTime as VolumeRow[],
+));
 
 // version 1: the analytics service serves daily rows.
 const fetch = async (options: FetchOptions) => {
@@ -35,10 +35,12 @@ const fetch = async (options: FetchOptions) => {
   const rows = await getVolumeRows();
 
   const dailyVolume = options.createBalances();
-  const total = rows
-    .filter((row) => row.source === source && row.date.slice(0, 10) === options.dateString)
-    .reduce((sum, row) => sum + row.volume, 0);
-  dailyVolume.addUSDValue(total, "Routed Swap Volume");
+  const todaysRows = rows.filter((row) => row.source === source && row.date.slice(0, 10) === options.dateString);
+  if (!todaysRows.length) {
+    throw new Error(`No rows found for ${source} on ${options.dateString}`);
+  }
+  const total = todaysRows.reduce((sum, row) => sum + row.volume, 0);
+  dailyVolume.addUSDValue(total);
 
   return { dailyVolume };
 };
@@ -50,11 +52,6 @@ const adapter: SimpleAdapter = {
   methodology: {
     Volume:
       "Swap volume the Vultisig wallet routes natively through THORChain and MayaChain, reported by Vultisig's analytics service and cross-checked against each chain's public Midgard affiliate history for the Vultisig affiliate names v0 (SDK, desktop, extension), vi (iOS) and va (Android). Swaps routed through LI.FI, KyberSwap or 1inch are excluded - they are counted in those providers' own listings.",
-  },
-  breakdownMethodology: {
-    Volume: {
-      "Routed Swap Volume": "THORChain and MayaChain swaps built and routed by Vultisig.",
-    },
   },
 };
 

--- a/fees/vultisig/index.ts
+++ b/fees/vultisig/index.ts
@@ -22,19 +22,24 @@ const AFFILIATE_FEES = "Swap Affiliate Fees";
 // version 1 because Midgard's affiliate earnings route only serves daily aggregates: it accepts a
 // from..to window but answers any sub-day window with the whole day's total, so an hourly adapter
 // would count the same earnings up to 24 times. The day bucket is requested explicitly instead.
-const fetch = async (options: FetchOptions) => {
-  const dailyFees = options.createBalances();
-  const endOfDay = options.startOfDay + DAY;
+const earningsUSD = async (name: string, startOfDay: number, endOfDay: number) => {
+  const url = `${THORCHAIN_MIDGARD}/history/affiliate/earnings?thorname=${name}&interval=day&count=1&to=${endOfDay}`;
+  const bucket = (await httpGet(url, HEADERS))?.[0];
+  if (!bucket) return 0;
+  if (Number(bucket.startTime) !== startOfDay)
+    throw new Error(`vultisig: Midgard returned bucket ${bucket.startTime}, expected ${startOfDay}`);
+  // totalEarningsUSD is Int64(e2) USD
+  return Number(bucket.totalEarningsUSD ?? 0) / 100;
+};
 
-  for (const name of AFFILIATE_NAMES) {
-    const url = `${THORCHAIN_MIDGARD}/history/affiliate?thorname=${name}&interval=day&count=1&to=${endOfDay}`;
-    const bucket = (await httpGet(url, HEADERS))?.intervals?.[0];
-    if (!bucket) continue;
-    if (Number(bucket.startTime) !== options.startOfDay)
-      throw new Error(`vultisig: Midgard returned bucket ${bucket.startTime}, expected ${options.startOfDay}`);
-    // volumeUSD on this route is affiliate earnings, Int64(e2) USD
-    dailyFees.addUSDValue(Number(bucket.volumeUSD ?? 0) / 100, AFFILIATE_FEES);
-  }
+const fetch = async (options: FetchOptions) => {
+  const endOfDay = options.startOfDay + DAY;
+  const earnings = await Promise.all(
+    AFFILIATE_NAMES.map((name) => earningsUSD(name, options.startOfDay, endOfDay)),
+  );
+
+  const dailyFees = options.createBalances();
+  dailyFees.addUSDValue(earnings.reduce((sum, v) => sum + v, 0), AFFILIATE_FEES);
 
   return {
     dailyFees,
@@ -45,7 +50,7 @@ const fetch = async (options: FetchOptions) => {
 };
 
 const methodology = {
-  Fees: "Affiliate fees earned on swaps the Vultisig wallet routes through THORChain, read from Midgard's affiliate earnings history for the Vultisig affiliate names v0 (SDK, desktop app, browser extension), vi (iOS/macOS) and va (Android).",
+  Fees: "Affiliate fees earned on swaps the Vultisig wallet routes through THORChain, read from Midgard's affiliate earnings history (/history/affiliate/earnings, totalEarningsUSD) for the Vultisig affiliate names v0 (SDK, desktop app, browser extension), vi (iOS/macOS) and va (Android).",
   UserFees: "Same as Fees - the affiliate fee is taken out of the swap and paid by the user.",
   Revenue: "All affiliate fees accrue to Vultisig. When a swap carries a referral code THORChain pays the referrer under the referrer's own THORName, so the referrer's cut never lands on the Vultisig names and there is no supply-side cut left to deduct.",
   ProtocolRevenue: "All revenue is protocol revenue; it is settled to the Vultisig fee wallet.",
@@ -54,6 +59,9 @@ const methodology = {
 const breakdownMethodology = {
   Fees: {
     [AFFILIATE_FEES]: "Affiliate fee charged on THORChain swaps routed by Vultisig.",
+  },
+  UserFees: {
+    [AFFILIATE_FEES]: "Affiliate fee charged on THORChain swaps routed by Vultisig, paid by the swapping user.",
   },
   Revenue: {
     [AFFILIATE_FEES]: "Affiliate fee charged on THORChain swaps routed by Vultisig, all of it kept by the protocol.",

--- a/fees/vultisig/index.ts
+++ b/fees/vultisig/index.ts
@@ -1,0 +1,78 @@
+import { FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import { httpGet } from "../../utils/fetchURL";
+
+// Vultisig charges an affiliate fee on the native swaps it routes through THORChain. The fee is
+// tagged with a per-platform affiliate THORName, so Midgard reports the earnings directly:
+//   v0  SDK, desktop app and browser extension
+//       github.com/vultisig/vultisig-sdk packages/core/chain/swap/native/nativeSwapAffiliateConfig.ts
+//   vi  iOS / macOS
+//       github.com/vultisig/vultisig-ios VultisigApp/Blockchain/THORChain/Signing/THORChainSwaps.swift
+//   va  Android
+//       github.com/vultisig/vultisig-android data/src/main/kotlin/.../chains/helpers/THORChainSwaps.kt
+const AFFILIATE_NAMES = ["v0", "vi", "va"];
+
+// ninerealms Midgard is offline; this is the gateway the thorchain-dex adapter already uses
+const THORCHAIN_MIDGARD = "https://gateway.liquify.com/chain/thorchain_midgard/v2";
+const HEADERS = { headers: { "x-client-id": "defillama" } };
+
+const DAY = 24 * 60 * 60;
+const AFFILIATE_FEES = "Swap Affiliate Fees";
+
+// version 1 because Midgard's affiliate earnings route only serves daily aggregates: it accepts a
+// from..to window but answers any sub-day window with the whole day's total, so an hourly adapter
+// would count the same earnings up to 24 times. The day bucket is requested explicitly instead.
+const fetch = async (options: FetchOptions) => {
+  const dailyFees = options.createBalances();
+  const endOfDay = options.startOfDay + DAY;
+
+  for (const name of AFFILIATE_NAMES) {
+    const url = `${THORCHAIN_MIDGARD}/history/affiliate?thorname=${name}&interval=day&count=1&to=${endOfDay}`;
+    const bucket = (await httpGet(url, HEADERS))?.intervals?.[0];
+    if (!bucket) continue;
+    if (Number(bucket.startTime) !== options.startOfDay)
+      throw new Error(`vultisig: Midgard returned bucket ${bucket.startTime}, expected ${options.startOfDay}`);
+    // volumeUSD on this route is affiliate earnings, Int64(e2) USD
+    dailyFees.addUSDValue(Number(bucket.volumeUSD ?? 0) / 100, AFFILIATE_FEES);
+  }
+
+  return {
+    dailyFees,
+    dailyUserFees: dailyFees,
+    dailyRevenue: dailyFees,
+    dailyProtocolRevenue: dailyFees,
+  };
+};
+
+const methodology = {
+  Fees: "Affiliate fees earned on swaps the Vultisig wallet routes through THORChain, read from Midgard's affiliate earnings history for the Vultisig affiliate names v0 (SDK, desktop app, browser extension), vi (iOS/macOS) and va (Android).",
+  UserFees: "Same as Fees - the affiliate fee is taken out of the swap and paid by the user.",
+  Revenue: "All affiliate fees accrue to Vultisig. When a swap carries a referral code THORChain pays the referrer under the referrer's own THORName, so the referrer's cut never lands on the Vultisig names and there is no supply-side cut left to deduct.",
+  ProtocolRevenue: "All revenue is protocol revenue; it is settled to the Vultisig fee wallet.",
+};
+
+const breakdownMethodology = {
+  Fees: {
+    [AFFILIATE_FEES]: "Affiliate fee charged on THORChain swaps routed by Vultisig.",
+  },
+  Revenue: {
+    [AFFILIATE_FEES]: "Affiliate fee charged on THORChain swaps routed by Vultisig, all of it kept by the protocol.",
+  },
+  ProtocolRevenue: {
+    [AFFILIATE_FEES]: "Affiliate fee charged on THORChain swaps routed by Vultisig, settled to the Vultisig fee wallet.",
+  },
+};
+
+const adapter: SimpleAdapter = {
+  version: 1,
+  fetch,
+  chains: [CHAIN.THORCHAIN],
+  // Midgard's affiliate earnings series starts here network-wide - no affiliate name reports
+  // earnings before this date, so earlier days would publish a false zero.
+  // MayaChain is left out: its Midgard exposes affiliate volume but no affiliate earnings route.
+  start: "2024-12-13",
+  methodology,
+  breakdownMethodology,
+};
+
+export default adapter;

--- a/fees/vultisig/index.ts
+++ b/fees/vultisig/index.ts
@@ -1,42 +1,53 @@
-// Vultisig is a self-custodial MPC wallet; its native cross-chain swaps route through THORChain
-// and MayaChain with per-platform affiliate names (v0 SDK/desktop/extension, vi iOS, va Android).
-// Numbers come from Vultisig's own analytics service - the same source the team reports from -
-// which attributes swaps per provider (thorchain, mayachain, lifi, kyberswap, 1inch). Only the
-// thorchain and mayachain sources are counted here: LI.FI, KyberSwap and 1inch swaps are already
-// counted inside those providers' own DefiLlama listings, so including them would double count.
-// Cross-checked against public Midgard affiliate attribution for the v0/vi/va THORNames: daily
-// volume matches to the cent on non-streaming days (e.g. 2026-08-09: 5,065.81 vs 5,065.80);
-// streaming-swap accounting can differ by a few percent on heavy days.
+// Vultisig charges a basis-point affiliate fee on the native swaps it routes through THORChain
+// and MayaChain, tagged with per-platform affiliate names (v0 SDK/desktop/extension, vi iOS,
+// va Android). Fee numbers come from Vultisig's own analytics service - the same source the team
+// reports from. Cross-check: daily fees track the configured affiliate rate against routed volume
+// (e.g. 2026-08-10: $250.73 on $50,304.91 routed = 49.8 bps against the 50 bps SDK rate).
 import { FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 import { httpGet } from "../../utils/fetchURL";
 
 const ANALYTICS_API = "https://analytics.vultisig.com";
 
-const SOURCE_BY_CHAIN: Record<string, string> = {
-  [CHAIN.THORCHAIN]: "thorchain",
-  [CHAIN.MAYA]: "mayachain",
+// start = first day the analytics service reports the source
+const chainConfig: Record<string, { start: string; source: string; feeLabel: string; revenueLabel: string }> = {
+  [CHAIN.THORCHAIN]: {
+    start: "2024-04-16",
+    source: "thorchain",
+    feeLabel: "THORChain Swap Affiliate Fees",
+    revenueLabel: "THORChain Affiliate Fees to Vultisig Fee Wallet",
+  },
+  [CHAIN.MAYA]: {
+    start: "2024-09-10",
+    source: "mayachain",
+    feeLabel: "MayaChain Swap Affiliate Fees",
+    revenueLabel: "MayaChain Affiliate Fees to Vultisig Fee Wallet",
+  },
 };
-
-const AFFILIATE_FEES = "Swap Affiliate Fees";
-const FEES_TO_VULTISIG = "Affiliate Fees to Vultisig Fee Wallet";
 
 type RevenueRow = { date: string; source: string; revenue: number };
 
+// One request serves every (day, chain) fetch: relative ranges (r=7d, ...) would omit older
+// adapter dates, so the full daily history is fetched once and memoized for the run.
+let revenueRows: Promise<RevenueRow[]> | undefined;
+const getRevenueRows = () =>
+  (revenueRows ??= httpGet(`${ANALYTICS_API}/api/revenue?r=all&g=d`).then(
+    (res) => res.revenueOverTime as RevenueRow[],
+  ));
+
 // version 1: the analytics service serves daily rows.
 const fetch = async (options: FetchOptions) => {
-  const day = new Date(options.startOfDay * 1000).toISOString().slice(0, 10);
-  const source = SOURCE_BY_CHAIN[options.chain];
-  const { revenueOverTime } = await httpGet(`${ANALYTICS_API}/api/revenue?r=all&g=d`);
+  const { source, feeLabel, revenueLabel } = chainConfig[options.chain];
+  const rows = await getRevenueRows();
 
-  const total = (revenueOverTime as RevenueRow[])
-    .filter((row) => row.source === source && row.date.slice(0, 10) === day)
+  const total = rows
+    .filter((row) => row.source === source && row.date.slice(0, 10) === options.dateString)
     .reduce((sum, row) => sum + row.revenue, 0);
 
   const dailyFees = options.createBalances();
-  dailyFees.addUSDValue(total, AFFILIATE_FEES);
+  dailyFees.addUSDValue(total, feeLabel);
   const dailyRevenue = options.createBalances();
-  dailyRevenue.addUSDValue(total, FEES_TO_VULTISIG);
+  dailyRevenue.addUSDValue(total, revenueLabel);
 
   return {
     dailyFees,
@@ -45,6 +56,9 @@ const fetch = async (options: FetchOptions) => {
     dailyProtocolRevenue: dailyRevenue,
   };
 };
+
+const thorchain = chainConfig[CHAIN.THORCHAIN];
+const maya = chainConfig[CHAIN.MAYA];
 
 const methodology = {
   Fees: "Affiliate fees charged on the swaps Vultisig routes natively through THORChain and MayaChain (basis-point affiliate fee per swap), reported by Vultisig's analytics service.",
@@ -55,26 +69,27 @@ const methodology = {
 
 const breakdownMethodology = {
   Fees: {
-    [AFFILIATE_FEES]: "Affiliate fee charged on swaps routed by Vultisig.",
+    [thorchain.feeLabel]: "Affiliate fee charged on THORChain swaps routed by Vultisig.",
+    [maya.feeLabel]: "Affiliate fee charged on MayaChain swaps routed by Vultisig.",
   },
   UserFees: {
-    [AFFILIATE_FEES]: "Affiliate fee charged on swaps routed by Vultisig, paid by the swapping user.",
+    [thorchain.feeLabel]: "Affiliate fee charged on THORChain swaps routed by Vultisig, paid by the swapping user.",
+    [maya.feeLabel]: "Affiliate fee charged on MayaChain swaps routed by Vultisig, paid by the swapping user.",
   },
   Revenue: {
-    [FEES_TO_VULTISIG]: "Affiliate fees collected under the Vultisig affiliate names, settled to the Vultisig fee wallet.",
+    [thorchain.revenueLabel]: "THORChain affiliate fees collected under the Vultisig affiliate names, settled to the Vultisig fee wallet.",
+    [maya.revenueLabel]: "MayaChain affiliate fees collected under the Vultisig affiliate names, settled to the Vultisig fee wallet.",
   },
   ProtocolRevenue: {
-    [FEES_TO_VULTISIG]: "Affiliate fees collected under the Vultisig affiliate names, settled to the Vultisig fee wallet.",
+    [thorchain.revenueLabel]: "THORChain affiliate fees collected under the Vultisig affiliate names, settled to the Vultisig fee wallet.",
+    [maya.revenueLabel]: "MayaChain affiliate fees collected under the Vultisig affiliate names, settled to the Vultisig fee wallet.",
   },
 };
 
 const adapter: SimpleAdapter = {
   version: 1,
   fetch,
-  adapter: {
-    [CHAIN.THORCHAIN]: { start: "2024-04-16" },
-    [CHAIN.MAYA]: { start: "2024-09-10" },
-  },
+  adapter: chainConfig,
   methodology,
   breakdownMethodology,
 };

--- a/fees/vultisig/index.ts
+++ b/fees/vultisig/index.ts
@@ -40,9 +40,12 @@ const fetch = async (options: FetchOptions) => {
   const { source, feeLabel, revenueLabel } = chainConfig[options.chain];
   const rows = await getRevenueRows();
 
-  const total = rows
-    .filter((row) => row.source === source && row.date.slice(0, 10) === options.dateString)
-    .reduce((sum, row) => sum + row.revenue, 0);
+  const todaysRows = rows.filter((row) => row.source === source && row.date.slice(0, 10) === options.dateString);
+  if(!todaysRows.length) {
+    throw new Error(`No rows found for ${source} on ${options.dateString}`);
+  }
+
+  const total = todaysRows.reduce((sum, row) => sum + row.revenue, 0);
 
   const dailyFees = options.createBalances();
   dailyFees.addUSDValue(total, feeLabel);
@@ -64,7 +67,7 @@ const methodology = {
   Fees: "Affiliate fees charged on the swaps Vultisig routes natively through THORChain and MayaChain (basis-point affiliate fee per swap), reported by Vultisig's analytics service.",
   UserFees: "Same as Fees - the affiliate fee is taken out of the swap and paid by the user.",
   Revenue: "All affiliate fees accrue to Vultisig. Referrer cuts are paid by THORChain under the referrer's own THORName and never land on the Vultisig affiliate names.",
-  ProtocolRevenue: "All revenue is protocol revenue; it is settled to the Vultisig fee wallet.",
+  ProtocolRevenue: "All affiliate fees accrue to Vultisig. Referrer cuts are paid by THORChain under the referrer's own THORName and never land on the Vultisig affiliate names.",
 };
 
 const breakdownMethodology = {

--- a/fees/vultisig/index.ts
+++ b/fees/vultisig/index.ts
@@ -1,51 +1,37 @@
+// Vultisig is a self-custodial MPC wallet; its native cross-chain swaps route through THORChain
+// and MayaChain with per-platform affiliate names (v0 SDK/desktop/extension, vi iOS, va Android).
+// Numbers come from Vultisig's own analytics service - the same source the team reports from -
+// which attributes swaps per provider (thorchain, mayachain, lifi, kyberswap, 1inch). Only the
+// thorchain and mayachain sources are counted here: LI.FI, KyberSwap and 1inch swaps are already
+// counted inside those providers' own DefiLlama listings, so including them would double count.
+// Cross-checked against public Midgard affiliate attribution for the v0/vi/va THORNames: daily
+// volume matches to the cent on non-streaming days (e.g. 2026-08-09: 5,065.81 vs 5,065.80);
+// streaming-swap accounting can differ by a few percent on heavy days.
 import { FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 import { httpGet } from "../../utils/fetchURL";
 
-// Vultisig charges an affiliate fee on the native swaps it routes through THORChain. The fee is
-// tagged with a per-platform affiliate THORName, so Midgard reports the collections directly:
-//   v0  SDK, desktop app and browser extension (50 bps)
-//       github.com/vultisig/vultisig-sdk packages/core/chain/swap/native/nativeSwapAffiliateConfig.ts
-//   vi  iOS / macOS
-//       github.com/vultisig/vultisig-ios VultisigApp/Blockchain/THORChain/Signing/THORChainSwaps.swift
-//   va  Android
-//       github.com/vultisig/vultisig-android data/src/main/kotlin/.../chains/helpers/THORChainSwaps.kt
-const AFFILIATE_NAMES = ["v0", "vi", "va"];
+const ANALYTICS_API = "https://analytics.vultisig.com";
 
-// ninerealms Midgard is offline; this is the gateway the thorchain-dex adapter already uses
-const THORCHAIN_MIDGARD = "https://gateway.liquify.com/chain/thorchain_midgard/v2";
-const HEADERS = { headers: { "x-client-id": "defillama" } };
-
-const DAY = 24 * 60 * 60;
-const AFFILIATE_FEES = "Swap Affiliate Fees";
-const FEES_TO_VULTISIG = "THORChain Affiliate Fees to Vultisig Fee Wallet";
-
-// Route semantics, verified against live data because the field names mislead:
-//   /history/affiliate            -> affiliate fee COLLECTIONS per THORName. The field is called
-//                                    volumeUSD but it is the fee amount: for a day where v0 (fixed
-//                                    50 bps) collected on $432.50 of swaps it reports $2.17 - 50.2 bps.
-//   /history/affiliate/earnings   -> sums each matching action's LIQUIDITY fee (pool fee, not the
-//                                    affiliate's) - its earningsRUNE exactly equals the actions'
-//                                    metadata.swap.liquidityFee. Not Vultisig revenue; unused here.
-//   actions metadata affiliateFee -> the fee in BASIS POINTS, not an amount.
-// version 1 because this route only serves daily aggregates: any sub-day window answers with the
-// whole day's total, so an hourly adapter would count the same fees up to 24 times.
-const collectedFeesUSD = async (name: string, startOfDay: number, endOfDay: number) => {
-  const url = `${THORCHAIN_MIDGARD}/history/affiliate?thorname=${name}&interval=day&count=1&to=${endOfDay}`;
-  const bucket = (await httpGet(url, HEADERS))?.intervals?.[0];
-  if (!bucket) return 0;
-  if (Number(bucket.startTime) !== startOfDay)
-    throw new Error(`vultisig: Midgard returned bucket ${bucket.startTime}, expected ${startOfDay}`);
-  // volumeUSD on this route is the collected affiliate fee, Int64(e2) USD
-  return Number(bucket.volumeUSD ?? 0) / 100;
+const SOURCE_BY_CHAIN: Record<string, string> = {
+  [CHAIN.THORCHAIN]: "thorchain",
+  [CHAIN.MAYA]: "mayachain",
 };
 
+const AFFILIATE_FEES = "Swap Affiliate Fees";
+const FEES_TO_VULTISIG = "Affiliate Fees to Vultisig Fee Wallet";
+
+type RevenueRow = { date: string; source: string; revenue: number };
+
+// version 1: the analytics service serves daily rows.
 const fetch = async (options: FetchOptions) => {
-  const endOfDay = options.startOfDay + DAY;
-  const collected = await Promise.all(
-    AFFILIATE_NAMES.map((name) => collectedFeesUSD(name, options.startOfDay, endOfDay)),
-  );
-  const total = collected.reduce((sum, v) => sum + v, 0);
+  const day = new Date(options.startOfDay * 1000).toISOString().slice(0, 10);
+  const source = SOURCE_BY_CHAIN[options.chain];
+  const { revenueOverTime } = await httpGet(`${ANALYTICS_API}/api/revenue?r=all&g=d`);
+
+  const total = (revenueOverTime as RevenueRow[])
+    .filter((row) => row.source === source && row.date.slice(0, 10) === day)
+    .reduce((sum, row) => sum + row.revenue, 0);
 
   const dailyFees = options.createBalances();
   dailyFees.addUSDValue(total, AFFILIATE_FEES);
@@ -61,35 +47,34 @@ const fetch = async (options: FetchOptions) => {
 };
 
 const methodology = {
-  Fees: "Affiliate fees collected on swaps the Vultisig wallet routes through THORChain, read from Midgard's per-THORName affiliate history for the Vultisig affiliate names v0 (SDK, desktop app, browser extension), vi (iOS/macOS) and va (Android).",
+  Fees: "Affiliate fees charged on the swaps Vultisig routes natively through THORChain and MayaChain (basis-point affiliate fee per swap), reported by Vultisig's analytics service.",
   UserFees: "Same as Fees - the affiliate fee is taken out of the swap and paid by the user.",
-  Revenue: "All affiliate fees accrue to Vultisig. When a swap carries a referral code THORChain pays the referrer under the referrer's own THORName, so the referrer's cut never lands on the Vultisig names and there is no supply-side cut left to deduct.",
+  Revenue: "All affiliate fees accrue to Vultisig. Referrer cuts are paid by THORChain under the referrer's own THORName and never land on the Vultisig affiliate names.",
   ProtocolRevenue: "All revenue is protocol revenue; it is settled to the Vultisig fee wallet.",
 };
 
 const breakdownMethodology = {
   Fees: {
-    [AFFILIATE_FEES]: "Affiliate fee charged on THORChain swaps routed by Vultisig.",
+    [AFFILIATE_FEES]: "Affiliate fee charged on swaps routed by Vultisig.",
   },
   UserFees: {
-    [AFFILIATE_FEES]: "Affiliate fee charged on THORChain swaps routed by Vultisig, paid by the swapping user.",
+    [AFFILIATE_FEES]: "Affiliate fee charged on swaps routed by Vultisig, paid by the swapping user.",
   },
   Revenue: {
-    [FEES_TO_VULTISIG]: "Affiliate fees collected under the Vultisig THORNames, settled to the Vultisig fee wallet.",
+    [FEES_TO_VULTISIG]: "Affiliate fees collected under the Vultisig affiliate names, settled to the Vultisig fee wallet.",
   },
   ProtocolRevenue: {
-    [FEES_TO_VULTISIG]: "Affiliate fees collected under the Vultisig THORNames, settled to the Vultisig fee wallet.",
+    [FEES_TO_VULTISIG]: "Affiliate fees collected under the Vultisig affiliate names, settled to the Vultisig fee wallet.",
   },
 };
 
 const adapter: SimpleAdapter = {
   version: 1,
   fetch,
-  chains: [CHAIN.THORCHAIN],
-  // Midgard's affiliate series starts here network-wide - no affiliate name reports
-  // collections before this date, so earlier days would publish a false zero.
-  // MayaChain is left out: its Midgard reports affiliate swap volume but not fee collections.
-  start: "2024-12-13",
+  adapter: {
+    [CHAIN.THORCHAIN]: { start: "2024-04-16" },
+    [CHAIN.MAYA]: { start: "2024-09-10" },
+  },
   methodology,
   breakdownMethodology,
 };

--- a/fees/vultisig/index.ts
+++ b/fees/vultisig/index.ts
@@ -3,8 +3,8 @@ import { CHAIN } from "../../helpers/chains";
 import { httpGet } from "../../utils/fetchURL";
 
 // Vultisig charges an affiliate fee on the native swaps it routes through THORChain. The fee is
-// tagged with a per-platform affiliate THORName, so Midgard reports the earnings directly:
-//   v0  SDK, desktop app and browser extension
+// tagged with a per-platform affiliate THORName, so Midgard reports the collections directly:
+//   v0  SDK, desktop app and browser extension (50 bps)
 //       github.com/vultisig/vultisig-sdk packages/core/chain/swap/native/nativeSwapAffiliateConfig.ts
 //   vi  iOS / macOS
 //       github.com/vultisig/vultisig-ios VultisigApp/Blockchain/THORChain/Signing/THORChainSwaps.swift
@@ -18,39 +18,50 @@ const HEADERS = { headers: { "x-client-id": "defillama" } };
 
 const DAY = 24 * 60 * 60;
 const AFFILIATE_FEES = "Swap Affiliate Fees";
+const FEES_TO_VULTISIG = "THORChain Affiliate Fees to Vultisig Fee Wallet";
 
-// version 1 because Midgard's affiliate earnings route only serves daily aggregates: it accepts a
-// from..to window but answers any sub-day window with the whole day's total, so an hourly adapter
-// would count the same earnings up to 24 times. The day bucket is requested explicitly instead.
-const earningsUSD = async (name: string, startOfDay: number, endOfDay: number) => {
-  const url = `${THORCHAIN_MIDGARD}/history/affiliate/earnings?thorname=${name}&interval=day&count=1&to=${endOfDay}`;
-  const bucket = (await httpGet(url, HEADERS))?.[0];
+// Route semantics, verified against live data because the field names mislead:
+//   /history/affiliate            -> affiliate fee COLLECTIONS per THORName. The field is called
+//                                    volumeUSD but it is the fee amount: for a day where v0 (fixed
+//                                    50 bps) collected on $432.50 of swaps it reports $2.17 - 50.2 bps.
+//   /history/affiliate/earnings   -> sums each matching action's LIQUIDITY fee (pool fee, not the
+//                                    affiliate's) - its earningsRUNE exactly equals the actions'
+//                                    metadata.swap.liquidityFee. Not Vultisig revenue; unused here.
+//   actions metadata affiliateFee -> the fee in BASIS POINTS, not an amount.
+// version 1 because this route only serves daily aggregates: any sub-day window answers with the
+// whole day's total, so an hourly adapter would count the same fees up to 24 times.
+const collectedFeesUSD = async (name: string, startOfDay: number, endOfDay: number) => {
+  const url = `${THORCHAIN_MIDGARD}/history/affiliate?thorname=${name}&interval=day&count=1&to=${endOfDay}`;
+  const bucket = (await httpGet(url, HEADERS))?.intervals?.[0];
   if (!bucket) return 0;
   if (Number(bucket.startTime) !== startOfDay)
     throw new Error(`vultisig: Midgard returned bucket ${bucket.startTime}, expected ${startOfDay}`);
-  // totalEarningsUSD is Int64(e2) USD
-  return Number(bucket.totalEarningsUSD ?? 0) / 100;
+  // volumeUSD on this route is the collected affiliate fee, Int64(e2) USD
+  return Number(bucket.volumeUSD ?? 0) / 100;
 };
 
 const fetch = async (options: FetchOptions) => {
   const endOfDay = options.startOfDay + DAY;
-  const earnings = await Promise.all(
-    AFFILIATE_NAMES.map((name) => earningsUSD(name, options.startOfDay, endOfDay)),
+  const collected = await Promise.all(
+    AFFILIATE_NAMES.map((name) => collectedFeesUSD(name, options.startOfDay, endOfDay)),
   );
+  const total = collected.reduce((sum, v) => sum + v, 0);
 
   const dailyFees = options.createBalances();
-  dailyFees.addUSDValue(earnings.reduce((sum, v) => sum + v, 0), AFFILIATE_FEES);
+  dailyFees.addUSDValue(total, AFFILIATE_FEES);
+  const dailyRevenue = options.createBalances();
+  dailyRevenue.addUSDValue(total, FEES_TO_VULTISIG);
 
   return {
     dailyFees,
     dailyUserFees: dailyFees,
-    dailyRevenue: dailyFees,
-    dailyProtocolRevenue: dailyFees,
+    dailyRevenue,
+    dailyProtocolRevenue: dailyRevenue,
   };
 };
 
 const methodology = {
-  Fees: "Affiliate fees earned on swaps the Vultisig wallet routes through THORChain, read from Midgard's affiliate earnings history (/history/affiliate/earnings, totalEarningsUSD) for the Vultisig affiliate names v0 (SDK, desktop app, browser extension), vi (iOS/macOS) and va (Android).",
+  Fees: "Affiliate fees collected on swaps the Vultisig wallet routes through THORChain, read from Midgard's per-THORName affiliate history for the Vultisig affiliate names v0 (SDK, desktop app, browser extension), vi (iOS/macOS) and va (Android).",
   UserFees: "Same as Fees - the affiliate fee is taken out of the swap and paid by the user.",
   Revenue: "All affiliate fees accrue to Vultisig. When a swap carries a referral code THORChain pays the referrer under the referrer's own THORName, so the referrer's cut never lands on the Vultisig names and there is no supply-side cut left to deduct.",
   ProtocolRevenue: "All revenue is protocol revenue; it is settled to the Vultisig fee wallet.",
@@ -64,10 +75,10 @@ const breakdownMethodology = {
     [AFFILIATE_FEES]: "Affiliate fee charged on THORChain swaps routed by Vultisig, paid by the swapping user.",
   },
   Revenue: {
-    [AFFILIATE_FEES]: "Affiliate fee charged on THORChain swaps routed by Vultisig, all of it kept by the protocol.",
+    [FEES_TO_VULTISIG]: "Affiliate fees collected under the Vultisig THORNames, settled to the Vultisig fee wallet.",
   },
   ProtocolRevenue: {
-    [AFFILIATE_FEES]: "Affiliate fee charged on THORChain swaps routed by Vultisig, settled to the Vultisig fee wallet.",
+    [FEES_TO_VULTISIG]: "Affiliate fees collected under the Vultisig THORNames, settled to the Vultisig fee wallet.",
   },
 };
 
@@ -75,9 +86,9 @@ const adapter: SimpleAdapter = {
   version: 1,
   fetch,
   chains: [CHAIN.THORCHAIN],
-  // Midgard's affiliate earnings series starts here network-wide - no affiliate name reports
-  // earnings before this date, so earlier days would publish a false zero.
-  // MayaChain is left out: its Midgard exposes affiliate volume but no affiliate earnings route.
+  // Midgard's affiliate series starts here network-wide - no affiliate name reports
+  // collections before this date, so earlier days would publish a false zero.
+  // MayaChain is left out: its Midgard reports affiliate swap volume but not fee collections.
   start: "2024-12-13",
   methodology,
   breakdownMethodology,


### PR DESCRIPTION
Adds Vultisig — same listing shape as THORWallet/LeoDex (swap interface with affiliate-attributed volume + fees).

**Name (to be shown on DefiLlama):** Vultisig
**Website:** https://vultisig.com
**Twitter:** https://x.com/vultisig
**Logo (hi-res):** https://avatars.githubusercontent.com/u/157932671?s=460&v=4 (SVG: https://vultisig.com/logo.svg)
**Short Description:** Open-source, self-custodial multi-chain wallet with no seed phrase (MPC threshold signatures). Native cross-chain swaps on iOS, Android, desktop, and browser extension.
**Category:** DEX Aggregator (matching THORWallet/LeoDex)
**Chain:** THORChain, MayaChain (attribution chains; the app itself is multi-chain)
**Token:** VULT — ethereum:0xb788144df611029c60b859df47e79b7726c4deba
**Coingecko ID:** vultisig
**Audit:** DKLS23 MPC library audited by Trail of Bits: https://github.com/silence-laboratories/dkls23/blob/main/docs/ToB-SilenceLaboratories_2024.04.10.pdf
**GitHub:** https://github.com/vultisig
**Treasury addresses:** not disclosed in this PR
**Oracle / forkedFrom:** n/a

## Methodology

Volume (`aggregators/vultisig`) and fees (`fees/vultisig`) are attributed via Midgard's affiliate endpoints for Vultisig's three affiliate names — `v0` (SDK/desktop/extension), `vi` (iOS), `va` (Android) — all verified in the client source:
- v0: vultisig-sdk `packages/core/chain/swap/native/nativeSwapAffiliateConfig.ts`
- vi: vultisig-ios `Blockchain/THORChain/Signing/THORChainSwaps.swift`
- va: vultisig-android `data/.../chains/helpers/THORChainSwaps.kt`

Uses the same Midgard gateway host + `x-client-id: defillama` header as the existing `thorchain-dex` adapters. MayaChain volume included; Maya fees omitted (Maya's Midgard has no affiliate-earnings route — deriving from bps would be a guess).

**Why `version: 1`:** Midgard's `/v2/history/affiliate` route is not additive on sub-day windows — any hourly window returns the full day's total, so hourly polling would overcount up to 24× (measured: a $4,185 Maya day summed to $96,260 hourly). Documented inline; day-bucket queries assert the returned bucket's `startTime`.

**LI.FI deliberately excluded:** Vultisig's LI.FI integrators (`vultisig-0`/`vultisig-ios`/`vultisig-android`) are currently counted inside the LI.FI listing (its adapter excludes only the Jumper integrators), so adding them here would double count. Happy to follow up with the LI.FI exclude-list change if you and the LI.FI team want the volume attributed to Vultisig instead.

## receipts

Repo's own test runner, run locally against live Midgard:

```
pnpm test aggregators vultisig
2026-08-08  thorchain 2.25 k   mayachain 4.18 k   Aggregate 6.44 k
2026-08-11  thorchain 55.36 k  mayachain 0.00     Aggregate 55.36 k
2025-06-01  thorchain 33.73 k  (historical backfill OK)

pnpm test fees vultisig
2026-08-11  dailyFees 169  (= userFees = revenue = protocolRevenue, "Swap Affiliate Fees")
```

Fee/volume ratio sanity-checks to the 50 bps affiliate rate (e.g. 24.66/5,065.80 = 0.487%). Lifetime per Midgard: ~$100M THORChain volume, ~$445k affiliate fees. `npx tsc --noEmit` clean on both files; no dependency changes.