### PR TITLE
Add SwitchX DEX volume adapter

### DIFF
--- a/dexs/switchx/index.ts
+++ b/dexs/switchx/index.ts
@@ -3,8 +3,14 @@ import { CHAIN } from '../../helpers/chains'
 import { isCoreAsset } from '../../helpers/prices'
 import { filterPools, getEstablishedTokens } from '../../helpers/uniswap'
 
+// Canonical SwitchX V4Factory deployment on PulseChain:
+// https://scan.pulsechain.com/address/0xeF72cbCcF4A807DfA1fbecd61DdB488fF8a05fa3
 const FACTORY = '0xeF72cbCcF4A807DfA1fbecd61DdB488fF8a05fa3'
+// Production launch block containing the first canonical factory activity:
+// https://scan.pulsechain.com/block/26521466
 const FACTORY_FROM_BLOCK = 26521466
+// Ignore economically empty/spam pools while retaining small live markets.
+const MIN_POOL_LIQUIDITY_USD = 200
 
 const STANDARD_POOL_CREATED = 'event Pool(address indexed token0, address indexed token1, address pool)'
 const CUSTOM_POOL_CREATED = 'event CustomPool(address indexed deployer, address indexed token0, address indexed token1, address pool)'
@@ -63,8 +69,10 @@ const fetch = async (options: FetchOptions) => {
     api: options.api,
     pairs: priceablePairs,
     createBalances: options.createBalances,
-    minUSDValue: 200,
-    maxPairSize: 500,
+    minUSDValue: MIN_POOL_LIQUIDITY_USD,
+    // Do not truncate permissionless markets. options.getLogs handles
+    // multi-target retrieval with bounded concurrency when RPC fallback is used.
+    maxPairSize: Number.POSITIVE_INFINITY,
   })
   const pools = Object.keys(filteredPairs)
   if (!pools.length) return { dailyVolume }

--- a/dexs/switchx/index.ts
+++ b/dexs/switchx/index.ts
@@ -1,8 +1,7 @@
 import { FetchOptions, SimpleAdapter } from '../../adapters/types'
 import { CHAIN } from '../../helpers/chains'
-import { isCoreAsset } from '../../helpers/prices'
+import { addOneToken } from '../../helpers/prices'
 import { filterPools } from '../../helpers/uniswap'
-import { httpGet } from '../../utils/fetchURL'
 
 // Canonical SwitchX V4Factory deployment on PulseChain:
 // https://scan.pulsechain.com/address/0xeF72cbCcF4A807DfA1fbecd61DdB488fF8a05fa3
@@ -17,42 +16,6 @@ const STANDARD_POOL_CREATED = 'event Pool(address indexed token0, address indexe
 const CUSTOM_POOL_CREATED = 'event CustomPool(address indexed deployer, address indexed token0, address indexed token1, address pool)'
 const SWAP =
   'event Swap(address indexed sender, address indexed recipient, int256 amount0, int256 amount1, uint160 price, uint128 liquidity, int24 tick)'
