### PR TITLE
Add Astro (astro-fun) fees adapter

### DIFF
--- a/fees/astro-fun.ts
+++ b/fees/astro-fun.ts
@@ -1,0 +1,99 @@
+import ADDRESSES from "../helpers/coreAssets.json";
+import { FetchOptions, SimpleAdapter } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+import { METRIC } from "../helpers/metrics";
+
+// Astro is a crash game. Every round is settled on-chain against the
+// BankrollVault, which custodies the LP bankroll, the player balances and the
+// stakes in play.
+const BANKROLL_VAULT = "0x58D2f2D46af20C357885d540A9c02fDD791Ee1CF";
+
+// Emitted once per settled round: the total staked by players and the total
+// credited back to the winners. The difference is the house win for the round.
+const ROUND_SETTLED =
+  "event RoundSettled(uint256 totalBets, uint256 totalPayouts, uint256 newPoolAssets)";
+
+// Emitted when a settlement leaves the vault share price above its high water
+// mark. operatorFeeUSDC is the performance fee taken by the protocol on that
+// gain (50% of the eligible profit, minted to the operator as vault shares).
+const PROFIT_RECORDED =
+  "event ProfitRecorded(uint256 grossProfit, uint256 operatorFeeUSDC, uint256 operatorSharesMinted, uint256 newHWM)";
+
+const fetch = async (options: FetchOptions) => {
+  const dailyFees = options.createBalances();
+  const dailyRevenue = options.createBalances();
+  const dailySupplySideRevenue = options.createBalances();
+
+  const [settledLogs, profitLogs] = await Promise.all([
+    options.getLogs({ targets: [BANKROLL_VAULT], eventAbi: ROUND_SETTLED }),
+    options.getLogs({ targets: [BANKROLL_VAULT], eventAbi: PROFIT_RECORDED }),
+  ]);
+
+  // Gross gaming revenue: what players staked minus what they were paid out.
+  let grossGamingRevenue = 0n;
+  for (const log of settledLogs) {
+    const totalBets: bigint = log.totalBets;
+    const totalPayouts: bigint = log.totalPayouts;
+    grossGamingRevenue += totalBets - totalPayouts;
+  }
+
+  // Protocol's cut, read from the events rather than assumed: the fee only
+  // applies to profit above the vault's high water mark, so it is not a flat
+  // share of the gross gaming revenue.
+  let operatorFees = 0n;
+  for (const log of profitLogs) {
+    const operatorFeeUSDC: bigint = log.operatorFeeUSDC;
+    operatorFees += operatorFeeUSDC;
+  }
+
+  dailyFees.add(ADDRESSES.robinhood.USDG, grossGamingRevenue, METRIC.PROTOCOL_FEES);
+  dailyRevenue.add(ADDRESSES.robinhood.USDG, operatorFees, METRIC.PERFORMANCE_FEES);
+  // Everything the protocol does not take stays in the bankroll and accrues to
+  // the LPs through the ASTROLP share price. On a losing day this is negative:
+  // the LPs, not the protocol, absorb the players' winnings.
+  dailySupplySideRevenue.add(
+    ADDRESSES.robinhood.USDG,
+    grossGamingRevenue - operatorFees,
+    METRIC.LP_FEES
+  );
+
+  return {
+    dailyFees,
+    dailyRevenue,
+    dailyProtocolRevenue: dailyRevenue,
+    dailySupplySideRevenue,
+  };
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  pullHourly: true,
+  fetch,
+  chains: [CHAIN.ROBINHOOD],
+  start: "2026-08-11", // BankrollVault deployment
+  // The house can lose: on a day where players cash out more than they stake,
+  // the gross gaming revenue and the LPs' share of it are both negative.
+  allowNegativeValue: true,
+  methodology: {
+    Fees: "Gross gaming revenue: the total staked by players in settled rounds minus the total paid out to them.",
+    Revenue: "Performance fee taken by the protocol on the bankroll's profit above its high water mark (50% of the eligible gain).",
+    ProtocolRevenue: "All of the performance fee goes to the protocol operator.",
+    SupplySideRevenue: "Gross gaming revenue left to the bankroll liquidity providers, accruing to the ASTROLP share price.",
+  },
+  breakdownMethodology: {
+    Fees: {
+      [METRIC.PROTOCOL_FEES]: "Gross gaming revenue from settled crash rounds, in USDG.",
+    },
+    Revenue: {
+      [METRIC.PERFORMANCE_FEES]: "Performance fee on bankroll profit above the high water mark, minted to the operator as ASTROLP shares.",
+    },
+    SupplySideRevenue: {
+      [METRIC.LP_FEES]: "Gross gaming revenue net of the performance fee, accruing to the bankroll liquidity providers.",
+    },
+    ProtocolRevenue: {
+      [METRIC.PERFORMANCE_FEES]: "Performance fee on bankroll profit above the high water mark, minted to the operator as ASTROLP shares.",
+    },
+  },
+};
+
+export default adapter;

--- a/fees/astro-fun.ts
+++ b/fees/astro-fun.ts
@@ -1,7 +1,6 @@
 import ADDRESSES from "../helpers/coreAssets.json";
 import { FetchOptions, SimpleAdapter } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
-import { METRIC } from "../helpers/metrics";
 
 // Astro is a crash game. Every round is settled on-chain against the
 // BankrollVault, which custodies the LP bankroll, the player balances and the
