### PR TITLE
Thorswap: add v5.1 fee collector

### DIFF
--- a/fees/thorswap/index.ts
+++ b/fees/thorswap/index.ts
@@ -4,7 +4,12 @@ import { addTokensReceived } from "../../helpers/token";
 
 const fetch = async (options: FetchOptions): Promise<FetchResultFees> => {
   const dailyFees = await addTokensReceived({
-    targets: ['0x546e7b1f4b4Df6CDb19fbDdFF325133EBFE04BA7', '0x6Ee1f539DDf1515eE49B58A5E9ae84C2E7643490', '0x6d1eff1aFF1dc9978d851D09d9d15f2938Da7BD7'], // v3, v4, v5 fee collectors
+    targets: [
+      '0x546e7b1f4b4Df6CDb19fbDdFF325133EBFE04BA7',
+      '0x6Ee1f539DDf1515eE49B58A5E9ae84C2E7643490',
+      '0x6d1eff1aFF1dc9978d851D09d9d15f2938Da7BD7',
+      '0x335Fd459eADf098f8B2f26692936Ee3D5Bb425A2',
+    ], // v3, v4, v5 and v5.1 fee collectors
     tokens: ['0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48'],
     options
   })


### PR DESCRIPTION
### What

Adds a new source of fees to the Thorswap adapter: the **v5.1 fee collector** `0x335Fd459eADf098f8B2f26692936Ee3D5Bb425A2` on Ethereum.

Thorswap deployed this contract on **2026-07-10**, and swap fees have been routed to it since. It was missing from the adapter's `targets`, so everything collected there has been going uncounted.

### Verification

USDC `Transfer` logs to each collector over blocks `25498462` → `25799778` (2026-07-10 → 2026-08-21):

| collector | address | transfers | USDC received |
|---|---|---|---|
| v3 | `0x546e7b1f4b4Df6CDb19fbDdFF325133EBFE04BA7` | 0 | 0.00 |
| v4 | `0x6Ee1f539DDf1515eE49B58A5E9ae84C2E7643490` | 0 | 0.00 |
| v5 | `0x6d1eff1aFF1dc9978d851D09d9d15f2938Da7BD7` | 71 | 87,602.90 |
| **v5.1 (new)** | `0x335Fd459eADf098f8B2f26692936Ee3D5Bb425A2` | **175** | **195,953.64** |

The new collector accounts for ~69% of fee revenue over that window, so without this change the adapter under-reports Thorswap fees by roughly two thirds.

### ⚠️ Backfill needed

**This adapter needs to be backfilled starting from the v5.1 contract's deployment date, 2026-07-10.** Data already stored for 2026-07-10 onwards is too low and will not self-correct.

### Test output

`npm run test fees thorswap <date>`, run for every day from deployment to now:

```
2026-07-10 | Daily fees: 0.00     protocol: 0.00     holders: 0.00
2026-07-11 | Daily fees: 27.62 k  protocol: 6.91 k   holders: 20.72 k
2026-07-12 | Daily fees: 5.13 k   protocol: 1.28 k   holders: 3.85 k
2026-07-13 | Daily fees: 1.06 k   protocol: 265.00   holders: 794.00
2026-07-14 | Daily fees: 4.08 k   protocol: 1.02 k   holders: 3.06 k
2026-07-15 | Daily fees: 6.50 k   protocol: 1.63 k   holders: 4.88 k
2026-07-16 | Daily fees: 24.78 k  protocol: 6.19 k   holders: 18.58 k
2026-07-17 | Daily fees: 6.92 k   protocol: 1.73 k   holders: 5.19 k
2026-07-18 | Daily fees: 6.37 k   protocol: 1.59 k   holders: 4.78 k
2026-07-19 | Daily fees: 6.63 k   protocol: 1.66 k   holders: 4.97 k
2026-07-20 | Daily fees: 5.19 k   protocol: 1.30 k   holders: 3.89 k
2026-07-21 | Daily fees: 10.17 k  protocol: 2.54 k   holders: 7.63 k
2026-07-22 | Daily fees: 11.13 k  protocol: 2.78 k   holders: 8.35 k
2026-07-23 | Daily fees: 13.18 k  protocol: 3.30 k   holders: 9.89 k
2026-07-24 | Daily fees: 15.11 k  protocol: 3.78 k   holders: 11.33 k
2026-07-25 | Daily fees: 1.05 k   protocol: 262.00   holders: 787.00
2026-07-26 | Daily fees: 1.54 k   protocol: 385.00   holders: 1.16 k
2026-07-27 | Daily fees: 3.97 k   protocol: 992.00   holders: 2.98 k
2026-07-28 | Daily fees: 1.63 k   protocol: 408.00   holders: 1.23 k
2026-07-29 | Daily fees: 3.27 k   protocol: 818.00   holders: 2.45 k
2026-07-30 | Daily fees: 7.06 k   protocol: 1.77 k   holders: 5.30 k
2026-07-31 | Daily fees: 2.77 k   protocol: 693.00   holders: 2.08 k
2026-08-01 | Daily fees: 14.43 k  protocol: 3.61 k   holders: 10.82 k
2026-08-02 | Daily fees: 5.42 k   protocol: 1.35 k   holders: 4.06 k
2026-08-03 | Daily fees: 2.44 k   protocol: 609.00   holders: 1.83 k
2026-08-04 | Daily fees: 9.24 k   protocol: 2.31 k   holders: 6.93 k
2026-08-05 | Daily fees: 6.75 k   protocol: 1.69 k   holders: 5.06 k
2026-08-06 | Daily fees: 5.51 k   protocol: 1.38 k   holders: 4.13 k
2026-08-07 | Daily fees: 6.44 k   protocol: 1.61 k   holders: 4.83 k
2026-08-08 | Daily fees: 2.50 k   protocol: 625.00   holders: 1.87 k
2026-08-09 | Daily fees: 1.20 k   protocol: 300.00   holders: 899.00
2026-08-10 | Daily fees: 1.01 k   protocol: 254.00   holders: 761.00
2026-08-11 | Daily fees: 4.44 k   protocol: 1.11 k   holders: 3.33 k
2026-08-12 | Daily fees: 8.71 k   protocol: 2.18 k   holders: 6.53 k
2026-08-13 | Daily fees: 0.00     protocol: 0.00     holders: 0.00
2026-08-14 | Daily fees: 0.00     protocol: 0.00     holders: 0.00
2026-08-15 | Daily fees: 1.06 k   protocol: 266.00   holders: 799.00
2026-08-16 | Daily fees: 2.47 k   protocol: 616.00   holders: 1.85 k
2026-08-17 | Daily fees: 1.47 k   protocol: 366.00   holders: 1.10 k
2026-08-18 | Daily fees: 9.24 k   protocol: 2.31 k   holders: 6.93 k
2026-08-19 | Daily fees: 14.63 k  protocol: 3.66 k   holders: 10.97 k
2026-08-20 | Daily fees: 11.58 k  protocol: 2.89 k   holders: 8.68 k
2026-08-21 | Daily fees: 9.81 k   protocol: 2.45 k   holders: 7.36 k
```

Methodology is unchanged: fees = USDC received by Thorswap fee collectors; 25% protocol revenue, 75% holders revenue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
