### PR TITLE
[add] rwaperp - add perpetuals volume adapter

### DIFF
--- a/dexs/rwaperp/index.ts
+++ b/dexs/rwaperp/index.ts
@@ -1,0 +1,59 @@
+import { FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import { httpGet } from "../../utils/fetchURL";
+
+const STATS_URL =
+  "https://api-market.rwaperp.xyz/md/volume/builder/daily_stats?broker_id=rwaperp_xyz";
+
+type DailyStat = {
+  date: string;
+  takerVolume: string;
+};
+
+let statsByDate: Promise<Record<string, DailyStat>> | undefined;
+
+const fetch = async ({ dateString }: FetchOptions) => {
+  if (!statsByDate) {
+    statsByDate = httpGet(STATS_URL)
+      .then((rows: DailyStat[]) => {
+        const map: Record<string, DailyStat> = {};
+        rows.forEach((row) => {
+          map[row.date.slice(0, 10)] = row;
+        });
+        return map;
+      })
+      .catch((e) => {
+        statsByDate = undefined;
+        throw e;
+      });
+  }
+
+  const day = (await statsByDate)[dateString];
+  if (!day) {
+    throw new Error(`No daily stats found for ${dateString} from RWA Perp API`);
+  }
+
+  const volume = Number(day.takerVolume);
+  if (isNaN(volume)) {
+    throw new Error(
+      `Invalid takerVolume from RWA Perp API for ${dateString}: ${day.takerVolume}`,
+    );
+  }
+
+  return { dailyVolume: volume };
+};
+
+const methodology = {
+  Volume:
+    "Perpetual futures trading volume on RWA Perp. Volume is attributed to X Layer, RWA Perp's primary deployment chain.",
+};
+
+const adapter: SimpleAdapter = {
+  version: 1,
+  fetch,
+  chains: [CHAIN.XLAYER],
+  start: "2026-08-19",
+  methodology,
+};
+
+export default adapter;


### PR DESCRIPTION
## Summary
- Add a standalone `dexs/rwaperp` adapter to track RWA Perp perpetual futures volume.
- Data source: `https://api-market.rwaperp.xyz/md/volume/builder/daily_stats?broker_id=rwaperp_xyz`
- Volume metric: daily taker volume only.
- Chain attribution: X Layer (primary deployment chain).

## Test plan
- [x] `pnpm test dexs rwaperp`
- [x] `pnpm test dexs rwaperp 2026-08-20`
- [x] Verified adapter returns expected daily volume (~2.06k on 2026-08-19)

---

##### Name (to be shown on DefiLlama):
RWA Perp

##### Twitter Link:
https://x.com/rwaperp

##### List of audit links if any:


##### Website Link:
https://www.rwaperp.xyz/

##### Logo (High resolution, will be shown with rounded borders):
https://app.rwaperp.xyz/brand/logo-mark.svg

##### Current TVL:


##### Treasury Addresses (if the protocol has treasury)


##### Chain:
X Layer

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed): (https://api.coingecko.com/api/v3/coins/list)


##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)


##### Short Description (to be shown on DefiLlama):
RWA Perp is a perpetual futures trading platform.

##### Token address and ticker if any:


##### Category (full list at https://defillama.com/categories) *Please choose only one:
Derivatives

##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.):


##### Implementation Details: Briefly describe how the oracle is integrated into your project:


##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage:


##### forkedFrom (Does your project originate from another project):


##### methodology (what is being counted as tvl, how is tvl being calculated):
Perpetual futures taker volume on RWA Perp. Daily volume is sourced from protocol daily stats and attributed to X Layer as the primary deployment chain.

##### Github org/user (Optional, if your code is open source, we can track activity):


##### Does this project have a referral program?
Yes

Made with [Cursor](https://cursor.com)