### PR TITLE
Add LP Agent fees adapter (Solana + Robinhood Chain)

### DIFF
--- a/fees/lp-agent.ts
+++ b/fees/lp-agent.ts
@@ -19,9 +19,11 @@
 // commission — they hold no user funds, run no treasury operations, and have
 // never sent a transfer out.
 //
-// dailyFees = dailyRevenue = dailyProtocolRevenue = everything those wallets
-// receive. LP Agent keeps all of it: there is no token, no holder distribution
-// and no supply-side split paid out on chain.
+// Those wallet receipts are the 8% performance fee (dailyRevenue =
+// dailyProtocolRevenue). Gross claimed LP fees are back-calculated as
+// commission / 0.08; the remaining 92% stays in the user's wallet
+// (dailySupplySideRevenue). Underlying DEX swap fees are already tracked by
+// Meteora / Uniswap, so this adapter is marked doublecounted.
 //
 // On Robinhood Chain only the native gas token is counted. The commission there
 // settles in native ETH, which the Allium trace fallback picks up whether it
@@ -31,27 +33,63 @@
 // -----------------------------------------------------------------------------------------------------
 import { Dependencies, FetchOptions, SimpleAdapter } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
+import { METRIC } from "../helpers/metrics";
 import { getETHReceived, getSolanaReceived } from "../helpers/token";
 
 const SOLANA_FEE_WALLET = "6ibaAcfpedjQucEpia9YtvkD6C3pEEf6zEdTutQzPb7M";
 const ROBINHOOD_FEE_WALLET = "0x56bf1CcC07988eB1fFB071C420c3a987252e501F";
 
+// 8% of claimed LP fees, per https://docs.lpagent.io/fee
+const PERFORMANCE_FEE_RATE = 0.08;
+
 const fetch = async (options: FetchOptions) => {
-  const dailyFees = options.createBalances();
+  const commission = options.createBalances();
 
   if (options.chain === CHAIN.SOLANA) {
-    await getSolanaReceived({ options, target: SOLANA_FEE_WALLET, balances: dailyFees });
+    await getSolanaReceived({ options, target: SOLANA_FEE_WALLET, balances: commission });
   } else {
-    await getETHReceived({ options, target: ROBINHOOD_FEE_WALLET, balances: dailyFees });
+    await getETHReceived({ options, target: ROBINHOOD_FEE_WALLET, balances: commission });
   }
 
-  return { dailyFees, dailyRevenue: dailyFees, dailyProtocolRevenue: dailyFees };
+  const dailyRevenue = options.createBalances();
+  dailyRevenue.addBalances(commission, METRIC.PERFORMANCE_FEES);
+
+  const dailySupplySideRevenue = options.createBalances();
+  dailySupplySideRevenue.addBalances(commission.clone((1 - PERFORMANCE_FEE_RATE) / PERFORMANCE_FEE_RATE), METRIC.LP_FEES);
+
+  const dailyFees = options.createBalances();
+  dailyFees.addBalances(dailySupplySideRevenue);
+  dailyFees.addBalances(dailyRevenue);
+
+  return {
+    dailyFees,
+    dailyRevenue,
+    dailyProtocolRevenue: dailyRevenue,
+    dailySupplySideRevenue,
+  };
 };
 
 const methodology = {
-  Fees: "The 8% commission LP Agent charges on the LP fees each managed position claims — taken at claim time and on the fee portion of a decrease or close, never on position principal. Measured as the value received by LP Agent's fee wallet on each chain.",
-  Revenue: "All fees charged are kept by LP Agent.",
-  ProtocolRevenue: "Same as Revenue — LP Agent has no token and distributes none of the fees on chain.",
+  Fees: "Total LP trading fees claimed by managed positions (Meteora DLMM and DAMM v2 on Solana, Uniswap V3 on Robinhood Chain). LP Agent's on-chain footprint is only the 8% commission, so gross claimed fees are back-calculated as commission / 0.08.",
+  Revenue: "The 8% commission LP Agent takes on claimed LP fees — at claim time and on the fee portion of a decrease or close, never on position principal. Measured as transfers into the per-chain fee wallet. LP Agent retains all of it.",
+  ProtocolRevenue: "The 8% commission retained by LP Agent. There is no token, no holder split, and no on-chain distribution of this inflow.",
+  SupplySideRevenue: "The remaining 92% of claimed LP fees, which stay in the user's own wallet.",
+};
+
+const breakdownMethodology = {
+  Fees: {
+    [METRIC.LP_FEES]: "92% of claimed LP trading fees kept by the position owner after LP Agent's commission.",
+    [METRIC.PERFORMANCE_FEES]: "LP Agent's 8% commission on claimed LP fees, received by the per-chain fee wallet.",
+  },
+  Revenue: {
+    [METRIC.PERFORMANCE_FEES]: "The 8% commission retained by LP Agent. There is no token, no holder split, and no on-chain distribution of this inflow.",
+  },
+  ProtocolRevenue: {
+    [METRIC.PERFORMANCE_FEES]: "The 8% commission retained by LP Agent. The fee wallets are receive-only EOAs; none of this inflow is distributed on chain.",
+  },
+  SupplySideRevenue: {
+    [METRIC.LP_FEES]: "92% of claimed LP trading fees remaining in the user's wallet after the 8% commission.",
+  },
 };
 
 const adapter: SimpleAdapter = {
@@ -63,7 +101,10 @@ const adapter: SimpleAdapter = {
     [CHAIN.SOLANA]: { start: "2025-06-01" },
     [CHAIN.ROBINHOOD]: { start: "2026-08-18" },
   },
+  isExpensiveAdapter: true,
   methodology,
+  breakdownMethodology,
+  doublecounted: true, // underlying Meteora / Uniswap V3 swap fees
 };
 
 export default adapter;

