### PR TITLE
accountable: add citrea chain

### DIFF
--- a/fees/accountable.ts
+++ b/fees/accountable.ts
@@ -49,6 +49,14 @@ const config: Record<string, { factories: string[], start: string }> = {
     ],
     start: "2026-07-22",
   },
+  [CHAIN.CITREA]: {
+    factories: [
+      "0x4927Ce3402035b801A1bEdDC498b7fb2fe9eA181",
+      "0x2f5CAc28cf80D465d7C8D67a49c8e36710a4B83B",
+      "0x9f1EB2be7b6a7e611c270bbdb0A3358786769518",
+    ],
+    start: "2026-04-21",
+  },
 };
 
 // aHYPER Looping Vault (vault 0x23b148d8f389C5821739381f1FF87bB7e1162566) is


### PR DESCRIPTION
Adds Citrea to the Accountable fees adapter, same pattern as Robinhood (#8711) — factory addresses match the ones already used in the TVL adapter (`projects/accountable/index.js`). Start date (2026-04-21) is the first Citrea deposit date, per an existing internal reconciliation note.

Currently two active vaults there, both OPEN_TERM credit vaults created by the openterm factory (verified on-chain: enumerable at indices 5 and 6 with no gap), so no `EXTRA_STRATEGIES` needed.

Unlike Robinhood, Citrea's public RPC (`rpc.mainnet.citrea.xyz`) has full archive depth — verified locally with `npm test fees accountable 2026-08-10 citrea`, which runs clean against the public RPC with no premium RPC needed: ~$222/day fees, ~$6.67/day protocol revenue on ~$2.66M TVL, consistent with the vaults' reported APYs.
