### PR TITLE
fix(kinetiq-markets) - dedupe builder-routed HIP-3 volume

### DIFF
--- a/dexs/kinetiq-markets.ts
+++ b/dexs/kinetiq-markets.ts
@@ -1,15 +1,31 @@
+import { FetchOptions, SimpleAdapter } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
 import { fetchBuilderCodeRevenue, fetchHIP3DeployerData } from "../helpers/hyperliquid";
-import { FetchOptions, SimpleAdapter } from "../adapters/types";
 
 const KINETIQ_MARKETS_LEGACY_END_DATE = "2026-06-20";
+const KINETIQ_MARKETS_BUILDER_ADDRESS = '0x42f3226007290b02c5a0b15bccbb1ba6df04f992';
 
 const fetch = async (options: FetchOptions) => {
   const deployerId = options.dateString > KINETIQ_MARKETS_LEGACY_END_DATE ? 'mkts' : 'km';
   const { dailyVolume: builderVolume, dailyFees: builderFees } = await fetchBuilderCodeRevenue({
     options,
-    builder_address: '0x42f3226007290b02c5a0b15bccbb1ba6df04f992',
+    builder_address: KINETIQ_MARKETS_BUILDER_ADDRESS,
   });
+
+  const builderHip3OverlapVolume = options.createBalances();
+
+  // No builder activity means the builder/HIP-3 intersection is necessarily zero.
+  if (await builderVolume.getUSDValue()) {
+    const { dailyVolume: builderHip3Volume } = await fetchBuilderCodeRevenue({
+      options,
+      builder_address: KINETIQ_MARKETS_BUILDER_ADDRESS,
+      market: 'hip3',
+      hip3DeployerId: deployerId,
+    });
+
+    builderHip3OverlapVolume.add(builderHip3Volume);
+  }
+
   const { dailyPerpVolume: hip3Volume, dailyPerpFee: hip3Fees, dailyDeployerFee: hip3DeployerFee } = await fetchHIP3DeployerData({
     options,
     hip3DeployerId: deployerId,
@@ -21,6 +37,7 @@ const fetch = async (options: FetchOptions) => {
   const dailySupplySideRevenue = options.createBalances();
 
   dailyVolume.add(builderVolume);
+  dailyVolume.subtract(builderHip3OverlapVolume);
   dailyVolume.add(hip3Volume);
 
   // Builder-code fees are retained entirely by Kinetiq.
@@ -49,6 +66,7 @@ const adapter: SimpleAdapter = {
   start: '2025-12-16',
   doublecounted: true,
   methodology: {
+    Volume: "Unique trading volume routed through Kinetiq Markets' builder code or executed on Kinetiq's HIP-3 markets. Builder-routed trades on Kinetiq's own HIP-3 markets are counted once.",
     Fees: "Trading fees paid by users on Hyperliquid via Kinetiq's builder code and its HIP-3 markets.",
     Revenue: "Builder-code fees (retained by Kinetiq) plus Kinetiq's deployer-fee cut of its HIP-3 market fees.",
     ProtocolRevenue: "Same as Revenue — retained by Kinetiq.",

--- a/helpers/hyperliquid.ts
+++ b/helpers/hyperliquid.ts
@@ -1,14 +1,14 @@
-import { FetchOptions, SimpleAdapter } from "../adapters/types";
-import * as fs from "fs";
-import * as path from "path";
+import { Balances } from "@defillama/sdk";
 import axios from "axios";
+import * as fs from "fs";
 import { decompressFrame } from "lz4-napi";
-import { getEnv } from "./env";
+import * as path from "path";
+import { FetchOptions, SimpleAdapter } from "../adapters/types";
 import { httpGet, httpPost } from "../utils/fetchURL";
 import { formatAddress, sleep } from "../utils/utils";
-import { Balances } from "@defillama/sdk";
-import { findClosest } from "./utils/findClosest";
 import { CHAIN } from "./chains";
+import { getEnv } from "./env";
+import { findClosest } from "./utils/findClosest";
 
 export type HyperliquidMarket = "all" | "hip3" | "hip4";
 
@@ -33,16 +33,22 @@ export const fetchBuilderCodeRevenue = async ({
   options,
   builder_address,
   market = "all",
+  hip3DeployerId,
 }: {
   options: FetchOptions;
   builder_address: string;
   market?: HyperliquidMarket;
+  hip3DeployerId?: string;
 }) => {
   const startTimestamp = options.startOfDay;
   const dailyFees = options.createBalances();
   const dailyVolume = options.createBalances();
   const isHIP3Market = market === "hip3";
   const isHIP4Market = market === "hip4";
+
+  if (hip3DeployerId && !isHIP3Market) {
+    throw new Error("hip3DeployerId requires market='hip3'");
+  }
 
   // try with llama hl indexer
   const endpoint = getEnv("LLAMA_HL_INDEXER");
@@ -141,6 +147,9 @@ export const fetchBuilderCodeRevenue = async ({
 
           // Source: asset ID docs; HIP-3 perps use {dex}:{coin}, HIP-4 outcomes use #<encoding>.
           if (isHIP3Market && !coin?.includes(":")) {
+            continue;
+          }
+          if (hip3DeployerId && !coin?.startsWith(`${hip3DeployerId}:`)) {
             continue;
           }
           if (isHIP4Market && !/^#\d+$/.test(coin)) {

--- a/helpers/hyperliquid.ts
+++ b/helpers/hyperliquid.ts
@@ -22,6 +22,7 @@ export type HyperliquidMarket = "all" | "hip3" | "hip4";
  *
  * @param options - FetchOptions containing startOfDay timestamp and other utilities
  * @param builder_address - The builder address to fetch data for
+ * @param hip3DeployerId - Optional HIP-3 namespace filter; includes only `${hip3DeployerId}:*` coins and requires `market: "hip3"`
  * @returns Promise with dailyVolume, dailyFees, dailyRevenue, dailyProtocolRevenue
  */
 // hl indexer only supports data from this date


### PR DESCRIPTION
## Summary

Avoid double-counting volume routed through Kinetiq Markets' builder code when the same fills execute on Kinetiq's own HIP-3 deployment.

The existing adapter combines:

- all volume routed through the Markets builder code; and
- all volume executed on Kinetiq's `km` / `mkts` HIP-3 deployment.

Some fills belong to both datasets. The adapter currently adds both complete balances, so the intersection is counted twice.

This PR changes the volume calculation from:

```text
builder volume + Kinetiq HIP-3 volume
```

to:

```text
builder volume
+ Kinetiq HIP-3 volume
- builder volume executed on Kinetiq HIP-3
```

## Changes

- Extend `fetchBuilderCodeRevenue()` with an optional exact HIP-3 deployer filter.
- Preserve the existing broad `market: "hip3"` behavior when no deployer ID is provided.
- Match builder fills against Kinetiq's active namespace:
  - `km:` on legacy dates
  - `mkts:` after the migration
- Subtract the matching builder/HIP-3 intersection from `dailyVolume`.
- Add volume methodology documenting the unique-volume calculation.

## Validation

Hyperliquid's public per-builder fill files expose each fill's `coin`, `px`, and `sz`, allowing the intersection to be calculated directly.

Tracked builder:

```text
0x42f3226007290b02c5a0b15bccbb1ba6df04f992
```

### 2026-08-26

```text
Total builder volume:                  $4,706,926.42
Builder volume executed on mkts:*:       $752,097.55
Builder volume outside mkts:*:         $3,954,828.86
Overlap share of builder volume:              15.98%
```

The overlapping fills were:

```text
mkts:USTECH    744 fills    $515,370.02
mkts:US500     421 fills    $236,727.54
```

The remaining `$3.955M` is intentionally retained. It represents Markets-routed activity on native Hyperliquid perps, other HIP-3 deployments, and spot markets.

### 2026-08-27

```text
Total builder volume:                  $1,369,253.01
Builder volume executed on mkts:*:       $241,226.32
Builder volume outside mkts:*:         $1,128,026.69
Overlap share of builder volume:              17.62%
```

DefiLlama displayed approximately `$16.93M` for that day. Subtracting the demonstrated intersection implies approximately `$16.69M` of unique combined volume while retaining builder activity routed outside Kinetiq's own deployment.

Across these two dates, the publicly demonstrated duplicated volume was:

```text
$752,097.55 + $241,226.32 = $993,323.87
```

## Scope

This PR intentionally does not:

- change fees, revenue, protocol revenue, or supply-side revenue;
- redefine Kinetiq Markets as a DEX-only adapter.

It preserves the existing combined builder-plus-HIP-3 scope and changes only the volume calculation from a raw sum to a set union.

## Reviewer note: filtered data source

For `market: "all"`, production can fetch builder totals from `LLAMA_HL_INDEXER`. The exact HIP-3-filtered lookup currently uses Hyperliquid's public daily `builder_fills` archive.

The public file for `2026-08-28` was unavailable when checked, even though DefiLlama already displayed data for that date.

Does `LLAMA_HL_INDEXER` already expose builder volume broken down by coin or HIP-3 deployer?

If it does, the exact-deployer filter should use that internal breakdown so total builder volume and overlap come from the same timely source. Otherwise, this may require an indexer extension before the change is safe for recent dates.

## Tests

- `npm run ts-check`
- `git diff --check`

A complete local Kinetiq adapter run requires the private `LLAMA_HL_INDEXER`.
