### PR TITLE
[Fees] Rainbow Wallet - add Robinhood Chain, use actual bridge fees

### DIFF
--- a/fees/rainbow-wallet.ts
+++ b/fees/rainbow-wallet.ts
@@ -39,6 +39,9 @@ const chainConfig: ChainConfig = {
   [CHAIN.RONIN]: { router: rainbowRouter, duneChain: 'ronin', start: '2025-10-14' },
   [CHAIN.MEGAETH]: { router: rainbowRouter, duneChain: 'megaeth', start: '2025-12-02' },
   [CHAIN.ROBINHOOD]: { router: rainbowRouter, duneChain: 'robinhood', start: '2026-07-10' },
+  [CHAIN.XDAI]: { router: rainbowRouter, duneChain: 'gnosis', start: '2026-03-01' },
+  [CHAIN.ABSTRACT]: { router: rainbowRouter, duneChain: 'abstract', start: '2026-03-01' },
+  [CHAIN.ERA]: { router: rainbowRouter, duneChain: 'zksync', start: '2026-07-17' },
 }
 
 const getRouterValues = (config: ChainConfig) => Object.entries(config)

--- a/fees/rainbow-wallet.ts
+++ b/fees/rainbow-wallet.ts
@@ -139,8 +139,8 @@ const PRE_APRIL_SQL = (options: FetchOptions, activeChainConfig: ChainConfig) =>
   relay_bridge AS (
       SELECT
           r.chain,
-          SUM(rb.usd_vol)          AS volume,
-          SUM(rb.usd_vol) * 0.0025 AS fees
+          SUM(rb.usd_vol)  AS volume,
+          SUM(rb.fee_usd)  AS fees
       FROM dune.rainbowdotme.result_rainbow_relay_tx rb
       INNER JOIN routers r
         ON rb.origin = r.blockchain
@@ -200,8 +200,8 @@ const POST_APRIL_SQL = (options: FetchOptions, activeChainConfig: ChainConfig) =
   relay_bridge AS (
       SELECT
           r.chain,
-          SUM(rb.usd_vol)          AS volume,
-          SUM(rb.usd_vol) * 0.0025 AS fees
+          SUM(rb.usd_vol)  AS volume,
+          SUM(rb.fee_usd)  AS fees
       FROM dune.rainbowdotme.result_rainbow_relay_tx rb
       INNER JOIN routers r
         ON rb.origin = r.blockchain
@@ -257,23 +257,23 @@ const fetch: any = async (options: FetchOptions) => {
 }
 
 const methodology = {
-  Fees: "0.85% fees from trading volume and 0.25% fees from bridge relaying volume",
-  Revenue: "0.85% revenue from trading volume and 0.25% revenue from bridge relaying volume",
-  ProtocolRevenue: "0.85% protocol revenue from trading volume and 0.25% protocol revenue from bridge relaying volume",
+  Fees: "0.85% fees from trading volume, plus the bridge relaying fee charged on each bridge transfer",
+  Revenue: "0.85% revenue from trading volume, plus the bridge relaying fee charged on each bridge transfer",
+  ProtocolRevenue: "0.85% protocol revenue from trading volume, plus the bridge relaying fee charged on each bridge transfer",
 }
 
 const breakdownMethodology = {
   Fees: {
     [METRIC.SWAP_FEES]: "0.85% of the volume is fees",
-    'Bridge Fees': "0.25% of the volume is fees",
+    'Bridge Fees': "the relaying fee charged on each bridge transfer",
   },
   Revenue: {
     [METRIC.SWAP_FEES]: "0.85% of the volume is revenue",
-    'Bridge Fees': "0.25% of the volume is revenue",
+    'Bridge Fees': "the relaying fee charged on each bridge transfer",
   },
   ProtocolRevenue: {
     [METRIC.SWAP_FEES]: "0.85% of the volume is protocol revenue",
-    'Bridge Fees': "0.25% of the volume is protocol revenue",
+    'Bridge Fees': "the relaying fee charged on each bridge transfer",
   }
 }
 

--- a/fees/rainbow-wallet.ts
+++ b/fees/rainbow-wallet.ts
@@ -38,6 +38,7 @@ const chainConfig: ChainConfig = {
   [CHAIN.PLUME]: { router: rainbowRouter, duneChain: 'plume', start: '2025-10-14' },
   [CHAIN.RONIN]: { router: rainbowRouter, duneChain: 'ronin', start: '2025-10-14' },
   [CHAIN.MEGAETH]: { router: rainbowRouter, duneChain: 'megaeth', start: '2025-12-02' },
+  [CHAIN.ROBINHOOD]: { router: rainbowRouter, duneChain: 'robinhood', start: '2026-07-10' },
 }
 
 const getRouterValues = (config: ChainConfig) => Object.entries(config)


### PR DESCRIPTION

Name (as shown on DefiLlama): Rainbow Wallet
Twitter link: https://x.com/rainbowdotme
Website link: https://rainbow.me
Chain(s): Robinhood, Gnosis, Abstract, zkSync Era (added; 30 existing chains unchanged)

## Summary

Updates the existing `rainbow-wallet.ts` adapter with two corrections.

**Adds four missing chains.** The queries restrict to declared chains via `WHERE ... IN (${duneChainList})`, built from `chainConfig`. Robinhood Chain has been in Rainbow's Dune swap table since **2026-07-10** but was absent from `chainConfig`, so its rows were filtered out at query time. It is now the largest single source of Rainbow swap fees — on 2026-08-29/30 the adapter reported ~12% of actual swap revenue. Gnosis, Abstract and zkSync Era appear in the bridge table only and were likewise dropped.

**Uses the real bridge fee.** `result_rainbow_relay_tx` now exposes a `fee_usd` column, replacing a hardcoded 0.25% of volume. The constant did not match reality: effective rate runs 0.28%-0.82% by day, and ~15% of rows have `fee_usd = 0` (sponsored transfers the flat rate wrongly charged). It understated bridge fees by roughly 2x.

## How it works

Four entries added to `chainConfig`:

```ts
[CHAIN.ROBINHOOD]: { router: rainbowRouter, duneChain: 'robinhood', start: '2026-07-10' },
[CHAIN.XDAI]:      { router: rainbowRouter, duneChain: 'gnosis',    start: '2026-03-01' },
[CHAIN.ABSTRACT]:  { router: rainbowRouter, duneChain: 'abstract',  start: '2026-03-01' },
[CHAIN.ERA]:       { router: rainbowRouter, duneChain: 'zksync',    start: '2026-07-17' },
```

- all four `CHAIN` keys already exist in `helpers/chains.ts`; `CHAIN.ERA` is used for zkSync Era across the repo in preference to `CHAIN.ZKSYNC`
- each `duneChain` matches the Dune `network`/`origin` value exactly, so the existing joins resolve with no new mapping — `getRouterValues` and `getDuneChainList` both derive from `chainConfig`
- each `start` is the chain's first row in the Dune tables, so `getActiveChainConfig` excludes it from every earlier window
- `router` is inert for these chains: the post-April query joins on `network` only, and the bridge leg joins on `origin`

Bridge fees, in **both** `PRE_APRIL_SQL` and `POST_APRIL_SQL`:

```diff
-          SUM(rb.usd_vol)          AS volume,
-          SUM(rb.usd_vol) * 0.0025 AS fees
+          SUM(rb.usd_vol)  AS volume,
+          SUM(rb.fee_usd)  AS fees
```

| Leg | Source |
|-----|--------|
| Swap fees, from 2026-04-01 | `result_rainbow_swaps_core_aggregated_with_prices_since_april`, `usd_fee`, chains from `chainConfig` |
| Swap fees, before 2026-04-01 | `dex.trades` + `dex_aggregator.trades` matched on router address, 0.85% of volume |
| Bridge fees, both windows | `result_rainbow_relay_tx`, `fee_usd` per transfer |

## Methodology

| Metric | Description |
|--------|-------------|
| Fees | 0.85% of swap volume, plus the relaying fee charged on each bridge transfer |
| Revenue | All fees go to Rainbow |
| ProtocolRevenue | Same as Revenue |

Methodology strings updated to drop the 0.25% claim. Start date: 2022-03-04 (per-chain starts in `chainConfig`).

## Verification

`ts-node cli/testAdapter.ts fees rainbow-wallet <date>` against current `master`:

| Date | Swap before | Swap after | Bridge before | Bridge after |
|------|-------------|------------|---------------|--------------|
| 2026-08-28 | \$1,585.54 | \$5,712.87 | \$307.90 | \$1,051.94 |
| 2026-08-29 | \$729.98 | \$6,776.53 | \$336.71 | \$2,081.14 |
| 2026-08-30 | \$685.22 | \$5,656.33 | \$222.59 | \$2,520.41 |

Swap fees 2026-08-20..30 total: **\$18,622 -> \$45,312**.

**No regressions:**

| Date | Result |
|------|--------|
| 2026-06-14 (post-April, pre-Robinhood) | `Skipping robinhood because the configured start time is Fri, 10 Jul 2026`; swap unchanged at \$347.18 |
| 2026-03-14 (pre-April `dex.trades` branch) | swap unchanged at \$1,156.37, Robinhood skipped, query runs clean |

Before these changes the published series was reproduced from Dune to the dollar (Aug 26-30: 3,230 / 4,824 / 1,893 / 1,068 / 907 against published 3,230 / 4,825 / 1,895 / 1,067 / 906), confirming the shortfall is the allowlist and the fee constant rather than indexing lag.

Note: `result_rainbow_relay_tx` recently had its `origin` values normalized to match Dune chain names (previously `avalanche` instead of `avalanche_c`, and Monad/MegaETH/Plasma/Sonic/B3 as raw chain IDs). With that in place every origin in the table now maps to a `chainConfig` entry, and `duneChain` serves both the swap and bridge joins.

## Backfill request

Please **refill from 2026-07-10** once merged — Robinhood's first row is on that date with zero fees before it, so it is both the correct `start` and the correct refill boundary.

Window **2026-07-10 - 2026-08-30** (52 days):

| | |
|---|---|
| Currently published | \$67,286 |
| After both changes | **\$162,085** (swap \$122,754 + bridge \$39,331) |
| Recovered | **\$94,799 — 2.41x** |

These fees were genuinely earned on every day in the window and were excluded only by the allowlist and the fee constant, so a refill restores real history rather than restating anything. Without it the correction applies to new days only.

The adapter is `isExpensiveAdapter: true` at one Dune execution per day, so this is ~52 queries. The added chains sit in the same pre-aggregated tables as every other chain, so there is no extra per-day query weight.
