### PR TITLE
jupiter-dca: track Trigger V2 fees

### DIFF
--- a/fees/jupiter-dca.ts
+++ b/fees/jupiter-dca.ts
@@ -103,9 +103,8 @@ const fetchFeesSolana = async (options: FetchOptions) => {
 
 
 const adapter: SimpleAdapter = {
-  version: 2,
+  version: 1,
   pullHourly: true,
-  doublecounted: true,
   isExpensiveAdapter: true,
   // Legacy DCA fees come from Allium (unchanged), Trigger V2 fees from Dune.
   dependencies: [Dependencies.ALLIUM, Dependencies.DUNE],

--- a/fees/jupiter-dca.ts
+++ b/fees/jupiter-dca.ts
@@ -83,8 +83,14 @@ const fetchFeesSolana = async (options: FetchOptions) => {
 
   const buybackRatio = jupBuybackRatioFromRevenue(options.startOfDay);
   const revenueHolders = dailyRevenue.clone(buybackRatio);
-  const revenueProtocol = dailyRevenue.clone(1 - buybackRatio);
-  dailyProtocolRevenue.add(revenueProtocol);
+  dailyProtocolRevenue.add(
+    legacyFees.clone(1 - buybackRatio),
+    JUPITER_METRICS.JupDCAFees,
+  );
+  dailyProtocolRevenue.add(
+    triggerV2Fees.clone(1 - buybackRatio),
+    JUPITER_METRICS.JupTriggerV2Fees,
+  );
   dailyHoldersRevenue.add(revenueHolders, JUPITER_METRICS.TokenBuyBack);
 
   return {

--- a/fees/jupiter-dca.ts
+++ b/fees/jupiter-dca.ts
@@ -1,24 +1,90 @@
 import { Dependencies, FetchOptions, SimpleAdapter } from "../adapters/types"
 import { CHAIN } from "../helpers/chains"
+import { queryDuneSql } from "../helpers/dune"
 import { getSolanaReceived } from "../helpers/token"
-import { JUPITER_METRICS, jupBuybackRatioFromRevenue } from "./jupiter";
+import { JUPITER_FEE_AUTHORITIES, JUPITER_METRICS, jupBuybackRatioFromRevenue } from "./jupiter";
 
-const fethcFeesSolana = async (options: FetchOptions) => {
-  const fees = await getSolanaReceived({ options, targets: [
-    'CpoD6tWAsMDeyvVG2q2rD1JbDY6d4AujnvAn2NdrhZV2'
-  ]})
+const LEGACY_DCA_FEE_WALLET = 'CpoD6tWAsMDeyvVG2q2rD1JbDY6d4AujnvAn2NdrhZV2'
+
+// Trigger V2 keeps orders off-chain and settles each fill as a plain Jupiter V6
+// swap, so the keeper paying the network fee is the only on-chain identifier.
+// Not to be confused with the gasless payer gasTzr94Pmp4Gf8vknQnqxeYxdgwFjbgdJa4msYRpnB.
+const TRIGGER_V2_KEEPER = 'gasBidSWW5zmwXs3gn8TG2ijzKkrwpyM7ucwjgDQst6'
+const TRIGGER_V2_START_TIMESTAMP = 1773100800 // 2026-03-10
+
+async function getTriggerV2Fees(options: FetchOptions) {
+  const fees = options.createBalances()
+  if (options.endTimestamp <= TRIGGER_V2_START_TIMESTAMP) return fees
+
+  const feeAuthorities = JUPITER_FEE_AUTHORITIES.map((address) => `'${address}'`).join(', ')
+  // Half-open on purpose: the shared TIME_RANGE macro closes the upper bound,
+  // which double counts the boundary second on an hourly adapter.
+  const timeRange = (column: string) =>
+    `${column} >= from_unixtime(${options.startTimestamp}) AND ${column} < from_unixtime(${options.endTimestamp})`
+
+  const rows: { token: string; amount: string }[] = await queryDuneSql(options, `
+    WITH keeper_transfers AS (
+      SELECT tx_id, token_mint_address, amount, amount_display
+      FROM tokens_solana.transfers
+      WHERE ${timeRange('block_time')}
+        AND tx_signer = '${TRIGGER_V2_KEEPER}'
+    ),
+    trigger_txs AS (
+      SELECT DISTINCT tx_id FROM keeper_transfers
+    ),
+    -- account_activity is decimal adjusted, so recover the raw amount from the
+    -- raw/display ratio of the same token in the same set of transactions.
+    token_scale AS (
+      SELECT token_mint_address, MAX(CAST(amount AS DOUBLE) / amount_display) AS scale
+      FROM keeper_transfers
+      WHERE amount_display > 0
+      GROUP BY 1
+    ),
+    -- The fee authorities double as Jupiter's shared routing accounts, so swap
+    -- volume passes through them. Only the net change per transaction is fee
+    -- income; summing inbound transfers overstates it by orders of magnitude.
+    fee_net AS (
+      SELECT a.tx_id, a.token_mint_address AS mint, SUM(a.token_balance_change) AS net
+      FROM solana.account_activity a
+      JOIN trigger_txs t ON t.tx_id = a.tx_id
+      WHERE ${timeRange('a.block_time')}
+        AND a.tx_success
+        AND a.token_mint_address IS NOT NULL
+        AND a.token_balance_owner IN (${feeAuthorities})
+      GROUP BY 1, 2
+    )
+    SELECT
+      fee_net.mint AS token,
+      CAST(SUM(fee_net.net) * MAX(token_scale.scale) AS DECIMAL(38, 0)) AS amount
+    FROM fee_net
+    JOIN token_scale ON token_scale.token_mint_address = fee_net.mint
+    WHERE fee_net.net > 0
+    GROUP BY 1
+  `)
+
+  rows.forEach(({ token, amount }) => fees.add(token, amount))
+  return fees
+}
+
+const fetchFeesSolana = async (options: FetchOptions) => {
+  const [legacyFees, triggerV2Fees] = await Promise.all([
+    getSolanaReceived({ options, targets: [LEGACY_DCA_FEE_WALLET] }),
+    getTriggerV2Fees(options),
+  ])
   const dailyFees = options.createBalances();
   const dailyRevenue = options.createBalances();
   const dailyProtocolRevenue = options.createBalances();
   const dailyHoldersRevenue = options.createBalances();
-  
-  dailyFees.add(fees, JUPITER_METRICS.JupDCAFees);
-  dailyRevenue.add(fees, JUPITER_METRICS.JupDCAFees);
-  
+
+  dailyFees.add(legacyFees, JUPITER_METRICS.JupDCAFees);
+  dailyFees.add(triggerV2Fees, JUPITER_METRICS.JupTriggerV2Fees);
+  dailyRevenue.add(legacyFees, JUPITER_METRICS.JupDCAFees);
+  dailyRevenue.add(triggerV2Fees, JUPITER_METRICS.JupTriggerV2Fees);
+
   const buybackRatio = jupBuybackRatioFromRevenue(options.startOfDay);
   const revenueHolders = dailyRevenue.clone(buybackRatio);
   const revenueProtocol = dailyRevenue.clone(1 - buybackRatio);
-  dailyProtocolRevenue.add(revenueProtocol, JUPITER_METRICS.JupDCAFees);
+  dailyProtocolRevenue.add(revenueProtocol);
   dailyHoldersRevenue.add(revenueHolders, JUPITER_METRICS.TokenBuyBack);
 
   return {
@@ -33,28 +99,34 @@ const fethcFeesSolana = async (options: FetchOptions) => {
 const adapter: SimpleAdapter = {
   version: 2,
   pullHourly: true,
-  dependencies: [Dependencies.ALLIUM],
+  doublecounted: true,
+  isExpensiveAdapter: true,
+  // Legacy DCA fees come from Allium (unchanged), Trigger V2 fees from Dune.
+  dependencies: [Dependencies.ALLIUM, Dependencies.DUNE],
   adapter: {
     [CHAIN.SOLANA]: {
-      fetch: fethcFeesSolana,
+      fetch: fetchFeesSolana,
       start: '2024-01-01',
     },
   },
   methodology: {
-    Fees: 'All DCA trading fees.',
-    Revenue: 'All fees collected by protocol and JUP token holders.',
+    Fees: 'Legacy DCA fees are measured from the dedicated DCA fee wallet. Trigger V2 fees are the net token balance increase of Jupiter fee authorities in swaps settled by the Trigger keeper.',
+    Revenue: 'Legacy DCA fees and Trigger V2 fees collected by Jupiter. Trigger V2 fees are also part of the Jupiter aggregator adapter, hence this adapter is marked as double counted.',
     ProtocolRevenue: 'Share of 50% fees collected by protocol, it was 100% before 2025-02-17.',
     HoldersRevenue: 'From 2025-02-17, share of 50% fees to buy back JUP tokens.',
   },
   breakdownMethodology: {
     Fees: {
-      [JUPITER_METRICS.JupDCAFees]: 'All DCA trading fees.',
+      [JUPITER_METRICS.JupDCAFees]: 'Legacy DCA fees received by the dedicated DCA fee wallet.',
+      [JUPITER_METRICS.JupTriggerV2Fees]: 'Trigger V2 fees, covering both recurring (DCA) and price/limit orders. Jupiter stores the order type off-chain, so the two cannot be separated on-chain.',
     },
     Revenue: {
-      [JUPITER_METRICS.JupDCAFees]: 'All fees collected by protocol and JUP token holders',
+      [JUPITER_METRICS.JupDCAFees]: 'Legacy DCA fees collected by Jupiter and JUP token holders.',
+      [JUPITER_METRICS.JupTriggerV2Fees]: 'Trigger V2 fees collected by Jupiter. Overlaps with the aggregator swap fees.',
     },
     ProtocolRevenue: {
       [JUPITER_METRICS.JupDCAFees]: 'Share of 50% fees collected by protocol, it was 100% before 2025-02-17.',
+      [JUPITER_METRICS.JupTriggerV2Fees]: 'Trigger V2 fees allocated to the Jupiter treasury after the token buyback share.',
     },
     HoldersRevenue: {
       [JUPITER_METRICS.TokenBuyBack]: 'From 2025-02-17, share of 50% fees to buy back JUP tokens.',

--- a/fees/jupiter.ts
+++ b/fees/jupiter.ts
@@ -9,6 +9,36 @@ import { METRIC } from "../helpers/metrics"
 const JUP_BUY_BACK_START_TIME = 1739750400;
 export const jupBuybackRatioFromRevenue = (timestamp: number) => timestamp >= JUP_BUY_BACK_START_TIME ? 0.5 : 0;
 
+// Jupiter program authorities that accumulate Swap V2 fees before they are
+// swept to the central revenue wallet. Exported so product adapters can use
+// the same canonical set when attributing a subset of aggregator fees.
+export const JUPITER_FEE_AUTHORITIES = [
+  'BQ72nSv9f3PRyRKCBnHLVrerrv37CYTHm5h3s9VSGQDV',
+  '2MFoS3MPtvyQ4Wh4M9pdfPjz6UhVoNbFbGJAskCPCj3h',
+  'HU23r7UoZbqTUuh3vA7emAGztFtqwTeVips789vqxxBw',
+  '3CgvbiM3op4vjrrjH2zcrQUwsqh5veNVRjFCB9N6sRoD',
+  '6LXutJvKUw8Q5ue2gCgKHQdAN4suWW8awzFVC6XCguFx',
+  'CapuXNQoDviLvU1PxFiizLgPNQCxrsag1uMeyk6zLVps',
+  'GGztQqQ6pCPaJQnNpXBgELr5cs3WwDakRbh1iEMzjgSJ',
+  '9nnLbotNTcUhvbrsA6Mdkx45Sm82G35zo28AqUvjExn8',
+  '3LoAYHuSd7Gh8d7RTFnhvYtiTiefdZ5ByamU42vkzd76',
+  'DSN3j1ykL3obAVNv7ZX49VsFCPe4LqzxHnmtLiPwY6xg',
+  '69yhtoJR4JYPPABZcSNkzuqbaFbwHsCkja1sP1Q2aVT5',
+  '6U91aKa8pmMxkJwBCfPTmUEfZi6dHe7DcFq2ALvB2tbB',
+  '7iWnBRRhBCiNXXPhqiGzvvBkKrvFSWqqmxRyu9VyYBxE',
+  '4xDsmeTWPNjgSVSS1VTfzFq3iHZhp77ffPkAmkZkdu71',
+  'GP8StUXNYSZjPikyRsvkTbvRV1GBxMErb59cpeCJnDf1',
+  'HFqp6ErWHY6Uzhj8rFyjYuDya2mXUpYEk8VW75K9PSiY',
+  '6zQecXhjYTifDGYxbW7vRTQBrBYsi1Uac6BEJ4WzefWS',
+  'GgY8theL9n9hQPoz2keQM8y6z8T6G6BH9FPLjBtkF9Hd',
+  'G4FUwFD1h4tb4R6jkZXuoyst7YNbYTcJH3MvCUguss6E',
+  'F2Xjd4ZJYz6SfszyUVGzLUzAHRRhfU2iJacCfW5GCJHM',
+  '3cHRcBKWbJeL2qyjgQ8wdSYxmRYW1ZyC2nVqTakAj57G',
+  '6Ugimjtgk7rk5SbZNzcYvZiM3P6ki4Uq3QGtTHWNn8co',
+  '4QKRxAfawktf6szGUP456AqBvaKSnmuGy91QnqdBDSke',
+  '9kiYqGSb1nbYMc5xxZQHhKvJR57LLAHVyDvSQ3FHjDPK',
+]
+
 export const JUPITER_METRICS = {
   // Aggregator
   AggSwapFees: 'Aggregator Swap Fees',
@@ -50,6 +80,7 @@ export const JUPITER_METRICS = {
 
   // DCA
   JupDCAFees: 'Jup DCA Trading Fees',
+  JupTriggerV2Fees: 'Trigger V2 Fees',
 
   // Studio
   JupStudioFees: 'Jup Studio Trading Fees',
@@ -61,34 +92,12 @@ export const JUPITER_METRICS = {
 }
 
 const fetch = async (options: FetchOptions) => {
+  const feeAuthorityRows = JUPITER_FEE_AUTHORITIES.map((address) => `('${address}')`).join(',\n        ')
   const data: { amount_usd: number }[] = await queryAllium(`
     WITH addr_list AS (
       SELECT addr
       FROM (VALUES
-        ('BQ72nSv9f3PRyRKCBnHLVrerrv37CYTHm5h3s9VSGQDV'),
-        ('2MFoS3MPtvyQ4Wh4M9pdfPjz6UhVoNbFbGJAskCPCj3h'),
-        ('HU23r7UoZbqTUuh3vA7emAGztFtqwTeVips789vqxxBw'),
-        ('3CgvbiM3op4vjrrjH2zcrQUwsqh5veNVRjFCB9N6sRoD'),
-        ('6LXutJvKUw8Q5ue2gCgKHQdAN4suWW8awzFVC6XCguFx'),
-        ('CapuXNQoDviLvU1PxFiizLgPNQCxrsag1uMeyk6zLVps'),
-        ('GGztQqQ6pCPaJQnNpXBgELr5cs3WwDakRbh1iEMzjgSJ'),
-        ('9nnLbotNTcUhvbrsA6Mdkx45Sm82G35zo28AqUvjExn8'),
-        ('3LoAYHuSd7Gh8d7RTFnhvYtiTiefdZ5ByamU42vkzd76'),
-        ('DSN3j1ykL3obAVNv7ZX49VsFCPe4LqzxHnmtLiPwY6xg'),
-        ('69yhtoJR4JYPPABZcSNkzuqbaFbwHsCkja1sP1Q2aVT5'),
-        ('6U91aKa8pmMxkJwBCfPTmUEfZi6dHe7DcFq2ALvB2tbB'),
-        ('7iWnBRRhBCiNXXPhqiGzvvBkKrvFSWqqmxRyu9VyYBxE'),
-        ('4xDsmeTWPNjgSVSS1VTfzFq3iHZhp77ffPkAmkZkdu71'),
-        ('GP8StUXNYSZjPikyRsvkTbvRV1GBxMErb59cpeCJnDf1'),
-        ('HFqp6ErWHY6Uzhj8rFyjYuDya2mXUpYEk8VW75K9PSiY'),
-        ('6zQecXhjYTifDGYxbW7vRTQBrBYsi1Uac6BEJ4WzefWS'),
-        ('GgY8theL9n9hQPoz2keQM8y6z8T6G6BH9FPLjBtkF9Hd'),
-        ('G4FUwFD1h4tb4R6jkZXuoyst7YNbYTcJH3MvCUguss6E'),
-        ('F2Xjd4ZJYz6SfszyUVGzLUzAHRRhfU2iJacCfW5GCJHM'),
-        ('3cHRcBKWbJeL2qyjgQ8wdSYxmRYW1ZyC2nVqTakAj57G'),
-        ('6Ugimjtgk7rk5SbZNzcYvZiM3P6ki4Uq3QGtTHWNn8co'),
-        ('4QKRxAfawktf6szGUP456AqBvaKSnmuGy91QnqdBDSke'),
-        ('9kiYqGSb1nbYMc5xxZQHhKvJR57LLAHVyDvSQ3FHjDPK')
+        ${feeAuthorityRows}
       ) AS v(addr)
     )
     


### PR DESCRIPTION
Jupiter moved DCA and limit orders to **Trigger V2** on 2026-03-10: orders are stored off-chain, funds sit in custodial vault wallets, and a keeper settles each fill as a plain Jupiter V6 swap. 

This adds a `Trigger V2 Fees` metric to `fees/jupiter-dca.ts`, sourced from Dune, since I could test better with Dune.

### Method

Fills are identified by the keeper that pays the network fee (`gasBidSWW5zmwXs3gn8TG2ijzKkrwpyM7ucwjgDQst6`). The fee is the **net** token balance change of Jupiter's 24 fee authorities inside those transactions.

### Validation

- **Full day 2026-08-11:** `$1,521.46` through the adapter code path, `$1,521.32` recomputing the same Dune result independently, and `~$1,350` extrapolated from 250 keeper transactions sampled straight from RPC. That is ~1.5% of `Jupiter Aggregator` on the same days.
- **Against an independent third party:** Blockworks publishes a daily Jupiter limit-order revenue series (~99% V2) reading `$1,686 / $1,259 / $1,173` for 8–10 Aug 2026, i.e. 1.22%–1.64% of the aggregator. The 11 Aug figure above (1.49%) sits inside that band.
- `tsc --project tsconfig.json` clean. The legacy Allium half is unchanged and was not executed locally (no Allium key).

### Notable
1. **DCA and price/limit orders are not separated.** Jupiter keeps the order type off-chain and the V2 history API is per-wallet and JWT-gated, so the metric covers both. 
2. **`doublecounted: true` is new for this adapter.** These fees land in the same fee authorities that `fees/jupiter.ts` sweeps, so they are already inside `Jupiter Aggregator`.