### PR TITLE
fwa: cap the buyback revenue leg at the fees the window recorded

### DIFF
--- a/fees/fwa/index.ts
+++ b/fees/fwa/index.ts
@@ -141,7 +141,13 @@ const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
     dailyProtocolRevenue.addGasToken(proRata(amount, teamShare), label);
     dailySupplySideRevenue.addGasToken(proRata(amount, nftHoldersShare), nftLabel);
   });
-  dailyRevenue.addGasToken(toTokenBuyback, METRICS.TokenBuyBack);
+  // ProtocolFeesToToken fires when the slice is paid out, which can be a later window than the
+  // one that accrued it, so it can exceed this window's protocolTake - that is why splitterShare
+  // clamps above. Book only the part this window actually earned as revenue, or revenue plus
+  // supply side would exceed the fees the window recorded. Holders revenue keeps the full amount:
+  // it is an attribution of the buyback and is allowed to land in a different window.
+  const buybackFromWindowFees = toTokenBuyback > protocolTake ? protocolTake : toTokenBuyback;
+  dailyRevenue.addGasToken(buybackFromWindowFees, METRICS.TokenBuyBack);
   dailyHoldersRevenue.addGasToken(toTokenBuyback, METRICS.TokenBuyBack);
 
   // Retroactive buybacks: 327 ETH of already-earned team fees swapped for FWA on a fixed


### PR DESCRIPTION
`GUIDELINES.md` says `dailyFees = dailyRevenue + dailySupplySideRevenue` holds within the same period. For fwa it doesn't: `dailyRevenue + dailySupplySideRevenue` exceeds `dailyFees` on 30 of the last 31 days.

### Cause

`ProtocolFeesToToken` is emitted when the slice is **paid out**, and the adapter runs hourly (`pullHourly: true`), so a payout can land in a later window than the fees that funded it. The code already anticipates this one step earlier:

```ts
let splitterShare = protocolTake - toTokenBuyback;
if (splitterShare < 0n) splitterShare = 0n;      // clamped
...
dailyRevenue.addGasToken(toTokenBuyback, METRICS.TokenBuyBack);   // not clamped
```

When `toTokenBuyback > protocolTake`, `splitterShare` clamps to 0 so the pro-rata components contribute nothing, but the *full* `toTokenBuyback` still goes into `dailyRevenue`. The window then books revenue against fees it never recorded:

- `toTokenBuyback <= protocolTake` → `revenue + supplySide = splitterShare + toTokenBuyback = protocolTake` ✅
- `toTokenBuyback > protocolTake` → `revenue + supplySide = 0 + toTokenBuyback > protocolTake` ❌

Capping the revenue leg at `protocolTake` makes both branches equal `protocolTake`. `dailyHoldersRevenue` deliberately keeps the full amount — per the same guidelines, `dailyRevenue = dailyProtocolRevenue + dailyHoldersRevenue` is "an attribution rule, not a per-day equality check", so a buyback is allowed to be attributed in a different window from the fees behind it.

### Size of it, measured two independent ways

Hourly reconstruction straight from the contract's own logs on `0xB276F62DB0ce8CA2Ca5bc522695bE604521eAc1c` — `SUM(GREATEST(ProtocolFeesToToken_hour − OwnerFeesAccrued_hour, 0))`:

| day | clamp excess (ETH) | ProtocolFeesToToken | OwnerFeesAccrued |
|---|---:|---:|---:|
| 2026-08-04 | 0.6175 | 5.4576 | 66.3063 |
| 2026-08-05 | 3.0608 | 11.7458 | 16.8633 |
| 2026-08-06 | 4.6792 | 20.2801 | 21.4883 |
| 2026-08-07 | 10.2671 | 31.6731 | 30.0282 |
| 2026-08-08 | 11.4537 | 21.9003 | 21.8493 |
| 2026-08-09 | 4.8741 | 18.7300 | 18.5134 |
| 2026-08-24 | 0.2321 | 113.4850 | 113.5149 |
| … | … | | |
| **2026-08-02 → 08-31** | **36.0574** | | |

Independently, summing the positive `dailyRevenue + dailySupplySideRevenue − dailyFees` from the published daily series over the same window gives **$70,997**, on 30 of 31 days.

Worth noting the tail, because it shows this is structural rather than a one-off from the ramp: from 2026-08-10 the two events match almost exactly at *daily* granularity (08-16: 8.1004 vs 8.1004; 08-29: 3.3532 vs 3.3532), yet the *hourly* windows still leak 0.005–0.23 ETH a day. The 97% concentration in 08-04..08-09 is just when the fee-to-buyback share was being ramped up; the mechanism keeps firing at a smaller scale.

### Not touching the other half

`dailyHoldersRevenue > dailyRevenue` on most days is **not** a defect and is left alone: it's the 327 ETH retroactive buyback added in #8598, a flat 11.94 ETH/day (12 × 0.995 ETH) from 2026-08-05, which `GUIDELINES.md` classifies under Tokenholder Income as off-statement. Its funding fees were already booked when they accrued, and the program ends when the budget runs out.

### Verification

Local run for 2026-08-06 with the change: fees 30.99k, revenue 39.85k, supply side −8.86k → revenue + supply side = 30.99k, exactly fees. The Token Buy Back row now shows revenue 29,550 against holders 34,585, i.e. only the part that window earned. (The adapter is log-heavy across an hourly window, so consecutive local runs don't reproduce the same totals; the on-chain reconstruction above is the deterministic measure.)
