### PR TITLE
metamask: add the missing Solana leg to swap volume, the chain reports fees but no volume

### DIFF
--- a/aggregators/metamask.ts
+++ b/aggregators/metamask.ts
@@ -1,9 +1,10 @@
 import * as sdk from "@defillama/sdk";
 import { Chain, FetchResultV2 } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
-import { Adapter, FetchOptions } from "../adapters/types";
+import { Adapter, Dependencies, FetchOptions } from "../adapters/types";
 import { formatAddress, sleep } from "../utils/utils";
 import { getDefaultDexTokensBlacklisted } from "../helpers/lists";
+import { queryAllium } from "../helpers/allium";
 
 type IConfig = {
   [s: string | Chain]: {
@@ -64,6 +65,45 @@ export const configs: IConfig = {
     getTrasnactionLimit: 10000,
     start: '2026-01-13',
   },
+}
+
+// MetaMask's two Solana fee wallets. A swap pays one of them in the same transaction, which is
+// how fees/metamask.ts already identifies MetaMask activity on Solana - the volume side simply had
+// no Solana leg, so the chain reports fees while reporting no swap volume at all.
+const SOLANA_FEE_WALLETS = [
+  '47YRE7eLAdYzvGqSH1XLg2o8xUtywk7sS5BKv1oR4Y7i',
+  'HbBHuvgWoChfztoqz2izLRF5mSoLKQXfU68kueBmhcmL',
+];
+
+// Only transactions that also carry a decoded swap count. The same wallets collect bridge fees,
+// and a bridge has no swap notional behind it.
+export const fetchSolana = async (options: FetchOptions): Promise<FetchResultV2> => {
+  const wallets = SOLANA_FEE_WALLETS.map((wallet) => `'${wallet}'`).join(', ');
+  const query = `
+    WITH metamask_txs AS (
+      SELECT DISTINCT txn_id
+      FROM solana.assets.transfers
+      WHERE to_address IN (${wallets})
+        AND block_timestamp >= TO_TIMESTAMP_NTZ(${options.startTimestamp})
+        AND block_timestamp < TO_TIMESTAMP_NTZ(${options.endTimestamp})
+    ),
+    hop_dedup AS (
+      SELECT t.usd_amount
+      FROM solana.dex.trades t
+      INNER JOIN metamask_txs m ON t.txn_id = m.txn_id
+      WHERE t.block_timestamp >= TO_TIMESTAMP_NTZ(${options.startTimestamp})
+        AND t.block_timestamp < TO_TIMESTAMP_NTZ(${options.endTimestamp})
+      QUALIFY ROW_NUMBER() OVER (
+        PARTITION BY t.txn_id, t.instruction_index
+        ORDER BY t.usd_amount DESC
+      ) = 1
+    )
+    SELECT COALESCE(SUM(usd_amount), 0) AS volume
+    FROM hop_dedup
+  `;
+
+  const data = await queryAllium(query);
+  return { dailyVolume: data[0]?.volume ?? 0 };
 }
 
 async function retry(chain: string, fromBlock: number, toBlock: number, address: string): Promise<Array<any>> {
@@ -127,7 +167,12 @@ const adapter: Adapter = {
   version: 2,
   pullHourly: true,
   fetch,
-  adapter: configs,
+  adapter: {
+    ...configs,
+    [CHAIN.SOLANA]: { fetch: fetchSolana, start: '2025-08-12' },
+  },
+  dependencies: [Dependencies.ALLIUM],
+  isExpensiveAdapter: true,
 }
 
 export default adapter;


### PR DESCRIPTION
`fees/metamask` has had a Solana leg since #a1688ce (Feb 2026) and reports real money there — **$298,131 over the last 30 days**, $10,418 on 2026-09-01. `aggregators/metamask` is EVM-only, so MetaMask's Solana **swap volume has never been reported at all**.

```
fees/metamask       chains: Arbitrum Avalanche BSC Base Ethereum Hyperliquid Linea Monad OP Polygon Solana
aggregators/metamask chains: Arbitrum Avalanche BSC Base Ethereum Hyperliquid Linea Monad OP Polygon
```

Nothing was ever removed — the commit that added the Solana fees leg only exported `configs`/`fetch` from this file and moved the methodology across; a Solana volume leg simply never existed.

## The change

Same identification the fees adapter already uses — transactions that pay one of MetaMask's two Solana fee wallets — then the swaps inside those transactions, taken from Allium `solana.dex.trades` and counted once per outer instruction (largest hop). That is the shape `aggregators/riftbeam` and `aggregators/ride-markets` already use for Solana, so the dependency stays `ALLIUM` and `pullHourly` still holds.

## Why only the transactions that carry a swap

The fee wallets collect bridge fees as well as swap fees — the methodology text says "trading, swapping, bridging". On 2026-08-31, 4,267 transactions paid those wallets and only 2,251 contained a decoded swap. Sampling the other 2,016 shows why: they are dominated by a program that never co-occurs with a swap, and by `RangohQxaWip6i1twAAnRVLmob9j88fid7sq2DMAATW` (Rango, a cross-chain aggregator). Counting them would put bridge flow into swap volume, so the join to the trades table drops them.

## The fee rate proves the volume is right

The number to be careful about is which hop counts. I did not pick a convention — I measured it. Splitting 2026-08-31 by route length:

| hops in tx | txs | fees | volume (hop-sum) | rate | volume (largest hop) | rate |
|---|---:|---:|---:|---:|---:|---:|
| 1 | 1,322 | $2,879 | $155,354 | **1.853%** | $155,354 | **1.853%** |
| 2 | 594 | $1,998 | $193,286 | 1.034% | $114,664 | 1.743% |
| 3 | 260 | $2,312 | $223,294 | 1.035% | $111,591 | 2.072% |
| 4 | 73 | $851 | $132,419 | 0.643% | $55,072 | 1.545% |

Single-hop transactions have no convention to choose — hop-sum and largest-hop are the same number — so they give the true rate: **1.853%**. Multi-hop transactions reproduce that rate under largest-hop (1.5–2.1%) and roughly halve it under hop-sum (0.6–1.0%), which is the double-count. So largest-hop is the correct measure, and across all swap transactions that day it implies **1.841%** against **1.853%** from the single-hop ground truth.

For reference the EVM side of this same adapter runs at 0.83–0.92% implied (it hardcodes 0.85%), so MetaMask's Solana rate is genuinely about twice its EVM rate — that is the product, not an artefact.

## Restored volume

Reconstructed with the same logic on Dune's equivalent tables:

| day | volume | DefiLlama today |
|---|---:|---:|
| 2026-08-28 | $607,324 | 0 |
| 2026-08-29 | $481,299 | 0 |
| 2026-08-30 | $351,708 | 0 |
| 2026-08-31 | $436,812 | 0 |

Deduplicating per `(txn_id, instruction_index)` as this PR does, versus per `(tx, trader)`, differs by 0.3–1.1% on those days, so the choice of partition is not load-bearing.

One caveat worth stating plainly: I verified the logic against Dune, since I have no Allium key. The query shape, table names and columns are copied from the merged `aggregators/riftbeam` and the `solana.assets.transfers` / `txn_id` usage in `dexs/basedbid`, `dexs/moonshot-money` and `fees/photon`, but the Allium query itself has not been executed.
