### PR TITLE
[fix] dextools - stop double-counting burnt DEXT as protocol revenue

### DIFF
--- a/fees/dextools.ts
+++ b/fees/dextools.ts
@@ -49,8 +49,6 @@ const tokens = {
     [CHAIN.BASE]: []
 } as any;
 
-const DEXT = "0xfb7b4564402e5500db5bb6d63ae671302777c75a";
-
 const target_even: any = {
     [CHAIN.ETHEREUM]: [
         '0x4f62c60468A8F4291fec23701A73a325b2540765',
@@ -78,17 +76,29 @@ const fetchEvm = async (options: FetchOptions) => {
     if (tokens[options.chain].length > 0) {
         await addTokensReceived({ options, tokens: tokens[options.chain], targets: target_even[options.chain], balances: dailyFees })
     }
+    // DEXT is a subset of dailyFees on both Ethereum and BSC (on BSC, DEXT is the entire
+    // ERC20 fee stream, see `tokens[CHAIN.BSC]` above) and per methodology is fully burnt,
+    // i.e. it belongs to holders, not the protocol. Track it on both chains and subtract it
+    // out of dailyProtocolRevenue below rather than double-booking it as 100% protocol
+    // revenue. Use the chain-specific DEXT address (Ethereum and BSC have different DEXT
+    // contracts, see `tokens` above) via the plural `tokens` param, not singular `token` -
+    // `_addTokensReceivedIndexer` only forwards `tokens`, so `token` alone silently drops
+    // the filter on the indexer fast path and would sweep in every token received (USDC,
+    // USDT, ...), not just DEXT.
+    const dextForChain = tokens[options.chain][0]
     const dailyHoldersRevenue = options.createBalances();
-    if (options.chain === CHAIN.ETHEREUM)
-        await addTokensReceived({ options, token: DEXT, targets: target_even[options.chain], balances: dailyHoldersRevenue })
+    if (dextForChain && (options.chain === CHAIN.ETHEREUM || options.chain === CHAIN.BSC))
+        await addTokensReceived({ options, tokens: [dextForChain], targets: target_even[options.chain], balances: dailyHoldersRevenue })
     await getETHReceived({ options, balances: dailyFees, targets: target_even[options.chain] })
-    return { dailyFees, dailyRevenue: dailyFees, dailyProtocolRevenue: dailyFees, dailyHoldersRevenue }
+    const dailyProtocolRevenue = dailyFees.clone();
+    dailyProtocolRevenue.subtract(dailyHoldersRevenue);
+    return { dailyFees, dailyRevenue: dailyFees, dailyProtocolRevenue, dailyHoldersRevenue }
 }
 
 const methodology = {
     Fees: 'All fees paid by users for token profile listing.',
     Revenue: 'All fees collected by DexTools.',
-    ProtocolRevenue: 'All fees collected by DexTools.',
+    ProtocolRevenue: 'All fees collected by DexTools, excluding the DEXT social-update fees that are burnt (see HoldersRevenue).',
     HoldersRevenue: 'All the social update fees paid in DEXT are burnt',
 }
 


### PR DESCRIPTION
## What

DEXT is a subset of `dailyFees` on Ethereum (the first entry in the Ethereum fee-token list) and the *entire* ERC20 fee stream on BSC (`tokens[CHAIN.BSC]` is `[DEXT]` only). Per the adapter's own methodology (`HoldersRevenue: "All the social update fees paid in DEXT are burnt"`), this DEXT belongs to holders, not the protocol.

The old code counted DEXT into `dailyHoldersRevenue` on Ethereum **and** set `dailyProtocolRevenue = dailyFees` (100% of fees) — the same object, so DEXT was double-booked as both holders revenue and protocol revenue. On BSC the holders-revenue branch was guarded `if (chain === ETHEREUM)` only, so BSC never got any holders revenue at all, and its entire (fully-burnt) fee stream was wrongly booked as 100% protocol revenue.

30d materiality at time of writing: fees ~$77,029, protocolRevenue was ~$77,029 (100%, wrong) with holdersRevenue only ~$10,601 from Ethereum (BSC's burn wasn't counted at all) — protocol revenue overstated ~13.8% on Ethereum, and BSC's overstatement was complete (100% of a fully-burnt stream booked as protocol).

`AGENTS.md:228` names this exact bug class: *"Missing dailyProtocolRevenue/dailyHoldersRevenue split when the protocol keeps some and distributes some."*

## Fix

- Extended holders-revenue tracking to BSC.
- Derived `dailyProtocolRevenue` as `dailyFees.clone(); .subtract(dailyHoldersRevenue)` instead of aliasing `dailyFees` directly (same pattern as `dexs/ekubo-evm.ts`/`dexs/kinetiq-markets.ts`).
- Used the chain-correct DEXT contract address (Ethereum and BSC have **different** DEXT contracts) via `tokens[options.chain][0]`, passed through the plural `tokens` param — not singular `token`, since `_addTokensReceivedIndexer` only forwards `tokens` and silently drops the filter on the indexer fast path otherwise (would have swept in USDC/USDT too). Caught by an adversarial review pass on the first draft, which had this exact bug.
- Updated the `ProtocolRevenue` methodology text to reflect the DEXT exclusion.

## Testing

Couldn't run the live end-to-end adapter test — it depends on `Dependencies.ALLIUM` and we don't have an Allium API key (same class of limitation as `GRAPH_API_KEY`-gated adapters elsewhere). Instead verified the actual arithmetic in isolation using the real `@defillama/sdk` `Balances` class (not a mock), simulating realistic token receipts:

- **Ethereum**: `dailyFees = {DEXT: 1000, USDC: 5000}`, `dailyHoldersRevenue = {DEXT: 1000}` → pre-fix `dailyProtocolRevenue = {DEXT: 1000, USDC: 5000}` (wrong), post-fix `{DEXT: 0, USDC: 5000}` (correct).
- **BSC**: `dailyFees = {DEXT: 2000}`, pre-fix `dailyHoldersRevenue = {}` / `dailyProtocolRevenue = {DEXT: 2000}` (wrong), post-fix `dailyHoldersRevenue = {DEXT: 2000}` / `dailyProtocolRevenue = {DEXT: 0}` (correct).
- Regression check confirming the first draft's hardcoded-Ethereum-address bug would have found zero BSC DEXT (silently reproducing the original bug even after "fixing" the guard) — this is exactly what the adversarial review caught and what's fixed in the final diff.

`tsc --project tsconfig.json --noEmit` clean repo-wide.

## Known gap, not addressed here

This adapter has no `breakdownMethodology` (repo convention for labeled fee breakdowns). Adding it would require restructuring every `.add()` call in the file to carry metric labels — out of scope for this fix and a real risk of scope creep on a double-counting bug fix. Flagging honestly rather than attempting it here.