### PR TITLE
crypto cards: nexo is missing bsc ($12.5M/30d) and bleap is missing three chains ($259k/30d)

### DIFF
--- a/helpers/crypto-card.ts
+++ b/helpers/crypto-card.ts
@@ -164,6 +164,10 @@ const cryptoCardProtocols: Record<string, SimpleAdapter> = {
       start: '2022-11-01',
       paymentRecipients: NexoCardPaymentRecipients,
     },
+    [CHAIN.BSC]: {
+      start: '2022-11-01',
+      paymentRecipients: NexoCardPaymentRecipients,
+    },
   }),
   'holyheld': cryptoCardAdapterExport({
     [CHAIN.ETHEREUM]: {

--- a/helpers/crypto-card.ts
+++ b/helpers/crypto-card.ts
@@ -138,6 +138,19 @@ const cryptoCardProtocols: Record<string, SimpleAdapter> = {
         '0x0c06ccf38114ddfc35e07427b9424adcca9f44f8',
       ]
     },
+    // the same wallet is paid on these three as well
+    [CHAIN.ETHEREUM]: {
+      start: '2024-10-25',
+      paymentRecipients: ['0x476756C3d75A05757E3e8abaD6736EA6AB14675f'],
+    },
+    [CHAIN.POLYGON]: {
+      start: '2024-10-25',
+      paymentRecipients: ['0x476756C3d75A05757E3e8abaD6736EA6AB14675f'],
+    },
+    [CHAIN.BASE]: {
+      start: '2024-10-25',
+      paymentRecipients: ['0x476756C3d75A05757E3e8abaD6736EA6AB14675f'],
+    },
   }),
   'nexo-card': cryptoCardAdapterExport({
     [CHAIN.ETHEREUM]: {


### PR DESCRIPTION
Website: https://nexo.com — Twitter: https://twitter.com/Nexo

Nexo's four card settlement wallets are configured on ethereum, polygon, base, arbitrum, optimism and avax. They also receive on **BSC**, and nothing counts it.

Between 2026-08-06 and 2026-09-05 those same four addresses took **$12,486,015** on BSC — 19 of the 24 days with data were above $100k, median $590,150:

| day | USD | day | USD |
|---|---|---|---|
| 2026-08-19 | 1,099,013 | 2026-08-25 | 1,049,852 |
| 2026-08-20 | 1,199,484 | 2026-08-27 | 590,150 |
| 2026-08-21 | 1,299,139 | 2026-08-31 | 900,099 |
| 2026-08-24 | 799,903 | 2026-09-01 | 1,099,986 |

For scale, the adapter published **$115,723,583** over that same window, so BSC is **+10.8%**.

**It is the same flow the configured chains already count.** Same four recipients, and the two tokens carrying it are exactly the pair `DefaultPaymentTokens[CHAIN.BSC]` already lists:

```
USDT  0x55d398326f99059ff775485246999027b3197955   $10,485,707   27 transfers over 19 days
USDC  0x8ac76a51cc950d9822d68b83fe1ad97b32cd580d   $ 2,700,022    8 transfers over  8 days
```

Transfers between the recipients themselves are excluded, matching the helper's `logFilter`.

I checked that this is the same kind of flow rather than treasury movement, because the helper counts any inflow as card volume. On BSC it is a handful of large senders (5 addresses, $0.8M–$1.9M each); the **already-counted** ethereum leg has the same shape, dominated by large senders including `0x28c6c06298d514db089934071355e5743bf21d60`. BSC is not a different kind of flow being pulled in — it is the same one on a seventh chain.

The quiet days corroborate it too: 08-22, 08-23 and 08-30 are near zero on BSC, and those are exactly the weekend settlement gaps the other chains show. Of nexo-card's 57 published zero days, 44 fall on a Saturday or Sunday, and I confirmed on-chain that 2026-08-23 really had no material inflow on any chain — so those zeros are correct and are not what this PR is about.

`tsc --noEmit` is clean. The adapter cannot be run end-to-end locally without a Llama Indexer key (it falls back to RPC log scans across seven chains and exhausts the pool), but the run does now dispatch BSC, and the figures above are measured directly against the recipients on-chain.

Unrelated but worth noting next to this: #8950 covers three *other* card adapters whose recipient wallets have gone stale. This is a different failure — the wallets are fine, the chain was simply never added.
