### PR TITLE
feat: add Lyra Market fees adapter

### DIFF
--- a/fees/lyra-market.ts
+++ b/fees/lyra-market.ts
@@ -1,0 +1,138 @@
+import { Adapter, FetchOptions } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+import { METRIC } from "../helpers/metrics";
+
+// ─────────────────────────────────────────────
+// Lyra Market — RWA trading interface
+//
+// LyraSwapRouter routes user swaps between USDC and tokenized real-world
+// asset tokens into Uniswap v2/v3/v4 pools via Uniswap's UniversalRouter,
+// and charges an interface fee on the USDC leg of each trade.
+//
+// The router is stateless: it pulls USDC (or the RWA token) from the trader,
+// executes the route, and forwards the output to the trader within the same
+// transaction. It custodies nothing, and the pool liquidity it trades against
+// belongs to Uniswap LPs — so Lyra reports no TVL of its own for this product,
+// and the volume below also executes on Uniswap -> doublecounted.
+// ─────────────────────────────────────────────
+
+// LyraSwapRouter, Ethereum mainnet.
+const ROUTER = "0xDF39355e24e6e92Ca9D00180e687dd131B6B7ee5";
+const DEPLOY_BLOCK = 25544021; // 2026-07-16
+
+// Canonical Ethereum USDC — every trade has USDC on one side, and the
+// interface fee is always denominated in it.
+const USDC = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48";
+
+const INTERFACE_FEE_EVENT =
+  "event InterfaceFeeCollected(address indexed token, address indexed trader, uint256 feeUsdc, bool isBuy)";
+const FEE_BPS_UPDATED_EVENT =
+  "event FeeBpsUpdated(uint16 oldBps, uint16 newBps)";
+
+// Rate set in the router's constructor at deploy. The owner can change it
+// through setFeeBps (capped by MAX_FEE_BPS), which emits FeeBpsUpdated — no
+// such event has fired to date, so this has been the rate since launch.
+const INITIAL_FEE_BPS = 20n; // 0.20%
+const BPS_DENOM = 10000n;
+
+async function fetch(options: FetchOptions) {
+  // Separate balance objects — the framework post-processes each independently.
+  const dailyVolume = options.createBalances();
+  const dailyFees = options.createBalances();
+  const dailyRevenue = options.createBalances();
+
+  // Build the fee-rate history from logs rather than calling feeBps() at the
+  // period's block: that call needs archive state, which the public RPC pool
+  // often cannot serve for anything but recent blocks.
+  const rateLogs = await options.getLogs({
+    target: ROUTER,
+    eventAbi: FEE_BPS_UPDATED_EVENT,
+    fromBlock: DEPLOY_BLOCK,
+    toBlock: await options.getToBlock(),
+    entireLog: true,
+    parseLog: true,
+    cacheInCloud: true,
+  });
+  const rateChanges = rateLogs
+    .map((log: any) => ({
+      block: Number(log.blockNumber),
+      bps: BigInt(log.parsedLog.args.newBps),
+    }))
+    .sort((a: any, b: any) => a.block - b.block);
+
+  const feeBpsAt = (block: number) => {
+    let bps = INITIAL_FEE_BPS;
+    for (const change of rateChanges) {
+      if (change.block > block) break;
+      bps = change.bps;
+    }
+    return bps;
+  };
+
+  const logs = await options.getLogs({
+    target: ROUTER,
+    eventAbi: INTERFACE_FEE_EVENT,
+    entireLog: true,
+    parseLog: true,
+  });
+
+  for (const log of logs) {
+    const fee = BigInt(log.parsedLog.args.feeUsdc);
+
+    // The router takes its cut off the gross USDC leg in both directions —
+    // on a buy from the USDC sent in, on a sell from the USDC received —
+    // so the traded notional is exactly fee / feeRate.
+    dailyVolume.add(USDC, (fee * BPS_DENOM) / feeBpsAt(Number(log.blockNumber)));
+
+    dailyFees.add(USDC, fee, METRIC.TRADING_FEES);
+    dailyRevenue.add(USDC, fee, METRIC.TRADING_FEES);
+  }
+
+  return {
+    dailyVolume,
+    dailyFees,
+    dailyUserFees: dailyFees,
+    dailyRevenue,
+    dailyProtocolRevenue: dailyRevenue,
+  };
+}
+
+const methodology = {
+  Volume:
+    "USDC notional of swaps routed through LyraSwapRouter into Uniswap v2/v3/v4 pools, reconstructed from each InterfaceFeeCollected event by dividing the collected fee by the fee rate in effect at that block. The fee is charged on the gross USDC leg of every trade, so this reproduces the traded notional exactly. As with any aggregator, this volume also executes on Uniswap and is counted there under Uniswap's own adapter.",
+  Fees: "The interface fee LyraSwapRouter charges on the USDC leg of each routed swap (0.20% since deploy), taken from the InterfaceFeeCollected event. Uniswap's LP fee is excluded — it is paid to Uniswap LPs and Lyra cannot capture it.",
+  Revenue:
+    "Equal to fees. There is no supply side: Lyra provides no liquidity for this product, so nothing is shared with LPs.",
+  ProtocolRevenue:
+    "All interface fees are sent to the Lyra fee collector. No token exists and no share is paid to holders.",
+  UserFees: "The full interface fee is paid by the trader on each swap.",
+};
+
+const breakdownMethodology = {
+  Fees: {
+    [METRIC.TRADING_FEES]:
+      "0.20% interface fee on the USDC leg of each swap routed through LyraSwapRouter.",
+  },
+  Revenue: {
+    [METRIC.TRADING_FEES]:
+      "The interface fee is retained in full — no liquidity providers to share it with.",
+  },
+  ProtocolRevenue: {
+    [METRIC.TRADING_FEES]: "Interface fees accrue to the Lyra fee collector.",
+  },
+  UserFees: {
+    [METRIC.TRADING_FEES]: "Interface fee paid by the trader on each swap.",
+  },
+};
+
+const adapter: Adapter = {
+  version: 2,
+  pullHourly: true,
+  fetch,
+  chains: [CHAIN.ETHEREUM],
+  start: "2026-07-16",
+  methodology,
+  breakdownMethodology,
+};
+
+export default adapter;

