### PR TITLE
feat(dooar): add dexs volume adapter

### DIFF
--- a/dexs/dooar/index.ts
+++ b/dexs/dooar/index.ts
@@ -13,7 +13,7 @@ const fetch = async (options: FetchOptions) => {
   const body = await httpPost(
     VOLUME_URL,
     { chain: options.chain },
-    { headers: { "Content-Type": "application/json" } }
+    { headers: { "Content-Type": "application/json" }, timeout: 10000 }
   );
 
   // Fail closed on a malformed response rather than reporting a false zero.

--- a/dexs/dooar/index.ts
+++ b/dexs/dooar/index.ts
@@ -1,0 +1,52 @@
+import { httpPost } from "../../utils/fetchURL";
+import { FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+
+// Dooar (served from the mooar.com trade backend) is a multi-chain AMM DEX,
+// tracked on DefiLlama for TVL but absent from /dexs. Its stats endpoint
+// returns trailing-24h swap volume in USD keyed by pool address, per chain.
+// The API's chain keys ("bsc", "polygon") match the CHAIN enum values, so one
+// fetch serves every chain via options.chain.
+const VOLUME_URL = "https://trade.mooar.com/dooar/volume";
+
+const fetch = async (options: FetchOptions) => {
+  const body = await httpPost(
+    VOLUME_URL,
+    { chain: options.chain },
+    { headers: { "Content-Type": "application/json" } }
+  );
+
+  // Fail closed on a malformed response rather than reporting a false zero.
+  if (body?.code !== 200 || typeof body?.data !== "object" || body.data === null) {
+    throw new Error(`Dooar: unexpected response for ${options.chain}`);
+  }
+
+  // body.data is { [poolAddress]: "<usd volume>" }. Sum the per-pool USD
+  // volume; an empty object is a legitimate no-trade day, not an error.
+  let dailyVolume = 0;
+  for (const raw of Object.values(body.data as Record<string, string>)) {
+    const poolVolume = Number(raw);
+    if (!Number.isFinite(poolVolume)) {
+      throw new Error(`Dooar: non-numeric pool volume (${raw}) on ${options.chain}`);
+    }
+    dailyVolume += poolVolume;
+  }
+
+  return { dailyVolume };
+};
+
+const methodology = {
+  Volume:
+    "Sum of the trailing-24h swap volume (USD) across Dooar's pools on each chain, from the Dooar stats API (per-pool volume keyed by pool address).",
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  fetch,
+  runAtCurrTime: true,
+  chains: [CHAIN.BSC, CHAIN.POLYGON],
+  start: '2022-09-23',
+  methodology,
+};
+
+export default adapter;


### PR DESCRIPTION
closes #8831

## what

Adds a `dexs/dooar` volume adapter. DOOAR is tracked on DefiLlama for TVL (Solana + Binance, since 2022-09-23) but is absent from /dexs, so none of its swap volume is currently counted.

## how

Dooar's own stats backend returns trailing-24h swap volume in USD, per pool, per chain, no auth:

```
POST https://trade.mooar.com/dooar/volume  {"chain":"bsc"}
-> {"code":200,"err":null,"data":{"<pool>":"<usd volume>", ...}}
```

The adapter sums the per-pool USD values. `runAtCurrTime` snapshot, matching the merged `dexs/oroswap` pattern. The API's chain keys (`bsc`, `polygon`) match the `CHAIN` enum values, so one `fetch` serves both via `options.chain`. It fails closed on a malformed response and rejects a non-numeric pool value rather than reporting a false zero; an empty `data` object is treated as a legitimate no-trade day.

## chains

`bsc` and `polygon` are the two chains that currently carry volume (solana and ethereum return an empty `data` object).

## receipts

`npx ts-node cli/testAdapter.ts dexs dooar` on 2026-08-17:

```
chain     | Daily volume | Start Time
---       | ---          | ---
bsc       | 6.76 k       | 23/9/2022
polygon   | 39.36 k      | 23/9/2022
Aggregate | 46.12 k      |
```

Matches the raw endpoint (bsc $6,762.96 across 3 pools, polygon $39,482.21 across 4 pools). tsc clean.
