### PR TITLE
uniswap v2: read x layer from logs, it has published 0 for 96 days since the clickhouse migration

### DIFF
--- a/dexs/uniswap-v2.ts
+++ b/dexs/uniswap-v2.ts
@@ -82,8 +82,9 @@ const chainConfig: Record<string, {
     start: '2026-03-23',
   },
   [CHAIN.XLAYER]: {
+    // X Layer isn't in evm_indexer either, so fall back to the RPC-backed LOGS path.
     factory: '0xDf38F24fE153761634Be942F9d859f3DBA857E95',
-    source: 'CLICKHOUSE',
+    source: 'LOGS',
     start: '2026-01-05',
     feeSwitchDate: "2026-03-08",
   },


### PR DESCRIPTION
Website: https://app.uniswap.org — Twitter: https://twitter.com/Uniswap

Uniswap V2 on X Layer has published **0 every day since 2026-05-31**, 96 days. That is not a quiet chain — it is the source change.

**What happened.** #7369 (2026-06-02) moved this adapter off Dune, and X Layer went with it:

```diff
   [CHAIN.XLAYER]: {
     factory: '0xDf38F24fE153761634Be942F9d859f3DBA857E95',
-    source: 'DUNE',
+    source: 'CLICKHOUSE',
     start: '2026-01-05',
-    duneId: 'xlayer',
```

The published per-chain series lines up with that exactly — X Layer's last non-zero day is **2026-05-31**, two days before the merge, after 144 non-zero days since 2026-01-07.

**The pairs are trading.** The factory reports `allPairsLength() = 5161`, and scanning the chain for the V2 `Swap` topic over 24 hours found **1,691 swaps landing on just its 40 newest pairs**. For calibration, the same scan on Base — which this adapter publishes normally — finds 1,128 on its 40 newest.

The chain is also covered elsewhere: **Uniswap V3 still reads X Layer through Dune and publishes $855,986,551 over 30 days**, so nothing about X Layer itself is unavailable.

**The fix is the fallback this file already uses.** Zora and Ink are both on `LOGS` with the comment *"isn't in evm_indexer, so fall back to the RPC-backed LOGS path"*. X Layer is the same case, so it gets the same treatment — no new dependency, and `filterPools` still applies the whitelist and TVL floor before any log is fetched, so the pair count stays bounded.

Running the adapter on this branch:

```
$ npm run test dexs uniswap-v2.ts 2026-09-04 xlayer
Start Date:  Thu, 03 Sep 2026 00:00:00 GMT
End Date:    Fri, 04 Sep 2026 00:00:00 GMT
XLAYER
Daily volume: 481.24 k
Daily fees:   1.44 k

label           | Daily fees | Daily supply side revenue
Token Swap Fees | 1444.13    |
LP fees         |            | 1444.13
```

against the 0 that is published today. `tsc --noEmit` is clean.

Two related things I looked at and deliberately left alone:

- **Unichain** is dark the same way (last non-zero 2026-01-13, well before #7369, so a different cause). Its factory reports **1,046,214 pairs**, which makes the LOGS path the wrong answer there — Uniswap V3 reads Unichain through Dune and publishes $173,561,221 over 30 days, so that leg wants the Dune route rather than this one. Happy to do it separately if you want it.
- **Blast** reports 0 correctly: 151 pairs and **0** V2 swaps chain-wide in 24 hours. **Ink** is already on `LOGS`; its 39 pairs saw 30 swaps in 24 hours but none survive the token whitelist, so its 0 is the filter working as intended.
