### PR TITLE
feat(fees): add NeoSoul Credits top-up revenue on BNB Chain

### DIFF
--- a/fees/neosoul.ts
+++ b/fees/neosoul.ts
@@ -1,0 +1,77 @@
+import { FetchOptions, SimpleAdapter } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+import { addTokensReceived } from "../helpers/token";
+import ADDRESSES from "../helpers/coreAssets.json";
+
+// NeoSoul revenue address (Safe) that receives every Credits top-up payment.
+// Credits are sold through NeoTrade, the product NeoSoul operates.
+// https://bscscan.com/address/0xa83bdeef155cdff1e03df944c1013521044d79fb
+const REVENUE_ADDRESS = "0xa83bdeef155cdff1e03df944c1013521044d79fb";
+
+// dailyFees uses a source label; dailyRevenue uses source + destination.
+const CREDITS_TOPUP = "Credits Top-ups";
+const CREDITS_TOPUP_TO_PROTOCOL = "Credits Top-ups To Protocol";
+
+// Users buy platform Credits with USDT on BNB Chain at a flat 1 USDT = 1,000
+// Credits, offered as three fixed top-up tiers:
+//   5 USDT   -> 5,000 Credits
+//   20 USDT  -> 20,000 Credits
+//   100 USDT -> 100,000 Credits
+// USDT is the only token accepted for top-ups, so it is the only one counted.
+const fetch = async (options: FetchOptions) => {
+  const dailyFees = options.createBalances();
+
+  const topUps = await addTokensReceived({
+    options,
+    target: REVENUE_ADDRESS,
+    token: ADDRESSES.bsc.USDT,
+  });
+  dailyFees.addBalances(topUps, CREDITS_TOPUP);
+
+  // NeoSoul keeps 100% of top-up payments, so revenue equals fees; it is
+  // rebuilt here to carry the destination label the revenue dimensions need.
+  const dailyRevenue = options.createBalances();
+  dailyRevenue.addBalances(topUps, CREDITS_TOPUP_TO_PROTOCOL);
+
+  return {
+    dailyFees,
+    dailyUserFees: dailyFees,
+    dailyRevenue,
+    dailyProtocolRevenue: dailyRevenue,
+  };
+};
+
+const methodology = {
+  Fees: "USDT paid by users to top up platform Credits on NeoTrade, the product NeoSoul operates, at a flat rate of 1 USDT = 1,000 Credits. Counted as USDT transfers into the protocol revenue address on BNB Chain.",
+  UserFees: "All fees are paid by users purchasing Credits; there are no other fee sources.",
+  Revenue: "100% of Credits top-up payments are protocol revenue.",
+  ProtocolRevenue: "NeoSoul retains 100% of Credits top-up payments.",
+};
+
+const breakdownMethodology = {
+  Fees: {
+    [CREDITS_TOPUP]: "USDT paid by users to top up platform Credits on NeoTrade.",
+  },
+  UserFees: {
+    [CREDITS_TOPUP]: "USDT paid by users to top up platform Credits on NeoTrade.",
+  },
+  Revenue: {
+    [CREDITS_TOPUP_TO_PROTOCOL]: "Credits top-up payments retained by NeoSoul; none is passed on to a supply side.",
+  },
+  ProtocolRevenue: {
+    [CREDITS_TOPUP_TO_PROTOCOL]: "Credits top-up payments retained by NeoSoul; none is passed on to a supply side.",
+  },
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  pullHourly: true,
+  fetch,
+  chains: [CHAIN.BSC],
+  // First Credits top-up received on 2026-08-13.
+  start: "2026-08-13",
+  methodology,
+  breakdownMethodology,
+};
+
+export default adapter;


### PR DESCRIPTION
Adds a fees/revenue adapter for **NeoSoul**, an AI economic infrastructure layer on BNB Chain. NeoSoul builds agents that discover, evolve and transact as independent economic actors.

