### PR TITLE
fix: pacifica adapters from reporting partial historical volume

### DIFF
--- a/dexs/pacifica-spot/index.ts
+++ b/dexs/pacifica-spot/index.ts
@@ -21,6 +21,7 @@ const fetch = async (options: FetchOptions) => {
       const data = await fetchURLAutoHandleRateLimit(`https://api.pacifica.fi/api/v1/kline?symbol=${ticker}&interval=1d&start_time=${(options.startOfDay) * 1000}`)
       const todaysData = data.data.find((kline: any) => kline.t == options.startOfDay * 1000);
       if (todaysData) dailyVolume += (todaysData.v * +todaysData.c) / 2; // They include taker + maker in ohlcv candles
+      else throw new Error(`No data found for ${ticker} on ${options.startOfDay}`);
       await new Promise(r => setTimeout(r, 4000));
     })
 

--- a/dexs/pacifica-spot/index.ts
+++ b/dexs/pacifica-spot/index.ts
@@ -10,7 +10,8 @@ const fetch = async (options: FetchOptions) => {
   }
 
   const tickers = data.data
-    .filter((tradeSummary: any) => tradeSummary.instrument_type === 'spot')
+    .filter((tradeSummary: any) => tradeSummary.instrument_type === 'spot'
+      && (!tradeSummary.created_at || tradeSummary.created_at < options.endTimestamp * 1000))
     .map((tradeSummary: any) => tradeSummary.symbol)
   let dailyVolume = 0;
 

--- a/dexs/pacifica-spot/index.ts
+++ b/dexs/pacifica-spot/index.ts
@@ -14,15 +14,16 @@ const fetch = async (options: FetchOptions) => {
     .map((tradeSummary: any) => tradeSummary.symbol)
   let dailyVolume = 0;
 
-  await PromisePool.withConcurrency(1)
+  const { errors } = await PromisePool.withConcurrency(1)
     .for(tickers)
     .process(async (ticker) => {
       const data = await fetchURLAutoHandleRateLimit(`https://api.pacifica.fi/api/v1/kline?symbol=${ticker}&interval=1d&start_time=${(options.startOfDay) * 1000}`)
-      const todaysData = data.data.filter((kline: any) => kline.t == options.startOfDay * 1000);
-      const volume = (todaysData[0].v * +todaysData[0].c) / 2; // They include taker + maker in ohlcv candles
-      dailyVolume += volume;
+      const todaysData = data.data.find((kline: any) => kline.t == options.startOfDay * 1000);
+      if (todaysData) dailyVolume += (todaysData.v * +todaysData.c) / 2; // They include taker + maker in ohlcv candles
       await new Promise(r => setTimeout(r, 4000));
     })
+
+  if (errors.length) throw errors[0];
 
   return { dailyVolume }
 }

--- a/dexs/pacifica/index.ts
+++ b/dexs/pacifica/index.ts
@@ -29,15 +29,16 @@ const fetch = async (options: FetchOptions) => {
     .map((tradeSummary: any) => tradeSummary.symbol)
   let dailyVolume = 0;
 
-  await PromisePool.withConcurrency(1)
+  const { errors } = await PromisePool.withConcurrency(1)
     .for(tickers)
     .process(async (ticker) => {
       const data = await fetchURLAutoHandleRateLimit(`https://api.pacifica.fi/api/v1/kline?symbol=${ticker}&interval=1d&start_time=${(options.startOfDay) * 1000}`)
-      const todaysData = data.data.filter((kline: any) => kline.t == options.startOfDay * 1000);
-      const volume = (todaysData[0].v * +todaysData[0].c) / 2; // They include taker + maker in ohlcv candles
-      dailyVolume += volume;
+      const todaysData = data.data.find((kline: any) => kline.t == options.startOfDay * 1000);
+      if (todaysData) dailyVolume += (todaysData.v * +todaysData.c) / 2; // They include taker + maker in ohlcv candles
       await new Promise(r => setTimeout(r, 4000));
     })
+
+  if (errors.length) throw errors[0];
 
   return { dailyVolume }
 }

--- a/dexs/pacifica/index.ts
+++ b/dexs/pacifica/index.ts
@@ -36,6 +36,7 @@ const fetch = async (options: FetchOptions) => {
       const data = await fetchURLAutoHandleRateLimit(`https://api.pacifica.fi/api/v1/kline?symbol=${ticker}&interval=1d&start_time=${(options.startOfDay) * 1000}`)
       const todaysData = data.data.find((kline: any) => kline.t == options.startOfDay * 1000);
       if (todaysData) dailyVolume += (todaysData.v * +todaysData.c) / 2; // They include taker + maker in ohlcv candles
+      else throw new Error(`No data found for ${ticker} on ${options.dateString}`);
       await new Promise(r => setTimeout(r, 4000));
     })
 

--- a/dexs/pacifica/index.ts
+++ b/dexs/pacifica/index.ts
@@ -25,7 +25,8 @@ const fetch = async (options: FetchOptions) => {
   }
 
   const tickers = data.data
-    .filter((tradeSummary: any) => tradeSummary.instrument_type === 'perpetual')
+    .filter((tradeSummary: any) => tradeSummary.instrument_type === 'perpetual'
+      && (!tradeSummary.created_at || tradeSummary.created_at < options.endTimestamp * 1000))
     .map((tradeSummary: any) => tradeSummary.symbol)
   let dailyVolume = 0;
 


### PR DESCRIPTION
## Description

The Pacifica spot and perpetual adapters fetch historical candles for each market using `PromisePool`.

`PromisePool` collects worker failures in its `errors` result instead of rejecting the pool. Because both adapters ignored those errors, a failed market request was omitted while volume from successful markets was still returned. This produced a valid-looking but incomplete daily-volume value.

The adapters also accessed the first matching candle without checking whether one existed. A successful API response with no candle for the requested day therefore caused a runtime error.

## Validation

- Verified empty candle responses return zero volume.
- Verified worker request failures are propagated.
- Ran `npm run ts-check`.
- Ran `npm run ts-check-cli`.
- Ran `git diff --check`.