### PR TITLE
[fix] Flap.sh - fix fee accounting

### DIFF
--- a/dexs/flap.ts
+++ b/dexs/flap.ts
@@ -133,8 +133,16 @@ const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
     let safe: string | undefined = config.safe;
     try {
       safe = await options.api.call({ target: portal, abi: "address:FEE_RECEIVER" });
-    } catch {
-      // keep chain fallback
+    } catch (e) {
+      const msg = String((e as any)?.message ?? e);
+      const missingGetter = /execution reverted|returned no data|FUNCTION_SELECTOR_NOT_RECOGNIZED/i.test(msg);
+      if (!missingGetter) throw e;
+      if (!config.safe) {
+        console.log(`flap: FEE_RECEIVER missing on ${options.chain}, skipping treasury fees`);
+        return;
+      }
+      console.log(`flap: FEE_RECEIVER() unsupported on ${options.chain}, using fallback ${config.safe}`);
+      safe = config.safe;
     }
     if (!safe) {
       console.log(`flap: FEE_RECEIVER missing on ${options.chain}, skipping treasury fees`);

--- a/dexs/flap.ts
+++ b/dexs/flap.ts
@@ -2,34 +2,39 @@ import { FetchOptions, FetchResultV2, SimpleAdapter } from "../adapters/types";
 import ADDRESSES from "../helpers/coreAssets.json";
 import { CHAIN } from "../helpers/chains";
 import { queryClickhouse } from "../helpers/indexer";
+import { addTokensReceived } from "../helpers/token";
 
-const BONDING_CURVE_FEES = "Bonding Curve Fees";
 const NATIVE_TOKEN = ADDRESSES.null;
+const TREASURY_RECEIVED = "Treasury Received";
 
 // Source: https://docs.flap.sh/flap/developers/deployed-contract-addresses
-const chainConfig: Record<string, { start: string; portal: string; fromBlock: number; useIndexer?: boolean }> = {
+const chainConfig: Record<string, { start: string; portal: string; fromBlock: number; useIndexer?: boolean, safe: string }> = {
   [CHAIN.BSC]: {
     start: "2024-06-27",
     portal: "0xe2cE6ab80874Fa9Fa2aAE65D277Dd6B8e65C9De0",
     fromBlock: 39980228,
     useIndexer: true,
+    safe: "0x8a08D98CBB218fceB318Ecf3aBc1BA43D8A7aB0E",
   },
   [CHAIN.ROBINHOOD]: {
     start: "2026-07-08",
     portal: "0x26605f322f7fF986f381bB9A6e3f5DAb0bEaEb09",
     fromBlock: 4180724,
+    safe: "0xa4A727E0918cf9B39639Fc4cB7D742d39C5352a4",
   },
   [CHAIN.XLAYER]: {
     start: "2025-08-18",
     portal: "0xb30D8c4216E1f21F27444D2FfAee3ad577808678",
     fromBlock: 31165559,
     useIndexer: true,
+    safe: "0xAC4f9Ba4E48cAafBa17164FBCb078091651Ae361",
   },
   [CHAIN.MONAD]: {
     start: "2025-10-30",
     portal: "0x30e8ee7b5881bf2E158A0514f2150aabe2c68b23",
     fromBlock: 32284042,
     useIndexer: true,
+    safe: "0xA77dc19CF7CB7ab50b661Ce5AB6D37954F8022f4",
   },
 };
 
@@ -37,20 +42,25 @@ const eventAbis = {
   tokenBought: "event TokenBought(uint256 ts, address token, address buyer, uint256 amount, uint256 eth, uint256 fee, uint256 postPrice)",
   tokenSold: "event TokenSold(uint256 ts, address token, address seller, uint256 amount, uint256 eth, uint256 fee, uint256 postPrice)",
   tokenQuoteSet: "event TokenQuoteSet(address token, address quoteToken)",
+  safeReceived: "event SafeReceived(address indexed sender, uint256 value)",
 };
 
 const TOKEN_BOUGHT_TOPIC0 = "0xa800a2038683844fac66747f771bfdfae862eb28b16bcfa387afa9fbacce8ff7";
 const TOKEN_SOLD_TOPIC0 = "0x03a4693e592f5e75dc7c136acb39b146d2b4966c0e509c34f362dee02b3b861a";
 const TOKEN_QUOTE_SET_TOPIC0 = "0x3ceb902d3c555c21c3415b6aa839104b18e4825b2f8324011ff979089a507a8c";
+const TRANSFER_TOPIC0 = "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef";
+const SAFE_RECEIVED_TOPIC0 = "0x3d0ce9bfc3ed7d6862dbb28b2dea94561fe714a1b4d019aa8af39730d1ad7c3d";
 
 const shortAddrOf = (addr: string) => addr.substring(0, 10).toLowerCase();
+const padAddress = (addr: string) => "0x" + "0".repeat(24) + addr.slice(2).toLowerCase();
 
 const BLOCKS_PER_BATCH = 10000;
 
 type TradeTotals = {
   volumeByToken: Record<string, string | bigint>;
-  feesByToken: Record<string, string | bigint>;
   quoteByToken: Record<string, string>;
+  // every quote token ever configured, for tracking fee-safe inflows
+  quoteTokens: string[];
 };
 
 // ClickHouse path: aggregate the day's trades per token server-side, then map
@@ -68,8 +78,7 @@ const getTradesFromIndexer = async (options: FetchOptions, portal: string): Prom
   const trades = await queryClickhouse<any>(`
     SELECT
       concat('0x', substring(data, 91, 40)) AS token,
-      toString(SUM(reinterpretAsUInt256(reverse(unhex(substring(data, 259, 64)))))) AS volume,
-      toString(SUM(reinterpretAsUInt256(reverse(unhex(substring(data, 323, 64)))))) AS fees
+      toString(SUM(reinterpretAsUInt256(reverse(unhex(substring(data, 259, 64)))))) AS volume
     FROM evm_indexer.logs
     PREWHERE chain = ${chainId}
       AND short_address = '${shortAddrOf(target)}'
@@ -82,13 +91,20 @@ const getTradesFromIndexer = async (options: FetchOptions, portal: string): Prom
   `);
 
   const volumeByToken: Record<string, string> = {};
-  const feesByToken: Record<string, string> = {};
-  trades.forEach((row: any) => {
-    volumeByToken[row.token] = row.volume;
-    feesByToken[row.token] = row.fees;
-  });
+  trades.forEach((row: any) => { volumeByToken[row.token] = row.volume; });
 
-  // No time filter: quotes are set once at creation and never change.
+  // No time filter on either quote query: quotes are set once at creation and never change.
+  const distinctQuotes = await queryClickhouse<any>(`
+    SELECT DISTINCT concat('0x', substring(data, 91, 40)) AS quote
+    FROM evm_indexer.logs
+    PREWHERE chain = ${chainId}
+      AND short_address = '${shortAddrOf(target)}'
+      AND short_topic0 = '${TOKEN_QUOTE_SET_TOPIC0.substring(0, 10)}'
+      AND address = '${target}'
+      AND topic0 = '${TOKEN_QUOTE_SET_TOPIC0}'
+  `);
+  const quoteTokens = distinctQuotes.map((row: any) => row.quote);
+
   const quoteByToken: Record<string, string> = {};
   if (trades.length) {
     const tokenList = trades.map((row: any) => `'${row.token.slice(2)}'`).join(",");
@@ -107,7 +123,7 @@ const getTradesFromIndexer = async (options: FetchOptions, portal: string): Prom
     quotes.forEach((row: any) => { quoteByToken[row.token] = row.quote; });
   }
 
-  return { volumeByToken, feesByToken, quoteByToken };
+  return { volumeByToken, quoteByToken, quoteTokens };
 };
 
 const getTradesFromLogs = async (options: FetchOptions, portal: string, fromBlock: number): Promise<TradeTotals> => {
@@ -127,14 +143,13 @@ const getTradesFromLogs = async (options: FetchOptions, portal: string, fromBloc
   });
   const quoteByToken: Record<string, string> = {};
   quoteLogs.forEach((log: any) => { quoteByToken[log.token.toLowerCase()] = log.quoteToken.toLowerCase(); });
+  const quoteTokens = [...new Set(Object.values(quoteByToken))];
 
   const volumeByToken: Record<string, bigint> = {};
-  const feesByToken: Record<string, bigint> = {};
   const processTradeLogs = (logs: any[]) => {
     logs.forEach((log) => {
       const token = log.token.toLowerCase();
       volumeByToken[token] = (volumeByToken[token] ?? 0n) + BigInt(log.eth);
-      feesByToken[token] = (feesByToken[token] ?? 0n) + BigInt(log.fee);
     });
   };
 
@@ -152,59 +167,107 @@ const getTradesFromLogs = async (options: FetchOptions, portal: string, fromBloc
     processTradeLogs(sellLogs);
   }
 
-  return { volumeByToken, feesByToken, quoteByToken };
+  return { volumeByToken, quoteByToken, quoteTokens };
+};
+
+// Safe inflows via ClickHouse: ERC20 Transfer events on the quote tokens with
+// the Safe as recipient (topic2), plus native via SafeReceived on the Safe.
+// Sums are computed server-side, one row per quote token comes back.
+const addSafeInflowsFromIndexer = async (options: FetchOptions, safe: string, erc20Quotes: string[], balances: any) => {
+  const chainId = Number(options.api.chainId);
+  const target = safe.toLowerCase();
+  const [fromBlock, toBlock] = await Promise.all([
+    options.getFromBlock(),
+    options.getToBlock(),
+  ]);
+
+  if (erc20Quotes.length) {
+    const shortList = [...new Set(erc20Quotes.map(shortAddrOf))].map((a) => `'${a}'`).join(",");
+    const addressList = erc20Quotes.map((a) => `'${a.toLowerCase()}'`).join(",");
+    const transfers = await queryClickhouse<any>(`
+      SELECT
+        address AS token,
+        toString(SUM(reinterpretAsUInt256(reverse(unhex(substring(data, 3, 64)))))) AS amount
+      FROM evm_indexer.logs
+      PREWHERE chain = ${chainId}
+        AND short_address IN (${shortList})
+        AND short_topic0 = '${TRANSFER_TOPIC0.substring(0, 10)}'
+        AND address IN (${addressList})
+        AND topic0 = '${TRANSFER_TOPIC0}'
+        AND topic2 = '${padAddress(target)}'
+        AND block_number >= ${fromBlock}
+        AND block_number <= ${toBlock}
+      GROUP BY address
+    `);
+    transfers.forEach((row: any) => balances.add(row.token, row.amount, TREASURY_RECEIVED));
+  }
+
+  const native = await queryClickhouse<any>(`
+    SELECT toString(SUM(reinterpretAsUInt256(reverse(unhex(substring(data, 3, 64)))))) AS amount
+    FROM evm_indexer.logs
+    PREWHERE chain = ${chainId}
+      AND short_address = '${shortAddrOf(target)}'
+      AND short_topic0 = '${SAFE_RECEIVED_TOPIC0.substring(0, 10)}'
+      AND address = '${target}'
+      AND topic0 = '${SAFE_RECEIVED_TOPIC0}'
+      AND block_number >= ${fromBlock}
+      AND block_number <= ${toBlock}
+  `);
+  if (native.length && native[0].amount !== "0") balances.addGasToken(native[0].amount, TREASURY_RECEIVED);
 };
 
 const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
