### PR TITLE
yield-basis: mark the fees adapter doublecounted, its fees come from Curve pools

### DIFF
--- a/fees/yield-basis/index.ts
+++ b/fees/yield-basis/index.ts
@@ -206,6 +206,12 @@ const adapter: SimpleAdapter = {
     methodology,
     breakdownMethodology,
     allowNegativeValue: true,
+    // The yield and admin fees booked here are the downstream share of trading
+    // fees earned in the Yield Basis pools, which are Curve pools. dexs/curve
+    // already reports those trading fees, and reports them gross, so counting
+    // this adapter in the aggregates as well would count the same flow twice.
+    // dexs/yield-basis carries the same flag for the volume side of this overlap.
+    doublecounted: true,
 }
 
 export default adapter;


### PR DESCRIPTION
Fixes #8622.

`fees/yield-basis` books the downstream share of trading fees earned in the Yield Basis pools, which are Curve pools. `dexs/curve` already reports those trading fees. Counting both in the aggregates counts the same flow twice.

This sets `doublecounted: true` on `fees/yield-basis`. `dexs/yield-basis` already carries the same flag for the volume side of the same overlap, so this makes the two halves consistent.

The adapter's own output is unchanged; the flag only affects aggregation.

Curve is left alone deliberately. Those trading fees really were paid in Curve pools, and Curve should report them gross.
