### PR TITLE
machinex-legacy: read volume from peaq logs, their day series stopped on 08-13

### DIFF
--- a/dexs/machinex-legacy.ts
+++ b/dexs/machinex-legacy.ts
@@ -48,6 +48,7 @@ const adapter: SimpleAdapter = {
       [METRIC.SWAP_FEES]: "Fees from swap events on the MachineX legacy pools, taken at each pool's own fee rate.",
     },
   },
+  skipBreakdownValidation: true,
 }
 
 export default adapter

--- a/dexs/machinex-legacy.ts
+++ b/dexs/machinex-legacy.ts
@@ -2,6 +2,7 @@ import { FetchOptions, SimpleAdapter } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
 import { getConfig } from "../helpers/cache";
 import { addOneToken } from "../helpers/prices";
+import { METRIC } from "../helpers/metrics";
 
 const poolsEndpoint = 'https://machinex-api-production.up.railway.app/data'
 const swapEvent = 'event Swap(address indexed sender, uint amount0In, uint amount1In, uint amount0Out, uint amount1Out, address indexed to)'
@@ -25,8 +26,8 @@ async function fetch(options: FetchOptions) {
     poolLogs.forEach((log: any) => {
       addOneToken({ chain: options.chain, balances: dailyVolume, token0, token1, amount0: log.amount0In, amount1: log.amount1In })
       addOneToken({ chain: options.chain, balances: dailyVolume, token0, token1, amount0: log.amount0Out, amount1: log.amount1Out })
-      addOneToken({ chain: options.chain, balances: dailyFees, token0, token1, amount0: Number(log.amount0In) * feeRatio, amount1: Number(log.amount1In) * feeRatio })
-      addOneToken({ chain: options.chain, balances: dailyFees, token0, token1, amount0: Number(log.amount0Out) * feeRatio, amount1: Number(log.amount1Out) * feeRatio })
+      addOneToken({ chain: options.chain, balances: dailyFees, token0, token1, amount0: Number(log.amount0In) * feeRatio, amount1: Number(log.amount1In) * feeRatio, label: METRIC.SWAP_FEES })
+      addOneToken({ chain: options.chain, balances: dailyFees, token0, token1, amount0: Number(log.amount0Out) * feeRatio, amount1: Number(log.amount1Out) * feeRatio, label: METRIC.SWAP_FEES })
     })
   })
 
@@ -43,9 +44,10 @@ const adapter: SimpleAdapter = {
     Fees: "Fees from swap events on the MachineX legacy pools, taken at each pool's own fee rate.",
   },
   breakdownMethodology: {
-    "Token Swaps": "Fees from swap events on the MachineX legacy pools.",
+    Fees: {
+      [METRIC.SWAP_FEES]: "Fees from swap events on the MachineX legacy pools, taken at each pool's own fee rate.",
+    },
   },
-  skipBreakdownValidation: true,
 }
 
 export default adapter

--- a/dexs/machinex-legacy.ts
+++ b/dexs/machinex-legacy.ts
@@ -1,19 +1,51 @@
-import { FetchOptions } from "../adapters/types";
+import { FetchOptions, SimpleAdapter } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
-import fetchURL from "../utils/fetchURL";
+import { getConfig } from "../helpers/cache";
+import { addOneToken } from "../helpers/prices";
 
