### PR TITLE
Add topblast.lol — TON launchpad (fees + volume)

### DIFF
--- a/fees/topblast-lol/index.ts
+++ b/fees/topblast-lol/index.ts
@@ -1,0 +1,64 @@
+/**
+ * Topblast / GroypFi — Fees & Revenue on TON
+ *
+ * 1% platform fee on every swap routed through the aggregator
+ * (DeDust, STON.fi, Tonco, Bidask). 100% of fees are protocol revenue
+ * used for GROYP buybacks.
+ *
+ * Data source: public, no-API-key stats endpoint
+ *   https://gyihzeiwelsuikfrschp.supabase.co/functions/v1/defillama?date=YYYY-MM-DD
+ *
+ * The endpoint reads incoming TON transfers to the on-chain house fee wallet:
+ *   UQDu4AiT__JKuqT0Znje0RoXIQMPcj4uIGYZme3UK4hFlE_Q
+ *   0:eee00893fff24abaa4f46678ded11a1721030f723e2e20661999edd42b884594
+ */
+
+import { FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import { httpGet } from "../../utils/fetchURL";
+
+const STATS_API = "https://gyihzeiwelsuikfrschp.supabase.co/functions/v1/defillama";
+
+interface DayStats {
+  date: string;
+  dailyFees: number;
+  dailyUserFees: number;
+  dailyRevenue: number;
+  dailyHoldersRevenue: number;
+  dailyVolume: number;
+}
+
+const fetch = async (options: FetchOptions) => {
+  const date = new Date(options.startTimestamp * 1000)
+    .toISOString()
+    .slice(0, 10);
+
+  const stats: DayStats = await httpGet(`${STATS_API}?date=${date}`);
+
+  return {
+    dailyFees: stats.dailyFees,
+    dailyUserFees: stats.dailyUserFees,
+    dailyRevenue: stats.dailyRevenue,
+    dailyHoldersRevenue: stats.dailyHoldersRevenue,
+  };
+};
+
+const methodology = {
+  Fees: "1% platform fee collected on-chain at the house fee wallet from all swap sources (Swap Widget, Terminal, Launchpad, @groypfi_bot).",
+  UserFees: "Same as Fees — users pay the 1% platform fee on every swap.",
+  Revenue: "100% of fees are protocol revenue used for GROYP token buybacks.",
+  HoldersRevenue: "100% of revenue is used for GROYP token buybacks, benefiting token holders.",
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  adapter: {
+    [CHAIN.TON]: {
+      fetch,
+      start: "2026-05-01",
+      meta: { methodology },
+    },
+  },
+};
+
+export default adapter;

--- a/fees/topblast-lol/index.ts
+++ b/fees/topblast-lol/index.ts
@@ -1,19 +1,24 @@
 /**
- * Topblast / GroypFi — Fees & Revenue on TON
+ * topblast.lol — TON launchpad (DeDust Uranus bonding curves)
  *
- * 1% platform fee on every swap routed through the aggregator
- * (DeDust, STON.fi, Tonco, Bidask). 100% of fees are protocol revenue
- * used for GROYP buybacks.
+ * Volume: USD notional of bonding-curve buys and sells.
+ * Fees:   trading fees on every bonding-curve buy/sell plus token launch fees,
+ *         measured from on-chain TON inflows to the two protocol fee wallets:
+ *           UQClgkR0eLgWAR0tZh8YbQyDqa-Jn5wUP1XHPLDB6RmAPySF
+ *           0:a582447478b816011d2d661f186d0c83a9af899f9c143f55c73cb0c1e919803f
+ *           UQDu4AiT__JKuqT0Znje0RoXIQMPcj4uIGYZme3UK4hFlE_Q
+ *           0:eee00893fff24abaa4f46678ded11a1721030f723e2e20661999edd42b884594
  *
- * Data source: public, no-API-key stats endpoint
+ * 100% of collected fees are protocol revenue. Nothing is shared with LPs or
+ * token holders, so SupplySideRevenue and HoldersRevenue are 0. Downstream
+ * uses of that revenue (tournament prize pools) are discretionary protocol
+ * spending, not a holder distribution.
+ *
+ * Data source: public, no-API-key stats endpoint (full-UTC-day granularity)
  *   https://gyihzeiwelsuikfrschp.supabase.co/functions/v1/defillama?date=YYYY-MM-DD
- *
- * The endpoint reads incoming TON transfers to the on-chain house fee wallet:
- *   UQDu4AiT__JKuqT0Znje0RoXIQMPcj4uIGYZme3UK4hFlE_Q
- *   0:eee00893fff24abaa4f46678ded11a1721030f723e2e20661999edd42b884594
  */
 
-import { FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { FetchOptions, FetchResult, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 import { httpGet } from "../../utils/fetchURL";
 
@@ -21,42 +26,69 @@ const STATS_API = "https://gyihzeiwelsuikfrschp.supabase.co/functions/v1/defilla
 
 interface DayStats {
   date: string;
+  dailyVolume: number;
   dailyFees: number;
   dailyUserFees: number;
   dailyRevenue: number;
+  dailyProtocolRevenue: number;
+  dailySupplySideRevenue: number;
   dailyHoldersRevenue: number;
-  dailyVolume: number;
 }
 
-const fetch = async (options: FetchOptions) => {
-  const date = new Date(options.startTimestamp * 1000)
-    .toISOString()
-    .slice(0, 10);
+// The source only exposes full UTC days, so this is a version 1 (daily) adapter.
+const fetch = async (options: FetchOptions): Promise<FetchResult> => {
+  const date = new Date(options.startOfDay * 1000).toISOString().slice(0, 10);
 
   const stats: DayStats = await httpGet(`${STATS_API}?date=${date}`);
 
   return {
+    dailyVolume: stats.dailyVolume,
     dailyFees: stats.dailyFees,
     dailyUserFees: stats.dailyUserFees,
     dailyRevenue: stats.dailyRevenue,
-    dailyHoldersRevenue: stats.dailyHoldersRevenue,
+    dailyProtocolRevenue: stats.dailyProtocolRevenue ?? stats.dailyRevenue,
+    dailySupplySideRevenue: 0,
+    dailyHoldersRevenue: 0,
   };
 };
 
 const methodology = {
-  Fees: "1% platform fee collected on-chain at the house fee wallet from all swap sources (Swap Widget, Terminal, Launchpad, @groypfi_bot).",
-  UserFees: "Same as Fees — users pay the 1% platform fee on every swap.",
-  Revenue: "100% of fees are protocol revenue used for GROYP token buybacks.",
-  HoldersRevenue: "100% of revenue is used for GROYP token buybacks, benefiting token holders.",
+  Volume:
+    "USD notional of all buys and sells executed on topblast.lol bonding curves on TON, derived from collected fees at the 1% fee rate (volume = fees / 0.01).",
+  Fees: "Trading fees on every bonding-curve buy/sell plus token launch fees, collected on-chain at the two topblast.lol fee wallets (UQClgkR0eLgWAR0tZh8YbQyDqa-Jn5wUP1XHPLDB6RmAPySF and UQDu4AiT__JKuqT0Znje0RoXIQMPcj4uIGYZme3UK4hFlE_Q). Wallet-to-wallet transfers and failed transactions are excluded.",
+  UserFees: "Same as Fees — traders pay the fee on every bonding-curve buy/sell, and creators pay the launch fee.",
+  Revenue:
+    "100% of collected fees are retained by the protocol. Creator and deployer fees are claimed directly on-chain by those wallets and never reach the protocol fee wallets, so they are not counted.",
+  ProtocolRevenue:
+    "100% of collected fees. Discretionary downstream spending of that revenue (Parabola and Topblast Friday tournament prize pools) is not a holder or LP distribution.",
+  SupplySideRevenue: "0 — bonding-curve venue, no fees are shared with liquidity providers.",
+  HoldersRevenue: "0 — no fees are distributed to token holders.",
+};
+
+const breakdownMethodology = {
+  Volume: {
+    "Bonding curve trades": "Buys and sells on topblast.lol bonding curves on TON.",
+  },
+  Fees: {
+    "Trading fees": "1% fee on every bonding-curve buy and sell.",
+    "Launch fees": "Fees paid by creators when deploying a token.",
+  },
+  Revenue: {
+    "Protocol revenue": "100% of trading and launch fees retained by topblast.lol.",
+  },
+  ProtocolRevenue: {
+    "Protocol revenue": "100% of trading and launch fees retained by topblast.lol.",
+  },
 };
 
 const adapter: SimpleAdapter = {
-  version: 2,
+  version: 1,
   adapter: {
     [CHAIN.TON]: {
       fetch,
+      // topblast.lol went live 1 May 2026 — no protocol fees exist before this date.
       start: "2026-05-01",
-      meta: { methodology },
+      meta: { methodology, breakdownMethodology },
     },
   },
 };

--- a/fees/topblast-lol/index.ts
+++ b/fees/topblast-lol/index.ts
@@ -20,6 +20,7 @@
 
 import { FetchOptions, FetchResult, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
+import { METRIC } from "../../helpers/metrics";
 import { httpGet } from "../../utils/fetchURL";
 
 const STATS_API = "https://gyihzeiwelsuikfrschp.supabase.co/functions/v1/defillama";
@@ -35,18 +36,28 @@ interface DayStats {
   dailyHoldersRevenue: number;
 }
 
-// The source only exposes full UTC days, so this is a version 1 (daily) adapter.
+const LAUNCH_FEES = "Launch Fees";
+
 const fetch = async (options: FetchOptions): Promise<FetchResult> => {
-  const date = new Date(options.startOfDay * 1000).toISOString().slice(0, 10);
+  const date = options.dateString;
 
   const stats: DayStats = await httpGet(`${STATS_API}?date=${date}`);
+  const volume = Number(stats.dailyVolume);
+  const fees = Number(stats.dailyFees) || 0;
+  // Bonding-curve trades are 1%. Anything above that cap is token launch fees.
+  const tradingFees = Math.min(fees, volume * 0.01);
+  const launchFees = Math.max(0, fees - tradingFees);
+
+  const dailyFees = options.createBalances();
+  dailyFees.addUSDValue(tradingFees, METRIC.TRADING_FEES);
+  dailyFees.addUSDValue(launchFees, LAUNCH_FEES);
 
   return {
-    dailyVolume: stats.dailyVolume,
-    dailyFees: stats.dailyFees,
-    dailyUserFees: stats.dailyUserFees,
-    dailyRevenue: stats.dailyRevenue,
-    dailyProtocolRevenue: stats.dailyProtocolRevenue ?? stats.dailyRevenue,
+    dailyVolume: volume,
+    dailyFees,
+    dailyUserFees: dailyFees,
+    dailyRevenue: dailyFees,
+    dailyProtocolRevenue: dailyFees,
     dailySupplySideRevenue: 0,
     dailyHoldersRevenue: 0,
   };
@@ -54,43 +65,36 @@ const fetch = async (options: FetchOptions): Promise<FetchResult> => {
 
 const methodology = {
   Volume:
-    "USD notional of all buys and sells executed on topblast.lol bonding curves on TON, derived from collected fees at the 1% fee rate (volume = fees / 0.01).",
-  Fees: "Trading fees on every bonding-curve buy/sell plus token launch fees, collected on-chain at the two topblast.lol fee wallets (UQClgkR0eLgWAR0tZh8YbQyDqa-Jn5wUP1XHPLDB6RmAPySF and UQDu4AiT__JKuqT0Znje0RoXIQMPcj4uIGYZme3UK4hFlE_Q). Wallet-to-wallet transfers and failed transactions are excluded.",
+    "USD notional of all buys and sells executed on topblast.lol bonding curves on TON.",
+  Fees: "Trading fees on every bonding-curve buy/sell plus token launch fees, collected on-chain at the two topblast.lol fee wallets (UQClgkR0eLgWAR0tZh8YbQyDqa-Jn5wUP1XHPLDB6RmAPySF and UQDu4AiT__JKuqT0Znje0RoXIQMPcj4uIGYZme3UK4hFlE_Q). Wallet-to-wallet transfers and failed transactions are excluded. Trading fees are capped at 1% of volume; any remainder is launch fees.",
   UserFees: "Same as Fees — traders pay the fee on every bonding-curve buy/sell, and creators pay the launch fee.",
   Revenue:
-    "100% of collected fees are retained by the protocol. Creator and deployer fees are claimed directly on-chain by those wallets and never reach the protocol fee wallets, so they are not counted.",
+    "100% of collected fees(trading fees + launch fees) are retained by the protocol. Creator and deployer fees are claimed directly on-chain by those wallets and never reach the protocol fee wallets, so they are not counted.",
   ProtocolRevenue:
-    "100% of collected fees. Discretionary downstream spending of that revenue (Parabola and Topblast Friday tournament prize pools) is not a holder or LP distribution.",
+    "100% of collected fees(trading fees + launch fees). Discretionary downstream spending of that revenue (Parabola and Topblast Friday tournament prize pools) is not a holder or LP distribution.",
   SupplySideRevenue: "0 — bonding-curve venue, no fees are shared with liquidity providers.",
   HoldersRevenue: "0 — no fees are distributed to token holders.",
 };
 
+const feeBreakdown = {
+  [METRIC.TRADING_FEES]: "1% fee on every bonding-curve buy and sell, capped at 1% of daily volume.",
+  [LAUNCH_FEES]: "Remainder of collected fees above 1% of daily volume, paid by creators when deploying a token.",
+};
+
 const breakdownMethodology = {
-  Volume: {
-    "Bonding curve trades": "Buys and sells on topblast.lol bonding curves on TON.",
-  },
-  Fees: {
-    "Trading fees": "1% fee on every bonding-curve buy and sell.",
-    "Launch fees": "Fees paid by creators when deploying a token.",
-  },
-  Revenue: {
-    "Protocol revenue": "100% of trading and launch fees retained by topblast.lol.",
-  },
-  ProtocolRevenue: {
-    "Protocol revenue": "100% of trading and launch fees retained by topblast.lol.",
-  },
+  Fees: feeBreakdown,
+  UserFees: feeBreakdown,
+  Revenue: feeBreakdown,
+  ProtocolRevenue: feeBreakdown,
 };
 
 const adapter: SimpleAdapter = {
   version: 1,
-  adapter: {
-    [CHAIN.TON]: {
-      fetch,
-      // topblast.lol went live 1 May 2026 — no protocol fees exist before this date.
-      start: "2026-05-01",
-      meta: { methodology, breakdownMethodology },
-    },
-  },
+  fetch,
+  chains: [CHAIN.TON],
+  start: "2026-05-01",
+  methodology,
+  breakdownMethodology,
 };
 
 export default adapter;


### PR DESCRIPTION
# Add topblast.lol (TON launchpad) fees/volume adapter

**Protocol:** topblast.lol
**Website:** https://topblast.lol
**Twitter:** https://x.com/topblastlol
**Chain:** TON
**Category:** Launchpad
**CoinGecko ID:** topblastlol-launchpad
**Launch date:** 2026-05-01 (adapter `start`; no protocol fees exist before this date)
**Audit:** https://github.com/VBS-Labs/Audit-Report/blob/main/TOPBLAST%20DAPP%20AUDIT%20REPORT.pdf (VBS Labs)

## What this adds
`projects/topblast-lol/index.ts` — a v2 `SimpleAdapter` reporting daily volume, fees and
revenue for topblast.lol, a token launchpad on TON built on DeDust Uranus bonding curves.

## Data source
A public, unauthenticated endpoint we host:
`GET https://gyihzeiwelsuikfrschp.supabase.co/functions/v1/defillama?start=<unix>&end=<unix>`
returning `{ start, end, volume, fees, revenue }` in USD for the requested window.
No API key required, no rate limit for DefiLlama.

## Methodology
- **Volume:** USD notional of all buys and sells on topblast.lol bonding curves.
- **Fees / UserFees:** trading fees on each bonding-curve buy/sell plus launch fees, measured
  from on-chain inflows to the two protocol fee wallets:
  - `UQClgkR0eLgWAR0tZh8YbQyDqa-Jn5wUP1XHPLDB6RmAPySF`
  - `UQDu4AiT__JKuqT0Znje0RoXIQMPcj4uIGYZme3UK4hFlE_Q`
- **Revenue / ProtocolRevenue:** 100% of fees, retained by the protocol. Creator and deployer
  fees are claimed directly on-chain by those wallets without protocol interference, so they
  never touch the fee wallets and are not double-counted.
- **SupplySideRevenue / HoldersRevenue:** 0 — no LP or holder split.

### Note on revenue usage
10% of topblast.lol revenue funds the ongoing **Parabola Tournament**, and most of each
Friday's revenue funds the weekly **Topblast Friday Tournament**. Both prize pools are held
at `UQA1PmH68WqdRGF72s7K1cVoI0-M9r3uiEfZhCd3Qc2FDlzB`. These are downstream uses of protocol
revenue, so they are still reported as ProtocolRevenue.

Logo PR: DefiLlama/icons → 
<img width="512" height="512" alt="topblast-lol" src="https://github.com/user-attachments/assets/c422e636-bde2-4eae-bc08-b8654d81f160" />

Happy to adjust naming, slug or methodology wording if needed.
