### PR TITLE
stonkbrokers: wire the live Safe Launch pad address

### DIFF
--- a/fees/stonkbrokers/index.ts
+++ b/fees/stonkbrokers/index.ts
@@ -89,6 +89,7 @@ const LAUNCH_BOOSTER_BPS = 9000n;
 // receives its slice THROUGH the pad's tax split, so only pad events are read
 // (reading card events too would double count).
 const SAFE_LAUNCH_PADS: string[] = [
+  "0xEcA5726dae1e53365c37fFc02369d947A91d71f9", // StonkSafeLaunchpad, public open 2026-08-17 22:06 UTC
 ];
 // Production tax split, applied by the go-live `setFeeSplit(1650, 1650, 5000)`
 // and snapshotted into every launch: creator / protocol / locked-LP reserve,


### PR DESCRIPTION
## Summary

- #8809 added full Safe Launch pad tracking (SafeBuy/SafeSell snipe-tax fees, volume, and the 16.5% creator / 16.5% protocol / 17% StockBooster+referrer / 50% locked-LP split legs) but shipped with an **empty pad address list** — the singleton had not deployed yet.
- The pad is now live on Robinhood Chain: [`0xEcA5726dae1e53365c37fFc02369d947A91d71f9`](https://robinhoodchain.blockscout.com/address/0xEcA5726dae1e53365c37fFc02369d947A91d71f9) (source-verified, public open 2026-08-17 22:06 UTC). This one-line change appends it, activating the already-merged decode path.

## Test

`yarn test fees stonkbrokers` against the live chain — first 24h of the public open records **$279,973 daily snipe tax on $1.17M window volume**, with all four split legs itemized in the breakdown (creator $46.2k / StockBooster+Clock In Card referrers $47.6k / permanently locked LP reserve $140.0k / protocol accrual $46.2k). No other legs changed.

Made with [Cursor](https://cursor.com)