### PR TITLE
feat(rocket): add options open interest adapter (open-interest/rocket-options)

### DIFF
--- a/helpers/rocket.ts
+++ b/helpers/rocket.ts
@@ -1,0 +1,65 @@
+/*
+ * Shared helpers for the Rocket adapters (dexs/rocket, options/rocket, open-interest/rocket-*).
+ *
+ * Rocket public API: https://beta.rocket-cluster-1.com (docs: https://api.docs.rocketfi.io/)
+ *
+ * GET /instruments is paginated: `pageNumber` is 0-based and `pageSize` is capped at 1000 by the
+ * server. Calling it without params silently returns only the first 1000 instruments, so every
+ * consumer must walk all pages (there are ~1.8k trading instruments once options are included).
+ */
+
+import fetchURL from "../utils/fetchURL";
+
+export const ROCKET_API = "https://beta.rocket-cluster-1.com";
+
+// Wire type is a string; known values are PERP, FUTURE, CALL_OPTION, PUT_OPTION (spot may be added)
+export interface RocketInstrument {
+    id: string;
+    ticker: string;
+    instrumentType: string;
+    underlyingAsset: string;
+    settlementAsset: string;
+    isTrading: boolean;
+    lastMatchPrice: string;
+}
+
+export interface RocketInstrumentStats {
+    openInterest: number;
+    volume24h: string;
+    quoteVolume24h: string;
+}
+
+export interface RocketInstrumentsResponse {
+    instruments: Record<string, RocketInstrument>;
+    instrumentStats: Record<string, RocketInstrumentStats>;
+}
+
+export const isRocketOption = (t: string) => t === "CALL_OPTION" || t === "PUT_OPTION";
+export const isRocketLinear = (t: string) => t === "PERP" || t === "FUTURE";
+
+const PAGE_SIZE = 1000; // server-side maximum
+const MAX_PAGES = 50;   // safety stop (~50k instruments)
+
+/** Fetch every page of GET /instruments and merge them. Throws if paging never terminates. */
+export async function fetchRocketInstruments(): Promise<RocketInstrumentsResponse> {
+    const instruments: Record<string, RocketInstrument> = {};
+    const instrumentStats: Record<string, RocketInstrumentStats> = {};
+    for (let page = 0; ; page++) {
+        if (page >= MAX_PAGES) throw new Error(`Rocket: /instruments did not terminate after ${MAX_PAGES} pages`);
+        const res: RocketInstrumentsResponse = await fetchURL(`${ROCKET_API}/instruments?pageNumber=${page}&pageSize=${PAGE_SIZE}`);
+        const pageInstruments = res?.instruments ?? {};
+        Object.assign(instruments, pageInstruments);
+        Object.assign(instrumentStats, res?.instrumentStats ?? {});
+        if (Object.keys(pageInstruments).length < PAGE_SIZE) break;
+    }
+    return { instruments, instrumentStats };
+}
+
+/** Underlying asset -> last match price of its perp market, used to value options in USD. */
+export function rocketUnderlyingPrices(instruments: Record<string, RocketInstrument>): Record<string, number> {
+    const prices: Record<string, number> = {};
+    for (const inst of Object.values(instruments)) {
+        if (inst.instrumentType === "PERP") prices[inst.underlyingAsset] = Number(inst.lastMatchPrice);
+    }
+    return prices;
+}

--- a/helpers/rocket.ts
+++ b/helpers/rocket.ts
@@ -34,25 +34,33 @@ export interface RocketInstrumentsResponse {
     instrumentStats: Record<string, RocketInstrumentStats>;
 }
 
+/** True for option instruments (instrumentType CALL_OPTION or PUT_OPTION). */
 export const isRocketOption = (t: string) => t === "CALL_OPTION" || t === "PUT_OPTION";
+
+/** True for linear derivatives (instrumentType PERP or FUTURE), i.e. everything that is not an option. */
 export const isRocketLinear = (t: string) => t === "PERP" || t === "FUTURE";
 
 const PAGE_SIZE = 1000; // server-side maximum
-const MAX_PAGES = 50;   // safety stop (~50k instruments)
+const MAX_PAGES = 50;   // safety stop (~50k instruments); one extra terminating page is allowed
 
