### PR TITLE
truemarkets: enumerate v4 pools from markets, not fee events

### DIFF
--- a/dexs/truemarkets.ts
+++ b/dexs/truemarkets.ts
@@ -4,9 +4,15 @@ import ADDRESSES from '../helpers/coreAssets.json'
 import { addTokensReceived } from '../helpers/token'
 import { filterPools2 } from '../helpers/uniswap'
 
-// TrueMarkets contract addresses on Base: https://github.com/truemarketsorg/true-contracts/blob/main/network_config.json
+// Trueo contract addresses on Base: https://github.com/trueo-protocol/trueo-contracts/blob/main/network_config.json
 const TRUTH_MARKET_MANAGER = '0x61A98Bef11867c69489B91f340fE545eEfc695d7'
-const FEE_COLLECTOR = '0x39339E149c2D916aa899Bf73D2Debb15F4755d9D'
+// A dedicated FeeCollector is deployed per Uniswap v4 hook generation. Every generation that has
+// been live must be read: a retired hook keeps charging fees until its markets resolve, so dropping
+// the old collector undercounts and pinning only the old one misses everything current.
+const FEE_COLLECTORS = [
+  '0x39339E149c2D916aa899Bf73D2Debb15F4755d9D', // hook 0x1cFeAD8E66cebC5E51093Dfd247Ad34f841740c4
+  '0x8C6c622A7DE8cEbD1A43e2Fb8363ebbE9120134F', // hook 0x3E83479B2276EcFb7C7181F67b5d092d3511e0C4 (current)
+]
 const LAUNCHPAD = '0xeD3ebc2e17a0CC20D22Ff7b7d13488F187fD1af6'
 const LAUNCHPAD_FEE_RECEIVER = '0x3F168219dadf4460dC6Ad93eaa3641340C1330D6'
 const UNISWAP_V4_POOL_MANAGER = '0x498581fF718922c3f8e6A244956aF099B2652b2b'
@@ -14,6 +20,7 @@ const UNISWAP_V4_POSITION_MANAGER = '0x7c5f5a4bbd8fd63184577525326123b519429bdc'
 const TYD_TOKEN = '0xb13CF163d916917d9cD6E836905cA5f12a1dEF4B'.toLowerCase()
 const USDC_TOKEN = ADDRESSES.base.USDC.toLowerCase()
 const ZERO_ADDRESS = ADDRESSES.null
