### PR TITLE
fix(drift-trade): drop the removed 3-argument fetch signature

### DIFF
--- a/open-interest/drift-trade.ts
+++ b/open-interest/drift-trade.ts
@@ -1,8 +1,8 @@
 import { CHAIN } from "../helpers/chains";
-import { FetchOptions, SimpleAdapter } from "../adapters/types";
+import { SimpleAdapter } from "../adapters/types";
 import fetchURL from "../utils/fetchURL";
 
-async function fetch(_t: any, _tt: any, options: FetchOptions) {
+async function fetch() {
   const contractsResponse = await fetchURL('https://data.api.drift.trade/stats/markets');
   const longOpenInterestAtEnd = contractsResponse.markets
     .filter((contract: any) => contract.marketType === 'perp' && contract.status == 'active')


### PR DESCRIPTION
Not a new protocol listing, so the form is replaced with details per the template.

Drift — Website: https://drift.trade · Twitter: https://x.com/DriftProtocol

## The bug

`open-interest/drift-trade.ts` declares the v1 signature `GUIDELINES.md` records as removed:

```ts
async function fetch(_t: any, _tt: any, options: FetchOptions) {
```

> The old v1 3-argument signature `(timestamp, chainBlocks, options)` no longer exists and will fail - never use it. Migrate any adapter still using it to `(options)`.

[`adapters/utils/runAdapter.ts:261`](https://github.com/DefiLlama/dimension-adapters/blob/master/adapters/utils/runAdapter.ts#L261) calls it with a single argument:

```ts
result = await (fetchFunction as FetchV2)(options);
```

so `_t` receives the `FetchOptions` object and the parameter actually *named* `options` is always `undefined`:

```
old (_t, _tt, options) -> { _t: 'object', _tt: 'undefined', options: 'undefined' }
new (options)          -> { options: 'object', chain: 'solana' }

old signature touching options.startTimestamp
  -> TypeError: Cannot read properties of undefined (reading 'startTimestamp')
```

Nothing breaks today only because the body never reads `options` — it fetches a URL and sums the response. That makes the declaration a trap rather than a live failure: the first line to reach for `options.startTimestamp`, `options.createBalances()` or anything else on it throws.

## The fix

Remove the argument rather than renaming it to `options`, since `GUIDELINES.md` also asks:

> Do NOT declare fetch arguments you never use

65 other adapters already use a zero-argument `fetch` for exactly this reason (`dexs/yei-swap.ts`, `dexs/initia-dex.ts`, `dexs/saros-dlmm.ts`, …), so this matches the house shape. The now-unused `FetchOptions` import goes with it.

## This was the last one

I swept every `fetch` definition under the dimension folders with comments stripped. After filtering trailing-comma single arguments (`fetch(options: FetchOptions,)`) and curried helpers that legitimately take extra config (`silo-finance`, `invariant`, `size-credit`, `thorswap`), `drift-trade.ts` was the only remaining adapter on the old shape.

## Testing

No behaviour change — same URL fetched, same three values returned.

- `pnpm ts-check` passes
- `npx ts-node --transpile-only cli/testAdapter.ts open-interest drift-trade` gets past the signature and into the request (it then fails on `getaddrinfo ENOTFOUND data.api.drift.trade`, which is my local DNS — `host` resolves it to CloudFront fine, and an unrelated CloudFront host fails the same way from here, so I could not exercise the response path end-to-end)
- No `package.json` / lockfile changes