### PR TITLE
hylo-protocol: source fees from the Hylo public API (/v1/protocol/fees)

### DIFF
--- a/fees/hylo-protocol/index.ts
+++ b/fees/hylo-protocol/index.ts
@@ -1,4 +1,4 @@
-import { Dependencies, FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 import { queryDuneSql } from "../../helpers/dune";
 import { httpGet } from "../../utils/fetchURL";
@@ -7,42 +7,7 @@ import { httpGet } from "../../utils/fetchURL";
 const FEES_URL = "https://api.hylo.so/v1/protocol/fees";
 const DIGEST_URL = "https://api.hylo.so/v1/protocol/digest";
 const VALIDATOR_URL = "https://api.hylo.so/v1/validator/revenue";
-
-interface FeeRow {
-  operation: string;
-  token: string;
-  market?: string;
-  fee: string;
-  usd: string;
-}
-
-interface FeeDay {
-  date: string;
-  byToken: { token: string; fee: string; usd: string }[];
-  byOperation: FeeRow[];
-}
-
-interface DigestDay {
-  date: string;
-  markets: { market: string; yieldToPool?: { token: string; amount: string; usd: string } }[];
-}
-
-interface ValidatorDay {
-  date: string;
-  total?: string; // SOL
-}
-
-// Hylo validator: inflation commission + Jito tips + block rewards, in SOL.
-// Inflation and Jito settle once per epoch; days with no activity are omitted.
-const addValidatorRevenue = async (options: FetchOptions, balances: any) => {
-  const date = options.dateString;
-  const res = await httpGet(`${VALIDATOR_URL}?from=${date}&to=${date}`);
-  const day: ValidatorDay | undefined = (res?.daily || []).find((d: ValidatorDay) => d.date === date);
-  if (!day) return;
-  const sol = Number(day.total ?? 0);
-  if (!Number.isFinite(sol)) throw new Error(`Hylo API returned a bad validator total for ${date}: ${JSON.stringify(day)}`);
-  balances.addCGToken("solana", sol, "Validator Revenue");
-};
+const LEGACY_URL = "https://api.hylo.so/activity/volumes";
 
 const OPERATION_LABELS: Record<string, string> = {
   MintStablecoin: "Mint/Redeem Fees",
@@ -57,20 +22,18 @@ const OPERATION_LABELS: Record<string, string> = {
   SwapLeverToStableExo: "Swap Fees",
   SwapLst: "Swap Fees",
   UserWithdraw: "Earn Pool Withdrawal Fees",
-  HarvestYield: "Yield Fees",
-  HarvestBorrowRate: "Yield Fees",
+  HarvestYield: "LST Yield Share",
+  HarvestBorrowRate: "Borrow Rate Fees",
 };
 
 const fetchFromApi = async (options: FetchOptions) => {
   const date = options.dateString;
-  const [feesRes, digestRes] = await Promise.all([
+  const [feesRes, digestRes, validatorRes] = await Promise.all([
     httpGet(`${FEES_URL}?from=${date}&to=${date}`),
     httpGet(`${DIGEST_URL}?from=${date}&to=${date}`),
+    httpGet(`${VALIDATOR_URL}?from=${date}&to=${date}`),
   ]);
-  const feeDay: FeeDay | undefined = (feesRes?.daily || []).find((d: FeeDay) => d.date === date);
-  if (!feeDay) throw new Error(`Hylo API returned no fee data for ${date}`);
-  const digestDay: DigestDay | undefined = (digestRes?.daily || []).find((d: DigestDay) => d.date === date);
-  if (!digestDay) throw new Error(`Hylo API returned no digest data for ${date}`);
+  const feeDay = feesRes.daily.find((d: any) => d.date === date);
 
   const dailyRevenue = options.createBalances();
   for (const row of feeDay.byOperation) {
@@ -80,14 +43,22 @@ const fetchFromApi = async (options: FetchOptions) => {
   }
 
   const dailySupplySideRevenue = options.createBalances();
-  for (const market of digestDay.markets || []) {
-    if (!market.yieldToPool) continue;
-    const usd = Number(market.yieldToPool.usd);
-    if (!Number.isFinite(usd)) throw new Error(`Hylo API returned a bad yieldToPool value for ${date}: ${JSON.stringify(market)}`);
-    dailySupplySideRevenue.addUSDValue(usd, "Earn Pool Yield");
+  if (date < "2025-12-06") {
+    // digest yieldToPool returns the protocol cut instead of the pool share before the Dec 2025 earn pool migration
+    const to = new Date((options.startOfDay + 86400) * 1000).toISOString().slice(0, 10);
+    const legacyRes = await httpGet(`${LEGACY_URL}?from=${date}&to=${to}`);
+    const legacyDay = legacyRes.volumes.find((v: any) => v.date === date);
+    dailySupplySideRevenue.addUSDValue(Number(legacyDay.yield_harvested_usd), "Earn Pool Yield");
+  } else {
+    const digestDay = digestRes.daily.find((d: any) => d.date === date);
+    for (const market of digestDay.markets) {
+      if (market.yieldToPool) dailySupplySideRevenue.addUSDValue(Number(market.yieldToPool.usd), "Earn Pool Yield");
+    }
   }
 
-  await addValidatorRevenue(options, dailyRevenue);
+  // validator income settles per epoch, days without a payout are omitted
+  const validatorDay = validatorRes.daily.find((d: any) => d.date === date);
+  if (validatorDay) dailyRevenue.addCGToken("solana", Number(validatorDay.total), "Validator Revenue");
 
   const dailyFees = options.createBalances();
   dailyFees.addBalances(dailyRevenue);
@@ -209,20 +180,17 @@ const fetchFromDune = async (options: FetchOptions) => {
   };
 };
 
-const fetch = async (options: FetchOptions) => {
-  try {
-    return await fetchFromApi(options);
-  } catch (e) {
-    console.error("Hylo API failed, falling back to Dune", e);
-    return await fetchFromDune(options);
-  }
+const fetch: any = async (options: FetchOptions) => {
+  return fetchFromApi(options);
+  // kept for on-chain verification of the API numbers
+  return fetchFromDune(options);
 };
 
 const methodology = {
-  Fees: "Protocol fees collected from users (api.hylo.so/v1/protocol/fees), Hylo validator revenue (api.hylo.so/v1/validator/revenue), plus the yield paid to earn pool depositors (api.hylo.so/v1/protocol/digest).",
-  Revenue: "Protocol fees (mint/redeem, hyUSD/levercoin swaps, earn pool withdrawals, protocol share of harvested LST yield and borrow rate) and Hylo validator revenue (inflation commission, Jito tips, block rewards).",
-  ProtocolRevenue: "Same as Revenue; all protocol fees accrue to the protocol.",
-  SupplySideRevenue: "Harvested LST yield and borrow rate (in hyUSD) distributed to earn pool depositors.",
+  Fees: "Fees users pay to mint, redeem and swap hyUSD and levercoins (xSOL, xBTC), earn pool withdrawal fees, the staking yield and exo market borrow rate harvested from the collateral reserves, and the income of the Hylo validator.",
+  Revenue: "The portion kept by the protocol: all user-paid fees, the protocol's share of harvested yield and borrow rate, and Hylo validator income (block rewards, Jito tips, inflation commission).",
+  ProtocolRevenue: "Same as Revenue; Hylo has no token, all revenue accrues to the protocol.",
+  SupplySideRevenue: "The share of harvested yield and borrow rate paid to hyUSD depositors in the earn pool.",
 };
 
 const breakdownMethodology = {
@@ -230,9 +198,11 @@ const breakdownMethodology = {
     "Mint/Redeem Fees": "Fees on minting and redeeming hyUSD and levercoins (xSOL, xBTC, ...) against the collateral vaults.",
     "Swap Fees": "Fees on swaps between hyUSD and levercoins, and on LST swaps.",
     "Earn Pool Withdrawal Fees": "Fees on withdrawals from the hyUSD earn pool.",
-    "Yield Fees": "Protocol share of harvested LST yield and exo pair borrow rate.",
+    "LST Yield Share": "Protocol share of the staking yield harvested from the SOL LST collateral (JitoSOL, HyloSOL).",
+    "Borrow Rate Fees": "Protocol share of the borrow rate charged on exo pair markets (USDC, cbBTC, HYPE).",
     "Validator Revenue": "Hylo validator inflation commission, Jito tips and block rewards (SOL).",
     "Earn Pool Yield": "Harvested LST yield and borrow rate paid out to earn pool depositors.",
+    "Other Fees": "Protocol fees from operations not yet categorized above.",
   },
   SupplySideRevenue: {
     "Earn Pool Yield": "Harvested LST yield and borrow rate paid out to earn pool depositors.",
@@ -240,12 +210,10 @@ const breakdownMethodology = {
 };
 
 const adapter: SimpleAdapter = {
-  version: 2,
+  version: 1, // the Hylo API only serves daily aggregates
   fetch,
-  start: "2025-04-01",
+  start: "2025-04-13", // first day with data on the Hylo API
   chains: [CHAIN.SOLANA],
-  dependencies: [Dependencies.DUNE],
-  isExpensiveAdapter: true,
   methodology,
   breakdownMethodology,
 };

--- a/fees/hylo-protocol/index.ts
+++ b/fees/hylo-protocol/index.ts
@@ -7,7 +7,6 @@ import { httpGet } from "../../utils/fetchURL";
 const FEES_URL = "https://api.hylo.so/v1/protocol/fees";
 const DIGEST_URL = "https://api.hylo.so/v1/protocol/digest";
 const VALIDATOR_URL = "https://api.hylo.so/v1/validator/revenue";
-const LEGACY_URL = "https://api.hylo.so/activity/volumes";
 
 const OPERATION_LABELS: Record<string, string> = {
   MintStablecoin: "Mint/Redeem Fees",
@@ -43,17 +42,9 @@ const fetchFromApi = async (options: FetchOptions) => {
   }
 
   const dailySupplySideRevenue = options.createBalances();
-  if (date < "2025-12-06") {
-    // digest yieldToPool returns the protocol cut instead of the pool share before the Dec 2025 earn pool migration
-    const to = new Date((options.startOfDay + 86400) * 1000).toISOString().slice(0, 10);
-    const legacyRes = await httpGet(`${LEGACY_URL}?from=${date}&to=${to}`);
-    const legacyDay = legacyRes.volumes.find((v: any) => v.date === date);
-    dailySupplySideRevenue.addUSDValue(Number(legacyDay.yield_harvested_usd), "Earn Pool Yield");
-  } else {
-    const digestDay = digestRes.daily.find((d: any) => d.date === date);
-    for (const market of digestDay.markets) {
-      if (market.yieldToPool) dailySupplySideRevenue.addUSDValue(Number(market.yieldToPool.usd), "Earn Pool Yield");
-    }
+  const digestDay = digestRes.daily.find((d: any) => d.date === date);
+  for (const market of digestDay.markets) {
+    if (market.yieldToPool) dailySupplySideRevenue.addUSDValue(Number(market.yieldToPool.usd), "Earn Pool Yield");
   }
 
   // validator income settles per epoch, days without a payout are omitted

--- a/fees/hylo-protocol/index.ts
+++ b/fees/hylo-protocol/index.ts
@@ -1,175 +1,214 @@
 import { Dependencies, FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 import { queryDuneSql } from "../../helpers/dune";
-import fetchURL from "../../utils/fetchURL";
+import { httpGet } from "../../utils/fetchURL";
 
-// Hylo Protocol fee accounts
-const HYUSD_FEE_ACCOUNT = "3HT6dD6APJh89XJs9rkn3BmsvkXE9jPG9dWJmUjWu6TS";
-const JITOSOL_FEE_ACCOUNT = "FpLaqELxKRm6S3bjfNSknwZu43TL89VYkwuMDwsRMj59";
-const HYLOSOL_FEE_ACCOUNT = "CZbazc6YTRC9QyvxqPJpmerChyuzEHAdX854CB7PbQGb";
+// Docs: https://api.hylo.so/docs
+const FEES_URL = "https://api.hylo.so/v1/protocol/fees";
+const DIGEST_URL = "https://api.hylo.so/v1/protocol/digest";
 
-const HYUSD_MINT = "5YMkXAYccHSGnHn9nob9xEvv6Pvka9DZWH7nTbotTu9E";
-const JITOSOL_MINT = "J1toso1uCk3RLmjorhTtrVwY9HJ7X8V9yYac6Y7kGCPn";
-const HYLOSOL_MINT = "hy1oXYgrBW6PVcJ4s6s2FKavRdwgWTXdfE69AxT7kPT";
+interface FeeRow {
+  operation: string;
+  token: string;
+  market?: string;
+  fee: string;
+  usd: string;
+}
+
+interface FeeDay {
+  date: string;
+  byToken: { token: string; fee: string; usd: string }[];
+  byOperation: FeeRow[];
+}
+
+interface DigestDay {
+  date: string;
+  markets: { market: string; yieldToPool?: { token: string; amount: string; usd: string } }[];
+}
+
+const OPERATION_LABELS: Record<string, string> = {
+  MintStablecoin: "Mint/Redeem Fees",
+  RedeemStablecoin: "Mint/Redeem Fees",
+  MintLevercoin: "Mint/Redeem Fees",
+  RedeemLevercoin: "Mint/Redeem Fees",
+  MintLevercoinExo: "Mint/Redeem Fees",
+  RedeemLevercoinExo: "Mint/Redeem Fees",
+  SwapStableToLever: "Swap Fees",
+  SwapLeverToStable: "Swap Fees",
+  SwapStableToLeverExo: "Swap Fees",
+  SwapLeverToStableExo: "Swap Fees",
+  SwapLst: "Swap Fees",
+  UserWithdraw: "Earn Pool Withdrawal Fees",
+  HarvestYield: "Yield Fees",
+  HarvestBorrowRate: "Yield Fees",
+};
 
 const fetchFromApi = async (options: FetchOptions) => {
-  const date = new Date(options.startOfDay * 1000).toISOString().slice(0, 10);
-  const to_date = new Date((options.startOfDay + 86400) * 1000).toISOString().slice(0, 10);
-
-  // includes v2 fees, to verify data on chain: Bz6Xsr7vTo2oSFxjmJVpoC4bVNGVpP5egbdVk4Jeu1JZ, oacVCceELzvyK944xDJaMGhVKzwkaY9yBHw2uifhLJ8
-  const url = `https://api.hylo.so/activity/volumes?from=${date}&to=${to_date}`;
-  const res = await fetchURL(url);
-  const row = res?.volumes?.find((v: any) => v.date === date);
-  if (!row) throw new Error(`Hylo API returned no data for ${date}`);
+  const date = options.dateString;
+  const [feesRes, digestRes] = await Promise.all([
+    httpGet(`${FEES_URL}?from=${date}&to=${date}`),
+    httpGet(`${DIGEST_URL}?from=${date}&to=${date}`),
+  ]);
+  const feeDay: FeeDay | undefined = (feesRes?.daily || []).find((d: FeeDay) => d.date === date);
+  if (!feeDay) throw new Error(`Hylo API returned no fee data for ${date}`);
+  const digestDay: DigestDay | undefined = (digestRes?.daily || []).find((d: DigestDay) => d.date === date);
+  if (!digestDay) throw new Error(`Hylo API returned no digest data for ${date}`);
 
   const dailyRevenue = options.createBalances();
-  const dailyYields = options.createBalances();
+  for (const row of feeDay.byOperation) {
+    const usd = Number(row.usd);
+    if (!Number.isFinite(usd)) throw new Error(`Hylo API returned a bad usd value for ${date}: ${JSON.stringify(row)}`);
+    dailyRevenue.addUSDValue(usd, OPERATION_LABELS[row.operation] ?? "Other Fees");
+  }
+
+  const dailySupplySideRevenue = options.createBalances();
+  for (const market of digestDay.markets || []) {
+    if (!market.yieldToPool) continue;
+    const usd = Number(market.yieldToPool.usd);
+    if (!Number.isFinite(usd)) throw new Error(`Hylo API returned a bad yieldToPool value for ${date}: ${JSON.stringify(market)}`);
+    dailySupplySideRevenue.addUSDValue(usd, "Earn Pool Yield");
+  }
+
   const dailyFees = options.createBalances();
-
-  // Amounts are decimal strings in human units; convert to raw using token decimals.
-  dailyRevenue.addUSDValue(+row.fee_hyusd); // hyUSD is pegged to $1
-  dailyRevenue.add(JITOSOL_MINT, Math.floor(+row.fee_jitosol * 1e9));
-  dailyRevenue.add(HYLOSOL_MINT, Math.floor(+row.fee_hylosol * 1e9));
-
-  // yield_harvested is denominated in hyUSD (stability pool yields distributed to users)
-  dailyYields.addUSDValue(+row.yield_harvested);
-
   dailyFees.addBalances(dailyRevenue);
-  dailyFees.addBalances(dailyYields);
+  dailyFees.addBalances(dailySupplySideRevenue);
 
   return {
     dailyFees,
     dailyRevenue,
-    dailySupplySideRevenue: dailyYields,
+    dailyProtocolRevenue: dailyRevenue,
+    dailySupplySideRevenue,
   };
 };
 
+// Dune fallback: transfers into the fee authority PDAs + hyUSD minted to the earn pool on harvests.
+const HYUSD_MINT = "5YMkXAYccHSGnHn9nob9xEvv6Pvka9DZWH7nTbotTu9E";
+const EARN_POOL_HYUSD_OWNER = "5YrRAQag9BbJkauDtJkd1vsTquXT6N46oU8rJ66GDxHd";
+
+const FEE_ACCOUNTS: { owner: string; mint: string; label: string }[] = [
+  { owner: "3HT6dD6APJh89XJs9rkn3BmsvkXE9jPG9dWJmUjWu6TS", mint: HYUSD_MINT, label: "hyUSD" },
+  { owner: "FpLaqELxKRm6S3bjfNSknwZu43TL89VYkwuMDwsRMj59", mint: "J1toso1uCk3RLmjorhTtrVwY9HJ7X8V9yYac6Y7kGCPn", label: "JitoSOL" },
+  { owner: "925PhdF3ZXqEEWvgnSQDSSHZVoS3rhMLEfBot2cWmgpu", mint: "hy1oXYgrBW6PVcJ4s6s2FKavRdwgWTXdfE69AxT7kPT", label: "HyloSOL" },
+  { owner: "39ACqviD7R5XyGBcwwV1YVru4uvSmz5Pgt7S9RxPRPkL", mint: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v", label: "USDC" },
+  { owner: "BqhiD7AdKeYfR6mex2zYhhheoEXpPTfsYG6vnTJ9ERk2", mint: "cbbtcf3aa214zXHbiAZQwf4122FBYbraNdFqgw4iMij", label: "cbBTC" },
+  { owner: "8Xrf6qAvuH3kXfVWJGT49aBLSEUGHyG8ETuvvnu5VRSr", mint: "98sMhvDwXj1RQi5c5Mndm3vPe9cBqPrbLaufMXFNMh5g", label: "HYPE" },
+];
+
 const fetchFromDune = async (options: FetchOptions) => {
   const dailyRevenue = options.createBalances();
-  const dailyYields = options.createBalances();
+  const dailySupplySideRevenue = options.createBalances();
   const dailyFees = options.createBalances();
 
-  // Query for protocol fees (revenue)
-  const revenueQuery = `
-    SELECT
-      token_mint_address,
-      SUM(amount) AS total_fees,
-      'revenue' AS data_type
-    FROM
-      tokens_solana.transfers
-    WHERE
-      TIME_RANGE
-      AND (
-        (to_owner = '${HYUSD_FEE_ACCOUNT}' AND token_mint_address = '5YMkXAYccHSGnHn9nob9xEvv6Pvka9DZWH7nTbotTu9E') 
-        OR 
-        (to_owner = '${JITOSOL_FEE_ACCOUNT}' AND token_mint_address = 'J1toso1uCk3RLmjorhTtrVwY9HJ7X8V9yYac6Y7kGCPn')
-        OR 
-        (to_owner = '${HYLOSOL_FEE_ACCOUNT}' AND token_mint_address = 'hy1oXYgrBW6PVcJ4s6s2FKavRdwgWTXdfE69AxT7kPT')
-        
-      )
-    GROUP BY
-      token_mint_address
-  `;
+  const feeFilter = FEE_ACCOUNTS
+    .map((a) => `(to_owner = '${a.owner}' AND token_mint_address = '${a.mint}')`)
+    .join("\n        OR ");
 
-  // Query for stability pool yields distributed to users
-  const yieldsQuery = `
-    WITH stability_pool_yields AS (
-      SELECT 
-        tx_id,
+  const query = `
+    WITH revenue_data AS (
+      SELECT
         token_mint_address,
-        amount
+        SUM(amount) AS total_fees,
+        'revenue' AS data_type
       FROM tokens_solana.transfers
       WHERE TIME_RANGE
-        AND to_owner = '5YrRAQag9BbJkauDtJkd1vsTquXT6N46oU8rJ66GDxHd'
-        AND token_mint_address = '5YMkXAYccHSGnHn9nob9xEvv6Pvka9DZWH7nTbotTu9E'
+        AND (
+        ${feeFilter}
+        )
+      GROUP BY token_mint_address
+    ),
+    earn_pool_yields AS (
+      SELECT tx_id, token_mint_address, amount
+      FROM tokens_solana.transfers
+      WHERE TIME_RANGE
+        AND to_owner = '${EARN_POOL_HYUSD_OWNER}'
+        AND token_mint_address = '${HYUSD_MINT}'
         AND from_owner IS NULL  -- Only actual mints
     ),
-    xsol_transfer_txs AS (
+    other_token_txs AS (
       SELECT DISTINCT tx_id
       FROM tokens_solana.transfers
       WHERE TIME_RANGE
-        AND token_mint_address = '4sWNB8zGWHkh6UnmwiEtzNxL4XrN7uK9tosbESbJFfVs'  -- xSOL
+        AND tx_id IN (SELECT tx_id FROM earn_pool_yields)
+        AND token_mint_address <> '${HYUSD_MINT}'
         AND amount > 0
-    )
-    SELECT 
-      token_mint_address,
-      SUM(amount) AS total_fees,
-      'yield' AS data_type
-    FROM stability_pool_yields s
-    LEFT JOIN xsol_transfer_txs x ON s.tx_id = x.tx_id
-    WHERE x.tx_id IS NULL  -- Exclude transactions with any xSOL transfers
-                           -- This is because stability pool operations also mint/burn hyUSD to this wallet,
-                           -- so if a transaction has xSOL movement it means it's not a yield distribution but just a swap
-    GROUP BY token_mint_address
-  `;
-  // Combine both queries into one to reduce query cost
-  const combinedQuery = `
-    WITH revenue_data AS (
-      ${revenueQuery}
     ),
     yields_data AS (
-      ${yieldsQuery}
+      -- Swaps, rebalances and pool deposits also mint hyUSD to the pool; only
+      -- harvests touch hyUSD alone, so drop txs that move any other token.
+      SELECT
+        s.token_mint_address,
+        SUM(s.amount) AS total_fees,
+        'yield' AS data_type
+      FROM earn_pool_yields s
+      LEFT JOIN other_token_txs x ON s.tx_id = x.tx_id
+      WHERE x.tx_id IS NULL
+      GROUP BY s.token_mint_address
     )
     SELECT * FROM revenue_data
-    UNION ALL 
+    UNION ALL
     SELECT * FROM yields_data
   `;
-  const combinedData = await  queryDuneSql(options, combinedQuery)
-  const revenue = combinedData.filter(i => i.data_type === 'revenue');
-  const yields = combinedData.filter(i => i.data_type === 'yield');
+  const rows = await queryDuneSql(options, query);
 
-  // Process protocol fees (revenue)
-  revenue.forEach((row: any) => {
-    if (row.token_mint_address === '5YMkXAYccHSGnHn9nob9xEvv6Pvka9DZWH7nTbotTu9E') {
-      // hyUSD is pegged to $1, so we can add it as USD value directly
-      dailyRevenue.addUSDValue(row.total_fees / 1e6); // 6 decimals for hyUSD
-    } else {
-      // For other tokens (like jitoSOL), use automatic price conversion
-      dailyRevenue.add(row.token_mint_address, row.total_fees);
+  rows.forEach((row: any) => {
+    const amount = Number(row.total_fees) || 0;
+    if (row.data_type === "revenue") {
+      if (row.token_mint_address === HYUSD_MINT) dailyRevenue.addUSDValue(amount / 1e6);
+      else dailyRevenue.add(row.token_mint_address, amount);
+    } else if (row.data_type === "yield" && row.token_mint_address === HYUSD_MINT) {
+      dailySupplySideRevenue.addUSDValue(amount / 1e6);
     }
   });
 
-  // Process stability pool yields
-  yields.forEach((row: any) => {
-    if (row.token_mint_address === '5YMkXAYccHSGnHn9nob9xEvv6Pvka9DZWH7nTbotTu9E') {
-      // hyUSD is pegged to $1, so we can add it as USD value directly
-      dailyYields.addUSDValue(row.total_fees / 1e6); // 6 decimals for hyUSD
-    }
-  });
-
-  // Calculate total user fees (revenue + yields)
   dailyFees.addBalances(dailyRevenue);
-  dailyFees.addBalances(dailyYields);
+  dailyFees.addBalances(dailySupplySideRevenue);
 
   return {
-    dailyRevenue,           // Protocol revenue only
-    dailySupplySideRevenue: dailyYields, // Stability pool yields distributed to users
-    dailyFees          // Protocol revenue + stability pool yields
-  }
-}
+    dailyFees,
+    dailyRevenue,
+    dailyProtocolRevenue: dailyRevenue,
+    dailySupplySideRevenue,
+  };
+};
 
-const fetch: any = async (options: FetchOptions) => {
-  return fetchFromApi(options);
+const fetch = async (options: FetchOptions) => {
   try {
     return await fetchFromApi(options);
   } catch (e) {
-    // Fall back to Dune query if the Hylo API is unavailable
+    console.error("Hylo API failed, falling back to Dune", e);
     return await fetchFromDune(options);
   }
 };
 
+const methodology = {
+  Fees: "Protocol fees collected from users (api.hylo.so/v1/protocol/fees) plus the yield paid to earn pool depositors (api.hylo.so/v1/protocol/digest).",
+  Revenue: "Protocol fees: mint/redeem fees, hyUSD/levercoin swap fees, earn pool withdrawal fees, and the protocol's share of harvested LST yield and borrow rate.",
+  ProtocolRevenue: "Same as Revenue; all protocol fees accrue to the protocol.",
+  SupplySideRevenue: "Harvested LST yield and borrow rate (in hyUSD) distributed to earn pool depositors.",
+};
+
+const breakdownMethodology = {
+  Fees: {
+    "Mint/Redeem Fees": "Fees on minting and redeeming hyUSD and levercoins (xSOL, xBTC, ...) against the collateral vaults.",
+    "Swap Fees": "Fees on swaps between hyUSD and levercoins, and on LST swaps.",
+    "Earn Pool Withdrawal Fees": "Fees on withdrawals from the hyUSD earn pool.",
+    "Yield Fees": "Protocol share of harvested LST yield and exo pair borrow rate.",
+    "Earn Pool Yield": "Harvested LST yield and borrow rate paid out to earn pool depositors.",
+  },
+  SupplySideRevenue: {
+    "Earn Pool Yield": "Harvested LST yield and borrow rate paid out to earn pool depositors.",
+  },
+};
+
 const adapter: SimpleAdapter = {
-  version: 1,
+  version: 2,
   fetch,
-  start: '2025-04-01',
+  start: "2025-04-01",
   chains: [CHAIN.SOLANA],
   dependencies: [Dependencies.DUNE],
   isExpensiveAdapter: true,
-  methodology: {
-    Fees: "Stability pool yields (in hyUSD) distributed to users.",
-    Revenue: "Swap fees, and part of reserve LSTs yield",
-    SupplySideRevenue: "Stability pool yields (in hyUSD) distributed to users.",
-  },
+  methodology,
+  breakdownMethodology,
 };
 
 export default adapter;

--- a/fees/hylo-protocol/index.ts
+++ b/fees/hylo-protocol/index.ts
@@ -6,6 +6,7 @@ import { httpGet } from "../../utils/fetchURL";
 // Docs: https://api.hylo.so/docs
 const FEES_URL = "https://api.hylo.so/v1/protocol/fees";
 const DIGEST_URL = "https://api.hylo.so/v1/protocol/digest";
+const VALIDATOR_URL = "https://api.hylo.so/v1/validator/revenue";
 
 interface FeeRow {
   operation: string;
@@ -25,6 +26,23 @@ interface DigestDay {
   date: string;
   markets: { market: string; yieldToPool?: { token: string; amount: string; usd: string } }[];
 }
+
+interface ValidatorDay {
+  date: string;
+  total?: string; // SOL
+}
+
+// Hylo validator: inflation commission + Jito tips + block rewards, in SOL.
+// Inflation and Jito settle once per epoch; days with no activity are omitted.
+const addValidatorRevenue = async (options: FetchOptions, balances: any) => {
+  const date = options.dateString;
+  const res = await httpGet(`${VALIDATOR_URL}?from=${date}&to=${date}`);
+  const day: ValidatorDay | undefined = (res?.daily || []).find((d: ValidatorDay) => d.date === date);
+  if (!day) return;
+  const sol = Number(day.total ?? 0);
+  if (!Number.isFinite(sol)) throw new Error(`Hylo API returned a bad validator total for ${date}: ${JSON.stringify(day)}`);
+  balances.addCGToken("solana", sol, "Validator Revenue");
+};
 
 const OPERATION_LABELS: Record<string, string> = {
   MintStablecoin: "Mint/Redeem Fees",
@@ -69,6 +87,8 @@ const fetchFromApi = async (options: FetchOptions) => {
     dailySupplySideRevenue.addUSDValue(usd, "Earn Pool Yield");
   }
 
+  await addValidatorRevenue(options, dailyRevenue);
+
   const dailyFees = options.createBalances();
   dailyFees.addBalances(dailyRevenue);
   dailyFees.addBalances(dailySupplySideRevenue);
@@ -84,6 +104,7 @@ const fetchFromApi = async (options: FetchOptions) => {
 // Dune fallback: transfers into the fee authority PDAs + hyUSD minted to the earn pool on harvests.
 const HYUSD_MINT = "5YMkXAYccHSGnHn9nob9xEvv6Pvka9DZWH7nTbotTu9E";
 const EARN_POOL_HYUSD_OWNER = "5YrRAQag9BbJkauDtJkd1vsTquXT6N46oU8rJ66GDxHd";
+const VALIDATOR_IDENTITY = "hy1oMaD3ViyJ8i6w1xjP79zAWBBaRd1zWdTW8zYXnwu";
 
 const FEE_ACCOUNTS: { owner: string; mint: string; label: string }[] = [
   { owner: "3HT6dD6APJh89XJs9rkn3BmsvkXE9jPG9dWJmUjWu6TS", mint: HYUSD_MINT, label: "hyUSD" },
@@ -143,10 +164,25 @@ const fetchFromDune = async (options: FetchOptions) => {
       LEFT JOIN other_token_txs x ON s.tx_id = x.tx_id
       WHERE x.tx_id IS NULL
       GROUP BY s.token_mint_address
+    ),
+    validator_data AS (
+      -- Block fee rewards credited to the validator identity. Inflation
+      -- commission is 0% and Jito tips are claimed via merkle proofs, so
+      -- solana.rewards does not carry them.
+      SELECT
+        'SOL' AS token_mint_address,
+        CAST(SUM(lamports) AS DOUBLE) AS total_fees,
+        'validator' AS data_type
+      FROM solana.rewards
+      WHERE TIME_RANGE
+        AND recipient = '${VALIDATOR_IDENTITY}'
+        AND reward_type = 'Fee'
     )
     SELECT * FROM revenue_data
     UNION ALL
     SELECT * FROM yields_data
+    UNION ALL
+    SELECT * FROM validator_data
   `;
   const rows = await queryDuneSql(options, query);
 
@@ -157,6 +193,8 @@ const fetchFromDune = async (options: FetchOptions) => {
       else dailyRevenue.add(row.token_mint_address, amount);
     } else if (row.data_type === "yield" && row.token_mint_address === HYUSD_MINT) {
       dailySupplySideRevenue.addUSDValue(amount / 1e6);
+    } else if (row.data_type === "validator") {
+      dailyRevenue.addCGToken("solana", amount / 1e9, "Validator Revenue");
     }
   });
 
@@ -181,8 +219,8 @@ const fetch = async (options: FetchOptions) => {
 };
 
 const methodology = {
-  Fees: "Protocol fees collected from users (api.hylo.so/v1/protocol/fees) plus the yield paid to earn pool depositors (api.hylo.so/v1/protocol/digest).",
-  Revenue: "Protocol fees: mint/redeem fees, hyUSD/levercoin swap fees, earn pool withdrawal fees, and the protocol's share of harvested LST yield and borrow rate.",
+  Fees: "Protocol fees collected from users (api.hylo.so/v1/protocol/fees), Hylo validator revenue (api.hylo.so/v1/validator/revenue), plus the yield paid to earn pool depositors (api.hylo.so/v1/protocol/digest).",
+  Revenue: "Protocol fees (mint/redeem, hyUSD/levercoin swaps, earn pool withdrawals, protocol share of harvested LST yield and borrow rate) and Hylo validator revenue (inflation commission, Jito tips, block rewards).",
   ProtocolRevenue: "Same as Revenue; all protocol fees accrue to the protocol.",
   SupplySideRevenue: "Harvested LST yield and borrow rate (in hyUSD) distributed to earn pool depositors.",
 };
@@ -193,6 +231,7 @@ const breakdownMethodology = {
     "Swap Fees": "Fees on swaps between hyUSD and levercoins, and on LST swaps.",
     "Earn Pool Withdrawal Fees": "Fees on withdrawals from the hyUSD earn pool.",
     "Yield Fees": "Protocol share of harvested LST yield and exo pair borrow rate.",
+    "Validator Revenue": "Hylo validator inflation commission, Jito tips and block rewards (SOL).",
     "Earn Pool Yield": "Harvested LST yield and borrow rate paid out to earn pool depositors.",
   },
   SupplySideRevenue: {


### PR DESCRIPTION
## Summary

Hylo now exposes dedicated revenue endpoints on its public API (docs: https://api.hylo.so/docs). This PR moves the `hylo-protocol` fees adapter to the v1 API and keeps Dune as a verifiable fallback.

**API path (primary)**
- `/v1/protocol/fees?from=<day>&to=<day>`: daily protocol fee rollup per token and per operation, USD-valued at event time. Every row is a fee that accrued to the protocol → `dailyRevenue` / `dailyProtocolRevenue`.
- `/v1/protocol/digest?from=<day>&to=<day>`: per-market `yieldToPool`, the harvested yield paid to earn pool depositors → `dailySupplySideRevenue`.
- `/v1/validator/revenue?from=<day>&to=<day>`: Hylo validator revenue in SOL (block rewards + Jito tips + inflation commission) → `dailyRevenue`, label "Validator Revenue".
- `dailyFees` = protocol fees + validator revenue + yield to pool.
- Covers all fee tokens, including the v2 exo pairs (USDC, cbBTC, HYPE) the previous adapter missed. Adds a fee breakdown by operation group.

**Dune fallback** (runs only when the API call fails; same metrics, on-chain)
- Fee transfers into the protocol fee authority PDAs, now incl. USDC, cbBTC, HYPE.
- Fixes the HyloSOL filter: the old query used the fee *token account* as `to_owner`; the owner is the fee authority PDA `925Phd…`, so HyloSOL fees never matched.
- Earn pool yield: rebalance swaps (`SwapLstToUsdc`, `SwapExoToUsdc`) also mint hyUSD to the pool without moving a levercoin, so the old "exclude txs with xSOL" filter overcounted. Harvests are the only pool mints whose tx touches hyUSD alone; the filter now uses that.
- Validator: `solana.rewards` `Fee` rewards to the identity `hy1oMaD3…`. Inflation commission is 0% and Jito tips are merkle-claimed, so they are not in `solana.rewards` (small: ~0.3 SOL/epoch).

## Test (day 2026-08-19)

API path, `npm test -- fees hylo-protocol 2026-08-20`:
```
Daily fees:                17.42 k  (+764 validator → 18.18 k after validator indexer backfill)
Daily revenue:             13.31 k
Daily protocol revenue:    13.31 k
Daily supply side revenue: 4.72 k

label                     | Daily fees | Daily revenue | Daily supply side revenue
Yield Fees                | 248        | 248           |
Mint/Redeem Fees          | 9395       | 9395          |
Swap Fees                 | 2856       | 2856          |
Earn Pool Withdrawal Fees | 44         | 44            |
Validator Revenue         | 764        | 764           |
Earn Pool Yield           | 4718       |               | 4718
```

Dune fallback (API host pointed at an invalid domain), same day:
- fee token amounts identical to the API (hyUSD 3155.02, JitoSOL 18.359, HyloSOL 7.890, USDC 158.17, cbBTC 0.01511, HYPE 82.378)
- earn pool yield 4,718 hyUSD identical
- validator 264 blocks / 8.6497 SOL = API `blockRewards` exactly; API total 8.9536 SOL adds Jito tips
- USD totals differ only by pricing source (13.59k vs 13.31k revenue)