### PR TITLE
feat(winr-protocol): add fees adapter for Arbitrum bankroll

### DIFF
--- a/fees/winr-protocol/index.ts
+++ b/fees/winr-protocol/index.ts
@@ -4,7 +4,10 @@ import { CHAIN } from "../../helpers/chains";
 // JustBet runs on WINR Protocol. Game logic and accounting are off-chain; the
 // only on-chain money flows are between the escrow and the bankroll vault,
 // settled via merkle roots roughly every 5 minutes.
+
+// WINRBankroll - https://arbiscan.io/address/0x5eD22F7693fea5A0B45dB31771aa94E941b6df8a
 const BANKROLL = '0x5eD22F7693fea5A0B45dB31771aa94E941b6df8a';
+// WINR token, 18 decimals - https://arbiscan.io/token/0xD77B108d4f6cefaa0Cae9506A934e825BEccA46E
 const WINR = '0xD77B108d4f6cefaa0Cae9506A934e825BEccA46E';
 
 // Escrow-only entry points on the bankroll: the house banking a win, and the
@@ -12,8 +15,12 @@ const WINR = '0xD77B108d4f6cefaa0Cae9506A934e825BEccA46E';
 const ProfitReceived = 'event ProfitReceived(uint256 amount)';
 const LossCovered = 'event LossCovered(uint256 amount)';
 
