### PR TITLE
fragment: refuse a day ton.messages has not been loaded for, three real days are published as zero

### DIFF
--- a/fees/fragment/index.ts
+++ b/fees/fragment/index.ts
@@ -40,36 +40,26 @@ async function fetch(options: FetchOptions): Promise<FetchResult> {
   const fragmentAddressList = FRAGMENT_ADDRESSES.map(a => `'${a}'`).join(', ');
   const telegramAddressList = TELEGRAM_WALLETS.map(a => `'${a}'`).join(', ');
 
+  // Both sides read the same window of the same table, so they are one pass. message_count is that
+  // window's total row count: it separates a day Fragment really took nothing from a day
+  // ton.messages has not been loaded for, which the sums cannot do on their own.
   const query = `
-    WITH fees AS (
-      SELECT SUM(value / 1e9) AS ton_received
-      FROM ton.messages
-      WHERE direction = 'in'
-        AND NOT bounced
-        AND value > 0
-        AND destination IN (${fragmentAddressList})
-        AND source NOT IN (${fragmentAddressList})
-        AND source NOT IN (${telegramAddressList})
-        AND block_time >= from_unixtime(${options.fromTimestamp})
-        AND block_time < from_unixtime(${options.toTimestamp})
-    ),
-    supply_side AS (
-      SELECT SUM(value / 1e9) AS ton_sent
-      FROM ton.messages
-      WHERE direction = 'in'
-        AND NOT bounced
-        AND value > 0
-        AND source IN (${fragmentAddressList})
-        AND destination NOT IN (${fragmentAddressList})
-        AND destination NOT IN (${telegramAddressList})
-        AND block_time >= from_unixtime(${options.fromTimestamp})
-        AND block_time < from_unixtime(${options.toTimestamp})
-    )
     SELECT
-      COALESCE(fees.ton_received, 0) AS ton_received,
-      COALESCE(supply_side.ton_sent, 0) AS ton_sent
-    FROM fees
-    CROSS JOIN supply_side`;
+      COUNT(*) AS message_count,
+      COALESCE(SUM(CASE WHEN destination IN (${fragmentAddressList})
+                         AND source NOT IN (${fragmentAddressList})
+                         AND source NOT IN (${telegramAddressList})
+                        THEN value / 1e9 END), 0) AS ton_received,
+      COALESCE(SUM(CASE WHEN source IN (${fragmentAddressList})
+                         AND destination NOT IN (${fragmentAddressList})
+                         AND destination NOT IN (${telegramAddressList})
+                        THEN value / 1e9 END), 0) AS ton_sent
+    FROM ton.messages
+    WHERE direction = 'in'
+      AND NOT bounced
+      AND value > 0
+      AND block_time >= from_unixtime(${options.fromTimestamp})
+      AND block_time < from_unixtime(${options.toTimestamp})`;
 
   const queryResults = await queryDuneSql(options, query);
 
@@ -79,6 +69,12 @@ async function fetch(options: FetchOptions): Promise<FetchResult> {
 
   if (queryResults[0].ton_received == null || queryResults[0].ton_sent == null) {
     throw new Error(`Unexpected Dune result shape: ${JSON.stringify(queryResults[0])}`);
+  }
+
+  // A TON day carries millions of messages, so an empty window means the table has not been loaded
+  // that far yet rather than that nothing happened. Publishing the sums as a zero day would bury it.
+  if (Number(queryResults[0].message_count) === 0) {
+    throw new Error(`ton.messages has no rows for ${options.dateString}, refusing to report it as a zero fee day`);
   }
 
   const dailyFees = options.createBalances();


### PR DESCRIPTION
Website: https://fragment.com — Twitter: https://twitter.com/telegram

Both halves of the query end in `COALESCE(..., 0)`, so a window with no rows at all comes back as `ton_received = 0, ton_sent = 0` — indistinguishable from a day Fragment genuinely took nothing. The null check passes, and a zero day gets published.

That has happened three times, on a series that otherwise sits near $1M/day:

| day | published fees | adapter on this branch | `ton.messages` rows in that window today |
|---|---|---|---|
| 2026-06-17 | **0** | 893.45 k | 1,908,969 |
| 2026-08-02 | **0** | 800.21 k | 2,285,453 |
| 2026-08-15 | **0** | 894.46 k | 2,069,452 |
| 2026-08-16 | 855,271 | 855.29 k | 2,012,165 |
| 2026-09-02 | 958,436 | 952.38 k | — |

About $2.6M of fees are sitting in the series as zeros. The last two rows are the control: days that were published correctly come back unchanged, to 0.002% on 08-16.

The two-hour wait at the top of `fetch` is what this leans on, and it is clearly not always long enough for `ton.messages`; rather than guess at a longer one, the adapter now asks the data whether the window exists. A TON day carries around two million qualifying messages, so an empty window is the table not being loaded that far yet, never a quiet day.

The two sides read the same window of the same table with the same `direction` / `bounced` / `value` filters, so they are folded into one pass that also returns that window's row count — the same rows, scanned once instead of twice, with the count coming for free.

```sql
SELECT
  COUNT(*) AS message_count,
  COALESCE(SUM(CASE WHEN destination IN (...) AND source NOT IN (...) THEN value / 1e9 END), 0) AS ton_received,
  COALESCE(SUM(CASE WHEN source IN (...) AND destination NOT IN (...) THEN value / 1e9 END), 0) AS ton_sent
FROM ton.messages
WHERE direction = 'in' AND NOT bounced AND value > 0
  AND block_time >= from_unixtime(...) AND block_time < from_unixtime(...)
```

`tsc --noEmit` is clean. The `test` check will be red because the runner has no Dune key.
