### PR TITLE
feat(aggregators): add routhex and autobahn Solana aggregators

### DIFF
--- a/aggregators/autobahn/index.ts
+++ b/aggregators/autobahn/index.ts
@@ -1,0 +1,56 @@
+import { CHAIN } from "../../helpers/chains";
+import {
+  Dependencies,
+  FetchOptions,
+  SimpleAdapter,
+} from "../../adapters/types";
+import { queryDuneSql } from "../../helpers/dune";
+
+// Autobahn is a Solana swap aggregator. Every swap it routes is initiated by its
+// on-chain executor program, which dex_solana.trades tags via `trade_source`. A
+// single swap can touch several pools (multi-hop), producing one row per hop, so
+// we deduplicate to one representative row per swap instruction — the largest-USD
+// hop per (tx_id, trader_id, outer_instruction_index) — mirroring the Jupiter
+// aggregator adapter's methodology, before summing.
+const AUTOBAHN_EXECUTOR = "bZbg2i9RhaQg2mEwYDRdrtacQZWKuiioRUmTzmNpu4D";
+
+const fetch = async (options: FetchOptions) => {
+  const data = await queryDuneSql(
+    options,
+    `
+    SELECT COALESCE(SUM(amount_usd), 0) AS volume
+    FROM (
+      SELECT
+        amount_usd,
+        ROW_NUMBER() OVER (
+          PARTITION BY tx_id, trader_id, outer_instruction_index
+          ORDER BY amount_usd DESC
+        ) AS rn
+      FROM dex_solana.trades
+      WHERE block_time >= from_unixtime(${options.startTimestamp})
+        AND block_time <  from_unixtime(${options.endTimestamp})
+        AND trade_source = '${AUTOBAHN_EXECUTOR}'
+    )
+    WHERE rn = 1
+    `,
+  );
+
+  return { dailyVolume: data[0].volume };
+};
+
+const adapter: SimpleAdapter = {
+  version: 1,
+  fetch,
+  start: "2026-07-09", // first observed trade in dex_solana.trades
+  chains: [CHAIN.SOLANA],
+  dependencies: [Dependencies.DUNE],
+  methodology: {
+    Volume:
+      "Sum of the USD value of all swaps routed through the Autobahn aggregator, " +
+      "read from dex_solana.trades filtered by Autobahn's executor program as trade_source. " +
+      "Multi-hop swaps are deduplicated to the largest-USD hop per swap instruction to avoid double counting.",
+  },
+  isExpensiveAdapter: true,
+};
+
+export default adapter;

