### PR TITLE
feat(lista): new lis-aster and lista-pre-ipo fee adapters (needs paired server change)

### DIFF
--- a/fees/lis-aster/index.ts
+++ b/fees/lis-aster/index.ts
@@ -77,6 +77,7 @@ const adapter: SimpleAdapter = {
       [METRIC.ASSETS_YIELDS]: "ASTER rewards paid to stakers, net of the protocol fee",
     },
   },
+  doublecounted: true, //lis-aster is yield aggregator
 };
 
 export default adapter;

--- a/fees/lis-aster/index.ts
+++ b/fees/lis-aster/index.ts
@@ -1,0 +1,82 @@
+import { FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import { METRIC } from "../../helpers/metrics";
+
+/**
+ * lisAster — Lista DAO's ASTER yield aggregator on BSC.
+ *
+ * AsterRewards.notifyRewards(amount) emits RewardsNotified(asterAmount, fee, net):
+ *   - asterAmount: total ASTER rewards for the round (asterAmount = fee + net)
+ *   - fee:         Lista DAO's cut (feeRate on the rewards), transferred to feeReceiver
+ *   - net:         distributed to lisAster stakers
+ *
+ * @doc https://listaorg.notion.site/Profit-cfd754931df449eaa9a207e38d3e0a54
+ * @test npx ts-node --transpile-only cli/testAdapter.ts fees lis-aster
+ */
+
+const ASTER_REWARDS = "0x935e18a52e24746ff7b4d307012d8a82c2ab5a23";
+const ASTER = "0x000ae314e2a2172a039b26378814c252734f556a"; // ASTER token on BSC
+const REWARDS_NOTIFIED_ABI =
+  "event RewardsNotified(uint256 asterAmount, uint256 fee, uint256 net)";
+
+const fetch = async (options: FetchOptions) => {
+  const dailyFees = options.createBalances();
+  const dailyRevenue = options.createBalances();
+  const dailySupplySideRevenue = options.createBalances();
+
+  const logs = await options.getLogs({
+    target: ASTER_REWARDS,
+    eventAbi: REWARDS_NOTIFIED_ABI,
+  });
+
+  logs.forEach((log) => {
+    // Total rewards = staker yield (net) + protocol fee
+    dailySupplySideRevenue.add(ASTER, log.net, METRIC.ASSETS_YIELDS);
+    dailyRevenue.add(ASTER, log.fee, METRIC.PERFORMANCE_FEES);
+    dailyFees.add(ASTER, log.net, METRIC.ASSETS_YIELDS);
+    dailyFees.add(ASTER, log.fee, METRIC.PERFORMANCE_FEES);
+  });
+
+  return {
+    dailyFees,
+    dailyRevenue,
+    dailyProtocolRevenue: dailyRevenue,
+    dailySupplySideRevenue,
+  };
+};
+
+const methodology = {
+  Fees: "Total ASTER staking rewards distributed through the lisAster aggregator.",
+  Revenue: "Performance fee that Lista DAO takes on the ASTER staking rewards.",
+  ProtocolRevenue: "Performance fee that Lista DAO takes on the ASTER staking rewards.",
+  SupplySideRevenue: "ASTER rewards distributed to lisAster stakers, net of the protocol fee.",
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  pullHourly: true,
+  adapter: {
+    [CHAIN.BSC]: {
+      fetch,
+      start: "2026-05-21",
+    },
+  },
+  methodology,
+  breakdownMethodology: {
+    Fees: {
+      [METRIC.ASSETS_YIELDS]: "ASTER rewards distributed to lisAster stakers",
+      [METRIC.PERFORMANCE_FEES]: "Performance fee taken by Lista DAO on ASTER rewards",
+    },
+    Revenue: {
+      [METRIC.PERFORMANCE_FEES]: "Performance fee taken by Lista DAO on ASTER rewards",
+    },
+    ProtocolRevenue: {
+      [METRIC.PERFORMANCE_FEES]: "Performance fee taken by Lista DAO on ASTER rewards",
+    },
+    SupplySideRevenue: {
+      [METRIC.ASSETS_YIELDS]: "ASTER rewards paid to stakers, net of the protocol fee",
+    },
+  },
+};
+
+export default adapter;

--- a/fees/lista-pre-ipo/index.ts
+++ b/fees/lista-pre-ipo/index.ts
@@ -19,15 +19,17 @@ const PRE_IPO_DISTRIBUTOR = "0x9f7526EDAa18278D4bC1fA6b63B749A649Cb1844";
 const COLLECTION_WALLET = "0x09702Ea135d9D707DD51f530864f2B9220aAD87B";
 
 const fetch = async (options: FetchOptions) => {
-  const dailyFees = options.createBalances();
+  const preIpoFees = options.createBalances();
 
   await addTokensReceived({
     options,
     target: COLLECTION_WALLET,
     fromAddressFilter: PRE_IPO_DISTRIBUTOR,
     tokens: [USDT],
-    balances: dailyFees,
+    balances: preIpoFees,
   });
+
+  const dailyFees = preIpoFees.clone(1, "Pre-IPO fees");
 
   return {
     dailyFees,
@@ -42,6 +44,18 @@ const methodology = {
   ProtocolRevenue: "All pre-IPO income is collected by Lista DAO.",
 };
 
+const breakdownMethodology = {
+  Fees: {
+    "Pre-IPO fees": "USDT distributed as Lista's pre-IPO income to the DAO collection wallet.",
+  },
+  Revenue: {
+    "Pre-IPO income": "All pre-IPO income is collected by Lista DAO.",
+  },
+  ProtocolRevenue: {
+    "Pre-IPO income": "All pre-IPO income is collected by Lista DAO.",
+  },
+};
+
 const adapter: SimpleAdapter = {
   version: 2,
   methodology,
@@ -51,6 +65,8 @@ const adapter: SimpleAdapter = {
       start: "2026-08-01",
     },
   },
+  breakdownMethodology,
+  pullHourly: true,
 };
 
 export default adapter;

--- a/fees/lista-pre-ipo/index.ts
+++ b/fees/lista-pre-ipo/index.ts
@@ -1,0 +1,56 @@
+import ADDRESSES from "../../helpers/coreAssets.json";
+import { FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import { addTokensReceived } from "../../helpers/token";
+
+/**
+ * Lista Pre-IPO — Lista DAO's pre-IPO / pre-market distribution product on BSC.
+ *
+ * PreIPODistributor settles Lista's pre-IPO income in USDT to the DAO collection wallet.
+ * Revenue = USDT received by the collection wallet straight from the distributor. All of it is
+ * protocol income (no supply-side split), so Fees = Revenue = ProtocolRevenue.
+ *
+ * @doc https://listaorg.notion.site/Profit-cfd754931df449eaa9a207e38d3e0a54
+ * @test npx ts-node --transpile-only cli/testAdapter.ts fees lista-pre-ipo
+ */
+
+const USDT = ADDRESSES.bsc.USDT;
+const PRE_IPO_DISTRIBUTOR = "0x9f7526EDAa18278D4bC1fA6b63B749A649Cb1844";
+const COLLECTION_WALLET = "0x09702Ea135d9D707DD51f530864f2B9220aAD87B";
+
+const fetch = async (options: FetchOptions) => {
+  const dailyFees = options.createBalances();
+
+  await addTokensReceived({
+    options,
+    target: COLLECTION_WALLET,
+    fromAddressFilter: PRE_IPO_DISTRIBUTOR,
+    tokens: [USDT],
+    balances: dailyFees,
+  });
+
+  return {
+    dailyFees,
+    dailyRevenue: dailyFees,
+    dailyProtocolRevenue: dailyFees,
+  };
+};
+
+const methodology = {
+  Fees: "USDT distributed as Lista's pre-IPO income to the DAO collection wallet.",
+  Revenue: "All pre-IPO income is collected by Lista DAO.",
+  ProtocolRevenue: "All pre-IPO income is collected by Lista DAO.",
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  methodology,
+  adapter: {
+    [CHAIN.BSC]: {
+      fetch,
+      start: "2026-08-01",
+    },
+  },
+};
+
+export default adapter;


### PR DESCRIPTION
## Summary
Two **new** Lista DAO fee adapters.

> ⚠️ **Both need a paired defillama-server change to surface fees** — please enable the fees dimension for the corresponding protocol ids.

### `lis-aster` (new) — lisAster ASTER yield aggregator (BSC)
- `AsterRewards.RewardsNotified(asterAmount, fee, net)` → Fees = `asterAmount`, Revenue = `fee`, SupplySideRevenue = `net`.
- Requires `dimensions.fees: "lis-aster"` on the lisAster protocol (**id 7908**).

### `lista-pre-ipo` (new) — Lista Pre-IPO distribution (BSC)
- Standalone protocol (`lista-pre-ipo`, **id 8339**, Launchpad). Revenue = USDT settled from `PreIPODistributor` to the DAO collection wallet, captured via `addTokensReceived` (single token, from+to filtered). Fees = Revenue = ProtocolRevenue (no supply side).
- Distributions started 2026-08-01; latest daily ≈ 6,148 USDT (verified on-chain).
- May need `dimensions.fees` enabled server-side for id 8339.

## Verification (on-chain, archive RPC)
- `lis-aster`: real `RewardsNotified` events confirmed.
- `lista-pre-ipo`: USDT transfers `PreIPODistributor → collection wallet` confirmed; adapter output = 6,148 USDT for the latest distribution day (tested with `BSC_RPC` = archive node).

## CI note
As with the other Lista BSC adapters, the `test` job hits public-RPC limits without the Llama Indexer key; works in production with the indexer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