-  const { portal, fromBlock, useIndexer } = chainConfig[options.chain];
+  const { portal, fromBlock, useIndexer, safe } = chainConfig[options.chain];
   const dailyVolume = options.createBalances();
   const dailyFees = options.createBalances();
-  const dailyRevenue = options.createBalances();
-  const dailyProtocolRevenue = options.createBalances();
 
-  const { volumeByToken, feesByToken, quoteByToken } = useIndexer
+  const { volumeByToken, quoteByToken, quoteTokens } = useIndexer
     ? await getTradesFromIndexer(options, portal)
     : await getTradesFromLogs(options, portal, fromBlock);
 
   Object.keys(volumeByToken).forEach((token) => {
-    const quoteToken = quoteByToken[token]
+    const quoteToken = quoteByToken[token];
     if (!quoteToken) return;
-    if (quoteToken === NATIVE_TOKEN) {
-      dailyVolume.addGasToken(volumeByToken[token]);
-      dailyFees.addGasToken(feesByToken[token], BONDING_CURVE_FEES);
-      dailyRevenue.addGasToken(feesByToken[token], BONDING_CURVE_FEES);
-      dailyProtocolRevenue.addGasToken(feesByToken[token], BONDING_CURVE_FEES);
-    } else {
-      dailyVolume.add(quoteToken, volumeByToken[token]);
-      dailyFees.add(quoteToken, feesByToken[token], BONDING_CURVE_FEES);
-      dailyRevenue.add(quoteToken, feesByToken[token], BONDING_CURVE_FEES);
-      dailyProtocolRevenue.add(quoteToken, feesByToken[token], BONDING_CURVE_FEES);
-    }
+    if (quoteToken === NATIVE_TOKEN) dailyVolume.addGasToken(volumeByToken[token]);
+    else dailyVolume.add(quoteToken, volumeByToken[token]);
   });
 
