### PR TITLE
accountable: add robinhood chain

### DIFF
--- a/fees/accountable.ts
+++ b/fees/accountable.ts
@@ -41,6 +41,14 @@ const config: Record<string, { factories: string[], start: string }> = {
     ],
     start: "2026-02-13",
   },
+  [CHAIN.ROBINHOOD]: {
+    factories: [
+      "0x017273Eeb06Ee9f863020269417DB9559FD94173",
+      "0x474B612F970491801743BF0e4B9153620FC36096",
+      "0xA4d6a4aD35fc632aEE1dC48A2aEc2aaa37B51F9f",
+    ],
+    start: "2026-07-22",
+  },
 };
 
 // aHYPER Looping Vault (vault 0x23b148d8f389C5821739381f1FF87bB7e1162566) is


### PR DESCRIPTION
Adds Robinhood Chain to the Accountable fees adapter, same pattern as the other chains — factory addresses match the ones already used in the TVL adapter (`projects/accountable/index.js`), start date is the factory deployment date (2026-07-22).

Currently one active vault there (via the yield factory), NAV-priced (share price path), matching what the adapter already handles for other chains.

Note per our chat: the public RPC (`rpc.mainnet.chain.robinhood.com`) only retains a few minutes of state, so this will fail against it — the run needs the premium RPC on your side to reach day-start state. Let me know how the test goes.
