### PR TITLE
indigo: treat an empty totals array as a broken response, not zero fees

### DIFF
--- a/fees/indigo/index.ts
+++ b/fees/indigo/index.ts
@@ -8,7 +8,7 @@ const ANALYTICS_API_ENDPOINT = 'https://analytics.indigoprotocol.io';
 const fetchRevenueTotals = async (endpoint: string, options: FetchOptions): Promise<Record<string, string | number>> => {
   const url = `${ANALYTICS_API_ENDPOINT}/api/revenue/${endpoint}?totals&inflows_only&from=${options.startTimestamp}&to=${options.endTimestamp}`;
   const { data } = await axios.get(url);
-  if (!data || typeof data.totals !== 'object' || data.totals === null) {
+  if (!data || typeof data.totals !== 'object' || data.totals === null || Array.isArray(data.totals)) {
     throw new Error(`Indigo ${endpoint} returned an unexpected response: ${JSON.stringify(data)?.slice(0, 200)}`);
   }
   return data.totals;


### PR DESCRIPTION
Fixes #9010

indigo has published exactly $0 since 2026-06-10, 83 days now, while tvl went up 29% and 172 cdps settled interest during august. the adapter never threw, so it read as a clean zero rather than a broken adapter.

the analytics api changes shape when its indexer stops populating `value_flow`:

```
collector-flows  2026-05-21  dict  {"lovelace": 685196}
collector-flows  2026-08-30  list  []
flows            2026-05-21  dict  {"lovelace": 888010407}
flows            2026-08-30  list  []
```

`typeof [] === 'object'` and `[] !== null`, so an empty array walks straight past the shape guard, `Object.entries([])` adds nothing, and the day lands on $0.

rejecting an array is enough. it does not need a value check, so a genuinely quiet day that returns `{}` or `{lovelace: 0}` still publishes 0 correctly; an array is never a valid totals map.

```
$ npx ts-node cli/testAdapter.ts fees indigo 2026-08-26
Error: Indigo collector-flows returned an unexpected response: {"totals":[]}

$ npx ts-node cli/testAdapter.ts fees indigo 2026-05-21     # pre-break control
Daily fees: 385.00
Daily revenue: 385.00
Daily protocol revenue: 377.00
Daily holders revenue: 7.62
```

this does not recover the 83 days, indigo's own api no longer serves them, but it stops new false zeros and surfaces the outage instead of hiding it.
