### PR TITLE
dodo: refuse dashboard zeros for chains that were trading

### DIFF
--- a/dexs/dodo/index.ts
+++ b/dexs/dodo/index.ts
@@ -84,10 +84,29 @@ interface IDailyResponse {
 const fetch = async (options: FetchOptions) => {
   const chain = chainConversion(options.chain)
   const dailyResponse = (await postURL(dailyEndpoint, dailyVolumePayload(chain))) as IDailyResponse
+  const list = dailyResponse.data.dashboard_chain_day_data.list
+  const day = list.find((item: any) => item.timestamp === options.startOfDay)
 
-  return {
-    dailyVolume: dailyResponse.data.dashboard_chain_day_data.list.find((item: any) => item.timestamp === options.startOfDay)?.volume[chain],
+  if (!day)
+    throw new Error(`dodo: dashboard_chain_day_data has no ${chain} row for ${options.dateString}`)
+
+  const dailyVolume = Number(day.volume[chain])
+
+  if (!Number.isFinite(dailyVolume))
+    throw new Error(`dodo: ${chain} is missing from the volume object for ${options.dateString}`)
+
+  if (dailyVolume === 0) {
+    const trailing = list
+      .filter((item: any) => item.timestamp < options.startOfDay && item.timestamp >= options.startOfDay - 7 * 24 * 60 * 60)
+      .map((item: any) => Number(item.volume[chain]))
+      .filter((value: number) => Number.isFinite(value))
+      .sort((a: number, b: number) => a - b)
+    const median = trailing.length ? trailing[Math.floor(trailing.length / 2)] : 0
+    if (median > 10000)
+      throw new Error(`dodo: ${chain} reports 0 volume for ${options.dateString} against a 7 day median of ${Math.round(median)}, refusing to publish a day the dashboard has not finished aggregating`)
   }
+
+  return { dailyVolume }
 }
 
 const chainConversion = (chain: string): string => {


### PR DESCRIPTION
Fixes #9111

`gateway.dodoex.io` returns 0 for a chain that it has not finished aggregating and fills the real number in a day or two later. the fetch had no guard, so those zeros went out as volume and were never revisited: 263,359,877 stored against 481,499,056 on the dashboard now over the 45 days to 08-31, 45.3% under, with days reading $7, $1, $22 and $6 on a $10m/day dex.

the number itself was never wrong, 15 of those 45 days match the dashboard to the dollar. so this only refuses days rather than changing how any value is read:

- no row for the day, or the chain absent from the volume object, now throws instead of returning `undefined`
- a 0 throws when that chain's own trailing 7-day median in the same response is above $10k

the median floor keeps the dust chains quiet. optimism, base, linea and scroll do $0-50 a day and land on a genuine 0 constantly; over the 45 days the guard refuses 24 chain-days across 10 days and touches a dust chain once.

```
$ npx ts-node cli/testAdapter.ts dexs dodo 2026-08-22
Error: dodo: arbitrum reports 0 volume for 2026-08-21 against a 7 day median of 585862,
refusing to publish a day the dashboard has not finished aggregating

$ npx ts-node cli/testAdapter.ts dexs dodo 2026-08-28
arbitrum  | 1.56 M
bsc       | 259.18 k
ethereum  | 5.65 M
polygon   | 6.85 M
avax      | 1.08 M
optimism  | 48.00
base      | 0.03
linea     | 0.00
scroll    | 0.00
Aggregate | 15.40 M
```

the second is chart day 08-27, which we already have as 15,397,966.

one thing i can't check from outside: this only recovers the volume if a chain-day that errored gets refilled once the dashboard settles. if refill is per protocol-day rather than per chain-day then the day still lands short, because on the worst days every chain worth counting is 0 at fetch time and only the dust chains answer. either way it stops us publishing a number we have good reason to distrust, and an erroring chain is at least visible. you'll know the refill semantics better than i do, happy to change the shape of this if the answer is that the adapter should be reading DODOSwap logs instead.
