### PR TITLE
dodo: repoint volume at the keyless gateway host, api key returns 403 request deny

### DIFF
--- a/dexs/dodo/index.ts
+++ b/dexs/dodo/index.ts
@@ -16,7 +16,12 @@ import { addOneToken } from "../../helpers/prices";
   // [HECO]: "https://n10.hg.network/subgraphs/name/dodoex-mine-v3-heco/heco",
   // [OKEXCHAIN]: "https://graph.kkt.one/subgraphs/name/dodoex/dodoex-v2-okchain",
 } as ChainEndpoints */
-const dailyEndpoint = "https://api.dodoex.io/graphql?opname=FetchDashboardDailyData&apikey=graphqldefiLlamadodoYzj5giof"
+// api.dodoex.io needs an API key and the one this adapter carried now comes back
+// 403 "request deny" (a bogus key gets 401 "Invalid API key", so it is recognised
+// and refused, not mistyped). gateway.dodoex.io serves the same
+// FetchDashboardDailyData query with no key and is the host fees/dodo-fees.ts
+// already uses.
+const dailyEndpoint = "https://gateway.dodoex.io/graphql?opname=FetchDashboardDailyData"
 const chains = [
   CHAIN.ARBITRUM,
   CHAIN.BSC,


### PR DESCRIPTION
Fixes #8815.

`dexs/dodo` has published nothing since 2026-08-14. `total24h` is null and the chart stops with no trailing zeros, so the adapter was throwing, not writing zeros.

## Cause

`dexs/dodo/index.ts` posted to `api.dodoex.io/graphql?...&apikey=graphqldefiLlamadodoYzj5giof`. That key now returns 403 `{"message":"request deny"}`. It is a refusal rather than a bad key, and the three-way comparison is what shows it. Same POST body, same host, only the key varies:

| request | status | body |
|---|---|---|
| no `apikey` param | 401 | `{"message":"Missing API key in request"}` |
| `apikey=bogus` | 401 | `{"message":"Invalid API key in request"}` |
| the key in the repo | 403 | `{"message":"request deny"}` |

## Fix

Repoint at `gateway.dodoex.io/graphql?opname=FetchDashboardDailyData`, which serves the identical `FetchDashboardDailyData` query with no key at all. That is the host `fees/dodo-fees.ts` already uses, which is why DODO fees kept publishing right through this outage while volume went dark. No new dependency, no new header: a plain axios request works, only a request with a completely absent User-Agent gets the HTML page instead.

## Verified equivalent, not just reachable

Summed the gateway's per-chain figures for days the old key still worked and compared against what DefiLlama actually published:

| day | gateway sum | published | delta |
|---|---|---|---|
| 2026-08-11 | 10,298,562.9 | 10,298,563 | rounding |
| 2026-08-13 | 8,196,138 | 8,191,230 | 0.06% |

The days that are missing are served too.

Test run after the change, for 2026-08-16, resolves all nine configured chains:

```
arbitrum  | 208.04 k
bsc       | 205.72 k
ethereum  | 3.06 M
polygon   | 2.03 M
avax      | 359.88 k
optimism  | 0.00
base      | 0.10
linea     | 0.00
scroll    | 0.00
Aggregate | 5.87 M
```

## One thing worth flagging

The loss was already partial before the full stop, so the gap is wider than the last chart point suggests. On 2026-08-14 DefiLlama published only polygon 2,479,410 and avalanche 131,026, while the gateway reports ethereum 5,065,125, arbitrum 948,518 and bsc 68,795 for that same day. Some chains were being denied ahead of the others, which fits a per-request quota or rate limit on the key rather than a clean cutoff.

If anyone would rather keep the key-gated host and renew the key with DODO instead, that works too and this PR can be closed. I went with the keyless host because it removes the credential from the repo entirely and is already proven in `fees/dodo-fees.ts`.
