### PR TITLE
dexs: apply the shared Dune token blacklist to uniswap, pancakeswap and aerodrome

### DIFF
--- a/dexs/aerodrome-slipstream/index.ts
+++ b/dexs/aerodrome-slipstream/index.ts
@@ -1,7 +1,7 @@
 import * as sdk from '@defillama/sdk';
 import { FetchOptions, FetchResult, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
-import { getDefaultDexTokensBlacklisted } from '../../helpers/lists';
+import { getDexTokensBlacklisted } from '../../helpers/lists';
 import { addOneToken } from '../../helpers/prices';
 import { getEstablishedTokens, getWashPools } from '../../helpers/uniswap';
 import { formatAddress } from '../../utils/utils';
@@ -126,7 +126,7 @@ const fetch = async (fetchOptions: FetchOptions): Promise<FetchResult> => {
 
   // ignore pools holding blacklisted (scam/wash-traded) tokens - everything
   // downstream (volume, fees, revenue splits) derives from rawPools
-  const blacklistTokens = new Set(getDefaultDexTokensBlacklisted(chain))
+  const blacklistTokens = new Set(await getDexTokensBlacklisted(fetchOptions))
   rawPools = rawPools.filter(({ token0, token1 }: any) => !blacklistTokens.has(formatAddress(token0)) && !blacklistTokens.has(formatAddress(token1)))
 
   // drop the day's wash-flagged pools (see getWashPools), unless every side is

--- a/dexs/aerodrome/index.ts
+++ b/dexs/aerodrome/index.ts
@@ -1,7 +1,7 @@
 import * as sdk from '@defillama/sdk';
 import { FetchOptions, FetchResult, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
-import { getDefaultDexTokensBlacklisted } from '../../helpers/lists';
+import { getDexTokensBlacklisted } from '../../helpers/lists';
 import { addOneToken } from '../../helpers/prices';
 import { getEstablishedTokens, getWashPools } from '../../helpers/uniswap';
 import { formatAddress } from '../../utils/utils';
@@ -96,7 +96,7 @@ const getVolumeFeesAndRevenue = async (
 
   // ignore pools holding blacklisted (scam/wash-traded) tokens - everything
   // downstream (volume, fees, revenue splits) derives from rawPools
-  const blacklistTokens = new Set(getDefaultDexTokensBlacklisted(chain))
+  const blacklistTokens = new Set(await getDexTokensBlacklisted(fetchOptions))
   let rawPools = (await fetchOptions.getLogs({ target: CONFIG.PoolFactory, fromBlock: 3200668, eventAbi: eventAbis.event_pool_created, onlyArgs: true, cacheInCloud: true, skipIndexer: true }))
     .filter(({ token0, token1 }: any) => !blacklistTokens.has(formatAddress(token0)) && !blacklistTokens.has(formatAddress(token1)))
 

--- a/dexs/pancakeswap-infinity.ts
+++ b/dexs/pancakeswap-infinity.ts
@@ -1,7 +1,7 @@
 import * as sdk from "@defillama/sdk";
 import { BaseAdapter, FetchOptions, SimpleAdapter } from "../adapters/types"
 import { CHAIN } from "../helpers/chains"
-import { getDefaultDexTokensBlacklisted } from "../helpers/lists"
+import { getDexTokensBlacklisted } from "../helpers/lists"
 import { addOneToken } from "../helpers/prices"
 
 const METRIC = {
@@ -15,7 +15,7 @@ const METRIC = {
 // https://developer.pancakeswap.finance/contracts/infinity/resources/addresses
 // Both CLAMM (CLPoolManager) and LBAMM (BinPoolManager) launched together as part of Infinity.
 const config: any = {
-  [CHAIN.BSC]: { clPoolManager: '0xa0ffb9c1ce1fe56963b0321b32e7a0302114058b', binPoolManager: '0xc697d2898e0d09264376196696c51d7abbbaa4a9', fromBlock: 47214308, start: '2025-03-06', blacklistTokens: getDefaultDexTokensBlacklisted(CHAIN.BSC) },
+  [CHAIN.BSC]: { clPoolManager: '0xa0ffb9c1ce1fe56963b0321b32e7a0302114058b', binPoolManager: '0xc697d2898e0d09264376196696c51d7abbbaa4a9', fromBlock: 47214308, start: '2025-03-06' },
   [CHAIN.BASE]: { clPoolManager: '0xa0ffb9c1ce1fe56963b0321b32e7a0302114058b', binPoolManager: '0xc697d2898e0d09264376196696c51d7abbbaa4a9', fromBlock: 30544106, start: '2025-05-23' },
 }
 const adapter: SimpleAdapter = {
@@ -112,8 +112,10 @@ async function trackPoolManager({ getLogs, chain, target, fromBlock, getFromBloc
   })
 }
 
-async function fetch({ getLogs, createBalances, chain, fromApi, toApi }: FetchOptions) {
-  const { clPoolManager, binPoolManager, fromBlock, blacklistTokens } = config[chain]
+async function fetch(options: FetchOptions) {
+  const { getLogs, createBalances, chain, fromApi, toApi } = options
+  const { clPoolManager, binPoolManager, fromBlock } = config[chain]
+  const blacklistTokens = await getDexTokensBlacklisted(options)
   const getFromBlock = Number(fromApi.block)
   const getToBlock = Number(toApi.block)
   const dailyVolume = createBalances()

--- a/dexs/pancakeswap-v2.ts
+++ b/dexs/pancakeswap-v2.ts
@@ -5,7 +5,7 @@ import * as sdk from "@defillama/sdk";
 import { httpGet } from "../utils/fetchURL";
 import { getEnv } from "../helpers/env";
 import { queryClickhouse } from "../helpers/indexer";
-import { getDefaultDexTokensWhitelisted } from "../helpers/lists";
+import { getDefaultDexTokensWhitelisted, getDexTokensBlacklisted } from "../helpers/lists";
 import { Row } from "@clickhouse/client";
 
 const METRIC = {
@@ -432,7 +432,8 @@ const fetchV2 = async (options: FetchOptions) => {
     const adapter = getUniV2LogAdapter({
       factory: logConfig.factory,
       eventAbi: ABIS.SWAP_EVENT,
-      pairCreatedAbi: ABIS.POOL_CREATE
+      pairCreatedAbi: ABIS.POOL_CREATE,
+      blacklistTokens: await getDexTokensBlacklisted(options),
     });
     const logStats = await adapter(options);
     const fees = calculateFeesBalances(logStats.dailyVolume);

--- a/dexs/pancakeswap-v3.ts
+++ b/dexs/pancakeswap-v3.ts
@@ -1,5 +1,5 @@
 import { CHAIN } from "../helpers/chains";
-import { getDefaultDexTokensWhitelisted } from "../helpers/lists";
+import { getDefaultDexTokensWhitelisted, getDexTokensBlacklisted } from "../helpers/lists";
 import { BaseAdapter, FetchOptions, SimpleAdapter } from "../adapters/types";
 import { getUniV3LogAdapter, UniGetRevenueRatioProps } from '../helpers/uniswap';
 import { queryClickhouse } from "../helpers/indexer";
@@ -263,10 +263,11 @@ const fetchBsc = async (options: FetchOptions) => {
   };
 };
 
-const buildEvmFetcher = (factory: string) => {
+const buildEvmFetcher = (factory: string) => async (options: FetchOptions) => {
   const evmAdapter = getUniV3LogAdapter({
     factory,
     swapEvent: poolSwapEvent,
+    blacklistTokens: await getDexTokensBlacklisted(options),
     userFeesRatio: 1,
     getRevenueRatio: ({ poolFeeTier }: UniGetRevenueRatioProps) => {
       const _protocolRevenueRatio = getProtocolRevenueRatio(poolFeeTier);
@@ -278,7 +279,7 @@ const buildEvmFetcher = (factory: string) => {
       };
     },
   })
-  return async (options: FetchOptions) => evmAdapter(options)
+  return evmAdapter(options)
 }
 
 const pancakeSolanaExplorer = 'https://sol-explorer.pancakeswap.com/api/cached/v1/pools/info/list?poolType=concentrated&poolSortField=default&order=desc'

--- a/dexs/squadswap-thanos.ts
+++ b/dexs/squadswap-thanos.ts
@@ -1,6 +1,6 @@
 import { FetchOptions, SimpleAdapter } from "../adapters/types"
 import { CHAIN } from "../helpers/chains"
-import { getDefaultDexTokensBlacklisted } from "../helpers/lists"
+import { getDexTokensBlacklisted } from "../helpers/lists"
 import { addOneToken } from "../helpers/prices"
 
 const METRIC = {
@@ -11,8 +11,8 @@ const METRIC = {
 
 // SquadSwap Thanos is SquadSwap's v4, both CLAMM (CLPoolManager) and LBAMM (BinPoolManager) launched together.
 const config: any = {
-  [CHAIN.BSC]: { clPoolManager: '0x9d3b119eff69cd81d324f654062b6ffa3dd7f405', binPoolManager: '0xd7a5a9df1719ee83a4d10749019caabf137debac', fromBlock: 74380131, start: '2026-01-07', blacklistTokens: getDefaultDexTokensBlacklisted(CHAIN.BSC) },
-  [CHAIN.BASE]: { clPoolManager: '0xbb07a7bdfc50829ce932adccc0498f0e29f49f50', binPoolManager: '0xd243e0c2fc2a91eace239e0c54023559a47c5f04', fromBlock: 40500004, start: '2026-01-07', blacklistTokens: getDefaultDexTokensBlacklisted(CHAIN.BASE) },
+  [CHAIN.BSC]: { clPoolManager: '0x9d3b119eff69cd81d324f654062b6ffa3dd7f405', binPoolManager: '0xd7a5a9df1719ee83a4d10749019caabf137debac', fromBlock: 74380131, start: '2026-01-07' },
+  [CHAIN.BASE]: { clPoolManager: '0xbb07a7bdfc50829ce932adccc0498f0e29f49f50', binPoolManager: '0xd243e0c2fc2a91eace239e0c54023559a47c5f04', fromBlock: 40500004, start: '2026-01-07' },
 }
 
 const adapter: SimpleAdapter = {
@@ -95,8 +95,10 @@ async function trackPoolManager({ getLogs, chain, target, fromBlock, initializeA
   })
 }
 
-async function fetch({ getLogs, createBalances, chain }: FetchOptions) {
-  const { clPoolManager, binPoolManager, fromBlock, blacklistTokens } = config[chain]
+async function fetch(options: FetchOptions) {
+  const { getLogs, createBalances, chain } = options
+  const { clPoolManager, binPoolManager, fromBlock } = config[chain]
+  const blacklistTokens = await getDexTokensBlacklisted(options)
   const dailyVolume = createBalances()
   const swapFees = createBalances()
   const revenue = createBalances()

--- a/dexs/uniswap-v2.ts
+++ b/dexs/uniswap-v2.ts
@@ -2,7 +2,7 @@ import { CHAIN } from "../helpers/chains";
 import { Adapter, FetchOptions, FetchResultV2 } from "../adapters/types";
 import { getUniV2LogAdapter } from "../helpers/uniswap";
 import { queryClickhouse } from "../helpers/indexer";
-import { getDefaultDexTokensWhitelisted } from "../helpers/lists";
+import { getDefaultDexTokensWhitelisted, getDexTokensBlacklisted } from "../helpers/lists";
 import { Row } from "@clickhouse/client";
 
 type Source = 'LOGS' | 'CLICKHOUSE';
@@ -266,7 +266,7 @@ const fetch = async (options: FetchOptions) => {
   }
 
   if (config.source === 'LOGS') {
-    const fetchFunction = getUniV2LogAdapter({ factory: config.factory, ...getLogAdapterConfig(options), allowReadPairs: options.chain === CHAIN.ZORA });
+    const fetchFunction = getUniV2LogAdapter({ factory: config.factory, ...getLogAdapterConfig(options), allowReadPairs: options.chain === CHAIN.ZORA, blacklistTokens: await getDexTokensBlacklisted(options) });
     return await fetchFunction(options);
   } else if (config.source === 'CLICKHOUSE') {
     return await fetchClickhouse(options, config);

--- a/dexs/uniswap-v3.ts
+++ b/dexs/uniswap-v3.ts
@@ -3,6 +3,7 @@ import { FetchOptions, FetchV2, SimpleAdapter } from "../adapters/types";
 import { addOneToken } from "../helpers/prices";
 import { queryDune } from "../helpers/dune";
 import { httpPost } from "../utils/fetchURL";
+import { DUNE_DEX_BLACKLIST_TABLE } from "../helpers/lists";
 import {
   getEstablishedTokens, getUniV3LogAdapter, washDayStart, WASH_DUST_USD, WASH_MIN_TRADES,
   WASH_MIN_USD, WASH_TRADES_PER_EOA, WASH_USD_MIN_TRADES_PER_EOA, WASH_USD_PER_EOA,
@@ -60,22 +61,28 @@ async function fetchHoldersRevenue(options: FetchOptions) {
 // so SUM per token gives that token's total traded amount; addOneToken later
 // counts one (priceable) side as volume. No token whitelist: DefiLlama pricing
 // (+ <$10k-TVL rule) drops unpriceable tokens, and fetchWashPools drops pools
-// whose flow is too concentrated to be organic.
+// whose flow is too concentrated to be organic. Swaps touching a token in the
+// shared Dune blacklist (DUNE_DEX_BLACKLIST_TABLE, per chain or 'any') are
+// dropped in-query, so scam quote tokens never reach pricing.
 function buildQuery(blockchains: string[], options: FetchOptions): string {
   const inList = blockchains.map((b) => `'${b}'`).join(',');
   return `
-    SELECT blockchain, project_contract_address AS pool, t.token, CAST(SUM(t.amount) AS VARCHAR) AS amount
-    FROM dex.trades
+    SELECT d.blockchain, d.project_contract_address AS pool, t.token, CAST(SUM(t.amount) AS VARCHAR) AS amount
+    FROM dex.trades d
     CROSS JOIN UNNEST(
-      ARRAY[token_bought_address, token_sold_address],
-      ARRAY[token_bought_amount_raw, token_sold_amount_raw]
+      ARRAY[d.token_bought_address, d.token_sold_address],
+      ARRAY[d.token_bought_amount_raw, d.token_sold_amount_raw]
     ) AS t (token, amount)
-    WHERE blockchain IN (${inList})
-      AND project = 'uniswap'
-      AND version = '3'
-      AND block_time >= from_unixtime(${options.startTimestamp})
-      AND block_time < from_unixtime(${options.endTimestamp})
-    GROUP BY blockchain, project_contract_address, t.token`;
+    LEFT JOIN ${DUNE_DEX_BLACKLIST_TABLE} b0 ON b0.address = d.token_bought_address AND b0.chain IN ('any', d.blockchain)
+    LEFT JOIN ${DUNE_DEX_BLACKLIST_TABLE} b1 ON b1.address = d.token_sold_address AND b1.chain IN ('any', d.blockchain)
+    WHERE d.blockchain IN (${inList})
+      AND d.project = 'uniswap'
+      AND d.version = '3'
+      AND d.block_time >= from_unixtime(${options.startTimestamp})
+      AND d.block_time < from_unixtime(${options.endTimestamp})
+      AND b0.address IS NULL
+      AND b1.address IS NULL
+    GROUP BY d.blockchain, d.project_contract_address, t.token`;
 }
 
 // Same wash test the v4 adapter runs (see there). v3 is barely exposed - 0.4% of

--- a/dexs/uniswap-v4.ts
+++ b/dexs/uniswap-v4.ts
@@ -57,7 +57,7 @@ import { BaseAdapter, FetchOptions, SimpleAdapter } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
 import ADDRESSES from '../helpers/coreAssets.json';
 import { queryDune } from "../helpers/dune";
-import { getDefaultDexTokensBlacklisted } from "../helpers/lists";
+import { getDexTokensBlacklisted } from "../helpers/lists";
 import { isCoreAsset } from "../helpers/prices";
 import {
   getEstablishedTokens, washDayStart, WASH_DUST_USD, WASH_MIN_TRADES, WASH_MIN_USD,
@@ -402,7 +402,7 @@ async function fetch(options: FetchOptions) {
         }
       }
 
-      const blacklistTokens = new Set(getDefaultDexTokensBlacklisted(options.chain))
+      const blacklistTokens = new Set(await getDexTokensBlacklisted(options))
       const washPools = options.preFetchedResults?.washPools?.[DUNE_CHAIN[options.chain]]
       // flagged pools whose sides are all established (core or CG-listed) are
       // spared - one batched price lookup, see getEstablishedTokens

--- a/helpers/dune.ts
+++ b/helpers/dune.ts
@@ -278,6 +278,9 @@ const tableName = {
   [CHAIN.AVAX]: "avalanche_c"
 } as any
 
+// DefiLlama chain key -> Dune `blockchain` slug
+export const duneBlockchain = (chain: string): string => tableName[chain] ?? chain
+
 export const queryDuneSql = (options: any, query: string, { extraUIDKey }: { extraUIDKey?: string } = {}) => {
 
   return queryDune("3996608", {

--- a/helpers/lists.ts
+++ b/helpers/lists.ts
@@ -1,6 +1,8 @@
+import { FetchOptions } from "../adapters/types";
 import { formatAddress } from "../utils/utils";
 import { getConfig } from "./cache";
 import { CHAIN } from "./chains";
+import { duneBlockchain, queryDune } from "./dune";
 
 export const DefaultDexTokensBlacklisted: Record<string, Array<string>> = {
   [CHAIN.ETHEREUM]: [
@@ -128,6 +130,47 @@ export function getDefaultDexTokensBlacklisted(chain: string): Array<string> {
   return DefaultDexTokensBlacklisted[chain]
     ? DefaultDexTokensBlacklisted[chain].map((item) => formatAddress(item))
     : [];
+}
+
+// Shared scam/fake-token list maintained on Dune, applied on top of
+// DefaultDexTokensBlacklisted. Add new offenders there, not here:
+// https://dune.com/data/dune.zteam.dataset_dex_blacklist
+// Columns: address (varbinary, joins directly on dex.trades token columns),
+// chain (varchar Dune blockchain slug, or 'any' for every chain). For an
+// in-query filter see dexs/uniswap-v3.ts; for a client-side list use
+// getDexTokensBlacklisted below.
+export const DUNE_DEX_BLACKLIST_TABLE = 'dune.zteam.dataset_dex_blacklist';
+
+let duneDexBlacklist: Promise<Record<string, Set<string>>> | undefined;
+
+// One Dune call per process; the dataset is a few thousand rows. A failure
+// throws (and clears the cache so the next call retries) - reporting unfiltered
+// would republish scam volume as real.
+function fetchDuneDexBlacklist(options: FetchOptions): Promise<Record<string, Set<string>>> {
+  if (!duneDexBlacklist) {
+    duneDexBlacklist = queryDune('3996608', { fullQuery: `SELECT chain, address FROM ${DUNE_DEX_BLACKLIST_TABLE}` }, options, { extraUIDKey: 'dex-blacklist' })
+      .then((rows: any[]) => {
+        const byChain: Record<string, Set<string>> = {};
+        for (const row of rows) {
+          if (!row.address || !row.chain) continue;
+          (byChain[String(row.chain).toLowerCase()] ??= new Set()).add(formatAddress(row.address));
+        }
+        return byChain;
+      })
+      .catch((e) => { duneDexBlacklist = undefined; throw e; });
+  }
+  return duneDexBlacklist;
+}
+
+// DefaultDexTokensBlacklisted for the chain + the Dune dataset's 'any' rows and
+// the chain's own rows. Lowercased. Use this in adapters instead of
+// getDefaultDexTokensBlacklisted whenever a Dune dependency is acceptable.
+export async function getDexTokensBlacklisted(options: FetchOptions): Promise<Array<string>> {
+  const byChain = await fetchDuneDexBlacklist(options);
+  const tokens = new Set(getDefaultDexTokensBlacklisted(options.chain));
+  for (const token of byChain['any'] ?? []) tokens.add(token);
+  for (const token of byChain[duneBlockchain(options.chain)] ?? []) tokens.add(token);
+  return [...tokens];
 }
 
 export function getAllDexTokensBlacklisted(): Array<string> {

--- a/helpers/uniswap.ts
+++ b/helpers/uniswap.ts
@@ -130,6 +130,18 @@ export async function filterPools({ api, pairs, createBalances, maxPairSize = 42
   return Object.fromEntries(sortedPairs)
 }
 
+// drop pairs where either side is a blacklisted token (see helpers/lists.ts)
+function filterBlacklistedTokens(pairObject: IJSON<string[]>, blacklistTokens?: string[]): IJSON<string[]> {
+  if (!blacklistTokens?.length) return pairObject
+  const blacklist = new Set(blacklistTokens.map(i => i.toLowerCase()))
+  const filtered: IJSON<string[]> = {}
+  for (const [pair, tokens] of Object.entries(pairObject)) {
+    if (tokens.some(token => blacklist.has(String(token).toLowerCase()))) continue
+    filtered[pair] = tokens
+  }
+  return filtered
+}
+
 function filterBlacklistedPools(pairObject: IJSON<string[]>, blacklistPools?: string[]): IJSON<string[]> {
   if (!blacklistPools?.length) return pairObject
 
@@ -145,7 +157,7 @@ const defaultV2SwapEvent = 'event Swap(address indexed sender, uint amount0In, u
 const notifyRewardEvent = 'event NotifyReward(address indexed from,address indexed reward,uint256 indexed epoch,uint256 amount)';
 
 export const getUniV2LogAdapter: any = (v2Config: UniV2Config): FetchV2 => {
-  let { factory, fees = 0.003, swapEvent = defaultV2SwapEvent, stableFees = 1 / 10000, voter, maxPairSize, customLogic, blacklistedAddresses, userFeesRatio, revenueRatio, protocolRevenueRatio, holdersRevenueRatio, blacklistPools, allowReadPairs } = v2Config
+  let { factory, fees = 0.003, swapEvent = defaultV2SwapEvent, stableFees = 1 / 10000, voter, maxPairSize, customLogic, blacklistedAddresses, userFeesRatio, revenueRatio, protocolRevenueRatio, holdersRevenueRatio, blacklistPools, blacklistTokens, allowReadPairs } = v2Config
   const fetch: FetchV2 = async (fetchOptions) => {
     const { createBalances, getLogs, chain, api } = fetchOptions
     let blacklistedAddressesSet: any
@@ -184,7 +196,7 @@ export const getUniV2LogAdapter: any = (v2Config: UniV2Config): FetchV2 => {
     const dailyVolume = createBalances()
     const swapFees = createBalances()
     const blacklistPoolsSet = blacklistPools ? new Set(blacklistPools.map(i => i.toLowerCase())) : null
-    const pairsToFilter = filterBlacklistedPools(pairObject, blacklistPools)
+    const pairsToFilter = filterBlacklistedPools(filterBlacklistedTokens(pairObject, blacklistTokens), blacklistPools)
     const filteredPairs = await filterPools({ api, pairs: pairsToFilter, createBalances, maxPairSize })
     const pairIds = Object.keys(filteredPairs)
     api.log(`uniV2RunLog: Filtered to ${pairIds.length}/${pairs.length} pairs Factory: ${factory} Chain: ${chain}`)
@@ -268,7 +280,7 @@ const defaultAlgebraV3PoolCreatedEvent = 'event Pool (address indexed token0, ad
 // Algebra Constants.COMMUNITY_FEE_DENOMINATOR, same on V1.9 and Integral
 const COMMUNITY_FEE_DENOMINATOR = 1e3
 
-export const getUniV3LogAdapter: any = ({ factory, poolCreatedEvent, swapEvent = defaultV3SwapEvent, customLogic, isAlgebraV3 = false, isAlgebraV2 = false, userFeesRatio, revenueRatio, protocolRevenueRatio, holdersRevenueRatio, blacklistPools, pools, getRevenueRatio, dynamicProtocolFees = false, algebraCommunityFee = false }: UniV3Config): FetchV2 => {
+export const getUniV3LogAdapter: any = ({ factory, poolCreatedEvent, swapEvent = defaultV3SwapEvent, customLogic, isAlgebraV3 = false, isAlgebraV2 = false, userFeesRatio, revenueRatio, protocolRevenueRatio, holdersRevenueRatio, blacklistPools, blacklistTokens, pools, getRevenueRatio, dynamicProtocolFees = false, algebraCommunityFee = false }: UniV3Config): FetchV2 => {
   const fetch: FetchV2 = async (fetchOptions) => {
     const { createBalances, getLogs, chain, api } = fetchOptions
     const pairObject: IJSON<string[]> = {}
@@ -332,7 +344,7 @@ export const getUniV3LogAdapter: any = ({ factory, poolCreatedEvent, swapEvent =
     }
 
     const blacklistPoolsSet = blacklistPools ? new Set(blacklistPools.map(i => i.toLowerCase())) : null
-    const pairsToFilter = filterBlacklistedPools(pairObject, blacklistPools)
+    const pairsToFilter = filterBlacklistedPools(filterBlacklistedTokens(pairObject, blacklistTokens), blacklistPools)
     const filteredPairs = await filterPools({ api, pairs: pairsToFilter, createBalances })
     const dailyVolume = createBalances()
     const swapFees = createBalances()
@@ -462,6 +474,7 @@ type UniV2Config = {
   protocolRevenueRatio?: number,
   holdersRevenueRatio?: number,
   blacklistPools?: Array<string>,
+  blacklistTokens?: Array<string>, // pairs holding any of these tokens are skipped
   allowReadPairs?: boolean;
 }
 
@@ -488,6 +501,7 @@ type UniV3Config = {
   start?: string,
   deadFrom?: string,
   blacklistPools?: Array<string>,
+  blacklistTokens?: Array<string>, // pools holding any of these tokens are skipped
   pools?: string[], // alternative to providing factory
   dynamicProtocolFees?: boolean,
   // read each Algebra pool's community fee and pass it to getRevenueRatio


### PR DESCRIPTION
Scam/fake tokens are now blacklisted from the shared Dune dataset `dune.zteam.dataset_dex_blacklist` (columns `address` varbinary, `chain` = Dune slug or `any`), on top of the static `DefaultDexTokensBlacklisted` list in `helpers/lists.ts`.

- `helpers/lists.ts`: `getDexTokensBlacklisted(options)` returns the static list merged with the dataset's `any` rows and the chain's rows. One Dune call per process, cached. A Dune failure throws rather than reporting unfiltered volume.
- `helpers/uniswap.ts`: `blacklistTokens` option on `getUniV2LogAdapter` / `getUniV3LogAdapter`, pairs holding a listed token are skipped.
- `dexs/uniswap-v3.ts`: the dex.trades query LEFT JOINs the dataset on both token legs and drops matching swaps in-query.
- `dexs/uniswap-v2.ts` (LOGS chains), `pancakeswap-v2.ts` (LOGS chains), `pancakeswap-v3.ts` (EVM log chains): pass the merged list to the log adapter.
- `dexs/uniswap-v4.ts`, `aerodrome`, `aerodrome-slipstream`, `pancakeswap-infinity`, `squadswap-thanos`: swap `getDefaultDexTokensBlacklisted` for the merged list.

Tested on 2026-08-31 (`DISABLE_PULL_HOURLY=true`): aerodrome-slipstream 427.6M vs 434.8M published, uniswap-v4 base 41.0M vs 41.2M, uniswap-v2 optimism 292 vs 291, pancakeswap-v3 base and pancakeswap-v2 base run clean. `npm run ts-check` passes.