### PR TITLE
exclude specific Native RFQ recipients from volume

### DIFF
--- a/dexs/native/index.ts
+++ b/dexs/native/index.ts
@@ -12,6 +12,12 @@ const chainConfig: Record<string, { start: number }> = {
 
 const RFQ_TRADE_EVENT = 'event RFQTrade(address recipient, address sellerToken, address buyerToken, uint256 sellerTokenAmount, uint256 buyerTokenAmount, bytes16 quoteId, address signer)';
 
+// RFQ fills to these contracts are excluded from volume
+const SKIP_RECIPIENTS = new Set([
+  '0x309fcdd159c15e6305f1b02489a14e870e4df052',
+  '0x23e2b37415ee3b9cfe1ae522e42e2b66fd2d9494',
+]);
+
 const fetch: FetchV2 = async (options: FetchOptions) => {
   const { getLogs, createBalances } = options;
   const dailyVolume = createBalances();
@@ -23,6 +29,7 @@ const fetch: FetchV2 = async (options: FetchOptions) => {
   });
 
   logs.forEach((log: any) => {
+    if (SKIP_RECIPIENTS.has(String(log.recipient).toLowerCase())) return;
     dailyVolume.add(log.buyerToken, log.buyerTokenAmount);
   });
 
@@ -40,7 +47,7 @@ const adapter: SimpleAdapter = {
   pullHourly: true,
   fetch,
   methodology,
-  adapter: chainConfig,
+  adapter: chainConfig as any,
 };
 
 export default adapter;

--- a/dexs/native/index.ts
+++ b/dexs/native/index.ts
@@ -12,7 +12,7 @@ const chainConfig: Record<string, { start: number }> = {
 
 const RFQ_TRADE_EVENT = 'event RFQTrade(address recipient, address sellerToken, address buyerToken, uint256 sellerTokenAmount, uint256 buyerTokenAmount, bytes16 quoteId, address signer)';
 
-// RFQ fills to these contracts are excluded from volume
+// Unofficial adapter contracts that sat as RFQ recipient for the Jul-Aug 2026 BSC volume spike. Not Binance or Native. Same deployer rotated 0x309fcd -> 0x23e2b374.
 const SKIP_RECIPIENTS = new Set([
   '0x309fcdd159c15e6305f1b02489a14e870e4df052',
   '0x23e2b37415ee3b9cfe1ae522e42e2b66fd2d9494',


### PR DESCRIPTION
## Summary

Skip Native `RFQTrade` fills whose recipient is one of two unofficial adapter contracts. They are not Binance and not Native. Almost all of the Jul-Aug 2026 BSC volume spike settled to them.

## Why

Native BSC daily volume (dashboard, Native Swap):

| Date | BSC volume |
| --- | --- |
| 1-12 Jul (early July avg) | ~$3.7M/day |
| 19 Jul | $123M |
| 26 Jul (peak) | $963M |
| 5 Aug | $211M |
| 6 Aug | $41M |
| 15 Aug | $14M |

QQQB (the pair that printed the spike) has ~1,861 circulating tokens / ~$1.3M mcap. $500M-$1B/day on that float is not organic user flow.

## On-chain

19 Jul to 6 Aug, Native RFQ fills on the spike pool `0x9af2f3c0cd35283e13f7087e2b34b1444b57a44c`:

- ~8.15M fills
- 99.36% had RFQ recipient `0x309fcdd159c15e6305f1b02489a14e870e4df052`
- Pair was QQQB (`0x205812cd...`) / USDT, ping-ponged both ways
- One Native MM signer on those fills: `0x129b3d9a0a6e4beab88f5cb1e57995d72a6e24f1`

26 Jul, fills that went through Binance DEX Router `0xb300000b72deaeb607a12d5f54773d1c19c7028d`:

- 950,251 fills
- 950,250 had recipient `0x309fcd...`
- 42,510 unique `tx.from`, and `tx.from` was never the recipient

Same day, same router, on the quiet Native pool `0x9197a811...`: 24 fills, 15 senders, distinct per-user recipients, none of them `0x309fcd...`. Real Binance Wallet flow already uses the user as recipient. The spike path uses these two adapter contracts instead.

From 7 Aug the same operator rotated to `0x23e2b37415ee3b9cfe1ae522e42e2b66fd2d9494` (100% of fills on the new pool `0xabd4336e...`).

## Ownership

Both contracts are unverified DODO-style adapters (`sellBase` / `sellQuote` / `WETH`). Tokens pass through (balances ~0). They were deployed by the same unlabeled EOA through Nick's CREATE2 factory:

- Deployer: [`0x108901749Cb5C0286576499524efBBBD056F680D`](https://bscscan.com/address/0x108901749cb5c0286576499524efbbbd056f680d)
- Factory: `0x4e59b44847b379578588920cA78FbF26c0B4956C`
- Recip1 created 31 Oct 2025: [tx](https://bscscan.com/tx/0xbb339fb1d7eb680969e341ad4b9491efa391ac705d868d9e0da09710110c2ce2)
- Recip2 created ~7 Aug 2026: [tx](https://bscscan.com/tx/0x9064703739eaf98929abe5e8ad5c258255adf39bec1677c710de20bf1584ee50)

Native's own BSC routers are `0xC6a5cD6C...`, `0xF064b069...`, `0x0f9f2366...`. None of those match.

## What is not skipped

Binance DEX Router stays. Organic Native volume through that router keeps the user's own address as RFQ recipient.

## Test plan

- Refill Native BSC volume after merge
