### PR TITLE
accountable: exclude aHYPER Looping Vault from fee tracking

### DIFF
--- a/fees/accountable.ts
+++ b/fees/accountable.ts
@@ -63,10 +63,12 @@ const config: Record<string, { factories: string[], start: string }> = {
 
 // aHYPER Looping Vault (vault 0x23b148d8f389C5821739381f1FF87bB7e1162566) is
 // EOA-deployed rather than created by a registered factory, so enumeration
-// cannot reach it. The TVL adapter carries the same exception.
-const EXTRA_STRATEGIES: Record<string, { address: string, deployedOn: string }[]> = {
-  [CHAIN.MONAD]: [{ address: "0xE19b272b2fe4a54103A41F9B1c65dB3D2F6d886D", deployedOn: "2026-04-28" }],
-};
+// cannot reach it. Excluded from fee tracking: it's a hidden, still-in-testing
+// vault whose configured 10% performanceFee/50% managerSplit is not actually
+// being charged, so booking fees off its share-price growth would overstate
+// protocol revenue. Re-add once fee collection is live for it. The TVL
+// adapter carries the EOA-deployed exception separately and is unaffected.
+const EXTRA_STRATEGIES: Record<string, { address: string, deployedOn: string }[]> = {};
 
 const abis = {
   getStrategiesCount: "function getStrategiesCount() view returns (uint256)",


### PR DESCRIPTION
## Summary
- `aHYPER Looping Vault` (0x23b148d8f389C5821739381f1FF87bB7e1162566, monad) has a `performanceFee`/`managerSplit` configured on-chain via the FeeManager's defaults (10% / 50%), but it's a hidden, still-in-testing deployment and the Accountable team confirmed fee collection is not actually active for it yet.
- The current adapter books fees off this vault's share-price growth (via `EXTRA_STRATEGIES`, since it's EOA-deployed and not reachable by factory enumeration), which overstates protocol revenue for a vault that isn't actually charging fees.
- This PR removes it from `EXTRA_STRATEGIES` in the fees adapter only. The TVL adapter's own EOA-deployed exception for this vault is untouched.

## Test plan
- [x] Confirmed via direct on-chain read that `feeStructure(strategy)` for this vault is unset (falls back to FeeManager defaults), and independently confirmed via the Accountable admin panel that `performanceFee=10%`/`managerSplit=50%` would apply if fee collection were active.
- [x] Confirmed zero `FeeSharesMinted` and zero `Collected` events have ever fired for this vault on-chain, consistent with fee collection not being active.
- [x] Confirmed with the Accountable team directly that this vault does not currently generate protocol revenue.
- [ ] Re-add the `EXTRA_STRATEGIES` entry (with an appropriate `deployedOn` date) once fee collection is live for this vault.