### PR TITLE
curators: Kamino management fee reads a USD figure as a token amount

### DIFF
--- a/helpers/curators/index.ts
+++ b/helpers/curators/index.ts
@@ -371,10 +371,11 @@ export async function getKaminoVaultFee(options: FetchOptions, balances: Balance
     }
 
     const perfFee = grossInterest * perfFeeRate
-    // History `tvl` and `interest` are human-denominated; scale both to raw units.
-    // Use the first in-window snapshot so mgmt fee tracks that day's AUM, not live prevAum.
-    const tvl = Number(points[0]?.tvl ?? 0)
-    const mgmtFee = tvl * 10 ** decimals * mgmtFeeRate * elapsed / YEAR_SECS
+    // `prevAum` is the vault's AUM in raw token units, which is what the balance
+    // entry below is denominated in. The history snapshots carry `tvl` in USD, not
+    // in token units, so they cannot be used here without a price. Same field and
+    // same accrual as fees/sentora.ts.
+    const mgmtFee = Number(state.prevAum ?? 0) * mgmtFeeRate * elapsed / YEAR_SECS
 
     if (grossInterest > 0) {
       if (breakdownFees) {


### PR DESCRIPTION
`getKaminoVaultFee` computes the management fee from the history snapshot's `tvl` field scaled by `10 ** decimals`, and books the result against `tokenMint`. The Kamino API returns those two things in different units:

- `state.prevAum` is the vault's AUM in **raw token units**
- the history snapshot's `tvl` is **USD**

Both are visible on the RockawayX SOL vault `Hoffq...` at the same moment:

| field | value | meaning |
|---|---|---|
| `state.prevAum` | 34,927,903,529,404 | 34,927.90 SOL at 9 decimals |
| history `tvl` | 2,686,661 | USD |
| history `solTvl` | 34,925.32 | SOL |
| `/metrics` `tokensInvested` | 34,928.25 | SOL |
| `/metrics` `tokensInvestedUsd` | 2,872,798 | USD |

So the fee is computed in USD and then added as if it were the token.

## Magnitude

For the SOL vault this is a **76.9x overstatement**. With a hypothetical `managementFeeBps` of 100:

```
current:  73.61 SOL/day  = $6,054/day
fixed:     0.9569 SOL/day = $78.71/day
sanity:   1%/yr on $2,872,798 = $78.71/day
```

## Not currently visible

Both RockawayX vaults have `managementFeeBps = 0`, so this leg contributes nothing today and no published number is wrong. It is shared curator code though, and it fires the moment a Kamino vault with a management fee is added. Flagging it now rather than after it lands.

## The fix

Read `state.prevAum`, which is already in the units the balance entry expects and is the same field `fees/sentora.ts` uses for the same accrual.

This gives up the "AUM as of that day rather than live `prevAum`" intent stated in the original comment. The history snapshots cannot serve that intent without a price: the only token-denominated field there is `solTvl`, which is SOL and not the vault's own token. If you would rather keep the per-day AUM, that needs a price source the helper does not currently have, and I would rather not add one silently.

## Rest of the function checked too

I read the whole thing rather than only the line that looked wrong:

- **the interest leg is correct.** `interest` *is* token-denominated, unlike `tvl`. On the SOL vault the 24h delta of 5.04 annualises to 5.27% against the API's own `apy24h` of 4.96%; reading it as USD would imply 0.068%. The history point also carries `interest` and `interestSol` as identical values.
- units on the performance fee are fine, it is a ratio of `grossInterest`.
- the identity holds: `revenue + supplySide = (perfFee + mgmtFee) + (grossInterest - perfFee) = grossInterest + mgmtFee = fees`.
- the window filter is inclusive at both ends, which is right for a last-minus-first delta since consecutive windows telescope rather than double count.
- history is hourly, not date-grained, so the `points.length >= 2` guard is not at risk on a daily window (25 points in the last one).

## Test

`npm run test fees rockawayx` is unchanged: Kamino Yields 3741 / supply side 3554 / performance fees 187, and no management fee line before or after. The one-unit drift against the pre-change run is live price movement between the two runs, not this diff. `tsc --noEmit` is clean.

Follows #8836 (@gomesalexandre).
