### PR TITLE
Add CL8Y DEX volume and fees (Terra Classic)

### DIFF
--- a/dexs/cl8y-dex/index.ts
+++ b/dexs/cl8y-dex/index.ts
@@ -25,7 +25,8 @@ const adapter: SimpleAdapter = {
   version: 1,
   fetch,
   chains: [CHAIN.TERRA],
-  start: "2026-05-01",
+  // First UTC day GET /api/v1/defillama/daily returns 200. Earlier days 404.
+  start: "2026-08-17",
   methodology: {
     Volume:
       "UTC calendar-day SUM(swap_events.volume_usd) once per taker swap. Excludes columbus-5 gem pairs, wrap/unwrap, UST1 window, and limit_order_fills.",

--- a/dexs/cl8y-dex/index.ts
+++ b/dexs/cl8y-dex/index.ts
@@ -1,0 +1,35 @@
+import { FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import { httpGet } from "../../utils/fetchURL";
+
+// UTC-day rollup. Version 1: indexer cannot split a calendar day into hourly ranges.
+const INDEXER_DAILY = "https://indexer.dex.cl8y.com/api/v1/defillama/daily";
+
+function asNumberOrNull(value: unknown): number | null {
+  if (value == null) return null;
+  if (value === "0") return 0;
+  const n = Number(value);
+  return Number.isFinite(n) ? n : null;
+}
+
+const fetch = async (options: FetchOptions) => {
+  const data = await httpGet(`${INDEXER_DAILY}?timestamp=${options.startOfDay}`);
+  const dailyVolume = asNumberOrNull(data?.volume_usd);
+  if (dailyVolume == null) {
+    throw new Error(`cl8y-dex dailyVolume unpriced or missing for ${options.startOfDay}`);
+  }
+  return { dailyVolume };
+};
+
+const adapter: SimpleAdapter = {
+  version: 1,
+  fetch,
+  chains: [CHAIN.TERRA],
+  start: "2026-05-01",
+  methodology: {
+    Volume:
+      "UTC calendar-day SUM(swap_events.volume_usd) once per taker swap. Excludes columbus-5 gem pairs, wrap/unwrap, UST1 window, and limit_order_fills.",
+  },
+};
+
+export default adapter;

--- a/fees/cl8y-dex/index.ts
+++ b/fees/cl8y-dex/index.ts
@@ -69,7 +69,8 @@ const adapter: SimpleAdapter = {
   version: 1,
   fetch,
   chains: [CHAIN.TERRA],
-  start: "2026-05-01",
+  // First UTC day GET /api/v1/defillama/daily returns 200. Earlier days 404.
+  start: "2026-08-17",
   methodology,
   breakdownMethodology,
 };

--- a/fees/cl8y-dex/index.ts
+++ b/fees/cl8y-dex/index.ts
@@ -1,0 +1,77 @@
+import { FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import { METRIC } from "../../helpers/metrics";
+import { httpGet } from "../../utils/fetchURL";
+
+// UTC-day rollup. Version 1: indexer cannot split a calendar day into hourly ranges.
+const INDEXER_DAILY = "https://indexer.dex.cl8y.com/api/v1/defillama/daily";
+
+function asNumberOrNull(value: unknown): number | null {
+  if (value == null) return null;
+  if (value === "0") return 0;
+  const n = Number(value);
+  return Number.isFinite(n) ? n : null;
+}
+
+function usdOrZero(value: unknown): number {
+  return asNumberOrNull(value) ?? 0;
+}
+
+const fetch = async (options: FetchOptions) => {
+  const data = await httpGet(`${INDEXER_DAILY}?timestamp=${options.startOfDay}`);
+  const dailyFeesUsd = asNumberOrNull(data?.daily_fees_usd);
+  if (dailyFeesUsd == null) {
+    throw new Error(`cl8y-dex dailyFees unpriced or missing for ${options.startOfDay}`);
+  }
+
+  const fees = data?.fees || {};
+  const swapFees =
+    usdOrZero(fees.swap_amm) + usdOrZero(fees.book_take) + usdOrZero(fees.limit_place);
+  const wrapFees = usdOrZero(fees.wrap) + usdOrZero(fees.unwrap);
+  const mintRedeemFees = usdOrZero(fees.ust1_mint) + usdOrZero(fees.ust1_redeem);
+
+  const dailyFees = options.createBalances();
+  const dailyRevenue = options.createBalances();
+  if (swapFees) dailyFees.addUSDValue(swapFees, METRIC.SWAP_FEES);
+  if (wrapFees) dailyFees.addUSDValue(wrapFees, METRIC.DEPOSIT_WITHDRAW_FEES);
+  if (mintRedeemFees) dailyFees.addUSDValue(mintRedeemFees, METRIC.MINT_REDEEM_FEES);
+  const labeled = swapFees + wrapFees + mintRedeemFees;
+  if (dailyFeesUsd > labeled) dailyFees.addUSDValue(dailyFeesUsd - labeled);
+
+  dailyRevenue.addUSDValue(asNumberOrNull(data?.daily_revenue_usd) ?? dailyFeesUsd);
+
+  return {
+    dailyFees,
+    dailyRevenue,
+    dailyProtocolRevenue: dailyRevenue,
+    dailySupplySideRevenue: 0,
+  };
+};
+
+const methodology = {
+  Fees:
+    "Treasury-bound pair commission (swap + book take + limit place) plus labeled wrap/window fees. spread_amount and community-tax extra-debit are not fees.",
+  Revenue: "Same as Fees — protocol keeps pair treasury commission.",
+  ProtocolRevenue: "Same as Fees.",
+  SupplySideRevenue: "0 — LPs earn inventory/spread, not a transferred commission.",
+};
+
+const breakdownMethodology = {
+  Fees: {
+    [METRIC.SWAP_FEES]:
+      "Pair pool commission_amount, limit_order_fills.commission_amount, and maker placement fee to FEE_CONFIG.treasury",
+    [METRIC.DEPOSIT_WITHDRAW_FEES]: "Pinned wrap-mapper wrap/unwrap treasury fee",
+    [METRIC.MINT_REDEEM_FEES]: "Pinned ust1-window mint/redeem fee",
+  },
+};
+
+const adapter: SimpleAdapter = {
+  version: 1,
+  fetch,
+  chains: [CHAIN.TERRA],
+  start: "2026-05-01",
+  methodology,
+  breakdownMethodology,
+};
+
+export default adapter;

--- a/fees/cl8y-dex/index.ts
+++ b/fees/cl8y-dex/index.ts
@@ -32,18 +32,30 @@ const fetch = async (options: FetchOptions) => {
 
   const dailyFees = options.createBalances();
   const dailyRevenue = options.createBalances();
-  if (swapFees) dailyFees.addUSDValue(swapFees, METRIC.SWAP_FEES);
-  if (wrapFees) dailyFees.addUSDValue(wrapFees, METRIC.DEPOSIT_WITHDRAW_FEES);
-  if (mintRedeemFees) dailyFees.addUSDValue(mintRedeemFees, METRIC.MINT_REDEEM_FEES);
+  const dailyProtocolRevenue = options.createBalances();
+  const addBreakdown = (balances: ReturnType<FetchOptions["createBalances"]>) => {
+    if (swapFees) balances.addUSDValue(swapFees, METRIC.SWAP_FEES);
+    if (wrapFees) balances.addUSDValue(wrapFees, METRIC.DEPOSIT_WITHDRAW_FEES);
+    if (mintRedeemFees) balances.addUSDValue(mintRedeemFees, METRIC.MINT_REDEEM_FEES);
+  };
+
+  addBreakdown(dailyFees);
   const labeled = swapFees + wrapFees + mintRedeemFees;
   if (dailyFeesUsd > labeled) dailyFees.addUSDValue(dailyFeesUsd - labeled);
 
-  dailyRevenue.addUSDValue(asNumberOrNull(data?.daily_revenue_usd) ?? dailyFeesUsd);
+  const dailyRevenueUsd = asNumberOrNull(data?.daily_revenue_usd) ?? dailyFeesUsd;
+  addBreakdown(dailyRevenue);
+  addBreakdown(dailyProtocolRevenue);
+  if (dailyRevenueUsd > labeled) {
+    const remainder = dailyRevenueUsd - labeled;
+    dailyRevenue.addUSDValue(remainder);
+    dailyProtocolRevenue.addUSDValue(remainder);
+  }
 
   return {
     dailyFees,
     dailyRevenue,
-    dailyProtocolRevenue: dailyRevenue,
+    dailyProtocolRevenue,
     dailySupplySideRevenue: 0,
   };
 };
@@ -51,8 +63,10 @@ const fetch = async (options: FetchOptions) => {
 const methodology = {
   Fees:
     "Treasury-bound pair commission (swap + book take + limit place) plus labeled wrap/window fees. spread_amount and community-tax extra-debit are not fees.",
-  Revenue: "Same as Fees — protocol keeps pair treasury commission.",
-  ProtocolRevenue: "Same as Fees.",
+  Revenue:
+    "Treasury commission credited to the protocol on swaps, book takes, limit placements, wrap/unwrap, and UST1 mint/redeem. Excludes LP spread and community-tax debits.",
+  ProtocolRevenue:
+    "Net protocol income from treasury-bound commissions on trading and ancillary services (wrap/unwrap, UST1 window). No share is routed to LPs or token holders.",
   SupplySideRevenue: "0 — LPs earn inventory/spread, not a transferred commission.",
 };
 
@@ -62,6 +76,20 @@ const breakdownMethodology = {
       "Pair pool commission_amount, limit_order_fills.commission_amount, and maker placement fee to FEE_CONFIG.treasury",
     [METRIC.DEPOSIT_WITHDRAW_FEES]: "Pinned wrap-mapper wrap/unwrap treasury fee",
     [METRIC.MINT_REDEEM_FEES]: "Pinned ust1-window mint/redeem fee",
+  },
+  Revenue: {
+    [METRIC.SWAP_FEES]:
+      "Treasury commission retained by the protocol on AMM swaps, book takes, and limit-order placements",
+    [METRIC.DEPOSIT_WITHDRAW_FEES]: "Protocol revenue from wrap-mapper treasury fees on wrap and unwrap",
+    [METRIC.MINT_REDEEM_FEES]: "Protocol revenue from UST1 window mint and redeem treasury fees",
+  },
+  ProtocolRevenue: {
+    [METRIC.SWAP_FEES]:
+      "Trading commission routed to FEE_CONFIG.treasury — the protocol's share of swap, book-take, and limit-placement activity",
+    [METRIC.DEPOSIT_WITHDRAW_FEES]:
+      "Wrap-mapper treasury fees on wrap and unwrap, fully retained by the protocol",
+    [METRIC.MINT_REDEEM_FEES]:
+      "UST1 window mint and redeem treasury fees, fully retained by the protocol",
   },
 };
 


### PR DESCRIPTION
**NOTE**

Please keep "Allow edits by maintainers" enabled.

---

##### Name (to be shown on DefiLlama):
CL8Y DEX

##### Twitter Link:


##### List of audit links if any:


##### Website Link:
https://dex.cl8y.com

##### Logo (High resolution, will be shown with rounded borders):
https://dex.cl8y.com/logo.png

##### Current TVL:
See companion TVL PR on DefiLlama-Adapters (`projects/cl8y-dex`). Llama-priced pool TVL ~$13.3k.

##### Treasury Addresses (if the protocol has treasury)
terra16j5u6ey7a84g40sr3gd94nzg5w5fm45046k9s2347qhfpwm5fr6sem3lr2

##### Chain:
Terra Classic (`terra`)

##### Coingecko ID:


##### Coinmarketcap ID:


##### Short Description (to be shown on DefiLlama):
Terra Classic hybrid AMM + on-chain limit book at dex.cl8y.com

##### Token address and ticker if any:
terra16wtml2q66g82fdkx66tap0qjkahqwp4lwq3ngtygacg5q0kzycgqvhpax3 (CL8Y)

##### Category:
Dexs

##### Oracle Provider(s):
None for these adapters. Volume/fees are UTC-day USD from the pinned indexer rollup.

##### Implementation Details:
`GET https://indexer.dex.cl8y.com/api/v1/defillama/daily?timestamp=<unix_00:00_utc>`

##### Documentation/Proof:
https://gitlab.com/PlasticDigits/cl8y-dex-terraclassic/-/blob/main/docs/DEFILLAMA.md

##### forkedFrom:
Terraswap-style factory/pair query interface. Contracts are original CL8Y.

##### methodology:
**Volume:** UTC calendar-day `SUM(swap_events.volume_usd)` once per taker swap. Excludes columbus-5 gem pairs, wrap/unwrap, UST1 window, and `limit_order_fills`.

**Fees / Revenue / ProtocolRevenue:** Treasury-bound pair commission (`swap_amm` + `book_take` + `limit_place`) plus labeled wrap/window fees. `spread_amount` and community-tax extra-debit are not fees.

**SupplySideRevenue:** `0` — LPs earn inventory/spread, not a transferred commission.

##### Github org/user:
https://gitlab.com/PlasticDigits/cl8y-dex-terraclassic

##### Does this project have a referral program?
No

---

Version 1 because the indexer only returns one UTC calendar day (cannot split hourly).

**Hold for indexer deploy:** `GET /api/v1/defillama/daily` is implemented in GitLab MR https://gitlab.com/PlasticDigits/cl8y-dex-terraclassic/-/merge_requests/425 and is not on Coolify yet (live host currently 404s). Please keep this draft until that route is live; we will mark ready and comment with `pnpm test dexs cl8y-dex` / `pnpm test fees cl8y-dex` output.

TVL adapter is a separate PR on DefiLlama-Adapters (`projects/cl8y-dex`).

Made with [Cursor](https://cursor.com)