### PR TITLE
feat: add Stratabook volume/fees adapter (Solana CLOB)

### DIFF
--- a/dexs/stratabook/index.ts
+++ b/dexs/stratabook/index.ts
@@ -120,7 +120,7 @@ const fetch = async (options: FetchOptions) => {
           s.outer_instruction_index,
           s.account_arguments,
           t.msg AS msg,
-          CAST(from_big_endian_64(reverse(SUBSTR(from_base64(SUBSTR(t.msg, 15)), 82, 8))) AS DECIMAL(38,0)) AS fill_size,
+          CAST(varbinary_to_uint256(reverse(SUBSTR(from_base64(SUBSTR(t.msg, 15)), 82, 8))) AS DECIMAL(38,0)) AS fill_size,
           SUM(CASE WHEN t.msg LIKE 'Program data: %' THEN 1 ELSE 0 END) OVER (
             PARTITION BY s.tx_id, s.outer_instruction_index, s.inner_instruction_index
             ORDER BY t.ord

--- a/dexs/stratabook/index.ts
+++ b/dexs/stratabook/index.ts
@@ -208,8 +208,7 @@ const fetch = async (options: FetchOptions) => {
 };
 
 const adapter: SimpleAdapter = {
-  version: 2,
-  pullHourly: true,
+  version: 1,
   chains: [CHAIN.SOLANA],
   start: "2026-08-09", // first on-chain activity on the CLOB program
   fetch,

--- a/dexs/stratabook/index.ts
+++ b/dexs/stratabook/index.ts
@@ -107,21 +107,27 @@ const fetch = async (options: FetchOptions) => {
   // onward and only decode lines with exactly one remaining (the last) —
   // nested programs' payloads have ≥1 later Program-data line and are
   // rejected instead of being miscounted as fills.
+  //
+  // Defensive decode: some 'Program data:' lines in Dune's log_messages are
+  // NOT valid base64 (a program can log arbitrary text with that prefix, and
+  // Dune can store control chars). Trino's from_base64 is strict and would
+  // fail the whole query, so we wrap it in try() (NULL on invalid input) and
+  // keep only rows whose payload actually decodes.
   const sql = `
     WITH fills AS (
       SELECT
         tx_id,
         outer_instruction_index,
         account_arguments,
-        fill_size
+        CAST(varbinary_to_uint256(reverse(SUBSTR(payload, 82, 8))) AS DECIMAL(38,0)) AS fill_size
       FROM (
         SELECT
           s.tx_id,
           s.outer_instruction_index,
           s.account_arguments,
           t.msg AS msg,
-          CAST(varbinary_to_uint256(reverse(SUBSTR(from_base64(SUBSTR(t.msg, 15)), 82, 8))) AS DECIMAL(38,0)) AS fill_size,
-          SUM(CASE WHEN t.msg LIKE 'Program data: %' THEN 1 ELSE 0 END) OVER (
+          try(from_base64(SUBSTR(t.msg, 15))) AS payload,
+          SUM(CASE WHEN try(from_base64(SUBSTR(t.msg, 15))) IS NOT NULL THEN 1 ELSE 0 END) OVER (
             PARTITION BY s.tx_id, s.outer_instruction_index, s.inner_instruction_index
             ORDER BY t.ord
             ROWS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING
@@ -132,9 +138,9 @@ const fetch = async (options: FetchOptions) => {
           AND s.tx_success = true
           AND TIME_RANGE
       )
-      WHERE msg LIKE 'Program data: %'
-        AND to_hex(SUBSTR(from_base64(SUBSTR(msg, 15)), 1, 1)) = '03'
-        AND LENGTH(from_base64(SUBSTR(msg, 15))) >= 100
+      WHERE payload IS NOT NULL
+        AND to_hex(SUBSTR(payload, 1, 1)) = '03'
+        AND LENGTH(payload) >= 100
         AND data_lines_from_here = 1
     ),
     with_fee AS (

--- a/dexs/stratabook/index.ts
+++ b/dexs/stratabook/index.ts
@@ -6,7 +6,7 @@
  *
  * Data source: Dune Analytics (no Solana RPC). All on-chain events are
  * indexed by Dune's `solana.instruction_calls` table, which carries the
- * raw per-tx log messages for every program invocation.
+ * raw per-instruction log messages for every program invocation.
  *
  * ── Protocol ───────────────────────────────────────────────────────
  *
@@ -21,7 +21,7 @@
  * Every match emits an `OrderFilled` event via `sol_log_data`:
  *
  *   Program data: <base64>   (100 bytes)
- *     [0]        tag          = 3 (EventTag::OrderFilled)  -> base64 prefix "Aw=="
+ *     [0]        tag          = 3 (EventTag::OrderFilled)
  *     [1..33]    maker_pda
  *     [33..65]   taker_pda
  *     [65..73]   maker_order_id   (u64 LE)
@@ -87,64 +87,91 @@ const fetch = async (options: FetchOptions) => {
   const dailyProtocolRevenue = options.createBalances();
   const dailySupplySideRevenue = options.createBalances();
 
-  // Fills: CLOB invocations whose log messages carry an OrderFilled event
-  // (tag 3 -> base64 payload starts "Aw=="). fill_size = u64 LE at byte 81
-  // (1-indexed SQL byte 82). Each log line = one fill event; volume is
-  // summed from events, so batch settles (2 fills/tx) count each once.
-  // Base mint per tx = the token transfer whose amount equals a fill_size
-  // (verified: the base-side transfer is 1:1 with the event's fill_size).
+  // Fills: CLOB invocations whose log messages carry an OrderFilled event.
+  // Tag 3 is checked as an exact decoded byte (to_hex of the first payload
+  // byte = '03') — a base64 prefix like "Aw==" is invalid for a 100-byte
+  // payload (padding only at the very end), so we decode and inspect bytes.
+  // fill_size = u64 LE at byte 81 (1-indexed SQL byte 82). Volume is summed
+  // from events, so batch settles (2 fills/tx) count each once.
+  // Base mint per fill = the token transfer whose amount equals that fill's
+  // fill_size, correlated by instruction identity (the transfer happens
+  // inside the CLOB settle instruction: transfer.outer_instruction_index ==
+  // instruction.instruction_index) — not a tx-level cross-product.
   // Market = the account-argument that is in our known market list, used
-  // to look up taker_fee_bps.
+  // to look up taker_fee_bps (resolved per fill in a CTE before grouping).
   const sql = `
     WITH fills AS (
       SELECT
         s.tx_id,
+        s.instruction_index,
         s.account_arguments,
-        CAST(from_big_endian_64(reverse(SUBSTR(from_base64(SUBSTR(t.msg, 15)), 82, 8))) AS DOUBLE) AS fill_size
+        CAST(from_big_endian_64(reverse(SUBSTR(from_base64(SUBSTR(t.msg, 15)), 82, 8))) AS DECIMAL(38,0)) AS fill_size
       FROM solana.instruction_calls s
       CROSS JOIN UNNEST(s.log_messages) AS t(msg)
       WHERE s.executing_account = '${CLOB_PROGRAM}'
         AND s.tx_success = true
         AND TIME_RANGE
-        AND t.msg LIKE 'Program data: Aw==%'
+        AND t.msg LIKE 'Program data: %'
+        AND to_hex(SUBSTR(from_base64(SUBSTR(t.msg, 15)), 1, 1)) = '03'
         AND LENGTH(from_base64(SUBSTR(t.msg, 15))) >= 100
     ),
-    mints AS (
-      SELECT DISTINCT f.tx_id, tr.mint AS base_mint
+    with_fee AS (
+      SELECT
+        f.tx_id,
+        f.instruction_index,
+        f.fill_size,
+        COALESCE(mk.fee_bps, 10) AS fee_bps
       FROM fills f
+      LEFT JOIN (VALUES
+        ${MARKET_FEE_VALUES}
+      ) AS mk(market, fee_bps)
+        ON contains(f.account_arguments, mk.market)
+    ),
+    -- One base mint per settle instruction: the transfer whose amount
+    -- equals a fill_size and whose outer_instruction_index is the CLOB
+    -- settle instruction. If a settle resolves to more than one mint the
+    -- fill-to-transfer match is ambiguous — exclude those fills entirely
+    -- rather than producing a tx-level cross-product (no 1:1 markets in
+    -- Stratabook today, but guard anyway).
+    settle_mints AS (
+      SELECT
+        wf.tx_id,
+        wf.instruction_index,
+        COUNT(DISTINCT tr.token_mint_address) AS mint_count,
+        MIN(tr.token_mint_address) AS base_mint
+      FROM with_fee wf
       JOIN tokens_solana.transfers tr
-        ON tr.tx_id = f.tx_id
-       AND CAST(tr.amount AS DOUBLE) = f.fill_size
+        ON tr.tx_id = wf.tx_id
+       AND tr.outer_instruction_index = wf.instruction_index
+       AND CAST(tr.amount AS DECIMAL(38,0)) = wf.fill_size
       WHERE TIME_RANGE
+      GROUP BY wf.tx_id, wf.instruction_index
     )
     SELECT
-      m.base_mint AS mint,
-      SUM(f.fill_size) AS volume,
-      SUM(f.fill_size) * COALESCE(
-        (
-          SELECT mk.fee_bps
-          FROM (VALUES
-            ${MARKET_FEE_VALUES}
-          ) AS mk(market, fee_bps)
-          WHERE ARRAY_CONTAINS(f.account_arguments, mk.market)
-          LIMIT 1
-        ), 10
-      ) / 10000.0 AS fees
-    FROM fills f
-    JOIN mints m ON f.tx_id = m.tx_id
-    GROUP BY m.base_mint
+      sm.base_mint AS mint,
+      CAST(SUM(wf.fill_size) AS DECIMAL(38,0)) AS volume,
+      -- DECIMAL arithmetic: floor-division fee per fill, identical to the
+      -- on-chain parser's (fill_size * fee_bps) / 10000n semantics.
+      CAST(SUM(wf.fill_size * wf.fee_bps / 10000) AS DECIMAL(38,0)) AS fees
+    FROM with_fee wf
+    JOIN settle_mints sm
+      ON wf.tx_id = sm.tx_id
+     AND wf.instruction_index = sm.instruction_index
+    WHERE sm.mint_count = 1
+    GROUP BY sm.base_mint
   `;
 
   const rows: any[] = await queryDuneSql(options, sql);
 
   for (const row of rows ?? []) {
     if (!row.mint || !row.volume) continue;
-    dailyVolume.add(row.mint, String(Math.round(row.volume)));
-    if (row.fees > 0) {
-      const fees = String(Math.round(row.fees));
-      dailyFees.add(row.mint, fees, "Swap Fees");
-      dailyRevenue.add(row.mint, fees, "Swap Fees To Protocol");
-      dailyProtocolRevenue.add(row.mint, fees, "Swap Fees To Protocol");
+    // Dune returns DECIMAL columns as strings; pass them straight through —
+    // no Number/Math.round, which would lose u64 precision above 2^53.
+    dailyVolume.add(row.mint, row.volume);
+    if (row.fees && parseFloat(row.fees) > 0) {
+      dailyFees.add(row.mint, row.fees, "Swap Fees");
+      dailyRevenue.add(row.mint, row.fees, "Swap Fees To Protocol");
+      dailyProtocolRevenue.add(row.mint, row.fees, "Swap Fees To Protocol");
     }
   }
 

--- a/dexs/stratabook/index.ts
+++ b/dexs/stratabook/index.ts
@@ -270,9 +270,9 @@ const fetch = async (options: FetchOptions) => {
           // The protocol retains the full taker fee (supply-side = 0),
           // so it counts as both revenue and protocol revenue.
           const takerFee = (fillSize * BigInt(market.takerFeeBps)) / 10000n;
-          dailyFees.add(market.baseMint, takerFee.toString());
-          dailyRevenue.add(market.baseMint, takerFee.toString());
-          dailyProtocolRevenue.add(market.baseMint, takerFee.toString());
+          dailyFees.add(market.baseMint, takerFee.toString(), "Swap Fees");
+          dailyRevenue.add(market.baseMint, takerFee.toString(), "Swap Fees To Protocol");
+          dailyProtocolRevenue.add(market.baseMint, takerFee.toString(), "Swap Fees To Protocol");
         }
       }
       processed += signatures.length;
@@ -312,13 +312,13 @@ const adapter: SimpleAdapter = {
   },
   breakdownMethodology: {
     Fees: {
-      "swap fees": "taker_fee_bps on all fills",
+      "Swap Fees": "taker_fee_bps on all fills",
     },
     Revenue: {
-      "swap fees": "taker_fee_bps on all fills",
+      "Swap Fees To Protocol": "taker_fee_bps on all fills",
     },
     ProtocolRevenue: {
-      "swap fees": "taker_fee_bps on all fills",
+      "Swap Fees To Protocol": "taker_fee_bps on all fills",
     },
   },
 };

--- a/dexs/stratabook/index.ts
+++ b/dexs/stratabook/index.ts
@@ -30,7 +30,7 @@
  * Volume = Σ fill_size (base side, USD-priced by DefiLlama).
  * The market PDA for a fill is recovered from the tx's account list
  * (settle txs pass exactly one Market account; layout verified
- * 2026-08-12 against live mainnet accounts).
+ * against live mainnet accounts).
  *
  * ── Fees / Revenue methodology ─────────────────────────────────────
  *
@@ -169,13 +169,12 @@ async function fetchTxs(signatures: string[]): Promise<any[]> {
     // sequential fallback
     const out: any[] = [];
     for (const signature of signatures) {
-      try {
-        out.push(await withRetry((url) => rpc(url, "getTransaction", [
-          signature, { maxSupportedTransactionVersion: 0, encoding: "json" },
-        ])));
-      } catch {
-        out.push(null); // not found / expired — skip
-      }
+      // RPC returning null = tx expired from node storage (legit skip).
+      // Persistent RPC errors must propagate — silently dropping txs
+      // would understate volume.
+      out.push(await withRetry((url) => rpc(url, "getTransaction", [
+        signature, { maxSupportedTransactionVersion: 0, encoding: "json" },
+      ])));
       await sleep(120);
     }
     return out;
@@ -190,7 +189,7 @@ const fetch = async (options: FetchOptions) => {
   const dailySupplySideRevenue = createBalances();
 
   const markets = await getMarkets();
-  if (markets.size === 0) return { dailyVolume, dailyFees, dailyRevenue, dailySupplySideRevenue };
+  if (markets.size === 0) throw new Error("Stratabook: no market accounts found — cannot compute volume (data source unavailable)");
 
   const start = options.startTimestamp;
   const end = options.endTimestamp;
@@ -198,13 +197,14 @@ const fetch = async (options: FetchOptions) => {
   let before: string | undefined;
   let processed = 0;
   let done = false;
+  let historyExhausted = false;
 
   while (!done && processed < MAX_SIGS_PER_RUN) {
     const sigs = (await withRetry((url) => rpc(url, "getSignaturesForAddress", [
       CLOB_PROGRAM,
       { limit: 100, ...(before ? { before } : {}) },
     ]))) ?? [];
-    if (sigs.length === 0) break;
+    if (sigs.length === 0) { historyExhausted = true; break; }
 
     // collect the chunk of sigs that are still within the window
     const inWindow: { signature: string }[] = [];
@@ -218,7 +218,7 @@ const fetch = async (options: FetchOptions) => {
     const signatures = inWindow.map((s) => s.signature);
     const txs = await fetchTxs(signatures);
     for (const tx of txs) {
-        if (!tx?.meta || tx.blockTime == null) continue;
+        if (!tx?.meta || tx.meta.err || tx.blockTime == null) continue;
         if (tx.blockTime < start) { done = true; continue; }
         if (tx.blockTime >= end) continue;
 
@@ -238,7 +238,14 @@ const fetch = async (options: FetchOptions) => {
         if (txMarkets.length === 0) continue;
         const market = txMarkets[0]; // settle txs carry exactly one Market account
 
+        // Only decode "Program data:" payloads emitted while the CLOB
+        // program itself is the active invocation — a non-Stratabook
+        // program's event in the same tx must not be counted.
+        let inClobInvoke = false;
         for (const log of tx.meta.logMessages ?? []) {
+          if (log.startsWith(`Program ${CLOB_PROGRAM} invoke`)) { inClobInvoke = true; continue; }
+          if (log.startsWith(`Program ${CLOB_PROGRAM} success`) || log.startsWith(`Program ${CLOB_PROGRAM} failed`)) { inClobInvoke = false; continue; }
+          if (!inClobInvoke) continue;
           if (!log.startsWith("Program data: ")) continue;
           const buf = Buffer.from(log.slice("Program data: ".length), "base64");
           if (buf.length < 100 || buf[0] !== EVENT_ORDER_FILLED) continue;
@@ -258,21 +265,26 @@ const fetch = async (options: FetchOptions) => {
       processed += signatures.length;
       await sleep(150); // be gentle with public RPCs
 
-      if (sigs.length < 100) break;
+      if (sigs.length < 100) { historyExhausted = true; break; }
       before = sigs[sigs.length - 1].signature;
     }
+
+  // Never publish balances from a partial scan: if we hit the signature
+  // cap before exhausting the historical window, the result would
+  // understate volume. No data is better than wrong data.
+  if (!done && !historyExhausted && processed >= MAX_SIGS_PER_RUN) {
+    throw new Error(`Stratabook: signature cap (${MAX_SIGS_PER_RUN}) hit before reaching window start — refusing partial data`);
+  }
 
   return { dailyVolume, dailyFees, dailyRevenue, dailySupplySideRevenue };
 };
 
 const adapter: SimpleAdapter = {
   version: 2,
-  adapter: {
-    [CHAIN.SOLANA]: {
-      fetch,
-      start: "2026-08-09", // first on-chain activity on the CLOB program
-    },
-  },
+  pullHourly: true,
+  chains: [CHAIN.SOLANA],
+  start: "2026-08-09", // first on-chain activity on the CLOB program
+  fetch,
   methodology: {
     Volume:
       "Trading volume from on-chain OrderFilled events on the Stratabook CLOB program, " +

--- a/dexs/stratabook/index.ts
+++ b/dexs/stratabook/index.ts
@@ -99,21 +99,43 @@ const fetch = async (options: FetchOptions) => {
   // instruction.outer_instruction_index) — not a tx-level cross-product.
   // Market = the account-argument that is in our known market list, used
   // to look up taker_fee_bps (resolved per fill in a CTE before grouping).
+  // Emitter binding: a CLOB instruction can CPI-invoke nested programs, and
+  // their log lines land in the same instruction's log_messages. The CLOB's
+  // own OrderFilled fires AFTER all nested invocations complete (verified on
+  // live mainnet fills), so it is always the LAST 'Program data:' line in
+  // the instruction's log slice. We count Program-data lines from each line
+  // onward and only decode lines with exactly one remaining (the last) —
+  // nested programs' payloads have ≥1 later Program-data line and are
+  // rejected instead of being miscounted as fills.
   const sql = `
     WITH fills AS (
       SELECT
-        s.tx_id,
-        s.outer_instruction_index,
-        s.account_arguments,
-        CAST(from_big_endian_64(reverse(SUBSTR(from_base64(SUBSTR(t.msg, 15)), 82, 8))) AS DECIMAL(38,0)) AS fill_size
-      FROM solana.instruction_calls s
-      CROSS JOIN UNNEST(s.log_messages) AS t(msg)
-      WHERE s.executing_account = '${CLOB_PROGRAM}'
-        AND s.tx_success = true
-        AND TIME_RANGE
-        AND t.msg LIKE 'Program data: %'
-        AND to_hex(SUBSTR(from_base64(SUBSTR(t.msg, 15)), 1, 1)) = '03'
-        AND LENGTH(from_base64(SUBSTR(t.msg, 15))) >= 100
+        tx_id,
+        outer_instruction_index,
+        account_arguments,
+        fill_size
+      FROM (
+        SELECT
+          s.tx_id,
+          s.outer_instruction_index,
+          s.account_arguments,
+          t.msg AS msg,
+          CAST(from_big_endian_64(reverse(SUBSTR(from_base64(SUBSTR(t.msg, 15)), 82, 8))) AS DECIMAL(38,0)) AS fill_size,
+          SUM(CASE WHEN t.msg LIKE 'Program data: %' THEN 1 ELSE 0 END) OVER (
+            PARTITION BY s.tx_id, s.outer_instruction_index, s.inner_instruction_index
+            ORDER BY t.ord
+            ROWS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING
+          ) AS data_lines_from_here
+        FROM solana.instruction_calls s
+        CROSS JOIN UNNEST(s.log_messages) WITH ORDINALITY AS t(msg, ord)
+        WHERE s.executing_account = '${CLOB_PROGRAM}'
+          AND s.tx_success = true
+          AND TIME_RANGE
+      )
+      WHERE msg LIKE 'Program data: %'
+        AND to_hex(SUBSTR(from_base64(SUBSTR(msg, 15)), 1, 1)) = '03'
+        AND LENGTH(from_base64(SUBSTR(msg, 15))) >= 100
+        AND data_lines_from_here = 1
     ),
     with_fee AS (
       SELECT

--- a/dexs/stratabook/index.ts
+++ b/dexs/stratabook/index.ts
@@ -4,6 +4,10 @@
  * PR target: https://github.com/DefiLlama/dimension-adapters
  * Final path: `dexs/stratabook/index.ts`
  *
+ * Data source: Dune Analytics (no Solana RPC). All on-chain events are
+ * indexed by Dune's `solana.instruction_calls` table, which carries the
+ * raw per-tx log messages for every program invocation.
+ *
  * ── Protocol ───────────────────────────────────────────────────────
  *
  * Stratabook is a fully on-chain CLOB on Solana with three execution
@@ -17,7 +21,7 @@
  * Every match emits an `OrderFilled` event via `sol_log_data`:
  *
  *   Program data: <base64>   (100 bytes)
- *     [0]        tag          = 3 (EventTag::OrderFilled)
+ *     [0]        tag          = 3 (EventTag::OrderFilled)  -> base64 prefix "Aw=="
  *     [1..33]    maker_pda
  *     [33..65]   taker_pda
  *     [65..73]   maker_order_id   (u64 LE)
@@ -27,266 +31,121 @@
  *     [97]       source           (0=L1, 1=L2, 2=L3-AVL, 3=MEV, 4=L3-AVL-wrapped)
  *     [98..99]   maker_filled / taker_filled flags
  *
- * Volume = Σ fill_size (base side, USD-priced by DefiLlama).
- * The market PDA for a fill is recovered from the tx's account list
- * (settle txs pass exactly one Market account; layout verified
- * against live mainnet accounts).
+ * Volume = Σ fill_size (base side), minted to the base token via
+ * `tokens_solana.transfers` (the base-side transfer amount equals
+ * fill_size exactly — verified against live mainnet fills).
  *
  * ── Fees / Revenue methodology ─────────────────────────────────────
  *
  *   taker fee  = fill_size × Market.taker_fee_bps   (all sources)
  *   maker rebate = 0 (ships 0, never wired — no rebate paid today)
  *
+ * The taker fee accrues inside the CLOB's escrow accounting (not as a
+ * separate token transfer — maker/taker transfers are exactly equal and
+ * opposite), so it is computed from fill_size × the market's configured
+ * rate. Market fee config lives in market account data, which Dune does
+ * not index for this program; the per-market taker_fee_bps map below was
+ * read from live mainnet market accounts on 2026-08-12 (9 markets) and
+ * must be extended when new markets launch.
+ *
  *   dailyFees    = taker fee (what users pay)
  *   dailyRevenue = dailyFees (taker fee kept in full; maker rebate 0)
+ *   dailyProtocolRevenue = dailyFees (supply-side revenue is 0)
  *   dailySupplySideRevenue = 0 (no LP incentives paid)
- *
- * Market account layout (program-rust/src/state/market.rs, byte offsets
- * verified against live mainnet accounts):
- *   [8..40]  base_mint, [40..72] quote_mint, [72..104] base_vault,
- *   [104..136] quote_vault, [160..162] taker_fee_bps (u16 LE),
- *   [162..164] maker_rebate_bps (u16 LE, 0), [164..166] swap_fee_bps (u16 LE),
- *   [300] base_decimals, [301] quote_decimals
  */
 
-import { FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { Dependencies, FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
-import axios from "axios";
-import { getEnv } from "../../helpers/env";
+import { queryDuneSql } from "../../helpers/dune";
 
 const CLOB_PROGRAM = "strataZWURmW6bzMWpkLCAFxNFrQXCNSE9cSmBmdPgP";
-const MARKET_DATA_SIZES = [384, 416]; // Market V2, V3 account sizes
 
-// Market account field offsets (see header)
-const MKT_BASE_MINT = 8;
-const MKT_QUOTE_MINT = 40;
-const MKT_TAKER_FEE_BPS = 160;
-const MKT_SWAP_FEE_BPS = 164;
-
-const EVENT_ORDER_FILLED = 3;
-const FILL_SIZE_OFF = 81;
-const SETTLE_PRICE_OFF = 89;
-const SOURCE_OFF = 97;
-
-const BATCH = 40; // txs per batch RPC call
-const MAX_SIGS_PER_RUN = 2000; // safety cap
-const FALLBACK_RPCS = [
-  "https://api.mainnet-beta.solana.com",
-  "https://solana-rpc.publicnode.com",
-];
-
-// ── tiny base58 (no external dep) ──────────────────────────────────
-const B58_ALPHABET = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
-function base58Encode(bytes: Uint8Array): string {
-  let x = BigInt("0x" + Buffer.from(bytes).toString("hex"));
-  let out = "";
-  while (x > 0n) {
-    out = B58_ALPHABET[Number(x % 58n)] + out;
-    x /= 58n;
-  }
-  for (const b of bytes) if (b === 0) out = "1" + out; else break;
-  return out;
-}
-
-async function rpc(url: string, method: string, params: unknown[]): Promise<any> {
-  const { data } = await axios.post(url, { jsonrpc: "2.0", id: 1, method, params }, { timeout: 60000 });
-  if (data.error) throw new Error(`RPC ${method}: ${JSON.stringify(data.error)}`);
-  return data.result;
-}
-
-async function rpcBatch(url: string, requests: { method: string; params: unknown[] }[]): Promise<any[]> {
-  const body = requests.map((r, i) => ({ jsonrpc: "2.0", id: i, method: r.method, params: r.params }));
-  const { data } = await axios.post(url, body, { timeout: 90000 });
-  const byId = new Map<number, any>(data.map((d: any) => [d.id, d]));
-  return requests.map((_, i) => {
-    const item = byId.get(i);
-    if (item?.error) throw new Error(`RPC batch item error: ${JSON.stringify(item.error)}`);
-    return item?.result;
-  });
-}
-
-interface MarketInfo {
-  baseMint: string;
-  quoteMint: string;
-  takerFeeBps: number;
-  swapFeeBps: number;
-}
-
-async function getMarkets(): Promise<Map<string, MarketInfo>> {
-  const markets = new Map<string, MarketInfo>();
-  for (const size of MARKET_DATA_SIZES) {
-    const accounts = await withRetry((url) => rpc(url, "getProgramAccounts", [CLOB_PROGRAM, { encoding: "base64", filters: [{ dataSize: size }] }]));
-    for (const acc of accounts ?? []) {
-      const buf = Buffer.from(acc.account.data[0], "base64");
-      if (buf.length < 384) continue;
-      markets.set(acc.pubkey, {
-        baseMint: base58Encode(buf.subarray(MKT_BASE_MINT, MKT_BASE_MINT + 32)),
-        quoteMint: base58Encode(buf.subarray(MKT_QUOTE_MINT, MKT_QUOTE_MINT + 32)),
-        takerFeeBps: buf.readUInt16LE(MKT_TAKER_FEE_BPS),
-        swapFeeBps: buf.readUInt16LE(MKT_SWAP_FEE_BPS),
-      });
-    }
-  }
-  return markets;
-}
-
-interface Fill {
-  fillSize: bigint;
-  source: number;
-}
-
-const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
-
-async function withRetry<T>(fn: (url: string) => Promise<T>, tries = 4): Promise<T> {
-  const primary = getEnv("SOLANA_RPC");
-  const urls = [primary, ...FALLBACK_RPCS.filter((u) => u !== primary)];
-  let lastErr: any;
-  for (let i = 0; i < tries; i++) {
-    try {
-      return await fn(urls[i % urls.length]);
-    } catch (e: any) {
-      lastErr = e;
-      const status = e?.response?.status;
-      const retryable = status === 429 || status >= 500 || !status || e?.code === "ECONNABORTED";
-      if (i === tries - 1 || !retryable) throw e;
-      await sleep(600 * (i + 1));
-    }
-  }
-  throw lastErr;
-}
-
-// Fetch tx JSON for a list of signatures. Tries one batch against the
-// configured RPC (DefiLlama infra supports batches); if that fails,
-// falls back to sequential single-tx fetches with endpoint rotation
-// (public RPCs commonly cap getTransaction batches at 1).
-async function fetchTxs(signatures: string[]): Promise<any[]> {
-  try {
-    return await rpcBatch(getEnv("SOLANA_RPC"), signatures.map((signature) => ({
-      method: "getTransaction",
-      params: [signature, { maxSupportedTransactionVersion: 0, encoding: "json" }],
-    })));
-  } catch {
-    // sequential fallback
-    const out: any[] = [];
-    for (const signature of signatures) {
-      // RPC returning null = tx expired from node storage (legit skip).
-      // Persistent RPC errors must propagate — silently dropping txs
-      // would understate volume.
-      out.push(await withRetry((url) => rpc(url, "getTransaction", [
-        signature, { maxSupportedTransactionVersion: 0, encoding: "json" },
-      ])));
-      await sleep(120);
-    }
-    return out;
-  }
-}
+// taker_fee_bps per market, read from live mainnet market accounts
+// (dataSize=416, taker_fee_bps at offset 160) on 2026-08-12. Verified
+// values are 5 or 10 bps across all 9 markets. Update when new markets
+// launch (e.g. `gh api ...` GPA probe of the CLOB program).
+const MARKET_TAKER_FEE_BPS: Record<string, number> = {
+  "6cDuRk75Yd1247XCBCG8TCVksyyf43bUWdK7Vn7AhHhn": 5,
+  "CmcjkZNVQHWw32tZGWo3sXSPVj6XyLdYQeHW1KKVFKTq": 10,
+  "Dth4Lvf227CVy1TwUHsagZ3RSH2Qdua8c9xSQVk6vASu": 5,
+  "EDXXti2SQqadtpBqeur1o1cakgmVeF21ePgSPCzC5udK": 10,
+  "EqiJfyKDH1Z4kfCph8eFjYig6UXNgW6ypAAcUx4L1zX4": 10,
+  "FLDpuWMW31G1jBdVhGVyoZnpvBSwJKeSdp5iYmZW9m1F": 10,
+  "FyVFPaqq2ZM1ctKwd5AdpzQmK9GqwfooRfGLzKN61Uvh": 10,
+  "G3uTbTDGFQrNwdvDNSCu2rQbSx4Ujfm75vgUdENR8h4J": 10,
+  "GheWH6HirA15RX4hLTTbDEy3vZWHVAcVvUcPRtAwXng7": 10,
+};
+// SQL VALUES list generated from the map above — single source of truth.
+const MARKET_FEE_VALUES = Object.entries(MARKET_TAKER_FEE_BPS)
+  .map(([m, bps]) => `('${m}', ${bps})`)
+  .join(",\n            ");
 
 const fetch = async (options: FetchOptions) => {
-  const { createBalances } = options;
-  const dailyVolume = createBalances();
-  const dailyFees = createBalances();
-  const dailyRevenue = createBalances();
-  const dailyProtocolRevenue = createBalances();
-  const dailySupplySideRevenue = createBalances();
+  const dailyVolume = options.createBalances();
+  const dailyFees = options.createBalances();
+  const dailyRevenue = options.createBalances();
+  const dailyProtocolRevenue = options.createBalances();
+  const dailySupplySideRevenue = options.createBalances();
 
-  const markets = await getMarkets();
-  if (markets.size === 0) throw new Error("Stratabook: no market accounts found — cannot compute volume (data source unavailable)");
+  // Fills: CLOB invocations whose log messages carry an OrderFilled event
+  // (tag 3 -> base64 payload starts "Aw=="). fill_size = u64 LE at byte 81
+  // (1-indexed SQL byte 82). Each log line = one fill event; volume is
+  // summed from events, so batch settles (2 fills/tx) count each once.
+  // Base mint per tx = the token transfer whose amount equals a fill_size
+  // (verified: the base-side transfer is 1:1 with the event's fill_size).
+  // Market = the account-argument that is in our known market list, used
+  // to look up taker_fee_bps.
+  const sql = `
+    WITH fills AS (
+      SELECT
+        s.tx_id,
+        s.account_arguments,
+        CAST(from_big_endian_64(reverse(SUBSTR(from_base64(SUBSTR(t.msg, 15)), 82, 8))) AS DOUBLE) AS fill_size
+      FROM solana.instruction_calls s
+      CROSS JOIN UNNEST(s.log_messages) AS t(msg)
+      WHERE s.executing_account = '${CLOB_PROGRAM}'
+        AND s.tx_success = true
+        AND TIME_RANGE
+        AND t.msg LIKE 'Program data: Aw==%'
+        AND LENGTH(from_base64(SUBSTR(t.msg, 15))) >= 100
+    ),
+    mints AS (
+      SELECT DISTINCT f.tx_id, tr.mint AS base_mint
+      FROM fills f
+      JOIN tokens_solana.transfers tr
+        ON tr.tx_id = f.tx_id
+       AND CAST(tr.amount AS DOUBLE) = f.fill_size
+      WHERE TIME_RANGE
+    )
+    SELECT
+      m.base_mint AS mint,
+      SUM(f.fill_size) AS volume,
+      SUM(f.fill_size) * COALESCE(
+        (
+          SELECT mk.fee_bps
+          FROM (VALUES
+            ${MARKET_FEE_VALUES}
+          ) AS mk(market, fee_bps)
+          WHERE ARRAY_CONTAINS(f.account_arguments, mk.market)
+          LIMIT 1
+        ), 10
+      ) / 10000.0 AS fees
+    FROM fills f
+    JOIN mints m ON f.tx_id = m.tx_id
+    GROUP BY m.base_mint
+  `;
 
-  const start = options.startTimestamp;
-  const end = options.endTimestamp;
+  const rows: any[] = await queryDuneSql(options, sql);
 
-  let before: string | undefined;
-  let processed = 0;
-  let done = false;
-  let historyExhausted = false;
-
-  while (!done && processed < MAX_SIGS_PER_RUN) {
-    const sigs = (await withRetry((url) => rpc(url, "getSignaturesForAddress", [
-      CLOB_PROGRAM,
-      { limit: 100, ...(before ? { before } : {}) },
-    ]))) ?? [];
-    if (sigs.length === 0) { historyExhausted = true; break; }
-
-    // collect the chunk of sigs that are still within the window
-    const inWindow: { signature: string }[] = [];
-    for (const s of sigs) {
-      if (s.blockTime != null && s.blockTime < start) { done = true; break; }
-      inWindow.push(s);
+  for (const row of rows ?? []) {
+    if (!row.mint || !row.volume) continue;
+    dailyVolume.add(row.mint, String(Math.round(row.volume)));
+    if (row.fees > 0) {
+      const fees = String(Math.round(row.fees));
+      dailyFees.add(row.mint, fees, "Swap Fees");
+      dailyRevenue.add(row.mint, fees, "Swap Fees To Protocol");
+      dailyProtocolRevenue.add(row.mint, fees, "Swap Fees To Protocol");
     }
-    if (inWindow.length === 0) break;
-
-    // fetch txs in batches (self-adapting to RPC batch limits)
-    const signatures = inWindow.map((s) => s.signature);
-    const txs = await fetchTxs(signatures);
-    for (const tx of txs) {
-        if (!tx?.meta || tx.meta.err || tx.blockTime == null) continue;
-        if (tx.blockTime < start) { done = true; continue; }
-        if (tx.blockTime >= end) continue;
-
-        const accountKeys: string[] = [];
-        if (tx.transaction?.message?.accountKeys) {
-          for (const k of tx.transaction.message.accountKeys) {
-            accountKeys.push(typeof k === "string" ? k : k.pubkey);
-          }
-        }
-        // v0 txs: CPI-loaded addresses live in meta.loadedAddresses
-        const loaded = tx.meta?.loadedAddresses;
-        if (loaded) {
-          accountKeys.push(...(loaded.writable ?? []), ...(loaded.readonly ?? []));
-        }
-        // market(s) touched by this tx
-        const txMarkets = [...accountKeys].map((k) => markets.get(k)).filter((m): m is MarketInfo => !!m);
-        if (txMarkets.length === 0) continue;
-        const market = txMarkets[0]; // settle txs carry exactly one Market account
-
-        // Only decode "Program data:" payloads while the CLOB program is
-        // the top of the invocation stack. CLOB CPI-invokes nested programs
-        // (liquidity/pricing, token programs) mid-invocation; their events
-        // must not be counted, and CLOB's own OrderFilled event fires after
-        // those nested invocations complete.
-        const invocationStack: string[] = [];
-        for (const log of tx.meta.logMessages ?? []) {
-          const invoke = /^Program (\S+) invoke \[\d+\]$/.exec(log);
-          if (invoke) {
-            invocationStack.push(invoke[1]);
-            continue;
-          }
-          if (/^Program \S+ (success|failed:)/.test(log)) {
-            invocationStack.pop();
-            continue;
-          }
-          if (invocationStack.at(-1) !== CLOB_PROGRAM) continue;
-          if (!log.startsWith("Program data: ")) continue;
-          const buf = Buffer.from(log.slice("Program data: ".length), "base64");
-          if (buf.length < 100 || buf[0] !== EVENT_ORDER_FILLED) continue;
-
-          const fillSize = buf.readBigUInt64LE(FILL_SIZE_OFF);
-          if (fillSize === 0n) continue;
-          const source = buf[SOURCE_OFF];
-
-          dailyVolume.add(market.baseMint, fillSize.toString());
-
-          // fees: taker fee on every fill (maker rebate ships 0).
-          // The protocol retains the full taker fee (supply-side = 0),
-          // so it counts as both revenue and protocol revenue.
-          const takerFee = (fillSize * BigInt(market.takerFeeBps)) / 10000n;
-          dailyFees.add(market.baseMint, takerFee.toString(), "Swap Fees");
-          dailyRevenue.add(market.baseMint, takerFee.toString(), "Swap Fees To Protocol");
-          dailyProtocolRevenue.add(market.baseMint, takerFee.toString(), "Swap Fees To Protocol");
-        }
-      }
-      processed += signatures.length;
-      await sleep(150); // be gentle with public RPCs
-
-      if (sigs.length < 100) { historyExhausted = true; break; }
-      before = sigs[sigs.length - 1].signature;
-    }
-
-  // Never publish balances from a partial scan: if we hit the signature
-  // cap before exhausting the historical window, the result would
-  // understate volume. No data is better than wrong data.
-  if (!done && !historyExhausted && processed >= MAX_SIGS_PER_RUN) {
-    throw new Error(`Stratabook: signature cap (${MAX_SIGS_PER_RUN}) hit before reaching window start — refusing partial data`);
   }
 
   return { dailyVolume, dailyFees, dailyRevenue, dailyProtocolRevenue, dailySupplySideRevenue };
@@ -298,12 +157,15 @@ const adapter: SimpleAdapter = {
   chains: [CHAIN.SOLANA],
   start: "2026-08-09", // first on-chain activity on the CLOB program
   fetch,
+  dependencies: [Dependencies.DUNE],
+  isExpensiveAdapter: true,
   methodology: {
     Volume:
       "Trading volume from on-chain OrderFilled events on the Stratabook CLOB program, " +
-      "covering L1 orderbook, L2 RFQ, and L3 Sonar/AVL routed fills. Sum of base-side fill sizes, USD-priced by DefiLlama.",
+      "covering L1 orderbook, L2 RFQ, and L3 Sonar/AVL routed fills. Sum of base-side fill sizes, " +
+      "USD-priced by DefiLlama. Sourced from Dune's solana.instruction_calls.",
     Fees:
-      "Taker fee (Market.taker_fee_bps) on all fills. Maker rebate ships 0 and is not paid.",
+      "Taker fee (Market.taker_fee_bps, 5 or 10 bps) on all fills. Maker rebate ships 0 and is not paid.",
     Revenue:
       "Taker fee kept in full (maker rebate ships 0 and is not paid).",
     ProtocolRevenue:

--- a/dexs/stratabook/index.ts
+++ b/dexs/stratabook/index.ts
@@ -96,14 +96,14 @@ const fetch = async (options: FetchOptions) => {
   // Base mint per fill = the token transfer whose amount equals that fill's
   // fill_size, correlated by instruction identity (the transfer happens
   // inside the CLOB settle instruction: transfer.outer_instruction_index ==
-  // instruction.instruction_index) — not a tx-level cross-product.
+  // instruction.outer_instruction_index) — not a tx-level cross-product.
   // Market = the account-argument that is in our known market list, used
   // to look up taker_fee_bps (resolved per fill in a CTE before grouping).
   const sql = `
     WITH fills AS (
       SELECT
         s.tx_id,
-        s.instruction_index,
+        s.outer_instruction_index,
         s.account_arguments,
         CAST(from_big_endian_64(reverse(SUBSTR(from_base64(SUBSTR(t.msg, 15)), 82, 8))) AS DECIMAL(38,0)) AS fill_size
       FROM solana.instruction_calls s
@@ -118,7 +118,7 @@ const fetch = async (options: FetchOptions) => {
     with_fee AS (
       SELECT
         f.tx_id,
-        f.instruction_index,
+        f.outer_instruction_index,
         f.fill_size,
         COALESCE(mk.fee_bps, 10) AS fee_bps
       FROM fills f
@@ -136,16 +136,17 @@ const fetch = async (options: FetchOptions) => {
     settle_mints AS (
       SELECT
         wf.tx_id,
-        wf.instruction_index,
+        wf.outer_instruction_index,
         COUNT(DISTINCT tr.token_mint_address) AS mint_count,
         MIN(tr.token_mint_address) AS base_mint
       FROM with_fee wf
       JOIN tokens_solana.transfers tr
         ON tr.tx_id = wf.tx_id
-       AND tr.outer_instruction_index = wf.instruction_index
+       AND tr.outer_instruction_index = wf.outer_instruction_index
        AND CAST(tr.amount AS DECIMAL(38,0)) = wf.fill_size
-      WHERE TIME_RANGE
-      GROUP BY wf.tx_id, wf.instruction_index
+      WHERE tr.block_time >= from_unixtime(${options.startTimestamp})
+        AND tr.block_time < from_unixtime(${options.endTimestamp})
+      GROUP BY wf.tx_id, wf.outer_instruction_index
     )
     SELECT
       sm.base_mint AS mint,
@@ -156,7 +157,7 @@ const fetch = async (options: FetchOptions) => {
     FROM with_fee wf
     JOIN settle_mints sm
       ON wf.tx_id = sm.tx_id
-     AND wf.instruction_index = sm.instruction_index
+     AND wf.outer_instruction_index = sm.outer_instruction_index
     WHERE sm.mint_count = 1
     GROUP BY sm.base_mint
   `;

--- a/dexs/stratabook/index.ts
+++ b/dexs/stratabook/index.ts
@@ -186,6 +186,7 @@ const fetch = async (options: FetchOptions) => {
   const dailyVolume = createBalances();
   const dailyFees = createBalances();
   const dailyRevenue = createBalances();
+  const dailyProtocolRevenue = createBalances();
   const dailySupplySideRevenue = createBalances();
 
   const markets = await getMarkets();
@@ -238,14 +239,23 @@ const fetch = async (options: FetchOptions) => {
         if (txMarkets.length === 0) continue;
         const market = txMarkets[0]; // settle txs carry exactly one Market account
 
-        // Only decode "Program data:" payloads emitted while the CLOB
-        // program itself is the active invocation — a non-Stratabook
-        // program's event in the same tx must not be counted.
-        let inClobInvoke = false;
+        // Only decode "Program data:" payloads while the CLOB program is
+        // the top of the invocation stack. CLOB CPI-invokes nested programs
+        // (liquidity/pricing, token programs) mid-invocation; their events
+        // must not be counted, and CLOB's own OrderFilled event fires after
+        // those nested invocations complete.
+        const invocationStack: string[] = [];
         for (const log of tx.meta.logMessages ?? []) {
-          if (log.startsWith(`Program ${CLOB_PROGRAM} invoke`)) { inClobInvoke = true; continue; }
-          if (log.startsWith(`Program ${CLOB_PROGRAM} success`) || log.startsWith(`Program ${CLOB_PROGRAM} failed`)) { inClobInvoke = false; continue; }
-          if (!inClobInvoke) continue;
+          const invoke = /^Program (\S+) invoke \[\d+\]$/.exec(log);
+          if (invoke) {
+            invocationStack.push(invoke[1]);
+            continue;
+          }
+          if (/^Program \S+ (success|failed:)/.test(log)) {
+            invocationStack.pop();
+            continue;
+          }
+          if (invocationStack.at(-1) !== CLOB_PROGRAM) continue;
           if (!log.startsWith("Program data: ")) continue;
           const buf = Buffer.from(log.slice("Program data: ".length), "base64");
           if (buf.length < 100 || buf[0] !== EVENT_ORDER_FILLED) continue;
@@ -256,10 +266,13 @@ const fetch = async (options: FetchOptions) => {
 
           dailyVolume.add(market.baseMint, fillSize.toString());
 
-          // fees: taker fee on every fill (maker rebate ships 0)
+          // fees: taker fee on every fill (maker rebate ships 0).
+          // The protocol retains the full taker fee (supply-side = 0),
+          // so it counts as both revenue and protocol revenue.
           const takerFee = (fillSize * BigInt(market.takerFeeBps)) / 10000n;
           dailyFees.add(market.baseMint, takerFee.toString());
           dailyRevenue.add(market.baseMint, takerFee.toString());
+          dailyProtocolRevenue.add(market.baseMint, takerFee.toString());
         }
       }
       processed += signatures.length;
@@ -276,7 +289,7 @@ const fetch = async (options: FetchOptions) => {
     throw new Error(`Stratabook: signature cap (${MAX_SIGS_PER_RUN}) hit before reaching window start — refusing partial data`);
   }
 
-  return { dailyVolume, dailyFees, dailyRevenue, dailySupplySideRevenue };
+  return { dailyVolume, dailyFees, dailyRevenue, dailyProtocolRevenue, dailySupplySideRevenue };
 };
 
 const adapter: SimpleAdapter = {
@@ -293,6 +306,8 @@ const adapter: SimpleAdapter = {
       "Taker fee (Market.taker_fee_bps) on all fills. Maker rebate ships 0 and is not paid.",
     Revenue:
       "Taker fee kept in full (maker rebate ships 0 and is not paid).",
+    ProtocolRevenue:
+      "Taker fee retained by the protocol in full (supply-side revenue is 0, so all fees are protocol revenue).",
     SupplySideRevenue: "0 — no LP incentives paid.",
   },
   breakdownMethodology: {
@@ -300,6 +315,9 @@ const adapter: SimpleAdapter = {
       "swap fees": "taker_fee_bps on all fills",
     },
     Revenue: {
+      "swap fees": "taker_fee_bps on all fills",
+    },
+    ProtocolRevenue: {
       "swap fees": "taker_fee_bps on all fills",
     },
   },

--- a/dexs/stratabook/index.ts
+++ b/dexs/stratabook/index.ts
@@ -1,0 +1,296 @@
+/**
+ * Stratabook (Strata DEX) — Solana CLOB + vault + Sonar aggregator.
+ *
+ * PR target: https://github.com/DefiLlama/dimension-adapters
+ * Final path: `dexs/stratabook/index.ts`
+ *
+ * ── Protocol ───────────────────────────────────────────────────────
+ *
+ * Stratabook is a fully on-chain CLOB on Solana with three execution
+ * layers, all settled by the same CLOB program
+ * (`strataZWURmW6bzMWpkLCAFxNFrQXCNSE9cSmBmdPgP`):
+ *
+ *   L1 — native limit-order book fills        (source = 0)
+ *   L2 — RFQ / MM-signed quote settlement     (source = 1)
+ *   L3 — Sonar aggregator / AVL routed swaps  (source = 2, 4)
+ *
+ * Every match emits an `OrderFilled` event via `sol_log_data`:
+ *
+ *   Program data: <base64>   (100 bytes)
+ *     [0]        tag          = 3 (EventTag::OrderFilled)
+ *     [1..33]    maker_pda
+ *     [33..65]   taker_pda
+ *     [65..73]   maker_order_id   (u64 LE)
+ *     [73..81]   taker_order_id   (u64 LE)
+ *     [81..89]   fill_size        (u64 LE, base-token atoms)
+ *     [89..97]   settle_price     (u64 LE, quote atoms per base atom)
+ *     [97]       source           (0=L1, 1=L2, 2=L3-AVL, 3=MEV, 4=L3-AVL-wrapped)
+ *     [98..99]   maker_filled / taker_filled flags
+ *
+ * Volume = Σ fill_size (base side, USD-priced by DefiLlama).
+ * The market PDA for a fill is recovered from the tx's account list
+ * (settle txs pass exactly one Market account; layout verified
+ * 2026-08-12 against live mainnet accounts).
+ *
+ * ── Fees / Revenue methodology ─────────────────────────────────────
+ *
+ *   taker fee  = fill_size × Market.taker_fee_bps   (all sources)
+ *   maker rebate = 0 (ships 0, never wired — no rebate paid today)
+ *
+ *   dailyFees    = taker fee (what users pay)
+ *   dailyRevenue = dailyFees (taker fee kept in full; maker rebate 0)
+ *   dailySupplySideRevenue = 0 (no LP incentives paid)
+ *
+ * Market account layout (program-rust/src/state/market.rs, byte offsets
+ * verified against live mainnet accounts):
+ *   [8..40]  base_mint, [40..72] quote_mint, [72..104] base_vault,
+ *   [104..136] quote_vault, [160..162] taker_fee_bps (u16 LE),
+ *   [162..164] maker_rebate_bps (u16 LE, 0), [164..166] swap_fee_bps (u16 LE),
+ *   [300] base_decimals, [301] quote_decimals
+ */
+
+import { FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import axios from "axios";
+import { getEnv } from "../../helpers/env";
+
+const CLOB_PROGRAM = "strataZWURmW6bzMWpkLCAFxNFrQXCNSE9cSmBmdPgP";
+const MARKET_DATA_SIZES = [384, 416]; // Market V2, V3 account sizes
+
+// Market account field offsets (see header)
+const MKT_BASE_MINT = 8;
+const MKT_QUOTE_MINT = 40;
+const MKT_TAKER_FEE_BPS = 160;
+const MKT_SWAP_FEE_BPS = 164;
+
+const EVENT_ORDER_FILLED = 3;
+const FILL_SIZE_OFF = 81;
+const SETTLE_PRICE_OFF = 89;
+const SOURCE_OFF = 97;
+
+const BATCH = 40; // txs per batch RPC call
+const MAX_SIGS_PER_RUN = 2000; // safety cap
+const FALLBACK_RPCS = [
+  "https://api.mainnet-beta.solana.com",
+  "https://solana-rpc.publicnode.com",
+];
+
+// ── tiny base58 (no external dep) ──────────────────────────────────
+const B58_ALPHABET = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
+function base58Encode(bytes: Uint8Array): string {
+  let x = BigInt("0x" + Buffer.from(bytes).toString("hex"));
+  let out = "";
+  while (x > 0n) {
+    out = B58_ALPHABET[Number(x % 58n)] + out;
+    x /= 58n;
+  }
+  for (const b of bytes) if (b === 0) out = "1" + out; else break;
+  return out;
+}
+
+async function rpc(url: string, method: string, params: unknown[]): Promise<any> {
+  const { data } = await axios.post(url, { jsonrpc: "2.0", id: 1, method, params }, { timeout: 60000 });
+  if (data.error) throw new Error(`RPC ${method}: ${JSON.stringify(data.error)}`);
+  return data.result;
+}
+
+async function rpcBatch(url: string, requests: { method: string; params: unknown[] }[]): Promise<any[]> {
+  const body = requests.map((r, i) => ({ jsonrpc: "2.0", id: i, method: r.method, params: r.params }));
+  const { data } = await axios.post(url, body, { timeout: 90000 });
+  const byId = new Map<number, any>(data.map((d: any) => [d.id, d]));
+  return requests.map((_, i) => {
+    const item = byId.get(i);
+    if (item?.error) throw new Error(`RPC batch item error: ${JSON.stringify(item.error)}`);
+    return item?.result;
+  });
+}
+
+interface MarketInfo {
+  baseMint: string;
+  quoteMint: string;
+  takerFeeBps: number;
+  swapFeeBps: number;
+}
+
+async function getMarkets(): Promise<Map<string, MarketInfo>> {
+  const markets = new Map<string, MarketInfo>();
+  for (const size of MARKET_DATA_SIZES) {
+    const accounts = await withRetry((url) => rpc(url, "getProgramAccounts", [CLOB_PROGRAM, { encoding: "base64", filters: [{ dataSize: size }] }]));
+    for (const acc of accounts ?? []) {
+      const buf = Buffer.from(acc.account.data[0], "base64");
+      if (buf.length < 384) continue;
+      markets.set(acc.pubkey, {
+        baseMint: base58Encode(buf.subarray(MKT_BASE_MINT, MKT_BASE_MINT + 32)),
+        quoteMint: base58Encode(buf.subarray(MKT_QUOTE_MINT, MKT_QUOTE_MINT + 32)),
+        takerFeeBps: buf.readUInt16LE(MKT_TAKER_FEE_BPS),
+        swapFeeBps: buf.readUInt16LE(MKT_SWAP_FEE_BPS),
+      });
+    }
+  }
+  return markets;
+}
+
+interface Fill {
+  fillSize: bigint;
+  source: number;
+}
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+async function withRetry<T>(fn: (url: string) => Promise<T>, tries = 4): Promise<T> {
+  const primary = getEnv("SOLANA_RPC");
+  const urls = [primary, ...FALLBACK_RPCS.filter((u) => u !== primary)];
+  let lastErr: any;
+  for (let i = 0; i < tries; i++) {
+    try {
+      return await fn(urls[i % urls.length]);
+    } catch (e: any) {
+      lastErr = e;
+      const status = e?.response?.status;
+      const retryable = status === 429 || status >= 500 || !status || e?.code === "ECONNABORTED";
+      if (i === tries - 1 || !retryable) throw e;
+      await sleep(600 * (i + 1));
+    }
+  }
+  throw lastErr;
+}
+
+// Fetch tx JSON for a list of signatures. Tries one batch against the
+// configured RPC (DefiLlama infra supports batches); if that fails,
+// falls back to sequential single-tx fetches with endpoint rotation
+// (public RPCs commonly cap getTransaction batches at 1).
+async function fetchTxs(signatures: string[]): Promise<any[]> {
+  try {
+    return await rpcBatch(getEnv("SOLANA_RPC"), signatures.map((signature) => ({
+      method: "getTransaction",
+      params: [signature, { maxSupportedTransactionVersion: 0, encoding: "json" }],
+    })));
+  } catch {
+    // sequential fallback
+    const out: any[] = [];
+    for (const signature of signatures) {
+      try {
+        out.push(await withRetry((url) => rpc(url, "getTransaction", [
+          signature, { maxSupportedTransactionVersion: 0, encoding: "json" },
+        ])));
+      } catch {
+        out.push(null); // not found / expired — skip
+      }
+      await sleep(120);
+    }
+    return out;
+  }
+}
+
+const fetch = async (options: FetchOptions) => {
+  const { createBalances } = options;
+  const dailyVolume = createBalances();
+  const dailyFees = createBalances();
+  const dailyRevenue = createBalances();
+  const dailySupplySideRevenue = createBalances();
+
+  const markets = await getMarkets();
+  if (markets.size === 0) return { dailyVolume, dailyFees, dailyRevenue, dailySupplySideRevenue };
+
+  const start = options.startTimestamp;
+  const end = options.endTimestamp;
+
+  let before: string | undefined;
+  let processed = 0;
+  let done = false;
+
+  while (!done && processed < MAX_SIGS_PER_RUN) {
+    const sigs = (await withRetry((url) => rpc(url, "getSignaturesForAddress", [
+      CLOB_PROGRAM,
+      { limit: 100, ...(before ? { before } : {}) },
+    ]))) ?? [];
+    if (sigs.length === 0) break;
+
+    // collect the chunk of sigs that are still within the window
+    const inWindow: { signature: string }[] = [];
+    for (const s of sigs) {
+      if (s.blockTime != null && s.blockTime < start) { done = true; break; }
+      inWindow.push(s);
+    }
+    if (inWindow.length === 0) break;
+
+    // fetch txs in batches (self-adapting to RPC batch limits)
+    const signatures = inWindow.map((s) => s.signature);
+    const txs = await fetchTxs(signatures);
+    for (const tx of txs) {
+        if (!tx?.meta || tx.blockTime == null) continue;
+        if (tx.blockTime < start) { done = true; continue; }
+        if (tx.blockTime >= end) continue;
+
+        const accountKeys: string[] = [];
+        if (tx.transaction?.message?.accountKeys) {
+          for (const k of tx.transaction.message.accountKeys) {
+            accountKeys.push(typeof k === "string" ? k : k.pubkey);
+          }
+        }
+        // v0 txs: CPI-loaded addresses live in meta.loadedAddresses
+        const loaded = tx.meta?.loadedAddresses;
+        if (loaded) {
+          accountKeys.push(...(loaded.writable ?? []), ...(loaded.readonly ?? []));
+        }
+        // market(s) touched by this tx
+        const txMarkets = [...accountKeys].map((k) => markets.get(k)).filter((m): m is MarketInfo => !!m);
+        if (txMarkets.length === 0) continue;
+        const market = txMarkets[0]; // settle txs carry exactly one Market account
+
+        for (const log of tx.meta.logMessages ?? []) {
+          if (!log.startsWith("Program data: ")) continue;
+          const buf = Buffer.from(log.slice("Program data: ".length), "base64");
+          if (buf.length < 100 || buf[0] !== EVENT_ORDER_FILLED) continue;
+
+          const fillSize = buf.readBigUInt64LE(FILL_SIZE_OFF);
+          if (fillSize === 0n) continue;
+          const source = buf[SOURCE_OFF];
+
+          dailyVolume.add(market.baseMint, fillSize.toString());
+
+          // fees: taker fee on every fill (maker rebate ships 0)
+          const takerFee = (fillSize * BigInt(market.takerFeeBps)) / 10000n;
+          dailyFees.add(market.baseMint, takerFee.toString());
+          dailyRevenue.add(market.baseMint, takerFee.toString());
+        }
+      }
+      processed += signatures.length;
+      await sleep(150); // be gentle with public RPCs
+
+      if (sigs.length < 100) break;
+      before = sigs[sigs.length - 1].signature;
+    }
+
+  return { dailyVolume, dailyFees, dailyRevenue, dailySupplySideRevenue };
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  adapter: {
+    [CHAIN.SOLANA]: {
+      fetch,
+      start: "2026-08-09", // first on-chain activity on the CLOB program
+    },
+  },
+  methodology: {
+    Volume:
+      "Trading volume from on-chain OrderFilled events on the Stratabook CLOB program, " +
+      "covering L1 orderbook, L2 RFQ, and L3 Sonar/AVL routed fills. Sum of base-side fill sizes, USD-priced by DefiLlama.",
+    Fees:
+      "Taker fee (Market.taker_fee_bps) on all fills. Maker rebate ships 0 and is not paid.",
+    Revenue:
+      "Taker fee kept in full (maker rebate ships 0 and is not paid).",
+    SupplySideRevenue: "0 — no LP incentives paid.",
+  },
+  breakdownMethodology: {
+    Fees: {
+      "swap fees": "taker_fee_bps on all fills",
+    },
+    Revenue: {
+      "swap fees": "taker_fee_bps on all fills",
+    },
+  },
+};
+
+export default adapter;


### PR DESCRIPTION
Adds the **Stratabook** volume, fees, and revenue adapter for Solana.

**Protocol:** Stratabook (Strata DEX) — fully on-chain CLOB on Solana with three execution layers, all settled by the same CLOB program `strataZWURmW6bzMWpkLCAFxNFrQXCNSE9cSmBmdPgP`:
- L1 native orderbook fills (source 0)
- L2 RFQ / MM-signed quotes (source 1)
- L3 Sonar aggregator / AVL routed swaps (source 2, 4)

**Volume:** parsed from on-chain `OrderFilled` events (`sol_log_data`, 100-byte payload) — tag 3, `fill_size` at bytes 81-89, `settle_price` 89-97, `source` 97. Sum of base-side fill sizes, USD-priced by DefiLlama. No warehouse dependency.

**Fees/Revenue:** taker fee (`Market.taker_fee_bps`, read live from market accounts) on all fills; maker rebate ships 0 and is not paid; supply-side revenue 0 (no LP incentives).

**Chain:** Solana · **Category:** Dexs · **Start:** 2026-08-09 (first on-chain activity)

Methodology and full event layout documented in the adapter header comment.
