### PR TITLE
Orchard: add the v2 game contract to fees, revenue and volume (Robinhood Chain)

### DIFF
--- a/fees/orchard/index.ts
+++ b/fees/orchard/index.ts
@@ -1,49 +1,60 @@
 // Orchard — fees & revenue adapter.
 //
-// Orchard is a plot game on Robinhood Chain (chainId 4663). Players plant ETH on a
-// 5x5 grid; the ETH is swapped to AAPL (Apple stock token) inside the same transaction,
-// so the game is played in AAPL. Every 75s round one plot blooms and whoever planted
-// there splits the harvest from the other 24 plots.
+// Orchard is a plot game on Robinhood Chain (chainId 4663), played in AAPL (Apple stock
+// token). Players plant on a 5x5 grid; every 75s round one plot blooms and whoever planted
+// there splits the harvest from the other 24 plots. Two versions of the game contract run
+// side by side and are summed here:
 //
-// Contracts (Robinhood Chain):
-//   Orchard: 0xEbB8b167c0992cFdc497A995a8Cf7167acAA0A1A
-//   AAPL:    0xaF3D76f1834A1d425780943C99Ea8A608f8a93f9
+//   Orchard v1: 0xEbB8b167c0992cFdc497A995a8Cf7167acAA0A1A  (since 2026-07-22)
+//   Orchard v2: 0x86510b3df745C67a993A66CB08720Ed158d44549  (since 2026-09-03)
+//   AAPL:       0xaF3D76f1834A1d425780943C99Ea8A608f8a93f9
 //
 // Two fees are extracted, both in AAPL:
 //
-// 1. Admin fee, on every plant (Orchard._credit /._creditMany):
-//      adminCut = bought * adminFeeBps / BPS   (the configured rate; 1% at time of writing)
-//      stake    = bought - adminCut
-//    Withdrawn by the owner via collectAdmin(address) -> protocol revenue.
+// 1. Admin fee, withdrawn by the owner via collectAdmin(address) -> protocol revenue.
+//    - v1 takes it on every plant (Orchard._credit /._creditMany): the ETH is swapped to
+//      AAPL inside the plant transaction and adminCut = bought * adminFeeBps / BPS is carved
+//      out of it, so stake = bought - adminCut. Reconstructed per Planted event.
+//    - v2 takes it when the keeper seals a round (OrchardV2.seal): the whole round's ETH is
+//      swapped to AAPL at once and adminFeeBps is carved out of what was bought; plants made
+//      from a player's AAPL balance pay the same rate on their value, and batched plants pay
+//      an extra batchFeeBps (0 at time of writing) on top. All of it lands in adminAccrued,
+//      so it is measured exactly as the growth of adminAccrued over the window plus whatever
+//      collectAdmin withdrew inside it.
 //
-// 2. Rake, on every revealed round with a winner (Orchard._reveal):
+// 2. Rake, identical in both versions, on every revealed round with a winner (v1 _reveal,
+//    v2 _settle):
 //      lossPool = totalStake - winningStake
 //      rake     = lossPool * rakeBps / BPS     (10% today)
 //    split into stakers = rake * STAKERS_BPS / BPS (a fixed 10%, contract constant),
 //    jackpot = rake * jackpotBps / BPS (50% today), treasury = the remainder (40% today).
 //
-// rakeBps and jackpotBps are owner-adjustable and stored per round, so both are read
-// back from rounds(id) instead of being hardcoded — historical rounds keep their own rate.
-// adminFeeBps is likewise owner-adjustable; it is resolved per plant from the window's
-// opening value plus any AdminFeeBpsSet emitted inside the window.
+// rakeBps and jackpotBps are owner-adjustable and stored per round, so both are read back
+// from the round (v1 rounds(id), v2 getRound(id)) instead of being hardcoded — historical
+// rounds keep their own rate. v1's adminFeeBps is likewise owner-adjustable and is not
+// carried in the Planted events; it is resolved per plant from the window's opening value
+// plus any AdminFeeBpsSet emitted inside the window.
 //
-// Rounds where the blooming plot is empty settle through an early return in _reveal:
-// no rake is taken at all and the whole pot rolls into the jackpot, so they contribute
-// volume but no fees.
+// Rounds where the blooming plot is empty settle through an early return: no rake is taken
+// at all and the whole pot rolls into the jackpot, so they contribute volume but no fees.
 //
 // The 10% juice on claim(): NOT counted. It is a hardcoded constant that is recycled to