-  return { dailyVolume, dailyFees, dailyUserFees: dailyFees, dailyRevenue, dailyProtocolRevenue };
+  // Fees: every quote-token inflow to the Flap fee Safe, from any sender
+  // bonding-curve fees, token-tax payouts, graduation fees and LP fee claims
+  // all settle there.
+  const erc20Quotes = quoteTokens.filter((token) => token !== NATIVE_TOKEN);
+  if (useIndexer) {
+    await addSafeInflowsFromIndexer(options, safe, erc20Quotes, dailyFees);
+  } else {
+    const erc20Transfers = await addTokensReceived({ options, target: safe, tokens: erc20Quotes });
+    dailyFees.addBalances(erc20Transfers, TREASURY_RECEIVED);
+    const nativeLogs = await options.getLogs({ target: safe, eventAbi: eventAbis.safeReceived });
+    nativeLogs.forEach((log: any) => dailyFees.addGasToken(log.value, TREASURY_RECEIVED));
+  }
+
+  return { dailyVolume, dailyFees, dailyUserFees: dailyFees, dailyRevenue: dailyFees, dailyProtocolRevenue: dailyFees };
 };
 
 const methodology = {
   Volume: "Buy and sell volume on Flap bonding curves before tokens move to a DEX.",
-  Fees: "Fees users pay on Flap bonding-curve buys and sells. Token taxes are excluded.",
-  UserFees: "Fees users pay on Flap bonding-curve buys and sells.",
-  Revenue: "Fees kept by Flap from bonding-curve trades.",
-  ProtocolRevenue: "Fees kept by Flap from bonding-curve trades.",
+  Fees: "All quote tokens received by the Flap fee Safe, from any sender. Includes bonding-curve fees, token-tax payouts, graduation fees, and other quote inflows such as airdrops.",
+  UserFees: "Same as Fees — all quote inflows to the fee Safe.",
+  Revenue: "All quote tokens received by the Flap fee Safe, from any sender.",
+  ProtocolRevenue: "All quote tokens received by the Flap fee Safe, from any sender.",
 };
 
 const breakdownMethodology = {
   Fees: {
-    [BONDING_CURVE_FEES]: "Fees users pay on Flap bonding-curve buys and sells.",
+    [TREASURY_RECEIVED]: "Quote tokens transferred to the Flap fee Safe (native SafeReceived and ERC20 Transfer to the Safe), with no sender filter.",
   },
   UserFees: {
-    [BONDING_CURVE_FEES]: "Fees users pay on Flap bonding-curve buys and sells.",
+    [TREASURY_RECEIVED]: "Quote tokens transferred to the Flap fee Safe (native SafeReceived and ERC20 Transfer to the Safe), with no sender filter.",
   },
   Revenue: {
-    [BONDING_CURVE_FEES]: "Fees kept by Flap from bonding-curve trades.",
+    [TREASURY_RECEIVED]: "Quote tokens received by the Flap fee Safe.",
   },
   ProtocolRevenue: {
-    [BONDING_CURVE_FEES]: "Fees kept by Flap from bonding-curve trades.",
+    [TREASURY_RECEIVED]: "Quote tokens received by the Flap fee Safe.",
   },
 };
 

