### PR TITLE
woofi: read every chain from the stat api, one failing subgraph blanks all 15

### DIFF
--- a/dexs/woofi/index.ts
+++ b/dexs/woofi/index.ts
@@ -1,26 +1,30 @@
-import * as sdk from "@defillama/sdk";
 import { Chain } from "../../adapters/types";
 import { FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
-import request, { gql } from "graphql-request";
 import { getTimestampAtStartOfDayUTC } from "../../utils/date";
 import { httpGet } from "../../utils/fetchURL";
 
-
-const endpoints: Record<Chain, string> = {
-  [CHAIN.AVAX]: sdk.graph.modifyEndpoint('BL45YVVLVkCRGaAtyTjvuRt1yHnUt4QbZg8bWcZtLvLm'),
-  [CHAIN.BSC]: sdk.graph.modifyEndpoint('CxWDreK8yXVX9qxLTNoyTrcNT2uojrPiseC7mBqRENem'),
-  [CHAIN.FANTOM]: sdk.graph.modifyEndpoint('B1TxafnDavup8z9rwi5TKDwZxCBR24tw8sFeyLSShhiP'),
-  [CHAIN.POLYGON]: sdk.graph.modifyEndpoint('Bn68xGN5mLu9cAVgCNrACxXWf5FR1dDQ6JxvXzimd7eZ'),
-  [CHAIN.ARBITRUM]: sdk.graph.modifyEndpoint('9wYUKdu85CGGwiV8mawEUwMhj4go7dx6ezfSkh9DUrFa'),
-  [CHAIN.OPTIMISM]: sdk.graph.modifyEndpoint('F7nNhkyaR53fs14vhfJmsUAotN1aJiyMbVc677ngFHWU'),
-  [CHAIN.ERA]: sdk.graph.modifyEndpoint('DxS3HgpNUjaujQEeom9CyTmrRbLH31PYX3JdiJkgRh7D'),
-  [CHAIN.POLYGON_ZKEVM]: sdk.graph.modifyEndpoint('FbGJ32HNCStF9df3M1GXQCs4MUsSY4tAPh3MZyKMV2M5'),
-  [CHAIN.LINEA]: sdk.graph.modifyEndpoint('4TN6UVFc77yYu3YdUxFv6wkFXkNEeueWi8oGrAg8BcfM'),
-  [CHAIN.BASE]: sdk.graph.modifyEndpoint('EHcBkzfegM51XJmxb26DcB6RmvhNTaoY692aiNHC9Bm5'),
-  [CHAIN.SONIC]: sdk.graph.modifyEndpoint('7dkVEmyCHvjnYYUJ9DR1t2skkZrdbfSWpK6wpMbF9CEk'),
-  [CHAIN.BERACHAIN]: sdk.graph.modifyEndpoint('FGF5X13mGLYu2GN7pK4LYuMeS95WENHAgPDP8JDCJyTy'),
-  [CHAIN.MONAD]: sdk.graph.modifyEndpoint('B5oecz9PHofaQmUMP8ws2iYsNTxXhEtcghsA2jMSsJAP'),
+// every chain reads from the woofi stat api. the subgraphs behind the old
+// per-chain endpoints are unreliable and they all shared one Promise.all, so a
+// single failing one blanked the whole adapter. #8920 already moved mantle,
+// hyperevm and solana here for the same reason.
+const apiNetworks: Record<Chain, string> = {
+  [CHAIN.AVAX]: "avax",
+  [CHAIN.BSC]: "bsc",
+  [CHAIN.FANTOM]: "fantom",
+  [CHAIN.POLYGON]: "polygon",
+  [CHAIN.ARBITRUM]: "arbitrum",
+  [CHAIN.OPTIMISM]: "optimism",
+  [CHAIN.ERA]: "zksync",
+  [CHAIN.POLYGON_ZKEVM]: "polygon_zkevm",
+  [CHAIN.LINEA]: "linea",
+  [CHAIN.BASE]: "base",
+  [CHAIN.MANTLE]: "mantle",
+  [CHAIN.SONIC]: "sonic",
+  [CHAIN.BERACHAIN]: "berachain",
+  [CHAIN.SOLANA]: "solana",
+  [CHAIN.HYPERLIQUID]: "hyperevm",
+  [CHAIN.MONAD]: "monad",
 };
 
 type TStartTime = {
@@ -45,40 +49,6 @@ const startTime: TStartTime = {
   [CHAIN.MONAD]: 1764201600,
 };
 
-interface FetchResult {
-  dayData: {
-    volumeUSD: string;
-  }
-  globalVariables: Array<{
-    totalVolumeUSD: string;
-  }>
-}
-const fetchVolume = async (options: FetchOptions) => {
-  const start = getTimestampAtStartOfDayUTC(options.endTimestamp)
-  const dateId = Math.floor(start / 86400);
-  const query = gql`
-    {
-    dayData(id: ${dateId}) {
-        volumeUSD
-      },
-      globalVariables {
-        totalVolumeUSD
-      }
-    }
-  `;
-  const response: FetchResult = (await request(endpoints[options.chain], query));
-  return {
-    timestamp: start,
-    dailyVolume: Number(response?.dayData?.volumeUSD || 0) / 1e18,
-  }
-}
-
-const apiNetworks: Record<Chain, string> = {
-  [CHAIN.SOLANA]: "solana",
-  [CHAIN.MANTLE]: "mantle",
-  [CHAIN.HYPERLIQUID]: "hyperevm",
-};
-
 const fetchApiVolume = async (options: FetchOptions) => {
   const apiURL = `https://api.woofi.com/stat?period=all&network=${apiNetworks[options.chain]}`;
   const response = await httpGet(apiURL);
@@ -87,28 +57,26 @@ const fetchApiVolume = async (options: FetchOptions) => {
 
   const result = response?.data?.find((item) => item.timestamp === startOfDayUTC.toString());
 
+  // a row carrying zero is a real quiet day and several chains have had those
+  // for months. a missing row means the api has nothing for that day, so throw
+  // rather than publish a zero that is not one.
+  if (!result) throw new Error(`woofi: no stat row for ${apiNetworks[options.chain]} at ${startOfDayUTC}`);
+
   return {
-    dailyVolume: result ? Number(result.volume_usd) / 1e18 : 0,
+    dailyVolume: Number(result.volume_usd) / 1e18,
   }
 }
 
-const volume = Object.keys(endpoints).reduce(
+const volume = Object.keys(apiNetworks).reduce(
   (acc, chain) => ({
     ...acc,
     [chain]: {
-      fetch: fetchVolume,
+      fetch: fetchApiVolume,
       start: startTime[chain],
     },
   }),
   {}
 );
-
-Object.keys(apiNetworks).forEach((chain) => {
-  volume[chain] = {
-    fetch: fetchApiVolume,
-    start: startTime[chain],
-  };
-});
 
 const adapter: SimpleAdapter = {
   version: 1,


### PR DESCRIPTION
## What

WOOFi Swap keeps dropping whole days. Published `dailyVolume` has no point at all for 08-19, 08-20 or 08-22, and `total24h` is null:

| day | published |
|---|---|
| 08-17 | 5,955,702 |
| 08-18 | 4,984,664 |
| 08-19 | missing |
| 08-20 | missing |
| 08-21 | 11,775,618 |
| 08-22 | missing |

Nothing is wrong with the protocol on those days. The 13 remaining subgraph chains all resolve through `sdk.graph.modifyEndpoint`, and every chain in this adapter shares a single `Promise.all`, so one endpoint failing takes the other fourteen with it. That is why the series flaps rather than showing one chain going quiet.

#8920 already moved mantle, hyperevm and solana onto `api.woofi.com/stat` for exactly this reason. That api turns out to carry every chain, so this moves the rest across and drops the graph dependency entirely.

Credit to @0xshubhs, this is their fix from #8920 applied to the other twelve chains.

## The api matches the subgraphs

Comparing the api against the published per-chain figures on the three days that did publish. Worst case is 0.14% on Base, most chains agree to the dollar:

| 2026-08-21 | published | api |
|---|---|---|
| Arbitrum | 3,264,637 | 3,264,636 |
| OP Mainnet | 2,971,409 | 2,971,408 |
| Polygon | 2,481,352 | 2,481,351 |
| Avalanche | 2,058,607 | 2,058,606 |
| Base | 878,349 | 877,117 |
| Monad | 121,264 | 121,263 |
| BSC, Linea, Sonic, Berachain, ZKsync, Fantom, Mantle, Solana, Hyperliquid | 0 | 0 |
| **total** | **11,775,618** | **11,774,386** |

08-17 and 08-18 line up the same way: 5,955,702 vs 5,954,709, and 4,984,664 vs 4,982,591.

## The zeros are real

Those nine zero chains are not gaps. BSC has had no volume since 2026-05-06, linea since 2026-03-16, sonic since 2026-04-20, berachain since 2026-05-07, mantle and solana since 2026-04-20, zksync and polygon_zkevm long before that. Each reports an explicit zero row rather than no row.

That distinction is why the missing-row case now throws instead of returning `0`. A row carrying zero is a quiet day and should publish as zero. No row means the api has nothing for that day, and publishing a zero there is the same false zero this adapter has been producing.

## Test

`npm run test dexs woofi`. The date argument is the end of the window, so a run dated 08-22 is the 08-21 day.

| run | day | aggregate | published |
|---|---|---|---|
| 08-19 | 08-18 | 4.98 M | 4,984,664 |
| 08-22 | 08-21 | 11.77 M | 11,775,618 |
| 08-20 | 08-19 | 12.08 M | nothing |

All 15 chains return without error on each run.

## One thing to flag

This takes the adapter from 3 api calls per run to 15, and `api.woofi.com` does rate limit. I tripped a 429 running the same day repeatedly while testing. 15 calls spread across a normal run should be well inside it, but I could not prove that from here.
