### PR TITLE
lifi: read the per-chain fee forwarder, 15 chains have published $0 since the router migration

### DIFF
--- a/fees/lifi/index.ts
+++ b/fees/lifi/index.ts
@@ -16,6 +16,30 @@ const FeeRouters: Record<string, string> = {
 const DefaultFeeRouter = '0xc18d9e84b8687a2645447a61e52c455dac1675e1'
 const FeeRouter2608 = '0xce40449b773a3e6e5e769adb4e567179d4828cbd'
 
+// The routers above are not deployed on every chain: LI.FI ships a chain-specific FeeForwarder to
+// some of them, and on those chains both addresses have no bytecode at all, so the FeesForwarded
+// leg reads nothing and fees publish as zero. Robinhood is the clearest case - 1,235 FeesForwarded
+// in the last 50k blocks at its own forwarder, none at either address above. Both generations are
+// listed for the same reason the older routers are still read: refills across a migration stay
+// correct. source: https://github.com/lifinance/contracts/tree/main/deployments (FeeForwarder)
+const ChainFeeForwarders: Record<string, string[]> = {
+	[CHAIN.ABSTRACT]: ['0xA577ddDa8E06BE1a0705fE9c6e6Ce2D2011100c9', '0x973Be760B2992D7F01f0d66bEb48A172d10FB79a'],
+	[CHAIN.BERACHAIN]: ['0xc431Ee11b784960CF6ed6a69f91B93fB565b4d44', '0x135566E8702A377D3F7Ec9f0a2bD8009901E8693'],
+	[CHAIN.ERA]: ['0xA577ddDa8E06BE1a0705fE9c6e6Ce2D2011100c9', '0x92870bEd7554532ddE5213aC0f304573D79AaB24'],
+	[CHAIN.FUSE]: ['0x79C3F5B651Ee5782Ba15d968B088458cd5f1f4EF'],
+	[CHAIN.HEMI]: ['0xA5971Bd73Dbb879aAaA6fEcB95Dc3fD50c2e3C25', '0xB401ccdA43C36935e6059C02103E9541FbA3337E'],
+	[CHAIN.INK]: ['0xA5971Bd73Dbb879aAaA6fEcB95Dc3fD50c2e3C25', '0xB401ccdA43C36935e6059C02103E9541FbA3337E'],
+	[CHAIN.KATANA]: ['0xaaa55A0157670Ff2b4CF82F5cd2C754FE54BA574', '0x51586Ff93Ded33DbEb6D5fA68d046Fd036251D8A'],
+	[CHAIN.LINEA]: ['0x72015d314542457cBB6BF14318d82464E4D413ec', '0xD8b700cEd3e486c3c4FC31Fc0c3b3590e1a52D7e'],
+	[CHAIN.MANTLE]: ['0x79C3F5B651Ee5782Ba15d968B088458cd5f1f4EF'],
+	[CHAIN.METIS]: ['0xF46B6684DF5D121D5FDD6cA76Ef4919c65887083', '0x531207ED256C75d26401aEd744333265E4b9029c'],
+	[CHAIN.MONAD]: ['0xA5971Bd73Dbb879aAaA6fEcB95Dc3fD50c2e3C25', '0xB401ccdA43C36935e6059C02103E9541FbA3337E'],
+	[CHAIN.PLUME]: ['0xa2D39966793873f4514E5EcBDB0e1a84cAffa650', '0x32ca3c43c2807EbB7d82212BeeC31c1b7BaaD146'],
+	[CHAIN.ROBINHOOD]: ['0xF4BFFE4dfC693f37715A47c15BdA8af9ed8f7Cf1', '0x4e0eb4c17A2Fc64f06314aFa4d3646241784ab3a'],
+	[CHAIN.SONEIUM]: ['0xA5971Bd73Dbb879aAaA6fEcB95Dc3fD50c2e3C25', '0xB401ccdA43C36935e6059C02103E9541FbA3337E'],
+	[CHAIN.UNICHAIN]: ['0xA5971Bd73Dbb879aAaA6fEcB95Dc3fD50c2e3C25', '0xB401ccdA43C36935e6059C02103E9541FbA3337E'],
+}
+
 // LI.FI's own share of a FeesForwarded payout; every other recipient is an integrator. Verified as
 // the one recipient present on all 21 chains that had payouts on 2026-07-23.
 const LifiRecipient = '0xc06ebbefd94032b85424d51906e2a335efae264b'
@@ -47,8 +71,16 @@ const fetch = async (options: FetchOptions) => {
 		addFee(log._token, log._lifiFee, true);
 	});
 
