### PR TITLE
gmgn: rebuild volume from Dune's first-party tables, the uploaded dataset it reads stopped on 2026-08-25

### DIFF
--- a/dexs/gmgnai.ts
+++ b/dexs/gmgnai.ts
@@ -45,13 +45,61 @@ const chainConfig: Record<string, { duneName: string, start: string }> = {
   }
 }
 
+// GMGN takes its 1% fee inside the swap transaction, so its volume is the dex trades that
+// sit in the transactions paying its fee collectors - the same transaction set fees/gmgnai.ts
+// measures. Keying on the collectors rather than on a router list also survives GMGN rotating
+// routers, which it does: on ethereum the flow moved from 0x4313c378.. to 0xb030e926.. on
+// 2026-01-14, and a hardcoded router would have dropped 99% of that day's volume.
+const EVM_FEE_COLLECTOR = '0xb8159ba378904F803639D274cEc79F788931c9C8';
+const SOLANA_FEE_WALLETS = [
+  'BB5dnY55FXS1e1NXqZDwCzgdYJdMCj3B92PU6Q5Fb6DT',
+  '7sHXjs1j7sDJGVSMSPjD1b4v3FD6uRSvRWfhRdfv5BiA',
+  'HeZVpHj9jLwTVtMMbzQRf6mLtFPkWNSg11o68qrbUBa3',
+  'ByRRgnZenY6W2sddo1VJzX9o4sMU4gPDUkcmgrpGBxRy',
+  'DXfkEGoo6WFsdL7x6gLZ7r6Hw2S6HrtrAQVPWYx2A1s9',
+  '3t9EKmRiAUcQUYzTZpNojzeGP1KBAVEEbDNmy6wECQpK',
+  'DymeoWc5WLNiQBaoLuxrxDnDRvLgGZ1QGsEoCAM7Jsrx',
+  'dBhdrmwBkRa66XxBuAK4WZeZnsZ6bHeHCCLXa3a8bTJ',
+  '6TxjC5wJzuuZgTtnTMipwwULEbMPx5JPW3QwWkdTGnrn',
+];
+
+const sqlList = (xs: string[]) => xs.map((x) => `'${x}'`).join(', ');
+const EVM_DUNE_CHAINS = Object.values(chainConfig).map((c) => c.duneName).filter((c) => c !== 'solana');
+
+// Dune lags ~10h; skip days whose end is too recent to avoid undercounting.
+const assertIndexed = (options: FetchOptions) => {
+  const tenHoursAgo = Date.now() - 10 * 60 * 60 * 1000;
+  if (options.toTimestamp * 1000 > tenHoursAgo) {
+    throw new Error('End timestamp is less than 10 hours ago, skipping due to dune indexing delay');
+  }
+};
+
 async function prefetch(options: FetchOptions) {
+  assertIndexed(options);
+  const wallets = sqlList(SOLANA_FEE_WALLETS);
+  const evmChains = sqlList(EVM_DUNE_CHAINS);
   const query = `
-    SELECT
-      blockchain,COALESCE(SUM(CAST(volume_usd AS double)), 0) AS daily_volume
-    FROM dune.adam_tehc_co.dataset_gmgn_daily
-    WHERE day = '${options.dateString}'
-    GROUP BY blockchain
+    WITH evm_fee_txs AS (
+      SELECT DISTINCT blockchain, block_date, tx_hash
+      FROM tokens.transfers
+      WHERE TIME_RANGE AND "to" = ${EVM_FEE_COLLECTOR} AND blockchain IN (${evmChains})
+    ),
+    sol_fee_txs AS (
+      SELECT DISTINCT tx_id
+      FROM solana.account_activity
+      WHERE TIME_RANGE AND tx_success AND balance_change > 0 AND address IN (${wallets})
+    )
+    SELECT t.blockchain AS blockchain, SUM(t.amount_usd) AS daily_volume
+    FROM dex.trades t
+    INNER JOIN evm_fee_txs f ON f.blockchain = t.blockchain AND f.block_date = t.block_date AND f.tx_hash = t.tx_hash
+    WHERE TIME_RANGE AND t.blockchain IN (${evmChains})
+    GROUP BY 1
+    UNION ALL
+    SELECT 'solana' AS blockchain, SUM(t.amount_usd) AS daily_volume
+    FROM dex_solana.trades t
+    INNER JOIN sol_fee_txs f ON f.tx_id = t.tx_id
+    WHERE TIME_RANGE AND t.trader_id NOT IN (${wallets})
+    GROUP BY 1
   `;
   const queryResults = await queryDuneSql(options, query)
   if (queryResults.length === 0) {
@@ -77,6 +125,9 @@ const adapter: SimpleAdapter = {
   dependencies: [Dependencies.DUNE],
   isExpensiveAdapter: true,
   doublecounted: true,
+  methodology: {
+    Volume: "US-dollar value of the token swaps people make through GMGN, taken from Dune's decoded dex trades and restricted to the transactions that pay a GMGN fee collector. Swaps routed through venues Dune has not decoded are not included, so the figure is a floor.",
+  },
 };
 
 export default adapter;

--- a/dexs/gmgnai.ts
+++ b/dexs/gmgnai.ts
@@ -1,3 +1,4 @@
+import ADDRESSES from '../helpers/coreAssets.json';
 import { Dependencies, FetchOptions, SimpleAdapter } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
 import { queryDuneSql } from "../helpers/dune";
@@ -63,8 +64,26 @@ const SOLANA_FEE_WALLETS = [
   '6TxjC5wJzuuZgTtnTMipwwULEbMPx5JPW3QwWkdTGnrn',
 ];
 
+// GMGN takes its fee in the native gas token and in the chain's main stablecoin - the same assets
+// fees/gmgnai.ts books as fees. Matching the fee asset by contract address means a token someone
+// sends to the collector cannot mark an unrelated swap as GMGN's. A chain with no entry here still
+// counts its native-token fees.
+const NATIVE = '0x0000000000000000000000000000000000000000';
+const FEE_STABLE_BY_CHAIN: Record<string, string> = {
+  ethereum: ADDRESSES.ethereum.USDC,
+  bnb: ADDRESSES.bsc.USDC,
+  base: ADDRESSES.base.USDC,
+  monad: (ADDRESSES as any).monad?.USDC,
+  hyperevm: (ADDRESSES as any).hyperliquid?.USDC,
+  robinhood: ADDRESSES.robinhood.USDG, // usdg is the main stablecoin on robinhood
+  arbitrum: (ADDRESSES as any).arbitrum?.USDC_CIRCLE, // arbitrum.USDC is bridged USDC.e
+};
+
 const sqlList = (xs: string[]) => xs.map((x) => `'${x}'`).join(', ');
 const EVM_DUNE_CHAINS = Object.values(chainConfig).map((c) => c.duneName).filter((c) => c !== 'solana');
+const evmFeeFilter = EVM_DUNE_CHAINS
+  .map((chain) => `(blockchain = '${chain}' AND contract_address IN (${[NATIVE, FEE_STABLE_BY_CHAIN[chain]].filter(Boolean).join(', ')}))`)
+  .join(' OR ');
 
 // Dune lags ~10h; skip days whose end is too recent to avoid undercounting.
 const assertIndexed = (options: FetchOptions) => {
@@ -82,7 +101,7 @@ async function prefetch(options: FetchOptions) {
     WITH evm_fee_txs AS (
       SELECT DISTINCT blockchain, block_date, tx_hash
       FROM tokens.transfers
-      WHERE TIME_RANGE AND "to" = ${EVM_FEE_COLLECTOR} AND blockchain IN (${evmChains})
+      WHERE TIME_RANGE AND "to" = ${EVM_FEE_COLLECTOR} AND (${evmFeeFilter})
     ),
     sol_fee_txs AS (
       SELECT DISTINCT tx_id


### PR DESCRIPTION
`dexs/gmgn` has published nothing since 2026-08-25. `total24h` is `null`, `total30d` is $2,382,941,413, and the last stored day was $112,658,427.

The adapter's only source is a user-uploaded Dune table. Querying it today, every chain stops on the same day:

```
blockchain | max_day    | min_day    | rows
base       | 2026-08-25 | 2024-06-12 |  791
bnb        | 2026-08-25 | 2024-12-02 |  613
ethereum   | 2026-08-25 | 2023-08-05 | 1066
hyperevm   | 2026-08-25 | 2026-05-21 |   81
megaeth    | 2026-08-23 | 2026-03-02 |   55
monad      | 2026-08-25 | 2026-01-01 |  227
robinhood  | 2026-08-25 | 2026-07-03 |   54
solana     | 2026-08-25 | 2024-03-20 |  889
xlayer     | 2026-08-25 | 2026-06-23 |   64
```

There is no `arbitrum` row at all, so the chain added in #8877 has reported $0 every day since 2026-08-19 even though the collector took real fees there ($33,780 on 2026-08-31 alone). `prefetch` throws on an empty day, which takes all ten chains down together.

GMGN itself is trading normally — the fees adapter reported $2,062,504 on 2026-08-31 off Dune's first-party tables.

## The change

Volume comes from `dex.trades` / `dex_solana.trades`, restricted to the transactions that pay a GMGN fee collector. That is the same transaction set `fees/gmgnai.ts` already measures, so the two adapters can no longer drift apart, and it needs no new addresses beyond the ones that file already maintains. `prefetch`/`fetch` keep their existing shape; the 10-hour Dune-indexing guard matches the sibling bot adapters.

## Why the fee collector rather than a router list

GMGN rotates routers. On ethereum, 2026-01-14 through 01-16 the flow ran through `0xb030e926..`, not the `0x4313c378..` the previous EVM code hardcoded:

```
2026-01-14  0xb030e926..  222 hops   $41,170     0x4313c378..  6 hops  $682
2026-01-15  0xb030e926..  104 hops   $32,273     0x4313c378..  5 hops  $322
2026-01-16  0xb030e926..   97 hops   $26,393
```

The uploaded table's own value for 2026-01-15 is $32,594 = $32,273 + $322, i.e. it counted both. A hardcoded router would have dropped 99% of that day. Joining on the fee collector picks up any router GMGN moves to.

## It reproduces the retired table exactly

Restricted to the transactions whose fee was paid in the **native gas token**, the reconstruction equals the retired table to the dollar on six of the nine EVM chains:

| chain | 2026-08-25 table | reconstruction, native-fee txs only | ratio |
|---|---:|---:|---:|
| ethereum | 1,471,211 | 1,471,211 | 1.0000 |
| bnb | 54,357,045 | 54,357,045 | 1.0000 |
| base | 8,351,935 | 8,351,935 | 1.0000 |
| hyperevm | 2,098,037 | 2,098,037 | 1.0000 |
| monad | 72,069 | 72,069 | 1.0000 |
| xlayer | 689,911 | 689,911 | 1.0000 |

Across 13 days sampled from 2025-08-15 to 2026-08-25, ethereum matches 13/13 and monad 10/10 at 1.0000 (ethereum, monad and xlayer need no native-fee restriction because GMGN takes only native fees there).

The other three: robinhood is 1.023 native-fee-only, and 1.004 once the trades are restricted to the rows Dune had actually written by noon the next day; arbitrum has no row in the table at all; megaeth is 0 on both.

## Where it differs, and why

**EVM, +2.7% to +6.8% on bsc/base/hyperevm.** The retired table counted only transactions whose fee was paid in the native token. This counts the USDC-fee transactions too — 22,848 on bsc, 1,304 on base, 577 on hyperevm on 2026-08-25 — and that is the whole difference. `fees/gmgnai.ts` already books those USDC inflows as GMGN fees, so leaving their volume out made the two adapters disagree about the same transactions.

**Solana, 1.48-1.56x.** The Solana leg is the query this adapter itself used before #8661, restored. I checked the two formulations return identical rows: on 2026-08-07 both `solana.account_activity` and the retired `solana.transactions`/`account_keys` form give 335,557 transactions and $10,954,496.

The retired table's Solana series drifted low during 2026, and the fees adapter shows it. GMGN charges 1%:

| day | table volume | implied rate | this PR | implied rate |
|---|---:|---:|---:|---:|
| 2025-06-15 | 10,922,827 | 1.02% | 10,985,724 | 1.02% |
| 2025-10-15 | 6,232,472 | 0.99% | 6,322,553 | 0.97% |
| 2026-06-15 | 6,130,733 | **1.47%** | 9,584,635 | 0.94% |
| 2026-07-05 | 6,585,669 | **1.52%** | 9,796,743 | 1.02% |
| 2026-08-22 | 9,174,159 | **1.48%** | 13,599,876 | 1.00% |
| 2026-08-25 | 12,372,730 | **1.44%** | 18,359,943 | 0.97% |

(rate = the fees adapter's on-chain daily fees ÷ volume.) A 1% fee cannot produce 1.44% of the volume it was charged on. The table and this PR agree in 2025, when both imply ~1%; the table's 2026 numbers imply a rate that is not possible. Ethereum sits at 0.85–1.09% across all 13 sampled days on both.

## Local runs

```
2026-08-25            2026-08-29
ethereum      1.47 M  ethereum    413.74 k
solana       18.36 M  solana       21.56 M
base          8.81 M  base          4.04 M
bsc          57.58 M  bsc          36.45 M
monad        72.07 k  monad        136.00
hyperliquid   2.24 M  hyperliquid 515.33 k
megaeth        0.00   megaeth        0.00
xlayer      689.91 k  xlayer      338.19 k
robinhood    34.14 M  robinhood   117.26 M
arbitrum    164.93 k  arbitrum     86.13 k
Aggregate   123.52 M  Aggregate   180.66 M
```

Cost: the adapter's query for one full day across all ten chains is **2.74 Dune credits**, measured on 2026-08-22 (free tier). Same order as the fees adapter's daily query.

## Two things left deliberately unchanged

- **Per-hop, not per-transaction.** The retired series summed every pool hop, so a routed swap counts more than once, and that is preserved here so this stays a source change. It is not free: on 2026-08-25 per-`(tx, taker)` deduplication would give bsc 50.81M instead of 57.58M and xlayer 303k instead of 690k. The sibling bots (axiom, bullx, photon, trojan) do deduplicate. Happy to send that as a follow-up if you want volume aligned with them.
- **No amount check on the fee.** A transaction counts when the collector receives the native gas token or the chain's main stablecoin, matching the assets `fees/gmgnai.ts` books; it does not verify the amount is 1% of the trade. Bundling an unrelated swap in would mean actually paying GMGN a fee in one of those assets.

Refs #9099.
