### PR TITLE
solstice: read distributed yield on-chain, Pyth Hermes now requires an API key

### DIFF
--- a/fees/solstice-usx/index.ts
+++ b/fees/solstice-usx/index.ts
@@ -9,10 +9,11 @@ import { METRIC } from "../../helpers/metrics";
 // rate multiplied by supply; the protocol distributes that yield on-chain instead, so the transfer
 // is read directly and no rate feed is needed.
 //
-// Solstice's yield account emits a TransferInYield event on each DistributeYield call. Its payload
+// Solstice's yield program emits a TransferInYield event on each DistributeYield call. Its payload
 // carries the USX amount handed to the eUSX backing account, which is exactly the yield accrued to
-// eUSX holders for the period.
-const YIELD_ACCOUNT = "HARVSXaBpt1TuD4PvqnscCQLzAWgDzGpkDadr76a489L";
+// eUSX holders for the period; the amount reconciles with the USX token balance delta the same
+// transaction records.
+const YIELD_PROGRAM = "HARVSXaBpt1TuD4PvqnscCQLzAWgDzGpkDadr76a489L";
 const USX = "6FrrzDk5mQARGc1TDYoyVnSyRdds1t4PbtohCD6p3tgG";
 const TRANSFER_IN_YIELD_DISCRIMINATOR = "3983162e2b54bd7a";
 // Anchor lays the event out as an 8 byte discriminator then its fields; the transferred USX amount
@@ -22,10 +23,22 @@ const AMOUNT_OFFSET = 72;
 const FEES_YIELD_LABEL = METRIC.ASSETS_YIELDS;
 const SUPPLY_SIDE_YIELD_LABEL = 'eUSX Yield To Holders';
 
+// Every signature in the window is fetched, so one transient failure would otherwise take the whole
+// day down with it. The error is still raised once the attempts are spent rather than turned into a
+// missing distribution.
 const rpc = async (method: string, params: any[]) => {
-    const { data } = await axios.post(getEnv('SOLANA_RPC'), { jsonrpc: "2.0", id: 1, method, params });
-    if (data.error) throw new Error(`solstice: solana rpc ${method} failed: ${JSON.stringify(data.error)}`);
-    return data.result;
+    let lastError: any;
+    for (let attempt = 0; attempt < 3; attempt++) {
+        try {
+            const { data } = await axios.post(getEnv('SOLANA_RPC'), { jsonrpc: "2.0", id: 1, method, params });
+            if (data.error) throw new Error(`solstice: solana rpc ${method} failed: ${JSON.stringify(data.error)}`);
+            return data.result;
+        } catch (e) {
+            lastError = e;
+            await new Promise(resolve => setTimeout(resolve, 500 * (attempt + 1)));
+        }
+    }
+    throw lastError;
 };
 
 // The yield account is only touched by these distributions, a couple of transactions a day, so
