### PR TITLE
[feat] shield-swap - add Aleo volume, fees, revenue and transactions

### DIFF
--- a/active-users/shield-swap.ts
+++ b/active-users/shield-swap.ts
@@ -1,0 +1,43 @@
+import { FetchOptions, SimpleAdapter } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+import fetchURL from "../utils/fetchURL";
+
+// Shield Swap is a confidential concentrated-liquidity AMM on Aleo. Its AMM program is
+// shield_swap.aleo, and the Aleo node RPC counts calls to a program per day for the last 90 days.
+// https://docs.provable.com/docs/api/v2/get-explorer-metrics-program-range
+const AMM = "shield_swap.aleo";
+const RETENTION_DAYS = 90;
+const CALLS_PER_DAY = `https://api.provable.com/v2/mainnet/metrics/program/${AMM}/range/${RETENTION_DAYS}`;
+
+const ONE_DAY = 24 * 60 * 60;
+
+const fetch = async (options: FetchOptions) => {
+  // The endpoint is a rolling window, so a day that has aged out cannot be read at all - reporting
+  // zero there would look like a day with no trading.
+  if (options.startOfDay < Math.floor(Date.now() / 1000) - RETENTION_DAYS * ONE_DAY)
+    throw new Error(`shield-swap: ${options.dateString} is older than the ${RETENTION_DAYS} day call-metrics window`);
+
+  const days: { day: string; calls: number }[] = await fetchURL(CALLS_PER_DAY);
+  const day = days.find((entry) => entry.day.slice(0, 10) === options.dateString);
+
+  // Days with no calls are omitted from the response rather than returned as zero.
+  return { dailyTransactionsCount: day?.calls ?? 0 };
+};
+
+const adapter: SimpleAdapter = {
+  version: 1,
+  fetch,
+  chains: [CHAIN.ALEO],
+  // First calls to shield_swap.aleo: the pools were created and traded on 2026-07-30.
+  start: '2026-07-30',
+  methodology: {
+    Transactions: `Accepted and rejected calls to ${AMM} per day, counted by the Aleo node RPC. A trade is two calls: the swap and the claim that settles its output.`,
+  },
+  breakdownMethodology: {
+    Transactions: {
+      [AMM]: "Every accepted or rejected call to the AMM program: swaps, the claims that settle them, and liquidity operations. Not broken down further - the node reports calls per program, not per function.",
+    },
+  },
+};
+
+export default adapter;

