### PR TITLE
Virtual Protocol: add Solana to the volume and fees adapters

### DIFF
--- a/dexs/virtual-protocol.ts
+++ b/dexs/virtual-protocol.ts
@@ -25,7 +25,7 @@ const fetch = async (options: FetchOptions) => {
 }
 
 const methodology = {
-  Volume: "Bonding-curve trading volume on Virtual Protocol's own venue, reconstructed on-chain (no private tables). Bonding pairs are collected from the bonding-factory events (PreLaunched/Launched for the current factory generation, PairCreated for the legacy Base FFactories); volume is the VIRTUAL leg of each FPair Swap, priced to USD. Post-graduation trades are excluded as they occur on third-party DEXs already counted elsewhere. Covers Base (legacy + current factories) and Robinhood. On Solana the venue is Virtual Protocol's Meteora Dynamic Bonding Curve: pools come from the DBC configs quoted in VIRTUAL and volume is the VIRTUAL leg of each DBC swap, with post-graduation trading (Meteora DAMM v2) and pre-DBC activity excluded.",
+  Volume: "Bonding-curve trading volume on Virtual Protocol's own venue, reconstructed on-chain (no private tables). Bonding pairs are collected from the bonding-factory events (PreLaunched/Launched for the current factory generation, PairCreated for the legacy Base FFactories); volume is the VIRTUAL leg of each FPair Swap, priced to USD. Post-graduation trades are excluded as they occur on third-party DEXs already counted elsewhere. Covers Base (legacy + current factories) and Robinhood. On Solana both bonding venues are counted: Virtual Protocol's own program from 2025-02, whose pools are found from the tax paid in each swap because that program is not decoded, and its Meteora Dynamic Bonding Curve from 2026-08-21, whose pools come from the VIRTUAL-quoted DBC configs.",
 }
 
 const adapter: SimpleAdapter = {
@@ -34,7 +34,7 @@ const adapter: SimpleAdapter = {
   adapter: {
     [CHAIN.BASE]: { start: "2024-10-15", },
     [CHAIN.ROBINHOOD]: { start: "2026-07-02", },
-    [CHAIN.SOLANA]: { start: "2026-08-21", },
+    [CHAIN.SOLANA]: { start: "2025-02-11", },
   },
   prefetch,
   dependencies: [Dependencies.DUNE],

--- a/dexs/virtual-protocol.ts
+++ b/dexs/virtual-protocol.ts
@@ -25,7 +25,7 @@ const fetch = async (options: FetchOptions) => {
 }
 
 const methodology = {
-  Volume: "Bonding-curve trading volume on Virtual Protocol's own venue, reconstructed on-chain (no private tables). Bonding pairs are collected from the bonding-factory events (PreLaunched/Launched for the current factory generation, PairCreated for the legacy Base FFactories); volume is the VIRTUAL leg of each FPair Swap, priced to USD. Post-graduation trades are excluded as they occur on third-party DEXs already counted elsewhere. Covers Base (legacy + current factories) and Robinhood.",
+  Volume: "Bonding-curve trading volume on Virtual Protocol's own venue, reconstructed on-chain (no private tables). Bonding pairs are collected from the bonding-factory events (PreLaunched/Launched for the current factory generation, PairCreated for the legacy Base FFactories); volume is the VIRTUAL leg of each FPair Swap, priced to USD. Post-graduation trades are excluded as they occur on third-party DEXs already counted elsewhere. Covers Base (legacy + current factories) and Robinhood. On Solana the venue is Virtual Protocol's Meteora Dynamic Bonding Curve: pools come from the DBC configs quoted in VIRTUAL and volume is the VIRTUAL leg of each DBC swap, with post-graduation trading (Meteora DAMM v2) and pre-DBC activity excluded.",
 }
 
 const adapter: SimpleAdapter = {
@@ -34,6 +34,7 @@ const adapter: SimpleAdapter = {
   adapter: {
     [CHAIN.BASE]: { start: "2024-10-15", },
     [CHAIN.ROBINHOOD]: { start: "2026-07-02", },
+    [CHAIN.SOLANA]: { start: "2026-08-21", },
   },
   prefetch,
   dependencies: [Dependencies.DUNE],

--- a/fees/virtual-protocol.ts
+++ b/fees/virtual-protocol.ts
@@ -28,7 +28,7 @@ const fetch = async (options: FetchOptions) => {
 }
 
 const methodology = {
-  Fees: 'Revenue from Virtual Protocol across several streams: 1) Base Virtual-fun (legacy buy/sell transactions), 2) Base Virtual-app (legacy non-trading), 3) Base CBBTC-prototype (direct transfers to prototype wallet), 4) Base CBBTC-sentient (outflows from tax manager representing agent treasury distributions), 5) the new 1% platform fee collected in USD stablecoins (USDC on Base, USDG on Robinhood) to the platform tax wallet. Also includes Ethereum VIRTUAL transfers to the protocol dev/ecosystem wallet. Individual ecosystem and treasury transfers are replaced by the tax manager outflow method to avoid double counting.',
+  Fees: 'Revenue from Virtual Protocol across several streams: 1) Base Virtual-fun (legacy buy/sell transactions), 2) Base Virtual-app (legacy non-trading), 3) Base CBBTC-prototype (direct transfers to prototype wallet), 4) Base CBBTC-sentient (outflows from tax manager representing agent treasury distributions), 5) the new 1% platform fee collected in USD stablecoins (USDC on Base, USDG on Robinhood) to the platform tax wallet, and 6) Solana, in two parts: the pre-DBC bonding tax collected as VIRTUAL from 2025-02, and from 2026-08-21 the trading tax distributed in JupUSD, the Solana analogue of the USDC and USDG legs and likewise covering bonding and post-graduation trading alike. Also includes Ethereum VIRTUAL transfers to the protocol dev/ecosystem wallet. Individual ecosystem and treasury transfers are replaced by the tax manager outflow method to avoid double counting.',
   Revenue: 'Fees collected by the Protocol.',
   ProtocolRevenue: 'Revenue from all sources to the Protocol.',
 }
@@ -40,6 +40,7 @@ const adapter: SimpleAdapter = {
     [CHAIN.BASE]: { start: "2024-10-15", },
     [CHAIN.ETHEREUM]: { start: "2025-06-11", },
     [CHAIN.ROBINHOOD]: { start: "2026-07-02", },
+    [CHAIN.SOLANA]: { start: "2025-02-11", },
   },
   prefetch,
   dependencies: [Dependencies.DUNE],

--- a/helpers/queries/virtual-protocol-volume.sql
+++ b/helpers/queries/virtual-protocol-volume.sql
@@ -19,9 +19,7 @@
 -- Solana's venue is Virtual Protocol's Meteora Dynamic Bonding Curve. A fresh DBC config is
 -- created per agent launch, each quoted in VIRTUAL, so the config is the Solana equivalent of a
 -- factory: evtCreateConfig/V2 where quote_mint = VIRTUAL -> evtSwap on those configs. Volume is
--- the VIRTUAL leg, 9 decimals, taken gross to match what dex_solana.trades reports. Scoping on
--- quote_mint rather than fee_claimer survives an operator key rotation; if a third party ever
--- launches a VIRTUAL-quoted DBC pool, add fee_claimer = 'AamUJY5hvSPCcpw2e6mzCuMsxrdQKVnN8iFeYKSZNFcf'.
+-- the VIRTUAL leg, 9 decimals, taken gross to match what dex_solana.trades reports.
 -- Post-graduation trading (Meteora DAMM v2) is excluded as on EVM, as is pre-DBC activity.
 WITH
     base_pairs AS (
@@ -86,16 +84,24 @@ WITH
     ),
 
     sol_configs AS (
+        -- DBC is permissionless, so quote_mint alone is not an ownership boundary: a second
+        -- party has already created VIRTUAL-quoted configs (GrnTP8qz…, 4 configs on 2026-08-18,
+        -- no shared signer, no pools launched). fee_claimer is the partner authority fixed at
+        -- config creation; Virtual Protocol has used one throughout (111 configs, 2026-08-21
+        -- onward). If it is ever rotated this undercounts loudly rather than overcounting
+        -- silently, which is the safer way round.
         SELECT config
         FROM meteora_solana.dynamic_bonding_curve_evt_evtcreateconfig
-        WHERE quote_mint = '3iQL8BFS2vE7mww4ehAqQHAsbmRNCrPxizWAT2Zfyr9y'
+        WHERE quote_mint  = '3iQL8BFS2vE7mww4ehAqQHAsbmRNCrPxizWAT2Zfyr9y'
+        AND   fee_claimer = 'AamUJY5hvSPCcpw2e6mzCuMsxrdQKVnN8iFeYKSZNFcf'
 
         -- UNION, not UNION ALL: every config is emitted into both tables, so ALL doubles it
         UNION
 
         SELECT config
         FROM meteora_solana.dynamic_bonding_curve_evt_evtcreateconfigv2
-        WHERE quote_mint = '3iQL8BFS2vE7mww4ehAqQHAsbmRNCrPxizWAT2Zfyr9y'
+        WHERE quote_mint  = '3iQL8BFS2vE7mww4ehAqQHAsbmRNCrPxizWAT2Zfyr9y'
+        AND   fee_claimer = 'AamUJY5hvSPCcpw2e6mzCuMsxrdQKVnN8iFeYKSZNFcf'
     ),
     sol_bonding AS (
         SELECT COALESCE(SUM(

--- a/helpers/queries/virtual-protocol-volume.sql
+++ b/helpers/queries/virtual-protocol-volume.sql
@@ -105,10 +105,11 @@ WITH
     ),
     sol_bonding AS (
         SELECT COALESCE(SUM(
-            -- buy = VIRTUAL in, sell = VIRTUAL out. amount_in, NOT actual_input_amount:
-            -- the latter is net of the fee taken off the quote side before the curve.
+            -- Both legs net of the quote-side fee, so they mean the same thing and match the EVM
+            -- arms (which read what reached the pool after the tax). actual_input_amount, NOT
+            -- amount_in: at the 99% launch cliff amount_in is mostly fee (13.8% of 2026-08-24).
             CASE WHEN s.trade_direction = 1
-                 THEN cast(s.amount_in as double)
+                 THEN cast(json_extract_scalar(s.swap_result, '$.SwapResult.actual_input_amount') as double)
                  ELSE cast(json_extract_scalar(s.swap_result, '$.SwapResult.output_amount') as double)
             END
         ) / 1e9, 0) as virtual_volume
@@ -120,9 +121,55 @@ WITH
         AND cast(s.evt_block_time as timestamp) >= from_unixtime({{startTimestamp}})
         AND cast(s.evt_block_time as timestamp) < from_unixtime({{endTimestamp}})
     )
+    ,
+    -- Solana's first bonding venue, before DBC: Virtual Protocol's own program, live 2025-02 to
+    -- 2026-08-21. Dune does not decode it, so there are no swap events to read -- as with
+    -- Robinhood's FPair bonding, which is why that arm reads raw logs. Pools are instead found
+    -- from the tax: every swap paid ~1% to the collector in the same tx and the payer is always
+    -- the user, never the pool (27,618/27,618 in 2025-02), so the pool is the side of the
+    -- VIRTUAL leg that is not the taxer, and anything that ever pays tax is a router or user.
+    sol_prebond_tax AS (
+        SELECT tx_id, max(from_owner) as taxer
+        FROM tokens_solana.transfers
+        WHERE token_mint_address = '3iQL8BFS2vE7mww4ehAqQHAsbmRNCrPxizWAT2Zfyr9y'
+        AND to_owner = '933jV351WDG23QTcHPqLFJxyYRrEPWRTR3qoPWi3jwEL'
+        -- block_date is the partition column; bound it as well as the timestamp
+        AND block_date >= cast(from_unixtime({{startTimestamp}}) as date)
+        AND block_date <= cast(from_unixtime({{endTimestamp}}) as date)
+        AND block_time >= from_unixtime({{startTimestamp}})
+        AND block_time <  from_unixtime({{endTimestamp}})
+        GROUP BY 1
+    ),
+    sol_prebond_swaps AS (
+        SELECT t.tx_id, t.amount_display as amt,
+            CASE WHEN t.from_owner = x.taxer THEN t.to_owner ELSE t.from_owner END as pool
+        FROM tokens_solana.transfers t
+        JOIN sol_prebond_tax x ON x.tx_id = t.tx_id
+        WHERE t.token_mint_address = '3iQL8BFS2vE7mww4ehAqQHAsbmRNCrPxizWAT2Zfyr9y'
+        -- block_date only (partition pruning); the tx set is already time-bounded
+        AND t.block_date >= cast(from_unixtime({{startTimestamp}}) as date)
+        AND t.block_date <= cast(from_unixtime({{endTimestamp}}) as date)
+        AND t.to_owner   <> '933jV351WDG23QTcHPqLFJxyYRrEPWRTR3qoPWi3jwEL'
+        AND t.from_owner <> '933jV351WDG23QTcHPqLFJxyYRrEPWRTR3qoPWi3jwEL'
+        AND (t.from_owner = x.taxer OR t.to_owner = x.taxer)
+    ),
+    sol_prebond AS (
+        SELECT COALESCE(SUM(amt), 0) as virtual_volume
+        FROM (
+            SELECT s.amt, row_number() over (partition by s.tx_id order by s.amt desc) as rn
+            FROM sol_prebond_swaps s
+            LEFT JOIN (SELECT DISTINCT taxer FROM sol_prebond_tax) tx ON tx.taxer = s.pool
+            WHERE tx.taxer IS NULL
+            -- graduation moves a pool's whole balance out in one transfer; not a sell
+            AND s.pool <> '67zLsVD39roVXCtoqs9W1Fzh9Bnz6iCwmF7sY1GEvic6'
+            AND s.amt > 0
+        ) d
+        WHERE rn = 1
+    )
 
 SELECT 'base' as chain, (SELECT virtual_volume FROM base_bonding) as virtual_volume
 UNION ALL
 SELECT 'robinhood' as chain, (SELECT virtual_volume FROM rh_bonding) as virtual_volume
 UNION ALL
-SELECT 'solana' as chain, (SELECT virtual_volume FROM sol_bonding) as virtual_volume
+SELECT 'solana' as chain,
+       (SELECT virtual_volume FROM sol_prebond) + (SELECT virtual_volume FROM sol_bonding) as virtual_volume

--- a/helpers/queries/virtual-protocol-volume.sql
+++ b/helpers/queries/virtual-protocol-volume.sql
@@ -16,11 +16,14 @@
 -- VIRTUAL leg is data words 3 + 4 (amount1In + amount1Out; verified against on-chain VIRTUAL
 -- transfers). VIRTUAL amounts are returned in token units and priced to USD by the adapter.
 --
--- Solana's venue is Virtual Protocol's Meteora Dynamic Bonding Curve. A fresh DBC config is
--- created per agent launch, each quoted in VIRTUAL, so the config is the Solana equivalent of a
--- factory: evtCreateConfig/V2 where quote_mint = VIRTUAL -> evtSwap on those configs. Volume is
--- the VIRTUAL leg, 9 decimals, taken gross to match what dex_solana.trades reports.
--- Post-graduation trading (Meteora DAMM v2) is excluded as on EVM, as is pre-DBC activity.
+-- Solana has had two Virtual Protocol venues and both are counted. From 2026-08-21 it is their
+-- Meteora Dynamic Bonding Curve: a fresh config per agent launch, each quoted in VIRTUAL, so the
+-- config is the Solana equivalent of a factory -- evtCreateConfig/V2 scoped by quote_mint AND
+-- fee_claimer -> evtSwap on those configs. Before that, from 2025-02, it was Virtual Protocol's
+-- own bonding program, which Dune does not decode; its pools are recovered from the tax paid in
+-- each swap (see sol_prebond). Volume is the VIRTUAL leg, 9 decimals, net of the quote-side fee
+-- on both legs to match the EVM arms.
+-- Post-graduation trading (Meteora DAMM v2) is excluded as on EVM.
 WITH
     base_pairs AS (
         -- Current factory (0x1A5400...): PreLaunched/Launched, pair = topic2

--- a/helpers/queries/virtual-protocol-volume.sql
+++ b/helpers/queries/virtual-protocol-volume.sql
@@ -15,6 +15,14 @@
 -- Volume = FPair Swap logs (topic0 0x298c349c) on those pairs. token1 = VIRTUAL, so the
 -- VIRTUAL leg is data words 3 + 4 (amount1In + amount1Out; verified against on-chain VIRTUAL
 -- transfers). VIRTUAL amounts are returned in token units and priced to USD by the adapter.
+--
+-- Solana's venue is Virtual Protocol's Meteora Dynamic Bonding Curve. A fresh DBC config is
+-- created per agent launch, each quoted in VIRTUAL, so the config is the Solana equivalent of a
+-- factory: evtCreateConfig/V2 where quote_mint = VIRTUAL -> evtSwap on those configs. Volume is
+-- the VIRTUAL leg, 9 decimals, taken gross to match what dex_solana.trades reports. Scoping on
+-- quote_mint rather than fee_claimer survives an operator key rotation; if a third party ever
+-- launches a VIRTUAL-quoted DBC pool, add fee_claimer = 'AamUJY5hvSPCcpw2e6mzCuMsxrdQKVnN8iFeYKSZNFcf'.
+-- Post-graduation trading (Meteora DAMM v2) is excluded as on EVM, as is pre-DBC activity.
 WITH
     base_pairs AS (
         -- Current factory (0x1A5400...): PreLaunched/Launched, pair = topic2
@@ -61,8 +69,9 @@ WITH
         FROM base.logs l
         JOIN base_pairs p ON l.contract_address = p.pair
         WHERE l.topic0 = 0x298c349c742327269dc8de6ad66687767310c948ea309df826f5bd103e19d207
+        -- half-open [start, end) so a boundary-instant swap is not counted in two days
         AND l.block_time >= from_unixtime({{startTimestamp}})
-        AND l.block_time <= from_unixtime({{endTimestamp}})
+        AND l.block_time < from_unixtime({{endTimestamp}})
     ),
     rh_bonding AS (
         SELECT COALESCE(SUM(
@@ -73,9 +82,41 @@ WITH
         JOIN rh_pairs p ON l.contract_address = p.pair
         WHERE l.topic0 = 0x298c349c742327269dc8de6ad66687767310c948ea309df826f5bd103e19d207
         AND l.block_time >= from_unixtime({{startTimestamp}})
-        AND l.block_time <= from_unixtime({{endTimestamp}})
+        AND l.block_time < from_unixtime({{endTimestamp}})
+    ),
+
+    sol_configs AS (
+        SELECT config
+        FROM meteora_solana.dynamic_bonding_curve_evt_evtcreateconfig
+        WHERE quote_mint = '3iQL8BFS2vE7mww4ehAqQHAsbmRNCrPxizWAT2Zfyr9y'
+
+        -- UNION, not UNION ALL: every config is emitted into both tables, so ALL doubles it
+        UNION
+
+        SELECT config
+        FROM meteora_solana.dynamic_bonding_curve_evt_evtcreateconfigv2
+        WHERE quote_mint = '3iQL8BFS2vE7mww4ehAqQHAsbmRNCrPxizWAT2Zfyr9y'
+    ),
+    sol_bonding AS (
+        SELECT COALESCE(SUM(
+            -- buy = VIRTUAL in, sell = VIRTUAL out. amount_in, NOT actual_input_amount:
+            -- the latter is net of the fee taken off the quote side before the curve.
+            CASE WHEN s.trade_direction = 1
+                 THEN cast(s.amount_in as double)
+                 ELSE cast(json_extract_scalar(s.swap_result, '$.SwapResult.output_amount') as double)
+            END
+        ) / 1e9, 0) as virtual_volume
+        FROM meteora_solana.dynamic_bonding_curve_evt_evtswap s
+        JOIN sol_configs c ON s.config = c.config
+        -- evt_block_date is the partition column; bound it as well as the timestamp
+        WHERE s.evt_block_date >= cast(from_unixtime({{startTimestamp}}) as date)
+        AND s.evt_block_date <= cast(from_unixtime({{endTimestamp}}) as date)
+        AND cast(s.evt_block_time as timestamp) >= from_unixtime({{startTimestamp}})
+        AND cast(s.evt_block_time as timestamp) < from_unixtime({{endTimestamp}})
     )
 
 SELECT 'base' as chain, (SELECT virtual_volume FROM base_bonding) as virtual_volume
 UNION ALL
 SELECT 'robinhood' as chain, (SELECT virtual_volume FROM rh_bonding) as virtual_volume
+UNION ALL
+SELECT 'solana' as chain, (SELECT virtual_volume FROM sol_bonding) as virtual_volume

--- a/helpers/queries/virtual-protocol.sql
+++ b/helpers/queries/virtual-protocol.sql
@@ -121,63 +121,42 @@ WITH
         AND contract_address = 0x5fc5360d0400a0fd4f2af552add042d716f1d168
         AND evt_block_time >= from_unixtime({{startTimestamp}})
         AND evt_block_time <= from_unixtime({{endTimestamp}})
+    ),
+
+    -- Solana pre-DBC era: Virtual Protocol ran its own bonding program until 2026-08-21 and
+    -- collected the tax as VIRTUAL into one wallet. Same shape as the tax-manager arms above.
+    sol_prototype_fees AS (
+        SELECT COALESCE(SUM(amount_display), 0) as amt
+        FROM tokens_solana.transfers
+        WHERE token_mint_address = '3iQL8BFS2vE7mww4ehAqQHAsbmRNCrPxizWAT2Zfyr9y'
+        AND to_owner = '933jV351WDG23QTcHPqLFJxyYRrEPWRTR3qoPWi3jwEL'
+        -- block_date is the partition column; bound it as well as the timestamp
+        AND block_date >= cast(from_unixtime({{startTimestamp}}) as date)
+        AND block_date <= cast(from_unixtime({{endTimestamp}}) as date)
+        AND block_time >= from_unixtime({{startTimestamp}})
+        AND block_time <  from_unixtime({{endTimestamp}})
+    ),
+
+    -- Solana from 2026-08-21: the tax is distributed by an operator wallet and settles in
+    -- JupUSD -- the Solana analogue of USDC on Base and USDG on Robinhood, so this is measured
+    -- the same realized, wallet-scoped way and likewise spans bonding AND post-graduation trading.
+    -- Only the JupUSD leg is revenue; the wallet's VIRTUAL/USDC/USDT/wSOL flows are the swap and
+    -- conversion plumbing it uses to settle, and would double count.
+    -- Note this is why the DBC per-swap fee is NOT also counted: the bonding fee is claimed, sold
+    -- and paid out through this same wallet, so accruing it at the swap would count it twice. The
+    -- launch anti-sniper surcharge never reaches here -- it is swept to a custody wallet and spent
+    -- buying the agent token for its creator -- so this leg is already net of it.
+    sol_graduated_fees AS (
+        SELECT COALESCE(SUM(amount_display), 0) as amt
+        FROM tokens_solana.transfers
+        WHERE token_mint_address = 'JuprjznTrTSp2UFa3ZBUFgwdAmtZCq4MQCwysN55USD'
+        AND from_owner = 'Bo2jk8vNANP3cEgsEWCszvzy9mPR8CPqQKenUkNbyBHm'
+        -- block_date is the partition column; bound it as well as the timestamp
+        AND block_date >= cast(from_unixtime({{startTimestamp}}) as date)
+        AND block_date <= cast(from_unixtime({{endTimestamp}}) as date)
+        AND block_time >= from_unixtime({{startTimestamp}})
+        AND block_time <  from_unixtime({{endTimestamp}})
     )
-
-    -- -- Solana contracts for agent tokens
-    -- sol_contracts AS (
-    --     SELECT DISTINCT token_mint_address
-    --     FROM (
-    --         SELECT token_mint_address
-    --         FROM tokens_solana.transfers
-    --         WHERE tx_id IN (
-    --             SELECT tx_id
-    --             FROM tokens_solana.transfers
-    --             WHERE to_owner = '933jV351WDG23QTcHPqLFJxyYRrEPWRTR3qoPWi3jwEL'
-    --             AND token_mint_address = '3iQL8BFS2vE7mww4ehAqQHAsbmRNCrPxizWAT2Zfyr9y'
-    --             AND block_time >= timestamp '2024-08-30'
-    --             AND block_time <= from_unixtime({{endTimestamp}})
-    --         )
-    --         AND block_time >= timestamp '2024-08-30'
-    --         AND block_time <= from_unixtime({{endTimestamp}})
-    --         AND token_mint_address NOT IN ('3iQL8BFS2vE7mww4ehAqQHAsbmRNCrPxizWAT2Zfyr9y', 'So11111111111111111111111111111111111111112')
-    --         AND token_mint_address LIKE '%virt%'
-    --     ) agent_tokens
-    -- ),
-
-    -- -- Solana trading volume for sentient revenue
-    -- sol_volume AS (
-    --     SELECT
-    --         COALESCE(SUM(
-    --             CASE
-    --                 WHEN token_bought_mint_address = '3iQL8BFS2vE7mww4ehAqQHAsbmRNCrPxizWAT2Zfyr9y' THEN token_bought_amount
-    --                 ELSE token_sold_amount
-    --             END
-    --         ), 0) as base_token_amount
-    --     FROM dex_solana.trades
-    --     WHERE (
-    --         (
-    --             token_bought_mint_address IN (SELECT token_mint_address FROM sol_contracts)
-    --             AND token_sold_mint_address = '3iQL8BFS2vE7mww4ehAqQHAsbmRNCrPxizWAT2Zfyr9y'
-    --         )
-    --         OR (
-    --             token_sold_mint_address IN (SELECT token_mint_address FROM sol_contracts)
-    --             AND token_bought_mint_address = '3iQL8BFS2vE7mww4ehAqQHAsbmRNCrPxizWAT2Zfyr9y'
-    --         )
-    --     )
-    --     AND block_time >= from_unixtime({{startTimestamp}})
-    --     AND block_time <= from_unixtime({{endTimestamp}})
-    -- ),
-
-    -- -- Solana prototype fees (starts from 2024-08-30)
-    -- sol_prototype_fees AS (
-    --     SELECT
-    --         COALESCE(SUM(amount) / power(10, 9), 0) as amt
-    --     FROM tokens_solana.transfers
-    --     WHERE token_mint_address = '3iQL8BFS2vE7mww4ehAqQHAsbmRNCrPxizWAT2Zfyr9y'
-    --     AND block_time >= GREATEST(from_unixtime({{startTimestamp}}), TIMESTAMP '2024-08-30')
-    --     AND block_time <= from_unixtime({{endTimestamp}})
-    --     AND to_owner = '933jV351WDG23QTcHPqLFJxyYRrEPWRTR3qoPWi3jwEL'
-    -- )
 
 -- Final output following original query structure exactly
 SELECT
@@ -224,15 +203,14 @@ FROM (
         COALESCE(rru.amt, 0) as usd_fees
     FROM robinhood_rev_usdg rru
 
-    -- UNION ALL
+    UNION ALL
 
-    -- -- Solana revenues (from sol_trading_rev)
-    -- -- Sol prototype fees
-    -- -- Sol sentient (1% of trading volume)
-    -- SELECT
-    --     'solana' as chain,
-    --     ( COALESCE(spf.amt, 0) + COALESCE(sv.base_token_amount * 0.01, 0) ) as virtual_fees,
-    --     0 as cbbtc_fees
-    -- FROM sol_prototype_fees spf
-    -- CROSS JOIN sol_volume sv
+    -- Solana revenues: bonding-curve trading fee accrued to Virtual Protocol, in VIRTUAL
+    SELECT
+        'solana' as chain,
+        COALESCE(spf.amt, 0) as virtual_fees,   -- pre-DBC bonding tax, in VIRTUAL, from 2025-02
+        0 as cbbtc_fees,
+        COALESCE(sgf.amt, 0) as usd_fees        -- JupUSD distribution, from 2026-08-21
+    FROM sol_prototype_fees spf
+    CROSS JOIN sol_graduated_fees sgf
 ) AS combined_revenues


### PR DESCRIPTION
## Summary

Adds **Solana** to both **Virtual Protocol** adapters, per review — fees covered, volume pre-graduation only. Solana has had two bonding venues, both Virtual Protocol's own. Self-contained, no private tables, as in #8132.

| venue | period |
|---|---|
| Virtual Protocol's own program | 2025-02 → 2026-08-21 |
| Meteora Dynamic Bonding Curve | 2026-08-21 → |

### Fees — `fees/virtual-protocol.ts`, `helpers/queries/virtual-protocol.sql`

Measured **at the wallet**, like the Base and Robinhood arms, so it spans bonding **and post-graduation** trading alike:

| leg | asset | wallet | from |
|---|---|---|---|
| pre-DBC bonding tax | VIRTUAL | `933jV351…` | 2025-02 |
| trading tax distribution | JupUSD | `Bo2jk8…` | 2026-08-21 |

- Only the JupUSD leg is revenue — that wallet's VIRTUAL/USDC/USDT/wSOL flows are the plumbing it settles through.
- The **DBC per-swap fee is not also counted**: the bonding fee is claimed, sold and paid out through that same wallet, so accruing it at the swap would count it twice.
- The **launch anti-sniper surcharge is excluded** — it never reaches these wallets, being swept to a custody wallet and spent buying the agent token for its creator. Same treatment as Base.
- Replaces the commented-out Solana block, which estimated fees as 1% × volume and found agents by matching `%virt%` in the mint address. Its one sound part, the prototype-fee collector, is restored as live code.
- Base, Ethereum and Robinhood unchanged — verified by running the committed version and this one over the same window.

### Volume — `dexs/virtual-protocol.ts`, `helpers/queries/virtual-protocol-volume.sql`

**Pre-graduation only**, matching Base and Robinhood.

| venue | how pools are found | scale |
|---|---|---|
| Meteora DBC | `evtCreateConfig` / `evtCreateConfigV2` where `quote_mint` is VIRTUAL **and** `fee_claimer` is Virtual Protocol's | 111 configs |
| Own program | not decoded by Dune, so no swap events exist — pools come from the tax instead: the payer is always the user, never the pool (27,618/27,618 in 2025-02), so the pool is whichever side of the VIRTUAL leg is not the taxer | 10,268,966 VIRTUAL / 31,356 swaps |

- `fee_claimer` is required, not optional: DBC is permissionless and a third party has already created VIRTUAL-quoted configs, so `quote_mint` alone is not an ownership boundary.
- Volume is the VIRTUAL leg **net of the quote-side fee** on both sides. This corrects the Solana branch as first pushed, which took buys gross: launches open at a 99% anti-sniper fee decaying to 1%, so `amount_in` on a launch-day buy is mostly fee rather than traded notional (13.8% of 2026-08-24). Net also matches the EVM arms, which read what reached the pool after the tax was skimmed ahead of it.
- **Excluded:** post-graduation trading (Meteora DAMM v2 / Dynamic AMM — already counted on DefiLlama) and graduation migration (moves a pool's whole balance out in one transfer; not a sell).
- Also: `base_bonding` and `rh_bonding` used `<= endTimestamp`, so a boundary-instant swap fell in two consecutive days; all branches now use `<`. No published number moves — 0 boundary swaps in 851,352, Base/Robinhood byte-identical before and after. Happy to split this out.

### Test
```
$ pnpm test dexs virtual-protocol       # bonding-curve volume
base      | 69.93 k   | 15/10/2024
robinhood | 151.91 k  | 2/7/2026
solana    | 15.87 k   | 11/2/2025

$ pnpm test fees virtual-protocol
base      | 10.16 k   | 15/10/2024
ethereum  | 0.00      | 11/6/2025
robinhood | 11.72 k   | 2/7/2026
solana    | 1.47 k    | 11/2/2025
```
> Note: as in #8132, the `test` CI job fails with `DUNE_API_KEYS ... not set` — Dune secrets aren't exposed to CI here, so this is expected for any Dune-based adapter (`ts-check` passes). Verified locally with a Dune key (output above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
