### PR TITLE
[feat] resolvium - track HIP-4 builder volume and fees

### DIFF
--- a/factory/hyperliquid.ts
+++ b/factory/hyperliquid.ts
@@ -350,6 +350,16 @@ const builderConfigs: Record<string, BuilderConfig> = {
     start: "2026-05-13",
     market: "hip4",
   },
+  "resolvium": {
+    // Protocol: https://www.resolvium.xyz/
+    // Builder verified from Resolvium's Hyperliquid Mainnet
+    // approveBuilderFee action.
+    // Historical fills:
+    // https://stats-data.hyperliquid.xyz/Mainnet/builder_fills/0x90536b9d94d65c9fabd372002bdfc2ef012231b2/20260527.csv.lz4
+    addresses: ["0x90536b9d94d65c9fabd372002bdfc2ef012231b2"],
+    start: "2026-05-27",
+    market: "hip4",
+  },
   "pear-interface": {
     addresses: ["0xa47d4d99191db54a4829cdf3de2417e527c3b042"],
     start: "2025-07-08",


### PR DESCRIPTION
## Summary

- Adds Resolvium as a Hyperliquid HIP-4 prediction/outcome market builder.
- Tracks builder-attributed HIP-4 trading volume through the existing Hyperliquid factory.
- Uses `market: "hip4"` so only HIP-4 `#<asset>` fills are included.
- Opened as a draft because historical builder activity is limited to three low-volume days in May 2026.
- Related to #7602.

## Protocol Details

- Protocol: Resolvium
- Website: https://www.resolvium.xyz/
- Chain: Hyperliquid
- Market: HIP-4 outcome markets
- Builder address: `0x90536b9d94d65c9fabd372002bdfc2ef012231b2`
- Start date: `2026-05-27`

## Builder Address

The builder address was verified from Resolvium's current Hyperliquid Mainnet `approveBuilderFee` action:

    type: approveBuilderFee
    hyperliquidChain: Mainnet
    builder: 0x90536b9d94d65c9fabd372002bdfc2ef012231b2

Hyperliquid also publishes historical builder fills for this exact address:

https://stats-data.hyperliquid.xyz/Mainnet/builder_fills/0x90536b9d94d65c9fabd372002bdfc2ef012231b2/20260527.csv.lz4

## Historical Validation

Historical builder-fill data is sparse, but all observed fills are exclusively HIP-4 assets.

| Fill date | HIP-4 rows | Non-HIP-4 rows | Raw notional | Builder fees |
|---|---:|---:|---:|---:|
| 2026-05-27 | 2 | 0 | $29.10015 | $0 |
| 2026-05-28 | 4 | 0 | $58.48575 | $0 |
| 2026-05-29 | 8 | 0 | $108.37128 | $0 |

## Draft Status / Data Quality

This PR is intentionally opened as a draft because Resolvium's historical builder activity is very sparse.

The builder has confirmed HIP-4 fills on May 27-29, 2026, totaling approximately $196 in raw notional. No additional builder-fill files were found from May 30 through August 19, 2026.

The integration is nevertheless verifiable:

- Resolvium currently requests approval for this exact builder address through a Hyperliquid Mainnet `approveBuilderFee` action.
- Hyperliquid publishes completed historical builder-fill files for the address.
- All 14 observed fills are HIP-4 `#<asset>` fills, with zero non-HIP-4 activity.

The draft is intended to let maintainers decide whether the confirmed attribution is sufficient for inclusion despite the low and stale historical activity.

Adapter validation:

    TZ=UTC pnpm test dexs resolvium 2026-05-28
    Daily volume: 29.00
    Daily fees: 0.00

    TZ=UTC pnpm test dexs resolvium 2026-05-29
    Daily volume: 58.00
    Daily fees: 0.00

    TZ=UTC pnpm test dexs resolvium 2026-05-30
    Daily volume: 108.00
    Daily fees: 0.00

The fees surface was also validated on the same three completed historical dates and returned zero builder fees, matching the raw Hyperliquid builder-fill data.

## Tests

- `TZ=UTC pnpm test dexs resolvium 2026-05-28`
- `TZ=UTC pnpm test dexs resolvium 2026-05-29`
- `TZ=UTC pnpm test dexs resolvium 2026-05-30`
- `TZ=UTC pnpm test fees resolvium 2026-05-28`
- `TZ=UTC pnpm test fees resolvium 2026-05-29`
- `TZ=UTC pnpm test fees resolvium 2026-05-30`
- `pnpm ts-check`
- `git diff --check`