### PR TITLE
derive: Fix volume and revenue double count

### DIFF
--- a/fees/lyra-v2.ts
+++ b/fees/lyra-v2.ts
@@ -24,6 +24,8 @@ type DailyFeesRow = {
 
 const FEES_ENDPOINT = "https://stats-api.derive.xyz/fees";
 
+const toDayString = (timestamp: number) => new Date(timestamp * 1000).toISOString().slice(0, 10);
+
 const fetch = (instrument: string) => async (options: FetchOptions) => {
   const durationSeconds = Math.max(0, options.endTimestamp - options.startTimestamp);
   const endTimeIso = new Date(options.endTimestamp * 1000).toISOString();
@@ -41,11 +43,18 @@ const fetch = (instrument: string) => async (options: FetchOptions) => {
   if (!rows || rows.length === 0)
     throw new Error(`No data returned from Derive fees endpoint for url: ${url}`);
 
+  // The endpoint returns (duration / 86400) + 1 daily rows: it includes the day
+  // that endTime falls on as well as the full requested range. Summing every row
+  // therefore counts an extra day, which doubles the totals on a daily run.
+  // Keep only the days that fall inside [startTimestamp, endTimestamp).
+  const firstDay = toDayString(options.startTimestamp);
+  const lastDay = toDayString(options.endTimestamp - 1);
 
   let grossFeesUsd = 0;
   let grossRevenueUsd = 0;
 
   for (const r of rows) {
+    if (r.day < firstDay || r.day > lastDay) continue;
     grossFeesUsd += (Number(r.makerFees) || 0) + (Number(r.takerFees) || 0);
     grossRevenueUsd += (Number(r.makerFees) || 0) + (Number(r.takerFees) || 0) - (Number(r.makerRebates) || 0) - (Number(r.takerRebates) || 0);
   }

--- a/fees/lyra-v2.ts
+++ b/fees/lyra-v2.ts
@@ -24,8 +24,6 @@ type DailyFeesRow = {
 
 const FEES_ENDPOINT = "https://stats-api.derive.xyz/fees";
 
-const toDayString = (timestamp: number) => new Date(timestamp * 1000).toISOString().slice(0, 10);
-
 const fetch = (instrument: string) => async (options: FetchOptions) => {
   const durationSeconds = Math.max(0, options.endTimestamp - options.startTimestamp);
   const endTimeIso = new Date(options.endTimestamp * 1000).toISOString();
@@ -43,18 +41,11 @@ const fetch = (instrument: string) => async (options: FetchOptions) => {
   if (!rows || rows.length === 0)
     throw new Error(`No data returned from Derive fees endpoint for url: ${url}`);
 
-  // The endpoint returns (duration / 86400) + 1 daily rows: it includes the day
-  // that endTime falls on as well as the full requested range. Summing every row
-  // therefore counts an extra day, which doubles the totals on a daily run.
-  // Keep only the days that fall inside [startTimestamp, endTimestamp).
-  const firstDay = toDayString(options.startTimestamp);
-  const lastDay = toDayString(options.endTimestamp - 1);
-
   let grossFeesUsd = 0;
   let grossRevenueUsd = 0;
 
   for (const r of rows) {
-    if (r.day < firstDay || r.day > lastDay) continue;
+    if (r.day !== options.dateString) continue;
     grossFeesUsd += (Number(r.makerFees) || 0) + (Number(r.takerFees) || 0);
     grossRevenueUsd += (Number(r.makerFees) || 0) + (Number(r.takerFees) || 0) - (Number(r.makerRebates) || 0) - (Number(r.takerRebates) || 0);
   }


### PR DESCRIPTION
It looks like Derive was accidentally double counting a lot of numbers on the defillama dashboard. which I first noted when comparing their in house dashboard (https://app.derive.xyz/stats) to defillama's (https://defillama.com/protocol/derive).

After a quick investigation it looks like there are just some minor range issues that end up leading to each day being counted twice. This quick fix ensures each added day only falls between the desired date timestamps, preventing that double count. 