### PR TITLE
termix: include campaign-vault protocol fees

### DIFF
--- a/fees/termix.ts
+++ b/fees/termix.ts
@@ -3,11 +3,23 @@ import { CHAIN } from "../helpers/chains";
 import { addTokensReceived } from "../helpers/token";
 import ADDRESSES from '../helpers/coreAssets.json';
 
-// Escrow contracts charge a 2% protocol fee (protocolFeeBps = 200) on each
-// settled job and transfer it to the fee recipient.
+// Escrow and campaign-vault contracts charge a 2% protocol fee
+// (protocolFeeBps = 200) on each settlement and transfer it to the fee recipient.
 const FEE_RECIPIENT = "0x1095deD95CB6e81C01204F7A94950dd559195E42";
 
 const ESCROW_FEES = "Escrow Fees";
+const CAMPAIGN_FEES = "Campaign Vault Fees";
+
+const CAMPAIGN_VAULTS: Record<string, string[]> = {
+  [CHAIN.BSC]: [
+    "0x5BaE7834B32a4b357F65dd20248068993466D294", // campaign vault (USDC)
+    "0x16261F2BCbE8Ee47065C5ecB4be32c1571289809", // campaign vault (USDT)
+  ],
+  [CHAIN.BASE]: [
+    "0x97d14D248d956148a34E4fe636CDdBa8BB80E551", // campaign vault (USDC)
+    "0x911d5c2a20dDA9bE9daE53fE3AD9183e5b583D7f", // campaign vault (USDT)
+  ],
+};
 
 const CONFIG: Record<string, { escrow: string; token: string }[]> = {
   [CHAIN.BSC]: [
@@ -46,6 +58,15 @@ const fetch = async (options: FetchOptions) => {
 
   dailyFees.addBalances(received, ESCROW_FEES);
 
+  const campaignFees = await addTokensReceived({
+    options,
+    tokens,
+    targets: [FEE_RECIPIENT],
+    fromAdddesses: CAMPAIGN_VAULTS[options.chain],
+  });
+
+  dailyFees.addBalances(campaignFees, CAMPAIGN_FEES);
+
   return {
     dailyFees,
     dailyRevenue: dailyFees,
@@ -54,20 +75,23 @@ const fetch = async (options: FetchOptions) => {
 };
 
 const methodology = {
-  Fees: "2% protocol fee charged on each settled job, paid in USDC/USDT from the escrow contracts to the protocol fee recipient.",
-  Revenue: "100% of protocol fees (2% of job settlement) go to the protocol fee recipient.",
-  ProtocolRevenue: "Same as revenue — the full 2% job settlement fee.",
+  Fees: "2% protocol fee charged on each settlement (jobs via escrow, campaigns via campaign vault), paid in USDC/USDT to the protocol fee recipient.",
+  Revenue: "100% of protocol fees (2% of settlements) go to the protocol fee recipient.",
+  ProtocolRevenue: "Same as revenue — the full 2% settlement fee.",
 };
 
 const breakdownMethodology = {
   Fees: {
     [ESCROW_FEES]: "2% protocol fee on jobs settled through the escrow contracts, paid in USDC or USDT.",
+    [CAMPAIGN_FEES]: "2% protocol fee on campaign settlements through the campaign-vault contracts, paid in USDC or USDT.",
   },
   Revenue: {
     [ESCROW_FEES]: "100% of escrow protocol fees (2% of job settlement) go to the fee recipient.",
+    [CAMPAIGN_FEES]: "100% of campaign-vault protocol fees (2% of campaign settlement) go to the fee recipient.",
   },
   ProtocolRevenue: {
     [ESCROW_FEES]: "Same as revenue — the full 2% job settlement fee.",
+    [CAMPAIGN_FEES]: "Same as revenue — the full 2% campaign settlement fee.",
   },
 };
 


### PR DESCRIPTION
Follow-up to #9096 — adds the **campaign-vault contracts** as protocol-fee sources for `termix`.

The campaign-vault contracts charge the same 2% protocol fee (`protocolFeeBps = 200`) on campaign settlements and send it to the same fee recipient as the escrow contracts. The original adapter only counted escrow → fee-recipient transfers, so campaign fees were missed (currently small, ~$257 cumulative, but growing with campaign activity): https://dune.com/queries/8582252 shows the full inflow breakdown by source.

Changes:
- Add BSC/Base campaign-vault addresses as a second `addTokensReceived` source with its own `Campaign Vault Fees` breakdown label.
- Update methodology wording to cover both settlement paths.

Test output (`npm run test fees termix`):
```
chain     | Daily fees | Daily revenue | Daily protocol revenue
bsc       | 12.72 k    | 12.72 k      | 12.72 k
base      | 4.35 k     | 4.35 k       | 4.35 k
Aggregate | 17.07 k    | 17.07 k      | 17.07 k
```


---

**Refill request** 🙏 : while you're here — could you also run a historical refill for `termix` from the adapter start dates (`2026-07-03` BSC / `2026-08-06` Base)? Cumulative fees currently only count from the listing date (~$38.7k shown vs ~$326k actual on-chain: https://dune.com/queries/8571351). The adapter reads token transfers only, so it backfills cleanly. Also asked in #9096 after merge.
