### PR TITLE
crshmarket: add the new market contract, adapter went to zeros on 08-17

### DIFF
--- a/dexs/crshmarket/index.ts
+++ b/dexs/crshmarket/index.ts
@@ -1,11 +1,13 @@
 import { FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 
-// CRSH's parimutuel market contracts on Monad. The second address is the
-// legacy deployment; keeping it here preserves historical coverage.
-// Current: https://monadscan.com/address/0x968279784d780c02a79b1c58ad69aaa832f09342
+// CRSH's parimutuel market contracts on Monad. Older addresses are kept for
+// historical coverage.
+// Current: https://monadscan.com/address/0x8964d7c989bf4b9bbd179ecd205544d3bb5b10f8
+// Legacy: https://monadscan.com/address/0x968279784d780c02a79b1c58ad69aaa832f09342
 // Legacy: https://monadscan.com/address/0x7b9256fd345b6dfa78017094cae64b153de21fb2
 const MARKET_CONTRACTS = [
+  "0x8964d7C989bF4B9bbd179ecd205544d3bb5B10F8",
   "0x968279784d780c02a79b1c58ad69aaa832f09342",
   "0x7b9256fd345b6dFa78017094caE64B153dE21fb2",
 ];

--- a/fees/crshmarket/index.ts
+++ b/fees/crshmarket/index.ts
@@ -2,11 +2,13 @@ import { FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 import { METRIC } from "../../helpers/metrics";
 
-// CRSH's parimutuel market contracts on Monad. The second address is the
-// legacy deployment; keeping it here preserves historical coverage.
-// Current: https://monadscan.com/address/0x968279784d780c02a79b1c58ad69aaa832f09342
+// CRSH's parimutuel market contracts on Monad. Older addresses are kept for
+// historical coverage.
+// Current: https://monadscan.com/address/0x8964d7c989bf4b9bbd179ecd205544d3bb5b10f8
+// Legacy: https://monadscan.com/address/0x968279784d780c02a79b1c58ad69aaa832f09342
 // Legacy: https://monadscan.com/address/0x7b9256fd345b6dfa78017094cae64b153de21fb2
 const MARKET_CONTRACTS = [
+  "0x8964d7C989bF4B9bbd179ecd205544d3bb5B10F8",
   "0x968279784d780c02a79b1c58ad69aaa832f09342",
   "0x7b9256fd345b6dFa78017094caE64B153dE21fb2",
 ];


### PR DESCRIPTION
Fixes #8941

CRSH moved to a new parimutuel market contract on monad on 08-17 (`0x8964d7c989bf4b9bbd179ecd205544d3bb5b10f8`, first BetPlaced at block 96701569). the adapter only listed the previous two deployments, so both the dexs and fees adapters have published zeros since. `owner()` on all three contracts is the same address and the event signatures are unchanged, so the fix is just adding the new address to MARKET_CONTRACTS in both adapters.

harness on the 08-21 day, both run twice:

- dexs: $14.62k daily volume (independent rpc sweep of the same day: 1,807 BetPlaced, $14,623)
- fees: $894.89 daily fees (sweep: 261 ProtocolFeeReleased, $893)

the old contracts still resolve for historical days: 08-16 reproduces $618k against the published $618,180.