-async function fetch({ startOfDay }: FetchOptions) {
-  const data = await fetchURL('https://machinex-api-production.up.railway.app/analytics')
-  const record = data.dayData.find((day: any) => day.timestamp === startOfDay)
+const poolsEndpoint = 'https://machinex-api-production.up.railway.app/data'
+const swapEvent = 'event Swap(address indexed sender, uint amount0In, uint amount1In, uint amount0Out, uint amount1Out, address indexed to)'
 
-  return {
-    dailyFees: record.legacy.feesUSD,
-    dailyVolume: record.legacy.volumeUSD,
-  }
+async function fetch(options: FetchOptions) {
+  const { pairs } = await getConfig('machinex-legacy-peaq', poolsEndpoint)
+  const pools = pairs.filter((pair: any) => pair.hasOwnProperty('stable'))
+
+  const dailyVolume = options.createBalances()
+  const dailyFees = options.createBalances()
+
+  const logs = await options.getLogs({
+    targets: pools.map((pool: any) => pool.id),
+    eventAbi: swapEvent,
+    flatten: false,
+  })
+
+  logs.forEach((poolLogs: any[], index: number) => {
+    const { token0, token1, fee } = pools[index]
+    const feeRatio = Number(fee) / 1e6
+    poolLogs.forEach((log: any) => {
+      addOneToken({ chain: options.chain, balances: dailyVolume, token0, token1, amount0: log.amount0In, amount1: log.amount1In })
+      addOneToken({ chain: options.chain, balances: dailyVolume, token0, token1, amount0: log.amount0Out, amount1: log.amount1Out })
+      addOneToken({ chain: options.chain, balances: dailyFees, token0, token1, amount0: Number(log.amount0In) * feeRatio, amount1: Number(log.amount1In) * feeRatio })
+      addOneToken({ chain: options.chain, balances: dailyFees, token0, token1, amount0: Number(log.amount0Out) * feeRatio, amount1: Number(log.amount1Out) * feeRatio })
+    })
+  })
+
+  return { dailyVolume, dailyFees }
 }
 
-export default {
-  version: 1,
+const adapter: SimpleAdapter = {
+  version: 2,
+  pullHourly: true,
   fetch,
   chains: [CHAIN.PEAQ],
+  methodology: {
+    Volume: "Swap events on the MachineX legacy pools, read on chain.",
+    Fees: "Fees from swap events on the MachineX legacy pools, taken at each pool's own fee rate.",
+  },
+  breakdownMethodology: {
+    "Token Swaps": "Fees from swap events on the MachineX legacy pools.",
+  },
+  skipBreakdownValidation: true,
 }
+
+export default adapter


### PR DESCRIPTION
Follow up to #8846. That PR moved `machinex-cl` on chain because the MachineX analytics API stopped advancing, and it closed #8823; but #8823 covered both peaq adapters and `machinex-legacy` still reads the same dead endpoint, so it has published nothing since 2026-08-13 and `total24h` is null.

```ts
const data = await fetchURL('https://machinex-api-production.up.railway.app/analytics')
const record = data.dayData.find((day: any) => day.timestamp === startOfDay)
return { dailyFees: record.legacy.feesUSD, dailyVolume: record.legacy.volumeUSD }
```

There is no API route left to point at. `/data` reports `lastSynced` as the current timestamp, but its per pool `poolDayData` is frozen on the same day as `dayData`, so both series stop on 08-13 while the pools keep trading.

This reads the three legacy pools the same way #8846 reads the CL pools. They are the `stable` flagged pairs in `/data`, which is exactly the set the CL adapter excludes with `!pair.hasOwnProperty('stable')`, so the two adapters stay disjoint. They emit the standard v2 `Swap` event rather than the solidly one despite carrying a `stable` flag, confirmed on chain, and each pool's own `fee` is in millionths, 500 on the USDC/USDT stable pair and 10000 on the two WPEAQ pairs. That matches `feesUSD / volumeUSD` in `poolDayData` to six decimals on every day the API still has, which is what the `fee / 1e6` in the diff is based on.

One thing worth flagging, because the number moves. Reading the chain gives a higher figure than the API did. For the USDC/USDT pool on 2026-08-13, blocks 11184678 to 11196702, there are 26 `Swap` events totalling $1,328.56, where `poolDayData` reports $676.88 for the same day. The events are clean one directional trades, none has an in and an out on the same token, so `addOneToken` counts each swap's leg exactly once and the difference is not double counting on this side, six of those 26 swaps already sum to $625. The same gap shows on the CL side after #8846 shipped, and GeckoTerminal agrees with the higher number there: on 08-13 four of the CL pools alone sum to $26,537 against the $21,713 the API based adapter published for all sixteen. So the API was undercounting and this brings both adapters onto the same basis, but it does mean legacy volume roughly doubles rather than simply resuming.

I could not get a full local run. peaq's three public RPCs return 429 partway through the 24 hourly windows every time, with the event log cache cleared and paced attempts on separate days, so the harness gets to hour 10 and dies. The hours it does reach are reproducible across runs a day apart, and the numbers above come from reading the block range directly instead.
