### PR TITLE
curators: kamino window drops its last hour, undercounting yield ~4-5% a day

### DIFF
--- a/helpers/curators/index.ts
+++ b/helpers/curators/index.ts
@@ -356,11 +356,16 @@ export async function getKaminoVaultFee(options: FetchOptions, balances: Balance
     const perfFeeRate = Number(state.performanceFeeBps ?? 0) / 1e4
     const mgmtFeeRate = Number(state.managementFeeBps ?? 0) / 1e4
 
-    // History is requested with a ±1 day pad (API is date-grained); keep only
-    // snapshots that fall inside this fetch window.
+    // History is requested with a ±1 day pad; keep only snapshots inside this
+    // fetch window. Snapshots are hourly and land on the hour, so the upper
+    // bound has to be endTimestamp (the window's closing midnight) and not
+    // toTimestamp (23:59:59). Bounding at toTimestamp drops the closing
+    // snapshot, leaving a 00:00 -> 23:00 delta that misses the window's last
+    // hour, and since the next window starts at its own 00:00 that hour is
+    // never counted by any window.
     const points: any[] = (Array.isArray(history) ? history : history?.history ?? [])
       .map((p: any) => ({ ...p, _ts: Date.parse(p.timestamp ?? p.date ?? '') / 1000 }))
-      .filter((p: any) => isFinite(p._ts) && p._ts >= options.fromTimestamp && p._ts <= options.toTimestamp)
+      .filter((p: any) => isFinite(p._ts) && p._ts >= options.fromTimestamp && p._ts <= options.endTimestamp)
       .sort((a: any, b: any) => a._ts - b._ts)
 
     let grossInterest = 0


### PR DESCRIPTION
Follow-up to #8836, which added the Kamino kvault leg to the curator framework. The accounting there is right; the window bound is off by one snapshot.

## The bug

`getKaminoVaultFee` reads the vault's cumulative `interest` at the window bounds and takes the delta. The in-window filter is:

```ts
p._ts >= options.fromTimestamp && p._ts <= options.toTimestamp
```

`toTimestamp` is 23:59:59, one second before the window's closing midnight. The kvaults metrics history is **hourly** and lands exactly on the hour, so the closing 00:00 snapshot is filtered out and the delta spans 00:00 → 23:00. That is 23 hours, not 24.

Because the next window starts at its own 00:00, the 23:00 → 00:00 hour is never counted by any window.

Straight from the API, RWA USDC (`DWSXb18xZApz29vnQpgR2m6MynCT7PznaXt7Ut7M7KaP`), cumulative `interest`:

```
2026-08-18 00:00   674599.66441
2026-08-18 23:00   678116.68356   <- last point the filter keeps
2026-08-19 00:00   678269.69886   <- closing snapshot, dropped

in-window delta   3517.01915
true day          3670.03445
short by             153.01530   = 4.17%
```

4.17% is exactly 1/24, as expected for a dropped hour; the actual figure moves day to day with that hour's yield.

## Fix

Bound on `options.endTimestamp` (= `toTimestamp + 1`, the closing midnight) instead of `toTimestamp`.

The closing snapshot is **already in the fetched payload** — the request pads the date range by a day on each side — so this only widens the filter and adds no call.

Windows stay contiguous and nothing double counts: `interest` is a cumulative counter, so the boundary reading is the end of one window and the start of the next, and only deltas are taken.

## Test

Pinned windows, solana leg, `Kamino Yields`:

| window | before | after | recovered |
|---|---|---|---|
| 2026-08-16 | 3,725 | 3,917 | +5.16% |
| 2026-08-17 | 3,758 | 3,959 | +5.08% |
| 2026-08-19 | 3,888 | 4,057 | +4.35% |

Supply side and performance fees move with it, and the identity holds on both sides:

```
before   3570 + 188 = 3758
after    3761 + 198 = 3959
```

## Blast radius

Scoped to `getKaminoVaultFee`, which only runs when `kaminoVaults` is set. No existing EVM curator entry changes — I re-ran the full rockawayx adapter and the ethereum/base/bsc/sei legs are unchanged. `rockawayx` solana is the only consumer today, but this is in the shared helper, so it would apply to any future Kamino curator entry.