-// players who have not claimed yet (juiceIndex) — it never reaches protocol control, so
-// it is a player-to-player transfer rather than a fee.
+// players who have not claimed yet (juiceIndex; on v2 a slice is also reserved for v1
+// players bridging their harvest over) — it never reaches protocol control, so it is a
+// player-to-player transfer rather than a fee.
 
 import { Adapter, FetchOptions } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 import { getPositionedLogArgs } from "../../helpers/logs";
 
-const ORCHARD = "0xEbB8b167c0992cFdc497A995a8Cf7167acAA0A1A";
+const ORCHARD_V1 = "0xEbB8b167c0992cFdc497A995a8Cf7167acAA0A1A";
+const ORCHARD_V2 = "0x86510b3df745C67a993A66CB08720Ed158d44549";
+const ORCHARD_V2_DEPLOY_BLOCK = 53786732;
 const AAPL = "0xaF3D76f1834A1d425780943C99Ea8A608f8a93f9";
 
 const BPS = 10000n;
-const STAKERS_BPS = 1000n; // Orchard.STAKERS_BPS, a contract constant: 10% of the rake
+const STAKERS_BPS = 1000n; // Orchard.STAKERS_BPS, a contract constant in both versions: 10% of the rake
+const FLAG_AAPL = 1n; // OrchardV2.FLAG_AAPL: the entry was planted from the player's AAPL balance, not ETH
 
 const RAKE = "Rake";
 const ADMIN_FEE = "Admin Fee";
@@ -51,18 +62,36 @@ const JACKPOT = "Rake to Jackpot";
 const TREASURY_BUYBACK = "Rake to Buyback";
 const STAKING_REWARDS = "Rake to Stakers";
 
+// v1
 const PLANTED =
   "event Planted(address indexed player, uint256 indexed round, uint8 plot, uint256 ethIn, uint256 stake)";
 const PLANTED_MANY =
   "event PlantedMany(address indexed player, uint256 indexed startRound, uint16 roundCount, uint32 plotMask, uint256 ethIn, uint256 totalStake)";
-const REVEALED =
-  "event Revealed(uint256 indexed round, uint8 winningPlot, uint256 winningStake, uint256 netLossPool)";
 const ADMIN_FEE_BPS_SET = "event AdminFeeBpsSet(uint16 bps)";
-
 const ROUNDS_ABI =
   "function rounds(uint256) view returns (uint64 sealBlock, bool revealed, bool voided, uint8 winningPlot, uint16 rakeBps, uint16 jackpotBps, uint32 jackpotOdds, uint256 totalStake, uint256 winningStake, uint256 netLossPool, uint256 entryIndex, uint256 jackpotWon)";
 
