### PR TITLE
feat(prjx): add Project X volume and fees adapters

### DIFF
--- a/dexs/prjx/index.ts
+++ b/dexs/prjx/index.ts
@@ -1,42 +1,11 @@
-import { httpGet } from "../../utils/fetchURL";
 import { SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
+import { fetchProjectXPools } from "../../helpers/prjx";
 
-// Project X is a Uniswap-V3-style AMM on Hyperliquid L1. Its pools endpoint
-// returns a per-pool rolling 24h `volume24h` in USD (the summed `tvlUSD`
-// reconciles with the DefiLlama TVL). The host needs a browser User-Agent.
-const POOLS_URL = "https://api.prjx.com/pools";
-const HEADERS = { "User-Agent": "Mozilla/5.0" };
-const PAGE_LIMIT = 100; // API caps a page at 100
-
-interface Pool {
-  volume24h: string;
-  fee24h: string;
-}
-
-interface PoolsResponse {
-  pools: Pool[];
-  totalCount: number;
-}
-
-// The endpoint pages by offset/limit (max 100), so walk offsets up to totalCount.
-const fetchAllPools = async (): Promise<Pool[]> => {
-  const first: PoolsResponse = await httpGet(`${POOLS_URL}?limit=${PAGE_LIMIT}&offset=0`, { headers: HEADERS });
-  if (!Array.isArray(first?.pools)) throw new Error("Project X: pools unavailable");
-  const pools = [...first.pools];
-  const total = Number(first.totalCount);
-  for (let offset = PAGE_LIMIT; offset < total; offset += PAGE_LIMIT) {
-    const page: PoolsResponse = await httpGet(`${POOLS_URL}?limit=${PAGE_LIMIT}&offset=${offset}`, {
-      headers: HEADERS,
-    });
-    if (!Array.isArray(page?.pools)) throw new Error("Project X: pools page unavailable");
-    pools.push(...page.pools);
-  }
-  return pools;
-};
-
+// Project X is a Uniswap-V3-style AMM on Hyperliquid L1, tracked on DefiLlama
+// for TVL but absent from /dexs. Sum the per-pool rolling-24h USD volume.
 const fetch = async () => {
-  const dailyVolume = (await fetchAllPools()).reduce((acc, pool) => {
+  const dailyVolume = (await fetchProjectXPools()).reduce((acc, pool) => {
     const volume = Number(pool.volume24h);
     if (!Number.isFinite(volume)) throw new Error(`Project X: invalid volume24h ${pool.volume24h}`);
     return acc + volume;

--- a/dexs/prjx/index.ts
+++ b/dexs/prjx/index.ts
@@ -1,0 +1,63 @@
+import { httpGet } from "../../utils/fetchURL";
+import { SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+
+// Project X is a Uniswap-V3-style AMM on Hyperliquid L1. Its pools endpoint
+// returns a per-pool rolling 24h `volume24h` in USD (the summed `tvlUSD`
+// reconciles with the DefiLlama TVL). The host needs a browser User-Agent.
+const POOLS_URL = "https://api.prjx.com/pools";
+const HEADERS = { "User-Agent": "Mozilla/5.0" };
+const PAGE_LIMIT = 100; // API caps a page at 100
+
+interface Pool {
+  volume24h: string;
+  fee24h: string;
+}
+
+interface PoolsResponse {
+  pools: Pool[];
+  totalCount: number;
+}
+
+// The endpoint pages by offset/limit (max 100), so walk offsets up to totalCount.
+const fetchAllPools = async (): Promise<Pool[]> => {
+  const first: PoolsResponse = await httpGet(`${POOLS_URL}?limit=${PAGE_LIMIT}&offset=0`, { headers: HEADERS });
+  if (!Array.isArray(first?.pools)) throw new Error("Project X: pools unavailable");
+  const pools = [...first.pools];
+  const total = Number(first.totalCount);
+  for (let offset = PAGE_LIMIT; offset < total; offset += PAGE_LIMIT) {
+    const page: PoolsResponse = await httpGet(`${POOLS_URL}?limit=${PAGE_LIMIT}&offset=${offset}`, {
+      headers: HEADERS,
+    });
+    if (!Array.isArray(page?.pools)) throw new Error("Project X: pools page unavailable");
+    pools.push(...page.pools);
+  }
+  return pools;
+};
+
+const fetch = async () => {
+  const dailyVolume = (await fetchAllPools()).reduce((acc, pool) => {
+    const volume = Number(pool.volume24h);
+    if (!Number.isFinite(volume)) throw new Error(`Project X: invalid volume24h ${pool.volume24h}`);
+    return acc + volume;
+  }, 0);
+  return { dailyVolume };
+};
+
+const methodology = {
+  Volume: "Sum of the trailing-24h swap volume across Project X's pools (per-pool volume24h, USD), from the Project X pools API.",
+};
+
+const adapter: SimpleAdapter = {
+  adapter: {
+    [CHAIN.HYPERLIQUID]: {
+      fetch,
+      // The API exposes only a rolling 24h snapshot, so run at current time.
+      runAtCurrTime: true,
+      start: '2025-07-08',
+    },
+  },
+  methodology,
+};
+
+export default adapter;

--- a/fees/prjx/index.ts
+++ b/fees/prjx/index.ts
@@ -1,0 +1,67 @@
+import { httpGet } from "../../utils/fetchURL";
+import { FetchResultV2, SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+
+// Project X is a Uniswap-V3-style AMM on Hyperliquid L1. Its pools endpoint
+// returns a per-pool rolling 24h `fee24h` in USD (the summed `tvlUSD` reconciles
+// with the DefiLlama TVL). The host needs a browser User-Agent.
+const POOLS_URL = "https://api.prjx.com/pools";
+const HEADERS = { "User-Agent": "Mozilla/5.0" };
+const PAGE_LIMIT = 100; // API caps a page at 100
+
+interface Pool {
+  fee24h: string;
+}
+
+interface PoolsResponse {
+  pools: Pool[];
+  totalCount: number;
+}
+
+// The endpoint pages by offset/limit (max 100), so walk offsets up to totalCount.
+const fetchAllPools = async (): Promise<Pool[]> => {
+  const first: PoolsResponse = await httpGet(`${POOLS_URL}?limit=${PAGE_LIMIT}&offset=0`, { headers: HEADERS });
+  if (!Array.isArray(first?.pools)) throw new Error("Project X: pools unavailable");
+  const pools = [...first.pools];
+  const total = Number(first.totalCount);
+  for (let offset = PAGE_LIMIT; offset < total; offset += PAGE_LIMIT) {
+    const page: PoolsResponse = await httpGet(`${POOLS_URL}?limit=${PAGE_LIMIT}&offset=${offset}`, {
+      headers: HEADERS,
+    });
+    if (!Array.isArray(page?.pools)) throw new Error("Project X: pools page unavailable");
+    pools.push(...page.pools);
+  }
+  return pools;
+};
+
+const fetch = async (): Promise<FetchResultV2> => {
+  const dailyFees = (await fetchAllPools()).reduce((acc, pool) => {
+    const fee = Number(pool.fee24h);
+    if (!Number.isFinite(fee)) throw new Error(`Project X: invalid fee24h ${pool.fee24h}`);
+    return acc + fee;
+  }, 0);
+  // A Uniswap-V3-style AMM: the swap fee is paid by traders and accrues to the
+  // liquidity providers, so the same figure is user fees and supply-side revenue.
+  return { dailyFees, dailyUserFees: dailyFees, dailySupplySideRevenue: dailyFees };
+};
+
+const methodology = {
+  Fees: "Sum of the trailing-24h swap fees across Project X's pools (per-pool fee24h, USD), from the Project X pools API.",
+  UserFees: "Swap fees paid by traders.",
+  SupplySideRevenue: "All swap fees accrue to the liquidity providers.",
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  adapter: {
+    [CHAIN.HYPERLIQUID]: {
+      fetch,
+      // The API exposes only a rolling 24h snapshot, so run at current time.
+      runAtCurrTime: true,
+      start: '2025-07-08',
+    },
+  },
+  methodology,
+};
+
+export default adapter;

--- a/fees/prjx/index.ts
+++ b/fees/prjx/index.ts
@@ -1,47 +1,19 @@
-import { httpGet } from "../../utils/fetchURL";
 import { FetchResultV2, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
+import { fetchProjectXPools } from "../../helpers/prjx";
 
-// Project X is a Uniswap-V3-style AMM on Hyperliquid L1. Its pools endpoint
-// returns a per-pool rolling 24h `fee24h` in USD (the summed `tvlUSD` reconciles
-// with the DefiLlama TVL). The host needs a browser User-Agent.
-const POOLS_URL = "https://api.prjx.com/pools";
-const HEADERS = { "User-Agent": "Mozilla/5.0" };
-const PAGE_LIMIT = 100; // API caps a page at 100
-
-interface Pool {
-  fee24h: string;
-}
-
-interface PoolsResponse {
-  pools: Pool[];
-  totalCount: number;
-}
-
-// The endpoint pages by offset/limit (max 100), so walk offsets up to totalCount.
-const fetchAllPools = async (): Promise<Pool[]> => {
-  const first: PoolsResponse = await httpGet(`${POOLS_URL}?limit=${PAGE_LIMIT}&offset=0`, { headers: HEADERS });
-  if (!Array.isArray(first?.pools)) throw new Error("Project X: pools unavailable");
-  const pools = [...first.pools];
-  const total = Number(first.totalCount);
-  for (let offset = PAGE_LIMIT; offset < total; offset += PAGE_LIMIT) {
-    const page: PoolsResponse = await httpGet(`${POOLS_URL}?limit=${PAGE_LIMIT}&offset=${offset}`, {
-      headers: HEADERS,
-    });
-    if (!Array.isArray(page?.pools)) throw new Error("Project X: pools page unavailable");
-    pools.push(...page.pools);
-  }
-  return pools;
-};
-
+// Project X is a Uniswap-V3-style AMM on Hyperliquid L1, tracked on DefiLlama
+// for TVL but absent from /fees. Sum the per-pool rolling-24h USD swap fees.
 const fetch = async (): Promise<FetchResultV2> => {
-  const dailyFees = (await fetchAllPools()).reduce((acc, pool) => {
+  const dailyFees = (await fetchProjectXPools()).reduce((acc, pool) => {
     const fee = Number(pool.fee24h);
     if (!Number.isFinite(fee)) throw new Error(`Project X: invalid fee24h ${pool.fee24h}`);
     return acc + fee;
   }, 0);
-  // A Uniswap-V3-style AMM: the swap fee is paid by traders and accrues to the
-  // liquidity providers, so the same figure is user fees and supply-side revenue.
+  // A Uniswap-V3-style AMM: the pool swap fee is paid by traders and accrues to
+  // the liquidity providers, so the same figure is user fees and supply-side
+  // revenue. Project X does not publish a protocol-fee split, so none is
+  // deducted as protocol revenue.
   return { dailyFees, dailyUserFees: dailyFees, dailySupplySideRevenue: dailyFees };
 };
 

--- a/helpers/prjx.ts
+++ b/helpers/prjx.ts
@@ -8,6 +8,7 @@ import { httpGet } from "../utils/fetchURL";
 const POOLS_URL = "https://api.prjx.com/pools";
 const HEADERS = { "User-Agent": "Mozilla/5.0" };
 const PAGE_LIMIT = 100; // API caps a page at 100
+const PAGE_CONCURRENCY = 5; // parallel page requests after the first
 
 export interface PrjxPool {
   volume24h: string;
@@ -27,9 +28,13 @@ const fetchPage = async (offset: number): Promise<PrjxPool[]> => {
   return res.pools;
 };
 
-// Fetch page 1 to learn totalCount, then pull the remaining pages concurrently.
-// Fails closed on a missing/invalid totalCount or a short result rather than
-// silently under-reporting.
+/**
+ * Fetch every Project X pool. Reads page 1 to learn `totalCount`, then pulls the
+ * remaining pages concurrently. Fails closed on a missing/invalid `totalCount`
+ * or a short result rather than silently under-reporting.
+ *
+ * @returns All pools, each with its rolling-24h `volume24h` and `fee24h` (USD).
+ */
 export async function fetchProjectXPools(): Promise<PrjxPool[]> {
   const first: PoolsResponse = await httpGet(`${POOLS_URL}?limit=${PAGE_LIMIT}&offset=0`, { headers: HEADERS });
   if (!Array.isArray(first?.pools)) throw new Error("Project X: pools unavailable");
@@ -41,7 +46,7 @@ export async function fetchProjectXPools(): Promise<PrjxPool[]> {
 
   const offsets: number[] = [];
   for (let offset = PAGE_LIMIT; offset < total; offset += PAGE_LIMIT) offsets.push(offset);
-  const { results, errors } = await PromisePool.withConcurrency(5).for(offsets).process(fetchPage);
+  const { results, errors } = await PromisePool.withConcurrency(PAGE_CONCURRENCY).for(offsets).process(fetchPage);
   if (errors.length) throw new Error(`Project X: ${errors.length} pools page request(s) failed`);
 
   const pools = [...first.pools, ...results.flat()];

--- a/helpers/prjx.ts
+++ b/helpers/prjx.ts
@@ -1,0 +1,52 @@
+import { PromisePool } from "@supercharge/promise-pool";
+import { httpGet } from "../utils/fetchURL";
+
+// Project X is a Uniswap-V3-style AMM on Hyperliquid L1. Its pools endpoint
+// returns per-pool rolling-24h `volume24h` and `fee24h` in USD (the summed
+// `tvlUSD` reconciles with the DefiLlama TVL). The host needs a browser
+// User-Agent. Shared by dexs/prjx and fees/prjx.
+const POOLS_URL = "https://api.prjx.com/pools";
+const HEADERS = { "User-Agent": "Mozilla/5.0" };
+const PAGE_LIMIT = 100; // API caps a page at 100
+
+export interface PrjxPool {
+  volume24h: string;
+  fee24h: string;
+}
+
+interface PoolsResponse {
+  pools: PrjxPool[];
+  totalCount: number;
+}
+
+const fetchPage = async (offset: number): Promise<PrjxPool[]> => {
+  const res: PoolsResponse = await httpGet(`${POOLS_URL}?limit=${PAGE_LIMIT}&offset=${offset}`, {
+    headers: HEADERS,
+  });
+  if (!Array.isArray(res?.pools)) throw new Error("Project X: pools unavailable");
+  return res.pools;
+};
+
+// Fetch page 1 to learn totalCount, then pull the remaining pages concurrently.
+// Fails closed on a missing/invalid totalCount or a short result rather than
+// silently under-reporting.
+export async function fetchProjectXPools(): Promise<PrjxPool[]> {
+  const first: PoolsResponse = await httpGet(`${POOLS_URL}?limit=${PAGE_LIMIT}&offset=0`, { headers: HEADERS });
+  if (!Array.isArray(first?.pools)) throw new Error("Project X: pools unavailable");
+
+  const total = Number(first.totalCount);
+  if (!Number.isSafeInteger(total) || total < 0) {
+    throw new Error(`Project X: invalid totalCount ${first.totalCount}`);
+  }
+
+  const offsets: number[] = [];
+  for (let offset = PAGE_LIMIT; offset < total; offset += PAGE_LIMIT) offsets.push(offset);
+  const { results, errors } = await PromisePool.withConcurrency(5).for(offsets).process(fetchPage);
+  if (errors.length) throw new Error(`Project X: ${errors.length} pools page request(s) failed`);
+
+  const pools = [...first.pools, ...results.flat()];
+  if (pools.length < total) {
+    throw new Error(`Project X: expected ${total} pools, got ${pools.length}`);
+  }
+  return pools;
+}


### PR DESCRIPTION
closes #8828

### what

Adds **volume and fees adapters for Project X** (prjx), a Uniswap-V3-style AMM on Hyperliquid L1. It is tracked on DefiLlama for TVL (~$37.1M) but was absent from both `/dexs` and `/fees`.

### how

Project X's pools API returns per-pool USD figures, so both adapters are a paginated sum:

- **`dexs/prjx`** - `dailyVolume` = sum of per-pool `volume24h`.
- **`fees/prjx`** - `dailyFees` = sum of per-pool `fee24h`. It's a V3 AMM, so the swap fee is paid by traders (`dailyUserFees`) and accrues to the liquidity providers (`dailySupplySideRevenue`).
- The endpoint pages by `offset`/`limit` (max 100), so both walk offsets up to `totalCount` (335 pools). The host needs a browser `User-Agent`, which `httpGet` sends. It exposes only a rolling 24h snapshot, so both use `runAtCurrTime`.

### receipts

```
$ npx ts-node --transpile-only cli/testAdapter.ts dexs prjx
HYPERLIQUID 👇
Daily volume: 27.62 M

$ npx ts-node --transpile-only cli/testAdapter.ts fees prjx
Daily fees: 21.40 k
Daily user fees: 21.40 k
Daily supply side revenue: 21.40 k
```

The summed `tvlUSD` from the same response reconciles with the DefiLlama TVL (~$37.1M), confirming the figures are USD. `tsc --noEmit` clean.
