### PR TITLE
[adapter] 1inch-agg - add Robinhood Chain

### DIFF
--- a/aggregators/1inch-agg/index.ts
+++ b/aggregators/1inch-agg/index.ts
@@ -39,6 +39,7 @@ const chainConfig: Record<
   [CHAIN.SOLANA]: { dune: "solana", start: "2025-04-25" },
   [CHAIN.SONIC]: { dune: "sonic", start: "2025-05-26" },
   [CHAIN.UNICHAIN]: { dune: "unichain", start: "2025-05-26" },
+  [CHAIN.ROBINHOOD]: { dune: "robinhood", start: "2026-06-23" },
 };
 
 const prefetch = async (options: FetchOptions) => {


### PR DESCRIPTION
Adds Robinhood Chain to the 1inch aggregator adapter.

- Website: https://1inch.io
- Twitter: https://x.com/1inch

## Change

One line in `aggregators/1inch-agg/index.ts`:

```ts
[CHAIN.ROBINHOOD]: { dune: "robinhood", start: "2026-06-23" },
```

No query change: the 1inch spellbook now exposes `robinhood` in `oneinch.swaps` (`exposed = ["ar", "lo", "cc"]`, duneanalytics/spellbook#9918), covering both AggregationRouterV6 deployments on the chain (`0x1111...42a65` and the chain-specific `0x5a70...89c7`).

## Dune run

`start` is `min(block_date)` present for the chain, per the convention in the file:

```sql
select min(block_date) as first_day, count(*) as rows_all,
       count(amount_usd) as rows_priced, sum(amount_usd) as usd_all
from oneinch.swaps where blockchain = 'robinhood'
```

| first_day | rows_all | rows_priced | usd_all |
|---|---|---|---|
| 2026-06-23 | 512,525 | 492,319 (96.1%) | $139,091,680 |

Matches on-chain history: first router `swap()` landed 2026-06-23T12:29:01Z.

Daily volume with the adapter's dedup logic is a continuous series from 2026-06-23 (only 06-27/28 have no swaps on chain): $176 on the first day, $7.09M on 2026-07-08, $7.53M / 19,081 swaps / 6,646 users on 2026-09-03.

Checks over 2026-08-28 - 09-04: excluding second-side duplicates, failed executions and LO/CC fills inside AR transactions moves $495 of $43.35M, so no double counting; 21,851 distinct users with top-5 = 12.8% of volume, so no wash-trading concentration.
