### PR TITLE
lifi: include Jumper volume (remove integrator exclusion)

### DIFF
--- a/aggregators/lifi/index.ts
+++ b/aggregators/lifi/index.ts
@@ -6,11 +6,11 @@ import { formatAddress } from "../../utils/utils";
 
 
 const LifiSwapEvent = "event LiFiGenericSwapCompleted(bytes32 indexed transactionId, string integrator, string referrer, address receiver, address fromAssetId, address toAssetId, uint256 fromAmount, uint256 toAmount)"
-const integrators = ['jumper.exchange', 'transferto.xyz', 'jumper.exchange.gas', 'lifi-gasless-jumper']
 
 const fetch: any = async (options: FetchOptions): Promise<FetchResultVolume> => {
   if (options.chain === CHAIN.BITCOIN || options.chain === CHAIN.SOLANA) {
-    const dailyVolume = await fetchVolumeFromLIFIAPI(options.chain, options.startTimestamp, options.endTimestamp, integrators, [], 'same-chain');
+    // count all integrators, including Jumper
+    const dailyVolume = await fetchVolumeFromLIFIAPI(options.chain, options.startTimestamp, options.endTimestamp, [], [], 'same-chain');
     return {
       dailyVolume: dailyVolume
     };
@@ -34,9 +34,8 @@ const fetch: any = async (options: FetchOptions): Promise<FetchResultVolume> => 
   }
 
   logs.forEach((log: any) => {
-    if (!integrators.includes(log.integrator)) {
-      dailyVolume.add(log.fromAssetId, log.fromAmount);
-    }
+    // count all integrators, including Jumper
+    dailyVolume.add(log.fromAssetId, log.fromAmount);
   });
 
   return { dailyVolume } as any;

--- a/bridge-aggregators/lifi/index.ts
+++ b/bridge-aggregators/lifi/index.ts
@@ -4,11 +4,11 @@ import { fetchVolumeFromLIFIAPI, LifiDiamonds } from "../../helpers/aggregators/
 
 
 const LifiBridgeEvent = "event LiFiTransferStarted((bytes32 transactionId, string bridge, string integrator, address referrer, address sendingAssetId, address receiver, uint256 minAmount, uint256 destinationChainId, bool hasSourceSwaps, bool hasDestinationCall) bridgeData)"
-const exclude_integrators = ['jumper.exchange', 'transferto.xyz', 'jumper.exchange.gas', 'lifi-gasless-jumper']
 
 const fetch: any = async (options: FetchOptions): Promise<FetchResultVolume> => {
   if (options.chain === CHAIN.BITCOIN || options.chain === CHAIN.SOLANA) {
-    const dailyVolume = await fetchVolumeFromLIFIAPI(options.chain, options.startTimestamp, options.endTimestamp, [], exclude_integrators, 'cross-chain');
+    // count all integrators, including Jumper
+    const dailyVolume = await fetchVolumeFromLIFIAPI(options.chain, options.startTimestamp, options.endTimestamp, [], [], 'cross-chain');
     return {
       dailyBridgeVolume: dailyVolume
     };
@@ -21,10 +21,9 @@ const fetch: any = async (options: FetchOptions): Promise<FetchResultVolume> => 
   });
 
   logs.forEach((e: any) => {
-    const { bridgeData: { integrator, sendingAssetId, minAmount } } = e;
-    if (!exclude_integrators.includes(integrator)) {
-      dailyVolume.add(sendingAssetId, minAmount);
-    }
+    const { bridgeData: { sendingAssetId, minAmount } } = e;
+    // count all integrators, including Jumper
+    dailyVolume.add(sendingAssetId, minAmount);
   });
 
   return { dailyBridgeVolume: dailyVolume } as any;


### PR DESCRIPTION
The LI.FI bridge (`bridge-aggregators/lifi`) and swap (`aggregators/lifi`) adapters currently exclude the Jumper integrators (`jumper.exchange`, `transferto.xyz`, `jumper.exchange.gas`, `lifi-gasless-jumper`). This removes that exclusion on both the on-chain and analytics-API paths, so the LI.FI adapters report **total LI.FI volume including Jumper**.

The separate `jumper.exchange` / `jumper-exchange` adapters are intentionally left unchanged, so Jumper is still reported on its own.