### PR TITLE
satori oi: mark dead, same DNS-dead host as the volume leg that was already marked

### DIFF
--- a/open-interest/satori-oi.ts
+++ b/open-interest/satori-oi.ts
@@ -26,6 +26,11 @@ const adapter: SimpleAdapter = {
   fetch,
   start: '2023-05-13',
   runAtCurrTime: true,
+  // Same DNS-dead host as the volume leg, which was marked dead in daa93f11d. This leg kept
+  // reporting until 2026-07-07 because open interest was the last field the API still served.
+  // Satori's own vaults on Polygon zkEVM hold 0 USDC and the Ethereum ones were emptied on
+  // 2026-07-23, so there is no position left for it to report.
+  deadFrom: '2026-07-08',
 };
 
 export default adapter;


### PR DESCRIPTION
`open-interest/satori-oi.ts` reads `https://trade.satori.finance/api/data-center/pub/analytics/dashboard/integration`.

That is the same host as the volume leg, which was marked dead in `daa93f11d` with the note *"satori.finance + trade.satori.finance DNS-dead"*. The open-interest leg reads the same host and was left running, so it has been erroring on every run since. Its last published point is **2026-07-07 = $545,436**, and there has been nothing since.

## The host

`satori.finance`, `www.satori.finance` and `trade.satori.finance` all return **SERVFAIL** (DNS status 2) from both Cloudflare's and Google's resolvers — the delegation itself is broken, so nothing under that domain is reachable.

## The protocol

The volume leg's note dates the death from fees going to dust. The vaults say the same thing independently, and they are what this adapter is meant to be measuring:

| chain | vault | USDC balance now |
|---|---|---|
| Polygon zkEVM | `0x62e724cB…56940` | **0.000000** |
| Polygon zkEVM | `0xA59a2365…c2aBb` | **0.000000** |
| Linea | `0xfb371E70…18425` | 0.003129 |
| Scroll | `0xfb371E70…18425` | 0.002026 |
| Ethereum | `0x0857f8a6…bffde` | 0.49 |
| Arbitrum | `0x5aCCEb99…EEED7` | 0.00 |
| Base | `0x668a9711…d5aed` | 0.00 |

Polygon zkEVM is the only chain this adapter is configured for, and both of its vaults hold exactly zero.

The wind-down is visible in the transfers too: Arbitrum and Base were emptied on 2026-04-16/17, and the two Ethereum vaults sent out 23,127 and 310,769 USDC on **2026-07-23**, after which the only inbound transfers are dust airdrops. DefiLlama's own TVL for `satori-perp` is now $10,161 across fourteen chains, with Polygon zkEVM, Base, Arbitrum, zkSync Era, X Layer, Scroll, Zircuit, TON and Plume all at exactly $0.

## The date

`2026-07-08`, the day after this leg's last published point. The volume leg uses `2026-06-24` because that is when *fees* fell to dust; open interest was the last field the API still served, so the two legs stopped on different days and each is marked from its own.
