### PR TITLE
[ADD] Rapid Launch - Solana fees adapter

### DIFF
--- a/fees/rapid-launch.ts
+++ b/fees/rapid-launch.ts
@@ -1,7 +1,6 @@
 import { Dependencies, FetchOptions, SimpleAdapter } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
 import ADDRESSES from "../helpers/coreAssets.json";
-import { METRIC } from "../helpers/metrics";
 import { getSolanaReceived } from "../helpers/token";
 
 // The legacy collector was swept into the current collector on 2025-07-05:
@@ -13,6 +12,8 @@ const CURRENT_FEE_COLLECTOR = "rapidXMVLw5uBieKHDGvF9k4xSSDXyD2FC5wLTAajaJ";
 // Legacy dedicated fee collector: https://orbmarkets.io/address/feesEi65EDHZ7jVMPUicJtnCyTnsoqnQB93GHqLZ6BC/history
 const LEGACY_FEE_COLLECTOR = "feesEi65EDHZ7jVMPUicJtnCyTnsoqnQB93GHqLZ6BC";
 const FEE_COLLECTORS = [CURRENT_FEE_COLLECTOR, LEGACY_FEE_COLLECTOR];
+const COLLECTOR_FEES = "Rapid Launch Collector Fees";
+const COLLECTOR_FEES_TO_TREASURY = "Rapid Launch Collector Fees To Treasury";
 
 /** Fetches external SOL receipts sent to Rapid Launch's dedicated fee collectors. */
 const fetch = async (options: FetchOptions) => {
@@ -29,13 +30,15 @@ const fetch = async (options: FetchOptions) => {
   });
 
   const dailyFees = options.createBalances();
-  dailyFees.addBalances(received, METRIC.PROTOCOL_FEES);
+  dailyFees.addBalances(received, COLLECTOR_FEES);
+  const dailyRevenue = options.createBalances();
+  dailyRevenue.addBalances(received, COLLECTOR_FEES_TO_TREASURY);
 
   return {
     dailyFees,
     dailyUserFees: dailyFees,
-    dailyRevenue: dailyFees,
-    dailyProtocolRevenue: dailyFees,
+    dailyRevenue,
+    dailyProtocolRevenue: dailyRevenue,
   };
 };
 
@@ -55,8 +58,16 @@ const adapter: SimpleAdapter = {
   },
   breakdownMethodology: {
     Fees: {
-      [METRIC.PROTOCOL_FEES]:
+      [COLLECTOR_FEES]:
         "SOL received by the current and legacy Rapid Launch fee collectors from external addresses.",
+    },
+    Revenue: {
+      [COLLECTOR_FEES_TO_TREASURY]:
+        "SOL receipts retained by Rapid Launch after excluding collector-to-collector transfers.",
+    },
+    ProtocolRevenue: {
+      [COLLECTOR_FEES_TO_TREASURY]:
+        "SOL receipts retained by Rapid Launch as protocol revenue.",
     },
   },
 };

--- a/fees/rapid-launch.ts
+++ b/fees/rapid-launch.ts
@@ -12,8 +12,17 @@ const CURRENT_FEE_COLLECTOR = "rapidXMVLw5uBieKHDGvF9k4xSSDXyD2FC5wLTAajaJ";
 // Legacy dedicated fee collector: https://orbmarkets.io/address/feesEi65EDHZ7jVMPUicJtnCyTnsoqnQB93GHqLZ6BC/history
 const LEGACY_FEE_COLLECTOR = "feesEi65EDHZ7jVMPUicJtnCyTnsoqnQB93GHqLZ6BC";
 const FEE_COLLECTORS = [CURRENT_FEE_COLLECTOR, LEGACY_FEE_COLLECTOR];
