### PR TITLE
hylo-protocol: source fees from the Hylo public API (/v1/protocol/fees)

### DIFF
--- a/fees/hylo-protocol/index.ts
+++ b/fees/hylo-protocol/index.ts
@@ -38,7 +38,7 @@ const OPERATION_LABELS: Record<string, string> = {
   SwapStableToLeverExo: "Swap Fees",
   SwapLeverToStableExo: "Swap Fees",
   SwapLst: "Swap Fees",
-  UserWithdraw: "Stability Pool Withdrawal Fees",
+  UserWithdraw: "Earn Pool Withdrawal Fees",
   HarvestYield: "Yield Fees",
   HarvestBorrowRate: "Yield Fees",
 };
@@ -66,7 +66,7 @@ const fetchFromApi = async (options: FetchOptions) => {
     if (!market.yieldToPool) continue;
     const usd = Number(market.yieldToPool.usd);
     if (!Number.isFinite(usd)) throw new Error(`Hylo API returned a bad yieldToPool value for ${date}: ${JSON.stringify(market)}`);
-    dailySupplySideRevenue.addUSDValue(usd, "Stability Pool Yield");
+    dailySupplySideRevenue.addUSDValue(usd, "Earn Pool Yield");
   }
 
   const dailyFees = options.createBalances();
@@ -81,10 +81,10 @@ const fetchFromApi = async (options: FetchOptions) => {
   };
 };
 
-// Dune fallback: transfers into the fee authority PDAs + hyUSD minted to the stability pool on harvests.
+// Dune fallback: transfers into the fee authority PDAs + hyUSD minted to the earn pool on harvests.
 const HYUSD_MINT = "5YMkXAYccHSGnHn9nob9xEvv6Pvka9DZWH7nTbotTu9E";
 const XSOL_MINT = "4sWNB8zGWHkh6UnmwiEtzNxL4XrN7uK9tosbESbJFfVs";
-const STABILITY_POOL_HYUSD_OWNER = "5YrRAQag9BbJkauDtJkd1vsTquXT6N46oU8rJ66GDxHd";
+const EARN_POOL_HYUSD_OWNER = "5YrRAQag9BbJkauDtJkd1vsTquXT6N46oU8rJ66GDxHd";
 
 const FEE_ACCOUNTS: { owner: string; mint: string; label: string }[] = [
   { owner: "3HT6dD6APJh89XJs9rkn3BmsvkXE9jPG9dWJmUjWu6TS", mint: HYUSD_MINT, label: "hyUSD" },
@@ -117,11 +117,11 @@ const fetchFromDune = async (options: FetchOptions) => {
         )
       GROUP BY token_mint_address
     ),
