### PR TITLE
stonkbrokers: Stonklauncher V2/r2 pads + Anvil Robinhood ETH fee rails

### DIFF
--- a/dexs/clutch-anvil/index.ts
+++ b/dexs/clutch-anvil/index.ts
@@ -24,16 +24,17 @@ import { METRIC } from "../../helpers/metrics";
 // burned (deflationary on the token), staker fee streams to the staking
 // vault as rewards. We expose the full fee tranche as protocol revenue.
 //
-// Robinhood Chain (v2 generation, live 2026-08-05) additionally charges a
-// flat oracle-priced ~$2 ETH fee on every swap, emitted per swap as:
+// Robinhood Chain (v2/v3 generation, live 2026-08-05) additionally charges:
 //
 //   event RobinhoodSwapFeePaid(
 //     address indexed payer, uint256 feeWei, address treasury, address booster
 //   )
+//   event LoanEthFeePaid(uint256 indexed loanId, address indexed payer, uint256 amount)
+//   event ActivationEthFeePaid(uint256 indexed tokenId, address indexed payer, uint256 amount)
 //
-// That ETH fee is protocol revenue (split 50% treasury / 50% StockBooster
-// rewards engine); the token-denominated protocolFee/stakerFee tranche keeps
-// the same burn/staker semantics as the other chains.
+// Flat oracle-priced ETH fees (~$2 swap / ~$2 loan create / ~$1 soft-staking
+// activate). Swap fee splits 50% treasury / 50% StockBooster; loan +
+// activation ETH fees go 100% to the treasury.
 
 const chainsConfig: Record<string, { factory: string; fromBlock: number; start: string }> = {
   [CHAIN.ETHEREUM]: {
@@ -70,6 +71,12 @@ const NFT_SOLD_ABI =
 const ROBINHOOD_SWAP_FEE_ABI =
   "event RobinhoodSwapFeePaid(address indexed payer, uint256 feeWei, address treasury, address booster)";
 
+const LOAN_ETH_FEE_ABI =
+  "event LoanEthFeePaid(uint256 indexed loanId, address indexed payer, uint256 amount)";
+
+const ACTIVATION_ETH_FEE_ABI =
+  "event ActivationEthFeePaid(uint256 indexed tokenId, address indexed payer, uint256 amount)";
+
 const fetch = async (options: FetchOptions): Promise<FetchResult> => {
   const { chain, createBalances, getLogs } = options;
   const { factory, fromBlock } = chainsConfig[chain];
@@ -87,9 +94,13 @@ const fetch = async (options: FetchOptions): Promise<FetchResult> => {
   });
 
   const ammByToken = new Map<string, string>();
+  const loanVaults: string[] = [];
+  const stakingVaults: string[] = [];
   markets.forEach((m: any) => {
     if (!m?.ammVault || !m?.token) return;
     ammByToken.set(m.ammVault.toLowerCase(), m.token.toLowerCase());
+    if (m.loanVault) loanVaults.push(String(m.loanVault).toLowerCase());
+    if (m.stakingVault) stakingVaults.push(String(m.stakingVault).toLowerCase());
   });
 
   const ammVaults = Array.from(ammByToken.keys());
@@ -136,9 +147,8 @@ const fetch = async (options: FetchOptions): Promise<FetchResult> => {
     dailySupplySideRevenue.add(token, args.stakerFee, 'Fees to NFT stakers');
   }
 
-  // Robinhood markets also pay a flat oracle-priced ETH fee (~$2) per swap,
-  // routed 50% to the protocol treasury and 50% to the StonkBrokers
-  // StockBooster rewards engine — counted as protocol revenue.
+  // Robinhood markets also pay flat oracle-priced ETH fees on swaps, loans,
+  // and soft-staking activations.
   if (chain === CHAIN.ROBINHOOD) {
     const ethFeeLogs = await getLogs({
       targets: ammVaults,
@@ -153,6 +163,37 @@ const fetch = async (options: FetchOptions): Promise<FetchResult> => {
       dailyRevenue.addGasToken(Number(log.feeWei) * protocolShare, 'Robinhood ETH swap fee to protocol');
       dailySupplySideRevenue.addGasToken(Number(log.feeWei) * (1 - protocolShare), 'Robinhood ETH swap fee to StockBooster rewards engine');
     }
+
+    const uniqueLoans = [...new Set(loanVaults)];
+    const uniqueStaking = [...new Set(stakingVaults)];
+
+    if (uniqueLoans.length > 0) {
+      const loanFeeLogs = await getLogs({
+        targets: uniqueLoans,
+        eventAbi: LOAN_ETH_FEE_ABI,
+        flatten: true,
+      });
+      for (const log of loanFeeLogs) {
+        const amount = BigInt(log.amount);
+        if (amount <= 0n) continue;
+        dailyFees.addGasToken(amount, 'Robinhood ETH loan-creation fee');
+        dailyRevenue.addGasToken(amount, 'Robinhood ETH loan-creation fee');
+      }
+    }
+
+    if (uniqueStaking.length > 0) {
+      const actFeeLogs = await getLogs({
+        targets: uniqueStaking,
+        eventAbi: ACTIVATION_ETH_FEE_ABI,
+        flatten: true,
+      });
+      for (const log of actFeeLogs) {
+        const amount = BigInt(log.amount);
+        if (amount <= 0n) continue;
+        dailyFees.addGasToken(amount, 'Robinhood ETH soft-staking activation fee');
+        dailyRevenue.addGasToken(amount, 'Robinhood ETH soft-staking activation fee');
+      }
+    }
   }
 
   return {
@@ -166,26 +207,32 @@ const fetch = async (options: FetchOptions): Promise<FetchResult> => {
 
 const methodology = {
   Volume: "Sum of buy totalCost and sell grossPayout from NFTBought + NFTSold events across every AMM vault deployed by the Clutch Anvil factory.",
-  Fees: "Sum of protocolFee + stakerFee fields from NFTBought + NFTSold events. Protocol fee is burned; staker fee streams to the NFT staking vault as rewards. On Robinhood Chain every swap additionally pays a flat oracle-priced ~$2 ETH fee (RobinhoodSwapFeePaid).",
-  Revenue: "Robinhood Chain only: the flat ETH swap fee, split 50% to the protocol treasury.",
-  ProtocolRevenue: "Robinhood Chain only: the flat ETH swap fee, split 50% to the protocol treasury.",
-  SupplySideRevenue: "Includes NFTs burned from protocol revenue and staker fees distributed to the NFT stakers plus 50% of the flat oracle-priced ~$2 ETH fee per Robinhood Chain that goes to the StonkBrokers StockBooster rewards engine.",
+  Fees: "Sum of protocolFee + stakerFee fields from NFTBought + NFTSold events. Protocol fee is burned; staker fee streams to the NFT staking vault as rewards. On Robinhood Chain every swap additionally pays a flat oracle-priced ~$2 ETH fee (RobinhoodSwapFeePaid), every loan create pays ~$2 ETH (LoanEthFeePaid), and every soft-staking activate/upgrade pays ~$1 ETH (ActivationEthFeePaid).",
+  Revenue: "Robinhood Chain only: 50% of the flat ETH swap fee to the protocol treasury, plus 100% of loan-creation and soft-staking activation ETH fees to the treasury.",
+  ProtocolRevenue: "Robinhood Chain only: 50% of the flat ETH swap fee to the protocol treasury, plus 100% of loan-creation and soft-staking activation ETH fees to the treasury.",
+  SupplySideRevenue: "Includes NFTs burned from protocol revenue and staker fees distributed to the NFT stakers plus 50% of the flat oracle-priced ~$2 ETH fee per Robinhood Chain swap that goes to the StonkBrokers StockBooster rewards engine.",
 }
 
 const breakdownMethodology = {
   Fees: {
     [METRIC.TRADING_FEES]: "Sum of protocolFee + stakerFee fields from NFTBought + NFTSold events (protocol fee burned, staker fee to the NFT staking vault), plus the flat ~$2 ETH fee per swap on Robinhood Chain.",
+    'Robinhood ETH loan-creation fee': "Flat oracle-priced ~$2 ETH fee on every Anvil loan create (LoanEthFeePaid), 100% to the treasury.",
+    'Robinhood ETH soft-staking activation fee': "Flat oracle-priced ~$1 ETH fee on every soft-staking activate/upgrade (ActivationEthFeePaid), 100% to the treasury.",
   },
   Revenue: {
-    'Robinhood ETH swap fee to protocol': "50% of the flat oracle-priced ~$2 ETH fee per Robinhood Chain goes to the protocol treasury.",
+    'Robinhood ETH swap fee to protocol': "50% of the flat oracle-priced ~$2 ETH fee per Robinhood Chain swap goes to the protocol treasury.",
+    'Robinhood ETH loan-creation fee': "100% of LoanEthFeePaid → treasury.",
+    'Robinhood ETH soft-staking activation fee': "100% of ActivationEthFeePaid → treasury.",
   },
   ProtocolRevenue: {
-    'Robinhood ETH swap fee to protocol': "50% of the flat oracle-priced ~$2 ETH fee per Robinhood Chain goes to the protocol treasury.",
+    'Robinhood ETH swap fee to protocol': "50% of the flat oracle-priced ~$2 ETH fee per Robinhood Chain swap goes to the protocol treasury.",
+    'Robinhood ETH loan-creation fee': "100% of LoanEthFeePaid → treasury.",
+    'Robinhood ETH soft-staking activation fee': "100% of ActivationEthFeePaid → treasury.",
   },
   SupplySideRevenue: {
     'Fees to NFT burn': "Sum of protocolFee fields from NFTBought + NFTSold events. Protocol fee is burned directly rewarding NFT holders (supply side)",
     'Fees to NFT stakers': "Sum of stakerFee fields from NFTBought + NFTSold events. Staker fee streams to the NFT staking vault as rewards.",
-    'Robinhood ETH swap fee to StockBooster rewards engine': "50% of the flat oracle-priced ~$2 ETH fee per Robinhood Chain goes to the StonkBrokers StockBooster rewards engine.",
+    'Robinhood ETH swap fee to StockBooster rewards engine': "50% of the flat oracle-priced ~$2 ETH fee per Robinhood Chain swap goes to the StonkBrokers StockBooster rewards engine.",
   },
 }
 

--- a/fees/stonkbrokers/index.ts
+++ b/fees/stonkbrokers/index.ts
@@ -138,6 +138,7 @@ const SAFE_LAUNCH_PADS: SafePad[] = [
   { addr: "0xd82da1D8ef59959b170b59147283Ab1F2F1Ca86A", quote: QUOTE.SPCX, gen: "r2" },
   { addr: "0x644b19512052A1b6d38d7B16C6c3Fb1d3F7270D2", quote: QUOTE.USO, gen: "r2" },
 ];
+const SAFE_PAD_TARGETS = SAFE_LAUNCH_PADS.map((p) => p.addr);
 // Production tax split, applied by the go-live `setFeeSplit(1650, 1650, 5000)`
 // and snapshotted into every launch: creator / protocol / locked-LP reserve,
 // remainder (1700) punches through the Clock In Card → ~0.5% of tax to the
@@ -354,29 +355,18 @@ const fetchRobinhood = async (options: FetchOptions) => {
     eventAbi: WALL_BOUGHT,
   });
 
-  // Group Safe Launch pads by quote so multi-target getLogs stays same-denomination.
-  // (onlyArgs strips log.address, so mixed-quote targets would mis-attribute.)
-  const padsByQuote = new Map<string, string[]>();
-  for (const p of SAFE_LAUNCH_PADS) {
-    const key = p.quote === null ? "native" : p.quote.toLowerCase();
-    let bucket = padsByQuote.get(key);
-    if (!bucket) {
-      bucket = [];
-      padsByQuote.set(key, bucket);
-    }
-    bucket.push(p.addr);
-  }
-  const quoteKeyOf = (key: string): string | null => (key === "native" ? null : key);
-
-  const safeLogBatches = await Promise.all(
-    [...padsByQuote.entries()].map(async ([key, targets]) => {
-      const [buys, sells] = await Promise.all([
-        options.getLogs({ targets, eventAbi: SAFE_BUY }),
-        options.getLogs({ targets, eventAbi: SAFE_SELL }),
-      ]);
-      return { quote: quoteKeyOf(key), buys, sells };
+  const [safeBuyLogsByPad, safeSellLogsByPad] = await Promise.all([
+    options.getLogs({
+      targets: SAFE_PAD_TARGETS,
+      eventAbi: SAFE_BUY,
+      flatten: false,
     }),
-  );
+    options.getLogs({
+      targets: SAFE_PAD_TARGETS,
+      eventAbi: SAFE_SELL,
+      flatten: false,
+    }),
+  ]);
 
   // Bonding-curve launcher pools (closed factory — residual trading).
   const launched = await options.getLogs({
@@ -574,39 +564,40 @@ const fetchRobinhood = async (options: FetchOptions) => {
   // Fee split per launch snapshot: 16.5% creator / 16.5% protocol / 50%
   // locked-LP (or ICO Bonus on degen) / 17% Clock In Card. Protocol leg =
   // revenue; LP/ICO = supply-side. LpFeeBonded re-settles already-counted tax.
-  for (const batch of safeLogBatches) {
-    for (const log of batch.buys) {
+  for (let i = 0; i < SAFE_LAUNCH_PADS.length; i++) {
+    const quote = SAFE_LAUNCH_PADS[i].quote;
+    for (const log of safeBuyLogsByPad[i] ?? []) {
       const tax = BigInt(log.taxPaid ?? 0);
       const gross = BigInt(log.ethIn ?? log.quoteIn ?? 0);
-      if (gross > 0n) addSafeQuote(dailyVolume, batch.quote, gross);
+      if (gross > 0n) addSafeQuote(dailyVolume, quote, gross);
       if (tax <= 0n) continue;
       const toCreator = (tax * SAFE_CREATOR_BPS) / 10_000n;
       const toProtocol = (tax * SAFE_PROTOCOL_BPS) / 10_000n;
       const toLp = (tax * SAFE_LP_BPS) / 10_000n;
       const toBoosterAndRef = tax - toCreator - toProtocol - toLp;
-      addSafeQuote(dailyFees, batch.quote, tax, LABELS.SAFE_TAX);
-      addSafeQuote(dailyRevenue, batch.quote, toProtocol, LABELS.SAFE_TAX_PROTOCOL);
-      addSafeQuote(dailyProtocolRevenue, batch.quote, toProtocol, LABELS.SAFE_TAX_PROTOCOL);
-      addSafeQuote(dailySupplySideRevenue, batch.quote, toCreator, LABELS.SAFE_TAX_CREATOR);
-      addSafeQuote(dailySupplySideRevenue, batch.quote, toBoosterAndRef, LABELS.SAFE_TAX_BOOSTER);
-      addSafeQuote(dailySupplySideRevenue, batch.quote, toLp, LABELS.SAFE_TAX_LP);
+      addSafeQuote(dailyFees, quote, tax, LABELS.SAFE_TAX);
+      addSafeQuote(dailyRevenue, quote, toProtocol, LABELS.SAFE_TAX_PROTOCOL);
+      addSafeQuote(dailyProtocolRevenue, quote, toProtocol, LABELS.SAFE_TAX_PROTOCOL);
+      addSafeQuote(dailySupplySideRevenue, quote, toCreator, LABELS.SAFE_TAX_CREATOR);
+      addSafeQuote(dailySupplySideRevenue, quote, toBoosterAndRef, LABELS.SAFE_TAX_BOOSTER);
+      addSafeQuote(dailySupplySideRevenue, quote, toLp, LABELS.SAFE_TAX_LP);
     }
-    for (const log of batch.sells) {
+    for (const log of safeSellLogsByPad[i] ?? []) {
       const tax = BigInt(log.taxPaid ?? 0);
       const netOut = BigInt(log.ethOut ?? log.quoteOut ?? 0);
       const gross = netOut + tax;
-      if (gross > 0n) addSafeQuote(dailyVolume, batch.quote, gross);
+      if (gross > 0n) addSafeQuote(dailyVolume, quote, gross);
       if (tax <= 0n) continue;
       const toCreator = (tax * SAFE_CREATOR_BPS) / 10_000n;
       const toProtocol = (tax * SAFE_PROTOCOL_BPS) / 10_000n;
       const toLp = (tax * SAFE_LP_BPS) / 10_000n;
       const toBoosterAndRef = tax - toCreator - toProtocol - toLp;
-      addSafeQuote(dailyFees, batch.quote, tax, LABELS.SAFE_TAX);
-      addSafeQuote(dailyRevenue, batch.quote, toProtocol, LABELS.SAFE_TAX_PROTOCOL);
-      addSafeQuote(dailyProtocolRevenue, batch.quote, toProtocol, LABELS.SAFE_TAX_PROTOCOL);
-      addSafeQuote(dailySupplySideRevenue, batch.quote, toCreator, LABELS.SAFE_TAX_CREATOR);
-      addSafeQuote(dailySupplySideRevenue, batch.quote, toBoosterAndRef, LABELS.SAFE_TAX_BOOSTER);
-      addSafeQuote(dailySupplySideRevenue, batch.quote, toLp, LABELS.SAFE_TAX_LP);
+      addSafeQuote(dailyFees, quote, tax, LABELS.SAFE_TAX);
+      addSafeQuote(dailyRevenue, quote, toProtocol, LABELS.SAFE_TAX_PROTOCOL);
+      addSafeQuote(dailyProtocolRevenue, quote, toProtocol, LABELS.SAFE_TAX_PROTOCOL);
+      addSafeQuote(dailySupplySideRevenue, quote, toCreator, LABELS.SAFE_TAX_CREATOR);
+      addSafeQuote(dailySupplySideRevenue, quote, toBoosterAndRef, LABELS.SAFE_TAX_BOOSTER);
+      addSafeQuote(dailySupplySideRevenue, quote, toLp, LABELS.SAFE_TAX_LP);
     }
   }
 

--- a/fees/stonkbrokers/index.ts
+++ b/fees/stonkbrokers/index.ts
@@ -563,18 +563,37 @@ const fetchRobinhood = async (options: FetchOptions) => {
   }
 
   // ── Safe Launch / Stonklauncher pads (V1 ETH + quoted + V2 + r2) ────────
-  // Window buys AND sells pay the same decaying tax. Volume is gross quote
-  // notional (SafeBuy.ethIn includes the tax; SafeSell.ethOut is net of it —
-  // field names are legacy; quoted lanes carry quote-token amounts).
-  // Split per launch snapshot: 16.5% creator / 16.5% protocol / 50% locked-LP
-  // reserve (or ICO Bonus kickstarter on degen modes) / 17% via the Clock In
-  // Card. Only the protocol leg is revenue; LP/ICO is supply-side.
-  // LpFeeBonded at bond re-settles already-counted tax (never re-added here).
+  // Window buys AND sells pay the same decaying tax.
+  // Volume (mirrors HoodMint ethGross discipline):
+  //   buy  → quoteIn / ethIn (tax-inclusive gross)
+  //   sell → quoteOut/ethOut + taxPaid (gross quote leaving the curve)
+  // Field names differ by generation (ethIn on V1, quoteIn on V2) but are
+  // positional twins — read both. Process buys/sells separately so a decoder
+  // that zeroes missing fields cannot collapse sell volume to 0 via ethIn=0.
+  // Fee split per launch snapshot: 16.5% creator / 16.5% protocol / 50%
+  // locked-LP (or ICO Bonus on degen) / 17% Clock In Card. Protocol leg =
+  // revenue; LP/ICO = supply-side. LpFeeBonded re-settles already-counted tax.
   for (const batch of safeLogBatches) {
-    for (const log of [...batch.buys, ...batch.sells]) {
-      const tax = BigInt(log.taxPaid);
-      const gross =
-        log.ethIn !== undefined ? BigInt(log.ethIn) : BigInt(log.ethOut) + tax;
+    for (const log of batch.buys) {
+      const tax = BigInt(log.taxPaid ?? 0);
+      const gross = BigInt(log.ethIn ?? log.quoteIn ?? 0);
+      if (gross > 0n) addSafeQuote(dailyVolume, batch.quote, gross);
+      if (tax <= 0n) continue;
+      const toCreator = (tax * SAFE_CREATOR_BPS) / 10_000n;
+      const toProtocol = (tax * SAFE_PROTOCOL_BPS) / 10_000n;
+      const toLp = (tax * SAFE_LP_BPS) / 10_000n;
+      const toBoosterAndRef = tax - toCreator - toProtocol - toLp;
+      addSafeQuote(dailyFees, batch.quote, tax, LABELS.SAFE_TAX);
+      addSafeQuote(dailyRevenue, batch.quote, toProtocol, LABELS.SAFE_TAX_PROTOCOL);
+      addSafeQuote(dailyProtocolRevenue, batch.quote, toProtocol, LABELS.SAFE_TAX_PROTOCOL);
+      addSafeQuote(dailySupplySideRevenue, batch.quote, toCreator, LABELS.SAFE_TAX_CREATOR);
+      addSafeQuote(dailySupplySideRevenue, batch.quote, toBoosterAndRef, LABELS.SAFE_TAX_BOOSTER);
+      addSafeQuote(dailySupplySideRevenue, batch.quote, toLp, LABELS.SAFE_TAX_LP);
+    }
+    for (const log of batch.sells) {
+      const tax = BigInt(log.taxPaid ?? 0);
+      const netOut = BigInt(log.ethOut ?? log.quoteOut ?? 0);
+      const gross = netOut + tax;
       if (gross > 0n) addSafeQuote(dailyVolume, batch.quote, gross);
       if (tax <= 0n) continue;
       const toCreator = (tax * SAFE_CREATOR_BPS) / 10_000n;
@@ -714,7 +733,7 @@ const adapter: SimpleAdapter = {
   },
   methodology: {
     Volume:
-      "ETH notional of StonkBrokers NFT AMM fills (ethFeePaid ÷ fee bps) + Broker Box ticket notional (PullOpened.ticketWei) + Certificate Counter stock purchases (spendWei) + Broker Box sell-backs (SoldBack ethOut + SoldBackUsdg usdgOut) + anti-snipe launch-curve buys (WallBought.ethIn) + Safe Launch / Stonklauncher window trades across every pad generation (V1 ETH + V1 quoted + V2 + r2; quote-token denominated on quoted/WETH lanes) + StonkCurvePool Trade.quoteAmount on the bonding-curve launcher.",
+      "Trading notional across every StonkBrokers / Stonklauncher surface: NFT AMM fills (ethFeePaid ÷ fee bps) + Broker Box tickets + Certificate Counter spend + Broker Box sell-backs + anti-snipe WallBought.ethIn + Safe Launch / Stonklauncher window buys AND sells on every pad generation (V1 ETH, V1 quoted, V2, r2 — buy = tax-inclusive quoteIn/ethIn, sell = quoteOut/ethOut + taxPaid, quote-token denominated on quoted/WETH lanes) + StonkCurvePool Trade.quoteAmount on the bonding-curve launcher.",
     Fees:
       "ETH fees on NFT AMM trades + NFT-backed loans; $STONKBROKER broker activation/upgrade fees; Broker Box gachapon 10% edge + 5% sell-back spread + Certificate Counter $2 fee; Safety Deposit Box liquidity-locker protocol cuts (Uniswap V3/V4 + up. DEX v2/CL lockers); the Relay swap-desk 1% app fee (Base USDC forwarded to StockBooster); the anti-snipe fair-launch snipe tax (time-decay tax on launch-curve buys, 90% StockBooster / 10% launch dev); Safe Launch / Stonklauncher snipe tax on window buys and sells across all pad generations (16.5% creator / 16.5% protocol / 50% locked-LP or ICO Bonus / 17% StockBooster + Clock In Card referrers); StonkCurvePool 1% trade fees (33/33/33 waterfall); and StonkVestingLocker 0.01% deposit fees.",
     Revenue:
@@ -727,6 +746,18 @@ const adapter: SimpleAdapter = {
       "70% of NFTFi ETH fees → StockBooster stock dividends; Broker Box creator+booster edge (5% of ticket on official machines) + counter StockBooster half; 90% of locker fees → SafetyDepositClockIn broker claims; Relay swap-desk 1% app fees forwarded to StockBooster; 90% of the anti-snipe launch tax → StockBooster dividends to activated brokers; 10% of the anti-snipe launch tax → launch dev; Safe Launch / Stonklauncher tax legs to the launch creator (16.5%), StockBooster + Clock In Card referrers (17%), and the permanently locked LP reserve / ICO Bonus (50%); bonding-curve creator (33.33%) + StonkBrokers Directed Clock In / pot (33.33%).",
   },
   breakdownMethodology: {
+    Volume: {
+      [LABELS.AMM_FEES]:
+        "NFT AMM trade notional implied from ethFeePaid ÷ fee bps (10% random / 15% specific).",
+      [LABELS.GACHA_FEES]:
+        "Broker Box PullOpened.ticketWei + SoldBack/SoldBackUsdg payouts + Certificate Counter spendWei.",
+      [LABELS.LAUNCH_TAX]:
+        "Anti-snipe one-off launch buys (WallBought.ethIn).",
+      [LABELS.SAFE_TAX]:
+        "Safe Launch / Stonklauncher window buy+sell notional on every pad (V1 ETH + V1 quoted + V2 + r2). Buys = tax-inclusive quote in; sells = net quote out + tax.",
+      [LABELS.CURVE_FEES]:
+        "StonkCurvePool Trade.quoteAmount (bonding-curve launcher residual volume).",
+    },
     Fees: {
       [LABELS.AMM_FEES]: "ETH trade fees on buyRandomNFT / buySpecificNFT / sellNFT.",
       [LABELS.LOAN_FEES]: "Upfront ETH borrow fees on NFT-backed loans.",

--- a/fees/stonkbrokers/index.ts
+++ b/fees/stonkbrokers/index.ts
@@ -35,13 +35,14 @@ import { addTokensReceived } from "../../helpers/token";
  *    StonkBrokers (Directed Clock In + jackpot pot).
  * 9. Token vesting locker (StonkVestingLocker): 0.01% (1 bps) deposit fee.
  *
- * Volume (protocol volume chart):
+ * Volume (protocol volume chart — same dailyVolume feeds the dexs/stonkbrokers listing):
  * - NFT AMM notional (ethFeePaid ÷ fee bps)
  * - Broker Box ticket notional (PullOpened.ticketWei)
  * - Certificate Counter stock purchase (CertificateBought.spendWei)
  * - Broker Box sell-backs (SoldBack ethOut + SoldBackUsdg usdgOut)
  * - Anti-snipe launch buys (WallBought.ethIn)
- * - Safe Launch / Stonklauncher window trades across every pad generation
+ * - Safe Launch / Stonklauncher window buys AND sells on every pad generation
+ *   (buy = tax-inclusive quote in; sell = net quote out + tax)
  * - StonkCurvePool Trade.quoteAmount (bonding-curve launcher)
  */
 

--- a/fees/stonkbrokers/index.ts
+++ b/fees/stonkbrokers/index.ts
@@ -22,13 +22,18 @@ import { addTokensReceived } from "../../helpers/token";
  *    90% StockBooster / 10% launch dev, pushed live per trade. First
  *    production launch: Card Wall ($WALL), 2026-08-14 — raise bonded into
  *    permanently locked LP, so the tax is the only extractable fee leg.
- * 7. Safe Launch pad (StonkSafeLaunchpad, public go-live 2026-08-17): the
- *    permissionless generalization of the same anti-snipe curve as ONE
- *    singleton. Every window buy/sell pays the decaying snipe tax, split
- *    16.5% launch creator / 16.5% protocol accrual / 50% locked-LP reserve
- *    (escrowed per launch, deepens the token's own permanently locked pools
- *    at bond) / 17% StockBooster via the Clock In Card referral contract
- *    (~0.5% of tax pays the referrer, the rest funds Clock In dividends).
+ * 7. Safe Launch / Stonklauncher pads (public go-live 2026-08-17, V2 live
+ *    2026-08-21/22, r2/"v3" pad generation 2026-08-23): every window buy/sell
+ *    pays the decaying snipe tax, split 16.5% launch creator / 16.5% protocol
+ *    accrual / 50% locked-LP reserve (or ICO Bonus kickstarter on degen modes)
+ *    / 17% StockBooster via the Clock In Card (~0.5% of tax to the referrer).
+ *    Covers the V1 ETH pad, all V1 quoted lanes, all V2 lanes, and all r2
+ *    lanes. Quoted-lane amounts are denominated in the lane's quote token
+ *    (STONK / USDG / WETH / tokenized stocks), not native ETH.
+ * 8. Stonk Launcher bonding-curve factory (closed; residual trading): 1%
+ *    trade fee on StonkCurvePool, waterfall 33/33/33 creator / protocol /
+ *    StonkBrokers (Directed Clock In + jackpot pot).
+ * 9. Token vesting locker (StonkVestingLocker): 0.01% (1 bps) deposit fee.
  *
  * Volume (protocol volume chart):
  * - NFT AMM notional (ethFeePaid ÷ fee bps)
@@ -36,7 +41,8 @@ import { addTokensReceived } from "../../helpers/token";
  * - Certificate Counter stock purchase (CertificateBought.spendWei)
  * - Broker Box sell-backs (SoldBack ethOut + SoldBackUsdg usdgOut)
  * - Anti-snipe launch buys (WallBought.ethIn)
- * - Safe Launch window trades (SafeBuy.ethIn + SafeSell gross ethOut+tax)
+ * - Safe Launch / Stonklauncher window trades across every pad generation
+ * - StonkCurvePool Trade.quoteAmount (bonding-curve launcher)
  */
 
 const AMM_VAULT = "0xE302733accF4800146E55fC45B46b4E4fFC032D2";
@@ -82,14 +88,54 @@ const ANTI_SNIPE_LAUNCHES = [
 ];
 const LAUNCH_BOOSTER_BPS = 9000n;
 
-// Safe Launch pad — the permissionless singleton successor of the one-off
-// anti-snipe launches above (launches keyed by id, no per-launch deploys).
-// Public go-live 2026-08-17; append the pad address once deployed. The
-// ClockInCard referral contract (0xcC9232eFD27B392fF9F96a6DCD45F12C9b6A1542)
-// receives its slice THROUGH the pad's tax split, so only pad events are read
-// (reading card events too would double count).
-const SAFE_LAUNCH_PADS: string[] = [
-  "0xEcA5726dae1e53365c37fFc02369d947A91d71f9", // StonkSafeLaunchpad, public open 2026-08-17 22:06 UTC
+// Safe Launch / Stonklauncher pads. quote=null → native ETH (legacy ETH pad);
+// otherwise amounts in SafeBuy/SafeSell are the lane's quote token (field
+// names stay ethIn/ethOut on-chain). ClockInCard punches ride the tax split
+// — do NOT also read card events (double-count).
+const ROBINHOOD_WETH = ADDRESSES.robinhood.WETH;
+const QUOTE = {
+  WETH: ROBINHOOD_WETH,
+  STONK: "0xe934e36A439C94017B64a3FecE66AF12099aBF50",
+  USDG: ADDRESSES.robinhood.USDG,
+  GME: "0x1b0E319c6A659F002271B69dB8A7df2F911c153E",
+  NVDA: "0xd0601CE157Db5bdC3162BbaC2a2C8aF5320D9EEC",
+  AAPL: "0xaF3D76f1834A1d425780943C99Ea8A608f8a93f9",
+  SPCX: "0x4a0E65A3EcceC6dBe60AE065F2e7bb85Fae35eEa",
+  USO: "0xa30FA36Db767ad9eD3f7a60fC79526fB4d56D344",
+} as const;
+
+type SafePad = { addr: string; quote: string | null; gen: "v1-eth" | "v1-quoted" | "v2" | "r2" };
+
+const SAFE_LAUNCH_PADS: SafePad[] = [
+  // V1 ETH pad (native ETH amounts)
+  { addr: "0xEcA5726dae1e53365c37fFc02369d947A91d71f9", quote: null, gen: "v1-eth" },
+  // V1 quoted lanes (StonkSafeLaunchpadQuoted)
+  { addr: "0x77103B69f680BCd3df75F7D7ed3a67030130736a", quote: QUOTE.STONK, gen: "v1-quoted" },
+  { addr: "0xa70A17f5522Bb0c701380Df1b0897b4BE5161564", quote: QUOTE.USDG, gen: "v1-quoted" },
+  { addr: "0xbAb114C56d12d26e901D0f14B4583Cc0a02537b4", quote: QUOTE.GME, gen: "v1-quoted" },
+  { addr: "0x2e512f316751589eB521B7c55Ee9E824ABb80B8E", quote: QUOTE.NVDA, gen: "v1-quoted" },
+  { addr: "0xFDEb6d19354ed2eB905bfB9899086A5270302eF3", quote: QUOTE.AAPL, gen: "v1-quoted" },
+  { addr: "0xcCfe8A38D0C1ba104E362eDCf85DAda11de2Ae62", quote: QUOTE.SPCX, gen: "v1-quoted" },
+  { addr: "0xd31228e555d0759ed627E3249Ab6F7C286b9B8af", quote: QUOTE.USO, gen: "v1-quoted" },
+  { addr: "0xABEa69101B2a19347A34339F24cAD8b9523E9c29", quote: QUOTE.WETH, gen: "v1-quoted" },
+  // V2 lanes (StonkSafeLaunchpadV2, opened 2026-08-21/22)
+  { addr: "0xFCd61B25BbF3AbD6cf0070D6328E351cc30EEC9f", quote: QUOTE.WETH, gen: "v2" },
+  { addr: "0x8f6782c5Aa37804d08a9b7bf3984Ff3245Fd6cD4", quote: QUOTE.STONK, gen: "v2" },
+  { addr: "0xd4F20033586977A2511f4A2DB4aF7C79a340D70a", quote: QUOTE.USDG, gen: "v2" },
+  { addr: "0x4B9Dcd6CCFAeF0f6D23065Dd78E79d5E20ec8cFD", quote: QUOTE.GME, gen: "v2" },
+  { addr: "0xEe96d955d5634813374ecE4C74F2C0ff71B1F9fB", quote: QUOTE.NVDA, gen: "v2" },
+  { addr: "0xB0453A81Cbf963903409FFF18AD92941e1c7a864", quote: QUOTE.AAPL, gen: "v2" },
+  { addr: "0x0c3b4EDED41696eFF0ed70841f132B519d81c947", quote: QUOTE.SPCX, gen: "v2" },
+  { addr: "0xDb3C81C841ff88db6cDFbDDB0eE049D162A6053B", quote: QUOTE.USO, gen: "v2" },
+  // r2 / "v3" pad generation (abort() C-01 patch, BYO path, 2026-08-23)
+  { addr: "0x5BCEefBa6fDf437A7388aDC5c9056c827baca3B3", quote: QUOTE.WETH, gen: "r2" },
+  { addr: "0x406fd0B957bb8cF1dd57C78540D009578e971131", quote: QUOTE.STONK, gen: "r2" },
+  { addr: "0xF0A06Ac7BBb0cc3049B68c257c3ee27CcEA40eeA", quote: QUOTE.USDG, gen: "r2" },
+  { addr: "0x5b21F8a5Ef81586627B4725844aD447325d0992B", quote: QUOTE.GME, gen: "r2" },
+  { addr: "0xDf03953DCA8dB733345278A0c5fd2E81fa2A9B54", quote: QUOTE.NVDA, gen: "r2" },
+  { addr: "0xc522DfaE0D1a140257702392B665183a6De7657f", quote: QUOTE.AAPL, gen: "r2" },
+  { addr: "0xd82da1D8ef59959b170b59147283Ab1F2F1Ca86A", quote: QUOTE.SPCX, gen: "r2" },
+  { addr: "0x644b19512052A1b6d38d7B16C6c3Fb1d3F7270D2", quote: QUOTE.USO, gen: "r2" },
 ];
 // Production tax split, applied by the go-live `setFeeSplit(1650, 1650, 5000)`
 // and snapshotted into every launch: creator / protocol / locked-LP reserve,
@@ -98,6 +144,16 @@ const SAFE_LAUNCH_PADS: string[] = [
 const SAFE_CREATOR_BPS = 1650n;
 const SAFE_PROTOCOL_BPS = 1650n;
 const SAFE_LP_BPS = 5000n;
+
+// Bonding-curve Stonk Launcher factory (closed; residual curve trading).
+const LAUNCHER_FACTORY = "0x80a77001456bc986083678F9a112B1EC2Aa07281";
+const LAUNCHER_FACTORY_START = 34_876_725;
+const LAUNCHER_CREATOR_BPS = 3333n;
+const LAUNCHER_STONK_BPS = 3333n;
+// protocol = 10000 - 3333 - 3333 = 3334
+
+// Token vesting locker — 1 bps deposit fee → SafetyDepositClockInV3.
+const VESTING_LOCKER = "0x2b4aD79DA7BD3bF340bBd2aD2039b149214e9Aa9";
 
 const NFT_SOLD =
   "event NFTSold(address indexed seller, uint256 indexed tokenId, uint256 tokensOut, uint256 ethFeePaid, uint256 boosterShare, uint256 protocolShare)";
@@ -135,6 +191,12 @@ const SAFE_BUY =
   "event SafeBuy(uint256 indexed id, address indexed buyer, uint256 ethIn, uint256 taxPaid, uint256 taxBps, uint256 tokensOut, uint256 mcapUsd8)";
 const SAFE_SELL =
   "event SafeSell(uint256 indexed id, address indexed seller, uint256 tokensIn, uint256 taxPaid, uint256 taxBps, uint256 ethOut, uint256 mcapUsd8)";
+const TOKEN_LAUNCHED =
+  "event TokenLaunched(address indexed creator, address indexed memeToken, address indexed pool, string name, string symbol, string metadataURI, bytes32 imageHash)";
+const CURVE_TRADE =
+  "event Trade(address indexed trader, bool indexed isBuy, uint256 quoteAmount, uint256 tokenAmount, uint256 feeAmount, uint256 newRealQuote, uint256 newSold)";
+const POSITION_LOCKED =
+  "event PositionLocked(address indexed token, uint256 indexed lockTokenId, address indexed owner, address vault, uint64 startUnlock, uint64 finishUnlock, uint256 initialAmount, uint256 feeAmount)";
 
 /** USDG on Robinhood Chain — sell-back rail payout token. */
 const ROBINHOOD_USDG = "0x5fc5360d0400a0fd4f2af552add042d716f1d168";
@@ -163,11 +225,16 @@ const LABELS = {
   LAUNCH_TAX: "Anti-snipe launch tax (time-decay snipe tax on curve buys)",
   LAUNCH_TAX_DIVIDENDS: "Anti-snipe launch tax → StockBooster dividends (90%)",
   LAUNCH_TAX_DEV: "Anti-snipe launch tax → launch dev (10%)",
-  SAFE_TAX: "Safe Launch snipe tax (time-decay tax on window trades)",
+  SAFE_TAX: "Safe Launch / Stonklauncher snipe tax (time-decay tax on window trades)",
   SAFE_TAX_PROTOCOL: "Safe Launch tax → protocol accrual (16.5%)",
   SAFE_TAX_CREATOR: "Safe Launch tax → launch creator (16.5%)",
   SAFE_TAX_BOOSTER: "Safe Launch tax → StockBooster + Clock In Card referrers (17%)",
-  SAFE_TAX_LP: "Safe Launch tax → permanently locked LP reserve (50%)",
+  SAFE_TAX_LP: "Safe Launch tax → permanently locked LP reserve / ICO Bonus (50%)",
+  CURVE_FEES: "Stonk Launcher bonding-curve trade fees (1%)",
+  CURVE_PROTOCOL: "Bonding-curve fees → protocol (33.34%)",
+  CURVE_CREATOR: "Bonding-curve fees → creator (33.33%)",
+  CURVE_STONK: "Bonding-curve fees → StonkBrokers Directed Clock In / pot (33.33%)",
+  VESTING_FEES: "Token vesting locker deposit fees (0.01%)",
 };
 
 const RANDOM_FEE_BPS = 1000n;
@@ -230,6 +297,24 @@ function addProtocolCut(
   else balances.addToken(token, amount, label);
 }
 
+/** Add a Safe Launch quote amount: native ETH when quote is null, else the quote token. */
+function addSafeQuote(
+  balances: ReturnType<FetchOptions["createBalances"]>,
+  quote: string | null,
+  amount: bigint,
+  label?: string,
+) {
+  if (amount <= 0n) return;
+  if (!quote) {
+    if (label) balances.addGasToken(amount, label);
+    else balances.addGasToken(amount);
+  } else if (label) {
+    balances.addToken(quote, amount, label);
+  } else {
+    balances.addToken(quote, amount);
+  }
+}
+
 const LOCKER_META: { addr: string; kind: LockerKind }[] = [
   { addr: LOCKER_V3, kind: "v3" },
   { addr: LOCKER_V4, kind: "v4" },
@@ -268,12 +353,53 @@ const fetchRobinhood = async (options: FetchOptions) => {
     eventAbi: WALL_BOUGHT,
   });
 
-  const [safeBuyLogs, safeSellLogs] = SAFE_LAUNCH_PADS.length
-    ? await Promise.all([
-        options.getLogs({ targets: SAFE_LAUNCH_PADS, eventAbi: SAFE_BUY }),
-        options.getLogs({ targets: SAFE_LAUNCH_PADS, eventAbi: SAFE_SELL }),
-      ])
-    : [[], []];
+  // Group Safe Launch pads by quote so multi-target getLogs stays same-denomination.
+  // (onlyArgs strips log.address, so mixed-quote targets would mis-attribute.)
+  const padsByQuote = new Map<string, string[]>();
+  for (const p of SAFE_LAUNCH_PADS) {
+    const key = p.quote === null ? "native" : p.quote.toLowerCase();
+    let bucket = padsByQuote.get(key);
+    if (!bucket) {
+      bucket = [];
+      padsByQuote.set(key, bucket);
+    }
+    bucket.push(p.addr);
+  }
+  const quoteKeyOf = (key: string): string | null => (key === "native" ? null : key);
+
+  const safeLogBatches = await Promise.all(
+    [...padsByQuote.entries()].map(async ([key, targets]) => {
+      const [buys, sells] = await Promise.all([
+        options.getLogs({ targets, eventAbi: SAFE_BUY }),
+        options.getLogs({ targets, eventAbi: SAFE_SELL }),
+      ]);
+      return { quote: quoteKeyOf(key), buys, sells };
+    }),
+  );
+
+  // Bonding-curve launcher pools (closed factory — residual trading).
+  const launched = await options.getLogs({
+    target: LAUNCHER_FACTORY,
+    fromBlock: LAUNCHER_FACTORY_START,
+    eventAbi: TOKEN_LAUNCHED,
+    cacheInCloud: true,
+  });
+  const curvePools = [
+    ...new Set(
+      launched
+        .map((l: any) => String(l.pool || "").toLowerCase())
+        .filter((a: string) => /^0x[0-9a-f]{40}$/.test(a)),
+    ),
+  ];
+  const curveTradeLogs =
+    curvePools.length > 0
+      ? await options.getLogs({ targets: curvePools, eventAbi: CURVE_TRADE })
+      : [];
+
+  const vestingLockedLogs = await options.getLogs({
+    target: VESTING_LOCKER,
+    eventAbi: POSITION_LOCKED,
+  });
 
   const [edgeLogs, pullLogs, soldBackLogs, soldBackUsdgLogs] = await Promise.all([
     options.getLogs({
@@ -436,31 +562,60 @@ const fetchRobinhood = async (options: FetchOptions) => {
     dailySupplySideRevenue.addGasToken(tax - toBooster, LABELS.LAUNCH_TAX_DEV);
   }
 
-  // ── Safe Launch pad (singleton anti-snipe curve, go-live 2026-08-17) ─────
-  // Window buys AND sells pay the same decaying tax. Volume is gross ETH
-  // notional (SafeBuy.ethIn includes the tax; SafeSell.ethOut is net of it).
+  // ── Safe Launch / Stonklauncher pads (V1 ETH + quoted + V2 + r2) ────────
+  // Window buys AND sells pay the same decaying tax. Volume is gross quote
+  // notional (SafeBuy.ethIn includes the tax; SafeSell.ethOut is net of it —
+  // field names are legacy; quoted lanes carry quote-token amounts).
   // Split per launch snapshot: 16.5% creator / 16.5% protocol / 50% locked-LP
-  // reserve (escrowed, deepens the token's own permanently locked pools at
-  // bond) / 17% via the Clock In Card (≈0.5% of tax to the referrer, rest to
-  // StockBooster Clock In dividends). Only the protocol leg is revenue; the
-  // LP reserve is deliberately supply-side — it becomes permanently locked
-  // liquidity nobody can withdraw, not protocol income. LpFeeBonded at bond
-  // re-settles already-counted tax (never re-added here).
-  for (const log of [...safeBuyLogs, ...safeSellLogs]) {
-    const tax = BigInt(log.taxPaid);
-    const gross = log.ethIn !== undefined ? BigInt(log.ethIn) : BigInt(log.ethOut) + tax;
-    if (gross > 0n) dailyVolume.addGasToken(gross);
-    if (tax <= 0n) continue;
-    const toCreator = (tax * SAFE_CREATOR_BPS) / 10_000n;
-    const toProtocol = (tax * SAFE_PROTOCOL_BPS) / 10_000n;
-    const toLp = (tax * SAFE_LP_BPS) / 10_000n;
-    const toBoosterAndRef = tax - toCreator - toProtocol - toLp;
-    dailyFees.addGasToken(tax, LABELS.SAFE_TAX);
-    dailyRevenue.addGasToken(toProtocol, LABELS.SAFE_TAX_PROTOCOL);
-    dailyProtocolRevenue.addGasToken(toProtocol, LABELS.SAFE_TAX_PROTOCOL);
-    dailySupplySideRevenue.addGasToken(toCreator, LABELS.SAFE_TAX_CREATOR);
-    dailySupplySideRevenue.addGasToken(toBoosterAndRef, LABELS.SAFE_TAX_BOOSTER);
-    dailySupplySideRevenue.addGasToken(toLp, LABELS.SAFE_TAX_LP);
+  // reserve (or ICO Bonus kickstarter on degen modes) / 17% via the Clock In
+  // Card. Only the protocol leg is revenue; LP/ICO is supply-side.
+  // LpFeeBonded at bond re-settles already-counted tax (never re-added here).
+  for (const batch of safeLogBatches) {
+    for (const log of [...batch.buys, ...batch.sells]) {
+      const tax = BigInt(log.taxPaid);
+      const gross =
+        log.ethIn !== undefined ? BigInt(log.ethIn) : BigInt(log.ethOut) + tax;
+      if (gross > 0n) addSafeQuote(dailyVolume, batch.quote, gross);
+      if (tax <= 0n) continue;
+      const toCreator = (tax * SAFE_CREATOR_BPS) / 10_000n;
+      const toProtocol = (tax * SAFE_PROTOCOL_BPS) / 10_000n;
+      const toLp = (tax * SAFE_LP_BPS) / 10_000n;
+      const toBoosterAndRef = tax - toCreator - toProtocol - toLp;
+      addSafeQuote(dailyFees, batch.quote, tax, LABELS.SAFE_TAX);
+      addSafeQuote(dailyRevenue, batch.quote, toProtocol, LABELS.SAFE_TAX_PROTOCOL);
+      addSafeQuote(dailyProtocolRevenue, batch.quote, toProtocol, LABELS.SAFE_TAX_PROTOCOL);
+      addSafeQuote(dailySupplySideRevenue, batch.quote, toCreator, LABELS.SAFE_TAX_CREATOR);
+      addSafeQuote(dailySupplySideRevenue, batch.quote, toBoosterAndRef, LABELS.SAFE_TAX_BOOSTER);
+      addSafeQuote(dailySupplySideRevenue, batch.quote, toLp, LABELS.SAFE_TAX_LP);
+    }
+  }
+
+  // ── Bonding-curve Stonk Launcher (closed factory, residual trades) ───────
+  // Trade.feeAmount is the full 1% fee; waterfall 3333/3334/3333
+  // creator / protocol / StonkBrokers. Quote on production launches is ETH.
+  for (const log of curveTradeLogs) {
+    const quoteAmt = BigInt(log.quoteAmount);
+    const fee = BigInt(log.feeAmount);
+    if (quoteAmt > 0n) dailyVolume.addGasToken(quoteAmt);
+    if (fee <= 0n) continue;
+    const toCreator = (fee * LAUNCHER_CREATOR_BPS) / 10_000n;
+    const toStonk = (fee * LAUNCHER_STONK_BPS) / 10_000n;
+    const toProtocol = fee - toCreator - toStonk;
+    dailyFees.addGasToken(fee, LABELS.CURVE_FEES);
+    dailyRevenue.addGasToken(toProtocol, LABELS.CURVE_PROTOCOL);
+    dailyProtocolRevenue.addGasToken(toProtocol, LABELS.CURVE_PROTOCOL);
+    dailySupplySideRevenue.addGasToken(toCreator, LABELS.CURVE_CREATOR);
+    dailySupplySideRevenue.addGasToken(toStonk, LABELS.CURVE_STONK);
+  }
+
+  // ── Token vesting locker deposit fees (1 bps) ───────────────────────────
+  for (const log of vestingLockedLogs) {
+    const fee = BigInt(log.feeAmount);
+    if (fee <= 0n) continue;
+    const token = String(log.token || ZERO).toLowerCase();
+    addProtocolCut(dailyFees, token, fee, LABELS.VESTING_FEES);
+    addProtocolCut(dailyRevenue, token, fee, LABELS.VESTING_FEES);
+    addProtocolCut(dailyProtocolRevenue, token, fee, LABELS.VESTING_FEES);
   }
 
   // ── Liquidity locker protocol cuts ───────────────────────────────────────
@@ -559,17 +714,17 @@ const adapter: SimpleAdapter = {
   },
   methodology: {
     Volume:
-      "ETH notional of StonkBrokers NFT AMM fills (ethFeePaid ÷ fee bps) + Broker Box ticket notional (PullOpened.ticketWei) + Certificate Counter stock purchases (spendWei) + Broker Box sell-backs (SoldBack ethOut + SoldBackUsdg usdgOut) + anti-snipe launch-curve buys (WallBought.ethIn) + Safe Launch window trades (SafeBuy.ethIn and SafeSell gross ethOut + tax).",
+      "ETH notional of StonkBrokers NFT AMM fills (ethFeePaid ÷ fee bps) + Broker Box ticket notional (PullOpened.ticketWei) + Certificate Counter stock purchases (spendWei) + Broker Box sell-backs (SoldBack ethOut + SoldBackUsdg usdgOut) + anti-snipe launch-curve buys (WallBought.ethIn) + Safe Launch / Stonklauncher window trades across every pad generation (V1 ETH + V1 quoted + V2 + r2; quote-token denominated on quoted/WETH lanes) + StonkCurvePool Trade.quoteAmount on the bonding-curve launcher.",
     Fees:
-      "ETH fees on NFT AMM trades + NFT-backed loans; $STONKBROKER broker activation/upgrade fees; Broker Box gachapon 10% edge + 5% sell-back spread + Certificate Counter $2 fee; Safety Deposit Box liquidity-locker protocol cuts (Uniswap V3/V4 + up. DEX v2/CL lockers); the Relay swap-desk 1% app fee (Base USDC forwarded to StockBooster); the anti-snipe fair-launch snipe tax (time-decay tax on launch-curve buys, 90% StockBooster / 10% launch dev); and the Safe Launch pad snipe tax on window buys and sells (16.5% creator / 16.5% protocol / 50% locked-LP reserve / 17% StockBooster + Clock In Card referrers).",
+      "ETH fees on NFT AMM trades + NFT-backed loans; $STONKBROKER broker activation/upgrade fees; Broker Box gachapon 10% edge + 5% sell-back spread + Certificate Counter $2 fee; Safety Deposit Box liquidity-locker protocol cuts (Uniswap V3/V4 + up. DEX v2/CL lockers); the Relay swap-desk 1% app fee (Base USDC forwarded to StockBooster); the anti-snipe fair-launch snipe tax (time-decay tax on launch-curve buys, 90% StockBooster / 10% launch dev); Safe Launch / Stonklauncher snipe tax on window buys and sells across all pad generations (16.5% creator / 16.5% protocol / 50% locked-LP or ICO Bonus / 17% StockBooster + Clock In Card referrers); StonkCurvePool 1% trade fees (33/33/33 waterfall); and StonkVestingLocker 0.01% deposit fees.",
     Revenue:
-      "Protocol-retained share: 30% of NFTFi ETH fees, protocol share of activation fees, Broker Box protocol accrual (5% of ticket) + sell-back spread + counter treasury half, 10% of locker fees, and the 16.5% protocol leg of the Safe Launch snipe tax.",
+      "Protocol-retained share: 30% of NFTFi ETH fees, protocol share of activation fees, Broker Box protocol accrual (5% of ticket) + sell-back spread + counter treasury half, 10% of locker fees, the 16.5% protocol leg of the Safe Launch / Stonklauncher snipe tax, 33.34% of bonding-curve trade fees, and vesting-locker deposit fees.",
     ProtocolRevenue:
-      "30% of NFTFi ETH fees → ProtocolFeeSink; protocol share of $STONKBROKER activation fees; Broker Box protocol accrual + sell-back bankroll spread + counter treasury half; 10% of locker fees → protocol wallet; 16.5% of the Safe Launch snipe tax → protocol accrual.",
+      "30% of NFTFi ETH fees → ProtocolFeeSink; protocol share of $STONKBROKER activation fees; Broker Box protocol accrual + sell-back bankroll spread + counter treasury half; 10% of locker fees → protocol wallet; 16.5% of the Safe Launch / Stonklauncher snipe tax → protocol accrual; 33.34% of bonding-curve trade fees; vesting-locker deposit fees.",
     HoldersRevenue:
       "Half of the $STONKBROKER activation/upgrade fees burned.",
     SupplySideRevenue:
-      "70% of NFTFi ETH fees → StockBooster stock dividends; Broker Box creator+booster edge (5% of ticket on official machines) + counter StockBooster half; 90% of locker fees → SafetyDepositClockIn broker claims; Relay swap-desk 1% app fees forwarded to StockBooster; 90% of the anti-snipe launch tax → StockBooster dividends to activated brokers; 10% of the anti-snipe launch tax → launch dev; Safe Launch tax legs to the launch creator (16.5%), StockBooster + Clock In Card referrers (17%), and the permanently locked LP reserve (50%).",
+      "70% of NFTFi ETH fees → StockBooster stock dividends; Broker Box creator+booster edge (5% of ticket on official machines) + counter StockBooster half; 90% of locker fees → SafetyDepositClockIn broker claims; Relay swap-desk 1% app fees forwarded to StockBooster; 90% of the anti-snipe launch tax → StockBooster dividends to activated brokers; 10% of the anti-snipe launch tax → launch dev; Safe Launch / Stonklauncher tax legs to the launch creator (16.5%), StockBooster + Clock In Card referrers (17%), and the permanently locked LP reserve / ICO Bonus (50%); bonding-curve creator (33.33%) + StonkBrokers Directed Clock In / pot (33.33%).",
   },
   breakdownMethodology: {
     Fees: {
@@ -587,7 +742,11 @@ const adapter: SimpleAdapter = {
       [LABELS.LAUNCH_TAX]:
         "Time-decay snipe tax on anti-snipe fair-launch curve buys (99% at launch, falling 1%/minute over a 99-minute window; WallBought.taxPaid). Split 90% StockBooster / 10% launch dev, pushed live per trade.",
       [LABELS.SAFE_TAX]:
-        "Time-decay snipe tax on Safe Launch pad window buys AND sells (SafeBuy/SafeSell taxPaid). Split 16.5% launch creator / 16.5% protocol / 50% locked-LP reserve / 17% StockBooster + Clock In Card referrers, snapshotted per launch.",
+        "Time-decay snipe tax on Safe Launch / Stonklauncher window buys AND sells (SafeBuy/SafeSell taxPaid) across the V1 ETH pad, V1 quoted lanes, V2 lanes, and r2 pads. Split 16.5% launch creator / 16.5% protocol / 50% locked-LP reserve or ICO Bonus / 17% StockBooster + Clock In Card referrers, snapshotted per launch. Quoted-lane amounts are in the quote token.",
+      [LABELS.CURVE_FEES]:
+        "1% trade fee on StonkCurvePool (bonding-curve Stonk Launcher factory), waterfall 33.33% creator / 33.34% protocol / 33.33% StonkBrokers.",
+      [LABELS.VESTING_FEES]:
+        "0.01% (1 bps) StonkVestingLocker deposit fee (PositionLocked.feeAmount), routed to SafetyDepositClockInV3.",
     },
     Revenue: {
       [LABELS.AMM_PROTOCOL_TREASURY]: "30% of ETH AMM fees retained by ProtocolFeeSink.",
@@ -598,7 +757,9 @@ const adapter: SimpleAdapter = {
         "5% sell-back spread retained in machine bankroll (treasury-reclaimable on official machines).",
       [LABELS.COUNTER_PROTOCOL]: "Half of the Certificate Counter $2 fee → treasury.",
       [LABELS.LOCKER_PROTOCOL]: "10% of locker protocol fees → protocol wallet.",
-      [LABELS.SAFE_TAX_PROTOCOL]: "16.5% protocol leg of the Safe Launch snipe tax.",
+      [LABELS.SAFE_TAX_PROTOCOL]: "16.5% protocol leg of the Safe Launch / Stonklauncher snipe tax.",
+      [LABELS.CURVE_PROTOCOL]: "33.34% of bonding-curve trade fees → protocol.",
+      [LABELS.VESTING_FEES]: "StonkVestingLocker deposit fees → SafetyDepositClockInV3.",
     },
     ProtocolRevenue: {
       [LABELS.AMM_PROTOCOL_TREASURY]: "30% of ETH AMM fees retained by ProtocolFeeSink.",
@@ -609,7 +770,9 @@ const adapter: SimpleAdapter = {
         "5% sell-back spread retained in machine bankroll (treasury-reclaimable on official machines).",
       [LABELS.COUNTER_PROTOCOL]: "Half of the Certificate Counter $2 fee → treasury.",
       [LABELS.LOCKER_PROTOCOL]: "10% of locker protocol fees → protocol wallet.",
-      [LABELS.SAFE_TAX_PROTOCOL]: "16.5% protocol leg of the Safe Launch snipe tax.",
+      [LABELS.SAFE_TAX_PROTOCOL]: "16.5% protocol leg of the Safe Launch / Stonklauncher snipe tax.",
+      [LABELS.CURVE_PROTOCOL]: "33.34% of bonding-curve trade fees → protocol.",
+      [LABELS.VESTING_FEES]: "StonkVestingLocker deposit fees → SafetyDepositClockInV3.",
     },
     HoldersRevenue: {
       [LABELS.ACTIVATION_BURN]: "Burned share of $STONKBROKER activation fees (deflationary).",
@@ -630,11 +793,14 @@ const adapter: SimpleAdapter = {
         "90% of the anti-snipe launch snipe tax → StockBooster → Clock In stock dividends to activated brokers.",
       [LABELS.LAUNCH_TAX_DEV]:
         "10% of the anti-snipe launch snipe tax → launch dev.",
-      [LABELS.SAFE_TAX_CREATOR]: "16.5% of the Safe Launch snipe tax → launch creator.",
+      [LABELS.SAFE_TAX_CREATOR]: "16.5% of the Safe Launch / Stonklauncher snipe tax → launch creator.",
       [LABELS.SAFE_TAX_BOOSTER]:
-        "17% of the Safe Launch snipe tax punched through the Clock In Card: ~0.5% of tax to the referrer, the rest to StockBooster Clock In dividends.",
+        "17% of the Safe Launch / Stonklauncher snipe tax punched through the Clock In Card: ~0.5% of tax to the referrer, the rest to StockBooster Clock In dividends.",
       [LABELS.SAFE_TAX_LP]:
-        "50% of the Safe Launch snipe tax escrowed as the launch's LP reserve — joins the raise at bond and becomes permanently locked liquidity (excess uncoverable by the token reserve goes to StockBooster).",
+        "50% of the Safe Launch / Stonklauncher snipe tax escrowed as the launch's LP reserve (joins the raise at bond into permanently locked liquidity) or streamed to the ICO Bonus kickstarter on degen modes.",
+      [LABELS.CURVE_CREATOR]: "33.33% of bonding-curve trade fees → launch creator.",
+      [LABELS.CURVE_STONK]:
+        "33.33% of bonding-curve trade fees → StonkBrokers Directed Clock In engine / jackpot pot.",
     },
   },
 };


### PR DESCRIPTION
## Summary
- **fees/stonkbrokers**: track snipe-tax volume/fees on every Stonklauncher pad generation — V1 ETH pad, all 8 V1 quoted lanes, all 8 V2 lanes, and all 8 r2 pads — with quote-token-correct attribution (STONK/USDG/WETH/stocks, not gas-token mislabeling on quoted lanes). Also adds residual bonding-curve `StonkCurvePool` Trade fees (closed factory) and `StonkVestingLocker` 1 bps deposit fees.
- **dexs/clutch-anvil**: on Robinhood Chain, also count `LoanEthFeePaid` (~$2) and soft-staking `ActivationEthFeePaid` (~$1) as protocol revenue (100% treasury), alongside the existing swap ETH fee.

## Test plan
- [ ] `npm test fees stonkbrokers` (or DefiLlama CI) for a recent day with V2 activity
- [ ] Confirm quoted-lane fees price via `robinhood:` coin keys (STONK/WETH/GME already priced)
- [ ] `npm test dexs clutch-anvil` on Robinhood for a day with loan/activation activity
- [ ] Spot-check no double-count of ClockInCard punches (still pad-events only)


Made with [Cursor](https://cursor.com)