### PR TITLE
usdd: accrue tron stability fees on vault debt, not circulating supply

### DIFF
--- a/fees/usdd/index.ts
+++ b/fees/usdd/index.ts
@@ -46,23 +46,18 @@ const TRON_HISTORY_API = "https://app-api.usdd.io/data-platform/collateral-histo
 const toWad = (rad: bigint) => rad / RAY;
 const blockOf = ({ blockNumber, block, block_number }: any) => Number(blockNumber ?? block ?? block_number);
 
-const tronRate = (markets: any[]) => {
-  let debt = 0;
-  let fees = 0;
-
-  markets.forEach(({ curMinted, stabilityFee }) => {
-    const minted = Number(curMinted ?? 0);
-    debt += minted;
-    fees += minted * Number(stabilityFee ?? 0);
-  });
-
-  return debt ? fees / debt : 0;
-};
+const tronAnnualFees = (markets: any[]) =>
+  markets.reduce((sum, { curMinted, stabilityFee }) =>
+    sum + Number(curMinted ?? 0) * Number(stabilityFee ?? 0), 0);
 
 const tronDebt = (items: any[], timestamp: number) => {
   const day = new Date(timestamp * 1000).toISOString().slice(0, 10);
   return Number(items.find((item) => item.time?.startsWith(day))?.debt ?? 0);
 };
+
+const tronLatestSupply = (items: any[]) =>
+  items.reduce((latest, item) =>
+    (item.time ?? '') > (latest?.time ?? '') ? item : latest, items[0]);
 
 const fetch = async (options: FetchOptions) => {
   const dailyFees = options.createBalances();
@@ -75,7 +70,12 @@ const fetch = async (options: FetchOptions) => {
     
     const YEAR = 365 * 24 * 3600;
     const timeframe = options.toTimestamp - options.fromTimestamp;
-    const fee = tronDebt(history.data?.items ?? [], options.fromTimestamp) * tronRate(collaterals.data?.items ?? []) * timeframe / YEAR;
+    const items = history.data?.items ?? [];
+    const supplyOnDay = tronDebt(items, options.fromTimestamp);
+    const supplyNow = Number(tronLatestSupply(items)?.debt ?? 0);
+    const annualFees = tronAnnualFees(collaterals.data?.items ?? []);
+    if (!supplyNow) throw new Error('usdd: tron collateral-history returned no dated supply rows');
+    const fee = annualFees * (supplyOnDay / supplyNow) * timeframe / YEAR;
 
     dailyFees.addUSDValue(fee, METRIC.BORROW_INTEREST);
 


### PR DESCRIPTION
Fixes #8898

the tron leg pairs a rate weighted over vault debt with a debt figure that is circulating supply:

```ts
const fee = tronDebt(history) * tronRate(collaterals) * timeframe / YEAR;
```

`tronRate` weights `stabilityFee` by `curMinted` across ilks, so it is the average rate on $463m of vault debt. `tronDebt` reads `debt` from `collateral-history`, which equals `mintedUSDD` and `usddTotalSupply` to within 0.08% and is $1.22b. the gap is USDD not minted against a fee-paying vault, and it does not accrue stability fees.

as of today:

```
vault debt            463,435,710
annual fees             2,348,832   (= sum curMinted * stabilityFee)
vault-weighted rate      0.005068
circulating supply  1,218,413,599

published formula   supply * vaultRate         = $16,919/day
this PR             annualFees * supplyRatio   = $6,435/day
                                          2.629x overstated
```

`api.llama.fi/summary/fees/usdd` reads 17,096 for 09-01 and tron is effectively the whole line, so that is the path being taken.

the numerator `tronRate` computes and then divides away is already the answer, `sum(curMinted_i * stabilityFee_i)` is the annual accrual. i kept `collateral-history` in, scaling by `supplyOnDay / supplyNow`, so the day-to-day shape still comes from the dated series instead of going flat; on the latest day the ratio is 1 and the fee is just the vault accrual. equivalent to the second framing in the issue, applying a supply-weighted rate of `2348832 / 1218413599 = 0.001928` to dated supply.

the open question from the issue stands and this does not solve it: `vault/collaterals` is a current snapshot with no date parameter, so a backfill applies today's per-ilk mix to older days. if there is a dated endpoint for per-ilk `curMinted` that would be the clean fix. this is strictly better than what is there now on both axes though, right level today, same dated shape.

also added a throw when `collateral-history` returns no dated rows, since `supplyOnDay / supplyNow` would otherwise be `0/0`.

harness could not be used for this one, the tron rpcs rate-limit locally (429 from trongrid, 500 from drpc) before the adapter runs, and the tron branch never touches a block anyway. the numbers above are computed straight off the two endpoints the adapter reads.
