### PR TITLE
[fix] frontier-fun - track the v1.2 redeploy and read fee splits from events

### DIFF
--- a/active-users/frontier-fun.ts
+++ b/active-users/frontier-fun.ts
@@ -2,36 +2,36 @@ import { FetchOptions, SimpleAdapter } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
 
 // Frontier (frontier.fun) — bonding-curve token launchpad on Robinhood Chain (4663).
-// Tracks the v1.2 production deployment (live 2026-08-15). Every market trades
-// against one shared BondingCurve, and every launch (curve or direct-seed) goes
-// through one factory, so two targets cover all user-facing activity. Swaps on a
-// token's Uniswap V4 pool are Uniswap activity, not Frontier's, and are excluded
-// for the same reason the volume adapter excludes them.
-// Both deployed in block 36671438.
-// https://robinhoodchain.blockscout.com/address/0xEAaa2aE7De8B80d7a59eCF08B078EfAC6FcE6659
-const BONDING_CURVE = "0xEAaa2aE7De8B80d7a59eCF08B078EfAC6FcE6659";
-// https://robinhoodchain.blockscout.com/address/0xe3A826C056e578c240D362BF4C2fa53E5c0c17a5
-const FACTORY = "0xe3A826C056e578c240D362BF4C2fa53E5c0c17a5";
+// Every market trades against one shared BondingCurve, and every launch (curve or
+// direct-seed) goes through one factory, so the two contracts of each deployment
+// cover all user-facing activity. v1 (live 2026-07-30) and v1.2 (live 2026-08-15)
+// are both counted; neither replaced the other in this adapter. Swaps on a token's
+// Uniswap V4 pool are Uniswap activity, not Frontier's, and are excluded for the
+// same reason the volume adapter excludes them.
+// v1 — both deployed in block 23472343.
+const BONDING_CURVE_V1 = "0xCCa442899dFD80bf04340fa8C245C7EB02F71DD4";
+const FACTORY_V1 = "0x3cbC9395046607C083B383DC3588A3e8308dFf54";
+
+// v1.2 production — both deployed in block 36671438.
+const BONDING_CURVE_V12 = "0xEAaa2aE7De8B80d7a59eCF08B078EfAC6FcE6659";
+const FACTORY_V12 = "0xe3A826C056e578c240D362BF4C2fa53E5c0c17a5";
+
+const BUY_EVENT =
+  "event Buy(address indexed user, address indexed token, uint256 amount, uint256 amountOut, uint256 totalSupply, uint256 marketCap, uint256 price, uint256 reserveBalance)";
+const SELL_EVENT =
+  "event Sell(address indexed user, address indexed token, uint256 amount, uint256 amountOut, uint256 totalSupply, uint256 marketCap, uint256 price, uint256 reserveBalance)";
+const COIN_DEPLOYED_V1 =
+  "event CoinDeployed(address indexed creator, address indexed token, address factory, address lp, string name, string symbol, string description, string image, uint256 initialSupply, uint256 maxSupply, uint256 initialETHReserves, uint256 initialPrice, uint256 initialMarketCap, uint256 targetETH)";
+const COIN_DEPLOYED_V12 =
+  "event CoinDeployed(address indexed creator, address indexed token, address factory, address lp, string name, string symbol, string description, string image, uint256 initialSupply, uint256 maxSupply, uint256 initialETHReserves, uint256 initialPrice, uint256 initialMarketCap, uint256 targetETH, bool indexed directSeed)";
 
 const activityEvents = [
-  {
-    target: BONDING_CURVE,
-    userField: "user",
-    eventAbi:
-      "event Buy(address indexed user, address indexed token, uint256 amount, uint256 amountOut, uint256 totalSupply, uint256 marketCap, uint256 price, uint256 reserveBalance)",
-  },
-  {
-    target: BONDING_CURVE,
-    userField: "user",
-    eventAbi:
-      "event Sell(address indexed user, address indexed token, uint256 amount, uint256 amountOut, uint256 totalSupply, uint256 marketCap, uint256 price, uint256 reserveBalance)",
-  },
-  {
-    target: FACTORY,
-    userField: "creator",
-    eventAbi:
-      "event CoinDeployed(address indexed creator, address indexed token, address factory, address lp, string name, string symbol, string description, string image, uint256 initialSupply, uint256 maxSupply, uint256 initialETHReserves, uint256 initialPrice, uint256 initialMarketCap, uint256 targetETH, bool indexed directSeed)",
-  },
+  { target: BONDING_CURVE_V1, userField: "user", eventAbi: BUY_EVENT },
+  { target: BONDING_CURVE_V1, userField: "user", eventAbi: SELL_EVENT },
+  { target: FACTORY_V1, userField: "creator", eventAbi: COIN_DEPLOYED_V1 },
+  { target: BONDING_CURVE_V12, userField: "user", eventAbi: BUY_EVENT },
+  { target: BONDING_CURVE_V12, userField: "user", eventAbi: SELL_EVENT },
+  { target: FACTORY_V12, userField: "creator", eventAbi: COIN_DEPLOYED_V12 },
 ] as const;
 
 async function fetch(options: FetchOptions) {
@@ -60,22 +60,14 @@ async function fetch(options: FetchOptions) {
   };
 }
 
-// Version 1 deliberately, despite this reading on-chain logs. dailyActiveUsers is
-// a daily-unique count, which does not decompose into hourly slices: under
-// version 2 the runner sums 24 hourly results, so a wallet that trades in six
-// different hours is counted six times. Measured on 2026-08-05, the same day
-// reports 20 active users at version 1 and 401 at version 2 + pullHourly, off the
-// identical 914 transactions. Transaction counts do partition correctly, but the
-// adapter cannot be split per metric. Every other active-users adapter is
-// version 1 for the same reason.
 const adapter: SimpleAdapter = {
   version: 1,
   fetch,
   chains: [CHAIN.ROBINHOOD],
-  // v1.2 production deployment, block 36671438.
-  start: "2026-08-15",
+  // First CoinDeployed event (v1), block 23650298.
+  start: "2026-07-30",
   methodology:
-    "Counts unique addresses that bought or sold on a Frontier bonding curve (BondingCurve Buy/Sell) or launched a token (BCTokenFactory CoinDeployed), and the transactions those actions occurred in. Swaps on graduated tokens' Uniswap V4 pools are counted as Uniswap activity and excluded here.",
+    "Counts unique addresses that bought or sold on a Frontier bonding curve (BondingCurve Buy/Sell) or launched a token (BCTokenFactory CoinDeployed) on either the v1 or v1.2 deployment, and the transactions those actions occurred in. Swaps on graduated tokens' Uniswap V4 pools are counted as Uniswap activity and excluded here.",
 };
 
 export default adapter;

--- a/active-users/frontier-fun.ts
+++ b/active-users/frontier-fun.ts
@@ -2,16 +2,16 @@ import { FetchOptions, SimpleAdapter } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
 
 // Frontier (frontier.fun) — bonding-curve token launchpad on Robinhood Chain (4663).
-// Every market trades against one shared BondingCurve, and every launch goes
+// Tracks the v1.2 production deployment (live 2026-08-15). Every market trades
+// against one shared BondingCurve, and every launch (curve or direct-seed) goes
 // through one factory, so two targets cover all user-facing activity. Swaps on a
