### PR TITLE
Add Fables volume & fees adapter (Robinhood Chain)

### DIFF
--- a/dexs/fables.ts
+++ b/dexs/fables.ts
@@ -1,6 +1,7 @@
 import { BaseAdapter, FetchOptions, FetchResultV2, SimpleAdapter } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
 import ADDRESSES from "../helpers/coreAssets.json";
+import { METRIC } from "../helpers/metrics";
 import { isCoreAsset } from "../helpers/prices";
 
 // Fables — a dynamic-fee ve(3,3) DEX built on Uniswap v4 on Robinhood Chain.
@@ -11,9 +12,9 @@ import { isCoreAsset } from "../helpers/prices";
 // the only place Fables swap volume is counted, and it does not overlap with the Uniswap v4 adapter.
 //
 // Pools are enumerated from the on-chain FablesPoolRegistry (activePools), so registering or
-// retiring a pool there automatically starts or stops tracking here — no pool is hardcoded. Each
-// pool's swaps are read directly by its indexed pool id, rather than scanning the whole PoolManager
-// (which carries every other protocol's Robinhood v4 traffic too).
+// retiring a pool there automatically starts or stops tracking here — no pool is hardcoded. Swaps
+// are read in one PoolManager getLogs call, with topic1 OR'd across every registered pool id so
+// other Robinhood v4 traffic is not pulled in.
 
 const POOL_MANAGER = "0x8366a39cc670b4001a1121b8f6a443a643e40951"; // Uniswap v4 PoolManager on Robinhood
 const REGISTRY = "0x159a113e012593d9b3cc63ad45e30f0467e13ef3"; // FablesPoolRegistry
@@ -27,40 +28,46 @@ const ActivePoolsAbi =
 const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
   const dailyVolume = options.createBalances();
   const dailyFees = options.createBalances();
+  const dailySupplySideRevenue = options.createBalances();
 
   const pools = await options.api.call({ target: REGISTRY, abi: ActivePoolsAbi });
+  if (!pools.length) {
+    return { dailyVolume, dailyFees, dailyUserFees: dailyFees, dailySupplySideRevenue, dailyRevenue: 0, dailyProtocolRevenue: 0 };
+  }
 
+  const byId = new Map<string, { token: string; useToken0: boolean }>();
   for (const p of pools) {
     const currency0 = String(p.key.currency0);
     const currency1 = String(p.key.currency1);
-
-    // Only this pool's swaps: the pool id is topic1 of the indexed Swap event.
-    const logs = await options.getLogs({
-      target: POOL_MANAGER,
-      eventAbi: SwapEvent,
-      topics: [SWAP_TOPIC, p.id],
-    });
-    if (!logs.length) continue;
-
     // Price on the native / core-asset leg where possible so a thin-liquidity token can't set value.
     const useToken0 =
       currency0 === ADDRESSES.null ||
       isCoreAsset(options.chain, currency0) ||
       !isCoreAsset(options.chain, currency1);
-    const token = useToken0 ? currency0 : currency1;
+    byId.set(String(p.id).toLowerCase(), { token: useToken0 ? currency0 : currency1, useToken0 });
+  }
 
-    for (const log of logs) {
-      const amount = Math.abs(Number(useToken0 ? log.amount0 : log.amount1));
-      dailyVolume.add(token, amount);
-      dailyFees.add(token, (amount * Number(log.fee)) / 1e6); // dynamic fee carried in each Swap event
-    }
+  const logs = await options.getLogs({
+    target: POOL_MANAGER,
+    eventAbi: SwapEvent,
+    topics: [SWAP_TOPIC, [...byId.keys()]] as any,
+  });
+
+  for (const log of logs) {
+    const pool = byId.get(String(log.id).toLowerCase());
+    if (!pool) continue;
+    const amount = Math.abs(Number(pool.useToken0 ? log.amount0 : log.amount1));
+    dailyVolume.add(pool.token, amount);
+    const fee = (amount * Number(log.fee)) / 1e6; // dynamic fee carried in each Swap event
+    dailyFees.add(pool.token, fee, METRIC.SWAP_FEES);
+    dailySupplySideRevenue.add(pool.token, fee, METRIC.LP_FEES);
   }
 
   return {
     dailyVolume,
     dailyFees,
     dailyUserFees: dailyFees,
-    dailySupplySideRevenue: dailyFees, // fees accrue to LPs; no protocol fee switch yet
+    dailySupplySideRevenue, // fees accrue to LPs; no protocol fee switch yet
     dailyRevenue: 0,
     dailyProtocolRevenue: 0,
   };
