### PR TITLE
reservoir-tools-amm: drop zero chain, both its rpcs are gone

### DIFF
--- a/factory/uniV2.ts
+++ b/factory/uniV2.ts
@@ -728,7 +728,7 @@ const configs: Record<string, Record<string, any>> = {
   "reservoir-tools-amm": {
     [CHAIN.ABSTRACT]: { factory: '0x566d7510dEE58360a64C9827257cF6D0Dc43985E', start: '2025-01-07', userFeesRatio: 1, revenueRatio: 0, protocolRevenueRatio: 0, holdersRevenueRatio: 0 },
     [CHAIN.INK]: { factory: '0xfe57A6BA1951F69aE2Ed4abe23e0f095DF500C04', start: '2025-01-07', userFeesRatio: 1, revenueRatio: 0, protocolRevenueRatio: 0, holdersRevenueRatio: 0 },
-    [CHAIN.ZERO]: { factory: '0x1B4427e212475B12e62f0f142b8AfEf3BC18B559', start: '2025-01-07', userFeesRatio: 1, revenueRatio: 0, protocolRevenueRatio: 0, holdersRevenueRatio: 0 },
+    // [CHAIN.ZERO]: { factory: '0x1B4427e212475B12e62f0f142b8AfEf3BC18B559', start: '2025-01-07', userFeesRatio: 1, revenueRatio: 0, protocolRevenueRatio: 0, holdersRevenueRatio: 0 },
   },
   "shapeswap-v2": {
     [CHAIN.SHAPE]: { factory: '0xb411eAF2f2070822B26E372E3Ea63c5060BA45E6', start: '2024-12-13', userFeesRatio: 1, revenueRatio: 0, protocolRevenueRatio: 0, holdersRevenueRatio: 0 },


### PR DESCRIPTION
Fixes #8714.

Same one-line change as #8747, on the sibling adapter. Both of zero_network's configured RPCs are gone, so the leg throws on `getBlock` and takes the whole multi-chain run down with it:

```
rpc.zerion.io/v1/zero  ->  {"code":-32035,"message":"Node is not available."}
zero.drpc.org          ->  "chain is not available on free plan, please upgrade to paid plan"
```

Those are the only two entries in `providers.json` for it. drpc paywalled the chain sometime after 08-13, which is when `sakuraswap-amm` stopped publishing, it last recorded 2026-08-12 while `sakuraswap-clmm`, which had this entry removed by #8747, is current through 08-14 on the same two live chains.

On master:

```
$ npm test dexs reservoir-tools-amm
------ ERROR ------
Error: No RPCs available for zero_network
```

With this change:

```
chain     | Daily volume | Daily fees
abstract  | 9.63 k       | 28.89
ink       | 0.00         | 0.00
Aggregate | 9.63 k       | 28.89
```

Second run $9.63k / $28.88.

Commented out rather than deleted, same as the RARI entry at `factory/uniV2.ts:493`; Zero Network itself is alive, just slow with no public RPC left, so this can be uncommented if one shows up.
