### PR TITLE
ronin: point at tenderly, the configured rpcs cant do getLogs anymore

### DIFF
--- a/helpers/env.ts
+++ b/helpers/env.ts
@@ -27,6 +27,7 @@ const DEFAULTS: any = {
   MANTLE_ARCHIVAL_RPC: 'https://explorer.mantle.xyz/api/eth-rpc',
   GATELAYER_RPC: 'https://www.gatescan.org/gatelayer/api/eth-rpc',
   ROBINHOOD_RPC: 'https://rpc.mainnet.chain.robinhood.com',
+  RONIN_RPC: 'https://ronin.gateway.tenderly.co,https://gateway.tenderly.co/public/ronin',
   SHIDO_RPC: 'https://shidoscan.net/api/eth-rpc',
   SAGA_RPC: "https://sagaevm.jsonrpc.sagarpc.io",
   SAGA_WHITELISTED_RPC: 'https://sagaevm-archive.jsonrpc.sagarpc.io',


### PR DESCRIPTION
Fixes #8713

Every log-based Ronin adapter has been erroring since 2026-08-04/05. Both RPCs configured for ronin in `providers.json` are unusable for `eth_getLogs`:

```
Llama RPC error! method: getLogs
- host: https://ronin.drpc.org         error: Request failed with status code 500
- host: https://api.roninchain.com/rpc error: Invalid params
- host: https://api.roninchain.com/rpc error: Request failed with status code 429
```

drpc is a hard 500 on everything, including a plain `eth_getBlockByNumber` half a million blocks back. `api.roninchain.com/rpc` returns `Invalid params` for a topic-filtered `eth_getLogs` even over 1000 blocks, so it isn't a range cap that chunking gets around, that request shape just isn't supported there.

I probed every other Ronin endpoint I could find with a full day of blocks (28,800 at 3s). Two answer: `ronin.gateway.tenderly.co` (6,418 logs) and `gateway.tenderly.co/public/ronin` (6,419). thirdweb has archive but hits "Log response size exceeded"; blastapi/ankr/chainstack are 401/403, 1rpc/0xrpc/publicnode/blockpi are 400/404, and lgns/meowrpc/stakely/onfinality/public-rpc don't resolve. Full table in #8713.

Both survivors are Tenderly, which is the same pair-of-hostnames shape ethereum already has in `providers.json`.

`getChainRPCs` prepends the env value to the `providers.json` list instead of replacing it, so ronin becomes `[tenderly, tenderly-public, drpc, roninchain]` and the existing two stay as fallbacks. `_performAction` sets `noPlayingAround` for `getLogs`, so the working host is tried first there. Same pattern as `HYPERLIQUID_RPC` and `ROBINHOOD_RPC` in that file.

Verified on three adapters that error out on master:

| adapter | before | after |
|---|---|---|
| `dexs/katana-v3` | getLogs failure on every host | $69.11k volume, $230 fees, $38 protocol revenue |
| `dexs/katana` | getLogs failure on every host | $117.14k volume, $352.22 fees, $58.56 protocol revenue |
| `fees/axie-infinity` | getLogs failure on every host | $4.67k fees, $4.53k revenue |
