### PR TITLE
uniswap v2/v3/v4: measure fee-switch protocol revenue at the pool instead of firepit burns

### DIFF
--- a/dexs/uniswap-v2.ts
+++ b/dexs/uniswap-v2.ts
@@ -103,20 +103,15 @@ const chainConfig: Record<string, {
 function getLogAdapterConfig(options: FetchOptions) {
   // UNIfication has officially been executed onchain
   // https://x.com/Uniswap/status/2005018127260942798
+  // after the switch the 0.30% swap fee splits 0.25% to LPs and 0.05% to the
+  // protocol (1/6 of fees), all of which buys back and burns UNI
+  const revenueRatio = isFeeSwitchOn(options) ? 1 / 6 : 0
+  return { userFeesRatio: 1, revenueRatio, protocolRevenueRatio: 0, holdersRevenueRatio: revenueRatio }
+}
+
+function isFeeSwitchOn(options: FetchOptions): boolean {
   const feeSwitchDate = chainConfig[options.chain]?.feeSwitchDate;
-  if (feeSwitchDate && options.dateString >= feeSwitchDate) {
-    return {
-      userFeesRatio: 1,
-      revenueRatio: 0, // Tracked combined in Uniswap V3 adapter
-      protocolRevenueRatio: 0,
-    }
-  } else {
-    return {
-      userFeesRatio: 1,
-      revenueRatio: 0,
-      protocolRevenueRatio: 0,
-    }
-  }
+  return !!feeSwitchDate && options.dateString >= feeSwitchDate;
 }
 
 // --- ClickHouse (evm_indexer) helpers ---
@@ -195,18 +190,25 @@ type SwapAggRow = Row & { pair: string; amount0_out: string; amount1_out: string
 
 async function fetchClickhouse(options: FetchOptions, config: typeof chainConfig[string]): Promise<FetchResultV2> {
   const dailyVolume = options.createBalances();
-  const feeRates = getLogAdapterConfig(options);
 
-  const emptyResult = (): FetchResultV2 => {
+  // 0.30% swap fee; after the fee switch 0.05% of volume goes to the protocol
+  // (UNI buyback and burn) and 0.25% stays with LPs
+  const protocolRate = isFeeSwitchOn(options) ? 0.0005 : 0;
+  const buildResult = (): FetchResultV2 => {
     const dailyFees = dailyVolume.clone(0.003);
+    const dailyRevenue = dailyVolume.clone(protocolRate);
     return {
       dailyVolume,
       dailyFees,
       dailyUserFees: dailyFees,
-      dailySupplySideRevenue: dailyFees, // Revenue share subtracted in Uniswap V3 adapter
-      dailyRevenue: 0, // Tracked combined in Uniswap V3 adapter
+      dailySupplySideRevenue: dailyVolume.clone(0.003 - protocolRate),
+      dailyRevenue,
       dailyProtocolRevenue: 0,
+      dailyHoldersRevenue: dailyRevenue,
     };
+  };
+  const emptyResult = (): FetchResultV2 => {
+    return buildResult();
   };
 
   const whitelistedTokens = (await getDefaultDexTokensWhitelisted({ chain: options.chain })).map(t => t.toLowerCase());
@@ -248,15 +250,7 @@ async function fetchClickhouse(options: FetchOptions, config: typeof chainConfig
     dailyVolume.add(tokens.token1, row.amount1_out);
   }
 
-  const dailyFees = dailyVolume.clone(0.003);
-  return {
-    dailyVolume,
-    dailyFees,
-    dailyUserFees: dailyFees,
-    dailySupplySideRevenue: dailyFees, // Revenue share subtracted in Uniswap V3 adapter
-    dailyRevenue: 0, // Tracked combined in Uniswap V3 adapter
-    dailyProtocolRevenue: 0,
-  };
+  return buildResult();
 }
 
 const fetch = async (options: FetchOptions) => {
@@ -276,12 +270,12 @@ const fetch = async (options: FetchOptions) => {
 }
 
 const methodology = {
-  Fees: "User pays 0.3% fees on each swap.",
-  UserFees: "User pays 0.3% fees on each swap.",
-  Revenue: 'From 28 Dec 2025, 17% (0% before) fees on Ethereum, From 8 Mar 2026, 17% (0% before) fees on Optimism, Arbitrum, Base, Zora, XLayer chains shared to buy back and burn UNI. (Tracked combined in Uniswap V3 adapter)',
-  ProtocolRevenue: 'Protocol make no revenue.',
-  SupplySideRevenue: '83% (100% before fee switch) of fees are distributed to liquidity providers.',
-  HoldersRevenue: 'From 28 Dec 2025, 17% (0% before) fees on Ethereum shared to buy back and burn UNI, From 8 Mar 2026, 17% (0% before) fees on Optimism, Arbitrum, Base, Zora, XLayer chains shared to buy back and burn UNI (Tracked combined in Uniswap V3 adapter)',
+  Fees: "Traders pay a 0.30% fee on each swap.",
+  UserFees: "Traders pay a 0.30% fee on each swap.",
+  Revenue: '0.05% of swap volume (1/6 of fees) where the fee switch is on (Ethereum since 28 Dec 2025, Optimism, Arbitrum, Base, Zora, X Layer since 8 Mar 2026, Polygon and BSC since 2 Jun 2026), all of it used to buy back and burn UNI.',
+  ProtocolRevenue: 'Protocol treasury keeps nothing, protocol fees go to the UNI buyback and burn.',
+  SupplySideRevenue: '0.25% of swap volume to LPs after the fee switch (the full 0.30% before).',
+  HoldersRevenue: '0.05% of swap volume used to buy back and burn UNI where the fee switch is on.',
 }
 
 const adapter: Adapter = {

--- a/dexs/uniswap-v3.ts
+++ b/dexs/uniswap-v3.ts
@@ -18,42 +18,12 @@ import {
 // fetchers just read config.blockchain. Buyback/holders-revenue is shared with
 // the on-chain adapter.
 
-const HOLDERS_REVENUE_CONFIG: Record<string, { feeSwitchDate: string | null; firepit: string | null }> = {
-  [CHAIN.ETHEREUM]: { feeSwitchDate: "2025-12-29", firepit: '0x0D5Cd355e2aBEB8fb1552F56c965B867346d6721' },
-  [CHAIN.OPTIMISM]: { feeSwitchDate: "2026-03-08", firepit: '0x94460443Ca27FFC1baeCa61165fde18346C91AbD' },
-  [CHAIN.ARBITRUM]: { feeSwitchDate: "2026-03-08", firepit: '0xB8018422bcE25D82E70cB98FdA96a4f502D89427' },
-  [CHAIN.BASE]: { feeSwitchDate: "2026-03-08", firepit: '0xFf77c0ED0B6b13A20446969107E5867abc46f53a' },
-  [CHAIN.CELO]: { feeSwitchDate: "2026-06-02", firepit: '0x2758FbaA228D7d3c41dD139F47dab1a27bF9bc25' },
-  [CHAIN.WC]: { feeSwitchDate: "2026-03-08", firepit: '0x455e844D286631566cF98D6cb2996149734618C6' },
-  [CHAIN.ZORA]: { feeSwitchDate: "2026-03-08", firepit: '0x2f98eD4D04e633169FbC941BFCc54E785853b143' },
-  [CHAIN.XLAYER]: { feeSwitchDate: "2026-03-08", firepit: '0xe122E231cb52aea99690963Fd73E91e33E97468f' },
-  [CHAIN.BSC]: { feeSwitchDate: "2026-06-02", firepit: '0xa59FfbB55D91Fc32b44A06F0b9cc6036a4afbcE2' },
-  [CHAIN.POLYGON]: { feeSwitchDate: "2026-06-02", firepit: '0xa59FfbB55D91Fc32b44A06F0b9cc6036a4afbcE2' },
-  [CHAIN.ROBINHOOD]: { feeSwitchDate: "2026-07-27", firepit: '0x7A8F74C2585F84C781F951B7F2FF21337D5B630B' },
-  [CHAIN.UNICHAIN]: { feeSwitchDate: "2026-01-09", firepit: '0xe0A780E9105aC10Ee304448224Eb4A2b11A77eeB' },
-}
-
-const THRESHOLD_FUNCTION_ABI = 'uint256:threshold'
-const RELEASED_EVENT_ABI = 'event Released (uint256 indexed nonce, address indexed recipient, address[] assets)'
-
-async function fetchHoldersRevenue(options: FetchOptions) {
-  const dailyHoldersRevenue = options.createBalances()
-  const { feeSwitchDate, firepit } = HOLDERS_REVENUE_CONFIG[options.chain] ?? {}
-  if (!firepit || !feeSwitchDate || options.dateString < feeSwitchDate) {
-    return dailyHoldersRevenue
-  }
-
-  const [releaseLogs, threshold] = await Promise.all([
-    options.getLogs({ target: firepit, eventAbi: RELEASED_EVENT_ABI }),
-    options.api.call({ target: firepit, abi: THRESHOLD_FUNCTION_ABI }),
-  ])
-
-  if (!releaseLogs.length || !threshold) return dailyHoldersRevenue
-
-  const amount = Number(releaseLogs.length) * Number(threshold) / 1e18
-  dailyHoldersRevenue.addCGToken("uniswap", amount)
-  return dailyHoldersRevenue
-}
+// Protocol fee (UNIfication fee switch) is read per pool from slot0.feeProtocol:
+// low 4 bits = denominator for token0-input swaps, high 4 bits for token1-input
+// swaps (0 = off; 4 = 1/4 of the LP fee on 0.01%/0.05% tiers, 6 = 1/6 on
+// 0.30%/1% tiers). Read at the window end block so refills reproduce the day.
+const SLOT0_ABI = 'function slot0() view returns (uint160 sqrtPriceX96, int24 tick, uint16 observationIndex, uint16 observationCardinality, uint16 observationCardinalityNext, uint8 feeProtocol, bool unlocked)'
+const protocolShare = (denominator: number) => denominator ? 1 / denominator : 0
 
 // raw per-pool, per-token traded amount from dex.trades, for one or more Dune
 // blockchains. UNNEST explodes each swap's bought + sold legs into one row each,
@@ -184,6 +154,8 @@ async function fetchFromDune(options: FetchOptions) {
   // permitFailure doesn't cover a fully-dead-RPC chunk (sdk multiCall throws on it),
   // so guard: without fee tiers we keep volume and report 0 fees for this chain.
   let poolFees: any[] = await options.api.multiCall({ abi: 'uint256:fee', calls: pools, permitFailure: true });
+  const slot0s: any[] = await options.api.multiCall({ abi: SLOT0_ABI, calls: pools, permitFailure: true });
+  const dailyRevenue = options.createBalances();
 
   pools.forEach((pool, i) => {
     const { tokens, amounts } = byPool[pool];
@@ -194,12 +166,16 @@ async function fetchFromDune(options: FetchOptions) {
     // one priceable side = swap volume (mirrors the on-chain adapter)
     addOneToken({ chain: options.chain, balances: dailyVolume, token0, token1, amount0, amount1 });
     const fee = poolFees[i] ? Number(poolFees[i]) / 1e6 : 0;
-    if (fee) addOneToken({ chain: options.chain, balances: dailyFees, token0, token1, amount0: Number(amount0) * fee, amount1: Number(amount1) * fee });
+    if (!fee) return;
+    addOneToken({ chain: options.chain, balances: dailyFees, token0, token1, amount0: Number(amount0) * fee, amount1: Number(amount1) * fee });
+    // token0 amounts carry the token0-input protocol denominator and vice versa
+    const feeProtocol = Number(slot0s[i]?.feeProtocol ?? 0);
+    const share0 = protocolShare(feeProtocol & 0xf);
+    const share1 = protocolShare(feeProtocol >> 4);
+    if (share0 || share1) addOneToken({ chain: options.chain, balances: dailyRevenue, token0, token1, amount0: Number(amount0) * fee * share0, amount1: Number(amount1) * fee * share1 });
   });
 
-  const dailyHoldersRevenue = await fetchHoldersRevenue(options);
-  const dailyRevenue = await dailyHoldersRevenue.getUSDValue();
-  const dailySupplySideRevenue = (await dailyFees.getUSDValue()) - dailyRevenue;
+  const dailySupplySideRevenue = (await dailyFees.getUSDValue()) - (await dailyRevenue.getUSDValue());
 
   return {
     dailyVolume,
@@ -207,7 +183,7 @@ async function fetchFromDune(options: FetchOptions) {
     dailyUserFees: dailyFees,
     dailyRevenue,
     dailyProtocolRevenue: 0,
-    dailyHoldersRevenue,
+    dailyHoldersRevenue: dailyRevenue, // all protocol fees fund the UNI buyback and burn (UNIfication)
     dailySupplySideRevenue,
   }
 }
@@ -229,17 +205,16 @@ async function fetchFromOku(options: FetchOptions) {
 
   const dailyVolume = response.reduce((acc, item) => acc + item.volume, 0);
   const dailyFees = response.reduce((acc, item) => acc + item.fees, 0);
-  const dailyHoldersRevenue = await fetchHoldersRevenue(options);
-  const dailyRevenue = await dailyHoldersRevenue.getUSDValue();
 
+  // no fee switch on the Oku-served chains, all fees stay with LPs
   return {
     dailyVolume,
     dailyFees,
     dailyUserFees: dailyFees,
-    dailySupplySideRevenue: dailyFees - dailyRevenue,
-    dailyRevenue,
+    dailySupplySideRevenue: dailyFees,
+    dailyRevenue: 0,
     dailyProtocolRevenue: 0,
-    dailyHoldersRevenue,
+    dailyHoldersRevenue: 0,
   }
 }
 
@@ -260,19 +235,15 @@ async function fetchFromLogs(options: FetchOptions) {
     protocolRevenueRatio: 0,
   })(options);
 
-  const dailyHoldersRevenue = await fetchHoldersRevenue(options);
-  const feesToLps = (await dailyFees.getUSDValue()) - (await dailyHoldersRevenue.getUSDValue());
-  const dailySupplySideRevenue = options.createBalances();
-  dailySupplySideRevenue.addUSDValue(feesToLps, "LP fees");
-
+  // no fee switch on 0G, all fees stay with LPs
   return {
     dailyVolume,
     dailyFees,
     dailyUserFees,
-    dailyRevenue: dailyHoldersRevenue,
+    dailyRevenue: 0,
     dailyProtocolRevenue: 0,
-    dailyHoldersRevenue,
-    dailySupplySideRevenue,
+    dailyHoldersRevenue: 0,
+    dailySupplySideRevenue: dailyFees,
   };
 }
 
@@ -326,12 +297,12 @@ const chainConfig: Record<string, { blockchain: string; start: string; fetch: Fe
 
 const methodology = {
   Volume: "Swap volume, excluding wash trading: pools whose daily trades come from too few distinct addresses to be organic, unless every pool token is a core asset or CoinGecko-listed.",
-  Fees: "Swap fees from paid by users.",
-  UserFees: "User pays fees on each swap.",
-  Revenue: 'From 28 Dec 2025, a portion of fees a collected to buy back and burn UNI on Ethereum, From 8 Mar 2026, on Optimism, Arbitrum, Base, WC, Zora, XLayer, From 2 Jun 2026, on Polygon, BSC, Celo, From 27 Jul 2026, on Robinhood',
-  ProtocolRevenue: 'Protocol make no revenue.',
-  SupplySideRevenue: 'Fees distributed to LPs post protocol fee collection',
-  HoldersRevenue: 'From 28 Dec 2025, a portion of fees a collected to buy back and burn UNI on Ethereum, From 8 Mar 2026, on Optimism, Arbitrum, Base, WC, Zora, XLayer, From 2 Jun 2026, on Polygon, BSC, Celo, From 27 Jul 2026, on Robinhood',
+  Fees: "Swap fees paid by traders, per pool fee tier.",
+  UserFees: "Swap fees paid by traders.",
+  Revenue: 'Per-pool protocol share of swap fees read from the pool (1/4 of fees on 0.01% and 0.05% tiers, 1/6 on 0.30% and 1% tiers where the fee switch is on: Ethereum since 28 Dec 2025, Optimism, Arbitrum, Base, World Chain, Zora, X Layer since 8 Mar 2026, Polygon, BSC, Celo since 2 Jun 2026, Robinhood since 27 Jul 2026), all of it used to buy back and burn UNI.',
+  ProtocolRevenue: 'Protocol treasury keeps nothing, protocol fees go to the UNI buyback and burn.',
+  SupplySideRevenue: 'Swap fees left to LPs after the protocol share.',
+  HoldersRevenue: 'Protocol share of swap fees used to buy back and burn UNI.',
 }
 
 const adapter: SimpleAdapter = {
@@ -340,8 +311,6 @@ const adapter: SimpleAdapter = {
   methodology,
   adapter: chainConfig,
   prefetch,
-  // supply side can be negative on days revenue (v2+v3 buyback) exceeds v3 fees
-  allowNegativeValue: true,
 }
 
 export default adapter;

--- a/dexs/uniswap-v4.ts
+++ b/dexs/uniswap-v4.ts
@@ -64,6 +64,7 @@ import {
   WASH_TRADES_PER_EOA, WASH_USD_MIN_TRADES_PER_EOA, WASH_USD_PER_EOA,
 } from "../helpers/uniswap";
 import { formatAddress } from "../utils/utils";
+import { ethers } from "ethers";
 
 interface IUniswapConfig {
   poolManager: string;
@@ -254,6 +255,33 @@ function getPoolKey(poolId: string): string {
   return poolId.slice(0, 52);
 }
 
+// Protocol fee (UNIfication fee switch, live on v4 from 2026-07-27) is stored per
+// pool in PoolManager slot0 as a uint24: low 12 bits = zeroForOne fee, high 12
+// bits = oneForZero fee, both in pips (1e6 = 100%, max 1000 = 0.1%). It is taken
+// from the swap input before the LP fee, and the Swap event's `fee` already is
+// the combined rate (protocol + LP - protocol*LP). Read at the window end block
+// via extsload so refills reproduce the rate that applied on that day.
+// Layout: v4-core Slot0.sol (PROTOCOL_FEE_OFFSET = 184), StateLibrary.sol (POOLS_SLOT = 6).
+const EXTSLOAD_ABI = 'function extsload(bytes32 slot) view returns (bytes32)'
+const POOLS_SLOT = ethers.zeroPadValue('0x06', 32)
+function slot0Slot(poolId: string): string {
+  return ethers.keccak256(ethers.concat([poolId, POOLS_SLOT]))
+}
+async function getProtocolFees(options: FetchOptions, poolManager: string, poolIds: string[]): Promise<Record<string, { zeroForOne: number; oneForZero: number }>> {
+  const slots: any[] = await options.api.multiCall({
+    abi: EXTSLOAD_ABI,
+    calls: poolIds.map(poolId => ({ target: poolManager, params: [slot0Slot(poolId)] })),
+    permitFailure: true,
+  })
+  const fees: Record<string, { zeroForOne: number; oneForZero: number }> = {}
+  poolIds.forEach((poolId, i) => {
+    if (!slots[i]) return
+    const protocolFee = Number((BigInt(slots[i]) >> 184n) & 0xffffffn)
+    fees[poolId] = { zeroForOne: protocolFee & 0xfff, oneForZero: protocolFee >> 12 }
+  })
+  return fees
+}
+
 // Wash-trading filter. The scam here is a fake-ticker token (several unrelated
 // contracts all called "OpenAI"/"Claude") paired against real USDC, churned by a
 // handful of bots for a day or two, then rugged. The core-asset pricing from
@@ -343,6 +371,8 @@ const prefetch: any = async (options: FetchOptions) => {
 async function fetch(options: FetchOptions) {
   const dailyFees = options.createBalances()
   const dailyVolume = options.createBalances()
+  const dailyRevenue = options.createBalances()
+  const dailySupplySideRevenue = options.createBalances()
 
   const config = Configs[options.chain];
   if (!config) {
@@ -403,6 +433,7 @@ async function fetch(options: FetchOptions) {
       }
 
       const blacklistTokens = new Set(getDefaultDexTokensBlacklisted(options.chain))
+      const protocolFees = await getProtocolFees(options, config.poolManager, Object.keys(pools).filter(id => pools[id]))
       const washPools = options.preFetchedResults?.washPools?.[DUNE_CHAIN[options.chain]]
       // flagged pools whose sides are all established (core or CG-listed) are
       // spared - one batched price lookup, see getEstablishedTokens
@@ -432,7 +463,17 @@ async function fetch(options: FetchOptions) {
           const useToken0 = currency0 === ADDRESSES.null || isCoreAsset(options.chain, currency0) || !isCoreAsset(options.chain, currency1)
           const token = useToken0 ? currency0 : currency1
           const amount = Math.abs(Number(useToken0 ? event.amount0 : event.amount1))
-          dailyFees.add(token, amount * (Number(event.fee) / 1e6))
+          // swap deltas are from the swapper's view: negative = paid in, so
+          // amount0 < 0 is a zeroForOne swap and picks that direction's protocol fee.
+          // Both rates are applied to the priced side (same approximation as the
+          // fee line above), protocol fee is a share of the same gross amount.
+          const zeroForOne = Number(event.amount0) < 0
+          const pf = protocolFees[poolId]
+          const protocolPips = pf ? (zeroForOne ? pf.zeroForOne : pf.oneForZero) : 0
+          const swapPips = Number(event.fee)
+          dailyFees.add(token, amount * (swapPips / 1e6))
+          dailyRevenue.add(token, amount * (protocolPips / 1e6))
+          dailySupplySideRevenue.add(token, amount * ((swapPips - protocolPips) / 1e6))
           dailyVolume.add(token, amount)
         }
       }
@@ -443,10 +484,10 @@ async function fetch(options: FetchOptions) {
     dailyVolume,
     dailyFees,
     dailyUserFees: dailyFees,
-    dailySupplySideRevenue: dailyFees,
-    dailyRevenue: 0, // tracked in uniswap-v3 adapter
+    dailySupplySideRevenue,
+    dailyRevenue,
     dailyProtocolRevenue: 0,
-    dailyHoldersRevenue: 0, // tracked in uniswap-v3 adapter
+    dailyHoldersRevenue: dailyRevenue, // all protocol fees fund the UNI buyback and burn (UNIfication)
   }
 }
 
@@ -457,12 +498,12 @@ const adapter: SimpleAdapter = {
   prefetch,
   methodology: {
     Volume: 'Swap volume, excluding wash trading: pools whose daily trades come from too few distinct addresses to be organic, unless every pool token is a core asset or CoinGecko-listed.',
-    Fees: 'Swap fees paid by users.',
-    UserFees: 'Swap fees paid by users.',
-    Revenue: 'Fee switch enabled on 27 Jul 2026 (tracked in uniswap-v3 adapter), a part of fees collected to buy back and burn UNI.',
-    ProtocolRevenue: 'Protocol makes no revenue.',
-    SupplySideRevenue: 'Part of fees distributed to LPs after protocol cut. (It was 100% of fees before fee switch(27 Jul 2026)).',
-    HoldersRevenue: 'Fee switch enabled on 27 Jul 2026 (tracked in uniswap-v3 adapter), a part of fees collected to buy back and burn UNI.',
+    Fees: 'Swap fees paid by traders: the pool LP fee plus, since the v4 fee switch (27 Jul 2026), the per-pool protocol fee taken from the swap input.',
+    UserFees: 'Swap fees paid by traders.',
+    Revenue: 'Per-pool protocol fee read from the PoolManager (0 before the 27 Jul 2026 fee switch), all of it used to buy back and burn UNI.',
+    ProtocolRevenue: 'Protocol treasury keeps nothing, protocol fees go to the UNI buyback and burn.',
+    SupplySideRevenue: 'LP fee share of swap fees (100% of fees before the 27 Jul 2026 fee switch).',
+    HoldersRevenue: 'Protocol fees used to buy back and burn UNI (since 27 Jul 2026).',
   },
   fetch,
 };


### PR DESCRIPTION
Uniswap v4 showed no revenue although the v4 fee switch has been live since 2026-07-27: the adapter hardcoded revenue and holders revenue to 0 and deferred to the v3 adapter, which counted UNI burned by the firepit `Released` events. The firepit pools protocol fees from v2, v3 and v4, so no version could report its own revenue and the split by version and chain was wrong.

Each adapter now measures the protocol fee at the pool, on the day it accrues:

- `dexs/uniswap-v4.ts`: reads each pool's `protocolFee` from PoolManager slot0 via `extsload` at the window end (low 12 bits zeroForOne, high 12 bits oneForZero, pips). Revenue = swap amount x that rate; the Swap event `fee` is already protocol + LP so fees are unchanged, supply side = fees - protocol fee.
- `dexs/uniswap-v3.ts`: reads `slot0.feeProtocol` per pool (denominator 4 on 0.01%/0.05% tiers, 6 on 0.30%/1% tiers, 0 = off) and takes fee / denominator as revenue, token0 and token1 amounts using their own denominators. Firepit config, `fetchHoldersRevenue` and `allowNegativeValue` removed. Oku and 0G chains have no fee switch and report 0 revenue.
- `dexs/uniswap-v2.ts`: after each chain's fee-switch date 1/6 of fees (0.05% of volume) is revenue, both on the ClickHouse and the logs path.

All protocol fees fund the UNI buyback and burn, so `dailyHoldersRevenue = dailyRevenue` and `dailyProtocolRevenue = 0` on all three. Fee rates are read from chain state at the window end, so refills reproduce the rate of that day without date tables.

Tested for 2026-08-31 (`DISABLE_PULL_HOURLY=true`):
- v4 arbitrum: volume 24.16M and fees 26.1k match the published 24.25M / 26.2k, revenue 2.85k (was 0)
- v3 ethereum: fees 255.7k, revenue 48.3k (19%, between the 1/6 and 1/4 tiers)
- v2 ethereum: fees 51.5k, revenue 8.6k (1/6)

Needs a refill of v2, v3 and v4 revenue/holders revenue from 2025-12-29 (first fee-switch date).