### PR TITLE
valiant-trade: refuse zero-swap days, the swapStat api serves zeros for days it has not ingested yet

### DIFF
--- a/dexs/valiant-trade/index.ts
+++ b/dexs/valiant-trade/index.ts
@@ -14,6 +14,9 @@ async function fetch(options: FetchOptions) {
   const url = `${baseUrl}?start=${options.fromTimestamp}&end=${options.toTimestamp}`;
   const data = await httpGet(url);
 
+  if (!data.totalSwaps)
+    throw new Error(`swapStat has no swaps for ${options.dateString} yet; every zero day this api has served was later backfilled with real volume`);
+
   return {
     dailyVolume: data.totalSwapVolume,
     dailyFees: data.totalFees,


### PR DESCRIPTION
Fixes #9165. the swapStat api answers 200 with all-zero fields for windows its ingestion has not reached, and the adapter forwarded them as real $0 days; five settled days published as $0 that the api later backfilled (~$1.74m, including $1.71m on 2026-03-29 alone; table on the issue). the dex has never had a genuine zero-swap day in its 255-day history, so `totalSwaps == 0` from this api only ever means not-ingested-yet; throwing keeps the day refillable instead of freezing a fake zero.

harness both directions:
- `npm test dexs valiant-trade 2026-09-01` (settled day) → volume $2.13k, fees $7.57, matching the api to the cent
- `npm test dexs valiant-trade 2026-08-30` (settled day) → volume $22.03k, the corrected value for 08-29 (prod holds the $20,551 partial read)
- `npm test dexs valiant-trade 2026-09-03` (day the api has not ingested) → throws `swapStat has no swaps for 2026-09-02 yet`

if the daily run fires before the api settles the previous day, the test check will show that same throw; that is the guard working, not a broken patch; the day fills on the next refill instead of publishing $0.
