### PR TITLE
edgex: stop the v1 fee leg, its api now returns v2's series

### DIFF
--- a/fees/edgex/index.ts
+++ b/fees/edgex/index.ts
@@ -90,7 +90,7 @@ const breakdownMethodology = {
 const adapter: SimpleAdapter = {
   version: 1,
   adapter: {
-    [CHAIN.EDGEX]: { fetch, start: '2025-02-25'},
+    [CHAIN.EDGEX]: { fetch, start: '2025-02-25', deadFrom: '2026-08-15' },
     [CHAIN.ETHEREUM]: { fetch: fetchBB, start: '2026-04-01'},
   },
   methodology,


### PR DESCRIPTION
Fixes #9108

`pro.edgex.exchange/api/v1/public/quote/fee` and `edgex-prod-v2.edgex.exchange/api/v2/public/quote/fee` now serve the same series, same 115 days, both starting 2026-05-09, fee and revenue equal to the cent on every one of them. so `fees/edgex` and `fees/edgeX-v2` have been returning the same number since 08-28 and `parent#edgex` reports double: 403,016 on 08-28 against 201,508 charged, 248,800 on 08-31 against 124,400.

the last day the v1 endpoint served its own number was 08-14 (2,546). it served nothing from 08-15, which is why `edgeX Perps` has a literal 0 on the 13 days to 08-27 rather than failing, the edgex leg throws but the ethereum leg still returns.

`deadFrom: '2026-08-15'` on the edgex leg keeps v1's real history through 08-14 and stops both symptoms. the ethereum leg stays live: it tracks EDGE buybacks as holders revenue, which `fees/edgeX-v2` does not report, so nothing duplicates it.

```
$ npx ts-node cli/testAdapter.ts fees edgex 2026-08-21
Skipping edgex because the adapter ended at Sat, 15 Aug 2026
ETHEREUM 👇
Daily fees: 0.00
Daily holders revenue: 21.76 k

$ npx ts-node cli/testAdapter.ts fees edgex 2026-08-10
chain     | Daily fees | Daily revenue | Daily supply side revenue | Daily holders revenue
edgex     | 53.83 k    | 39.77 k       | 14.06 k                   | 0.00
ethereum  | 0.00       | 0.00          | 0.00                      | 21.49 k
```
