### PR TITLE
feat(curators): count RockawayX's Kamino kvaults on Solana

### DIFF
--- a/factory/curators.ts
+++ b/factory/curators.ts
@@ -411,6 +411,18 @@ const configs: Record<string, CuratorConfig> = {
         morpho: ['0x6137dcfdd3c83fe2922b1cba4105d2e92b327a06'],
         start: '2026-03-22',
       },
+      [CHAIN.SOLANA]: {
+        // Kamino kvaults curated by RockawayX. Both share vaultAdminAuthority
+        // 5WodE5oHa6Uy16zg4eTep9t6DqJKx7jFN6bomAm7bVQv, which owns exactly these
+        // two: "RWA USDC" (DWSX...) and "RockawayX SOL" (Hoff...). The third vault
+        // listed under RockawayX on the TVL side ("Marinade USD", 2TNC...) has a
+        // different admin authority, so it is not attributed here.
+        kaminoVaults: [
+          'DWSXb18xZApz29vnQpgR2m6MynCT7PznaXt7Ut7M7KaP',
+          'HoffqVZUNGGpEAhE42E1DqNYSwJjCkorfgiBN6NpT2or',
+        ],
+        start: '2026-01-13',
+      },
     },
   },
   "seamless-vaults": {

--- a/helpers/curators/index.ts
+++ b/helpers/curators/index.ts
@@ -342,15 +342,12 @@ export async function getKaminoVaultFee(options: FetchOptions, balances: Balance
   const endDate = new Date((options.toTimestamp + 86400) * 1000).toISOString().split('T')[0]
   const elapsed = options.toTimestamp - options.fromTimestamp
 
-  const perVault = await Promise.all(vaults.map(async vault => {
+  for (const vault of vaults) {
     const [config, history] = await Promise.all([
       fetchURL(`${KAMINO_API}/kvaults/vaults/${vault}`),
       fetchURL(`${KAMINO_API}/kvaults/vaults/${vault}/metrics/history?start=${startDate}&end=${endDate}`),
     ])
-    return { config, history }
-  }))
 
-  for (const { config, history } of perVault) {
     const state = config?.state
     if (!state?.tokenMint) continue
 
@@ -359,7 +356,8 @@ export async function getKaminoVaultFee(options: FetchOptions, balances: Balance
     const perfFeeRate = Number(state.performanceFeeBps ?? 0) / 1e4
     const mgmtFeeRate = Number(state.managementFeeBps ?? 0) / 1e4
 
-    // `interest` is cumulative since inception, so the window yield is last - first.
+    // History is requested with a ±1 day pad (API is date-grained); keep only
+    // snapshots that fall inside this fetch window.
     const points: any[] = (Array.isArray(history) ? history : history?.history ?? [])
       .map((p: any) => ({ ...p, _ts: Date.parse(p.timestamp ?? p.date ?? '') / 1000 }))
       .filter((p: any) => isFinite(p._ts) && p._ts >= options.fromTimestamp && p._ts <= options.toTimestamp)
@@ -367,15 +365,16 @@ export async function getKaminoVaultFee(options: FetchOptions, balances: Balance
 
     let grossInterest = 0
     if (points.length >= 2) {
+      // `interest` is cumulative since inception, so the window yield is last - first.
       const delta = Number(points[points.length - 1].interest ?? 0) - Number(points[0].interest ?? 0)
       if (delta > 0) grossInterest = delta * 10 ** decimals
     }
 
     const perfFee = grossInterest * perfFeeRate
-    // `interest` is human-denominated (matches interestUsd) so grossInterest is
-    // scaled above; `prevAum` is already in raw base units, so the management
-    // fee needs no extra scale. Matches fees/sentora.ts.
-    const mgmtFee = Number(state.prevAum ?? 0) * mgmtFeeRate * elapsed / YEAR_SECS
+    // History `tvl` and `interest` are human-denominated; scale both to raw units.
+    // Use the first in-window snapshot so mgmt fee tracks that day's AUM, not live prevAum.
+    const tvl = Number(points[0]?.tvl ?? 0)
+    const mgmtFee = tvl * 10 ** decimals * mgmtFeeRate * elapsed / YEAR_SECS
 
     if (grossInterest > 0) {
       if (breakdownFees) {

--- a/helpers/curators/index.ts
+++ b/helpers/curators/index.ts
@@ -2,6 +2,10 @@ import * as sdk from "@defillama/sdk";
 import { BaseAdapter, FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { ABI, EulerConfigs, MorphoConfigs } from "./configs";
 import { CHAIN } from "../chains";
+import fetchURL from "../../utils/fetchURL";
+
+const KAMINO_API = 'https://api.kamino.finance';
+const YEAR_SECS = 365 * 24 * 60 * 60;
 
 const METRICS = {
   // use this label for all yield sources if breakdownFees was not set
@@ -18,6 +22,10 @@ const METRICS = {
   EulerYields: 'Euler Yields',
   EulerYieldsToSuppliers: 'Euler Yields Distributed To Supliers',
   EulerPerformanceFee: 'Euler Performance Fees',
+  KaminoYields: 'Kamino Yields',
+  KaminoYieldsToSuppliers: 'Kamino Yields Distributed To Supliers',
+  KaminoPerformanceFee: 'Kamino Performance Fees',
+  KaminoManagementFee: 'Kamino Management Fees',
 }
 
 export interface CuratorConfig {
@@ -37,6 +45,10 @@ export interface CuratorConfig {
 
       // creators of euler vaults
       eulerVaultOwners?: Array<string>;
+
+      // Kamino kvault addresses (Solana). Curated vaults are attributed by
+      // vaultAdminAuthority off-chain; only the confirmed addresses are listed.
+      kaminoVaults?: Array<string>;
     }
   }
 }
@@ -319,6 +331,71 @@ export async function getEulerVaultFee(options: FetchOptions, balances: Balances
   }
 }
 
+// Kamino kvaults (Solana). Mirrors the accounting in fees/sentora.ts: the vault's
+// cumulative `interest` metric is read at the window bounds and the delta is the
+// gross yield; the performance fee (performanceFeeBps) is curator revenue, the
+// rest is supply side. Management fee (managementFeeBps) accrues per-second on AUM.
+export async function getKaminoVaultFee(options: FetchOptions, balances: Balances, vaults: Array<string>, breakdownFees?: boolean) {
+  if (!vaults.length) return
+
+  const startDate = new Date((options.fromTimestamp - 86400) * 1000).toISOString().split('T')[0]
+  const endDate = new Date((options.toTimestamp + 86400) * 1000).toISOString().split('T')[0]
+  const elapsed = options.toTimestamp - options.fromTimestamp
+
+  const perVault = await Promise.all(vaults.map(async vault => {
+    const [config, history] = await Promise.all([
+      fetchURL(`${KAMINO_API}/kvaults/vaults/${vault}`),
+      fetchURL(`${KAMINO_API}/kvaults/vaults/${vault}/metrics/history?start=${startDate}&end=${endDate}`),
+    ])
+    return { config, history }
+  }))
+
+  for (const { config, history } of perVault) {
+    const state = config?.state
+    if (!state?.tokenMint) continue
+
+    const tokenMint = state.tokenMint as string
+    const decimals = Number(state.tokenMintDecimals ?? 0) || 6
+    const perfFeeRate = Number(state.performanceFeeBps ?? 0) / 1e4
+    const mgmtFeeRate = Number(state.managementFeeBps ?? 0) / 1e4
+
+    // `interest` is cumulative since inception, so the window yield is last - first.
+    const points: any[] = (Array.isArray(history) ? history : history?.history ?? [])
+      .map((p: any) => ({ ...p, _ts: Date.parse(p.timestamp ?? p.date ?? '') / 1000 }))
+      .filter((p: any) => isFinite(p._ts) && p._ts >= options.fromTimestamp && p._ts <= options.toTimestamp)
+      .sort((a: any, b: any) => a._ts - b._ts)
+
+    let grossInterest = 0
+    if (points.length >= 2) {
+      const delta = Number(points[points.length - 1].interest ?? 0) - Number(points[0].interest ?? 0)
+      if (delta > 0) grossInterest = delta * 10 ** decimals
+    }
+
+    const perfFee = grossInterest * perfFeeRate
+    // `interest` is human-denominated (matches interestUsd) so grossInterest is
+    // scaled above; `prevAum` is already in raw base units, so the management
+    // fee needs no extra scale. Matches fees/sentora.ts.
+    const mgmtFee = Number(state.prevAum ?? 0) * mgmtFeeRate * elapsed / YEAR_SECS
+
+    if (grossInterest > 0) {
+      if (breakdownFees) {
+        balances.dailyFees.add(tokenMint, grossInterest, METRICS.KaminoYields)
+        balances.dailyRevenue.add(tokenMint, perfFee, METRICS.KaminoPerformanceFee)
+        balances.dailySupplySideRevenue.add(tokenMint, grossInterest - perfFee, METRICS.KaminoYieldsToSuppliers)
+      } else {
+        balances.dailyFees.add(tokenMint, grossInterest, METRICS.AssetYields)
+        balances.dailyRevenue.add(tokenMint, perfFee, METRICS.AssetYields)
+        balances.dailySupplySideRevenue.add(tokenMint, grossInterest - perfFee, METRICS.AssetYields)
+      }
+    }
+    if (mgmtFee > 0) {
+      const label = breakdownFees ? METRICS.KaminoManagementFee : METRICS.AssetYields
+      balances.dailyFees.add(tokenMint, mgmtFee, label)
+      balances.dailyRevenue.add(tokenMint, mgmtFee, label)
+    }
+  }
+}
+
 async function getMorphoVaultV2Fee(options: FetchOptions, balances: Balances, vaults: Array<string>, breakdownFees?: boolean) {
   const vaultInfo = await getVaultERC4626Info(options, vaults, true)
   const vaultPerformanceFeeRates = await options.api.multiCall({
@@ -380,17 +457,22 @@ export function getCuratorExport(curatorConfig: CuratorConfig): SimpleAdapter {
       [METRICS.MorphoYields]: 'Interest yields generated from deposited assets in Morpho',
       [METRICS.MorphoManagementFee]: 'Management fees charged on assets deposited in Morpho vaults',
       [METRICS.EulerYields]: 'Interest yields generated from deposited assets in Euler',
+      [METRICS.KaminoYields]: 'Interest yields generated from deposited assets in Kamino kvaults',
+      [METRICS.KaminoManagementFee]: 'Management fees charged on assets deposited in Kamino kvaults',
     },
     Revenue: {
       [METRICS.AssetYields]: 'Portion of interest yields retained by vault curators as management and performance fees',
       [METRICS.MorphoPerformanceFee]: 'Performance fees charged from vaults in Morpho',
       [METRICS.MorphoManagementFee]: 'Management fees charged from vaults in Morpho',
       [METRICS.EulerPerformanceFee]: 'Performance fees charged from vaults in Euler',
+      [METRICS.KaminoPerformanceFee]: 'Performance fees charged from Kamino kvaults',
+      [METRICS.KaminoManagementFee]: 'Management fees charged from Kamino kvaults',
     },
     SupplySideRevenue: {
       [METRICS.AssetYields]: 'Portion of interest yields distributed to vault depositors/investors after curator fees are deducted',
       [METRICS.MorphoYieldsToSuppliers]: 'Interest yields generated from deposited assets in Morpho distributed to suppliers',
       [METRICS.EulerYieldsToSuppliers]: 'Interest yields generated from deposited assets in Euler distributed to suppliers',
+      [METRICS.KaminoYieldsToSuppliers]: 'Interest yields from Kamino kvaults distributed to suppliers',
     },
   }
   const exportObject: BaseAdapter = {}
@@ -424,6 +506,9 @@ export function getCuratorExport(curatorConfig: CuratorConfig): SimpleAdapter {
         }
         if (eulerVaults.length > 0) {
           await getEulerVaultFee(options, { dailyFees, dailyRevenue, dailySupplySideRevenue }, eulerVaults, curatorConfig.breakdownFees)
+        }
+        if (vaults.kaminoVaults && vaults.kaminoVaults.length > 0) {
+          await getKaminoVaultFee(options, { dailyFees, dailyRevenue, dailySupplySideRevenue }, vaults.kaminoVaults, curatorConfig.breakdownFees)
         }
 
         const blacklistedTokensForChain = blacklistedTokens[options.chain]?.filter(token => options.dateString >= token.from)?.map(token => token.token)


### PR DESCRIPTION
closes #8708

## what

RockawayX curates two Kamino kvaults on Solana (RWA USDC + RockawayX SOL) that the curator framework had no path to, so ~$3.8k/day of gross yield and its 5% curator revenue went uncounted. This adds Kamino (Solana) support to the framework and attributes those two vaults to RockawayX.

## how

`factory/curators.ts` auto-generates a fees adapter per curator via `getCuratorExport`, which was EVM-only (Morpho/Euler). This change:

1. Adds an optional `kaminoVaults?: string[]` field to the per-chain `CuratorConfig`.
2. Adds a `getKaminoVaultFee` helper that reads `api.kamino.finance/kvaults/vaults/<addr>` + `/metrics/history`, takes the cumulative `interest` delta over the window as gross yield, books `performanceFeeBps` as curator revenue and the rest as supply side. This mirrors the accrual already shipped in `fees/sentora.ts` (`accrueKamino`).
3. Calls it behind a guard (`if (vaults.kaminoVaults?.length)`) after the Euler block, so **existing EVM curators are untouched** - they set no `kaminoVaults`.
4. Adds the two vault addresses under a `[CHAIN.SOLANA]` entry on the `rockawayx` config.

Attribution is by `vaultAdminAuthority`: both vaults are owned by `5WodE5oHa6Uy16zg4eTep9t6DqJKx7jFN6bomAm7bVQv`. The third vault listed under RockawayX on the TVL side ("Marinade USD", `2TNC...`) has a different admin authority, so it is deliberately excluded.

## on the fees/kamino-lending overlap

A kvault's `interest` is a slice of the same borrower-paid dollars `fees/kamino-lending` books, the same way Morpho curators overlap morpho-blue. This mirrors the treatment already accepted for `fees/sentora.ts`'s Kamino leg (no `doublecounted` flag today); if that gets a systemic decision it should apply to both Sentora and RockawayX together.

## receipts

`npx ts-node cli/testAdapter.ts fees rockawayx` on 2026-08-17:

```
chain     | Daily fees | Daily revenue | Daily supply side revenue | Start Time
---       | ---        | ---           | ---                       | ---
ethereum  | 7.47 k     | 330.00        | 7.14 k                    | 6/3/2026
base      | 0.00       | 0.00          | 0.00                      | 1/6/2026
bsc       | 0.00       | 0.00          | 0.00                      | 16/4/2026
sei       | 2.17 k     | 326.00        | 1.84 k                    | 22/3/2026
solana    | 3.78 k     | 189.00        | 3.59 k                    | 13/1/2026
```

The new solana leg is $3,780/day gross, $189 revenue (exactly 5% = the vaults' `performanceFeeBps` of 500), $3,591 supply side - matching the ~$3-4k/day the issue estimated. The EVM legs are unchanged from before this PR (additive change). tsc clean.
