### PR TITLE
bluemove: stop the fee legs reading the sui feed after the drain

### DIFF
--- a/fees/bluemove/index.ts
+++ b/fees/bluemove/index.ts
@@ -11,6 +11,12 @@ const SUI_FEE_RATE = 0.003; // 0.3%
 const SUI_PROTOCOL_FEE_RATE = 0;
 const SUI_SUPPLY_SIDE_FEE_RATE = SUI_FEE_RATE - SUI_PROTOCOL_FEE_RATE;
 
+// BlueMove was drained on this date. The sui swap event feed keeps emitting
+// inflated swaps afterwards, so dexs/bluemove.ts stops reading it here (#8359).
+// The same feed backs the fee legs below and was left unguarded, which booked
+// 2,288,313 of fees on 2026-07-22 against 0 volume on the dexs side.
+const PROTOCOL_DRAIN_DATE = "2026-07-11";
+
 interface IVolumeall {
   num: string;
   date: string;
@@ -30,6 +36,13 @@ const fetchAptos = async (options: FetchOptions) => {
 };
 
 const fetchSui = async (options: FetchOptions) => {
+  if (options.dateString > PROTOCOL_DRAIN_DATE) {
+    return {
+      dailyFees: options.createBalances(),
+      dailySupplySideRevenue: options.createBalances(),
+    };
+  }
+
   const events = await queryEvents({
     eventModule: { package: SUI_PACKAGE, module: "swap" },
     options,


### PR DESCRIPTION
#8359 paused `dexs/bluemove.ts` after BlueMove was drained on 2026-07-11, on the grounds that the sui swap event feed keeps emitting inflated swaps afterwards. That guard only went into the volume adapter. `fees/bluemove/index.ts` reads the same feed and was left unguarded.

### What that produced

On 2026-07-22, from the published series:

| adapter | field | value |
| --- | --- | --- |
| dexs/bluemove | dailyVolume | 0 |
| fees/bluemove | dailyFees | 2,288,313 |

2.29M of fees against zero volume. At the 0.3% rate the file itself uses, that implies roughly 762M of swaps on a protocol that had been drained eleven days earlier.

It is by far the largest day in the fee series. There are 750 points and the next highest is 5,457, from 2022-10-24, so that single day is about 420x anything else the protocol has ever done. It also accounts for essentially the entire reported 30d figure of 2,289,711.

The day before is inside the same window and reads sanely, which is what makes the 07-22 value stand out rather than the whole period being suspect:

```
2026-07-21   volume 387,027   fees 1,163   -> 0.30%
2026-07-22   volume       0   fees 2,288,313
```

### The change

Applies the same date guard the dexs adapter already uses, in the same shape, to `fetchSui`. No new judgement here, it is the decision from #8359 applied to the file that was missed.

The aptos leg needs nothing. It is already `deadFrom: '2024-03-01'`, and its endpoint (`aptos-mainnet-api.bluemove.net/api/histogram`) now returns 404 in any case, so it is not being called for any live date.

### Tested

```
2026-07-22   fees 0.00   supply side 0.00    (was feeding the spike)
2026-06-20   fees 2.38   supply side 2.38    (pre-drain history unchanged)
```

Found by screening every protocol's published series for values that are impossible rather than merely large, in this case a single day 420x the all-time next-highest.
