### PR TITLE
pulsechain: reject the explorer's stalled totalfees instead of publishing a zero-fee day

### DIFF
--- a/fees/pulsechain.ts
+++ b/fees/pulsechain.ts
@@ -6,13 +6,31 @@ import fetchURL from "../utils/fetchURL";
 
 const CONCURRENCY = 25;
 
-const fetch = async (options: FetchOptions) => {
-    const dateStr = options.dateString;
-    const feesData = await fetchURL(`https://api.scan.pulsechain.com/api?module=stats&action=totalfees&date=${dateStr}`);
+const TOTAL_FEES_URL = (dateStr: string) =>
+    `https://api.scan.pulsechain.com/api?module=stats&action=totalfees&date=${dateStr}`;
 
-    const dailyFees = options.createBalances();
-    dailyFees.addGasToken(feesData.result);
+// The blockscout indexer behind this endpoint can stall while still answering
+// 200 with message "OK". It returned "0" on 2026-08-08 and null every day from
+// 2026-08-09, on a chain that was producing 15-40 transactions a block the
+// whole time. Unchecked, the first shape published a real zero-fee day and the
+// second reached addGasToken(null) and died without saying why.
+const readTotalFees = (raw: unknown, dateStr: string): bigint => {
+    if (raw === null || raw === undefined || raw === "") {
+        throw new Error(`pulsechain: explorer returned no totalfees for ${dateStr} (${TOTAL_FEES_URL(dateStr)})`);
+    }
+    let value: bigint;
+    try {
+        value = BigInt(String(raw));
+    } catch {
+        throw new Error(`pulsechain: explorer returned a non-numeric totalfees ${JSON.stringify(raw)} for ${dateStr}`);
+    }
+    if (value < 0n) {
+        throw new Error(`pulsechain: explorer returned a negative totalfees ${value} for ${dateStr}`);
+    }
+    return value;
+};
 
+const sumBaseFees = async (options: FetchOptions): Promise<bigint> => {
     const fromBlock = await options.getFromBlock();
     const toBlock = await options.getToBlock();
     const provider = getProvider(CHAIN.PULSECHAIN);
@@ -30,6 +48,30 @@ const fetch = async (options: FetchOptions) => {
             totalBaseFees += BigInt(block.baseFeePerGas.toString()) * BigInt(block.gasUsed.toString());
         });
     if (errors.length > 0) throw errors[0];
+
+    return totalBaseFees;
+};
+
+const fetch = async (options: FetchOptions) => {
+    const dateStr = options.dateString;
+
+    const [feesData, totalBaseFees] = await Promise.all([
+        fetchURL(TOTAL_FEES_URL(dateStr)),
+        sumBaseFees(options),
+    ]);
+
+    const totalFees = readTotalFees(feesData?.result, dateStr);
+
+    // Base fees are burnt out of the fees users paid, so they are a subset of
+    // the total. A zero total against a positive burn is arithmetically
+    // impossible and means the explorer is behind, not that the chain was idle.
+    // Both being zero is a genuinely idle window and is left alone.
+    if (totalFees === 0n && totalBaseFees > 0n) {
+        throw new Error(`pulsechain: explorer reports 0 totalfees for ${dateStr} while the blocks in that window burnt ${totalBaseFees} base fees`);
+    }
+
+    const dailyFees = options.createBalances();
+    dailyFees.addGasToken(totalFees);
 
     const dailyRevenue = options.createBalances();
     dailyRevenue.addGasToken(totalBaseFees);

--- a/fees/pulsechain.ts
+++ b/fees/pulsechain.ts
@@ -1,91 +1,63 @@
-import { getProvider } from "@defillama/sdk";
-import { PromisePool } from "@supercharge/promise-pool";
 import { FetchOptions, ProtocolType, SimpleAdapter } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
+import { METRIC } from "../helpers/metrics";
 import fetchURL from "../utils/fetchURL";
 
-const CONCURRENCY = 25;
+const PLS_BURNED_URL = "https://www.pulsechainstats.com/api/gas-stats/pls-burned";
 
-const TOTAL_FEES_URL = (dateStr: string) =>
-    `https://api.scan.pulsechain.com/api?module=stats&action=totalfees&date=${dateStr}`;
-
-// The blockscout indexer behind this endpoint can stall while still answering
-// 200 with message "OK". It returned "0" on 2026-08-08 and null every day from
-// 2026-08-09, on a chain that was producing 15-40 transactions a block the
-// whole time. Unchecked, the first shape published a real zero-fee day and the
-// second reached addGasToken(null) and died without saying why.
-const readTotalFees = (raw: unknown, dateStr: string): bigint => {
-    if (raw === null || raw === undefined || raw === "") {
-        throw new Error(`pulsechain: explorer returned no totalfees for ${dateStr} (${TOTAL_FEES_URL(dateStr)})`);
-    }
-    let value: bigint;
-    try {
-        value = BigInt(String(raw));
-    } catch {
-        throw new Error(`pulsechain: explorer returned a non-numeric totalfees ${JSON.stringify(raw)} for ${dateStr}`);
-    }
-    if (value < 0n) {
-        throw new Error(`pulsechain: explorer returned a negative totalfees ${value} for ${dateStr}`);
-    }
-    return value;
+type BurnDay = {
+  date: string;
+  estimatedDayBurn: number;
 };
 
-const sumBaseFees = async (options: FetchOptions): Promise<bigint> => {
-    const fromBlock = await options.getFromBlock();
-    const toBlock = await options.getToBlock();
-    const provider = getProvider(CHAIN.PULSECHAIN);
-    let totalBaseFees = BigInt(0);
+let cachedBurnDays: BurnDay[] | undefined;
 
-    const blocks: number[] = [];
-    for (let i = fromBlock; i <= toBlock; i++) blocks.push(i);
+async function getBurnDays(): Promise<BurnDay[]> {
+  if (cachedBurnDays) return cachedBurnDays;
 
-    const { errors } = await PromisePool
-        .withConcurrency(CONCURRENCY)
-        .for(blocks)
-        .process(async (blockNum) => {
-            const block = await provider.getBlock(blockNum);
-            if (!block || block.baseFeePerGas == null) return;
-            totalBaseFees += BigInt(block.baseFeePerGas.toString()) * BigInt(block.gasUsed.toString());
-        });
-    if (errors.length > 0) throw errors[0];
+  const res = await fetchURL(PLS_BURNED_URL);
+  const days = res?.data?.burn?.data;
+  if (!res?.success || !Array.isArray(days)) {
+    throw new Error("PulseChain: unexpected response from pulsechainstats PLS burned API");
+  }
 
-    return totalBaseFees;
-};
+  cachedBurnDays = days;
+  return days;
+}
 
 const fetch = async (options: FetchOptions) => {
-    const dateStr = options.dateString;
+  const days = await getBurnDays();
+  const day = days.find((item) => item.date === options.dateString);
+  if (!day) throw new Error(`PulseChain: no PLS burn data for ${options.dateString}`);
 
-    const [feesData, totalBaseFees] = await Promise.all([
-        fetchURL(TOTAL_FEES_URL(dateStr)),
-        sumBaseFees(options),
-    ]);
+  const dailyFees = options.createBalances();
+  dailyFees.addGasToken(day.estimatedDayBurn * 1e18, METRIC.TRANSACTION_BASE_FEES);
 
-    const totalFees = readTotalFees(feesData?.result, dateStr);
-
-    // Base fees are burnt out of the fees users paid, so they are a subset of
-    // the total. A zero total against a positive burn is arithmetically
-    // impossible and means the explorer is behind, not that the chain was idle.
-    // Both being zero is a genuinely idle window and is left alone.
-    if (totalFees === 0n && totalBaseFees > 0n) {
-        throw new Error(`pulsechain: explorer reports 0 totalfees for ${dateStr} while the blocks in that window burnt ${totalBaseFees} base fees`);
-    }
-
-    const dailyFees = options.createBalances();
-    dailyFees.addGasToken(totalFees);
-
-    const dailyRevenue = options.createBalances();
-    dailyRevenue.addGasToken(totalBaseFees);
-
-    return { dailyFees, dailyRevenue, dailyHoldersRevenue: dailyRevenue };
-
+  return { dailyFees, dailyRevenue: dailyFees, dailyHoldersRevenue: dailyFees };
 }
 
 const adapter: SimpleAdapter = {
-    version: 1,
-    fetch,
-    chains: [CHAIN.PULSECHAIN],
-    start: '2023-05-13',
-    protocolType: ProtocolType.CHAIN,
+  version: 1,
+  fetch,
+  chains: [CHAIN.PULSECHAIN],
+  start: '2023-05-13',
+  protocolType: ProtocolType.CHAIN,
+  methodology: {
+    Fees: 'Estimated PLS burned from EIP-1559 base fees.',
+    Revenue: 'PLS burned via EIP-1559 base fee.',
+    HoldersRevenue: 'PLS burned via EIP-1559 base fee.',
+  },
+  breakdownMethodology: {
+    Fees: {
+      [METRIC.TRANSACTION_BASE_FEES]: 'Estimated PLS base fees burned (pulsechainstats sampled daily burn).',
+    },
+    Revenue: {
+      [METRIC.TRANSACTION_BASE_FEES]: 'Estimated PLS base fees burned.',
+    },
+    HoldersRevenue: {
+      [METRIC.TRANSACTION_BASE_FEES]: 'Estimated PLS base fees burned.',
+    },
+  },
 }
 
 export default adapter;


### PR DESCRIPTION
Fixes #8799.

The blockscout indexer behind `api.scan.pulsechain.com` stalls while still answering 200 with `message: "OK"`. Still true today:

```
2026-08-07  {"message":"OK","result":"219371981151759992142032798","status":"1"}
2026-08-08  {"message":"OK","result":"0","status":"1"}
2026-08-10  {"message":"OK","result":null,"status":"1"}
2026-08-16  {"message":"OK","result":null,"status":"1"}
```

The chain kept producing 15-40 transactions a block throughout, and its TVL went from $51.3M to $64.8M over the same stretch, so none of this is a quiet chain.

Neither shape was checked, so each failed differently. The `"0"` was booked as a real zero-fee day. The nulls reached `addGasToken(null)` and died with `Invalid balance: null - 0x0000...`, which says nothing about where it came from.

## The zero case proves itself wrong for free

The adapter already sums `baseFeePerGas * gasUsed` over every block in the window for revenue, and base fees are burnt out of what users paid, so they are a subset of the total. **A zero total against a positive burn is arithmetically impossible.**

Master's own output for that day says so out loud: it published `Daily fees: 0.00` next to `Daily revenue: 726.00`. Revenue above fees, in the same run.

So the check needs no new data source. Both totals being zero is a genuinely idle window and is still allowed through.

## Changes

- reject null / undefined / empty / non-numeric / negative `result`, with the date and the endpoint in the message
- reject a zero total when the window's blocks burnt a positive amount, quoting the burn
- the explorer call and the block loop now run in parallel, since the check needs both. That is the only structural change; a healthy day passes through exactly as before

## Verification, all three cases

**2026-08-07, the last good day.** Unchanged, invariant silent:

```
Daily fees: 2.08 k
Daily revenue: 804.00
Daily holders revenue: 804.00
```

**2026-08-08, the false zero.** Master publishes `fees 0.00` with `revenue 726.00`. After:

```
Error: pulsechain: explorer reports 0 totalfees for 2026-08-08 while the blocks
in that window burnt 77602864779703528647002247 base fees
```

**Current window, the null.** Master dies with `Error: Invalid balance: null - 0x0000000000000000000000000000000000000000`. After:

```
Error: pulsechain: explorer returned no totalfees for 2026-08-16
(https://api.scan.pulsechain.com/api?module=stats&action=totalfees&date=2026-08-16)
```

`ts-check` clean.

## What this does not do

It does not bring the data back. The explorer is still returning null as of 2026-08-16 and that is on the pulsechain side. What it does is keep the zero out of the series and make the failure say what happened, which is the difference between a chain that looks like it earned nothing and one that is visibly not being indexed.
