### PR TITLE
edgex: stop the v1 open-interest leg, it now mirrors v2 and double-counts $571.6M of OI

### DIFF
--- a/open-interest/edgeX.ts
+++ b/open-interest/edgeX.ts
@@ -16,6 +16,9 @@ const adapter: SimpleAdapter = {
     fetch,
     start: "2024-08-06",
     runAtCurrTime: true,
+    // The v1 host now serves v2's exchange-wide figure, so this leg duplicates open-interest/edgex-v2.
+    // Same cause and same date as the v1 fee leg, stopped in #9109.
+    deadFrom: "2026-08-15",
 }
 
 export default adapter;


### PR DESCRIPTION
`open-interest/edgeX` and `open-interest/edgex-v2` are both reporting the same exchange-wide figure, so edgeX's open interest is counted twice. Today both slugs report **571,591,689**, and the parent protocol shows **$1,156,814,039** against a real venue OI of about $571.6M.

This is the same cause, and the same date, as the v1 **fee** leg that was stopped in #9109 — that PR added `deadFrom: '2026-08-15'` to `fees/edgex`. The open-interest leg reads the same v1 host and was missed.

### The two hosts are one backend

Three paired snapshots taken about fifteen seconds apart. The values are byte-identical to 28 significant digits, and so is the moving `trades` counter:

| | `pro.edgex.exchange` v1 | `edgex-prod-v2.edgex.exchange` v2 |
|---|---|---|
| 1 | 573010297.1693516664680816878 / 977583 | 573010297.1693516664680816878 / 977583 |
| 2 | 573010297.1693516664680816878 / 977583 | 573010297.1693516664680816878 / 977583 |
| 3 | 573007516.71894653990748439720 / 977629 | 573007516.71894653990748439720 / 977629 |

A shared cache would not track a trade counter through a change like that.

### What the published series shows

`edgex-perps` (this adapter) reported its own small v1 book until 2026-08-15, went to zero for thirteen days, then jumped 230× on 08-29 and has tracked `edgex-v2` ever since:

| day | edgex-perps | edgex-v2 |
|---|---:|---:|
| 08-14 | 2,548,152 | — |
| 08-15 | 2,548,152 | — |
| 08-16 → 08-28 | 0 | 464.6M → 574.6M |
| 08-29 | 587,824,925 | 587,266,208 |
| 08-31 | 590,673,805 | 591,286,207 |
| 09-02 | 571,591,689 | 571,591,689 |

08-14 and 08-15 are identical to the dollar, so the v1 feed had already frozen before it went dark — which is why `deadFrom` is set to the same `2026-08-15` the fee fix used rather than a day later.

### Size

The parent protocol is overstated by 100%. Against the dimension total of $24,117,818,706, the duplicate is **$571,591,689, or 2.37% of all tracked open interest**.

`open-interest/edgex-v2` is untouched and remains the single source. `ts-check` passes, and the adapter now reports `EDGEX is dead (deadFrom 2026-08-15); skipping run.`
