### PR TITLE
fix maple-finance: crash on pre-2023 days, dead OTC leg, wrong buyback rate

### DIFF
--- a/fees/maple-finance.ts
+++ b/fees/maple-finance.ts
@@ -25,12 +25,16 @@ const service_fees_paid_event = 'event ServiceFeesPaid(address loan_, uint256 de
 const strategy_fees_paid_event = 'event StrategyFeesCollected (uint256 fees)';
 const interest_paid_event = 'event PaymentMade (uint256 principalPaid_, uint256 interestPaid_)';
 
+// Share of revenue spent buying back SYRUP. Each rate is confirmed against the monthly
+// buybacks published on https://maple.finance/transparency (buyback / revenue, same month).
+// ponytail: MIP-021 is tiered on MONTHLY revenue (10% under $1.5m, 20% to $2m, 30% above) and a
+// daily fetch cannot see the month, so 10% is hardcoded - Maple has run $1.0-1.4m/month all of
+// 2026. Revisit if a month clears $1.5m, or when MIP-021's 6-month term ends (Jan 2027).
 function getHoldersRevenueShare(date: number): number {
-  if (date < 1761955200) { // 2025-11-01
-    return 0
-  } else {
-    return 0.25;
-  }
+  if (date < 1735689600) return 0     // no buyback before 2025-01-01
+  if (date < 1751328000) return 0.2   // MIP-013 / MIP-016, Q1+Q2 2025
+  if (date < 1782950400) return 0.25  // MIP-019 Syrup Strategic Fund, 2025-07-01 -> 2026-06-30
+  return 0.1                          // MIP-021 tiered buyback, from 2026-07-01
 }
 
 const STRATEGY_FEES = 'Strategy Fees';
