### PR TITLE
[feat] N1 Exchange - add volume and open-interest adapter

### DIFF
--- a/dexs/n1-exchange/index.ts
+++ b/dexs/n1-exchange/index.ts
@@ -1,0 +1,82 @@
+import { FetchOptions, FetchResultVolume, SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import { httpGet } from "../../utils/fetchURL";
+import { sleep } from "../../utils/utils";
+
+const N1_API = "https://api-mainnet.n1.xyz";
+
+interface N1Market {
+  marketId: number;
+  symbol: string;
+}
+
+interface N1InfoResponse {
+  markets: N1Market[];
+}
+
+interface N1MarketStats {
+  volumeQuote24h: number;
+  indexPrice: number | null;
+  perpStats: {
+    open_interest: number;
+  } | null;
+}
+
+async function fetch(_options: FetchOptions): Promise<FetchResultVolume> {
+  const info: N1InfoResponse = await httpGet(`${N1_API}/info`);
+  if (!Array.isArray(info.markets) || info.markets.length === 0) {
+    throw new Error("N1 info endpoint returned no markets");
+  }
+
+  let dailyVolume = 0;
+  let openInterestAtEnd = 0;
+
+  for (const market of info.markets) {
+    if (!market.symbol.endsWith("USD")) continue;
+
+    // Pace requests to stay within the public API's rate limits.
+    await sleep(200);
+    const stats: N1MarketStats = await httpGet(
+      `${N1_API}/market/${market.marketId}/stats`,
+    );
+
+    const volume = Number(stats.volumeQuote24h);
+    const indexPrice = Number(stats.indexPrice);
+    const openInterest = Number(stats.perpStats?.open_interest);
+    if (
+      !Number.isFinite(volume) ||
+      volume < 0 ||
+      !Number.isFinite(indexPrice) ||
+      indexPrice < 0 ||
+      !Number.isFinite(openInterest) ||
+      openInterest < 0
+    ) {
+      throw new Error(`N1 market ${market.marketId} returned invalid stats`);
+    }
+
+    dailyVolume += volume;
+    openInterestAtEnd += openInterest * indexPrice;
+  }
+
+  return { dailyVolume, openInterestAtEnd };
+}
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  // Proton exposes rolling 24-hour totals, so hourly slices cannot be summed.
+  pullHourly: false,
+  adapter: {
+    [CHAIN.N1]: {
+      fetch,
+      runAtCurrTime: true,
+    },
+  },
+  methodology: {
+    Volume:
+      "Rolling 24-hour quote volume reported by Proton across all N1 Exchange USD perpetual markets.",
+    OpenInterest:
+      "Current notional open interest across all N1 Exchange USD perpetual markets, calculated as base open interest multiplied by index price.",
+  },
+};
+
+export default adapter;

