### PR TITLE
ekubo: pad token addresses and catch the 0x0 native token

### DIFF
--- a/dexs/ekubo/index.ts
+++ b/dexs/ekubo/index.ts
@@ -10,8 +10,10 @@ const chainConfig: Record<string, { start: string, chainId: String }> = {
   [CHAIN.ROBINHOOD]: { start: '2026-07-21', chainId: "4663" },
 }
 
-function toAddress(numberString: string): string {
-  return numberString === '0' ? ADDRESSES.null : `0x${new BigNumber(numberString).toString(16)}`;
+function toAddress(numberString: string, chain: string): string {
+  const hex = new BigNumber(numberString).toString(16)
+  if (hex === '0') return ADDRESSES.null
+  return chain === CHAIN.STARKNET ? `0x${hex}` : `0x${hex.padStart(40, '0')}`
 }
 
 const fetch = async (options: FetchOptions) => {
@@ -25,15 +27,15 @@ const fetch = async (options: FetchOptions) => {
   const responseRevenue: any[] = (await httpGet('https://prod-api.ekubo.org/overview/revenue?chainId=' + chainId)).revenueByTokenByDate
 
   responseVolumes.filter((t) => t.date.split('T')[0] === dateStr).map((t) => {
-    const token = toAddress(t.token)
+    const token = toAddress(t.token, options.chain)
     dailyVolume.add(token, t.volume)
     dailyFees.add(token, t.fees)
   })
 
   responseRevenue.filter((t) => t.date.split('T')[0] === dateStr).map((t) => {
     // add withdrawal fees to fees too
-    dailyFees.add(toAddress(t.token), t.revenue)
-    dailyRevenue.add(toAddress(t.token), t.revenue)
+    dailyFees.add(toAddress(t.token, options.chain), t.revenue)
+    dailyRevenue.add(toAddress(t.token, options.chain), t.revenue)
   })
 
   const dailySupplySideRevenue = dailyFees.clone()


### PR DESCRIPTION
Fixes #8786

`toAddress` hex-encodes a number and doesn't zero-pad, and its native-token check compares against `"0"` while the api actually sends `"0x0"`. Both produce addresses that can't be priced, so those tokens' volume and fees get silently dropped.

On ethereum that's native ETH and Ekubo's own EKUBO token (`0x04c4...`, leading zero byte), which together drop more fees than the adapter publishes, $51,440 dropped vs $35,822 published over 30 days. On robinhood it's ETH, WETH, RDDT and CASHCAT, which is 84% of the chain's volume.

Padding to 20 bytes on evm and comparing after the hex conversion fixes both. Starknet takes the old path deliberately, its unpriced tokens stay unpriced when padded to 64, so they're genuinely missing from the price db and this shouldn't pretend to fix them.

Harness on 2026-08-13:

```
                  master                      patched
starknet    1.92M vol / 989 fees        1.92M vol / 989 fees     unchanged
ethereum   15.54M vol / 882 fees       15.65M vol / 1.74k fees
robinhood   1.81M vol / 900 fees        3.31M vol / 1.03k fees
```

Starknet is untouched, and the ethereum fee move matches an independent replay of the same api endpoints for that day ($882 + $856 dropped = $1,738 vs $1,740 from the harness). Ran it twice with identical numbers, and on 2026-08-10 as a second day. `tsc --noEmit` clean, same error count as master.

Only the last ~30 days are visible from the api so that's what I could measure, but the code path has been the same since the adapter was added, so stored history is understated the same way and would need a refill.
