### PR TITLE
propr: repoint revenue api to api.propr.xyz

### DIFF
--- a/fees/propr/index.ts
+++ b/fees/propr/index.ts
@@ -2,7 +2,7 @@ import { SimpleAdapter, FetchOptions } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 import { httpGet } from "../../utils/fetchURL";
 
-const PROPR_API = "https://www.propr.xyz/api/propr";
+const PROPR_API = "https://api.propr.xyz";
 const REVENUE_HISTORY_DAYS = 1000;
 const PAYOUTS = "0x6E810d5c33a4355cE1b4107F5722787bFD7AcF24";
 const PAYOUT_EVENT = "event PayoutEvent(uint8 indexed reason, bytes12 indexed payoutId, bytes12 indexed userId, bytes12 accountId, address token, uint256 amount, address from, address to, address signer)";


### PR DESCRIPTION
Fixes #9013

`www.propr.xyz/api/propr` now serves a next.js 404 page, so the adapter has thrown on every run since 2026-07-26, 32 days of `total24h: null`. the endpoint moved to `api.propr.xyz` with the same `{date, dailyRevenue, cumulativeRevenue}` shape.

```
$ npx ts-node cli/testAdapter.ts fees propr 2026-08-26
master   ------ ERROR ------ Request failed with status code 404
patched  Daily fees: 52.58 k   (Challenge Fees & Subscriptions | 52582)

$ npx ts-node cli/testAdapter.ts fees propr 2026-07-25     # last published day
patched  Daily fees: 10.53 k   (Challenge Fees & Subscriptions | 10527)
```

the control day matches the 10527 the site published for 2026-07-24, so it's the same series on the new host.