### PR TITLE
bouncebit-cedefi: throw when the fee api has no entry for the day instead of publishing zero

### DIFF
--- a/fees/bouncebit-cedefi/index.ts
+++ b/fees/bouncebit-cedefi/index.ts
@@ -2,7 +2,7 @@ import { Adapter, FetchOptions } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 import fetchURL from "../../utils/fetchURL";
 
-const bbscanApiURL = "https://api-portal.bouncebit.io/api/fee/stats";
+const bbscanApiURL = "https://api.bouncebit.io/api/v4/dashboard/fee/stats";
 
 interface DailyStats {
   date: string;
@@ -14,12 +14,12 @@ const fetch = async (options: FetchOptions) => {
   const stats: DailyStats[] = (await fetchURL(bbscanApiURL)).result;
 
   const lastStat = stats[stats.length - 1];
-  if (!lastStat || options.startOfDay > lastStat.timestamp) {
+  if (!lastStat || options.dateString > lastStat.date) {
     throw new Error(`api has no fee stats for ${options.dateString} yet, last available day is ${lastStat?.date}`);
   }
 
   const dailyFees = (() => {
-    const idx = stats.findIndex(stat => stat.timestamp === options.startOfDay);
+    const idx = stats.findIndex(stat => stat.date === options.dateString);
     if (idx === -1) return 0;
     if (idx === 0) return stats[0]?.fee || 0;
     return (stats[idx]?.fee || 0) - (stats[idx - 1]?.fee || 0)

--- a/fees/bouncebit-cedefi/index.ts
+++ b/fees/bouncebit-cedefi/index.ts
@@ -13,6 +13,11 @@ interface DailyStats {
 const fetch = async (options: FetchOptions) => {
   const stats: DailyStats[] = (await fetchURL(bbscanApiURL)).result;
 
+  const lastStat = stats[stats.length - 1];
+  if (!lastStat || options.startOfDay > lastStat.timestamp) {
+    throw new Error(`api has no fee stats for ${options.dateString} yet, last available day is ${lastStat?.date}`);
+  }
+
   const dailyFees = (() => {
     const idx = stats.findIndex(stat => stat.timestamp === options.startOfDay);
     if (idx === -1) return 0;


### PR DESCRIPTION
Fixes #8998

the adapter maps a day missing from `api-portal.bouncebit.io/api/fee/stats` to $0. the api's daily list currently ends at 08-23 (their stats job lags), so 08-24 and 08-25 published as wrong zeros on a series that runs $10-19k/day.

the list is 650 contiguous daily entries with no gaps, so a day past the last entry can only mean "not produced yet"; this now throws, which leaves the day absent and refillable instead of a fake zero. days inside the list behave exactly as before.

harness verified both directions twice: day 08-22 still returns 16.32k (matches published 16,315), day 08-24 now throws `api has no fee stats for 2026-08-24 yet, last available day is 2026-08-23`.

08-24 and 08-25 will need a refill once the api catches up.
