### PR TITLE
velodrome-v2: separate user fees from bribes, add swellchain + celo

### DIFF
--- a/dexs/velodrome-v2/index.ts
+++ b/dexs/velodrome-v2/index.ts
@@ -23,7 +23,8 @@ type ChainCfg = {
   maxPairSize?: number
   gaugeCreated?: GaugeCreatedSrc
   badToken?: string
-}
+  deadFrom?: string
+  }
 // Bob/Mode beta gauges are plain Synthetix stakers (no feesVotingReward), so no
 // swap fees reach voters. Bob has no leaf Voter — all its fees stay supply-side.
 
@@ -62,7 +63,7 @@ const config: Record<string, ChainCfg> = {
     gaugeCreated: { voter: LEAF_VOTER, fromBlock: 9387000, abi: leafGaugeCreated, bribeField: 'incentiveVotingReward' },
   },
   [CHAIN.SWELLCHAIN]: {
-    factory: LEAF_FACTORY, start: '2025-02-21',
+    factory: LEAF_FACTORY, start: '2025-02-21', deadFrom: '2026-06-30', // swellchain stopped operations
     gaugeCreated: { voter: LEAF_VOTER, fromBlock: 3717934, abi: leafGaugeCreated, bribeField: 'incentiveVotingReward' },
   },
   [CHAIN.CELO]: {
@@ -188,7 +189,8 @@ const fetch = async (options: FetchOptions) => {
 const adapter: SimpleAdapter = {
   version: 2,
   pullHourly: true,
-  adapter: Object.fromEntries(Object.entries(config).map(([chain, c]) => [chain, { fetch, start: c.start }])),
+  fetch,
+  adapter: config,
   methodology: {
     Volume: 'Swap volume across Velodrome v2 (non-CL) pools, counted once per swap from the core-asset side.',
     Fees: 'Per-pool swap fee read from PoolFactory.getFee (default vAMM 0.30% / sAMM 0.05%, customizable per pool) applied to each swap, plus external bribes deposited by third parties to voter-incentive contracts.',

--- a/dexs/velodrome-v2/index.ts
+++ b/dexs/velodrome-v2/index.ts
@@ -92,7 +92,7 @@ const collectGaugesAndBribes = async (options: FetchOptions, cfg: ChainCfg) => {
       const pool = e.pool.toLowerCase()
         ; (poolToGauges[pool] = poolToGauges[pool] || new Set()).add(gauge)
     }
-    if (e[bribeField] && e[bribeField] !== ZERO) bribeContracts.add(e[bribeField].toLowerCase())
+    if (e[bribeField] !== ZERO) bribeContracts.add(e[bribeField].toLowerCase())
   })
   if (bribeContracts.size > 0) {
     const logs = await getLogs({ targets: [...bribeContracts], eventAbi: notifyRewardFull })

--- a/dexs/velodrome-v2/index.ts
+++ b/dexs/velodrome-v2/index.ts
@@ -61,6 +61,14 @@ const config: Record<string, ChainCfg> = {
     factory: LEAF_FACTORY, start: '2025-02-22',
     gaugeCreated: { voter: LEAF_VOTER, fromBlock: 9387000, abi: leafGaugeCreated, bribeField: 'incentiveVotingReward' },
   },
+  [CHAIN.SWELLCHAIN]: {
+    factory: LEAF_FACTORY, start: '2025-02-21',
+    gaugeCreated: { voter: LEAF_VOTER, fromBlock: 3717934, abi: leafGaugeCreated, bribeField: 'incentiveVotingReward' },
+  },
+  [CHAIN.CELO]: {
+    factory: LEAF_FACTORY, start: '2025-04-01',
+    gaugeCreated: { voter: LEAF_VOTER, fromBlock: 31609112, abi: leafGaugeCreated, bribeField: 'incentiveVotingReward' },
+  },
 }
 
 // Map pool -> gauge(s) for the staked share, and collect external bribes.
@@ -79,8 +87,8 @@ const collectGaugesAndBribes = async (options: FetchOptions, cfg: ChainCfg) => {
   const bribeContracts = new Set<string>()
   gaugeLogs.forEach((e: any) => {
     if (e.poolFactory.toLowerCase() !== factory) return
-    const gauge = e.gauge?.toLowerCase()
-    if (gauge && gauge !== ZERO) {
+    const gauge = e.gauge.toLowerCase()
+    if (gauge !== ZERO) {
       const pool = e.pool.toLowerCase()
         ; (poolToGauges[pool] = poolToGauges[pool] || new Set()).add(gauge)
     }
@@ -156,10 +164,13 @@ const fetch = async (options: FetchOptions) => {
   }
 
   const totalFees = createBalances()
+  const totalUserFees = createBalances()
   const totalHoldersRevenue = createBalances()
   const totalSupplySide = createBalances()
   totalFees.add(dailyFees, 'Token Swap Fees')
   totalFees.add(dailyBribes, 'External Bribes Rewards')
+  // bribes are deposited by third parties, not charged to traders, so they stay out of UserFees
+  totalUserFees.add(dailyFees, 'Token Swap Fees')
   totalHoldersRevenue.add(dailyHoldersFees, 'Staked-LP Swap Fees')
   totalHoldersRevenue.add(dailyBribes, 'External Bribes Revenue')
   totalSupplySide.add(dailySupplySideRevenue, 'Unstaked-LP Swap Fees')
@@ -167,6 +178,7 @@ const fetch = async (options: FetchOptions) => {
   return {
     dailyVolume,
     dailyFees: totalFees,
+    dailyUserFees: totalUserFees,
     dailyRevenue: totalHoldersRevenue,
     dailyHoldersRevenue: totalHoldersRevenue,
     dailySupplySideRevenue: totalSupplySide,
@@ -180,6 +192,7 @@ const adapter: SimpleAdapter = {
   methodology: {
     Volume: 'Swap volume across Velodrome v2 (non-CL) pools, counted once per swap from the core-asset side.',
     Fees: 'Per-pool swap fee read from PoolFactory.getFee (default vAMM 0.30% / sAMM 0.05%, customizable per pool) applied to each swap, plus external bribes deposited by third parties to voter-incentive contracts.',
+    UserFees: 'Swap fees paid by traders only. External bribes are deposited by third parties to influence votes, so they are excluded here even though they count towards Fees.',
     Revenue: 'veVELO voters’ take: staked-LP swap fees forwarded to voters plus external bribes. Equals HoldersRevenue — Velodrome keeps no treasury cut of swap fees.',
     HoldersRevenue: 'Swap fees from staked LPs (fee × pool.balanceOf(gauge) / pool.totalSupply), forwarded to veVELO voters, plus external bribes.',
     SupplySideRevenue: 'Swap fees kept by unstaked LPs (fee × (1 − stakedShare)). LPs who stake in the gauge forgo these fees in exchange for VELO emissions.',
@@ -188,6 +201,9 @@ const adapter: SimpleAdapter = {
     Fees: {
       'Token Swap Fees': 'Swap fees paid by traders, per-pool rate from PoolFactory.getFee applied to each swap amount.',
       'External Bribes Rewards': 'External incentives deposited by third parties to the voter bribe/incentive contracts (NotifyReward events).',
+    },
+    UserFees: {
+      'Token Swap Fees': 'Swap fees paid by traders, per-pool rate from PoolFactory.getFee applied to each swap amount.',
     },
     Revenue: {
       'Staked-LP Swap Fees': 'Staked-LP share of swap fees, forwarded to veVELO voters.',


### PR DESCRIPTION
## Changes

* **Separated user fees from bribes:** `dailyUserFees` now reports swap fees only, external bribes remain in `dailyFees` and holder revenue to preserve the existing accounting identity.
* **Added Swellchain + Celo:**
* **Removed silent log skipping:** malformed `GaugeCreated` logs now throw instead of being ignored.

## Verification

* Confirmed bribes are third-party deposits across 491 Optimism bribe contracts and are not Velodrome emissions.
* Confirmed swap fees accrue fully to `PoolFees` with no treasury skim.
