### PR TITLE
wisdomtree: read the 1 month t-bill yield from the treasury, hermes now needs an api key

### DIFF
--- a/fees/wisdomtree/index.ts
+++ b/fees/wisdomtree/index.ts
@@ -41,10 +41,29 @@ const onchainData: Record<string, Record<string, string>> = {
 
 const NASDAQ_API_URL = "https://api.nasdaq.com/api/quote";
 const STELLAR_API_URL = "https://api.stellar.expert/explorer/public/asset"
-const PYTH_1M_TBILL_YIELD_URL = "https://hermes.pyth.network/v2/updates/price/latest?ids%5B%5D=0x60076f4fc0dfd634a88b5c3f41e7f8af80b403ca365442b81e582ceb8fc421a2";
+//Pyth's Hermes endpoint started requiring an API key on 2026-08-26 and now answers 401, which took
+//this adapter down with it. The rate it served is the US 1 month T-bill yield, which the Treasury
+//publishes itself without a key, in percent, in the daily yield curve.
+const TREASURY_YIELD_CURVE_URL = (year: number) => `https://home.treasury.gov/resource-center/data-chart-center/interest-rates/daily-treasury-rates.csv/${year}/all?type=daily_treasury_yield_curve&field_tdr_date_value=${year}&page&_format=csv`;
 const headers = {
     "user-agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4430.212 Safari/537.36"
 };
+
+//Rows are newest first and the Treasury only publishes on business days, so the first one is the
+//latest available rate. The previous year is the fallback for the first days of January, before
+//that year's file has any rows.
+async function get1MonthTBillYield(year: number): Promise<number> {
+    for (const y of [year, year - 1]) {
+        const csv = await httpGet(TREASURY_YIELD_CURVE_URL(y), { headers, responseType: "text" });
+        const rows = String(csv).split("\n").filter(row => row.trim());
+        if (rows.length < 2) continue;
+        const column = rows[0].split(",").map(name => name.trim().replace(/"/g, "")).indexOf("1 Mo");
+        if (column < 0) continue;
+        const yieldPercent = Number(rows[1].split(",")[column]);
+        if (Number.isFinite(yieldPercent)) return yieldPercent;
+    }
+    throw new Error("Could not read the 1 month yield from the treasury daily yield curve");
+}
 
 async function prefetch(options: FetchOptions): Promise<any> {
     for (const [fund, fundDetails] of offChainData) {
@@ -102,8 +121,8 @@ async function prefetch(options: FetchOptions): Promise<any> {
                 fundDetails.nav = +(result.data.primaryData.lastSalePrice.slice(1));
             }
             if (fundDetails.type === "yield") {
-                const result = await httpGet(PYTH_1M_TBILL_YIELD_URL); //Money market yeilds are almost equivalent to tbill yields
-                fundDetails.netYield = result.parsed[0].price.price / 1e8;
+                //Money market yeilds are almost equivalent to tbill yields
+                fundDetails.netYield = await get1MonthTBillYield(new Date(options.startOfDay * 1000).getUTCFullYear());
             }
 
             if (fundDetails.type === "crypto") {


### PR DESCRIPTION
Part of #9088.

`fees/wisdomtree` has produced **no data point at all since 2026-08-26**. It reported $78,922 that day and had been steady at ~$78k/day before it:

```
$ curl -s "https://api.llama.fi/summary/fees/wisdomtree" | jq '{total24h,total30d}'
{ "total24h": null, "total30d": 1791909 }
last three non-zero days: 08-24 $78,444 | 08-25 $78,375 | 08-26 $78,922
```

## Cause

`prefetch` reads the 1-month T-bill yield from Pyth Hermes, with no fallback:

```ts
const result = await httpGet(PYTH_1M_TBILL_YIELD_URL);
fundDetails.netYield = result.parsed[0].price.price / 1e8;
```

Hermes began requiring an API key on 2026-08-26 and now answers **401 `unauthorized`** to everyone else:

```
$ curl -s -o /dev/null -w '%{http_code}' "https://hermes.pyth.network/v2/updates/price/latest?ids[]=0xe62df..."
401
```

The throw in `prefetch` takes the whole adapter down, which is why every chain disappears at once rather than reporting zero. `benchmarks.pyth.network` is gated the same way (401 on values; its open metadata does not list this feed), so there is no keyless Pyth route left.

Same cutover that #9164 just fixed for zest-v1/zest-v2. Those needed token prices and could move to `coins.llama.fi`; this one needs a rates feed, so it goes to the rate's own publisher instead.

## Fix

The US Treasury publishes that exact rate itself, keyless, in the daily yield curve, as the `1 Mo` column — and in percent, which is the unit this file already uses (the backfill branch assigns `netYield = 4.7` and the fee maths divides by 100).

## The two sources agree

Recomputing Ethereum WTGXX fees from the Treasury `1 Mo` rate and the token's own `totalSupply()` at each day's last block reproduces DefiLlama's published series:

| date | WTGXX supply (Ethereum) | Treasury 1 Mo | recomputed | published (all chains) |
|---|---:|---:|---:|---:|
| 2026-08-24 | 755,663,632 | 3.79 | **78,465** | **78,444** |
| 2026-08-25 | 754,813,633 | 3.79 | **78,377** | **78,375** |
| 2026-08-26 | 1,004,956,158 | 3.80 | 104,626 | 78,922 |

08-24 and 08-25 land inside **0.03%**, which is what pins the replacement to the feed it replaces. 08-26 is higher because WTGXX supply jumped from 754.8M to 1,005.0M during that day and the adapter samples supply at a point in time.

## Result

```
$ npx ts-node --transpile-only cli/testAdapter.ts fees wisdomtree

chain         | Daily fees | Daily revenue | Daily supply side revenue | Daily protocol revenue
arbitrum      | 1.18 k     | 77.00         | 1.10 k                    | 77.00
ethereum      | 126.50 k   | 8.26 k        | 118.24 k                  | 8.26 k
off_chain     | 1.15 k     | 1.15 k        | 0.00                      | 1.15 k
plume_mainnet | 0.00       | 0.00          | 0.00                      | 0.00
stellar       | 310.00     | 60.00         | 250.00                    | 60.00
Aggregate     | 129.13 k   | 9.54 k        | 119.59 k                  | 9.54 k

Management Fees   9,541
Assets Yields   119,593
```

$129.13k against $78.9k on the last published day is not the source: WTGXX supply on Ethereum has grown from 755,663,632 to 1,205,522,333 since 08-24.

## Notes

- Rows come newest-first and the Treasury only publishes on business days, so the first row is the latest available rate. The previous year is the fallback for the first days of January, before that year's file has rows.
- The year-scoped CSV is the only shape that serves: `/all/all` is 403 and the month-scoped and year-less paths return no rows.
- `fees/solstice-usx` is the last adapter still on Hermes. It needs the eUSX redemption *rate* rather than a market price, so it wants its own source and is not bundled here.
