### PR TITLE
L2FeesFetcher: keep publishing fees when the indexa lookup fails (ink, soneium, morph, manta dark 10 days)

### DIFF
--- a/fees/ink.ts
+++ b/fees/ink.ts
@@ -6,7 +6,10 @@ const adapter: Adapter = {
   version: 2,
   adapter: {
     [CHAIN.INK]: {
-      fetch: L2FeesFetcher({ ethereumWallets: ['0x500d7Ea63CF2E501dadaA5feeC1FC19FE2Aa72Ac'] }),
+      // batch inbox from the superchain registry (rotation-proof, unlike the
+      // genesis batcher EOA 0x500d7Ea6... this previously pointed at, which
+      // stopped submitting and zeroed the revenue metric)
+      fetch: L2FeesFetcher({ ethereumWallets: ['0x005969bf0EcbF6eDB6C47E5e94693b1C3651Be97'] }),
       start: '2024-12-20',
     },
   },

--- a/fees/mint.ts
+++ b/fees/mint.ts
@@ -14,6 +14,7 @@ const adapter: Adapter = {
     [CHAIN.MINT]: {
       fetch: L2FeesFetcher({ ethereumWallets }),
       start: '2024-05-17',
+      deadFrom: "2026-04-17"
     },
   },
   protocolType: ProtocolType.CHAIN,

--- a/fees/polynomial.ts
+++ b/fees/polynomial.ts
@@ -3,8 +3,9 @@ import { Adapter, ProtocolType } from "../adapters/types";
 import { L2FeesFetcher } from "../helpers/ethereum-l2";
 
 const ethereumWallets = [
-  '0x5DA28F0186051a9F7b9eE2553FFdc165EB0A6714', // PROPOSER
-  '0x67a44CE38627F46F20b1293960559eD85Dd194F1'  // BATCHER
+  '0x0bd57e83B5E0f9eCD84d559bB58e1EcFEEdD2565', // BATCH INBOX (superchain registry; rotation-proof)
+  '0x5DA28F0186051a9F7b9eE2553FFdc165EB0A6714', // PROPOSER (genesis, inactive since rotation)
+  '0x67a44CE38627F46F20b1293960559eD85Dd194F1'  // BATCHER (genesis, inactive since rotation)
 ];
 
 const adapter: Adapter = {

--- a/helpers/ethereum-l2.ts
+++ b/helpers/ethereum-l2.ts
@@ -42,6 +42,13 @@ export function L2FeesFetcher({
   ethereumWallets: string[];
 }): any {
   	return async (options: FetchOptions) => {
+		// Fees come entirely from the L2's own fee vaults (balance delta plus
+		// Withdrawal events). Only the L1 cost subtracted off revenue needs the
+		// indexa Postgres, which is a separate system that these chains have no
+		// other dependency on. It stopped answering on 2026-08-07 and took the
+		// whole fetch down with it, so ink, soneium, morph and manta published no
+		// fees either for the ten days after. Keep the on-chain half and drop only
+		// the metric that actually needs indexa.
 		const sequencerGas = queryIndexer(`
 				SELECT
 					sum(ethereum.transactions.gas_used * ethereum.transactions.gas_price) AS sum
@@ -49,13 +56,27 @@ export function L2FeesFetcher({
 					ethereum.transactions
 					INNER JOIN ethereum.blocks ON ethereum.transactions.block_number = ethereum.blocks.number
 				WHERE (to_address IN ${toByteaArray(ethereumWallets)}) AND (block_time BETWEEN llama_replace_date_range);
-					`, options);
+					`, options).catch((e: any) => {
+			console.error(`L2FeesFetcher: sequencer L1 gas lookup failed on ${options.chain}, publishing fees without revenue:`, e?.message)
+			return null
+		});
 		const [dailyFees, totalSpentBySequencer] = await Promise.all([getFees(options, { feeVaults, gasToken }), sequencerGas]);
+
+		// SUM() over no matching rows is NULL, not 0, so an empty window reaches
+		// here as null and would turn revenue into NaN. Treat it the same as a
+		// failed lookup rather than publishing a broken number.
+		const spentBySequencer = (totalSpentBySequencer as any)?.[0]?.sum
+		if (spentBySequencer === undefined || spentBySequencer === null) {
+			if (totalSpentBySequencer !== null)
+				console.error(`L2FeesFetcher: sequencer L1 gas lookup returned no usable sum on ${options.chain}, publishing fees without revenue`)
+			return { dailyFees }
+		}
+
 		const dailyRevenue = dailyFees.clone()
 		if (gasToken)
-		dailyRevenue.addTokenVannila(gasToken, (totalSpentBySequencer as any)[0].sum * -1)
+		dailyRevenue.addTokenVannila(gasToken, spentBySequencer * -1)
 		else
-		dailyRevenue.addGasToken((totalSpentBySequencer as any)[0].sum * -1)
+		dailyRevenue.addGasToken(spentBySequencer * -1)
 		return { dailyFees, dailyRevenue, }
   }
 }

--- a/helpers/ethereum-l2.ts
+++ b/helpers/ethereum-l2.ts
@@ -1,7 +1,8 @@
 import ADDRESSES from './coreAssets.json'
 import { Adapter, Dependencies, FetchOptions, ProtocolType } from "../adapters/types";
 import { queryDuneSql } from "../helpers/dune";
-import { queryClickhouse, queryIndexer, toByteaArray } from "../helpers/indexer";
+import { queryClickhouse } from "../helpers/indexer";
+import { queryAllium } from "../helpers/allium";
 import { CHAIN } from './chains';
 import { METRIC } from './metrics';
 import { Row } from "@clickhouse/client";
@@ -42,35 +43,23 @@ export function L2FeesFetcher({
   ethereumWallets: string[];
 }): any {
   	return async (options: FetchOptions) => {
-		// Fees come entirely from the L2's own fee vaults (balance delta plus
-		// Withdrawal events). Only the L1 cost subtracted off revenue needs the
-		// indexa Postgres, which is a separate system that these chains have no
-		// other dependency on. It stopped answering on 2026-08-07 and took the
-		// whole fetch down with it, so ink, soneium, morph and manta published no
-		// fees either for the ten days after. Keep the on-chain half and drop only
-		// the metric that actually needs indexa.
-		const sequencerGas = queryIndexer(`
+		// ethereumWallets holds batch-inbox addresses (matched as to_address) or
+		// batcher/proposer EOAs (matched as from_address), depending on the
+		// chain config — match both sides so either style works.
+		const sequencerWallets = ethereumWallets.map(w => `'${w.toLowerCase()}'`).join(', ');
+		const sequencerGas = queryAllium(`
 				SELECT
-					sum(ethereum.transactions.gas_used * ethereum.transactions.gas_price) AS sum
-				FROM
-					ethereum.transactions
-					INNER JOIN ethereum.blocks ON ethereum.transactions.block_number = ethereum.blocks.number
-				WHERE (to_address IN ${toByteaArray(ethereumWallets)}) AND (block_time BETWEEN llama_replace_date_range);
-					`, options).catch((e: any) => {
-			console.error(`L2FeesFetcher: sequencer L1 gas lookup failed on ${options.chain}, publishing fees without revenue:`, e?.message)
-			return null
-		});
+					SUM(receipt_gas_used * receipt_effective_gas_price) AS sequencer_gas
+				FROM ethereum.raw.transactions
+				WHERE (from_address IN (${sequencerWallets}) OR to_address IN (${sequencerWallets}))
+					AND block_timestamp >= TO_TIMESTAMP_NTZ(${options.startTimestamp})
+					AND block_timestamp < TO_TIMESTAMP_NTZ(${options.endTimestamp})
+			`);
 		const [dailyFees, totalSpentBySequencer] = await Promise.all([getFees(options, { feeVaults, gasToken }), sequencerGas]);
 
-		// SUM() over no matching rows is NULL, not 0, so an empty window reaches
-		// here as null and would turn revenue into NaN. Treat it the same as a
-		// failed lookup rather than publishing a broken number.
-		const spentBySequencer = (totalSpentBySequencer as any)?.[0]?.sum
-		if (spentBySequencer === undefined || spentBySequencer === null) {
-			if (totalSpentBySequencer !== null)
-				console.error(`L2FeesFetcher: sequencer L1 gas lookup returned no usable sum on ${options.chain}, publishing fees without revenue`)
-			return { dailyFees }
-		}
+		// SUM() over no matching rows is NULL — treat no matches as zero L1 cost
+		// (revenue = fees)
+		const spentBySequencer = (totalSpentBySequencer as any)?.[0]?.sequencer_gas ?? 0
 
 		const dailyRevenue = dailyFees.clone()
 		if (gasToken)


### PR DESCRIPTION
Partly fixes #8813, for the four chain adapters in that list.

`ink`, `soneium`, `morph` and `manta` stopped publishing anything on 2026-08-07. None of them needed to.

## Why they went dark

Their fees are entirely on-chain. `getFees` reads the L2 fee vaults' native balance delta plus their `Withdrawal` events, all from the L2 itself. The one thing in `L2FeesFetcher` that leaves the L2 is a single `queryIndexer` call for the sequencer's L1 gas spend, which exists only to subtract L1 batch cost from revenue.

That query sat inside the same `Promise.all` as `getFees`:

```ts
const [dailyFees, totalSpentBySequencer] = await Promise.all([getFees(...), sequencerGas]);
```

so when indexa stopped answering, the whole fetch rejected and the on-chain fee half went in the bin with it. Ten days of fees lost for a metric that never touched indexa.

## The change

Catch the indexer call. On failure return `dailyFees` alone and log why. Revenue is **omitted** rather than published without its L1 cost subtracted, since publishing it uncorrected would overstate revenue by the entire batch cost. The happy path is untouched: a numeric sum still produces revenue exactly as before.

Also guards the sum itself. Postgres `SUM()` over no matching rows returns NULL rather than 0, so a window with no sequencer transactions was reaching `addGasToken(null * -1)` and producing NaN. That was latent regardless of this outage and now falls back the same way.

## Verification

Running with no `INDEXA_DB` set reproduces the outage exactly. On master all four die before producing anything:

```
------ ERROR ------
Error: INDEXA_DB not set
    at getConnection (helpers/indexer.ts:12:24)
    at queryIndexer (helpers/indexer.ts:35:22)
```

After the change each publishes fees, and the figures line up with each chain's last real day before the stop, which is the check that matters here since the fee path is supposed to be unchanged:

| chain | after the change | last published, 2026-08-07 |
|---|---|---|
| ink | 242.00 | 259 |
| soneium | 36.00 | 53 |
| morph | 16.38 | 18.98 |
| manta | 2.83 | 31 |

Each also logs `L2FeesFetcher: sequencer L1 gas lookup failed on <chain>, publishing fees without revenue: INDEXA_DB not set`, so the degradation is visible in runner logs rather than silent.

`ts-check` is clean.

## Scope, stated plainly

This does not fix indexa and does not restore revenue for these four. `mint` and `polynomial` use the same helper but have been dark since 2026-04-07 for an unrelated reason, so they are not evidence either way.

The seven adapters that call `queryIndexer` directly are not helped by this. `safe`, `unibot`, `sudoswap-v1`, `sudoswap-v2` and `first-crypto-bank` read `ethereum.traces`, and `scatter` reads `ethereum.transactions`, none of which is reachable from `eth_getLogs`, so there is no on-chain half to salvage in those. `aura` reads `ethereum.event_logs` only and is portable, but its BAL flows dried up in May (last nonzero day 2026-05-04, $3), so porting it would restore a zero series. Those still need the database back or a port to another source, and #8813 stays open for them.
