### PR TITLE
usdd: fix sdk import and missing block numbers that have thrown since 08-18

### DIFF
--- a/fees/usdd/index.ts
+++ b/fees/usdd/index.ts
@@ -1,4 +1,4 @@
-import sdk from "@defillama/sdk";
+import * as sdk from "@defillama/sdk";
 import { FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 import { METRIC } from "../../helpers/metrics";
@@ -85,18 +85,18 @@ const fetch = async (options: FetchOptions) => {
   const config = chainConfig[options.chain] as any;
 
   const [folds, sells, buys, barks] = await Promise.all([
-    options.getLogs({ target: config.vat, eventAbi: ABI.fold }),
+    options.getLogs({ target: config.vat, eventAbi: ABI.fold, onlyArgs: false }),
     options.getLogs({ targets: config.psms, eventAbi: ABI.sellGem, flatten: true }),
     options.getLogs({ targets: config.psms, eventAbi: ABI.buyGem, flatten: true }),
-    options.getLogs({ target: config.dog, eventAbi: ABI.bark }),
+    options.getLogs({ target: config.dog, eventAbi: ABI.bark, onlyArgs: false }),
   ]);
 
   for (const log of folds) {
-    const rateDelta = BigInt(log.rate ?? 0);
+    const rateDelta = BigInt(log.args.rate ?? 0);
     if (rateDelta <= 0n) continue;
 
     const api = new sdk.ChainApi({ chain: options.chain, block: blockOf(log) });
-    const [art] = await api.call({ target: config.vat, abi: ABI.vatIlks, params: [log.i] });
+    const [art] = await api.call({ target: config.vat, abi: ABI.vatIlks, params: [log.args.i] });
     const fee = toWad(BigInt(art) * rateDelta);
 
     dailyFees.add(config.usdd, fee, METRIC.BORROW_INTEREST);
@@ -111,8 +111,8 @@ const fetch = async (options: FetchOptions) => {
 
   for (const log of barks) {
     const api = new sdk.ChainApi({ chain: options.chain, block: blockOf(log) });
-    const [, chop] = await api.call({ target: config.dog, abi: ABI.dogIlks, params: [log.ilk] });
-    const penalty = BigInt(chop) > WAD ? toWad(BigInt(log.due ?? 0) * (BigInt(chop) - WAD) / WAD) : 0n;
+    const [, chop] = await api.call({ target: config.dog, abi: ABI.dogIlks, params: [log.args.ilk] });
+    const penalty = BigInt(chop) > WAD ? toWad(BigInt(log.args.due ?? 0) * (BigInt(chop) - WAD) / WAD) : 0n;
     if (!penalty) continue;
 
     dailyFees.add(config.usdd, penalty, METRIC.LIQUIDATION_FEES);


### PR DESCRIPTION
Fixes #8896

`fees/usdd` has thrown on every run since 2026-08-18 and recorded no data points at all, dropping about $17.2k/day of Tron stability fees.

Two latent bugs, both in the ethereum/bsc branch, both dormant until the vat emitted its first `Fold` events on 08-18:

- `import sdk from "@defillama/sdk"`; the package has no default export, so `sdk` is undefined and `new sdk.ChainApi(...)` throws. `esModuleInterop` and `allowSyntheticDefaultImports` are both on, so it type-checks clean and only fails at runtime. Switched to `import * as sdk`, which is what the rest of the repo uses for `sdk.ChainApi`.
- `blockOf(log)` returned `NaN`. `getLogs` defaults to `onlyArgs: true`, so the logs carry decoded args and no block field, and `eth_call` got a bad block param. Passed `onlyArgs: false` on the two calls that need a block and read the event fields through `log.args`.

The ethereum values do not change; all six ilks have `Art = 0`, so its borrow interest really is $0. The crash was killing the whole protocol run and taking Tron with it.

```
$ npm test fees usdd 2026-08-19 ethereum
completes all 24 slots, 0.00 (was: TypeError: Cannot read properties of undefined (reading 'ChainApi'))

$ npm test fees usdd 2026-08-19 tron
Daily fees: 17.19 k

$ npm test fees usdd 2026-08-20 tron
Daily fees: 17.14 k
```

Prior published days were 17.35k (08-17), 17.38k (08-16), 17.21k (08-15), so the restored values line up.

`npm run ts-check` passes.
