### PR TITLE
velodrome-slipstream: split swap fees between voters and unstaked LPs

### DIFF
--- a/dexs/velodrome-slipstream/index.ts
+++ b/dexs/velodrome-slipstream/index.ts
@@ -51,11 +51,19 @@ interface ILog {
 const forSwaps = 'function forSwaps(uint256 _limit, uint256 _offset) view returns ((address lp, int24 type, address token0, address token1, address factory, uint256 pool_fee)[])'
 const event_swap = 'event Swap(address indexed sender, address indexed recipient, int256 amount0, int256 amount1, uint160 sqrtPriceX96, uint128 liquidity, int24 tick)'
 
+const poolAbis = {
+  liquidity: 'function liquidity() view returns (uint128)',
+  stakedLiquidity: 'function stakedLiquidity() view returns (uint128)',
+  unstakedFee: 'function unstakedFee() view returns (uint24)',
+}
+
 const fetch = async (fetchOptions: FetchOptions): Promise<FetchResult> => {
   const { api, createBalances, getFromBlock, startOfDay, chain, getLogs } = fetchOptions
   const [fromBlock, toBlock] = await Promise.all([getFromBlock(), await api.getBlock() - 100])
   const dailyVolume = createBalances()
   const dailyFees = createBalances()
+  const dailyHoldersRevenue = createBalances()
+  const dailySupplySideRevenue = createBalances()
   const pairs: string[] = [];
   const pairInfoMap: Record<string, IForSwap> = {};
   let currentOffset = 0;
@@ -90,6 +98,22 @@ const fetch = async (fetchOptions: FetchOptions): Promise<FetchResult> => {
   }
 
   sdk.log('velodrome pairs', pairs.length, 'all pairs', pairs.length, chain)
+
+  const [liquidity, stakedLiquidity, unstakedFee] = await Promise.all([
+    api.multiCall({ abi: poolAbis.liquidity, calls: pairs }),
+    api.multiCall({ abi: poolAbis.stakedLiquidity, calls: pairs }),
+    api.multiCall({ abi: poolAbis.unstakedFee, calls: pairs }),
+  ])
+  // kept in ppm so the split can be applied in BigInt and always add back up to the fee
+  const holdersShareppm: Record<string, bigint> = {}
+  pairs.forEach((pool, i) => {
+    const activeLiquidity = Number(liquidity[i])
+    const staked = Math.min(Number(stakedLiquidity[i]), activeLiquidity)
+    const stakedShare = activeLiquidity > 0 ? staked / activeLiquidity : 0
+    const share = stakedShare + (1 - stakedShare) * Number(unstakedFee[i]) / 1_000_000
+    holdersShareppm[pool] = BigInt(Math.round(share * 1_000_000))
+  })
+
   const targetChunkSize = 10;
   const pairChunks = sdk.util.sliceIntoChunks(pairs, targetChunkSize);
 
@@ -99,16 +123,19 @@ const fetch = async (fetchOptions: FetchOptions): Promise<FetchResult> => {
 
     logs.forEach((logs: ILog[], idx) => {
       const pool = targets[idx];
-      
+
       if (pairInfoMap[pool]) {
         const { token1, pool_fee } = pairInfoMap[pool];
-  
+
         logs.forEach((log: any) => {
           const amount1 = Math.abs(Number(log.amount1));
-          const fee = Math.round((amount1 * Number(pool_fee)) / 1_000_000);
-  
+          const fee = BigInt(Math.round((amount1 * Number(pool_fee)) / 1_000_000));
+          const toHolders = fee * holdersShareppm[pool] / 1_000_000n;
+
           dailyVolume.add(token1, BigInt(amount1));
-          dailyFees.add(token1, BigInt(fee));
+          dailyFees.add(token1, fee, 'Token Swap Fees');
+          dailyHoldersRevenue.add(token1, toHolders, 'Swap Fees To Voters');
+          dailySupplySideRevenue.add(token1, fee - toHolders, 'Swap Fees To Unstaked LPs');
         });
       }
     });
@@ -118,9 +145,10 @@ const fetch = async (fetchOptions: FetchOptions): Promise<FetchResult> => {
 
   return {
     dailyVolume,
-    dailyFees: dailyFees.clone(1, 'Token Swap Fees'),
-    dailyRevenue: dailyFees.clone(1, 'Staked-LP Fees And Unstaked-LP Rake'),
-    dailyHoldersRevenue: dailyFees.clone(1, 'Staked-LP Fees And Unstaked-LP Rake'),
+    dailyFees,
+    dailyRevenue: dailyHoldersRevenue,
+    dailyHoldersRevenue,
+    dailySupplySideRevenue,
   }
 }
 
@@ -128,19 +156,23 @@ const adapters: SimpleAdapter = {
   version: 2,
   pullHourly: true,
   methodology: {
-    Fees: 'Total swap fees paid by users',
-    Revenue: 'Swap feesare distributed to holders',
-    HoldersRevenue: 'Swap fees are distributed to holders',
+    Fees: 'Total swap fees paid by users.',
+    Revenue: 'The share of swap fees that goes to veVELO voters: everything earned by liquidity staked in a gauge, plus the rake taken from unstaked liquidity.',
+    HoldersRevenue: 'The share of swap fees that goes to veVELO voters: everything earned by liquidity staked in a gauge, plus the rake taken from unstaked liquidity.',
+    SupplySideRevenue: 'The share of swap fees kept by liquidity providers who have not staked their position in a gauge, after the rake.',
   },
   breakdownMethodology: {
     Fees: {
-      'Token Swap Fees': 'Total swap fees paid by users',
+      'Token Swap Fees': 'Total swap fees paid by users.',
     },
     Revenue: {
-      'Staked-LP Fees And Unstaked-LP Rake': 'Total swap fees distributed to holders',
+      'Swap Fees To Voters': 'Fees earned by gauge-staked liquidity plus the rake on unstaked liquidity, both claimable by voters.',
     },
     HoldersRevenue: {
-      'Staked-LP Fees And Unstaked-LP Rake': 'Total swap fees distributed to holders',
+      'Swap Fees To Voters': 'Fees earned by gauge-staked liquidity plus the rake on unstaked liquidity, both claimable by voters.',
+    },
+    SupplySideRevenue: {
+      'Swap Fees To Unstaked LPs': 'Fees earned by liquidity that is not staked in a gauge, net of the rake, which stays with the position owner.',
     },
   },
   adapter: {


### PR DESCRIPTION
## Changes

* Split Slipstream swap fees using each pool’s `stakedLiquidity / liquidity` and `unstakedFee`, matching `CLPool.calculateFees`.
* Added `dailySupplySideRevenue` for fees retained by unstaked LPs; `dailyRevenue` / `dailyHoldersRevenue` now report only the voter share.
* Read `liquidity()`, `stakedLiquidity()` and `unstakedFee()` per pool and cache the resulting LP share in ppm.

## Verification

`pnpm test dexs velodrome-slipstream 2026-08-20`:

| Chain    |    Fees | Voters | Unstaked LPs |
| -------- | ------: | -----: | -----------: |
| Optimism | $10,079 | $9,560 |         $519 |
| Ink      |  $5,188 | $2,674 |       $2,513 |