-/** Fetch every page of GET /instruments and merge them. Throws if paging never terminates. */
+/**
+ * Fetch every page of GET /instruments and merge them.
+ * Fails closed: throws on a malformed page (missing `instruments` or `instrumentStats`) or if the
+ * endpoint keeps returning full pages beyond MAX_PAGES, so a partial snapshot is never returned.
+ */
 export async function fetchRocketInstruments(): Promise<RocketInstrumentsResponse> {
     const instruments: Record<string, RocketInstrument> = {};
     const instrumentStats: Record<string, RocketInstrumentStats> = {};
-    for (let page = 0; ; page++) {
-        if (page >= MAX_PAGES) throw new Error(`Rocket: /instruments did not terminate after ${MAX_PAGES} pages`);
+    for (let page = 0; page <= MAX_PAGES; page++) {
         const res: RocketInstrumentsResponse = await fetchURL(`${ROCKET_API}/instruments?pageNumber=${page}&pageSize=${PAGE_SIZE}`);
-        const pageInstruments = res?.instruments ?? {};
-        Object.assign(instruments, pageInstruments);
-        Object.assign(instrumentStats, res?.instrumentStats ?? {});
-        if (Object.keys(pageInstruments).length < PAGE_SIZE) break;
+        if (!res || typeof res.instruments !== "object" || typeof res.instrumentStats !== "object") {
+            throw new Error(`Rocket: malformed /instruments response on page ${page}`);
+        }
+        Object.assign(instruments, res.instruments);
+        Object.assign(instrumentStats, res.instrumentStats);
+        if (Object.keys(res.instruments).length < PAGE_SIZE) return { instruments, instrumentStats };
     }
-    return { instruments, instrumentStats };
+    throw new Error(`Rocket: /instruments did not terminate after ${MAX_PAGES} full pages`);
 }
 
 /** Underlying asset -> last match price of its perp market, used to value options in USD. */
@@ -62,4 +70,15 @@ export function rocketUnderlyingPrices(instruments: Record<string, RocketInstrum
         if (inst.instrumentType === "PERP") prices[inst.underlyingAsset] = Number(inst.lastMatchPrice);
     }
     return prices;
+}
+
+/**
+ * Parse a non-negative numeric field from the API. Throws (fail closed) when the value is
+ * missing, blank, non-numeric or negative, so bad upstream data never becomes a silent 0.
+ */
+export function rocketNonNegative(value: unknown, what: string): number {
+    if (value === undefined || value === null || String(value).trim() === "") throw new Error(`Rocket: missing ${what}`);
+    const n = Number(value);
+    if (!Number.isFinite(n) || n < 0) throw new Error(`Rocket: invalid ${what}: ${JSON.stringify(value)}`);
+    return n;
 }

--- a/open-interest/rocket-options.ts
+++ b/open-interest/rocket-options.ts
@@ -4,49 +4,21 @@
  * as a separate open-interest adapter rather than inside the options adapter.
  *
  * Data source:
- *   GET /instruments - per-instrument stats; openInterest on option instruments is in contracts
- *                      (1 contract = 1 unit of underlying), valued at the underlying perp's
- *                      last match price.
+ *   GET /instruments (all pages) - per-instrument stats; openInterest on option instruments is in
+ *                                  contracts (1 contract = 1 unit of underlying), valued at the
+ *                                  underlying perp's last match price.
  *
  * Website: https://rocketfi.io
  * API Docs: https://api.docs.rocketfi.io/
  */
 
 import { FetchOptions, SimpleAdapter } from "../adapters/types";
-import fetchURL from "../utils/fetchURL";
 import { CHAIN } from "../helpers/chains";
