### PR TITLE
pancakeswap-prediction: fix the notional formula, add the BTC and ETH markets

### DIFF
--- a/dexs/pancakeswap-prediction/index.ts
+++ b/dexs/pancakeswap-prediction/index.ts
@@ -3,6 +3,7 @@ import { CHAIN } from "../../helpers/chains";
 import ADDRESSES from '../../helpers/coreAssets.json'
 
 // All three live markets are staked in native BNB and emit identical events.
+// Addresses from https://docs.pancakeswap.finance/play/prediction/prediction-faq
 const PREDICTION_MARKETS = [
   "0x18B2A687610328590Bc8F2e5fEdDe3b582A49cdA", // BNBUSD
   "0x48781a7d35f6137a9135Bbb984AF65fd6AB25618", // BTCUSD, live since 2025-09-08
@@ -48,7 +49,7 @@ async function fetch(options: FetchOptions) {
     eventAbi: EVENT_ABI.REWARDS_CALCULATED,
   });
 
-  // treasuryAmount is the settled fee, so a tie (whole pot to treasury) is covered too
+  // treasuryAmount is the settled fee, so rounds with no winners (whole pot to treasury) are covered too
   rewardLogs.forEach(reward => {
     dailyFees.add(ADDRESSES.bsc.WBNB, reward.treasuryAmount);
   });
