### PR TITLE
clanker: add Robinhood chain

### DIFF
--- a/fees/clanker.ts
+++ b/fees/clanker.ts
@@ -37,6 +37,13 @@ const CHAIN_CONFIG: Record<string, { feeWallets: string[]; weth: string; start: 
     weth: CoreAddresses.monad.WETH,
     start: "2025-10-20",
   },
+  [CHAIN.ROBINHOOD]: {
+    // the Clanker factory itself, same role the clanker_factory entry plays on
+    // base and unichain. Deployed 2026-07-08 at block 4570632.
+    feeWallets: ['0xD3f2cC1731b7Fd17f28798835C2E02f0a1839A94'],
+    weth: CoreAddresses.robinhood.WETH,
+    start: "2026-07-08",
+  },
 };
 
 const fetch = async (options: FetchOptions) => {


### PR DESCRIPTION
Clanker has been live on Robinhood Chain since 2026-07-08 and `fees/clanker.ts` never had an entry for it. On a same day run the chain produces more fees than Base does.

## The deployment

The whole v4 stack is deployed and verified on the explorer. I found it from a live pool rather than by name matching: GeckoTerminal's top `clanker-robinhood` pool is `0xZAPS / WETH`, its base token `0xDd90bFa4adC7F4401E611AbaC692D939F9F4CB07` is a `ClankerToken`, and the deployment transaction touches

| contract | address |
|---|---|
| Clanker (factory) | `0xD3f2cC1731b7Fd17f28798835C2E02f0a1839A94` |
| ClankerLpLockerFeeConversion | `0x290F735F63824BB5836cDe24a35F5103A5B5Bc99` |
| ClankerHookStaticFeeV2 | `0x48B8F6AD3A1b4aA477314c9a23035b8F84dDe8cc` |

The factory was deployed at block 4570632, 2026-07-08. It is the fee wallet, the same role the `clanker_factory` entry already plays on base and unichain, and it takes WETH straight from the PoolManager on every swap. It holds 11.6 WETH today.

None of the fee wallets already in `CHAIN_CONFIG` exist on Robinhood, so this is a new address rather than a reused one. I checked all six, every one is codeless with zero balance there.

## Checking the fee split actually holds here

The adapter models Clanker's cut as 1/6 of the total fee, `dailyFees = rawRevenue.clone(6)` and `dailySupplySideRevenue = rawRevenue.clone(5)`, from the 0.2% protocol fee charged on top of a 1.0% creator fee. Rather than assume that config carries over to a new chain, I measured it.

Over blocks 54424556 to 54434192 there are 16 transactions that pay both the factory and the LP locker. The locker to factory ratio:

```
4.9807  4.9904  4.9601  4.9922  4.9922  4.0413  4.9814  4.9922
4.9801  4.9755  4.9920  4.9755  4.9818  4.9922  4.9922  4.9922
```

15 of 16 sit in 4.96 to 4.99 against the 5.00 the documented split implies. So the creators are paid 5x what the factory takes here, same as elsewhere, and the existing `clone(6)` and `clone(5)` handling is correct without modification.

The CLANKER buyback leg stays gated to Base. No buyback wallet exists on Robinhood.

## Test

`npm run test fees clanker`, window 2026-09-04:

```
chain     | Daily fees | Daily revenue | Daily supply side revenue
base      | 10.53 k    | 1.75 k        | 8.77 k
arbitrum  | 0.10       | 0.02          | 0.09
unichain  | 0.00       | 0.00          | 0.00
ethereum  | 21.04      | 3.51          | 17.53
monad     | 0.00       | 0.00          | 0.00
robinhood | 12.56 k    | 2.09 k        | 10.47 k
Aggregate | 23.11 k    | 3.85 k        | 19.26 k
```

Aggregate goes from 10.55k to 23.11k. Robinhood supply side over revenue is 5.01, matching the on chain ratio above.
