### PR TITLE
curators: drop block-analitica's Base vaults, moonwell-vaults already books them

### DIFF
--- a/factory/curators.ts
+++ b/factory/curators.ts
@@ -92,9 +92,10 @@ const configs: Record<string, CuratorConfig> = {
       [CHAIN.ETHEREUM]: {
         morpho: ['0x38989BBA00BDF8181F4082995b3DEAe96163aC5D', '0x2C25f6C25770fFEC5959D34B94Bf898865e5D6b1', '0x186514400e52270cef3D80e1c6F8d10A75d47344'],
       },
-      [CHAIN.BASE]: {
-        morpho: ['0xa0E430870c4604CcfC7B38Ca7845B1FF653D0ff1', '0xc1256Ae5FF1cf2719D4937adb3bbCCab2E00A2Ca', '0x543257eF2161176D7C8cD90BA65C2d4CaEF5a796', '0xf24608E0CCb972b0b0f4A6446a0BBf58c701a026'],
-      },
+      // The four Base Moonwell vaults that used to be listed here are already
+      // resolved by the moonwell-vaults owner below, so both entries booked the
+      // same fees. Morpho's API also reports their curator as Anthias Labs, not
+      // Block Analitica.
     },
   },
   "clearstar": {


### PR DESCRIPTION
`block-analitica` lists four Base Moonwell vaults explicitly, and `moonwell-vaults` resolves the same four through its `morphoVaultOwners` entry (`0x17e7bB9fe7983947FdCf02c1E3d8e6C92C21da54`). Both entries have been booking the same fees.

### Proven locally, not inferred

Same shell, same window, on master before the change:

| entry | chain | fees | revenue | supply side |
| --- | --- | --- | --- | --- |
| `block-analitica` | base | 1169 | 175 | 994 |
| `moonwell-vaults` | base | 1169 | 175 | 994 |

Identical on all three metrics.

The published series says the same thing. Base reads the same value under both names, while `block-analitica`'s Ethereum leg reads exactly 0 every day:

| day | block-analitica Base | moonwell-vaults Base | block-analitica Ethereum |
| --- | --- | --- | --- |
| 08-17 | 1272 | 1272 | 0 |
| 08-18 | 1101 | 1101 | 0 |
| 08-19 | 1106 | 1126 | 0 |
| 08-20 | 1205 | 1205 | 0 |
| 08-21 | 1183 | 1167 | 0 |

### Attribution also points away from Block Analitica

Morpho's API reports the curator of all four as **Anthias Labs**:

| vault | name | assets |
| --- | --- | --- |
| `0xa0E430870c4604CcfC7B38Ca7845B1FF653D0ff1` | Moonwell Flagship ETH | $6.10M |
| `0xc1256Ae5FF1cf2719D4937adb3bbCCab2E00A2Ca` | Moonwell Flagship USDC | $7.92M |
| `0x543257eF2161176D7C8cD90BA65C2d4CaEF5a796` | Moonwell Frontier cbBTC | $2.01M |
| `0xf24608E0CCb972b0b0f4A6446a0BBf58c701a026` | Moonwell Flagship EURC | $1.06M |

Block Analitica's real vaults are the three Ethereum ones already listed in the same entry, which Morpho reports as co-curated with B.Protocol. Those are kept.

### After the change

`moonwell-vaults` is unchanged at 1.17k fees / 175 revenue on Base, so no coverage is lost. `block-analitica` reports its Ethereum vaults only. Those read 0 today, which is not something this PR introduces: the Ethereum leg has published 0 every day in the current series, and the three vaults hold $117,858 between them.

### What I deliberately did not do

I did not add an `anthias` entry. The TVL repo attributes these vaults to Anthias Labs while this repo has them under `moonwell-vaults`, and adding a third name would just recreate the double count under a different label. Which of the two names should carry them is a naming call for a maintainer, not something to decide in a dedupe fix.

### Test

`npm run test fees block-analitica` and `npm run test fees moonwell-vaults`
