### PR TITLE
sablier: rebuild the fee adapter on the real fee source

### DIFF
--- a/fees/sablier.ts
+++ b/fees/sablier.ts
@@ -1,92 +1,117 @@
-import { FetchOptions, SimpleAdapter } from "../adapters/types";
+import type { FetchOptions, SimpleAdapter } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
-import { request } from "graphql-request";
+import { postURL } from "../utils/fetchURL";
 
-const chainConfig: Record<string, { endpoint: string; chainId: number }> = {
-  [CHAIN.ETHEREUM]: {
-    endpoint: "https://indexer.hyperindex.xyz/53b7e25/v1/graphql",
-    chainId: 1,
-  },
-  [CHAIN.OPTIMISM]: {
-    endpoint: "https://indexer.hyperindex.xyz/53b7e25/v1/graphql",
-    chainId: 10,
-  },
-  [CHAIN.ARBITRUM]: {
-    endpoint: "https://indexer.hyperindex.xyz/53b7e25/v1/graphql",
-    chainId: 42161,
-  },
-  [CHAIN.BASE]: {
-    endpoint: "https://indexer.hyperindex.xyz/53b7e25/v1/graphql",
-    chainId: 8453,
-  },
+// Sablier charges one fee: a flat USD-denominated minimum, paid in native gas
+// token on claim. No percentage fee on streamed value. The broker fee in Lockup
+// <= v2.x went to third-party front-ends, never Sablier, and is gone in v3.0.
+//
+// Source is Sablier's fee indexer, deduped per fee-paying tx and gated on
+// 2025-02-03 (the day charging began). We sum native `amount`, not `amountUSD`
+// (cents), so pricing goes through DefiLlama. Do NOT use the streams indexer's
+// `fee` column -- it is the whole tx value, e.g. 232 ETH on a stream-NFT sale.
+
+const INDEXER = "https://indexer.hyperindex.xyz/7672d32/v1/graphql";
+
+// start = first fee-paying transaction on that chain, from the fee indexer.
+const CONFIG: Record<string, { chainId: number; start: string }> = {
+  [CHAIN.ETHEREUM]: { chainId: 1, start: "2025-02-05" },
+  [CHAIN.OPTIMISM]: { chainId: 10, start: "2025-02-03" },
+  [CHAIN.XDC]: { chainId: 50, start: "2025-02-21" },
+  [CHAIN.BSC]: { chainId: 56, start: "2025-02-08" },
+  [CHAIN.UNICHAIN]: { chainId: 130, start: "2025-08-14" },
+  [CHAIN.POLYGON]: { chainId: 137, start: "2025-02-25" },
+  [CHAIN.MONAD]: { chainId: 143, start: "2025-12-02" },
+  [CHAIN.SONIC]: { chainId: 146, start: "2025-11-05" },
+  [CHAIN.ERA]: { chainId: 324, start: "2025-02-03" },
+  [CHAIN.HYPERLIQUID]: { chainId: 999, start: "2025-10-22" },
+  [CHAIN.LIGHTLINK_PHOENIX]: { chainId: 1890, start: "2025-06-12" },
+  [CHAIN.ABSTRACT]: { chainId: 2741, start: "2025-02-04" },
+  [CHAIN.ROBINHOOD]: { chainId: 4663, start: "2026-07-26" },
+  [CHAIN.SSEED]: { chainId: 5330, start: "2025-05-05" },
+  [CHAIN.BASE]: { chainId: 8453, start: "2025-02-04" },
+  [CHAIN.MODE]: { chainId: 34443, start: "2025-05-07" },
+  [CHAIN.ARBITRUM]: { chainId: 42161, start: "2025-02-04" },
+  [CHAIN.AVAX]: { chainId: 43114, start: "2025-02-04" },
+  [CHAIN.SOPHON]: { chainId: 50104, start: "2025-07-25" },
+  [CHAIN.LINEA]: { chainId: 59144, start: "2025-02-16" },
+  [CHAIN.BERACHAIN]: { chainId: 80094, start: "2025-02-20" },
+  [CHAIN.BLAST]: { chainId: 81457, start: "2025-02-18" },
+  [CHAIN.CHILIZ]: { chainId: 88888, start: "2025-02-27" },
+  [CHAIN.SCROLL]: { chainId: 534352, start: "2025-02-03" },
 };
 
-// Fetch only fee-enabled contracts (exclude legacy)
-const CONTRACT_QUERY = `
-query getContracts($chainId: numeric!) {
-  Contract(where: {
-    chainId: { _eq: $chainId }
-    category: { _nin: ["LEGACY"] }
-  }) {
-    address
-    category
+const PAGE_SIZE = 1000;
+
+const buildQuery = (from: number, to: number, cursor: string) => `{
+  FeeTransaction(
+    where: {
+      timestamp: {_gte: "${new Date(from * 1000).toISOString()}", _lt: "${new Date(to * 1000).toISOString()}"}
+      id: {_gt: "${cursor}"}
+    }
+    order_by: {id: asc}
+    limit: ${PAGE_SIZE}
+  ) {
+    id
+    chainId
+    amount
   }
-}
-`;
+}`;
 
-async function getFeeContracts(chain: string) {
-  const endpoint = chainConfig[chain].endpoint;
-  const chainId = chainConfig[chain].chainId;
-  if (!endpoint || !chainId) return [];
-
-  const res = await request(endpoint, CONTRACT_QUERY, { chainId });
-  if (!res?.Contract) return [];
-
-  return res.Contract.map((c: any) => c.address);
+interface Row {
+  id: string;
+  chainId: string;
+  amount: string;
 }
 
-const fetch = async ({ chain, createBalances, getLogs }: FetchOptions) => {
-  const dailyFees = createBalances();
+const fetchWindow = async (from: number, to: number) => {
+  const all: Row[] = [];
+  let cursor = "";
+  while (true) {
+    const res: { data: { FeeTransaction: Row[] } } = await postURL(INDEXER, {
+      query: buildQuery(from, to, cursor),
+    });
+    const rows = res.data.FeeTransaction;
+    all.push(...rows);
+    if (rows.length < PAGE_SIZE) break;
+    cursor = rows[rows.length - 1].id;
+  }
+  return all;
+};
 
-  const targets = await getFeeContracts(chain);
-  if (!targets.length) return {};
+// Hold only the active window: keeping all of them grows unbounded on backfills,
+// and dropping on settle refetches per chain when chains run sequentially.
+let cached: { key: string; rows: Promise<Row[]> } | undefined;
 
-  const airdropLogs = await getLogs({
-    topics: ["0x1dcd2362ae467d43bf31cbcac0526c0958b23eb063e011ab49a5179c839ed9a9"],
-    targets,
-  });
+const getWindow = (from: number, to: number) => {
+  const key = `${from}-${to}`;
+  if (cached?.key !== key) cached = { key, rows: fetchWindow(from, to) };
+  return cached.rows;
+};
 
-  const streamLogs = await getLogs({
-    topics: ["0x1a7b0d6c8f96b874563b711cf97793fe3be5dc42dbd1e0720ce40f326918e817"],
-    targets,
-  });
-
-  const lockupLogs = await getLogs({
-    topics: ["0x40b88e5c41c5a97ffb7b6ef88a0a2d505aa0c634cf8a0275cb236ea7dd87ed4d"],
-    targets,
-  });
-
-  dailyFees.addUSDValue(
-    airdropLogs.length * 3 +
-    streamLogs.length +
-    lockupLogs.length
-  );
+const fetch = async (options: FetchOptions) => {
+  const dailyFees = options.createBalances();
+  const { chainId } = CONFIG[options.chain];
+  const rows = await getWindow(options.fromTimestamp, options.toTimestamp);
+  for (const r of rows) if (Number(r.chainId) === chainId) dailyFees.addGasToken(r.amount);
 
   return {
     dailyFees,
     dailyRevenue: dailyFees,
+    dailyProtocolRevenue: dailyFees,
   };
 };
 
 const adapter: SimpleAdapter = {
   version: 2,
-  fetch,
   pullHourly: true,
-  adapter: chainConfig as any,
   methodology: {
-    Fees: "Interface and contract fees paid by users for Lockup, Flow, and Airdrop products.",
-    Revenue: "Portion of collected fees attributed to Sablier.",
+    Fees: "The flat fee users pay when they claim tokens from a Sablier stream or airdrop. It is charged in the chain's native coin and targets a fixed dollar amount (around $1, waived to $0 on most chains since 22 April 2026, though the Sablier app still attaches it by default). Nothing is charged as a percentage of the tokens being streamed. Counted from 3 February 2025, the day Sablier began charging.",
+    Revenue: "All of it. The fee is Sablier's only income and none of it is shared with liquidity providers, stream creators, or integrators.",
+    ProtocolRevenue: "All of it goes to the Sablier treasury. There is no token buyback, burn, or staking distribution, so holders receive nothing.",
   },
+  adapter: CONFIG,
+  fetch,
 };
 
 export default adapter;

--- a/fees/sablier.ts
+++ b/fees/sablier.ts
@@ -1,6 +1,9 @@
 import type { FetchOptions, SimpleAdapter } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
+import { METRIC } from "../helpers/metrics";
 import { postURL } from "../utils/fetchURL";
+
+const CLAIM_FEES_TO_TREASURY = "Claim Fees To Treasury";
 
 // Sablier charges one fee: a flat USD-denominated minimum, paid in native gas
 // token on claim. No percentage fee on streamed value. The broker fee in Lockup
@@ -85,20 +88,34 @@ let cached: { key: string; rows: Promise<Row[]> } | undefined;
 
 const getWindow = (from: number, to: number) => {
   const key = `${from}-${to}`;
-  if (cached?.key !== key) cached = { key, rows: fetchWindow(from, to) };
+  if (cached?.key !== key)
+    cached = {
+      key,
+      rows: fetchWindow(from, to).catch((e) => {
+        // drop it so the next call refetches instead of replaying the failure
+        if (cached?.key === key) cached = undefined;
+        throw e;
+      }),
+    };
   return cached.rows;
 };
 
 const fetch = async (options: FetchOptions) => {
+  // labels differ by dimension: source on fees, destination on revenue
   const dailyFees = options.createBalances();
+  const dailyRevenue = options.createBalances();
   const { chainId } = CONFIG[options.chain];
   const rows = await getWindow(options.fromTimestamp, options.toTimestamp);
-  for (const r of rows) if (Number(r.chainId) === chainId) dailyFees.addGasToken(r.amount);
+  for (const r of rows) {
+    if (Number(r.chainId) !== chainId) continue;
+    dailyFees.addGasToken(r.amount, METRIC.DEPOSIT_WITHDRAW_FEES);
+    dailyRevenue.addGasToken(r.amount, CLAIM_FEES_TO_TREASURY);
+  }
 
   return {
     dailyFees,
-    dailyRevenue: dailyFees,
-    dailyProtocolRevenue: dailyFees,
+    dailyRevenue,
+    dailyProtocolRevenue: dailyRevenue,
   };
 };
 
@@ -109,6 +126,17 @@ const adapter: SimpleAdapter = {
     Fees: "The flat fee users pay when they claim tokens from a Sablier stream or airdrop. It is charged in the chain's native coin and targets a fixed dollar amount (around $1, waived to $0 on most chains since 22 April 2026, though the Sablier app still attaches it by default). Nothing is charged as a percentage of the tokens being streamed. Counted from 3 February 2025, the day Sablier began charging.",
     Revenue: "All of it. The fee is Sablier's only income and none of it is shared with liquidity providers, stream creators, or integrators.",
     ProtocolRevenue: "All of it goes to the Sablier treasury. There is no token buyback, burn, or staking distribution, so holders receive nothing.",
+  },
+  breakdownMethodology: {
+    Fees: {
+      [METRIC.DEPOSIT_WITHDRAW_FEES]: "Flat native-token fee charged when a recipient claims from a Lockup stream, a Flow stream, or an airdrop campaign",
+    },
+    Revenue: {
+      [CLAIM_FEES_TO_TREASURY]: "The whole claim fee; none of it is shared with LPs, stream creators, or integrators",
+    },
+    ProtocolRevenue: {
+      [CLAIM_FEES_TO_TREASURY]: "Swept to the Sablier treasury via the comptroller",
+    },
   },
   adapter: CONFIG,
   fetch,


### PR DESCRIPTION
## Changes

* Rebuilt `fees/sablier.ts` on Sablier's fee indexer instead of log counts × hardcoded fees.
* Removed the dead airdrop path, stale fee constants, `LEGACY` filter, and `$0` fallbacks.
* Added the **2025-02-03** fee start and chain-specific starts across **24 chains**.
* Added `dailyProtocolRevenue`; all fees are protocol revenue with no supply-side split.
* Uses native-token `amount` via `addGasToken` for DefiLlama pricing.
* Shares one indexer request per window across chains.

## Verification

* `pnpm test fees sablier` passes all 24 hourly slots: **$49.53** for 2026-08-04 16:00 → 2026-08-05 16:00 UTC.
* Direct indexer query: **$45.30** for 2026-08-04; global daily fees are within the observed **$31–73** range.
* Historical on-chain/indexer reconciliation confirms **$175,213.84** all-time fees.
