### PR TITLE
feat(aggregators): add Vurto Swap

### DIFF
--- a/aggregators/vurto/index.ts
+++ b/aggregators/vurto/index.ts
@@ -17,8 +17,8 @@ import { httpGet } from "../../utils/fetchURL";
 const API = "https://swap.vurto.cc/api/stats/daily-volume";
 
 // The day per-swap USD volume started being recorded. Earlier days are not
-// zero-volume days, they are days without a record, so the adapter refuses them
-// instead of claiming a zero that would be indistinguishable from no trading.
+// zero-volume days, they are days without a record, so the adapter does not
+// claim them.
 const START = "2026-08-11";
 
 const CHAIN_IDS: Record<string, number> = {
@@ -33,19 +33,35 @@ const CHAIN_IDS: Record<string, number> = {
   [CHAIN.AVAX]: 43114,
 };
 
+const VOLUME_LABEL = "Swap volume";
+
 const fetch = async (options: FetchOptions): Promise<FetchResult> => {
   const chainId = CHAIN_IDS[options.chain];
   const res = await httpGet(`${API}?chainId=${chainId}&timestamp=${options.startOfDay}`);
+  const dailyVolume = options.createBalances();
   // The endpoint answers 0 on a day without a confirmed swap and never errors,
   // so a quiet day does not break the series.
-  return { dailyVolume: res?.dailyVolume ?? 0 };
+  dailyVolume.addUSDValue(res?.dailyVolume ?? 0, VOLUME_LABEL);
+  return { dailyVolume };
+};
+
+const methodology = {
+  Volume: "Sum of the USD value delivered by every confirmed swap routed through Vurto, priced at the moment each swap settled.",
+};
+
+const breakdownMethodology = {
+  Volume: {
+    [VOLUME_LABEL]: "USD value of the output of every confirmed swap, across the single, Double In, Double Out and basket modes.",
+  },
 };
 
 const adapter: SimpleAdapter = {
   version: 1,
-  adapter: Object.fromEntries(
-    Object.keys(CHAIN_IDS).map((chain) => [chain, { fetch, start: START }]),
-  ),
+  chains: Object.keys(CHAIN_IDS),
+  start: START,
+  fetch,
+  methodology,
+  breakdownMethodology,
 };
 
 export default adapter;

--- a/aggregators/vurto/index.ts
+++ b/aggregators/vurto/index.ts
@@ -33,15 +33,13 @@ const CHAIN_IDS: Record<string, number> = {
   [CHAIN.AVAX]: 43114,
 };
 
-const VOLUME_LABEL = "Swap volume";
-
 const fetch = async (options: FetchOptions): Promise<FetchResult> => {
   const chainId = CHAIN_IDS[options.chain];
   const res = await httpGet(`${API}?chainId=${chainId}&timestamp=${options.startOfDay}`);
   const dailyVolume = options.createBalances();
   // The endpoint answers 0 on a day without a confirmed swap and never errors,
   // so a quiet day does not break the series.
-  dailyVolume.addUSDValue(res?.dailyVolume ?? 0, VOLUME_LABEL);
+  dailyVolume.addUSDValue(res?.dailyVolume ?? 0);
   return { dailyVolume };
 };
 
@@ -49,11 +47,6 @@ const methodology = {
   Volume: "Sum of the USD value delivered by every confirmed swap routed through Vurto, priced at the moment each swap settled.",
 };
 
-const breakdownMethodology = {
-  Volume: {
-    [VOLUME_LABEL]: "USD value of the output of every confirmed swap, across the single, Double In, Double Out and basket modes.",
-  },
-};
 
 const adapter: SimpleAdapter = {
   version: 1,
@@ -61,7 +54,6 @@ const adapter: SimpleAdapter = {
   start: START,
   fetch,
   methodology,
-  breakdownMethodology,
 };
 
 export default adapter;

--- a/aggregators/vurto/index.ts
+++ b/aggregators/vurto/index.ts
@@ -1,0 +1,51 @@
+import { FetchOptions, FetchResult, SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import { httpGet } from "../../utils/fetchURL";
+
+/**
+ * Vurto Swap is a non-custodial meta-aggregator. It quotes the same trade
+ * across several liquidity providers at once and ranks the routes by the amount
+ * that actually reaches the user's wallet, after gas and every fee.
+ *
+ * Volume comes from Vurto's own public API rather than from on-chain events,
+ * which the aggregator guidelines allow when on-chain tracking is impractical.
+ * It is impractical here: only the many-to-many basket mode routes through the
+ * VurtoSwapRouter contract, while single swaps and the two Double modes are
+ * signed straight against the winning provider's own router, so there is no
+ * single contract that observes every trade.
+ */
+const API = "https://swap.vurto.cc/api/stats/daily-volume";
+
+// The day per-swap USD volume started being recorded. Earlier days are not
+// zero-volume days, they are days without a record, so the adapter refuses them
+// instead of claiming a zero that would be indistinguishable from no trading.
+const START = "2026-08-11";
+
+const CHAIN_IDS: Record<string, number> = {
+  [CHAIN.ETHEREUM]: 1,
+  [CHAIN.OPTIMISM]: 10,
+  [CHAIN.BSC]: 56,
+  [CHAIN.XDAI]: 100,
+  [CHAIN.UNICHAIN]: 130,
+  [CHAIN.POLYGON]: 137,
+  [CHAIN.BASE]: 8453,
+  [CHAIN.ARBITRUM]: 42161,
+  [CHAIN.AVAX]: 43114,
+};
+
+const fetch = async (options: FetchOptions): Promise<FetchResult> => {
+  const chainId = CHAIN_IDS[options.chain];
+  const res = await httpGet(`${API}?chainId=${chainId}&timestamp=${options.startOfDay}`);
+  // The endpoint answers 0 on a day without a confirmed swap and never errors,
+  // so a quiet day does not break the series.
+  return { dailyVolume: res?.dailyVolume ?? 0 };
+};
+
+const adapter: SimpleAdapter = {
+  version: 1,
+  adapter: Object.fromEntries(
+    Object.keys(CHAIN_IDS).map((chain) => [chain, { fetch, start: START }]),
+  ),
+};
+
+export default adapter;


### PR DESCRIPTION
Vurto Swap is a non-custodial meta-aggregator on 9 EVM chains. It quotes the same trade across several liquidity providers at once (Velora, KyberSwap, 1inch and CoW Protocol) and ranks the routes by the amount that actually reaches the user's wallet, after gas and every fee.

**Site:** https://swap.vurto.cc

### Data source

Volume comes from Vurto's own public API rather than from on-chain events, which `aggregators/GUIDELINES.md` allows when on-chain tracking is impractical.

It is impractical here: only the many-to-many basket mode routes through our own `VurtoSwapRouter` contract. Single swaps and both Double modes are signed straight against the winning provider's own router, so there is no single contract that observes every trade. Tracking fee transfers does not close the gap either, because our fee only exists when the winning route beats the runner-up, so a legitimate trade can settle without any transfer of ours.

The endpoint is public and needs no key:

```
GET https://swap.vurto.cc/api/stats/daily-volume?chainId=8453&timestamp=<startOfDay>
```

It answers `0` on a day without a confirmed swap and never errors, so a quiet day does not break the series.

### Start date

`2026-08-11` is the day per-swap USD volume started being recorded. Earlier days are not zero-volume days, they are days without a record, so the adapter does not claim them.

### Test run

```
$ npm test aggregators/vurto

chain     | Daily volume | Start Time
arbitrum  | 8.13 k       | 11/8/2026
Aggregate | 8.13 k
```