--- a/fees/lp-agent.ts
+++ b/fees/lp-agent.ts
@@ -5,34 +5,29 @@
 // closes concentrated-liquidity positions on their behalf — Meteora (DLMM and
 // DAMM v2) on Solana, and Uniswap V3 on Robinhood Chain.
 //
-// LP Agent charges its users three fees, and every one of them settles as a
-// transfer into a single fee wallet per chain:
+// LP Agent charges a single fee: an 8% commission on the LP fees a managed
+// position claims. It is taken at claim time and on the fee portion of a
+// decrease or close, never on position principal, and it settles as a transfer
+// into one fee wallet per chain:
 //
-//   1. 8% commission on the LP fees a position claims — taken at claim time and
-//      on the fee portion of a decrease/close, never on principal.
-//   2. 20% performance fee on a position's realised PnL, taken when the position
-//      is closed and audited.
-//   3. Swap referral commission on the aggregator routes the agent uses to enter
-//      and exit positions.
-//
-// Fee wallets. Both are plain externally-owned accounts that exist only to
-// receive these fees — they hold no user funds, run no treasury operations, and
-// have never sent a transfer out:
 //   Solana:          6ibaAcfpedjQucEpia9YtvkD6C3pEEf6zEdTutQzPb7M
 //                    https://solscan.io/account/6ibaAcfpedjQucEpia9YtvkD6C3pEEf6zEdTutQzPb7M
 //   Robinhood Chain: 0x56bf1CcC07988eB1fFB071C420c3a987252e501F
 //                    https://robinhoodchain.blockscout.com/address/0x56bf1CcC07988eB1fFB071C420c3a987252e501F
 //
+// Both are plain externally-owned accounts that exist only to receive this
+// commission — they hold no user funds, run no treasury operations, and have
+// never sent a transfer out.
+//
 // dailyFees = dailyRevenue = dailyProtocolRevenue = everything those wallets
 // receive. LP Agent keeps all of it: there is no token, no holder distribution
 // and no supply-side split paid out on chain.
 //