-// Invert stake -> bought for the admin cut. The contract floors adminCut, so
+// v2
+const V2_PLANTED =
+  "event Planted(address indexed player, uint256 indexed round, uint32 plotMask, uint96 value, uint8 flags)";
+const ADMIN_COLLECTED = "event AdminCollected(address indexed to, uint256 aaplAmount)";
+const GET_ROUND_ABI =
+  "function getRound(uint256) view returns ((bytes32 root, uint96 totalEth, uint96 netAapl, uint64 sealBlock, uint96 totalStake, bool revealed, bool voided, uint8 winningPlot, uint16 rakeBps, uint16 adminFeeBps, uint16 batchFeeBps, uint16 jackpotBps, uint32 jackpotOdds, uint128 winningStake, uint128 netLossPool, uint256 entryIndex, uint256 jackpotWon))";
+
+// both
+const REVEALED =
+  "event Revealed(uint256 indexed round, uint8 winningPlot, uint256 winningStake, uint256 netLossPool)";
+
+type Ledger = {
+  dailyVolume: ReturnType<FetchOptions["createBalances"]>;
+  dailyFees: ReturnType<FetchOptions["createBalances"]>;
+  dailyRevenue: ReturnType<FetchOptions["createBalances"]>;
+  dailySupplySideRevenue: ReturnType<FetchOptions["createBalances"]>;
+  dailyHoldersRevenue: ReturnType<FetchOptions["createBalances"]>;
+  dailyProtocolRevenue: ReturnType<FetchOptions["createBalances"]>;
+};
+
+// Invert stake -> bought for the v1 admin cut. The contract floors adminCut, so
 // stake = bought - floor(bought * bps / BPS); start from the closed form and nudge
 // within the flooring error until the contract's math reproduces the emitted stake.
 const deriveAdminCut = (stake: bigint, bps: bigint): bigint => {
@@ -77,24 +106,56 @@ const deriveAdminCut = (stake: bigint, bps: bigint): bigint => {
   return candidate - stake;
 };
 
-const fetch = async (options: FetchOptions) => {
-  const dailyVolume = options.createBalances();
-  const dailyFees = options.createBalances();
-  const dailySupplySideRevenue = options.createBalances();
-  const dailyRevenue = options.createBalances();
-  const dailyHoldersRevenue = options.createBalances();
-  const dailyProtocolRevenue = options.createBalances();
+const addAdminFee = (ledger: Ledger, amount: bigint) => {
+  if (amount === 0n) return;
+  ledger.dailyFees.add(AAPL, amount, ADMIN_FEE);
+  ledger.dailyRevenue.add(AAPL, amount, ADMIN_FEE);
+  ledger.dailyProtocolRevenue.add(AAPL, amount, ADMIN_FEE);
+};
 
+// The rake and its three destinations, from the round state read back after the reveal.
+// The emitted netLossPool already has any jackpot payout folded in, which is why the round
+// is read instead of deriving the loss pool from the event. Same split in both versions.
+const addRake = (ledger: Ledger, rounds: any[]) => {
+  for (const round of rounds) {
+    const totalStake = BigInt(round.totalStake);
+    const winningStake = BigInt(round.winningStake);
+    // Empty blooming plot: the settle returns early, no rake is taken.
+    if (winningStake === 0n) continue;
+
+    const rake = ((totalStake - winningStake) * BigInt(round.rakeBps)) / BPS;
+    if (rake === 0n) continue;
+
+    const toStakers = (rake * STAKERS_BPS) / BPS;
+    const toJackpot = (rake * BigInt(round.jackpotBps)) / BPS;
+    const toTreasury = rake - toStakers - toJackpot;
+
+    ledger.dailyFees.add(AAPL, toStakers + toJackpot + toTreasury, RAKE);
+
+    // The jackpot is paid back out to players, so it is a cost of revenue.
+    ledger.dailySupplySideRevenue.add(AAPL, toJackpot, JACKPOT);
+
+    ledger.dailyRevenue.add(AAPL, toStakers, STAKING_REWARDS);
+    ledger.dailyRevenue.add(AAPL, toTreasury, TREASURY_BUYBACK);
+
+    // Both destinations end up with SEED holders: the stakers' cut is flushed to
+    // SeedStaking as AAPL yield, the treasury cut buys SEED back and burns it.
+    ledger.dailyHoldersRevenue.add(AAPL, toStakers, STAKING_REWARDS);
+    ledger.dailyHoldersRevenue.add(AAPL, toTreasury, TREASURY_BUYBACK);
+  }
+};
+
+const fetchV1 = async (options: FetchOptions, ledger: Ledger) => {
   // --- 1. plants: ETH wagered (volume) + the admin cut on the AAPL bought ---
   // adminFeeBps is owner-adjustable and is not carried in the Planted events, so the
   // configured rate is resolved per event: start from the value at the window's first
   // block and replay any AdminFeeBpsSet emitted inside the window on top of it. A rate
   // change mid-window therefore applies only to the plants that came after it.
   const startAdminFeeBps = BigInt(
-    await options.fromApi.call({ abi: "uint16:adminFeeBps", target: ORCHARD })
+    await options.fromApi.call({ abi: "uint16:adminFeeBps", target: ORCHARD_V1 })
   );
 
-  const feeChanges = (await getPositionedLogArgs(options, { target: ORCHARD, eventAbi: ADMIN_FEE_BPS_SET }))
+  const feeChanges = (await getPositionedLogArgs(options, { target: ORCHARD_V1, eventAbi: ADMIN_FEE_BPS_SET }))
     .map((log: any) => ({
       blockNumber: Number(log.blockNumber),
       logIndex: Number(log.logIndex),
@@ -116,79 +177,102 @@ const fetch = async (options: FetchOptions) => {
     return bps;
   };
 
-  const planted = await getPositionedLogArgs(options, { target: ORCHARD, eventAbi: PLANTED });
-  const plantedMany = await getPositionedLogArgs(options, { target: ORCHARD, eventAbi: PLANTED_MANY });
+  const planted = await getPositionedLogArgs(options, { target: ORCHARD_V1, eventAbi: PLANTED });
+  const plantedMany = await getPositionedLogArgs(options, { target: ORCHARD_V1, eventAbi: PLANTED_MANY });
 
   const addPlant = (log: any, stake: bigint) => {
-    dailyVolume.addGasToken(log.ethIn);
+    ledger.dailyVolume.addGasToken(log.ethIn);
     const bps = rateAt(Number(log.blockNumber), Number(log.logIndex));
-    const adminCut = deriveAdminCut(stake, bps);
-    dailyFees.add(AAPL, adminCut, ADMIN_FEE);
-    dailyRevenue.add(AAPL, adminCut, ADMIN_FEE);
-    dailyProtocolRevenue.add(AAPL, adminCut, ADMIN_FEE);
+    addAdminFee(ledger, deriveAdminCut(stake, bps));
   };
 
   for (const log of planted) addPlant(log, BigInt(log.stake));
   for (const log of plantedMany) addPlant(log, BigInt(log.totalStake));
 
-  // --- 2. reveals: the rake and its three destinations ---
-  // The emitted netLossPool already has any jackpot payout folded in, so the round
-  // state is read back instead of deriving the loss pool from the event.
-  const revealed = await options.getLogs({ target: ORCHARD, eventAbi: REVEALED });
+  // --- 2. reveals: the rake ---
+  const revealed = await options.getLogs({ target: ORCHARD_V1, eventAbi: REVEALED });
+  if (!revealed.length) return;
 
-  if (revealed.length) {
-    const rounds = await options.api.multiCall({
-      abi: ROUNDS_ABI,
-      target: ORCHARD,
-      calls: revealed.map((log: any) => ({ params: [log.round.toString()] })),
-    });
+  const rounds = await options.api.multiCall({
+    abi: ROUNDS_ABI,
+    target: ORCHARD_V1,
+    calls: revealed.map((log: any) => ({ params: [log.round.toString()] })),
+  });
+  addRake(ledger, rounds);
+};
 
-    for (const round of rounds) {
-      const totalStake = BigInt(round.totalStake);
-      const winningStake = BigInt(round.winningStake);
-      // Empty blooming plot: _reveal returns early, no rake is taken.
-      if (winningStake === 0n) continue;
+const fetchV2 = async (options: FetchOptions, ledger: Ledger) => {
+  const [fromBlock, toBlock] = await Promise.all([options.getFromBlock(), options.getToBlock()]);
+  if (toBlock < ORCHARD_V2_DEPLOY_BLOCK) return;
 
-      const rake = ((totalStake - winningStake) * BigInt(round.rakeBps)) / BPS;
-      if (rake === 0n) continue;
-
-      const toStakers = (rake * STAKERS_BPS) / BPS;
-      const toJackpot = (rake * BigInt(round.jackpotBps)) / BPS;
-      const toTreasury = rake - toStakers - toJackpot;
-
-      dailyFees.add(AAPL, toStakers + toJackpot + toTreasury, RAKE);
-
-      // The jackpot is paid back out to players, so it is a cost of revenue.
-      dailySupplySideRevenue.add(AAPL, toJackpot, JACKPOT);
-
-      dailyRevenue.add(AAPL, toStakers, STAKING_REWARDS);
-      dailyRevenue.add(AAPL, toTreasury, TREASURY_BUYBACK);
-
-      // Both destinations end up with SEED holders: the stakers' cut is flushed to
-      // SeedStaking as AAPL yield, the treasury cut buys SEED back and burns it.
-      dailyHoldersRevenue.add(AAPL, toStakers, STAKING_REWARDS);
-      dailyHoldersRevenue.add(AAPL, toTreasury, TREASURY_BUYBACK);
-    }
+  // --- 1. plants: what was wagered (volume). value is ETH, or AAPL when FLAG_AAPL is set ---
+  // Planted is emitted once per entry whatever the entry point (plant, plantMany,
+  // plantBatch, standing orders), so it is the single source for volume.
+  const planted = await options.getLogs({ target: ORCHARD_V2, eventAbi: V2_PLANTED });
+  for (const log of planted) {
+    if (BigInt(log.flags) & FLAG_AAPL) ledger.dailyVolume.add(AAPL, log.value);
+    else ledger.dailyVolume.addGasToken(log.value);
   }
 
+  // --- 2. seals: the admin fee ---
+  // Every admin-fee component of a seal (the cut on the AAPL bought for the round, the same
+  // rate on AAPL-denominated plants, the batch fee on batched plants) is added to
+  // adminAccrued, and collectAdmin is the only thing that ever decreases it. The fee taken
+  // inside the window is therefore the growth of adminAccrued plus the withdrawals, which
+  // captures the exact on-chain flooring without replaying the round's entry list.
+  // Consecutive windows share their boundary block, so the state delta covers
+  // (fromBlock, toBlock] and withdrawals emitted at fromBlock itself are left to the
+  // previous window.
+  const adminBefore =
+    fromBlock < ORCHARD_V2_DEPLOY_BLOCK
+      ? 0n
+      : BigInt(await options.fromApi.call({ abi: "uint256:adminAccrued", target: ORCHARD_V2 }));
+  const adminAfter = BigInt(await options.api.call({ abi: "uint256:adminAccrued", target: ORCHARD_V2 }));
+  const collected = (await getPositionedLogArgs(options, { target: ORCHARD_V2, eventAbi: ADMIN_COLLECTED }))
+    .filter((log: any) => Number(log.blockNumber) > fromBlock)
+    .reduce((sum: bigint, log: any) => sum + BigInt(log.aaplAmount), 0n);
+  addAdminFee(ledger, adminAfter - adminBefore + collected);
+
+  // --- 3. reveals: the rake ---
+  const revealed = await options.getLogs({ target: ORCHARD_V2, eventAbi: REVEALED });
+  if (!revealed.length) return;
+
+  const rounds = await options.api.multiCall({
+    abi: GET_ROUND_ABI,
+    target: ORCHARD_V2,
+    calls: revealed.map((log: any) => ({ params: [log.round.toString()] })),
+  });
+  addRake(ledger, rounds);
+};
+
+const fetch = async (options: FetchOptions) => {
+  const ledger: Ledger = {
+    dailyVolume: options.createBalances(),
+    dailyFees: options.createBalances(),
+    dailyRevenue: options.createBalances(),
+    dailySupplySideRevenue: options.createBalances(),
+    dailyHoldersRevenue: options.createBalances(),
+    dailyProtocolRevenue: options.createBalances(),
+  };
+
+  await fetchV1(options, ledger);
+  await fetchV2(options, ledger);
+
   return {
-    dailyVolume,
-    dailyFees,
-    dailyUserFees: dailyFees,
-    dailyRevenue,
-    dailySupplySideRevenue,
-    dailyHoldersRevenue,
-    dailyProtocolRevenue,
+    ...ledger,
+    dailyUserFees: ledger.dailyFees,
   };
 };
 
 const methodology = {
-  Volume: "Total ETH planted on the grid, taken from the Planted and PlantedMany events.",
+  Volume:
+    "Everything planted on the grid across both game versions: ETH from the v1 Planted and PlantedMany events, and ETH or AAPL from the v2 Planted events (v2 lets players plant from an AAPL balance).",
   Fees:
-    "Every plant pays an admin fee, at the configured adminFeeBps rate (1% at time of writing), on the AAPL bought with it. Every revealed round with a winner pays that round's configured rakeBps on the loss pool (the stakes on the 24 plots that did not bloom), split into a fixed 10% to SEED stakers (STAKERS_BPS, a contract constant), the round's configured jackpotBps share to the Golden Apple jackpot, and the remainder to the treasury. Rounds where the blooming plot is empty take no rake — the whole pot rolls into the jackpot.",
+    "Every plant pays an admin fee at the configured adminFeeBps rate (1% at time of writing) on the AAPL it buys — taken inside the plant on v1, and at the round's seal on v2 (where AAPL-denominated plants pay the same rate on their value and batched plants an extra batchFeeBps, 0 at time of writing). Every revealed round with a winner pays that round's configured rakeBps on the loss pool (the stakes on the 24 plots that did not bloom), split into a fixed 10% to SEED stakers (STAKERS_BPS, a contract constant), the round's configured jackpotBps share to the Golden Apple jackpot, and the remainder to the treasury. Rounds where the blooming plot is empty take no rake — the whole pot rolls into the jackpot.",
   UserFees: "Same as Fees — both the admin fee and the rake are paid by players out of what they planted.",
   Revenue: "Gross profit: the admin fee plus the stakers and treasury cuts of the rake. The jackpot cut is excluded because it is paid back out to players.",
-  ProtocolRevenue: "The admin fee taken on every plant at the configured adminFeeBps rate, withdrawn by the owner via collectAdmin.",
+  ProtocolRevenue:
+    "The admin fee, withdrawn by the owner via collectAdmin: reconstructed per plant on v1, and on v2 measured as the growth of adminAccrued over the window plus the amounts withdrawn inside it.",
   HoldersRevenue:
     "Value reaching SEED holders: the fixed 10% of each round's rake flushed to SeedStaking as AAPL yield for stakers, plus the treasury remainder that buys SEED back on the DEX and burns it.",
   SupplySideRevenue: "The round's configured jackpotBps share of its rake, routed to the Golden Apple jackpot and paid back out to players when it hits.",
@@ -196,12 +280,12 @@ const methodology = {
 
 const breakdownMethodology = {
   Fees: {
-    [ADMIN_FEE]: "The configured adminFeeBps share of the AAPL bought on every plant (Planted and PlantedMany events), resolved per event so rate changes apply only from the block they take effect.",
-    RAKE: "The rake taken on every revealed round with a winner.",
+    [ADMIN_FEE]: "The configured adminFeeBps share of the AAPL bought with every plant: per Planted/PlantedMany event on v1, and per sealed round on v2 (as the growth of adminAccrued plus collectAdmin withdrawals, which also carries the v2 batch fee).",
+    RAKE: "The rake taken on every revealed round with a winner, on both versions.",
   },
   UserFees: {
-    [ADMIN_FEE]: "The configured adminFeeBps share of the AAPL bought on every plant (Planted and PlantedMany events), resolved per event so rate changes apply only from the block they take effect.",
-    RAKE: "The rake taken on every revealed round with a winner.",
+    [ADMIN_FEE]: "The configured adminFeeBps share of the AAPL bought with every plant: per Planted/PlantedMany event on v1, and per sealed round on v2 (as the growth of adminAccrued plus collectAdmin withdrawals, which also carries the v2 batch fee).",
+    RAKE: "The rake taken on every revealed round with a winner, on both versions.",
   },
   Revenue: {
     [ADMIN_FEE]: "Admin fee on every plant, at the configured adminFeeBps rate.",


### PR DESCRIPTION
Orchard v2 went live on Robinhood Chain on 2026-09-03 (`0x86510b3df745C67a993A66CB08720Ed158d44549`, deployed at block 53786732). v1 (`0xEbB8b167c0992cFdc497A995a8Cf7167acAA0A1A`) stays open, so the adapter now sums both game contracts. The v1 path is unchanged, only moved into `fetchV1`; the rake split is shared by both versions.

How v2 differs and how it is measured:
- **Volume**: v2 emits one `Planted(player, round, plotMask, value, flags)` per entry whatever the entry point (single plant, many rounds, batched, standing orders). `value` is ETH, or AAPL when `FLAG_AAPL` is set (v2 lets players plant from an AAPL balance), and is added as such.
- **Admin fee**: v1 takes it inside each plant, so it is reconstructed per event as before. v2 takes it when the keeper seals the round: the round's ETH is swapped to AAPL at once and `adminFeeBps` is carved out of what was bought; AAPL-denominated entries pay the same rate on their value and batched entries an extra `batchFeeBps` (0 today). All of it is added to `adminAccrued`, and `collectAdmin` is the only thing that decreases it, so the fee taken inside the window is the growth of `adminAccrued` between the window's blocks plus any `AdminCollected` inside it (withdrawals at the shared boundary block are left to the previous window). This reproduces the contract's own flooring exactly without replaying each round's entry list. Before the deploy block the opening value is taken as 0 instead of calling a contract that does not exist yet.
- **Rake**: identical formula and split in both versions (`rakeBps` on the loss pool → fixed 10% to SEED stakers, `jackpotBps` to the jackpot, remainder to the treasury), read back per revealed round from `getRound(id)` on v2 as it is from `rounds(id)` on v1. Empty blooming plots take no rake, as before.
- The 10% claim juice is still not counted: on v2 part of it is reserved for v1 players bridging their harvest over, but it never reaches protocol control either way.

Validated locally with `npm run test fees orchard 1788480000` (the 2026-09-03 UTC day, the launch day of v2): volume $441, fees $43 (admin fee $4.38, rake $39), revenue $24, protocol revenue $4.38, supply-side $19, holders $19. The admin fee figure was checked against the chain: it is exactly the v2 `adminAccrued` at the window's end block (0.011865 AAPL, no withdrawals yet) plus the ten v1 plants of the day (0.001482 AAPL), at the AAPL price DefiLlama had for that day. No dependency or lockfile changes.
