### PR TITLE
Add Alandale adapter (Robinhood Chain ve(3,3) DEX)

### DIFF
--- a/dexs/alandale/index.ts
+++ b/dexs/alandale/index.ts
@@ -2,7 +2,6 @@ import { CHAIN } from '../../helpers/chains';
 import { FetchOptions, IJSON, SimpleAdapter } from '../../adapters/types';
 import { addOneToken } from '../../helpers/prices';
 import { METRIC } from '../../helpers/metrics';
-import { ethers } from 'ethers';
 
 const FACTORY = '0x16494A80E08Bcb9285D87b67149d7b01774D82F8';
 const FROM_BLOCK = 27941500;
@@ -20,12 +19,12 @@ const COMMUNITY_FEE_DENOMINATOR = 1e3;
 
 type Point = { block: number; index: number; value: number };
 
-const toPoints = (iface: ethers.Interface, logs: any[]): Point[] =>
+const toPoints = (logs: any[]): Point[] =>
   logs
     .map((log: any) => ({
       block: Number(log.blockNumber),
-      index: Number(log.logIndex ?? log.index ?? 0),
-      value: Number(iface.parseLog(log)?.args[0]),
+      index: Number(log.logIndex),
+      value: Number(log.args[0]),
     }))
     .sort((a, b) => a.block - b.block || a.index - b.index);
 
