### PR TITLE
suilend: repoint at api.suilend.fi, global.suilend.fi no longer resolves

### DIFF
--- a/dexs/steamm.ts
+++ b/dexs/steamm.ts
@@ -3,7 +3,7 @@ import { CHAIN } from "../helpers/chains";
 import fetchURL from "../utils/fetchURL";
 import PromisePool from "@supercharge/promise-pool";
 
-const suilendPoolsURL = () => `https://global.suilend.fi/steamm/pools/all`;
+const suilendPoolsURL = () => `https://api.suilend.fi/steamm/pools/all`;
 
 interface PoolInfo {
   id: string;
@@ -21,7 +21,7 @@ const suilendPoolHistoricalURL = (
   fromTimestamp: number,
   toTimestamp: number
 ) =>
-  `https://global.suilend.fi/steamm/historical/volume?startTimestampS=${fromTimestamp}&endTimestampS=${toTimestamp}&intervalS=${60 * 60 * 24}&poolId=${poolId}`;
+  `https://api.suilend.fi/steamm/historical/volume?startTimestampS=${fromTimestamp}&endTimestampS=${toTimestamp}&intervalS=${60 * 60 * 24}&poolId=${poolId}`;
 
 
 async function fetchPoolsStats(startTimestamp: number, endTimestamp: number): Promise<Array<PoolInfo>> {

--- a/fees/springsui-ecosystem/index.ts
+++ b/fees/springsui-ecosystem/index.ts
@@ -9,7 +9,7 @@ interface FeeStats {
 }
 
 const fetch = async (options: FetchOptions) => {
-  const suilendFeesURL = 'https://global.suilend.fi/springsui/stats/fees';
+  const suilendFeesURL = 'https://api.suilend.fi/springsui/stats/fees';
   const url = `${suilendFeesURL}?endTimestamp=${options.endTimestamp}&startTimestamp=${options.startTimestamp}`
   const stats: FeeStats = (await fetchURL(url));
   

--- a/fees/suilend/index.ts
+++ b/fees/suilend/index.ts
@@ -5,7 +5,7 @@ import {
 import { CHAIN } from "../../helpers/chains";
 import fetchURL from "../../utils/fetchURL";
 
-export const SUILEND_API_ENDPOINT = 'https://global.suilend.fi';
+export const SUILEND_API_ENDPOINT = 'https://api.suilend.fi';
 const suilendFeesURL = SUILEND_API_ENDPOINT + '/stats/fees';
 
 export const SuiLendMetrics = {


### PR DESCRIPTION
`global.suilend.fi` stopped resolving. Against a public resolver it is NXDOMAIN:

```
$ dig @8.8.8.8 global.suilend.fi A
;; ->>HEADER<<- opcode: QUERY, status: NXDOMAIN
;; flags: qr rd ra; QUERY: 1, ANSWER: 0
```

`suilend.fi` and `api.suilend.fi` both resolve normally.

Four adapters read that host, and none of them has published anything since 2026-08-17:

| adapter | last 1y | last published day |
| --- | --- | --- |
| fees/suilend | 15.4M | 08-17, 9.04k |
| fees/springsui | 2.25M | 08-17, 1.67k |
| fees/springsui-ecosystem | 867k | 08-17, 510 |
| fees/steamm | 1.35M | 08-17, 28 |
| dexs/steamm | 951M volume | total24h is null |

`api.suilend.fi` serves the same paths with the same response shapes. I checked every path
these adapters use, all 200 with the same schema:

- `/stats/fees?startTimestamp=&endTimestamp=`
- `/springsui/stats/fees?startTimestamp=&endTimestamp=`
- `/steamm/pools/all`
- `/steamm/historical/fees?startTimestampS=&endTimestampS=&intervalS=&poolId=`
- `/steamm/historical/volume?startTimestampS=&endTimestampS=&intervalS=&poolId=`
- `/send/charts/send?period=all`

Test runs, next to what each adapter last published on 08-17:

```
fees suilend              11.56k fees, 2.72k revenue, 8.85k supply side   (was 9.04k)
fees springsui             1.86k fees, 27 revenue, 1.83k supply side      (was 1.67k)
fees springsui-ecosystem     563 fees, 12 revenue, 552 supply side        (was 510)
fees steamm                  181 fees, 36 revenue, 145 supply side        (was 28)
dexs steamm               266.12k volume
```

Host change only, no logic touched.