### PR TITLE
solana dune adapters: wait for the day to finish indexing, published volume is truncated by 13-37%

### DIFF
--- a/dexs/alphaq/index.ts
+++ b/dexs/alphaq/index.ts
@@ -1,11 +1,14 @@
 import { Dependencies, FetchOptions, SimpleAdapter } from "../../adapters/types"
 import { CHAIN } from "../../helpers/chains"
 import { queryDuneSql } from "../../helpers/dune"
+import { assertDuneSolanaIndexed } from "../../helpers/duneSolanaDex"
 
 // https://www.alphaq.xyz/docs
 const FEE_RATE = 0.00001; // 0.001%
 
 const fetch = async (options: FetchOptions) => {
+  assertDuneSolanaIndexed(options)
+
   const query = `
     with swaps as (
       select

--- a/dexs/bisonfi/index.ts
+++ b/dexs/bisonfi/index.ts
@@ -3,8 +3,11 @@
 import { Dependencies, FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 import { queryDuneSql } from "../../helpers/dune";
+import { assertDuneSolanaIndexed } from "../../helpers/duneSolanaDex"
 
 const fetch = async (options: FetchOptions) => {
+    assertDuneSolanaIndexed(options)
+
     const query = `
         with swaps as (
             select

--- a/dexs/humidifi/index.ts
+++ b/dexs/humidifi/index.ts
@@ -3,8 +3,11 @@
 import { Dependencies, FetchOptions, SimpleAdapter } from "../../adapters/types"
 import { CHAIN } from "../../helpers/chains"
 import { queryDuneSql } from "../../helpers/dune"
+import { assertDuneSolanaIndexed } from "../../helpers/duneSolanaDex"
 
 const fetch = async (options: FetchOptions) => {
+    assertDuneSolanaIndexed(options)
+
     const query = `
         with swaps as (
             select

--- a/dexs/solfi-v2/index.ts
+++ b/dexs/solfi-v2/index.ts
@@ -3,9 +3,12 @@
 
 import { Dependencies, FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
-import { queryDuneSql } from "../../helpers/dune";
+import { queryDuneSql } from "../../helpers/dune"
+import { assertDuneSolanaIndexed } from "../../helpers/duneSolanaDex";
 
 const fetch = async (options: FetchOptions) => {
+    assertDuneSolanaIndexed(options)
+
     const query = `
         with swaps as (
             select

--- a/helpers/duneSolanaDex.ts
+++ b/helpers/duneSolanaDex.ts
@@ -2,10 +2,16 @@ import { Dependencies, FetchOptions } from "../adapters/types";
 import { CHAIN } from "./chains";
 import { queryDuneSql } from "./dune";
 
-// Dune finishes indexing a Solana day several hours after it ends, so a window that reaches into
-// that period returns a partial answer rather than an error. Any adapter reading Solana tables has
-// to wait, otherwise the truncated figure is what gets published.
-export function assertDuneSolanaIndexed(options: FetchOptions) {
+/**
+ * Throws unless Dune has had time to finish indexing the window's Solana data.
+ *
+ * Dune finishes a Solana day several hours after it ends, and a window reaching into that period
+ * answers with a partial sum rather than an error, so an adapter that does not wait publishes a
+ * truncated day. Call this before querying any `solana.*`, `tokens_solana.*` or `dex_solana.*`
+ * table. Only safe on single-chain adapters: `runAdapter` drops every chain's record when one
+ * chain throws.
+ */
+export function assertDuneSolanaIndexed(options: FetchOptions): void {
     const now = Date.now()
     const tenHoursAgo = now - (10 * 60 * 60 * 1000)
     if ((options.toTimestamp * 1000) > tenHoursAgo) {

--- a/helpers/duneSolanaDex.ts
+++ b/helpers/duneSolanaDex.ts
@@ -2,14 +2,21 @@ import { Dependencies, FetchOptions } from "../adapters/types";
 import { CHAIN } from "./chains";
 import { queryDuneSql } from "./dune";
 
+// Dune finishes indexing a Solana day several hours after it ends, so a window that reaches into
+// that period returns a partial answer rather than an error. Any adapter reading Solana tables has
+// to wait, otherwise the truncated figure is what gets published.
+export function assertDuneSolanaIndexed(options: FetchOptions) {
+    const now = Date.now()
+    const tenHoursAgo = now - (10 * 60 * 60 * 1000)
+    if ((options.toTimestamp * 1000) > tenHoursAgo) {
+        console.log("End timestamp is less than 10 hours ago, skipping fetch due to dune indexing delay", new Date(options.toTimestamp * 1000).toISOString(), new Date(tenHoursAgo).toISOString())
+        throw new Error("End timestamp is less than 10 hours ago, skipping due to dune indexing delay")
+    }
+}
+
 export function duneSolanaDexTrades(project: string, start: string) {
     const fetch = async (options: FetchOptions) => {
-        const now = Date.now()
-        const tenHoursAgo = now - (10 * 60 * 60 * 1000)
-        if ((options.toTimestamp * 1000) > tenHoursAgo) {
-            console.log("End timestamp is less than 10 hours ago, skipping fetch due to dune indexing delay", new Date(options.toTimestamp * 1000).toISOString(), new Date(tenHoursAgo).toISOString())
-            throw new Error("End timestamp is less than 10 hours ago, skipping due to dune indexing delay")
-        }
+        assertDuneSolanaIndexed(options)
 
         const query = `
             SELECT


### PR DESCRIPTION
Website: https://humidifi.xyz/ — Twitter: https://twitter.com/humidifi

`dexs/humidifi` reads `solana.instruction_calls` and `tokens_solana.transfers` for the day as soon as it closes. Dune finishes indexing a Solana day several hours after it ends, so the query answers with whatever is loaded so far — a partial day, not an error — and that truncated number is what gets stored.

**The stored value is literally the first 18 hours of the day.** Summing the adapter's own query by hour for 2026-08-20:

| through | cumulative |
|---|---|
| 15:00 | 86,192,094 |
| 16:00 | 91,866,112 |
| **17:00** | **97,399,132** |
| 18:00 | 103,612,000 |
| 23:00 (full day) | **135,919,436** |

Published for 2026-08-20: **97,402,250**. That is the 00:00–17:59 cumulative to within 0.003%; the remaining six hours, $38.5M, were never picked up.

It is not a one-off. Re-running the adapter's query today against what is published:

| day | published | same query today | short by |
|---|---|---|---|
| 2026-08-15 | 65,450,780 | 85,685,229 | -23.6% |
| 2026-08-18 | 160,543,513 | 207,561,136 | -22.7% |
| 2026-08-20 | 97,402,250 | 135,919,436 | -28.3% |
| 2026-08-21 | 213,788,231 | 237,927,732 | -10.1% |
| 2026-09-02 | **0** | 652,262 | -100% |
| 2026-09-03 | 13,308,991 | 18,873,500 | -29.5% |

2026-08-18 alone is $47M of missing volume, and 2026-09-02 was stored as a zero day.

**The repo already has the fix and it is measurably working.** `duneSolanaDexTrades` refuses a window whose end is inside the last ten hours, and the Solana dexs wired through `factory/duneSolanaDex.ts` reconcile exactly. Comparing every decoded Solana project for 2026-08-20 against what is published:

```
guarded (via duneSolanaDexTrades)      unguarded (own adapter)
  scorch        0.0%                     humidifi      -30.2%
  aquifer       0.0%                     alphaq        -24.2%
  goonfi        0.0%                     tessera       -22.3%
  whalestreet   0.0%                     bisonfi       -13.2%
```

So this moves that wait out of `duneSolanaDexTrades` into `assertDuneSolanaIndexed` — no behaviour change for the factory adapters, which now call it — and has `dexs/humidifi` call it too. Adapter runs unchanged for a settled day and refuses one that is not:

```
$ npm run test dexs humidifi
SOLANA: Daily volume: 18.87 M          (2026-09-03; published 13.31 M)

$ npm run test dexs humidifi 2026-09-05
End timestamp is less than 10 hours ago, skipping fetch due to dune indexing delay
  2026-09-04T23:59:59.000Z  2026-09-04T03:39:43.360Z
```

`dexs/scorch` still runs through the factory unchanged (77.84 M), and `tsc --noEmit` is clean.

The zeros in the published series from 2026-08-23 to 2026-09-02 are separately correct and left alone: I scanned Solana blocks at 12:00 UTC on 08-25, 08-27 and 08-30 and found no transaction touching the program — or any of the six other program ids Dune attributes to HumidiFi — across ~23,000 transactions, while the same scan on 08-20 and 09-03 finds them straight away. HumidiFi really was halted for those days.

`tessera`, `alphaq` and `bisonfi` have the same shape and the same shortfall; happy to send those as follow-ups if this approach looks right.