-// On Robinhood Chain only the native gas token is counted. Both fee streams there
-// settle in native ETH — the commission is a plain native transfer, and the
-// referral cut on a native-input route arrives as an internal call — whereas the
-// handful of ERC20 transfers that wallet has received are operational top-ups and
-// unsolicited airdrops rather than fees, and counting them would overstate
-// revenue.
+// On Robinhood Chain only the native gas token is counted. The commission there
+// settles in native ETH, which the Allium trace fallback picks up whether it
+// arrives as a top-level transfer or an internal call. The handful of ERC20
+// transfers that wallet has received are operational top-ups and unsolicited
+// airdrops rather than fees, and counting them would overstate revenue.
 // -----------------------------------------------------------------------------------------------------
 import { Dependencies, FetchOptions, SimpleAdapter } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
@@ -54,7 +49,7 @@ const fetch = async (options: FetchOptions) => {
 };
 
 const methodology = {
-  Fees: "Fees LP Agent charges for managing a user's liquidity positions: an 8% commission on the LP fees each position claims, a 20% performance fee on a position's realised PnL, and the swap referral commission on the routes used to enter and exit positions. Measured as the value received by LP Agent's fee wallet on each chain.",
+  Fees: "The 8% commission LP Agent charges on the LP fees each managed position claims — taken at claim time and on the fee portion of a decrease or close, never on position principal. Measured as the value received by LP Agent's fee wallet on each chain.",
   Revenue: "All fees charged are kept by LP Agent.",
   ProtocolRevenue: "Same as Revenue — LP Agent has no token and distributes none of the fees on chain.",
 };

--- a/fees/lp-agent.ts
+++ b/fees/lp-agent.ts
@@ -1,0 +1,74 @@
+// LP Agent — fees & revenue adapter.
+//
+// LP Agent (https://lpagent.io) is an automated liquidity-management agent. Users
+// keep custody of their own wallets; the agent opens, rebalances, compounds and
+// closes concentrated-liquidity positions on their behalf — Meteora (DLMM and
+// DAMM v2) on Solana, and Uniswap V3 on Robinhood Chain.
+//
+// LP Agent charges its users three fees, and every one of them settles as a
+// transfer into a single fee wallet per chain:
+//
+//   1. 8% commission on the LP fees a position claims — taken at claim time and
+//      on the fee portion of a decrease/close, never on principal.
+//   2. 20% performance fee on a position's realised PnL, taken when the position
+//      is closed and audited.
+//   3. Swap referral commission on the aggregator routes the agent uses to enter
+//      and exit positions.
+//
+// Fee wallets. Both are plain externally-owned accounts that exist only to
+// receive these fees — they hold no user funds, run no treasury operations, and
+// have never sent a transfer out:
+//   Solana:          6ibaAcfpedjQucEpia9YtvkD6C3pEEf6zEdTutQzPb7M
+//                    https://solscan.io/account/6ibaAcfpedjQucEpia9YtvkD6C3pEEf6zEdTutQzPb7M
+//   Robinhood Chain: 0x56bf1CcC07988eB1fFB071C420c3a987252e501F
+//                    https://robinhoodchain.blockscout.com/address/0x56bf1CcC07988eB1fFB071C420c3a987252e501F
+//
+// dailyFees = dailyRevenue = dailyProtocolRevenue = everything those wallets
+// receive. LP Agent keeps all of it: there is no token, no holder distribution
+// and no supply-side split paid out on chain.
+//
+// On Robinhood Chain only the native gas token is counted. Both fee streams there
+// settle in native ETH — the commission is a plain native transfer, and the
+// referral cut on a native-input route arrives as an internal call — whereas the
+// handful of ERC20 transfers that wallet has received are operational top-ups and
+// unsolicited airdrops rather than fees, and counting them would overstate
+// revenue.
+// -----------------------------------------------------------------------------------------------------
+import { Dependencies, FetchOptions, SimpleAdapter } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+import { getETHReceived, getSolanaReceived } from "../helpers/token";
+
+const SOLANA_FEE_WALLET = "6ibaAcfpedjQucEpia9YtvkD6C3pEEf6zEdTutQzPb7M";
+const ROBINHOOD_FEE_WALLET = "0x56bf1CcC07988eB1fFB071C420c3a987252e501F";
+
+const fetch = async (options: FetchOptions) => {
+  const dailyFees = options.createBalances();
+
+  if (options.chain === CHAIN.SOLANA) {
+    await getSolanaReceived({ options, target: SOLANA_FEE_WALLET, balances: dailyFees });
+  } else {
+    await getETHReceived({ options, target: ROBINHOOD_FEE_WALLET, balances: dailyFees });
+  }
+
+  return { dailyFees, dailyRevenue: dailyFees, dailyProtocolRevenue: dailyFees };
+};
+
+const methodology = {
+  Fees: "Fees LP Agent charges for managing a user's liquidity positions: an 8% commission on the LP fees each position claims, a 20% performance fee on a position's realised PnL, and the swap referral commission on the routes used to enter and exit positions. Measured as the value received by LP Agent's fee wallet on each chain.",
+  Revenue: "All fees charged are kept by LP Agent.",
+  ProtocolRevenue: "Same as Revenue — LP Agent has no token and distributes none of the fees on chain.",
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  pullHourly: true,
+  dependencies: [Dependencies.ALLIUM],
+  fetch,
+  adapter: {
+    [CHAIN.SOLANA]: { start: "2025-06-01" },
+    [CHAIN.ROBINHOOD]: { start: "2026-08-18" },
+  },
+  methodology,
+};
+
+export default adapter;