-
-const ROCKET_API_URL = 'https://beta.rocket-cluster-1.com';
-
-type InstrumentType = "PERP" | "FUTURE" | "CALL_OPTION" | "PUT_OPTION";
-
-interface Instrument {
-    id: string;
-    ticker: string;
-    instrumentType: InstrumentType;
-    underlyingAsset: string;
-    lastMatchPrice: string;
-}
-
-interface InstrumentStats {
-    openInterest: number;
-}
-
-interface InstrumentsResponse {
-    instruments: Record<string, Instrument>;
-    instrumentStats: Record<string, InstrumentStats>;
-}
-
-const isOption = (t: InstrumentType) => t === "CALL_OPTION" || t === "PUT_OPTION";
+import { fetchRocketInstruments, isRocketOption, rocketUnderlyingPrices } from "../helpers/rocket";
 
 async function fetch(options: FetchOptions) {
-    const { instruments, instrumentStats }: InstrumentsResponse = await fetchURL(`${ROCKET_API_URL}/instruments`);
-
-    // Underlying valued at the corresponding perp market's last match price
-    const underlyingPrice: Record<string, number> = {};
-    for (const inst of Object.values(instruments)) {
-        if (inst.instrumentType === "PERP") underlyingPrice[inst.underlyingAsset] = Number(inst.lastMatchPrice);
-    }
+    const { instruments, instrumentStats } = await fetchRocketInstruments();
+    const underlyingPrice = rocketUnderlyingPrices(instruments);
 
     const openInterestAtEnd = options.createBalances();
     for (const [id, stats] of Object.entries(instrumentStats)) {
@@ -55,20 +27,21 @@ async function fetch(options: FetchOptions) {
             console.log(`Rocket options OI: stats returned for unknown instrument ${id}, skipping`);
             continue;
         }
-        if (!isOption(inst.instrumentType)) continue;
+        if (!isRocketOption(inst.instrumentType)) continue;
+        const oi = Number(stats.openInterest ?? 0);
+        if (!Number.isFinite(oi)) throw new Error(`Rocket options OI: invalid openInterest for ${inst.ticker}: ${stats.openInterest}`);
+        if (oi === 0) continue;
         const price = underlyingPrice[inst.underlyingAsset];
-        if (!price) {
-            console.log(`Rocket options OI: no perp price for underlying ${inst.underlyingAsset} (${inst.ticker}), skipping`);
-            continue;
-        }
-        openInterestAtEnd.addUSDValue(Number(stats.openInterest ?? 0) * price, "Options open interest");
+        // Fail closed: a missing underlying price would silently under-count the snapshot
+        if (!price) throw new Error(`Rocket options OI: no perp price for underlying ${inst.underlyingAsset} (${inst.ticker})`);
+        openInterestAtEnd.addUSDValue(oi * price, "Options open interest");
     }
 
     return { openInterestAtEnd };
 }
 
 const methodology = {
-    OpenInterest: "Sum of outstanding option contracts across all listed BTC and ETH options, valued at the underlying's perpetual market last match price (one side, consistent with Rocket's perp OI adapter).",
+    OpenInterest: "Sum of outstanding option contracts across all listed BTC and ETH options (GET /instruments, all pages), valued at the underlying's perpetual market last match price (one side, consistent with Rocket's perp OI adapter).",
 };
 
 const breakdownMethodology = {
@@ -78,10 +51,9 @@ const breakdownMethodology = {
 };
 
 const adapter: SimpleAdapter = {
-    version: 2,
+    // version 1: the API only exposes a live snapshot (no historical time ranges)
+    version: 1,
     runAtCurrTime: true,
-    // Rocket exposes a live snapshot only, so hourly slices cannot be reconstructed.
-    pullHourly: false,
     fetch,
     chains: [CHAIN.OFF_CHAIN],
     start: '2026-08-31',

--- a/open-interest/rocket-options.ts
+++ b/open-interest/rocket-options.ts
@@ -1,0 +1,92 @@
+/*
+ * Open interest for options traded on Rocket (companion to options/rocket, which reports
+ * notional & premium volume). Mirrors open-interest/derive-options.ts: options OI is reported
+ * as a separate open-interest adapter rather than inside the options adapter.
+ *
+ * Data source:
+ *   GET /instruments - per-instrument stats; openInterest on option instruments is in contracts
+ *                      (1 contract = 1 unit of underlying), valued at the underlying perp's
+ *                      last match price.
+ *
+ * Website: https://rocketfi.io
+ * API Docs: https://api.docs.rocketfi.io/
+ */
+
+import { FetchOptions, SimpleAdapter } from "../adapters/types";
+import fetchURL from "../utils/fetchURL";
+import { CHAIN } from "../helpers/chains";
+
+const ROCKET_API_URL = 'https://beta.rocket-cluster-1.com';
+
+type InstrumentType = "PERP" | "FUTURE" | "CALL_OPTION" | "PUT_OPTION";
+
+interface Instrument {
+    id: string;
+    ticker: string;
+    instrumentType: InstrumentType;
+    underlyingAsset: string;
+    lastMatchPrice: string;
+}
+
+interface InstrumentStats {
+    openInterest: number;
+}
+
+interface InstrumentsResponse {
+    instruments: Record<string, Instrument>;
+    instrumentStats: Record<string, InstrumentStats>;
+}
+
+const isOption = (t: InstrumentType) => t === "CALL_OPTION" || t === "PUT_OPTION";
+
+async function fetch(options: FetchOptions) {
+    const { instruments, instrumentStats }: InstrumentsResponse = await fetchURL(`${ROCKET_API_URL}/instruments`);
+
+    // Underlying valued at the corresponding perp market's last match price
+    const underlyingPrice: Record<string, number> = {};
+    for (const inst of Object.values(instruments)) {
+        if (inst.instrumentType === "PERP") underlyingPrice[inst.underlyingAsset] = Number(inst.lastMatchPrice);
+    }
+
+    const openInterestAtEnd = options.createBalances();
+    for (const [id, stats] of Object.entries(instrumentStats)) {
+        const inst = instruments[id];
+        if (!inst) {
+            console.log(`Rocket options OI: stats returned for unknown instrument ${id}, skipping`);
+            continue;
+        }
+        if (!isOption(inst.instrumentType)) continue;
+        const price = underlyingPrice[inst.underlyingAsset];
+        if (!price) {
+            console.log(`Rocket options OI: no perp price for underlying ${inst.underlyingAsset} (${inst.ticker}), skipping`);
+            continue;
+        }
+        openInterestAtEnd.addUSDValue(Number(stats.openInterest ?? 0) * price, "Options open interest");
+    }
+
+    return { openInterestAtEnd };
+}
+
+const methodology = {
+    OpenInterest: "Sum of outstanding option contracts across all listed BTC and ETH options, valued at the underlying's perpetual market last match price (one side, consistent with Rocket's perp OI adapter).",
+};
+
+const breakdownMethodology = {
+    OpenInterest: {
+        "Options open interest": "Open option contracts x underlying perp last match price.",
+    },
+};
+
+const adapter: SimpleAdapter = {
+    version: 2,
+    runAtCurrTime: true,
+    // Rocket exposes a live snapshot only, so hourly slices cannot be reconstructed.
+    pullHourly: false,
+    fetch,
+    chains: [CHAIN.OFF_CHAIN],
+    start: '2026-08-31',
+    methodology,
+    breakdownMethodology,
+};
+
+export default adapter;

--- a/open-interest/rocket-options.ts
+++ b/open-interest/rocket-options.ts
@@ -14,34 +14,34 @@
 
 import { FetchOptions, SimpleAdapter } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
-import { fetchRocketInstruments, isRocketOption, rocketUnderlyingPrices } from "../helpers/rocket";
+import { fetchRocketInstruments, isRocketOption, rocketNonNegative, rocketUnderlyingPrices } from "../helpers/rocket";
 
-async function fetch(options: FetchOptions) {
+const fetch = async (options: FetchOptions) => {
     const { instruments, instrumentStats } = await fetchRocketInstruments();
     const underlyingPrice = rocketUnderlyingPrices(instruments);
 
+    // Fail closed on inconsistent upstream data rather than publishing a partial snapshot
+    for (const id of Object.keys(instrumentStats)) {
+        if (!instruments[id]) throw new Error(`Rocket options OI: stats returned for unknown instrument ${id}`);
+    }
+
     const openInterestAtEnd = options.createBalances();
-    for (const [id, stats] of Object.entries(instrumentStats)) {
-        const inst = instruments[id];
-        if (!inst) {
-            console.log(`Rocket options OI: stats returned for unknown instrument ${id}, skipping`);
-            continue;
-        }
+    for (const [id, inst] of Object.entries(instruments)) {
         if (!isRocketOption(inst.instrumentType)) continue;
-        const oi = Number(stats.openInterest ?? 0);
-        if (!Number.isFinite(oi)) throw new Error(`Rocket options OI: invalid openInterest for ${inst.ticker}: ${stats.openInterest}`);
+        const stats = instrumentStats[id];
+        if (!stats) throw new Error(`Rocket options OI: no stats for option ${inst.ticker}`);
+        const oi = rocketNonNegative(stats.openInterest, `openInterest for ${inst.ticker}`);
         if (oi === 0) continue;
         const price = underlyingPrice[inst.underlyingAsset];
-        // Fail closed: a missing underlying price would silently under-count the snapshot
         if (!price) throw new Error(`Rocket options OI: no perp price for underlying ${inst.underlyingAsset} (${inst.ticker})`);
         openInterestAtEnd.addUSDValue(oi * price, "Options open interest");
     }
 
     return { openInterestAtEnd };
-}
+};
 
 const methodology = {
-    OpenInterest: "Sum of outstanding option contracts across all listed BTC and ETH options (GET /instruments, all pages), valued at the underlying's perpetual market last match price (one side, consistent with Rocket's perp OI adapter).",
+    OpenInterest: "Sum of outstanding option contracts across all listed option underlyings on Rocket (currently BTC and ETH; GET /instruments, all pages), valued at the underlying's perpetual market last match price (one side, consistent with Rocket's perp OI adapter).",
 };
 
 const breakdownMethodology = {


### PR DESCRIPTION
Adds open interest for Rocket's options as a **separate open-interest adapter** (`open-interest/rocket-options.ts`), following the same pattern as `open-interest/derive-options.ts` — i.e. not inside `options/rocket`, per the note on #9132 that options adapters don't carry OI.

- OI = open option contracts (`openInterest` on CALL_OPTION/PUT_OPTION instruments from `GET /instruments`, **all pages**) x the underlying's perp last match price, one side only — consistent with the existing `open-interest/rocket-oi.ts` perp adapter (Derive doubles theirs; we've kept Rocket's perp and options OI on the same one-sided basis).
- Adds `helpers/rocket.ts` (shared with #9171, identical content) that walks the paginated `/instruments` endpoint — `pageNumber` is 0-based and `pageSize` is capped at 1000, and the bare endpoint silently returns only the first 1000 of ~1.8k instruments.
- Review feedback applied: fail closed (throw) on a missing underlying price or non-finite OI instead of publishing a partial snapshot; wire `instrumentType` typed as string with a narrow option predicate; `version: 1` since the API only exposes a live snapshot; labeled balance + `breakdownMethodology`.

Verified against the live API just now with all pages merged: ≈ $4.3M options OI (BTC ≈ $4.13M, ETH ≈ $0.19M), matching the figure shown in Rocket's UI.

This is meant to attach to the **Rocket Options** listing (the same way derive-options attaches to Derive's options listing) — please let me know if the mapping needs anything from our side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KJaRgbKaZLRqG86Wbrxi5k

**NOTE**

#### Please enable "Allow edits by maintainers" while putting up the PR.

---

> - If you would like to add a `tvl` adapter please submit the PR [here](https://github.com/DefiLlama/DefiLlama-Adapters).

1. Once your adapter has been merged, it takes time to show on the UI. If more than 24 hours have passed, please let us know in Discord.
2. Please fill the form below **only if the PR is for listing a new protocol** else it can be ignored/replaced with reason/details about the PR
3. **For updating listing info** Please send a mail to metadata@defillama.com
4. Do not edit/push `package.json/package-lock.json` file as part of your changes
5. No need to go to our discord/other channel and announce that you've created a PR, we monitor all PRs and will review it asap

---

##### Name (to be shown on DefiLlama):

##### Twitter Link:

##### List of audit links if any:

##### Website Link:

##### Logo (High resolution, will be shown with rounded borders):

##### Current TVL:

##### Treasury Addresses (if the protocol has treasury)

##### Chain:

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed): (https://api.coingecko.com/api/v3/coins/list)

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)

##### Short Description (to be shown on DefiLlama):

##### Token address and ticker if any:

##### Category (full list at https://defillama.com/categories) \*Please choose only one:

##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.):

##### Implementation Details: Briefly describe how the oracle is integrated into your project:

##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage:

##### forkedFrom (Does your project originate from another project):

##### methodology (what is being counted as tvl, how is tvl being calculated):

##### Github org/user (Optional, if your code is open source, we can track activity):

##### Does this project have a referral program?
