### PR TITLE
pump.fun: wait for dune to finish indexing the solana day, published volume is ~31% short

### DIFF
--- a/dexs/pumpfun.ts
+++ b/dexs/pumpfun.ts
@@ -4,8 +4,11 @@ import ADDRESSES from '../helpers/coreAssets.json'
 import { Dependencies, FetchOptions, SimpleAdapter } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
 import { queryDuneSql } from "../helpers/dune";
+import { assertDuneSolanaIndexed } from "../helpers/duneSolanaDex";
 
 const fetch: any = async (options: FetchOptions) => {
+  assertDuneSolanaIndexed(options)
+
   const vol = await queryDuneSql(options, `
     SELECT 
       SUM(


### PR DESCRIPTION
`dexs/pumpfun.ts` reads `dex_solana.trades` for the day that has just closed. Dune's Solana pipeline finishes a day several hours after it ends, so the query answers with a partial sum instead of an error, and the truncated number is what gets stored.

**The published series is a median 69.2% of what the adapter's own query returns today.** Re-running the exact query in the file for the 30 days ending 2026-09-03, against the published `dailyVolume` converted back to SOL at DefiLlama's own historical price for each day:

| day | query today (SOL) | published (USD) | implied (SOL) | published / today |
|---|---|---|---|---|
| 2026-08-05 | 1,458,895 | 76,201,320 | 1,033,748 | 0.709 |
| 2026-08-10 | 1,560,237 | 86,052,587 | 1,129,207 | 0.724 |
| 2026-08-15 | 1,367,379 | 71,854,244 | 954,380 | 0.698 |
| 2026-08-20 | 1,598,748 | 97,782,117 | 1,146,033 | 0.717 |
| 2026-08-25 | 1,682,461 | 112,176,084 | 1,136,640 | 0.676 |
| 2026-08-30 | 1,287,797 | 91,647,307 | 867,462 | 0.674 |
| 2026-09-03 | 1,047,021 | 75,202,080 | 748,714 | 0.715 |

Median 0.692 over the 30 days, highest 0.762, and never once above that. Two days are far worse (0.372 on 2026-08-26 and 0.374 on 2026-09-01). On 2026-09-03 that is **$75.2M published against $108.85M** from a local run of the patched adapter — about $33M/day of real volume that is never counted.

**The gap is the clock, not the method.** Summing the same query by hour for 2026-09-03 gives 724,470 SOL through 17:00 UTC and 775,701 SOL through 18:00 UTC. The published value implies 748,714 SOL, i.e. the stored number is roughly the first 18.5 hours of the day — which is the Solana pipeline's ~6h lag measured from the moment the day closed.

**Control, same day, same table.** The Solana adapters already wired through `factory/duneSolanaDex.ts` all wait, and all reconcile exactly:

```
jupiterz     dune 99,629,950   published 99,626,734   1.000
scorch       dune 77,841,617   published 77,856,004   1.000
goonfi       dune 46,761,237   published 46,761,138   1.000
whalestreet  dune  2,803,564   published  2,803,564   1.000
```

while the four adapters that got this same guard in #9221 were at 0.705 / 0.773 / 0.772 / 0.628 on 2026-09-03, before it took effect.

**The fix** is the guard already in `helpers/duneSolanaDex.ts` from #9221, three lines. `dexs/pumpfun.ts` is Solana-only, so throwing cannot affect another chain's record; the run is retried and the day lands complete a few hours later, the same way `dexs/humidifi`, `dexs/alphaq`, `dexs/bisonfi`, `dexs/solfi-v2` and `dexs/tessera` now do.

Verified locally:

```
$ npx ts-node --transpile-only cli/testAdapter.ts dexs pumpfun 2026-09-04
SOLANA
Daily volume: 108.85 M          <- 2026-09-03, published value was 75.20 M

$ npx ts-node --transpile-only cli/testAdapter.ts dexs pumpfun
End timestamp is less than 10 hours ago, skipping due to dune indexing delay
```

The `test` check fails on this adapter for the usual reason — CI sets no `DUNE_API_KEYS`, so every Dune-backed adapter throws at `helpers/dune.ts:17`. Same as #8970, #8524 and #9104, which all merged with `test: failure` and `ts-check: success`. The run above went through `queryDuneSql` with a local key, i.e. the same code path.
