### PR TITLE
hydration-dex: repoint to the indexer host and throw on an empty result

### DIFF
--- a/dexs/hydration-dex/index.ts
+++ b/dexs/hydration-dex/index.ts
@@ -2,6 +2,8 @@ import type { FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 import { request } from "graphql-request";
 
+const INDEXER_URL = "https://orca-main-aggr-indx.indexer.hydration.cloud/graphql";
+
 
 const fetch = async (options: FetchOptions) => {
 
@@ -23,7 +25,12 @@ const fetch = async (options: FetchOptions) => {
     }
   `;
 
-  const queryResult = await request("https://orca-prod-pool-02.catfish.hydration.cloud/graphql", query);
+  const queryResult = await request(INDEXER_URL, query);
+
+  const nodes = queryResult.platformTotalVolumesByPeriod.nodes;
+  if (!nodes.length) {
+    throw new Error(`Hydration indexer has no volume data for ${toDateQuery(options.fromTimestamp)}`);
+  }
 
   const dailyVolume = options.createBalances();
   const dailyFees = options.createBalances();
@@ -32,7 +39,7 @@ const fetch = async (options: FetchOptions) => {
   const dailyHoldersRevenue = options.createBalances();
   const dailyProtocolRevenue = options.createBalances();
 
-  for (const node of queryResult.platformTotalVolumesByPeriod.nodes) {
+  for (const node of nodes) {
     dailyVolume.addUSDValue(Number(node.totalVolNorm));
     dailyFees.addUSDValue(Number(node.xykpoolFeeVolNorm), 'XYK Pools Fees');
     dailyFees.addUSDValue(Number(node.stableswapFeeVolNorm), 'StableSwap Fees');


### PR DESCRIPTION
Fixes #9025

`orca-prod-pool-02.catfish.hydration.cloud` no longer accepts connections on 443, dns resolves, nothing listening, so the adapter has thrown since 2026-08-24 and can't heal on its own. `orca-main-aggr-indx.indexer.hydration.cloud` is the host `projects/hydradx` already uses for tvl, and it serves the identical `platformTotalVolumesByPeriod` query.

```
$ npx ts-node cli/testAdapter.ts dexs hydration-dex 2026-08-22
master   FetchError: connect ETIMEDOUT 135.181.128.254:443
patched  Daily volume: 5.59 M   (XYK 1.8 | StableSwap 383 | Omnipool 2965)
```

that matches the $5,587,849 the site published for 2026-08-21.

hydration's indexer is itself stalled at block 13762692 / 2026-08-24T13:33Z while the chain is at 13,862,001 as of this morning, so the same query returns `nodes: []` for recent days. repointing on its own would turn today's visible break into a silent $0, so the empty case throws instead:

```
$ npx ts-node cli/testAdapter.ts dexs hydration-dex 2026-08-27
Error: Hydration indexer has no volume data for 2026-08-25T23:59:59.000Z
```

adapter heals by itself once their indexer catches up. `fees/hydradx` is dark for the same underlying reason but its host only 500s, and i couldn't find a live alternative for `/api/v1/fees/charts`, so i've left it.