@@ -34,7 +47,7 @@ const signaturesInWindow = async (fromTimestamp: number, toTimestamp: number) =>
     const signatures: string[] = [];
     let before: string | undefined;
     while (true) {
-        const page = await rpc("getSignaturesForAddress", [YIELD_ACCOUNT, before ? { limit: 1000, before } : { limit: 1000 }]);
+        const page = await rpc("getSignaturesForAddress", [YIELD_PROGRAM, before ? { limit: 1000, before } : { limit: 1000 }]);
         if (!page?.length) break;
         for (const entry of page) {
             if (entry.blockTime >= fromTimestamp && entry.blockTime < toTimestamp && !entry.err) signatures.push(entry.signature);
@@ -48,15 +61,32 @@ const signaturesInWindow = async (fromTimestamp: number, toTimestamp: number) =>
     return signatures;
 };
 
+// A distribution is a chain of cross program invocations, so the transaction's logs carry data from
+// several programs and a signature only proves the yield program was touched somewhere. Invocations
+// nest, so the program a log belongs to is the innermost frame still open, tracked as a stack; only
+// the frames the yield program itself is executing in can carry its events.
+const yieldProgramEvents = (logs: string[]) => {
+    const events: Buffer[] = [];
+    const frames: string[] = [];
+    for (const log of logs) {
+        const invoked = log.match(/^Program (\S+) invoke \[\d+\]$/);
+        if (invoked) { frames.push(invoked[1]); continue; }
+        if (/^Program \S+ (success|failed)/.test(log)) { frames.pop(); continue; }
+        const emitted = log.match(/^Program data: (\S+)$/);
+        if (emitted && frames[frames.length - 1] === YIELD_PROGRAM)
+            events.push(Buffer.from(emitted[1], "base64"));
+    }
+    return events;
+};
+
 const yieldFromTransaction = async (signature: string) => {
     const tx = await rpc("getTransaction", [signature, { encoding: "jsonParsed", maxSupportedTransactionVersion: 0 }]);
-    // A null result means the node could not serve the transaction, not that it distributed nothing;
-    // treating it as zero would quietly understate the day.
-    if (!tx) throw new Error(`solstice: solana rpc returned no transaction for ${signature}`);
+    // No transaction, or one without metadata, means the node could not serve the logs, not that
+    // nothing was distributed; treating either as zero would quietly understate the day.
+    if (!tx?.meta?.logMessages)
+        throw new Error(`solstice: solana rpc returned no transaction logs for ${signature}`);
     let amount = 0;
-    for (const log of (tx?.meta?.logMessages ?? [])) {
-        if (!log.includes("Program data:")) continue;
-        const event = Buffer.from(log.split("Program data:")[1].trim(), "base64");
+    for (const event of yieldProgramEvents(tx.meta.logMessages)) {
         if (event.length < AMOUNT_OFFSET + 8) continue;
         if (event.subarray(0, 8).toString("hex") !== TRANSFER_IN_YIELD_DISCRIMINATOR) continue;
         amount += Number(event.readBigUInt64LE(AMOUNT_OFFSET));

--- a/fees/solstice-usx/index.ts
+++ b/fees/solstice-usx/index.ts
@@ -39,7 +39,10 @@ const signaturesInWindow = async (fromTimestamp: number, toTimestamp: number) =>
         for (const entry of page) {
             if (entry.blockTime >= fromTimestamp && entry.blockTime < toTimestamp && !entry.err) signatures.push(entry.signature);
         }
-        if (page[page.length - 1].blockTime < fromTimestamp || page.length < 1000) break;
+        // A signature whose blockTime is still null has not been timestamped yet, so the page says
+        // nothing about whether the window is covered; keep paging rather than stopping short of it.
+        const oldest = [...page].reverse().find((entry: any) => typeof entry.blockTime === "number");
+        if (page.length < 1000 || (oldest && oldest.blockTime < fromTimestamp)) break;
         before = page[page.length - 1].signature;
     }
     return signatures;
@@ -47,6 +50,9 @@ const signaturesInWindow = async (fromTimestamp: number, toTimestamp: number) =>
 
 const yieldFromTransaction = async (signature: string) => {
     const tx = await rpc("getTransaction", [signature, { encoding: "jsonParsed", maxSupportedTransactionVersion: 0 }]);
+    // A null result means the node could not serve the transaction, not that it distributed nothing;
+    // treating it as zero would quietly understate the day.
+    if (!tx) throw new Error(`solstice: solana rpc returned no transaction for ${signature}`);
     let amount = 0;
     for (const log of (tx?.meta?.logMessages ?? [])) {
         if (!log.includes("Program data:")) continue;

--- a/fees/solstice-usx/index.ts
+++ b/fees/solstice-usx/index.ts
@@ -1,83 +1,101 @@
+import axios from "axios";
 import { FetchOptions, FetchResultFees, SimpleAdapter } from "../../adapters/types";
-import { PromisePool } from "@supercharge/promise-pool";
 import { CHAIN } from "../../helpers/chains";
-import { getTokenSupply } from '../../helpers/solana';
-import fetchURL from "../../utils/fetchURL";
+import { getEnv } from "../../helpers/env";
 import { METRIC } from "../../helpers/metrics";
 
-const EUSX = '3ThdFZQKM6kRyVGLG48kaPg5TRMhYMKY1iCRa9xop1WC';
-const PYTH_EUSX_REDEMPTION_PRICE_ID = 'f36e12e65d2969b242fb97d3ebaa32ec55d5794189b64d1a07dc4f41425c9378';
-const PYTH_HERMES_PRICE_API = 'https://hermes.pyth.network/v2/updates/price';
+// Pyth's Hermes endpoint started requiring an API key and now answers 401, which took the previous
+// version of this adapter down with it. It priced yield as the daily change in the eUSX redemption
+// rate multiplied by supply; the protocol distributes that yield on-chain instead, so the transfer
+// is read directly and no rate feed is needed.
+//
+// Solstice's yield account emits a TransferInYield event on each DistributeYield call. Its payload
+// carries the USX amount handed to the eUSX backing account, which is exactly the yield accrued to
+// eUSX holders for the period.
+const YIELD_ACCOUNT = "HARVSXaBpt1TuD4PvqnscCQLzAWgDzGpkDadr76a489L";
+const USX = "6FrrzDk5mQARGc1TDYoyVnSyRdds1t4PbtohCD6p3tgG";
+const TRANSFER_IN_YIELD_DISCRIMINATOR = "3983162e2b54bd7a";
+// Anchor lays the event out as an 8 byte discriminator then its fields; the transferred USX amount
+// is the u64 at byte 72.
+const AMOUNT_OFFSET = 72;
+
 const FEES_YIELD_LABEL = METRIC.ASSETS_YIELDS;
 const SUPPLY_SIDE_YIELD_LABEL = 'eUSX Yield To Holders';
 
-const getRedemptionPrice = async (timestamp: number) => {
-  const response = await fetchURL(`${PYTH_HERMES_PRICE_API}/${timestamp}?ids%5B%5D=${PYTH_EUSX_REDEMPTION_PRICE_ID}`);
-  const pythPrice = response?.parsed?.[0]?.price;
-  const price = Number(pythPrice?.price);
-  const exponent = Number(pythPrice?.expo);
-
-  if (!Number.isFinite(price) || !Number.isInteger(exponent))
-    throw new Error(`Pyth Hermes returned invalid EUSX redemption price for ${timestamp}`);
-
-  return price * 10 ** exponent;
+const rpc = async (method: string, params: any[]) => {
+    const { data } = await axios.post(getEnv('SOLANA_RPC'), { jsonrpc: "2.0", id: 1, method, params });
+    if (data.error) throw new Error(`solstice: solana rpc ${method} failed: ${JSON.stringify(data.error)}`);
+    return data.result;
 };
 
-const fetch: any = async (options: FetchOptions): Promise<FetchResultFees> => {
-  const dailyFees = options.createBalances();
+// The yield account is only touched by these distributions, a couple of transactions a day, so
+// walking its signatures back to the start of the day is cheap.
+const signaturesInWindow = async (fromTimestamp: number, toTimestamp: number) => {
+    const signatures: string[] = [];
+    let before: string | undefined;
+    while (true) {
+        const page = await rpc("getSignaturesForAddress", [YIELD_ACCOUNT, before ? { limit: 1000, before } : { limit: 1000 }]);
+        if (!page?.length) break;
+        for (const entry of page) {
+            if (entry.blockTime >= fromTimestamp && entry.blockTime < toTimestamp && !entry.err) signatures.push(entry.signature);
+        }
+        if (page[page.length - 1].blockTime < fromTimestamp || page.length < 1000) break;
+        before = page[page.length - 1].signature;
+    }
+    return signatures;
+};
 
-  const { results, errors } = await PromisePool
-    .withConcurrency(2)
-    .for([options.fromTimestamp, options.endTimestamp])
-    .process(async (timestamp) => [timestamp, await getRedemptionPrice(timestamp)] as const);
+const yieldFromTransaction = async (signature: string) => {
+    const tx = await rpc("getTransaction", [signature, { encoding: "jsonParsed", maxSupportedTransactionVersion: 0 }]);
+    let amount = 0;
+    for (const log of (tx?.meta?.logMessages ?? [])) {
+        if (!log.includes("Program data:")) continue;
+        const event = Buffer.from(log.split("Program data:")[1].trim(), "base64");
+        if (event.length < AMOUNT_OFFSET + 8) continue;
+        if (event.subarray(0, 8).toString("hex") !== TRANSFER_IN_YIELD_DISCRIMINATOR) continue;
+        amount += Number(event.readBigUInt64LE(AMOUNT_OFFSET));
+    }
+    return amount;
+};
 
-  if (errors.length > 0) throw errors[0];
+const fetch = async (options: FetchOptions): Promise<FetchResultFees> => {
+    const dailyFees = options.createBalances();
+    const dailySupplySideRevenue = options.createBalances();
 
-  const pricesByTimestamp = new Map(results);
-  const priceYesterday = pricesByTimestamp.get(options.fromTimestamp);
-  const priceToday = pricesByTimestamp.get(options.endTimestamp);
+    const signatures = await signaturesInWindow(options.startTimestamp, options.endTimestamp);
+    const amounts = await Promise.all(signatures.map(yieldFromTransaction));
+    const distributed = amounts.reduce((total, amount) => total + amount, 0);
 
-  if (!priceToday || !priceYesterday || !Number.isFinite(priceYesterday) || !Number.isFinite(priceToday))
-    throw new Error("Pyth Hermes returned incomplete EUSX redemption prices");
+    dailyFees.add(USX, distributed, FEES_YIELD_LABEL);
+    dailySupplySideRevenue.add(USX, distributed, SUPPLY_SIDE_YIELD_LABEL);
 
-  const totalSupply = await getTokenSupply(EUSX)
-  const dailyYield = (priceToday - priceYesterday) * totalSupply;
-
-  if (!Number.isFinite(dailyYield))
-    throw new Error("Pyth API returned invalid EUSX redemption prices");
-
-  dailyFees.addUSDValue(dailyYield, FEES_YIELD_LABEL);
-  const dailySupplySideRevenue = options.createBalances();
-  dailySupplySideRevenue.addUSDValue(dailyYield, SUPPLY_SIDE_YIELD_LABEL);
-
-  return {
-    dailyFees,
-    dailyRevenue: 0,
-    dailySupplySideRevenue,
-  };
+    return {
+        dailyFees,
+        dailyRevenue: 0,
+        dailySupplySideRevenue,
+    };
 };
 
 const adapters: SimpleAdapter = {
-  version: 1,
-  fetch,
-  chains: [CHAIN.SOLANA],
-  start: '2025-10-05',
-  allowNegativeValue: true, // Yield strategies aren't risk-free
-  methodology: {
-    Fees: 'Yield generated from Solstice various strategies',
-    Revenue: 'No protocol revenue (yield fully passed to eUSX holders)',
-    SupplySideRevenue: 'Total yield accrued through eUSX price appreciation, distributed to holders',
-  },
-  breakdownMethodology: {
-    Fees: {
-      [FEES_YIELD_LABEL]: 'Daily change in eUSX/USX redemption rate multiplied by total eUSX supply',
+    version: 1,
+    fetch,
+    chains: [CHAIN.SOLANA],
+    start: '2025-10-05',
+    methodology: {
+        Fees: 'USX paid into the eUSX backing account by Solstice yield distributions, which is the yield eUSX holders accrue.',
+        Revenue: 'No protocol revenue (yield fully passed to eUSX holders)',
+        SupplySideRevenue: 'All distributed yield goes to eUSX holders.',
     },
-    Revenue: 'No protocol revenue; all eUSX redemption-rate yield is passed through to eUSX holders.',
-    SupplySideRevenue: {
-      [SUPPLY_SIDE_YIELD_LABEL]: '100% of eUSX redemption-rate yield is distributed to eUSX holders',
-    },
-    HoldersRevenue: 'Not separately tracked in this adapter; holder distributions are represented in SupplySideRevenue.',
-  }
+    breakdownMethodology: {
+        Fees: {
+            [FEES_YIELD_LABEL]: 'USX transferred in by each DistributeYield call over the day.',
+        },
+        Revenue: 'No protocol revenue; all yield is passed through to eUSX holders.',
+        SupplySideRevenue: {
+            [SUPPLY_SIDE_YIELD_LABEL]: '100% of distributed yield is credited to eUSX holders',
+        },
+        HoldersRevenue: 'Not separately tracked in this adapter; holder distributions are represented in SupplySideRevenue.',
+    }
 };
 
 export default adapters;


### PR DESCRIPTION
`fees/solstice-usx` has published nothing since **2026-08-25**. It is the last adapter in the repo reading Pyth's Hermes endpoint (`git grep -l "hermes.pyth" upstream/master` returns only this file), and Hermes now requires a key:

```
GET https://hermes.pyth.network/v2/updates/price/<ts>?ids[]=f36e12e6…  ->  401 unauthorized
GET https://hermes.pyth.network/v2/updates/price/latest?ids[]=f36e12e6… ->  401 unauthorized
```

Its `/v2/price_feeds` metadata endpoint is still public and confirms the feed is a *"Crypto Redemption Rate"* for the Solstice yield-bearing stablecoin, but the values are gone. Same cause as #9164 (zest) and #9193 (wisdomtree); the fix is different because this is a redemption rate, not a market price.

## Not a price problem

The old version computed `(redemptionRate(today) − redemptionRate(yesterday)) × totalSupply(eUSX)`. **DefiLlama's own price for eUSX cannot stand in for that feed** — it is a market price and it goes *down* on some days (1.039748 → 1.040492 → 1.041009 → 1.039997 → 1.038421), while a redemption rate only rises. Substituting it would have produced negative yield days and would not reproduce the published series.

Solstice distributes the yield on-chain, so the transfer can be read directly and no rate feed is needed at all.

## What is read, and how it was checked

Each `DistributeYield` call emits a `TransferInYield` Anchor event from Solstice's program (`eUSXyKoZ6aGejYVbnp3wtWQ1E8zuokLAJPecPxxtgG3`). Rather than trust the layout, I matched one event against the transaction's actual token movements:

```
tx 3eD1bAgCXTThX2Mvg7iryVMo…   2026-09-04 09:02:07 UTC
  Program log: Instruction: DistributeYield
  Program log: Instruction: TransferInYield
  event u64 @ byte 72 = 666,330,000            ->  666.330000 USX

  token balances, mint 6FrrzDk5…  (USX)
    eUSX backing acct   21,630,658.240651 -> 21,631,324.570651   (+666.330000)
    yield acct          12,660.360031     -> 11,994.030031       (-666.330000)
```

The field is the transferred amount to the cent, so `dailyFees` is the sum of that u64 over the day, added as USX and priced by the framework.

The events are read from the yield account `HARVSXaBpt1TuD4PvqnscCQLzAWgDzGpkDadr76a489L`, which only these distributions touch — **1,183 signatures across 376 days, median 3 a day** — so walking its signatures back to the start of a day is a couple of RPC calls, not a program-wide scan.

## It reproduces the series the dead feed produced

Run locally against days the old adapter still covered:

| requested day | this adapter | DefiLlama published |
|---|---|---|
| 2026-08-23 | $4.57k | $4,566 |
| 2026-08-25 | $4.57k | $4,559 |
| 2026-09-03 | $1.31k | (feed already dead) |

and decoding the full event history gives the same shape day by day — 8,198.55 USX/day across 2026-08-14…08-19 against published 8,183 / 8,159 / 8,180 / 8,188 / 8,187 / 8,179, i.e. inside ~0.2% once USX's ~$0.9995 price is applied. So this is not a new methodology, it is the same number from a source that still exists.

## One bug fixed by construction

The old code called `getTokenSupply(EUSX)`, which returns the **current** mint supply regardless of the day requested, so every historical/backfill day was multiplied by today's supply. The rebuild reads the amount actually distributed on the day and never touches supply, so that goes away.

`allowNegativeValue` is dropped with it — the previous version needed it because a rate delta could come out negative; a distributed transfer cannot.

## CI

`ts-check` passes. The `test` check uses the default public `SOLANA_RPC` (`api.mainnet-beta.solana.com`), which rate-limits `getSignaturesForAddress`; the table above is a real local run against a Helius endpoint.
