### PR TITLE
[feat] hyperevm - split base and priority gas fees

### DIFF
--- a/fees/hyperevm.ts
+++ b/fees/hyperevm.ts
@@ -4,22 +4,35 @@ import { CHAIN } from "../helpers/chains";
 import { queryClickhouse } from "../helpers/indexer";
 import { METRIC } from "../helpers/metrics";
 
-// Replaces the prior Dune query:
-//   SELECT SUM(gas_price * gas_used) FROM hyperevm.transactions
-//   WHERE block_time BETWEEN <day>
-// Direct mapping into the indexer's `evm_indexer.transactions`. Uses
-// `effective_gas_price` (which equals `gas_price` on HyperEVM for legacy txs
-// and is the actually-paid price on EIP-1559 txs).
+// Total gas fees preserve the existing gas_used * effective_gas_price calculation.
+// Base fees use each transaction's block base_fee_per_gas; priority fees are
+// derived as total fees minus base fees.
 const SQL_GAS_FEES = `
   SELECT
-    CAST(sum(toDecimal256(gas_used, 0) * toDecimal256(effective_gas_price, 0)) AS String) AS gas_fees_wei
-  FROM evm_indexer.transactions
-  WHERE chain = {chain:UInt64}
-    AND block_number >= {fromBlock:UInt32}
-    AND block_number <  {toBlock:UInt32}
+    CAST(sum(toDecimal256(t.gas_used, 0) * toDecimal256(t.effective_gas_price, 0)) AS String) AS total_fees_wei,
+    CAST(sum(toDecimal256(t.gas_used, 0) * toDecimal256(b.base_fee_per_gas, 0)) AS String) AS base_fees_wei,
+    toString(count()) AS tx_count,
+    toString(countIf(b.height = t.block_number)) AS matched_transactions
+  FROM evm_indexer.transactions AS t
+  ANY LEFT JOIN (
+    SELECT height, base_fee_per_gas
+    FROM evm_indexer.blocks
+    WHERE chain = {chain:UInt64}
+      AND height >= {fromBlock:UInt32}
+      AND height < {toBlock:UInt32}
+      AND base_fee_per_gas IS NOT NULL
+  ) AS b ON b.height = t.block_number
+  WHERE t.chain = {chain:UInt64}
+    AND t.block_number >= {fromBlock:UInt32}
+    AND t.block_number < {toBlock:UInt32}
 `;
 
-type FeesRow = Row & { gas_fees_wei: string };
+type FeesRow = Row & {
+  total_fees_wei: string;
+  base_fees_wei: string;
+  tx_count: string;
+  matched_transactions: string;
+};
 
 const fetch = async (options: FetchOptions) => {
   const dailyFees = options.createBalances();
@@ -36,8 +49,26 @@ const fetch = async (options: FetchOptions) => {
     toBlock: safeBlock,
   });
 
-  const gasFeesWei = BigInt(rows?.[0]?.gas_fees_wei ?? "0");
-  dailyFees.addGasToken(gasFeesWei, METRIC.TRANSACTION_GAS_FEES);
+  const totalFeesWei = BigInt(rows?.[0]?.total_fees_wei ?? "0");
+  const baseFeesWei = BigInt(rows?.[0]?.base_fees_wei ?? "0");
+  const txCount = Number(rows?.[0]?.tx_count ?? "0");
+  const matchedTransactions = Number(rows?.[0]?.matched_transactions ?? "0");
+
+  if (matchedTransactions !== txCount) {
+    throw new Error(
+      `HyperEVM fee split missing block headers: matched=${matchedTransactions}, txCount=${txCount}`
+    );
+  }
+
+  if (baseFeesWei > totalFeesWei) {
+    throw new Error(
+      `HyperEVM base fees exceed total gas fees: base=${baseFeesWei}, total=${totalFeesWei}`
+    );
+  }
+
+  const priorityFeesWei = totalFeesWei - baseFeesWei;
+  dailyFees.addGasToken(baseFeesWei, METRIC.TRANSACTION_BASE_FEES);
+  dailyFees.addGasToken(priorityFeesWei, METRIC.TRANSACTION_PRIORITY_FEES);
 
   return { dailyFees, dailyRevenue: dailyFees, dailyHoldersRevenue: dailyFees };
 };
