### PR TITLE
layerzero: the ZRO buyback is reported as revenue, making revenue up to 122x the fees

### DIFF
--- a/fees/layerzero.ts
+++ b/fees/layerzero.ts
@@ -120,16 +120,15 @@ const fetch = async (options: FetchOptions) => {
       target: ZRO_BUYBACK_WALLET,
       tokens: [ZRO_TOKEN],
     });
-    // The buyback is funded from an allocation rather than a cut of the day's messaging fees, and
-    // it lands in one transfer a month, so booking it as revenue makes revenue exceed the fees it
-    // is supposed to be a share of. Kept to holders' revenue, the way euler books its EUL buyback.
-    dailyHoldersRevenue.addBalances(buyback.clone(1, METRIC.TOKEN_BUY_BACK));
+    const buybackHolders = buyback.clone(1, METRIC.TOKEN_BUY_BACK);
+    dailyRevenue.addBalances(buybackHolders);
+    dailyHoldersRevenue.addBalances(buybackHolders);
   }
 
   return {
     dailyFees,
     dailyRevenue,
-    dailyProtocolRevenue: dailyRevenue,
+    dailyProtocolRevenue: 0,
     dailyHoldersRevenue,
     dailySupplySideRevenue,
   };
@@ -142,8 +141,8 @@ const adapter: Adapter = {
   adapter: config,
   methodology: {
     Fees: "Native token fees paid by users for cross-chain messaging, summed from ExecutorFeePaid and DVNFeePaid events on SendUln302 (V2 default) and SendUln301 (V1-compat through V2 endpoints) across supported chains.",
-    Revenue: "Zero. LayerZero takes a 0% protocol take rate on messaging fees, so all of them are supply side.",
-    ProtocolRevenue: "Zero, for the same reason as Revenue.",
+    Revenue: "ZRO buybacks funded by Stargate ecosystem allocation routed to LayerZero Foundation. LayerZero takes a 0% protocol take rate on messaging fees.",
+    ProtocolRevenue: "LayerZero takes a 0% protocol take rate on messaging fees.",
     HoldersRevenue: "ZRO buybacks distributed to ZRO holders.",
     SupplySideRevenue: "Approximately 100% of messaging fees flow to DVNs and Executors that secure and deliver cross-chain messages.",
   },
@@ -152,7 +151,9 @@ const adapter: Adapter = {
       'DVN_FEES': "Native token fees paid to required and optional DVNs that verify cross-chain messages.",
       'EXECUTOR_FEES': "Native token fees paid to Executors that deliver and execute messages on the destination chain.",
     },
-    Revenue: "No protocol revenue; messaging fees are paid straight to DVNs and Executors.",
+    Revenue: {
+      [METRIC.TOKEN_BUY_BACK]: "ZRO bought back using Stargate ecosystem revenue.",
+    },
     HoldersRevenue: {
       [METRIC.TOKEN_BUY_BACK]: "ZRO bought back and distributed to holders.",
     },

--- a/fees/layerzero.ts
+++ b/fees/layerzero.ts
@@ -120,9 +120,10 @@ const fetch = async (options: FetchOptions) => {
       target: ZRO_BUYBACK_WALLET,
       tokens: [ZRO_TOKEN],
     });