--- a/fees/lyra-market.ts
+++ b/fees/lyra-market.ts
@@ -1,6 +1,7 @@
 import { Adapter, FetchOptions } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
 import { METRIC } from "../helpers/metrics";
+import ADDRESSES from "../helpers/coreAssets.json";
 
 // ─────────────────────────────────────────────
 // Lyra Market — RWA trading interface
@@ -22,7 +23,7 @@ const DEPLOY_BLOCK = 25544021; // 2026-07-16
 
 // Canonical Ethereum USDC — every trade has USDC on one side, and the
 // interface fee is always denominated in it.
-const USDC = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48";
+const USDC = ADDRESSES.ethereum.USDC;
 
 const INTERFACE_FEE_EVENT =
   "event InterfaceFeeCollected(address indexed token, address indexed trader, uint256 feeUsdc, bool isBuy)";
@@ -102,9 +103,9 @@ const methodology = {
     "USDC notional of swaps routed through LyraSwapRouter into Uniswap v2/v3/v4 pools, reconstructed from each InterfaceFeeCollected event by dividing the collected fee by the fee rate in effect at that block. The fee is charged on the gross USDC leg of every trade, so this reproduces the traded notional exactly. As with any aggregator, this volume also executes on Uniswap and is counted there under Uniswap's own adapter.",
   Fees: "The interface fee LyraSwapRouter charges on the USDC leg of each routed swap (0.20% since deploy), taken from the InterfaceFeeCollected event. Uniswap's LP fee is excluded — it is paid to Uniswap LPs and Lyra cannot capture it.",
   Revenue:
-    "Equal to fees. There is no supply side: Lyra provides no liquidity for this product, so nothing is shared with LPs.",
+    "Equal to fees (0.20% of the swap's notional value). There is no supply side: Lyra provides no liquidity for this product, so nothing is shared with LPs.",
   ProtocolRevenue:
-    "All interface fees are sent to the Lyra fee collector. No token exists and no share is paid to holders.",
+    "All interface fees (0.20% of the swap's notional value) are sent to the Lyra fee collector. No token exists and no share is paid to holders.",
   UserFees: "The full interface fee is paid by the trader on each swap.",
 };
 
