### PR TITLE
feat(xoxno-lending): add liquidations, active-users and new-users adapters

### DIFF
--- a/active-users/xoxno-lending.ts
+++ b/active-users/xoxno-lending.ts
@@ -22,7 +22,9 @@ const CHAIN_CONFIGS: Record<string, ChainConfig> = {
   [CHAIN.STELLAR]: {
     chainName: "Stellar",
     userStatsExportPath: "/integrations/lending/stellar/active-users",
-    start: "2026-06-21",
+    // Mainnet contracts were deployed at ledger 64140891,
+    // 2026-08-27T00:55Z. An earlier start only backfills zeros.
+    start: "2026-08-27",
   },
 
   // Add MultiversX later with the same API response shape:

--- a/active-users/xoxno-lending.ts
+++ b/active-users/xoxno-lending.ts
@@ -1,0 +1,97 @@
+import { FetchOptions, SimpleAdapter } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+
+const API_BASE = "https://api.xoxno.com";
+const HEADERS = { "User-Agent": "dune-analytics" };
+const REQUEST_TIMEOUT_MS = 5_000;
+
+type ChainConfig = {
+  chainName: string;
+  userStatsExportPath: string;
+  start: string;
+};
+
+type UserStatsExport = {
+  activeUsers?: number;
+  newUsers?: number;
+  activeAccounts?: number;
+  transactions?: number;
+};
+
+const CHAIN_CONFIGS: Record<string, ChainConfig> = {
+  [CHAIN.STELLAR]: {
+    chainName: "Stellar",
+    userStatsExportPath: "/integrations/lending/stellar/active-users",
+    start: "2026-06-21",
+  },
+
+  // Add MultiversX later with the same API response shape:
+  // [CHAIN.MULTIVERSX]: {
+  //   chainName: "MultiversX",
+  //   userStatsExportPath: "/integrations/lending/multiversx/active-users",
+  //   start: "YYYY-MM-DD",
+  // },
+};
+
+function dayRange(timestamp: number) {
+  const day = new Date(timestamp * 1000);
+  day.setUTCHours(0, 0, 0, 0);
+
+  const next = new Date(day);
+  next.setUTCDate(next.getUTCDate() + 1);
+
+  return {
+    startTime: day.toISOString().slice(0, 10),
+    endTime: next.toISOString().slice(0, 10),
+  };
+}
+
+async function fetchUserStats(options: FetchOptions): Promise<UserStatsExport> {
+  const { startTime, endTime } = dayRange(options.startTimestamp);
+  const path = CHAIN_CONFIGS[options.chain].userStatsExportPath;
+  const url = `${API_BASE}${path}?startTime=${startTime}&endTime=${endTime}`;
+  const response = await fetch(url, {
+    headers: HEADERS,
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `XOXNO lending user-stats export failed: ${response.status}`,
+    );
+  }
+
+  return (await response.json()) as UserStatsExport;
+}
+
+async function fetchActiveUsers(options: FetchOptions) {
+  const stats = await fetchUserStats(options);
+
+  // Users are counted by OWNER (wallet address), not sub-account: one owner
+  // holds many lending sub-accounts, so the wallet is the real user count.
+  return {
+    dailyActiveUsers: Number(stats.activeUsers ?? 0),
+    dailyTransactionsCount: Number(stats.transactions ?? 0),
+  };
+}
+
+const methodology = {
+  ActiveUsers:
+    "Distinct owner wallet addresses that performed a lending action (supply, borrow, repay, withdraw, liquidation) in the day, from the on-chain position activity feed. Sub-accounts of the same wallet are collapsed to one user.",
+  TransactionsCount:
+    "Count of lending position actions in the day across all markets.",
+};
+
+const adapter: SimpleAdapter = {
+  version: 1,
+  fetch: fetchActiveUsers,
+  adapter: Object.fromEntries(
+    Object.entries(CHAIN_CONFIGS).map(([chain, config]) => [
+      chain,
+      { start: config.start },
+    ]),
+  ),
+  methodology,
+};
+
+export default adapter;

--- a/active-users/xoxno-lending.ts
+++ b/active-users/xoxno-lending.ts
@@ -79,9 +79,8 @@ async function fetchActiveUsers(options: FetchOptions) {
 
 const methodology = {
   ActiveUsers:
-    "Distinct owner wallet addresses that performed a lending action (supply, borrow, repay, withdraw, liquidation) in the day, from the on-chain position activity feed. Sub-accounts of the same wallet are collapsed to one user.",
-  TransactionsCount:
-    "Count of lending position actions in the day across all markets.",
+    "Wallets that supplied, borrowed, repaid or withdrew during the day.",
+  TransactionsCount: "Number of lending actions during the day.",
 };
 
 const adapter: SimpleAdapter = {

--- a/fees/xoxno-lending/index.ts
+++ b/fees/xoxno-lending/index.ts
@@ -91,8 +91,8 @@ async function makeFetchFees(options: FetchOptions) {
 
 const methodology = {
   Fees: "Borrower interest and lending fees collected by the protocol.",
-  Revenue: "All collected fees. The protocol keeps the full amount.",
-  ProtocolRevenue: "All collected fees. The protocol keeps the full amount.",
+  Revenue: "Borrower interest and lending fees collected by the protocol.",
+  ProtocolRevenue: "Borrower interest and lending fees collected by the protocol.",
   SupplySideRevenue: "Supplier interest is not included in the reported fees.",
 };
 

--- a/fees/xoxno-lending/index.ts
+++ b/fees/xoxno-lending/index.ts
@@ -26,7 +26,9 @@ const CHAIN_CONFIGS: Record<string, ChainConfig> = {
   [CHAIN.STELLAR]: {
     chainName: "Stellar",
     revenueExportPath: "/integrations/lending/stellar/revenue",
-    start: "2026-06-21",
+    // Mainnet contracts were deployed at ledger 64140891,
+    // 2026-08-27T00:55Z. An earlier start only backfills zeros.
+    start: "2026-08-27",
   },
 
   // Add MultiversX later with the same API response shape:

--- a/fees/xoxno-lending/index.ts
+++ b/fees/xoxno-lending/index.ts
@@ -90,14 +90,10 @@ async function makeFetchFees(options: FetchOptions) {
   }
 
 const methodology = {
-  Fees:
-    "Borrower-paid interest and explicit lending fees derived from daily protocol revenue deltas.",
-  Revenue:
-    "Protocol revenue is the positive daily delta of cumulative on-chain pool protocol_revenue(asset), summed across markets.",
-  ProtocolRevenue:
-    "Same as revenue for the current XOXNO lending export.",
-  SupplySideRevenue:
-    "Reported as 0 until supplier-side interest revenue is exported separately.",
+  Fees: "Borrower interest and lending fees collected by the protocol.",
+  Revenue: "All collected fees. The protocol keeps the full amount.",
+  ProtocolRevenue: "All collected fees. The protocol keeps the full amount.",
+  SupplySideRevenue: "Supplier interest is not included in the reported fees.",
 };
 
 const adapter: SimpleAdapter = {

--- a/liquidations/xoxno-lending/index.ts
+++ b/liquidations/xoxno-lending/index.ts
@@ -24,7 +24,9 @@ const CHAIN_CONFIGS: Record<string, ChainConfig> = {
   [CHAIN.STELLAR]: {
     chainName: "Stellar",
     liquidationsExportPath: "/integrations/lending/stellar/liquidations",
-    start: "2026-06-21",
+    // Mainnet contracts were deployed at ledger 64140891,
+    // 2026-08-27T00:55Z. An earlier start only backfills zeros.
+    start: "2026-08-27",
   },
 
   // Add MultiversX later with the same API response shape:

--- a/liquidations/xoxno-lending/index.ts
+++ b/liquidations/xoxno-lending/index.ts
@@ -1,0 +1,96 @@
+import { FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+
+const API_BASE = "https://api.xoxno.com";
+const HEADERS = { "User-Agent": "dune-analytics" };
+const REQUEST_TIMEOUT_MS = 5_000;
+
+type ChainConfig = {
+  chainName: string;
+  liquidationsExportPath: string;
+  start: string;
+};
+
+type LiquidationPoint = {
+  seizedUsd?: number;
+  repaidUsd?: number;
+};
+
+type LiquidationsExport = {
+  points?: LiquidationPoint[];
+};
+
+const CHAIN_CONFIGS: Record<string, ChainConfig> = {
+  [CHAIN.STELLAR]: {
+    chainName: "Stellar",
+    liquidationsExportPath: "/integrations/lending/stellar/liquidations",
+    start: "2026-06-21",
+  },
+
+  // Add MultiversX later with the same API response shape:
+  // [CHAIN.MULTIVERSX]: {
+  //   chainName: "MultiversX",
+  //   liquidationsExportPath: "/integrations/lending/multiversx/liquidations",
+  //   start: "YYYY-MM-DD",
+  // },
+};
+
+function dayRange(timestamp: number) {
+  const day = new Date(timestamp * 1000);
+  day.setUTCHours(0, 0, 0, 0);
+
+  const next = new Date(day);
+  next.setUTCDate(next.getUTCDate() + 1);
+
+  return {
+    startTime: day.toISOString().slice(0, 10),
+    endTime: next.toISOString().slice(0, 10),
+  };
+}
+
+function sumField(points: LiquidationPoint[], field: keyof LiquidationPoint) {
+  return points.reduce((sum, point) => sum + Number(point[field] ?? 0), 0);
+}
+
+async function fetchLiquidations(options: FetchOptions) {
+  const { startTime, endTime } = dayRange(options.startTimestamp);
+  const path = CHAIN_CONFIGS[options.chain].liquidationsExportPath;
+  const url = `${API_BASE}${path}?startTime=${startTime}&endTime=${endTime}&bin=1d`;
+  const response = await fetch(url, {
+    headers: HEADERS,
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `XOXNO lending liquidations export failed: ${response.status}`,
+    );
+  }
+
+  const data = (await response.json()) as LiquidationsExport;
+  const points = Array.isArray(data.points) ? data.points : [];
+
+  // Collateral seized from liquidated borrowers (USD), summed over the day.
+  const dailyCollateralLiquidated = sumField(points, "seizedUsd");
+
+  return { dailyCollateralLiquidated };
+}
+
+const methodology = {
+  CollateralLiquidated:
+    "USD value of collateral seized from liquidated XOXNO lending borrowers, from the on-chain liquidation event feed (position:liquidation), summed per day across markets.",
+};
+
+const adapter: SimpleAdapter = {
+  version: 1,
+  fetch: fetchLiquidations,
+  adapter: Object.fromEntries(
+    Object.entries(CHAIN_CONFIGS).map(([chain, config]) => [
+      chain,
+      { start: config.start },
+    ]),
+  ),
+  methodology,
+};
+
+export default adapter;

--- a/liquidations/xoxno-lending/index.ts
+++ b/liquidations/xoxno-lending/index.ts
@@ -80,7 +80,7 @@ async function fetchLiquidations(options: FetchOptions) {
 
 const methodology = {
   CollateralLiquidated:
-    "USD value of collateral seized from liquidated XOXNO lending borrowers, from the on-chain liquidation event feed (position:liquidation), summed per day across markets.",
+    "Value of collateral seized from borrowers in liquidations.",
 };
 
 const adapter: SimpleAdapter = {

--- a/new-users/xoxno-lending.ts
+++ b/new-users/xoxno-lending.ts
@@ -1,0 +1,94 @@
+import { FetchOptions, SimpleAdapter } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+
+const API_BASE = "https://api.xoxno.com";
+const HEADERS = { "User-Agent": "dune-analytics" };
+const REQUEST_TIMEOUT_MS = 5_000;
+
+type ChainConfig = {
+  chainName: string;
+  userStatsExportPath: string;
+  start: string;
+};
+
+type UserStatsExport = {
+  activeUsers?: number;
+  newUsers?: number;
+  activeAccounts?: number;
+  transactions?: number;
+};
+
+const CHAIN_CONFIGS: Record<string, ChainConfig> = {
+  [CHAIN.STELLAR]: {
+    chainName: "Stellar",
+    userStatsExportPath: "/integrations/lending/stellar/active-users",
+    start: "2026-06-21",
+  },
+
+  // Add MultiversX later with the same API response shape:
+  // [CHAIN.MULTIVERSX]: {
+  //   chainName: "MultiversX",
+  //   userStatsExportPath: "/integrations/lending/multiversx/active-users",
+  //   start: "YYYY-MM-DD",
+  // },
+};
+
+function dayRange(timestamp: number) {
+  const day = new Date(timestamp * 1000);
+  day.setUTCHours(0, 0, 0, 0);
+
+  const next = new Date(day);
+  next.setUTCDate(next.getUTCDate() + 1);
+
+  return {
+    startTime: day.toISOString().slice(0, 10),
+    endTime: next.toISOString().slice(0, 10),
+  };
+}
+
+async function fetchUserStats(options: FetchOptions): Promise<UserStatsExport> {
+  const { startTime, endTime } = dayRange(options.startTimestamp);
+  const path = CHAIN_CONFIGS[options.chain].userStatsExportPath;
+  const url = `${API_BASE}${path}?startTime=${startTime}&endTime=${endTime}`;
+  const response = await fetch(url, {
+    headers: HEADERS,
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `XOXNO lending user-stats export failed: ${response.status}`,
+    );
+  }
+
+  return (await response.json()) as UserStatsExport;
+}
+
+async function fetchNewUsers(options: FetchOptions) {
+  const stats = await fetchUserStats(options);
+
+  // New owners = wallets whose first-ever lending action (global minimum)
+  // falls in the day. Counted by owner wallet, not sub-account.
+  return {
+    dailyNewUsers: Number(stats.newUsers ?? 0),
+  };
+}
+
+const methodology = {
+  NewUsers:
+    "Distinct owner wallet addresses whose first-ever XOXNO lending action falls in the day, from the on-chain position activity feed. Sub-accounts of the same wallet are collapsed to one user.",
+};
+
+const adapter: SimpleAdapter = {
+  version: 1,
+  fetch: fetchNewUsers,
+  adapter: Object.fromEntries(
+    Object.entries(CHAIN_CONFIGS).map(([chain, config]) => [
+      chain,
+      { start: config.start },
+    ]),
+  ),
+  methodology,
+};
+
+export default adapter;

--- a/new-users/xoxno-lending.ts
+++ b/new-users/xoxno-lending.ts
@@ -77,8 +77,7 @@ async function fetchNewUsers(options: FetchOptions) {
 }
 
 const methodology = {
-  NewUsers:
-    "Distinct owner wallet addresses whose first-ever XOXNO lending action falls in the day, from the on-chain position activity feed. Sub-accounts of the same wallet are collapsed to one user.",
+  NewUsers: "Wallets using XOXNO lending for the first time.",
 };
 
 const adapter: SimpleAdapter = {

--- a/new-users/xoxno-lending.ts
+++ b/new-users/xoxno-lending.ts
@@ -22,7 +22,9 @@ const CHAIN_CONFIGS: Record<string, ChainConfig> = {
   [CHAIN.STELLAR]: {
     chainName: "Stellar",
     userStatsExportPath: "/integrations/lending/stellar/active-users",
-    start: "2026-06-21",
+    // Mainnet contracts were deployed at ledger 64140891,
+    // 2026-08-27T00:55Z. An earlier start only backfills zeros.
+    start: "2026-08-27",
   },
 
   // Add MultiversX later with the same API response shape:


### PR DESCRIPTION
Adds the remaining dimensions for the XOXNO lending deployment on Stellar, alongside the existing fees adapter.

- **liquidations** — daily collateral liquidated
- **active-users** — daily active users and transaction count
- **new-users** — daily new users

All three follow the same shape as the fees adapter: a per-chain config, a UTC day range, and a single call to the protocol's event-sourced integration API.

**Also corrects the backfill start.** All four adapters declared `start: "2026-06-21"`, but the mainnet contracts were not deployed until `2026-08-27`. Every earlier day backfills a guaranteed zero, so the start is moved to the deployment date.

**Testing.** Each adapter runs against production with the corrected start:

```
fees          fees 0.00  revenue 0.00  protocol revenue 0.00  supply side 0.00
liquidations  collateral liquidated 0.00
active-users  active users 0.00  transactions 0.00
new-users     new users 0.00
```

Note: the protocol is deployed but not yet open, so these are currently 0.