### PR TITLE
bullbit: one delisted symbol NaNs the whole open-interest sum, dark since 2026-07-06

### DIFF
--- a/open-interest/bullbit-perp-dex-oi.ts
+++ b/open-interest/bullbit-perp-dex-oi.ts
@@ -15,13 +15,21 @@ const fetch = async (_options: FetchOptions) => {
     .process(async (symbol: string) => {
       const oi = await fetchURLAutoHandleRateLimit(`${baseUrl}/perp/v1/open-interest?symbol=${symbol}`);
       await sleep(500);
-      return oi;
+      return { symbol, oi };
     });
 
-  const openInterestAtEnd = oiResponses.reduce(
-    (acc: number, oi: any) => acc + Number(oi.notionalValue),
-    0
-  );
+  // A symbol can be listed on /ticker/24hr while /open-interest answers 200 with
+  // {"success":false,"error":{"code":"NOTFOUND"}} and no notionalValue. Skip those instead of
+  // letting one of them turn the whole sum into NaN; the guard below still fires if every
+  // symbol fails.
+  const openInterestAtEnd = oiResponses.reduce((acc: number, { symbol, oi }: any) => {
+    const notionalValue = Number(oi?.notionalValue);
+    if (!Number.isFinite(notionalValue)) {
+      console.info(`bullbit: no open interest returned for ${symbol}, skipping it`);
+      return acc;
+    }
+    return acc + notionalValue;
+  }, 0);
 
   if (!openInterestAtEnd)
     throw new Error("No open interest data found");


### PR DESCRIPTION
`open-interest/bullbit-perp-dex-oi` has published nothing since **2026-07-06**. The venue is not dormant — its open interest right now is **$19,915,342.79**, and the protocol's fees leg is live (`/summary/fees/bullbit-perp-dex` has data through 2026-09-01, $169 in the last 24h). It is not in `factory/deadAdapters.json`.

### One delisted symbol turns the whole sum into NaN

The adapter takes the symbol list from `/perp/v1/ticker/24hr`, then sums `notionalValue` from `/perp/v1/open-interest?symbol=…` for each. `IPUSD` is still in the ticker list, but its open-interest call answers **HTTP 200 with an error body and no `notionalValue`**:

```
GET /perp/v1/open-interest?symbol=BTCUSD -> {"symbol":"BTCUSD","notionalValue":7961684.66264000}
GET /perp/v1/open-interest?symbol=IPUSD  -> {"success":false,"error":{"code":"NOTFOUND","msg":"Symbol not found"}}
```

`Number(undefined)` is `NaN`, `acc + NaN` is `NaN` for the rest of the reduce, and `if (!openInterestAtEnd) throw` then fires because `NaN` is falsy. So a single delisted market takes down all 41.

I walked every symbol individually against the live API: 41 listed, 40 return a `notionalValue`, exactly one (`IPUSD`) returns the error object, and the 40 valid ones sum to **$19,915,342.79** (BTCUSD 7,961,684.66; HYPEUSD 7,235,013.64; XRPUSD 2,660,568.78; ETHUSD 753,294.28; SOLUSD 492,858.36; …).

### Reproduced and fixed locally

Before, on `master`:

```
Error: No open interest data found
    at fetch (open-interest/bullbit-perp-dex-oi.ts:27:11)
```

After this change:

```
bullbit: no open interest returned for IPUSD, skipping it
OFF_CHAIN
Open interest at end: 19.92 M
```

which matches the independent per-symbol sum above.

The published series stops dead at 2026-07-06 ($18,338,282, 43 points, `total24h`/`total7d`/`total30d` all null), so this has been silent for 58 days.

Non-numeric responses are skipped and logged rather than swallowed, and the `!openInterestAtEnd` guard is left in place — it still throws if *every* symbol fails, which is the case that should surface.

`ts-check` passes.
