### PR TITLE
aave: drop only the stuck reserves instead of the whole pool (aave-v2 ethereum, realt-rmm-v2, colend zeroed)

### DIFF
--- a/helpers/aave/index.ts
+++ b/helpers/aave/index.ts
@@ -36,11 +36,34 @@ const LiquidityIndexDecimals = BigInt(1e27);
 const SECONDS_PER_YEAR = 365 * 24 * 60 * 60;
 const MAX_REASONABLE_SUPPLY_APR = 10; // 1000% APR
 
+// The stuck-markets cache records one entry per pool, whose value names the
+// offending reserves in a fixed shape: "SYMBOL: reason", several of them joined
+// by " | ". Every one of the 41 entries in the cache follows it, including
+// awkward ones like "SolvBTC.b", "USDC.e", "oUSDC", "WETH/USDT WLP" and
+// "T-2250_2750-WETH-USDC", none of which contain a colon or a pipe.
+//
+// Returns an empty array for anything it cannot read, which the caller treats as
+// "drop the whole pool", i.e. the behaviour before reserve-level filtering.
+export function parseStuckReserveSymbols(reason: unknown): Array<string> {
+  if (typeof reason !== 'string' || !reason.trim()) return []
+  const symbols = reason
+    .split('|')
+    .map(segment => {
+      const separator = segment.indexOf(':')
+      return separator === -1 ? '' : segment.slice(0, separator).trim()
+    })
+    .filter(Boolean)
+  // A partially parseable reason is not good enough: one unreadable segment
+  // would let its reserve through. Treat the whole thing as unreadable.
+  if (symbols.length !== reason.split('|').length) return []
+  return [...new Set(symbols)]
+}
+
 export async function getPoolFees(pool: AaveLendingPoolConfig, options: FetchOptions, balances: {
   dailyFees: sdk.Balances,
   dailySupplySideRevenue: sdk.Balances,
   dailyProtocolRevenue: sdk.Balances,
-}) {
+}, skipReserveSymbols?: Array<string>) {
   // get reserve (token) list which are supported by the lending pool
   const reservesList: Array<string> = await options.fromApi.call({
     target: pool.lendingPoolProxy,
@@ -51,6 +74,36 @@ export async function getPoolFees(pool: AaveLendingPoolConfig, options: FetchOpt
   // in this case the market is not exists yet
   if (!reservesList || reservesList.length == 0) {
     return;
+  }
+
+  // Resolve the stuck-reserve symbols the cache names for this pool into reserve
+  // indexes, so only those reserves are dropped instead of the whole pool.
+  //
+  // Deliberately fails closed: if any named symbol cannot be matched to a
+  // reserve on this pool, we skip the entire pool, which is exactly what the
+  // caller did before this existed. So the worst case is the previous
+  // behaviour, never a stuck reserve slipping into the totals.
+  let skipReserveIndexes = new Set<number>()
+  if (skipReserveSymbols?.length && reservesList?.length) {
+    const symbols: Array<string | null> = await options.fromApi.multiCall({
+      abi: 'string:symbol',
+      calls: reservesList,
+      permitFailure: true,
+    })
+    const wanted = new Set(skipReserveSymbols.map(symbol => symbol.trim().toLowerCase()))
+    const matched = new Set<string>()
+    symbols.forEach((symbol, index) => {
+      const normalised = typeof symbol === 'string' ? symbol.trim().toLowerCase() : ''
+      if (normalised && wanted.has(normalised)) {
+        skipReserveIndexes.add(index)
+        matched.add(normalised)
+      }
+    })
+    if (matched.size !== wanted.size) {
+      const unmatched = [...wanted].filter(symbol => !matched.has(symbol))
+      sdk.log(`aave: ${options.chain} ${pool.lendingPoolProxy} could not match stuck reserve symbol(s) ${unmatched.join(', ')}, skipping the whole pool`)
+      return
+    }
   }
 
   // get reserve configs
@@ -82,6 +135,7 @@ export async function getPoolFees(pool: AaveLendingPoolConfig, options: FetchOpt
 
   // all calculations use BigInt because aave math has 27 decimals
   for (let reserveIndex = 0; reserveIndex < reservesList.length; reserveIndex++) {
+    if (skipReserveIndexes.has(reserveIndex)) continue
     if (!reserveDataBefore[reserveIndex] || !reserveDataAfter[reserveIndex]) continue
     if (pool.version !== 1 && !reserveConfigs[reserveIndex]) continue
 
@@ -250,16 +304,33 @@ export function aaveExport(exportConfig: {[key: string]: AaveAdapterExportConfig
 
         const aaveInsolventMarketsCacheKey = `tvl-adapter-cache/cache/insolvent-markets/aave.json`;
         const insolventMarketsDetails = await cache.readCache(aaveInsolventMarketsCacheKey, { readFromR2Cache: true });
-        const stuckMarkets = Object.keys((insolventMarketsDetails.stuck ?? {})?.[options.chain] ?? {}).map(item => item.toLowerCase());
+        // Keyed by lowercased pool address, value is the cache's reason string.
+        const stuckReasons: Record<string, unknown> = {};
+        for (const [poolAddress, reason] of Object.entries((insolventMarketsDetails.stuck ?? {})?.[options.chain] ?? {})) {
+          stuckReasons[poolAddress.toLowerCase()] = reason;
+        }
         const insolventMarkets = Object.keys((insolventMarketsDetails.insolvent ?? {})?.[options.chain] ?? {}).map(item => item.toLowerCase());
 
         for (const pool of config.pools) {
-          if (stuckMarkets.includes(pool.lendingPoolProxy.toLowerCase()) || insolventMarkets.includes(pool.lendingPoolProxy.toLowerCase())) continue;
+          const poolAddress = pool.lendingPoolProxy.toLowerCase();
+
+          // Insolvency stays pool-level. A backing gap or unrepayable debt is a
+          // statement about the market as a whole, not about one reserve's rate.
+          if (insolventMarkets.includes(poolAddress)) continue;
+
+          let skipReserveSymbols: Array<string> | undefined;
+          if (poolAddress in stuckReasons) {
+            skipReserveSymbols = parseStuckReserveSymbols(stuckReasons[poolAddress]);
+            // No parseable symbols means we cannot tell which reserves are stuck,
+            // so fall back to dropping the pool the way this did before.
+            if (!skipReserveSymbols.length) continue;
+          }
+
           await getPoolFees(pool, options, {
             dailyFees,
             dailySupplySideRevenue,
             dailyProtocolRevenue,
-          })
+          }, skipReserveSymbols)
         }
 
         return {


### PR DESCRIPTION
Fixes #8798.

#8494 added an automatic skip for stuck and insolvent aave markets. The detection behind it is per reserve but the skip was applied per pool, so one bad reserve stopped a pool reporting fees for all of its healthy reserves.

## What was lost

| protocol | effect | flagged because of |
|---|---|---|
| `aave-v2` | ethereum leg to exactly 0, other chains fine | sUSD, retired, zero underlying supply |
| `realt-rmm-marketplace-v2` | whole protocol to 0 on $29.9M of live TVL | REUSD |
| `colend-protocol` | whole protocol to 0 | SolvBTC.b |
| `extra-finance-xlend` | partial | WETH |

Aave V2 ethereum was the quiet one: polygon and avalanche keep reporting, so `summary/fees/aave-v2` still returned nonzero totals and nothing looked wrong from the top line.

## Why this is now a PR

In the issue I said the change had to start in the cache repo, because the cache names the offending reserves only inside a human-readable sentence. That turned out to be wrong. The sentence has a completely regular shape, `SYMBOL: reason` joined by ` | `, and all 21 stuck entries follow it. So it can be parsed here, resolved against the pool's reserves on chain, and used to skip just those indexes.

## Fails closed

This is the part that makes it safe to merge. If a named symbol cannot be matched to a reserve on the pool, or the reason string does not parse cleanly, the **whole pool is skipped exactly as before**. A reason that only partly parses is treated as unparseable rather than partly trusted, since one unreadable segment would otherwise let its reserve through. The worst case is the old behaviour, never a stuck reserve leaking into the totals.

## Insolvency deliberately left alone

Only the `stuck` bucket moves to reserve level. A backing gap or unrepayable debt is a statement about the market as a whole, not about one reserve's rate, so `insolvent` stays pool-level. That is the conservative reading of the judgement call raised in the issue, and it happens to cover every case above, since all four are in the `stuck` bucket.

If you would rather `insolvent` went reserve-level too, it is the same one-line change at the call site and I am happy to add it.

## Verification

Same shell, stashing the patch in and out between runs:

| adapter | master | with the fix |
|---|---|---|
| `aave-v2` ethereum | 0.00 | **3.77 k** |
| `aave-v2` polygon | 960.00 | 960.00 |
| `aave-v2` avax | 51.00 | 51.00 |
| `aave-v2` aggregate | 1.01 k | **4.78 k** |
| `realt-rmm-marketplace-v2` | 0.00 | **664.00** |
| `colend-protocol` | 0.00 | **61.00** |
| `extra-finance-xlend` | 14.00 | **52.00** |

polygon and avax are byte-identical, which is the check that the change only touches flagged pools. And 3.77 k for aave-v2 ethereum sits right where it was before the zeroing: it published 3,360 on 2026-07-28 and 1,700 on 2026-07-29.

The parser was run against every entry in the live cache. 21 of 21 parse, including `SolvBTC.b`, `USDC.e`, `oUSDC`, `WETH/USDT WLP`, and a multi-reserve entry with eight symbols. Edge cases return an empty array for `undefined`, empty string, a reason with no colon, and a partly broken reason, and de-duplicate a repeated symbol.

`ts-check` clean. `getPoolFees` takes the symbol list as an optional fourth argument, so the four callers outside the factory (`neverland`, `valas-finance`, `aave-v3`, `spark`) are unchanged.

## Two things I could not check here

`aave-v3` will not run in this environment at all. It dies on BSC public RPC state pruning:

```
Llama RPC error! method: call
- host: https://bsc-dataseed.binance.org error: missing trie node
- host: https://public-bsc-mainnet.fastnode.io error: state at block #116220714 is pruned
```

That happens identically on master and with this change, so it is pre-existing and not something this introduces, but it does mean I have not seen aave-v3 run end to end.

Relatedly, harmony is the one aave-v3 pool in the stuck list (LINK and WONE) and there is no harmony RPC available here, so I have not confirmed those two symbols resolve. The fail-closed path is what covers it: if they do not resolve, harmony behaves exactly as it does today.

## Note on the pools not mapped here

The cache holds 21 stuck and 20 insolvent pools, and a number of them (`base`, `blast`, `bsc`, `fuse`, `hedera`, `hemi`, `iotaevm`, `klaytn`, `sei`, `sonic`, `xlayer` entries) do not correspond to any pool configured in `helpers/aave/index.ts`, so nothing in this repo reads them and they are unaffected either way.
