### PR TITLE
uniswap v3: scroll and blast publish 0 while their pools trade, dune stopped carrying them

### DIFF
--- a/dexs/uniswap-v3.ts
+++ b/dexs/uniswap-v3.ts
@@ -245,6 +245,9 @@ async function fetchFromOku(options: FetchOptions) {
 
 const factoryConfig: Record<string, string> ={
   [CHAIN.OG]: "0xcb2436774C3e191c85056d248EF4260ce5f27A9D",
+  // dex.trades has all but stopped carrying uni-v3 rows for these two, so they read the pools directly
+  [CHAIN.SCROLL]: "0x70C62C8b8e801124A4Aa81ce07b637A3e83cb919",
+  [CHAIN.BLAST]: "0x792edAdE80af5fC680d96a2eD80A44247D2Cf6Fd",
 }
 
 async function fetchFromLogs(options: FetchOptions) {
@@ -291,10 +294,10 @@ const chainConfig: Record<string, { blockchain: string; start: string; fetch: Fe
   [CHAIN.AVAX]: { blockchain: 'avalanche_c', start: '2023-06-21', fetch: fetchFromDune },
   [CHAIN.BASE]: { blockchain: 'base', start: '2023-07-31', fetch: fetchFromDune },
   [CHAIN.ERA]: { blockchain: 'zksync', start: '2023-08-31', fetch: fetchFromDune },
-  [CHAIN.SCROLL]: { blockchain: 'scroll', start: '2023-10-14', fetch: fetchFromDune },
+  [CHAIN.SCROLL]: { blockchain: 'scroll', start: '2023-10-14', fetch: fetchFromLogs },
   [CHAIN.LINEA]: { blockchain: 'linea', start: '2023-11-11', fetch: fetchFromDune },
   [CHAIN.XDAI]: { blockchain: 'gnosis', start: '2023-11-28', fetch: fetchFromDune },
-  [CHAIN.BLAST]: { blockchain: 'blast', start: '2024-03-05', fetch: fetchFromDune },
+  [CHAIN.BLAST]: { blockchain: 'blast', start: '2024-03-05', fetch: fetchFromLogs },
   [CHAIN.ZORA]: { blockchain: 'zora', start: '2024-03-26', fetch: fetchFromDune },
   [CHAIN.MANTLE]: { blockchain: 'mantle', start: '2024-05-16', fetch: fetchFromDune },
   [CHAIN.WC]: { blockchain: 'worldchain', start: '2024-08-28', fetch: fetchFromDune },


### PR DESCRIPTION
Website: https://app.uniswap.org — Twitter: https://twitter.com/Uniswap

Uniswap V3 publishes **0 on Scroll and Blast**. Both read `fetchFromDune`, and `dex.trades` has all but stopped carrying uni-v3 rows for them:

```sql
SELECT block_date, blockchain, count(*), sum(amount_usd)
FROM dex.trades
WHERE blockchain IN ('scroll','blast','zora')
  AND project = 'uniswap' AND version = '3' AND block_date >= date '2026-08-14'
```

returns three rows in total — scroll 2026-08-19 ($0.36), 08-20 ($0.05), 08-23 ($0.03) — and nothing at all for blast or zora.

**They are still trading.** Scanning 24h of v3 `Swap` logs on each chain and resolving every emitting pool's `factory()` against the Uniswap V3 factory the TVL adapter uses:

| chain | uniswap v3 factory | uniswap pools | uniswap swaps 24h | all v3-shaped swaps 24h |
|---|---|---|---|---|
| scroll | `0x70C62C8b…` | 6 | **165** | 1,553 across 71 pools |
| blast | `0x792edAdE…` | 8 | **95** | 2,132 across 68 pools |

The factory step is the part that matters: the v3 `Swap` topic is shared by every fork, and on both chains most of that volume belongs to other factories. Attributing by raw topic would have overstated this by 10x. Scans were 10/10 and 55/55 chunks with no failures.

The fix uses the path already in this file — `fetchFromLogs`, which OG uses — with the factories added to `factoryConfig`. Running it:

```
scroll   Daily volume 6.23 k   Daily fees 2.01
blast    Daily volume 72.18    Daily fees 0.36
```

**On size, so nobody has to discover it themselves:** this is small. Scroll last did real volume in January ($88k on 2026-01-14) and is now ~$6k/day; Blast is ~$72/day. It is not recovering a large number — it is the difference between a chain reporting nothing and a chain reporting what it does. If you would rather carry two more RPC-backed chains than have that, I am happy to close it.

Zora is deliberately left alone: it shows 32 v3-shaped swaps across 5 pools in 24h, and I did not confirm how many are Uniswap's, so there is nothing I can stand behind there yet.

`tsc --noEmit` is clean.
