### PR TITLE
[feat] OVERDOG - add Polymarket builder volume

### DIFF
--- a/factory/polymarket.ts
+++ b/factory/polymarket.ts
@@ -30,6 +30,7 @@ const dexsConfigs: Record<string, { builder: string; start: string; builderCode?
   "yeno": { builder: "yeno-markets", start: "2026-06-26", builderCode: "0x5bffd61a6dbfca06f19a543cac4b9e433378ac9992d70b8a40824720e353498f" },
   "smartx": { builder: "SmartX", start: "2026-02-27", builderCode: "0x58d3820045831c879b218ec64514dc191eebadf31a4641670293fddf542643c3" },
   "virae": { builder: "Virae.ai", start: "2026-05-02", builderCode: "0xcb5f0c1b63c47ad9193a5d1a95a2055076eec604be4abb019025dd0e3554a7cc" },
+  "overdog": { builder: "OVERDOG", start: "2026-03-27", builderCode: "0x21d90db23c70a5901c0ee20f0ee20cf7f98fce24795a4e99cbf79cf0d8d63905" },
 };
 
 const feesConfigs: Record<string, { builderName: string; builderCode: string; start: string }> = {


### PR DESCRIPTION
## Add OVERDOG Polymarket builder volume

Adds OVERDOG to the existing Polymarket builder factory for attributed daily notional volume and cash volume.

The adapter uses Polymarket's public builder APIs and the verified OVERDOG builder code. It does not report TVL, because OVERDOG is a betting interface over Polymarket and does not operate a separate liquidity protocol.

**No `feesConfigs` entry is included, deliberately.** OVERDOG does not charge through Polymarket's v2 builder-fee mechanism — its own fee is taken by its gateway, outside Polymarket. `builderFee` on `/builder/trades` is `0` for every day sampled (2026-08-09, -11, -14, -16), so a fees adapter would report zero indefinitely. Happy to add one later if that ever changes.

### Listing metadata

##### Name (to be shown on DefiLlama):

OVERDOG

##### Twitter Link:

https://x.com/overdog_bet

##### List of audit links if any:

N/A — this submission covers an interface and its Polymarket-attributed activity, not a new custody contract.

##### Website Link:

https://overdog.bet

##### Logo (High resolution, will be shown with rounded borders):

https://overdog.bet/icon-512.png

##### Current TVL:

N/A — OVERDOG does not claim protocol TVL.

##### Treasury Addresses (if the protocol has treasury):

N/A — no treasury contract, and no Polymarket builder-fee revenue to route (see the note above).

##### Chain:

Polygon

##### Coingecko ID:

N/A

##### Coinmarketcap ID:

N/A

##### Short Description (to be shown on DefiLlama):

A sportsbook built on Polymarket liquidity — 19 sports and 12 esports with live in-play markets, multi-leg parlays across markets, and USDT deposits with no KYC.

##### Token address and ticker if any:

N/A

##### Category:

Interface

##### Oracle Provider(s):

OVERDOG does not operate a market-resolution oracle; the tracked markets and their resolution are provided by Polymarket.

##### Implementation Details:

The adapter queries Polymarket's public daily builder-volume series and the CLOB Builder Trades endpoint using OVERDOG's verified builder identity and builder code.

##### Documentation/Proof:

- https://docs.polymarket.com/api-reference/builders/get-daily-builder-volume-time-series
- https://docs.polymarket.com/api-reference/trade/get-builder-trades
- https://builders.polymarket.com/ — OVERDOG is listed as a verified builder
- https://docs.overdog.bet/

##### forkedFrom:

No.

##### methodology:

- Notional volume: Polymarket's daily builder-volume series for the verified `OVERDOG` builder. Note this series is denominated in **contracts**, not USD.
- Cash volume: sum of `sizeUsdc` over the builder's attributed CLOB trades for the day.
- Fees: not tracked — see the note above.

##### Github org/user:

Closed source. PR submitted from https://github.com/Kocher1

##### Does this project have a referral program?

Yes.

### Verification

`2026-08-17` (covering the 2026-08-16 UTC day):

```text
ts-node --transpile-only cli/testAdapter.ts dexs overdog 2026-08-17

🦙 Running OVERDOG adapter from polymarket factory 🦙
---------------------------------------------------
Start Date:     Sun, 16 Aug 2026 00:00:00 GMT
End Date:       Mon, 17 Aug 2026 00:00:00 GMT
---------------------------------------------------

POLYGON 👇
Backfill start time: 27/3/2026
Daily notional volume: 11.21 k
Daily volume: 6.36 k
```

Cross-checked independently against the upstream APIs for the same day — `11206.85` from the daily
builder series, and `6357.98` summed from `sizeUsdc` over 185 attributed trades — which match the
adapter's output.

```text
tsc --project tsconfig.json
passed
```
