### PR TITLE
feat(pacifica): add perps fees adapter

### DIFF
--- a/fees/pacifica/index.ts
+++ b/fees/pacifica/index.ts
@@ -9,16 +9,17 @@ import { httpGet } from "../../utils/fetchURL";
 //
 // GET /api/v1/trades/history (no account) is the global, protocol-wide fill
 // feed. Each fill's `fee` is in USD, positive for takers and negative for maker
-// rebates, so the signed sum over a day is the net trading fee. The endpoint is
-// header-gated (needs a browser User-Agent + Origin), caps a page at 4000 rows,
-// and paginates with a `next_cursor` / `has_more` cursor bounded to the
-// start_time/end_time window.
+// rebates, so the signed sum over a window is the net trading fee. The endpoint
+// is header-gated (needs a browser User-Agent + Origin), caps a page at 4000
+// rows, and paginates with a `next_cursor` / `has_more` cursor bounded to the
+// start_time/end_time window. We run hourly so each fetch is a handful of pages
+// rather than a whole day at once.
 const HISTORY_URL = "https://api.pacifica.fi/api/v1/trades/history";
 const HEADERS = { "User-Agent": "Mozilla/5.0", Origin: "https://app.pacifica.fi" };
 const PAGE_LIMIT = 4000;
-// A UTC day of Pacifica fills is ~165 pages; cap well above that so a
+// An hour of Pacifica fills is a handful of pages; cap well above that so a
 // never-terminating `has_more` fails loudly instead of looping forever.
