### PR TITLE
jupiter-lend-dex: read pool tokens from the swap calls instead of init_dex

### DIFF
--- a/dexs/jupiter-lend-dex/index.ts
+++ b/dexs/jupiter-lend-dex/index.ts
@@ -2,67 +2,63 @@ import { Dependencies, FetchOptions, SimpleAdapter } from "../../adapters/types"
 import { CHAIN } from "../../helpers/chains";
 import { queryDuneSql } from "../../helpers/dune";
 
-// Volume = every swap's input-side amount priced in the input token.
-// - swap_in (exact-in): amount_in is a call argument (dex_call_swap_in.amount_in).
-// - swap_out (exact-out): amount_in is not a call arg, but the DEX emits a LogSwap event
-//   (Anchor `emit!`) which appears as a "Program data: yvLkHCXC..." line in call_log_messages.
-//   We decode the base64 payload and read amount_in (u64 LE at byte 11 after the 8-byte
-//   Anchor discriminator + u16 dex_id + u8 swap_0_to_1). Verified against on-chain data:
-//   the 3 historical swap_out txs decode to 1,283,885 / 1,283,391 / 1,501,258 — matching
-//   the actual token transfers.
+// Volume = one leg of every swap, priced in that leg's token.
+// - swap_in (exact-in): amount_in is a call argument, so value the input leg.
+// - swap_out (exact-out): amount_out is a call argument, so value the output leg.
 //
