### PR TITLE
mark seven adapters dead whose only data source no longer resolves in DNS

### DIFF
--- a/dexs/blum/index.ts
+++ b/dexs/blum/index.ts
@@ -23,6 +23,9 @@ const adapter = {
       start: '2024-10-24',
     },
   },
+  // tonfunstats-eqnd7.ondigitalocean.app is NXDOMAIN, so this adapter has no host to query.
+  // Last published point 2025-10-31 ($93) and TVL reads 0.
+  deadFrom: '2025-11-01',
 }
 
 export default adapter

--- a/dexs/ponytaswap/index.ts
+++ b/dexs/ponytaswap/index.ts
@@ -27,6 +27,10 @@ const adapter: SimpleAdapter = {
   fetch,
   chains: [CHAIN.RPG],
   start: '2023-03-06',
+  // www.ponytaswap.finance and the ponytaswap.finance apex are both NXDOMAIN, so the only source
+  // this adapter has cannot answer. Last published point 2025-06-04, last non-zero 2024-12-27,
+  // and its TVL has read 0 since 2026-01-26.
+  deadFrom: '2025-06-05',
 };
 
 export default adapter;

--- a/dexs/rush/index.ts
+++ b/dexs/rush/index.ts
@@ -31,6 +31,9 @@ const adapter: SimpleAdapter = {
   chains: [CHAIN.SOLANA],
   start: "2025-11-07",
   methodology,
+  // stats.rushbot.io is NXDOMAIN and so is the rushbot.io apex. The adapter only ever produced
+  // 24 points, the last on 2025-12-01 ($11), and the protocol no longer reports TVL.
+  deadFrom: '2025-12-02',
 };
 
 export default adapter;

--- a/dexs/seiyan-fun/index.ts
+++ b/dexs/seiyan-fun/index.ts
@@ -23,6 +23,9 @@ const adapter = {
   fetch,
   chains: [CHAIN.SEI],
   start: SEIYAN_FUN_INITIAL_TIMESTAMP,
+  // seiyan.fun is NXDOMAIN, apex included, so there is no host left to query. Last published
+  // point 2025-07-02, last non-zero 2025-06-30 ($8), and the protocol no longer reports TVL.
+  deadFrom: '2025-07-03',
 };
 
 export default adapter;

--- a/dexs/utyabswap/index.ts
+++ b/dexs/utyabswap/index.ts
@@ -24,6 +24,9 @@ const adapter: any = {
       start: '2024-12-9',
     },
   },
+  // api.utyabswap.com is NXDOMAIN and the utyabswap.com apex resolves with no A record. Last
+  // published point 2025-08-26 ($1,994) and TVL is down to $6.
+  deadFrom: '2025-08-27',
 };
 
 export default adapter;

--- a/dexs/vanswap/index.ts
+++ b/dexs/vanswap/index.ts
@@ -23,6 +23,10 @@ const adapter: SimpleAdapter = {
   fetch,
   chains: [CHAIN.VISION],
   start: 1647302400,
+  // www.vanswap.org and the vanswap.org apex both SERVFAIL from Cloudflare and Google, i.e. the
+  // delegation itself is broken. Last published point 2024-12-09 ($7,798) and TVL fell from
+  // $3.16M to 0 on 2026-02-20.
+  deadFrom: '2024-12-10',
 };
 
 export default adapter;

--- a/options/arrow-markets/index.ts
+++ b/options/arrow-markets/index.ts
@@ -19,6 +19,10 @@ export const v2_adapter: SimpleAdapter = {
       start: '2024-02-08'
     },
   },
+  // api-rfq-testnet.prd.arrowmarkets.info is NXDOMAIN and the arrowmarkets.info apex resolves
+  // with no A record. It was also a testnet host, which is why every recent day it did answer
+  // came back as 0. Last non-zero 2026-05-23 ($26), TVL 0.
+  deadFrom: '2026-08-07',
 };
 
 


### PR DESCRIPTION
I resolved every hostname referenced in the repo — 1,396 distinct hosts across all `*.ts` files — against both Cloudflare's and Google's DNS-over-HTTPS resolvers. 93 of them no longer resolve. Filtering to adapters whose **only** data source is one of those hosts, that have no `deadFrom`, and that are currently publishing nothing, leaves the seven below.

Each one is unrecoverable rather than merely broken: there is no host left to query, so no retry, key or query change can bring it back.

| adapter | host it reads | host DNS | apex DNS | last published point | TVL now |
|---|---|---|---|---|---|
| `dexs/ponytaswap` | `www.ponytaswap.finance` | NXDOMAIN | NXDOMAIN | 2025-06-04 (last non-zero 2024-12-27) | $0 since 2026-01-26 |
| `dexs/seiyan-fun` | `seiyan.fun` | NXDOMAIN | NXDOMAIN | 2025-07-02 (last non-zero 2025-06-30, $8) | no longer reported |
| `dexs/rush` | `stats.rushbot.io` | NXDOMAIN | NXDOMAIN | 2025-12-01 ($11, 24 points ever) | no longer reported |
| `dexs/vanswap` | `www.vanswap.org` | SERVFAIL | SERVFAIL | 2024-12-09 ($7,798) | $3.16M → $0 on 2026-02-20 |
| `dexs/utyabswap` | `api.utyabswap.com` | NXDOMAIN | no A record | 2025-08-26 ($1,994) | $6 |
| `dexs/blum` | `tonfunstats-eqnd7.ondigitalocean.app` | NXDOMAIN | — | 2025-10-31 ($93) | $0 |
| `options/arrow-markets` | `api-rfq-testnet.prd.arrowmarkets.info` | NXDOMAIN | no A record | 2026-08-06 (last non-zero 2026-05-23, $26) | $0 |

SERVFAIL rather than NXDOMAIN means the delegation itself is broken — both resolvers agree, so it is the domain and not one resolver's view.

Two details worth calling out. `options/arrow-markets` was pointed at a **testnet** RFQ host, which is why the days it did still answer came back as `0`. And `dexs/vanswap`'s TVL going from $3.16M to zero on 2026-02-20 is independent of the DNS failure, so the protocol and not just the feed is gone.

Each `deadFrom` is the day after that adapter's own last published point, so no already-stored history is affected.

## Files I checked and deliberately did not include

`tonfunstats-eqnd7.ondigitalocean.app` is read by three adapters, not one — `dexs/blum`, `dexs/bigpump` and `dexs/tonpump`. All three are equally unable to fetch. I am only marking `blum`, whose TVL reads $0.

`bigpump` and `tonpump` still report TVL that updates daily off on-chain state ($12,170 and $1,782 as of 2026-09-03), so I can show this data source is dead but not that either protocol is, and marking a live protocol dead would replace a gap with a wrong zero. Both need a TON-side rebuild or a call from someone with more context than I have, which is a different change from this one.

I also excluded every other adapter on the 93-host list that either already carries `deadFrom`, still publishes through a second live source, or belongs to a protocol I could show is still alive.
