### PR TITLE
x402: add Celo facilitator (x402.celo.org) settlement address

### DIFF
--- a/dexs/x402/facilitators.ts
+++ b/dexs/x402/facilitators.ts
@@ -125,6 +125,8 @@ export const facilitators: Record<string, string[]> = {
         "0x103040545ac5031a11e8c03dd11324c7333a13c7",
         // virtuals
         "0x80735b3f7808e2e229ace880dbe85e80115631ca",
+        // x402.celo.org (Celo facilitator)
+        "0x0d74d5cefd2e7f24e623330ebe3d8d4cb45ffb48",
         // x402jobs
         "0x51fec16843e49b99aaf9814e525aee1756e66a62",
         // x402rs


### PR DESCRIPTION
This PR is not a new protocol listing — it adds one facilitator settlement address to the existing x402 adapter's registry (`dexs/x402/facilitators.ts`), so the form is replaced with details per the template instructions.

## What

Adds the settlement relayer address of **x402.celo.org**, the x402 facilitator for Celo (`https://api.x402.celo.org`, self-hosted deployment of [x402-rs](https://github.com/x402-rs/x402-rs), operated by [celo-org](https://github.com/celo-org/x402-facilitator)) to the EVM facilitator list:

- `0x0d74d5cefd2e7f24e623330ebe3d8d4cb45ffb48`

Celo is already in the adapter's `DUNE_CHAIN_MAP`, so no other change is needed. The address is not among the upstream `x402rs` addresses already listed.

## Evidence

All settlements are `transferWithAuthorization` (EIP-3009) transactions submitted by this relayer on Celo mainnet (chain id 42220), settling USDC (`0xcebA9300f2b948710d2653dD7B07f33A8B32118C`) and USDT (`0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e`) — both indexed by Dune `tokens.transfers`.

Public Dune query using the same filters as this adapter (`tx_from = relayer`, `"from" != tx_from`, `"from" != "to"`): https://dune.com/queries/8364875

As of 2026-08-17: **750,582 settlements**, ~$32.8k USD volume, 769 unique payers, 424 unique payees; first settlement 2026-07-01, active daily since.

## Testing

The adapter is Dune-backed (`isExpensiveAdapter`), so I did not run `npm run test dexs x402` to avoid spending your Dune credits from CI defaults — the standalone query above validates the address against the exact same `tokens.transfers` filters. Happy to run it if you prefer.