--- a/dexs/shield-swap/index.ts
+++ b/dexs/shield-swap/index.ts
@@ -1,0 +1,309 @@
+import { PromisePool } from "@supercharge/promise-pool";
+import { FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import { METRIC } from "../../helpers/metrics";
+import {
+  AleoTransition,
+  aleoBigInt,
+  aleoBool,
+  aleoNumber,
+  firstPublicOutput,
+  futureArguments,
+  getAleoMappingValue,
+  getAleoProgramCallsSince,
+  getAleoTransactionTransitions,
+  parseAleoPlaintext,
+} from "../../helpers/aleo";
+
+// Shield Swap is a confidential concentrated-liquidity AMM on Aleo. Swap sizes, routes and pool
+// state are public on the ledger, so every number below is read from Aleo chain state.
+// https://shield.fi/docs/confidentiality/public-data
+const AMM = "shield_swap.aleo";
+
+const SWAP = "swap";
+const SWAP_MULTI_HOP = "swap_multi_hop";
+const CLAIM = "claim_swap_output";
+const CLAIM_NO_REFUND = "claim_swap_output_no_refund";
+
+// The protocol keeps `fee_protocol / PROTOCOL_FEE_DENOMINATOR` of every swap fee; the rest accrues
+// to the LP position. `fee_protocol` itself is read per pool from the on-chain `slots` mapping.
+// https://shield.fi/docs/reference/constants-and-limits ("The protocol share is fee_protocol / 16")
+const PROTOCOL_FEE_DENOMINATOR = 16n;
+
+// Pool `fee` is a u16 count of parts per million (200 => 0.02%), same source as above.
+const FEE_PPM_DENOMINATOR = 1_000_000n;
+
+// A swap settles in a separate claim transaction, observed 23-151s after the swap over a 493-claim
+// sample. Half an hour of slack keeps the number of transactions read per run near the number of
+// swaps in the window.
+const CLAIM_LAG_SECONDS = 30 * 60;
+
+// AMM-side ARC-20 token ids, read off the on-chain `pools` mapping. Aleo carries no decimal
+// registry - "The AMM uses native token base units directly. It has no on-chain decimal scale or
+// normalization registry." (https://shield.fi/docs/reference/constants-and-limits) - so decimals and
+// the price feed are pinned here, matching the Shield Swap TVL adapter. USDCx is a USD stablecoin on
+// Aleo with no DefiLlama price feed of its own, so it is priced at parity via usd-coin; a de-peg
+// would overstate volume and fees. A swap whose input token is missing from this list is logged and
+// skipped so one newly approved asset cannot take out the whole window; the log says to add it here.
+const TOKENS: Record<string, { symbol: string; decimals: number; coingeckoId: string }> = {
+  "724721105858008932013114020280511843613117371369744086165619field": { symbol: "ALEO", decimals: 6, coingeckoId: "aleo" },
+  "1926848598207449231969field": { symbol: "ETH", decimals: 18, coingeckoId: "ethereum" },
+  "2000279227181771747937field": { symbol: "SOL", decimals: 9, coingeckoId: "solana" },
+  "469661199361043738096225field": { symbol: "wBTC", decimals: 8, coingeckoId: "bitcoin" },
+  "212707628815602939926313406778312270053663804591730917421274098438979020915field": { symbol: "USDCx", decimals: 6, coingeckoId: "usd-coin" },
+};
+
+interface Pool {
+  token0: string;
+  token1: string;
+  feePpm: bigint;
+  feeProtocol: bigint;
+}
+
+interface Hop {
+  pool: string;
+  zeroForOne: boolean;
+}
+
+interface Swap {
+  swapId: string;
+  amountIn: bigint;
+  hops: Hop[];
+}
+
+interface Claim {
+  remainder: bigint;
+}
+
+/** The AMM's own transition inside a transaction, named so a missing one is diagnosable. */
+function transitionOf(transitions: AleoTransition[], functionName: string, transactionId: string): AleoTransition {
+  const transition = transitions?.find((t) => t.program === AMM && t.function === functionName);
+  // The call list said this transaction calls the AMM, so a missing transition means the RPC
+  // returned a transaction we cannot read - surface which one rather than a bare TypeError.
+  if (!transition) throw new Error(`shield-swap: ${transactionId} has no ${AMM}/${functionName} transition`);
+  return transition;
+}
+
+/** A single-hop swap: the request struct carries the pool, direction and input size. */
+function parseSwap(transitions: AleoTransition[], transactionId: string): Swap {
+  const transition = transitionOf(transitions, SWAP, transactionId);
+  // swap(request, token0, token1, swap_id, ...) - the request struct carries pool, direction and size
+  const request = futureArguments(transition)[0];
+  if (typeof request !== "object" || Array.isArray(request)) throw new Error("shield-swap: malformed swap request");
+  return {
+    swapId: firstPublicOutput(transition),
+    amountIn: aleoBigInt(request.amount_in),
+    hops: [{ pool: request.pool as string, zeroForOne: aleoBool(request.zero_for_one) }],
+  };
+}
+
+/** A routed swap: hop0..hopN-1 are the legs actually taken, hop_count says how many. */
+function parseMultiHopSwap(transitions: AleoTransition[], transactionId: string): Swap {
+  const transition = transitionOf(transitions, SWAP_MULTI_HOP, transactionId);
+  const request = futureArguments(transition)[0];
+  if (typeof request !== "object" || Array.isArray(request)) throw new Error("shield-swap: malformed multi-hop request");
+  // Routes are 2 or 3 hops; unused hop slots repeat the previous hop, so only hop_count entries count.
+  // https://shield.fi/docs/reference/constants-and-limits
+  const hopCount = aleoNumber(request.hop_count);
+  const hops: Hop[] = [];
+  for (let i = 0; i < hopCount; i++) {
+    const hop = request[`hop${i}`];
+    if (typeof hop !== "object" || Array.isArray(hop)) throw new Error(`shield-swap: malformed hop${i}`);
+    hops.push({ pool: hop.pool as string, zeroForOne: aleoBool(hop.zero_for_one) });
+  }
+  return {
+    swapId: firstPublicOutput(transition),
+    amountIn: aleoBigInt(request.amount_in),
+    hops,
+  };
+}
+
+/** The settlement of a swap: the part of the input that was not filled, and so refunded. */
+function parseClaim(transitions: AleoTransition[], functionName: string, transactionId: string): [string, Claim] {
+  const transition = transitionOf(transitions, functionName, transactionId);
+  // claim_swap_output(swap_id, token_in, token_out, amount_out, amount_remaining, ...)
+  // amount_remaining is denominated in token_in.
+  // claim_swap_output_no_refund has no remainder argument.
+  const args = futureArguments(transition);
+  const swapId = args[0] as string;
+  return [swapId, { remainder: functionName === CLAIM ? aleoBigInt(args[4]) : 0n }];
+}
+
+// Fee tier and protocol split change only by admin action, so they are resolved once per process
+// rather than re-read for every window a run covers. Mappings hold current consensus state rather
+// than history (https://shield.fi/docs/reference/mappings), so a backfilled window is priced with
+// today's fee tier; both have been unchanged (200/800/100/200 ppm, fee_protocol 5) since launch.
+// Keyed on the in-flight promise, not the resolved value, so windows running concurrently share one
+// read instead of each issuing its own. A rejected read is evicted so a later window can retry.
+const poolCache: Record<string, Promise<Pool>> = {};
+// Matches the concurrency the Aleo helper uses for its own reads, so a run stays inside the same
+// request budget whether it is reading pools or transactions.
+const POOL_CONCURRENCY = 3;
+
+/** Pool state for a key, shared between concurrent callers and retried after a failure. */
+function loadPool(poolKey: string): Promise<Pool> {
+  if (!poolCache[poolKey])
+    poolCache[poolKey] = getPool(poolKey).catch((e) => {
+      delete poolCache[poolKey];
+      throw e;
+    });
+  return poolCache[poolKey];
+}
+
+/** Fee tier and protocol split of one pool, read from the AMM's pools and slots mappings. */
+async function getPool(poolKey: string): Promise<Pool> {
+  const [poolState, slot] = await Promise.all([
+    getAleoMappingValue(AMM, "pools", poolKey),
+    getAleoMappingValue(AMM, "slots", poolKey),
+  ]);
+  if (!poolState || !slot) throw new Error(`shield-swap: pool ${poolKey} is missing on-chain state`);
+  const pool = parseAleoPlaintext(poolState);
+  const slotState = parseAleoPlaintext(slot);
+  if (typeof pool !== "object" || Array.isArray(pool) || typeof slotState !== "object" || Array.isArray(slotState))
+    throw new Error(`shield-swap: malformed state for pool ${poolKey}`);
+  return {
+    token0: pool.token0 as string,
+    token1: pool.token1 as string,
+    feePpm: aleoBigInt(pool.fee),
+    feeProtocol: aleoBigInt(slotState.fee_protocol),
+  };
+}
+
+const fetch = async (options: FetchOptions) => {
+  const dailyVolume = options.createBalances();
+  const dailyFees = options.createBalances();
+  const dailyRevenue = options.createBalances();
+  const dailySupplySideRevenue = options.createBalances();
+
+  const calls = await getAleoProgramCallsSince(AMM, options.fromTimestamp);
+  const accepted = calls.filter((call) => call.status === "Accepted");
+  if (!accepted.length) throw new Error("shield-swap: no accepted AMM calls returned by the Aleo RPC");
+
+  const swapCalls = accepted.filter(
+    (call) =>
+      (call.function_id === SWAP || call.function_id === SWAP_MULTI_HOP) &&
+      call.block_timestamp >= options.fromTimestamp &&
+      call.block_timestamp < options.toTimestamp
+  );
+  // Claims settle a swap and publish the exact filled output and the unspent input. A claim always
+  // follows its swap, and never by much, so the window is extended forward rather than read whole.
+  const claimCalls = accepted.filter(
+    (call) =>
+      (call.function_id === CLAIM || call.function_id === CLAIM_NO_REFUND) &&
+      call.block_timestamp >= options.fromTimestamp &&
+      call.block_timestamp < options.toTimestamp + CLAIM_LAG_SECONDS
+  );
+
+  const transitions = await getAleoTransactionTransitions([
+    ...new Set([...swapCalls, ...claimCalls].map((call) => call.transaction_id)),
+  ]);
+
+  const claims: Record<string, Claim> = {};
+  for (const call of claimCalls) {
+    const [swapId, claim] = parseClaim(transitions[call.transaction_id], call.function_id, call.transaction_id);
+    claims[swapId] = claim;
+  }
+
+  const swaps = swapCalls.map((call) =>
+    call.function_id === SWAP
+      ? parseSwap(transitions[call.transaction_id], call.transaction_id)
+      : parseMultiHopSwap(transitions[call.transaction_id], call.transaction_id)
+  );
+
+  const needed = [...new Set(swaps.flatMap((swap) => swap.hops.map((hop) => hop.pool)))];
+  const { errors } = await PromisePool.withConcurrency(POOL_CONCURRENCY)
+    .for(needed.filter((poolKey) => !poolCache[poolKey]))
+    .process(async (poolKey) => {
+      await loadPool(poolKey);
+    });
+  if (errors.length) throw errors[0];
+  const pools: Record<string, Pool> = Object.fromEntries(
+    await Promise.all(needed.map(async (key) => [key, await loadPool(key)] as const))
+  );
+
+  for (const swap of swaps) {
+    const claim = claims[swap.swapId];
+    // The tick-walk loop is capped, so a swap can fill partially and refund the rest on claim.
+    // An unsettled swap has no published refund yet; partial fills are rare enough that treating it
+    // as fully filled is the closest available estimate.
+    const filledIn = swap.amountIn - (claim?.remainder ?? 0n);
+    if (filledIn <= 0n) continue;
+
+    const entryPool = pools[swap.hops[0].pool];
+    const entryTokenId = swap.hops[0].zeroForOne ? entryPool.token0 : entryPool.token1;
+
+    const token = TOKENS[entryTokenId];
+    // The admin can approve an asset before this list knows how to price it. That is recoverable:
+    // log it and keep the swaps we can price rather than losing the whole window.
+    if (!token) {
+      // console, not sdk.log: sdk.log only prints under LLAMA_DEBUG_MODE, which would make the gap
+      // invisible on a normal run - the whole point is that the omission is visible.
+      console.error(`shield-swap: no price feed for token ${entryTokenId} (swap ${swap.swapId}), swap skipped`);
+      continue;
+    }
+    const notional = Number(filledIn) / 10 ** token.decimals;
+    if (!Number.isFinite(notional)) throw new Error(`shield-swap: bad ${token.symbol} amount ${filledIn}`);
+
+    // Every pool is quoted against a stablecoin, so a route carries the same notional through each of
+    // its hops, less the fee taken on the way. The entry leg's exact input therefore sizes the whole
+    // route, and every hop is counted at that notional.
+    for (const hop of swap.hops) {
+      const pool = pools[hop.pool];
+
+      const fees = (Number(pool.feePpm) / Number(FEE_PPM_DENOMINATOR)) * notional;
+      const revenue = (Number(pool.feeProtocol) / Number(PROTOCOL_FEE_DENOMINATOR)) * fees;
+
+      dailyVolume.addCGToken(token.coingeckoId, notional);
+      dailyFees.addCGToken(token.coingeckoId, fees, METRIC.SWAP_FEES);
+      dailyRevenue.addCGToken(token.coingeckoId, revenue, METRIC.PROTOCOL_FEES);
+      dailySupplySideRevenue.addCGToken(token.coingeckoId, fees - revenue, METRIC.LP_FEES);
+    }
+  }
+
+  return {
+    dailyVolume,
+    dailyFees,
+    dailyUserFees: dailyFees,
+    dailyRevenue,
+    dailyProtocolRevenue: dailyRevenue,
+    dailySupplySideRevenue,
+  };
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  // Hourly: the Aleo RPC has no time or block filter, so reaching a window means paging back from
+  // the head. Hourly windows keep that walk short, and the helper caches it across the windows of a
+  // single run.
+  pullHourly: true,
+  fetch,
+  chains: [CHAIN.ALEO],
+  start: '2026-07-30',
+  methodology: {
+    Volume: "Input notional of every accepted swap and swap_multi_hop call to shield_swap.aleo, read from the public swap request on the Aleo ledger and counted once per hop of the route.",
+    Fees: "Swap volume multiplied by each pool's on-chain fee tier (the pools mapping stores it as parts per million).",
+    UserFees: "Identical to Fees - traders pay the whole swap fee.",
+    Revenue: "The protocol's cut of the swap fee, fee_protocol/16 per the pool's on-chain slots entry.",
+    ProtocolRevenue: "Same as Revenue; Shield Swap has no token, so none of it is passed to holders.",
+    SupplySideRevenue: "The remaining (16 - fee_protocol)/16 of the swap fee, which accrues to the concentrated-liquidity position that provided it.",
+  },
+  breakdownMethodology: {
+    Fees: {
+      [METRIC.SWAP_FEES]: "Swap volume times the pool fee tier read from the on-chain pools mapping.",
+    },
+    UserFees: {
+      [METRIC.SWAP_FEES]: "Swap fees paid by traders.",
+    },
+    Revenue: {
+      [METRIC.PROTOCOL_FEES]: "fee_protocol/16 of the swap fee, retained by the protocol.",
+    },
+    ProtocolRevenue: {
+      [METRIC.PROTOCOL_FEES]: "fee_protocol/16 of the swap fee, retained by the protocol.",
+    },
+    SupplySideRevenue: {
+      [METRIC.LP_FEES]: "(16 - fee_protocol)/16 of the swap fee, credited to liquidity positions.",
+    },
+  },
+};
+
+export default adapter;

--- a/helpers/aleo.ts
+++ b/helpers/aleo.ts
@@ -1,0 +1,332 @@
+import axios from "axios";
+import { PromisePool } from "@supercharge/promise-pool";
+import { sleep } from "../utils/utils";
+
+// Provable API v2 is the public Aleo node/indexer RPC: https://docs.provable.com/docs/api/v2/intro
+const ALEO_RPC = "https://api.provable.com/v2/mainnet";
+
+// Documented public rate limit is 5 req/s: https://docs.provable.com/docs/api/v2/intro
+const CONCURRENCY = 3;
+
+// Retry budget for the transient proxy failures described on aleoGet.
+const RETRY_ATTEMPTS = 5;
+const RETRY_BASE_MS = 500;
+
+// `/programs/:programID/latest-calls/paginated` serves the program's full call history, newest
+// first, via keyset pagination. The cursor parameters must be spelled exactly `cursor_block_number`
+// and `cursor_transition_id` - any other name is silently ignored and the first page is returned
+// again. The node rejects a `limit` above 50, so that is the most a page can carry.
+const PAGE_SIZE = 50;
+
+// The walk has no natural end other than the cursor running out, so bound it: a cursor that keeps
+// advancing without reaching the window would otherwise spin indefinitely. 4000 pages is 200k calls,
+// several years of headroom at current volume, and reaching it means something is wrong rather than
+// that the history is long.
+const MAX_PAGES = 4000;
+
+// Head pages walked while catching up to what is already cached before giving up and starting the
+// walk over. Ten pages is 500 calls, far more than arrives between two windows of the same run.
+const MAX_HEAD_PAGES = 10;
+
+export interface AleoProgramCall {
+  transaction_id: string;
+  function_id: string;
+  block_number: number;
+  block_timestamp: number;
+  status: string;
+}
+
+/** Raw shapes the node returns, narrowed at the boundary rather than trusted as `any`. */
+interface RawProgramCall {
+  transaction_id: string;
+  function_id: string;
+  block_number: number;
+  block_timestamp: string | number;
+  status: string;
+}
+
+interface RawPaginatedCalls {
+  calls: RawProgramCall[];
+  next_cursor: AleoCursor | null;
+  prev_cursor: AleoCursor | null;
+}
+
+interface RawTransaction {
+  execution?: { transitions?: AleoTransition[] };
+}
+
+export interface AleoTransition {
+  program: string;
+  function: string;
+  inputs: { type: string; value?: string }[];
+  outputs: { type: string; value?: string }[];
+}
+
+/** A timeout or dropped socket (no response at all), rate limiting, or a server-side failure. */
+function isTransient(e: unknown): boolean {
+  if (!axios.isAxiosError(e)) return false;
+  const status = e.response?.status;
+  return status === undefined || status === 429 || status >= 500;
+}
+
+/**
+ * The public endpoint sits behind a proxy that intermittently returns 502/522 under load, so each
+ * read is retried with a backoff before the error is allowed to fail the run.
+ */
+async function aleoGet(path: string, attempt = 0): Promise<unknown> {
+  try {
+    // axios rather than fetchURL: fetchURL rejects a falsy body, and `null` is the node's normal
+    // answer for a mapping key that has no entry, which is a value here and not a failure.
+    const { data } = await axios.get(`${ALEO_RPC}${path}`, { timeout: 30000 });
+    return data ?? null;
+  } catch (e) {
+    // Five attempts backing off from 500ms doubles to 8s of waiting, which clears the proxy's
+    // transient 502/522 bursts; beyond that the endpoint is genuinely down and the run should fail.
+    // A 4xx is the node rejecting the request itself, so retrying it only delays the same failure.
+    if (!isTransient(e) || attempt >= RETRY_ATTEMPTS - 1) throw e;
+    await sleep(RETRY_BASE_MS * 2 ** attempt);
+    return aleoGet(path, attempt + 1);
+  }
+}
+
+/**
+ * Reads a value out of a program mapping. Returns null when the key has no entry - Aleo finalizers
+ * distinguish `get` from `get_or_use`, so an absent key is a normal state, not an error.
+ */
+export async function getAleoMappingValue(programId: string, mapping: string, key: string): Promise<string | null> {
+  const value = await aleoGet(`/program/${programId}/mapping/${mapping}/${key}`);
+  if (value === null || value === undefined) return null; // absent key, a normal finalizer state
+  if (typeof value !== "string") throw new Error(`aleo: ${programId}/${mapping}/${key} is not a plaintext value`);
+  return value;
+}
+
+interface AleoCursor {
+  block_number: number;
+  transition_id: string;
+}
+
+interface CallWalk {
+  calls: AleoProgramCall[]; // newest first
+  cursor: AleoCursor | null; // where to resume walking backwards; null once history is exhausted
+  pages: number; // pages fetched so far, bounded by MAX_PAGES
+  chain: Promise<void>; // serialises concurrent extensions of the same walk
+}
+
+// Concurrent first callers must share one head request rather than each starting a rival walk.
+const walkInit: Record<string, Promise<CallWalk>> = {};
+
+/** Identity of a call: unique per (block, transaction, function), which the node guarantees. */
+const callKey = (call: AleoProgramCall) => `${call.block_number}:${call.transaction_id}:${call.function_id}`;
+
+/** Program calls arrive with block_timestamp as a string; make it a number once, at the edge. */
+const normalise = (call: RawProgramCall): AleoProgramCall => ({ ...call, block_timestamp: Number(call.block_timestamp) });
+
+/** One page of a program's call history, plus the cursor that continues it backwards. */
+async function fetchPage(programId: string, cursor: AleoCursor | null) {
+  const query = cursor
+    ? `?limit=${PAGE_SIZE}&cursor_block_number=${cursor.block_number}&cursor_transition_id=${cursor.transition_id}`
+    : `?limit=${PAGE_SIZE}`;
+  const page = (await aleoGet(`/programs/${programId}/latest-calls/paginated${query}`)) as RawPaginatedCalls | null;
+  if (!page || !Array.isArray(page.calls))
+    throw new Error(`aleo: unexpected paginated latest-calls response for ${programId}`);
+  return { calls: page.calls.map(normalise), next: page.next_cursor ?? null };
+}
+
+/**
+ * Pulls in calls accepted since the walk was built. The cached head goes stale the moment a new
+ * block lands, so every request re-reads the head and stitches the new calls on rather than trusting
+ * what it already has. Normally that is a single page.
+ */
+async function refreshHead(programId: string, walk: CallWalk): Promise<void> {
+  const known = new Set(walk.calls.slice(0, PAGE_SIZE * MAX_HEAD_PAGES).map(callKey));
+  const fresh: AleoProgramCall[] = [];
+  let cursor: AleoCursor | null = null;
+
+  for (let page = 0; page < MAX_HEAD_PAGES; page++) {
+    const { calls, next } = await fetchPage(programId, cursor);
+    if (!calls.length) break;
+    const overlap = calls.findIndex((call) => known.has(callKey(call)));
+    fresh.push(...(overlap === -1 ? calls : calls.slice(0, overlap)));
+    if (overlap !== -1 || !next) {
+      if (fresh.length) walk.calls.unshift(...fresh);
+      return;
+    }
+    cursor = next;
+  }
+
+  // More new calls than we are willing to stitch: keep what we just read and walk back from there.
+  if (fresh.length) {
+    walk.calls = fresh;
+    walk.cursor = cursor;
+  }
+}
+
+/**
+ * Accepted + rejected calls to a program back to `sinceTimestamp`, newest first.
+ *
+ * The node offers no time or block filter, so reaching a window means paging back from the head.
+ * The walk is therefore cached per program and extended, not repeated: a run that covers 24 hourly
+ * windows pages the history once rather than once per window.
+ */
+export async function getAleoProgramCallsSince(programId: string, sinceTimestamp: number): Promise<AleoProgramCall[]> {
+  if (!walkInit[programId])
+    walkInit[programId] = (async () => {
+      const first = await fetchPage(programId, null);
+      if (!first.calls.length) throw new Error(`aleo: no calls returned for ${programId}`);
+      return {
+        calls: first.calls,
+        cursor: first.next,
+        pages: 1,
+        chain: Promise.resolve(),
+      };
+    })().catch((e) => {
+      delete walkInit[programId];
+      throw e;
+    });
+
+  const walk = await walkInit[programId];
+
+  const work = async () => {
+    // Newest first: pick up anything added since the walk was built, then reach back as needed.
+    await refreshHead(programId, walk);
+    while (walk.cursor && walk.calls[walk.calls.length - 1].block_timestamp >= sinceTimestamp) {
+      if (walk.pages >= MAX_PAGES)
+        throw new Error(
+          `aleo: walked ${walk.pages} pages of ${programId} calls without reaching ${sinceTimestamp}`
+        );
+      const { calls, next } = await fetchPage(programId, walk.cursor);
+      walk.pages++;
+      if (!calls.length) {
+        walk.cursor = null; // reached the program's first call
+        break;
+      }
+      walk.calls.push(...calls);
+      walk.cursor = next;
+    }
+  };
+
+  // Slots run concurrently; keep one walk in flight so pages are not fetched twice.
+  walk.chain = walk.chain.then(work, work);
+  await walk.chain;
+  return walk.calls;
+}
+
+/** Fetches transactions by id and returns the transitions of each, keyed by transaction id. */
+export async function getAleoTransactionTransitions(transactionIds: string[]): Promise<Record<string, AleoTransition[]>> {
+  const transitions: Record<string, AleoTransition[]> = {};
+  const { errors } = await PromisePool.withConcurrency(CONCURRENCY)
+    .for(transactionIds)
+    .process(async (id) => {
+      const tx = (await aleoGet(`/transaction/${id}`)) as RawTransaction | null;
+      transitions[id] = tx?.execution?.transitions ?? [];
+    });
+  if (errors.length) throw errors[0];
+  return transitions;
+}
+
+export type AleoValue = string | AleoValue[] | { [key: string]: AleoValue };
+
+const STRUCTURAL = new Set(["{", "}", "[", "]", ",", ":"]);
+
+const TOKEN = /\s*([{}\[\],:]|[^{}\[\],:\s]+)\s*/y;
+
+/**
+ * Parses the Aleo plaintext that the RPC returns for mapping values, public inputs/outputs and
+ * future arguments: `{ pool: 123field, zero_for_one: true, amount_in: 4500u128 }`.
+ */
+export function parseAleoPlaintext(plaintext: string): AleoValue {
+  const tokens: string[] = [];
+  TOKEN.lastIndex = 0;
+  while (TOKEN.lastIndex < plaintext.length) {
+    const at = TOKEN.lastIndex;
+    const match = TOKEN.exec(plaintext);
+    // A sticky match that fails, or consumes nothing, means the input is not Aleo plaintext.
+    if (!match || TOKEN.lastIndex === at)
+      throw new Error(`aleo: unparsable plaintext at offset ${at}: ${plaintext}`);
+    tokens.push(match[1]);
+  }
+
+  let position = 0;
+  const value = (): AleoValue => {
+    const token = tokens[position];
+    if (token === undefined) throw new Error(`aleo: unexpected end of plaintext: ${plaintext}`);
+    if (token === "{") {
+      position++;
+      const struct: { [key: string]: AleoValue } = {};
+      while (tokens[position] !== "}") {
+        const key = tokens[position++];
+        if (key === undefined) throw new Error(`aleo: unterminated struct in plaintext: ${plaintext}`);
+        if (tokens[position++] !== ":") throw new Error(`aleo: malformed struct in plaintext: ${plaintext}`);
+        if (Object.prototype.hasOwnProperty.call(struct, key))
+          throw new Error(`aleo: duplicate struct key ${key} in plaintext: ${plaintext}`);
+        struct[key] = value();
+        // Members are comma separated; anything else here means the input is not what we think.
+        if (tokens[position] === ",") position++;
+        else if (tokens[position] !== "}")
+          throw new Error(`aleo: expected ',' or '}' after struct member ${key} in plaintext: ${plaintext}`);
+      }
+      position++;
+      return struct;
+    }
+    if (token === "[") {
+      position++;
+      const array: AleoValue[] = [];
+      while (tokens[position] !== "]") {
+        array.push(value());
+        if (tokens[position] === ",") position++;
+        else if (tokens[position] !== "]")
+          throw new Error(`aleo: expected ',' or ']' after array element in plaintext: ${plaintext}`);
+      }
+      position++;
+      return array;
+    }
+    // `}`, `]`, `,` and `:` are structure, never values: `{a:]}` must not parse as { a: "]" }.
+    if (STRUCTURAL.has(token))
+      throw new Error(`aleo: unexpected '${token}' where a value was expected in plaintext: ${plaintext}`);
+    position++;
+    return token;
+  };
+  const parsed = value();
+  // Trailing tokens mean the input was not a single well-formed value; do not return a partial parse.
+  if (position !== tokens.length)
+    throw new Error(`aleo: trailing tokens in plaintext after position ${position}: ${plaintext}`);
+  return parsed;
+}
+
+/** Strips the Aleo integer suffix (`u8`, `u128`, `i32`, ...) and returns a BigInt. */
+export function aleoBigInt(value: AleoValue): bigint {
+  if (typeof value !== "string") throw new Error(`aleo: expected a literal, got ${JSON.stringify(value)}`);
+  return BigInt(value.replace(/(u|i)\d+$/, ""));
+}
+
+/** Same as aleoBigInt for values known to fit a JS number, e.g. hop counts and decimals. */
+export function aleoNumber(value: AleoValue): number {
+  return Number(aleoBigInt(value));
+}
+
+/** Aleo plaintext booleans are the bare words `true` and `false`. */
+export function aleoBool(value: AleoValue): boolean {
+  if (value !== "true" && value !== "false") throw new Error(`aleo: expected a bool, got ${JSON.stringify(value)}`);
+  return value === "true";
+}
+
+/** The first public output of a transition - Shield Swap returns swap and position ids this way. */
+export function firstPublicOutput(transition: AleoTransition): string {
+  const output = transition.outputs.find((o) => o.type === "public");
+  if (!output?.value) throw new Error(`aleo: ${transition.program}/${transition.function} has no public output`);
+  return output.value;
+}
+
+/**
+ * Arguments of a transition's finalize future, with the nested futures of imported programs dropped
+ * so that the remaining entries line up with the finalizer's own parameters.
+ */
+export function futureArguments(transition: AleoTransition): AleoValue[] {
+  const future = transition.outputs.find((o) => o.type === "future");
+  if (!future?.value) throw new Error(`aleo: ${transition.program}/${transition.function} has no future output`);
+  const parsed = parseAleoPlaintext(future.value);
+  if (typeof parsed !== "object" || Array.isArray(parsed)) throw new Error(`aleo: malformed future output`);
+  const args = parsed.arguments;
+  if (!Array.isArray(args)) throw new Error(`aleo: malformed future arguments`);
+  return args.filter((arg) => !(typeof arg === "object" && !Array.isArray(arg) && "_program_id" in arg));
+}

--- a/helpers/chains.ts
+++ b/helpers/chains.ts
@@ -92,6 +92,7 @@ export enum CHAIN {
   ULTRON = "ultron",
   STELLAR = "stellar",
   ALGORAND = "algorand",
+  ALEO = "aleo",
   TELOS = "telos",
   TOMOCHAIN = "tomochain",
   BITGERT = "bitgert",


### PR DESCRIPTION
# Shield Swap (Aleo): volume, fees, revenue and transactions

Website: https://shield.fi/ · App: https://swap.shield.fi/ · Twitter: https://twitter.com/ShieldFi
Docs: https://shield.fi/docs · Already listed for TVL: https://defillama.com/protocol/shield-swap (id 8477)

Shield Swap is a confidential concentrated-liquidity AMM on Aleo. It is already listed for TVL;
this adds the dimension metrics.

- `dexs/shield-swap` — Volume, Fees, UserFees, Revenue, ProtocolRevenue, SupplySideRevenue
- `active-users/shield-swap` — Transactions
- `helpers/aleo.ts` — new chain helper (mapping reads, paginated program calls, transitions, Aleo
  plaintext parsing), plus `CHAIN.ALEO`

## Sourcing — everything is read from Aleo chain state

Swap sizes, routes, pool fee tiers and the protocol fee split are all public on the Aleo ledger
(https://shield.fi/docs/confidentiality/public-data), so no protocol API is used.

- **Volume** — the public `amount_in` of every accepted `swap` / `swap_multi_hop` call to
  `shield_swap.aleo`, less the unspent input that `claim_swap_output` publishes, counted per hop of
  the route (same convention as the Uniswap adapters).
- **Fees** — that notional x the pool's fee tier, read as parts-per-million from the on-chain
  `pools` mapping. Verified on all four live pools: 200/800/100/200 ppm.
- **Revenue** — `fee_protocol / 16` from the on-chain `slots` mapping. `fee_protocol` reads `5u8` on
  every pool, matching the documented constant
  (https://shield.fi/docs/reference/constants-and-limits). SupplySideRevenue is the remaining 11/16.

Aleo has no on-chain decimal registry, so decimals and price feeds are pinned in the adapter,
matching the existing TVL adapter. An unknown token id throws rather than being skipped.

## Validation

`npm run test dexs shield-swap` — 24 hourly slots, 203s, all green:

```
Daily volume: 388.70 k | fees: 112.20 | revenue: 35.07 | supply side revenue: 77.14
```

`Revenue / Fees = 35.07 / 112.20 = 0.31256` — exactly 5/16, end to end.

Cross-checked against the protocol's own indexer (not used by the adapter, only for validation).
Reconstructing single hours from ledger transitions and pricing both sides identically:

| hour (UTC) | adapter | indexer | diff |
|---|---|---|---|
| 05:00-06:00 | $24,069.90 | $24,005.76 | +0.27% |
| 06:00-07:00 | $21,677.99 | $21,623.79 | +0.25% |
| 07:00-08:00 | $23,374.10 | $23,348.40 | +0.11% |

The small positive bias is the fee on multi-hop closing legs plus swaps whose settling claim has not
landed yet inside the window.

## Why the paginated calls endpoint

`/programs/:id/latest-calls` serves only the last 1000 calls (~3.6h of activity, and shrinking).
`/programs/:id/latest-calls/paginated` has no such limit. Walking it reaches the program's first
call (2026-07-30 18:36:53 UTC) in 402 pages, and the per-day call counts reconcile **exactly** with
`/metrics/program/:id/range/90` across all 18 historical days, so past windows are fully
measurable and refills work. The walk has zero duplicate `(block_number, transaction_id,
function_id)` keys across 20,082 rows.

The node offers no time or block filter, so reaching a window means paging back from the head.
`getAleoProgramCallsSince` caches that walk per program and extends it rather than repeating it, so
a run covering 24 hourly windows pages the history once instead of once per window.

## Notes for reviewers

- **Backfill cost.** Because there is no range filter, a stateless per-window walk makes a full
  backfill from launch roughly 145k requests against a 100k/day public rate limit, so it may need
  throttling across two days. Steady-state hourly runs are ~300 requests/hour. A
  `from_timestamp`/`to_timestamp` filter on that endpoint would remove this entirely.
- **Transactions** counts accepted and rejected calls to `shield_swap.aleo` per day, as reported by
  the node. A trade is two calls (the swap and the claim that settles it), so this reads roughly 2x
  the trade count; stated in the methodology.
