### PR TITLE
fix(gmx-v2-swap): key VolumeInfo by startOfDay instead of latest 1d row

### DIFF
--- a/dexs/gmx-v2-gmx-v2-swap.ts
+++ b/dexs/gmx-v2-gmx-v2-swap.ts
@@ -1,6 +1,7 @@
 import request, { gql } from 'graphql-request';
 import { FetchOptions, SimpleAdapter } from '../adapters/types';
 import { CHAIN } from '../helpers/chains';
+import { getTimestampAtStartOfDayUTC } from '../utils/date';
 
 const endpoints: { [key: string]: string } = {
   [CHAIN.ARBITRUM]: 'https://gmx.squids.live/gmx-synthetics-arbitrum:prod/api/graphql',
@@ -9,41 +10,27 @@ const endpoints: { [key: string]: string } = {
   [CHAIN.MEGAETH]: "https://gmx.squids.live/gmx-synthetics-megaeth:prod/api/graphql",
 };
 
-const historicalDataSwap = gql`
-  query get_volume($period: String!) {
-    volumeInfos(
-      where: { period_eq: $period }
-      limit: 1
-      orderBy: timestamp_DESC
-    ) {
-      swapVolumeUsd
-    }
-  }
-`;
-
-interface IGraphResponse {
-  volumeInfos: Array<{
-    swapVolumeUsd: string;
-  }>;
-}
-
 const fetch = async (options: FetchOptions) => {
-  const dailyData: IGraphResponse = await request(
-    endpoints[options.chain],
-    historicalDataSwap,
-    {
-      period: '1d',
+  const dayTimestamp = getTimestampAtStartOfDayUTC(options.startOfDay)
+  const query = gql`
+    query get_volume($id: String!) {
+      volumeInfos(where: {id_eq: $id, period_eq: "1d"}, limit: 1) {
+        swapVolumeUsd
+      }
     }
-  );
-  const dailyVolume =
-    dailyData.volumeInfos.length > 0
-      ? Number(dailyData.volumeInfos[0].swapVolumeUsd) * 10 ** -30
-      : 0;
+  `
+  const dailyData = await request(endpoints[options.chain], query, {
+    id: '1d:' + String(dayTimestamp),
+  })
+
+  const dailyVolume = dailyData.volumeInfos.length > 0
+    ? Number(dailyData.volumeInfos[0].swapVolumeUsd) * 10 ** -30
+    : 0
 
   return {
     dailyVolume,
-  };
-};
+  }
+}
 
 const methodology = {
   Volume: 'Sum of daily total volume for all markets on a given day.',


### PR DESCRIPTION
## Problem
GMX V2 `VolumeInfo` is one global row per UTC day (`id = 1d:{dayStart}`).

The swap volume adapter queried `period_eq: "1d"` with `orderBy: timestamp_DESC, limit: 1` and never passed the requested day. That always returns the latest bucket (usually today, still filling).

The perp sibling (`dexs/gmx-v2-gmx-v2-trade.ts`) already keys `id_eq: "1d:" + startOfDay`.

Consequences:
- A daily job for yesterday stores today's incomplete swap volume
- Any refill writes the same latest-day number onto every historical day

Checked against the live Arbitrum squid on 24-08-2026.
## Summary
- Fetch `volumeInfos` with `id_eq: "1d:" + startOfDay`, same as the trade adapter
- Keep `swapVolumeUsd` and the 1e30 scale