### PR TITLE
convex: count the LP CRV leg in dailyFees, supply side was 5.7x the reported total

### DIFF
--- a/fees/convex.ts
+++ b/fees/convex.ts
@@ -67,7 +67,7 @@ const fetchBribesUSDForDay = async (dayTimestamp: number): Promise<number> => {
 // ─── Methodology ──────────────────────────────────────────────────────────────
 const methodology = {
   UserFees: "No user fees",
-  Fees: "CRV and FXS earned by cvxCRV/cvxFXS stakers and CVX lockers from Convex's fee take, plus reUSD locker revenue and Votium bribes. Supply-side LP CRV rewards excluded from dailyFees.",
+  Fees: "All CRV and FXS harvested through Convex: the protocol's own fee take (cvxCRV/cvxFXS stakers and CVX lockers) plus the LP share passed through to pool stakers, plus reUSD locker revenue and Votium bribes.",
   HoldersRevenue: "CRV/CVX/FXS flowing to CVX lockers and cvxCRV/cvxFXS stakers, plus Votium bribes",
   Revenue: "Sum of protocol revenue and holders' revenue",
   ProtocolRevenue: "reUSD revenue directed to Convex treasury",
@@ -76,7 +76,7 @@ const methodology = {
 
 const breakdownMethodology = {
   Fees: {
-    "CRV Revenue": "CRV flowing to cvxCRV stakers (lockIncentive) and CVX lockers (stakerIncentive)",
+    "CRV Revenue": "CRV harvested through Convex: the fee take flowing to cvxCRV stakers (lockIncentive) and CVX lockers (stakerIncentive), plus the LP share passed through to pool stakers",
     "CVX Revenue": "CVX emissions flowing to cvxCRV stakers",
     "FXS Revenue": "FXS flowing to cvxFXS stakers, CVX lockers and LP providers via Convex's Frax-side fee contracts",
     "Others Revenue": "reUSD locker revenue",
@@ -272,7 +272,16 @@ const fetch = async (options: FetchOptions) => {
   dailyRevenue.addBalances(cvxCrvStakerCVX, "CVX Revenue");
   dailyHoldersRevenue.addBalances(cvxCrvStakerCVX, "CVX Revenue");
 
-  // LP supply-side CRV (extrapolated)
+  // LP supply-side CRV (extrapolated).
+  //
+  // This also belongs in dailyFees. fees/GUIDELINES.md defines dailyFees as
+  // "All fees from ALL sources - total value flow into protocol ecosystem" and
+  // requires dailyFees = dailyRevenue + dailySupplySideRevenue to hold within
+  // the same period. Leaving the LP leg out of fees broke that badly: the
+  // adapter was reporting 25.40k of supply-side revenue paid out of 4.44k of
+  // total fees. The FXS gauge leg below already books its supply-side amount
+  // into both, so this is also what makes the adapter consistent with itself.
+  dailyFees.addBalances(supplySideCRV, "CRV Revenue");
   dailySupplySideRevenue.addBalances(supplySideCRV, "CRV Revenue");
 
   // FXS claimed by cvxFXS stakers / CVX lockers (STKFXS_STAKING) → fees + revenue + holders


### PR DESCRIPTION
Fixes #8795.

`fees/convex` computes the LP share of harvested CRV and books it into `dailySupplySideRevenue` only, never into `dailyFees`. The methodology string said so outright: *"Supply-side LP CRV rewards excluded from dailyFees."*

## Why that is a defect and not a preference

`fees/GUIDELINES.md` settles it rather than precedent doing so:

- `dailyFees` is defined as "All fees from ALL sources - total value flow into protocol ecosystem"
- `dailyFees = dailyRevenue + dailySupplySideRevenue` is listed under **Income Statement Identities**, prefaced with "These are the most common review failures. Verify them on every fees PR"
- Cost of Funds explicitly includes "Staking Rewards passed through (less fees)", which is exactly what the LP CRV leg is

Measured live on master, the gap is not subtle:

| metric | master |
|---|---|
| `dailyFees` | 4.44 k |
| `dailyRevenue` | 4.44 k |
| `dailySupplySideRevenue` | **25.40 k** |

The adapter reported paying out $25.40k of supply-side revenue out of $4.44k of total fees. Supply side was 5.7x the total it is supposed to be a share of.

## The adapter also disagreed with itself

The FXS gauge leg, forty lines below, already does it the other way:

```ts
if (fxsDistribAmount > 0n) {
  dailyFees.add(FXS_TOKEN, fxsDistribAmount, "FXS Revenue");
  dailySupplySideRevenue.add(FXS_TOKEN, fxsDistribAmount, "FXS Revenue");
}
```

Only the CRV leg was treated differently. Whichever convention is preferred, one adapter should not apply both.

## After

| metric | master | with the fix |
|---|---|---|
| `dailyFees` | 4.44 k | **29.83 k** |
| `dailyRevenue` | 4.44 k | 4.44 k |
| `dailySupplySideRevenue` | 25.40 k | 25.40 k |
| `dailyHoldersRevenue` | 4.44 k | 4.44 k |
| `dailyProtocolRevenue` | 0.00 | 0.00 |

4,437 + 25,396 = 29,833 exactly. Only the fees top line moves, which is the number that was wrong. `ts-check` clean.

The extrapolation itself is unchanged and was already verified on chain: the Booster's `lockIncentive` 1000 + `stakerIncentive` 450 + `earmarkIncentive` 50 + `platformFee` 200 = 1700 bps, so 83% of harvested CRV is the LP share, which is what the 5.7x ratio reflects.

## The counter-argument, on the record

The LP share of CRV is Curve gauge emissions passed through Convex, not a fee a user paid Convex, so someone could reasonably want it out of the top line. I raised that myself in #8795 and left the call to you.

What changed my mind is that the guidelines answer this specific case: they name pass-through staking rewards as Cost of Funds, and Cost of Funds only makes sense as a deduction from something that was counted first.

If the intent really is to exclude it, the consistent version is to drop it from `dailySupplySideRevenue` too and give the FXS leg the same treatment, rather than leave the identity 5.7x out. Happy to send that shape instead if you would rather go that way, it is a smaller diff than this one.
