### PR TITLE
fix(lista-lending): correct under-reported revenue (~0.7% → ~18–20%)

### DIFF
--- a/fees/lista-lending/index.ts
+++ b/fees/lista-lending/index.ts
@@ -1,20 +1,20 @@
 import { FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 import { METRIC } from "../../helpers/metrics";
+import { getConfig } from "../../helpers/cache";
 
 /**
  * Lista Lending (Moolah) — a Morpho-Blue fork on BSC and Ethereum.
  *
  * Fees / SupplySide / Revenue are derived from on-chain interest accrual (same shape as the
- * canonical `fees/morpho` adapter), so the full borrow interest — including the yield earned by
+ * canonical Morpho adapter), so the full borrow interest — including the yield earned by
  * suppliers/lenders — is captured, not only Lista's protocol cut:
  *
  *   - Fees              = total borrow interest across all markets (Moolah `AccrueInterest.interest`).
- *   - Revenue           = Lista's market protocol fee = interest × market fee.
+ *   - Revenue           = Lista's protocol cut = market protocol fee (interest × market.fee) +
+ *                         MoolahVault management fee (vault `AccrueInterest.feeShares`, only for the
+ *                         self-operated vaults whose feeRecipient is Lista's LendingFeeRecipient).
  *   - SupplySideRevenue = Fees − Revenue = interest distributed to suppliers/lenders.
- *
- * Scope note: this tracks the Moolah lending *markets*. The separate MoolahVault management fee
- * (a MetaMorpho-style vault layer, like Morpho vs MetaMorpho on DefiLlama) is out of scope here.
  *
  * @doc https://listaorg.notion.site/Profit-cfd754931df449eaa9a207e38d3e0a54
  * @test npx ts-node --transpile-only cli/testAdapter.ts fees lista-lending
@@ -26,17 +26,46 @@ const MOOLAH: Record<string, string> = {
   [CHAIN.BSC]: "0x8F73b65B4caAf64FBA2aF91cC5D4a2A1318E5D8C",
   [CHAIN.ETHEREUM]: "0xf820fB4680712CD7263a0D3D024D5b5aEA82Fd70",
 };
+// Lista's LendingFeeRecipient — the fee recipient set on self-operated MoolahVaults. Used to keep
+// only Lista's own vaults (third-party curators route their fee elsewhere).
+const LENDING_FEE_RECIPIENT: Record<string, string> = {
+  [CHAIN.BSC]: "0x2E2Eed557FAb1d2E11fEA1E1a23FF8f1b23551f3",
+  [CHAIN.ETHEREUM]: "0xd10a024602E042dcb9C19e21682c3b896c8B0d30",
+};
+const API_CHAIN: Record<string, string> = {
+  [CHAIN.BSC]: "bsc",
+  [CHAIN.ETHEREUM]: "ethereum",
+};
+const PAGE_SIZE = 100;
+const vaultListUrl = (chain: string, page: number) =>
+  `https://api.lista.org/api/moolah/vault/list?page=${page}&pageSize=${PAGE_SIZE}&sort=depositsUsd&order=desc&chain=${API_CHAIN[chain]}`;
 
 const abis = {
   AccrueInterest:
     "event AccrueInterest(bytes32 indexed id, uint256 prevBorrowRate, uint256 interest, uint256 feeShares)",
-  // idToMarketParams is immutable per market id.
   idToMarketParams:
     "function idToMarketParams(bytes32) view returns (address loanToken, address collateralToken, address oracle, address irm, uint256 lltv)",
-  // market().fee is the protocol fee rate (WAD). Read per fetch window; it is effectively constant
-  // within a day and changes only via rare governance SetFee calls.
   market:
     "function market(bytes32) view returns (uint128 totalSupplyAssets, uint128 totalSupplyShares, uint128 totalBorrowAssets, uint128 totalBorrowShares, uint128 lastUpdate, uint128 fee)",
+  VaultAccrueInterest: "event AccrueInterest(uint256 newTotalAssets, uint256 feeShares)",
+};
+
+// Paginate the full vault inventory; throw (rather than silently under-report) if the API/cache
+// returns an invalid response.
+const getVaultAddresses = async (chain: string): Promise<string[]> => {
+  const addresses: string[] = [];
+  let page = 1;
+  let total = Infinity;
+  while (addresses.length < total) {
+    const res = await getConfig(`lista-lending/vaults-${chain}-${page}`, vaultListUrl(chain, page));
+    const list = res?.data?.list;
+    if (!Array.isArray(list)) throw new Error(`Lista vault list unavailable for ${chain}`);
+    total = Number(res.data.total ?? list.length);
+    addresses.push(...list.map((v: any) => v.address));
+    if (list.length === 0) break;
+    page++;
+  }
+  return addresses;
 };
 
 const fetch = async (options: FetchOptions) => {
@@ -45,9 +74,10 @@ const fetch = async (options: FetchOptions) => {
   const dailyRevenue = options.createBalances();
   const dailySupplySideRevenue = options.createBalances();
 
-  const logs = await options.getLogs({ target: MOOLAH[chain], eventAbi: abis.AccrueInterest });
+  // ---- Market layer: total borrow interest + market protocol fee ----
+  const interestLogs = await options.getLogs({ target: MOOLAH[chain], eventAbi: abis.AccrueInterest });
 
-  const marketIds = [...new Set(logs.map((log: any) => String(log.id)))];
+  const marketIds = [...new Set(interestLogs.map((log: any) => String(log.id)))];
   const loanToken: Record<string, string> = {};
   const marketFeeRate: Record<string, bigint> = {};
   if (marketIds.length) {
@@ -61,7 +91,7 @@ const fetch = async (options: FetchOptions) => {
     });
   }
 
-  for (const log of logs) {
+  for (const log of interestLogs) {
     const id = String(log.id);
     const token = loanToken[id];
     if (!token) continue;
@@ -70,6 +100,38 @@ const fetch = async (options: FetchOptions) => {
     dailyFees.add(token, interest, METRIC.BORROW_INTEREST);
     dailyRevenue.add(token, marketFee, METRIC.BORROW_INTEREST);
     dailySupplySideRevenue.add(token, interest - marketFee, METRIC.BORROW_INTEREST);
+  }
+
+  // ---- Vault layer: MoolahVault management fee (Lista-operated vaults only) ----
+  const vaults = await getVaultAddresses(chain);
+  if (vaults.length) {
+    const feeRecipients = await api.multiCall({ abi: "address:feeRecipient", calls: vaults, permitFailure: true });
+    const listaVaults = vaults.filter(
+      (_, i) => feeRecipients[i]?.toLowerCase() === LENDING_FEE_RECIPIENT[chain].toLowerCase()
+    );
+
+    if (listaVaults.length) {
+      const vaultLogs = await options.getLogs({ targets: listaVaults, eventAbi: abis.VaultAccrueInterest, flatten: false });
+      const feeShares = listaVaults.map((_, i) =>
+        (vaultLogs[i] ?? []).reduce((sum: bigint, log: any) => sum + BigInt(log.feeShares), 0n)
+      );
+      const [assets, tokens] = await Promise.all([
+        api.multiCall({
+          abi: "function convertToAssets(uint256) view returns (uint256)",
+          calls: listaVaults.map((v, i) => ({ target: v, params: [feeShares[i].toString()] })),
+          permitFailure: true,
+        }),
+        api.multiCall({ abi: "address:asset", calls: listaVaults, permitFailure: true }),
+      ]);
+      listaVaults.forEach((_, i) => {
+        const feeAssets = assets[i] ? BigInt(assets[i]) : 0n;
+        if (feeAssets > 0n && tokens[i]) {
+          // Vault management fee is Lista revenue carved out of the market supply side.
+          dailyRevenue.add(tokens[i], feeAssets, METRIC.MANAGEMENT_FEES);
+          dailySupplySideRevenue.subtractToken(tokens[i], feeAssets, METRIC.BORROW_INTEREST);
+        }
+      });
+    }
   }
 
   return {
@@ -82,16 +144,24 @@ const fetch = async (options: FetchOptions) => {
 
 const methodology = {
   Fees: "Total borrow interest paid by borrowers across all Moolah markets.",
-  Revenue: "Lista's market protocol fee = borrow interest × the market fee rate.",
-  ProtocolRevenue: "Same as Revenue — the market protocol fee is collected by Lista DAO.",
-  SupplySideRevenue: "Borrow interest distributed to suppliers/lenders, net of the market protocol fee.",
+  Revenue: "Lista's protocol cut: the market protocol fee (interest × market fee) plus the management fee on self-operated MoolahVaults.",
+  ProtocolRevenue: "Same as Revenue — all lending fees are collected by Lista DAO.",
+  SupplySideRevenue: "Borrow interest distributed to suppliers/lenders, net of Lista's protocol cut.",
 };
 
 const breakdownMethodology = {
   Fees: { [METRIC.BORROW_INTEREST]: "Total interest paid by borrowers across all Moolah markets." },
-  Revenue: { [METRIC.BORROW_INTEREST]: "Market protocol fee = borrow interest × market fee rate." },
-  ProtocolRevenue: { [METRIC.BORROW_INTEREST]: "Market protocol fee = borrow interest × market fee rate." },
-  SupplySideRevenue: { [METRIC.BORROW_INTEREST]: "Interest distributed to suppliers/lenders, net of the market fee." },
+  Revenue: {
+    [METRIC.BORROW_INTEREST]: "Market protocol fee = interest × market fee.",
+    [METRIC.MANAGEMENT_FEES]: "Management fee on self-operated MoolahVaults (feeRecipient = Lista's LendingFeeRecipient).",
+  },
+  ProtocolRevenue: {
+    [METRIC.BORROW_INTEREST]: "Market protocol fee = interest × market fee.",
+    [METRIC.MANAGEMENT_FEES]: "Management fee on self-operated MoolahVaults.",
+  },
+  SupplySideRevenue: {
+    [METRIC.BORROW_INTEREST]: "Interest to suppliers/lenders, net of the market fee and vault management fee.",
+  },
 };
 
 const adapter: SimpleAdapter = {

--- a/fees/lista-lending/index.ts
+++ b/fees/lista-lending/index.ts
@@ -1,94 +1,160 @@
 import { FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
-import { addTokensReceived } from "../../helpers/token";
+import { METRIC } from "../../helpers/metrics";
+import { getConfig } from "../../helpers/cache";
 
 /**
- * Lista Lending (Moolah) protocol revenue.
+ * Lista Lending (Moolah) — a Morpho-Blue fork on BSC and Ethereum.
  *
- * All lending fees are collected via LendingFeeRecipient, which forwards them to two downstream
- * receivers:
- *   - vault management fee (10% of vault yield) -> `vaultFeeRecipient`  (LendingRevenueDistributor)
- *   - market protocol fee  (% of borrow interest) -> `marketFeeRecipient` (shared treasury / ListaRevenueDistributor)
+ * Fees / SupplySide / Revenue are derived from on-chain interest accrual (same shape as the
+ * canonical Morpho adapter), so the full borrow interest — including the yield earned by
+ * suppliers/lenders — is captured, not only Lista's protocol cut:
  *
- * Revenue = tokens received by those receivers. The market receiver is a shared treasury that also
- * collects CDP stability fees and other income, so the market fee is isolated by only counting
- * transfers that come straight from the Moolah lending contract.
- *
- * This is claim/settlement-timed: fees are booked when the bot claims & forwards them (unclaimed
- * fees are simply counted later, when claimed), so cumulative totals are exact even though any
- * single day can be lumpy. Contract team confirmed counting via these receivers is correct.
+ *   - Fees              = total borrow interest across all markets (Moolah `AccrueInterest.interest`).
+ *   - Revenue           = Lista's protocol cut = market protocol fee (interest × market.fee) +
+ *                         MoolahVault management fee (vault `AccrueInterest.feeShares`, only for the
+ *                         self-operated vaults whose feeRecipient is Lista's LendingFeeRecipient).
+ *   - SupplySideRevenue = Fees − Revenue = interest distributed to suppliers/lenders.
  *
  * @doc https://listaorg.notion.site/Profit-cfd754931df449eaa9a207e38d3e0a54
  * @test npx ts-node --transpile-only cli/testAdapter.ts fees lista-lending
  */
 
-// Moolah lending contract (source of the market protocol-fee transfers).
+const WAD = 10n ** 18n;
+
 const MOOLAH: Record<string, string> = {
   [CHAIN.BSC]: "0x8F73b65B4caAf64FBA2aF91cC5D4a2A1318E5D8C",
   [CHAIN.ETHEREUM]: "0xf820fB4680712CD7263a0D3D024D5b5aEA82Fd70",
 };
-// Downstream fee receivers, read on-chain from LendingFeeRecipient.{market,vault}FeeRecipient().
-// Hardcoded here (they are set-once config) so the adapter only makes indexed getLogs calls — a
-// live eth_call for these at the window's end block fails on pruned public RPCs ("missing trie node").
-const MARKET_FEE_RECIPIENT: Record<string, string> = {
-  [CHAIN.BSC]: "0x34B504A5CF0fF41F8A480580533b6Dda687fa3Da",
-  [CHAIN.ETHEREUM]: "0x0fe5741e8dFe53618c4056F745fad531118640D9",
-};
-const VAULT_FEE_RECIPIENT: Record<string, string> = {
-  [CHAIN.BSC]: "0xea55952a51ddd771d6eBc45Bd0B512276dd0b866",
+// Lista's LendingFeeRecipient — the fee recipient set on self-operated MoolahVaults. Used to keep
+// only Lista's own vaults (third-party curators route their fee elsewhere).
+const LENDING_FEE_RECIPIENT: Record<string, string> = {
+  [CHAIN.BSC]: "0x2E2Eed557FAb1d2E11fEA1E1a23FF8f1b23551f3",
   [CHAIN.ETHEREUM]: "0xd10a024602E042dcb9C19e21682c3b896c8B0d30",
 };
+const VAULT_LIST_API =
+  "https://api.lista.org/api/moolah/vault/list?page=1&pageSize=100&sort=depositsUsd&order=desc&chain=";
+const API_CHAIN: Record<string, string> = {
+  [CHAIN.BSC]: "bsc",
+  [CHAIN.ETHEREUM]: "ethereum",
+};
 
-const VAULT_MANAGEMENT_FEE = "Vault Management Fee";
-const MARKET_PROTOCOL_FEE = "Market Protocol Fee";
+const abis = {
+  AccrueInterest:
+    "event AccrueInterest(bytes32 indexed id, uint256 prevBorrowRate, uint256 interest, uint256 feeShares)",
+  idToMarketParams:
+    "function idToMarketParams(bytes32) view returns (address loanToken, address collateralToken, address oracle, address irm, uint256 lltv)",
+  market:
+    "function market(bytes32) view returns (uint128 totalSupplyAssets, uint128 totalSupplyShares, uint128 totalBorrowAssets, uint128 totalBorrowShares, uint128 lastUpdate, uint128 fee)",
+  VaultAccrueInterest: "event AccrueInterest(uint256 newTotalAssets, uint256 feeShares)",
+};
+
+const getVaultAddresses = async (chain: string): Promise<string[]> => {
+  const data = await getConfig(`lista-lending/vaults-${chain}`, VAULT_LIST_API + API_CHAIN[chain]);
+  return (data?.data?.list ?? []).map((v: any) => v.address);
+};
 
 const fetch = async (options: FetchOptions) => {
-  const { chain } = options;
+  const { chain, api } = options;
+  const dailyFees = options.createBalances();
   const dailyRevenue = options.createBalances();
+  const dailySupplySideRevenue = options.createBalances();
 
-  // Vault management fee: the vault fee recipient is a lending-only distributor, so count all inflows.
-  const vaultFees = options.createBalances();
-  await addTokensReceived({ options, target: VAULT_FEE_RECIPIENT[chain], balances: vaultFees });
-  dailyRevenue.addBalances(vaultFees, VAULT_MANAGEMENT_FEE);
+  // ---- Market layer: total borrow interest + market protocol fee ----
+  const interestLogs = await options.getLogs({ target: MOOLAH[chain], eventAbi: abis.AccrueInterest });
 
-  // Market protocol fee: the market fee recipient is a shared treasury (BSC also routes CDP stability
-  // fees here), so only count transfers coming straight from the Moolah lending contract.
-  const marketFees = options.createBalances();
-  await addTokensReceived({
-    options,
-    target: MARKET_FEE_RECIPIENT[chain],
-    fromAddressFilter: MOOLAH[chain],
-    balances: marketFees,
-  });
-  dailyRevenue.addBalances(marketFees, MARKET_PROTOCOL_FEE);
+  const marketIds = [...new Set(interestLogs.map((log: any) => String(log.id)))];
+  const loanToken: Record<string, string> = {};
+  const marketFeeRate: Record<string, bigint> = {};
+  if (marketIds.length) {
+    const [params, markets] = await Promise.all([
+      api.multiCall({ abi: abis.idToMarketParams, calls: marketIds.map((id) => ({ target: MOOLAH[chain], params: [id] })) }),
+      api.multiCall({ abi: abis.market, calls: marketIds.map((id) => ({ target: MOOLAH[chain], params: [id] })) }),
+    ]);
+    marketIds.forEach((id, i) => {
+      loanToken[id] = params[i].loanToken;
+      marketFeeRate[id] = BigInt(markets[i].fee);
+    });
+  }
+
+  for (const log of interestLogs) {
+    const id = String(log.id);
+    const token = loanToken[id];
+    if (!token) continue;
+    const interest = BigInt(log.interest);
+    const marketFee = (interest * marketFeeRate[id]) / WAD;
+    dailyFees.add(token, interest, METRIC.BORROW_INTEREST);
+    dailyRevenue.add(token, marketFee, METRIC.BORROW_INTEREST);
+    dailySupplySideRevenue.add(token, interest - marketFee, METRIC.BORROW_INTEREST);
+  }
+
+  // ---- Vault layer: MoolahVault management fee (Lista-operated vaults only) ----
+  const vaults = await getVaultAddresses(chain);
+  if (vaults.length) {
+    const feeRecipients = await api.multiCall({ abi: "address:feeRecipient", calls: vaults, permitFailure: true });
+    const listaVaults = vaults.filter(
+      (_, i) => feeRecipients[i]?.toLowerCase() === LENDING_FEE_RECIPIENT[chain].toLowerCase()
+    );
+
+    if (listaVaults.length) {
+      const vaultLogs = await options.getLogs({ targets: listaVaults, eventAbi: abis.VaultAccrueInterest, flatten: false });
+      const feeShares = listaVaults.map((_, i) =>
+        (vaultLogs[i] ?? []).reduce((sum: bigint, log: any) => sum + BigInt(log.feeShares), 0n)
+      );
+      const [assets, tokens] = await Promise.all([
+        api.multiCall({
+          abi: "function convertToAssets(uint256) view returns (uint256)",
+          calls: listaVaults.map((v, i) => ({ target: v, params: [feeShares[i].toString()] })),
+          permitFailure: true,
+        }),
+        api.multiCall({ abi: "address:asset", calls: listaVaults, permitFailure: true }),
+      ]);
+      listaVaults.forEach((_, i) => {
+        const feeAssets = assets[i] ? BigInt(assets[i]) : 0n;
+        if (feeAssets > 0n && tokens[i]) {
+          // Vault management fee is Lista revenue carved out of the market supply side.
+          dailyRevenue.add(tokens[i], feeAssets, METRIC.MANAGEMENT_FEES);
+          dailySupplySideRevenue.subtractToken(tokens[i], feeAssets, METRIC.BORROW_INTEREST);
+        }
+      });
+    }
+  }
 
   return {
-    dailyFees: dailyRevenue,
+    dailyFees,
     dailyRevenue,
     dailyProtocolRevenue: dailyRevenue,
+    dailySupplySideRevenue,
   };
 };
 
 const methodology = {
-  Fees: "Lending fees collected by Lista DAO: the market protocol fee (a % of borrow interest) plus the 10% management fee on self-operated MoolahVaults.",
-  Revenue: "Same as Fees — all lending fees accrue to Lista DAO via LendingFeeRecipient's downstream receivers.",
+  Fees: "Total borrow interest paid by borrowers across all Moolah markets.",
+  Revenue: "Lista's protocol cut: the market protocol fee (interest × market fee) plus the management fee on self-operated MoolahVaults.",
   ProtocolRevenue: "Same as Revenue — all lending fees are collected by Lista DAO.",
+  SupplySideRevenue: "Borrow interest distributed to suppliers/lenders, net of Lista's protocol cut.",
 };
 
 const breakdownMethodology = {
-  [VAULT_MANAGEMENT_FEE]: "10% management fee on self-operated MoolahVaults, received by the vault fee recipient (LendingRevenueDistributor).",
-  [MARKET_PROTOCOL_FEE]: "Protocol fee on Moolah market borrow interest, received straight from the Moolah lending contract by the market fee recipient.",
+  Fees: { [METRIC.BORROW_INTEREST]: "Total interest paid by borrowers across all Moolah markets." },
+  Revenue: {
+    [METRIC.BORROW_INTEREST]: "Market protocol fee = interest × market fee.",
+    [METRIC.MANAGEMENT_FEES]: "Management fee on self-operated MoolahVaults (feeRecipient = Lista's LendingFeeRecipient).",
+  },
+  ProtocolRevenue: {
+    [METRIC.BORROW_INTEREST]: "Market protocol fee = interest × market fee.",
+    [METRIC.MANAGEMENT_FEES]: "Management fee on self-operated MoolahVaults.",
+  },
+  SupplySideRevenue: {
+    [METRIC.BORROW_INTEREST]: "Interest to suppliers/lenders, net of the market fee and vault management fee.",
+  },
 };
 
 const adapter: SimpleAdapter = {
   version: 2,
   pullHourly: true,
   methodology,
-  breakdownMethodology: {
-    Fees: breakdownMethodology,
-    Revenue: breakdownMethodology,
-    ProtocolRevenue: breakdownMethodology,
-  },
+  breakdownMethodology,
   adapter: {
     [CHAIN.BSC]: { fetch, start: "2025-04-16" },
     // Lista Lending launched on Ethereum later.

--- a/fees/lista-lending/index.ts
+++ b/fees/lista-lending/index.ts
@@ -1,20 +1,20 @@
 import { FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 import { METRIC } from "../../helpers/metrics";
-import { getConfig } from "../../helpers/cache";
 
 /**
  * Lista Lending (Moolah) — a Morpho-Blue fork on BSC and Ethereum.
  *
  * Fees / SupplySide / Revenue are derived from on-chain interest accrual (same shape as the
- * canonical Morpho adapter), so the full borrow interest — including the yield earned by
+ * canonical `fees/morpho` adapter), so the full borrow interest — including the yield earned by
  * suppliers/lenders — is captured, not only Lista's protocol cut:
  *
  *   - Fees              = total borrow interest across all markets (Moolah `AccrueInterest.interest`).
- *   - Revenue           = Lista's protocol cut = market protocol fee (interest × market.fee) +
- *                         MoolahVault management fee (vault `AccrueInterest.feeShares`, only for the
- *                         self-operated vaults whose feeRecipient is Lista's LendingFeeRecipient).
+ *   - Revenue           = Lista's market protocol fee = interest × market fee.
  *   - SupplySideRevenue = Fees − Revenue = interest distributed to suppliers/lenders.
+ *
+ * Scope note: this tracks the Moolah lending *markets*. The separate MoolahVault management fee
+ * (a MetaMorpho-style vault layer, like Morpho vs MetaMorpho on DefiLlama) is out of scope here.
  *
  * @doc https://listaorg.notion.site/Profit-cfd754931df449eaa9a207e38d3e0a54
  * @test npx ts-node --transpile-only cli/testAdapter.ts fees lista-lending
@@ -26,32 +26,17 @@ const MOOLAH: Record<string, string> = {
   [CHAIN.BSC]: "0x8F73b65B4caAf64FBA2aF91cC5D4a2A1318E5D8C",
   [CHAIN.ETHEREUM]: "0xf820fB4680712CD7263a0D3D024D5b5aEA82Fd70",
 };
-// Lista's LendingFeeRecipient — the fee recipient set on self-operated MoolahVaults. Used to keep
-// only Lista's own vaults (third-party curators route their fee elsewhere).
-const LENDING_FEE_RECIPIENT: Record<string, string> = {
-  [CHAIN.BSC]: "0x2E2Eed557FAb1d2E11fEA1E1a23FF8f1b23551f3",
-  [CHAIN.ETHEREUM]: "0xd10a024602E042dcb9C19e21682c3b896c8B0d30",
-};
-const VAULT_LIST_API =
-  "https://api.lista.org/api/moolah/vault/list?page=1&pageSize=100&sort=depositsUsd&order=desc&chain=";
-const API_CHAIN: Record<string, string> = {
-  [CHAIN.BSC]: "bsc",
-  [CHAIN.ETHEREUM]: "ethereum",
-};
 
 const abis = {
   AccrueInterest:
     "event AccrueInterest(bytes32 indexed id, uint256 prevBorrowRate, uint256 interest, uint256 feeShares)",
+  // idToMarketParams is immutable per market id.
   idToMarketParams:
     "function idToMarketParams(bytes32) view returns (address loanToken, address collateralToken, address oracle, address irm, uint256 lltv)",
+  // market().fee is the protocol fee rate (WAD). Read per fetch window; it is effectively constant
+  // within a day and changes only via rare governance SetFee calls.
   market:
     "function market(bytes32) view returns (uint128 totalSupplyAssets, uint128 totalSupplyShares, uint128 totalBorrowAssets, uint128 totalBorrowShares, uint128 lastUpdate, uint128 fee)",
-  VaultAccrueInterest: "event AccrueInterest(uint256 newTotalAssets, uint256 feeShares)",
-};
-
-const getVaultAddresses = async (chain: string): Promise<string[]> => {
-  const data = await getConfig(`lista-lending/vaults-${chain}`, VAULT_LIST_API + API_CHAIN[chain]);
-  return (data?.data?.list ?? []).map((v: any) => v.address);
 };
 
 const fetch = async (options: FetchOptions) => {
@@ -60,10 +45,9 @@ const fetch = async (options: FetchOptions) => {
   const dailyRevenue = options.createBalances();
   const dailySupplySideRevenue = options.createBalances();
 
-  // ---- Market layer: total borrow interest + market protocol fee ----
-  const interestLogs = await options.getLogs({ target: MOOLAH[chain], eventAbi: abis.AccrueInterest });
+  const logs = await options.getLogs({ target: MOOLAH[chain], eventAbi: abis.AccrueInterest });
 
-  const marketIds = [...new Set(interestLogs.map((log: any) => String(log.id)))];
+  const marketIds = [...new Set(logs.map((log: any) => String(log.id)))];
   const loanToken: Record<string, string> = {};
   const marketFeeRate: Record<string, bigint> = {};
   if (marketIds.length) {
@@ -77,7 +61,7 @@ const fetch = async (options: FetchOptions) => {
     });
   }
 
-  for (const log of interestLogs) {
+  for (const log of logs) {
     const id = String(log.id);
     const token = loanToken[id];
     if (!token) continue;
@@ -86,38 +70,6 @@ const fetch = async (options: FetchOptions) => {
     dailyFees.add(token, interest, METRIC.BORROW_INTEREST);
     dailyRevenue.add(token, marketFee, METRIC.BORROW_INTEREST);
     dailySupplySideRevenue.add(token, interest - marketFee, METRIC.BORROW_INTEREST);
-  }
-
-  // ---- Vault layer: MoolahVault management fee (Lista-operated vaults only) ----
-  const vaults = await getVaultAddresses(chain);
-  if (vaults.length) {
-    const feeRecipients = await api.multiCall({ abi: "address:feeRecipient", calls: vaults, permitFailure: true });
-    const listaVaults = vaults.filter(
-      (_, i) => feeRecipients[i]?.toLowerCase() === LENDING_FEE_RECIPIENT[chain].toLowerCase()
-    );
-
-    if (listaVaults.length) {
-      const vaultLogs = await options.getLogs({ targets: listaVaults, eventAbi: abis.VaultAccrueInterest, flatten: false });
-      const feeShares = listaVaults.map((_, i) =>
-        (vaultLogs[i] ?? []).reduce((sum: bigint, log: any) => sum + BigInt(log.feeShares), 0n)
-      );
-      const [assets, tokens] = await Promise.all([
-        api.multiCall({
-          abi: "function convertToAssets(uint256) view returns (uint256)",
-          calls: listaVaults.map((v, i) => ({ target: v, params: [feeShares[i].toString()] })),
-          permitFailure: true,
-        }),
-        api.multiCall({ abi: "address:asset", calls: listaVaults, permitFailure: true }),
-      ]);
-      listaVaults.forEach((_, i) => {
-        const feeAssets = assets[i] ? BigInt(assets[i]) : 0n;
-        if (feeAssets > 0n && tokens[i]) {
-          // Vault management fee is Lista revenue carved out of the market supply side.
-          dailyRevenue.add(tokens[i], feeAssets, METRIC.MANAGEMENT_FEES);
-          dailySupplySideRevenue.subtractToken(tokens[i], feeAssets, METRIC.BORROW_INTEREST);
-        }
-      });
-    }
   }
 
   return {
@@ -130,24 +82,16 @@ const fetch = async (options: FetchOptions) => {
 
 const methodology = {
   Fees: "Total borrow interest paid by borrowers across all Moolah markets.",
-  Revenue: "Lista's protocol cut: the market protocol fee (interest × market fee) plus the management fee on self-operated MoolahVaults.",
-  ProtocolRevenue: "Same as Revenue — all lending fees are collected by Lista DAO.",
-  SupplySideRevenue: "Borrow interest distributed to suppliers/lenders, net of Lista's protocol cut.",
+  Revenue: "Lista's market protocol fee = borrow interest × the market fee rate.",
+  ProtocolRevenue: "Same as Revenue — the market protocol fee is collected by Lista DAO.",
+  SupplySideRevenue: "Borrow interest distributed to suppliers/lenders, net of the market protocol fee.",
 };
 
 const breakdownMethodology = {
   Fees: { [METRIC.BORROW_INTEREST]: "Total interest paid by borrowers across all Moolah markets." },
-  Revenue: {
-    [METRIC.BORROW_INTEREST]: "Market protocol fee = interest × market fee.",
-    [METRIC.MANAGEMENT_FEES]: "Management fee on self-operated MoolahVaults (feeRecipient = Lista's LendingFeeRecipient).",
-  },
-  ProtocolRevenue: {
-    [METRIC.BORROW_INTEREST]: "Market protocol fee = interest × market fee.",
-    [METRIC.MANAGEMENT_FEES]: "Management fee on self-operated MoolahVaults.",
-  },
-  SupplySideRevenue: {
-    [METRIC.BORROW_INTEREST]: "Interest to suppliers/lenders, net of the market fee and vault management fee.",
-  },
+  Revenue: { [METRIC.BORROW_INTEREST]: "Market protocol fee = borrow interest × market fee rate." },
+  ProtocolRevenue: { [METRIC.BORROW_INTEREST]: "Market protocol fee = borrow interest × market fee rate." },
+  SupplySideRevenue: { [METRIC.BORROW_INTEREST]: "Interest distributed to suppliers/lenders, net of the market fee." },
 };
 
 const adapter: SimpleAdapter = {

--- a/fees/lista-lending/index.ts
+++ b/fees/lista-lending/index.ts
@@ -82,9 +82,7 @@ const breakdownMethodology = {
 
 const adapter: SimpleAdapter = {
   version: 2,
-  // Explicit per repo guideline. Kept false: fees are settlement-timed claim events (no intra-day
-  // signal), and hourly would multiply the getLogs load on public RPCs when the indexer is absent.
-  pullHourly: false,
+  pullHourly: true,
   methodology,
   breakdownMethodology: {
     Fees: breakdownMethodology,

--- a/fees/lista-lending/index.ts
+++ b/fees/lista-lending/index.ts
@@ -1,152 +1,81 @@
 import { FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
-import { getConfig } from "../../helpers/cache";
-import { httpGet } from "../../utils/fetchURL";
+import { addTokensReceived } from "../../helpers/token";
 
 /**
- * Fetches data from Lista DAO
+ * Lista Lending (Moolah) protocol revenue.
+ *
+ * All lending fees are collected via LendingFeeRecipient, which forwards them to two downstream
+ * receivers:
+ *   - vault management fee (10% of vault yield) -> `vaultFeeRecipient`  (LendingRevenueDistributor)
+ *   - market protocol fee  (% of borrow interest) -> `marketFeeRecipient` (shared treasury / ListaRevenueDistributor)
+ *
+ * Revenue = tokens received by those receivers. The market receiver is a shared treasury that also
+ * collects CDP stability fees and other income, so the market fee is isolated by only counting
+ * transfers that come straight from the Moolah lending contract.
+ *
+ * This is claim/settlement-timed: fees are booked when the bot claims & forwards them (unclaimed
+ * fees are simply counted later, when claimed), so cumulative totals are exact even though any
+ * single day can be lumpy. Contract team confirmed counting via these receivers is correct.
+ *
  * @doc https://listaorg.notion.site/Profit-cfd754931df449eaa9a207e38d3e0a54
  * @test npx ts-node --transpile-only cli/testAdapter.ts fees lista-lending
- * Specify time by put it at the end of the command (in seconds)
  */
 
-// const eventContract = "0x2E2Eed557FAb1d2E11fEA1E1a23FF8f1b23551f3";
-
-interface VaultResponse {
-  code: string;
-  msg: string;
-  data: {
-    total: number;
-    list: Array<{
-      address: string;
-      curator: string;
-      fee: number;
-    }>;
-  };
-}
-
-interface VaultInfo {
-  address: string;
-  fee: number;
-  ownedByDao: boolean;
-}
-
-interface ApyHistoryResponse {
-  code: string;
-  msg: string;
-  data: Array<{
-    chartTime: number;
-    apy: string;
-    emissionApy: string;
-    totalAssets: string;
-    totalAssetsUsd: string;
-  }>;
-}
-
-const getVaultInfo = async (): Promise<VaultInfo[]> => {
-  const data: VaultResponse = await getConfig('lista-lending-vaults', 'https://api.lista.org/api/moolah/vault/list?page=1&pageSize=100&sort=depositsUsd&order=desc');
-  return data.data.list.map((vault) => ({
-    address: vault.address.toLowerCase(),
-    fee: vault.fee,
-    ownedByDao: vault.curator.toLowerCase().replace(/\s/g, "") === "listadao",
-  }));
+// Moolah lending contract (source of the market protocol-fee transfers).
+const MOOLAH: Record<string, string> = {
+  [CHAIN.BSC]: "0x8F73b65B4caAf64FBA2aF91cC5D4a2A1318E5D8C",
+  [CHAIN.ETHEREUM]: "0xf820fB4680712CD7263a0D3D024D5b5aEA82Fd70",
+};
+// Downstream fee receivers, read on-chain from LendingFeeRecipient.{market,vault}FeeRecipient().
+// Hardcoded here (they are set-once config) so the adapter only makes indexed getLogs calls — a
+// live eth_call for these at the window's end block fails on pruned public RPCs ("missing trie node").
+const MARKET_FEE_RECIPIENT: Record<string, string> = {
+  [CHAIN.BSC]: "0x34B504A5CF0fF41F8A480580533b6Dda687fa3Da",
+  [CHAIN.ETHEREUM]: "0x0fe5741e8dFe53618c4056F745fad531118640D9",
+};
+const VAULT_FEE_RECIPIENT: Record<string, string> = {
+  [CHAIN.BSC]: "0xea55952a51ddd771d6eBc45Bd0B512276dd0b866",
+  [CHAIN.ETHEREUM]: "0xd10a024602E042dcb9C19e21682c3b896c8B0d30",
 };
 
-// // Event ABIs
-// const vaultFeeClaimedEvent =
-//   "event VaultFeeClaimed(address vault, address token, uint256 assets, uint256 shares)";
-// const marketFeeClaimedEvent =
-//   "event MarketFeeClaimed(bytes32 id, address token, uint256 assets, uint256 shares)";
-
 const fetch = async (options: FetchOptions) => {
-  const dailyFees = options.createBalances();
+  const { chain } = options;
   const dailyRevenue = options.createBalances();
-  const dailySupplySideRevenue = options.createBalances();
-  const vaultInfoList = await getVaultInfo();
 
-  // // Get VaultFeeClaimed events
-  // const vaultFeeLogs = await options.getLogs({
-  //   target: eventContract,
-  //   eventAbi: vaultFeeClaimedEvent,
-  // });
+  // Vault management fee: the vault fee recipient is a lending-only distributor, so count all inflows.
+  await addTokensReceived({ options, target: VAULT_FEE_RECIPIENT[chain], balances: dailyRevenue });
 
-  // // Get MarketFeeClaimed events
-  // const marketFeeLogs = await options.getLogs({
-  //   target: eventContract,
-  //   eventAbi: marketFeeClaimedEvent,
-  // });
-
-  // // Process vault fees (performance fees) - only for ListaDAO curator vaults
-  // vaultFeeLogs.forEach((log) => {
-  //   const vaultInfo = vaultInfoList.find(v => v.address === log.vault.toLowerCase());
-  //   if (!vaultInfo?.ownedByDao) return;
-  //   dailyRevenue.add(log.token, log.assets);
-  // });
-
-  // // Process market fees
-  // marketFeeLogs.forEach((log) => dailyRevenue.add(log.token, log.assets));
-
-  // Calculate supply side revenue and protocol revenue from APY history
-  for (const vaultInfo of vaultInfoList) {
-    const url = `https://api.lista.org/api/moolah/vault/apy/history?address=${vaultInfo.address}&startTime=${options.startTimestamp}&endTime=${options.endTimestamp}`;
-    const data: ApyHistoryResponse = await httpGet(url);
-
-    if (data.data && data.data.length > 0) {
-      const dayData = data.data[0];
-      const apy = parseFloat(dayData.apy);
-      const totalAssetsUsd = parseFloat(dayData.totalAssetsUsd);
-
-      const dailyInterest = (apy * totalAssetsUsd) / 365;
-
-      dailyFees.addCGToken('usd-coin', dailyInterest, 'Borrow Interest');
-      
-      if (vaultInfo.ownedByDao) {
-        const performanceFee = dailyInterest * (vaultInfo.fee);
-        const performanceFeeToCurators = performanceFee * 0.5;
-        dailyRevenue.addCGToken("usd-coin", performanceFeeToCurators, 'Performance Fees');
-        dailySupplySideRevenue.addCGToken("usd-coin", performanceFeeToCurators, 'Curators Fees');
-        dailySupplySideRevenue.addCGToken("usd-coin", dailyInterest - performanceFee, 'Borrow Interest To Lenders');
-      } else {
-        dailySupplySideRevenue.addCGToken("usd-coin", dailyInterest, 'Borrow Interest To Lenders');
-      }
-    }
-    await new Promise(resolve => setTimeout(resolve, 500));
-  }
+  // Market protocol fee: the market fee recipient is a shared treasury (BSC also routes CDP stability
+  // fees here), so only count transfers coming straight from the Moolah lending contract.
+  await addTokensReceived({
+    options,
+    target: MARKET_FEE_RECIPIENT[chain],
+    fromAddressFilter: MOOLAH[chain],
+    balances: dailyRevenue,
+  });
 
   return {
-    dailyFees,
+    dailyFees: dailyRevenue,
     dailyRevenue,
     dailyProtocolRevenue: dailyRevenue,
-    dailySupplySideRevenue,
   };
 };
 
 const methodology = {
-  Fees: "Interest earned by lenders from borrowers",
-  Revenue: "ListaDAO Curator vaults performance fees (in basis points) charged on vault interest",
-  ProtocolRevenue: "ListaDAO Curator vaults performance fees (in basis points) charged on vault interest",
-  SupplySideRevenue: "Interest earned by lenders in the vaults and fees to curators",
+  Fees: "Lending fees collected by Lista DAO: the market protocol fee (a % of borrow interest) plus the 10% management fee on self-operated MoolahVaults.",
+  Revenue: "Same as Fees — all lending fees accrue to Lista DAO via LendingFeeRecipient's downstream receivers.",
+  ProtocolRevenue: "Same as Revenue — all lending fees are collected by Lista DAO.",
 };
 
 const adapter: SimpleAdapter = {
-  version: 1,
-  fetch,
-  chains: [CHAIN.BSC],
-  start: '2025-04-16',
-  isExpensiveAdapter: true,
+  version: 2,
   methodology,
-  breakdownMethodology: {
-    Fees: {
-      'Borrow Interest': 'Interest earned by lenders from borrowers',
-    },
-    Revenue: {
-      'Performance Fees': 'ListaDAO Curator vaults performance fees (in basis points) charged on vault interest',
-    },
-    SupplySideRevenue: {
-      'Curators Fees': 'Performance fees paid to vaults curators.',
-      'Borrow Interest To Lenders': 'Interest earned by lenders in the vaults',
-    },
-  }
+  adapter: {
+    [CHAIN.BSC]: { fetch, start: "2025-04-16" },
+    // Lista Lending launched on Ethereum later.
+    [CHAIN.ETHEREUM]: { fetch, start: "2025-10-02" },
+  },
 };
 
 export default adapter;

--- a/fees/lista-lending/index.ts
+++ b/fees/lista-lending/index.ts
@@ -39,21 +39,28 @@ const VAULT_FEE_RECIPIENT: Record<string, string> = {
   [CHAIN.ETHEREUM]: "0xd10a024602E042dcb9C19e21682c3b896c8B0d30",
 };
 
+const VAULT_MANAGEMENT_FEE = "Vault Management Fee";
+const MARKET_PROTOCOL_FEE = "Market Protocol Fee";
+
 const fetch = async (options: FetchOptions) => {
   const { chain } = options;
   const dailyRevenue = options.createBalances();
 
   // Vault management fee: the vault fee recipient is a lending-only distributor, so count all inflows.
-  await addTokensReceived({ options, target: VAULT_FEE_RECIPIENT[chain], balances: dailyRevenue });
+  const vaultFees = options.createBalances();
+  await addTokensReceived({ options, target: VAULT_FEE_RECIPIENT[chain], balances: vaultFees });
+  dailyRevenue.addBalances(vaultFees, VAULT_MANAGEMENT_FEE);
 
   // Market protocol fee: the market fee recipient is a shared treasury (BSC also routes CDP stability
   // fees here), so only count transfers coming straight from the Moolah lending contract.
+  const marketFees = options.createBalances();
   await addTokensReceived({
     options,
     target: MARKET_FEE_RECIPIENT[chain],
     fromAddressFilter: MOOLAH[chain],
-    balances: dailyRevenue,
+    balances: marketFees,
   });
+  dailyRevenue.addBalances(marketFees, MARKET_PROTOCOL_FEE);
 
   return {
     dailyFees: dailyRevenue,
@@ -68,9 +75,22 @@ const methodology = {
   ProtocolRevenue: "Same as Revenue — all lending fees are collected by Lista DAO.",
 };
 
+const breakdownMethodology = {
+  [VAULT_MANAGEMENT_FEE]: "10% management fee on self-operated MoolahVaults, received by the vault fee recipient (LendingRevenueDistributor).",
+  [MARKET_PROTOCOL_FEE]: "Protocol fee on Moolah market borrow interest, received straight from the Moolah lending contract by the market fee recipient.",
+};
+
 const adapter: SimpleAdapter = {
   version: 2,
+  // Explicit per repo guideline. Kept false: fees are settlement-timed claim events (no intra-day
+  // signal), and hourly would multiply the getLogs load on public RPCs when the indexer is absent.
+  pullHourly: false,
   methodology,
+  breakdownMethodology: {
+    Fees: breakdownMethodology,
+    Revenue: breakdownMethodology,
+    ProtocolRevenue: breakdownMethodology,
+  },
   adapter: {
     [CHAIN.BSC]: { fetch, start: "2025-04-16" },
     // Lista Lending launched on Ethereum later.


### PR DESCRIPTION
## Summary
Fix revenue/fees tracking in the `lista-lending` (Moolah, a Morpho-Blue fork) adapter. The previous method mis-reported both **Fees** (it missed the interest paid to suppliers) and **Revenue** (an API-APY estimate reported ~0.7% of Fees).

## Background — how the accuracy drifted
- Originally (#2948, 2025-04) the adapter was **event-based**: it read claimed fees from `LendingFeeRecipient`.
- #5798 replaced that with an **API-APY estimate** (`dailyInterest = apy × TVL / 365`), and #7272 multiplied it by `× 0.5`.

## Change — on-chain interest accrual (Morpho-Blue shape)
Rewritten to read Moolah's on-chain `AccrueInterest` events so the **full borrow interest (including supplier/lender yield) is captured**, not only Lista's protocol cut:

- **Fees** = total borrow interest across all markets = Σ `Moolah.AccrueInterest.interest`.
- **Revenue / ProtocolRevenue** = Lista's full lending take:
  - market protocol fee = `interest × market.fee` (WAD), plus
  - MoolahVault management fee = vault `AccrueInterest.feeShares` valued via `convertToAssets`, counted **only** for self-operated vaults whose `feeRecipient` is Lista's `LendingFeeRecipient` (third-party curators excluded).
- **SupplySideRevenue** = `Fees − Revenue` = interest distributed to suppliers/lenders.

Market ids come from the `AccrueInterest` logs; `loanToken` (immutable) and fee rate are resolved on-chain (`idToMarketParams`, `market`). The vault inventory is paginated from Lista's API (addresses only) and throws on an invalid/unavailable response. Covers BSC + Ethereum.

## Verification (on-chain, archive RPC)
- Identity holds: `Fees = SupplySideRevenue + Revenue` (e.g. one BSC+ETH day: Fees $13,349 = SupplySide $9,823 + market fee $1,335 + vault fee $2,190).
- Market fee comes out to exactly **10%** of interest (`1,335 / 13,349`), matching the on-chain `market.fee`.
- The vault management fee is settlement-lumpy per day (MetaMorpho accrues on asset growth since the vault's last touch) but cumulatively correct; it is subtracted from SupplySide so the identity always holds.

## CI note
The `test` job runs against public BSC RPCs with **no archive state / Llama Indexer key**, so `getLogs` and historical state reads hit public-node limits (`missing trie node` / log-range) — the same failure many recently-merged fee PRs and the existing `lista-lisusd` / `lista-rwa` adapters have here. Verified locally with `BSC_RPC` / `ETHEREUM_RPC` pointed at archive nodes; runs fine in production with the indexer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
