### PR TITLE
fix: raindex double-counts every clear-matched trade by 2x

### DIFF
--- a/dexs/raindex/index.ts
+++ b/dexs/raindex/index.ts
@@ -200,7 +200,7 @@ async function fetchV3Vol({ api, getLogs }: FetchOptions, dailyVolume: Balances)
       const clearLog = clearLogs[i].find(v => v.transactionHash === log.transactionHash)
       if (clearLog) {
         const {
-          clearStateChange: { aliceOutput, bobInput }
+          clearStateChange: { aliceOutput }
         } = abi_v3.decodeEventLog("AfterClear", log.data)
         const {
           alice: { validOutputs },
@@ -209,8 +209,9 @@ async function fetchV3Vol({ api, getLogs }: FetchOptions, dailyVolume: Balances)
 
         const token1 = validOutputs[Number(aliceOutputIOIndex)]
 
+        // aliceOutput and bobInput are the two observations of the SAME transfer leg
+        // (what alice sends == what bob receives), not two separate legs - count once.
         dailyVolume.add(token1.token, aliceOutput.toString())
-        dailyVolume.add(token1.token, bobInput.toString())
       }
     })
   })
@@ -255,7 +256,7 @@ async function fetchV4Vol({ api, getLogs }: FetchOptions, dailyVolume: Balances)
       const clearLog = clearLogs[i].find(v => v.transactionHash === log.transactionHash)
       if (clearLog) {
         const {
-          clearStateChange: { aliceOutput, bobInput }
+          clearStateChange: { aliceOutput }
         } = abi_v4.decodeEventLog("AfterClear", log.data)
         const {
           alice: { validOutputs },
@@ -264,8 +265,9 @@ async function fetchV4Vol({ api, getLogs }: FetchOptions, dailyVolume: Balances)
 
         const token1 = validOutputs[Number(aliceOutputIOIndex)]
 
+        // aliceOutput and bobInput are the two observations of the SAME transfer leg
+        // (what alice sends == what bob receives), not two separate legs - count once.
         dailyVolume.add(token1.token, aliceOutput.toString())
-        dailyVolume.add(token1.token, bobInput.toString())
       }
     })
   })
@@ -316,7 +318,7 @@ async function fetchV5_V6Vol({ api, getLogs }: FetchOptions, dailyVolume: Balanc
       const clearLog = clearLogs[i].find(v => v.transactionHash === log.transactionHash)
       if (clearLog) {
         const {
-          clearStateChange: { aliceOutput, bobInput }
+          clearStateChange: { aliceOutput }
         } = abi_v5_v6.decodeEventLog("AfterClearV2", log.data)
         const {
           alice: { validOutputs },
@@ -325,8 +327,9 @@ async function fetchV5_V6Vol({ api, getLogs }: FetchOptions, dailyVolume: Balanc
 
         const token = validOutputs[Number(aliceOutputIOIndex)].token.toLowerCase()
         tokenSet.add(token)
+        // aliceOutput and bobInput are the two observations of the SAME transfer leg
+        // (what alice sends == what bob receives), not two separate legs - count once.
         rawVols.push({ token, rawFloat: aliceOutput.toString() })
-        rawVols.push({ token, rawFloat: bobInput.toString() })
       }
     })
   })
@@ -352,25 +355,29 @@ async function fetchV5_V6Vol({ api, getLogs }: FetchOptions, dailyVolume: Balanc
     calls: tokenList.map((target) => ({ target })),
   });
 
