### PR TITLE
Add TermiX fees adapter (BSC + Base)

### DIFF
--- a/fees/termix.ts
+++ b/fees/termix.ts
@@ -1,42 +1,51 @@
 import { FetchOptions, SimpleAdapter } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
 import { addTokensReceived } from "../helpers/token";
+import ADDRESSES from '../helpers/coreAssets.json';
 
 // Escrow contracts charge a 2% protocol fee (protocolFeeBps = 200) on each
 // settled job and transfer it to the fee recipient.
 const FEE_RECIPIENT = "0x1095deD95CB6e81C01204F7A94950dd559195E42";
 
-const CONFIG: Record<string, { escrows: string[]; tokens: string[] }> = {
-  [CHAIN.BSC]: {
-    escrows: [
-      "0x6A52ba4C84b348FaEAe13dDC7A97b4F6af23913C", // escrow (USDC)
-      "0xCE02f987D8b8AF694E13C8a843Db9c77caBF544c", // escrow (USDT)
-    ],
-    tokens: [
-      "0x8AC76a51cc950d9822D68b83fE1Ad97B32Cd580d", // USDC
-      "0x55d398326f99059fF775485246999027B3197955", // USDT
-    ],
-  },
-  [CHAIN.BASE]: {
-    escrows: [
-      "0xc3d963E0856A2c2d6F75C83C1355f680fd8F9f10", // escrow (USDC)
-      "0xFf3f7038c4919A420B30D7B3533cb386D5898189", // escrow (USDT)
-    ],
-    tokens: [
-      "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913", // USDC
-      "0xfde4C96c8593536E31F229EA8f37b2ADa2699bb2", // USDT
-    ],
-  },
+const ESCROW_FEES = "Escrow Fees";
+
+const CONFIG: Record<string, { escrow: string; token: string }[]> = {
+  [CHAIN.BSC]: [
+    {
+      escrow: "0x6A52ba4C84b348FaEAe13dDC7A97b4F6af23913C",
+      token: ADDRESSES.bsc.USDC,
+    },
+    {
+      escrow: "0xCE02f987D8b8AF694E13C8a843Db9c77caBF544c",
+      token: ADDRESSES.bsc.USDT,
+    },
+  ],
+  [CHAIN.BASE]: [
+    {
+      escrow: "0xc3d963E0856A2c2d6F75C83C1355f680fd8F9f10",
+      token: ADDRESSES.base.USDC,
+    },
+    {
+      escrow: "0xFf3f7038c4919A420B30D7B3533cb386D5898189",
+      token: ADDRESSES.base.USDT,
+    },
+  ],
 };
 
 const fetch = async (options: FetchOptions) => {
-  const { escrows, tokens } = CONFIG[options.chain];
-  const dailyFees = await addTokensReceived({
+  const dailyFees = options.createBalances();
+  const tokens = CONFIG[options.chain].map(({ token }) => token);
+  const escrows = CONFIG[options.chain].map(({ escrow }) => escrow);
+
+  const received = await addTokensReceived({
     options,
     tokens,
     targets: [FEE_RECIPIENT],
     fromAdddesses: escrows,
   });
+
+  dailyFees.addBalances(received, ESCROW_FEES);
+
   return {
     dailyFees,
     dailyRevenue: dailyFees,
@@ -46,18 +55,32 @@ const fetch = async (options: FetchOptions) => {
 
 const methodology = {
   Fees: "2% protocol fee charged on each settled job, paid in USDC/USDT from the escrow contracts to the protocol fee recipient.",
-  Revenue: "100% of protocol fees go to the protocol fee recipient.",
+  Revenue: "100% of protocol fees (2% of job settlement) go to the protocol fee recipient.",
   ProtocolRevenue: "Same as revenue — the full 2% job settlement fee.",
+};
+
+const breakdownMethodology = {
+  Fees: {
+    [ESCROW_FEES]: "2% protocol fee on jobs settled through the escrow contracts, paid in USDC or USDT.",
+  },
+  Revenue: {
+    [ESCROW_FEES]: "100% of escrow protocol fees (2% of job settlement) go to the fee recipient.",
+  },
+  ProtocolRevenue: {
+    [ESCROW_FEES]: "Same as revenue — the full 2% job settlement fee.",
+  },
 };
 
 const adapter: SimpleAdapter = {
   version: 2,
+  pullHourly: true,
   fetch,
   chains: [
     [CHAIN.BSC, { start: "2026-07-03" }],
     [CHAIN.BASE, { start: "2026-08-06" }],
   ],
   methodology,
+  breakdownMethodology,
 };
 
 export default adapter;

--- a/fees/termix.ts
+++ b/fees/termix.ts
@@ -1,0 +1,63 @@
+import { FetchOptions, SimpleAdapter } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+import { addTokensReceived } from "../helpers/token";
+
+// Escrow contracts charge a 2% protocol fee (protocolFeeBps = 200) on each
+// settled job and transfer it to the fee recipient.
+const FEE_RECIPIENT = "0x1095deD95CB6e81C01204F7A94950dd559195E42";
+
+const CONFIG: Record<string, { escrows: string[]; tokens: string[] }> = {
+  [CHAIN.BSC]: {
+    escrows: [
+      "0x6A52ba4C84b348FaEAe13dDC7A97b4F6af23913C", // escrow (USDC)
+      "0xCE02f987D8b8AF694E13C8a843Db9c77caBF544c", // escrow (USDT)
+    ],
+    tokens: [
+      "0x8AC76a51cc950d9822D68b83fE1Ad97B32Cd580d", // USDC
+      "0x55d398326f99059fF775485246999027B3197955", // USDT
+    ],
+  },
+  [CHAIN.BASE]: {
+    escrows: [
+      "0xc3d963E0856A2c2d6F75C83C1355f680fd8F9f10", // escrow (USDC)
+      "0xFf3f7038c4919A420B30D7B3533cb386D5898189", // escrow (USDT)
+    ],
+    tokens: [
+      "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913", // USDC
+      "0xfde4C96c8593536E31F229EA8f37b2ADa2699bb2", // USDT
+    ],
+  },
+};
+
+const fetch = async (options: FetchOptions) => {
+  const { escrows, tokens } = CONFIG[options.chain];
+  const dailyFees = await addTokensReceived({
+    options,
+    tokens,
+    targets: [FEE_RECIPIENT],
+    fromAdddesses: escrows,
+  });
+  return {
+    dailyFees,
+    dailyRevenue: dailyFees,
+    dailyProtocolRevenue: dailyFees,
+  };
+};
+
+const methodology = {
+  Fees: "2% protocol fee charged on each settled job, paid in USDC/USDT from the escrow contracts to the protocol fee recipient.",
+  Revenue: "100% of protocol fees go to the protocol fee recipient.",
+  ProtocolRevenue: "Same as revenue — the full 2% job settlement fee.",
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  fetch,
+  chains: [
+    [CHAIN.BSC, { start: "2026-07-03" }],
+    [CHAIN.BASE, { start: "2026-08-06" }],
+  ],
+  methodology,
+};
+
+export default adapter;


### PR DESCRIPTION
Adds a fees adapter for **TermiX** (https://termix.ai) — a trustless marketplace where AI agents hire agents. Jobs are funded into on-chain escrow in USDC/USDT and released on completion.

TVL adapter PR (pending): https://github.com/DefiLlama/DefiLlama-Adapters/pull/20798

### Methodology
- **Fees**: the escrow contracts charge a 2% protocol fee (`protocolFeeBps = 200`, readable on-chain) on each settled job, transferred in USDC/USDT to the fee recipient `0x1095deD95CB6e81C01204F7A94950dd559195E42`.
- **Revenue / ProtocolRevenue**: 100% of that fee.
- Implementation: `addTokensReceived` filtered to transfers **from the escrow contracts** to the fee recipient, so unrelated transfers to that address are excluded.

### Contracts
| Chain | Escrow (USDC) | Escrow (USDT) |
|---|---|---|
| BSC | `0x6A52ba4C84b348FaEAe13dDC7A97b4F6af23913C` | `0xCE02f987D8b8AF694E13C8a843Db9c77caBF544c` |
| Base | `0xc3d963E0856A2c2d6F75C83C1355f680fd8F9f10` | `0xFf3f7038c4919A420B30D7B3533cb386D5898189` |

### On-chain verification
- Cumulative fees to date ≈ **$307.8k** (BSC ~$227.0k since 2026-07-03, Base ~$80.8k since 2026-08-06): https://dune.com/queries/8571351
- Cumulative escrow volume ≈ $15.4M: https://dune.com/queries/8571317

### Test output (`npm run test fees termix`)
```
chain     | Daily fees | Daily revenue | Daily protocol revenue | Start Time
bsc       | 2.98 k     | 2.98 k       | 2.98 k                 | 3/7/2026
base      | 5.14 k     | 5.14 k       | 5.14 k                 | 6/8/2026
Aggregate | 8.13 k     | 8.13 k       | 8.13 k                 |
```