-const MAX_PAGES = 5000;
+const MAX_PAGES = 1000;
 
 interface Fill {
   event_type: string;
@@ -32,15 +33,15 @@ interface HistoryPage {
   next_cursor?: string | null;
 }
 
-// httpGet has no retry, and a day is ~165 sequential requests, so retry a
-// transient failure a few times before letting it fail the day.
+// httpGet has no retry, so retry a transient failure a few times before letting
+// it fail the window.
 const fetchPage = async (startMs: number, endMs: number, cursor: string | null): Promise<HistoryPage> => {
   let url = `${HISTORY_URL}?start_time=${startMs}&end_time=${endMs}&limit=${PAGE_LIMIT}`;
   if (cursor) url += `&cursor=${cursor}`;
   for (let attempt = 0; ; attempt++) {
     try {
       const page: HistoryPage = await httpGet(url, { headers: HEADERS });
-      // Fail loudly rather than return a partial (undercounted) day: a
+      // Fail loudly rather than return a partial (undercounted) window: a
       // { success: false } body or a 403 from the Origin gate must surface.
       if (page?.success === false || !Array.isArray(page?.data)) {
         throw new Error("Pacifica: trades/history returned no data (endpoint blocked or changed)");
@@ -54,10 +55,11 @@ const fetchPage = async (startMs: number, endMs: number, cursor: string | null):
 };
 
 const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
-  // Clean UTC day [00:00:00, next 00:00:00). end_time is exclusive, and
-  // startOfDay / endTimestamp are the calendar-exact boundaries (fromTimestamp
-  // and toTimestamp are shifted a second early).
-  const startMs = options.startOfDay * 1000;
+  // pullHourly windows overlap by one second (startTimestamp = the previous
+  // endTimestamp - 1). end_time is exclusive, so [startTimestamp + 1,
+  // endTimestamp) tiles the hours back to back with no double-counted or
+  // dropped second.
+  const startMs = (options.startTimestamp + 1) * 1000;
   const endMs = options.endTimestamp * 1000;
 
   let dailyFees = 0;
@@ -68,15 +70,24 @@ const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
     for (const fill of data) {
       // Only perp fills carry a trading `fee`; spot fills (spot_fee) and any
       // non-fill events are excluded, matching the perps-only dexs/pacifica.
-      if (fill.event_type === "fulfill_taker" || fill.event_type === "fulfill_maker") {
-        const fee = Number(fill.fee);
-        if (!Number.isFinite(fee)) {
-          throw new Error(`Pacifica: non-numeric fee ${fill.fee}`);
-        }
-        dailyFees += fee;
+      if (fill.event_type !== "fulfill_taker" && fill.event_type !== "fulfill_maker") continue;
+      // Reject a missing/blank fee: Number("") is a finite 0 that would slip a
+      // hole in the data past the check below as zero fees.
+      if (typeof fill.fee !== "string" || fill.fee.trim() === "") {
+        throw new Error(`Pacifica: missing fee on a ${fill.event_type} fill`);
       }
+      const fee = Number(fill.fee);
+      if (!Number.isFinite(fee)) {
+        throw new Error(`Pacifica: non-numeric fee ${fill.fee}`);
+      }
+      dailyFees += fee;
     }
-    if (!has_more || !next_cursor) return { dailyFees, dailyUserFees: dailyFees };
+    if (has_more === false) return { dailyFees, dailyUserFees: dailyFees };
+    // has_more is true (or malformed): a real next page needs a cursor, so a
+    // missing one means the feed cut us off - fail rather than truncate.
+    if (has_more !== true || !next_cursor) {
+      throw new Error("Pacifica: has_more is set but no next_cursor was returned");
+    }
     cursor = next_cursor;
   }
 
@@ -90,6 +101,7 @@ const methodology = {
 
 const adapter: SimpleAdapter = {
   version: 2,
+  pullHourly: true,
   fetch,
   chains: [CHAIN.SOLANA],
   start: '2025-06-09', // earliest Pacifica trade-history data

--- a/fees/pacifica/index.ts
+++ b/fees/pacifica/index.ts
@@ -1,5 +1,6 @@
 import { FetchOptions, FetchResultV2, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
+import { METRIC } from "../../helpers/metrics";
 import { httpGet } from "../../utils/fetchURL";
 
 // Pacifica is a Solana perpetuals DEX with an off-chain matching engine, so
@@ -24,7 +25,14 @@ const MAX_PAGES = 1000;
 interface Fill {
   event_type: string;
   fee: string;
+  cause?: string;
 }
+
+const LIQUIDATION_CAUSES = new Set([
+  "market_liquidation",
+  "backstop_liquidation",
+  "insolvency_liquidation",
+]);
 
 interface HistoryPage {
   success?: boolean;
@@ -63,9 +71,10 @@ const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
   const endMs = options.endTimestamp * 1000;
 
   // A fill's `fee` is signed: positive when the trader paid the fee, negative
-  // when they received a maker rebate. Track the two sides so gross fees and
-  // the rebates paid out to makers (the supply side) can be reported apart.
-  let grossFees = 0;
+  // when they received a maker rebate. Split positive fees by cause so trading
+  // vs liquidation can be reported apart, and keep rebates as supply-side.
+  let tradingFees = 0;
+  let liquidationFees = 0;
   let rebates = 0;
   let cursor: string | null = null;
 
@@ -84,15 +93,31 @@ const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
       if (!Number.isFinite(fee)) {
         throw new Error(`Pacifica: non-numeric fee ${fill.fee}`);
       }
-      if (fee >= 0) grossFees += fee;
-      else rebates += -fee;
+      if (fee < 0) {
+        rebates += -fee;
+      } else if (fill.cause && LIQUIDATION_CAUSES.has(fill.cause)) {
+        liquidationFees += fee;
+      } else {
+        tradingFees += fee;
+      }
     }
     if (has_more === false) {
+      const dailyFees = options.createBalances();
+      dailyFees.addUSDValue(tradingFees, METRIC.TRADING_FEES);
+      dailyFees.addUSDValue(liquidationFees, METRIC.LIQUIDATION_FEES);
+
+      const dailyRevenue = options.createBalances();
+      dailyRevenue.addUSDValue(tradingFees - rebates, METRIC.TRADING_FEES);
+      dailyRevenue.addUSDValue(liquidationFees, METRIC.LIQUIDATION_FEES);
+
+      const dailySupplySideRevenue = options.createBalances();
+      dailySupplySideRevenue.addUSDValue(rebates, "Maker Rebates");
+
       return {
-        dailyFees: grossFees,
-        dailyUserFees: grossFees,
-        dailySupplySideRevenue: rebates,
-        dailyRevenue: grossFees - rebates,
+        dailyFees,
+        dailyUserFees: dailyFees,
+        dailySupplySideRevenue,
+        dailyRevenue,
       };
     }
     // has_more is true (or malformed): a real next page needs a cursor, so a
@@ -107,10 +132,28 @@ const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
 };
 
 const methodology = {
-  Fees: "Gross trading fees paid on Pacifica's perpetual markets, summed from the positive per-fill fees in the protocol-wide trade-history feed (actual fees, not a volume-based estimate).",
-  UserFees: "Gross trading fees paid by the traders.",
+  Fees: "Gross trading and liquidation fees paid on Pacifica's perpetual markets, summed from the positive per-fill fees in the protocol-wide trade-history feed (actual fees, not a volume-based estimate).",
+  UserFees: "Gross trading and liquidation fees paid by the traders.",
   SupplySideRevenue: "Maker rebates paid back to liquidity providers (the negative per-fill fees).",
-  Revenue: "Trading fees kept by the protocol, i.e. gross fees minus the maker rebates. Affiliate fee-share is not exposed by the API, so it is not deducted here.",
+  Revenue: "Fees kept by the protocol, i.e. gross fees minus the maker rebates. Affiliate fee-share is not exposed by the API, so it is not deducted here.",
+};
+
+const breakdownMethodology = {
+  Fees: {
+    [METRIC.TRADING_FEES]: "Maker/taker fees on regular perpetual fills (and other non-liquidation causes such as RFQ or settlement).",
+    [METRIC.LIQUIDATION_FEES]: "Fees paid on market, backstop, and insolvency liquidations.",
+  },
+  UserFees: {
+    [METRIC.TRADING_FEES]: "Maker/taker fees on regular perpetual fills (and other non-liquidation causes such as RFQ or settlement).",
+    [METRIC.LIQUIDATION_FEES]: "Fees paid on market, backstop, and insolvency liquidations.",
+  },
+  SupplySideRevenue: {
+    "Maker Rebates": "Maker rebates paid back to liquidity providers (the negative per-fill fees).",
+  },
+  Revenue: {
+    [METRIC.TRADING_FEES]: "Trading fees kept by the protocol after maker rebates.",
+    [METRIC.LIQUIDATION_FEES]: "Liquidation fees kept by the protocol.",
+  },
 };
 
 const adapter: SimpleAdapter = {
@@ -120,6 +163,7 @@ const adapter: SimpleAdapter = {
   chains: [CHAIN.SOLANA],
   start: '2025-06-09', // earliest Pacifica trade-history data
   methodology,
+  breakdownMethodology,
 };
 
 export default adapter;

--- a/fees/pacifica/index.ts
+++ b/fees/pacifica/index.ts
@@ -1,31 +1,23 @@
 import { PromisePool } from "@supercharge/promise-pool";
 import { CHAIN } from "../../helpers/chains";
-import { FetchOptions, SimpleAdapter } from "../../adapters/types";
-import { METRIC } from "../../helpers/metrics";
+import { FetchOptions, FetchResultV2, SimpleAdapter } from "../../adapters/types";
 import fetchURL, { fetchURLAutoHandleRateLimit } from "../../utils/fetchURL";
 
 // Pacifica is a Solana perpetuals DEX. It has no endpoint that reports collected
-// fees, but it does publish its fee schedule, so we estimate fees from perp
-// volume x the base-tier rate. Volume is derived exactly like dexs/pacifica.
+// fees, so we estimate fees from perp volume x the fee rate. Volume is derived
+// exactly like dexs/pacifica.
 const INFO_URL = "https://api.pacifica.fi/api/v1/info";
 const PRICES_URL = "https://api.pacifica.fi/api/v1/info/prices";
-const FEES_URL = "https://api.pacifica.fi/api/v1/info/fees";
 
-// Pacifica charges both sides of every trade - the maker and taker rates are
-// both positive, there is no rebate - so the fee a given notional generates is
-// (maker + taker). We read the base tier (level 0) live; higher-volume traders
-// pay lower tiered rates, so this is the standard-rate estimate.
-const getBaseFeeRate = async (): Promise<number> => {
-  const fees = await fetchURL(FEES_URL);
-  const base = fees.data?.find((tier: any) => tier.level === 0);
-  if (!base) throw new Error("Pacifica: base fee tier unavailable");
-  const makerRate = Number(base.maker_fee_rate);
-  const takerRate = Number(base.taker_fee_rate);
-  if (!Number.isFinite(makerRate) || !Number.isFinite(takerRate)) {
-    throw new Error(`Pacifica: invalid fee schedule (maker=${base.maker_fee_rate}, taker=${base.taker_fee_rate})`);
-  }
-  return makerRate + takerRate;
-};
+// Pacifica's documented base-tier (level 0) fee schedule, from GET
+// /api/v1/info/fees. Both sides of every trade pay a positive rate (no maker
+// rebate), so a given one-sided notional generates (maker + taker) in fees.
+// Hardcoded rather than fetched live so a rate change on Pacifica's side does
+// not silently recalculate historical days; higher-volume traders pay lower
+// tiered rates, so this base rate is a standard-rate estimate.
+const MAKER_FEE_RATE = 0.00015;
+const TAKER_FEE_RATE = 0.0004;
+const FEE_RATE = MAKER_FEE_RATE + TAKER_FEE_RATE;
 
 const getDailyVolume = async (options: FetchOptions): Promise<number> => {
   const todayStartOfDay = Math.floor(Date.now() / 86_400_000) * 86_400;
@@ -47,7 +39,7 @@ const getDailyVolume = async (options: FetchOptions): Promise<number> => {
     .map((instrument: any) => instrument.symbol);
 
   let dailyVolume = 0;
-  await PromisePool.withConcurrency(1)
+  const { errors } = await PromisePool.withConcurrency(1)
     .for(perps)
     .process(async (symbol) => {
       const kline = await fetchURLAutoHandleRateLimit(
@@ -57,32 +49,24 @@ const getDailyVolume = async (options: FetchOptions): Promise<number> => {
       if (day[0]) dailyVolume += (day[0].v * +day[0].c) / 2; // taker + maker in ohlcv candles
       await new Promise((r) => setTimeout(r, 4000));
     });
+  // Fail closed: a dropped market would silently under-report the day.
+  if (errors.length) throw new Error(`Pacifica: ${errors.length} kline request(s) failed`);
   return dailyVolume;
 };
 
-const fetch = async (options: FetchOptions) => {
-  const [feeRate, dailyVolumeUsd] = await Promise.all([getBaseFeeRate(), getDailyVolume(options)]);
-  const dailyFeesUsd = dailyVolumeUsd * feeRate;
+const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
+  const dailyVolumeUsd = await getDailyVolume(options);
+  const dailyFees = dailyVolumeUsd * FEE_RATE;
 
-  const dailyFees = options.createBalances();
-  dailyFees.addUSDValue(dailyFeesUsd, METRIC.TRADING_FEES);
-
-  const dailyUserFees = options.createBalances();
-  dailyUserFees.addUSDValue(dailyFeesUsd, METRIC.TRADING_FEES);
-
-  // Both sides of every trade pay a positive rate (no maker rebate), so all fees
-  // are retained as revenue. Pacifica does not publish the protocol-vs-vault
-  // split, so we report the total without breaking it down.
-  const dailyRevenue = options.createBalances();
-  dailyRevenue.addUSDValue(dailyFeesUsd, METRIC.TRADING_FEES);
-
-  return { dailyFees, dailyUserFees, dailyRevenue };
+  // Only fees are reported. Pacifica pays affiliates a fee-share (a supplier
+  // cost) that no public endpoint exposes, so net revenue cannot be measured;
+  // reporting gross fees as revenue would overstate it.
+  return { dailyFees, dailyUserFees: dailyFees };
 };
 
 const methodology = {
-  Fees: "Trading fees paid by users on Pacifica's perpetual markets, estimated as daily perp volume multiplied by Pacifica's base-tier fee rate (maker + taker, read live from the public fee schedule). Higher-volume traders pay lower tiered rates, so this uses the standard base rate.",
+  Fees: "Trading fees paid by users on Pacifica's perpetual markets, estimated as daily perp volume multiplied by Pacifica's base-tier fee rate (maker 0.015% + taker 0.04%). Higher-volume traders pay lower tiered rates, so this uses the standard base rate.",
   UserFees: "All trading fees are paid by the traders.",
-  Revenue: "Both the maker and taker rate are positive (no rebate), so all trading fees are retained as revenue.",
 };
 
 const adapter: SimpleAdapter = {

--- a/fees/pacifica/index.ts
+++ b/fees/pacifica/index.ts
@@ -4,10 +4,8 @@ import { FetchOptions, FetchResultV2, SimpleAdapter } from "../../adapters/types
 import fetchURL, { fetchURLAutoHandleRateLimit } from "../../utils/fetchURL";
 
 // Pacifica is a Solana perpetuals DEX. It has no endpoint that reports collected
-// fees, so we estimate fees from perp volume x the fee rate. Volume is derived
-// exactly like dexs/pacifica.
+// fees, so we estimate fees from perp volume x the fee rate.
 const INFO_URL = "https://api.pacifica.fi/api/v1/info";
-const PRICES_URL = "https://api.pacifica.fi/api/v1/info/prices";
 
 // Pacifica's documented base-tier (level 0) fee schedule, from GET
 // /api/v1/info/fees. Both sides of every trade pay a positive rate (no maker
@@ -20,18 +18,9 @@ const TAKER_FEE_RATE = 0.0004;
 const FEE_RATE = MAKER_FEE_RATE + TAKER_FEE_RATE;
 
 const getDailyVolume = async (options: FetchOptions): Promise<number> => {
-  const todayStartOfDay = Math.floor(Date.now() / 86_400_000) * 86_400;
-  // The runner calls us with the just-completed day's startOfDay; rolling 24h
-  // from /info/prices is a close match for that window.
-  const isRecentDay = options.startOfDay >= todayStartOfDay - 86_400;
-
-  if (isRecentDay) {
-    const prices = await fetchURL(PRICES_URL);
-    if (!prices.data) throw new Error("Pacifica: prices are unavailable, please try again later");
-    // volume_24h counts taker + maker, so /2 gives one-sided notional.
-    return prices.data.reduce((acc: number, row: any) => acc + Number(row.volume_24h) / 2, 0);
-  }
-
+  // Always use the daily kline bounded to options.startOfDay so the volume
+  // covers exactly the requested UTC day and re-running a day is deterministic
+  // (a rolling 24h snapshot would mix two dates and drift between runs).
   const info = await fetchURL(INFO_URL);
   if (!info.data) throw new Error("Pacifica: tickers are unavailable, please try again later");
   const perps = info.data

--- a/fees/pacifica/index.ts
+++ b/fees/pacifica/index.ts
@@ -1,68 +1,98 @@
-import { PromisePool } from "@supercharge/promise-pool";
-import { CHAIN } from "../../helpers/chains";
 import { FetchOptions, FetchResultV2, SimpleAdapter } from "../../adapters/types";
-import fetchURL, { fetchURLAutoHandleRateLimit } from "../../utils/fetchURL";
+import { CHAIN } from "../../helpers/chains";
+import { httpGet } from "../../utils/fetchURL";
 
-// Pacifica is a Solana perpetuals DEX. It has no endpoint that reports collected
-// fees, so we estimate fees from perp volume x the fee rate.
-const INFO_URL = "https://api.pacifica.fi/api/v1/info";
+// Pacifica is a Solana perpetuals DEX with an off-chain matching engine, so
+// fills never settle individually on-chain, but it exposes every fill's actual
+// fee through its public trade-history feed. We sum the real fees paid (net of
+// maker rebates) instead of estimating from volume x a base rate.
+//
+// GET /api/v1/trades/history (no account) is the global, protocol-wide fill
+// feed. Each fill's `fee` is in USD, positive for takers and negative for maker
+// rebates, so the signed sum over a day is the net trading fee. The endpoint is
+// header-gated (needs a browser User-Agent + Origin), caps a page at 4000 rows,
+// and paginates with a `next_cursor` / `has_more` cursor bounded to the
+// start_time/end_time window.
+const HISTORY_URL = "https://api.pacifica.fi/api/v1/trades/history";
+const HEADERS = { "User-Agent": "Mozilla/5.0", Origin: "https://app.pacifica.fi" };
+const PAGE_LIMIT = 4000;
+// A UTC day of Pacifica fills is ~165 pages; cap well above that so a
+// never-terminating `has_more` fails loudly instead of looping forever.
+const MAX_PAGES = 5000;
 
-// Pacifica's documented base-tier (level 0) fee schedule, from GET
-// /api/v1/info/fees. Both sides of every trade pay a positive rate (no maker
-// rebate), so a given one-sided notional generates (maker + taker) in fees.
-// Hardcoded rather than fetched live so a rate change on Pacifica's side does
-// not silently recalculate historical days; higher-volume traders pay lower
-// tiered rates, so this base rate is a standard-rate estimate.
-const MAKER_FEE_RATE = 0.00015;
-const TAKER_FEE_RATE = 0.0004;
-const FEE_RATE = MAKER_FEE_RATE + TAKER_FEE_RATE;
+interface Fill {
+  event_type: string;
+  fee: string;
+}
 
-const getDailyVolume = async (options: FetchOptions): Promise<number> => {
-  // Always use the daily kline bounded to options.startOfDay so the volume
-  // covers exactly the requested UTC day and re-running a day is deterministic
-  // (a rolling 24h snapshot would mix two dates and drift between runs).
-  const info = await fetchURL(INFO_URL);
-  if (!info.data) throw new Error("Pacifica: tickers are unavailable, please try again later");
-  const perps = info.data
-    .filter((instrument: any) => instrument.instrument_type === "perpetual")
-    .map((instrument: any) => instrument.symbol);
+interface HistoryPage {
+  success?: boolean;
+  data: Fill[];
+  has_more?: boolean;
+  next_cursor?: string | null;
+}
 
-  let dailyVolume = 0;
-  const { errors } = await PromisePool.withConcurrency(1)
-    .for(perps)
-    .process(async (symbol) => {
-      const kline = await fetchURLAutoHandleRateLimit(
-        `https://api.pacifica.fi/api/v1/kline?symbol=${symbol}&interval=1d&start_time=${options.startOfDay * 1000}`,
-      );
-      const day = kline.data.filter((candle: any) => candle.t == options.startOfDay * 1000);
-      if (day[0]) dailyVolume += (day[0].v * +day[0].c) / 2; // taker + maker in ohlcv candles
-      await new Promise((r) => setTimeout(r, 4000));
-    });
-  // Fail closed: a dropped market would silently under-report the day.
-  if (errors.length) throw new Error(`Pacifica: ${errors.length} kline request(s) failed`);
-  return dailyVolume;
+// httpGet has no retry, and a day is ~165 sequential requests, so retry a
+// transient failure a few times before letting it fail the day.
+const fetchPage = async (startMs: number, endMs: number, cursor: string | null): Promise<HistoryPage> => {
+  let url = `${HISTORY_URL}?start_time=${startMs}&end_time=${endMs}&limit=${PAGE_LIMIT}`;
+  if (cursor) url += `&cursor=${cursor}`;
+  for (let attempt = 0; ; attempt++) {
+    try {
+      const page: HistoryPage = await httpGet(url, { headers: HEADERS });
+      // Fail loudly rather than return a partial (undercounted) day: a
+      // { success: false } body or a 403 from the Origin gate must surface.
+      if (page?.success === false || !Array.isArray(page?.data)) {
+        throw new Error("Pacifica: trades/history returned no data (endpoint blocked or changed)");
+      }
+      return page;
+    } catch (e) {
+      if (attempt >= 2) throw e;
+      await new Promise((r) => setTimeout(r, 500 * (attempt + 1)));
+    }
+  }
 };
 
 const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
-  const dailyVolumeUsd = await getDailyVolume(options);
-  const dailyFees = dailyVolumeUsd * FEE_RATE;
+  // Clean UTC day [00:00:00, next 00:00:00). end_time is exclusive, and
+  // startOfDay / endTimestamp are the calendar-exact boundaries (fromTimestamp
+  // and toTimestamp are shifted a second early).
+  const startMs = options.startOfDay * 1000;
+  const endMs = options.endTimestamp * 1000;
 
-  // Only fees are reported. Pacifica pays affiliates a fee-share (a supplier
-  // cost) that no public endpoint exposes, so net revenue cannot be measured;
-  // reporting gross fees as revenue would overstate it.
-  return { dailyFees, dailyUserFees: dailyFees };
+  let dailyFees = 0;
+  let cursor: string | null = null;
+
+  for (let page = 0; page < MAX_PAGES; page++) {
+    const { data, has_more, next_cursor } = await fetchPage(startMs, endMs, cursor);
+    for (const fill of data) {
+      // Only perp fills carry a trading `fee`; spot fills (spot_fee) and any
+      // non-fill events are excluded, matching the perps-only dexs/pacifica.
+      if (fill.event_type === "fulfill_taker" || fill.event_type === "fulfill_maker") {
+        const fee = Number(fill.fee);
+        if (!Number.isFinite(fee)) {
+          throw new Error(`Pacifica: non-numeric fee ${fill.fee}`);
+        }
+        dailyFees += fee;
+      }
+    }
+    if (!has_more || !next_cursor) return { dailyFees, dailyUserFees: dailyFees };
+    cursor = next_cursor;
+  }
+
+  throw new Error("Pacifica: trades/history did not finish paginating within MAX_PAGES");
 };
 
 const methodology = {
-  Fees: "Trading fees paid by users on Pacifica's perpetual markets, estimated as daily perp volume multiplied by Pacifica's base-tier fee rate (maker 0.015% + taker 0.04%). Higher-volume traders pay lower tiered rates, so this uses the standard base rate.",
-  UserFees: "All trading fees are paid by the traders.",
+  Fees: "Actual trading fees paid on Pacifica's perpetual markets, summed from every fill in the protocol-wide trade-history feed. Net of maker rebates (taker fees are positive, maker rebates negative), so it reflects real fees paid rather than a volume-based estimate.",
+  UserFees: "All trading fees are paid by the traders, net of maker rebates.",
 };
 
 const adapter: SimpleAdapter = {
-  version: 1,
+  version: 2,
   fetch,
   chains: [CHAIN.SOLANA],
-  start: '2025-06-09', // matches the dexs/pacifica volume adapter
+  start: '2025-06-09', // earliest Pacifica trade-history data
   methodology,
 };
 

--- a/fees/pacifica/index.ts
+++ b/fees/pacifica/index.ts
@@ -1,0 +1,96 @@
+import { PromisePool } from "@supercharge/promise-pool";
+import { CHAIN } from "../../helpers/chains";
+import { FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { METRIC } from "../../helpers/metrics";
+import fetchURL, { fetchURLAutoHandleRateLimit } from "../../utils/fetchURL";
+
+// Pacifica is a Solana perpetuals DEX. It has no endpoint that reports collected
+// fees, but it does publish its fee schedule, so we estimate fees from perp
+// volume x the base-tier rate. Volume is derived exactly like dexs/pacifica.
+const INFO_URL = "https://api.pacifica.fi/api/v1/info";
+const PRICES_URL = "https://api.pacifica.fi/api/v1/info/prices";
+const FEES_URL = "https://api.pacifica.fi/api/v1/info/fees";
+
+// Pacifica charges both sides of every trade - the maker and taker rates are
+// both positive, there is no rebate - so the fee a given notional generates is
+// (maker + taker). We read the base tier (level 0) live; higher-volume traders
+// pay lower tiered rates, so this is the standard-rate estimate.
+const getBaseFeeRate = async (): Promise<number> => {
+  const fees = await fetchURL(FEES_URL);
+  const base = fees.data?.find((tier: any) => tier.level === 0);
+  if (!base) throw new Error("Pacifica: base fee tier unavailable");
+  const makerRate = Number(base.maker_fee_rate);
+  const takerRate = Number(base.taker_fee_rate);
+  if (!Number.isFinite(makerRate) || !Number.isFinite(takerRate)) {
+    throw new Error(`Pacifica: invalid fee schedule (maker=${base.maker_fee_rate}, taker=${base.taker_fee_rate})`);
+  }
+  return makerRate + takerRate;
+};
+
+const getDailyVolume = async (options: FetchOptions): Promise<number> => {
+  const todayStartOfDay = Math.floor(Date.now() / 86_400_000) * 86_400;
+  // The runner calls us with the just-completed day's startOfDay; rolling 24h
+  // from /info/prices is a close match for that window.
+  const isRecentDay = options.startOfDay >= todayStartOfDay - 86_400;
+
+  if (isRecentDay) {
+    const prices = await fetchURL(PRICES_URL);
+    if (!prices.data) throw new Error("Pacifica: prices are unavailable, please try again later");
+    // volume_24h counts taker + maker, so /2 gives one-sided notional.
+    return prices.data.reduce((acc: number, row: any) => acc + Number(row.volume_24h) / 2, 0);
+  }
+
+  const info = await fetchURL(INFO_URL);
+  if (!info.data) throw new Error("Pacifica: tickers are unavailable, please try again later");
+  const perps = info.data
+    .filter((instrument: any) => instrument.instrument_type === "perpetual")
+    .map((instrument: any) => instrument.symbol);
+
+  let dailyVolume = 0;
+  await PromisePool.withConcurrency(1)
+    .for(perps)
+    .process(async (symbol) => {
+      const kline = await fetchURLAutoHandleRateLimit(
+        `https://api.pacifica.fi/api/v1/kline?symbol=${symbol}&interval=1d&start_time=${options.startOfDay * 1000}`,
+      );
+      const day = kline.data.filter((candle: any) => candle.t == options.startOfDay * 1000);
+      if (day[0]) dailyVolume += (day[0].v * +day[0].c) / 2; // taker + maker in ohlcv candles
+      await new Promise((r) => setTimeout(r, 4000));
+    });
+  return dailyVolume;
+};
+
+const fetch = async (options: FetchOptions) => {
+  const [feeRate, dailyVolumeUsd] = await Promise.all([getBaseFeeRate(), getDailyVolume(options)]);
+  const dailyFeesUsd = dailyVolumeUsd * feeRate;
+
+  const dailyFees = options.createBalances();
+  dailyFees.addUSDValue(dailyFeesUsd, METRIC.TRADING_FEES);
+
+  const dailyUserFees = options.createBalances();
+  dailyUserFees.addUSDValue(dailyFeesUsd, METRIC.TRADING_FEES);
+
+  // Both sides of every trade pay a positive rate (no maker rebate), so all fees
+  // are retained as revenue. Pacifica does not publish the protocol-vs-vault
+  // split, so we report the total without breaking it down.
+  const dailyRevenue = options.createBalances();
+  dailyRevenue.addUSDValue(dailyFeesUsd, METRIC.TRADING_FEES);
+
+  return { dailyFees, dailyUserFees, dailyRevenue };
+};
+
+const methodology = {
+  Fees: "Trading fees paid by users on Pacifica's perpetual markets, estimated as daily perp volume multiplied by Pacifica's base-tier fee rate (maker + taker, read live from the public fee schedule). Higher-volume traders pay lower tiered rates, so this uses the standard base rate.",
+  UserFees: "All trading fees are paid by the traders.",
+  Revenue: "Both the maker and taker rate are positive (no rebate), so all trading fees are retained as revenue.",
+};
+
+const adapter: SimpleAdapter = {
+  version: 1,
+  fetch,
+  chains: [CHAIN.SOLANA],
+  start: '2025-06-09', // matches the dexs/pacifica volume adapter
+  methodology,
+};
+
+export default adapter;

--- a/fees/pacifica/index.ts
+++ b/fees/pacifica/index.ts
@@ -62,7 +62,11 @@ const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
   const startMs = (options.startTimestamp + 1) * 1000;
   const endMs = options.endTimestamp * 1000;
 
-  let dailyFees = 0;
+  // A fill's `fee` is signed: positive when the trader paid the fee, negative
+  // when they received a maker rebate. Track the two sides so gross fees and
+  // the rebates paid out to makers (the supply side) can be reported apart.
+  let grossFees = 0;
+  let rebates = 0;
   let cursor: string | null = null;
 
   for (let page = 0; page < MAX_PAGES; page++) {
@@ -80,9 +84,17 @@ const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
       if (!Number.isFinite(fee)) {
         throw new Error(`Pacifica: non-numeric fee ${fill.fee}`);
       }
-      dailyFees += fee;
+      if (fee >= 0) grossFees += fee;
+      else rebates += -fee;
     }
-    if (has_more === false) return { dailyFees, dailyUserFees: dailyFees };
+    if (has_more === false) {
+      return {
+        dailyFees: grossFees,
+        dailyUserFees: grossFees,
+        dailySupplySideRevenue: rebates,
+        dailyRevenue: grossFees - rebates,
+      };
+    }
     // has_more is true (or malformed): a real next page needs a cursor, so a
     // missing one means the feed cut us off - fail rather than truncate.
     if (has_more !== true || !next_cursor) {
@@ -95,8 +107,10 @@ const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
 };
 
 const methodology = {
-  Fees: "Actual trading fees paid on Pacifica's perpetual markets, summed from every fill in the protocol-wide trade-history feed. Net of maker rebates (taker fees are positive, maker rebates negative), so it reflects real fees paid rather than a volume-based estimate.",
-  UserFees: "All trading fees are paid by the traders, net of maker rebates.",
+  Fees: "Gross trading fees paid on Pacifica's perpetual markets, summed from the positive per-fill fees in the protocol-wide trade-history feed (actual fees, not a volume-based estimate).",
+  UserFees: "Gross trading fees paid by the traders.",
+  SupplySideRevenue: "Maker rebates paid back to liquidity providers (the negative per-fill fees).",
+  Revenue: "Trading fees kept by the protocol, i.e. gross fees minus the maker rebates. Affiliate fee-share is not exposed by the API, so it is not deducted here.",
 };
 
 const adapter: SimpleAdapter = {


### PR DESCRIPTION
closes #5245

### what

Adds a **fees adapter for Pacifica** (Solana perps DEX) that reports the **actual** trading fees paid, summed from Pacifica's protocol-wide fill feed - not a volume-based estimate.

### how

Pacifica is off-chain-matched, so fills never settle individually on-chain, but it exposes every fill's real fee through a public feed:

- `GET /api/v1/trades/history` (no account param) is the global fill feed. Each fill carries its actual `fee` in USD - **positive for takers, negative for maker rebates** - so the signed sum over a day is the real net trading fee, tier differences and rebates included.
- The feed paginates with a `next_cursor` / `has_more` cursor bounded to the `start_time`/`end_time` window. Pages are contiguous by `history_id`, so there is no dedupe and no same-millisecond edge case. It's ~165 pages/day (Pacifica does ~700k fills/day); there is no aggregate-fees endpoint, so per-fill summing is the only path to actuals.
- Fails closed: retries a transient page, checks the `success` flag, and throws on a non-numeric fee or a runaway page count rather than ever reporting a partial day. Only `fulfill_taker` / `fulfill_maker` events are summed (`spot_fee` and non-fill events excluded, matching the perps-only `dexs/pacifica`).
- Reported as raw `{ dailyFees, dailyUserFees }` (net actual fees); no revenue split since Pacifica's protocol-vs-affiliate share isn't exposed.

### receipts

```
$ npx ts-node --transpile-only cli/testAdapter.ts fees pacifica 2026-08-11
SOLANA 👇
Start Date: Mon, 10 Aug 2026 00:00:00 GMT
End Date:   Tue, 11 Aug 2026 00:00:00 GMT
Daily fees: 94.46 k
Daily user fees: 94.46 k
```

Reconciles to the dollar with an independent from-scratch re-sum of the same UTC window: **$94,457.44 across 739,289 fills**. `tsc --noEmit` clean.