### PR TITLE
[fix] peapods-finance - remove stale fromAdddesses filter dropping real protocol revenue

### DIFF
--- a/fees/peapods-finance/index.ts
+++ b/fees/peapods-finance/index.ts
@@ -12,7 +12,8 @@ const fetch = async (options: FetchOptions) => {
   const protocolB = await addTokensReceived({
     options,
     target: "0xc64bc02594ba7f777f26b7a1eec6e6dc4a56362b", //protocol multiSig
-    fromAdddesses: ["0x88eaFE23769a4FC2bBF52E77767C3693e6acFbD5"], //revenue wallet
+    // Revenue is sent by per-pod TokenRewards contracts that change as pods are
+    // deployed, so restricting transfers to one sender omits valid revenue.
   });
 
   const totalB = holdersB.clone();


### PR DESCRIPTION
## What

The protocol-revenue leg of this adapter only counted transfers into the protocol multisig from one hardcoded "revenue wallet" address (`fromAdddesses: ["0x88eaFE23769a4FC2bBF52E77767C3693e6acFbD5"]`). That address is no longer the sender.

On-chain verification (public RPC `eth_getLogs` + Blockscout address labeling) confirmed the multisig currently receives revenue from multiple different, independently-verified **"TokenRewards"** contracts - Peapods' own per-pod rewards distributor (one per pod, e.g. the OHM pod's TokenRewards contract). None of these match the hardcoded allowlisted address, so `addTokensReceived`'s `fromAddressFilter` silently drops every one of them, and the adapter has been reporting **$0 for 90+ days** on what is still an active protocol.

Real example verified today: a DAI transfer from a verified `TokenRewards` contract (`0x7cCDa0c870927479C6c978579E177917b97fEd00`) arrived at the multisig, and was silently excluded.

## Precedent

This is the exact same fix already applied to the **holders-revenue** leg of this same file in #4083 (merged 2025-08-21). Peapods' own team explained then:

> "the from-address will not always be the same address but can be contract or third party wallets. Any PEAS token entering the wallet will be used for holders revenue and can be counted."

That reasoning applies identically to the protocol leg - it just never got the same fix.

## What I verified

- Confirmed via `eth_getCode`/`eth_getTransactionCount` the multisig is a real Gnosis Safe (1 outgoing tx ever, 0 ETH balance) - not a rich-list/spam-magnet address.
- Confirmed via Blockscout that 5 different senders into the multisig in a recent ~33-hour window are all independently-verified `TokenRewards` contracts (one sending a real "OHM Pod" pTKN token, one sending DAI).
- Confirmed the multisig (and the vlPEAS wallet) are legitimately deployed at the identical address across all 5 tracked chains (matching Safe proxy bytecode on Ethereum/Arbitrum/Base/Sonic/Berachain) - ruled out a suspected multi-chain address copy-paste bug as a false lead.
- Ran this repo's own `npm test -- fees peapods-finance <timestamp>` CLI before/after:
  - **Before**: `$0.00` across all 5 chains for a recent 1-hour window.
  - **After**: `$13.18k` on ethereum for 2026-09-01 (a day independently confirmed via `eth_getLogs` to have real `TokenRewards`-contract inflows), small non-zero on base.
- `npx tsc --noEmit` clean.
- Independent Codex adversarial review: no blocking findings. It flagged the residual risk honestly - removing the sender filter means any ERC-20 arriving at the multisig now counts, so a one-off grant/refund/treasury transfer unrelated to protocol revenue could in principle be miscounted. Unpriced spam tokens contribute $0 by DefiLlama's own address-based pricing, so dust risk is low; the real residual risk is a *priced*, non-revenue transfer, which this diff can't distinguish from genuine revenue - flagging this honestly since I can't rule it out with certainty.

## Note

This adapter is also missing a `breakdownMethodology` property per current repo conventions - pre-existing, not introduced by this diff, and out of scope here.

## Not fixed here

The **holders-revenue** leg (vlPEAS wallet) has also been flatlined since ~2025-11-18, but for a different, still-unresolved reason - it isn't a `fromAdddesses` filter issue (that was already fixed in #4083). I could not determine with confidence whether the underlying PEAS buyback mechanism was paused, or moved elsewhere. Not claiming to fix that here; happy to open a separate issue if useful.