### PR TITLE
add Morpheus volume and fees on Robinhood

### DIFF
--- a/factory/uniSubgraph.ts
+++ b/factory/uniSubgraph.ts
@@ -213,6 +213,22 @@ const configs: Record<string, SubgraphConfig> = {
       Revenue: 0,
     },
   },
+  "morpheus": {
+    graphUrls: {
+      [CHAIN.ROBINHOOD]: "https://api.goldsky.com/api/public/project_cm8pwdzcow9bu01xm6gdhatu4/subgraphs/analytics/v1.0.0/gn",
+    },
+    start: "2026-08-13",
+    totalVolume: { factory: "factories", field: "totalVolumeUSD" },
+    totalFees: { factory: "factories", field: "totalFeesUSD" },
+    feesPercent: {
+      type: "fees",
+      Fees: 100,
+      UserFees: 100,
+      Revenue: 10,
+      ProtocolRevenue: 10,
+      SupplySideRevenue: 90,
+    },
+  },
   "sparkdex-v4": {
     graphUrls: {
       [CHAIN.FLARE]: "https://api.goldsky.com/api/public/project_cm1tgcbwdqg8b01un9jf4a64o/subgraphs/sparkdex-v4/latest/gn",


### PR DESCRIPTION
Adding volume and fees for already listed Morpheus on Robinhood.

- Protocol: https://defillama.com/protocol/morpheus
- Subgraph: Goldsky analytics
- Fee split: 10% protocol / 90% LPs (`communityFee = 100/1000`)

Please also add the website, it is missing on the listing:
https://hood.morpheus.farm/swap