### PR TITLE
[add] STONX - token incentives

### DIFF
--- a/dexs/stonx.ts
+++ b/dexs/stonx.ts
@@ -3,6 +3,7 @@ import { Adapter, FetchOptions } from "../adapters/types";
 import ADDRESSES from "../helpers/coreAssets.json";
 import { CHAIN } from "../helpers/chains";
 import { METRIC } from "../helpers/metrics";
+import { getStonxEmissions, STONX, STONX_LP_INCENTIVES } from "../helpers/stonxEmissions";
 import { httpGet } from "../utils/fetchURL";
 
 const API = "https://prod-api.ekubo.org";
@@ -88,7 +89,9 @@ async function getVe33Pools(): Promise<Ve33Pool[]> {
 const fetch = async (options: FetchOptions) => {
   const dailyVolume = options.createBalances();
   const dailyFees = options.createBalances();
+  const dailyRevenue = options.createBalances();
   const dailyHoldersRevenue = options.createBalances();
+  const dailySupplySideRevenue = options.createBalances();
   const pools = await getVe33Pools();
 
   const { results, errors } = await PromisePool.withConcurrency(API_CONCURRENCY)
@@ -108,18 +111,23 @@ const fetch = async (options: FetchOptions) => {
         const address = tokenIdToAddress(token);
         dailyVolume.add(address, volume);
         dailyFees.add(address, fees, METRIC.SWAP_FEES);
+        dailyRevenue.add(address, ve33_fees, VOTER_FEES);
         dailyHoldersRevenue.add(address, ve33_fees, VOTER_FEES);
       });
   });
+
+  const emitted = await getStonxEmissions(options);
+  dailySupplySideRevenue.add(STONX, emitted, STONX_LP_INCENTIVES);
+  dailyRevenue.add(STONX, -emitted, STONX_LP_INCENTIVES);
 
   return {
     dailyVolume,
     dailyFees,
     dailyUserFees: dailyFees,
-    dailyRevenue: dailyHoldersRevenue,
+    dailyRevenue,
     dailyHoldersRevenue,
     dailyProtocolRevenue: 0,
-    dailySupplySideRevenue: 0,
+    dailySupplySideRevenue,
   };
 };
 