-    const buybackHolders = buyback.clone(1, METRIC.TOKEN_BUY_BACK);
-    dailyRevenue.addBalances(buybackHolders);
-    dailyHoldersRevenue.addBalances(buybackHolders);
+    // The buyback is funded from an allocation rather than a cut of the day's messaging fees, and
+    // it lands in one transfer a month, so booking it as revenue makes revenue exceed the fees it
+    // is supposed to be a share of. Kept to holders' revenue, the way euler books its EUL buyback.
+    dailyHoldersRevenue.addBalances(buyback.clone(1, METRIC.TOKEN_BUY_BACK));
   }
 
   return {
@@ -141,8 +142,8 @@ const adapter: Adapter = {
   adapter: config,
   methodology: {
     Fees: "Native token fees paid by users for cross-chain messaging, summed from ExecutorFeePaid and DVNFeePaid events on SendUln302 (V2 default) and SendUln301 (V1-compat through V2 endpoints) across supported chains.",
-    Revenue: "ZRO buybacks funded by Stargate ecosystem allocation routed to LayerZero Foundation. LayerZero takes a 0% protocol take rate on messaging fees.",
-    ProtocolRevenue: "ZRO buybacks funded by Stargate ecosystem allocation.",
+    Revenue: "Zero. LayerZero takes a 0% protocol take rate on messaging fees, so all of them are supply side.",
+    ProtocolRevenue: "Zero, for the same reason as Revenue.",
     HoldersRevenue: "ZRO buybacks distributed to ZRO holders.",
     SupplySideRevenue: "Approximately 100% of messaging fees flow to DVNs and Executors that secure and deliver cross-chain messages.",
   },
@@ -151,9 +152,7 @@ const adapter: Adapter = {
       'DVN_FEES': "Native token fees paid to required and optional DVNs that verify cross-chain messages.",
       'EXECUTOR_FEES': "Native token fees paid to Executors that deliver and execute messages on the destination chain.",
     },
-    Revenue: {
-      [METRIC.TOKEN_BUY_BACK]: "ZRO bought back using Stargate ecosystem revenue.",
-    },
+    Revenue: "No protocol revenue; messaging fees are paid straight to DVNs and Executors.",
     HoldersRevenue: {
       [METRIC.TOKEN_BUY_BACK]: "ZRO bought back and distributed to holders.",
     },


### PR DESCRIPTION
Website: https://layerzero.network — Twitter: https://twitter.com/LayerZero_Core

LayerZero's `dailyRevenue` and `dailyProtocolRevenue` carry the monthly ZRO buyback, while `dailyFees` carries the day's messaging fees. Those are different quantities, so revenue lands above total fees every time the buyback happens:

| day | dailyFees | dailyRevenue | ratio |
|---|---|---|---|
| 2025-11-14 | 7,407 | 815,300 | **110×** |
| 2025-11-29 | 3,062 | 370,811 | 121× |
| 2026-01-15 | 6,511 | 474,860 | 73× |
| 2026-02-16 | 3,067 | 374,656 | **122×** |
| 2026-03-08 | 2,192 | 255,793 | 117× |
| 2026-04-07 | 7,107 | 264,158 | 37× |
| 2026-05-04 | 6,180 | 206,556 | 33× |
| 2026-06-02 | 5,525 | 141,229 | 26× |
| 2026-07-08 | 4,136 | 134,502 | 33× |
| 2026-08-06 | 4,897 | 131,592 | 27× |
| 2026-09-04 | 11,737 | 193,539 | 16× |

Twelve days in total, and revenue is 0 on every other day. The file's own methodology already says the opposite of what the numbers show — *"LayerZero takes a 0% protocol take rate on messaging fees"* — while `dailyProtocolRevenue` reports $193,539 for today.

**What the spike actually is.** Scanning ZRO `Transfer` logs into the buyback wallet `0x6ac55e733dff03a54251670df0667774e8f7d28f` over the last 40 days returns exactly one:

```
block 25900659  2026-09-04T01:26:47.000Z  183,904.15 ZRO
  from 0x6fbb4368893fc48d04ed9980d27a732f5ded9323
  tx   0x448d21dc93867a4715abbc0099b493136420a98d27b9b172df9b4e40d750ece2
```

One transfer a month, funded from an allocation rather than a cut of the messaging fees this adapter measures. It is real value to ZRO holders, but it is not a share of the day's fees, which is what Revenue is supposed to be.

**The fix follows what the repo already does with buybacks.** `fees/euler` books its EUL buyback into holders' revenue only, with the same reasoning written next to it:

```ts
dailyHoldersRevenue.add(..., METRIC.TOKEN_BUY_BACK)
// don't add holder revenue to dailyFees
// because, fees collected from one day, buy back back happend on days later
```

`fees/chainflip` and `fees/edgex` do the same. So the buyback stays in `dailyHoldersRevenue` here and comes out of `dailyRevenue` / `dailyProtocolRevenue`, which then match the 0% take rate the methodology states.

Ethereum leg for 2026-08-06, before and after:

```
                          upstream        this branch
Daily fees                1.68 k          1.68 k
Daily revenue           131.06 k          0.00
Daily protocol revenue  131.06 k          0.00
Daily holders revenue   131.06 k        131.06 k
Daily supply side        1.68 k          1.68 k
```

Fees and supply-side are untouched; the buyback is still reported, just on the line it belongs to. `tsc --noEmit` is clean.

If you would rather keep the buyback as revenue, the other way to make the identity hold is to add it to `dailyFees` as well — happy to switch, but euler's timing argument is why I did not: the fees that funded a given month's buyback were earned across the previous month, not on the day the transfer lands.
