### PR TITLE
sushiswap-agg: add the BSC, Gnosis and Hemi fee legs, all three have routed since 2025-08-23 with no fees reported

### DIFF
--- a/fees/sushiswap-agg.ts
+++ b/fees/sushiswap-agg.ts
@@ -24,6 +24,9 @@ const RP9_ADDRESS: any = {
   [CHAIN.POLYGON_ZKEVM]: '0x81602EF321C46d73f5Ba7f476947AE1a862957dc',
   [CHAIN.MANTLE]: '0x81602EF321C46d73f5Ba7f476947AE1a862957dc',
   [CHAIN.KATANA]: '0x81602EF321C46d73f5Ba7f476947AE1a862957dc',
+  [CHAIN.BSC]: '0x81602EF321C46d73f5Ba7f476947AE1a862957dc',
+  [CHAIN.XDAI]: '0x81602EF321C46d73f5Ba7f476947AE1a862957dc',
+  [CHAIN.HEMI]: '0x81602EF321C46d73f5Ba7f476947AE1a862957dc',
 }
 
 const RP9_1_ADDRESS: any = {
@@ -35,6 +38,9 @@ const RP9_1_ADDRESS: any = {
   [CHAIN.POLYGON_ZKEVM]: '0x3b0aa7d38bf3c103bf02d1de2e37568cbed3d6e8',
   [CHAIN.MANTLE]: '0x3b0aa7d38bf3c103bf02d1de2e37568cbed3d6e8',
   [CHAIN.KATANA]: '0x3b0aa7d38bf3c103bf02d1de2e37568cbed3d6e8',
+  [CHAIN.BSC]: '0x3b0aa7d38bf3c103bf02d1de2e37568cbed3d6e8',
+  [CHAIN.XDAI]: '0x3b0aa7d38bf3c103bf02d1de2e37568cbed3d6e8',
+  [CHAIN.HEMI]: '0x3b0aa7d38bf3c103bf02d1de2e37568cbed3d6e8',
 }
 
 const RP9_2_ADDRESS: any = {
@@ -46,6 +52,9 @@ const RP9_2_ADDRESS: any = {
   [CHAIN.POLYGON_ZKEVM]: '0xd2b37ade14708bf18904047b1e31f8166d39612b',
   [CHAIN.MANTLE]: '0xd2b37ade14708bf18904047b1e31f8166d39612b',
   [CHAIN.KATANA]: '0xd2b37ade14708bf18904047b1e31f8166d39612b',
+  [CHAIN.BSC]: '0xd2b37ade14708bf18904047b1e31f8166d39612b',
+  [CHAIN.XDAI]: '0xd2b37ade14708bf18904047b1e31f8166d39612b',
+  [CHAIN.HEMI]: '0xd2b37ade14708bf18904047b1e31f8166d39612b',
 }
 
 const RP10_ADDRESS: any = {
@@ -57,6 +66,9 @@ const RP10_ADDRESS: any = {
   [CHAIN.POLYGON_ZKEVM]: '0xe89aab725a2b2c0656248dcccc894a04661be55a',
   [CHAIN.MANTLE]: '0xe89aab725a2b2c0656248dcccc894a04661be55a',
   [CHAIN.KATANA]: '0xe89aab725a2b2c0656248dcccc894a04661be55a',
+  [CHAIN.BSC]: '0xe89aab725a2b2c0656248dcccc894a04661be55a',
+  [CHAIN.XDAI]: '0xe89aab725a2b2c0656248dcccc894a04661be55a',
+  [CHAIN.HEMI]: '0xe89aab725a2b2c0656248dcccc894a04661be55a',
 }
 
 const RP11_ADDRESS: any = {
@@ -70,6 +82,9 @@ const RP11_ADDRESS: any = {
   [CHAIN.KATANA]: '0xc10ee9031f2a0b84766a86b55a8d90f357910fb4',
   [CHAIN.ERA]: '0xc10ee9031f2a0b84766a86b55a8d90f357910fb4',
   [CHAIN.LINEA]: '0xc10ee9031f2a0b84766a86b55a8d90f357910fb4',
+  [CHAIN.BSC]: '0xc10ee9031f2a0b84766a86b55a8d90f357910fb4',
+  [CHAIN.XDAI]: '0xc10ee9031f2a0b84766a86b55a8d90f357910fb4',
+  [CHAIN.HEMI]: '0xc10ee9031f2a0b84766a86b55a8d90f357910fb4',
 }
 
 const ROUTE_RP7_EVENT = 'event Route(address indexed from, address to, address indexed tokenIn, address tokenOut, uint256 amountIn, uint256 amountOut, int256 slippage, uint32 indexed referralCode)'
@@ -141,5 +156,8 @@ export default {
     [CHAIN.KATANA]: { start: '2025-07-04', },
     [CHAIN.ERA]: { start: '2026-02-08', },
     [CHAIN.LINEA]: { start: '2026-02-08', },
+    [CHAIN.BSC]: { start: '2025-08-23', },
+    [CHAIN.XDAI]: { start: '2025-08-23', },
+    [CHAIN.HEMI]: { start: '2025-08-23', },
   }
 }


### PR DESCRIPTION
The SushiSwap RouteProcessors are deployed at the same address on every chain, so each generation is one entry per chain in this file's maps. The maps stop at 11 chains. **BSC, Gnosis and Hemi have been routing through those same contracts since 2025-08-23 and report no fees at all**, even though `aggregators/sushiswap-agg` already tracks the volume on all three.

### The routers are live on these chains

Counting `Route` logs (`0xbbb02a24…` and `0x84b514c5…`, the two ABIs this file already uses) on the five RouteProcessor addresses:

| chain | RP9 | RP9_1 | RP9_2 | RP10 | RP11 | first seen |
|---|---:|---:|---:|---:|---:|---|
| bsc | 26,351 | 2,386,052 | 7,157,269 | 60,332 | 869,682 | 2025-08-23 |
| gnosis | 1,077 | 5,020 | 25,412 | 900 | 41,545 | 2025-08-23 |
| hemi | 10,917 | 28,555 | 12,213 | 1,299 | 21,643 | 2025-08-23 |

That is why all five maps are updated rather than only the current one — each of these chains has run through four router generations, and adding only RP11 would leave everything before 2026-02-24 at zero. `start` is set to 2025-08-23, the first `Route` log on each of the three; there are no RP8 logs on any of them, so RP8 is left alone.

Over the last 14 days BSC emitted 25,759 `Route` logs, more than Ethereum's 22,229 over the same window.

### Before / after

Local run of `cli/testAdapter.ts fees sushiswap-agg 2026-09-01`, against 0.2% of the volume this protocol already publishes for the same chain and day (0.2% is the `FLAT_FEE` this file applies):

| chain | published fees today | this PR | 0.2% of published volume | ratio |
|---|---:|---:|---:|---:|
| bsc | $0 | $378.77 | $278.44 | 1.36 |
| gnosis | $0 | $166.33 | $164.94 | 1.008 |
| hemi | $0 | $270.12 | $271.92 | 0.993 |

Gnosis and Hemi land within 1%. BSC comes in 1.36× the volume-derived estimate, which is the same direction as the chains already covered — Ethereum runs 1.17×, Base 1.12×, Polygon 1.11× on the 30-day figures, so the on-chain `amountIn` this file prices is consistently a little above what the volume adapter reports.

Against the 30-day totals — $142,094 in fees on $67.4M of volume — the three chains carry $4,374,467 (bsc), $3,012,060 (gnosis) and $1,005,810 (hemi) of already-published volume, so roughly $16.8k/30d, about 12% on top of what the adapter reports today.

### Chains deliberately left out

RP11 is also live on 15 other chains that this file does not cover. I left them out because their combined implied contribution is about $2.6k/30d and I only verified 14-day activity for them, not the full router history needed to set an honest `start`:

celo $692, avax $880, megaeth $271, berachain $246, monad $188, plasma $102, hyperliquid $86, boba $74, sonic $34, scroll $6, arbitrum_nova $4, apechain $2, fantom $1, taiko $0.5 (implied 30d fees, from published volume). Cronos has 3,248 `Route` logs in 14 days but no volume tracked on the sibling adapter, so I did not add it either.

One thing I noticed while checking the rate but did not touch: Arbitrum currently reports $11,411 of fees against $748,998 of volume, an implied 1.5% rather than 0.2%. Every other covered chain sits between 0.19% and 0.23%.

`ts-check` passes.