@@ -76,14 +83,26 @@ const methodology = {
   ProtocolRevenue: "No protocol fee is enabled yet.",
 };
 
+const breakdownMethodology = {
+  Fees: {
+    [METRIC.SWAP_FEES]: "Dynamic swap fees paid by traders, taken from each Uniswap v4 Swap event.",
+  },
+  UserFees: {
+    [METRIC.SWAP_FEES]: "Dynamic swap fees paid by traders, taken from each Uniswap v4 Swap event.",
+  },
+  SupplySideRevenue: {
+    [METRIC.LP_FEES]: "All swap fees accrue to liquidity providers; Fables takes no protocol fee yet.",
+  },
+};
+
 const adapter: SimpleAdapter = {
   version: 2,
   pullHourly: true,
   fetch,
-  adapter: {
-    [CHAIN.ROBINHOOD]: { start: "2026-08-15" },
-  } as BaseAdapter,
+  chains: [CHAIN.ROBINHOOD],
+  start: "2026-08-15",
   methodology,
+  breakdownMethodology,
 };
 
 export default adapter;

--- a/dexs/fables.ts
+++ b/dexs/fables.ts
@@ -1,0 +1,89 @@
+import { BaseAdapter, FetchOptions, FetchResultV2, SimpleAdapter } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+import ADDRESSES from "../helpers/coreAssets.json";
+import { isCoreAsset } from "../helpers/prices";
+
+// Fables — a dynamic-fee ve(3,3) DEX built on Uniswap v4 on Robinhood Chain.
+//
+// Fables initializes its pools directly on the canonical v4 PoolManager, not through Uniswap's
+// PositionManager, so dexs/uniswap-v4.ts cannot resolve their poolKeys and skips them (verified:
+// PositionManager.poolKeys returns the zero key for every Fables pool). This adapter is therefore
+// the only place Fables swap volume is counted, and it does not overlap with the Uniswap v4 adapter.
+//
+// Pools are enumerated from the on-chain FablesPoolRegistry (activePools), so registering or
+// retiring a pool there automatically starts or stops tracking here — no pool is hardcoded. Each
+// pool's swaps are read directly by its indexed pool id, rather than scanning the whole PoolManager
+// (which carries every other protocol's Robinhood v4 traffic too).
+
+const POOL_MANAGER = "0x8366a39cc670b4001a1121b8f6a443a643e40951"; // Uniswap v4 PoolManager on Robinhood
+const REGISTRY = "0x159a113e012593d9b3cc63ad45e30f0467e13ef3"; // FablesPoolRegistry
+const SWAP_TOPIC = "0x40e9cecb9f5f1f1c5b9c97dec2917b7ee92e57ba5563708daca94dd84ad7112f"; // v4 Swap topic0
+
+const SwapEvent =
+  "event Swap(bytes32 indexed id, address indexed sender, int128 amount0, int128 amount1, uint160 sqrtPriceX96, uint128 liquidity, int24 tick, uint24 fee)";
+const ActivePoolsAbi =
+  "function activePools() view returns (tuple(tuple(address currency0, address currency1, uint24 fee, int24 tickSpacing, address hooks) key, bytes32 id, bool active)[])";
+
+const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
+  const dailyVolume = options.createBalances();
+  const dailyFees = options.createBalances();
+
+  const pools = await options.api.call({ target: REGISTRY, abi: ActivePoolsAbi });
+
+  for (const p of pools) {
+    const currency0 = String(p.key.currency0);
+    const currency1 = String(p.key.currency1);
+
+    // Only this pool's swaps: the pool id is topic1 of the indexed Swap event.
+    const logs = await options.getLogs({
+      target: POOL_MANAGER,
+      eventAbi: SwapEvent,
+      topics: [SWAP_TOPIC, p.id],
+    });
+    if (!logs.length) continue;
+
+    // Price on the native / core-asset leg where possible so a thin-liquidity token can't set value.
+    const useToken0 =
+      currency0 === ADDRESSES.null ||
+      isCoreAsset(options.chain, currency0) ||
+      !isCoreAsset(options.chain, currency1);
+    const token = useToken0 ? currency0 : currency1;
+
+    for (const log of logs) {
+      const amount = Math.abs(Number(useToken0 ? log.amount0 : log.amount1));
+      dailyVolume.add(token, amount);
+      dailyFees.add(token, (amount * Number(log.fee)) / 1e6); // dynamic fee carried in each Swap event
+    }
+  }
+
+  return {
+    dailyVolume,
+    dailyFees,
+    dailyUserFees: dailyFees,
+    dailySupplySideRevenue: dailyFees, // fees accrue to LPs; no protocol fee switch yet
+    dailyRevenue: 0,
+    dailyProtocolRevenue: 0,
+  };
+};
+
+const methodology = {
+  Volume:
+    "Swap volume across every Fables pool, enumerated from the on-chain FablesPoolRegistry (activePools) and read from the Uniswap v4 PoolManager Swap logs by each pool's indexed id, counted on the core-asset/native leg. Fables pools are not counted by the Uniswap v4 adapter (their poolKeys are not registered in Uniswap's PositionManager), so there is no overlap.",
+  Fees: "Swap fees paid by users, using the dynamic fee carried in each Swap event.",
+  UserFees: "Swap fees paid by users.",
+  SupplySideRevenue: "All swap fees accrue to liquidity providers; Fables takes no protocol fee yet.",
+  Revenue: "No protocol fee is enabled yet.",
+  ProtocolRevenue: "No protocol fee is enabled yet.",
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  pullHourly: true,
+  fetch,
+  adapter: {
+    [CHAIN.ROBINHOOD]: { start: "2026-08-15" },
+  } as BaseAdapter,
+  methodology,
+};
+
+export default adapter;


