### PR TITLE
Add StockRip fees, revenue and volume adapter (Robinhood Chain)

### DIFF
--- a/fees/stockrip/index.ts
+++ b/fees/stockrip/index.ts
@@ -6,9 +6,10 @@ import { ChainApi } from "@defillama/sdk";
 // acquisition fee to be allocated one at random, then keep it, relist it, or take a discounted
 // settlement of its backing.
 const CORE = "0x32E8D5b0b8643dC002864a2F5e4481E59eb714CB";
+// Rewards module: credits part of each acquisition fee back to the purchaser as RIP buying power
+const REWARDS = "0x91D032555CB90A8B2792eEaB5F192c41A6a647eF";
 // Uniswap v4 hook on the ETH/RIP pool: 1% fee on every swap, paid to the protocol treasury
 const HOOK = "0xf295127365a2C3055FdfBa01b0596dA56DCFa444";
-const BPS = 10_000n;
 const Q192 = 1n << 192n;
 
 const METRICS = {
@@ -29,11 +30,13 @@ const ABIS = {
   DepositorBidAcceptedAsTokens: "event DepositorBidAcceptedAsTokens(uint256 indexed listingId, address indexed purchaser, address indexed depositor, uint256 ethPayout, uint256 retained, uint256 tokenOut)",
   OwnerFeesAccrued: "event OwnerFeesAccrued(uint256 amount)",
   ProtocolFeesToToken: "event ProtocolFeesToToken(uint256 amount)",
+  AcquisitionTokenAccrued: "event AcquisitionTokenAccrued(address indexed purchaser, uint256 indexed requestId, uint256 slice)",
   HookFee: "event HookFee(bytes32 indexed id, address indexed sender, uint128 feeAmount0, uint128 feeAmount1)",
   Trade: "event Trade(uint160 sqrtPriceX96, int128 ethAmount, int128 tokenAmount)",
   acquisitions: "function acquisitions(uint256) view returns (address purchaser, uint256 requestBlock, uint256 priceEscrowed, uint256 listingId, uint8 status)",
-  acquisitionTokenSlice: "function acquisitionTokenSlice(uint256) view returns (uint256)",
 };
+
+const sumBy = (logs: any[], field: string | number) => logs.reduce((acc: bigint, log: any) => acc + BigInt(log.args[field]), 0n);
 
 const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
   const dailyVolume = options.createBalances();
@@ -43,91 +46,77 @@ const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
   const dailyProtocolRevenue = options.createBalances();
   const dailyHoldersRevenue = options.createBalances();
 
-  const [allocated, topListingFunded, nftKept, nftRelisted, bidAccepted, bidAcceptedAsTokens, ownerFees, feesToToken, hookFees, trades] = await Promise.all([
-    options.getLogs({ target: CORE, eventAbi: ABIS.NFTAllocated }),
-    options.getLogs({ target: CORE, eventAbi: ABIS.TopListingFunded }),
-    options.getLogs({ target: CORE, eventAbi: ABIS.NFTKept }),
-    options.getLogs({ target: CORE, eventAbi: ABIS.NFTRelisted }),
-    options.getLogs({ target: CORE, eventAbi: ABIS.DepositorBidAccepted }),
-    options.getLogs({ target: CORE, eventAbi: ABIS.DepositorBidAcceptedAsTokens }),
-    options.getLogs({ target: CORE, eventAbi: ABIS.OwnerFeesAccrued }),
-    options.getLogs({ target: CORE, eventAbi: ABIS.ProtocolFeesToToken }),
-    options.getLogs({ target: HOOK, eventAbi: ABIS.HookFee, onlyArgs: false }),
-    options.getLogs({ target: HOOK, eventAbi: ABIS.Trade, onlyArgs: false }),
-  ]);
-
-  // Robinhood Chain's public RPC is not an archive node, so state is read at the latest block.
-  // Acquisition records are immutable once written and the fee config has not changed since launch.
-  const api = new ChainApi({ chain: options.chain });
-  const [ownerSettlementFeeBps, retainedToProtocol] = await Promise.all([
-    api.call({ target: CORE, abi: 'uint256:ownerSettlementFeeBps' }),
-    api.call({ target: CORE, abi: 'bool:retainedToProtocol' }),
+  const getLogs = (target: string, eventAbi: string) => options.getLogs({ target, eventAbi, onlyArgs: false });
+  const [allocated, topListingFunded, nftKept, nftRelisted, bidAccepted, bidAcceptedAsTokens, ownerFees, feesToToken, slices, hookFees, trades] = await Promise.all([
+    getLogs(CORE, ABIS.NFTAllocated),
+    getLogs(CORE, ABIS.TopListingFunded),
+    getLogs(CORE, ABIS.NFTKept),
+    getLogs(CORE, ABIS.NFTRelisted),
+    getLogs(CORE, ABIS.DepositorBidAccepted),
+    getLogs(CORE, ABIS.DepositorBidAcceptedAsTokens),
+    getLogs(CORE, ABIS.OwnerFeesAccrued),
+    getLogs(CORE, ABIS.ProtocolFeesToToken),
+    getLogs(REWARDS, ABIS.AcquisitionTokenAccrued),
+    getLogs(HOOK, ABIS.HookFee),
+    getLogs(HOOK, ABIS.Trade),
   ]);
 
   // Acquisition fees are booked when the request is allocated. NFTAllocated does not carry the
-  // fee, so the escrowed price and the purchaser's RIP slice are read back per request id.
-  // Refunded, expired and slippage-cancelled requests never allocate, so they are excluded.
-  const requestIds = allocated.map((log: any) => log.requestId.toString());
-  const [acquisitions, slices] = await Promise.all([
-    api.multiCall({ abi: ABIS.acquisitions, target: CORE, calls: requestIds }),
-    api.multiCall({ abi: ABIS.acquisitionTokenSlice, target: CORE, calls: requestIds }),
-  ]);
-  let acquisitionVolume = 0n;
-  let acquisitionFees = 0n;
-  acquisitions.forEach((acq: any, i: number) => {
-    const price = BigInt(acq.priceEscrowed);
-    acquisitionVolume += price;
-    // The slice credited back to the purchaser as RIP buying power is netted out.
-    acquisitionFees += price - BigInt(slices[i]);
-  });
+  // fee, so the escrowed price is read from the acquisition record, which is never modified after
+  // the request. Robinhood Chain's public RPC is not an archive node, so it is read at the latest
+  // block. Refunded, expired and slippage-cancelled requests never allocate and are excluded.
+  const api = new ChainApi({ chain: options.chain });
+  const acquisitions = await api.multiCall({ abi: ABIS.acquisitions, target: CORE, calls: allocated.map((log: any) => log.args.requestId.toString()) });
+  const acquisitionVolume = acquisitions.reduce((acc: bigint, acq: any) => acc + BigInt(acq.priceEscrowed), 0n);
+  // The slice credited back to the purchaser as RIP buying power is netted out. It is emitted by
+  // the rewards module in the allocation transaction.
+  const acquisitionFees = acquisitionVolume - sumBy(slices, 2); // args.slice is shadowed by Array.prototype.slice
   dailyVolume.addGasToken(acquisitionVolume);
   dailyFees.addGasToken(acquisitionFees, METRICS.AcquisitionFees);
 
-  // Settlement fee when the backing returns to the depositor (purchaser keeps or relists):
-  // the events carry the depositor payout net of the cut, so gross the fee back up.
-  const settleBps = BigInt(ownerSettlementFeeBps);
+  // Every protocol accrual emits OwnerFeesAccrued in the transaction that produced it, so accruals
+  // are attributed by the settlement or allocation event sharing their transaction hash. This
+  // avoids reading fee rates that the owner can change.
+  const txsOf = (logs: any[]) => new Set(logs.map((log: any) => log.transactionHash));
+  const settlementTxs = txsOf([...nftKept, ...nftRelisted]);
+  const discountedTxs = txsOf([...bidAccepted, ...bidAcceptedAsTokens]);
   let settlementFees = 0n;
-  nftKept.forEach((log: any) => { settlementFees += BigInt(log.backing) * settleBps / (BPS - settleBps); });
-  nftRelisted.forEach((log: any) => { settlementFees += BigInt(log.toDepositor) * settleBps / (BPS - settleBps); });
-  dailyFees.addGasToken(settlementFees, METRICS.SettlementFees);
-
-  // Backing retained when the purchaser takes the discounted settlement instead of the basket.
-  // Protocol revenue when retainedToProtocol, otherwise shared among active depositors.
-  let retained = 0n;
-  bidAccepted.forEach((log: any) => { retained += BigInt(log.retained); });
-  bidAcceptedAsTokens.forEach((log: any) => { retained += BigInt(log.retained); });
-  dailyFees.addGasToken(retained, METRICS.RetainedSettlements);
-  if (!retainedToProtocol) dailySupplySideRevenue.addGasToken(retained, METRICS.RetainedSettlements);
-
-  // OwnerFeesAccrued covers every protocol accrual, so the protocol's cut of acquisition fees is
-  // what remains after the settlement-side accruals above.
-  let totalOwnerFees = 0n;
-  ownerFees.forEach((log: any) => { totalOwnerFees += BigInt(log.amount); });
-  let acquisitionCut = totalOwnerFees - settlementFees - (retainedToProtocol ? retained : 0n);
-  if (acquisitionCut < 0n) acquisitionCut = 0n;
+  let retainedToProtocol = 0n;
+  let acquisitionCut = 0n;
+  ownerFees.forEach((log: any) => {
+    const amount = BigInt(log.args.amount);
+    if (settlementTxs.has(log.transactionHash)) settlementFees += amount;
+    else if (discountedTxs.has(log.transactionHash)) retainedToProtocol += amount;
+    else acquisitionCut += amount;
+  });
   if (acquisitionCut > acquisitionFees) acquisitionCut = acquisitionFees;
 
-  // The rest of the acquisition fee goes to depositors: a share to the top-backed listing's pot,
-  // the remainder split equally across active listings.
-  let topListingShare = 0n;
-  topListingFunded.forEach((log: any) => { topListingShare += BigInt(log.amount); });
+  // Settlement fee when the backing returns to the depositor (purchaser keeps or relists).
+  dailyFees.addGasToken(settlementFees, METRICS.SettlementFees);
+  dailyRevenue.addGasToken(settlementFees, METRICS.SettlementFees);
+  dailyProtocolRevenue.addGasToken(settlementFees, METRICS.SettlementFees);
+
+  // Backing retained when the purchaser takes the discounted settlement instead of the basket.
+  // Kept by the protocol by default; the remainder, if any, was shared among active depositors.
+  const retained = sumBy(bidAccepted, 'retained') + sumBy(bidAcceptedAsTokens, 'retained');
+  dailyFees.addGasToken(retained, METRICS.RetainedSettlements);
+  dailyRevenue.addGasToken(retainedToProtocol, METRICS.RetainedSettlements);
+  dailyProtocolRevenue.addGasToken(retainedToProtocol, METRICS.RetainedSettlements);
+  if (retained > retainedToProtocol) dailySupplySideRevenue.addGasToken(retained - retainedToProtocol, METRICS.RetainedSettlements);
+
+  // The protocol's cut of acquisition fees; the rest goes to depositors as a share to the
+  // top-backed listing's pot and an equal split across active listings.
+  dailyRevenue.addGasToken(acquisitionCut, METRICS.AcquisitionFees);
+  dailyProtocolRevenue.addGasToken(acquisitionCut, METRICS.AcquisitionFees);
+  const topListingShare = sumBy(topListingFunded, 'amount');
   let depositorShare = acquisitionFees - acquisitionCut - topListingShare;
   if (depositorShare < 0n) depositorShare = 0n;
   dailySupplySideRevenue.addGasToken(depositorShare, METRICS.AcquisitionFees);
   dailySupplySideRevenue.addGasToken(topListingShare, METRICS.TopListingReward);
 
-  dailyRevenue.addGasToken(acquisitionCut, METRICS.AcquisitionFees);
-  dailyRevenue.addGasToken(settlementFees, METRICS.SettlementFees);
-  dailyProtocolRevenue.addGasToken(acquisitionCut, METRICS.AcquisitionFees);
-  dailyProtocolRevenue.addGasToken(settlementFees, METRICS.SettlementFees);
-  if (retainedToProtocol) {
-    dailyRevenue.addGasToken(retained, METRICS.RetainedSettlements);
-    dailyProtocolRevenue.addGasToken(retained, METRICS.RetainedSettlements);
-  }
-
   // Accrued protocol fees are paid out later; a protocolFeeToTokenBps slice can go to RIP buybacks
   // at that time. Recorded as holders revenue when the payout happens.
-  feesToToken.forEach((log: any) => { dailyHoldersRevenue.addGasToken(log.amount, METRICS.TokenBuyBack); });
+  feesToToken.forEach((log: any) => { dailyHoldersRevenue.addGasToken(log.args.amount, METRICS.TokenBuyBack); });
 
   // Hook swap fees. Sells pay in ETH (feeAmount0). Buys pay in RIP (feeAmount1), which the hook
   // swaps to ETH inside the same afterSwap call without emitting the amount, so it is valued at
@@ -159,7 +148,7 @@ const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
 
 const methodology = {
   Volume: "Gross ETH paid by purchasers for acquisitions (rips), excluding refunded, expired, or slippage-cancelled requests.",
-  Fees: "Acquisition fees paid by basket purchasers (net of the slice returned to them as RIP buying power), settlement fees and retained penalties taken from listing backings, plus the 1% hook fee on every ETH/RIP swap.",
+  Fees: "Acquisition fees paid by basket purchasers (net of the slice credited back to them as RIP buying power), settlement fees and retained backing taken from listings, plus the 1% hook fee on every ETH/RIP swap.",
   Revenue: "The protocol's cut of acquisition and settlement fees, retained settlement penalties, and hook swap fees.",
   ProtocolRevenue: "Revenue paid to the protocol treasury.",
   HoldersRevenue: "Protocol fees diverted to RIP buybacks.",
@@ -169,14 +158,14 @@ const methodology = {
 const breakdownMethodology = {
   Fees: {
     [METRICS.AcquisitionFees]: "ETH paid by purchasers to acquire a random basket from the pool, net of the slice credited back to the purchaser as RIP buying power.",
-    [METRICS.SettlementFees]: "1% of the listing backing, charged when a settlement returns the backing to the depositor (purchaser keeps or relists the basket).",
+    [METRICS.SettlementFees]: "Fee on the listing backing, charged when a settlement returns the backing to the depositor (purchaser keeps or relists the basket).",
     [METRICS.RetainedSettlements]: "The share of the listing backing retained when a purchaser takes the discounted settlement instead of the basket.",
     [METRICS.SwapFees]: "1% hook fee on every ETH/RIP swap: taken in ETH on sells, and in RIP on buys, which the hook converts to ETH in the same transaction (valued at the swap's pool price).",
   },
   Revenue: {
-    [METRICS.AcquisitionFees]: "Protocol cut (1%) of acquisition fees.",
+    [METRICS.AcquisitionFees]: "Protocol cut of acquisition fees.",
     [METRICS.SettlementFees]: "Settlement fees accrue entirely to the protocol.",
-    [METRICS.RetainedSettlements]: "Retained settlement penalties accrue to the protocol.",
+    [METRICS.RetainedSettlements]: "Retained settlement backing kept by the protocol.",
     [METRICS.SwapFees]: "Hook swap fees accrue entirely to the protocol.",
   },
   ProtocolRevenue: {

--- a/fees/stockrip/index.ts
+++ b/fees/stockrip/index.ts
@@ -4,15 +4,19 @@ import { ChainApi } from "@defillama/sdk";
 
 // StockRip: depositors list a basket NFT (tokenized stocks) with ETH backing, purchasers pay an
 // acquisition fee to be allocated one at random, then keep it, relist it, or take a discounted
-// settlement of its backing.
+// settlement of its backing. Contracts are verified on Robinhood Chain Blockscout.
+// StockRip core: https://robinhoodchain.blockscout.com/address/0x32E8D5b0b8643dC002864a2F5e4481E59eb714CB
 const CORE = "0x32E8D5b0b8643dC002864a2F5e4481E59eb714CB";
-// Rewards module: credits part of each acquisition fee back to the purchaser as RIP buying power
+// StockRipRewards, credits part of each acquisition fee back to the purchaser as RIP buying power:
+// https://robinhoodchain.blockscout.com/address/0x91D032555CB90A8B2792eEaB5F192c41A6a647eF
 const REWARDS = "0x91D032555CB90A8B2792eEaB5F192c41A6a647eF";
-// Uniswap v4 hook on the ETH/RIP pool: 1% fee on every swap, paid to the protocol treasury
+// StockRipTokenHook, Uniswap v4 hook on the ETH/RIP pool, fee paid to the protocol treasury:
+// https://robinhoodchain.blockscout.com/address/0xf295127365a2C3055FdfBa01b0596dA56DCFa444
 const HOOK = "0xf295127365a2C3055FdfBa01b0596dA56DCFa444";
-const Q192 = 1n << 192n;
-const BPS = 10_000n;
+// StockRipTokenHook.FEE_BIPS: flat 1% on every swap in both directions (constant in the verified source above)
 const HOOK_FEE_BIPS = 100n;
+const BPS = 10_000n;
+const Q192 = 1n << 192n;
 
 const METRICS = {
   AcquisitionFees: 'Acquisition Fees',

--- a/fees/stockrip/index.ts
+++ b/fees/stockrip/index.ts
@@ -1,5 +1,6 @@
 import { FetchOptions, FetchResultV2, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
+import { ChainApi } from "@defillama/sdk";
 
 // StockRip: depositors list a basket NFT (tokenized stocks) with ETH backing, purchasers pay an
 // acquisition fee to be allocated one at random, then keep it, relist it, or take a discounted
@@ -55,12 +56,12 @@ const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
     options.getLogs({ target: HOOK, eventAbi: ABIS.Trade, onlyArgs: false }),
   ]);
 
-  // The core went live on 2026-07-27. The adapter starts a day earlier so the launch day is fully
-  // covered by hourly windows; windows before deployment have nothing to read.
-  const coreEvents = nftKept.length + nftRelisted.length + bidAccepted.length + bidAcceptedAsTokens.length + ownerFees.length;
-  const [ownerSettlementFeeBps, retainedToProtocol] = coreEvents === 0 ? [0, true] : await Promise.all([
-    options.api.call({ target: CORE, abi: 'uint256:ownerSettlementFeeBps' }),
-    options.api.call({ target: CORE, abi: 'bool:retainedToProtocol' }),
+  // Robinhood Chain's public RPC is not an archive node, so state is read at the latest block.
+  // Acquisition records are immutable once written and the fee config has not changed since launch.
+  const api = new ChainApi({ chain: options.chain });
+  const [ownerSettlementFeeBps, retainedToProtocol] = await Promise.all([
+    api.call({ target: CORE, abi: 'uint256:ownerSettlementFeeBps' }),
+    api.call({ target: CORE, abi: 'bool:retainedToProtocol' }),
   ]);
 
   // Acquisition fees are booked when the request is allocated. NFTAllocated does not carry the
@@ -68,8 +69,8 @@ const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
   // Refunded, expired and slippage-cancelled requests never allocate, so they are excluded.
   const requestIds = allocated.map((log: any) => log.requestId.toString());
   const [acquisitions, slices] = await Promise.all([
-    options.api.multiCall({ abi: ABIS.acquisitions, target: CORE, calls: requestIds }),
-    options.api.multiCall({ abi: ABIS.acquisitionTokenSlice, target: CORE, calls: requestIds }),
+    api.multiCall({ abi: ABIS.acquisitions, target: CORE, calls: requestIds }),
+    api.multiCall({ abi: ABIS.acquisitionTokenSlice, target: CORE, calls: requestIds }),
   ]);
   let acquisitionVolume = 0n;
   let acquisitionFees = 0n;

--- a/fees/stockrip/index.ts
+++ b/fees/stockrip/index.ts
@@ -1,6 +1,7 @@
 import { FetchOptions, FetchResultV2, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 import { ChainApi } from "@defillama/sdk";
+import { ethers } from "ethers";
 
 // StockRip: depositors list a basket NFT (tokenized stocks) with ETH backing, purchasers pay an
 // acquisition fee to be allocated one at random, then keep it, relist it, or take a discounted
@@ -15,7 +16,9 @@ const REWARDS = "0x91D032555CB90A8B2792eEaB5F192c41A6a647eF";
 const HOOK = "0xf295127365a2C3055FdfBa01b0596dA56DCFa444";
 // StockRipTokenHook.FEE_BIPS: flat 1% on every swap in both directions (constant in the verified source above)
 const HOOK_FEE_BIPS = 100n;
+// Basis-point denominator
 const BPS = 10_000n;
+// Uniswap sqrtPriceX96 is a Q64.96 fixed-point square root, so price = sqrtPriceX96^2 / 2^192
 const Q192 = 1n << 192n;
 
 const METRICS = {
@@ -27,7 +30,7 @@ const METRICS = {
   TokenBuyBack: 'RIP Buyback',
 };
 
-const ABIS = {
+const EVENTS = {
   NFTAllocated: "event NFTAllocated(uint256 indexed requestId, uint256 indexed listingId, address indexed purchaser, address depositor, uint256 value, uint256 randomWord)",
   TopListingFunded: "event TopListingFunded(uint256 indexed listingId, uint256 amount, uint256 newPot)",
   NFTKept: "event NFTKept(uint256 indexed listingId, address indexed purchaser, address indexed depositor, uint256 backing)",
@@ -39,9 +42,10 @@ const ABIS = {
   AcquisitionTokenAccrued: "event AcquisitionTokenAccrued(address indexed purchaser, uint256 indexed requestId, uint256 slice)",
   HookFee: "event HookFee(bytes32 indexed id, address indexed sender, uint128 feeAmount0, uint128 feeAmount1)",
   Trade: "event Trade(uint160 sqrtPriceX96, int128 ethAmount, int128 tokenAmount)",
-  acquisitions: "function acquisitions(uint256) view returns (address purchaser, uint256 requestBlock, uint256 priceEscrowed, uint256 listingId, uint8 status)",
 };
+const ACQUISITIONS_ABI = "function acquisitions(uint256) view returns (address purchaser, uint256 requestBlock, uint256 priceEscrowed, uint256 listingId, uint8 status)";
 
+const iface = new ethers.Interface(Object.values(EVENTS));
 const sumBy = (logs: any[], field: string | number) => logs.reduce((acc: bigint, log: any) => acc + BigInt(log.args[field]), 0n);
 
 const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
@@ -52,27 +56,31 @@ const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
   const dailyProtocolRevenue = options.createBalances();
   const dailyHoldersRevenue = options.createBalances();
 
-  const getLogs = (target: string, eventAbi: string) => options.getLogs({ target, eventAbi, onlyArgs: false });
-  const [allocated, topListingFunded, nftKept, nftRelisted, bidAccepted, bidAcceptedAsTokens, ownerFees, feesToToken, slices, hookFees, trades] = await Promise.all([
-    getLogs(CORE, ABIS.NFTAllocated),
-    getLogs(CORE, ABIS.TopListingFunded),
-    getLogs(CORE, ABIS.NFTKept),
-    getLogs(CORE, ABIS.NFTRelisted),
-    getLogs(CORE, ABIS.DepositorBidAccepted),
-    getLogs(CORE, ABIS.DepositorBidAcceptedAsTokens),
-    getLogs(CORE, ABIS.OwnerFeesAccrued),
-    getLogs(CORE, ABIS.ProtocolFeesToToken),
-    getLogs(REWARDS, ABIS.AcquisitionTokenAccrued),
-    getLogs(HOOK, ABIS.HookFee),
-    getLogs(HOOK, ABIS.Trade),
+  // One log query per contract, keyed by event name after decoding, to stay within the public
+  // RPC's rate limit.
+  const byEvent: Record<string, any[]> = {};
+  Object.keys(EVENTS).forEach((name) => { byEvent[name] = []; });
+  const fetchLogs = async (target: string, names: string[]) => {
+    const topics = names.map((name) => iface.getEvent(name)!.topicHash);
+    const raw = await options.getLogs({ target, topics: [topics] as any, entireLog: true });
+    raw.forEach((log: any) => {
+      const parsed = iface.parseLog(log);
+      if (parsed) byEvent[parsed.name].push({ args: parsed.args, transactionHash: log.transactionHash, logIndex: Number(log.logIndex ?? log.index) });
+    });
+  };
+  await Promise.all([
+    fetchLogs(CORE, ['NFTAllocated', 'TopListingFunded', 'NFTKept', 'NFTRelisted', 'DepositorBidAccepted', 'DepositorBidAcceptedAsTokens', 'OwnerFeesAccrued', 'ProtocolFeesToToken']),
+    fetchLogs(REWARDS, ['AcquisitionTokenAccrued']),
+    fetchLogs(HOOK, ['HookFee', 'Trade']),
   ]);
+  const { NFTAllocated: allocated, TopListingFunded: topListingFunded, NFTKept: nftKept, NFTRelisted: nftRelisted, DepositorBidAccepted: bidAccepted, DepositorBidAcceptedAsTokens: bidAcceptedAsTokens, OwnerFeesAccrued: ownerFees, ProtocolFeesToToken: feesToToken, AcquisitionTokenAccrued: slices, HookFee: hookFees, Trade: trades } = byEvent;
 
   // Acquisition fees are booked when the request is allocated. NFTAllocated does not carry the
   // fee, so the escrowed price is read from the acquisition record, which is never modified after
   // the request. Robinhood Chain's public RPC is not an archive node, so it is read at the latest
   // block. Refunded, expired and slippage-cancelled requests never allocate and are excluded.
   const api = new ChainApi({ chain: options.chain });
-  const acquisitions = await api.multiCall({ abi: ABIS.acquisitions, target: CORE, calls: allocated.map((log: any) => log.args.requestId.toString()) });
+  const acquisitions = await api.multiCall({ abi: ACQUISITIONS_ABI, target: CORE, calls: allocated.map((log: any) => log.args.requestId.toString()) });
   const acquisitionVolume = acquisitions.reduce((acc: bigint, acq: any) => acc + BigInt(acq.priceEscrowed), 0n);
   // The slice credited back to the purchaser as RIP buying power is netted out. It is emitted by
   // the rewards module in the allocation transaction.

--- a/fees/stockrip/index.ts
+++ b/fees/stockrip/index.ts
@@ -11,6 +11,8 @@ const REWARDS = "0x91D032555CB90A8B2792eEaB5F192c41A6a647eF";
 // Uniswap v4 hook on the ETH/RIP pool: 1% fee on every swap, paid to the protocol treasury
 const HOOK = "0xf295127365a2C3055FdfBa01b0596dA56DCFa444";
 const Q192 = 1n << 192n;
+const BPS = 10_000n;
+const HOOK_FEE_BIPS = 100n;
 
 const METRICS = {
   AcquisitionFees: 'Acquisition Fees',
@@ -120,22 +122,24 @@ const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
 
   // Hook swap fees. Sells pay in ETH (feeAmount0). Buys pay in RIP (feeAmount1), which the hook
   // swaps to ETH inside the same afterSwap call without emitting the amount, so it is valued at
-  // the pool price on that swap's Trade event (currency0 = ETH, currency1 = RIP). The hook serves
-  // one pool and afterSwap emits HookFee then Trade for each swap, so a swap's Trade is the first
-  // one after its HookFee in the same transaction.
-  const tradesByTx = new Map<string, any[]>();
+  // the pool price on that swap's Trade event (currency0 = ETH, currency1 = RIP). A buy's Trade
+  // is identified in the same transaction by its RIP output: the fee is a flat 1% of it.
+  const buyTradesByTx = new Map<string, any[]>();
   trades.forEach((log: any) => {
-    const list = tradesByTx.get(log.transactionHash) ?? [];
+    if (BigInt(log.args.tokenAmount) <= 0n) return;
+    const list = buyTradesByTx.get(log.transactionHash) ?? [];
     list.push(log);
-    tradesByTx.set(log.transactionHash, list);
+    buyTradesByTx.set(log.transactionHash, list);
   });
   let swapFees = 0n;
   hookFees.forEach((log: any) => {
     swapFees += BigInt(log.args.feeAmount0);
     const ripFee = BigInt(log.args.feeAmount1);
     if (ripFee === 0n) return;
-    const trade = (tradesByTx.get(log.transactionHash) ?? []).find((t: any) => Number(t.logIndex) > Number(log.logIndex));
-    if (!trade) return;
+    const candidates = buyTradesByTx.get(log.transactionHash) ?? [];
+    const i = candidates.findIndex((t: any) => BigInt(t.args.tokenAmount) * HOOK_FEE_BIPS / BPS === ripFee);
+    if (i < 0) return;
+    const [trade] = candidates.splice(i, 1);
     const sqrtPriceX96 = BigInt(trade.args.sqrtPriceX96);
     swapFees += ripFee * Q192 / (sqrtPriceX96 * sqrtPriceX96);
   });

--- a/fees/stockrip/index.ts
+++ b/fees/stockrip/index.ts
@@ -1,0 +1,211 @@
+import { FetchOptions, FetchResultV2, SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+
+// StockRip: depositors list a basket NFT (tokenized stocks) with ETH backing, purchasers pay an
+// acquisition fee to be allocated one at random, then keep it, relist it, or take a discounted
+// settlement of its backing.
+const CORE = "0x32E8D5b0b8643dC002864a2F5e4481E59eb714CB";
+// Uniswap v4 hook on the ETH/RIP pool: 1% fee on every swap, paid to the protocol treasury
+const HOOK = "0xf295127365a2C3055FdfBa01b0596dA56DCFa444";
+const BPS = 10_000n;
+const Q192 = 1n << 192n;
+
+const METRICS = {
+  AcquisitionFees: 'Acquisition Fees',
+  SettlementFees: 'Settlement Fees',
+  RetainedSettlements: 'Retained Settlement Penalties',
+  TopListingReward: 'Top Listing Reward',
+  SwapFees: 'Swap Fees',
+  TokenBuyBack: 'RIP Buyback',
+};
+
+const ABIS = {
+  NFTAllocated: "event NFTAllocated(uint256 indexed requestId, uint256 indexed listingId, address indexed purchaser, address depositor, uint256 value, uint256 randomWord)",
+  TopListingFunded: "event TopListingFunded(uint256 indexed listingId, uint256 amount, uint256 newPot)",
+  NFTKept: "event NFTKept(uint256 indexed listingId, address indexed purchaser, address indexed depositor, uint256 backing)",
+  NFTRelisted: "event NFTRelisted(uint256 indexed listingId, uint256 indexed newListingId, uint256 toDepositor)",
+  DepositorBidAccepted: "event DepositorBidAccepted(uint256 indexed listingId, address indexed purchaser, address indexed depositor, uint256 payout, uint256 retained)",
+  DepositorBidAcceptedAsTokens: "event DepositorBidAcceptedAsTokens(uint256 indexed listingId, address indexed purchaser, address indexed depositor, uint256 ethPayout, uint256 retained, uint256 tokenOut)",
+  OwnerFeesAccrued: "event OwnerFeesAccrued(uint256 amount)",
+  ProtocolFeesToToken: "event ProtocolFeesToToken(uint256 amount)",
+  HookFee: "event HookFee(bytes32 indexed id, address indexed sender, uint128 feeAmount0, uint128 feeAmount1)",
+  Trade: "event Trade(uint160 sqrtPriceX96, int128 ethAmount, int128 tokenAmount)",
+  acquisitions: "function acquisitions(uint256) view returns (address purchaser, uint256 requestBlock, uint256 priceEscrowed, uint256 listingId, uint8 status)",
+  acquisitionTokenSlice: "function acquisitionTokenSlice(uint256) view returns (uint256)",
+};
+
+const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
+  const dailyVolume = options.createBalances();
+  const dailyFees = options.createBalances();
+  const dailyRevenue = options.createBalances();
+  const dailySupplySideRevenue = options.createBalances();
+  const dailyProtocolRevenue = options.createBalances();
+  const dailyHoldersRevenue = options.createBalances();
+
+  const [allocated, topListingFunded, nftKept, nftRelisted, bidAccepted, bidAcceptedAsTokens, ownerFees, feesToToken, hookFees, trades] = await Promise.all([
+    options.getLogs({ target: CORE, eventAbi: ABIS.NFTAllocated }),
+    options.getLogs({ target: CORE, eventAbi: ABIS.TopListingFunded }),
+    options.getLogs({ target: CORE, eventAbi: ABIS.NFTKept }),
+    options.getLogs({ target: CORE, eventAbi: ABIS.NFTRelisted }),
+    options.getLogs({ target: CORE, eventAbi: ABIS.DepositorBidAccepted }),
+    options.getLogs({ target: CORE, eventAbi: ABIS.DepositorBidAcceptedAsTokens }),
+    options.getLogs({ target: CORE, eventAbi: ABIS.OwnerFeesAccrued }),
+    options.getLogs({ target: CORE, eventAbi: ABIS.ProtocolFeesToToken }),
+    options.getLogs({ target: HOOK, eventAbi: ABIS.HookFee, onlyArgs: false }),
+    options.getLogs({ target: HOOK, eventAbi: ABIS.Trade, onlyArgs: false }),
+  ]);
+
+  // The core went live on 2026-07-27. The adapter starts a day earlier so the launch day is fully
+  // covered by hourly windows; windows before deployment have nothing to read.
+  const coreEvents = nftKept.length + nftRelisted.length + bidAccepted.length + bidAcceptedAsTokens.length + ownerFees.length;
+  const [ownerSettlementFeeBps, retainedToProtocol] = coreEvents === 0 ? [0, true] : await Promise.all([
+    options.api.call({ target: CORE, abi: 'uint256:ownerSettlementFeeBps' }),
+    options.api.call({ target: CORE, abi: 'bool:retainedToProtocol' }),
+  ]);
+
+  // Acquisition fees are booked when the request is allocated. NFTAllocated does not carry the
+  // fee, so the escrowed price and the purchaser's RIP slice are read back per request id.
+  // Refunded, expired and slippage-cancelled requests never allocate, so they are excluded.
+  const requestIds = allocated.map((log: any) => log.requestId.toString());
+  const [acquisitions, slices] = await Promise.all([
+    options.api.multiCall({ abi: ABIS.acquisitions, target: CORE, calls: requestIds }),
+    options.api.multiCall({ abi: ABIS.acquisitionTokenSlice, target: CORE, calls: requestIds }),
+  ]);
+  let acquisitionVolume = 0n;
+  let acquisitionFees = 0n;
+  acquisitions.forEach((acq: any, i: number) => {
+    const price = BigInt(acq.priceEscrowed);
+    acquisitionVolume += price;
+    // The slice credited back to the purchaser as RIP buying power is netted out.
+    acquisitionFees += price - BigInt(slices[i]);
+  });
+  dailyVolume.addGasToken(acquisitionVolume);
+  dailyFees.addGasToken(acquisitionFees, METRICS.AcquisitionFees);
+
+  // Settlement fee when the backing returns to the depositor (purchaser keeps or relists):
+  // the events carry the depositor payout net of the cut, so gross the fee back up.
+  const settleBps = BigInt(ownerSettlementFeeBps);
+  let settlementFees = 0n;
+  nftKept.forEach((log: any) => { settlementFees += BigInt(log.backing) * settleBps / (BPS - settleBps); });
+  nftRelisted.forEach((log: any) => { settlementFees += BigInt(log.toDepositor) * settleBps / (BPS - settleBps); });
+  dailyFees.addGasToken(settlementFees, METRICS.SettlementFees);
+
+  // Backing retained when the purchaser takes the discounted settlement instead of the basket.
+  // Protocol revenue when retainedToProtocol, otherwise shared among active depositors.
+  let retained = 0n;
+  bidAccepted.forEach((log: any) => { retained += BigInt(log.retained); });
+  bidAcceptedAsTokens.forEach((log: any) => { retained += BigInt(log.retained); });
+  dailyFees.addGasToken(retained, METRICS.RetainedSettlements);
+  if (!retainedToProtocol) dailySupplySideRevenue.addGasToken(retained, METRICS.RetainedSettlements);
+
+  // OwnerFeesAccrued covers every protocol accrual, so the protocol's cut of acquisition fees is
+  // what remains after the settlement-side accruals above.
+  let totalOwnerFees = 0n;
+  ownerFees.forEach((log: any) => { totalOwnerFees += BigInt(log.amount); });
+  let acquisitionCut = totalOwnerFees - settlementFees - (retainedToProtocol ? retained : 0n);
+  if (acquisitionCut < 0n) acquisitionCut = 0n;
+  if (acquisitionCut > acquisitionFees) acquisitionCut = acquisitionFees;
+
+  // The rest of the acquisition fee goes to depositors: a share to the top-backed listing's pot,
+  // the remainder split equally across active listings.
+  let topListingShare = 0n;
+  topListingFunded.forEach((log: any) => { topListingShare += BigInt(log.amount); });
+  let depositorShare = acquisitionFees - acquisitionCut - topListingShare;
+  if (depositorShare < 0n) depositorShare = 0n;
+  dailySupplySideRevenue.addGasToken(depositorShare, METRICS.AcquisitionFees);
+  dailySupplySideRevenue.addGasToken(topListingShare, METRICS.TopListingReward);
+
+  // A protocolFeeToTokenBps slice of the protocol take can go to RIP buybacks at payout time
+  // (holders revenue); the rest is paid to the treasury.
+  const protocolTake = acquisitionCut + settlementFees + (retainedToProtocol ? retained : 0n);
+  let toTokenBuyback = 0n;
+  feesToToken.forEach((log: any) => { toTokenBuyback += BigInt(log.amount); });
+  if (toTokenBuyback > protocolTake) toTokenBuyback = protocolTake;
+  const treasuryShare = protocolTake - toTokenBuyback;
+  const proRata = (amount: bigint, share: bigint) => protocolTake > 0n ? amount * share / protocolTake : 0n;
+  const components: [bigint, string][] = [
+    [acquisitionCut, METRICS.AcquisitionFees],
+    [settlementFees, METRICS.SettlementFees],
+    [retainedToProtocol ? retained : 0n, METRICS.RetainedSettlements],
+  ];
+  components.forEach(([amount, label]) => {
+    dailyRevenue.addGasToken(amount, label);
+    dailyProtocolRevenue.addGasToken(proRata(amount, treasuryShare), label);
+  });
+  dailyHoldersRevenue.addGasToken(toTokenBuyback, METRICS.TokenBuyBack);
+
+  // Hook swap fees. Sells pay in ETH (feeAmount0). Buys pay in RIP (feeAmount1), which the hook
+  // swaps to ETH in the same transaction without emitting the amount, so it is valued at the pool
+  // price on the swap's Trade event (currency0 = ETH, currency1 = RIP).
+  const tradesByTx = new Map<string, any[]>();
+  trades.forEach((log: any) => {
+    const list = tradesByTx.get(log.transactionHash) ?? [];
+    list.push(log);
+    tradesByTx.set(log.transactionHash, list);
+  });
+  let swapFees = 0n;
+  hookFees.forEach((log: any) => {
+    swapFees += BigInt(log.args.feeAmount0);
+    const ripFee = BigInt(log.args.feeAmount1);
+    if (ripFee === 0n) return;
+    const trade = (tradesByTx.get(log.transactionHash) ?? []).find((t: any) => Number(t.logIndex) > Number(log.logIndex));
+    if (!trade) return;
+    const sqrtPriceX96 = BigInt(trade.args.sqrtPriceX96);
+    swapFees += ripFee * Q192 / (sqrtPriceX96 * sqrtPriceX96);
+  });
+  dailyFees.addGasToken(swapFees, METRICS.SwapFees);
+  dailyRevenue.addGasToken(swapFees, METRICS.SwapFees);
+  dailyProtocolRevenue.addGasToken(swapFees, METRICS.SwapFees);
+
+  return { dailyVolume, dailyFees, dailyRevenue, dailyProtocolRevenue, dailyHoldersRevenue, dailySupplySideRevenue };
+};
+
+const methodology = {
+  Volume: "Gross ETH paid by purchasers for acquisitions (rips), excluding refunded, expired, or slippage-cancelled requests.",
+  Fees: "Acquisition fees paid by basket purchasers (net of the slice returned to them as RIP buying power), settlement fees and retained penalties taken from listing backings, plus the 1% hook fee on every ETH/RIP swap.",
+  Revenue: "The protocol's cut of acquisition and settlement fees, retained settlement penalties, and hook swap fees.",
+  ProtocolRevenue: "Revenue paid to the protocol treasury.",
+  HoldersRevenue: "Protocol fees diverted to RIP buybacks.",
+  SupplySideRevenue: "Share of acquisition fees distributed to basket depositors (equal split across active listings plus the top-listing pot).",
+};
+
+const breakdownMethodology = {
+  Fees: {
+    [METRICS.AcquisitionFees]: "ETH paid by purchasers to acquire a random basket from the pool, net of the slice credited back to the purchaser as RIP buying power.",
+    [METRICS.SettlementFees]: "1% of the listing backing, charged when a settlement returns the backing to the depositor (purchaser keeps or relists the basket).",
+    [METRICS.RetainedSettlements]: "The share of the listing backing retained when a purchaser takes the discounted settlement instead of the basket.",
+    [METRICS.SwapFees]: "1% hook fee on every ETH/RIP swap: taken in ETH on sells, and in RIP on buys, which the hook converts to ETH in the same transaction (valued at the swap's pool price).",
+  },
+  Revenue: {
+    [METRICS.AcquisitionFees]: "Protocol cut (1%) of acquisition fees.",
+    [METRICS.SettlementFees]: "Settlement fees accrue entirely to the protocol.",
+    [METRICS.RetainedSettlements]: "Retained settlement penalties accrue to the protocol.",
+    [METRICS.SwapFees]: "Hook swap fees accrue entirely to the protocol.",
+  },
+  ProtocolRevenue: {
+    [METRICS.AcquisitionFees]: "Protocol cut of acquisition fees paid to the treasury.",
+    [METRICS.SettlementFees]: "Settlement fees paid to the treasury.",
+    [METRICS.RetainedSettlements]: "Retained settlement penalties paid to the treasury.",
+    [METRICS.SwapFees]: "Hook swap fees paid to the treasury.",
+  },
+  HoldersRevenue: {
+    [METRICS.TokenBuyBack]: "Protocol fees diverted to RIP buybacks.",
+  },
+  SupplySideRevenue: {
+    [METRICS.AcquisitionFees]: "Share of acquisition fees distributed to basket depositors, split equally across active listings.",
+    [METRICS.TopListingReward]: "Share of acquisition fees accruing to the depositor of the top-backed listing.",
+    [METRICS.RetainedSettlements]: "Retained settlement penalties redistributed among active depositors when not routed to the protocol.",
+  },
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  pullHourly: true,
+  fetch,
+  chains: [CHAIN.ROBINHOOD],
+  start: '2026-07-26',
+  methodology,
+  breakdownMethodology,
+};
+
+export default adapter;

--- a/fees/stockrip/index.ts
+++ b/fees/stockrip/index.ts
@@ -116,28 +116,24 @@ const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
   dailySupplySideRevenue.addGasToken(depositorShare, METRICS.AcquisitionFees);
   dailySupplySideRevenue.addGasToken(topListingShare, METRICS.TopListingReward);
 
-  // A protocolFeeToTokenBps slice of the protocol take can go to RIP buybacks at payout time
-  // (holders revenue); the rest is paid to the treasury.
-  const protocolTake = acquisitionCut + settlementFees + (retainedToProtocol ? retained : 0n);
-  let toTokenBuyback = 0n;
-  feesToToken.forEach((log: any) => { toTokenBuyback += BigInt(log.amount); });
-  if (toTokenBuyback > protocolTake) toTokenBuyback = protocolTake;
-  const treasuryShare = protocolTake - toTokenBuyback;
-  const proRata = (amount: bigint, share: bigint) => protocolTake > 0n ? amount * share / protocolTake : 0n;
-  const components: [bigint, string][] = [
-    [acquisitionCut, METRICS.AcquisitionFees],
-    [settlementFees, METRICS.SettlementFees],
-    [retainedToProtocol ? retained : 0n, METRICS.RetainedSettlements],
-  ];
-  components.forEach(([amount, label]) => {
-    dailyRevenue.addGasToken(amount, label);
-    dailyProtocolRevenue.addGasToken(proRata(amount, treasuryShare), label);
-  });
-  dailyHoldersRevenue.addGasToken(toTokenBuyback, METRICS.TokenBuyBack);
+  dailyRevenue.addGasToken(acquisitionCut, METRICS.AcquisitionFees);
+  dailyRevenue.addGasToken(settlementFees, METRICS.SettlementFees);
+  dailyProtocolRevenue.addGasToken(acquisitionCut, METRICS.AcquisitionFees);
+  dailyProtocolRevenue.addGasToken(settlementFees, METRICS.SettlementFees);
+  if (retainedToProtocol) {
+    dailyRevenue.addGasToken(retained, METRICS.RetainedSettlements);
+    dailyProtocolRevenue.addGasToken(retained, METRICS.RetainedSettlements);
+  }
+
+  // Accrued protocol fees are paid out later; a protocolFeeToTokenBps slice can go to RIP buybacks
+  // at that time. Recorded as holders revenue when the payout happens.
+  feesToToken.forEach((log: any) => { dailyHoldersRevenue.addGasToken(log.amount, METRICS.TokenBuyBack); });
 
   // Hook swap fees. Sells pay in ETH (feeAmount0). Buys pay in RIP (feeAmount1), which the hook
-  // swaps to ETH in the same transaction without emitting the amount, so it is valued at the pool
-  // price on the swap's Trade event (currency0 = ETH, currency1 = RIP).
+  // swaps to ETH inside the same afterSwap call without emitting the amount, so it is valued at
+  // the pool price on that swap's Trade event (currency0 = ETH, currency1 = RIP). The hook serves
+  // one pool and afterSwap emits HookFee then Trade for each swap, so a swap's Trade is the first
+  // one after its HookFee in the same transaction.
   const tradesByTx = new Map<string, any[]>();
   trades.forEach((log: any) => {
     const list = tradesByTx.get(log.transactionHash) ?? [];
@@ -167,7 +163,7 @@ const methodology = {
   Revenue: "The protocol's cut of acquisition and settlement fees, retained settlement penalties, and hook swap fees.",
   ProtocolRevenue: "Revenue paid to the protocol treasury.",
   HoldersRevenue: "Protocol fees diverted to RIP buybacks.",
-  SupplySideRevenue: "Share of acquisition fees distributed to basket depositors (equal split across active listings plus the top-listing pot).",
+  SupplySideRevenue: "Share of acquisition fees distributed to basket depositors (equal split across active listings plus the top-listing pot), plus retained settlement backing when it is configured to go to depositors instead of the protocol.",
 };
 
 const breakdownMethodology = {


### PR DESCRIPTION
**NOTE**

#### Please enable "Allow edits by maintainers" while putting up the PR.

---

> - If you would like to add a `tvl` adapter please submit the PR [here](https://github.com/DefiLlama/DefiLlama-Adapters).

1. Once your adapter has been merged, it takes time to show on the UI. If more than 24 hours have passed, please let us know in Discord.
2. Please fill the form below **only if the PR is for listing a new protocol** else it can be ignored/replaced with reason/details about the PR
3. **For updating listing info** Please send a mail to metadata@defillama.com
4. Do not edit/push `package.json/package-lock.json` file as part of your changes
5. No need to go to our discord/other channel and announce that you've created a PR, we monitor all PRs and will review it asap

---
##### Name (to be shown on DefiLlama):

StockRip

##### Twitter Link:

https://x.com/stockripx

##### List of audit links if any:

None.

##### Website Link:

https://stockrip.com/

##### Logo (High resolution, will be shown with rounded borders):

https://pbs.twimg.com/profile_images/2081370597347794945/ODz5Z1IM_400x400.jpg

##### Current TVL:

~$143,000 (already tracked, https://defillama.com/protocol/stockrip)

##### Treasury Addresses (if the protocol has treasury)

0x0781C4380096f8Bbb31b5690b181C31E079FfE02 (Robinhood Chain)

##### Chain:

Robinhood Chain

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed):

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed):

##### Short Description (to be shown on DefiLlama):

Draw a random tokenized stock position from an onchain pool. Every listing carries the ETH backing its depositor committed, and that backing is the standing bid a winner can take instead of the shares.

##### Token address and ticker if any:

RIP, 0xe4b8723d202FDD0298B1D7496A86656b2986C532 on Robinhood Chain.
Market: https://dexscreener.com/robinhood/0x6ad6aa41fed2528a76979a615e3c5f3e0ab494f5abc5e1c15362ad6151187a43

##### Category (full list at https://defillama.com/categories) *Please choose only one:

Gamified Mining

##### Oracle Provider(s):

Chainlink (Data Feeds)

##### Implementation Details:

Not relevant to this adapter. Every figure is read from contract events and state and denominated in ETH; pricing is left to DefiLlama.

##### Documentation/Proof:

https://stockrip.com/
Core: https://robinhoodchain.blockscout.com/address/0x32E8D5b0b8643dC002864a2F5e4481E59eb714CB
Swap hook (Uniswap v4, ETH/RIP): https://robinhoodchain.blockscout.com/address/0xf295127365a2C3055FdfBa01b0596dA56DCFa444
Treasury: https://robinhoodchain.blockscout.com/address/0x0781C4380096f8Bbb31b5690b181C31E079FfE02

##### forkedFrom (Does your project originate from another project):

##### methodology (what is being counted as tvl, how is tvl being calculated):

Volume: gross ETH paid by purchasers for acquisitions (rips), read from the escrowed price of every request that was allocated in the window. Refunded, expired and slippage-cancelled requests never allocate and are excluded.

Fees: acquisition fees net of the slice credited back to the purchaser as RIP buying power, plus the settlement fee taken when a listing's backing returns to its depositor, plus the backing retained when a purchaser takes the discounted settlement, plus the 1% hook fee on every ETH/RIP swap.

Revenue: the protocol's cut of acquisition fees, settlement fees, retained settlement backing, and hook swap fees. All of it is paid to the treasury (protocol revenue) except any slice diverted to RIP buybacks (holders revenue), which is read from the ProtocolFeesToToken event.

Supply side revenue: the share of acquisition fees distributed to basket depositors, split equally across active listings plus the top-listing pot.

Rates are not hardcoded. ownerSettlementFeeBps and retainedToProtocol are read from the core; the protocol's acquisition cut is taken from OwnerFeesAccrued after removing the settlement-side accruals, so config changes are picked up automatically. Buy-side hook fees are taken in RIP and swapped to ETH by the hook in the same transaction, so they are valued at the pool price stamped on that swap's Trade event.

Start is set to 2026-07-26, one day before the core deployed, so the launch day is covered in full by hourly windows.

##### Github org/user (Optional, if your code is open source, we can track activity):

##### Does this project have a referral program?

No.
