### PR TITLE
alphasec-spot: dont publish the api's placeholder row as real zeros

### DIFF
--- a/dexs/alphasec-spot.ts
+++ b/dexs/alphasec-spot.ts
@@ -14,6 +14,15 @@ const fetch = async (options: FetchOptions) => {
   const data = await httpGet(url);
   const stats = data.result;
 
+  if (!stats || Number(stats.updatedAt) <= Number(stats.timestamp))
+    throw new Error(
+      `alphasec-spot: api.alphasec.trade has not finalised ${options.startOfDay} yet (volume ${stats?.dailyVolume}, timestamp ${stats?.timestamp}, updatedAt ${stats?.updatedAt})`,
+    );
+
+  const dailyVolume = Number(stats.dailyVolume);
+  if (!Number.isFinite(dailyVolume))
+    throw new Error(`alphasec-spot: api.alphasec.trade returned no usable volume (${stats.dailyVolume}) for ${options.startOfDay}`);
+
   const dailyFees = options.createBalances();
   const dailyRevenue = options.createBalances();
   const dailySupplySideRevenue = options.createBalances();
@@ -23,7 +32,7 @@ const fetch = async (options: FetchOptions) => {
   dailySupplySideRevenue.addUSDValue(stats.dailySupplySideRevenue, metrics.TradingRebatesAndCommissions);
 
   return {
-    dailyVolume: stats.dailyVolume,
+    dailyVolume,
     dailyFees,
     dailyRevenue,
     dailySupplySideRevenue,


### PR DESCRIPTION
Fixes #8748

`dexs/alphasec-spot` has published `$0` volume on **62 of its 253 days**, and `api.alphasec.trade` has correct non-zero volume for **all 62**. $168,610,465 dropped, 6.2% on top of the $2.71B currently shown all-time.

Neither the adapter nor the API is broken. The API answers `HTTP 200` with an all-zero row for a day it hasn't finalised yet:

```
today     ?startOfDay=1786579200 -> 200 {"dailyVolume":0,...,"timestamp":1786579200,"updatedAt":1786579200}
yesterday ?startOfDay=1786492800 -> 200 {"dailyVolume":7143115,...,"updatedAt":1786581006}
```

No error, no missing field, nothing to catch; the row is written ~24.5h after the day starts (`updatedAt - timestamp` is 88,206s on every finalised row I checked), and a run landing before that stores zeros permanently. `dailyVolume` was passed through raw and `addUSDValue(0)` is a no-op, so nothing flags it.

`updatedAt <= timestamp` is exact for this: true for every placeholder row (today, a future date, `startOfDay=0`), false for every real one. So a genuinely quiet day would still publish `$0` correctly, I checked all 62 zero days against the API and none of them were genuinely quiet, but the guard doesn't assume that.

Fees mostly survived (6 days lost, $11,012) because `dexs` and `fees` run as separate jobs and only the `dexs` one keeps landing in the pre-00:30 window; which is why the protocol looks alive on the fees chart the whole time. The two are tightly coupled: implied fee rate is a flat 0.0500% across the 190 days where both published, so the fee series alone says volume was never zero on those days.

Verified:

| run | result |
|---|---|
| `2026-08-10` (covers 08-09, we published $0) | Daily volume 4.06 M, fees 2.44 k |
| `2026-08-13` (covers 08-12, we published $0) | Daily volume 7.14 M, fees 4.29 k |
| `2026-08-14` (covers today, not finalised) | throws `has not finalised 1786579200 yet (volume 0, timestamp 1786579200, updatedAt 1786579200)` |

Both finalised days match the API exactly and are unchanged from master's behaviour when it happens to run late enough.
