### PR TITLE
Add Drake Exchange fees and volume adapters (Monad)

### DIFF
--- a/dexs/drake-exchange/index.ts
+++ b/dexs/drake-exchange/index.ts
@@ -1,0 +1,29 @@
+import { FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+
+const TRADING = "0xE6dfD064F1CFf4F62236fC862A2543EA98380F32";
+const AUSD = "0x00000000eFE302BEAA2b3e6e1b18d08D69a9012a";
+
+const fetch = async ({ getLogs, createBalances }: FetchOptions) => {
+    const dailyVolume = createBalances();
+
+    const logs = await getLogs({
+        target: TRADING,
+        eventAbi:
+            "event TakerOrderExecuted(uint256 indexed orderId, address indexed portfolio, uint256 indexed instId, uint8 side, uint8 orderKind, uint256 executionPrice, uint256 orderbookVolume, uint256 vaultVolume)",
+    });
+
+    logs.forEach((log: any) => {
+        const total = BigInt(log.orderbookVolume) + BigInt(log.vaultVolume);
+        dailyVolume.add(AUSD, total);
+    });
+
+    return { dailyVolume };
+};
+
+export default {
+    version: 2,
+    adapter: {
+        [CHAIN.MONAD]: { fetch, start: 1783409183 },
+    },
+} as SimpleAdapter;

--- a/dexs/drake-exchange/index.ts
+++ b/dexs/drake-exchange/index.ts
@@ -4,10 +4,10 @@ import { CHAIN } from "../../helpers/chains";
 const TRADING = "0xE6dfD064F1CFf4F62236fC862A2543EA98380F32";
 const AUSD = "0x00000000eFE302BEAA2b3e6e1b18d08D69a9012a";
 
-const fetch = async ({ getLogs, createBalances }: FetchOptions) => {
-    const dailyVolume = createBalances();
+const fetch = async (options: FetchOptions) => {
+    const dailyVolume = options.createBalances();
 
-    const logs = await getLogs({
+    const logs = await options.getLogs({
         target: TRADING,
         eventAbi:
             "event TakerOrderExecuted(uint256 indexed orderId, address indexed portfolio, uint256 indexed instId, uint8 side, uint8 orderKind, uint256 executionPrice, uint256 orderbookVolume, uint256 vaultVolume)",

--- a/dexs/drake-exchange/index.ts
+++ b/dexs/drake-exchange/index.ts
@@ -23,7 +23,8 @@ const fetch = async (options: FetchOptions) => {
 
 export default {
     version: 2,
-    adapter: {
-        [CHAIN.MONAD]: { fetch, start: 1783409183 },
-    },
+    pullHourly: true,
+    chains: [CHAIN.MONAD],
+    start: 1783409183,
+    fetch,
 } as SimpleAdapter;

--- a/fees/drake-exchange/index.ts
+++ b/fees/drake-exchange/index.ts
@@ -1,0 +1,137 @@
+import { FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import { METRIC } from "../../helpers/metrics";
+
+const TRADING = "0xE6dfD064F1CFf4F62236fC862A2543EA98380F32";
+const COMMON_HELPER = "0x4939AEf78CD2Dc2bAE5bf9DA51C61A113Cae909a";
+const AUSD = "0x00000000eFE302BEAA2b3e6e1b18d08D69a9012a";
+const PLATFORM_MANAGER = "0x7940575377C3c2ABdA23813c123b4C880E217d6d";
+
+const COMMISSION_FEE = 3;
+const MARGIN_CHANGE_FEE = 4;
+
+type FeeSplit = { vault: number; treasury: number };
+type SplitSchedule = Array<{ fromBlock: number } & FeeSplit>;
+
+// Last matching fromBlock wins. Append a row when the on-chain split changes.
+const ORDERBOOK_SPLIT: SplitSchedule = [
+    { fromBlock: 0, vault: 0.2, treasury: 0.8 },
+];
+
+const AMM_SPLIT: SplitSchedule = [
+    { fromBlock: 0, vault: 0.6, treasury: 0.4 },
+    { fromBlock: 96996873, vault: 0.4, treasury: 0.6 },
+];
+
+function splitAt(schedule: SplitSchedule, block: number): FeeSplit {
+    let split = schedule[0];
+    for (const row of schedule) {
+        if (block >= row.fromBlock) split = row;
+    }
+    return split;
+}
+
+const fetch = async ({ getLogs, createBalances }: FetchOptions) => {
+    const dailyFees = createBalances();
+    const dailyRevenue = createBalances();
+    const dailySupplySideRevenue = createBalances();
+
+    const trades = await getLogs({
+        target: TRADING,
+        eventAbi:
+            "event TakerOrderExecuted(uint256 indexed orderId, address indexed portfolio, uint256 indexed instId, uint8 side, uint8 orderKind, uint256 executionPrice, uint256 orderbookVolume, uint256 vaultVolume)",
+    });
+    const fillRatioByTx: Record<string, number> = {};
+    trades.forEach((t: any) => {
+        const ob = BigInt(t.orderbookVolume);
+        const amm = BigInt(t.vaultVolume);
+        const total = ob + amm;
+        if (total > 0n)
+            fillRatioByTx[t.transactionHash] = Number(ob) / Number(total);
+    });
+
+    const transfers = await getLogs({
+        target: COMMON_HELPER,
+        eventAbi:
+            "event AssetTransferred(address indexed _portfolio, uint8 _actionType, int256 _amountIn)",
+    });
+
+    transfers.forEach((tr: any) => {
+        if (
+            tr._actionType !== COMMISSION_FEE &&
+            tr._actionType !== MARGIN_CHANGE_FEE
+        )
+            return;
+        const amt =
+            tr._amountIn < 0n ? -BigInt(tr._amountIn) : BigInt(tr._amountIn);
+
+        if (tr._actionType === MARGIN_CHANGE_FEE) {
+            dailyFees.add(AUSD, amt, METRIC.MARGIN_FEES);
+            dailySupplySideRevenue.add(AUSD, amt, METRIC.MARGIN_FEES);
+            return;
+        }
+
+        dailyFees.add(AUSD, amt, METRIC.TRADING_FEES);
+        const ratio = fillRatioByTx[tr.transactionHash] ?? 0;
+        const block = Number(tr.blockNumber);
+        const orderbookSplit = splitAt(ORDERBOOK_SPLIT, block);
+        const ammSplit = splitAt(AMM_SPLIT, block);
+        const vaultPct =
+            ratio * orderbookSplit.vault + (1 - ratio) * ammSplit.vault;
+        const treasuryPct = 1 - vaultPct;
+        dailySupplySideRevenue.add(
+            AUSD,
+            (amt * BigInt(Math.round(vaultPct * 10000))) / 10000n,
+            METRIC.TRADING_FEES,
+        );
+        dailyRevenue.add(
+            AUSD,
+            (amt * BigInt(Math.round(treasuryPct * 10000))) / 10000n,
+            METRIC.TRADING_FEES,
+        );
+    });
+
+    const fbFees = await getLogs({
+        target: PLATFORM_MANAGER, // confirm emitting contract — see TL;DR
+        eventAbi:
+            "event PositionPendingFBFeeCharged(address indexed portfolio, int256 totalFBFee)",
+    });
+    fbFees.forEach((f: any) => {
+        if (f.totalFBFee <= 0n) return;
+        dailyFees.add(AUSD, BigInt(f.totalFBFee), METRIC.BORROW_INTEREST);
+        dailySupplySideRevenue.add(AUSD, BigInt(f.totalFBFee), METRIC.BORROW_INTEREST);
+    });
+
+    return { dailyFees, dailyRevenue, dailySupplySideRevenue };
+};
+
+const breakdownMethodology = {
+    Fees: {
+        [METRIC.TRADING_FEES]: "Trading commission on orderbook and AMM fills.",
+        [METRIC.MARGIN_FEES]: "Isolated margin add/reduce fees.",
+        [METRIC.BORROW_INTEREST]: "Net borrowing and imbalance funding fees charged to traders.",
+    },
+    Revenue: {
+        [METRIC.TRADING_FEES]: "Treasury share of trading commission per the orderbook and AMM splits in effect at that block.",
+    },
+    SupplySideRevenue: {
+        [METRIC.TRADING_FEES]: "Liquidity vault share of trading commission per the orderbook and AMM splits in effect at that block.",
+        [METRIC.MARGIN_FEES]: "100% of isolated margin add/reduce fees routed to the liquidity vault.",
+        [METRIC.BORROW_INTEREST]: "100% of borrowing and funding fees routed to the liquidity vault.",
+    },
+};
+
+export default {
+    version: 2,
+    adapter: {
+        [CHAIN.MONAD]: { fetch, start: 1783409183 },
+    },
+    methodology: {
+        Fees: "All trading commission fees (orderbook + AMM), isolated margin add/reduce fees, and net borrowing/imbalance funding fees charged to traders.",
+        Revenue:
+            "Share of trade commission fees routed to the Operation Vault (treasury) per the orderbook and AMM splits in effect at that block.",
+        SupplySideRevenue:
+            "Share routed to the Liquidity Vault per the orderbook and AMM splits in effect at that block, plus 100% of margin-change and borrowing/funding fees.",
+    },
+    breakdownMethodology,
+} as SimpleAdapter;

--- a/fees/drake-exchange/index.ts
+++ b/fees/drake-exchange/index.ts
@@ -31,12 +31,12 @@ function splitAt(schedule: SplitSchedule, block: number): FeeSplit {
     return split;
 }
 
-const fetch = async ({ getLogs, createBalances }: FetchOptions) => {
-    const dailyFees = createBalances();
-    const dailyRevenue = createBalances();
-    const dailySupplySideRevenue = createBalances();
+const fetch = async (options: FetchOptions) => {
+    const dailyFees = options.createBalances();
+    const dailyRevenue = options.createBalances();
+    const dailySupplySideRevenue = options.createBalances();
 
-    const trades = await getLogs({
+    const trades = await options.getLogs({
         target: TRADING,
         eventAbi:
             "event TakerOrderExecuted(uint256 indexed orderId, address indexed portfolio, uint256 indexed instId, uint8 side, uint8 orderKind, uint256 executionPrice, uint256 orderbookVolume, uint256 vaultVolume)",
@@ -50,7 +50,7 @@ const fetch = async ({ getLogs, createBalances }: FetchOptions) => {
             fillRatioByTx[t.transactionHash] = Number(ob) / Number(total);
     });
 
-    const transfers = await getLogs({
+    const transfers = await options.getLogs({
         target: COMMON_HELPER,
         eventAbi:
             "event AssetTransferred(address indexed _portfolio, uint8 _actionType, int256 _amountIn)",
@@ -91,7 +91,7 @@ const fetch = async ({ getLogs, createBalances }: FetchOptions) => {
         );
     });
 
-    const fbFees = await getLogs({
+    const fbFees = await options.getLogs({
         target: PLATFORM_MANAGER, // confirm emitting contract — see TL;DR
         eventAbi:
             "event PositionPendingFBFeeCharged(address indexed portfolio, int256 totalFBFee)",

--- a/fees/drake-exchange/index.ts
+++ b/fees/drake-exchange/index.ts
@@ -123,9 +123,10 @@ const breakdownMethodology = {
 
 export default {
     version: 2,
-    adapter: {
-        [CHAIN.MONAD]: { fetch, start: 1783409183 },
-    },
+    pullHourly: true,
+    chains: [CHAIN.MONAD],
+    start: 1783409183,
+    fetch,
     methodology: {
         Fees: "All trading commission fees (orderbook + AMM), isolated margin add/reduce fees, and net borrowing/imbalance funding fees charged to traders.",
         Revenue:

--- a/fees/drake-exchange/index.ts
+++ b/fees/drake-exchange/index.ts
@@ -38,13 +38,14 @@ const fetch = async (options: FetchOptions) => {
 
     const trades = await options.getLogs({
         target: TRADING,
+        onlyArgs: false,
         eventAbi:
             "event TakerOrderExecuted(uint256 indexed orderId, address indexed portfolio, uint256 indexed instId, uint8 side, uint8 orderKind, uint256 executionPrice, uint256 orderbookVolume, uint256 vaultVolume)",
     });
     const fillRatioByTx: Record<string, number> = {};
     trades.forEach((t: any) => {
-        const ob = BigInt(t.orderbookVolume);
-        const amm = BigInt(t.vaultVolume);
+        const ob = BigInt(t.args.orderbookVolume);
+        const amm = BigInt(t.args.vaultVolume);
         const total = ob + amm;
         if (total > 0n)
             fillRatioByTx[t.transactionHash] = Number(ob) / Number(total);
@@ -52,20 +53,23 @@ const fetch = async (options: FetchOptions) => {
 
     const transfers = await options.getLogs({
         target: COMMON_HELPER,
+        onlyArgs: false,
         eventAbi:
             "event AssetTransferred(address indexed _portfolio, uint8 _actionType, int256 _amountIn)",
     });
 
     transfers.forEach((tr: any) => {
         if (
-            tr._actionType !== COMMISSION_FEE &&
-            tr._actionType !== MARGIN_CHANGE_FEE
+            tr.args._actionType !== COMMISSION_FEE &&
+            tr.args._actionType !== MARGIN_CHANGE_FEE
         )
             return;
         const amt =
-            tr._amountIn < 0n ? -BigInt(tr._amountIn) : BigInt(tr._amountIn);
+            tr.args._amountIn < 0n
+                ? -BigInt(tr.args._amountIn)
+                : BigInt(tr.args._amountIn);
 
-        if (tr._actionType === MARGIN_CHANGE_FEE) {
+        if (tr.args._actionType === MARGIN_CHANGE_FEE) {
             dailyFees.add(AUSD, amt, METRIC.MARGIN_FEES);
             dailySupplySideRevenue.add(AUSD, amt, METRIC.MARGIN_FEES);
             return;


### PR DESCRIPTION
## Summary

- Add `fees/drake-exchange` (v2): trading commission, isolated margin fees, and net borrowing/funding fees from on-chain logs on Monad.
- Add `dexs/drake-exchange` (v2): daily notional volume from `TakerOrderExecuted` (orderbook + AMM vault).
- Commission is split between the liquidity vault and treasury using block-keyed `ORDERBOOK_SPLIT` / `AMM_SPLIT` schedules.
---

##### Name (to be shown on DefiLlama):
Drake Exchange

##### Twitter Link:
https://x.com/DrakeExchange

##### List of audit links if any:
https://docs.drake.exchange/security/audit-report

##### Website Link:
https://drake.exchange/

##### Logo (High resolution, will be shown with rounded borders):
https://docs.drake.exchange/info/media-kit

##### Chain:
Monad

##### Short Description (to be shown on DefiLlama):
Fully on-chain perpetual exchange on Monad with hybrid CLOB + AMM liquidity and isolated/cross-margin portfolios.

##### Category (full list at https://defillama.com/categories) *Please choose only one:
Derivatives

##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.):
Pyth Network

##### Implementation Details: Briefly describe how the oracle is integrated into your project:
Off-chain operators fetch signed prices from active oracle networks, normalize them, drop stale (>60s) or invalid values, then write a simple average on-chain. Aggregated prices are used for AMM vault quotes, margin checks, liquidations, funding, and position valuation. Chainlink Data Streams reports are verified on-chain through Chainlink's verification contract when needed for trades, liquidations, or position updates.

##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage:
https://docs.drake.exchange/trading/oracle-price


##### methodology (what is being counted as tvl, how is tvl being calculated):
N/A for this PR (fees + volume only). Fees: all trading commission, isolated margin add/reduce fees, and net borrowing/imbalance funding fees. Revenue: treasury share of commission per the orderbook/AMM split in effect at that block. Supply-side: liquidity vault share of commission plus 100% of margin-change and borrowing/funding fees. Volume: taker notional (`orderbookVolume + vaultVolume`) in AUSD.


##### forkedFrom (Does your project originate from another project):
No

##### Github org/user (Optional, if your code is open source, we can track activity):
https://github.com/drxprotocol

##### Does this project have a referral program?
Yes. https://docs.drake.exchange/community/referrals
