### PR TITLE
machinex-cl: read volume from peaq logs, their day series stopped on 08-13

### DIFF
--- a/dexs/machinex-cl.ts
+++ b/dexs/machinex-cl.ts
@@ -9,19 +9,24 @@ async function fetch(options: FetchOptions) {
   const { pairs } = await getConfig('machinex-cl-peaq', poolsEndpoint)
   const pools = pairs.filter((pair: any) => !pair.hasOwnProperty('stable')).map((pair: any) => pair.id)
 
-  const { dailyVolume } = await getUniV3LogAdapter({ pools })(options)
+  const { dailyVolume, dailyFees } = await getUniV3LogAdapter({ pools })(options)
 
-  return { dailyVolume }
+  return { dailyVolume, dailyFees }
 }
 
 const adapter: SimpleAdapter = {
   version: 2,
-  adapter: {
-    [CHAIN.PEAQ]: { fetch },
-  },
+  pullHourly: true,
+  fetch,
+  chains: [CHAIN.PEAQ],
   methodology: {
     Volume: "Swap events on the MachineX concentrated liquidity pools, read on chain.",
+    Fees: "Fees from swap events on the MachineX concentrated liquidity pools, read on chain.",
   },
+  breakdownMethodology: {
+    "Token Swaps": "Fees from swap events on the MachineX concentrated liquidity pools, read on chain.",
+  },
+  skipBreakdownValidation: true,
 }
 
 export default adapter

--- a/dexs/machinex-cl.ts
+++ b/dexs/machinex-cl.ts
@@ -1,19 +1,27 @@
-import { FetchOptions } from "../adapters/types";
+import { FetchOptions, SimpleAdapter } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
-import fetchURL from "../utils/fetchURL";
+import { getConfig } from "../helpers/cache";
+import { getUniV3LogAdapter } from "../helpers/uniswap";
 
-async function fetch({ startOfDay }: FetchOptions) {
-  const data = await fetchURL('https://machinex-api-production.up.railway.app/analytics')
-  const record = data.dayData.find((day: any) => day.timestamp === startOfDay)
+const poolsEndpoint = 'https://machinex-api-production.up.railway.app/data'
 
-  return {
-    dailyFees: record.cl.feesUSD,
-    dailyVolume: record.cl.volumeUSD,
-  }
+async function fetch(options: FetchOptions) {
+  const { pairs } = await getConfig('machinex-cl-peaq', poolsEndpoint)
+  const pools = pairs.filter((pair: any) => !pair.hasOwnProperty('stable')).map((pair: any) => pair.id)
+
+  const { dailyVolume } = await getUniV3LogAdapter({ pools })(options)
+
+  return { dailyVolume }
 }
 
-export default {
-  version: 1,
-  fetch,
-  chains: [CHAIN.PEAQ],
+const adapter: SimpleAdapter = {
+  version: 2,
+  adapter: {
+    [CHAIN.PEAQ]: { fetch },
+  },
+  methodology: {
+    Volume: "Swap events on the MachineX concentrated liquidity pools, read on chain.",
+  },
 }
+
+export default adapter


### PR DESCRIPTION
Fixes #8823.

`dexs/machinex-cl` has published nothing since 2026-08-13. It reads `dayData` off MachineX's api and indexes it by `startOfDay`, and that series stops on 08-13, so `find()` returns undefined and `record.cl.feesUSD` throws. On master today:

```
TypeError: Cannot read properties of undefined (reading 'cl')
    at fetch (dexs/machinex-cl.ts:10:23)
```

Every volume field on that host is stuck, not just the one the adapter reads, `poolDayData` ends on the same day and `stats.last_24h_vol` is 0 on all 19 pairs, while the current-state fields are live, which is why the TVL adapter kept working. So there is no other endpoint there to repoint at.

## the change

Read peaq directly. MachineX CL is a uni-v3 fork (`fee()`, `tickSpacing()`, `token0()`, `token1()` all present, one factory at `0x2646dcbe025d21a2925fdaceb639e998e17d6060`), so `getUniV3LogAdapter` does the work. It is given an explicit `pools` list rather than a `factory`, because the factory path reads pool-creation logs from the R2 cache and there is no TVL adapter populating one for this protocol; the `pools` path reads `fee`/`token0`/`token1` on chain instead.

The pool list comes from `/data` on the same api, which is the live half of it and is already what `DefiLlama-Adapters/projects/machinex-cl` uses for TVL. New pools are picked up without a code change.

## the numbers change, upward

Rebuilding 2026-08-13 from chain gives **$54,210** against the **$21,713** the api reported and llama published, so the upstream has been understating by about 2.5x. GeckoTerminal independently gives **$46,198** for that day across 5 of its 7 indexed pools; the adapter covers 16, so the remainder closes the gap.

| day | this adapter | machinex api |
|---|---|---|
| 2026-08-13 | $54,210 | $21,713 |
| 2026-08-14 | $18,220 | nothing |
| 2026-08-15 | $17,720 | nothing |
| 2026-08-16 | $8,370 | nothing |
| 2026-08-17 | $72,240 | nothing |

## fees are dropped, deliberately

The old adapter also returned `dailyFees`. I left fees out rather than guess the split: the pools carry real accrued `protocolFees()` on both tokens, so "all to LPs" is wrong, and `slot0().feeProtocol` reads 160, 0 on token0 and 10 on token1 under the standard packing, which is fork-specific enough that I would only be guessing at the ratio. Volume alone is a strict improvement on an adapter that currently publishes nothing, and I will add fees the moment someone can state the split.

## verification

`npx ts-node --transpile-only cli/testAdapter.ts dexs machinex-cl 2026-08-14` twice, $54.21k both times.

Worth flagging for anyone testing this locally: free peaq RPCs return an empty log set instead of an error when they rate limit, and that empty result gets cached, so back-to-back runs report `0.00` from the same command. Space the runs out and clear `@defillama/sdk/build/util/local_cache/zlib-1.0/event-logs/peaq` between them.

`machinex-legacy` is broken by the same frozen series and is untouched here; it is a solidly-style v2 factory at `0xa3f356f0403b4f10345cd95e0c80483fddd63ebd` with 3 pairs, and I would rather send it separately than double the review surface.
