### PR TITLE
rsk: point at the blockscout proxy, none of the configured rpcs can do getLogs

### DIFF
--- a/helpers/env.ts
+++ b/helpers/env.ts
@@ -38,6 +38,7 @@ const DEFAULTS: any = {
   ROBINHOOD_RPC: 'https://rpc.mainnet.chain.robinhood.com',
   RISE_ARCHIVAL_RPC: 'https://explorer.risechain.com/api/eth-rpc', // public rpc.risechain.com caps eth_getLogs at 5000 blocks
   RONIN_RPC: 'https://ronin.gateway.tenderly.co,https://gateway.tenderly.co/public/ronin',
+  RSK_RPC: 'https://rootstock.blockscout.com/api/eth-rpc', // none of the configured rsk rpcs implement eth_getLogs
   SHIDO_RPC: 'https://shidoscan.net/api/eth-rpc',
   SAGA_RPC: "https://sagaevm.jsonrpc.sagarpc.io",
   SAGA_WHITELISTED_RPC: 'https://sagaevm-archive.jsonrpc.sagarpc.io',

--- a/helpers/env.ts
+++ b/helpers/env.ts
@@ -38,7 +38,7 @@ const DEFAULTS: any = {
   ROBINHOOD_RPC: 'https://rpc.mainnet.chain.robinhood.com',
   RISE_ARCHIVAL_RPC: 'https://explorer.risechain.com/api/eth-rpc', // public rpc.risechain.com caps eth_getLogs at 5000 blocks
   RONIN_RPC: 'https://ronin.gateway.tenderly.co,https://gateway.tenderly.co/public/ronin',
-  RSK_RPC: 'https://rootstock.blockscout.com/api/eth-rpc', // none of the configured rsk rpcs implement eth_getLogs
+  RSK_RPC: 'https://rootstock.blockscout.com/api/eth-rpc', // the rsk hosts in providers.json have no eth_getLogs, this blockscout proxy does
   SHIDO_RPC: 'https://shidoscan.net/api/eth-rpc',
   SAGA_RPC: "https://sagaevm.jsonrpc.sagarpc.io",
   SAGA_WHITELISTED_RPC: 'https://sagaevm-archive.jsonrpc.sagarpc.io',


### PR DESCRIPTION
Same shape as #8746 (ronin), for rsk: every RPC configured for rsk in `providers.json` rejects `eth_getLogs`, so any log-based rsk adapter throws.

```
providers.json rsk.rpc = [
  https://rootstock.drpc.org,
  https://rsk-mainnet.gateway.tatum.io,
  https://mycrypto.rsk.co,
  https://public-node.rsk.co
]
```

I probed each with one day of blocks (2,880 at ~30s) against a real contract:

| host | `eth_blockNumber` | `eth_getLogs` |
|---|---|---|
| `rootstock.drpc.org` | ok | HTTP 400, `the method eth_getLogs does not exist/is not available` |
| `rsk-mainnet.gateway.tatum.io` | ok | `Requested range is over limit of 100`, and at 100-block chunks it returns `the method eth_getLogs does not exist/is not available` (0/12 chunks) |
| `mycrypto.rsk.co` | ok | `the method eth_getLogs does not exist/is not available` |
| `public-node.rsk.co` | ok | `the method eth_getLogs does not exist/is not available` |

So it is not a range cap that chunking gets around — three of the four don't implement the method, and the fourth doesn't either once you get past its range check.

Every other rsk endpoint I could find is unusable: `rootstock-mainnet.public.blastapi.io` 403 ("Blast API is no longer…"), `rpc.ankr.com/rootstock` 403, `rsk-mainnet.rpc.thirdweb.com` `Invalid chain`, `1rpc.io/rootstock` 400, and `rootstock.gateway.tenderly.co`, `gateway.tenderly.co/public/rootstock`, `rsk.public-rpc.com`, `rootstock-rpc.publicnode.com` 404 / do not resolve. `mainnet.sovryn.app/rpc` answers `eth_blockNumber` but also has no `eth_getLogs`.

The one that works is the Rootstock Blockscout proxy, which is the same idiom already used here for harmony, smartbch, fuse, swellchain, pulsechain, xrpl_evm, mantle, bitkub and rise:

| check | `rootstock.blockscout.com/api/eth-rpc` |
|---|---|
| `eth_getLogs`, 1 day | ok (4/4 repeats) |
| range 1k / 5k / 10k / 50k blocks | ok — no cap hit at 50,000 |
| archival: logs + `eth_getBlockByNumber` at ~1 day / 1 month / 6 months / 1 year back | ok at every depth |

Before/after through the SDK, same block range, `skipCacheRead: true` (the cache will happily serve a previous run, so this needs the flag):

```
without RSK_RPC:  getEventLogs(rsk, EisenSwapCompleted) -> throws
with    RSK_RPC:  getEventLogs(rsk, EisenSwapCompleted) -> 2 logs, blocks 9198380..9199893
```

`getChainRPCs` prepends the env value rather than replacing the list, so rsk becomes `[blockscout, drpc, tatum, mycrypto, public-node]` and the existing four stay as fallbacks:

```
providerConfigs: [
  'https://rootstock.blockscout.com/api/eth-rpc',
  'https://rootstock.drpc.org',
  'https://rsk-mainnet.gateway.tatum.io',
  'https://mycrypto.rsk.co',
  'https://public-node.rsk.co'
]
```

Adapters that call `getLogs` with rsk configured: `aggregators/eisen`, `aggregators/sushiswap-agg`, `fees/layerzero`, `fees/midas-rwa`, `fees/solv-finance`.

One caveat so this isn't oversold: eisen is currently dark (nothing since 2026-08-28) and rsk is the first thing that throws for it, but it is not the only one — `https://coins.llama.fi/block/cronos/<ts>` returns a 500 and the rsk fix alone doesn't get eisen to complete locally. That looks like a separate server-side issue rather than anything in this repo, so I've left it out of this PR.
