### PR TITLE
obol: throw when the api omits total_fees_eth_denominated

### DIFF
--- a/fees/obol/index.ts
+++ b/fees/obol/index.ts
@@ -24,7 +24,10 @@ const correctedTotalRevenues: Record<string, number> = {
 const fetchCumulativeData = async (dateStr: string) => {
   const url = `${ENDPOINT_BASE}?limit=1&page=0&timestamp=${encodeURIComponent(dateStr)}`;
   const data = await httpGet(url);
-  return { totalFees: Number(data.total_fees_eth_denominated ?? 0), totalRevenue: correctedTotalRevenues[dateStr] ?? Number(data.total_revenue ?? 0) };
+  if (data?.total_fees_eth_denominated == null) {
+    throw new Error(`Obol API returned no fee data for ${dateStr}`);
+  }
+  return { totalFees: Number(data.total_fees_eth_denominated), totalRevenue: correctedTotalRevenues[dateStr] ?? Number(data.total_revenue ?? 0) };
 };
 
 const getPreviousDay = (dateStr: string) => {


### PR DESCRIPTION
Fixes #9011

the obol tvs endpoint stopped returning `total_fees_eth_denominated` and `total_revenue` on 2026-08-17. the adapter is a day-over-day delta on a cumulative total, so the `?? 0` fallback produced a -858 eth (-$1.64M) delta on the changeover day and an exact 0 every day since; no error, so it reads as a live protocol earning nothing while tvl sits at $622M.

harness, with the change:

```
fees obol 2026-08-26   -> Error: Obol API returned no fee data for 2026-08-25
fees obol 2026-08-18   -> Error: Obol API returned no fee data for 2026-08-17   (was -1.64 M)
fees obol 2026-08-17   -> fees -1200, supply side -5323, revenue 4124           (unchanged)
```

the control day matches what the site currently publishes for 08-16 (-1198 / -5317 / 4119).