### PR TITLE
cellana: rebuild volume and fees from its own swap events, the API and the site are both gone

### DIFF
--- a/dexs/cellana-finance/index.ts
+++ b/dexs/cellana-finance/index.ts
@@ -1,49 +1,68 @@
-import { httpGet } from "../../utils/fetchURL";
-import { SimpleAdapter, FetchOptions } from "../../adapters/types";
+import { Dependencies, FetchOptions, FetchResult, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
-//API
-const config_rule = {
-    headers: {
-        'user-agent': 'axios/1.6.7'
-    },
-    withCredentials: true
-}
-const cellanaDappUrl = 'https://api.cellana.finance/api/v1/tool/trading-volume-chart?timeframe=';
+import { queryDuneSql } from "../../helpers/dune";
+import { view } from "../../helpers/aptos";
 
-const dayEndpoint = (endTimestamp: number, timeframe: string) =>
-    cellanaDappUrl + timeframe + `&endTimestamp=${endTimestamp}`
+// api.cellana.finance is NXDOMAIN and the cellana.finance apex resolves with no A record, so the
+// dapp endpoint this adapter read is gone along with the site. The pools are still trading, mostly
+// routed in by aggregators, so volume and fees are read from the swap events they emit.
+const CELLANA = "0x4bf51972879e3b95c4781a5cdcb9e1ee24ef483e7d22f2d903626f126df62bd1";
+const SWAP_EVENT = `${CELLANA}::liquidity_pool::SwapEvent`;
+const BPS = 10000;
 
-interface IVolumeall {
-    value: number;
-    timestamp: string;
-}
+const fetch = async (options: FetchOptions): Promise<FetchResult> => {
+    const dailyVolume = options.createBalances();
+    const dailyFees = options.createBalances();
 
-const fetch = async (options: FetchOptions) => {
-    const dayVolumeQuery = (await httpGet(dayEndpoint(options.toTimestamp, "VOLUME_1H"), config_rule)).data;
-    const dailyVolume = dayVolumeQuery.reduce((partialSum: number, a: IVolumeall) => partialSum + a.value, 0);
+    // The event names the coin paid in and the amount, so a swap is booked once from the side it
+    // was paid in on rather than from both legs.
+    const rows: { pool: string, from_token: string, amount_in: number }[] = await queryDuneSql(options, `
+        SELECT json_extract_scalar(data, '$.pool') AS pool,
+               json_extract_scalar(data, '$.from_token') AS from_token,
+               sum(cast(json_extract_scalar(data, '$.amount_in') AS double)) AS amount_in
+        FROM aptos.events
+        WHERE TIME_RANGE
+          AND event_type = '${SWAP_EVENT}'
+          AND tx_success = true
+        GROUP BY 1, 2
+    `);
 
+    // Each pool sets its own rate and the fee is taken off the amount paid in: for a pool whose
+    // swap_fee_bps is 10, get_amount_out reports a fee of exactly amount_in / 1000 on either side.
+    // A day touches a couple of dozen pools, so this is one call per pool that actually traded.
+    const pools = [...new Set(rows.map((row) => row.pool))];
+    const feeBps: Record<string, number> = {};
+    await Promise.all(pools.map(async (pool) => {
+        const [bps] = await view(`${CELLANA}::liquidity_pool::swap_fee_bps`, [], [pool]);
+        feeBps[pool] = Number(bps);
+    }));
 
-    const dayFeesQuery = (await httpGet(dayEndpoint(options.toTimestamp, "FEE_1H"), config_rule)).data;
-    const dailyFees = dayFeesQuery.reduce((partialSum: number, a: IVolumeall) => partialSum + a.value, 0);
-    const dailyProtocolRevenue = 0;
-    const dailyHoldersRevenue = dailyFees;
+    for (const row of rows) {
+        dailyVolume.add(row.from_token, row.amount_in);
+        dailyFees.add(row.from_token, row.amount_in * feeBps[row.pool] / BPS);
+    }
 
     return {
         dailyVolume,
         dailyFees,
         dailyRevenue: dailyFees,
-        dailyProtocolRevenue,
-        dailyHoldersRevenue,
+        dailyProtocolRevenue: 0,
+        dailyHoldersRevenue: dailyFees,
     };
 };
 
-
 const adapter: SimpleAdapter = {
-    adapter: {
-        [CHAIN.APTOS]: {
-            fetch,
-            start: '2024-02-28'
-        },
+    version: 1,
+    fetch,
+    chains: [CHAIN.APTOS],
+    start: '2024-02-28',
+    dependencies: [Dependencies.DUNE],
+    methodology: {
+        Volume: "Sum of the coin paid into each swap on Cellana's pools, from the liquidity_pool SwapEvent. Each swap is counted once, on the side it was paid in on.",
+        Fees: "Swap fees, taken off the amount paid in at each pool's own swap_fee_bps.",
+        Revenue: "All swap fees, which on Cellana go to veCELL voters rather than the protocol.",
+        ProtocolRevenue: "Cellana keeps no share of swap fees.",
+        HoldersRevenue: "All swap fees are distributed to veCELL voters.",
     },
 };
 

--- a/dexs/cellana-finance/index.ts
+++ b/dexs/cellana-finance/index.ts
@@ -1,7 +1,7 @@
 import { Dependencies, FetchOptions, FetchResult, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 import { queryDuneSql } from "../../helpers/dune";
-import { view } from "../../helpers/aptos";
+import { getVersionFromTimestamp, view } from "../../helpers/aptos";
 
 // api.cellana.finance is NXDOMAIN and the cellana.finance apex resolves with no A record, so the
 // dapp endpoint this adapter read is gone along with the site. The pools are still trading, mostly
@@ -16,10 +16,12 @@ const fetch = async (options: FetchOptions): Promise<FetchResult> => {
 
     // The event names the coin paid in and the amount, so a swap is booked once from the side it
     // was paid in on rather than from both legs.
-    const rows: { pool: string, from_token: string, amount_in: number }[] = await queryDuneSql(options, `
+    // amount_in is a u64 and can exceed what a double represents exactly, so it is summed as a
+    // 38 digit decimal and returned as text; Balances.add takes the string unrounded.
+    const rows: { pool: string, from_token: string, amount_in: string }[] = await queryDuneSql(options, `
         SELECT json_extract_scalar(data, '$.pool') AS pool,
                json_extract_scalar(data, '$.from_token') AS from_token,
-               sum(cast(json_extract_scalar(data, '$.amount_in') AS double)) AS amount_in
+               cast(sum(cast(json_extract_scalar(data, '$.amount_in') AS decimal(38,0))) AS varchar) AS amount_in
         FROM aptos.events
         WHERE TIME_RANGE
           AND event_type = '${SWAP_EVENT}'
@@ -30,16 +32,21 @@ const fetch = async (options: FetchOptions): Promise<FetchResult> => {
     // Each pool sets its own rate and the fee is taken off the amount paid in: for a pool whose
     // swap_fee_bps is 10, get_amount_out reports a fee of exactly amount_in / 1000 on either side.
     // A day touches a couple of dozen pools, so this is one call per pool that actually traded.
+    // The rate is mutable (set_pool_swap_fee), so it is read at the end of the day being requested
+    // rather than at head. Public Aptos fullnodes prune state after about ten days and answer 410
+    // for older versions, so for anything past that the current rate is the only one obtainable.
+    const version = await getVersionFromTimestamp(new Date(options.endTimestamp * 1000)).catch(() => undefined);
     const pools = [...new Set(rows.map((row) => row.pool))];
     const feeBps: Record<string, number> = {};
     await Promise.all(pools.map(async (pool) => {
-        const [bps] = await view(`${CELLANA}::liquidity_pool::swap_fee_bps`, [], [pool]);
+        const readFee = (ledgerVersion?: number) => view(`${CELLANA}::liquidity_pool::swap_fee_bps`, [], [pool], ledgerVersion);
+        const [bps] = version === undefined ? await readFee() : await readFee(version).catch(() => readFee());
         feeBps[pool] = Number(bps);
     }));
 
     for (const row of rows) {
         dailyVolume.add(row.from_token, row.amount_in);
-        dailyFees.add(row.from_token, row.amount_in * feeBps[row.pool] / BPS);
+        dailyFees.add(row.from_token, (BigInt(row.amount_in) * BigInt(feeBps[row.pool]) / BigInt(BPS)).toString());
     }
 
     return {

--- a/dexs/cellana-finance/index.ts
+++ b/dexs/cellana-finance/index.ts
@@ -64,6 +64,7 @@ const adapter: SimpleAdapter = {
     chains: [CHAIN.APTOS],
     start: '2024-02-28',
     dependencies: [Dependencies.DUNE],
+    isExpensiveAdapter: true,
     methodology: {
         Volume: "Sum of the coin paid into each swap on Cellana's pools, from the liquidity_pool SwapEvent. Each swap is counted once, on the side it was paid in on.",
         Fees: "Swap fees, taken off the amount paid in at each pool's own swap_fee_bps.",


### PR DESCRIPTION
Closes #9213.

`dexs/cellana-finance` has published exactly `0` since **2026-04-11**. Its endpoint `api.cellana.finance/api/v1/tool/trading-volume-chart` is NXDOMAIN and the `cellana.finance` apex resolves NOERROR with **zero A records**, so the site went with it (both checked against Cloudflare's and Google's resolvers).

That reads like a dead protocol. It isn't — the pools are still trading, so this reads volume and fees from the swap events they emit.

## The protocol is alive

`liquidity_pool::all_pool_addresses` returns **270 pools**. Asking the Aptos indexer for one busy pool's latest transactions gives six versions all on **2026-09-03 between 21:22 and 21:25 UTC**, and reading those back from `/v1/transactions/by_version/…` they carry `liquidity_pool::SwapEvent`s whose entry functions show the flow now arrives through aggregators rather than Cellana's own front end:

```
0x…::panora_swap::router_entry
0x…::executor::execute_flash_route_coin
0x…::aave_gate::run
```

which is exactly what a DEX with a dead website and live pools looks like.

## Volume

The event is self-describing, so no pool-to-token map and no direction inference is needed:

```json
{"pool":"0x234f0be5…","from_token":"0x1::aptos_coin::AptosCoin",
 "to_token":"0xf22bede2…::asset::USDC","amount_in":"3122256822","amount_out":"19022107"}
```

Counting only `from_token`/`amount_in` books each swap once, on the side it was paid in on — the same convention `dexs/bluemove.ts` uses for its Sui swaps.

## Fees

Each pool sets its own rate, and the fee is taken off the amount paid in. `swap_fee_bps` for pool `0x234f0be5…` is `10`, and `get_amount_out` confirms what that means rather than leaving it to assumption — the returned fee is exactly `amount_in / 1000` on **either** side of the pool:

```
get_amount_out(pool, 0x50fdfa97…, 1000000)   -> out=167455003  fee=1000     (10.0000 bps)
get_amount_out(pool, 0x50fdfa97…, 100000000) -> out=16710481527 fee=100000  (10.0000 bps)
get_amount_out(pool, 0xedc2704f…, 1000000)   -> out=5959       fee=1000     (10.0000 bps)
get_amount_out(pool, 0xedc2704f…, 100000000) -> out=595961     fee=100000   (10.0000 bps)
```

A day touches only a couple of dozen pools (23 on 2026-09-02, 29 across three days) out of the 270, so the rate is read once per pool that actually traded. The revenue split is unchanged from the previous version — Cellana is ve(3,3), swap fees go to veCELL voters, so `protocolRevenue` stays 0 and `holdersRevenue` is the whole fee.

## Result

Run locally against Dune for three days:

| requested day | volume | fees |
|---|---|---|
| 2026-09-02 | $23.61k | $20.00 |
| 2026-09-01 | $16.79k | $15.00 |
| 2026-08-30 | $9.00k | $7.98 |

Cross-checked independently: querying `aptos.events` directly for 2026-09-02 gives **6,117 swaps** and **$23,649.80** of input-side volume, against the adapter's $23.61k — the small gap is the framework pricing at the day's historical prices where my check used current ones.

## Why Allium/Dune rather than a node

The Aptos indexer's `events` table is **deprecated** — it now answers *"Request for Deprecated Resource: events … Events v1 table deprecation and end of support September 8th"* — and the schema has no event query field left at all. Walking `/transactions/by_version/…` per pool is not viable for a day. Dune's `aptos.events` still carries them, and `queryDuneSql` is already the repo's path for this.

## CI

The `test` check fails with `DUNE_API_KEYS environment variable is not set`; the workflow sets no secrets, so every Dune-backed adapter does this (#8970, #8524 and #9104 all merged with `test: failure` and `ts-check: success`). `ts-check` passes, and the table above is a real local run with a key.
