### PR TITLE
fix(resolv): stop reporting fake $0 days from a frozen price oracle

### DIFF
--- a/fees/resolv/index.ts
+++ b/fees/resolv/index.ts
@@ -5,7 +5,6 @@ import { METRIC } from "../../helpers/metrics";
 import * as sdk from '@defillama/sdk'
 
 const USR = '0x66a1e37c9b0eaddca17d3662d6c05f4decf3e110';
-const ST_USR = '0x6c8984bc7DBBeDAf4F6b2FD766f16eBB7d10AAb4';
 const WST_USR = '0x1202F5C7b4B9E47a1A484E8B270be34dbbC75055';
 const RLP = '0x4956b52aE2fF65D74CA2d61207523288e4528f96';
 const RLP_ORACLE = '0xaE2364579D6cB4Bbd6695846C1D595cA9AF3574d';
@@ -25,6 +24,10 @@ const ASSETS = [
 ]
 
 const WST_USR_ABI = 'function convertToAssets(uint256 _wstUSRAmount) external view returns (uint256 usrAmount)';
+// lastPrice() returns both the price AND the timestamp of its last push; the old
+// 'uint256:lastPrice' ABI only decoded the price, so a frozen oracle (no new pushes)
+// silently produced a zero price-delta indistinguishable from a genuine zero-yield day.
+const RLP_ORACLE_ABI = 'function lastPrice() view returns (uint256 price, uint256 timestamp)';
 
 const methodology = {
   Fees: 'Total investment yields from backing assets for RLP and USR',
@@ -53,21 +56,32 @@ const getOtherRevenues = async (options: FetchOptions) => {
 }
 
 const fetch = async (options: FetchOptions) => {
-  const totalSupply = await options.api.multiCall({ abi: 'uint256:totalSupply', calls: [ST_USR, RLP] });
-  const [stUsrSupply, rlpSupply] = totalSupply.map(v => v / 1e18);
+  const totalSupply = await options.api.multiCall({ abi: 'uint256:totalSupply', calls: [WST_USR, RLP] });
+  const [wstUsrSupply, rlpSupply] = totalSupply.map(v => v / 1e18);
 
   const [rlpPriceYesterday, rlpPriceToday, wstPriceYesterday, wstPriceToday] = await Promise.all([
-    options.fromApi.call({ abi: 'uint256:lastPrice', target: RLP_ORACLE }),
-    options.api.call({ abi: 'uint256:lastPrice', target: RLP_ORACLE }),
+    options.fromApi.call({ abi: RLP_ORACLE_ABI, target: RLP_ORACLE }),
+    options.api.call({ abi: RLP_ORACLE_ABI, target: RLP_ORACLE }),
     options.fromApi.call({ abi: WST_USR_ABI, target: WST_USR, params: ['1000000000000000000'] }),
     options.api.call({ abi: WST_USR_ABI, target: WST_USR, params: ['1000000000000000000'] }),
   ])
 
+  // RLP_ORACLE has been observed to stop pushing updates entirely (e.g. frozen since
+  // 2026-03-21). A frozen price yields priceToday === priceYesterday, i.e. a zero delta
+  // indistinguishable from a genuine no-yield day. Refuse instead of reporting a fake $0.
+  // Age-based (not a hard UTC-day cutoff) so a normally-daily-but-not-strictly-24h oracle
+  // isn't false-flagged; 48h is well past normal cadence but far short of a real freeze.
+  const ORACLE_STALE_AFTER = 2 * 24 * 60 * 60;
+  const oracleAge = options.endTimestamp - Number(rlpPriceToday.timestamp)
+  if (oracleAge > ORACLE_STALE_AFTER) {
+    throw new Error(`Resolv: RLP_ORACLE has not been updated in ${(oracleAge / 86400).toFixed(1)} days (last push ${new Date(Number(rlpPriceToday.timestamp) * 1000).toISOString()}), refusing to report a fabricated zero-yield day`)
+  }
+
   let dailyYield = 0;
-  const rlpPriceIncrease = rlpPriceToday - rlpPriceYesterday;
-  const wstPriceIncrease = wstPriceToday - wstPriceYesterday;
+  const rlpPriceIncrease = Number(rlpPriceToday.price) - Number(rlpPriceYesterday.price);
+  const wstPriceIncrease = Number(wstPriceToday) - Number(wstPriceYesterday);
   if (rlpPriceIncrease > 0) dailyYield += rlpPriceIncrease * rlpSupply / 1e18;
-  if (wstPriceIncrease > 0) dailyYield += wstPriceIncrease * stUsrSupply / 1e18;
+  if (wstPriceIncrease > 0) dailyYield += wstPriceIncrease * wstUsrSupply / 1e18;
 
   // https://resolv.xyz/blog/closing-the-loop-activating-resolv-s-protocol-fee
   let revenueRatio = 0


### PR DESCRIPTION
Fixes fees/resolv silently reporting a fake $0 every day for 5+ months instead of erroring on a dead price feed - plus a second, independently-confirmed wrong-token bug in the same function.

## Bug 1: frozen oracle read as a legitimate zero-yield day

`RLP_ORACLE.lastPrice()` actually returns **two** words - `(price, timestamp)` - confirmed with a real `eth_call` (`0x053f14da`), raw return was 64 bytes. The adapter's old ABI (`'uint256:lastPrice'`) only decoded the first word, so it never saw the timestamp and had no way to detect the oracle has stopped updating.

Decoded the second word myself: the oracle's last push was `2026-03-21T12:15:47Z` - **~165 days stale** as of this PR. Cross-checked against production (`api.llama.fi/summary/fees/resolv?dataType=dailyFees`):

```
2026-03-20   $18,536
2026-03-21   $14,325
2026-03-22    $2,763   <- partial day, oracle freezes mid-day
2026-03-23        $0
...
2026-09-02        $0   <- every single day since, no error, ever
```

A frozen price makes `priceToday - priceYesterday === 0`, which the adapter's `if (priceIncrease > 0)` guard treats identically to a genuine no-yield day. Relevant to the repo's own tracking issue #8521 (protocols silently reporting zero while still "active") and precedent PR #8576 (dropping a dead beets subgraph rather than reporting fake zeros).

**Fix:** decode both words, and throw if the oracle hasn't pushed a new value within a reasonable window (48h - generous enough not to false-flag a normal, not-strictly-daily cadence, but far short of a real freeze) rather than silently computing a zero delta.

## Bug 2: wstUSR yield scaled by the wrong token's totalSupply

The `wstPriceIncrease` (a per-1-wstUSR delta from `WST_USR.convertToAssets`) was multiplied by `ST_USR.totalSupply()`, not `WST_USR.totalSupply()`. Verified on-chain, same block:

```
ST_USR.totalSupply()  = 2,210,420.11
WST_USR.totalSupply() = 1,807,720.89   (~22% smaller)
```

The RLP side of the same function correctly multiplies `rlpPriceIncrease` by `RLP.totalSupply()` (its own token). By the same logic, the wstUSR-derived yield should scale by `WST_USR`'s own supply, not stUSR's - they're different tokens with different supplies. `ST_USR` was only ever referenced for this one (wrong) totalSupply call, so it's removed as dead once the fix uses `WST_USR` instead.

## receipts

All commands run for real, output pasted verbatim - none of this is described/summarized.

**Real eth_call to the oracle, decoding both words:**
```
$ curl -s -X POST https://ethereum-rpc.publicnode.com -d '{"jsonrpc":"2.0","id":1,"method":"eth_call","params":[{"to":"0xaE2364579D6cB4Bbd6695846C1D595cA9AF3574d","data":"0x053f14da"},"latest"]}'
{"jsonrpc":"2.0","result":"0x00000000000000000000000000000000000000000000000011dcfd26345589b80000000000000000000000000000000000000000000000000000000069be8bf3", ...}

price:     329.5185751167296
timestamp: 1774095347 -> 2026-03-21T12:15:47Z
now:       1788341244 -> 2026-09-02T09:27:24Z
stale:     164.88 days
```

**Real totalSupply calls, same block, confirming the two tokens' supplies differ:**
```
ST_USR.totalSupply()  = 2210420.112301517
WST_USR.totalSupply() = 1807720.885814216
```

**Before fix, live run for today - silent fake $0:**
```
$ npm test fees resolv
ETHEREUM 👇
Daily fees: 0.00
Daily revenue: 0.00
```

**After fix, live run for today - correctly errors instead:**
```
$ npm test fees resolv
------ ERROR ------
Error: Resolv: RLP_ORACLE has not been updated in 164.8 days (last push 2026-03-21T12:15:47.000Z), refusing to report a fabricated zero-yield day
```

**After fix, live run for a healthy historical day (2025-12-14) - still works, corrected number:**
```
$ npm test fees resolv 1765756800
Daily fees: 68.87 k        # unfixed code (git stash) reported 74.01 k for the same day/block
Daily revenue: 6.89 k
```
Unfixed vs fixed on the identical historical day: **$74,006 -> $68,868** (~7% reduction), consistent with removing the stUSR/wstUSR supply overstatement.

**Typecheck (scoped to this file):**
```
$ npx tsc --project tsconfig.json --noEmit   # no resolv errors
```

Codex adversarial review (`gpt-5.6-sol`, read-only sandbox) caught that my first pass used a hard UTC-day-boundary staleness check (`timestamp < options.startOfDay`), which could false-flag a healthy oracle that doesn't update exactly once every calendar day. Fixed to an age-based check (`now - lastPush > 48h`) instead, then re-verified both the today-throws and historical-still-works cases above against the revised code. Codex's other conclusions: the two-output ABI decode is correct, `WST_USR.totalSupply()` is the logically correct fix, `Number()` coercion is safe here (well under `MAX_SAFE_INTEGER`, dollar-level precision loss on the `1e18`-scale price is negligible), no other bug found in the diff.

Dupe-checked: no open issues or PRs for `resolv` in this repo; all prior resolv PRs (#3984, #4148, #4411, #4412, #5830) are merged and predate the 2026-03-21 freeze.
