### PR TITLE
fix(rocketpool): count megapool rewards dropped since saturn 1

### DIFF
--- a/fees/rocketpool.ts
+++ b/fees/rocketpool.ts
@@ -140,10 +140,12 @@ async function fetch(options: FetchOptions): Promise<FetchResultV2> {
   const megapoolExistsKeys = minipoolAddresses.map((address) =>
     ethers.solidityPackedKeccak256(['string', 'address'], ['megapool.exists', address])
   );
+  // getBool returns false for an unset key and never reverts, so unlike the
+  // minipool getters above it needs no permitFailure - letting a genuine RPC
+  // failure throw is preferable to silently dropping a megapool's rewards.
   const isMegapool = await options.api.multiCall({
     abi: 'function getBool(bytes32) view returns (bool)',
     calls: megapoolExistsKeys.map((key) => ({ target: rocketStorage, params: [key] })),
-    permitFailure: true,
   })
   // Scope RewardsDistributed to confirmed megapool emitters. Its topic0 is a
   // plain five-uint256 signature that unrelated contracts also emit, so an
@@ -156,6 +158,11 @@ async function fetch(options: FetchOptions): Promise<FetchResultV2> {
       eventAbi: 'event RewardsDistributed(uint256 nodeAmount, uint256 voterAmount, uint256 rethAmount, uint256 protocolDaoAmount, uint256 time)',
     })
     for (const log of rewardsDistributedLogs) {
+      // The full beacon reward is counted as fees and flows to supply side, the
+      // same as the minipool path above. Saturn 1 added a voter share (~9%) and
+      // a protocol-DAO share (currently 0%) that are arguably protocol revenue
+      // rather than supply-side; reclassifying them is left to a follow-up so
+      // this change stays scoped to the dropped-fees fix (see #8812).
       const beaconReward = Number(log.nodeAmount) + Number(log.voterAmount) + Number(log.rethAmount) + Number(log.protocolDaoAmount)
       dailyFees.addGasToken(beaconReward, METRIC.STAKING_REWARDS)
     }

--- a/fees/rocketpool.ts
+++ b/fees/rocketpool.ts
@@ -1,4 +1,5 @@
 import * as sdk from "@defillama/sdk";
+import { ethers } from "ethers";
 import ADDRESSES from '../helpers/coreAssets.json'
 import { Adapter, FetchOptions, FetchResultV2 } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
@@ -126,7 +127,40 @@ async function fetch(options: FetchOptions): Promise<FetchResultV2> {
 
     dailyFees.addGasToken(rewardFromBeacon, METRIC.STAKING_REWARDS)
   }
