### PR TITLE
fix(o1-launchpad): add missing Base RWA v4 suite

### DIFF
--- a/fees/o1-launchpad/index.ts
+++ b/fees/o1-launchpad/index.ts
@@ -99,6 +99,7 @@ const chainConfig: Record<string, ChainConfig> = {
         factory: "0xe3ab924c72463c1ac8d1d8352ee640b89eb1ea64",
         hook: "0xa068cf4c52abdd3479145c4b3cbd8e3d71542a44",
         feeEscrow: "0xabe87e4af23dafad0a170aa900d574c03d904597",
+        // First suite block: https://basescan.org/block/48364845
         firstBlock: 48_364_845,
         legacyFeeCurrency: true,
         launchFeeCurrency: "none",
@@ -109,6 +110,7 @@ const chainConfig: Record<string, ChainConfig> = {
         factory: "0xa52ad458ce0282a971ecc71c051a32f28946bb9f",
         hook: "0x985c14baa2a18316ffda0aefb3a632fadfca2acc",
         feeEscrow: "0xa2cbd9065cec93c443cafb0837a62800ee7c4a84",
+        // First suite block: https://basescan.org/block/48451098
         firstBlock: 48_451_098,
         legacyFeeCurrency: false,
         launchFeeCurrency: "quote",
@@ -119,6 +121,7 @@ const chainConfig: Record<string, ChainConfig> = {
         factory: "0x1de58a6769526a03a504d9d59b8757cd8097dc57",
         hook: "0xbca7774615c74b7991a111f1c7b2d0efea61aacc",
         feeEscrow: "0xcf9ed8f4145eac9059bcd83227eeb8591fac0a9a",
+        // First suite block: https://basescan.org/block/49121014
         firstBlock: 49_121_014,
         legacyFeeCurrency: false,
         launchFeeCurrency: "native",
@@ -129,6 +132,7 @@ const chainConfig: Record<string, ChainConfig> = {
         factory: "0xff70918ef17a2d74d683a8297813b177bafad1f4",
         hook: "0x3b2b979df21036cee51b8debb13100e2cb8deacc",
         feeEscrow: "0x1d8c991a9019df7d72adcd8dea6f12d600c9d02f",
+        // First suite block: https://basescan.org/block/50137081
         firstBlock: 50_137_081,
         legacyFeeCurrency: false,
         launchFeeCurrency: "native",
@@ -145,6 +149,7 @@ const chainConfig: Record<string, ChainConfig> = {
         factory: "0x8b40fc20c405d47d725c9723d056a1c6f62bbccf",
         hook: "0xe960e6c80c74cfdf03c91e7af4e1f5f53f096a44",
         feeEscrow: "0xf5681c4c0dc0c2e32c9d127b3cc0fc992b584553",
+        // First suite block: https://robinhoodchain.blockscout.com/block/2131131
         firstBlock: 2_131_131,
         legacyFeeCurrency: true,
         launchFeeCurrency: "none",
@@ -155,6 +160,7 @@ const chainConfig: Record<string, ChainConfig> = {
         factory: "0x76f0923ac4df0a079a10f628a7bce6426ccd344a",
         hook: "0xca4b035a5dbfa2a00fc5dcb08fd1c5a22d0eaa44",
         feeEscrow: "0x00d5701a92794c3744428b62646e7bc4e77a0a9a",
+        // First suite block: https://robinhoodchain.blockscout.com/block/4415287
         firstBlock: 4_415_287,
         legacyFeeCurrency: true,
         launchFeeCurrency: "none",
@@ -165,6 +171,7 @@ const chainConfig: Record<string, ChainConfig> = {
         factory: "0x411f21283d3e492bc395027329e08f9f4f560ba5",
         hook: "0x441f773b3bb1ed4c6457d0528624112e43c02acc",
         feeEscrow: "0x32f7a9a05bd62487d085ad494e14ec42543e19d2",
+        // First suite block: https://robinhoodchain.blockscout.com/block/6131279
         firstBlock: 6_131_279,
         legacyFeeCurrency: false,
         launchFeeCurrency: "quote",
@@ -175,6 +182,7 @@ const chainConfig: Record<string, ChainConfig> = {
         factory: "0xe64ac4113848bbc1a6dde1a6d1da96720a36f297",
         hook: "0x778b0c4eea7d35d66513b587ba87fc9084b0eacc",
         feeEscrow: "0x4f2b1cda8748cd64c56039bf5e2e54bc13d4a3d7",
+        // First suite block: https://robinhoodchain.blockscout.com/block/18487505
         firstBlock: 18_487_505,
         legacyFeeCurrency: false,
         launchFeeCurrency: "native",

--- a/fees/o1-launchpad/index.ts
+++ b/fees/o1-launchpad/index.ts
@@ -27,6 +27,7 @@ interface Suite {
   factory: string;
   hook: string;
   feeEscrow: string;
+  firstBlock: number;
   legacyFeeCurrency: boolean;
   launchFeeCurrency: "none" | "quote" | "native";
 }
@@ -98,6 +99,7 @@ const chainConfig: Record<string, ChainConfig> = {
         factory: "0xe3ab924c72463c1ac8d1d8352ee640b89eb1ea64",
         hook: "0xa068cf4c52abdd3479145c4b3cbd8e3d71542a44",
         feeEscrow: "0xabe87e4af23dafad0a170aa900d574c03d904597",
+        firstBlock: 48_364_845,
         legacyFeeCurrency: true,
         launchFeeCurrency: "none",
       },
@@ -107,6 +109,7 @@ const chainConfig: Record<string, ChainConfig> = {
         factory: "0xa52ad458ce0282a971ecc71c051a32f28946bb9f",
         hook: "0x985c14baa2a18316ffda0aefb3a632fadfca2acc",
         feeEscrow: "0xa2cbd9065cec93c443cafb0837a62800ee7c4a84",
+        firstBlock: 48_451_098,
         legacyFeeCurrency: false,
         launchFeeCurrency: "quote",
       },
@@ -116,6 +119,17 @@ const chainConfig: Record<string, ChainConfig> = {
         factory: "0x1de58a6769526a03a504d9d59b8757cd8097dc57",
         hook: "0xbca7774615c74b7991a111f1c7b2d0efea61aacc",
         feeEscrow: "0xcf9ed8f4145eac9059bcd83227eeb8591fac0a9a",
+        firstBlock: 49_121_014,
+        legacyFeeCurrency: false,
+        launchFeeCurrency: "native",
+      },
+      // https://basescan.org/address/0xff70918ef17a2d74d683a8297813b177bafad1f4
+      {
+        id: "base-mainnet-rwa-timestamp-v4",
+        factory: "0xff70918ef17a2d74d683a8297813b177bafad1f4",
+        hook: "0x3b2b979df21036cee51b8debb13100e2cb8deacc",
+        feeEscrow: "0x1d8c991a9019df7d72adcd8dea6f12d600c9d02f",
+        firstBlock: 50_137_081,
         legacyFeeCurrency: false,
         launchFeeCurrency: "native",
       },
@@ -131,6 +145,7 @@ const chainConfig: Record<string, ChainConfig> = {
         factory: "0x8b40fc20c405d47d725c9723d056a1c6f62bbccf",
         hook: "0xe960e6c80c74cfdf03c91e7af4e1f5f53f096a44",
         feeEscrow: "0xf5681c4c0dc0c2e32c9d127b3cc0fc992b584553",
+        firstBlock: 2_131_131,
         legacyFeeCurrency: true,
         launchFeeCurrency: "none",
       },
@@ -140,6 +155,7 @@ const chainConfig: Record<string, ChainConfig> = {
         factory: "0x76f0923ac4df0a079a10f628a7bce6426ccd344a",
         hook: "0xca4b035a5dbfa2a00fc5dcb08fd1c5a22d0eaa44",
         feeEscrow: "0x00d5701a92794c3744428b62646e7bc4e77a0a9a",
+        firstBlock: 4_415_287,
         legacyFeeCurrency: true,
         launchFeeCurrency: "none",
       },
@@ -149,6 +165,7 @@ const chainConfig: Record<string, ChainConfig> = {
         factory: "0x411f21283d3e492bc395027329e08f9f4f560ba5",
         hook: "0x441f773b3bb1ed4c6457d0528624112e43c02acc",
         feeEscrow: "0x32f7a9a05bd62487d085ad494e14ec42543e19d2",
+        firstBlock: 6_131_279,
         legacyFeeCurrency: false,
         launchFeeCurrency: "quote",
       },
@@ -158,6 +175,7 @@ const chainConfig: Record<string, ChainConfig> = {
         factory: "0xe64ac4113848bbc1a6dde1a6d1da96720a36f297",
         hook: "0x778b0c4eea7d35d66513b587ba87fc9084b0eacc",
         feeEscrow: "0x4f2b1cda8748cd64c56039bf5e2e54bc13d4a3d7",
+        firstBlock: 18_487_505,
         legacyFeeCurrency: false,
         launchFeeCurrency: "native",
       },
@@ -259,6 +277,7 @@ const reconcileSuite = (
 ) => {
   const eventsByTransaction = new Map<string, Array<TradeEvent | CreditEvent>>();
   const addEvent = (event: TradeEvent | CreditEvent) => {
+    if (event.blockNumber < suite.firstBlock) return;
     const key = transactionKey(suite, event.transactionHash);
     const events = eventsByTransaction.get(key);
     if (events) events.push(event);


### PR DESCRIPTION
## Summary

- register the missing Base RWA timestamp v4 production suite for o1 Launchpad
- keep the historical Base v1/v2/v3 and Robinhood suites unchanged
- record each suite's authoritative deployment block and ignore pre-deployment Trade/Credited events
- preserve the existing DefiLlama methodology: historical-hourly pricing, platform swap fees plus token launch fees as Revenue, and creator/referrer fees as SupplySideRevenue

## Root cause

The adapter did not include the currently active Base RWA v4 contracts:

- factory: `0xFf70918Ef17A2D74d683a8297813B177BaFaD1f4`
- hook: `0x3b2b979DF21036CEe51B8debB13100e2CB8DeaCC`
- escrow: `0x1D8c991A9019df7D72ADCd8deA6f12D600C9d02f`
- first block: `50,137,081` (2026-08-18 14:31:49 UTC)

The suite uses timestamp fee accounting, quote-denominated swap fees, and native token launch fees.

## Reconciliation

For the complete UTC window 2026-07-27 00:00 through 2026-08-26 00:00:

- previous DefiLlama Revenue: about $849,455
- local standard-runner result after adding v4: about $934,674
- v4 Revenue contribution in that run: about $85,219
- Analytics Platform fees snapshot for the same trade window: about $1,113,564

The remaining difference is expected to include Analytics current-price revaluation versus DefiLlama historical-hourly prices, approximately $13k of launch fees included only by DefiLlama, hourly rounding, and observed Indexer/RPC log completeness variance. No USD values or date-specific adjustments are hard-coded.

`splitTransaction` remains fail-closed. On-chain samples satisfy the creator/referrer/platform identity; observed drops were caused by incomplete Credit log responses, so this PR does not guess allocations or change the split logic.

## Validation

- `npm run ts-check -- --pretty false`
- `npm run ts-check-cli -- --pretty false`
- `npm test -- fees o1-launchpad 2026-08-18 base`
- `npm test -- fees o1-launchpad 2026-08-18T19:00:00Z base`
- verified an on-chain v4 referral trade where creator + referrer + platform equals totalFee
- verified all Base factory/hook/escrow addresses are unique

## Backfill

Please recompute Base fees, revenue, and supply-side revenue from block `50,137,081` so the historical charts include v4.