### PR TITLE
[fix] strata-markets - book negative strategy yield as negative supply side revenue

### DIFF
--- a/fees/strata-markets/index.ts
+++ b/fees/strata-markets/index.ts
@@ -144,16 +144,21 @@ async function processCDO(
   const exitFeeToTranche = sumLogField(feeAccrued, "amountToTranche");
   const exitFeesTotal = exitFeeToReserve + exitFeeToTranche;
 
-  // we calculate this yield from the delta of strategy assets
-  // if delta is negative, the losses are absorbed by the tranches
-  // and so it's safe to set yield to 0. this doesn't mean the losses 
-  // of the strtegy are ignored. they are compensated by tranches & reserves
-  // and so the protocol yield doesn't get negative even if the strategy performs badly
-  let yieldAmount = navEnd - navStart - inflows + outflowsToUsers + reserveOut;
-  if (yieldAmount < 0n) yieldAmount = 0n;
+  // we calculate this yield from the delta of strategy assets.
+  // this can be negative when the strategy marks down, which happens on the
+  // RWA-backed CDOs whose NAV follows a discrete oracle (sUSDat/STRC) rather
+  // than a monotonic exchange rate. those losses are absorbed by the tranches,
+  // so they belong in supply side revenue as a negative, not clamped away.
+  // clamping each window at zero only ever books the up moves and ratchets
+  // cumulative fees upwards, which is worse under pullHourly because a day is
+  // cut into 24 chances to discard downside instead of 1.
+  const yieldAmount = navEnd - navStart - inflows + outflowsToUsers + reserveOut;
 
+  // the reserve takes a performance fee out of yield, but does not refund it on
+  // a loss, so on a negative window the whole markdown lands on the tranches.
   const ONE = 10n ** 18n;
-  const protocolFromYield = (yieldAmount * reserveBps) / ONE;
+  const protocolFromYield =
+    yieldAmount > 0n ? (yieldAmount * reserveBps) / ONE : 0n;
   const supplyFromYield = yieldAmount - protocolFromYield;
 
   dailyFees.add(baseAsset, yieldAmount.toString());
@@ -205,7 +210,7 @@ const methodology = {
   Fees: "Includes yield generated on deposited assets and redemption fees charged by Strata.",
   Revenue: "Protocol revenue consists of performance fees (5-10%) charged by Strata on the yield generated and redemption fees paid by the users.",
   ProtocolRevenue: "Protocol revenue consists of performance and redemption fees collected by Strata, including the portion of fees shared with reserve.",
-  SupplySideRevenue: "Net yield distributed to tranches (after performance fees) plus the portion of redemption fees that remain in the tranche.",
+  SupplySideRevenue: "Net yield distributed to tranches (after performance fees) plus the portion of redemption fees that remain in the tranche. Goes negative on days a strategy marks down, since those losses are absorbed by the tranches.",
 };
 
 const earliestStart = CDOS.reduce(
@@ -220,6 +225,7 @@ const adapter: SimpleAdapter = {
   chains: [CHAIN.ETHEREUM],
   start: earliestStart,
   methodology,
+  allowNegativeValue: true, // strategy NAV can mark down, the loss is absorbed by the tranches
 };
 
 export default adapter;


### PR DESCRIPTION
Protocol: **Strata Markets**

Follows @bheluga's read on #8721, that the cumulative problem is the clamp on negative yield rather than the size of the spikes. Opening this separately because it is a different change from the cap in that PR, not a revision of it. #8721 and the earlier #7822 both proposed capping; this does not cap anything.

## The problem

`processCDO` clamps each window's yield at zero:

```ts
let yieldAmount = navEnd - navStart - inflows + outflowsToUsers + reserveOut;
if (yieldAmount < 0n) yieldAmount = 0n;
```

On a strategy whose NAV oscillates, that only ever books the up moves. Cumulative fees ratchet upward by the entire sum of the discarded down moves. `pullHourly: true` makes it worse, because a day is cut into 24 chances to discard downside instead of 1.

## Measurement

21 days, 2026-07-22 10:00Z to 2026-08-12 10:00Z, 504 hourly windows. I replicated this exact expression against archive `totalAssets()` reads, with `Deposit`/`Withdraw` on both tranches and `ReserveReduced` on the CDO netted out the same way `processCDO` does, then summed it with and without the clamp.

| CDO | booked with clamp | true cumulative | negative windows dropped |
|---|---|---|---|
| **sUSDat** | **1,283,333** | **436,845** | **61 windows, -846,489** |
| sUSDe | 152,071 | 152,071 | 0 |
| mHYPER | 4,794 | 4,794 | 0 |
| mm1USD | 6,451 | 6,451 | 0 |

Base-asset units, roughly 1 USD each. No `ReserveReduced` events fired on any of the four in the window.

sUSDat cumulative was inflated **2.94x**, and it is the only CDO affected. Its NAV is 98.4% STRC marked by a discrete oracle that steps both ways. The other three track monotonic exchange rates or rebases and did not produce a single negative window in three weeks, which is also why a cap is the wrong instrument here: it would clip strategies whose cumulative is already correct.

The same data aggregated to 24h windows gives 1.63x and 7 negative windows, against 2.94x and 61 at 1h. That difference is the `pullHourly` amplification.

## The change

Let the negative through. The losses are absorbed by the tranches, so they belong in supply side revenue as a negative rather than being dropped.

The reserve takes a performance fee out of positive yield but does not refund it on a loss, so `protocolFromYield` is held at zero on a negative window and the whole markdown lands on the tranches. `dailyFees = dailyRevenue + dailySupplySideRevenue` still holds exactly.

Adds `allowNegativeValue`, which is what the curator framework already does for vaults (`helpers/curators/index.ts`, "we allow negative fees for vaults because vaults can make yields or make loss too"), and what `fees/accountable.ts`, `fees/alchemix-v3.ts` and `fees/puffer-vaults.ts` do for the same reason.

## Ruling out unnetted flows

A negative window would be meaningless if it were just a withdrawal the adapter failed to net. It is not. The two largest sUSDat withdrawals in the period line up with the NAV drop across their own blocks to within a third of a dollar:

| withdrawal | strategy NAV drop | difference |
|---|---|---|
| 192,440.482 (block 25647798) | 192,440.179 | 0.303 |
| 165,349.112 (block 25625001) | 165,348.800 | 0.312 |

So withdrawals are funded from the strategy and net out, and the negative windows are real markdowns.

## Testing

`npm run test fees strata-markets`.

Single daily window (`DISABLE_PULL_HOURLY=true`) completes clean:

```
Daily fees: 61.69 k
Daily revenue: 422.00
Daily protocol revenue: 422.00
Daily supply side revenue: 61.27 k
```

Hourly, the negative windows now come through instead of being zeroed, with protocol revenue staying non-negative and the identity holding:

```
 (7/24) start: 3 PM - 11/08  |  fees - -183.00   | revenue - 16.00 | supply side revenue - -200.00
(10/24) start: 5 PM - 11/08  |  fees - -12.52 k  | revenue - 16.00 | supply side revenue - -12.54 k
```

Reproduced across two runs at the same wall-clock hour. Unmodified master books those same windows as `fees 16.00 / supply side 0`.

What I could not do locally: a complete 24-slot hourly run. Public archive RPCs run out partway through, which is the same wall the CI run on #8721 hit. That is not specific to this change, unmodified master fails the same way on the same endpoints, and one master run that did complete gave 77.92k fees / 423 revenue / 77.50k supply side for the Aug 11 09:00Z window. `tsc` is clean on the file, checked directly since `tsconfig.json`'s `fees/*` glob does not reach `fees/<name>/index.ts`.

## One thing worth a maintainer's call

The clamp was added deliberately in #7001 with the reasoning that protocol yield should not go negative even when a strategy performs badly. I think the measurement above shows the cost of that, and @bheluga's comment on #8721 asks for the opposite treatment, but since @0xnaman1 wrote the original I would rather flag the disagreement than quietly reverse it.

Separately, sUSDat's flowless drift over this window annualizes to about 69% APR against a 14.34% base APR. I could not attribute the remainder and it is most likely STRC simply marking up over these three weeks. Nothing in this PR depends on it, but I would not treat the sUSDat "true cumulative" figure as a statement about real yield.