-  
+
+  // Since Saturn 1, node operators can run megapools instead of minipools.
+  // Megapools deposit their rETH reward share through the same EtherDeposited
+  // event, but do not implement getNodeDepositBalance/getNodeFee, so they
+  // revert above and are skipped by the minipool loop. Pick them up from their
+  // own RewardsDistributed event. The node leg is defined on-chain as the
+  // residual (nodeAmount = reward - the other three legs), so the four legs sum
+  // exactly to the full pre-split beacon reward - the megapool analogue of the
+  // minipool rewardFromBeacon above, with no bond/commission gross-up needed.
+  const rocketStorage = '0x1d8f8f00cfa6758d7bE78336684788Fb0ee0Fa46';
+  const megapoolExistsKeys = minipoolAddresses.map((address) =>
+    ethers.solidityPackedKeccak256(['string', 'address'], ['megapool.exists', address])
+  );
+  const isMegapool = await options.api.multiCall({
+    abi: 'function getBool(bytes32) view returns (bool)',
+    calls: megapoolExistsKeys.map((key) => ({ target: rocketStorage, params: [key] })),
+    permitFailure: true,
+  })
+  // Scope RewardsDistributed to confirmed megapool emitters. Its topic0 is a
+  // plain five-uint256 signature that unrelated contracts also emit, so an
+  // unscoped scan would overcount; the EtherDeposited senders are the natural,
+  // already-collected candidate set.
+  const megapoolAddresses = minipoolAddresses.filter((_, i) => isMegapool[i] === true)
+  if (megapoolAddresses.length > 0) {
+    const rewardsDistributedLogs = await options.getLogs({
+      targets: megapoolAddresses,
+      eventAbi: 'event RewardsDistributed(uint256 nodeAmount, uint256 voterAmount, uint256 rethAmount, uint256 protocolDaoAmount, uint256 time)',
+    })
+    for (const log of rewardsDistributedLogs) {
+      const beaconReward = Number(log.nodeAmount) + Number(log.voterAmount) + Number(log.rethAmount) + Number(log.protocolDaoAmount)
+      dailyFees.addGasToken(beaconReward, METRIC.STAKING_REWARDS)
+    }
+  }
+
   // MEV and execution rewards
   const transactions = await sdk.indexer.getTransactions({
     chain: options.chain,


### PR DESCRIPTION
closes #8812

## the bug

`fees/rocketpool.ts` reads rETH `EtherDeposited` and, for each sender, calls the minipool getters `getNodeDepositBalance()`/`getNodeFee()`; if either is null it `continue`s. Since Saturn 1, node operators can run **megapools**, which deposit their rETH reward share through the same event but do not implement those getters, so they revert and hit the `continue` - their rewards are silently dropped. #8812 measured 78.23 ETH dropped across 53 deposits / 31 megapools.

## the fix

After the minipool loop, pick megapools up from their own `RewardsDistributed` event:

1. Filter the `EtherDeposited` senders to confirmed megapools via `rocketStorage.getBool(keccak256("megapool.exists", addr))`.
2. Read `RewardsDistributed(nodeAmount, voterAmount, rethAmount, protocolDaoAmount, time)` scoped to those addresses.
3. Sum the four amount legs into `dailyFees`.

The four legs sum **exactly** to the full pre-split beacon reward: on-chain the node leg is defined as the residual (`nodeAmount = reward - the other three`), so no bond/commission gross-up is needed and it is robust to bond-ratio variation across megapools. This is the megapool analogue of the minipool `rewardFromBeacon`, so mixing both in `dailyFees` is apples-to-apples.

The minipool loop keeps dropping megapool `EtherDeposited` (getters revert), so each megapool distribution is counted once, here, at full value - no double count.

## why scoped, and why no principal leaks in

- `RewardsDistributed` is a plain five-uint256 signature that unrelated contracts also emit, so it is scoped to confirmed megapool emitters (the already-collected `EtherDeposited` senders), never an unscoped topic scan.
- A validator **exit** does not route through this event: `RewardsDistributed` is emitted at a single site (`_distributeAmount`), which is guarded `require(numExitingValidators == 0)` + `require(numLockedValidators == 0)`, and exit capital is dispersed by the separate `_notifyFinalBalance` path (which emits no `RewardsDistributed`). So the leg-sum is pure reward, never ~32 ETH of principal.

## scope

This counts the previously-dropped megapool rewards, consistent with the existing minipool treatment (full reward to `dailyFees` -> supply side, revenue stays 0). Saturn 1 added a voter share (~9%) and protocol-DAO share (0% today) that are arguably protocol revenue; reclassifying them is left to a follow-up per the reporter's request, and noted in a code comment.

## receipts (on-chain, 2026-08-17)

Validated the exact adapter logic against mainnet via an archive RPC:

- `megapool.exists` -> **true** for a real megapool (`0x3fe4...46f4`), **false** for a minipool and for rETH itself (detection, no false positives).
- A real `RewardsDistributed` log summed `nodeAmount + voterAmount + rethAmount + protocolDaoAmount = 1.5755 ETH`, with `voterAmount / rethAmount = 0.104651 = 9/86` exactly - matching the ground-truth ratio in #8812, confirming the leg-sum and that these are genuine Saturn-1 distributions.

The adapter can't be run end-to-end locally (the pre-existing MEV branch needs a Llama indexer key), so the new megapool path was validated in isolation as above. tsc clean.
