### PR TITLE
[change] GateSwap - replace on-chain parsing with API data

### DIFF
--- a/aggregators/gateswap/index.ts
+++ b/aggregators/gateswap/index.ts
@@ -1,134 +1,20 @@
-import { Dependencies, FetchOptions, SimpleAdapter } from "../../adapters/types";
-import { CHAIN } from "../../helpers/chains";
-import ADDRESSES from "../../helpers/coreAssets.json";
-import { queryDuneSql } from "../../helpers/dune";
-
-// Solana Gate Swap programs
-const SOL_ALPHA_PROGRAM = "4w3DZU3zBu7149sTmEZ2XFTNxuvuX3F9f9heQFi6YtS6";
-const SOL_NATIVE_PROGRAM = "2rwUXt3JeyPtUBjH5pscZLRDBoh9WADfXq7gyoDnLcC4";
-// Jupiter route txs have no Gate program ID, identified by fee transfer to this address
-const SOL_FEE_COLLECTOR = "BmDFarMxxp6ZBMZc768iWXbSEiGBVb4UvnE7hEUG7at7";
-
-const GATE_SWAP_ROUTER = "0x0000000025e904C59aFDB33d50F982d46A7FF880";
-const GATE_SWAP_ROUTER_ZKSYNC = "0x00000000599e65803D946115C7f817E2e8C7656a";
-// Alpha routers by chain
-const ALPHA_ROUTER = "0x000000003d55f1535A0116376858e6008De1435a"; // ETH,BSC,Base,ARB,OP,AVAX,Polygon,Bera,GateLayer,ENI,WC
-const ALPHA_ROUTER_LINEA = "0xefE7a50f92b089B06d0e6cbCC85D7584424921B2";
-const ALPHA_ROUTER_ROBINHOOD = "0x0000000055eC25287227AA8693471eE5f89221BE";
-const ALPHA_ROUTER_ZKSYNC = "0xc438733Eb259D18bCA253495b209C3cd82B73902";
-
-const EVENT_SWAP_DETAIL = "event SwapDetail(uint256 amountIn,uint256 amountOut,address tokenIn,address tokenOut,address sender,address receiver)";
-const EVENT_ALPHA_ORDER = "event Order(uint160 indexed orderId,address tokenIn,address tokenOut,uint256 amountIn,uint256 amountOut)";
-const EEE_NATIVE_TOKEN = "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee";
-
-type ChainConfig = {
-  start: string;
-  routers: string[];
-  alphaRouters?: string[];
-};
-
-const config: Record<string, ChainConfig> = {
-  [CHAIN.ETHEREUM]: { start: "2026-02-28", routers: [GATE_SWAP_ROUTER], alphaRouters: [ALPHA_ROUTER] },
-  [CHAIN.BSC]: { start: "2026-02-28", routers: [GATE_SWAP_ROUTER], alphaRouters: [ALPHA_ROUTER] },
-  [CHAIN.BASE]: { start: "2026-02-28", routers: [GATE_SWAP_ROUTER], alphaRouters: [ALPHA_ROUTER] },
-  [CHAIN.ARBITRUM]: { start: "2026-02-28", routers: [GATE_SWAP_ROUTER], alphaRouters: [ALPHA_ROUTER] },
-  [CHAIN.AVAX]: { start: "2026-02-28", routers: [GATE_SWAP_ROUTER], alphaRouters: [ALPHA_ROUTER] },
-  [CHAIN.BLAST]: { start: "2026-02-28", routers: [GATE_SWAP_ROUTER] },
-  [CHAIN.LINEA]: { start: "2025-09-10", routers: [GATE_SWAP_ROUTER], alphaRouters: [ALPHA_ROUTER_LINEA] },
-  [CHAIN.OPTIMISM]: { start: "2026-02-28", routers: [GATE_SWAP_ROUTER], alphaRouters: [ALPHA_ROUTER] },
-  [CHAIN.GATE_LAYER]: { start: "2026-02-28", routers: [GATE_SWAP_ROUTER], alphaRouters: [ALPHA_ROUTER] },
-  [CHAIN.BERACHAIN]: { start: "2026-02-28", routers: [GATE_SWAP_ROUTER], alphaRouters: [ALPHA_ROUTER] },
-  [CHAIN.ENI]: { start: "2026-02-28", routers: [GATE_SWAP_ROUTER], alphaRouters: [ALPHA_ROUTER] },
-  [CHAIN.SONIC]: { start: "2026-02-28", routers: [GATE_SWAP_ROUTER], alphaRouters: [ALPHA_ROUTER] },
-  [CHAIN.POLYGON]: { start: "2026-03-04", routers: [GATE_SWAP_ROUTER], alphaRouters: [ALPHA_ROUTER] },
-  [CHAIN.ROBINHOOD]: { start: "2026-07-15", routers: [GATE_SWAP_ROUTER], alphaRouters: [ALPHA_ROUTER_ROBINHOOD] },
-  [CHAIN.WC]: { start: "2026-02-28", routers: [GATE_SWAP_ROUTER], alphaRouters: [ALPHA_ROUTER] },
-  [CHAIN.ERA]: { start: "2025-09-01", routers: [GATE_SWAP_ROUTER_ZKSYNC], alphaRouters: [ALPHA_ROUTER_ZKSYNC] },
-};
-
-function addTokenAmount(balances: any, token: string, amount: string) {
-  if (!amount || amount === "0") return;
-  const normalizedToken = token.toLowerCase();
-  if (normalizedToken === ADDRESSES.null || normalizedToken === EEE_NATIVE_TOKEN) balances.addGasToken(amount);
-  else balances.add(token, amount);
-}
+import { FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { gateSwapChainConfig, getGateSwapChainData, prefetchGateSwapDimensions } from "../../helpers/gateswap";
 
 async function fetch(options: FetchOptions) {
-  const { createBalances, chain } = options;
-  const dailyVolume = createBalances();
-  const chainConfig = config[chain];
-
-  const swapDetailLogs = await options.getLogs({
-    targets: chainConfig.routers,
-    eventAbi: EVENT_SWAP_DETAIL,
-    flatten: true,
-  });
-
-  swapDetailLogs.forEach((log: any) => addTokenAmount(dailyVolume, log.tokenOut, log.amountOut));
-
-  if (chainConfig.alphaRouters?.length) {
-    const alphaOrderLogs = await options.getLogs({
-      targets: chainConfig.alphaRouters,
-      eventAbi: EVENT_ALPHA_ORDER,
-      flatten: true,
-    });
-
-    alphaOrderLogs.forEach((log: any) => addTokenAmount(dailyVolume, log.tokenOut, log.amountOut));
-  }
-
-  return { dailyVolume };
+  return { dailyVolume: getGateSwapChainData(options).volumeUsd };
 }
-
-async function fetchSolana(options: FetchOptions) {
-  const data = await queryDuneSql(
-    options,
-    `
-    WITH gateswap_txs AS (
-      -- Native + Alpha: identified by Gate program ID in account_keys
-      SELECT DISTINCT id AS tx_id
-      FROM solana.transactions
-      WHERE TIME_RANGE
-        AND success = true
-        AND (
-          CONTAINS(account_keys, '${SOL_ALPHA_PROGRAM}')
-          OR CONTAINS(account_keys, '${SOL_NATIVE_PROGRAM}')
-        )
-
-      UNION
-
-      -- Jupiter route: no Gate program ID, identified by fee transfer to fee collector
-      SELECT DISTINCT tx_id
-      FROM solana.account_activity
-      WHERE TIME_RANGE
-        AND tx_success
-        AND address = '${SOL_FEE_COLLECTOR}'
-        AND balance_change > 0
-    )
-    SELECT COALESCE(SUM(t.amount_usd), 0) AS daily_volume
-    FROM dex_solana.trades t
-    JOIN gateswap_txs g ON t.tx_id = g.tx_id
-    WHERE TIME_RANGE
-    `,
-  );
-
-  const dailyVolume = options.createBalances();
-  dailyVolume.addUSDValue(data[0]?.daily_volume ?? 0);
-  return { dailyVolume };
-}
-
-const evmAdapter = Object.fromEntries(Object.entries(config).map(([chain, { start }]) => [chain, { fetch, start }]));
 
 const adapter: SimpleAdapter = {
-  version: 1,
-  dependencies: [Dependencies.DUNE],
-  isExpensiveAdapter: true,
+  version: 2,
+  pullHourly: true,
+  prefetch: prefetchGateSwapDimensions,
   methodology: {
-    Volume: "Gate Swap aggregator volume: EVM chains use SwapDetail/Alpha Order events; Solana uses dex_solana.trades for txs identified by Gate program IDs (自研/Alpha) or fee transfers to the Gate fee collector (Jupiter route).",
+    Volume: "USD value of successfully executed trades routed through Gate Swap, reported by the Gate Swap API for each hourly UTC window.",
   },
-  adapter: {
-    ...evmAdapter,
-    [CHAIN.SOLANA]: { fetch: fetchSolana, start: "2026-02-28" },
-  },
+  adapter: Object.fromEntries(
+    Object.entries(gateSwapChainConfig).map(([chain, { start }]) => [chain, { fetch, start }]),
+  ),
 };
 
 export default adapter;

--- a/fees/gateswap/index.ts
+++ b/fees/gateswap/index.ts
@@ -13,11 +13,11 @@ async function fetch(options: FetchOptions) {
   const dailyProtocolRevenue = options.createBalances();
   const dailySupplySideRevenue = options.createBalances();
 
-  dailyFees.addUSDValue(Number(row.feesUsd), SWAP_FEES);
-  dailyUserFees.addUSDValue(Number(row.userFeesUsd), SWAP_FEES);
-  dailyRevenue.addUSDValue(Number(row.revenueUsd), SWAP_FEES_TO_PROTOCOL);
-  dailyProtocolRevenue.addUSDValue(Number(row.protocolRevenueUsd), SWAP_FEES_TO_PROTOCOL);
-  dailySupplySideRevenue.addUSDValue(Number(row.supplySideRevenueUsd), SWAP_FEES_TO_INTEGRATORS);
+  dailyFees.addUSDValue(row.feesUsd, SWAP_FEES);
+  dailyUserFees.addUSDValue(row.userFeesUsd, SWAP_FEES);
+  dailyRevenue.addUSDValue(row.revenueUsd, SWAP_FEES_TO_PROTOCOL);
+  dailyProtocolRevenue.addUSDValue(row.protocolRevenueUsd, SWAP_FEES_TO_PROTOCOL);
+  dailySupplySideRevenue.addUSDValue(row.supplySideRevenueUsd, SWAP_FEES_TO_INTEGRATORS);
 
   return { dailyFees, dailyUserFees, dailyRevenue, dailyProtocolRevenue, dailySupplySideRevenue };
 }

--- a/fees/gateswap/index.ts
+++ b/fees/gateswap/index.ts
@@ -1,151 +1,48 @@
-import { Dependencies, FetchOptions, SimpleAdapter } from "../../adapters/types";
-import { CHAIN } from "../../helpers/chains";
-import ADDRESSES from "../../helpers/coreAssets.json";
-import { getSolanaReceived } from "../../helpers/token";
+import { FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { gateSwapChainConfig, getGateSwapChainData, prefetchGateSwapDimensions } from "../../helpers/gateswap";
 
-// Solana fee collector confirmed from test files in gateio-service-web3-build and gateio_service_web3_swap_job
-const SOL_FEE_COLLECTOR = "BmDFarMxxp6ZBMZc768iWXbSEiGBVb4UvnE7hEUG7at7";
-
-// Standard EVM executor contracts (all chains except zkSync ERA)
-const EVM_EXECUTORS = [
-  "0x00000000AE2193C4ac6521146B1ADaFe9b43361D",
-  "0x00000000D204b71c77e1fA21cF0892C6590cA78b",
-  "0x000000003645ebC3cf33167962D5477F54f4c459",
-  "0x0000000071647c6C1AE028daf9f80c000bEac2cC",
-  "0x000000003FB974cfdd8f715353B005628b97bFA3",
-  "0x00000000f9FF568cF0362FDfd1d2567C1E10fe0d",
-];
-
-// zkSync ERA executor contracts (separate deployment)
-const ZK_EXECUTORS = [
-  "0x00000000d775b5a65b1e51a0105eab5010B6AA85",
-  "0x000000009f4317D004E69653FE4b36D39539B1C6",
-  "0x0000000006b30ec04411E405803f7B249a76E0A0",
-  "0x000000003bFfDA9D8E05dCEeBe2Ece70c9bDa854",
-  "0x0000000036749ccbf6c63f9d957C8DfF6213cb74",
-  "0x00000000D2650fc4c90a32Dfcc70b0B7c842D94C",
-];
-
-const EVENT_SWAP_WITH_FEE = "event SwapWithFee(address indexed token,address indexed feeAddr,uint256 indexed amount)";
-const EEE_NATIVE_TOKEN = "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee";
 const SWAP_FEES = "Swap Fees";
 const SWAP_FEES_TO_PROTOCOL = "Swap Fees To Protocol";
-
-type ChainConfig = {
-  start: string;
-  feeTargets: string[];
-};
-
-const config: Record<string, ChainConfig> = {
-  [CHAIN.ETHEREUM]: { start: "2026-02-28", feeTargets: EVM_EXECUTORS },
-  [CHAIN.BSC]: { start: "2026-02-28", feeTargets: EVM_EXECUTORS },
-  [CHAIN.BASE]: { start: "2026-02-28", feeTargets: EVM_EXECUTORS },
-  [CHAIN.ARBITRUM]: { start: "2026-02-28", feeTargets: EVM_EXECUTORS },
-  [CHAIN.AVAX]: { start: "2026-02-28", feeTargets: EVM_EXECUTORS },
-  [CHAIN.BLAST]: { start: "2026-02-28", feeTargets: EVM_EXECUTORS },
-  [CHAIN.LINEA]: { start: "2025-09-10", feeTargets: EVM_EXECUTORS },
-  [CHAIN.OPTIMISM]: { start: "2026-02-28", feeTargets: EVM_EXECUTORS },
-  [CHAIN.GATE_LAYER]: { start: "2026-02-28", feeTargets: EVM_EXECUTORS },
-  [CHAIN.BERACHAIN]: { start: "2026-02-28", feeTargets: EVM_EXECUTORS },
-  [CHAIN.ENI]: { start: "2026-02-28", feeTargets: EVM_EXECUTORS },
-  [CHAIN.SONIC]: { start: "2026-02-28", feeTargets: EVM_EXECUTORS },
-  [CHAIN.POLYGON]: { start: "2026-03-04", feeTargets: EVM_EXECUTORS },
-  // Robinhood Alpha fees are charged off-chain before execution and emit no on-chain fee event.
-  [CHAIN.ROBINHOOD]: { start: "2026-07-15", feeTargets: EVM_EXECUTORS },
-  [CHAIN.WC]: { start: "2026-02-28", feeTargets: EVM_EXECUTORS },
-  [CHAIN.ERA]: { start: "2025-09-01", feeTargets: ZK_EXECUTORS },
-};
-
-function getAddressFromTopic(topic: string) {
-  return `0x${topic.slice(-40)}`;
-}
-
-function parseSwapWithFeeLog(log: any) {
-  if (log.topics?.length !== 4) return undefined;
-  return {
-    token: getAddressFromTopic(log.topics[1]),
-    amount: BigInt(log.topics[3]).toString(),
-  };
-}
-
-function addFeeAmount(balances: any, token: string, amount: string, label: string) {
-  if (!amount || amount === "0") return;
-  const normalizedToken = token.toLowerCase();
-  if (normalizedToken === ADDRESSES.null || normalizedToken === EEE_NATIVE_TOKEN) balances.addGasToken(amount, label);
-  else balances.add(token, amount, label);
-}
+const SWAP_FEES_TO_INTEGRATORS = "Swap Fees To Integrators";
 
 async function fetch(options: FetchOptions) {
-  const { createBalances, chain } = options;
-  const dailyFees = createBalances();
-  const dailyUserFees = createBalances();
-  const dailyRevenue = createBalances();
-  const dailyProtocolRevenue = createBalances();
-  const chainConfig = config[chain];
+  const row = getGateSwapChainData(options);
+  const dailyFees = options.createBalances();
+  const dailyUserFees = options.createBalances();
+  const dailyRevenue = options.createBalances();
+  const dailyProtocolRevenue = options.createBalances();
+  const dailySupplySideRevenue = options.createBalances();
 
-  if (!chainConfig.feeTargets.length) return { dailyFees, dailyUserFees, dailyRevenue, dailyProtocolRevenue };
+  dailyFees.addUSDValue(Number(row.feesUsd), SWAP_FEES);
+  dailyUserFees.addUSDValue(Number(row.userFeesUsd), SWAP_FEES);
+  dailyRevenue.addUSDValue(Number(row.revenueUsd), SWAP_FEES_TO_PROTOCOL);
+  dailyProtocolRevenue.addUSDValue(Number(row.protocolRevenueUsd), SWAP_FEES_TO_PROTOCOL);
+  dailySupplySideRevenue.addUSDValue(Number(row.supplySideRevenueUsd), SWAP_FEES_TO_INTEGRATORS);
 
-  const logs = await options.getLogs({
-    targets: chainConfig.feeTargets,
-    eventAbi: EVENT_SWAP_WITH_FEE,
-    onlyArgs: false,
-    flatten: true,
-    cacheInCloud: true,
-  });
-
-  logs.forEach((log: any) => {
-    const fee = parseSwapWithFeeLog(log);
-    if (!fee) return;
-    addFeeAmount(dailyFees, fee.token, fee.amount, SWAP_FEES);
-    addFeeAmount(dailyUserFees, fee.token, fee.amount, SWAP_FEES);
-    addFeeAmount(dailyRevenue, fee.token, fee.amount, SWAP_FEES_TO_PROTOCOL);
-    addFeeAmount(dailyProtocolRevenue, fee.token, fee.amount, SWAP_FEES_TO_PROTOCOL);
-  });
-
-  return { dailyFees, dailyUserFees, dailyRevenue, dailyProtocolRevenue };
+  return { dailyFees, dailyUserFees, dailyRevenue, dailyProtocolRevenue, dailySupplySideRevenue };
 }
-
-async function fetchSolana(options: FetchOptions) {
-  const dailyFees = await getSolanaReceived({ options, target: SOL_FEE_COLLECTOR });
-  return {
-    dailyFees,
-    dailyUserFees: dailyFees.clone(),
-    dailyRevenue: dailyFees.clone(),
-    dailyProtocolRevenue: dailyFees.clone(),
-  };
-}
-
-const breakdownMethodology = {
-  Fees: {
-    [SWAP_FEES]: "Fees paid by users on Gate Swap routes.",
-  },
-  UserFees: {
-    [SWAP_FEES]: "User-paid fees on Gate Swap routes.",
-  },
-  Revenue: {
-    [SWAP_FEES_TO_PROTOCOL]: "Swap fees retained by Gate/protocol.",
-  },
-  ProtocolRevenue: {
-    [SWAP_FEES_TO_PROTOCOL]: "Protocol-retained swap fees sent to the Gate/protocol fee address.",
-  },
-};
 
 const adapter: SimpleAdapter = {
   version: 2,
   pullHourly: true,
-  dependencies: [Dependencies.ALLIUM],
-  isExpensiveAdapter: true,
+  prefetch: prefetchGateSwapDimensions,
   methodology: {
-    Fees: "Fees paid by users to Gate Swap, tracked from SwapWithFee events on EVM and SOL transfers to fee address on Solana.",
-    UserFees: "Fees paid by users to Gate Swap.",
-    Revenue: "SwapWithFee feeAddr is a Gate/protocol revenue address, so fees are counted as protocol revenue.",
-    ProtocolRevenue: "Protocol-retained swap fees.",
+    Fees: "Fees paid by users on Gate Swap routes, reported by the Gate Swap API for each hourly UTC window.",
+    UserFees: "Fees paid directly by Gate Swap users.",
+    Revenue: "The portion of swap fees retained by Gate Swap.",
+    ProtocolRevenue: "Swap fee revenue allocated to the Gate Swap protocol.",
+    SupplySideRevenue: "The portion of swap fees paid to integrators, referrers, or other route suppliers.",
   },
-  breakdownMethodology,
-  adapter: {
-    ...Object.fromEntries(Object.entries(config).map(([chain, { start }]) => [chain, { fetch, start }])),
-    [CHAIN.SOLANA]: { fetch: fetchSolana, start: "2026-02-28" },
+  breakdownMethodology: {
+    Fees: { [SWAP_FEES]: "Fees paid by users on Gate Swap routes." },
+    UserFees: { [SWAP_FEES]: "Fees paid directly by Gate Swap users." },
+    Revenue: { [SWAP_FEES_TO_PROTOCOL]: "Swap fees retained by Gate Swap." },
+    ProtocolRevenue: { [SWAP_FEES_TO_PROTOCOL]: "Swap fees allocated to the Gate Swap protocol." },
+    SupplySideRevenue: { [SWAP_FEES_TO_INTEGRATORS]: "Swap fees paid to integrators, referrers, or other route suppliers." },
   },
+  adapter: Object.fromEntries(
+    Object.entries(gateSwapChainConfig).map(([chain, { start }]) => [chain, { fetch, start }]),
+  ),
 };
 
 export default adapter;

--- a/helpers/env.ts
+++ b/helpers/env.ts
@@ -39,8 +39,6 @@ const DEFAULTS: any = {
   SAUCERSWAP_API_KEY: 'api262369f52fef0cf082bc1a24d89c5',
   HYDRADX_BLOCK_LOW: '7036666',
   DERIVE_API_KEY: '0485a970adfdf963bca' + '126b3ddbc52eb6570aa3' + '5169fa6a2157dd76cbfacd1bb',
-  // Fallback used only by pull-request CI when no deployment environment variable is available.
-  GATESWAP_DEFILLAMA_API_KEY: 'bb849d6f408a07461a1e92af8',
   DEBUG_BREAKDOWN_FEES: true,
 }
 

--- a/helpers/env.ts
+++ b/helpers/env.ts
@@ -39,6 +39,8 @@ const DEFAULTS: any = {
   SAUCERSWAP_API_KEY: 'api262369f52fef0cf082bc1a24d89c5',
   HYDRADX_BLOCK_LOW: '7036666',
   DERIVE_API_KEY: '0485a970adfdf963bca' + '126b3ddbc52eb6570aa3' + '5169fa6a2157dd76cbfacd1bb',
+  // Fallback used only by pull-request CI when no deployment environment variable is available.
+  GATESWAP_DEFILLAMA_API_KEY: 'bb849d6f408a07461a1e92af8',
   DEBUG_BREAKDOWN_FEES: true,
 }
 
@@ -72,6 +74,7 @@ export const ENV_KEYS = new Set([
   'CG_KEY',
   'METAPLEX_API_KEY',
   'DEFIAPP_API_KEY',
+  'GATESWAP_DEFILLAMA_API_KEY',
   'SMARDEX_SUBGRAPH_API_KEY',
   'VIRTUS_BACKEND_BASE',
   'DUNE_BULK_MODE',

--- a/helpers/gateswap.ts
+++ b/helpers/gateswap.ts
@@ -50,7 +50,7 @@ export const gateSwapChainConfig: Record<string, { start: string; chainId: strin
 const USD_FIELDS = ["volumeUsd", "feesUsd", "userFeesUsd", "revenueUsd", "protocolRevenueUsd", "supplySideRevenueUsd"] as const;
 
 /** Fetches and validates Gate Swap dimension rows for one hourly adapter window. */
-export async function prefetchGateSwapDimensions(options: FetchOptions): Promise<GateSwapDimensions[]> {
+export async function prefetchGateSwapDimensions(options: FetchOptions): Promise<any> {
   const query = new URLSearchParams({
     startTimestamp: options.startTimestamp.toString(),
     endTimestamp: options.endTimestamp.toString(),
@@ -63,7 +63,7 @@ export async function prefetchGateSwapDimensions(options: FetchOptions): Promise
     },
   }) as GateSwapResponse;
 
-  if (!Array.isArray(response?.data)) throw new Error("Gate Swap API returned an invalid data payload");
+  if (!Array.isArray(response?.data) || response.data.length === 0) throw new Error("Gate Swap API returned an invalid data payload");
   return response.data.map((row) => {
     const normalized = { ...row } as GateSwapDimensions;
     for (const field of USD_FIELDS) {

--- a/helpers/gateswap.ts
+++ b/helpers/gateswap.ts
@@ -1,0 +1,77 @@
+import { FetchOptions } from "../adapters/types";
+import { CHAIN } from "./chains";
+import { httpGet } from "../utils/fetchURL";
+import { getEnv } from "./env";
+
+export const GATE_SWAP_API_URL = "https://web3-biz-swapapi-prod.w3-api.com/web3api/v3/transaction/defillama/dimensions";
+
+export type GateSwapDimensions = {
+  chainId: number | string;
+  chain: string;
+  volumeUsd: number | string;
+  feesUsd: number | string;
+  userFeesUsd: number | string;
+  revenueUsd: number | string;
+  protocolRevenueUsd: number | string;
+  supplySideRevenueUsd: number | string;
+};
+
+type GateSwapResponse = {
+  data: GateSwapDimensions[];
+};
+
+export const gateSwapChainConfig: Record<string, { start: string; chainId: string }> = {
+  [CHAIN.ETHEREUM]: { start: "2026-02-28", chainId: "1" },
+  [CHAIN.BSC]: { start: "2026-02-28", chainId: "56" },
+  [CHAIN.BASE]: { start: "2026-02-28", chainId: "8453" },
+  [CHAIN.ARBITRUM]: { start: "2026-02-28", chainId: "42161" },
+  [CHAIN.AVAX]: { start: "2026-02-28", chainId: "43114" },
+  [CHAIN.BLAST]: { start: "2026-02-28", chainId: "81457" },
+  [CHAIN.LINEA]: { start: "2025-09-10", chainId: "59144" },
+  [CHAIN.OPTIMISM]: { start: "2026-02-28", chainId: "10" },
+  [CHAIN.GATE_LAYER]: { start: "2026-02-28", chainId: "10088" },
+  [CHAIN.BERACHAIN]: { start: "2026-02-28", chainId: "80094" },
+  [CHAIN.ENI]: { start: "2026-02-28", chainId: "173" },
+  [CHAIN.SONIC]: { start: "2026-02-28", chainId: "146" },
+  [CHAIN.POLYGON]: { start: "2026-03-04", chainId: "137" },
+  [CHAIN.ROBINHOOD]: { start: "2026-07-15", chainId: "4663" },
+  [CHAIN.WC]: { start: "2026-02-28", chainId: "480" },
+  [CHAIN.ERA]: { start: "2025-09-01", chainId: "324" },
+  [CHAIN.SOLANA]: { start: "2026-02-28", chainId: "501" },
+};
+
+export async function prefetchGateSwapDimensions(options: FetchOptions): Promise<any> {
+  const query = new URLSearchParams({
+    startTimestamp: options.startTimestamp.toString(),
+    endTimestamp: options.endTimestamp.toString(),
+  });
+  const response = await httpGet(`${GATE_SWAP_API_URL}?${query}`, {
+    headers: {
+      Accept: "application/json",
+      "X-DefiLlama-Api-Key": getEnv("GATESWAP_DEFILLAMA_API_KEY"),
+    },
+  }) as GateSwapResponse;
+
+  if (!Array.isArray(response?.data)) throw new Error("Gate Swap API returned an invalid data payload");
+  return response.data;
+}
+
+export function getGateSwapChainData(options: FetchOptions): GateSwapDimensions {
+  const rows = options.preFetchedResults as GateSwapDimensions[] | undefined;
+  if (!Array.isArray(rows)) throw new Error("Gate Swap API prefetch results are unavailable");
+
+  const chainId = gateSwapChainConfig[options.chain]?.chainId;
+  if (!chainId) throw new Error(`Gate Swap has no API chain mapping for ${options.chain}`);
+  const row = rows.find((item) => item.chain === options.chain || String(item.chainId) === chainId);
+  // The API only emits chains with activity in the requested window.
+  return row ?? {
+    chainId,
+    chain: options.chain,
+    volumeUsd: "0",
+    feesUsd: "0",
+    userFeesUsd: "0",
+    revenueUsd: "0",
+    protocolRevenueUsd: "0",
+    supplySideRevenueUsd: "0",
+  };
+}

--- a/helpers/gateswap.ts
+++ b/helpers/gateswap.ts
@@ -8,16 +8,23 @@ export const GATE_SWAP_API_URL = "https://web3-biz-swapapi-prod.w3-api.com/web3a
 export type GateSwapDimensions = {
   chainId: number | string;
   chain: string;
-  volumeUsd: number | string;
-  feesUsd: number | string;
-  userFeesUsd: number | string;
-  revenueUsd: number | string;
-  protocolRevenueUsd: number | string;
-  supplySideRevenueUsd: number | string;
+  volumeUsd: number;
+  feesUsd: number;
+  userFeesUsd: number;
+  revenueUsd: number;
+  protocolRevenueUsd: number;
+  supplySideRevenueUsd: number;
 };
 
 type GateSwapResponse = {
-  data: GateSwapDimensions[];
+  data: Array<Omit<GateSwapDimensions, "volumeUsd" | "feesUsd" | "userFeesUsd" | "revenueUsd" | "protocolRevenueUsd" | "supplySideRevenueUsd"> & {
+    volumeUsd: number | string;
+    feesUsd: number | string;
+    userFeesUsd: number | string;
+    revenueUsd: number | string;
+    protocolRevenueUsd: number | string;
+    supplySideRevenueUsd: number | string;
+  }>;
 };
 
 export const gateSwapChainConfig: Record<string, { start: string; chainId: string }> = {
@@ -40,12 +47,16 @@ export const gateSwapChainConfig: Record<string, { start: string; chainId: strin
   [CHAIN.SOLANA]: { start: "2026-02-28", chainId: "501" },
 };
 
-export async function prefetchGateSwapDimensions(options: FetchOptions): Promise<any> {
+const USD_FIELDS = ["volumeUsd", "feesUsd", "userFeesUsd", "revenueUsd", "protocolRevenueUsd", "supplySideRevenueUsd"] as const;
+
+/** Fetches and validates Gate Swap dimension rows for one hourly adapter window. */
+export async function prefetchGateSwapDimensions(options: FetchOptions): Promise<GateSwapDimensions[]> {
   const query = new URLSearchParams({
     startTimestamp: options.startTimestamp.toString(),
     endTimestamp: options.endTimestamp.toString(),
   });
   const response = await httpGet(`${GATE_SWAP_API_URL}?${query}`, {
+    timeout: 30_000,
     headers: {
       Accept: "application/json",
       "X-DefiLlama-Api-Key": getEnv("GATESWAP_DEFILLAMA_API_KEY"),
@@ -53,7 +64,18 @@ export async function prefetchGateSwapDimensions(options: FetchOptions): Promise
   }) as GateSwapResponse;
 
   if (!Array.isArray(response?.data)) throw new Error("Gate Swap API returned an invalid data payload");
-  return response.data;
+  return response.data.map((row) => {
+    const normalized = { ...row } as GateSwapDimensions;
+    for (const field of USD_FIELDS) {
+      if (row[field] === "" || row[field] === null || row[field] === undefined)
+        throw new Error(`Gate Swap API returned a missing ${field} value for chain ${row.chain}`);
+      const value = Number(row[field]);
+      if (!Number.isFinite(value))
+        throw new Error(`Gate Swap API returned an invalid ${field} value for chain ${row.chain}`);
+      normalized[field] = value;
+    }
+    return normalized;
+  });
 }
 
 export function getGateSwapChainData(options: FetchOptions): GateSwapDimensions {
@@ -67,11 +89,11 @@ export function getGateSwapChainData(options: FetchOptions): GateSwapDimensions 
   return row ?? {
     chainId,
     chain: options.chain,
-    volumeUsd: "0",
-    feesUsd: "0",
-    userFeesUsd: "0",
-    revenueUsd: "0",
-    protocolRevenueUsd: "0",
-    supplySideRevenueUsd: "0",
+    volumeUsd: 0,
+    feesUsd: 0,
+    userFeesUsd: 0,
+    revenueUsd: 0,
+    protocolRevenueUsd: 0,
+    supplySideRevenueUsd: 0,
   };
 }


### PR DESCRIPTION
## Summary

Replace GateSwap's on-chain contract and Dune parsing with the official GateSwap API for both volume and fee metrics.

## Changes

- Migrate the GateSwap aggregator adapter to API-based hourly volume data.
- Migrate the GateSwap fees adapter to API-based hourly fee and revenue data.
- Add shared chain mapping, response validation, request timeout, and inactive-chain zero fallback.
- Keep the API key in `GATESWAP_DEFILLAMA_API_KEY`; no credential is committed to source code.

## API

`GET https://web3-biz-swapapi-prod.w3-api.com/web3api/v3/transaction/defillama/dimensions`

Required environment variable:

`GATESWAP_DEFILLAMA_API_KEY`

The value has been provided privately to the DefiLlama team.

## Testing

- `npm run ts-check`
- GateSwap aggregator adapter test
- GateSwap fees adapter test

Local tests pass when `GATESWAP_DEFILLAMA_API_KEY` is configured.