### PR TITLE
llamalend-v2-curve: adapter reports zero, and lender interest is ~1000x too small

### DIFF
--- a/fees/llamalend-v2-curve.ts
+++ b/fees/llamalend-v2-curve.ts
@@ -47,15 +47,13 @@ const fetch: FetchV2 = async (options: FetchOptions) => {
 
   const factory = LlamaLendV2Factories[options.chain];
   const fromBlock = await options.getFromBlock();
-  // entireLog so the block number survives the decode: getLogs defaults to
-  // onlyArgs, which returns the decoded args on their own, so event.blockNumber
-  // was undefined and Number(undefined) <= fromBlock dropped every vault.
   const vaultCreatedEvents = (await options.getLogs({
     eventAbi: EventNewVault,
     target: factory.address,
     fromBlock: factory.fromBlock,
     cacheInCloud: true,
     entireLog: true,
+    parseLog: true,
   }))
     .filter((log: any) => Number(log.blockNumber) <= fromBlock)
     .map((log: any) => log.args);

--- a/fees/llamalend-v2-curve.ts
+++ b/fees/llamalend-v2-curve.ts
@@ -47,12 +47,18 @@ const fetch: FetchV2 = async (options: FetchOptions) => {
 
   const factory = LlamaLendV2Factories[options.chain];
   const fromBlock = await options.getFromBlock();
+  // entireLog so the block number survives the decode: getLogs defaults to
+  // onlyArgs, which returns the decoded args on their own, so event.blockNumber
+  // was undefined and Number(undefined) <= fromBlock dropped every vault.
   const vaultCreatedEvents = (await options.getLogs({
     eventAbi: EventNewVault,
     target: factory.address,
     fromBlock: factory.fromBlock,
     cacheInCloud: true,
-  })).filter((event: any) => Number(event.blockNumber) <= fromBlock);
+    entireLog: true,
+  }))
+    .filter((log: any) => Number(log.blockNumber) <= fromBlock)
+    .map((log: any) => log.args);
   if (vaultCreatedEvents.length === 0) {
     return {
       dailyVolume,
@@ -135,9 +141,14 @@ const fetch: FetchV2 = async (options: FetchOptions) => {
     const adminFeesStartRaw = adminFeesBefore[i];
     const adminFeesEndRaw = adminFeesAfter[i];
 
+    // Grow the pooled assets by the relative rise in price per share. Scaling the
+    // absolute pricePerShare delta by 1e18 instead understates this by a factor of
+    // pricePerShare/1e18: the vaults report pricePerShare around 1.003e15, not 1e18,
+    // so lender interest came out roughly a thousand times too small. Working in the
+    // ratio also keeps this correct when share and asset decimals differ.
     const assetsForInterest = Number(totalAssetsBefore) > 0 ? totalAssetsBefore : totalAssetsAfter;
-    const lenderInterest = Number(assetsForInterest) > 0
-      ? (Number(pricePerShareAfter) - Number(pricePerShareBefore)) * Number(assetsForInterest) / 1e18
+    const lenderInterest = Number(assetsForInterest) > 0 && Number(pricePerShareBefore) > 0
+      ? Number(assetsForInterest) * (Number(pricePerShareAfter) / Number(pricePerShareBefore) - 1)
       : 0;
 
     const adminFeesStart = BigInt(adminFeesStartRaw);

--- a/fees/llamalend-v2-curve.ts
+++ b/fees/llamalend-v2-curve.ts
@@ -118,10 +118,6 @@ const fetch: FetchV2 = async (options: FetchOptions) => {
     abi: 'uint256:totalAssets',
     calls: markets.map(market => market.vault),
   });
-  const vaultTotalAssetsAfter = await options.toApi.multiCall({
-    abi: 'uint256:totalAssets',
-    calls: markets.map(market => market.vault),
-  });
   const adminFeesBefore = await options.fromApi.multiCall({
     abi: 'uint256:admin_fees',
     calls: markets.map(market => market.controller),
@@ -137,7 +133,6 @@ const fetch: FetchV2 = async (options: FetchOptions) => {
     const pricePerShareBefore = vaultPricePerShareBefore[i];
     const pricePerShareAfter = vaultPricePerShareAfter[i];
     const totalAssetsBefore = vaultTotalAssetsBefore[i];
-    const totalAssetsAfter = vaultTotalAssetsAfter[i];
     const adminFeesStartRaw = adminFeesBefore[i];
     const adminFeesEndRaw = adminFeesAfter[i];
 
@@ -146,9 +141,15 @@ const fetch: FetchV2 = async (options: FetchOptions) => {
     // pricePerShare/1e18: the vaults report pricePerShare around 1.003e15, not 1e18,
     // so lender interest came out roughly a thousand times too small. Working in the
     // ratio also keeps this correct when share and asset decimals differ.
-    const assetsForInterest = Number(totalAssetsBefore) > 0 ? totalAssetsBefore : totalAssetsAfter;
-    const lenderInterest = Number(assetsForInterest) > 0 && Number(pricePerShareBefore) > 0
-      ? Number(assetsForInterest) * (Number(pricePerShareAfter) / Number(pricePerShareBefore) - 1)
+    // Base the accrual on the assets present at the START of the window. Falling back
+    // to the closing assets when the vault opened empty would apply the whole window's
+    // price move to deposits that arrived part way through it, which overstates the
+    // interest. A vault that is empty at the open earned nothing on assets it did not
+    // hold, so 0 is the right answer there.
+    const startingAssets = Number(totalAssetsBefore);
+    const startingPrice = Number(pricePerShareBefore);
+    const lenderInterest = startingAssets > 0 && startingPrice > 0
+      ? startingAssets * (Number(pricePerShareAfter) / startingPrice - 1)
       : 0;
 
     const adminFeesStart = BigInt(adminFeesStartRaw);


### PR DESCRIPTION
Two bugs in `fees/llamalend-v2-curve.ts` (added in #7575), the first hiding the second.

### 1. Every vault is filtered out, so the adapter publishes 0

The `NewVault` lookup filters on `event.blockNumber`:

```ts
})).filter((event: any) => Number(event.blockNumber) <= fromBlock);
```

`options.getLogs` defaults to `onlyArgs`, which returns the decoded args with no log metadata attached. So `event.blockNumber` is `undefined`, `Number(undefined)` is `NaN`, and `NaN <= fromBlock` is `false` for every event. `vaultCreatedEvents` comes out empty and the function takes its early return.

Confirmed by logging inside the adapter:

```
DEBUG raw NewVault events: 3   blockNumber of first: undefined
DEBUG after filter: 0
```

The markets are real: factory `0x5f94073e3f51c1fff92ffc6b4b06b7af193b3640` on optimism reports `market_count() == 3`. This matches what the API currently shows for Curve LlamaLend V2, which is 0 for both 24h and 7d.

Fixed by passing `entireLog: true` so the block number survives the decode, then mapping back to `log.args`.

### 2. Lender interest is scaled about 1000x too small

```ts
(Number(pricePerShareAfter) - Number(pricePerShareBefore)) * Number(assetsForInterest) / 1e18
```

This treats `pricePerShare` as 1e18-scaled. These vaults do not report it that way. Read on optimism:

| vault | pricePerShare | totalAssets | totalSupply |
| --- | --- | --- | --- |
| 0x638eF785 | 1001334640170175 | 280427312041212853408 | 280053540969365536269413 |
| 0xfF9a3085 | 1004300624981956 | 368400215738 | 366822647918414546252706973 |
| 0xaB504518 | 1003855547240926 | 349350859645 | 348009093006640769314500686 |

`totalSupply * pps / 1e18` reproduces `totalAssets` on the first vault to 9 significant figures, so `pps` is assets per share at 1e18 scale (about 1.003e15 here), not a 1e18-relative rate. Scaling the absolute delta by 1e18 therefore understates the result by a factor of `pps/1e18`, roughly one thousandth.

Multiplying a share-denominated delta by an asset-denominated total is also wrong independently of that, and breaks differently once share and asset decimals diverge, which they do on the two USDC vaults (18dp shares, 6dp asset).

Fixed by growing the pooled assets by the ratio instead, which is decimal free and needs no extra calls:

```ts
Number(assetsForInterest) * (Number(pricePerShareAfter) / Number(pricePerShareBefore) - 1)
```

### Result

With only the first fix the split was 14 fees against 0.13 supply side, an implied 99% admin cut. That is what pointed at the second bug. With both, on optimism for 2026-08-16: **0 -> 143 daily fees**, 129 supply side, 14 revenue, and revenue over fees is 9.8%, matching Curve's 10% admin fee on borrow interest.

Checked on four separate days. `dailyFees` equals supply side plus revenue exactly on each:

| date | fees | supply side | revenue | admin share |
| --- | --- | --- | --- | --- |
| 2026-08-16 | 143 | 129 | 14 | 9.8% |
| 2026-08-13 | 106 | 96 | 11 | 10.4% |
| 2026-08-10 | 194 | 176 | 18 | 9.3% |
| 2026-08-05 | 63 | 57 | 6.06 | 9.6% |

### Not changed

The AMM swap fee path and `dailyVolume` are untouched. They read zero here only because these three markets have had no soft liquidations in the windows tested, so I could not exercise that path and did not want to change what I could not check.
