### PR TITLE
feat(strata-markets): add nOPAL (Nest BlackOpal LiquidStone II) fee tracking

### DIFF
--- a/fees/strata-markets/index.ts
+++ b/fees/strata-markets/index.ts
@@ -66,6 +66,15 @@ const CDOS: CDOConfig[] = [
     srt: "0x35bFF778d3fc53a561486BF28e761428499232Eb",
     start: "2026-05-23",
   },
+  {
+    name: "nOPAL",
+    cdo: "0xaE212D8515BA65C719f23dBad6bF73B74d4e4edE",
+    accounting: "0xB6F3d2deF3058d4Faf07E7104DE2f69c638f2BF7",
+    strategy: "0x5aeCBb5719a9468CdCfa6673d1DDC1Cf72a5a4aA",
+    jrt: "0x1b2b8cFEF0b7B1Fad216b55fefeEb0c3349Da141",
+    srt: "0x8a646Edc4633ADBA5Ec87DedaF3Af958e268FE96",
+    start: "2026-07-09",
+  },
 ];
 
 // events 


### PR DESCRIPTION
Adds the nOPAL CDO to the Strata Markets fee adapter.

nOPAL is a Nest Credit RWA vault (BlackOpal LiquidStone II) deployed on Ethereum. Base asset is USDC, with a 5% performance fee (`reserveBps = 5e16`).

| Contract | Address |
|---|---|
| CDO | `0xaE212D8515BA65C719f23dBad6bF73B74d4e4edE` |
| Accounting | `0xB6F3d2deF3058d4Faf07E7104DE2f69c638f2BF7` (DiscreteAccounting) |
| Strategy | `0x5aeCBb5719a9468CdCfa6673d1DDC1Cf72a5a4aA` (NestOpalStrategy) |
| JRT | `0x1b2b8cFEF0b7B1Fad216b55fefeEb0c3349Da141` |
| SRT | `0x8a646Edc4633ADBA5Ec87DedaF3Af958e268FE96` |

nOPAL uses a Nest Accountant with discrete rate updates. The `allowNegativeValue: true` flag (merged in #8728) already handles potential NAV oscillation correctly.