### PR TITLE
fly-trade: add the Robinhood fee leg, the protocol's #2 chain has no entry in the fee config

### DIFF
--- a/fees/fly-trade/index.ts
+++ b/fees/fly-trade/index.ts
@@ -56,6 +56,7 @@ const chainConfig: Record<string, { router: string; start: string }> = {
   [CHAIN.TELOS]: { router: ROUTER_B, start: "2026-05-03" },
   [CHAIN.ERA]: { router: ROUTER_C, start: "2026-05-03" },
   [CHAIN.PHAROS]: { router: ROUTER_D, start: "2026-05-03" },
+  [CHAIN.ROBINHOOD]: { router: ROUTER_A, start: "2026-06-24" },
 };
 
 const swapEvent =


### PR DESCRIPTION
`fees/fly-trade` covers 31 chains but has no `chainConfig` entry for Robinhood, so the chain can never produce a number. DefiLlama already tracks **$116,537,566 / 30d** of fly.trade volume there through `aggregators/magpie` (Robinhood was added to the volume adapter in #8089), and it is the protocol's second-largest chain.

### The chain is live on the router this adapter already reads

`0x20f6ee51340adeed01a59b0e65cb3703f3dc860c` (the default `ROUTER_A` used by most chains in this file) is deployed on Robinhood — 8,679 bytes of code. Routers B, C and D and the legacy fee collector all return empty code there, so `ROUTER_A` is the correct target, matching the file's existing comment.

It has emitted `Swap` continuously since **2026-06-24 18:50:43 UTC** (955,758 events to date). Over the last 35 days it is the **second-busiest fly chain by Swap count**:

| chain | Swap events, last 35d | in `chainConfig`? |
|---|---:|---|
| bsc | 637,614 | yes |
| **robinhood** | **465,078** | **no** |
| base | 458,782 | yes |
| ethereum | 31,781 | yes |
| avalanche | 24,422 | yes |

### The fees land on the same receiver the BSC leg already counts

Every fee entry on Robinhood pays `0xcd6b980029e6e6e0733ac8ec3e02be9410d09799`. Decoding recent `Swap` logs on BSC — a chain this adapter already tracks and where DefiLlama reports $63,184/30d — shows the **same** address as the fee receiver, and the four `consumerId` values seen on Robinhood also appear on BSC. So this change introduces no new fee semantics; it runs the existing code path on a chain that was missing from the map.

### Measured impact

I pulled every `Swap` log for two full days over the Robinhood RPC, decoded the fee arrays, and priced each token through `coins.llama.fi` at the end of each hourly window — the same hourly cadence the adapter runs at (`pullHourly: true`). Log counts match Dune's independent count for both days exactly (15,631 and 4,185).

| day | Swap events | dailyFees | dailyRevenue | dailySupplySideRevenue |
|---|---:|---:|---:|---:|
| 2026-08-20 (quiet) | 4,185 | $1,116 | $480 | $636 |
| 2026-08-31 (busy) | 15,631 | $15,868 | $8,716 | $7,152 |

For scale, fly.trade currently reports **$111,926 across 30 days and all 31 configured chains**, so the busy day alone is ~14% of a month of everything else. Both figures are lower bounds: 450 of the 612 fee/surplus tokens on 2026-08-31 have no DefiLlama price and are dropped, which is the framework's normal behaviour.

### Verification against the adapter itself

The public Robinhood RPC rate-limits my IP, so the local harness only completed the first four hourly windows before hitting 429. Those four windows match my independent reconstruction to the cent:

| hour (UTC, 2026-08-31) | harness fees / revenue / supply-side | reconstruction |
|---|---|---|
| 00:00 | 98 / 31 / 68 | 99.23 / 31.33 / 67.90 |
| 01:00 | 67 / 43 / 24 | 67.31 / 43.11 / 24.20 |
| 02:00 | 345 / 149 / 196 | 345.46 / 149.12 / 196.34 |
| 03:00 | 231 / 132 / 99 | 230.85 / 132.11 / 98.74 |

(The harness prints whole dollars.) The 429s are a limit on my IP against the public endpoint — `ROBINHOOD_RPC` is configured in production and other adapters already read this chain on-chain.

`start` is set to `2026-06-24`, the day of the first `Swap` event on Robinhood. That is after the `MIGRATION_TS` cutover, so the router branch applies to the chain's entire history and the legacy fee-collector branch is never taken (that collector has no code on Robinhood either).

Solana and Fogo also report fly.trade volume with no fees, but they are SVM and need a separate implementation — not in this diff.

`ts-check` passes.
