### PR TITLE
nad-fun: keep V2 pair metadata out of the dust filter

### DIFF
--- a/dexs/nad-fun.ts
+++ b/dexs/nad-fun.ts
@@ -401,20 +401,25 @@ async function getV2PairMetadata(options: FetchOptions) {
     };
   });
 
-  // Drop dust pairs: keep only those whose pooled token value clears the
-  // default filterPools threshold ($200), matching the uniswap-fork helpers.
+  // Drop dust pairs from the swap-log targets: keep only those whose pooled
+  // token value clears the default filterPools threshold ($200), matching the
+  // uniswap-fork helpers.
+  //
+  // The metadata map is deliberately NOT filtered. NadFunPair is deployed by
+  // BondingCurve._create at token creation and only seeded with liquidity at
+  // graduation, so every token still on the curve has a pair holding nothing.
+  // Those pairs still emit Collect, and the fee loop reads its rates out of
+  // this map: dropping them there leaves creatorFeeRate and the protocol rates
+  // at 0, which trips the `totalRate === 0` early return and discards the fees
+  // entirely while revenue, which does not come through here, still counts.
   const filteredPairs = await filterPools({
     api: options.api,
     pairs: pairTokens,
     createBalances: options.createBalances,
   });
   const keptPairs = pairs.filter((pair: string) => filteredPairs[pair] !== undefined);
-  const keptPairMeta: Record<string, V2PairMeta> = {};
-  keptPairs.forEach((pair: string) => {
-    keptPairMeta[pair] = pairMeta[pair];
-  });
 
-  return { pairs: keptPairs, pairMeta: keptPairMeta };
+  return { pairs: keptPairs, pairMeta };
 }
 
 async function getV2TokenQuoteMap(options: FetchOptions, tokens: string[]) {


### PR DESCRIPTION
Fixes #8629.

`getV2PairMetadata` runs the pair list through `filterPools` and returns only the survivors in **both** `pairs` and `pairMeta`. The $200 pooled-value floor is correct for `pairs`, which is only used as the target list for the Swap logs that drive volume. It is not correct for `pairMeta`, which the Collect loop reads for every pair it sees.

### Why nad.fun specifically

`NadFunPair` is deployed by `BondingCurve._create` at token creation, and only seeded with liquidity at graduation. A token still on the curve therefore has a pair holding nothing.

I sampled 14 pairs across the whole index range, from index 5 to index 1770 of 1779, and every one reports zero reserves. Checked `0xC43b3F281472E310d786F7fEfdB48DE27A8b5e4A` directly: `balanceOf` is 0 for both tokens and LP `totalSupply` is 0. So the filter is removing nearly the entire pair set, not a dust tail.

Those pairs still emit `Collect`. With no entry in `pairMeta` the rates fall through to `meta?.creatorFeeRate ?? 0` and the protocol equivalents, the `totalRate === 0` guard returns early, and that event's fees are discarded. Revenue does not come through this path, so it survives, and the published series ends up with revenue above fees:

```
2026-08-05   fees 520   revenue 1102
2026-08-06   fees 400   revenue  422
```

### The change

Keep `filterPools` gating `pairs`; return `pairMeta` unfiltered.

### Measurement

Same shell, `DISABLE_PULL_HOURLY=true`, 2026-08-05, only this change between the two runs:

| metric | before | after |
| --- | --- | --- |
| volume | 183.98k | 183.98k |
| fees | 522 | **2.42k** |
| revenue | 1.12k | 1.12k |
| supply side | 352 | **1.30k** |

Volume and revenue come out identical, which is the point: the dust filter still does its job on the volume path, and the revenue path is untouched. Only the fee legs move.

`dailyFees` now equals revenue plus supply side exactly (1.12k + 1.30k = 2.42k). Before, 1.12k + 352 did not add up to 522, which is what the issue was reporting.

Fee breakdown that reappears on this day: Protocol Fees 978, Creator Fees 1,027, LP Fees 225, Foundation Fees from LPs 92, Creators Fees from LPs 92.

### Relation to the reported fix

@bc1phugo tested removing `filterPools` altogether and measured 2,370 in fees for this day. This is the narrower version of that, landing at 2,420 while leaving volume filtered, so the dust pools stay out of the swap-log target list.
