### PR TITLE
gmgnai: add arbitrum to the fees EVM chain map, it has reported $0 since #8877

### DIFF
--- a/fees/gmgnai.ts
+++ b/fees/gmgnai.ts
@@ -72,6 +72,8 @@ const EVM_CHAINS: Record<string, { dune: string; usdc?: string }> = {
   // usdg is the main stablecoin on robinhood
   [CHAIN.ROBINHOOD]: { dune: 'robinhood', usdc: ADDRESSES.robinhood.USDG },
   [CHAIN.XLAYER]: { dune: 'xlayer' },
+  // arbitrum.USDC in coreAssets is bridged USDC.e; GMGN's collector is on native USDC
+  [CHAIN.ARBITRUM]: { dune: 'arbitrum', usdc: ADDRESSES.arbitrum.USDC_CIRCLE },
 };
 
 // Solana referral-distribution wallets: GMGN funds these (mainly from BCNsHAH28…)


### PR DESCRIPTION
#8877 added arbitrum to `chainConfig` in `fees/gmgnai.ts`, but the SQL filter is built from `EVM_CHAINS`, which it did not touch:

```ts
const evmFilter = Object.values(EVM_CHAINS)
  .map(({ dune, usdc }) => `(blockchain = '${dune}' AND contract_address IN (...))`)
  .join(' OR ')
```

So the arbitrum leg has queried nothing and reported $0 on every day since its 2026-08-19 start, while the collector was taking real fees there.

Native-ETH inflows to `0xb8159ba378904F803639D274cEc79F788931c9C8` on arbitrum, one row per day since the start date:

```
day         transfers   fees_usd
2026-08-19      8,666   10,442.91
2026-08-20      1,050    1,248.43
2026-08-21        949    1,354.41
2026-08-22        397      643.18
2026-08-23        646      898.54
2026-08-24        761    1,492.81
2026-08-25      1,201    1,656.20
2026-08-26      2,127    3,571.96
2026-08-27      1,995    4,567.67
2026-08-28        588    1,391.10
2026-08-29        459      857.63
2026-08-30      2,059    3,854.16
2026-08-31     14,988   33,780.43
```

$65,759 over 13 days, and the trend is up — 2026-08-31 alone is $33,780 against the $0 currently published.

Running the adapter for 2026-08-31 with this line:

```
chain       | Daily fees | Daily revenue | Daily supply side revenue
bsc         | 351.46 k   | 295.23 k      | 56.23 k
ethereum    | 6.54 k     | 5.50 k        | 1.05 k
base        | 27.16 k    | 22.81 k       | 4.34 k
monad       | 182.00     | 153.00        | 29.00
hyperliquid | 25.18 k    | 21.16 k       | 4.03 k
megaeth     | 0.00       | 0.00          | 0.00
solana      | 185.77 k   | 107.57 k      | 78.20 k
xlayer      | 246.00     | 207.00        | 39.00
robinhood   | 1.54 M     | 1.29 M        | 245.79 k
arbitrum    | 33.78 k    | 28.38 k       | 5.41 k
```

The arbitrum figure matches the on-chain total for that day to the dollar.

On the USDC address: `ADDRESSES.arbitrum.USDC` is bridged USDC.e, so the entry uses `USDC_CIRCLE` (native USDC) to match the canonical-USDC intent of the other chains. GMGN has only taken native ETH on arbitrum so far — no ERC-20 has reached the collector there — but it does take USDC on ethereum, bsc, base and hyperevm, so the leg is there for when it starts.
