### PR TITLE
feat(fees): add adapter for GrowStreams

### DIFF
--- a/fees/vara-grow-streams/index.ts
+++ b/fees/vara-grow-streams/index.ts
@@ -1,99 +1,33 @@
+import { PromisePool } from "@supercharge/promise-pool";
 import type { FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
+import { METRIC } from "../../helpers/metrics";
 import { postURL } from "../../utils/fetchURL";
-import { PromisePool } from "@supercharge/promise-pool";
 
-// Vara RPC - public Gear node for Sails queries via gear_calculateReplyForHandle
-// Source: https://github.com/DefiLlama/DefiLlama-Adapters/blob/main/projects/vara-ethereum-bridge/index.js
-// Source: https://github.com/DefiLlama/DefiLlama-Adapters/blob/main/projects/vara-rivrdex/index.js
 const VARA_RPC = "https://rpc.vara.network";
-
-// StreamCore Sails program - on-chain streaming state machine (StreamService)
-// IDL is displayed at "Metadata/Sails" tab of Explorer
-// Explorer: https://idea.gear-tech.io/programs/0x8298c2eea5c6bbe55a9cfe72283b5399098fd6a54d9a2a14c2bedba8eea50659?node=wss%3A%2F%2Frpc.vara.network
-// Verified via GetConfig fee_bps=250 at 2026-08-25
 const STREAM_CORE = "0x8298c2eea5c6bbe55a9cfe72283b5399098fd6a54d9a2a14c2bedba8eea50659";
-
-// wVARA VFT - underlying token for streams (token field in StreamCreated events)
-// IDL is displayed at "Metadata/Sails" tab of Explorer
-// Explorer: https://idea.gear-tech.io/programs/0xf5e9cb1d1e46b0cda6578dd1684b30f281a45dfaa390e4945b7bfc8ab3e27f3d?node=wss%3A%2F%2Frpc.vara.network
-// Source: https://github.com/DefiLlama/DefiLlama-Adapters/blob/main/projects/vara-rivrdex/index.js
-// Note: all 2,200 streams observed use this token (growstreams.xyz)
-const WVARA = "0xf5e9cb1d1e46b0cda6578dd1684b30f281a45dfaa390e4945b7bfc8ab3e27f3d";
-
-// Hex without 0x for SCALE actor_id comparison (as stored on-chain)
-const WVARA_HEX = WVARA.slice(2).toLowerCase();
-
-// Zero account for gear_calculateReplyForHandle read-only queries
-// Source: https://github.com/DefiLlama/DefiLlama-Adapters/blob/main/projects/vara-ethereum-bridge/index.js
-// Source: https://github.com/DefiLlama/DefiLlama-Adapters/blob/main/projects/vara-rivrdex/index.js
+const WVARA = "f5e9cb1d1e46b0cda6578dd1684b30f281a45dfaa390e4945b7bfc8ab3e27f3d";
 const ZERO_ACCOUNT = "0x" + "0".repeat(64);
-
-// Gas limit for gear_calculateReplyForHandle - covers Sails query decoding
-// Source: https://github.com/DefiLlama/DefiLlama-Adapters/blob/main/projects/vara-ethereum-bridge/index.js
-// Source: https://github.com/DefiLlama/DefiLlama-Adapters/blob/main/projects/vara-rivrdex/index.js
 const GAS_LIMIT = 750000000000;
-
-// VARA decimals - 1 VARA = 1e12 planck, used for CG pricing and fee accounting
-// Source: https://github.com/DefiLlama/DefiLlama-Adapters/blob/main/projects/vara-grow-streams/index.js
 const VARA_DECIMALS = 1e12;
-
-const STREAMING_FEES = "Streaming Fees";
-const STREAMING_FEES_TO_TREASURY = "Streaming Fees To Treasury";
-const STREAMING_VOLUME = "Streaming Volume";
 
 function scaleString(value: string): Buffer {
   const bytes = Buffer.from(value, "utf8");
-  if (bytes.length >= 64) throw new Error("vara-grow-streams: route segment too long");
   return Buffer.concat([Buffer.from([bytes.length << 2]), bytes]);
 }
 function route(service: string, method: string): Buffer {
   return Buffer.concat([scaleString(service), scaleString(method)]);
 }
 
-const ROUTE_TOTAL = route("StreamService", "TotalStreams");
-const ROUTE_ACTIVE = route("StreamService", "ActiveStreams");
 const ROUTE_CONFIG = route("StreamService", "GetConfig");
 const ROUTE_GETSTREAM = route("StreamService", "GetStream");
 
-function u64LE(buf: Buffer, offset = 0): number {
+function u64LE(buf: Buffer, offset = 0) {
   return Number(buf.readBigUInt64LE(offset));
 }
-function u128LE(buf: Buffer, offset = 0): bigint {
-  const lo = buf.readBigUInt64LE(offset);
-  const hi = buf.readBigUInt64LE(offset + 8);
-  return lo + (hi << 64n);
-}
 
-type Config = {
-  admin: string;
-  minBufferSeconds: number;
-  nextStreamId: number;
-  tokenVault: string;
-  superTokenCount: number;
-  feeBps: number;
-  treasury: string;
-};
-
-type Stream = {
-  id: number;
-  sender: string;
-  receiver: string;
-  token: string; // hex without 0x
-  flowRate: bigint;
-  startTime: number;
-  lastUpdate: number;
-  deposited: bigint;
-  withdrawn: bigint;
-  streamed: bigint;
-  status: number; // 0 Active, 1 Paused, 2 Stopped
-};
-
-async function sleep(ms: number) {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
 async function rpcCall(program: string, payloadHex: string): Promise<Buffer> {
-  let lastErr: any;
+  let lastErr: unknown;
   for (let attempt = 0; attempt < 6; attempt++) {
     try {
       const res: any = await postURL(
@@ -101,23 +35,17 @@ async function rpcCall(program: string, payloadHex: string): Promise<Buffer> {
         { jsonrpc: "2.0", id: 1, method: "gear_calculateReplyForHandle", params: [ZERO_ACCOUNT, program, payloadHex, GAS_LIMIT, 0] },
         1
       );
-      if (res.error) throw new Error(`gear_calculateReplyForHandle failed: ${JSON.stringify(res.error)}`);
+      if (res.error) throw new Error(JSON.stringify(res.error));
       const result = res.result;
-      if (!result || !result.payload || result.payload === "0x" || !result.code?.Success) {
-        throw new Error(`failed reply from ${program}: ${JSON.stringify(result?.code)} payload=${result?.payload}`);
+      if (!result?.payload || result.payload === "0x" || !result.code?.Success) {
+        throw new Error(`failed reply: ${JSON.stringify(result?.code)}`);
       }
       return Buffer.from(result.payload.slice(2), "hex");
-    } catch (e: any) {
+    } catch (e) {
       lastErr = e;
-      const msg = String(e?.message ?? e);
-      const is429 = msg.includes("429") || String(e?.axiosError ?? "").includes("429") || msg.includes("Too Many Requests");
-      if (is429 && attempt < 5) {
-        const backoff = 400 * Math.pow(2, attempt) + Math.random() * 200;
-        await sleep(backoff);
-        continue;
-      }
-      if (attempt < 2) {
-        await sleep(200 * (attempt + 1));
+      const msg = String((e as any)?.message ?? e);
+      if (attempt < 5 && (msg.includes("429") || msg.includes("Too Many Requests") || attempt < 2)) {
+        await new Promise((r) => setTimeout(r, 400 * 2 ** attempt + Math.random() * 200));
         continue;
       }
       throw e;
@@ -126,192 +54,89 @@ async function rpcCall(program: string, payloadHex: string): Promise<Buffer> {
   throw lastErr;
 }
 
-function decodeTotalStreams(buf: Buffer): number {
-  if (!buf.subarray(0, ROUTE_TOTAL.length).equals(ROUTE_TOTAL)) throw new Error("vara-grow-streams: malformed TotalStreams reply");
-  const rest = buf.subarray(ROUTE_TOTAL.length);
-  if (rest.length < 8) throw new Error("vara-grow-streams: TotalStreams reply too short");
-  return u64LE(rest, 0);
-}
-function decodeActiveStreams(buf: Buffer): number {
-  if (!buf.subarray(0, ROUTE_ACTIVE.length).equals(ROUTE_ACTIVE)) throw new Error("vara-grow-streams: malformed ActiveStreams reply");
-  const rest = buf.subarray(ROUTE_ACTIVE.length);
-  if (rest.length < 8) throw new Error("vara-grow-streams: ActiveStreams reply too short");
-  return u64LE(rest, 0);
-}
-function decodeConfig(buf: Buffer): Config {
-  if (!buf.subarray(0, ROUTE_CONFIG.length).equals(ROUTE_CONFIG)) throw new Error("vara-grow-streams: malformed GetConfig reply");
+type Stream = { startTime: number; deposited: bigint };
+
+function decodeConfig(buf: Buffer): { nextStreamId: number; feeBps: number } {
+  if (!buf.subarray(0, ROUTE_CONFIG.length).equals(ROUTE_CONFIG)) throw new Error("malformed GetConfig");
   const rest = buf.subarray(ROUTE_CONFIG.length);
-  let off = 0;
-  const admin = "0x" + rest.subarray(off, off + 32).toString("hex"); off += 32;
-  const minBufferSeconds = u64LE(rest, off); off += 8;
-  const nextStreamId = u64LE(rest, off); off += 8;
-  const tokenVault = "0x" + rest.subarray(off, off + 32).toString("hex"); off += 32;
-  const superTokenCount = rest.readUInt32LE(off); off += 4;
-  const feeBps = rest.readUInt16LE(off); off += 2;
-  const treasury = "0x" + rest.subarray(off, off + 32).toString("hex"); off += 32;
-  return { admin, minBufferSeconds, nextStreamId, tokenVault, superTokenCount, feeBps, treasury };
+  // admin(32) minBuffer(8) nextStreamId(8) tokenVault(32) superTokenCount(4) feeBps(2)
+  return { nextStreamId: u64LE(rest, 40), feeBps: rest.readUInt16LE(84) };
 }
-function decodeStream(buf: Buffer): Stream | null {
-  if (!buf.subarray(0, ROUTE_GETSTREAM.length).equals(ROUTE_GETSTREAM)) throw new Error("vara-grow-streams: malformed GetStream reply");
+
+function decodeStream(buf: Buffer): { token: string; startTime: number; deposited: bigint } | null {
+  if (!buf.subarray(0, ROUTE_GETSTREAM.length).equals(ROUTE_GETSTREAM)) throw new Error("malformed GetStream");
   const rest = buf.subarray(ROUTE_GETSTREAM.length);
-  if (rest.length === 0) return null;
-  const opt = rest[0];
-  if (opt === 0) return null;
-  if (opt !== 1) throw new Error(`vara-grow-streams: unexpected GetStream opt ${opt}`);
-  let off = 1;
-  const id = u64LE(rest, off); off += 8;
-  const sender = rest.subarray(off, off + 32).toString("hex"); off += 32;
-  const receiver = rest.subarray(off, off + 32).toString("hex"); off += 32;
-  const token = rest.subarray(off, off + 32).toString("hex"); off += 32;
-  const flowRate = u128LE(rest, off); off += 16;
-  const startTime = u64LE(rest, off); off += 8;
-  const lastUpdate = u64LE(rest, off); off += 8;
-  const deposited = u128LE(rest, off); off += 16;
-  const withdrawn = u128LE(rest, off); off += 16;
-  const streamed = u128LE(rest, off); off += 16;
-  const status = rest[off];
-  return { id, sender, receiver, token, flowRate, startTime, lastUpdate, deposited, withdrawn, streamed, status };
+  if (rest.length === 0 || rest[0] === 0) return null;
+  if (rest[0] !== 1) throw new Error(`unexpected GetStream opt ${rest[0]}`);
+  // opt(1) id(8) sender(32) receiver(32) token(32) flowRate(16) startTime(8) lastUpdate(8) deposited(16)
+  const token = rest.subarray(73, 105).toString("hex");
+  const startTime = u64LE(rest, 121);
+  const deposited = rest.readBigUInt64LE(137) + (rest.readBigUInt64LE(145) << 64n);
+  return { token, startTime, deposited };
 }
 
-type Snapshot = {
-  totalStreams: number;
-  activeStreams: number;
-  config: Config;
-  wvaraStreams: Stream[];
-  // stats for logging / methodology
-  statusCounts: Record<string, number>;
-  totalDepositedAll: bigint;
-  totalStreamedAll: bigint;
-};
-
-let cachedSnapshot: Promise<Snapshot> | undefined;
-function getSnapshot(): Promise<Snapshot> {
-  if (!cachedSnapshot) {
-    cachedSnapshot = (async (): Promise<Snapshot> => {
-      const totalBufP = rpcCall(STREAM_CORE, "0x" + ROUTE_TOTAL.toString("hex"));
-      const activeBufP = rpcCall(STREAM_CORE, "0x" + ROUTE_ACTIVE.toString("hex"));
-      const configBufP = rpcCall(STREAM_CORE, "0x" + ROUTE_CONFIG.toString("hex"));
-      const [totalBuf, activeBuf, configBuf] = await Promise.all([totalBufP, activeBufP, configBufP]);
-      const totalStreams = decodeTotalStreams(totalBuf);
-      const activeStreams = decodeActiveStreams(activeBuf);
-      const config = decodeConfig(configBuf);
-
-      // fetch all streams - ids are dense 1..nextStreamId-1; TotalStreams may lag nextStreamId.
-      // Historical note: GrowStreams never physically deletes a Stream; Stop/Pause only flips StreamStatus
-      // (Active 0 / Paused 1 / Stopped 2) - see stream-core.idl. So GetStream returning None (opt 0) means
-      // never-created id, not a deleted historical stream. Reading current state + filtering by start_time
-      // therefore preserves history without needing archival block queries or event replay. If deletion
-      // were introduced, this must switch to events or historical `at` block queries (gear_calculateReplyForHandle supports `at`).
-      const upper = Math.max(totalStreams, config.nextStreamId - 1);
-      const ids = Array.from({ length: upper }, (_, i) => i + 1); // ids start at 1; 0 is None
-      const allStreams: Stream[] = [];
-
-      // Bounded PromisePool for non-EVM Vara RPC reads (respects 429 via rpcCall backoff + per-call jitter)
+let cached: Promise<{ feeBps: number; streams: Stream[] }> | undefined;
+function getSnapshot() {
+  if (!cached) {
+    cached = (async () => {
+      const { nextStreamId, feeBps } = decodeConfig(await rpcCall(STREAM_CORE, "0x" + ROUTE_CONFIG.toString("hex")));
+      const ids = Array.from({ length: Math.max(0, nextStreamId - 1) }, (_, i) => i + 1);
       const { results, errors } = await PromisePool.withConcurrency(10).for(ids).process(async (id) => {
-        await sleep(40 + Math.random() * 80); // spread load to avoid burst 429 (replaces manual chunk sleep)
+        await new Promise((r) => setTimeout(r, 40 + Math.random() * 80));
         const idBuf = Buffer.alloc(8);
         idBuf.writeBigUInt64LE(BigInt(id), 0);
-        const p = "0x" + Buffer.concat([ROUTE_GETSTREAM, idBuf]).toString("hex");
-        const buf = await rpcCall(STREAM_CORE, p); // throws on failure - do not swallow, so cache invalidation triggers
-        return decodeStream(buf); // null for never-created id, Stream for existing (including Stopped)
+        return decodeStream(await rpcCall(STREAM_CORE, "0x" + Buffer.concat([ROUTE_GETSTREAM, idBuf]).toString("hex")));
       });
-
-      if (errors.length > 0) {
-        // System-level failure: do not cache partial data - propagate so outer catch invalidates cachedSnapshot
-        // and caller receives no financial metrics rather than under-reported values.
-        throw new Error(`vara-grow-streams: ${errors.length}/${ids.length} GetStream calls failed: ${String((errors[0] as any)?.message ?? errors[0])}`);
-      }
-      for (const s of results as (Stream | null)[]) if (s) allStreams.push(s);
-
-      const wvaraStreams = allStreams.filter((s) => s.token.toLowerCase() === WVARA_HEX);
-      const statusCounts: Record<string, number> = { Active: 0, Paused: 0, Stopped: 0, Other: 0 };
-      let totalDepositedAll = 0n;
-      let totalStreamedAll = 0n;
-      for (const s of wvaraStreams) {
-        totalDepositedAll += s.deposited;
-        totalStreamedAll += s.streamed;
-        if (s.status === 0) statusCounts.Active++;
-        else if (s.status === 1) statusCounts.Paused++;
-        else if (s.status === 2) statusCounts.Stopped++;
-        else statusCounts.Other++;
-      }
-
-      console.info(
-        `vara-grow-streams snapshot: totalStreams=${totalStreams} activeStreams=${activeStreams} wvaraStreams=${wvaraStreams.length} feeBps=${config.feeBps} statusCounts=${JSON.stringify(statusCounts)} totalDeposited=${Number(totalDepositedAll) / VARA_DECIMALS} VARA`
-      );
-
-      return { totalStreams, activeStreams, config, wvaraStreams, statusCounts, totalDepositedAll, totalStreamedAll };
+      if (errors.length) throw new Error(`${errors.length}/${ids.length} GetStream calls failed`);
+      const streams = (results as Awaited<ReturnType<typeof decodeStream>>[])
+        .filter((s): s is NonNullable<typeof s> => !!s && s.token.toLowerCase() === WVARA)
+        .map(({ startTime, deposited }) => ({ startTime, deposited }));
+      return { feeBps, streams };
     })().catch((e) => {
-      // invalidate cache on failure so next call retries
-      cachedSnapshot = undefined;
+      cached = undefined;
       throw e;
     });
   }
-  return cachedSnapshot;
+  return cached;
 }
 
 const fetch = async (options: FetchOptions) => {
   const dailyFees = options.createBalances();
   const dailyRevenue = options.createBalances();
   const dailyVolume = options.createBalances();
-
-  const snap = await getSnapshot();
-  const { wvaraStreams, config } = snap;
-  const feeBps = config.feeBps; // e.g. 250 = 2.5%
-
-  const from = options.fromTimestamp;
-  const to = options.toTimestamp;
+  const { feeBps, streams } = await getSnapshot();
 
   let volumePlancks = 0n;
-  for (const s of wvaraStreams) {
-    if (s.startTime >= from && s.startTime < to) {
-      volumePlancks += s.deposited;
-    }
+  for (const s of streams) {
+    if (s.startTime >= options.fromTimestamp && s.startTime < options.toTimestamp) volumePlancks += s.deposited;
   }
-
   if (volumePlancks > 0n) {
-    const feesPlancks = (volumePlancks * BigInt(feeBps)) / 10000n;
+    const feesVara = Number((volumePlancks * BigInt(feeBps)) / 10000n) / VARA_DECIMALS;
     const volumeVara = Number(volumePlancks) / VARA_DECIMALS;
-    const feesVara = Number(feesPlancks) / VARA_DECIMALS;
-
-    dailyFees.addCGToken("vara-network", feesVara, STREAMING_FEES);
-    dailyRevenue.addCGToken("vara-network", feesVara, STREAMING_FEES_TO_TREASURY);
-    dailyVolume.addCGToken("vara-network", volumeVara, STREAMING_VOLUME);
+    dailyFees.addCGToken("vara-network", feesVara, METRIC.SERVICE_FEES);
+    dailyRevenue.addCGToken("vara-network", feesVara, METRIC.SERVICE_FEES);
+    dailyVolume.addCGToken("vara-network", volumeVara);
   }
 
-  if (volumePlancks > 0n) {
-    console.info(
-      `vara-grow-streams ${options.dateString} ${options.fromTimestamp}->${options.toTimestamp}: volume=${Number(volumePlancks) / VARA_DECIMALS} VARA fees=${Number((volumePlancks * BigInt(feeBps)) / 10000n) / VARA_DECIMALS} VARA totalStreams=${snap.totalStreams}`
-    );
-  }
-
-  return {
-    dailyFees,
-    dailyRevenue,
-    dailyProtocolRevenue: dailyRevenue,
-    dailyVolume,
-  };
+  return { dailyFees, dailyRevenue, dailyProtocolRevenue: dailyRevenue, dailyVolume };
 };
 
 const methodology = {
-  Fees: "2.5% streaming fee (fee_bps from StreamService::GetConfig) applied to every new wVARA stream's initial_deposit (Stream.deposited where token == wVARA 0xf5e9cb1d1e46b0cda6578dd1684b30f281a45dfaa390e4945b7bfc8ab3e27f3d). Daily fees = sum(deposited in day) * fee_bps / 10_000. Historical total streamed = sum of all wVARA deposited across all streams (current TotalStreams).",
-  Revenue: "All streaming fees are retained by the protocol treasury (no supply-side share). Daily revenue == daily fees.",
-  ProtocolRevenue: "100% of streaming fees to treasury (config.treasury).",
-  Volume: "Total wVARA deposited into streams whose start_time falls in the day - approximates money routed through the streaming protocol that day. Cumulative sum equals historical money streamed.",
+  Fees: "fee_bps (StreamService::GetConfig, currently 250 = 2.5%) on each new wVARA stream's deposited amount. Counted on the stream's start_time, so days with no new streams are 0.",
+  Revenue: "All streaming fees (currently 2.5%) go to the protocol treasury.",
+  ProtocolRevenue: "All streaming fees (currently 2.5%) go to the protocol treasury.",
+  Volume: "wVARA deposited into streams whose start_time falls in the window.",
 };
 
 const breakdownMethodology = {
   Fees: {
-    [STREAMING_FEES]: "wVARA streaming fee = deposited * fee_bps / 10_000 for streams created that day (token == wVARA; gVARA super-token underlies wVARA for streaming).",
+    [METRIC.SERVICE_FEES]: "deposited * fee_bps / 10_000 for wVARA streams created in the window.",
   },
   Revenue: {
-    [STREAMING_FEES_TO_TREASURY]: "Full fee to GrowStreams treasury; no LP or staker cut.",
+    [METRIC.SERVICE_FEES]: "Full fee to GrowStreams treasury; no supply-side cut.",
   },
   ProtocolRevenue: {
-    [STREAMING_FEES_TO_TREASURY]: "Swept to treasury via SuperTokenService::CollectFee.",
-  },
-  Volume: {
-    [STREAMING_VOLUME]: "Sum of Stream.deposited for wVARA streams created that day.",
+    [METRIC.SERVICE_FEES]: "Full fee to GrowStreams treasury; no supply-side cut.",
   },
 };
 
@@ -319,9 +144,7 @@ const adapter: SimpleAdapter = {
   version: 2,
   pullHourly: true,
   chains: [CHAIN.VARA],
-  // Launch date is 2026-06-21 (first StreamCreated at 2026-06-21 11:49 UTC, id 1).
-  // Start is set to 2026-06-20 to satisfy hourly validStart (cleanPreviousDay = endTimestamp - 86400) so all 24 hourly slots of 2026-06-21 are queryable.
-  // 2026-06-20 has 0 streams/volume/fees, so no data outside stated scope. Aligns with review: keep 2026-06-20 or document as above.
+  // First StreamCreated is 2026-06-21; start one day earlier so hourly backfill covers that full day.
   start: "2026-06-20",
   fetch,
   methodology,

--- a/fees/vara-grow-streams/index.ts
+++ b/fees/vara-grow-streams/index.ts
@@ -9,14 +9,15 @@ import { PromisePool } from "@supercharge/promise-pool";
 const VARA_RPC = "https://rpc.vara.network";
 
 // StreamCore Sails program - on-chain streaming state machine (StreamService)
-// Source: GrowStreams_IDL_Files/stream-core.idl
+// IDL is displayed at "Metadata/Sails" tab of Explorer
 // Explorer: https://idea.gear-tech.io/programs/0x8298c2eea5c6bbe55a9cfe72283b5399098fd6a54d9a2a14c2bedba8eea50659?node=wss%3A%2F%2Frpc.vara.network
 // Verified via GetConfig fee_bps=250 at 2026-08-25
 const STREAM_CORE = "0x8298c2eea5c6bbe55a9cfe72283b5399098fd6a54d9a2a14c2bedba8eea50659";
 
 // wVARA VFT - underlying token for streams (token field in StreamCreated events)
+// IDL is displayed at "Metadata/Sails" tab of Explorer
+// Explorer: https://idea.gear-tech.io/programs/0xf5e9cb1d1e46b0cda6578dd1684b30f281a45dfaa390e4945b7bfc8ab3e27f3d?node=wss%3A%2F%2Frpc.vara.network
 // Source: https://github.com/DefiLlama/DefiLlama-Adapters/blob/main/projects/vara-rivrdex/index.js
-// Source: GrowStreams_IDL_Files/wvara.idl
 // Note: all 2,200 streams observed use this token (growstreams.xyz)
 const WVARA = "0xf5e9cb1d1e46b0cda6578dd1684b30f281a45dfaa390e4945b7bfc8ab3e27f3d";
 

--- a/fees/vara-grow-streams/index.ts
+++ b/fees/vara-grow-streams/index.ts
@@ -318,6 +318,9 @@ const adapter: SimpleAdapter = {
   version: 2,
   pullHourly: true,
   chains: [CHAIN.VARA],
+  // Launch date is 2026-06-21 (first StreamCreated at 2026-06-21 11:49 UTC, id 1).
+  // Start is set to 2026-06-20 to satisfy hourly validStart (cleanPreviousDay = endTimestamp - 86400) so all 24 hourly slots of 2026-06-21 are queryable.
+  // 2026-06-20 has 0 streams/volume/fees, so no data outside stated scope. Aligns with review: keep 2026-06-20 or document as above.
   start: "2026-06-20",
   fetch,
   methodology,

--- a/fees/vara-grow-streams/index.ts
+++ b/fees/vara-grow-streams/index.ts
@@ -1,13 +1,19 @@
 import type { FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 import { postURL } from "../../utils/fetchURL";
+import { PromisePool } from "@supercharge/promise-pool";
 
+// Vara RPC — public Gear node, also used by DefiLlama TVL adapters (see projects/vara-ethereum-bridge/index.js:7, projects/vara-rivrdex/index.js:3)
 const VARA_RPC = "https://rpc.vara.network";
+// StreamCore Sails program — on-chain streaming state machine (StreamService). Source: GrowStreams_IDL_Files/stream-core.idl + explorer https://idea.gear-tech.io/programs/0x8298c2eea5c6bbe55a9cfe72283b5399098fd6a54d9a2a14c2bedba8eea50659?node=wss%3A%2F%2Frpc.vara.network ; verified via GetConfig fee_bps=250 at 2026-08-25
 const STREAM_CORE = "0x8298c2eea5c6bbe55a9cfe72283b5399098fd6a54d9a2a14c2bedba8eea50659";
+// wVARA VFT — underlying token for streams (token field in StreamCreated events). Source: growstreams.xyz + vara-rivrdex TVL & GrowStreams_IDL_Files/wvara.idl ; all 2,200 streams observed use this token
 const WVARA = "0xf5e9cb1d1e46b0cda6578dd1684b30f281a45dfaa390e4945b7bfc8ab3e27f3d";
 const WVARA_HEX = WVARA.slice(2).toLowerCase();
 const ZERO_ACCOUNT = "0x" + "0".repeat(64);
+// Gas limit for gear_calculateReplyForHandle — 750B covers Sails query decoding (see projects/vara-ethereum-bridge/index.js:10, projects/vara-rivrdex/index.js:5)
 const GAS_LIMIT = 750000000000;
+// VARA has 12 decimals (1 VARA = 1e12 planck) — used for CG pricing. Source: Vara docs / projects/vara-grow-streams/index.js:7 (VARA_DECIMALS=1e12)
 const VARA_DECIMALS = 1e12;
 
 const STREAMING_FEES = "Streaming Fees";
@@ -168,43 +174,30 @@ function getSnapshot(): Promise<Snapshot> {
       const activeStreams = decodeActiveStreams(activeBuf);
       const config = decodeConfig(configBuf);
 
-      // fetch all streams in parallel with limited concurrency
-      // Stream ids are dense from 1 .. nextStreamId-1; TotalStreams may be slightly lower than that if some ids were never used
+      // fetch all streams — ids are dense 1..nextStreamId-1; TotalStreams may lag nextStreamId.
+      // Historical note: GrowStreams never physically deletes a Stream; Stop/Pause only flips StreamStatus
+      // (Active 0 / Paused 1 / Stopped 2) — see stream-core.idl. So GetStream returning None (opt 0) means
+      // never-created id, not a deleted historical stream. Reading current state + filtering by start_time
+      // therefore preserves history without needing archival block queries or event replay. If deletion
+      // were introduced, this must switch to events or historical `at` block queries (gear_calculateReplyForHandle supports `at`).
       const upper = Math.max(totalStreams, config.nextStreamId - 1);
       const ids = Array.from({ length: upper }, (_, i) => i + 1); // ids start at 1; 0 is None
       const allStreams: Stream[] = [];
 
-      // filter out gaps where GetStream returns None (id 0 or deleted)
-      // Chunked fetching to respect Vara RPC rate limits (429)
-      const CHUNK_SIZE = 10;
-      const allResults: (Stream | null)[] = [];
-      let chunkErrors = 0;
-      for (let i = 0; i < ids.length; i += CHUNK_SIZE) {
-        const chunk = ids.slice(i, i + CHUNK_SIZE);
-        const resultsChunk = await Promise.all(
-          chunk.map(async (id) => {
-            const idBuf = Buffer.alloc(8);
-            idBuf.writeBigUInt64LE(BigInt(id), 0);
-            const p = "0x" + Buffer.concat([ROUTE_GETSTREAM, idBuf]).toString("hex");
-            try {
-              const buf = await rpcCall(STREAM_CORE, p);
-              return decodeStream(buf);
-            } catch (e) {
-              chunkErrors++;
-              console.warn(`vara-grow-streams: GetStream ${id} failed: ${(e as any)?.message ?? e}`);
-              return null;
-            }
-          })
-        );
-        allResults.push(...resultsChunk);
-        if (i + CHUNK_SIZE < ids.length) await sleep(120);
-      }
-      const results = allResults;
-      const errors: any[] = chunkErrors ? [{ message: `${chunkErrors} GetStream calls failed in chunks` }] : [];
+      // Bounded PromisePool for non-EVM Vara RPC reads (respects 429 via rpcCall backoff + per-call jitter)
+      const { results, errors } = await PromisePool.withConcurrency(10).for(ids).process(async (id) => {
+        await sleep(40 + Math.random() * 80); // spread load to avoid burst 429 (replaces manual chunk sleep)
+        const idBuf = Buffer.alloc(8);
+        idBuf.writeBigUInt64LE(BigInt(id), 0);
+        const p = "0x" + Buffer.concat([ROUTE_GETSTREAM, idBuf]).toString("hex");
+        const buf = await rpcCall(STREAM_CORE, p); // throws on failure — do not swallow, so cache invalidation triggers
+        return decodeStream(buf); // null for never-created id, Stream for existing (including Stopped)
+      });
 
       if (errors.length > 0) {
-        // log but don't hard fail unless all failed
-        console.warn(`vara-grow-streams: ${errors.length}/${ids.length} GetStream calls failed`, (errors[0] as any)?.message ?? errors[0]);
+        // System-level failure: do not cache partial data — propagate so outer catch invalidates cachedSnapshot
+        // and caller receives no financial metrics rather than under-reported values.
+        throw new Error(`vara-grow-streams: ${errors.length}/${ids.length} GetStream calls failed: ${String((errors[0] as any)?.message ?? errors[0])}`);
       }
       for (const s of results as (Stream | null)[]) if (s) allStreams.push(s);
 
@@ -264,12 +257,9 @@ const fetch = async (options: FetchOptions) => {
     dailyVolume.addCGToken("vara-network", volumeVara, STREAMING_VOLUME);
   }
 
-  // Log per-day diagnostics (useful for backfills)
-  // Includes current global stats so dashboards can reference them in methodology
-  if (options.startOfDay % 86400 === 0) {
-    // only log once per day invocation to avoid spam in hourly mode
+  if (volumePlancks > 0n) {
     console.info(
-      `vara-grow-streams day ${options.dateString}: volumePlancks=${volumePlancks} feesBps=${feeBps} totalStreams=${snap.totalStreams} activeStreams=${snap.activeStreams} wvaraDepositedTotal=${Number(snap.totalDepositedAll) / VARA_DECIMALS}`
+      `vara-grow-streams ${options.dateString} ${options.fromTimestamp}->${options.toTimestamp}: volume=${Number(volumePlancks) / VARA_DECIMALS} VARA fees=${Number((volumePlancks * BigInt(feeBps)) / 10000n) / VARA_DECIMALS} VARA totalStreams=${snap.totalStreams}`
     );
   }
 
@@ -304,9 +294,10 @@ const breakdownMethodology = {
 };
 
 const adapter: SimpleAdapter = {
-  version: 1,
+  version: 2,
+  pullHourly: true,
   chains: [CHAIN.VARA],
-  start: "2026-06-21",
+  start: "2026-06-20",
   fetch,
   methodology,
   breakdownMethodology,

--- a/fees/vara-grow-streams/index.ts
+++ b/fees/vara-grow-streams/index.ts
@@ -3,17 +3,38 @@ import { CHAIN } from "../../helpers/chains";
 import { postURL } from "../../utils/fetchURL";
 import { PromisePool } from "@supercharge/promise-pool";
 
-// Vara RPC — public Gear node, also used by DefiLlama TVL adapters (see projects/vara-ethereum-bridge/index.js:7, projects/vara-rivrdex/index.js:3)
+// Vara RPC - public Gear node for Sails queries via gear_calculateReplyForHandle
+// Source: https://github.com/DefiLlama/DefiLlama-Adapters/blob/main/projects/vara-ethereum-bridge/index.js
+// Source: https://github.com/DefiLlama/DefiLlama-Adapters/blob/main/projects/vara-rivrdex/index.js
 const VARA_RPC = "https://rpc.vara.network";
-// StreamCore Sails program — on-chain streaming state machine (StreamService). Source: GrowStreams_IDL_Files/stream-core.idl + explorer https://idea.gear-tech.io/programs/0x8298c2eea5c6bbe55a9cfe72283b5399098fd6a54d9a2a14c2bedba8eea50659?node=wss%3A%2F%2Frpc.vara.network ; verified via GetConfig fee_bps=250 at 2026-08-25
+
+// StreamCore Sails program - on-chain streaming state machine (StreamService)
+// Source: GrowStreams_IDL_Files/stream-core.idl
+// Explorer: https://idea.gear-tech.io/programs/0x8298c2eea5c6bbe55a9cfe72283b5399098fd6a54d9a2a14c2bedba8eea50659?node=wss%3A%2F%2Frpc.vara.network
+// Verified via GetConfig fee_bps=250 at 2026-08-25
 const STREAM_CORE = "0x8298c2eea5c6bbe55a9cfe72283b5399098fd6a54d9a2a14c2bedba8eea50659";
-// wVARA VFT — underlying token for streams (token field in StreamCreated events). Source: growstreams.xyz + vara-rivrdex TVL & GrowStreams_IDL_Files/wvara.idl ; all 2,200 streams observed use this token
+
+// wVARA VFT - underlying token for streams (token field in StreamCreated events)
+// Source: https://github.com/DefiLlama/DefiLlama-Adapters/blob/main/projects/vara-rivrdex/index.js
+// Source: GrowStreams_IDL_Files/wvara.idl
+// Note: all 2,200 streams observed use this token (growstreams.xyz)
 const WVARA = "0xf5e9cb1d1e46b0cda6578dd1684b30f281a45dfaa390e4945b7bfc8ab3e27f3d";
+
+// Hex without 0x for SCALE actor_id comparison (as stored on-chain)
 const WVARA_HEX = WVARA.slice(2).toLowerCase();
+
+// Zero account for gear_calculateReplyForHandle read-only queries
+// Source: https://github.com/DefiLlama/DefiLlama-Adapters/blob/main/projects/vara-ethereum-bridge/index.js
+// Source: https://github.com/DefiLlama/DefiLlama-Adapters/blob/main/projects/vara-rivrdex/index.js
 const ZERO_ACCOUNT = "0x" + "0".repeat(64);
-// Gas limit for gear_calculateReplyForHandle — 750B covers Sails query decoding (see projects/vara-ethereum-bridge/index.js:10, projects/vara-rivrdex/index.js:5)
+
+// Gas limit for gear_calculateReplyForHandle - covers Sails query decoding
+// Source: https://github.com/DefiLlama/DefiLlama-Adapters/blob/main/projects/vara-ethereum-bridge/index.js
+// Source: https://github.com/DefiLlama/DefiLlama-Adapters/blob/main/projects/vara-rivrdex/index.js
 const GAS_LIMIT = 750000000000;
-// VARA has 12 decimals (1 VARA = 1e12 planck) — used for CG pricing. Source: Vara docs / projects/vara-grow-streams/index.js:7 (VARA_DECIMALS=1e12)
+
+// VARA decimals - 1 VARA = 1e12 planck, used for CG pricing and fee accounting
+// Source: https://github.com/DefiLlama/DefiLlama-Adapters/blob/main/projects/vara-grow-streams/index.js
 const VARA_DECIMALS = 1e12;
 
 const STREAMING_FEES = "Streaming Fees";
@@ -174,9 +195,9 @@ function getSnapshot(): Promise<Snapshot> {
       const activeStreams = decodeActiveStreams(activeBuf);
       const config = decodeConfig(configBuf);
 
-      // fetch all streams — ids are dense 1..nextStreamId-1; TotalStreams may lag nextStreamId.
+      // fetch all streams - ids are dense 1..nextStreamId-1; TotalStreams may lag nextStreamId.
       // Historical note: GrowStreams never physically deletes a Stream; Stop/Pause only flips StreamStatus
-      // (Active 0 / Paused 1 / Stopped 2) — see stream-core.idl. So GetStream returning None (opt 0) means
+      // (Active 0 / Paused 1 / Stopped 2) - see stream-core.idl. So GetStream returning None (opt 0) means
       // never-created id, not a deleted historical stream. Reading current state + filtering by start_time
       // therefore preserves history without needing archival block queries or event replay. If deletion
       // were introduced, this must switch to events or historical `at` block queries (gear_calculateReplyForHandle supports `at`).
@@ -190,12 +211,12 @@ function getSnapshot(): Promise<Snapshot> {
         const idBuf = Buffer.alloc(8);
         idBuf.writeBigUInt64LE(BigInt(id), 0);
         const p = "0x" + Buffer.concat([ROUTE_GETSTREAM, idBuf]).toString("hex");
-        const buf = await rpcCall(STREAM_CORE, p); // throws on failure — do not swallow, so cache invalidation triggers
+        const buf = await rpcCall(STREAM_CORE, p); // throws on failure - do not swallow, so cache invalidation triggers
         return decodeStream(buf); // null for never-created id, Stream for existing (including Stopped)
       });
 
       if (errors.length > 0) {
-        // System-level failure: do not cache partial data — propagate so outer catch invalidates cachedSnapshot
+        // System-level failure: do not cache partial data - propagate so outer catch invalidates cachedSnapshot
         // and caller receives no financial metrics rather than under-reported values.
         throw new Error(`vara-grow-streams: ${errors.length}/${ids.length} GetStream calls failed: ${String((errors[0] as any)?.message ?? errors[0])}`);
       }
@@ -275,7 +296,7 @@ const methodology = {
   Fees: "2.5% streaming fee (fee_bps from StreamService::GetConfig) applied to every new wVARA stream's initial_deposit (Stream.deposited where token == wVARA 0xf5e9cb1d1e46b0cda6578dd1684b30f281a45dfaa390e4945b7bfc8ab3e27f3d). Daily fees = sum(deposited in day) * fee_bps / 10_000. Historical total streamed = sum of all wVARA deposited across all streams (current TotalStreams).",
   Revenue: "All streaming fees are retained by the protocol treasury (no supply-side share). Daily revenue == daily fees.",
   ProtocolRevenue: "100% of streaming fees to treasury (config.treasury).",
-  Volume: "Total wVARA deposited into streams whose start_time falls in the day — approximates money routed through the streaming protocol that day. Cumulative sum equals historical money streamed.",
+  Volume: "Total wVARA deposited into streams whose start_time falls in the day - approximates money routed through the streaming protocol that day. Cumulative sum equals historical money streamed.",
 };
 
 const breakdownMethodology = {

--- a/fees/vara-grow-streams/index.ts
+++ b/fees/vara-grow-streams/index.ts
@@ -1,0 +1,315 @@
+import type { FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import { postURL } from "../../utils/fetchURL";
+
+const VARA_RPC = "https://rpc.vara.network";
+const STREAM_CORE = "0x8298c2eea5c6bbe55a9cfe72283b5399098fd6a54d9a2a14c2bedba8eea50659";
+const WVARA = "0xf5e9cb1d1e46b0cda6578dd1684b30f281a45dfaa390e4945b7bfc8ab3e27f3d";
+const WVARA_HEX = WVARA.slice(2).toLowerCase();
+const ZERO_ACCOUNT = "0x" + "0".repeat(64);
+const GAS_LIMIT = 750000000000;
+const VARA_DECIMALS = 1e12;
+
+const STREAMING_FEES = "Streaming Fees";
+const STREAMING_FEES_TO_TREASURY = "Streaming Fees To Treasury";
+const STREAMING_VOLUME = "Streaming Volume";
+
+function scaleString(value: string): Buffer {
+  const bytes = Buffer.from(value, "utf8");
+  if (bytes.length >= 64) throw new Error("vara-grow-streams: route segment too long");
+  return Buffer.concat([Buffer.from([bytes.length << 2]), bytes]);
+}
+function route(service: string, method: string): Buffer {
+  return Buffer.concat([scaleString(service), scaleString(method)]);
+}
+
+const ROUTE_TOTAL = route("StreamService", "TotalStreams");
+const ROUTE_ACTIVE = route("StreamService", "ActiveStreams");
+const ROUTE_CONFIG = route("StreamService", "GetConfig");
+const ROUTE_GETSTREAM = route("StreamService", "GetStream");
+
+function u64LE(buf: Buffer, offset = 0): number {
+  return Number(buf.readBigUInt64LE(offset));
+}
+function u128LE(buf: Buffer, offset = 0): bigint {
+  const lo = buf.readBigUInt64LE(offset);
+  const hi = buf.readBigUInt64LE(offset + 8);
+  return lo + (hi << 64n);
+}
+
+type Config = {
+  admin: string;
+  minBufferSeconds: number;
+  nextStreamId: number;
+  tokenVault: string;
+  superTokenCount: number;
+  feeBps: number;
+  treasury: string;
+};
+
+type Stream = {
+  id: number;
+  sender: string;
+  receiver: string;
+  token: string; // hex without 0x
+  flowRate: bigint;
+  startTime: number;
+  lastUpdate: number;
+  deposited: bigint;
+  withdrawn: bigint;
+  streamed: bigint;
+  status: number; // 0 Active, 1 Paused, 2 Stopped
+};
+
+async function sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+async function rpcCall(program: string, payloadHex: string): Promise<Buffer> {
+  let lastErr: any;
+  for (let attempt = 0; attempt < 6; attempt++) {
+    try {
+      const res: any = await postURL(
+        VARA_RPC,
+        { jsonrpc: "2.0", id: 1, method: "gear_calculateReplyForHandle", params: [ZERO_ACCOUNT, program, payloadHex, GAS_LIMIT, 0] },
+        1
+      );
+      if (res.error) throw new Error(`gear_calculateReplyForHandle failed: ${JSON.stringify(res.error)}`);
+      const result = res.result;
+      if (!result || !result.payload || result.payload === "0x" || !result.code?.Success) {
+        throw new Error(`failed reply from ${program}: ${JSON.stringify(result?.code)} payload=${result?.payload}`);
+      }
+      return Buffer.from(result.payload.slice(2), "hex");
+    } catch (e: any) {
+      lastErr = e;
+      const msg = String(e?.message ?? e);
+      const is429 = msg.includes("429") || String(e?.axiosError ?? "").includes("429") || msg.includes("Too Many Requests");
+      if (is429 && attempt < 5) {
+        const backoff = 400 * Math.pow(2, attempt) + Math.random() * 200;
+        await sleep(backoff);
+        continue;
+      }
+      if (attempt < 2) {
+        await sleep(200 * (attempt + 1));
+        continue;
+      }
+      throw e;
+    }
+  }
+  throw lastErr;
+}
+
+function decodeTotalStreams(buf: Buffer): number {
+  if (!buf.subarray(0, ROUTE_TOTAL.length).equals(ROUTE_TOTAL)) throw new Error("vara-grow-streams: malformed TotalStreams reply");
+  const rest = buf.subarray(ROUTE_TOTAL.length);
+  if (rest.length < 8) throw new Error("vara-grow-streams: TotalStreams reply too short");
+  return u64LE(rest, 0);
+}
+function decodeActiveStreams(buf: Buffer): number {
+  if (!buf.subarray(0, ROUTE_ACTIVE.length).equals(ROUTE_ACTIVE)) throw new Error("vara-grow-streams: malformed ActiveStreams reply");
+  const rest = buf.subarray(ROUTE_ACTIVE.length);
+  if (rest.length < 8) throw new Error("vara-grow-streams: ActiveStreams reply too short");
+  return u64LE(rest, 0);
+}
+function decodeConfig(buf: Buffer): Config {
+  if (!buf.subarray(0, ROUTE_CONFIG.length).equals(ROUTE_CONFIG)) throw new Error("vara-grow-streams: malformed GetConfig reply");
+  const rest = buf.subarray(ROUTE_CONFIG.length);
+  let off = 0;
+  const admin = "0x" + rest.subarray(off, off + 32).toString("hex"); off += 32;
+  const minBufferSeconds = u64LE(rest, off); off += 8;
+  const nextStreamId = u64LE(rest, off); off += 8;
+  const tokenVault = "0x" + rest.subarray(off, off + 32).toString("hex"); off += 32;
+  const superTokenCount = rest.readUInt32LE(off); off += 4;
+  const feeBps = rest.readUInt16LE(off); off += 2;
+  const treasury = "0x" + rest.subarray(off, off + 32).toString("hex"); off += 32;
+  return { admin, minBufferSeconds, nextStreamId, tokenVault, superTokenCount, feeBps, treasury };
+}
+function decodeStream(buf: Buffer): Stream | null {
+  if (!buf.subarray(0, ROUTE_GETSTREAM.length).equals(ROUTE_GETSTREAM)) throw new Error("vara-grow-streams: malformed GetStream reply");
+  const rest = buf.subarray(ROUTE_GETSTREAM.length);
+  if (rest.length === 0) return null;
+  const opt = rest[0];
+  if (opt === 0) return null;
+  if (opt !== 1) throw new Error(`vara-grow-streams: unexpected GetStream opt ${opt}`);
+  let off = 1;
+  const id = u64LE(rest, off); off += 8;
+  const sender = rest.subarray(off, off + 32).toString("hex"); off += 32;
+  const receiver = rest.subarray(off, off + 32).toString("hex"); off += 32;
+  const token = rest.subarray(off, off + 32).toString("hex"); off += 32;
+  const flowRate = u128LE(rest, off); off += 16;
+  const startTime = u64LE(rest, off); off += 8;
+  const lastUpdate = u64LE(rest, off); off += 8;
+  const deposited = u128LE(rest, off); off += 16;
+  const withdrawn = u128LE(rest, off); off += 16;
+  const streamed = u128LE(rest, off); off += 16;
+  const status = rest[off];
+  return { id, sender, receiver, token, flowRate, startTime, lastUpdate, deposited, withdrawn, streamed, status };
+}
+
+type Snapshot = {
+  totalStreams: number;
+  activeStreams: number;
+  config: Config;
+  wvaraStreams: Stream[];
+  // stats for logging / methodology
+  statusCounts: Record<string, number>;
+  totalDepositedAll: bigint;
+  totalStreamedAll: bigint;
+};
+
+let cachedSnapshot: Promise<Snapshot> | undefined;
+function getSnapshot(): Promise<Snapshot> {
+  if (!cachedSnapshot) {
+    cachedSnapshot = (async (): Promise<Snapshot> => {
+      const totalBufP = rpcCall(STREAM_CORE, "0x" + ROUTE_TOTAL.toString("hex"));
+      const activeBufP = rpcCall(STREAM_CORE, "0x" + ROUTE_ACTIVE.toString("hex"));
+      const configBufP = rpcCall(STREAM_CORE, "0x" + ROUTE_CONFIG.toString("hex"));
+      const [totalBuf, activeBuf, configBuf] = await Promise.all([totalBufP, activeBufP, configBufP]);
+      const totalStreams = decodeTotalStreams(totalBuf);
+      const activeStreams = decodeActiveStreams(activeBuf);
+      const config = decodeConfig(configBuf);
+
+      // fetch all streams in parallel with limited concurrency
+      // Stream ids are dense from 1 .. nextStreamId-1; TotalStreams may be slightly lower than that if some ids were never used
+      const upper = Math.max(totalStreams, config.nextStreamId - 1);
+      const ids = Array.from({ length: upper }, (_, i) => i + 1); // ids start at 1; 0 is None
+      const allStreams: Stream[] = [];
+
+      // filter out gaps where GetStream returns None (id 0 or deleted)
+      // Chunked fetching to respect Vara RPC rate limits (429)
+      const CHUNK_SIZE = 10;
+      const allResults: (Stream | null)[] = [];
+      let chunkErrors = 0;
+      for (let i = 0; i < ids.length; i += CHUNK_SIZE) {
+        const chunk = ids.slice(i, i + CHUNK_SIZE);
+        const resultsChunk = await Promise.all(
+          chunk.map(async (id) => {
+            const idBuf = Buffer.alloc(8);
+            idBuf.writeBigUInt64LE(BigInt(id), 0);
+            const p = "0x" + Buffer.concat([ROUTE_GETSTREAM, idBuf]).toString("hex");
+            try {
+              const buf = await rpcCall(STREAM_CORE, p);
+              return decodeStream(buf);
+            } catch (e) {
+              chunkErrors++;
+              console.warn(`vara-grow-streams: GetStream ${id} failed: ${(e as any)?.message ?? e}`);
+              return null;
+            }
+          })
+        );
+        allResults.push(...resultsChunk);
+        if (i + CHUNK_SIZE < ids.length) await sleep(120);
+      }
+      const results = allResults;
+      const errors: any[] = chunkErrors ? [{ message: `${chunkErrors} GetStream calls failed in chunks` }] : [];
+
+      if (errors.length > 0) {
+        // log but don't hard fail unless all failed
+        console.warn(`vara-grow-streams: ${errors.length}/${ids.length} GetStream calls failed`, (errors[0] as any)?.message ?? errors[0]);
+      }
+      for (const s of results as (Stream | null)[]) if (s) allStreams.push(s);
+
+      const wvaraStreams = allStreams.filter((s) => s.token.toLowerCase() === WVARA_HEX);
+      const statusCounts: Record<string, number> = { Active: 0, Paused: 0, Stopped: 0, Other: 0 };
+      let totalDepositedAll = 0n;
+      let totalStreamedAll = 0n;
+      for (const s of wvaraStreams) {
+        totalDepositedAll += s.deposited;
+        totalStreamedAll += s.streamed;
+        if (s.status === 0) statusCounts.Active++;
+        else if (s.status === 1) statusCounts.Paused++;
+        else if (s.status === 2) statusCounts.Stopped++;
+        else statusCounts.Other++;
+      }
+
+      console.info(
+        `vara-grow-streams snapshot: totalStreams=${totalStreams} activeStreams=${activeStreams} wvaraStreams=${wvaraStreams.length} feeBps=${config.feeBps} statusCounts=${JSON.stringify(statusCounts)} totalDeposited=${Number(totalDepositedAll) / VARA_DECIMALS} VARA`
+      );
+
+      return { totalStreams, activeStreams, config, wvaraStreams, statusCounts, totalDepositedAll, totalStreamedAll };
+    })().catch((e) => {
+      // invalidate cache on failure so next call retries
+      cachedSnapshot = undefined;
+      throw e;
+    });
+  }
+  return cachedSnapshot;
+}
+
+const fetch = async (options: FetchOptions) => {
+  const dailyFees = options.createBalances();
+  const dailyRevenue = options.createBalances();
+  const dailyVolume = options.createBalances();
+
+  const snap = await getSnapshot();
+  const { wvaraStreams, config } = snap;
+  const feeBps = config.feeBps; // e.g. 250 = 2.5%
+
+  const from = options.fromTimestamp;
+  const to = options.toTimestamp;
+
+  let volumePlancks = 0n;
+  for (const s of wvaraStreams) {
+    if (s.startTime >= from && s.startTime < to) {
+      volumePlancks += s.deposited;
+    }
+  }
+
+  if (volumePlancks > 0n) {
+    const feesPlancks = (volumePlancks * BigInt(feeBps)) / 10000n;
+    const volumeVara = Number(volumePlancks) / VARA_DECIMALS;
+    const feesVara = Number(feesPlancks) / VARA_DECIMALS;
+
+    dailyFees.addCGToken("vara-network", feesVara, STREAMING_FEES);
+    dailyRevenue.addCGToken("vara-network", feesVara, STREAMING_FEES_TO_TREASURY);
+    dailyVolume.addCGToken("vara-network", volumeVara, STREAMING_VOLUME);
+  }
+
+  // Log per-day diagnostics (useful for backfills)
+  // Includes current global stats so dashboards can reference them in methodology
+  if (options.startOfDay % 86400 === 0) {
+    // only log once per day invocation to avoid spam in hourly mode
+    console.info(
+      `vara-grow-streams day ${options.dateString}: volumePlancks=${volumePlancks} feesBps=${feeBps} totalStreams=${snap.totalStreams} activeStreams=${snap.activeStreams} wvaraDepositedTotal=${Number(snap.totalDepositedAll) / VARA_DECIMALS}`
+    );
+  }
+
+  return {
+    dailyFees,
+    dailyRevenue,
+    dailyProtocolRevenue: dailyRevenue,
+    dailyVolume,
+  };
+};
+
+const methodology = {
+  Fees: "2.5% streaming fee (fee_bps from StreamService::GetConfig) applied to every new wVARA stream's initial_deposit (Stream.deposited where token == wVARA 0xf5e9cb1d1e46b0cda6578dd1684b30f281a45dfaa390e4945b7bfc8ab3e27f3d). Daily fees = sum(deposited in day) * fee_bps / 10_000. Historical total streamed = sum of all wVARA deposited across all streams (current TotalStreams).",
+  Revenue: "All streaming fees are retained by the protocol treasury (no supply-side share). Daily revenue == daily fees.",
+  ProtocolRevenue: "100% of streaming fees to treasury (config.treasury).",
+  Volume: "Total wVARA deposited into streams whose start_time falls in the day — approximates money routed through the streaming protocol that day. Cumulative sum equals historical money streamed.",
+};
+
+const breakdownMethodology = {
+  Fees: {
+    [STREAMING_FEES]: "wVARA streaming fee = deposited * fee_bps / 10_000 for streams created that day (token == wVARA; gVARA super-token underlies wVARA for streaming).",
+  },
+  Revenue: {
+    [STREAMING_FEES_TO_TREASURY]: "Full fee to GrowStreams treasury; no LP or staker cut.",
+  },
+  ProtocolRevenue: {
+    [STREAMING_FEES_TO_TREASURY]: "Swept to treasury via SuperTokenService::CollectFee.",
+  },
+  Volume: {
+    [STREAMING_VOLUME]: "Sum of Stream.deposited for wVARA streams created that day.",
+  },
+};
+
+const adapter: SimpleAdapter = {
+  version: 1,
+  chains: [CHAIN.VARA],
+  start: "2026-06-21",
+  fetch,
+  methodology,
+  breakdownMethodology,
+};
+
+export default adapter;


### PR DESCRIPTION
##### Name (to be shown on DefiLlama):
GrowStreams

##### Twitter Link:
- https://x.com/GrowwStreams

##### List of audit links if any:
- N/A

##### Website Link:
- https://growstreams.xyz

##### Logo (High resolution, will be shown with rounded borders):
- https://growstreams.xyz/_next/image?url=%2Flogo.png&w=384&q=75

##### Current TVL:
- ~$30 (payment streaming protocol, not AMM/Lending). TVL in DefiLlama-Adapters (`projects/vara-grow-streams/index.js`) = spendable native VARA of `token_vault 0x20099b7637ae936670f54464c4109d1f028fbb63230e151ea4ef29c4a94cbcef` + backing of `wVARA 0xf5e9cb1d1e46b0cda6578dd1684b30f281a45dfaa390e4945b7bfc8ab3e27f3d`/`gVARA 0x04314af41b7dbac322e3e66920211d2f799719e1cdc3122a99752f72b6ae84ee` capped by supply. Historical streamed: ~777,453 VARA (~$350 at time of writing) across 2,200 streams.

##### Treasury Addresses (if the protocol has treasury)
- SS58: `kGiaMA7wophBP4BuJRyCUPTrkrgMfYFL78KaZmAF44WYjuPM2` (hex `0x868111d85b4c429dbf5f2d54111c580cd9bc12a53ac377760d89bfe2813e7410` — `admin` & `treasury` from `StreamService::GetConfig`)
- Config proof: `wss://rpc.vara.network` `0x8298c2eea5c6bbe55a9cfe72283b5399098fd6a54d9a2a14c2bedba8eea50659` query `GetConfig`:
```json
{
  "admin": "0x868111d85b4c429dbf5f2d54111c580cd9bc12a53ac377760d89bfe2813e7410",
  "min_buffer_seconds": 3600,
  "next_stream_id": 2212,
  "token_vault": "0x20099b7637ae936670f54464c4109d1f028fbb63230e151ea4ef29c4a94cbcef",
  "super_token_count": 1,
  "fee_bps": 250,
  "treasury": "0x868111d85b4c429dbf5f2d54111c580cd9bc12a53ac377760d89bfe2813e7410"
}
```
Convert via https://ss58.org

##### Chain:
- Vara Network

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed): (https://api.coingecko.com/api/v3/coins/list)
- vara-network (used in adapter via `addCGToken("vara-network", ...)`) — CEX listing N/A

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)
- N/A

##### Short Description (to be shown on DefiLlama):
Real-time token streaming on Vara Network. Composable smart contracts for payroll, subscriptions, bounties, grants, and revenue sharing. Fees adapter tracks 2.5% streaming fee on wVARA flows.

##### Token address and ticker if any:
- N/A, GROW Token is coming soon

##### Category (full list at https://defillama.com/categories) *Please choose only one:
- Payments

##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.):
- N/A (streaming uses on-chain `flow_rate * elapsed` accounting; pricing via DefiLlama `vara-network` CG feed)

##### Implementation Details: Briefly describe how the oracle is integrated into your project:
- N/A

##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage:
- N/A — IDLs: `GrowStreams_IDL_Files/stream-core.idl` (`StreamService::GetConfig` `fee_bps`, `TotalStreams`, `ActiveStreams`, `GetStream`) and `super-token.idl` (`CollectFee`).

##### forkedFrom (Does your project originate from another project):
- Original project

##### methodology (what is being counted as tvl, how is tvl being calculated):
**Adapter:** `fees/vara-grow-streams/index.ts` (`CHAIN.VARA`, `version:1`, `start:2026-06-21`), via `gear_calculateReplyForHandle` on `https://rpc.vara.network`.

- **Source:** `StreamCore` `0x8298c2eea5c6bbe55a9cfe72283b5399098fd6a54d9a2a14c2bedba8eea50659` SCALE-encoded Sails routes (`StreamService::GetConfig`/`TotalStreams`/`ActiveStreams`/`GetStream`), same pattern as `projects/vara-ethereum-bridge/index.js` & `projects/vara-rivrdex/index.js`.
- **Fees:** `fee_bps = 250` (2.5%) from `GetConfig`. Daily `fees = Σ(Stream.deposited where token == wVARA 0xf5e9cb1d1e46b0cda6578dd1684b30f281a45dfaa390e4945b7bfc8ab3e27f3d and start_time in [fromTimestamp, toTimestamp)) * fee_bps / 10_000`. Label: `Streaming Fees`.
- **Revenue/ProtocolRevenue:** 100% to treasury (`CollectFee` to `config.treasury`), no supply-side share. `dailyRevenue == dailyFees == dailyProtocolRevenue`. Labels: `Streaming Fees To Treasury`.
- **Volume (extra dimension):** `dailyVolume = Σ deposited` (wVARA) for streams created that day — historical cumulative = ~777,453 VARA across 2,200 streams (snapshot: `Active 2165 / Paused 8 / Stopped 27`). Example explorer event:
```json
{
  "id": 2211,
  "sender": "0x1ad30e491c71da3461ff33fc09e6774101430d8b8927a90525ec39dfa5345541",
  "receiver": "0x5c7655911de5a2a59afa5143fe03e81a7729f8da2c408227c53959d6dd2c9610",
  "token": "0xf5e9cb1d1e46b0cda6578dd1684b30f281a45dfaa390e4945b7bfc8ab3e27f3d",
  "flow_rate": 16666666666,
  "start_time": 1787389104,
  "initial_deposit": 97500000000000
}
```
Explorer: https://idea.gear-tech.io/programs/0x8298c2eea5c6bbe55a9cfe72283b5399098fd6a54d9a2a14c2bedba8eea50659/events?node=wss%3A%2F%2Frpc.vara.network & https://idea.gear-tech.io/state/sails/0x8298c2eea5c6bbe55a9cfe72283b5399098fd6a54d9a2a14c2bedba8eea50659?node=wss%3A%2F%2Frpc.vara.network

- **Backfill:** `start_time` is immutable, so current snapshot suffices for historical `fromTimestamp` filtering; chunked `GetStream` (10 concurrency, 120ms delay, 429 backoff) with cached snapshot (`getSnapshot()`).
- **Scope:** Only `wVARA` (gVARA super-token `0x04314af41b7dbac322e3e66920211d2f799719e1cdc3122a99752f72b6ae84ee` wraps wVARA for `min(rate*elapsed, buffer)` payouts; other bridge tokens `wUSDC/wUSDT/WETH/WBTC` have ~$10k RivrDEX liquidity and are excluded until material).

##### Github org/user (Optional, if your code is open source, we can track activity):
- https://github.com/BlockX-AI

##### Does this project have a referral program?
- N/A
