### PR TITLE
sxbet: fix the start date and split revenue by destination

### DIFF
--- a/dexs/sxbet/index.ts
+++ b/dexs/sxbet/index.ts
@@ -4,6 +4,9 @@ import fetchURL from "../../utils/fetchURL";
 
 const SXBET_API = "https://api.prod.sx.bet/analytics"
 
+// WSX buybacks ran Oct-Dec 2025; from 2026 the commission is swept to the treasury instead
+const TREASURY_SWEEP_START = 1767225600 // 2026-01-01
+
 async function fetch(options: FetchOptions): Promise<FetchResult> {
     const volumeData = (await fetchURL(`${SXBET_API}/volume?interval=day&aggregate=false&startDate=${options.startOfDay}&endDate=${options.endTimestamp}`)).data;
     const dailyVolume = volumeData[0].usdVolume;
@@ -13,19 +16,26 @@ async function fetch(options: FetchOptions): Promise<FetchResult> {
 
     const openInterestAtEnd = (await fetchURL(`${SXBET_API}/openInterest`)).data;
 
-    return {
+    const result: FetchResult = {
         dailyVolume,
         dailyFees,
         dailyRevenue: dailyFees,
         openInterestAtEnd,
     }
+
+    if (options.startOfDay < TREASURY_SWEEP_START) result.dailyHoldersRevenue = dailyFees;
+    else result.dailyProtocolRevenue = dailyFees;
+
+    return result;
 }
 
 const methodology = {
-    Volume: "Total USD value of bets matched on the SX Bet exchange each day, from the protocol's public analytics API.",
-    Fees: "SX Bet takes no commission on single bets and a 5% commission on the profit of winning parlays. This is the total commission collected that day; losing bets pay nothing.",
-    Revenue: "Equal to fees — the protocol keeps the full parlay commission and pays none of it to market makers (they earn from the bets they win). This revenue was historically distributed to SX token stakers, but the SX token is being sunset (holder snapshot taken 15 May 2026).",
-    OpenInterest: "Total USD value of open (unsettled) bet positions on the exchange at the end of the day.",
+    Volume: "Total amount staked on bets matched each day. Every bet is funded by two people whose stakes are pooled into a single payout, so both stakes are counted — they are separate money, not the same money counted twice.",
+    Fees: "SX Bet takes no commission on single bets. On parlays it takes 5% of the winner's profit, charged to whichever side wins — market makers pay it too when they win, and losing bets pay nothing. The exchange charged no commission at all between 29 February 2024 and 1 October 2025, and used an earlier fee schedule before that; both are reflected here as reported by the exchange.",
+    Revenue: "Equal to fees. None of the commission is shared with market makers — they earn from the bets they win, not from a cut of the fee.",
+    HoldersRevenue: "Through 2025 the collected commission was spent buying SX tokens on the open market.",
+    ProtocolRevenue: "From January 2026 the collected commission is sent to the team's treasury instead of funding token buybacks.",
+    OpenInterest: "Total amount staked on bets that have been matched but not yet settled. The exchange only publishes this as a current figure, so it reflects the latest snapshot rather than the state on a past date.",
 }
 
 const adapter: SimpleAdapter = {

--- a/dexs/sxbet/index.ts
+++ b/dexs/sxbet/index.ts
@@ -20,6 +20,7 @@ async function fetch(options: FetchOptions): Promise<FetchResult> {
         dailyVolume,
         dailyFees,
         dailyRevenue: dailyFees,
+        dailySupplySideRevenue: 0,
         openInterestAtEnd,
     }
 
@@ -32,7 +33,8 @@ async function fetch(options: FetchOptions): Promise<FetchResult> {
 const methodology = {
     Volume: "Total amount staked on bets matched each day. Every bet is funded by two people whose stakes are pooled into a single payout, so both stakes are counted — they are separate money, not the same money counted twice.",
     Fees: "SX Bet takes no commission on single bets. On parlays it takes 5% of the winner's profit, charged to whichever side wins — market makers pay it too when they win, and losing bets pay nothing. The exchange charged no commission at all between 29 February 2024 and 1 October 2025, and used an earlier fee schedule before that; both are reflected here as reported by the exchange.",
-    Revenue: "Equal to fees. None of the commission is shared with market makers — they earn from the bets they win, not from a cut of the fee.",
+    Revenue: "Equal to fees, because none of the commission is shared with anyone else.",
+    SupplySideRevenue: "Zero. Market makers get no share of the commission — they profit from the bets they win. The USDC maker rewards programme is a separate incentive budget, not a cut of fees.",
     HoldersRevenue: "Through 2025 the collected commission was spent buying SX tokens on the open market.",
     ProtocolRevenue: "From January 2026 the collected commission is sent to the team's treasury instead of funding token buybacks.",
     OpenInterest: "Total amount staked on bets that have been matched but not yet settled. The exchange only publishes this as a current figure, so it reflects the latest snapshot rather than the state on a past date.",
@@ -42,7 +44,8 @@ const adapter: SimpleAdapter = {
     version: 1,
     fetch,
     chains: [CHAIN.SXR],
-    start: '2019-03-04',
+    // volume data begins 2020-09-23 but the revenue series has gaps until 2020-12-06
+    start: '2020-12-07',
     methodology,
 };
 


### PR DESCRIPTION
## Changes

* Split `dailyRevenue` by the collector's destination: **holders revenue through 2025** and **protocol revenue from 2026**; supply-side revenue remains 0.
* Corrected methodology for the 5% parlay fee, including maker/taker applicability and the 2024–2025 zero-fee period.
* Clarified that open interest is a **current live snapshot**, not an end-of-day historical value.

## Verification

* 2025-11-15: **$530 holders revenue**; 2026-01-01: **$68 protocol revenue**.
