### PR TITLE
gluex: mark dead, both routers went silent on 2026-03-17

### DIFF
--- a/aggregators/gluex-protocol/index.ts
+++ b/aggregators/gluex-protocol/index.ts
@@ -129,6 +129,10 @@ const adapter: SimpleAdapter = {
   pullHourly: true,
   adapter: {},
   start: '2025-03-14',
+  // Both routers stopped emitting Routed on 2026-03-17 (HyperEVM 08:36:42 UTC, which carried
+  // 99.9% of the final day's volume, and Base 00:05:09 UTC) and neither signature has fired from
+  // any address on any covered chain since. gluex.xyz is a parked for-sale domain.
+  deadFrom: '2026-03-18',
   fetch,
   chains: Object.keys({ ...ROUTERS_OLD, ...ROUTERS_NEW }),
   methodology,


### PR DESCRIPTION
`aggregators/gluex-protocol` last published a non-zero value on **2026-03-17** and has written an explicit `$0` on every day since — 161 days, on both the volume and the fees leg. It is not erroring; it runs, finds no logs, and stores a successful zero.

## The routers stopped

Both configured routers emitted their final `Routed` event on 2026-03-17:

| chain | router | last `Routed` |
|---|---|---|
| HyperEVM | `0xe95f6eaeae1e4d650576af600b33d9f7e5f9f7fd` | block 29,973,507 — 2026-03-17 08:36:42 UTC |
| Base | `0xe95f6eaeae1e4d650576af600b33d9f7e5f9f7fd` | block 43,458,281 — 2026-03-17 00:05:09 UTC |
| Ethereum | `0xe95f6eaeae1e4d650576af600b33d9f7e5f9f7fd` | block 24,652,792 — 2026-03-14 02:40:11 UTC |
| Ethereum | `0x6Ec7612828B776cC746fe0Ee5381CC93878844f7` | block 23,016,689 — 2025-07-28 09:15:35 UTC |

HyperEVM is the chain that matters here: on the last live day it carried **$831,903 of the $832,494** total, so any check that skips it is testing the wrong chain. Per-chain, the wind-down was staged rather than a single break — Gnosis stopped 2025-12-07, Unichain and Berachain 2025-12-16, BSC 12-24, Avalanche 12-31, OP Mainnet 2026-01-01, Polygon 01-04, Arbitrum 01-31, then Base and HyperEVM together on 03-17.

## There is no successor

Scanning HyperEVM for **both** `Routed` signatures across **every address**, not just the two known routers:

```
topics [0xc3abfc5221d6a68c4aea21a86d5ec3f135dd55a8b3949268207ba6ddc1a4dce0,
        0x5e521321e80942e089aa52b7fc771168567b97a6322f12d75ae43b264fff9c77]
blocks 42,849,120 -> 44,849,120  (2,000,000 blocks, 0 errored chunks)   ->  0 logs
any log at all from either router over the same range                   ->  0 logs
```

Ethereum, Base, BSC and Arbitrum return nothing over their recent ranges either (108k, 180k, 80k and 180k blocks respectively). And `gluex.xyz` now serves a parked "This domain may be for sale" page, so the routers were not simply replaced somewhere I did not look.

## Dating

`deadFrom: '2026-03-18'` — the first fully silent day, rather than the last live one. Unlike the odos shutdown (#8647) there is no dated public announcement to anchor on, so the on-chain silence is the only honest boundary.

Verified:

```
$ npx ts-node --transpile-only cli/testAdapter.ts aggregators gluex-protocol
🦙 GLUEX-PROTOCOL is dead (deadFrom 2026-03-18); skipping run.
```

One file covers both dimensions, so this stops the volume and fees legs together.

This changes no published figure — both are already `$0`. What it stops is 18 chains being queried every run for a protocol that has not emitted since March.
