### PR TITLE
[feat] Loopr - add fees and revenue adapter

### DIFF
--- a/fees/loopr.ts
+++ b/fees/loopr.ts
@@ -1,0 +1,213 @@
+import { FetchOptions, SimpleAdapter } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+
+// LooprBasketFactory (permissionless registry of LooprBasket index tokens),
+// deployed 2026-09-03 — the adapter's `start` date must not predate this,
+// since basketCount()/baskets() are direct contract calls that fail against
+// blocks pinned before the factory existed (unlike getLogs, which just
+// returns an empty range for a pre-deployment period).
+const FACTORY = "0xf6B7e67816622a1E6dDb898EEB09cA8eb8e3D2B0";
+const BASKETS_ABI =
+  "function baskets(uint256) view returns (address basket, address creator, bool active)";
+const CONSTITUENTS_ABI = "address[]:constituents";
+const UNITS_PER_SHARE_ABI = "uint256[]:unitsPerShare";
+const MINTED_ABI =
+  "event Minted(address indexed sender, address indexed to, uint256 basketAmount, uint256 fee)";
+
+const CREATOR_FEE_SHARE_BPS = 7_000n; // 70% of a basket's mint fee to that basket's own creator
+const BPS_DENOM = 10_000n;
+const ONE_E18 = 1_000_000_000_000_000_000n;
+
+// LOOPR is Loopr's own token, launched through Pons;
+const PONS_HOOK = "0xE5e702641Ea86F4ae6cC3cDaeD2B886f976Be044";
+const LOOPR_POOL_ID =
+  "0x3658188598546bc4b1c3abf66cee57b23cf917ec820c33a6a511e8bb0d2e90ef";
+const POOL_FEES_SWEPT_TOPIC0 =
+  "0x2f3c43579b9064b6f28edcf41608f3815792d274a56afe024359703cb4ea9b30";
+const POOL_FEES_SWEPT_ABI =
+  "event PoolFeesSwept(bytes32 indexed poolId, uint256 protocolAmount, uint256 buybackAmount, uint256 creatorAmount, uint256 tokensLocked)";
+
+// LooprCommunityVault — Loopr's own buyback-and-burn contract. Holds ETH from
+// sponsorships/partnerships/creator-tax sweeps and burns LOOPR bought against
+// the live pool.
+const COMMUNITY_VAULT = "0xBE931190dFfC00B937b164A352BFC39140163c8c";
+const DEPOSITED_ABI =
+  "event Deposited(address indexed from, uint256 amount, string source)";
+
+const fetch = async (options: FetchOptions) => {
+  const dailyFees = options.createBalances();
+  const dailyRevenue = options.createBalances();
+  const dailyProtocolRevenue = options.createBalances();
+  const dailySupplySideRevenue = options.createBalances();
+
+  // ---- 1. LooprBasket mint fees (in-kind, fixed-recipe index tokens) ----
+  const basketCount = Number(
+    await options.api.call({ target: FACTORY, abi: "uint256:basketCount" }),
+  );
+
+  if (basketCount > 0) {
+    const basketIds = Array.from({ length: basketCount }, (_, i) => i);
+    const basketInfos = await options.api.multiCall({
+      target: FACTORY,
+      abi: BASKETS_ABI,
+      calls: basketIds,
+    });
+    const basketAddresses: string[] = basketInfos.map((b: any) => b.basket);
+
+    const [constituentsPerBasket, unitsPerBasket] = await Promise.all([
+      options.api.multiCall({ abi: CONSTITUENTS_ABI, calls: basketAddresses }),
+      options.api.multiCall({
+        abi: UNITS_PER_SHARE_ABI,
+        calls: basketAddresses,
+      }),
+    ]);
+
+    const constituentsByBasket: Record<string, string[]> = {};
+    const unitsByBasket: Record<string, bigint[]> = {};
+    basketAddresses.forEach((addr, i) => {
+      constituentsByBasket[addr.toLowerCase()] = constituentsPerBasket[i];
+      unitsByBasket[addr.toLowerCase()] = unitsPerBasket[i].map((u: any) =>
+        BigInt(u),
+      );
+    });
+
+    const mintLogs = await options.getLogs({
+      targets: basketAddresses,
+      eventAbi: MINTED_ABI,
+      entireLog: true,
+      parseLog: true,
+    });
+
+    mintLogs.forEach((log: any) => {
+      const fee = BigInt(log.args.fee);
+      if (fee === 0n) return;
+
+      const basketAddr = log.address.toLowerCase();
+      const assets = constituentsByBasket[basketAddr];
+      const units = unitsByBasket[basketAddr];
+
+      assets.forEach((asset: string, i: number) => {
+        // The mint fee is minted as extra basket shares, backed by the same
+        // fixed recipe every other share is: fee shares * unitsPerShare[i].
+        const amount = (fee * units[i]) / ONE_E18;
+        if (amount === 0n) return;
+
+        const creatorCut = (amount * CREATOR_FEE_SHARE_BPS) / BPS_DENOM;
+        const protocolCut = amount - creatorCut;
+
+        dailyFees.add(asset, amount, "Basket Mint Fees");
+        dailyRevenue.add(asset, protocolCut, "Basket Mint Fees To Loopr");
+        dailyProtocolRevenue.add(
+          asset,
+          protocolCut,
+          "Basket Mint Fees To Loopr",
+        );
+        dailySupplySideRevenue.add(
+          asset,
+          creatorCut,
+          "Basket Mint Fees To Basket Creators",
+        );
+      });
+    });
+  }
+
+  // ---- 2. LOOPR token creator tax ----
+  const sweptLogs = await options.getLogs({
+    target: PONS_HOOK,
+    eventAbi: POOL_FEES_SWEPT_ABI,
+    topics: [POOL_FEES_SWEPT_TOPIC0, LOOPR_POOL_ID],
+    entireLog: true,
+    parseLog: true,
+  });
+
+  sweptLogs.forEach((log: any) => {
+    const creatorAmount = BigInt(log.args.creatorAmount);
+    const protocolAmount = BigInt(log.args.protocolAmount);
+    const totalAmount = creatorAmount + protocolAmount;
+    if (totalAmount === 0n) return;
+
+    dailyFees.addGasToken(totalAmount, "LOOPR Token Creator Tax");
+    dailyRevenue.addGasToken(totalAmount, "LOOPR Token Creator Tax");
+    dailyProtocolRevenue.addGasToken(totalAmount, "LOOPR Token Creator Tax");
+  });
+
+  // ---- 3. Community vault deposits (sponsorships, partnerships, sweeps) ----
+  const depositLogs = await options.getLogs({
+    target: COMMUNITY_VAULT,
+    eventAbi: DEPOSITED_ABI,
+    entireLog: true,
+    parseLog: true,
+  });
+
+  depositLogs.forEach((log: any) => {
+    const amount = BigInt(log.args.amount);
+    if (amount === 0n) return;
+
+    dailyFees.addGasToken(amount, "LOOPR Community Vault Deposits");
+    dailyRevenue.addGasToken(amount, "LOOPR Community Vault Deposits");
+    dailyProtocolRevenue.addGasToken(amount, "LOOPR Community Vault Deposits");
+  });
+
+  return {
+    dailyFees,
+    dailyRevenue,
+    dailyProtocolRevenue,
+    dailySupplySideRevenue,
+  };
+};
+
+const methodology = {
+  Fees: "Loopr basket mint fees (paid in-kind by minters, in the basket's own constituent tokens), the LOOPR-token creator + protocol tax collected via launchpad hook, and ETH deposited into Loopr's community vault.",
+  Revenue:
+    "Loopr's 30% cut of each basket's mint fee, the LOOPR token creator + protocol tax paid to Loopr's own wallet, and ETH deposited into Loopr's community vault.",
+  ProtocolRevenue:
+    "Same as Revenue — all legs accrue directly to Loopr, not to a separate treasury/DAO split.",
+  SupplySideRevenue:
+    "The 70% of each basket's mint fee paid to that specific basket's own (possibly third-party, permissionless) creator.",
+};
+
+const breakdownMethodology = {
+  Fees: {
+    "Basket Mint Fees":
+      "Mint fee charged on LooprBasket index-token mints, paid in-kind in the basket's constituent tokens.",
+    "LOOPR Token Creator Tax":
+      "LOOPR token creator's and protocol's cut of the swap tax on LOOPR/ETH, both paid to Loopr's own wallet.",
+    "LOOPR Community Vault Deposits":
+      "ETH deposited into Loopr's LooprCommunityVault (sponsorships, partnerships, creator-tax sweeps).",
+  },
+  Revenue: {
+    "Basket Mint Fees To Loopr":
+      "Loopr protocol's 30% share of every basket's mint fee.",
+    "LOOPR Token Creator Tax":
+      "LOOPR token creator's and protocol's cut of the swap tax, both paid to Loopr's own wallet.",
+    "LOOPR Community Vault Deposits":
+      "ETH deposited into Loopr's LooprCommunityVault (sponsorships, partnerships, creator-tax sweeps).",
+  },
+  ProtocolRevenue: {
+    "Basket Mint Fees To Loopr":
+      "Loopr protocol's 30% share of every basket's mint fee.",
+    "LOOPR Token Creator Tax":
+      "LOOPR token creator's and protocol's cut of the swap tax, both paid to Loopr's own wallet.",
+    "LOOPR Community Vault Deposits":
+      "ETH deposited into Loopr's LooprCommunityVault (sponsorships, partnerships, creator-tax sweeps).",
+  },
+  SupplySideRevenue: {
+    "Basket Mint Fees To Basket Creators":
+      "The 70% of a basket's mint fee paid to that basket's own creator (permissionless — may not be Loopr itself).",
+  },
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  pullHourly: true,
+  methodology,
+  breakdownMethodology,
+  adapter: {
+    [CHAIN.ROBINHOOD]: {
+      fetch,
+      start: "2026-09-03",
+    },
+  },
+};
+
+export default adapter;

