### PR TITLE
Add Surge Credit liquidations adapter

### DIFF
--- a/liquidations/surgecredit/index.ts
+++ b/liquidations/surgecredit/index.ts
@@ -1,0 +1,53 @@
+import { FetchOptions, SimpleAdapter } from '../../adapters/types'
+import { CHAIN } from '../../helpers/chains'
+
+// Surge liquidations run as Dutch auctions: VaultManager opens an auction over an
+// unhealthy loan's BTC collateral, and AuctionHouse.buy() is the single point at
+// which that collateral leaves the borrower.
+const VAULT_MANAGER = '0x0D5D12de1cC71060A38F25DD9d24DA1DD6eB705a'
+
+// AuctionHouse is swappable — VaultManager has been repointed at a fresh proxy
+// before — so the houses that have served Base are listed here and the live one is
+// read on-chain, keeping history intact across a future swap.
+const AUCTION_HOUSES = ['0xE5Ff1E177dDE3FC33f5457855b14e6bD3B0C6566']
+
+// buy() emits LogAuctionBought and LogAuctionFinalized over the same collateral in
+// a single call, so only one of the two may be counted. LogAuctionCreated is not
+// usable either: an auction can expire or be cancelled without a sale.
+const AuctionBought =
+  'event LogAuctionBought(uint256 indexed nftId, address indexed winner, bytes btcAddress, uint256 originalDebt, uint256 actualPaid, uint256 collateralSats)'
+
+const fetch = async (options: FetchOptions) => {
+  const dailyCollateralLiquidated = options.createBalances()
+
+  const live = await options.api.call({ target: VAULT_MANAGER, abi: 'address:auctionHouse' })
+  const targets = Array.from(new Set([...AUCTION_HOUSES, live].map((address: string) => address.toLowerCase())))
+
+  const logsPerHouse = await Promise.all(
+    targets.map(target => options.getLogs({ target, eventAbi: AuctionBought }))
+  )
+
+  for (const log of logsPerHouse.flat()) {
+    // Collateral is native BTC held in the borrower's Taproot vault; on Base it
+    // exists only as a satoshi amount, so there is no ERC20 to price against.
+    dailyCollateralLiquidated.addCGToken('bitcoin', Number(log.collateralSats) / 1e8)
+  }
+
+  return { dailyCollateralLiquidated }
+}
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  adapter: {
+    [CHAIN.BASE]: {
+      fetch,
+      start: '2026-02-02',
+    },
+  },
+  methodology: {
+    CollateralLiquidated:
+      "Total USD value of native BTC collateral seized from borrowers when a Surge liquidation auction is bought, read from the `collateralSats` field of AuctionHouse `LogAuctionBought` events on Base and priced as bitcoin.",
+  },
+}
+
+export default adapter

--- a/liquidations/surgecredit/index.ts
+++ b/liquidations/surgecredit/index.ts
@@ -47,6 +47,12 @@ const adapter: SimpleAdapter = {
     CollateralLiquidated:
       "Total USD value of native BTC collateral seized from borrowers when a Surge liquidation auction is bought, read from the `collateralSats` field of AuctionHouse `LogAuctionBought` events on Base and priced as bitcoin.",
   },
+  breakdownMethodology: {
+    CollateralLiquidated: {
+      'BTC Collateral':
+        'Native BTC seized from a borrower when a liquidation auction is bought, summed from the `collateralSats` field of AuctionHouse `LogAuctionBought` events and priced as bitcoin. Collateral sits in a per-loan non-custodial Taproot vault, so it has no ERC20 representation on Base.',
+    },
+  },
 }
 
 export default adapter

--- a/liquidations/surgecredit/index.ts
+++ b/liquidations/surgecredit/index.ts
@@ -23,11 +23,9 @@ const fetch = async (options: FetchOptions) => {
   const live = await options.api.call({ target: VAULT_MANAGER, abi: 'address:auctionHouse' })
   const targets = Array.from(new Set([...AUCTION_HOUSES, live].map((address: string) => address.toLowerCase())))
 
-  const logsPerHouse = await Promise.all(
-    targets.map(target => options.getLogs({ target, eventAbi: AuctionBought }))
-  )
+  const logs = await options.getLogs({ targets, eventAbi: AuctionBought })
 
-  for (const log of logsPerHouse.flat()) {
+  for (const log of logs) {
     // Collateral is native BTC held in the borrower's Taproot vault; on Base it
     // exists only as a satoshi amount, so there is no ERC20 to price against.
     dailyCollateralLiquidated.addCGToken('bitcoin', Number(log.collateralSats) / 1e8)
@@ -38,6 +36,7 @@ const fetch = async (options: FetchOptions) => {
 
 const adapter: SimpleAdapter = {
   version: 2,
+  pullHourly: true,
   adapter: {
     [CHAIN.BASE]: {
       fetch,


### PR DESCRIPTION
Adds a `liquidations/` adapter for **Surge Credit**.

Not a new listing — Surge Credit is already on DefiLlama ([surge-credit](https://defillama.com/protocol/surge-credit), TVL adapter merged in DefiLlama/DefiLlama-Adapters#20190). Per note 2 in the template the listing form is replaced with the details below; identification kept for reference.

##### Name:
Surge Credit (existing listing, slug `surge-credit`)

##### Website / Twitter:
[surge.credit](https://surge.credit) · [@surge_credit](https://x.com/surge_credit)

##### Chain:
Base (8453) — liquidations are settled on Base; the collateral itself is native BTC

##### Category:
Lending

##### Audits:
Reardencode, CredShields

##### Github org/user:
surgecredit

##### Dimension added:
`dailyCollateralLiquidated` — total USD value of native BTC collateral seized from borrowers

##### methodology:
Surge liquidates an unhealthy loan through a Dutch auction rather than an instant seizure:

1. `VaultManager` opens an auction over the loan's BTC collateral → `AuctionHouse.LogAuctionCreated`
2. A liquidator calls `AuctionHouse.buy()` at the current descending price → `LogAuctionBought`
3. The BTC is later delivered to the winner's Bitcoin address → `LogBtcDelivered`

The adapter counts step 2 only, summing `LogAuctionBought.collateralSats`.

Two events were deliberately not used:

- `buy()` emits **both** `LogAuctionBought` and `LogAuctionFinalized` over the same collateral in a single call (`AuctionHouseUpgradeable.sol:359-367`), so counting both would exactly double the figure.
- `LogAuctionCreated` would overcount: an auction can expire or be cancelled with no sale (`LogAuctionCancelled`), and collateral that was never seized would be reported as liquidated.

`LogAuctionBought` is therefore the single point at which collateral actually leaves the borrower.

Collateral is native BTC held in a per-loan non-custodial Taproot vault. On Base it exists only as a satoshi amount with no ERC20 representation, so it is priced via `addCGToken('bitcoin', sats / 1e8)`.

##### Contracts (Base, 8453):

| Contract | Address |
|---|---|
| VaultManager | `0x0D5D12de1cC71060A38F25DD9d24DA1DD6eB705a` |
| AuctionHouse (proxy) | `0xE5Ff1E177dDE3FC33f5457855b14e6bD3B0C6566` |

The AuctionHouse is swappable — `VaultManager` has been repointed at a fresh proxy before on testnet — so the adapter reads the live house from `VaultManager.auctionHouse()` and unions it with the known historical list, keeping backfills correct across a future swap instead of silently returning zero.




