### PR TITLE
bloom: discover the routers from bloom's own fee event, the hardcoded list went stale

### DIFF
--- a/dexs/bloom.ts
+++ b/dexs/bloom.ts
@@ -6,52 +6,22 @@ type DuneVolumeRow = {
   daily_volume?: string | number | null;
 };
 
-const chainConfig: Record<string, { start: string; contractAddresses?: string[]; duneChain?: string }> = {
+// Bloom emits this event from every router it deploys, so the routers are discovered from it
+// rather than listed by hand. The hand-kept list is what broke: BSC moved to a new router on
+// 2026-08-03 and Base has rotated four times since July, taking both chains to zero volume.
+const BLOOM_FEE_TOPIC = "0x2d720abb2e4bf42730e89955397ce0f5b08db0caff9be7e08ca184a8b1b2db2f";
+
+const chainConfig: Record<string, { start: string; duneChain?: string }> = {
   [CHAIN.SOLANA]: {
     start: "2024-10-01",
   },
   [CHAIN.BASE]: {
     start: "2024-12-12",
     duneChain: "base",
-    contractAddresses: [
-      "0xb1000058c87d843fc0154591ff9d72af5e7213d5",
-      "0xaa82714222d11919b0fb07b9cf938f3080748b0a",
-      "0xc6ad39388bad9f197ad2842e6cdbc4bf7f3d5cc4",
-      "0x284808b823e61a399fec52e1ba71d9afb1905150",
-      "0x2e8759e33116b0f101390ddd3d8ce9f6b0817db2",
-      "0x5ee5635f02a43f21085f69fa68c1325393a6d7fb",
-      "0xa9a05f046163224e81770c7d29fc98392064eb96",
-      "0x3daa9624e217c854ba10905d639e4d0c5958f4bd",
-      "0x3964dfb31fc89e2616f7553ae02649c4058350eb",
-      "0x6e0ee964f2afe05eeb72512f06ffb741ce7ebd86",
-      "0x95b14c6015084c766b2daa2ba3ead4c528781d29",
-      "0x28356428e67263d231293a8326bf362d2e840936",
-      "0xdb25696c6db64f1fda5d0528cd9e2ee7fbe2c466",
-      "0xdd93c422bcc8b363e2510ef01030050d845b0fd5",
-      "0x5e504b55646d9c103bbccc5831230cfbfa6314f4",
-      "0x3156cc687073313a7a021fefc90fdb63e3ec1e27",
-      "0x20de462708a2f53ed0ca7d3718d4278c38752e12",
-      "0x2ae980b825acdbc2faf7b594f8a59a83750e3531",
-      "0x1413e2f212eb6cf072dcd71cb7a26b2a63819c53",
-      "0x4061a31d8c03a12598127966e301bae3bdccff40",
-    ],
   },
   [CHAIN.BSC]: {
     start: "2025-02-13",
     duneChain: "bnb",
-    contractAddresses: [
-      "0xb1000058c87d843fc0154591ff9d72af5e7213d5",
-      "0x8f2d511be49919722358d3217a0775e54b1368fb",
-      "0x3b95a6b1f890ae2f6862ac5be37f27c3b542112b",
-      "0x8f73798b3ee029dfbafca96d015fbf6bfe8d1fc7",
-      "0xaf1ab69d1675db5aeba18000590fd64858f37fb4",
-      "0x554d8519e93474955e69d467dbac50f2fed186c4",
-      "0xb0b2fb0e2852ec94d8bee3b2a42e02b16ddd5b62",
-      "0xb5f1f0413d9965c484cf7d2df2a329798dc34616",
-      "0x0ba81c91fe41301b760b44285cc2fd034619015a",
-      "0xd4f1afd0331255e848c119ca39143d41144f7cb3",
-      "0x015ae929e9a74fb739267553b6fd7ea9d2a318af",
-    ],
   },
 };
 
@@ -65,9 +35,18 @@ const fetchSolana = (options: FetchOptions) => queryDuneSql(options, `
     AND is_last_trade_in_transaction = true
 `) as Promise<DuneVolumeRow[]>;
 
-const fetchEvm = (options: FetchOptions, config: { start: string; contractAddresses?: string[]; duneChain?: string }) => {
+const fetchEvm = (options: FetchOptions, config: { start: string; duneChain?: string }) => {
   return queryDuneSql(options, `
-    WITH bot_trades AS (
+    WITH bloom_routers AS (
+      SELECT DISTINCT
+        contract_address
+      FROM
+        ${config.duneChain}.logs
+      WHERE
+        topic0 = ${BLOOM_FEE_TOPIC}
+        AND TIME_RANGE
+    ),
+    bot_trades AS (
       SELECT
         trades.tx_hash,
         trades.evt_index,
@@ -76,7 +55,7 @@ const fetchEvm = (options: FetchOptions, config: { start: string; contractAddres
         dex.trades
       WHERE
         trades.blockchain = '${config.duneChain}'
-        AND trades.tx_to IN (${config.contractAddresses?.join(", ")})
+        AND trades.tx_to IN (SELECT contract_address FROM bloom_routers)
         AND TIME_RANGE
     ),
     last_trades AS (


### PR DESCRIPTION
Bloom's BSC and Base volume have both been $0 while Solana keeps reporting, so the protocol total looks alive and hides it. BSC's last non-zero day was 2026-08-03; Base has been flat zero for far longer.

Nothing is wrong with Dune. `fetchEvm` filters `dex.trades` on `tx_to IN (<hardcoded list>)`, and Bloom has since rotated its routers away from every address in that list.

### The cutover, from Bloom's own fee event

`fees/bloom.ts` already identifies Bloom contracts by the event topic `0x2d720abb…`. Grouping `bnb.logs` by emitter on that topic:

| router | first | last | logs |
|---|---|---|---|
| `0x0b6df1888ed6aced6fc50ab39f354a7c8d08c9b1` — **not in the list** | 2026-08-03 19:09:26 | 2026-09-01 09:00:02 | 26,020 |
| `0xb1000058c87d843fc0154591ff9d72af5e7213d5` — in the list | 2026-07-20 00:16:03 | **2026-08-03 22:18:48** | 4,346 |

A three-hour overlap and a clean handoff on 2026-08-03, which is exactly the day the published series goes to zero.

It is Bloom's: the new router was created at 18:42:52 that day by `0x51fd7131…`, whose only two inbound funding transfers on BSC both come from `0x224bede1…` — the EOA that deployed `0xb1000058…` in the first place.

Base is the same failure, further along. Four contracts have emitted that topic since July and **none of them are in the adapter's twenty-address list**:

| router | first | last | logs |
|---|---|---|---|
| `0x7aef6bb1604c8bad36f663979a78430298e2581e` | 2026-08-18 23:38:17 | 2026-09-01 06:01:01 | 1,500 |
| `0x2bcd342b43fa9610b537c0c52a4793fd5bd290af` | 2026-08-15 09:14:39 | 2026-08-18 23:21:07 | 511 |
| `0x1ce3712395ee4798ac9548b3e0220ea6a2b61e79` | 2026-07-01 02:12:23 | 2026-08-14 20:03:39 | 1,217 |
| `0xa538ad204049850fd4ba8f5b33479c7e7defd00b` | 2026-08-14 19:06:23 | 2026-08-15 08:48:35 | 9 |

Base rotated four times in two months, so appending today's addresses would just move the next outage a few weeks out. Deriving the set from the event Bloom itself emits keeps it correct through the next rotation.

### It reproduces the current adapter exactly

On days the hardcoded list was still current, discovery returns the identical number — same last-trade-per-transaction dedupe, nothing else changed:

| day (BSC) | topic-discovered | hardcoded list | DefiLlama published |
|---|---:|---:|---:|
| 2026-07-15 | $3,987 | $3,987 | $3,987 |
| 2026-07-16 | $16,757 | $16,757 | $16,757 |

And on a day that currently publishes zero, the adapter now returns what the chain actually did:

```
$ npx ts-node --transpile-only cli/testAdapter.ts dexs bloom 2026-08-30
solana    | 1.25 M
base      | 9.62 k      <- published as 0
bsc       | 71.19 k     <- published as 0
```

Both match an independent Dune reconstruction of that window to the dollar ($71,187 BSC, $9,624 Base). Over 2026-08-04..08-31 the unconfigured BSC router alone did about $2.5M, and Base is running roughly $34k/day.

### Scope

Only `dexs/bloom.ts`. `fees/bloom.ts` carries the same stale lists and is also $0 on both chains — it filters `getLogs` by `topics: [topic]` **and** `targets: contracts`, so dropping the `targets` there would fix it the same way. I left it out to keep this diff to one file and one behaviour change; happy to send it as a follow-up.

The removed address arrays are the mechanism that broke, so they go with it rather than being left as dead config.
