### PR TITLE
jediswap v1: mark dead, same gone host and apex as the v2 leg

### DIFF
--- a/dexs/jediswap/index.ts
+++ b/dexs/jediswap/index.ts
@@ -47,6 +47,10 @@ const adapter: SimpleAdapter = {
   fetch,
   chains: [CHAIN.STARKNET],
   start: '2022-11-28',
+  // Same situation as the v2 adapter, marked dead in #9207: api.jediswap.xyz is NXDOMAIN and the
+  // jediswap.xyz apex resolves with no A record, so the app is gone too. Last published point
+  // 2025-07-30, last non-zero 2025-01-15 ($167).
+  deadFrom: '2025-07-31',
 };
 
 export default adapter;


### PR DESCRIPTION
Follow-up to #9207, which marked `dexs/jediswap-v2` dead. The v1 adapter is the same protocol in the same state and was missed.

`dexs/jediswap` reads `https://api.jediswap.xyz/graphql`. Checked against both Cloudflare's and Google's DoH resolvers:

| host | result |
|---|---|
| `api.jediswap.xyz` (this adapter) | **NXDOMAIN** |
| `api.v2.jediswap.xyz` (already marked dead in #9207) | NXDOMAIN |
| `app.jediswap.xyz` | NXDOMAIN |
| `jediswap.xyz` | NOERROR, **zero A records** |

So the API and the app are both gone, and the apex is registered but publishes no address — the registration outlived the deployment. There is nothing to repoint to.

The published series agrees: last point **2025-07-30**, last non-zero **2025-01-15 ($167)**.

`deadFrom` is `2025-07-31`, the day after that last point, matching the date used for the v2 leg so the two halves of the same protocol stop on the same day. No stored history changes.
