### PR TITLE
vultisig: a day with no rows for a source is zero volume, not an error

### DIFF
--- a/aggregators/vultisig/index.ts
+++ b/aggregators/vultisig/index.ts
@@ -35,10 +35,11 @@ const fetch = async (options: FetchOptions) => {
   const rows = await getVolumeRows();
 
   const dailyVolume = options.createBalances();
-  const todaysRows = rows.filter((row) => row.source === source && row.date.slice(0, 10) === options.dateString);
-  if (!todaysRows.length) {
-    throw new Error(`No rows found for ${source} on ${options.dateString}`);
+  const sourceRows = rows.filter((row) => row.source === source);
+  if (!sourceRows.length) {
+    throw new Error(`No rows found for ${source}`);
   }
+  const todaysRows = sourceRows.filter((row) => row.date.slice(0, 10) === options.dateString);
   const total = todaysRows.reduce((sum, row) => sum + row.volume, 0);
   dailyVolume.addUSDValue(total);
 

--- a/fees/vultisig/index.ts
+++ b/fees/vultisig/index.ts
@@ -40,10 +40,11 @@ const fetch = async (options: FetchOptions) => {
   const { source, feeLabel, revenueLabel } = chainConfig[options.chain];
   const rows = await getRevenueRows();
 
-  const todaysRows = rows.filter((row) => row.source === source && row.date.slice(0, 10) === options.dateString);
-  if(!todaysRows.length) {
-    throw new Error(`No rows found for ${source} on ${options.dateString}`);
+  const sourceRows = rows.filter((row) => row.source === source);
+  if (!sourceRows.length) {
+    throw new Error(`No rows found for ${source}`);
   }
+  const todaysRows = sourceRows.filter((row) => row.date.slice(0, 10) === options.dateString);
 
   const total = todaysRows.reduce((sum, row) => sum + row.revenue, 0);
 


### PR DESCRIPTION
Fixes #8943

the vultisig analytics service omits days with no swaps instead of emitting zero rows, so the mayachain series has always had gaps (08-09, 08-10, 08-13, 08-16 while the chain was live). the adapter treated a missing (source, date) as an error, and one chain throwing fails the whole protocol run - so every mayachain-empty day also dropped the live thorchain numbers, and with mayachain globally halted since 08-18 the protocol has been fully dark since.

this keeps the fail-closed throw for a source that is entirely absent from the response (attribution renamed or dropped) and returns zero for a merely missing day.

harness on the 08-21 day, both adapters run twice: aggregators thorchain $37.73k + mayachain 0 (the service reports $37,728 for thorchain that day), fees thorchain $164 + mayachain 0. previously both legs threw.