### PR TITLE
feat: add Prism Network fees adapter

### DIFF
--- a/fees/prism-network/index.ts
+++ b/fees/prism-network/index.ts
@@ -1,0 +1,52 @@
+import { Adapter, FetchOptions } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+
+// Prism Network rents GPUs by the second. A renter funds an escrow up front and
+// the escrow finalises the lease onchain, splitting what was actually consumed
+// between the protocol and the operator whose machine served it. Unused deposit
+// is refunded in the same transaction and is not a fee.
+const ESCROW = "0x62C042265991bEa17B07229322A01850974626dA";
+const USDG = "0x5fc5360D0400a0Fd4f2af552ADD042D716F1d168";
+
+// `charged` is what the renter paid for the time consumed, and it is exactly
+// `fee + providerPaid`, so the three metrics come from one event with no
+// double counting and no price lookup of our own.
+const LEASE_FINALIZED =
+  "event LeaseFinalized(uint256 indexed leaseId, uint256 charged, uint256 fee, uint256 providerPaid, uint256 refunded, bytes32 receiptHash)";
+
+const fetch = async (options: FetchOptions) => {
+  const dailyFees = options.createBalances();
+  const dailyRevenue = options.createBalances();
+  const dailySupplySideRevenue = options.createBalances();
+
+  const logs = await options.getLogs({ target: ESCROW, eventAbi: LEASE_FINALIZED });
+  for (const log of logs) {
+    dailyFees.add(USDG, log.charged);
+    dailyRevenue.add(USDG, log.fee);
+    dailySupplySideRevenue.add(USDG, log.providerPaid);
+  }
+
+  return {
+    dailyFees,
+    dailyRevenue,
+    dailyProtocolRevenue: dailyRevenue,
+    dailySupplySideRevenue,
+  };
+};
+
+const methodology = {
+  Fees: "USDG charged to renters when a GPU lease is finalised onchain. Deposits are taken up front but only the time actually consumed is charged; the unused remainder is refunded in the same transaction and is not counted.",
+  Revenue: "The protocol's share of each finalised lease, currently 10% of the amount charged.",
+  ProtocolRevenue: "Same as revenue. The protocol's share accrues to the Prism treasury and none of it is distributed to token holders.",
+  SupplySideRevenue: "The remainder of each finalised lease, paid to the operator whose GPU served it.",
+};
+
+const adapter: Adapter = {
+  version: 2,
+  methodology,
+  adapter: {
+    [CHAIN.ROBINHOOD]: { fetch, start: "2026-08-13" },
+  },
+};
+
+export default adapter;

--- a/fees/prism-network/index.ts
+++ b/fees/prism-network/index.ts
@@ -14,6 +14,10 @@ const USDG = "0x5fc5360D0400a0Fd4f2af552ADD042D716F1d168";
 const LEASE_FINALIZED =
   "event LeaseFinalized(uint256 indexed leaseId, uint256 charged, uint256 fee, uint256 providerPaid, uint256 refunded, bytes32 receiptHash)";
 
+const GPU_LEASE_RENT = "GPU Lease Rent";
+const GPU_LEASE_RENT_TO_PROTOCOL = "GPU Lease Rent To Protocol";
+const GPU_LEASE_RENT_TO_PROVIDERS = "GPU Lease Rent To Providers";
+
 const fetch = async (options: FetchOptions) => {
   const dailyFees = options.createBalances();
   const dailyRevenue = options.createBalances();
@@ -21,9 +25,9 @@ const fetch = async (options: FetchOptions) => {
 
   const logs = await options.getLogs({ target: ESCROW, eventAbi: LEASE_FINALIZED });
   for (const log of logs) {
-    dailyFees.add(USDG, log.charged);
-    dailyRevenue.add(USDG, log.fee);
-    dailySupplySideRevenue.add(USDG, log.providerPaid);
+    dailyFees.add(USDG, log.charged, GPU_LEASE_RENT);
+    dailyRevenue.add(USDG, log.fee, GPU_LEASE_RENT_TO_PROTOCOL);
+    dailySupplySideRevenue.add(USDG, log.providerPaid, GPU_LEASE_RENT_TO_PROVIDERS);
   }
 
   return {
@@ -37,16 +41,33 @@ const fetch = async (options: FetchOptions) => {
 const methodology = {
   Fees: "USDG charged to renters when a GPU lease is finalised onchain. Deposits are taken up front but only the time actually consumed is charged; the unused remainder is refunded in the same transaction and is not counted.",
   Revenue: "The protocol's share of each finalised lease, currently 10% of the amount charged.",
-  ProtocolRevenue: "Same as revenue. The protocol's share accrues to the Prism treasury and none of it is distributed to token holders.",
+  ProtocolRevenue: "Same as revenue (10% of GPU lease amount). The protocol's share accrues to the Prism treasury and none of it is distributed to token holders.",
   SupplySideRevenue: "The remainder of each finalised lease, paid to the operator whose GPU served it.",
+};
+
+const breakdownMethodology = {
+  Fees: {
+    [GPU_LEASE_RENT]: "USDG charged for GPU time actually consumed when a lease is finalised. Unused deposit is refunded in the same transaction and is not counted.",
+  },
+  Revenue: {
+    [GPU_LEASE_RENT_TO_PROTOCOL]: "Protocol share of each finalised GPU lease, currently 10% of the amount charged.",
+  },
+  ProtocolRevenue: {
+    [GPU_LEASE_RENT_TO_PROTOCOL]: "Protocol share of each finalised GPU lease, currently 10% of the amount charged, accruing to the Prism treasury.",
+  },
+  SupplySideRevenue: {
+    [GPU_LEASE_RENT_TO_PROVIDERS]: "Remainder of each finalised GPU lease, paid to the operator whose GPU served it.",
+  },
 };
 
 const adapter: Adapter = {
   version: 2,
+  pullHourly: true,
   methodology,
-  adapter: {
-    [CHAIN.ROBINHOOD]: { fetch, start: "2026-08-13" },
-  },
+  breakdownMethodology,
+  chains: [CHAIN.ROBINHOOD],
+  start: "2026-08-13",
+  fetch,
 };
 
 export default adapter;


### PR DESCRIPTION
Prism Network rents GPUs by the second on Robinhood Chain (`CHAIN.ROBINHOOD`, already tracked by DefiLlama). A renter funds an escrow up front and the escrow finalises the lease on chain.

## Methodology

One event carries all three metrics, so nothing is double counted and no price lookup is needed beyond USDG, which DefiLlama already prices on this chain:

```
LeaseFinalized(leaseId, charged, fee, providerPaid, refunded, receiptHash)
```

`charged` is what the renter paid for the time actually consumed, and it is exactly `fee + providerPaid`. Deposits are taken up front, but the unused remainder is refunded in the same transaction and is not counted as a fee.

| Metric | Source |
| --- | --- |
| `dailyFees` | `charged` |
| `dailyRevenue`, `dailyProtocolRevenue` | `fee`, currently 10% |
| `dailySupplySideRevenue` | `providerPaid`, to the GPU operator |

## Testing

```
ROBINHOOD_RPC="https://rpc.mainnet.chain.robinhood.com" pnpm test fees prism-network
ROBINHOOD_RPC="https://rpc.mainnet.chain.robinhood.com" pnpm test fees prism-network 2026-08-15
```

Both pass. The backfill run was checked against an independent tally of the same logs: for 2026-08-14 both report 3.54 charged, 0.35 protocol, 3.19 supply side across 17 leases.

Escrow: `0x62C042265991bEa17B07229322A01850974626dA`
Start date: 2026-08-13, the first finalised lease.