### PR TITLE
refactor(o1-launchpad): source fees and revenue from Dune materialized view

### DIFF
--- a/fees/o1-launchpad/index.ts
+++ b/fees/o1-launchpad/index.ts
@@ -1,429 +1,151 @@
-import { FetchOptions, FetchResultV2, SimpleAdapter } from "../../adapters/types";
+import { Dependencies, FetchOptions, FetchResultV2, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
-import { METRIC } from "../../helpers/metrics";
-import ADDRESSES from '../../helpers/coreAssets.json'
+import { queryDuneSql } from "../../helpers/dune";
 
-const ZERO_ADDRESS = ADDRESSES.null;
-const BASE_USDC = ADDRESSES.base.USDC;
-const ROBINHOOD_USDG = ADDRESSES.robinhood.USDG;
+const DUNE_MATERIALIZED_VIEW = "dune.stambouli_o1.result_daily_fee_revenue";
+const UTC_DAY_SECONDS = 24 * 60 * 60;
 
-const TOKEN_LAUNCH_FEES = "Token Launch Fees";
-const SWAP_FEES_TO_CREATORS = "Swap Fees to Creators";
-const SWAP_FEES_TO_REFERRERS = "Swap Fees to Referrers";
-const SWAP_FEES_TO_PROTOCOL = "Swap Fees to Protocol";
-const TOKEN_LAUNCH_FEES_TO_PROTOCOL = "Token Launch Fees to Protocol";
+const MARKETS = ["Crypto", "Stocks"] as const;
+type Market = typeof MARKETS[number];
 
-const TRADE_EVENT =
-  "event Trade(bytes32 indexed id, address indexed executor, address indexed referrer, address feeCurrency, uint256 totalFee, bytes32 comment)";
-const CREDITED_EVENT =
-  "event Credited(address indexed recipient, address indexed currency, uint256 amount)";
-const LAUNCH_FEE_PAID_EVENT =
-  "event LaunchFeePaid(address indexed payer, address indexed quote, address indexed treasury, uint256 amount)";
+type DuneFeeRevenueRow = {
+  date: string;
+  chain: string;
+  market: string;
+  fee_usd: number | string;
+  revenue_usd: number | string;
+};
 
-type NumericValue = bigint | number | string;
+const duneChainNames: Record<string, string> = {
+  [CHAIN.BASE]: "Base",
+  [CHAIN.ROBINHOOD]: "Robinhood",
+};
 
-interface Suite {
-  id: string;
-  factory: string;
-  hook: string;
-  feeEscrow: string;
-  firstBlock: number;
-  legacyFeeCurrency: boolean;
-  launchFeeCurrency: "none" | "quote" | "native";
-}
-
-interface ChainConfig {
-  start: string;
-  suites: Suite[];
-  legacyQuotes: Set<string>;
-}
-
-interface DecodedLog<TArgs> {
-  address: string;
-  transactionHash: string;
-  blockNumber: number;
-  logIndex?: number;
-  index?: number;
-  args: TArgs;
-}
-
-interface TradeArgs {
-  referrer: string;
-  feeCurrency: string;
-  totalFee: NumericValue;
-}
-
-interface CreditArgs {
-  recipient: string;
-  currency: string;
-  amount: NumericValue;
-}
-
-interface LaunchFeeArgs {
-  quote: string;
-  amount: NumericValue;
-}
-
-interface PositionedEvent {
-  transactionHash: string;
-  blockNumber: number;
-  logIndex: number;
-}
-
-interface TradeEvent extends PositionedEvent {
-  referrer: string;
-  currency: string;
-  totalFee: bigint;
-}
-
-interface CreditEvent extends PositionedEvent {
-  recipient: string;
-  currency: string;
-  amount: bigint;
-}
-
-interface FeeAllocation {
-  trade: TradeEvent;
-  creatorFee: bigint;
-  referrerFee: bigint;
-  platformFee: bigint;
-}
-
-const chainConfig: Record<string, ChainConfig> = {
-  [CHAIN.BASE]: {
-    start: "2026-07-01",
-    suites: [
-      // https://basescan.org/address/0xe3ab924c72463c1ac8d1d8352ee640b89eb1ea64
-      {
-        id: "base-mainnet-block-v1",
-        factory: "0xe3ab924c72463c1ac8d1d8352ee640b89eb1ea64",
-        hook: "0xa068cf4c52abdd3479145c4b3cbd8e3d71542a44",
-        feeEscrow: "0xabe87e4af23dafad0a170aa900d574c03d904597",
-        // First suite block: https://basescan.org/block/48364845
-        firstBlock: 48_364_845,
-        legacyFeeCurrency: true,
-        launchFeeCurrency: "none",
-      },
-      // https://basescan.org/address/0xa52ad458ce0282a971ecc71c051a32f28946bb9f
-      {
-        id: "base-mainnet-timestamp-v2",
-        factory: "0xa52ad458ce0282a971ecc71c051a32f28946bb9f",
-        hook: "0x985c14baa2a18316ffda0aefb3a632fadfca2acc",
-        feeEscrow: "0xa2cbd9065cec93c443cafb0837a62800ee7c4a84",
-        // First suite block: https://basescan.org/block/48451098
-        firstBlock: 48_451_098,
-        legacyFeeCurrency: false,
-        launchFeeCurrency: "quote",
-      },
-      // https://basescan.org/address/0x1de58a6769526a03a504d9d59b8757cd8097dc57
-      {
-        id: "base-mainnet-rwa-timestamp-v3",
-        factory: "0x1de58a6769526a03a504d9d59b8757cd8097dc57",
-        hook: "0xbca7774615c74b7991a111f1c7b2d0efea61aacc",
-        feeEscrow: "0xcf9ed8f4145eac9059bcd83227eeb8591fac0a9a",
-        // First suite block: https://basescan.org/block/49121014
-        firstBlock: 49_121_014,
-        legacyFeeCurrency: false,
-        launchFeeCurrency: "native",
-      },
-      // https://basescan.org/address/0xff70918ef17a2d74d683a8297813b177bafad1f4
-      {
-        id: "base-mainnet-rwa-timestamp-v4",
-        factory: "0xff70918ef17a2d74d683a8297813b177bafad1f4",
-        hook: "0x3b2b979df21036cee51b8debb13100e2cb8deacc",
-        feeEscrow: "0x1d8c991a9019df7d72adcd8dea6f12d600c9d02f",
-        // First suite block: https://basescan.org/block/50137081
-        firstBlock: 50_137_081,
-        legacyFeeCurrency: false,
-        launchFeeCurrency: "native",
-      },
-    ],
-    legacyQuotes: new Set([ZERO_ADDRESS, BASE_USDC]),
+const labels: Record<Market, { fees: string; revenue: string }> = {
+  Crypto: {
+    fees: "Crypto Fees",
+    revenue: "Crypto Fees to Protocol",
   },
-  [CHAIN.ROBINHOOD]: {
-    start: "2026-07-01",
-    suites: [
-      // https://robinhoodchain.blockscout.com/address/0x8b40fc20c405d47d725c9723d056a1c6f62bbccf
-      {
-        id: "robinhood-block-v1",
-        factory: "0x8b40fc20c405d47d725c9723d056a1c6f62bbccf",
-        hook: "0xe960e6c80c74cfdf03c91e7af4e1f5f53f096a44",
-        feeEscrow: "0xf5681c4c0dc0c2e32c9d127b3cc0fc992b584553",
-        // First suite block: https://robinhoodchain.blockscout.com/block/2131131
-        firstBlock: 2_131_131,
-        legacyFeeCurrency: true,
-        launchFeeCurrency: "none",
-      },
-      // https://robinhoodchain.blockscout.com/address/0x76f0923ac4df0a079a10f628a7bce6426ccd344a
-      {
-        id: "robinhood-block-v2",
-        factory: "0x76f0923ac4df0a079a10f628a7bce6426ccd344a",
-        hook: "0xca4b035a5dbfa2a00fc5dcb08fd1c5a22d0eaa44",
-        feeEscrow: "0x00d5701a92794c3744428b62646e7bc4e77a0a9a",
-        // First suite block: https://robinhoodchain.blockscout.com/block/4415287
-        firstBlock: 4_415_287,
-        legacyFeeCurrency: true,
-        launchFeeCurrency: "none",
-      },
-      // https://robinhoodchain.blockscout.com/address/0x411f21283d3e492bc395027329e08f9f4f560ba5
-      {
-        id: "robinhood-timestamp-v3",
-        factory: "0x411f21283d3e492bc395027329e08f9f4f560ba5",
-        hook: "0x441f773b3bb1ed4c6457d0528624112e43c02acc",
-        feeEscrow: "0x32f7a9a05bd62487d085ad494e14ec42543e19d2",
-        // First suite block: https://robinhoodchain.blockscout.com/block/6131279
-        firstBlock: 6_131_279,
-        legacyFeeCurrency: false,
-        launchFeeCurrency: "quote",
-      },
-      // https://robinhoodchain.blockscout.com/address/0xe64ac4113848bbc1a6dde1a6d1da96720a36f297
-      {
-        id: "robinhood-rwa-timestamp-v4",
-        factory: "0xe64ac4113848bbc1a6dde1a6d1da96720a36f297",
-        hook: "0x778b0c4eea7d35d66513b587ba87fc9084b0eacc",
-        feeEscrow: "0x4f2b1cda8748cd64c56039bf5e2e54bc13d4a3d7",
-        // First suite block: https://robinhoodchain.blockscout.com/block/18487505
-        firstBlock: 18_487_505,
-        legacyFeeCurrency: false,
-        launchFeeCurrency: "native",
-      },
-    ],
-    legacyQuotes: new Set([ZERO_ADDRESS, ROBINHOOD_USDG]),
+  Stocks: {
+    fees: "Stocks Fees",
+    revenue: "Stocks Fees to Protocol",
   },
 };
 
-const normalizeAddress = (address: string) => address.toLowerCase();
-const toBigInt = (value: NumericValue) => BigInt(value.toString());
-const transactionKey = (suite: Suite, hash: string) => `${suite.id}:${hash}`;
-
-const positionOf = <TArgs>(log: DecodedLog<TArgs>): PositionedEvent => {
-  const logIndex = log.logIndex ?? log.index;
-  if (logIndex === undefined) throw new Error("o1 Launchpad event is missing its log index");
-  return {
-    transactionHash: normalizeAddress(log.transactionHash),
-    blockNumber: Number(log.blockNumber),
-    logIndex: Number(logIndex),
-  };
+const assertOutsideMaterializedViewRefreshWindow = () => {
+  const utcHour = new Date().getUTCHours();
+  if (utcHour < 2) {
+    throw new Error(
+      "o1 Launchpad Dune materialized view is refreshing between 00:00 and 02:00 UTC",
+    );
+  }
 };
 
-const addToken = (
-  balances: ReturnType<FetchOptions["createBalances"]>,
-  currency: string,
-  amount: bigint,
-  label: string,
+const prefetch = async (options: FetchOptions) => {
+  assertOutsideMaterializedViewRefreshWindow();
+
+  return queryDuneSql(options, `
+    SELECT date, chain, market, fee_usd, revenue_usd
+    FROM ${DUNE_MATERIALIZED_VIEW}
+    WHERE date = '${options.dateString}'
+    ORDER BY chain, market
+  `);
+};
+
+const toFiniteNonNegativeNumber = (
+  value: number | string,
+  field: "fee_usd" | "revenue_usd",
+  row: DuneFeeRevenueRow,
 ) => {
-  if (amount === 0n) return;
-  if (currency === ZERO_ADDRESS) balances.addGasToken(amount, label);
-  else balances.add(currency, amount, label);
-};
-
-const dedupeLogs = <TArgs>(logs: DecodedLog<TArgs>[]) => {
-  const unique = new Map<string, DecodedLog<TArgs>>();
-  for (const log of logs) {
-    const position = positionOf(log);
-    unique.set(
-      `${normalizeAddress(log.address)}:${position.transactionHash}:${position.blockNumber}:${position.logIndex}`,
-      log,
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    throw new Error(
+      `Invalid ${field} for ${row.date} ${row.chain} ${row.market}: ${value}`,
     );
   }
-  return [...unique.values()];
+  return parsed;
 };
 
-const splitTransaction = (unorderedEvents: Array<TradeEvent | CreditEvent>): FeeAllocation[] => {
-  const events = [...unorderedEvents].sort((left, right) => left.logIndex - right.logIndex);
-  const allocations: FeeAllocation[] = [];
-  let pendingCredits: CreditEvent[] = [];
-
-  for (const event of events) {
-    if ("amount" in event) {
-      pendingCredits.push(event);
-      continue;
-    }
-    if (!pendingCredits.length) return [];
-    if (pendingCredits.some((credit) => credit.currency !== event.currency)) return [];
-
-    const referrerCredits = pendingCredits.filter(
-      (credit) => event.referrer !== ZERO_ADDRESS && credit.recipient === event.referrer,
-    );
-    const nonReferrerCredits = pendingCredits.filter(
-      (credit) => event.referrer === ZERO_ADDRESS || credit.recipient !== event.referrer,
-    );
-    const creditedTotal = pendingCredits.reduce((sum, credit) => sum + credit.amount, 0n);
-    if (creditedTotal !== event.totalFee || !nonReferrerCredits.length) return [];
-
-    allocations.push({
-      trade: event,
-      creatorFee: nonReferrerCredits.slice(0, -1).reduce((sum, credit) => sum + credit.amount, 0n),
-      referrerFee: referrerCredits.reduce((sum, credit) => sum + credit.amount, 0n),
-      platformFee: nonReferrerCredits[nonReferrerCredits.length - 1].amount,
-    });
-    pendingCredits = [];
-  }
-
-  return pendingCredits.length ? [] : allocations;
-};
-
-const decodeTrade = (log: DecodedLog<TradeArgs>): TradeEvent => ({
-  ...positionOf(log),
-  referrer: normalizeAddress(log.args.referrer),
-  currency: normalizeAddress(log.args.feeCurrency),
-  totalFee: toBigInt(log.args.totalFee),
-});
-
-const decodeCredit = (log: DecodedLog<CreditArgs>): CreditEvent => ({
-  ...positionOf(log),
-  recipient: normalizeAddress(log.args.recipient),
-  currency: normalizeAddress(log.args.currency),
-  amount: toBigInt(log.args.amount),
-});
-
-const reconcileSuite = (
-  suite: Suite,
-  legacyQuotes: Set<string>,
-  tradeLogs: DecodedLog<TradeArgs>[],
-  creditLogs: DecodedLog<CreditArgs>[],
-) => {
-  const eventsByTransaction = new Map<string, Array<TradeEvent | CreditEvent>>();
-  const addEvent = (event: TradeEvent | CreditEvent) => {
-    if (event.blockNumber < suite.firstBlock) return;
-    const key = transactionKey(suite, event.transactionHash);
-    const events = eventsByTransaction.get(key);
-    if (events) events.push(event);
-    else eventsByTransaction.set(key, [event]);
-  };
-  for (const log of tradeLogs) addEvent(decodeTrade(log));
-  for (const log of creditLogs) addEvent(decodeCredit(log));
-
-  const allocations: FeeAllocation[] = [];
-  for (const events of eventsByTransaction.values()) {
-    if (suite.legacyFeeCurrency && events.every((event) => !legacyQuotes.has(event.currency))) continue;
-    allocations.push(...splitTransaction(events));
-  }
-  return allocations;
-};
-
-const PARSED_LOG_FETCH_OPTIONS = {
-  entireLog: true,
-  parseLog: true,
-} as const;
-
-
-const fetchAllocations = async (options: FetchOptions, config: ChainConfig) => {
-  const { suites, legacyQuotes } = config;
-  const [tradeLogsPerHook, creditLogsPerEscrow] = await Promise.all([
-    options.getLogs({
-      targets: suites.map((suite) => suite.hook),
-      eventAbi: TRADE_EVENT,
-      flatten: false,
-      ...PARSED_LOG_FETCH_OPTIONS,
-    }),
-      options.getLogs({
-      targets: suites.map((suite) => suite.feeEscrow),
-      eventAbi: CREDITED_EVENT,
-      flatten: false,
-      ...PARSED_LOG_FETCH_OPTIONS,
-    }),
-  ]);
-
-  return suites.map((suite, index) => reconcileSuite(
-    suite,
-    legacyQuotes,
-    dedupeLogs(tradeLogsPerHook[index] ?? []),
-    dedupeLogs(creditLogsPerEscrow[index] ?? []),
-  ));
-};
-
-const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
-  const config = chainConfig[options.chain];
-  if (!config) throw new Error(`Unsupported o1 Launchpad chain ${options.chain}`);
-
-  const launchFeeSuites = config.suites.filter((suite) => suite.launchFeeCurrency !== "none");
-  const launchFeeLogsPerFactory = launchFeeSuites.length
-    ? await options.getLogs({
-      targets: launchFeeSuites.map((suite) => suite.factory),
-      eventAbi: LAUNCH_FEE_PAID_EVENT,
-      flatten: false,
-    }) as LaunchFeeArgs[][]
-    : [];
-
+const createEmptyResult = (options: FetchOptions) => {
   const dailyFees = options.createBalances();
-  const dailyUserFees = options.createBalances();
   const dailyRevenue = options.createBalances();
-  const dailyProtocolRevenue = options.createBalances();
-  const dailySupplySideRevenue = options.createBalances();
-
-  const allocationsBySuite = await fetchAllocations(options, config);
-  for (const [suiteIndex, suite] of config.suites.entries()) {
-    for (const { trade, creatorFee, referrerFee, platformFee } of allocationsBySuite[suiteIndex]) {
-      if (suite.legacyFeeCurrency && !config.legacyQuotes.has(trade.currency)) continue;
-      addToken(dailyFees, trade.currency, trade.totalFee, METRIC.SWAP_FEES);
-      addToken(dailyUserFees, trade.currency, trade.totalFee, METRIC.SWAP_FEES);
-      addToken(dailySupplySideRevenue, trade.currency, creatorFee, SWAP_FEES_TO_CREATORS);
-      addToken(dailySupplySideRevenue, trade.currency, referrerFee, SWAP_FEES_TO_REFERRERS);
-      addToken(dailyRevenue, trade.currency, platformFee, SWAP_FEES_TO_PROTOCOL);
-      addToken(dailyProtocolRevenue, trade.currency, platformFee, SWAP_FEES_TO_PROTOCOL);
-    }
-  }
-
-  for (const [suiteIndex, suite] of launchFeeSuites.entries()) {
-    for (const log of launchFeeLogsPerFactory[suiteIndex] ?? []) {
-      const currency = suite.launchFeeCurrency === "native"
-        ? ZERO_ADDRESS
-        : normalizeAddress(log.quote);
-      const amount = toBigInt(log.amount);
-      addToken(dailyFees, currency, amount, TOKEN_LAUNCH_FEES);
-      addToken(dailyUserFees, currency, amount, TOKEN_LAUNCH_FEES);
-      addToken(dailyRevenue, currency, amount, TOKEN_LAUNCH_FEES_TO_PROTOCOL);
-      addToken(dailyProtocolRevenue, currency, amount, TOKEN_LAUNCH_FEES_TO_PROTOCOL);
-    }
-  }
 
   return {
     dailyFees,
-    dailyUserFees,
     dailyRevenue,
-    dailyProtocolRevenue,
-    dailySupplySideRevenue,
   };
 };
 
+const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
+  const result = createEmptyResult(options);
+
+  // The Dune source contains completed-day totals. Hourly adapter results are
+  // summed by DefiLlama, so record each daily total only in its final UTC hour.
+  if (options.endTimestamp % UTC_DAY_SECONDS !== 0) return result;
+
+  const duneChainName = duneChainNames[options.chain];
+  if (!duneChainName) throw new Error(`Unsupported o1 Launchpad chain ${options.chain}`);
+
+  const rows = (options.preFetchedResults ?? []) as DuneFeeRevenueRow[];
+  const chainRows = rows.filter((row) => row.chain === duneChainName);
+  if (chainRows.length !== MARKETS.length) {
+    throw new Error(
+      `Expected ${MARKETS.length} o1 Launchpad Dune rows for ${duneChainName} on ${options.dateString}, received ${chainRows.length}`,
+    );
+  }
+
+  for (const market of MARKETS) {
+    const marketRows = chainRows.filter((row) => row.market === market);
+    if (marketRows.length !== 1) {
+      throw new Error(
+        `Expected one o1 Launchpad Dune row for ${duneChainName} ${market} on ${options.dateString}, received ${marketRows.length}`,
+      );
+    }
+
+    const row = marketRows[0];
+    const fees = toFiniteNonNegativeNumber(row.fee_usd, "fee_usd", row);
+    const revenue = toFiniteNonNegativeNumber(row.revenue_usd, "revenue_usd", row);
+    if (revenue > fees) {
+      throw new Error(
+        `o1 Launchpad revenue exceeds fees for ${duneChainName} ${market} on ${options.dateString}: ${revenue} > ${fees}`,
+      );
+    }
+
+    const marketLabels = labels[market];
+    result.dailyFees.addUSDValue(fees, marketLabels.fees);
+    result.dailyRevenue.addUSDValue(revenue, marketLabels.revenue);
+  }
+
+  return result;
+};
+
 const methodology = {
-  Fees: "Quote-denominated swap fees plus token-launch fees paid through o1 Launchpad. Legacy swap fees paid in launched tokens are excluded because they cannot be priced consistently.",
-  UserFees: "Swap fees paid by traders plus token-launch fees paid by creators.",
-  Revenue: "The platform share of swap fees plus token-launch fees received by the protocol.",
-  ProtocolRevenue: "The platform share of swap fees plus token-launch fees received by the protocol.",
-  SupplySideRevenue: "Swap fees allocated to token creators and referrers.",
-  HoldersRevenue: "No fees are distributed to token holders.",
+  Fees: "Quote-denominated swap fees plus token-launch fees, valued in USD at event time by the o1 Launchpad Dune materialized view.",
+  Revenue: "The platform and fixed protocol share of swap fees plus token-launch fees.",
 };
 
 const breakdownMethodology = {
-  Fees: {
-    [METRIC.SWAP_FEES]: "Quote-denominated fees charged when launch tokens are traded.",
-    [TOKEN_LAUNCH_FEES]: "Fees charged when a token is launched through a current production factory.",
-  },
-  UserFees: {
-    [METRIC.SWAP_FEES]: "Quote-denominated fees paid by traders.",
-    [TOKEN_LAUNCH_FEES]: "Fees paid by creators when launching a token.",
-  },
-  Revenue: {
-    [SWAP_FEES_TO_PROTOCOL]: "Swap fees allocated to the platform treasury.",
-    [TOKEN_LAUNCH_FEES_TO_PROTOCOL]: "Token-launch fees received by the platform treasury.",
-  },
-  ProtocolRevenue: {
-    [SWAP_FEES_TO_PROTOCOL]: "Swap fees allocated to the platform treasury.",
-    [TOKEN_LAUNCH_FEES_TO_PROTOCOL]: "Token-launch fees received by the platform treasury.",
-  },
-  SupplySideRevenue: {
-    [SWAP_FEES_TO_CREATORS]: "Swap fees allocated to token creators.",
-    [SWAP_FEES_TO_REFERRERS]: "Swap fees allocated to valid referrers.",
-  },
+  Fees: Object.fromEntries(MARKETS.map((market) => [
+    labels[market].fees,
+    `${market} market swap and token-launch fees.`,
+  ])),
+  Revenue: Object.fromEntries(MARKETS.map((market) => [
+    labels[market].revenue,
+    `${market} market fees retained by the protocol.`,
+  ])),
 };
 
 const adapter: SimpleAdapter = {
+  // Deliberately hourly: this only scans a precomputed materialized view, and
+  // fetch attributes its completed-day total to one hourly slot.
   version: 2,
   pullHourly: true,
+  prefetch,
   fetch,
-  adapter: chainConfig,
+  chains: [CHAIN.BASE, CHAIN.ROBINHOOD],
+  start: "2026-07-01",
+  dependencies: [Dependencies.DUNE],
+  isExpensiveAdapter: true,
   methodology,
   breakdownMethodology,
 };

--- a/fees/o1-launchpad/index.ts
+++ b/fees/o1-launchpad/index.ts
@@ -41,8 +41,12 @@ const assertOutsideMaterializedViewRefreshWindow = () => {
   }
 };
 
+const isFinalUtcHour = (options: FetchOptions) =>
+  options.endTimestamp % UTC_DAY_SECONDS === 0;
+
 const prefetch = async (options: FetchOptions) => {
   assertOutsideMaterializedViewRefreshWindow();
+  if (!isFinalUtcHour(options)) return [];
 
   return queryDuneSql(options, `
     SELECT date, chain, market, fee_usd, revenue_usd
@@ -81,7 +85,7 @@ const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
 
   // The Dune source contains completed-day totals. Hourly adapter results are
   // summed by DefiLlama, so record each daily total only in its final UTC hour.
-  if (options.endTimestamp % UTC_DAY_SECONDS !== 0) return result;
+  if (!isFinalUtcHour(options)) return result;
 
   const duneChainName = duneChainNames[options.chain];
   if (!duneChainName) throw new Error(`Unsupported o1 Launchpad chain ${options.chain}`);

--- a/fees/o1-launchpad/index.ts
+++ b/fees/o1-launchpad/index.ts
@@ -3,7 +3,6 @@ import { CHAIN } from "../../helpers/chains";
 import { queryDuneSql } from "../../helpers/dune";
 
 const DUNE_MATERIALIZED_VIEW = "dune.stambouli_o1.result_daily_fee_revenue";
-const UTC_DAY_SECONDS = 24 * 60 * 60;
 
 const MARKETS = ["Crypto", "Stocks"] as const;
 type Market = typeof MARKETS[number];
@@ -21,14 +20,16 @@ const duneChainNames: Record<string, string> = {
   [CHAIN.ROBINHOOD]: "Robinhood",
 };
 
-const labels: Record<Market, { fees: string; revenue: string }> = {
+const labels: Record<Market, { fees: string; revenue: string; supplySide: string }> = {
   Crypto: {
     fees: "Crypto Fees",
     revenue: "Crypto Fees to Protocol",
+    supplySide: "Crypto Fees to Creators and Referrers",
   },
   Stocks: {
     fees: "Stocks Fees",
     revenue: "Stocks Fees to Protocol",
+    supplySide: "Stocks Fees to Creators and Referrers",
   },
 };
 
@@ -41,12 +42,8 @@ const assertOutsideMaterializedViewRefreshWindow = () => {
   }
 };
 
-const isFinalUtcHour = (options: FetchOptions) =>
-  options.endTimestamp % UTC_DAY_SECONDS === 0;
-
 const prefetch = async (options: FetchOptions) => {
   assertOutsideMaterializedViewRefreshWindow();
-  if (!isFinalUtcHour(options)) return [];
 
   return queryDuneSql(options, `
     SELECT date, chain, market, fee_usd, revenue_usd
@@ -73,19 +70,17 @@ const toFiniteNonNegativeNumber = (
 const createEmptyResult = (options: FetchOptions) => {
   const dailyFees = options.createBalances();
   const dailyRevenue = options.createBalances();
+  const dailySupplySideRevenue = options.createBalances();
 
   return {
     dailyFees,
     dailyRevenue,
+    dailySupplySideRevenue,
   };
 };
 
 const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
   const result = createEmptyResult(options);
-
-  // The Dune source contains completed-day totals. Hourly adapter results are
-  // summed by DefiLlama, so record each daily total only in its final UTC hour.
-  if (!isFinalUtcHour(options)) return result;
 
   const duneChainName = duneChainNames[options.chain];
   if (!duneChainName) throw new Error(`Unsupported o1 Launchpad chain ${options.chain}`);
@@ -115,9 +110,11 @@ const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
       );
     }
 
+    const supplySide = fees - revenue;
     const marketLabels = labels[market];
     result.dailyFees.addUSDValue(fees, marketLabels.fees);
     result.dailyRevenue.addUSDValue(revenue, marketLabels.revenue);
+    result.dailySupplySideRevenue.addUSDValue(supplySide, marketLabels.supplySide);
   }
 
   return result;
@@ -125,7 +122,8 @@ const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
 
 const methodology = {
   Fees: "Quote-denominated swap fees plus token-launch fees, valued in USD at event time by the o1 Launchpad Dune materialized view.",
-  Revenue: "The platform and fixed protocol share of swap fees plus token-launch fees.",
+  Revenue: "The platform share of swap fees plus token-launch fees received by the protocol.",
+  SupplySideRevenue: "Swap fees allocated to token creators and referrers.",
 };
 
 const breakdownMethodology = {
@@ -137,13 +135,14 @@ const breakdownMethodology = {
     labels[market].revenue,
     `${market} market fees retained by the protocol.`,
   ])),
+  SupplySideRevenue: Object.fromEntries(MARKETS.map((market) => [
+    labels[market].supplySide,
+    `${market} market swap fees allocated to token creators and referrers.`,
+  ])),
 };
 
 const adapter: SimpleAdapter = {
-  // Deliberately hourly: this only scans a precomputed materialized view, and
-  // fetch attributes its completed-day total to one hourly slot.
-  version: 2,
-  pullHourly: true,
+  version: 1,
   prefetch,
   fetch,
   chains: [CHAIN.BASE, CHAIN.ROBINHOOD],


### PR DESCRIPTION
## Summary

Update the existing o1 Launchpad fees adapter on Base and Robinhood to use the precomputed Dune materialized view:

`dune.stambouli_o1.result_daily_fee_revenue`

This is an adapter update, not a new protocol listing or a TVL submission.

- Replace adapter-side raw-log processing with a date-filtered Dune query.
- Fetch both chains together through a shared prefetch.
- Return only `dailyFees` and `dailyRevenue`.
- Provide Crypto and Stocks breakdowns for both metrics.
- Keep the existing start date of `2026-07-01`.
- No changes to `package.json` or lockfiles.

## Methodology

- **Fees:** Quote-denominated swap fees plus token-launch fees, valued in USD at event time.
- **Revenue:** The platform and fixed protocol components of swap fees, plus token-launch fees. Creator and referrer shares are excluded from revenue.

The adapter validates the expected Crypto and Stocks rows for each chain and rejects missing or duplicate rows, non-finite or negative amounts, and revenue exceeding fees.

## Refresh and hourly handling

The materialized view is refreshed daily between 00:00 and 02:00 UTC. The adapter throws during this window before issuing a Dune query.

The source contains completed UTC-day aggregates, not genuine hourly data. With `version: 2` and `pullHourly: true`, the adapter records each daily total only in the final UTC hourly slot. Other slots return zero and skip the Dune query, preventing repeated counting and unnecessary executions.

This requests a maintainer-approved exception to the repository's usual Dune `version: 1` rule. The hourly slots are an accounting representation of daily data, not observed hourly activity.

## Validation

- `npm run ts-check` — passed.
- `DEBUG_BREAKDOWN_FEES=true npm test -- fees o1-launchpad 1788220800` — passed with Dune credentials.
- Verified that non-terminal hourly slots return zero.
- Verified that the refresh-window guard throws before querying Dune.
- `git diff --check` — passed.

Validated results for `2026-08-31`:

- Base: Fees **$70.71k**, Revenue **$37.32k**.
- Robinhood: Fees **$164.75k**, Revenue **$85.41k**.
- Combined: Fees **$235.46k**, Revenue **$122.74k**.

Live adapter tests require `DUNE_API_KEYS`. The previous fork CI run failed because this environment variable was unavailable; the credentialed local test passed. No API keys are included in this PR.

## Project links

- [Website](https://launch.o1.exchange)
- [Twitter / X](https://x.com/o1_exchange)
- [Dune analytics dashboard](https://dune.com/stambouli_o1/o1-launchpad-analytics)