### PR TITLE
Add Cantex adapter (Canton)

### DIFF
--- a/dexs/cantex/index.ts
+++ b/dexs/cantex/index.ts
@@ -1,9 +1,6 @@
-// DefiLlama dimension adapter for Cantex (volume + fees).
-// Submit as dexs/cantex/index.ts in https://github.com/DefiLlama/dimension-adapters
-// (see README.md in this directory).
-
 import { FetchOptions, FetchResult, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
+import { METRIC } from "../../helpers/metrics";
 import fetchURL from "../../utils/fetchURL";
 
 const VOLUME_URL = "https://api.cantex.io/v1/public/volume";
@@ -22,8 +19,6 @@ type VolumeResponse = {
 };
 
 const fetch = async (options: FetchOptions): Promise<FetchResult> => {
-  // DefiLlama v2 supplies an inclusive window; the Cantex endpoint takes a
-  // half-open [start, end), so normalize the lower bound (same as Temple).
   const startTime = new Date((options.startTimestamp + 1) * 1000).toISOString();
   const endTime = new Date(options.endTimestamp * 1000).toISOString();
   const params = new URLSearchParams({ start_time: startTime, end_time: endTime });
@@ -43,13 +38,13 @@ const fetch = async (options: FetchOptions): Promise<FetchResult> => {
   dailyVolume.addCGToken(CANTON_COIN_CG_ID, volumeCC);
 
   const dailyFees = options.createBalances();
-  dailyFees.addCGToken(CANTON_COIN_CG_ID, feesCC);
+  dailyFees.addCGToken(CANTON_COIN_CG_ID, feesCC, METRIC.SWAP_FEES);
 
   const dailyProtocolRevenue = options.createBalances();
-  dailyProtocolRevenue.addCGToken(CANTON_COIN_CG_ID, protocolFeesCC);
+  dailyProtocolRevenue.addCGToken(CANTON_COIN_CG_ID, protocolFeesCC, METRIC.PROTOCOL_FEES);
 
   const dailySupplySideRevenue = options.createBalances();
-  dailySupplySideRevenue.addCGToken(CANTON_COIN_CG_ID, lpFeesCC);
+  dailySupplySideRevenue.addCGToken(CANTON_COIN_CG_ID, lpFeesCC, METRIC.LP_FEES);
 
   return {
     dailyVolume,
@@ -71,12 +66,32 @@ const methodology = {
   SupplySideRevenue: "The liquidity providers' share of swap fees.",
 };
 
+const breakdownMethodology = {
+  Fees: {
+    [METRIC.SWAP_FEES]: "Swap fees charged by Cantex pools (pool fee rate applied to each swap), denominated in CC.",
+  },
+  UserFees: {
+    [METRIC.SWAP_FEES]: "Swap fees paid by traders on each Cantex swap.",
+  },
+  Revenue: {
+    [METRIC.PROTOCOL_FEES]: "The protocol's share of swap fees (per-pool admin fee share).",
+  },
+  ProtocolRevenue: {
+    [METRIC.PROTOCOL_FEES]: "The protocol's share of swap fees (per-pool admin fee share).",
+  },
+  SupplySideRevenue: {
+    [METRIC.LP_FEES]: "The liquidity providers' share of swap fees.",
+  },
+};
+
 const adapter: SimpleAdapter = {
   version: 2,
+  pullHourly: true,
   fetch,
   chains: [CHAIN.CANTON],
-  start: "2026-06-01", // FIXME: set to the first Cantex mainnet swap date before submitting
+  start: "2026-01-14",
   methodology,
+  breakdownMethodology,
 };
 
 export default adapter;

--- a/dexs/cantex/index.ts
+++ b/dexs/cantex/index.ts
@@ -1,0 +1,82 @@
+// DefiLlama dimension adapter for Cantex (volume + fees).
+// Submit as dexs/cantex/index.ts in https://github.com/DefiLlama/dimension-adapters
+// (see README.md in this directory).
+
+import { FetchOptions, FetchResult, SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import fetchURL from "../../utils/fetchURL";
+
+const VOLUME_URL = "https://api.cantex.io/v1/public/volume";
+const CANTON_COIN_CG_ID = "canton-network";
+
+type VolumeResponse = {
+  data: {
+    start_time: string;
+    end_time: string;
+    swap_count: string;
+    volume_cc: string;
+    fees_cc: string;
+    lp_fees_cc: string;
+    protocol_fees_cc: string;
+  };
+};
+
+const fetch = async (options: FetchOptions): Promise<FetchResult> => {
+  // DefiLlama v2 supplies an inclusive window; the Cantex endpoint takes a
+  // half-open [start, end), so normalize the lower bound (same as Temple).
+  const startTime = new Date((options.startTimestamp + 1) * 1000).toISOString();
+  const endTime = new Date(options.endTimestamp * 1000).toISOString();
+  const params = new URLSearchParams({ start_time: startTime, end_time: endTime });
+  const response: VolumeResponse = await fetchURL(`${VOLUME_URL}?${params}`);
+
+  const d = response?.data;
+  const volumeCC = Number(d?.volume_cc);
+  const feesCC = Number(d?.fees_cc);
+  const lpFeesCC = Number(d?.lp_fees_cc);
+  const protocolFeesCC = Number(d?.protocol_fees_cc);
+  if (![volumeCC, feesCC, lpFeesCC, protocolFeesCC].every((v) => Number.isFinite(v) && v >= 0))
+    throw new Error("cantex: volume response malformed");
+
+  // Every Cantex pool is CC-paired, so the CC leg of each swap single-counts
+  // the volume; DefiLlama prices CC via its CoinGecko id.
+  const dailyVolume = options.createBalances();
+  dailyVolume.addCGToken(CANTON_COIN_CG_ID, volumeCC);
+
+  const dailyFees = options.createBalances();
+  dailyFees.addCGToken(CANTON_COIN_CG_ID, feesCC);
+
+  const dailyProtocolRevenue = options.createBalances();
+  dailyProtocolRevenue.addCGToken(CANTON_COIN_CG_ID, protocolFeesCC);
+
+  const dailySupplySideRevenue = options.createBalances();
+  dailySupplySideRevenue.addCGToken(CANTON_COIN_CG_ID, lpFeesCC);
+
+  return {
+    dailyVolume,
+    dailyFees,
+    dailyUserFees: dailyFees,
+    dailyRevenue: dailyProtocolRevenue,
+    dailyProtocolRevenue,
+    dailySupplySideRevenue,
+  };
+};
+
+const methodology = {
+  Volume:
+    "24h swap volume across all Cantex AMM pools. Every pool is CC-paired, so volume is single-counted as the Canton Coin leg of each on-chain swap, fetched from the Cantex public API (api.cantex.io/v1/public/volume) for the requested window and priced via Canton Coin's CoinGecko listing.",
+  Fees: "Swap fees charged by Cantex pools (pool fee rate applied to each swap), denominated in CC.",
+  UserFees: "Same as Fees: all swap fees are paid by traders.",
+  Revenue: "The protocol's share of swap fees (per-pool admin fee share).",
+  ProtocolRevenue: "The protocol's share of swap fees (per-pool admin fee share).",
+  SupplySideRevenue: "The liquidity providers' share of swap fees.",
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  fetch,
+  chains: [CHAIN.CANTON],
+  start: "2026-06-01", // FIXME: set to the first Cantex mainnet swap date before submitting
+  methodology,
+};
+
+export default adapter;


### PR DESCRIPTION
Adds a volume/fees/revenue adapter for **Cantex** (Canton) — already listed; TVL adapter merged in DefiLlama/DefiLlama-Adapters#20699.

- Website: https://cantex.io · Twitter: https://x.com/Cantex_io · Docs: https://docs.cantex.io/developers/public-api/
- Reports `dailyVolume`, `dailyFees`, `dailyUserFees`, `dailyRevenue`/`dailyProtocolRevenue` (protocol's admin fee share) and `dailySupplySideRevenue` (LP share).
- Source: `https://api.cantex.io/v1/public/volume?start_time=&end_time=` — windowed aggregates over on-chain Canton swap events. Version 2 with full historical backfill from 2026-01-14 (first mainnet swap); `pullHourly: true` (the endpoint serves arbitrary half-open windows cheaply).
- Volume is single-counted as the Canton Coin leg of each swap (every Cantex pool is CC-paired), priced via CC's CoinGecko listing (`canton-network`). Fees are pool swap fees, split 90% LP / 10% protocol per the on-chain admin fee share.
- Underlying data is third-party verifiable via Canton explicit disclosure: https://docs.cantex.io/developers/public-api/market-data/#pools-proof — same verification approach as the merged TVL adapter.

Tested with `npm run test dexs/cantex` (prints current-day volume/fees consistent with our own stats).