### PR TITLE
contango: price open interest with the last available price, it has published $0 since 2025-12-27

### DIFF
--- a/dexs/contango/index.ts
+++ b/dexs/contango/index.ts
@@ -2,53 +2,61 @@ import { Dependencies, FetchOptions, SimpleAdapter } from "../../adapters/types"
 import { CHAIN } from "../../helpers/chains";
 import { queryDuneSql } from "../../helpers/dune";
 
-const chainMap: Record<string, string> = {
-  [CHAIN.ETHEREUM]: "mainnet",
-  [CHAIN.XDAI]: "gnosis",
-  [CHAIN.AVAX]: "avalanche",
-  [CHAIN.BSC]: "bsc",
+const chainConfig: Record<string, { duneName: string; start: string }> = {
+  [CHAIN.ARBITRUM]: { duneName: "arbitrum", start: "2023-10-03" },
+  [CHAIN.OPTIMISM]: { duneName: "optimism", start: "2023-10-02" },
+  [CHAIN.ETHEREUM]: { duneName: "mainnet", start: "2023-10-03" },
+  [CHAIN.POLYGON]: { duneName: "polygon", start: "2023-10-13" },
+  [CHAIN.BASE]: { duneName: "base", start: "2023-10-09" },
+  [CHAIN.XDAI]: { duneName: "gnosis", start: "2023-10-06" },
+  [CHAIN.AVAX]: { duneName: "avalanche", start: "2024-08-11" },
+  [CHAIN.LINEA]: { duneName: "linea", start: "2024-08-11" },
+  [CHAIN.BSC]: { duneName: "bsc", start: "2024-06-07" },
+  [CHAIN.SCROLL]: { duneName: "scroll", start: "2024-08-11" },
 };
 
-const fetch = async (options: FetchOptions) => {
-  const { chain, fromTimestamp, toTimestamp } = options;
-  const mappedChain = chainMap[chain] ?? chain
-  const query = `
-    WITH volume AS (
-      SELECT SUM(ABS(QUANTITY_USD)) AS VOL_USD 
-      FROM DUNE.CONTANGO_XYZ.RESULT_V2_ALL_TRADES
-      WHERE TIMESTAMP >= from_unixtime(${fromTimestamp}) AND TIMESTAMP <= from_unixtime(${toTimestamp}) AND chain = '${mappedChain}'
-    ), 
-    oi as (
-      with LONG_OI_DELTA as (
-        SELECT DATE_TRUNC('day', T.TIMESTAMP) AS TIMESTAMP, T.BASE AS ASSET, SUM(T.QUANTITY) AS DELTA
-        FROM DUNE.CONTANGO_XYZ.V2_TRANSACTIONS AS T
-        WHERE T.chain = '${mappedChain}' AND T.DIRECTION = 'Long'
-        GROUP BY 1, 2
-      ),
-      SHORT_OI_DELTA as (
-        SELECT DATE_TRUNC('day', T.TIMESTAMP) AS TIMESTAMP, T.BASE AS ASSET, SUM(T.QUANTITY) * -1 AS DELTA
-        FROM DUNE.CONTANGO_XYZ.V2_TRANSACTIONS AS T
-        WHERE T.chain = '${mappedChain}' AND T.DIRECTION = 'Short'
-        GROUP BY 1, 2
+const duneChains = Object.values(chainConfig).map(({ duneName }) => duneName);
+const duneChainsSql = duneChains.map((chain) => `'${chain}'`).join(", ");
+
+const buildQuery = (fromTimestamp: number, toTimestamp: number) => `
+  WITH volume AS (
+    SELECT chain, SUM(ABS(QUANTITY_USD)) AS VOL_USD 
+    FROM DUNE.CONTANGO_XYZ.RESULT_V2_ALL_TRADES
+    WHERE TIMESTAMP >= from_unixtime(${fromTimestamp}) AND TIMESTAMP <= from_unixtime(${toTimestamp})
+      AND chain IN (${duneChainsSql})
+    GROUP BY chain
+  ), 
+  oi as (
+    with LONG_OI_DELTA as (
+      SELECT T.chain, DATE_TRUNC('day', T.TIMESTAMP) AS TIMESTAMP, T.BASE AS ASSET, SUM(T.QUANTITY) AS DELTA
+      FROM DUNE.CONTANGO_XYZ.V2_TRANSACTIONS AS T
+      WHERE T.chain IN (${duneChainsSql}) AND T.DIRECTION = 'Long'
+      GROUP BY 1, 2, 3
+    ),
+    SHORT_OI_DELTA as (
+      SELECT T.chain, DATE_TRUNC('day', T.TIMESTAMP) AS TIMESTAMP, T.BASE AS ASSET, SUM(T.QUANTITY) * -1 AS DELTA
+      FROM DUNE.CONTANGO_XYZ.V2_TRANSACTIONS AS T
+      WHERE T.chain IN (${duneChainsSql}) AND T.DIRECTION = 'Short'
+      GROUP BY 1, 2, 3
     ), 
     OI_DELTA as (
-      SELECT COALESCE(L.TIMESTAMP, S.TIMESTAMP) AS TIMESTAMP, COALESCE(L.ASSET, S.ASSET) AS ASSET, COALESCE(L.DELTA, 0) + COALESCE(S.DELTA, 0) AS DELTA
+      SELECT COALESCE(L.chain, S.chain) AS chain, COALESCE(L.TIMESTAMP, S.TIMESTAMP) AS TIMESTAMP, COALESCE(L.ASSET, S.ASSET) AS ASSET, COALESCE(L.DELTA, 0) + COALESCE(S.DELTA, 0) AS DELTA
       FROM LONG_OI_DELTA L
-      LEFT JOIN SHORT_OI_DELTA S ON (S.TIMESTAMP = L.TIMESTAMP AND S.ASSET = L.ASSET)
+      LEFT JOIN SHORT_OI_DELTA S ON (S.TIMESTAMP = L.TIMESTAMP AND S.ASSET = L.ASSET AND S.chain = L.chain)
     ),
     ASSETS as (
-      SELECT distinct ASSET
+      SELECT distinct chain, ASSET
       FROM OI_DELTA
     ),
     OI_DIRTY as (
-      SELECT TS.TIMESTAMP AS TIMESTAMP, A.ASSET AS ASSET, SUM(OI_DELTA.DELTA) OVER (PARTITION BY A.ASSET ORDER BY TS.TIMESTAMP) AS OI
+      SELECT TS.TIMESTAMP AS TIMESTAMP, A.chain AS chain, A.ASSET AS ASSET, SUM(OI_DELTA.DELTA) OVER (PARTITION BY A.chain, A.ASSET ORDER BY TS.TIMESTAMP) AS OI
       FROM DUNE.CONTANGO_XYZ.RESULT_DAILY_TIMESTAMPS TS
       CROSS JOIN ASSETS A
-      LEFT JOIN OI_DELTA ON OI_DELTA.TIMESTAMP = TS.TIMESTAMP AND OI_DELTA.ASSET = A.ASSET
+      LEFT JOIN OI_DELTA ON OI_DELTA.TIMESTAMP = TS.TIMESTAMP AND OI_DELTA.ASSET = A.ASSET AND OI_DELTA.chain = A.chain
       WHERE TS.TIMESTAMP <= DATE_TRUNC('day', from_unixtime(${toTimestamp}))
     ),
     OI as (
-      SELECT TIMESTAMP, ASSET, 
+      SELECT TIMESTAMP, chain, ASSET, 
       CASE
         WHEN OI < 0 THEN 0
         ELSE OI
@@ -56,10 +64,6 @@ const fetch = async (options: FetchOptions) => {
       FROM OI_DIRTY
     ), 
     PRICE_AS_OF as (
-      -- RESULT_V2_DAILY_PRICES_USD is refreshed a day behind V2_TRANSACTIONS, so joining a price
-      -- on an exact date drops every asset on the day being requested and the sum below collapses
-      -- to zero. Carry the last price at or before that day instead; on any day the table already
-      -- covers this picks that same day's price, so it does not change historical values.
       SELECT ASSET, PRICE FROM (
         SELECT ASSET, PRICE, ROW_NUMBER() OVER (PARTITION BY ASSET ORDER BY TIMESTAMP DESC) AS RN
         FROM DUNE.CONTANGO_XYZ.RESULT_V2_DAILY_PRICES_USD
@@ -67,72 +71,42 @@ const fetch = async (options: FetchOptions) => {
       ) WHERE RN = 1
     ),
     OI_USD as (
-      SELECT OI.TIMESTAMP, OI.OI * PRICE.PRICE AS OI_USD
+      SELECT OI.chain, OI.TIMESTAMP, OI.OI * PRICE.PRICE AS OI_USD
       FROM OI
       INNER JOIN PRICE_AS_OF AS PRICE ON PRICE.ASSET = OI.ASSET
     )
-      SELECT '${mappedChain}' AS chain, TIMESERIES.TIMESTAMP AS TIMESTAMP, COALESCE(SUM(OI.OI_USD), 0) AS OI_USD
+      SELECT OI.chain, TIMESERIES.TIMESTAMP AS TIMESTAMP, COALESCE(SUM(OI.OI_USD), 0) AS OI_USD
       FROM DUNE.CONTANGO_XYZ.RESULT_DAILY_TIMESTAMPS AS TIMESERIES
       LEFT JOIN OI_USD as OI ON OI.TIMESTAMP = TIMESERIES.TIMESTAMP
       WHERE TIMESERIES.TIMESTAMP > DATE_TRUNC('day', from_unixtime(${fromTimestamp})) AND TIMESERIES.TIMESTAMP <= DATE_TRUNC('day', from_unixtime(${toTimestamp}))
       GROUP BY 1, 2
-    )
-    SELECT volume.VOL_USD, oi.OI_USD, oi.TIMESTAMP
-    FROM volume CROSS JOIN oi
-  `;
+  )
+  SELECT volume.chain, volume.VOL_USD, oi.OI_USD
+  FROM volume
+  LEFT JOIN oi ON oi.chain = volume.chain
+`;
 
-  const response = await queryDuneSql(options, query);
+const prefetch = async (options: FetchOptions) => {
+  const { fromTimestamp, toTimestamp } = options;
+  return queryDuneSql(options, buildQuery(fromTimestamp, toTimestamp));
+};
+
+const fetch = async (options: FetchOptions) => {
+  const { chain } = options;
+  const duneChain = chainConfig[chain].duneName;
+  const response = (options.preFetchedResults || []).filter((row: any) => row.chain === duneChain);
 
   return {
-    dailyVolume: Number(response[0].VOL_USD ? response[0].VOL_USD : 0),
-    openInterestAtEnd: Number(response[0].OI_USD ? response[0].OI_USD : 0),
+    dailyVolume: Number(response[0]?.VOL_USD ?? 0),
+    openInterestAtEnd: Number(response[0]?.OI_USD ?? 0),
   };
 };
 
 const adapter: SimpleAdapter = {
   dependencies: [Dependencies.DUNE],
   isExpensiveAdapter: true,
-  adapter: {
-    [CHAIN.ARBITRUM]: {
-      fetch,
-      start: "2023-10-03",
-    },
-    [CHAIN.OPTIMISM]: {
-      fetch,
-      start: "2023-10-02",
-    },
-    [CHAIN.ETHEREUM]: {
-      fetch,
-      start: "2023-10-03",
-    },
-    [CHAIN.POLYGON]: {
-      fetch,
-      start: "2023-10-13",
-    },
-    [CHAIN.BASE]: {
-      fetch,
-      start: "2023-10-09",
-    },
-    [CHAIN.XDAI]: {
-      fetch,
-      start: "2023-10-06",
-    },
-    [CHAIN.AVAX]: {
-      fetch,
-      start: "2024-08-11",
-    },
-    [CHAIN.LINEA]: {
-      fetch,
-      start: "2024-08-11",
-    },
-    [CHAIN.BSC]: {
-      fetch,
-      start: "2024-06-07",
-    },
-    [CHAIN.SCROLL]: {
-      fetch,
-      start: "2024-08-11",
-    },
-  },
+  prefetch,
+  fetch,
+  adapter: chainConfig,
 };
 export default adapter;

--- a/dexs/contango/index.ts
+++ b/dexs/contango/index.ts
@@ -55,11 +55,21 @@ const fetch = async (options: FetchOptions) => {
       END AS OI
       FROM OI_DIRTY
     ), 
+    PRICE_AS_OF as (
+      -- RESULT_V2_DAILY_PRICES_USD is refreshed a day behind V2_TRANSACTIONS, so joining a price
+      -- on an exact date drops every asset on the day being requested and the sum below collapses
+      -- to zero. Carry the last price at or before that day instead; on any day the table already
+      -- covers this picks that same day's price, so it does not change historical values.
+      SELECT ASSET, PRICE FROM (
+        SELECT ASSET, PRICE, ROW_NUMBER() OVER (PARTITION BY ASSET ORDER BY TIMESTAMP DESC) AS RN
+        FROM DUNE.CONTANGO_XYZ.RESULT_V2_DAILY_PRICES_USD
+        WHERE TIMESTAMP <= DATE_TRUNC('day', from_unixtime(${toTimestamp}))
+      ) WHERE RN = 1
+    ),
     OI_USD as (
       SELECT OI.TIMESTAMP, OI.OI * PRICE.PRICE AS OI_USD
       FROM OI
-      INNER JOIN DUNE.CONTANGO_XYZ.RESULT_V2_DAILY_PRICES_USD AS PRICE 
-      ON (PRICE.ASSET = OI.ASSET AND PRICE.TIMESTAMP = OI.TIMESTAMP)
+      INNER JOIN PRICE_AS_OF AS PRICE ON PRICE.ASSET = OI.ASSET
     )
       SELECT '${mappedChain}' AS chain, TIMESERIES.TIMESTAMP AS TIMESTAMP, COALESCE(SUM(OI.OI_USD), 0) AS OI_USD
       FROM DUNE.CONTANGO_XYZ.RESULT_DAILY_TIMESTAMPS AS TIMESERIES


### PR DESCRIPTION
Closes #5068.

`contango-v2` open interest has published an explicit **$0 every day since 2025-12-27** — 249 consecutive zero days. The adapter is not erroring: `totalDataChartBreakdown` carries all ten chains every day, each at `0`.

```
2025-12-26   Ethereum 94,778,320  Base 16,471,730  Arbitrum 14,325,091  OP 8,827,687
             Avalanche 5,136,678  Gnosis 1,580,957  Polygon 371,178  BSC 123,801
             Linea 45,227  Scroll 15,784                        TOTAL 141,676,453
2025-12-27   all ten chains 0                                   TOTAL 0
```

The protocol is alive. `fees/contango` is an independent on-chain adapter (`addTokensReceived`, no Dune, no subgraph) and reports `total24h $19.04`, `total7d $77.79`, non-zero on each of the last four days.

## Root cause

The `oi` half of the Dune query prices each day's position size with an exact-date join:

```sql
INNER JOIN DUNE.CONTANGO_XYZ.RESULT_V2_DAILY_PRICES_USD AS PRICE
ON (PRICE.ASSET = OI.ASSET AND PRICE.TIMESTAMP = OI.TIMESTAMP)
```

`RESULT_V2_DAILY_PRICES_USD` is refreshed a day behind `V2_TRANSACTIONS` — today it ends at 2026-08-31 while transactions run to 2026-09-01. So on the day the adapter actually asks for there is no price row, the `INNER JOIN` drops every asset, and the outer `COALESCE(SUM(OI.OI_USD), 0)` turns the empty result into a successful `$0`.

**The query is correct in hindsight and wrong in real time**, which is why nothing looks broken when you re-run it. Running this file's own query verbatim through the same wrapper the adapter uses — `queryDuneSql`, Dune query `3996608` — for a range of requested days:

| day requested | Ethereum | Arbitrum |
|---|---|---|
| 2026-09-01 | **0** | **0** |
| 2026-08-31 | 66,625,879.06 | 7,976,364.02 |
| 2026-06-15 | 49,756,376.27 | 6,705,181.31 |
| 2026-01-15 | 109,154,524.12 | 15,715,346.32 |
| 2025-12-26 | 94,778,320.27 | 14,325,090.65 |

Only the most recent day fails, and that is the only day the adapter ever asks for. 249 zeros out of 249 days means the lag is structural, not occasional — had the price table ever caught up before a run, that day would be non-zero.

Note the last row: replaying the query for **2025-12-26 reproduces DefiLlama's own last published values to the cent** (94,778,320.27 against 94,778,320 and 14,325,090.65 against 14,325,091). The methodology is intact; only the timing of the price join is broken.

Not an upstream outage — the four source tables are healthy. `V2_TRANSACTIONS` runs to 2026-09-01 on nine chains, `RESULT_V2_ALL_TRADES` to 2026-09-01, `RESULT_DAILY_TIMESTAMPS` to 2026-09-06, and all 179 assets in `V2_TRANSACTIONS.BASE` appear in the price table's `ASSET` (179/179 overlap, 248 assets priced per day).

The cliff date is the merge date of #5378 (2025-12-27), which replaced the DNS-dead Satsuma subgraph with this query, so the OI branch has never once produced a non-zero value in production.

## Fix

Carry the last price at or before the requested day instead of requiring an exact date match. On any day the price table already covers, that resolves to the same day's price, so historical values do not move.

**No regression** — old and new join produce identical values to the cent:

```
2026-08-31 arbitrum  old=      7,976,364.02  new=      7,976,364.02  SAME
2026-08-31 mainnet   old=     66,625,879.06  new=     66,625,879.06  SAME
2026-06-15 arbitrum  old=      6,705,181.31  new=      6,705,181.31  SAME
2026-06-15 mainnet   old=     49,756,376.27  new=     49,756,376.27  SAME
2026-01-15 arbitrum  old=     15,715,346.32  new=     15,715,346.32  SAME
2026-01-15 mainnet   old=    109,154,524.12  new=    109,154,524.12  SAME
2025-12-26 arbitrum  old=     14,325,090.65  new=     14,325,090.65  SAME
2025-12-26 mainnet   old=     94,778,320.27  new=     94,778,320.27  SAME
```

**The day that was broken**, all ten chains, 2026-09-01:

```
mainnet        66,625,879.06        gnosis      1,135,558.38
arbitrum        7,976,362.80        avalanche   1,162,739.67
base            6,740,545.37        polygon       283,072.82
optimism        4,286,984.87        bsc            74,163.81
                                    linea          29,318.92
                                    scroll         13,022.80
TOTAL          88,327,648.50   (published: 0)
```

## Notes

- Same failure mode as #8970 (dtrade), where `COALESCE(..., 0)` turned an incomplete Dune window into a valid-looking zero. That one throws so the run can be retried, which is right when the lag is intermittent. Here the price table is behind on *every* run, so throwing would leave the series permanently empty; the position data itself is complete and only its valuation is a day old.
- Scope is the price join only. `dailyVolume` and the Dune `volume` CTE are untouched, and I left `Number(response[0].OI_USD ? ... : 0)` alone rather than converting it to a throw as in #8524/#8525 — once the join works there is a real value to publish, and changing both would mix two concerns in one diff.
- Open interest is a stock, so a one-day-old valuation is a rounding-level effect: Ethereum moves 66,625,879 → 67,213,856 between 2026-08-31 and 08-30, under 1%.
- The red `test` check is `DUNE_API_KEYS environment variable is not set` — the runner has no keys, so it cannot execute any Dune-backed adapter. #8970, #8524 and #9104 all merged with the same red `test` and green `ts-check`.
