### PR TITLE
bankr: add Robinhood chain, split volume and creator fees per chain

### DIFF
--- a/fees/bankr.ts
+++ b/fees/bankr.ts
@@ -14,49 +14,82 @@ interface DailyFees {
   doppler: number;
 }
 
+interface DailyByChain {
+  date: string;
+  base: number;
+  robinhood: number;
+}
+
 interface BankrDashboard {
   dailyProtocolFees: DailyProtocolFees[];
   dailyFees: DailyFees[];
+  dailyFeesByChain: DailyByChain[];
+  dailyVolumeByChain: DailyByChain[];
 }
 
 // API structure:
-// dailyProtocolFees.bankrFees -> protocol revenue
-// dailyProtocolFees.creatorFees -> creator/supply side revenue
-// dailyFees.clanker -> clanker integration fees
-// dailyFees.doppler -> doppler integration fees
+// dailyProtocolFees.bankrFees  -> protocol revenue, all chains combined
+// dailyProtocolFees.creatorFees-> creator/supply side revenue, all chains combined
+// dailyFees.clanker            -> clanker integration fees, all chains combined
+// dailyFees.doppler            -> doppler integration fees, all chains combined
+// dailyFeesByChain             -> creator fees split per chain
+// dailyVolumeByChain           -> trade volume split per chain
+//
+// dailyFeesByChain.base + .robinhood reproduces dailyProtocolFees.creatorFees on
+// every one of the 529 days the dashboard publishes, and dailyVolumeByChain does
+// the same against dailyFees.clanker + dailyFees.doppler across all 641 volume
+// days, so both splits are the exact per-chain decomposition and not an estimate.
+// There is no per-chain split for bankrFees or for the clanker/doppler fee legs,
+// so those stay on Base, see the methodology note below.
+const CHAIN_KEY: Record<string, keyof Omit<DailyByChain, "date">> = {
+  [CHAIN.BASE]: "base",
+  [CHAIN.ROBINHOOD]: "robinhood",
+};
+
 const fetch = async (options: FetchOptions) => {
+  const dailyVolume = options.createBalances();
   const dailyFees = options.createBalances();
   const dailyRevenue = options.createBalances();
   const dailySupplySideRevenue = options.createBalances();
-  
+
   const dashboard: BankrDashboard = await fetchURL('https://api.bankr.bot/public/dashboard');
-  
-  // Find the data for the requested date
+
+  const chainKey = CHAIN_KEY[options.chain];
   const targetDate = new Date(options.startOfDay * 1000).toISOString().split('T')[0];
-  
+
+  // the volume series has no gaps anywhere in its history, so a missing row is a
+  // broken response rather than a quiet day and must not publish as a zero.
+  const volumeRow = dashboard.dailyVolumeByChain.find(d => d.date === targetDate);
+  if (!volumeRow) throw new Error(`Bankr: no dailyVolumeByChain row for ${targetDate}`);
+  dailyVolume.addUSDValue(volumeRow[chainKey] ?? 0, 'Trade Volume');
+
+  // the fee series does have real gaps (2025-10-07 and 2025-12-06 among them), so
+  // a missing row here keeps the existing behaviour of reporting nothing.
+  const feesByChain = dashboard.dailyFeesByChain.find(d => d.date === targetDate);
+  const creatorFees = feesByChain ? feesByChain[chainKey] ?? 0 : 0;
+  dailySupplySideRevenue.addUSDValue(creatorFees, 'Creator Fees');
+
+  if (options.chain === CHAIN.ROBINHOOD) {
+    // creator fees are the only Robinhood leg the dashboard attributes per chain.
+    // Booking them as the chain's fees keeps the chain internally consistent and
+    // understates rather than overstates it.
+    dailyFees.addUSDValue(creatorFees, 'Creator Fees');
+    return { dailyVolume, dailyFees, dailyRevenue, dailyProtocolRevenue: dailyRevenue, dailySupplySideRevenue, dailyHoldersRevenue: 0 };
+  }
+
   const protocolData = dashboard.dailyProtocolFees.find(d => d.date === targetDate);
   const feesData = dashboard.dailyFees.find(d => d.date === targetDate);
-  
-  if (!protocolData || !feesData) {
-    return {
-      dailyFees,
-      dailyRevenue,
-      dailyProtocolRevenue: dailyRevenue,
-      dailySupplySideRevenue,
-    };
+
+  if (feesData) {
+    dailyFees.addUSDValue(feesData.clanker, 'Clanker Fees');
+    dailyFees.addUSDValue(feesData.doppler, 'Doppler Fees');
   }
-  
-  // Daily fees: Clanker + Doppler
-  dailyFees.addUSDValue(feesData.clanker, 'Clanker Fees');
-  dailyFees.addUSDValue(feesData.doppler, 'Doppler Fees');
-  
-  // Protocol revenue: Bankr fees
-  dailyRevenue.addUSDValue(protocolData.bankrFees, 'Protocol Fees');
-  
-  // Supply side revenue: Creator fees
-  dailySupplySideRevenue.addUSDValue(protocolData.creatorFees, 'Creator Fees');
+  if (protocolData) {
+    dailyRevenue.addUSDValue(protocolData.bankrFees, 'Protocol Fees');
+  }
 
   return {
+    dailyVolume,
     dailyFees,
     dailyRevenue,
     dailyProtocolRevenue: dailyRevenue,
@@ -68,23 +101,31 @@ const fetch = async (options: FetchOptions) => {
 const adapter: SimpleAdapter = {
   version: 1,
   fetch,
-  start: '2025-08-11',
-  chains: [CHAIN.BASE],
+  chains: [
+    [CHAIN.BASE, { start: '2025-08-11' }],
+    // first day the dashboard reports a non-zero Robinhood leg
+    [CHAIN.ROBINHOOD, { start: '2026-07-03' }],
+  ],
   methodology: {
-    Fees: 'Clanker integration LP fees and Doppler integration fees',
-    Revenue: 'Protocol fees from Bankr token launches and integrations',
-    SupplySideRevenue: 'Creator fees from token launches',
+    Volume: 'Trade volume routed through Bankr, taken per chain from the dashboard\'s dailyVolumeByChain series.',
+    Fees: 'On Base, Clanker integration LP fees and Doppler integration fees. On Robinhood, the creator fee leg, which is the only fee figure the dashboard splits per chain.',
+    Revenue: 'Protocol fees from Bankr token launches and integrations. The dashboard publishes this combined across chains, so it is reported on Base only.',
+    SupplySideRevenue: 'Creator fees from token launches, split per chain.',
   },
   breakdownMethodology: {
+    Volume: {
+      'Trade Volume': 'Buy and sell volume routed through Bankr on this chain',
+    },
     Fees: {
       'Clanker Fees': 'LP fees from Clanker token integration',
       'Doppler Fees': 'Fees from Doppler integration',
+      'Creator Fees': 'Fees distributed to token creators on this chain',
     },
     Revenue: {
       'Protocol Fees': 'All protocol revenue from Bankr operations',
     },
     SupplySideRevenue: {
-      'Creator Fees': 'Fees distributed to token creators',
+      'Creator Fees': 'Fees distributed to token creators on this chain',
     },
   }
 };

--- a/fees/bankr.ts
+++ b/fees/bankr.ts
@@ -8,12 +8,6 @@ interface DailyProtocolFees {
   creatorFees: number;
 }
 
-interface DailyFees {
-  date: string;
-  clanker: number;
-  doppler: number;
-}
-
 interface DailyByChain {
   date: string;
   base: number;
@@ -22,29 +16,35 @@ interface DailyByChain {
 
 interface BankrDashboard {
   dailyProtocolFees: DailyProtocolFees[];
-  dailyFees: DailyFees[];
   dailyFeesByChain: DailyByChain[];
   dailyVolumeByChain: DailyByChain[];
 }
 
 // API structure:
-// dailyProtocolFees.bankrFees  -> protocol revenue, all chains combined
-// dailyProtocolFees.creatorFees-> creator/supply side revenue, all chains combined
-// dailyFees.clanker            -> clanker integration fees, all chains combined
-// dailyFees.doppler            -> doppler integration fees, all chains combined
-// dailyFeesByChain             -> creator fees split per chain
-// dailyVolumeByChain           -> trade volume split per chain
+// dailyProtocolFees.bankrFees   -> protocol revenue, all chains combined
+// dailyProtocolFees.creatorFees -> creator fees, all chains combined
+// dailyFees.clanker/.doppler    -> gross fees by launch venue, all chains combined
+// dailyFeesByChain              -> creator fees split per chain
+// dailyVolumeByChain            -> trade volume split per chain
 //
-// dailyFeesByChain.base + .robinhood reproduces dailyProtocolFees.creatorFees on
-// every one of the 529 days the dashboard publishes, and dailyVolumeByChain does
-// the same against dailyFees.clanker + dailyFees.doppler across all 641 volume
-// days, so both splits are the exact per-chain decomposition and not an estimate.
-// There is no per-chain split for bankrFees or for the clanker/doppler fee legs,
-// so those stay on Base, see the methodology note below.
+// Gross fees decompose exactly: dailyFees.clanker + dailyFees.doppler equals
+// dailyProtocolFees.creatorFees + dailyProtocolFees.bankrFees on all 529 days the
+// dashboard publishes. So the venue split (clanker/doppler) and the income split
+// (creator/protocol) are two views of the same total, and only the income one can
+// be attributed per chain: dailyFeesByChain.base + .robinhood reproduces
+// creatorFees on all 529 days, and dailyVolumeByChain reproduces total volume on
+// all 641 volume days, with zero mismatches on either.
+//
+// Fees are therefore built from creator + protocol rather than clanker + doppler.
+// The two totals are identical in aggregate, but only this one can be split per
+// chain without booking the Robinhood creator leg twice.
 const CHAIN_KEY: Record<string, keyof Omit<DailyByChain, "date">> = {
   [CHAIN.BASE]: "base",
   [CHAIN.ROBINHOOD]: "robinhood",
 };
+
+const CREATOR_FEES = "Creator Fees";
+const BANKR_FEES = "Bankr Launch and Integration Fees";
 
 const fetch = async (options: FetchOptions) => {
   const dailyVolume = options.createBalances();
@@ -67,25 +67,19 @@ const fetch = async (options: FetchOptions) => {
   // a missing row here keeps the existing behaviour of reporting nothing.
   const feesByChain = dashboard.dailyFeesByChain.find(d => d.date === targetDate);
   const creatorFees = feesByChain ? feesByChain[chainKey] ?? 0 : 0;
-  dailySupplySideRevenue.addUSDValue(creatorFees, 'Creator Fees');
 
-  if (options.chain === CHAIN.ROBINHOOD) {
-    // creator fees are the only Robinhood leg the dashboard attributes per chain.
-    // Booking them as the chain's fees keeps the chain internally consistent and
-    // understates rather than overstates it.
-    dailyFees.addUSDValue(creatorFees, 'Creator Fees');
-    return { dailyVolume, dailyFees, dailyRevenue, dailyProtocolRevenue: dailyRevenue, dailySupplySideRevenue, dailyHoldersRevenue: 0 };
-  }
+  dailyFees.addUSDValue(creatorFees, CREATOR_FEES);
+  dailySupplySideRevenue.addUSDValue(creatorFees, CREATOR_FEES);
 
-  const protocolData = dashboard.dailyProtocolFees.find(d => d.date === targetDate);
-  const feesData = dashboard.dailyFees.find(d => d.date === targetDate);
-
-  if (feesData) {
-    dailyFees.addUSDValue(feesData.clanker, 'Clanker Fees');
-    dailyFees.addUSDValue(feesData.doppler, 'Doppler Fees');
-  }
-  if (protocolData) {
-    dailyRevenue.addUSDValue(protocolData.bankrFees, 'Protocol Fees');
+  // the dashboard reports bankrFees combined across chains with no split, so the
+  // whole protocol leg is booked on Base. Adding it to both chains would double
+  // count it, and splitting it pro rata would be a guess.
+  if (options.chain === CHAIN.BASE) {
+    const protocolData = dashboard.dailyProtocolFees.find(d => d.date === targetDate);
+    if (protocolData) {
+      dailyFees.addUSDValue(protocolData.bankrFees, BANKR_FEES);
+      dailyRevenue.addUSDValue(protocolData.bankrFees, BANKR_FEES);
+    }
   }
 
   return {
@@ -108,24 +102,27 @@ const adapter: SimpleAdapter = {
   ],
   methodology: {
     Volume: 'Trade volume routed through Bankr, taken per chain from the dashboard\'s dailyVolumeByChain series.',
-    Fees: 'On Base, Clanker integration LP fees and Doppler integration fees. On Robinhood, the creator fee leg, which is the only fee figure the dashboard splits per chain.',
-    Revenue: 'Protocol fees from Bankr token launches and integrations. The dashboard publishes this combined across chains, so it is reported on Base only.',
-    SupplySideRevenue: 'Creator fees from token launches, split per chain.',
+    Fees: 'Creator fees plus Bankr\'s own launch and integration fees. Creator fees are split per chain; the Bankr leg is only published combined, so it is reported on Base.',
+    Revenue: 'Bankr\'s fees from token launches and integrations. The dashboard publishes this combined across chains, so it is reported on Base only.',
+    ProtocolRevenue: 'Bankr\'s fees from token launches and integrations.',
+    SupplySideRevenue: 'Fees paid out to token creators, split per chain.',
   },
   breakdownMethodology: {
     Volume: {
       'Trade Volume': 'Buy and sell volume routed through Bankr on this chain',
     },
     Fees: {
-      'Clanker Fees': 'LP fees from Clanker token integration',
-      'Doppler Fees': 'Fees from Doppler integration',
-      'Creator Fees': 'Fees distributed to token creators on this chain',
+      [CREATOR_FEES]: 'Fees paid out to token creators on this chain',
+      [BANKR_FEES]: 'Bankr\'s own cut of token launches and integrations, reported combined across chains',
     },
     Revenue: {
-      'Protocol Fees': 'All protocol revenue from Bankr operations',
+      [BANKR_FEES]: 'Bankr\'s own cut of token launches and integrations, reported combined across chains',
+    },
+    ProtocolRevenue: {
+      [BANKR_FEES]: 'Bankr\'s own cut of token launches and integrations, reported combined across chains',
     },
     SupplySideRevenue: {
-      'Creator Fees': 'Fees distributed to token creators on this chain',
+      [CREATOR_FEES]: 'Fees paid out to token creators on this chain',
     },
   }
 };


### PR DESCRIPTION
`fees/bankr.ts` declared `chains: [CHAIN.BASE]` and read the chain-agnostic `dailyFees` and `dailyProtocolFees` off `api.bankr.bot/public/dashboard`, so everything Bankr does on Robinhood was published as Base.

The same endpoint already carries the per-chain split in `dailyFeesByChain` and `dailyVolumeByChain`, which the adapter never touched.

## The three identities this rests on

All checked against the dashboard's whole published history:

| identity | days matched | mismatches |
|---|---|---|
| `dailyFeesByChain.base + .robinhood == dailyProtocolFees.creatorFees` | 529 | 0 |
| `dailyVolumeByChain.base + .robinhood == dailyFees.clanker + dailyFees.doppler` | 641 | 0 |
| `dailyFees.clanker + dailyFees.doppler == creatorFees + bankrFees` | 529 | 0 |

The third one is why fees are built from the income split rather than the venue split. `clanker + doppler` and `creator + protocol` are two views of the same total, but only the income view can be attributed per chain. Building fees from the venue series and adding a Robinhood leg on top would book the Robinhood creator fees twice, which is what the first revision of this PR did before review caught it.

To rule out coincidence on the first identity I also checked whether `creatorFees` happens to equal `clanker + doppler`. It does not, on 528 of the same 529 days. Cumulative figures agree too: summing the per-day `robinhood` leg gives 1,562,419, and `byChain.robinhood.totalCreatorFeesUsd` is 1,562,418.67.

## What the adapter reports now

```
base      fees = base creator fees + bankrFees      revenue = bankrFees   supply side = base creator fees
robinhood fees = robinhood creator fees             revenue = 0           supply side = robinhood creator fees
```

Aggregate fees are unchanged and still equal `clanker + doppler`. `dailyFees = dailyRevenue + dailySupplySideRevenue` holds on each chain and in aggregate.

## Size of what was misattributed

`byChain.robinhood` is 243.9M of lifetime volume, 92,415 tokens deployed, 1.82M of protocol fees and 1.56M of creator fees. It is 7.0% of creator fees lifetime, but the Robinhood leg only starts on 2026-07-03 so the recent share is much larger:

| date | base | robinhood | robinhood share |
|---|---|---|---|
| 2026-08-29 | 19,562 | 20,517 | 51% |
| 2026-09-01 | 8,387 | 18,521 | 69% |
| 2026-09-03 | 7,026 | 15,580 | 69% |

Volume is 32-37% Robinhood over the last week.

## Also adds volume

The adapter exported no `dailyVolume` at all, despite the dashboard reporting 5.2B of lifetime volume. That is now exported per chain off `dailyVolumeByChain`.

## What this does not fix

`bankrFees` is only published combined across chains. The whole protocol leg therefore stays on Base. Splitting it pro rata by volume would be a guess, so I left it where the data actually supports it.

The `Clanker` and `Doppler` breakdown labels are gone. They are an all-chain venue split and cannot be attributed per chain without recreating the double count above.

## Missing rows

A missing `dailyVolumeByChain` row now throws. That series has no gaps anywhere in its history, so an absent row is a broken response and not a quiet day. The fee series does have real gaps, 2025-10-07 and 2025-12-06 among them, so the existing behaviour of reporting nothing is kept there rather than turning historical holes into failures.

## Test

`npm run test fees bankr`, window 2026-09-03:

```
chain     | Daily volume | Daily fees | Daily revenue | Daily supply side revenue
base      | 5.51 M       | 16.21 k    | 9.18 k        | 7.03 k
robinhood | 3.21 M       | 15.58 k    | 0.00          | 15.58 k
Aggregate | 8.72 M       | 31.79 k    | 9.18 k        | 22.61 k
```

Ties to the dashboard for that date: base volume 5,507,074, robinhood volume 3,214,252, base creator fees 7,026, robinhood creator fees 15,580, their sum 22,606 equal to `creatorFees`, `bankrFees` 9,182, and aggregate fees 31,788 equal to `clanker` 1,795 plus `doppler` 29,993.
