### PR TITLE
Add HertzFlow volume, fees, and open interest adapters

### DIFF
--- a/dexs/hertzflow.ts
+++ b/dexs/hertzflow.ts
@@ -1,0 +1,203 @@
+import { FetchOptions, FetchResultV2, SimpleAdapter } from '../adapters/types'
+import { CHAIN } from '../helpers/chains'
+
+// BSC mainnet EventEmitter: https://bscscan.com/address/0xf6030850365F79E7a8CAB31850A063199fd0CC10
+const EVENT_EMITTER = '0xf6030850365F79E7a8CAB31850A063199fd0CC10'
+// EventLog1 topic0 and indexed keccak256("PositionFeesCollected") event-name topic.
+const EVENT_LOG_1_TOPIC = '0x137a44067c8961cd7e1d876f4754a5a3a75989b4552f1843fc69c3b372def160'
+const POSITION_FEES_COLLECTED_TOPIC = '0xe096982abd597114bdaa4a60612f87fabfcc7206aa12d61c50e7ba1e6c291100'
+
+// GMX v2-compatible USD values use 30-decimal fixed-point precision:
+// https://github.com/gmx-io/gmx-synthetics/blob/main/contracts/utils/Precision.sol#L23
+const USD_DECIMALS = 30
+const USD_PRECISION = 10n ** BigInt(USD_DECIMALS)
+
+// BSC mainnet token contracts:
+// HFUSD: https://bscscan.com/address/0x7F7AD43d1Baa6BeA7f53F72D97D90b4FC0f662DF
+// HFUSD1: https://bscscan.com/address/0x026C39Ab4B07f4C8C62b5824F0F9D7BE5087405a
+// U: https://bscscan.com/address/0xcE24439F2D9C6a2289F741120FE202248B666666
+// USD1: https://bscscan.com/address/0x8d0D000Ee44948FC98c9B98A4FA4921476f08B0d
+const HFUSD = '0x7F7AD43d1Baa6BeA7f53F72D97D90b4FC0f662DF'
+const HFUSD1 = '0x026C39Ab4B07f4C8C62b5824F0F9D7BE5087405a'
+const U = '0xcE24439F2D9C6a2289F741120FE202248B666666'
+const USD1 = '0x8d0D000Ee44948FC98c9B98A4FA4921476f08B0d'
+
+const WRAPPER_TO_UNDERLYING: Record<string, string> = {
+  [HFUSD.toLowerCase()]: U,
+  [HFUSD1.toLowerCase()]: USD1,
+}
+
+const EVENT_LOG_1_ABI = 'event EventLog1(address msgSender, string eventName, string indexed eventNameHash, bytes32 indexed topic1, tuple(tuple(tuple(string key, address value)[] items, tuple(string key, address[] value)[] arrayItems) addressItems, tuple(tuple(string key, uint256 value)[] items, tuple(string key, uint256[] value)[] arrayItems) uintItems, tuple(tuple(string key, int256 value)[] items, tuple(string key, int256[] value)[] arrayItems) intItems, tuple(tuple(string key, bool value)[] items, tuple(string key, bool[] value)[] arrayItems) boolItems, tuple(tuple(string key, bytes32 value)[] items, tuple(string key, bytes32[] value)[] arrayItems) bytes32Items, tuple(tuple(string key, bytes value)[] items, tuple(string key, bytes[] value)[] arrayItems) bytesItems, tuple(tuple(string key, string value)[] items, tuple(string key, string[] value)[] arrayItems) stringItems) eventData)'
+
+type KeyValue = { key?: string; value?: any; 0?: string; 1?: any }
+
+function toRecord(items: KeyValue[]): Record<string, any> {
+  return Object.fromEntries(items.map((item) => [item.key ?? item[0], item.value ?? item[1]]))
+}
+
+function value(record: Record<string, any>, key: string): bigint {
+  const item = record[key]
+  return item == null ? 0n : BigInt(item.toString())
+}
+
+function add(balance: any, token: string, amount: bigint, label: string) {
+  if (amount > 0n) balance.add(token, amount.toString(), label)
+}
+
+function assertSubtract(minuend: bigint, subtrahend: bigint, context: string): bigint {
+  if (subtrahend > minuend) {
+    throw new Error(`HertzFlow ${context} breakdown exceeds its gross amount`)
+  }
+  return minuend - subtrahend
+}
+
+function usd30(amount: bigint): string {
+  const fraction = (amount % USD_PRECISION).toString().padStart(USD_DECIMALS, '0').replace(/0+$/, '')
+  return `${amount / USD_PRECISION}${fraction ? `.${fraction}` : ''}`
+}
+
+const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
+  const dailyVolume = options.createBalances()
+  const dailyFees = options.createBalances()
+  const dailyUserFees = options.createBalances()
+  const dailyRevenue = options.createBalances()
+  const dailyProtocolRevenue = options.createBalances()
+  const dailySupplySideRevenue = options.createBalances()
+
+  // HertzFlow emits all protocol events through one universal contract. The
+  // event-name topic is therefore required to isolate PositionFeesCollected.
+  const logs = await options.getLogs({
+    targets: [EVENT_EMITTER],
+    topics: [EVENT_LOG_1_TOPIC, POSITION_FEES_COLLECTED_TOPIC],
+    eventAbi: EVENT_LOG_1_ABI,
+  })
+
+  for (const log of logs) {
+    const eventData = log.eventData ?? log[4]
+    const addresses = toRecord(eventData.addressItems.items)
+    const uints = toRecord(eventData.uintItems.items)
+    const collateralToken = addresses.collateralToken
+    const feeToken = WRAPPER_TO_UNDERLYING[collateralToken.toLowerCase()] ?? collateralToken
+
+    const tradeSizeUsd = value(uints, 'tradeSizeUsd')
+    const positionFee = value(uints, 'positionFeeAmount')
+    const traderDiscount = value(uints, 'referral.traderDiscountAmount')
+    const l1Reward = value(uints, 'referral.l1RewardAmount')
+    const l2Reward = value(uints, 'referral.l2RewardAmount')
+    const borrowingFee = value(uints, 'borrowingFeeAmount')
+    const borrowingToProtocol = value(uints, 'borrowingFeeAmountForFeeReceiver')
+    const liquidationFee = value(uints, 'liquidationFeeAmount')
+    const liquidationToProtocol = value(uints, 'liquidationFeeAmountForFeeReceiver')
+    const totalToProtocol = value(uints, 'feeReceiverAmount')
+    const positionToPool = value(uints, 'positionFeeAmountForPool')
+    const uiFee = value(uints, 'uiFeeAmount')
+
+    const positionUserFees = assertSubtract(positionFee, traderDiscount, 'trader discount')
+    const positionToProtocol = assertSubtract(
+      totalToProtocol,
+      borrowingToProtocol + liquidationToProtocol,
+      'protocol fee receiver',
+    )
+    const borrowingToPool = assertSubtract(borrowingFee, borrowingToProtocol, 'borrowing fee')
+    const liquidationToPool = assertSubtract(liquidationFee, liquidationToProtocol, 'liquidation fee')
+    const referralRewards = l1Reward + l2Reward
+    const positionCreditOffset = assertSubtract(
+      assertSubtract(positionUserFees, positionToProtocol, 'position fee protocol share'),
+      positionToPool + referralRewards,
+      'position fee supply-side share',
+    )
+
+    dailyVolume.addUSDValue(Number(usd30(tradeSizeUsd)), 'Perpetual Trading Volume')
+
+    add(dailyFees, feeToken, positionUserFees, 'Position Fees')
+    add(dailyFees, feeToken, borrowingFee, 'Borrowing Fees')
+    add(dailyFees, feeToken, liquidationFee, 'Liquidation Fees')
+    add(dailyFees, feeToken, uiFee, 'UI Fees')
+
+    add(dailyUserFees, feeToken, positionUserFees, 'Position Fees')
+    add(dailyUserFees, feeToken, borrowingFee, 'Borrowing Fees')
+    add(dailyUserFees, feeToken, liquidationFee, 'Liquidation Fees')
+    add(dailyUserFees, feeToken, uiFee, 'UI Fees')
+
+    add(dailyRevenue, feeToken, positionToProtocol, 'Position Fees To Protocol')
+    add(dailyRevenue, feeToken, borrowingToProtocol, 'Borrowing Fees To Protocol')
+    add(dailyRevenue, feeToken, liquidationToProtocol, 'Liquidation Fees To Protocol')
+
+    add(dailyProtocolRevenue, feeToken, positionToProtocol, 'Position Fees To Protocol')
+    add(dailyProtocolRevenue, feeToken, borrowingToProtocol, 'Borrowing Fees To Protocol')
+    add(dailyProtocolRevenue, feeToken, liquidationToProtocol, 'Liquidation Fees To Protocol')
+
+    add(dailySupplySideRevenue, feeToken, positionToPool, 'Position Fees To LPs')
+    add(dailySupplySideRevenue, feeToken, borrowingToPool, 'Borrowing Fees To LPs')
+    add(dailySupplySideRevenue, feeToken, liquidationToPool, 'Liquidation Fees To LPs')
+    add(dailySupplySideRevenue, feeToken, referralRewards, 'Referral Rewards')
+    add(dailySupplySideRevenue, feeToken, uiFee, 'UI Fees To Integrators')
+    add(dailySupplySideRevenue, feeToken, positionCreditOffset, 'Position Fees To Credit Claim Vault')
+  }
+
+  return {
+    dailyVolume,
+    dailyFees,
+    dailyUserFees,
+    dailyRevenue,
+    dailyProtocolRevenue,
+    dailySupplySideRevenue,
+  }
+}
+
+const methodology = {
+  Volume: 'Notional size of each executed position increase or decrease, including liquidation closes. Each PositionFeesCollected event represents one trader action, so no maker-side volume is added.',
+  Fees: 'Position fees paid after trading discounts, plus borrowing, liquidation, and UI fees. Funding transfers between traders are excluded.',
+  UserFees: 'All position, borrowing, liquidation, and UI fees actually paid by traders after referral discounts.',
+  Revenue: 'The position, borrowing, and liquidation fee amounts accrued as claimable protocol fees and withdrawable through FeeHandler.',
+  ProtocolRevenue: 'The protocol fee share of position, borrowing, and liquidation fees held through FeeHandler.',
+  SupplySideRevenue: 'Fees allocated to LPs, affiliates, UI integrators, and the credit fee claim vault.',
+}
+
+const breakdownMethodology = {
+  Volume: {
+    'Perpetual Trading Volume': 'Notional USD size executed against HertzFlow market liquidity.',
+  },
+  Fees: {
+    'Position Fees': 'Open and close fees paid by traders after trading discounts.',
+    'Borrowing Fees': 'Accrued borrowing fees paid when a position is updated or closed.',
+    'Liquidation Fees': 'Additional fee charged when a position is liquidated.',
+    'UI Fees': 'Optional fee charged by the interface selected by the trader.',
+  },
+  UserFees: {
+    'Position Fees': 'Open and close fees paid by traders after referral discounts.',
+    'Borrowing Fees': 'Accrued borrowing fees paid by traders.',
+    'Liquidation Fees': 'Liquidation fees paid by traders.',
+    'UI Fees': 'Optional interface fees paid by traders.',
+  },
+  Revenue: {
+    'Position Fees To Protocol': 'Protocol fee receiver share of position fees after rebates.',
+    'Borrowing Fees To Protocol': 'Protocol fee receiver share of borrowing fees.',
+    'Liquidation Fees To Protocol': 'Protocol fee receiver share of liquidation fees.',
+  },
+  ProtocolRevenue: {
+    'Position Fees To Protocol': 'Protocol fee receiver share of position fees after rebates.',
+    'Borrowing Fees To Protocol': 'Protocol fee receiver share of borrowing fees.',
+    'Liquidation Fees To Protocol': 'Protocol fee receiver share of liquidation fees.',
+  },
+  SupplySideRevenue: {
+    'Position Fees To LPs': 'Position fee share retained by market liquidity providers.',
+    'Borrowing Fees To LPs': 'Borrowing fee share retained by market liquidity providers.',
+    'Liquidation Fees To LPs': 'Liquidation fee share retained by market liquidity providers.',
+    'Referral Rewards': 'Position fee rebates paid to first- and second-level affiliates.',
+    'UI Fees To Integrators': 'UI fees paid to external interface operators.',
+    'Position Fees To Credit Claim Vault': 'LP-bound position fees transferred to the credit claim vault when a trader applies a credit fee offset.',
+  },
+}
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  pullHourly: true,
+  chains: [CHAIN.BSC],
+  start: '2026-08-14',
+  fetch,
+  methodology,
+  breakdownMethodology,
+}
+
+export default adapter

