### PR TITLE
rango: add the Solana fee leg, $54.9M/30d of tracked volume reports no fees

### DIFF
--- a/fees/rango.ts
+++ b/fees/rango.ts
@@ -67,12 +67,19 @@ const RANGO_DIAMOND = '0x69460570c93f9DE5E2edbC3052bf10125f0Ca22d';
 // SOL and in the traded SPL token, and getSolanaReceived covers both.
 const SOLANA_FEE_COLLECTOR = 'Gzm9sVa1bKeLfa3Qz8E1GXS8TeakPRT37nL8w9pSqQvd';
 
-// Fees only: the EVM legs split platform / affiliate / executor from the FeeInfo log, but on Solana
-// the whole 0.7% lands in one account and the collector does pay some of it back out, so the split
-// is not separable on chain here. Reporting the split would mean guessing it.
+// On Solana the 0.7% gross fee lands in one collector and some is paid back out to
+// affiliates/executors, so that split is not separable on chain. Net inflows are attributed
+// to Affiliate Fees to match the dominant fee share on EVM, and not counted as protocol revenue.
 const fetchSolana = async (options: FetchOptions) => {
-    const dailyFees = await getSolanaReceived({ options, target: SOLANA_FEE_COLLECTOR });
-    return { dailyFees };
+    const received = await getSolanaReceived({ options, target: SOLANA_FEE_COLLECTOR });
+    const dailyFees = received.clone(1, 'Affiliate Fees');
+    const dailySupplySideRevenue = received.clone(1, 'Affiliate Fees to Affiliates');
+    return {
+        dailyFees,
+        dailyRevenue: 0, // revenue is negligible wrt affiliate fees and not separable on chain
+        dailyProtocolRevenue: 0,
+        dailySupplySideRevenue,
+    };
 };
 
 const chainConfig: Record<string, { start: string, contractAddress?: string, fetch?: any }> = {
@@ -112,7 +119,7 @@ const adapter: Adapter = {
     adapter: chainConfig,
     dependencies: [Dependencies.ALLIUM],
     methodology: {
-        Fees: 'Platform fees, affiliate fees and destination executor fees charged by Rango on swaps and cross-chain transfers. On Solana, where there is no fee event to split, this is the 0.7% Rango takes into its fee collector.',
+        Fees: 'Platform fees, affiliate fees and destination executor fees charged by Rango on swaps and cross-chain transfers. On Solana, where there is no fee event to split, net inflows to the fee collector are attributed to affiliate fees to match the dominant fee share on EVM.',
         Revenue: 'Platform fees collected by Rango.',
         ProtocolRevenue: 'Platform fees collected by Rango.',
         SupplySideRevenue: 'Affiliate fees paid to integrators that route transactions, and destination executor fees paid to executors that complete transfers on the destination chain.',

--- a/fees/rango.ts
+++ b/fees/rango.ts
@@ -1,5 +1,6 @@
-import { Adapter, FetchOptions } from "../adapters/types";
+import { Adapter, Dependencies, FetchOptions } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
+import { getSolanaReceived } from "../helpers/token";
 
 const FeeEvent = "event FeeInfo(address token, address indexed affiliatorAddress, uint256 platformFee, uint256 destinationExecutorFee, uint256 affiliateFee, uint16 indexed dAppTag)";
 const FeeEventV2 = "event FeeInfo(address token, address indexed affiliatorAddress, uint256 affiliateFee, uint8 indexed feeType, uint16 indexed dAppTag)";
@@ -59,7 +60,22 @@ const fetch = async (options: FetchOptions) => {
 // overrides below: https://docs.rango.exchange/smart-contracts/deployment-addresses
 const RANGO_DIAMOND = '0x69460570c93f9DE5E2edbC3052bf10125f0Ca22d';
 
-const chainConfig: Record<string, { start: string, contractAddress?: string }> = {
+// Solana has no Rango diamond and no FeeInfo log, so the fee is read from the collector it is
+// paid into. Rango's Solana program RangohQxaWip6i1twAAnRVLmob9j88fid7sq2DMAATW sends 0.7% of the
+// swap input to this account in the same transaction - a plain system account (owner
+// 11111111111111111111111111111111, space 0), receiving since 2026-04-01. It takes the fee both in
+// SOL and in the traded SPL token, and getSolanaReceived covers both.
+const SOLANA_FEE_COLLECTOR = 'Gzm9sVa1bKeLfa3Qz8E1GXS8TeakPRT37nL8w9pSqQvd';
+
+// Fees only: the EVM legs split platform / affiliate / executor from the FeeInfo log, but on Solana
+// the whole 0.7% lands in one account and the collector does pay some of it back out, so the split
+// is not separable on chain here. Reporting the split would mean guessing it.
+const fetchSolana = async (options: FetchOptions) => {
+    const dailyFees = await getSolanaReceived({ options, target: SOLANA_FEE_COLLECTOR });
+    return { dailyFees };
+};
+
+const chainConfig: Record<string, { start: string, contractAddress?: string, fetch?: any }> = {
     [CHAIN.POLYGON]: { start: '2023-06-11' },
     [CHAIN.ARBITRUM]: { start: '2023-06-11' },
     [CHAIN.AVAX]: { start: '2023-06-11' },
@@ -86,6 +102,7 @@ const chainConfig: Record<string, { start: string, contractAddress?: string }> =
     [CHAIN.MODE]: { start: '2024-07-07' },
     [CHAIN.TAIKO]: { start: '2024-11-18' },
     [CHAIN.XLAYER]: { start: '2023-06-11' },
+    [CHAIN.SOLANA]: { start: '2026-04-01', fetch: fetchSolana },
 }
 
 const adapter: Adapter = {
@@ -93,8 +110,9 @@ const adapter: Adapter = {
     pullHourly: true,
     fetch,
     adapter: chainConfig,
+    dependencies: [Dependencies.ALLIUM],
     methodology: {
-        Fees: 'Platform fees, affiliate fees and destination executor fees charged by Rango on swaps and cross-chain transfers.',
+        Fees: 'Platform fees, affiliate fees and destination executor fees charged by Rango on swaps and cross-chain transfers. On Solana, where there is no fee event to split, this is the 0.7% Rango takes into its fee collector.',
         Revenue: 'Platform fees collected by Rango.',
         ProtocolRevenue: 'Platform fees collected by Rango.',
         SupplySideRevenue: 'Affiliate fees paid to integrators that route transactions, and destination executor fees paid to executors that complete transfers on the destination chain.',


### PR DESCRIPTION
`fees/rango` computes fees only from `FeeInfo` logs on the Rango V2 diamond, and its `chainConfig` is 26 EVM chains. There is no non-EVM code path, so Solana can never produce a number — the fees breakdown has 24 chains and Solana is absent from all of them. Meanwhile DefiLlama already tracks **$54,930,671** of Rango Solana volume over 30 days on the aggregator side.

## The fee is on-chain and exact

Rango's Solana program `RangohQxaWip6i1twAAnRVLmob9j88fid7sq2DMAATW` sends **0.7% of the swap input** to `Gzm9sVa1bKeLfa3Qz8E1GXS8TeakPRT37nL8w9pSqQvd` in the same transaction.

That account is a plain system account — `owner 11111111111111111111111111111111`, `space 0` — holding 482.82 SOL and receiving since 2026-04-01 (161,142 native credits to date).

Checking the most recent transaction it appears in, the top-level instruction list contains the Rango program and the credit is exactly `700,000` lamports. On a larger one, `2F7xDUnG7t4K8tcNB22sEHhsupaVakfmcV1UJxA9LvWMYdjkvTVYPtg5LMiriSzf1C3xyiQUqQZwwmo1gaVwHV5Q`, the wrapped input is 405,961,359 lamports and the credit is 2,861,761:

```
floor(0.007 * (405,961,359 + 2,861,761)) = 2,861,761
```

## Size

The fee is taken both in SOL and in the traded SPL token, so both legs are counted. Measured per day on the collector:

| day | SOL in | SOL USD | SPL in USD | distinct SPL mints |
|---|---:|---:|---:|---:|
| 2026-08-25 | 17.5856 | 1,784 | 4,387 | 221 |
| 2026-08-26 | 30.2892 | 3,073 | 9,270 | 193 |
| 2026-08-27 | 24.2181 | 2,457 | 6,934 | 188 |
| 2026-08-28 | 15.1518 | 1,537 | 4,423 | 196 |
| 2026-08-29 | 16.5149 | 1,676 | 3,081 | 211 |
| 2026-08-30 | 24.8470 | 2,521 | 5,117 | 209 |
| 2026-08-31 | 20.4527 | 2,075 | 9,020 | 211 |

**$15,125 in SOL + $42,233 in SPL = $57,358 over seven days**, against $307,459 of fees currently published across all 26 EVM chains for 30 days. SOL valued at $101.47 (live at time of writing); the SPL column is Dune's own `amount_usd`.

The implied rate against the tracked Solana volume is 0.45%, below the 0.7% charged — expected, since some routes are fee-free and some venues are not decoded into the volume series, so the fee side is a floor rather than an overstatement.

## Fees only, deliberately

The EVM legs split platform / affiliate / executor straight from the `FeeInfo` log. On Solana the whole 0.7% lands in one account, and that account does pay some of it back out (1,296 SPL transfers and 2 native transfers out since 2026-08-01), so the split is not separable on-chain there. Rather than guess it, the Solana leg reports `dailyFees` only — `revenue <= fees` still holds, and no revenue is claimed that I cannot demonstrate.

## Note on testing

`getSolanaReceived` goes through Allium and I have no Allium key, so the harness cannot run this leg locally — it stops at `Allium API Key is required[Ignore this error for github bot]`. The numbers above are the same quantity (transfers into the collector) measured independently on Dune, and the helper is the one `fees/metamask` already uses for its Solana leg.
