### PR TITLE
feat: temporarily remove four AZverse broker interfaces (keep azx-perps)

### DIFF
--- a/factory/azverse.ts
+++ b/factory/azverse.ts
@@ -4,10 +4,6 @@ import { createFactoryExports } from "./registry";
 // broker_id values are returned by https://app.azverse.xyz/exapi/stats/v1/stats/public/defillama/brokers
 const brokerConfigs = {
   "azx-perps": { brokerId: "AZVERSE", brokerName: "AZX", start: "2025-12-31" },
-  "avodex-perps": { brokerId: "AVODEX", brokerName: "AvoDex", start: "2025-12-31" },
-  "monster-perps": { brokerId: "MONSTER", brokerName: "Monster", start: "2025-12-31" },
-  "bbx-perps": { brokerId: "BBXCOM", brokerName: "BBX", start: "2025-12-31" },
-  "xox-perps": { brokerId: "XOX", brokerName: "XOX", start: "2025-12-31" },
 };
 
 const dexsProtocols = Object.fromEntries(


### PR DESCRIPTION
## Summary

Temporarily removes four AZverse broker-interface adapters from both the volume (dexs) and fees factory registries:

- `avodex-perps`
- `monster-perps`
- `bbx-perps`
- `xox-perps`

`azx-perps` remains listed and unchanged. The canonical `azverse` / `azverse-spot` adapters are not affected.

## Reason

At AZverse's request. These four are early-stage partner interfaces; as part of a phased go-to-market, the partners prefer to be listed at a later time, and may be reintroduced once ready.

If the corresponding protocol/metadata pages remain visible after this change is deployed, could you please also hide them? (They may live in the main DefiLlama config repo rather than this one.)

## Testing

- `pnpm run ts-check`
- Verified the AZverse factory lists contain only `azx-perps` for both `dexs` and `fees`
- `pnpm test dexs azx-perps 2026-08-20` → `Daily volume: 56.78 M`
