### PR TITLE
GIGA DEX: combine Classic, CL and BrownFi pools into one adapter

### DIFF
--- a/dexs/brownfi-v3/index.ts
+++ b/dexs/brownfi-v3/index.ts
@@ -5,7 +5,9 @@ import { addOneToken } from "../../helpers/prices";
 import { cache } from "@defillama/sdk";
 import { METRIC } from "../../helpers/metrics";
 
-const chainConfig: Record<string, { factory: string, pairConfig: string, start: string }> = {
+export type BrownFiV3ChainConfig = Record<string, { factory: string, pairConfig: string, start: string }>
+
+const chainConfig: BrownFiV3ChainConfig = {
   [CHAIN.BERACHAIN]: {
     factory: "0x6Ccf36d3EaE84b2eB608704070B90f4419BBcD28",
     pairConfig: "0x4955e0d8A7f25Ba83216946C17fe791D8C49c43a",
@@ -34,7 +36,7 @@ const abis = {
   getConfig: "function getConfig(address pair) external view returns (tuple(uint256 kB, uint256 kQ, uint64 lambda, uint32 fee, uint32 feeSplit, uint32 compress, uint32 sSell, uint32 sBuy, uint32 fixS, uint32 disThreshold, uint32 sBound, uint32 pythWeight, uint32 gamma))"
 };
 
-const fetch = async (options: FetchOptions) => {
+export const getBrownFiV3Fetch = (chainConfig: BrownFiV3ChainConfig) => async (options: FetchOptions) => {
   const { factory, pairConfig } = chainConfig[options.chain];
   const { createBalances, getLogs, chain, api } = options
   const cacheKey = `tvl-adapter-cache/cache/uniswap-forks/${factory.toLowerCase()}-${chain}.json`
@@ -103,7 +105,7 @@ const fetch = async (options: FetchOptions) => {
   };
 };
 
-const methodology = {
+export const methodology = {
   Fees: "Fees from swap transactions.",
   UserFees: "Fees from swap transactions.",
   Revenue: "Protocol share from swap fees.",
@@ -112,7 +114,7 @@ const methodology = {
   HoldersRevenue: "Holders do not earn any revenue.",
 }
 
-const breakdownMethodology = {
+export const breakdownMethodology = {
   Fees: {
     [METRIC.SWAP_FEES]: "Fees from swap transactions.",
   },
@@ -130,7 +132,7 @@ const breakdownMethodology = {
 const adapters: SimpleAdapter = {
   version: 2,
   pullHourly: true,
-  fetch,
+  fetch: getBrownFiV3Fetch(chainConfig),
   adapter: chainConfig,
   methodology,
   breakdownMethodology,

--- a/dexs/giga-dex/index.ts
+++ b/dexs/giga-dex/index.ts
@@ -1,0 +1,113 @@
+import { Balances } from "@defillama/sdk";
+import { FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import { METRIC } from "../../helpers/metrics";
+import { getUniV2LogAdapter, getUniV3LogAdapter } from "../../helpers/uniswap";
+import { getBrownFiV3Fetch } from "../brownfi-v3";
+
+const CLASSIC_FACTORY = "0x6Fdf38f92eAd1adFc04B73aaa947ab254f6c0916";
+const CL_FACTORY = "0xEce6eCd61177336ea6Fb9b17937AC439D85EE20B";
+const BROWNFI_FACTORY = "0x831880Bd3b331249DF63bacC6e21495e5e8f1eAA";
+const BROWNFI_PAIR_CONFIG = "0xD3F729D909a7E84669A35c3F25b37b4AC3487784";
+
+const REVENUE_RATIO = 0.2; // protocol treasury's share of swap fees
+
+// GIGA DEX Classic (uniswap-v2 style) pools
+const classicFetch = getUniV2LogAdapter({
+  factory: CLASSIC_FACTORY,
+  fees: 0.003,
+  stableFees: 0.003,
+  userFeesRatio: 1,
+  revenueRatio: REVENUE_RATIO,
+  protocolRevenueRatio: REVENUE_RATIO,
+});
+
+// PancakeSwap-V3 CL fork: Swap event carries extra protocolFeesToken0/1 fields,
+// so the default Uniswap-V3 event signature does not match its logs.
+const CL_SWAP_EVENT = "event Swap(address indexed sender, address indexed recipient, int256 amount0, int256 amount1, uint160 sqrtPriceX96, uint128 liquidity, int24 tick, uint128 protocolFeesToken0, uint128 protocolFeesToken1)";
+
+// GIGA DEX Concentrated Liquidity pools
+const clFetch = getUniV3LogAdapter({
+  factory: CL_FACTORY,
+  swapEvent: CL_SWAP_EVENT,
+  userFeesRatio: 1,
+  revenueRatio: REVENUE_RATIO,
+  protocolRevenueRatio: REVENUE_RATIO,
+});
+
+// BrownFi oracle-based AMM pools deployed for GIGA DEX,
+// fee and protocol share (feeSplit) are read on-chain per pair
+const brownfiFetch = getBrownFiV3Fetch({
+  [CHAIN.ROBINHOOD]: {
+    factory: BROWNFI_FACTORY,
+    pairConfig: BROWNFI_PAIR_CONFIG,
+    start: '2026-07-29',
+  },
+});
+
+// classic and CL fetches already emit these labels, BrownFi balances are
+// merged under them too so the breakdown stays unified
+const dimensionLabels: Record<string, string | undefined> = {
+  dailyVolume: undefined,
+  dailyFees: METRIC.SWAP_FEES,
+  dailyUserFees: 'Trading fees',
+  dailyRevenue: 'Protocol fees',
+  dailyProtocolRevenue: 'Protocol fees',
+  dailySupplySideRevenue: 'LP fees',
+};
+
+const fetch = async (options: FetchOptions) => {
+  // Run all three pool systems and merge their balances into a single result.
+  const classic = await classicFetch(options);
+  const cl = await clFetch(options);
+  const brownfi = await brownfiFetch(options);
+
+  const result: Record<string, Balances> = {};
+  for (const [dimension, label] of Object.entries(dimensionLabels)) {
+    const balances = options.createBalances();
+    if (classic[dimension] && typeof classic[dimension] !== 'number') balances.addBalances(classic[dimension]);
+    if (cl[dimension] && typeof cl[dimension] !== 'number') balances.addBalances(cl[dimension]);
+    if (brownfi[dimension] && typeof brownfi[dimension] !== 'number') balances.addBalances(brownfi[dimension], label);
+    result[dimension] = balances;
+  }
+  return result;
+};
+
+const methodology = {
+  Fees: "Swap fees paid by traders across GIGA DEX Classic (v2 stable + volatile), Concentrated Liquidity and BrownFi oracle-based pools.",
+  UserFees: "Traders pay the full swap fee on every trade.",
+  Revenue: "Share of swap fees kept by the GIGA protocol treasury (20% on Classic and CL pools, per-pair feeSplit read on-chain for BrownFi pools).",
+  ProtocolRevenue: "Share of swap fees routed to the GIGA protocol treasury.",
+  SupplySideRevenue: "Share of swap fees paid to liquidity providers.",
+  HoldersRevenue: "Holders do not earn any revenue.",
+};
+
+const breakdownMethodology = {
+  Fees: {
+    [METRIC.SWAP_FEES]: "Swap fees paid by traders across Classic, CL and BrownFi pools.",
+  },
+  UserFees: {
+    'Trading fees': "Full swap fee paid by traders on every trade.",
+  },
+  Revenue: {
+    'Protocol fees': "Share of swap fees kept by the GIGA protocol treasury.",
+  },
+  ProtocolRevenue: {
+    'Protocol fees': "Share of swap fees kept by the GIGA protocol treasury.",
+  },
+  SupplySideRevenue: {
+    'LP fees': "Share of swap fees paid to liquidity providers.",
+  },
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  pullHourly: true,
+  fetch,
+  chains: [CHAIN.ROBINHOOD],
+  start: '2026-07-15',
+  methodology,
+  breakdownMethodology,
+};
+
+export default adapter;

--- a/factory/uniV2.ts
+++ b/factory/uniV2.ts
@@ -800,9 +800,6 @@ const configs: Record<string, Record<string, any>> = {
   "parityswap-v2": {
     [CHAIN.ROBINHOOD]: { factory: "0xaA5f8c18EF9be81ffED30c223F9CD0D012a2AdB9", fees: 0.003, revenueRatio: 1 / 6, protocolRevenueRatio: 1 / 6, start: "2026-07-20" }
   },
-  "giga-dex": {
-    [CHAIN.ROBINHOOD]: { factory: "0x6Fdf38f92eAd1adFc04B73aaa947ab254f6c0916", fees: 0.003, stableFees: 0.003, userFeesRatio: 1, revenueRatio: 0.2, protocolRevenueRatio: 0.2, start: "2026-07-15" }
-  },
   "bulbaswap-v2": {
     [CHAIN.MORPH]: { factory: "0x8D2A8b8F7d200d75Bf5F9E84e01F9272f90EFB8b", fees: 0.0035, userFeesRatio: 1, revenueRatio: 2 / 7, protocolRevenueRatio: 2 / 7, start: "2024-10-27" }
   }

--- a/factory/uniV3.ts
+++ b/factory/uniV3.ts
@@ -407,9 +407,6 @@ const configs: Record<string, Record<string, any>> = {
   'sheriff-v3': { 
     [CHAIN.ROBINHOOD]: { factory: '0x21Fd9aB06cc927E66013e89b045c26b3eDE7bB20', start: "2026-07-06", isAlgebraV3: true, userFeesRatio: 1, revenueRatio: 0.2, protocolRevenueRatio: 0.2 },
   },
-  'giga-dex-cl': {
-    [CHAIN.ROBINHOOD]: { factory: '0xEce6eCd61177336ea6Fb9b17937AC439D85EE20B', start: "2026-07-15", swapEvent: protocolFeesSwapEvent, userFeesRatio: 1, revenueRatio: 0.2, protocolRevenueRatio: 0.2 }
-  },
   "betterswap-v3": {
     [CHAIN.VECHAIN]: { factory: '0xf9f1722f95d036efbd1352d84e3a3755f8027b39', userFeesRatio: 1, revenueRatio: 0, protocolRevenueRatio: 0, start: "2026-07-20", },
   },


### PR DESCRIPTION
- Move giga-dex (factory/uniV2.ts) and giga-dex-cl (factory/uniV3.ts) into a single dexs/giga-dex adapter covering the whole GIGA DEX project:
  - Classic uniswap-v2 style pools (same config as the old factory entry)
  - Concentrated Liquidity pools (pancake-v3 fork, same config as giga-dex-cl)
  - BrownFi oracle-based AMM pools deployed for GIGA DEX on Robinhood Chain factory: 0x831880Bd3b331249DF63bacC6e21495e5e8f1eAA pairConfig: 0xD3F729D909a7E84669A35c3F25b37b4AC3487784 (factory.pairConfig()) first pair created 2026-07-29
- Refactor dexs/brownfi-v3 to export a reusable getBrownFiV3Fetch(chainConfig) (behavior unchanged) so BrownFi white-label deployments share the logic

Note: the giga-dex-cl module is removed, its volume now counts under giga-dex; the GIGA V3 listing should be merged into GIGA V2 server-side.