### PR TITLE
mark six more adapters dead: the only data source is gone and the protocol site with it

### DIFF
--- a/dexs/claimswap/index.ts
+++ b/dexs/claimswap/index.ts
@@ -41,6 +41,9 @@ const adapter: SimpleAdapter = {
   fetch,
   chains: [CHAIN.KLAYTN],
   start: START_TIME,
+  // data-api.claimswap.org and the claimswap.org apex both SERVFAIL. Last published point
+  // 2026-04-27, last non-zero 2025-07-28 ($11,202).
+  deadFrom: '2026-04-28',
 };
 
 export default adapter;

--- a/dexs/jediswap-v2/index.ts
+++ b/dexs/jediswap-v2/index.ts
@@ -41,6 +41,9 @@ const adapter: SimpleAdapter = {
   fetch,
   chains: [CHAIN.STARKNET],
   start: '2024-02-10',
+  // api.v2.jediswap.xyz is NXDOMAIN and the jediswap.xyz apex resolves with no A record, so the
+  // app is gone too. Last published point 2025-07-30, last non-zero 2025-01-15 ($167).
+  deadFrom: '2025-07-31',
 };
 
 export default adapter;

--- a/dexs/pixelswap/index.ts
+++ b/dexs/pixelswap/index.ts
@@ -39,6 +39,9 @@ const adapter: any = {
             start: '2024-09-11',
         },
     },
+    // api.pixelswap.io and the pixelswap.io apex both SERVFAIL, so the delegation itself is broken.
+    // Last published point 2026-01-28, last non-zero 2024-12-06 ($510).
+    deadFrom: '2026-01-29',
 };
 
 export default adapter;

--- a/dexs/polkadex/index.ts
+++ b/dexs/polkadex/index.ts
@@ -22,7 +22,10 @@ const adapter: SimpleAdapter = {
       fetch: fetchVolume,
       start: '2024-01-03'
     }
-  }
+  },
+  // integration-api.polkadex.trade and the polkadex.trade apex both SERVFAIL. Last published
+  // point 2025-01-14 ($1).
+  deadFrom: '2025-01-15',
 };
 
 export default adapter;

--- a/dexs/swapline/index.ts
+++ b/dexs/swapline/index.ts
@@ -33,6 +33,9 @@ const adapter: SimpleAdapter = {
     [CHAIN.ARBITRUM]: fetchObject,
     [CHAIN.SHIMMER_EVM]: fetchObject,
   },
+  // Both API hosts and the swapline.com apex resolve with no A record. All four chains read the
+  // same two hosts, so none of them can report. Last published point 2024-06-03 ($18,388).
+  deadFrom: '2024-06-04',
 };
 
 export default adapter;

--- a/dexs/xpress/index.ts
+++ b/dexs/xpress/index.ts
@@ -46,6 +46,9 @@ const adapter: SimpleAdapter = {
   version: 1,
   fetch,
   chains: [CHAIN.SONIC],
+  // The subgraph host is up but answers `deployment u61208/s106679/latest does not exist`, and
+  // xpress.trade is NXDOMAIN, so there is nothing left to read. Last published point 2026-06-07.
+  deadFrom: '2026-06-08',
 };
 
 export default adapter;


### PR DESCRIPTION
Follow-up to #9203, from the same repo-wide DNS sweep. These six are the cases where **the data source and the protocol's own website are both gone** — so unlike a broken endpoint, there is nothing to repoint to and no app still using them.

Every DNS result below is from both Cloudflare's and Google's DoH resolvers, and they agree in every case.

| adapter | source it reads | source DNS | apex | apex DNS | last published point |
|---|---|---|---|---|---|
| `dexs/xpress` | `api.studio.thegraph.com/query/61208/onchain-clob-sonic` | host up, **deployment gone** | `xpress.trade` | NXDOMAIN | 2026-06-07 |
| `dexs/jediswap-v2` | `api.v2.jediswap.xyz` | NXDOMAIN | `jediswap.xyz` | NOERROR, 0 A records | 2025-07-30 (last non-zero 2025-01-15, $167) |
| `dexs/pixelswap` | `api.pixelswap.io` | SERVFAIL | `pixelswap.io` | SERVFAIL | 2026-01-28 (last non-zero 2024-12-06, $510) |
| `dexs/swapline` | `api.swapline.com` + `api-c.swapline.com` | NOERROR, 0 A records | `swapline.com` | NOERROR, 0 A records | 2024-06-03 ($18,388) |
| `dexs/claimswap` | `data-api.claimswap.org` | SERVFAIL | `claimswap.org` | SERVFAIL | 2026-04-27 (last non-zero 2025-07-28, $11,202) |
| `dexs/polkadex` | `integration-api.polkadex.trade` | SERVFAIL | `polkadex.trade` | SERVFAIL | 2025-01-14 ($1) |

`xpress` is the one that is not a DNS failure. Its Graph Studio host is perfectly healthy — it just no longer has the deployment:

```
$ curl -s -XPOST https://api.studio.thegraph.com/query/61208/onchain-clob-sonic/version/latest \
    -d '{"query":"{ _meta { block { number } } }"}'
{"errors":[{"message":"deployment `u61208/s106679/latest` does not exist"}]}
```

which together with `xpress.trade` being NXDOMAIN makes it the same situation as the rest.

The three DNS states are deliberately reported separately because they are different claims. **NXDOMAIN** means the name does not exist. **SERVFAIL** means the domain's own nameservers no longer answer, i.e. the delegation is broken. **NOERROR with zero A records** means the domain is still registered and its DNS is healthy, but it publishes no address — the registration outlived the deployment.

`dexs/swapline` is worth one note: it is configured for four chains (Fantom, Optimism, Arbitrum, Shimmer EVM), but all four share the same two hosts, so no single chain can still report and marking the adapter rather than a leg is correct here.

Each `deadFrom` is the day after that adapter's own last published point, so no stored history changes.