-// graduated token's Uniswap V4 pool are Uniswap activity, not Frontier's, and are
-// excluded for the same reason the volume adapter excludes them.
-// Both deployed in block 23472343; the factory registered this curve in the same
-// block (BondingCurveUpdated) and has never pointed at another one.
-// https://robinhoodchain.blockscout.com/address/0xCCa442899dFD80bf04340fa8C245C7EB02F71DD4
-const BONDING_CURVE = "0xCCa442899dFD80bf04340fa8C245C7EB02F71DD4";
-// https://robinhoodchain.blockscout.com/address/0x3cbC9395046607C083B383DC3588A3e8308dFf54
-const FACTORY = "0x3cbC9395046607C083B383DC3588A3e8308dFf54";
+// token's Uniswap V4 pool are Uniswap activity, not Frontier's, and are excluded
+// for the same reason the volume adapter excludes them.
+// Both deployed in block 36671438.
+// https://robinhoodchain.blockscout.com/address/0xEAaa2aE7De8B80d7a59eCF08B078EfAC6FcE6659
+const BONDING_CURVE = "0xEAaa2aE7De8B80d7a59eCF08B078EfAC6FcE6659";
+// https://robinhoodchain.blockscout.com/address/0xe3A826C056e578c240D362BF4C2fa53E5c0c17a5
+const FACTORY = "0xe3A826C056e578c240D362BF4C2fa53E5c0c17a5";
 
 const activityEvents = [
   {
@@ -30,7 +30,7 @@ const activityEvents = [
     target: FACTORY,
     userField: "creator",
     eventAbi:
-      "event CoinDeployed(address indexed creator, address indexed token, address factory, address lp, string name, string symbol, string description, string image, uint256 initialSupply, uint256 maxSupply, uint256 initialETHReserves, uint256 initialPrice, uint256 initialMarketCap, uint256 targetETH)",
+      "event CoinDeployed(address indexed creator, address indexed token, address factory, address lp, string name, string symbol, string description, string image, uint256 initialSupply, uint256 maxSupply, uint256 initialETHReserves, uint256 initialPrice, uint256 initialMarketCap, uint256 targetETH, bool indexed directSeed)",
   },
 ] as const;
 
@@ -72,8 +72,8 @@ const adapter: SimpleAdapter = {
   version: 1,
   fetch,
   chains: [CHAIN.ROBINHOOD],
-  // First CoinDeployed event, block 23650298.
-  start: "2026-07-30",
+  // v1.2 production deployment, block 36671438.
+  start: "2026-08-15",
   methodology:
     "Counts unique addresses that bought or sold on a Frontier bonding curve (BondingCurve Buy/Sell) or launched a token (BCTokenFactory CoinDeployed), and the transactions those actions occurred in. Swaps on graduated tokens' Uniswap V4 pools are counted as Uniswap activity and excluded here.",
 };

--- a/dexs/frontier-fun/index.ts
+++ b/dexs/frontier-fun/index.ts
@@ -92,7 +92,7 @@ const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
     // Configured rates at deployment: creator 5%, protocol 0%, caller refund 0%
     // of the raised ETH — the event keeps the split exact if they change.
     const feesPaid = await options.getLogs({
-      targets: graduations.map((log: any) => String(log.token)),
+      targets: [...new Set(graduations.map((log: any) => String(log.token)))],
       eventAbi: GRADUATION_FEES_PAID_EVENT,
     });
     feesPaid.forEach((log: any) => {

--- a/dexs/frontier-fun/index.ts
+++ b/dexs/frontier-fun/index.ts
@@ -1,63 +1,47 @@
-import { PromisePool } from "@supercharge/promise-pool";
 import { Adapter, FetchOptions, FetchResultV2 } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 import ADDRESSES from "../../helpers/coreAssets.json";
 
 // Frontier (frontier.fun) is a bonding-curve token launchpad on Robinhood Chain (4663).
 //
-// Every launched token trades against one shared BondingCurve contract that emits
-// Buy/Sell for all markets. When a curve fills, the token wraps its raised ETH,
-// pays out graduation fees, and seeds a Uniswap V4 pool (LPSeeded); post-graduation
-// swaps are already counted by the uniswap-v4 adapter on this chain and are not
-// double counted here.
-// https://robinhoodchain.blockscout.com/address/0xCCa442899dFD80bf04340fa8C245C7EB02F71DD4
-const BONDING_CURVE = "0xCCa442899dFD80bf04340fa8C245C7EB02F71DD4";
-// https://robinhoodchain.blockscout.com/address/0x3cbC9395046607C083B383DC3588A3e8308dFf54
-const FACTORY = "0x3cbC9395046607C083B383DC3588A3e8308dFf54";
-// Seeds the Uniswap V4 pool at graduation. Source: BCTokenFactory.liquidityManager().
-const LIQUIDITY_MANAGER = "0x97f3578083396D4ef2042868c6aE9d4eC91007A6";
-// Takes a cut of the curve trade fee for referred trades and holds it as WETH
-// until the referrer claims. Source: BondingCurve.referralManager().
-const REFERRAL_MANAGER = "0x6Fb1160A663834e8E53E411CC7202A01F1b144DD";
+// Tracks the v1.2 production deployment (live 2026-08-15). Every launched token
+// trades against one shared BondingCurve contract that emits Buy/Sell for all
+// markets, and every fee split is emitted on-chain (CurveFeeDistributed per
+// trade, GraduationFeesPaid at graduation), so nothing is reconstructed from
+// rates. All fee payouts are pushed as WETH at source: referrer, creator and
+// the protocol treasury are paid inside the trade or graduation.
+//
+// When a curve fills, the token pays out graduation fees and seeds a Uniswap V4
+// pool (LPSeeded); post-graduation swaps are already counted by the uniswap-v4
+// adapter on this chain and are not double counted here. Direct-seed launches
+// skip the curve and are born on their V4 pool: they emit no curve events and
+// their swaps (including the optional dev buy, a real V4 swap) are likewise the
+// uniswap-v4 adapter's.
+//
+// https://robinhoodchain.blockscout.com/address/0xEAaa2aE7De8B80d7a59eCF08B078EfAC6FcE6659
+// Factory: 0xe3A826C056e578c240D362BF4C2fa53E5c0c17a5.
+const BONDING_CURVE = "0xEAaa2aE7De8B80d7a59eCF08B078EfAC6FcE6659";
 const WETH = ADDRESSES.robinhood.WETH;
 
-// keccak256("Transfer(address,address,uint256)"), the standard ERC20 topic0.
-const TRANSFER_TOPIC = "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef";
-const asTopic = (address: string) => "0x" + address.slice(2).toLowerCase().padStart(64, "0");
-
-// Both events emit the GROSS ETH notional, but the fee's share of it differs by leg:
-//   Buy.amount     is msg.value (fee-inclusive), so the fee is txFee / (10000 + txFee).
-//   Sell.amountOut is pre-fee proceeds, so the fee is txFee / 10000.
-// Treating either leg as net of the fee overstates both volume and fees.
+// Both events emit the GROSS ETH notional (Buy.amount is msg.value,
+// fee-inclusive; Sell.amountOut is pre-fee proceeds).
 const BUY_EVENT =
   "event Buy(address indexed user, address indexed token, uint256 amount, uint256 amountOut, uint256 totalSupply, uint256 marketCap, uint256 price, uint256 reserveBalance)";
 const SELL_EVENT =
   "event Sell(address indexed user, address indexed token, uint256 amount, uint256 amountOut, uint256 totalSupply, uint256 marketCap, uint256 price, uint256 reserveBalance)";
 const LP_SEEDED_EVENT = "event LPSeeded(address indexed token, address indexed pool)";
-const TRANSFER_EVENT = "event Transfer(address indexed from, address indexed to, uint256 value)";
-const TX_FEE_UPDATED_EVENT = "event TxFeeUpdated(uint256 fee)";
-const REFERRAL_REWARD_EVENT =
-  "event ReferralRewardReceived(address indexed referrer, address indexed referredUser, address indexed token, uint256 reward, bool isDirect)";
-const OWNERSHIP_TRANSFERRED_EVENT =
-  "event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)";
-const COIN_DEPLOYED_EVENT =
-  "event CoinDeployed(address indexed creator, address indexed token, address factory, address lp, string name, string symbol, string description, string image, uint256 initialSupply, uint256 maxSupply, uint256 initialETHReserves, uint256 initialPrice, uint256 initialMarketCap, uint256 targetETH)";
-
-// Block the BondingCurve and BCTokenFactory were both deployed in. The factory
-// registered this curve in the same block (BondingCurveUpdated) and has never
-// pointed at another one, so no earlier trades exist elsewhere.
-const DEPLOY_BLOCK = 23472343;
-// Trade fee the curve was constructed with. The constructor emits TxFeeUpdated,
-// so the log scan below normally supplies the rate; this is the documented
-// fallback if that scan ever comes back empty. Source: BondingCurve.txFee().
-const INITIAL_TX_FEE_BPS = 150n;
-
-// Fee rates on these contracts are basis points out of 10000.
-const BPS = 10_000n;
-// Split of the curve trade fee: 75% to the token's creator, 25% to the protocol
-// (referral rewards come out of the protocol's quarter, never the creator's).
-// Documented at https://docs.frontier.fun/fees-and-revenue.
-const CURVE_FEE_CREATOR_BPS = 7_500n;
+// One event per non-zero-fee trade carrying the fee's exact split
+// (referralAmount + creatorAmount + protocolAmount == totalFee). It exists
+// because the total is not reliably reconstructable off Buy/Sell (the
+// supply-capping final buy recomputes the fee fee-exclusive, sells round on
+// amountOut + 1) and the creator share is owner-tunable
+// (BCTokenFactory.creatorShareBps).
+const CURVE_FEE_DISTRIBUTED_EVENT =
+  "event CurveFeeDistributed(address indexed token, uint256 totalFee, uint256 referralAmount, uint256 creatorAmount, uint256 protocolAmount, address feeRecipient)";
+// Emitted once by the graduating token in _seedLP with the graduation fee
+// breakdown.
+const GRADUATION_FEES_PAID_EVENT =
+  "event GraduationFeesPaid(address indexed feeRecipient, address indexed caller, uint256 creatorAmount, uint256 protocolAmount, uint256 refundAmount)";
 
 const LABEL = {
   // sources
@@ -69,34 +53,7 @@ const LABEL = {
   TradeFeesToReferrers: "Curve Trade Fees to Referrers",
   GraduationToProtocol: "Graduation Fees to Protocol",
   GraduationToSupplySide: "Graduation Fees to Creators",
-};
-
-const logIndexOf = (log: any) => Number(log.logIndex ?? log.index ?? 0);
-
-/**
- * Cumulative governance logs as a timeline, oldest first, so a value can be
- * resolved as of the moment a given log was emitted rather than as of the end of
- * the window. Both the trade fee and the factory owner have changed on-chain.
- */
-const asTimeline = (logs: any[], read: (log: any) => any) =>
-  logs
-    .map((log: any) => ({
-      block: Number(log.blockNumber),
-      index: logIndexOf(log),
-      value: read(log),
-    }))
-    .sort((a, b) => a.block - b.block || a.index - b.index);
-
-/** The timeline value in force when `log` was emitted. */
-const valueAt = (timeline: ReturnType<typeof asTimeline>, log: any, fallback: any) => {
-  const block = Number(log.blockNumber);
-  const index = logIndexOf(log);
-  let current = fallback;
-  for (const entry of timeline) {
-    if (entry.block > block || (entry.block === block && entry.index > index)) break;
-    current = entry.value;
-  }
-  return current;
+  GraduationToCaller: "Graduation Refund to Caller",
 };
 
 const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
@@ -105,146 +62,56 @@ const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
   const dailyProtocolRevenue = options.createBalances();
   const dailySupplySideRevenue = options.createBalances();
 
-  // The trade fee is governed on-chain, so it is tracked through its own event
-  // rather than hardcoded. It is read from logs rather than an eth_call because
-  // Robinhood Chain's public RPC prunes state and rejects historical calls, which
-  // would break every backfill.
-  const [buyLogs, sellLogs, graduations, feeChanges] = await Promise.all([
-    options.getLogs({ target: BONDING_CURVE, eventAbi: BUY_EVENT, onlyArgs: false }),
-    options.getLogs({ target: BONDING_CURVE, eventAbi: SELL_EVENT, onlyArgs: false }),
+  const [buyLogs, sellLogs, feeSplits, graduations] = await Promise.all([
+    options.getLogs({ target: BONDING_CURVE, eventAbi: BUY_EVENT }),
+    options.getLogs({ target: BONDING_CURVE, eventAbi: SELL_EVENT }),
+    options.getLogs({ target: BONDING_CURVE, eventAbi: CURVE_FEE_DISTRIBUTED_EVENT }),
     options.getLogs({ target: BONDING_CURVE, eventAbi: LP_SEEDED_EVENT }),
-    options.getLogs({
-      target: BONDING_CURVE,
-      eventAbi: TX_FEE_UPDATED_EVENT,
-      fromBlock: DEPLOY_BLOCK,
-      cacheInCloud: true,
-      onlyArgs: false,
-    }),
   ]);
 
-  const feeTimeline = asTimeline(feeChanges, (log: any) => BigInt(log.args.fee));
-  const txFeeBpsAt = (log: any) => valueAt(feeTimeline, log, INITIAL_TX_FEE_BPS);
+  buyLogs.forEach((log: any) => dailyVolume.addGasToken(BigInt(log.amount)));
+  sellLogs.forEach((log: any) => dailyVolume.addGasToken(BigInt(log.amountOut)));
 
-  const addTrade = (gross: bigint, fee: bigint) => {
-    dailyVolume.addGasToken(gross);
-    dailyFees.addGasToken(fee, LABEL.CurveTradeFees);
-    const creatorCut = (fee * CURVE_FEE_CREATOR_BPS) / BPS;
-    dailySupplySideRevenue.addGasToken(creatorCut, LABEL.TradeFeesToCreators);
-    dailyProtocolRevenue.addGasToken(fee - creatorCut, LABEL.TradeFeesToProtocol);
-  };
-
-  buyLogs.forEach((log: any) => {
-    const gross = BigInt(log.args.amount);
-    const txFeeBps = txFeeBpsAt(log);
-    addTrade(gross, (gross * txFeeBps) / (BPS + txFeeBps));
-  });
-  sellLogs.forEach((log: any) => {
-    const gross = BigInt(log.args.amountOut);
-    addTrade(gross, (gross * txFeeBpsAt(log)) / BPS);
-  });
-
-  // A referred trade routes part of the protocol's quarter to the referrer, paid
-  // in WETH by the ReferralManager. It comes out of protocol revenue rather than
-  // adding to it, since the docs are explicit it never comes out of the creator's
-  // share (ReferralManager.directRefFeeBps is 9.09% of the fee, well inside that quarter).
-  const referralRewards = await options.getLogs({
-    target: REFERRAL_MANAGER,
-    eventAbi: REFERRAL_REWARD_EVENT,
-  });
-  referralRewards.forEach((log: any) => {
-    const reward = BigInt(log.reward);
-    if (reward === 0n) return;
-    // Denominations follow the money: the protocol's share accrued to the curve
-    // as native ETH, and the referrer's slice left it wrapped, so the referrer is
-    // credited in WETH rather than the gas token.
-    dailyProtocolRevenue.addGasToken(-reward, LABEL.TradeFeesToProtocol);
-    dailySupplySideRevenue.add(WETH, reward, LABEL.TradeFeesToReferrers);
+  // The referral share comes off the top, the creator share
+  // (BCTokenFactory.creatorShareBps, owner-tunable, set to 50% at deployment)
+  // applies to the fee net of referral, and the protocol keeps the residual —
+  // the event guarantees referral + creator + protocol == totalFee to the wei.
+  feeSplits.forEach((log: any) => {
+    dailyFees.add(WETH, BigInt(log.totalFee), LABEL.CurveTradeFees);
+    const referral = BigInt(log.referralAmount);
+    if (referral !== 0n) dailySupplySideRevenue.add(WETH, referral, LABEL.TradeFeesToReferrers);
+    const creator = BigInt(log.creatorAmount);
+    if (creator !== 0n) dailySupplySideRevenue.add(WETH, creator, LABEL.TradeFeesToCreators);
+    const protocol = BigInt(log.protocolAmount);
+    if (protocol !== 0n) dailyProtocolRevenue.add(WETH, protocol, LABEL.TradeFeesToProtocol);
   });
 
   if (graduations.length) {
-    // At graduation a token wraps its fee share of the ETH it raised and pays it
-    // out, currently 5% to the creator (BCToken.CREATOR_FEE) and 0% to the factory
-    // owner (BCToken.PROTOCOL_FEE), while the rest seeds the Uniswap V4 pool as
-    // native ETH. Reading the WETH transfers instead of applying the configured
-    // rates keeps the split exact across per-token fee settings and changes to them.
-    //
-    // The creator comes from the token's own CoinDeployed event, and the protocol
-    // owner from the factory's ownership history, which has been rotated once.
-    const [launches, ownershipChanges] = await Promise.all([
-      options.getLogs({
-        target: FACTORY,
-        eventAbi: COIN_DEPLOYED_EVENT,
-        fromBlock: DEPLOY_BLOCK,
-        cacheInCloud: true,
-      }),
-      options.getLogs({
-        target: FACTORY,
-        eventAbi: OWNERSHIP_TRANSFERRED_EVENT,
-        fromBlock: DEPLOY_BLOCK,
-        cacheInCloud: true,
-        onlyArgs: false,
-      }),
-    ]);
-
-    const creatorOf: Record<string, string> = {};
-    launches.forEach((log: any) => {
-      creatorOf[String(log.token).toLowerCase()] = String(log.creator).toLowerCase();
+    // Each graduating token emits its own fee breakdown in the same transaction
+    // as the curve's LPSeeded, so the scan is bounded to the day's graduates.
+    // Configured rates at deployment: creator 5%, protocol 0%, caller refund 0%
+    // of the raised ETH — the event keeps the split exact if they change.
+    const feesPaid = await options.getLogs({
+      targets: graduations.map((log: any) => String(log.token)),
+      eventAbi: GRADUATION_FEES_PAID_EVENT,
     });
-    // The owner has already been rotated once, so it is resolved per payout
-    // rather than taken as the latest: a graduation that predates the rotation
-    // paid the owner of the day.
-    const ownerTimeline = asTimeline(ownershipChanges, (log: any) =>
-      String(log.args.newOwner).toLowerCase()
-    );
-
-    // One getLogs per graduation, bounded so a backfill day with many
-    // graduations cannot flood the RPC endpoint.
-    const { results: payoutLegs, errors: payoutErrors } = await PromisePool.withConcurrency(5)
-      .for(graduations)
-      .process(async (log: any) => {
-        const transfers = await options.getLogs({
-          target: WETH,
-          eventAbi: TRANSFER_EVENT,
-          topics: [TRANSFER_TOPIC, asTopic(log.token)],
-          onlyArgs: false,
-        });
-        return transfers.map((transfer: any) => ({
-          transfer,
-          token: String(log.token).toLowerCase(),
-        }));
-      });
-
-    // PromisePool collects rejections instead of rethrowing them. Swallowing one
-    // would silently drop a graduation's fees and understate the day, so fail the
-    // run rather than report a partial figure.
-    if (payoutErrors.length) {
-      throw new Error(
-        `[frontier-fun] ${payoutErrors.length} of ${graduations.length} graduation payout queries failed: ${payoutErrors[0].message}`
-      );
-    }
-
-    payoutLegs.flat().forEach(({ transfer, token }: any) => {
-      const recipient = String(transfer.args.to).toLowerCase();
-      // Guard for a WETH-paired pool: today's markets seed with native ETH, so
-      // no WETH ever reaches the LiquidityManager, but a WETH leg would be
-      // liquidity rather than a fee.
-      if (recipient === LIQUIDITY_MANAGER.toLowerCase()) return;
-      const amount = BigInt(transfer.args.value);
-      if (amount === 0n) return;
-
-      // The contract pays exactly two fee legs here: CREATOR_FEE to the creator
-      // and PROTOCOL_FEE to the factory owner. Anything else is not a known fee,
-      // so it is reported rather than guessed at.
-      if (recipient === creatorOf[token]) {
-        dailyFees.add(WETH, amount, LABEL.GraduationFees);
-        dailySupplySideRevenue.add(WETH, amount, LABEL.GraduationToSupplySide);
-      } else if (recipient === valueAt(ownerTimeline, transfer, "")) {
-        dailyFees.add(WETH, amount, LABEL.GraduationFees);
-        dailyProtocolRevenue.add(WETH, amount, LABEL.GraduationToProtocol);
-      } else {
-        console.error(
-          `[frontier-fun] unclassified graduation payout from ${token} to ${recipient}, not counted`
-        );
+    feesPaid.forEach((log: any) => {
+      const creator = BigInt(log.creatorAmount);
+      if (creator !== 0n) {
+        dailyFees.add(WETH, creator, LABEL.GraduationFees);
+        dailySupplySideRevenue.add(WETH, creator, LABEL.GraduationToSupplySide);
+      }
+      const protocol = BigInt(log.protocolAmount);
+      if (protocol !== 0n) {
+        dailyFees.add(WETH, protocol, LABEL.GraduationFees);
+        dailyProtocolRevenue.add(WETH, protocol, LABEL.GraduationToProtocol);
+      }
+      // Paid out of the raised ETH to whoever triggered graduation — a keeper
+      // incentive, so it counts as a fee to the supply side, not the protocol.
+      const refund = BigInt(log.refundAmount);
+      if (refund !== 0n) {
+        dailyFees.add(WETH, refund, LABEL.GraduationFees);
+        dailySupplySideRevenue.add(WETH, refund, LABEL.GraduationToCaller);
       }
     });
   }
@@ -266,28 +133,28 @@ const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
 
 const methodology = {
   Volume:
-    "Gross ETH notional (fees included) of buys and sells executed on Frontier bonding curves, taken directly from the shared BondingCurve contract's Buy/Sell events, both of which emit the gross figure. Once a curve fills it graduates to a Uniswap V4 pool on the canonical PoolManager; those swaps are counted by the uniswap-v4 adapter on Robinhood Chain and are not double counted here.",
-  Fees: "The bonding-curve trade fee charged on every buy and sell (1.5% of the trade's cost at the time of writing, rate tracked on-chain via TxFeeUpdated), plus the fees a token pays out of the ETH it raised when its curve fills and seeds its Uniswap V4 pool.",
+    "Gross ETH notional (fees included) of buys and sells executed on Frontier bonding curves, taken directly from the shared BondingCurve contract's Buy/Sell events, both of which emit the gross figure. Once a curve fills it graduates to a Uniswap V4 pool on the canonical PoolManager; those swaps, and the swaps of direct-seed launches that skip the curve entirely, are counted by the uniswap-v4 adapter on Robinhood Chain and are not double counted here.",
+  Fees: "The bonding-curve trade fee charged on every buy and sell (1.5% of the trade's cost at the time of writing), plus the fees a token pays out of the ETH it raised when its curve fills and seeds its Uniswap V4 pool. Both are read exactly from the on-chain fee events (CurveFeeDistributed, GraduationFeesPaid).",
   UserFees: "Same as Fees: every fee is paid by traders out of their trade or out of the ETH they raised.",
   Revenue:
-    "Protocol revenue: the protocol's 25% of the bonding-curve trade fee, net of the referrer's share on referred trades (which comes out of that 25%), plus the protocol owner's share of graduation payouts. Frontier has no protocol token, so there is no holders revenue and Revenue equals ProtocolRevenue.",
+    "Protocol revenue: the protocol's residual share of the bonding-curve trade fee after the referrer's and creator's cuts (creator share owner-tunable via creatorShareBps, 50% net of referral at the time of writing), plus the protocol's share of graduation payouts, pushed to a dedicated treasury as WETH at source. Frontier has no protocol token, so there is no holders revenue and Revenue equals ProtocolRevenue.",
   ProtocolRevenue:
-    "The protocol's 25% of the bonding-curve trade fee, net of referrer rewards, plus WETH sent to the factory owner at graduation.",
+    "The protocol's residual share of the bonding-curve trade fee (50% at the time of writing, net of referrer rewards), plus its share of graduation payouts (0% at the time of writing), delivered to the protocol treasury.",
   SupplySideRevenue:
-    "The creator's 75% of every bonding-curve trade fee, the referrer's share on referred trades, and the graduation fee paid to the token creator (5% of the ETH its curve raised).",
+    "The creator's share of every bonding-curve trade fee (50% at the time of writing), the referrer's share on referred trades, the graduation fee paid to the token creator (5% of the ETH its curve raised), and the graduation refund paid to the caller who triggered graduation (0% at the time of writing).",
 };
 
 const feesBreakdown = {
   [LABEL.CurveTradeFees]:
-    "Trade fee withheld by the bonding curve on every buy and sell, at the on-chain txFee rate (150 bps at the time of writing). Buy.amount is fee-inclusive so the fee is txFee/(10000+txFee) of it; Sell.amountOut is pre-fee so the fee is txFee/10000 of it.",
+    "Trade fee withheld by the bonding curve on every buy and sell, at the on-chain txFee rate (150 bps at the time of writing), emitted per trade by CurveFeeDistributed.",
   [LABEL.GraduationFees]:
-    "WETH paid out of the ETH a token raised when its curve fills, to the creator (5%) and the factory owner (0% at the time of writing). The ETH that seeds the Uniswap V4 pool is liquidity, not a fee, and is excluded.",
+    "Fees paid in WETH out of the ETH a token raised when its curve fills: to the creator (5%), the protocol (0% at the time of writing) and a refund to the graduation caller (0% at the time of writing). The ETH that seeds the Uniswap V4 pool is liquidity, not a fee, and is excluded.",
 };
 
 const protocolRevenueBreakdown = {
   [LABEL.TradeFeesToProtocol]:
-    "The protocol's 25% of the bonding-curve trade fee, net of the referrer's share on referred trades.",
-  [LABEL.GraduationToProtocol]: "Graduation payout sent to the factory owner.",
+    "The protocol's residual share of the bonding-curve trade fee (50% at the time of writing), net of the referrer's share on referred trades.",
+  [LABEL.GraduationToProtocol]: "The protocol's share of the graduation payout.",
 };
 
 const breakdownMethodology = {
@@ -299,11 +166,13 @@ const breakdownMethodology = {
   ProtocolRevenue: protocolRevenueBreakdown,
   SupplySideRevenue: {
     [LABEL.TradeFeesToCreators]:
-      "The token creator's 75% of every bonding-curve trade fee.",
+      "The token creator's share of every bonding-curve trade fee (owner-tunable, 50% at the time of writing).",
     [LABEL.TradeFeesToReferrers]:
-      "The referrer's share of the curve trade fee on a referred trade, held as WETH by the ReferralManager until claimed.",
+      "The referrer's share of the curve trade fee on a referred trade, paid in WETH.",
     [LABEL.GraduationToSupplySide]:
       "The graduation fee paid to the token creator, 5% of the ETH its curve raised.",
+    [LABEL.GraduationToCaller]:
+      "The graduation refund paid to the caller who triggered graduation (0% at the time of writing).",
   },
 };
 
@@ -312,7 +181,7 @@ const adapter: Adapter = {
   pullHourly: true,
   fetch,
   chains: [CHAIN.ROBINHOOD],
-  start: "2026-07-30", // first CoinDeployed event, block 23650298
+  start: "2026-08-15", // v1.2 production deployment, block 36671438
   methodology,
   breakdownMethodology,
 };

--- a/dexs/frontier-fun/index.ts
+++ b/dexs/frontier-fun/index.ts
@@ -1,53 +1,55 @@
+import { PromisePool } from "@supercharge/promise-pool";
 import { Adapter, FetchOptions, FetchResultV2 } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 import ADDRESSES from "../../helpers/coreAssets.json";
 
 // Frontier (frontier.fun) is a bonding-curve token launchpad on Robinhood Chain (4663).
 //
-// Tracks the v1.2 production deployment (live 2026-08-15). Every launched token
-// trades against one shared BondingCurve contract that emits Buy/Sell for all
-// markets, and every fee split is emitted on-chain (CurveFeeDistributed per
-// trade, GraduationFeesPaid at graduation), so nothing is reconstructed from
-// rates. All fee payouts are pushed as WETH at source: referrer, creator and
-// the protocol treasury are paid inside the trade or graduation.
-//
+// v1 (live 2026-07-30) and v1.2 (live 2026-08-15) are both counted. Every launched
+// token trades against one shared BondingCurve that emits Buy/Sell for all markets.
 // When a curve fills, the token pays out graduation fees and seeds a Uniswap V4
 // pool (LPSeeded); post-graduation swaps are already counted by the uniswap-v4
 // adapter on this chain and are not double counted here. Direct-seed launches
-// skip the curve and are born on their V4 pool: they emit no curve events and
-// their swaps (including the optional dev buy, a real V4 swap) are likewise the
-// uniswap-v4 adapter's.
-//
-// https://robinhoodchain.blockscout.com/address/0xEAaa2aE7De8B80d7a59eCF08B078EfAC6FcE6659
-// Factory: 0xe3A826C056e578c240D362BF4C2fa53E5c0c17a5.
-const BONDING_CURVE = "0xEAaa2aE7De8B80d7a59eCF08B078EfAC6FcE6659";
+// (v1.2) skip the curve and are born on their V4 pool: they emit no curve events
+// and their swaps are likewise the uniswap-v4 adapter's.
 const WETH = ADDRESSES.robinhood.WETH;
 
-// Both events emit the GROSS ETH notional (Buy.amount is msg.value,
-// fee-inclusive; Sell.amountOut is pre-fee proceeds).
 const BUY_EVENT =
   "event Buy(address indexed user, address indexed token, uint256 amount, uint256 amountOut, uint256 totalSupply, uint256 marketCap, uint256 price, uint256 reserveBalance)";
 const SELL_EVENT =
   "event Sell(address indexed user, address indexed token, uint256 amount, uint256 amountOut, uint256 totalSupply, uint256 marketCap, uint256 price, uint256 reserveBalance)";
 const LP_SEEDED_EVENT = "event LPSeeded(address indexed token, address indexed pool)";
-// One event per non-zero-fee trade carrying the fee's exact split
-// (referralAmount + creatorAmount + protocolAmount == totalFee). It exists
-// because the total is not reliably reconstructable off Buy/Sell (the
-// supply-capping final buy recomputes the fee fee-exclusive, sells round on
-// amountOut + 1) and the creator share is owner-tunable
-// (BCTokenFactory.creatorShareBps).
+
+// v1 — both deployed in block 23472343.
+const V1_BONDING_CURVE = "0xCCa442899dFD80bf04340fa8C245C7EB02F71DD4";
+const V1_FACTORY = "0x3cbC9395046607C083B383DC3588A3e8308dFf54";
+const V1_LIQUIDITY_MANAGER = "0x97f3578083396D4ef2042868c6aE9d4eC91007A6";
+const V1_REFERRAL_MANAGER = "0x6Fb1160A663834e8E53E411CC7202A01F1b144DD";
+const V1_DEPLOY_BLOCK = 23472343;
+const V1_INITIAL_TX_FEE_BPS = 150n;
+const BPS = 10_000n;
+const V1_CURVE_FEE_CREATOR_BPS = 7_500n;
+const TRANSFER_TOPIC = "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef";
+const asTopic = (address: string) => "0x" + address.slice(2).toLowerCase().padStart(64, "0");
+const TRANSFER_EVENT = "event Transfer(address indexed from, address indexed to, uint256 value)";
+const TX_FEE_UPDATED_EVENT = "event TxFeeUpdated(uint256 fee)";
+const REFERRAL_REWARD_EVENT =
+  "event ReferralRewardReceived(address indexed referrer, address indexed referredUser, address indexed token, uint256 reward, bool isDirect)";
+const OWNERSHIP_TRANSFERRED_EVENT =
+  "event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)";
+const V1_COIN_DEPLOYED_EVENT =
+  "event CoinDeployed(address indexed creator, address indexed token, address factory, address lp, string name, string symbol, string description, string image, uint256 initialSupply, uint256 maxSupply, uint256 initialETHReserves, uint256 initialPrice, uint256 initialMarketCap, uint256 targetETH)";
+
+// v1.2 production — both deployed in block 36671438.
+const V12_BONDING_CURVE = "0xEAaa2aE7De8B80d7a59eCF08B078EfAC6FcE6659";
 const CURVE_FEE_DISTRIBUTED_EVENT =
   "event CurveFeeDistributed(address indexed token, uint256 totalFee, uint256 referralAmount, uint256 creatorAmount, uint256 protocolAmount, address feeRecipient)";
-// Emitted once by the graduating token in _seedLP with the graduation fee
-// breakdown.
 const GRADUATION_FEES_PAID_EVENT =
   "event GraduationFeesPaid(address indexed feeRecipient, address indexed caller, uint256 creatorAmount, uint256 protocolAmount, uint256 refundAmount)";
 
 const LABEL = {
-  // sources
   CurveTradeFees: "Curve Trade Fees",
   GraduationFees: "Graduation Fees",
-  // destinations
   TradeFeesToProtocol: "Curve Trade Fees to Protocol",
   TradeFeesToCreators: "Curve Trade Fees to Creators",
   TradeFeesToReferrers: "Curve Trade Fees to Referrers",
@@ -56,26 +58,163 @@ const LABEL = {
   GraduationToCaller: "Graduation Refund to Caller",
 };
 
-const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
-  const dailyVolume = options.createBalances();
-  const dailyFees = options.createBalances();
-  const dailyProtocolRevenue = options.createBalances();
-  const dailySupplySideRevenue = options.createBalances();
+const logIndexOf = (log: any) => Number(log.logIndex ?? log.index ?? 0);
+
+const asTimeline = (logs: any[], read: (log: any) => any) =>
+  logs
+    .map((log: any) => ({
+      block: Number(log.blockNumber),
+      index: logIndexOf(log),
+      value: read(log),
+    }))
+    .sort((a, b) => a.block - b.block || a.index - b.index);
+
+const valueAt = (timeline: ReturnType<typeof asTimeline>, log: any, fallback: any) => {
+  const block = Number(log.blockNumber);
+  const index = logIndexOf(log);
+  let current = fallback;
+  for (const entry of timeline) {
+    if (entry.block > block || (entry.block === block && entry.index > index)) break;
+    current = entry.value;
+  }
+  return current;
+};
+
+type DayBalances = {
+  dailyVolume: ReturnType<FetchOptions["createBalances"]>;
+  dailyFees: ReturnType<FetchOptions["createBalances"]>;
+  dailyProtocolRevenue: ReturnType<FetchOptions["createBalances"]>;
+  dailySupplySideRevenue: ReturnType<FetchOptions["createBalances"]>;
+};
+
+const addV1 = async (options: FetchOptions, day: DayBalances) => {
+  const { dailyVolume, dailyFees, dailyProtocolRevenue, dailySupplySideRevenue } = day;
+
+  const [buyLogs, sellLogs, graduations, feeChanges] = await Promise.all([
+    options.getLogs({ target: V1_BONDING_CURVE, eventAbi: BUY_EVENT, onlyArgs: false }),
+    options.getLogs({ target: V1_BONDING_CURVE, eventAbi: SELL_EVENT, onlyArgs: false }),
+    options.getLogs({ target: V1_BONDING_CURVE, eventAbi: LP_SEEDED_EVENT }),
+    options.getLogs({
+      target: V1_BONDING_CURVE,
+      eventAbi: TX_FEE_UPDATED_EVENT,
+      fromBlock: V1_DEPLOY_BLOCK,
+      cacheInCloud: true,
+      onlyArgs: false,
+    }),
+  ]);
+
+  const feeTimeline = asTimeline(feeChanges, (log: any) => BigInt(log.args.fee));
+  const txFeeBpsAt = (log: any) => valueAt(feeTimeline, log, V1_INITIAL_TX_FEE_BPS);
+
+  const addTrade = (gross: bigint, fee: bigint) => {
+    dailyVolume.addGasToken(gross);
+    dailyFees.addGasToken(fee, LABEL.CurveTradeFees);
+    const creatorCut = (fee * V1_CURVE_FEE_CREATOR_BPS) / BPS;
+    dailySupplySideRevenue.addGasToken(creatorCut, LABEL.TradeFeesToCreators);
+    dailyProtocolRevenue.addGasToken(fee - creatorCut, LABEL.TradeFeesToProtocol);
+  };
+
+  buyLogs.forEach((log: any) => {
+    const gross = BigInt(log.args.amount);
+    const txFeeBps = txFeeBpsAt(log);
+    addTrade(gross, (gross * txFeeBps) / (BPS + txFeeBps));
+  });
+  sellLogs.forEach((log: any) => {
+    const gross = BigInt(log.args.amountOut);
+    addTrade(gross, (gross * txFeeBpsAt(log)) / BPS);
+  });
+
+  const referralRewards = await options.getLogs({
+    target: V1_REFERRAL_MANAGER,
+    eventAbi: REFERRAL_REWARD_EVENT,
+  });
+  referralRewards.forEach((log: any) => {
+    const reward = BigInt(log.reward);
+    if (reward === 0n) return;
+    dailyProtocolRevenue.addGasToken(-reward, LABEL.TradeFeesToProtocol);
+    dailySupplySideRevenue.add(WETH, reward, LABEL.TradeFeesToReferrers);
+  });
+
+  if (!graduations.length) return;
+
+  const [launches, ownershipChanges] = await Promise.all([
+    options.getLogs({
+      target: V1_FACTORY,
+      eventAbi: V1_COIN_DEPLOYED_EVENT,
+      fromBlock: V1_DEPLOY_BLOCK,
+      cacheInCloud: true,
+    }),
+    options.getLogs({
+      target: V1_FACTORY,
+      eventAbi: OWNERSHIP_TRANSFERRED_EVENT,
+      fromBlock: V1_DEPLOY_BLOCK,
+      cacheInCloud: true,
+      onlyArgs: false,
+    }),
+  ]);
+
+  const creatorOf: Record<string, string> = {};
+  launches.forEach((log: any) => {
+    creatorOf[String(log.token).toLowerCase()] = String(log.creator).toLowerCase();
+  });
+  const ownerTimeline = asTimeline(ownershipChanges, (log: any) =>
+    String(log.args.newOwner).toLowerCase()
+  );
+
+  const { results: payoutLegs, errors: payoutErrors } = await PromisePool.withConcurrency(5)
+    .for(graduations)
+    .process(async (log: any) => {
+      const transfers = await options.getLogs({
+        target: WETH,
+        eventAbi: TRANSFER_EVENT,
+        topics: [TRANSFER_TOPIC, asTopic(log.token)],
+        onlyArgs: false,
+      });
+      return transfers.map((transfer: any) => ({
+        transfer,
+        token: String(log.token).toLowerCase(),
+      }));
+    });
+
+  if (payoutErrors.length) {
+    throw new Error(
+      `[frontier-fun] ${payoutErrors.length} of ${graduations.length} v1 graduation payout queries failed: ${payoutErrors[0].message}`
+    );
+  }
+
+  payoutLegs.flat().forEach(({ transfer, token }: any) => {
+    const recipient = String(transfer.args.to).toLowerCase();
+    if (recipient === V1_LIQUIDITY_MANAGER.toLowerCase()) return;
+    const amount = BigInt(transfer.args.value);
+    if (amount === 0n) return;
+
+    if (recipient === creatorOf[token]) {
+      dailyFees.add(WETH, amount, LABEL.GraduationFees);
+      dailySupplySideRevenue.add(WETH, amount, LABEL.GraduationToSupplySide);
+    } else if (recipient === valueAt(ownerTimeline, transfer, "")) {
+      dailyFees.add(WETH, amount, LABEL.GraduationFees);
+      dailyProtocolRevenue.add(WETH, amount, LABEL.GraduationToProtocol);
+    } else {
+      console.error(
+        `[frontier-fun] unclassified v1 graduation payout from ${token} to ${recipient}, not counted`
+      );
+    }
+  });
+};
+
+const addV12 = async (options: FetchOptions, day: DayBalances) => {
+  const { dailyVolume, dailyFees, dailyProtocolRevenue, dailySupplySideRevenue } = day;
 
   const [buyLogs, sellLogs, feeSplits, graduations] = await Promise.all([
-    options.getLogs({ target: BONDING_CURVE, eventAbi: BUY_EVENT }),
-    options.getLogs({ target: BONDING_CURVE, eventAbi: SELL_EVENT }),
-    options.getLogs({ target: BONDING_CURVE, eventAbi: CURVE_FEE_DISTRIBUTED_EVENT }),
-    options.getLogs({ target: BONDING_CURVE, eventAbi: LP_SEEDED_EVENT }),
+    options.getLogs({ target: V12_BONDING_CURVE, eventAbi: BUY_EVENT }),
+    options.getLogs({ target: V12_BONDING_CURVE, eventAbi: SELL_EVENT }),
+    options.getLogs({ target: V12_BONDING_CURVE, eventAbi: CURVE_FEE_DISTRIBUTED_EVENT }),
+    options.getLogs({ target: V12_BONDING_CURVE, eventAbi: LP_SEEDED_EVENT }),
   ]);
 
   buyLogs.forEach((log: any) => dailyVolume.addGasToken(BigInt(log.amount)));
   sellLogs.forEach((log: any) => dailyVolume.addGasToken(BigInt(log.amountOut)));
 
-  // The referral share comes off the top, the creator share
-  // (BCTokenFactory.creatorShareBps, owner-tunable, set to 50% at deployment)
-  // applies to the fee net of referral, and the protocol keeps the residual —
-  // the event guarantees referral + creator + protocol == totalFee to the wei.
   feeSplits.forEach((log: any) => {
     dailyFees.add(WETH, BigInt(log.totalFee), LABEL.CurveTradeFees);
     const referral = BigInt(log.referralAmount);
@@ -86,93 +225,94 @@ const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
     if (protocol !== 0n) dailyProtocolRevenue.add(WETH, protocol, LABEL.TradeFeesToProtocol);
   });
 
-  if (graduations.length) {
-    // Each graduating token emits its own fee breakdown in the same transaction
-    // as the curve's LPSeeded, so the scan is bounded to the day's graduates.
-    // Configured rates at deployment: creator 5%, protocol 0%, caller refund 0%
-    // of the raised ETH — the event keeps the split exact if they change.
-    const feesPaid = await options.getLogs({
-      targets: [...new Set(graduations.map((log: any) => String(log.token)))],
-      eventAbi: GRADUATION_FEES_PAID_EVENT,
-    });
-    feesPaid.forEach((log: any) => {
-      const creator = BigInt(log.creatorAmount);
-      if (creator !== 0n) {
-        dailyFees.add(WETH, creator, LABEL.GraduationFees);
-        dailySupplySideRevenue.add(WETH, creator, LABEL.GraduationToSupplySide);
-      }
-      const protocol = BigInt(log.protocolAmount);
-      if (protocol !== 0n) {
-        dailyFees.add(WETH, protocol, LABEL.GraduationFees);
-        dailyProtocolRevenue.add(WETH, protocol, LABEL.GraduationToProtocol);
-      }
-      // Paid out of the raised ETH to whoever triggered graduation — a keeper
-      // incentive, so it counts as a fee to the supply side, not the protocol.
-      const refund = BigInt(log.refundAmount);
-      if (refund !== 0n) {
-        dailyFees.add(WETH, refund, LABEL.GraduationFees);
-        dailySupplySideRevenue.add(WETH, refund, LABEL.GraduationToCaller);
-      }
-    });
-  }
+  if (!graduations.length) return;
 
-  // Frontier has no protocol token, so there are no holders revenue and
-  // Revenue == ProtocolRevenue == Fees - SupplySideRevenue. Cloned so the two
-  // returned dimensions do not alias the same Balances instance.
-  const dailyRevenue = dailyProtocolRevenue.clone();
+  const feesPaid = await options.getLogs({
+    targets: [...new Set(graduations.map((log: any) => String(log.token)))],
+    eventAbi: GRADUATION_FEES_PAID_EVENT,
+  });
+  feesPaid.forEach((log: any) => {
+    const creator = BigInt(log.creatorAmount);
+    if (creator !== 0n) {
+      dailyFees.add(WETH, creator, LABEL.GraduationFees);
+      dailySupplySideRevenue.add(WETH, creator, LABEL.GraduationToSupplySide);
+    }
+    const protocol = BigInt(log.protocolAmount);
+    if (protocol !== 0n) {
+      dailyFees.add(WETH, protocol, LABEL.GraduationFees);
+      dailyProtocolRevenue.add(WETH, protocol, LABEL.GraduationToProtocol);
+    }
+    const refund = BigInt(log.refundAmount);
+    if (refund !== 0n) {
+      dailyFees.add(WETH, refund, LABEL.GraduationFees);
+      dailySupplySideRevenue.add(WETH, refund, LABEL.GraduationToCaller);
+    }
+  });
+};
+
+const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
+  const day: DayBalances = {
+    dailyVolume: options.createBalances(),
+    dailyFees: options.createBalances(),
+    dailyProtocolRevenue: options.createBalances(),
+    dailySupplySideRevenue: options.createBalances(),
+  };
+
+  await addV1(options, day);
+  await addV12(options, day);
+
+  const dailyRevenue = day.dailyProtocolRevenue.clone();
 
   return {
-    dailyVolume,
-    dailyFees,
-    dailyUserFees: dailyFees,
+    dailyVolume: day.dailyVolume,
+    dailyFees: day.dailyFees,
+    dailyUserFees: day.dailyFees,
     dailyRevenue,
-    dailyProtocolRevenue,
-    dailySupplySideRevenue,
+    dailyProtocolRevenue: day.dailyProtocolRevenue,
+    dailySupplySideRevenue: day.dailySupplySideRevenue,
   };
 };
 
 const methodology = {
   Volume:
-    "Gross ETH notional (fees included) of buys and sells executed on Frontier bonding curves, taken directly from the shared BondingCurve contract's Buy/Sell events, both of which emit the gross figure. Once a curve fills it graduates to a Uniswap V4 pool on the canonical PoolManager; those swaps, and the swaps of direct-seed launches that skip the curve entirely, are counted by the uniswap-v4 adapter on Robinhood Chain and are not double counted here.",
-  Fees: "The bonding-curve trade fee charged on every buy and sell (1.5% of the trade's cost at the time of writing), plus the fees a token pays out of the ETH it raised when its curve fills and seeds its Uniswap V4 pool. Both are read exactly from the on-chain fee events (CurveFeeDistributed, GraduationFeesPaid).",
+    "Gross ETH notional (fees included) of buys and sells executed on Frontier bonding curves (v1 and v1.2), taken directly from each shared BondingCurve contract's Buy/Sell events, both of which emit the gross figure. Once a curve fills it graduates to a Uniswap V4 pool on the canonical PoolManager; those swaps, and the swaps of v1.2 direct-seed launches that skip the curve entirely, are counted by the uniswap-v4 adapter on Robinhood Chain and are not double counted here.",
+  Fees: "The bonding-curve trade fee charged on every buy and sell (1.5% of the trade's cost at the time of writing), plus the fees a token pays out of the ETH it raised when its curve fills and seeds its Uniswap V4 pool. v1 reconstructs the trade fee from the on-chain txFee timeline and graduation payouts from WETH transfers; v1.2 reads both exactly from CurveFeeDistributed and GraduationFeesPaid.",
   UserFees: "Same as Fees: every fee is paid by traders out of their trade or out of the ETH they raised.",
   Revenue:
-    "Protocol revenue: the protocol's residual share of the bonding-curve trade fee after the referrer's and creator's cuts (creator share owner-tunable via creatorShareBps, 50% net of referral at the time of writing), plus the protocol's share of graduation payouts, pushed to a dedicated treasury as WETH at source. Frontier has no protocol token, so there is no holders revenue and Revenue equals ProtocolRevenue.",
+    "Protocol revenue across both deployments: on v1, the protocol's 25% of the bonding-curve trade fee net of referrer rewards plus the factory owner's graduation share; on v1.2, the residual share of the trade fee after referrer and creator cuts (creator share owner-tunable via creatorShareBps) plus the protocol's graduation share, pushed to a dedicated treasury as WETH. Frontier has no protocol token, so there is no holders revenue and Revenue equals ProtocolRevenue.",
   ProtocolRevenue:
-    "The protocol's residual share of the bonding-curve trade fee (50% at the time of writing, net of referrer rewards), plus its share of graduation payouts (0% at the time of writing), delivered to the protocol treasury.",
+    "v1: 25% of the curve trade fee net of referrer rewards, plus WETH sent to the factory owner at graduation. v1.2: residual share of the curve trade fee (50% at the time of writing, net of referrer rewards) plus its share of graduation payouts (0% at the time of writing).",
   SupplySideRevenue:
-    "The creator's share of every bonding-curve trade fee (50% at the time of writing), the referrer's share on referred trades, the graduation fee paid to the token creator (5% of the ETH its curve raised), and the graduation refund paid to the caller who triggered graduation (0% at the time of writing).",
+    "v1: the creator's 75% of every curve trade fee, referrer rewards, and the 5% graduation fee to the token creator. v1.2: the creator's share of every curve trade fee (50% at the time of writing), referrer rewards, the 5% graduation fee to the creator, and the graduation refund to the caller (0% at the time of writing).",
 };
 
 const feesBreakdown = {
   [LABEL.CurveTradeFees]:
-    "Trade fee withheld by the bonding curve on every buy and sell, at the on-chain txFee rate (150 bps at the time of writing), emitted per trade by CurveFeeDistributed.",
+    "Trade fee withheld by the bonding curve on every buy and sell, at the on-chain txFee rate (150 bps at the time of writing). v1 reconstructs it from Buy/Sell and TxFeeUpdated; v1.2 emits it per trade as CurveFeeDistributed.",
   [LABEL.GraduationFees]:
-    "Fees paid in WETH out of the ETH a token raised when its curve fills: to the creator (5%), the protocol (0% at the time of writing) and a refund to the graduation caller (0% at the time of writing). The ETH that seeds the Uniswap V4 pool is liquidity, not a fee, and is excluded.",
+    "Fees paid in WETH out of the ETH a token raised when its curve fills. v1 classifies WETH transfers to the creator (5%) and factory owner (0% at the time of writing); v1.2 uses GraduationFeesPaid (creator 5%, protocol 0%, caller refund 0% at the time of writing). The ETH that seeds the Uniswap V4 pool is liquidity, not a fee, and is excluded.",
 };
 
 const protocolRevenueBreakdown = {
   [LABEL.TradeFeesToProtocol]:
-    "The protocol's residual share of the bonding-curve trade fee (50% at the time of writing), net of the referrer's share on referred trades.",
+    "The protocol's share of the bonding-curve trade fee, net of the referrer's share on referred trades (25% on v1; residual after creator/referrer on v1.2, 50% at the time of writing).",
   [LABEL.GraduationToProtocol]: "The protocol's share of the graduation payout.",
 };
 
 const breakdownMethodology = {
-  // dailyUserFees is dailyFees, and dailyRevenue is dailyProtocolRevenue, so those
-  // pairs share the same breakdown.
   Fees: feesBreakdown,
   UserFees: feesBreakdown,
   Revenue: protocolRevenueBreakdown,
   ProtocolRevenue: protocolRevenueBreakdown,
   SupplySideRevenue: {
     [LABEL.TradeFeesToCreators]:
-      "The token creator's share of every bonding-curve trade fee (owner-tunable, 50% at the time of writing).",
+      "The token creator's share of every bonding-curve trade fee (75% on v1; owner-tunable, 50% at the time of writing on v1.2).",
     [LABEL.TradeFeesToReferrers]:
       "The referrer's share of the curve trade fee on a referred trade, paid in WETH.",
     [LABEL.GraduationToSupplySide]:
       "The graduation fee paid to the token creator, 5% of the ETH its curve raised.",
     [LABEL.GraduationToCaller]:
-      "The graduation refund paid to the caller who triggered graduation (0% at the time of writing).",
+      "The v1.2 graduation refund paid to the caller who triggered graduation (0% at the time of writing).",
   },
 };
 
@@ -181,7 +321,7 @@ const adapter: Adapter = {
   pullHourly: true,
   fetch,
   chains: [CHAIN.ROBINHOOD],
-  start: "2026-08-15", // v1.2 production deployment, block 36671438
+  start: "2026-07-30", // first CoinDeployed event (v1), block 23650298
   methodology,
   breakdownMethodology,
 };


### PR DESCRIPTION
Updates the **Frontier** adapters (`dexs/frontier-fun`, `active-users/frontier-fun`, first added in #8637) after the protocol's v1.2 production redeploy on Robinhood Chain.

### What changed on-chain

Frontier redeployed its full contract stack on 2026-08-15 (block 36671438) and the project now runs exclusively on the new deployment:

| | v1 (previous) | v1.2 (current) |
|---|---|---|
| BCTokenFactory | `0x3cbC9395046607C083B383DC3588A3e8308dFf54` | `0xe3A826C056e578c240D362BF4C2fa53E5c0c17a5` |
| BondingCurve | `0xCCa442899dFD80bf04340fa8C245C7EB02F71DD4` | `0xEAaa2aE7De8B80d7a59eCF08B078EfAC6FcE6659` |

The v1.2 contracts emit the fee accounting this adapter previously had to reconstruct:

- **`CurveFeeDistributed`** — one event per trade with the exact fee split, guaranteed `referral + creator + protocol == totalFee` to the wei. This replaces deriving the fee from `Buy`/`Sell` notionals at the `TxFeeUpdated` rate and applying the documented 75/25 creator/protocol split — which is now a live owner-tunable knob (`creatorShareBps`), set to **50%** on the new deployment, so hardcoding it would misreport revenue going forward.
- **`GraduationFeesPaid`** — one event per graduation with the creator/protocol/caller-refund breakdown, replacing the WETH-`Transfer` classification heuristics (and the `CoinDeployed` creator map and factory ownership timeline they required).
- All fee legs are pushed as **WETH at source** (referrer, creator, and a dedicated protocol treasury), so every fee leg is credited in WETH.

### Adapter changes

- `dexs/frontier-fun`: points at the v1.2 BondingCurve; volume unchanged in method (gross ETH notional from `Buy`/`Sell`); fees/revenue read from the two events above; graduation scan bounded to the day's `LPSeeded` tokens. **`start` moved from 2026-07-30 to 2026-08-15.**
- `active-users/frontier-fun`: same address switch, plus the new `CoinDeployed` signature (gains `bool indexed directSeed`); same start-date move.
- v1.2 added **direct-seed launches** (tokens born directly on their Uniswap V4 pool, no curve phase). They emit no curve events; their swaps are counted by `dexs/uniswap-v4.ts` on this chain, exactly like post-graduation swaps of curve tokens — the same no-double-counting rule as before.

### Note for the reviewer

The team's decision is to drop the v1 deployment entirely rather than aggregate both (the old cohort is inactive since the redeploy). Since `start` moved forward, **stored records for `frontier-fun` before 2026-08-15 (both dimensions and active users) should be discarded** — please let me know if that needs anything on my side.

### Validation

```
pnpm test dexs frontier-fun               # latest day
pnpm test active-users frontier-fun       # not covered by CI, tested by hand
pnpm run ts-check && pnpm run ts-check-cli
```

Latest day (2026-08-15 → 2026-08-16 UTC window at time of testing):

```
Daily volume: 4.09 k
Daily fees: 60.87
Daily revenue: 30.43
Daily protocol revenue: 30.43
Daily supply side revenue: 30.43

label                        | Daily fees | Daily supply side revenue | Daily revenue
Curve Trade Fees             | 60.87      |                           |
Curve Trade Fees to Creators |            | 30.43                     |
Curve Trade Fees to Protocol |            |                           | 30.43
```

The 50/50 split matches the on-chain `creatorShareBps = 5000` (`CreatorShareUpdated` at block 36671442), and total fees are ~1.49% of volume, consistent with the 150 bps `txFee` across both legs. No graduation has occurred yet on the v1.2 curve (zero `LPSeeded`), so the `GraduationFeesPaid` path follows the ABI but could not be exercised against live data.

Active users on 2026-08-15: 26 daily active users, 735 transactions.
