### PR TITLE
blackhole-CL, supernova-CL: pool discovery asks for an event neither factory emits

### DIFF
--- a/dexs/blackhole-CL.ts
+++ b/dexs/blackhole-CL.ts
@@ -4,7 +4,7 @@ import { filterPools } from "../helpers/uniswap";
 import { ethers } from "ethers";
 import { addOneToken } from "../helpers/prices";
 
-const poolEvent = 'event CustomPool(address indexed token0, address indexed token1, address pool)'
+const poolEvent = 'event Pool(address indexed token0, address indexed token1, address pool)'
 const customPoolEvent = 'event CustomPool(address indexed deployer, address indexed token0, address indexed token1, address pool)'
 const poolSwapEvent = 'event Swap(address indexed sender, address indexed recipient, int256 amount0, int256 amount1, uint160 sqrtPriceX96, uint128 liquidity, int24 tick)'
 const globalStateAbi = 'function globalState() view returns (uint160 price, int24 tick, uint16 lastFee, uint8 pluginConfig, uint16 communityFee, bool unlocked)'

--- a/dexs/supernova-CL.ts
+++ b/dexs/supernova-CL.ts
@@ -4,7 +4,7 @@ import { filterPools } from "../helpers/uniswap";
 import { ethers } from "ethers";
 import { addOneToken } from "../helpers/prices";
 
-const poolEvent = 'event CustomPool(address indexed token0, address indexed token1, address pool)'
+const poolEvent = 'event Pool(address indexed token0, address indexed token1, address pool)'
 const customPoolEvent = 'event CustomPool(address indexed deployer, address indexed token0, address indexed token1, address pool)'
 const poolSwapEvent = 'event Swap(address indexed sender, address indexed recipient, int256 amount0, int256 amount1, uint160 sqrtPriceX96, uint128 liquidity, int24 tick)'
 const globalStateAbi = 'function globalState() view returns (uint160 price, int24 tick, uint16 lastFee, uint8 pluginConfig, uint16 communityFee, bool unlocked)'


### PR DESCRIPTION
Website: https://blackhole.xyz / https://supernova.finance — Twitter: https://twitter.com/blackholedex

Both adapters ask their Algebra factory for a pool-creation event that does not exist.

```ts
const poolEvent       = 'event CustomPool(address indexed token0, address indexed token1, address pool)'
const customPoolEvent = 'event CustomPool(address indexed deployer, address indexed token0, address indexed token1, address pool)'
```

`keccak256("CustomPool(address,address,address)")` is `0xd1d363de4c22d7cd3cf84bbc63838640649a6a45bd1f0969cfe684c79705f1ad`. The public signature database has no entry for it, and scanning each factory from its `fromBlock` to head returns nothing:

| adapter | chain | factory | `Pool(...)` | `CustomPool(4-arg)` | the configured `poolEvent` |
|---|---|---|---|---|---|
| blackhole-CL | avax | `0x512eb749…` | **2** | 65 | **0** |
| supernova-CL | ethereum | `0x44b7fbd4…` | **0** | 52 | **0** |

(0 failed chunks on both, with retries; an earlier pass that swallowed chunk errors under-counted, which is why the numbers are stated with the failure count.)

Decoding what the blackhole factory actually emits:

```
0x8a5f030f…  CustomPool(address,address,address,address)   65   <- the second call already matches this
0x91ccaa7a…  Pool(address,address,address)                  2   <- nobody asks for this
0x2f878811…  RoleGranted / 0xf6391f5c… RoleRevoked / 0x5e38e259… DefaultPluginFactory
```

Algebra's standard creation event is `Pool(address indexed token0, address indexed token1, address pool)`; the 4-argument `CustomPool` the second call already asks for is the custom-deployer variant. So the first call can never match, and standard (non-custom) pools are never discovered.

**This changes nothing today, and I would rather say so than dress it up.** Both pools blackhole created through `Pool(...)` are empty:

```
0x61c48716f6e03229b1e250aefddf429c48e75165  WAVAX/0xcd94a876…  liquidity=0  swaps in 24h=0
0xab463b94c20d5a8296190e5025ca2c31e075c56c  WAVAX/0xc541C985…  liquidity=0  swaps in 24h=0
```

and supernova has never created one. Running both adapters before and after:

```
                     upstream            this branch
blackhole-CL avax    volume 7.03 M       volume 7.02 M
                     fees   2.89 k       fees   2.89 k
                     rev    2.83 k       rev    2.83 k
supernova-CL eth     volume 407.05 k     volume 406.91 k
                     fees   359.73       fees   359.70
                     rev    353.90       rev    353.87
```

The difference is intra-run pricing, under 0.04%.

What the change buys is that the path stops being latently broken: the moment either protocol creates a standard pool with liquidity, its volume would silently go missing, and blackhole has already created two that way. It also stops a full-history `getLogs` from block 65,218,551 / 24,390,427 that can never return a row.

`tsc --noEmit` is clean. Both files carry the identical constant and were changed together in #8354, so they are in one PR here for the same reason; happy to split if you prefer.
