### PR TITLE
swaap-v2: read the day's own snapshot, not the next day's — 54% of volume goes unpublished

### DIFF
--- a/dexs/swaap-v2.ts
+++ b/dexs/swaap-v2.ts
@@ -84,8 +84,11 @@ interface Data {
 }
 
 const getVolume = async (options: FetchOptions) => {
-  const starttimestamp = options.startOfDay;
-  const endtimestamp = starttimestamp + 86400;
+  // A swaapSnapshot accumulates through the day its id names, so a day's volume is its own
+  // snapshot minus the previous day's. Reading the next day's snapshot shifted the series one
+  // day forward and, in production, read that snapshot while it was still filling up.
+  const endtimestamp = options.startOfDay;
+  const starttimestamp = endtimestamp - 86400;
   const startId = config[options.chain].id + '-' + starttimestamp;
   const endId = config[options.chain].id + '-' + endtimestamp;
 


### PR DESCRIPTION
`dexs/swaap-v2` derives a day's volume from two `swaapSnapshot` entities:

```ts
const starttimestamp = options.startOfDay;
const endtimestamp = starttimestamp + 86400;
```

A `swaapSnapshot` accumulates through the day its id names, so the volume of day D is `snapshot(D) − snapshot(D−1)`. The adapter reads `snapshot(D+1) − snapshot(D)` instead, which is day D+1's volume — and since production runs shortly after day D closes, `snapshot(D+1)` is still filling up when it is read, so what actually gets published is the first few minutes of the next day.

### Which window is right

The subgraph carries `totalSwapCount` alongside `totalSwapVolume`, so the two candidate windows can be tested against an independent on-chain swap count. Random sample of 30 days per chain (`random.seed(42)`) drawn from 2025-09-01 … 2026-07-31:

| chain | days | `snapshot(D) − snapshot(D−1)` matches on-chain count | current `snapshot(D+1) − snapshot(D)` | median USD error vs on-chain |
|---|---:|---:|---:|---:|
| ethereum | 30 | **30/30** | 0/30 | 0.07% |
| polygon | 30 | **30/30** | 0/30 | 0.07% |
| base | 30 | **30/30** | 0/30 | 0.02% |
| bsc | 30 | **30/30** | 0/30 | 0.06% |
| optimism | 30 | **30/30** | 0/30 | 0.08% |

150/150 against 0/150. On the two days I looked at first, the counts line up exactly: Ethereum 2026-08-30 had 379 swaps on-chain and `snapshot(08-30) − snapshot(08-29)` is 379, while the current window gives 287 — which is 08-31's count.

The adapter's own config corroborates the convention: `firstDayVolume` for Polygon is `240.41984714755376`, and `swaapSnapshot("2-1688083200")` — Polygon's start date, 2023-06-30 — holds `totalSwapVolume` `240.41984714755376` with `totalSwapCount` 2. The first day's volume is that day's own snapshot.

### What it costs today

Over the 60 days to 2026-08-31:

| chain | correct | published | ratio | days published below half |
|---|---:|---:|---:|---:|
| ethereum | $390,678,244 | $178,286,784 | 0.456 | 39/60 |
| polygon | $795,514 | $264,052 | 0.332 | 38/60 |
| base | $4,610,263 | $1,844,422 | 0.400 | 40/60 |
| bsc | $4,257,130 | $1,620,304 | 0.381 | 39/60 |
| optimism | $2,191,263 | $1,385,825 | 0.632 | 33/60 |
| **total** | **$402,532,414** | **$183,401,386** | **0.456** | |

**$219,131,027 (54.4%) not published over 60 days.**

### Before / after, every chain, 2026-08-30

Local run of `cli/testAdapter.ts dexs swaap-v2 2026-08-31`, against an independent on-chain reconstruction:

| chain | published today | this PR | on-chain |
|---|---:|---:|---:|
| ethereum | 163,597 | 4.22 M | $4,224,207.90 |
| base | 1,616 | 77.16 k | $77,088.79 |
| bsc | 0 | 5.34 k | $5,335.71 |
| polygon | 0 | 2.76 k | $2,756.27 |
| optimism | 0 | 186.00 | $186.30 |

### Missing-snapshot exposure is unchanged

If a boundary snapshot is absent, `|| 0` makes the delta the whole cumulative. I counted the days exposed to that over each chain's full history, for both windows: ethereum 21 vs 21, polygon 0 vs 0, base 1 vs 1, bsc 5 vs 5, optimism 3 vs 3. The window moves, the exposure does not, so this change neither adds nor removes that risk.

`dexs/swaap-v1` is a separate on-chain adapter and is unaffected. `ts-check` passes.
