### PR TITLE
Add Midas Hyperliquid builder code adapter

### DIFF
--- a/factory/hyperliquid.ts
+++ b/factory/hyperliquid.ts
@@ -844,6 +844,20 @@ const builderConfigs: Record<string, BuilderConfig> = {
       ProtocolRevenue: "Builder fees collected by Trending for trades executed through its non-custodial interface.",
     },
     breakdownFees: true,
+  },
+  "midas-perps": {
+    // Midas (midasmarkets.xyz) builder code, lowercased to match HL's builder_fills files.
+    addresses: ["0x990a91cb54c6db7037d3f8105e848c635d4d909f"],
+    // First day with builder fills for this code, verified against
+    // stats-data.hyperliquid.xyz/Mainnet/builder_fills (nothing before this date).
+    start: "2026-01-15",
+    methodology: {
+      Volume: "Notional volume of Hyperliquid trades (perps, spot and HIP-3 equity markets) routed through Midas' AI trading app.",
+      Fees: "Builder code fees paid by users on Hyperliquid trades executed through Midas (0.05% on perps, 0.25% on spot).",
+      Revenue: "Builder code fees collected by Midas from Hyperliquid trades.",
+      ProtocolRevenue: "Builder code fees collected by Midas from Hyperliquid trades.",
+    },
+    breakdownFees: true,
   }
 };
 

--- a/factory/hyperliquid.ts
+++ b/factory/hyperliquid.ts
@@ -853,7 +853,12 @@ const builderConfigs: Record<string, BuilderConfig> = {
     start: "2026-01-15",
     methodology: {
       Volume: "Notional volume of Hyperliquid trades (perps, spot and HIP-3 equity markets) routed through Midas' AI trading app.",
-      Fees: "Builder code fees paid by users on Hyperliquid trades executed through Midas (0.05% on perps, 0.25% on spot).",
+      // Rate is descriptive only: fees are summed from the per-fill `builder_fee`
+      // column, not computed from this number. 0.05% is the rate observed across
+      // every fill in the builder_fills data, and sits under Hyperliquid's builder
+      // cap of 0.1% perps / 1% spot
+      // (https://hyperliquid.gitbook.io/hyperliquid-docs/trading/builder-codes).
+      Fees: "Builder code fees (0.05%) paid by users on Hyperliquid trades executed through Midas.",
       Revenue: "Builder code fees collected by Midas from Hyperliquid trades.",
       ProtocolRevenue: "Builder code fees collected by Midas from Hyperliquid trades.",
     },


### PR DESCRIPTION
Adds Midas as a Hyperliquid builder-code protocol. Midas routes user trades to Hyperliquid with its own builder code, so this is a single config entry in the existing `factory/hyperliquid.ts` builder factory rather than a new adapter file.

**Builder address:** `0x990a91cb54c6db7037d3f8105e848c635d4d909f` (lowercased to match HL's `builder_fills` files)
**Start:** `2026-01-15` — the first day with builder fills on `stats-data.hyperliquid.xyz/Mainnet/builder_fills/`. Every earlier date, back through December 2025, returns 403.

### Validation

Run against real HL data, `npm test -- dexs midas-perps <date>`:

| Date (end) | Daily volume | Daily fees |
| --- | --- | --- |
| 2026-01-16 (first day) | $71.00 | $0.07 |
| 2026-08-04 | $14.60k | $8.01 |
| 2026-08-05 | $88.17k | $44.00 |
| 2026-08-06 | $57.75k | $29.00 |
| 2026-08-07 | $48.98k | $26.00 |
| 2026-08-08 | $93.25k | $47.00 |
| 2026-08-09 | $1.87k | $1.06 |
| 2026-08-10 | $1.11k | $0.56 |
| 2026-08-11 | $93.86k | $55.00 |
| 2026-08-12 | $238.75k | $120.00 |

Fee/volume ratios land at ~5bps throughout, matching the 0.05% perps builder fee.

Cross-checked against Hyperliquid itself: summing `builder_fee` across every `builder_fills` file from 2026-01-15 through 2026-08-12 gives $1,484 of lifetime builder fees on $1.92M of volume, versus `builderRewards` of $1,571.66 returned today by HL's `referral` info endpoint for the same address — the difference being the two days not included in the sum.

---

##### Name (to be shown on DefiLlama):
Midas

##### Twitter Link:
https://x.com/midasmarketsxyz

##### List of audit links if any:
N/A

##### Website Link:
https://midasmarkets.xyz

##### Logo (High resolution, will be shown with rounded borders):
https://midasmarkets.xyz/icon.png

##### Current TVL:
N/A — no TVL, this is a Hyperliquid builder-code frontend. Dimensions only (volume / fees / revenue).

##### Treasury Addresses (if the protocol has treasury)
N/A

##### Chain:
Hyperliquid

##### Coingecko ID:

##### Coinmarketcap ID:

##### Short Description (to be shown on DefiLlama):
AI-powered trading app. Trade crypto perps, tokenized equities, and spot tokens with one-click AI signals.

##### Token address and ticker if any:
No token

##### Category (full list at https://defillama.com/categories) *Please choose only one:
Derivatives

##### Oracle Provider(s):
N/A — no oracle, all trades settle on Hyperliquid.

##### Implementation Details:
N/A

##### Documentation/Proof:
N/A

##### forkedFrom (Does your project originate from another project):
N/A

##### methodology (what is being counted as tvl, how is tvl being calculated):
No TVL. Volume is the notional of Hyperliquid fills carrying the Midas builder code; fees/revenue/protocol revenue are the `builder_fee` on those same fills (0.05% on perps, 0.25% on spot), all read from HL's `builder_fills` dataset. Marked `doublecounted` by the builder factory, since the volume also counts toward Hyperliquid.

##### Github org/user (Optional, if your code is open source, we can track activity):
N/A — closed source

##### Does this project have a referral program?
No