--- a/dexs/n1-exchange/index.ts
+++ b/dexs/n1-exchange/index.ts
@@ -1,9 +1,12 @@
+import { PromisePool } from "@supercharge/promise-pool";
 import { FetchOptions, FetchResultVolume, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 import { httpGet } from "../../utils/fetchURL";
 import { sleep } from "../../utils/utils";
 
 const N1_API = "https://api-mainnet.n1.xyz";
+const N1_API_CONCURRENCY = 5;
+const N1_API_REQUEST_DELAY_MS = 200;
 
 interface N1Market {
   marketId: number;
@@ -22,58 +25,82 @@ interface N1MarketStats {
   } | null;
 }
 
-async function fetch(_options: FetchOptions): Promise<FetchResultVolume> {
+async function fetch(options: FetchOptions): Promise<FetchResultVolume> {
+  if (options.chain !== CHAIN.N1) {
+    throw new Error(`Unsupported chain: ${options.chain}`);
+  }
+
   const info: N1InfoResponse = await httpGet(`${N1_API}/info`);
   if (!Array.isArray(info.markets) || info.markets.length === 0) {
     throw new Error("N1 info endpoint returned no markets");
   }
 
-  let dailyVolume = 0;
-  let openInterestAtEnd = 0;
-
-  for (const market of info.markets) {
-    if (!market.symbol.endsWith("USD")) continue;
-
-    // Pace requests to stay within the public API's rate limits.
-    await sleep(200);
-    const stats: N1MarketStats = await httpGet(
-      `${N1_API}/market/${market.marketId}/stats`,
-    );
-
-    const volume = Number(stats.volumeQuote24h);
-    const indexPrice = Number(stats.indexPrice);
-    const openInterest = Number(stats.perpStats?.open_interest);
-    if (
-      !Number.isFinite(volume) ||
-      volume < 0 ||
-      !Number.isFinite(indexPrice) ||
-      indexPrice < 0 ||
-      !Number.isFinite(openInterest) ||
-      openInterest < 0
-    ) {
-      throw new Error(`N1 market ${market.marketId} returned invalid stats`);
-    }
-
-    dailyVolume += volume;
-    openInterestAtEnd += openInterest * indexPrice;
+  const usdMarkets = info.markets.filter((market) => market.symbol.endsWith("USD"));
+  if (usdMarkets.length === 0) {
+    throw new Error("N1 info endpoint returned no USD markets");
   }
+
+  const { results, errors } = await PromisePool
+    .withConcurrency(N1_API_CONCURRENCY)
+    .for(usdMarkets)
+    .process(async (market) => {
+      // N1's public API permits 50 requests per second. Five workers pausing
+      // 200 ms before each request keep this adapter below that limit.
+      await sleep(N1_API_REQUEST_DELAY_MS);
+      const stats: N1MarketStats = await httpGet(
+        `${N1_API}/market/${market.marketId}/stats`,
+      );
+
+      if (stats.indexPrice === null) {
+        throw new Error(`N1 market ${market.marketId} returned a null index price`);
+      }
+
+      const volume = Number(stats.volumeQuote24h);
+      const indexPrice = Number(stats.indexPrice);
+      const openInterest = Number(stats.perpStats?.open_interest);
+      if (
+        !Number.isFinite(volume) ||
+        volume < 0 ||
+        !Number.isFinite(indexPrice) ||
+        indexPrice < 0 ||
+        !Number.isFinite(openInterest) ||
+        openInterest < 0
+      ) {
+        throw new Error(`N1 market ${market.marketId} returned invalid stats`);
+      }
+
+      return {
+        volume,
+        openInterest: openInterest * indexPrice,
+      };
+    });
+
+  if (errors.length > 0) {
+    throw new Error(
+      `Failed to fetch ${errors.length} of ${usdMarkets.length} N1 markets: ${errors[0].message}`,
+    );
+  }
+
+  const dailyVolume = results.reduce((sum, result) => sum + result.volume, 0);
+  const openInterestAtEnd = results.reduce(
+    (sum, result) => sum + result.openInterest,
+    0,
+  );
 
   return { dailyVolume, openInterestAtEnd };
 }
 
 const adapter: SimpleAdapter = {
   version: 2,
-  // Proton exposes rolling 24-hour totals, so hourly slices cannot be summed.
+  fetch,
+  chains: [CHAIN.N1],
+  start: "2025-12-08",
+  runAtCurrTime: true,
+  // N1 exposes rolling 24-hour totals, so hourly slices cannot be summed.
   pullHourly: false,
-  adapter: {
-    [CHAIN.N1]: {
-      fetch,
-      runAtCurrTime: true,
-    },
-  },
   methodology: {
     Volume:
-      "Rolling 24-hour quote volume reported by Proton across all N1 Exchange USD perpetual markets.",
+      "Rolling 24-hour quote volume reported by N1 across all N1 Exchange USD perpetual markets.",
     OpenInterest:
       "Current notional open interest across all N1 Exchange USD perpetual markets, calculated as base open interest multiplied by index price.",
   },

--- a/dexs/n1-exchange/index.ts
+++ b/dexs/n1-exchange/index.ts
@@ -4,6 +4,7 @@ import { CHAIN } from "../../helpers/chains";
 import { httpGet } from "../../utils/fetchURL";
 import { sleep } from "../../utils/utils";
 
+// Canonical N1 public mainnet API endpoint.
 const N1_API = "https://api-mainnet.n1.xyz";
 const N1_API_CONCURRENCY = 5;
 const N1_API_REQUEST_DELAY_MS = 200;
@@ -18,10 +19,10 @@ interface N1InfoResponse {
 }
 
 interface N1MarketStats {
-  volumeQuote24h: number;
+  volumeQuote24h: number | null;
   indexPrice: number | null;
   perpStats: {
-    open_interest: number;
+    open_interest: number | null;
   } | null;
 }
 
@@ -51,8 +52,12 @@ async function fetch(options: FetchOptions): Promise<FetchResultVolume> {
         `${N1_API}/market/${market.marketId}/stats`,
       );
 
-      if (stats.indexPrice === null) {
-        throw new Error(`N1 market ${market.marketId} returned a null index price`);
+      if (
+        stats.volumeQuote24h === null ||
+        stats.indexPrice === null ||
+        stats.perpStats?.open_interest === null
+      ) {
+        throw new Error(`N1 market ${market.marketId} returned null stats`);
       }
 
       const volume = Number(stats.volumeQuote24h);


### PR DESCRIPTION
## Summary

Adds a derivatives adapter for N1 Exchange under `dexs/n1-exchange`.

The adapter reports rolling 24-hour perpetual volume and current open interest using N1's public mainnet API.

## Changes

- Fetches markets from `https://api-mainnet.n1.xyz/info`.
- Fetches rolling statistics from `/market/{marketId}/stats`.
- Aggregates statistics across all USD perpetual markets.
- Uses bounded concurrency below N1's 50 requests-per-second public API limit.
- Fails on missing markets, partial request failures, null prices, and invalid statistics.
- Uses `runAtCurrTime` because N1 reports rolling 24-hour statistics.
- Starts on `2025-12-08`, the first date available from N1 market history.

## Methodology

- `dailyVolume` is the sum of `volumeQuote24h` across all USD perpetual markets.
- `openInterestAtEnd` is the sum of `perpStats.open_interest * indexPrice` across all USD perpetual markets.

## Validation

```text
bun run test dexs n1-exchange

N1
Daily volume: 1.17 M
Open interest at end: 1.33 M
```

Additional checks:

```text
bun run ts-check
bun run ts-check-cli
git diff --check
```

## Project information

- Name: N1 Exchange
- Website: https://app.n1.xyz/
- X: https://x.com/N1Chain
- Chain: N1
- Category: Derivatives
- Description: High-performance perpetual futures exchange built on N1.
