### PR TITLE
[fix] Rialto - restore route-action volume accounting

### DIFF
--- a/aggregators/rialto-aggregator/index.ts
+++ b/aggregators/rialto-aggregator/index.ts
@@ -3,19 +3,16 @@ import { CHAIN } from "../../helpers/chains";
 
 const RIALTO_ROUTER = '0xC94135b63772b91D79d0A2DaAb2a8801f32359bD';
 
-const swapExecutedEvent = 'event SwapExecuted(address indexed sender, address indexed recipient, address indexed sellToken, address buyToken, uint256 sellAmount, uint256 buyAmount, bytes32 quoteId, bytes32 referralCode)';
+const routeActionEvent = 'event RouteActionExecuted(uint256 indexed hopIndex, uint8 kind, address indexed pool, address tokenIn, address tokenOut, uint256 amountIn, uint256 amountOut)';
 const feeChargedEvent = 'event FeeCharged(address indexed token, address indexed recipient, uint256 amount, uint16 bps, bytes32 integratorId)';
 
-/**
- * Returns volume and fees emitted by completed Rialto swaps for the requested period.
- */
 async function fetch(options: FetchOptions) {
   const dailyVolume = options.createBalances();
   const dailyFees = options.createBalances();
 
-  const swapExecutedLogs = await options.getLogs({
+  const routeActionLogs = await options.getLogs({
     target: RIALTO_ROUTER,
-    eventAbi: swapExecutedEvent,
+    eventAbi: routeActionEvent,
   });
 
   const feeChargedLogs = await options.getLogs({
@@ -23,8 +20,8 @@ async function fetch(options: FetchOptions) {
     eventAbi: feeChargedEvent,
   });
 
-  for (const log of swapExecutedLogs) {
-    dailyVolume.add(log.sellToken, log.sellAmount);
+  for (const log of routeActionLogs) {
+    dailyVolume.add(log.tokenIn, log.amountIn);
   }
 
   for (const log of feeChargedLogs) {
@@ -40,7 +37,7 @@ async function fetch(options: FetchOptions) {
 }
 
 const methodology = {
-  Volume: "Input volume emitted once for each completed swap routed through Rialto.",
+  Volume: "Volume of all swaps routed through Rialto router.",
   Fees: "5-10 BPs of platform fees charged on all swaps.",
   Revenue: "5-10 BPs of platform fees charged on all swaps.",
   ProtocolRevenue: "5-10 BPs of platform fees charged on all swaps.",


### PR DESCRIPTION
This reverts #9037 and restores Rialto aggregator volume accounting from `RouteActionExecuted`.

After discussions with members of the Robinhood Chain community, I am reverting #9037 because counting only the top-level user input is not the preferred way to measure routed activity here.

Each route leg is executed independently against underlying liquidity. Restoring `RouteActionExecuted` accounting captures the full volume processed across multi-hop and split routes.

Validation:

- `pnpm run ts-check`
- `git diff --check`
- Historical adapter test against Robinhood Chain
