### PR TITLE
docs: expand AGENTS.md with testing, placement, data-source and maintenance rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ wash/
 .claude
 CLAUDE.md
 skills/dimension-failure-fixer/
+
+data-audit/
+cli/blacklistCandidates.js

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,3 @@ wash/
 .claude
 CLAUDE.md
 skills/dimension-failure-fixer/
-
-data-audit/
-cli/blacklistCandidates.js

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -145,7 +145,8 @@ const adapter: SimpleAdapter = {
 |-----------|----------|-------------|
 | `dailyNotionalVolume` | YES | Notional volume of options contracts |
 | `dailyPremiumVolume` | YES | Premium volume collected/paid |
-| `openInterestAtEnd` | Optional | Open interest at period end |
+
+Options adapters do not export open interest; it is a perps-only dimension.
 
 ### Fees (Income Statement Model)
 
@@ -245,7 +246,7 @@ npm run test <type> <slug> [YYYY-MM-DD] [chain1,chain2]
 
 - The bare slug resolves both file-based adapters (`<type>/<slug>.ts` or `<type>/<slug>/index.ts`) and factory-listed keys (e.g. a key in `factory/uniV3.ts`).
 - The date argument is the END of the window: to reproduce day D, pass D+1. The optional last argument limits the run to those chains.
-- For a fix to a live adapter also read the published series: `https://api.llama.fi/summary/<type>/<slug>?dataType=dailyVolume` (or `dailyFees`). A series ending in a null `total24h` means the adapter throws; a hard $0 after big days with no taper means source lag, not zero activity.
+- For a fix to a live adapter also read the published series: `https://api.llama.fi/summary/<type>/<slug>?dataType=<dimension>` with the category's required dimension (`dailyVolume`, `dailyFees`, `dailyBridgeVolume`, `dailyNotionalVolume`, `openInterestAtEnd`, ...). A series ending in a null `total24h` means the adapter throws; for flow metrics a hard $0 after big days with no taper means source lag, not zero activity (for snapshot metrics like open interest a drop to 0 is a bug either way).
 - `DEBUG_BREAKDOWN_FEES=true npm run test fees <slug> <date>` prints the per-label breakdown table.
 - `balances.debug()` inside a fetch prints the largest token values and addresses (useful for decimals/pricing problems).
 - Run several random past days, not just one. Zeros on random days with known activity, or values an order of magnitude off the protocol's own UI/explorer/Dune, block the listing until explained. CI proves little: forked PRs get no Dune keys and public RPCs may be non-archival, so a local run is the real check.
@@ -333,7 +334,7 @@ The wrong vehicle is a blocker, decide this first:
 ## Maintaining existing adapters
 
 - **Dead protocol**: `deadFrom: 'YYYY-MM-DD'` top-level (sibling of `version`/`fetch`/`chains`) with a `// reason` comment, on every adapter file of the protocol. Keep the fetch logic, `start` and chains so history stays refillable. Long-dead adapters are later swept into `factory/deadAdapters.json` (file deleted, slug recorded), so a "missing" adapter may live there.
-- `deadFrom` on the adapter is global. Per-chain config entries accept their own `deadFrom`; use it when a frozen or sunset RPC would otherwise throw and take every other chain down. Otherwise end a single chain by returning empty after a date guard (live) or by commenting it out plus refill (retroactive). Never store empty/zero rows.
+- `deadFrom` on the adapter is global. To end a single chain going forward, set `deadFrom` on that chain's config entry: the runner skips the chain before calling `fetch`, so nothing is stored (this is also the fix for a frozen or sunset RPC that would otherwise throw and take every other chain down). Do not return an empty result from `fetch` as a shutdown mechanism, it is still recorded as a row; if a date guard is needed inside `fetch`, throw past it. To end a chain retroactively, comment it out and refill. Never store empty or zero rows.
 - An optional enrichment call (an L1 cost lookup, a price read) in the same `Promise.all` as the required metric takes both down. Catch the optional call, publish the metric and OMIT the derived value rather than publishing it uncorrected.
 - When a source breaks but the protocol is alive, the fix is another source, never `deadFrom` and never a zero fallback. Fees dropping to 0 with healthy TVL usually means a changed fee address, not a dead protocol.
 - **Disable a chain**: comment the entry out in place with a reason everywhere it appears (config, chains array, per-chain map); never delete.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -146,7 +146,7 @@ const adapter: SimpleAdapter = {
 | `dailyNotionalVolume` | YES | Notional volume of options contracts |
 | `dailyPremiumVolume` | YES | Premium volume collected/paid |
 
-Options adapters do not export open interest; it is a perps-only dimension.
+Open interest is currently exported for perps and futures only. Options adapters do not export it yet: raw notional OI is not comparable across expiries and strikes, and a measure normalized for time to expiry and distance from the current price is still to be defined.
 
 ### Fees (Income Statement Model)
 
@@ -246,7 +246,7 @@ npm run test <type> <slug> [YYYY-MM-DD] [chain1,chain2]
 
 - The bare slug resolves both file-based adapters (`<type>/<slug>.ts` or `<type>/<slug>/index.ts`) and factory-listed keys (e.g. a key in `factory/uniV3.ts`).
 - The date argument is the END of the window: to reproduce day D, pass D+1. The optional last argument limits the run to those chains.
-- For a fix to a live adapter also read the published series: `https://api.llama.fi/summary/<type>/<slug>?dataType=<dimension>` with the category's required dimension (`dailyVolume`, `dailyFees`, `dailyBridgeVolume`, `dailyNotionalVolume`, `openInterestAtEnd`, ...). A series ending in a null `total24h` means the adapter throws; for flow metrics a hard $0 after big days with no taper means source lag, not zero activity (for snapshot metrics like open interest a drop to 0 is a bug either way).
+- For a fix to a live adapter also read the published series: `https://api.llama.fi/summary/<type>/<slug>?dataType=<dimension>`, once per required dimension of the category (`dailyVolume`; `dailyFees` and `dailyRevenue`; `dailyBridgeVolume`; `dailyNotionalVolume` and `dailyPremiumVolume`; `openInterestAtEnd`). A series ending in a null `total24h` means the adapter throws. For flow metrics a hard $0 after big days with no taper means source lag, not zero activity. Snapshot metrics (open interest) are judged by the end-of-window value: 0 is valid only when no positions remain, a drop to 0 while the venue still has open positions is a bug.
 - `DEBUG_BREAKDOWN_FEES=true npm run test fees <slug> <date>` prints the per-label breakdown table.
 - `balances.debug()` inside a fetch prints the largest token values and addresses (useful for decimals/pricing problems).
 - Run several random past days, not just one. Zeros on random days with known activity, or values an order of magnitude off the protocol's own UI/explorer/Dune, block the listing until explained. CI proves little: forked PRs get no Dune keys and public RPCs may be non-archival, so a local run is the real check.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -234,3 +234,106 @@ These are the issues that come up most often in review - check every PR for them
 - v2 adapters keying time windows off `startOfDay` instead of `startTimestamp`
 - `noTarget` getLogs, raw `topics`, missing `multiCall`, or `try/catch` that swallows errors
 - Cumulative data returned where 24h/daily data is expected
+
+## Testing an adapter locally
+
+```bash
+npm run test <type> <slug> [YYYY-MM-DD]
+```
+
+- The bare slug resolves both file-based adapters (`<type>/<slug>.ts` or `<type>/<slug>/index.ts`) and factory-listed keys (e.g. a key in `factory/uniV3.ts`).
+- The date argument is the END of the window: to reproduce day D, pass D+1.
+- `DEBUG_BREAKDOWN_FEES=true npm run test fees <slug> <date>` prints the per-label breakdown table.
+- `balances.debug()` inside a fetch prints the largest token values and addresses (useful for decimals/pricing problems).
+- Run several random past days, not just one. Zeros on random days with known activity, or values an order of magnitude off the protocol's own UI/explorer/Dune, block the listing until explained. CI proves little: forked PRs get no Dune keys and public RPCs may be non-archival, so a local run is the real check.
+
+## Where a new adapter goes
+
+The wrong vehicle is a blocker, decide this first:
+
+| Protocol kind | Where |
+|---|---|
+| Uniswap v2/v3 fork, Algebra fork, standard subgraph DEX | ONE config entry in `factory/uniV2.ts` / `factory/uniV3.ts` / `factory/uniSubgraph.ts`, never a standalone file (see `dexs/AGENTS.md`) |
+| Compound v2 fork | `factory/compoundV2.ts` (fees and liquidations derive from the same entry) |
+| Aave fork liquidations | `factory/aaveLiquidations.ts` (derived from the fee config) |
+| Chain-level native fees | config entry first: `helpers/evmChainFees.ts` (plain EVM RPC), `factory/routescan.ts`, `factory/blockscout.ts`; a standalone `fees/<chain>.ts` with `protocolType: ProtocolType.CHAIN` only when no factory fits |
+| Vault curator (Morpho/Euler owners) | `factory/curators.ts` |
+| Hyperliquid builder code | one entry in `factory/hyperliquid.ts` (volume and fees are both derived from it) |
+| Normalized perp volume | one entry in `factory/normalizedVolume.ts` |
+| Active/new users, tx count | `active-users/<slug>.ts`, `new-users/<slug>.ts`; for chains check `users/chains.ts` config paths first |
+| Anything genuinely custom | `<type>/<slug>.ts` |
+
+- Grep the protocol name AND slug across all type folders, `factory/*.ts` and `factory/deadAdapters.json` before adding anything. An existing adapter for the same metric is a duplicate (closed, not fixed); if a factory entry already exists, extend it (add the chain) instead of adding a second key.
+- `factory/registry.ts` is not edited, factories auto-expose their configs.
+- Fee ratios in factory entries come from the protocol's documented split only; omit the ratio fields rather than guess (volume still works without them).
+- New chain: add a `CHAIN` enum member in `helpers/chains.ts` (string value = the DefiLlama chain slug, match neighbours' casing/order); a dedicated RPC goes in `DEFAULTS` in `helpers/env.ts`. Add chain support together with the protocol that needs it; config no live adapter consumes is rejected.
+- Fully off-chain venues get their own chain key (or `off_chain`), never the host EVM chain.
+- Pool/yield additions belong in `DefiLlama/yield-server`; token emission schedules belong in `DefiLlama/emissions-adapters`, not here.
+
+## Naming, identity and listings
+
+- The folder/file name IS the listing slug: kebab-case, lowercase (an uppercase folder once broke the pipeline). Versioned deployments get `-v2`/`-v3` suffixed keys. Separate listing per product or version (spot vs perp, v2 vs v3).
+- When `x.ts` and `x/index.ts` both exist the `.ts` wins, so never keep both.
+- Never rename adapter files/folders or chain keys, never delete adapters, chains or history: they are the link to the listing and its stored data.
+- Listing prerequisites: website, X/Twitter and docs in the PR body, and a priceable token/asset (on CoinGecko with real liquidity) where pricing is needed. Do not edit `coreAssets.json` (it is a whitelisted pricing-token list, not an address book).
+- The server-side wiring (`dimensions: { <type>: "<slug>" }` in defillama-server) is a separate follow-up: name it in the PR body so it can be done after merge.
+
+## Adapter mechanics
+
+- `start` and `deadFrom` are `'YYYY-MM-DD'` strings. `start` is the earliest date that ACTUALLY returns data. A failing old date is a bug to fix, not a reason to move `start` later. If the start cannot be determined, omit it rather than guess.
+- `runAtCurrTime: true` only when history is genuinely impossible (then no `start`); remove it as soon as the source supports history. Verify that a project API actually honours its from/to params; if it ignores them, drop the filters and use `runAtCurrTime` instead of caching wrong-window data as history.
+- Rate-based fees scale by `toTimestamp - fromTimestamp`, never an assumed 86400.
+- Missing data must THROW, never return 0/empty silently: the refill job caches whatever the adapter returns. Sources with a publication delay must throw inside the delay window; stale data is never presented as the current day.
+- `dependencies: [Dependencies.DUNE]` (or `ALLIUM`) when the adapter queries the warehouse.
+- One simple adapter per listing; avoid multi-adapter breakdown wrappers, they make refills nearly impossible.
+- `.clone()` a balances object when you need the same amounts in two exports; never add the same instance to two exports.
+- `doublecounted: true` when an underlying tracked protocol already counts the flow (Uniswap v4 hooks, builder codes).
+- `cacheInCloud: true` only for small, slowly-changing config scans (pool-created lists), never for per-window event data.
+- No adapter-level scheduling or refill configuration (reconcile windows, run delays): that lives server-side.
+- Never edit `package.json`, lockfiles or `.github/` in an adapter PR.
+
+## Data source rules
+
+- No number beats a wrong number: if a value cannot be verified (ideally on-chain), track only the verifiable slice. Reported-only APIs with no trade-level data are not listed.
+- Preference order: on-chain event logs > DefiLlama indexer > Dune/Allium > project API with history > 24h-only API with `runAtCurrTime` (last resort). Never a blackbox API that cannot refill an arbitrary past day. On chains with unreliable RPCs, ask for an aggregated daily endpoint rather than a `getLogs` adapter that cannot complete.
+- Verify that the event you pass to `getLogs` exists on the deployed contract's verified source. A `getLogs` on a non-existent event signature returns zero and passes CI.
+- Check the unit of every source column: a value already in USD goes through `addUSDValue`, never scaled by token decimals.
+- Use point-in-time lookups (as of the window end) for supplies and balances, never current-state reads, so refills reproduce history.
+- Prefer dynamic on-chain/API discovery of pools and markets over hardcoded static lists; a static list cites its maintained source inline.
+- No estimates: no fee-tier assumptions, no APY-derived fees, no fixed rate where tiers exist, never fees derived from a yield API. Read fee rates and treasury addresses from the contract where possible.
+- Pricing: prefer the source's own USD values summed in-query, or count the known/major token side of a trade, over pricing long-tail tokens; blacklist mispriced tokens. Never assume a token is USD-pegged: allowlist verified pegs explicitly and skip unknown pools.
+- Fee-wallet tracking: exclude transfers between the protocol's own wallets; on mixed-use wallets scope with `fromAddresses` (verified payer/router contracts) and comment each address's role with a sample tx. EOA-to-EOA transfers count only with verified provenance.
+- Solana: attribute transfers at the instruction level (emitting program), never by tx id alone; batched unrelated transfers over-count.
+- Never source metrics from a competitor's website, only the protocol's own endpoints or on-chain data. Credit external dashboards/query authors as the source in the adapter.
+- Never shift a query window into the future to match an external reporting cycle: the runner queries today and future windows find nothing.
+- Dune: raw SQL inline (no `DUNE_QUERY_ID`), never a committed API key, return only the requested day's aggregate (billing is per row, never full history), keep nested subqueries within ~3 levels, and build in a delay for Solana indexing lag. A query that hits Dune's 30 minute timeout is rejected.
+
+## getLogs performance
+
+- Hundreds of targets is the sanctioned exception to `targets`: fetching all logs by `topic0` and filtering client-side is more efficient there (the indexer caps no-target queries at 10k-block ranges).
+- Avoid `streamLogs`; avoid per-event RPC calls and full-block scans; do not raise public-RPC pressure (slow but un-rate-limited wins). An adapter that 429s in CI is blocked: remove request concurrency first, then ask the team for better endpoints.
+
+## Maintaining existing adapters
+
+- **Dead protocol**: `deadFrom: 'YYYY-MM-DD'` top-level (sibling of `version`/`fetch`/`chains`) with a `// reason` comment, on every adapter file of the protocol. Keep the fetch logic, `start` and chains so history stays refillable. Long-dead adapters are later swept into `factory/deadAdapters.json` (file deleted, slug recorded), so a "missing" adapter may live there.
+- `deadFrom` is adapter-global. To end a single chain, return empty after a date guard (live) or comment the chain out plus refill (retroactive). Never store empty/zero rows.
+- When a source breaks but the protocol is alive, the fix is another source, never `deadFrom` and never a zero fallback. Fees dropping to 0 with healthy TVL usually means a changed fee address, not a dead protocol.
+- **Disable a chain**: comment the entry out in place with a reason everywhere it appears (config, chains array, per-chain map); never delete.
+- **Migrations and behaviour changes**: any change without a time guard silently overwrites correct history on the next refill. Contract/API migrations use date-based switching with `start` unchanged; a fee-rate change needs its date and a timestamp condition.
+- **Labels**: changing an existing breakdown label string forces a full history refill, keep them. Whoever changes values or labels refills history; never refill to a team's retroactively sanitised numbers.
+- Every mitigation/toggle carries a short factual reason comment. Minimal diff, match the file's formatting.
+
+## Writing `methodology` and `breakdownMethodology` text
+
+- `methodology`: one plain-English sentence per metric key, written for an end user with zero context. Name where the money comes from, not the mechanism. State known exclusions explicitly ("excludes the HLP vault and HyperEVM fees"). Human-readable names, not `CONSTANT_CASE`.
+- Name fee types precisely: a percentage taken on yield earned is a performance fee, not a management fee.
+- State split changes with their date in one sentence ("15% to treasury since September 2025, 0% before"). Numbers and percentages come from the code or the protocol's docs, never from memory.
+- The label check is bidirectional: every `.add()`/`.addUSDValue()` label appears in `breakdownMethodology` under each metric it flows into (same spelling), and every entry there has code emitting it.
+
+## Wash and fake volume
+
+- Wash volume comes OUT of volume; fees genuinely paid to a real party may stay in fees. Incentive-farming volume is excluded even when the trades are real.
+- Surgical removal only (specific pairs/pools/senders/txs, then structural filters, then temporarily hiding one chain with a reason); never drop a whole protocol when part of the volume is real. A hard cap is a last resort and its rationale must be a code comment.
+- Keep detection heuristics out of PR text and public docs (filters get circumvented). If you cannot tell organic from fake with the information at hand, say what evidence is needed; a wrong filter is worse than none.
+- Self-trading = participants taking no real profit or loss. Arb and strategy bots paying real fees are legitimate. An implausible volume-to-OI or volume-to-TVL ratio is the strongest single wash signal.
+- Genuine spikes (airdrop, launch, depeg, market event, first buyback day, migration) are whitelisted server-side, not smoothed in the adapter. Exploit-day fees/volume are excluded, not whitelisted.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,8 @@ These guidelines apply to ALL adapters in this repository.
 ## PR Description
 
 - Always provide Website and twitter links in the description
+- Pre-answer the questions every review asks: is a 0-volume/0-fee day correct for this protocol? Why do the numbers differ from the protocol's own dashboard? Did the fee rate or split ever change, and when? Is this related to an existing listing or an open PR? Does the fee-to-volume ratio make sense? If this changes an existing adapter, is a refill needed and from which date?
+- `skills/adapter-author/references/validation.md` and `patterns.md` hold the authoring checklist (metric keys, category routing). A PR that fails it fails review.
 
 ## Code Structure
 
@@ -238,11 +240,12 @@ These are the issues that come up most often in review - check every PR for them
 ## Testing an adapter locally
 
 ```bash
-npm run test <type> <slug> [YYYY-MM-DD]
+npm run test <type> <slug> [YYYY-MM-DD] [chain1,chain2]
 ```
 
 - The bare slug resolves both file-based adapters (`<type>/<slug>.ts` or `<type>/<slug>/index.ts`) and factory-listed keys (e.g. a key in `factory/uniV3.ts`).
-- The date argument is the END of the window: to reproduce day D, pass D+1.
+- The date argument is the END of the window: to reproduce day D, pass D+1. The optional last argument limits the run to those chains.
+- For a fix to a live adapter also read the published series: `https://api.llama.fi/summary/<type>/<slug>?dataType=dailyVolume` (or `dailyFees`). A series ending in a null `total24h` means the adapter throws; a hard $0 after big days with no taper means source lag, not zero activity.
 - `DEBUG_BREAKDOWN_FEES=true npm run test fees <slug> <date>` prints the per-label breakdown table.
 - `balances.debug()` inside a fetch prints the largest token values and addresses (useful for decimals/pricing problems).
 - Run several random past days, not just one. Zeros on random days with known activity, or values an order of magnitude off the protocol's own UI/explorer/Dune, block the listing until explained. CI proves little: forked PRs get no Dune keys and public RPCs may be non-archival, so a local run is the real check.
@@ -274,6 +277,9 @@ The wrong vehicle is a blocker, decide this first:
 
 - The folder/file name IS the listing slug: kebab-case, lowercase (an uppercase folder once broke the pipeline). Versioned deployments get `-v2`/`-v3` suffixed keys. Separate listing per product or version (spot vs perp, v2 vs v3).
 - When `x.ts` and `x/index.ts` both exist the `.ts` wins, so never keep both.
+- One protocol maps to one fees file; versions stay separate listings, and counting legacy pools inside the current adapter double counts the legacy listing. When a chain gets a standalone fee adapter, drop its blockscout/routescan factory entry.
+- A single pool or hook is not a protocol. List only chains with real activity; hundreds of chains with zero cumulative volume is not a feature.
+- Hyperliquid builder codes: verify the address belongs to the claimed protocol before listing it.
 - Never rename adapter files/folders or chain keys, never delete adapters, chains or history: they are the link to the listing and its stored data.
 - Listing prerequisites: website, X/Twitter and docs in the PR body, and a priceable token/asset (on CoinGecko with real liquidity) where pricing is needed. Do not edit `coreAssets.json` (it is a whitelisted pricing-token list, not an address book).
 - The server-side wiring (`dimensions: { <type>: "<slug>" }` in defillama-server) is a separate follow-up: name it in the PR body so it can be done after merge.
@@ -281,16 +287,23 @@ The wrong vehicle is a blocker, decide this first:
 ## Adapter mechanics
 
 - `start` and `deadFrom` are `'YYYY-MM-DD'` strings. `start` is the earliest date that ACTUALLY returns data. A failing old date is a bug to fix, not a reason to move `start` later. If the start cannot be determined, omit it rather than guess.
-- `runAtCurrTime: true` only when history is genuinely impossible (then no `start`); remove it as soon as the source supports history. Verify that a project API actually honours its from/to params; if it ignores them, drop the filters and use `runAtCurrTime` instead of caching wrong-window data as history.
+- `runAtCurrTime: true` only when history is genuinely impossible (then no `start`); remove it as soon as the source supports history. Verify that a project API actually honours its from/to params. An API that ignores `end` and only serves today/yesterday buckets gets throw-on-null for other dates (the day is recorded as missing), NOT `runAtCurrTime`, which would store the partial running total. If the team's API back-fills during the day, say so in the PR: the adapter can be delayed server-side by a few hours.
 - Rate-based fees scale by `toTimestamp - fromTimestamp`, never an assumed 86400.
-- Missing data must THROW, never return 0/empty silently: the refill job caches whatever the adapter returns. Sources with a publication delay must throw inside the delay window; stale data is never presented as the current day.
+- Missing data must THROW, never return 0/empty silently: the refill job caches whatever the adapter returns. Single-row daily Dune/Allium sources throw when the row is missing or the metric is null; `COALESCE(..., 0)` or `Number(row?.x) || 0` turns ingestion lag into a stored $0. Sources with a publication delay must throw inside the delay window; stale data is never presented as the current day.
 - `dependencies: [Dependencies.DUNE]` (or `ALLIUM`) when the adapter queries the warehouse.
 - One simple adapter per listing; avoid multi-adapter breakdown wrappers, they make refills nearly impossible.
 - `.clone()` a balances object when you need the same amounts in two exports; never add the same instance to two exports.
 - `doublecounted: true` when an underlying tracked protocol already counts the flow (Uniswap v4 hooks, builder codes).
 - `cacheInCloud: true` only for small, slowly-changing config scans (pool-created lists), never for per-window event data.
 - No adapter-level scheduling or refill configuration (reconcile windows, run delays): that lives server-side.
-- Never edit `package.json`, lockfiles or `.github/` in an adapter PR.
+- Never edit `package.json`, lockfiles, `.github/`, `adapters/types.ts`, `cli/buildModules.ts` or `factory/registry.ts` in an adapter PR.
+- Time filters are half-open: `>= options.startTimestamp AND < options.endTimestamp` on the block time. `<=` double counts the boundary second.
+- Stock metrics (open interest, TVL-like snapshots) are read once at the window end. Summing them across hourly pulls inflates them 24x.
+- `options.getLogs` returns decoded args only. When `blockNumber`, `logIndex`, `txHash` or the emitter matter, pass `onlyArgs: false` or use `getPositionedLogArgs` from `helpers/logs.ts`.
+- `permitFailure: true` on calls to pools known to exist hides RPC errors as zeros; do not use it as a convenience.
+- `Number(bigint) / 1e18` loses precision past 2^53. Keep amounts as strings/BigInt into the balances object.
+- Chain parity: every chain in the volume adapter has a fee leg and vice versa, or the gap is stated in the adapter.
+- When an API is the accepted source, keep the on-chain fee wallets, logger contracts or program ids as comments next to the code so the adapter can be rebuilt if the API disappears.
 
 ## Data source rules
 
@@ -303,7 +316,11 @@ The wrong vehicle is a blocker, decide this first:
 - No estimates: no fee-tier assumptions, no APY-derived fees, no fixed rate where tiers exist, never fees derived from a yield API. Read fee rates and treasury addresses from the contract where possible.
 - Pricing: prefer the source's own USD values summed in-query, or count the known/major token side of a trade, over pricing long-tail tokens; blacklist mispriced tokens. Never assume a token is USD-pegged: allowlist verified pegs explicitly and skip unknown pools.
 - Fee-wallet tracking: exclude transfers between the protocol's own wallets; on mixed-use wallets scope with `fromAddresses` (verified payer/router contracts) and comment each address's role with a sample tx. EOA-to-EOA transfers count only with verified provenance.
-- Solana: attribute transfers at the instruction level (emitting program), never by tx id alone; batched unrelated transfers over-count.
+- Solana: attribute transfers at the instruction level (emitting program), never by tx id alone; batched unrelated transfers over-count. Prefer Dune/Allium over raw RPC signature scanning.
+- Identify a protocol's pools/configs by its OWN authority (fee claimer, deployer, factory), never by quote token: third parties can create look-alike configs before the protocol launches. Router/pool discovery from the protocol's own events beats a stale hardcoded list once the emitter's provenance is proven.
+- Governance-set rates read at the window's opening block are acceptable when changes are rare; replaying in-window rate-change events ordered by (blockNumber, logIndex) is exact.
+- Cumulative-counter sources need the closing snapshot too: 25 hourly points bound 24 intervals, dropping the last one loses 4-5% a day.
+- Self-reported APIs from privacy ledgers are accepted for VOLUME only, with a sample settlement id; fees are dropped rather than estimated.
 - Never source metrics from a competitor's website, only the protocol's own endpoints or on-chain data. Credit external dashboards/query authors as the source in the adapter.
 - Never shift a query window into the future to match an external reporting cycle: the runner queries today and future windows find nothing.
 - Dune: raw SQL inline (no `DUNE_QUERY_ID`), never a committed API key, return only the requested day's aggregate (billing is per row, never full history), keep nested subqueries within ~3 levels, and build in a delay for Solana indexing lag. A query that hits Dune's 30 minute timeout is rejected.
@@ -311,14 +328,16 @@ The wrong vehicle is a blocker, decide this first:
 ## getLogs performance
 
 - Hundreds of targets is the sanctioned exception to `targets`: fetching all logs by `topic0` and filtering client-side is more efficient there (the indexer caps no-target queries at 10k-block ranges).
-- Avoid `streamLogs`; avoid per-event RPC calls and full-block scans; do not raise public-RPC pressure (slow but un-rate-limited wins). An adapter that 429s in CI is blocked: remove request concurrency first, then ask the team for better endpoints.
+- The number of `getLogs` calls per run is a budget: one call with `targets` beats one call per pool. Avoid `streamLogs`; avoid per-event RPC calls and full-block scans; do not raise public-RPC pressure (slow but un-rate-limited wins). An adapter that 429s in CI is blocked: remove request concurrency first, then ask the team for better endpoints.
 
 ## Maintaining existing adapters
 
 - **Dead protocol**: `deadFrom: 'YYYY-MM-DD'` top-level (sibling of `version`/`fetch`/`chains`) with a `// reason` comment, on every adapter file of the protocol. Keep the fetch logic, `start` and chains so history stays refillable. Long-dead adapters are later swept into `factory/deadAdapters.json` (file deleted, slug recorded), so a "missing" adapter may live there.
-- `deadFrom` is adapter-global. To end a single chain, return empty after a date guard (live) or comment the chain out plus refill (retroactive). Never store empty/zero rows.
+- `deadFrom` on the adapter is global. Per-chain config entries accept their own `deadFrom`; use it when a frozen or sunset RPC would otherwise throw and take every other chain down. Otherwise end a single chain by returning empty after a date guard (live) or by commenting it out plus refill (retroactive). Never store empty/zero rows.
+- An optional enrichment call (an L1 cost lookup, a price read) in the same `Promise.all` as the required metric takes both down. Catch the optional call, publish the metric and OMIT the derived value rather than publishing it uncorrected.
 - When a source breaks but the protocol is alive, the fix is another source, never `deadFrom` and never a zero fallback. Fees dropping to 0 with healthy TVL usually means a changed fee address, not a dead protocol.
 - **Disable a chain**: comment the entry out in place with a reason everywhere it appears (config, chains array, per-chain map); never delete.
+- **Retiring an old endpoint must not shrink history**: run an old date on both versions; new code returning 0 where the old had values blocks until the new source is backfilled.
 - **Migrations and behaviour changes**: any change without a time guard silently overwrites correct history on the next refill. Contract/API migrations use date-based switching with `start` unchanged; a fee-rate change needs its date and a timestamp condition.
 - **Labels**: changing an existing breakdown label string forces a full history refill, keep them. Whoever changes values or labels refills history; never refill to a team's retroactively sanitised numbers.
 - Every mitigation/toggle carries a short factual reason comment. Minimal diff, match the file's formatting.

--- a/aggregator-options/AGENTS.md
+++ b/aggregator-options/AGENTS.md
@@ -25,7 +25,7 @@ Options aggregators route options trades through multiple protocols/vaults to fi
 
 ## Open Interest
 
-Options aggregators do not export open interest (`openInterestAtEnd` and the long/short variants are perps-only dimensions).
+Open interest is currently exported for perps and futures only. Options adapters do not export it yet: raw notional OI is not comparable across expiries and strikes, and a measure normalized for time to expiry and distance from the current price is still to be defined.
 
 ## Data Sources
 

--- a/aggregator-options/AGENTS.md
+++ b/aggregator-options/AGENTS.md
@@ -23,13 +23,9 @@ Options aggregators route options trades through multiple protocols/vaults to fi
 - The actual premium paid/received for options contracts
 - This is what users actually pay to enter positions
 
-## Optional Dimensions
+## Open Interest
 
-| Dimension | Description |
-|-----------|-------------|
-| `openInterestAtEnd` | Total open interest at period end |
-| `longOpenInterestAtEnd` | Long positions open interest |
-| `shortOpenInterestAtEnd` | Short positions open interest |
+Options aggregators do not export open interest (`openInterestAtEnd` and the long/short variants are perps-only dimensions).
 
 ## Data Sources
 

--- a/aggregators/AGENTS.md
+++ b/aggregators/AGENTS.md
@@ -54,3 +54,9 @@ If the aggregator charges fees and this adapter returns fee/revenue dimensions, 
 2. Not tracking all chains the aggregator operates on
 3. Missing integration/partner fees as supply-side revenue
 4. Counting failed/reverted transactions
+
+## Aggregator fees are the aggregator's own fees
+
+- Fees users pay to the UNDERLYING DEX or bridge are not the aggregator's fees; only the aggregator's own fee (positive slippage, integrator fee, protocol fee) belongs in `dailyFees`.
+- Cashbacks/rebates paid back to users go in `dailyFees` with a supply-side label; referral payouts are a cost, excluded from revenue when measurable.
+- Set `doublecounted: true` when the routed volume is already counted by a tracked underlying protocol.

--- a/aggregators/AGENTS.md
+++ b/aggregators/AGENTS.md
@@ -59,4 +59,3 @@ If the aggregator charges fees and this adapter returns fee/revenue dimensions, 
 
 - Fees users pay to the UNDERLYING DEX or bridge are not the aggregator's fees; only the aggregator's own fee (positive slippage, integrator fee, protocol fee) belongs in `dailyFees`.
 - Cashbacks/rebates paid back to users go in `dailyFees` with a supply-side label; referral payouts are a cost, excluded from revenue when measurable.
-- Set `doublecounted: true` when the routed volume is already counted by a tracked underlying protocol.

--- a/bridge-aggregators/AGENTS.md
+++ b/bridge-aggregators/AGENTS.md
@@ -47,6 +47,10 @@ If the bridge aggregator charges fees and this adapter returns fee/revenue dimen
 - `dailyRevenue` - Aggregator's portion
 - `dailySupplySideRevenue` - Relayer/partner fees
 
+## Scope
+
+Bridges themselves are tracked in the `DefiLlama/bridges` repo. A bridge gets no bridge-aggregator adapter here; only routers that aggregate several bridges belong in this folder.
+
 ## Common Mistakes to Avoid
 
 1. Double-counting with underlying bridge adapters

--- a/dexs/AGENTS.md
+++ b/dexs/AGENTS.md
@@ -73,18 +73,18 @@ const fetch = async (options: FetchOptions) => {
 
 ## What counts as volume
 
-- Volume is gross of fees (a buy's volume is amount in plus the fee).
+- Volume is gross of fees: report what the trader put in before the fee was taken. Add the fee back only when the source amount is net of it (a buy recorded as `amountIn` with the fee already deducted), never when the amount already includes it, and value both in the same token/basis.
 - One side of the swap only. Swaps only: no LP add/remove, deposits/withdrawals, borrows, transfers, NFT trades or bet wagers (track their fees instead).
 - Volume is verifiable USER action. A protocol's OWN actions (mint/redeem, hedging, rebalances) are never volume. Liquidations are not perp volume (they have their own `liquidations/` adapter type). HLP / market-maker / vault PnL is never fees.
 - Beware per-side events: some order books emit a maker row AND a taker row for the same fill; summing both double counts.
 - Ticker APIs: never sum `base_volume + quote_volume`, they are the same trades in two units. To check that an API reports single-sided volume, compare a low-liquidity pair's minute candle against its trade history (trade history is always taker volume).
 - Prediction markets follow the Polymarket convention: volume = (maker + taker) / 2. State whether volume is cash (collateral paid) or notional; cash goes in `dailyVolume`, notional optionally in `dailyNotionalVolume`.
-- Dune `dex.trades` / `dex_solana.trades` rows are per pool HOP. Aggregators, bots and terminals count one row per swap per trader (partition by tx AND trader; a tx-only key drops batched users). Exclude self-trades (maker == taker). Darkpool fills count the source leg only, never taker + filler.
+- Dune `dex.trades` / `dex_solana.trades` rows are per pool HOP, so summing rows for an aggregator, bot or terminal counts a multi-hop swap several times. Collapse hops to one swap: prefer the router's own swap event or the user-facing leg (first hop's token in, or last hop's token out); when only `dex.trades` is available, partition by `(tx_hash, trader)` (Solana: `(tx_id, trader)`) and take that leg once. A tx-only key drops batched users; `(tx_hash, evt_index)` keeps every hop and re-introduces the double count. Accepted trade-off: two separate swaps by the same trader in one tx merge into one. Exclude self-trades (maker == taker). Darkpool fills count the source leg only, never taker + filler.
 - Trading bots, terminals and any venue whose swaps settle on a tracked DEX set `doublecounted: true`.
 - A scam quote token priced off the "core asset" side (fake WETH/USDC pairs) can inflate volume by billions; the fix is the token blacklist, not a cap.
 - Launchpads: count only pre-bonding volume on their own curve; post-migration volume belongs to the receiving DEX. Launchpads trading on another protocol's pools track fees only.
-- Perp DEXs reporting very large volume (tens of millions per day and up) need per-trade maker/taker data before the number is trusted. Maker+taker complaints are answered with the normalized-volume metric, not adapter changes.
-- Open interest is exported in USD (contracts times price for the window), never raw contract units. OI covers both sides (longs + shorts) uniformly and should be roughly TVL-stable; an OI source that only serves current data uses `runAtCurrTime`.
+- Perp DEXs reporting very large volume (tens of millions per day and up) need per-trade maker/taker data before the number is trusted. `dailyVolume` must be taker-only regardless; the normalized-volume metric (`factory/normalizedVolume.ts`) is a supplemental cross-venue comparison, not a substitute for removing maker-side rows.
+- Open interest is exported in USD (contracts times the mark/index price at the window end), never raw contract units, following the venue's total-OI convention (see `open-interest/AGENTS.md`); an OI source that only serves current data uses `runAtCurrTime`.
 - No volume breakdowns: breakdown labels are for fees only.
 - Set `doublecounted: true` when an underlying tracked protocol already counts the flow (e.g. Uniswap v4 hooks, builder codes).
 

--- a/dexs/AGENTS.md
+++ b/dexs/AGENTS.md
@@ -81,7 +81,7 @@ const fetch = async (options: FetchOptions) => {
 - Prediction markets follow the Polymarket convention: volume = (maker + taker) / 2. State whether volume is cash (collateral paid) or notional; cash goes in `dailyVolume`, notional optionally in `dailyNotionalVolume`.
 - Dune `dex.trades` / `dex_solana.trades` rows are per pool HOP, so summing rows for an aggregator, bot or terminal counts a multi-hop swap several times. Collapse hops to one swap: prefer the router's own swap event or the user-facing leg (first hop's token in, or last hop's token out); when only `dex.trades` is available, partition by `(tx_hash, trader)` (Solana: `(tx_id, trader)`) and take that leg once. A tx-only key drops batched users; `(tx_hash, evt_index)` keeps every hop and re-introduces the double count. Accepted trade-off: two separate swaps by the same trader in one tx merge into one. Exclude self-trades (maker == taker). Darkpool fills count the source leg only, never taker + filler.
 - Trading bots, terminals and any venue whose swaps settle on a tracked DEX set `doublecounted: true`.
-- A scam quote token priced off the "core asset" side (fake WETH/USDC pairs) can inflate volume by billions; the fix is the token blacklist, not a cap.
+- A scam quote token priced off the "core asset" side (fake WETH/USDC pairs) can inflate volume by billions; the fix is the token blacklist, not a cap. For Uniswap, Aerodrome, PancakeSwap and the other Dune-driven EVM DEX adapters the shared list is the Dune dataset `dune.zteam.dataset_dex_blacklist` (https://dune.com/data/dune.zteam.dataset_dex_blacklist): add the fake/scam token there so every adapter that joins on it drops it at once.
 - Launchpads: count only pre-bonding volume on their own curve; post-migration volume belongs to the receiving DEX. Launchpads trading on another protocol's pools track fees only.
 - Perp DEXs reporting very large volume (tens of millions per day and up) need per-trade maker/taker data before the number is trusted. `dailyVolume` must be taker-only regardless; the normalized-volume metric (`factory/normalizedVolume.ts`) is a supplemental cross-venue comparison, not a substitute for removing maker-side rows.
 - Open interest is exported in USD (contracts times the mark/index price at the window end), never raw contract units, following the venue's total-OI convention (see `open-interest/AGENTS.md`); an OI source that only serves current data uses `runAtCurrTime`.
@@ -113,7 +113,7 @@ Uniswap v2/v3 forks, Algebra forks and standard-subgraph DEXs are NOT new files.
 
 - If the slug is already listed, extend the existing entry (add the chain) instead of adding a second key.
 - Fee ratios only from the protocol's documented split; omit them rather than guess.
-- Spam/fake tokens that pollute uni-style volume go in the central blacklist (`helpers/lists.ts`, `getDefaultDexTokensBlacklisted`), not into individual adapters.
+- Spam/fake tokens that pollute uni-style volume go in a central blacklist, not into individual adapters: `helpers/lists.ts` (`getDefaultDexTokensBlacklisted`) for log/subgraph-based adapters, and the Dune dataset `dune.zteam.dataset_dex_blacklist` for the Dune-driven EVM DEX adapters.
 
 ## Fees/Revenue Tracking
 

--- a/dexs/AGENTS.md
+++ b/dexs/AGENTS.md
@@ -71,6 +71,46 @@ const fetch = async (options: FetchOptions) => {
 - Be extra vigilant on Solana due to lower transaction fees
 - Remove affected pairs during farming campaigns that incentivize wash trading
 
+## What counts as volume
+
+- One side of the swap only. Swaps only: no LP add/remove, deposits/withdrawals, borrows, transfers, NFT trades or bet wagers (track their fees instead).
+- Volume is verifiable USER action. A protocol's OWN actions (mint/redeem, hedging, rebalances) are never volume. Liquidations are not perp volume (they have their own `liquidations/` adapter type). HLP / market-maker / vault PnL is never fees.
+- Beware per-side events: some order books emit a maker row AND a taker row for the same fill; summing both double counts.
+- Ticker APIs: never sum `base_volume + quote_volume`, they are the same trades in two units. To check that an API reports single-sided volume, compare a low-liquidity pair's minute candle against its trade history (trade history is always taker volume).
+- Prediction markets: state whether volume is cash (collateral paid) or notional. Cash goes in `dailyVolume`; notional optionally in `dailyNotionalVolume`.
+- Launchpads: count only pre-bonding volume on their own curve; post-migration volume belongs to the receiving DEX. Launchpads trading on another protocol's pools track fees only.
+- Perp DEXs reporting very large volume (tens of millions per day and up) need per-trade maker/taker data before the number is trusted. Maker+taker complaints are answered with the normalized-volume metric, not adapter changes.
+- Open interest is exported in USD (contracts times price for the window), never raw contract units. OI covers both sides (longs + shorts) uniformly and should be roughly TVL-stable; an OI source that only serves current data uses `runAtCurrTime`.
+- No volume breakdowns: breakdown labels are for fees only.
+- Set `doublecounted: true` when an underlying tracked protocol already counts the flow (e.g. Uniswap v4 hooks, builder codes).
+
+## Fork listings go through the factories
+
+Uniswap v2/v3 forks, Algebra forks and standard-subgraph DEXs are NOT new files. Add one config entry:
+
+`factory/uniV2.ts` / `factory/uniV3.ts` (`configs` for volume, derives fees when ratios are present; `feesConfigs` for fees-only; uniV3 Algebra forks add `isAlgebraV3: true`):
+
+```ts
+'example-v2': {
+  [CHAIN.BASE]: { factory: '0x...', start: '2025-01-01', fees: 0.25/100, userFeesRatio: 1, revenueRatio: 0.4, protocolRevenueRatio: 0.4 },
+},
+```
+
+`factory/uniSubgraph.ts` (`graphUrls` are subgraph deployment IDs, not full URLs):
+
+```ts
+'example-spot': {
+  graphUrls: { [CHAIN.BASE]: "<deployment id>" },
+  totalVolume: { factory: "factories", field: 'totalVolumeUSD' },
+  feesPercent: { type: "fees", ProtocolRevenue: 0, UserFees: 100, SupplySideRevenue: 100, Revenue: 0 },
+  start: '2025-01-20',
+},
+```
+
+- If the slug is already listed, extend the existing entry (add the chain) instead of adding a second key.
+- Fee ratios only from the protocol's documented split; omit them rather than guess.
+- Spam/fake tokens that pollute uni-style volume go in the central blacklist (`helpers/lists.ts`, `getDefaultDexTokensBlacklisted`), not into individual adapters.
+
 ## Fees/Revenue Tracking
 
 If this adapter also tracks fees/revenue dimensions, follow the guidelines in `fees/AGENTS.md`. Include:

--- a/dexs/AGENTS.md
+++ b/dexs/AGENTS.md
@@ -73,11 +73,15 @@ const fetch = async (options: FetchOptions) => {
 
 ## What counts as volume
 
+- Volume is gross of fees (a buy's volume is amount in plus the fee).
 - One side of the swap only. Swaps only: no LP add/remove, deposits/withdrawals, borrows, transfers, NFT trades or bet wagers (track their fees instead).
 - Volume is verifiable USER action. A protocol's OWN actions (mint/redeem, hedging, rebalances) are never volume. Liquidations are not perp volume (they have their own `liquidations/` adapter type). HLP / market-maker / vault PnL is never fees.
 - Beware per-side events: some order books emit a maker row AND a taker row for the same fill; summing both double counts.
 - Ticker APIs: never sum `base_volume + quote_volume`, they are the same trades in two units. To check that an API reports single-sided volume, compare a low-liquidity pair's minute candle against its trade history (trade history is always taker volume).
-- Prediction markets: state whether volume is cash (collateral paid) or notional. Cash goes in `dailyVolume`; notional optionally in `dailyNotionalVolume`.
+- Prediction markets follow the Polymarket convention: volume = (maker + taker) / 2. State whether volume is cash (collateral paid) or notional; cash goes in `dailyVolume`, notional optionally in `dailyNotionalVolume`.
+- Dune `dex.trades` / `dex_solana.trades` rows are per pool HOP. Aggregators, bots and terminals count one row per swap per trader (partition by tx AND trader; a tx-only key drops batched users). Exclude self-trades (maker == taker). Darkpool fills count the source leg only, never taker + filler.
+- Trading bots, terminals and any venue whose swaps settle on a tracked DEX set `doublecounted: true`.
+- A scam quote token priced off the "core asset" side (fake WETH/USDC pairs) can inflate volume by billions; the fix is the token blacklist, not a cap.
 - Launchpads: count only pre-bonding volume on their own curve; post-migration volume belongs to the receiving DEX. Launchpads trading on another protocol's pools track fees only.
 - Perp DEXs reporting very large volume (tens of millions per day and up) need per-trade maker/taker data before the number is trusted. Maker+taker complaints are answered with the normalized-volume metric, not adapter changes.
 - Open interest is exported in USD (contracts times price for the window), never raw contract units. OI covers both sides (longs + shorts) uniformly and should be roughly TVL-stable; an OI source that only serves current data uses `runAtCurrTime`.

--- a/fees/AGENTS.md
+++ b/fees/AGENTS.md
@@ -327,11 +327,9 @@ If this adapter also tracks volume (dexs/ style metrics), see `dexs/AGENTS.md` f
 - On lending/curator adapters a multi-x fee jump from an unknown market is a fabricated market until proven; verify the market against the protocol's own registry before counting it.
 - Negative values are legitimate for realized losses and must be counted (with `allowNegativeValue: true` and an inline reason), but formula-derived fees (e.g. mint/redeem deltas) cap at zero.
 - Export explicit zeros (`dailyRevenue: 0`) for a component the protocol genuinely lacks, but 0 is not "unavailable": never default an UNKNOWN component to zero, omit it until the flow is known. When a revenue/supply split cannot be derived from the source, export gross `dailyFees` only with `skipBreakdownValidation: true` plus a comment; never publish gross inflows as `dailyProtocolRevenue`.
-- A protocol with no fees at all is not worth listing.
 
 ## Chain adapters
 
-- `protocolType: ProtocolType.CHAIN` is required; it distinguishes a chain from a protocol.
 - Fees = user-paid transaction fees only. Revenue = the burnt portion or DAO/treasury inflow only. Block rewards, validator/staker payouts and emissions are neither.
 - Rollup sequencer costs and blob fees paid to mainnet are `dailySupplySideRevenue`; chain revenue = fees minus those.
 - MEV and blockspace-auction income (Jito tips, Timeboost, Flashbots-style builders) is a SEPARATE listing, not part of the chain's fees.

--- a/fees/AGENTS.md
+++ b/fees/AGENTS.md
@@ -305,6 +305,10 @@ If this adapter also tracks volume (dexs/ style metrics), see `dexs/AGENTS.md` f
 - Yield, LST and vault protocols: `dailyFees` = the TOTAL yield generated (the depositor share is supply side), computed from exchange-rate growth on a supply snapshot, not from TVL deltas and not from sporadic claim/harvest events. If the source reports yield after the protocol cut, gross it back up.
 - Never cap or smooth legitimate lumpy yield (batched distributions, stale-oracle catch-ups): every cap trigger permanently discards real yield.
 - The single most common blocking question: `fees == revenue` on an LP, lending or yield protocol. Ask what the supply side gets before merging.
+- Share-price vaults: scale the per-share rate delta by SHARE SUPPLY, never by `totalAssets`; gross up when the rate is already net of the fee. Basis points divide by 10000.
+- Management fees are charged on assets, not carved out of interest: fees = interest + management fee, revenue = performance fee + management fee, supply side = interest minus performance fee.
+- Yesterday's fees may be today's revenue when the protocol books on receipt, as long as cumulative fees >= cumulative revenue. Never "floor" fees at the sum of the components to force a per-day identity.
+- Holders revenue funded from the protocol's side is a reclassification from `dailyProtocolRevenue` to `dailyHoldersRevenue`; check `Revenue = ProtocolRevenue + HoldersRevenue` per CHAIN and expect negative protocol revenue on funding days.
 
 ## Classification rules
 
@@ -316,6 +320,11 @@ If this adapter also tracks volume (dexs/ style metrics), see `dexs/AGENTS.md` f
 - GMV is not fees: keep fees net and track gross flow as its own metric. Buyback-exceeds-sales days on collectibles models legitimately go negative.
 - No revenue-share split without public confirmation. Absent published evidence, attribute nothing to the alleged partner and export the flow you can see.
 - A self-declared margin percentage from the team is not accepted as a fee rate; derive it from on-chain flows.
+- A flat or base-tier fee rate times notional is not a fee metric, not even as an "upper bound": ship volume-only until real per-fill fees exist. A trade feed with signed per-fill fees is the fix (positive = taker fees, negative = maker rebates as supply side).
+- Buybacks of NON-governance assets (cards, boxes, launched tokens) are never holders revenue: collectibles buybacks subtract from fees; launched-token dividends, buyback-burns and locked liquidity are supply side. Dividends to brokers/affiliates who paid for the role are not holders revenue. Spread that lands in hedging/settler contracts and never reaches the treasury is market-maker income, supply side.
+- Buybacks executed off-chain via a CEX need transparency (published wallet, tx list) before they count as holders revenue.
+- Adapters built on Uniswap pools account for Uniswap's own protocol fee where the fee switch is on.
+- On lending/curator adapters a multi-x fee jump from an unknown market is a fabricated market until proven; verify the market against the protocol's own registry before counting it.
 - Negative values are legitimate for realized losses and must be counted (with `allowNegativeValue: true` and an inline reason), but formula-derived fees (e.g. mint/redeem deltas) cap at zero.
 - Export explicit zeros (`dailyRevenue: 0`) for a component the protocol genuinely lacks, but 0 is not "unavailable": never default an UNKNOWN component to zero, omit it until the flow is known. When a revenue/supply split cannot be derived from the source, export gross `dailyFees` only with `skipBreakdownValidation: true` plus a comment; never publish gross inflows as `dailyProtocolRevenue`.
 - A protocol with no fees at all is not worth listing.

--- a/fees/AGENTS.md
+++ b/fees/AGENTS.md
@@ -298,3 +298,32 @@ const breakdownMethodology = {
 ## Volume Tracking
 
 If this adapter also tracks volume (dexs/ style metrics), see `dexs/AGENTS.md` for volume-specific rules. Both fees and volume can coexist in a fees adapter.
+
+## Accrual basis
+
+- Count fees and revenue when they ACCRUE if possible, not when they are paid or claimed, and use one consistent basis. A one-year borrow repaid today is not today's revenue; a quarterly fee claim is not one day's fees. If the source does not provide an accrual basis, use the payment/claim date instead.
+- Yield, LST and vault protocols: `dailyFees` = the TOTAL yield generated (the depositor share is supply side), computed from exchange-rate growth on a supply snapshot, not from TVL deltas and not from sporadic claim/harvest events. If the source reports yield after the protocol cut, gross it back up.
+- Never cap or smooth legitimate lumpy yield (batched distributions, stale-oracle catch-ups): every cap trigger permanently discards real yield.
+- The single most common blocking question: `fees == revenue` on an LP, lending or yield protocol. Ask what the supply side gets before merging.
+
+## Classification rules
+
+- `dailyHoldersRevenue` is only value flowing to the protocol's OWN token holders. No token = no holders revenue. If all revenue goes to buybacks, set `dailyProtocolRevenue: 0`.
+- Burns count as holders revenue only when funded by real receipts (fee burns, market buybacks). Treasury-funded own token burns and mint-and-burn accounting burns are never holders revenue. Measure buybacks at the fee source, not at distribution.
+- Never fees or revenue: governance-token emissions, token taxes, referral/referrer shares (supply side at most). LP, liquidator, insurance-fund and node-operator shares are `dailySupplySideRevenue`.
+- Fees to vault managers/curators are `dailySupplySideRevenue`. An underlying platform's cut of a product's fees (e.g. the launchpad's share of a trading bot's fees) is supply side too.
+- NFT-marketplace creator royalties are `dailySupplySideRevenue` only; inside `dailyRevenue` they double count.
+- GMV is not fees: keep fees net and track gross flow as its own metric. Buyback-exceeds-sales days on collectibles models legitimately go negative.
+- No revenue-share split without public confirmation. Absent published evidence, attribute nothing to the alleged partner and export the flow you can see.
+- A self-declared margin percentage from the team is not accepted as a fee rate; derive it from on-chain flows.
+- Negative values are legitimate for realized losses and must be counted (with `allowNegativeValue: true` and an inline reason), but formula-derived fees (e.g. mint/redeem deltas) cap at zero.
+- Export explicit zeros (`dailyRevenue: 0`) for a component the protocol genuinely lacks, but 0 is not "unavailable": never default an UNKNOWN component to zero, omit it until the flow is known. When a revenue/supply split cannot be derived from the source, export gross `dailyFees` only with `skipBreakdownValidation: true` plus a comment; never publish gross inflows as `dailyProtocolRevenue`.
+- A protocol with no fees at all is not worth listing.
+
+## Chain adapters
+
+- `protocolType: ProtocolType.CHAIN` is required; it distinguishes a chain from a protocol.
+- Fees = user-paid transaction fees only. Revenue = the burnt portion or DAO/treasury inflow only. Block rewards, validator/staker payouts and emissions are neither.
+- Rollup sequencer costs and blob fees paid to mainnet are `dailySupplySideRevenue`; chain revenue = fees minus those.
+- MEV and blockspace-auction income (Jito tips, Timeboost, Flashbots-style builders) is a SEPARATE listing, not part of the chain's fees.
+- Cover ALL execution environments of the chain (e.g. EVM plus native VM), and document source quirks (zero-fee system txs, cumulative vs daily) as code comments.

--- a/helpers/AGENTS.md
+++ b/helpers/AGENTS.md
@@ -115,7 +115,7 @@ METRIC.PROTOCOL_FEES         // 'Protocol Fees'
 |------|-----------|----------|
 | `curators/index.ts` | `getCuratorExport`, `CuratorConfig` | Vault curators (Morpho/Euler owners); configs live in `factory/curators.ts` |
 | `lists.ts` | `getDefaultDexTokensBlacklisted(chain)` | Central spam/fake token blacklist for uni-style DEX adapters |
-| `getChainFees.ts` | `fetchTransactionFees` | Chain gas fees from the indexer |
+| `getChainFees.ts` | `fetchTransactionFees` | Chain gas fees from the Allium query engine |
 | `routescanFees.ts` | Routescan chain fees | Paired with `factory/routescan.ts` |
 | `near.ts` | `nearView` | NEAR view calls |
 | `oklink.ts` | OKLink queries | Chains covered by OKLink |

--- a/helpers/AGENTS.md
+++ b/helpers/AGENTS.md
@@ -109,6 +109,22 @@ METRIC.PROTOCOL_FEES         // 'Protocol Fees'
 | `lists.ts` | List management | Protocol/chain lists |
 | `erc4626.ts` | ERC4626 helpers | Vault standard |
 
+### More Helpers Worth Knowing
+
+| File | Functions | Use Case |
+|------|-----------|----------|
+| `curators/index.ts` | `getCuratorExport`, `CuratorConfig` | Vault curators (Morpho/Euler owners); configs live in `factory/curators.ts` |
+| `lists.ts` | `getDefaultDexTokensBlacklisted(chain)` | Central spam/fake token blacklist for uni-style DEX adapters |
+| `getChainFees.ts` | `fetchTransactionFees` | Chain gas fees from the indexer |
+| `routescanFees.ts` | Routescan chain fees | Paired with `factory/routescan.ts` |
+| `near.ts` | `nearView` | NEAR view calls |
+| `oklink.ts` | OKLink queries | Chains covered by OKLink |
+| `env.ts` | `DEFAULTS` | Default RPC URLs per chain, `DEBUG_BREAKDOWN_FEES` |
+| `cache.ts` | `getConfig` | Cached remote config that survives source outages |
+| `../users/utils/routescanStats.ts`, `subscanStats.ts` | Chain users | Active users for Routescan / Substrate chains; wiring in `users/chains.ts` |
+
+`token.ts` blacklist parameters: `getSolanaReceived({ blacklists, blacklist_signers, blacklist_mints })`, `addGasTokensReceived({ blacklist_fromAddresses })`. On mixed-use wallets, scope with `fromAddresses` and comment each address's role.
+
 ## Usage Examples
 
 ### Using Protocol Helpers

--- a/open-interest/AGENTS.md
+++ b/open-interest/AGENTS.md
@@ -55,4 +55,4 @@ If this adapter returns fee/revenue dimensions, follow the guidelines in `fees/A
 - Follow the venue's total-OI convention: if the venue's total already counts each contract once, do not add longs and shorts on top of it. Apply the same convention to every market of the adapter. A large day-to-day swing without a matching price or position change usually means a unit or side bug.
 - A source that only serves current OI uses `runAtCurrTime: true`; snapshot metrics never carry cumulative columns.
 - OI is a snapshot at the window end, never a sum over the window. Under `pullHourly` a summed OI comes out 24x too high.
-- Open interest is a perps/futures metric. Options protocols export `dailyNotionalVolume` and `dailyPremiumVolume` and do not export open interest.
+- Open interest is currently exported for perps and futures only. Options adapters do not export it yet: raw notional OI is not comparable across expiries and strikes, and a measure normalized for time to expiry and distance from the current price is still to be defined.

--- a/open-interest/AGENTS.md
+++ b/open-interest/AGENTS.md
@@ -51,8 +51,8 @@ If this adapter returns fee/revenue dimensions, follow the guidelines in `fees/A
 
 ## Units and sources
 
-- Export open interest in USD (contracts times price for the window), never raw contract units.
-- Cover both sides (longs + shorts) uniformly; OI should be roughly TVL-stable, a wild day-to-day swing usually means a unit or side bug.
+- Export open interest in USD, never raw contract units: contracts (times the contract size/multiplier where the venue has one) times the mark or index price AT THE WINDOW END, not a window average. Inverse and quanto contracts use the venue's own notional formula; state it in a comment.
+- Follow the venue's total-OI convention: if the venue's total already counts each contract once, do not add longs and shorts on top of it. Apply the same convention to every market of the adapter. A large day-to-day swing without a matching price or position change usually means a unit or side bug.
 - A source that only serves current OI uses `runAtCurrTime: true`; snapshot metrics never carry cumulative columns.
 - OI is a snapshot at the window end, never a sum over the window. Under `pullHourly` a summed OI comes out 24x too high.
-- Open interest is a perps metric; options protocols export notional and premium volume instead.
+- Open interest is a perps/futures metric. Options protocols export `dailyNotionalVolume` and `dailyPremiumVolume` and do not export open interest.

--- a/open-interest/AGENTS.md
+++ b/open-interest/AGENTS.md
@@ -54,4 +54,5 @@ If this adapter returns fee/revenue dimensions, follow the guidelines in `fees/A
 - Export open interest in USD (contracts times price for the window), never raw contract units.
 - Cover both sides (longs + shorts) uniformly; OI should be roughly TVL-stable, a wild day-to-day swing usually means a unit or side bug.
 - A source that only serves current OI uses `runAtCurrTime: true`; snapshot metrics never carry cumulative columns.
+- OI is a snapshot at the window end, never a sum over the window. Under `pullHourly` a summed OI comes out 24x too high.
 - Open interest is a perps metric; options protocols export notional and premium volume instead.

--- a/open-interest/AGENTS.md
+++ b/open-interest/AGENTS.md
@@ -48,3 +48,10 @@ If this adapter returns fee/revenue dimensions, follow the guidelines in `fees/A
 2. Not accounting for leverage in notional calculations
 3. Missing multi-market aggregation
 4. Not handling liquidated positions
+
+## Units and sources
+
+- Export open interest in USD (contracts times price for the window), never raw contract units.
+- Cover both sides (longs + shorts) uniformly; OI should be roughly TVL-stable, a wild day-to-day swing usually means a unit or side bug.
+- A source that only serves current OI uses `runAtCurrTime: true`; snapshot metrics never carry cumulative columns.
+- Open interest is a perps metric; options protocols export notional and premium volume instead.

--- a/options/AGENTS.md
+++ b/options/AGENTS.md
@@ -21,13 +21,9 @@ These guidelines apply to all adapters in the `options/` directory.
 - This is real capital changing hands
 - More relevant for revenue calculations
 
-## Optional Dimensions
+## Open Interest
 
-| Dimension | Description |
-|-----------|-------------|
-| `openInterestAtEnd` | Total open interest at period end |
-| `longOpenInterestAtEnd` | Long positions (buyers) open interest |
-| `shortOpenInterestAtEnd` | Short positions (sellers) open interest |
+Options adapters do not export open interest (`openInterestAtEnd` and the long/short variants are perps-only dimensions). Notional and premium volume are the options metrics.
 
 ## Data Sources
 

--- a/options/AGENTS.md
+++ b/options/AGENTS.md
@@ -70,3 +70,8 @@ If this adapter returns fee/revenue dimensions, follow the guidelines in `fees/A
 3. Missing exercise/settlement events
 4. Double-counting expired options
 5. Not separating call vs put metrics when useful
+
+## Scope
+
+- Export `dailyNotionalVolume` + `dailyPremiumVolume`, never plain `dailyVolume`.
+- Perpetual options (funding-based, no expiry) do not belong on the options dashboard.

--- a/options/AGENTS.md
+++ b/options/AGENTS.md
@@ -23,7 +23,7 @@ These guidelines apply to all adapters in the `options/` directory.
 
 ## Open Interest
 
-Options adapters do not export open interest (`openInterestAtEnd` and the long/short variants are perps-only dimensions). Notional and premium volume are the options metrics.
+Open interest is currently exported for perps and futures only. Options adapters do not export it yet: raw notional OI is not comparable across expiries and strikes, and a measure normalized for time to expiry and distance from the current price is still to be defined. Notional and premium volume are the options metrics.
 
 ## Data Sources
 


### PR DESCRIPTION
Adds the review conventions that come up repeatedly in PR reviews but were not yet written down, so contributors and CodeRabbit can check against them.

Root `AGENTS.md`
- how to test an adapter locally (`npm run test`, the date argument is the window end, `DEBUG_BREAKDOWN_FEES`, `balances.debug()`, run several past days)
- where a new adapter goes (factory entries for uni/compound/aave forks, chain fees, curators, Hyperliquid builders, normalized volume, users) and the duplicate check against `factory/*.ts` and `deadAdapters.json`
- naming and listing identity (slug = folder name, never rename or delete, `.ts` wins over `x/index.ts`, listing prerequisites, server-side `dimensions` follow-up)
- adapter mechanics (`start`/`deadFrom` strings, `runAtCurrTime`, scale by the real window, throw on missing data, `dependencies`, `.clone()`, `doublecounted`, `cacheInCloud`)
- data source rules (source tiering, verify events exist on the contract, USD column units, point-in-time reads, no estimates, pricing/peg allowlists, fee-wallet scoping, Solana instruction-level attribution, Dune cost rules)
- getLogs performance, maintaining existing adapters (`deadFrom`, disabling a chain, time-guarded migrations, label strings force refills), methodology text rules, wash/fake volume policy

`fees/AGENTS.md`: accrual basis, yield/LST fees from exchange-rate growth, holders revenue and burn rules, classification of emissions/token taxes/referrals/curators/creator royalties, GMV vs fees, explicit zeros vs unknown components with `skipBreakdownValidation`, chain adapter rules (`ProtocolType.CHAIN`, MEV as a separate listing, blob costs as supply side).

`dexs/AGENTS.md`: what counts as volume (one side, swaps only, per-side events, ticker APIs, prediction markets, launchpads, OI in USD, no volume breakdowns) and fork listing via the factory files with config examples.

`helpers/AGENTS.md`: helpers missing from the catalog (curators, `lists.ts`, `getChainFees.ts`, `routescanFees.ts`, `near.ts`, `oklink.ts`, `env.ts`, `getConfig`, users stats) and the `token.ts` blacklist parameters.

`aggregators/`, `open-interest/`, `options/`: aggregator fees vs underlying fees, OI units and sources, options never export `dailyVolume`.

Documentation only, no adapter changes.