### PR TITLE
flowx: throw when the fees api returns 0 instead of publishing it

### DIFF
--- a/fees/flowx-finance/index.ts
+++ b/fees/flowx-finance/index.ts
@@ -36,9 +36,12 @@ const fetch = async ({ fromTimestamp, toTimestamp }: FetchOptions) => {
     endTime: toTimestamp * 1000,
   });
   const totalFees: IExchangeStats = statsRes.exchangeTotalFeesInPeriod;
-  return {
-    dailyFees: totalFees.totalFees,
-  };
+  const dailyFees = Number(totalFees?.totalFees);
+  if (!Number.isFinite(dailyFees) || dailyFees <= 0)
+    throw new Error(
+      `flowx-finance: api.flowx.finance returned no usable fees (${totalFees?.totalFees}) for ${fromTimestamp}-${toTimestamp}`,
+    );
+  return { dailyFees };
 };
 
 const adapter: SimpleAdapter = {

--- a/fees/flowx-v3/index.ts
+++ b/fees/flowx-v3/index.ts
@@ -42,9 +42,12 @@ const fetch = async ({ fromTimestamp, toTimestamp }: FetchOptions) => {
     endTime: toTimestamp * 1000,
   });
   const totalFees: IExchangeStats = statsRes.getClmmExchangeTotalFeesInPeriod;
-  return {
-    dailyFees: totalFees.totalFees,
-  };
+  const dailyFees = Number(totalFees?.totalFees);
+  if (!Number.isFinite(dailyFees) || dailyFees <= 0)
+    throw new Error(
+      `flowx-v3: api.flowx.finance returned no usable fees (${totalFees?.totalFees}) for ${fromTimestamp}-${toTimestamp}`,
+    );
+  return { dailyFees };
 };
 
 const adapter: SimpleAdapter = {


### PR DESCRIPTION
Fixes #8732

Both FlowX fee adapters take `totalFees` off `api.flowx.finance/flowx-be/graphql`
and pass it to `dailyFees` unchecked. That endpoint answers `"0"` for every window
now, so both have been writing fabricated `$0` days since January.

```
fees/flowx-v3        last non-zero 2026-01-14   210 zero days   priorZeros 0/328
fees/flowx-finance   last non-zero 2026-01-18   206 zero days   priorZeros 0/338
```

Neither had reported a single zero day before this, and the volume adapters for
the same two protocols read from Dune rather than the first-party API and are
still reporting every day (`dexs/flowx-v3` $34,633 and `dexs/flowx-finance`
$35,836 on 2026-08-11), so the protocol is trading and only the fee transport is
gone.

Checked it isn't a units or naming change before writing this: seconds instead of
ms also returns `"0"`, a one-year window in ms returns `BusinessLogicError` while
the same in seconds returns `"0"` (so the server does parse the ms input), and
both field names are still the only valid ones on the schema. Introspection is
disabled so there's no replacement field to repoint at.

Since `priorZeros` is 0 on both, a zero out of this endpoint is never a real quiet
day, so throwing can't suppress legitimate data. Same shape as #8686.

Before:

```
$ npm test fees flowx-v3          SUI  Daily fees: 0.00
$ npm test fees flowx-finance     SUI  Daily fees: 0.00
```

After:

```
$ npm test fees flowx-v3
Error: flowx-v3: api.flowx.finance returned no usable fees (0) for 1786459375-1786545775

$ npm test fees flowx-finance
Error: flowx-finance: api.flowx.finance returned no usable fees (0) for 1786459376-1786545776
```

Parsing once and testing `!Number.isFinite(v) || v <= 0` rather than `!(v > 0)`
so `"Infinity"` and overflowing values like `"1e999"` are rejected too.
