### PR TITLE
 [fix] Drake Exchange - fix volume calculation and add open-interest adapter

### DIFF
--- a/fees/drake-exchange/index.ts
+++ b/fees/drake-exchange/index.ts
@@ -15,6 +15,11 @@ const MARGIN_CHANGE_FEE = 4;
 // notional (AUSD base units) = size * executionPrice / SIZE_SCALE.
 const SIZE_SCALE = 10_000n;
 
+// dailyVolume breakdown labels: taker fills are matched against the orderbook, the
+// liquidity vault (AMM), or both in one fill.
+const ORDERBOOK_VOLUME = "Orderbook Volume";
+const AMM_VOLUME = "AMM Volume";
+
 type FeeSplit = { vault: number; treasury: number };
 type SplitSchedule = Array<{ fromBlock: number } & FeeSplit>;
 
@@ -53,11 +58,12 @@ const fetch = async (options: FetchOptions) => {
         const ob = BigInt(t.args.orderbookVolume);
         const amm = BigInt(t.args.vaultVolume);
         const totalSize = ob + amm;
+        const price = BigInt(t.args.executionPrice);
 
-        dailyVolume.add(
-            AUSD,
-            (totalSize * BigInt(t.args.executionPrice)) / SIZE_SCALE,
-        );
+        if (ob > 0n)
+            dailyVolume.add(AUSD, (ob * price) / SIZE_SCALE, ORDERBOOK_VOLUME);
+        if (amm > 0n)
+            dailyVolume.add(AUSD, (amm * price) / SIZE_SCALE, AMM_VOLUME);
         // Venue split is a size ratio (both legs share the same execution price).
         if (totalSize > 0n)
             fillRatioByTx[t.transactionHash] = Number(ob) / Number(totalSize);
@@ -132,6 +138,12 @@ const fetch = async (options: FetchOptions) => {
 };
 
 const breakdownMethodology = {
+    Volume: {
+        [ORDERBOOK_VOLUME]:
+            "Notional (size x execution price, in AUSD) of taker fills matched against the orderbook.",
+        [AMM_VOLUME]:
+            "Notional (size x execution price, in AUSD) of taker fills matched against the liquidity vault (AMM).",
+    },
     Fees: {
         [METRIC.TRADING_FEES]: "Trading commission on orderbook and AMM fills.",
         [METRIC.MARGIN_FEES]: "Isolated margin add/reduce fees.",
@@ -163,6 +175,7 @@ export default {
     start: "2026-07-07",
     fetch,
     methodology: {
+        Volume: "Notional taker volume (size x execution price, in AUSD) across orderbook and AMM fills.",
         Fees: "All trading commission fees (orderbook + AMM), isolated margin add/reduce fees, and net borrowing/imbalance funding fees charged to traders.",
         Revenue:
             "Share of trade commission fees routed to the Operation Vault (treasury) per the orderbook and AMM splits in effect at that block.",

--- a/fees/drake-exchange/index.ts
+++ b/fees/drake-exchange/index.ts
@@ -11,6 +11,10 @@ const PLATFORM_MANAGER = "0x7940575377C3c2ABdA23813c123b4C880E217d6d";
 const COMMISSION_FEE = 3;
 const MARGIN_CHANGE_FEE = 4;
 
+// Order sizes carry 4 decimals on-chain (TypeLibrary.BPS_SCALING_FACTOR = 1e4);
+// notional (AUSD base units) = size * executionPrice / SIZE_SCALE.
+const SIZE_SCALE = 10_000n;
+
 type FeeSplit = { vault: number; treasury: number };
 type SplitSchedule = Array<{ fromBlock: number } & FeeSplit>;
 
@@ -48,12 +52,15 @@ const fetch = async (options: FetchOptions) => {
     trades.forEach((t: any) => {
         const ob = BigInt(t.args.orderbookVolume);
         const amm = BigInt(t.args.vaultVolume);
+        const totalSize = ob + amm;
 
-        const total =
-            ((ob + amm) * BigInt(t.args.executionPrice)) / BigInt(1e4);
-        dailyVolume.add(AUSD, total);
-        if (total > 0n)
-            fillRatioByTx[t.transactionHash] = Number(ob) / Number(total);
+        dailyVolume.add(
+            AUSD,
+            (totalSize * BigInt(t.args.executionPrice)) / SIZE_SCALE,
+        );
+        // Venue split is a size ratio (both legs share the same execution price).
+        if (totalSize > 0n)
+            fillRatioByTx[t.transactionHash] = Number(ob) / Number(totalSize);
     });
 
     const transfers = await options.getLogs({

--- a/fees/drake-exchange/index.ts
+++ b/fees/drake-exchange/index.ts
@@ -48,7 +48,9 @@ const fetch = async (options: FetchOptions) => {
     trades.forEach((t: any) => {
         const ob = BigInt(t.args.orderbookVolume);
         const amm = BigInt(t.args.vaultVolume);
-        const total = ob + amm;
+
+        const total =
+            ((ob + amm) * BigInt(t.args.executionPrice)) / BigInt(1e4);
         dailyVolume.add(AUSD, total);
         if (total > 0n)
             fillRatioByTx[t.transactionHash] = Number(ob) / Number(total);
@@ -106,28 +108,44 @@ const fetch = async (options: FetchOptions) => {
     fbFees.forEach((f: any) => {
         if (f.totalFBFee <= 0n) return;
         dailyFees.add(AUSD, BigInt(f.totalFBFee), METRIC.BORROW_INTEREST);
-        dailySupplySideRevenue.add(AUSD, BigInt(f.totalFBFee), METRIC.BORROW_INTEREST);
+        dailySupplySideRevenue.add(
+            AUSD,
+            BigInt(f.totalFBFee),
+            METRIC.BORROW_INTEREST,
+        );
     });
 
-    return { dailyVolume, dailyFees, dailyRevenue, dailyProtocolRevenue: dailyRevenue, dailySupplySideRevenue };
+    return {
+        dailyVolume,
+        dailyFees,
+        dailyRevenue,
+        dailyProtocolRevenue: dailyRevenue,
+        dailySupplySideRevenue,
+    };
 };
 
 const breakdownMethodology = {
     Fees: {
         [METRIC.TRADING_FEES]: "Trading commission on orderbook and AMM fills.",
         [METRIC.MARGIN_FEES]: "Isolated margin add/reduce fees.",
-        [METRIC.BORROW_INTEREST]: "Net borrowing and imbalance funding fees charged to traders.",
+        [METRIC.BORROW_INTEREST]:
+            "Net borrowing and imbalance funding fees charged to traders.",
     },
     Revenue: {
-        [METRIC.TRADING_FEES]: "Treasury share of trading commission per the orderbook and AMM splits in effect at that block.",
+        [METRIC.TRADING_FEES]:
+            "Treasury share of trading commission per the orderbook and AMM splits in effect at that block.",
     },
     ProtocolRevenue: {
-        [METRIC.TRADING_FEES]: "Treasury share of trading commission per the orderbook and AMM splits in effect at that block.",
+        [METRIC.TRADING_FEES]:
+            "Treasury share of trading commission per the orderbook and AMM splits in effect at that block.",
     },
     SupplySideRevenue: {
-        [METRIC.TRADING_FEES]: "Liquidity vault share of trading commission per the orderbook and AMM splits in effect at that block.",
-        [METRIC.MARGIN_FEES]: "100% of isolated margin add/reduce fees routed to the liquidity vault.",
-        [METRIC.BORROW_INTEREST]: "100% of borrowing and funding fees routed to the liquidity vault.",
+        [METRIC.TRADING_FEES]:
+            "Liquidity vault share of trading commission per the orderbook and AMM splits in effect at that block.",
+        [METRIC.MARGIN_FEES]:
+            "100% of isolated margin add/reduce fees routed to the liquidity vault.",
+        [METRIC.BORROW_INTEREST]:
+            "100% of borrowing and funding fees routed to the liquidity vault.",
     },
 };
 
@@ -135,13 +153,14 @@ export default {
     version: 2,
     pullHourly: true,
     chains: [CHAIN.MONAD],
-    start: '2026-07-07',
+    start: "2026-07-07",
     fetch,
     methodology: {
         Fees: "All trading commission fees (orderbook + AMM), isolated margin add/reduce fees, and net borrowing/imbalance funding fees charged to traders.",
         Revenue:
             "Share of trade commission fees routed to the Operation Vault (treasury) per the orderbook and AMM splits in effect at that block.",
-        ProtocolRevenue: "Share of trade commission fees routed to the Operation Vault (treasury) per the orderbook and AMM splits in effect at that block.",
+        ProtocolRevenue:
+            "Share of trade commission fees routed to the Operation Vault (treasury) per the orderbook and AMM splits in effect at that block.",
         SupplySideRevenue:
             "Share routed to the Liquidity Vault per the orderbook and AMM splits in effect at that block, plus 100% of margin-change and borrowing/funding fees.",
     },

--- a/open-interest/drake-exchange.ts
+++ b/open-interest/drake-exchange.ts
@@ -1,0 +1,128 @@
+/**
+ * Drake Exchange (Monad) open-interest adapter.
+ *
+ * Reads per-instrument long/short open interest directly from the PlatformManager
+ * contract at the end of each period and reports:
+ *   - openInterestAtEnd      = sum over instruments of (long + short)
+ *   - longOpenInterestAtEnd  = sum over instruments of long OI
+ *   - shortOpenInterestAtEnd = sum over instruments of short OI
+ */
+import { ChainApi } from "@defillama/sdk";
+import { FetchOptions, SimpleAdapter } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+import ADDRESSES from "../helpers/coreAssets.json";
+
+/** PlatformManager proxy on Monad mainnet; owns OI state and the instrument registry. */
+const PLATFORM_MANAGER = "0x7940575377C3c2ABdA23813c123b4C880E217d6d";
+/** Settlement token; every OI value returned by PlatformManager is denominated in it. */
+const AUSD = ADDRESSES.monad.AUSD;
+
+/** PlatformManager view ABIs used by this adapter. */
+const ABI = {
+    /** Next unassigned instrument id; live instrument ids are 1 .. nextInstId-1. */
+    nextInstId: "function nextInstId() view returns (uint256)",
+    /** Long-side notional OI for one instrument, in AUSD base units. */
+    openInterestLong:
+        "function openInterestLong(uint256 _instId) view returns (uint256)",
+    /** Short-side notional OI for one instrument, in AUSD base units. */
+    openInterestShort:
+        "function openInterestShort(uint256 _instId) view returns (uint256)",
+};
+
+/**
+ * Stale-oracle retry parameters.
+ *
+ * openInterestLong/Short price positions through oracle (maxPublishAge = 12s on-chain),
+ * so a read at a block with no fresh oracle update reverts.
+ * On failure the adapter walks *backwards* from the period-end block in steps of
+ * RETRY_STEP_BLOCKS (Monad ~0.4s blocks, so 25 blocks ~= 10s) for up to MAX_ATTEMPTS
+ * attempts, keeping the reported value at-or-before period end.
+ */
+const RETRY_STEP_BLOCKS = 25;
+const MAX_ATTEMPTS = 6; // covers ~1 minute before the end block
+
+/**
+ * Reads long and short OI for every live instrument at the block pinned on `api`.
+ *
+ * @param api ChainApi bound to the block to read state at.
+ * @returns Raw per-instrument OI arrays (index i => instrument id i+1), in AUSD base units.
+ * @throws If any underlying call reverts (e.g. no fresh oracle update) or the RPC fails.
+ */
+async function readOpenInterest(api: ChainApi) {
+    const nextInstId = Number(
+        await api.call({ target: PLATFORM_MANAGER, abi: ABI.nextInstId }),
+    );
+    // instrument ids are 1 .. nextInstId-1
+    const calls = Array.from({ length: nextInstId - 1 }, (_, i) => ({
+        target: PLATFORM_MANAGER,
+        params: [i + 1],
+    }));
+    const [longs, shorts] = await Promise.all([
+        api.multiCall({ abi: ABI.openInterestLong, calls }),
+        api.multiCall({ abi: ABI.openInterestShort, calls }),
+    ]);
+    return { longs, shorts };
+}
+
+/**
+ * Fetches end-of-period open interest.
+ *
+ * Attempt 0 uses `options.api` (already pinned to the period-end block); subsequent
+ * attempts construct a ChainApi at progressively earlier blocks per the retry parameters
+ * above.
+ *
+ * @param options DefiLlama fetch options for the period.
+ * @returns `openInterestAtEnd`, `longOpenInterestAtEnd`, `shortOpenInterestAtEnd` as Balances.
+ */
+const fetch = async (options: FetchOptions) => {
+    const toBlock = await options.getToBlock();
+    let result: { longs: any[]; shorts: any[] } | undefined;
+    let lastError: unknown;
+    for (let attempt = 0; attempt < MAX_ATTEMPTS && !result; attempt++) {
+        const api =
+            attempt === 0
+                ? options.api
+                : new ChainApi({
+                      chain: options.chain,
+                      block: toBlock - attempt * RETRY_STEP_BLOCKS,
+                  });
+        try {
+            result = await readOpenInterest(api);
+        } catch (e) {
+            lastError = e;
+        }
+    }
+    if (!result)
+        throw new Error(
+            `drake-exchange OI: no fresh oracle price within ${MAX_ATTEMPTS} attempts before block ${toBlock}: ${lastError}`,
+        );
+
+    const longOpenInterestAtEnd = options.createBalances();
+    const shortOpenInterestAtEnd = options.createBalances();
+    // Values are already in AUSD base units (6 decimals): size * oracle price / 1e4
+    result.longs.forEach((oi: any) => longOpenInterestAtEnd.add(AUSD, oi));
+    result.shorts.forEach((oi: any) => shortOpenInterestAtEnd.add(AUSD, oi));
+
+    const openInterestAtEnd = longOpenInterestAtEnd.clone();
+    openInterestAtEnd.addBalances(shortOpenInterestAtEnd);
+
+    return { openInterestAtEnd, longOpenInterestAtEnd, shortOpenInterestAtEnd };
+};
+
+/**
+ * Adapter definition. `start` matches the fees adapter's launch date.
+ * `pullHourly` is deliberately false: open interest is a point-in-time snapshot, not a flow.
+ * Under pullHourly the runner sums the 24 hourly records into the daily value, which would
+ * report ~24x the real OI. With daily pulls the single end-of-day reading is stored as-is.
+ */
+export default {
+    version: 2,
+    pullHourly: false, // OI is a snapshot; hourly records would be summed into the daily value
+    chains: [CHAIN.MONAD],
+    start: "2026-07-07",
+    fetch,
+    methodology: {
+        OpenInterest:
+            "Sum of long and short open interest across all instruments, read from contract state at the end of the period. Values are notional in AUSD (position size x oracle price).",
+    },
+} as SimpleAdapter;

--- a/open-interest/drake-exchange.ts
+++ b/open-interest/drake-exchange.ts
@@ -30,23 +30,54 @@ const ABI = {
 };
 
 /**
- * Stale-oracle retry parameters.
+ * Oracle-revert retry parameters.
  *
- * openInterestLong/Short price positions through oracle (maxPublishAge = 12s on-chain),
- * so a read at a block with no fresh oracle update reverts.
- * On failure the adapter walks *backwards* from the period-end block in steps of
+ * openInterestLong/Short price positions through the oracle (maxPublishAge = 12s on-chain),
+ * so a read at a block with no fresh, valid oracle price reverts. Only those reverts are
+ * retried: the adapter walks *backwards* from the period-end block in steps of
  * RETRY_STEP_BLOCKS (Monad ~0.4s blocks, so 25 blocks ~= 10s) for up to MAX_ATTEMPTS
- * attempts, keeping the reported value at-or-before period end.
+ * attempts, keeping the reported value at-or-before period end. Any other error (RPC or
+ * transport failure, unrelated contract revert) is rethrown immediately so the run fails
+ * rather than reporting OI from an earlier block.
  */
 const RETRY_STEP_BLOCKS = 25;
 const MAX_ATTEMPTS = 6; // covers ~1 minute before the end block
+
+/**
+ * 4-byte selectors of the transient oracle-validation reverts raised while pricing OI:
+ * Pyth `StalePrice()` and OracleRouter `ConfidenceTooHigh()` / `FuturePriceTimestamp()`.
+ */
+const ORACLE_REVERT_SELECTORS = [
+    "0x19abf40e", // StalePrice()
+    "0x9ebd92e3", // ConfidenceTooHigh()
+    "0x06a874f5", // FuturePriceTimestamp()
+];
+
+/**
+ * True when `error` is a contract revert carrying one of ORACLE_REVERT_SELECTORS.
+ *
+ * The sdk's multiCall wraps per-call reverts into `_underlyingErrors` strings that embed the
+ * revert data (e.g. `invalid length for result data (value="0x19abf40e", ...)`), so the
+ * selector can be matched by substring. RPC/transport failures carry no selector and are
+ * therefore never treated as retryable.
+ */
+function isOracleRevert(error: any): boolean {
+    const parts = [
+        error?.message,
+        error?._underlyingError,
+        ...(Array.isArray(error?._underlyingErrors) ? error._underlyingErrors : []),
+    ].map((part) => String(part ?? "").toLowerCase());
+    return parts.some((part) =>
+        ORACLE_REVERT_SELECTORS.some((selector) => part.includes(selector)),
+    );
+}
 
 /**
  * Reads long and short OI for every live instrument at the block pinned on `api`.
  *
  * @param api ChainApi bound to the block to read state at.
  * @returns Raw per-instrument OI arrays (index i => instrument id i+1), in AUSD base units.
- * @throws If any underlying call reverts (e.g. no fresh oracle update) or the RPC fails.
+ * @throws If any underlying call reverts (e.g. stale oracle price) or the RPC fails.
  */
 async function readOpenInterest(api: ChainApi) {
     const nextInstId = Number(
@@ -69,7 +100,9 @@ async function readOpenInterest(api: ChainApi) {
  *
  * Attempt 0 uses `options.api` (already pinned to the period-end block); subsequent
  * attempts construct a ChainApi at progressively earlier blocks per the retry parameters
- * above.
+ * above. Only oracle-validation reverts (see `isOracleRevert`) trigger a retry; every other
+ * error is rethrown at once. If all attempts fail the last oracle error is rethrown so the
+ * run fails loudly instead of recording zero OI.
  *
  * @param options DefiLlama fetch options for the period.
  * @returns `openInterestAtEnd`, `longOpenInterestAtEnd`, `shortOpenInterestAtEnd` as Balances.
@@ -89,12 +122,13 @@ const fetch = async (options: FetchOptions) => {
         try {
             result = await readOpenInterest(api);
         } catch (e) {
+            if (!isOracleRevert(e)) throw e;
             lastError = e;
         }
     }
     if (!result)
         throw new Error(
-            `drake-exchange OI: no fresh oracle price within ${MAX_ATTEMPTS} attempts before block ${toBlock}: ${lastError}`,
+            `drake-exchange OI: no valid oracle price within ${MAX_ATTEMPTS} attempts before block ${toBlock}: ${lastError}`,
         );
 
     const longOpenInterestAtEnd = options.createBalances();

--- a/open-interest/drake-exchange.ts
+++ b/open-interest/drake-exchange.ts
@@ -7,7 +7,6 @@
  *   - longOpenInterestAtEnd  = sum over instruments of long OI
  *   - shortOpenInterestAtEnd = sum over instruments of short OI
  */
-import { ChainApi } from "@defillama/sdk";
 import { FetchOptions, SimpleAdapter } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
 import ADDRESSES from "../helpers/coreAssets.json";
@@ -30,58 +29,15 @@ const ABI = {
 };
 
 /**
- * Oracle-revert retry parameters.
+ * Fetches end-of-period open interest. `options.api` is pinned to the period-end block.
  *
- * openInterestLong/Short price positions through the oracle (maxPublishAge = 12s on-chain),
- * so a read at a block with no fresh, valid oracle price reverts. Only those reverts are
- * retried: the adapter walks *backwards* from the period-end block in steps of
- * RETRY_STEP_BLOCKS (Monad ~0.4s blocks, so 25 blocks ~= 10s) for up to MAX_ATTEMPTS
- * attempts, keeping the reported value at-or-before period end. Any other error (RPC or
- * transport failure, unrelated contract revert) is rethrown immediately so the run fails
- * rather than reporting OI from an earlier block.
+ * @param options DefiLlama fetch options for the period.
+ * @returns `openInterestAtEnd`, `longOpenInterestAtEnd`, `shortOpenInterestAtEnd` as Balances.
+ * @throws If any view reverts (e.g. stale oracle price at the end block) or the RPC fails.
  */
-const RETRY_STEP_BLOCKS = 25;
-const MAX_ATTEMPTS = 6; // covers ~1 minute before the end block
-
-/**
- * 4-byte selectors of the transient oracle-validation reverts raised while pricing OI:
- * Pyth `StalePrice()` and OracleRouter `ConfidenceTooHigh()` / `FuturePriceTimestamp()`.
- */
-const ORACLE_REVERT_SELECTORS = [
-    "0x19abf40e", // StalePrice()
-    "0x9ebd92e3", // ConfidenceTooHigh()
-    "0x06a874f5", // FuturePriceTimestamp()
-];
-
-/**
- * True when `error` is a contract revert carrying one of ORACLE_REVERT_SELECTORS.
- *
- * The sdk's multiCall wraps per-call reverts into `_underlyingErrors` strings that embed the
- * revert data (e.g. `invalid length for result data (value="0x19abf40e", ...)`), so the
- * selector can be matched by substring. RPC/transport failures carry no selector and are
- * therefore never treated as retryable.
- */
-function isOracleRevert(error: any): boolean {
-    const parts = [
-        error?.message,
-        error?._underlyingError,
-        ...(Array.isArray(error?._underlyingErrors) ? error._underlyingErrors : []),
-    ].map((part) => String(part ?? "").toLowerCase());
-    return parts.some((part) =>
-        ORACLE_REVERT_SELECTORS.some((selector) => part.includes(selector)),
-    );
-}
-
-/**
- * Reads long and short OI for every live instrument at the block pinned on `api`.
- *
- * @param api ChainApi bound to the block to read state at.
- * @returns Raw per-instrument OI arrays (index i => instrument id i+1), in AUSD base units.
- * @throws If any underlying call reverts (e.g. stale oracle price) or the RPC fails.
- */
-async function readOpenInterest(api: ChainApi) {
+const fetch = async (options: FetchOptions) => {
     const nextInstId = Number(
-        await api.call({ target: PLATFORM_MANAGER, abi: ABI.nextInstId }),
+        await options.api.call({ target: PLATFORM_MANAGER, abi: ABI.nextInstId }),
     );
     // instrument ids are 1 .. nextInstId-1
     const calls = Array.from({ length: nextInstId - 1 }, (_, i) => ({
@@ -89,53 +45,15 @@ async function readOpenInterest(api: ChainApi) {
         params: [i + 1],
     }));
     const [longs, shorts] = await Promise.all([
-        api.multiCall({ abi: ABI.openInterestLong, calls }),
-        api.multiCall({ abi: ABI.openInterestShort, calls }),
+        options.api.multiCall({ abi: ABI.openInterestLong, calls }),
+        options.api.multiCall({ abi: ABI.openInterestShort, calls }),
     ]);
-    return { longs, shorts };
-}
-
-/**
- * Fetches end-of-period open interest.
- *
- * Attempt 0 uses `options.api` (already pinned to the period-end block); subsequent
- * attempts construct a ChainApi at progressively earlier blocks per the retry parameters
- * above. Only oracle-validation reverts (see `isOracleRevert`) trigger a retry; every other
- * error is rethrown at once. If all attempts fail the last oracle error is rethrown so the
- * run fails loudly instead of recording zero OI.
- *
- * @param options DefiLlama fetch options for the period.
- * @returns `openInterestAtEnd`, `longOpenInterestAtEnd`, `shortOpenInterestAtEnd` as Balances.
- */
-const fetch = async (options: FetchOptions) => {
-    const toBlock = await options.getToBlock();
-    let result: { longs: any[]; shorts: any[] } | undefined;
-    let lastError: unknown;
-    for (let attempt = 0; attempt < MAX_ATTEMPTS && !result; attempt++) {
-        const api =
-            attempt === 0
-                ? options.api
-                : new ChainApi({
-                      chain: options.chain,
-                      block: toBlock - attempt * RETRY_STEP_BLOCKS,
-                  });
-        try {
-            result = await readOpenInterest(api);
-        } catch (e) {
-            if (!isOracleRevert(e)) throw e;
-            lastError = e;
-        }
-    }
-    if (!result)
-        throw new Error(
-            `drake-exchange OI: no valid oracle price within ${MAX_ATTEMPTS} attempts before block ${toBlock}: ${lastError}`,
-        );
 
     const longOpenInterestAtEnd = options.createBalances();
     const shortOpenInterestAtEnd = options.createBalances();
     // Values are already in AUSD base units (6 decimals): size * oracle price / 1e4
-    result.longs.forEach((oi: any) => longOpenInterestAtEnd.add(AUSD, oi));
-    result.shorts.forEach((oi: any) => shortOpenInterestAtEnd.add(AUSD, oi));
+    longs.forEach((oi: any) => longOpenInterestAtEnd.add(AUSD, oi));
+    shorts.forEach((oi: any) => shortOpenInterestAtEnd.add(AUSD, oi));
 
     const openInterestAtEnd = longOpenInterestAtEnd.clone();
     openInterestAtEnd.addBalances(shortOpenInterestAtEnd);


### PR DESCRIPTION
### `fees/drake-exchange` — fix volume
- `dailyVolume` was summing raw position sizes (`orderbookVolume + vaultVolume`) instead of notional.
  Now multiplies by `executionPrice / 1e4` so volume is reported in AUSD notional.
- Formatting only otherwise (multi-line breakdown strings, return object); no logic change to fees/revenue.

### `open-interest/drake-exchange` — new adapter
- Reads `openInterestLong(instId)` / `openInterestShort(instId)` from `Contract` for every instrument `1..nextInstId-1` at the period-end block.
- Values are already AUSD notional (`size × oracle price / 1e4`), added to Balances keyed on AUSD.
- Returns `openInterestAtEnd` (long + short), `longOpenInterestAtEnd`, `shortOpenInterestAtEnd`.
- Instruments are discovered dynamically via `nextInstId`, so new listings are picked up automatically.
- `pullHourly: false` — OI is a snapshot, not a flow; hourly records would be summed into the daily value
  (same reasoning as `open-interest/tristero-margin.ts`).

### Testing
- `pnpm test open-interest drake-exchange` → OI $11.03k (long $5.06k / short $5.97k), matches raw contract reads.
- `pnpm test open-interest drake-exchange 2026-08-24` → $11.22k (long $5.80k / short $5.42k).
- Backfill verified from `2026-07-07` (launch day = 0 OI, first positions on 07-08).
- `pnpm test fees drake-exchange` → daily volume $9.73k in AUSD notional, fees $2.00.