--- a/fees/loopr.ts
+++ b/fees/loopr.ts
@@ -74,8 +74,7 @@ const fetch = async (options: FetchOptions) => {
     const mintLogs = await options.getLogs({
       targets: basketAddresses,
       eventAbi: MINTED_ABI,
-      entireLog: true,
-      parseLog: true,
+      onlyArgs: false,
     });
 
     mintLogs.forEach((log: any) => {
@@ -116,13 +115,11 @@ const fetch = async (options: FetchOptions) => {
     target: PONS_HOOK,
     eventAbi: POOL_FEES_SWEPT_ABI,
     topics: [POOL_FEES_SWEPT_TOPIC0, LOOPR_POOL_ID],
-    entireLog: true,
-    parseLog: true,
   });
 
   sweptLogs.forEach((log: any) => {
-    const creatorAmount = BigInt(log.args.creatorAmount);
-    const protocolAmount = BigInt(log.args.protocolAmount);
+    const creatorAmount = BigInt(log.creatorAmount);
+    const protocolAmount = BigInt(log.protocolAmount);
     const totalAmount = creatorAmount + protocolAmount;
     if (totalAmount === 0n) return;
 
@@ -135,12 +132,10 @@ const fetch = async (options: FetchOptions) => {
   const depositLogs = await options.getLogs({
     target: COMMUNITY_VAULT,
     eventAbi: DEPOSITED_ABI,
-    entireLog: true,
-    parseLog: true,
   });
 
   depositLogs.forEach((log: any) => {
-    const amount = BigInt(log.args.amount);
+    const amount = BigInt(log.amount);
     if (amount === 0n) return;
 
     dailyFees.addGasToken(amount, "LOOPR Community Vault Deposits");
@@ -161,7 +156,7 @@ const methodology = {
   Revenue:
     "Loopr's 30% cut of each basket's mint fee, the LOOPR token creator + protocol tax paid to Loopr's own wallet, and ETH deposited into Loopr's community vault.",
   ProtocolRevenue:
-    "Same as Revenue — all legs accrue directly to Loopr, not to a separate treasury/DAO split.",
+    "Loopr's 30% cut of each basket's mint fee, the LOOPR token creator + protocol tax paid to Loopr's own wallet, and ETH deposited into Loopr's community vault.",
   SupplySideRevenue:
     "The 70% of each basket's mint fee paid to that specific basket's own (possibly third-party, permissionless) creator.",
 };
@@ -208,6 +203,7 @@ const adapter: SimpleAdapter = {
       start: "2026-09-03",
     },
   },
+  doublecounted: true,
 };
 
 export default adapter;


### PR DESCRIPTION
Adds a fees/revenue adapter for Loopr — permissionless in-kind index baskets, plus Loopr's own LOOPR/ETH pool and community vault — onRobinhood Chain. New listing (not previously on DefiLlama).

**Why it is event-based rather than rate-based.** All three fee sources here are flat, one-shot charges emitted directly on the actionthat creates them — there's no APR/utilisation curve to integrate against:

- `Minted(address indexed sender, address indexed to, uint256 basketAmount, uint256 fee)` — per-basket mint fee, minted in-kind as extra basket shares, split 70/30 creator/Loopr
- `PoolFeesSwept(bytes32 indexed poolId, uint256 protocolAmount, uint256 buybackAmount, uint256 creatorAmount, uint256 tokensLocked)` — swap tax swept on the LOOPR/ETH pool, filtered to Loopr's own `poolId`
- `Deposited(address indexed from, uint256 amount, string source)` — ETH deposited into Loopr's own `LooprCommunityVault` (sponsorships, partnerships, creator-tax sweeps)

Basket mint fees are paid in-kind in the basket's own constituents; the pool tax and vault deposits are both ETH — so no price lookup ambiguity either way.

**Split.** `CREATOR_FEE_SHARE_BPS` (70%) is hardcoded, but unlike a governance-settable parameter, this one is safe to hardcode: it's `public constant` in `LooprBasket.sol` (verified on Sourcify), baked into every basket's bytecode with no setter. The remaining 30% mints straight to the `LooprBasketFactory` address as Loopr's own cut.

- `dailyFees` — basket mint fees (in constituents) + LOOPR/ETH pool swap tax + vault deposits (gas token)
- `dailyRevenue` / `dailyProtocolRevenue` — Loopr's 30% of every basket's mint fee, the pool's creator + protocol tax cut, and vault deposits
- `dailySupplySideRevenue` — the 70% of each basket's mint fee paid to that basket's own (possibly third-party, permissionless) creator


**Testing.** `npm test fees/loopr.ts` runs clean and reports real, non-zero numbers — daily fees ~2.64k (mostly the LOOPR pool's swap tax, plus a handful of basket mints). Verified the event ABIs hash to the same topic0 the deployed contracts emit:

| event | topic0 |
|---|---|
| `Minted` | `0x03f17d66ad3bf18e9412eb06582908831508cdb9b8da9cddb1431f645a5b8632` |
| `PoolFeesSwept` | `0x2f3c43579b9064b6f28edcf41608f3815792d274a56afe024359703cb4ea9b30` |
| `Deposited` | `0x6f85d9948d6ca3dd6ce6ce7d175da22b4e865827ae6fcd530ec7edac1240f928` |

 Contracts (all verified on Robinhood Chain Blockscout):
  - [`LooprBasketFactory`](https://robinhoodchain.blockscout.com/address/0xf6B7e67816622a1E6dDb898EEB09cA8eb8e3D2B0)
  - [`LooprBasket`](https://robinhoodchain.blockscout.com/address/0x9233fa52d6466f33d58b21aee7db70a8543aaf90) (example instance)
  - [`PonsV2MemeHook`](https://robinhoodchain.blockscout.com/address/0xE5e702641Ea86F4ae6cC3cDaeD2B886f976Be044)
  - [`LooprCommunityVault`](https://robinhoodchain.blockscout.com/address/0xBE931190dFfC00B937b164A352BFC39140163c8c)

---

##### Name (to be shown on DefiLlama):
Loopr
##### Twitter Link:
https://x.com/LooprFund

##### List of audit links if any:
- 
##### Website Link:
https://loopr.fund

##### Logo (High resolution, will be shown with rounded borders):
<img width="1440" height="1440" alt="Loopr-Logo-green (2)" src="https://github.com/user-attachments/assets/4f396318-31fc-4d2e-b484-524efa519d28" />

##### Current TVL:

##### Treasury Addresses (if the protocol has treasury)

##### Chain:
Robinhood 

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed): (https://api.coingecko.com/api/v3/coins/list)

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)

##### Short Description (to be shown on DefiLlama):
Loopr puts that capital to work through stock-backed USDG borrowing, yield-enhanced 
DualPools, and programmable equity baskets. Its Dual Loop Hook connects Stock Token/USDG liquidity with external yield 
venues—combining trading fees with eligible idle-capital yield.
  
##### Token address and ticker if any:
0x8815cbAE8777d042Ff5dFabc3f298fe5Fc58AD65 (LOOPR), Robinhood Chain

##### Category (full list at https://defillama.com/categories) \*Please choose only one:
Yield

##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.):
N/A — fees are charged in-kind (basket 
  constituent tokens) or in the gas token, no price oracle involved

##### Implementation Details: Briefly describe how the oracle is integrated into your project:

##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage:

##### forkedFrom (Does your project originate from another project):

##### methodology (what is being counted as tvl, how is tvl being calculated):

##### Github org/user (Optional, if your code is open source, we can track activity):

##### Does this project have a referral program?
No