+  // keep only rawVols whose token has a resolved decimals value, and keep the
+  // filtered array itself (not the original rawVols) so `vols[i]` always lines
+  // up with `validRawVols[i]` below - indexing back into the unfiltered rawVols
+  // after a filter silently mis-attributes every entry past the first drop.
+  const validRawVols = rawVols.filter((rawVol) => {
+    const index = tokenList.indexOf(rawVol.token);
+    return index > -1 && typeof decimals[index] !== 'undefined' && decimals[index] !== null
+  })
+
   // format the floats to actual token value
   const vols = await api.multiCall({
     permitFailure: true,
     target: floats[api.chain],
     abi: ABI_V5_V6.float.toFixedDecimalLossy,
-    calls: rawVols
-      .filter((rawVol) => {
-        const index = tokenList.indexOf(rawVol.token);
-        return index > -1 && typeof decimals[index] !== undefined && decimals[index] !== null
-      })
-      .map((rawVol) => ({
-        params: [rawVol.rawFloat, decimals[tokenList.indexOf(rawVol.token)]]
+    calls: validRawVols.map((rawVol) => ({
+      params: [rawVol.rawFloat, decimals[tokenList.indexOf(rawVol.token)]]
     })),
   });
 
   // add vols
   vols.forEach((vol, i) => {
     if (!vol) return // skip error results
-    dailyVolume.add(rawVols[i].token, vol[0].toString())
+    dailyVolume.add(validRawVols[i].token, vol[0].toString())
   })
 }
 


### PR DESCRIPTION
## bug

`dexs/raindex/index.ts` decodes on-chain RainDEX orderbook `AfterClear`+`Clear` events to compute swap volume. For every clear-matched trade, the code pushed **both** `aliceOutput` and `bobInput` as separate volume entries for the same token:

```ts
const token = validOutputs[Number(aliceOutputIOIndex)].token.toLowerCase()
rawVols.push({ token, rawFloat: aliceOutput.toString() })
rawVols.push({ token, rawFloat: bobInput.toString() })   // same token, both halves of ONE transfer
```

`aliceOutput` (what alice sends of token A) and `bobInput` (what bob receives of token A) are the two observations of the **same** internal ledger movement, not two separate legs of the trade. Bob's actual counter-leg (`bobOutput`, token B, the other half of the two-token swap) is never counted at all — there's no `token2` anywhere in this file. The adapter's own `TakeOrder` branch a few lines below adds exactly one amount per fill, so the two paths in the same file were internally inconsistent by exactly 2x.

Same bug shape duplicated at all three orderbook-version code paths: v3 (`:212-213`), v4 (`:267-268`), v5/v6 (`:328-329`).

### why aliceOutput == bobInput, not just usually

RainDEX orderbooks use internal vault accounting for clears — a clear decrements alice's output vault and increments bob's input vault by the same internal amount, with no direct ERC20 transfer (and therefore no fee-on-transfer/rounding path) between the two sides of that leg. So they're not just "usually equal", they're the same number by the contract's own accounting model.

### on-chain proof (real Flare mainnet data, not synthetic)

Queried the real Flare v4 orderbook (`0xcee8cd002f151a536394e564b84076c41bbbcd4d`) via a public Blockscout RPC and decoded 5 real matched `AfterClear`+`Clear` pairs:

```
tx 0xd0e976234920dca590210c2ecb316616753fb8fb883cea01704503f8fe7d5fea
  aliceOutput=14931989949155081831  bobInput=14931989949155081831  equal=true
  bobOutput=8598523  aliceInput=8565489  equal=false   <- the ACTUAL other leg, never counted

tx 0xc286a9cc9c9ec2ad365d2522f91a241eb887b3fbc7bb498433c48d74284f180d
  aliceOutput=5016432829169870307  bobInput=5016432829169870307  equal=true

tx 0x29361dc017c9f89629f828f9a0c3dcd685d20f10b86b26daf94cde1a6b563131
  aliceOutput=0  bobInput=0  equal=true

tx 0x6afd718b453d374f2357d0ba24e0e028171f067dbd0ac6e1505a83c144eed29e
  aliceOutput=0  bobInput=0  equal=true

tx 0xce1b55c118b823ac2f4086f7c09c0b147665d78da1891e28136371a36f170200
  aliceOutput=0  bobInput=0  equal=true
```

5/5 exact matches on `aliceOutput`/`bobInput`; `bobOutput`/`aliceInput` (the real second leg) diverges as expected, since that's genuinely a different token amount.

### isolated before/after (proves exactly 2x, not "some inflation")

Summed the old vs. new code's contribution across 2 real matched clears in one block window on the same orderbook:

```
matched AfterClear+Clear pairs found: 2
OLD (buggy) summed token1 volume across these pairs: 39896845556649904276
NEW (fixed) summed token1 volume across these pairs: 19948422778324952138
ratio old/new: 2
```

### honest scoping — current-day impact

Per this repo's own recent adapter output, there have been no clears on Base/Polygon/Arbitrum orderbooks in the last 30 days, so *today's* reported daily volume is not currently inflated by this bug. The damage is in **stored history and allTime totals** (the v5/v6 orderbooks alone carry 1000+ historical clear events), and it re-inflates the moment clears resume on any chain. This isn't a "the dashboard is wrong right now" bug so much as "the historical record is wrong and will get wrong again."

## second, independent fix — index-misalignment in the v5/v6 decimals-filtering step

```ts
const vols = await api.multiCall({
  ...
  calls: rawVols
    .filter((rawVol) => { ... })   // filtered array
    .map((rawVol) => ({ ... })),
});
vols.forEach((vol, i) => {
  dailyVolume.add(rawVols[i].token, vol[0].toString())   // indexed into the UNFILTERED array
})
```

`vols` is computed from a **filtered** version of `rawVols`, but the result loop indexes back into the **original unfiltered** `rawVols[i]`. Confirmed this is live, not just theoretical: a failed `decimals()` call via `api.multiCall({ permitFailure: true, ... })` returns `null` (verified empirically against the real `@defillama/sdk` against a real bad target on Flare — `[null, "18"]`), and the existing `decimals[index] !== null` check correctly filters that entry out. So whenever any token's decimals lookup fails, `vols` becomes shorter than `rawVols`, and every volume entry *after* the drop gets attributed to the wrong token for the rest of the batch.

Fixed by naming the filtered array (`validRawVols`) and using it consistently for both building `calls` and indexing the result:

```ts
const validRawVols = rawVols.filter((rawVol) => {
  const index = tokenList.indexOf(rawVol.token);
  return index > -1 && typeof decimals[index] !== 'undefined' && decimals[index] !== null
})
const vols = await api.multiCall({ ..., calls: validRawVols.map(...) });
vols.forEach((vol, i) => {
  dailyVolume.add(validRawVols[i].token, vol[0].toString())
})
```

Standalone logic test proving the fix (filter correctly drops the failed-decimals entry, and the result stays correctly indexed):

```
OLD filter (typeof bug) kept: 2 / 3 -- (the null-check already filters correctly on its own)
naive-fix-only (still using rawVols[i]) would misattribute vols[1] (should be C=300) to token: B <- WRONG
NEW fixed code correctly filters to 2 entries, correctly indexed:
  vols[0] -> token A (rawFloat 100)
  vols[1] -> token C (rawFloat 300)
PASS: B correctly dropped, A and C correctly retained and indexed
```

Honest note: the adjacent `typeof decimals[index] !== undefined` was also dead code (always `true` — `typeof` returns a string, which is never `=== undefined`), but fixing that clause alone has **no separate live effect** today, since the existing `!== null` check already does the real filtering work. Fixed it anyway for correctness since it's directly adjacent to the index fix, but not claiming it as an independent behavior change.

## testing

Ran the repo's real adapter test harness (`pnpm test dexs raindex <date> <chain>`) end-to-end against the live Flare chain via a custom RPC (default node RPC's 30-block `eth_getLogs` cap made the default run silently return 0 — used `FLARE_RPC` env override per this repo's README):

```
$ npx ts-node --transpile-only cli/testAdapter.ts dexs raindex 2025-11-29 flare   # fixed code
FLARE 👇
Daily volume: 1.13 k

$ git stash && npx ts-node --transpile-only cli/testAdapter.ts dexs raindex 2025-11-29 flare   # original code
FLARE 👇
Daily volume: 1.14 k
```

(Small diff at the day-aggregate level because most of that day's volume came from `TakeOrder` fills, which were never affected by this bug — the isolated before/after above is the precise measurement of the actually-buggy code path.)

`tsc --project tsconfig.json --noEmit` clean.

## codex review

Ran `codex exec` synchronously as an adversarial second reviewer with the two questions that matter most here (is dropping `bobInput` ever lossy for a real edge case like partial fills/fee-on-transfer/rounding; is the indexing fix sound). It did not return output within 5 minutes and was killed rather than left running in the background — falling back to a thorough self-review instead, which is recorded in this PR's commit message and above (vault-accounting argument for why `aliceOutput`/`bobInput` can't diverge, and the indexing-fix walkthrough).

## risk

Low — reduces reported volume for the affected code path only (no new volume manufactured), and every change is confirmed against real on-chain data or a standalone logic test, not just static reasoning.