-    stability_pool_yields AS (
+    earn_pool_yields AS (
       SELECT tx_id, token_mint_address, amount
       FROM tokens_solana.transfers
       WHERE TIME_RANGE
-        AND to_owner = '${STABILITY_POOL_HYUSD_OWNER}'
+        AND to_owner = '${EARN_POOL_HYUSD_OWNER}'
         AND token_mint_address = '${HYUSD_MINT}'
         AND from_owner IS NULL  -- Only actual mints
     ),
@@ -139,7 +139,7 @@ const fetchFromDune = async (options: FetchOptions) => {
         s.token_mint_address,
         SUM(s.amount) AS total_fees,
         'yield' AS data_type
-      FROM stability_pool_yields s
+      FROM earn_pool_yields s
       LEFT JOIN xsol_transfer_txs x ON s.tx_id = x.tx_id
       WHERE x.tx_id IS NULL
       GROUP BY s.token_mint_address
@@ -181,22 +181,22 @@ const fetch = async (options: FetchOptions) => {
 };
 
 const methodology = {
-  Fees: "Protocol fees collected from users (api.hylo.so/v1/protocol/fees) plus the yield paid to stability pool depositors (api.hylo.so/v1/protocol/digest).",
-  Revenue: "Protocol fees: mint/redeem fees, hyUSD/levercoin swap fees, stability pool withdrawal fees, and the protocol's share of harvested LST yield and borrow rate.",
+  Fees: "Protocol fees collected from users (api.hylo.so/v1/protocol/fees) plus the yield paid to earn pool depositors (api.hylo.so/v1/protocol/digest).",
+  Revenue: "Protocol fees: mint/redeem fees, hyUSD/levercoin swap fees, earn pool withdrawal fees, and the protocol's share of harvested LST yield and borrow rate.",
   ProtocolRevenue: "Same as Revenue; all protocol fees accrue to the protocol.",
-  SupplySideRevenue: "Harvested LST yield and borrow rate (in hyUSD) distributed to stability pool depositors.",
+  SupplySideRevenue: "Harvested LST yield and borrow rate (in hyUSD) distributed to earn pool depositors.",
 };
 
 const breakdownMethodology = {
   Fees: {
     "Mint/Redeem Fees": "Fees on minting and redeeming hyUSD and levercoins (xSOL, xBTC, ...) against the collateral vaults.",
     "Swap Fees": "Fees on swaps between hyUSD and levercoins, and on LST swaps.",
-    "Stability Pool Withdrawal Fees": "Fees on withdrawals from the hyUSD stability pool.",
+    "Earn Pool Withdrawal Fees": "Fees on withdrawals from the hyUSD earn pool.",
     "Yield Fees": "Protocol share of harvested LST yield and exo pair borrow rate.",
-    "Stability Pool Yield": "Harvested LST yield and borrow rate paid out to stability pool depositors.",
+    "Earn Pool Yield": "Harvested LST yield and borrow rate paid out to earn pool depositors.",
   },
   SupplySideRevenue: {
-    "Stability Pool Yield": "Harvested LST yield and borrow rate paid out to stability pool depositors.",
+    "Earn Pool Yield": "Harvested LST yield and borrow rate paid out to earn pool depositors.",
   },
 };
 

--- a/fees/hylo-protocol/index.ts
+++ b/fees/hylo-protocol/index.ts
@@ -133,7 +133,7 @@ const fetchFromDune = async (options: FetchOptions) => {
         AND amount > 0
     ),
     yields_data AS (
-      -- Stability pool operations also mint/burn hyUSD to this wallet; a tx with
+      -- Earn pool operations also mint/burn hyUSD to this wallet; a tx with
       -- xSOL movement is a swap, not a yield distribution, so exclude those.
       SELECT
         s.token_mint_address,

--- a/fees/hylo-protocol/index.ts
+++ b/fees/hylo-protocol/index.ts
@@ -1,5 +1,6 @@
-import { FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { Dependencies, FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
+import { queryDuneSql } from "../../helpers/dune";
 import { httpGet } from "../../utils/fetchURL";
 
 // Hylo Protocol — protocol revenue from the public API.
@@ -51,7 +52,7 @@ const OPERATION_LABELS: Record<string, string> = {
   HarvestBorrowRate: "Yield Fees",
 };
 
-const fetch = async (options: FetchOptions) => {
+const fetchFromApi = async (options: FetchOptions) => {
   const date = options.dateString;
   const [feesRes, digestRes] = await Promise.all([
     httpGet(`${FEES_URL}?from=${date}&to=${date}`),
@@ -89,6 +90,109 @@ const fetch = async (options: FetchOptions) => {
   };
 };
 
+// --- Dune fallback ---------------------------------------------------------
+// Used when the Hylo API is unavailable. Sums token transfers into the
+// protocol fee authority PDAs (the owners of the fee token accounts), one per
+// fee token, plus the hyUSD minted to the stability pool on yield harvests.
+const HYUSD_MINT = "5YMkXAYccHSGnHn9nob9xEvv6Pvka9DZWH7nTbotTu9E";
+const XSOL_MINT = "4sWNB8zGWHkh6UnmwiEtzNxL4XrN7uK9tosbESbJFfVs";
+const STABILITY_POOL_HYUSD_OWNER = "5YrRAQag9BbJkauDtJkd1vsTquXT6N46oU8rJ66GDxHd";
+
+const FEE_ACCOUNTS: { owner: string; mint: string; label: string }[] = [
+  { owner: "3HT6dD6APJh89XJs9rkn3BmsvkXE9jPG9dWJmUjWu6TS", mint: HYUSD_MINT, label: "hyUSD" },
+  { owner: "FpLaqELxKRm6S3bjfNSknwZu43TL89VYkwuMDwsRMj59", mint: "J1toso1uCk3RLmjorhTtrVwY9HJ7X8V9yYac6Y7kGCPn", label: "JitoSOL" },
+  { owner: "925PhdF3ZXqEEWvgnSQDSSHZVoS3rhMLEfBot2cWmgpu", mint: "hy1oXYgrBW6PVcJ4s6s2FKavRdwgWTXdfE69AxT7kPT", label: "HyloSOL" },
+  // Hylo v2 exo pairs
+  { owner: "39ACqviD7R5XyGBcwwV1YVru4uvSmz5Pgt7S9RxPRPkL", mint: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v", label: "USDC" },
+  { owner: "BqhiD7AdKeYfR6mex2zYhhheoEXpPTfsYG6vnTJ9ERk2", mint: "cbbtcf3aa214zXHbiAZQwf4122FBYbraNdFqgw4iMij", label: "cbBTC" },
+  { owner: "8Xrf6qAvuH3kXfVWJGT49aBLSEUGHyG8ETuvvnu5VRSr", mint: "98sMhvDwXj1RQi5c5Mndm3vPe9cBqPrbLaufMXFNMh5g", label: "HYPE" },
+];
+
+const fetchFromDune = async (options: FetchOptions) => {
+  const dailyRevenue = options.createBalances();
+  const dailySupplySideRevenue = options.createBalances();
+  const dailyFees = options.createBalances();
+
+  const feeFilter = FEE_ACCOUNTS
+    .map((a) => `(to_owner = '${a.owner}' AND token_mint_address = '${a.mint}')`)
+    .join("\n        OR ");
+
+  const query = `
+    WITH revenue_data AS (
+      SELECT
+        token_mint_address,
+        SUM(amount) AS total_fees,
+        'revenue' AS data_type
+      FROM tokens_solana.transfers
+      WHERE TIME_RANGE
+        AND (
+        ${feeFilter}
+        )
+      GROUP BY token_mint_address
+    ),
+    stability_pool_yields AS (
+      SELECT tx_id, token_mint_address, amount
+      FROM tokens_solana.transfers
+      WHERE TIME_RANGE
+        AND to_owner = '${STABILITY_POOL_HYUSD_OWNER}'
+        AND token_mint_address = '${HYUSD_MINT}'
+        AND from_owner IS NULL  -- Only actual mints
+    ),
+    xsol_transfer_txs AS (
+      SELECT DISTINCT tx_id
+      FROM tokens_solana.transfers
+      WHERE TIME_RANGE
+        AND token_mint_address = '${XSOL_MINT}'
+        AND amount > 0
+    ),
+    yields_data AS (
+      -- Stability pool operations also mint/burn hyUSD to this wallet; a tx with
+      -- xSOL movement is a swap, not a yield distribution, so exclude those.
+      SELECT
+        s.token_mint_address,
+        SUM(s.amount) AS total_fees,
+        'yield' AS data_type
+      FROM stability_pool_yields s
+      LEFT JOIN xsol_transfer_txs x ON s.tx_id = x.tx_id
+      WHERE x.tx_id IS NULL
+      GROUP BY s.token_mint_address
+    )
+    SELECT * FROM revenue_data
+    UNION ALL
+    SELECT * FROM yields_data
+  `;
+  const rows = await queryDuneSql(options, query);
+
+  rows.forEach((row: any) => {
+    const amount = Number(row.total_fees) || 0;
+    if (row.data_type === "revenue") {
+      if (row.token_mint_address === HYUSD_MINT) dailyRevenue.addUSDValue(amount / 1e6); // hyUSD is pegged to $1 (6 decimals)
+      else dailyRevenue.add(row.token_mint_address, amount);
+    } else if (row.data_type === "yield" && row.token_mint_address === HYUSD_MINT) {
+      dailySupplySideRevenue.addUSDValue(amount / 1e6);
+    }
+  });
+
+  dailyFees.addBalances(dailyRevenue);
+  dailyFees.addBalances(dailySupplySideRevenue);
+
+  return {
+    dailyFees,
+    dailyRevenue,
+    dailyProtocolRevenue: dailyRevenue,
+    dailySupplySideRevenue,
+  };
+};
+
+const fetch = async (options: FetchOptions) => {
+  try {
+    return await fetchFromApi(options);
+  } catch (e) {
+    console.error("Hylo API failed, falling back to Dune", e);
+    return await fetchFromDune(options);
+  }
+};
+
 const methodology = {
   Fees: "Protocol fees collected from users (api.hylo.so/v1/protocol/fees) plus the yield paid to stability pool depositors (api.hylo.so/v1/protocol/digest).",
   Revenue: "Protocol fees: mint/redeem fees, hyUSD/levercoin swap fees, stability pool withdrawal fees, and the protocol's share of harvested LST yield and borrow rate.",
@@ -114,6 +218,8 @@ const adapter: SimpleAdapter = {
   fetch,
   start: "2025-04-01",
   chains: [CHAIN.SOLANA],
+  dependencies: [Dependencies.DUNE],
+  isExpensiveAdapter: true,
   methodology,
   breakdownMethodology,
 };

--- a/fees/hylo-protocol/index.ts
+++ b/fees/hylo-protocol/index.ts
@@ -3,16 +3,7 @@ import { CHAIN } from "../../helpers/chains";
 import { queryDuneSql } from "../../helpers/dune";
 import { httpGet } from "../../utils/fetchURL";
 
-// Hylo Protocol — protocol revenue from the public API.
 // Docs: https://api.hylo.so/docs
-// GET /v1/protocol/fees returns the indexer's daily fee rollup, broken down by
-// token and by operation. Every row is a fee that accrued to the protocol
-// (mint/redeem/swap fees, stability-pool withdrawal fees, and the protocol's
-// share of harvested yield and borrow rate). Amounts are exact decimal strings
-// and come with a USD valuation at the time of the event.
-// GET /v1/protocol/digest returns the daily activity digest; per market it
-// carries `yieldToPool`, the yield (in hyUSD) paid out to stability pool
-// depositors. That is supply-side revenue, not protocol revenue.
 const FEES_URL = "https://api.hylo.so/v1/protocol/fees";
 const DIGEST_URL = "https://api.hylo.so/v1/protocol/digest";
 
@@ -25,13 +16,13 @@ interface FeeRow {
 }
 
 interface FeeDay {
-  date: string; // UTC day, YYYY-MM-DD
+  date: string;
   byToken: { token: string; fee: string; usd: string }[];
   byOperation: FeeRow[];
 }
 
 interface DigestDay {
-  date: string; // UTC day, YYYY-MM-DD
+  date: string;
   markets: { market: string; yieldToPool?: { token: string; amount: string; usd: string } }[];
 }
 
@@ -90,10 +81,7 @@ const fetchFromApi = async (options: FetchOptions) => {
   };
 };
 
-// --- Dune fallback ---------------------------------------------------------
-// Used when the Hylo API is unavailable. Sums token transfers into the
-// protocol fee authority PDAs (the owners of the fee token accounts), one per
-// fee token, plus the hyUSD minted to the stability pool on yield harvests.
+// Dune fallback: transfers into the fee authority PDAs + hyUSD minted to the stability pool on harvests.
 const HYUSD_MINT = "5YMkXAYccHSGnHn9nob9xEvv6Pvka9DZWH7nTbotTu9E";
 const XSOL_MINT = "4sWNB8zGWHkh6UnmwiEtzNxL4XrN7uK9tosbESbJFfVs";
 const STABILITY_POOL_HYUSD_OWNER = "5YrRAQag9BbJkauDtJkd1vsTquXT6N46oU8rJ66GDxHd";
@@ -102,7 +90,6 @@ const FEE_ACCOUNTS: { owner: string; mint: string; label: string }[] = [
   { owner: "3HT6dD6APJh89XJs9rkn3BmsvkXE9jPG9dWJmUjWu6TS", mint: HYUSD_MINT, label: "hyUSD" },
   { owner: "FpLaqELxKRm6S3bjfNSknwZu43TL89VYkwuMDwsRMj59", mint: "J1toso1uCk3RLmjorhTtrVwY9HJ7X8V9yYac6Y7kGCPn", label: "JitoSOL" },
   { owner: "925PhdF3ZXqEEWvgnSQDSSHZVoS3rhMLEfBot2cWmgpu", mint: "hy1oXYgrBW6PVcJ4s6s2FKavRdwgWTXdfE69AxT7kPT", label: "HyloSOL" },
-  // Hylo v2 exo pairs
   { owner: "39ACqviD7R5XyGBcwwV1YVru4uvSmz5Pgt7S9RxPRPkL", mint: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v", label: "USDC" },
   { owner: "BqhiD7AdKeYfR6mex2zYhhheoEXpPTfsYG6vnTJ9ERk2", mint: "cbbtcf3aa214zXHbiAZQwf4122FBYbraNdFqgw4iMij", label: "cbBTC" },
   { owner: "8Xrf6qAvuH3kXfVWJGT49aBLSEUGHyG8ETuvvnu5VRSr", mint: "98sMhvDwXj1RQi5c5Mndm3vPe9cBqPrbLaufMXFNMh5g", label: "HYPE" },
@@ -166,7 +153,7 @@ const fetchFromDune = async (options: FetchOptions) => {
   rows.forEach((row: any) => {
     const amount = Number(row.total_fees) || 0;
     if (row.data_type === "revenue") {
-      if (row.token_mint_address === HYUSD_MINT) dailyRevenue.addUSDValue(amount / 1e6); // hyUSD is pegged to $1 (6 decimals)
+      if (row.token_mint_address === HYUSD_MINT) dailyRevenue.addUSDValue(amount / 1e6);
       else dailyRevenue.add(row.token_mint_address, amount);
     } else if (row.data_type === "yield" && row.token_mint_address === HYUSD_MINT) {
       dailySupplySideRevenue.addUSDValue(amount / 1e6);

--- a/fees/hylo-protocol/index.ts
+++ b/fees/hylo-protocol/index.ts
@@ -83,7 +83,6 @@ const fetchFromApi = async (options: FetchOptions) => {
 
 // Dune fallback: transfers into the fee authority PDAs + hyUSD minted to the earn pool on harvests.
 const HYUSD_MINT = "5YMkXAYccHSGnHn9nob9xEvv6Pvka9DZWH7nTbotTu9E";
-const XSOL_MINT = "4sWNB8zGWHkh6UnmwiEtzNxL4XrN7uK9tosbESbJFfVs";
 const EARN_POOL_HYUSD_OWNER = "5YrRAQag9BbJkauDtJkd1vsTquXT6N46oU8rJ66GDxHd";
 
 const FEE_ACCOUNTS: { owner: string; mint: string; label: string }[] = [
@@ -125,22 +124,23 @@ const fetchFromDune = async (options: FetchOptions) => {
         AND token_mint_address = '${HYUSD_MINT}'
         AND from_owner IS NULL  -- Only actual mints
     ),
-    xsol_transfer_txs AS (
+    other_token_txs AS (
       SELECT DISTINCT tx_id
       FROM tokens_solana.transfers
       WHERE TIME_RANGE
-        AND token_mint_address = '${XSOL_MINT}'
+        AND tx_id IN (SELECT tx_id FROM earn_pool_yields)
+        AND token_mint_address <> '${HYUSD_MINT}'
         AND amount > 0
     ),
     yields_data AS (
-      -- Earn pool operations also mint/burn hyUSD to this wallet; a tx with
-      -- xSOL movement is a swap, not a yield distribution, so exclude those.
+      -- Swaps, rebalances and pool deposits also mint hyUSD to the pool; only
+      -- harvests touch hyUSD alone, so drop txs that move any other token.
       SELECT
         s.token_mint_address,
         SUM(s.amount) AS total_fees,
         'yield' AS data_type
       FROM earn_pool_yields s
-      LEFT JOIN xsol_transfer_txs x ON s.tx_id = x.tx_id
+      LEFT JOIN other_token_txs x ON s.tx_id = x.tx_id
       WHERE x.tx_id IS NULL
       GROUP BY s.token_mint_address
     )

--- a/fees/hylo-protocol/index.ts
+++ b/fees/hylo-protocol/index.ts
@@ -9,7 +9,11 @@ import { httpGet } from "../../utils/fetchURL";
 // (mint/redeem/swap fees, stability-pool withdrawal fees, and the protocol's
 // share of harvested yield and borrow rate). Amounts are exact decimal strings
 // and come with a USD valuation at the time of the event.
+// GET /v1/protocol/digest returns the daily activity digest; per market it
+// carries `yieldToPool`, the yield (in hyUSD) paid out to stability pool
+// depositors. That is supply-side revenue, not protocol revenue.
 const FEES_URL = "https://api.hylo.so/v1/protocol/fees";
+const DIGEST_URL = "https://api.hylo.so/v1/protocol/digest";
 
 interface FeeRow {
   operation: string;
@@ -23,6 +27,11 @@ interface FeeDay {
   date: string; // UTC day, YYYY-MM-DD
   byToken: { token: string; fee: string; usd: string }[];
   byOperation: FeeRow[];
+}
+
+interface DigestDay {
+  date: string; // UTC day, YYYY-MM-DD
+  markets: { market: string; yieldToPool?: { token: string; amount: string; usd: string } }[];
 }
 
 const OPERATION_LABELS: Record<string, string> = {
@@ -44,28 +53,47 @@ const OPERATION_LABELS: Record<string, string> = {
 
 const fetch = async (options: FetchOptions) => {
   const date = options.dateString;
-  const res = await httpGet(`${FEES_URL}?from=${date}&to=${date}`);
-  const day: FeeDay | undefined = (res?.daily || []).find((d: FeeDay) => d.date === date);
-  if (!day) throw new Error(`Hylo API returned no fee data for ${date}`);
+  const [feesRes, digestRes] = await Promise.all([
+    httpGet(`${FEES_URL}?from=${date}&to=${date}`),
+    httpGet(`${DIGEST_URL}?from=${date}&to=${date}`),
+  ]);
+  const feeDay: FeeDay | undefined = (feesRes?.daily || []).find((d: FeeDay) => d.date === date);
+  if (!feeDay) throw new Error(`Hylo API returned no fee data for ${date}`);
+  const digestDay: DigestDay | undefined = (digestRes?.daily || []).find((d: DigestDay) => d.date === date);
+  if (!digestDay) throw new Error(`Hylo API returned no digest data for ${date}`);
 
-  const dailyFees = options.createBalances();
-  for (const row of day.byOperation) {
+  const dailyRevenue = options.createBalances();
+  for (const row of feeDay.byOperation) {
     const usd = Number(row.usd);
     if (!Number.isFinite(usd)) throw new Error(`Hylo API returned a bad usd value for ${date}: ${JSON.stringify(row)}`);
-    dailyFees.addUSDValue(usd, OPERATION_LABELS[row.operation] ?? "Other Fees");
+    dailyRevenue.addUSDValue(usd, OPERATION_LABELS[row.operation] ?? "Other Fees");
   }
+
+  const dailySupplySideRevenue = options.createBalances();
+  for (const market of digestDay.markets || []) {
+    if (!market.yieldToPool) continue;
+    const usd = Number(market.yieldToPool.usd);
+    if (!Number.isFinite(usd)) throw new Error(`Hylo API returned a bad yieldToPool value for ${date}: ${JSON.stringify(market)}`);
+    dailySupplySideRevenue.addUSDValue(usd, "Stability Pool Yield");
+  }
+
+  const dailyFees = options.createBalances();
+  dailyFees.addBalances(dailyRevenue);
+  dailyFees.addBalances(dailySupplySideRevenue);
 
   return {
     dailyFees,
-    dailyRevenue: dailyFees,
-    dailyProtocolRevenue: dailyFees,
+    dailyRevenue,
+    dailyProtocolRevenue: dailyRevenue,
+    dailySupplySideRevenue,
   };
 };
 
 const methodology = {
-  Fees: "Protocol fees collected from users, from the Hylo public API (api.hylo.so/v1/protocol/fees): mint/redeem fees, hyUSD/xSOL (and exo pair) swap fees, stability pool withdrawal fees, and the protocol's share of harvested LST yield and borrow rate.",
-  Revenue: "All collected fees accrue to the protocol.",
-  ProtocolRevenue: "All collected fees accrue to the protocol.",
+  Fees: "Protocol fees collected from users (api.hylo.so/v1/protocol/fees) plus the yield paid to stability pool depositors (api.hylo.so/v1/protocol/digest).",
+  Revenue: "Protocol fees: mint/redeem fees, hyUSD/levercoin swap fees, stability pool withdrawal fees, and the protocol's share of harvested LST yield and borrow rate.",
+  ProtocolRevenue: "Same as Revenue; all protocol fees accrue to the protocol.",
+  SupplySideRevenue: "Harvested LST yield and borrow rate (in hyUSD) distributed to stability pool depositors.",
 };
 
 const breakdownMethodology = {
@@ -74,6 +102,10 @@ const breakdownMethodology = {
     "Swap Fees": "Fees on swaps between hyUSD and levercoins, and on LST swaps.",
     "Stability Pool Withdrawal Fees": "Fees on withdrawals from the hyUSD stability pool.",
     "Yield Fees": "Protocol share of harvested LST yield and exo pair borrow rate.",
+    "Stability Pool Yield": "Harvested LST yield and borrow rate paid out to stability pool depositors.",
+  },
+  SupplySideRevenue: {
+    "Stability Pool Yield": "Harvested LST yield and borrow rate paid out to stability pool depositors.",
   },
 };
 

--- a/fees/hylo-protocol/index.ts
+++ b/fees/hylo-protocol/index.ts
@@ -1,175 +1,89 @@
-import { Dependencies, FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
-import { queryDuneSql } from "../../helpers/dune";
-import fetchURL from "../../utils/fetchURL";
+import { httpGet } from "../../utils/fetchURL";
 
-// Hylo Protocol fee accounts
-const HYUSD_FEE_ACCOUNT = "3HT6dD6APJh89XJs9rkn3BmsvkXE9jPG9dWJmUjWu6TS";
-const JITOSOL_FEE_ACCOUNT = "FpLaqELxKRm6S3bjfNSknwZu43TL89VYkwuMDwsRMj59";
-const HYLOSOL_FEE_ACCOUNT = "CZbazc6YTRC9QyvxqPJpmerChyuzEHAdX854CB7PbQGb";
+// Hylo Protocol — protocol revenue from the public API.
+// Docs: https://api.hylo.so/docs
+// GET /v1/protocol/fees returns the indexer's daily fee rollup, broken down by
+// token and by operation. Every row is a fee that accrued to the protocol
+// (mint/redeem/swap fees, stability-pool withdrawal fees, and the protocol's
+// share of harvested yield and borrow rate). Amounts are exact decimal strings
+// and come with a USD valuation at the time of the event.
+const FEES_URL = "https://api.hylo.so/v1/protocol/fees";
 
-const HYUSD_MINT = "5YMkXAYccHSGnHn9nob9xEvv6Pvka9DZWH7nTbotTu9E";
-const JITOSOL_MINT = "J1toso1uCk3RLmjorhTtrVwY9HJ7X8V9yYac6Y7kGCPn";
-const HYLOSOL_MINT = "hy1oXYgrBW6PVcJ4s6s2FKavRdwgWTXdfE69AxT7kPT";
+interface FeeRow {
+  operation: string;
+  token: string;
+  market?: string;
+  fee: string;
+  usd: string;
+}
 
-const fetchFromApi = async (options: FetchOptions) => {
-  const date = new Date(options.startOfDay * 1000).toISOString().slice(0, 10);
-  const to_date = new Date((options.startOfDay + 86400) * 1000).toISOString().slice(0, 10);
+interface FeeDay {
+  date: string; // UTC day, YYYY-MM-DD
+  byToken: { token: string; fee: string; usd: string }[];
+  byOperation: FeeRow[];
+}
 
-  // includes v2 fees, to verify data on chain: Bz6Xsr7vTo2oSFxjmJVpoC4bVNGVpP5egbdVk4Jeu1JZ, oacVCceELzvyK944xDJaMGhVKzwkaY9yBHw2uifhLJ8
-  const url = `https://api.hylo.so/activity/volumes?from=${date}&to=${to_date}`;
-  const res = await fetchURL(url);
-  const row = res?.volumes?.find((v: any) => v.date === date);
-  if (!row) throw new Error(`Hylo API returned no data for ${date}`);
+const OPERATION_LABELS: Record<string, string> = {
+  MintStablecoin: "Mint/Redeem Fees",
+  RedeemStablecoin: "Mint/Redeem Fees",
+  MintLevercoin: "Mint/Redeem Fees",
+  RedeemLevercoin: "Mint/Redeem Fees",
+  MintLevercoinExo: "Mint/Redeem Fees",
+  RedeemLevercoinExo: "Mint/Redeem Fees",
+  SwapStableToLever: "Swap Fees",
+  SwapLeverToStable: "Swap Fees",
+  SwapStableToLeverExo: "Swap Fees",
+  SwapLeverToStableExo: "Swap Fees",
+  SwapLst: "Swap Fees",
+  UserWithdraw: "Stability Pool Withdrawal Fees",
+  HarvestYield: "Yield Fees",
+  HarvestBorrowRate: "Yield Fees",
+};
 
-  const dailyRevenue = options.createBalances();
-  const dailyYields = options.createBalances();
+const fetch = async (options: FetchOptions) => {
+  const date = options.dateString;
+  const res = await httpGet(`${FEES_URL}?from=${date}&to=${date}`);
+  const day: FeeDay | undefined = (res?.daily || []).find((d: FeeDay) => d.date === date);
+  if (!day) throw new Error(`Hylo API returned no fee data for ${date}`);
+
   const dailyFees = options.createBalances();
-
-  // Amounts are decimal strings in human units; convert to raw using token decimals.
-  dailyRevenue.addUSDValue(+row.fee_hyusd); // hyUSD is pegged to $1
-  dailyRevenue.add(JITOSOL_MINT, Math.floor(+row.fee_jitosol * 1e9));
-  dailyRevenue.add(HYLOSOL_MINT, Math.floor(+row.fee_hylosol * 1e9));
-
-  // yield_harvested is denominated in hyUSD (stability pool yields distributed to users)
-  dailyYields.addUSDValue(+row.yield_harvested);
-
-  dailyFees.addBalances(dailyRevenue);
-  dailyFees.addBalances(dailyYields);
+  for (const row of day.byOperation) {
+    const usd = Number(row.usd);
+    if (!Number.isFinite(usd)) throw new Error(`Hylo API returned a bad usd value for ${date}: ${JSON.stringify(row)}`);
+    dailyFees.addUSDValue(usd, OPERATION_LABELS[row.operation] ?? "Other Fees");
+  }
 
   return {
     dailyFees,
-    dailyRevenue,
-    dailySupplySideRevenue: dailyYields,
+    dailyRevenue: dailyFees,
+    dailyProtocolRevenue: dailyFees,
   };
 };
 
-const fetchFromDune = async (options: FetchOptions) => {
-  const dailyRevenue = options.createBalances();
-  const dailyYields = options.createBalances();
-  const dailyFees = options.createBalances();
+const methodology = {
+  Fees: "Protocol fees collected from users, from the Hylo public API (api.hylo.so/v1/protocol/fees): mint/redeem fees, hyUSD/xSOL (and exo pair) swap fees, stability pool withdrawal fees, and the protocol's share of harvested LST yield and borrow rate.",
+  Revenue: "All collected fees accrue to the protocol.",
+  ProtocolRevenue: "All collected fees accrue to the protocol.",
+};
 
-  // Query for protocol fees (revenue)
-  const revenueQuery = `
-    SELECT
-      token_mint_address,
-      SUM(amount) AS total_fees,
-      'revenue' AS data_type
-    FROM
-      tokens_solana.transfers
-    WHERE
-      TIME_RANGE
-      AND (
-        (to_owner = '${HYUSD_FEE_ACCOUNT}' AND token_mint_address = '5YMkXAYccHSGnHn9nob9xEvv6Pvka9DZWH7nTbotTu9E') 
-        OR 
-        (to_owner = '${JITOSOL_FEE_ACCOUNT}' AND token_mint_address = 'J1toso1uCk3RLmjorhTtrVwY9HJ7X8V9yYac6Y7kGCPn')
-        OR 
-        (to_owner = '${HYLOSOL_FEE_ACCOUNT}' AND token_mint_address = 'hy1oXYgrBW6PVcJ4s6s2FKavRdwgWTXdfE69AxT7kPT')
-        
-      )
-    GROUP BY
-      token_mint_address
-  `;
-
-  // Query for stability pool yields distributed to users
-  const yieldsQuery = `
-    WITH stability_pool_yields AS (
-      SELECT 
-        tx_id,
-        token_mint_address,
-        amount
-      FROM tokens_solana.transfers
-      WHERE TIME_RANGE
-        AND to_owner = '5YrRAQag9BbJkauDtJkd1vsTquXT6N46oU8rJ66GDxHd'
-        AND token_mint_address = '5YMkXAYccHSGnHn9nob9xEvv6Pvka9DZWH7nTbotTu9E'
-        AND from_owner IS NULL  -- Only actual mints
-    ),
-    xsol_transfer_txs AS (
-      SELECT DISTINCT tx_id
-      FROM tokens_solana.transfers
-      WHERE TIME_RANGE
-        AND token_mint_address = '4sWNB8zGWHkh6UnmwiEtzNxL4XrN7uK9tosbESbJFfVs'  -- xSOL
-        AND amount > 0
-    )
-    SELECT 
-      token_mint_address,
-      SUM(amount) AS total_fees,
-      'yield' AS data_type
-    FROM stability_pool_yields s
-    LEFT JOIN xsol_transfer_txs x ON s.tx_id = x.tx_id
-    WHERE x.tx_id IS NULL  -- Exclude transactions with any xSOL transfers
-                           -- This is because stability pool operations also mint/burn hyUSD to this wallet,
-                           -- so if a transaction has xSOL movement it means it's not a yield distribution but just a swap
-    GROUP BY token_mint_address
-  `;
-  // Combine both queries into one to reduce query cost
-  const combinedQuery = `
-    WITH revenue_data AS (
-      ${revenueQuery}
-    ),
-    yields_data AS (
-      ${yieldsQuery}
-    )
-    SELECT * FROM revenue_data
-    UNION ALL 
-    SELECT * FROM yields_data
-  `;
-  const combinedData = await  queryDuneSql(options, combinedQuery)
-  const revenue = combinedData.filter(i => i.data_type === 'revenue');
-  const yields = combinedData.filter(i => i.data_type === 'yield');
-
-  // Process protocol fees (revenue)
-  revenue.forEach((row: any) => {
-    if (row.token_mint_address === '5YMkXAYccHSGnHn9nob9xEvv6Pvka9DZWH7nTbotTu9E') {
-      // hyUSD is pegged to $1, so we can add it as USD value directly
-      dailyRevenue.addUSDValue(row.total_fees / 1e6); // 6 decimals for hyUSD
-    } else {
-      // For other tokens (like jitoSOL), use automatic price conversion
-      dailyRevenue.add(row.token_mint_address, row.total_fees);
-    }
-  });
-
-  // Process stability pool yields
-  yields.forEach((row: any) => {
-    if (row.token_mint_address === '5YMkXAYccHSGnHn9nob9xEvv6Pvka9DZWH7nTbotTu9E') {
-      // hyUSD is pegged to $1, so we can add it as USD value directly
-      dailyYields.addUSDValue(row.total_fees / 1e6); // 6 decimals for hyUSD
-    }
-  });
-
-  // Calculate total user fees (revenue + yields)
-  dailyFees.addBalances(dailyRevenue);
-  dailyFees.addBalances(dailyYields);
-
-  return {
-    dailyRevenue,           // Protocol revenue only
-    dailySupplySideRevenue: dailyYields, // Stability pool yields distributed to users
-    dailyFees          // Protocol revenue + stability pool yields
-  }
-}
-
-const fetch: any = async (options: FetchOptions) => {
-  return fetchFromApi(options);
-  try {
-    return await fetchFromApi(options);
-  } catch (e) {
-    // Fall back to Dune query if the Hylo API is unavailable
-    return await fetchFromDune(options);
-  }
+const breakdownMethodology = {
+  Fees: {
+    "Mint/Redeem Fees": "Fees on minting and redeeming hyUSD and levercoins (xSOL, xBTC, ...) against the collateral vaults.",
+    "Swap Fees": "Fees on swaps between hyUSD and levercoins, and on LST swaps.",
+    "Stability Pool Withdrawal Fees": "Fees on withdrawals from the hyUSD stability pool.",
+    "Yield Fees": "Protocol share of harvested LST yield and exo pair borrow rate.",
+  },
 };
 
 const adapter: SimpleAdapter = {
-  version: 1,
+  version: 2,
   fetch,
-  start: '2025-04-01',
+  start: "2025-04-01",
   chains: [CHAIN.SOLANA],
-  dependencies: [Dependencies.DUNE],
-  isExpensiveAdapter: true,
-  methodology: {
-    Fees: "Stability pool yields (in hyUSD) distributed to users.",
-    Revenue: "Swap fees, and part of reserve LSTs yield",
-    SupplySideRevenue: "Stability pool yields (in hyUSD) distributed to users.",
-  },
+  methodology,
+  breakdownMethodology,
 };
 
 export default adapter;


### PR DESCRIPTION
## Summary

Hylo now exposes a dedicated protocol revenue endpoint: `GET https://api.hylo.so/v1/protocol/fees` (docs: https://api.hylo.so/docs). This PR moves the `hylo-protocol` fees adapter to the v1 API and keeps Dune as a fallback.

**API path (primary)**
- `/v1/protocol/fees?from=<day>&to=<day>`: the indexer's daily fee rollup per token and per operation, with a USD valuation at event time. Every row is a fee that accrued to the protocol → `dailyRevenue` / `dailyProtocolRevenue`.
- `/v1/protocol/digest?from=<day>&to=<day>`: per-market `yieldToPool`, the harvested yield paid to earn pool depositors → `dailySupplySideRevenue`.
- `dailyFees` = protocol fees + yield to pool (same definition as before).
- Covers all fee tokens, including the v2 exo pairs (USDC, cbBTC, HYPE) that the previous adapter missed.
- Adds a fee breakdown by operation group.

**Dune fallback** (runs only when the API call fails)
- Extended with the USDC, cbBTC and HYPE fee authorities.
- Fixes the HyloSOL filter: the old query used the fee *token account* as `to_owner`; the owner is the fee authority PDA `925Phd…`, so HyloSOL fees never matched.
- Yield: rebalance swaps (`SwapLstToUsdc`, `SwapExoToUsdc`) also mint hyUSD to the pool without moving a levercoin, so the old "exclude txs with xSOL" filter overcounted. Harvests are the only pool mints whose tx touches hyUSD alone; the filter now uses that.

## Test

API path, `npm test -- fees hylo-protocol 2026-08-20` (day 2026-08-19):
```
Daily fees:                17.26 k
Daily revenue:             12.54 k
Daily protocol revenue:    12.54 k
Daily supply side revenue: 4.72 k

label                     | Daily fees | Daily revenue | Daily supply side revenue
Yield Fees                | 248        | 248           |
Mint/Redeem Fees          | 9395       | 9395          |
Swap Fees                 | 2856       | 2856          |
Earn Pool Withdrawal Fees | 44         | 44            |
Earn Pool Yield           | 4718       |               | 4718
```

Dune fallback (API host pointed at an invalid domain), same day: token amounts identical to the API (hyUSD 3155.02, JitoSOL 18.359, HyloSOL 7.890, USDC 158.17, cbBTC 0.01511, HYPE 82.378), yield 4,718 hyUSD identical; USD total 12.85k vs 12.54k from pricing source only. Also checked 2026-06-01: 2.23k on both paths.