### PR TITLE
holdstation-defutures: disable the dead BSC leg and ask the API for the requested day

### DIFF
--- a/fees/holdstation-defutures.ts
+++ b/fees/holdstation-defutures.ts
@@ -1,7 +1,6 @@
 import fetchURL from "../utils/fetchURL";
 import { FetchOptions, SimpleAdapter } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
-import { getUniqStartOfTodayTimestamp } from "../helpers/getUniSubgraphVolume";
 
 const historicalVolumeBerachainEndpoint = (from: string, to: string) =>
 	`https://api-trading-bera.holdstation.com/api/fees/summary/internal?fromDate=${from}&toDate=${to}`;
@@ -48,13 +47,11 @@ const endpointMap: {
 const fetch = async (options: FetchOptions) => {
 	const { historical, daily } = endpointMap[options.chain];
 
-	const dayTimestamp = getUniqStartOfTodayTimestamp(
-		new Date(options.startTimestamp * 1000)
-	);
-	const fromTimestamp = new Date(dayTimestamp * 1000)
-		.toISOString()
-		.split("T")[0];
-	const toTimestamp = new Date((dayTimestamp + 60 * 60 * 24) * 1000)
+	// startTimestamp is one second before the day being requested, so flooring it to a day landed
+	// on the day before and the adapter asked the API for the wrong date. dateString is already the
+	// requested day.
+	const fromTimestamp = options.dateString;
+	const toTimestamp = new Date((options.startOfDay + 60 * 60 * 24) * 1000)
 		.toISOString()
 		.split("T")[0];
 
@@ -113,10 +110,12 @@ const adapter: SimpleAdapter = {
 			fetch,
 			start: "2025-06-04",
 		},
-		[CHAIN.BSC]: {
-			fetch,
-			start: "2025-09-03",
-		},
+		// bnbfutures.holdstation.com has been returning 502 on every path, the host root included,
+		// and its throw takes World Chain down with it. Last non-zero BSC fee day was 2026-05-05.
+		// [CHAIN.BSC]: {
+		// 	fetch,
+		// 	start: "2025-09-03",
+		// },
 	},
 	methodology,
 	breakdownMethodology,


### PR DESCRIPTION
`fees/holdstation-defutures` has published nothing at all since **2026-05-12**. Two separate defects, both in this file.

## 1. A dead chain leg is taking a live one down with it

The adapter is configured for World Chain and BSC. BSC reads `bnbfutures.holdstation.com`, which returns **502 Bad Gateway on every path, including the host root**:

```
/api/trading-history/volume-by-day?fromDate=2026-09-02&toDate=2026-09-02  -> 502
/api/fees/summary/internal?fromDate=2026-09-01&toDate=2026-09-03          -> 502
/api/trading-pairs/oi/sum                                                 -> 502
https://bnbfutures.holdstation.com/                                       -> 502
```

I probed it seven times over several hours; it is 502 every time, so this is the origin being down and not a transient. BSC's last non-zero fee day was 2026-05-05, which lines up.

`adapters/utils/runAdapter.ts` runs the chains under `await Promise.all(...)` and `getChainResult`'s catch rethrows, so one chain throwing discards **every** chain's record for that day. That is why the whole adapter is empty rather than just its BSC half.

World Chain is meanwhile completely healthy and trading:

```
$ curl 'https://worldfuture.holdstation.com/api/trading-history/volume-by-day?fromDate=2026-09-01&toDate=2026-09-01'
[{"date":"2026-09-01","volume":"235567.29","totalVolume":"386159774.95"}]

$ curl '...?fromDate=2026-09-02&toDate=2026-09-02'
[{"date":"2026-09-02","volume":"80388.01","totalVolume":"386240162.96"}]
```

$386.2M of cumulative volume, still moving day to day. Commenting the BSC leg out lets it through. That is how the Berachain leg in this same file was already handled, and it follows #9168, where the dfio leg was disabled rather than marked dead for exactly this reason.

## 2. It asks the API for the wrong day

`getUniqStartOfTodayTimestamp(new Date(options.startTimestamp * 1000))` looks like it floors the requested day, but `startTimestamp` is **one second before** it:

```
startOfDay      1788307200  2026-09-02T00:00:00.000Z
startTimestamp  1788307199  2026-09-01T23:59:59.000Z
old derivation  -> 2026-09-01     <- fetched
new derivation  -> 2026-09-02     <- requested
```

Since this API returns exactly the date range asked for (a single-day query returns that one day and nothing else), the adapter was reporting the previous day's number as the requested day's. `options.dateString` is already the requested day, so it replaces the whole derivation.

This only becomes visible once the adapter runs again, which is why it is in the same change: fixing the leg alone would restore the series shifted one day.

Local runs for the 2026-09-02 window, before and after:

```
before:  Daily volume: 235.57 k     <- 2026-09-01's figure
after:   Daily volume:  80.39 k     <- 2026-09-02's figure, matches the API exactly
```

## Notes

World Chain has no `historical` endpoint configured, so it reports `dailyFees` as `0` while its volume is real. That is pre-existing behaviour and I have left it alone rather than invent a fee source for it.

`open-interest/holdstation-defutures-oi.ts` reads the same 502 host and BSC is its only chain, so it has published nothing since 2026-05-13 (and its last five points were the same frozen $188,600). I have not touched it here: HoldStation's own site is up, so I can show this host is gone but not that their BSC perp product is, and that call is better made by someone with more context than guessed at from outside.