@@ -39,18 +43,18 @@ const fetch = async (options: FetchOptions) => {
 
   if (options.chain === CHAIN.OFF_CHAIN) {
     const duneQuery = `
-    select coalesce(otc_revenue, 0) as otc_fees from dune."maple-finance".dataset_maple_otc_by_day where timestamp = ${options.toTimestamp}`;
+    select coalesce(otc_revenue, 0) as otc_fees from dune."maple-finance".dataset_maple_otc_by_day where timestamp >= ${options.startOfDay} and timestamp < ${options.startOfDay + 86400}`;
     const duneData = await queryDuneSql(options, duneQuery);
 
-    const dailyFees = options.createBalances();
-    dailyFees.addUSDValue(duneData?.[0]?.otc_fees || 0, METRIC.MANAGEMENT_FEES);
     const holdersShare = getHoldersRevenueShare(options.startOfDay);
+    const dailyFees = options.createBalances();
+    dailyFees.addUSDValue(Number(duneData?.[0]?.otc_fees || 0), METRIC.MANAGEMENT_FEES);
 
     return {
       dailyFees,
       dailyRevenue: dailyFees,
       dailyProtocolRevenue: dailyFees.clone(1 - holdersShare),
-      dailyHoldersRevenue: dailyFees.clone(holdersShare),
+      dailyHoldersRevenue: dailyFees.clone(holdersShare, METRIC.TOKEN_BUY_BACK),
       dailySupplySideRevenue: 0
     }
   }
@@ -59,9 +63,6 @@ const fetch = async (options: FetchOptions) => {
   const dailyFees = options.createBalances();
   const dailyRevenue = options.createBalances();
   const dailySupplySideRevenue = options.createBalances();
-  const dailyProtocolRevenue = options.createBalances();
-  const dailyHoldersRevenue = options.createBalances();
-
   const holdersShare = getHoldersRevenueShare(options.startOfDay);
 
   const [fromBlock, toBlock] = await Promise.all([options.getFromBlock(), options.getToBlock()]);
@@ -103,6 +104,7 @@ const fetch = async (options: FetchOptions) => {
         targets: fixed_term_loans,
         eventAbi: interest_paid_event,
         entireLog: true,
+        parseLog: true,
       })
 
       logs_origination_fees.forEach((e: any) => {
@@ -112,12 +114,6 @@ const fetch = async (options: FetchOptions) => {
 
         dailyRevenue.add(asset, e.delegateOriginationFee_, METRIC.MANAGEMENT_FEES)
         dailyRevenue.add(asset, e.platformOriginationFee_, METRIC.MANAGEMENT_FEES)
-
-        dailyProtocolRevenue.add(asset, Number(e.delegateOriginationFee_) * (1 - holdersShare), METRIC.MANAGEMENT_FEES)
-        dailyProtocolRevenue.add(asset, Number(e.platformOriginationFee_) * (1 - holdersShare), METRIC.MANAGEMENT_FEES)
-
-        dailyHoldersRevenue.add(asset, Number(e.delegateOriginationFee_) * holdersShare, METRIC.MANAGEMENT_FEES)
-        dailyHoldersRevenue.add(asset, Number(e.platformOriginationFee_) * holdersShare, METRIC.MANAGEMENT_FEES)
 
       })
 
@@ -133,15 +129,6 @@ const fetch = async (options: FetchOptions) => {
         dailyRevenue.add(asset, e.platformServiceFee_, METRIC.SERVICE_FEES)
         dailyRevenue.add(asset, e.partialRefinancePlatformServiceFee_, METRIC.SERVICE_FEES)
 
-        dailyProtocolRevenue.add(asset, Number(e.delegateServiceFee_) * (1 - holdersShare), METRIC.SERVICE_FEES)
-        dailyProtocolRevenue.add(asset, Number(e.partialRefinanceDelegateServiceFee_) * (1 - holdersShare), METRIC.SERVICE_FEES)
-        dailyProtocolRevenue.add(asset, Number(e.platformServiceFee_) * (1 - holdersShare), METRIC.SERVICE_FEES)
-        dailyProtocolRevenue.add(asset, Number(e.partialRefinancePlatformServiceFee_) * (1 - holdersShare), METRIC.SERVICE_FEES)
-
-        dailyHoldersRevenue.add(asset, Number(e.delegateServiceFee_) * holdersShare, METRIC.SERVICE_FEES)
-        dailyHoldersRevenue.add(asset, Number(e.partialRefinanceDelegateServiceFee_) * holdersShare, METRIC.SERVICE_FEES)
-        dailyHoldersRevenue.add(asset, Number(e.platformServiceFee_) * holdersShare, METRIC.SERVICE_FEES)
-        dailyHoldersRevenue.add(asset, Number(e.partialRefinancePlatformServiceFee_) * holdersShare, METRIC.SERVICE_FEES)
       })
 
       logs_interest_paid.forEach((e: any) => {
@@ -152,15 +139,15 @@ const fetch = async (options: FetchOptions) => {
     }
   }
 
-  if (toBlock < 17372608) {
-    return {
-      dailyFees,
-      dailyRevenue,
-      dailySupplySideRevenue,
-      dailyProtocolRevenue,
-      dailyHoldersRevenue,
-    }
-  }
+  const splitRevenue = () => ({
+    dailyFees,
+    dailyRevenue,
+    dailySupplySideRevenue,
+    dailyProtocolRevenue: dailyRevenue.clone(1 - holdersShare),
+    dailyHoldersRevenue: dailyRevenue.clone(holdersShare, METRIC.TOKEN_BUY_BACK),
+  })
+
+  if (toBlock < 17372608) return splitRevenue()
 
   const logs_open_term_loan_manager_deployed = await getLogs({
     target: openTermLoanManagerFactory,
@@ -204,15 +191,6 @@ const fetch = async (options: FetchOptions) => {
       dailyRevenue.add(asset, e.delegateServiceFee_, METRIC.SERVICE_FEES)
       dailyRevenue.add(asset, e.platformServiceFee_, METRIC.SERVICE_FEES)
 
-      dailyProtocolRevenue.add(asset, Number(e.delegateManagementFee_) * (1 - holdersShare), METRIC.MANAGEMENT_FEES)
-      dailyProtocolRevenue.add(asset, Number(e.platformManagementFee_) * (1 - holdersShare), METRIC.MANAGEMENT_FEES)
-      dailyProtocolRevenue.add(asset, Number(e.delegateServiceFee_) * (1 - holdersShare), METRIC.SERVICE_FEES)
-      dailyProtocolRevenue.add(asset, Number(e.platformServiceFee_) * (1 - holdersShare), METRIC.SERVICE_FEES)
-
-      dailyHoldersRevenue.add(asset, Number(e.delegateManagementFee_) * holdersShare, METRIC.TOKEN_BUY_BACK)
-      dailyHoldersRevenue.add(asset, Number(e.platformManagementFee_) * holdersShare, METRIC.TOKEN_BUY_BACK)
-      dailyHoldersRevenue.add(asset, Number(e.delegateServiceFee_) * holdersShare, METRIC.TOKEN_BUY_BACK)
-      dailyHoldersRevenue.add(asset, Number(e.platformServiceFee_) * holdersShare, METRIC.TOKEN_BUY_BACK)
     })
   }
 
@@ -248,18 +226,10 @@ const fetch = async (options: FetchOptions) => {
 
       dailyFees.add(asset, e.args.fees, STRATEGY_FEES)
       dailyRevenue.add(asset, e.args.fees, STRATEGY_FEES)
-      dailyProtocolRevenue.add(asset, Number(e.args.fees) * (1 - holdersShare), STRATEGY_FEES)
-      dailyHoldersRevenue.add(asset, Number(e.args.fees) * holdersShare, METRIC.TOKEN_BUY_BACK)
     })
   }
 
-  return {
-    dailyFees,
-    dailyRevenue,
-    dailySupplySideRevenue,
-    dailyProtocolRevenue,
-    dailyHoldersRevenue,
-  }
+  return splitRevenue()
 }
 
 const adapters: SimpleAdapter = {
@@ -274,16 +244,16 @@ const adapters: SimpleAdapter = {
     }
   },
   methodology: {
-    Fees: "Total interest and fees paid by borrowers on both fixed-term and open-term loans, including net interest, management fees, service fees, strategy fees and origination fees.",
+    Fees: "Total interest and fees paid by borrowers on both fixed-term and open-term loans, including net interest, management fees, service fees, strategy fees and origination fees, plus off-chain OTC desk revenue.",
     Revenue: "Total revenue flowing to Maple protocol and delegates, including management fees, service fees, strategy fees and origination fees from both fixed-term and open-term loans.",
-    ProtocolRevenue: "Revenue flowing to Maple protocol treasuries (75% of total revenue, with 25% allocated to SYRUP token buybacks from MIP-019).",
+    ProtocolRevenue: "Revenue flowing to Maple protocol treasuries, i.e. total revenue less the share allocated to SYRUP buybacks.",
     SupplySideRevenue: "Net interest earned by liquidity providers/depositors in Maple pools from both fixed-term and open-term loan payments.",
-    HoldersRevenue: "25% of protocol revenue used to buy back SYRUP tokens from MIP-019 (starting Nov 2025).",
+    HoldersRevenue: "Share of revenue used to buy back SYRUP tokens: 20% from Jan 2025 (MIP-013/016), 25% from Jul 2025 (MIP-019), 10% from Jul 2026 (MIP-021). Matched against the monthly buybacks published on https://maple.finance/transparency.",
   },
   breakdownMethodology: {
     Fees: {
       [METRIC.BORROW_INTEREST]: 'Net interest paid by borrowers on open-term loans.',
-      [METRIC.MANAGEMENT_FEES]: 'Management fees from open-term loans and origination fees from fixed-term loans, paid to protocol and delegates.',
+      [METRIC.MANAGEMENT_FEES]: 'Management fees from open-term loans, origination fees from fixed-term loans, and off-chain OTC desk revenue, paid to protocol and delegates.',
       [METRIC.SERVICE_FEES]: 'Service fees from both fixed-term and open-term loans, paid to protocol and delegates.',
       [STRATEGY_FEES]: 'Aave/sky Strategy fees paid to protocol.',
     },
@@ -301,7 +271,7 @@ const adapters: SimpleAdapter = {
       [STRATEGY_FEES]: 'Aave/sky Strategy fees share to Maple protocol.',
     },
     HoldersRevenue: {
-      [METRIC.TOKEN_BUY_BACK]: '25% of all protocol revenue used for SYRUP token buybacks (from MIP-019, starting Nov 2025).',
+      [METRIC.TOKEN_BUY_BACK]: 'Share of revenue used for SYRUP token buybacks: 20% from Jan 2025, 25% from Jul 2025 (MIP-019), 10% from Jul 2026 (MIP-021).',
     },
   },
   dependencies: [Dependencies.DUNE],

--- a/fees/maple-finance.ts
+++ b/fees/maple-finance.ts
@@ -24,9 +24,11 @@ const service_fees_paid_event = 'event ServiceFeesPaid(address loan_, uint256 de
 const management_fees_paid_event = 'event ManagementFeesPaid(address indexed loan_, uint256 delegateManagementFee_, uint256 platformManagementFee_)';
 const strategy_fees_paid_event = 'event StrategyFeesCollected (uint256 fees)';
 // Fixed-term loans have shipped three PaymentMade signatures. interestPaid_ is always the second
-// argument; the trailing fee arguments are the same fees the fee manager reports, so only the
-// interest is read here. Matching just the two-argument version silently dropped every fixed-term
-// payment from 2022-12 on.
+// argument. Matching only the two-argument version silently dropped every fixed-term payment from
+// 2022-09 on. The three-argument fees_ is the same fee MapleLoanFeeManager reports (checked: all
+// 94 of those payments carry a fee-manager event in the same tx), so it is ignored here; the
+// four-argument delegate/treasury fees predate the fee manager and are reported nowhere else, so
+// they are counted. Both are charged on top of the interest, not taken out of it.
 const interest_paid_events = [
   'event PaymentMade(uint256 principalPaid_, uint256 interestPaid_)',
   'event PaymentMade(uint256 principalPaid_, uint256 interestPaid_, uint256 fees_)',
@@ -143,6 +145,13 @@ const fetch = async (options: FetchOptions) => {
         const asset = fixed_term_loan_to_asset[e.address?.toLowerCase()]
         dailyFees.add(asset, e.args.interestPaid_, METRIC.BORROW_INTEREST)
         dailySupplySideRevenue.add(asset, e.args.interestPaid_, METRIC.BORROW_INTEREST)
+
+        if (e.args.treasuryFeePaid_ !== undefined) {
+          dailyFees.add(asset, e.args.delegateFeePaid_, METRIC.SERVICE_FEES)
+          dailyFees.add(asset, e.args.treasuryFeePaid_, METRIC.SERVICE_FEES)
+          dailyRevenue.add(asset, e.args.delegateFeePaid_, METRIC.SERVICE_FEES)
+          dailyRevenue.add(asset, e.args.treasuryFeePaid_, METRIC.SERVICE_FEES)
+        }
       })
     }
 

--- a/fees/maple-finance.ts
+++ b/fees/maple-finance.ts
@@ -2,6 +2,7 @@ import { CHAIN } from "../helpers/chains";
 import { Dependencies, FetchOptions, SimpleAdapter } from "../adapters/types";
 import { METRIC } from '../helpers/metrics';
 import { queryDuneSql } from "../helpers/dune";
+import { httpGet } from "../utils/fetchURL";
 
 const feeManager = '0xFeACa6A5703E6F9DE0ebE0975C93AE34c00523F2'
 
@@ -49,16 +50,60 @@ function getHoldersRevenueShare(date: number): number {
 
 const STRATEGY_FEES = 'Strategy Fees';
 
+// Maple stopped updating their daily OTC dataset on Dune after 2025-10-09 (all October rows are
+// null), so from 2025-10-01 the off-chain number is recovered from what they still publish: the
+// monthly total revenue on https://maple.finance/transparency (which includes OTC) minus our own
+// on-chain revenue for that month, spread evenly over the month's days. The monthly residual
+// reconciles with the real OTC dataset where both exist (2025-06: residual $797k vs dataset
+// $813k) and with inverting their published buybacks (buyback / rate matches revenue to ~0.15%).
+const OTC_DATASET_STALE_TS = 1759276800 // 2025-10-01
+
+async function getOtcFromDuneDataset(options: FetchOptions): Promise<number> {
+  const duneQuery = `
+    select coalesce(otc_revenue, 0) as otc_fees from dune."maple-finance".dataset_maple_otc_by_day where timestamp >= ${options.startOfDay} and timestamp < ${options.startOfDay + 86400}`;
+  const duneData = await queryDuneSql(options, duneQuery);
+  return Number(duneData?.[0]?.otc_fees || 0)
+}
+
+async function getOtcResidualFromTransparency(options: FetchOptions): Promise<number> {
+  const day = new Date(options.startOfDay * 1000)
+  const monthStartMs = Date.UTC(day.getUTCFullYear(), day.getUTCMonth(), 1)
+  const daysInMonth = new Date(Date.UTC(day.getUTCFullYear(), day.getUTCMonth() + 1, 0)).getUTCDate()
+
+  // monthly total revenue (incl. OTC), server-rendered into the transparency page
+  const html: string = await httpGet('https://maple.finance/transparency', { headers: { 'User-Agent': 'Mozilla/5.0' } })
+  const propsMatch = html.match(/RevChartInner[^>]*props="([^"]*)"/)
+  if (!propsMatch) throw new Error('maple transparency page: RevChartInner props not found')
+  const props = JSON.parse(propsMatch[1].replace(/&quot;/g, '"').replace(/&amp;/g, '&'))
+  const monthRow = props.datasets[1].ALL[1].find((r: any) => r[1].ts[1] === monthStartMs)
+  if (!monthRow) return 0 // month not published yet
+  const publishedMonthRevenue = monthRow[1].revenueUsd[1]
+
+  // our on-chain revenue for the same month, from the served series (the ethereum leg of this
+  // adapter; stable for these dates - none of the ethereum-side history fixes touch post-2025-09)
+  const summary = await httpGet('https://api.llama.fi/summary/fees/maple-finance?dataType=dailyRevenue')
+  let onchainMonthRevenue = 0
+  for (const [ts, byChain] of summary.totalDataChartBreakdown ?? []) {
+    const d = new Date(ts * 1000)
+    if (Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), 1) !== monthStartMs) continue
+    onchainMonthRevenue += Object.entries(byChain as Record<string, Record<string, number>>)
+      .filter(([chain]) => chain !== 'Off Chain')
+      .reduce((sum, [, byProtocol]) => sum + Object.values(byProtocol).reduce((a, b) => a + b, 0), 0)
+  }
+
+  return Math.max(0, publishedMonthRevenue - onchainMonthRevenue) / daysInMonth
+}
+
 const fetch = async (options: FetchOptions) => {
 
   if (options.chain === CHAIN.OFF_CHAIN) {
-    const duneQuery = `
-    select coalesce(otc_revenue, 0) as otc_fees from dune."maple-finance".dataset_maple_otc_by_day where timestamp >= ${options.startOfDay} and timestamp < ${options.startOfDay + 86400}`;
-    const duneData = await queryDuneSql(options, duneQuery);
+    const otcFees = options.startOfDay < OTC_DATASET_STALE_TS
+      ? await getOtcFromDuneDataset(options)
+      : await getOtcResidualFromTransparency(options)
 
     const holdersShare = getHoldersRevenueShare(options.startOfDay);
     const dailyFees = options.createBalances();
-    dailyFees.addUSDValue(Number(duneData?.[0]?.otc_fees || 0), METRIC.MANAGEMENT_FEES);
+    dailyFees.addUSDValue(otcFees, METRIC.MANAGEMENT_FEES);
 
     return {
       dailyFees,
@@ -307,7 +352,7 @@ const adapters: SimpleAdapter = {
   breakdownMethodology: {
     Fees: {
       [METRIC.BORROW_INTEREST]: 'Net interest paid by borrowers on open-term loans.',
-      [METRIC.MANAGEMENT_FEES]: 'Management fees from open-term and fixed-term loans, origination fees from fixed-term loans, and off-chain OTC desk revenue, paid to protocol and delegates.',
+      [METRIC.MANAGEMENT_FEES]: 'Management fees from open-term and fixed-term loans, origination fees from fixed-term loans, and off-chain OTC desk revenue (from Oct 2025 estimated as Maple published monthly revenue minus on-chain revenue, spread over the month), paid to protocol and delegates.',
       [METRIC.SERVICE_FEES]: 'Service fees from both fixed-term and open-term loans, paid to protocol and delegates.',
       [STRATEGY_FEES]: 'Aave/sky Strategy fees paid to protocol.',
     },

--- a/fees/maple-finance.ts
+++ b/fees/maple-finance.ts
@@ -12,7 +12,7 @@ const claimed_funds_distributed_event = 'event ClaimedFundsDistributed(address i
 const loan_manager_deployed_event = 'event InstanceDeployed(uint256 indexed version_, address indexed instance_, bytes initializationArguments_)'
 
 // Fixed-Term Loan
-// const fixedTermLoanManagerFactory = '0x1551717AE4FdCB65ed028F7fB7abA39908f6A7A6'
+const fixedTermLoanManagerFactory = '0x1551717AE4FdCB65ed028F7fB7abA39908f6A7A6'
 const fixedTermLoanFactoryV1 = '0x36a7350309B2Eb30F3B908aB0154851B5ED81db0'
 const fixedTermLoanFactoryV2 = '0xeA067DB5B32CE036Ee5D8607DBB02f544768dBC6'
 
@@ -21,9 +21,17 @@ const aaveStrategyFactory = '0x01ab799f77F9a9f4dd0D2b6E7C83DCF3F48D5650'
 
 const origination_fees_paid_event = 'event OriginationFeesPaid(address loan_, uint256 delegateOriginationFee_, uint256 platformOriginationFee_)';
 const service_fees_paid_event = 'event ServiceFeesPaid(address loan_, uint256 delegateServiceFee_, uint256 partialRefinanceDelegateServiceFee_, uint256 platformServiceFee_, uint256 partialRefinancePlatformServiceFee_)'
-//const management_fees_paid_event = 'event ManagementFeesPaid(address loan_, uint256 delegateManagementFee_, uint256 platformManagementFee_)';
+const management_fees_paid_event = 'event ManagementFeesPaid(address indexed loan_, uint256 delegateManagementFee_, uint256 platformManagementFee_)';
 const strategy_fees_paid_event = 'event StrategyFeesCollected (uint256 fees)';
-const interest_paid_event = 'event PaymentMade (uint256 principalPaid_, uint256 interestPaid_)';
+// Fixed-term loans have shipped three PaymentMade signatures. interestPaid_ is always the second
+// argument; the trailing fee arguments are the same fees the fee manager reports, so only the
+// interest is read here. Matching just the two-argument version silently dropped every fixed-term
+// payment from 2022-12 on.
+const interest_paid_events = [
+  'event PaymentMade(uint256 principalPaid_, uint256 interestPaid_)',
+  'event PaymentMade(uint256 principalPaid_, uint256 interestPaid_, uint256 fees_)',
+  'event PaymentMade(uint256 principalPaid_, uint256 interestPaid_, uint256 delegateFeePaid_, uint256 treasuryFeePaid_)',
+]
 
 // Share of revenue spent buying back SYRUP. Each rate is confirmed against the monthly
 // buybacks published on https://maple.finance/transparency (buyback / revenue, same month).
@@ -100,12 +108,12 @@ const fetch = async (options: FetchOptions) => {
         eventAbi: service_fees_paid_event,
       })
 
-      const logs_interest_paid = await getLogs({
+      const logs_interest_paid = (await Promise.all(interest_paid_events.map(eventAbi => getLogs({
         targets: fixed_term_loans,
-        eventAbi: interest_paid_event,
+        eventAbi,
         entireLog: true,
         parseLog: true,
-      })
+      })))).flat()
 
       logs_origination_fees.forEach((e: any) => {
         const asset = fixed_term_loan_to_asset[e.loan_?.toLowerCase()]
@@ -135,6 +143,43 @@ const fetch = async (options: FetchOptions) => {
         const asset = fixed_term_loan_to_asset[e.address?.toLowerCase()]
         dailyFees.add(asset, e.args.interestPaid_, METRIC.BORROW_INTEREST)
         dailySupplySideRevenue.add(asset, e.args.interestPaid_, METRIC.BORROW_INTEREST)
+      })
+    }
+
+    // Fixed-term management fees are a cut of the interest above (12.5% on the pools seen), not an
+    // extra charge, so they are revenue and have to come back off the supply side. The open-term
+    // leg already gets this right by booking netInterest_.
+    const logs_fixed_term_loan_manager_deployed = await getLogs({
+      target: fixedTermLoanManagerFactory,
+      eventAbi: loan_manager_deployed_event,
+      fromBlock: 16155123, // Dec-11-2022, first manager
+      cacheInCloud: true,
+    })
+    const fixed_term_loan_managers: string[] = logs_fixed_term_loan_manager_deployed.map(e => e.instance_);
+
+    if (fixed_term_loan_managers.length) {
+      const manager_assets = await options.api.multiCall({ abi: 'address:fundsAsset', calls: fixed_term_loan_managers })
+
+      const manager_to_asset: Record<string, string> = {};
+      fixed_term_loan_managers.forEach((manager, i) => {
+        manager_to_asset[manager.toLowerCase()] = manager_assets[i];
+      })
+
+      const logs_management_fees = await getLogs({
+        targets: fixed_term_loan_managers,
+        eventAbi: management_fees_paid_event,
+        entireLog: true,
+        parseLog: true,
+      })
+
+      logs_management_fees.forEach((t: any) => {
+        const e = t.args;
+        const asset = manager_to_asset[t.address?.toLowerCase()]
+        dailyRevenue.add(asset, e.delegateManagementFee_, METRIC.MANAGEMENT_FEES)
+        dailyRevenue.add(asset, e.platformManagementFee_, METRIC.MANAGEMENT_FEES)
+
+        dailySupplySideRevenue.add(asset, -Number(e.delegateManagementFee_), METRIC.BORROW_INTEREST)
+        dailySupplySideRevenue.add(asset, -Number(e.platformManagementFee_), METRIC.BORROW_INTEREST)
       })
     }
   }
@@ -247,18 +292,18 @@ const adapters: SimpleAdapter = {
     Fees: "Total interest and fees paid by borrowers on both fixed-term and open-term loans, including net interest, management fees, service fees, strategy fees and origination fees, plus off-chain OTC desk revenue.",
     Revenue: "Total revenue flowing to Maple protocol and delegates, including management fees, service fees, strategy fees and origination fees from both fixed-term and open-term loans.",
     ProtocolRevenue: "Revenue flowing to Maple protocol treasuries, i.e. total revenue less the share allocated to SYRUP buybacks.",
-    SupplySideRevenue: "Net interest earned by liquidity providers/depositors in Maple pools from both fixed-term and open-term loan payments.",
+    SupplySideRevenue: "Net interest earned by liquidity providers/depositors in Maple pools from both fixed-term and open-term loan payments, after the management fee the pool takes out of that interest.",
     HoldersRevenue: "Share of revenue used to buy back SYRUP tokens: 20% from Jan 2025 (MIP-013/016), 25% from Jul 2025 (MIP-019), 10% from Jul 2026 (MIP-021). Matched against the monthly buybacks published on https://maple.finance/transparency.",
   },
   breakdownMethodology: {
     Fees: {
       [METRIC.BORROW_INTEREST]: 'Net interest paid by borrowers on open-term loans.',
-      [METRIC.MANAGEMENT_FEES]: 'Management fees from open-term loans, origination fees from fixed-term loans, and off-chain OTC desk revenue, paid to protocol and delegates.',
+      [METRIC.MANAGEMENT_FEES]: 'Management fees from open-term and fixed-term loans, origination fees from fixed-term loans, and off-chain OTC desk revenue, paid to protocol and delegates.',
       [METRIC.SERVICE_FEES]: 'Service fees from both fixed-term and open-term loans, paid to protocol and delegates.',
       [STRATEGY_FEES]: 'Aave/sky Strategy fees paid to protocol.',
     },
     SupplySideRevenue: {
-      [METRIC.BORROW_INTEREST]: 'Net interest distributed to liquidity providers.',
+      [METRIC.BORROW_INTEREST]: 'Interest distributed to liquidity providers, net of the management fee taken out of it.',
     },
     Revenue: {
       [METRIC.MANAGEMENT_FEES]: 'Management fees from open-term loans and origination fees from fixed-term loans.',

--- a/fees/maple-finance.ts
+++ b/fees/maple-finance.ts
@@ -302,7 +302,7 @@ const adapters: SimpleAdapter = {
     Revenue: "Total revenue flowing to Maple protocol and delegates, including management fees, service fees, strategy fees and origination fees from both fixed-term and open-term loans.",
     ProtocolRevenue: "Revenue flowing to Maple protocol treasuries, i.e. total revenue less the share allocated to SYRUP buybacks.",
     SupplySideRevenue: "Net interest earned by liquidity providers/depositors in Maple pools from both fixed-term and open-term loan payments, after the management fee the pool takes out of that interest.",
-    HoldersRevenue: "Share of revenue used to buy back SYRUP tokens: 20% from Jan 2025 (MIP-013/016), 25% from Jul 2025 (MIP-019), 10% from Jul 2026 (MIP-021). Matched against the monthly buybacks published on https://maple.finance/transparency.",
+    HoldersRevenue: "Share of revenue used to buy back SYRUP tokens: 20% from Jan 2025 (MIP-013/016), 25% from Jul 2025 (MIP-019), 10% from Jul 2026 (MIP-021).",
   },
   breakdownMethodology: {
     Fees: {

--- a/fees/maple-finance.ts
+++ b/fees/maple-finance.ts
@@ -2,7 +2,6 @@ import { CHAIN } from "../helpers/chains";
 import { Dependencies, FetchOptions, SimpleAdapter } from "../adapters/types";
 import { METRIC } from '../helpers/metrics';
 import { queryDuneSql } from "../helpers/dune";
-import { httpGet } from "../utils/fetchURL";
 
 const feeManager = '0xFeACa6A5703E6F9DE0ebE0975C93AE34c00523F2'
 
@@ -50,60 +49,16 @@ function getHoldersRevenueShare(date: number): number {
 
 const STRATEGY_FEES = 'Strategy Fees';
 
-// Maple stopped updating their daily OTC dataset on Dune after 2025-10-09 (all October rows are
-// null), so from 2025-10-01 the off-chain number is recovered from what they still publish: the
-// monthly total revenue on https://maple.finance/transparency (which includes OTC) minus our own
-// on-chain revenue for that month, spread evenly over the month's days. The monthly residual
-// reconciles with the real OTC dataset where both exist (2025-06: residual $797k vs dataset
-// $813k) and with inverting their published buybacks (buyback / rate matches revenue to ~0.15%).
-const OTC_DATASET_STALE_TS = 1759276800 // 2025-10-01
-
-async function getOtcFromDuneDataset(options: FetchOptions): Promise<number> {
-  const duneQuery = `
-    select coalesce(otc_revenue, 0) as otc_fees from dune."maple-finance".dataset_maple_otc_by_day where timestamp >= ${options.startOfDay} and timestamp < ${options.startOfDay + 86400}`;
-  const duneData = await queryDuneSql(options, duneQuery);
-  return Number(duneData?.[0]?.otc_fees || 0)
-}
-
-async function getOtcResidualFromTransparency(options: FetchOptions): Promise<number> {
-  const day = new Date(options.startOfDay * 1000)
-  const monthStartMs = Date.UTC(day.getUTCFullYear(), day.getUTCMonth(), 1)
-  const daysInMonth = new Date(Date.UTC(day.getUTCFullYear(), day.getUTCMonth() + 1, 0)).getUTCDate()
-
-  // monthly total revenue (incl. OTC), server-rendered into the transparency page
-  const html: string = await httpGet('https://maple.finance/transparency', { headers: { 'User-Agent': 'Mozilla/5.0' } })
-  const propsMatch = html.match(/RevChartInner[^>]*props="([^"]*)"/)
-  if (!propsMatch) throw new Error('maple transparency page: RevChartInner props not found')
-  const props = JSON.parse(propsMatch[1].replace(/&quot;/g, '"').replace(/&amp;/g, '&'))
-  const monthRow = props.datasets[1].ALL[1].find((r: any) => r[1].ts[1] === monthStartMs)
-  if (!monthRow) return 0 // month not published yet
-  const publishedMonthRevenue = monthRow[1].revenueUsd[1]
-
-  // our on-chain revenue for the same month, from the served series (the ethereum leg of this
-  // adapter; stable for these dates - none of the ethereum-side history fixes touch post-2025-09)
-  const summary = await httpGet('https://api.llama.fi/summary/fees/maple-finance?dataType=dailyRevenue')
-  let onchainMonthRevenue = 0
-  for (const [ts, byChain] of summary.totalDataChartBreakdown ?? []) {
-    const d = new Date(ts * 1000)
-    if (Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), 1) !== monthStartMs) continue
-    onchainMonthRevenue += Object.entries(byChain as Record<string, Record<string, number>>)
-      .filter(([chain]) => chain !== 'Off Chain')
-      .reduce((sum, [, byProtocol]) => sum + Object.values(byProtocol).reduce((a, b) => a + b, 0), 0)
-  }
-
-  return Math.max(0, publishedMonthRevenue - onchainMonthRevenue) / daysInMonth
-}
-
 const fetch = async (options: FetchOptions) => {
 
   if (options.chain === CHAIN.OFF_CHAIN) {
-    const otcFees = options.startOfDay < OTC_DATASET_STALE_TS
-      ? await getOtcFromDuneDataset(options)
-      : await getOtcResidualFromTransparency(options)
+    const duneQuery = `
+    select coalesce(otc_revenue, 0) as otc_fees from dune."maple-finance".dataset_maple_otc_by_day where timestamp >= ${options.startOfDay} and timestamp < ${options.startOfDay + 86400}`;
+    const duneData = await queryDuneSql(options, duneQuery);
 
     const holdersShare = getHoldersRevenueShare(options.startOfDay);
     const dailyFees = options.createBalances();
-    dailyFees.addUSDValue(otcFees, METRIC.MANAGEMENT_FEES);
+    dailyFees.addUSDValue(Number(duneData?.[0]?.otc_fees || 0), METRIC.MANAGEMENT_FEES);
 
     return {
       dailyFees,
@@ -352,7 +307,7 @@ const adapters: SimpleAdapter = {
   breakdownMethodology: {
     Fees: {
       [METRIC.BORROW_INTEREST]: 'Net interest paid by borrowers on open-term loans.',
-      [METRIC.MANAGEMENT_FEES]: 'Management fees from open-term and fixed-term loans, origination fees from fixed-term loans, and off-chain OTC desk revenue (from Oct 2025 estimated as Maple published monthly revenue minus on-chain revenue, spread over the month), paid to protocol and delegates.',
+      [METRIC.MANAGEMENT_FEES]: 'Management fees from open-term and fixed-term loans, origination fees from fixed-term loans, and off-chain OTC desk revenue, paid to protocol and delegates.',
       [METRIC.SERVICE_FEES]: 'Service fees from both fixed-term and open-term loans, paid to protocol and delegates.',
       [STRATEGY_FEES]: 'Aave/sky Strategy fees paid to protocol.',
     },


### PR DESCRIPTION
Three real bugs in `fees/maple-finance.ts`, all confirmed against Maple's own published numbers on https://maple.finance/transparency and independently against Dune.

### 1. The adapter threw for every day before 2023-06-20

The fixed-term-loan `PaymentMade` `getLogs` call passed `entireLog: true` without `parseLog: true`, so `e.args` was `undefined` and `e.args.interestPaid_` raised a TypeError on any day that had a fixed-term payment. The configured start is `2022-01-01`, but the served series began 2023-06-20, which is just the first day with no fixed-term payment left to crash on.

Spot check for 2022-08-14: the adapter now reports $153,742 against $153,822 of on-chain USDC interest in the two `PaymentMade` events that day.

### 2. The off-chain OTC leg has never contributed anything

The Dune query filtered `where timestamp = options.toTimestamp`, but the dataset is keyed on **end** of day (`23:59:59`), and v1 `toTimestamp` is itself `timestamp - 1`. The predicate could never match, so the `OFF_CHAIN` chain has returned $0 for every day since it was added in #5827.

Switched to a `startOfDay` day window. This recovers **$5.61M** of revenue over 2024-05 to 2025-09 and accounts for nearly the whole gap against Maple's published revenue. With it applied, DL + OTC lands within a few percent of Maple's own monthly figure for every month the dataset covers (2025-06: $495,740 + $812,990 = $1,308,730 vs Maple's $1,292,622).

### 3. HoldersRevenue used the wrong start date and rate

The adapter had a flat 25% from 2025-11-01 citing MIP-019. Maple's published buyback table shows buybacks running since **Jan 2025**, and each row divided by that month's published revenue lands on its governance rate to within 0.15%:

| month | buyback | revenue | ratio | regime |
|---|---|---|---|---|
| 2025-01 | $81,256 | $408,384 | 19.90% | MIP-013, 20% |
| 2025-03 | $74,200 | $369,055 | 20.11% | |
| 2025-06 | $260,000 | $1,292,622 | 20.11% | MIP-016 Q2 |
| 2025-07 | $326,000 | $1,301,690 | 25.04% | MIP-019 SSF, 25% |
| 2025-09 | $375,750 | $1,500,751 | 25.04% | |
| 2025-11 | $529,119 | $2,113,552 | 25.04% | |
| 2026-07 | $136,768 | $1,367,683 | 10.00% | MIP-021 tiered |

The months with no row (Oct 2025, Dec 2025, Jan-May 2026) are execution timing, not policy: the Syrup Strategic Fund accrues monthly and buys in batches, and Jun 2026's 29% is a catch-up. Booking HoldersRevenue on the accrual is the right basis for a daily series.

MIP-021 (passed 99.97%, first buybacks Aug 2026, 6-month term) tiers the rate on **monthly** revenue: 10% under \$1.5M, 20% to \$2M, 30% above. A daily fetch cannot see the month, and estimating the tier from `dailyRevenue * 30` overstates by 2.3-2.5x because daily revenue is lumpy (90-day median \$13.9k against a \$162k max). Maple has run \$1.0-1.4M/month all through 2026, so 10% is hardcoded from 2026-07-01 with a comment naming the ceiling and when to revisit.

### Cleanup

The per-event `dailyProtocolRevenue.add(...)` / `dailyHoldersRevenue.add(...)` pairs were a flat ratio of `dailyRevenue`, so they collapse into one `clone()` each. 11 duplicated lines removed, same output.

### Verification that nothing else is missing

Monthly `dailyRevenue` from the DL API against the same components summed independently on Dune (open-term `ClaimedFundsDistributed` management+service fees, fixed-term origination+service fees, raw `StrategyFeesCollected` logs):

| month | Dune | DL API |
|---|---|---|
| 2025-12 | $1,262,325 | $1,262,155 |
| 2026-01 | $1,150,280 | $1,150,216 |
| 2026-03 | $1,338,646 | $1,338,696 |
| 2026-05 | $798,992 | $798,845 |
| 2026-07 | $1,024,479 | $1,024,386 |

All five live open-term loan managers (syrupUSDC, syrupUSDT, syrupUSDG, Maple Institutional, and the pool added 2026-05-25) are enumerated from the factory. Maple's Base / Plasma / Robinhood-chain contracts are CCIP token pools for bridged syrupUSDC, not lending pools. Aave/Sky strategies were genuinely wound down around 2026-04-20, so the zero after April is real.

### Follow-ups outside this PR

- **Refill required**: full history from 2022-01-01 on both chains. 2022-01-01 to 2023-06-19 is brand new, 2024-05 to 2025-09 gains the OTC leg, and 2025-01-01 onwards changes the Protocol/Holders split.
- `dune."maple-finance".dataset_maple_otc_by_day` has not been updated since 2025-10-09 (rows exist to that date, all null from 2025-10-01). It is Maple's own uploaded dataset. Until they refresh it the OFF_CHAIN leg reports $0 and we understate revenue by roughly $700k/month, about $7.5M to date.
- Maple V1 history (2021-06 to 2022-07, LoanFactory `0x908cc851bc757248514e060ad8bd0a03908308ee`) is still uncounted, about $21.5M of borrower interest. Not added here because the natural revenue source for that era, `pool_evt_claim` on the 7 V1 pools, also claims interest from the v3 loans this adapter counts, so wiring it in risks a double-count over 2022.