@@ -67,7 +68,7 @@ async function fetch(options: FetchOptions) {
 const methodology = {
   Volume: "Everything staked on the up and down sides of every five-minute round, across the BNB, BTC and ETH price markets.",
   NotionalVolume: "The size of each round's pot, which is what gets paid out when the round settles. Both sides stake into the same pot, so this matches the amount staked.",
-  Fees: "3% of each round's total pot, counting both the winning and the losing stakes, taken when the round settles. If the price finishes exactly where it started, the whole pot goes to the treasury instead.",
+  Fees: "3% of each round's total pot, counting both the winning and the losing stakes, taken when the round settles. When a round ends with nobody to pay out - the price finishes exactly where it started, or every bet was on the losing side — the whole pot goes to the treasury instead.",
   Revenue: "All of the fee is kept. Winners are paid out of the losing stakes, so there are no liquidity providers or market makers taking a share.",
   ProtocolRevenue: "Zero. Everything the treasury collects is spent on buying back and burning CAKE, so none of it is retained.",
   HoldersRevenue: "All the revenue goes to CAKE buyback and burn",
@@ -75,7 +76,7 @@ const methodology = {
 
 const breakdownMethodology = {
   Fees: {
-    [METRIC.PredictionFees]: "3% of each round's total pot, taken when the round settles",
+    [METRIC.PredictionFees]: "3% of each round's total pot, taken when the round settles, or the whole pot when a round ends with no winners",
   },
   Revenue: {
     [METRIC.PredictionRevenueToHolders]: "All the fee is kept as revenue, it will be used to buy back and burn CAKE",

--- a/dexs/pancakeswap-prediction/index.ts
+++ b/dexs/pancakeswap-prediction/index.ts
@@ -2,7 +2,13 @@ import { FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 import ADDRESSES from '../../helpers/coreAssets.json'
 
-const PCS_BNB_PREDICTION_CONTRACT = "0x18B2A687610328590Bc8F2e5fEdDe3b582A49cdA";
+// All three live markets are staked in native BNB and emit identical events.
+const PREDICTION_MARKETS = [
+  "0x18B2A687610328590Bc8F2e5fEdDe3b582A49cdA", // BNBUSD
+  "0x48781a7d35f6137a9135Bbb984AF65fd6AB25618", // BTCUSD, live since 2025-09-08
+  "0x7451F994A8D510CBCB46cF57D50F31F188Ff58F5", // ETHUSD, live since 2025-09-08
+];
+
 const EVENT_ABI = {
   REWARDS_CALCULATED: "event RewardsCalculated (uint256 indexed epoch, uint256 rewardBaseCalAmount, uint256 rewardAmount, uint256 treasuryAmount)",
   BET_BEAR: "event BetBear (address indexed sender,uint256 indexed epoch, uint256 amount)",
@@ -18,73 +24,58 @@ const METRIC = {
 async function fetch(options: FetchOptions) {
   const dailyVolume = options.createBalances();
   const dailyFees = options.createBalances();
-  const dailyNotionalVolume = options.createBalances();
-
-  const epochData: Map<number, { bullAmount: bigint; bearAmount: bigint }> = new Map();
 
   const bullLogs = await options.getLogs({
-    target: PCS_BNB_PREDICTION_CONTRACT,
+    targets: PREDICTION_MARKETS,
     eventAbi: EVENT_ABI.BET_BULL,
   });
 
   bullLogs.forEach(bet => {
     dailyVolume.add(ADDRESSES.bsc.WBNB, bet.amount);
-    const epoch = bet.epoch;
-    const data = epochData.get(epoch) || { bullAmount: 0n, bearAmount: 0n };
-    data.bullAmount += BigInt(bet.amount);
-    epochData.set(epoch, data);
   });
 
   const bearLogs = await options.getLogs({
-    target: PCS_BNB_PREDICTION_CONTRACT,
+    targets: PREDICTION_MARKETS,
     eventAbi: EVENT_ABI.BET_BEAR,
   });
 
   bearLogs.forEach(bet => {
     dailyVolume.add(ADDRESSES.bsc.WBNB, bet.amount);
-    const epoch = bet.epoch;
-    const data = epochData.get(epoch) || { bullAmount: 0n, bearAmount: 0n };
-    data.bearAmount += BigInt(bet.amount);
-    epochData.set(epoch, data);
   });
 
   const rewardLogs = await options.getLogs({
-    target: PCS_BNB_PREDICTION_CONTRACT,
+    targets: PREDICTION_MARKETS,
     eventAbi: EVENT_ABI.REWARDS_CALCULATED,
   });
 
+  // treasuryAmount is the settled fee, so a tie (whole pot to treasury) is covered too
   rewardLogs.forEach(reward => {
     dailyFees.add(ADDRESSES.bsc.WBNB, reward.treasuryAmount);
   });
 
-  epochData.forEach(({ bullAmount, bearAmount }) => {
-    if (bullAmount > 0n && bearAmount > 0n) {
-      const total = bullAmount + bearAmount;
-      const notional = (total * (bullAmount * bullAmount + bearAmount * bearAmount)) / (bullAmount * bearAmount);
-      dailyNotionalVolume.add(ADDRESSES.bsc.WBNB, notional);
-    }
-  });
-
   return {
     dailyVolume,
+    // both sides stake into one pot, and the pot is what settlement pays out
+    dailyNotionalVolume: dailyVolume.clone(),
     dailyFees: dailyFees.clone(1, METRIC.PredictionFees),
     dailyRevenue: dailyFees.clone(1, METRIC.PredictionRevenueToHolders),
-    dailyNotionalVolume,
     dailyProtocolRevenue: 0,
     dailyHoldersRevenue: dailyFees.clone(1, METRIC.BuyBackAndBurn),
   };
 }
 
 const methodology = {
-  Fees: "3% from winners' share is taken as fee",
-  Revenue: "All the fee is kept as revenue",
-  ProtocolRevenue: "Protocol doesn't take any revenue share",
+  Volume: "Everything staked on the up and down sides of every five-minute round, across the BNB, BTC and ETH price markets.",
+  NotionalVolume: "The size of each round's pot, which is what gets paid out when the round settles. Both sides stake into the same pot, so this matches the amount staked.",
+  Fees: "3% of each round's total pot, counting both the winning and the losing stakes, taken when the round settles. If the price finishes exactly where it started, the whole pot goes to the treasury instead.",
+  Revenue: "All of the fee is kept. Winners are paid out of the losing stakes, so there are no liquidity providers or market makers taking a share.",
+  ProtocolRevenue: "Zero. Everything the treasury collects is spent on buying back and burning CAKE, so none of it is retained.",
   HoldersRevenue: "All the revenue goes to CAKE buyback and burn",
 };
 
 const breakdownMethodology = {
   Fees: {
-    [METRIC.PredictionFees]: "3% from winners' share is taken as fee",
+    [METRIC.PredictionFees]: "3% of each round's total pot, taken when the round settles",
   },
   Revenue: {
     [METRIC.PredictionRevenueToHolders]: "All the fee is kept as revenue, it will be used to buy back and burn CAKE",


### PR DESCRIPTION
## Changes

* Fixed `dailyNotionalVolume` to equal the parimutuel pot (`dailyVolume`) instead of the inflated cross-odds formula.
* Added the live BTCUSD and ETHUSD markets.
* Corrected fee methodology: the 3% treasury fee applies to the **total pot**, with ties sending the full pot to treasury.
* Added/updated methodology for Volume, NotionalVolume, Revenue, and ProtocolRevenue.

## Verification

* `pnpm test dexs pancakeswap-prediction`: notional is now **1.00× volume**; fees remain ~3%.
* BTCUSD/ETHUSD events verified against live logs, both markets are advancing epochs.
