### PR TITLE
chore(justbet): mark dimension adapters dead from 2025-11-01

### DIFF
--- a/dexs/justbet/index.ts
+++ b/dexs/justbet/index.ts
@@ -94,5 +94,5 @@ export default {
   },
   version: 2,
   pullHourly: true,
-  deadFrom: '2025-11-01', // WINR Chain was shut down
+  deadFrom: '2026-01-02', // WINR Chain was shut down
 } as Adapter;

--- a/dexs/justbet/index.ts
+++ b/dexs/justbet/index.ts
@@ -94,4 +94,5 @@ export default {
   },
   version: 2,
   pullHourly: true,
+  deadFrom: '2025-11-01', // WINR Chain was shut down
 } as Adapter;

--- a/fees/justbet/index.ts
+++ b/fees/justbet/index.ts
@@ -54,7 +54,7 @@ export default {
   },
   allowNegativeValue: true, // casino lose money on some days
   version: 2,
-  deadFrom: '2025-11-01', // WINR Chain was shut down
+  deadFrom: '2026-01-02', // WINR Chain was shut down
   methodology: {
     Fees: "All fees collected from user bets.",
     Revenue: "Fees collected from user bets.",

--- a/fees/justbet/index.ts
+++ b/fees/justbet/index.ts
@@ -54,6 +54,7 @@ export default {
   },
   allowNegativeValue: true, // casino lose money on some days
   version: 2,
+  deadFrom: '2025-11-01', // WINR Chain was shut down
   methodology: {
     Fees: "All fees collected from user bets.",
     Revenue: "Fees collected from user bets.",


### PR DESCRIPTION
**Allow edits by maintainers is enabled.** No new dependencies; no lockfile changes.

## Mark the JustBet dimension adapters dead from 2025-11-01

WINR Chain was shut down on **2025-11-01**. Both `dexs/justbet` and `fees/justbet` are scoped exclusively to `CHAIN.WINR` and read V1 contracts that no longer exist:

- `VaultAdapter 0xc942b79E51fe075c9D8d2c7501A596b4430b9Dd7`
- `GameLogEmitter 0xCA54fAa01bf1606e4b6a62871071DAF9347aFB52`

The `fees` adapter additionally depends on `shareTokenAddress` / `liquidityManagerAddress` from `getAllDataBatch`, which belong to a share-token bankroll design the protocol no longer uses.

**Marking dead rather than deleting**, so the historical fees and volume series are preserved rather than erased. `deadFrom` is set at module root, matching the dominant convention in this repo (42 root-level usages vs 13 chain-level) and the precedence order at `adapters/utils/runAdapter.ts:470` (`module.deadFrom ?? adapterObject[chain]?.deadFrom`). Both adapters are single-chain, so root level is unambiguous.

This is consistent with how the JustBet **TVL** adapter was already retired upstream in `DefiLlama-Adapters` — archived in `registries/deadAdapters.json` as `{"winr":{"tvl":"_f"},"deadFrom":"2026-07-17"}`.

The protocol has since migrated to a hybrid off-chain model on Arbitrum: game logic and accounting run off-chain, with only the bankroll vault and escrow on-chain, settled via merkle roots roughly every 5 minutes. **A replacement fees adapter for Arbitrum follows in a separate PR** (`fees/winr-protocol`).

Nothing else in either file is changed — two lines total.