### PR TITLE
[fix] curve - bribes revenue reads zero since its upstream froze, point at a live feed

### DIFF
--- a/fees/curve.ts
+++ b/fees/curve.ts
@@ -20,7 +20,13 @@ const fetchBribesRevenue = async (options: FetchOptions) => {
     return dailyBribesRevenue;
   }
 
-  const stats = await fetchURL(`https://storage.googleapis.com/crvhub_cloudbuild/data/bounties/stats.json`)
+  // Source swapped 2026-08: the crvhub bounties file stopped updating on
+  // 2026-07-11, so every day since reads as a zero delta. CurveDEX publishes
+  // the same schema, rebuilt 4x/day from Votemarket (on-chain campaigns) and
+  // Votium. Basis note: it counts incentives ADDED rather than claimed - field
+  // names keep crvhub's spelling for compatibility, and the root carries
+  // `basis` / `granularity` / `disclaimer` spelling that out.
+  const stats = await fetchURL(`https://llama.box/curvedex/api/bribes/stats.json`)
   const daily: any[] = stats.claimsLast365Days?.claims ?? []
   const inception: any[] = stats.claimsSinceInception?.claims ?? []
 


### PR DESCRIPTION
Disclosure up front: I maintain the feed this PR points to. It is published by CurveDEX (llama.box/curvedex), an alternative Curve front-end, and rebuilt four times a day by us. I am proposing it because the current source stopped publishing, not because it is ours — judge it on the numbers below and swap it out for anything better.

**The problem.** `fetchBribesRevenue` reads crvhub's bounties file. Its last data point is **2026-07-11 11:34 UTC**, so `cumulative(endOfDay) - cumulative(startOfDay)` has resolved to 0 for every day since — Curve bribes revenue has been silently missing for six weeks. The file still returns HTTP 200, which is why nothing alerted.

**The replacement.** Same field names, same five windows (7 / 30 / 180 / 365 days and since inception), rebuilt four times a day from the first sources: Votemarket on-chain campaigns and Votium rounds, the two platforms carrying current Curve bribe volume.

**Replaying this adapter's own logic** over the trailing 30 days, measured 2026-08-23 12:05 UTC:

| source | 30-day total | days with a non-zero delta |
|---|---|---|
| crvhub (current) | $0 | 0 / 30 |
| this feed | $480,717 | 6 / 30 |

Six non-zero days out of thirty is the real cadence, not a gap: incentives land on the Thursday epoch they fund (Votemarket) and on the biweekly Tuesday round (Votium). The payload says so in `granularity`.

**Two axes, kept separate on purpose.** The series is cumulative exactly like crvhub's, so this adapter's `cumulative(endOfDay) - cumulative(startOfDay)` needs no change. What is being accumulated differs: incentives **added** (committed on Votemarket / Votium) rather than **claimed**. crvhub's own claimed series was lumpy anyway — claims settle biweekly, weeks after the vote they pay for. Field names keep crvhub's spelling so nothing downstream breaks, and the payload states this itself in `basis`, `granularity` and `disclaimer`. History starts 2023-09-19, so days before that fall through to your `claimsSinceInception` branch as they do today.

Docs: llama.box/curvedex/api/bribes/ — happy to adjust the shape or the basis if you would rather have claimed-only.