### PR TITLE
accountable: floor NAV depositors leg at zero, fixes negative fees

### DIFF
--- a/fees/accountable.ts
+++ b/fees/accountable.ts
@@ -103,6 +103,7 @@ const MANAGER = "Fees To Vault Manager";
 const PROTOCOL = "Fees To Protocol";
 
 const big = (v: any) => (v === null || v === undefined ? 0n : BigInt(v));
+const bigMax = (a: bigint, b: bigint) => (a > b ? a : b);
 
 const listStrategies = async (options: FetchOptions): Promise<string[]> => {
   const api = options.toApi;
@@ -505,7 +506,12 @@ const fetch = async (options: FetchOptions) => {
           `Accountable: could not read the manager split of ${strategies[priced[k]]} on ${options.chain}`,
         );
 
-      const depositors = big(closeAssets[k]) - big(openAssets[k]);
+      // A NAV write-down is a loss, not a negative fee: floor the
+      // depositors' share-price-appreciation leg at zero so a dip never
+      // pushes gross (and therefore the fee split) negative, and never gets
+      // netted against an unrelated same-day fee-share mint (which would
+      // otherwise silently understate a real crystallization).
+      const depositors = bigMax(0n, big(closeAssets[k]) - big(openAssets[k]));
       const gross = depositors + big(mintedAssets[k]);
 
       // The fee is booked as it accrues, from the rates the FeeManager holds


### PR DESCRIPTION
## Summary
- For NAV/looping/fixed-term vaults, `dailyFees`/`dailyRevenue` were computed from `gross = (closeAssets - openAssets) + mintedAssets`, with no floor. A NAV write-down (or any day the on-chain share value dips between the two read blocks) pushed `gross` negative, and the performance-fee split (`fee = gross * performanceFee / DENOM`) went negative with it, so a legitimate vault loss surfaced as negative revenue rather than being absorbed.
- Also affected: a write-down landing on the same day as a real fee-share mint silently netted the two together, understating a genuine crystallization instead of reporting it in full.
- Floored the depositors' share-price leg at zero (`bigMax(0n, closeAssets - openAssets)`) before adding the minted-shares leg, so `gross` is only ever the real crystallized/accrued value, never negative.

## Test plan
- Could not exercise this against live chain state end-to-end: the affected chain (Robinhood) is only reachable through a public RPC that prunes state after ~2h, so no day-boundary window is queryable locally.
- Verified the changed arithmetic in isolation with a standalone script covering 4 scenarios (normal appreciating day, pure write-down, write-down + same-day mint, flat day): confirms `dailyFees`/`dailyRevenue`/the depositors leg are never negative after the fix, non-write-down days are byte-for-byte unchanged, and the write-down+mint case now reports the full minted amount instead of a netted-down figure.
- `tsc --project tsconfig.json --noEmit`: clean.