### PR TITLE
[fix] Ophis - report complete fees, volume, and users

### DIFF
--- a/active-users/ophis.ts
+++ b/active-users/ophis.ts
@@ -1,7 +1,16 @@
 import { FetchOptions, SimpleAdapter } from "../adapters/types";
-import { fetchOphisChainDay, ophisChainConfig } from "../helpers/ophis";
+import { CHAIN } from "../helpers/chains";
+import { fetchOphisChainDay, fetchOphisProtocolDay, OPHIS_START, ophisChainConfig } from "../helpers/ophis";
 
 const fetch = async (options: FetchOptions) => {
+  if (options.chain === CHAIN.CHAIN_GLOBAL) {
+    const totals = await fetchOphisProtocolDay(options);
+    return {
+      dailyActiveUsers: totals.users,
+      dailyTransactionsCount: totals.transactions,
+    };
+  }
+
   const row = await fetchOphisChainDay(options);
   return {
     dailyActiveUsers: row?.users ?? 0,
@@ -12,9 +21,14 @@ const fetch = async (options: FetchOptions) => {
 const adapter: SimpleAdapter = {
   version: 1,
   fetch,
-  adapter: ophisChainConfig,
+  // Per-chain user counts are not additive when one wallet uses multiple chains.
+  // chain_global supplies DefiLlama's aggregate while retaining chain breakdowns.
+  adapter: {
+    ...ophisChainConfig,
+    [CHAIN.CHAIN_GLOBAL]: { start: OPHIS_START },
+  },
   methodology: {
-    ActiveUsers: "Unique Ophis-attributed user wallets with at least one successfully settled fill during the UTC day, sourced from Ophis' validated settlement-fill ledger.",
+    ActiveUsers: "Unique Ophis-attributed user wallets with at least one successfully settled fill during the UTC day, deduplicated across all supported chains and sourced from Ophis' validated settlement-fill ledger.",
     Transactions: "Distinct onchain settlement transaction hashes containing successfully settled Ophis-attributed fills during the UTC day.",
   },
   breakdownMethodology: {

--- a/active-users/ophis.ts
+++ b/active-users/ophis.ts
@@ -1,37 +1,8 @@
 import { FetchOptions, SimpleAdapter } from "../adapters/types";
-import { CHAIN } from "../helpers/chains";
-import fetchURL from "../utils/fetchURL";
-
-const API = "https://rebates.ophis.fi/defillama";
-
-const chainIds: Record<string, number> = {
-  [CHAIN.ETHEREUM]: 1,
-  [CHAIN.OPTIMISM]: 10,
-  [CHAIN.BSC]: 56,
-  [CHAIN.XDAI]: 100,
-  [CHAIN.UNICHAIN]: 130,
-  [CHAIN.POLYGON]: 137,
-  [CHAIN.ROBINHOOD]: 4663,
-  [CHAIN.BASE]: 8453,
-  [CHAIN.PLASMA]: 9745,
-  [CHAIN.ARBITRUM]: 42161,
-  [CHAIN.AVAX]: 43114,
-  [CHAIN.INK]: 57073,
-  [CHAIN.LINEA]: 59144,
-};
-
-interface ChainDay {
-  chainId: number;
-  transactions: number;
-  users: number;
-}
+import { fetchOphisChainDay, ophisChainConfig } from "../helpers/ophis";
 
 const fetch = async (options: FetchOptions) => {
-  const response = await fetchURL(`${API}?date=${encodeURIComponent(options.dateString)}`);
-  if (!response?.ok || !Array.isArray(response.chains)) {
-    throw new Error(`ophis: incomplete reporting response for ${options.dateString}`);
-  }
-  const row = (response.chains as ChainDay[]).find((item) => item.chainId === chainIds[options.chain]);
+  const row = await fetchOphisChainDay(options);
   return {
     dailyActiveUsers: row?.users ?? 0,
     dailyTransactionsCount: row?.transactions ?? 0,
@@ -41,8 +12,7 @@ const fetch = async (options: FetchOptions) => {
 const adapter: SimpleAdapter = {
   version: 1,
   fetch,
-  chains: Object.keys(chainIds),
-  start: "2026-05-14",
+  adapter: ophisChainConfig,
 };
 
 export default adapter;

--- a/active-users/ophis.ts
+++ b/active-users/ophis.ts
@@ -13,6 +13,18 @@ const adapter: SimpleAdapter = {
   version: 1,
   fetch,
   adapter: ophisChainConfig,
+  methodology: {
+    ActiveUsers: "Unique Ophis-attributed user wallets with at least one successfully settled fill during the UTC day, sourced from Ophis' validated settlement-fill ledger.",
+    Transactions: "Distinct onchain settlement transaction hashes containing successfully settled Ophis-attributed fills during the UTC day.",
+  },
+  breakdownMethodology: {
+    ActiveUsers: {
+      "Ophis traders": "Unique attributed user wallets across successfully settled Ophis fills.",
+    },
+    Transactions: {
+      "Ophis settlements": "Distinct settlement transaction hashes; multiple fills in one transaction are counted once.",
+    },
+  },
 };
 
 export default adapter;

--- a/active-users/ophis.ts
+++ b/active-users/ophis.ts
@@ -1,0 +1,48 @@
+import { FetchOptions, SimpleAdapter } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+import fetchURL from "../utils/fetchURL";
+
+const API = "https://rebates.ophis.fi/defillama";
+
+const chainIds: Record<string, number> = {
+  [CHAIN.ETHEREUM]: 1,
+  [CHAIN.OPTIMISM]: 10,
+  [CHAIN.BSC]: 56,
+  [CHAIN.XDAI]: 100,
+  [CHAIN.UNICHAIN]: 130,
+  [CHAIN.POLYGON]: 137,
+  [CHAIN.ROBINHOOD]: 4663,
+  [CHAIN.BASE]: 8453,
+  [CHAIN.PLASMA]: 9745,
+  [CHAIN.ARBITRUM]: 42161,
+  [CHAIN.AVAX]: 43114,
+  [CHAIN.INK]: 57073,
+  [CHAIN.LINEA]: 59144,
+};
+
+interface ChainDay {
+  chainId: number;
+  transactions: number;
+  users: number;
+}
+
+const fetch = async (options: FetchOptions) => {
+  const response = await fetchURL(`${API}?date=${encodeURIComponent(options.dateString)}`);
+  if (!response?.ok || !Array.isArray(response.chains)) {
+    throw new Error(`ophis: incomplete reporting response for ${options.dateString}`);
+  }
+  const row = (response.chains as ChainDay[]).find((item) => item.chainId === chainIds[options.chain]);
+  return {
+    dailyActiveUsers: row?.users ?? 0,
+    dailyTransactionsCount: row?.transactions ?? 0,
+  };
+};
+
+const adapter: SimpleAdapter = {
+  version: 1,
+  fetch,
+  chains: Object.keys(chainIds),
+  start: "2026-05-14",
+};
+
+export default adapter;

--- a/aggregators/ophis/index.ts
+++ b/aggregators/ophis/index.ts
@@ -1,9 +1,13 @@
 import { FetchOptions, FetchResult, SimpleAdapter } from "../../adapters/types";
 import { fetchOphisChainDay, ophisChainConfig } from "../../helpers/ophis";
 
+const OPHIS_SETTLED_VOLUME = "Ophis settled swap volume";
+
 const fetch = async (options: FetchOptions): Promise<FetchResult> => {
   const row = await fetchOphisChainDay(options);
-  return { dailyVolume: row?.volumeUsd ?? 0 };
+  const dailyVolume = options.createBalances();
+  dailyVolume.addUSDValue(row?.volumeUsd ?? 0, OPHIS_SETTLED_VOLUME);
+  return { dailyVolume };
 };
 
 const adapter: SimpleAdapter = {
@@ -12,6 +16,11 @@ const adapter: SimpleAdapter = {
   adapter: ophisChainConfig,
   methodology: {
     Volume: "USD notional of successfully settled swaps routed through Ophis. Each GPv2Settlement Trade fill is counted once at settlement time, including partial fills, and underlying DEX hops are not double-counted.",
+  },
+  breakdownMethodology: {
+    Volume: {
+      [OPHIS_SETTLED_VOLUME]: "USD notional from Ophis' validated settlement-fill ledger.",
+    },
   },
 };
 

--- a/aggregators/ophis/index.ts
+++ b/aggregators/ophis/index.ts
@@ -1,0 +1,47 @@
+import { FetchOptions, FetchResult, SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import fetchURL from "../../utils/fetchURL";
+
+const API = "https://rebates.ophis.fi/defillama";
+
+const chainIds: Record<string, number> = {
+  [CHAIN.ETHEREUM]: 1,
+  [CHAIN.OPTIMISM]: 10,
+  [CHAIN.BSC]: 56,
+  [CHAIN.XDAI]: 100,
+  [CHAIN.UNICHAIN]: 130,
+  [CHAIN.POLYGON]: 137,
+  [CHAIN.ROBINHOOD]: 4663,
+  [CHAIN.BASE]: 8453,
+  [CHAIN.PLASMA]: 9745,
+  [CHAIN.ARBITRUM]: 42161,
+  [CHAIN.AVAX]: 43114,
+  [CHAIN.INK]: 57073,
+  [CHAIN.LINEA]: 59144,
+};
+
+interface ChainDay {
+  chainId: number;
+  volumeUsd: number;
+}
+
+const fetch = async (options: FetchOptions): Promise<FetchResult> => {
+  const response = await fetchURL(`${API}?date=${encodeURIComponent(options.dateString)}`);
+  if (!response?.ok || !Array.isArray(response.chains)) {
+    throw new Error(`ophis: incomplete reporting response for ${options.dateString}`);
+  }
+  const row = (response.chains as ChainDay[]).find((item) => item.chainId === chainIds[options.chain]);
+  return { dailyVolume: row?.volumeUsd ?? 0 };
+};
+
+const adapter: SimpleAdapter = {
+  version: 1,
+  fetch,
+  chains: Object.keys(chainIds),
+  start: "2026-05-14",
+  methodology: {
+    Volume: "USD notional of successfully settled swaps routed through Ophis. Each GPv2Settlement Trade fill is counted once at settlement time, including partial fills, and underlying DEX hops are not double-counted.",
+  },
+};
+
+export default adapter;

--- a/aggregators/ophis/index.ts
+++ b/aggregators/ophis/index.ts
@@ -1,44 +1,15 @@
 import { FetchOptions, FetchResult, SimpleAdapter } from "../../adapters/types";
-import { CHAIN } from "../../helpers/chains";
-import fetchURL from "../../utils/fetchURL";
-
-const API = "https://rebates.ophis.fi/defillama";
-
-const chainIds: Record<string, number> = {
-  [CHAIN.ETHEREUM]: 1,
-  [CHAIN.OPTIMISM]: 10,
-  [CHAIN.BSC]: 56,
-  [CHAIN.XDAI]: 100,
-  [CHAIN.UNICHAIN]: 130,
-  [CHAIN.POLYGON]: 137,
-  [CHAIN.ROBINHOOD]: 4663,
-  [CHAIN.BASE]: 8453,
-  [CHAIN.PLASMA]: 9745,
-  [CHAIN.ARBITRUM]: 42161,
-  [CHAIN.AVAX]: 43114,
-  [CHAIN.INK]: 57073,
-  [CHAIN.LINEA]: 59144,
-};
-
-interface ChainDay {
-  chainId: number;
-  volumeUsd: number;
-}
+import { fetchOphisChainDay, ophisChainConfig } from "../../helpers/ophis";
 
 const fetch = async (options: FetchOptions): Promise<FetchResult> => {
-  const response = await fetchURL(`${API}?date=${encodeURIComponent(options.dateString)}`);
-  if (!response?.ok || !Array.isArray(response.chains)) {
-    throw new Error(`ophis: incomplete reporting response for ${options.dateString}`);
-  }
-  const row = (response.chains as ChainDay[]).find((item) => item.chainId === chainIds[options.chain]);
+  const row = await fetchOphisChainDay(options);
   return { dailyVolume: row?.volumeUsd ?? 0 };
 };
 
 const adapter: SimpleAdapter = {
   version: 1,
   fetch,
-  chains: Object.keys(chainIds),
-  start: "2026-05-14",
+  adapter: ophisChainConfig,
   methodology: {
     Volume: "USD notional of successfully settled swaps routed through Ophis. Each GPv2Settlement Trade fill is counted once at settlement time, including partial fills, and underlying DEX hops are not double-counted.",
   },

--- a/fees/ophis/index.ts
+++ b/fees/ophis/index.ts
@@ -51,7 +51,7 @@ const fetch = async (options: FetchOptions) => {
 };
 
 const methodology = {
-  Fees: "Ophis fees assessed on successfully settled Ophis-attributed fills, including the 1 bp base fee and capped price-improvement capture. Values come from Ophis' settlement-fill ledger and are priced in USD at settlement.",
+    Fees: "Ophis fees assessed on successfully settled Ophis-attributed fills, including the 1 bp base fee and capped price-improvement capture. Values come from Ophis' settlement-fill ledger, are bucketed by settlement date, and are valued in USD by the reporting indexer.",
   UserFees: "Total Ophis fees assessed on successfully settled fills.",
   Revenue: "Fees retained by Ophis. Ophis-operated chains retain the full fee; on CoW-hosted chains this is net of CoW Protocol's 25% partner-fee share.",
   ProtocolRevenue: "Revenue retained by Ophis after CoW Protocol's hosted-chain share.",

--- a/fees/ophis/index.ts
+++ b/fees/ophis/index.ts
@@ -1,51 +1,69 @@
-import { CHAIN } from "../../helpers/chains";
 import { FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import fetchURL from "../../utils/fetchURL";
 
-const FEE_RECIPIENT = "0x858f0F5eE954846D47155F5203c04aF1819eCeF8";
-const START = "2026-06-08";
-const SAFE_RECEIVED_EVENT = "event SafeReceived (address indexed sender, uint256 value)"
+const API = "https://rebates.ophis.fi/defillama";
+const START = "2026-05-14";
+
+const chainIds: Record<string, number> = {
+  [CHAIN.ETHEREUM]: 1,
+  [CHAIN.OPTIMISM]: 10,
+  [CHAIN.BSC]: 56,
+  [CHAIN.XDAI]: 100,
+  [CHAIN.UNICHAIN]: 130,
+  [CHAIN.POLYGON]: 137,
+  [CHAIN.ROBINHOOD]: 4663,
+  [CHAIN.BASE]: 8453,
+  [CHAIN.PLASMA]: 9745,
+  [CHAIN.ARBITRUM]: 42161,
+  [CHAIN.AVAX]: 43114,
+  [CHAIN.INK]: 57073,
+  [CHAIN.LINEA]: 59144,
+};
+
+interface ChainDay {
+  chainId: number;
+  feesUsd: number;
+  revenueUsd: number;
+  supplySideRevenueUsd: number;
+}
 
 const fetch = async (options: FetchOptions) => {
-  const SafeReceivedLogs = await options.getLogs({
-    target: FEE_RECIPIENT,
-    eventAbi: SAFE_RECEIVED_EVENT,
-  })
-
-  const dailyFees = options.createBalances()
-
-  for (const log of SafeReceivedLogs) {
-    dailyFees.addGasToken(log.value, 'Partner Fees')
+  const response = await fetchURL(`${API}?date=${encodeURIComponent(options.dateString)}`);
+  if (!response?.ok || !Array.isArray(response.chains)) {
+    throw new Error(`ophis: incomplete reporting response for ${options.dateString}`);
   }
+  const row = (response.chains as ChainDay[]).find((item) => item.chainId === chainIds[options.chain]);
+  const dailyFees = options.createBalances()
+  const dailyRevenue = options.createBalances();
+  const dailySupplySideRevenue = options.createBalances();
+  dailyFees.addUSDValue(row?.feesUsd ?? 0);
+  dailyRevenue.addUSDValue(row?.revenueUsd ?? 0);
+  dailySupplySideRevenue.addUSDValue(row?.supplySideRevenueUsd ?? 0);
 
-  return { dailyFees, dailyRevenue: dailyFees, dailyProtocolRevenue: dailyFees };
+  return {
+    dailyFees,
+    dailyUserFees: dailyFees,
+    dailyRevenue,
+    dailyProtocolRevenue: dailyRevenue,
+    dailySupplySideRevenue,
+  };
 };
 
 const methodology = {
-  Fees: "Flat partner fee taken on every Ophis swap (10 bps standard, 1 bp on stablecoin pairs), measured as gas tokens received by protocol safe wallet.",
-  Revenue: "All flat partner fees taken on every Ophis swap (10 bps standard, 1 bp on stablecoin pairs), measured as gas tokens received by protocol safe wallet is retained by Ophis.",
-  ProtocolRevenue: "All flat partner fees taken on every Ophis swap (10 bps standard, 1 bp on stablecoin pairs), measured as gas tokens received by protocol safe wallet is retained by Ophis.",
+  Fees: "Ophis fees assessed on successfully settled Ophis-attributed fills, including the 1 bp base fee and capped price-improvement capture. Values come from Ophis' settlement-fill ledger and are priced in USD at settlement.",
+  UserFees: "Total Ophis fees assessed on successfully settled fills.",
+  Revenue: "Fees retained by Ophis. Ophis-operated chains retain the full fee; on CoW-hosted chains this is net of CoW Protocol's 25% partner-fee share.",
+  ProtocolRevenue: "Revenue retained by Ophis after CoW Protocol's hosted-chain share.",
+  SupplySideRevenue: "CoW Protocol's 25% share of Ophis fees on CoW-hosted chains; zero on Ophis-operated chains.",
 };
 
-const breakdownMethodology = {
-  Fees: {
-    'Partner Fees': 'Flat partner fee taken on every Ophis swap (10 bps standard, 1 bp on stablecoin pairs), measured as gas tokens received by protocol safe wallet.',
-  },
-  Revenue: {
-    'Partner Fees': 'All flat partner fees taken on every Ophis swap (10 bps standard, 1 bp on stablecoin pairs), measured as gas tokens received by protocol safe wallet is retained by Ophis.',
-  },
-  ProtocolRevenue: {
-    'Partner Fees': 'All flat partner fees taken on every Ophis swap (10 bps standard, 1 bp on stablecoin pairs), measured as gas tokens received by protocol safe wallet is retained by Ophis.',
-  },
-}
-
 const adapter: SimpleAdapter = {
-  version: 2,
-  pullHourly: true,
+  version: 1,
   fetch,
   methodology,
-  breakdownMethodology,
   start: START,
-  chains: [CHAIN.ETHEREUM, CHAIN.OPTIMISM, CHAIN.BSC, CHAIN.XDAI, CHAIN.POLYGON, CHAIN.BASE, CHAIN.ARBITRUM, CHAIN.AVAX, CHAIN.LINEA, CHAIN.INK, CHAIN.PLASMA],
+  chains: Object.keys(chainIds),
 };
 
 export default adapter;

--- a/fees/ophis/index.ts
+++ b/fees/ophis/index.ts
@@ -1,45 +1,18 @@
 import { FetchOptions, SimpleAdapter } from "../../adapters/types";
-import { CHAIN } from "../../helpers/chains";
-import fetchURL from "../../utils/fetchURL";
+import { fetchOphisChainDay, ophisChainConfig } from "../../helpers/ophis";
 
-const API = "https://rebates.ophis.fi/defillama";
-const START = "2026-05-14";
-
-const chainIds: Record<string, number> = {
-  [CHAIN.ETHEREUM]: 1,
-  [CHAIN.OPTIMISM]: 10,
-  [CHAIN.BSC]: 56,
-  [CHAIN.XDAI]: 100,
-  [CHAIN.UNICHAIN]: 130,
-  [CHAIN.POLYGON]: 137,
-  [CHAIN.ROBINHOOD]: 4663,
-  [CHAIN.BASE]: 8453,
-  [CHAIN.PLASMA]: 9745,
-  [CHAIN.ARBITRUM]: 42161,
-  [CHAIN.AVAX]: 43114,
-  [CHAIN.INK]: 57073,
-  [CHAIN.LINEA]: 59144,
-};
-
-interface ChainDay {
-  chainId: number;
-  feesUsd: number;
-  revenueUsd: number;
-  supplySideRevenueUsd: number;
-}
+const OPHIS_FEES = "Ophis swap fees";
+const OPHIS_REVENUE = "Ophis protocol revenue";
+const COW_HOSTED_SHARE = "CoW Protocol hosted-chain share";
 
 const fetch = async (options: FetchOptions) => {
-  const response = await fetchURL(`${API}?date=${encodeURIComponent(options.dateString)}`);
-  if (!response?.ok || !Array.isArray(response.chains)) {
-    throw new Error(`ophis: incomplete reporting response for ${options.dateString}`);
-  }
-  const row = (response.chains as ChainDay[]).find((item) => item.chainId === chainIds[options.chain]);
-  const dailyFees = options.createBalances()
+  const row = await fetchOphisChainDay(options);
+  const dailyFees = options.createBalances();
   const dailyRevenue = options.createBalances();
   const dailySupplySideRevenue = options.createBalances();
-  dailyFees.addUSDValue(row?.feesUsd ?? 0);
-  dailyRevenue.addUSDValue(row?.revenueUsd ?? 0);
-  dailySupplySideRevenue.addUSDValue(row?.supplySideRevenueUsd ?? 0);
+  dailyFees.addUSDValue(row?.feesUsd ?? 0, OPHIS_FEES);
+  dailyRevenue.addUSDValue(row?.revenueUsd ?? 0, OPHIS_REVENUE);
+  dailySupplySideRevenue.addUSDValue(row?.supplySideRevenueUsd ?? 0, COW_HOSTED_SHARE);
 
   return {
     dailyFees,
@@ -50,20 +23,37 @@ const fetch = async (options: FetchOptions) => {
   };
 };
 
+// Fee policy and hosted-chain share sources:
+// https://github.com/ophis-fi/ophis/blob/main/apps/rebate-indexer/src/stats-page.ts
+// https://github.com/ophis-fi/ophis/blob/main/apps/rebate-indexer/src/earnings.ts
 const methodology = {
-    Fees: "Ophis fees assessed on successfully settled Ophis-attributed fills, including the 1 bp base fee and capped price-improvement capture. Values come from Ophis' settlement-fill ledger, are bucketed by settlement date, and are valued in USD by the reporting indexer.",
-  UserFees: "Total Ophis fees assessed on successfully settled fills.",
+  Fees: "Ophis fees assessed on successfully settled Ophis-attributed fills, including the 1 bp base fee and capped price-improvement capture. Values come from Ophis' settlement-fill ledger, are bucketed by settlement date, and are valued in USD by the reporting indexer.",
   Revenue: "Fees retained by Ophis. Ophis-operated chains retain the full fee; on CoW-hosted chains this is net of CoW Protocol's 25% partner-fee share.",
   ProtocolRevenue: "Revenue retained by Ophis after CoW Protocol's hosted-chain share.",
   SupplySideRevenue: "CoW Protocol's 25% share of Ophis fees on CoW-hosted chains; zero on Ophis-operated chains.",
+};
+
+const breakdownMethodology = {
+  Fees: {
+    [OPHIS_FEES]: "Base and capped price-improvement fees assessed on successfully settled Ophis fills.",
+  },
+  Revenue: {
+    [OPHIS_REVENUE]: "Fees retained by Ophis after any hosted-chain share.",
+  },
+  ProtocolRevenue: {
+    [OPHIS_REVENUE]: "Fees retained by Ophis after any hosted-chain share.",
+  },
+  SupplySideRevenue: {
+    [COW_HOSTED_SHARE]: "CoW Protocol's share on CoW-hosted chains.",
+  },
 };
 
 const adapter: SimpleAdapter = {
   version: 1,
   fetch,
   methodology,
-  start: START,
-  chains: Object.keys(chainIds),
+  breakdownMethodology,
+  adapter: ophisChainConfig,
 };
 
 export default adapter;

--- a/helpers/ophis.ts
+++ b/helpers/ophis.ts
@@ -1,0 +1,114 @@
+import { FetchOptions } from "../adapters/types";
+import { CHAIN } from "./chains";
+import fetchURL from "../utils/fetchURL";
+
+const API = "https://rebates.ophis.fi/defillama";
+const START = "2026-05-14";
+
+// Canonical reporting-chain list and IDs:
+// https://github.com/ophis-fi/ophis/blob/main/apps/rebate-indexer/src/scan/chains.ts
+export const ophisChainConfig: Record<string, { id: number; start: string }> = {
+  [CHAIN.ETHEREUM]: { id: 1, start: START },
+  [CHAIN.OPTIMISM]: { id: 10, start: START },
+  [CHAIN.BSC]: { id: 56, start: START },
+  [CHAIN.XDAI]: { id: 100, start: START },
+  [CHAIN.UNICHAIN]: { id: 130, start: START },
+  [CHAIN.POLYGON]: { id: 137, start: START },
+  [CHAIN.ROBINHOOD]: { id: 4663, start: START },
+  [CHAIN.BASE]: { id: 8453, start: START },
+  [CHAIN.PLASMA]: { id: 9745, start: START },
+  [CHAIN.ARBITRUM]: { id: 42161, start: START },
+  [CHAIN.AVAX]: { id: 43114, start: START },
+  [CHAIN.INK]: { id: 57073, start: START },
+  [CHAIN.LINEA]: { id: 59144, start: START },
+};
+
+export interface OphisChainDay {
+  chainId: number;
+  volumeUsd: number;
+  feesUsd: number;
+  revenueUsd: number;
+  supplySideRevenueUsd: number;
+  trades: number;
+  transactions: number;
+  users: number;
+}
+
+interface OphisDayResponse {
+  ok: true;
+  date: string;
+  chains: OphisChainDay[];
+}
+
+const responseCache = new Map<string, Promise<OphisDayResponse>>();
+const supportedChainIds = new Set(Object.values(ophisChainConfig).map(({ id }) => id));
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null;
+
+const isNonNegativeFinite = (value: unknown): value is number =>
+  typeof value === "number" && Number.isFinite(value) && value >= 0;
+
+const isNonNegativeInteger = (value: unknown): value is number =>
+  isNonNegativeFinite(value) && Number.isInteger(value);
+
+const validateChainDay = (value: unknown, date: string): OphisChainDay => {
+  if (!isRecord(value) || !isNonNegativeInteger(value.chainId))
+    throw new Error(`ophis: invalid chain row for ${date}`);
+
+  const usdFields = ["volumeUsd", "feesUsd", "revenueUsd", "supplySideRevenueUsd"] as const;
+  const countFields = ["trades", "transactions", "users"] as const;
+  for (const field of usdFields)
+    if (!isNonNegativeFinite(value[field]))
+      throw new Error(`ophis: invalid ${field} for chain ${value.chainId} on ${date}`);
+  for (const field of countFields)
+    if (!isNonNegativeInteger(value[field]))
+      throw new Error(`ophis: invalid ${field} for chain ${value.chainId} on ${date}`);
+
+  const row = value as unknown as OphisChainDay;
+  if (row.transactions > row.trades || row.users > row.trades)
+    throw new Error(`ophis: inconsistent activity counts for chain ${row.chainId} on ${date}`);
+
+  // Accommodate only JSON floating-point rounding, not an accounting mismatch.
+  const feeTolerance = Math.max(1e-9, row.feesUsd * 1e-12);
+  if (Math.abs(row.feesUsd - row.revenueUsd - row.supplySideRevenueUsd) > feeTolerance)
+    throw new Error(`ophis: unbalanced fee split for chain ${row.chainId} on ${date}`);
+
+  return row;
+};
+
+const fetchOphisDay = (date: string): Promise<OphisDayResponse> => {
+  const cached = responseCache.get(date);
+  if (cached) return cached;
+
+  const pending = (async () => {
+    const response: unknown = await fetchURL(`${API}?date=${encodeURIComponent(date)}`);
+    if (!isRecord(response) || response.ok !== true || response.date !== date || !Array.isArray(response.chains))
+      throw new Error(`ophis: incomplete reporting response for ${date}`);
+
+    const chains = response.chains.map((row) => validateChainDay(row, date));
+    const returnedChainIds = new Set<number>();
+    for (const row of chains) {
+      if (!supportedChainIds.has(row.chainId))
+        throw new Error(`ophis: unsupported chain ${row.chainId} returned for ${date}`);
+      if (returnedChainIds.has(row.chainId))
+        throw new Error(`ophis: duplicate chain ${row.chainId} returned for ${date}`);
+      returnedChainIds.add(row.chainId);
+    }
+
+    return { ok: true as const, date, chains };
+  })();
+
+  responseCache.set(date, pending);
+  pending.catch(() => {
+    if (responseCache.get(date) === pending) responseCache.delete(date);
+  });
+  return pending;
+};
+
+export const fetchOphisChainDay = async (options: FetchOptions): Promise<OphisChainDay | undefined> => {
+  const config = ophisChainConfig[options.chain];
+  if (!config) throw new Error(`ophis: unsupported DefiLlama chain ${options.chain}`);
+  const response = await fetchOphisDay(options.dateString);
+  return response.chains.find(({ chainId }) => chainId === config.id);
+};

--- a/helpers/ophis.ts
+++ b/helpers/ophis.ts
@@ -106,6 +106,15 @@ const fetchOphisDay = (date: string): Promise<OphisDayResponse> => {
   return pending;
 };
 
+/**
+ * Fetches and validates Ophis reporting data for one day and chain.
+ * `options.chain` must be one of the keys in {@link ophisChainConfig}.
+ *
+ * @returns The validated chain row, or `undefined` when a valid response has no
+ * activity row for the requested chain.
+ * @throws If the chain is unsupported or the API response is stale, malformed,
+ * duplicated, incomplete, or internally inconsistent.
+ */
 export const fetchOphisChainDay = async (options: FetchOptions): Promise<OphisChainDay | undefined> => {
   const config = ophisChainConfig[options.chain];
   if (!config) throw new Error(`ophis: unsupported DefiLlama chain ${options.chain}`);

--- a/helpers/ophis.ts
+++ b/helpers/ophis.ts
@@ -3,24 +3,24 @@ import { CHAIN } from "./chains";
 import fetchURL from "../utils/fetchURL";
 
 const API = "https://rebates.ophis.fi/defillama";
-const START = "2026-05-14";
+export const OPHIS_START = "2026-05-14";
 
 // Canonical reporting-chain list and IDs:
 // https://github.com/ophis-fi/ophis/blob/main/apps/rebate-indexer/src/scan/chains.ts
 export const ophisChainConfig: Record<string, { id: number; start: string }> = {
-  [CHAIN.ETHEREUM]: { id: 1, start: START },
-  [CHAIN.OPTIMISM]: { id: 10, start: START },
-  [CHAIN.BSC]: { id: 56, start: START },
-  [CHAIN.XDAI]: { id: 100, start: START },
-  [CHAIN.UNICHAIN]: { id: 130, start: START },
-  [CHAIN.POLYGON]: { id: 137, start: START },
-  [CHAIN.ROBINHOOD]: { id: 4663, start: START },
-  [CHAIN.BASE]: { id: 8453, start: START },
-  [CHAIN.PLASMA]: { id: 9745, start: START },
-  [CHAIN.ARBITRUM]: { id: 42161, start: START },
-  [CHAIN.AVAX]: { id: 43114, start: START },
-  [CHAIN.INK]: { id: 57073, start: START },
-  [CHAIN.LINEA]: { id: 59144, start: START },
+  [CHAIN.ETHEREUM]: { id: 1, start: OPHIS_START },
+  [CHAIN.OPTIMISM]: { id: 10, start: OPHIS_START },
+  [CHAIN.BSC]: { id: 56, start: OPHIS_START },
+  [CHAIN.XDAI]: { id: 100, start: OPHIS_START },
+  [CHAIN.UNICHAIN]: { id: 130, start: OPHIS_START },
+  [CHAIN.POLYGON]: { id: 137, start: OPHIS_START },
+  [CHAIN.ROBINHOOD]: { id: 4663, start: OPHIS_START },
+  [CHAIN.BASE]: { id: 8453, start: OPHIS_START },
+  [CHAIN.PLASMA]: { id: 9745, start: OPHIS_START },
+  [CHAIN.ARBITRUM]: { id: 42161, start: OPHIS_START },
+  [CHAIN.AVAX]: { id: 43114, start: OPHIS_START },
+  [CHAIN.INK]: { id: 57073, start: OPHIS_START },
+  [CHAIN.LINEA]: { id: 59144, start: OPHIS_START },
 };
 
 export interface OphisChainDay {
@@ -34,9 +34,12 @@ export interface OphisChainDay {
   users: number;
 }
 
+export type OphisProtocolDay = Omit<OphisChainDay, "chainId">;
+
 interface OphisDayResponse {
   ok: true;
   date: string;
+  totals: OphisProtocolDay;
   chains: OphisChainDay[];
 }
 
@@ -77,6 +80,29 @@ const validateChainDay = (value: unknown, date: string): OphisChainDay => {
   return row;
 };
 
+const validateProtocolDay = (value: unknown, date: string): OphisProtocolDay => {
+  if (!isRecord(value)) throw new Error(`ophis: invalid protocol totals for ${date}`);
+
+  const usdFields = ["volumeUsd", "feesUsd", "revenueUsd", "supplySideRevenueUsd"] as const;
+  const countFields = ["trades", "transactions", "users"] as const;
+  for (const field of usdFields)
+    if (!isNonNegativeFinite(value[field]))
+      throw new Error(`ophis: invalid protocol ${field} for ${date}`);
+  for (const field of countFields)
+    if (!isNonNegativeInteger(value[field]))
+      throw new Error(`ophis: invalid protocol ${field} for ${date}`);
+
+  const totals = value as unknown as OphisProtocolDay;
+  if (totals.transactions > totals.trades || totals.users > totals.trades)
+    throw new Error(`ophis: inconsistent protocol activity counts for ${date}`);
+
+  const feeTolerance = Math.max(1e-9, totals.feesUsd * 1e-12);
+  if (Math.abs(totals.feesUsd - totals.revenueUsd - totals.supplySideRevenueUsd) > feeTolerance)
+    throw new Error(`ophis: unbalanced protocol fee split for ${date}`);
+
+  return totals;
+};
+
 const fetchOphisDay = (date: string): Promise<OphisDayResponse> => {
   const cached = responseCache.get(date);
   if (cached) return cached;
@@ -86,6 +112,7 @@ const fetchOphisDay = (date: string): Promise<OphisDayResponse> => {
     if (!isRecord(response) || response.ok !== true || response.date !== date || !Array.isArray(response.chains))
       throw new Error(`ophis: incomplete reporting response for ${date}`);
 
+    const totals = validateProtocolDay(response.totals, date);
     const chains = response.chains.map((row) => validateChainDay(row, date));
     const returnedChainIds = new Set<number>();
     for (const row of chains) {
@@ -96,7 +123,24 @@ const fetchOphisDay = (date: string): Promise<OphisDayResponse> => {
       returnedChainIds.add(row.chainId);
     }
 
-    return { ok: true as const, date, chains };
+    const additiveUsdFields = ["volumeUsd", "feesUsd", "revenueUsd", "supplySideRevenueUsd"] as const;
+    for (const field of additiveUsdFields) {
+      const chainSum = chains.reduce((sum, row) => sum + row[field], 0);
+      const tolerance = Math.max(1e-9, Math.abs(totals[field]) * 1e-12);
+      if (Math.abs(totals[field] - chainSum) > tolerance)
+        throw new Error(`ophis: protocol ${field} does not match chain sum for ${date}`);
+    }
+    for (const field of ["trades", "transactions"] as const) {
+      const chainSum = chains.reduce((sum, row) => sum + row[field], 0);
+      if (totals[field] !== chainSum)
+        throw new Error(`ophis: protocol ${field} does not match chain sum for ${date}`);
+    }
+    const maxChainUsers = chains.reduce((max, row) => Math.max(max, row.users), 0);
+    const summedChainUsers = chains.reduce((sum, row) => sum + row.users, 0);
+    if (totals.users < maxChainUsers || totals.users > summedChainUsers)
+      throw new Error(`ophis: invalid cross-chain user total for ${date}`);
+
+    return { ok: true as const, date, totals, chains };
   })();
 
   responseCache.set(date, pending);
@@ -121,3 +165,7 @@ export const fetchOphisChainDay = async (options: FetchOptions): Promise<OphisCh
   const response = await fetchOphisDay(options.dateString);
   return response.chains.find(({ chainId }) => chainId === config.id);
 };
+
+/** Fetches the validated protocol-wide totals, including cross-chain user deduplication. */
+export const fetchOphisProtocolDay = async (options: FetchOptions): Promise<OphisProtocolDay> =>
+  (await fetchOphisDay(options.dateString)).totals;


### PR DESCRIPTION
## What changed
- replace the native-Safe-receipt fee proxy with Ophis settlement-fill accounting
- add Ophis aggregator volume across all 13 supported chains
- add active users and settlement transaction counts
- deduplicate protocol-wide active users across chains with DefiLlama's `chain_global` metric while preserving per-chain breakdowns
- include Unichain and Robinhood Chain, which were absent from the prior fee adapter
- split hosted-chain fees into Ophis revenue (75%) and CoW Protocol supply-side revenue (25%)
- update the current 1 bp + capped price-improvement methodology

## Why
The previous adapter counted only native `SafeReceived` events. Most Ophis fees settle in ERC-20 tokens and/or through CoW fee accounting, so that proxy omitted real fee days while also lacking volume, users, and transactions.

The API is fail-closed: it returns HTTP 503 whenever a settlement fill is unverified, unpriced, missing transaction/user identity, or a verified trade has not passed the exact-UID settlement-count audit.

## Validation
- `pnpm ts-check`
- `pnpm test fees ophis 2026-08-27` -> $0.4018 fees, $0.3014 protocol revenue, $0.1005 supply-side revenue
- `pnpm test aggregators ophis 2026-08-27` -> $5,236.2408 volume
- `pnpm test active-users ophis 2026-08-27` -> per-chain breakdowns validated
- ingestion aggregate -> 6 cross-chain-deduplicated active users, 7 settlement transactions
- source-to-ledger comparison -> 46 active UTC days plus an empty day, zero field mismatches
- production ledger -> 112 fills / 112 UIDs / 112 settlement txs; zero unverified, unpriced, identity-less, router-user, testnet, or settlement-audit-gap rows
- historical Unichain repair -> 6 fills, $53.5701 volume, $0.0420701 fees

Source endpoint: https://rebates.ophis.fi/defillama?date=2026-08-26
Indexer fixes: https://github.com/ophis-fi/ophis/pull/1246, https://github.com/ophis-fi/ophis/pull/1247, https://github.com/ophis-fi/ophis/pull/1248, https://github.com/ophis-fi/ophis/pull/1249, https://github.com/ophis-fi/ophis/pull/1250, https://github.com/ophis-fi/ophis/pull/1251, https://github.com/ophis-fi/ophis/pull/1252, https://github.com/ophis-fi/ophis/pull/1253

