### PR TITLE
[feat] epsilon-exchange - add Robinhood Chain aggregator adapter with volume and fees

### DIFF
--- a/aggregators/epsilon-exchange/index.ts
+++ b/aggregators/epsilon-exchange/index.ts
@@ -1,67 +1,218 @@
 import { FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
-import { getTransactions } from "../../helpers/getTxReceipts";
+import { getTransactions, getTxReceipts } from "../../helpers/getTxReceipts";
 
-// EpsilonRouter v7 on Robinhood Chain.
-const ROUTER = "0x367832cF3787b69fEFA1a0fdF3FcEE9DBc7631C1";
+// Epsilon (epsilon.exchange) on Robinhood Chain. Two router eras:
+//  - v7   (2026-07-14 → 2026-08-06): 5-field Swapped, no aggregation collector.
+//  - v7.1 (2026-08-19 → now):        Swapped grew fee-split fields (referrer,
+//    referralFee, aggregationFee, feeToken), which changes the event selector.
+// OrderFilled kept the same signature across both.
+const V7_ROUTER = "0x367832cf3787b69fefa1a0fdf3fcee9dbc7631c1";
+const V71_ROUTER = "0xdb41fa80016dc946ceb7b8512c3423463d3f260f";
 
-// Direct swaps carry the full token pair in the event.
-const SWAPPED =
+// FeeVault — protocol commission (VAT on the keeper+referral legs) and captured
+// surplus land here on both router versions (router.feeCollector()).
+const FEE_COLLECTOR = "0x8bdd3f2476501d2b1550792e7df8aa72f4adc70e";
+// Aggregation-fee collector (v7.1 only, router.aggregationFeeCollector()).
+const AGGREGATION_FEE_COLLECTOR = "0xac834ee1a23458d84035724327c66236771fb96d";
+
+const SWAPPED_V7 =
   "event Swapped(address indexed user, address indexed tokenIn, address indexed tokenOut, uint256 amountIn, uint256 amountOut)";
+const SWAPPED_V71 =
+  "event Swapped(address indexed user, address indexed tokenIn, address indexed tokenOut, uint256 amountIn, uint256 amountOut, address referrer, uint256 referralFee, uint256 aggregationFee, address feeToken)";
 
 // Order fills (limit / DCA / trailing-stop executions) carry only hash +
 // amounts, NOT the pair.
 const ORDER_FILLED =
   "event OrderFilled(bytes32 indexed orderHash, address indexed maker, address indexed keeper, uint256 amountIn, uint256 amountOut, uint256 remaining)";
 
-// The pair lives in the `Order` struct — the first, fully-static arg of the
-// keeper's execute* call: struct Order { uint256 salt; address maker; address
-// receiver; address tokenIn; ... }. So tokenIn is the 4th ABI word after the
-// selector; its address is the last 20 of that 32-byte word. In 0x-prefixed
-// hex: 2 + (4 + 3*32)*2 + 24 = 226 .. 266.
-const TOKEN_IN_START = 226;
-const TOKEN_IN_END = 266;
+const TRANSFER_TOPIC = "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef";
+
+// The `Order` struct is the first, fully-static arg of the keeper's execute*
+// call: struct Order { uint256 salt; address maker; address receiver; address
+// tokenIn; address tokenOut; uint256 amountIn; uint256 triggerPrice; uint256
+// triggerAmountOut; MakerTraits makerTraits; address referrer; uint32
+// referralFeePpm; }. An address at struct word N sits in calldata hex at
+// 2 + (4 + N*32)*2 + 24 .. +40 (0x prefix + selector + N words + 12 pad bytes).
+const structAddr = (input: string, word: number): string =>
+  "0x" + input.slice(2 + (4 + word * 32) * 2 + 24, 2 + (4 + word * 32) * 2 + 64).toLowerCase();
+const RECEIVER_WORD = 2;
+const TOKEN_IN_WORD = 3;
+const REFERRER_WORD = 9;
+// Minimum calldata length to safely read the referrer word.
+const MIN_INPUT_LEN = 2 + (4 + (REFERRER_WORD + 1) * 32) * 2;
+
+const ZERO_ADDR = "0x0000000000000000000000000000000000000000";
+
+const METRIC = {
+  DIRECT_SWAPS: "Direct Swaps",
+  ORDER_FILLS: "Order Fills",
+  PROTOCOL_COMMISSION: "Protocol Commission",
+  AGGREGATION_FEES: "Aggregation Fees",
+  KEEPER_FEES: "Keeper Execution Fees",
+  REFERRAL_FEES: "Referral Fees",
+};
+
+type TxMeta = {
+  router: string;
+  // Addresses whose incoming router transfers are fee legs.
+  keepers: Set<string>;
+  referrers: Set<string>;
+  // Trade payout recipients (maker/receiver/swap user) — never counted as
+  // fees, even if one of them also happens to be the referrer (self-referral).
+  payouts: Set<string>;
+};
 
 const fetch = async (options: FetchOptions) => {
   const dailyVolume = options.createBalances();
+  const dailyFees = options.createBalances();
+  const dailyRevenue = options.createBalances();
+  const dailySupplySideRevenue = options.createBalances();
 
-  // 1) Direct swaps — value the input leg straight from the event.
-  const swaps = await options.getLogs({ target: ROUTER, eventAbi: SWAPPED });
-  for (const s of swaps) dailyVolume.add(s.tokenIn, s.amountIn);
+  const txMeta = new Map<string, TxMeta>();
+  const meta = (txHash: string, router: string): TxMeta => {
+    const key = txHash.toLowerCase();
+    let m = txMeta.get(key);
+    if (!m) {
+      m = { router, keepers: new Set(), referrers: new Set(), payouts: new Set() };
+      txMeta.set(key, m);
+    }
+    return m;
+  };
 
-  // 2) Order fills — amountIn is the filled slice (from the event); tokenIn is
-  //    recovered from the fill-tx calldata. Fetch each unique fill-tx once.
-  const fills: any[] = await options.getLogs({ target: ROUTER, eventAbi: ORDER_FILLED, entireLog: true, parseLog: true });
-  if (fills.length) {
-    const txHashes = [...new Set(fills.map((l) => l.transactionHash))];
-    const txs = await getTransactions(options.chain, txHashes);
-    const inputByTx: Record<string, string> = {};
-    for (let i = 0; i < txHashes.length; i++) {
-      const hash = txHashes[i].toLowerCase();
-      const tx = txs[i];
-      if (!tx?.hash) throw new Error(`Missing transaction for OrderFilled tx ${hash}`);
-      const input = tx.data ?? "0x";
-      if (input.length < TOKEN_IN_END) {
-        throw new Error(`Unexpected calldata for OrderFilled tx ${hash}`);
-      }
-      inputByTx[hash] = input;
+  for (const { router, swappedAbi } of [
+    { router: V7_ROUTER, swappedAbi: SWAPPED_V7 },
+    { router: V71_ROUTER, swappedAbi: SWAPPED_V71 },
+  ]) {
+    // 1) Direct swaps — value the input leg straight from the event.
+    const swaps: any[] = await options.getLogs({ target: router, eventAbi: swappedAbi, entireLog: true, parseLog: true });
+    for (const s of swaps) {
+      dailyVolume.add(s.args.tokenIn, s.args.amountIn, METRIC.DIRECT_SWAPS);
+      const m = meta(s.transactionHash, router);
+      m.payouts.add(String(s.args.user).toLowerCase());
+      if (s.args.referrer !== undefined) m.referrers.add(String(s.args.referrer).toLowerCase());
     }
 
-    for (const log of fills) {
-      const txHash = log.transactionHash.toLowerCase();
-      const input = inputByTx[txHash];
-      if (!input) throw new Error(`Missing calldata for OrderFilled log in tx ${txHash}`);
-      const tokenIn = "0x" + input.slice(TOKEN_IN_START, TOKEN_IN_END);
-      dailyVolume.add(tokenIn, log.args.amountIn);
+    // 2) Order fills — amountIn is the filled slice (from the event); tokenIn,
+    //    receiver and referrer are recovered from the fill-tx calldata (the
+    //    Order struct). Fetch each unique fill-tx once.
+    const fills: any[] = await options.getLogs({ target: router, eventAbi: ORDER_FILLED, entireLog: true, parseLog: true });
+    if (fills.length) {
+      const txHashes = [...new Set(fills.map((l) => l.transactionHash.toLowerCase()))];
+      const txs = await getTransactions(options.chain, txHashes);
+      const inputByTx: Record<string, string> = {};
+      for (let i = 0; i < txHashes.length; i++) {
+        const hash = txHashes[i];
+        const tx = txs[i];
+        if (!tx?.hash) throw new Error(`Missing transaction for OrderFilled tx ${hash}`);
+        const input = tx.data ?? "0x";
+        if (input.length < MIN_INPUT_LEN) throw new Error(`Unexpected calldata for OrderFilled tx ${hash}`);
+        inputByTx[hash] = input;
+      }
+
+      for (const log of fills) {
+        const txHash = log.transactionHash.toLowerCase();
+        const input = inputByTx[txHash];
+        if (!input) throw new Error(`Missing calldata for OrderFilled log in tx ${txHash}`);
+        dailyVolume.add(structAddr(input, TOKEN_IN_WORD), log.args.amountIn, METRIC.ORDER_FILLS);
+
+        const m = meta(txHash, router);
+        m.keepers.add(String(log.args.keeper).toLowerCase());
+        m.payouts.add(String(log.args.maker).toLowerCase());
+        m.payouts.add(structAddr(input, RECEIVER_WORD));
+        // Referrer sits in the Order struct only on the v7.1 router.
+        if (router === V71_ROUTER) m.referrers.add(structAddr(input, REFERRER_WORD));
+      }
     }
   }
 
-  return { dailyVolume };
+  // 3) Fee legs — every fee is paid as an ERC20 transfer out of the router in
+  //    the trade tx: protocol commission → FeeVault, aggregation fee → the
+  //    aggregation collector, keeper fee → the fill keeper, referral fee → the
+  //    order/swap referrer. Routing legs and trade payouts are ignored because
+  //    only known fee recipients are counted.
+  const feeTxHashes = [...txMeta.keys()];
+  if (feeTxHashes.length) {
+    const receipts = await getTxReceipts(options.chain, feeTxHashes);
+    for (let i = 0; i < feeTxHashes.length; i++) {
+      const receipt = receipts[i];
+      if (!receipt) throw new Error(`Missing receipt for Epsilon tx ${feeTxHashes[i]}`);
+      const m = txMeta.get(feeTxHashes[i])!;
+      for (const log of receipt.logs ?? []) {
+        if (log.topics?.[0] !== TRANSFER_TOPIC || log.topics.length < 3) continue;
+        const from = "0x" + log.topics[1].slice(26).toLowerCase();
+        if (from !== m.router) continue;
+        const to = "0x" + log.topics[2].slice(26).toLowerCase();
+        const token = log.address;
+        const amount = log.data;
+
+        if (to === FEE_COLLECTOR) {
+          dailyFees.add(token, amount, METRIC.PROTOCOL_COMMISSION);
+          dailyRevenue.add(token, amount, METRIC.PROTOCOL_COMMISSION);
+        } else if (to === AGGREGATION_FEE_COLLECTOR) {
+          dailyFees.add(token, amount, METRIC.AGGREGATION_FEES);
+          dailyRevenue.add(token, amount, METRIC.AGGREGATION_FEES);
+        } else if (m.keepers.has(to)) {
+          dailyFees.add(token, amount, METRIC.KEEPER_FEES);
+          dailySupplySideRevenue.add(token, amount, METRIC.KEEPER_FEES);
+        } else if (m.referrers.has(to) && to !== ZERO_ADDR && !m.payouts.has(to)) {
+          dailyFees.add(token, amount, METRIC.REFERRAL_FEES);
+          dailySupplySideRevenue.add(token, amount, METRIC.REFERRAL_FEES);
+        }
+      }
+    }
+  }
+
+  return {
+    dailyVolume,
+    dailyFees,
+    dailyUserFees: dailyFees,
+    dailyRevenue,
+    dailyProtocolRevenue: dailyRevenue,
+    dailySupplySideRevenue,
+  };
 };
 
 const methodology = {
-  Volume: "Sum of direct swap volumes and order fill volumes (limit, DCA and trailing-stop orders) routed through the Epsilon router on Robinhood Chain",
-}
+  Volume:
+    "Sum of direct aggregated-swap volumes and order fill volumes (limit, DCA and trailing-stop executions) routed through the Epsilon router on Robinhood Chain, valued on the input token leg.",
+  Fees: "All fee legs charged on trades, measured from on-chain token transfers out of the router: protocol commission (including captured surplus), aggregation fees, keeper execution fees and referral fees.",
+  UserFees: "All fees are paid by traders out of trade proceeds.",
+  Revenue: "Protocol commission and aggregation fees, both collected by protocol-owned collectors.",
+  ProtocolRevenue: "All revenue accrues to the protocol treasury (FeeVault and aggregation collector); there is no token.",
+  SupplySideRevenue: "Keeper execution fees paid to order executors and referral fees paid to third-party referrers/integrators (permissionless rev-share).",
+};
+
+const breakdownMethodology = {
+  Volume: {
+    [METRIC.DIRECT_SWAPS]: "Aggregated market swaps executed directly through the router (Swapped events).",
+    [METRIC.ORDER_FILLS]: "Keeper executions of limit, DCA and trailing-stop orders (OrderFilled events).",
+  },
+  Fees: {
+    [METRIC.PROTOCOL_COMMISSION]: "Protocol cut (VAT) charged on top of keeper and referral fees, plus captured price-improvement surplus, transferred to the FeeVault.",
+    [METRIC.AGGREGATION_FEES]: "Fee on aggregated swap routes, transferred to the aggregation-fee collector.",
+    [METRIC.KEEPER_FEES]: "Execution fee paid to the keeper that fills a resting order.",
+    [METRIC.REFERRAL_FEES]: "Referral leg paid to the referrer address named on the order or swap (permissionless rev-share).",
+  },
+  UserFees: {
+    [METRIC.PROTOCOL_COMMISSION]: "Paid by traders as part of each trade's fee legs.",
+    [METRIC.AGGREGATION_FEES]: "Paid by traders on aggregated swap routes.",
+    [METRIC.KEEPER_FEES]: "Paid by makers on order fills.",
+    [METRIC.REFERRAL_FEES]: "Paid by traders on referred flow.",
+  },
+  Revenue: {
+    [METRIC.PROTOCOL_COMMISSION]: "Protocol commission and captured surplus kept in the FeeVault.",
+    [METRIC.AGGREGATION_FEES]: "Aggregation fees kept by the protocol's aggregation collector.",
+  },
+  ProtocolRevenue: {
+    [METRIC.PROTOCOL_COMMISSION]: "Protocol commission and captured surplus kept in the FeeVault.",
+    [METRIC.AGGREGATION_FEES]: "Aggregation fees kept by the protocol's aggregation collector.",
+  },
+  SupplySideRevenue: {
+    [METRIC.KEEPER_FEES]: "Execution fees earned by keepers for filling orders.",
+    [METRIC.REFERRAL_FEES]: "Referral fees earned by third-party referrers and integrators.",
+  },
+};
 
 const adapter: SimpleAdapter = {
   version: 2,
@@ -70,6 +221,7 @@ const adapter: SimpleAdapter = {
   fetch,
   start: "2026-07-14",
   methodology,
+  breakdownMethodology,
 };
 
 export default adapter;

--- a/aggregators/epsilon-exchange/index.ts
+++ b/aggregators/epsilon-exchange/index.ts
@@ -2,23 +2,16 @@ import { FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 import { getTransactions, getTxReceipts } from "../../helpers/getTxReceipts";
 
-// Epsilon (epsilon.exchange) on Robinhood Chain. Two router eras:
-//  - v7   (2026-07-14 → 2026-08-06): 5-field Swapped, no aggregation collector.
-//  - v7.1 (2026-08-19 → now):        Swapped grew fee-split fields (referrer,
-//    referralFee, aggregationFee, feeToken), which changes the event selector.
-// OrderFilled kept the same signature across both.
-const V7_ROUTER = "0x367832cf3787b69fefa1a0fdf3fcee9dbc7631c1";
-const V71_ROUTER = "0xdb41fa80016dc946ceb7b8512c3423463d3f260f";
+// Epsilon (epsilon.exchange) on Robinhood Chain — v7.1 router.
+const ROUTER = "0xdb41fa80016dc946ceb7b8512c3423463d3f260f";
 
 // FeeVault — protocol commission (VAT on the keeper+referral legs) and captured
-// surplus land here on both router versions (router.feeCollector()).
+// surplus land here (router.feeCollector()).
 const FEE_COLLECTOR = "0x8bdd3f2476501d2b1550792e7df8aa72f4adc70e";
-// Aggregation-fee collector (v7.1 only, router.aggregationFeeCollector()).
+// Aggregation-fee collector (router.aggregationFeeCollector()).
 const AGGREGATION_FEE_COLLECTOR = "0xac834ee1a23458d84035724327c66236771fb96d";
 
-const SWAPPED_V7 =
-  "event Swapped(address indexed user, address indexed tokenIn, address indexed tokenOut, uint256 amountIn, uint256 amountOut)";
-const SWAPPED_V71 =
+const SWAPPED =
   "event Swapped(address indexed user, address indexed tokenIn, address indexed tokenOut, uint256 amountIn, uint256 amountOut, address referrer, uint256 referralFee, uint256 aggregationFee, address feeToken)";
 
 // Order fills (limit / DCA / trailing-stop executions) carry only hash +
@@ -54,7 +47,6 @@ const METRIC = {
 };
 
 type TxMeta = {
-  router: string;
   // Addresses whose incoming router transfers are fee legs.
   keepers: Set<string>;
   referrers: Set<string>;
@@ -70,59 +62,53 @@ const fetch = async (options: FetchOptions) => {
   const dailySupplySideRevenue = options.createBalances();
 
   const txMeta = new Map<string, TxMeta>();
-  const meta = (txHash: string, router: string): TxMeta => {
+  const meta = (txHash: string): TxMeta => {
     const key = txHash.toLowerCase();
     let m = txMeta.get(key);
     if (!m) {
-      m = { router, keepers: new Set(), referrers: new Set(), payouts: new Set() };
+      m = { keepers: new Set(), referrers: new Set(), payouts: new Set() };
       txMeta.set(key, m);
     }
     return m;
   };
 
-  for (const { router, swappedAbi } of [
-    { router: V7_ROUTER, swappedAbi: SWAPPED_V7 },
-    { router: V71_ROUTER, swappedAbi: SWAPPED_V71 },
-  ]) {
-    // 1) Direct swaps — value the input leg straight from the event.
-    const swaps: any[] = await options.getLogs({ target: router, eventAbi: swappedAbi, entireLog: true, parseLog: true });
-    for (const s of swaps) {
-      dailyVolume.add(s.args.tokenIn, s.args.amountIn, METRIC.DIRECT_SWAPS);
-      const m = meta(s.transactionHash, router);
-      m.payouts.add(String(s.args.user).toLowerCase());
-      if (s.args.referrer !== undefined) m.referrers.add(String(s.args.referrer).toLowerCase());
+  // 1) Direct swaps — value the input leg straight from the event.
+  const swaps: any[] = await options.getLogs({ target: ROUTER, eventAbi: SWAPPED, entireLog: true, parseLog: true });
+  for (const s of swaps) {
+    dailyVolume.add(s.args.tokenIn, s.args.amountIn, METRIC.DIRECT_SWAPS);
+    const m = meta(s.transactionHash);
+    m.payouts.add(String(s.args.user).toLowerCase());
+    m.referrers.add(String(s.args.referrer).toLowerCase());
+  }
+
+  // 2) Order fills — amountIn is the filled slice (from the event); tokenIn,
+  //    receiver and referrer are recovered from the fill-tx calldata (the
+  //    Order struct). Fetch each unique fill-tx once.
+  const fills: any[] = await options.getLogs({ target: ROUTER, eventAbi: ORDER_FILLED, entireLog: true, parseLog: true });
+  if (fills.length) {
+    const txHashes = [...new Set(fills.map((l) => l.transactionHash.toLowerCase()))];
+    const txs = await getTransactions(options.chain, txHashes);
+    const inputByTx: Record<string, string> = {};
+    for (let i = 0; i < txHashes.length; i++) {
+      const hash = txHashes[i];
+      const tx = txs[i];
+      if (!tx?.hash) throw new Error(`Missing transaction for OrderFilled tx ${hash}`);
+      const input = tx.data ?? "0x";
+      if (input.length < MIN_INPUT_LEN) throw new Error(`Unexpected calldata for OrderFilled tx ${hash}`);
+      inputByTx[hash] = input;
     }
 
-    // 2) Order fills — amountIn is the filled slice (from the event); tokenIn,
-    //    receiver and referrer are recovered from the fill-tx calldata (the
-    //    Order struct). Fetch each unique fill-tx once.
-    const fills: any[] = await options.getLogs({ target: router, eventAbi: ORDER_FILLED, entireLog: true, parseLog: true });
-    if (fills.length) {
-      const txHashes = [...new Set(fills.map((l) => l.transactionHash.toLowerCase()))];
-      const txs = await getTransactions(options.chain, txHashes);
-      const inputByTx: Record<string, string> = {};
-      for (let i = 0; i < txHashes.length; i++) {
-        const hash = txHashes[i];
-        const tx = txs[i];
-        if (!tx?.hash) throw new Error(`Missing transaction for OrderFilled tx ${hash}`);
-        const input = tx.data ?? "0x";
-        if (input.length < MIN_INPUT_LEN) throw new Error(`Unexpected calldata for OrderFilled tx ${hash}`);
-        inputByTx[hash] = input;
-      }
+    for (const log of fills) {
+      const txHash = log.transactionHash.toLowerCase();
+      const input = inputByTx[txHash];
+      if (!input) throw new Error(`Missing calldata for OrderFilled log in tx ${txHash}`);
+      dailyVolume.add(structAddr(input, TOKEN_IN_WORD), log.args.amountIn, METRIC.ORDER_FILLS);
 
-      for (const log of fills) {
-        const txHash = log.transactionHash.toLowerCase();
-        const input = inputByTx[txHash];
-        if (!input) throw new Error(`Missing calldata for OrderFilled log in tx ${txHash}`);
-        dailyVolume.add(structAddr(input, TOKEN_IN_WORD), log.args.amountIn, METRIC.ORDER_FILLS);
-
-        const m = meta(txHash, router);
-        m.keepers.add(String(log.args.keeper).toLowerCase());
-        m.payouts.add(String(log.args.maker).toLowerCase());
-        m.payouts.add(structAddr(input, RECEIVER_WORD));
-        // Referrer sits in the Order struct only on the v7.1 router.
-        if (router === V71_ROUTER) m.referrers.add(structAddr(input, REFERRER_WORD));
-      }
+      const m = meta(txHash);
+      m.keepers.add(String(log.args.keeper).toLowerCase());
+      m.payouts.add(String(log.args.maker).toLowerCase());
+      m.payouts.add(structAddr(input, RECEIVER_WORD));
+      m.referrers.add(structAddr(input, REFERRER_WORD));
     }
   }
 
@@ -141,7 +127,7 @@ const fetch = async (options: FetchOptions) => {
       for (const log of receipt.logs ?? []) {
         if (log.topics?.[0] !== TRANSFER_TOPIC || log.topics.length < 3) continue;
         const from = "0x" + log.topics[1].slice(26).toLowerCase();
-        if (from !== m.router) continue;
+        if (from !== ROUTER) continue;
         const to = "0x" + log.topics[2].slice(26).toLowerCase();
         const token = log.address;
         const amount = log.data;
@@ -219,7 +205,7 @@ const adapter: SimpleAdapter = {
   pullHourly: true,
   chains: [CHAIN.ROBINHOOD],
   fetch,
-  start: "2026-07-14",
+  start: "2026-08-19",
   methodology,
   breakdownMethodology,
 };

--- a/aggregators/epsilon-exchange/index.ts
+++ b/aggregators/epsilon-exchange/index.ts
@@ -1,3 +1,4 @@
+import { Interface, ZeroAddress } from "ethers";
 import { FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 import { getTransactions, getTxReceipts } from "../../helpers/getTxReceipts";
@@ -19,7 +20,9 @@ const SWAPPED =
 const ORDER_FILLED =
   "event OrderFilled(bytes32 indexed orderHash, address indexed maker, address indexed keeper, uint256 amountIn, uint256 amountOut, uint256 remaining)";
 
-const TRANSFER_TOPIC = "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef";
+const erc20Interface = new Interface([
+  "event Transfer(address indexed from, address indexed to, uint256 value)",
+]);
 
 // The `Order` struct is the first, fully-static arg of the keeper's execute*
 // call: struct Order { uint256 salt; address maker; address receiver; address
@@ -34,8 +37,6 @@ const TOKEN_IN_WORD = 3;
 const REFERRER_WORD = 9;
 // Minimum calldata length to safely read the referrer word.
 const MIN_INPUT_LEN = 2 + (4 + (REFERRER_WORD + 1) * 32) * 2;
-
-const ZERO_ADDR = "0x0000000000000000000000000000000000000000";
 
 const METRIC = {
   DIRECT_SWAPS: "Direct Swaps",
@@ -125,12 +126,15 @@ const fetch = async (options: FetchOptions) => {
       if (!receipt) throw new Error(`Missing receipt for Epsilon tx ${feeTxHashes[i]}`);
       const m = txMeta.get(feeTxHashes[i])!;
       for (const log of receipt.logs ?? []) {
-        if (log.topics?.[0] !== TRANSFER_TOPIC || log.topics.length < 3) continue;
-        const from = "0x" + log.topics[1].slice(26).toLowerCase();
+        // ERC721 Transfer shares the same topic hash but has 4 topics — skip.
+        if (!log.topics || log.topics.length !== 3) continue;
+        const parsed = erc20Interface.parseLog(log as any);
+        if (!parsed || parsed.name !== "Transfer") continue;
+        const from = String(parsed.args.from).toLowerCase();
         if (from !== ROUTER) continue;
-        const to = "0x" + log.topics[2].slice(26).toLowerCase();
+        const to = String(parsed.args.to).toLowerCase();
         const token = log.address;
-        const amount = log.data;
+        const amount = parsed.args.value;
 
         if (to === FEE_COLLECTOR) {
           dailyFees.add(token, amount, METRIC.PROTOCOL_COMMISSION);
@@ -141,7 +145,7 @@ const fetch = async (options: FetchOptions) => {
         } else if (m.keepers.has(to)) {
           dailyFees.add(token, amount, METRIC.KEEPER_FEES);
           dailySupplySideRevenue.add(token, amount, METRIC.KEEPER_FEES);
-        } else if (m.referrers.has(to) && to !== ZERO_ADDR && !m.payouts.has(to)) {
+        } else if (m.referrers.has(to) && to !== ZeroAddress && !m.payouts.has(to)) {
           dailyFees.add(token, amount, METRIC.REFERRAL_FEES);
           dailySupplySideRevenue.add(token, amount, METRIC.REFERRAL_FEES);
         }
@@ -162,8 +166,7 @@ const fetch = async (options: FetchOptions) => {
 const methodology = {
   Volume:
     "Sum of direct aggregated-swap volumes and order fill volumes (limit, DCA and trailing-stop executions) routed through the Epsilon router on Robinhood Chain, valued on the input token leg.",
-  Fees: "All fee legs charged on trades, measured from on-chain token transfers out of the router: protocol commission (including captured surplus), aggregation fees, keeper execution fees and referral fees.",
-  UserFees: "All fees are paid by traders out of trade proceeds.",
+  Fees: "All fee legs charged on trades, measured from on-chain token transfers out of the router: protocol commission (including captured surplus), aggregation fees, keeper execution fees and referral fees. All fees are paid by traders out of trade proceeds.",
   Revenue: "Protocol commission and aggregation fees, both collected by protocol-owned collectors.",
   ProtocolRevenue: "All revenue accrues to the protocol treasury (FeeVault and aggregation collector); there is no token.",
   SupplySideRevenue: "Keeper execution fees paid to order executors and referral fees paid to third-party referrers/integrators (permissionless rev-share).",
@@ -179,12 +182,6 @@ const breakdownMethodology = {
     [METRIC.AGGREGATION_FEES]: "Fee on aggregated swap routes, transferred to the aggregation-fee collector.",
     [METRIC.KEEPER_FEES]: "Execution fee paid to the keeper that fills a resting order.",
     [METRIC.REFERRAL_FEES]: "Referral leg paid to the referrer address named on the order or swap (permissionless rev-share).",
-  },
-  UserFees: {
-    [METRIC.PROTOCOL_COMMISSION]: "Paid by traders as part of each trade's fee legs.",
-    [METRIC.AGGREGATION_FEES]: "Paid by traders on aggregated swap routes.",
-    [METRIC.KEEPER_FEES]: "Paid by makers on order fills.",
-    [METRIC.REFERRAL_FEES]: "Paid by traders on referred flow.",
   },
   Revenue: {
     [METRIC.PROTOCOL_COMMISSION]: "Protocol commission and captured surplus kept in the FeeVault.",

--- a/aggregators/epsilon-exchange/index.ts
+++ b/aggregators/epsilon-exchange/index.ts
@@ -1,0 +1,75 @@
+import { FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import { getTransactions } from "../../helpers/getTxReceipts";
+
+// EpsilonRouter v7 on Robinhood Chain.
+const ROUTER = "0x367832cF3787b69fEFA1a0fdF3FcEE9DBc7631C1";
+
+// Direct swaps carry the full token pair in the event.
+const SWAPPED =
+  "event Swapped(address indexed user, address indexed tokenIn, address indexed tokenOut, uint256 amountIn, uint256 amountOut)";
+
+// Order fills (limit / DCA / trailing-stop executions) carry only hash +
+// amounts, NOT the pair.
+const ORDER_FILLED =
+  "event OrderFilled(bytes32 indexed orderHash, address indexed maker, address indexed keeper, uint256 amountIn, uint256 amountOut, uint256 remaining)";
+
+// The pair lives in the `Order` struct — the first, fully-static arg of the
+// keeper's execute* call: struct Order { uint256 salt; address maker; address
+// receiver; address tokenIn; ... }. So tokenIn is the 4th ABI word after the
+// selector; its address is the last 20 of that 32-byte word. In 0x-prefixed
+// hex: 2 + (4 + 3*32)*2 + 24 = 226 .. 266.
+const TOKEN_IN_START = 226;
+const TOKEN_IN_END = 266;
+
+const fetch = async (options: FetchOptions) => {
+  const dailyVolume = options.createBalances();
+
+  // 1) Direct swaps — value the input leg straight from the event.
+  const swaps = await options.getLogs({ target: ROUTER, eventAbi: SWAPPED });
+  for (const s of swaps) dailyVolume.add(s.tokenIn, s.amountIn);
+
+  // 2) Order fills — amountIn is the filled slice (from the event); tokenIn is
+  //    recovered from the fill-tx calldata. Fetch each unique fill-tx once.
+  const fills: any[] = await options.getLogs({ target: ROUTER, eventAbi: ORDER_FILLED, entireLog: true, parseLog: true });
+  if (fills.length) {
+    const txHashes = [...new Set(fills.map((l) => l.transactionHash))];
+    const txs = await getTransactions(options.chain, txHashes);
+    const inputByTx: Record<string, string> = {};
+    for (let i = 0; i < txHashes.length; i++) {
+      const hash = txHashes[i].toLowerCase();
+      const tx = txs[i];
+      if (!tx?.hash) throw new Error(`Missing transaction for OrderFilled tx ${hash}`);
+      const input = tx.data ?? "0x";
+      if (input.length < TOKEN_IN_END) {
+        throw new Error(`Unexpected calldata for OrderFilled tx ${hash}`);
+      }
+      inputByTx[hash] = input;
+    }
+
+    for (const log of fills) {
+      const txHash = log.transactionHash.toLowerCase();
+      const input = inputByTx[txHash];
+      if (!input) throw new Error(`Missing calldata for OrderFilled log in tx ${txHash}`);
+      const tokenIn = "0x" + input.slice(TOKEN_IN_START, TOKEN_IN_END);
+      dailyVolume.add(tokenIn, log.args.amountIn);
+    }
+  }
+
+  return { dailyVolume };
+};
+
+const methodology = {
+  Volume: "Sum of direct swap volumes and order fill volumes (limit, DCA and trailing-stop orders) routed through the Epsilon router on Robinhood Chain",
+}
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  pullHourly: true,
+  chains: [CHAIN.ROBINHOOD],
+  fetch,
+  start: "2026-07-14",
+  methodology,
+};
+
+export default adapter;


### PR DESCRIPTION
##### Name (to be shown on DefiLlama):

Epsilon

##### Twitter Link:

https://x.com/TradeEpsilon

##### List of audit links if any:

—

##### Website Link:

https://www.epsilon.exchange

##### Logo (High resolution, will be shown with rounded borders):

https://app.epsilon.exchange/icon-512.png

##### Current TVL:

n/a (aggregator + order engine, non-custodial — no TVL)

##### Treasury Addresses (if the protocol has treasury)

##### Chain:

Robinhood Chain (chain id 4663)

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed): (https://api.coingecko.com/api/v3/coins/list)

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)

##### Short Description (to be shown on DefiLlama):

DEX aggregator and on-chain order engine on Robinhood Chain. Market swaps plus limit, DCA and trailing-stop orders executed by keepers, with a public API, MCP server and SDKs for AI agents and builders.

##### Token address and ticker if any:

None

##### Category (full list at https://defillama.com/categories) \*Please choose only one:

DEX Aggregator

##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.):

Chainlink, Uniswap TWAP

##### Implementation Details: Briefly describe how the oracle is integrated into your project:

Order triggers (limit / stop / trailing-stop) are verified at execution time by an on-chain price verifier that composes Chainlink feeds with Uniswap TWAP oracles; swaps themselves settle against aggregated DEX liquidity.

##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage:


##### forkedFrom (Does your project originate from another project):

No

##### methodology (what is being counted as tvl, how is tvl being calculated):

Volume: direct aggregated swaps (`Swapped` events) + keeper order fills (`OrderFilled` events) through the Epsilon router, valued on the input token leg; fill pairs are recovered from the `Order` struct in the fill-tx calldata. Fees: measured from the actual on-chain fee-leg ERC20 transfers out of the router — protocol commission + captured surplus → FeeVault and aggregation fees → aggregation collector (revenue); keeper execution fees and referral fees (supply side). Breakdown labels + `breakdownMethodology` included. Start: 2026-08-19 (current router deployment).

##### Github org/user (Optional, if your code is open source, we can track activity):

##### Does this project have a referral program?

Yes — a permissionless referral rev-share: any integrator can name a referrer address on quotes/orders and earn the referral fee leg on fills.

---

## Testing

`npm test aggregators epsilon-exchange 2026-08-28`:

```
ROBINHOOD
Daily volume: 3.39
Daily fees: 0.01 (Protocol Commission 0.0026 / Keeper Execution Fees 0.0015 / Aggregation Fees 0.0037)
```