-// LogSwap discriminator = [0xCA,0xF2,0xE4,0x1C,0x25,0xC2,0x34,0x22]; base64 = "yvLkHCXCNCIC".
+// Pool token identity comes from the swap calls, NOT from init_dex: init_dex decodes
+// account_token_1 as the system program for the oldest pool (the USDC/USDT pool, which
+// is ~98% of all swaps), which would send half that pool's volume to an unpriceable
+// mint. init_dex is kept as the fallback for pools that have never traded.
 
 const fetch = async (options: FetchOptions) => {
   const sql = `
-    WITH pools AS (
-      SELECT DISTINCT
-        account_dex     AS pool,
-        account_token_0 AS token_0,
-        account_token_1 AS token_1
+    WITH pool_tokens_swap AS (
+      SELECT DISTINCT account_dex AS pool, account_token_0 AS token_0, account_token_1 AS token_1
+      FROM jupiter_lend_solana.dex_call_swap_in
+      UNION
+      SELECT DISTINCT account_dex, account_token_0, account_token_1
+      FROM jupiter_lend_solana.dex_call_swap_out
+    ),
+    pool_tokens_init AS (
+      SELECT DISTINCT account_dex AS pool, account_token_0 AS token_0, account_token_1 AS token_1
       FROM jupiter_lend_solana.dex_call_init_dex
     ),
-    swap_in_vol AS (
+    pools AS (
       SELECT
-        s.account_dex                     AS pool,
-        s.swap0to1                        AS swap0to1,
-        CAST(s.amount_in AS DOUBLE)       AS amount_in
-      FROM jupiter_lend_solana.dex_call_swap_in s
-      WHERE s.call_block_time >= from_unixtime(${options.startTimestamp})
-        AND s.call_block_time <  from_unixtime(${options.endTimestamp})
+        COALESCE(s.pool, i.pool)       AS pool,
+        COALESCE(s.token_0, i.token_0) AS token_0,
+        COALESCE(s.token_1, i.token_1) AS token_1
+      FROM pool_tokens_init i
+      FULL OUTER JOIN pool_tokens_swap s ON i.pool = s.pool
     ),
-    swap_out_events AS (
-      SELECT
-        s.account_dex                                                             AS pool,
-        s.swap0to1                                                                AS swap0to1,
-        CAST(from_big_endian_64(reverse(SUBSTR(from_base64(SUBSTR(msg, 15)), 12, 8))) AS DOUBLE) AS amount_in
-      FROM jupiter_lend_solana.dex_call_swap_out s
-      CROSS JOIN UNNEST(s.call_log_messages) AS t(msg)
-      WHERE s.call_block_time >= from_unixtime(${options.startTimestamp})
-        AND s.call_block_time <  from_unixtime(${options.endTimestamp})
-        AND msg LIKE 'Program data: yvLkHCXCNCIC%'
-    ),
-    all_swaps AS (
-      SELECT pool, swap0to1, amount_in FROM swap_in_vol
+    swaps AS (
+      SELECT account_dex AS pool, swap0to1, TRUE AS is_exact_in, CAST(amount_in AS DOUBLE) AS amount
+      FROM jupiter_lend_solana.dex_call_swap_in
+      WHERE call_block_time >= from_unixtime(${options.startTimestamp})
+        AND call_block_time <  from_unixtime(${options.endTimestamp})
       UNION ALL
-      SELECT pool, swap0to1, amount_in FROM swap_out_events
+      SELECT account_dex, swap0to1, FALSE, CAST(amount_out AS DOUBLE)
+      FROM jupiter_lend_solana.dex_call_swap_out
+      WHERE call_block_time >= from_unixtime(${options.startTimestamp})
+        AND call_block_time <  from_unixtime(${options.endTimestamp})
     )
     SELECT
-      p.token_0,
-      p.token_1,
-      a.swap0to1,
-      SUM(a.amount_in) AS amount_in_sum
-    FROM all_swaps a
-    JOIN pools p ON a.pool = p.pool
-    GROUP BY p.token_0, p.token_1, a.swap0to1
+      CASE WHEN s.is_exact_in
+           THEN CASE WHEN s.swap0to1 THEN p.token_0 ELSE p.token_1 END
+           ELSE CASE WHEN s.swap0to1 THEN p.token_1 ELSE p.token_0 END
+      END           AS mint,
+      SUM(s.amount) AS amount
+    FROM swaps s
+    JOIN pools p ON s.pool = p.pool
+    GROUP BY 1
   `;
 
   const rows: any[] = await queryDuneSql(options, sql);
   const dailyVolume = options.createBalances();
 
   for (const row of rows) {
-    const inputMint: string = row.swap0to1 ? row.token_0 : row.token_1;
-    dailyVolume.add(inputMint, Number(row.amount_in_sum));
+    dailyVolume.add(row.mint, Number(row.amount));
   }
 
   return { dailyVolume };
@@ -72,12 +68,12 @@ const adapter: SimpleAdapter = {
   version: 1,
   fetch,
   chains: [CHAIN.SOLANA],
-  start: '2026-06-18',
+  start: '2026-06-22',
   dependencies: [Dependencies.DUNE],
   isExpensiveAdapter: true,
   methodology: {
     Volume:
-      "Notional traded (input-side, priced in the input token) across all Jupiter Lend AMM pools. For exact-in swaps (dex_call_swap_in), amount_in is read directly from the call argument. For exact-out swaps (dex_call_swap_out), amount_in is decoded from the LogSwap Anchor event embedded in call_log_messages (Program data: yvLkHCXCNCIC... base64 line): after the 8-byte discriminator and u16/u8 header, the u64 little-endian at byte 11 is amount_in. Per-pool token identity comes from dex_call_init_dex.",
+      "Notional traded across all Jupiter Lend AMM pools. Exact-in swaps (dex_call_swap_in) are valued on the input leg using the amount_in call argument; exact-out swaps (dex_call_swap_out) are valued on the output leg using the amount_out call argument. Per-pool token identity comes from the swap calls, with dex_call_init_dex as a fallback for pools that have never traded.",
   },
 };
 

--- a/fees/jupiter-lend-dex/index.ts
+++ b/fees/jupiter-lend-dex/index.ts
@@ -1,17 +1,19 @@
 import { Dependencies, FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 import { queryDuneSql } from "../../helpers/dune";
-import { METRIC } from "../../helpers/metrics";
 
-// Fees = per-swap (input notional * fee_at_that_time / 1e6), priced in the input token.
+// Fees = per-swap (leg notional * fee_at_that_time / 1e6), priced in that leg's token.
 // Fee history is init_dex ∪ every subsequent update_fee_and_revenue_cut call, window-joined
-// so a swap always uses the fee that was live at its block_time.
+// on block_time so a swap always uses the fee that was live when it executed.
 //
-// amount_in resolution:
-// - swap_in: exact from call arg (dex_call_swap_in.amount_in).
-// - swap_out: decoded from the Anchor LogSwap event in call_log_messages
-//   ("Program data: yvLkHCXCNCIC..." — base64 payload after 8-byte discriminator + u16 dex_id
-//   + u8 swap_0_to_1, u64 little-endian amount_in at byte 11).
+// Leg valued:
+// - swap_in (exact-in): input leg, from the amount_in call argument.
+// - swap_out (exact-out): output leg, from the amount_out call argument.
+//
+// Pool token identity comes from the swap calls, NOT from init_dex: init_dex decodes
+// account_token_1 as the system program for the oldest pool (the USDC/USDT pool, which
+// is ~98% of all swaps), which would send half that pool's fees to an unpriceable mint.
+// init_dex is kept as the fallback for pools that have never traded.
 //
 // Revenue split: LP = fee * (1 - revenue_cut/1e6). Protocol = fee * revenue_cut/1e6.
 // Jupiter and Fluid share the protocol cut 50/50. AMM fees do NOT feed the JUP buyback.
@@ -22,77 +24,70 @@ const JUPITER_SHARE_OF_PROTOCOL = 0.5;
 
 const fetch = async (options: FetchOptions) => {
   const sql = `
-    WITH pools AS (
-      SELECT DISTINCT
-        account_dex     AS pool,
-        account_token_0 AS token_0,
-        account_token_1 AS token_1
+    WITH pool_tokens_swap AS (
+      SELECT DISTINCT account_dex AS pool, account_token_0 AS token_0, account_token_1 AS token_1
+      FROM jupiter_lend_solana.dex_call_swap_in
+      UNION
+      SELECT DISTINCT account_dex, account_token_0, account_token_1
+      FROM jupiter_lend_solana.dex_call_swap_out
+    ),
+    pool_tokens_init AS (
+      SELECT DISTINCT account_dex AS pool, account_token_0 AS token_0, account_token_1 AS token_1
       FROM jupiter_lend_solana.dex_call_init_dex
     ),
-    fee_events AS (
+    pools AS (
+      SELECT
+        COALESCE(s.pool, i.pool)       AS pool,
+        COALESCE(s.token_0, i.token_0) AS token_0,
+        COALESCE(s.token_1, i.token_1) AS token_1
+      FROM pool_tokens_init i
+      FULL OUTER JOIN pool_tokens_swap s ON i.pool = s.pool
+    ),
+    rate_events AS (
       SELECT
         account_dex AS pool,
+        call_block_time,
         CAST(json_extract_scalar(params, '$.InitDexParams.fee') AS BIGINT)         AS fee,
-        CAST(json_extract_scalar(params, '$.InitDexParams.revenue_cut') AS BIGINT) AS revenue_cut,
-        call_block_time
+        CAST(json_extract_scalar(params, '$.InitDexParams.revenue_cut') AS BIGINT) AS revenue_cut
       FROM jupiter_lend_solana.dex_call_init_dex
       UNION ALL
-      SELECT
-        account_dex AS pool,
-        fee,
-        revenue_cut,
-        call_block_time
+      SELECT account_dex, call_block_time, fee, revenue_cut
       FROM jupiter_lend_solana.dex_call_update_fee_and_revenue_cut
     ),
-    fee_ranges AS (
+    rates AS (
       SELECT
         pool, fee, revenue_cut,
         call_block_time                                                        AS effective_from,
         LEAD(call_block_time) OVER (PARTITION BY pool ORDER BY call_block_time) AS effective_to
-      FROM fee_events
+      FROM rate_events
     ),
-    swap_in_rows AS (
-      SELECT
-        s.account_dex                     AS pool,
-        s.swap0to1                        AS swap0to1,
-        s.call_block_time,
-        CAST(s.amount_in AS DOUBLE)       AS amount_in
-      FROM jupiter_lend_solana.dex_call_swap_in s
-      WHERE s.call_block_time >= from_unixtime(${options.startTimestamp})
-        AND s.call_block_time <  from_unixtime(${options.endTimestamp})
-    ),
-    swap_out_rows AS (
-      SELECT
-        s.account_dex                     AS pool,
-        s.swap0to1                        AS swap0to1,
-        s.call_block_time,
-        CAST(from_big_endian_64(reverse(SUBSTR(from_base64(SUBSTR(msg, 15)), 12, 8))) AS DOUBLE) AS amount_in
-      FROM jupiter_lend_solana.dex_call_swap_out s
-      CROSS JOIN UNNEST(s.call_log_messages) AS t(msg)
-      WHERE s.call_block_time >= from_unixtime(${options.startTimestamp})
-        AND s.call_block_time <  from_unixtime(${options.endTimestamp})
-        AND msg LIKE 'Program data: yvLkHCXCNCIC%'
-    ),
-    all_swaps AS (
-      SELECT pool, swap0to1, call_block_time, amount_in FROM swap_in_rows
+    swaps AS (
+      SELECT account_dex AS pool, call_block_time, swap0to1, TRUE AS is_exact_in,
+             CAST(amount_in AS DOUBLE) AS amount
+      FROM jupiter_lend_solana.dex_call_swap_in
+      WHERE call_block_time >= from_unixtime(${options.startTimestamp})
+        AND call_block_time <  from_unixtime(${options.endTimestamp})
       UNION ALL
-      SELECT pool, swap0to1, call_block_time, amount_in FROM swap_out_rows
-    ),
-    priced AS (
-      SELECT
-        p.token_0,
-        p.token_1,
-        a.swap0to1,
-        a.amount_in,
-        fr.fee,
-        fr.revenue_cut
-      FROM all_swaps a
-      JOIN pools p       ON a.pool = p.pool
-      JOIN fee_ranges fr ON fr.pool = a.pool
-        AND a.call_block_time >= fr.effective_from
-        AND (fr.effective_to IS NULL OR a.call_block_time < fr.effective_to)
+      SELECT account_dex, call_block_time, swap0to1, FALSE,
+             CAST(amount_out AS DOUBLE)
+      FROM jupiter_lend_solana.dex_call_swap_out
+      WHERE call_block_time >= from_unixtime(${options.startTimestamp})
+        AND call_block_time <  from_unixtime(${options.endTimestamp})
     )
-    SELECT * FROM priced
+    SELECT
+      CASE WHEN s.is_exact_in
+           THEN CASE WHEN s.swap0to1 THEN p.token_0 ELSE p.token_1 END
+           ELSE CASE WHEN s.swap0to1 THEN p.token_1 ELSE p.token_0 END
+      END                                                                  AS mint,
+      SUM(s.amount * r.fee / ${FEE_SCALE})                                 AS fee_amount,
+      SUM(s.amount * r.fee / ${FEE_SCALE} * r.revenue_cut / ${REVENUE_CUT_SCALE})
+                                                                           AS protocol_cut_amount
+    FROM swaps s
+    JOIN pools p ON s.pool = p.pool
+    JOIN rates r ON r.pool = s.pool
+      AND s.call_block_time >= r.effective_from
+      AND (r.effective_to IS NULL OR s.call_block_time < r.effective_to)
+    GROUP BY 1
   `;
 
   const rows: any[] = await queryDuneSql(options, sql);
@@ -103,24 +98,19 @@ const fetch = async (options: FetchOptions) => {
   const dailyProtocolRevenue = options.createBalances();
 
   for (const row of rows) {
-    const inputMint: string = row.swap0to1 ? row.token_0 : row.token_1;
-    const amountIn = Number(row.amount_in);
-    if (!amountIn) continue;
+    const feeInToken = Number(row.fee_amount);
+    if (!feeInToken) continue;
 
-    const feeRate = Number(row.fee) / FEE_SCALE;
-    const revenueCutFraction = Number(row.revenue_cut) / REVENUE_CUT_SCALE;
-
-    const feeInToken = amountIn * feeRate;
-    const protocolCut = feeInToken * revenueCutFraction;
+    const protocolCut = Number(row.protocol_cut_amount);
     const lpShare = feeInToken - protocolCut;
     const jupiterShare = protocolCut * JUPITER_SHARE_OF_PROTOCOL;
     const fluidShare = protocolCut - jupiterShare;
 
-    dailyFees.add(inputMint, feeInToken, "Jupiter Lend Dex Swap Fees");
-    dailySupplySideRevenue.add(inputMint, lpShare, "Jupiter Lend Dex Swap Fees to LPs");
-    dailySupplySideRevenue.add(inputMint, fluidShare, "Jupiter Lend Dex Swap Fees to Fluid");
-    dailyRevenue.add(inputMint, jupiterShare, "Jupiter Lend Dex Swap Fees to Protocol");
-    dailyProtocolRevenue.add(inputMint, jupiterShare, "Jupiter Lend Dex Swap Fees to Protocol");
+    dailyFees.add(row.mint, feeInToken, "Jupiter Lend Dex Swap Fees");
+    dailySupplySideRevenue.add(row.mint, lpShare, "Jupiter Lend Dex Swap Fees to LPs");
+    dailySupplySideRevenue.add(row.mint, fluidShare, "Jupiter Lend Dex Swap Fees to Fluid");
+    dailyRevenue.add(row.mint, jupiterShare, "Jupiter Lend Dex Swap Fees to Protocol");
+    dailyProtocolRevenue.add(row.mint, jupiterShare, "Jupiter Lend Dex Swap Fees to Protocol");
   }
 
   return {
@@ -133,7 +123,7 @@ const fetch = async (options: FetchOptions) => {
 
 const breakdownMethodology = {
   Fees: {
-    "Jupiter Lend Dex Swap Fees": "Total swap fees, priced in the input token.",
+    "Jupiter Lend Dex Swap Fees": "Total swap fees, priced in the valued leg's token.",
   },
   Revenue: {
     "Jupiter Lend Dex Swap Fees to Protocol": "Jupiter's share of the protocol cut: fees x (revenue_cut/1e6) x 50%.",
@@ -151,11 +141,11 @@ const adapter: SimpleAdapter = {
   version: 1,
   fetch,
   chains: [CHAIN.SOLANA],
-  start: '2026-06-18',
+  start: '2026-06-22',
   dependencies: [Dependencies.DUNE],
   isExpensiveAdapter: true,
   methodology: {
-    Fees: "Total swap fees, priced in the input token. Per-swap fee = amount_in x (pool.fee / 1e6) where pool.fee is the value live at the swap's block_time (sourced from init_dex plus every update_fee_and_revenue_cut call, window-joined via effective range). amount_in is exact for swap_in (call arg) and swap_out (LogSwap Anchor event decoded from call_log_messages, u64 LE at byte 11 of the payload).",
+    Fees: "Total swap fees, priced in the valued leg's token. Per-swap fee = amount x (pool.fee / 1e6) where pool.fee is the value live at the swap's block_time (sourced from init_dex plus every update_fee_and_revenue_cut call, window-joined via effective range). Exact-in swaps are valued on the input leg (amount_in call argument), exact-out swaps on the output leg (amount_out call argument). Per-pool token identity comes from the swap calls, with dex_call_init_dex as a fallback for pools that have never traded.",
     SupplySideRevenue: "LP share of swap fees plus Fluid's protocol share. LP share = fees x (1 - revenue_cut/1e6). Fluid receives 50% of the protocol cut per Jupiter Lend / Fluid arrangement.",
     Revenue: "Jupiter's share of the protocol cut: fees x (revenue_cut/1e6) x 50%.",
     ProtocolRevenue: "Jupiter's share of the protocol cut: fees x (revenue_cut/1e6) x 50%.",


### PR DESCRIPTION
## Problem

`dex_call_init_dex` decodes `account_token_1` as the system program (`11111111111111111111111111111111`) for pool `FfEJYz4hLLFe4KyNyKYCjvfhMfbtpLH3CXpcPe8nhmfy`, the USDC/USDT pool. Both adapters took pool token identity from that table alone, so every swap on that pool with `swap0to1 = false` was attributed to an unpriceable mint and dropped. The other side was labelled USDT where the pool's `token_0` is actually USDC; identical price and decimals meant the USD figure happened to survive.

That pool is 559,421 of 568,155 swaps to date. The dropped side is 259,079 swaps, around $84.6M of cumulative notional.

## Changes

Pool token identity now comes from `dex_call_swap_in` ∪ `dex_call_swap_out`, with `dex_call_init_dex` kept as the fallback for pools that have never traded.

`swap_out` volume now reads the `amount_out` call argument and values the output leg. This replaces the `call_log_messages` unnest that decoded `amount_in` out of the base64 `LogSwap` payload. There are three `swap_out` calls in the table's entire history, and one of them has no matching log line, so the previous inner join silently dropped it.

The fees query aggregates by mint in SQL instead of returning one row per swap. This is a correctness fix, not just an efficiency one: the Dune results endpoint returns at most 32,000 rows, and `helpers/dune.ts` does not paginate, so the previous per-swap result set was silently truncated. 2026-08-24 had 72,309 swaps and the adapter received 32,000 of them, an arbitrary subset that varied between executions. Three runs of the unchanged adapter on that day returned $14.00, $22.00 and $14.00 of daily fees. Aggregating in SQL brings the result set to one row per mint, well inside the cap.

`start` moves from `2026-06-18`, the pool creation date, to `2026-06-22`, the first swap.

Unchanged: the 1e6 scaling of `fee` and `revenue_cut`, the per-pool rate timeline built from `init_dex` ∪ `update_fee_and_revenue_cut` and joined on `call_block_time`, and the 50/50 Jupiter/Fluid split of the protocol cut.

## Verification

`npm test dexs jupiter-lend-dex 2026-08-25` returns $29.05M daily volume, against $14.84M before this change.

`npm test fees jupiter-lend-dex 2026-08-25` returns $128.00 daily fees, splitting to $96 supply side, $16 to Fluid within supply side, and $16 Jupiter revenue against the 25% `revenue_cut` live that day. It is now stable across runs, where the previous version returned between $14 and $22 for the same day.

`npm test dexs jupiter-lend-dex 2026-08-14` returns $1.02M and `npm test fees jupiter-lend-dex 2026-08-14` returns $87.00. That day had a mid-day fee change on the main pool, so it exercises the rate window join.

`npm test dexs jupiter-lend-dex 2026-08-19` returns $3.10M and `npm test fees jupiter-lend-dex 2026-08-19` returns $7.39. `npm test dexs jupiter-lend-dex 2026-07-02` returns $5.34. `npm test dexs jupiter-lend-dex 2026-06-25`, a day with no swaps, returns 0 without erroring.

Cumulative volume through 2026-08-25 comes to $168,120,432, reconciling against Jupiter's own Dune model of the same pools to within $0.07.

`npm run ts-check` passes.
