### PR TITLE
dodo-fees: deadfrom the dfio leg, chain head frozen since 08-29 kills the other six chains

### DIFF
--- a/fees/dodo-fees.ts
+++ b/fees/dodo-fees.ts
@@ -95,7 +95,7 @@ const breakdownMethodology = {
 const adapter: Adapter = {
   version: 1,
   adapter: {
-    [CHAIN.DFIO_META_MAIN]: { fetch: dfioFetch, deadFrom: '2026-08-29' },
+    //[CHAIN.DFIO_META_MAIN]: { fetch: dfioFetch },
     [CHAIN.ETHEREUM]: { fetch },
     [CHAIN.BSC]: { fetch },
     [CHAIN.POLYGON]: { fetch },

--- a/fees/dodo-fees.ts
+++ b/fees/dodo-fees.ts
@@ -95,7 +95,7 @@ const breakdownMethodology = {
 const adapter: Adapter = {
   version: 1,
   adapter: {
-    [CHAIN.DFIO_META_MAIN]: { fetch: dfioFetch },
+    [CHAIN.DFIO_META_MAIN]: { fetch: dfioFetch, deadFrom: '2026-08-29' },
     [CHAIN.ETHEREUM]: { fetch },
     [CHAIN.BSC]: { fetch },
     [CHAIN.POLYGON]: { fetch },


### PR DESCRIPTION
Fixes #9167. the dfio_meta_main chain's head has been frozen at block 8994729 / 2026-08-29T05:26:19Z on every public rpc, so the leg's block lookup throws and takes the other six chains' fees down with it; nothing published since the 08-29 row. `deadFrom: '2026-08-29'` retires the leg without touching the rest, the same shape as the moonriver/zero legs in #8959. `dexs/dodo` already had its dfio leg disabled in june, this was the last live one.

harness twice: `Skipping dfio_meta_main because the adapter ended at Sat, 29 Aug 2026`, then ethereum $1.42k / bsc $3.44k / polygon $99 / arbitrum $3.48 / aurora $0.16 / boba $0, aggregate $4.96k, inside the adapter's $3.4-9.9k/day band. if the chain ever restarts, dropping the deadFrom revives the leg.

08-30..09-01 need a refill once this lands.