+// The current collector distributes 14% of each sweep to these referral wallets.
+// Representative distribution: https://solscan.io/tx/4HkyycaGr5kh1LArpyisEHJFsHLr4sMDcBjgAd7rCBLsJgb7v9J3ThrZD4JYcorkWtEmEWaKJJy2NG6of2ECvV4H
+const REFERRAL_RECIPIENTS = [
+  "3os7e5tBFKXFhKZ8igzpCpZr8cw5DvwHrc5bZwELjiLL", // 6.2%
+  "AaNQ9Bf2knDsxPSCjwLDRpCi6Ejgov9CGUNVdF5LyFUB", // 5.2%
+  "A8pkLHANwLsHoRLe2zKGVnehNsUQXM9S1FortS1hRuHi", // 1.6%
+  "H9zga9rFmAoZ3VQHhXYe3VTJiGvhc3cqVjCHrXM8kvti", // 1.0%
+];
 const COLLECTOR_FEES = "Rapid Launch Collector Fees";
 const COLLECTOR_FEES_TO_TREASURY = "Rapid Launch Collector Fees To Treasury";
+const REFERRAL_FEES_TO_REFERRERS = "Rapid Launch Referral Fees To Referrers";
 
 /** Fetches external SOL receipts sent to Rapid Launch's dedicated fee collectors. */
 const fetch = async (options: FetchOptions) => {
@@ -21,24 +30,39 @@ const fetch = async (options: FetchOptions) => {
   // historically also collected fees in standalone System Program transfers.
   // The dedicated collector is therefore the stable attribution signal; filtering
   // by one launchpad program would omit both integrations and most legacy fees.
-  const received = await getSolanaReceived({
-    options,
-    targets: FEE_COLLECTORS,
-    mints: [ADDRESSES.solana.SOL],
-    blacklists: FEE_COLLECTORS,
-    blacklist_signers: FEE_COLLECTORS,
-  });
+  const [received, referralDistributions] = await Promise.all([
+    getSolanaReceived({
+      options,
+      targets: FEE_COLLECTORS,
+      mints: [ADDRESSES.solana.SOL],
+      blacklists: FEE_COLLECTORS,
+      blacklist_signers: FEE_COLLECTORS,
+    }),
+    getSolanaReceived({
+      options,
+      targets: REFERRAL_RECIPIENTS,
+      mints: [ADDRESSES.solana.SOL],
+      fromAddresses: FEE_COLLECTORS,
+    }),
+  ]);
 
   const dailyFees = options.createBalances();
   dailyFees.addBalances(received, COLLECTOR_FEES);
+  const dailySupplySideRevenue = options.createBalances();
+  dailySupplySideRevenue.addBalances(
+    referralDistributions,
+    REFERRAL_FEES_TO_REFERRERS,
+  );
   const dailyRevenue = options.createBalances();
   dailyRevenue.addBalances(received, COLLECTOR_FEES_TO_TREASURY);
+  dailyRevenue.subtract(referralDistributions, COLLECTOR_FEES_TO_TREASURY);
 
   return {
     dailyFees,
     dailyUserFees: dailyFees,
     dailyRevenue,
     dailyProtocolRevenue: dailyRevenue,
+    dailySupplySideRevenue,
   };
 };
 
@@ -53,8 +77,10 @@ const adapter: SimpleAdapter = {
   methodology: {
     Fees: "SOL fees paid by users for Rapid Launch token deployment and trading tools.",
     Revenue:
-      "Fees collected by Rapid Launch, excluding transfers between its fee collectors.",
+      "Fees collected by Rapid Launch after referral distributions are paid to referrers.",
     ProtocolRevenue: "Same as Revenue.",
+    SupplySideRevenue:
+      "SOL distributed from Rapid Launch's fee collectors to referral recipients.",
   },
   breakdownMethodology: {
     Fees: {
@@ -68,6 +94,10 @@ const adapter: SimpleAdapter = {
     ProtocolRevenue: {
       [COLLECTOR_FEES_TO_TREASURY]:
         "SOL receipts retained by Rapid Launch as protocol revenue.",
+    },
+    SupplySideRevenue: {
+      [REFERRAL_FEES_TO_REFERRERS]:
+        "SOL distributed by Rapid Launch's fee collectors to referral recipients.",
     },
   },
 };

--- a/fees/rapid-launch.ts
+++ b/fees/rapid-launch.ts
@@ -1,0 +1,62 @@
+import { Dependencies, FetchOptions, SimpleAdapter } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+import ADDRESSES from "../helpers/coreAssets.json";
+import { METRIC } from "../helpers/metrics";
+import { getSolanaReceived } from "../helpers/token";
+
+// The legacy collector was swept into the current collector on 2025-07-05.
+// Excluding transfers and signatures from both collectors prevents that treasury
+// migration (and any later internal movements) from being counted as user fees.
+const FEE_COLLECTORS = [
+  "feesEi65EDHZ7jVMPUicJtnCyTnsoqnQB93GHqLZ6BC",
+  "rapidXMVLw5uBieKHDGvF9k4xSSDXyD2FC5wLTAajaJ",
+];
+
+async function fetch(options: FetchOptions) {
+  const received = await getSolanaReceived({
+    options,
+    targets: FEE_COLLECTORS,
+    mints: [ADDRESSES.solana.SOL],
+    blacklists: FEE_COLLECTORS,
+    blacklist_signers: FEE_COLLECTORS,
+  });
+
+  const dailyFees = options.createBalances();
+  dailyFees.addBalances(received, METRIC.PROTOCOL_FEES);
+
+  return {
+    dailyFees,
+    dailyUserFees: dailyFees,
+    dailyRevenue: dailyFees,
+    dailyProtocolRevenue: dailyFees,
+  };
+}
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  pullHourly: true,
+  dependencies: [Dependencies.ALLIUM],
+  isExpensiveAdapter: true,
+  adapter: {
+    [CHAIN.SOLANA]: {
+      fetch,
+      start: "2025-04-01",
+    },
+  },
+  methodology: {
+    Fees: "SOL fees paid by users for Rapid Launch token deployment and trading tools.",
+    UserFees:
+      "SOL fees paid by users for Rapid Launch token deployment and trading tools.",
+    Revenue:
+      "Fees collected by Rapid Launch, excluding transfers between its fee collectors.",
+    ProtocolRevenue: "Same as Revenue.",
+  },
+  breakdownMethodology: {
+    Fees: {
+      [METRIC.PROTOCOL_FEES]:
+        "SOL received by the current and legacy Rapid Launch fee collectors from external addresses.",
+    },
+  },
+};
+
+export default adapter;

--- a/fees/rapid-launch.ts
+++ b/fees/rapid-launch.ts
@@ -1,3 +1,4 @@
+import { PromisePool } from "@supercharge/promise-pool";
 import { Dependencies, FetchOptions, SimpleAdapter } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
 import ADDRESSES from "../helpers/coreAssets.json";
@@ -30,21 +31,41 @@ const fetch = async (options: FetchOptions) => {
   // historically also collected fees in standalone System Program transfers.
   // The dedicated collector is therefore the stable attribution signal; filtering
   // by one launchpad program would omit both integrations and most legacy fees.
-  const [received, referralDistributions] = await Promise.all([
-    getSolanaReceived({
-      options,
-      targets: FEE_COLLECTORS,
-      mints: [ADDRESSES.solana.SOL],
-      blacklists: FEE_COLLECTORS,
-      blacklist_signers: FEE_COLLECTORS,
-    }),
-    getSolanaReceived({
-      options,
-      targets: REFERRAL_RECIPIENTS,
-      mints: [ADDRESSES.solana.SOL],
-      fromAddresses: FEE_COLLECTORS,
-    }),
-  ]);
+  const queries = [
+    {
+      key: "received",
+      run: () =>
+        getSolanaReceived({
+          options,
+          targets: FEE_COLLECTORS,
+          mints: [ADDRESSES.solana.SOL],
+          blacklists: FEE_COLLECTORS,
+          blacklist_signers: FEE_COLLECTORS,
+        }),
+    },
+    {
+      key: "referralDistributions",
+      run: () =>
+        getSolanaReceived({
+          options,
+          targets: REFERRAL_RECIPIENTS,
+          mints: [ADDRESSES.solana.SOL],
+          fromAddresses: FEE_COLLECTORS,
+        }),
+    },
+  ] as const;
+
+  const { results, errors } = await PromisePool.withConcurrency(2)
+    .for(queries)
+    .process(async ({ key, run }) => [key, await run()] as const);
+
+  if (errors.length) throw errors[0];
+
+  const queryResults = new Map(results);
+  const received = queryResults.get("received");
+  const referralDistributions = queryResults.get("referralDistributions");
+  if (!received || !referralDistributions)
+    throw new Error("Rapid Launch fee queries returned incomplete results");
 
   const dailyFees = options.createBalances();
   dailyFees.addBalances(received, COLLECTOR_FEES);

--- a/fees/rapid-launch.ts
+++ b/fees/rapid-launch.ts
@@ -12,7 +12,7 @@ const CURRENT_FEE_COLLECTOR = "rapidXMVLw5uBieKHDGvF9k4xSSDXyD2FC5wLTAajaJ";
 // Legacy dedicated fee collector: https://orbmarkets.io/address/feesEi65EDHZ7jVMPUicJtnCyTnsoqnQB93GHqLZ6BC/history
 const LEGACY_FEE_COLLECTOR = "feesEi65EDHZ7jVMPUicJtnCyTnsoqnQB93GHqLZ6BC";
 const FEE_COLLECTORS = [CURRENT_FEE_COLLECTOR, LEGACY_FEE_COLLECTOR];
-// The current collector distributes 14% of each sweep to these referral wallets.
+// The current collector's observed split distributes 14% to these referral wallets.
 // Representative distribution: https://solscan.io/tx/4HkyycaGr5kh1LArpyisEHJFsHLr4sMDcBjgAd7rCBLsJgb7v9J3ThrZD4JYcorkWtEmEWaKJJy2NG6of2ECvV4H
 const REFERRAL_RECIPIENTS = [
   "3os7e5tBFKXFhKZ8igzpCpZr8cw5DvwHrc5bZwELjiLL", // 6.2%
@@ -89,11 +89,11 @@ const adapter: SimpleAdapter = {
     },
     Revenue: {
       [COLLECTOR_FEES_TO_TREASURY]:
-        "SOL receipts retained by Rapid Launch after excluding collector-to-collector transfers.",
+        "Gross collector fees minus SOL distributed to referral recipients.",
     },
     ProtocolRevenue: {
       [COLLECTOR_FEES_TO_TREASURY]:
-        "SOL receipts retained by Rapid Launch as protocol revenue.",
+        "Gross collector fees minus SOL distributed to referral recipients, retained as protocol revenue.",
     },
     SupplySideRevenue: {
       [REFERRAL_FEES_TO_REFERRERS]:

--- a/fees/rapid-launch.ts
+++ b/fees/rapid-launch.ts
@@ -1,4 +1,3 @@
-import { PromisePool } from "@supercharge/promise-pool";
 import { Dependencies, FetchOptions, SimpleAdapter } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
 import ADDRESSES from "../helpers/coreAssets.json";
@@ -31,41 +30,20 @@ const fetch = async (options: FetchOptions) => {
   // historically also collected fees in standalone System Program transfers.
   // The dedicated collector is therefore the stable attribution signal; filtering
   // by one launchpad program would omit both integrations and most legacy fees.
-  const queries = [
-    {
-      key: "received",
-      run: () =>
-        getSolanaReceived({
-          options,
-          targets: FEE_COLLECTORS,
-          mints: [ADDRESSES.solana.SOL],
-          blacklists: FEE_COLLECTORS,
-          blacklist_signers: FEE_COLLECTORS,
-        }),
-    },
-    {
-      key: "referralDistributions",
-      run: () =>
-        getSolanaReceived({
-          options,
-          targets: REFERRAL_RECIPIENTS,
-          mints: [ADDRESSES.solana.SOL],
-          fromAddresses: FEE_COLLECTORS,
-        }),
-    },
-  ] as const;
+  const received = await getSolanaReceived({
+    options,
+    targets: FEE_COLLECTORS,
+    mints: [ADDRESSES.solana.SOL],
+    blacklists: FEE_COLLECTORS,
+    blacklist_signers: FEE_COLLECTORS,
+  });
 
-  const { results, errors } = await PromisePool.withConcurrency(2)
-    .for(queries)
-    .process(async ({ key, run }) => [key, await run()] as const);
-
-  if (errors.length) throw errors[0];
-
-  const queryResults = new Map(results);
-  const received = queryResults.get("received");
-  const referralDistributions = queryResults.get("referralDistributions");
-  if (!received || !referralDistributions)
-    throw new Error("Rapid Launch fee queries returned incomplete results");
+  const referralDistributions = await getSolanaReceived({
+    options,
+    targets: REFERRAL_RECIPIENTS,
+    mints: [ADDRESSES.solana.SOL],
+    fromAddresses: FEE_COLLECTORS,
+  });
 
   const dailyFees = options.createBalances();
   dailyFees.addBalances(received, COLLECTOR_FEES);
@@ -99,7 +77,7 @@ const adapter: SimpleAdapter = {
     Fees: "SOL fees paid by users for Rapid Launch token deployment and trading tools.",
     Revenue:
       "Fees collected by Rapid Launch after referral distributions are paid to referrers.",
-    ProtocolRevenue: "Same as Revenue.",
+    ProtocolRevenue: "Fees collected by Rapid Launch after referral distributions are paid to referrers..",
     SupplySideRevenue:
       "SOL distributed from Rapid Launch's fee collectors to referral recipients.",
   },

--- a/fees/rapid-launch.ts
+++ b/fees/rapid-launch.ts
@@ -4,15 +4,22 @@ import ADDRESSES from "../helpers/coreAssets.json";
 import { METRIC } from "../helpers/metrics";
 import { getSolanaReceived } from "../helpers/token";
 
-// The legacy collector was swept into the current collector on 2025-07-05.
+// The legacy collector was swept into the current collector on 2025-07-05:
+// https://solscan.io/tx/2doyJpiA2V7V4tSMaqfbtSTieR8HsFieWuPHc8MZUCT7aZSUT3Fo8VoV1pKHJHxiteRoTG1ZS9QEPnqfUZDHTjce
 // Excluding transfers and signatures from both collectors prevents that treasury
 // migration (and any later internal movements) from being counted as user fees.
-const FEE_COLLECTORS = [
-  "feesEi65EDHZ7jVMPUicJtnCyTnsoqnQB93GHqLZ6BC",
-  "rapidXMVLw5uBieKHDGvF9k4xSSDXyD2FC5wLTAajaJ",
-];
+// Current dedicated fee collector: https://orbmarkets.io/address/rapidXMVLw5uBieKHDGvF9k4xSSDXyD2FC5wLTAajaJ/transfers
+const CURRENT_FEE_COLLECTOR = "rapidXMVLw5uBieKHDGvF9k4xSSDXyD2FC5wLTAajaJ";
+// Legacy dedicated fee collector: https://orbmarkets.io/address/feesEi65EDHZ7jVMPUicJtnCyTnsoqnQB93GHqLZ6BC/history
+const LEGACY_FEE_COLLECTOR = "feesEi65EDHZ7jVMPUicJtnCyTnsoqnQB93GHqLZ6BC";
+const FEE_COLLECTORS = [CURRENT_FEE_COLLECTOR, LEGACY_FEE_COLLECTOR];
 
-async function fetch(options: FetchOptions) {
+/** Fetches external SOL receipts sent to Rapid Launch's dedicated fee collectors. */
+const fetch = async (options: FetchOptions) => {
+  // Rapid Launch builds transactions against third-party launchpad programs and
+  // historically also collected fees in standalone System Program transfers.
+  // The dedicated collector is therefore the stable attribution signal; filtering
+  // by one launchpad program would omit both integrations and most legacy fees.
   const received = await getSolanaReceived({
     options,
     targets: FEE_COLLECTORS,
@@ -30,23 +37,18 @@ async function fetch(options: FetchOptions) {
     dailyRevenue: dailyFees,
     dailyProtocolRevenue: dailyFees,
   };
-}
+};
 
 const adapter: SimpleAdapter = {
   version: 2,
   pullHourly: true,
   dependencies: [Dependencies.ALLIUM],
   isExpensiveAdapter: true,
-  adapter: {
-    [CHAIN.SOLANA]: {
-      fetch,
-      start: "2025-04-01",
-    },
-  },
+  fetch,
+  chains: [CHAIN.SOLANA],
+  start: "2025-04-01",
   methodology: {
     Fees: "SOL fees paid by users for Rapid Launch token deployment and trading tools.",
-    UserFees:
-      "SOL fees paid by users for Rapid Launch token deployment and trading tools.",
     Revenue:
       "Fees collected by Rapid Launch, excluding transfers between its fee collectors.",
     ProtocolRevenue: "Same as Revenue.",


### PR DESCRIPTION
## Summary

Adds a Solana fees/revenue adapter for Rapid Launch.

The adapter sums external native-SOL inflows into Rapid Launch's legacy and current fee collectors. Transfers and transaction signatures originating from either collector are excluded, preventing treasury movements from being reported as user fees.

## Methodology and validation

- Current collector: `rapidXMVLw5uBieKHDGvF9k4xSSDXyD2FC5wLTAajaJ`
- Legacy collector: `feesEi65EDHZ7jVMPUicJtnCyTnsoqnQB93GHqLZ6BC`
- Only native SOL is counted.
- External inflows are reported as `dailyFees`, `dailyUserFees`, `dailyRevenue`, and `dailyProtocolRevenue`.
- Internal transfers between the collectors are excluded by sender and signer.
- The legacy collector was drained into the current collector on 2025-07-05. The migration transaction is excluded: https://solscan.io/tx/2doyJpiA2V7V4tSMaqfbtSTieR8HsFieWuPHc8MZUCT7aZSUT3Fo8VoV1pKHJHxiteRoTG1ZS9QEPnqfUZDHTjce
- Rapid Launch's Dune dashboard currently shows approximately $4.23m lifetime fees and $411m lifetime volume. Its underlying query is private, so the adapter independently derives fees from the public onchain collectors: https://dune.com/rapidlaunch/rapidlaunch
- Explorer references:
  - https://orbmarkets.io/address/rapidXMVLw5uBieKHDGvF9k4xSSDXyD2FC5wLTAajaJ/transfers?pageSize=30
  - https://orbmarkets.io/address/feesEi65EDHZ7jVMPUicJtnCyTnsoqnQB93GHqLZ6BC/history

## Tests

- `pnpm ts-check` — passed
- `pnpm exec prettier --check fees/rapid-launch.ts` — passed
- `pnpm test fees rapid-launch 2025-07-05` — adapter discovery passed; data fetch requires the Allium API key used by CI (`Allium API Key is required[Ignore this error for github bot]`)

---

##### Name (to be shown on DefiLlama):

Rapid Launch

##### Twitter Link:

N/A (no official X link is published on the website)

##### List of audit links if any:

N/A

##### Website Link:

https://rapidlaunch.io/

##### Logo (High resolution, will be shown with rounded borders):

https://rapidlaunch.io/brand/logo.png

##### Current TVL:

N/A — fees adapter only

##### Treasury Addresses (if the protocol has treasury)

- Current Solana fee collector: `rapidXMVLw5uBieKHDGvF9k4xSSDXyD2FC5wLTAajaJ`
- Legacy Solana fee collector: `feesEi65EDHZ7jVMPUicJtnCyTnsoqnQB93GHqLZ6BC`

##### Chain:

Solana

##### Coingecko ID:

N/A

##### Coinmarketcap ID:

N/A

##### Short Description (to be shown on DefiLlama):

Rapid Launch is a token-deployment and trading toolkit that lets users deploy tokens across major launchpads and manage bundled buys, wallets, and automated trading workflows.

##### Token address and ticker if any:

N/A

##### Category:

Launchpad

##### Oracle Provider(s):

None

##### Implementation Details:

N/A — the fees adapter reads native-SOL transfers to the published fee collectors.

##### Documentation/Proof:

- https://rapidlaunch.io/
- https://rapidlaunch.io/docs
- https://dune.com/rapidlaunch/rapidlaunch
- Explorer links and migration transaction above

##### forkedFrom:

No

##### methodology:

Fees-only adapter. It sums external native-SOL inflows into the current and legacy Rapid Launch fee collectors. Transfers and signatures originating from either collector are excluded so the 2025-07-05 wallet migration and later treasury movements are not double-counted.

##### Github org/user:

N/A

##### Does this project have a referral program?

Unknown