--- a/aggregators/autobahn/index.ts
+++ b/aggregators/autobahn/index.ts
@@ -41,7 +41,7 @@ const fetch = async (options: FetchOptions) => {
 const adapter: SimpleAdapter = {
   version: 1,
   fetch,
-  start: "2026-07-09", // first observed trade in dex_solana.trades
+  start: "2026-01-15", // first trade in dex_solana.trades (Dune MIN(block_time))
   chains: [CHAIN.SOLANA],
   dependencies: [Dependencies.DUNE],
   methodology: {

--- a/aggregators/routhex/index.ts
+++ b/aggregators/routhex/index.ts
@@ -1,0 +1,35 @@
+import { httpGet } from "../../utils/fetchURL";
+import { FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+
+// Routhex is a Solana meta-aggregator: it compares quotes across underlying
+// providers (Jupiter, DFlow, Autobahn) and returns the best route. Because it
+// delegates execution to those providers' programs, a routhex swap has no single
+// on-chain program/event that could be decoded on Dune. Volume is therefore
+// served from routhex's own indexer, which persists every routed swap with its
+// USD value. The endpoint sums usd_volume over the [start, end) window that
+// DefiLlama's fetch() passes and returns it as `dailyVolume`.
+const VOLUME_ENDPOINT = "https://swap.io/internal-api/pulsar-persister-api/defillama/volume";
+
+const fetch = async ({ fromTimestamp, toTimestamp }: FetchOptions) => {
+  const res = await httpGet(
+    `${VOLUME_ENDPOINT}?start=${fromTimestamp}&end=${toTimestamp}`
+  );
+  return { dailyVolume: res.dailyVolume };
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  adapter: {
+    [CHAIN.SOLANA]: {
+      fetch,
+      start: "2025-10-01", // first swap volume observed in the indexer (Oct 2025)
+    },
+  },
+  methodology: {
+    Volume:
+      "Sum of the USD value of all swaps routed by the Routhex aggregator, as recorded by Routhex's transaction indexer.",
+  },
+};
+
+export default adapter;

--- a/aggregators/routhex/index.ts
+++ b/aggregators/routhex/index.ts
@@ -3,29 +3,25 @@ import { FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 
 // Routhex is a Solana meta-aggregator: it compares quotes across underlying
-// providers (Jupiter, DFlow, Autobahn) and returns the best route. Because it
-// delegates execution to those providers' programs, a routhex swap has no single
-// on-chain program/event that could be decoded on Dune. Volume is therefore
-// served from routhex's own indexer, which persists every routed swap with its
-// USD value. The endpoint sums usd_volume over the [start, end) window that
-// DefiLlama's fetch() passes and returns it as `dailyVolume`.
+// providers (Jupiter, DFlow, Autobahn, OKX) and returns the best route. Because it
+// delegates execution to those providers' programs, a Routhex swap has no single
+// on-chain program/event to decode on Dune. Volume is served from Routhex's own
+// indexer, which persists every routed swap with its USD value; the endpoint sums
+// usd_volume over the [start, end) window and returns it as `dailyVolume`.
 const VOLUME_ENDPOINT = "https://swap.io/internal-api/pulsar-persister-api/defillama/volume";
 
-const fetch = async ({ fromTimestamp, toTimestamp }: FetchOptions) => {
+const fetch = async (options: FetchOptions) => {
   const res = await httpGet(
-    `${VOLUME_ENDPOINT}?start=${fromTimestamp}&end=${toTimestamp}`
+    `${VOLUME_ENDPOINT}?start=${options.startTimestamp}&end=${options.endTimestamp}`
   );
   return { dailyVolume: res.dailyVolume };
 };
 
 const adapter: SimpleAdapter = {
-  version: 2,
-  adapter: {
-    [CHAIN.SOLANA]: {
-      fetch,
-      start: "2025-10-01", // first swap volume observed in the indexer (Oct 2025)
-    },
-  },
+  version: 1,
+  fetch,
+  chains: [CHAIN.SOLANA],
+  start: "2025-10-01", // first swap volume observed in the indexer (Oct 2025)
   methodology: {
     Volume:
       "Sum of the USD value of all swaps routed by the Routhex aggregator, as recorded by Routhex's transaction indexer.",


### PR DESCRIPTION
Adds two Solana swap aggregators from the Swap.io team (volume-only; aggregators
  have no TVL). Same team as the existing "Swap.io CLMM" (defillama id 6829,
  https://swap.io) — ideally grouped under a shared "Swap.io" parent protocol,
  using the same logo as Swap.io CLMM.

  ## Swap.io Routhex (aggregators/routhex)
  Solana DEX meta-aggregator routing swaps across Jupiter, DFlow, Autobahn and OKX
  for best execution. No single on-chain program to decode — volume is served from
  Routhex's own indexer.
  - Display name: Swap.io Routhex
  - Chain: Solana
  - Category: DEX Aggregator
  - Website: https://swap.io
  - Logo: same as Swap.io CLMM (https://icons.llamao.fi/icons/protocols/swap.io-clmm)
  - Volume endpoint: GET https://swap.io/internal-api/pulsar-persister-api/defillama/volume?start=<unix>&end=<unix> => {"dailyVolume": <usd>}
  - Methodology: sum of USD value of every swap routed by Routhex in the window.
  - Tested locally: `npm test aggregators routhex` ✅

  ## Swap.io Autobahn (aggregators/autobahn)
  Solana DEX aggregator (our deployment) with on-chain executor program
  `bZbg2i9RhaQg2mEwYDRdrtacQZWKuiioRUmTzmNpu4D`. Swaps are tagged in
  dex_solana.trades via trade_source, so volume is read from Dune.
  - Display name: Swap.io Autobahn
  - Chain: Solana
  - Category: DEX Aggregator
  - Website: https://swap.io
  - Logo: same as Swap.io CLMM (https://icons.llamao.fi/icons/protocols/swap.io-clmm)
  - Methodology: sum of amount_usd from dex_solana.trades where trade_source is the
    executor program; multi-hop deduped to the largest-USD hop per swap instruction
    (same as the Jupiter aggregator adapter, PR #8289).
  - Data source: Dune (dependencies: [DUNE])