### PR TITLE
fix(fees): include Keep staged creator fees

### DIFF
--- a/fees/keep.ts
+++ b/fees/keep.ts
@@ -36,6 +36,8 @@ const FINALIZED_D30_PREFIX = "2Vt0QavIXBI";
 const SUCCESS_EXECUTED_PREFIX = "Trx57IcWNIY";
 const IDEA_FUNDING_RELEASED_PREFIX = "PKK4EmjFDVo";
 
+const PROGRAM_DEPLOYMENT = "2026-06-14";
+
 /**
  * One Dune call: USDC inflows to the platform ATA (protocol revenue) plus
  * project-owner staged raise fees and the share decoded from FeesHarvested
@@ -49,34 +51,38 @@ const IDEA_FUNDING_RELEASED_PREFIX = "PKK4EmjFDVo";
  *
  * Filter the ATA with to_token_account, not to_owner — to_owner is the
  * platform fee-receiver wallet, not this token account.
+ *
+ * ProjectCreated has to be read from before the current day, so it is bounded
+ * by the program deployment date to keep it from scanning Solana history.
  */
 const getKeepFees = async (options: FetchOptions) => {
   const programs = KEEP_PROGRAMS.map((program) => `'${program}'`).join(", ");
   const rows = await queryDuneSql(options, `
-    WITH fee_txs AS (
-      SELECT DISTINCT i.tx_id
+    WITH events AS (
+      SELECT DISTINCT i.tx_id, substr(log_message, 15) AS payload
       FROM solana.instruction_calls i
       CROSS JOIN UNNEST(i.log_messages) AS logs(log_message)
       WHERE i.tx_success = TRUE
         AND i.outer_executing_account IN (${programs})
         AND TIME_RANGE
-        AND (
-          starts_with(log_message, 'Program data: ${BOOTSTRAPPED_PREFIX}')
-          OR starts_with(log_message, 'Program data: ${FINALIZED_D7_PREFIX}')
-          OR starts_with(log_message, 'Program data: ${FINALIZED_D30_PREFIX}')
-          OR starts_with(log_message, 'Program data: ${SUCCESS_EXECUTED_PREFIX}')
-          OR starts_with(log_message, 'Program data: ${FEES_HARVESTED_PREFIX}')
-        )
+        AND starts_with(log_message, 'Program data: ')
     ),
-    platform AS (
-      SELECT COALESCE(SUM(amount), 0) AS amount
-      FROM tokens_solana.transfers t
-      JOIN fee_txs f ON f.tx_id = t.tx_id
-      WHERE t.to_token_account = '${PLATFORM_FEE_USDC_ATA}'
-        AND t.token_mint_address = '${USDC}'
-        AND t.outer_executing_account IN (${programs})
-        AND t.block_time >= from_unixtime(${options.startTimestamp})
-        AND t.block_time <= from_unixtime(${options.endTimestamp})
+    usdc_transfers AS (
+      SELECT tx_id, amount, to_token_account, to_owner
+      FROM tokens_solana.transfers
+      WHERE token_mint_address = '${USDC}'
+        AND outer_executing_account IN (${programs})
+        AND TIME_RANGE
+    ),
+    staged_fee_txs AS (
+      SELECT DISTINCT
+        tx_id,
+        to_base58(varbinary_substring(from_base64(payload), 9, 32)) AS launchpad
+      FROM events
+      WHERE starts_with(payload, '${BOOTSTRAPPED_PREFIX}')
+        OR starts_with(payload, '${FINALIZED_D7_PREFIX}')
+        OR starts_with(payload, '${FINALIZED_D30_PREFIX}')
+        OR starts_with(payload, '${SUCCESS_EXECUTED_PREFIX}')
     ),
     project_owners AS (
       SELECT DISTINCT
@@ -86,80 +92,37 @@ const getKeepFees = async (options: FetchOptions) => {
       CROSS JOIN UNNEST(i.log_messages) AS logs(log_message)
       WHERE i.tx_success = TRUE
         AND i.outer_executing_account IN (${programs})
+        AND i.block_time >= TIMESTAMP '${PROGRAM_DEPLOYMENT}'
         AND starts_with(log_message, 'Program data: ${PROJECT_CREATED_PREFIX}')
-    ),
-    staged_fee_txs AS (
-      SELECT DISTINCT
-        i.tx_id,
-        CASE
-          WHEN starts_with(log_message, 'Program data: ${BOOTSTRAPPED_PREFIX}')
-            THEN to_base58(varbinary_substring(from_base64(substr(log_message, 15)), 9, 32))
-          WHEN starts_with(log_message, 'Program data: ${FINALIZED_D7_PREFIX}')
-            THEN to_base58(varbinary_substring(from_base64(substr(log_message, 15)), 9, 32))
-          WHEN starts_with(log_message, 'Program data: ${FINALIZED_D30_PREFIX}')
-            THEN to_base58(varbinary_substring(from_base64(substr(log_message, 15)), 9, 32))
-          WHEN starts_with(log_message, 'Program data: ${SUCCESS_EXECUTED_PREFIX}')
-            THEN to_base58(varbinary_substring(from_base64(substr(log_message, 15)), 9, 32))
-        END AS launchpad
-      FROM solana.instruction_calls i
-      CROSS JOIN UNNEST(i.log_messages) AS logs(log_message)
-      WHERE i.tx_success = TRUE
-        AND i.outer_executing_account IN (${programs})
-        AND TIME_RANGE
-        AND (
-          starts_with(log_message, 'Program data: ${BOOTSTRAPPED_PREFIX}')
-          OR starts_with(log_message, 'Program data: ${FINALIZED_D7_PREFIX}')
-          OR starts_with(log_message, 'Program data: ${FINALIZED_D30_PREFIX}')
-          OR starts_with(log_message, 'Program data: ${SUCCESS_EXECUTED_PREFIX}')
-        )
-    ),
-    staged_project AS (
-      SELECT COALESCE(SUM(t.amount), 0) AS amount
-      FROM tokens_solana.transfers t
-      JOIN staged_fee_txs s ON s.tx_id = t.tx_id
-      JOIN project_owners p
-        ON p.launchpad = s.launchpad
-       AND p.project_owner = t.to_owner
-      WHERE t.token_mint_address = '${USDC}'
-        AND t.outer_executing_account IN (${programs})
-        AND t.block_time >= from_unixtime(${options.startTimestamp})
-        AND t.block_time <= from_unixtime(${options.endTimestamp})
-    ),
-    funding_release_events AS (
-      SELECT DISTINCT
-        i.tx_id,
-        substr(log_message, 15) AS payload
-      FROM solana.instruction_calls i
-      CROSS JOIN UNNEST(i.log_messages) AS logs(log_message)
-      WHERE i.tx_success = TRUE
-        AND i.outer_executing_account IN (${programs})
-        AND TIME_RANGE
-        AND starts_with(log_message, 'Program data: ${IDEA_FUNDING_RELEASED_PREFIX}')
-    ),
-    harvested_project_events AS (
-      SELECT DISTINCT
-        i.tx_id,
-        substr(log_message, 15) AS payload
-      FROM solana.instruction_calls i
-      CROSS JOIN UNNEST(i.log_messages) AS logs(log_message)
-      WHERE i.tx_success = TRUE
-        AND i.outer_executing_account IN (${programs})
-        AND TIME_RANGE
-        AND starts_with(log_message, 'Program data: ${FEES_HARVESTED_PREFIX}')
-    ),
-    harvested_project AS (
-      SELECT COALESCE(SUM(
-        varbinary_to_uint256(reverse(varbinary_substring(from_base64(payload), 81, 8)))
-      ), 0) AS amount
-      FROM harvested_project_events
     )
     SELECT
-      (SELECT amount FROM platform) AS platform_amount,
-      (SELECT amount FROM staged_project)
-        + COALESCE((SELECT SUM(
-            varbinary_to_uint256(reverse(varbinary_substring(from_base64(payload), 73, 8)))
-          ) FROM funding_release_events), 0)
-        + (SELECT amount FROM harvested_project) AS project_amount
+      (
+        SELECT COALESCE(SUM(amount), 0)
+        FROM usdc_transfers
+        WHERE to_token_account = '${PLATFORM_FEE_USDC_ATA}'
+      ) AS platform_amount,
+      (
+        SELECT COALESCE(SUM(t.amount), 0)
+        FROM usdc_transfers t
+        JOIN staged_fee_txs s ON s.tx_id = t.tx_id
+        JOIN project_owners p
+          ON p.launchpad = s.launchpad
+         AND p.project_owner = t.to_owner
+      )
+      + (
+        SELECT COALESCE(SUM(
+          varbinary_to_uint256(reverse(varbinary_substring(from_base64(payload), 73, 8)))
+        ), 0)
+        FROM events
+        WHERE starts_with(payload, '${IDEA_FUNDING_RELEASED_PREFIX}')
+      )
+      + (
+        SELECT COALESCE(SUM(
+          varbinary_to_uint256(reverse(varbinary_substring(from_base64(payload), 81, 8)))
+        ), 0)
+        FROM events
+        WHERE starts_with(payload, '${FEES_HARVESTED_PREFIX}')
+      ) AS project_amount
   `);
 
   const dailyRevenue = options.createBalances();

--- a/fees/keep.ts
+++ b/fees/keep.ts
@@ -3,17 +3,12 @@
 // Programs (mainnet): Full Launch ETVtC29T7ExxYyWSkpzKPxzrL3SRyrGPRhZe3FwXmFAo
 //                    Idea Mode 2ww3589FBTgwbCd9sbpBjosiDszsigoqArh5xuc7F2Ve
 //
-// Where Keep's fees come from (verified from the program source):
-//   1. Success platform fee — PLATFORM_FEE_BPS = 500 (5%) of each successful
-//      raise, swept to the platform fee receiver in settle_success.rs.
-//   2. Trading-fee harvest — harvest_fees.rs skims the accrued-fee (√k) fraction
-//      of the burned Raydium LP; the platform's share (platform_amount) is
-//      transferred to the platform fee receiver's USDC ATA, the project's share
-//      (project_amount = fee_split_project_bps) to the project owner's USDC ATA.
-//      Emitted as FeesHarvested { harvested_usdc, project_amount, platform_amount }.
+// All output is derived from on-chain USDC receipts. Platform receipts are
+// filtered by the Keep programs and destination USDC token account; project
+// receipts include staged raise-fee transfers and FeesHarvested events.
 //
-// Both PLATFORM slices (success 5% + harvest platform_amount) land in the platform
-// fee-receiver USDC ATA, so daily USDC received there = Keep's protocol revenue.
+// All platform slices (staged raise fees + harvest platform_amount) land in the
+// platform fee-receiver USDC ATA, so daily USDC received there = protocol revenue.
 
 import { Dependencies, FetchOptions, SimpleAdapter } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
@@ -34,15 +29,23 @@ const KEEP_PROGRAMS = [
 // Anchor's first eight event bytes, base64-encoded. The complete event payload
 // is decoded below; the prefix is only used to select FeesHarvested log lines.
 const FEES_HARVESTED_PREFIX = "Huy2vk3+TAo";
+const PROJECT_CREATED_PREFIX = "wAqjHbkfQ6g";
+const BOOTSTRAPPED_PREFIX = "ONeHjsYunZs";
+const FINALIZED_D7_PREFIX = "JXozXYf7Ulg";
+const FINALIZED_D30_PREFIX = "2Vt0QavIXBI";
+const SUCCESS_EXECUTED_PREFIX = "Trx57IcWNIY";
+const IDEA_FUNDING_RELEASED_PREFIX = "PKK4EmjFDVo";
 
 /**
- * One Dune call: USDC inflows to the platform ATA (protocol revenue) plus the
- * project-owner share decoded from FeesHarvested events (supply-side).
+ * One Dune call: USDC inflows to the platform ATA (protocol revenue) plus
+ * project-owner staged raise fees and the share decoded from FeesHarvested
+ * events (supply-side).
  *
- * Event layout is Anchor discriminator (8 bytes), launchpad (32), project
- * owner (32), harvested_usdc (u64), project_amount (u64), platform_amount
- * (u64), tokens_burned (u64). Borsh integers are little-endian, hence the
- * byte reversal before Dune's numeric conversion.
+ * Idea Mode pays the creator 3% at Bootstrap, another 7% at successful
+ * settlement, and releases the final 35% through the creator funding stream.
+ * These are ordinary SPL transfers, not FeesHarvested events, so the project
+ * owner is resolved from ProjectCreated and stream releases are counted from
+ * the IdeaFundingReleased event emitted after each actual transfer.
  *
  * Filter the ATA with to_token_account, not to_owner — to_owner is the
  * platform fee-receiver wallet, not this token account.
@@ -50,14 +53,90 @@ const FEES_HARVESTED_PREFIX = "Huy2vk3+TAo";
 const getKeepFees = async (options: FetchOptions) => {
   const programs = KEEP_PROGRAMS.map((program) => `'${program}'`).join(", ");
   const rows = await queryDuneSql(options, `
-    WITH platform AS (
-      SELECT COALESCE(SUM(amount), 0) AS amount
-      FROM tokens_solana.transfers
-      WHERE to_token_account = '${PLATFORM_FEE_USDC_ATA}'
-        AND token_mint_address = '${USDC}'
+    WITH fee_txs AS (
+      SELECT DISTINCT i.tx_id
+      FROM solana.instruction_calls i
+      CROSS JOIN UNNEST(i.log_messages) AS logs(log_message)
+      WHERE i.tx_success = TRUE
+        AND i.outer_executing_account IN (${programs})
         AND TIME_RANGE
+        AND (
+          starts_with(log_message, 'Program data: ${BOOTSTRAPPED_PREFIX}')
+          OR starts_with(log_message, 'Program data: ${FINALIZED_D7_PREFIX}')
+          OR starts_with(log_message, 'Program data: ${FINALIZED_D30_PREFIX}')
+          OR starts_with(log_message, 'Program data: ${SUCCESS_EXECUTED_PREFIX}')
+          OR starts_with(log_message, 'Program data: ${FEES_HARVESTED_PREFIX}')
+        )
     ),
-    fee_events AS (
+    platform AS (
+      SELECT COALESCE(SUM(amount), 0) AS amount
+      FROM tokens_solana.transfers t
+      JOIN fee_txs f ON f.tx_id = t.tx_id
+      WHERE t.to_token_account = '${PLATFORM_FEE_USDC_ATA}'
+        AND t.token_mint_address = '${USDC}'
+        AND t.outer_executing_account IN (${programs})
+        AND t.block_time >= from_unixtime(${options.startTimestamp})
+        AND t.block_time <= from_unixtime(${options.endTimestamp})
+    ),
+    project_owners AS (
+      SELECT DISTINCT
+        to_base58(varbinary_substring(from_base64(substr(log_message, 15)), 17, 32)) AS launchpad,
+        to_base58(varbinary_substring(from_base64(substr(log_message, 15)), 81, 32)) AS project_owner
+      FROM solana.instruction_calls i
+      CROSS JOIN UNNEST(i.log_messages) AS logs(log_message)
+      WHERE i.tx_success = TRUE
+        AND i.outer_executing_account IN (${programs})
+        AND starts_with(log_message, 'Program data: ${PROJECT_CREATED_PREFIX}')
+    ),
+    staged_fee_txs AS (
+      SELECT DISTINCT
+        i.tx_id,
+        CASE
+          WHEN starts_with(log_message, 'Program data: ${BOOTSTRAPPED_PREFIX}')
+            THEN to_base58(varbinary_substring(from_base64(substr(log_message, 15)), 9, 32))
+          WHEN starts_with(log_message, 'Program data: ${FINALIZED_D7_PREFIX}')
+            THEN to_base58(varbinary_substring(from_base64(substr(log_message, 15)), 9, 32))
+          WHEN starts_with(log_message, 'Program data: ${FINALIZED_D30_PREFIX}')
+            THEN to_base58(varbinary_substring(from_base64(substr(log_message, 15)), 9, 32))
+          WHEN starts_with(log_message, 'Program data: ${SUCCESS_EXECUTED_PREFIX}')
+            THEN to_base58(varbinary_substring(from_base64(substr(log_message, 15)), 9, 32))
+        END AS launchpad
+      FROM solana.instruction_calls i
+      CROSS JOIN UNNEST(i.log_messages) AS logs(log_message)
+      WHERE i.tx_success = TRUE
+        AND i.outer_executing_account IN (${programs})
+        AND TIME_RANGE
+        AND (
+          starts_with(log_message, 'Program data: ${BOOTSTRAPPED_PREFIX}')
+          OR starts_with(log_message, 'Program data: ${FINALIZED_D7_PREFIX}')
+          OR starts_with(log_message, 'Program data: ${FINALIZED_D30_PREFIX}')
+          OR starts_with(log_message, 'Program data: ${SUCCESS_EXECUTED_PREFIX}')
+        )
+    ),
+    staged_project AS (
+      SELECT COALESCE(SUM(t.amount), 0) AS amount
+      FROM tokens_solana.transfers t
+      JOIN staged_fee_txs s ON s.tx_id = t.tx_id
+      JOIN project_owners p
+        ON p.launchpad = s.launchpad
+       AND p.project_owner = t.to_owner
+      WHERE t.token_mint_address = '${USDC}'
+        AND t.outer_executing_account IN (${programs})
+        AND t.block_time >= from_unixtime(${options.startTimestamp})
+        AND t.block_time <= from_unixtime(${options.endTimestamp})
+    ),
+    funding_release_events AS (
+      SELECT DISTINCT
+        i.tx_id,
+        substr(log_message, 15) AS payload
+      FROM solana.instruction_calls i
+      CROSS JOIN UNNEST(i.log_messages) AS logs(log_message)
+      WHERE i.tx_success = TRUE
+        AND i.outer_executing_account IN (${programs})
+        AND TIME_RANGE
+        AND starts_with(log_message, 'Program data: ${IDEA_FUNDING_RELEASED_PREFIX}')
+    ),
+    harvested_project_events AS (
       SELECT DISTINCT
         i.tx_id,
         substr(log_message, 15) AS payload
@@ -68,15 +147,19 @@ const getKeepFees = async (options: FetchOptions) => {
         AND TIME_RANGE
         AND starts_with(log_message, 'Program data: ${FEES_HARVESTED_PREFIX}')
     ),
-    project AS (
+    harvested_project AS (
       SELECT COALESCE(SUM(
         varbinary_to_uint256(reverse(varbinary_substring(from_base64(payload), 81, 8)))
       ), 0) AS amount
-      FROM fee_events
+      FROM harvested_project_events
     )
     SELECT
       (SELECT amount FROM platform) AS platform_amount,
-      (SELECT amount FROM project) AS project_amount
+      (SELECT amount FROM staged_project)
+        + COALESCE((SELECT SUM(
+            varbinary_to_uint256(reverse(varbinary_substring(from_base64(payload), 73, 8)))
+          ) FROM funding_release_events), 0)
+        + (SELECT amount FROM harvested_project) AS project_amount
   `);
 
   const dailyRevenue = options.createBalances();
@@ -110,21 +193,21 @@ const adapter: SimpleAdapter = {
   isExpensiveAdapter: true,
   doublecounted: true, // raydium
   methodology: {
-    Fees: "All Keep USDC fees: the platform fee-receiver inflows plus the project-owner share of harvested Raydium trading fees. The refundable raise principal and LP liquidity are excluded.",
+    Fees: "All Keep USDC fees: platform fee-receiver inflows plus project-owner staged raise-fee transfers and harvested Raydium trading-fee shares. Refundable raise principal and LP liquidity are excluded.",
     Revenue: "The platform portion of Keep fees, received by the platform fee-receiver USDC account. The project-owner share is reported as Supply Side Revenue.",
-    SupplySideRevenue: "The project-owner share of harvested Raydium trading fees, decoded from Keep's on-chain FeesHarvested events.",
+    SupplySideRevenue: "Project-owner staged raise-fee transfers plus the project share of harvested Raydium trading fees, counted only after the on-chain transfer/event occurs.",
     ProtocolRevenue: "USDC fees received by Keep's platform fee-receiver account.",
   },
   breakdownMethodology: {
     Fees: {
       [METRIC.PROTOCOL_FEES]: "Platform fee slices received by Keep's platform USDC ATA.",
-      [METRIC.CREATOR_FEES]: "Project-owner share emitted in FeesHarvested events.",
+      [METRIC.CREATOR_FEES]: "Project-owner staged raise-fee transfers and share emitted in FeesHarvested events.",
     },
     Revenue: {
       [METRIC.PROTOCOL_FEES]: "Platform fee slices retained by Keep's platform treasury.",
     },
     SupplySideRevenue: {
-      [METRIC.CREATOR_FEES]: "Project-owner share paid from harvested trading fees.",
+      [METRIC.CREATOR_FEES]: "Project-owner staged raise-fee transfers and share paid from harvested trading fees.",
     },
     ProtocolRevenue: {
       [METRIC.PROTOCOL_FEES]: "Platform fee slices received by Keep's platform treasury.",


### PR DESCRIPTION
## What changed

Keep Idea Mode pays creator fees in staged USDC transfers, not only in `FeesHarvested` events. This updates the adapter to count the actual project-owner receipts:

- Bootstrap: 3% creator tranche
- D+7 pass: additional 7% creator tranche
- D+30 success: final 35% creator tranche
- Raydium trading-fee creator share from `FeesHarvested`

The query resolves `project_owner` from `ProjectCreated`, binds lifecycle event transactions to their launchpad, and sums only USDC transfers to that owner. Platform inflows remain scoped to the Keep programs and the verified platform USDC token account.

## Evidence

- Mainnet Idea Bootstrap tx `3qSDCWb75FfpQsw7fmdfUDy77ZVQiC57SfPrBH3feu6YBhkmwQ3tTNBkQ31WCGSF77SKbaBs6K6E8QGtfG8qZPyS`: project owner +60 USDC, platform receiver +40 USDC on a 2,000 USDC raise.
- `pnpm ts-check` passes.
- Adapter import smoke passes.
- Fork adapter execution reaches Dune and returns HTTP 401 with an intentionally invalid key; no Dune credential is available in this environment.

This is a follow-up to merged PR #8928.