+const ZERO_BYTES32 = '0x' + '0'.repeat(64)
 
 const ABI = {
   numberOfActiveMarkets: 'uint256:numberOfActiveMarkets',
@@ -33,6 +40,8 @@ const ABI = {
 
 const SWAP_TOPIC_V4 = '0x40e9cecb9f5f1f1c5b9c97dec2917b7ee92e57ba5563708daca94dd84ad7112f'
 const getPoolKey = (poolId: string) => poolId.slice(0, 52)
+// Pool ids are OR'd into topic1; chunked so the filter stays a sane size.
+const POOL_ID_CHUNK = 500
 
 async function fetch(options: FetchOptions): Promise<FetchResult> {
   const dailyVolume = options.createBalances()
@@ -40,7 +49,7 @@ async function fetch(options: FetchOptions): Promise<FetchResult> {
   const launchpadFees = options.createBalances()
 
   const feeTrackedLogs = await options.getLogs({
-    target: FEE_COLLECTOR,
+    targets: FEE_COLLECTORS,
     eventAbi: ABI.PoolFeeTracked,
   })
 
@@ -57,49 +66,10 @@ async function fetch(options: FetchOptions): Promise<FetchResult> {
 
   dailyFees.add(launchpadFees, "Launchpad Fees")
 
-  const v4PoolIdsFromFees = [...new Set(feeTrackedLogs.map((log: any) => log.poolId as string))]
-
   feeTrackedLogs.forEach((log: any) => {
     const currency = log.currency.toLowerCase()
     dailyFees.add(currency === TYD_TOKEN ? USDC_TOKEN : log.currency, log.amount, "Trading Fees")
   })
-
-  if (v4PoolIdsFromFees.length > 0) {
-    const poolConfigs = await options.api.multiCall({
-      abi: ABI.poolKeys,
-      calls: v4PoolIdsFromFees.map((poolId) => ({
-        target: UNISWAP_V4_POSITION_MANAGER,
-        params: [getPoolKey(poolId)],
-      })),
-      permitFailure: true,
-    })
-
-    const v4TydPos: Record<string, 0 | 1> = {}
-    v4PoolIdsFromFees.forEach((poolId, i) => {
-      if (poolConfigs[i]) {
-        v4TydPos[poolId] = poolConfigs[i].currency0.toLowerCase() === TYD_TOKEN ? 0 : 1
-      }
-    })
-
-    const v4SwapLogs = await Promise.all(
-      v4PoolIdsFromFees.map((poolId) =>
-        options
-          .getLogs({
-            target: UNISWAP_V4_POOL_MANAGER,
-            topics: [SWAP_TOPIC_V4, poolId],
-            eventAbi: ABI.SwapV4,
-          })
-          .then((logs) => logs.map((log: any) => ({ ...log, poolId })))
-      )
-    )
-
-    v4SwapLogs.flat().forEach((log: any) => {
-      const pos = v4TydPos[log.poolId]
-      if (pos === undefined) return
-      const amount = BigInt(pos === 0 ? log.amount0 : log.amount1)
-      dailyVolume.add(ADDRESSES.base.USDC, amount < 0n ? -amount : amount)
-    })
-  }
 
   const numMarkets = await options.api.call({
     target: TRUTH_MARKET_MANAGER,
@@ -115,6 +85,71 @@ async function fetch(options: FetchOptions): Promise<FetchResult> {
         params: [i],
       })),
     })
+
+    // V2 markets: Uniswap v4 pool ids come from the markets themselves, not from FeeCollector fee
+    // events. Deriving them from fees coupled volume to the fee configuration: a FeeCollector
+    // rotation, a protocol fee set to 0 (the hook returns early and emits nothing), or a swap whose
+    // fee rounds to zero all silently zeroed the volume of pools that were trading normally.
+    const poolIdResults = await options.api.multiCall({
+      abi: ABI.getPoolIds,
+      calls: marketAddresses,
+      permitFailure: true,
+    })
+
+    const v4PoolIds: string[] = []
+    poolIdResults.forEach((result: any) => {
+      if (!result) return
+      const [yesPoolId, noPoolId] = result
+      if (yesPoolId && yesPoolId !== ZERO_BYTES32) v4PoolIds.push(yesPoolId.toLowerCase())
+      if (noPoolId && noPoolId !== ZERO_BYTES32) v4PoolIds.push(noPoolId.toLowerCase())
+    })
+
+    const uniqueV4PoolIds = [...new Set(v4PoolIds)]
+
+    if (uniqueV4PoolIds.length > 0) {
+      const v4SwapLogs: any[] = []
+      const tradedPoolIds = new Set<string>()
+
+      for (let i = 0; i < uniqueV4PoolIds.length; i += POOL_ID_CHUNK) {
+        const logs = await options.getLogs({
+          target: UNISWAP_V4_POOL_MANAGER,
+          topics: [SWAP_TOPIC_V4, uniqueV4PoolIds.slice(i, i + POOL_ID_CHUNK)] as any,
+          eventAbi: ABI.SwapV4,
+        })
+        logs.forEach((log: any) => {
+          v4SwapLogs.push(log)
+          tradedPoolIds.add(String(log.id).toLowerCase())
+        })
+      }
+
+      // Resolve currency order only for the pools that actually traded, not all of them.
+      const tradedPoolIdList = [...tradedPoolIds]
+
+      if (tradedPoolIdList.length > 0) {
+        const poolConfigs = await options.api.multiCall({
+          abi: ABI.poolKeys,
+          calls: tradedPoolIdList.map((poolId) => ({
+            target: UNISWAP_V4_POSITION_MANAGER,
+            params: [getPoolKey(poolId)],
+          })),
+          permitFailure: true,
+        })
+
+        const v4TydPos: Record<string, 0 | 1> = {}
+        tradedPoolIdList.forEach((poolId, i) => {
+          if (poolConfigs[i]) {
+            v4TydPos[poolId] = poolConfigs[i].currency0.toLowerCase() === TYD_TOKEN ? 0 : 1
+          }
+        })
+
+        v4SwapLogs.forEach((log: any) => {
+          const pos = v4TydPos[String(log.id).toLowerCase()]
+          if (pos === undefined) return
+          const amount = BigInt(pos === 0 ? log.amount0 : log.amount1)
+          dailyVolume.add(ADDRESSES.base.USDC, amount < 0n ? -amount : amount)
+        })
+      }
+    }
 
     // Batch fetch V3 pool addresses (V1 markets)
     const poolAddrsResults = await options.api.multiCall({
@@ -183,23 +218,23 @@ async function fetch(options: FetchOptions): Promise<FetchResult> {
 
 const methodology = {
   Volume:
-    'Volume is calculated from Swap events on TrueMarkets prediction market pools. V1 markets use Uniswap V3 pools (USDC pairs), V2 markets use Uniswap V4 pools (TYD pairs). Only the stablecoin side of swaps is counted.',
-  Fees: 'Trading fees are tracked via PoolFeeTracked events from the FeeCollector contract (V4 pools only). Launchpad protocol fees (charged on proposal graduation and Live-phase withdrawals) are tracked via TYD transfers from the Launchpad to the fee receiver.',
+    'Volume is calculated from Swap events on TrueMarkets prediction market pools, enumerated from the active markets on TruthMarketManager. V1 markets use Uniswap V3 pools (USDC pairs), V2 markets use Uniswap V4 pools (TYD pairs). Only the stablecoin side of swaps is counted.',
+  Fees: 'Trading fees are tracked via PoolFeeTracked events from the FeeCollector contracts (V4 pools only; one per hook generation). Launchpad protocol fees (charged on proposal graduation and Live-phase withdrawals) are tracked via TYD transfers from the Launchpad to the fee receiver.',
   Revenue: 'All the trading fees (v4 pools only) and launchpad fees are considered revenue.',
   ProtocolRevenue: 'All the trading fees (v4 pools only) and launchpad fees are considered protocol revenue.',
 }
 
 const breakdownMethodology = {
   Fees: {
-    "Trading Fees": "Trading fees are tracked via PoolFeeTracked events from the FeeCollector contract (V4 pools only).",
+    "Trading Fees": "Trading fees are tracked via PoolFeeTracked events from the FeeCollector contracts (V4 pools only; one per hook generation).",
     "Launchpad Fees": "Launchpad protocol fees (charged on proposal graduation and Live-phase withdrawals) are tracked via TYD transfers from the Launchpad to the fee receiver.",
   },
   Revenue: {
-    "Trading Fees": "Trading fees are tracked via PoolFeeTracked events from the FeeCollector contract (V4 pools only).",
+    "Trading Fees": "Trading fees are tracked via PoolFeeTracked events from the FeeCollector contracts (V4 pools only; one per hook generation).",
     "Launchpad Fees": "Launchpad protocol fees (charged on proposal graduation and Live-phase withdrawals) are tracked via TYD transfers from the Launchpad to the fee receiver.",
   },
   ProtocolRevenue: {
-    "Trading Fees": "Trading fees are tracked via PoolFeeTracked events from the FeeCollector contract (V4 pools only).",
+    "Trading Fees": "Trading fees are tracked via PoolFeeTracked events from the FeeCollector contracts (V4 pools only; one per hook generation).",
     "Launchpad Fees": "Launchpad protocol fees (charged on proposal graduation and Live-phase withdrawals) are tracked via TYD transfers from the Launchpad to the fee receiver.",
   },
 }


### PR DESCRIPTION
## Problem

`dexs/truemarkets.ts` reports far too little volume for Trueo (listed here as TrueMarkets), and often exactly zero.

V4 pool ids were discovered from `PoolFeeTracked` events on a single hardcoded `FEE_COLLECTOR`, and the volume path ran only over whatever that discovery returned:

```ts
const feeTrackedLogs = await options.getLogs({ target: FEE_COLLECTOR, ... })
const v4PoolIdsFromFees = [...new Set(feeTrackedLogs.map((log) => log.poolId))]
if (v4PoolIdsFromFees.length > 0) { /* the entire v4 volume calculation */ }
```

I work on Trueo. We deploy a **dedicated FeeCollector per Uniswap v4 hook generation**, and the address in this file is the retired generation's — the current one is in our public [`network_config.json`](https://github.com/trueo-protocol/trueo-contracts/blob/main/network_config.json), which this file's own header comment links to. Pools on the current hook therefore never entered the volume calculation.

The failure is intermittent rather than a fixed undercount: some markets on the retired generation are still trading, so the reported figure is whatever that generation happened to do that day — sometimes a small number, often zero.

Verified on Base:

- `hook(0x3E83479B…11e0C4).feeCollector()` → `0x8C6c622A…20134F`, while this file used `0x39339E14…55d9D`
- `FeeCollector(0x39339E14…55d9D).hookAddress()` → `0x1cFeAD8E…740c4`, the retired hook
- `FeeCollector(0x8C6c622A…20134F).hookAddress()` → `0x3E83479B…11e0C4`, the hook every live pool uses
- `poolFeeAccumulated(poolId, TYD)` sampled across the market range: newer markets accrue only on the new collector, older markets only on the old

## Changes

- **v4 pool ids are enumerated from `TruthMarketManager`'s active markets via `getPoolIds()`** — already declared in the ABI here but never called — alongside the existing `getPoolAddresses()` lookup v1 markets use. Volume no longer depends on the fee configuration at all, so a future FeeCollector rotation, a protocol fee set to zero (the hook returns early and emits nothing), or a swap whose fee rounds to zero cannot silently zero it again.
- Swap logs are read in chunks with the pool ids OR'd into `topic1`, following the pattern in `dexs/fables.ts`. `poolKeys` is resolved only for pools that actually traded in the window rather than all ~880 of them.
- **Trading fees are read from every FeeCollector generation**, not one. A retired hook keeps charging until its markets resolve, so both are needed — swapping in only the new address would have dropped the old generation's fees.
- The header comment now points at the protocol's current public config repo (`trueo-protocol/trueo-contracts`); the old link still resolves but is no longer the canonical location.
- No other hardcoded address here is stale. I checked `TRUTH_MARKET_MANAGER` (`numberOfActiveMarkets()` responds and is still growing), `LAUNCHPAD_FEE_RECEIVER` (`launchpad.feeReceiver()` returns exactly that address), `TYD_TOKEN` (currency1 of the live pools) and the two Uniswap addresses.

## Testing

`npm test dexs truemarkets`, same 24h window (ending 2026-09-03T04:59:59Z):

| | volume | fees |
| --- | --- | --- |
| master | 0.00 | 50.00 (launchpad only; no trading fees at all) |
| this PR | 276.05 | 50.62 (launchpad 50 + trading 0.77) |

`npm run ts-check` passes.

## Note on naming

The protocol has rebranded from TrueMarkets to **Trueo**. Beyond the header comment above, I've left every identifier, filename and methodology string in this PR untouched so the fix stays reviewable on its own — happy to send the rename separately if you'd like it, and let me know whether the listing metadata needs a change on your side too.
