### PR TITLE
[fix] hyperliquid-spot - track spot deployment auction burns

### DIFF
--- a/dexs/hyperliquid-spot/index.ts
+++ b/dexs/hyperliquid-spot/index.ts
@@ -1,13 +1,21 @@
 import { FetchOptions, FetchResultV2, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 import { METRIC } from "../../helpers/metrics";
-import { getRevenueRatioShares, LLAMA_HL_INDEXER_FROM_TIME, queryHyperliquidIndexer, queryHypurrscanApi } from "../../helpers/hyperliquid";
+import {
+  getRevenueRatioShares,
+  LLAMA_HL_INDEXER_FROM_TIME,
+  queryHyperliquidIndexer,
+  queryHypurrscanApi,
+  queryHypurrscanSpotAuctionBurns,
+} from "../../helpers/hyperliquid";
+
+const SPOT_DEPLOYMENT_AUCTION_BURNS = "Spot Deployment Auction Burns";
 
 const methodology = {
-  Fees: "Include spot trading fees and unit protocol fees, excluding perps fees.",
-  Revenue: "99% of fees go to Assistance Fund for buying HYPE tokens, excluding unit protocol fees.",
+  Fees: "Include spot trading fees, unit protocol fees, and HYPE burned in successful HIP-1 token-deployment auctions, excluding perps fees.",
+  Revenue: "99% of spot trading fees go to Assistance Fund for buying HYPE tokens, excluding unit protocol fees; HYPE paid in successful HIP-1 token-deployment auctions is burned.",
   ProtocolRevenue: "Protocol doesn't keep any fees.",
-  HoldersRevenue: "99% of fees go to Assistance Fund for buying HYPE tokens, excluding unit protocol fees.",
+  HoldersRevenue: "99% of spot trading fees go to Assistance Fund for buying HYPE tokens, excluding unit protocol fees; HYPE paid in successful HIP-1 token-deployment auctions is permanently burned.",
   SupplySideRevenue: "1% of fees go to HLP Vault suppliers, before 30 Aug 2025 it was 3% + fees for unit protocol.",
 }
 
@@ -15,16 +23,19 @@ const breakdownMethodology = {
   Fees: {
     'Spot Fees': 'Fees collected on all spot trades, excluding trades on markets with Unit assets (eg bridged BTC).',
     'Spot fees on Unit markets': 'Fees from spot trades on markets that include an asset deployed by Unit, in these spot markets all fees go to Unit.',
+    [SPOT_DEPLOYMENT_AUCTION_BURNS]: 'HYPE paid and permanently burned in successful HIP-1 token-deployment auctions.',
   },
   Revenue: {
     'Spot Fees': '99% of spot trade fees, excluding perp fees and unit protocol fees.',
+    [SPOT_DEPLOYMENT_AUCTION_BURNS]: 'HIP-1 token-deployment auction payments permanently burned rather than retained or distributed.',
   },
   SupplySideRevenue: {
     'Unit Revenue': 'All fees earned on Unit spot markets go to Unit',
     'HLP': '1% of the spot fees go to HLP vault (used to be 3% before 30 Aug 2025)',
   },
   HoldersRevenue: {
-    [METRIC.TOKEN_BUY_BACK]: "99% of spot trade fees (excluding perp fees and unit protocol fees) for buy back HYPE tokens."
+    [METRIC.TOKEN_BUY_BACK]: "99% of spot trade fees (excluding perp fees and unit protocol fees) for buy back HYPE tokens.",
+    [SPOT_DEPLOYMENT_AUCTION_BURNS]: 'HYPE permanently removed from supply through successful HIP-1 token-deployment auctions.',
   },
 }
 
@@ -33,7 +44,10 @@ async function fetch(options: FetchOptions): Promise<FetchResultV2> {
 
   if (options.startOfDay < LLAMA_HL_INDEXER_FROM_TIME) {
     // get fees from hypurrscan, no volume
-    const result = await queryHypurrscanApi(options);
+    const [result, dailySpotAuctionBurns] = await Promise.all([
+      queryHypurrscanApi(options),
+      queryHypurrscanSpotAuctionBurns(options),
+    ]);
 
     const dailyFees = options.createBalances()
     const dailyRevenue = options.createBalances()
@@ -41,9 +55,15 @@ async function fetch(options: FetchOptions): Promise<FetchResultV2> {
     const dailyHoldersRevenue = options.createBalances()
 
     dailyFees.add(result.dailySpotFees, 'Spot Fees')
+    dailyFees.add(dailySpotAuctionBurns, SPOT_DEPLOYMENT_AUCTION_BURNS)
+
     dailyRevenue.add(result.dailySpotFees.clone(holdersShare), 'Spot Fees')
+    dailyRevenue.add(dailySpotAuctionBurns, SPOT_DEPLOYMENT_AUCTION_BURNS)
+
     dailySupplySideRevenue.add(result.dailySpotFees.clone(hlpShare), 'HLP')
+
     dailyHoldersRevenue.add(result.dailySpotFees.clone(holdersShare), METRIC.TOKEN_BUY_BACK)
+    dailyHoldersRevenue.add(dailySpotAuctionBurns, SPOT_DEPLOYMENT_AUCTION_BURNS)
 
     return {
       dailyFees,
@@ -53,7 +73,10 @@ async function fetch(options: FetchOptions): Promise<FetchResultV2> {
       dailyProtocolRevenue: 0,
     }
   } else {
-    const result = await queryHyperliquidIndexer(options);
+    const [result, dailySpotAuctionBurns] = await Promise.all([
+      queryHyperliquidIndexer(options),
+      queryHypurrscanSpotAuctionBurns(options),
+    ]);
 
     // spot volume
     const dailyVolume = result.dailySpotVolume;
@@ -66,6 +89,7 @@ async function fetch(options: FetchOptions): Promise<FetchResultV2> {
     // all spot fees
     dailyFees.add(result.dailySpotRevenue, 'Spot Fees')
     dailyFees.add(result.dailyUnitRevenue, 'Spot fees on Unit markets')
+    dailyFees.add(dailySpotAuctionBurns, SPOT_DEPLOYMENT_AUCTION_BURNS)
 
     // unit revenue + 1% spot revenue
     dailySupplySideRevenue.add(result.dailySpotRevenue.clone(hlpShare), 'HLP')
@@ -73,7 +97,10 @@ async function fetch(options: FetchOptions): Promise<FetchResultV2> {
     
     // 99% of spot fees
     dailyRevenue.add(result.dailySpotRevenue.clone(holdersShare), 'Spot Fees')
+    dailyRevenue.add(dailySpotAuctionBurns, SPOT_DEPLOYMENT_AUCTION_BURNS)
+
     dailyHoldersRevenue.add(result.dailySpotRevenue.clone(holdersShare), METRIC.TOKEN_BUY_BACK)
+    dailyHoldersRevenue.add(dailySpotAuctionBurns, SPOT_DEPLOYMENT_AUCTION_BURNS)
 
     return {
       dailyVolume,

--- a/dexs/hyperliquid-spot/index.ts
+++ b/dexs/hyperliquid-spot/index.ts
@@ -13,9 +13,9 @@ const SPOT_DEPLOYMENT_AUCTION_BURNS = "Spot Deployment Auction Burns";
 
 const methodology = {
   Fees: "Include spot trading fees, unit protocol fees, and HYPE burned in successful HIP-1 token-deployment auctions, excluding perps fees.",
-  Revenue: "99% of spot trading fees go to Assistance Fund for buying HYPE tokens, excluding unit protocol fees; HYPE paid in successful HIP-1 token-deployment auctions is burned.",
+  Revenue: "97% of spot trading fees before 30 Aug 2025 and 99% thereafter go to Assistance Fund for buying HYPE tokens, excluding unit protocol fees; HYPE paid in successful HIP-1 token-deployment auctions is burned.",
   ProtocolRevenue: "Protocol doesn't keep any fees.",
-  HoldersRevenue: "99% of spot trading fees go to Assistance Fund for buying HYPE tokens, excluding unit protocol fees; HYPE paid in successful HIP-1 token-deployment auctions is permanently burned.",
+  HoldersRevenue: "97% of spot trading fees before 30 Aug 2025 and 99% thereafter go to Assistance Fund for buying HYPE tokens, excluding unit protocol fees; HYPE paid in successful HIP-1 token-deployment auctions is permanently burned.",
   SupplySideRevenue: "1% of fees go to HLP Vault suppliers, before 30 Aug 2025 it was 3% + fees for unit protocol.",
 }
 
@@ -26,7 +26,7 @@ const breakdownMethodology = {
     [SPOT_DEPLOYMENT_AUCTION_BURNS]: 'HYPE paid and permanently burned in successful HIP-1 token-deployment auctions.',
   },
   Revenue: {
-    'Spot Fees': '99% of spot trade fees, excluding perp fees and unit protocol fees.',
+    'Spot Fees': '97% of spot trade fees before 30 Aug 2025 and 99% thereafter, excluding perp fees and unit protocol fees.',
     [SPOT_DEPLOYMENT_AUCTION_BURNS]: 'HIP-1 token-deployment auction payments permanently burned rather than retained or distributed.',
   },
   SupplySideRevenue: {
@@ -34,7 +34,7 @@ const breakdownMethodology = {
     'HLP': '1% of the spot fees go to HLP vault (used to be 3% before 30 Aug 2025)',
   },
   HoldersRevenue: {
-    [METRIC.TOKEN_BUY_BACK]: "99% of spot trade fees (excluding perp fees and unit protocol fees) for buy back HYPE tokens.",
+    [METRIC.TOKEN_BUY_BACK]: "97% of spot trade fees before 30 Aug 2025 and 99% thereafter, excluding perp fees and unit protocol fees, for buying back HYPE tokens.",
     [SPOT_DEPLOYMENT_AUCTION_BURNS]: 'HYPE permanently removed from supply through successful HIP-1 token-deployment auctions.',
   },
 }

--- a/helpers/hyperliquid.ts
+++ b/helpers/hyperliquid.ts
@@ -555,6 +555,23 @@ interface HypurrscanSpotAuction {
 const HYPURRSCAN_SPOT_AUCTIONS_API =
   "https://api.hypurrscan.io/pastAuctions";
 
+// Enforce the endpoint's Unix-millisecond contract: 13-digit timestamps
+// reject accidental seconds (< 1e12) and microseconds (>= 1e13).
+const MIN_PLAUSIBLE_UNIX_TIMESTAMP_MS = 1_000_000_000_000;
+const MAX_PLAUSIBLE_UNIX_TIMESTAMP_MS = 10_000_000_000_000;
+
+/**
+ * Fetches successful HIP-1 token-deployment auctions from Hypurrscan and
+ * returns HYPE burned within the half-open
+ * [options.startTimestamp, options.endTimestamp) interval.
+ *
+ * The endpoint returns Unix timestamps in milliseconds. Legacy deployment
+ * payments are non-negative, while HYPE burns are negative deployer balance
+ * changes whose positive magnitudes are summed.
+ *
+ * @throws If the response is malformed, timestamps have implausible units, or
+ * the historical deployment-payment sign convention is missing or changes.
+ */
 export async function queryHypurrscanSpotAuctionBurns(
   options: FetchOptions,
 ): Promise<Balances> {
@@ -566,17 +583,29 @@ export async function queryHypurrscanSpotAuctionBurns(
   }
 
   const auctions: HypurrscanSpotAuction[] = response
-    .map((item: any, index: number) => {
-      const time = Number(item?.time);
-      const rawDeployGas = item?.deployGas;
-
+    .map((item: unknown, index: number) => {
       if (
-        !Number.isSafeInteger(time) ||
-        time < 1_000_000_000_000 ||
-        time >= 10_000_000_000_000
+        typeof item !== "object" ||
+        item === null ||
+        Array.isArray(item)
       ) {
         throw new Error(
-          `Invalid Hypurrscan spot auction timestamp at index ${index}: ${item?.time}`,
+          `Invalid Hypurrscan spot auction record at index ${index}`,
+        );
+      }
+
+      const record = item as Record<string, unknown>;
+      const rawTime = record.time;
+      const rawDeployGas = record.deployGas;
+
+      if (
+        typeof rawTime !== "number" ||
+        !Number.isSafeInteger(rawTime) ||
+        rawTime < MIN_PLAUSIBLE_UNIX_TIMESTAMP_MS ||
+        rawTime >= MAX_PLAUSIBLE_UNIX_TIMESTAMP_MS
+      ) {
+        throw new Error(
+          `Invalid Hypurrscan spot auction timestamp at index ${index}: ${String(rawTime)}`,
         );
       }
 
@@ -587,18 +616,21 @@ export async function queryHypurrscanSpotAuctionBurns(
           rawDeployGas.trim() === "")
       ) {
         throw new Error(
-          `Invalid Hypurrscan spot auction deployGas at index ${index}: ${rawDeployGas}`,
+          `Invalid Hypurrscan spot auction deployGas at index ${index}: ${String(rawDeployGas)}`,
         );
       }
 
       const deployGas = Number(rawDeployGas);
       if (!Number.isFinite(deployGas)) {
         throw new Error(
-          `Invalid Hypurrscan spot auction deployGas at index ${index}: ${rawDeployGas}`,
+          `Invalid Hypurrscan spot auction deployGas at index ${index}: ${String(rawDeployGas)}`,
         );
       }
 
-      return { time, deployGas };
+      return {
+        time: rawTime,
+        deployGas,
+      };
     })
     .sort((a, b) => a.time - b.time);
 

--- a/helpers/hyperliquid.ts
+++ b/helpers/hyperliquid.ts
@@ -547,127 +547,30 @@ export async function queryHypurrscanApi(
   return result;
 }
 
-interface HypurrscanSpotAuction {
-  time: number;
-  deployGas: number;
-}
-
 const HYPURRSCAN_SPOT_AUCTIONS_API =
   "https://api.hypurrscan.io/pastAuctions";
 
-// Enforce the endpoint's Unix-millisecond contract: 13-digit timestamps
-// reject accidental seconds (< 1e12) and microseconds (>= 1e13).
-const MIN_PLAUSIBLE_UNIX_TIMESTAMP_MS = 1_000_000_000_000;
-const MAX_PLAUSIBLE_UNIX_TIMESTAMP_MS = 10_000_000_000_000;
-
-/**
- * Fetches successful HIP-1 token-deployment auctions from Hypurrscan and
- * returns HYPE burned within the half-open
- * [options.startTimestamp, options.endTimestamp) interval.
- *
- * The endpoint returns Unix timestamps in milliseconds. Legacy deployment
- * payments are non-negative, while HYPE burns are negative deployer balance
- * changes whose positive magnitudes are summed.
- *
- * @throws If the response is malformed, timestamps have implausible units, or
- * the historical deployment-payment sign convention is missing or changes.
- */
 export async function queryHypurrscanSpotAuctionBurns(
   options: FetchOptions,
 ): Promise<Balances> {
   const dailyBurns = options.createBalances();
   const response = await httpGet(HYPURRSCAN_SPOT_AUCTIONS_API);
-
-  if (!Array.isArray(response)) {
-    throw new Error("Invalid Hypurrscan spot auctions response: expected array");
-  }
-
-  const auctions: HypurrscanSpotAuction[] = response
-    .map((item: unknown, index: number) => {
-      if (
-        typeof item !== "object" ||
-        item === null ||
-        Array.isArray(item)
-      ) {
-        throw new Error(
-          `Invalid Hypurrscan spot auction record at index ${index}`,
-        );
-      }
-
-      const record = item as Record<string, unknown>;
-      const rawTime = record.time;
-      const rawDeployGas = record.deployGas;
-
-      if (
-        typeof rawTime !== "number" ||
-        !Number.isSafeInteger(rawTime) ||
-        rawTime < MIN_PLAUSIBLE_UNIX_TIMESTAMP_MS ||
-        rawTime >= MAX_PLAUSIBLE_UNIX_TIMESTAMP_MS
-      ) {
-        throw new Error(
-          `Invalid Hypurrscan spot auction timestamp at index ${index}: ${String(rawTime)}`,
-        );
-      }
-
-      if (
-        (typeof rawDeployGas !== "string" &&
-          typeof rawDeployGas !== "number") ||
-        (typeof rawDeployGas === "string" &&
-          rawDeployGas.trim() === "")
-      ) {
-        throw new Error(
-          `Invalid Hypurrscan spot auction deployGas at index ${index}: ${String(rawDeployGas)}`,
-        );
-      }
-
-      const deployGas = Number(rawDeployGas);
-      if (!Number.isFinite(deployGas)) {
-        throw new Error(
-          `Invalid Hypurrscan spot auction deployGas at index ${index}: ${String(rawDeployGas)}`,
-        );
-      }
-
-      return {
-        time: rawTime,
-        deployGas,
-      };
-    })
-    .sort((a, b) => a.time - b.time);
-
-  let hasSeenHypeAuction = false;
-  let hypeBurned = 0;
   const startTimeMs = options.startTimestamp * 1000;
   const endTimeMs = options.endTimestamp * 1000;
 
-  for (const auction of auctions) {
-    if (auction.deployGas < 0) {
-      hasSeenHypeAuction = true;
-    } else if (auction.deployGas > 0 && hasSeenHypeAuction) {
-      throw new Error(
-        "Invalid Hypurrscan spot auction history: positive deployGas after HYPE-denominated auctions began",
-      );
-    }
-
-    // Hypurrscan records legacy USDC-denominated deployment payments as
-    // positive values and HYPE burns as negative deployer balance changes.
-    if (
-      auction.deployGas < 0 &&
-      auction.time >= startTimeMs &&
-      auction.time < endTimeMs
-    ) {
-      hypeBurned -= auction.deployGas;
+  // Negative deployGas is HYPE burned; positive is pre-HYPE-era proceeds collected in USDC-> Assistance Fund.
+  let hypeBurned = 0;
+  let usdcCollected = 0;
+  for (const item of response) {
+    if (item.time >= startTimeMs && item.time < endTimeMs) {
+      const deployGas = Number(item.deployGas);
+      if (deployGas < 0) hypeBurned += Math.abs(deployGas);
+      else usdcCollected += deployGas;
     }
   }
 
-  if (!hasSeenHypeAuction) {
-    throw new Error(
-      "Invalid Hypurrscan spot auction history: no HYPE-denominated negative deployGas records",
-    );
-  }
-
-  if (hypeBurned > 0) {
-    dailyBurns.addCGToken("hyperliquid", hypeBurned);
-  }
+  if (hypeBurned) dailyBurns.addCGToken("hyperliquid", hypeBurned);
+  if (usdcCollected) dailyBurns.addCGToken("usd-coin", usdcCollected);
 
   return dailyBurns;
 }

--- a/helpers/hyperliquid.ts
+++ b/helpers/hyperliquid.ts
@@ -547,6 +547,99 @@ export async function queryHypurrscanApi(
   return result;
 }
 
+interface HypurrscanSpotAuction {
+  time: number;
+  deployGas: number;
+}
+
+const HYPURRSCAN_SPOT_AUCTIONS_API =
+  "https://api.hypurrscan.io/pastAuctions";
+
+export async function queryHypurrscanSpotAuctionBurns(
+  options: FetchOptions,
+): Promise<Balances> {
+  const dailyBurns = options.createBalances();
+  const response = await httpGet(HYPURRSCAN_SPOT_AUCTIONS_API);
+
+  if (!Array.isArray(response)) {
+    throw new Error("Invalid Hypurrscan spot auctions response: expected array");
+  }
+
+  const auctions: HypurrscanSpotAuction[] = response
+    .map((item: any, index: number) => {
+      const time = Number(item?.time);
+      const rawDeployGas = item?.deployGas;
+
+      if (
+        !Number.isSafeInteger(time) ||
+        time < 1_000_000_000_000 ||
+        time >= 10_000_000_000_000
+      ) {
+        throw new Error(
+          `Invalid Hypurrscan spot auction timestamp at index ${index}: ${item?.time}`,
+        );
+      }
+
+      if (
+        (typeof rawDeployGas !== "string" &&
+          typeof rawDeployGas !== "number") ||
+        (typeof rawDeployGas === "string" &&
+          rawDeployGas.trim() === "")
+      ) {
+        throw new Error(
+          `Invalid Hypurrscan spot auction deployGas at index ${index}: ${rawDeployGas}`,
+        );
+      }
+
+      const deployGas = Number(rawDeployGas);
+      if (!Number.isFinite(deployGas)) {
+        throw new Error(
+          `Invalid Hypurrscan spot auction deployGas at index ${index}: ${rawDeployGas}`,
+        );
+      }
+
+      return { time, deployGas };
+    })
+    .sort((a, b) => a.time - b.time);
+
+  let hasSeenHypeAuction = false;
+  let hypeBurned = 0;
+  const startTimeMs = options.startTimestamp * 1000;
+  const endTimeMs = options.endTimestamp * 1000;
+
+  for (const auction of auctions) {
+    if (auction.deployGas < 0) {
+      hasSeenHypeAuction = true;
+    } else if (auction.deployGas > 0 && hasSeenHypeAuction) {
+      throw new Error(
+        "Invalid Hypurrscan spot auction history: positive deployGas after HYPE-denominated auctions began",
+      );
+    }
+
+    // Hypurrscan records legacy USDC-denominated deployment payments as
+    // positive values and HYPE burns as negative deployer balance changes.
+    if (
+      auction.deployGas < 0 &&
+      auction.time >= startTimeMs &&
+      auction.time < endTimeMs
+    ) {
+      hypeBurned -= auction.deployGas;
+    }
+  }
+
+  if (!hasSeenHypeAuction) {
+    throw new Error(
+      "Invalid Hypurrscan spot auction history: no HYPE-denominated negative deployGas records",
+    );
+  }
+
+  if (hypeBurned > 0) {
+    dailyBurns.addCGToken("hyperliquid", hypeBurned);
+  }
+
+  return dailyBurns;
+}
+
 export const fetchHIP3DeployerData = async ({
   options,
   hip3DeployerId,


### PR DESCRIPTION
# Hyperliquid Spot Deployment Auction Burns

Fixes #8324

**Website:** https://hyperliquid.xyz
**Twitter:** https://x.com/HyperliquidX

## Summary

Hyperliquid spot token deployments are paid through HIP-1 Dutch auctions. HYPE-denominated deployment payments are permanently burned, but the `hyperliquid-spot` adapter currently reports only spot trading fees and Unit market fees.

This change:

* adds a helper for successful historical HIP-1 token-deployment auctions;
* sums HYPE burns within the adapter’s half-open `[startTimestamp, endTimestamp)` window;
* adds deployment-auction burns to Fees, Revenue, and Holders Revenue;
* updates the methodology and fee breakdown with a dedicated `Spot Deployment Auction Burns` label;
* fails closed on malformed source data or an unexpected change to the historical sign convention.

Pair-deployment auctions and HIP-3 perp-deployment auctions are intentionally out of scope.

## Data Source

The adapter uses Hypurrscan’s public `/pastAuctions` endpoint, which returns successful historical token-deployment auctions and their realized `deployGas`.

This avoids using `/deploys`, where repeated attempts can appear more than once, and avoids estimating the realized payment from `maxGas` or from the live auction gauge.

Hypurrscan is already used in `helpers/hyperliquid.ts` for historical Hyperliquid fee data. This PR introduces no new external provider, npm dependency, or lockfile change.

The historical response currently follows a clean transition:

* legacy deployment records use positive or zero `deployGas`;
* HYPE-denominated deployment burns use negative `deployGas`;
* no positive record appears after the negative HYPE-denominated records begin.

The helper counts only negative `deployGas` values and converts the negative deployer balance change into a positive HYPE burn amount. It throws if the source becomes malformed, contains no HYPE-denominated records, or later returns a positive deployment amount after the HYPE-era transition.

## Accounting

Auction burns are classified as follows:

| Dimension           | Treatment                                                                      |
| ------------------- | ------------------------------------------------------------------------------ |
| Fees                | Includes the HYPE paid by the deployer                                         |
| Revenue             | Includes the burned amount because it is not paid to a supply-side participant |
| Holders Revenue     | Includes the value permanently removed from HYPE supply                        |
| Protocol Revenue    | Unchanged; Hyperliquid does not retain the payment                             |
| Supply-Side Revenue | Unchanged; no LP, builder, or other supplier receives it                       |

This preserves:

```text
Fees = Revenue + SupplySideRevenue
Revenue = ProtocolRevenue + HoldersRevenue
```

## Validation

### Pre-indexer path: legacy payment excluded

```bash
DEBUG_BREAKDOWN_FEES=true \
pnpm test dexs hyperliquid-spot 2025-05-26
```

This covers May 25, 2025 UTC. The auction in that window has a positive legacy `deployGas`, so no deployment-auction burn is emitted.

### Pre-indexer path: first HYPE burn included

```bash
DEBUG_BREAKDOWN_FEES=true \
pnpm test dexs hyperliquid-spot 2025-05-27
```

This covers May 26, 2025 UTC.

The source reports:

```text
978.37515038 HYPE
```

The adapter reports:

```text
Spot Deployment Auction Burns
Daily fees:            $36,298
Daily revenue:         $36,298
Daily holders revenue: $36,298
```

The burn does not enter Protocol Revenue or Supply-Side Revenue.

### Modern indexer path

The modern branch was exercised against a local fixture matching the current `LLAMA_HL_INDEXER /v1/data/hourly` response consumed by `queryHyperliquidIndexer`.

For August 18, 2026 UTC:

```text
500.03974444 HYPE
```

was reported under Fees, Revenue, and Holders Revenue.

For August 16, 2026 UTC, which contained no successful token-deployment auction, no auction-burn row was emitted and the existing spot-fee allocation remained unchanged.

### Independent cumulative check

The cumulative HYPE burn calculated from the current `/pastAuctions` history was independently compared against the spot-auction burn total shown by hl.eco and matched.

### Static checks

```bash
./node_modules/.bin/tsc --project tsconfig.json --noEmit
git diff --check
```

Both pass.

## Internal Indexer Question

The public `queryHyperliquidIndexer` consumer does not currently read a field for spot token-deployment auction burns.

If the private `LLAMA_HL_INDEXER` response already exposes a canonical, historically backfilled value, I am happy to switch the helper to that field. In particular, it would be useful to confirm:

1. the field name;
2. its denomination and sign convention;
3. whether it is backfilled from the May 2025 HYPE transition;
4. whether it is separate from, or already included in, `spotFeeByTokens`.

## Scope

Only these files are changed:

```text
helpers/hyperliquid.ts
dexs/hyperliquid-spot/index.ts
```

No packages, dependencies, or lockfiles are modified.

## Acknowledgements

Thanks to @Himess for identifying the missing accounting component and to @0xshubhs for investigating the gauge behavior and documenting the duplicate-attempt hazard in `/deploys`.
