### PR TITLE
o1-exchange: mark volume doublecounted, its a 1% terminal like gmgn

### DIFF
--- a/dexs/o1-exchange/index.ts
+++ b/dexs/o1-exchange/index.ts
@@ -115,6 +115,7 @@ const adapter: SimpleAdapter = {
   },
   isExpensiveAdapter: true,
   dependencies: [Dependencies.DUNE],
+  doublecounted: true,
 };
 
 export default adapter;


### PR DESCRIPTION
Follow-up to #8788 / #8789. Same class, much smaller: **$4,917,237/30d**.

o1.exchange is a trading terminal that takes a cut per trade, so its volume is the same swaps already counted at the DEXs that executed them. It's the last unflagged protocol of any size in the `Telegram Bot` / `Trading App` categories; after gmgn merged, the only others left are $28 and $3.

The adapter says it outright:

```
Volume: 'Total trading volume is calculated as fees multiplied by 100, since trading fees are 1% of the volume.'
Fees:   'User pays 1% fee on each trade'
```

and the fees themselves are measured as transfers into its fee-collector wallets, `to_owner = 'FUzZ2SPwLPAKaHubxQzRsk9K8dXb4YBMR6hTrYEMFFZc'` on solana, `0x1E493E7CF969FD7607A8ACe7198f6C02e5eF85A4` / `0xc98218Df72975EE1472919d2685e5BD215Baaad4` on base, `0x68AF11c8A93B373BA97217963878B097083726f0` on bnb. A 1% cut skimmed into a wallet is an interface fee; the trade happened elsewhere. Its three chains (solana, base, bsc) are all ones where DefiLlama already counts the underlying DEXs, and `/protocol/o1-exchange` has no tvl listing, so there are no o1 pools for the volume to have traded against.

Same scope as gmgn, dexs only, `fees/` untouched, since the 1% is genuinely o1's own revenue.

Can't run it locally (`DUNE_API_KEYS` not set) but this is a declarative flag that doesn't touch `prefetch`/`fetch`, so there's no number to verify. `tsc --noEmit` clean, same as master.

Still unchecked and deliberately not in this PR: the `Interface` category has four unflagged ones (Kreo, MetaMask Predictions, Polycule, Rainbow Predictions, ~$178k/24h combined) sitting next to the flagged Gate Predictions and Traderline Predictions. They look like the same thing but that category is mixed, so I'd rather verify each than sweep them in.
