### PR TITLE
feat: add Quote to Hyperliquid builder-code adapters

### DIFF
--- a/factory/hyperliquid.ts
+++ b/factory/hyperliquid.ts
@@ -863,6 +863,17 @@ const builderConfigs: Record<string, BuilderConfig> = {
       ProtocolRevenue: "Builder code fees collected by Midas from Hyperliquid trades.",
     },
     breakdownFees: true,
+  },
+  "quote": {
+    addresses: ["0x459b632f49023881cd45d8f0003297ebe16a13d6"],
+    start: "2026-07-30",
+    methodology: {
+      Volume: "Notional volume of Hyperliquid trades (perps, spot and HIP-3 markets) executed through Quote.",
+      Fees: "Builder code fees paid by users on Hyperliquid trades executed through Quote.",
+      Revenue: "Builder code fees collected by Quote from Hyperliquid trades.",
+      ProtocolRevenue: "Builder code fees collected by Quote from Hyperliquid trades.",
+    },
+    breakdownFees: true,
   }
 };
 


### PR DESCRIPTION
New listing: **Quote**, an execution stack on Hyperliquid. Adds one entry to `builderConfigs` in `factory/hyperliquid.ts`, which feeds both the dexs and fees surfaces.

Validated with `npm test dexs quote 2026-08-21`:

```
🦙 Running QUOTE adapter from hyperliquid factory 🦙
HYPERLIQUID 👇
Backfill start time: 30/7/2026
Daily volume: 61.88 k
Daily fees: 13.00
Daily revenue: 13.00
Daily protocol revenue: 13.00

FEES BREAKDOWN 👇
label                         | Daily fees | Daily revenue
Hyperliquid Builder Code Fees | 13         | 13
```

Cross-checked against the raw builder-fills file for that day (`20260820.csv.lz4`): 254 fills, $61,888.15 notional, $13.2489 builder fees — volume matches to the cent. `tsc --project tsconfig.json --noEmit` passes. No `package.json` / `package-lock.json` changes.

`start` is `2026-07-30`, the first day the builder-fills feed returns data for this address (earlier dates 403). Volume covers core perps, spot and HIP-3 markets, so `market` stays at the `"all"` default.

---

##### Name (to be shown on DefiLlama):

Quote

##### Twitter Link:

https://x.com/quotemarkets

##### List of audit links if any:

None. Quote deploys no contracts; orders are signed by the user and settle on Hyperliquid.

##### Website Link:

https://quotemarkets.xyz

##### Logo (High resolution, will be shown with rounded borders):

https://4082675139-files.gitbook.io/~/files/v0/b/gitbook-x-prod.appspot.com/o/spaces%2FhURgR92OECYWj7OaMgcs%2Fuploads%2FlXabXnpX6x1Lstm2KMkQ%2FQuote%20logo.png?alt=media&token=6495078b-2d35-40f1-af0f-73efd0311ab3

##### Current TVL:

N/A. Quote is non-custodial and holds no user funds. This is a volume/fees listing only.

##### Treasury Addresses (if the protocol has treasury)

None.

##### Chain:

Hyperliquid

##### Coingecko ID:

N/A. no token.

##### Coinmarketcap ID:

N/A. no token.

##### Short Description (to be shown on DefiLlama):

Execution stack for Hyperliquid that paces and prices orders against the book to cut spread crossing and slippage.

##### Token address and ticker if any:

None.

##### Category:

Trading App

##### Oracle Provider(s):

None. Quote runs no oracle. Pricing, margining and settlement are all Hyperliquid's.

##### Implementation Details:

N/A

##### Documentation/Proof:

https://quote.gitbook.io/quote-docs

##### forkedFrom:

N/A

##### methodology:

Volume is the notional value (`px` × `sz`) of Hyperliquid fills tagged with Quote's builder code `0x459b632f49023881cd45d8f0003297ebe16a13d6`, covering core perps, spot and HIP-3 markets. Fees are the sum of the per-fill `builder_fee` column from the same feed, all of which is retained by Quote, so Revenue and ProtocolRevenue equal Fees. Both come from `fetchBuilderCodeRevenue` in `helpers/hyperliquid.ts`. Marked `doublecounted` by `exportBuilderAdapter`, since the same volume is already reported by Hyperliquid.

##### Github org/user (Optional):


##### Does this project have a referral program?

Yes: https://quote.gitbook.io/quote-docs/your-account/referrals