### PR TITLE
chore: mark 01 Exchange dead

### DIFF
--- a/open-interest/01-xyz.ts
+++ b/open-interest/01-xyz.ts
@@ -22,6 +22,7 @@ const fetch = async (_options: FetchOptions) => {
 
 const adapter: SimpleAdapter = {
   version: 2,
+  deadFrom: "2026-07-08",
   adapter: {
     [CHAIN.N1]: {
       fetch,


### PR DESCRIPTION
## Summary

Marks the legacy 01 Exchange adapter dead from `2026-07-08`.

## Context

01 Exchange was acquired and sunset as a separate destination effective
July 8, 2026. It is no longer operational as an independent project.

## Change

Adds a root-level `deadFrom: "2026-07-08"` to
`open-interest/01-xyz.ts`.

This preserves the historical 01 Exchange data while stopping future
adapter runs. No existing fetch logic or dependencies are changed.

## Verification

- Confirmed the official sunset date from the project announcement.
- No dependency or lockfile changes.
- No unrelated files changed.