--- a/dexs/flap.ts
+++ b/dexs/flap.ts
@@ -12,29 +12,32 @@ const chainConfig: Record<string, {
   start: string;
   portal: string;
   fromBlock: number;
-  safe?: string;
+  // Fee Safe — portals do not expose address:FEE_RECEIVER
+  safe: string;
 }> = {
   [CHAIN.BSC]: {
     start: "2024-06-27",
     portal: "0xe2cE6ab80874Fa9Fa2aAE65D277Dd6B8e65C9De0",
     fromBlock: 39980228,
-    // FEE_RECEIVER fallback  (BSC treasury Safe)
-    safe: "0x8a08d98cbb218fceb318ecf3abc1ba43d8a7ab0e",
+    safe: "0x8a08D98CBB218fceB318Ecf3aBc1BA43D8A7aB0E",
   },
   [CHAIN.ROBINHOOD]: {
     start: "2026-07-08",
     portal: "0x26605f322f7fF986f381bB9A6e3f5DAb0bEaEb09",
     fromBlock: 4180724,
+    safe: "0xa4A727E0918cf9B39639Fc4cB7D742d39C5352a4",
   },
   [CHAIN.XLAYER]: {
     start: "2025-08-18",
     portal: "0xb30D8c4216E1f21F27444D2FfAee3ad577808678",
     fromBlock: 31165559,
+    safe: "0xAC4f9Ba4E48cAafBa17164FBCb078091651Ae361",
   },
   [CHAIN.MONAD]: {
     start: "2025-10-30",
     portal: "0x30e8ee7b5881bf2E158A0514f2150aabe2c68b23",
     fromBlock: 32284042,
+    safe: "0xA77dc19CF7CB7ab50b661Ce5AB6D37954F8022f4",
   },
 };
 
