### PR TITLE
[feat] Virae - add Polymarket builder volume and fees

### DIFF
--- a/factory/polymarket.ts
+++ b/factory/polymarket.ts
@@ -29,6 +29,7 @@ const dexsConfigs: Record<string, { builder: string; start: string; builderCode?
   "wager-up-pilot": { builder: "WagerUpPilot", start: "2026-04-07", builderCode: "0xbc37cc54237a06aa0d380814fadf2f5b6d20483300833f381e4727f1066845fb" },
   "yeno": { builder: "yeno-markets", start: "2026-06-26", builderCode: "0x5bffd61a6dbfca06f19a543cac4b9e433378ac9992d70b8a40824720e353498f" },
   "smartx": { builder: "SmartX", start: "2026-02-27", builderCode: "0x58d3820045831c879b218ec64514dc191eebadf31a4641670293fddf542643c3" },
+  "virae": { builder: "Virae.ai", start: "2026-05-02", builderCode: "0xcb5f0c1b63c47ad9193a5d1a95a2055076eec604be4abb019025dd0e3554a7cc" },
 };
 
 const feesConfigs: Record<string, { builderName: string; builderCode: string; start: string }> = {
@@ -43,6 +44,7 @@ const feesConfigs: Record<string, { builderName: string; builderCode: string; st
   "traderline": { builderName: "traderline", builderCode: "0x6b0e773fada0a2ec67c956b25a737d353a534ea33db56c717ba7854346c67984", start: "2026-04-28" },
   "yeno": { builderName: "yeno-markets", builderCode: "0x5bffd61a6dbfca06f19a543cac4b9e433378ac9992d70b8a40824720e353498f", start: "2026-06-26" },
   "smartx": { builderName: "SmartX", builderCode: "0x58d3820045831c879b218ec64514dc191eebadf31a4641670293fddf542643c3", start: "2026-04-28" },
+  "virae": { builderName: "Virae.ai", builderCode: "0xcb5f0c1b63c47ad9193a5d1a95a2055076eec604be4abb019025dd0e3554a7cc", start: "2026-04-28" },
 }
 
 const dexsProtocols: Record<string, any> = {};


### PR DESCRIPTION
## Add Virae Polymarket builder volume and fees

This adds Virae to the existing Polymarket builder factory for:

- attributed daily notional volume and cash volume;
- Polymarket v2 builder fees, revenue, and protocol revenue.

The adapter uses Polymarket's public builder APIs and the verified Virae builder code. It does not report TVL because Virae is a non-custodial trading interface and does not operate a separate liquidity protocol.

### Listing metadata

##### Name (to be shown on DefiLlama):

Virae

##### Twitter Link:

https://x.com/virae_dot_ai

##### List of audit links if any:

N/A — this submission covers an interface and its Polymarket-attributed activity, not a new custody contract.

##### Website Link:

https://www.virae.ai

##### Logo (High resolution, will be shown with rounded borders):

https://www.virae.ai/virae/virae-mark.svg

##### Current TVL:

N/A — Virae does not claim protocol TVL.

##### Treasury Addresses (if the protocol has treasury):

Polygon fee collectors:

- 0x85b17c892Abf4BBC6e2066b3df82FA6Bb3F9316A
- 0xc517201f285A3e7d45585dd631545780389783BC

These addresses receive Virae platform-fee revenue in pUSD through an 80%/20% routing pool. They are supplied as listing metadata only in this PR; their transfers are not added to the adapter metrics.

##### Chain:

Polygon

##### Coingecko ID:

N/A

##### Coinmarketcap ID:

N/A

##### Short Description (to be shown on DefiLlama):

AI-powered prediction-market trading interface with instant execution, copy trading, whale insights, portfolio analytics, and automated trading tools.

##### Token address and ticker if any:

N/A

##### Category:

Interface

##### Oracle Provider(s):

Virae does not operate a separate market-resolution oracle; the tracked trades and markets are provided by Polymarket.

##### Implementation Details:

The adapter queries Polymarket's public builder volume and Builder Trades endpoints using Virae's verified builder identity and builder code.

##### Documentation/Proof:

- https://docs.polymarket.com/builders/fees
- https://docs.polymarket.com/api-reference/trade/get-builder-trades
- https://docs.polymarket.com/api-reference/builders/get-daily-builder-volume-time-series
- https://www.virae.ai/partners

##### forkedFrom:

No.

##### methodology:

- Volume: Polymarket-attributed trades for the verified `Virae.ai` builder. Cash volume sums `sizeUsdc`; notional volume uses Polymarket's daily builder-volume series.
- Fees and revenue: Polymarket v2 `builderFee` attributed to Virae. These metrics intentionally exclude Virae's separate pUSD platform-fee collector transfers until a distinct on-chain methodology is reviewed.

##### Github org/user:

https://github.com/Virae-Labs

##### Does this project have a referral program?

Yes.

### Verification

Tested against 2026-08-14 UTC:

```text
pnpm test dexs virae 2026-08-15
Daily notional volume: 114.00
Daily volume: 87.00

pnpm test fees virae 2026-08-15
Daily fees: 0.07
Daily revenue: 0.07
Daily protocol revenue: 0.07
Polymarket Builder Fees: 0.06690000000000002

pnpm ts-check
passed
```
