### PR TITLE
[feat] edgeX-v2 - add open interest adapter

### DIFF
--- a/open-interest/edgeX-v2.ts
+++ b/open-interest/edgeX-v2.ts
@@ -4,9 +4,12 @@ import fetchURL from "../utils/fetchURL";
 
 const openInterestEndpoint = "https://edgex-prod-v2.edgex.exchange/api/v2/public/quote/getTicketSummary?period=LAST_DAY_1"
 
-const fetch = async (_options: FetchOptions) => {
+const fetch = async (options: FetchOptions) => {
     const openInterest = await fetchURL(openInterestEndpoint);
-    const openInterestAtEnd = openInterest.data.tickerSummary.openInterest;
+    const openInterestAtEnd = openInterest?.data?.tickerSummary?.openInterest;
+    if (!openInterestAtEnd) {
+        throw new Error(`No open interest data found for ${options.dateString} in edgeX v2 response`);
+    }
     return { openInterestAtEnd };
 }
 

--- a/open-interest/edgeX-v2.ts
+++ b/open-interest/edgeX-v2.ts
@@ -7,7 +7,7 @@ const openInterestEndpoint = "https://edgex-prod-v2.edgex.exchange/api/v2/public
 const fetch = async (options: FetchOptions) => {
     const openInterest = await fetchURL(openInterestEndpoint);
     const openInterestAtEnd = openInterest?.data?.tickerSummary?.openInterest;
-    if (!openInterestAtEnd) {
+    if (openInterestAtEnd === undefined || openInterestAtEnd === null || openInterestAtEnd === '') {
         throw new Error(`No open interest data found for ${options.dateString} in edgeX v2 response`);
     }
     return { openInterestAtEnd };

--- a/open-interest/edgeX-v2.ts
+++ b/open-interest/edgeX-v2.ts
@@ -1,0 +1,21 @@
+import { FetchOptions, SimpleAdapter } from "../adapters/types"
+import { CHAIN } from "../helpers/chains";
+import fetchURL from "../utils/fetchURL";
+
+const openInterestEndpoint = "https://edgex-prod-v2.edgex.exchange/api/v2/public/quote/getTicketSummary?period=LAST_DAY_1"
+
+const fetch = async (_options: FetchOptions) => {
+    const openInterest = await fetchURL(openInterestEndpoint);
+    const openInterestAtEnd = openInterest.data.tickerSummary.openInterest;
+    return { openInterestAtEnd };
+}
+
+const adapter: SimpleAdapter = {
+    version: 1,
+    chains: [CHAIN.EDGEX],
+    fetch,
+    start: "2026-05-12",
+    runAtCurrTime: true,
+}
+
+export default adapter;


### PR DESCRIPTION
## Description

Adds an open interest adapter for **edgeX V2** (protocol id 7927, slug `edgex-v2`).

edgeX has migrated to V2 infrastructure. The existing `open-interest/edgeX.ts` adapter still queries the legacy endpoint `https://pro.edgex.exchange/api/v1/public/quote/getTicketSummary`, which now reports ~0 daily volume and only ~$2.5M residual open interest, while the actual open interest lives on the V2 API.

This adapter queries the V2 endpoint:
`https://edgex-prod-v2.edgex.exchange/api/v2/public/quote/getTicketSummary?period=LAST_DAY_1`

Start date `2026-05-12` matches the existing `fees/edgeX-v2` adapter.

## Test output

```
npm test open-interest edgeX-v2

🦙 Running EDGEX-V2 adapter 🦙
---------------------------------------------------
Start Date:	Sat, 15 Aug 2026 00:00:00 GMT
End Date:	Sun, 16 Aug 2026 00:00:00 GMT
---------------------------------------------------

EDGEX 👇
Open interest at end: 456.65 M
```

Matches the live V2 API value (~$456.6M) and the edgeX V2 frontend.