### PR TITLE
lyra-market: set doublecounted, its volume executes in Uniswap pools

### DIFF
--- a/fees/lyra-market.ts
+++ b/fees/lyra-market.ts
@@ -129,6 +129,9 @@ const breakdownMethodology = {
 const adapter: Adapter = {
   version: 2,
   pullHourly: true,
+  // The router is an interface on top of Uniswap: every swap it reports executes in a
+  // Uniswap v2/v3/v4 pool that Uniswap's own adapter already counts.
+  doublecounted: true,
   fetch,
   chains: [CHAIN.ETHEREUM],
   start: "2026-07-16",


### PR DESCRIPTION
`fees/lyra-market.ts` already states that its volume double counts Uniswap, in two places, but never sets the flag.

The file comment:

> It custodies nothing, and the pool liquidity it trades against belongs to Uniswap LPs — so Lyra reports no TVL of its own for this product, and the volume below also executes on Uniswap -> doublecounted.

and the Volume methodology:

> As with any aggregator, this volume also executes on Uniswap and is counted there under Uniswap's own adapter.

So the notional is currently added to the DEX aggregate on top of Uniswap's own count. This sets `doublecounted: true`.

### Verifying the routing at the address level

Rather than take the comment's word for it, I took a recent `InterfaceFeeCollected` log from LyraSwapRouter `0xDF39355e24e6e92Ca9D00180e687dd131B6B7ee5` and read the pool the swap actually went through.

Tx `0x6ce91d529e8e0797f34675ba52be57e083a2786ab0e8d2c83ac682e9a7a9e4d0`, pool `0x970a7749ecaa4394c8b2bf5f2471f41fd6b79288`:

| call | value |
| --- | --- |
| `factory()` | `0x1F98431c8aD98523631AE4a59f267346ea31F984` (Uniswap V3 factory) |
| `token0()` | `0x437cc33344a0B27A429f795ff6B469C72698B291` (wM) |
| `token1()` | `0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48` (USDC) |
| `fee()` | `100` |

It is a real Uniswap V3 pool, so the notional is real Uniswap V3 volume.

Volume affected is 11.6k/day, 130k over 7d, 380k all time.

### Fees are not affected

The 0.20% interface fee is Lyra's own and Uniswap does not count it, so I checked that the flag would not suppress the fee series. It does not: `eulerswap` carries `doublecounted: true` and still publishes both fees (0.53/24h) and volume (9.35k/24h). 25 other adapters in the repo set the flag while returning `dailyVolume` and `dailyFees` from the same adapter, so this shape is the normal one.

While in the file I also confirmed the rate the adapter assumes is still right: `feeBps()` reads `20` live, and `FeeBpsUpdated` has never fired since the deploy block, which is what `INITIAL_FEE_BPS` relies on.

### Test

`npm run test fees lyra-market`

```
Daily volume: 11.22 k
Daily fees: 22.43
Daily user fees: 22.43
Daily revenue: 22.43
Daily protocol revenue: 22.43
```

22.43 / 11.22k is 0.1999%, matching the 0.20% rate, and matching the published series (11,602 volume / 23.2 fees).