### PR DESCRIPTION
Fees adapter for **LP Agent** — an automated liquidity-management agent. Users keep custody of their own wallets while the agent opens, rebalances, compounds and closes concentrated-liquidity positions for them: Meteora (DLMM, DAMM v2) on Solana and Uniswap V3 on Robinhood Chain.

Submitted here at @RohanNero's suggestion after our TVL adapter was closed in DefiLlama/DefiLlama-Adapters#20566 ("if you charge any fees we may be able to include them here").

### Fees

One fee: an **8% commission on the LP fees a managed position claims**, taken at claim time and on the fee portion of a decrease or close, never on principal. No performance fee, no aggregator referral cut.

`dailyFees = dailyRevenue = dailyProtocolRevenue` — LP Agent keeps all of it. No token, no holders revenue, no supply-side split.

### Fee wallets

Plain EOAs that only receive this commission — no user funds, and neither has ever sent a transfer out.

| Chain | Address | Start |
|---|---|---|
| Solana | [`6ibaAcfpedjQucEpia9YtvkD6C3pEEf6zEdTutQzPb7M`](https://solscan.io/account/6ibaAcfpedjQucEpia9YtvkD6C3pEEf6zEdTutQzPb7M) | 2025-06-01 |
| Robinhood Chain | [`0x56bf1CcC07988eB1fFB071C420c3a987252e501F`](https://robinhoodchain.blockscout.com/address/0x56bf1CcC07988eB1fFB071C420c3a987252e501F) | 2026-08-18 |

Solana uses `getSolanaReceived`, Robinhood uses `getETHReceived` (chain 4663 goes through the helper's `raw.traces` fallback, same as `fees/kyberswap-aggregator.ts`). Robinhood counts the native token only — its ERC20 inflows are operational top-ups and airdrops, not fees.

The `test` job fails with `Allium API Key is required[Ignore this error for github bot]`; `ts-check` passes.

### Protocol metadata

LP Agent isn't listed on DefiLlama yet, so it needs a protocol entry:

- **Name:** LP Agent
- **Website:** https://lpagent.io
- **Twitter:** https://x.com/lpagent_io
- **Logo:** https://app.lpagent.io/logo.svg (512px PNG: https://app.lpagent.io/manifest-icon-512.maskable.png)
- **Category:** Liquidity Automation
- **Chains:** Solana, Robinhood Chain
