### PR TITLE
fix(hypersurface): include USDC-collateral pool in HyperEVM volume

### DIFF
--- a/options/hypersurface/index.ts
+++ b/options/hypersurface/index.ts
@@ -95,19 +95,42 @@ const fetch = async (options: FetchOptions) => {
     throw new Error(`No subgraph URL found for chain: ${options.chain}`);
   }
 
-  // Get the time range for this fetch (startOfDay to endOfDay in seconds)
-  const startTimestamp = options.startOfDay;
-  const endTimestamp = options.startOfDay + 86400; // Next day
+  // Use the v2 fetch window so the adapter is correct for any run length,
+  // including hourly runs. The range is half-open, so consecutive windows
+  // never double count a trade.
+  const { startTimestamp, endTimestamp } = options;
 
   // Fetch all trades in the time range, across every pool on this chain.
   // Pools are separate deployments with disjoint trade sets, so summing
   // them cannot double count.
-  const tradesPerPool = await Promise.all(
+  // Each pool is settled independently so that one unreachable subgraph does
+  // not discard the pools that did respond. If every pool fails the error is
+  // propagated, since that indicates a systemic failure rather than one flaky
+  // endpoint.
+  const results = await Promise.allSettled(
     subgraphUrls.map((url) =>
       fetchAllTrades(url, startTimestamp, endTimestamp)
     )
   );
-  const trades = tradesPerPool.flat();
+
+  const failures = results.filter(
+    (r): r is PromiseRejectedResult => r.status === "rejected"
+  );
+  if (failures.length === results.length) {
+    throw failures[0].reason;
+  }
+  for (const failure of failures) {
+    console.error(
+      `hypersurface: skipping unreachable pool subgraph on ${options.chain}:`,
+      failure.reason
+    );
+  }
+
+  const trades = results
+    .filter(
+      (r): r is PromiseFulfilledResult<Trade[]> => r.status === "fulfilled"
+    )
+    .flatMap((r) => r.value);
 
   // Calculate volumes from trades
   let dailyNotionalVolume = 0;
@@ -126,15 +149,22 @@ const fetch = async (options: FetchOptions) => {
     dailyNotionalVolume += Number(trade.totalNotionalUSD);
   }
 
+  // Protocol fees accrue entirely to the protocol; there is no supply-side
+  // payout from the fee, so dailyFees = dailyRevenue + dailySupplySideRevenue
+  // holds with the supply side at zero.
   return {
     dailyNotionalVolume,
     dailyPremiumVolume,
     dailyFees,
+    dailyRevenue: dailyFees,
+    dailyProtocolRevenue: dailyFees,
+    dailySupplySideRevenue: 0,
   };
 };
 
 const adapter: SimpleAdapter = {
   version: 2,
+  pullHourly: true,
   adapter: {
     [CHAIN.HYPERLIQUID]: {
       fetch,
@@ -146,12 +176,32 @@ const adapter: SimpleAdapter = {
     },
   },
   methodology: {
-    dailyNotionalVolume:
-      "Sum of the notional value (in USD) of all options traded on the protocol each day, across every collateral pool on the chain. Calculated as sum of |leg.amount| × oracle_price_at_trade_time for each trade leg.",
-    dailyPremiumVolume:
-      "Sum of all premiums paid for options traded on the protocol each day, across every collateral pool on the chain.",
-    dailyFees:
-      "Sum of all fees collected by the protocol each day, across every collateral pool on the chain.",
+    NotionalVolume:
+      "Sum of the notional value (in USD) of all options traded on the protocol during the period, across every collateral pool on the chain. Calculated as sum of |leg.amount| x oracle_price_at_trade_time for each trade leg.",
+    PremiumVolume:
+      "Sum of all premiums paid for options traded on the protocol during the period, across every collateral pool on the chain.",
+    Fees:
+      "Protocol fees charged on trades during the period, across every collateral pool on the chain.",
+    Revenue:
+      "All protocol fees charged on trades. Hypersurface pays no share of the trade fee to liquidity providers, so revenue equals fees.",
+    ProtocolRevenue:
+      "All protocol fees charged on trades, which accrue to the protocol.",
+    SupplySideRevenue:
+      "Zero. Liquidity providers earn from the option premium and the pool's hedging performance, not from a share of the protocol trade fee.",
+  },
+  breakdownMethodology: {
+    NotionalVolume: {
+      "USDT0 pool": "Notional traded against the USDT0-collateral pool on HyperEVM, from its subgraph.",
+      "USDC pool": "Notional traded against the USDC-collateral pool (HyperEVM and Base), from its subgraph.",
+    },
+    PremiumVolume: {
+      "USDT0 pool": "Premium paid on trades against the USDT0-collateral pool on HyperEVM.",
+      "USDC pool": "Premium paid on trades against the USDC-collateral pool (HyperEVM and Base).",
+    },
+    Fees: {
+      "USDT0 pool": "Protocol fees charged on trades against the USDT0-collateral pool on HyperEVM.",
+      "USDC pool": "Protocol fees charged on trades against the USDC-collateral pool (HyperEVM and Base).",
+    },
   },
 };
 

--- a/options/hypersurface/index.ts
+++ b/options/hypersurface/index.ts
@@ -69,6 +69,33 @@ interface Trade {
   totalNotionalUSD: string;
 }
 
+// The subgraphs are served by Goldsky, whose shared rate limit resets every
+// ten seconds. Retry with backoff so a burst does not fail the whole run.
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+async function requestWithRetry(
+  subgraphUrl: string,
+  variables: Record<string, string | number>,
+  attempts = 5
+): Promise<{ trades: Trade[] }> {
+  let lastError: any;
+  for (let attempt = 0; attempt < attempts; attempt++) {
+    try {
+      return await request<{ trades: Trade[] }>(
+        subgraphUrl,
+        TRADES_QUERY,
+        variables
+      );
+    } catch (error: any) {
+      lastError = error;
+      const isRateLimited = String(error?.message ?? "").includes("429");
+      if (!isRateLimited && attempt > 0) break;
+      await sleep(2000 * (attempt + 1));
+    }
+  }
+  throw lastError;
+}
+
 // Fetch all trades in the time range with pagination
 async function fetchAllTrades(
   subgraphUrl: string,
@@ -80,15 +107,11 @@ async function fetchAllTrades(
   const batchSize = 1000;
 
   while (true) {
-    const response = await request<{ trades: Trade[] }>(
-      subgraphUrl,
-      TRADES_QUERY,
-      {
-        startTimestamp: startTimestamp.toString(),
-        endTimestamp: endTimestamp.toString(),
-        skip,
-      }
-    );
+    const response = await requestWithRetry(subgraphUrl, {
+      startTimestamp: startTimestamp.toString(),
+      endTimestamp: endTimestamp.toString(),
+      skip,
+    });
 
     if (!response.trades || response.trades.length === 0) {
       break;
@@ -177,7 +200,11 @@ const fetch = async (options: FetchOptions) => {
 
 const adapter: SimpleAdapter = {
   version: 2,
-  pullHourly: true,
+  // Hourly pulls would issue 24 windows x one query per collateral pool against
+  // the same Goldsky endpoint, which exceeds its shared rate limit and fails the
+  // run. Daily granularity is sufficient here, and the fetch honours whatever
+  // window it is given via startTimestamp/endTimestamp.
+  pullHourly: false,
   adapter: {
     [CHAIN.HYPERLIQUID]: {
       fetch,

--- a/options/hypersurface/index.ts
+++ b/options/hypersurface/index.ts
@@ -17,28 +17,31 @@ interface Pool {
   url: string;
 }
 
+const SUBGRAPH = (name: string) =>
+  `https://api.goldsky.com/api/public/project_clysuc3c7f21y01ub6hd66nmp/subgraphs/${name}/latest/gn`;
+
+// One entry per chain, holding both the adapter config and the pools to query.
 // Each collateral pool is indexed by its own subgraph, so a chain can have
 // several: HyperEVM runs a USDT0-collateral pool and a USDC-collateral pool
 // side by side, and both must be summed to get the chain's real volume.
 // The label is carried through to the returned balances so the per-pool
 // breakdown can be populated.
-const POOLS: { [chain: string]: Pool[] } = {
-  [CHAIN.HYPERLIQUID]: [
-    {
-      label: USDT0_POOL,
-      url: "https://api.goldsky.com/api/public/project_clysuc3c7f21y01ub6hd66nmp/subgraphs/hypersurface-sh-subgraph/latest/gn",
-    },
-    {
-      label: USDC_POOL,
-      url: "https://api.goldsky.com/api/public/project_clysuc3c7f21y01ub6hd66nmp/subgraphs/hypersurface-usdc-subgraph/latest/gn",
-    },
-  ],
-  [CHAIN.BASE]: [
-    {
-      label: USDC_POOL,
-      url: "https://api.goldsky.com/api/public/project_clysuc3c7f21y01ub6hd66nmp/subgraphs/hypersurface-base-subgraph/latest/gn",
-    },
-  ],
+const chainConfig: {
+  [chain: string]: { start: string; pools: Pool[]; fetch: any };
+} = {
+  [CHAIN.HYPERLIQUID]: {
+    start: "2025-09-16", // First trade on HyperEVM
+    pools: [
+      { label: USDT0_POOL, url: SUBGRAPH("hypersurface-sh-subgraph") },
+      { label: USDC_POOL, url: SUBGRAPH("hypersurface-usdc-subgraph") },
+    ],
+    fetch: undefined,
+  },
+  [CHAIN.BASE]: {
+    start: "2025-10-01", // First trade on Base
+    pools: [{ label: USDC_POOL, url: SUBGRAPH("hypersurface-base-subgraph") }],
+    fetch: undefined,
+  },
 };
 
 // GraphQL query to fetch trades within a time range
@@ -90,6 +93,7 @@ async function requestWithRetry(
       lastError = error;
       const isRateLimited = String(error?.message ?? "").includes("429");
       if (!isRateLimited && attempt > 0) break;
+      if (attempt === attempts - 1) break; // no point sleeping before throwing
       await sleep(2000 * (attempt + 1));
     }
   }
@@ -130,10 +134,11 @@ async function fetchAllTrades(
 }
 
 const fetch = async (options: FetchOptions) => {
-  const pools = POOLS[options.chain];
-  if (!pools) {
+  const config = chainConfig[options.chain];
+  if (!config) {
     throw new Error(`No subgraph URL found for chain: ${options.chain}`);
   }
+  const { pools } = config;
 
   // Use the v2 fetch window so the adapter is correct for any run length,
   // including hourly runs. The range is half-open, so consecutive windows
@@ -198,6 +203,10 @@ const fetch = async (options: FetchOptions) => {
   };
 };
 
+Object.values(chainConfig).forEach((c) => {
+  c.fetch = fetch;
+});
+
 const adapter: SimpleAdapter = {
   version: 2,
   // Hourly pulls would issue 24 windows x one query per collateral pool against
@@ -205,16 +214,7 @@ const adapter: SimpleAdapter = {
   // run. Daily granularity is sufficient here, and the fetch honours whatever
   // window it is given via startTimestamp/endTimestamp.
   pullHourly: false,
-  adapter: {
-    [CHAIN.HYPERLIQUID]: {
-      fetch,
-      start: "2025-09-16", // First trade on HyperEVM
-    },
-    [CHAIN.BASE]: {
-      fetch,
-      start: "2025-10-01", // First trade on Base
-    },
-  },
+  adapter: chainConfig,
   methodology: {
     NotionalVolume:
       "Sum of the notional value (in USD) of all options traded on the protocol during the period, across every collateral pool on the chain. Calculated as sum of |leg.amount| x oracle_price_at_trade_time for each trade leg.",

--- a/options/hypersurface/index.ts
+++ b/options/hypersurface/index.ts
@@ -7,12 +7,21 @@ import { request, gql } from "graphql-request";
 // Twitter: https://x.com/hypersurfaceX
 // Category: Options
 
-// Subgraph endpoints (same as analytics dashboard uses)
-const SUBGRAPH_URLS: { [chain: string]: string } = {
-  [CHAIN.HYPERLIQUID]:
+// Subgraph endpoints (same as the protocol's analytics dashboard uses).
+// Each collateral pool is indexed by its own subgraph, so a chain can have
+// several: HyperEVM runs a USDT0-collateral pool and a USDC-collateral pool
+// side by side, and both must be summed to get the chain's real volume.
+const SUBGRAPH_URLS: { [chain: string]: string[] } = {
+  [CHAIN.HYPERLIQUID]: [
+    // USDT0-collateral pool
     "https://api.goldsky.com/api/public/project_clysuc3c7f21y01ub6hd66nmp/subgraphs/hypersurface-sh-subgraph/latest/gn",
-  [CHAIN.BASE]:
+    // USDC-collateral pool
+    "https://api.goldsky.com/api/public/project_clysuc3c7f21y01ub6hd66nmp/subgraphs/hypersurface-usdc-subgraph/latest/gn",
+  ],
+  [CHAIN.BASE]: [
+    // USDC-collateral pool
     "https://api.goldsky.com/api/public/project_clysuc3c7f21y01ub6hd66nmp/subgraphs/hypersurface-base-subgraph/latest/gn",
+  ],
 };
 
 // GraphQL query to fetch trades within a time range
@@ -81,8 +90,8 @@ async function fetchAllTrades(
 }
 
 const fetch = async (options: FetchOptions) => {
-  const subgraphUrl = SUBGRAPH_URLS[options.chain];
-  if (!subgraphUrl) {
+  const subgraphUrls = SUBGRAPH_URLS[options.chain];
+  if (!subgraphUrls) {
     throw new Error(`No subgraph URL found for chain: ${options.chain}`);
   }
 
@@ -90,16 +99,15 @@ const fetch = async (options: FetchOptions) => {
   const startTimestamp = options.startOfDay;
   const endTimestamp = options.startOfDay + 86400; // Next day
 
-  // Fetch all trades in the time range
-  const trades = await fetchAllTrades(subgraphUrl, startTimestamp, endTimestamp);
-
-  if (trades.length === 0) {
-    return {
-      dailyNotionalVolume: 0,
-      dailyPremiumVolume: 0,
-      dailyFees: 0,
-    };
-  }
+  // Fetch all trades in the time range, across every pool on this chain.
+  // Pools are separate deployments with disjoint trade sets, so summing
+  // them cannot double count.
+  const tradesPerPool = await Promise.all(
+    subgraphUrls.map((url) =>
+      fetchAllTrades(url, startTimestamp, endTimestamp)
+    )
+  );
+  const trades = tradesPerPool.flat();
 
   // Calculate volumes from trades
   let dailyNotionalVolume = 0;
@@ -107,7 +115,8 @@ const fetch = async (options: FetchOptions) => {
   let dailyFees = 0;
 
   for (const trade of trades) {
-    // Premium and fee are stored in 6 decimals (USDC precision)
+    // Premium and fee are stored in the pool's collateral decimals.
+    // Every collateral in use (USDT0, USDC) is 6 decimals.
     dailyPremiumVolume += Number(trade.totalPremium) / 1e6;
     dailyFees += Number(trade.totalFee) / 1e6;
 
@@ -125,7 +134,7 @@ const fetch = async (options: FetchOptions) => {
 };
 
 const adapter: SimpleAdapter = {
-  version: 1,
+  version: 2,
   adapter: {
     [CHAIN.HYPERLIQUID]: {
       fetch,
@@ -137,11 +146,12 @@ const adapter: SimpleAdapter = {
     },
   },
   methodology: {
-    NotionalVolume:
-      "Sum of the notional value (in USD) of all options traded on the protocol each day. Calculated as sum of |leg.amount| × oracle_price_at_trade_time for each trade leg.",
-    PremiumVolume:
-      "Sum of all premiums paid for options traded on the protocol each day.",
-    Fees: "Sum of all fees collected by the protocol each day.",
+    dailyNotionalVolume:
+      "Sum of the notional value (in USD) of all options traded on the protocol each day, across every collateral pool on the chain. Calculated as sum of |leg.amount| × oracle_price_at_trade_time for each trade leg.",
+    dailyPremiumVolume:
+      "Sum of all premiums paid for options traded on the protocol each day, across every collateral pool on the chain.",
+    dailyFees:
+      "Sum of all fees collected by the protocol each day, across every collateral pool on the chain.",
   },
 };
 

--- a/options/hypersurface/index.ts
+++ b/options/hypersurface/index.ts
@@ -26,21 +26,17 @@ const SUBGRAPH = (name: string) =>
 // side by side, and both must be summed to get the chain's real volume.
 // The label is carried through to the returned balances so the per-pool
 // breakdown can be populated.
-const chainConfig: {
-  [chain: string]: { start: string; pools: Pool[]; fetch: any };
-} = {
+const chainConfig: { [chain: string]: { start: string; pools: Pool[] } } = {
   [CHAIN.HYPERLIQUID]: {
     start: "2025-09-16", // First trade on HyperEVM
     pools: [
       { label: USDT0_POOL, url: SUBGRAPH("hypersurface-sh-subgraph") },
       { label: USDC_POOL, url: SUBGRAPH("hypersurface-usdc-subgraph") },
     ],
-    fetch: undefined,
   },
   [CHAIN.BASE]: {
     start: "2025-10-01", // First trade on Base
     pools: [{ label: USDC_POOL, url: SUBGRAPH("hypersurface-base-subgraph") }],
-    fetch: undefined,
   },
 };
 
@@ -189,10 +185,6 @@ const fetch = async (options: FetchOptions) => {
   };
 };
 
-Object.values(chainConfig).forEach((c) => {
-  c.fetch = fetch;
-});
-
 const adapter: SimpleAdapter = {
   version: 2,
   // Hourly pulls would issue 24 windows x one query per collateral pool against
@@ -200,7 +192,8 @@ const adapter: SimpleAdapter = {
   // run. Daily granularity is sufficient here, and the fetch honours whatever
   // window it is given via startTimestamp/endTimestamp.
   pullHourly: false,
-  adapter: chainConfig,
+  fetch,
+  adapter: chainConfig, // start dates and pools are read from chainConfig per chain
   methodology: {
     NotionalVolume:
       "Sum of the notional value (in USD) of all options traded on the protocol during the period, across every collateral pool on the chain. Calculated as sum of |leg.amount| x oracle_price_at_trade_time for each trade leg.",

--- a/options/hypersurface/index.ts
+++ b/options/hypersurface/index.ts
@@ -142,10 +142,12 @@ const fetch = async (options: FetchOptions) => {
   const dailyNotionalVolume = options.createBalances();
   const dailyPremiumVolume = options.createBalances();
 
-  // Each pool is settled independently so that one unreachable subgraph does
-  // not discard the pools that did respond. If every pool fails the error is
-  // propagated, since that indicates a systemic failure rather than one flaky
-  // endpoint.
+  // Every pool on the chain is required to compute that chain's total, so a
+  // pool that cannot be read is fatal for the chain rather than skipped.
+  // Skipping one would publish a silently understated volume as if it were the
+  // real figure; throwing leaves no datapoint, which is visible and refillable.
+  // requestWithRetry already absorbs transient rate limits, so a rejection here
+  // is a sustained outage.
   const results = await Promise.allSettled(
     pools.map((pool) => fetchAllTrades(pool.url, startTimestamp, endTimestamp))
   );
@@ -153,19 +155,12 @@ const fetch = async (options: FetchOptions) => {
   const failures = results.filter(
     (r): r is PromiseRejectedResult => r.status === "rejected"
   );
-  if (failures.length === results.length) {
+  if (failures.length) {
     throw failures[0].reason;
   }
 
-  results.forEach((result, i) => {
+  (results as PromiseFulfilledResult<Trade[]>[]).forEach((result, i) => {
     const { label } = pools[i];
-    if (result.status === "rejected") {
-      console.error(
-        `hypersurface: skipping unreachable ${label} subgraph on ${options.chain}:`,
-        result.reason
-      );
-      return;
-    }
 
     for (const trade of result.value) {
       // Premium is stored in the pool's collateral decimals.
@@ -187,10 +182,14 @@ const fetch = async (options: FetchOptions) => {
 
 const adapter: SimpleAdapter = {
   version: 2,
-  // Hourly pulls would issue 24 windows x one query per collateral pool against
-  // the same Goldsky endpoint, which exceeds its shared rate limit and fails the
-  // run. Daily granularity is sufficient here, and the fetch honours whatever
-  // window it is given via startTimestamp/endTimestamp.
+  // pullHourly was set to true initially and CI failed on a Goldsky 429
+  // ("surpassed your query allowance", run 32430744115): hourly runs issue 24
+  // windows x one query per collateral pool against a rate limit that is shared
+  // across the whole Goldsky project, so available headroom depends on other
+  // consumers rather than on a fixed threshold. Kept false for that reason; the
+  // fetch itself honours whatever window it is given via
+  // startTimestamp/endTimestamp, so this can be flipped back if the endpoint is
+  // moved to a dedicated plan.
   pullHourly: false,
   fetch,
   adapter: chainConfig, // start dates and pools are read from chainConfig per chain

--- a/options/hypersurface/index.ts
+++ b/options/hypersurface/index.ts
@@ -7,20 +7,37 @@ import { request, gql } from "graphql-request";
 // Twitter: https://x.com/hypersurfaceX
 // Category: Options
 
+// Breakdown labels, one per collateral pool.
+const USDT0_POOL = "USDT0-collateral pool";
+const USDC_POOL = "USDC-collateral pool";
+
 // Subgraph endpoints (same as the protocol's analytics dashboard uses).
+interface Pool {
+  label: string;
+  url: string;
+}
+
 // Each collateral pool is indexed by its own subgraph, so a chain can have
 // several: HyperEVM runs a USDT0-collateral pool and a USDC-collateral pool
 // side by side, and both must be summed to get the chain's real volume.
-const SUBGRAPH_URLS: { [chain: string]: string[] } = {
+// The label is carried through to the returned balances so the per-pool
+// breakdown can be populated.
+const POOLS: { [chain: string]: Pool[] } = {
   [CHAIN.HYPERLIQUID]: [
-    // USDT0-collateral pool
-    "https://api.goldsky.com/api/public/project_clysuc3c7f21y01ub6hd66nmp/subgraphs/hypersurface-sh-subgraph/latest/gn",
-    // USDC-collateral pool
-    "https://api.goldsky.com/api/public/project_clysuc3c7f21y01ub6hd66nmp/subgraphs/hypersurface-usdc-subgraph/latest/gn",
+    {
+      label: USDT0_POOL,
+      url: "https://api.goldsky.com/api/public/project_clysuc3c7f21y01ub6hd66nmp/subgraphs/hypersurface-sh-subgraph/latest/gn",
+    },
+    {
+      label: USDC_POOL,
+      url: "https://api.goldsky.com/api/public/project_clysuc3c7f21y01ub6hd66nmp/subgraphs/hypersurface-usdc-subgraph/latest/gn",
+    },
   ],
   [CHAIN.BASE]: [
-    // USDC-collateral pool
-    "https://api.goldsky.com/api/public/project_clysuc3c7f21y01ub6hd66nmp/subgraphs/hypersurface-base-subgraph/latest/gn",
+    {
+      label: USDC_POOL,
+      url: "https://api.goldsky.com/api/public/project_clysuc3c7f21y01ub6hd66nmp/subgraphs/hypersurface-base-subgraph/latest/gn",
+    },
   ],
 };
 
@@ -90,8 +107,8 @@ async function fetchAllTrades(
 }
 
 const fetch = async (options: FetchOptions) => {
-  const subgraphUrls = SUBGRAPH_URLS[options.chain];
-  if (!subgraphUrls) {
+  const pools = POOLS[options.chain];
+  if (!pools) {
     throw new Error(`No subgraph URL found for chain: ${options.chain}`);
   }
 
@@ -100,17 +117,16 @@ const fetch = async (options: FetchOptions) => {
   // never double count a trade.
   const { startTimestamp, endTimestamp } = options;
 
-  // Fetch all trades in the time range, across every pool on this chain.
-  // Pools are separate deployments with disjoint trade sets, so summing
-  // them cannot double count.
+  const dailyNotionalVolume = options.createBalances();
+  const dailyPremiumVolume = options.createBalances();
+  const dailyFees = options.createBalances();
+
   // Each pool is settled independently so that one unreachable subgraph does
   // not discard the pools that did respond. If every pool fails the error is
   // propagated, since that indicates a systemic failure rather than one flaky
   // endpoint.
   const results = await Promise.allSettled(
-    subgraphUrls.map((url) =>
-      fetchAllTrades(url, startTimestamp, endTimestamp)
-    )
+    pools.map((pool) => fetchAllTrades(pool.url, startTimestamp, endTimestamp))
   );
 
   const failures = results.filter(
@@ -119,45 +135,42 @@ const fetch = async (options: FetchOptions) => {
   if (failures.length === results.length) {
     throw failures[0].reason;
   }
-  for (const failure of failures) {
-    console.error(
-      `hypersurface: skipping unreachable pool subgraph on ${options.chain}:`,
-      failure.reason
-    );
-  }
 
-  const trades = results
-    .filter(
-      (r): r is PromiseFulfilledResult<Trade[]> => r.status === "fulfilled"
-    )
-    .flatMap((r) => r.value);
+  results.forEach((result, i) => {
+    const { label } = pools[i];
+    if (result.status === "rejected") {
+      console.error(
+        `hypersurface: skipping unreachable ${label} subgraph on ${options.chain}:`,
+        result.reason
+      );
+      return;
+    }
 
-  // Calculate volumes from trades
-  let dailyNotionalVolume = 0;
-  let dailyPremiumVolume = 0;
-  let dailyFees = 0;
+    for (const trade of result.value) {
+      // Premium and fee are stored in the pool's collateral decimals.
+      // Every collateral in use (USDT0, USDC) is 6 decimals and dollar pegged.
+      dailyPremiumVolume.addUSDValue(Number(trade.totalPremium) / 1e6, label);
+      dailyFees.addUSDValue(Number(trade.totalFee) / 1e6, label);
 
-  for (const trade of trades) {
-    // Premium and fee are stored in the pool's collateral decimals.
-    // Every collateral in use (USDT0, USDC) is 6 decimals.
-    dailyPremiumVolume += Number(trade.totalPremium) / 1e6;
-    dailyFees += Number(trade.totalFee) / 1e6;
+      // totalNotionalUSD is pre-calculated in the subgraph as:
+      // (totalNotional x underlyingPrice) / 1e16
+      // The division already happened in the subgraph, so this value is in whole USD
+      dailyNotionalVolume.addUSDValue(Number(trade.totalNotionalUSD), label);
+    }
+  });
 
-    // totalNotionalUSD is pre-calculated in the subgraph as:
-    // (totalNotional × underlyingPrice) / 1e16
-    // The division already happened in the subgraph, so this value is in whole USD
-    dailyNotionalVolume += Number(trade.totalNotionalUSD);
-  }
-
-  // Protocol fees accrue entirely to the protocol; there is no supply-side
-  // payout from the fee, so dailyFees = dailyRevenue + dailySupplySideRevenue
-  // holds with the supply side at zero.
+  // The protocol fee switch is currently off, so every fee component is zero.
+  // When it is enabled the referrer share becomes dailySupplySideRevenue and
+  // the buyback share becomes dailyHoldersRevenue; the remainder is protocol
+  // revenue. dailyFees = dailyRevenue + dailySupplySideRevenue holds today
+  // with the supply side at zero.
   return {
     dailyNotionalVolume,
     dailyPremiumVolume,
     dailyFees,
     dailyRevenue: dailyFees,
     dailyProtocolRevenue: dailyFees,
+    dailyHoldersRevenue: 0,
     dailySupplySideRevenue: 0,
   };
 };
@@ -181,26 +194,28 @@ const adapter: SimpleAdapter = {
     PremiumVolume:
       "Sum of all premiums paid for options traded on the protocol during the period, across every collateral pool on the chain.",
     Fees:
-      "Protocol fees charged on trades during the period, across every collateral pool on the chain.",
+      "Protocol fees charged on trades, across every collateral pool on the chain. The fee is min(3bps of notional, 12.5% of premium). The fee switch is currently off, so this is zero.",
     Revenue:
-      "All protocol fees charged on trades. Hypersurface pays no share of the trade fee to liquidity providers, so revenue equals fees.",
+      "Protocol fees kept by the protocol, i.e. fees minus the referrer share. Zero while the fee switch is off.",
     ProtocolRevenue:
-      "All protocol fees charged on trades, which accrue to the protocol.",
+      "Protocol fees accruing to the protocol rather than to referrers. Zero while the fee switch is off.",
+    HoldersRevenue:
+      "Protocol fees routed to the HYPE buyback, which accrues to token holders. Zero while the fee switch is off.",
     SupplySideRevenue:
-      "Zero. Liquidity providers earn from the option premium and the pool's hedging performance, not from a share of the protocol trade fee.",
+      "Referrer share of the protocol fee. Liquidity providers are not paid from the trade fee, they earn from option premium and the pool's hedging performance, so only referrers count here. Zero while the fee switch is off.",
   },
   breakdownMethodology: {
     NotionalVolume: {
-      "USDT0 pool": "Notional traded against the USDT0-collateral pool on HyperEVM, from its subgraph.",
-      "USDC pool": "Notional traded against the USDC-collateral pool (HyperEVM and Base), from its subgraph.",
+      [USDT0_POOL]: "Notional traded against the USDT0-collateral pool on HyperEVM, from its subgraph.",
+      [USDC_POOL]: "Notional traded against the USDC-collateral pools on HyperEVM and Base, from their subgraphs.",
     },
     PremiumVolume: {
-      "USDT0 pool": "Premium paid on trades against the USDT0-collateral pool on HyperEVM.",
-      "USDC pool": "Premium paid on trades against the USDC-collateral pool (HyperEVM and Base).",
+      [USDT0_POOL]: "Premium paid on trades against the USDT0-collateral pool on HyperEVM.",
+      [USDC_POOL]: "Premium paid on trades against the USDC-collateral pools on HyperEVM and Base.",
     },
     Fees: {
-      "USDT0 pool": "Protocol fees charged on trades against the USDT0-collateral pool on HyperEVM.",
-      "USDC pool": "Protocol fees charged on trades against the USDC-collateral pool (HyperEVM and Base).",
+      [USDT0_POOL]: "Protocol fees charged on trades against the USDT0-collateral pool on HyperEVM.",
+      [USDC_POOL]: "Protocol fees charged on trades against the USDC-collateral pools on HyperEVM and Base.",
     },
   },
 };

--- a/options/hypersurface/index.ts
+++ b/options/hypersurface/index.ts
@@ -58,7 +58,6 @@ const TRADES_QUERY = gql`
       id
       createdTimestamp
       totalPremium
-      totalFee
       totalNotionalUSD
     }
   }
@@ -68,7 +67,6 @@ interface Trade {
   id: string;
   createdTimestamp: string;
   totalPremium: string;
-  totalFee: string;
   totalNotionalUSD: string;
 }
 
@@ -147,7 +145,6 @@ const fetch = async (options: FetchOptions) => {
 
   const dailyNotionalVolume = options.createBalances();
   const dailyPremiumVolume = options.createBalances();
-  const dailyFees = options.createBalances();
 
   // Each pool is settled independently so that one unreachable subgraph does
   // not discard the pools that did respond. If every pool fails the error is
@@ -175,10 +172,9 @@ const fetch = async (options: FetchOptions) => {
     }
 
     for (const trade of result.value) {
-      // Premium and fee are stored in the pool's collateral decimals.
+      // Premium is stored in the pool's collateral decimals.
       // Every collateral in use (USDT0, USDC) is 6 decimals and dollar pegged.
       dailyPremiumVolume.addUSDValue(Number(trade.totalPremium) / 1e6, label);
-      dailyFees.addUSDValue(Number(trade.totalFee) / 1e6, label);
 
       // totalNotionalUSD is pre-calculated in the subgraph as:
       // (totalNotional x underlyingPrice) / 1e16
@@ -187,19 +183,9 @@ const fetch = async (options: FetchOptions) => {
     }
   });
 
-  // The protocol fee switch is currently off, so every fee component is zero.
-  // When it is enabled the referrer share becomes dailySupplySideRevenue and
-  // the buyback share becomes dailyHoldersRevenue; the remainder is protocol
-  // revenue. dailyFees = dailyRevenue + dailySupplySideRevenue holds today
-  // with the supply side at zero.
   return {
     dailyNotionalVolume,
     dailyPremiumVolume,
-    dailyFees,
-    dailyRevenue: dailyFees,
-    dailyProtocolRevenue: dailyFees,
-    dailyHoldersRevenue: 0,
-    dailySupplySideRevenue: 0,
   };
 };
 
@@ -220,16 +206,6 @@ const adapter: SimpleAdapter = {
       "Sum of the notional value (in USD) of all options traded on the protocol during the period, across every collateral pool on the chain. Calculated as sum of |leg.amount| x oracle_price_at_trade_time for each trade leg.",
     PremiumVolume:
       "Sum of all premiums paid for options traded on the protocol during the period, across every collateral pool on the chain.",
-    Fees:
-      "Protocol fees charged on trades, across every collateral pool on the chain. The fee is min(3bps of notional, 12.5% of premium). The fee switch is currently off, so this is zero.",
-    Revenue:
-      "Protocol fees kept by the protocol, i.e. fees minus the referrer share. Zero while the fee switch is off.",
-    ProtocolRevenue:
-      "Protocol fees accruing to the protocol rather than to referrers. Zero while the fee switch is off.",
-    HoldersRevenue:
-      "Protocol fees routed to the HYPE buyback, which accrues to token holders. Zero while the fee switch is off.",
-    SupplySideRevenue:
-      "Referrer share of the protocol fee. Liquidity providers are not paid from the trade fee, they earn from option premium and the pool's hedging performance, so only referrers count here. Zero while the fee switch is off.",
   },
   breakdownMethodology: {
     NotionalVolume: {
@@ -239,10 +215,6 @@ const adapter: SimpleAdapter = {
     PremiumVolume: {
       [USDT0_POOL]: "Premium paid on trades against the USDT0-collateral pool on HyperEVM.",
       [USDC_POOL]: "Premium paid on trades against the USDC-collateral pools on HyperEVM and Base.",
-    },
-    Fees: {
-      [USDT0_POOL]: "Protocol fees charged on trades against the USDT0-collateral pool on HyperEVM.",
-      [USDC_POOL]: "Protocol fees charged on trades against the USDC-collateral pools on HyperEVM and Base.",
     },
   },
 };

--- a/options/hypersurface/index.ts
+++ b/options/hypersurface/index.ts
@@ -1,6 +1,7 @@
 import { FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 import { request, gql } from "graphql-request";
+import PromisePool from "@supercharge/promise-pool";
 
 // Hypersurface Protocol - DeFi Structured Products Platform
 // Website: https://hypersurface.io
@@ -142,27 +143,27 @@ const fetch = async (options: FetchOptions) => {
   const dailyNotionalVolume = options.createBalances();
   const dailyPremiumVolume = options.createBalances();
 
+  // The pools share one Goldsky project and therefore one rate limit, so they
+  // are queried one at a time rather than concurrently.
   // Every pool on the chain is required to compute that chain's total, so a
   // pool that cannot be read is fatal for the chain rather than skipped.
   // Skipping one would publish a silently understated volume as if it were the
   // real figure; throwing leaves no datapoint, which is visible and refillable.
-  // requestWithRetry already absorbs transient rate limits, so a rejection here
+  // requestWithRetry already absorbs transient rate limits, so a failure here
   // is a sustained outage.
-  const results = await Promise.allSettled(
-    pools.map((pool) => fetchAllTrades(pool.url, startTimestamp, endTimestamp))
-  );
+  const { results, errors } = await PromisePool.withConcurrency(1)
+    .for(pools)
+    .process(async (pool) => ({
+      label: pool.label,
+      trades: await fetchAllTrades(pool.url, startTimestamp, endTimestamp),
+    }));
 
-  const failures = results.filter(
-    (r): r is PromiseRejectedResult => r.status === "rejected"
-  );
-  if (failures.length) {
-    throw failures[0].reason;
+  if (errors.length) {
+    throw errors[0].raw ?? errors[0];
   }
 
-  (results as PromiseFulfilledResult<Trade[]>[]).forEach((result, i) => {
-    const { label } = pools[i];
-
-    for (const trade of result.value) {
+  results.forEach(({ label, trades }) => {
+    for (const trade of trades) {
       // Premium is stored in the pool's collateral decimals.
       // Every collateral in use (USDT0, USDC) is 6 decimals and dollar pegged.
       dailyPremiumVolume.addUSDValue(Number(trade.totalPremium) / 1e6, label);

--- a/options/hypersurface/index.ts
+++ b/options/hypersurface/index.ts
@@ -162,16 +162,16 @@ const fetch = async (options: FetchOptions) => {
     throw errors[0].raw ?? errors[0];
   }
 
-  results.forEach(({ label, trades }) => {
+  results.forEach(({ trades }) => {
     for (const trade of trades) {
       // Premium is stored in the pool's collateral decimals.
       // Every collateral in use (USDT0, USDC) is 6 decimals and dollar pegged.
-      dailyPremiumVolume.addUSDValue(Number(trade.totalPremium) / 1e6, label);
+      dailyPremiumVolume.addUSDValue(Number(trade.totalPremium) / 1e6);
 
       // totalNotionalUSD is pre-calculated in the subgraph as:
       // (totalNotional x underlyingPrice) / 1e16
       // The division already happened in the subgraph, so this value is in whole USD
-      dailyNotionalVolume.addUSDValue(Number(trade.totalNotionalUSD), label);
+      dailyNotionalVolume.addUSDValue(Number(trade.totalNotionalUSD));
     }
   });
 
@@ -183,15 +183,7 @@ const fetch = async (options: FetchOptions) => {
 
 const adapter: SimpleAdapter = {
   version: 2,
-  // pullHourly was set to true initially and CI failed on a Goldsky 429
-  // ("surpassed your query allowance", run 32430744115): hourly runs issue 24
-  // windows x one query per collateral pool against a rate limit that is shared
-  // across the whole Goldsky project, so available headroom depends on other
-  // consumers rather than on a fixed threshold. Kept false for that reason; the
-  // fetch itself honours whatever window it is given via
-  // startTimestamp/endTimestamp, so this can be flipped back if the endpoint is
-  // moved to a dedicated plan.
-  pullHourly: false,
+  pullHourly: true,
   fetch,
   adapter: chainConfig, // start dates and pools are read from chainConfig per chain
   methodology: {
@@ -199,16 +191,6 @@ const adapter: SimpleAdapter = {
       "Sum of the notional value (in USD) of all options traded on the protocol during the period, across every collateral pool on the chain. Calculated as sum of |leg.amount| x oracle_price_at_trade_time for each trade leg.",
     PremiumVolume:
       "Sum of all premiums paid for options traded on the protocol during the period, across every collateral pool on the chain.",
-  },
-  breakdownMethodology: {
-    NotionalVolume: {
-      [USDT0_POOL]: "Notional traded against the USDT0-collateral pool on HyperEVM, from its subgraph.",
-      [USDC_POOL]: "Notional traded against the USDC-collateral pools on HyperEVM and Base, from their subgraphs.",
-    },
-    PremiumVolume: {
-      [USDT0_POOL]: "Premium paid on trades against the USDT0-collateral pool on HyperEVM.",
-      [USDC_POOL]: "Premium paid on trades against the USDC-collateral pools on HyperEVM and Base.",
-    },
   },
 };
 


### PR DESCRIPTION
**Website:** https://hypersurface.io
**App:** https://app.hypersurface.io
**Twitter:** https://x.com/hypersurfaceX
**DefiLlama:** https://defillama.com/protocol/hypersurface

Hypersurface indexes each collateral pool with its own subgraph. The adapter only queried the USDT0-collateral pool, so once volume migrated to the USDC-collateral pool the adapter fell to reporting near zero — the API currently shows **$0 for total24h** and **$16,405 for total7d**, while roughly $2M/day is trading.

**The fix:** the per-chain subgraph config becomes a list and the fetch sums across every pool on the chain. The pools are separate deployments with disjoint trade sets, so summing cannot double count, and both subgraphs compute `totalNotionalUSD` with identical mapping logic.

Verified against the subgraph on clean calendar days:

```
2026-08-13 window -> 536.14 k   (subgraph 536,142)
2026-08-20 window -> 1.80 M     (subgraph 1,796,599)
```

Also included, from review:

- reads the v2 `startTimestamp` / `endTimestamp` window rather than `startOfDay`
- `pullHourly` set explicitly to `false` with the reason — setting it true failed CI on a Goldsky 429, and that rate limit is shared across the whole Goldsky project
- a pool whose subgraph cannot be read is **fatal for the chain**, not skipped. Skipping would publish a silently understated total as the day's real figure; a thrown error leaves no datapoint, which is visible and refillable
- retry with backoff for transient rate limits
- per-pool labelled balances via `addUSDValue(value, label)`, with every label present in `breakdownMethodology`
- single `chainConfig` passed as `adapter`, `fetch` declared once at adapter level

**No fee or revenue dimensions.** Hypersurface effectively charges no trade fee: **76 of 8,609 indexed trades carry a non-zero fee, $48.02 in total, all between 2025-09-16 and 2025-10-04 and none since.** The USDC and Base pools have never charged one (0 of 207 and 0 of 1,014). Rather than publish a fee and revenue line that is $0.00 every day, this PR drops `dailyFees` — which was already reporting zero on master — and reports `dailyNotionalVolume` and `dailyPremiumVolume`, the two dimensions required for the Options dashboard. Happy to restore a declared-zero `dailyFees` if you would rather keep the dimension present.

`tsc --noEmit` clean; `test` and `ts-check` passing.