### PR TITLE
houdiniswap: route the volume api through the proxy, cloudflare blocks node

### DIFF
--- a/aggregators/houdiniswap/index.ts
+++ b/aggregators/houdiniswap/index.ts
@@ -1,4 +1,4 @@
-import fetchURL from "../../utils/fetchURL";
+import { proxiedFetch } from "../../utils/fetchURL";
 import { CHAIN } from "../../helpers/chains";
 import { FetchOptions } from "../../adapters/types";
 
@@ -61,7 +61,7 @@ const fetch = async (options: FetchOptions) => {
   const defaultRes = {
     dailyVolume: 0,
   }
-  const res = await fetchURL(url);
+  const res = await proxiedFetch(url);
   const targetDay = startTimestamp;
   const dailyData = res.find((item: any) => item.timestamp === targetDay);
   if (!dailyData) {


### PR DESCRIPTION
Fixes #8712

`aggregators/houdiniswap` has published nothing since 2026-08-07, `api.houdiniswap.com` is now behind a Cloudflare managed challenge and every request from node comes back 403.

The data is fine. Same URL the adapter builds, via curl with a browser UA:

```
[{"timestamp":1786320000,"totalUSD":587631.0276252365}]   HTTP 200
```

That's ethereum alone on 2026-08-09, a day the chart has nothing for.

I checked what the block is keyed on before picking a fix, since a header change would have been the cheaper patch. From one machine, one IP, same minute: curl with a browser UA gets 200 on both HTTP/2 and HTTP/1.1; node `https`, node `axios` and node's global `fetch` all get 403 with that identical UA, with and without Accept/Accept-Language. Forcing a Chrome-shaped TLS handshake out of node (Chrome cipher list, `ecdhCurve: X25519:P-256:P-384`, Chrome sigalgs, TLS 1.2-1.3 pinning) is 403 on every variant too. So it's the client fingerprint, not the UA and not the IP, and there's no header or agent option that gets node past it.

`proxiedFetch` is the mechanism already in the repo for this, `fees/space-and-time.ts` uses it, and it falls back to plain `httpGet` when `PROXY_AUTH` isn't set, so nothing changes for anyone running without the proxy.

Heads up on CI: this can't go green from a fork. Without `PROXY_AUTH` it takes the fallback path and hits the same 403 described above. It needs a run with the proxy configured to confirm. Full evidence table is in #8712.

I left `if (!dailyData) return { dailyVolume: 0 }` alone, with 40+ chains configured most of them legitimately have no row on a given day, so making that throw would kill the adapter. The 403 already throws, which is why the chart stops rather than flatlining at zero.