@@ -69,19 +68,12 @@ const breakdownMethodology = {
 const fetch = async (options: FetchOptions) => {
   const { createBalances, getLogs, chain } = options;
 
-  const poolIface = new ethers.Interface([poolCreatedEvent]);
-  const feeIface = new ethers.Interface([feeEvent]);
-  const communityIface = new ethers.Interface([communityFeeEvent]);
-  const defaultFeeIface = new ethers.Interface([defaultFeeEvent]);
-  const defaultCommunityIface = new ethers.Interface([defaultCommunityFeeEvent]);
+  const cached = { fromBlock: FROM_BLOCK, entireLog: true, cacheInCloud: true, parseLog: true } as const;
 
-  const cached = { fromBlock: FROM_BLOCK, entireLog: true, cacheInCloud: true } as const;
-
-  const poolLogs = await getLogs({ target: FACTORY, eventAbi: poolCreatedEvent, ...cached });
+  const poolLogs = await getLogs({ target: FACTORY, eventAbi: poolCreatedEvent, fromBlock: FROM_BLOCK, cacheInCloud: true });
   const pairObject: IJSON<string[]> = {};
   poolLogs.forEach((log: any) => {
-    const args = poolIface.parseLog(log)?.args;
-    if (args) pairObject[args.pool] = [args.token0, args.token1];
+    pairObject[log.pool] = [log.token0, log.token1];
   });
   const pools = Object.keys(pairObject);
 
@@ -106,23 +98,21 @@ const fetch = async (options: FetchOptions) => {
   const communityLogs = await getLogs({ targets: pools, eventAbi: communityFeeEvent, flatten: false, ...cached });
   const swapLogs = await getLogs({ targets: pools, eventAbi: swapEvent, flatten: false, entireLog: true });
 
-  const defaultFees = toPoints(defaultFeeIface, defaultFeeLogs);
-  const defaultCommunityFees = toPoints(defaultCommunityIface, defaultCommunityLogs);
-
-  const swapIface = new ethers.Interface([swapEvent]);
+  const defaultFees = toPoints(defaultFeeLogs);
+  const defaultCommunityFees = toPoints(defaultCommunityLogs);
 
   pools.forEach((pool, i) => {
     const logs = swapLogs[i];
     if (!logs?.length) return;
 
     const [token0, token1] = pairObject[pool];
-    const poolFees = toPoints(feeIface, feeLogs[i] ?? []);
-    const poolCommunityFees = toPoints(communityIface, communityLogs[i] ?? []);
+    const poolFees = toPoints(feeLogs[i] ?? []);
+    const poolCommunityFees = toPoints(communityLogs[i] ?? []);
 
     logs.forEach((log: any) => {
       const block = Number(log.blockNumber);
-      const index = Number(log.logIndex ?? log.index ?? 0);
-      const args = swapIface.parseLog(log)?.args;
+      const index = Number(log.logIndex);
+      const args = log.args;
       if (!args) return;
 
       const fee =

--- a/dexs/alandale/index.ts
+++ b/dexs/alandale/index.ts
@@ -1,0 +1,184 @@
+import { CHAIN } from '../../helpers/chains';
+import { FetchOptions, IJSON, SimpleAdapter } from '../../adapters/types';
+import { addOneToken } from '../../helpers/prices';
+import { METRIC } from '../../helpers/metrics';
+import { ethers } from 'ethers';
+
+const FACTORY = '0x16494A80E08Bcb9285D87b67149d7b01774D82F8';
+const FROM_BLOCK = 27941500;
+
+const poolCreatedEvent = 'event Pool(address indexed token0, address indexed token1, address pool)';
+const swapEvent =
+  'event Swap(address indexed sender, address indexed recipient, int256 amount0, int256 amount1, uint160 price, uint128 liquidity, int24 tick)';
+const feeEvent = 'event Fee(uint16 fee)';
+const communityFeeEvent = 'event CommunityFee(uint16 communityFeeNew)';
+const defaultFeeEvent = 'event DefaultFee(uint16 newDefaultFee)';
+const defaultCommunityFeeEvent = 'event DefaultCommunityFee(uint8 newDefaultCommunityFee)';
+
+const FEE_DENOMINATOR = 1e6;
+const COMMUNITY_FEE_DENOMINATOR = 1e3;
+
+type Point = { block: number; index: number; value: number };
+
+const toPoints = (iface: ethers.Interface, logs: any[]): Point[] =>
+  logs
+    .map((log: any) => ({
+      block: Number(log.blockNumber),
+      index: Number(log.logIndex ?? log.index ?? 0),
+      value: Number(iface.parseLog(log)?.args[0]),
+    }))
+    .sort((a, b) => a.block - b.block || a.index - b.index);
+
+const valueAt = (points: Point[], block: number, index: number, fallback: number): number => {
+  let out = fallback;
+  for (const p of points) {
+    if (p.block > block || (p.block === block && p.index > index)) break;
+    out = p.value;
+  }
+  return out;
+};
+
+const methodology = {
+  Volume: 'Swap volume across Alandale concentrated-liquidity pools, counted once per swap.',
+  Fees: "All swap fees paid by traders, using each pool's Algebra dynamic fee as it stood at the block of each swap.",
+  UserFees: 'All swap fees paid by traders.',
+  Revenue: "Swap fees routed out of the pool to the fee vault, taken from each pool's on-chain community fee. This is the veLUTE voters' share.",
+  HoldersRevenue:
+    'Vault-routed swap fees, forwarded through the pool gauge to veLUTE voters. The fee vault sends its entire take to the gauge, so this equals Revenue.',
+  SupplySideRevenue:
+    'Swap fees kept by liquidity providers. LPs do not earn fees while a pool routes its full community fee onward; instead they are compensated with LUTE emissions. Currently zero, since every pool routes 100%.',
+};
+
+const LOCKER_FEES = 'Swap Fees to veLUTE lockers';
+
+const breakdownMethodology = {
+  Fees: {
+    [METRIC.SWAP_FEES]: 'Swap fees collected from all pools.',
+  },
+  Revenue: {
+    [LOCKER_FEES]: 'Portion of swap fees going to the veLUTE lockers.',
+  },
+  HoldersRevenue: {
+    [LOCKER_FEES]: 'Portion of swap fees going to the veLUTE lockers.',
+  },
+  SupplySideRevenue: {
+    [METRIC.LP_FEES]: 'Portion of swap fees kept by liquidity providers.',
+  },
+};
+
+const fetch = async (options: FetchOptions) => {
+  const { createBalances, getLogs, chain } = options;
+
+  const poolIface = new ethers.Interface([poolCreatedEvent]);
+  const feeIface = new ethers.Interface([feeEvent]);
+  const communityIface = new ethers.Interface([communityFeeEvent]);
+  const defaultFeeIface = new ethers.Interface([defaultFeeEvent]);
+  const defaultCommunityIface = new ethers.Interface([defaultCommunityFeeEvent]);
+
+  const cached = { fromBlock: FROM_BLOCK, entireLog: true, cacheInCloud: true } as const;
+
+  const poolLogs = await getLogs({ target: FACTORY, eventAbi: poolCreatedEvent, ...cached });
+  const pairObject: IJSON<string[]> = {};
+  poolLogs.forEach((log: any) => {
+    const args = poolIface.parseLog(log)?.args;
+    if (args) pairObject[args.pool] = [args.token0, args.token1];
+  });
+  const pools = Object.keys(pairObject);
+
+  const dailyVolume = createBalances();
+  const dailyFees = createBalances();
+  const dailyRevenue = createBalances();
+  const dailyHoldersRevenue = createBalances();
+  const dailySupplySideRevenue = createBalances();
+  const empty = {
+    dailyVolume,
+    dailyFees,
+    dailyUserFees: dailyFees,
+    dailyRevenue,
+    dailyHoldersRevenue,
+    dailySupplySideRevenue,
+  };
+  if (!pools.length) return empty;
+
+  const defaultFeeLogs = await getLogs({ target: FACTORY, eventAbi: defaultFeeEvent, ...cached });
+  const defaultCommunityLogs = await getLogs({ target: FACTORY, eventAbi: defaultCommunityFeeEvent, ...cached });
+  const feeLogs = await getLogs({ targets: pools, eventAbi: feeEvent, flatten: false, ...cached });
+  const communityLogs = await getLogs({ targets: pools, eventAbi: communityFeeEvent, flatten: false, ...cached });
+  const swapLogs = await getLogs({ targets: pools, eventAbi: swapEvent, flatten: false, entireLog: true });
+
+  const defaultFees = toPoints(defaultFeeIface, defaultFeeLogs);
+  const defaultCommunityFees = toPoints(defaultCommunityIface, defaultCommunityLogs);
+
+  const swapIface = new ethers.Interface([swapEvent]);
+
+  pools.forEach((pool, i) => {
+    const logs = swapLogs[i];
+    if (!logs?.length) return;
+
+    const [token0, token1] = pairObject[pool];
+    const poolFees = toPoints(feeIface, feeLogs[i] ?? []);
+    const poolCommunityFees = toPoints(communityIface, communityLogs[i] ?? []);
+
+    logs.forEach((log: any) => {
+      const block = Number(log.blockNumber);
+      const index = Number(log.logIndex ?? log.index ?? 0);
+      const args = swapIface.parseLog(log)?.args;
+      if (!args) return;
+
+      const fee =
+        valueAt(poolFees, block, index, valueAt(defaultFees, block, Infinity, 0)) / FEE_DENOMINATOR;
+      const communityShare =
+        valueAt(poolCommunityFees, block, index, valueAt(defaultCommunityFees, block, Infinity, 0)) /
+        COMMUNITY_FEE_DENOMINATOR;
+
+      const amount0 = args.amount0;
+      const amount1 = args.amount1;
+      const fee0 = amount0.toString() * fee;
+      const fee1 = amount1.toString() * fee;
+
+      addOneToken({ chain, balances: dailyVolume, token0, token1, amount0, amount1 });
+      addOneToken({ chain, balances: dailyFees, token0, token1, amount0: fee0, amount1: fee1, label: METRIC.SWAP_FEES });
+      addOneToken({
+        chain,
+        balances: dailyHoldersRevenue,
+        token0,
+        token1,
+        amount0: fee0 * communityShare,
+        amount1: fee1 * communityShare,
+        label: LOCKER_FEES,
+      });
+      addOneToken({
+        chain,
+        balances: dailySupplySideRevenue,
+        token0,
+        token1,
+        amount0: fee0 * (1 - communityShare),
+        amount1: fee1 * (1 - communityShare),
+        label: METRIC.LP_FEES,
+      });
+    });
+  });
+
+  dailyRevenue.addBalances(dailyHoldersRevenue);
+
+  return {
+    dailyVolume,
+    dailyFees,
+    dailyUserFees: dailyFees,
+    dailyRevenue,
+    dailyHoldersRevenue,
+    dailySupplySideRevenue,
+  };
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  pullHourly: true,
+  fetch,
+  chains: [CHAIN.ROBINHOOD],
+  start: '2026-08-04',
+  methodology,
+  breakdownMethodology,
+};
+
+export default adapter;


### PR DESCRIPTION
*(both are required in the PR description by `GUIDELINES.md`)*

Alandale is a ve(3,3) DEX on Robinhood Chain, running Algebra Integral
concentrated-liquidity pools. `version: 2`, `pullHourly: true`, no new dependencies.

### Fee split — read on-chain, not assumed

Every pool routes **100% of swap fees** out of the pool (`globalState.communityFee = 1000/1000`) and
the FeesVault forwards **100% to the gauge** (`toGaugeRate = 10000/10000`, zero other recipients).
Verified across all 11 live pools. So:

- `Revenue` = `HoldersRevenue` = `Fees` — all swap fees reach veLUTE voters
- `SupplySideRevenue` = 0 — LPs are paid in LUTE emissions instead of swap fees
- Alandale takes no protocol cut

The community fee is read per swap from `CommunityFee` events, so a change to it is picked up
automatically. The vault's gauge rate is not readable from events (it is set at initialisation and
emits nothing), so it is not re-read per run; it was verified as 10000/10000 with zero other
recipients across all 11 vaults.

### Why this does not use `getUniV3LogAdapter`

**`fee()` is the wrong number.** Algebra exposes `globalState.lastFee` — the rate a swap actually
paid — and `fee()`, a forward-looking quote recomputed from volatility state that drifts from it
even on pools with zero swaps. The helper reads `fee()` once at the end-of-window block and applies
it to every swap in that window. On WETH/SPCX that is 123 against the 117 actually charged, ~5%
overstated, and it cannot capture intra-window fee movement at all.

This adapter instead reconstructs the rate from `Fee(uint16)`, `CommunityFee(uint16)` and
`DefaultFee(uint16)` events into a per-pool timeline, matching each swap to the rate in force at
its exact `(blockNumber, logIndex)`. Verified against `globalState.lastFee` on all 11 pools. A
useful side effect is that it needs no historical state at all, which also sidesteps the ~17-minute
state window on this chain's public RPC.

Log-index ordering matters because the plugin sets the fee in `beforeSwap`, so a `Fee` event and the
swap it applies to share a block; ordering by block alone would apply a later `Fee` retroactively.

Log queries are issued sequentially rather than concurrently, to stay within RPC rate limits.

**Validation:** volume reconciles against the protocol's own subgraph over an identical window —
$157,180 reported against $157,084 from the subgraph, a 0.06% difference. Note the protocol's own UI
shows a larger figure because it uses a rolling 24h window and counts both sides of each swap;
DefiLlama's convention is one side per swap.

---

