### PR TITLE
garden: throw when the orders endpoint returns nothing instead of publishing zero (12 false zero days)

### DIFF
--- a/bridge-aggregators/garden/index.ts
+++ b/bridge-aggregators/garden/index.ts
@@ -188,7 +188,14 @@ async function fetchTransactionsInDateRange(startTimestamp: number, endTimestamp
         const response: GardenApiResponse = await fetchURL(
             `${baseUrl}?page=${currentPage}&per_page=200&status=completed`
         );
+        // Same reasoning as fees/garden: an empty first page is a source failure,
+        // not a zero-volume day, and letting it through publishes a real 0.
         if (response.status !== "Ok" || !response.result.data.length) {
+            if (currentPage === 1) {
+                throw new Error(
+                    `garden bridge: orders endpoint returned no usable data on page 1 (status ${response.status}, ${response.result?.data?.length ?? "no"} rows)`
+                );
+            }
             break;
         }
         for (const tx of response.result.data) {

--- a/fees/garden/index.ts
+++ b/fees/garden/index.ts
@@ -120,7 +120,19 @@ async function fetchTransactionsInDateRange(startTimestamp: number, endTimestamp
         const response: GardenApiResponse = await fetchURL(
             `https://api.garden.finance/v2/orders?status=completed&per_page=500&page=${currentPage}`
         );
-        if (response.status !== "Ok" || !response.result.data.length) break;
+        // An empty page after the first is just the end of pagination. An empty
+        // FIRST page means the source returned nothing for the whole window, and
+        // falling through to `return { fees }` publishes a real 0 for every chain.
+        // That is what put twelve false zero-fee days in the chart between
+        // 2026-07-27 and 2026-08-07 while the endpoint was failing. Fail instead.
+        if (response.status !== "Ok" || !response.result.data.length) {
+            if (currentPage === 1) {
+                throw new Error(
+                    `garden fees: orders endpoint returned no usable data on page 1 (status ${response.status}, ${response.result?.data?.length ?? "no"} rows)`
+                );
+            }
+            break;
+        }
 
         for (const tx of response.result.data) {
             const txTimestamp = new Date(tx.created_at).getTime() / 1000;


### PR DESCRIPTION
Related to #8814. This is the half that is fixable inside the repo.

## The defect

Both garden adapters paginate `api.garden.finance/v2/orders` and leave the loop like this:

```ts
if (response.status !== "Ok" || !response.result.data.length) break;
```

An empty page after the first is the normal end of pagination. An empty **first** page is not. It means the source returned nothing for the whole window, and the loop then falls through to an empty `fees` map, so the adapter publishes a real `0` for every chain rather than failing.

That path fired in production. `fees/garden` has twelve explicit zero-fee days in its chart:

```
2026-07-23=1415  2026-07-24=879  2026-07-25=1547  2026-07-26=1217
2026-07-27=0 ... 2026-08-07=0
```

Density over the sixty days before the run of zeros was 60 of 60 nonzero at a median around $1,217/day, so this is not a protocol that legitimately earns nothing for twelve consecutive days. After 2026-08-07 the endpoint began 404ing and the series stops instead, which is the visible failure mode and the reason the zeros in front of it are easy to walk past.

## The change

Page 1 with a non-Ok status or no rows now throws, with the status and row count in the message. Later pages keep breaking exactly as before. Applied to `bridge-aggregators/garden` as well, which reads the same endpoint with the same loop shape.

`ts-check` clean.

## What I could not test, said plainly

This is not provable end to end right now. Every route under `/v2` on that host returns 404, so the run errors on the request itself before reaching this branch, identically before and after the change:

```
------ ERROR ------
Request failed with status code 404
```

The evidence that the branch fires in production is the twelve zeros already sitting in the published series. The change is on the "API answers but answers empty" path, which is unreachable from here while the host 404s.

## What this does not fix

Garden's data is still gone and this PR does not bring it back. For the record, on what I ruled out:

- every documented route 404s with `content-length: 0`: `/v2/orders`, `/v2/chains`, `/v2/assets`, `/v2/volume`, `/v2/quote`, `/v2/liquidity`, `/v2/fiat`, `/info`, plus the root-level variants
- `/health` still returns 200 with `{"database":true,"ok":true,"poller":{"ok":true,"secondsSinceSweep":2},...}`, so the service is up and sweeping
- its own OpenAPI spec at docs.garden.finance/api-reference/openapi.json still documents `/v2/orders` and now declares a global `garden-app-id` apiKey requirement
- supplying that app id does not help. The Garden frontend ships one publicly in its bundle and every route above still 404s with it set, on `garden-app-id`, `api-key` and `x-api-key`
- the frontend's own code still calls `/v2/orders`, and it has separately moved its swap path onto Flashnet

So the read API this adapter depends on has been withdrawn rather than moved somewhere I can find. Restoring the data needs someone with a Garden contact, which is why #8814 exists. Merging this at least stops the next outage from writing zeros into the series first.
