### PR TITLE
icp: derive revenue from fees instead of a second unrelated counter

### DIFF
--- a/fees/icp.ts
+++ b/fees/icp.ts
@@ -25,13 +25,11 @@ async function fetch(options: FetchOptions) {
 
   const feesInIcp = xdrBurned / xdrPerIcp;
 
-  const revenueInIcp = (Number(current.icp_burned_total) - Number(previous.icp_burned_total)) / 1e8;
-
   const dailyFees = options.createBalances();
   const dailyRevenue = options.createBalances();
 
   dailyFees.addCGToken("internet-computer", feesInIcp, 'Transaction Fees');
-  dailyRevenue.addCGToken("internet-computer", Number(revenueInIcp), 'Token Burn');
+  dailyRevenue.addCGToken("internet-computer", feesInIcp, 'Token Burn');
 
   return {
     dailyFees,
@@ -48,7 +46,7 @@ const adapter: SimpleAdapter = {
   protocolType: ProtocolType.CHAIN,
   methodology: {
     Fees: "Cycles consumed on the network converted to ICP equivalent using the daily average ICP/XDR conversion rate.",
-    Revenue: "ICP tokens burned to mint cycles and for transaction fees.",
+    Revenue: "Same as fees. Consumed cycles are destroyed, and node providers are paid from newly minted ICP rather than out of fees, so no part of the fee is paid to a supply side.",
     HoldersRevenue: "Same as revenue, as burns are deflationary benefiting holders.",
   },
   breakdownMethodology: {
@@ -56,7 +54,7 @@ const adapter: SimpleAdapter = {
       'Transaction Fees': "Cycles consumed on the Internet Computer network, converted to ICP equivalent using the daily average ICP/XDR conversion rate.",
     },
     Revenue: {
-      'Token Burn': "ICP tokens burned to mint cycles and for transaction fees.",
+      'Token Burn': "Cycles consumed are destroyed, so the whole fee is burned.",
     },
   }
 };


### PR DESCRIPTION
Fixes #9044

fees are read from `total_cycle_burn_till_date` (cycles consumed by canisters) and revenue from
`icp_burned_total` (ICP burned, mostly to mint cycles). those are different events at different
points in the cycle lifecycle, cycles minted on one day can sit unspent for months, so neither
number bounds the other, and revenue comes out above fees on **235 of the 1,207 days** both series
exist (19.5%), $3,376,381 all time and $1,540,037 across 49 days in the last year. worst day is
2025-08-28 at 80x.

`GUIDELINES.md` has `Revenue = Fees - SupplySideRevenue`, so this also shows up as a missing supply
side rather than a negative one, because the derived `fees - revenue` is clamped at zero.

## which counter to keep

consumed cycles are destroyed, and node providers are compensated with newly minted ICP rather than
out of fees, so no part of an ICP fee is paid to a supply side. that makes it a burn-only chain in
the same shape as an EIP-1559 base fee: revenue is the whole fee, supply side is zero, and the burn
is deflationary so holders revenue is the same number again.

so this keeps the cycle counter, which is what users actually paid for service in the period, and
derives revenue from it. **the fees series is unchanged**: only revenue and holders revenue move,
and only onto the fee they came from.

the alternative would be to make `icp_burned_total` the source for both fees and revenue. i did not
pick that one because it is cash basis rather than accrual: fees would spike on days when someone
prepays for a large block of cycles instead of on the days the compute was used, and it would
rewrite the headline fees series. happy to switch if you would rather have that.

## harness, before and after

```
                          master                    this branch
2026-08-27   fees 5.46k   revenue 9.33k  (1.71x)    fees 5.46k   revenue 5.46k
2026-08-26   fees 5.17k   revenue 2.45k             fees 5.17k   revenue 5.17k
```

08-27 is one of the 235 violating days and 08-26 is a normal one; fees are identical in both
directions.

```
FEES BREAKDOWN
label            | Daily fees | Daily revenue | Daily holders revenue
Transaction Fees | 5459       |               |
Token Burn       |            | 5459          | 5459
```

the `Token Burn` breakdown label is kept so the revenue breakdown still reads as the burn it is.