### PR DESCRIPTION
Adds a volume + fees adapter for **Fables**, a dynamic-fee ve(3,3) DEX built on Uniswap v4 on Robinhood Chain. (TVL adapter submitted separately to DefiLlama-Adapters.)

It enumerates every pool from the on-chain `FablesPoolRegistry` (`activePools()`) and reads each pool's swaps from the Uniswap v4 PoolManager by its **indexed pool id** (topic-filtered, so it never scans unrelated PoolManager traffic). Volume is counted on the core-asset/native leg; fees use the dynamic fee carried in each `Swap` event. No pool addresses are hardcoded. Dry-run via `pnpm test dexs fables 2026-08-19`: ~$47.7k volume, ~$29.5 fees.

**Not `doublecounted`, deliberately** — and this differs from the existing `dexs/alphix.ts` (`doublecounted: true`) on purpose. Fables initializes its pools directly on the v4 PoolManager, not via Uniswap's PositionManager, so `PositionManager.poolKeys(poolId)` returns the zero key for every Fables pool (verified on-chain) and `dexs/uniswap-v4.ts` skips them — Fables volume is counted nowhere else. (Alphix's Base/Arbitrum pools *are* resolvable in the PositionManager, which is why that adapter is doublecounted.)

"Allow edits by maintainers" is enabled.

## (New listing)

##### Name (to be shown on DefiLlama):
Fables

##### Twitter Link:
https://x.com/fablesfi

##### List of audit links if any:
https://www.fables.fi/docs/security (built on the audited Alphix v4 hook architecture)

##### Website Link:
https://www.fables.fi/

##### Logo (High resolution, will be shown with rounded borders):
Attached in a comment below.

##### Current TVL:
~$52.5k

##### Treasury Addresses (if the protocol has treasury):
None (no treasury yet)

##### Chain:
Robinhood Chain

##### Coingecko ID:
— (no token)

##### Coinmarketcap ID:
— (no token)

##### Short Description (to be shown on DefiLlama):
A dynamic-fee ve(3,3) DEX built on Uniswap v4. Each pool charges a fee tuned to its asset — calendar-based for tokenised stocks, volatility-based for crypto — so LPs are paid more when a trade is more likely to be against them.

##### Token address and ticker if any:
None (no token yet)

##### Category:
Dexs

##### Oracle Provider(s):
None — fees are computed on-chain from session/time and pool config; no external price oracle.

##### Implementation Details:
N/A (no oracle)

##### Documentation/Proof:
https://www.fables.fi/docs

##### forkedFrom (Does your project originate from another project):
Not a fork.

##### methodology (what is being counted):
Sums Uniswap v4 PoolManager Swap logs for each pool id registered in the on-chain FablesPoolRegistry; fees use the dynamic fee carried in each Swap event.

##### Github org/user:
—

##### Does this project have a referral program?
No
