### PR TITLE
fix: preserve getLogs metadata required by adapters

### DIFF
--- a/dexs/autorange.ts
+++ b/dexs/autorange.ts
@@ -43,7 +43,7 @@ const fetch = async (options: FetchOptions) => {
 
   const [positionInitLogs, rebalancedLogs] = await Promise.all([
     options.getLogs({ targets: vaults, eventAbi: positionInitAbi, flatten: false }),
-    options.getLogs({ targets: vaults, eventAbi: rebalancedAbi, flatten: false }),
+    options.getLogs({ targets: vaults, eventAbi: rebalancedAbi, flatten: false, onlyArgs: false }),
   ]);
 
   vaults.forEach((_, i) => {
@@ -55,11 +55,11 @@ const fetch = async (options: FetchOptions) => {
 
   const anyRebalances = rebalancedLogs.some((logs: any[]) => logs?.length);
   if (anyRebalances) {
-    const increaseLogs = await options.getLogs({ target: positionManager, eventAbi: increaseLiquidityAbi });
+    const increaseLogs = await options.getLogs({ target: positionManager, eventAbi: increaseLiquidityAbi, onlyArgs: false });
 
     const byTokenId = new Map<string, any[]>();
     (increaseLogs ?? []).forEach((log: any) => {
-      const key = String(log.tokenId);
+      const key = String(log.args.tokenId);
       const existing = byTokenId.get(key);
       if (existing) existing.push(log);
       else byTokenId.set(key, [log]);
@@ -67,13 +67,13 @@ const fetch = async (options: FetchOptions) => {
 
     vaults.forEach((_, i) => {
       (rebalancedLogs[i] ?? []).forEach((log: any) => {
-        const matches = (byTokenId.get(String(log.newTokenId)) ?? []).filter(
+        const matches = (byTokenId.get(String(log.args.newTokenId)) ?? []).filter(
           (m: any) => m.transactionHash === log.transactionHash,
         );
         if (!matches.length) return;
         matches.forEach((match) => {
-          dailyVolume.add(token0s[i], match.amount0);
-          dailyVolume.add(token1s[i], match.amount1);
+          dailyVolume.add(token0s[i], match.args.amount0);
+          dailyVolume.add(token1s[i], match.args.amount1);
         });
       });
     });

--- a/fees/basisos/index.ts
+++ b/fees/basisos/index.ts
@@ -1,5 +1,6 @@
 import { Adapter, FetchOptions } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
+import { getPositionedLogArgs } from "../../helpers/logs";
 import { METRIC } from "../../helpers/metrics";
 
 /**
@@ -39,7 +40,7 @@ const fetch = async (options: FetchOptions) => {
     const toBlock = await options.getToBlock();
 
     // Fetch all relevant events for the day
-    const vaultStates = await options.getLogs({
+    const vaultStates = await getPositionedLogArgs(options, {
       target: vault,
       eventAbi: "event VaultState(uint256 indexed totalAssets, uint256 indexed totalSupply)",
       fromBlock,
@@ -91,7 +92,7 @@ const fetch = async (options: FetchOptions) => {
       let latestState = null;
 
       while (!latestState && currentBlock > VAULT_STATE_BLOCK_LIMIT) {
-        const previousStates = await options.getLogs({
+        const previousStates = await getPositionedLogArgs(options, {
           target: vault,
           eventAbi: "event VaultState(uint256 indexed totalAssets, uint256 indexed totalSupply)",
           fromBlock: Math.max(VAULT_STATE_BLOCK_LIMIT, currentBlock - 50000),

--- a/fees/elara/index.ts
+++ b/fees/elara/index.ts
@@ -1,5 +1,6 @@
 import { FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
+import { getPositionedLogArgs } from "../../helpers/logs";
 import { METRIC } from "../../helpers/metrics";
 
 const VAULT = "0x8B0665a66d4E046dd5E77a42856F8180F9bb19ef";
@@ -84,10 +85,10 @@ const fetch = async (options: FetchOptions) => {
   const dailyProtocolRevenue = options.createBalances();
   const dailySupplySideRevenue = options.createBalances();
 
-  const redeemLogs = await options.getLogs({ target: VAULT, eventAbi: ABI.redeemed });
-  const redemptionFeeUpdateLogs = await options.getLogs({ target: VAULT, eventAbi: ABI.redemptionFeeUpdated });
-  const managementFeeUpdateLogs = await options.getLogs({ target: VAULT, eventAbi: ABI.managementFeeUpdated });
-  const managementFeeAccruedLogs = await options.getLogs({ target: VAULT, eventAbi: ABI.managementFeeAccrued });
+  const redeemLogs = await getPositionedLogArgs(options, { target: VAULT, eventAbi: ABI.redeemed });
+  const redemptionFeeUpdateLogs = await getPositionedLogArgs(options, { target: VAULT, eventAbi: ABI.redemptionFeeUpdated });
+  const managementFeeUpdateLogs = await getPositionedLogArgs(options, { target: VAULT, eventAbi: ABI.managementFeeUpdated });
+  const managementFeeAccruedLogs = await getPositionedLogArgs(options, { target: VAULT, eventAbi: ABI.managementFeeAccrued });
   const feesCollectedLogs = await options.getLogs({ target: VAULT, eventAbi: ABI.feesCollected });
   const stakingYieldLogs = await options.getLogs({
     target: ELUSD,

--- a/fees/kasu.ts
+++ b/fees/kasu.ts
@@ -2,6 +2,7 @@ import { FetchOptions, FetchV2, SimpleAdapter } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
 import CoreAssets from "../helpers/coreAssets.json";
 import { getBlock } from "../helpers/getBlock";
+import { getPositionedLogArgs } from "../helpers/logs";
 import { METRIC } from "../helpers/metrics";
 
 type Deployment = {
@@ -126,13 +127,13 @@ const fetch: FetchV2 = async (options: FetchOptions) => {
         target: systemVariables,
         abi: 'function feeRates() view returns (uint256 ecosystemFeeRate, uint256 protocolFeeRate)',
       }),
-      options.getLogs({
+      getPositionedLogArgs(options, {
         target: systemVariables,
         eventAbi: PerformanceFeeUpdatedEvent,
         fromBlock: factoryStartBlock,
         cacheInCloud: true,
       }),
-      options.getLogs({
+      getPositionedLogArgs(options, {
         target: systemVariables,
         eventAbi: FeeRatesUpdatedEvent,
         fromBlock: factoryStartBlock,
@@ -152,7 +153,7 @@ const fetch: FetchV2 = async (options: FetchOptions) => {
     // 3. Fetch FeesOwedIncreased logs across the lookback window (3 epochs back).
     // Each log represents one epoch's worth of interest, which we spread evenly
     // across the epoch and attribute the overlap with [windowStart, windowEnd].
-    const feeLogs = await options.getLogs({
+    const feeLogs = await getPositionedLogArgs(options, {
       targets: pools,
       eventAbi: FeesOwedIncreasedEvent,
       fromBlock: lookbackFromBlock,

--- a/fees/midas-rwa/index.ts
+++ b/fees/midas-rwa/index.ts
@@ -492,12 +492,12 @@ const fetch = async (options: FetchOptions) => {
 	if (allVaults.length > 0) {
 		const logOpts = { targets: allVaults, flatten: true };
 		const [redeemLogs, redeemCustomLogs, depositLogs, depositCustomLogs, redeemRequestLogs, redeemRequestCustomLogs, depositRequestLogs, depositRequestCustomLogs] = await Promise.all([
-			getLogs({ ...logOpts, eventAbi: ABI.redeemInstant }),
-			getLogs({ ...logOpts, eventAbi: ABI.redeemInstantCustom }),
+			getLogs({ ...logOpts, eventAbi: ABI.redeemInstant, onlyArgs: false }),
+			getLogs({ ...logOpts, eventAbi: ABI.redeemInstantCustom, onlyArgs: false }),
 			getLogs({ ...logOpts, eventAbi: ABI.depositInstant}),
 			getLogs({ ...logOpts, eventAbi: ABI.depositInstantCustom}),
-			getLogs({ ...logOpts, eventAbi: ABI.redeemRequest }),
-			getLogs({ ...logOpts, eventAbi: ABI.redeemRequestCustom }),
+			getLogs({ ...logOpts, eventAbi: ABI.redeemRequest, onlyArgs: false }),
+			getLogs({ ...logOpts, eventAbi: ABI.redeemRequestCustom, onlyArgs: false }),
 			getLogs({ ...logOpts, eventAbi: ABI.depositRequest }),
 			getLogs({ ...logOpts, eventAbi: ABI.depositRequestCustom }),
 		]);
@@ -531,7 +531,7 @@ const fetch = async (options: FetchOptions) => {
 
 		// Process redeem fees (feeAmount) — instant + request-based
 		for (const log of [...redeemLogs, ...redeemCustomLogs, ...redeemRequestLogs, ...redeemRequestCustomLogs]) {
-			const feeAmount = Number(log.feeAmount);
+			const feeAmount = Number(log.args.feeAmount);
 			if (feeAmount <= 0) continue;
 			const info = vaultToToken[log.address?.toLowerCase()];
 			if (!info) continue;

--- a/fees/orchard/index.ts
+++ b/fees/orchard/index.ts
@@ -37,6 +37,7 @@
 
 import { Adapter, FetchOptions } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
+import { getPositionedLogArgs } from "../../helpers/logs";
 
 const ORCHARD = "0xEbB8b167c0992cFdc497A995a8Cf7167acAA0A1A";
 const AAPL = "0xaF3D76f1834A1d425780943C99Ea8A608f8a93f9";
@@ -93,7 +94,7 @@ const fetch = async (options: FetchOptions) => {
     await options.fromApi.call({ abi: "uint16:adminFeeBps", target: ORCHARD })
   );
 
-  const feeChanges = (await options.getLogs({ target: ORCHARD, eventAbi: ADMIN_FEE_BPS_SET }))
+  const feeChanges = (await getPositionedLogArgs(options, { target: ORCHARD, eventAbi: ADMIN_FEE_BPS_SET }))
     .map((log: any) => ({
       blockNumber: Number(log.blockNumber),
       logIndex: Number(log.logIndex),
@@ -115,8 +116,8 @@ const fetch = async (options: FetchOptions) => {
     return bps;
   };
 
-  const planted = await options.getLogs({ target: ORCHARD, eventAbi: PLANTED });
-  const plantedMany = await options.getLogs({ target: ORCHARD, eventAbi: PLANTED_MANY });
+  const planted = await getPositionedLogArgs(options, { target: ORCHARD, eventAbi: PLANTED });
+  const plantedMany = await getPositionedLogArgs(options, { target: ORCHARD, eventAbi: PLANTED_MANY });
 
   const addPlant = (log: any, stake: bigint) => {
     dailyVolume.addGasToken(log.ethIn);

--- a/helpers/logs.ts
+++ b/helpers/logs.ts
@@ -1,0 +1,37 @@
+import { FetchGetLogsOptions, FetchOptions } from "../adapters/types";
+
+export type PositionedLogArgs = Record<string, any> & {
+  blockNumber: number;
+  logIndex: number;
+};
+
+type PositionedLogOptions = Omit<FetchGetLogsOptions, "eventAbi" | "flatten" | "onlyArgs"> & {
+  eventAbi: string;
+  flatten?: true;
+  onlyArgs?: never;
+};
+
+/**
+ * Fetch decoded event arguments together with their on-chain position.
+ *
+ * FetchOptions.getLogs defaults to decoded arguments only, which omits log
+ * metadata. Callers that replay configuration changes need the block and log
+ * index as well as the decoded arguments to preserve event ordering.
+ */
+export async function getPositionedLogArgs(
+  options: Pick<FetchOptions, "getLogs">,
+  params: PositionedLogOptions,
+): Promise<PositionedLogArgs[]> {
+  const logs = await options.getLogs({ ...params, onlyArgs: false });
+
+  return logs.map((log: any) => {
+    const blockNumber = Number(log?.blockNumber ?? log?.block_number ?? log?.block);
+    const logIndex = Number(log?.logIndex ?? log?.log_index ?? log?.index);
+
+    if (!log?.args || !Number.isFinite(blockNumber) || !Number.isFinite(logIndex)) {
+      throw new Error("getPositionedLogArgs: decoded log is missing blockNumber, logIndex, or args");
+    }
+
+    return { ...log.args, blockNumber, logIndex };
+  });
+}


### PR DESCRIPTION
## Description

`FetchOptions.getLogs` defaults to returning decoded event arguments only. This removes metadata such as `blockNumber`, `logIndex`, `transactionHash`, and the emitting contract address.

Several adapters relied on that metadata for event ordering, historical rate selection, transaction matching, or vault attribution. This could produce incorrect calculations or silently skip events.

## Validation

- `npm run ts-check`
- `npm run ts-check-cli`
- `git diff --check`