--- a/open-interest/hertzflow.ts
+++ b/open-interest/hertzflow.ts
@@ -1,4 +1,3 @@
-import { ChainApi } from '@defillama/sdk'
 import { AbiCoder, keccak256 } from 'ethers'
 import { FetchOptions, SimpleAdapter } from '../adapters/types'
 import { CHAIN } from '../helpers/chains'
@@ -34,10 +33,7 @@ function usd30(amount: bigint): string {
 }
 
 const fetch = async (options: FetchOptions) => {
-  // runAtCurrTime makes this a latest-state snapshot, so avoid pinning calls to
-  // a recent BSC block whose state may already be pruned by public RPCs.
-  const api = new ChainApi({ chain: options.chain })
-  const markets: any[] = await api.call({
+  const markets: any[] = await options.api.call({
     target: READER,
     abi: GET_MARKETS_ABI,
     params: [DATA_STORE, 0, MAX_MARKETS],
@@ -55,7 +51,7 @@ const fetch = async (options: FetchOptions) => {
     }
   }
 
-  const values = await api.multiCall({
+  const values = await options.api.multiCall({
     target: DATA_STORE,
     abi: GET_UINT_ABI,
     calls,
@@ -79,7 +75,6 @@ const fetch = async (options: FetchOptions) => {
 const adapter: SimpleAdapter = {
   version: 2,
   pullHourly: false, // OI is a snapshot; hourly records would be summed into the daily value
-  runAtCurrTime: true, // BSC public RPCs prune historical state quickly; OI is a current snapshot
   chains: [CHAIN.BSC],
   start: '2026-08-14',
   fetch,

--- a/open-interest/hertzflow.ts
+++ b/open-interest/hertzflow.ts
@@ -1,0 +1,91 @@
+import { ChainApi } from '@defillama/sdk'
+import { AbiCoder, keccak256 } from 'ethers'
+import { FetchOptions, SimpleAdapter } from '../adapters/types'
+import { CHAIN } from '../helpers/chains'
+
+// BSC mainnet DataStore: https://bscscan.com/address/0xc244A37A17CE7aa14E1BDD73f6a047Ed6B56f6B8
+const DATA_STORE = '0xc244A37A17CE7aa14E1BDD73f6a047Ed6B56f6B8'
+// BSC mainnet Reader: https://bscscan.com/address/0xFC370bA161F4B54B12574c7e0a2121Cea57854A1
+const READER = '0xFC370bA161F4B54B12574c7e0a2121Cea57854A1'
+// Upper bound for Reader pagination; the current deployment has four markets.
+const MAX_MARKETS = 1000
+// GMX v2-compatible USD values use 30-decimal fixed-point precision:
+// https://github.com/gmx-io/gmx-synthetics/blob/main/contracts/utils/Precision.sol#L23
+const USD_DECIMALS = 30
+const USD_PRECISION = 10n ** BigInt(USD_DECIMALS)
+
+const GET_MARKETS_ABI = 'function getMarkets(address dataStore, uint256 start, uint256 end) view returns (tuple(address marketToken, address indexToken, address longToken, address shortToken)[])'
+const GET_UINT_ABI = 'function getUint(bytes32 key) view returns (uint256)'
+const coder = AbiCoder.defaultAbiCoder()
+const OPEN_INTEREST = keccak256(coder.encode(['string'], ['OPEN_INTEREST']))
+
+function openInterestKey(market: string, collateralToken: string, isLong: boolean): string {
+  return keccak256(
+    coder.encode(
+      ['bytes32', 'address', 'address', 'bool'],
+      [OPEN_INTEREST, market, collateralToken, isLong],
+    ),
+  )
+}
+
+function usd30(amount: bigint): string {
+  const fraction = (amount % USD_PRECISION).toString().padStart(USD_DECIMALS, '0').replace(/0+$/, '')
+  return `${amount / USD_PRECISION}${fraction ? `.${fraction}` : ''}`
+}
+
+const fetch = async (options: FetchOptions) => {
+  // runAtCurrTime makes this a latest-state snapshot, so avoid pinning calls to
+  // a recent BSC block whose state may already be pruned by public RPCs.
+  const api = new ChainApi({ chain: options.chain })
+  const markets: any[] = await api.call({
+    target: READER,
+    abi: GET_MARKETS_ABI,
+    params: [DATA_STORE, 0, MAX_MARKETS],
+  })
+
+  const calls: { params: [string]; isLong: boolean }[] = []
+  for (const market of markets) {
+    const marketToken = market.marketToken ?? market[0]
+    const longToken = market.longToken ?? market[2]
+    const shortToken = market.shortToken ?? market[3]
+
+    for (const collateralToken of new Set<string>([longToken, shortToken])) {
+      calls.push({ params: [openInterestKey(marketToken, collateralToken, true)], isLong: true })
+      calls.push({ params: [openInterestKey(marketToken, collateralToken, false)], isLong: false })
+    }
+  }
+
+  const values = await api.multiCall({
+    target: DATA_STORE,
+    abi: GET_UINT_ABI,
+    calls,
+  })
+
+  let longOpenInterest = 0n
+  let shortOpenInterest = 0n
+  values.forEach((item: any, index: number) => {
+    const amount = BigInt(item.toString())
+    if (calls[index].isLong) longOpenInterest += amount
+    else shortOpenInterest += amount
+  })
+
+  return {
+    openInterestAtEnd: usd30(longOpenInterest + shortOpenInterest),
+    longOpenInterestAtEnd: usd30(longOpenInterest),
+    shortOpenInterestAtEnd: usd30(shortOpenInterest),
+  }
+}
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  pullHourly: false, // OI is a snapshot; hourly records would be summed into the daily value
+  runAtCurrTime: true, // BSC public RPCs prune historical state quickly; OI is a current snapshot
+  chains: [CHAIN.BSC],
+  start: '2026-08-14',
+  fetch,
+  methodology: {
+    OpenInterest: 'Current long and short notional open interest in USD across every HertzFlow market and supported collateral token, read from the latest DataStore state.',
+  },
+}
+
+export default adapter


### PR DESCRIPTION
Adds HertzFlow's BNB Chain perpetual volume, fees/revenue, and open-interest adapters.

Implementation summary:

- Volume uses `tradeSizeUsd` from one `PositionFeesCollected` event per executed trader action, avoiding maker/taker double counting.
- Fees split position fees paid after trading discounts, borrowing fees, liquidation fees, and UI fees into protocol revenue and supply-side allocations for LPs, affiliates, UI integrators, and credit offsets.
- Funding transfers between traders are excluded from protocol fees.
- Open interest is read from the latest `DataStore` state and runs as a current daily snapshot rather than an hourly flow.

Validation:

- `npm test -- dexs hertzflow 2026-08-28`
  - Daily volume: approximately $1.73M
  - Daily fees: approximately $827.08
  - Daily user fees: approximately $827.08
  - Daily protocol revenue: approximately $284.06
- `npm test -- open-interest hertzflow 1788170685`
  - Total OI at validation time: approximately $62.79K
  - Long OI: approximately $44.09K; short OI: approximately $18.70K
- `npm run ts-check -- --pretty false`
- Raw per-token balances satisfy `dailyFees = dailyRevenue + dailySupplySideRevenue` exactly.

##### Name (to be shown on DefiLlama):

HertzFlow

##### Twitter Link:

https://x.com/Hertzflow_xyz

##### List of audit links if any:

- [BlockSec HertzFlow Perpetual Contracts Audit](https://219277942-files.gitbook.io/~/files/v0/b/gitbook-x-prod.appspot.com/o/spaces%2FhOhbsStDwzyOGMriEWAP%2Fuploads%2FB7m5dRF5hSpAGXOaW1X9%2Fblocksec_hertzflow_perp_contracts_signed_20260715.pdf?alt=media&token=6886fba4-79d9-4afb-9f75-85afbc5dc338)
- [CertiK HertzFlow Audit](https://219277942-files.gitbook.io/~/files/v0/b/gitbook-x-prod.appspot.com/o/spaces%2FhOhbsStDwzyOGMriEWAP%2Fuploads%2FzLJU26hyCg73IWhPRCZF%2FCertiK-REP-Hertzflow---Audit__final-20260828T012948Z%20(1).pdf?alt=media&token=fd11f6a5-f98b-4d2d-a56f-4c43261d2e86)

##### Website Link:

https://www.hertzflow.xyz/

##### Logo (High resolution, will be shown with rounded borders):

https://www.hertzflow.xyz/home-static/mediakit/logo.png

##### Current TVL:

Approximately $6.13M on BNB Chain at the time of submission.

##### Treasury Addresses (if the protocol has treasury)

0x4E9D7c8dB803E85Cc7B369176Ed6e4f9Ab6bC597 (FeeHandler; protocol fee custody contract)

##### Chain:

BNB Chain

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed):


##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed):


##### Short Description (to be shown on DefiLlama):

HertzFlow is a permissionless, self-custodial perpetuals exchange on BNB Chain with isolated liquidity pools and multi-market liquidity vaults.

##### Token address and ticker if any:

No enabled governance token. A GovToken contract was deployed but is disabled in the BSC mainnet role configuration.

##### Category (full list at https://defillama.com/categories) *Please choose only one:

Derivatives

##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.):

HertzFlow's signed `gmOracle` provider. The official documentation describes Pyth Network as the primary off-chain reference-price source and CEX index prices as fallback sources.

##### Implementation Details: Briefly describe how the oracle is integrated into your project:

Keepers submit signed minimum and maximum prices with user actions. The on-chain Oracle verifies authorized signers, timestamps, and configured deviation limits before the execution contracts consume those prices. Supported BSC tokens are configured to use the on-chain `gmOracle` provider; Pyth and CEX indexes are upstream reference sources rather than contracts called directly by the protocol.

##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage:

https://hertzflow.gitbook.io/hertzflow-docs/tech-docs/smart-contract

##### forkedFrom (Does your project originate from another project):

GMX Synthetics (GMX v2)

##### methodology (what is being counted as tvl, how is tvl being calculated):

Volume is the notional USD size of executed position increases and decreases. Fees are the position fees actually paid after trading discounts, plus borrowing, liquidation, and UI fees; all protocol and supply-side allocations are derived from the emitted fee breakdown. Funding transfers between traders are excluded. Open interest is the current sum of long and short USD notional stored for all markets and collateral tokens.

##### Github org/user (Optional, if your code is open source, we can track activity):


##### Does this project have a referral program?

Yes.
