### PR TITLE
Fix: should not skip any recipient on native

### DIFF
--- a/dexs/native/index.ts
+++ b/dexs/native/index.ts
@@ -12,12 +12,6 @@ const chainConfig: Record<string, { start: number }> = {
 
 const RFQ_TRADE_EVENT = 'event RFQTrade(address recipient, address sellerToken, address buyerToken, uint256 sellerTokenAmount, uint256 buyerTokenAmount, bytes16 quoteId, address signer)';
 
-// Unofficial adapter contracts that sat as RFQ recipient for the Jul-Aug 2026 BSC volume spike. Not Binance or Native. Same deployer rotated 0x309fcd -> 0x23e2b374.
-const SKIP_RECIPIENTS = new Set([
-  '0x309fcdd159c15e6305f1b02489a14e870e4df052',
-  '0x23e2b37415ee3b9cfe1ae522e42e2b66fd2d9494',
-]);
-
 const fetch: FetchV2 = async (options: FetchOptions) => {
   const { getLogs, createBalances } = options;
   const dailyVolume = createBalances();
@@ -29,7 +23,6 @@ const fetch: FetchV2 = async (options: FetchOptions) => {
   });
 
   logs.forEach((log: any) => {
-    if (SKIP_RECIPIENTS.has(String(log.recipient).toLowerCase())) return;
     dailyVolume.add(log.buyerToken, log.buyerTokenAmount);
   });
 


### PR DESCRIPTION
## Summary
Revert the Native `RFQTrade` recipient skip added in https://github.com/DefiLlama/dimension-adapters/pull/8890. Count all RFQ fills again, including those whose recipient is `0x309fcdd159c15e6305f1b02489a14e870e4df052` or `0x23e2b37415ee3b9cfe1ae522e42e2b66fd2d9494`.

## Why
#8890 treated those two contracts as unofficial adapters and excluded them because they received almost all of the Jul–Aug 2026 BSC volume spike.

We have since confirmed with the LiquidMesh (BSC aggregator) team that:
- they deployed these adapter contracts
- volume on those days is from real users trading to earn Binance Alpha points. That flow should be counted as Native volume. Skipping those recipients undercounts Native BSC.

## What changed
Removed `SKIP_RECIPIENTS` and the recipient filter in `dexs/native/index.ts`. Every `RFQTrade` log is included in `dailyVolume`.