@@ -115,13 +116,13 @@ const breakdownMethodology = {
   },
   Revenue: {
     [METRIC.TRADING_FEES]:
-      "The interface fee is retained in full — no liquidity providers to share it with.",
+      "The interface fee (0.20% of the swap's notional value) is retained in full — no liquidity providers to share it with.",
   },
   ProtocolRevenue: {
-    [METRIC.TRADING_FEES]: "Interface fees accrue to the Lyra fee collector.",
+    [METRIC.TRADING_FEES]: "Interface fees (0.20% of the swap's notional value) accrue to the Lyra fee collector.",
   },
   UserFees: {
-    [METRIC.TRADING_FEES]: "Interface fee paid by the trader on each swap.",
+    [METRIC.TRADING_FEES]: "Interface fee (0.20% of the swap's notional value) paid by the trader on each swap.",
   },
 };
 


### PR DESCRIPTION
Adds a fees adapter for **Lyra Market**, an RWA trading interface on Ethereum.

`LyraSwapRouter` routes user swaps between USDC and tokenized real-world-asset tokens into Uniswap v2/v3/v4 pools via Uniswap's UniversalRouter, and takes an interface fee on the USDC leg of each trade. The router is stateless — it never custodies funds, and the liquidity it trades against is Uniswap's — so there is no TVL claim here, and the reported volume also executes on Uniswap (doublecounted).

Volume and fees are both read from the router's `InterfaceFeeCollected` logs on-chain; no API is involved. The fee is charged on the gross USDC leg in both directions, so dividing the collected fee by the router's on-chain `feeBps` reconstructs the traded notional exactly.

Tested: `pnpm test fees lyra-market 2026-08-17` → daily volume $21.16k, fees $42.31, all under the `Trading Fees` label. Cross-checked against an independent scan of the same day's logs (42.33 USDC of fees across 32 swaps; the small delta is day-boundary block alignment).

One disclosure up front, since I'd rather you hear it from me than find it: the protocol launched on 2026-07-16 and a meaningful share of the volume to date comes from our own market-making and fee-testing wallets rather than from third-party users — 494 swaps across 14 addresses so far, ~$334k of cumulative notional and ~$668 of fees. Nothing is faked and every number above is reconstructed from on-chain logs, but I don't want the concentration to be read as organic demand. Happy to hold this PR until external flow dominates if you'd prefer that.

---

##### Name (to be shown on DefiLlama):
Lyra Market

##### Twitter Link:
https://x.com/lyraprotocolapp

##### List of audit links if any:
None — the router is unaudited.

##### Website Link:
https://www.lyraprotocol.app/

##### Logo (High resolution, will be shown with rounded borders):
https://www.lyraprotocol.app/logo-dark.png (512x512)

##### Current TVL:
None. This product routes into Uniswap pools and custodies nothing — the router's balance is zero by design. (A separate TVL adapter for Lyra's own ERC-3643 AMM may follow later.)

##### Treasury Addresses (if the protocol has treasury)
Ethereum: 0xCD642580F62784e4FBeE47F4329ceA046505f23E (fee collector — `LyraSwapRouter.feeCollector()`)

##### Chain:
Ethereum

##### Coingecko ID:
(none)

##### Coinmarketcap ID:
(none)

##### Short Description (to be shown on DefiLlama):
Lyra Market is a trading interface for tokenized real-world assets, routing USDC swaps into Uniswap liquidity and charging a 0.20% interface fee.

##### Token address and ticker if any:
No token.

##### Category:
Trading App

##### Oracle Provider(s):
None. Prices come from the Uniswap pools being traded against (QuoterV2 for v3/v4, reserve math for v2); no external oracle is used.

##### Implementation Details:
N/A — no oracle integration.

##### Documentation/Proof:
https://docs.lyraprotocol.app/

##### forkedFrom:
Not a fork.

##### methodology:
Volume: USDC notional of swaps routed through `LyraSwapRouter` (0xDF39355e24e6e92Ca9D00180e687dd131B6B7ee5), reconstructed from each `InterfaceFeeCollected` event by dividing the collected fee by the router's on-chain `feeBps`. As with any aggregator, this volume also executes on Uniswap and is counted there under Uniswap's own adapter.
Fees: the 0.20% interface fee taken on the USDC leg of each routed swap. Uniswap's LP fee is excluded — it accrues to Uniswap LPs and Lyra cannot capture it.
Revenue: equal to fees; there is no supply side, as Lyra provides no liquidity for this product.
Protocol revenue: all interface fees go to the fee collector above. No token, so no holders' revenue.

##### Github org/user (Optional):
<TODO>

##### Does this project have a referral program?
<TODO>