### PR TITLE
brine (TanX.fi): mark dead from 2026-08-06, the endpoint has returned a literal zero every day since

### DIFF
--- a/dexs/brine/index.ts
+++ b/dexs/brine/index.ts
@@ -12,6 +12,10 @@ const fetch = async (options: FetchOptions) => {
 };
 
 const adapter: SimpleAdapter = {
+  // Retail trading was switched off on 2026-08-06 while TanX moves to an
+  // institution-only platform, and the volume endpoint has answered a literal
+  // "0" with status "success" every day since. See DefiLlama/dimension-adapters#8689.
+  deadFrom: '2026-08-06',
   adapter: {
     [CHAIN.ETHEREUM]: {
       fetch,


### PR DESCRIPTION
`dexs/brine` publishes `payload.volume` straight through. That value went from $5,874,429 on 2026-08-05 to exactly 0 on 2026-08-06, and has been 0 on every day since, 13 days as of 2026-08-19. I checked this date by date against the endpoint rather than reading it off the published chart:

```
08-06=0  08-07=0  08-08=0  08-09=0  08-10=0  08-11=0  08-12=0
08-13=0  08-14=0  08-15=0  08-16=0  08-17=0  08-18=0
```

## The zero is real, not a broken feed

The endpoint answers 200 with `status: "success"`, the echoed `payload.timestamp` matches what was asked for, and older dates still return the same figures that were published at the time (`2026-08-04 -> 6498282.61`, `2026-08-05 -> 5874428.92`).

@0xshubhs raised this in #8689 and @DarkLord017 answered there that TanX is moving to an institution-focused platform and retail trading has stopped, with users told to withdraw their funds. #8689 was closed on that basis and the diagnosis is theirs, not mine.

## What was left over

Nothing marks the adapter dead, so it goes on publishing $0 indefinitely and counts as a live-but-zero dex in the aggregates. @0xshubhs flagged exactly that in the closing comment of #8689, reading it as protocol metadata and not fixable in this repo. `deadFrom` is in this repo and 73 adapters already use it, so it is. Credit for the finding is entirely theirs, and I am happy to close this in favour of their own PR if they would rather send it.

## The tradeoff, stated rather than buried

The team's wording was that *retail* trading stopped, not that the venue closed. If institutional flow later shows up on this endpoint, `deadFrom` will suppress it and the date will need to move or come out. Set against 13 straight zero days and TVL sitting flat and idle at ~$270k, publishing zeros indefinitely looks like the worse of the two, but this is a judgement call and easy to revert if you read it the other way.

## Test

`npm run test dexs brine` now prints `BRINE is dead (deadFrom 2026-08-06); skipping run.`
