### PR TITLE
[feat] robin-labs - add fees and volume adapter for Robinhood Chain

### DIFF
--- a/fees/robin-labs/index.ts
+++ b/fees/robin-labs/index.ts
@@ -14,14 +14,26 @@ import { METRIC } from "../../helpers/metrics";
  * `floor` is counted as SUPPLY SIDE, not revenue: it is minted into that coin's permanent buy wall. The
  * protocol has no withdraw path to it, so it is liquidity provided to the coin rather than value retained.
  *
- * `burn` is EXCLUDED from both fees and supply-side revenue. It buys and burns the launched coin's own supply,
+ * `burn` is EXCLUDED from both fees and supply-side revenue. It buys and burns the LAUNCHED coin's own supply,
  * so per fees/GUIDELINES.md ("subtract the buyback directly from fees rather than adding it to
  * dailySupplySideRevenue") it is netted out rather than reported as supplier income. It is not
- * dailyHoldersRevenue either: that is reserved for the protocol's own governance token, and this burns the
+ * dailyHoldersRevenue either: that is reserved for the protocol's own value-accrual token, and this burns the
  * launched memecoin.
  *
- * At graduation the curve pays a fixed reward to the protocol and the creator, capped at a quarter of the
- * raise each, which is booked from the Graduated event.
+ * `platformCut` IS counted, as ordinary protocol revenue. PadRouter.withdrawPlatformCut() pays it to owner()
+ * and nowhere else, so on-chain it is simply ETH retained by the treasury. The team's stated intent is to buy
+ * back the protocol token with it off-chain, but nothing on-chain executes or proves that, so this adapter
+ * does not book it as dailyHoldersRevenue. If those buybacks ever land on-chain and become traceable, this is
+ * the line to move.
+ *
+ * REWARD LEGS: when a RewardVault is wired, PadRouter charges an extra 0.25% on top of the fee above and
+ * routes it to traders (buys) or coin holders (sells), emitting RewardAccrued. That is a real fee the trader
+ * paid and a real cost of funds, so it is added to BOTH dailyFees and dailySupplySideRevenue. The legs are off
+ * whenever rewardVault == address(0), in which case no event is emitted and these terms are simply zero.
+ *
+ * GRADUATION: the curve pays a fixed 0.5 ETH to the protocol and 0.5 ETH to the creator, each capped at a
+ * quarter of the raise. CurvePool emits Graduated.raisedWeth AFTER deducting both, so the cap has to be
+ * re-derived from the gross raise — see the inversion below.
  */
 
 // PadRouter — the swap desk every trade routes through. Deployed 2026-07-24, verified on Blockscout:
@@ -40,6 +52,8 @@ const BOUGHT_EVENT = "event Bought(address indexed token, address indexed buyer,
 const SOLD_EVENT = "event Sold(address indexed token, address indexed seller, uint256 tokensIn, uint256 fee, uint256 ethOut)";
 const FEE_SPLIT_EVENT = "event FeeSplit(address indexed token, uint256 platform, uint256 deferred, uint256 platformCut, uint256 dev, uint256 floor, uint256 burn)";
 const GRADUATED_EVENT = "event Graduated(address indexed bond, uint256 raisedWeth, uint256 leftoverToken)";
+// Emitted only when a RewardVault is wired; the extra 0.25% leg rides on top of the fee in FeeSplit.
+const REWARD_ACCRUED_EVENT = "event RewardAccrued(address indexed token, uint8 side, uint256 amount)";
 const LAUNCHED_EVENT = "event Launched(address indexed token, address indexed curve, address indexed pool, address dev, uint256 devBought)";
 
 // CurvePadFactory v1, verified on Blockscout:
@@ -55,10 +69,11 @@ async function fetch(options: FetchOptions) {
   const dailyProtocolRevenue = options.createBalances();
   const dailySupplySideRevenue = options.createBalances();
 
-  const [bought, sold, feeSplits] = await Promise.all([
+  const [bought, sold, feeSplits, rewardLegs] = await Promise.all([
     options.getLogs({ target: PAD_ROUTER, eventAbi: BOUGHT_EVENT }),
     options.getLogs({ target: PAD_ROUTER, eventAbi: SOLD_EVENT }),
     options.getLogs({ target: PAD_ROUTER, eventAbi: FEE_SPLIT_EVENT }),
+    options.getLogs({ target: PAD_ROUTER, eventAbi: REWARD_ACCRUED_EVENT }),
   ]);
 
   // Volume is the ETH leg of each trade: what a buyer put in, what a seller took out.
@@ -78,6 +93,13 @@ async function fetch(options: FetchOptions) {
     dailySupplySideRevenue.addGasToken(log.floor, "Trading Fees to Coin Floor");
   }
 
+  // The 0.25% reward leg is charged on top of the fee and paid straight out to traders/holders, so it is both
+  // a fee and a cost of funds. Zero rows here whenever the vault is unset.
+  for (const log of rewardLegs) {
+    dailyFees.addGasToken(log.amount, "Trader and Holder Rewards");
+    dailySupplySideRevenue.addGasToken(log.amount, "Trader and Holder Rewards");
+  }
+
   // Graduation: a fixed 0.5 ETH to the protocol and 0.5 ETH to the creator, each capped at raise/4.
   const launches = await options.getLogs({
     targets: PAD_FACTORIES,
@@ -90,7 +112,11 @@ async function fetch(options: FetchOptions) {
   if (curves.length) {
     const graduations = await options.getLogs({ targets: curves, eventAbi: GRADUATED_EVENT, flatten: true });
     for (const log of graduations) {
-      const reward = log.raisedWeth / 4n < GRAD_REWARD_WEI ? log.raisedWeth / 4n : GRAD_REWARD_WEI;
+      // CurvePool does `reward = min(GRAD_REWARD, gross/4)` and then emits `raisedWeth = gross - 2*reward`,
+      // so the emitted number is NET. Invert it: the cap binds exactly when gross >= 4*GRAD_REWARD, which
+      // after the deduction is net >= 2*GRAD_REWARD. Below that the curve paid gross/4 apiece, and since
+      // net = gross - 2*(gross/4) = gross/2, each reward is simply net/2.
+      const reward = log.raisedWeth >= 2n * GRAD_REWARD_WEI ? GRAD_REWARD_WEI : log.raisedWeth / 2n;
       dailyFees.addGasToken(reward * 2n, "Graduation Rewards");
       dailyRevenue.addGasToken(reward, "Graduation Reward to Protocol");
       dailyProtocolRevenue.addGasToken(reward, "Graduation Reward to Protocol");
@@ -103,10 +129,10 @@ async function fetch(options: FetchOptions) {
 
 const methodology = {
   Volume: "The ETH leg of every buy and sell routed through the Robin Labs swap desk.",
-  Fees: "Per-coin trading fees of 1%-4% per side, chosen by each creator at launch and immutable afterwards, plus the fixed rewards paid out when a coin graduates. The share of each fee used to buy back and burn the launched coin is netted out rather than counted.",
-  Revenue: "The protocol's share of trading fees, including the portion deferred until a coin graduates and the buy-back cut on above-default fee tiers, plus the protocol's graduation reward.",
-  ProtocolRevenue: "All protocol revenue is retained by the protocol treasury; the live deployment routes none of it to token holders.",
-  SupplySideRevenue: "The creator's share of trading fees and their graduation reward, plus the share minted into that coin's permanent buy wall.",
+  Fees: "Per-coin trading fees of 1%-4% per side, chosen by each creator at launch and immutable afterwards, the 0.25% trader/holder reward leg when a RewardVault is wired, and the fixed rewards paid out when a coin graduates. The share of each fee used to buy back and burn the launched coin is netted out rather than counted.",
+  Revenue: "The protocol's share of trading fees, including the portion deferred until a coin graduates and the 25% treasury cut of above-default fee tiers, plus the protocol's graduation reward.",
+  ProtocolRevenue: "All protocol revenue is retained by the treasury. The live deployment has no on-chain path routing any of it to token holders, so none is booked as holders revenue.",
+  SupplySideRevenue: "The creator's share of trading fees and their graduation reward, the share minted into that coin's permanent buy wall, and the 0.25% reward leg paid out to traders and coin holders.",
 };
 
 const breakdownMethodology = {
@@ -114,19 +140,21 @@ const breakdownMethodology = {
   Fees: {
     [METRIC.SWAP_FEES]: "The full per-side trading fee paid by the trader.",
     "Graduation Rewards": "0.5 ETH to the protocol and 0.5 ETH to the creator when a coin graduates, each capped at a quarter of the raise.",
+    "Trader and Holder Rewards": "The 0.25% leg charged on top of the fee and paid to traders on buys and coin holders on sells.",
   },
   Revenue: {
-    "Trading Fees to Protocol": "The protocol's share of each trading fee, plus the graduation-deferred portion and the buy-back cut.",
+    "Trading Fees to Protocol": "The protocol's share of each trading fee, plus the graduation-deferred portion and the 25% treasury cut of above-default tiers.",
     "Graduation Reward to Protocol": "The protocol's fixed reward when a coin graduates.",
   },
   ProtocolRevenue: {
-    "Trading Fees to Protocol": "The protocol's share of each trading fee, plus the graduation-deferred portion and the buy-back cut.",
+    "Trading Fees to Protocol": "The protocol's share of each trading fee, plus the graduation-deferred portion and the 25% treasury cut of above-default tiers.",
     "Graduation Reward to Protocol": "The protocol's fixed reward when a coin graduates.",
   },
   SupplySideRevenue: {
     [METRIC.CREATOR_FEES]: "The coin creator's share of each trading fee, claimable from escrow.",
     "Trading Fees to Coin Floor": "Minted into that coin's permanent buy wall; the protocol has no withdraw path to it.",
     "Graduation Reward to Creator": "The creator's fixed reward when their coin graduates.",
+    "Trader and Holder Rewards": "The 0.25% leg paid straight out to traders on buys and coin holders on sells.",
   },
 };
 

--- a/fees/robin-labs/index.ts
+++ b/fees/robin-labs/index.ts
@@ -11,17 +11,30 @@ import { METRIC } from "../../helpers/metrics";
  *
  *   FeeSplit(token, platform, deferred, platformCut, dev, floor, burn)
  *
- * `floor` is counted as SUPPLY SIDE, not revenue: it is minted into that coin's permanent buy wall, which the
- * protocol has no withdraw path to. It is value handed to the coin, not retained by the protocol.
+ * `floor` is counted as SUPPLY SIDE, not revenue: it is minted into that coin's permanent buy wall. The
+ * protocol has no withdraw path to it, so it is liquidity provided to the coin rather than value retained.
+ *
+ * `burn` is EXCLUDED from both fees and supply-side revenue. It buys and burns the launched coin's own supply,
+ * so per fees/GUIDELINES.md ("subtract the buyback directly from fees rather than adding it to
+ * dailySupplySideRevenue") it is netted out rather than reported as supplier income. It is not
+ * dailyHoldersRevenue either: that is reserved for the protocol's own governance token, and this burns the
+ * launched memecoin.
  *
  * At graduation the curve pays a fixed reward to the protocol and the creator, capped at a quarter of the
  * raise each, which is booked from the Graduated event.
  */
 
+// PadRouter — the swap desk every trade routes through. Deployed 2026-07-24, verified on Blockscout:
+// https://robinhoodchain.blockscout.com/address/0xA6BaAB820809C7fC8350311776627298f91F07eC
 const PAD_ROUTER = "0xA6BaAB820809C7fC8350311776627298f91F07eC";
+// Deployment block of the stack; nothing can be emitted before it, so log scans start here.
 const ROUTER_DEPLOYED_BLOCK = 17752965;
 
-const GRAD_REWARD_WEI = 500000000000000000n; // 0.5 ETH to protocol and to creator, each
+// CurvePool.GRAD_REWARD — a fixed 0.5 ETH paid to the protocol and to the creator when a coin graduates,
+// each capped at raise/4 by the same contract. Source: contracts/CurvePool.sol in Robinlabz/Labs.
+const GRAD_REWARD_WEI = 500000000000000000n;
+
+const TRADING_VOLUME = "Trading Volume";
 
 const BOUGHT_EVENT = "event Bought(address indexed token, address indexed buyer, uint256 ethIn, uint256 fee, uint256 tokensOut)";
 const SOLD_EVENT = "event Sold(address indexed token, address indexed seller, uint256 tokensIn, uint256 fee, uint256 ethOut)";
@@ -29,14 +42,17 @@ const FEE_SPLIT_EVENT = "event FeeSplit(address indexed token, uint256 platform,
 const GRADUATED_EVENT = "event Graduated(address indexed bond, uint256 raisedWeth, uint256 leftoverToken)";
 const LAUNCHED_EVENT = "event Launched(address indexed token, address indexed curve, address indexed pool, address dev, uint256 devBought)";
 
-// v1 factory. WHEN v2 DEPLOYS, ADD ITS ADDRESS HERE — graduation rewards from v2 coins are invisible
-// otherwise, and the adapter will silently under-report revenue with no error to notice.
+// CurvePadFactory v1, verified on Blockscout:
+// https://robinhoodchain.blockscout.com/address/0x8aa92d5297fEC45cbC7F16A32F4aed5D3AC58074
+// WHEN v2 DEPLOYS, ADD ITS ADDRESS HERE — graduation rewards from v2 coins are invisible otherwise, and the
+// adapter will silently under-report revenue with no error to notice.
 const PAD_FACTORIES = ["0x8aa92d5297fEC45cbC7F16A32F4aed5D3AC58074"];
 
 async function fetch(options: FetchOptions) {
   const dailyVolume = options.createBalances();
   const dailyFees = options.createBalances();
   const dailyRevenue = options.createBalances();
+  const dailyProtocolRevenue = options.createBalances();
   const dailySupplySideRevenue = options.createBalances();
 
   const [bought, sold, feeSplits] = await Promise.all([
@@ -46,18 +62,20 @@ async function fetch(options: FetchOptions) {
   ]);
 
   // Volume is the ETH leg of each trade: what a buyer put in, what a seller took out.
-  for (const log of bought) dailyVolume.addGasToken(log.ethIn);
-  for (const log of sold) dailyVolume.addGasToken(log.ethOut);
+  for (const log of bought) dailyVolume.addGasToken(log.ethIn, TRADING_VOLUME);
+  for (const log of sold) dailyVolume.addGasToken(log.ethOut, TRADING_VOLUME);
 
   for (const log of feeSplits) {
     const toProtocol = log.platform + log.deferred + log.platformCut;
-    const toSupplySide = log.dev + log.floor + log.burn;
+    // log.burn is deliberately absent: it is a buyback of the launched coin, netted out of fees per the
+    // guidelines rather than reported as supplier income.
+    const toSupplySide = log.dev + log.floor;
 
     dailyFees.addGasToken(toProtocol + toSupplySide, METRIC.SWAP_FEES);
     dailyRevenue.addGasToken(toProtocol, "Trading Fees to Protocol");
+    dailyProtocolRevenue.addGasToken(toProtocol, "Trading Fees to Protocol");
     dailySupplySideRevenue.addGasToken(log.dev, METRIC.CREATOR_FEES);
     dailySupplySideRevenue.addGasToken(log.floor, "Trading Fees to Coin Floor");
-    dailySupplySideRevenue.addGasToken(log.burn, METRIC.TOKEN_BUY_BACK);
   }
 
   // Graduation: a fixed 0.5 ETH to the protocol and 0.5 ETH to the creator, each capped at raise/4.
@@ -75,22 +93,24 @@ async function fetch(options: FetchOptions) {
       const reward = log.raisedWeth / 4n < GRAD_REWARD_WEI ? log.raisedWeth / 4n : GRAD_REWARD_WEI;
       dailyFees.addGasToken(reward * 2n, "Graduation Rewards");
       dailyRevenue.addGasToken(reward, "Graduation Reward to Protocol");
+      dailyProtocolRevenue.addGasToken(reward, "Graduation Reward to Protocol");
       dailySupplySideRevenue.addGasToken(reward, "Graduation Reward to Creator");
     }
   }
 
-  return { dailyVolume, dailyFees, dailyRevenue, dailySupplySideRevenue };
+  return { dailyVolume, dailyFees, dailyRevenue, dailyProtocolRevenue, dailySupplySideRevenue };
 }
 
 const methodology = {
   Volume: "The ETH leg of every buy and sell routed through the Robin Labs swap desk.",
-  Fees: "Per-coin trading fees of 1%-4% per side, chosen by each creator at launch and immutable afterwards, plus the fixed rewards paid out when a coin graduates.",
+  Fees: "Per-coin trading fees of 1%-4% per side, chosen by each creator at launch and immutable afterwards, plus the fixed rewards paid out when a coin graduates. The share of each fee used to buy back and burn the launched coin is netted out rather than counted.",
   Revenue: "The protocol's share of trading fees, including the portion deferred until a coin graduates and the buy-back cut on above-default fee tiers, plus the protocol's graduation reward.",
-  SupplySideRevenue: "The creator's share of trading fees and their graduation reward, the share minted into that coin's permanent buy wall, and the auto-burn share.",
+  ProtocolRevenue: "All protocol revenue is retained by the protocol treasury; the live deployment routes none of it to token holders.",
+  SupplySideRevenue: "The creator's share of trading fees and their graduation reward, plus the share minted into that coin's permanent buy wall.",
 };
 
 const breakdownMethodology = {
-  Volume: { [METRIC.SWAP_FEES]: "ETH in on buys and ETH out on sells, routed through the swap desk." },
+  Volume: { [TRADING_VOLUME]: "ETH in on buys and ETH out on sells, routed through the swap desk." },
   Fees: {
     [METRIC.SWAP_FEES]: "The full per-side trading fee paid by the trader.",
     "Graduation Rewards": "0.5 ETH to the protocol and 0.5 ETH to the creator when a coin graduates, each capped at a quarter of the raise.",
@@ -99,10 +119,13 @@ const breakdownMethodology = {
     "Trading Fees to Protocol": "The protocol's share of each trading fee, plus the graduation-deferred portion and the buy-back cut.",
     "Graduation Reward to Protocol": "The protocol's fixed reward when a coin graduates.",
   },
+  ProtocolRevenue: {
+    "Trading Fees to Protocol": "The protocol's share of each trading fee, plus the graduation-deferred portion and the buy-back cut.",
+    "Graduation Reward to Protocol": "The protocol's fixed reward when a coin graduates.",
+  },
   SupplySideRevenue: {
     [METRIC.CREATOR_FEES]: "The coin creator's share of each trading fee, claimable from escrow.",
     "Trading Fees to Coin Floor": "Minted into that coin's permanent buy wall; the protocol has no withdraw path to it.",
-    [METRIC.TOKEN_BUY_BACK]: "Used to buy and burn that coin's own supply.",
     "Graduation Reward to Creator": "The creator's fixed reward when their coin graduates.",
   },
 };

--- a/fees/robin-labs/index.ts
+++ b/fees/robin-labs/index.ts
@@ -1,0 +1,120 @@
+import { FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import { METRIC } from "../../helpers/metrics";
+
+/*
+ * Robin Labs — a bonding-curve launchpad on Robinhood Chain (robinlab.io).
+ *
+ * Every trade goes through PadRouter, which emits Bought/Sold for the volume and one FeeSplit carrying the
+ * fee ALREADY broken into its destinations. Nothing below re-derives a rate or infers a split — it reports the
+ * exact wei that moved, so a per-coin fee change (creators pick 1%-4% per side) needs no adapter change.
+ *
+ *   FeeSplit(token, platform, deferred, platformCut, dev, floor, burn)
+ *
+ * `floor` is counted as SUPPLY SIDE, not revenue: it is minted into that coin's permanent buy wall, which the
+ * protocol has no withdraw path to. It is value handed to the coin, not retained by the protocol.
+ *
+ * At graduation the curve pays a fixed reward to the protocol and the creator, capped at a quarter of the
+ * raise each, which is booked from the Graduated event.
+ */
+
+const PAD_ROUTER = "0xA6BaAB820809C7fC8350311776627298f91F07eC";
+const ROUTER_DEPLOYED_BLOCK = 17752965;
+
+const GRAD_REWARD_WEI = 500000000000000000n; // 0.5 ETH to protocol and to creator, each
+
+const BOUGHT_EVENT = "event Bought(address indexed token, address indexed buyer, uint256 ethIn, uint256 fee, uint256 tokensOut)";
+const SOLD_EVENT = "event Sold(address indexed token, address indexed seller, uint256 tokensIn, uint256 fee, uint256 ethOut)";
+const FEE_SPLIT_EVENT = "event FeeSplit(address indexed token, uint256 platform, uint256 deferred, uint256 platformCut, uint256 dev, uint256 floor, uint256 burn)";
+const GRADUATED_EVENT = "event Graduated(address indexed bond, uint256 raisedWeth, uint256 leftoverToken)";
+const LAUNCHED_EVENT = "event Launched(address indexed token, address indexed curve, address indexed pool, address dev, uint256 devBought)";
+
+// v1 factory. WHEN v2 DEPLOYS, ADD ITS ADDRESS HERE — graduation rewards from v2 coins are invisible
+// otherwise, and the adapter will silently under-report revenue with no error to notice.
+const PAD_FACTORIES = ["0x8aa92d5297fEC45cbC7F16A32F4aed5D3AC58074"];
+
+async function fetch(options: FetchOptions) {
+  const dailyVolume = options.createBalances();
+  const dailyFees = options.createBalances();
+  const dailyRevenue = options.createBalances();
+  const dailySupplySideRevenue = options.createBalances();
+
+  const [bought, sold, feeSplits] = await Promise.all([
+    options.getLogs({ target: PAD_ROUTER, eventAbi: BOUGHT_EVENT }),
+    options.getLogs({ target: PAD_ROUTER, eventAbi: SOLD_EVENT }),
+    options.getLogs({ target: PAD_ROUTER, eventAbi: FEE_SPLIT_EVENT }),
+  ]);
+
+  // Volume is the ETH leg of each trade: what a buyer put in, what a seller took out.
+  for (const log of bought) dailyVolume.addGasToken(log.ethIn);
+  for (const log of sold) dailyVolume.addGasToken(log.ethOut);
+
+  for (const log of feeSplits) {
+    const toProtocol = log.platform + log.deferred + log.platformCut;
+    const toSupplySide = log.dev + log.floor + log.burn;
+
+    dailyFees.addGasToken(toProtocol + toSupplySide, METRIC.SWAP_FEES);
+    dailyRevenue.addGasToken(toProtocol, "Trading Fees to Protocol");
+    dailySupplySideRevenue.addGasToken(log.dev, METRIC.CREATOR_FEES);
+    dailySupplySideRevenue.addGasToken(log.floor, "Trading Fees to Coin Floor");
+    dailySupplySideRevenue.addGasToken(log.burn, METRIC.TOKEN_BUY_BACK);
+  }
+
+  // Graduation: a fixed 0.5 ETH to the protocol and 0.5 ETH to the creator, each capped at raise/4.
+  const launches = await options.getLogs({
+    targets: PAD_FACTORIES,
+    eventAbi: LAUNCHED_EVENT,
+    fromBlock: ROUTER_DEPLOYED_BLOCK,
+    cacheInCloud: true,
+    flatten: true,
+  });
+  const curves = launches.map((l: any) => l.curve);
+  if (curves.length) {
+    const graduations = await options.getLogs({ targets: curves, eventAbi: GRADUATED_EVENT, flatten: true });
+    for (const log of graduations) {
+      const reward = log.raisedWeth / 4n < GRAD_REWARD_WEI ? log.raisedWeth / 4n : GRAD_REWARD_WEI;
+      dailyFees.addGasToken(reward * 2n, "Graduation Rewards");
+      dailyRevenue.addGasToken(reward, "Graduation Reward to Protocol");
+      dailySupplySideRevenue.addGasToken(reward, "Graduation Reward to Creator");
+    }
+  }
+
+  return { dailyVolume, dailyFees, dailyRevenue, dailySupplySideRevenue };
+}
+
+const methodology = {
+  Volume: "The ETH leg of every buy and sell routed through the Robin Labs swap desk.",
+  Fees: "Per-coin trading fees of 1%-4% per side, chosen by each creator at launch and immutable afterwards, plus the fixed rewards paid out when a coin graduates.",
+  Revenue: "The protocol's share of trading fees, including the portion deferred until a coin graduates and the buy-back cut on above-default fee tiers, plus the protocol's graduation reward.",
+  SupplySideRevenue: "The creator's share of trading fees and their graduation reward, the share minted into that coin's permanent buy wall, and the auto-burn share.",
+};
+
+const breakdownMethodology = {
+  Volume: { [METRIC.SWAP_FEES]: "ETH in on buys and ETH out on sells, routed through the swap desk." },
+  Fees: {
+    [METRIC.SWAP_FEES]: "The full per-side trading fee paid by the trader.",
+    "Graduation Rewards": "0.5 ETH to the protocol and 0.5 ETH to the creator when a coin graduates, each capped at a quarter of the raise.",
+  },
+  Revenue: {
+    "Trading Fees to Protocol": "The protocol's share of each trading fee, plus the graduation-deferred portion and the buy-back cut.",
+    "Graduation Reward to Protocol": "The protocol's fixed reward when a coin graduates.",
+  },
+  SupplySideRevenue: {
+    [METRIC.CREATOR_FEES]: "The coin creator's share of each trading fee, claimable from escrow.",
+    "Trading Fees to Coin Floor": "Minted into that coin's permanent buy wall; the protocol has no withdraw path to it.",
+    [METRIC.TOKEN_BUY_BACK]: "Used to buy and burn that coin's own supply.",
+    "Graduation Reward to Creator": "The creator's fixed reward when their coin graduates.",
+  },
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  pullHourly: true,
+  fetch,
+  chains: [CHAIN.ROBINHOOD],
+  start: "2026-07-24",
+  methodology,
+  breakdownMethodology,
+};
+
+export default adapter;


### PR DESCRIPTION
Adds a fees/volume adapter for Robin Labs, a bonding-curve launchpad on Robinhood Chain.

Every trade routes through `PadRouter`, which emits a `FeeSplit` event carrying the fee already broken into its destinations, so the adapter reports the exact amounts that moved rather than re-deriving a rate. Creators pick a 1–4% per-side fee at launch, immutable afterwards, which is why no rate is hardcoded.

The floor share is counted as SupplySideRevenue rather than Revenue deliberately: it is minted into that coin's permanent buy wall, which the protocol has no withdraw path to, so it is value handed to the coin and not retained by the protocol.

Test: `npm test fees robin-labs`

##### Name (to be shown on DefiLlama):
Robin Labs

##### Twitter Link:
https://x.com/ROBINLABZZ

##### List of audit links if any:
None

##### Website Link:
https://www.robinlab.io

##### Logo (High resolution, will be shown with rounded borders):
https://www.robinlab.io/assets/logo-mark.png

##### Current TVL:
N/A — this PR adds a fees/volume adapter only, no TVL adapter.

##### Treasury Addresses (if the protocol has treasury)
N/A

##### Chain:
Robinhood Chain

##### Coingecko ID:
(not listed)

##### Coinmarketcap ID:
(not listed)

##### Short Description (to be shown on DefiLlama):
Bonding-curve launchpad on Robinhood Chain. Coins launch into a real Uniswap v3 pair, and on graduation liquidity is locked permanently alongside a protocol-owned buy wall that cannot be withdrawn.

##### Token address and ticker if any:
ROBIN — 0x6696fe29288b586017e6f264c0091dba6c5ebeaf

##### Category:
Launchpad

##### Oracle Provider(s):
None — the protocol uses no external price oracle.

##### Implementation Details:
N/A, no oracle is used. Pricing comes from the Uniswap v3 pool itself.

##### Documentation/Proof:
https://www.robinlab.io/docs.html

##### forkedFrom:
None

##### methodology (what is being counted):
Fees: the full per-side trading fee paid by traders (1–4%, set per coin by its creator at launch), plus the fixed rewards paid out when a coin graduates.
Revenue: the protocol's share of each trading fee, including the portion deferred until graduation and the buy-back cut on above-default fee tiers, plus the protocol's graduation reward.
SupplySideRevenue: the creator's share and their graduation reward, and the share minted into that coin's permanent buy wall. The auto-burn share is netted out of fees rather than counted as supply-side revenue, per fees/GUIDELINES.md.

##### Github org/user:
https://github.com/Robinlabz/Labs

##### Does this project have a referral program?
No
