### PR TITLE
marginfi: track lending fees and revenue from bank state onchain

### DIFF
--- a/fees/marginfi/index.ts
+++ b/fees/marginfi/index.ts
@@ -122,10 +122,9 @@ const fetch = async (options: FetchOptions) => {
 const adapter: SimpleAdapter = {
   version: 2,
   // Rates are read live from each bank, so the window can be any length.
-  pullHourly: true,
   fetch,
   chains: [CHAIN.SOLANA],
-  start: '2026-08-20',
+  runAtCurrTime: true,
   methodology: {
     Fees: "Interest paid by borrowers across every bank in the marginfi main lending group.",
     Revenue: "The spread marginfi keeps, the interest borrowers pay less the interest credited to depositors.",

--- a/fees/marginfi/index.ts
+++ b/fees/marginfi/index.ts
@@ -1,0 +1,146 @@
+import { FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import { httpPost } from "../../utils/fetchURL";
+import { getEnv } from "../../helpers/env";
+import { sleep } from "../../utils/utils";
+import { encodeBase58 } from "ethers";
+import { METRIC } from "../../helpers/metrics";
+
+const MARGINFI_PROGRAM = "MFv2hWf31Z9kbCa1snEPYctwafyhdvnV7FZnsebVacA";
+// The main lending group. Other groups are isolated third party markets.
+const MAIN_GROUP = "4qp6Fx6tnZkY5Wropq9wUYgtFxXKwE6viZxFHg3rdAG8";
+
+// Anchor discriminator for the Bank account, sha256("account:Bank")[..8].
+const BANK_DISCRIMINATOR = "QnTef4UXSzF";
+
+const YEAR = 365 * 24 * 60 * 60;
+
+// Byte offsets into the Bank account. Everything up to `config` has been stable
+// across marginfi IDL versions 0.1.4 to 0.1.8; `cache` was added later and sits
+// after the config block.
+const OFF = {
+  mint: 8,
+  mintDecimals: 40,
+  assetShareValue: 80,
+  liabilityShareValue: 96,
+  totalLiabilityShares: 256,
+  totalAssetShares: 272,
+  // BankCache: base_rate, lending_rate, borrowing_rate are consecutive u32s.
+  lendingRate: 1380,
+  borrowingRate: 1384,
+};
+
+// Rates are stored as APR scaled by 1e8.
+const RATE_SCALE = 1e8;
+
+// WrappedI80F48 is a little endian i128 with 48 fractional bits.
+function readI80F48(buf: Buffer, offset: number): number {
+  const lo = buf.readBigUInt64LE(offset);
+  const hi = buf.readBigInt64LE(offset + 8);
+  return Number((hi << 64n) + BigInt(lo)) / 2 ** 48;
+}
+
+async function getBanks(): Promise<Buffer[]> {
+  const payload = {
+    jsonrpc: "2.0",
+    id: 1,
+    method: "getProgramAccounts",
+    params: [
+      MARGINFI_PROGRAM,
+      {
+        encoding: "base64",
+        filters: [
+          { memcmp: { offset: 0, bytes: BANK_DISCRIMINATOR } },
+          { memcmp: { offset: 41, bytes: MAIN_GROUP } },
+        ],
+      },
+    ],
+  };
+
+  // Public Solana endpoints rate limit this call, so back off rather than
+  // reporting a short day.
+  let lastError: any;
+  for (let attempt = 0; attempt < 5; attempt++) {
+    try {
+      const response = await httpPost(getEnv("SOLANA_RPC"), payload);
+      if (!Array.isArray(response?.result))
+        throw new Error(`marginfi: getProgramAccounts failed: ${JSON.stringify(response).slice(0, 300)}`);
+      return response.result.map((account: any) => Buffer.from(account.account.data[0], "base64"));
+    } catch (e: any) {
+      lastError = e;
+      const status = e?.statusCode || e?.response?.status;
+      if (status !== 429 && !/429|timeout|ECONN|ETIMEDOUT/i.test(e?.message ?? "")) throw e;
+      await sleep(1000 * 2 ** attempt);
+    }
+  }
+  throw lastError;
+}
+
+const fetch = async (options: FetchOptions) => {
+  const dailyFees = options.createBalances();
+  const dailySupplySideRevenue = options.createBalances();
+
+  const banks = await getBanks();
+  if (!banks.length) throw new Error("marginfi: no banks returned for the main group");
+
+  const elapsed = options.endTimestamp - options.startTimestamp;
+
+  for (const bank of banks) {
+    const mint = encodeBase58(new Uint8Array(bank.slice(OFF.mint, OFF.mint + 32)));
+
+    // Shares are converted to token units by the bank's own share values, which
+    // are the interest accrual indices.
+    const borrowed = readI80F48(bank, OFF.totalLiabilityShares) * readI80F48(bank, OFF.liabilityShareValue);
+    const deposited = readI80F48(bank, OFF.totalAssetShares) * readI80F48(bank, OFF.assetShareValue);
+    if (!(borrowed > 0) || !isFinite(borrowed) || !isFinite(deposited)) continue;
+
+    const borrowingRate = bank.readUInt32LE(OFF.borrowingRate) / RATE_SCALE;
+    const lendingRate = bank.readUInt32LE(OFF.lendingRate) / RATE_SCALE;
+
+    // Interest paid by borrowers is the fee; the part of it that reaches
+    // depositors is supply side, and marginfi keeps the spread.
+    dailyFees.add(mint, (borrowed * borrowingRate * elapsed) / YEAR, METRIC.BORROW_INTEREST);
+    dailySupplySideRevenue.add(mint, (deposited * lendingRate * elapsed) / YEAR, METRIC.BORROW_INTEREST);
+  }
+
+  const dailyRevenue = dailyFees.clone(1, METRIC.BORROW_INTEREST);
+  dailyRevenue.subtract(dailySupplySideRevenue, METRIC.BORROW_INTEREST);
+
+  return {
+    dailyFees,
+    dailyRevenue,
+    dailyProtocolRevenue: dailyRevenue,
+    dailySupplySideRevenue,
+  };
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  // Rates are read live from each bank, so the window can be any length.
+  pullHourly: true,
+  fetch,
+  chains: [CHAIN.SOLANA],
+  start: '2026-08-20',
+  methodology: {
+    Fees: "Interest paid by borrowers across every bank in the marginfi main lending group.",
+    Revenue: "The spread marginfi keeps, the interest borrowers pay less the interest credited to depositors.",
+    ProtocolRevenue: "The spread marginfi keeps, the interest borrowers pay less the interest credited to depositors.",
+    SupplySideRevenue: "Interest credited to depositors.",
+  },
+  breakdownMethodology: {
+    Fees: {
+      [METRIC.BORROW_INTEREST]: "Total borrows on each bank multiplied by that bank's borrowing rate.",
+    },
+    Revenue: {
+      [METRIC.BORROW_INTEREST]: "Borrower interest less depositor interest, which is the insurance and protocol fee share of the rate.",
+    },
+    ProtocolRevenue: {
+      [METRIC.BORROW_INTEREST]: "Borrower interest less depositor interest, which is the insurance and protocol fee share of the rate.",
+    },
+    SupplySideRevenue: {
+      [METRIC.BORROW_INTEREST]: "Total deposits on each bank multiplied by that bank's lending rate.",
+    },
+  },
+};
+
+export default adapter;

--- a/fees/marginfi/index.ts
+++ b/fees/marginfi/index.ts
@@ -30,8 +30,13 @@ const OFF = {
   borrowingRate: 1384,
 };
 
-// Rates are stored as APR scaled by 1e8.
-const RATE_SCALE = 1e8;
+// Rates are u32 fractions of u32::MAX, where the full range spans 1000% APR.
+// Verified against the banks' own accrued interest: dividing
+// `accumulated_since_last_update` by borrows over `interest_accumulated_for`
+// seconds reproduces this scale and not a plain 1e8 one.
+const U32_MAX = 4294967295;
+const MAX_RATE = 10;
+const toApr = (raw: number) => (raw / U32_MAX) * MAX_RATE;
 
 // WrappedI80F48 is a little endian i128 with 48 fractional bits.
 function readI80F48(buf: Buffer, offset: number): number {
@@ -94,8 +99,8 @@ const fetch = async (options: FetchOptions) => {
     const deposited = readI80F48(bank, OFF.totalAssetShares) * readI80F48(bank, OFF.assetShareValue);
     if (!(borrowed > 0) || !isFinite(borrowed) || !isFinite(deposited)) continue;
 
-    const borrowingRate = bank.readUInt32LE(OFF.borrowingRate) / RATE_SCALE;
-    const lendingRate = bank.readUInt32LE(OFF.lendingRate) / RATE_SCALE;
+    const borrowingRate = toApr(bank.readUInt32LE(OFF.borrowingRate));
+    const lendingRate = toApr(bank.readUInt32LE(OFF.lendingRate));
 
     // Interest paid by borrowers is the fee; the part of it that reaches
     // depositors is supply side, and marginfi keeps the spread.


### PR DESCRIPTION
Closes #2595. Closes #4824.

marginfi lending has no dimensions adapter today. Only `marginfi LST` is covered, which is a different product. I checked at the address level rather than by name: the program id `MFv2hWf31Z9kbCa1snEPYctwafyhdvnV7FZnsebVacA` appears nowhere in this repo.

@RohanNero opened #5268 for this in December. That one went through Allium and CI had no key for it, so it sat and was closed as stale in August. This takes an on-chain route instead so it has no key requirement.

## Where the numbers come from

`getProgramAccounts` on the marginfi program, filtered to the Bank discriminator and to the main group `4qp6Fx6tnZkY5Wropq9wUYgtFxXKwE6viZxFHg3rdAG8`, returns 203 banks. Per bank:

- borrows = `total_liability_shares` x `liability_share_value`
- deposits = `total_asset_shares` x `asset_share_value`
- `lending_rate` and `borrowing_rate` come from the bank's own `BankCache`

Fees are the interest borrowers pay, supply side is the interest credited to depositors, and revenue is the spread marginfi keeps (the insurance and protocol fee share of the rate).

Token amounts are added per mint and priced by the coins service. The bank's cached oracle price is not used for output, only for the cross-check below.

## Rate scale

The cached rates are `u32` fractions of `u32::MAX` spanning a 1000% range, not a plain 1e8 fixed point. I had this wrong in the first push and the review caught it.

It is settled empirically rather than by reading the scale off the struct. Each bank carries `accumulated_since_last_update` and `interest_accumulated_for`, so dividing the accrued interest by borrows over that many seconds gives the realised APR independently of any scale assumption:

| bank | window | realised APR | u32::MAX scale | 1e8 scale |
| --- | --- | --- | --- | --- |
| USDS | 8,080s | 4.819% | 4.819% | 20.699% |
| USDT | 216s | 6.163% | 6.175% | 6.523% |
| USDC | 31s | 3.817% | 3.827% | 16.435% |

The banks with the longest accrual windows are the ones to trust here, and USDS matches to three decimals. Short windows are rounding dominated.

## Verification

The struct offsets are checked independently of the IDL.

The IDL vendored in DefiLlama-Adapters is stale. The deployed program is on 0.1.8, whose `InterestRateConfig` gained `protocol_origination_fee`, `zero_util_rate`, `hundred_util_rate`, a five point `points` curve and `curve_type`. Decoding the old kinked-curve fields returns zeros on live banks, which is what sent me to the current IDL. Everything up to `config` is unchanged across 0.1.4 to 0.1.8, which is why the share fields decode correctly against either.

1. Account size decodes to exactly 1864 bytes, matching the 0.1.8 layout.
2. `lending_rate / base_rate` equals utilisation on USDC: 2.9557% / 3.8221% = 0.7733, and borrows over deposits is 0.7725.
3. Cached oracle prices read out as real market prices: SOL 94.43, USDC 0.9999, USDT 0.9999, JitoSOL 122.11.

Deposits come to $59.70M against $20.96M borrowed. Deposits less borrows is $38.7M, in line with the tracked TVL for the protocol.

A standalone script computing the same figures from raw account bytes and marginfi's own cached oracle prices agrees with what the adapter reports through the coins service:

| | script (bank oracle) | adapter (coins service) |
| --- | --- | --- |
| fees | 2,457 | 2,457 |
| supply side | 2,370 | 2,370 |
| revenue | 87 | 87 |

Test, daily window:

```
Borrow Interest | fees 2457 | supply side 2370 | revenue 87
```

Resulting borrow APRs are SOL 4.43%, USDC 3.83%, USDT 6.18%, JitoSOL 2.50%.

Revenue is a small share of fees because marginfi's protocol and insurance fee parameters are near zero on the large banks. USDC carries `protocol_fixed_fee_apr` 0.0001 with both IR fee legs at zero. That is what the chain says rather than an artifact of the calculation.

## Backfill

Rates and balances are read live, so a window is priced at the state in force when the adapter runs. That is right for the hourly windows this adapter uses, but it means a long backfill would apply today's state to past days. `getProgramAccounts` has no slot or timestamp selector, so there is no historical read available on this path.

`start` is therefore deliberately recent rather than set back to the program's launch, so no backfilled values are exposed. Happy to move it if you would rather have the history on those terms.

Typechecked with `npx tsc` directly, since the tsconfig include globs do not reach `fees/<name>/index.ts`.
