### PR TITLE
kriya: rebuild AMM volume from its own swap events, the API and the site are both gone

### DIFF
--- a/dexs/kriya-dex/index.ts
+++ b/dexs/kriya-dex/index.ts
@@ -1,4 +1,4 @@
-import { FetchOptions, FetchResult, SimpleAdapter } from "../../adapters/types";
+import { Dependencies, FetchOptions, FetchResult, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 import { queryAllium } from "../../helpers/allium";
 
@@ -17,12 +17,8 @@ const inputCoin = (eventType: string) =>
 const fetch = async (options: FetchOptions): Promise<FetchResult> => {
     const dailyVolume = options.createBalances();
 
-    // Whole UTC day, half open. Kriya emits a few thousand swaps a day, which is more than the
-    // GraphQL RPC will page back through, so this reads the events from Allium the way
-    // queryEventsAllium in helpers/sui.ts does. The type is selected as well as the payload
-    // because the coin paid in is carried in the event's type parameter.
-    const start = new Date(options.startOfDay * 1000).toISOString();
-    const end = new Date((options.startOfDay + 86400) * 1000).toISOString();
+    const start = new Date(options.fromTimestamp * 1000).toISOString();
+    const end = new Date(options.toTimestamp * 1000).toISOString();
 
     const rows: { type: string, parsed_json: any }[] = await queryAllium(`
         SELECT type, parsed_json
@@ -41,7 +37,10 @@ const fetch = async (options: FetchOptions): Promise<FetchResult> => {
 };
 
 const adapter: SimpleAdapter = {
-    version: 1,
+    version: 2,
+    pullHourly: true,
+    dependencies: [Dependencies.ALLIUM],
+    isExpensiveAdapter: true,
     fetch,
     chains: [CHAIN.SUI],
     start: '2023-05-09',

--- a/dexs/kriya-dex/index.ts
+++ b/dexs/kriya-dex/index.ts
@@ -1,35 +1,53 @@
-import fetchURL from "../../utils/fetchURL"
 import { FetchOptions, FetchResult, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
-import { getUniqStartOfTodayTimestamp } from "../../helpers/getUniSubgraphVolume";
+import { queryAllium } from "../../helpers/allium";
 
-type IUrl = {
-    [s: string]: string;
-}
+// api.kriya.finance is NXDOMAIN and the kriya.finance apex resolves with no A record, so the
+// endpoint this adapter read is gone along with the site. The AMM itself is still trading, so
+// volume comes from the swap events its pools emit.
+const PACKAGE = "0xa0eba10b173538c8fecca1dff298e488402cc9ff374f8a12ca7758eebe830b66";
+const SWAP_EVENT = `${PACKAGE}::spot_dex::SwapEvent`;
 
-const url: IUrl = {
-    [CHAIN.SUI]: `https://api.kriya.finance/defillama/amm/`
-}
-
-interface IVolume {
-    dailyVolume: number,
-}
+// The event is emitted as SwapEvent<CoinIn>: its single type parameter is the coin that went INTO
+// the pool, which is what amount_in is denominated in. The payload carries no direction field, so
+// the type parameter is the only thing that identifies the side.
+const inputCoin = (eventType: string) =>
+    eventType.slice(eventType.indexOf("<") + 1, eventType.lastIndexOf(">")).trim();
 
 const fetch = async (options: FetchOptions): Promise<FetchResult> => {
-    const dayTimestamp = getUniqStartOfTodayTimestamp(new Date(options.startTimestamp * 1000));
-    const volumeUrl = `${url[options.chain]}?timestamp=${dayTimestamp}`;
-    const volume: IVolume = (await fetchURL(volumeUrl))?.data;
+    const dailyVolume = options.createBalances();
 
-    return {
-        dailyVolume: `${volume?.dailyVolume || 0}`
-    };
-}
+    // Whole UTC day, half open. Kriya emits a few thousand swaps a day, which is more than the
+    // GraphQL RPC will page back through, so this reads the events from Allium the way
+    // queryEventsAllium in helpers/sui.ts does. The type is selected as well as the payload
+    // because the coin paid in is carried in the event's type parameter.
+    const start = new Date(options.startOfDay * 1000).toISOString();
+    const end = new Date((options.startOfDay + 86400) * 1000).toISOString();
+
+    const rows: { type: string, parsed_json: any }[] = await queryAllium(`
+        SELECT type, parsed_json
+        FROM sui.raw.events
+        WHERE checkpoint_timestamp >= '${start}' AND checkpoint_timestamp < '${end}'
+          AND type LIKE '${SWAP_EVENT}<%'
+    `);
+
+    if (!rows.length)
+        throw new Error(`kriya: no ${SWAP_EVENT} rows for ${start}, refusing to report it as no volume`);
+
+    // Only the coin paid in is counted, so each swap is booked once rather than from both sides.
+    for (const row of rows) dailyVolume.add(inputCoin(row.type), row.parsed_json.amount_in);
+
+    return { dailyVolume };
+};
 
 const adapter: SimpleAdapter = {
     version: 1,
     fetch,
     chains: [CHAIN.SUI],
     start: '2023-05-09',
+    methodology: {
+        Volume: "Sum of the coin paid into each swap on Kriya's AMM pools, read from the spot_dex SwapEvent the pool emits. Each swap is counted once, on the side that was paid in.",
+    },
 };
 
 export default adapter;


### PR DESCRIPTION
Closes #9210.

`dexs/kriya-dex` has published nothing since **2026-04-28**. Its endpoint `api.kriya.finance/defillama/amm/` is NXDOMAIN and the `kriya.finance` apex resolves NOERROR with **zero A records**, so the site went with it (both checked against Cloudflare's and Google's DoH resolvers).

Everything about that says "mark it dead". **It isn't dead** — the AMM is still trading, so this reads volume from the pools' own swap events instead.

## The protocol is alive

```graphql
# https://graphql.mainnet.sui.io/graphql
{ events(last: 50, filter: {type: "0xa0eba10b…830b66::spot_dex::SwapEvent"}) {
    nodes { timestamp contents { json type { repr } } } } }
```

On **2026-09-03** the AMM emitted swaps continuously from 00:0x through 20:44. Over the fully covered 14:00–20:29 window (6.48 h, 600 swaps) I priced the input side with `coins.llama.fi` at **$4,323.18**, across **153 distinct swappers** with the busiest address at only 11.7% of swaps — real user flow, not one wallet cycling.

For contrast GeckoTerminal reports $163.69 of 24h volume for `kriya-dex`. Its per-pool TVLs match mine exactly (its USDC/SUI pool at $100,884 is the same pool where I measured 299 swaps / $3,557.50 in 6.5 h), so it has the pools right and the volume stale — its Kriya integration presumably stopped when the API did.

## Why the input side, and how that is known

The event is emitted as `SwapEvent<CoinIn>`, and the payload has **no direction field**:

```json
{"pool_id":"0x5af4976b…","user":"0x2129…","reserve_x":"49976716941",
 "reserve_y":"65037344332525","amount_in":"1498995000","amount_out":"1150368"}
```

so the single type parameter is the only thing identifying which side was paid in. I verified that rather than assuming it: for every consecutive pair of swaps on the same pool, I checked whether the reserve of the coin named in the type parameter moved by exactly `amount_in` and the other by exactly `-amount_out`, using each pool object's `Pool<CoinX, CoinY>` ordering. **585 of 588 pairs match exactly (99.5%)** — which also pins `reserve_x`/`reserve_y` as post-swap. The three that miss are pairs with a liquidity event in between.

Counting only the coin paid in books each swap once. That is the same convention `dexs/bluemove.ts` uses for its Sui swaps (`amount_x_in > 0 ? add(token_x_in) : add(token_y_in)`).

## Why Allium and not the GraphQL RPC

I wrote this on `queryEvents` from `helpers/sui.ts` first. It silently returns a fraction of the day, because the endpoint's backward pagination has a **traversal budget rather than a time limit** — `hasPreviousPage` goes false early, and non-deterministically (paging with `last: 10` stopped after 285 events, `last: 50` after 1,370).

Measured through the helper itself, one event type per row:

| event type | 2026-09-03 | 2026-09-01 | 2026-08-20 |
|---|---|---|---|
| kriya `spot_dex::SwapEvent` | 150 | **0** | **0** |
| waterx `events::PositionOpened` | 9 | 14 | 85 |
| typus-perp `position::OrderFilledEvent` | 1 | 1 | 1 |

So the helper is fine for its current callers — they emit few enough events that it pages back weeks. Kriya emits a few thousand a day and exhausts the budget inside one day, which would have shipped a silent ~90% undercount. `helpers/sui.ts` already says as much (*"graphql queryEvents doesn't retrieve historical events so we use allium for this"*), so this uses Allium, with the same `sui.raw.events` query shape as `queryEventsAllium` — selecting `type` as well as `parsed_json`, since the coin paid in lives in the type.

The empty-result guard is there so that an Allium outage surfaces instead of being published as a legitimate zero, which is what this adapter's previous silence looked like.

## One thing deliberately left alone

`dexs/kriya-clmm` is a different package (`0xf6c05e2d…`) and is **not** included. Its last `trade::SwapEvent` was **2026-08-12T14:22Z**; after that only `RemoveLiquidityEvent`, `ClosePositionEvent` and fee/reward collection through **2026-08-24**, and nothing at all since. Its event also has a real `x_for_y` field and no type parameters, so it needs a pool-to-coin-type map rather than this code path. Different evidence, different fix — it should not ride along on this one.

## CI

The `test` check fails with `Allium API Key is required[Ignore this error for github bot]` — the workflow sets no secrets, so this is the same situation as every Dune-backed adapter (#8970, #8524, #9104 all merged with `test: failure` and `ts-check: success`). `ts-check` passes.
