### PR TITLE
ntm: route the fee api through the proxy, it 403s datacenter ips

### DIFF
--- a/fees/ntm/index.ts
+++ b/fees/ntm/index.ts
@@ -1,7 +1,12 @@
 import { CHAIN } from "../../helpers/chains";
 import { FetchOptions } from "../../adapters/types";
-import { httpGet } from "../../utils/fetchURL";
+import { proxiedFetch } from "../../utils/fetchURL";
 
+// api.ntm.ai answers normally from a residential IP and returns 403 to a
+// datacenter IP, which is why nothing has been published since 2026-07-29.
+// Routed through the shared proxy, the same treatment aggregators/houdiniswap
+// and fees/space-and-time already use. proxiedFetch falls back to a direct
+// request when PROXY_AUTH is unset, so local runs and CI are unchanged.
 const endpoint = "https://api.ntm.ai/feesAndRevenues.php?";
 const chainToken: Record<string, string> = {
   [CHAIN.TON]: "the-open-network",
@@ -20,7 +25,7 @@ const fetchFeesAndRevenues = async (options: FetchOptions) => {
     .toISOString()
     .split(".")[0];
   const url = `${endpoint}start_date=${startTime}&end_date=${endTime}&chain=${options.chain}`;
-  const res = await httpGet(url);
+  const res = await proxiedFetch(url);
 
   // Reject anything that is not a real number before it reaches addCGToken.
   // Number(undefined) is NaN and Number(null)/Number("")/Number(" ")/Number([])


### PR DESCRIPTION
Fixes #8816.

`fees/ntm` has published nothing since 2026-07-29. `total24h` and `total7d` are both null and the chart stops rather than trailing zeros, which is the adapter erroring rather than writing a real zero. Density before the stop was 60 of the last 60 days nonzero at roughly $1,330/day, so this is not a protocol that pays in bursts. `total30d` is $13.5k and `total1y` is $678k.

## The source is healthy, the caller's IP is the problem

`api.ntm.ai/feesAndRevenues.php` answers 200 for every chain in `chainToken` and for the individual days inside the gap, so this is not a backfill hole.

The diagnosis came out of CI on #8820, not from guessing. That PR's `test` job ran the adapter on a GitHub Actions runner:

```
🦙 Running NTM adapter 🦙
------ ERROR ------
Request failed with status code 403
```

The identical request from a residential IP returns 200 with any User-Agent, including no User-Agent header at all. `axios/1.7.2`, `axios/0.27.2`, `node` and `Mozilla/5.0` all return 200. So the block is on the caller's IP, not on the request shape, and a datacenter runner is exactly what production is.

## Why the proxy

`proxiedFetch` is already the repo's treatment for this failure mode:

- `aggregators/houdiniswap` switched to it in #8745 ("cloudflare blocks node"). It had a gap over 08-08 to 08-11, the change merged 08-14, and it has published every day since, currently $1.94M on 08-18.
- `fees/space-and-time` uses it and is current through 08-18.

`proxiedFetch` falls back to a direct request when `PROXY_AUTH` is unset, so local runs and CI behave exactly as they do today. The `readAmount` guard added in #8820 still applies to whatever comes back, so a bad body still throws rather than publishing a zero.

## Test

Run locally, which takes the fallback path:

```
chain     | Daily fees | Daily revenue
ethereum  | 287.00     | 287.00
bsc       | 301.00     | 301.00
avax      | 76.00      | 76.00
solana    | 231.00     | 231.00
tron      | 566.00     | 566.00
ton       | 13.00      | 13.00
Aggregate | 1.47 k     | 1.47 k
```

In line with the pre-stop level of roughly $1,330/day.

## What this does not prove

I cannot verify from here that the proxy's egress IP is not also blocked by ntm, since I do not have `PROXY_AUTH`. What is established is that the block is IP-based rather than header-based, and that this same proxy clears the same class of block for houdiniswap. If ntm blocks the proxy too, the adapter keeps erroring and keeps publishing nothing, which is the current behaviour, so this cannot make things worse.
