### PR TITLE
fix(dtrade): prevent zeros from Dune ingestion lag

### DIFF
--- a/fees/dtrade/index.ts
+++ b/fees/dtrade/index.ts
@@ -11,7 +11,8 @@ const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
   //https://dune.com/queries/5351226
   const query = `
     SELECT
-      COALESCE(SUM(CAST(value AS DOUBLE)) / 1e9, 0) AS fee_ton
+      COALESCE(SUM(CAST(value AS DOUBLE)) / 1e9, 0) AS fee_ton,
+      (SELECT CAST(to_unixtime(MAX(block_time)) AS BIGINT) FROM ton.messages) AS ingested_to
     FROM ton.messages
     WHERE block_time >= from_unixtime(${options.startTimestamp})
       AND block_time < from_unixtime(${options.endTimestamp})
@@ -21,8 +22,13 @@ const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
       AND LOWER(comment) LIKE '%dtrade%'
   `;
 
-  const queryResult = await queryDuneSql(options, query);
-  const feeTon = queryResult[0].fee_ton;
+  const [queryResult] = await queryDuneSql(options, query);
+  const ingestedTo = Number(queryResult?.ingested_to);
+  if (!Number.isFinite(ingestedTo) || ingestedTo < options.endTimestamp) {
+    throw new Error(`DTrade: ton.messages has not indexed through ${new Date(options.endTimestamp * 1000).toISOString()}`);
+  }
+
+  const feeTon = queryResult.fee_ton;
   // Mirrors the xRocket TON Trading Bots dashboard's DTrade methodology:
   // inferred volume = collected fees / 1% effective fee rate.
   const inferredVolumeTon = feeTon / DTRADE_EFFECTIVE_FEE_RATE;

--- a/fees/dtrade/index.ts
+++ b/fees/dtrade/index.ts
@@ -12,7 +12,7 @@ const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
   const query = `
     SELECT
       COALESCE(SUM(CAST(value AS DOUBLE)) / 1e9, 0) AS fee_ton,
-      (SELECT CAST(to_unixtime(MAX(block_time)) AS BIGINT) FROM ton.messages) AS ingested_to
+      (SELECT CAST(to_unixtime(MAX(block_time)) AS BIGINT) FROM ton.messages WHERE block_time >= from_unixtime(${options.startTimestamp})) AS ingested_to
     FROM ton.messages
     WHERE block_time >= from_unixtime(${options.startTimestamp})
       AND block_time < from_unixtime(${options.endTimestamp})
@@ -24,7 +24,8 @@ const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
 
   const [queryResult] = await queryDuneSql(options, query);
   const ingestedTo = Number(queryResult?.ingested_to);
-  if (!Number.isFinite(ingestedTo) || ingestedTo < options.endTimestamp) {
+  const dustSeconds = 10;
+  if (!Number.isFinite(ingestedTo) || ingestedTo < options.endTimestamp - dustSeconds) {
     throw new Error(`DTrade: ton.messages has not indexed through ${new Date(options.endTimestamp * 1000).toISOString()}`);
   }
 


### PR DESCRIPTION
## Problem

The DTrade adapter queries `ton.messages` for daily fee payments and infers volume as 100× the collected fees.

Dune does not always finish indexing the requested window before the adapter runs. When this happens, the query returns no matching rows and `COALESCE(..., 0)` converts the incomplete result into a valid-looking zero.

Because fees and volume are processed independently, they can query Dune at different ingestion stages. This has produced:

- Zero-fee days while the DTrade fee wallet remained active.
- Volume values inconsistent with the adapter’s fixed 1% fee relationship.

## Change

The query now also returns the latest indexed `ton.messages.block_time`.

Before publishing balances, the adapter verifies that this timestamp has reached the requested window end. If indexing is incomplete, it throws an error so the run can be retried instead of storing partial data as zero.

The existing fee query, Dune data source, token pricing, and volume methodology remain unchanged.

## Expected result

- Incomplete Dune windows are no longer published as zero.
- Fees and inferred volume are only returned after Dune has indexed the complete window.
- The relationship `dailyVolume = dailyFees / 0.01` remains consistent across both dimensions.