### PR TITLE
tessera: solana leg is short by half every day, same dune indexing wait as #9221

### DIFF
--- a/dexs/tessera/index.ts
+++ b/dexs/tessera/index.ts
@@ -3,8 +3,11 @@
 import { Dependencies, FetchOptions, FetchResult, SimpleAdapter } from "../../adapters/types"
 import { CHAIN } from "../../helpers/chains"
 import { queryDuneSql } from "../../helpers/dune"
+import { assertDuneSolanaIndexed } from "../../helpers/duneSolanaDex"
 
 const fetchSolana = async (options: FetchOptions) => {
+  assertDuneSolanaIndexed(options)
+
   const query = `
     select 
       sum(amount_usd) as daily_volume


### PR DESCRIPTION
Website: https://tessera.trade — Twitter: https://twitter.com/tessera_trade

Follow-up to #9221. Tessera has the same Dune indexing shortfall, and measured per chain it is much larger than the protocol-level number I quoted in that PR. Its published Solana leg against the same query run today:

| day | published (Solana leg) | same query today | short by |
|---|---|---|---|
| 2026-08-20 | 109,099,072 | 214,910,925 | **-49.2%** |
| 2026-08-31 | 60,808,040 | 121,495,294 | -50.0% |
| 2026-09-01 | 26,410,846 | 114,590,893 | **-77.0%** |
| 2026-09-02 | 33,783,152 | 77,646,886 | -56.5% |
| 2026-09-03 | 43,553,023 | 122,054,854 | -64.3% |

Around half the Solana volume is missing every day — $78.5M on 2026-09-03 alone, on a protocol that publishes about $93M a day in total.

**Why it was held back, and what changed.** I left this one out of #9221 because the adapter also runs Base and BSC, and `getChainResult` rethrows inside `runAdapter`'s `Promise.all`, so one chain throwing drops the whole run. The question was whether that loses the EVM legs or merely delays them.

It delays them. `dexs/trading-terminal` and `fees/trading-terminal` already carry exactly this wait on a Solana leg alongside EVM chains, and their EVM legs publish normally — `fees/terminal` has 256 non-zero days on Ethereum, 229 on Base and 225 on BSC out of 314 points. The run is retried, not lost.

On this branch:

```
$ npm run test dexs tessera 2026-09-04 solana
SOLANA
Daily volume: 122.06 M            (published for that day: 43,553,023)

$ npm run test dexs tessera 2026-09-06 solana
End timestamp is less than 10 hours ago, skipping fetch due to dune indexing delay
  2026-09-05T23:59:59.000Z  2026-09-04T08:40:49.948Z

$ npm run test dexs tessera 2026-09-04 base
BASE
Daily volume: 35.99 M             (EVM leg unchanged)
```

`tsc --noEmit` is clean. The `test` check will be red because the runner has no Dune key.

This is the last of the five adapters with that shape; the other four went in with #9221.
