### PR TITLE
ave.ai: base leg reads a router that stopped emitting, published 0 since 2026-07-24

### DIFF
--- a/dexs/aveai/index.ts
+++ b/dexs/aveai/index.ts
@@ -3,40 +3,48 @@ import { CHAIN } from "../../helpers/chains";
 import ADDRESSES from "../../helpers/coreAssets.json";
 import { queryDuneSql } from "../../helpers/dune";
 
-const chainConfig: Record<string, { start: string; router: string; swapEvent?: string }> = {
+const chainConfig: Record<string, { start: string; routers: string[]; swapEvent?: string }> = {
   [CHAIN.BASE]: {
     start: "2025-07-03",
-    router: "0x282970F452371454332Ca522cE59F318a2C81484",
+    // The first router stopped emitting and Base has published 0 since 2026-07-24. The other two
+    // are byte-identical redeployments of it under the same owner, 0x31781b4E7FB61756BD0a0Ef7850d5e7bf6270FC4,
+    // which also owns the router on every other chain here.
+    routers: [
+      "0x282970F452371454332Ca522cE59F318a2C81484",
+      "0x8a33650bbBd7622D7bF1b98d4ae851c134126C18",
+      "0xf0eBB9bA1c3cd95c315f4F80197b85782E756e49",
+    ],
     swapEvent: "event Swap(address trader, address tokenIn, address tokenOut, address recipient, uint256 amountIn, uint256 amountOut)",
   },
   [CHAIN.BSC]: {
     start: "2025-07-03",
-    router: "0xd270845b7EBb0B013DfCCD9cA782a57Bfb7A359A",
+    routers: ["0xd270845b7EBb0B013DfCCD9cA782a57Bfb7A359A"],
     swapEvent: "event Swap(address trader, address tokenIn, address tokenOut, address recipient, uint256 amountIn, uint256 amountOut)",
   },
   [CHAIN.ETHEREUM]: {
     start: "2025-07-15",
-    router: "0x60943cb06b76A24431659165c81a03c16F1C325C",
+    routers: ["0x60943cb06b76A24431659165c81a03c16F1C325C"],
     swapEvent: "event Swap(address trader, address tokenIn, address tokenOut, address recipient, uint256 amountIn, uint256 amountOut)",
   },
   [CHAIN.HYPERLIQUID]: {
     start: "2025-05-31",
-    router: "0x81DA6BCd98AE46621A1E9743a3F51B10B7e16D97",
+    routers: ["0x81DA6BCd98AE46621A1E9743a3F51B10B7e16D97"],
     swapEvent: "event Swap(address trader, address tokenIn, address tokenOut, address recipient, uint256 amountIn, uint256 amountOut)",
   },
   [CHAIN.SOLANA]: {
     start: "2025-01-17",
-    router: "AveaiuA1emN71q9mS2QQ9BEWNAAHmp8sHSvwLFHQjufM",
+    routers: ["AveaiuA1emN71q9mS2QQ9BEWNAAHmp8sHSvwLFHQjufM"],
   },
 };
 
 const fetchEVM = async (options: FetchOptions): Promise<FetchResult> => {
   const dailyVolume = options.createBalances();
-  const { router, swapEvent } = chainConfig[options.chain];
+  const { routers, swapEvent } = chainConfig[options.chain];
 
   const logs = await options.getLogs({
-    target: router,
+    targets: routers,
     eventAbi: swapEvent,
+    flatten: true,
   });
 
   logs.forEach((log) => {
@@ -51,7 +59,7 @@ const fetchEVM = async (options: FetchOptions): Promise<FetchResult> => {
 };
 
 const fetchSolana = async (options: FetchOptions): Promise<FetchResult> => {
-  const { router } = chainConfig[CHAIN.SOLANA];
+  const [router] = chainConfig[CHAIN.SOLANA].routers;
 
   // Use 10 hours delay as dune has indexing delay for dex_solana.trades table
   const tenHoursAgo = Date.now() - (10 * 60 * 60 * 1000);


### PR DESCRIPTION
Website: https://ave.ai — Twitter: https://twitter.com/AveAi_Official

ave.ai's Base leg has published **0 since 2026-07-24**. The router it reads has stopped emitting; the swaps moved to redeployments of the same contract.

**The configured router is silent, and it is not a scan artifact.** A seven-day chain-wide scan of the adapter's own Swap topic (`0x20efd6d5…`) on Base, **101 of 101 chunks, zero failures**:

| address | Swap logs / 7d | owner() | runtime code |
|---|---|---|---|
| `0x282970F4…` **configured** | **0** | `0x31781b4E…` | 2227 bytes |
| `0x8a33650b…` | 1,796 | `0x31781b4E…` | **byte-identical to the configured router** |
| `0xf0eBB9bA…` | 414 | `0x31781b4E…` | **byte-identical to the configured router** |
| `0x4f5ea345…` | 261 | `0x31781b4E…` | 7484 bytes — same owner, different contract |
| `0x589ff9f1…` | 1,833 | `0x6a74649a…` | 3710 bytes — **different owner, not ave.ai** |

**Attribution, since that Swap signature is generic enough that another protocol could use it.** `owner()` on the configured router is `0x31781b4E7FB61756BD0a0Ef7850d5e7bf6270FC4`, and the same address owns ave.ai's router on every other chain in this file — all four with identical 2227-byte runtime code:

```
ethereum     0x60943cb06b76A24431659165c81a03c16F1C325C  owner=0x31781b4E…  codeLen=2227
bsc          0xd270845b7EBb0B013DfCCD9cA782a57Bfb7A359A  owner=0x31781b4E…  codeLen=2227
hyperliquid  0x81DA6BCd98AE46621A1E9743a3F51B10B7e16D97  owner=0x31781b4E…  codeLen=2227
base         0x282970F452371454332Ca522cE59F318a2C81484  owner=0x31781b4E…  codeLen=2227
```

The two added routers have that owner **and** byte-identical code, so they are the same contract redeployed. `0x589ff9f1…`, which emits more of these events than either of them, has a different owner and is deliberately excluded — that is the whole reason for checking rather than adding every emitter of the topic.

**`0x4f5ea345…` is left out on purpose.** It shares the owner but not the bytecode, so I can show it is run by the same operator but not that it is the same aggregator product, and over-counting is worse than under-counting. It is 261 of the 2,471 same-owner logs; happy to add it if you know it belongs.

Result — `chainConfig` now takes a `routers` list and the fetch uses `targets`:

```
$ npm run test dexs aveai 2026-09-04 base
BASE   Daily volume: 0.00        (upstream)
BASE   Daily volume: 28.10 k     (this branch)

$ npm run test dexs aveai 2026-09-04 ethereum
ETHEREUM  Daily volume: 53.86 k  (unchanged; published 55,514)
```

`tsc --noEmit` is clean.

One thing I could not establish: the BSC leg last published on 2026-08-15 and may be the same story, but every wide `eth_getLogs` I tried against the public BSC endpoints failed (26 of 26 chunks), so I have no evidence either way and have left BSC alone rather than guess.