@@ -49,6 +80,34 @@ const adapter: Adapter = {
   start: '2025-02-21',
   protocolType: ProtocolType.CHAIN,
   // isExpensiveAdapter: true,
+  methodology: {
+    Fees:
+      "Total HyperEVM gas fees paid by users, split into EIP-1559 base fees and priority fees.",
+    Revenue:
+      "All HyperEVM gas fees are burned. Base fees are removed from EVM supply and priority fees are sent to the EVM zero address.",
+    HoldersRevenue:
+      "All HyperEVM gas fees are burned, reducing HYPE supply.",
+  },
+  breakdownMethodology: {
+    Fees: {
+      [METRIC.TRANSACTION_BASE_FEES]:
+        "EIP-1559 base fees paid by HyperEVM users.",
+      [METRIC.TRANSACTION_PRIORITY_FEES]:
+        "Priority fees paid by HyperEVM users.",
+    },
+    Revenue: {
+      [METRIC.TRANSACTION_BASE_FEES]:
+        "EIP-1559 base fees burned by removing them from HyperEVM supply.",
+      [METRIC.TRANSACTION_PRIORITY_FEES]:
+        "HyperEVM priority fees sent to the EVM zero address and burned.",
+    },
+    HoldersRevenue: {
+      [METRIC.TRANSACTION_BASE_FEES]:
+        "EIP-1559 base fees burned, reducing HYPE supply.",
+      [METRIC.TRANSACTION_PRIORITY_FEES]:
+        "HyperEVM priority fees sent to the EVM zero address and burned, reducing HYPE supply.",
+    },
+  },
 }
 
 export default adapter;

--- a/fees/hyperevm.ts
+++ b/fees/hyperevm.ts
@@ -5,23 +5,18 @@ import { queryClickhouse } from "../helpers/indexer";
 import { METRIC } from "../helpers/metrics";
 
 // Total gas fees preserve the existing gas_used * effective_gas_price calculation.
-// Base fees use each transaction's block base_fee_per_gas; priority fees are
+// Base fees use each transaction's block baseFeePerGas; priority fees are
 // derived as total fees minus base fees.
 const SQL_GAS_FEES = `
   SELECT
     CAST(sum(toDecimal256(t.gas_used, 0) * toDecimal256(t.effective_gas_price, 0)) AS String) AS total_fees_wei,
-    CAST(sum(toDecimal256(t.gas_used, 0) * toDecimal256(b.base_fee_per_gas, 0)) AS String) AS base_fees_wei,
+    CAST(sum(toDecimal256(t.gas_used, 0) * toDecimal256(b.baseFeePerGas, 0)) AS String) AS base_fees_wei,
     toString(count()) AS tx_count,
-    toString(countIf(b.height = t.block_number)) AS matched_transactions
+    toString(countIf(b.height = t.block_number AND b.baseFeePerGas IS NOT NULL)) AS matched_transactions
   FROM evm_indexer.transactions AS t
-  ANY LEFT JOIN (
-    SELECT height, base_fee_per_gas
-    FROM evm_indexer.blocks
-    WHERE chain = {chain:UInt64}
-      AND height >= {fromBlock:UInt32}
-      AND height < {toBlock:UInt32}
-      AND base_fee_per_gas IS NOT NULL
-  ) AS b ON b.height = t.block_number
+  ANY LEFT JOIN evm_indexer.blocks AS b
+    ON b.chain = t.chain
+    AND b.height = t.block_number
   WHERE t.chain = {chain:UInt64}
     AND t.block_number >= {fromBlock:UInt32}
     AND t.block_number < {toBlock:UInt32}


### PR DESCRIPTION
## Summary

Split HyperEVM gas fees into EIP-1559 base fees and priority fees.

The existing adapter already tracks the correct total as:

`gas_used * effective_gas_price`

This PR preserves that total and reports it as:

- `Transaction Base Fees`
- `Transaction Priority Fees`

HyperEVM burns both components: base fees are removed from EVM supply and priority fees are sent to the EVM zero address.

## Calculation

- `totalFees = sum(gas_used * effective_gas_price)`
- `baseFees = sum(gas_used * base_fee_per_gas)`
- `priorityFees = totalFees - baseFees`

The adapter verifies that all transactions match a block header and that base fees never exceed total fees.

Aggregate Fees, Revenue, and Holders Revenue are unchanged.

## Validation

For 2026-08-24, the final calculation was independently reproduced on Dune:

| Metric | HYPE | Share |
| --- | ---: | ---: |
| Total gas fees | 1,615.366581 | 100% |
| Base fees | 235.835993 | 14.60% |
| Priority fees | 1,379.530589 | 85.40% |

- 693,202 transactions
- 693,202 matched block headers
- Direct priority-fee calculation reconciles with `totalFees - baseFees` to **0 wei**
- `pnpm ts-check` ✅
- `git diff --check` ✅

I could not perform local execution because the existing adapter requires `CLICKHOUSE_CONFIG`. The fee split itself was independently reproduced against Dune.

Website: https://hyperliquid.xyz  
Twitter: https://x.com/HyperliquidX  
Docs: https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/hyperevm
