### PR TITLE
mark three adapters dead whose Graph deployments no longer exist

### DIFF
--- a/dexs/swapbased-perps.ts
+++ b/dexs/swapbased-perps.ts
@@ -104,6 +104,9 @@ const adapter: SimpleAdapter = {
   fetch,
   chains: [CHAIN.BASE],
   start: "2023-07-09",
+  // The subgraph host is healthy but answers `deployment u67101/s62270/latest does not exist`.
+  // Open interest only ever produced six points, the last on 2023-11-13 ($164).
+  deadFrom: '2023-11-14',
 };
 
 export default adapter;

--- a/fees/metavault-v3/index.ts
+++ b/fees/metavault-v3/index.ts
@@ -54,6 +54,10 @@ const adapter: Adapter = {
   fetch,
   chains: [CHAIN.LINEA, CHAIN.SCROLL],
   start: '2024-03-01',
+  // Neither subgraph can answer: the Scroll one is gone (`deployment u55804/s43740/latest does not
+  // exist`) and the Linea one returns `indexing_error` to every query even though _meta responds.
+  // metavault-v3 is already marked dead in factory/uniSubgraph.ts for the same subgraph.
+  deadFrom: '2024-03-02',
   methodology: {
     Fees: "Fees collected from user trading fees",
   },

--- a/fees/metavault-v3/index.ts
+++ b/fees/metavault-v3/index.ts
@@ -57,7 +57,7 @@ const adapter: Adapter = {
   // Neither subgraph can answer: the Scroll one is gone (`deployment u55804/s43740/latest does not
   // exist`) and the Linea one returns `indexing_error` to every query even though _meta responds.
   // metavault-v3 is already marked dead in factory/uniSubgraph.ts for the same subgraph.
-  deadFrom: '2024-03-02',
+  deadFrom: '2024-11-20',
   methodology: {
     Fees: "Fees collected from user trading fees",
   },

--- a/fees/zeebu/index.ts
+++ b/fees/zeebu/index.ts
@@ -81,7 +81,9 @@ const adapter: SimpleAdapter = {
   },
   // Both subgraphs this adapter reads are gone: `deployment u89152/s85605/latest does not exist`
   // (BSC) and `u89152/s86401/latest` (Base). Each chain has exactly one source, so neither can run.
-  deadFrom: '2026-09-03',
+  // The runtime only stops an adapter when deadFrom is strictly before the previous day, so this is
+  // dated back rather than to today. This module has no published series to date the break from.
+  deadFrom: '2026-09-01',
 }
 
 export default adapter;

--- a/fees/zeebu/index.ts
+++ b/fees/zeebu/index.ts
@@ -79,6 +79,9 @@ const adapter: SimpleAdapter = {
     [CHAIN.BASE]: { start: 1728518400 },
     [CHAIN.BSC]: { start: 1688083200 },
   },
+  // Both subgraphs this adapter reads are gone: `deployment u89152/s85605/latest does not exist`
+  // (BSC) and `u89152/s86401/latest` (Base). Each chain has exactly one source, so neither can run.
+  deadFrom: '2026-09-03',
 }
 
 export default adapter;


### PR DESCRIPTION
I queried `{ _meta { block { number } } }` against every Graph Studio subgraph referenced anywhere in the repo — 26 of them. **16 return `deployment ... does not exist`.** Most of those adapters already carry `deadFrom` (lexer, amped, polter, quickswap-hydra, edebase). These three do not, and each one's dead deployment is its only way to get data.

| adapter | subgraph | result |
|---|---|---|
| `dexs/swapbased-perps` | `67101/swapbased-perps-core` | `deployment u67101/s62270/latest does not exist` |
| `fees/metavault-v3` (Scroll) | `55804/metavault-v3` | `deployment u55804/s43740/latest does not exist` |
| `fees/metavault-v3` (Linea) | `55804/linea-v3` | `_meta` answers, but every data query returns `indexing_error` |
| `fees/zeebu` (BSC) | `89152/fees_reward` | `deployment u89152/s85605/latest does not exist` |
| `fees/zeebu` (Base) | `89152/fees_reward_base` | `deployment u89152/s86401/latest does not exist` |

The host itself is fine in every case — `api.studio.thegraph.com` resolves and answers, it just no longer has these deployments. So this is not a transient outage and no retry or endpoint change recovers it.

`fees/metavault-v3` is the one worth a second look. Its Linea subgraph looks alive if you only check `_meta`:

```
$ curl -s -XPOST .../55804/linea-v3/version/latest -d '{"query":"{ _meta { block { number timestamp } } }"}'
{"data":{"_meta":{"block":{"number":31923382,...}}}}          # block from 2026-09-03

$ curl -s -XPOST .../55804/linea-v3/version/latest -d '{"query":"{ feeStats(where:{period:\"daily\"}, first: 20) { feeUsd } }"}'
{"errors":[{"message":"indexing_error"}]}
```

So both of its legs are unusable, not just Scroll's, and `metavault-v3` is already marked dead in `factory/uniSubgraph.ts` for the same subgraph — this file was missed. Metavault's own published history agrees the protocol is long gone: Metavault.Trade's last non-zero day is 2024-11-19 ($1) and Metavault Derivatives V2's is 2024-11-02 ($2).

`dexs/swapbased-perps` never really worked — open interest produced six points in total, the last on 2023-11-13 ($164) — so `deadFrom` is dated to the day after that. Note this is only SwapBased's **perps** adapter; SwapBased AMM and SwapBased Concentrated Liquidity are separate files, are healthy, and published $1,307 and $2,948 today. They are untouched.

Both zeebu chains lose their only source, so the adapter is dated from today rather than from a last-good day.

## Checked and deliberately excluded

- `fees/core-markets` (Blast, `62472/core-analytics-082`) — deployment is also gone, but the protocol still reports **$266,485** of TVL and I could not show it is dead, only that this subgraph is. Marking a live protocol dead would replace a gap with a wrong zero, so it needs a repoint or someone with more context, not this change.
- `fees/nuri-exchange-v2/bribes.ts` (`66247/nuri-cl`) — deployment gone, but `fees_bribes` is exported and never imported anywhere, so nothing calls it. Nuri CL itself is healthy and published $5,439 of volume today.
- `fees/ssv-network` (`88140/ssv-fee-tracker`) — deployment gone, but that subgraph is only read by `fetchLegacy`, which runs for days before the 2026-04-22 cSSV migration. Current days take the on-chain path and the adapter is publishing normally ($7,472 in the last 24h), so only historical backfill is affected.
