### PR TITLE
kittypunch-stable: discover pools onchain, the goldsky subgraph was deleted

### DIFF
--- a/dexs/kittypunch-stable.ts
+++ b/dexs/kittypunch-stable.ts
@@ -1,52 +1,46 @@
-import request from "graphql-request";
 import type { FetchOptions, FetchResult, SimpleAdapter } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
-import { getConfig } from "../helpers/cache";
 import { addOneToken } from "../helpers/prices";
 
-const subgraphUrl = "https://api.goldsky.com/api/public/project_cm33d1338c1jc010e715n1z6n/subgraphs/stable-swap-factory-ng-contracts-subgraph-flow-mainnet/2.2.0/gn"
+const cryptoSwapEvent = 'event TokenExchange(address indexed buyer, uint256 sold_id, uint256 tokens_sold, uint256 bought_id, uint256 tokens_bought, uint256 fee, uint256 packed_price_scale)'
+
+const factories = [
+  {
+    factory: "0x4412140D52C1F5834469a061927811Abb6026dB7",
+    coinsAbi: 'function get_coins(address) view returns (address[])',
+    swapEvent: 'event TokenExchange(address indexed buyer, int128 sold_id, uint256 tokens_sold, int128 bought_id, uint256 tokens_bought)',
+  },
+  {
+    factory: "0xf0E48dC92f66E246244dd9F33b02f57b0E69fBa9",
+    coinsAbi: 'function get_coins(address) view returns (address[2])',
+    swapEvent: cryptoSwapEvent,
+  },
+  {
+    factory: "0xebd098c60b1089f362AC9cfAd9134CBD29408226",
+    coinsAbi: 'function get_coins(address) view returns (address[3])',
+    swapEvent: cryptoSwapEvent,
+  },
+]
 
 const fetch = async (
-  { createBalances, chain, getLogs, }: FetchOptions
+  { createBalances, chain, getLogs, api }: FetchOptions
 ): Promise<FetchResult> => {
-  const {pools, tokenMap} = await getConfig('kittpunch/stable-' + chain, '', {
-    fetcher: async () => {
-      const query = `{  pools {
-    address
-    tokens {
-      id
-      token {
-        id
-      }
-    }
-  }}`
-      const res = await request(subgraphUrl, query);
-      const tokenMap: {[id: string]: string} = {}
-      res.pools.forEach((pool: { tokens: { id: string, token: { id: string } }[] }) => {
-        pool.tokens.forEach((token) => {
-          tokenMap[token.id] = token.token.id
-        })
-      })
-      const pools = res.pools.map((pool: { address: string }) => pool.address)
-      return {pools, tokenMap}
-    }
-  })
-
-  const logs = await getLogs({
-    targets: pools,
-    eventAbi: 'event TokenExchange(address indexed buyer, int128 sold_id, uint256 tokens_sold, int128 bought_id, uint256 tokens_bought)',
-    flatten: false,
-  })
-
   const dailyVolume = createBalances()
-  logs.forEach((_logs, idx) => {
-    const pool = pools[idx]
-    _logs.forEach((log: any) => {
-      const token0 = tokenMap[pool+'-'+log.sold_id]
-      const token1 = tokenMap[pool+'-'+log.bought_id]
-      addOneToken({ chain, balances: dailyVolume, token0, amount0: log.tokens_sold, token1, amount1: log.tokens_bought })
+
+  for (const { factory, coinsAbi, swapEvent } of factories) {
+    const pools = await api.fetchList({ lengthAbi: 'pool_count', itemAbi: 'pool_list', target: factory })
+    if (!pools.length) continue
+    const coins = await api.multiCall({ abi: coinsAbi, calls: pools, target: factory })
+    const logs = await getLogs({ targets: pools, eventAbi: swapEvent, flatten: false })
+    logs.forEach((poolLogs: any[], i: number) => {
+      poolLogs.forEach((log: any) => {
+        const token0 = coins[i][Number(log.sold_id)]
+        const token1 = coins[i][Number(log.bought_id)]
+        addOneToken({ chain, balances: dailyVolume, token0, amount0: log.tokens_sold, token1, amount1: log.tokens_bought })
+      })
     })
-  })
+  }
+
   return { dailyVolume }
 };
 


### PR DESCRIPTION
Fixes #8929

the goldsky subgraph this adapter used for pool discovery was deleted, so it has been running on the frozen r2 config cache: 10 pools cached vs 21 onchain across the three curve-ng factories. on top of that the crypto-ng pools were never counted at all since the adapter only decoded the stableswap-ng int128 TokenExchange variant.

this drops the subgraph and builds the pool list onchain with pool_count/pool_list/get_coins per factory, the same way projects/kittypunch-stable does for tvl, and decodes the matching TokenExchange signature per factory.

harness before/after on the same windows: 2026-08-19 $8.58k -> $96.0k, 2026-08-20 $7.05k -> $44.2k, both before values matching what production published to the dollar. numbers and per-pool evidence in the issue.
