### PR TITLE
feat: add RiftBeam aggregator (Solana)

### DIFF
--- a/aggregators/riftbeam/index.ts
+++ b/aggregators/riftbeam/index.ts
@@ -1,34 +1,37 @@
-import { SimpleAdapter } from "../../adapters/types";
+import { FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 import { httpGet } from "../../utils/fetchURL";
 
+// Public volume endpoint — aggregated SOL swap volume via RiftBeam engine
 const VOLUME_ENDPOINT = "https://swaptitan.net/v1/riftbeam/volume";
+const DAY_SECONDS = 86400; // seconds per day, for query window
 
-const fetch = async (timestamp: number) => {
-  const dayEnd = timestamp;
-  const dayStart = timestamp - 86400;
-  try {
-    const url = `${VOLUME_ENDPOINT}?from=${dayStart}&to=${dayEnd}`;
-    const res = await httpGet(url);
-    return {
-      dailyVolume: res.dailyVolume?.toString() ?? "0",
-      timestamp,
-    };
-  } catch (e) {
-    return { dailyVolume: "0", timestamp };
+const fetch = async (options: FetchOptions) => {
+  const from = options.startTimestamp;
+  const to = options.endTimestamp ?? from + DAY_SECONDS;
+  const url = `${VOLUME_ENDPOINT}?from=${from}&to=${to}`;
+  const res = await httpGet(url);
+  if (res.dailyVolume == null) {
+    throw new Error(`[riftbeam] missing dailyVolume in response: ${JSON.stringify(res)}`);
   }
+  return {
+    dailyVolume: String(res.dailyVolume),
+  };
+};
+
+const methodology = {
+  Volume: "Trading volume routed through RiftBeam DEX aggregator on Solana (Orca CLMM, Raydium CLMM, Pump.fun AMM).",
 };
 
 const adapter: SimpleAdapter = {
-  version: 1,
+  version: 2,
   adapter: {
     [CHAIN.SOLANA]: {
       fetch,
-      start: async () => 1753574400,
+      start: "2025-07-27",
       meta: {
-        methodology: {
-          Volume: "Trading volume routed through RiftBeam on Solana.",
-        },
+        methodology,
+        breakdownMethodology: methodology,
       },
     },
   },

--- a/aggregators/riftbeam/index.ts
+++ b/aggregators/riftbeam/index.ts
@@ -2,17 +2,17 @@ import { FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 import { httpGet } from "../../utils/fetchURL";
 
-// Public volume endpoint — aggregated SOL swap volume via RiftBeam engine
 const VOLUME_ENDPOINT = "https://swaptitan.net/v1/riftbeam/volume";
-const DAY_SECONDS = 86400; // seconds per day, for query window
+const DAY_SECONDS = 86400;
+const TIMEOUT_MS = 10000;
 
 const fetch = async (options: FetchOptions) => {
   const from = options.startTimestamp;
   const to = options.endTimestamp ?? from + DAY_SECONDS;
   const url = `${VOLUME_ENDPOINT}?from=${from}&to=${to}`;
-  const res = await httpGet(url);
+  const res = await httpGet(url, { timeout: TIMEOUT_MS });
   if (res.dailyVolume == null) {
-    throw new Error(`[riftbeam] missing dailyVolume in response: ${JSON.stringify(res)}`);
+    throw new Error(`[riftbeam] missing dailyVolume: ${JSON.stringify(res)}`);
   }
   return {
     dailyVolume: String(res.dailyVolume),

--- a/aggregators/riftbeam/index.ts
+++ b/aggregators/riftbeam/index.ts
@@ -1,0 +1,37 @@
+import { SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import { httpGet } from "../../utils/fetchURL";
+
+const VOLUME_ENDPOINT = "https://swaptitan.net/v1/riftbeam/volume";
+
+const fetch = async (timestamp: number) => {
+  const dayEnd = timestamp;
+  const dayStart = timestamp - 86400;
+  try {
+    const url = `${VOLUME_ENDPOINT}?from=${dayStart}&to=${dayEnd}`;
+    const res = await httpGet(url);
+    return {
+      dailyVolume: res.dailyVolume?.toString() ?? "0",
+      timestamp,
+    };
+  } catch (e) {
+    return { dailyVolume: "0", timestamp };
+  }
+};
+
+const adapter: SimpleAdapter = {
+  version: 1,
+  adapter: {
+    [CHAIN.SOLANA]: {
+      fetch,
+      start: async () => 1753574400,
+      meta: {
+        methodology: {
+          Volume: "Trading volume routed through RiftBeam on Solana.",
+        },
+      },
+    },
+  },
+};
+
+export default adapter;

--- a/aggregators/riftbeam/index.ts
+++ b/aggregators/riftbeam/index.ts
@@ -1,40 +1,57 @@
-import { FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { Dependencies, FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
-import { httpGet } from "../../utils/fetchURL";
+import { queryAllium } from "../../helpers/allium";
 
-const VOLUME_ENDPOINT = "https://swaptitan.net/v1/riftbeam/volume";
-const DAY_SECONDS = 86400;
-const TIMEOUT_MS = 10000;
+// Marker program included in RiftBeam-routed swap txs (empty invoke + "RiftBeam" memo).
+// The swap itself is executed via Jupiter (and historically other AMMs).
+const RIFTBEAM_PROGRAM = "DYR2SfXreL4wMPKjWzgWv17r7qHJk3kyp1R7k3MsKkEV";
 
 const fetch = async (options: FetchOptions) => {
-  const from = options.startTimestamp;
-  const to = options.endTimestamp ?? from + DAY_SECONDS;
-  const url = `${VOLUME_ENDPOINT}?from=${from}&to=${to}`;
-  const res = await httpGet(url, { timeout: TIMEOUT_MS });
-  if (res.dailyVolume == null) {
-    throw new Error(`[riftbeam] missing dailyVolume: ${JSON.stringify(res)}`);
-  }
+  const start = options.startTimestamp;
+  const end = options.endTimestamp;
+  const query = `
+    WITH rift_txs AS (
+      SELECT DISTINCT txn_id
+      FROM solana.raw.instructions
+      WHERE program_id = '${RIFTBEAM_PROGRAM}'
+        AND block_timestamp >= TO_TIMESTAMP_NTZ(${start})
+        AND block_timestamp < TO_TIMESTAMP_NTZ(${end})
+    ),
+    hop_dedup AS (
+      SELECT t.usd_amount
+      FROM solana.dex.trades t
+      INNER JOIN rift_txs r ON t.txn_id = r.txn_id
+      WHERE t.block_timestamp >= TO_TIMESTAMP_NTZ(${start})
+        AND t.block_timestamp < TO_TIMESTAMP_NTZ(${end})
+      QUALIFY ROW_NUMBER() OVER (
+        PARTITION BY t.txn_id, t.instruction_index
+        ORDER BY t.usd_amount DESC
+      ) = 1
+    )
+    SELECT COALESCE(SUM(usd_amount), 0) AS volume
+    FROM hop_dedup
+  `;
+
+  const data = await queryAllium(query);
   return {
-    dailyVolume: String(res.dailyVolume),
+    dailyVolume: data[0]?.volume ?? 0,
   };
 };
 
 const methodology = {
-  Volume: "Trading volume routed through RiftBeam DEX aggregator on Solana (Orca CLMM, Raydium CLMM, Pump.fun AMM).",
+  Volume:
+    "USD notional of swaps in successful Solana transactions that invoke the RiftBeam marker program (DYR2SfXreL4wMPKjWzgWv17r7qHJk3kyp1R7k3MsKkEV). Sourced from Allium solana.dex.trades, counting each outer instruction once (largest hop USD) so multi-hop Jupiter routes are not double-counted.",
 };
 
 const adapter: SimpleAdapter = {
   version: 2,
-  adapter: {
-    [CHAIN.SOLANA]: {
-      fetch,
-      start: "2025-07-27",
-      meta: {
-        methodology,
-        breakdownMethodology: methodology,
-      },
-    },
-  },
+  pullHourly: true,
+  fetch,
+  start: "2026-08-16",
+  chains: [CHAIN.SOLANA],
+  dependencies: [Dependencies.ALLIUM],
+  isExpensiveAdapter: true,
+  methodology,
 };
 
 export default adapter;


### PR DESCRIPTION
## RiftBeam - Native Solana DEX Aggregator

**Protocol:** RiftBeam Aggregator v1
**Chain:** Solana
**Type:** Aggregator
**Contact:** support@terafabpay.de

### What is RiftBeam?

RiftBeam is a native Solana DEX aggregator routing swaps across Orca CLMM, Raydium CLMM, and Pump.fun AMM pools. It focuses on newly graduated Pump.fun pools and thin liquidity markets that other aggregators miss.

On-chain program: `DYR2SfXreL4wMPKjWzgWv17r7qHJk3kyp1R7k3MsKkEV`

### Volume Endpoint

```
GET https://swaptitan.net/v1/riftbeam/volume?from=<unix>&to=<unix>
=> { "dailyVolume": 123.45, "swapCount": 42, "fromTs": "...", "toTs": "...", "solPriceUsd": 180 }
```

Volume = SOL input amount x SOL/USD price (Jupiter Price API). Start timestamp: 2025-07-27.
