### PR TITLE
uniV2 factory: deadFromMap never reached the fees and subgraph builds

### DIFF
--- a/factory/uniV2.ts
+++ b/factory/uniV2.ts
@@ -1180,6 +1180,7 @@ const methodologyMap: Record<string, any> = {
 
 const deadFromMap: Record<string, string> = {
   "auragi": '2025-06-01',
+  "capx": '2026-07-31',
   "fcon-dex": '2023-12-12',
   "metavault-amm-v2": '2025-06-04',
   "beamswap": "2025-08-12",
@@ -1700,7 +1701,9 @@ for (const [name, config] of Object.entries(configs)) {
 
 // Build subgraph dex protocols
 for (const [name, config] of Object.entries(subgraphConfigs)) {
-  protocols[name] = buildSubgraphAdapter(config)
+  const adapter = buildSubgraphAdapter(config)
+  if (deadFromMap[name]) adapter.deadFrom = deadFromMap[name]
+  protocols[name] = adapter
 }
 
 // Build fees protocols
@@ -1709,6 +1712,7 @@ for (const [name, config] of Object.entries(feesConfigs)) {
   const adapter = uniV2Exports(config)
   adapter.skipBreakdownValidation = true // allow old protocols return only fees
   if (feesMethodologyMap[name]) adapter.methodology = feesMethodologyMap[name]
+  if (deadFromMap[name]) adapter.deadFrom = deadFromMap[name]
   feesProtocols[name] = adapter
 }
 

--- a/helpers/blockscoutFees.ts
+++ b/helpers/blockscoutFees.ts
@@ -78,7 +78,7 @@ export const chainConfigMap: any = {
   [CHAIN.RARI]: { CGToken: 'ethereum', explorer: "https://mainnet.explorer.rarichain.org/", start: '2024-01-20' },
   [CHAIN.XRPL_EVM]: { CGToken: 'ripple', explorer: 'https://explorer.xrplevm.org' },
   [CHAIN.APPCHAIN]: { CGToken: 'ethereum', explorer: "https://explorer.appchain.xyz/", start: '2024-11-08' },
-  [CHAIN.CAPX]: { CGToken: 'capx-ai', explorer: "https://www.capxscan.com/" },
+  [CHAIN.CAPX]: { CGToken: 'capx-ai', explorer: "https://www.capxscan.com/", deadFrom: '2026-07-31' },
   [CHAIN.BSQUARED]: { CGToken: 'bitcoin', explorer: 'https://explorer.bsquared.network/node-api/proxy', start: '2025-07-06' },
   [CHAIN.SANKO]: { CGToken: 'dream-machine-token', explorer: 'https://explorer.sanko.xyz/' },
   [CHAIN.ALIENX]: { CGToken: 'ethereum', explorer: 'https://explorer.alienxchain.io/api' },


### PR DESCRIPTION
`deadFromMap` in `factory/uniV2.ts` was only wired into the loop that builds `protocols` from `configs`. The loops that build `feesProtocols` from `feesConfigs` and the subgraph adapters from `subgraphConfigs` never read it, so any name living in one of those two maps carried a `deadFrom` that did nothing.

3 of the 7 existing entries are in that position:

| name | deadFrom | lives in | still publishing |
|---|---|---|---|
| beamswap | 2025-08-12 | feesConfigs | yes, daily $0 rows for dexs and fees, latest point 2026-08-15 |
| zircon-gamma | 2023-03-26 | subgraphConfigs | ran on to 2024-03-28 |
| capx | added here | feesConfigs | yes, until the chain went away |

Both the `fees` and `dexs` factory lists put `uniV2` ahead of `uniV2:fees`, so a name absent from `configs` resolves to `feesProtocols` for both adapter types. That is why capx and beamswap were unreachable by the flag from either side.

## Capx chain is gone, not quiet

- Its only RPC in `providers.json`, `capx-mainnet.calderachain.xyz`, is NXDOMAIN. A control request to another Caldera chain RPC from the same shell answers fine, so this is not local networking.
- `capxscan.com` resolves but nginx returns 404 on every path including the root, so the blockscout stats endpoint `helpers/blockscoutFees.ts` uses is gone too.
- chainId 757 is not in chainid.network's registry.
- CAPX has no price on `coins.llama.fi`, and Capx Chain reports $0 TVL.

Last real published day is 2026-07-30 for both fees and volume ($1,438 and $140,304), then a gap, then explicit $0 on 08-13 and 08-14. `deadFrom` is set to 2026-07-31.

The `blockscoutFees` `chainConfigMap` entry for capx gets the same date. That export is currently shadowed by `uniV2:fees` for the `capx` protocol name, so it is not what was producing the published numbers, but the chain behind it is the same dead one and the flag belongs there either way.

## Verified

- `fees capx`, `dexs capx`, `fees beamswap` and `dexs beamswap` all now print `is dead; skipping run` instead of running. Before this change all four ran and died on `No RPCs available for capx` / published zeros.
- Control: `fees merchant-moe-dex` is in `feesConfigs` and not in `deadFromMap`, and still runs and returns real numbers, so live adapters on that path are unaffected.
- `tsc --noEmit` is clean.

## Not covered

I did not audit whether any other protocol currently reachable through `feesConfigs` or `subgraphConfigs` should be dead but has no `deadFromMap` entry at all. This only makes the existing entries take effect and adds capx.
