### PR TITLE
feat(oroswap): add volume and fees adapters

### DIFF
--- a/dexs/oroswap/index.ts
+++ b/dexs/oroswap/index.ts
@@ -14,9 +14,15 @@ const HEADERS = {
 
 const fetch = async () => {
   const data = await httpGet(POOLS_URL, { headers: HEADERS });
-  const dailyVolume = Number(data?.totalVolume24H);
+  const raw = data?.totalVolume24H;
+  // Reject missing/blank before Number(): Number(null) and Number("") are a
+  // finite 0, which would silently report zero volume.
+  if (raw === null || raw === undefined || raw === "") {
+    throw new Error("OroSwap: missing totalVolume24H");
+  }
+  const dailyVolume = Number(raw);
   if (!Number.isFinite(dailyVolume)) {
-    throw new Error(`OroSwap: invalid totalVolume24H (${data?.totalVolume24H})`);
+    throw new Error(`OroSwap: non-numeric totalVolume24H (${raw})`);
   }
   return { dailyVolume };
 };

--- a/dexs/oroswap/index.ts
+++ b/dexs/oroswap/index.ts
@@ -1,0 +1,40 @@
+import { httpGet } from "../../utils/fetchURL";
+import { SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+
+// OroSwap is an AMM DEX on ZIGChain. Its pool-manager endpoint returns a
+// server-side aggregate `totalVolume24H` (USD), alongside per-pool figures.
+// The mainnet host is header-gated (403 without a browser UA + Origin), which
+// httpGet can satisfy; this is a header check, not a Cloudflare challenge.
+const POOLS_URL = "https://api-mainnet.oroswap.org/api/poolmanager/pools?offset=0&limit=1000";
+const HEADERS = {
+  "User-Agent": "Mozilla/5.0",
+  Origin: "https://app.oroswap.org",
+};
+
+const fetch = async () => {
+  const data = await httpGet(POOLS_URL, { headers: HEADERS });
+  const dailyVolume = Number(data?.totalVolume24H);
+  if (!Number.isFinite(dailyVolume)) {
+    throw new Error(`OroSwap: invalid totalVolume24H (${data?.totalVolume24H})`);
+  }
+  return { dailyVolume };
+};
+
+const methodology = {
+  Volume: "Total USD value of swaps across OroSwap's pools over the trailing 24h, taken from the OroSwap pool-manager API's aggregate totalVolume24H.",
+};
+
+const adapter: SimpleAdapter = {
+  adapter: {
+    [CHAIN.ZIGCHAIN]: {
+      fetch,
+      // The endpoint only exposes a rolling 24h snapshot, so run at current time.
+      runAtCurrTime: true,
+      start: '2025-09-27', // earliest OroSwap pool
+    },
+  },
+  methodology,
+};
+
+export default adapter;

--- a/dexs/oroswap/index.ts
+++ b/dexs/oroswap/index.ts
@@ -32,14 +32,10 @@ const methodology = {
 };
 
 const adapter: SimpleAdapter = {
-  adapter: {
-    [CHAIN.ZIGCHAIN]: {
-      fetch,
-      // The endpoint only exposes a rolling 24h snapshot, so run at current time.
-      runAtCurrTime: true,
-      start: '2025-09-27', // earliest OroSwap pool
-    },
-  },
+  fetch,
+  runAtCurrTime: true,
+  chains: [CHAIN.ZIGCHAIN],
+  version: 2,
   methodology,
 };
 

--- a/fees/oroswap/index.ts
+++ b/fees/oroswap/index.ts
@@ -18,8 +18,16 @@ const fetch = async (): Promise<FetchResultV2> => {
   if (!pools.length) throw new Error("OroSwap: no pools returned");
 
   const dailyFees = pools.reduce((acc: number, pool: any) => {
-    const fees = Number(pool?.details?.fees24H);
-    return acc + (Number.isFinite(fees) ? fees : 0);
+    const raw = pool?.details?.fees24H;
+    // Fail closed on a malformed pool rather than treating it as zero fees.
+    if (raw === null || raw === undefined || raw === "") {
+      throw new Error(`OroSwap: missing fees24H for pool ${pool?.details?.poolName ?? "?"}`);
+    }
+    const fees = Number(raw);
+    if (!Number.isFinite(fees)) {
+      throw new Error(`OroSwap: non-numeric fees24H (${raw}) for pool ${pool?.details?.poolName ?? "?"}`);
+    }
+    return acc + fees;
   }, 0);
 
   // Swap fees are paid by the trader; report fees only (raw numbers so no

--- a/fees/oroswap/index.ts
+++ b/fees/oroswap/index.ts
@@ -1,6 +1,7 @@
-import { httpGet } from "../../utils/fetchURL";
-import { FetchResultV2, SimpleAdapter } from "../../adapters/types";
+import fetchURL, { httpGet } from "../../utils/fetchURL";
+import { FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
+import { METRIC } from "../../helpers/metrics";
 
 // OroSwap is an AMM DEX on ZIGChain. The pool-manager endpoint exposes a
 // per-pool `fees24H` (USD); there is no aggregate fees field, so we sum them.
@@ -11,33 +12,112 @@ const HEADERS = {
   "User-Agent": "Mozilla/5.0",
   Origin: "https://app.oroswap.org",
 };
+const FACTORY = "zig1xx3aupmgv3ce537c0yce8zzd3sz567syaltr2tdehu3y803yz6gsc6tz85";
+const BPS_DENOM = 10_000;
 
-const fetch = async (): Promise<FetchResultV2> => {
-  const data = await httpGet(POOLS_URL, { headers: HEADERS });
+// CosmWasm PairType JSON: { xyk: {} } | { stable: {} } | { custom: "xyk_25" }
+const pairTypeKey = (pairType: any): string => {
+  if (!pairType || typeof pairType !== "object") {
+    throw new Error(`OroSwap: missing pair_type (${JSON.stringify(pairType)})`);
+  }
+  const keys = Object.keys(pairType);
+  if (keys.length !== 1) {
+    throw new Error(`OroSwap: malformed pair_type ${JSON.stringify(pairType)}`);
+  }
+  const kind = keys[0];
+  return kind === "custom" ? `custom:${pairType.custom}` : kind;
+};
+
+const fetch = async (options: FetchOptions) => {
+  const query = btoa(JSON.stringify({ config: {} }));
+  const [data, factoryConfig] = await Promise.all([
+    httpGet(POOLS_URL, { headers: HEADERS }),
+    fetchURL(`https://api.zigchain.com/cosmwasm/wasm/v1/contract/${FACTORY}/smart/${query}`),
+  ]);
+
+  const pairConfigs: any[] = factoryConfig?.data?.pair_configs;
+  if (!Array.isArray(pairConfigs) || !pairConfigs.length) {
+    throw new Error("OroSwap: factory config missing pair_configs");
+  }
+
+  // maker_fee_bps is the share of swap fees sent to the Maker (protocol), not
+  // the swap fee itself. 2000 = 20% protocol / 80% LPs.
+  const makerShareByType = new Map<string, number>();
+  for (const cfg of pairConfigs) {
+    const key = pairTypeKey(cfg?.pair_type);
+    const makerBps = Number(cfg?.maker_fee_bps);
+    if (!Number.isFinite(makerBps) || makerBps < 0 || makerBps > BPS_DENOM) {
+      throw new Error(`OroSwap: invalid maker_fee_bps (${cfg?.maker_fee_bps}) for ${key}`);
+    }
+    makerShareByType.set(key, makerBps / BPS_DENOM);
+  }
+
   const pools = [...(data?.xyk ?? []), ...(data?.custom ?? [])];
   if (!pools.length) throw new Error("OroSwap: no pools returned");
 
-  const dailyFees = pools.reduce((acc: number, pool: any) => {
+  const dailyFees = options.createBalances();
+  const dailyProtocolRevenue = options.createBalances();
+  const dailySupplySideRevenue = options.createBalances();
+
+  for (const pool of pools) {
+    const name = pool?.details?.poolName ?? pool?.pair_contract_addr ?? "?";
     const raw = pool?.details?.fees24H;
     // Fail closed on a malformed pool rather than treating it as zero fees.
     if (raw === null || raw === undefined || raw === "") {
-      throw new Error(`OroSwap: missing fees24H for pool ${pool?.details?.poolName ?? "?"}`);
+      throw new Error(`OroSwap: missing fees24H for pool ${name}`);
     }
     const fees = Number(raw);
     if (!Number.isFinite(fees)) {
-      throw new Error(`OroSwap: non-numeric fees24H (${raw}) for pool ${pool?.details?.poolName ?? "?"}`);
+      throw new Error(`OroSwap: non-numeric fees24H (${raw}) for pool ${name}`);
     }
-    return acc + fees;
-  }, 0);
 
-  // Swap fees are paid by the trader; report fees only (raw numbers so no
-  // revenue split is required). The protocol-vs-LP share is not exposed.
-  return { dailyFees, dailyUserFees: dailyFees };
+    const key = pairTypeKey(pool?.pair?.pair_type);
+    const makerShare = makerShareByType.get(key);
+    if (makerShare === undefined) {
+      throw new Error(`OroSwap: no factory pair_config matching pair_type ${key} (pool ${name})`);
+    }
+
+    const protocolFees = fees * makerShare;
+    const lpFees = fees - protocolFees;
+
+    dailyFees.addUSDValue(fees, METRIC.SWAP_FEES);
+    dailyProtocolRevenue.addUSDValue(protocolFees, METRIC.PROTOCOL_FEES);
+    dailySupplySideRevenue.addUSDValue(lpFees, METRIC.LP_FEES);
+  }
+
+  return {
+    dailyFees,
+    dailyUserFees: dailyFees,
+    dailyRevenue: dailyProtocolRevenue,
+    dailyProtocolRevenue,
+    dailySupplySideRevenue,
+  };
 };
 
 const methodology = {
   Fees: "Sum of the trailing-24h swap fees across OroSwap's pools (per-pool fees24H, USD), from the OroSwap pool-manager API.",
   UserFees: "All swap fees are paid by the traders.",
+  Revenue: "Share of swap fees sent to the Maker contract (maker_fee_bps / 10000), matched per pool by pair_type against the factory pair_configs.",
+  ProtocolRevenue: "Same as Revenue: maker_fee_bps of each pool's swap fees, retained by the protocol.",
+  SupplySideRevenue: "Remainder of swap fees (1 - maker_fee_bps / 10000) paid to liquidity providers.",
+};
+
+const breakdownMethodology = {
+  Fees: {
+    [METRIC.SWAP_FEES]: "Trailing-24h swap fees charged on OroSwap pools.",
+  },
+  UserFees: {
+    [METRIC.SWAP_FEES]: "Traders pay the full swap fee.",
+  },
+  Revenue: {
+    [METRIC.PROTOCOL_FEES]: "maker_fee_bps share of swap fees collected by the Maker contract.",
+  },
+  ProtocolRevenue: {
+    [METRIC.PROTOCOL_FEES]: "maker_fee_bps share of swap fees collected by the Maker contract.",
+  },
+  SupplySideRevenue: {
+    [METRIC.LP_FEES]: "Swap fees remaining after the maker_fee_bps protocol cut, paid to LPs.",
+  },
 };
 
 const adapter: SimpleAdapter = {
@@ -47,10 +127,11 @@ const adapter: SimpleAdapter = {
       fetch,
       // The endpoint only exposes a rolling 24h snapshot, so run at current time.
       runAtCurrTime: true,
-      start: '2025-09-27', // earliest OroSwap pool
+      start: "2025-09-27", // earliest OroSwap pool
     },
   },
   methodology,
+  breakdownMethodology,
 };
 
 export default adapter;

--- a/fees/oroswap/index.ts
+++ b/fees/oroswap/index.ts
@@ -1,0 +1,48 @@
+import { httpGet } from "../../utils/fetchURL";
+import { FetchResultV2, SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+
+// OroSwap is an AMM DEX on ZIGChain. The pool-manager endpoint exposes a
+// per-pool `fees24H` (USD); there is no aggregate fees field, so we sum them.
+// The mainnet host is header-gated (403 without a browser UA + Origin), which
+// httpGet can satisfy; this is a header check, not a Cloudflare challenge.
+const POOLS_URL = "https://api-mainnet.oroswap.org/api/poolmanager/pools?offset=0&limit=1000";
+const HEADERS = {
+  "User-Agent": "Mozilla/5.0",
+  Origin: "https://app.oroswap.org",
+};
+
+const fetch = async (): Promise<FetchResultV2> => {
+  const data = await httpGet(POOLS_URL, { headers: HEADERS });
+  const pools = [...(data?.xyk ?? []), ...(data?.custom ?? [])];
+  if (!pools.length) throw new Error("OroSwap: no pools returned");
+
+  const dailyFees = pools.reduce((acc: number, pool: any) => {
+    const fees = Number(pool?.details?.fees24H);
+    return acc + (Number.isFinite(fees) ? fees : 0);
+  }, 0);
+
+  // Swap fees are paid by the trader; report fees only (raw numbers so no
+  // revenue split is required). The protocol-vs-LP share is not exposed.
+  return { dailyFees, dailyUserFees: dailyFees };
+};
+
+const methodology = {
+  Fees: "Sum of the trailing-24h swap fees across OroSwap's pools (per-pool fees24H, USD), from the OroSwap pool-manager API.",
+  UserFees: "All swap fees are paid by the traders.",
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  adapter: {
+    [CHAIN.ZIGCHAIN]: {
+      fetch,
+      // The endpoint only exposes a rolling 24h snapshot, so run at current time.
+      runAtCurrTime: true,
+      start: '2025-09-27', // earliest OroSwap pool
+    },
+  },
+  methodology,
+};
+
+export default adapter;

--- a/helpers/chains.ts
+++ b/helpers/chains.ts
@@ -191,6 +191,7 @@ export enum CHAIN {
   SKALE_EUROPA = "europa",
   IOTAEVM = "iotaevm",
   ZKLINK = "zklink",
+  ZIGCHAIN = "zigchain",
   DEXALOT = "dexalot",
   IMMUTABLEX = "imx",
   CHAINFLIP = "chainflip",


### PR DESCRIPTION
closes #8810

### what

Adds **volume and fees adapters for OroSwap**, an AMM DEX on ZIGChain. It is tracked on DefiLlama for TVL (~$3.8M) but was absent from both `/dexs` and `/fees`.

### how

OroSwap's pool-manager API exposes the numbers directly, so both adapters are single-endpoint pulls:

- **`dexs/oroswap`** - `dailyVolume = totalVolume24H`, the server-side aggregate the API returns (confirmed USD: `totalLiquidity` from the same response matches the DefiLlama TVL).
- **`fees/oroswap`** - `dailyFees = sum(pool.details.fees24H)` across all pools. There is no aggregate fees field, so we sum the per-pool values. Reported as raw `{ dailyFees, dailyUserFees }` (fees only) since the protocol-vs-LP split isn't exposed.
- **`CHAIN.ZIGCHAIN`** added to `helpers/chains.ts`.

The endpoint only exposes a rolling 24h snapshot (no historical backfill), so both run with `runAtCurrTime: true`, the same pattern as `dexs/oraidex`. The host is header-gated (403 without a browser `User-Agent` + `Origin`), which `httpGet` satisfies; it is a header check, not a Cloudflare challenge.

### receipts

```
$ npx ts-node --transpile-only cli/testAdapter.ts dexs oroswap
ZIGCHAIN 👇
Daily volume: 567.13 k

$ npx ts-node --transpile-only cli/testAdapter.ts fees oroswap
Daily fees: 516.00
Daily user fees: 516.00
```

Both reconcile against the raw API response for the same pull: aggregate `totalVolume24H` ~$567k and summed per-pool `fees24H` ~$516. `tsc --noEmit` clean.
