### PR TITLE
[feat] giga-dex - track Classic and BrownFi pools in the giga-dex adapter

### DIFF
--- a/dexs/brownfi-v3/index.ts
+++ b/dexs/brownfi-v3/index.ts
@@ -5,7 +5,9 @@ import { addOneToken } from "../../helpers/prices";
 import { cache } from "@defillama/sdk";
 import { METRIC } from "../../helpers/metrics";
 
-const chainConfig: Record<string, { factory: string, pairConfig: string, start: string }> = {
+export type BrownFiV3ChainConfig = Record<string, { factory: string, pairConfig: string, start: string }>
+
+const chainConfig: BrownFiV3ChainConfig = {
   [CHAIN.BERACHAIN]: {
     factory: "0x6Ccf36d3EaE84b2eB608704070B90f4419BBcD28",
     pairConfig: "0x4955e0d8A7f25Ba83216946C17fe791D8C49c43a",
@@ -26,11 +28,8 @@ const chainConfig: Record<string, { factory: string, pairConfig: string, start: 
     pairConfig: "0xEf83E21b3C45e75cC29ae6aC493dB3821eD87B83",
     start: '2026-06-22',
   },
-  [CHAIN.ROBINHOOD]: {
-    factory: "0x831880Bd3b331249DF63bacC6e21495e5e8f1eAA",
-    pairConfig: "0xD3F729D909a7E84669A35c3F25b37b4AC3487784",
-    start: '2026-07-29',
-  },
+  // the Robinhood Chain deployment is a GIGA DEX white-label,
+  // tracked under the giga-dex adapter instead
 };
 
 const brownfiV3SwapEvent = "event Swap(address indexed sender,uint amount0In,uint amount1In,uint amount0Out,uint amount1Out,uint amount0OutRequested,uint amount1OutRequested,uint pythPrice0,uint pythPrice1,uint ammPrice,uint adjPrice,uint sPrice0,uint sPrice1,address indexed to)"
@@ -39,7 +38,7 @@ const abis = {
   getConfig: "function getConfig(address pair) external view returns (tuple(uint256 kB, uint256 kQ, uint64 lambda, uint32 fee, uint32 feeSplit, uint32 compress, uint32 sSell, uint32 sBuy, uint32 fixS, uint32 disThreshold, uint32 sBound, uint32 pythWeight, uint32 gamma))"
 };
 
-const fetch = async (options: FetchOptions) => {
+export const getBrownFiV3Fetch = (chainConfig: BrownFiV3ChainConfig) => async (options: FetchOptions) => {
   const { factory, pairConfig } = chainConfig[options.chain];
   const { createBalances, getLogs, chain, api } = options
   const cacheKey = `tvl-adapter-cache/cache/uniswap-forks/${factory.toLowerCase()}-${chain}.json`
@@ -108,7 +107,7 @@ const fetch = async (options: FetchOptions) => {
   };
 };
 
-const methodology = {
+export const methodology = {
   Fees: "Fees from swap transactions.",
   UserFees: "Fees from swap transactions.",
   Revenue: "Protocol share from swap fees.",
@@ -117,7 +116,7 @@ const methodology = {
   HoldersRevenue: "Holders do not earn any revenue.",
 }
 
-const breakdownMethodology = {
+export const breakdownMethodology = {
   Fees: {
     [METRIC.SWAP_FEES]: "Fees from swap transactions.",
   },
@@ -135,7 +134,7 @@ const breakdownMethodology = {
 const adapters: SimpleAdapter = {
   version: 2,
   pullHourly: true,
-  fetch,
+  fetch: getBrownFiV3Fetch(chainConfig),
   adapter: chainConfig,
   methodology,
   breakdownMethodology,

--- a/dexs/giga-dex/index.ts
+++ b/dexs/giga-dex/index.ts
@@ -1,0 +1,109 @@
+import { Balances } from "@defillama/sdk";
+import { FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import { METRIC } from "../../helpers/metrics";
+import { getUniV2LogAdapter } from "../../helpers/uniswap";
+import { getBrownFiV3Fetch } from "../brownfi-v3";
+
+// GIGA DEX Classic (uniswap-v2 style) factory on Robinhood Chain, first pair created 2026-07-15
+// https://robinhoodchain.blockscout.com/address/0x6Fdf38f92eAd1adFc04B73aaa947ab254f6c0916
+const CLASSIC_FACTORY = "0x6Fdf38f92eAd1adFc04B73aaa947ab254f6c0916";
+
+// BrownFi oracle-based AMM factory deployed for GIGA DEX, first pair created 2026-07-29
+// https://robinhoodchain.blockscout.com/address/0x831880Bd3b331249DF63bacC6e21495e5e8f1eAA
+const BROWNFI_FACTORY = "0x831880Bd3b331249DF63bacC6e21495e5e8f1eAA";
+// factory.pairConfig(), holds the per-pair fee and feeSplit
+// https://robinhoodchain.blockscout.com/address/0xD3F729D909a7E84669A35c3F25b37b4AC3487784
+const BROWNFI_PAIR_CONFIG = "0xD3F729D909a7E84669A35c3F25b37b4AC3487784";
+const BROWNFI_START = '2026-07-29';
+const BROWNFI_START_TIMESTAMP = 1785283200; // 2026-07-29T00:00:00Z
+
+// Classic pairs charge a flat 0.3% swap fee (UniswapV2Pair fork, hardcoded in the pair contract),
+// of which the protocol treasury keeps 20% via feeTo, same values the giga-dex factory entry used
+const CLASSIC_FEES = 0.003;
+const REVENUE_RATIO = 0.2;
+
+// GIGA DEX Classic (uniswap-v2 style) pools
+const classicFetch = getUniV2LogAdapter({
+  factory: CLASSIC_FACTORY,
+  fees: CLASSIC_FEES,
+  stableFees: CLASSIC_FEES,
+  userFeesRatio: 1,
+  revenueRatio: REVENUE_RATIO,
+  protocolRevenueRatio: REVENUE_RATIO,
+});
+
+// BrownFi oracle-based AMM pools deployed for GIGA DEX,
+// fee and protocol share (feeSplit) are read on-chain per pair
+const brownfiFetch = getBrownFiV3Fetch({
+  [CHAIN.ROBINHOOD]: {
+    factory: BROWNFI_FACTORY,
+    pairConfig: BROWNFI_PAIR_CONFIG,
+    start: BROWNFI_START,
+  },
+});
+
+// the Classic fetch already emits these labels, BrownFi balances are
+// merged under them too so the breakdown stays unified
+const dimensionLabels: Record<string, string | undefined> = {
+  dailyVolume: undefined,
+  dailyFees: METRIC.SWAP_FEES,
+  dailyUserFees: 'Trading fees',
+  dailyRevenue: 'Protocol fees',
+  dailyProtocolRevenue: 'Protocol fees',
+  dailySupplySideRevenue: 'LP fees',
+};
+
+const fetch = async (options: FetchOptions) => {
+  // Run both pool systems and merge their balances into a single result.
+  const classic = await classicFetch(options);
+  // BrownFi pools only exist from BROWNFI_START, skip them on earlier runs
+  const brownfi = options.startTimestamp >= BROWNFI_START_TIMESTAMP ? await brownfiFetch(options) : {} as Record<string, any>;
+
+  const result: Record<string, Balances> = {};
+  for (const [dimension, label] of Object.entries(dimensionLabels)) {
+    const balances = options.createBalances();
+    if (classic[dimension] && typeof classic[dimension] !== 'number') balances.addBalances(classic[dimension]);
+    if (brownfi[dimension] && typeof brownfi[dimension] !== 'number') balances.addBalances(brownfi[dimension], label);
+    result[dimension] = balances;
+  }
+  return result;
+};
+
+const methodology = {
+  Fees: "Swap fees paid by traders across GIGA DEX Classic (v2 stable + volatile) and BrownFi oracle-based pools.",
+  UserFees: "Traders pay the full swap fee on every trade.",
+  Revenue: "Share of swap fees kept by the GIGA protocol treasury (20% on Classic pools, per-pair feeSplit read on-chain for BrownFi pools).",
+  ProtocolRevenue: "Share of swap fees routed to the GIGA protocol treasury.",
+  SupplySideRevenue: "Share of swap fees paid to liquidity providers.",
+};
+
+const breakdownMethodology = {
+  Fees: {
+    [METRIC.SWAP_FEES]: "Swap fees paid by traders across Classic and BrownFi pools.",
+  },
+  UserFees: {
+    'Trading fees': "Full swap fee paid by traders on every trade.",
+  },
+  Revenue: {
+    'Protocol fees': "Share of swap fees kept by the GIGA protocol treasury.",
+  },
+  ProtocolRevenue: {
+    'Protocol fees': "Share of swap fees kept by the GIGA protocol treasury.",
+  },
+  SupplySideRevenue: {
+    'LP fees': "Share of swap fees paid to liquidity providers.",
+  },
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  pullHourly: true,
+  fetch,
+  chains: [CHAIN.ROBINHOOD],
+  start: '2026-07-15',
+  methodology,
+  breakdownMethodology,
+};
+
+export default adapter;

--- a/factory/uniV2.ts
+++ b/factory/uniV2.ts
@@ -807,9 +807,6 @@ const configs: Record<string, Record<string, any>> = {
   "parityswap-v2": {
     [CHAIN.ROBINHOOD]: { factory: "0xaA5f8c18EF9be81ffED30c223F9CD0D012a2AdB9", fees: 0.003, revenueRatio: 1 / 6, protocolRevenueRatio: 1 / 6, start: "2026-07-20" }
   },
-  "giga-dex": {
-    [CHAIN.ROBINHOOD]: { factory: "0x6Fdf38f92eAd1adFc04B73aaa947ab254f6c0916", fees: 0.003, stableFees: 0.003, userFeesRatio: 1, revenueRatio: 0.2, protocolRevenueRatio: 0.2, start: "2026-07-15" }
-  },
   "bulbaswap-v2": {
     [CHAIN.MORPH]: { factory: "0x8D2A8b8F7d200d75Bf5F9E84e01F9272f90EFB8b", fees: 0.0035, userFeesRatio: 1, revenueRatio: 2 / 7, protocolRevenueRatio: 2 / 7, start: "2024-10-27" }
   }


### PR DESCRIPTION
Following up on the review — v2 and v3 stay separate.

`giga-dex-cl` is back to being an untouched `factory/uniV3.ts` entry; this PR now only concerns the GIGA V2 listing.

- Move `giga-dex` from `factory/uniV2.ts` into `dexs/giga-dex` so it can cover both pool types that listing serves on Robinhood Chain:
  - Classic uniswap-v2 style pools (same config as the old factory entry)
  - BrownFi oracle-based AMM pools deployed for GIGA DEX
    factory: `0x831880Bd3b331249DF63bacC6e21495e5e8f1eAA`
    pairConfig: `0xD3F729D909a7E84669A35c3F25b37b4AC3487784` (`factory.pairConfig()`)
    first pair created 2026-07-29
  BrownFi results are merged under the labels the Classic fetch already emits, so the breakdown stays unified, and they are skipped for windows starting before the 2026-07-29 deployment.
- Refactor `dexs/brownfi-v3` to export a reusable `getBrownFiV3Fetch(chainConfig)` (behavior unchanged) so BrownFi white-label deployments share the logic
- Remove the Robinhood entry added to brownfi-v3 in #8967: that deployment is the GIGA DEX white-label, now attributed to giga-dex to avoid double counting

No server-side listing changes needed.
