### PR TITLE
fix(xoxno-lending): report gross fees, and add MultiversX

### DIFF
--- a/active-users/xoxno-lending.ts
+++ b/active-users/xoxno-lending.ts
@@ -6,7 +6,6 @@ const HEADERS = { "User-Agent": "dune-analytics" };
 const REQUEST_TIMEOUT_MS = 5_000;
 
 type ChainConfig = {
-  chainName: string;
   userStatsExportPath: string;
   start: string;
 };
@@ -18,21 +17,20 @@ type UserStatsExport = {
   transactions?: number;
 };
 
+// Both chains publish the same export contract, so the only per-chain
+// difference is the path and the first-indexed-event date. DefiLlama
+// lists MultiversX under its legacy key, CHAIN.ELROND.
+// `start` is each chain's first day with data; an earlier date only
+// backfills zeros.
 const CHAIN_CONFIGS: Record<string, ChainConfig> = {
   [CHAIN.STELLAR]: {
-    chainName: "Stellar",
     userStatsExportPath: "/integrations/lending/stellar/active-users",
-    // Mainnet contracts were deployed at ledger 64140891,
-    // 2026-08-27T00:55Z. An earlier start only backfills zeros.
     start: "2026-08-27",
   },
-
-  // Add MultiversX later with the same API response shape:
-  // [CHAIN.MULTIVERSX]: {
-  //   chainName: "MultiversX",
-  //   userStatsExportPath: "/integrations/lending/multiversx/active-users",
-  //   start: "YYYY-MM-DD",
-  // },
+  [CHAIN.ELROND]: {
+    userStatsExportPath: "/integrations/lending/multiversx/active-users",
+    start: "2025-08-07",
+  },
 };
 
 function dayRange(timestamp: number) {
@@ -69,8 +67,6 @@ async function fetchUserStats(options: FetchOptions): Promise<UserStatsExport> {
 async function fetchActiveUsers(options: FetchOptions) {
   const stats = await fetchUserStats(options);
 
-  // Users are counted by OWNER (wallet address), not sub-account: one owner
-  // holds many lending sub-accounts, so the wallet is the real user count.
   return {
     dailyActiveUsers: Number(stats.activeUsers ?? 0),
     dailyTransactionsCount: Number(stats.transactions ?? 0),

--- a/fees/xoxno-lending/index.ts
+++ b/fees/xoxno-lending/index.ts
@@ -1,15 +1,10 @@
 import { FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
+import { METRIC } from "../../helpers/metrics";
 
 const API_BASE = "https://api.xoxno.com";
 const HEADERS = { "User-Agent": "dune-analytics" };
-const REQUEST_TIMEOUT_MS = 5_000;
-
-type ChainConfig = {
-  chainName: string;
-  revenueExportPath: string;
-  start: string;
-};
+const REQUEST_TIMEOUT_MS = 10_000;
 
 type RevenuePoint = {
   dailyFeesUsd?: number;
@@ -18,87 +13,103 @@ type RevenuePoint = {
   dailySupplySideRevenueUsd?: number;
 };
 
-type RevenueExport = {
-  points?: RevenuePoint[];
-};
+type RevenueExport = { points?: RevenuePoint[] };
 
+type ChainConfig = { revenueExportPath: string; start: string };
+
+// `start` is each chain's first day with data; an earlier date only
+// backfills zeros.
 const CHAIN_CONFIGS: Record<string, ChainConfig> = {
   [CHAIN.STELLAR]: {
-    chainName: "Stellar",
     revenueExportPath: "/integrations/lending/stellar/revenue",
-    // Mainnet contracts were deployed at ledger 64140891,
-    // 2026-08-27T00:55Z. An earlier start only backfills zeros.
     start: "2026-08-27",
   },
-
-  // Add MultiversX later with the same API response shape:
-  // [CHAIN.MULTIVERSX]: {
-  //   chainName: "MultiversX",
-  //   revenueExportPath: "/integrations/lending/multiversx/revenue",
-  //   start: "YYYY-MM-DD",
-  // },
+  [CHAIN.ELROND]: {
+    revenueExportPath: "/integrations/lending/multiversx/revenue",
+    start: "2025-08-07",
+  },
 };
 
 function dayRange(timestamp: number) {
   const day = new Date(timestamp * 1000);
   day.setUTCHours(0, 0, 0, 0);
-
   const next = new Date(day);
   next.setUTCDate(next.getUTCDate() + 1);
-
   return {
     startTime: day.toISOString().slice(0, 10),
     endTime: next.toISOString().slice(0, 10),
   };
 }
 
-function sumField(points: RevenuePoint[], field: keyof RevenuePoint) {
+function sumField(points: RevenuePoint[], field: keyof RevenuePoint): number {
   return points.reduce((sum, point) => sum + Number(point[field] ?? 0), 0);
 }
 
-async function makeFetchFees(options: FetchOptions) {
-    const { startTime, endTime } = dayRange(options.startTimestamp);
-    const path = CHAIN_CONFIGS[options.chain].revenueExportPath
-    const url = `${API_BASE}${path}?startTime=${startTime}&endTime=${endTime}`
-    const response = await fetch(url, {
-      headers: HEADERS,
-      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
-    });
+const fetch_ = async (options: FetchOptions) => {
+  const { startTime, endTime } = dayRange(options.startTimestamp);
+  const { revenueExportPath } = CHAIN_CONFIGS[options.chain];
+  const url = `${API_BASE}${revenueExportPath}?startTime=${startTime}&endTime=${endTime}`;
 
-    if (!response.ok) {
-      throw new Error(
-        `XOXNO lending revenue export failed: ${response.status}`,
-      );
-    }
-
-    const data = (await response.json()) as RevenueExport;
-    const points = Array.isArray(data.points) ? data.points : [];
-    const dailyFees = sumField(points, "dailyFeesUsd");
-    const dailyRevenue = sumField(points, "dailyRevenueUsd");
-    const dailyProtocolRevenue = sumField(points, "dailyProtocolRevenueUsd");
-    const dailySupplySideRevenue = sumField(
-      points,
-      "dailySupplySideRevenueUsd",
+  const response = await fetch(url, {
+    headers: HEADERS,
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+  });
+  if (!response.ok) {
+    throw new Error(
+      `XOXNO lending revenue export failed for ${options.chain}: ${response.status}`,
     );
-
-    return {
-      dailyFees,
-      dailyRevenue,
-      dailyProtocolRevenue,
-      dailySupplySideRevenue,
-    };
   }
 
+  const data = (await response.json()) as RevenueExport;
+  const points = Array.isArray(data.points) ? data.points : [];
+
+  const out: Record<string, ReturnType<typeof options.createBalances>> = {};
+  for (const [key, field] of [
+    ["dailyFees", "dailyFeesUsd"],
+    ["dailyRevenue", "dailyRevenueUsd"],
+    ["dailyProtocolRevenue", "dailyProtocolRevenueUsd"],
+    ["dailySupplySideRevenue", "dailySupplySideRevenueUsd"],
+  ] as const) {
+    out[key] = options.createBalances();
+    out[key].addUSDValue(sumField(points, field), METRIC.BORROW_INTEREST);
+  }
+  return out;
+};
+
 const methodology = {
-  Fees: "Borrower interest and lending fees collected by the protocol.",
-  Revenue: "Borrower interest and lending fees collected by the protocol.",
-  ProtocolRevenue: "Borrower interest and lending fees collected by the protocol.",
-  SupplySideRevenue: "Supplier interest is not included in the reported fees.",
+  Fees: "All interest paid by borrowers, plus flash-loan, strategy (leverage) and liquidation fees.",
+  Revenue:
+    "The protocol's share: the reserve-factor cut of borrow interest, plus 100% of flash-loan, strategy and liquidation fees.",
+  ProtocolRevenue:
+    "Same as Revenue. All protocol revenue is minted as supply shares owned by the protocol and swept to the treasury on claim.",
+  SupplySideRevenue:
+    "Interest distributed to suppliers: borrow interest net of the reserve factor.",
+};
+
+const breakdownMethodology = {
+  Fees: {
+    [METRIC.BORROW_INTEREST]:
+      "Gross interest paid by borrowers across every market, plus flash-loan, strategy (leverage) and liquidation fees.",
+  },
+  Revenue: {
+    [METRIC.BORROW_INTEREST]:
+      "The reserve-factor share of borrow interest plus 100% of flash-loan, strategy and liquidation fees.",
+  },
+  ProtocolRevenue: {
+    [METRIC.BORROW_INTEREST]:
+      "The reserve-factor share of borrow interest plus 100% of flash-loan, strategy and liquidation fees.",
+  },
+  SupplySideRevenue: {
+    [METRIC.BORROW_INTEREST]:
+      "Borrow interest net of the reserve factor, accrued to suppliers through the supply index.",
+  },
 };
 
 const adapter: SimpleAdapter = {
+  // External API returning daily aggregates only; v2 block-range fetching is
+  // not possible against it.
   version: 1,
-  fetch: makeFetchFees,
+  fetch: fetch_,
   adapter: Object.fromEntries(
     Object.entries(CHAIN_CONFIGS).map(([chain, config]) => [
       chain,
@@ -106,6 +117,7 @@ const adapter: SimpleAdapter = {
     ]),
   ),
   methodology,
+  breakdownMethodology,
 };
 
 export default adapter;

--- a/liquidations/xoxno-lending/index.ts
+++ b/liquidations/xoxno-lending/index.ts
@@ -6,7 +6,6 @@ const HEADERS = { "User-Agent": "dune-analytics" };
 const REQUEST_TIMEOUT_MS = 5_000;
 
 type ChainConfig = {
-  chainName: string;
   liquidationsExportPath: string;
   start: string;
 };
@@ -20,21 +19,20 @@ type LiquidationsExport = {
   points?: LiquidationPoint[];
 };
 
+// Both chains publish the same export contract, so the only per-chain
+// difference is the path and the first-indexed-event date. DefiLlama
+// lists MultiversX under its legacy key, CHAIN.ELROND.
+// `start` is each chain's first day with data; an earlier date only
+// backfills zeros.
 const CHAIN_CONFIGS: Record<string, ChainConfig> = {
   [CHAIN.STELLAR]: {
-    chainName: "Stellar",
     liquidationsExportPath: "/integrations/lending/stellar/liquidations",
-    // Mainnet contracts were deployed at ledger 64140891,
-    // 2026-08-27T00:55Z. An earlier start only backfills zeros.
     start: "2026-08-27",
   },
-
-  // Add MultiversX later with the same API response shape:
-  // [CHAIN.MULTIVERSX]: {
-  //   chainName: "MultiversX",
-  //   liquidationsExportPath: "/integrations/lending/multiversx/liquidations",
-  //   start: "YYYY-MM-DD",
-  // },
+  [CHAIN.ELROND]: {
+    liquidationsExportPath: "/integrations/lending/multiversx/liquidations",
+    start: "2025-08-14",
+  },
 };
 
 function dayRange(timestamp: number) {
@@ -72,7 +70,6 @@ async function fetchLiquidations(options: FetchOptions) {
   const data = (await response.json()) as LiquidationsExport;
   const points = Array.isArray(data.points) ? data.points : [];
 
-  // Collateral seized from liquidated borrowers (USD), summed over the day.
   const dailyCollateralLiquidated = sumField(points, "seizedUsd");
 
   return { dailyCollateralLiquidated };

--- a/new-users/xoxno-lending.ts
+++ b/new-users/xoxno-lending.ts
@@ -6,7 +6,6 @@ const HEADERS = { "User-Agent": "dune-analytics" };
 const REQUEST_TIMEOUT_MS = 5_000;
 
 type ChainConfig = {
-  chainName: string;
   userStatsExportPath: string;
   start: string;
 };
@@ -18,21 +17,20 @@ type UserStatsExport = {
   transactions?: number;
 };
 
+// Both chains publish the same export contract, so the only per-chain
+// difference is the path and the first-indexed-event date. DefiLlama
+// lists MultiversX under its legacy key, CHAIN.ELROND.
+// `start` is each chain's first day with data; an earlier date only
+// backfills zeros.
 const CHAIN_CONFIGS: Record<string, ChainConfig> = {
   [CHAIN.STELLAR]: {
-    chainName: "Stellar",
     userStatsExportPath: "/integrations/lending/stellar/active-users",
-    // Mainnet contracts were deployed at ledger 64140891,
-    // 2026-08-27T00:55Z. An earlier start only backfills zeros.
     start: "2026-08-27",
   },
-
-  // Add MultiversX later with the same API response shape:
-  // [CHAIN.MULTIVERSX]: {
-  //   chainName: "MultiversX",
-  //   userStatsExportPath: "/integrations/lending/multiversx/active-users",
-  //   start: "YYYY-MM-DD",
-  // },
+  [CHAIN.ELROND]: {
+    userStatsExportPath: "/integrations/lending/multiversx/active-users",
+    start: "2025-08-07",
+  },
 };
 
 function dayRange(timestamp: number) {
@@ -69,8 +67,6 @@ async function fetchUserStats(options: FetchOptions): Promise<UserStatsExport> {
 async function fetchNewUsers(options: FetchOptions) {
   const stats = await fetchUserStats(options);
 
-  // New owners = wallets whose first-ever lending action (global minimum)
-  // falls in the day. Counted by owner wallet, not sub-account.
   return {
     dailyNewUsers: Number(stats.newUsers ?? 0),
   };


### PR DESCRIPTION
XOXNO Lending is an overcollateralized lending protocol on MultiversX and Stellar.

This PR fixes the fees adapter. It was reporting only the protocol's cut as fees, so fees and revenue came out identical and supply side revenue was always zero. Fees are now the full interest paid by borrowers, split between the protocol and the suppliers.

It also adds MultiversX, which holds most of the protocol's TVL and was not tracked at all.