### PR TITLE
[fix] qubic-mining - stop reporting fake $0 days when the burn feed goes stale

### DIFF
--- a/fees/qubic-mining/index.ts
+++ b/fees/qubic-mining/index.ts
@@ -12,6 +12,7 @@ interface QubicBurnData {
   amount: number;
   txId: string;
   moneyFlew: boolean;
+  burnFlag: boolean;
   epochNumber: number;
   timestamp: string;
   price: number;
@@ -20,7 +21,18 @@ interface QubicBurnData {
 const fetch = async (options: FetchOptions) => {
   const data: QubicBurnData[] = await fetchURL(API_ENDPOINT);
 
-  const dailyQubicBurnt = data.reduce((totalBurnt: number, item: any) => {
+  // This community-run feed has previously gone stale for months at a time while still
+  // returning HTTP 200 with old data - if its latest record predates the requested day,
+  // "zero burns matched" is indistinguishable from "the feed stopped updating", so refuse
+  // instead of silently reporting $0.
+  const latestRecordDate = data.reduce((max: string, item: QubicBurnData) => {
+    const date = item.timestamp.split('T')[0];
+    return date > max ? date : max;
+  }, '');
+  if (latestRecordDate < options.dateString)
+    throw new Error(`qubic-mining: burn feed's latest record (${latestRecordDate}) predates requested date ${options.dateString} - feed may be stale`);
+
+  const dailyQubicBurnt = data.reduce((totalBurnt: number, item: QubicBurnData) => {
     const date = item.timestamp.split('T')[0];
     if (date === options.dateString && item.burnFlag)
       totalBurnt += item.amount;
@@ -45,12 +57,22 @@ const methodology = {
   HoldersRevenue: 'All fees are used to buy back QUBIC and burn them.',
 };
 
+const breakdownMethodology = {
+  Fees: {
+    'Mining rewards': 'QUBIC value of Monero mining rewards routed through the burn mechanism.',
+  },
+  HoldersRevenue: {
+    'QUBIC burns': 'All fees are used to buy back QUBIC and burn them, benefiting all token holders.',
+  },
+};
+
 const adapter: SimpleAdapter = {
   version: 1,
   fetch: fetch,
   start: '2025-05-14',
   chains: [CHAIN.QUBIC],
   methodology,
+  breakdownMethodology,
 };
 
 export default adapter;


### PR DESCRIPTION
## What

`fees/qubic-mining/index.ts` reads a single community-run host (`fattydoge.top`, not an official Qubic API) that returns its entire burn history in one call. The adapter filters client-side for the requested day. The feed itself stopped updating on **2026-06-26**, and the last record with `burnFlag: true` is dated **2026-05-04** - confirmed live via a fresh curl (153 records total, sorted by timestamp).

Requesting any day after the feed's own latest record silently matched zero records and returned `dailyFees: 0` as if that were a genuine zero-burn day - **120 zero days** on a network that's independently alive (`rpc.qubic.org` shows a current epoch/229, CoinGecko shows real recent 24h trading volume ~$820k).

```
$ curl https://fattydoge.top/api/qubic/burn/all
-> 153 records, latest timestamp 2026-06-26T15:45:23
-> latest burnFlag=true record: 2026-05-04T21:51:51
```

## Fix

Refuse when the feed's own latest record predates the requested date, instead of treating "the feed hasn't reached this far" the same as "zero burns that day". Valid historical requests within the feed's real coverage are unaffected.

Also fixes `QubicBurnData`'s interface, which declared `moneyFlew` but not the `burnFlag` field the code actually reads (verified live that `burnFlag` genuinely exists on the real payload, both `true` and `false` values present) - the reduce callback's `item: any` was silently masking this incomplete type. Added `breakdownMethodology` per this repo's convention.

## Testing

- `npm test fees qubic-mining <recent date>` - before: silent `Daily fees: 0.00`, no error. After: throws `qubic-mining: burn feed's latest record (2026-06-26) predates requested date 2026-09-01 - feed may be stale`.
- `npm test fees qubic-mining <2026-05-04>` - unchanged `$251.78k` before and after this diff, confirming a genuinely valid historical burn day still computes correctly and doesn't trip the new check.
- `tsc --noEmit` - clean, zero errors repo-wide.
- Codex adversarial review (run synchronously): no blocking findings. Confirmed the staleness comparison logic is correct (distinguishes "feed hasn't reached this date" from "feed has this date but zero burns"), the lexical `YYYY-MM-DD` string comparison is safe (canonical fixed-width format on both sides), and the `any` -> `QubicBurnData` type fix is behavior-neutral (TS types are erased at runtime). It noted one residual, non-regression limitation: the check can't detect a feed that stopped *partway through* its final recorded day - a known limitation, not something this diff claims to solve.

Dupe-checked: no open issue or PR covers this specific staleness bug. #5468 (merged) was an earlier, different fix to this same adapter.

**Confidence note**: I could not independently prove Qubic burns *continued* after 2026-05-04 through a source other than this feed (Qubic's non-EVM architecture makes this harder to verify on-chain than most adapters here) - the fix intentionally doesn't assert burns have permanently stopped, it just refuses to guess when the feed itself goes stale. If a maintainer can confirm burns are genuinely, permanently dead, `deadFrom` may be the more accurate long-term fix; this PR is the safe default in the meantime.