+const FEE_LABEL = 'Net Gaming Revenue';
+const LP_LABEL = 'Net Gaming Revenue To LPs';
+
 const fetch = async (options: FetchOptions) => {
   const dailyFees = options.createBalances();
+  const dailySupplySideRevenue = options.createBalances();
 
   const [profits, losses] = await Promise.all([
     options.getLogs({ target: BANKROLL, eventAbi: ProfitReceived }),
@@ -25,29 +32,42 @@ const fetch = async (options: FetchOptions) => {
   profits.forEach((log: any) => { net += BigInt(log.amount) });
   losses.forEach((log: any) => { net -= BigInt(log.amount) });
 
-  dailyFees.add(WINR, net);
+  dailyFees.add(WINR, net, FEE_LABEL);
+  dailySupplySideRevenue.add(WINR, net, LP_LABEL);
 
   return {
     dailyFees,
-    dailySupplySideRevenue: dailyFees,
+    dailySupplySideRevenue,
     dailyRevenue: 0,
     dailyProtocolRevenue: 0,
   };
 };
 
 const methodology = {
-  Fees: 'Net gaming revenue captured by the bankroll, measured as WINR flowing in via ProfitReceived minus WINR flowing out via LossCovered. Gross wagered volume is not observable on-chain; games run off-chain and only net settlement reaches Arbitrum.',
-  SupplySideRevenue: 'Equal to Fees. All net gaming revenue accrues to bankroll liquidity providers through share price appreciation; there is no separate distribution transaction.',
-  Revenue: 'Zero. The protocol\'s own share of gaming revenue is accounted off-chain in the escrow ledger and does not appear on-chain, so it is deliberately not reported here rather than estimated.',
+  Fees: 'Net gaming revenue (NGR) settled to the bankroll, measured as WINR received via ProfitReceived minus WINR paid out via LossCovered. This is an NGR figure standing in for a Fees field that conventionally carries GGR: gross wagered turnover is not observable on-chain because games run off-chain, and creator rewards, affiliate commissions and VIP cashback are already deducted in the off-chain escrow ledger before settlement. NGR is the most complete figure derivable from chain data, and this is a known limitation rather than an omission.',
+  SupplySideRevenue: 'Equal to Fees. All settled net gaming revenue accrues to bankroll liquidity providers through share price appreciation; there is no separate distribution transaction.',
+  Revenue: 'Zero. No protocol share is deducted on-chain - a 30 day reconciliation shows 100% of settled net gaming revenue accruing to bankroll liquidity providers through share price appreciation, with no leakage to any other on-chain party. The protocol does capture revenue at the application layer, but it is charged and accounted entirely off-chain and is not derivable from chain data, so it is deliberately not estimated here.',
+  ProtocolRevenue: 'Zero, for the same reason as Revenue: no protocol share is taken on-chain, and application-layer revenue is not observable from chain data.',
+};
+
+const breakdownMethodology = {
+  Fees: {
+    [FEE_LABEL]: 'WINR received by the bankroll via ProfitReceived minus WINR paid out via LossCovered, per ~5 minute settlement.',
+  },
+  SupplySideRevenue: {
+    [LP_LABEL]: 'The same net amount, accruing to bankroll liquidity providers through share price appreciation rather than a distribution transaction.',
+  },
 };
 
 const adapter: SimpleAdapter = {
   version: 2,
+  pullHourly: true,
   fetch,
   chains: [CHAIN.ARBITRUM],
   start: '2026-05-20', // first ProfitReceived; bankroll deployed 2026-05-19
   allowNegativeValue: true, // players win outright on some days
   methodology,
+  breakdownMethodology,
 };
 
 export default adapter;

--- a/fees/winr-protocol/index.ts
+++ b/fees/winr-protocol/index.ts
@@ -1,0 +1,53 @@
+import { FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+
+// JustBet runs on WINR Protocol. Game logic and accounting are off-chain; the
+// only on-chain money flows are between the escrow and the bankroll vault,
+// settled via merkle roots roughly every 5 minutes.
+const BANKROLL = '0x5eD22F7693fea5A0B45dB31771aa94E941b6df8a';
+const WINR = '0xD77B108d4f6cefaa0Cae9506A934e825BEccA46E';
+
+// Escrow-only entry points on the bankroll: the house banking a win, and the
+// bankroll covering a player win.
+const ProfitReceived = 'event ProfitReceived(uint256 amount)';
+const LossCovered = 'event LossCovered(uint256 amount)';
+
+const fetch = async (options: FetchOptions) => {
+  const dailyFees = options.createBalances();
+
+  const [profits, losses] = await Promise.all([
+    options.getLogs({ target: BANKROLL, eventAbi: ProfitReceived }),
+    options.getLogs({ target: BANKROLL, eventAbi: LossCovered }),
+  ]);
+
+  // Net house PnL. Negative on days where players win overall, which is routine.
+  let net = 0n;
+  profits.forEach((log: any) => { net += BigInt(log.amount) });
+  losses.forEach((log: any) => { net -= BigInt(log.amount) });
+
+  dailyFees.add(WINR, net);
+
+  return {
+    dailyFees,
+    dailySupplySideRevenue: dailyFees,
+    dailyRevenue: 0,
+    dailyProtocolRevenue: 0,
+  };
+};
+
+const methodology = {
+  Fees: 'Net gaming revenue captured by the bankroll, measured as WINR flowing in via ProfitReceived minus WINR flowing out via LossCovered. Gross wagered volume is not observable on-chain; games run off-chain and only net settlement reaches Arbitrum.',
+  SupplySideRevenue: 'Equal to Fees. All net gaming revenue accrues to bankroll liquidity providers through share price appreciation; there is no separate distribution transaction.',
+  Revenue: 'Zero. The protocol\'s own share of gaming revenue is accounted off-chain in the escrow ledger and does not appear on-chain, so it is deliberately not reported here rather than estimated.',
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  fetch,
+  chains: [CHAIN.ARBITRUM],
+  start: '2026-05-20', // first ProfitReceived; bankroll deployed 2026-05-19
+  allowNegativeValue: true, // players win outright on some days
+  methodology,
+};
+
+export default adapter;


### PR DESCRIPTION
**Allow edits by maintainers is enabled.** No new dependencies; no lockfile changes.

## `fees/winr-protocol` — replacement fees adapter on Arbitrum

JustBet / WINR Protocol migrated from a fully on-chain casino to a hybrid off-chain model. Game logic, RNG, rake, affiliate and VIP accounting all run off-chain; only the **bankroll vault** and the **escrow** remain on-chain, settled via merkle roots roughly every 5 minutes. WINR Chain was shut down on 2025-11-01 and the old `fees/justbet` adapter is being retired in a companion PR.

This adapter measures net gaming revenue on Arbitrum from the bankroll's two escrow-only entry points:

- `ProfitReceived(uint256)` — the house banking a win
- `LossCovered(uint256)` — the bankroll paying out a player win

`dailyFees = ProfitReceived − LossCovered`, denominated in WINR.

Bankroll: [`0x5eD22F7693fea5A0B45dB31771aa94E941b6df8a`](https://arbiscan.io/address/0x5eD22F7693fea5A0B45dB31771aa94E941b6df8a) · WINR: [`0xD77B108d4f6cefaa0Cae9506A934e825BEccA46E`](https://arbiscan.io/token/0xD77B108d4f6cefaa0Cae9506A934e825BEccA46E) (18 dec)

### Field mapping

| Field | Value | Label | Why |
|---|---|---|---|
| `dailyFees` | `ProfitReceived − LossCovered` | `Net Gaming Revenue` | Net house edge actually captured on-chain |
| `dailySupplySideRevenue` | same | `Net Gaming Revenue To LPs` | 100% accrues to bankroll LPs via share price (proven below) |
| `dailyRevenue` | `0` | — | No protocol cut is observable on-chain |
| `dailyProtocolRevenue` | `0` | — | Same |
| `dailyHoldersRevenue` | **omitted** | — | Zero on-chain basis (proven below) |

Source and destination labels are carried on separate `createBalances()` objects, per GUIDELINES.md lines 195–196, and both have matching `breakdownMethodology` entries on the default export.

### This is an NGR figure, not GGR — stated as a known limitation

WINR defines GGR as player losses *before* creator rewards, affiliate commissions and VIP cashback, with NGR as the remainder. Those deductions are all applied in the off-chain escrow ledger **before** settlement, so what reaches the bankroll via `ProfitReceived` is already NGR.

`dailyFees` therefore carries an NGR figure in a field that conventionally carries GGR. Gross wagered turnover is not recoverable on-chain — games run off-chain and only net settlement reaches Arbitrum — so NGR is the most complete figure derivable from chain data. This is documented explicitly in the `methodology.Fees` string rather than left implied.

### Revenue is zero *on-chain*, which is not the same as zero

`dailyRevenue` and `dailyProtocolRevenue` are `0` because **no protocol share is deducted on-chain**, which the reconciliation below proves directly. The protocol does capture revenue at the application layer, but it is charged and accounted entirely off-chain and is not derivable from chain data, so it is deliberately not estimated here rather than guessed at. Reporting `0` is a statement about on-chain observability, not a claim that no revenue exists.

The retired `fees/justbet` adapter reported a **60% revenue / 20% holders-revenue split**. That split has no on-chain basis in the current architecture and is deliberately **not** carried over.

### `start` date

`start: '2026-05-20'`, derived from chain data rather than assumed:

- Bankroll's first-ever event (`OwnershipTransferred`, deployment): block **464,512,584** — 2026-05-19T16:09:53Z
- First `ProfitReceived`: block **464,889,407** — 2026-05-20T18:20:05Z, 627.75 WINR, tx `0x9c9c68db…4f1ed1`

### `allowNegativeValue: true` is required

The house loses outright on a meaningful share of days. Over a 30-day sample, **8 of 31 days were negative**, worst at −1,656,812 WINR. Without the flag those days break.

### Verification

30-day sample (2026-07-12 → 2026-08-11):

- **55,990,329 WINR** in via **3,640** `ProfitReceived`
- **44,574,118 WINR** out via **2,513** `LossCovered`
- **Net +11,416,211 WINR**

**All net PnL reaches LPs, with zero on-chain leakage.** The bankroll's own state reconciles to the event stream exactly:

```
Δ principalPool  89,863,628  =  11,416,211 net PnL
                              + 142,762,794 deposits claimed
                              −  64,315,377 withdrawals claimed
                              residual 0.00%
```

`Δ totalShares` closes independently at **0.00%** on the complementary word pairing of the same two claim events, cross-confirming the decode. Over the window `exchangeRate` moved **1.023781282 → 1.051131999** (+2.67%), and `principalPool ≡ exchangeRate × totalShares` holds at both endpoints — i.e. profit accrues purely through share price, with no distribution transaction and no other on-chain recipient. This is the direct evidence behind `dailyRevenue: 0`.

**Holders revenue is zero on-chain.** Both WINRStakingV2 deployments — `0x248D0105ec632505c797bbA8F19f4787f0deBd64` and `0x4E34d32f5422693e478C8E836daeCa78031841f5` — received **zero** inbound WINR and **zero** inbound USDC across the same 30 days. Control-validated: an identical topic filter shape returns 51 inbound transfers to the escrow over the same window, so the zero is a real result and not a broken filter. `dailyHoldersRevenue` is therefore omitted rather than reported as zero.

**Gross wagered volume is not observable on-chain** and is not reported. The old `dexs/justbet` derived volume by decoding per-bet receipts from a game-log emitter on WINR Chain, which has no Arbitrum successor.

### Test output

Run with `pullHourly: true`, so the runner evaluates 24 hourly slices and sums them. Two known-negative days, confirming the negative value survives rather than being clamped or dropped (the CLI's date argument is the window end, so it reports the preceding UTC day):

```
$ npm run test fees winr-protocol 2026-07-22
====== TOTAL DAILY AGGREGATED (sum of slots per chain) ======

ARBITRUM 👇
End timestamp: 1784678399 (2026-07-21T23:59:59.000Z)
Daily fees: -1.78 k
Daily supply side revenue: -1.78 k
Daily revenue: 0.00
Daily protocol revenue: 0.00

FEES BREAKDOWN 👇

label                     | Daily fees | Daily supply side revenue
---                       | ---        | ---
Net Gaming Revenue        | -1779.4655 |
Net Gaming Revenue To LPs |            | -1779.4655
```

```
$ npm run test fees winr-protocol 2026-08-10
====== TOTAL DAILY AGGREGATED (sum of slots per chain) ======

ARBITRUM 👇
End timestamp: 1786319999 (2026-08-09T23:59:59.000Z)
Daily fees: -7.06 k
Daily supply side revenue: -7.06 k
Daily revenue: 0.00
Daily protocol revenue: 0.00

FEES BREAKDOWN 👇

label                     | Daily fees | Daily supply side revenue
---                       | ---        | ---
Net Gaming Revenue        | -7064.3    |
Net Gaming Revenue To LPs |            | -7064.3
```

And a positive day for contrast:

```
$ npm run test fees winr-protocol 2026-07-14
====== TOTAL DAILY AGGREGATED (sum of slots per chain) ======

ARBITRUM 👇
End timestamp: 1783987199 (2026-07-13T23:59:59.000Z)
Daily fees: 4.29 k
Daily supply side revenue: 4.29 k
Daily revenue: 0.00
Daily protocol revenue: 0.00

FEES BREAKDOWN 👇

label                     | Daily fees        | Daily supply side revenue
---                       | ---               | ---
Net Gaming Revenue        | 4290.059499999999 |
Net Gaming Revenue To LPs |                   | 4290.059499999999
```

Underlying WINR quantities for those three days are −620,325 / −1,656,812 / +2,189,864 WINR respectively.

**Note on `pullHourly` and the USD figures.** Enabling `pullHourly: true` (required for `version: 2` adapters per GUIDELINES.md line 55, and specifically recommended for EVM-log adapters at line 12) changes the reported USD totals by a few percent relative to a single daily window, because each hourly slice is priced at that hour's WINR price rather than pricing the daily total at one price point. The underlying WINR quantity is unchanged — running with `DISABLE_PULL_HOURLY=true` reproduces the single-window figures exactly (−1735 / −7449 / +4708 for the three days above). The direction of the difference varies by day (−2.5%, +5.1%, −8.9%), consistent with intraday price movement rather than any systematic bias or double-counting. USD figures also move by a fraction of a percent between runs as price snapshots are refined; the token quantities are fixed.

### Slug binding — please correct me if I have this wrong

I could not find an explicit folder→protocol-slug mapping file in this repo, so I've assumed binding is by convention (directory name = protocol slug), consistent with how `justbet` was laid out. `winr-protocol` is live as protocol **id 3032**, chains `["Arbitrum"]`, so the target entry already exists. If there is a server-side mapping I can't see from here, please point me at it and I'll adjust the directory name.

Separately, and outside this PR: the `winr-protocol` listing is currently categorised as "Prediction Market", which is inaccurate for a casino bankroll. I'll send that to metadata@defillama.com rather than change it here.