The ecosystem has two products: **EvoEvo** (https://evoevo.ai), where agents are created, tested and improved, and **NeoTrade** (https://neotrade.pro), the autonomous trading surface where agents analyze markets and execute strategies within user-defined capital and risk parameters. Credits are sold on NeoTrade, which is why the docs link and the on-chain revenue address below sit under the NeoTrade name.

Website: https://neosoul.ai
Whitepaper: https://neosoul.ai/Whitepaper.pdf
Twitter: https://x.com/NeoSoulAI
Docs: https://docs.neotrade.pro

## (Needs to be filled only for new listings)

##### Name (to be shown on DefiLlama):

NeoSoul

##### Twitter Link:

https://x.com/NeoSoulAI

##### List of audit links if any:

https://scalebit.xyz/reports/neotrade-wallet-sdk-Audit-Report-2026-8-25.pdf

ScaleBit (BitsLab), 2026-08-25, covering the `neotrade-wallet-sdk` TypeScript packages (wallet key derivation, encrypted keystore, signing gateway) at `github.com/NeoSoul-AI/neotrade-wallet-sdk`. Note this audit covers the wallet SDK, not the revenue address this adapter reads.

##### Website Link:

https://neosoul.ai

##### Logo (High resolution, will be shown with rounded borders):

Attached in the comment below.

##### Current TVL:

Not applicable. The protocol does not custody user funds, so there is no TVL. This PR adds fees/revenue only.

##### Treasury Addresses (if the protocol has treasury)

None.

##### Chain:

BNB Chain (bsc)

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed):

None, the protocol has no token.

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed):

None, the protocol has no token.

##### Short Description (to be shown on DefiLlama):

AI agents that analyze markets and execute strategies within user-defined capital and risk limits. Users pay in USDT Credits.

##### Token address and ticker if any:

None, the protocol has no token.

##### Category (full list at https://defillama.com/categories) *Please choose only one:

AI Agents

##### Oracle Provider(s):

None. The adapter reads ERC-20 Transfer logs directly and does not depend on any oracle.

##### Implementation Details:

Not applicable, no oracle is used.

##### Documentation/Proof:

Not applicable, no oracle is used.

##### forkedFrom (Does your project originate from another project):

Not a fork.

##### methodology (what is being counted as tvl, how is tvl being calculated):

Counted as fees: USDT paid by users to top up platform Credits, at a flat rate of 1 USDT = 1,000 Credits. Sold as three fixed tiers:

| Tier | Credits |
|---|---|
| 5 USDT | 5,000 |
| 20 USDT | 20,000 |
| 100 USDT | 100,000 |

The adapter sums USDT `Transfer` events into the revenue address `0xa83bdeef155cdff1e03df944c1013521044d79fb` on BNB Chain, using the existing `addTokensReceived` helper. All of it is protocol revenue: `dailyFees` = `dailyUserFees` = `dailyRevenue` = `dailyProtocolRevenue`.

USDT is the only accepted payment token. I verified this by scanning `Transfer` logs into the address for USDT, USDC, BUSD and WBNB across the full life of the contract: only USDT has any inflow, the other three are exactly zero.

`start` is set to 2026-08-13, the date of the first Credits top-up.

##### Github org/user (Optional, if your code is open source, we can track activity):

https://github.com/NeoSoul-AI

##### Does this project have a referral program?

No.

## Verification

`npm test fees/neosoul.ts` returns data for all 24 hourly slots, daily total 14.35k.

Cross-checked against Dune over the adapter's own tested window (2026-09-01 03:00 → 2026-09-02 03:00 UTC):

| Source | Amount |
|---|---|
| Adapter | 14,350 USDT |
| Dune | 14,350 USDT (2,063 transfers) |

Dune query: https://dune.com/queries/8582085

Note that comparing the adapter against Dune's calendar-day grouping shows 14,350 vs 14,150; that 200 USDT gap is purely the different window boundaries, and the two agree exactly once the windows match.

Daily revenue over the last 7 full days averages ~9.3k USDT. Per-tier totals since launch: https://dune.com/queries/8581942
