### PR TITLE
gmgn: mark volume doublecounted like every other trading bot

### DIFF
--- a/dexs/gmgnai.ts
+++ b/dexs/gmgnai.ts
@@ -72,6 +72,7 @@ const adapter: SimpleAdapter = {
   adapter: chainConfig,
   dependencies: [Dependencies.DUNE],
   isExpensiveAdapter: true,
+  doublecounted: true,
 };
 
 export default adapter;


### PR DESCRIPTION
Fixes #8788

GMGN is the biggest trading bot on the site and the only one of its size without `doublecounted`, so its **$2,516,265,594 of 30d volume ($23.0B all-time)** sits inside the headline dex total on top of the same swaps already counted at the DEXs that executed them.

The flag does gate that total, checked against `/overview/dexs`, sum of all 1308 protocols is $192,324,535,770, the 60 flagged ones are $3,468,327,509, and the difference is $188,856,208,260, which equals the published `total30d` to the dollar. GMGN is 1.33% of it.

Of the 18 Telegram Bot / Trading App protocols with volume, 16 already set this: Axiom, fomo Wallet, Terminal, Trojan, Photon, moonshot.money, BONKbot, Ave.ai, Banana Gun, SolTradingBot, BullX, Telemetry, Pepeboost, Unibot. GMGN is larger than any of them.

That it routes rather than provides liquidity is in this repo, `fees/gmgnai.ts` says "GMGN takes its 1% fee in the native gas token AND USDC", collected by "nine Solana fee-collection wallets ... they only receive per-trade fee inflows". A 1% per-trade cut is an interface fee. `/protocol/gmgn` also returns `currentChainTvls: {}`, so there are no GMGN pools for $2.5B of swaps to have happened against.

Only the dexs adapter. `fees/gmgnai` stays as is; the 1% is GMGN's own revenue and no flagged bot sets this on its fees adapter either.

Can't run this one locally (`DUNE_API_KEYS` not set), but the change is a declarative flag and doesn't touch `prefetch`/`fetch`, so there's no number to verify, `tsc --noEmit` is clean, same as master.

Flagged on the issue and worth repeating here: this has never had the flag, from #7417 through #7853/#8657/#8661, so I've assumed oversight rather than intent. Happy to close if it was deliberate. Also unsure whether flipping it needs a historical recompute of the aggregate or whether that's derived on read.
