### PR TITLE
mark moonbeam and moonriver dead, both stopped producing blocks on 2026-08-10

### DIFF
--- a/helpers/deadChains.ts
+++ b/helpers/deadChains.ts
@@ -1,7 +1,9 @@
 import * as sdk from "@defillama/sdk"
 
 export const deadChains = [
-  ...sdk.chainUtils.getDeadChains()
+  ...sdk.chainUtils.getDeadChains(),
+  'moonbeam', // parachain wind-down announced 2026-07-03, GLMR migrated to Base, last block 16796699 on 2026-08-10: https://forum.moonbeam.network/t/multisig-maintenance-wind-down-moonbeam-moonriver-and-moonbase-july-2026/2512
+  'moonriver', // same wind-down as moonbeam, MOVR migrated to Base, last block 17381654 on 2026-08-10
 ]
 
 


### PR DESCRIPTION
Fixes #8776

Both chains were wound down by the Moonbeam team and stopped producing blocks on 2026-08-10, moonriver at block 17381654 (08:27:48Z), moonbeam at 16796699 (11:36:12Z). Every reachable provider in `providers.json` reports the same head and none of them advance, so it is a halted chain and not something a new RPC would fix. Announcement and migration to Base: https://forum.moonbeam.network/t/multisig-maintenance-wind-down-moonbeam-moonriver-and-moonbase-july-2026/2512

They are not in the dead-chains list yet, so the staleness guard throws on the block lookup, `fromBlock` never gets set, and `getLogs` takes down the entire multi-chain run. `npm test fees moonwell` on master:

```
error fetching block Error: Last block for moonriver is 7132 minutes behind ...
error fetching block Error: Last block for moonbeam is 6944 minutes behind ...
------ ERROR ------
Error: fromBlock or fromTimestamp is required
```

With this change:

```
chain     | Daily fees | Daily revenue | Daily supply side revenue
base      | 8.09 k     | 1.02 k        | 7.08 k
optimism  | 133.00     | 14.00         | 119.00
ethereum  | 207.00     | 24.00         | 184.00
Aggregate | 8.43 k     | 1.05 k        | 7.38 k
```

Ran both twice, same numbers each time. `npm run ts-check` is clean.

8 adapters are currently writing nothing at all because of this (`total24h == null`, `total7d > 0`), padswap $2.1M/30d, li.fi-bridge-aggregator $841k across 46 configured chains, moonwell-lending $142k, sushiswap-agg, beefy, rango, portal, synapse. Most of them last published on 2026-08-10.

Also checked the adapters where one of these is the only chain (`moonwell-apollo` on moonriver, `moonwell-artemis` on moonbeam), with the change they exit cleanly with no rows instead of erroring, so nothing regresses.

I put these in `helpers/deadChains.ts` rather than the sdk list so it takes effect without waiting on an sdk bump. Happy to move it to `chainUtils` instead if you would rather keep them all in one place.

Harmony has also stopped producing blocks and breaks layerzero, defi-kingdoms, viperswap and swap-country in exactly the same way, but a rollback is still being discussed there so I have not touched it; that one is in #8777.
