### PR TITLE
temple: correct the historical fee rate and guard non-USD-quoted markets

### DIFF
--- a/dexs/temple/index.ts
+++ b/dexs/temple/index.ts
@@ -4,9 +4,16 @@ import fetchURL from "../../utils/fetchURL";
 
 const API_BASE_URL = "https://api.templedigitalgroup.com/api/exchange";
 const SETTLED_VOLUME_URL = `${API_BASE_URL}/settled_volume`;
-const MAKER_FEE_BPS = 0.5;
-const TAKER_FEE_BPS = 1;
+const TICKERS_URL = `${API_BASE_URL}/tickers`;
 const BPS = 10000;
+
+// Temple cut trading fees from maker 10 / taker 15 bps.
+const FEE_CUT_DATE = "2026-05-09";
+const FEES_BEFORE_CUT = { maker: 10, taker: 15 };
+const FEES_AFTER_CUT = { maker: 0.5, taker: 1 };
+
+// settled_volume counts USDA and USDCx at $1 and drops every other quote asset without erroring
+const USD_QUOTES = ["USDA", "USDCx"];
 
 type SettledVolumeResponse = {
   start_time: string;
@@ -14,7 +21,23 @@ type SettledVolumeResponse = {
   total_volume_usd: number;
 };
 
+type Ticker = {
+  ticker_id: string;
+  target_currency: string;
+};
+
+const assertEveryMarketQuotesUSD = async () => {
+  const tickers: Ticker[] = await fetchURL(TICKERS_URL);
+  const excluded = tickers.filter((t) => !USD_QUOTES.includes(t.target_currency));
+  if (excluded.length)
+    throw new Error(
+      `Temple listed markets settled_volume excludes: ${excluded.map((t) => t.ticker_id).join(", ")}`,
+    );
+};
+
 const fetch = async (options: FetchOptions): Promise<FetchResult> => {
+  await assertEveryMarketQuotesUSD();
+
   // DefiLlama v2 supplies an inclusive `toTimestamp` and derives
   // `startTimestamp` as end - 1 day - 1 second. The Temple endpoint accepts
   // half-open windows capped at exactly 24 hours, so normalize the lower bound.
@@ -28,9 +51,8 @@ const fetch = async (options: FetchOptions): Promise<FetchResult> => {
   const response: SettledVolumeResponse = await fetchURL(
     `${SETTLED_VOLUME_URL}?${params}`,
   );
-  const dailyVolume = Number(response?.total_volume_usd);
+  const dailyVolume = Number(response.total_volume_usd);
   if (
-    !response ||
     Date.parse(response.start_time) !== requestStartTimestamp * 1000 ||
     Date.parse(response.end_time) !== options.endTimestamp * 1000 ||
     !Number.isFinite(dailyVolume) ||
@@ -38,13 +60,16 @@ const fetch = async (options: FetchOptions): Promise<FetchResult> => {
   )
     throw new Error("Temple settled volume response malformed or mismatched");
 
+  const { maker, taker } =
+    options.dateString < FEE_CUT_DATE ? FEES_BEFORE_CUT : FEES_AFTER_CUT;
   const dailyFees = options.createBalances();
-  dailyFees.addUSDValue(dailyVolume * MAKER_FEE_BPS / BPS, "Maker Fees");
-  dailyFees.addUSDValue(dailyVolume * TAKER_FEE_BPS / BPS, "Taker Fees");
+  dailyFees.addUSDValue(dailyVolume * maker / BPS, "Maker Fees");
+  dailyFees.addUSDValue(dailyVolume * taker / BPS, "Taker Fees");
 
   return {
     dailyVolume,
     dailyFees,
+    dailyUserFees: dailyFees,
     dailyRevenue: dailyFees,
     dailyProtocolRevenue: dailyFees,
     dailySupplySideRevenue: 0,
@@ -53,25 +78,35 @@ const fetch = async (options: FetchOptions): Promise<FetchResult> => {
 
 const methodology = {
   Volume:
-    "Settled spot orderbook volume across Temple markets quoted in the USD-pegged USDA and USDCx assets. Temple aggregates current and legacy markets for the requested half-open time window.",
-  Fees: "Trading fees charged by the Temple orderbook: 0.5 bps maker + 1 bp taker = 1.5 bps applied to settled volume.",
-  Revenue: "All trading fees are retained by the protocol.",
-  ProtocolRevenue: "All trading fees are retained by the protocol.",
-  SupplySideRevenue: "Zero. No trading-fee share is paid to liquidity providers or market makers.",
+    "Value of every trade settled on Temple's orderbook during the day, counted once per trade. All markets are quoted in USDA or USDCx, both worth one dollar.",
+  Fees:
+    "1.5 bps of trade value: 0.5 bps from the maker and 1 bp from the taker. Trades before 2026-05-09 use the old 10 bps maker / 15 bps taker rates.",
+  UserFees: "Traders pay the entire fee, since both sides of a trade are charged.",
+  Revenue: "Temple keeps every trading fee.",
+  ProtocolRevenue: "All trading fees go to Temple.",
+  SupplySideRevenue:
+    "Zero. Both sides pay a fee and none is paid back out, so makers get no share.",
 };
+
+const makerFeeMethodology = "Maker side of each trade: 0.5 bps, or 10 bps before 2026-05-09.";
+const takerFeeMethodology = "Taker side of each trade: 1 bp, or 15 bps before 2026-05-09.";
 
 const breakdownMethodology = {
   Fees: {
-    "Maker Fees": "0.5 bps maker fee applied to settled volume.",
-    "Taker Fees": "1 bp taker fee applied to settled volume.",
+    "Maker Fees": makerFeeMethodology,
+    "Taker Fees": takerFeeMethodology,
+  },
+  UserFees: {
+    "Maker Fees": makerFeeMethodology,
+    "Taker Fees": takerFeeMethodology,
   },
   Revenue: {
-    "Maker Fees": "0.5 bps maker fee applied to settled volume.",
-    "Taker Fees": "1 bp taker fee applied to settled volume.",
+    "Maker Fees": makerFeeMethodology,
+    "Taker Fees": takerFeeMethodology,
   },
   ProtocolRevenue: {
-    "Maker Fees": "0.5 bps maker fee applied to settled volume.",
-    "Taker Fees": "1 bp taker fee applied to settled volume.",
+    "Maker Fees": makerFeeMethodology,
+    "Taker Fees": takerFeeMethodology,
   },
 };
 
@@ -80,7 +115,7 @@ const adapter: SimpleAdapter = {
   fetch,
   chains: [CHAIN.CANTON],
   start: "2025-12-18",
-  // One bounded aggregate request is made for each daily backfill window.
+  // One bounded aggregate request covers each daily backfill window.
   pullHourly: false,
   methodology,
   breakdownMethodology,


### PR DESCRIPTION
## Changes

* Added the historical **25 bps** fee rate (10 bps maker + 15 bps taker) through **2026-05-08**, with the current 1.5 bps rate from 2026-05-09.
* Added a USD-quote guard using `/api/exchange/tickers` so newly traded non-USD markets fail loudly instead of being silently excluded.
* Removed optional response handling so malformed API responses throw.


## Verification

* Live end-to-end runs reproduce the API exactly:

  * 2026-03-15: **$191.4k volume / $478.54 fees = 25 bps**
  * 2026-08-05: **$7.77M / $1,164.93 = 1.5 bps**
* Fee boundary: **2026-05-08 → 25 bps**, **2026-05-09 → 1.5 bps**.