### PR TITLE
ember: make the fee window's upper bound exclusive, a backfill books the day twice

### DIFF
--- a/fees/ember-protocol.ts
+++ b/fees/ember-protocol.ts
@@ -5,7 +5,13 @@ import { CHAIN } from "../helpers/chains";
 const ember_fees_url="https://vaults.api.sui-prod.bluefin.io/api/v2/vaults/fees"
 
 const fetch = async (options: FetchOptions): Promise<FetchResultFees> => {
-  const result= await fetchURL(`${ember_fees_url}?startTimestampInMs=${options.startTimestamp*1000}&endTimestampInMs=${options.endTimestamp*1000}`);
+  // endTimestampInMs is inclusive on the API side, and fees arrive as one discrete
+  // accrual event at 00:00 UTC. runAdapter hands us endTimestamp = midnight, which
+  // lands exactly on the next day's event, so a day window returns two events and
+  // books roughly double. Live runs escape it only because that event does not
+  // exist yet when the job fires; a backfill of a past day does not. Shave a
+  // millisecond off so the upper bound is effectively exclusive.
+  const result= await fetchURL(`${ember_fees_url}?startTimestampInMs=${options.startTimestamp*1000}&endTimestampInMs=${options.endTimestamp*1000-1}`);
   const feesUsdE9=result.feesUsdE9;
   const revenueUsdE9=result.revenueUsdE9;
 


### PR DESCRIPTION
Partially addresses #8625. This is the window half only, see the bottom for what it does not fix.

## The bug

`vaults.api.sui-prod.bluefin.io/api/v2/vaults/fees` treats `endTimestampInMs` as **inclusive**, and Ember's fees arrive as one discrete accrual event at 00:00 UTC rather than accruing across the day.

`runAdapter` hands the adapter `endTimestamp = toTimestamp + 1` (`adapters/utils/runAdapter.ts:428`), which is exactly midnight. That lands precisely on the next day's accrual event, so a one-day window returns two events.

Reproduced against the live endpoint, single-day midnight-to-midnight windows:

| day | inclusive `[a,b]` | exclusive `[a,b-1s]` | ratio |
|---|---|---|---|
| 2026-08-13 | 48,006.05 | 23,494.81 | 2.04 |
| 2026-08-14 | 32,572.16 | 24,511.24 | 1.33 |
| 2026-08-15 | 16,774.40 | 8,147.57 | 2.06 |
| 2026-08-16 | 16,055.50 | 8,626.84 | 1.86 |
| 2026-08-17 | 15,336.60 | 7,428.66 | 2.06 |

Each day's boundary event is counted in both adjacent windows. The exclusive value for 08-14 (24,511.24) is exactly the excess the inclusive 08-13 window picked up. Summing five inclusive single days gives 128,744.71 against 79,825.15 for the same five days requested as one span.

## Why the published chart looks fine anyway

Because on a live run the next day's event does not exist yet when the job fires. Published 08-15, 08-16 and 08-17 are 8,148 / 8,627 / 7,429, which match the exclusive column exactly. So this is latent rather than currently visible, and it bites on a backfill or a refill of a past day.

## Test

Same window, 2026-08-18, whose live published value is **7,908**:

```
before   fees 26.74 k   revenue 131
after    fees  7.91 k   revenue  36
```

Re-running master against that day today books 3.4x. The fix reproduces the published figure to the dollar.

## What this does not fix

The chain attribution question in #8625 is untouched. The adapter still declares `chains: [CHAIN.SUI]` and books a chain-agnostic figure entirely under Sui while most of Ember's TVL is not on Sui. I could not settle that one and I am not guessing at it here: the API has no per-chain split, `?chain=sui` and `?chainIdentifier=sui` return byte-identical payloads to the bare call, and `/vaults/fees/breakdown` and `/vaults/fees/by-chain` both 404. Someone with visibility into what `feesUsdE9` aggregates has to answer it, so I have left #8625 open for that half.

An exclusive upper bound on the API side would be the better fix, since it would also make multi-day queries correct. This is the adapter-side half that can be done here.