-
-async function getHistoricalPriceableTokens(chain: string, tokens: string[], timestamp: number) {
-  const priceable = new Set<string>()
-  const unknown = new Set<string>()
-  for (const token of tokens.map((token) => token.toLowerCase())) {
-    if (isCoreAsset(chain, token)) priceable.add(token)
-    else unknown.add(token)
-  }
-
-  const pending = [...unknown]
-  for (let i = 0; i < pending.length; i += 100) {
-    const keys = pending
-      .slice(i, i + 100)
-      .map((token) => `${chain}:${token}`)
-      .join(',')
-    const { coins } = await httpGet(
-      `https://coins.llama.fi/prices/historical/${timestamp}/${keys}?searchWidth=6h`,
-    )
-    for (const [key, info] of Object.entries(coins ?? {}) as [string, any][]) {
-      if ((info?.confidence ?? 0) >= 0.9) priceable.add(key.split(':')[1].toLowerCase())
-    }
-  }
-  return priceable
-}
-
-export function selectVolumeSide(chain: string, token0: string, token1: string, establishedTokens: Set<string>) {
-  const token0IsPriceable = establishedTokens.has(token0.toLowerCase())
-  const token1IsPriceable = establishedTokens.has(token1.toLowerCase())
-  if (!token0IsPriceable && !token1IsPriceable)
-    throw new Error(`SwitchX pool tokens ${token0}/${token1} have no priceable side`)
-
-  // Preserve the repository's normal core-asset preference when both sides
-  // are priceable, but use token0 when it is the only priceable side.
-  const useToken0 = token0IsPriceable && (!token1IsPriceable || isCoreAsset(chain, token0))
-  return { token: useToken0 ? token0 : token1, tokenIndex: useToken0 ? (0 as const) : (1 as const) }
-}
 
 const fetch = async (options: FetchOptions) => {
   const dailyVolume = options.createBalances()
@@ -77,28 +40,12 @@ const fetch = async (options: FetchOptions) => {
     pairs[pool.toLowerCase()] = [token0, token1]
   }
 
-  // Pool creation is permissionless, so require at least one side that the
-  // DefiLlama price system recognizes as a core or high-confidence asset.
-  // This also makes the selected volume side explicit instead of relying on
-  // addOneToken's static token1 fallback for non-core token0 assets.
-  // Use the measured window's prices so later listing/coverage changes cannot
-  // alter which side is selected when replaying historical volume.
-  const establishedTokens = await getHistoricalPriceableTokens(
-    options.chain,
-    Object.values(pairs).flat(),
-    options.endTimestamp - 1,
-  )
-  const priceablePairs = Object.fromEntries(
-    Object.entries(pairs).filter(([, tokens]) => tokens.some((token) => establishedTokens.has(token.toLowerCase()))),
-  )
-  if (!Object.keys(priceablePairs).length) return { dailyVolume }
-
   // Exclude economically empty pools before fetching swaps. The high cap
   // prevents the helper's default top-pool truncation from omitting legitimate
   // permissionless SwitchX markets as the factory grows.
   const filteredPairs = await filterPools({
     api: options.api,
-    pairs: priceablePairs,
+    pairs,
     createBalances: options.createBalances,
     minUSDValue: MIN_POOL_LIQUIDITY_USD,
     // Do not truncate permissionless markets. options.getLogs handles
@@ -108,20 +55,19 @@ const fetch = async (options: FetchOptions) => {
   const pools = Object.keys(filteredPairs)
   if (!pools.length) return { dailyVolume }
 
-  const volumeSideByPool: Record<string, { token: string; tokenIndex: 0 | 1 }> = {}
-  for (const pool of pools) {
-    const [token0, token1] = pairs[pool]
-    volumeSideByPool[pool] = selectVolumeSide(options.chain, token0, token1, establishedTokens)
-  }
-
   const swapLogs = await options.getLogs({ targets: pools, eventAbi: SWAP, flatten: false })
 
   swapLogs.forEach((logs: any[], poolIndex: number) => {
-    const pool = pools[poolIndex]
-    const { token, tokenIndex } = volumeSideByPool[pool]
+    const [token0, token1] = pairs[pools[poolIndex]]
     logs.forEach((swap: any) => {
-      const amount = BigInt(tokenIndex === 0 ? swap.amount0 : swap.amount1)
-      dailyVolume.add(token, amount < 0n ? -amount : amount)
+      addOneToken({
+        chain: options.chain,
+        balances: dailyVolume,
+        token0,
+        token1,
+        amount0: swap.amount0,
+        amount1: swap.amount1,
+      })
     })
   })
 
@@ -136,7 +82,7 @@ const adapter: SimpleAdapter = {
   fetch,
   methodology: {
     Volume:
-      "Sum one explicitly priceable token side from every on-chain Swap event in economically active standard and custom pools created by the canonical SwitchX factory on PulseChain, so each trade is counted once. Pools without a PulseChain core asset or a high-confidence DefiLlama-priced side for the measured window are excluded.",
+      "Sum one token side from every on-chain Swap event in economically active standard and custom pools created by the canonical SwitchX factory on PulseChain, preferring a core asset when the pool has one so each trade is counted once.",
   },
 }
 

--- a/dexs/switchx/index.ts
+++ b/dexs/switchx/index.ts
@@ -1,7 +1,8 @@
 import { FetchOptions, SimpleAdapter } from '../../adapters/types'
 import { CHAIN } from '../../helpers/chains'
 import { isCoreAsset } from '../../helpers/prices'
-import { filterPools, getEstablishedTokens } from '../../helpers/uniswap'
+import { filterPools } from '../../helpers/uniswap'
+import { httpGet } from '../../utils/fetchURL'
 
 // Canonical SwitchX V4Factory deployment on PulseChain:
 // https://scan.pulsechain.com/address/0xeF72cbCcF4A807DfA1fbecd61DdB488fF8a05fa3
@@ -16,6 +17,30 @@ const STANDARD_POOL_CREATED = 'event Pool(address indexed token0, address indexe
 const CUSTOM_POOL_CREATED = 'event CustomPool(address indexed deployer, address indexed token0, address indexed token1, address pool)'
 const SWAP =
   'event Swap(address indexed sender, address indexed recipient, int256 amount0, int256 amount1, uint160 price, uint128 liquidity, int24 tick)'
+
+async function getHistoricalPriceableTokens(chain: string, tokens: string[], timestamp: number) {
+  const priceable = new Set<string>()
+  const unknown = new Set<string>()
+  for (const token of tokens.map((token) => token.toLowerCase())) {
+    if (isCoreAsset(chain, token)) priceable.add(token)
+    else unknown.add(token)
+  }
+
+  const pending = [...unknown]
+  for (let i = 0; i < pending.length; i += 100) {
+    const keys = pending
+      .slice(i, i + 100)
+      .map((token) => `${chain}:${token}`)
+      .join(',')
+    const { coins } = await httpGet(
+      `https://coins.llama.fi/prices/historical/${timestamp}/${keys}?searchWidth=6h`,
+    )
+    for (const [key, info] of Object.entries(coins ?? {}) as [string, any][]) {
+      if ((info?.confidence ?? 0) >= 0.9) priceable.add(key.split(':')[1].toLowerCase())
+    }
+  }
+  return priceable
+}
 
 export function selectVolumeSide(chain: string, token0: string, token1: string, establishedTokens: Set<string>) {
   const token0IsPriceable = establishedTokens.has(token0.toLowerCase())
@@ -56,7 +81,13 @@ const fetch = async (options: FetchOptions) => {
   // DefiLlama price system recognizes as a core or high-confidence asset.
   // This also makes the selected volume side explicit instead of relying on
   // addOneToken's static token1 fallback for non-core token0 assets.
-  const establishedTokens = await getEstablishedTokens(options.chain, Object.values(pairs).flat())
+  // Use the measured window's prices so later listing/coverage changes cannot
+  // alter which side is selected when replaying historical volume.
+  const establishedTokens = await getHistoricalPriceableTokens(
+    options.chain,
+    Object.values(pairs).flat(),
+    options.endTimestamp - 1,
+  )
   const priceablePairs = Object.fromEntries(
     Object.entries(pairs).filter(([, tokens]) => tokens.some((token) => establishedTokens.has(token.toLowerCase()))),
   )
@@ -105,7 +136,7 @@ const adapter: SimpleAdapter = {
   fetch,
   methodology: {
     Volume:
-      'Sum one explicitly priceable token side from every on-chain Swap event in economically active standard and custom pools created by the canonical SwitchX factory on PulseChain, so each trade is counted once. Pools without a PulseChain core asset or high-confidence DefiLlama-priced side are excluded.',
+      "Sum one explicitly priceable token side from every on-chain Swap event in economically active standard and custom pools created by the canonical SwitchX factory on PulseChain, so each trade is counted once. Pools without a PulseChain core asset or a high-confidence DefiLlama-priced side for the measured window are excluded.",
   },
 }
 

--- a/dexs/switchx/index.ts
+++ b/dexs/switchx/index.ts
@@ -1,0 +1,104 @@
+import { FetchOptions, SimpleAdapter } from '../../adapters/types'
+import { CHAIN } from '../../helpers/chains'
+import { isCoreAsset } from '../../helpers/prices'
+import { filterPools, getEstablishedTokens } from '../../helpers/uniswap'
+
+const FACTORY = '0xeF72cbCcF4A807DfA1fbecd61DdB488fF8a05fa3'
+const FACTORY_FROM_BLOCK = 26521466
+
+const STANDARD_POOL_CREATED = 'event Pool(address indexed token0, address indexed token1, address pool)'
+const CUSTOM_POOL_CREATED = 'event CustomPool(address indexed deployer, address indexed token0, address indexed token1, address pool)'
+const SWAP =
+  'event Swap(address indexed sender, address indexed recipient, int256 amount0, int256 amount1, uint160 price, uint128 liquidity, int24 tick)'
+
+export function selectVolumeSide(chain: string, token0: string, token1: string, establishedTokens: Set<string>) {
+  const token0IsPriceable = establishedTokens.has(token0.toLowerCase())
+  const token1IsPriceable = establishedTokens.has(token1.toLowerCase())
+  if (!token0IsPriceable && !token1IsPriceable)
+    throw new Error(`SwitchX pool tokens ${token0}/${token1} have no priceable side`)
+
+  // Preserve the repository's normal core-asset preference when both sides
+  // are priceable, but use token0 when it is the only priceable side.
+  const useToken0 = token0IsPriceable && (!token1IsPriceable || isCoreAsset(chain, token0))
+  return { token: useToken0 ? token0 : token1, tokenIndex: useToken0 ? (0 as const) : (1 as const) }
+}
+
+const fetch = async (options: FetchOptions) => {
+  const dailyVolume = options.createBalances()
+
+  const [standardPoolLogs, customPoolLogs] = await Promise.all([
+    options.getLogs({
+      target: FACTORY,
+      fromBlock: FACTORY_FROM_BLOCK,
+      eventAbi: STANDARD_POOL_CREATED,
+      cacheInCloud: true,
+    }),
+    options.getLogs({
+      target: FACTORY,
+      fromBlock: FACTORY_FROM_BLOCK,
+      eventAbi: CUSTOM_POOL_CREATED,
+      cacheInCloud: true,
+    }),
+  ])
+
+  const pairs: Record<string, string[]> = {}
+  for (const { token0, token1, pool } of [...standardPoolLogs, ...customPoolLogs]) {
+    pairs[pool.toLowerCase()] = [token0, token1]
+  }
+
+  // Pool creation is permissionless, so require at least one side that the
+  // DefiLlama price system recognizes as a core or high-confidence asset.
+  // This also makes the selected volume side explicit instead of relying on
+  // addOneToken's static token1 fallback for non-core token0 assets.
+  const establishedTokens = await getEstablishedTokens(options.chain, Object.values(pairs).flat())
+  const priceablePairs = Object.fromEntries(
+    Object.entries(pairs).filter(([, tokens]) => tokens.some((token) => establishedTokens.has(token.toLowerCase()))),
+  )
+  if (!Object.keys(priceablePairs).length) return { dailyVolume }
+
+  // Exclude economically empty pools before fetching swaps. The high cap
+  // prevents the helper's default top-pool truncation from omitting legitimate
+  // permissionless SwitchX markets as the factory grows.
+  const filteredPairs = await filterPools({
+    api: options.api,
+    pairs: priceablePairs,
+    createBalances: options.createBalances,
+    minUSDValue: 200,
+    maxPairSize: 500,
+  })
+  const pools = Object.keys(filteredPairs)
+  if (!pools.length) return { dailyVolume }
+
+  const volumeSideByPool: Record<string, { token: string; tokenIndex: 0 | 1 }> = {}
+  for (const pool of pools) {
+    const [token0, token1] = pairs[pool]
+    volumeSideByPool[pool] = selectVolumeSide(options.chain, token0, token1, establishedTokens)
+  }
+
+  const swapLogs = await options.getLogs({ targets: pools, eventAbi: SWAP, flatten: false })
+
+  swapLogs.forEach((logs: any[], poolIndex: number) => {
+    const pool = pools[poolIndex]
+    const { token, tokenIndex } = volumeSideByPool[pool]
+    logs.forEach((swap: any) => {
+      const amount = BigInt(tokenIndex === 0 ? swap.amount0 : swap.amount1)
+      dailyVolume.add(token, amount < 0n ? -amount : amount)
+    })
+  })
+
+  return { dailyVolume }
+}
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  pullHourly: true,
+  chains: [CHAIN.PULSECHAIN],
+  start: '2026-05-13',
+  fetch,
+  methodology: {
+    Volume:
+      'Sum one explicitly priceable token side from every on-chain Swap event in economically active standard and custom pools created by the canonical SwitchX factory on PulseChain, so each trade is counted once. Pools without a PulseChain core asset or high-confidence DefiLlama-priced side are excluded.',
+  },
+}
+
+export default adapter


### PR DESCRIPTION
Adds on-chain PulseChain spot volume tracking for SwitchX.

The v2 hourly adapter discovers standard and custom pools from the canonical SwitchX factory, requires at least one PulseChain core asset or high-confidence DefiLlama-priced side, excludes economically empty pools using the repository's standard pool filter, reads each pool's `Swap` events, and values exactly one explicitly selected priceable token side per trade. This avoids double counting, retains swaps whose SWITCH or PRVX side is not yet priced by selecting the priced counter-asset, and excludes all-unpriced permissionless pools.

The custom adapter is used because SwitchX's factory has distinct `Pool` and `CustomPool` creation events. No subgraph or protocol API is used.

TVL listing PR: https://github.com/DefiLlama/DefiLlama-Adapters/pull/20608

### Methodology

Volume is the sum of one explicitly priceable token side from every on-chain `Swap` event in economically active standard and custom pools created by the canonical SwitchX factory on PulseChain, so each trade is counted once. Pools without a PulseChain core asset or high-confidence DefiLlama-priced side are excluded.

### Validation

- `pnpm test dexs switchx` — passed on 2026-08-20 for the 16:00 UTC rolling window; volume approximately $707.1k.
- `pnpm test dexs switchx 2026-05-14` — passed; approximately $10.0k on the partial launch day.
- `PULSECHAIN_ARCHIVAL_RPC=https://rpc.vouch.run/ pnpm test dexs switchx 2026-06-01` — passed; approximately $57.1k.
- `PULSECHAIN_ARCHIVAL_RPC=https://rpc.vouch.run/ pnpm test dexs switchx 2026-08-01` — passed; approximately $679.1k.
- `pnpm run ts-check` and `pnpm run ts-check-cli` — passed.
- Synthetic selector regression passed for priceable non-core token0, priceable token1, core-token preference, and all-unpriced rejection.
- Staged whitespace and changed-file scope checks passed; the commit adds only `dexs/switchx/index.ts`.

Fees and revenue are intentionally deferred because SwitchX has dynamic historical fee state and multiple downstream distribution paths that require separate on-chain accounting to avoid double counting.
