### PR TITLE
openbook: retire the allium-backed adapter, allium has no openbook rows

### DIFF
--- a/factory/alliumSolanaDex.ts
+++ b/factory/alliumSolanaDex.ts
@@ -1,18 +1,18 @@
 import { alliumSolanaDexExport } from "../helpers/alliumDex";
 import { createFactoryExports } from "./registry";
 
-// [alliumDexName, dexId, start]
-const dexsConfigs: Record<string, [string, string, string]> = {
+// [alliumDexName, dexId, start, deadFrom?]
+const dexsConfigs: Record<string, [string, string, string, string?]> = {
   "cropper-clmm": ["cropper", "cropper-whirlpool", "2024-04-24"],
   "fluxbeam": ["fluxbeam", "fluxbeam", "2023-05-29"],
   "obric-v2": ["obric", "obric-v2", "2024-06-04"],
-  "openbook": ["openbook", "openbook", "2022-01-27"],
+  "openbook": ["openbook", "openbook", "2022-01-27", "2025-04-17"],
   "solfi": ["solfi", "solfi", "2024-10-29"],
 };
 
 const dexsProtocols: Record<string, any> = {};
-for (const [name, [alliumDexName, dexId, start]] of Object.entries(dexsConfigs)) {
-  dexsProtocols[name] = alliumSolanaDexExport(alliumDexName, dexId, start);
+for (const [name, [alliumDexName, dexId, start, deadFrom]] of Object.entries(dexsConfigs)) {
+  dexsProtocols[name] = alliumSolanaDexExport(alliumDexName, dexId, start, deadFrom);
 }
 
 export const { protocolList, getAdapter } = createFactoryExports(dexsProtocols);

--- a/helpers/alliumDex.ts
+++ b/helpers/alliumDex.ts
@@ -3,7 +3,7 @@ import { queryAllium } from "./allium"
 import { CHAIN } from "./chains"
 
 
-export function alliumSolanaDexExport(dex_id: string, protocol: string, start: string) {
+export function alliumSolanaDexExport(dex_id: string, protocol: string, start: string, deadFrom?: string) {
   const fetch = async (options: FetchOptions) => {
     const query = `
       SELECT 
@@ -26,6 +26,7 @@ export function alliumSolanaDexExport(dex_id: string, protocol: string, start: s
     fetch,
     chains: [CHAIN.SOLANA],
     start,
+    ...(deadFrom ? { deadFrom } : {}),
     dependencies: [Dependencies.ALLIUM],
   }
 }


### PR DESCRIPTION
Fixes #8854

as agreed in the issue: @juansolana checked with allium access and there are no openbook rows at all, not under a different label, not under the canonical openbook v2 program id, not in `solana.dex.trades` or `crosschain.dex.trades`, and not in any yearly window from 2022 to 2025, while the other four factory adapters return data normally. so the series cannot be recovered from this source and the `$0` it publishes is not a measurement.

last non-zero day is 2025-04-16 at $87,781, followed by 503 consecutive zeros as of today, so `deadFrom: '2025-04-17'`.

this adds an optional 4th field to the factory config rather than deleting the entry, so the protocol keeps its history and can be brought back with one date if a working source turns up.

```
$ npx ts-node -e "..."
cropper-clmm   start=2024-04-24 deadFrom=(none)
fluxbeam       start=2023-05-29 deadFrom=(none)
obric-v2       start=2024-06-04 deadFrom=(none)
openbook       start=2022-01-27 deadFrom=2025-04-17
solfi          start=2024-10-29 deadFrom=(none)
```

note this deliberately does not touch the `?? 0` in the helper. my original suggestion there was wrong and i struck it in the thread, `SELECT SUM(...) as dailyvolume` has no `GROUP BY`, so it always returns exactly one row and `if (!data.length) throw` would never fire on any of the five. separating "allium has no rows for this protocol" from "this protocol had no trades today" needs a second wider-window query, which is a real cost on every run for the other four adapters that are working fine. happy to send that separately if you want it.
