### PR TITLE
verus: throw when the api reports no lp_volume instead of publishing zero

### DIFF
--- a/dexs/verus.ts
+++ b/dexs/verus.ts
@@ -12,8 +12,13 @@ const methodology = {
 const fetch = async () => {
   const response = await httpGet('https://marketapi.verus.services/getdefichaininfo');
 
+  const results = response.data.results;
+  if (!results.some((result: any) => typeof result.lp_volume === "number")) {
+    throw new Error("verus market api returned no lp_volume for any of its pools");
+  }
+
   let dailyVolume = 0;
-  for (const result of response.data.results) {
+  for (const result of results) {
     dailyVolume += Number(result.lp_volume);
   }
 


### PR DESCRIPTION
Fixes #8773.

`marketapi.verus.services/getdefichaininfo` is up and returns all 20 pools with their reserves intact, but `lp_volume` has been `null` on every one of them since 2026-07-24. `Number(null)` is `0`, so the sum came out to zero and 22 consecutive days got stored as genuine no-volume days.

The pools are still trading, their own ticker endpoint reports `volume: 0` on all 40 pairs while 34 of them have `high !== low`, including a 9.80% high-to-low range on USDC-VRSC. These are reserve-based conversion pools, so the price only moves when someone converts.

There is nowhere else to read volume from: `/gettotalvolume` and `/market/allTickers/new` both return HTTP 500, `/getcurrencyvolumes` returns `[null, null]` per pool, and `/gettvl` returns a pandas indexing error. Full survey in the issue.

So this only fixes the part that is fixable here, the adapter cannot currently tell "no conversions happened" from "the API did not report". A genuine quiet day comes back as `0`, a number, so requiring at least one numeric `lp_volume` leaves that path working and turns the null case into a retryable failure.

Before, on master:

```
$ npm test dexs verus
Daily volume: 0.00
Daily fees: 0.00
```

exit 0, nothing to alert on. After:

```
$ npm test dexs verus
------ ERROR ------
Error: verus market api returned no lp_volume for any of its pools
```

exit 1, same on a second run.

This will not backfill the 22 days, that needs the upstream API fixed. It stops the run from quietly adding more of them. Same shape as the guards merged for `hinkal` (#8581) and `pact` (#8547).