@@ -128,12 +136,12 @@ const methodology = {
     "Input-token volume from swaps across every Ekubo Core pool configured with the deployed STONX Ve33 extension on Robinhood Chain. Only the input side of each swap is counted.",
   Fees: "Swap fees paid by traders across all STONX Ve33 pools.",
   Revenue:
-    "All STONX Ve33 swap fees are routed to veSTONX voters. The protocol treasury takes no share.",
+    "Gross profit is swap fees routed to veSTONX voters minus STONX emissions paid to liquidity providers. It can be negative when emissions exceed fees.",
   HoldersRevenue:
     "All swap fees are allocated to veSTONX voters in proportion to the voting power assigned to each pool.",
   ProtocolRevenue: "Zero. The protocol treasury takes no share of STONX Ve33 swap fees.",
   SupplySideRevenue:
-    "Zero from swap fees. Liquidity-provider compensation is paid through STONX emissions and reported separately as token incentives.",
+    "STONX emissions paid to Ve33 liquidity providers are treated as Cost of Revenue and reported separately as token incentives.",
 };
 
 const breakdownMethodology = {
@@ -145,6 +153,10 @@ const breakdownMethodology = {
   },
   Revenue: {
     [VOTER_FEES]: "All swap fees routed to veSTONX voters.",
+    [STONX_LP_INCENTIVES]: "STONX liquidity-provider emissions deducted from gross profit.",
+  },
+  SupplySideRevenue: {
+    [STONX_LP_INCENTIVES]: "STONX emissions paid to Ve33 liquidity providers.",
   },
   HoldersRevenue: {
     [VOTER_FEES]: "All swap fees routed to veSTONX voters.",
@@ -157,6 +169,7 @@ const adapter: Adapter = {
   chains: [CHAIN.ROBINHOOD],
   start: "2026-07-30",
   doublecounted: true, // These swaps are already included in the broader Ekubo adapter.
+  allowNegativeValue: true, // LP emissions can exceed swap fees, making gross profit negative.
   methodology,
   breakdownMethodology,
 };

--- a/dexs/stonx.ts
+++ b/dexs/stonx.ts
@@ -133,7 +133,7 @@ const methodology = {
     "All swap fees are allocated to veSTONX voters in proportion to the voting power assigned to each pool.",
   ProtocolRevenue: "Zero. The protocol treasury takes no share of STONX Ve33 swap fees.",
   SupplySideRevenue:
-    "Zero. Liquidity providers receive STONX emissions rather than a share of swap fees.",
+    "Zero from swap fees. Liquidity-provider compensation is paid through STONX emissions and reported separately as token incentives.",
 };
 
 const breakdownMethodology = {

--- a/helpers/stonxEmissions.ts
+++ b/helpers/stonxEmissions.ts
@@ -1,0 +1,43 @@
+import { FetchOptions } from "../adapters/types";
+
+// Deployed Ekubo Ve33 extension on Robinhood Chain.
+// https://robinhoodchain.blockscout.com/address/0xD18685A514E59b06d59824e16Db07e73345d9953
+const VE33 = "0xD18685A514E59b06d59824e16Db07e73345d9953";
+// stakeToken() for the deployed Ve33 extension resolves to this STONX contract.
+// https://robinhoodchain.blockscout.com/token/0x570c5aa79c798e7a418412cc8399ae5bcce570c5
+export const STONX = "0x570c5aa79c798e7a418412cc8399ae5bcce570c5";
+// Ve33 contract deployment block on Robinhood Chain.
+// https://robinhoodchain.blockscout.com/address/0xD18685A514E59b06d59824e16Db07e73345d9953
+const DEPLOYMENT_BLOCK = 18_269_246;
+// Ekubo stores emission rates as tokens per second in Q32 fixed-point format.
+// https://github.com/EkuboProtocol/evm-contracts/blob/main/src/lens/Ve33DataFetcher.sol#L121-L123
+const Q32 = 1n << 32n;
+
+export const STONX_LP_INCENTIVES = "STONX LP Incentives";
+
+// https://github.com/EkuboProtocol/evm-contracts/blob/main/src/interfaces/extensions/IVe33.sol#L86-L87
+const EMISSIONS_SCHEDULED_EVENT =
+  "event EmissionsScheduled(address funder, uint64 startTime, uint64 endTime, uint160 rewardRate, uint128 amount)";
+
+/** Return scheduled STONX emissions overlapping the requested period. */
+export async function getStonxEmissions(options: FetchOptions): Promise<bigint> {
+  const toBlock = await options.getToBlock();
+  const schedules = await options.getLogs({
+    targets: [VE33],
+    eventAbi: EMISSIONS_SCHEDULED_EVENT,
+    fromBlock: DEPLOYMENT_BLOCK,
+    toBlock,
+    cacheInCloud: true,
+  });
+
+  let totalEmitted = 0n;
+  for (const schedule of schedules) {
+    const overlapStart = Math.max(options.startTimestamp, Number(schedule.startTime));
+    const overlapEnd = Math.min(options.endTimestamp, Number(schedule.endTime));
+    if (overlapEnd <= overlapStart) continue;
+
+    totalEmitted += (BigInt(schedule.rewardRate) * BigInt(overlapEnd - overlapStart)) / Q32;
+  }
+
+  return totalEmitted;
+}

--- a/incentives/stonx/index.ts
+++ b/incentives/stonx/index.ts
@@ -1,0 +1,47 @@
+import { Adapter, FetchOptions, FetchResultIncentives, ProtocolType } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+
+const VE33 = "0xD18685A514E59b06d59824e16Db07e73345d9953";
+const STONX = "0x570c5aa79c798e7a418412cc8399ae5bcce570c5";
+const DEPLOYMENT_BLOCK = 18_269_246;
+const Q32 = 1n << 32n;
+
+const EMISSIONS_SCHEDULED_EVENT =
+  "event EmissionsScheduled(address funder, uint64 startTime, uint64 endTime, uint160 rewardRate, uint128 amount)";
+
+/** Return the STONX emitted by every schedule overlapping the requested period. */
+const fetch = async (options: FetchOptions): Promise<FetchResultIncentives> => {
+  const tokenIncentives = options.createBalances();
+  const toBlock = await options.getToBlock();
+  const schedules = await options.getLogs({
+    target: VE33,
+    eventAbi: EMISSIONS_SCHEDULED_EVENT,
+    fromBlock: DEPLOYMENT_BLOCK,
+    toBlock,
+    cacheInCloud: true,
+  });
+
+  for (const schedule of schedules) {
+    const overlapStart = Math.max(options.startTimestamp, Number(schedule.startTime));
+    const overlapEnd = Math.min(options.endTimestamp, Number(schedule.endTime));
+    if (overlapEnd <= overlapStart) continue;
+
+    const emitted = (BigInt(schedule.rewardRate) * BigInt(overlapEnd - overlapStart)) / Q32;
+    tokenIncentives.add(STONX, emitted);
+  }
+
+  return { tokenIncentives };
+};
+
+const adapter: Adapter = {
+  version: 2,
+  fetch,
+  pullHourly: true,
+  chains: [CHAIN.ROBINHOOD],
+  start: "2026-07-31",
+  protocolType: ProtocolType.PROTOCOL,
+  methodology:
+    "STONX incentives scheduled by the deployed Ekubo Ve33 contract for liquidity providers. Each on-chain emission schedule is prorated to the requested time period using its Q32 reward rate, before pool-level allocation and claims.",
+};
+
+export default adapter;

--- a/incentives/stonx/index.ts
+++ b/incentives/stonx/index.ts
@@ -1,34 +1,12 @@
 import { Adapter, FetchOptions, FetchResultIncentives, ProtocolType } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
-
-const VE33 = "0xD18685A514E59b06d59824e16Db07e73345d9953";
-const STONX = "0x570c5aa79c798e7a418412cc8399ae5bcce570c5";
-const DEPLOYMENT_BLOCK = 18_269_246;
-const Q32 = 1n << 32n;
-
-const EMISSIONS_SCHEDULED_EVENT =
-  "event EmissionsScheduled(address funder, uint64 startTime, uint64 endTime, uint160 rewardRate, uint128 amount)";
+import { getStonxEmissions, STONX, STONX_LP_INCENTIVES } from "../../helpers/stonxEmissions";
 
 /** Return the STONX emitted by every schedule overlapping the requested period. */
 const fetch = async (options: FetchOptions): Promise<FetchResultIncentives> => {
   const tokenIncentives = options.createBalances();
-  const toBlock = await options.getToBlock();
-  const schedules = await options.getLogs({
-    target: VE33,
-    eventAbi: EMISSIONS_SCHEDULED_EVENT,
-    fromBlock: DEPLOYMENT_BLOCK,
-    toBlock,
-    cacheInCloud: true,
-  });
-
-  for (const schedule of schedules) {
-    const overlapStart = Math.max(options.startTimestamp, Number(schedule.startTime));
-    const overlapEnd = Math.min(options.endTimestamp, Number(schedule.endTime));
-    if (overlapEnd <= overlapStart) continue;
-
-    const emitted = (BigInt(schedule.rewardRate) * BigInt(overlapEnd - overlapStart)) / Q32;
-    tokenIncentives.add(STONX, emitted);
-  }
+  const emitted = await getStonxEmissions(options);
+  tokenIncentives.add(STONX, emitted, STONX_LP_INCENTIVES);
 
   return { tokenIncentives };
 };
@@ -42,6 +20,11 @@ const adapter: Adapter = {
   protocolType: ProtocolType.PROTOCOL,
   methodology:
     "STONX incentives scheduled by the deployed Ekubo Ve33 contract for liquidity providers. Each on-chain emission schedule is prorated to the requested time period using its Q32 reward rate, before pool-level allocation and claims.",
+  breakdownMethodology: {
+    TokenIncentives: {
+      [STONX_LP_INCENTIVES]: "Scheduled STONX emissions used to compensate Ve33 liquidity providers.",
+    },
+  },
 };
 
 export default adapter;


### PR DESCRIPTION
## Summary

- add an incentives adapter for STONX on Robinhood Chain
- report global STONX emissions scheduled by the deployed Ekubo Ve33 contract
- classify those LP emissions as `dailySupplySideRevenue` / Cost of Revenue in the STONX DEX adapter
- calculate gross profit as swap fees minus LP emissions
- share one on-chain emission calculation between the fees and incentives adapters

## Accounting

STONX Ve33 swap fees are routed to veSTONX voters, while liquidity providers are compensated through STONX emissions. The adapters therefore report:

- `dailyFees`: swap fees paid by traders
- `dailySupplySideRevenue`: scheduled STONX emissions paid to LPs
- `dailyRevenue`: swap fees minus STONX LP emissions; this can be negative
- `dailyHoldersRevenue`: swap fees routed to veSTONX voters
- `dailyProtocolRevenue`: zero, because the treasury takes no swap-fee share
- `tokenIncentives`: the same STONX emissions in the incentives dataset

The fee identity balances as `dailyFees = dailyRevenue + dailySupplySideRevenue`.

References:
- https://github.com/DefiLlama/dimension-adapters/blob/master/fees/GUIDELINES.md
- https://github.com/DefiLlama/dimension-adapters/blob/master/incentives/GUIDELINES.md

## Data source and calculation

The shared helper reads every `EmissionsScheduled` event from the deployed Ve33 contract and prorates each schedule to the requested interval:

`emitted = rewardRate * overlappingSeconds / 2^32`

Schedules are discovered dynamically from deployment block 18,269,246 through the requested end block, so later and overlapping schedules are included automatically.

- Ve33: `0xD18685A514E59b06d59824e16Db07e73345d9953`
- STONX: `0x570c5aa79c798e7a418412cc8399ae5bcce570c5`
- official event interface: https://github.com/EkuboProtocol/evm-contracts/blob/main/src/interfaces/extensions/IVe33.sol
- official Q32 emission calculation: https://github.com/EkuboProtocol/evm-contracts/blob/main/src/lens/Ve33DataFetcher.sol#L121-L123

The active schedule's Q32 rate corresponds to `3,346.517758871999286075 STONX/day`.

## Verification

- `pnpm ts-check`
- `DEBUG_BREAKDOWN_FEES=1 pnpm test incentives stonx/index.ts 2026-08-27`
  - all 24 hourly slots populated
  - token incentives: approximately `$2.84k`
- `DEBUG_BREAKDOWN_FEES=1 pnpm test dexs stonx.ts 2026-08-27`
  - daily volume: `$3.15m`
  - daily fees: `$1.14k`
  - daily Cost of Revenue: `$2.82k`
  - daily gross profit/revenue: `-$1.68k`
  - daily holders revenue: `$1.14k`
  - daily protocol revenue: `$0`

The USD incentive totals differ slightly between the hourly incentives run and daily fee run because DefiLlama prices the same token amount at different timestamps; both use the identical `3,346.517758871999286075 STONX/day` source calculation.
