### PR TITLE
add ride markets adapters (aggregator volume + fees)

### DIFF
--- a/aggregators/ride-markets/index.ts
+++ b/aggregators/ride-markets/index.ts
@@ -1,0 +1,63 @@
+import { Dependencies, FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import { queryAllium } from "../../helpers/allium";
+
+// On Ride Markets, the callers choose coin, duration, direction (up/down) and place a trade from
+// treasury. Each trade is executed through our Trade Executor program, which routes the
+// swap itself through Jupiter or DFlow.
+// https://solscan.io/account/tRADeQ3SJVHnFXv1rpwZzVt5HE6DWDu4J6cH34Md6ZA
+const TRADE_EXECUTOR = "tRADeQ3SJVHnFXv1rpwZzVt5HE6DWDu4J6cH34Md6ZA";
+
+// Anchor discriminator of `execute_intent`, the instruction that fills a trade.
+const EXECUTE_INTENT = "35822f9ae3dc7ad4";
+
+const fetch = async (options: FetchOptions) => {
+  const start = options.startTimestamp;
+  const end = options.endTimestamp;
+  const query = `
+    WITH fill_txs AS (
+      SELECT DISTINCT txn_id
+      FROM solana.raw.instructions
+      WHERE program_id = '${TRADE_EXECUTOR}'
+        AND data_hex_first16 = '${EXECUTE_INTENT}'
+        AND block_timestamp >= TO_TIMESTAMP_NTZ(${start})
+        AND block_timestamp < TO_TIMESTAMP_NTZ(${end})
+    ),
+    hop_dedup AS (
+      SELECT t.usd_amount
+      FROM solana.dex.trades t
+      INNER JOIN fill_txs f ON t.txn_id = f.txn_id
+      WHERE t.block_timestamp >= TO_TIMESTAMP_NTZ(${start})
+        AND t.block_timestamp < TO_TIMESTAMP_NTZ(${end})
+      QUALIFY ROW_NUMBER() OVER (
+        PARTITION BY t.txn_id, t.instruction_index
+        ORDER BY t.usd_amount DESC NULLS LAST
+      ) = 1
+    )
+    SELECT COALESCE(SUM(usd_amount), 0) AS volume
+    FROM hop_dedup
+  `;
+
+  const data = await queryAllium(query);
+  return {
+    dailyVolume: data[0]?.volume ?? 0,
+  };
+};
+
+const methodology = {
+  Volume:
+    "cumulative USD volme of the swaps Ride Markets routes on Solana, taken from Allium solana.dex.trades for transactions that carry an `execute_intent` instruction. Opening a trade and closing it are separate swaps and both are counted, as is each fill of a trade that executes in parts. Each outer instruction is counted once, at its largest hop, so multi-hop Jupiter routes are not double counted.",
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  pullHourly: true,
+  fetch,
+  start: "2026-03-21",
+  chains: [CHAIN.SOLANA],
+  dependencies: [Dependencies.ALLIUM],
+  isExpensiveAdapter: true,
+  methodology,
+};
+
+export default adapter;

--- a/fees/ride-markets/index.ts
+++ b/fees/ride-markets/index.ts
@@ -57,59 +57,62 @@ const fetch = async (options: FetchOptions) => {
   const timeRange = `block_timestamp >= TO_TIMESTAMP_NTZ(${options.startTimestamp})
         AND block_timestamp < TO_TIMESTAMP_NTZ(${options.endTimestamp})`;
 
-  // Settlement payouts, per settlement. `outer_program_id` keeps this to transfers the Trade
-  // Executor program itself made, and the vault keys each settlement so a transaction carrying two
-  // of them stays split.
-  const settlementQuery = `
-    WITH fee_legs AS (
-      SELECT txn_id, from_address AS vault, SUM(raw_amount) AS fee_total
+  // One Allium job: settlement legs (program USDC transfers, vault-keyed so two
+  // settlements in the same tx stay split) plus fee-wallet inflows on txs that
+  // invoke Trade Executor. `create_intent` is a CPI, so match `program_id` on
+  // `solana.raw.instructions` rather than scanning `solana.raw.transactions`.
+  const query = `
+    WITH ride_txs AS (
+      SELECT DISTINCT txn_id
+      FROM solana.raw.instructions
+      WHERE program_id = '${TRADE_EXECUTOR}'
+        AND ${timeRange}
+    ),
+    program_transfers AS (
+      SELECT txn_id, from_address, to_address, raw_amount
       FROM solana.assets.transfers
       WHERE outer_program_id = '${TRADE_EXECUTOR}'
-        AND to_address = '${FEE_WALLET}'
         AND mint = '${ADDRESSES.solana.USDC}'
         AND ${timeRange}
+    ),
+    fee_legs AS (
+      SELECT txn_id, from_address AS vault, SUM(raw_amount) AS fee_total
+      FROM program_transfers
+      WHERE to_address = '${FEE_WALLET}'
       GROUP BY txn_id, from_address
     ),
     payouts AS (
       SELECT txn_id, from_address AS vault, to_address AS recipient, SUM(raw_amount) AS amount
+      FROM program_transfers
+      WHERE to_address != '${FEE_WALLET}'
+      GROUP BY txn_id, from_address, to_address
+    ),
+    fee_inflows AS (
+      SELECT txn_id, raw_amount
       FROM solana.assets.transfers
-      WHERE outer_program_id = '${TRADE_EXECUTOR}'
-        AND to_address != '${FEE_WALLET}'
+      WHERE to_address = '${FEE_WALLET}'
+        AND from_address != '${FEE_WALLET}'
         AND mint = '${ADDRESSES.solana.USDC}'
         AND ${timeRange}
-      GROUP BY txn_id, from_address, to_address
     )
-    SELECT f.txn_id AS txn_id, f.vault AS vault, f.fee_total AS fee_total, p.amount AS amount
+    SELECT 'settlement' AS kind, f.txn_id AS txn_id, f.vault AS vault, f.fee_total AS fee_total, p.amount AS amount
     FROM fee_legs f
     LEFT JOIN payouts p ON p.txn_id = f.txn_id AND p.vault = f.vault
+    UNION ALL
+    SELECT 'inflow' AS kind, NULL AS txn_id, NULL AS vault, NULL AS fee_total, COALESCE(SUM(i.raw_amount), 0) AS amount
+    FROM fee_inflows i
+    INNER JOIN ride_txs r ON r.txn_id = i.txn_id
   `;
 
-  // What the fee wallet receives in transactions that use the Trade Executor program. Whatever the
-  // settlements above do not account for is the trade opening fee, which the frontend sends as a
-  // plain SPL transfer outside the program. `create_intent` runs as a CPI so it has no outer
-  // instruction to match on, but the program is still in the transaction's account keys.
-  const inflowQuery = `
-    WITH ride_txs AS (
-      SELECT txn_id
-      FROM solana.raw.transactions
-      WHERE success = true
-        AND ARRAY_CONTAINS('${TRADE_EXECUTOR}'::VARIANT, TRANSFORM(account_keys, x -> x:pubkey))
-        AND ${timeRange}
-    )
-    SELECT COALESCE(SUM(t.raw_amount), 0) AS amount
-    FROM solana.assets.transfers t
-    JOIN ride_txs r ON r.txn_id = t.txn_id
-    WHERE t.to_address = '${FEE_WALLET}'
-      AND t.from_address != '${FEE_WALLET}'
-      AND t.mint = '${ADDRESSES.solana.USDC}'
-      AND ${timeRange}
-  `;
-
-  const rows = await queryAllium(settlementQuery);
-  const inflow = await queryAllium(inflowQuery);
+  const rows = await queryAllium(query);
 
   const settlements = new Map<string, { feeTotal: number; payouts: number[] }>();
+  let inflowAmount = 0;
   rows.forEach((row: any) => {
+    if (String(row.kind).toLowerCase() === "inflow") {
+      inflowAmount = Number(row.amount ?? 0);
+      return;
+    }
     const key = `${row.txn_id}:${row.vault}`;
     if (!settlements.has(key)) settlements.set(key, { feeTotal: Number(row.fee_total), payouts: [] });
     if (row.amount) settlements.get(key)!.payouts.push(Number(row.amount));
@@ -121,7 +124,7 @@ const fetch = async (options: FetchOptions) => {
     settlementFees += feeTotal;
     callerFees += callerShare(feeTotal, payouts);
   });
-  const openingFees = Number(inflow[0]?.amount ?? 0) - settlementFees;
+  const openingFees = inflowAmount - settlementFees;
 
   const usdc = ADDRESSES.solana.USDC;
   dailyFees.add(usdc, openingFees, "Trade Opening Fees");
@@ -142,13 +145,13 @@ const fetch = async (options: FetchOptions) => {
 const methodology = {
   Fees: "Everything paid to trade on Ride Markets, in USDC: a fee when a trade is opened, a fee when it settles, and the share of the profit paid to the caller who deployed the trade.",
   Revenue: "The opening and settlement fees, which the protocol keeps.",
-  ProtocolRevenue: "Same as revenue, collected in the Ride Markets fee wallet.",
+  ProtocolRevenue: "The opening and settlement fees, which the protocol keeps.",
   SupplySideRevenue: "The profit share paid to callers, which never reaches the protocol.",
 };
 
 const breakdownMethodology = {
   Fees: {
-    "Trade Opening Fees": "Charged when a trade is opened, based on its volume. Taken by the frontend as a direct USDC transfer to the fee wallet, outside the Trade Executor program, so it is counted only in transactions that use that program and only for what the settlement fees do not already account for.",
+    "Trade Opening Fees": "Charged when a trade is opened, based on its volume. Taken by the frontend as a direct USDC transfer to the fee wallet, outside the Trade Executor program, so it is counted only in transactions that invoke that program (including CPI `create_intent`) and only for what the settlement fees do not already account for.",
     "Settlement Fees": "Charged by the Trade Executor program when a trade settles: 0.7% of the USDC returned to the treasury, plus a cut of the caller's profit share.",
     "Caller Profit Share": "Paid out of the treasury's realised profit to the caller who deployed the trade, at a rate the DAO sets. The protocol sets and enforces this rate but does not receive it.",
   },
@@ -157,8 +160,8 @@ const breakdownMethodology = {
     "Settlement Fees To Protocol": "All settlement fees are paid to the Ride Markets fee wallet.",
   },
   ProtocolRevenue: {
-    "Trade Opening Fees To Protocol": "Same as revenue.",
-    "Settlement Fees To Protocol": "Same as revenue.",
+    "Trade Opening Fees To Protocol": "All trade opening fees are paid to the Ride Markets fee wallet.",
+    "Settlement Fees To Protocol": "All settlement fees are paid to the Ride Markets fee wallet.",
   },
   SupplySideRevenue: {
     "Caller Profit Share To Callers": "Paid straight from the trade's proceeds to the caller, as the cost of sourcing the trade.",

--- a/fees/ride-markets/index.ts
+++ b/fees/ride-markets/index.ts
@@ -1,0 +1,170 @@
+import ADDRESSES from "../../helpers/coreAssets.json";
+import { Dependencies, FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import { queryAllium } from "../../helpers/allium";
+
+// On Ride Markets, the callers choose coin, duration, direction (up/down) and place a trade from
+// treasury. Each trade is executed through our Trade Executor program.
+// https://solscan.io/account/tRADeQ3SJVHnFXv1rpwZzVt5HE6DWDu4J6cH34Md6ZA
+const TRADE_EXECUTOR = "tRADeQ3SJVHnFXv1rpwZzVt5HE6DWDu4J6cH34Md6ZA";
+
+// Ride Markets collects every fee in USDC into this wallet.
+// https://solscan.io/account/ejBYopijneorWAQ1rN6FiZMvmfXbcjcz4mELCNMRsPW
+const FEE_WALLET = "ejBYopijneorWAQ1rN6FiZMvmfXbcjcz4mELCNMRsPW";
+
+// Settlement fee schedule, from the program.
+const SWAP_FEE_BPS = 70; // 0.7% of the USDC returned to the treasury
+const PAYOUT_RATIOS = [9, 99]; // caller share / profit fee, could be either 1% or 10%
+const RATIO_TOLERANCE = 0.005; // absorbs the program's integer division
+
+// The treasury is paid `gross - floor(gross * 70 / 10000)`, so its net recovers the gross.
+const grossFromNet = (net: number): number => {
+  const approx = Math.round(net / (1 - SWAP_FEE_BPS / 10000));
+  for (const gross of [approx - 2, approx - 1, approx, approx + 1, approx + 2]) {
+    if (gross - Math.floor((gross * SWAP_FEE_BPS) / 10000) === net) return gross;
+  }
+  return approx;
+};
+
+// A settlement instruction pays USDC to the fee wallet, to the treasury, and when the trade closed a linked
+// position with profit - to the caller.
+// If the trade yields profit, the protocol charges either 1% or 10% profit fees, and the caller's share 
+// must then be exactly 99x or 9x that profit fee.
+const callerShare = (feeTotal: number, payouts: number[]): number => {
+  if (feeTotal <= 0 || payouts.length < 2) return 0;
+  let bestError = Infinity;
+  let bestCaller = 0;
+  for (let i = 0; i < payouts.length; i++) {
+    const treasury = payouts[i];
+    const profitFee = feeTotal - (grossFromNet(treasury) - treasury);
+    if (profitFee <= 0) continue;
+    const rest = payouts.reduce((sum, p, j) => (j === i ? sum : sum + p), 0);
+    for (const ratio of PAYOUT_RATIOS) {
+      const error = Math.abs(rest - profitFee * ratio) / Math.max(rest, 1);
+      if (error <= RATIO_TOLERANCE && error < bestError) {
+        bestError = error;
+        bestCaller = rest;
+      }
+    }
+  }
+  return bestCaller;
+};
+
+const fetch = async (options: FetchOptions) => {
+  const dailyFees = options.createBalances();
+  const dailyRevenue = options.createBalances();
+  const dailySupplySideRevenue = options.createBalances();
+  const timeRange = `block_timestamp >= TO_TIMESTAMP_NTZ(${options.startTimestamp})
+        AND block_timestamp < TO_TIMESTAMP_NTZ(${options.endTimestamp})`;
+
+  // Settlement payouts, per settlement. `outer_program_id` keeps this to transfers the Trade
+  // Executor program itself made, and the vault keys each settlement so a transaction carrying two
+  // of them stays split.
+  const settlementQuery = `
+    WITH fee_legs AS (
+      SELECT txn_id, from_address AS vault, SUM(raw_amount) AS fee_total
+      FROM solana.assets.transfers
+      WHERE outer_program_id = '${TRADE_EXECUTOR}'
+        AND to_address = '${FEE_WALLET}'
+        AND mint = '${ADDRESSES.solana.USDC}'
+        AND ${timeRange}
+      GROUP BY txn_id, from_address
+    ),
+    payouts AS (
+      SELECT txn_id, from_address AS vault, to_address AS recipient, SUM(raw_amount) AS amount
+      FROM solana.assets.transfers
+      WHERE outer_program_id = '${TRADE_EXECUTOR}'
+        AND to_address != '${FEE_WALLET}'
+        AND mint = '${ADDRESSES.solana.USDC}'
+        AND ${timeRange}
+      GROUP BY txn_id, from_address, to_address
+    )
+    SELECT f.txn_id AS txn_id, f.vault AS vault, f.fee_total AS fee_total, p.amount AS amount
+    FROM fee_legs f
+    LEFT JOIN payouts p ON p.txn_id = f.txn_id AND p.vault = f.vault
+  `;
+
+  // Everything the fee wallet receives. Whatever the settlements above do not account for is the
+  // trade opening fee, which the frontend sends as a plain SPL transfer outside the program.
+  const inflowQuery = `
+    SELECT SUM(raw_amount) AS amount
+    FROM solana.assets.transfers
+    WHERE to_address = '${FEE_WALLET}'
+      AND from_address != '${FEE_WALLET}'
+      AND mint = '${ADDRESSES.solana.USDC}'
+      AND ${timeRange}
+  `;
+
+  const rows = await queryAllium(settlementQuery);
+  const inflow = await queryAllium(inflowQuery);
+
+  const settlements = new Map<string, { feeTotal: number; payouts: number[] }>();
+  rows.forEach((row: any) => {
+    const key = `${row.txn_id}:${row.vault}`;
+    if (!settlements.has(key)) settlements.set(key, { feeTotal: Number(row.fee_total), payouts: [] });
+    if (row.amount) settlements.get(key)!.payouts.push(Number(row.amount));
+  });
+
+  let settlementFees = 0;
+  let callerFees = 0;
+  settlements.forEach(({ feeTotal, payouts }) => {
+    settlementFees += feeTotal;
+    callerFees += callerShare(feeTotal, payouts);
+  });
+  const openingFees = Number(inflow[0]?.amount ?? 0) - settlementFees;
+
+  const usdc = ADDRESSES.solana.USDC;
+  dailyFees.add(usdc, openingFees, "Trade Opening Fees");
+  dailyFees.add(usdc, settlementFees, "Settlement Fees");
+  dailyFees.add(usdc, callerFees, "Caller Profit Share");
+  dailyRevenue.add(usdc, openingFees, "Trade Opening Fees To Protocol");
+  dailyRevenue.add(usdc, settlementFees, "Settlement Fees To Protocol");
+  dailySupplySideRevenue.add(usdc, callerFees, "Caller Profit Share To Callers");
+
+  return {
+    dailyFees,
+    dailyRevenue,
+    dailyProtocolRevenue: dailyRevenue,
+    dailySupplySideRevenue,
+  };
+};
+
+const methodology = {
+  Fees: "Everything paid to trade on Ride Markets, in USDC: a fee when a trade is opened, a fee when it settles, and the share of the profit paid to the caller who deployed the trade.",
+  Revenue: "The opening and settlement fees, which the protocol keeps.",
+  ProtocolRevenue: "Same as revenue, collected in the Ride Markets fee wallet.",
+  SupplySideRevenue: "The profit share paid to callers, which never reaches the protocol.",
+};
+
+const breakdownMethodology = {
+  Fees: {
+    "Trade Opening Fees": "Charged when a trade is opened, based on its volume. Taken by the frontend as a direct USDC transfer to the fee wallet, outside the Trade Executor program.",
+    "Settlement Fees": "Charged by the Trade Executor program when a trade settles: 0.7% of the USDC returned to the treasury, plus a cut of the caller's profit share.",
+    "Caller Profit Share": "Paid out of the treasury's realised profit to the caller who deployed the trade, at a rate the DAO sets. The protocol sets and enforces this rate but does not receive it.",
+  },
+  Revenue: {
+    "Trade Opening Fees To Protocol": "All trade opening fees are paid to the Ride Markets fee wallet.",
+    "Settlement Fees To Protocol": "All settlement fees are paid to the Ride Markets fee wallet.",
+  },
+  ProtocolRevenue: {
+    "Trade Opening Fees To Protocol": "Same as revenue.",
+    "Settlement Fees To Protocol": "Same as revenue.",
+  },
+  SupplySideRevenue: {
+    "Caller Profit Share To Callers": "Paid straight from the trade's proceeds to the caller, as the cost of sourcing the trade.",
+  },
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  pullHourly: true,
+  fetch,
+  start: "2026-06-11",
+  chains: [CHAIN.SOLANA],
+  dependencies: [Dependencies.ALLIUM],
+  isExpensiveAdapter: true,
+  methodology,
+  breakdownMethodology,
+};
+
+export default adapter;

--- a/fees/ride-markets/index.ts
+++ b/fees/ride-markets/index.ts
@@ -84,14 +84,24 @@ const fetch = async (options: FetchOptions) => {
     LEFT JOIN payouts p ON p.txn_id = f.txn_id AND p.vault = f.vault
   `;
 
-  // Everything the fee wallet receives. Whatever the settlements above do not account for is the
-  // trade opening fee, which the frontend sends as a plain SPL transfer outside the program.
+  // What the fee wallet receives in transactions that use the Trade Executor program. Whatever the
+  // settlements above do not account for is the trade opening fee, which the frontend sends as a
+  // plain SPL transfer outside the program. `create_intent` runs as a CPI so it has no outer
+  // instruction to match on, but the program is still in the transaction's account keys.
   const inflowQuery = `
-    SELECT SUM(raw_amount) AS amount
-    FROM solana.assets.transfers
-    WHERE to_address = '${FEE_WALLET}'
-      AND from_address != '${FEE_WALLET}'
-      AND mint = '${ADDRESSES.solana.USDC}'
+    WITH ride_txs AS (
+      SELECT txn_id
+      FROM solana.raw.transactions
+      WHERE success = true
+        AND ARRAY_CONTAINS('${TRADE_EXECUTOR}'::VARIANT, TRANSFORM(account_keys, x -> x:pubkey))
+        AND ${timeRange}
+    )
+    SELECT COALESCE(SUM(t.raw_amount), 0) AS amount
+    FROM solana.assets.transfers t
+    JOIN ride_txs r ON r.txn_id = t.txn_id
+    WHERE t.to_address = '${FEE_WALLET}'
+      AND t.from_address != '${FEE_WALLET}'
+      AND t.mint = '${ADDRESSES.solana.USDC}'
       AND ${timeRange}
   `;
 
@@ -138,7 +148,7 @@ const methodology = {
 
 const breakdownMethodology = {
   Fees: {
-    "Trade Opening Fees": "Charged when a trade is opened, based on its volume. Taken by the frontend as a direct USDC transfer to the fee wallet, outside the Trade Executor program.",
+    "Trade Opening Fees": "Charged when a trade is opened, based on its volume. Taken by the frontend as a direct USDC transfer to the fee wallet, outside the Trade Executor program, so it is counted only in transactions that use that program and only for what the settlement fees do not already account for.",
     "Settlement Fees": "Charged by the Trade Executor program when a trade settles: 0.7% of the USDC returned to the treasury, plus a cut of the caller's profit share.",
     "Caller Profit Share": "Paid out of the treasury's realised profit to the caller who deployed the trade, at a rate the DAO sets. The protocol sets and enforces this rate but does not receive it.",
   },


### PR DESCRIPTION


---

##### Name (to be shown on DefiLlama): 
Ride Markets

##### Twitter Link:
https://x.com/ridemarkets

##### List of audit links if any:
None

##### Website Link:
https://ride.markets/

##### Logo (High resolution, will be shown with rounded borders):
https://www.ride.markets/ride-logo.svg

##### Current TVL:
N/A for this PR

##### Treasury Addresses (if the protocol has treasury)
N/A

##### Chain:
Solana

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed):
not listed

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed):
not listed

##### Short Description (to be shown on DefiLlama):
Ride Markets lets you put passive capital to work behind your best trades. Risk a small amount; make a profitable trade and earn a share of the fund’s profits.

##### Token address and ticker if any:
None

##### Category (full list at https://defillama.com/categories) \*Please choose only one:
DEX Aggregator

##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.):
N/A

##### Implementation Details: Briefly describe how the oracle is integrated into your project:
N/A

##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage:
N/A

##### forkedFrom (Does your project originate from another project):
N/A

##### methodology (what is being counted as tvl, how is tvl being calculated):
Volume: The trades on the platform go through our Trade Executor Program `tRADeQ3SJVHnFXv1rpwZzVt5HE6DWDu4J6cH34Md6ZA`. Each trade goes through the `execute_intent` instruction, and internally this instruction routes the trade via either Jupiter or Dflow. We consider the aggregate of all trades placed through the Trade Executor program as the Ride Markets' volume.

Fees: The platform charges the opening and the closing fees on each trade. All the fees are routed to a single FEE_TAKER_WALLET=`ejBYopijneorWAQ1rN6FiZMvmfXbcjcz4mELCNMRsPW`. The opening fees is charged on the front-end based on volume and is a simple SPL transfer to the fee taker wallet. The settlement fees (closing fees) is charged via the `execute_intent` and `perp_finalize` instructions in the Trade Executor Program. 
The same instructions also share the profit with the callers on the profitable calls, adding to the supply side revenue, paid directly to the caller's address without sourcing through the protocol's wallet as a cost of sourcing the trade.

##### Github org/user (Optional, if your code is open source, we can track activity):
N/A 

##### Does this project have a referral program?
No
