### PR TITLE
fix ntm - reject unusable amounts instead of feeding them to addCGToken

### DIFF
--- a/fees/ntm/index.ts
+++ b/fees/ntm/index.ts
@@ -23,12 +23,15 @@ const fetchFeesAndRevenues = async (options: FetchOptions) => {
   const res = await httpGet(url);
 
   // Reject anything that is not a real number before it reaches addCGToken.
-  // Number(undefined) is NaN and Number(null)/Number("") are a finite 0, so a
-  // non-JSON body or a changed field name would otherwise land as a silent zero
-  // or an unreadable NaN instead of an error naming the endpoint.
+  // Number(undefined) is NaN and Number(null)/Number("")/Number(" ")/Number([])
+  // are all a finite 0, so a non-JSON body or a changed field name would
+  // otherwise land as a silent zero or an unreadable NaN instead of an error
+  // naming the endpoint. Only a number or a non-blank string is accepted.
   const readAmount = (raw: unknown, field: string): number => {
-    if (raw === null || raw === undefined || raw === "") {
-      throw new Error(`ntm: missing ${field} from ${url}`);
+    const usable =
+      typeof raw === "number" || (typeof raw === "string" && raw.trim() !== "");
+    if (!usable) {
+      throw new Error(`ntm: missing or non-numeric ${field} (${JSON.stringify(raw)}) from ${url}`);
     }
     const value = Number(raw);
     if (!Number.isFinite(value) || value < 0) {

--- a/fees/ntm/index.ts
+++ b/fees/ntm/index.ts
@@ -19,14 +19,31 @@ const fetchFeesAndRevenues = async (options: FetchOptions) => {
   const endTime = new Date(options.endTimestamp * 1000)
     .toISOString()
     .split(".")[0];
-  const res = await httpGet(
-    `${endpoint}start_date=${startTime}&end_date=${endTime}&chain=${options.chain}`,
-  );
+  const url = `${endpoint}start_date=${startTime}&end_date=${endTime}&chain=${options.chain}`;
+  const res = await httpGet(url);
+
+  // Reject anything that is not a real number before it reaches addCGToken.
+  // Number(undefined) is NaN and Number(null)/Number("") are a finite 0, so a
+  // non-JSON body or a changed field name would otherwise land as a silent zero
+  // or an unreadable NaN instead of an error naming the endpoint.
+  const readAmount = (raw: unknown, field: string): number => {
+    if (raw === null || raw === undefined || raw === "") {
+      throw new Error(`ntm: missing ${field} from ${url}`);
+    }
+    const value = Number(raw);
+    if (!Number.isFinite(value) || value < 0) {
+      throw new Error(`ntm: unusable ${field} (${JSON.stringify(raw)}) from ${url}`);
+    }
+    return value;
+  };
+
   const token = chainToken[options.chain];
+  if (!token) throw new Error(`ntm: no coingecko id mapped for chain ${options.chain}`);
+
   const dailyFees = options.createBalances();
   const dailyRevenue = options.createBalances();
-  dailyFees.addCGToken(token, res.fees_total);
-  dailyRevenue.addCGToken(token, res.revenue_total);
+  dailyFees.addCGToken(token, readAmount(res?.fees_total, "fees_total"));
+  dailyRevenue.addCGToken(token, readAmount(res?.revenue_total, "revenue_total"));
 
   return { dailyFees, dailyRevenue };
 };


### PR DESCRIPTION
Related to #8816.

**Scope note:** an earlier revision of this branch also swapped `httpGet` for `fetchURL` to get its three retries. That is dropped, per the discussion below. This is now response validation only.

## Situation

`fees/ntm` has published nothing since 2026-07-29. `total24h` and `total7d` are null and the chart stops rather than trailing zeros, so it is throwing.

Everything it depends on works when checked by hand:

- `api.ntm.ai/feesAndRevenues.php` answers for all six chains in `chainToken`, checked 2026-08-17: ethereum 0.05, bsc 0.25, avax 6, solana 3, tron 850, ton 5
- it answers for the days inside the gap too. Probing solana day by day: 07-29 → 3, 07-30 → 3, 07-31 → 1, 08-05 → 2, 08-10 → 2, 08-16 → 3. All 200, all under half a second
- it does not care about the User-Agent. `axios/1.7.2`, `axios/0.27.2`, `node`, `Mozilla/5.0` and no UA header at all all return 200
- the adapter runs clean locally at $1.54k/day, in line with the ~$1,330/day it published before the stop
- all six chains stopped on **exactly** 2026-07-29, which rules out a per-chain coingecko id problem

## Cause, now confirmed

The `test` job on the first revision of this branch answered it. Running the adapter on a GitHub Actions runner:

```
🦙 Running NTM adapter 🦙
------ ERROR ------
Request failed with status code 403
```

**403 from a datacenter IP**, against 200 from a residential one with any User-Agent. The only variable between the two callers is the network. So api.ntm.ai answers residential addresses and refuses datacenter ones, which explains both the simultaneous stop across all six chains and why the endpoint looks perfectly healthy to anyone checking by hand.

## Why the retry is gone

It was in here as a candidate fix, and the 403 rules it out: a deterministic refusal retries into three more refusals. It bought nothing and only widened the diff, so `httpGet` is left exactly as it was.

## What is left, and why it is still worth having

The response was used unchecked:

```ts
dailyFees.addCGToken(token, res.fees_total);
```

`Number(undefined)` is `NaN`, and both `Number(null)` and `Number("")` are a finite `0`. So a non-JSON body, a renamed field, or a Cloudflare challenge page returned with a 200 would land as an unreadable NaN or a **silent zero** rather than an error. Both amounts now go through a guard that throws naming the field and the endpoint, and a chain with no coingecko id mapped throws instead of calling `addCGToken(undefined, ...)`.

The silent-zero half is the part I would argue for on its own merits, independent of this outage: a 200-with-a-challenge-body is exactly the shape that writes a false zero into a series, which is the failure mode that is hard to notice afterwards.

## Verification

No behaviour change on valid data. Identical run before and after:

```
ethereum  | 286.00
bsc       | 302.00
avax      |  76.00
solana    | 303.00
tron      | 565.00
ton       |  13.00
Aggregate |  1.54 k
```

`ts-check` clean. The `test` job will stay red for as long as the runner is refused, and that red is the 403 above, not this diff.

## Not fixed by this

The data. That needs an allowlist request to NTM covering the runner's egress range, or routing this one adapter off a bare datacenter IP. Neither is a code change, so #8816 stays open for it.
