### PR TITLE
slingshot: mark dead, no volume since 2025-04-17 and the frozen canto leg now throws

### DIFF
--- a/dexs/slingshot/index.ts
+++ b/dexs/slingshot/index.ts
@@ -59,5 +59,6 @@ const adapters: SimpleAdapter = {
   fetch,
   chains: Object.keys(contract_address),
   start: '2023-05-09',
+  deadFrom: '2025-04-18',
 }
 export default adapters;


### PR DESCRIPTION
Fixes #8978

last nonzero day was 2025-04-17 ($4), 480 zero rows since, and slingshot.finance redirects to slingshot.app, the tracked routers on all six chains are idle. the canto leg now throws on the frozen rpc so even the zeros stopped publishing on 08-10. deadFrom 2025-04-18 at the adapter root, same as tapp-exchange. harness reports the adapter dead and skips instead of throwing.