### PR TITLE
sakuraswap clmm: drop zero chain

### DIFF
--- a/factory/uniV3.ts
+++ b/factory/uniV3.ts
@@ -285,8 +285,8 @@ const configs: Record<string, Record<string, any>> = {
   "reservoir-tools-clmm": {
     [CHAIN.ABSTRACT]: { factory: '0xA1160e73B63F322ae88cC2d8E700833e71D0b2a1', start: '2025-01-07', userFeesRatio: 1, revenueRatio: 0, protocolRevenueRatio: 0, holdersRevenueRatio: 0 },
     [CHAIN.INK]: { factory: '0x640887A9ba3A9C53Ed27D0F7e8246A4F933f3424', start: '2025-01-07', userFeesRatio: 1, revenueRatio: 0, protocolRevenueRatio: 0, holdersRevenueRatio: 0 },
-    [CHAIN.ZERO]: { factory: '0xA1160e73B63F322ae88cC2d8E700833e71D0b2a1', start: '2025-12-21', userFeesRatio: 1, revenueRatio: 0, protocolRevenueRatio: 0, holdersRevenueRatio: 0 },
-    // [CHAIN.REDSTONE]: { factory: '0xece75613Aa9b1680f0421E5B2eF376DF68aa83Bb', start: '2025-01-07', userFeesRatio: 1, revenueRatio: 0, protocolRevenueRatio: 0, holdersRevenueRatio: 0 },
+    //[CHAIN.ZERO]: { factory: '0xA1160e73B63F322ae88cC2d8E700833e71D0b2a1', start: '2025-12-21', userFeesRatio: 1, revenueRatio: 0, protocolRevenueRatio: 0, holdersRevenueRatio: 0 },
+    [CHAIN.REDSTONE]: { factory: '0xece75613Aa9b1680f0421E5B2eF376DF68aa83Bb', start: '2025-01-07', userFeesRatio: 1, revenueRatio: 0, protocolRevenueRatio: 0, holdersRevenueRatio: 0 },
   },
   "shapeswap-v3": {
     [CHAIN.SHAPE]: { factory: '0xeCf9288395797Da137f663a7DD0F0CDF918776F8', start: '2024-12-09', userFeesRatio: 1, revenueRatio: 0, protocolRevenueRatio: 0, holdersRevenueRatio: 0 },

--- a/factory/uniV3.ts
+++ b/factory/uniV3.ts
@@ -286,7 +286,7 @@ const configs: Record<string, Record<string, any>> = {
     [CHAIN.ABSTRACT]: { factory: '0xA1160e73B63F322ae88cC2d8E700833e71D0b2a1', start: '2025-01-07', userFeesRatio: 1, revenueRatio: 0, protocolRevenueRatio: 0, holdersRevenueRatio: 0 },
     [CHAIN.INK]: { factory: '0x640887A9ba3A9C53Ed27D0F7e8246A4F933f3424', start: '2025-01-07', userFeesRatio: 1, revenueRatio: 0, protocolRevenueRatio: 0, holdersRevenueRatio: 0 },
     [CHAIN.ZERO]: { factory: '0xA1160e73B63F322ae88cC2d8E700833e71D0b2a1', start: '2025-12-21', userFeesRatio: 1, revenueRatio: 0, protocolRevenueRatio: 0, holdersRevenueRatio: 0 },
-    [CHAIN.REDSTONE]: { factory: '0xece75613Aa9b1680f0421E5B2eF376DF68aa83Bb', start: '2025-01-07', userFeesRatio: 1, revenueRatio: 0, protocolRevenueRatio: 0, holdersRevenueRatio: 0 },
+    // [CHAIN.REDSTONE]: { factory: '0xece75613Aa9b1680f0421E5B2eF376DF68aa83Bb', start: '2025-01-07', userFeesRatio: 1, revenueRatio: 0, protocolRevenueRatio: 0, holdersRevenueRatio: 0 },
   },
   "shapeswap-v3": {
     [CHAIN.SHAPE]: { factory: '0xeCf9288395797Da137f663a7DD0F0CDF918776F8', start: '2024-12-09', userFeesRatio: 1, revenueRatio: 0, protocolRevenueRatio: 0, holdersRevenueRatio: 0 },


### PR DESCRIPTION
Refs #8714

`reservoir-tools-clmm` fans out to redstone, and that leg can only ever throw, the sdk's single configured RPC for the chain, `rpc.redstonechain.com`, is a dangling CNAME. It points at `d2gjzw31nxvj4c.cloudfront.net`, and that name returns no A record from the system resolver, 1.1.1.1 or 8.8.8.8; the distribution behind it is gone. `explorer.redstone.xyz` is Cloudflare error 1014, `690.rpc.thirdweb.com` and `redstone.drpc.org` don't work either, and the chain is at $0 TVL. Redstone last contributed volume on 2026-05-18.

It's also the one config difference between this adapter and `reservoir-tools-amm`; the AMM has no redstone entry and is still publishing (through 2026-08-12), while the CLMM stopped on 2026-08-07 on both of its working chains at once (Abstract and Ink, same day). I can't prove the DNS lapsed on that date, so I'm not filing this as the fix for #8714; a permanently unresolvable host in the fan-out is worth removing on its own.

Commented rather than deleted, matching how `factory/uniV2.ts:493` handles RARI, in case the chain comes back.

Left `[CHAIN.ZERO]` alone deliberately. Both of its public RPCs are down for me, which takes the adapter out locally, but that's a harness artifact; the AMM has the same zero_network entry and published on 2026-08-12, so production reaches it fine.

Verified with redstone off (and zero temporarily off too, so the run could complete locally):

```
chain     | Daily volume | Daily fees
abstract  | 154.04 k     | 124.88
ink       | 1.50 k       | 3.19
Aggregate | 155.53 k     | 128.07
```

Second run $153.86k / $1.50k, consistent. Master aborts before producing anything.