+	// de-duplicated: on a few chains the chain-specific forwarder IS one of the shared addresses,
+	// and passing it twice would count its logs twice.
+	const forwarderTargets = [...new Set([
+		FeeRouters[options.chain] ?? DefaultFeeRouter,
+		FeeRouter2608,
+		...(ChainFeeForwarders[options.chain] ?? []),
+	].map((address) => address.toLowerCase()))];
+
 	const forwarded: any[] = await options.getLogs({
-		targets: [FeeRouters[options.chain] ?? DefaultFeeRouter, FeeRouter2608],
+		targets: forwarderTargets,
 		eventAbi: FeesForwardedEvent,
 	});
 	forwarded.forEach((log: any) => {


### PR DESCRIPTION
#8982 added the router LI.FI moved to on 2026-08-20 and noted it "sits at the same address on every chain checked". That holds on 22 of the chains this adapter tracks. On 15 it does not, and on those the FeesForwarded leg has been reading contracts that do not exist.

`fees/lifi` reads `[FeeRouters[chain] ?? DefaultFeeRouter, FeeRouter2608]`. On Robinhood Chain (chainId 4663) both of those have **no bytecode**:

```
FeeCollector      0xAD257784C6D50640d1EFa31cfB3e75bD566f63BA   4717 bytes   FeesCollected  in last 50k blocks:     0
DefaultFeeRouter  0xc18d9e84b8687a2645447a61e52c455dac1675e1      0 bytes   FeesForwarded  in last 50k blocks:     0
FeeRouter2608     0xce40449b773a3e6e5e769adb4e567179d4828cbd      0 bytes   FeesForwarded  in last 50k blocks:     0
FeeForwarder v2   0xF4BFFE4dfC693f37715A47c15BdA8af9ed8f7Cf1   3037 bytes   FeesForwarded  in last 50k blocks: 1,235
```

The last line is the contract LI.FI's own deployments file lists for Robinhood, and the one the adapter never reads. Same shape on Linea and Unichain, checked on their own public RPCs:

```
linea     0x72015d314542457cBB6BF14318d82464E4D413ec  3037 bytes  26 events / 9k blocks   both shared addresses: 0 bytes, 0 events
unichain  0xA5971Bd73Dbb879aAaA6fEcB95Dc3fD50c2e3C25  3037 bytes   1 event  / 9k blocks   shared address:        0 bytes, 0 events
```

## Scope

Comparing `FeeForwarder` in each chain's deployment file against the two addresses the adapter reads, across the 49 chains in `LifiFeeCollectors`: **22 match, 15 differ, 12 have no EVM deployment file or are already `deadFrom`.** The 15 that differ are the ones added here. They are currently at $0 fees against $120.8M of 30d volume:

| chain | fees 30d | volume 30d |
|---|---:|---:|
| Robinhood Chain | 0 | 119,024,038 |
| Monad | 0 | 762,918 |
| Katana | 0 | 423,102 |
| Ink | 0 | 279,231 |
| Abstract | 0 | 99,494 |
| Linea | 0 | 41,309 |
| Soneium | 0 | 39,179 |
| ZKsync Era | 0 | 31,656 |
| Unichain | 0 | 29,057 |
| Mantle | 450 | 19,543 |
| Plume | 0 | 14,734 |
| Berachain | 0 | 8,749 |
| Hemi | 0 | 307 |
| Fuse | 1 | 247 |
| Metis | 0 | 2 |

For scale, the protocol's whole reported fee line is $1,165,448/30d.

## Harness, same day, only the adapter code differs

```
                 before    after
linea             0.00      7.71
ink               0.00    691.00
unichain          0.00      5.26
```

Robinhood Chain will not run locally — the public RPC 429s partway through a day of `getLogs` — so its size is measured on-chain instead. Over 2026-08-25..08-31, `0xc06ebbefd94032b85424d51906e2a335efae264b`, the exact `LifiRecipient` this adapter already keys revenue on, received **$33,293** there across 106,190 transfers (Dune `tokens.transfers`, blockchain `robinhood`), against $0 published on every one of those days. That is revenue only; integrator fees ride on the same events.

Note the adapter already calls `getLogs` on Robinhood today for the FeeCollector and the two shared routers, so this adds targets to a call that production already makes rather than introducing log reads on a new chain.

## Details

- Both forwarder generations are listed per chain, for the same reason the older routers are still read — refills across a migration stay correct. The predecessors come from `_deployments_log_file.json` (all v1.0.0, 2025-10-22, except Monad 2025-11-23); Robinhood's predecessor `0x4e0eb4c1..` is from the deployments history and has 2,939 bytes on chain with 0 events now.
- Fuse and Mantle list only their current forwarder because their v1.0.0 address **is** `DefaultFeeRouter`, already a target.
- Targets are de-duplicated before the `getLogs` call, so a chain whose specific forwarder happens to equal a shared address cannot have its logs counted twice.
- Addresses are taken from https://github.com/lifinance/contracts/tree/main/deployments and each one in the table above was checked for bytecode on its own chain.