@@ -128,27 +131,10 @@ const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
     }
   })();
 
-  // Fees match : every quote-token inflow to the fee Safe, any sender.
+  // Fees: every quote-token inflow to the fee Safe, any sender.
+  // Safe is hardcoded per chain — Portal has no address:FEE_RECEIVER view.
   const feePrep = (async () => {
-    let safe: string | undefined = config.safe;
-    try {
-      safe = await options.api.call({ target: portal, abi: "address:FEE_RECEIVER" });
-    } catch (e) {
-      const msg = String((e as any)?.message ?? e);
-      const missingGetter = /execution reverted|returned no data|FUNCTION_SELECTOR_NOT_RECOGNIZED/i.test(msg);
-      if (!missingGetter) throw e;
-      if (!config.safe) {
-        console.log(`flap: FEE_RECEIVER missing on ${options.chain}, skipping treasury fees`);
-        return;
-      }
-      console.log(`flap: FEE_RECEIVER() unsupported on ${options.chain}, using fallback ${config.safe}`);
-      safe = config.safe;
-    }
-    if (!safe) {
-      console.log(`flap: FEE_RECEIVER missing on ${options.chain}, skipping treasury fees`);
-      return;
-    }
-    safe = safe.toLowerCase();
+    const safe = config.safe.toLowerCase();
 
     const configLogs = await options.getLogs({
       target: portal,

--- a/dexs/flap.ts
+++ b/dexs/flap.ts
@@ -2,15 +2,24 @@ import { FetchOptions, FetchResultV2, SimpleAdapter } from "../adapters/types";
 import ADDRESSES from "../helpers/coreAssets.json";
 import { CHAIN } from "../helpers/chains";
 
-const BONDING_CURVE_FEES = "Bonding Curve Fees";
 const NATIVE_TOKEN = ADDRESSES.null;
+const TRANSFER_TOPIC = "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef";
+const QUOTE_CONFIG_TOPIC = "0x9a1f38e55c729ebf0c45d240a00b09f0a79a715df7cfd6e8942bd3f8da839199";
+const TREASURY_RECEIVED = "Treasury Received";
 
 // Source: https://docs.flap.sh/flap/developers/deployed-contract-addresses
-const chainConfig: Record<string, { start: string; portal: string; fromBlock: number }> = {
+const chainConfig: Record<string, {
+  start: string;
+  portal: string;
+  fromBlock: number;
+  safe?: string;
+}> = {
   [CHAIN.BSC]: {
     start: "2024-06-27",
     portal: "0xe2cE6ab80874Fa9Fa2aAE65D277Dd6B8e65C9De0",
     fromBlock: 39980228,
+    // FEE_RECEIVER fallback  (BSC treasury Safe)
+    safe: "0x8a08d98cbb218fceb318ecf3abc1ba43d8a7ab0e",
   },
   [CHAIN.ROBINHOOD]: {
     start: "2026-07-08",
@@ -33,12 +42,28 @@ const eventAbis = {
   tokenBought: "event TokenBought(uint256 ts, address token, address buyer, uint256 amount, uint256 eth, uint256 fee, uint256 postPrice)",
   tokenSold: "event TokenSold(uint256 ts, address token, address seller, uint256 amount, uint256 eth, uint256 fee, uint256 postPrice)",
   tokenQuoteSet: "event TokenQuoteSet(address token, address quoteToken)",
+  quoteTokenConfigurationSet: "event QuoteTokenConfigurationSet(address quoteToken, tuple(uint8 enabled, uint8 defaultCurve, uint8 alternativeCurve, uint8 nativeToQuoteSwapType, uint8 dexId) config)",
+  transfer: "event Transfer(address indexed from, address indexed to, uint256 value)",
+  safeReceived: "event SafeReceived(address indexed sender, uint256 value)",
 };
 
 const BLOCKS_PER_BATCH = 10000;
 
+const addressFromDataWord = (data: string, wordIndex = 0) => {
+  const hex = data.startsWith("0x") ? data.slice(2) : data;
+  const start = wordIndex * 64 + 24;
+  return ("0x" + hex.slice(start, start + 40)).toLowerCase();
+};
+
+const uniqueLower = (addresses: string[]) =>
+  [...new Set(addresses.map((a) => a.toLowerCase()).filter((a) => a && a !== NATIVE_TOKEN))];
+
+const padAddress = (address: string) =>
+  "0x" + address.replace(/^0x/i, "").toLowerCase().padStart(64, "0");
+
 const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
-  const { portal, fromBlock } = chainConfig[options.chain];
+  const config = chainConfig[options.chain];
+  const { portal, fromBlock } = config;
   const dailyVolume = options.createBalances();
   const dailyFees = options.createBalances();
   const dailyRevenue = options.createBalances();
@@ -48,6 +73,18 @@ const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
     options.getFromBlock(),
     options.getToBlock(),
   ]);
+
+  const addFee = (token: string, amount: any) => {
+    if (token === NATIVE_TOKEN) {
+      dailyFees.addGasToken(amount, TREASURY_RECEIVED);
+      dailyRevenue.addGasToken(amount, TREASURY_RECEIVED);
+      dailyProtocolRevenue.addGasToken(amount, TREASURY_RECEIVED);
+    } else {
+      dailyFees.add(token, amount, TREASURY_RECEIVED);
+      dailyRevenue.add(token, amount, TREASURY_RECEIVED);
+      dailyProtocolRevenue.add(token, amount, TREASURY_RECEIVED);
+    }
+  };
 
   // Map every token to its quote token once. TokenQuoteSet fires once per token
   // at creation, so this is fetched over the full history and cached in cloud.
@@ -66,58 +103,105 @@ const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
   const processTradeLogs = (logs: any[]) => {
     logs.forEach((log) => {
       const quoteToken = quoteTokens[log.token.toLowerCase()];
-      if(!quoteToken) return;
+      if (!quoteToken) return;
       if (quoteToken === NATIVE_TOKEN) {
         dailyVolume.addGasToken(log.eth);
-        dailyFees.addGasToken(log.fee, BONDING_CURVE_FEES);
-        dailyRevenue.addGasToken(log.fee, BONDING_CURVE_FEES);
-        dailyProtocolRevenue.addGasToken(log.fee, BONDING_CURVE_FEES);
       } else {
         dailyVolume.add(quoteToken, log.eth);
-        dailyFees.add(quoteToken, log.fee, BONDING_CURVE_FEES);
-        dailyRevenue.add(quoteToken, log.fee, BONDING_CURVE_FEES);
-        dailyProtocolRevenue.add(quoteToken, log.fee, BONDING_CURVE_FEES);
       }
     });
   };
 
-  // Fetch buy/sell logs in block-range batches and aggregate incrementally
-  // instead of loading the whole day's logs into memory at once. A single
-  // getLogs for the full window OOMs on busy days; batching bounds peak memory
-  // to one batch since each decoded array is released before the next fetch.
-  for (let start = dayFromBlock; start <= dayToBlock; start += BLOCKS_PER_BATCH) {
-    const end = Math.min(start + BLOCKS_PER_BATCH - 1, dayToBlock);
-    const [buyLogs, sellLogs] = await Promise.all([
-      options.getLogs({ target: portal, eventAbi: eventAbis.tokenBought, fromBlock: start, toBlock: end, skipCacheRead: true }),
-      options.getLogs({ target: portal, eventAbi: eventAbis.tokenSold, fromBlock: start, toBlock: end, skipCacheRead: true }),
-    ]);
-    processTradeLogs(buyLogs);
-    processTradeLogs(sellLogs);
-  }
+  const volumeLoop = (async () => {
+    // Fetch buy/sell logs in block-range batches and aggregate incrementally
+    // instead of loading the whole day's logs into memory at once. A single
+    // getLogs for the full window OOMs on busy days; batching bounds peak memory
+    // to one batch since each decoded array is released before the next fetch.
+    for (let start = dayFromBlock; start <= dayToBlock; start += BLOCKS_PER_BATCH) {
+      const end = Math.min(start + BLOCKS_PER_BATCH - 1, dayToBlock);
+      const [buyLogs, sellLogs] = await Promise.all([
+        options.getLogs({ target: portal, eventAbi: eventAbis.tokenBought, fromBlock: start, toBlock: end, skipCacheRead: true }),
+        options.getLogs({ target: portal, eventAbi: eventAbis.tokenSold, fromBlock: start, toBlock: end, skipCacheRead: true }),
+      ]);
+      processTradeLogs(buyLogs);
+      processTradeLogs(sellLogs);
+    }
+  })();
+
+  // Fees match : every quote-token inflow to the fee Safe, any sender.
+  const feePrep = (async () => {
+    let safe: string | undefined = config.safe;
+    try {
+      safe = await options.api.call({ target: portal, abi: "address:FEE_RECEIVER" });
+    } catch {
+      // keep chain fallback
+    }
+    if (!safe) {
+      console.log(`flap: FEE_RECEIVER missing on ${options.chain}, skipping treasury fees`);
+      return;
+    }
+    safe = safe.toLowerCase();
+
+    const configLogs = await options.getLogs({
+      target: portal,
+      eventAbi: eventAbis.quoteTokenConfigurationSet,
+      topics: [QUOTE_CONFIG_TOPIC],
+      fromBlock,
+      toBlock: dayToBlock,
+      cacheInCloud: true,
+      entireLog: true,
+    });
+    const erc20Quotes = uniqueLower(configLogs.map((log: any) => {
+      const decoded = log.quoteToken || log.args?.quoteToken;
+      if (decoded) return String(decoded);
+      return log.data ? addressFromDataWord(log.data, 0) : "";
+    }));
+
+    const nativeLogs = await options.getLogs({
+      target: safe,
+      eventAbi: eventAbis.safeReceived,
+    });
+    nativeLogs.forEach((log: any) => addFee(NATIVE_TOKEN, log.value));
+
+    if (erc20Quotes.length) {
+      const transferLogs = await options.getLogs({
+        targets: erc20Quotes,
+        eventAbi: eventAbis.transfer,
+        topics: [TRANSFER_TOPIC, null as any, padAddress(safe)],
+        flatten: false,
+      });
+      transferLogs.forEach((tokenLogs: any[], i: number) => {
+        const token = erc20Quotes[i];
+        (tokenLogs || []).forEach((log: any) => addFee(token, log.value));
+      });
+    }
+  })();
+
+  await Promise.all([volumeLoop, feePrep]);
 
   return { dailyVolume, dailyFees, dailyUserFees: dailyFees, dailyRevenue, dailyProtocolRevenue };
 };
 
 const methodology = {
   Volume: "Buy and sell volume on Flap bonding curves before tokens move to a DEX.",
-  Fees: "Fees users pay on Flap bonding-curve buys and sells. Token taxes are excluded.",
-  UserFees: "Fees users pay on Flap bonding-curve buys and sells.",
-  Revenue: "Fees kept by Flap from bonding-curve trades.",
-  ProtocolRevenue: "Fees kept by Flap from bonding-curve trades.",
+  Fees: "All quote tokens received by the Flap fee Safe, from any sender. Includes bonding-curve fees, token-tax payouts, graduation fees, and other quote inflows such as airdrops.",
+  UserFees: "Same as Fees — all quote inflows to the fee Safe.",
+  Revenue: "All quote tokens received by the Flap fee Safe, from any sender.",
+  ProtocolRevenue: "All quote tokens received by the Flap fee Safe, from any sender.",
 };
 
 const breakdownMethodology = {
   Fees: {
-    [BONDING_CURVE_FEES]: "Fees users pay on Flap bonding-curve buys and sells.",
+    [TREASURY_RECEIVED]: "Quote tokens transferred to the Flap fee Safe (native SafeReceived and ERC20 Transfer to the Safe), with no sender filter.",
   },
   UserFees: {
-    [BONDING_CURVE_FEES]: "Fees users pay on Flap bonding-curve buys and sells.",
+    [TREASURY_RECEIVED]: "Quote tokens transferred to the Flap fee Safe (native SafeReceived and ERC20 Transfer to the Safe), with no sender filter.",
   },
   Revenue: {
-    [BONDING_CURVE_FEES]: "Fees kept by Flap from bonding-curve trades.",
+    [TREASURY_RECEIVED]: "Quote tokens received by the Flap fee Safe.",
   },
   ProtocolRevenue: {
-    [BONDING_CURVE_FEES]: "Fees kept by Flap from bonding-curve trades.",
+    [TREASURY_RECEIVED]: "Quote tokens received by the Flap fee Safe.",
   },
 };
 


### PR DESCRIPTION
**NOTE**

#### Please enable "Allow edits by maintainers" while putting up the PR.

---

This is **not a new listing**. Flap is already listed: https://defillama.com/protocol/flap-sh

No `package.json` / `package-lock.json` changes.

---

## Summary

Update `dexs/flap.ts` fee / revenue accounting to match treasury receipts, instead of the bonding-curve event `fee` field.

- **Volume**: unchanged. Still `TokenBought` / `TokenSold` `eth` on the Portal bonding curve, priced in each token's quote from `TokenQuoteSet`. Graduated DEX volume is still excluded.
- **Fees / UserFees / Revenue / ProtocolRevenue**: all quote tokens received by the Flap fee Safe (`FEE_RECEIVER`), from **any sender**.
  - Native: `SafeReceived` on the Safe
  - ERC20: `Transfer` to the Safe for quote tokens from `QuoteTokenConfigurationSet`
  - Includes bonding-curve fees, token-tax payouts, graduation fees, and other quote inflows (e.g. airdrops)
  - No `from` whitelist
- Tokens are added via `createBalances()` (`add` / `addGasToken`). DefiLlama prices them and sums USD.

This replaces the previous "Bonding Curve Fees" breakdown (event `fee` only, token taxes excluded) with **Treasury Received**.

## Why

The event `fee` field undercounts protocol income. The fee Safe is the source of truth for what Flap actually receives.

BSC `FEE_RECEIVER` fallback: `0x8a08d98cbb218fceb318ecf3abc1ba43d8a7ab0e`

Portal addresses: https://docs.flap.sh/flap/developers/deployed-contract-addresses

## Methodology (adapter)

- **Volume**: Buy and sell volume on Flap bonding curves before tokens move to a DEX.
- **Fees / UserFees / Revenue / ProtocolRevenue**: All quote tokens received by the Flap fee Safe, from any sender.

## Chains

bsc, robinhood, xlayer, monad (existing config; BSC has a Safe fallback).

## Test plan

- [ ] `pnpm test dexs flap 2026-08-14 bsc` (UTC day 2026-08-13)
- [ ] `pnpm test dexs flap 2026-08-11 bsc` (UTC day 2026-08-10)
- [ ] Confirm breakdown label is `Treasury Received`
- [ ] Confirm `dailyFees` == `dailyUserFees` == `dailyRevenue` == `dailyProtocolRevenue`
- [ ] Volume still in the same ballpark as before (buy + sell on the curve)

Local BSC spot-checks (quote amounts priced with `coins.llama.fi` midday UTC; fast path, volume can miss tokens without a cached `TokenQuoteSet`):

| UTC day | Volume USD (lower bound) | Fees USD |
|---|---:|---:|
| 2026-08-13 | ~$15.0M | ~$254.6k |
| 2026-08-10 | ~$11.4M | ~$290.5k |