@@ -18,6 +17,11 @@ const ROUND_SETTLED =
 // gain (50% of the eligible profit, minted to the operator as vault shares).
 const PROFIT_RECORDED =
   "event ProfitRecorded(uint256 grossProfit, uint256 operatorFeeUSDC, uint256 operatorSharesMinted, uint256 newHWM)";
+
+// Breakdown labels: source of fees for dailyFees, destination for the splits.
+const HOUSE_WIN = "Crash Round House Win";
+const PERFORMANCE_FEE_TO_OPERATOR = "Bankroll Performance Fee To Operator";
+const HOUSE_WIN_TO_LPS = "Crash Round House Win To Liquidity Providers";
 
 const fetch = async (options: FetchOptions) => {
   const dailyFees = options.createBalances();
@@ -46,15 +50,15 @@ const fetch = async (options: FetchOptions) => {
     operatorFees += operatorFeeUSDC;
   }
 
-  dailyFees.add(ADDRESSES.robinhood.USDG, grossGamingRevenue, METRIC.PROTOCOL_FEES);
-  dailyRevenue.add(ADDRESSES.robinhood.USDG, operatorFees, METRIC.PERFORMANCE_FEES);
+  dailyFees.add(ADDRESSES.robinhood.USDG, grossGamingRevenue, HOUSE_WIN);
+  dailyRevenue.add(ADDRESSES.robinhood.USDG, operatorFees, PERFORMANCE_FEE_TO_OPERATOR);
   // Everything the protocol does not take stays in the bankroll and accrues to
   // the LPs through the ASTROLP share price. On a losing day this is negative:
   // the LPs, not the protocol, absorb the players' winnings.
   dailySupplySideRevenue.add(
     ADDRESSES.robinhood.USDG,
     grossGamingRevenue - operatorFees,
-    METRIC.LP_FEES
+    HOUSE_WIN_TO_LPS
   );
 
   return {
@@ -82,16 +86,16 @@ const adapter: SimpleAdapter = {
   },
   breakdownMethodology: {
     Fees: {
-      [METRIC.PROTOCOL_FEES]: "Gross gaming revenue from settled crash rounds, in USDG.",
+      [HOUSE_WIN]: "Gross gaming revenue from settled crash rounds, in USDG.",
     },
     Revenue: {
-      [METRIC.PERFORMANCE_FEES]: "Performance fee on bankroll profit above the high water mark, minted to the operator as ASTROLP shares.",
+      [PERFORMANCE_FEE_TO_OPERATOR]: "Performance fee on bankroll profit above the high water mark, minted to the operator as ASTROLP shares.",
     },
     SupplySideRevenue: {
-      [METRIC.LP_FEES]: "Gross gaming revenue net of the performance fee, accruing to the bankroll liquidity providers.",
+      [HOUSE_WIN_TO_LPS]: "Gross gaming revenue net of the performance fee, accruing to the bankroll liquidity providers.",
     },
     ProtocolRevenue: {
-      [METRIC.PERFORMANCE_FEES]: "Performance fee on bankroll profit above the high water mark, minted to the operator as ASTROLP shares.",
+      [PERFORMANCE_FEE_TO_OPERATOR]: "Performance fee on bankroll profit above the high water mark, minted to the operator as ASTROLP shares.",
     },
   },
 };


### PR DESCRIPTION
Fees/revenue adapter for **Astro**, already listed on DefiLlama (TVL added by a maintainer in DefiLlama/DefiLlama-Adapters#20666, key `astro-fun`): https://defillama.com/protocol/astro

- **Name:** Astro
- **Website:** https://astro.fun
- **Twitter:** https://x.com/astrofungame
- **Chain:** Robinhood Chain (4663)
- **Short description:** Astro is a provably fair crash game that settles in USDG. Users can either play or deposit and hold ASTROLP shares to take the House side.
- **Token:** none (ASTROLP is the ERC-4626 vault share, not a tradable token)

### What is counted

| Dimension | Value | Source |
|---|---|---|
| `dailyFees` | GGR: total staked − total paid out to winners | `RoundSettled` event |
| `dailyRevenue` | Operator performance fee | `ProfitRecorded` event |
| `dailyProtocolRevenue` | Same as revenue (no token, nothing to holders) | idem |
| `dailySupplySideRevenue` | The rest, accruing to LPs via the ASTROLP share price | derived |

Only `getLogs` on the BankrollVault (`0x58D2f2D46af20C357885d540A9c02fDD791Ee1CF`), no API calls, no new dependencies.

### Two things that look wrong but aren't

1. **`allowNegativeValue: true`** — on hours/days where players cash out more than they stake, the GGR and the LP share are negative. The bankroll (the LPs) absorbs the loss; this is the reality of a house-side product and other gambling adapters in the repo do the same.
2. **Revenue is not 50% of fees** — the performance fee only applies to vault profit above its high water mark, so the adapter reads `operatorFeeUSDC` from the event instead of applying a ratio. `Revenue = 0` alongside non-zero `Fees` is expected while the HWM has not been reclaimed.

### Test output (`pnpm test fees astro-fun`)

24 hourly slots, some positive, some negative:

```
ROBINHOOD
Daily fees: 39.77
Daily revenue: 0.00
Daily protocol revenue: 0.00
Daily supply side revenue: 39.77

label         | Daily fees | Daily supply side revenue
Protocol Fees | 39.77      |
LP Fees       |            | 39.77
```

Diff contains only `fees/astro-fun.ts` — no lockfile or `package.json` changes.
