### PR TITLE
factory/curators: add Sky Money, Armitage and Galaxy

### DIFF
--- a/factory/curators.ts
+++ b/factory/curators.ts
@@ -57,6 +57,19 @@ const configs: Record<string, CuratorConfig> = {
       },
     },
   },
+  "armitage": {
+    vaults: {
+      [CHAIN.ETHEREUM]: {
+        // Armitage by Wintermute, verified curator on api.morpho.org.
+        // Morpho VaultV2s, so fee() reverts and performanceFee() is the fee source.
+        morphoV2: [
+          '0x5dc53a23AdC9f2Bed98de6F59F7F309a7c71FF2B', // Wintermute USDC Prime
+          '0xA2EAaD0D586cF9FD73bb2c09cF6A7E3e187D68cd', // Wintermute USDC Select
+          '0x55C1B6e461a6334B567bAF0FEb5D728715446f05', // Pendle Ecosystem USDC
+        ],
+      },
+    },
+  },
   "avantgarde": {
     vaults: {
       [CHAIN.ETHEREUM]: {
@@ -159,6 +172,20 @@ const configs: Record<string, CuratorConfig> = {
     vaults: {
       [CHAIN.ETHEREUM]: {
         morphoVaultOwners: ['0xF92971B4D9e6257CF562400ed81d2986F28a8c26'],
+      },
+    },
+  },
+  "galaxy": {
+    vaults: {
+      [CHAIN.ETHEREUM]: {
+        // Galaxy Curation, verified curator on api.morpho.org, which lists this
+        // address on both chain 1 and chain 8453.
+        morphoVaultOwners: ['0x42D510eDeb9257f8D920d5B9f5109D95cB22419d'],
+        morphoVaultV2Owners: ['0x42D510eDeb9257f8D920d5B9f5109D95cB22419d'],
+      },
+      [CHAIN.BASE]: {
+        morphoVaultOwners: ['0x42D510eDeb9257f8D920d5B9f5109D95cB22419d'],
+        morphoVaultV2Owners: ['0x42D510eDeb9257f8D920d5B9f5109D95cB22419d'],
       },
     },
   },
@@ -400,6 +427,21 @@ const configs: Record<string, CuratorConfig> = {
     vaults: {
       [CHAIN.ETHEREUM]: {
         morphoVaultOwners: ['0x46057881E0B9d190920FB823F840B837f65745d5'],
+      },
+    },
+  },
+  "sky-money": {
+    vaults: {
+      [CHAIN.ETHEREUM]: {
+        // Sky Money, verified curator on api.morpho.org.
+        // Morpho VaultV2s, so fee() reverts and performanceFee() is the fee source.
+        morphoV2: [
+          '0x23f5E9c35820f4baB695Ac1F19c203cC3f8e1e11', // sky.money USDT Savings
+          '0xE15fcC81118895b67b6647BBd393182dF44E11E0', // sky.money USDS Flagship
+          '0x56bfa6f53669B836D1E0Dfa5e99706b12c373ecf', // sky.money USDC Risk Capital
+          '0xf42bca228D9bd3e2F8EE65Fec3d21De1063882d4', // sky.money USDS Risk Capital
+          '0x2bD3A43863c07B6A01581FADa0E1614ca5DF0E3d', // sky.money USDT Risk Capital
+        ],
       },
     },
   },


### PR DESCRIPTION
Three curators already have TVL coverage through `registries/curators.js` in DefiLlama-Adapters, under the same keys used here, but have no entry in `factory/curators.ts`, so none of them publish fees. This adds them.

| curator | chains | vaults | TVL | daily fees | daily revenue |
| --- | --- | --- | --- | --- | --- |
| sky-money | ethereum | 5 (VaultV2) | $113.9M | 7.30k | 0 |
| armitage | ethereum | 3 (VaultV2) | $84.4M | 10.86k | 173 |
| galaxy | ethereum, base | 3 funded | $68.8M | 5.87k | 93 |

### Vaults

sky-money, ethereum: USDT Savings $62.6M, USDS Flagship $36.5M, USDC Risk Capital $13.1M, USDS Risk Capital $1.18M, USDT Risk Capital $0.59M. `performanceFee()` is 0 on all five, so fees are entirely supply side and revenue is 0.

armitage, ethereum: Wintermute USDC Prime $20.5M, Wintermute USDC Select $36.7M, Pendle Ecosystem USDC $27.2M. Only the last has a fee, 5%.

galaxy, ethereum: Galaxy USDC Quality $24.3M, Galaxy USDT Quality $27.6M, Galaxy WETH Quality 8980.9 WETH. Base: Galaxy USDC Quality $26.5k.

### Notes on the config shape

The sky-money and armitage vault lists are copied straight from the TVL registry. Both sets are VaultV2s (`fee()` reverts, `performanceFee()` answers), so they go under `morphoV2` rather than `morpho`.

Galaxy needed `morphoVaultV2Owners` in addition to `morphoVaultOwners`. The TVL helper resolves V1 and V2 under the single `morphoVaultOwners` key while this repo splits them, so with `morphoVaultOwners` alone the adapter resolved 0 vaults on both chains.

### What was verified

Attribution: api.morpho.org lists Sky Money, Armitage by Wintermute and Galaxy Curation as verified curators, and lists `0x42D510eDeb9257f8D920d5B9f5109D95cB22419d` for Galaxy on both chain 1 and chain 8453, which is the address the TVL registry already uses.

Balances and fee rates were read on chain, not taken from the API.

Sweep check on the galaxy owner address, since it is an owner list rather than an explicit vault list: it resolves 7 vaults on ethereum and 1 on base. Only 3 of the 7 are funded; the other 4 hold 0 assets and are unnamed. The funded ones plus base come to $68.8M, matching what the TVL side reports.

The implied rates are 2.3% (sky-money), 4.7% (armitage) and 3.1% (galaxy) annualised, which is in range for stablecoin lending vaults.

None of the added vault addresses appear anywhere else in this repo, so nothing here is double counted.

### Left out on purpose

Cassa has a TVL entry and no fees entry, but both its EVK vaults have zero borrows, so it would publish zeros.

Anthias also has a TVL entry and no fees entry, but 4 of its 9 base vaults are already registered under another curator here, so adding it as written would double count. It needs a narrower vault list than the TVL registry has and I did not want to guess at it.

There are other curators with TVL entries and no fees entry that this PR does not touch, because the vault kinds they use (silo, erc4626, midasTokens, accountableVaults, upshift) are not supported by this repo's curator framework.
