### PR TITLE
omni-exchange-flux: mark dead, all fourteen of its subgraphs return 404

### DIFF
--- a/dexs/omni-exchange-flux/index.ts
+++ b/dexs/omni-exchange-flux/index.ts
@@ -89,6 +89,9 @@ const adapter: SimpleAdapter = {
   fetch,
   adapter: flux_SUBGRAPHS,
   methodology,
+  // All fourteen subgraphs this adapter reads (a clamm and a bin one on each of the seven chains)
+  // return 404 from Goldsky, so no chain has a source left. Last published point 2026-02-10 ($58).
+  deadFrom: '2026-02-11',
 };
 
 export default adapter;


### PR DESCRIPTION
`dexs/omni-exchange-flux` reads two Goldsky subgraphs per chain — a CLAMM one and a bin one — across seven chains. **All fourteen return 404.**

```
project_cltceeuudv1ij01x7ekxhfl46/subgraphs/omni-clamm-{base,arbitrum,optimism,avalanche,sonic,bsc,plasma}/prod/gn   -> 404
project_cltceeuudv1ij01x7ekxhfl46/subgraphs/omni-bin-{base,arbitrum,optimism,avalanche,sonic,bsc,plasma}/prod/gn     -> 404
```

`api.goldsky.com` itself is healthy — 64 of the 101 Goldsky subgraphs referenced elsewhere in this repo answer `_meta` normally — so this is those specific deployments being gone, not an outage. Every chain in the config loses both of its sources, so there is no leg left that could still report.

The published series agrees the product wound down well before the subgraphs went: last point **2026-02-10 ($58)**, and each chain's last non-zero day is months earlier —

| chain | last non-zero |
|---|---|
| Plasma | 2025-10-10 |
| Sonic | 2025-10-12 |
| Avalanche | 2025-11-14 |
| BSC | 2025-11-22 |
| Arbitrum | 2025-12-14 |
| OP Mainnet | 2025-12-16 |
| Base | 2026-02-10 |

To be clear about scope: this is only Omni Exchange's **Flux** product. Omni Exchange V2 and V3 are separate adapters, are healthy, and both published today ($0 and $29 respectively) — they are untouched, and Omni Exchange itself is not being marked dead.

`deadFrom` is the day after this adapter's own last published point, so no stored history changes.
