### PR TITLE
icdex: read volume from the pair canisters, the aggregator's 24h cache never decays

### DIFF
--- a/dexs/ICDex/index.ts
+++ b/dexs/ICDex/index.ts
@@ -72,6 +72,9 @@ const methodology = {
 
 const adapter: Adapter = {
   version: 2,
+  // stats() only reports a trailing-24h figure for the moment it is called; there is no hourly
+  // series to pull, which is why the chain also runs at current time.
+  pullHourly: false,
   adapter: {
     [CHAIN.ICP]: {
       fetch: fetch,

--- a/dexs/ICDex/index.ts
+++ b/dexs/ICDex/index.ts
@@ -1,28 +1,83 @@
-import { Adapter, FetchResultVolume } from "../../adapters/types"
+import { Adapter, FetchOptions, FetchResultVolume } from "../../adapters/types"
 import { CHAIN } from "../../helpers/chains";
 import fetchURL from "../../utils/fetchURL";
+import { queryCanisterDecoded } from "../../helpers/icp";
+import { PromisePool } from "@supercharge/promise-pool";
 
+// ICLighthouse's aggregator is still the only directory of ICDex pairs, so the pair list
+// comes from it, but its `usd_24h_volume` is a cache that is only refreshed when a pair
+// trades and is never decayed back to zero, so an idle pair keeps reporting its last busy
+// day forever. The volume is read from each pair canister's own stats() instead.
+const TICKERS_URL = 'https://gwhbq-7aaaa-aaaar-qabya-cai.raw.icp0.io/v1/tickers';
 
-const fetch = async (): Promise<FetchResultVolume> => {
-	let historicalVolume = (await fetchURL('https://gwhbq-7aaaa-aaaar-qabya-cai.raw.icp0.io/v1/latest'));
-	let dailyVolume = 0;
-	for (let key in historicalVolume) {
-		dailyVolume = dailyVolume + Number(historicalVolume[key].usd_24h_volume);
-	}
-	return {
-		dailyVolume: dailyVolume,
-	}
+const STATS_LABELS = ['price', 'change24h', 'vol24h', 'totalVol', 'value0', 'value1'];
+
+// Quote tokens ICDex pairs settle in, mapped to the id used for pricing.
+const QUOTE_TOKEN_GECKO_IDS: Record<string, string> = {
+  'ryjl3-tyaaa-aaaaa-aaaba-cai': 'internet-computer', // ICP
+  'xevnm-gaaaa-aaaar-qafnq-cai': 'chain-key-usdc',    // ckUSDC
+  'mxzaz-hqaaa-aaaar-qaada-cai': 'chain-key-bitcoin', // ckBTC
 };
 
+interface Ticker {
+  ticker_id: string;
+  target_currency: string;
+  pool_id: string;
+}
+
+const fetch = async (options: FetchOptions): Promise<FetchResultVolume> => {
+  const dailyVolume = options.createBalances();
+  const tickers: Ticker[] = await fetchURL(TICKERS_URL);
+  if (!tickers?.length) throw new Error('ICDex: no pairs returned by the ICLighthouse tickers endpoint');
+
+  const decimalsByToken = new Map<string, number>();
+  const getDecimals = async (token: string) => {
+    if (!decimalsByToken.has(token))
+      decimalsByToken.set(token, Number(await queryCanisterDecoded(token, 'icrc1_decimals')));
+    return decimalsByToken.get(token)!;
+  };
+
+  // vol24h is the traded amount on each side of the pair over the trailing 24h; the quote
+  // leg is used because every pair settles in one of a few liquid tokens.
+  const { results, errors } = await PromisePool
+    .withConcurrency(5)
+    .for(tickers)
+    .process(async (ticker) => {
+      try {
+        const stats = await queryCanisterDecoded(ticker.pool_id, 'stats', STATS_LABELS);
+        return { ticker, quoteVolume: BigInt(stats.vol24h.value1) };
+      } catch (e: any) {
+        // IC0537 means the pair canister has no Wasm module installed, so it cannot trade and
+        // its volume is genuinely zero. Every other failure has to surface.
+        if (e?.errorCode !== 'IC0537') throw e;
+        return { ticker, quoteVolume: 0n };
+      }
+    });
+  if (errors.length) throw errors[0].raw ?? errors[0];
+
+  for (const { ticker, quoteVolume } of results) {
+    if (quoteVolume === 0n) continue;
+    const geckoId = QUOTE_TOKEN_GECKO_IDS[ticker.target_currency];
+    if (!geckoId) throw new Error(`ICDex: no price source for quote token ${ticker.target_currency} (pair ${ticker.ticker_id})`);
+    dailyVolume.addCGToken(geckoId, Number(quoteVolume) / 10 ** await getDecimals(ticker.target_currency));
+  }
+
+  return { dailyVolume };
+};
+
+const methodology = {
+  Volume: "Trailing 24h traded amount reported by each ICDex pair canister's stats() call, valued on the quote-token side of every pair.",
+};
 
 const adapter: Adapter = {
-	adapter: {
-		[CHAIN.ICP]: {
-			fetch: fetch,
-			runAtCurrTime: true,
-			start: '2024-01-16',
-		},
-	}
+  adapter: {
+    [CHAIN.ICP]: {
+      fetch: fetch,
+      runAtCurrTime: true,
+      start: '2024-01-16',
+    },
+  },
+  methodology,
 };
 
 export default adapter;

--- a/dexs/ICDex/index.ts
+++ b/dexs/ICDex/index.ts
@@ -50,6 +50,7 @@ const fetch = async (options: FetchOptions): Promise<FetchResultVolume> => {
         // IC0537 means the pair canister has no Wasm module installed, so it cannot trade and
         // its volume is genuinely zero. Every other failure has to surface.
         if (e?.errorCode !== 'IC0537') throw e;
+        console.info(`ICDex: pair canister ${ticker.pool_id} has no Wasm module installed (${e?.errorCode}), counting it as zero volume`);
         return { ticker, quoteVolume: 0n };
       }
     });
@@ -70,6 +71,7 @@ const methodology = {
 };
 
 const adapter: Adapter = {
+  version: 2,
   adapter: {
     [CHAIN.ICP]: {
       fetch: fetch,

--- a/dexs/ICDex/index.ts
+++ b/dexs/ICDex/index.ts
@@ -12,6 +12,8 @@ const TICKERS_URL = 'https://gwhbq-7aaaa-aaaar-qabya-cai.raw.icp0.io/v1/tickers'
 
 const STATS_LABELS = ['price', 'change24h', 'vol24h', 'totalVol', 'value0', 'value1'];
 
+const LABEL = 'Spot trades';
+
 // Quote tokens ICDex pairs settle in, mapped to the id used for pricing.
 const QUOTE_TOKEN_GECKO_IDS: Record<string, string> = {
   'ryjl3-tyaaa-aaaaa-aaaba-cai': 'internet-computer', // ICP
@@ -60,7 +62,7 @@ const fetch = async (options: FetchOptions): Promise<FetchResultVolume> => {
     if (quoteVolume === 0n) continue;
     const geckoId = QUOTE_TOKEN_GECKO_IDS[ticker.target_currency];
     if (!geckoId) throw new Error(`ICDex: no price source for quote token ${ticker.target_currency} (pair ${ticker.ticker_id})`);
-    dailyVolume.addCGToken(geckoId, Number(quoteVolume) / 10 ** await getDecimals(ticker.target_currency));
+    dailyVolume.addCGToken(geckoId, Number(quoteVolume) / 10 ** await getDecimals(ticker.target_currency), LABEL);
   }
 
   return { dailyVolume };
@@ -68,6 +70,12 @@ const fetch = async (options: FetchOptions): Promise<FetchResultVolume> => {
 
 const methodology = {
   Volume: "Trailing 24h traded amount reported by each ICDex pair canister's stats() call, valued on the quote-token side of every pair.",
+};
+
+const breakdownMethodology = {
+  Volume: {
+    [LABEL]: "Trailing 24h traded amount on ICDex's order-book pairs, counted once per pair on its quote token (ICP, ckUSDC or ckBTC) so the two sides of a trade are not both counted.",
+  },
 };
 
 const adapter: Adapter = {
@@ -83,6 +91,7 @@ const adapter: Adapter = {
     },
   },
   methodology,
+  breakdownMethodology,
 };
 
 export default adapter;

--- a/helpers/icp.ts
+++ b/helpers/icp.ts
@@ -216,14 +216,26 @@ function decodeSleb128(bytes: Uint8Array, state: CursorState): bigint {
 
 // --- Candid decoder ---
 
-// Candid identifies record fields by a hash of their name, so callers pass a
-// { hash: name } map built with this to get readable keys back.
+/**
+ * Candid identifies a record field by a hash of its name rather than the name itself, so a decoded
+ * record comes back keyed by number. Build a `{ [hash]: name }` map with this to get readable keys.
+ * @param label the field name as written in the canister's Candid interface, e.g. `vol24h`
+ * @returns the 32-bit Candid field hash
+ */
 export function hashCandidLabel(label: string): number {
   let out = 0
   for (const codePoint of Buffer.from(label, 'utf8')) out = (out * 223 + codePoint) >>> 0
   return out
 }
 
+/**
+ * Decode a Candid-encoded reply. Candid is self-describing, so the concrete shape is only known at
+ * runtime and values are returned as `any`; narrow them at the adapter boundary. `nat`/`nat64`
+ * decode to `bigint`, `float64` to `number`, `opt` to a 0- or 1-element array.
+ * @param bytes the raw `DIDL...` payload returned by {@link queryCanister}
+ * @param labelHashMap `{ [hash]: name }` from {@link hashCandidLabel}; unmapped fields keep their hash
+ * @returns one entry per value in the reply tuple
+ */
 export function decodeCandid(bytes: Uint8Array, labelHashMap: Record<number, string> = {}): any[] {
   const state: CursorState = { i: 0 }
   if (Buffer.from(bytes.slice(0, 4)).toString('ascii') !== 'DIDL') throw new Error('Invalid Candid payload')
@@ -388,6 +400,12 @@ function principalTextToBytes(principalText: string): Buffer {
 
 // --- Query call ---
 
+/**
+ * Call a zero-argument query method on an Internet Computer canister and return the raw Candid reply.
+ * Throws on a replica reject, with `errorCode`/`rejectCode` attached so callers can distinguish a
+ * permanently dead canister (`IC0537`, no Wasm module installed) from a transient failure.
+ * @returns the raw `DIDL...` bytes, to be passed to {@link decodeCandid}
+ */
 export async function queryCanister({
   canisterId,
   methodName,
@@ -435,7 +453,11 @@ export async function queryCanister({
   }
 }
 
-// Convenience: query a zero-arg method and decode the reply in one step.
+/**
+ * Query a zero-argument method and decode its reply in one step.
+ * @param labels field names to resolve in the decoded records, e.g. `['vol24h', 'value1']`
+ * @returns the first value of the reply tuple, `any` for the reason given on {@link decodeCandid}
+ */
 export async function queryCanisterDecoded(
   canisterId: string,
   methodName: string,

--- a/helpers/icp.ts
+++ b/helpers/icp.ts
@@ -1,0 +1,448 @@
+// Minimal Internet Computer agent: CBOR + Candid, no extra dependencies.
+// Ported from DefiLlama-Adapters `projects/helper/chain/icp.js`, which liquidium and
+// onesec already use for TVL. Kept structurally identical so the two can be diffed.
+//
+// Only zero-argument query calls are supported, which is all any adapter here needs.
+
+const ICP_HOST = 'https://icp-api.io'
+const CANISTER_TIMEOUT_MS = 30_000
+const MAX_SAFE_BIGINT = BigInt(Number.MAX_SAFE_INTEGER)
+
+const CANDID_TYPE = {
+  null: -1,
+  bool: -2,
+  nat: -3,
+  int: -4,
+  nat8: -5,
+  nat64: -8,
+  float64: -14,
+  text: -15,
+  opt: -18,
+  vec: -19,
+  record: -20,
+  variant: -21,
+  principal: -24,
+}
+
+type CursorState = { i: number }
+
+// --- CBOR encoder ---
+
+function encodeCborHead(major: number, value: number | bigint): Buffer {
+  const n = BigInt(value)
+  if (n < 24n) return Buffer.from([(major << 5) | Number(n)])
+  if (n <= 0xffn) return Buffer.from([(major << 5) | 24, Number(n)])
+  if (n <= 0xffffn) return Buffer.from([(major << 5) | 25, Number((n >> 8n) & 0xffn), Number(n & 0xffn)])
+  if (n <= 0xffffffffn)
+    return Buffer.from([
+      (major << 5) | 26,
+      Number((n >> 24n) & 0xffn),
+      Number((n >> 16n) & 0xffn),
+      Number((n >> 8n) & 0xffn),
+      Number(n & 0xffn),
+    ])
+  const out = Buffer.alloc(9)
+  out[0] = (major << 5) | 27
+  for (let i = 0; i < 8; i++) out[1 + i] = Number((n >> BigInt(56 - i * 8)) & 0xffn)
+  return out
+}
+
+function encodeCbor(value: any): Buffer {
+  if (value === null) return Buffer.from([0xf6])
+  if (value === false) return Buffer.from([0xf4])
+  if (value === true) return Buffer.from([0xf5])
+
+  if (typeof value === 'number') {
+    if (!Number.isInteger(value) || value < 0) throw new Error('CBOR encoder only supports non-negative integers')
+    return encodeCborHead(0, BigInt(value))
+  }
+  if (typeof value === 'bigint') {
+    if (value < 0n) throw new Error('CBOR encoder only supports non-negative bigint')
+    return encodeCborHead(0, value)
+  }
+  if (Buffer.isBuffer(value) || value instanceof Uint8Array) {
+    const bytes = Buffer.from(value)
+    return Buffer.concat([encodeCborHead(2, bytes.length), bytes])
+  }
+  if (typeof value === 'string') {
+    const bytes = Buffer.from(value, 'utf8')
+    return Buffer.concat([encodeCborHead(3, bytes.length), bytes])
+  }
+  if (Array.isArray(value)) return Buffer.concat([encodeCborHead(4, value.length), ...value.map(encodeCbor)])
+  if (typeof value === 'object') {
+    const keys = Object.keys(value)
+    const chunks = [encodeCborHead(5, keys.length)]
+    for (const key of keys) {
+      chunks.push(encodeCbor(key))
+      chunks.push(encodeCbor(value[key]))
+    }
+    return Buffer.concat(chunks)
+  }
+  throw new Error(`Unsupported CBOR value type: ${typeof value}`)
+}
+
+// --- CBOR decoder ---
+
+function readCborUint(bytes: Uint8Array, state: CursorState, additionalInfo: number): bigint {
+  if (additionalInfo < 24) return BigInt(additionalInfo)
+  if (additionalInfo === 24) return BigInt(bytes[state.i++])
+  if (additionalInfo === 25) {
+    const out = (BigInt(bytes[state.i]) << 8n) | BigInt(bytes[state.i + 1])
+    state.i += 2
+    return out
+  }
+  if (additionalInfo === 26) {
+    const out =
+      (BigInt(bytes[state.i]) << 24n) |
+      (BigInt(bytes[state.i + 1]) << 16n) |
+      (BigInt(bytes[state.i + 2]) << 8n) |
+      BigInt(bytes[state.i + 3])
+    state.i += 4
+    return out
+  }
+  if (additionalInfo === 27) {
+    let out = 0n
+    for (let i = 0; i < 8; i++) out = (out << 8n) | BigInt(bytes[state.i++])
+    return out
+  }
+  throw new Error(`Unsupported CBOR additional info ${additionalInfo}`)
+}
+
+function decodeCbor(bytes: Uint8Array, state: CursorState = { i: 0 }): any {
+  const first = bytes[state.i++]
+  const major = first >> 5
+  const additionalInfo = first & 0x1f
+
+  if (major === 0) {
+    const out = readCborUint(bytes, state, additionalInfo)
+    return out <= MAX_SAFE_BIGINT ? Number(out) : out
+  }
+  if (major === 1) {
+    const out = -1n - readCborUint(bytes, state, additionalInfo)
+    return out >= BigInt(Number.MIN_SAFE_INTEGER) ? Number(out) : out
+  }
+  if (major === 2) {
+    if (additionalInfo === 31) {
+      const parts: Buffer[] = []
+      while (bytes[state.i] !== 0xff) parts.push(Buffer.from(decodeCbor(bytes, state)))
+      state.i += 1
+      return Buffer.concat(parts)
+    }
+    const length = Number(readCborUint(bytes, state, additionalInfo))
+    const out = bytes.slice(state.i, state.i + length)
+    state.i += length
+    return out
+  }
+  if (major === 3) {
+    if (additionalInfo === 31) {
+      let out = ''
+      while (bytes[state.i] !== 0xff) out += decodeCbor(bytes, state)
+      state.i += 1
+      return out
+    }
+    const length = Number(readCborUint(bytes, state, additionalInfo))
+    const out = Buffer.from(bytes.slice(state.i, state.i + length)).toString('utf8')
+    state.i += length
+    return out
+  }
+  if (major === 4) {
+    if (additionalInfo === 31) {
+      const out: any[] = []
+      while (bytes[state.i] !== 0xff) out.push(decodeCbor(bytes, state))
+      state.i += 1
+      return out
+    }
+    const length = Number(readCborUint(bytes, state, additionalInfo))
+    const out: any[] = []
+    for (let i = 0; i < length; i++) out.push(decodeCbor(bytes, state))
+    return out
+  }
+  if (major === 5) {
+    if (additionalInfo === 31) {
+      const out: any = {}
+      while (bytes[state.i] !== 0xff) {
+        const key = decodeCbor(bytes, state)
+        out[key] = decodeCbor(bytes, state)
+      }
+      state.i += 1
+      return out
+    }
+    const length = Number(readCborUint(bytes, state, additionalInfo))
+    const out: any = {}
+    for (let i = 0; i < length; i++) {
+      const key = decodeCbor(bytes, state)
+      out[key] = decodeCbor(bytes, state)
+    }
+    return out
+  }
+  if (major === 6) {
+    readCborUint(bytes, state, additionalInfo)
+    return decodeCbor(bytes, state)
+  }
+  if (major === 7) {
+    if (additionalInfo === 20) return false
+    if (additionalInfo === 21) return true
+    if (additionalInfo === 22) return null
+  }
+  throw new Error(`Unsupported CBOR major type ${major} with additional info ${additionalInfo}`)
+}
+
+// --- LEB128 ---
+
+function decodeUleb128(bytes: Uint8Array, state: CursorState): bigint {
+  let out = 0n
+  let shift = 0n
+  while (true) {
+    const byte = bytes[state.i++]
+    out |= BigInt(byte & 0x7f) << shift
+    if ((byte & 0x80) === 0) return out
+    shift += 7n
+  }
+}
+
+function decodeSleb128(bytes: Uint8Array, state: CursorState): bigint {
+  let out = 0n
+  let shift = 0n
+  let byte = 0
+  while (true) {
+    byte = bytes[state.i++]
+    out |= BigInt(byte & 0x7f) << shift
+    shift += 7n
+    if ((byte & 0x80) === 0) break
+  }
+  if (byte & 0x40) out |= -1n << shift
+  return out
+}
+
+// --- Candid decoder ---
+
+// Candid identifies record fields by a hash of their name, so callers pass a
+// { hash: name } map built with this to get readable keys back.
+export function hashCandidLabel(label: string): number {
+  let out = 0
+  for (const codePoint of Buffer.from(label, 'utf8')) out = (out * 223 + codePoint) >>> 0
+  return out
+}
+
+export function decodeCandid(bytes: Uint8Array, labelHashMap: Record<number, string> = {}): any[] {
+  const state: CursorState = { i: 0 }
+  if (Buffer.from(bytes.slice(0, 4)).toString('ascii') !== 'DIDL') throw new Error('Invalid Candid payload')
+  state.i = 4
+
+  const typeCount = Number(decodeUleb128(bytes, state))
+  const typeTable: any[] = []
+  const readTypeRef = () => Number(decodeSleb128(bytes, state))
+
+  for (let i = 0; i < typeCount; i++) {
+    const kind = Number(decodeSleb128(bytes, state))
+    if (kind === CANDID_TYPE.opt || kind === CANDID_TYPE.vec) {
+      typeTable.push({ kind, type: readTypeRef() })
+      continue
+    }
+    if (kind === CANDID_TYPE.record || kind === CANDID_TYPE.variant) {
+      const fieldCount = Number(decodeUleb128(bytes, state))
+      const fields: any[] = []
+      for (let j = 0; j < fieldCount; j++) {
+        const id = Number(decodeUleb128(bytes, state))
+        const type = readTypeRef()
+        fields.push({ id, type })
+      }
+      typeTable.push({ kind, fields })
+      continue
+    }
+    throw new Error(`Unsupported Candid type table kind ${kind}`)
+  }
+
+  const argCount = Number(decodeUleb128(bytes, state))
+  const argTypes: number[] = []
+  for (let i = 0; i < argCount; i++) argTypes.push(readTypeRef())
+
+  const decodeType = (typeRef: number): any => {
+    if (typeRef >= 0) {
+      const definition = typeTable[typeRef]
+      if (!definition) throw new Error(`Unknown Candid type ref ${typeRef}`)
+
+      if (definition.kind === CANDID_TYPE.opt) {
+        const tag = bytes[state.i++]
+        if (tag === 0) return []
+        if (tag === 1) return [decodeType(definition.type)]
+        throw new Error(`Invalid Candid opt tag ${tag}`)
+      }
+      if (definition.kind === CANDID_TYPE.vec) {
+        const length = Number(decodeUleb128(bytes, state))
+        const out: any[] = []
+        for (let i = 0; i < length; i++) out.push(decodeType(definition.type))
+        return out
+      }
+      if (definition.kind === CANDID_TYPE.record) {
+        const out: any = {}
+        for (const field of definition.fields) out[labelHashMap[field.id] || String(field.id)] = decodeType(field.type)
+        return out
+      }
+      if (definition.kind === CANDID_TYPE.variant) {
+        const index = Number(decodeUleb128(bytes, state))
+        const selectedField = definition.fields[index]
+        if (!selectedField) throw new Error(`Invalid Candid variant index ${index}`)
+        return { [labelHashMap[selectedField.id] || String(selectedField.id)]: decodeType(selectedField.type) }
+      }
+      throw new Error(`Unsupported Candid composite kind ${definition.kind}`)
+    }
+
+    if (typeRef === CANDID_TYPE.null) return null
+    if (typeRef === CANDID_TYPE.bool) {
+      const value = bytes[state.i++]
+      if (value !== 0 && value !== 1) throw new Error(`Invalid Candid bool value ${value}`)
+      return value === 1
+    }
+    if (typeRef === CANDID_TYPE.nat) return decodeUleb128(bytes, state)
+    if (typeRef === CANDID_TYPE.int) return decodeSleb128(bytes, state)
+    if (typeRef === CANDID_TYPE.nat8) return bytes[state.i++]
+    if (typeRef === CANDID_TYPE.nat64) {
+      let out = 0n
+      for (let i = 0; i < 8; i++) out |= BigInt(bytes[state.i++]) << BigInt(i * 8)
+      return out
+    }
+    if (typeRef === CANDID_TYPE.float64) {
+      const out = Buffer.from(bytes.slice(state.i, state.i + 8)).readDoubleLE()
+      state.i += 8
+      return out
+    }
+    if (typeRef === CANDID_TYPE.text) {
+      const length = Number(decodeUleb128(bytes, state))
+      const out = Buffer.from(bytes.slice(state.i, state.i + length)).toString('utf8')
+      state.i += length
+      return out
+    }
+    if (typeRef === CANDID_TYPE.principal) {
+      const principalTag = bytes[state.i++]
+      if (principalTag !== 1) throw new Error(`Invalid Candid principal tag ${principalTag}`)
+      const length = Number(decodeUleb128(bytes, state))
+      const principalBytes = bytes.slice(state.i, state.i + length)
+      state.i += length
+      return principalBytesToText(principalBytes)
+    }
+    throw new Error(`Unsupported Candid primitive type ${typeRef}`)
+  }
+
+  return argTypes.map(decodeType)
+}
+
+// --- Principal text <-> bytes ---
+
+function crc32(bytes: Uint8Array): number {
+  let crc = 0xffffffff
+  for (const value of bytes) {
+    crc ^= value
+    for (let i = 0; i < 8; i++) {
+      const mask = -(crc & 1)
+      crc = (crc >>> 1) ^ (0xedb88320 & mask)
+    }
+  }
+  return ~crc >>> 0
+}
+
+function bytesToBase32(bytes: Uint8Array, alphabet: string): string {
+  let out = ''
+  let value = 0
+  let bits = 0
+  for (const byte of bytes) {
+    value = (value << 8) | byte
+    bits += 8
+    while (bits >= 5) {
+      out += alphabet[(value >>> (bits - 5)) & 31]
+      bits -= 5
+    }
+  }
+  if (bits > 0) out += alphabet[(value << (5 - bits)) & 31]
+  return out
+}
+
+function principalBytesToText(principalBytes: Uint8Array): string {
+  const checksum = crc32(principalBytes)
+  const bytesWithChecksum = Buffer.concat([
+    Buffer.from([(checksum >>> 24) & 0xff, (checksum >>> 16) & 0xff, (checksum >>> 8) & 0xff, checksum & 0xff]),
+    Buffer.from(principalBytes),
+  ])
+  const base32 = bytesToBase32(bytesWithChecksum, 'abcdefghijklmnopqrstuvwxyz234567')
+  return (base32.match(/.{1,5}/g) as string[]).join('-')
+}
+
+function principalTextToBytes(principalText: string): Buffer {
+  const alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567'
+  const clean = principalText.replace(/-/g, '').toUpperCase()
+  let value = 0
+  let bits = 0
+  const out: number[] = []
+  for (const char of clean) {
+    const index = alphabet.indexOf(char)
+    if (index === -1) throw new Error(`Invalid principal character "${char}"`)
+    value = (value << 5) | index
+    bits += 5
+    if (bits >= 8) {
+      out.push((value >>> (bits - 8)) & 0xff)
+      bits -= 8
+    }
+  }
+  return Buffer.from(out).slice(4)
+}
+
+// --- Query call ---
+
+export async function queryCanister({
+  canisterId,
+  methodName,
+  host = ICP_HOST,
+  timeout = CANISTER_TIMEOUT_MS,
+}: {
+  canisterId: string
+  methodName: string
+  host?: string
+  timeout?: number
+}): Promise<Uint8Array> {
+  const content = {
+    request_type: 'query',
+    canister_id: principalTextToBytes(canisterId),
+    method_name: methodName,
+    arg: Buffer.from([68, 73, 68, 76, 0, 0]), // "DIDL" + 0 types + 0 args
+    sender: Buffer.from([4]), // anonymous
+    ingress_expiry: BigInt(Date.now() + 5 * 60 * 1000) * 1_000_000n,
+  }
+
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), timeout)
+  try {
+    const response = await fetch(`${host}/api/v2/canister/${canisterId}/query`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/cbor' },
+      body: encodeCbor({ content }) as any,
+      signal: controller.signal,
+    })
+    if (!response.ok) throw new Error(`Canister query failed with ${response.status}: ${await response.text()}`)
+
+    const decoded = decodeCbor(new Uint8Array(await response.arrayBuffer()))
+    if (decoded?.status !== 'replied' || !decoded?.reply?.arg) {
+      // Surface the replica's reject fields so callers can tell a permanently dead canister
+      // (e.g. IC0537, no Wasm module installed) from a transient failure.
+      const error: any = new Error(
+        `Canister ${canisterId} did not reply to ${methodName}: ${decoded?.reject_message ?? decoded?.status}`)
+      error.rejectCode = decoded?.reject_code
+      error.errorCode = decoded?.error_code
+      throw error
+    }
+    return decoded.reply.arg
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
+// Convenience: query a zero-arg method and decode the reply in one step.
+export async function queryCanisterDecoded(
+  canisterId: string,
+  methodName: string,
+  labels: string[] = [],
+): Promise<any> {
+  const labelHashMap: Record<number, string> = {}
+  for (const label of labels) labelHashMap[hashCandidLabel(label)] = label
+  const [value] = decodeCandid(await queryCanister({ canisterId, methodName }), labelHashMap)
+  return value
+}


### PR DESCRIPTION
Fixes #9092

ICDex has published $153,042–$153,712 every day for the last 35 days. The 57 days before that averaged $364.89 with a max of $3,835. The step is a single day: 2026-07-27 $1,090 → 2026-07-28 $153,163.

The adapter sums `usd_24h_volume` from ICLighthouse's stats canister. That canister only refreshes a pair's 24h entry when the pair trades, and never decays it back to zero, so an idle pair keeps reporting its last busy day forever. One pair is 99.18% of the total:

```json
"ckBTC/ICP": { "base_volume": "169.368960", "base_24h_volume": "1.708860",
               "quote_24h_volume": "34833.466314", "usd_24h_volume": "152145.462693" }
```

`base_24h_volume` of 1.708860/day is 623.7 ckBTC/year against a lifetime `base_volume` of 169.368960 — 3.7x the pair's entire history, every year. The USD figure is frozen at a stale rate too: 152145.462693/34833.466314 implies ICP $4.3678 and /1.708860 implies BTC $89,033, against $2.43 and $78,878 live.

The aggregator's own daily series (`/v1/stats`) stops on 2026-07-26, which is when it died.

### On-chain

Each pair canister's `stats()` is the truth. Querying all 32 pairs:

| pair | canister | on-chain `vol24h` | feed's 24h claim |
|---|---|---|---|
| ckBTC/ICP | `5u2c6-kyaaa-aaaar-qadiq-cai` | `{0, 0}` | 1.708860 ckBTC / 34,833.47 ICP |
| ICL/ICP | `52ypw-riaaa-aaaar-qadjq-cai` | `{0, 0}` | 19,950.4 ICL / 70.998 ICP |
| DKP/ICP | `3wq7v-gaaaa-aaaar-qad6a-cai` | `{6870000000000, 570000856}` | 68,700 DKP / 5.700009 ICP |

**Exactly 1 of 32 pairs has any 24h volume.** DKP is the control: it traded today and the feed matches the chain to the unit, so the pipeline is fine — only idle pairs are stale. ckBTC/ICP's `totalVol` on-chain still agrees with the feed's lifetime field, which rules out a units mistake: only the 24h field is wrong.

CoinGecko, which ingests the same `/v1/tickers` feed but applies its own staleness filter, keeps only DKP/ICP and reports $13.42 for the exchange.

### What this changes

```
before:  Daily volume: 153,406
after :  Daily volume: 14.00      (two consecutive runs, 10s and 32s)
```

5.70000856 ICP × $2.4334 = $13.87, and CoinGecko independently says $13.42.

### Why the volume now comes from the canisters

I went through the whole HTTP surface first and none of it can produce a correct number:

- `/v1/latest`, `/v1/tickers`, `/v1/pairs`, `/v1/orderbook`, `/v1/historical_trades`, `/v1/stats` — every query parameter I tried is ignored, each path returns one fixed payload
- `/v1/historical_trades` returns trades from 2023-10-19 whatever ticker you ask for
- the stuck amount is not a constant that could be subtracted: it holds for ~14 days and then drifts (2026-06-03 is $61,911 above it)
- `/v1/stats`'s cumulative `usd_total_vol` would work, but it stopped on 2026-07-26, and summing `/v1/latest`'s `usd_volume` today gives 1,302,782,237.96 against that series' final 1,310,026,500.16, so the two are not the same aggregate

The ICDex front end talks to the pair canisters directly (its bundle carries `HttpAgent`, `icp-api.io`, `/api/v2/canister`), so that is the only live source.

`helpers/icp.ts` is a port of `DefiLlama-Adapters/projects/helper/chain/icp.js`, the CBOR + Candid agent that `liquidium` and `onesec` already use for TVL. It is kept structurally identical so the two can be diffed; the only changes are TypeScript types, `int` added to the type table, and reject fields surfaced on the thrown error. No new dependency — it uses `Buffer` and global `fetch`, both already used in this repo.

Details worth flagging:

- **Quote side.** `vol24h` reports both legs; the quote leg is used because every pair settles in ICP, ckUSDC or ckBTC. It is not maker+taker doubled: for DKP/ICP, `value1 / (value0 × price)` = 1.0294, and the 3% is last-price vs VWAP.
- **Decimals** are read from each token's `icrc1_decimals` rather than hardcoded (ICP 8, ckUSDC 6, ckBTC 8, verified on-chain).
- **Three pair canisters** (`zfp4v-…`, `5i6yp-…`, `2rkjf-…`) reject every call with `IC0537 … the canister contains no Wasm module`. They have been uninstalled and cannot trade, so they contribute zero; any other error still throws.
- **An unpriceable quote token throws** rather than being dropped, so a new quote asset can't silently shrink the total. One listed pair is quoted in ICL, which has no price source — it currently has zero volume, and if it ever trades this will surface instead of under-reporting.
- **The pair list still comes from `/v1/tickers`**, since it is the only directory of ICDex pairs and the router's `getPairs` takes arguments this agent can't encode. That is metadata rather than volume, and it is the same list the adapter already used, so the worst case is a brand-new pair being missed rather than a wrong number.
- `runAtCurrTime` stays, because `vol24h` is a trailing-24h snapshot that only exists for the present.
