### PR TITLE
[feat] FairyLaunch - add BSC fees and volume adapter

### DIFF
--- a/fees/fairylaunch/index.ts
+++ b/fees/fairylaunch/index.ts
@@ -5,15 +5,12 @@ import { CHAIN } from "../../helpers/chains";
 const FACTORY = '0x28163d7943AA6715a9559D468B29c0343412E236';
 const FEE_MANAGER = '0xb6A7D47596D2202676822531F56EFeCeac309775';
 
-// Bloque exacto de despliegue de LaunchFactory en BSC Mainnet
-const FACTORY_DEPLOY_BLOCK = 116127983;
+// Bloque de despliegue del Factory en BSC Mainnet
+const FACTORY_DEPLOY_BLOCK = 
+116127983; // Ajusta con el número de bloque exacto del despliegue
 
-// Repartición de comisiones: 50% Protocolo (Treasury), 50% Creador
 const TREASURY_SHARE_PERCENT = 50n;
-
-// Acumulador en memoria para evitar re-escaneo redundante en ejecuciones horarias
-let cachedCurves: string[] = [];
-let lastFetchedBlock = FACTORY_DEPLOY_BLOCK;
+const cachedCurves = new Set<string>();
 
 const methodology = {
   Volume: 'ethAmount from Buy events + gross ethAmount (ethAmount + fee) from Sell events across all BondingCurves',
@@ -24,53 +21,35 @@ const methodology = {
 };
 
 const fetch = async (options: FetchOptions) => {
-  const { createBalances, getLogs } = options;
-  const [fromBlock, toBlock] = await Promise.all([
-    options.getFromBlock(),
-    options.getToBlock(),
-  ]);
+  const dailyVolume = options.createBalances();
+  const dailyFees = options.createBalances();
+  const dailyRevenue = options.createBalances();
+  const dailyProtocolRevenue = options.createBalances();
+  const dailySupplySideRevenue = options.createBalances();
 
-  const dailyVolume = createBalances();
-  const dailyFees = createBalances();
-  const dailyRevenue = createBalances();
-  const dailyProtocolRevenue = createBalances();
-  const dailySupplySideRevenue = createBalances();
-
-  // Si la prueba corre fuera de orden o reinicia rangos, reseteamos la memoria
-  if (fromBlock && fromBlock < lastFetchedBlock) {
-    lastFetchedBlock = FACTORY_DEPLOY_BLOCK;
-    cachedCurves = [];
-  }
-
-  // 1. Búsqueda incremental de BondingCurves creadas entre el último bloque procesado y toBlock
-  const launchLogs = await getLogs({
+  // 1. Obtener TODAS las curvas creadas desde el despliegue del Factory
+  const launchLogs = await options.getLogs({
     target: FACTORY,
+    fromBlock: FACTORY_DEPLOY_BLOCK,
     eventAbi: 'event LaunchCreated(uint256 indexed launchId, address indexed creator, address indexed token, address bondingCurve, string name, string symbol, string metadataUri)',
-    fromBlock: lastFetchedBlock,
-    toBlock: toBlock,
-    maxBlockRange: 20000,
   });
 
   for (const log of launchLogs) {
     if (log.bondingCurve && log.bondingCurve !== '0x0000000000000000000000000000000000000000') {
-      cachedCurves.push(log.bondingCurve.toLowerCase());
+      cachedCurves.add(log.bondingCurve.toLowerCase());
     }
   }
 
-  if (toBlock) {
-    lastFetchedBlock = toBlock;
-  }
+  const uniqueCurves = Array.from(cachedCurves);
 
-  const uniqueCurves = [...new Set(cachedCurves)];
-
-  // 2. Procesar compras y ventas correspondientes al rango de la hora evaluada
+  // 2. Consultar compras/ventas de las curvas ÚNICAMENTE dentro del rango del slot actual
   if (uniqueCurves.length > 0) {
-    const buyLogs = await getLogs({
+    const buyLogs = await options.getLogs({
       targets: uniqueCurves,
       eventAbi: 'event Buy(address indexed buyer, uint256 indexed launchId, uint256 ethAmount, uint256 tokenAmount, uint256 fee, uint256 priceAfter, uint256 ethReserveAfter, uint256 timestamp)',
     });
 
-    const sellLogs = await getLogs({
+    const sellLogs = await options.getLogs({
       targets: uniqueCurves,
       eventAbi: 'event Sell(address indexed seller, uint256 indexed launchId, uint256 tokenAmount, uint256 ethAmount, uint256 fee, uint256 priceAfter, uint256 ethReserveAfter, uint256 timestamp)',
     });
@@ -105,8 +84,8 @@ const fetch = async (options: FetchOptions) => {
     }
   }
 
-  // 3. Procesar Recompensas de Graduación emitidas en la hora evaluada
-  const rewardLogs = await getLogs({
+  // 3. Consultar graduaciones del slot actual
+  const rewardLogs = await options.getLogs({
     target: FEE_MANAGER,
     eventAbi: 'event GraduationRewardRecorded(address indexed creator, uint256 creatorReward, uint256 treasuryReward)',
   });

--- a/fees/fairylaunch/index.ts
+++ b/fees/fairylaunch/index.ts
@@ -1,5 +1,6 @@
 import { Adapter, FetchOptions } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
+import ADDRESSES from '../../helpers/coreAssets.json';
 
 // Factory contract on BSC Mainnet: https://bscscan.com/address/0x28163d7943AA6715a9559D468B29c0343412E236
 const FACTORY = '0x28163d7943AA6715a9559D468B29c0343412E236';
@@ -23,123 +24,100 @@ const fetch = async (options: FetchOptions) => {
   const dailySupplySideRevenue = options.createBalances();
 
   // 1. Descubrimiento incremental de curvas vía RPC multicall
-  try {
-    const totalLaunchesBN = await options.api.call({
+  const totalLaunchesBN = await options.api.call({
+    target: FACTORY,
+    abi: 'function totalLaunches() view returns (uint256)',
+  });
+
+  const totalLaunches = Number(totalLaunchesBN || 0);
+
+  if (totalLaunches > discoveredLaunchCount) {
+    const newLaunchIds = Array.from(
+      { length: totalLaunches - discoveredLaunchCount },
+      (_, i) => discoveredLaunchCount + i + 1
+    );
+
+    const launches = await options.api.multiCall({
       target: FACTORY,
-      abi: 'function totalLaunches() view returns (uint256)',
+      abi: 'function getLaunch(uint256 launchId) view returns ((uint256 launchId, address creator, address treasury, address token, address bondingCurve, bool graduated, uint256 createdAt, uint256 graduatedAt, string name, string symbol, string metadataUri))',
+      calls: newLaunchIds.map((id) => ({ params: [id] })),
     });
 
-    const totalLaunches = Number(totalLaunchesBN || 0);
+    for (const launch of launches) {
+      if (launch?.bondingCurve && launch.bondingCurve !== ADDRESSES.null) {
+        cachedCurves.add(launch.bondingCurve.toLowerCase());
+      }
+    }
 
-    if (totalLaunches > discoveredLaunchCount) {
-      const newLaunchIds = Array.from(
-        { length: totalLaunches - discoveredLaunchCount },
-        (_, i) => discoveredLaunchCount + i + 1
-      );
+    // Actualizar cursor solo tras éxito en el recorrido
+    discoveredLaunchCount = totalLaunches;
+  }
 
-      const launches = await options.api.multiCall({
-        target: FACTORY,
-        abi: 'function getLaunch(uint256 launchId) view returns ((uint256 launchId, address creator, address treasury, address token, address bondingCurve, bool graduated, uint256 createdAt, uint256 graduatedAt, string name, string symbol, string metadataUri))',
-        calls: newLaunchIds.map((id) => ({ params: [id] })),
-      });
+  const uniqueCurves = Array.from(cachedCurves);
 
-      for (const launch of launches) {
-        if (launch?.bondingCurve && launch.bondingCurve !== '0x0000000000000000000000000000000000000000') {
-          cachedCurves.add(launch.bondingCurve.toLowerCase());
-        }
+  // 2. Procesar compras y ventas por lotes
+  const [buyLogs, sellLogs] = await Promise.all([
+    options.getLogs({
+      targets: uniqueCurves,
+      eventAbi:
+        'event Buy(address indexed buyer, uint256 indexed launchId, uint256 ethAmount, uint256 tokenAmount, uint256 fee, uint256 priceAfter, uint256 ethReserveAfter, uint256 timestamp)',
+      flatten: true,
+    }),
+    options.getLogs({
+      targets: uniqueCurves,
+      eventAbi:
+        'event Sell(address indexed seller, uint256 indexed launchId, uint256 tokenAmount, uint256 ethAmount, uint256 fee, uint256 priceAfter, uint256 ethReserveAfter, uint256 timestamp)',
+      flatten: true,
+    }),
+  ]);
+
+  for (const log of buyLogs) {
+    const ethAmount = BigInt(log.ethAmount || 0);
+    const totalFee = BigInt(log.fee || 0);
+
+    if (ethAmount > 0n) {
+      dailyVolume.addGasToken(ethAmount);
+    }
+
+    if (totalFee > 0n) {
+      dailyFees.addGasToken(totalFee, 'Trading Fees');
+
+      const treasuryFee = (totalFee * TREASURY_SHARE_PERCENT) / SHARE_DENOMINATOR;
+      const creatorFee = totalFee - treasuryFee;
+
+      if (treasuryFee > 0n) {
+        dailyProtocolRevenue.addGasToken(treasuryFee, 'Treasury Trading Fees');
       }
 
-      // Actualizar cursor solo tras éxito en el recorrido
-      discoveredLaunchCount = totalLaunches;
-    }
-  } catch (error) {
-    console.warn('Fairylaunch RPC curve discovery failed; using LaunchCreated fallback', error);
-    // Fallback con fromTimestamp explícito si falla la llamada RPC directa
-    const launchLogs = await options.getLogs({
-      target: FACTORY,
-      eventAbi:
-        'event LaunchCreated(uint256 indexed launchId, address indexed creator, address indexed token, address bondingCurve, string name, string symbol, string metadataUri)',
-      fromTimestamp: 1786838400,
-    });
-
-    for (const log of launchLogs) {
-      if (
-        log.bondingCurve &&
-        log.bondingCurve !== '0x0000000000000000000000000000000000000000'
-      ) {
-        cachedCurves.add(log.bondingCurve.toLowerCase());
+      if (creatorFee > 0n) {
+        dailySupplySideRevenue.addGasToken(creatorFee, 'Creator Trading Fees');
       }
     }
   }
 
-  const uniqueCurves = Array.from(cachedCurves);
-  const BATCH_SIZE = 50;
+  for (const log of sellLogs) {
+    const netEthAmount = BigInt(log.ethAmount || 0);
+    const totalFee = BigInt(log.fee || 0);
 
-  // 2. Procesar compras y ventas por lotes
-  for (let i = 0; i < uniqueCurves.length; i += BATCH_SIZE) {
-    const batch = uniqueCurves.slice(i, i + BATCH_SIZE);
+    if (totalFee > 0n) {
+      dailyFees.addGasToken(totalFee, 'Trading Fees');
 
-    const [buyLogs, sellLogs] = await Promise.all([
-      options.getLogs({
-        targets: batch,
-        eventAbi:
-          'event Buy(address indexed buyer, uint256 indexed launchId, uint256 ethAmount, uint256 tokenAmount, uint256 fee, uint256 priceAfter, uint256 ethReserveAfter, uint256 timestamp)',
-      }),
-      options.getLogs({
-        targets: batch,
-        eventAbi:
-          'event Sell(address indexed seller, uint256 indexed launchId, uint256 tokenAmount, uint256 ethAmount, uint256 fee, uint256 priceAfter, uint256 ethReserveAfter, uint256 timestamp)',
-      }),
-    ]);
+      const treasuryFee = (totalFee * TREASURY_SHARE_PERCENT) / SHARE_DENOMINATOR;
+      const creatorFee = totalFee - treasuryFee;
 
-    for (const log of buyLogs) {
-      const ethAmount = BigInt(log.ethAmount || 0);
-      const totalFee = BigInt(log.fee || 0);
-
-      if (ethAmount > 0n) {
-        dailyVolume.addGasToken(ethAmount, 'Buy Volume');
+      if (treasuryFee > 0n) {
+        dailyProtocolRevenue.addGasToken(treasuryFee, 'Treasury Trading Fees');
       }
 
-      if (totalFee > 0n) {
-        dailyFees.addGasToken(totalFee, 'Trading Fees');
-
-        const treasuryFee = (totalFee * TREASURY_SHARE_PERCENT) / SHARE_DENOMINATOR;
-        const creatorFee = totalFee - treasuryFee;
-
-        if (treasuryFee > 0n) {
-          dailyProtocolRevenue.addGasToken(treasuryFee, 'Treasury Trading Fees');
-        }
-
-        if (creatorFee > 0n) {
-          dailySupplySideRevenue.addGasToken(creatorFee, 'Creator Trading Fees');
-        }
+      if (creatorFee > 0n) {
+        dailySupplySideRevenue.addGasToken(creatorFee, 'Creator Trading Fees');
       }
     }
 
-    for (const log of sellLogs) {
-      const netEthAmount = BigInt(log.ethAmount || 0);
-      const totalFee = BigInt(log.fee || 0);
+    const grossEthVolume = netEthAmount + totalFee;
 
-      if (totalFee > 0n) {
-        dailyFees.addGasToken(totalFee, 'Trading Fees');
-
-        const treasuryFee = (totalFee * TREASURY_SHARE_PERCENT) / SHARE_DENOMINATOR;
-        const creatorFee = totalFee - treasuryFee;
-
-        if (treasuryFee > 0n) {
-          dailyProtocolRevenue.addGasToken(treasuryFee, 'Treasury Trading Fees');
-        }
-
-        if (creatorFee > 0n) {
-          dailySupplySideRevenue.addGasToken(creatorFee, 'Creator Trading Fees');
-        }
-      }
-
-      const grossEthVolume = netEthAmount + totalFee;
-
-      if (grossEthVolume > 0n) {
-        dailyVolume.addGasToken(grossEthVolume, 'Sell Volume');
-      }
+    if (grossEthVolume > 0n) {
+      dailyVolume.addGasToken(grossEthVolume);
     }
   }
 
@@ -193,10 +171,6 @@ const methodology = {
 };
 
 const breakdownMethodology = {
-  Volume: {
-    'Buy Volume': 'BNB value from Buy events.',
-    'Sell Volume': 'Gross BNB value from Sell events.',
-  },
   Fees: {
     'Trading Fees': '1% trading fee collected on buys and sells.',
     'Graduation Rewards': 'Rewards recorded when tokens graduate.',
@@ -219,10 +193,10 @@ const adapter: Adapter = {
   version: 2,
   pullHourly: true,
   chains: [CHAIN.BSC],
-  start: 1786838400, // August 16, 2026 00:00:00 UTC
+  start: '2026-08-16',
   fetch,
   methodology,
   breakdownMethodology,
 };
 
-export default adapter;
+export default adapter; 

--- a/fees/fairylaunch/index.ts
+++ b/fees/fairylaunch/index.ts
@@ -9,25 +9,21 @@ const FEE_MANAGER = '0xb6A7D47596D2202676822531F56EFeCeac309775';
 
 // Fee configuration:
 // Total trading fee: 1% (100 BPS)
-// - Creator fee: 0.5% (50 BPS) - goes to token creator
-// - Treasury fee: 0.5% (50 BPS) - goes to protocol treasury
-// The treasury share is 50% of the total collected trading fee.
-// Source: BondingCurve contract Constants.TOTAL_FEE_BPS = 100, TREASURY_FEE_BPS = 50, CREATOR_FEE_BPS = 50
-const BPS_DENOMINATOR = 10000n;
-const TOTAL_FEE_BPS = 100n;
-const TREASURY_FEE_BPS = 50n;
-const CREATOR_FEE_BPS = 50n;
+// FeeManager splits fee 50/50: creatorShare = amount/2, treasuryShare = amount - creatorShare
+// Source: FeeManager._recordFee() in FeeManager.sol
+const CREATOR_SHARE_PERCENT = 50n; // 50%
+const TREASURY_SHARE_PERCENT = 50n; // 50%
 
 const methodology = {
   Volume: 'ethAmount from Buy events + ethAmount from Sell events across all BondingCurves',
-  Fees: 'Total trading fees (1% of trade volume) from Buy/Sell events + Graduation rewards',
-  Revenue: 'Treasury fees (50% of trading fees) + Treasury portion of graduation rewards',
+  Fees: 'Total trading fees from Buy/Sell events + Graduation rewards',
+  Revenue: 'Treasury fees + Treasury portion of graduation rewards',
   ProtocolRevenue: 'Treasury fees (50% of trading fees) + Treasury portion of graduation rewards',
   SupplySideRevenue: 'Creator fees (50% of trading fees) + Creator portion of graduation rewards',
 };
 
 const fetch = async (options: FetchOptions) => {
-  const { createBalances, getLogs } = options;
+  const { api, createBalances, getLogs } = options;
 
   const dailyVolume = createBalances();
   const dailyFees = createBalances();
@@ -35,22 +31,31 @@ const fetch = async (options: FetchOptions) => {
   const dailyProtocolRevenue = createBalances();
   const dailySupplySideRevenue = createBalances();
 
-  // Descubrir TODAS las BondingCurves creadas por el LaunchFactory
-  // Usamos los logs de LaunchCreated para encontrar todas las curvas históricas
-  const launchLogs = await getLogs({
-    targets: [FACTORY],
-    eventAbi: 'event LaunchCreated(uint256 indexed launchId, address indexed creator, address indexed token, address bondingCurve, string name, string symbol, string metadataUri)',
+  // DESCUBRIR TODAS las BondingCurves usando api.call (obtiene TODAS las curvas históricas)
+  const totalLaunches = await api.call({
+    target: FACTORY,
+    abi: 'uint256:totalLaunches',
   });
 
   const bondingCurves: string[] = [];
 
-  for (const log of launchLogs) {
-    if (log.bondingCurve && log.bondingCurve !== '0x0000000000000000000000000000000000000000') {
-      bondingCurves.push(log.bondingCurve.toLowerCase());
+  for (let i = 1; i <= Number(totalLaunches); i++) {
+    try {
+      const launch = await api.call({
+        target: FACTORY,
+        abi: 'function getLaunch(uint256) view returns (uint256 launchId, address creator, address treasury, address token, address bondingCurve, bool graduated, uint256 createdAt, uint256 graduatedAt, string name, string symbol, string metadataUri)',
+        params: [i],
+      });
+
+      if (launch.bondingCurve && launch.bondingCurve !== '0x0000000000000000000000000000000000000000') {
+        bondingCurves.push(launch.bondingCurve.toLowerCase());
+      }
+    } catch (e) {
+      // Ignorar errores individuales
     }
   }
 
-  // Fallback: si no se encuentran logs (RPC limitado), usar la BondingCurve conocida
+  // Fallback: si api.call falla (RPC limitado), usar la BondingCurve conocida
   if (bondingCurves.length === 0) {
     bondingCurves.push('0x3014646079673048abaa2d84c9a197eefcde7b9b');
   }
@@ -78,14 +83,14 @@ const fetch = async (options: FetchOptions) => {
   // Procesar Buy events
   for (const log of buyLogs) {
     const ethAmount = BigInt(log.ethAmount);
-    const totalFee = BigInt(log.fee); // fee total del trade (1%)
+    const totalFee = BigInt(log.fee);
 
     dailyVolume.addGasToken(ethAmount);
     dailyFees.addGasToken(totalFee);
     
-    // fee split: 50% treasury, 50% creator
-    const treasuryFee = totalFee * TREASURY_FEE_BPS / 100n; // 50% del fee total
-    const creatorFee = totalFee - treasuryFee; // 50% restante
+    // Fee split 50/50 según FeeManager._recordFee
+    const treasuryFee = totalFee * TREASURY_SHARE_PERCENT / 100n;
+    const creatorFee = totalFee - treasuryFee;
 
     dailyProtocolRevenue.addGasToken(treasuryFee);
     dailySupplySideRevenue.addGasToken(creatorFee);
@@ -99,14 +104,14 @@ const fetch = async (options: FetchOptions) => {
     dailyVolume.addGasToken(ethAmount);
     dailyFees.addGasToken(totalFee);
     
-    const treasuryFee = totalFee * TREASURY_FEE_BPS / 100n;
+    const treasuryFee = totalFee * TREASURY_SHARE_PERCENT / 100n;
     const creatorFee = totalFee - treasuryFee;
 
     dailyProtocolRevenue.addGasToken(treasuryFee);
     dailySupplySideRevenue.addGasToken(creatorFee);
   }
 
-  // Procesar Graduation Rewards (1 BNB por launch graduado)
+  // Procesar Graduation Rewards
   for (const log of rewardLogs) {
     const creatorReward = BigInt(log.creatorReward);
     const treasuryReward = BigInt(log.treasuryReward);

--- a/fees/fairylaunch/index.ts
+++ b/fees/fairylaunch/index.ts
@@ -8,12 +8,8 @@ const FEE_MANAGER = '0xb6A7D47596D2202676822531F56EFeCeac309775';
 // Bloque exacto de despliegue de LaunchFactory en BSC Mainnet
 const FACTORY_DEPLOY_BLOCK = 116127983;
 
-// Repartición de comisiones: 50% Protocolo, 50% Creador
+// Repartición de comisiones: 50% Protocolo (Treasury), 50% Creador
 const TREASURY_SHARE_PERCENT = 50n;
-
-// Caché en memoria para evitar re-escanear todo el historial en cada hora del test
-const knownCurves = new Set<string>();
-let lastFetchedBlock = FACTORY_DEPLOY_BLOCK;
 
 const methodology = {
   Volume: 'ethAmount from Buy events + gross ethAmount (ethAmount + fee) from Sell events across all BondingCurves',
@@ -24,7 +20,7 @@ const methodology = {
 };
 
 const fetch = async (options: FetchOptions) => {
-  const { createBalances, getLogs, fromBlock, toBlock } = options;
+  const { createBalances, getLogs, toBlock } = options;
 
   const dailyVolume = createBalances();
   const dailyFees = createBalances();
@@ -32,34 +28,25 @@ const fetch = async (options: FetchOptions) => {
   const dailyProtocolRevenue = createBalances();
   const dailySupplySideRevenue = createBalances();
 
-  // Si se ejecuta fuera de orden o se reinicia la prueba, reseteamos el puntero
-  if (fromBlock && fromBlock < lastFetchedBlock) {
-    lastFetchedBlock = FACTORY_DEPLOY_BLOCK;
-    knownCurves.clear();
-  }
-
-  // 1. Obtener de forma incremental solo los nuevos LaunchCreated desde la última lectura
+  // 1. Obtener TODAS las BondingCurves creadas desde el despliegue del Factory hasta la fecha evaluada
   const launchLogs = await getLogs({
     target: FACTORY,
     eventAbi: 'event LaunchCreated(uint256 indexed launchId, address indexed creator, address indexed token, address bondingCurve, string name, string symbol, string metadataUri)',
-    fromBlock: lastFetchedBlock,
+    fromBlock: FACTORY_DEPLOY_BLOCK,
     toBlock: toBlock,
   });
 
+  const bondingCurves: string[] = [];
+
   for (const log of launchLogs) {
     if (log.bondingCurve && log.bondingCurve !== '0x0000000000000000000000000000000000000000') {
-      knownCurves.add(log.bondingCurve.toLowerCase());
+      bondingCurves.push(log.bondingCurve.toLowerCase());
     }
   }
 
-  // Actualizamos el puntero del bloque para la siguiente hora
-  if (toBlock) {
-    lastFetchedBlock = toBlock;
-  }
+  const uniqueCurves = [...new Set(bondingCurves)];
 
-  const uniqueCurves = Array.from(knownCurves);
-
-  // 2. Procesar Compras y Ventas en el rango horario de options (fromBlock -> toBlock)
+  // 2. Procesar compras y ventas ocurridas en la ventana de 24h para todas las curvas registradas
   if (uniqueCurves.length > 0) {
     const buyLogs = await getLogs({
       targets: uniqueCurves,
@@ -101,7 +88,7 @@ const fetch = async (options: FetchOptions) => {
     }
   }
 
-  // 3. Procesar Recompensas de Graduación emitidas por FeeManager en la hora actual
+  // 3. Procesar Recompensas de Graduación del FeeManager en la ventana de 24h
   const rewardLogs = await getLogs({
     target: FEE_MANAGER,
     eventAbi: 'event GraduationRewardRecorded(address indexed creator, uint256 creatorReward, uint256 treasuryReward)',
@@ -130,7 +117,7 @@ const fetch = async (options: FetchOptions) => {
 
 const adapter: Adapter = {
   version: 2,
-  pullHourly: true,
+  pullHourly: false,
   chains: [CHAIN.BSC],
   start: 1786752000,
   fetch,

--- a/fees/fairylaunch/index.ts
+++ b/fees/fairylaunch/index.ts
@@ -29,6 +29,12 @@ let cachedCurves: Set<string> | null = null;
 // Track the last block we've scanned for new curves
 let lastScannedBlock = FACTORY_DEPLOYMENT_BLOCK;
 
+// Cache for known bonding curves to avoid re-scanning
+// This is the first known curve (FAIRYDOGE)
+const KNOWN_CURVES = new Set<string>([
+  '0x3014646079673048abAa2D84c9a197eefCDE7b9b'.toLowerCase(), // FAIRYDOGE
+]);
+
 const fetch = async (options: FetchOptions) => {
   const dailyVolume = options.createBalances();
   const dailyFees = options.createBalances();
@@ -36,17 +42,15 @@ const fetch = async (options: FetchOptions) => {
   const dailyProtocolRevenue = options.createBalances();
   const dailySupplySideRevenue = options.createBalances();
 
-  const currentBlock = await options.getToBlock();
-  
-  // Initialize cache if needed
+  // Initialize cache with known curves
   if (!cachedCurves) {
-    cachedCurves = new Set<string>();
-    lastScannedBlock = FACTORY_DEPLOYMENT_BLOCK;
+    cachedCurves = new Set<string>(KNOWN_CURVES);
   }
 
-  // Discover new bonding curves from CurveCreated events
-  // This automatically finds ALL curves (past and future)
-  if (currentBlock > lastScannedBlock) {
+  const currentBlock = await options.getToBlock();
+  
+  // Only scan for new curves every 100 blocks (avoid rate limits)
+  if (currentBlock > lastScannedBlock + 100) {
     const curveCreatedLogs = await options.getLogs({
       target: BONDING_CURVE_FACTORY,
       eventAbi: 'event CurveCreated(address indexed curve, uint256 indexed launchId)',
@@ -54,7 +58,6 @@ const fetch = async (options: FetchOptions) => {
       toBlock: currentBlock,
     });
 
-    // Add all discovered bonding curves to cache
     for (const log of curveCreatedLogs) {
       if (
         log.curve &&
@@ -65,7 +68,6 @@ const fetch = async (options: FetchOptions) => {
       }
     }
 
-    // Update last scanned block
     lastScannedBlock = currentBlock;
   }
 
@@ -81,72 +83,69 @@ const fetch = async (options: FetchOptions) => {
     };
   }
 
-  // Process buys and sells in batches for all discovered curves
-  for (let i = 0; i < uniqueCurves.length; i += BATCH_SIZE) {
-    const batch = uniqueCurves.slice(i, i + BATCH_SIZE);
+  // Process buys and sells - combine all curves into single getLogs call
+  // This reduces RPC calls and avoids rate limits
+  const [buyLogs, sellLogs] = await Promise.all([
+    options.getLogs({
+      targets: uniqueCurves,
+      eventAbi: 'event Buy(address indexed buyer, uint256 indexed launchId, uint256 ethAmount, uint256 tokenAmount, uint256 fee, uint256 priceAfter, uint256 ethReserveAfter, uint256 timestamp)',
+    }),
+    options.getLogs({
+      targets: uniqueCurves,
+      eventAbi: 'event Sell(address indexed seller, uint256 indexed launchId, uint256 tokenAmount, uint256 ethAmount, uint256 fee, uint256 priceAfter, uint256 ethReserveAfter, uint256 timestamp)',
+    }),
+  ]);
 
-    const [buyLogs, sellLogs] = await Promise.all([
-      options.getLogs({
-        targets: batch,
-        eventAbi: 'event Buy(address indexed buyer, uint256 indexed launchId, uint256 ethAmount, uint256 tokenAmount, uint256 fee, uint256 priceAfter, uint256 ethReserveAfter, uint256 timestamp)',
-      }),
-      options.getLogs({
-        targets: batch,
-        eventAbi: 'event Sell(address indexed seller, uint256 indexed launchId, uint256 tokenAmount, uint256 ethAmount, uint256 fee, uint256 priceAfter, uint256 ethReserveAfter, uint256 timestamp)',
-      }),
-    ]);
+  // Process Buy events
+  for (const log of buyLogs) {
+    const ethAmount = BigInt(log.ethAmount || 0);
+    const totalFee = BigInt(log.fee || 0);
 
-    // Process Buy events
-    for (const log of buyLogs) {
-      const ethAmount = BigInt(log.ethAmount || 0);
-      const totalFee = BigInt(log.fee || 0);
+    if (ethAmount > 0n) {
+      dailyVolume.addGasToken(ethAmount, 'Buy Volume');
+    }
 
-      if (ethAmount > 0n) {
-        dailyVolume.addGasToken(ethAmount, 'Buy Volume');
+    if (totalFee > 0n) {
+      dailyFees.addGasToken(totalFee, 'Trading Fees');
+      
+      // Fee split is 50/50 per FeeManager._recordFee()
+      // Source: https://bscscan.com/address/0xb6A7D47596D2202676822531F56EFeCeac309775#code
+      const creatorShare = totalFee / 2n;
+      const treasuryShare = totalFee - creatorShare;
+      
+      if (treasuryShare > 0n) {
+        dailyProtocolRevenue.addGasToken(treasuryShare, 'Treasury Trading Fees');
       }
+      if (creatorShare > 0n) {
+        dailySupplySideRevenue.addGasToken(creatorShare, 'Creator Trading Fees');
+      }
+    }
+  }
 
-      if (totalFee > 0n) {
-        dailyFees.addGasToken(totalFee, 'Trading Fees');
-        
-        // Fee split is 50/50 per FeeManager._recordFee()
-        // Source: https://bscscan.com/address/0xb6A7D47596D2202676822531F56EFeCeac309775#code
-        const creatorShare = totalFee / 2n;
-        const treasuryShare = totalFee - creatorShare;
-        
-        if (treasuryShare > 0n) {
-          dailyProtocolRevenue.addGasToken(treasuryShare, 'Treasury Trading Fees');
-        }
-        if (creatorShare > 0n) {
-          dailySupplySideRevenue.addGasToken(creatorShare, 'Creator Trading Fees');
-        }
+  // Process Sell events
+  for (const log of sellLogs) {
+    const netEthAmount = BigInt(log.ethAmount || 0);
+    const totalFee = BigInt(log.fee || 0);
+
+    if (totalFee > 0n) {
+      dailyFees.addGasToken(totalFee, 'Trading Fees');
+      
+      const creatorShare = totalFee / 2n;
+      const treasuryShare = totalFee - creatorShare;
+      
+      if (treasuryShare > 0n) {
+        dailyProtocolRevenue.addGasToken(treasuryShare, 'Treasury Trading Fees');
+      }
+      if (creatorShare > 0n) {
+        dailySupplySideRevenue.addGasToken(creatorShare, 'Creator Trading Fees');
       }
     }
 
-    // Process Sell events
-    for (const log of sellLogs) {
-      const netEthAmount = BigInt(log.ethAmount || 0);
-      const totalFee = BigInt(log.fee || 0);
-
-      if (totalFee > 0n) {
-        dailyFees.addGasToken(totalFee, 'Trading Fees');
-        
-        const creatorShare = totalFee / 2n;
-        const treasuryShare = totalFee - creatorShare;
-        
-        if (treasuryShare > 0n) {
-          dailyProtocolRevenue.addGasToken(treasuryShare, 'Treasury Trading Fees');
-        }
-        if (creatorShare > 0n) {
-          dailySupplySideRevenue.addGasToken(creatorShare, 'Creator Trading Fees');
-        }
-      }
-
-      // Volume = net ETH received + fee (gross volume)
-      const grossEthVolume = netEthAmount + totalFee;
-      
-      if (grossEthVolume > 0n) {
-        dailyVolume.addGasToken(grossEthVolume, 'Sell Volume');
-      }
+    // Volume = net ETH received + fee (gross volume)
+    const grossEthVolume = netEthAmount + totalFee;
+    
+    if (grossEthVolume > 0n) {
+      dailyVolume.addGasToken(grossEthVolume, 'Sell Volume');
     }
   }
 

--- a/fees/fairylaunch/index.ts
+++ b/fees/fairylaunch/index.ts
@@ -48,6 +48,7 @@ const fetch = async (options: FetchOptions) => {
     eventAbi: 'event LaunchCreated(uint256 indexed launchId, address indexed creator, address indexed token, address bondingCurve, string name, string symbol, string metadataUri)',
     fromBlock: lastFetchedBlock,
     toBlock: toBlock,
+    maxBlockRange: 20000,
   });
 
   for (const log of launchLogs) {

--- a/fees/fairylaunch/index.ts
+++ b/fees/fairylaunch/index.ts
@@ -11,6 +11,10 @@ const FACTORY_DEPLOY_BLOCK = 116127983;
 // Repartición de comisiones: 50% Protocolo (Treasury), 50% Creador
 const TREASURY_SHARE_PERCENT = 50n;
 
+// Acumulador en memoria para evitar re-escaneo redundante en ejecuciones horarias
+let cachedCurves: string[] = [];
+let lastFetchedBlock = FACTORY_DEPLOY_BLOCK;
+
 const methodology = {
   Volume: 'ethAmount from Buy events + gross ethAmount (ethAmount + fee) from Sell events across all BondingCurves',
   Fees: 'Total trading fees from Buy/Sell events + Graduation rewards',
@@ -20,7 +24,7 @@ const methodology = {
 };
 
 const fetch = async (options: FetchOptions) => {
-  const { createBalances, getLogs, toBlock } = options;
+  const { createBalances, getLogs, fromBlock, toBlock } = options;
 
   const dailyVolume = createBalances();
   const dailyFees = createBalances();
@@ -28,25 +32,33 @@ const fetch = async (options: FetchOptions) => {
   const dailyProtocolRevenue = createBalances();
   const dailySupplySideRevenue = createBalances();
 
-  // 1. Obtener TODAS las BondingCurves creadas desde el despliegue del Factory hasta la fecha evaluada
+  // Si la prueba corre fuera de orden o reinicia rangos, reseteamos la memoria
+  if (fromBlock && fromBlock < lastFetchedBlock) {
+    lastFetchedBlock = FACTORY_DEPLOY_BLOCK;
+    cachedCurves = [];
+  }
+
+  // 1. Búsqueda incremental de BondingCurves creadas entre el último bloque procesado y toBlock
   const launchLogs = await getLogs({
     target: FACTORY,
     eventAbi: 'event LaunchCreated(uint256 indexed launchId, address indexed creator, address indexed token, address bondingCurve, string name, string symbol, string metadataUri)',
-    fromBlock: FACTORY_DEPLOY_BLOCK,
+    fromBlock: lastFetchedBlock,
     toBlock: toBlock,
   });
 
-  const bondingCurves: string[] = [];
-
   for (const log of launchLogs) {
     if (log.bondingCurve && log.bondingCurve !== '0x0000000000000000000000000000000000000000') {
-      bondingCurves.push(log.bondingCurve.toLowerCase());
+      cachedCurves.push(log.bondingCurve.toLowerCase());
     }
   }
 
-  const uniqueCurves = [...new Set(bondingCurves)];
+  if (toBlock) {
+    lastFetchedBlock = toBlock;
+  }
 
-  // 2. Procesar compras y ventas ocurridas en la ventana de 24h para todas las curvas registradas
+  const uniqueCurves = [...new Set(cachedCurves)];
+
+  // 2. Procesar compras y ventas correspondientes al rango de la hora evaluada
   if (uniqueCurves.length > 0) {
     const buyLogs = await getLogs({
       targets: uniqueCurves,
@@ -88,7 +100,7 @@ const fetch = async (options: FetchOptions) => {
     }
   }
 
-  // 3. Procesar Recompensas de Graduación del FeeManager en la ventana de 24h
+  // 3. Procesar Recompensas de Graduación emitidas en la hora evaluada
   const rewardLogs = await getLogs({
     target: FEE_MANAGER,
     eventAbi: 'event GraduationRewardRecorded(address indexed creator, uint256 creatorReward, uint256 treasuryReward)',
@@ -117,7 +129,7 @@ const fetch = async (options: FetchOptions) => {
 
 const adapter: Adapter = {
   version: 2,
-  pullHourly: false,
+  pullHourly: true,
   chains: [CHAIN.BSC],
   start: 1786752000,
   fetch,

--- a/fees/fairylaunch/index.ts
+++ b/fees/fairylaunch/index.ts
@@ -1,11 +1,6 @@
 import { Adapter, FetchOptions } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 
-// Factory contract on BSC Mainnet
-// Deployed at block 116127972
-// Source: https://bscscan.com/address/0x28163d7943AA6715a9559D468B29c0343412E236
-const FACTORY = '0x28163d7943AA6715a9559D468B29c0343412E236';
-
 // FeeManager contract on BSC Mainnet
 // Source: https://bscscan.com/address/0xb6A7D47596D2202676822531F56EFeCeac309775
 const FEE_MANAGER = '0xb6A7D47596D2202676822531F56EFeCeac309775';
@@ -19,21 +14,9 @@ const BONDING_CURVE_FACTORY = '0x12959266beada47f0dce13a3a0e54ecfe4fddb29';
 // Source: Transaction 0x83c59454a1ab8d8e522d6a6af749cbe0cf63208239f1e51622370ebcfea5d7be
 const FACTORY_DEPLOYMENT_BLOCK = 116127972;
 
-// Batch size for processing bonding curves
-// BSC RPC endpoints can handle ~50 addresses per getLogs call without timeout
-const BATCH_SIZE = 50;
-
-// Cache for bonding curve addresses (persists across calls)
+// Cache for bonding curve addresses
 let cachedCurves: Set<string> | null = null;
-
-// Track the last block we've scanned for new curves
 let lastScannedBlock = FACTORY_DEPLOYMENT_BLOCK;
-
-// Cache for known bonding curves to avoid re-scanning
-// This is the first known curve (FAIRYDOGE)
-const KNOWN_CURVES = new Set<string>([
-  '0x3014646079673048abAa2D84c9a197eefCDE7b9b'.toLowerCase(), // FAIRYDOGE
-]);
 
 const fetch = async (options: FetchOptions) => {
   const dailyVolume = options.createBalances();
@@ -42,15 +25,16 @@ const fetch = async (options: FetchOptions) => {
   const dailyProtocolRevenue = options.createBalances();
   const dailySupplySideRevenue = options.createBalances();
 
-  // Initialize cache with known curves
+  const currentBlock = await options.getToBlock();
+
+  // Initialize cache
   if (!cachedCurves) {
-    cachedCurves = new Set<string>(KNOWN_CURVES);
+    cachedCurves = new Set<string>();
   }
 
-  const currentBlock = await options.getToBlock();
-  
-  // Only scan for new curves every 100 blocks (avoid rate limits)
-  if (currentBlock > lastScannedBlock + 100) {
+  // Discover curves from CurveCreated events
+  // Only scan if we haven't scanned recently (avoid rate limits)
+  if (cachedCurves.size === 0 || currentBlock > lastScannedBlock + 100) {
     const curveCreatedLogs = await options.getLogs({
       target: BONDING_CURVE_FACTORY,
       eventAbi: 'event CurveCreated(address indexed curve, uint256 indexed launchId)',
@@ -83,8 +67,8 @@ const fetch = async (options: FetchOptions) => {
     };
   }
 
-  // Process buys and sells - combine all curves into single getLogs call
-  // This reduces RPC calls and avoids rate limits
+  // Get Buy and Sell events from the bonding curves themselves
+  // Use targets array with discovered curves
   const [buyLogs, sellLogs] = await Promise.all([
     options.getLogs({
       targets: uniqueCurves,

--- a/fees/fairylaunch/index.ts
+++ b/fees/fairylaunch/index.ts
@@ -1,17 +1,29 @@
 import { Adapter, FetchOptions } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 
+// BSC Mainnet contracts
+// LaunchFactory: https://bscscan.com/address/0x28163d7943AA6715a9559D468B29c0343412E236#code
+// FeeManager: https://bscscan.com/address/0xb6A7D47596D2202676822531F56EFeCeac309775#code
 const FACTORY = '0x28163d7943AA6715a9559D468B29c0343412E236';
 const FEE_MANAGER = '0xb6A7D47596D2202676822531F56EFeCeac309775';
 
-const TREASURY_FEE_BPS = 50n;
+// Fee configuration:
+// Total trading fee: 1% (100 BPS)
+// - Creator fee: 0.5% (50 BPS) - goes to token creator
+// - Treasury fee: 0.5% (50 BPS) - goes to protocol treasury
+// The treasury share is 50% of the total collected trading fee.
+// Source: BondingCurve contract Constants.TOTAL_FEE_BPS = 100, TREASURY_FEE_BPS = 50, CREATOR_FEE_BPS = 50
 const BPS_DENOMINATOR = 10000n;
+const TOTAL_FEE_BPS = 100n;
+const TREASURY_FEE_BPS = 50n;
+const CREATOR_FEE_BPS = 50n;
 
 const methodology = {
   Volume: 'ethAmount from Buy events + ethAmount from Sell events across all BondingCurves',
-  Fees: 'fee from Buy/Sell events (1% trading fee)',
-  Revenue: 'Treasury fees (0.5% of trades) + Treasury portion of graduation rewards',
-  ProtocolRevenue: 'Treasury fees (0.5% of trades) + Treasury portion of graduation rewards',
+  Fees: 'Total trading fees (1% of trade volume) from Buy/Sell events + Graduation rewards',
+  Revenue: 'Treasury fees (50% of trading fees) + Treasury portion of graduation rewards',
+  ProtocolRevenue: 'Treasury fees (50% of trading fees) + Treasury portion of graduation rewards',
+  SupplySideRevenue: 'Creator fees (50% of trading fees) + Creator portion of graduation rewards',
 };
 
 const fetch = async (options: FetchOptions) => {
@@ -21,7 +33,10 @@ const fetch = async (options: FetchOptions) => {
   const dailyFees = createBalances();
   const dailyRevenue = createBalances();
   const dailyProtocolRevenue = createBalances();
+  const dailySupplySideRevenue = createBalances();
 
+  // Descubrir TODAS las BondingCurves creadas por el LaunchFactory
+  // Usamos los logs de LaunchCreated para encontrar todas las curvas históricas
   const launchLogs = await getLogs({
     targets: [FACTORY],
     eventAbi: 'event LaunchCreated(uint256 indexed launchId, address indexed creator, address indexed token, address bondingCurve, string name, string symbol, string metadataUri)',
@@ -35,50 +50,83 @@ const fetch = async (options: FetchOptions) => {
     }
   }
 
+  // Fallback: si no se encuentran logs (RPC limitado), usar la BondingCurve conocida
   if (bondingCurves.length === 0) {
     bondingCurves.push('0x3014646079673048abaa2d84c9a197eefcde7b9b');
   }
 
   const uniqueCurves = [...new Set(bondingCurves)];
 
+  // Eventos Buy de TODAS las BondingCurves
   const buyLogs = await getLogs({
     targets: uniqueCurves,
     eventAbi: 'event Buy(address indexed buyer, uint256 indexed launchId, uint256 ethAmount, uint256 tokenAmount, uint256 fee, uint256 priceAfter, uint256 ethReserveAfter, uint256 timestamp)',
   });
 
+  // Eventos Sell de TODAS las BondingCurves
   const sellLogs = await getLogs({
     targets: uniqueCurves,
     eventAbi: 'event Sell(address indexed seller, uint256 indexed launchId, uint256 tokenAmount, uint256 ethAmount, uint256 fee, uint256 priceAfter, uint256 ethReserveAfter, uint256 timestamp)',
   });
 
+  // Eventos GraduationRewardRecorded del FeeManager
   const rewardLogs = await getLogs({
     targets: [FEE_MANAGER],
     eventAbi: 'event GraduationRewardRecorded(address indexed creator, uint256 creatorReward, uint256 treasuryReward)',
   });
 
+  // Procesar Buy events
   for (const log of buyLogs) {
-    dailyVolume.addGasToken(BigInt(log.ethAmount));
-    dailyFees.addGasToken(BigInt(log.fee));
-    dailyProtocolRevenue.addGasToken(BigInt(log.fee) * TREASURY_FEE_BPS / BPS_DENOMINATOR);
+    const ethAmount = BigInt(log.ethAmount);
+    const totalFee = BigInt(log.fee); // fee total del trade (1%)
+
+    dailyVolume.addGasToken(ethAmount);
+    dailyFees.addGasToken(totalFee);
+    
+    // fee split: 50% treasury, 50% creator
+    const treasuryFee = totalFee * TREASURY_FEE_BPS / 100n; // 50% del fee total
+    const creatorFee = totalFee - treasuryFee; // 50% restante
+
+    dailyProtocolRevenue.addGasToken(treasuryFee);
+    dailySupplySideRevenue.addGasToken(creatorFee);
   }
 
+  // Procesar Sell events
   for (const log of sellLogs) {
-    dailyVolume.addGasToken(BigInt(log.ethAmount));
-    dailyFees.addGasToken(BigInt(log.fee));
-    dailyProtocolRevenue.addGasToken(BigInt(log.fee) * TREASURY_FEE_BPS / BPS_DENOMINATOR);
+    const ethAmount = BigInt(log.ethAmount);
+    const totalFee = BigInt(log.fee);
+
+    dailyVolume.addGasToken(ethAmount);
+    dailyFees.addGasToken(totalFee);
+    
+    const treasuryFee = totalFee * TREASURY_FEE_BPS / 100n;
+    const creatorFee = totalFee - treasuryFee;
+
+    dailyProtocolRevenue.addGasToken(treasuryFee);
+    dailySupplySideRevenue.addGasToken(creatorFee);
   }
 
+  // Procesar Graduation Rewards (1 BNB por launch graduado)
   for (const log of rewardLogs) {
-    dailyProtocolRevenue.addGasToken(BigInt(log.treasuryReward));
+    const creatorReward = BigInt(log.creatorReward);
+    const treasuryReward = BigInt(log.treasuryReward);
+    const totalReward = creatorReward + treasuryReward;
+
+    dailyFees.addGasToken(totalReward);
+    dailyProtocolRevenue.addGasToken(treasuryReward);
+    dailySupplySideRevenue.addGasToken(creatorReward);
   }
 
+  // Revenue = ProtocolRevenue + SupplySideRevenue
   dailyRevenue.addBalances(dailyProtocolRevenue);
+  dailyRevenue.addBalances(dailySupplySideRevenue);
 
   return {
     dailyVolume,
     dailyFees,
     dailyRevenue,
     dailyProtocolRevenue,
+    dailySupplySideRevenue,
   };
 };
 

--- a/fees/fairylaunch/index.ts
+++ b/fees/fairylaunch/index.ts
@@ -2,15 +2,8 @@ import { Adapter, FetchOptions } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 
 // BSC Mainnet Contracts
-// Factory: https://bscscan.com/address/0x28163d7943AA6715a9559D468B29c0343412E236
 const FACTORY = '0x28163d7943AA6715a9559D468B29c0343412E236';
-
-// FeeManager: https://bscscan.com/address/0xb6A7D47596D2202676822531F56EFeCeac309775
 const FEE_MANAGER = '0xb6A7D47596D2202676822531F56EFeCeac309775';
-
-// Factory Deployment Block on BSC Mainnet
-const FACTORY_DEPLOY_BLOCK = 
-116127983;
 
 // Repartición de comisiones: 50% Protocolo (Treasury), 50% Creador del token
 const TREASURY_SHARE_PERCENT = 50n;
@@ -33,24 +26,46 @@ const fetch = async (options: FetchOptions) => {
   const dailyProtocolRevenue = options.createBalances();
   const dailySupplySideRevenue = options.createBalances();
 
-  // 1. Descubrimiento de curvas: consulta histórica en cold start, o incremental en slots posteriores
-  const launchLogs = await options.getLogs({
-    target: FACTORY,
-    fromBlock: cachedCurves.size === 0 ? FACTORY_DEPLOY_BLOCK : undefined,
-    toBlock: options.getToBlock(),
-    eventAbi: 'event LaunchCreated(uint256 indexed launchId, address indexed creator, address indexed token, address bondingCurve, string name, string symbol, string metadataUri)',
-    maxBlockRange: 20000,
-  });
+  // 1. Descubrimiento directo de curvas vía RPC multicall (evita bloqueos/timeouts)
+  if (cachedCurves.size === 0) {
+    try {
+      const totalLaunches = await options.api.call({
+        target: FACTORY,
+        abi: 'function totalLaunches() view returns (uint256)',
+      });
 
-  for (const log of launchLogs) {
-    if (log.bondingCurve && log.bondingCurve !== '0x0000000000000000000000000000000000000000') {
-      cachedCurves.add(log.bondingCurve.toLowerCase());
+      const count = Number(totalLaunches);
+      if (count > 0) {
+        const launchIds = Array.from({ length: count }, (_, i) => i + 1);
+        const launches = await options.api.multiCall({
+          target: FACTORY,
+          abi: 'function getLaunch(uint256 launchId) view returns ((uint256 launchId, address creator, address treasury, address token, address bondingCurve, bool graduated, uint256 createdAt, uint256 graduatedAt, string name, string symbol, string metadataUri))',
+          calls: launchIds.map((id) => ({ params: [id] })),
+        });
+
+        for (const launch of launches) {
+          if (launch?.bondingCurve && launch.bondingCurve !== '0x0000000000000000000000000000000000000000') {
+            cachedCurves.add(launch.bondingCurve.toLowerCase());
+          }
+        }
+      }
+    } catch {
+      // Fallback a getLogs si la consulta directa falla
+      const launchLogs = await options.getLogs({
+        target: FACTORY,
+        eventAbi: 'event LaunchCreated(uint256 indexed launchId, address indexed creator, address indexed token, address bondingCurve, string name, string symbol, string metadataUri)',
+      });
+      for (const log of launchLogs) {
+        if (log.bondingCurve && log.bondingCurve !== '0x0000000000000000000000000000000000000000') {
+          cachedCurves.add(log.bondingCurve.toLowerCase());
+        }
+      }
     }
   }
 
   const uniqueCurves = Array.from(cachedCurves);
 
-  // 2. Procesamiento de trades solo si existen curvas registradas
+  // 2. Procesamiento de compras y ventas en las curvas registradas
   if (uniqueCurves.length > 0) {
     const buyLogs = await options.getLogs({
       targets: uniqueCurves,
@@ -123,7 +138,7 @@ const adapter: Adapter = {
   version: 2,
   pullHourly: true,
   chains: [CHAIN.BSC],
-  start: 1786752000, // 2026-08-17 00:00:00 UTC
+  start: 1786665600, // 16 de Agosto de 2026 00:00:00 UTC
   fetch,
   methodology,
   breakdownMethodology: methodology,

--- a/fees/fairylaunch/index.ts
+++ b/fees/fairylaunch/index.ts
@@ -22,7 +22,7 @@ const fetch = async (options: FetchOptions) => {
   const dailyProtocolRevenue = options.createBalances();
   const dailySupplySideRevenue = options.createBalances();
 
-  // 1. Descubrimiento incremental de curvas vía RPC multicall
+  // 1. Descubrimiento incremental de curvas vÃ­a RPC multicall
   try {
     const totalLaunchesBN = await options.api.call({
       target: FACTORY,
@@ -49,11 +49,12 @@ const fetch = async (options: FetchOptions) => {
         }
       }
 
-      // Actualizar cursor solo tras éxito en el recorrido
+      // Actualizar cursor solo tras Ã©xito en el recorrido
       discoveredLaunchCount = totalLaunches;
     }
-  } catch {
-    // Fallback con fromTimestamp explícito si falla la llamada RPC directa
+  } catch (error) {
+    console.warn('Fairylaunch RPC curve discovery failed; using LaunchCreated fallback', error);
+    // Fallback con fromTimestamp explÃ­cito si falla la llamada RPC directa
     const launchLogs = await options.getLogs({
       target: FACTORY,
       eventAbi:
@@ -142,7 +143,7 @@ const fetch = async (options: FetchOptions) => {
     }
   }
 
-  // 3. Recompensas de graduación desde FeeManager
+  // 3. Recompensas de graduaciÃ³n desde FeeManager
   const graduationRewardLogs = await options.getLogs({
     target: FEE_MANAGER,
     eventAbi:

--- a/fees/fairylaunch/index.ts
+++ b/fees/fairylaunch/index.ts
@@ -1,0 +1,88 @@
+import { Adapter, FetchOptions } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+
+const FACTORY = '0x28163d7943AA6715a9559D468B29c0343412E236';
+const FEE_MANAGER = '0xb6A7D47596D2202676822531F56EFeCeac309775';
+
+const TREASURY_FEE_BPS = 50n;
+const BPS_DENOMINATOR = 10000n;
+
+const fetch = async (options: FetchOptions) => {
+  const { createBalances, getLogs } = options;
+
+  const dailyVolume = createBalances();
+  const dailyFees = createBalances();
+  const dailyRevenue = createBalances();
+  const dailyProtocolRevenue = createBalances();
+
+  const launchLogs = await getLogs({
+    targets: [FACTORY],
+    eventAbi: 'event LaunchCreated(uint256 indexed launchId, address indexed creator, address indexed token, address bondingCurve, string name, string symbol, string metadataUri)',
+  });
+
+  const bondingCurves: string[] = [];
+
+  for (const log of launchLogs) {
+    if (log.bondingCurve && log.bondingCurve !== '0x0000000000000000000000000000000000000000') {
+      bondingCurves.push(log.bondingCurve.toLowerCase());
+    }
+  }
+
+  if (bondingCurves.length === 0) {
+    bondingCurves.push('0x3014646079673048abaa2d84c9a197eefcde7b9b');
+  }
+
+  const uniqueCurves = [...new Set(bondingCurves)];
+
+  const buyLogs = await getLogs({
+    targets: uniqueCurves,
+    eventAbi: 'event Buy(address indexed buyer, uint256 indexed launchId, uint256 ethAmount, uint256 tokenAmount, uint256 fee, uint256 priceAfter, uint256 ethReserveAfter, uint256 timestamp)',
+  });
+
+  const sellLogs = await getLogs({
+    targets: uniqueCurves,
+    eventAbi: 'event Sell(address indexed seller, uint256 indexed launchId, uint256 tokenAmount, uint256 ethAmount, uint256 fee, uint256 priceAfter, uint256 ethReserveAfter, uint256 timestamp)',
+  });
+
+  const rewardLogs = await getLogs({
+    targets: [FEE_MANAGER],
+    eventAbi: 'event GraduationRewardRecorded(address indexed creator, uint256 creatorReward, uint256 treasuryReward)',
+  });
+
+  for (const log of buyLogs) {
+    dailyVolume.addGasToken(BigInt(log.ethAmount));
+    dailyFees.addGasToken(BigInt(log.fee));
+    dailyProtocolRevenue.addGasToken(BigInt(log.fee) * TREASURY_FEE_BPS / BPS_DENOMINATOR);
+  }
+
+  for (const log of sellLogs) {
+    dailyVolume.addGasToken(BigInt(log.ethAmount));
+    dailyFees.addGasToken(BigInt(log.fee));
+    dailyProtocolRevenue.addGasToken(BigInt(log.fee) * TREASURY_FEE_BPS / BPS_DENOMINATOR);
+  }
+
+  for (const log of rewardLogs) {
+    dailyProtocolRevenue.addGasToken(BigInt(log.treasuryReward));
+  }
+
+  dailyRevenue.addBalances(dailyProtocolRevenue);
+
+  return {
+    dailyVolume,
+    dailyFees,
+    dailyRevenue,
+    dailyProtocolRevenue,
+  };
+};
+
+const adapter: Adapter = {
+  version: 2,
+  adapter: {
+    [CHAIN.BSC]: {
+      fetch,
+      start: 1786752000,
+    },
+  },
+};
+
+export default adapter;

--- a/fees/fairylaunch/index.ts
+++ b/fees/fairylaunch/index.ts
@@ -7,12 +7,8 @@ import { CHAIN } from "../../helpers/chains";
 const FACTORY = '0x28163d7943AA6715a9559D468B29c0343412E236';
 const FEE_MANAGER = '0xb6A7D47596D2202676822531F56EFeCeac309775';
 
-// Fee configuration:
-// Total trading fee: 1% (100 BPS)
-// FeeManager splits fee 50/50: creatorShare = amount/2, treasuryShare = amount - creatorShare
-// Source: FeeManager._recordFee() in FeeManager.sol
-const CREATOR_SHARE_PERCENT = 50n; // 50%
-const TREASURY_SHARE_PERCENT = 50n; // 50%
+// Fee split 50/50 según FeeManager._recordFee()
+const TREASURY_SHARE_PERCENT = 50n;
 
 const methodology = {
   Volume: 'ethAmount from Buy events + ethAmount from Sell events across all BondingCurves',
@@ -23,7 +19,7 @@ const methodology = {
 };
 
 const fetch = async (options: FetchOptions) => {
-  const { api, createBalances, getLogs } = options;
+  const { createBalances, getLogs } = options;
 
   const dailyVolume = createBalances();
   const dailyFees = createBalances();
@@ -31,31 +27,22 @@ const fetch = async (options: FetchOptions) => {
   const dailyProtocolRevenue = createBalances();
   const dailySupplySideRevenue = createBalances();
 
-  // DESCUBRIR TODAS las BondingCurves usando api.call (obtiene TODAS las curvas históricas)
-  const totalLaunches = await api.call({
-    target: FACTORY,
-    abi: 'uint256:totalLaunches',
+  // Descubrir TODAS las BondingCurves desde LaunchCreated logs
+  // getLogs con período amplio captura TODAS las curvas históricas
+  const launchLogs = await getLogs({
+    targets: [FACTORY],
+    eventAbi: 'event LaunchCreated(uint256 indexed launchId, address indexed creator, address indexed token, address bondingCurve, string name, string symbol, string metadataUri)',
   });
 
   const bondingCurves: string[] = [];
 
-  for (let i = 1; i <= Number(totalLaunches); i++) {
-    try {
-      const launch = await api.call({
-        target: FACTORY,
-        abi: 'function getLaunch(uint256) view returns (uint256 launchId, address creator, address treasury, address token, address bondingCurve, bool graduated, uint256 createdAt, uint256 graduatedAt, string name, string symbol, string metadataUri)',
-        params: [i],
-      });
-
-      if (launch.bondingCurve && launch.bondingCurve !== '0x0000000000000000000000000000000000000000') {
-        bondingCurves.push(launch.bondingCurve.toLowerCase());
-      }
-    } catch (e) {
-      // Ignorar errores individuales
+  for (const log of launchLogs) {
+    if (log.bondingCurve && log.bondingCurve !== '0x0000000000000000000000000000000000000000') {
+      bondingCurves.push(log.bondingCurve.toLowerCase());
     }
   }
 
-  // Fallback: si api.call falla (RPC limitado), usar la BondingCurve conocida
+  // Fallback: BondingCurve conocida
   if (bondingCurves.length === 0) {
     bondingCurves.push('0x3014646079673048abaa2d84c9a197eefcde7b9b');
   }
@@ -80,7 +67,6 @@ const fetch = async (options: FetchOptions) => {
     eventAbi: 'event GraduationRewardRecorded(address indexed creator, uint256 creatorReward, uint256 treasuryReward)',
   });
 
-  // Procesar Buy events
   for (const log of buyLogs) {
     const ethAmount = BigInt(log.ethAmount);
     const totalFee = BigInt(log.fee);
@@ -88,7 +74,6 @@ const fetch = async (options: FetchOptions) => {
     dailyVolume.addGasToken(ethAmount);
     dailyFees.addGasToken(totalFee);
     
-    // Fee split 50/50 según FeeManager._recordFee
     const treasuryFee = totalFee * TREASURY_SHARE_PERCENT / 100n;
     const creatorFee = totalFee - treasuryFee;
 
@@ -96,7 +81,6 @@ const fetch = async (options: FetchOptions) => {
     dailySupplySideRevenue.addGasToken(creatorFee);
   }
 
-  // Procesar Sell events
   for (const log of sellLogs) {
     const ethAmount = BigInt(log.ethAmount);
     const totalFee = BigInt(log.fee);
@@ -111,7 +95,6 @@ const fetch = async (options: FetchOptions) => {
     dailySupplySideRevenue.addGasToken(creatorFee);
   }
 
-  // Procesar Graduation Rewards
   for (const log of rewardLogs) {
     const creatorReward = BigInt(log.creatorReward);
     const treasuryReward = BigInt(log.treasuryReward);
@@ -122,7 +105,6 @@ const fetch = async (options: FetchOptions) => {
     dailySupplySideRevenue.addGasToken(creatorReward);
   }
 
-  // Revenue = ProtocolRevenue + SupplySideRevenue
   dailyRevenue.addBalances(dailyProtocolRevenue);
   dailyRevenue.addBalances(dailySupplySideRevenue);
 

--- a/fees/fairylaunch/index.ts
+++ b/fees/fairylaunch/index.ts
@@ -2,16 +2,21 @@ import { Adapter, FetchOptions } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 
 // BSC Mainnet contracts
-// LaunchFactory: https://bscscan.com/address/0x28163d7943AA6715a9559D468B29c0343412E236#code
-// FeeManager: https://bscscan.com/address/0xb6A7D47596D2202676822531F56EFeCeac309775#code
 const FACTORY = '0x28163d7943AA6715a9559D468B29c0343412E236';
 const FEE_MANAGER = '0xb6A7D47596D2202676822531F56EFeCeac309775';
 
-// Fee split 50/50 según FeeManager._recordFee()
+// Bloque exacto de despliegue de LaunchFactory en BSC Mainnet
+const FACTORY_DEPLOY_BLOCK = 116127983;
+
+// Repartición de comisiones: 50% Protocolo, 50% Creador
 const TREASURY_SHARE_PERCENT = 50n;
 
+// Caché en memoria para evitar re-escanear todo el historial en cada hora del test
+const knownCurves = new Set<string>();
+let lastFetchedBlock = FACTORY_DEPLOY_BLOCK;
+
 const methodology = {
-  Volume: 'ethAmount from Buy events + ethAmount from Sell events across all BondingCurves',
+  Volume: 'ethAmount from Buy events + gross ethAmount (ethAmount + fee) from Sell events across all BondingCurves',
   Fees: 'Total trading fees from Buy/Sell events + Graduation rewards',
   Revenue: 'Treasury fees + Treasury portion of graduation rewards',
   ProtocolRevenue: 'Treasury fees (50% of trading fees) + Treasury portion of graduation rewards',
@@ -19,7 +24,7 @@ const methodology = {
 };
 
 const fetch = async (options: FetchOptions) => {
-  const { createBalances, getLogs } = options;
+  const { createBalances, getLogs, fromBlock, toBlock } = options;
 
   const dailyVolume = createBalances();
   const dailyFees = createBalances();
@@ -27,73 +32,80 @@ const fetch = async (options: FetchOptions) => {
   const dailyProtocolRevenue = createBalances();
   const dailySupplySideRevenue = createBalances();
 
-  // Descubrir TODAS las BondingCurves desde LaunchCreated logs
-  // getLogs con período amplio captura TODAS las curvas históricas
-  const launchLogs = await getLogs({
-    targets: [FACTORY],
-    eventAbi: 'event LaunchCreated(uint256 indexed launchId, address indexed creator, address indexed token, address bondingCurve, string name, string symbol, string metadataUri)',
-  });
+  // Si se ejecuta fuera de orden o se reinicia la prueba, reseteamos el puntero
+  if (fromBlock && fromBlock < lastFetchedBlock) {
+    lastFetchedBlock = FACTORY_DEPLOY_BLOCK;
+    knownCurves.clear();
+  }
 
-  const bondingCurves: string[] = [];
+  // 1. Obtener de forma incremental solo los nuevos LaunchCreated desde la última lectura
+  const launchLogs = await getLogs({
+    target: FACTORY,
+    eventAbi: 'event LaunchCreated(uint256 indexed launchId, address indexed creator, address indexed token, address bondingCurve, string name, string symbol, string metadataUri)',
+    fromBlock: lastFetchedBlock,
+    toBlock: toBlock,
+  });
 
   for (const log of launchLogs) {
     if (log.bondingCurve && log.bondingCurve !== '0x0000000000000000000000000000000000000000') {
-      bondingCurves.push(log.bondingCurve.toLowerCase());
+      knownCurves.add(log.bondingCurve.toLowerCase());
     }
   }
 
-  // Fallback: BondingCurve conocida
-  if (bondingCurves.length === 0) {
-    bondingCurves.push('0x3014646079673048abaa2d84c9a197eefcde7b9b');
+  // Actualizamos el puntero del bloque para la siguiente hora
+  if (toBlock) {
+    lastFetchedBlock = toBlock;
   }
 
-  const uniqueCurves = [...new Set(bondingCurves)];
+  const uniqueCurves = Array.from(knownCurves);
 
-  // Eventos Buy de TODAS las BondingCurves
-  const buyLogs = await getLogs({
-    targets: uniqueCurves,
-    eventAbi: 'event Buy(address indexed buyer, uint256 indexed launchId, uint256 ethAmount, uint256 tokenAmount, uint256 fee, uint256 priceAfter, uint256 ethReserveAfter, uint256 timestamp)',
-  });
+  // 2. Procesar Compras y Ventas en el rango horario de options (fromBlock -> toBlock)
+  if (uniqueCurves.length > 0) {
+    const buyLogs = await getLogs({
+      targets: uniqueCurves,
+      eventAbi: 'event Buy(address indexed buyer, uint256 indexed launchId, uint256 ethAmount, uint256 tokenAmount, uint256 fee, uint256 priceAfter, uint256 ethReserveAfter, uint256 timestamp)',
+    });
 
-  // Eventos Sell de TODAS las BondingCurves
-  const sellLogs = await getLogs({
-    targets: uniqueCurves,
-    eventAbi: 'event Sell(address indexed seller, uint256 indexed launchId, uint256 tokenAmount, uint256 ethAmount, uint256 fee, uint256 priceAfter, uint256 ethReserveAfter, uint256 timestamp)',
-  });
+    const sellLogs = await getLogs({
+      targets: uniqueCurves,
+      eventAbi: 'event Sell(address indexed seller, uint256 indexed launchId, uint256 tokenAmount, uint256 ethAmount, uint256 fee, uint256 priceAfter, uint256 ethReserveAfter, uint256 timestamp)',
+    });
 
-  // Eventos GraduationRewardRecorded del FeeManager
+    for (const log of buyLogs) {
+      const ethAmount = BigInt(log.ethAmount);
+      const totalFee = BigInt(log.fee);
+
+      dailyVolume.addGasToken(ethAmount);
+      dailyFees.addGasToken(totalFee);
+
+      const treasuryFee = (totalFee * TREASURY_SHARE_PERCENT) / 100n;
+      const creatorFee = totalFee - treasuryFee;
+
+      dailyProtocolRevenue.addGasToken(treasuryFee);
+      dailySupplySideRevenue.addGasToken(creatorFee);
+    }
+
+    for (const log of sellLogs) {
+      const netEthAmount = BigInt(log.ethAmount);
+      const totalFee = BigInt(log.fee);
+      const grossEthVolume = netEthAmount + totalFee;
+
+      dailyVolume.addGasToken(grossEthVolume);
+      dailyFees.addGasToken(totalFee);
+
+      const treasuryFee = (totalFee * TREASURY_SHARE_PERCENT) / 100n;
+      const creatorFee = totalFee - treasuryFee;
+
+      dailyProtocolRevenue.addGasToken(treasuryFee);
+      dailySupplySideRevenue.addGasToken(creatorFee);
+    }
+  }
+
+  // 3. Procesar Recompensas de Graduación emitidas por FeeManager en la hora actual
   const rewardLogs = await getLogs({
-    targets: [FEE_MANAGER],
+    target: FEE_MANAGER,
     eventAbi: 'event GraduationRewardRecorded(address indexed creator, uint256 creatorReward, uint256 treasuryReward)',
   });
-
-  for (const log of buyLogs) {
-    const ethAmount = BigInt(log.ethAmount);
-    const totalFee = BigInt(log.fee);
-
-    dailyVolume.addGasToken(ethAmount);
-    dailyFees.addGasToken(totalFee);
-    
-    const treasuryFee = totalFee * TREASURY_SHARE_PERCENT / 100n;
-    const creatorFee = totalFee - treasuryFee;
-
-    dailyProtocolRevenue.addGasToken(treasuryFee);
-    dailySupplySideRevenue.addGasToken(creatorFee);
-  }
-
-  for (const log of sellLogs) {
-    const ethAmount = BigInt(log.ethAmount);
-    const totalFee = BigInt(log.fee);
-
-    dailyVolume.addGasToken(ethAmount);
-    dailyFees.addGasToken(totalFee);
-    
-    const treasuryFee = totalFee * TREASURY_SHARE_PERCENT / 100n;
-    const creatorFee = totalFee - treasuryFee;
-
-    dailyProtocolRevenue.addGasToken(treasuryFee);
-    dailySupplySideRevenue.addGasToken(creatorFee);
-  }
 
   for (const log of rewardLogs) {
     const creatorReward = BigInt(log.creatorReward);
@@ -105,8 +117,6 @@ const fetch = async (options: FetchOptions) => {
     dailySupplySideRevenue.addGasToken(creatorReward);
   }
 
-  // CORRECCIÓN: dailyRevenue SOLO incluye protocol revenue (treasury)
-  // NO incluye dailySupplySideRevenue (creator fees)
   dailyRevenue.addBalances(dailyProtocolRevenue);
 
   return {

--- a/fees/fairylaunch/index.ts
+++ b/fees/fairylaunch/index.ts
@@ -1,23 +1,19 @@
 import { Adapter, FetchOptions } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 
-// BSC Mainnet Contracts
+// Factory contract on BSC Mainnet: https://bscscan.com/address/0x28163d7943AA6715a9559D468B29c0343412E236
 const FACTORY = '0x28163d7943AA6715a9559D468B29c0343412E236';
+
+// FeeManager contract on BSC Mainnet: https://bscscan.com/address/0xb6A7D47596D2202676822531F56EFeCeac309775
 const FEE_MANAGER = '0xb6A7D47596D2202676822531F56EFeCeac309775';
 
-// Repartición de comisiones: 50% Protocolo (Treasury), 50% Creador del token
+// Protocol fee split (50% treasury, 50% creator): https://bscscan.com/address/0xb6A7D47596D2202676822531F56EFeCeac309775#code
 const TREASURY_SHARE_PERCENT = 50n;
+const SHARE_DENOMINATOR = 100n;
 
-// Registro persistente en memoria para almacenar las bonding curves descubiertas
+// In-memory cache for discovered bonding curves and cursor tracking
 const cachedCurves = new Set<string>();
-
-const methodology = {
-  Volume: 'ethAmount from Buy events + gross ethAmount (ethAmount + fee) from Sell events across all BondingCurves',
-  Fees: 'Total trading fees (1% per trade) + Graduation rewards',
-  Revenue: 'Treasury portion of trading fees (0.5%) + Treasury portion of graduation rewards',
-  ProtocolRevenue: 'Treasury fees (50% of trading fees) + Treasury portion of graduation rewards',
-  SupplySideRevenue: 'Creator fees (50% of trading fees) + Creator portion of graduation rewards',
-};
+let discoveredLaunchCount = 0;
 
 const fetch = async (options: FetchOptions) => {
   const dailyVolume = options.createBalances();
@@ -26,101 +22,149 @@ const fetch = async (options: FetchOptions) => {
   const dailyProtocolRevenue = options.createBalances();
   const dailySupplySideRevenue = options.createBalances();
 
-  // 1. Descubrimiento directo de curvas vía RPC multicall (evita bloqueos/timeouts)
-  if (cachedCurves.size === 0) {
-    try {
-      const totalLaunches = await options.api.call({
+  // 1. Descubrimiento incremental de curvas vía RPC multicall
+  try {
+    const totalLaunchesBN = await options.api.call({
+      target: FACTORY,
+      abi: 'function totalLaunches() view returns (uint256)',
+    });
+
+    const totalLaunches = Number(totalLaunchesBN || 0);
+
+    if (totalLaunches > discoveredLaunchCount) {
+      const newLaunchIds = Array.from(
+        { length: totalLaunches - discoveredLaunchCount },
+        (_, i) => discoveredLaunchCount + i + 1
+      );
+
+      const launches = await options.api.multiCall({
         target: FACTORY,
-        abi: 'function totalLaunches() view returns (uint256)',
+        abi: 'function getLaunch(uint256 launchId) view returns ((uint256 launchId, address creator, address treasury, address token, address bondingCurve, bool graduated, uint256 createdAt, uint256 graduatedAt, string name, string symbol, string metadataUri))',
+        calls: newLaunchIds.map((id) => ({ params: [id] })),
       });
 
-      const count = Number(totalLaunches);
-      if (count > 0) {
-        const launchIds = Array.from({ length: count }, (_, i) => i + 1);
-        const launches = await options.api.multiCall({
-          target: FACTORY,
-          abi: 'function getLaunch(uint256 launchId) view returns ((uint256 launchId, address creator, address treasury, address token, address bondingCurve, bool graduated, uint256 createdAt, uint256 graduatedAt, string name, string symbol, string metadataUri))',
-          calls: launchIds.map((id) => ({ params: [id] })),
-        });
-
-        for (const launch of launches) {
-          if (launch?.bondingCurve && launch.bondingCurve !== '0x0000000000000000000000000000000000000000') {
-            cachedCurves.add(launch.bondingCurve.toLowerCase());
-          }
+      for (const launch of launches) {
+        if (launch?.bondingCurve && launch.bondingCurve !== '0x0000000000000000000000000000000000000000') {
+          cachedCurves.add(launch.bondingCurve.toLowerCase());
         }
       }
-    } catch {
-      // Fallback a getLogs si la consulta directa falla
-      const launchLogs = await options.getLogs({
-        target: FACTORY,
-        eventAbi: 'event LaunchCreated(uint256 indexed launchId, address indexed creator, address indexed token, address bondingCurve, string name, string symbol, string metadataUri)',
-      });
-      for (const log of launchLogs) {
-        if (log.bondingCurve && log.bondingCurve !== '0x0000000000000000000000000000000000000000') {
-          cachedCurves.add(log.bondingCurve.toLowerCase());
-        }
+
+      // Actualizar cursor solo tras éxito en el recorrido
+      discoveredLaunchCount = totalLaunches;
+    }
+  } catch {
+    // Fallback con fromTimestamp explícito si falla la llamada RPC directa
+    const launchLogs = await options.getLogs({
+      target: FACTORY,
+      eventAbi:
+        'event LaunchCreated(uint256 indexed launchId, address indexed creator, address indexed token, address bondingCurve, string name, string symbol, string metadataUri)',
+      fromTimestamp: 1786838400,
+    });
+
+    for (const log of launchLogs) {
+      if (
+        log.bondingCurve &&
+        log.bondingCurve !== '0x0000000000000000000000000000000000000000'
+      ) {
+        cachedCurves.add(log.bondingCurve.toLowerCase());
       }
     }
   }
 
   const uniqueCurves = Array.from(cachedCurves);
+  const BATCH_SIZE = 50;
 
-  // 2. Procesamiento de compras y ventas en las curvas registradas
-  if (uniqueCurves.length > 0) {
-    const buyLogs = await options.getLogs({
-      targets: uniqueCurves,
-      eventAbi: 'event Buy(address indexed buyer, uint256 indexed launchId, uint256 ethAmount, uint256 tokenAmount, uint256 fee, uint256 priceAfter, uint256 ethReserveAfter, uint256 timestamp)',
-    });
+  // 2. Procesar compras y ventas por lotes
+  for (let i = 0; i < uniqueCurves.length; i += BATCH_SIZE) {
+    const batch = uniqueCurves.slice(i, i + BATCH_SIZE);
 
-    const sellLogs = await options.getLogs({
-      targets: uniqueCurves,
-      eventAbi: 'event Sell(address indexed seller, uint256 indexed launchId, uint256 tokenAmount, uint256 ethAmount, uint256 fee, uint256 priceAfter, uint256 ethReserveAfter, uint256 timestamp)',
-    });
+    const [buyLogs, sellLogs] = await Promise.all([
+      options.getLogs({
+        targets: batch,
+        eventAbi:
+          'event Buy(address indexed buyer, uint256 indexed launchId, uint256 ethAmount, uint256 tokenAmount, uint256 fee, uint256 priceAfter, uint256 ethReserveAfter, uint256 timestamp)',
+      }),
+      options.getLogs({
+        targets: batch,
+        eventAbi:
+          'event Sell(address indexed seller, uint256 indexed launchId, uint256 tokenAmount, uint256 ethAmount, uint256 fee, uint256 priceAfter, uint256 ethReserveAfter, uint256 timestamp)',
+      }),
+    ]);
 
     for (const log of buyLogs) {
-      const ethAmount = BigInt(log.ethAmount);
-      const totalFee = BigInt(log.fee);
+      const ethAmount = BigInt(log.ethAmount || 0);
+      const totalFee = BigInt(log.fee || 0);
 
-      dailyVolume.addGasToken(ethAmount);
-      dailyFees.addGasToken(totalFee);
+      if (ethAmount > 0n) {
+        dailyVolume.addGasToken(ethAmount, 'Buy Volume');
+      }
 
-      const treasuryFee = (totalFee * TREASURY_SHARE_PERCENT) / 100n;
-      const creatorFee = totalFee - treasuryFee;
+      if (totalFee > 0n) {
+        dailyFees.addGasToken(totalFee, 'Trading Fees');
 
-      dailyProtocolRevenue.addGasToken(treasuryFee);
-      dailySupplySideRevenue.addGasToken(creatorFee);
+        const treasuryFee = (totalFee * TREASURY_SHARE_PERCENT) / SHARE_DENOMINATOR;
+        const creatorFee = totalFee - treasuryFee;
+
+        if (treasuryFee > 0n) {
+          dailyProtocolRevenue.addGasToken(treasuryFee, 'Treasury Trading Fees');
+        }
+
+        if (creatorFee > 0n) {
+          dailySupplySideRevenue.addGasToken(creatorFee, 'Creator Trading Fees');
+        }
+      }
     }
 
     for (const log of sellLogs) {
-      const netEthAmount = BigInt(log.ethAmount);
-      const totalFee = BigInt(log.fee);
+      const netEthAmount = BigInt(log.ethAmount || 0);
+      const totalFee = BigInt(log.fee || 0);
+
+      if (totalFee > 0n) {
+        dailyFees.addGasToken(totalFee, 'Trading Fees');
+
+        const treasuryFee = (totalFee * TREASURY_SHARE_PERCENT) / SHARE_DENOMINATOR;
+        const creatorFee = totalFee - treasuryFee;
+
+        if (treasuryFee > 0n) {
+          dailyProtocolRevenue.addGasToken(treasuryFee, 'Treasury Trading Fees');
+        }
+
+        if (creatorFee > 0n) {
+          dailySupplySideRevenue.addGasToken(creatorFee, 'Creator Trading Fees');
+        }
+      }
+
       const grossEthVolume = netEthAmount + totalFee;
 
-      dailyVolume.addGasToken(grossEthVolume);
-      dailyFees.addGasToken(totalFee);
-
-      const treasuryFee = (totalFee * TREASURY_SHARE_PERCENT) / 100n;
-      const creatorFee = totalFee - treasuryFee;
-
-      dailyProtocolRevenue.addGasToken(treasuryFee);
-      dailySupplySideRevenue.addGasToken(creatorFee);
+      if (grossEthVolume > 0n) {
+        dailyVolume.addGasToken(grossEthVolume, 'Sell Volume');
+      }
     }
   }
 
-  // 3. Recompensas de graduación en FeeManager
-  const rewardLogs = await options.getLogs({
+  // 3. Recompensas de graduación desde FeeManager
+  const graduationRewardLogs = await options.getLogs({
     target: FEE_MANAGER,
-    eventAbi: 'event GraduationRewardRecorded(address indexed creator, uint256 creatorReward, uint256 treasuryReward)',
+    eventAbi:
+      'event GraduationRewardRecorded(address indexed creator, uint256 creatorReward, uint256 treasuryReward)',
   });
 
-  for (const log of rewardLogs) {
-    const creatorReward = BigInt(log.creatorReward);
-    const treasuryReward = BigInt(log.treasuryReward);
+  for (const log of graduationRewardLogs) {
+    const creatorReward = BigInt(log.creatorReward || 0);
+    const treasuryReward = BigInt(log.treasuryReward || 0);
     const totalReward = creatorReward + treasuryReward;
 
-    dailyFees.addGasToken(totalReward);
-    dailyProtocolRevenue.addGasToken(treasuryReward);
-    dailySupplySideRevenue.addGasToken(creatorReward);
+    if (totalReward > 0n) {
+      dailyFees.addGasToken(totalReward, 'Graduation Rewards');
+    }
+
+    if (treasuryReward > 0n) {
+      dailyProtocolRevenue.addGasToken(treasuryReward, 'Treasury Graduation Rewards');
+    }
+
+    if (creatorReward > 0n) {
+      dailySupplySideRevenue.addGasToken(creatorReward, 'Creator Graduation Rewards');
+    }
   }
 
   dailyRevenue.addBalances(dailyProtocolRevenue);
@@ -134,14 +178,50 @@ const fetch = async (options: FetchOptions) => {
   };
 };
 
+const methodology = {
+  Volume:
+    'BNB value from Buy events plus gross BNB value from Sell events across all Fairylaunch bonding curves.',
+  Fees:
+    'Total trading fees from buys and sells plus graduation rewards.',
+  Revenue:
+    'Treasury portion of trading fees plus treasury portion of graduation rewards.',
+  ProtocolRevenue:
+    'Treasury fees from trading and graduation rewards.',
+  SupplySideRevenue:
+    'Creator fees from trading and graduation rewards.',
+};
+
+const breakdownMethodology = {
+  Volume: {
+    'Buy Volume': 'BNB value from Buy events.',
+    'Sell Volume': 'Gross BNB value from Sell events.',
+  },
+  Fees: {
+    'Trading Fees': '1% trading fee collected on buys and sells.',
+    'Graduation Rewards': 'Rewards recorded when tokens graduate.',
+  },
+  Revenue: {
+    'Treasury Trading Fees': 'Treasury portion of trading fees.',
+    'Treasury Graduation Rewards': 'Treasury portion of graduation rewards.',
+  },
+  ProtocolRevenue: {
+    'Treasury Trading Fees': 'Treasury portion of trading fees.',
+    'Treasury Graduation Rewards': 'Treasury portion of graduation rewards.',
+  },
+  SupplySideRevenue: {
+    'Creator Trading Fees': 'Creator portion of trading fees.',
+    'Creator Graduation Rewards': 'Creator portion of graduation rewards.',
+  },
+};
+
 const adapter: Adapter = {
   version: 2,
   pullHourly: true,
   chains: [CHAIN.BSC],
-  start: 1786665600, // 16 de Agosto de 2026 00:00:00 UTC
+  start: 1786838400, // August 16, 2026 00:00:00 UTC
   fetch,
   methodology,
-  breakdownMethodology: methodology,
+  breakdownMethodology,
 };
 
 export default adapter;

--- a/fees/fairylaunch/index.ts
+++ b/fees/fairylaunch/index.ts
@@ -105,8 +105,9 @@ const fetch = async (options: FetchOptions) => {
     dailySupplySideRevenue.addGasToken(creatorReward);
   }
 
+  // CORRECCIÓN: dailyRevenue SOLO incluye protocol revenue (treasury)
+  // NO incluye dailySupplySideRevenue (creator fees)
   dailyRevenue.addBalances(dailyProtocolRevenue);
-  dailyRevenue.addBalances(dailySupplySideRevenue);
 
   return {
     dailyVolume,

--- a/fees/fairylaunch/index.ts
+++ b/fees/fairylaunch/index.ts
@@ -7,6 +7,13 @@ const FEE_MANAGER = '0xb6A7D47596D2202676822531F56EFeCeac309775';
 const TREASURY_FEE_BPS = 50n;
 const BPS_DENOMINATOR = 10000n;
 
+const methodology = {
+  Volume: 'ethAmount from Buy events + ethAmount from Sell events across all BondingCurves',
+  Fees: 'fee from Buy/Sell events (1% trading fee)',
+  Revenue: 'Treasury fees (0.5% of trades) + Treasury portion of graduation rewards',
+  ProtocolRevenue: 'Treasury fees (0.5% of trades) + Treasury portion of graduation rewards',
+};
+
 const fetch = async (options: FetchOptions) => {
   const { createBalances, getLogs } = options;
 
@@ -77,12 +84,12 @@ const fetch = async (options: FetchOptions) => {
 
 const adapter: Adapter = {
   version: 2,
-  adapter: {
-    [CHAIN.BSC]: {
-      fetch,
-      start: 1786752000,
-    },
-  },
+  pullHourly: true,
+  chains: [CHAIN.BSC],
+  start: 1786752000,
+  fetch,
+  methodology,
+  breakdownMethodology: methodology,
 };
 
 export default adapter;

--- a/fees/fairylaunch/index.ts
+++ b/fees/fairylaunch/index.ts
@@ -24,7 +24,11 @@ const methodology = {
 };
 
 const fetch = async (options: FetchOptions) => {
-  const { createBalances, getLogs, fromBlock, toBlock } = options;
+  const { createBalances, getLogs } = options;
+  const [fromBlock, toBlock] = await Promise.all([
+    options.getFromBlock(),
+    options.getToBlock(),
+  ]);
 
   const dailyVolume = createBalances();
   const dailyFees = createBalances();

--- a/fees/fairylaunch/index.ts
+++ b/fees/fairylaunch/index.ts
@@ -1,20 +1,33 @@
 import { Adapter, FetchOptions } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
-import ADDRESSES from '../../helpers/coreAssets.json';
 
-// Factory contract on BSC Mainnet: https://bscscan.com/address/0x28163d7943AA6715a9559D468B29c0343412E236
+// Factory contract on BSC Mainnet
+// Deployed at block 116127972
+// Source: https://bscscan.com/address/0x28163d7943AA6715a9559D468B29c0343412E236
 const FACTORY = '0x28163d7943AA6715a9559D468B29c0343412E236';
 
-// FeeManager contract on BSC Mainnet: https://bscscan.com/address/0xb6A7D47596D2202676822531F56EFeCeac309775
+// FeeManager contract on BSC Mainnet
+// Source: https://bscscan.com/address/0xb6A7D47596D2202676822531F56EFeCeac309775
 const FEE_MANAGER = '0xb6A7D47596D2202676822531F56EFeCeac309775';
 
-// Protocol fee split (50% treasury, 50% creator): https://bscscan.com/address/0xb6A7D47596D2202676822531F56EFeCeac309775#code
-const TREASURY_SHARE_PERCENT = 50n;
-const SHARE_DENOMINATOR = 100n;
+// BondingCurveFactory contract on BSC Mainnet
+// This contract emits CurveCreated events with curve address as indexed topic
+// Source: https://bscscan.com/address/0x12959266beada47f0dce13a3a0e54ecfe4fddb29
+const BONDING_CURVE_FACTORY = '0x12959266beada47f0dce13a3a0e54ecfe4fddb29';
 
-// In-memory cache for discovered bonding curves and cursor tracking
-const cachedCurves = new Set<string>();
-let discoveredLaunchCount = 0;
+// Factory deployment block on BSC Mainnet
+// Source: Transaction 0x83c59454a1ab8d8e522d6a6af749cbe0cf63208239f1e51622370ebcfea5d7be
+const FACTORY_DEPLOYMENT_BLOCK = 116127972;
+
+// Batch size for processing bonding curves
+// BSC RPC endpoints can handle ~50 addresses per getLogs call without timeout
+const BATCH_SIZE = 50;
+
+// Cache for bonding curve addresses (persists across calls)
+let cachedCurves: Set<string> | null = null;
+
+// Track the last block we've scanned for new curves
+let lastScannedBlock = FACTORY_DEPLOYMENT_BLOCK;
 
 const fetch = async (options: FetchOptions) => {
   const dailyVolume = options.createBalances();
@@ -23,109 +36,124 @@ const fetch = async (options: FetchOptions) => {
   const dailyProtocolRevenue = options.createBalances();
   const dailySupplySideRevenue = options.createBalances();
 
-  // 1. Descubrimiento incremental de curvas vía RPC multicall
-  const totalLaunchesBN = await options.api.call({
-    target: FACTORY,
-    abi: 'function totalLaunches() view returns (uint256)',
-  });
+  const currentBlock = await options.getToBlock();
+  
+  // Initialize cache if needed
+  if (!cachedCurves) {
+    cachedCurves = new Set<string>();
+    lastScannedBlock = FACTORY_DEPLOYMENT_BLOCK;
+  }
 
-  const totalLaunches = Number(totalLaunchesBN || 0);
-
-  if (totalLaunches > discoveredLaunchCount) {
-    const newLaunchIds = Array.from(
-      { length: totalLaunches - discoveredLaunchCount },
-      (_, i) => discoveredLaunchCount + i + 1
-    );
-
-    const launches = await options.api.multiCall({
-      target: FACTORY,
-      abi: 'function getLaunch(uint256 launchId) view returns ((uint256 launchId, address creator, address treasury, address token, address bondingCurve, bool graduated, uint256 createdAt, uint256 graduatedAt, string name, string symbol, string metadataUri))',
-      calls: newLaunchIds.map((id) => ({ params: [id] })),
+  // Discover new bonding curves from CurveCreated events
+  // This automatically finds ALL curves (past and future)
+  if (currentBlock > lastScannedBlock) {
+    const curveCreatedLogs = await options.getLogs({
+      target: BONDING_CURVE_FACTORY,
+      eventAbi: 'event CurveCreated(address indexed curve, uint256 indexed launchId)',
+      fromBlock: lastScannedBlock,
+      toBlock: currentBlock,
     });
 
-    for (const launch of launches) {
-      if (launch?.bondingCurve && launch.bondingCurve !== ADDRESSES.null) {
-        cachedCurves.add(launch.bondingCurve.toLowerCase());
+    // Add all discovered bonding curves to cache
+    for (const log of curveCreatedLogs) {
+      if (
+        log.curve &&
+        log.curve !== '0x0000000000000000000000000000000000000000' &&
+        /^0x[0-9a-fA-F]{40}$/.test(log.curve)
+      ) {
+        cachedCurves.add(log.curve.toLowerCase());
       }
     }
 
-    // Actualizar cursor solo tras éxito en el recorrido
-    discoveredLaunchCount = totalLaunches;
+    // Update last scanned block
+    lastScannedBlock = currentBlock;
   }
 
   const uniqueCurves = Array.from(cachedCurves);
 
-  // 2. Procesar compras y ventas por lotes
-  const [buyLogs, sellLogs] = await Promise.all([
-    options.getLogs({
-      targets: uniqueCurves,
-      eventAbi:
-        'event Buy(address indexed buyer, uint256 indexed launchId, uint256 ethAmount, uint256 tokenAmount, uint256 fee, uint256 priceAfter, uint256 ethReserveAfter, uint256 timestamp)',
-      flatten: true,
-    }),
-    options.getLogs({
-      targets: uniqueCurves,
-      eventAbi:
-        'event Sell(address indexed seller, uint256 indexed launchId, uint256 tokenAmount, uint256 ethAmount, uint256 fee, uint256 priceAfter, uint256 ethReserveAfter, uint256 timestamp)',
-      flatten: true,
-    }),
-  ]);
+  if (uniqueCurves.length === 0) {
+    return {
+      dailyVolume,
+      dailyFees,
+      dailyRevenue,
+      dailyProtocolRevenue,
+      dailySupplySideRevenue,
+    };
+  }
 
-  for (const log of buyLogs) {
-    const ethAmount = BigInt(log.ethAmount || 0);
-    const totalFee = BigInt(log.fee || 0);
+  // Process buys and sells in batches for all discovered curves
+  for (let i = 0; i < uniqueCurves.length; i += BATCH_SIZE) {
+    const batch = uniqueCurves.slice(i, i + BATCH_SIZE);
 
-    if (ethAmount > 0n) {
-      dailyVolume.addGasToken(ethAmount);
-    }
+    const [buyLogs, sellLogs] = await Promise.all([
+      options.getLogs({
+        targets: batch,
+        eventAbi: 'event Buy(address indexed buyer, uint256 indexed launchId, uint256 ethAmount, uint256 tokenAmount, uint256 fee, uint256 priceAfter, uint256 ethReserveAfter, uint256 timestamp)',
+      }),
+      options.getLogs({
+        targets: batch,
+        eventAbi: 'event Sell(address indexed seller, uint256 indexed launchId, uint256 tokenAmount, uint256 ethAmount, uint256 fee, uint256 priceAfter, uint256 ethReserveAfter, uint256 timestamp)',
+      }),
+    ]);
 
-    if (totalFee > 0n) {
-      dailyFees.addGasToken(totalFee, 'Trading Fees');
+    // Process Buy events
+    for (const log of buyLogs) {
+      const ethAmount = BigInt(log.ethAmount || 0);
+      const totalFee = BigInt(log.fee || 0);
 
-      const treasuryFee = (totalFee * TREASURY_SHARE_PERCENT) / SHARE_DENOMINATOR;
-      const creatorFee = totalFee - treasuryFee;
-
-      if (treasuryFee > 0n) {
-        dailyProtocolRevenue.addGasToken(treasuryFee, 'Treasury Trading Fees');
+      if (ethAmount > 0n) {
+        dailyVolume.addGasToken(ethAmount, 'Buy Volume');
       }
 
-      if (creatorFee > 0n) {
-        dailySupplySideRevenue.addGasToken(creatorFee, 'Creator Trading Fees');
+      if (totalFee > 0n) {
+        dailyFees.addGasToken(totalFee, 'Trading Fees');
+        
+        // Fee split is 50/50 per FeeManager._recordFee()
+        // Source: https://bscscan.com/address/0xb6A7D47596D2202676822531F56EFeCeac309775#code
+        const creatorShare = totalFee / 2n;
+        const treasuryShare = totalFee - creatorShare;
+        
+        if (treasuryShare > 0n) {
+          dailyProtocolRevenue.addGasToken(treasuryShare, 'Treasury Trading Fees');
+        }
+        if (creatorShare > 0n) {
+          dailySupplySideRevenue.addGasToken(creatorShare, 'Creator Trading Fees');
+        }
+      }
+    }
+
+    // Process Sell events
+    for (const log of sellLogs) {
+      const netEthAmount = BigInt(log.ethAmount || 0);
+      const totalFee = BigInt(log.fee || 0);
+
+      if (totalFee > 0n) {
+        dailyFees.addGasToken(totalFee, 'Trading Fees');
+        
+        const creatorShare = totalFee / 2n;
+        const treasuryShare = totalFee - creatorShare;
+        
+        if (treasuryShare > 0n) {
+          dailyProtocolRevenue.addGasToken(treasuryShare, 'Treasury Trading Fees');
+        }
+        if (creatorShare > 0n) {
+          dailySupplySideRevenue.addGasToken(creatorShare, 'Creator Trading Fees');
+        }
+      }
+
+      // Volume = net ETH received + fee (gross volume)
+      const grossEthVolume = netEthAmount + totalFee;
+      
+      if (grossEthVolume > 0n) {
+        dailyVolume.addGasToken(grossEthVolume, 'Sell Volume');
       }
     }
   }
 
-  for (const log of sellLogs) {
-    const netEthAmount = BigInt(log.ethAmount || 0);
-    const totalFee = BigInt(log.fee || 0);
-
-    if (totalFee > 0n) {
-      dailyFees.addGasToken(totalFee, 'Trading Fees');
-
-      const treasuryFee = (totalFee * TREASURY_SHARE_PERCENT) / SHARE_DENOMINATOR;
-      const creatorFee = totalFee - treasuryFee;
-
-      if (treasuryFee > 0n) {
-        dailyProtocolRevenue.addGasToken(treasuryFee, 'Treasury Trading Fees');
-      }
-
-      if (creatorFee > 0n) {
-        dailySupplySideRevenue.addGasToken(creatorFee, 'Creator Trading Fees');
-      }
-    }
-
-    const grossEthVolume = netEthAmount + totalFee;
-
-    if (grossEthVolume > 0n) {
-      dailyVolume.addGasToken(grossEthVolume);
-    }
-  }
-
-  // 3. Recompensas de graduación desde FeeManager
+  // Process graduation rewards from FeeManager
   const graduationRewardLogs = await options.getLogs({
     target: FEE_MANAGER,
-    eventAbi:
-      'event GraduationRewardRecorded(address indexed creator, uint256 creatorReward, uint256 treasuryReward)',
+    eventAbi: 'event GraduationRewardRecorded(address indexed creator, uint256 creatorReward, uint256 treasuryReward)',
   });
 
   for (const log of graduationRewardLogs) {
@@ -136,16 +164,15 @@ const fetch = async (options: FetchOptions) => {
     if (totalReward > 0n) {
       dailyFees.addGasToken(totalReward, 'Graduation Rewards');
     }
-
     if (treasuryReward > 0n) {
       dailyProtocolRevenue.addGasToken(treasuryReward, 'Treasury Graduation Rewards');
     }
-
     if (creatorReward > 0n) {
       dailySupplySideRevenue.addGasToken(creatorReward, 'Creator Graduation Rewards');
     }
   }
 
+  // Revenue = Protocol Revenue (treasury portion only)
   dailyRevenue.addBalances(dailyProtocolRevenue);
 
   return {
@@ -158,33 +185,32 @@ const fetch = async (options: FetchOptions) => {
 };
 
 const methodology = {
-  Volume:
-    'BNB value from Buy events plus gross BNB value from Sell events across all Fairylaunch bonding curves.',
-  Fees:
-    'Total trading fees from buys and sells plus graduation rewards.',
-  Revenue:
-    'Treasury portion of trading fees plus treasury portion of graduation rewards.',
-  ProtocolRevenue:
-    'Treasury fees from trading and graduation rewards.',
-  SupplySideRevenue:
-    'Creator fees from trading and graduation rewards.',
+  Volume: 'BNB value from Buy events plus gross BNB value from Sell events across all Fairylaunch bonding curves.',
+  Fees: 'Total trading fees from buys and sells plus graduation rewards.',
+  Revenue: 'Treasury portion of trading fees plus treasury portion of graduation rewards.',
+  ProtocolRevenue: 'Treasury fees from trading and graduation rewards.',
+  SupplySideRevenue: 'Creator fees from trading and graduation rewards.',
 };
 
 const breakdownMethodology = {
+  Volume: {
+    'Buy Volume': 'BNB value from Buy events.',
+    'Sell Volume': 'Gross BNB value from Sell events (net ETH + fee).',
+  },
   Fees: {
-    'Trading Fees': '1% trading fee collected on buys and sells.',
-    'Graduation Rewards': 'Rewards recorded when tokens graduate.',
+    'Trading Fees': 'Trading fee collected on buys and sells.',
+    'Graduation Rewards': 'Rewards recorded when tokens graduate to liquidity pools.',
   },
   Revenue: {
-    'Treasury Trading Fees': 'Treasury portion of trading fees.',
+    'Treasury Trading Fees': 'Treasury portion of trading fees (50%).',
     'Treasury Graduation Rewards': 'Treasury portion of graduation rewards.',
   },
   ProtocolRevenue: {
-    'Treasury Trading Fees': 'Treasury portion of trading fees.',
+    'Treasury Trading Fees': 'Treasury portion of trading fees (50%).',
     'Treasury Graduation Rewards': 'Treasury portion of graduation rewards.',
   },
   SupplySideRevenue: {
-    'Creator Trading Fees': 'Creator portion of trading fees.',
+    'Creator Trading Fees': 'Creator portion of trading fees (50%).',
     'Creator Graduation Rewards': 'Creator portion of graduation rewards.',
   },
 };
@@ -193,10 +219,12 @@ const adapter: Adapter = {
   version: 2,
   pullHourly: true,
   chains: [CHAIN.BSC],
-  start: '2026-08-16',
+  // Deployment block 116127972 - not a timestamp
+  // Source: https://bscscan.com/tx/0x83c59454a1ab8d8e522d6a6af749cbe0cf63208239f1e51622370ebcfea5d7be
+  start: 116127972,
   fetch,
   methodology,
   breakdownMethodology,
 };
 
-export default adapter; 
+export default adapter;

--- a/fees/fairylaunch/index.ts
+++ b/fees/fairylaunch/index.ts
@@ -1,21 +1,27 @@
 import { Adapter, FetchOptions } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 
-// BSC Mainnet contracts
+// BSC Mainnet Contracts
+// Factory: https://bscscan.com/address/0x28163d7943AA6715a9559D468B29c0343412E236
 const FACTORY = '0x28163d7943AA6715a9559D468B29c0343412E236';
+
+// FeeManager: https://bscscan.com/address/0xb6A7D47596D2202676822531F56EFeCeac309775
 const FEE_MANAGER = '0xb6A7D47596D2202676822531F56EFeCeac309775';
 
-// Bloque de despliegue del Factory en BSC Mainnet
+// Factory Deployment Block on BSC Mainnet
 const FACTORY_DEPLOY_BLOCK = 
-116127983; // Ajusta con el número de bloque exacto del despliegue
+116127983;
 
+// Repartición de comisiones: 50% Protocolo (Treasury), 50% Creador del token
 const TREASURY_SHARE_PERCENT = 50n;
+
+// Registro persistente en memoria para almacenar las bonding curves descubiertas
 const cachedCurves = new Set<string>();
 
 const methodology = {
   Volume: 'ethAmount from Buy events + gross ethAmount (ethAmount + fee) from Sell events across all BondingCurves',
-  Fees: 'Total trading fees from Buy/Sell events + Graduation rewards',
-  Revenue: 'Treasury fees + Treasury portion of graduation rewards',
+  Fees: 'Total trading fees (1% per trade) + Graduation rewards',
+  Revenue: 'Treasury portion of trading fees (0.5%) + Treasury portion of graduation rewards',
   ProtocolRevenue: 'Treasury fees (50% of trading fees) + Treasury portion of graduation rewards',
   SupplySideRevenue: 'Creator fees (50% of trading fees) + Creator portion of graduation rewards',
 };
@@ -27,11 +33,13 @@ const fetch = async (options: FetchOptions) => {
   const dailyProtocolRevenue = options.createBalances();
   const dailySupplySideRevenue = options.createBalances();
 
-  // 1. Obtener TODAS las curvas creadas desde el despliegue del Factory
+  // 1. Descubrimiento de curvas: consulta histórica en cold start, o incremental en slots posteriores
   const launchLogs = await options.getLogs({
     target: FACTORY,
-    fromBlock: FACTORY_DEPLOY_BLOCK,
+    fromBlock: cachedCurves.size === 0 ? FACTORY_DEPLOY_BLOCK : undefined,
+    toBlock: options.getToBlock(),
     eventAbi: 'event LaunchCreated(uint256 indexed launchId, address indexed creator, address indexed token, address bondingCurve, string name, string symbol, string metadataUri)',
+    maxBlockRange: 20000,
   });
 
   for (const log of launchLogs) {
@@ -42,7 +50,7 @@ const fetch = async (options: FetchOptions) => {
 
   const uniqueCurves = Array.from(cachedCurves);
 
-  // 2. Consultar compras/ventas de las curvas ÚNICAMENTE dentro del rango del slot actual
+  // 2. Procesamiento de trades solo si existen curvas registradas
   if (uniqueCurves.length > 0) {
     const buyLogs = await options.getLogs({
       targets: uniqueCurves,
@@ -84,7 +92,7 @@ const fetch = async (options: FetchOptions) => {
     }
   }
 
-  // 3. Consultar graduaciones del slot actual
+  // 3. Recompensas de graduación en FeeManager
   const rewardLogs = await options.getLogs({
     target: FEE_MANAGER,
     eventAbi: 'event GraduationRewardRecorded(address indexed creator, uint256 creatorReward, uint256 treasuryReward)',
@@ -115,7 +123,7 @@ const adapter: Adapter = {
   version: 2,
   pullHourly: true,
   chains: [CHAIN.BSC],
-  start: 1786752000,
+  start: 1786752000, // 2026-08-17 00:00:00 UTC
   fetch,
   methodology,
   breakdownMethodology: methodology,

--- a/fees/fairylaunch/index.ts
+++ b/fees/fairylaunch/index.ts
@@ -1,22 +1,20 @@
 import { Adapter, FetchOptions } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
+import ADDRESSES from '../../helpers/coreAssets.json';
 
-// FeeManager contract on BSC Mainnet
-// Source: https://bscscan.com/address/0xb6A7D47596D2202676822531F56EFeCeac309775
+// Factory contract on BSC Mainnet: https://bscscan.com/address/0x28163d7943AA6715a9559D468B29c0343412E236
+const FACTORY = '0x28163d7943AA6715a9559D468B29c0343412E236';
+
+// FeeManager contract on BSC Mainnet: https://bscscan.com/address/0xb6A7D47596D2202676822531F56EFeCeac309775
 const FEE_MANAGER = '0xb6A7D47596D2202676822531F56EFeCeac309775';
 
-// BondingCurveFactory contract on BSC Mainnet
-// This contract emits CurveCreated events with curve address as indexed topic
-// Source: https://bscscan.com/address/0x12959266beada47f0dce13a3a0e54ecfe4fddb29
-const BONDING_CURVE_FACTORY = '0x12959266beada47f0dce13a3a0e54ecfe4fddb29';
+// Protocol fee split (50% treasury, 50% creator): https://bscscan.com/address/0xb6A7D47596D2202676822531F56EFeCeac309775#code
+const TREASURY_SHARE_PERCENT = 50n;
+const SHARE_DENOMINATOR = 100n;
 
-// Factory deployment block on BSC Mainnet
-// Source: Transaction 0x83c59454a1ab8d8e522d6a6af749cbe0cf63208239f1e51622370ebcfea5d7be
-const FACTORY_DEPLOYMENT_BLOCK = 116127972;
-
-// Cache for bonding curve addresses
-let cachedCurves: Set<string> | null = null;
-let lastScannedBlock = FACTORY_DEPLOYMENT_BLOCK;
+// In-memory cache for discovered bonding curves and cursor tracking
+const cachedCurves = new Set<string>();
+let discoveredLaunchCount = 0;
 
 const fetch = async (options: FetchOptions) => {
   const dailyVolume = options.createBalances();
@@ -25,118 +23,109 @@ const fetch = async (options: FetchOptions) => {
   const dailyProtocolRevenue = options.createBalances();
   const dailySupplySideRevenue = options.createBalances();
 
-  const currentBlock = await options.getToBlock();
+  // 1. Descubrimiento incremental de curvas vía RPC multicall
+  const totalLaunchesBN = await options.api.call({
+    target: FACTORY,
+    abi: 'function totalLaunches() view returns (uint256)',
+  });
 
-  // Initialize cache
-  if (!cachedCurves) {
-    cachedCurves = new Set<string>();
-  }
+  const totalLaunches = Number(totalLaunchesBN || 0);
 
-  // Discover curves from CurveCreated events
-  // Only scan if we haven't scanned recently (avoid rate limits)
-  if (cachedCurves.size === 0 || currentBlock > lastScannedBlock + 100) {
-    const curveCreatedLogs = await options.getLogs({
-      target: BONDING_CURVE_FACTORY,
-      eventAbi: 'event CurveCreated(address indexed curve, uint256 indexed launchId)',
-      fromBlock: lastScannedBlock,
-      toBlock: currentBlock,
+  if (totalLaunches > discoveredLaunchCount) {
+    const newLaunchIds = Array.from(
+      { length: totalLaunches - discoveredLaunchCount },
+      (_, i) => discoveredLaunchCount + i + 1
+    );
+
+    const launches = await options.api.multiCall({
+      target: FACTORY,
+      abi: 'function getLaunch(uint256 launchId) view returns ((uint256 launchId, address creator, address treasury, address token, address bondingCurve, bool graduated, uint256 createdAt, uint256 graduatedAt, string name, string symbol, string metadataUri))',
+      calls: newLaunchIds.map((id) => ({ params: [id] })),
     });
 
-    for (const log of curveCreatedLogs) {
-      if (
-        log.curve &&
-        log.curve !== '0x0000000000000000000000000000000000000000' &&
-        /^0x[0-9a-fA-F]{40}$/.test(log.curve)
-      ) {
-        cachedCurves.add(log.curve.toLowerCase());
+    for (const launch of launches) {
+      if (launch?.bondingCurve && launch.bondingCurve !== ADDRESSES.null) {
+        cachedCurves.add(launch.bondingCurve.toLowerCase());
       }
     }
 
-    lastScannedBlock = currentBlock;
+    // Actualizar cursor solo tras éxito en el recorrido
+    discoveredLaunchCount = totalLaunches;
   }
 
   const uniqueCurves = Array.from(cachedCurves);
 
-  if (uniqueCurves.length === 0) {
-    return {
-      dailyVolume,
-      dailyFees,
-      dailyRevenue,
-      dailyProtocolRevenue,
-      dailySupplySideRevenue,
-    };
-  }
-
-  // Get Buy and Sell events from the bonding curves themselves
-  // Use targets array with discovered curves
+  // 2. Procesar compras y ventas por lotes
   const [buyLogs, sellLogs] = await Promise.all([
     options.getLogs({
       targets: uniqueCurves,
-      eventAbi: 'event Buy(address indexed buyer, uint256 indexed launchId, uint256 ethAmount, uint256 tokenAmount, uint256 fee, uint256 priceAfter, uint256 ethReserveAfter, uint256 timestamp)',
+      eventAbi:
+        'event Buy(address indexed buyer, uint256 indexed launchId, uint256 ethAmount, uint256 tokenAmount, uint256 fee, uint256 priceAfter, uint256 ethReserveAfter, uint256 timestamp)',
+      flatten: true,
     }),
     options.getLogs({
       targets: uniqueCurves,
-      eventAbi: 'event Sell(address indexed seller, uint256 indexed launchId, uint256 tokenAmount, uint256 ethAmount, uint256 fee, uint256 priceAfter, uint256 ethReserveAfter, uint256 timestamp)',
+      eventAbi:
+        'event Sell(address indexed seller, uint256 indexed launchId, uint256 tokenAmount, uint256 ethAmount, uint256 fee, uint256 priceAfter, uint256 ethReserveAfter, uint256 timestamp)',
+      flatten: true,
     }),
   ]);
 
-  // Process Buy events
   for (const log of buyLogs) {
     const ethAmount = BigInt(log.ethAmount || 0);
     const totalFee = BigInt(log.fee || 0);
 
     if (ethAmount > 0n) {
-      dailyVolume.addGasToken(ethAmount, 'Buy Volume');
+      dailyVolume.addGasToken(ethAmount);
     }
 
     if (totalFee > 0n) {
       dailyFees.addGasToken(totalFee, 'Trading Fees');
-      
-      // Fee split is 50/50 per FeeManager._recordFee()
-      // Source: https://bscscan.com/address/0xb6A7D47596D2202676822531F56EFeCeac309775#code
-      const creatorShare = totalFee / 2n;
-      const treasuryShare = totalFee - creatorShare;
-      
-      if (treasuryShare > 0n) {
-        dailyProtocolRevenue.addGasToken(treasuryShare, 'Treasury Trading Fees');
+
+      const treasuryFee = (totalFee * TREASURY_SHARE_PERCENT) / SHARE_DENOMINATOR;
+      const creatorFee = totalFee - treasuryFee;
+
+      if (treasuryFee > 0n) {
+        dailyProtocolRevenue.addGasToken(treasuryFee, 'Treasury Trading Fees');
       }
-      if (creatorShare > 0n) {
-        dailySupplySideRevenue.addGasToken(creatorShare, 'Creator Trading Fees');
+
+      if (creatorFee > 0n) {
+        dailySupplySideRevenue.addGasToken(creatorFee, 'Creator Trading Fees');
       }
     }
   }
 
-  // Process Sell events
   for (const log of sellLogs) {
     const netEthAmount = BigInt(log.ethAmount || 0);
     const totalFee = BigInt(log.fee || 0);
 
     if (totalFee > 0n) {
       dailyFees.addGasToken(totalFee, 'Trading Fees');
-      
-      const creatorShare = totalFee / 2n;
-      const treasuryShare = totalFee - creatorShare;
-      
-      if (treasuryShare > 0n) {
-        dailyProtocolRevenue.addGasToken(treasuryShare, 'Treasury Trading Fees');
+
+      const treasuryFee = (totalFee * TREASURY_SHARE_PERCENT) / SHARE_DENOMINATOR;
+      const creatorFee = totalFee - treasuryFee;
+
+      if (treasuryFee > 0n) {
+        dailyProtocolRevenue.addGasToken(treasuryFee, 'Treasury Trading Fees');
       }
-      if (creatorShare > 0n) {
-        dailySupplySideRevenue.addGasToken(creatorShare, 'Creator Trading Fees');
+
+      if (creatorFee > 0n) {
+        dailySupplySideRevenue.addGasToken(creatorFee, 'Creator Trading Fees');
       }
     }
 
-    // Volume = net ETH received + fee (gross volume)
     const grossEthVolume = netEthAmount + totalFee;
-    
+
     if (grossEthVolume > 0n) {
-      dailyVolume.addGasToken(grossEthVolume, 'Sell Volume');
+      dailyVolume.addGasToken(grossEthVolume);
     }
   }
 
-  // Process graduation rewards from FeeManager
+  // 3. Recompensas de graduación desde FeeManager
   const graduationRewardLogs = await options.getLogs({
     target: FEE_MANAGER,
-    eventAbi: 'event GraduationRewardRecorded(address indexed creator, uint256 creatorReward, uint256 treasuryReward)',
+    eventAbi:
+      'event GraduationRewardRecorded(address indexed creator, uint256 creatorReward, uint256 treasuryReward)',
   });
 
   for (const log of graduationRewardLogs) {
@@ -147,15 +136,16 @@ const fetch = async (options: FetchOptions) => {
     if (totalReward > 0n) {
       dailyFees.addGasToken(totalReward, 'Graduation Rewards');
     }
+
     if (treasuryReward > 0n) {
       dailyProtocolRevenue.addGasToken(treasuryReward, 'Treasury Graduation Rewards');
     }
+
     if (creatorReward > 0n) {
       dailySupplySideRevenue.addGasToken(creatorReward, 'Creator Graduation Rewards');
     }
   }
 
-  // Revenue = Protocol Revenue (treasury portion only)
   dailyRevenue.addBalances(dailyProtocolRevenue);
 
   return {
@@ -168,32 +158,33 @@ const fetch = async (options: FetchOptions) => {
 };
 
 const methodology = {
-  Volume: 'BNB value from Buy events plus gross BNB value from Sell events across all Fairylaunch bonding curves.',
-  Fees: 'Total trading fees from buys and sells plus graduation rewards.',
-  Revenue: 'Treasury portion of trading fees plus treasury portion of graduation rewards.',
-  ProtocolRevenue: 'Treasury fees from trading and graduation rewards.',
-  SupplySideRevenue: 'Creator fees from trading and graduation rewards.',
+  Volume:
+    'BNB value from Buy events plus gross BNB value from Sell events across all Fairylaunch bonding curves.',
+  Fees:
+    'Total trading fees from buys and sells plus graduation rewards.',
+  Revenue:
+    'Treasury portion of trading fees plus treasury portion of graduation rewards.',
+  ProtocolRevenue:
+    'Treasury fees from trading and graduation rewards.',
+  SupplySideRevenue:
+    'Creator fees from trading and graduation rewards.',
 };
 
 const breakdownMethodology = {
-  Volume: {
-    'Buy Volume': 'BNB value from Buy events.',
-    'Sell Volume': 'Gross BNB value from Sell events (net ETH + fee).',
-  },
   Fees: {
-    'Trading Fees': 'Trading fee collected on buys and sells.',
-    'Graduation Rewards': 'Rewards recorded when tokens graduate to liquidity pools.',
+    'Trading Fees': '1% trading fee collected on buys and sells.',
+    'Graduation Rewards': 'Rewards recorded when tokens graduate.',
   },
   Revenue: {
-    'Treasury Trading Fees': 'Treasury portion of trading fees (50%).',
+    'Treasury Trading Fees': 'Treasury portion of trading fees.',
     'Treasury Graduation Rewards': 'Treasury portion of graduation rewards.',
   },
   ProtocolRevenue: {
-    'Treasury Trading Fees': 'Treasury portion of trading fees (50%).',
+    'Treasury Trading Fees': 'Treasury portion of trading fees.',
     'Treasury Graduation Rewards': 'Treasury portion of graduation rewards.',
   },
   SupplySideRevenue: {
-    'Creator Trading Fees': 'Creator portion of trading fees (50%).',
+    'Creator Trading Fees': 'Creator portion of trading fees.',
     'Creator Graduation Rewards': 'Creator portion of graduation rewards.',
   },
 };
@@ -202,12 +193,10 @@ const adapter: Adapter = {
   version: 2,
   pullHourly: true,
   chains: [CHAIN.BSC],
-  // Deployment block 116127972 - not a timestamp
-  // Source: https://bscscan.com/tx/0x83c59454a1ab8d8e522d6a6af749cbe0cf63208239f1e51622370ebcfea5d7be
-  start: 116127972,
+  start: '2026-08-16',
   fetch,
   methodology,
   breakdownMethodology,
 };
 
-export default adapter;
+export default adapter; 


### PR DESCRIPTION
# Add FairyLaunch Adapter

## Protocol Description
FairyLaunch is a Pump.fun style launchpad on BSC using bonding curves. Each launch creates a dedicated BondingCurve where users trade tokens with native BNB.

## New Listing Information
- **Name:** FairyLaunch
- **Category:** Launchpad
- **Chain:** BSC
- **Website:** https://fairylaunch.xyz
- **Twitter:** https://x.com/FairyLaunch
- **Logo:** https://fairylaunch.xyz/logo.png
- **Current TVL:** $1.97 USD
- **Github Org:** https://github.com/FairyLaunch

## Contracts (BSC Mainnet)
- **LaunchFactory:** `0x28163d7943AA6715a9559D468B29c0343412E236`
- **FeeManager:** `0xb6A7D47596D2202676822531F56EFeCeac309775`
- **BondingCurveFactory:** `0x12959266beada47f0dce13a3a0e54ecfe4fddb29`

## Methodology
- **Volume:** `ethAmount` from Buy events + gross `ethAmount` (`ethAmount` + `fee`) from Sell events
- **Fees:** Total trading fees (1% per trade) + Graduation rewards
- **Revenue:** Treasury portion of trading fees (50%) + Treasury graduation rewards
- **Protocol Revenue:** Treasury fees from trading and graduation
- **Supply Side Revenue:** Creator portion of trading fees (50%) + Creator graduation rewards